### PR TITLE
fix(worktree): stop warning about a stale local base branch that does not exist yet (#15331)

### DIFF
--- a/src/main/git/worktree-add-local-base-refresh.test.ts
+++ b/src/main/git/worktree-add-local-base-refresh.test.ts
@@ -347,7 +347,7 @@ describe('addWorktree', () => {
   it('skips updating the local branch when it has diverged', async () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'abc123\n' }) // rev-parse refs/remotes/origin/main^{commit}
     gitExecFileAsyncMock.mockRejectedValueOnce(new Error('not a fast-forward'))
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'local-main\n' }) // rev-parse --verify --quiet refs/heads/main^{commit} (exists)
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'refs/heads/main\n' }) // for-each-ref refs/heads/main (exists)
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     resolveCreationBaseConfigWrite()
     gitExecFileAsyncMock.mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // config --get push.autoSetupRemote (unset)
@@ -370,7 +370,7 @@ describe('addWorktree', () => {
         expect.objectContaining({ cwd: '/repo' })
       ],
       [
-        ['rev-parse', '--verify', '--quiet', 'refs/heads/main^{commit}'],
+        ['for-each-ref', '--count=1', '--format=%(refname)', 'refs/heads/main'],
         expect.objectContaining({ cwd: '/repo' })
       ],
       [
@@ -415,7 +415,7 @@ describe('addWorktree', () => {
           "fatal: ambiguous argument 'refs/heads/feature-x...refs/remotes/origin/feature-x': unknown revision or path not in the working tree."
         )
       ) // rev-list: refs/heads/feature-x does not exist yet
-      .mockResolvedValueOnce({ stdout: '' }) // rev-parse --verify --quiet refs/heads/feature-x^{commit} (missing)
+      .mockResolvedValueOnce({ stdout: '' }) // for-each-ref refs/heads/feature-x (missing)
       .mockResolvedValueOnce({ stdout: '' }) // worktree add
       .mockResolvedValueOnce({ stdout: '' }) // config --local --replace-all branch.<branch>.base
       .mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // config --get push.autoSetupRemote (unset)
@@ -449,7 +449,7 @@ describe('addWorktree', () => {
     gitExecFileAsyncMock
       .mockResolvedValueOnce({ stdout: 'abc123\n' }) // rev-parse --verify --quiet refs/remotes/origin/main^{commit}
       .mockRejectedValueOnce(new Error('unknown revision refs/heads/main')) // rev-list: no local main
-      .mockResolvedValueOnce({ stdout: '' }) // rev-parse --verify --quiet refs/heads/main^{commit} (missing)
+      .mockResolvedValueOnce({ stdout: '' }) // for-each-ref refs/heads/main (missing)
       .mockResolvedValueOnce({ stdout: '' }) // worktree add
       .mockResolvedValueOnce({ stdout: '' }) // config --local --replace-all branch.<branch>.base
       .mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // config --get push.autoSetupRemote (unset)
@@ -459,11 +459,31 @@ describe('addWorktree', () => {
 
     expect(result.localBaseRefRefresh).toBeUndefined()
     expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toContainEqual([
-      'rev-parse',
-      '--verify',
-      '--quiet',
-      'refs/heads/main^{commit}'
+      'for-each-ref',
+      '--count=1',
+      '--format=%(refname)',
+      'refs/heads/main'
     ])
+  })
+
+  // A failed probe is not proof of absence, so the warning must survive it.
+  it('keeps the warning when the local base ref probe itself fails', async () => {
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'abc123\n' }) // rev-parse --verify --quiet refs/remotes/origin/main^{commit}
+      .mockRejectedValueOnce(new Error('rev-list failed')) // drift probe
+      .mockRejectedValueOnce(new Error('fatal: not a git repository')) // for-each-ref probe could not run
+      .mockResolvedValueOnce({ stdout: '' }) // worktree add
+      .mockResolvedValueOnce({ stdout: '' }) // config --local --replace-all branch.<branch>.base
+      .mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // config --get push.autoSetupRemote (unset)
+      .mockResolvedValueOnce({ stdout: '' }) // config --local set push.autoSetupRemote
+
+    const result = await addWorktree('/repo', '/repo-feature', 'my-feature', 'origin/main', true)
+
+    expect(result.localBaseRefRefresh).toEqual({
+      status: 'skipped_not_fast_forward',
+      baseRef: 'origin/main',
+      localBranch: 'main'
+    })
   })
 
   it('still suggests nothing but keeps the warning when the local base ref exists and diverged', async () => {
@@ -491,7 +511,7 @@ describe('addWorktree', () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'new-local\n' }) // rev-parse refs/heads/main^{commit}
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'remote-main\n' }) // rev-parse refs/remotes/origin/main^{commit}
     gitExecFileAsyncMock.mockRejectedValueOnce(new Error('not an ancestor')) // merge-base captured OIDs
-    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'new-local\n' }) // rev-parse --verify --quiet refs/heads/main^{commit} (exists)
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'refs/heads/main\n' }) // for-each-ref refs/heads/main (exists)
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     resolveCreationBaseConfigWrite()
     gitExecFileAsyncMock.mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // config --get push.autoSetupRemote (unset)
