### PR TITLE
fix(runtime): forward the client's resolved agent args to paired hosts

### DIFF
--- a/src/renderer/src/lib/launch-agent-in-new-tab-web-runtime.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab-web-runtime.test.ts
@@ -93,6 +93,9 @@ describe('launchAgentInNewTab paired web runtime', () => {
       activate: true,
       agentSessionKind: 'fresh',
       agent: 'claude',
+      // Why: an unconfigured client still resolves the default explicitly, so
+      // the host applies this client's launch defaults rather than its own.
+      agentArgs: '--dangerously-skip-permissions',
       viewMode: 'terminal'
     })
     expect(mocks.createTab).not.toHaveBeenCalled()
@@ -131,8 +134,30 @@ describe('launchAgentInNewTab paired web runtime', () => {
       startupCommandDelivery: 'shell-ready',
       prompt: 'fix the spinner',
       promptDelivery: 'auto-submit',
+      agentArgs: '--model gpt-5 --reasoning-effort high',
       viewMode: 'terminal'
     })
     expect(mocks.createTab).not.toHaveBeenCalled()
+  })
+
+  it('sends an explicit empty agentArgs override when the client is configured for Manual', async () => {
+    // Why (#15373): Manual is stored as an empty-string entry; without it riding
+    // along, a headless host re-resolved its own defaults and relaunched YOLO.
+    store.settings.agentDefaultArgs = { claude: '' }
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    const result = launchAgentInNewTab({
+      agent: 'claude',
+      worktreeId: 'wt-1',
+      groupId: 'group-1'
+    })
+
+    expect(result).toEqual(expect.objectContaining({ tabId: null }))
+    expect(mocks.createWebRuntimeSessionTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: 'claude',
+        agentArgs: ''
+      })
+    )
   })
 })

--- a/src/renderer/src/lib/launch-agent-in-new-tab-web-runtime.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab-web-runtime.test.ts
@@ -93,10 +93,11 @@ describe('launchAgentInNewTab paired web runtime', () => {
       activate: true,
       agentSessionKind: 'fresh',
       agent: 'claude',
-      // Why: the client resolves its default explicitly so the host cannot apply its own.
-      agentArgs: '--dangerously-skip-permissions',
       viewMode: 'terminal'
     })
+    // Why (#15373): an unconfigured client must not push the built-in YOLO default onto a host
+    // whose own Agent Permissions say Manual; omission keeps the host's choice.
+    expect(mocks.createWebRuntimeSessionTerminal.mock.calls[0]?.[0]).not.toHaveProperty('agentArgs')
     expect(mocks.createTab).not.toHaveBeenCalled()
     await Promise.resolve()
     expect(mocks.setActiveTabType).toHaveBeenCalledWith('terminal')
@@ -156,6 +157,24 @@ describe('launchAgentInNewTab paired web runtime', () => {
       expect.objectContaining({
         agent: 'claude',
         agentArgs: ''
+      })
+    )
+  })
+
+  it('forwards caller-supplied agent args even when the client has no configured default', async () => {
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    launchAgentInNewTab({
+      agent: 'claude',
+      worktreeId: 'wt-1',
+      groupId: 'group-1',
+      agentArgs: '--permission-mode plan'
+    })
+
+    expect(mocks.createWebRuntimeSessionTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: 'claude',
+        agentArgs: '--permission-mode plan'
       })
     )
   })

--- a/src/renderer/src/lib/launch-agent-in-new-tab-web-runtime.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab-web-runtime.test.ts
@@ -93,8 +93,7 @@ describe('launchAgentInNewTab paired web runtime', () => {
       activate: true,
       agentSessionKind: 'fresh',
       agent: 'claude',
-      // Why: an unconfigured client still resolves the default explicitly, so
-      // the host applies this client's launch defaults rather than its own.
+      // Why: the client resolves its default explicitly so the host cannot apply its own.
       agentArgs: '--dangerously-skip-permissions',
       viewMode: 'terminal'
     })

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -157,7 +157,12 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
       promptDelivery,
       pastePromptAfterReady: pasteDraftAfterLaunch,
       submitPastedPrompt,
