### PR TITLE
test(runtime): use the platform submit delay in the cancellation-during-verification test

### DIFF
--- a/src/main/runtime/agent-prompt-submission-runtime.test.ts
+++ b/src/main/runtime/agent-prompt-submission-runtime.test.ts
@@ -676,8 +676,10 @@ describe('agent prompt submission runtime', () => {
     })
     const rejected = expect(submission).rejects.toThrow('request_aborted')
 
-    // Why: the settle delay is platform-dependent (1_500 on Windows); a hardcoded 500 aborts before the Enter there.
+    // Why: the submit delay is 1_500 on Windows (ConPTY); a hardcoded 500 aborts before the Enter there.
     await vi.advanceTimersByTimeAsync(AGENT_PROMPT_SUBMIT_DELAY_MS)
+    // Why: pin the phase boundary so drift fails here instead of as an empty post-abort array.
+    expect(writes.filter((data) => data === '\r')).toHaveLength(1)
     controller.abort()
     await vi.runAllTimersAsync()
 

--- a/src/main/runtime/agent-prompt-submission-runtime.test.ts
+++ b/src/main/runtime/agent-prompt-submission-runtime.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { AGENT_PROMPT_BRACKETED_PASTE_END } from '../../shared/agent-prompt-injection'
+import {
+  AGENT_PROMPT_BRACKETED_PASTE_END,
+  AGENT_PROMPT_SUBMIT_DELAY_MS
+} from '../../shared/agent-prompt-injection'
 import { OrcaRuntimeService } from './orca-runtime'
 import { makeStore } from './runtime-rpc-worktree-store-fixtures'
 
@@ -673,7 +676,8 @@ describe('agent prompt submission runtime', () => {
     })
     const rejected = expect(submission).rejects.toThrow('request_aborted')
 
-    await vi.advanceTimersByTimeAsync(500)
+    // Why: the settle delay is platform-dependent (1_500 on Windows); a hardcoded 500 aborts before the Enter there.
+    await vi.advanceTimersByTimeAsync(AGENT_PROMPT_SUBMIT_DELAY_MS)
     controller.abort()
     await vi.runAllTimersAsync()
 