@@ -526,7 +546,7 @@ describe('addWorktree', () => {
         expect.objectContaining({ cwd: '/repo' })
       ],
       [
-        ['rev-parse', '--verify', '--quiet', 'refs/heads/main^{commit}'],
+        ['for-each-ref', '--count=1', '--format=%(refname)', 'refs/heads/main'],
         expect.objectContaining({ cwd: '/repo' })
       ],
       [

--- a/src/main/git/worktree-add-local-base-refresh.test.ts
+++ b/src/main/git/worktree-add-local-base-refresh.test.ts
@@ -347,13 +347,19 @@ describe('addWorktree', () => {
   it('skips updating the local branch when it has diverged', async () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'abc123\n' }) // rev-parse refs/remotes/origin/main^{commit}
     gitExecFileAsyncMock.mockRejectedValueOnce(new Error('not a fast-forward'))
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'local-main\n' }) // rev-parse --verify --quiet refs/heads/main^{commit} (exists)
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     resolveCreationBaseConfigWrite()
     gitExecFileAsyncMock.mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // config --get push.autoSetupRemote (unset)
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // config --local set push.autoSetupRemote
 
-    await addWorktree('/repo', '/repo-feature', 'feature/test', 'origin/main', true)
+    const result = await addWorktree('/repo', '/repo-feature', 'feature/test', 'origin/main', true)
 
+    expect(result.localBaseRefRefresh).toEqual({
+      status: 'skipped_not_fast_forward',
+      baseRef: 'origin/main',
+      localBranch: 'main'
+    })
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
       [
         ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'],
@@ -361,6 +367,10 @@ describe('addWorktree', () => {
       ],
       [
         ['rev-list', '--left-right', '--count', 'refs/heads/main...refs/remotes/origin/main'],
+        expect.objectContaining({ cwd: '/repo' })
+      ],
+      [
+        ['rev-parse', '--verify', '--quiet', 'refs/heads/main^{commit}'],
         expect.objectContaining({ cwd: '/repo' })
       ],
       [
@@ -405,6 +415,7 @@ describe('addWorktree', () => {
           "fatal: ambiguous argument 'refs/heads/feature-x...refs/remotes/origin/feature-x': unknown revision or path not in the working tree."
         )
       ) // rev-list: refs/heads/feature-x does not exist yet
+      .mockResolvedValueOnce({ stdout: '' }) // rev-parse --verify --quiet refs/heads/feature-x^{commit} (missing)
       .mockResolvedValueOnce({ stdout: '' }) // worktree add
       .mockResolvedValueOnce({ stdout: '' }) // config --local --replace-all branch.<branch>.base
       .mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // config --get push.autoSetupRemote (unset)
@@ -418,15 +429,8 @@ describe('addWorktree', () => {
       true
     )
 
-    expect(result.localBaseRefRefresh?.status).not.toBe('skipped_not_fast_forward')
-    expect(result.localBaseRefRefresh).toEqual({
-      status: 'updated',
-      baseRef: 'origin/feature-x',
-      localBranch: 'feature-x'
-    })
-    // The branch was created at the remote base — no extra probing, no ref mutation.
-    expect(gitExecFileAsyncMock.mock.calls).toHaveLength(6)
-    expect(gitExecFileAsyncMock.mock.calls[2]?.[0]).toEqual([
+    expect(result.localBaseRefRefresh).toBeUndefined()
+    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toContainEqual([
       'worktree',
       'add',
       '--no-track',
@@ -435,6 +439,50 @@ describe('addWorktree', () => {
       '/repo-feature-x',
       'refs/remotes/origin/feature-x'
     ])
+    // Nothing was refreshed, so no ref mutation.
+    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0][0])).not.toContain('update-ref')
+    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0][0])).not.toContain('reset')
+  })
+
+  // #15331: same missing-local-branch class, but the new branch name differs from the base's.
+  it('does not warn when the local base branch does not exist in a fetch-only clone', async () => {
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'abc123\n' }) // rev-parse --verify --quiet refs/remotes/origin/main^{commit}
+      .mockRejectedValueOnce(new Error('unknown revision refs/heads/main')) // rev-list: no local main
+      .mockResolvedValueOnce({ stdout: '' }) // rev-parse --verify --quiet refs/heads/main^{commit} (missing)
+      .mockResolvedValueOnce({ stdout: '' }) // worktree add
+      .mockResolvedValueOnce({ stdout: '' }) // config --local --replace-all branch.<branch>.base
+      .mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // config --get push.autoSetupRemote (unset)
+      .mockResolvedValueOnce({ stdout: '' }) // config --local set push.autoSetupRemote
+
+    const result = await addWorktree('/repo', '/repo-feature', 'my-feature', 'origin/main', true)
+
+    expect(result.localBaseRefRefresh).toBeUndefined()
+    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).toContainEqual([
+      'rev-parse',
+      '--verify',
+      '--quiet',
+      'refs/heads/main^{commit}'
+    ])
+  })
+
+  it('still suggests nothing but keeps the warning when the local base ref exists and diverged', async () => {
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'abc123\n' }) // rev-parse --verify --quiet refs/remotes/origin/main^{commit}
+      .mockResolvedValueOnce({ stdout: '2\t3\n' }) // rev-list: 2 local-only commits
+      .mockResolvedValueOnce({ stdout: '' }) // worktree add
+      .mockResolvedValueOnce({ stdout: '' }) // config --local --replace-all branch.<branch>.base
+      .mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // config --get push.autoSetupRemote (unset)
+      .mockResolvedValueOnce({ stdout: '' }) // config --local set push.autoSetupRemote
+
+    const result = await addWorktree('/repo', '/repo-feature', 'main', 'origin/main', true)
+
+    // Same branch name as the base, but rev-list succeeded: real divergence must still warn.
+    expect(result.localBaseRefRefresh).toEqual({
+      status: 'skipped_not_fast_forward',
+      baseRef: 'origin/main',
+      localBranch: 'main'
+    })
   })
 
   it('skips local base refresh when captured OIDs are no longer ancestor-safe', async () => {
@@ -443,6 +491,7 @@ describe('addWorktree', () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'new-local\n' }) // rev-parse refs/heads/main^{commit}
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'remote-main\n' }) // rev-parse refs/remotes/origin/main^{commit}
     gitExecFileAsyncMock.mockRejectedValueOnce(new Error('not an ancestor')) // merge-base captured OIDs
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'new-local\n' }) // rev-parse --verify --quiet refs/heads/main^{commit} (exists)
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     resolveCreationBaseConfigWrite()
     gitExecFileAsyncMock.mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // config --get push.autoSetupRemote (unset)
@@ -474,6 +523,10 @@ describe('addWorktree', () => {
       ],
       [
         ['merge-base', '--is-ancestor', 'new-local', 'remote-main'],
+        expect.objectContaining({ cwd: '/repo' })
+      ],
+      [
+        ['rev-parse', '--verify', '--quiet', 'refs/heads/main^{commit}'],
         expect.objectContaining({ cwd: '/repo' })
       ],
       [

--- a/src/main/git/worktree-add-local-base-refresh.test.ts
+++ b/src/main/git/worktree-add-local-base-refresh.test.ts
@@ -396,6 +396,47 @@ describe('addWorktree', () => {
     ])
   })
 
