### PR TITLE
fix(native-chat): keep Claude Fable selectable when the CLI probe omits it

### DIFF
--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
@@ -63,8 +63,9 @@ export function createNativeChatPtySessionOptions(
     return null
   }
   let models = [...(args.initialModels ?? catalog.models)]
-  // The enrichment cache only ever holds probe output, so being handed a list at all
-  // means `isDefault` below names the account's real default rather than the seed guess.
+  // The enrichment cache holds probe output plus consent-gated seed rows, which are stripped
+  // of `isDefault`, so being handed a list at all still means `isDefault` below names the
+  // account's real default rather than the seed guess.
   let modelsAreDiscovered = args.initialModels !== undefined
   let record =
     readNativeChatSessionOptionCache(args.scopeKey, args.fallbackScopeKey) ??

--- a/src/renderer/src/components/native-chat/native-chat-session-option-discovery.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-discovery.ts
@@ -79,7 +79,7 @@ export async function discoverNativeChatCatalogModels(
     !result.success ||
     result.models.length === 0 ||
     // Why: a spec's static fallback list must never pass as a probe result for an
-    // agent whose published list replaces rather than extends the seed.
+    // agent whose published list decides membership rather than only adding to the seed.
     ((agent === 'claude' || catalog?.discoveredModelsAreAuthoritative) &&
       result.catalogOrigin !== 'probe')
   ) {

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
@@ -98,7 +98,7 @@ describe('native chat session option enrichment', () => {
     )
   })
 