--- a/src/main/runtime/agent-prompt-submission-windows-submit-delay.test.ts
+++ b/src/main/runtime/agent-prompt-submission-windows-submit-delay.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type * as AgentPromptInjection from '../../shared/agent-prompt-injection'
+import { OrcaRuntimeService } from './orca-runtime'
+import { makeStore } from './runtime-rpc-worktree-store-fixtures'
+
+// Why: vi.mock factories are hoisted above module-scope consts, so the delay must be hoisted too.
+const { WINDOWS_SUBMIT_DELAY_MS } = vi.hoisted(() => ({ WINDOWS_SUBMIT_DELAY_MS: 1_500 }))
+const WORKTREE_PATH = '/tmp/worktree-a'
+
+// Why: AGENT_PROMPT_SUBMIT_DELAY_MS is frozen from process.platform at import, so the 1_500 ConPTY
+// path is otherwise unreachable on the Linux/macOS lanes that run this suite.
+vi.mock('../../shared/agent-prompt-injection', async (importOriginal) => ({
+  ...(await importOriginal<typeof AgentPromptInjection>()),
+  AGENT_PROMPT_SUBMIT_DELAY_MS: WINDOWS_SUBMIT_DELAY_MS
+}))
+
+vi.mock('../git/worktree', () => ({
+  listWorktrees: vi.fn().mockResolvedValue([
+    {
+      path: '/tmp/worktree-a',
+      head: 'abc',
+      branch: 'feature/prompt-verification',
+      isBare: false,
+      isMainWorktree: false
+    }
+  ]),
+  listWorktreesStrict: vi.fn().mockResolvedValue([
+    {
+      path: '/tmp/worktree-a',
+      head: 'abc',
+      branch: 'feature/prompt-verification',
+      isBare: false,
+      isMainWorktree: false
+    }
+  ])
+}))
+
+// Why: 'aider' is not a settlement agent, so submission takes the fixed-delay branch under test.
+async function createPromptRuntime(): Promise<{
+  runtime: OrcaRuntimeService
+  handle: string
+  writes: string[]
+}> {
+  const runtime = new OrcaRuntimeService(makeStore() as never)
+  const writes: string[] = []
+  runtime.setPtyController({
+    spawn: vi.fn().mockResolvedValue({ id: 'pty-prompt' }),
+    write: (_ptyId, data) => {
+      writes.push(data)
+      return true
+    },
+    kill: () => true,
+    getForegroundProcess: async () => null
+  })
+  const terminal = await runtime.createTerminal(`path:${WORKTREE_PATH}`, {
+    launchAgent: 'aider'
+  })
+  return { runtime, handle: terminal.handle, writes }
+}
+
+function countSubmits(writes: readonly string[]): number {
+  return writes.filter((data) => data === '\r').length
+}
+
+describe('agent prompt submission at the Windows submit delay', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('holds Enter until the full platform delay elapses', async () => {
+    vi.useFakeTimers()
+    const { runtime, handle, writes } = await createPromptRuntime()
+    const submission = runtime.sendTerminalAgentPrompt(handle, 'review this')
+    const stalled = expect(submission).rejects.toThrow('agent_prompt_stalled')
+
+    await vi.advanceTimersByTimeAsync(WINDOWS_SUBMIT_DELAY_MS - 1)
+    expect(countSubmits(writes)).toBe(0)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(countSubmits(writes)).toBe(1)
+
+    await vi.runAllTimersAsync()
+    await stalled
+  })
+
+  it('does not send another Enter after cancellation during verification', async () => {
+    vi.useFakeTimers()
+    const controller = new AbortController()
+    const { runtime, handle, writes } = await createPromptRuntime()
+    const submission = runtime.sendTerminalAgentPrompt(handle, 'review this', {
+      signal: controller.signal
+    })
+    const rejected = expect(submission).rejects.toThrow('request_aborted')
+
+    await vi.advanceTimersByTimeAsync(WINDOWS_SUBMIT_DELAY_MS)
+    expect(countSubmits(writes)).toBe(1)
+    controller.abort()
+    await vi.runAllTimersAsync()
+
+    await rejected
+    expect(countSubmits(writes)).toBe(1)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​108 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​106 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

Supersedes #15499 by @Tauri-EPO — carried over so it can run full CI (fork PRs only run `track-community-pr` in this repo). Original authorship is preserved in the commit (`3d939ae` / `test(runtime): abort after the platform submit delay in the cancellation-during-verification test`).

## ELI5

One of our tests pretends time is passing so it doesn't have to actually wait. It fast-forwarded a stopwatch by exactly 500ms, then checked that the app had pressed Enter. That works on macOS and Linux, where the app waits 500ms before pressing Enter — but on Windows the app deliberately waits 1,500ms (the Windows terminal draws big pastes more slowly, so pressing Enter early would leave the prompt half-typed). So on Windows the test fast-forwarded to 500ms, cancelled while the app was still waiting, and then complained that Enter was never pressed. The test now fast-forwards by whatever the real wait is on the current platform. This PR also adds a second test that fakes the Windows 1,500ms value so our Linux CI machines actually exercise that path.

## What Changed

Test-only. No product code is touched.

- `src/main/runtime/agent-prompt-submission-runtime.test.ts` — `does not send another Enter after cancellation during verification` now advances fake timers by the exported `AGENT_PROMPT_SUBMIT_DELAY_MS` instead of a hardcoded `500`. Also adds an assertion immediately before `controller.abort()` pinning that exactly one `\r` has been written, so future timing drift fails at the phase boundary rather than as an ambiguous empty array after the abort.
- `src/main/runtime/agent-prompt-submission-windows-submit-delay.test.ts` (new, 100 lines) — mocks `AGENT_PROMPT_SUBMIT_DELAY_MS` to the Windows value `1_500` and covers two things on the Ubuntu lanes: that Enter is withheld at `1_499` and written at `1_500`, and the cancellation-during-verification scenario at the Windows delay.

## Why

Root cause: `AGENT_PROMPT_SUBMIT_DELAY_MS` is `getAgentPromptSubmitDelayMs(process.platform)` (`src/shared/agent-prompt-injection.ts:17`) — `500` off-Windows, `1_500` on `win32`, because ConPTY renders long bracketed pastes more slowly and an early Enter leaves the task sitting in the agent's input buffer.

The test harness spawns `launchAgent: 'aider'`. `isTerminalSendSettlementAgent` (`src/main/runtime/orca-runtime.ts:40782`) only returns true for `claude`/`codex`, so `createAgentPromptRenderGate` returns `null` and submission takes the `else` branch `await waitForAgentPromptDelay(AGENT_PROMPT_SUBMIT_DELAY_MS, options.signal)` (`orca-runtime.ts:19421`). On Windows the abort at `t=500` therefore landed *inside* that delay, before the single `\r` at `orca-runtime.ts:19440` — so `toHaveLength(1)` saw `0`. That is exactly #15498, and it broke every Windows checkout of this suite.

Advancing by the platform constant makes the abort land inside `verifyAgentPromptSubmission`'s 50ms poll loop (`agent-prompt-submission-verification.ts`) on every platform, which is what the test name actually promises. Without the fix the test also silently degenerated into a duplicate of its sibling `...during settlement` test, so it was asserting nothing new. This matches existing repo precedent — `src/main/runtime/orca-runtime.test.ts:17009` already advances by `AGENT_PROMPT_SUBMIT_DELAY_MS - 1` for these same non-settlement agents.

The second file exists because the constant is frozen from `process.platform` at module import, so an Ubuntu runner only ever exercises the `500` path even after this fix. Without it, this exact regression class can silently reappear and only surface on contributors' Windows machines.

## Linked Issue

Fixes #15498

## Visual Proof

`N/A` — test-only change with no product code touched, so there is nothing user-visible to capture.

## Testing

Executed on **macOS only** (arm64). Windows and Linux are covered by reasoning plus the new mocked-delay suite, not by a real Windows run — see the caveat below.

```
npx vitest run --config config/vitest.config.ts \
  src/main/runtime/agent-prompt-submission-runtime.test.ts \
  src/main/runtime/agent-prompt-submission-verification.test.ts \
  src/main/runtime/agent-prompt-submission-windows-submit-delay.test.ts \
  src/shared/agent-prompt-injection.test.ts
# Test Files 4 passed (4) | Tests 49 passed (49)

npx vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t 'legacy fixed submit delay'
# 34 passed | 1150 skipped  (sibling consumer of the same constant)

npx oxlint <both changed files>                                              # clean
npx oxlint --config config/oxlint-code-quality-native-plugins.json <both> --deny-warnings   # exit 0
npx oxfmt --check <both>                                                     # all matched files correctly formatted
node config/scripts/check-max-lines-ratchet.mjs                              # OK, no new bypasses
```

Project-wide `pnpm typecheck` / `pnpm lint` were deliberately not run locally (they OOM with several agents active on this machine); CI covers them.

**Proof the new test actually bites.** Two deliberate regressions were introduced and reverted:

1. Replaced the cancellation replay's `advanceTimersByTimeAsync(WINDOWS_SUBMIT_DELAY_MS)` with a hardcoded `500` — i.e. reproducing the pre-fix test under the Windows delay. Result: `AssertionError: expected +0 to be 1`, the exact signature reported in #15498.
2. Hardcoded `waitForAgentPromptDelay(500, ...)` in `orca-runtime.ts` so product code stops honouring the platform constant. Result: `holds Enter until the full platform delay elapses` failed with `AssertionError: expected 1 to be +0`.

Both were restored; `git diff` confirms `orca-runtime.ts` is untouched on this branch.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Cross-platform** — this *is* the cross-platform fix: the hardcoded `500` was the only non-portable line, and it now derives from `getAgentPromptSubmitDelayMs(process.platform)`. No new path separators, no `metaKey`, no shell assumptions introduced. The new suite hardcodes `1_500` intentionally, as the value under test, not as an environment assumption.
- **SSH / remote** — N/A. Nothing here reports on, stops, or lists remote work; no execution-boundary verdict vocabulary is involved. The delay is applied by whichever host owns the PTY, unchanged.
- **Remote wire compatibility** — N/A. No RPC params, stream frames, or published content change; the diff never leaves test files.
- **Agent / integration compatibility** — the harness uses `aider` specifically because `claude`/`codex` take the render-gate path and never read this constant. The module mock spreads `importOriginal()`, so `AGENT_PROMPT_BRACKETED_PASTE_END`, `AGENT_PROMPT_SUBMIT`, and `buildAgentPromptPasteBytes` (all imported by `orca-runtime.ts:98-103`) keep their real values; only the delay is overridden. `orca-runtime.ts` is the sole non-test importer, so the mock's blast radius is contained.
- **Performance** — the new file adds roughly 5s of runner time and runs entirely on fake timers, so the `1_500` value costs no real wall-clock. No hot paths touched.
- **UI quality** — N/A, no UI surface.
- **Security risk** — none. Test-only, no new dependencies, no network, no filesystem, no process spawning.
- **Provider neutrality / folder workspaces / Git 2.25 baseline** — all untouched; no Git commands, provider APIs, or workspace-shape assumptions in the diff.
- **max-lines** — no disables added. `agent-prompt-submission-runtime.test.ts` is 689 lines against the 800-line test budget; the ratchet script passes.

**Contributor diff scan:** I reviewed @Tauri-EPO's commit line by line before cherry-picking rather than trusting the summary, since they are a first-time contributor. The complete patch is one file, +6/-2: a named-import addition and one call-site swap from `500` to the exported constant. No network calls, no `exec`/`spawn`/`eval`/dynamic import, no `process.env` or credential reads, no `package.json`/lockfile/`.npmrc`/install-hook changes, no new dependencies, no obfuscated or non-ASCII content, no workflow/updater/signing files, and no prompt-injection text planted in comments. Nothing found; the change cannot affect shipped behavior at all.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

One deliberate omission, flagged for reviewer judgement: I did **not** add `agent-prompt-submission-runtime.test.ts` to the `Test Windows-specific boundaries` list in `.github/workflows/pr.yml`. That file hardcodes POSIX fixture paths (`/tmp/worktree-a`), and I could not verify from macOS that its other 20 cases survive Windows path normalization — adding it risks red-lighting the `package_windows` job for reasons unrelated to this fix. The new mocked-delay suite gives deterministic coverage of the same regression class on every PR lane instead of only the packaging job. Happy to add the Windows lane entry in a follow-up if someone can confirm the suite is green on a real Windows runner.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
