### PR TITLE
fix(worktree): fast-forward a claimed existing branch inside its new worktree (#15645)

### DIFF
--- a/src/main/git/worktree-add-local-base-refresh.test.ts
+++ b/src/main/git/worktree-add-local-base-refresh.test.ts
@@ -42,6 +42,45 @@ describe('addWorktree', () => {
     translateWslOutputPathsMock.mockClear()
   })
 
+
+  it('fast-forwards a checked-out existing branch inside the new worktree (#15645)', async () => {
+    // The branch pre-exists locally, is behind origin, and the new worktree just
+    // checked it out — so the branch is OWNED by /repo-feature now.
+    const worktreeListOutput =
+      'worktree /repo\nHEAD aaa111\nbranch refs/heads/main\n\nworktree /repo-feature\nHEAD old-tip\nbranch refs/heads/feature\n'
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: '' }) // worktree add /repo-feature feature
+      .mockResolvedValueOnce({ stdout: 'remote-tip\n' }) // resolveWorktreeAddBaseRef existence probe (OID required)
+      .mockResolvedValueOnce({ stdout: '0\t2\n' }) // rev-list --left-right --count (behind only)
+      .mockResolvedValueOnce({ stdout: 'old-tip\n' }) // rev-parse refs/heads/feature^{commit}
+      .mockResolvedValueOnce({ stdout: 'remote-tip\n' }) // rev-parse remote tracking ref^{commit}
+      .mockResolvedValueOnce({ stdout: '' }) // merge-base --is-ancestor
+      .mockResolvedValueOnce({ stdout: worktreeListOutput }) // worktree list --porcelain
+      .mockResolvedValueOnce({ stdout: '' }) // status --porcelain (in /repo-feature, clean)
+      .mockResolvedValueOnce({ stdout: worktreeListOutput }) // worktree list recheck
+      .mockResolvedValueOnce({ stdout: '' }) // status recheck (still clean)
+      .mockResolvedValueOnce({ stdout: '' }) // reset --hard remote-tip (in /repo-feature)
+
+    const result = await addWorktree(
+      '/repo',
+      '/repo-feature',
+      'feature',
+      'origin/feature',
+      true,
+      false,
+      { checkoutExistingBranch: true }
+    )
+
+    // eslint-disable-next-line no-console
+    console.log('CALLS', JSON.stringify(gitExecFileAsyncMock.mock.calls.map((c) => c[0])))
+    expect(result.localBaseRefRefresh).toMatchObject({ status: 'updated' })
+    const reset = gitExecFileAsyncMock.mock.calls.find(
+      (call) => call[0][0] === 'reset'
+    ) as unknown as [string[], { cwd?: string }]
+    expect(reset[0]).toEqual(['reset', '--hard', 'remote-tip'])
+    expect(reset[1].cwd).toBe('/repo-feature')
+  })
+
   it('fast-forwards with reset --hard when localBranch is checked out in primary worktree', async () => {
     const worktreeListOutput =
       'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /repo-other\nHEAD def456\nbranch refs/heads/feature\n'

--- a/src/main/git/worktree-add-local-base-refresh.test.ts
+++ b/src/main/git/worktree-add-local-base-refresh.test.ts
@@ -99,6 +99,73 @@ describe('addWorktree', () => {
     expect(gitExecFileAsyncMock.mock.calls.find((call) => call[0][0] === 'reset')).toBeUndefined()
   })
 
+  it('surfaces a dirty owner worktree on the claim path (#15645)', async () => {
+    // Base is origin/main, so the local counterpart is `main` in the primary repo, not the claimed branch.
+    const worktreeListOutput = 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n'
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: '' }) // worktree add /repo-feature feature
+      .mockResolvedValueOnce({ stdout: 'remote-main\n' }) // resolveWorktreeAddBaseRef existence probe
+      .mockResolvedValueOnce({ stdout: '0\t2\n' }) // rev-list --left-right --count (behind only)
+      .mockResolvedValueOnce({ stdout: 'old-main\n' }) // rev-parse refs/heads/main^{commit}
+      .mockResolvedValueOnce({ stdout: 'remote-main\n' }) // rev-parse remote tracking ref^{commit}
+      .mockResolvedValueOnce({ stdout: '' }) // merge-base --is-ancestor
+      .mockResolvedValueOnce({ stdout: worktreeListOutput }) // worktree list --porcelain
+      .mockResolvedValueOnce({ stdout: ' M package.json\n' }) // status --porcelain (in /repo, dirty)
+
+    const result = await addWorktree(
+      '/repo',
+      '/repo-feature',
+      'feature',
+      'origin/main',
+      true,
+      false,
+      {
+        checkoutExistingBranch: true
+      }
+    )
+
+    expect(result.localBaseRefRefresh).toEqual({
+      status: 'skipped_dirty_worktree',
+      baseRef: 'origin/main',
+      localBranch: 'main',
+      ownerWorktreePath: '/repo'
+    })
+    expect(gitExecFileAsyncMock.mock.calls.find((call) => call[0][0] === 'reset')).toBeUndefined()
+  })
+
+  it('surfaces a git error on the claim path (#15645)', async () => {
+    const worktreeListOutput =
+      'worktree /repo\nHEAD aaa111\nbranch refs/heads/main\n\nworktree /repo-feature\nHEAD old-tip\nbranch refs/heads/feature\n'
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: '' }) // worktree add /repo-feature feature
+      .mockResolvedValueOnce({ stdout: 'remote-tip\n' }) // resolveWorktreeAddBaseRef existence probe
+      .mockResolvedValueOnce({ stdout: '0\t2\n' }) // rev-list --left-right --count (behind only)
+      .mockResolvedValueOnce({ stdout: 'old-tip\n' }) // rev-parse refs/heads/feature^{commit}
+      .mockResolvedValueOnce({ stdout: 'remote-tip\n' }) // rev-parse remote tracking ref^{commit}
+      .mockResolvedValueOnce({ stdout: '' }) // merge-base --is-ancestor
+      .mockResolvedValueOnce({ stdout: worktreeListOutput }) // worktree list --porcelain
+      .mockResolvedValueOnce({ stdout: '' }) // status --porcelain (clean)
+      .mockResolvedValueOnce({ stdout: worktreeListOutput }) // worktree list recheck
+      .mockResolvedValueOnce({ stdout: '' }) // status recheck (clean)
+      .mockRejectedValueOnce(new Error('cannot lock ref')) // reset --hard fails
+
+    const result = await addWorktree(
+      '/repo',
+      '/repo-feature',
+      'feature',
+      'origin/feature',
+      true,
+      false,
+      { checkoutExistingBranch: true }
+    )
+
+    expect(result.localBaseRefRefresh).toEqual({
+      status: 'skipped_error',
+      baseRef: 'origin/feature',
+      localBranch: 'feature'
+    })
+  })
+
   it('skips the claim-path refresh for sparse (--no-checkout) creates', async () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add --no-checkout
 

--- a/src/main/git/worktree-add-local-base-refresh.test.ts
+++ b/src/main/git/worktree-add-local-base-refresh.test.ts
@@ -42,7 +42,6 @@ describe('addWorktree', () => {
     translateWslOutputPathsMock.mockClear()
   })
 
-
   it('fast-forwards a checked-out existing branch inside the new worktree (#15645)', async () => {
     // The branch pre-exists locally, is behind origin, and the new worktree just
     // checked it out — so the branch is OWNED by /repo-feature now.
@@ -71,14 +70,56 @@ describe('addWorktree', () => {
       { checkoutExistingBranch: true }
     )
 
-    // eslint-disable-next-line no-console
-    console.log('CALLS', JSON.stringify(gitExecFileAsyncMock.mock.calls.map((c) => c[0])))
     expect(result.localBaseRefRefresh).toMatchObject({ status: 'updated' })
     const reset = gitExecFileAsyncMock.mock.calls.find(
       (call) => call[0][0] === 'reset'
     ) as unknown as [string[], { cwd?: string }]
     expect(reset[0]).toEqual(['reset', '--hard', 'remote-tip'])
     expect(reset[1].cwd).toBe('/repo-feature')
+  })
+
+  it('leaves a claimed branch with local-only commits silent (#15645)', async () => {
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: '' }) // worktree add /repo-feature feature
+      .mockResolvedValueOnce({ stdout: 'remote-tip\n' }) // resolveWorktreeAddBaseRef existence probe
+      .mockResolvedValueOnce({ stdout: '1\t2\n' }) // rev-list --left-right --count (ahead 1 -> not fast-forwardable)
+
+    const result = await addWorktree(
+      '/repo',
+      '/repo-feature',
+      'feature',
+      'origin/feature',
+      true,
+      false,
+      { checkoutExistingBranch: true }
+    )
+
+    // Claiming a branch you already have commits on is the normal case, not a warning worth an infinite toast.
+    expect(result.localBaseRefRefresh).toBeUndefined()
+    expect(gitExecFileAsyncMock.mock.calls.find((call) => call[0][0] === 'reset')).toBeUndefined()
+  })
+
+  it('skips the claim-path refresh for sparse (--no-checkout) creates', async () => {
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add --no-checkout
+
+    const result = await addWorktree(
+      '/repo',
+      '/repo-feature',
+      'feature',
+      'origin/feature',
+      true,
+      true,
+      { checkoutExistingBranch: true }
+    )
+
+    // A --no-checkout worktree has an empty index, so probing it would report a bogus dirty status.
+    expect(result.localBaseRefRefresh).toBeUndefined()
+    expect(gitExecFileAsyncMock.mock.calls).toEqual([
+      [
+        ['worktree', 'add', '--no-checkout', '/repo-feature', 'feature'],
+        { cwd: '/repo', timeout: WORKTREE_ADD_TIMEOUT_MS }
+      ]
+    ])
   })
 
   it('fast-forwards with reset --hard when localBranch is checked out in primary worktree', async () => {

--- a/src/main/git/worktree-add-local-base-refresh.test.ts
+++ b/src/main/git/worktree-add-local-base-refresh.test.ts
@@ -78,6 +78,31 @@ describe('addWorktree', () => {
     expect(reset[1].cwd).toBe('/repo-feature')
   })
 
+  it('skips the no-op reset when the claimed branch is already up to date (#15645)', async () => {
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: '' }) // worktree add /repo-feature feature
+      .mockResolvedValueOnce({ stdout: 'remote-tip\n' }) // resolveWorktreeAddBaseRef existence probe
+      .mockResolvedValueOnce({ stdout: '0\t0\n' }) // rev-list --left-right --count (already current)
+
+    const result = await addWorktree(
+      '/repo',
+      '/repo-feature',
+      'feature',
+      'origin/feature',
+      true,
+      false,
+      { checkoutExistingBranch: true }
+    )
+
+    expect(result.localBaseRefRefresh).toBeUndefined()
+    // The common claim: nothing to fast-forward, so no OID resolution, owner probes, or reset --hard.
+    expect(gitExecFileAsyncMock.mock.calls.map(([args]) => args)).toEqual([
+      ['worktree', 'add', '/repo-feature', 'feature'],
+      ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/feature^{commit}'],
+      ['rev-list', '--left-right', '--count', 'refs/heads/feature...refs/remotes/origin/feature']
+    ])
+  })
+
   it('leaves a claimed branch with local-only commits silent (#15645)', async () => {
     gitExecFileAsyncMock
       .mockResolvedValueOnce({ stdout: '' }) // worktree add /repo-feature feature

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -1018,6 +1018,23 @@ async function performAddWorktree(
   })
 
   if (options.checkoutExistingBranch) {
+    // Why (#15645): the just-created worktree owns the branch now, so the
+    // refresh's owner path fast-forwards it in place (reset --hard inside the
+    // owning worktree is the one mutation git permits here). Skipping this
+    // left a pre-existing local branch checked out at its own stale commit —
+    // with no upstream, nothing ever signalled the staleness.
+    if (refreshLocalBaseRef && baseBranch) {
+      const effectiveExistingBase = await resolveWorktreeAddBaseRef(baseBranch, (qualifiedRef) =>
+        hasWorktreeBaseCommitRef(repoPath, qualifiedRef, options)
+      )
+      localBaseRefRefresh = await refreshLocalBaseRefForWorktreeCreate(
+        repoPath,
+        baseBranch,
+        effectiveExistingBase,
+        options.remoteTrackingBase,
+        options
+      )
+    }
     return localBaseRefRefresh ? { localBaseRefRefresh } : {}
   }
 

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -240,7 +240,7 @@ async function evaluateLocalBaseRefRefreshability(
       return { refreshable: false, result: { ...resultBase, status: 'skipped_not_fast_forward' } }
     }
     if (!shouldInspectOwner(parsedDrift.behind)) {
-      // Why: a current local ref yields no update suggestion, so the advisory path skips OID resolution and owner inspection.
+      // Why: a current local ref has nothing to fast-forward, so skip OID resolution, owner inspection, and the no-op reset entirely.
       return undefined
     }
     const { stdout: localOidOutput } = await gitExecFileAsync(
@@ -875,7 +875,8 @@ async function refreshLocalBaseRefForWorktreeCreate(
     baseBranch,
     remoteTrackingRef,
     remoteTrackingBase,
-    options
+    options,
+    (behind) => behind > 0
   )
   if (!evaluation) {
     return undefined

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -1020,7 +1020,7 @@ async function performAddWorktree(
   })
 
   if (options.checkoutExistingBranch) {
-    // Why (#15645): run after the add — the new worktree owns the branch now, so the refresh's owner path can reset --hard it in place.
+    // Why (#15645): run after the add so the refresh's owner path can reset --hard the base ref's local counterpart in place — that is the branch this worktree just claimed when the base is its own remote-tracking ref, otherwise whichever worktree already holds that local branch (often the primary repo).
     // Why !noCheckout: a sparse create's index is still empty here, so the clean-status probe would false-positive dirty.
     if (refreshLocalBaseRef && baseBranch && !noCheckout) {
       const effectiveExistingBase = await resolveWorktreeAddBaseRef(baseBranch, (qualifiedRef) =>
@@ -1033,8 +1033,9 @@ async function performAddWorktree(
         options.remoteTrackingBase,
         options
       )
-      // Why: the user deliberately claimed this branch — local-only commits are expected, so only report a successful fast-forward instead of an infinite "not refreshed" warning this path never used to raise.
-      localBaseRefRefresh = claimedRefresh?.status === 'updated' ? claimedRefresh : undefined
+      // Why: the user deliberately claimed this branch, so local-only commits are expected and stay silent; a dirty owner or a git error still warns, because there the new worktree is stuck on the stale commit for a fixable reason.
+      localBaseRefRefresh =
+        claimedRefresh?.status === 'skipped_not_fast_forward' ? undefined : claimedRefresh
     }
     return localBaseRefRefresh ? { localBaseRefRefresh } : {}
   }

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -937,8 +937,9 @@ async function refreshLocalBaseRefForWorktreeCreate(
  * @remarks Side effects (best-effort, warn-only): passes `--no-track`, writes
  * `branch.<branch>.base` for new-branch worktrees with a base ref, and may
  * write `push.autoSetupRemote=true` to the repo's shared config. When
- * `checkoutExistingBranch` and `refreshLocalBaseRef` are both set, the claimed
- * branch itself may be fast-forwarded inside the new worktree after the add.
+ * `checkoutExistingBranch` and `refreshLocalBaseRef` are both set, the base
+ * ref's local counterpart may be fast-forwarded after the add, inside whichever
+ * worktree owns it (the new one when the base is the claimed branch's remote).
  */
 export async function addWorktree(
   repoPath: string,

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -936,7 +936,9 @@ async function refreshLocalBaseRefForWorktreeCreate(
  * @param baseBranch - Optional base branch to create from (defaults to HEAD)
  * @remarks Side effects (best-effort, warn-only): passes `--no-track`, writes
  * `branch.<branch>.base` for new-branch worktrees with a base ref, and may
- * write `push.autoSetupRemote=true` to the repo's shared config.
+ * write `push.autoSetupRemote=true` to the repo's shared config. When
+ * `checkoutExistingBranch` and `refreshLocalBaseRef` are both set, the claimed
+ * branch itself may be fast-forwarded inside the new worktree after the add.
  */
 export async function addWorktree(
   repoPath: string,
@@ -1018,22 +1020,21 @@ async function performAddWorktree(
   })
 
   if (options.checkoutExistingBranch) {
-    // Why (#15645): the just-created worktree owns the branch now, so the
-    // refresh's owner path fast-forwards it in place (reset --hard inside the
-    // owning worktree is the one mutation git permits here). Skipping this
-    // left a pre-existing local branch checked out at its own stale commit —
-    // with no upstream, nothing ever signalled the staleness.
-    if (refreshLocalBaseRef && baseBranch) {
+    // Why (#15645): run after the add — the new worktree owns the branch now, so the refresh's owner path can reset --hard it in place.
+    // Why !noCheckout: a sparse create's index is still empty here, so the clean-status probe would false-positive dirty.
+    if (refreshLocalBaseRef && baseBranch && !noCheckout) {
       const effectiveExistingBase = await resolveWorktreeAddBaseRef(baseBranch, (qualifiedRef) =>
         hasWorktreeBaseCommitRef(repoPath, qualifiedRef, options)
       )
-      localBaseRefRefresh = await refreshLocalBaseRefForWorktreeCreate(
+      const claimedRefresh = await refreshLocalBaseRefForWorktreeCreate(
         repoPath,
         baseBranch,
         effectiveExistingBase,
         options.remoteTrackingBase,
         options
       )
+      // Why: the user deliberately claimed this branch — local-only commits are expected, so only report a successful fast-forward instead of an infinite "not refreshed" warning this path never used to raise.
+      localBaseRefRefresh = claimedRefresh?.status === 'updated' ? claimedRefresh : undefined
     }
     return localBaseRefRefresh ? { localBaseRefRefresh } : {}
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​147 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​147 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 |

<!-- /orca-pr-loc -->

Supersedes #15815 by @yzxcj797 (alt: kaluli123123) — carried over so it can run full CI (fork PRs only run `track-community-pr` in this repo). Original authorship preserved in the commit.

## ELI5

When you create a workspace and tell Orca "use the branch I already have" instead of "make me a new branch", Orca checked that branch out exactly where it was — possibly weeks behind the remote — and then quietly gave up on catching it up. So you started working on old code with nothing on screen saying so. This makes Orca fast-forward that branch inside the brand-new workspace, which is the one moment git actually allows it.

## What Changed

`src/main/git/worktree.ts`, `performAddWorktree`:

- The `checkoutExistingBranch` ("claim an existing local branch") arm never assigned `localBaseRefRefresh`, so `return localBaseRefRefresh ? { localBaseRefRefresh } : {}` was dead code that always returned `{}`. It now runs the existing `refreshLocalBaseRefForWorktreeCreate` **after** the `worktree add`.
- Ordering is the load-bearing part: once the add completes, the new worktree owns the branch, so `evaluateLocalBaseRefRefreshability` finds it as `ownerWorktreePath`, re-verifies ownership, requires a clean `status --porcelain`, and fast-forwards with `reset --hard` *inside that worktree*.
- Scope precision: the refresh targets **the base ref's local counterpart**, which is the branch you just claimed only when the base is that branch's own remote-tracking ref (the case #15645 reports). `canCheckoutExistingLocalBranch` also admits a base like `origin/main` when `refs/heads/<claimed>` happens to sit at that OID; there the counterpart is `main` and the owner is whatever worktree has `main` checked out — usually the primary repo. That is the same mutation the new-branch arm already performs for a create from `origin/main` under this setting, and it is still gated by `ahead === 0` plus a clean-status check, so nothing can be lost. The code comment says this explicitly rather than claiming "the new worktree owns the branch".
- `skipped_not_fast_forward` is swallowed on this path (maintainer change on top of #15815). Claiming a branch you already have commits on is the normal case; surfacing it would raise a brand-new `duration: Infinity` warning toast whose text ("Local `<b>` does not exist or cannot be fast-forwarded cleanly…") is one of the things #15645 explicitly calls out as wrong.
- `skipped_dirty_worktree` and `skipped_error` **are** surfaced. Those are the two outcomes where the fix silently fails to land and the new workspace really is stuck on the stale commit for a fixable reason (commit/stash the owner worktree, or clear the locked ref); their toast text is accurate and actionable as written. `updated` stays silent as before.
- The refresh short-circuits when the local counterpart is already current (`behind === 0`), the same `(behind) => behind > 0` predicate `getLocalBaseRefUpdateSuggestionForWorktreeCreate` already passes. This is the most common claim of all, and without it all 10 subprocesses ran — ending in a `reset --hard` to the commit the worktree was already sitting on. Measured waste: +354 ms macOS / +751 ms Windows / +514 ms Linux, now ~0. It also removes a false warning: an already-current base with a *dirty* owner worktree used to raise the `skipped_dirty_worktree` toast telling you to update a branch that had nothing to update.
- The refresh is skipped for `--no-checkout` (sparse) creates (maintainer change). `addSparseWorktree` calls `addWorktree(..., noCheckout = true)`, and a `--no-checkout` worktree's index is empty relative to HEAD, so the clean-status probe reads staged deletions and false-positives as dirty.

No config is written, no relay/wire change, no new stream opcode, and behavior is unchanged when `refreshLocalBaseRefOnWorktreeCreate` is off.

## Why

Root cause: the local-base-ref refresh was only ever wired into the new-branch (`-b`) arm. On the claim path git will not let the primary repo move a ref that another worktree has checked out in any useful way — `update-ref` from the main repo does "succeed" but desyncs the new worktree's index (verified with real git 2.44: the fresh worktree immediately reports `M f.txt`). Doing the refresh *after* the add, through the existing owner path, uses `reset --hard` in the owning worktree, which is the correct and only safe mutation. `ahead !== 0` still short-circuits before any mutation, so local commits can never be lost.

I picked #15815 over the competing #15796 (+113/-38, 5 files, `push.autoSetupRemote` angle):

- #15796 does not address the stale-checkout symptom at all — the branch still lands on old code silently.
- `push.autoSetupRemote` is not an upstream: `branch.<b>.remote`/`.merge` stay unset, so `git pull`, `git status` ahead/behind, and Graphite base (all named in the issue) remain broken.
- Its stated rationale ("`--no-track` leaves no upstream until first push") does not apply to the claim path, which never passes `--no-track`.
- It writes `git config --local push.autoSetupRemote true`, which on a linked worktree lands in the shared common-dir config and mutates the whole repo, on a path where the user never asked Orca to create a branch.

The two are semantically complementary; if the upstream half is wanted, #15796's `ensurePushAutoSetupRemote` extraction is a reasonable standalone follow-up (they conflict textually — same block — so not concurrently).

## Linked Issue

Refs #15645 — **deliberately not a closing keyword.** This fixes the load-bearing half of the report (the new worktree silently landing on the stale commit). The report's second defect — the claimed branch being left with no upstream, which keeps `git pull`, `git status` ahead/behind and Graphite base broken — is *not* addressed here, so the issue must stay open after merge.

## Known limitations / follow-ups

Not covered here, deliberately, to keep the diff focused:

1. SSH/remote claim path — `src/main/ipc/worktree-remote.ts:1719` gates the refresh behind `&& !checkoutExistingBranch`, and `src/relay/git-handler-worktree-ops.ts` returns right after `worktree add`. Per `docs/reference/ssh-execution-boundary.md` that mutation must land in the relay op, not be simulated client-side.
2. Sparse claim creates are skipped rather than fixed; doing it properly means running the refresh after `addSparseWorktree`'s final `checkout`.
3. `localBaseRefRefreshFailedDetailNotFastForward` conflates "does not exist" with "has local-only commits".
4. The SSH analog `refreshLocalBaseRefForRemoteWorktreeCreate` (`src/main/ipc/worktree-remote.ts`) takes the same `shouldInspectOwner` parameter but still passes the default, so a `behind === 0` remote *new-branch* create pays owner probes it does not need. Left alone here to keep this diff to the claim path.
5. `refreshLocalBaseRefOnWorktreeCreate` defaults to `false` (`src/shared/constants.ts`), so the fix only reaches opted-in users. Open question: should claiming a branch fast-forward *that* branch regardless, given the operation is provably lossless (`ahead === 0` is enforced before any reset)?

## Visual Proof

`N/A` — no renderer code changed and no new toast component/copy was added. One behavior note: on the claim path a `skipped_dirty_worktree` / `skipped_error` result now reaches the existing `showLocalBaseRefRefreshToast`, which renders today's warning toast with today's copy. It needs a dirty owner worktree or a git failure to appear, and only when `refreshLocalBaseRefOnWorktreeCreate` is on.

## Testing

Ran on **macOS only** (arm64, git 2.44). Linux/Windows are covered by reasoning: no new git commands beyond ones already used here (`rev-list --left-right --count`, `rev-parse --verify`, `merge-base --is-ancestor`, `worktree list --porcelain`, `status --porcelain`, `reset --hard` — all far below the 2.25 baseline), no path-string manipulation, no shell interpolation (everything goes through the argv-array `gitExecFileAsync`).

Automated:

```
npx vitest run --config config/vitest.config.ts \
  src/main/git/worktree-add-local-base-refresh.test.ts \
  src/main/git/worktree-add-creation-config.test.ts \
  src/main/git/worktree-add-local-base-suggestion.test.ts \
  src/main/git/worktree-add-timeout-override.test.ts \
  src/main/git/add-sparse-worktree.test.ts \
  src/main/git/worktree-sparse-checkout.test.ts \
  src/relay/git-handler-worktree-ops.test.ts \
  src/main/ipc/worktrees-existing-branch-checkout.test.ts
# all passed (7 files / 75 tests in the latest run, which drops
# worktree-sparse-checkout.test.ts and adds the existing-branch IPC suite)

npx vitest run --config config/vitest.config.ts \
  src/renderer/src/store/slices/worktrees-create-base-status.test.ts \
  src/main/ipc/worktrees-ssh-local-base-refresh.test.ts
# 2 files, 27 tests passed (the two other consumers of `localBaseRefRefresh`)

npx vitest run --config config/vitest.config.ts \
  src/main/ipc/worktrees-existing-branch-checkout.test.ts \
  src/main/ipc/worktrees-ssh-branch-conflict-suffixing.test.ts \
  src/main/git/status-submodule-path-cache.test.ts \
  src/relay/git-handler-worktree-provisioning.test.ts
# 4 files, 47 tests passed

npx oxlint src/main/git/worktree.ts src/main/git/worktree-add-local-base-refresh.test.ts               # clean
npx oxlint --config config/oxlint-code-quality-native-plugins.json <same files> --deny-warnings        # clean
npx oxfmt --check <same files>                                                                         # clean
```

Re-run after the `behind === 0` short-circuit was added: `worktree-add-local-base-refresh` (16 tests, incl. the new one), `worktree-add-local-base-suggestion`, `worktree-add-creation-config`, `add-sparse-worktree`, `worktree-sparse-checkout`, `worktree-add-timeout-override`, `worktrees-ssh-local-base-refresh`, `git-handler-worktree-provisioning`, `worktrees-create-base-status` — 9 files / 113 tests passed; `npx oxlint` and `npx oxfmt --check` clean on both touched files.

Regression proof (each test was watched failing without the corresponding product change):

- With `src/main/git/worktree.ts` reverted to `origin/main`: `fast-forwards a checked-out existing branch inside the new worktree (#15645)` fails (1 failed / 12 passed).
- With only the maintainer hunk reverted (i.e. #15815 as submitted): `leaves a claimed branch with local-only commits silent (#15645)` and `skips the claim-path refresh for sparse (--no-checkout) creates` both fail (2 failed / 11 passed) — confirming both regressions were real, not theoretical.
- Without the `(behind) => behind > 0` short-circuit: `skips the no-op reset when the claimed branch is already up to date (#15645)` fails (1 failed / 15 passed) on the extra `rev-parse`/`worktree list`/`status`/`reset --hard` calls.
- With the outcome filter narrowed back to `status === 'updated' ? claimedRefresh : undefined`: `surfaces a dirty owner worktree on the claim path (#15645)` and `surfaces a git error on the claim path (#15645)` both fail (2 failed / 13 passed).

Real-git verification of the semantics the mocks can't prove (git 2.44), clone with local `feat` one commit behind `origin/feat`:

- `git worktree add <path> feat` → new worktree HEAD is at the **stale** commit, `status --porcelain --untracked-files=no` is empty (the bug, and why the clean-status gate passes).
- `git update-ref refs/heads/feat <remote> <local>` from the primary repo → the new worktree immediately reports `M f.txt` (why the bare-ref path is wrong here).
- `git -C <new worktree> reset --hard <origin/feat oid>` → HEAD now equals `origin/feat`, worktree clean (the path this PR takes).
- `git worktree add --no-checkout <path> -b tmp` → `status --porcelain --untracked-files=no` prints `D f.txt` (why sparse creates are skipped).

Not run: `pnpm typecheck` / full `pnpm lint` (CI covers; they OOM locally under parallel agents). End-to-end Orca UI create-flow was not exercised.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Cross-platform**: no `path` string building, no separator assumptions, no keyboard/accelerator surface. Git argv is identical on all three OSes; WSL path translation is untouched (`translateWslOutputPaths` is still applied by the shared refresh helper).
- **SSH/remote**: no change. The remote claim path stays gated off in `worktree-remote.ts` and the relay op is untouched, so no host/client behavior divergence is introduced. `AddWorktreeResult.localBaseRefRefresh` is a pre-existing optional field, so nothing new crosses the wire and no capability negotiation is needed — old clients paired with a new host see exactly what they see today.
- **Folder workspaces**: unaffected; this code only runs under `git worktree add`.
- **Provider neutrality**: pure git plumbing, no GitHub/GitLab-specific anything.
- **Git compatibility**: every command used predates 2.25 by years.
- **Agent/integration compatibility**: no IPC signature, settings key, or persisted-state change.
- **Performance** (measured, not estimated — Orca itself, ~16.5k tracked files, medians over 7–9 creates through the real `addWorktree`): when the claimed base is genuinely behind, the claim path adds **exactly 10 git subprocesses**, in this order — `rev-parse --verify --quiet <base>^{commit}`, `rev-list --left-right --count`, `rev-parse --verify` ×2, `merge-base --is-ancestor`, `worktree list --porcelain`, `status --porcelain --untracked-files=no` (in the new worktree), then the mutating path repeats `worktree list --porcelain` + `status --porcelain` as a TOCTOU re-check and finishes with `reset --hard`. Six are sub-20 ms plumbing; the cost is the three whole-tree operations (2× `status`, 1× `reset --hard`).

  | host (git) | `worktree add` baseline | added, base behind (the case this fixes) | added, base already current |
  | :--- | ---: | ---: | ---: |
  | macOS arm64 (2.44) | 1.90 s | **+658 ms** (+35%) | +27 ms (was +354 ms) |
  | Windows `awin` (2.55) | 6.64–7.37 s | **+903 ms** (+12%) | +39 ms (was +751 ms) |
  | Linux SSH box, run natively (2.43) | 0.83 s | **+709 ms** (+85%) | +4 ms (was +514 ms) |

  The already-current column is the `behind === 0` short-circuit described above: it exits after the same 2 calls as the `ahead > 0` case, whose measured cost is 27 / 39 / 4 ms. Before the short-circuit it ran the full 10, including a no-op `reset --hard`.

  Zero-cost cases are zero, verified by spawn count and not by assumption — setting off: 0 added calls; sparse/`--no-checkout` create: 0; no base ref: 0. Cheap cases: a non-remote-tracking base (plain local branch) costs 1 call (14 ms macOS / 19 ms Windows / 2 ms Linux); a claimed branch with local-only commits (`ahead > 0`) or one already up to date short-circuits after 2 calls (27 / 39 / 4 ms). SSH/relay creates pay nothing at all — `worktree-remote.ts` still gates the refresh behind `!checkoutExistingBranch` and `git-handler-worktree-ops.ts` returns right after the add — so no per-call SSH round trip is introduced. A Windows repo on a WSL filesystem is the worst shape: each git call crosses `wsl.exe` at ~70 ms measured, so the 10 calls cost ~700 ms of bridge alone.

  Two corrections to what this bullet used to say. (1) These are not all "cheap plumbing calls": `reset --hard` alone is 193 ms macOS / 485 ms Windows / 364 ms Linux. (2) It is **not** "already the cost paid by the new-branch path" — measured side by side in the identical repo shape, the new-branch arm's refresh costs **84 ms**, because the local base branch is usually checked out nowhere and it takes the bare-ref `update-ref` route. The claim path is ~8× that when the base is behind, because the just-created worktree is *always* the owner, which forces the two `status` walks and the `reset --hard`. Remaining honest cost: that full 10-call path still runs whenever the branch really is behind — worst measured case ~+903 ms on Windows for a repo this size — on the blocking create path (the workspace is not registered until `addWorktree` resolves), once per create, and only when `refreshLocalBaseRefOnWorktreeCreate` is on. That is the actual work of catching the branch up, not overhead.
- **UI quality**: no new component or copy. The existing local-base-ref warning toast can now fire on the claim path for the two genuinely-failed outcomes; `skipped_not_fast_forward` (the expected local-only-commits case) stays silent so the common path is not noisy.
- **Security**: no network, no filesystem writes outside git's own, no config mutation, no credential/secret access. All git calls go through the argv-array `execFile` wrapper, so no shell injection surface.
- **Contributor diff scan**: I reviewed #15815 hunk by hunk for malicious content. Two files, both under `src/`, no `package.json`/lockfile/workflow/script changes, no new dependencies, no network calls, no `eval`/dynamic `require`, no obfuscation, no credential or env access, and no prompt-injection text in comments or agent-readable files. The only defect found was sloppiness, not malice: a leftover `console.log('CALLS', ...)` with an `eslint-disable-next-line no-console` in the test, removed here.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Nothing here changes what the host publishes over the relay, so mixed client/host versions are unaffected.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)