+  // #15331: evaluation runs before `-b <branch>` exists, so rev-list fails on the missing local ref.
+  it('does not warn when worktree add itself creates the local base branch', async () => {
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'abc123\n' }) // rev-parse --verify --quiet refs/remotes/origin/feature-x^{commit}
+      .mockRejectedValueOnce(
+        new Error(
+          "fatal: ambiguous argument 'refs/heads/feature-x...refs/remotes/origin/feature-x': unknown revision or path not in the working tree."
+        )
+      ) // rev-list: refs/heads/feature-x does not exist yet
+      .mockResolvedValueOnce({ stdout: '' }) // worktree add
+      .mockResolvedValueOnce({ stdout: '' }) // config --local --replace-all branch.<branch>.base
+      .mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // config --get push.autoSetupRemote (unset)
+      .mockResolvedValueOnce({ stdout: '' }) // config --local set push.autoSetupRemote
+
+    const result = await addWorktree(
+      '/repo',
+      '/repo-feature-x',
+      'feature-x',
+      'origin/feature-x',
+      true
+    )
+
+    expect(result.localBaseRefRefresh?.status).not.toBe('skipped_not_fast_forward')
+    expect(result.localBaseRefRefresh).toEqual({
+      status: 'updated',
+      baseRef: 'origin/feature-x',
+      localBranch: 'feature-x'
+    })
+    // The branch was created at the remote base — no extra probing, no ref mutation.
+    expect(gitExecFileAsyncMock.mock.calls).toHaveLength(6)
+    expect(gitExecFileAsyncMock.mock.calls[2]?.[0]).toEqual([
+      'worktree',
+      'add',
+      '--no-track',
+      '-b',
+      'feature-x',
+      '/repo-feature-x',
+      'refs/remotes/origin/feature-x'
+    ])
+  })
+
   it('skips local base refresh when captured OIDs are no longer ancestor-safe', async () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'abc123\n' }) // rev-parse refs/remotes/origin/main^{commit}
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '0\t2\n' }) // stale rev-list result

--- a/src/main/git/worktree-base-ref-probe.ts
+++ b/src/main/git/worktree-base-ref-probe.ts
@@ -37,3 +37,32 @@ export async function hasWorktreeBaseCommitRef(
 ): Promise<boolean> {
   return (await resolveWorktreeBaseCommitOid(repoPath, qualifiedRef, options)) !== null
 }