-      agentArgs,
+      // Why: the raw param is undefined on ordinary UI launches, and omitting it
+      // lets a headless host apply its own defaults — so a client configured for
+      // Manual gets the host's YOLO default (#15373). Send the client-resolved
+      // value, empty string included: the host treats present-but-empty as an
+      // explicit no-args override.
+      agentArgs: effectiveAgentArgs,
       // Why: omission means terminal locally, but would let a paired host apply
       // its own default; send the client's resolved terminal choice explicitly.
       viewMode: initialViewModeProps.viewMode ?? 'terminal',

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -17,6 +17,7 @@ import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-co
 import { isWebRuntimeSessionActive } from '@/runtime/web-runtime-session'
 import { launchAgentInWebHostTab } from '@/lib/launch-agent-web-host-tab'
 import {
+  hasConfiguredTuiAgentLaunchArgs,
   resolveTuiAgentLaunchArgs,
   resolveTuiAgentLaunchEnv
 } from '../../../shared/tui-agent-launch-defaults'
@@ -106,6 +107,14 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
     agentArgs !== undefined
       ? agentArgs
       : resolveTuiAgentLaunchArgs(agent, store.settings?.agentDefaultArgs)
+  // Why (#15373): a paired host re-resolves omitted args against its own settings, so a client that
+  // actually chose a permission mode must send it — including Manual's empty string. An unconfigured
+  // client has chosen nothing, so stay silent rather than forcing the built-in YOLO default on the host.
+  const pairedHostAgentArgs =
+    agentArgs !== undefined ||
+    hasConfiguredTuiAgentLaunchArgs(agent, store.settings?.agentDefaultArgs)
+      ? effectiveAgentArgs
+      : undefined
   const agentEnv = resolveTuiAgentLaunchEnv(agent, store.settings?.agentDefaultEnv)
   const trimmedPrompt = prompt?.trim() ?? ''
   const hasPrompt = trimmedPrompt.length > 0
@@ -157,9 +166,7 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
       promptDelivery,
       pastePromptAfterReady: pasteDraftAfterLaunch,
       submitPastedPrompt,
-      // Why: the raw param is undefined on ordinary UI launches, so omission let a headless host apply its
-      // own YOLO default (#15373). Send the resolved value — present-but-empty is an explicit no-args override.
-      agentArgs: effectiveAgentArgs,
+      agentArgs: pairedHostAgentArgs,
       // Why: omission means terminal locally, but would let a paired host apply
       // its own default; send the client's resolved terminal choice explicitly.
       viewMode: initialViewModeProps.viewMode ?? 'terminal',

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -157,11 +157,8 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
       promptDelivery,
       pastePromptAfterReady: pasteDraftAfterLaunch,
       submitPastedPrompt,
-      // Why: the raw param is undefined on ordinary UI launches, and omitting it
-      // lets a headless host apply its own defaults — so a client configured for
-      // Manual gets the host's YOLO default (#15373). Send the client-resolved
-      // value, empty string included: the host treats present-but-empty as an
-      // explicit no-args override.
+      // Why: the raw param is undefined on ordinary UI launches, so omission let a headless host apply its
+      // own YOLO default (#15373). Send the resolved value — present-but-empty is an explicit no-args override.
       agentArgs: effectiveAgentArgs,
       // Why: omission means terminal locally, but would let a paired host apply
       // its own default; send the client's resolved terminal choice explicitly.
@@ -195,6 +192,7 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
     ...(startupPlan.env ? { env: startupPlan.env } : {}),
     launchConfig: startupPlan.launchConfig,
     launchAgent: agent,
+    // Why: the local launch command already bakes in the resolved args, so this override only records explicit caller intent.
     ...(agentArgs !== undefined ? { agentArgsOverride: agentArgs } : {}),
     ...(startupPlan.sessionOptions ? { sessionOptions: startupPlan.sessionOptions } : {}),
     ...(startupPlan.startupCommandDelivery

--- a/src/renderer/src/runtime/web-runtime-session-terminal-host-authority.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session-terminal-host-authority.test.ts
@@ -325,6 +325,65 @@ describe('createWebRuntimeSessionTerminal', () => {
     )
   })
 
