### PR TITLE
fix(pty): wrap codex without expanding or destroying a user alias

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -406,6 +406,8 @@ jobs:
             src/main/daemon/node-pty-fd-leak.test.ts \
             src/main/providers/local-pty-shell-ready-zsh-launch-environment.test.ts \
             src/main/providers/__tests__/shell-ready-framework-example.test.ts \
+            src/main/pty/codex-shell-launch-preflight.test.ts \
+            src/main/pty/omp-shell-wrapper-alias-safety.test.ts \
             src/main/pty/omp-shell-wrapper.node-pty.test.ts \
             src/main/shell-startup-feature-channel.test.ts \
             src/main/terminal-history-fish-session.node-pty.test.ts \

--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-bash-rcfile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-bash-rcfile.txt
@@ -59,7 +59,9 @@ __orca_omp() {
   fi
 }
 if [[ -n "${ORCA_OMP_STATUS_EXTENSION:-}" ]]; then
-  omp() { __orca_omp "$@"; }
+  # Why the function reserved word: it suppresses alias expansion of the name, which
+  # an `alias omp` otherwise rewrites at parse time, aborting the rest of the file.
+  function omp { __orca_omp "$@"; }
 fi
 
 # Why: Codex must keep using Orca's runtime CODEX_HOME after profile scripts.

--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-bash-rcfile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-bash-rcfile.txt
@@ -67,7 +67,8 @@ fi
 # Why: a typed alias expands inside the shell, after pane launch prep.
 # Why unalias inside the substitution: an alias named codex makes command -v
 # report the alias text, and the subshell leaves the user's own alias intact.
-# Why the trailing || : — zsh, unlike bash, inherits errexit into substitutions.
+# Why || : twice — zsh alone aborts inside the substitution, but every shell's
+# assignment adopts its exit status, so an absent codex trips set -e in bash too.
 __orca_codex_binary="$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)"
 if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" ]]; then
   # Why the function reserved word: it suppresses alias expansion of the name,

--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-bash-rcfile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-bash-rcfile.txt
@@ -65,9 +65,14 @@ fi
 # Why: Codex must keep using Orca's runtime CODEX_HOME after profile scripts.
 [[ -n "${ORCA_CODEX_HOME:-}" ]] && export CODEX_HOME="${ORCA_CODEX_HOME}"
 # Why: a typed alias expands inside the shell, after pane launch prep.
-__orca_codex_binary="$(command -v codex 2>/dev/null || :)"
+# Why unalias inside the substitution: an alias named codex makes command -v
+# report the alias text, and the subshell leaves the user's own alias intact.
+# Why the trailing || : — zsh, unlike bash, inherits errexit into substitutions.
+__orca_codex_binary="$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)"
 if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" ]]; then