+
+export type WorktreeBaseRefPresence = 'present' | 'absent' | 'unknown'
+
+/**
+ * Distinguish "the ref does not exist" from "the probe itself failed".
+ *
+ * Why for-each-ref: it exits 0 whether or not the pattern matches, so an empty result
+ * proves absence while a rejection still means the probe never ran (broken repo, dead
+ * SSH transport). `rev-parse --verify --quiet` exits 1 for both, and reading that as
+ * "absent" would silently drop warnings the caller must still surface.
+ *
+ * Executor-injected so the SSH path can route the same argv through the relay.
+ */
+export async function probeWorktreeBaseRefPresence(
+  runGit: (args: string[]) => Promise<{ stdout: string }>,
+  qualifiedRef: string
+): Promise<WorktreeBaseRefPresence> {
+  try {
+    const { stdout } = await runGit([
+      'for-each-ref',
+      '--count=1',
+      '--format=%(refname)',
+      qualifiedRef
+    ])
+    return stdout.trim() === qualifiedRef ? 'present' : 'absent'
+  } catch {
+    return 'unknown'
+  }
+}

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -33,7 +33,7 @@ import {
 import { withLocalGitCapabilityCacheForExecution } from './git-capability-state'
 import { gitExecFileAsync, translateWslOutputPaths } from './runner'
 import { resolveGitDir, runWithGitReadCacheInvalidation } from './status'
-import { hasWorktreeBaseCommitRef } from './worktree-base-ref-probe'
+import { hasWorktreeBaseCommitRef, probeWorktreeBaseRefPresence } from './worktree-base-ref-probe'
 
 export type AddWorktreeResult = {
   localBaseRefRefresh?: LocalBaseRefRefreshResult
@@ -267,7 +267,12 @@ async function evaluateLocalBaseRefRefreshability(
   } catch {
     // Why (#15331): the probes above also fail when refs/heads/<branch> is simply absent; a branch that
     // does not exist yet cannot be stale, so report nothing instead of a bogus divergence warning.
-    if (!(await hasWorktreeBaseCommitRef(repoPath, parsed.fullRef, options))) {
+    // Only a proven absence suppresses: an unusable repo leaves the warning alone.
+    const presence = await probeWorktreeBaseRefPresence(
+      (args) => gitExecFileAsync(args, gitExecOptions(repoPath, options)),
+      parsed.fullRef
+    )
+    if (presence === 'absent') {
       return undefined
     }
     return { refreshable: false, result: { ...resultBase, status: 'skipped_not_fast_forward' } }

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -1021,6 +1021,18 @@ async function performAddWorktree(
     return localBaseRefRefresh ? { localBaseRefRefresh } : {}
   }
 
+  // #15331: `-b` refuses an existing branch, so reaching here proves git just created localBranch at
+  // the remote base; the pre-create rev-list only failed because refs/heads/<branch> did not exist yet.
+  // SHORTCUT: local path only. The SSH equivalent (refreshLocalBaseRefForRemoteWorktreeCreate in
+  // src/main/ipc/worktree-remote.ts) evaluates pre-create too; mirror this once the warning is
+  // reported against a remote repo.
+  if (
+    localBaseRefRefresh?.status === 'skipped_not_fast_forward' &&
+    localBaseRefRefresh.localBranch === branch
+  ) {
+    localBaseRefRefresh = { ...localBaseRefRefresh, status: 'updated' }
+  }
+
   if (effectiveBase) {
     await persistWorktreeCreationBase(worktreePath, branch, effectiveBase, options)
   }

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -265,6 +265,11 @@ async function evaluateLocalBaseRefRefreshability(
     )
     drift = parsedDrift
   } catch {
+    // Why (#15331): the probes above also fail when refs/heads/<branch> is simply absent; a branch that
+    // does not exist yet cannot be stale, so report nothing instead of a bogus divergence warning.
+    if (!(await hasWorktreeBaseCommitRef(repoPath, parsed.fullRef, options))) {
+      return undefined
+    }
     return { refreshable: false, result: { ...resultBase, status: 'skipped_not_fast_forward' } }
   }
 
@@ -1019,18 +1024,6 @@ async function performAddWorktree(
 
   if (options.checkoutExistingBranch) {
     return localBaseRefRefresh ? { localBaseRefRefresh } : {}
-  }
-
-  // #15331: `-b` refuses an existing branch, so reaching here proves git just created localBranch at
-  // the remote base; the pre-create rev-list only failed because refs/heads/<branch> did not exist yet.
-  // SHORTCUT: local path only. The SSH equivalent (refreshLocalBaseRefForRemoteWorktreeCreate in
-  // src/main/ipc/worktree-remote.ts) evaluates pre-create too; mirror this once the warning is
-  // reported against a remote repo.
-  if (
-    localBaseRefRefresh?.status === 'skipped_not_fast_forward' &&
-    localBaseRefRefresh.localBranch === branch
-  ) {
-    localBaseRefRefresh = { ...localBaseRefRefresh, status: 'updated' }
   }
 
   if (effectiveBase) {

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -35,6 +35,7 @@ import {
 } from '../git/repo'
 import { resolveLocalGitUsername, getSshGitUsername } from '../git/git-username'
 import { hasCommitObjectViaGitExec } from '../git/commit-object-ref'
+import { probeWorktreeBaseRefPresence } from '../git/worktree-base-ref-probe'
 import { resolveWorktreeCreateBase } from '../worktree-create-base'
 import { resolveWorktreeAddBaseRef } from '../../shared/worktree/base-ref'
 import { getHostedReviewForBranch } from '../source-control/hosted-review'
@@ -1394,8 +1395,13 @@ async function evaluateRemoteLocalBaseRefRefreshability(
     }
   } catch {
     // Why (#15331): the probes above also fail when refs/heads/<branch> is simply absent; the relay's
-    // `worktree add -b` is about to create it, so there is nothing stale to warn about.
-    if (!(await hasCommitRefSsh(provider, repoPath, fullRef))) {
+    // `worktree add -b` is about to create it, so there is nothing stale to warn about. Only a proven
+    // absence suppresses: a dropped relay connection is not evidence the branch is missing.
+    const presence = await probeWorktreeBaseRefPresence(
+      (args) => provider.exec(args, repoPath),
+      fullRef
+    )
+    if (presence === 'absent') {
       return { refreshable: false, result: undefined }
     }
     return { refreshable: false, result: { ...resultBase, status: 'skipped_not_fast_forward' } }

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -181,7 +181,8 @@ type RemoteLocalBaseRefRefreshability =
     }
   | {
       refreshable: false
-      result: LocalBaseRefRefreshResult
+      // undefined = nothing to refresh (no local branch yet), so the caller reports no status at all.
+      result: LocalBaseRefRefreshResult | undefined
     }
 
 function appendWorktreeCreateWarning(current: string | undefined, next: string): string {
@@ -698,8 +699,7 @@ async function hasRemoteWorktreeBaseRef(
   repoPath: string,
   baseRef: string
 ): Promise<boolean> {
-  const refExists = (qualifiedRef: string) =>
-    hasRemoteTrackingRefSsh(provider, repoPath, qualifiedRef)
+  const refExists = (qualifiedRef: string) => hasCommitRefSsh(provider, repoPath, qualifiedRef)
   const resolvedBaseRef = await resolveWorktreeAddBaseRef(baseRef, refExists)
   if (resolvedBaseRef !== baseRef) {
     return true
@@ -710,8 +710,8 @@ async function hasRemoteWorktreeBaseRef(
   return hasRemoteCommitObject(provider, repoPath, baseRef)
 }
 
-// Why: hasRemoteCommitObject resolves only SHAs, not symbolic remote-tracking refs; detect those directly for the fetch-failed local fallback.
-async function hasRemoteTrackingRefSsh(
+// Why: hasRemoteCommitObject resolves only SHAs, not symbolic refs; resolve any qualified ref (remote-tracking or local head) directly.
+async function hasCommitRefSsh(
   provider: SshGitProvider,
   repoPath: string,
   ref: string
@@ -1262,7 +1262,7 @@ async function resolveRemoteWorktreeCreateBasePlan(
         baseBranchCandidate
       )
       if (remoteTrackingBase) {
-        if (await hasRemoteTrackingRefSsh(provider, repo.path, remoteTrackingBase.ref)) {
+        if (await hasCommitRefSsh(provider, repo.path, remoteTrackingBase.ref)) {
           return true
         }
         return hasRemoteWorktreeBaseRef(provider, repo.path, baseBranchCandidate)
@@ -1313,7 +1313,7 @@ export async function prefetchRemoteWorktreeCreateBase(
   }
   if (basePlan.remoteTrackingBase) {
     if (
-      (await hasRemoteTrackingRefSsh(provider, repo.path, basePlan.remoteTrackingBase.ref)) ||
+      (await hasCommitRefSsh(provider, repo.path, basePlan.remoteTrackingBase.ref)) ||
       !(await hasRemoteWorktreeBaseRef(provider, repo.path, basePlan.baseBranch))
     ) {
       await refreshRemoteTrackingBaseForWorktreeCreate(provider, repo, basePlan.remoteTrackingBase)
@@ -1333,7 +1333,7 @@ async function refreshLocalBaseRefForRemoteWorktreeCreate(
   provider: SshGitProvider,
   repoPath: string,
   remoteTrackingBase: RemoteTrackingBase
-): Promise<LocalBaseRefRefreshResult> {
+): Promise<LocalBaseRefRefreshResult | undefined> {
   const evaluation = await evaluateRemoteLocalBaseRefRefreshability(
     provider,
     repoPath,
@@ -1393,6 +1393,11 @@ async function evaluateRemoteLocalBaseRefRefreshability(
       }
     }
   } catch {
+    // Why (#15331): the probes above also fail when refs/heads/<branch> is simply absent; the relay's
+    // `worktree add -b` is about to create it, so there is nothing stale to warn about.
+    if (!(await hasCommitRefSsh(provider, repoPath, fullRef))) {
+      return { refreshable: false, result: undefined }
+    }
     return { refreshable: false, result: { ...resultBase, status: 'skipped_not_fast_forward' } }
   }
 
@@ -1550,7 +1555,7 @@ export async function createRemoteWorktree(
   let baseFallback: WorktreeCreateBaseFallback | undefined
 
   if (remoteTrackingBase) {
-    const hasRemoteTrackingBaseRef = await hasRemoteTrackingRefSsh(
+    const hasRemoteTrackingBaseRef = await hasCommitRefSsh(
       provider,
       repo.path,
       remoteTrackingBase.ref
@@ -1700,7 +1705,7 @@ export async function createRemoteWorktree(
       await refreshRemoteTrackingBaseForWorktreeCreate(provider, repo, remoteTrackingBase)
     } catch {
       // Why: a refresh failure shouldn't block create if a usable (stale) local base ref exists; probe after registerRoot and hard-fail only when none does.
-      if (!(await hasRemoteTrackingRefSsh(provider, repo.path, remoteTrackingBase.ref))) {
+      if (!(await hasCommitRefSsh(provider, repo.path, remoteTrackingBase.ref))) {
         throw new Error(
           `Could not refresh base ref "${baseBranch}" from "${remoteTrackingBase.remote}". Check your network and try again.`
         )

--- a/src/main/ipc/worktrees-ssh-local-base-refresh.test.ts
+++ b/src/main/ipc/worktrees-ssh-local-base-refresh.test.ts
@@ -474,4 +474,95 @@ describe('registerWorktreeHandlers', () => {
     })
     expect(result.localBaseRefUpdateSuggestion).toBeUndefined()
   })
+  // #15331: the pre-create merge-base probe fails when refs/heads/<branch> does not exist yet.
+  const buildMissingLocalBaseSshCase = (localHeadOid: string) => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    const provider = {
+      exec: vi.fn().mockImplementation(async (args: string[]) => {
+        if (args[0] === 'remote') {
+          return { stdout: 'origin\n', stderr: '' }
+        }
+        if (args[0] === 'rev-parse') {
+          const ref = args.at(-1) ?? ''
+          if (ref.startsWith('refs/heads/main')) {
+            return { stdout: localHeadOid, stderr: '' }
+          }
+          // Other refs/heads probes are the new-branch conflict check; it must stay unresolvable.
+          return { stdout: ref.startsWith('refs/heads/') ? '' : 'remote-main\n', stderr: '' }
+        }
+        if (args[0] === 'merge-base') {
+          throw new Error('fatal: Not a valid object name refs/heads/main')
+        }
+        return { stdout: '', stderr: '' }
+      }),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/repo-improve-dashboard',
+          head: 'abc123',
+          branch: 'refs/heads/improve-dashboard',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ]),
+      worktreeIsClean: vi.fn().mockResolvedValue({ clean: true }),
+      refreshLocalBaseRefForWorktreeCreate: vi.fn().mockResolvedValue(undefined)
+    }
+    store.getSettings.mockReturnValue({
+      branchPrefix: 'none',
+      nestWorkspaces: false,
+      refreshLocalBaseRefOnWorktreeCreate: true,
+      workspaceDir: '/workspace'
+    })
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue({
+      request: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    })
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
+    return provider
+  }
+
+  it('does not report an SSH local base refresh when the local base branch does not exist', async () => {
+    const provider = buildMissingLocalBaseSshCase('')
+
+    const result = (await handlers['worktrees:create'](null, {
+      repoId: 'repo-ssh',
+      name: 'improve-dashboard'
+    })) as CreateWorktreeResult
+
+    expect(provider.exec).toHaveBeenCalledWith(
+      ['rev-parse', '--verify', '--quiet', 'refs/heads/main^{commit}'],
+      '/remote/repo'
+    )
+    expect(result.localBaseRefRefresh).toBeUndefined()
+    expect(provider.refreshLocalBaseRefForWorktreeCreate).not.toHaveBeenCalled()
+  })
+
+  it('keeps the SSH not-fast-forward status when the local base branch exists and diverged', async () => {
+    const provider = buildMissingLocalBaseSshCase('local-main\n')
+
+    const result = (await handlers['worktrees:create'](null, {
+      repoId: 'repo-ssh',
+      name: 'improve-dashboard'
+    })) as CreateWorktreeResult
+
+    expect(result.localBaseRefRefresh).toEqual({
+      status: 'skipped_not_fast_forward',
+      baseRef: 'origin/main',
+      localBranch: 'main'
+    })
+    expect(provider.refreshLocalBaseRefForWorktreeCreate).not.toHaveBeenCalled()
+  })
 })

--- a/src/main/ipc/worktrees-ssh-local-base-refresh.test.ts
+++ b/src/main/ipc/worktrees-ssh-local-base-refresh.test.ts
@@ -475,7 +475,7 @@ describe('registerWorktreeHandlers', () => {
     expect(result.localBaseRefUpdateSuggestion).toBeUndefined()
   })
   // #15331: the pre-create merge-base probe fails when refs/heads/<branch> does not exist yet.
-  const buildMissingLocalBaseSshCase = (localHeadOid: string) => {
+  const buildMissingLocalBaseSshCase = (presence: 'absent' | 'present' | 'probe-failed') => {
     const repo = {
       id: 'repo-ssh',
       path: '/remote/repo',
@@ -490,10 +490,16 @@ describe('registerWorktreeHandlers', () => {
         if (args[0] === 'remote') {
           return { stdout: 'origin\n', stderr: '' }
         }
+        if (args[0] === 'for-each-ref' && args.at(-1) === 'refs/heads/main') {
+          if (presence === 'probe-failed') {
+            throw new Error('ssh: connection closed by remote host')
+          }
+          return { stdout: presence === 'present' ? 'refs/heads/main\n' : '', stderr: '' }
+        }
         if (args[0] === 'rev-parse') {
           const ref = args.at(-1) ?? ''
           if (ref.startsWith('refs/heads/main')) {
-            return { stdout: localHeadOid, stderr: '' }
+            return { stdout: presence === 'present' ? 'local-main\n' : '', stderr: '' }
           }
           // Other refs/heads probes are the new-branch conflict check; it must stay unresolvable.
           return { stdout: ref.startsWith('refs/heads/') ? '' : 'remote-main\n', stderr: '' }
@@ -535,7 +541,7 @@ describe('registerWorktreeHandlers', () => {
   }
 
   it('does not report an SSH local base refresh when the local base branch does not exist', async () => {
-    const provider = buildMissingLocalBaseSshCase('')
+    const provider = buildMissingLocalBaseSshCase('absent')
 
     const result = (await handlers['worktrees:create'](null, {
       repoId: 'repo-ssh',
@@ -543,7 +549,7 @@ describe('registerWorktreeHandlers', () => {
     })) as CreateWorktreeResult
 
     expect(provider.exec).toHaveBeenCalledWith(
-      ['rev-parse', '--verify', '--quiet', 'refs/heads/main^{commit}'],
+      ['for-each-ref', '--count=1', '--format=%(refname)', 'refs/heads/main'],
       '/remote/repo'
     )
     expect(result.localBaseRefRefresh).toBeUndefined()
@@ -551,7 +557,24 @@ describe('registerWorktreeHandlers', () => {
   })
 
   it('keeps the SSH not-fast-forward status when the local base branch exists and diverged', async () => {
-    const provider = buildMissingLocalBaseSshCase('local-main\n')
+    const provider = buildMissingLocalBaseSshCase('present')
+
+    const result = (await handlers['worktrees:create'](null, {
+      repoId: 'repo-ssh',
+      name: 'improve-dashboard'
+    })) as CreateWorktreeResult
+
+    expect(result.localBaseRefRefresh).toEqual({
+      status: 'skipped_not_fast_forward',
+      baseRef: 'origin/main',
+      localBranch: 'main'
+    })
+    expect(provider.refreshLocalBaseRefForWorktreeCreate).not.toHaveBeenCalled()
+  })
+
+  // Losing the relay mid-probe is not evidence the branch is missing.
+  it('keeps the SSH not-fast-forward status when the local base ref probe fails', async () => {
+    const provider = buildMissingLocalBaseSshCase('probe-failed')
 
     const result = (await handlers['worktrees:create'](null, {
       repoId: 'repo-ssh',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​229 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​228 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​61 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​50 |

<!-- /orca-pr-loc -->

Supersedes #15758 by @kaluli123123 — carried over so it can run full CI (fork PRs only run `track-community-pr` in this repo). Original authorship is preserved in the first commit; the second commit moves the fix to the root cause and covers the SSH path.

## ELI5

You create a workspace from `origin/some-branch` when you don't have a local `some-branch` yet. Everything works — the workspace is created and tracks the right base. But Orca still pops a sticky warning saying it couldn't refresh your local `some-branch`. The warning is nonsense: there was no local branch to refresh, and git was about to create one for you anyway. This stops Orca from complaining about a branch that doesn't exist yet, while keeping the warning for the case it was written for (you really do have local-only commits that block a fast-forward).

## What Changed

- `src/main/git/worktree.ts` — `evaluateLocalBaseRefRefreshability` wrapped every pre-create probe in one blanket `catch` that reported `skipped_not_fast_forward`. That catch now probes `refs/heads/<branch>` before labelling anything, and returns `undefined` — "nothing to refresh" — only when the ref is *proven* absent. The extra probe only runs on the failure path.
- `src/main/ipc/worktree-remote.ts` — same guard on the SSH/relay create path, where `evaluateRemoteLocalBaseRefRefreshability` had the identical defect (`merge-base --is-ancestor refs/heads/<branch> ...` throws when the ref is missing, and the relay then creates the branch with `worktree add --no-track -b`). `refreshLocalBaseRefForRemoteWorktreeCreate` now returns `LocalBaseRefRefreshResult | undefined`, matching the local signature.
- `src/main/git/worktree-base-ref-probe.ts` — new `probeWorktreeBaseRefPresence(runGit, ref)` returning `present | absent | unknown`, shared by both paths. It runs `git for-each-ref --count=1 --format=%(refname) <ref>`, which exits 0 whether or not the ref matches: an empty result *proves* absence, while a rejection stays `unknown`. `rev-parse --verify --quiet` exits 1 for both cases, so probing with it would have let a broken repo or a dropped relay connection masquerade as "nothing to refresh" and swallow a real divergence warning. Executor-injected so the SSH path routes the same argv through the relay.
- `hasRemoteTrackingRefSsh` -> `hasCommitRefSsh`: `hasRemoteWorktreeBaseRef` already passes it to `resolveWorktreeAddBaseRef`, which probes `refs/heads/<name>` candidates, so the old name lied before this PR too. Mechanical rename, 5 call sites, no behavior change.
- Tests: kept the contributor's regression scenario, added the sibling cases the original fix did not cover (new branch name different from base branch name; local branch present and genuinely diverged; probe itself fails; SSH equivalents of all three).

## Why

Root cause is a mislabel, not a stale result. `rev-list --left-right --count refs/heads/X...refs/remotes/origin/X` fails with "unknown revision" when `refs/heads/X` is absent, and that failure was funnelled into the same `skipped_not_fast_forward` status used for genuine divergence. The renderer turns that status into an `Infinity`-duration toast (`local-base-ref-refresh-toast.ts`), so a completely normal remote-only create looked like a failure.

#15758 fixed the symptom after the fact: it rewrote `skipped_not_fast_forward` to `updated` in `performAddWorktree` when the freshly created branch name matched the base's local branch name. Two problems with that placement:

1. It only closed half the bug. The ordinary flow — new branch `my-feature` off `origin/main` in a clone that has no local `main` (bare/worktree-only clones, fetch-only setups) — has `branch !== localBranch`, so the bogus toast still fired. Verified against the PR head before rewriting.
2. `status: 'updated'` asserts Orca fast-forwarded a branch it never touched. Inert today because the only consumer early-returns on `updated`, but it is a false claim in an IPC payload. `undefined` is the truthful state and is already what the advisory path (`getLocalBaseRefUpdateSuggestionForWorktreeCreate`) returns for the same condition.

Fixing it in the evaluator also removes the guard's hidden dependency on `git worktree add -b` refusing an existing branch — an invariant nothing in the tree pinned, and one a future switch to `-B`/`--force` would have silently broken into "suppress a real divergence warning".

## Linked Issue

Fixes #15331

## Visual Proof

N/A — no UI code changed. The only user-visible effect is the *absence* of an existing toast in a case where it was wrong; the toast component, copy, and the three real warning statuses (`skipped_not_fast_forward`, `skipped_dirty_worktree`, `skipped_error`) are untouched.

## Testing

Run on macOS only (Darwin 25.3.0). No Linux/Windows/real-SSH execution; those are covered by reasoning below plus CI.

```
npx vitest run --config config/vitest.config.ts \
  src/main/git/worktree-add-local-base-refresh.test.ts \
  src/main/ipc/worktrees-ssh-local-base-refresh.test.ts
-> 2 files, 21 tests passed

npx vitest run --config config/vitest.config.ts src/main/git/ src/main/ipc/worktree
-> 125 passed | 2 skipped (1465 tests passed, 4 skipped)

npx vitest run --config config/vitest.config.ts \
  src/main/ipc/worktrees src/main/providers/ssh-git-provider-worktree.test.ts \
  src/relay/git-handler-worktree-provisioning.test.ts \
  src/main/worktree-create-base-prefetch.test.ts
-> 31 files, 301 tests passed

npx oxlint <5 changed files>                                        -> clean
npx oxlint --config config/oxlint-code-quality-native-plugins.json \
  <5 changed files> --deny-warnings                                 -> clean
npx oxfmt --check <5 changed files>                                 -> clean
```

Red/green proof #1 — with both guards removed from the two product files and the tests left as-is.
(Re-run at the final head, where the file has 21 tests rather than the 19 it had when this proof was
first captured; the probe-failure test fails too, because it asserts the probe is called at all.)

```
x skips updating the local branch when it has diverged
x does not warn when worktree add itself creates the local base branch
x does not warn when the local base branch does not exist in a fetch-only clone
x keeps the warning when the local base ref probe itself fails
x skips local base refresh when captured OIDs are no longer ancestor-safe
x does not report an SSH local base refresh when the local base branch does not exist
Tests  6 failed | 15 passed (21)
```

Red/green proof #2 — for the "proven absence" narrowing, with `presence === 'absent'` widened
back to `presence !== 'present'` (exactly what a `rev-parse --verify --quiet` probe with a
blanket `catch` does) in both product files:

```
x keeps the warning when the local base ref probe itself fails
x keeps the SSH not-fast-forward status when the local base ref probe fails
Tests  2 failed | 19 passed (21)
```

Restoring the guards: 21/21 pass. (Several of those are pre-existing tests updated to assert the
new probe call and their `skipped_not_fast_forward` result explicitly, so they now pin
over-suppression as well as under-suppression.)

Not manually exercised in the running app.

### Independent verification (maintainer review, 2026-08-22)

Reproduced rather than re-read. Scratch harnesses drove the real product entry points
(`addWorktree`, the `worktrees:create` IPC handler) against real git repositories; the SSH harness
put every `provider.exec` argv through the relay's real `validateGitExecArgs` before running real
git, and the end-to-end SSH case ran against the real Linux host `openclaw` through the shipped
(pre-fix) app.

**1. Git-level mechanics the fix depends on** — macOS git 2.44.0 and openclaw git 2.43.0 agree:

```
$ git rev-list --left-right --count refs/heads/release...refs/remotes/origin/release   # ref absent
fatal: ambiguous argument '...': unknown revision or path not in the working tree
exit=128
$ git merge-base --is-ancestor refs/heads/<absent> refs/remotes/origin/<absent>
fatal: Not a valid object name refs/heads/<absent>
exit=128
$ git for-each-ref --count=1 --format=%(refname) refs/heads/release                    # ref absent
exit=0            <- empty stdout, exit 0: absence is *proven*
$ git rev-parse --verify --quiet refs/heads/nope
exit=1            <- indistinguishable from a failed probe, as the PR says
```

**2. Local path, real git, real `addWorktree`** — fetch-only clone holding local `main` only, base
`origin/release`, new branch `my-feature`:

| case | `origin/main` | PR head |
| --- | --- | --- |
| A remote-only base, new branch name ≠ base name | `{"baseRef":"origin/release","localBranch":"release","status":"skipped_not_fast_forward"}` | `undefined` |
| A2 remote-only base, new branch name = base name | `skipped_not_fast_forward` | `undefined` |
| B local `release` exists and genuinely diverged (`rev-list` ahead/behind = `1 1`) | `skipped_not_fast_forward` | `skipped_not_fast_forward` |
| C local `release` exists, refresh genuinely fails (ref points at a non-commit → `rev-list` exits 128, `for-each-ref` still prints `refs/heads/release`) | `skipped_not_fast_forward` | `skipped_not_fast_forward` |

So the false warning is reachable on `main` (A/A2 confirm the bug), and the true positives (B, C)
still fire on the PR head. Loading only the first commit (the contributor's `performAddWorktree`
rewrite) reproduces both problems this PR calls out: case A still returns
`skipped_not_fast_forward`, and case A2 returns `status: "updated"` for a branch Orca never
fast-forwarded.

**3. SSH path, real relay allowlist, real git** — `worktrees:create` with an SSH provider whose
`exec` validates through `src/relay/git-exec-validator.ts` and then runs real git:

| case | `origin/main` | PR head |
| --- | --- | --- |
| S1 remote-only base (host has no `refs/heads/main`) | `skipped_not_fast_forward` | `undefined`; probe argv `["for-each-ref","--count=1","--format=%(refname)","refs/heads/main"]` accepted by the allowlist |
| S2 local `main` exists and diverged (`merge-base --is-ancestor` exits 1) | `skipped_not_fast_forward` | `skipped_not_fast_forward` |
| S3 local `main` exists, probe throws (`ssh: connection closed by remote host`) | `skipped_not_fast_forward` | `skipped_not_fast_forward` |

S3 is the case a reviewer flagged as possibly broken — "a failed probe reads as absent, so a real
warning is dropped". It does not reproduce: `provider.exec` rejects on non-zero exit / transport
loss, `probeWorktreeBaseRefPresence` returns `unknown`, and the warning is preserved. Called
directly against real git, the probe returns `present` / `absent` / `unknown` (rejecting executor)
/ `unknown` (non-repo cwd) as documented.

**4. End-to-end over real SSH on `openclaw`, shipped app 1.4.188 (pre-fix)** — the bogus warning is
not hypothetical:

```
$ orca worktree create --project github:stablyai/orca --host ssh:ssh-1777360569033-yvz2mp \
    --name pr15871-ssh-a --base-branch origin/nwparker/stale-local-branch-refresh-warning \
    --setup skip --no-parent --json
  "branch": "refs/heads/pr15871-ssh-a",
  "localBaseRefRefresh": {
    "baseRef": "origin/nwparker/stale-local-branch-refresh-warning",
    "localBranch": "nwparker/stale-local-branch-refresh-warning",
    "status": "skipped_not_fast_forward"
  },
  "warnings": []
```

On the host, that local branch genuinely does not exist (`git branch --list` prints nothing), and
the created branch name differs from the base's local name — i.e. exactly the half of the bug
#15758's placement would not have fixed. The same create flow already sends
`for-each-ref --format=%(refname) refs/remotes` over `git.exec` today and the deployed relay
accepted it, which is direct evidence for the "old relays accept the probe unchanged" claim.

**5. The PR's own Testing block re-run at head** — all of it reproduces:

```
worktree-add-local-base-refresh.test.ts + worktrees-ssh-local-base-refresh.test.ts -> 21 passed
src/main/git/ + src/main/ipc/worktree                 -> 125 files, 1465 passed | 4 skipped
src/main/ipc/worktrees + ssh-git-provider-worktree + git-handler-worktree-provisioning
  + worktree-create-base-prefetch                     -> 31 files, 301 passed
npx oxlint <5 files>                                  -> clean
npx oxlint --config config/oxlint-code-quality-native-plugins.json <5 files> --deny-warnings -> clean
npx oxfmt --check <5 files>                           -> clean
```

Red/green proof #2 reproduces exactly as written (widening to `presence !== 'present'` fails the two
probe-failure tests, 19 passed). Proof #1's counts were stale and have been corrected above.

**Not verified:** the toast was not observed rendering. The running app exposes no CDP port and
restarting it was not safe from inside this session, so the user-visible half rests on the IPC
payloads above plus `create-worktree.ts:240` → `showLocalBaseRefRefreshToast`, which early-returns on
`undefined` and otherwise raises a `duration: Infinity` warning toast. Windows/WSL was not exercised.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Correctness** — the suppression is keyed on the ref's *proven* absence, not on an argv invariant, a name match, or a probe that failed for some other reason, so it cannot swallow a genuine divergence: if `refs/heads/X` is present — or if the probe could not answer — the `skipped_not_fast_forward` result is returned exactly as before. Explicitly pinned by the "local base ref exists and diverged" and "probe itself fails" cases on both the local and SSH sides.
- **Cross-platform** — no paths, no shell, no keyboard handling. The one added command is `git for-each-ref --count=1 --format=%(refname) <ref>`, which flows through the same `gitExecFileAsync` / WSL translation the surrounding probes already use and inherits `wslDistro` from the caller's options. `for-each-ref` is already in `wsl-direct-git-read-commands.ts`, so no login-shell banner can contaminate its stdout.
- **Git compatibility** — `for-each-ref --count --format` predates the 2.25 baseline by a decade, and `src/shared/git-binary-compatibility.test.ts` already exercises `for-each-ref --format=%(refname) --count=10` against every tested Git release. No new version boundary, no capability probe needed.
- **SSH / remote** — fixed on both sides in the same PR rather than deferred. `for-each-ref` has been in the relay's `git.exec` allowlist for a long time and `worktree-remote.ts` already calls it over `provider.exec`, so old relays accept the probe unchanged; `rev-list` is deliberately not reached for, since the file's own comment notes it is not exposed over the relay. Per the SSH execution boundary, a failed probe is treated as `unknown`, never as "the branch is gone". `src/relay/` is untouched.
- **Remote wire compatibility** — no RPC params, no stream opcodes, no new status enum value crosses the wire. `localBaseRefRefresh` was already optional in `src/shared/worktree/create-types.ts`, so an old client paired with a new host simply receives no field, which it already handles (`local-base-ref-refresh-toast.ts` no-ops on `undefined`). No capability negotiation required.
- **Folder workspaces** — this code path only runs for git worktree creation with a remote-tracking base; folder workspaces never enter it.
- **Provider neutrality** — nothing GitHub- or GitLab-specific; the remote name is taken from the base ref, not hardcoded.
- **Performance** — one extra `for-each-ref` per create, and only when a probe already failed. The success path is unchanged.
- **UI quality** — N/A, no renderer change.
- **Security** — no new process spawning beyond the existing git exec wrapper, no user-controlled argv concatenation (the ref is built from an already-parsed branch name and passed as a discrete argv element), no filesystem or credential access.
- **Contributor diff scan** — I read the full #15758 patch and pattern-scanned it: 2 files, 53 additions / 0 deletions, 1 commit, no new/renamed/deleted/binary files, no `package.json`, lockfile, workflow, build, updater, or lifecycle-hook changes; zero hits for URLs, `curl`/`wget`, `fetch(`, `exec(`/`eval(`, `child_process`, `spawn`, `process.env`, or token/secret/base64 patterns. The production change was 12 lines of in-memory logic and the test file only added vitest mock returns. Nothing malicious, nothing out of scope, no prompt-injection content in the added comments.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The contributor's `SHORTCUT:` in-code marker (a convention that appears nowhere else in `src/`) and the cross-file TODO are gone — the SSH follow-up it deferred is done here.

Does not touch the `checkoutExistingBranch` path, so #15645 / #15796 are unaffected: that path never resolves a base ref and never reaches this evaluator.

## Known limitations / follow-ups

- When the presence probe cannot answer (`unknown`), the evaluator keeps reporting `skipped_not_fast_forward` rather than the arguably more accurate `skipped_error`. That is deliberately the pre-#15331 status for that path — changing it would alter the toast copy users see for an unrelated failure class, which is out of scope for this fix. The safety property that matters (a failed probe never suppresses the warning) holds either way.
- A locally corrupt ref record (e.g. a garbage line in `packed-refs`) makes `for-each-ref` exit 0 with empty output, so git itself reports the branch as absent and the warning is now suppressed where `main` showed `skipped_not_fast_forward`. Confirmed by reproduction; treated as correct, since the probe faithfully reports what git can see.
- `for-each-ref` patterns match at `/` boundaries, so `refs/heads/foo` would also match `refs/heads/foo/bar`. The probe compares the returned refname exactly, so this cannot produce a false "present"; and Git forbids `foo` and `foo/bar` coexisting anyway.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)


