### PR TITLE
fix(worktree): collapse path-equal worktree rows without losing lineage

### DIFF
--- a/src/main/ipc/worktree-path-comparison.ts
+++ b/src/main/ipc/worktree-path-comparison.ts
@@ -99,8 +99,19 @@ function looksLikePosixAbsolutePath(pathValue: string): boolean {
   return pathValue.startsWith('/') && !pathValue.startsWith('//')
 }
 
+/** `\\\\wsl$\\<distro>` / `\\\\wsl.localhost\\<distro>` prefix of an already win32-normalized path. */
+const WSL_UNC_COMPARISON_PREFIX = /^\\\\(wsl\.localhost|wsl\$)\\([^\\]+)(\\[\s\S]*)?$/i
+
 function normalizeWindowsWorktreePathForComparison(pathValue: string): string {
-  return win32.normalize(win32.resolve(pathValue)).toLowerCase()
+  const normalized = win32.normalize(win32.resolve(pathValue))
+  const wslUnc = normalized.match(WSL_UNC_COMPARISON_PREFIX)
+  if (!wslUnc) {
+    return normalized.toLowerCase()
+  }
+  // Why: the WSL UNC aliases front a case-SENSITIVE Linux filesystem, so folding the
+  // whole path merges two real worktrees that differ only by case and drops one row.
+  // Only the alias and distro fold, matching the UNC server/share rule.
+  return `\\\\${wslUnc[1].toLowerCase()}\\${wslUnc[2].toLowerCase()}${wslUnc[3] ?? ''}`
 }
 
 function normalizePosixWorktreePathForComparison(

--- a/src/main/ipc/worktree-path-deduplication.test.ts
+++ b/src/main/ipc/worktree-path-deduplication.test.ts
@@ -44,6 +44,27 @@ describe('dedupeWorktreesByPath', () => {
     }
   )
 
+  it.each<NodeJS.Platform>(['darwin', 'linux', 'win32'])(
+    'keeps case-different WSL UNC worktrees on %s while folding alias and distro case',
+    (platform) => {
+      const worktrees = [
+        { id: 'wsl-upper', path: String.raw`\\wsl$\Ubuntu\home\dev\wt\Feature` },
+        { id: 'wsl-lower', path: String.raw`\\wsl$\Ubuntu\home\dev\wt\feature` },
+        { id: 'wsl-alias-case-duplicate', path: '//WSL$/ubuntu/home/dev/wt/./Feature' },
+        { id: 'wsl-localhost', path: String.raw`\\wsl.localhost\Ubuntu\home\dev\wt\Feature` }
+      ]
+
+      expect(dedupeWorktreesByPath(worktrees, platform).map((entry) => entry.id)).toEqual([
+        'wsl-upper',
+        'wsl-lower',
+        'wsl-localhost'
+      ])
+      expect(dedupeWorktreesByPath(worktrees, platform)).toEqual(
+        dedupeWithComparator(worktrees, platform)
+      )
+    }
+  )
+
   it('reads each path once for a large unique list', () => {
     let pathReads = 0
     const worktrees = Array.from({ length: 1_000 }, (_, index) => ({

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -4,6 +4,7 @@ import { readFile, stat } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import type { Store } from '../persistence'
 import { pruneLineageForMissingRepoWorktrees } from '../worktree-lineage-pruning'
+import { resolveRepoWorktreePathPlatform } from '../runtime/path-equal-worktree-row-collapse'
 import { isFolderRepo } from '../../shared/repo-kind'
 import { readBranchRenameFailureOutputForDisplay } from '../agent-hooks/branch-rename-failure-output'
 import { parseWorkspaceKey } from '../../shared/workspace-scope'
@@ -1303,7 +1304,12 @@ async function listDetectedWorktreesForCapturedRepo(
     }
     if (freshScan) {
       rememberLocalWorktreeRoots(store, repo, gitWorktrees)
-      pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
+      pruneLineageForMissingRepoWorktrees(
+        store,
+        repo,
+        gitWorktrees,
+        resolveRepoWorktreePathPlatform(repo)
+      )
     }
     loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
     return {
@@ -1921,7 +1927,12 @@ export function registerWorktreeHandlers(
         }
         if (freshScan) {
           rememberLocalWorktreeRoots(store, repo, gitWorktrees)
-          pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
+          pruneLineageForMissingRepoWorktrees(
+            store,
+            repo,
+            gitWorktrees,
+            resolveRepoWorktreePathPlatform(repo)
+          )
         }
         loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
         return buildDetectedGitWorktrees(store, repo, gitWorktrees)
@@ -1993,7 +2004,12 @@ export function registerWorktreeHandlers(
       }
       if (freshScan) {
         rememberLocalWorktreeRoots(store, repo, gitWorktrees)
-        pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
+        pruneLineageForMissingRepoWorktrees(
+          store,
+          repo,
+          gitWorktrees,
+          resolveRepoWorktreePathPlatform(repo)
+        )
       }
       loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
       return buildDetectedGitWorktrees(store, repo, gitWorktrees)

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -41217,6 +41217,68 @@ describe('OrcaRuntimeService', () => {
     expect(removeWorktreeLineage).not.toHaveBeenCalled()
   })
 
+  it('collapses path-equal rows in the detected worktree list', async () => {
+    vi.mocked(listWorktrees).mockResolvedValue([
+      {
+        path: TEST_WORKTREE_PATH,
+        head: 'abc',
+        branch: '',
+        isBare: false,
+        isMainWorktree: false
+      },
+      {
+        path: '/tmp/./worktree-a',
+        head: 'abc',
+        branch: 'feature/foo',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    const runtime = new OrcaRuntimeService(store as never)
+
+    const result = await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+
+    expect(result.worktrees.map((worktree) => worktree.id)).toEqual([TEST_WORKTREE_ID])
+    expect(result.worktrees[0]?.branch).toBe('feature/foo')
+  })
+
+  it('keeps terminals for a path-equal spelling the detected-list collapse drops', async () => {
+    const dotSpellingId = `${TEST_REPO_ID}::/tmp/./worktree-a`
+    const localProvider = {
+      listProcesses: vi.fn(async () => [
+        { id: `${dotSpellingId}@@session`, cwd: '/tmp/./worktree-a', title: 'shell' }
+      ]),
+      shutdown: vi.fn(async () => {})
+    }
+    vi.mocked(listWorktrees).mockResolvedValue([
+      {
+        path: TEST_WORKTREE_PATH,
+        head: 'abc',
+        branch: 'feature/foo',
+        isBare: false,
+        isMainWorktree: false
+      },
+      {
+        path: '/tmp/./worktree-a',
+        head: 'abc',
+        branch: 'feature/foo',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    const runtime = new OrcaRuntimeService(store as never, undefined, {
+      getLocalProvider: () => localProvider as never
+    })
+
+    const result = await runtime.teardownMissingManagedWorktreeTerminals(`id:${TEST_REPO_ID}`, [
+      TEST_WORKTREE_ID,
+      dotSpellingId
+    ])
+
+    expect(result).toEqual({ stoppedWorktreeIds: [] })
+    expect(localProvider.shutdown).not.toHaveBeenCalled()
+  })
+
   it('revalidates missing worktrees before stopping their local provider sessions', async () => {
     const deletedId = `${TEST_REPO_ID}::/tmp/deleted`
     const survivingId = `${TEST_REPO_ID}::/tmp/surviving`

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -23318,16 +23318,18 @@ export class OrcaRuntimeService {
   ): Promise<DetectedWorktreeListResult> {
     return this.listDetectedWorktreesForResolvedRepo(
       await this.resolveRepoSelectorForConnection(repoSelector, connectionId),
-      sourceDefaultsSupported
+      sourceDefaultsSupported,
+      true
     )
   }
 
   private async listDetectedWorktreesForResolvedRepo(
     repo: Repo,
-    sourceDefaultsSupported = true,
-    // Why opt-out: the terminal sweep judges "missing" against every spelling git reported, because
-    // a spelling the collapse drops still names a live directory and killing its PTYs is final.
-    collapsePathEqualRows = true
+    sourceDefaultsSupported: boolean,
+    // Why required, not defaulted: any caller that reasons about ABSENCE (the terminal sweep, a future
+    // orphan reaper) must pass false — a spelling the collapse drops still names a live directory, and
+    // killing its PTYs is final. A default would make that mistake compile.
+    collapsePathEqualRows: boolean
   ): Promise<DetectedWorktreeListResult> {
     const store = this.requireStore()
     const settings = store.getSettings()

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1052,6 +1052,10 @@ import {
 } from '../../shared/constants'
 import { pruneLineageForMissingRepoWorktrees } from '../worktree-lineage-pruning'
 import {
+  collapsePathEqualWorktreeRows,
+  resolveRepoWorktreePathPlatform
+} from './path-equal-worktree-row-collapse'
+import {
   createWorktreeCopiedPaths,
   createWorktreeLinkedPaths,
   createWorktreeSharedPaths,
@@ -23320,7 +23324,10 @@ export class OrcaRuntimeService {
 
   private async listDetectedWorktreesForResolvedRepo(
     repo: Repo,
-    sourceDefaultsSupported = true
+    sourceDefaultsSupported = true,
+    // Why opt-out: the terminal sweep judges "missing" against every spelling git reported, because
+    // a spelling the collapse drops still names a live directory and killing its PTYs is final.
+    collapsePathEqualRows = true
   ): Promise<DetectedWorktreeListResult> {
     const store = this.requireStore()
     const settings = store.getSettings()
@@ -23361,8 +23368,11 @@ export class OrcaRuntimeService {
     } catch {
       scan = { ok: false, worktrees: [] }
     }
+    const pathPlatform = resolveRepoWorktreePathPlatform(repo)
     if (scan.ok) {
-      pruneLineageForMissingRepoWorktrees(store, repo, scan.worktrees)
+      // Why raw rows: a spelling the collapse drops still names a live directory, so pruning
+      // against the collapsed set would read it as a deleted worktree.
+      pruneLineageForMissingRepoWorktrees(store, repo, scan.worktrees, pathPlatform)
     }
     const worktreeVisibilitySourceMatcher = createWorktreeVisibilitySourceMatcher(
       [repo.path, ...scan.worktrees.map((worktree) => worktree.path)],
@@ -23372,7 +23382,14 @@ export class OrcaRuntimeService {
     const expectedHostId = getRepoExecutionHostId(repo)
     const repoOwnerCount = store.getRepos().filter((candidate) => candidate.id === repo.id).length
     const metaById = store.getAllWorktreeMeta()
-    const detected = scan.worktrees.map((gitWorktree) => {
+    const rows = collapsePathEqualRows
+      ? collapsePathEqualWorktreeRows(scan.worktrees, {
+          repoPath: repo.path,
+          hasStoredMeta: (worktreePath) => metaById[`${repo.id}::${worktreePath}`] !== undefined,
+          platform: pathPlatform
+        })
+      : scan.worktrees
+    const detected = rows.map((gitWorktree) => {
       const worktreeId = `${repo.id}::${gitWorktree.path}`
       const meta = getRepoOwnedWorktreeMeta(repo, worktreeId, metaById, repoOwnerCount)
       const worktree = {
@@ -23412,7 +23429,7 @@ export class OrcaRuntimeService {
     // Why: rescanning by `id:` would re-resolve the already-resolved repo, and a
     // duplicate id across hosts makes that second lookup throw selector_ambiguous
     // even though the caller's selector was unique — losing the sweep entirely.
-    const detected = await this.listDetectedWorktreesForResolvedRepo(repo)
+    const detected = await this.listDetectedWorktreesForResolvedRepo(repo, true, false)
     if (!detected.authoritative) {
       return { stoppedWorktreeIds: [] }
     }

--- a/src/main/runtime/path-equal-worktree-row-collapse.test.ts
+++ b/src/main/runtime/path-equal-worktree-row-collapse.test.ts
@@ -53,6 +53,40 @@ describe('collapsePathEqualWorktreeRows', () => {
     ).toEqual([String.raw`C:\Work\Feature`])
   })
 
+  it.each<NodeJS.Platform>(['win32', 'linux', 'darwin'])(
+    'keeps case-different WSL UNC worktrees apart on %s',
+    (platform) => {
+      const rows = [
+        row(String.raw`\\wsl$\Ubuntu\home\me\wt\Feature`, { branch: 'refs/heads/Feature' }),
+        row(String.raw`\\wsl$\Ubuntu\home\me\wt\feature`, { branch: 'refs/heads/feature' }),
+        row(String.raw`\\wsl.localhost\Ubuntu\home\me\wt\Other`),
+        row(String.raw`\\wsl.localhost\Ubuntu\home\me\wt\other`)
+      ]
+
+      expect(
+        collapsePathEqualWorktreeRows(rows, {
+          repoPath: String.raw`\\wsl$\Ubuntu\home\me\repo`,
+          platform
+        }).map((entry) => entry.path)
+      ).toEqual(rows.map((entry) => entry.path))
+    }
+  )
+
+  it('collapses WSL UNC rows differing only by separator, dot segment or distro case', () => {
+    const rows = [
+      row(String.raw`\\wsl$\Ubuntu\home\me\wt\Feature`),
+      row('//wsl$/ubuntu/home/me/wt/./Feature/'),
+      row(String.raw`\\WSL$\Ubuntu\home\me\wt\Feature`)
+    ]
+
+    expect(
+      collapsePathEqualWorktreeRows(rows, {
+        repoPath: String.raw`\\wsl$\Ubuntu\home\me\repo`,
+        platform: 'win32'
+      }).map((entry) => entry.path)
+    ).toEqual([String.raw`\\wsl$\Ubuntu\home\me\wt\Feature`])
+  })
+
   it('keeps /tmp and /private/tmp apart for rows produced on a non-darwin host', () => {
     const rows = [row('/private/tmp/orca/feature'), row('/tmp/orca/feature')]
 

--- a/src/main/runtime/path-equal-worktree-row-collapse.test.ts
+++ b/src/main/runtime/path-equal-worktree-row-collapse.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import type { Repo } from '../../shared/repo-types'
+import type { GitWorktreeInfo } from '../../shared/worktree/types'
+import {
+  collapsePathEqualWorktreeRows,
+  resolveRepoWorktreePathPlatform
+} from './path-equal-worktree-row-collapse'
+
+function row(path: string, overrides: Partial<GitWorktreeInfo> = {}): GitWorktreeInfo {
+  return {
+    path,
+    head: 'abc123',
+    branch: 'refs/heads/feature',
+    isBare: false,
+    isMainWorktree: false,
+    ...overrides
+  }
+}
+
+function repo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: 'repo',
+    path: '/home/me/repo',
+    displayName: 'repo',
+    badgeColor: 'blue',
+    addedAt: 1,
+    ...overrides
+  }
+}
+
+describe('collapsePathEqualWorktreeRows', () => {
+  it.each<NodeJS.Platform>(['darwin', 'linux'])(
+    'keeps case-different POSIX paths apart on %s',
+    (platform) => {
+      const rows = [row('/home/me/Repo'), row('/home/me/repo')]
+
+      expect(
+        collapsePathEqualWorktreeRows(rows, { repoPath: '/home/me/repo', platform }).map(
+          (entry) => entry.path
+        )
+      ).toEqual(['/home/me/Repo', '/home/me/repo'])
+    }
+  )
+
+  it('collapses Windows slash styles and drive-letter casing', () => {
+    const rows = [row(String.raw`C:\Work\Feature`), row('c:/work/feature/')]
+
+    expect(
+      collapsePathEqualWorktreeRows(rows, {
+        repoPath: String.raw`C:\Work`,
+        platform: 'win32'
+      }).map((entry) => entry.path)
+    ).toEqual([String.raw`C:\Work\Feature`])
+  })
+
+  it('keeps /tmp and /private/tmp apart for rows produced on a non-darwin host', () => {
+    const rows = [row('/private/tmp/orca/feature'), row('/tmp/orca/feature')]
+
+    expect(
+      collapsePathEqualWorktreeRows(rows, { repoPath: '/tmp/orca', platform: 'linux' }).map(
+        (entry) => entry.path
+      )
+    ).toEqual(['/private/tmp/orca/feature', '/tmp/orca/feature'])
+    expect(
+      collapsePathEqualWorktreeRows(rows, { repoPath: '/tmp/orca', platform: 'darwin' })
+    ).toHaveLength(1)
+  })
+
+  it('collapses in place and merges the peer branch, head and flags', () => {
+    const rows = [
+      row('/home/me/repo/', { head: '', branch: '', isMainWorktree: false }),
+      row('/home/me/wt/feature', { branch: 'refs/heads/feature' }),
+      row('/home/me/repo', { branch: 'refs/heads/master', isMainWorktree: true, isSparse: true })
+    ]
+
+    const collapsed = collapsePathEqualWorktreeRows(rows, {
+      repoPath: '/home/me/repo',
+      platform: 'linux'
+    })
+
+    expect(collapsed).toHaveLength(2)
+    expect(collapsed[0]).toMatchObject({
+      path: '/home/me/repo',
+      head: 'abc123',
+      branch: 'refs/heads/master',
+      isMainWorktree: true,
+      isSparse: true
+    })
+    expect(collapsed[1].path).toBe('/home/me/wt/feature')
+  })
+
+  it('prefers a spelling that already owns metadata over git row order', () => {
+    const rows = [row('/home/me/wt/./feature'), row('/home/me/wt/feature')]
+
+    expect(
+      collapsePathEqualWorktreeRows(rows, {
+        repoPath: '/home/me/repo',
+        hasStoredMeta: (path) => path === '/home/me/wt/feature',
+        platform: 'linux'
+      })[0].path
+    ).toBe('/home/me/wt/feature')
+  })
+})
+
+describe('resolveRepoWorktreePathPlatform', () => {
+  it('treats remote-host rows as plain POSIX regardless of the desktop platform', () => {
+    expect(resolveRepoWorktreePathPlatform(repo({ connectionId: 'builder' }))).toBe('linux')
+    expect(resolveRepoWorktreePathPlatform(repo({ executionHostId: 'runtime:sandbox' }))).toBe(
+      'linux'
+    )
+    expect(resolveRepoWorktreePathPlatform(repo())).toBe(process.platform)
+  })
+})

--- a/src/main/runtime/path-equal-worktree-row-collapse.ts
+++ b/src/main/runtime/path-equal-worktree-row-collapse.ts
@@ -31,8 +31,9 @@ export function resolveRepoWorktreePathPlatform(repo: Repo): NodeJS.Platform {
  * metadata, else Git's first row) so the derived worktree id stays stable, and adopts the branch,
  * head and flags of the peers it absorbs.
  *
- * POSIX paths are never case-folded, including on macOS: APFS/HFSX can be formatted case-sensitive,
- * and silently dropping a real worktree row is worse than showing a duplicate one.
+ * Case-sensitive roots are never case-folded — POSIX paths (including on macOS, where APFS/HFSX can
+ * be formatted case-sensitive) and the WSL UNC aliases Windows hosts report worktrees under.
+ * Silently dropping a real worktree row is worse than showing a duplicate one.
  */
 export function collapsePathEqualWorktreeRows(
   rows: readonly GitWorktreeInfo[],

--- a/src/main/runtime/path-equal-worktree-row-collapse.ts
+++ b/src/main/runtime/path-equal-worktree-row-collapse.ts
@@ -1,0 +1,86 @@
+import { LOCAL_EXECUTION_HOST_ID, getRepoExecutionHostId } from '../../shared/execution-host'
+import type { Repo } from '../../shared/repo-types'
+import type { GitWorktreeInfo } from '../../shared/worktree/types'
+import { worktreePathComparisonKey } from '../ipc/worktree-path-comparison'
+
+export type PathEqualWorktreeRowCollapseOptions = {
+  /** The repo's own spelling of its root; the preferred survivor so `<repoId>::<path>` ids stay stable. */
+  repoPath: string
+  /** True when a spelling already owns persisted worktree metadata. */
+  hasStoredMeta?: (worktreePath: string) => boolean
+  /** Platform of the host that produced the rows — not necessarily the desktop's. */
+  platform?: NodeJS.Platform
+}
+
+/**
+ * Which platform's path rules apply to a repo's scanned rows.
+ *
+ * Why: rows can come from an SSH or runtime host, and applying the desktop's macOS `/private/tmp`
+ * firmlink remap to a remote host would collapse two directories that are genuinely distinct there.
+ */
+export function resolveRepoWorktreePathPlatform(repo: Repo): NodeJS.Platform {
+  return getRepoExecutionHostId(repo) === LOCAL_EXECUTION_HOST_ID ? process.platform : 'linux'
+}
+
+/**
+ * Collapse rows naming the same directory under different spellings (`.` or `..` segments, repeated
+ * or trailing separators, Windows slash style and drive-letter case) into a single row, in place, so
+ * Git's own ordering survives — downstream `slice(0, limit)` and `candidates[0]` callers depend on it.
+ *
+ * The survivor keeps the canonical spelling (the repo's own path, else a spelling that already has
+ * metadata, else Git's first row) so the derived worktree id stays stable, and adopts the branch,
+ * head and flags of the peers it absorbs.
+ *
+ * POSIX paths are never case-folded, including on macOS: APFS/HFSX can be formatted case-sensitive,
+ * and silently dropping a real worktree row is worse than showing a duplicate one.
+ */
+export function collapsePathEqualWorktreeRows(
+  rows: readonly GitWorktreeInfo[],
+  options: PathEqualWorktreeRowCollapseOptions
+): GitWorktreeInfo[] {
+  const platform = options.platform ?? process.platform
+  const survivorIndexByPathKey = new Map<string, number>()
+  const collapsed: GitWorktreeInfo[] = []
+  for (const row of rows) {
+    const pathKey = worktreePathComparisonKey(row.path, platform)
+    const survivorIndex = survivorIndexByPathKey.get(pathKey)
+    if (survivorIndex === undefined) {
+      survivorIndexByPathKey.set(pathKey, collapsed.length)
+      collapsed.push(row)
+      continue
+    }
+    collapsed[survivorIndex] = mergePathEqualRows(collapsed[survivorIndex], row, options)
+  }
+  return collapsed
+}
+
+function mergePathEqualRows(
+  survivor: GitWorktreeInfo,
+  duplicate: GitWorktreeInfo,
+  options: PathEqualWorktreeRowCollapseOptions
+): GitWorktreeInfo {
+  return {
+    ...survivor,
+    path: pickCanonicalSpelling(survivor.path, duplicate.path, options),
+    // Why: the stored-metadata fallback row carries an empty head/branch, so a real Git row fills them.
+    head: survivor.head || duplicate.head,
+    branch: survivor.branch || duplicate.branch,
+    isMainWorktree: survivor.isMainWorktree || duplicate.isMainWorktree,
+    ...(survivor.isSparse || duplicate.isSparse ? { isSparse: true } : {})
+  }
+}
+
+function pickCanonicalSpelling(
+  survivorPath: string,
+  duplicatePath: string,
+  options: PathEqualWorktreeRowCollapseOptions
+): string {
+  if (survivorPath === options.repoPath || duplicatePath === options.repoPath) {
+    return options.repoPath
+  }
+  const { hasStoredMeta } = options
+  if (!hasStoredMeta || hasStoredMeta(survivorPath) || !hasStoredMeta(duplicatePath)) {
+    return survivorPath
+  }
+  return duplicatePath
+}

--- a/src/main/runtime/repo-worktree-row-resolution.test.ts
+++ b/src/main/runtime/repo-worktree-row-resolution.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { ExecutionHostId } from '../../shared/execution-host'
 import type { Repo } from '../../shared/repo-types'
+import type { WorktreeLineage } from '../../shared/worktree/lineage-types'
 import type { WorktreeMeta } from '../../shared/worktree/meta-types'
 import type { GitWorktreeInfo, Worktree } from '../../shared/worktree/types'
 import type { Store } from '../persistence'
@@ -35,16 +36,35 @@ function gitWorktree(path: string): GitWorktreeInfo {
   }
 }
 
-function createDeps(repos: Repo[]): RepoWorktreeRowDeps & {
+/**
+ * Lineage removal is opt-in: a store without `removeWorktreeLineage` makes
+ * `pruneLineageForMissingRepoWorktrees` no-op, which is what the non-lineage cases here want.
+ */
+function createDeps(
+  repos: Repo[],
+  worktreeLineageById?: Record<string, WorktreeLineage>
+): RepoWorktreeRowDeps & {
   metaById: Record<string, WorktreeMeta>
+  removeWorktreeLineage: ReturnType<typeof vi.fn>
   scanRepo: ReturnType<typeof vi.fn<RepoWorktreeRowDeps['scanRepo']>>
   listFolderWorkspaces: ReturnType<typeof vi.fn<RepoWorktreeRowDeps['listFolderWorkspaces']>>
 } {
   const metaById: Record<string, WorktreeMeta> = {}
+  const removeWorktreeLineage = vi.fn((worktreeId: string) => {
+    delete worktreeLineageById?.[worktreeId]
+  })
   const store = {
     getRepos: () => repos,
     getAllWorktreeMeta: () => metaById,
-    getAllWorktreeLineage: () => ({}),
+    getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+    getAllWorktreeLineage: () => worktreeLineageById ?? {},
+    ...(worktreeLineageById
+      ? {
+          getAllWorkspaceLineage: () => ({}),
+          removeWorktreeLineage,
+          removeWorkspaceLineage: vi.fn()
+        }
+      : {}),
     getProjects: () => [],
     getSettings: () => ({}),
     setWorktreeMeta: (worktreeId: string, updates: Partial<WorktreeMeta>) => {
@@ -58,39 +78,116 @@ function createDeps(repos: Repo[]): RepoWorktreeRowDeps & {
     worktrees: [gitWorktree(owner.id === 'unrelated' ? '/unrelated/worktree' : '/same/worktree')]
   }))
   const listFolderWorkspaces = vi.fn<RepoWorktreeRowDeps['listFolderWorkspaces']>(() => [])
-  return { store, metaById, scanRepo, listFolderWorkspaces }
+  return { store, metaById, removeWorktreeLineage, scanRepo, listFolderWorkspaces }
+}
+
+function scanRow(path: string, overrides: Partial<GitWorktreeInfo> = {}): GitWorktreeInfo {
+  return {
+    path,
+    head: 'abc123',
+    branch: 'refs/heads/feature',
+    isBare: false,
+    isMainWorktree: false,
+    ...overrides
+  }
 }
 
 describe('path-equal worktree row collapse', () => {
-  it('keeps one row and prefers the git branch when the same path is listed twice', async () => {
+  it('collapses onto the repo path spelling and adopts the peer branch', async () => {
     const owner = repo('repo', '/home/me/repo')
     const deps = createDeps([owner])
     deps.scanRepo.mockResolvedValueOnce({
       ok: true,
       worktrees: [
-        {
-          path: '/home/me/repo',
-          head: '',
-          branch: '',
-          isBare: false,
-          isMainWorktree: true
-        },
-        {
-          path: '/home/me/./repo',
-          head: 'abc123',
-          branch: 'refs/heads/master',
-          isBare: false,
-          isMainWorktree: true
-        }
+        scanRow('/home/me/repo', { head: '', branch: '', isMainWorktree: true }),
+        scanRow('/home/me/./repo', { branch: 'refs/heads/master', isMainWorktree: true })
       ]
     })
 
     const rows = await resolveRepoWorktreeRows(deps, owner, deps.metaById, new Map())
+
     expect(rows).toHaveLength(1)
     expect(rows[0]).toMatchObject({
+      id: 'repo::/home/me/repo',
+      path: '/home/me/repo',
+      head: 'abc123',
       branch: 'refs/heads/master',
-      path: '/home/me/./repo'
+      isMainWorktree: true
     })
+  })
+
+  it('keeps the spelling that already owns worktree metadata', async () => {
+    const owner = repo('repo', '/home/me/repo')
+    const deps = createDeps([owner])
+    deps.metaById['repo::/home/me/wt/feature'] = {
+      instanceId: 'stable-instance',
+      comment: 'carried over'
+    } as WorktreeMeta
+    deps.scanRepo.mockResolvedValueOnce({
+      ok: true,
+      worktrees: [scanRow('/home/me/wt/./feature'), scanRow('/home/me/wt/feature')]
+    })
+
+    const rows = await resolveRepoWorktreeRows(deps, owner, deps.metaById, new Map())
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      id: 'repo::/home/me/wt/feature',
+      path: '/home/me/wt/feature',
+      comment: 'carried over'
+    })
+    expect(deps.metaById['repo::/home/me/wt/./feature']).toBeUndefined()
+    expect(deps.metaById['repo::/home/me/wt/feature'].instanceId).toBe('stable-instance')
+  })
+
+  it('never prunes lineage for a spelling the collapse dropped', async () => {
+    const owner = repo('repo', '/home/me/repo')
+    const childId = 'repo::/home/me/wt/./feature'
+    const worktreeLineageById: Record<string, WorktreeLineage> = {}
+    const deps = createDeps([owner], worktreeLineageById)
+    worktreeLineageById[childId] = {
+      worktreeId: childId,
+      worktreeInstanceId: 'child-instance',
+      parentWorktreeId: 'repo::/home/me/repo',
+      parentWorktreeInstanceId: 'parent-instance',
+      origin: 'manual',
+      capture: { source: 'manual-action', confidence: 'explicit' },
+      createdAt: 1
+    }
+    deps.scanRepo.mockResolvedValueOnce({
+      ok: true,
+      worktrees: [
+        scanRow('/home/me/repo', { isMainWorktree: true }),
+        scanRow('/home/me/wt/feature'),
+        scanRow('/home/me/wt/./feature')
+      ]
+    })
+
+    await resolveRepoWorktreeRows(deps, owner, deps.metaById, new Map())
+
+    expect(deps.removeWorktreeLineage).not.toHaveBeenCalled()
+    expect(worktreeLineageById[childId]).toBeDefined()
+  })
+
+  it('preserves git row order when a worktree has no branch', async () => {
+    const owner = repo('repo', '/home/me/repo')
+    const deps = createDeps([owner])
+    deps.scanRepo.mockResolvedValueOnce({
+      ok: true,
+      worktrees: [
+        scanRow('/home/me/repo', { branch: '', isMainWorktree: true }),
+        scanRow('/home/me/wt/detached', { branch: '' }),
+        scanRow('/home/me/wt/feature')
+      ]
+    })
+
+    const rows = await resolveRepoWorktreeRows(deps, owner, deps.metaById, new Map())
+
+    expect(rows.map((row) => row.path)).toEqual([
+      '/home/me/repo',
+      '/home/me/wt/detached',
+      '/home/me/wt/feature'
+    ])
   })
 })
 

--- a/src/main/runtime/repo-worktree-row-resolution.test.ts
+++ b/src/main/runtime/repo-worktree-row-resolution.test.ts
@@ -61,6 +61,39 @@ function createDeps(repos: Repo[]): RepoWorktreeRowDeps & {
   return { store, metaById, scanRepo, listFolderWorkspaces }
 }
 
+describe('path-equal worktree row collapse', () => {
+  it('keeps one row and prefers the git branch when the same path is listed twice', async () => {
+    const owner = repo('repo', '/home/me/repo')
+    const deps = createDeps([owner])
+    deps.scanRepo.mockResolvedValueOnce({
+      ok: true,
+      worktrees: [
+        {
+          path: '/home/me/repo',
+          head: '',
+          branch: '',
+          isBare: false,
+          isMainWorktree: true
+        },
+        {
+          path: '/home/me/./repo',
+          head: 'abc123',
+          branch: 'refs/heads/master',
+          isBare: false,
+          isMainWorktree: true
+        }
+      ]
+    })
+
+    const rows = await resolveRepoWorktreeRows(deps, owner, deps.metaById, new Map())
+    expect(rows).toHaveLength(1)
+    expect(rows[0]).toMatchObject({
+      branch: 'refs/heads/master',
+      path: '/home/me/./repo'
+    })
+  })
+})
+
 describe('host-qualified scoped worktree resolution', () => {
   it('scans only the selected local or SSH owner when repo ids and paths collide', async () => {
     const owners = [

--- a/src/main/runtime/repo-worktree-row-resolution.ts
+++ b/src/main/runtime/repo-worktree-row-resolution.ts
@@ -10,6 +10,7 @@ import type { WorktreeMeta } from '../../shared/worktree/meta-types'
 import type { ProjectExecutionRuntimeResolution } from '../../shared/project-execution-runtime'
 import type { Store } from '../persistence'
 import { areWorktreePathsEqual, mergeWorktree } from '../ipc/worktree-logic'
+import { dedupeWorktreesByPath } from '../ipc/worktree-path-comparison'
 import { pruneLineageForMissingRepoWorktrees } from '../worktree-lineage-pruning'
 import { getRepoOwnedWorktreeMeta } from '../worktree-metadata-ownership'
 import { resolveLocalProjectRuntimesForRepos } from '../project-runtime-git-options'
@@ -121,7 +122,12 @@ export async function resolveRepoWorktreeRows(
     RESOLVED_WORKTREE_REPO_TIMEOUT_MS,
     null
   )) ?? { ok: false, worktrees: listStoredWorktreeRowsForRepo(store, repo, repoOwnerCount) }
-  const gitWorktrees = scan.worktrees
+  const gitWorktrees = dedupeWorktreesByPath(
+    // Why: keep the git-scanned branch over a stored empty-branch clone of the same path (#15526).
+    [...scan.worktrees].sort(
+      (left, right) => Number(Boolean(right.branch)) - Number(Boolean(left.branch))
+    )
+  )
   if (scan.ok) {
     pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
   }

--- a/src/main/runtime/repo-worktree-row-resolution.ts
+++ b/src/main/runtime/repo-worktree-row-resolution.ts
@@ -10,10 +10,13 @@ import type { WorktreeMeta } from '../../shared/worktree/meta-types'
 import type { ProjectExecutionRuntimeResolution } from '../../shared/project-execution-runtime'
 import type { Store } from '../persistence'
 import { areWorktreePathsEqual, mergeWorktree } from '../ipc/worktree-logic'
-import { dedupeWorktreesByPath } from '../ipc/worktree-path-comparison'
 import { pruneLineageForMissingRepoWorktrees } from '../worktree-lineage-pruning'
 import { getRepoOwnedWorktreeMeta } from '../worktree-metadata-ownership'
 import { resolveLocalProjectRuntimesForRepos } from '../project-runtime-git-options'
+import {
+  collapsePathEqualWorktreeRows,
+  resolveRepoWorktreePathPlatform
+} from './path-equal-worktree-row-collapse'
 import type { RuntimeWorktreeScanResult } from './repo-worktree-resolution-scan'
 
 /**
@@ -122,15 +125,16 @@ export async function resolveRepoWorktreeRows(
     RESOLVED_WORKTREE_REPO_TIMEOUT_MS,
     null
   )) ?? { ok: false, worktrees: listStoredWorktreeRowsForRepo(store, repo, repoOwnerCount) }
-  const gitWorktrees = dedupeWorktreesByPath(
-    // Why: keep the git-scanned branch over a stored empty-branch clone of the same path (#15526).
-    [...scan.worktrees].sort(
-      (left, right) => Number(Boolean(right.branch)) - Number(Boolean(left.branch))
-    )
-  )
+  const pathPlatform = resolveRepoWorktreePathPlatform(repo)
+  // Why: prune against the raw rows so a spelling the collapse drops is never mistaken for a deleted worktree.
   if (scan.ok) {
-    pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
+    pruneLineageForMissingRepoWorktrees(store, repo, scan.worktrees, pathPlatform)
   }
+  const gitWorktrees = collapsePathEqualWorktreeRows(scan.worktrees, {
+    repoPath: repo.path,
+    hasStoredMeta: (worktreePath) => metaById[`${repo.id}::${worktreePath}`] !== undefined,
+    platform: pathPlatform
+  })
   const expectedHostId = getRepoExecutionHostId(repo)
   return gitWorktrees.map((gitWorktree) => {
     const worktreeId = `${repo.id}::${gitWorktree.path}`

--- a/src/main/worktree-lineage-pruning.test.ts
+++ b/src/main/worktree-lineage-pruning.test.ts
@@ -98,7 +98,7 @@ describe('pruneLineageForMissingRepoWorktrees', () => {
     }
     const store = createStore(worktreeLineageById, workspaceLineageByChildKey, metaById)
 
-    pruneLineageForMissingRepoWorktrees(store as never, repo, [])
+    pruneLineageForMissingRepoWorktrees(store as never, repo, [], 'linux')
 
     expect(store.removeWorktreeLineage).not.toHaveBeenCalled()
     expect(store.removeWorkspaceLineage).not.toHaveBeenCalled()
@@ -128,22 +128,27 @@ describe('pruneLineageForMissingRepoWorktrees', () => {
     }
     const store = createStore(worktreeLineageById, workspaceLineageByChildKey, metaById)
 
-    pruneLineageForMissingRepoWorktrees(store as never, repo, [
-      {
-        path: '/repo/live-parent',
-        head: 'a',
-        branch: 'main',
-        isBare: false,
-        isMainWorktree: false
-      },
-      {
-        path: '/repo/live-child',
-        head: 'b',
-        branch: 'child',
-        isBare: false,
-        isMainWorktree: false
-      }
-    ])
+    pruneLineageForMissingRepoWorktrees(
+      store as never,
+      repo,
+      [
+        {
+          path: '/repo/live-parent',
+          head: 'a',
+          branch: 'main',
+          isBare: false,
+          isMainWorktree: false
+        },
+        {
+          path: '/repo/live-child',
+          head: 'b',
+          branch: 'child',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ],
+      'linux'
+    )
 
     expect(store.removeWorktreeLineage).toHaveBeenCalledWith(missingChildId)
     expect(store.removeWorktreeLineage).not.toHaveBeenCalledWith(liveChildId)

--- a/src/main/worktree-lineage-pruning.test.ts
+++ b/src/main/worktree-lineage-pruning.test.ts
@@ -57,6 +57,35 @@ function createStore(
 }
 
 describe('pruneLineageForMissingRepoWorktrees', () => {
+  it('keeps lineage stored under another spelling of a live worktree path', () => {
+    const parentId = 'repo-1::/repo'
+    const childId = 'repo-1::/repo/./child'
+    const edge = lineage(childId, parentId)
+    const worktreeLineageById = { [childId]: edge }
+    const workspaceLineageByChildKey = {
+      [worktreeWorkspaceKey(childId)]: workspaceLineage(childId, parentId)
+    }
+    const metaById = {
+      [parentId]: { instanceId: edge.parentWorktreeInstanceId } as WorktreeMeta
+    }
+    const store = createStore(worktreeLineageById, workspaceLineageByChildKey, metaById)
+
+    pruneLineageForMissingRepoWorktrees(
+      store as never,
+      repo,
+      [
+        { path: '/repo', head: 'a', branch: 'main', isBare: false, isMainWorktree: true },
+        { path: '/repo/child/', head: 'b', branch: 'child', isBare: false, isMainWorktree: false }
+      ],
+      'linux'
+    )
+
+    expect(store.removeWorktreeLineage).not.toHaveBeenCalled()
+    expect(store.removeWorkspaceLineage).not.toHaveBeenCalled()
+    expect(store.setWorktreeMeta).not.toHaveBeenCalled()
+    expect(worktreeLineageById[childId]).toBe(edge)
+  })
+
   it('refuses an empty scan when the repo still has registered lineage', () => {
     const parentId = 'repo-1::/repo/parent'
     const childId = 'repo-1::/repo/child'

--- a/src/main/worktree-lineage-pruning.ts
+++ b/src/main/worktree-lineage-pruning.ts
@@ -40,7 +40,9 @@ export function pruneLineageForMissingRepoWorktrees(
   store: Store,
   repo: Repo,
   gitWorktrees: GitWorktreeInfo[],
-  platform: NodeJS.Platform = process.platform
+  // Why required: rows can come from an SSH or WSL host, and silently defaulting to the desktop's
+  // rules would apply macOS `/private/tmp` remapping to a remote host's paths.
+  platform: NodeJS.Platform
 ): void {
   if (
     typeof store.getAllWorktreeLineage !== 'function' ||

--- a/src/main/worktree-lineage-pruning.ts
+++ b/src/main/worktree-lineage-pruning.ts
@@ -4,6 +4,8 @@ import type { WorkspaceLineage, WorktreeLineage } from '../shared/worktree/linea
 import type { GitWorktreeInfo } from '../shared/worktree/types'
 import { getRepoExecutionHostId } from '../shared/execution-host'
 import { isWorkspaceKey, parseWorkspaceKey, worktreeWorkspaceKey } from '../shared/workspace-scope'
+import { splitWorktreeId } from '../shared/worktree/id'
+import { worktreePathComparisonKey } from './ipc/worktree-path-comparison'
 import type { Store } from './persistence'
 
 function worktreeIdBelongsToRepo(worktreeId: string, repoPrefix: string): boolean {
@@ -37,7 +39,8 @@ function hasStoredRepoLineage(
 export function pruneLineageForMissingRepoWorktrees(
   store: Store,
   repo: Repo,
-  gitWorktrees: GitWorktreeInfo[]
+  gitWorktrees: GitWorktreeInfo[],
+  platform: NodeJS.Platform = process.platform
 ): void {
   if (
     typeof store.getAllWorktreeLineage !== 'function' ||
@@ -56,6 +59,22 @@ export function pruneLineageForMissingRepoWorktrees(
     return
   }
   const liveIds = new Set(gitWorktrees.map((worktree) => `${repo.id}::${worktree.path}`))
+  const livePathKeys = new Set(
+    gitWorktrees.map((worktree) => worktreePathComparisonKey(worktree.path, platform))
+  )
+  // Why: lineage is keyed on a stored spelling, so a live worktree reported under another spelling of
+  // the same directory must never look "proven missing" — that deletion is irreversible.
+  const isLive = (worktreeId: string): boolean => {
+    if (liveIds.has(worktreeId)) {
+      return true
+    }
+    // Why not `...ForFilesystem`: folder-workspace instances legitimately share a directory, so their
+    // id suffix must keep them distinct here.
+    const worktreePath = splitWorktreeId(worktreeId)?.worktreePath
+    return worktreePath
+      ? livePathKeys.has(worktreePathComparisonKey(worktreePath, platform))
+      : false
+  }
   const expectedHostId = getRepoExecutionHostId(repo)
   const repoOwners = store.getRepos().filter((candidate) => candidate.id === repo.id)
   const canMutateWorktree = (worktreeId: string): boolean => {
@@ -68,7 +87,7 @@ export function pruneLineageForMissingRepoWorktrees(
       childScope?.type === 'worktree' &&
       worktreeIdBelongsToRepo(childScope.worktreeId, repoPrefix) &&
       canMutateWorktree(childScope.worktreeId) &&
-      !liveIds.has(childScope.worktreeId) &&
+      !isLive(childScope.worktreeId) &&
       isWorkspaceKey(childWorkspaceKey)
     ) {
       store.removeWorkspaceLineage?.(childWorkspaceKey)
@@ -78,7 +97,7 @@ export function pruneLineageForMissingRepoWorktrees(
     if (
       worktreeIdBelongsToRepo(childId, repoPrefix) &&
       canMutateWorktree(childId) &&
-      !liveIds.has(childId)
+      !isLive(childId)
     ) {
       // Why: a proven-missing path must not transfer its lineage to a future checkout at that path.
       store.removeWorktreeLineage(childId)
@@ -87,7 +106,7 @@ export function pruneLineageForMissingRepoWorktrees(
     if (
       worktreeIdBelongsToRepo(lineage.parentWorktreeId, repoPrefix) &&
       canMutateWorktree(lineage.parentWorktreeId) &&
-      !liveIds.has(lineage.parentWorktreeId)
+      !isLive(lineage.parentWorktreeId)
     ) {
       const parentMeta = store.getWorktreeMeta(lineage.parentWorktreeId)
       if (!parentMeta || parentMeta.instanceId === lineage.parentWorktreeInstanceId) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​414 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​394 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​179 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​164 |

<!-- /orca-pr-loc -->

Supersedes #15561 by @innocarpe — carried over so it can run full CI (fork PRs only run `track-community-pr` in this repo). Original authorship preserved in the commit.

## ELI5

Git can name the same folder in more than one way: `/home/me/repo`, `/home/me/./repo`, `C:\Work\Feature` vs `c:/work/feature/`. When two of those spellings reach the worktree list, Orca shows the same worktree twice — and it looks worse than a plain duplicate, because one of the copies shows up with no branch at all. This PR folds those spellings into one row, keeping the spelling Orca already knows, so nothing that points at that worktree (its comment, display name, lineage, `id:` selector) breaks.

## What Changed

- New `src/main/runtime/path-equal-worktree-row-collapse.ts`:
  - `collapsePathEqualWorktreeRows` groups rows by `worktreePathComparisonKey` **in place** (first slot wins) and merges the peers' `branch` / `head` / `isMainWorktree` / `isSparse` into the survivor.
  - The survivor's spelling is chosen by preference: the repo's own `path` > a spelling that already owns `worktreeMeta` > Git's first row.
  - `resolveRepoWorktreePathPlatform(repo)` returns `process.platform` for local repos and `'linux'` for SSH/runtime repos.
- `src/main/runtime/repo-worktree-row-resolution.ts` (`worktree.list`) uses it, and now calls `pruneLineageForMissingRepoWorktrees` with the **raw** scan rows, before the collapse.
- `src/main/runtime/orca-runtime.ts` (`worktree.detectedList`) uses it too — it serves the *same* cached scan, so without this the duplicate row stayed visible to remote/web clients, which hydrate from `worktree.detectedList`. `teardownMissingManagedWorktreeTerminals` explicitly opts **out** (third argument `false`): a spelling the collapse drops still names a live directory, so judging "missing" against the collapsed set would kill that worktree's PTYs. That third parameter (`collapsePathEqualRows`) is **required**, not defaulted — symmetric with `platform` above, so a future caller that reasons about absence has to state its choice instead of inheriting the collapsed list silently (see limitations). Both call sites are pinned by tests.
- `src/main/ipc/worktree-path-comparison.ts` stops case-folding WSL UNC paths (see Case sensitivity below); this also makes `areWorktreePathsEqual` / `dedupeWorktreesByPath` stop merging case-distinct WSL worktrees.
- `src/main/worktree-lineage-pruning.ts` gained an `isLive(worktreeId)` check: a stored id is live if it matches exactly *or* its path normalizes to the same comparison key as a scanned row. `platform` is a **required** parameter and all **five** non-test call sites (`runtime/repo-worktree-row-resolution.ts`, `runtime/orca-runtime.ts`, and three in `ipc/worktrees.ts` — lines 1307, 1930, 2007) pass `resolveRepoWorktreePathPlatform(repo)`, so a new call site cannot silently pick up the desktop's rules for a remote host.

## Why

#15561 fixed the duplicate row, but the way it did it introduced three problems that are worse than the duplicate:

1. **Lineage data loss (the important one).** The PR passed the *deduped* array to `pruneLineageForMissingRepoWorktrees`. That function builds `liveIds` from exact `${repo.id}::${worktree.path}` strings and permanently calls `store.removeWorktreeLineage` / `removeWorkspaceLineage` for anything absent, plus rotates the parent's `instanceId`. So every spelling the dedupe dropped was indistinguishable from a deleted worktree, and its persisted parent/child lineage was destroyed — on every successful scan, local and SSH, in exactly the scenario the PR exists to create. The added test could not catch it because the fake store had no `removeWorktreeLineage`, so the pruner early-returned.
2. **Worktree identity flip.** The PR sorted branch-bearing rows first so they would win the dedupe. `worktreeId` is derived from the surviving row's raw path, so when the branch-bearing row carried the non-canonical spelling the id changed (the PR's own test asserted `/home/me/./repo` survives). `metaById[worktreeId]` then misses, a *fresh* meta record is written, the old one is orphaned, and `resolveScopedWorktreeIdRow` stops resolving the previously-valid id — breaking `orca worktree show --worktree id:<old id>` and any client holding it.
3. **Global reordering.** The sort pushed *all* branchless rows (bare main worktrees, detached-HEAD checkouts) to the end of every repo's block, discarding Git's own ordering. `listManagedWorktrees` does `worktrees.slice(0, limit)` and `resolveWorktreeSelector` picks `candidates[0]`, so truncation and `path:` selector resolution both changed behavior even when there were no duplicates at all.

This version keeps the user-visible fix (one row, with the branch filled in) and drops all three.

Two points reviewers of the original PR raised, decided explicitly here:

- **Case sensitivity.** POSIX paths are **not** case-folded, on any platform including macOS. APFS/HFSX can be formatted case-sensitive, so `/Users/me/Repo` and `/Users/me/repo` can be two genuinely different directories; silently dropping a real worktree row is worse than showing a duplicate one. Drive-letter and plain UNC Windows paths keep the existing case-insensitive + slash-normalizing rules, which are correct there. **WSL UNC paths are the exception**: `\\wsl$\<distro>\...` / `\\wsl.localhost\<distro>\...` match `isWindowsAbsolutePathLike`, but they front a case-sensitive Linux filesystem (`isCaseInsensitiveRuntimeRoot` already says so), and every WSL worktree Orca reports has been rewritten into that UNC form by `translateWslOutputPaths`. `normalizeWindowsWorktreePathForComparison` therefore folds only the alias and distro (UNC server/share names) and preserves the rest, so two WSL worktrees differing only by case stay two rows. **This is not theoretical**: on the real Windows+WSL host, the shipped `main` build answered `orca worktree create --name caseb` with the path of a pre-existing `CaseB` worktree (`findCreatedWorktree` -> `areWorktreePathsEqual`), and the real `caseb` worktree Git had just created was then absent from `orca worktree list`. Pinned by `it.each(['darwin', 'linux'])('keeps case-different POSIX paths apart on %s')` and `it.each(['win32', 'linux', 'darwin'])('keeps case-different WSL UNC worktrees apart on %s')`, with a companion test asserting separator/dot-segment/distro-case WSL duplicates still collapse.
- **Remote paths.** `worktreePathComparisonKey` defaults to `process.platform`, and on darwin it remaps `/private/tmp/...` to `/tmp/...` (a macOS firmlink). Those rows can come from `provider.listWorktrees` on an SSH host where `/tmp` and `/private/tmp` are genuinely distinct directories. `resolveRepoWorktreePathPlatform` therefore feeds `'linux'` for any non-local execution host. Windows-looking remote paths are unaffected — `isWindowsAbsolutePathLike` still routes them to win32 rules regardless of the platform argument.

## Linked Issue

No linked issue — reported via PR #15561. Related sidebar report: #15526 (note: the sidebar path already ran `dedupeWorktreesByPath`, so #15526's three `master` rows are likely a separate `displayName` fallback issue and are **not** claimed as fixed here).

## Visual Proof

N/A — no renderer or styling change. This is main-process row resolution; the only user-visible effect is that the worktree catalog stops emitting two rows for one directory.

## Testing

Unit runs below are **macOS** (Darwin 25.3.0). The premises this change rests on were separately exercised on a **real Windows 11 + WSL2 host** — see *Real-hardware verification* at the end of this section.

```
npx vitest run --config config/vitest.config.ts \
  src/main/runtime/repo-worktree-row-resolution.test.ts \
  src/main/runtime/path-equal-worktree-row-collapse.test.ts \
  src/main/worktree-lineage-pruning.test.ts \
  src/main/ipc/worktree-path-deduplication.test.ts \
  src/main/ipc/worktree-logic.test.ts \
  src/main/ipc/worktree-logic-wsl.test.ts
# => 6 files passed, all green (includes the new WSL UNC cases)

npx oxlint <6 changed files>                                              # clean
npx oxlint --config config/oxlint-code-quality-native-plugins.json <6 changed files> --deny-warnings   # clean
npx oxfmt --check <6 changed files>                                       # clean
```

Second pass (detected-list collapse + required `platform`):

```
npx vitest run --config config/vitest.config.ts \
  src/main/runtime/orca-runtime.test.ts \
  src/main/runtime/repo-worktree-row-resolution.test.ts \
  src/main/runtime/path-equal-worktree-row-collapse.test.ts \
  src/main/worktree-lineage-pruning.test.ts \
  src/main/ipc/worktree-path-deduplication.test.ts
# => 5 files passed, 1217 tests

npx vitest run --config config/vitest.config.ts \
  src/main/ipc/worktrees-detected-scan-cache.test.ts \
  src/main/ipc/worktrees-ssh-provider-authority.test.ts \
  src/main/ipc/worktrees-lineage-hydration.test.ts \
  src/main/ipc/worktrees-windows.test.ts \
  src/main/ipc/worktree-logic.test.ts \
  src/main/ipc/worktree-logic-wsl.test.ts
# => 6 files passed, 130 tests
```

Regression evidence (the new tests were confirmed to fail without the product change):

- Reverting `repo-worktree-row-resolution.ts` and `worktree-lineage-pruning.ts` to the #15561 state makes 4 of the new tests fail: `collapses onto the repo path spelling and adopts the peer branch`, `keeps the spelling that already owns worktree metadata`, `never prunes lineage for a spelling the collapse dropped`, `preserves git row order when a worktree has no branch`.
- Reverting only `worktree-lineage-pruning.ts` makes `keeps lineage stored under another spelling of a live worktree path` fail.
- Reverting only the `worktree-path-comparison.ts` WSL branch makes the three `keeps case-different WSL UNC worktrees apart on <platform>` cases fail (both WSL rows collapse to one and a real worktree disappears).
- Dropping the collapse in `listDetectedWorktreesForResolvedRepo` makes `collapses path-equal rows in the detected worktree list` fail (`['repo-1::/tmp/worktree-a', 'repo-1::/tmp/./worktree-a']` instead of one row).
- Keeping the collapse but removing the teardown opt-out makes `keeps terminals for a path-equal spelling the detected-list collapse drops` fail with `stoppedWorktreeIds: ['repo-1::/tmp/./worktree-a']` — i.e. the sweep really would have killed a live worktree's terminals. That is why the opt-out exists.
- Making `platform` required has no dedicated runtime test: it is a compile-time constraint, and `resolveRepoWorktreePathPlatform` already has its own unit test. Same for making `collapsePathEqualRows` required — but the hazard it closes was reproduced first (see limitations), and the existing teardown test keeps guarding the behavior.

Third pass (required `collapsePathEqualRows`):

```
npx vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts
# => 1185 passed, 1 skipped

npx vitest run --config config/vitest.config.ts \
  src/main/runtime/repo-worktree-row-resolution.test.ts \
  src/main/runtime/path-equal-worktree-row-collapse.test.ts \
  src/main/worktree-lineage-pruning.test.ts \
  src/main/ipc/worktree-path-deduplication.test.ts \
  src/main/ipc/worktrees-detected-scan-cache.test.ts
# => 5 files passed, 45 tests

npx oxlint src/main/runtime/orca-runtime.ts                                       # clean
npx oxlint --config config/oxlint-code-quality-native-plugins.json src/main/runtime/orca-runtime.ts --deny-warnings   # clean
npx oxfmt --check src/main/runtime/orca-runtime.ts                                # clean
```
- Restored, all pass.

Not run (per repo policy for parallel agents; CI covers them): `pnpm typecheck`, full `pnpm lint`, `pnpm build`. The new standalone module was type-checked in isolation with `tsc --ignoreConfig --strict --noUnusedLocals`, clean.

Test-fidelity note for reviewers: making the fake store in `repo-worktree-row-resolution.test.ts` implement `removeWorktreeLineage` unconditionally broke the pre-existing `reuses fleet owner counts without reloading repos per row` test, because `pruneLineageForMissingRepoWorktrees` genuinely calls `store.getRepos()` once per repo in production — that assertion had only been passing because the fake store made the pruner early-return. Rather than silently weaken it here, lineage support in the fake store is opt-in (a second `createDeps` argument), so the test keeps testing exactly what it tested before. The pruner's per-repo `getRepos()` call is pre-existing and out of scope for this PR.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

### Real-hardware verification (Windows 11 host `awin`, Git 2.55.0.windows.3 + WSL2 Ubuntu-24.04 Git 2.43.0)

Everything below was executed on the real Windows/WSL host, not simulated. Scratch repos and worktrees were created and then deleted.

**1. Does `git worktree list --porcelain` ever emit two spellings of one directory?**

Every supported `git worktree` subcommand canonicalizes the path *at write time*, so under normal use the answer is **no**:

```
$ git worktree add "C:\tmp\pr15872\wtA" -b a ; git worktree add "c:/TMP/pr15872/wtB" -b b
$ git worktree add "C:\tmp\pr15872\.\wtD" -b d ; git worktree add "C:\tmp\pr15872\\wtE" -b e
$ git worktree add ../wtF -b f
$ git worktree list --porcelain
worktree C:/tmp/pr15872/repo
worktree C:/tmp/pr15872/wtA
worktree C:/tmp/pr15872/wtB      <- 'c:/TMP/...' normalized to the real on-disk case
worktree C:/tmp/pr15872/wtD      <- '\.\' collapsed
worktree C:/tmp/pr15872/wtE      <- '\\' collapsed
worktree C:/tmp/pr15872/wtF      <- relative resolved
```

Also verified on the host, all canonicalizing:

- `git -C c:/TMP/pr15872/repo worktree list --porcelain` still prints `worktree C:/tmp/pr15872/repo` — a mis-cased `repo.path` cannot make Git emit a mis-cased **main** row.
- junction: `git worktree add "C:\tmp\pr15872\linkdir\wtJ"` (where `linkdir` is a `mklink /J` junction) stores `C:/tmp/pr15872/real/wtJ/.git` — reparse points are resolved.
- `git worktree repair "c:/TMP/pr15872/./wtA"` leaves `gitdir` = `C:/tmp/pr15872/wtA/.git`.
- `git worktree move <wt> "c:/TMP/pr15872/./wtMoved"` stores `C:/tmp/pr15872/wtMoved/.git`.
- 8.3 short names could not be tested: `dir /x C:\tmp\pr15872` shows no short names on this volume (8.3 creation disabled).

But **`git worktree list` echoes `.git/worktrees/<name>/gitdir` verbatim — it never re-canonicalizes at read time**, and a duplicate registration is not pruned:

```
$ cp -r .git/worktrees/wtA .git/worktrees/wtAdup
$ printf "c:/TMP/pr15872/./wtA/.git" > .git/worktrees/wtAdup/gitdir
$ git worktree list --porcelain | grep -i -A2 wta
worktree c:/TMP/pr15872/./wtA
HEAD 7981d78929af27998bcce1afeb4c829f9200fa9e
branch refs/heads/a
--
worktree C:/tmp/pr15872/wtA
HEAD 7981d78929af27998bcce1afeb4c829f9200fa9e
branch refs/heads/a
$ git worktree prune -n
(no output — Git considers both registrations valid)
```

So the honest verdict: **the duplicate-spelling input is reachable but not reachable through any supported `git worktree` command.** It requires two admin registrations naming one directory — a hand-edited, copied, restored-from-backup, or half-completed-`move` `.git/worktrees/` tree, or a registration written by a tool other than `git worktree add`. Once that state exists, Git will keep printing both rows forever and `git worktree prune` will not clean it up. The collapse is a repair for corrupted-registration state, not for anything Git emits on its own.

Running the PR's own `collapsePathEqualWorktreeRows` on that real Git output, on the real Windows host (Node v24.18.0, `tsx`, source dumped byte-identical from the PR head `c15982d`):

```
platform win32 | raw git rows: 8
  RAW   C:/tmp/pr15872/repo | refs/heads/master
  RAW   c:/TMP/pr15872/./wtB | refs/heads/b
  RAW   C:/tmp/pr15872/real/wtJ | refs/heads/j
  RAW   C:/tmp/pr15872/wtB | refs/heads/b
  ...
collapsed rows: 7   (the two wtB spellings merged; every other row and Git's order preserved)
```

**2. WSL case sensitivity — the fix repairs an observed bug in `main`, not a hypothetical one.**

`\\wsl$`/`\\wsl.localhost` front a case-sensitive filesystem, so two worktrees differing only by case are two real directories:

```
$ wsl.exe -d Ubuntu-24.04 --exec bash -c "cd ~/pr15872/repo; git worktree list --porcelain"
worktree /home/neil/pr15872/repo          branch refs/heads/master
worktree /home/neil/orca/workspaces/repo/WT   branch refs/heads/upper2
worktree /home/neil/orca/workspaces/repo/wt   branch refs/heads/lower2
```

`translateWslOutputPaths` was confirmed to round-trip these correctly and **case-preserving** through the running (pre-PR) Orca server on `awin`:

```
$ orca worktree show --environment awin --worktree 'path:\\wsl.localhost\Ubuntu-24.04\home\neil\orca\workspaces\repo\WT' --json
  path=\\wsl.localhost\Ubuntu-24.04\home\neil\orca\workspaces\repo\WT  branch=refs/heads/upper2
$ orca worktree show ... \repo\wt --json
  path=\\wsl.localhost\Ubuntu-24.04\home\neil\orca\workspaces\repo\wt  branch=refs/heads/lower2
```

Then, against a WSL-backed repo registered in the **shipped `main`-based** Orca server on `awin`:

```
$ orca worktree create --environment awin --repo id:<wsl repo> --name CaseB   -> path ...\repo\CaseB   (correct)
$ orca worktree create --environment awin --repo id:<wsl repo> --name caseb   -> path ...\repo\CaseB   (WRONG)
```

Git confirms `caseb` really was created as its own directory and branch:

```
worktree /home/neil/orca/workspaces/repo/CaseB   branch refs/heads/CaseB
worktree /home/neil/orca/workspaces/repo/caseb   branch refs/heads/caseb
```

…but `orca worktree list --repo id:<wsl repo>` returned only 3 rows (repo, `CaseB`, `CaseA`) — **`caseb` was missing entirely**, while `orca worktree show --worktree path:...\caseb` still found it. Cause: `findCreatedWorktree` (`src/main/ipc/created-worktree-reconciliation.ts`) uses `areWorktreePathsEqual`, and on `main` `\\wsl.localhost\...\CaseB` and `\\wsl.localhost\...\caseb` compare **equal**, so the newly created worktree reconciles onto the pre-existing row.

The PR's normalization, run on the real host over those exact real paths (`main` vs PR side by side):

```
node v24.18.0 platform win32
--- case-different WSL worktrees (REAL dirs, both exist)
    L=\\wsl.localhost\Ubuntu-24.04\home\neil\orca\workspaces\repo\CaseB
    R=\\wsl.localhost\Ubuntu-24.04\home\neil\orca\workspaces\repo\caseb
    main: equal=true   key(L)=windows:\\wsl.localhost\ubuntu-24.04\...\caseb
                       key(R)=windows:\\wsl.localhost\ubuntu-24.04\...\caseb
    PR  : equal=false  key(L)=windows:\\wsl.localhost\ubuntu-24.04\...\CaseB
                       key(R)=windows:\\wsl.localhost\ubuntu-24.04\...\caseb
--- dot-segment spelling            main: equal=true    PR: equal=true
--- forward-slash spelling          main: equal=true    PR: equal=true
--- distro-name case                main: equal=true    PR: equal=true
--- dedupeWorktreesByPath([CaseB, caseb])
    main rows kept: ...\CaseB
    PR   rows kept: ...\CaseB | ...\caseb
```

So the WSL branch is verified on hardware to (a) stop merging two genuinely distinct directories and (b) keep collapsing separator, dot-segment and distro-case spellings.

**3. Can a real host emit both `\\wsl$\` and `\\wsl.localhost\` for one worktree? — No.**

- No production code emits the `wsl$` alias for a worktree path: `toWindowsWslPath` (`src/shared/wsl-paths.ts`) always writes `\\wsl.localhost\<distro>\...`, and that is the only rewriter `translateWslOutputPaths` uses.
- The one remaining entry point, a user-registered repo path, is normalized at the door. On the real host:

  ```
  $ orca repo add --environment awin --path '\\wsl$\Ubuntu-24.04\home\neil\pr15872\repo' --json
    ok=True repoId=7bc52547-...  path='\\wsl.localhost\Ubuntu-24.04\home\neil\pr15872\repo'
  ```

  Same repo id, alias rewritten — Orca never stored the `wsl$` spelling.

The alias asymmetry noted under *Known limitations* is therefore an unreachable-in-practice gap on this host, not a live duplicate-row source, and it is unchanged from `main` (`main` also reports `equal=false` for the two aliases — see the run above).

**Not verified on hardware:** the collapse's effect on the live Orca UI/`worktree.detectedList` under a PR build (no PR build was installed on `awin`; the running server is a `main` build), the SSH/remote row path on a real remote host, and the PR's vitest suite on Windows or Linux (still macOS-only).

## Review

- **Cross-platform.** Path comparison is delegated to the existing `worktreePathComparisonKey`, which already routes Windows-looking paths to win32 rules regardless of the `platform` argument. Every new test passes `platform` explicitly rather than reading `process.platform`, so the win32 and linux cases are exercised on a macOS runner. No path separator is hardcoded; no keyboard/accelerator code touched. Case folding is decided by path syntax, not by the client platform: Windows drive/UNC roots fold, POSIX and WSL UNC roots do not (deliberate, documented above and pinned in tests).
- **SSH / remote.** This runs on the execution host that owns the scan, and it only merges rows *within* one repo's scan result — never across hosts, and it never treats loss of contact as evidence of anything. The new path-key matching never uses the desktop's platform for a remote repo: `platform` is required on `pruneLineageForMissingRepoWorktrees` and every call site derives it from the repo's execution host, so the macOS `/private/tmp` firmlink remap is never applied to SSH rows on any surface. The lineage pruner's host-ownership gate (`canMutateWorktree`) is untouched, and the pruner change only ever makes it *less* destructive.
- **Agent / integration compatibility — published content DOES change (Rule 3).** No RPC param, frame shape, or opcode moves, but the second commit deliberately changes *what the host publishes*: `worktree.list` and `worktree.detectedList` now emit **one row where a path-equal pair previously produced two**, and remote/web clients hydrate from `detectedList`. Per `docs/reference/remote-wire-compatibility.md` that is exactly Rule 3 — "changing what the host publishes breaks old clients with no wire change" — so it reaches old clients and needs an assessment, not a dismissal. Assessed **safe, not capability-gated**, for these reasons:
  - **Old client / new host.** The client gets the de-duplicated row it arguably should always have seen. Same frame, same `<repoId>::<path>` id namespace, one fewer element, and the survivor is strictly *more* complete than either input row (it adopts the branch and head the branchless duplicate lacked). Nothing an old client reads changes meaning, units, or nullability, and no field stops being populated.
  - **Ids do not move, which is what an old client actually holds.** The survivor's spelling is chosen repo path > spelling that already owns `worktreeMeta` > git's first row, so the id an old client persisted is the one that survives; the dropped spelling is by construction the one *without* stored metadata. Making the branch-bearing row win regardless (problem 2 above) is the variant that would have been a real skew hazard, and this PR removes it.
  - **No new-client-only interpretation exists.** This PR changes no renderer or client code at all, so an old client and a new client parse the collapsed list identically. Rule 2's negotiation exists for a projection only the new peer can read; there is nothing here for a capability bit to gate.
  - **New client / old host.** The old host keeps publishing both rows and no reader in this PR *requires* the collapse, so that pairing degrades to exactly today's duplicate-row behavior (the Rule 1 "keep the reader tolerant" condition holds trivially — no field was added).
  - **Absence stays host-adjudicated.** The one consumer that reads a missing row as "gone" and acts destructively — `teardownMissingManagedWorktreeTerminals` — judges against the raw uncollapsed scan, so the collapse can never become the reason a live directory's PTYs are killed, for old and new clients alike.
  - One residual consequence for clients that *do* reason about absence is disclosed under limitations below rather than hidden here.
  - Not covered by `tests/e2e/cross-version-wire/` — that harness is terminal-stream only, as its own doc states; this is the worktree catalog RPC, so the reasoning above is the coverage.
- **Everything else.** No Git subcommand or option added — the 2.25 baseline is untouched. No provider-specific code, so GitLab and GitHub are equally unaffected. Folder workspaces bypass this path entirely via the `isFolderRepo` early return; the pruner deliberately uses `splitWorktreeId` (not `...ForFilesystem`) so folder-workspace instance suffixes keep same-directory instances distinct. Worktree ids are now *more* stable than before this PR, not less.
- **Performance.** The collapse is a single O(n) pass with one `Map`, replacing an O(n log n) sort plus the old `dedupeWorktreesByPath` pass. The pruner adds one `Set` build and, only on an exact-id miss, one extra `worktreePathComparisonKey` call per stored lineage edge. Per-repo, n is the worktree count — negligible.
- **UI quality.** N/A — no renderer change.
- **Security.** No new dependency, no network, filesystem, or process access; the code is pure string normalization over paths already in memory. The one risky class of behavior here is *destructive writes*, and this change removes one rather than adding one.
- **Contributor diff scan.** I read every hunk of #15561 (2 files, +40/-1, both TypeScript under `src/main`) before carrying it. No network or exfiltration sinks, no shell/eval construction, no `process.env` or credential reads, no package/lockfile/postinstall changes, no dependency or binary swaps, no obfuscated or encoded payloads, no updater/signing/notarization changes, and no prompt-injection text in any file an agent would later read (the only added prose is one code comment and test titles). Test fixtures are synthetic paths with no filesystem access. Benign — the problems with it were correctness, not intent.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Known limitations / follow-ups

- **Reasoning about absence over the collapsed list is a live hazard, now a compile error.** `listDetectedWorktreesForResolvedRepo`'s `collapsePathEqualRows` originally *defaulted* to `true` while `pruneLineageForMissingRepoWorktrees`'s `platform` was required — an asymmetry that hid the sharper trap: a spelling the collapse drops still names a live directory, so any future caller that treats a missing row as "deleted" (an orphan reaper, a cleanup sweep, a stale-metadata GC) would have inherited the collapsed list and acted on it, with nothing in the type system objecting. Reproduced, not assumed: reverting the sweep's `listDetectedWorktreesForResolvedRepo(repo, true, false)` to `(repo)` compiled cleanly and made `keeps terminals for a path-equal spelling the detected-list collapse drops` fail with `stoppedWorktreeIds: ['repo-1::/tmp/./worktree-a']` — a live worktree's PTYs killed by a one-word omission. The parameter is therefore **required** now (third commit, +2/-2 in `orca-runtime.ts` plus the comment): the same mistake no longer compiles. Residual: a brand-new consumer of the raw scan still has to make the same judgement consciously — required-ness forces the decision, it cannot make it.
- **The collapse's input comes from corrupted registration state, not from anything Git emits on its own.** Measured on Windows Git 2.55.0.windows.3 and WSL Git 2.43.0: `worktree add`, `worktree repair` and `worktree move` all canonicalize the path they store (drive-letter case to the real on-disk case, backslashes to forward slashes, `.` and doubled separators collapsed, relative paths resolved, junctions dereferenced), and `git -C <mis-cased path> worktree list` still prints the canonical main row. `git worktree list` does, however, echo `.git/worktrees/<name>/gitdir` **verbatim** and `git worktree prune` will not remove a second registration naming an already-registered directory — so a hand-edited, copied, restored-from-backup, or interrupted-`move` admin tree produces two permanent rows for one directory. That is the state this collapses. Reproduced end-to-end on hardware; see *Real-hardware verification*.
- **The client-side purge still reads the collapsed list as truth.** On the first authoritative scan after upgrade, `getRemovedWorktreeIdsAfterAuthoritativeScan` → `buildWorktreePurgeState` drops local tab/pane state for ids absent from `detectedList`, so if a user had tabs bound to the *dropped* spelling they are cleared, while the host deliberately keeps those PTYs alive (previous bullet). Effect: a one-time, one-directional stranding of a PTY the UI no longer shows a tab for — the same path any genuinely deleted worktree takes, and narrow in practice because the collapse preserves the spelling that owns `worktreeMeta`. Not fixed here: reuniting a purged tab with a surviving path-equal spelling is a client-side change, and this PR is main-process only.
- **`\\wsl$\<distro>` and `\\wsl.localhost\<distro>` remain distinct comparison keys.** They are two Windows aliases for the *same* directory, but `normalizeWindowsWorktreePathForComparison` folds only each alias's own case, not one alias into the other, so a repo whose git reports one worktree under each alias still shows two rows. A test pins this deliberately (`keeps case-different WSL UNC worktrees on %s while folding alias and distro case` asserts `wsl-upper`, `wsl-lower`, `wsl-localhost` all survive). Rationale: mapping the aliases together means deciding which one is canonical and rewriting user-visible paths into it, which is a bigger behavioral change than de-duplicating spellings of one string — and getting it wrong drops a real worktree row. Follow-up, not a regression: the two aliases were already distinct before this PR. **Checked on real hardware** (Windows 11 + WSL2, host `awin`): nothing in the product emits the `wsl$` alias for a worktree row — `toWindowsWslPath` only writes `\\wsl.localhost\<distro>\...` — and `orca repo add --path '\\wsl$\Ubuntu-24.04\...'` came back with the same repo id and the path rewritten to `\\wsl.localhost\...`. The gap is unreachable there, not merely unfixed.
- `buildDetectedGitWorktrees` (`src/main/ipc/worktrees.ts`, the `worktrees:listAll` IPC path) still uses the older `dedupeWorktreesByPath`, which **drops** the peer row instead of merging it, so it can still surface the branchless spelling with no branch. Reconciling those two dedupe semantics is a larger change than this PR should carry; the two RPC surfaces this PR does touch (`worktree.list`, `worktree.detectedList`) now agree.

## Notes

Not claimed fixed: the "3 masters in the sidebar" symptom in #15526. That path (`worktrees:listAll` -> `buildDetectedGitWorktrees`) already calls `dedupeWorktreesByPath`, which means those rows are probably not path-equal at all; the second comment on that issue attributes them to `displayName` falling back to the branch name. That belongs in a separate PR.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)




