### PR TITLE
fix(git): enable Windows long paths for worktree creation (local, sparse, and SSH hosts)

### DIFF
--- a/src/main/git/add-sparse-worktree.test.ts
+++ b/src/main/git/add-sparse-worktree.test.ts
@@ -1,5 +1,5 @@
 import type * as FsPromises from 'node:fs/promises'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest'
 
 const {
   gitExecFileAsyncMock,
@@ -67,6 +67,10 @@ beforeEach(() => {
 })
 
 describe('addSparseWorktree', () => {
+  // Why: argv now depends on the host OS, so pin a non-Windows default or the exact-argv
+  // assertions below would fail for a maintainer running vitest on Windows.
+  let platformSpy: MockInstance<() => NodeJS.Platform>
+
   beforeEach(() => {
     resetWorktreeGitMocks({
       gitExecFileAsyncMock,
@@ -75,6 +79,43 @@ describe('addSparseWorktree', () => {
       statMock,
       resolveGitDirMock
     })
+    platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+  })
+
+  afterEach(() => {
+    platformSpy.mockRestore()
+  })
+
+  it('enables long paths on the Windows commands that actually write the deep checkout', async () => {
+    // Why: `worktree add --no-checkout` writes nothing, so the long-path flag on it alone
+    // left sparse creation failing with "Filename too long" (issue #15785).
+    platformSpy.mockReturnValue('win32')
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
+
+    await addSparseWorktree('C:\\repo', 'C:\\repo-feature', 'feature/test', ['packages/web'])
+
+    const calls = getGitCalls()
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        'git -c core.longpaths=true sparse-checkout set -- packages/web',
+        'git -c core.longpaths=true checkout feature/test'
+      ])
+    )
+  })
+
+  it('omits the long-path option on non-Windows hosts', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
+
+    await addSparseWorktree('/repo', '/repo-feature', 'feature/test', ['packages/web'])
+
+    const calls = getGitCalls()
+    expect(calls).toEqual(
+      expect.arrayContaining([
+        'git sparse-checkout set -- packages/web',
+        'git checkout feature/test'
+      ])
+    )
+    expect(calls.some((call) => call.includes('core.longpaths'))).toBe(false)
   })
 
   it('separates sparse checkout directory operands from options', async () => {

--- a/src/main/git/worktree-add-creation-config.test.ts
+++ b/src/main/git/worktree-add-creation-config.test.ts
@@ -99,6 +99,43 @@ describe('addWorktree', () => {
     ])
   })
 
+  it('enables long paths for native Windows worktree creation', async () => {
+    const platform = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+
+    try {
+      await addWorktree('/repo', '/repo-feature', 'feature/test', 'feature/test', false, false, {
+        checkoutExistingBranch: true
+      })
+
+      expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+        ['-c', 'core.longpaths=true', 'worktree', 'add', '/repo-feature', 'feature/test'],
+        { cwd: '/repo', timeout: WORKTREE_ADD_TIMEOUT_MS }
+      )
+    } finally {
+      platform.mockRestore()
+    }
+  })
+
+  it('does not pass the Windows-only long-path option to WSL Git', async () => {
+    const platform = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+
+    try {
+      await addWorktree('/repo', '/repo-feature', 'feature/test', 'feature/test', false, false, {
+        checkoutExistingBranch: true,
+        wslDistro: 'Ubuntu'
+      })
+
+      expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+        ['worktree', 'add', '/repo-feature', 'feature/test'],
+        { cwd: '/repo', wslDistro: 'Ubuntu', timeout: WORKTREE_ADD_TIMEOUT_MS }
+      )
+    } finally {
+      platform.mockRestore()
+    }
+  })
+
   it('bounds the worktree add call with a positive timeout (STA-1292 OneDrive stall guard)', async () => {
     // Why: without a timeout, a OneDrive cloud-placeholder checkout can stall
     // `git worktree add` for minutes. Assert the runner receives a non-zero

--- a/src/main/git/worktree-add-creation-config.test.ts
+++ b/src/main/git/worktree-add-creation-config.test.ts
@@ -1,5 +1,5 @@
 // addWorktree: checkout creation, branch-base/push.autoSetupRemote config writes, ref qualification.
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest'
 
 const {
   gitExecFileAsyncMock,
@@ -40,10 +40,19 @@ describe('addWorktree', () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // config --local --replace-all branch.<branch>.base
   }
 
+  // Why: argv now depends on the host OS, so pin a non-Windows default or every
+  // exact-argv assertion below would fail for a maintainer running vitest on Windows.
+  let platformSpy: MockInstance<() => NodeJS.Platform>
+
   beforeEach(() => {
     gitExecFileAsyncMock.mockReset()
     gitExecFileSyncMock.mockReset()
     translateWslOutputPathsMock.mockClear()
+    platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+  })
+
+  afterEach(() => {
+    platformSpy.mockRestore()
   })
 
   it('creates the worktree without touching the local base ref by default', async () => {
@@ -100,41 +109,84 @@ describe('addWorktree', () => {
   })
 
   it('enables long paths for native Windows worktree creation', async () => {
-    const platform = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    platformSpy.mockReturnValue('win32')
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
 
-    try {
+    await addWorktree(
+      'C:\\repo',
+      'C:\\repo-feature',
+      'feature/test',
+      'feature/test',
+      false,
+      false,
+      { checkoutExistingBranch: true }
+    )
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['-c', 'core.longpaths=true', 'worktree', 'add', 'C:\\repo-feature', 'feature/test'],
+      { cwd: 'C:\\repo', timeout: WORKTREE_ADD_TIMEOUT_MS }
+    )
+  })
+
+  it('still enables long paths for a Windows-path repo that has a WSL distro configured', async () => {
+    // Why: a C:\ cwd can be served by host git.exe even with wslDistro set, and that
+    // is exactly the MAX_PATH-prone case; Linux git parses and ignores the key.
+    platformSpy.mockReturnValue('win32')
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+
+    await addWorktree(
+      'C:\\repo',
+      'C:\\repo-feature',
+      'feature/test',
+      'feature/test',
+      false,
+      false,
+      { checkoutExistingBranch: true, wslDistro: 'Ubuntu' }
+    )
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['-c', 'core.longpaths=true', 'worktree', 'add', 'C:\\repo-feature', 'feature/test'],
+      { cwd: 'C:\\repo', wslDistro: 'Ubuntu', timeout: WORKTREE_ADD_TIMEOUT_MS }
+    )
+  })
+
+  it('does not pass the Windows-only long-path option for a WSL UNC repo path', async () => {
+    platformSpy.mockReturnValue('win32')
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+
+    const repoPath = '\\\\wsl.localhost\\Ubuntu\\home\\dev\\repo'
+    await addWorktree(
+      repoPath,
+      '\\\\wsl.localhost\\Ubuntu\\home\\dev\\repo-feature',
+      'feature/test',
+      'feature/test',
+      false,
+      false,
+      { checkoutExistingBranch: true, wslDistro: 'Ubuntu' }
+    )
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['worktree', 'add', '\\\\wsl.localhost\\Ubuntu\\home\\dev\\repo-feature', 'feature/test'],
+      { cwd: repoPath, wslDistro: 'Ubuntu', timeout: WORKTREE_ADD_TIMEOUT_MS }
+    )
+  })
+
+  it.each(['darwin', 'linux'] as const)(
+    'does not pass the long-path option on %s',
+    async (platform) => {
+      platformSpy.mockReturnValue(platform)
+      gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
+
       await addWorktree('/repo', '/repo-feature', 'feature/test', 'feature/test', false, false, {
         checkoutExistingBranch: true
       })
 
       expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
-        ['-c', 'core.longpaths=true', 'worktree', 'add', '/repo-feature', 'feature/test'],
+        ['worktree', 'add', '/repo-feature', 'feature/test'],
         { cwd: '/repo', timeout: WORKTREE_ADD_TIMEOUT_MS }
       )
-    } finally {
-      platform.mockRestore()
     }
-  })
-
-  it('does not pass the Windows-only long-path option to WSL Git', async () => {
-    const platform = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
-
-    try {
-      await addWorktree('/repo', '/repo-feature', 'feature/test', 'feature/test', false, false, {
-        checkoutExistingBranch: true,
-        wslDistro: 'Ubuntu'
-      })
-
-      expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
-        ['worktree', 'add', '/repo-feature', 'feature/test'],
-        { cwd: '/repo', wslDistro: 'Ubuntu', timeout: WORKTREE_ADD_TIMEOUT_MS }
-      )
-    } finally {
-      platform.mockRestore()
-    }
-  })
+  )
 
   it('bounds the worktree add call with a positive timeout (STA-1292 OneDrive stall guard)', async () => {
     // Why: without a timeout, a OneDrive cloud-placeholder checkout can stall

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -975,7 +975,11 @@ async function performAddWorktree(
 ): Promise<AddWorktreeResult> {
   let localBaseRefRefresh: LocalBaseRefRefreshResult | undefined
   let localBaseRefUpdateSuggestion: LocalBaseRefUpdateSuggestion | undefined
-  const args = ['worktree', 'add']
+  // Why: enable long paths for this Windows checkout without changing user Git config.
+  const args =
+    process.platform === 'win32' && !options.wslDistro
+      ? ['-c', 'core.longpaths=true', 'worktree', 'add']
+      : ['worktree', 'add']
   let effectiveBase: string | undefined
   if (noCheckout) {
     args.push('--no-checkout')

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -14,6 +14,7 @@ import {
   scheduleWorktreeTrashDeletion
 } from '../worktree-trash'
 import { parseWslPath } from '../wsl'
+import { windowsLongPathGitArgs } from '../../shared/windows-long-path-git-args'
 import type {
   LocalBaseRefRefreshResult,
   LocalBaseRefUpdateSuggestion
@@ -976,10 +977,7 @@ async function performAddWorktree(
   let localBaseRefRefresh: LocalBaseRefRefreshResult | undefined
   let localBaseRefUpdateSuggestion: LocalBaseRefUpdateSuggestion | undefined
   // Why: enable long paths for this Windows checkout without changing user Git config.
-  const args =
-    process.platform === 'win32' && !options.wslDistro
-      ? ['-c', 'core.longpaths=true', 'worktree', 'add']
-      : ['worktree', 'add']
+  const args = [...windowsLongPathGitArgs(repoPath), 'worktree', 'add']
   let effectiveBase: string | undefined
   if (noCheckout) {
     args.push('--no-checkout')
@@ -1085,15 +1083,21 @@ export async function addSparseWorktree(
       options
     )
     created = true
+    // Why: `worktree add --no-checkout` writes no files, so these are the calls that
+    // actually materialize the deep path and need the long-path escape hatch.
+    const longPathArgs = windowsLongPathGitArgs(worktreePath)
     await gitExecFileAsync(
       ['sparse-checkout', 'init', '--cone'],
       gitExecOptions(worktreePath, options)
     )
     await gitExecFileAsync(
-      ['sparse-checkout', 'set', '--', ...directories],
+      [...longPathArgs, 'sparse-checkout', 'set', '--', ...directories],
       gitExecOptions(worktreePath, options)
     )
-    await gitExecFileAsync(['checkout', branch], gitExecOptions(worktreePath, options))
+    await gitExecFileAsync(
+      [...longPathArgs, 'checkout', branch],
+      gitExecOptions(worktreePath, options)
+    )
     return addResult
   } catch (error) {
     const wrapped: SparseWorktreeCreateError =

--- a/src/relay/git-handler-worktree-ops.test.ts
+++ b/src/relay/git-handler-worktree-ops.test.ts
@@ -31,12 +31,16 @@ describe('addWorktreeOp', () => {
   it('writes durable branch base config after creating an SSH new-branch worktree', async () => {
     const git = vi.fn<GitExec>(async () => ({ stdout: '', stderr: '' }))
 
-    await addWorktreeOp(git, {
-      repoPath: '/repo',
-      branchName: 'feature/test',
-      targetDir: '/repo-feature',
-      base: 'origin/main'
-    })
+    await addWorktreeOp(
+      git,
+      {
+        repoPath: '/repo',
+        branchName: 'feature/test',
+        targetDir: '/repo-feature',
+        base: 'origin/main'
+      },
+      'linux'
+    )
 
     expect(git.mock.calls.map((call) => call[0])).toEqual([
       ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'],
@@ -75,13 +79,17 @@ describe('addWorktreeOp', () => {
   it('does not write branch base config when checking out an existing SSH branch', async () => {
     const git = vi.fn<GitExec>(async () => ({ stdout: '', stderr: '' }))
 
-    await addWorktreeOp(git, {
-      repoPath: '/repo',
-      branchName: 'feature/test',
-      targetDir: '/repo-feature',
-      base: 'origin/main',
-      checkoutExistingBranch: true
-    })
+    await addWorktreeOp(
+      git,
+      {
+        repoPath: '/repo',
+        branchName: 'feature/test',
+        targetDir: '/repo-feature',
+        base: 'origin/main',
+        checkoutExistingBranch: true
+      },
+      'linux'
+    )
 
     expect(git.mock.calls.map((call) => call[0])).toEqual([
       ['worktree', 'add', '/repo-feature', 'feature/test']
@@ -91,15 +99,89 @@ describe('addWorktreeOp', () => {
   it('does not write branch base config when SSH creation has no base', async () => {
     const git = vi.fn<GitExec>(async () => ({ stdout: '', stderr: '' }))
 
-    await addWorktreeOp(git, {
-      repoPath: '/repo',
-      branchName: 'feature/no-base',
-      targetDir: '/repo-feature'
-    })
+    await addWorktreeOp(
+      git,
+      {
+        repoPath: '/repo',
+        branchName: 'feature/no-base',
+        targetDir: '/repo-feature'
+      },
+      'linux'
+    )
 
     expect(git.mock.calls.map((call) => call[0])).toEqual([
       ['worktree', 'add', '--no-track', '-b', 'feature/no-base', '/repo-feature'],
       ['config', '--get', 'push.autoSetupRemote']
+    ])
+  })
+
+  it('enables long paths when the SSH execution host is Windows', async () => {
+    // Why: only the host's OS matters — a macOS client can drive a Windows SSH host,
+    // which hits the same MAX_PATH ceiling (issue #15785).
+    const git = vi.fn<GitExec>(async () => ({ stdout: '', stderr: '' }))
+
+    await addWorktreeOp(
+      git,
+      {
+        repoPath: 'C:\\repo',
+        branchName: 'feature/test',
+        targetDir: 'C:\\repo-feature',
+        checkoutExistingBranch: true
+      },
+      'win32'
+    )
+
+    expect(git.mock.calls.map((call) => call[0])).toEqual([
+      ['-c', 'core.longpaths=true', 'worktree', 'add', 'C:\\repo-feature', 'feature/test']
+    ])
+  })
+
+  it('keeps --no-checkout ahead of -b once the long-path prefix is present', async () => {
+    const git = vi.fn<GitExec>(async () => ({ stdout: '', stderr: '' }))
+
+    await addWorktreeOp(
+      git,
+      {
+        repoPath: 'C:\\repo',
+        branchName: 'feature/test',
+        targetDir: 'C:\\repo-feature',
+        noCheckout: true
+      },
+      'win32'
+    )
+
+    expect(git.mock.calls[0][0]).toEqual([
+      '-c',
+      'core.longpaths=true',
+      'worktree',
+      'add',
+      '--no-track',
+      '--no-checkout',
+      '-b',
+      'feature/test',
+      'C:\\repo-feature'
+    ])
+  })
+
+  it('omits the long-path option on a WSL UNC target on a Windows SSH host', async () => {
+    const git = vi.fn<GitExec>(async () => ({ stdout: '', stderr: '' }))
+
+    await addWorktreeOp(
+      git,
+      {
+        repoPath: '\\\\wsl.localhost\\Ubuntu\\home\\dev\\repo',
+        branchName: 'feature/test',
+        targetDir: '\\\\wsl.localhost\\Ubuntu\\home\\dev\\repo-feature',
+        checkoutExistingBranch: true
+      },
+      'win32'
+    )
+
+    expect(git.mock.calls[0][0]).toEqual([
+      'worktree',
+      'add',
+      '\\\\wsl.localhost\\Ubuntu\\home\\dev\\repo-feature',
+      'feature/test'
     ])
   })
 
@@ -113,12 +195,16 @@ describe('addWorktreeOp', () => {
     })
 
     await expect(
-      addWorktreeOp(git, {
-        repoPath: '/repo',
-        branchName: 'feature/test',
-        targetDir: '/repo-feature',
-        base: 'origin/main'
-      })
+      addWorktreeOp(
+        git,
+        {
+          repoPath: '/repo',
+          branchName: 'feature/test',
+          targetDir: '/repo-feature',
+          base: 'origin/main'
+        },
+        'linux'
+      )
     ).resolves.toBeUndefined()
 
     expect(warnSpy).toHaveBeenCalledWith(

--- a/src/relay/git-handler-worktree-ops.ts
+++ b/src/relay/git-handler-worktree-ops.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path'
 import { resolveWorktreeAddBaseRef } from '../shared/worktree/base-ref'
+import { windowsLongPathGitArgs } from '../shared/windows-long-path-git-args'
 import type { GitExec } from './git-handler-ops'
 export { removeWorktreeOp } from './git-handler-worktree-remove'
 export { readRelayWorktreeList } from './git-handler-worktree-list'
@@ -28,7 +29,12 @@ async function persistRelayWorktreeCreationBase(
   }
 }
 
-export async function addWorktreeOp(git: GitExec, params: Record<string, unknown>): Promise<void> {
+export async function addWorktreeOp(
+  git: GitExec,
+  params: Record<string, unknown>,
+  // Why: only the execution host's OS matters here — the client may be macOS while the SSH host is Windows.
+  platform: NodeJS.Platform = process.platform
+): Promise<void> {
   const repoPath = params.repoPath as string
   const branchName = params.branchName as string
   const targetDir = params.targetDir as string
@@ -62,11 +68,14 @@ export async function addWorktreeOp(git: GitExec, params: Record<string, unknown
         })
       : undefined
 
+  // Why: a Windows SSH host hits the same MAX_PATH ceiling as a local Windows checkout.
+  const longPathArgs = windowsLongPathGitArgs(targetDir, platform)
   const args = checkoutExistingBranch
-    ? ['worktree', 'add', targetDir, branchName]
-    : ['worktree', 'add', '--no-track', '-b', branchName, targetDir]
+    ? [...longPathArgs, 'worktree', 'add', targetDir, branchName]
+    : [...longPathArgs, 'worktree', 'add', '--no-track', '-b', branchName, targetDir]
   if (!checkoutExistingBranch && noCheckout) {
-    args.splice(3, 0, '--no-checkout')
+    // Why: offset by the global-option prefix so --no-checkout still lands before -b.
+    args.splice(longPathArgs.length + 3, 0, '--no-checkout')
   }
   if (effectiveBase) {
     args.push(effectiveBase)

--- a/src/shared/windows-long-path-git-args.test.ts
+++ b/src/shared/windows-long-path-git-args.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { windowsLongPathGitArgs } from './windows-long-path-git-args'
+
+describe('windowsLongPathGitArgs', () => {
+  it('enables long paths for a Windows drive path', () => {
+    expect(windowsLongPathGitArgs('C:\\Users\\dev\\repo', 'win32')).toEqual([
+      '-c',
+      'core.longpaths=true'
+    ])
+  })
+
+  it.each(['darwin', 'linux'] as const)('returns nothing on %s', (platform) => {
+    expect(windowsLongPathGitArgs('/home/dev/repo', platform)).toEqual([])
+  })
+
+  it.each(['\\\\wsl.localhost\\Ubuntu\\home\\dev\\repo', '\\\\wsl$\\Ubuntu\\home\\dev\\repo'])(
+    'returns nothing for the WSL UNC path %s',
+    (cwd) => {
+      expect(windowsLongPathGitArgs(cwd, 'win32')).toEqual([])
+    }
+  )
+
+  it('never mutates the shared constant', () => {
+    const first = windowsLongPathGitArgs('C:\\repo', 'win32')
+    first.push('--bogus')
+    expect(windowsLongPathGitArgs('C:\\repo', 'win32')).toEqual(['-c', 'core.longpaths=true'])
+  })
+})

--- a/src/shared/windows-long-path-git-args.ts
+++ b/src/shared/windows-long-path-git-args.ts
@@ -1,0 +1,25 @@
+import { parseWslUncPath } from './wsl-paths'
+
+const WINDOWS_LONG_PATH_GIT_ARGS = ['-c', 'core.longpaths=true'] as const
+
+/**
+ * Global `git -c` options that let a Windows checkout exceed MAX_PATH.
+ *
+ * Why command scope: Git for Windows aborts deep checkouts with "Filename too
+ * long" unless core.longpaths is on, and `-c` applies it to this invocation
+ * only — never `--global`, `--system`, or `--local`, so no user config is
+ * written. Available since Git 1.9, well under the 2.25 baseline.
+ *
+ * Why keyed off cwd rather than a wslDistro option: a `C:\...` cwd can still be
+ * served by host git.exe even when a distro is configured, and Linux git parses
+ * and ignores the key, so only a true `\\wsl.localhost\...` path opts out.
+ */
+export function windowsLongPathGitArgs(
+  cwd: string,
+  platform: NodeJS.Platform = process.platform
+): string[] {
+  if (platform !== 'win32' || parseWslUncPath(cwd)) {
+    return []
+  }
+  return [...WINDOWS_LONG_PATH_GIT_ARGS]
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​271 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​26 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​245 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​49 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​42 |

<!-- /orca-pr-loc -->

Supersedes #15786 by @hwantage — carried over so it can run full CI (fork PRs only run `track-community-pr` in this repo). Original authorship is preserved in the first commit; the second commit adds the maintainer fixes described below.

## ELI5

Windows refuses to create files whose full path is longer than 260 characters unless a program explicitly asks for the long-path behavior. Orca creates worktrees in nested directories, so a repo with deep folder names blows past that limit and `git worktree add` dies with "Filename too long". Git has a switch for this (`core.longpaths`), and we now flip it for just the commands Orca runs — not by editing anyone's Git config — on the Windows worktree-creation paths Orca controls end to end: normal local creation, local sparse creation, and plain (non-sparse) creation on a remote Windows SSH host. Sparse creation *over SSH* is not covered — see "Known limitations" below.

## What Changed

- New `src/shared/windows-long-path-git-args.ts`: returns `['-c', 'core.longpaths=true']` for a Windows cwd, `[]` otherwise. Platform is an injectable parameter (matching `isWindowsLongPathWorktreeRemovalError` and `isWslLinkedWorktreeGitRoutingCandidate`).
- `src/main/git/worktree.ts`
  - `performAddWorktree` prefixes the `worktree add` argv (this is @hwantage's original fix, refactored onto the shared helper).
  - `addSparseWorktree` now also prefixes `sparse-checkout set` and `checkout <branch>`.
- `src/relay/git-handler-worktree-ops.ts`: `addWorktreeOp` takes an injectable `platform` (defaulting to the relay host's `process.platform`) and prefixes both argv branches. The hardcoded `args.splice(3, 0, '--no-checkout')` is now offset by the prefix length.
- Tests: new unit tests for the helper, Windows/non-Windows/WSL-UNC cases for local creation, a sparse-creation regression test, and Windows-host relay cases including one that pins `--no-checkout` position.

## Why

Root cause: Git for Windows aborts a checkout whose path exceeds `MAX_PATH` with "Filename too long" unless `core.longpaths` is enabled. Orca never set it.

Three things needed fixing beyond the original one-liner:

1. **Sparse worktrees were still broken.** `addSparseWorktree` calls `addWorktree` with `noCheckout=true`, so the flag decorated a `worktree add --no-checkout` that writes zero files. The commands that actually materialize the tree — `sparse-checkout set` and `checkout <branch>` — ran without it. Worse, that failure happens *after* `created = true`, so it fell into the rollback path and removed the worktree, presenting as a mysterious transient create failure.
2. **SSH hosts were never covered.** Remote creation goes through `ssh-git-provider.addWorktree` → relay `git.addWorktree` → `addWorktreeOp`, which builds its own argv. `worktree.ts` carries an explicit "SSH parity: relay's `addWorktreeOp` mirrors this — change both in lockstep" comment, and the relay demonstrably supports Windows hosts (`isWindowsAbsolutePath` in the same file). The client's `process.platform` is also the wrong process to ask here: only the execution host's OS matters.
3. **`!options.wslDistro` is not the routing predicate.** `resolveGitCommand` can return native host git for a WSL-linked worktree with a `C:\...` cwd even when `wslDistro` is set (`runner.ts:446-449`) — suppressing the flag in a genuinely MAX_PATH-prone case. Conversely a `\\wsl.localhost\...` cwd routes to WSL git even with `wslDistro` undefined. The predicate is now the cwd: apply on `win32` unless the path is a WSL UNC path.

Scope is deliberately command-level. `git -c key=value` applies to that invocation only — never `--global`, `--system`, or `--local` — so no user or repo config is mutated. Both `-c` and `core.longpaths` predate Git 1.9, well under the repo's 2.25 baseline, so no `GitCapabilityCache` entry or fallback is needed; a non-Windows Git parses and ignores the key (verified against Git 2.44 locally).

## Known limitations / follow-ups

- **Sparse creation over SSH is not covered.** `createRemoteWorktree` materializes the sparse tree with `provider.exec(['sparse-checkout', 'init', '--cone'])`, `provider.exec(['sparse-checkout', 'set', ...])` and `provider.exec(['checkout', <branch>])` (`src/main/ipc/worktree-remote.ts:1780-1782`). Those go through the relay's generic `git.exec` RPC, which (a) rejects any global option before the subcommand (`git-exec-validator.ts:154-162`, "Global git flags before the subcommand are not allowed") and (b) does not allowlist `sparse-checkout` or `checkout` at all (`ALLOWED_GIT_SUBCOMMANDS`, `git-exec-validator.ts:17-33`). Prefixing that argv would therefore not just fail to help, it would be rejected — covering it needs a narrow relay RPC (like the existing `git.addWorktree`), which is a security-reviewable change well beyond this PR's scope. Note this is not a regression from this PR: the relay has no `sparse-checkout` support today at all, so the remote sparse path is already blocked by the allowlist before MAX_PATH ever comes up.
- **Worktree *root* paths above ~215 chars still fail on Windows, with or without this flag.** Verified on real hardware (Git 2.55.0.windows.3): `core.longpaths=true` clears the "Filename too long" checkout error but Git then dies with `fatal: '$GIT_DIR' too big` — `setup_explicit_git_dir()` hard-checks `$GIT_DIR` (`<worktree>/.git`) against `PATH_MAX - 40`, and MinGW's `PATH_MAX` is 260. Measured cutoff: root length 215 succeeds, 216 fails. Not a regression (a 230-char root fails pre-fix too), and not fixable from Orca — it needs an upstream Git change. This fix targets the common shape instead: a short worktree root whose *checked-out files* exceed MAX_PATH.
- **Post-creation commands still lack the flag** — branch checkout and stash issued into an existing worktree. Removal already has a recovery path (`isWindowsLongPathWorktreeRemovalError` + `\\?\`-prefixed removal).

## Linked Issue

Fixes #15785

## Visual Proof

`N/A` — no UI, renderer, or user-visible surface changes. This only alters the argv of Git subprocesses.

## Testing

### Real Windows hardware verification (2026-08-22)

Host `awin` — Windows, Git Bash (MINGW64), `git version 2.55.0.windows.3`. Repo checked out at `C:/Users/neil/orca/orca`. Baseline config check first, so nothing masked the bug:

```
$ git --version; echo GLOBAL=[$(git config --global --get core.longpaths)]; echo SYSTEM=[$(git config --system --get core.longpaths)]; echo LOCAL=[$(git config --local --get core.longpaths)]
git version 2.55.0.windows.3
GLOBAL=[]
SYSTEM=[]
LOCAL=[]
```

**1. Original failure reproduced.** Scratch repo `C:\Users\neil\lp-test\src`, worktree target 276 chars:

```
$ git worktree add -b deep1 "$D" main   # ${#D}=276
Preparing worktree (new branch 'deep1')
fatal: could not create leading directories of 'C:/Users/neil/lp-test/wt/aaaa.../.git': Filename too long
EXIT=128
```

**2. The fix resolves the real-world shape** — short worktree root, tracked files that push past MAX_PATH (241-char relative path, 267 chars absolute):

```
$ git worktree add -b w1 /c/Users/neil/lp-test/wt2 main            # pre-fix argv
fatal: cannot create directory at 'd/aaaa.../aaaa...': Filename too long
EXIT=128

$ git -c core.longpaths=true worktree add -b w2 /c/Users/neil/lp-test/wt2 main   # post-fix argv
Preparing worktree (new branch 'w2')
HEAD is now at 5ae127f deepfile
EXIT=0
$ cat "$F"   # ABSLEN=267
deepcontent
```

**3. Sparse path — claim #1 in "Why" confirmed on hardware.** Replaying `addSparseWorktree`'s exact command sequence, the failing call is `checkout <branch>`, exactly as argued:

```
# pre-fix
worktree add --no-checkout --no-track -b s1 ... -> add_ok
sparse-checkout init --cone                    -> init_exit=0
sparse-checkout set -- d                       -> set_exit=0
checkout s1  -> fatal: cannot create directory at 'd/aaaa...': Filename too long ; checkout_exit=128

# post-fix
sparse-checkout init --cone                       -> init_exit=0
-c core.longpaths=true sparse-checkout set -- d   -> set_exit=0
-c core.longpaths=true checkout s2                -> Already on 's2' ; checkout_exit=0
cat <267-char path>                               -> deepcontent ; cat_exit=0
```

(`sparse-checkout init --cone` needs no prefix in practice: the worktree is always created `--no-checkout`, so there is no working tree for it to materialize. Exit 0 both times.)

**4. Config scope verified on hardware — nothing leaked.** After every command above:

```
GLOBAL=[]   SYSTEM=[]   SRC_LOCAL=[]   ORCAREPO_LOCAL=[]   git config --show-origin --get-all core.longpaths -> (empty)
```

**5. Relay argv ordering validated against real Git for Windows.** The `--no-checkout` splice offset produces a command real Git accepts, in both `addWorktreeOp` branches:

```
# argv exactly as addWorktreeOp emits it on win32 (splice puts --no-checkout after --no-track, before -b)
$ git -c core.longpaths=true worktree add --no-track --no-checkout -b r1 <path> main
Preparing worktree (new branch 'r1') ; exit=0 ; contents: ./ ../ .git   (no checkout, as intended)
$ git -c core.longpaths=true worktree add <path> ex1
Preparing worktree (checking out 'ex1') ; exit=0
```

(An earlier revision of this section quoted the operands as `--no-checkout --no-track`; that ordering is also accepted by Git but is not what the code produces. The block above is the produced argv, dumped from `addWorktreeOp` with a capturing `GitExec` and then run verbatim on `awin`.)

**New finding — hard ceiling on worktree *root* path length, independent of this fix.** `core.longpaths` does not make arbitrarily deep worktree *roots* work. Git for Windows' `setup_explicit_git_dir()` dies when `$GIT_DIR` (= `<worktree>/.git`) exceeds `PATH_MAX - 40`, and MinGW's `PATH_MAX` is 260. Measured boundary, all runs *with* `-c core.longpaths=true`:

```
len=150 exit=0   HEAD is now at 5ae127f deepfile
len=180 exit=0
len=200 exit=0
len=210 exit=0
len=214 exit=0
len=215 exit=0
len=216 exit=128  fatal: '$GIT_DIR' too big
len=220 exit=128  fatal: '$GIT_DIR' too big
len=240 exit=128  fatal: '$GIT_DIR' too big
len=276 exit=128  fatal: '$GIT_DIR' too big
```

This wall is not introduced by the PR — a 230-char root fails pre-fix too (exit 128, `fatal: could not create directory of '.git/worktrees/<basename>'...: Filename too long`; the exact path in the message shifts with the source repo's own path length). It is captured under "Known limitations". For scale on this host: Orca's own deepest tracked path is 117 chars and the worktree base `C:/Users/neil/orca/workspaces/orca/` is 35, so Orca-on-Orca stays well inside both limits; the fix matters for user repos with deeper trees.

**Not verified on hardware:** SSH creation against a *Windows* execution host. `awin` runs no sshd (`Get-Service sshd` returns nothing, 0 listeners on port 22) and Orca has no Windows SSH host registered (`orca host list` shows only a Linux SSH target), so `addWorktreeOp`'s Windows branch could not be exercised end to end — only its argv was validated against real Git for Windows (item 5). The remote *sparse* limitation was confirmed by code inspection only (`sparse-checkout`/`checkout` absent from `ALLOWED_GIT_SUBCOMMANDS`; `validateGitExecArgs` rejects any pre-subcommand global flag), not by an RPC round trip.


### Independent re-verification (second pass, 2026-08-22)

Everything above was re-run from scratch in a fresh scratch tree (`C:\Users\neil\lpv`, since deleted) on `awin` (`git version 2.55.0.windows.3`), plus a real Linux SSH host (`openclaw`, `git version 2.43.0`). Results:

```
# baseline, before any test command
git version 2.55.0.windows.3
GLOBAL=[] SYSTEM=[] LOCAL=[] ORIGIN=[]

# source repo: one tracked file at a 242-char relative path.
# `git add` itself needs the flag at this depth, which is the same MAX_PATH wall:
error: unable to index file 'd/aaaa…/f.txt'
fatal: adding files failed

# short worktree root (C:\Users\neil\lpv\wt1x = 21 chars), deep tracked file
git worktree add -b w1x  …                        -> PREFIX_EXIT=128
  fatal: cannot create directory at 'd/aaaa…': Filename too long
git -c core.longpaths=true worktree add -b w2x  … -> POSTFIX_EXIT=0
  checked-out file resolves at ABSLEN=268, `cat` returns its contents

# config scope, immediately after both runs
GLOBAL=[] SYSTEM=[] SRC_LOCAL=[] WT2_LOCAL=[] SHOW_ORIGIN=[]
```

Sparse sequence replayed verbatim, both ways:

```
# pre-fix (only `worktree add` prefixed, i.e. @hwantage's commit)
add_exit=0  init_exit=0  set_exit=0  checkout_exit=128
  fatal: cannot create directory at 'd/aaaa…': Filename too long

# post-fix (this PR)
add_exit=0  init_exit_NOPREFIX=0  set_exit=0  checkout_exit=0  -> "Already on 's2'"
  ABSLEN=268 ; cat -> deepcontent ; GLOBAL=[] SYSTEM=[] SP2_LOCAL=[]
```

Root-path ceiling re-measured independently against a *shallow* repo, so only root length varies. Boundary reproduces exactly:

```
winlen=200 exit=0     winlen=214 exit=0    winlen=215 exit=0
winlen=216 exit=128 fatal: '$GIT_DIR' too big
winlen=217 exit=128    winlen=220 exit=128    winlen=240 exit=128
```

Non-Windows argv proven unchanged two ways, not just asserted:

1. `addWorktreeOp` was driven with a capturing `GitExec` across all 12 combinations of `platform ∈ {win32, darwin, linux} × noCheckout × checkoutExistingBranch`, at this PR's head and at the merge base (`2b1254d`). The 8 non-Windows rows `diff` clean — byte-identical.
2. The **merge-base versions** of `worktree-add-creation-config.test.ts`, `add-sparse-worktree.test.ts` and `git-handler-worktree-ops.test.ts` — which pin full argv strings on darwin — were checked out over this PR's production code and run: `Test Files 3 passed (3) | Tests 32 passed (32)`.

Linux SSH host (`openclaw`, `hostPlatform: linux`): a worktree was created through the real `ssh-git-provider` → relay `git.addWorktree` path (succeeded), and afterwards `GLOBAL=[] SYSTEM=[] LOCAL=[] ORIGIN=[]`. Linux `git 2.43.0` also accepts and ignores `-c core.longpaths=true` (`LINUX_WITH_FLAG_EXIT=0`, `LINUX_NOFLAG_EXIT=0`, config still empty after).

The remote-sparse limitation is now confirmed by execution, not only inspection — `validateGitExecArgs` was called directly with each argv `createRemoteWorktree` sends:

```
["sparse-checkout","init","--cone"]                     -> REJECTED: git subcommand not allowed: sparse-checkout
["sparse-checkout","set","--","packages/web"]            -> REJECTED: git subcommand not allowed: sparse-checkout
["checkout","feature/x"]                                 -> REJECTED: git subcommand not allowed: checkout
["-c","core.longpaths=true","sparse-checkout","set",…]   -> REJECTED: Global git flags before the subcommand are not allowed
["-c","core.longpaths=true","checkout","feature/x"]      -> REJECTED: Global git flags before the subcommand are not allowed
```

Still **not** verified end to end, and correctly disclosed as such above: SSH creation against a Windows execution host. Re-checked on this pass — `awin` reports no `sshd` service and `0` listeners on port 22, and `orca host list` still shows exactly one SSH target, which is Linux.
### Local (macOS)


```
npx vitest run --config config/vitest.config.ts \
  src/shared/windows-long-path-git-args.test.ts \
  src/main/git/worktree-add-creation-config.test.ts \
  src/main/git/add-sparse-worktree.test.ts \
  src/main/git/worktree-sparse-checkout.test.ts \
  src/main/git/worktree-add-timeout-override.test.ts \
  src/main/git/worktree-add-local-base-refresh.test.ts \
  src/main/git/worktree-add-local-base-suggestion.test.ts \
  src/main/git/remove-worktree.test.ts \
  src/main/ipc/worktree-logic.test.ts \
  src/relay/git-handler-worktree-ops.test.ts \
  src/relay/git-handler-worktree-provisioning.test.ts
# 11 files passed, 212 tests passed

npx oxlint <changed files>                                                    # clean
npx oxlint --config config/oxlint-code-quality-native-plugins.json <changed files> --deny-warnings   # clean
```

Regression proof — with the two product files (`src/main/git/worktree.ts`, `src/relay/git-handler-worktree-ops.ts`) stashed back to @hwantage's original commit, 4 of the new tests fail and pass again once restored:

```
× relay: enables long paths when the SSH execution host is Windows
× relay: keeps --no-checkout ahead of -b once the long-path prefix is present
× sparse: enables long paths on the Windows commands that actually write the deep checkout
× local: still enables long paths for a Windows-path repo that has a WSL distro configured
Tests  4 failed | 38 passed
```

Note on the pre-existing suites: `worktree-add-creation-config.test.ts` and `add-sparse-worktree.test.ts` assert exact argv, which now depends on the host OS. Both suites pin `process.platform` to `darwin` in `beforeEach`, so they no longer silently fail for a maintainer running vitest on Windows (CI unit shards are `ubuntu-latest` and would have hidden that). The relay suite passes `platform` explicitly for the same reason.

Not run locally per repo policy for concurrent agents: `pnpm typecheck`, full `pnpm lint`, `pnpm build`. CI covers these.

## Review

- **Cross-platform**: the only behavior change is on `win32`; `darwin`/`linux` argv is byte-identical to before, asserted explicitly. No hardcoded path separators or modifier keys involved. WSL UNC paths (`\\wsl.localhost\...`, `\\wsl$\...`) opt out via `parseWslUncPath`, which is the platform-agnostic parser (the `parseWslPath` wrapper reads ambient `process.platform` and would defeat injection).
- **SSH / remote**: this is the main gap the original PR left. The relay path now keys off the *execution host's* platform, honoring `docs/reference/ssh-execution-boundary.md`. This covers plain remote creation only; the remote *sparse* path is out of reach from here (see Known limitations). No wire change: no RPC params, stream opcodes, or published content are altered — the fix is host-local argv construction, so mixed client/host versions are unaffected in both directions (`docs/reference/remote-wire-compatibility.md`).
- **Agent / integration compatibility**: `git -c` exports `GIT_CONFIG_PARAMETERS` to child processes, so a `post-checkout` hook inherits `core.longpaths=true` for that one invocation. That is documented Git behavior and not a privilege change. Telemetry still classifies the span correctly — `-c` is already in `GIT_GLOBAL_OPTIONS_WITH_OPERAND` (`src/main/observability/instrumentation.ts:34`), and `findSubcommandIndex` in `wsl-direct-git-read-commands.ts:58` already skips `-c` when detecting subcommands, so WSL direct-read routing is unaffected. Folder workspaces are unaffected (this is worktree-creation-only). Provider-neutral: no GitHub/GitLab surface touched.
- **Performance**: two extra argv strings per creation command. No new subprocess, probe, or I/O.
- **UI quality**: N/A.
- **Security**: `-c` is command-scope only; no `git config --global/--system/--local` write is introduced, so no user config is mutated. Values are literal constants passed as separate argv elements through the existing `execFile`-style path — no shell interpolation, and the relay's leading-`-` branch/base guard is untouched. The `--no-checkout` splice offset was the one real injection-adjacent risk (a wrong index would silently reorder the command); it is pinned by a test.
- **Contributor diff scan**: I reviewed @hwantage's commit `f269bf21` in full (2 files, +42/-1). It adds two literal argv strings and two unit tests. No network calls, no `child_process`/`eval`, no env or credential reads, no config writes, no dependency/lockfile/CI/workflow/entitlement changes, no obfuscation (diff is 100% ASCII), and no instruction-shaped text planted in comments or tests. Nothing malicious found.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance — all covered in Review above. Mobile is unaffected (main/relay process code only).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)