+  it('keeps an explicit empty agentArgs in the structured create payload', async () => {
+    // Why (#15373): Manual is stored as an empty string; dropping it here would let the host re-resolve YOLO.
+    const runtimeCall = vi.fn(async (request: { method: string }) => {
+      if (request.method === 'status.get') {
+        return {
+          id: 'status',
+          ok: true,
+          result: {
+            runtimeId: 'runtime-1',
+            graphStatus: 'ready',
+            runtimeProtocolVersion: 3,
+            minCompatibleRuntimeClientVersion: 2,
+            capabilities: ['agent-session.host-authority.v1']
+          }
+        }
+      }
+      if (request.method === 'terminal.createAgentSession') {
+        return {
+          id: 'agent-session',
+          ok: true,
+          result: {
+            terminal: {
+              handle: 'term-manual',
+              worktreeId: WORKTREE_ID,
+              tabId: 'host-tab-manual',
+              paneKey: `host-tab-manual:${FOCUS_LEAF_ID}`
+            },
+            disposition: 'created'
+          }
+        }
+      }
+      return { id: 'list', ok: true, result: makeSnapshot() }
+    })
+    vi.stubGlobal('window', {
+      api: { runtimeEnvironments: { call: runtimeCall } }
+    })
+
+    await expect(
+      createWebRuntimeSessionTerminal({
+        worktreeId: WORKTREE_ID,
+        agent: 'claude',
+        agentSessionKind: 'fresh',
+        agentArgs: '',
+        activate: true
+      })
+    ).resolves.toEqual({ status: 'created' })
+
+    const createRequest = runtimeCall.mock.calls.find(
+      ([request]) => request.method === 'terminal.createAgentSession'
+    )?.[0] as { params: Record<string, unknown> } | undefined
+    expect(createRequest?.params).toEqual({
+      clientOperationId: expect.stringMatching(/^\d{13}-[0-9a-f]{32}$/),
+      worktree: `id:${WORKTREE_ID}`,
+      agent: 'claude',
+      agentArgs: '',
+      presentation: 'background'
+    })
+  })
+
   it.each(['session.tabs.move', 'session.tabs.list'] as const)(
     'treats %s failure after host creation as accepted so callers do not duplicate the agent',
     async (failedMethod) => {

--- a/src/shared/tui-agent-launch-defaults.ts
+++ b/src/shared/tui-agent-launch-defaults.ts
@@ -79,16 +79,24 @@ export function getTuiAgentDefaultEnv(agent: TuiAgent): Record<string, string> {
   return { ...DEFAULT_TUI_AGENT_ENV[agent] }
 }
 
+/** Manual is stored as `''`, so the key's presence — not its truthiness — is the user's explicit choice. */
+export function hasConfiguredTuiAgentLaunchArgs(
+  agent: TuiAgent,
+  configuredArgs: Partial<Record<TuiAgent, string>> | null | undefined
+): boolean {
+  return Boolean(
+    configuredArgs &&
+    Object.hasOwn(configuredArgs, agent) &&
+    typeof configuredArgs[agent] === 'string'
+  )
+}
+
 export function resolveTuiAgentLaunchArgs(
   agent: TuiAgent,
   configuredArgs: Partial<Record<TuiAgent, string>> | null | undefined
 ): string {
-  if (
-    configuredArgs &&
-    Object.hasOwn(configuredArgs, agent) &&
-    typeof configuredArgs[agent] === 'string'
-  ) {
-    return configuredArgs[agent] ?? ''
+  if (hasConfiguredTuiAgentLaunchArgs(agent, configuredArgs)) {
+    return configuredArgs?.[agent] ?? ''
   }
   return getTuiAgentDefaultArgs(agent)
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​102 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​102 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 |

<!-- /orca-pr-loc -->

Supersedes #15611 by @yzxcj797 — carried over so it can run full CI (fork PRs only run `track-community-pr` in this repo). Original authorship preserved in the commit.

## ELI5

You can tell Orca how much freedom to give an agent — "Manual" (ask me before every action) or "YOLO" (just go). When your workspace runs on a paired remote Orca host, the client used to forget to tell the host which one you picked, so the host guessed using its own settings. A fresh headless server has no settings, so it fell back to the built-in YOLO default and launched the agent with `--dangerously-skip-permissions` even though you had chosen Manual. This makes the client send its answer along with the launch, so the host stops guessing.

## What Changed

`src/renderer/src/lib/launch-agent-in-new-tab.ts` now sends an `agentArgs` override to the paired host whenever the user's Agent Permissions actually express a choice for that agent (or a caller passed explicit args), instead of only when a caller passed explicit args. `src/shared/tui-agent-launch-defaults.ts` gains `hasConfiguredTuiAgentLaunchArgs`, the `Object.hasOwn` predicate `resolveTuiAgentLaunchArgs` already used internally, so "the user chose something" has one definition. Plus tests.

## Why

`launchAgentInNewTab` already computed `effectiveAgentArgs` and used it for the local startup command, but passed the raw `agentArgs` parameter to `launchAgentInWebHostTab`. On ordinary UI launches that parameter is `undefined`, so `launch-agent-web-host-tab.ts` omitted the field, `web-runtime-session.ts` had no `launchConfig.agentArgs` to fall back to for prompt-less launches, and the host took its `request.agentArgs === undefined` branch and re-resolved `resolveTuiAgentLaunchArgs(agent, settings.agentDefaultArgs)` against its own (unset) settings — which fall through to `DEFAULT_TUI_AGENT_ARGS`, the YOLO table. Local tabs were never affected because the resolved args are baked into the launch command.

Sending the value **including the empty string** is the point: Manual is stored as `agentDefaultArgs[agent] = ''` (`src/shared/tui-agent-permissions.ts`), and `resolveTuiAgentLaunchArgs` only falls back when the key is *absent* (`Object.hasOwn`), so `''` has to ride the wire to survive. The host's create/resume plans already treat present-but-empty as an explicit no-args override.

### Remote wire compatibility

Checked against `docs/reference/remote-wire-compatibility.md`. `CreateAgentSessionParams` is `.strict()`, so unknown keys are *rejected*, not stripped — that matters here, and this is still safe:

- **Old host, new client:** `agentArgs` is not a new field. It shipped with `terminal.createAgentSession` itself in b232df732bb (#9687), and both structured calls are gated behind `AGENT_SESSION_HOST_AUTHORITY_CAPABILITY` in `src/renderer/src/runtime/remote-agent-session-launch.ts`. A host that predates the field never advertises the capability, so it only ever receives the unchanged legacy `session.tabs.createTerminal` params. No old host can see an unknown key.
- **New host, old client (no field):** unchanged. The `request.agentArgs !== undefined` checks in `src/main/runtime/orca-runtime.ts` keep the existing host-default branch.
- No new opcode, no protocol version bump, no capability negotiation needed.

### Behavior decision worth calling out

The client's Agent Permissions setting is authoritative for paired launches **when the client has one** — matching the existing `viewMode` precedent one line below and the host's own `host-default` vs `client-override` fingerprint contract (already asserted by `orca-runtime.test.ts`).

An earlier revision of this PR sent the client's *fully resolved* value on every UI launch. That was rejected: `DEFAULT_TUI_AGENT_ARGS === YOLO_TUI_AGENT_ARGS`, so a client whose user never opened Agent Permissions would have started sending `--dangerously-skip-permissions` as an explicit `client-override`, overwriting a host that was deliberately configured for Manual (and any non-permission host args such as `--model`). That is the same bug pointing the other way, and it fails *open*. The override is therefore gated on `hasConfiguredTuiAgentLaunchArgs`:

| client `agentDefaultArgs[agent]` | wire | host launches with |
| :--- | :--- | :--- |
| `''` (Manual) | `agentArgs: ''` | no permission flag — **the #15373 fix** |
| `'--foo'` | `agentArgs: '--foo'` | `--foo` |
| absent (never configured) | field omitted | host's own resolution — unchanged from today |
| caller passed `agentArgs` explicitly | that value | that value — unchanged from today |

So the only behavior that changes is the one #15373 reports. The last row already worked; the third row is deliberately left alone.

### Known scope limits (not regressions, still broken after this PR)

1. The legacy `session.tabs.createTerminal` fallback carries no args for prompt-less launches (`web-runtime-session.ts`), so hosts predating the host-authority capability — and any transient capability-probe failure that falls back to legacy — still let the host default win. Adding an optional `agentArgs` param there would not help: the legacy path is taken precisely *because* the host is old, and an old host ignores the new field. The only client-side fix is to send a fully built `command` for prompt-less launches too, which makes `resolveMobileSessionTerminalCommand` take its early-return branch and skip `markLocalWorkspaceTrustedForAgent` / `markRemoteWorkspaceTrustedForAgent` — a trust regression. That needs its own design and PR.
1b. A client whose user never configured Agent Permissions still gets the host's resolution (see the table above). That is unchanged pre-existing behavior, not a regression — but it fails **open**, not closed: such a client lands on the host's `resolveTuiAgentLaunchArgs` fallback, and `DEFAULT_TUI_AGENT_ARGS === YOLO_TUI_AGENT_ARGS`.
1c. `remote-runtime-pty-transport.ts` has the same shape of gap on the *pane* transport: its `terminal.createAgentSession` call sends `agentArgs: agentArgsOverride`, and `launchAgentInNewTab` only sets `agentArgsOverride` on locally queued startups when a caller passed explicit args. Reaching it requires a tab whose startup was queued while the worktree had no runtime environment and which then spawns against one, so it is not the path #15373 reports, but it is real. Left alone deliberately: `agentArgsOverride` currently means "explicit caller intent" for every pty transport that reads it, and widening that meaning is a separate change with its own blast radius.
2. Permission modes expressed via env rather than argv (goose / `YOLO_TUI_AGENT_ENV`) are still host-resolved; `terminal.createAgentSession` has no env field, and adding one is a capability-negotiated wire change that collides with the deliberate rule that env and cmd overrides stay host-owned.
3. Mobile clients launch through `session.tabs.createTerminal` only, so the Android half of #15373 is untouched.

Follow-ups should be filed for those; #15373 should stay open until at least (1) and (2) land.

## Linked Issue

Refs #15373 — **deliberately not a closing keyword.** This fixes only the args-expressed permission modes on capability-supporting hosts (see scope limits above); the rest of #15373 is untouched, so the issue must stay open after merge.

Original community PR: #15611 by @yzxcj797. Bug reported by @kbumsik.

## Visual Proof

`N/A` — no UI surface changes. The observable difference is which flags the agent process is launched with on a paired remote host; there is nothing rendered to diff.

## Testing

All run on **macOS only** (Darwin 25.3.0). Linux/Windows are covered by reasoning, not execution: the change touches no path handling, no shell quoting, and no keyboard input — it forwards an already-computed string one call deeper, and the Windows-quoting suite was run as a regression guard anyway.

```
npx vitest run --config config/vitest.config.ts \
  src/renderer/src/lib/launch-agent-in-new-tab-web-runtime.test.ts \
  src/renderer/src/lib/launch-agent-in-new-tab.test.ts \
  src/renderer/src/lib/launch-agent-in-new-tab-cwd.test.ts \
  src/renderer/src/lib/launch-agent-in-new-tab-windows-quoting.test.ts \
  src/renderer/src/lib/launch-agent-session-continuation.test.ts \
  src/shared/tui-agent-startup.test.ts \
  src/shared/tui-agent-permissions.test.ts \
  src/renderer/src/lib/tui-agent-startup.test.ts
# all passed

npx vitest run --config config/vitest.config.ts \
  src/renderer/src/runtime/web-runtime-session-terminal-host-authority.test.ts \
  src/renderer/src/runtime/web-runtime-session-terminal-legacy-create.test.ts \
  src/renderer/src/components/tab-bar/QuickLaunchButton.test.ts \
  src/renderer/src/components/terminal-pane/terminal-agent-session-fork.test.ts \
  src/renderer/src/components/dashboard/launch-dashboard-agent.test.ts \
  src/renderer/src/components/right-sidebar/runSourceControlAgentActionStart.test.ts \
  src/renderer/src/lib/run-quick-command-in-new-tab.test.ts \
  src/renderer/src/lib/fix-checks-agent-launch.test.ts \
  src/renderer/src/components/floating-terminal/FloatingTerminalWindowControls.test.tsx \
  src/renderer/src/components/terminal-pane/pty-connection-agent-session-resume.test.ts \
  src/renderer/src/lib/launch-work-item-direct-agent.test.ts \
  src/renderer/src/lib/ai-vault-resume-command.test.ts \
  src/renderer/src/lib/resume-sleeping-agent-session.test.ts \
  src/main/persistence-settings-update.test.ts \
  src/main/runtime/orca-runtime-agent-session-operation.test.ts \
  src/main/runtime/remote-agent-session-host-authority.integration.test.ts
# all passed (every suite that reads agentDefaultArgs or resolveTuiAgentLaunchArgs)

npx oxlint <changed files>                                             # exit 0, clean
npx oxlint --config config/oxlint-code-quality-native-plugins.json \
  <changed files> --deny-warnings                                      # exit 0, clean
npx oxfmt --check <changed files>                                      # clean
```

**Negative checks (proof the tests actually catch the bug), both run and then reverted:**

1. Reverting `agentArgs: pairedHostAgentArgs` back to the original `agentArgs` (the pre-PR bug) → `forwards prompt launch env and captured config to the host runtime` and `sends an explicit empty agentArgs override when the client is configured for Manual` fail (2 failed / 2 passed).
1b. Setting it to the un-gated `agentArgs: effectiveAgentArgs` (the earlier revision of this PR) → `delegates agent quick launch to the host runtime` fails, because the unconfigured client sends `--dangerously-skip-permissions` (1 failed / 3 passed). Both reverted.
2. Refactoring the wire boundary in `web-runtime-session.ts` from `args.agentArgs !== undefined ? ... : ...` to `args.agentArgs || ...` → the new `keeps an explicit empty agentArgs in the structured create payload` test fails. That test exists specifically because the contributor's tests mock `web-runtime-session` wholesale and stop short of the payload, so a future truthiness refactor would have silently dropped Manual's empty string and restored this bug with every other test still green.

Not run locally per repo policy for parallel agents: `pnpm typecheck` and full `pnpm lint` (CI covers them).

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Cross-platform:** no path, separator, shell-quoting, or modifier-key code touched. The forwarded value is an opaque args string produced by the same resolver the local path already used. Windows-quoting suite re-run green.
- **SSH / remote:** this is the remote path. Reviewed against `docs/reference/ssh-execution-boundary.md` — no change to who owns execution; the host still builds and runs the command, it just stops re-deriving a client-owned preference. Wire compatibility analyzed in both directions above; the field is pre-existing and capability-gated.
- **Agent / integration compatibility:** every consumer verified — the `AgentArgs` zod schema accepts a nullable string with a 16KB cap, `''` produces no argv suffix in `buildAgentStartupPlan`, and the create-idempotency fingerprint already distinguishes `host-default` from `client-override` and stays stable across retries because the value is computed once outside the retry closure.
- **Performance:** none. One already-computed local passed instead of an undefined parameter.
- **UI quality:** N/A, no UI surface.
- **Security:** net privilege-narrowing, but **not** narrowing in every direction — one reachable case widens, by design. It stops a remote host from silently upgrading a Manual client to `--dangerously-skip-permissions`, and — by gating the override on `hasConfiguredTuiAgentLaunchArgs` — it stops an *unconfigured* client's built-in YOLO default from downgrading a host deliberately set to Manual. The deliberate widening: a client whose user **explicitly** configured YOLO now overrides a host set to Manual, where on main it inherited the host's Manual. That is the intended client-authority model (row 2 of the table above), and it is the one permission a configuration reachable through this diff gains. The residual scope limits above are permission settings failing *open*, which is why #15373 stays open.
- **Malicious-code scan of the contributor diff:** I reviewed the complete branch diff (2 files, +31/-1, one commit). No network sinks, no `child_process`/`exec`/`eval`/dynamic `require`, no new imports at all, no env or credential reads, no obfuscation, no lockfile/`package.json`/workflow/install-hook changes, and no instruction-shaped text in the added comments. The only production change is a one-token substitution using a local that was already computed and already used on the local launch path. Nothing outside the stated fix. Clean.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)