-  it('uses only discovered Claude rows and capabilities per host', async () => {
+  it('merges seed Claude rows with discovered capabilities per host', async () => {
     mocks.discoverRuntimeCommitMessageModels.mockResolvedValue({
       success: true,
       catalogOrigin: 'probe',
@@ -135,7 +135,10 @@ describe('native chat session option enrichment', () => {
     await vi.waitFor(() => expect(listener).toHaveBeenCalledOnce())
 
     const models = readNativeChatEnrichedModels('claude', 'ssh:host')!
-    expect(models.map(({ id }) => id)).toEqual(['opus[1m]', 'sonnet'])
+    // Why: seed rows the CLI omits (e.g. fable, which needs a one-time consent
+    // before list_models advertises it) must stay selectable, so the merge keeps
+    // every seed id and overlays discovered rows on top.
+    expect(models.map(({ id }) => id)).toEqual(['fable', 'opus', 'sonnet', 'haiku', 'opus[1m]'])
     const sonnetEffort = models.find(({ id }) => id === 'sonnet')?.options[0]
     expect(sonnetEffort?.kind).toMatchObject({
       type: 'select',

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
@@ -98,7 +98,7 @@ describe('native chat session option enrichment', () => {
     )
   })
 
-  it('merges seed Claude rows with discovered capabilities per host', async () => {
+  it('keeps consent-gated Fable while dropping seed aliases the host never listed', async () => {
     mocks.discoverRuntimeCommitMessageModels.mockResolvedValue({
       success: true,
       catalogOrigin: 'probe',
@@ -135,10 +135,11 @@ describe('native chat session option enrichment', () => {
     await vi.waitFor(() => expect(listener).toHaveBeenCalledOnce())
 
     const models = readNativeChatEnrichedModels('claude', 'ssh:host')!
-    // Why: seed rows the CLI omits (e.g. fable, which needs a one-time consent
-    // before list_models advertises it) must stay selectable, so the merge keeps
-    // every seed id and overlays discovered rows on top.
-    expect(models.map(({ id }) => id)).toEqual(['fable', 'opus', 'sonnet', 'haiku', 'opus[1m]'])
+    // Why: list_models hides Fable until the one-time consent, so its absence is not
+    // evidence the host lacks it — every other omitted seed alias still disappears.
+    expect(models.map(({ id }) => id)).toEqual(['fable', 'opus[1m]', 'sonnet'])
+    expect(models.some(({ id }) => id === 'opus')).toBe(false)
+    expect(models.some(({ id }) => id === 'haiku')).toBe(false)
     const sonnetEffort = models.find(({ id }) => id === 'sonnet')?.options[0]
     expect(sonnetEffort?.kind).toMatchObject({
       type: 'select',
@@ -161,6 +162,34 @@ describe('native chat session option enrichment', () => {
       ]
     })
     expect(readNativeChatEnrichedModels('claude', 'local')).toBeNull()
+  })
+
+  it('does not duplicate Fable when the host already lists it', async () => {
+    mocks.discoverRuntimeCommitMessageModels.mockResolvedValue({
+      success: true,
+      catalogOrigin: 'probe',
+      models: [
+        { id: 'fable', label: 'Fable', thinkingLevels: [{ id: 'max', label: 'Max' }] },
+        { id: 'sonnet', label: 'Sonnet' }
+      ]
+    })
+    const discover = vi.fn(() =>
+      discoverNativeChatCatalogModels('claude', {
+        settings: {},
+        worktreeId: 'repo::/worktree',
+        worktreePath: '/worktree'
+      })
+    )
+    const listener = vi.fn()
+    subscribeNativeChatEnrichedModels('claude', 'ssh:host', listener)
+
+    ensureNativeChatModelEnrichment({ agent: 'claude', hostKey: 'ssh:host', discover })
+    await vi.waitFor(() => expect(listener).toHaveBeenCalledOnce())
+
+    const models = readNativeChatEnrichedModels('claude', 'ssh:host')!
+    expect(models.map(({ id }) => id)).toEqual(['fable', 'sonnet'])
+    // The host's capabilities win over the seed's for a row it did list.
+    expect(models[0].options[0]?.kind).toMatchObject({ choices: [{ value: 'max', label: 'Max' }] })
   })
 
   it('carries grok’s probed default through discovery to the published rows', async () => {

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
@@ -101,12 +101,9 @@ export function ensureNativeChatModelEnrichment(args: {
       if (!discovered || discovered.length === 0) {
         return
       }
-      entry.models =
-        args.agent === 'claude'
-          ? [...discovered]
-          : catalog.discoveredModelsAreAuthoritative
-            ? mergeDiscoveredAuthoritativeModels(catalog.models, discovered)
-            : mergeCatalogModels(catalog.models, discovered)
+      entry.models = catalog.discoveredModelsAreAuthoritative
+        ? mergeDiscoveredAuthoritativeModels(catalog.models, discovered)
+        : mergeCatalogModels(catalog.models, discovered)
       for (const listener of entry.listeners) {
         listener([...entry.models])
       }

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
@@ -3,6 +3,7 @@ import {
   getAgentSessionOptionCatalog,
   mergeCatalogModels,
   mergeDiscoveredAuthoritativeModels,
+  withConsentGatedSeedModels,
   type CatalogModel
 } from '../../../../shared/agent-session-option-catalog'
 import { resolveNativeChatSessionOptionDefaults } from '../../../../shared/native-chat-session-option-defaults'
@@ -101,9 +102,12 @@ export function ensureNativeChatModelEnrichment(args: {
       if (!discovered || discovered.length === 0) {
         return
       }
-      entry.models = catalog.discoveredModelsAreAuthoritative
-        ? mergeDiscoveredAuthoritativeModels(catalog.models, discovered)
-        : mergeCatalogModels(catalog.models, discovered)
+      entry.models =
+        args.agent === 'claude'
+          ? withConsentGatedSeedModels(catalog, discovered)
+          : catalog.discoveredModelsAreAuthoritative
+            ? mergeDiscoveredAuthoritativeModels(catalog.models, discovered)
+            : mergeCatalogModels(catalog.models, discovered)
       for (const listener of entry.listeners) {
         listener([...entry.models])
       }

--- a/src/renderer/src/components/native-chat/use-native-chat-session-options.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-options.test.ts
@@ -82,10 +82,14 @@ describe('useNativeChatSessionOptions model reporting', () => {
     await waitFor(() =>
       expect(modelDescriptor(result.current.snapshot).currentValue).toBe('opus[1m]')
     )
-    // The invented family row is gone: every choice is one the host listed.
+    // Seed rows the host omitted (e.g. fable) stay selectable; discovered rows
+    // overlay the matching seed ids and append any new ones.
     expect(modelDescriptor(result.current.snapshot).choices.map((choice) => choice.value)).toEqual([
-      'opus[1m]',
-      'haiku'
+      'fable',
+      'opus',
+      'sonnet',
+      'haiku',
+      'opus[1m]'
     ])
   })
 
@@ -130,7 +134,7 @@ describe('useNativeChatSessionOptions model reporting', () => {
     await waitFor(() =>
       expect(
         modelDescriptor(result.current.snapshot).choices.map((choice) => choice.value)
-      ).toEqual(['opus[1m]', 'haiku'])
+      ).toEqual(['fable', 'opus', 'sonnet', 'haiku', 'opus[1m]'])
     )
     expect(modelDescriptor(result.current.snapshot).currentValue).toBeUndefined()
   })
@@ -171,7 +175,7 @@ describe('useNativeChatSessionOptions model reporting', () => {
     await waitFor(() =>
       expect(
         modelDescriptor(result.current.snapshot).choices.map((choice) => choice.value)
-      ).toEqual(['opus[1m]', 'haiku'])
+      ).toEqual(['fable', 'opus', 'sonnet', 'haiku', 'opus[1m]'])
     )
     expect(modelDescriptor(result.current.snapshot).currentValue).toBeUndefined()
   })

--- a/src/renderer/src/components/native-chat/use-native-chat-session-options.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-options.test.ts
@@ -82,14 +82,11 @@ describe('useNativeChatSessionOptions model reporting', () => {
     await waitFor(() =>
       expect(modelDescriptor(result.current.snapshot).currentValue).toBe('opus[1m]')
     )
-    // Seed rows the host omitted (e.g. fable) stay selectable; discovered rows
-    // overlay the matching seed ids and append any new ones.
+    // Invented family rows stay gone; only consent-gated Fable is re-added.
     expect(modelDescriptor(result.current.snapshot).choices.map((choice) => choice.value)).toEqual([
       'fable',
-      'opus',
-      'sonnet',
-      'haiku',
-      'opus[1m]'
+      'opus[1m]',
+      'haiku'
     ])
   })
 
@@ -134,7 +131,7 @@ describe('useNativeChatSessionOptions model reporting', () => {
     await waitFor(() =>
       expect(
         modelDescriptor(result.current.snapshot).choices.map((choice) => choice.value)
-      ).toEqual(['fable', 'opus', 'sonnet', 'haiku', 'opus[1m]'])
+      ).toEqual(['fable', 'opus[1m]', 'haiku'])
     )
     expect(modelDescriptor(result.current.snapshot).currentValue).toBeUndefined()
   })
@@ -175,7 +172,7 @@ describe('useNativeChatSessionOptions model reporting', () => {
     await waitFor(() =>
       expect(
         modelDescriptor(result.current.snapshot).choices.map((choice) => choice.value)
-      ).toEqual(['fable', 'opus', 'sonnet', 'haiku', 'opus[1m]'])
+      ).toEqual(['fable', 'opus[1m]', 'haiku'])
     )
     expect(modelDescriptor(result.current.snapshot).currentValue).toBeUndefined()
   })

--- a/src/shared/agent-session-option-catalog-claude-codex.ts
+++ b/src/shared/agent-session-option-catalog-claude-codex.ts
@@ -174,6 +174,9 @@ export const CLAUDE_SESSION_OPTION_CATALOG: AgentSessionOptionCatalog = {
     }
   },
   unknownModelOptions: [claudeEffort(true)],
+  // Why: list_models omits Fable until the account accepts its usage-credit consent,
+  // which only an interactive /model can collect.
+  consentGatedModelIds: ['fable'],
   listModels: {
     command: `echo '${CLAUDE_MODEL_LIST_STDIN.trim()}' | claude ${CLAUDE_MODEL_LIST_ARGS.join(' ')}`,
     parse: parseClaudeCatalogModels

--- a/src/shared/agent-session-option-catalog-types.ts
+++ b/src/shared/agent-session-option-catalog-types.ts
@@ -65,6 +65,9 @@ export type AgentSessionOptionCatalog = {
    * must be able to drop it rather than only add. Membership only — option menus
    * still come from the seed. */
   discoveredModelsAreAuthoritative?: true
+  /** Why: seed ids a successful probe may legitimately omit because the CLI hides them
+   * behind a one-time consent, so their absence is not evidence the host lacks them. */
+  consentGatedModelIds?: readonly string[]
   /** Set only when the `isDefault` model is provably what the CLI runs with no model
    * flag, so an untouched draft may show it as selected. Off means `isDefault` stays
    * decorative: agents whose default comes from account or user config would otherwise

--- a/src/shared/agent-session-option-catalog.test.ts
+++ b/src/shared/agent-session-option-catalog.test.ts
@@ -139,6 +139,19 @@ describe('agent session option catalog', () => {
     expect(merged.find(({ id }) => id === 'fable')?.options.map(({ id }) => id)).toEqual(['effort'])
   })
 
+  it('strips `isDefault` from a re-added gated row so it cannot pose as the probed default', () => {
+    const claude = getAgentSessionOptionCatalog('claude')!
+    const catalog = {
+      ...claude,
+      models: [{ id: 'fable', label: 'Fable', isDefault: true, options: [] }]
+    }
+    const merged = withConsentGatedSeedModels(catalog, [
+      { id: 'sonnet', label: 'Sonnet', options: [] }
+    ])
+    expect(merged.map(({ id }) => id)).toEqual(['fable', 'sonnet'])
+    expect(merged[0].isDefault).toBeUndefined()
+  })
+
   it('leaves a probe that already lists Fable untouched', () => {
     const catalog = getAgentSessionOptionCatalog('claude')!
     const discovered = [

--- a/src/shared/agent-session-option-catalog.test.ts
+++ b/src/shared/agent-session-option-catalog.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { getAgentSessionOptionCatalog, mergeCatalogModels } from './agent-session-option-catalog'
+import {
+  getAgentSessionOptionCatalog,
+  mergeCatalogModels,
+  withConsentGatedSeedModels
+} from './agent-session-option-catalog'
 import { resolveAgentSessionOptionLaunch } from './agent-session-option-launch'
 import {
   resolveNativeChatSessionOptionDefaults,
@@ -119,6 +123,36 @@ describe('agent session option catalog', () => {
     expect(sonnet.description).toBe('Sonnet 5 · Efficient')
     expect(sonnet.isDefault).toBe(true)
     expect(sonnet.options.map(({ id }) => id)).toEqual(['effort'])
+  })
+
+  it('re-adds only consent-gated Claude seed rows a probe omitted', () => {
+    const catalog = getAgentSessionOptionCatalog('claude')!
+    const merged = withConsentGatedSeedModels(catalog, [
+      { id: 'opus[1m]', label: 'Opus (1M context)', options: [] },
+      { id: 'sonnet', label: 'Sonnet', options: [] },
+      { id: 'haiku', label: 'Haiku', options: [] }
+    ])
+    expect(merged.map(({ id }) => id)).toEqual(['fable', 'opus[1m]', 'sonnet', 'haiku'])
+    // The seed's `opus` alias stays out: the host listing `opus[1m]` and not `opus` is
+    // evidence, unlike the consent-gated Fable row.
+    expect(merged.some(({ id }) => id === 'opus')).toBe(false)
+    expect(merged.find(({ id }) => id === 'fable')?.options.map(({ id }) => id)).toEqual(['effort'])
+  })
+
+  it('leaves a probe that already lists Fable untouched', () => {
+    const catalog = getAgentSessionOptionCatalog('claude')!
+    const discovered = [
+      { id: 'sonnet', label: 'Sonnet', options: [] },
+      { id: 'fable', label: 'Fable 5', options: [] }
+    ]
+    expect(withConsentGatedSeedModels(catalog, discovered)).toEqual(discovered)
+  })
+
+  it('returns discovery unchanged for a catalog with no consent-gated ids', () => {
+    const catalog = getAgentSessionOptionCatalog('cursor')!
+    expect(catalog.consentGatedModelIds).toBeUndefined()
+    const discovered = [{ id: 'auto', label: 'Auto', options: [] }]
+    expect(withConsentGatedSeedModels(catalog, discovered)).toEqual(discovered)
   })
 
   it('parses Cursor model discovery without treating headings as models', () => {

--- a/src/shared/agent-session-option-catalog.ts
+++ b/src/shared/agent-session-option-catalog.ts
@@ -54,7 +54,11 @@ export function findCatalogOption(
   return model?.options.find((option) => option.id === optionId)
 }
 
-/** Merge live rows over the static seed while retaining cataloged option mappings. */
+/** Merge live rows over the static seed while retaining cataloged option mappings.
+ *  Why: for agents whose discovered rows carry their own option menus (Claude's
+ *  per-model effort levels and fast-mode flag come from the CLI probe), the live
+ *  options win; for agents whose discovery returns no options, the seed's menus
+ *  are kept so the picker does not go blank. */
 export function mergeCatalogModels(
   seed: readonly CatalogModel[],
   discovered: readonly CatalogModel[]
@@ -66,7 +70,7 @@ export function mergeCatalogModels(
       return model
     }
     discoveredById.delete(model.id)
-    return { ...model, ...live, options: model.options }
+    return { ...model, ...live, options: live.options.length > 0 ? live.options : model.options }
   })
   return [...merged, ...discoveredById.values()]
 }

--- a/src/shared/agent-session-option-catalog.ts
+++ b/src/shared/agent-session-option-catalog.ts
@@ -85,7 +85,9 @@ export function withConsentGatedSeedModels(
   const missing = catalog.models.filter(
     (model) => gated.includes(model.id) && !discovered.some((live) => live.id === model.id)
   )
-  return [...missing, ...discovered]
+  // Why: consumers read `isDefault` on an enriched list as the probe's answer, and a row the
+  // probe never listed cannot name the account's default.
+  return [...missing.map(({ isDefault: _seeded, ...model }) => model), ...discovered]
 }
 
 /** Discovery decides membership; the seed keeps its option menus, which discovery never carries.

--- a/src/shared/agent-session-option-catalog.ts
+++ b/src/shared/agent-session-option-catalog.ts
@@ -54,11 +54,7 @@ export function findCatalogOption(
   return model?.options.find((option) => option.id === optionId)
 }
 
-/** Merge live rows over the static seed while retaining cataloged option mappings.
- *  Why: for agents whose discovered rows carry their own option menus (Claude's
- *  per-model effort levels and fast-mode flag come from the CLI probe), the live
- *  options win; for agents whose discovery returns no options, the seed's menus
- *  are kept so the picker does not go blank. */
+/** Merge live rows over the static seed while retaining cataloged option mappings. */
 export function mergeCatalogModels(
   seed: readonly CatalogModel[],
   discovered: readonly CatalogModel[]
@@ -70,9 +66,26 @@ export function mergeCatalogModels(
       return model
     }
     discoveredById.delete(model.id)
-    return { ...model, ...live, options: live.options.length > 0 ? live.options : model.options }
+    return { ...model, ...live, options: model.options }
   })
   return [...merged, ...discoveredById.values()]
+}
+
+/** Prepend seed rows the probe is allowed to hide, keeping discovery authoritative for the rest.
+ *  Why: a probe that omits a consent-gated id is not evidence the host cannot run it, but every
+ *  other seed id it omits is — so only the gated rows survive, ahead of the discovered list. */
+export function withConsentGatedSeedModels(
+  catalog: AgentSessionOptionCatalog,
+  discovered: readonly CatalogModel[]
+): CatalogModel[] {
+  const gated = catalog.consentGatedModelIds
+  if (!gated || gated.length === 0) {
+    return [...discovered]
+  }
+  const missing = catalog.models.filter(
+    (model) => gated.includes(model.id) && !discovered.some((live) => live.id === model.id)
+  )
+  return [...missing, ...discovered]
 }
 
 /** Discovery decides membership; the seed keeps its option menus, which discovery never carries.

--- a/src/shared/commit-message-agent-spec.ts
+++ b/src/shared/commit-message-agent-spec.ts
@@ -357,6 +357,12 @@ export const COMMIT_MESSAGE_AGENT_SPECS: Partial<Record<TuiAgent, CommitMessageA
       {
         // Why: Claude Code aliases track the account/provider's supported
         // model IDs; hardcoded version IDs can be rejected by Bedrock/Vertex.
+        id: 'fable',
+        label: 'Fable',
+        thinkingLevels: CLAUDE_THINKING_LEVELS,
+        defaultThinkingLevel: 'high'
+      },
+      {
         id: 'haiku',
         label: 'Haiku'
       },

--- a/src/shared/commit-message-agent-spec.ts
+++ b/src/shared/commit-message-agent-spec.ts
@@ -357,12 +357,6 @@ export const COMMIT_MESSAGE_AGENT_SPECS: Partial<Record<TuiAgent, CommitMessageA
       {
         // Why: Claude Code aliases track the account/provider's supported
         // model IDs; hardcoded version IDs can be rejected by Bedrock/Vertex.
-        id: 'fable',
-        label: 'Fable',
-        thinkingLevels: CLAUDE_THINKING_LEVELS,
-        defaultThinkingLevel: 'high'
-      },
-      {
         id: 'haiku',
         label: 'Haiku'
       },


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​86 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​80 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​27 |

<!-- /orca-pr-loc -->

Supersedes #15434 by @PannenetsF — carried over so it can run full CI (fork PRs only run `track-community-pr` in this repo). Original authorship is preserved in the first commit; the second commit narrows the fix.

## ELI5

Claude Fable exists in Orca's built-in list of Claude models, but the Claude CLI doesn't advertise it until you've accepted its one-time usage-credit notice. Orca asked the CLI "what models do you have?" and then threw away its own list and used only the CLI's answer — so Fable vanished from the picker and there was no way to select it, which meant no way to ever trigger the consent prompt. Now Orca keeps exactly that one hidden row and still trusts the CLI for everything else.

## What Changed

- `AgentSessionOptionCatalog` gains `consentGatedModelIds?: readonly string[]`; the Claude catalog sets it to `['fable']`.
- New `withConsentGatedSeedModels(catalog, discovered)` in `src/shared/agent-session-option-catalog.ts` prepends only seed rows whose id is consent-gated *and* absent from the probe result.
- `ensureNativeChatModelEnrichment` keeps its Claude branch and swaps the body from `[...discovered]` to that helper. Every other agent path is untouched.
- Stale comment in `native-chat-session-option-discovery.ts` reworded so the "spec fallback must never pass as a probe" guard still reads as live intent.
- `withConsentGatedSeedModels` drops `isDefault` from the rows it re-adds, so a gated seed row can never be read as the account's real CLI default. Latent today (Claude has no `defaultModelIsCliDefault` and the `fable` seed row carries no `isDefault`), but it keeps the `modelsAreDiscovered` invariant in `native-chat-pty-session-options.ts` true by construction rather than by coincidence; that file's stale invariant comment is updated to match.

Deliberately **not** carried over from #15434 (see Review below): the blanket `mergeCatalogModels` path for Claude, the `options: live.options.length > 0 ? …` change to `mergeCatalogModels`, and the new `fable` entry in `COMMIT_MESSAGE_AGENT_SPECS`.

## Why

Root cause: `ensureNativeChatModelEnrichment` special-cased Claude to `entry.models = [...discovered]`, so a *successful* `list_models` probe replaced the seed wholesale. The real CLI never lists `fable` before the one-time consent (interactive `/model` is what collects it), so a successful probe silently deleted the only row from which a user could accept it. Deadlock.

The wholesale replacement itself is correct and intentional (#12369, commit `40ea4ece1a5`): a seeded alias the CLI has retired is a fatal launch, and Claude has no `discoveredModelsAreAuthoritative`, so any id in the list is freely adoptable as the persisted `--model` launch default and is never retired by `retirePersistedModelMissingFromDiscovery`. Merging the whole seed back in would resurrect `opus` next to the host's real `opus[1m]`, plus `sonnet`/`haiku` on hosts that don't list them — and those ids can be persisted as launch flags for every launch site including workers. So the carve-out is scoped to exactly one id, and it is data on the catalog rather than another `agent === 'claude'` branch.

Model id: the picker uses the CLI **alias** `fable`, matching the catalog's documented alias convention (aliases resolve to the newest model of a family on whatever CLI the host has, so pinned version ids lie on part of the fleet). The API id `claude-fable-5` stays confined to `src/main/claude-usage/claude-model-pricing.ts`, which is correct and already current.

## Linked Issue

Fixes #15433

## Visual Proof

`N/A` — no pixels change. The only user-visible effect is which rows appear in the existing native-chat model picker, and I could not produce an honest before/after: reproducing it requires a real Claude CLI on an account that has *not* completed the Fable consent, which I do not have. What a reviewer should look at instead: open a Claude native chat, let the background probe settle, and confirm the picker lists **Fable** at the top plus exactly the rows the host CLI listed — specifically that no stale `Opus` row appears alongside `Opus (1M context)`. Selecting Fable on a non-consented account should hit the CLI's consent prompt, which `hasClaudeModelSwitchInteraction` already detects and hands off to the terminal.

## Testing

Ran on **macOS only**. Linux/Windows are covered by reasoning, not execution: the diff is pure in-memory catalog data with no paths, shell invocation, or keyboard handling.

```
npx vitest run --config config/vitest.config.ts \
  src/renderer/src/components/native-chat src/shared/agent-session-option-catalog.test.ts \
  src/shared/agent-session-option-catalog-grok.test.ts src/shared/commit-message-agent-spec.test.ts
→ 76 files, 863 tests passed

npx oxlint <9 changed files>                                     → clean
npx oxlint --config config/oxlint-code-quality-native-plugins.json <9 changed files> --deny-warnings → clean
```

Regression tests were proven to fail without the product change, in both directions:

1. Reverted `withConsentGatedSeedModels(catalog, discovered)` back to `[...discovered]` → 4 failures, e.g. `expected [ 'opus[1m]', 'sonnet' ] to deeply equal [ 'fable', 'opus[1m]', 'sonnet' ]`. This is the reported bug.
2. Applied #15434's broad `mergeCatalogModels` path instead → 2 failures, e.g. `expected [ 'fable', 'opus', 'sonnet', 'haiku' ] to deeply equal [ 'fable', 'sonnet' ]`. This is the over-broad fix.

3. Reverted the `isDefault` strip in `withConsentGatedSeedModels` back to `[...missing, ...discovered]` → 1 failure: `strips \`isDefault\` from a re-added gated row so it cannot pose as the probed default` — `AssertionError: expected true to be undefined`.

Then restored and re-ran green (`src/shared/agent-session-option-catalog.test.ts` + `src/renderer/src/components/native-chat` → 74 files, 789 tests passed; `npx oxlint`, `npx oxlint --config config/oxlint-code-quality-native-plugins.json --deny-warnings`, and `npx oxfmt --check` clean on the changed files). Tests added: `re-adds only consent-gated Claude seed rows a probe omitted`, `leaves a probe that already lists Fable untouched`, `returns discovery unchanged for a catalog with no consent-gated ids` (shared catalog); `keeps consent-gated Fable while dropping seed aliases the host never listed`, `does not duplicate Fable when the host already lists it` (enrichment). The `use-native-chat-session-options` assertions keep their original negative intent (`opus`/`sonnet` stay out) with only `fable` prepended.

Not run: `pnpm typecheck` / full `pnpm lint` / `pnpm build` — deferred to CI, which is the point of carrying this branch internally.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

**Contributor diff scan.** I reviewed @PannenetsF's commit `b6026075` for malicious content before carrying it: 44 lines across 5 TypeScript files under `src/`, no network calls, no `exec`/`spawn`/`eval`, no `process.env`/credential access, no dependency, lockfile, CI-workflow, updater, or install-hook changes, no obfuscation, and no prompt-injection text in the added comments (no `AGENTS.md`/`CLAUDE.md`/skill files touched). **Clean.** Every hunk sat inside the model-catalog path the PR body describes.

**Cross-platform.** No paths, no shell strings, no keyboard handling. Pure in-memory array filtering over catalog data. Identical on macOS/Linux/Windows/WSL.

**SSH/remote.** Enrichment is keyed per host (`enrichmentKey(agent, hostKey)`), and `resolveNativeChatModelDiscoveryHostKey` already separates `local` / `wsl:<distro>` / SSH scopes, so a consent-gated row re-added for one host never leaks to another. The carve-out is applied at the same point the old replacement was, so the execution-host boundary is unchanged — Orca still treats the host's probe as the authority for membership and never infers capability from loss of contact.

**Remote wire compatibility.** No RPC params, no stream opcodes, no change to what a host publishes. `catalogOrigin` is read, not altered. `consentGatedModelIds` is renderer/shared-local catalog data that never crosses the wire.

**Agent/integration compatibility.** Codex, Gemini, Cursor, and Grok take byte-identical code paths — the helper early-returns `[...discovered]` for any catalog without `consentGatedModelIds`, and `mergeCatalogModels` / `mergeDiscoveredAuthoritativeModels` are unmodified (I reverted #15434's edit to the former; it silently swapped seed option menus for a probed model that reported no capabilities, the opposite of what #12369 wanted). No git commands and no provider-specific code, so the Git 2.25 baseline and GitLab/GitHub neutrality are untouched.

**Persisted state.** This is the sharp edge, and it's why the fix is narrow: a newly selectable id becomes adoptable as the persisted `--model` launch default (`supportsWorkerLaunchPreferences: true`) and is never retired for Claude. The carve-out keeps that surface at exactly one id, which the CLI does accept once consent is given.

**Performance.** One `filter` plus a `some` over a 4-element seed, once per host, inside an already-async settle path. Not measurable.

**UI quality.** `N/A` — no component, style, token, or layout change.

**Security.** No new input is trusted. `consentGatedModelIds` is a static literal, not attacker-controlled, and the `--model` argv construction is unchanged. I dropped #15434's `COMMIT_MESSAGE_AGENT_SPECS` hunk specifically because it would have surfaced Fable in the Source Control AI picker, where `claude -p --output-format text --model fable` runs non-interactively and therefore cannot render the consent prompt — a hard failure with no in-app remedy, plus `defaultThinkingLevel: 'high'` on the priciest model against full staged diffs. That belongs in its own PR after someone actually runs it on a non-consented account.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

### Known limitations / follow-ups

- The re-added `fable` row appears for every Claude host whose probe omits it, including accounts that lack Fable entirely for reasons other than the pending consent. There is no signal in `list_models` output to tell those apart, so the row is offered and selecting it lands on whatever the CLI says. That is the same state as before the CLI ever gained `list_models`, and it is strictly better than the deadlock this PR fixes.
- Not verified against a real non-consented Claude account (see Visual Proof); the consent-prompt hand-off relies on the existing `claude-model-switch-confirmation` detection, which is unchanged here.

Follow-up worth tracking separately: offering Fable for Source Control AI commit messages, which needs `claude -p --model fable` verified on a non-consented account first.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