-  codex() {
+  # Why the function reserved word: it suppresses alias expansion of the name,
+  # which otherwise rewrites this header at parse time and aborts the whole file.
+  function codex {
     "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
     command codex "$@"
   }

--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zshenv.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zshenv.txt
@@ -105,7 +105,8 @@ __orca_deferred_init() {
     # Why: a typed alias expands inside the shell, after pane launch prep.
     # Why unalias inside the substitution: an alias named codex makes command -v
     # report the alias text, and the subshell leaves the user's own alias intact.
-    # Why the trailing || : — zsh, unlike bash, inherits errexit into substitutions.
+    # Why || : twice — zsh alone aborts inside the substitution, but every shell's
+    # assignment adopts its exit status, so an absent codex trips set -e in bash too.
     __orca_codex_binary="$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)"
     if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" ]]; then
       # Why the function reserved word: it suppresses alias expansion of the name,

--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zshenv.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zshenv.txt
@@ -97,7 +97,9 @@ __orca_deferred_init() {
       fi
     }
     if [[ -n "${ORCA_OMP_STATUS_EXTENSION:-}" ]]; then
-      omp() { __orca_omp "$@"; }
+      # Why the function reserved word: it suppresses alias expansion of the name, which
+      # an `alias omp` otherwise rewrites at parse time, aborting the rest of the file.
+      function omp { __orca_omp "$@"; }
     fi
 
     # Why: Codex must keep using Orca's runtime CODEX_HOME after rc files.

--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zshenv.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zshenv.txt
@@ -103,9 +103,14 @@ __orca_deferred_init() {
     # Why: Codex must keep using Orca's runtime CODEX_HOME after rc files.
     [[ -n "${ORCA_CODEX_HOME:-}" ]] && export CODEX_HOME="${ORCA_CODEX_HOME}"
     # Why: a typed alias expands inside the shell, after pane launch prep.
-    __orca_codex_binary="$(command -v codex 2>/dev/null || :)"
+    # Why unalias inside the substitution: an alias named codex makes command -v
+    # report the alias text, and the subshell leaves the user's own alias intact.
+    # Why the trailing || : — zsh, unlike bash, inherits errexit into substitutions.
+    __orca_codex_binary="$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)"
     if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" ]]; then
-      codex() {
+      # Why the function reserved word: it suppresses alias expansion of the name,
+      # which otherwise rewrites this header at parse time and aborts the whole file.
+      function codex {
         "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
         command codex "$@"
       }

--- a/src/main/__fixtures__/shell-wrapper-snapshots/local-bash-rcfile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/local-bash-rcfile.txt
@@ -68,9 +68,14 @@ fi
 # Why: Codex must keep using Orca's runtime CODEX_HOME after profile scripts.
 [[ -n "${ORCA_CODEX_HOME:-}" ]] && export CODEX_HOME="${ORCA_CODEX_HOME}"
 # Why: a typed alias expands inside the shell, after pane launch prep.
-__orca_codex_binary="$(command -v codex 2>/dev/null || :)"
+# Why unalias inside the substitution: an alias named codex makes command -v
+# report the alias text, and the subshell leaves the user's own alias intact.
+# Why the trailing || : — zsh, unlike bash, inherits errexit into substitutions.
+__orca_codex_binary="$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)"
 if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" ]]; then
-  codex() {
+  # Why the function reserved word: it suppresses alias expansion of the name,
+  # which otherwise rewrites this header at parse time and aborts the whole file.
+  function codex {
     "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
     command codex "$@"
   }

--- a/src/main/__fixtures__/shell-wrapper-snapshots/local-bash-rcfile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/local-bash-rcfile.txt
@@ -70,7 +70,8 @@ fi
 # Why: a typed alias expands inside the shell, after pane launch prep.
 # Why unalias inside the substitution: an alias named codex makes command -v
 # report the alias text, and the subshell leaves the user's own alias intact.
-# Why the trailing || : — zsh, unlike bash, inherits errexit into substitutions.
+# Why || : twice — zsh alone aborts inside the substitution, but every shell's
+# assignment adopts its exit status, so an absent codex trips set -e in bash too.
 __orca_codex_binary="$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)"
 if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" ]]; then
   # Why the function reserved word: it suppresses alias expansion of the name,

--- a/src/main/__fixtures__/shell-wrapper-snapshots/local-bash-rcfile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/local-bash-rcfile.txt
@@ -62,7 +62,9 @@ __orca_omp() {
   fi
 }
 if [[ -n "${ORCA_OMP_STATUS_EXTENSION:-}" ]]; then
-  omp() { __orca_omp "$@"; }
+  # Why the function reserved word: it suppresses alias expansion of the name, which
+  # an `alias omp` otherwise rewrites at parse time, aborting the rest of the file.
+  function omp { __orca_omp "$@"; }
 fi
 
 # Why: Codex must keep using Orca's runtime CODEX_HOME after profile scripts.

--- a/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zshenv.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zshenv.txt
@@ -105,7 +105,8 @@ __orca_deferred_init() {
     # Why: a typed alias expands inside the shell, after pane launch prep.
     # Why unalias inside the substitution: an alias named codex makes command -v
     # report the alias text, and the subshell leaves the user's own alias intact.
-    # Why the trailing || : — zsh, unlike bash, inherits errexit into substitutions.
+    # Why || : twice — zsh alone aborts inside the substitution, but every shell's
+    # assignment adopts its exit status, so an absent codex trips set -e in bash too.
     __orca_codex_binary="$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)"
     if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" ]]; then
       # Why the function reserved word: it suppresses alias expansion of the name,

--- a/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zshenv.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zshenv.txt
@@ -97,7 +97,9 @@ __orca_deferred_init() {
       fi
     }
     if [[ -n "${ORCA_OMP_STATUS_EXTENSION:-}" ]]; then
-      omp() { __orca_omp "$@"; }
+      # Why the function reserved word: it suppresses alias expansion of the name, which
+      # an `alias omp` otherwise rewrites at parse time, aborting the rest of the file.
+      function omp { __orca_omp "$@"; }
     fi
 
     # Why: Codex must keep using Orca's runtime CODEX_HOME after rc files.

--- a/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zshenv.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zshenv.txt
@@ -103,9 +103,14 @@ __orca_deferred_init() {
     # Why: Codex must keep using Orca's runtime CODEX_HOME after rc files.
     [[ -n "${ORCA_CODEX_HOME:-}" ]] && export CODEX_HOME="${ORCA_CODEX_HOME}"
     # Why: a typed alias expands inside the shell, after pane launch prep.
-    __orca_codex_binary="$(command -v codex 2>/dev/null || :)"
+    # Why unalias inside the substitution: an alias named codex makes command -v
+    # report the alias text, and the subshell leaves the user's own alias intact.
+    # Why the trailing || : — zsh, unlike bash, inherits errexit into substitutions.
+    __orca_codex_binary="$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)"
     if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" ]]; then
-      codex() {
+      # Why the function reserved word: it suppresses alias expansion of the name,
+      # which otherwise rewrites this header at parse time and aborts the whole file.
+      function codex {
         "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
         command codex "$@"
       }

--- a/src/main/__fixtures__/shell-wrapper-snapshots/relay-bash-rcfile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/relay-bash-rcfile.txt
@@ -51,7 +51,9 @@ __orca_omp() {
   fi
 }
 if [[ -n "${ORCA_OMP_STATUS_EXTENSION:-}" ]]; then
-  omp() { __orca_omp "$@"; }
+  # Why the function reserved word: it suppresses alias expansion of the name, which
+  # an `alias omp` otherwise rewrites at parse time, aborting the rest of the file.
+  function omp { __orca_omp "$@"; }
 fi
 
 if [[ -n "${ORCA_HISTFILE:-}" ]]; then

--- a/src/main/__fixtures__/shell-wrapper-snapshots/relay-zsh-zshenv.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/relay-zsh-zshenv.txt
@@ -71,7 +71,9 @@ __orca_deferred_init() {
       fi
     }
     if [[ -n "${ORCA_OMP_STATUS_EXTENSION:-}" ]]; then
-      omp() { __orca_omp "$@"; }
+      # Why the function reserved word: it suppresses alias expansion of the name, which
+      # an `alias omp` otherwise rewrites at parse time, aborting the rest of the file.
+      function omp { __orca_omp "$@"; }
     fi
   fi
   if [[ -n "${_orca_histfile:-}" ]]; then

--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -390,7 +390,7 @@ describe('resolveWindowsShellLaunchArgs', () => {
     const zshEnv = readFileSync(join(getShellReadyWrapperRoot(), 'zsh', '.zshenv'), 'utf8')
     for (const wrapperFile of [bashRcfile, zshEnv]) {
       expect(wrapperFile).toContain('command omp --extension "${ORCA_OMP_STATUS_EXTENSION}" "$@"')
-      expect(wrapperFile).toContain('omp() { __orca_omp "$@"; }')
+      expect(wrapperFile).toContain('function omp { __orca_omp "$@"; }')
       expect(wrapperFile).not.toContain('prime-agent()')
       expect(wrapperFile).not.toContain('__orca_prime_agent')
       expect(wrapperFile).not.toContain('ORCA_PRIME_AGENT_STATUS_EXTENSION')

--- a/src/main/pty/codex-preflight-profile-path-rewrite.test.ts
+++ b/src/main/pty/codex-preflight-profile-path-rewrite.test.ts
@@ -1,5 +1,13 @@
 import { execFileSync } from 'node:child_process'
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { delimiter, join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -21,6 +29,7 @@ type Fixture = {
   intendedMarker: string
   hijackMarker: string
   codexMarker: string
+  postSnippetMarker: string
   homePath: string
 }
 
@@ -30,7 +39,7 @@ function writeStub(path: string, markerPath: string): void {
   chmodSync(path, 0o755)
 }
 
-function buildFixture(): Fixture {
+function buildFixture(options: { aliasCodex?: boolean } = {}): Fixture {
   const root = mkdtempSync(join(tmpdir(), 'orca-codex-profile-path-'))
   roots.push(root)
   const resourcesPath = join(root, 'resources')
@@ -40,6 +49,7 @@ function buildFixture(): Fixture {
   const intendedMarker = join(root, 'intended-ran')
   const hijackMarker = join(root, 'hijack-ran')
   const codexMarker = join(root, 'codex-ran')
+  const postSnippetMarker = join(root, 'rcfile-continued')
   mkdirSync(hijackDir, { recursive: true })
   mkdirSync(codexDir, { recursive: true })
   mkdirSync(homePath, { recursive: true })
@@ -54,17 +64,33 @@ function buildFixture(): Fixture {
 
   // Why: /etc/profile runs first and macOS path_helper rebuilds PATH from /etc/paths,
   // so the profile must re-prepend both dirs to model a real user's dotfile winning.
+  const aliasLine = options.aliasCodex
+    ? `alias codex='GIT_AUTHOR_NAME=Codex codex --alias-flag'\n`
+    : ''
   writeFileSync(
     join(homePath, '.bash_profile'),
-    `export PATH=${JSON.stringify(codexDir)}:"$PATH"\nexport PATH=${JSON.stringify(hijackDir)}:"$PATH"\n`
+    `export PATH=${JSON.stringify(codexDir)}:"$PATH"\nexport PATH=${JSON.stringify(hijackDir)}:"$PATH"\n${aliasLine}`
   )
-  return { root, resourcesPath, intendedMarker, hijackMarker, codexMarker, homePath }
+  return {
+    root,
+    resourcesPath,
+    intendedMarker,
+    hijackMarker,
+    codexMarker,
+    postSnippetMarker,
+    homePath
+  }
 }
 
 function launchCodexThroughRcfile(fixture: Fixture, preflightValue: string): void {
   const rcfilePath = join(fixture.root, 'rcfile')
   writeFileSync(rcfilePath, getDaemonBashShellReadyRcfileContent(), 'utf8')
-  execFileSync('/bin/bash', ['--rcfile', rcfilePath, '-i', '-c', 'codex --version'], {
+  // Why the second command: the rcfile defines __orca_osc133_preexec *below* the
+  // codex wrapper, so its presence proves bash parsed past the snippet.
+  // Why the trailing `:` — the markers are this file's oracle, so a failed probe
+  // must surface as a missing marker, not an opaque non-zero exit from bash.
+  const command = `codex --version; declare -F __orca_osc133_preexec >/dev/null && printf ran > ${JSON.stringify(fixture.postSnippetMarker)}; :`
+  execFileSync('/bin/bash', ['--rcfile', rcfilePath, '-i', '-c', command], {
     stdio: 'ignore',
     env: {
       HOME: fixture.homePath,
@@ -112,6 +138,28 @@ describe.skipIf(!bashAvailable)('Codex preflight under a profile-rewritten PATH'
     expect(existsSync(fixture.hijackMarker)).toBe(false)
     // Guard against a vacuous pass: the wrapper must still have reached `command codex`.
     expect(existsSync(fixture.codexMarker)).toBe(true)
+  })
+
+  // Why: a user alias named codex used to expand into the wrapper's own `codex()`
+  // header, and bash abandons the rest of the rcfile at that syntax error — taking
+  // the OSC 133 hooks and the shell-ready marker defined below it with it.
+  it('finishes the rcfile and preserves the alias when the user aliased the name codex', () => {
+    const fixture = buildFixture({ aliasCodex: true })
+    const preflightCommand = resolveCodexShellLaunchPreflightCommand({
+      hooksEnabled: true,
+      isPackaged: true,
+      managedHomePath: join(fixture.root, 'codex-home'),
+      userDataPath: join(fixture.root, 'user-data'),
+      resourcesPath: fixture.resourcesPath
+    })
+
+    launchCodexThroughRcfile(fixture, preflightCommand as string)
+
+    expect(existsSync(fixture.postSnippetMarker)).toBe(true)
+    expect(existsSync(fixture.intendedMarker)).toBe(true)
+    expect(existsSync(fixture.hijackMarker)).toBe(false)
+    // The user's own alias must survive and still reach the binary.
+    expect(readFileSync(fixture.codexMarker, 'utf-8').trim()).toBe('--alias-flag --version')
   })
 
   // Why: pins the defect itself, so a regression back to an unqualified name fails here.

--- a/src/main/pty/codex-shell-launch-preflight.test.ts
+++ b/src/main/pty/codex-shell-launch-preflight.test.ts
@@ -92,6 +92,59 @@ describe.skipIf(process.platform === 'win32')('Codex shell launch preflight', ()
     expect(runAliasLaunch(root, getPosixCodexShellLaunchPreflight(), '/bin/zsh')).toBe('normal')
   })
 
+  it.each([
+    ['/bin/zsh', 'setopt aliases ALIAS_FUNC_DEF'],
+    ['/bin/bash', 'shopt -s expand_aliases']
+  ])(
+    'parses in %s when the user already aliased the name codex',
+    (shell, enableAliases) => {
+      if (!existsSync(shell)) {
+        return
+      }
+      const root = mkdtempSync(join(tmpdir(), 'orca-codex-named-alias-'))
+      roots.push(root)
+      const bin = join(root, 'bin')
+      mkdirSync(bin)
+      writeExecutable(join(bin, 'codex'), '#!/bin/sh\nprintf launched\\n')
+      writeExecutable(
+        join(bin, 'orca-test'),
+        '#!/bin/sh\n[ "$1 $2 $3" = "agent hooks prepare-codex" ] || exit 2\n'
+      )
+      // Why a sourced file nested in `if true`: zsh parses a compound command
+      // before running it, so `codex()` inside Orca's non-login zshrc gate
+      // expands a user alias even if `unalias` appears earlier in that `if`.
+      const startup = join(root, 'startup.sh')
+      writeFileSync(
+        startup,
+        [
+          enableAliases,
+          "alias codex='GIT_AUTHOR_NAME=Codex GIT_AUTHOR_EMAIL=codex@openai.com GIT_COMMITTER_NAME=Codex GIT_COMMITTER_EMAIL=codex@openai.com codex --dangerously-bypass-approvals-and-sandbox'",
+          'if true; then',
+          getPosixCodexShellLaunchPreflight(),
+          'fi',
+          'printf parsed\\n',
+          'codex'
+        ].join('\n')
+      )
+
+      const result = spawnSync(
+        shell,
+        shell.endsWith('/zsh') ? ['-f', startup] : ['--noprofile', '--norc', startup],
+        {
+          encoding: 'utf-8',
+          env: {
+            ...process.env,
+            PATH: `${bin}${delimiter}${process.env.PATH ?? ''}`,
+            ORCA_CODEX_LAUNCH_PREFLIGHT: join(bin, 'orca-test')
+          }
+        }
+      )
+
+      expect(result.status, result.stderr).toBe(0)
+      expect(result.stdout).toBe('parsed\nlaunched\n')
+    }
+  )
+
   it('still launches Codex when the best-effort preflight fails', () => {
     const root = mkdtempSync(join(tmpdir(), 'orca-codex-preflight-failure-'))
     roots.push(root)

--- a/src/main/pty/codex-shell-launch-preflight.test.ts
+++ b/src/main/pty/codex-shell-launch-preflight.test.ts
@@ -170,31 +170,35 @@ describe.skipIf(process.platform === 'win32')('Codex shell launch preflight', ()
     )
   })
 
-  it.each([
+  // Why a loop over it.each: an early `return` reported green on hosts without the
+  // shell, so the zsh half silently never ran on Linux. skipIf reports it as a skip.
+  for (const [shell, strict] of [
     ['/bin/bash', 'set -e'],
     ['/bin/zsh', 'setopt ERR_EXIT']
-  ])('keeps %s startup alive under strict error handling when Codex is absent', (shell, strict) => {
-    if (!existsSync(shell)) {
-      return
-    }
-    const root = mkdtempSync(join(tmpdir(), 'orca-codex-strict-startup-'))
-    roots.push(root)
+  ]) {
+    it.skipIf(!existsSync(shell))(
+      `keeps ${shell} startup alive under strict error handling when Codex is absent`,
+      () => {
+        const root = mkdtempSync(join(tmpdir(), 'orca-codex-strict-startup-'))
+        roots.push(root)
 
-    const output = execFileSync(
-      shell,
-      [
-        shell.endsWith('/zsh') ? '-f' : '--noprofile',
-        '-c',
-        `${strict}\n${getPosixCodexShellLaunchPreflight()}\nprintf alive`
-      ],
-      {
-        encoding: 'utf-8',
-        env: { ...process.env, PATH: root, ORCA_CODEX_LAUNCH_PREFLIGHT: 'orca-test' }
+        const output = execFileSync(
+          shell,
+          [
+            shell.endsWith('/zsh') ? '-f' : '--noprofile',
+            '-c',
+            `${strict}\n${getPosixCodexShellLaunchPreflight()}\nprintf alive`
+          ],
+          {
+            encoding: 'utf-8',
+            env: { ...process.env, PATH: root, ORCA_CODEX_LAUNCH_PREFLIGHT: 'orca-test' }
+          }
+        )
+
+        expect(output).toBe('alive')
       }
     )
-
-    expect(output).toBe('alive')
-  })
+  }
 
   it.skipIf(!fishAvailable)('preserves a user-defined fish function', () => {
     const output = execFileSync(

--- a/src/main/pty/codex-shell-launch-preflight.test.ts
+++ b/src/main/pty/codex-shell-launch-preflight.test.ts
@@ -1,4 +1,12 @@
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { delimiter, isAbsolute, join } from 'node:path'
 import { execFileSync, spawnSync } from 'node:child_process'
@@ -11,6 +19,8 @@ import {
 } from './codex-shell-launch-preflight'
 
 const roots: string[] = []
+const zshAvailable = existsSync('/bin/zsh')
+const bashAvailable = existsSync('/bin/bash')
 const fishAvailable = spawnSync('fish', ['--version']).status === 0
 const pwshAvailable =
   spawnSync('pwsh', ['-NoLogo', '-NoProfile', '-Command', 'exit 0']).status === 0
@@ -69,6 +79,57 @@ function runAliasLaunch(
   ).trim()
 }
 
+/** Launches a startup file that aliases the very name Orca wraps, then asserts the
+ *  wrapper installed, the preflight ran, and the user's alias still applies. */
+function expectNamedAliasSurvives(shell: string, enableAliases: string): void {
+  const root = mkdtempSync(join(tmpdir(), 'orca-codex-named-alias-'))
+  roots.push(root)
+  const bin = join(root, 'bin')
+  mkdirSync(bin)
+  const preflightMarker = join(root, 'preflight-ran')
+  writeExecutable(
+    join(bin, 'codex'),
+    '#!/bin/sh\nprintf "launched args=[%s] author=[%s]\\n" "$*" "$GIT_AUTHOR_NAME"\n'
+  )
+  writeExecutable(
+    join(bin, 'orca-test'),
+    `#!/bin/sh\nprintf '%s' "$*" > ${JSON.stringify(preflightMarker)}\n`
+  )
+  // Why nested in `if true`: the shell parses a whole compound command before
+  // running any of it, so the alias expands into the wrapper's own header.
+  const startup = join(root, 'startup.sh')
+  writeFileSync(
+    startup,
+    [
+      enableAliases,
+      "alias codex='GIT_AUTHOR_NAME=Codex codex --alias-flag'",
+      'if true; then',
+      getPosixCodexShellLaunchPreflight(),
+      'fi',
+      'printf "parsed\\n"',
+      'codex'
+    ].join('\n')
+  )
+
+  const result = spawnSync(
+    shell,
+    shell.endsWith('/zsh') ? ['-f', startup] : ['--noprofile', '--norc', startup],
+    {
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        PATH: `${bin}${delimiter}${process.env.PATH ?? ''}`,
+        ORCA_CODEX_LAUNCH_PREFLIGHT: join(bin, 'orca-test')
+      }
+    }
+  )
+
+  expect(result.status, result.stderr).toBe(0)
+  // The alias's own flags and env prefix must still reach the binary.
+  expect(result.stdout).toBe('parsed\nlaunched args=[--alias-flag] author=[Codex]\n')
+  expect(readFileSync(preflightMarker, 'utf-8')).toBe('agent hooks prepare-codex')
+}
+
 afterEach(() => {
   for (const root of roots.splice(0)) {
     rmSync(root, { recursive: true, force: true })
@@ -92,58 +153,13 @@ describe.skipIf(process.platform === 'win32')('Codex shell launch preflight', ()
     expect(runAliasLaunch(root, getPosixCodexShellLaunchPreflight(), '/bin/zsh')).toBe('normal')
   })
 
-  it.each([
-    ['/bin/zsh', 'setopt aliases ALIAS_FUNC_DEF'],
-    ['/bin/bash', 'shopt -s expand_aliases']
-  ])(
-    'parses in %s when the user already aliased the name codex',
-    (shell, enableAliases) => {
-      if (!existsSync(shell)) {
-        return
-      }
-      const root = mkdtempSync(join(tmpdir(), 'orca-codex-named-alias-'))
-      roots.push(root)
-      const bin = join(root, 'bin')
-      mkdirSync(bin)
-      writeExecutable(join(bin, 'codex'), '#!/bin/sh\nprintf launched\\n')
-      writeExecutable(
-        join(bin, 'orca-test'),
-        '#!/bin/sh\n[ "$1 $2 $3" = "agent hooks prepare-codex" ] || exit 2\n'
-      )
-      // Why a sourced file nested in `if true`: zsh parses a compound command
-      // before running it, so `codex()` inside Orca's non-login zshrc gate
-      // expands a user alias even if `unalias` appears earlier in that `if`.
-      const startup = join(root, 'startup.sh')
-      writeFileSync(
-        startup,
-        [
-          enableAliases,
-          "alias codex='GIT_AUTHOR_NAME=Codex GIT_AUTHOR_EMAIL=codex@openai.com GIT_COMMITTER_NAME=Codex GIT_COMMITTER_EMAIL=codex@openai.com codex --dangerously-bypass-approvals-and-sandbox'",
-          'if true; then',
-          getPosixCodexShellLaunchPreflight(),
-          'fi',
-          'printf parsed\\n',
-          'codex'
-        ].join('\n')
-      )
+  it.skipIf(!zshAvailable)('keeps a user alias named codex working in zsh', () => {
+    expectNamedAliasSurvives('/bin/zsh', 'setopt aliases')
+  })
 
-      const result = spawnSync(
-        shell,
-        shell.endsWith('/zsh') ? ['-f', startup] : ['--noprofile', '--norc', startup],
-        {
-          encoding: 'utf-8',
-          env: {
-            ...process.env,
-            PATH: `${bin}${delimiter}${process.env.PATH ?? ''}`,
-            ORCA_CODEX_LAUNCH_PREFLIGHT: join(bin, 'orca-test')
-          }
-        }
-      )
-
-      expect(result.status, result.stderr).toBe(0)
-      expect(result.stdout).toBe('parsed\nlaunched\n')
-    }
-  )
+  it.skipIf(!bashAvailable)('keeps a user alias named codex working in bash', () => {
+    expectNamedAliasSurvives('/bin/bash', 'shopt -s expand_aliases')
+  })
 
   it('still launches Codex when the best-effort preflight fails', () => {
     const root = mkdtempSync(join(tmpdir(), 'orca-codex-preflight-failure-'))

--- a/src/main/pty/codex-shell-launch-preflight.ts
+++ b/src/main/pty/codex-shell-launch-preflight.ts
@@ -60,12 +60,17 @@ function isExecutableFileOnDisk(path: string, platform: NodeJS.Platform): boolea
 
 export function getPosixCodexShellLaunchPreflight(): string {
   return `# Why: a typed alias expands inside the shell, after pane launch prep.
+# Why: unalias, then eval the function definition, so a user alias named
+# codex cannot expand into the function header at parse time (interactive
+# zsh ALIAS_FUNC_DEF, bash expand_aliases), even when this block sits
+# inside another compound command such as zshrc's non-login gate.
+unalias codex 2>/dev/null || true
 __orca_codex_binary="$(command -v codex 2>/dev/null || :)"
 if [[ -n "\${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "\${__orca_codex_binary:-}" && -x "\${__orca_codex_binary}" ]]; then
-  codex() {
+  eval 'codex() {
     "\${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
     command codex "$@"
-  }
+  }'
 fi
 unset __orca_codex_binary
 `

--- a/src/main/pty/codex-shell-launch-preflight.ts
+++ b/src/main/pty/codex-shell-launch-preflight.ts
@@ -60,17 +60,17 @@ function isExecutableFileOnDisk(path: string, platform: NodeJS.Platform): boolea
 
 export function getPosixCodexShellLaunchPreflight(): string {
   return `# Why: a typed alias expands inside the shell, after pane launch prep.
-# Why: unalias, then eval the function definition, so a user alias named
-# codex cannot expand into the function header at parse time (interactive
-# zsh ALIAS_FUNC_DEF, bash expand_aliases), even when this block sits
-# inside another compound command such as zshrc's non-login gate.
-unalias codex 2>/dev/null || true
-__orca_codex_binary="$(command -v codex 2>/dev/null || :)"
+# Why unalias inside the substitution: an alias named codex makes command -v
+# report the alias text, and the subshell leaves the user's own alias intact.
+# Why the trailing || : — zsh, unlike bash, inherits errexit into substitutions.
+__orca_codex_binary="$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)"
 if [[ -n "\${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "\${__orca_codex_binary:-}" && -x "\${__orca_codex_binary}" ]]; then
-  eval 'codex() {
+  # Why the function reserved word: it suppresses alias expansion of the name,
+  # which otherwise rewrites this header at parse time and aborts the whole file.
+  function codex {
     "\${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
     command codex "$@"
-  }'
+  }
 fi
 unset __orca_codex_binary
 `

--- a/src/main/pty/codex-shell-launch-preflight.ts
+++ b/src/main/pty/codex-shell-launch-preflight.ts
@@ -62,7 +62,8 @@ export function getPosixCodexShellLaunchPreflight(): string {
   return `# Why: a typed alias expands inside the shell, after pane launch prep.
 # Why unalias inside the substitution: an alias named codex makes command -v
 # report the alias text, and the subshell leaves the user's own alias intact.
-# Why the trailing || : — zsh, unlike bash, inherits errexit into substitutions.
+# Why || : twice — zsh alone aborts inside the substitution, but every shell's
+# assignment adopts its exit status, so an absent codex trips set -e in bash too.
 __orca_codex_binary="$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)"
 if [[ -n "\${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "\${__orca_codex_binary:-}" && -x "\${__orca_codex_binary}" ]]; then
   # Why the function reserved word: it suppresses alias expansion of the name,

--- a/src/main/pty/omp-shell-wrapper-alias-safety.test.ts
+++ b/src/main/pty/omp-shell-wrapper-alias-safety.test.ts
@@ -1,0 +1,70 @@
+import { spawnSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { getPosixOmpShellWrapper } from './omp-shell-wrapper'
+
+const roots: string[] = []
+const zshAvailable = existsSync('/bin/zsh')
+const bashAvailable = existsSync('/bin/bash')
+
+/** Sources the omp wrapper from a startup file that already aliased `omp`, then
+ *  asserts the file parsed to its end and the alias still reaches the binary. */
+function expectAliasedOmpNameSurvives(shell: string, enableAliases: string): void {
+  const root = mkdtempSync(join(tmpdir(), 'orca-omp-alias-'))
+  roots.push(root)
+  const bin = join(root, 'bin')
+  mkdirSync(bin)
+  writeFileSync(join(bin, 'omp'), '#!/bin/sh\nprintf "omp args=[%s]\\n" "$*"\n', { mode: 0o755 })
+  const extension = join(root, 'status-extension')
+  writeFileSync(extension, '')
+
+  const startup = join(root, 'startup.sh')
+  writeFileSync(
+    startup,
+    [
+      enableAliases,
+      "alias omp='omp config --alias-flag'",
+      getPosixOmpShellWrapper(),
+      'printf "parsed\\n"',
+      'omp'
+    ].join('\n')
+  )
+
+  const result = spawnSync(
+    shell,
+    shell.endsWith('/zsh') ? ['-f', startup] : ['--noprofile', '--norc', startup],
+    {
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        PATH: `${bin}${delimiter}${process.env.PATH ?? ''}`,
+        ORCA_OMP_STATUS_EXTENSION: extension
+      }
+    }
+  )
+
+  expect(result.status, result.stderr).toBe(0)
+  // `parsed` proves the shell got past the wrapper instead of abandoning the file.
+  expect(result.stdout).toBe('parsed\nomp args=[config --alias-flag]\n')
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+// Why: a user alias named omp used to expand into the wrapper's own `omp()`
+// header, and the shell abandons the rest of the startup file at that syntax
+// error — taking every hook Orca defines below the wrapper with it.
+describe.skipIf(process.platform === 'win32')('omp wrapper under a user alias named omp', () => {
+  it.skipIf(!bashAvailable)('keeps a user alias named omp working in bash', () => {
+    expectAliasedOmpNameSurvives('/bin/bash', 'shopt -s expand_aliases')
+  })
+
+  it.skipIf(!zshAvailable)('keeps a user alias named omp working in zsh', () => {
+    expectAliasedOmpNameSurvives('/bin/zsh', 'setopt aliases')
+  })
+})

--- a/src/main/pty/omp-shell-wrapper.ts
+++ b/src/main/pty/omp-shell-wrapper.ts
@@ -66,7 +66,9 @@ __orca_omp() {
   fi
 }
 if [[ -n "\${ORCA_OMP_STATUS_EXTENSION:-}" ]]; then
-  omp() { __orca_omp "$@"; }
+  # Why the function reserved word: it suppresses alias expansion of the name, which
+  # an \`alias omp\` otherwise rewrites at parse time, aborting the rest of the file.
+  function omp { __orca_omp "$@"; }
 fi
 `
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​268 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​41 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​227 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 |

<!-- /orca-pr-loc -->

> Supersedes #15552 by @terry-li-hm — carried over so it can run full CI (fork PRs only run `track-community-pr` in this repo). Original authorship preserved in the commit.

## ELI5

Orca injects a tiny `codex` shell function into every pane so it can repair Codex's trust state right before Codex starts. If you happen to have your own shell alias *named* `codex`, the shell rewrote Orca's function definition using your alias text before it ever ran it — producing a syntax error. bash doesn't just skip that line: it abandons the **rest of the startup file**, so the hooks and the shell-ready marker defined below it never got installed and the pane never signalled ready. This teaches Orca to define its function in a form the shell won't rewrite, while leaving your alias completely untouched.

## What Changed

`getPosixCodexShellLaunchPreflight()` (bash + zsh):

- Binary detection moved into the command substitution: `$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)`. A subshell alias table is discarded on exit, so the user's alias survives.
- The wrapper is now defined with the `function codex { … }` reserved-word form instead of `codex() { … }`. After `function`, the name is not in command position, so no alias expansion.
- No `eval` anywhere. #15552 proposed wrapping the definition in `eval '…'`; this PR takes the `function` route instead. `main` has no `eval` here, so this diff removes none — it declines to add one.

`getPosixOmpShellWrapper()` (bash + zsh) — the same defect, one snippet above:

- `omp() { __orca_omp "$@"; }` was the only other user-facing name the generated wrappers define with the alias-vulnerable `name() {` form, and it sits in the same `if …; then … fi` compound in the same bash rcfile. A user `alias omp` aborts the rcfile exactly the way a `codex` alias did, with the same blast radius (OSC 133 hooks and the shell-ready marker are both below it). Switched to `function omp { … }` and covered by `omp-shell-wrapper-alias-safety.test.ts`, which runs real `/bin/bash` and `/bin/zsh` and fails on `main`'s form in both. Audited the rest of the generated bash/zsh wrapper files: every remaining function they define is `__orca_`/`_orca_`-prefixed, so no other name is exposed to a user alias.

Tests:

- `codex-shell-launch-preflight.test.ts` — the contributor's regression case, with the fixture quoting fixed (`printf launched\n` unquoted printed `launchedn`, so the assertion could never match), honest per-shell `it.skipIf` instead of a silent `return`, a preflight marker file so the assertion isn't vacuous, and a new assertion that the user's alias flags **and** env prefix still reach the binary.
- `codex-preflight-profile-path-rewrite.test.ts` — a regression against the shape that actually ships: a real interactive bash driving `getDaemonBashShellReadyRcfileContent()` with a `codex` alias in the fixture `.bash_profile`. It asserts the rcfile parsed past the wrapper (via a probe for `__orca_osc133_preexec`, which is defined below the snippet), that the preflight ran, and that `--alias-flag` still reached the binary.
- `src/main/__fixtures__/shell-wrapper-snapshots/{local,daemon}-{bash-rcfile,zsh-zshenv}.txt` — regenerated. These are `toMatchFileSnapshot` fixtures, so a local run rewrites them silently and only CI fails; they have to ship with any snippet change. The fish fixtures carry no codex snippet and are untouched. `relay-*.txt` carries no codex snippet either, but does carry the omp wrapper, so the relay overlay picks up the alias protection through that half of the change.

## Why

Two distinct root causes, both real on `main`:

1. **bash rcfile abort.** In `local-pty-shell-ready-bash-rcfile.ts` and `daemon-bash-shell-ready-rcfile.ts` the snippet sits at top level *after* `source "$HOME/.bash_profile"`. With `expand_aliases` on and a user alias named `codex`, bash expands it into the `codex() {` header at parse time and dies — then abandons the remainder of the file. The OSC 133 hooks and the shell-ready marker are both defined below it, so the pane never signals ready. Reproduced on bash 3.2.57 and 5.3.9.
2. **zsh silent skip.** `command -v codex` returns the literal `alias codex='…'` text in both shells, so the `-x "$__orca_codex_binary"` guard fails and the preflight is skipped entirely for anyone with such an alias.

Why not the original PR's mechanism: it ran `unalias codex` at statement level, which permanently deletes the user's alias in every Orca pane. Verified side by side — with that snippet, typing `codex` yields `args=[] author=[]`; with this one, `args=[--alias-flag] author=[Codex]`. That silently changes git commit attribution and Codex's approval/sandbox posture, and for a user who aliased `codex` to *add* a restriction (`--sandbox read-only`, a policy wrapper) it silently strips their own guardrail. It also fired unconditionally — including where `resolveCodexShellLaunchPreflightCommand()` returns `null` (WSL, hooks off, no launcher on disk) and no wrapper is installed at all, making it pure collateral damage.

`eval` was not carried over either: in #15552 it only worked because the body happened to contain zero single quotes, and it turns a static definition into the exact shape a future change could make an injection point by interpolating a path. `function name` gives the same parse immunity with no `eval` and no interpolation.

Both `|| :` are load-bearing, not decoration — and the trailing one is **not** zsh-only. Measured under `set -e` with no `codex` on PATH, on macOS bash 3.2.57, bash 5.3.9 and zsh 5.9, and re-measured on real Linux (Ubuntu 24.04, bash 5.2.21 and zsh 5.9) — see Testing:

- **Trailing `|| :` (after `command -v`) — needed in every shell.** An assignment adopts its command substitution's exit status, and `command -v` exits non-zero when the name is absent (measured 1 on bash 5.2.21 and zsh 5.9; see Testing). Drop it and all three shells exit 1, bash included. Do not remove it believing bash is safe: that would break every user who has `set -e` in their profile and no `codex` installed.
- **`|| :` after `unalias` — this is the zsh-specific one.** Only zsh carries `errexit` inside a command substitution, so a failing `unalias` (no such alias) aborts the substitution there while bash runs on to `command -v`.

## Linked Issue

No linked issue — reported via PR #15552.

## Visual Proof

`N/A` — shell startup-file generation only. No renderer, component, or styling change; nothing about the pane's appearance changes on the success path.

## Testing

Actually executed, macOS 15 (arm64), bash 3.2.57 + bash 5.3.9 + zsh 5.9:

```
npx vitest run --config config/vitest.config.ts \
  src/main/pty/codex-shell-launch-preflight.test.ts \
  src/main/pty/codex-preflight-profile-path-rewrite.test.ts \
  src/main/daemon/shell-ready-bash-wrapper.test.ts \
  src/main/providers/local-pty-shell-ready-wrapper-generation.test.ts \
  src/main/ipc/pty-spawn-env-terminal-basics.test.ts \
  src/main/shell-wrapper-content-address.test.ts
# 6 files passed, 85 passed | 2 skipped (skips are fish/pwsh, not installed)

npx vitest run --config config/vitest.config.ts \
  src/main/powershell-osc133-bootstrap.test.ts src/main/pty/wsl-orca-env.test.ts \
  src/main/providers/local-pty-provider-windows-shell-launch.test.ts \
  src/main/providers/windows-shell-args.test.ts \
  src/main/daemon/pty-subprocess-windows-shell-launch.test.ts
# 82 passed

npx oxlint <3 changed files>                                            # exit 0
npx oxlint --config config/oxlint-code-quality-native-plugins.json ... --deny-warnings  # exit 0
npx oxfmt --check <3 changed files>                                     # exit 0

npx vitest run --config config/vitest.config.ts \
  src/main/pty/omp-shell-wrapper-alias-safety.test.ts \
  src/main/pty/omp-shell-wrapper.node-pty.test.ts \
  src/main/shell-wrapper-generated-file-snapshot.test.ts \
  src/main/providers/windows-shell-args.test.ts
# 4 files passed (omp sibling fix); the two new alias cases fail on `main`'s
# `omp() {` form in both /bin/bash 3.2.57 and /bin/zsh 5.9 (exit 1, syntax error,
# and the trailing `printf parsed` never reached — the rcfile-abort signature)
```

**The regression tests were proven non-vacuous — checked in both directions:**

- Against `main`'s snippet, all three new cases fail: zsh `parse error near '()'`, bash `syntax error near unexpected token '('`, and the rcfile case fails on the post-snippet marker being absent — which is the direct proof that bash abandons the rest of the rcfile.
- Against the *original PR's* snippet (statement-level `unalias` + `eval`), all three still fail, on the alias-survival assertions: `expected '--version' to be '--alias-flag --version'` and `expected 'launched args=[] author=[]' to be 'launched args=[--alias-flag] author=[Codex]'`. So they pin the destructive-unalias regression too, not just the parse error.

Also smoke-tested outside vitest against real shells with a fixture alias (`alias codex='GIT_AUTHOR_NAME=Codex codex --alias-flag'`) sourced inside an `if true; then … fi` compound, on `/bin/zsh` (5.9), `/bin/bash` (3.2.57) and `/opt/homebrew/bin/bash` (5.3.9): all three parse, write the preflight marker, and deliver `args=[--alias-flag] author=[Codex]`.

### Real Linux hardware — `openclaw` (Ubuntu 24.04.4 LTS, x86_64, kernel 7.0.0-28-generic)

Retires the "verified on macOS only" caveat. Shell builds actually present on that box:

```
$ /bin/bash --version | head -1
GNU bash, version 5.2.21(1)-release (x86_64-pc-linux-gnu)
$ zsh --version                        # stock Ubuntu 5.9 build, extracted from the
zsh 5.9 (x86_64-ubuntu-linux-gnu)      # noble/main zsh deb (no root on this host)
```

**1. Original bug reproduced on real Linux.** The exact `main` snippet, a user alias in the rc file, real interactive shells:

```
=== bash 5.2.21, `bash --rcfile <rc> -i -c ...`, main snippet ===
bash: /tmp/orca-alias.lmpXd8d1/rcfile: line 5: syntax error near unexpected token `('
bash: /tmp/orca-alias.lmpXd8d1/rcfile: line 5: `  codex() {'
codex is aliased to `GIT_AUTHOR_NAME=Codex codex --alias-flag'
rcfile-continued marker: ABSENT        <- bash abandoned the rest of the rcfile
preflight-ran marker:    ABSENT

=== zsh 5.9, `zsh -i` with ZDOTDIR/.zshrc, main snippet ===
/tmp/orca-alias.03AX2Dlq/zdot/.zshrc:5: parse error near `()'
rcfile-continued marker: ABSENT
preflight-ran marker:    ABSENT
```

Root cause 2 (the silent skip) also confirmed on both Linux shells:

```
bash  command -v -> alias codex='GIT_AUTHOR_NAME=Codex codex --alias-flag'
bash  -x guard: FAIL (preflight SKIPPED)
zsh   command -v -> alias codex='GIT_AUTHOR_NAME=Codex codex --alias-flag'
zsh   -x guard: FAIL (preflight SKIPPED)
```

**2. Fixed snippet on real Linux** — same rc files, shipped snippet:

```
=== bash 5.2.21 ===
codex is aliased to `GIT_AUTHOR_NAME=Codex codex --alias-flag'
launched args=[--alias-flag --version] author=[Codex]
POST_SNIPPET_FN_DEFINED
rcfile-continued marker: PRESENT
preflight-ran marker:    agent hooks prepare-codex

=== zsh 5.9 ===
codex: alias                           <- whence -w; the user's alias is intact
launched args=[--alias-flag --version] author=[Codex]
POST_SNIPPET_FN_DEFINED
rcfile-continued marker: PRESENT
preflight-ran marker:    agent hooks prepare-codex
```

The subshell `unalias` was checked directly too — after the substitution runs, `alias codex` still prints the user's definition and `whence -w codex` still says `codex: alias`, in both shells.

**3. Both halves of the `|| :` claim confirmed on real Linux builds** (`set -e` / `setopt ERR_EXIT`, empty `PATH` so no `codex`):

```
bash  set -e   shipped snippet (both || :)   exit=0 stdout=[alive]
bash  set -e   trailing '|| :' REMOVED       exit=1 stdout=[]
bash  set -e   unalias '|| :' REMOVED        exit=0 stdout=[alive]
zsh   ERR_EXIT shipped snippet (both || :)   exit=0 stdout=[alive]
zsh   ERR_EXIT trailing '|| :' REMOVED       exit=1 stdout=[]
zsh   ERR_EXIT unalias '|| :' REMOVED        exit=1 stdout=[]
```

Both mechanisms isolated on the same host:

```
bash assignment status=1 / zsh assignment status=1  # assignment adopts the substitution's
                                                    # status -> trailing `|| :` is NOT zsh-only
bash inner=[REACHED]   bash outer exit=0            # bash does not carry errexit into $( )
zsh  (no inner output) zsh  outer exit=1            # zsh does -> unalias guard IS zsh-specific
```

**4. Disclosed gap (`alias codex='npx codex'`) degrades safely on Linux.** The expansion does not start with the bare word, so the wrapper never intercepts and the preflight does not run — but nothing breaks:

```
=== bash 5.2.21, fixed snippet, alias codex='npx codex' ===
codex is aliased to `npx codex'
npx-ran args=[codex --version]
POST_SNIPPET_FN_DEFINED
rcfile-continued marker: PRESENT       <- rcfile intact
preflight-ran marker:    ABSENT        <- the known gap, and only that
```

Same shape under zsh 5.9. On `main` this same alias still aborts the bash rcfile (`syntax error near unexpected token '('`, `rcfile-continued: ABSENT`), so the fix strictly improves this case as well.

**5. The vitest suites, executed on that Linux host.** Branch checked out there as a worktree of the existing clone:

```
$ npx vitest run --config config/vitest.config.ts \
    src/main/pty/codex-shell-launch-preflight.test.ts \
    src/main/pty/codex-preflight-profile-path-rewrite.test.ts \
    src/main/pty/omp-shell-wrapper-alias-safety.test.ts
# 3 files passed, 24 passed | 7 skipped   (skips: zsh/fish/pwsh absent on the bare host)

$ npx vitest run --config config/vitest.config.ts \
    src/main/pty/omp-shell-wrapper-alias-safety.test.ts \
    src/main/pty/omp-shell-wrapper.node-pty.test.ts \
    src/main/shell-wrapper-generated-file-snapshot.test.ts \
    src/main/daemon/shell-ready-bash-wrapper.test.ts \
    src/main/providers/local-pty-shell-ready-wrapper-generation.test.ts
# 5 files passed, 54 passed | 1 skipped

# same three alias suites again, this time inside ubuntu:24.04 + `apt-get install zsh fish`
# on the same host, so /bin/zsh and fish actually exist:
# 3 files passed, 29 passed | 2 skipped   (only pwsh skipped; every zsh + fish case ran)
```

Non-vacuity re-proved **on Linux**, by reverting only the two prod snippets to `main` and re-running in that zsh-equipped container:

```
× keeps a user alias named omp working in bash    -> syntax error near unexpected token `('
× keeps a user alias named omp working in zsh     -> defining function based on alias `omp'
× keeps a user alias named codex working in bash  -> syntax error near unexpected token `('
× keeps a user alias named codex working in zsh   -> parse error near `()'
× finishes the rcfile and preserves the alias when the user aliased the name codex
                                                  -> expected false to be true
Tests  5 failed | 24 passed | 2 skipped
```

**6. Two CI-honesty defects the Linux run exposed — now fixed in this PR.** Neither is a defect in the shell fix itself; both are reasons the zsh half of it was never actually being checked away from macOS:

- `keeps /bin/zsh startup alive under strict error handling when Codex is absent` was an `it.each` case with an early `return` when the shell was missing, so on any host without `/bin/zsh` it reported **✓ green having executed nothing**. Now `it.skipIf(!existsSync(shell))` — verified reporting `↓` on `openclaw` (no zsh) and `✓` in the container (zsh present).
- Neither `codex-shell-launch-preflight.test.ts` nor `omp-shell-wrapper-alias-safety.test.ts` was in the `shell contracts` job, the only CI job that installs zsh. They ran only in the sharded `test` job on bare `ubuntu-latest`, where every zsh case skips. Both are now in the `shell contracts` list, so the zsh half of this fix is covered by a required check rather than by a macOS developer machine.

**Correction to the "Why" section above:** `command -v <absent-name>` exits **1**, not 127, in both bash 5.2.21 and zsh 5.9 — 127 is what `command <absent-name>` returns. The conclusion is unchanged: the assignment still adopts a non-zero status, so dropping the trailing `|| :` still kills the shell under `set -e` in bash as well as zsh (measured above).

**Still not executed:** Windows, and the SSH/remote *pane* path end to end. The Linux work above was driven over SSH to `openclaw`, but it exercises the generated snippet and the generators directly — it does not spawn a real daemon-managed remote pane. Windows is unaffected by reasoning (`windows-shell-args.ts` invokes the preflight directly, with no wrapper function), not by execution.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Cross-platform.** The change is confined to the POSIX (bash/zsh) template. `function name { }` and subshell `unalias` are bash and zsh features, not POSIX sh — correct here, since the only consumers are the bash rcfile and the zsh `.zshenv` wrapper, both of which already use `[[ ]]`. Linux is the same bash code path, executed identically; Windows `cmd.exe` (`windows-shell-args.ts`) is unaffected because it invokes the preflight directly with no wrapper function. No paths are constructed, so no separator assumptions. **Known gap, deliberately deferred:** fish and PowerShell have the same alias blindness (fish `type -t codex` → `function`; PowerShell `Get-Command` → `Alias`) and are untouched — in both, a user alias is genuinely indistinguishable from the user-defined `codex` command those wrappers intentionally preserve (there are existing tests asserting that preservation), so "fixing" them would trade one silent behavior change for another. Worth a separate issue, not a drive-by here.
- **SSH / remote.** The daemon rcfile generator is one of the two call sites, so remote panes get the identical fix. No RPC params, stream frames, or published content change, so `docs/reference/remote-wire-compatibility.md` is not implicated. Changing the snippet re-keys the content-addressed wrapper tree (`shell-wrapper-content-address.ts`) by design — that's the intended propagation mechanism; hosts pick up the new tree on next spawn, old trees are intentionally not GC'd, and there is no version constant to bump. Mixed-version client/host is safe because each side generates and consumes its own wrapper tree.
- **Agent / integration compatibility.** This *restores* compatibility: a user's `codex` alias now keeps working with its flags and env prefix intact, where before the pane either failed to signal ready (bash) or silently skipped trust repair (zsh). Users with a `codex` shell *function* rather than an alias are unaffected — `command -v` returns a bare name, the `-x` guard rejects it, and their function is preserved, exactly as before. No behavior change at all for the overwhelming majority who have no `codex` alias.
- **Performance.** One extra `unalias` builtin inside a command substitution that already ran at shell startup. No new process spawn, no new file I/O. Unmeasurable.
- **UI quality.** N/A — no renderer code touched.
- **Security.** Net improvement. The emitted snippet interpolates no user, env, or repo value — every byte is a static literal — and removing the `eval` eliminates a construct that a later change could trivially turn into a command-injection point by interpolating a path. The `unalias` is now scoped to a subshell, so it can no longer mutate the user's shell state; that also closes the case where a security-minded user's `--sandbox read-only` alias was being silently stripped. `ORCA_CODEX_LAUNCH_PREFLIGHT` is still invoked as a quoted absolute path (`resolveCodexShellLaunchPreflightCommand()` unchanged), so the PATH-hijack property that file's existing tests pin is preserved.
- **Contributor diff scan.** I reviewed the full contributor branch (`origin/main...pr-15552`: 1 commit, 2 files, +60/−2, both under `src/main/pty/`) for malicious content and found none — no network calls or URLs, no download-and-execute, no reads of credentials/SSH keys/env files, no writes outside `os.tmpdir()`, no `package.json`/lockfile/CI/updater/signing changes, no binaries or encoded payloads, and no prompt-injection text. The one construct warranting scrutiny, the added `eval`, evaluated a static single-quoted literal with no interpolation — not an injection vector as written, but fragile enough that I removed it anyway.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Known limitations / follow-ups

Real, deliberately out of scope for this PR — none of them is a regression, each is the same or better than `main`:

- **fish and PowerShell keep the alias blindness.** `getFishCodexShellLaunchPreflight()` gates on `type -t codex` = `file` and the PowerShell one on `CommandType -in Application, ExternalScript`, so a user alias named `codex` still means no preflight in those shells. Unlike bash/zsh there is no cheap way to tell a user alias apart from the user-defined `codex` command those wrappers deliberately preserve (existing tests pin that preservation), so a fix there is a design question, not a one-liner. Worth its own issue.
- **Per-name hardening does not scale; the region-wide form would.** Both this fix and the `omp` one immunise a name at a time, so the next wrapper Orca adds to the bash rcfile re-opens the same hole unless whoever writes it remembers `function`. The structural alternative is to switch alias expansion off across Orca's whole generated region — `shopt -u expand_aliases` right after `source "$HOME/.bash_profile"`, restored before the shell reaches the prompt (verified on bash 3.2.57: the file parses to the end and the user's alias still wins at the prompt afterwards). That is the right shape, but it moves the blast radius from two function headers to every line of the rcfile epilogue and leaves a restore obligation on every early-return path, which is not something to slip into a fix PR. Separate change.
- **The snippets still call `unalias`, `command`, and `unset` unprefixed.** The zsh wrapper file around them already routes every builtin through `builtin …`, which both bypasses a user function of that name and keeps the second word out of alias expansion; the shared POSIX codex/omp snippets do not. A user who has defined a function or alias named `command` or `unset` can therefore still steer the detection substitution and the `command codex "$@"` dispatch. Far rarer than an alias on the wrapped command itself, and fixing it means re-touching the shared snippet plus all six wrapper snapshots, so it belongs in its own pass over every generated snippet rather than here.
- **An alias whose expansion does not start with the bare word `codex` still bypasses the wrapper.** e.g. `alias codex='npx codex'` or `alias codex='/opt/bin/codex --sandbox read-only'`: alias expansion rewrites the command word to something that is not the function name, so the function never runs and the preflight is silently skipped. Verified against the shipped snippet in bash 5.3.9 — the binary launches with the alias's flags but no preflight marker is written. Same outcome as `main` (where the `-x` guard rejected the alias text anyway), and strictly better than `main` on bash, which aborted the whole rcfile.

## Notes

The original report cited `shell-ready/zsh/.zshrc:60` and `.zlogin:59`, which `main` no longer generates — the zsh fileset writes only `.zshenv` now, and the snippet lives inside `__orca_deferred_init()`, whose body is parsed before the user's `.zshrc` runs. So that specific trace is from an older tree, but **the bug is still real on main** by two other routes (the bash rcfile abort and the zsh silent skip), which is what this PR fixes and tests.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)






