### PR TITLE
fix(automations): honour the step in a cron field's bare start value

### DIFF
--- a/src/shared/automation-schedules.test.ts
+++ b/src/shared/automation-schedules.test.ts
@@ -23,6 +23,18 @@ function formatTimeForTest(hour: number, minute: number): string {
   }).format(date)
 }
 
+const CRON_ANCHOR = new Date('2026-05-01T00:00:00').getTime()
+
+function collectCronMinutes(cron: string, count: number): number[] {
+  const minutes: number[] = []
+  let cursor = CRON_ANCHOR
+  for (let index = 0; index < count; index += 1) {
+    cursor = nextAutomationOccurrenceAfter(cron, CRON_ANCHOR, cursor)
+    minutes.push(new Date(cursor).getMinutes())
+  }
+  return minutes
+}
+
 afterEach(() => {
   vi.restoreAllMocks()
 })
@@ -202,28 +214,47 @@ describe('automation schedules', () => {
 
   it('runs a bare start value with a step through the end of its field', () => {
     // Why: `5/15` means 5,20,35,50; dropping the step made the automation hourly.
-    const anchor = new Date('2026-05-01T00:00:00').getTime()
-    const runs: number[] = []
-    let cursor = anchor
-    for (let index = 0; index < 4; index += 1) {
-      const next = nextAutomationOccurrenceAfter('5/15 * * * *', anchor, cursor)
-      if (next === null) {
-        break
-      }
-      runs.push(new Date(next).getMinutes())
-      cursor = next
-    }
-
-    expect(runs).toEqual([5, 20, 35, 50])
-    // A bare value with no step still means exactly that value.
-    expect(new Date(nextAutomationOccurrenceAfter('5 * * * *', anchor, anchor)!).getMinutes()).toBe(
-      5
-    )
+    expect(collectCronMinutes('5/15 * * * *', 4)).toEqual([5, 20, 35, 50])
+    // A bare value with no step still means exactly that value, once per hour.
+    expect(collectCronMinutes('5 * * * *', 2)).toEqual([5, 5])
     // `1/2` in day-of-week is Mon/Wed/Fri/Sun, matching `1-7/2`.
     expect(isValidAutomationSchedule('0 9 * * 1/2')).toBe(true)
-    expect(nextAutomationOccurrenceAfter('0 9 * * 1/2', anchor, anchor)).toBe(
-      nextAutomationOccurrenceAfter('0 9 * * 1-7/2', anchor, anchor)
+    expect(nextAutomationOccurrenceAfter('0 9 * * 1/2', CRON_ANCHOR, CRON_ANCHOR)).toBe(
+      nextAutomationOccurrenceAfter('0 9 * * 1-7/2', CRON_ANCHOR, CRON_ANCHOR)
     )
+  })
+
+  it('classifies a stepped bare start as custom rather than hourly', () => {
+    // Why: with the step dropped, `5/15` collapsed to one minute and read as "Hourly at :05".
+    expect(classifyAutomationCronSchedule('5/15 * * * *').kind).toBe('custom')
+    expect(formatAutomationSchedule('5/15 * * * *')).toBe('Custom schedule')
+    expect(classifyAutomationCronSchedule('5 * * * *').kind).toBe('hourly')
+  })
+
+  it('treats a stepped bare start that spans every day as unrestricted', () => {
+    // Why: day restriction keys off set size, so `0/1` must widen to all seven days like `*`.
+    // Anchored past the 1st so a restricted day-of-week would switch match to OR and fire sooner.
+    const afterFirst = new Date('2026-05-01T10:00:00').getTime()
+    expect(nextAutomationOccurrenceAfter('0 9 1 * 0/1', CRON_ANCHOR, afterFirst)).toBe(
+      nextAutomationOccurrenceAfter('0 9 1 * *', CRON_ANCHOR, afterFirst)
+    )
+    expect(nextAutomationOccurrenceAfter('0 9 1 * 0/1', CRON_ANCHOR, afterFirst)).not.toBe(
+      nextAutomationOccurrenceAfter('0 9 1 * 0', CRON_ANCHOR, afterFirst)
+    )
+  })
+
+  it('keeps wildcard and range steps intact and applies steps per list element', () => {
+    expect(collectCronMinutes('*/15 * * * *', 4)).toEqual([15, 30, 45, 0])
+    expect(collectCronMinutes('5-30/10 * * * *', 3)).toEqual([5, 15, 25])
+    expect(collectCronMinutes('0,5/20 * * * *', 4)).toEqual([5, 25, 45, 0])
+  })
+
+  it('still rejects malformed steps instead of silently dropping them', () => {
+    expect(isValidAutomationSchedule('5/0 * * * *')).toBe(false)
+    expect(isValidAutomationSchedule('5/-1 * * * *')).toBe(false)
+    expect(isValidAutomationSchedule('5/abc * * * *')).toBe(false)
+    expect(isValidAutomationSchedule('5/ * * * *')).toBe(false)
+    expect(isValidAutomationSchedule('60/15 * * * *')).toBe(false)
   })
 
   it('rejects cron fields with malformed separators', () => {

--- a/src/shared/automation-schedules.test.ts
+++ b/src/shared/automation-schedules.test.ts
@@ -200,6 +200,34 @@ describe('automation schedules', () => {
     expect(isValidAutomationSchedule('0 9 * * 1-7')).toBe(true)
   })
 
+  it('runs a bare start value with a step through the end of its field', () => {
+    // Why: `5/15` is the shorthand every cron editor and Quartz read as
+    // "from 5, every 15" — 5,20,35,50. Dropping the step silently turned it
+    // into a single value, so the automation ran hourly instead.
+    const anchor = new Date('2026-05-01T00:00:00').getTime()
+    const runs: number[] = []
+    let cursor = anchor
+    for (let index = 0; index < 4; index += 1) {
+      const next = nextAutomationOccurrenceAfter('5/15 * * * *', anchor, cursor)
+      if (next === null) {
+        break
+      }
+      runs.push(new Date(next).getMinutes())
+      cursor = next
+    }
+
+    expect(runs).toEqual([5, 20, 35, 50])
+    // A bare value with no step still means exactly that value.
+    expect(new Date(nextAutomationOccurrenceAfter('5 * * * *', anchor, anchor)!).getMinutes()).toBe(
+      5
+    )
+    // `1/2` in day-of-week is Mon/Wed/Fri/Sun, matching `1-7/2`.
+    expect(isValidAutomationSchedule('0 9 * * 1/2')).toBe(true)
+    expect(nextAutomationOccurrenceAfter('0 9 * * 1/2', anchor, anchor)).toBe(
+      nextAutomationOccurrenceAfter('0 9 * * 1-7/2', anchor, anchor)
+    )
+  })
+
   it('rejects cron fields with malformed separators', () => {
     expect(isValidAutomationSchedule('*/15/2 9 * * *')).toBe(false)
     expect(isValidAutomationSchedule('0 9 1--5 * *')).toBe(false)

--- a/src/shared/automation-schedules.test.ts
+++ b/src/shared/automation-schedules.test.ts
@@ -241,6 +241,15 @@ describe('automation schedules', () => {
     expect(nextAutomationOccurrenceAfter('0 9 1 * 0/1', CRON_ANCHOR, afterFirst)).not.toBe(
       nextAutomationOccurrenceAfter('0 9 1 * 0', CRON_ANCHOR, afterFirst)
     )
+    // Known divergence (#15896): vixie restricts off a literal `*`, so it ORs `1/1` with Mondays
+    // and fires Wed Jul 1 as well. Pinned so the follow-up has to flip it on purpose.
+    const beforeJulyFirst = new Date('2026-06-30T10:00:00').getTime()
+    expect(nextAutomationOccurrenceAfter('0 0 1/1 * 1', CRON_ANCHOR, beforeJulyFirst)).toBe(
+      nextAutomationOccurrenceAfter('0 0 * * 1', CRON_ANCHOR, beforeJulyFirst)
+    )
+    expect(nextAutomationOccurrenceAfter('0 0 1/1 * 1', CRON_ANCHOR, beforeJulyFirst)).not.toBe(
+      nextAutomationOccurrenceAfter('0 0 1 * 1', CRON_ANCHOR, beforeJulyFirst)
+    )
   })
 
   it('keeps wildcard and range steps intact and applies steps per list element', () => {

--- a/src/shared/automation-schedules.test.ts
+++ b/src/shared/automation-schedules.test.ts
@@ -201,9 +201,7 @@ describe('automation schedules', () => {
   })
 
   it('runs a bare start value with a step through the end of its field', () => {
-    // Why: `5/15` is the shorthand every cron editor and Quartz read as
-    // "from 5, every 15" — 5,20,35,50. Dropping the step silently turned it
-    // into a single value, so the automation ran hourly instead.
+    // Why: `5/15` means 5,20,35,50; dropping the step made the automation hourly.
     const anchor = new Date('2026-05-01T00:00:00').getTime()
     const runs: number[] = []
     let cursor = anchor

--- a/src/shared/automation-schedules.ts
+++ b/src/shared/automation-schedules.ts
@@ -150,10 +150,7 @@ function parseCronField(args: {
       end = parseCronNumber(endPart, args.names ?? null, args.field)
     } else {
       start = parseCronNumber(rangePart, args.names ?? null, args.field)
-      // Why: `5/15` is the shorthand for `5-<max>/15` that Quartz and every cron
-      // editor read as "from 5, every 15". Ending at `start` kept the value and
-      // dropped the step, which no cron dialect does — the automation then ran
-      // once per field cycle instead of on the interval the user wrote.
+      // Why: `5/15` is the `5-<max>/15` shorthand; ending at `start` dropped the step.
       end = stepPart === undefined ? start : args.max
     }
 

--- a/src/shared/automation-schedules.ts
+++ b/src/shared/automation-schedules.ts
@@ -150,7 +150,11 @@ function parseCronField(args: {
       end = parseCronNumber(endPart, args.names ?? null, args.field)
     } else {
       start = parseCronNumber(rangePart, args.names ?? null, args.field)
-      end = start
+      // Why: `5/15` is the shorthand for `5-<max>/15` that Quartz and every cron
+      // editor read as "from 5, every 15". Ending at `start` kept the value and
+      // dropped the step, which no cron dialect does — the automation then ran
+      // once per field cycle instead of on the interval the user wrote.
+      end = stepPart === undefined ? start : args.max
     }
 
     const normalizedStart = args.normalize?.(start) ?? start


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​66 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​66 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

> **Supersedes #15605 by @kaluli123123** — carried over so it can run full CI (fork PRs only run `track-community-pr` in this repo). Original authorship is preserved in the commits (`vam <a@a.com>`); the third commit is maintainer-added test hardening.

## ELI5

If you set an automation's custom cron to `5/15 * * * *` — "every 15 minutes, starting at :05" — Orca accepted it as valid and then ran it **once an hour**. The `/15` was quietly thrown away during parsing, so the schedule editor said "Hourly at :05" and the automation fired at :05 and nowhere else. This makes the step count.

## What Changed

One line in `parseCronField` (`src/shared/automation-schedules.ts`):

```diff
-      end = start
+      // Why: `5/15` is the `5-<max>/15` shorthand; ending at `start` dropped the step.
+      end = stepPart === undefined ? start : args.max
```

Plus regression tests in `src/shared/automation-schedules.test.ts`.

## Why

**Root cause:** `parseCronField` splits a part on `/`, parses and *validates* the step, then computes `start`/`end`. Any part that was not `*` and contained no `-` fell into the single-value branch with `end = start`. The expansion loop `for (let value = start; value <= end; value += step)` therefore ran exactly once and the step was discarded — after having been validated. That is the "silently degrades yet validates" defect in #15723.

This is not display-only. `automation-schedule-operations.ts` and `automation-definition-operations.ts` both derive the persisted `nextRunAt` from `nextAutomationOccurrenceAfter`, so the dropped step changed when the automation actually fired.

**Why expand rather than reject:** `*` is already the shorthand for `min-max` inside this same function, so reading a bare start with a step as `start-max` extends a pattern that is already there rather than adding a new rule. It also matches Quartz / croniter / node-cron / Jenkins and the cron editors people paste from. Rejecting would invalidate already-saved automations, which is more destructive than correcting their cadence.

## Linked Issue

Fixes #15723

## Visual Proof

`N/A` — no layout, color, typography, or component change. The user-visible difference is *when* an automation fires, plus the schedule label. A reviewer who wants to see it: open Automations → edit an automation → Custom cron → enter `5/15 * * * *`. The status line under the cron input (`AutomationCustomCronPanel`) now reads **"Custom schedule"** where it previously read **"Hourly at :05"**, and the Next run column advances in 15-minute steps instead of hourly.

## Testing

Run on **macOS only** (Darwin 25.3.0). The change is pure shared parsing logic with no platform branches, no path handling, and no shell invocation, so Linux and Windows are covered by reasoning rather than execution; CI runs the suite on all three.

```
npx vitest run --config config/vitest.config.ts src/shared/automation-schedules.test.ts
  → 26 passed (was 21 before this PR)

npx vitest run --config config/vitest.config.ts src/shared/automation-schedules.test.ts src/main/automations/service.test.ts
  → 38 passed

npx vitest run --config config/vitest.config.ts src/renderer/src/components/automations src/cli/handlers
  → 58 files, 493 passed

npx oxlint src/shared/automation-schedules.ts src/shared/automation-schedules.test.ts
  → clean
npx oxlint --config config/oxlint-code-quality-native-plugins.json <same files> --deny-warnings
  → clean (exit 0)
npx oxfmt --check <same files>
  → clean
```

**Red → green, actually executed.** With the one product line reverted to `end = start` and the new tests in place, 4 of the 5 new tests fail:

```
× runs a bare start value with a step through the end of its field
    expected [ 5, 5, 5, 5 ] to deeply equal [ 5, 20, 35, 50 ]
× classifies a stepped bare start as custom rather than hourly
    expected 'hourly' to be 'custom'
× treats a stepped bare start that spans every day as unrestricted
    expected 1777824000000 to be 1780329600000
× keeps wildcard and range steps intact and applies steps per list element
    expected [ 5, +0, 5, +0 ] to deeply equal [ 5, 25, 45, +0 ]
  Tests  4 failed | 22 passed (26)
```

Restoring the line returns all 26 to green.

**What the tests cover**, beyond the headline case:
- Classification flip — `5/15 * * * *` must now classify `custom` / format as `"Custom schedule"`, and a bare `5 * * * *` must still classify `hourly`.
- Day restriction flip — `dayOfWeekRestricted` is `daysOfWeek.size !== 7`, so DOW `0/1` widening from `{0}` to all seven days flips `cronDateMatches` between OR and AND semantics. Asserted via `0 9 1 * 0/1` now matching `0 9 1 * *` and no longer matching `0 9 1 * 0`, anchored past the 1st so the OR/AND difference is observable. The mirror case in day-of-month (`0 0 1/1 * 1`) is pinned too — see the known-limitation note below.
- Non-regression — `*/15` → 15,30,45,0 and `5-30/10` → 5,15,25 are byte-identical before and after; list `0,5/20` applies the step per element → 5,25,45,0.
- Invalid steps still fail validation, not degrade: `5/0`, `5/-1`, `5/abc`, `5/`, `60/15` all return `false` from `isValidAutomationSchedule`.

- [x] I manually tested these changes locally — drove `nextAutomationOccurrenceAfter`, `classifyAutomationCronSchedule`, and `formatAutomationSchedule` over the affected expressions; not exercised through the automations UI
- [x] Automated tests added/updated, or explained why not below

## Review

**Contributor-diff malicious-code scan:** I reviewed the full contributor patch line by line (+28/−1 across exactly two `.ts` files). No network calls, no `eval`/`Function`/`child_process`/dynamic `import`, no `process.env` or credential reads, no dependency, lockfile, workflow, native-module, or installer-hook changes, no non-ASCII / bidi / homoglyph characters, and no prompt-injection text — the only prose added is one source comment and three one-line test comments, and no `AGENTS.md`/`CLAUDE.md`/docs/skills file is touched. The whole logic change is one readable ternary over a `Set<number>`. Nothing found. (Noting for provenance only: the commits are authored as a throwaway identity `vam <a@a.com>`.)

- **Correctness / blast radius:** grep confirms a single cron parser in the repo — no duplicate in `src/`, `mobile/`, or `cli/` — so there is no second implementation to drift from. The editor maps any valid cron to preset `custom` (`AutomationsPage.tsx`) rather than round-tripping through classification, so the label change cannot corrupt saved state.
- **Cross-platform:** pure shared logic. No `metaKey`, no path separators, no shell, no platform branch. macOS / Linux / Windows behave identically.
- **SSH / remote:** scheduling stays owned by the execution host; nothing here reports on, stops, or lists remote work. No change to the `live` / `unverifiable` / `exited` vocabulary.
- **Remote wire compatibility:** no new field, no new stream opcode, no capability negotiation needed — the cron string on the wire is unchanged. Per `docs/reference/remote-wire-compatibility.md` the *interpretation* still reaches mixed pairs: a new client paired with an **older** remote host will label a `5/15` automation "Custom schedule" while the old host still fires it hourly. This is label-only — the timestamp shown comes from the host's persisted `nextRunAt` (`AutomationListLocalRows.tsx`) and is never recomputed client-side, so the number stays truthful and the label self-heals on host upgrade.
- **Provider neutrality:** the same reinterpretation applies to third-party provider cron strings rendered through `external-automation-schedule-display.ts`. No GitHub-specific behavior or naming introduced; GitLab and other providers are unaffected.
- **Folder workspaces:** no worktree assumptions; scheduling is workspace-kind agnostic.
- **Performance:** unchanged. The expanded set is bounded by the field's own max (59/23/31/12/7), so there is no unbounded loop, and a denser minute set makes `nextAutomationOccurrenceAfter`'s minute scan terminate *sooner*.
- **UI quality:** N/A — no component, token, or layout change.
- **Security:** none. Cron parsing only; no new input surface, no new sink, and the existing `AUTOMATION_CRON_EXPRESSION_MAX_BYTES` cap is untouched.
- **Mobile / shortcuts:** N/A.
- **Lint budgets:** no `max-lines` disable added anywhere; the test file is 293 lines against an 800-line budget.

## Agent skill upstream boundary

- [x] Not applicable

## Notes

⚠️ **Live cadence change — worth a release note.** Any *existing* automation saved with `N/step` cron syntax starts firing at the interval its author wrote instead of once per field cycle. That is the correction, not a regression, but it takes effect on upgrade with no user action.

Two details support can use:

1. **No catch-up storm.** `evaluateAutomation` (`src/main/automations/service.ts`) creates at most one run per tick from `getLatestAutomationOccurrence` and then advances, so a denser schedule cannot backfill missed occurrences.
2. **One stale first run.** `nextRunAt` is only recomputed on create, on schedule edit, or after a run, so an existing `N/step` automation keeps its old hourly `nextRunAt`, fires once at the old slot, and only then tightens to the new cadence. Recomputing `nextRunAt` on store load would fix that, but it is a separate change and deliberately not folded in here.

**Known follow-up, deliberately not in this PR.** A step larger than the field span still degrades silently and still validates: `5/90 * * * *` and `*/90 * * * *` both parse to a single value and both return `true` from `isValidAutomationSchedule` — the same defect class as #15723 with a different trigger. The obvious guard (`step > args.max - args.min` → throw) is **not safe to land here**: `latestAutomationOccurrenceAtOrBefore` / `nextAutomationOccurrenceAfter` *throw* on an unparseable cron, and `AutomationService.evaluateAutomation` has no try/catch around them, so a single already-saved `5/90` automation would abort the whole evaluation tick and stall every other automation on that host. Fixing it correctly needs per-automation error isolation in the scheduler first. Filed as #15895.

**Known limitation, deliberately not in this PR — one class of cron gets *fewer* runs.** `parseCronExpression` infers day restriction from set size (`daysOfMonth.size !== 31`, `daysOfWeek.size !== 7`) rather than from a literal `*`, and `cronDateMatches` uses those flags to pick OR vs AND day matching. Because this PR makes `N/step` fill its field, three spellings cross that threshold and flip from restricted to unrestricted: day-of-month `1/1`, and day-of-week `0/1` / `1/1`. Measured before → after, anchored at 2026-05-01:

| expression | before this PR | after this PR | vixie/cronie |
|---|---|---|---|
| `0 0 1/1 * 1` | 1st of month **OR** Mondays | Mondays only | 1st **OR** Mondays |
| `0 9 1 * 0/1` | 1st **OR** Sundays | 1st only | 1st **OR** every day → daily |

So for those spellings the cadence change is a narrowing, not the widening the note above describes. The underlying heuristic flaw predates this PR — `0 9 1-31 * 1` already resolves to Mondays-only today — and fixing it properly means tracking vixie's `DOM_STAR`/`DOW_STAR` flags on `ParsedCron`, which also flips `1-31`, `0-7`, and `*/N` and so needs its own PR, tests, and release note. Filed as #15896. The `0 0 1/1 * 1` outcome is pinned by a test here with a `#15896` comment so that follow-up has to flip it deliberately rather than by accident.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass — targeted vitest, oxlint, the code-quality native-plugin lint, and oxfmt all pass locally (commands above); project-wide typecheck/lint/build left to CI

