### PR TITLE
fix(i18n): correct five Korean strings that changed meaning in machine translation

### DIFF
--- a/config/scripts/locale-ko-frozen-terminal-search-keywords.test.mjs
+++ b/config/scripts/locale-ko-frozen-terminal-search-keywords.test.mjs
@@ -1,0 +1,60 @@
+import fs from 'node:fs'
+
+import { describe, expect, it } from 'vitest'
+import { repairTranslatedValue } from './locale-translation-policy.mjs'
+
+// The frozen-terminal recovery entry is searchable only if both halves of the pair use the
+// UI's "stopped" sense; MT rendered `unfreeze` as 녹이다 (thawing ice), splitting them.
+const PAIR = [
+  { key: 'auto.components.settings.terminal.search.88561b3499', enValue: 'frozen', ko: '정지됨' },
+  {
+    key: 'auto.components.settings.terminal.search.d4daf4f612',
+    enValue: 'unfreeze',
+    ko: '정지 해제'
+  }
+]
+
+function readCatalog(locale) {
+  return JSON.parse(
+    fs.readFileSync(
+      new URL(`../../src/renderer/src/i18n/locales/${locale}.json`, import.meta.url),
+      'utf8'
+    )
+  )
+}
+
+function getValue(catalog, key) {
+  return key.split('.').reduce((value, part) => value[part], catalog)
+}
+
+describe('Korean frozen-terminal settings search keywords', () => {
+  it('repairs the machine-translated unfreeze keyword', () => {
+    expect(
+      repairTranslatedValue({
+        key: 'auto.components.settings.terminal.search.d4daf4f612',
+        enValue: 'unfreeze',
+        localeValue: '녹이다',
+        locale: 'ko'
+      })
+    ).toBe('정지 해제')
+  })
+
+  it('ships the pair in the Korean catalog', () => {
+    const catalog = readCatalog('ko')
+    for (const { key, ko } of PAIR) {
+      expect(getValue(catalog, key), key).toBe(ko)
+    }
+  })
+
+  it('survives the canonical catalog repair policy', () => {
+    const english = readCatalog('en')
+    const catalog = readCatalog('ko')
+    for (const { key, enValue } of PAIR) {
+      expect(getValue(english, key), key).toBe(enValue)
+      const localeValue = getValue(catalog, key)
+      expect(repairTranslatedValue({ key, enValue, localeValue, locale: 'ko' }), key).toBe(
+        localeValue
+      )
+    }
+  })
+})

--- a/config/scripts/locale-ko-key-overrides.json
+++ b/config/scripts/locale-ko-key-overrides.json
@@ -2210,6 +2210,9 @@
   "auto.components.settings.DeveloperPermissionsPane.e119f0d66b": {
     "ko": "자동화"
   },
+  "auto.components.settings.DeveloperPermissionsPane.f903bf20b5": {
+    "ko": "터미널과 개발 도구가 로컬 네트워크의 서비스에 연결할 수 있도록 허용합니다. macOS는 이 권한의 현재 상태를 Orca에 보고하지 않습니다."
+  },
   "auto.components.settings.ExperimentalPane.agentHibernation.idleMinutesDescription": {
     "ko": "완료된 백그라운드 agent를 Orca가 최대 절전 모드로 전환하기 전에 기다릴 유휴 시간(분)입니다."
   },
@@ -4088,6 +4091,9 @@
   "auto.components.shared.useDaemonActions.fe2ab66d45": {
     "ko": "세션 {{value1}}개 중 {{value0}}개를 종료했습니다. {{value2}}개가 종료를 거부했습니다."
   },
+  "auto.components.sidebar.AddRemoteHostDialog.sshImportSynced": {
+    "ko": "{{value0}} 호스트{{value1}}을(를) Orca에 추가했습니다."
+  },
   "auto.components.sidebar.AddRepoCreateStep.0ae45b8238": {
     "ko": "my-project"
   },
@@ -5002,6 +5008,12 @@
   },
   "auto.web.WebConnect.4a4c017be1": {
     "ko": "엔드포인트:"
+  },
+  "components.native-chat.approval.allow": {
+    "ko": "허용"
+  },
+  "components.native-chat.approval.deny": {
+    "ko": "거부"
   },
   "settings.appearance.statusBar.resourceUsageToggleDescription": {
     "ko": "리소스 관리자를 표시합니다. 클릭하면 CPU, 메모리, 세션, 데몬 제어, 워크스페이스 디스크 스캔을 볼 수 있습니다."

--- a/config/scripts/locale-search-keyword-overrides.mjs
+++ b/config/scripts/locale-search-keyword-overrides.mjs
@@ -37,6 +37,10 @@ export const SEARCH_KEYWORD_OVERRIDES = {
     prompt: '프롬프트',
     rename: '이름 변경',
     session: '세션',
+    // Why: MT read 'unfreeze' as thawing ice (녹이다). Pin it to the 정지됨 pair so
+    // frozen-terminal recovery stays reachable from the term the UI actually shows.
+    frozen: '정지됨',
+    unfreeze: '정지 해제',
     location: '위치',
     detect: '감지',
     path: '경로',

--- a/src/renderer/src/i18n/ko-ui-semantic-mistranslations.test.ts
+++ b/src/renderer/src/i18n/ko-ui-semantic-mistranslations.test.ts
@@ -18,7 +18,13 @@ const correctedValues = {
   'auto.components.right.sidebar.source.control.discard.confirmation.40e9357b2a':
     '이렇게 하면 HEAD에서 파일을 복원하고 파일 삭제를 취소합니다. 이 작업은 취소할 수 없습니다.',
   'auto.components.right.sidebar.source.control.primary.action.5a477d80cb':
-    '모든 변경 사항 스테이징'
+    '모든 변경 사항 스테이징',
+  'auto.components.settings.DeveloperPermissionsPane.f903bf20b5':
+    '터미널과 개발 도구가 로컬 네트워크의 서비스에 연결할 수 있도록 허용합니다. macOS는 이 권한의 현재 상태를 Orca에 보고하지 않습니다.',
+  'auto.components.sidebar.AddRemoteHostDialog.sshImportSynced':
+    '{{value0}} 호스트{{value1}}을(를) Orca에 추가했습니다.',
+  'components.native-chat.approval.allow': '허용',
+  'components.native-chat.approval.deny': '거부'
 } as const
 
 function getLocaleValue(path: string): unknown {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5116,7 +5116,7 @@
           "pairingCommand": "orca serve --pairing-address <host>",
           "pairingHelpSuffix": "한 다음 출력된 페어링 URL을 붙여넣으세요.",
           "sshImportAlreadySynced": "~/.ssh/config가 이미 동기화되어 있습니다.",
-          "sshImportSynced": "{{value0}} 호스트{{value1}}을(를) 동기화했습니다.",
+          "sshImportSynced": "{{value0}} 호스트{{value1}}을(를) Orca에 추가했습니다.",
           "sshImportFailed": "SSH 구성을 가져오지 못했습니다.",
           "sshPersistenceDefault": "이 호스트의 원격 터미널은 종료하거나 릴레이를 재설정할 때까지 계속 실행됩니다.",
           "advanced": "고급",
@@ -5776,7 +5776,7 @@
           "b2210b1b4f": "블루투스",
           "dfbc12c8c8": "USB 장치와 통신하는 하드웨어 디버깅 및 장치 도구입니다.",
           "bf51e4a542": "USB 장치",
-          "f903bf20b5": "네트워크의 개발 서버를 검색하고 액세스합니다.",
+          "f903bf20b5": "터미널과 개발 도구가 로컬 네트워크의 서비스에 연결할 수 있도록 허용합니다. macOS는 이 권한의 현재 상태를 Orca에 보고하지 않습니다.",
           "e7bb06007c": "LAN",
           "4a73f5217a": "다른 로컬 앱을 제어하는 ​​스크립트를 위한 Apple 이벤트.",
           "e119f0d66b": "자동화",
@@ -8921,7 +8921,7 @@
             "46d99ef4bb": "불투명도",
             "4c643695aa": "terminal 배경의 투명도를 제어합니다.",
             "b36fd2416d": "배경 불투명도",
-            "d4daf4f612": "녹이다",
+            "d4daf4f612": "정지 해제",
             "88561b3499": "정지됨",
             "0a05629060": "복구",
             "f66a7cf715": "터미널",
@@ -14493,8 +14493,8 @@
       },
       "approval": {
         "title": "{{value0}}을(를) 허용하시겠습니까?",
-        "allow": "허용하다",
-        "deny": "부인하다"
+        "allow": "허용",
+        "deny": "거부"
       },
       "launchPromptNotDelivered": "전달되지 않음 — 터미널을 확인하세요"
     },


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​67 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​66 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 |

<!-- /orca-pr-loc -->

## ELI5

Five Korean labels in the app said the wrong thing. One of them dropped an entire sentence — the one warning that macOS never tells Orca whether the "local network" permission is actually on — so a Korean user was reading a status indicator as though it were trustworthy. Another pair made the agent approval buttons read like a courtroom ("to disavow") instead of "Allow / Deny". This PR corrects the five strings and pins them so the translation-regeneration scripts can't quietly put the machine-translated wording back.

## What Changed

`src/renderer/src/i18n/locales/ko.json` — five values, no key names, no other locale:

| key | before | after |
|---|---|---|
| `auto.components.settings.DeveloperPermissionsPane.f903bf20b5` | 네트워크의 개발 서버를 검색하고 액세스합니다. | 터미널과 개발 도구가 로컬 네트워크의 서비스에 연결할 수 있도록 허용합니다. macOS는 이 권한의 현재 상태를 Orca에 보고하지 않습니다. |
| `components.native-chat.approval.allow` | 허용하다 | 허용 |
| `components.native-chat.approval.deny` | 부인하다 | 거부 |
| `auto.components.sidebar.AddRemoteHostDialog.sshImportSynced` | `{{value0}}` 호스트`{{value1}}`을(를) 동기화했습니다. | `{{value0}}` 호스트`{{value1}}`을(를) Orca에 추가했습니다. |
| `auto.components.settings.terminal.search.d4daf4f612` (`unfreeze`) | 녹이다 | 정지 해제 |

Plus the pinning layer, which is the part that makes the fix stick:

- `config/scripts/locale-ko-key-overrides.json` — four new `{"ko": "..."}` entries for the value keys (ko-only, as `locale-ko-key-overrides.test.mjs` requires).
- `config/scripts/locale-search-keyword-overrides.mjs` — `frozen: '정지됨'` and `unfreeze: '정지 해제'` in the `ko` map only. `.search.` keys are repaired through the keyword path (keyed on the *English* value), not the key-override path, so that is where this one belongs. `frozen` is a no-op against today's catalog and is there to stop regeneration from splitting the pair again.

Tests: four keys added to the existing `correctedValues` map in `ko-ui-semantic-mistranslations.test.ts`, and a new `config/scripts/locale-ko-frozen-terminal-search-keywords.test.mjs` for the keyword path.

No English source, no `ja`/`zh`/`es` catalog, no key names, no source code, no `package.json`/lockfile.

## Why

Root cause is not "a bad translator" — it is that these five leaves came out of the bulk MT pass and were never pinned in the override layer. `repairTranslatedValue` (`config/scripts/locale-translation-policy.mjs`) can only correct a value reachable by an exact key override, an exact English-value override, a `.search.` keyword override, or a regex phrase fix gated on `whenEnIncludes`/`whenEnMatches`. None of the five is reachable by any existing rule: they share no token with the `검토`→`리뷰` / `기술`→`스킬` term-drift rounds, and #1 is an *omission*, which no substitution rule can ever synthesize. So `ko.json` was the sole source of truth for them, and correcting only the catalog would leave the fix unpinned — `node config/scripts/repair-locale-catalog.mjs --locale ko` or a re-bootstrap would silently reinstate the MT output. Hence the catalog edit **and** the override entry for each.

Per-string rationale:

1. **Dropped caveat (the only one with real user-facing consequence).** English is 148 chars, Korean was 25, and the missing sentence is exactly the warning that the status indicator cannot be trusted. `DeveloperPermissionsPane.tsx` renders `<LocalNetworkConnectionTest />` for this row *because* macOS never reports the real state. Keeping the literal "macOS" is fine — the pane is gated by `showDesktopOnlySettings && isMac`, so no Linux/Windows reader sees it.
2. **Approval buttons.** `허용하다`/`부인하다` are dictionary verb infinitives, and `부인하다` specifically means "to disavow / deny an accusation". These are the option labels in `native-chat-interactive-prompt.ts` for the agent tool-approval card, i.e. the control gating a potentially destructive action, so the refuse button did not read as refusal. Every sibling locale already uses the noun form (zh 允许/拒绝, es Permitir/Denegar).
3. **SSH import toast.** Fires on the branch where new hosts were registered; the sibling key `sshImportAlreadySynced` is the one that genuinely means "in sync". The Korean reported an operation that did not happen and collided with its own sibling. Both `{{value0}}` and `{{value1}}` are retained (placeholder parity is enforced by `verify-localization-catalog.mjs`, and `value1` carries the English plural `s`).
4. **`unfreeze` → 녹이다** is thawing ice. Its pair `frozen` already ships as `정지됨`, so a Korean user searching Settings for the frozen-terminal recovery entry could not reach it from the term the UI actually shows.

## Linked Issue

Fixes #14139

## Visual Proof

`N/A` for before/after images — this is a string-only data change in one locale catalog, and the strings only render with the app language set to Korean, so a screenshot pair would be five isolated label crops rather than a layout diff. Nothing about layout, component selection, spacing, or styling changes.

A reviewer who wants to see it in the app: set Settings → Language to 한국어, then look at (a) Settings → Developer Permissions → the LAN/local-network row's help text, which should now be two sentences ending in `…Orca에 보고하지 않습니다.`; (b) the agent tool-approval card in native chat, whose buttons should read `허용` / `거부`; (c) the toast after importing `~/.ssh/config` with at least one new host, which should say `…Orca에 추가했습니다.`; (d) Settings search for `정지`, which should now surface the frozen-terminal recovery entry. One caveat worth flagging: (d) is a behavior change for anyone who had learned to type `녹이다` — that query stops matching. Acceptable, since it was matching a keyword no Korean speaker would type for this action.

## Testing

Run on **macOS only** (Darwin 25.3.0). Everything below is targeted; I did not run project-wide typecheck or full lint (CI covers those).

```
npx vitest run --config config/vitest.config.ts \
  src/renderer/src/i18n/ko-ui-semantic-mistranslations.test.ts \
  src/renderer/src/i18n/native-chat-locales.test.ts \
  src/renderer/src/i18n/locale-english-regression.test.ts \
  src/renderer/src/i18n/technical-literal-catalog-values.test.ts \
  config/scripts/locale-ko-key-overrides.test.mjs \
  config/scripts/macos-tcc-prompt-localization.test.mjs \
  config/scripts/locale-translation-policy-ko-round5.test.mjs \
  config/scripts/locale-ko-frozen-terminal-search-keywords.test.mjs
```
→ **8 files, 22 tests, all passing.** No pre-existing failures in this set.

```
node config/scripts/verify-localization-catalog.mjs      # exit 0; ko.json 11853/13244, placeholder parity clean
node config/scripts/audit-localization-coverage.mjs --check  # exit 0, 12 allowlisted candidates (unchanged)
npx oxlint <5 changed files>                             # exit 0
npx oxlint --config config/oxlint-code-quality-native-plugins.json <3 code files> --deny-warnings  # exit 0
npx oxfmt --check <5 changed files>                      # clean
```

**Proof the tests actually fail without the fix.** I stashed only the three product files (`ko.json`, `locale-ko-key-overrides.json`, `locale-search-keyword-overrides.mjs`), kept the tests, and re-ran:

```
× keeps the corrected values in the Korean catalog
    AssertionError: auto.components.settings.DeveloperPermissionsPane.f903bf20b5:
      expected '네트워크의 개발 서버를 검색하고 액세스합니다.' to be '터미널과 개발 도구가 …'
× keeps the corrected values in the translation overrides
    AssertionError: … expected undefined to be '터미널과 개발 도구가 …'
× repairs the machine-translated unfreeze keyword
    AssertionError: expected '녹이다' to be '정지 해제'
× ships the pair in the Korean catalog
    AssertionError: …d4daf4f612: expected '녹이다' to be '정지 해제'
Tests  4 failed | 1 passed
```
Restored the stash; all green again.

**Proof the pin and the catalog cannot drift apart.** I ran `node config/scripts/repair-locale-catalog.mjs --locale ko` both on this branch and on a clean `main` tree (with only the override-layer changes applied) and diffed the two resulting catalogs: **0 keys differ**, i.e. the override layer alone reproduces exactly the five values this PR writes into `ko.json`. All five are fixpoints of `repairTranslatedValue`.

Worth flagging honestly: that repair run also reports ~96 *unrelated* pre-existing leaf updates on `main` (phrase-fix rounds landed after the last catalog regeneration — e.g. `fast-forward할` → `fast-forward 할`, `재시도` → `다시 시도`). I deliberately did **not** include them; this PR's `ko.json` diff is exactly the five lines. That backlog is a separate regeneration PR.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

**Cross-platform.** No code path is touched — a bundled JSON catalog plus one build-time constant map, consumed identically on macOS/Linux/Windows. No `metaKey`, no path separators, no shell invocation. The one platform-specific *string* (the macOS caveat) lives in a pane gated by `showDesktopOnlySettings && isMac`, and `useSettingsNavigationMetadata.test.ts` already asserts `developer-permissions` is absent when `isMac: false`, so non-Mac readers never see it.

**SSH / remote execution.** String #3 is the SSH-config import toast. The correction moves it from "synced" back to "added … to Orca", which is the accurate scope: it describes a *local registration* of host entries, not contact with any host. It makes no reachability claim, so it does not touch the `live` / `unverifiable` / `exited` verdict vocabulary in `docs/reference/ssh-execution-boundary.md`. The old wording implying a completed sync was the defect.

**Remote wire compatibility.** None. i18n keys and catalogs are bundled client-side and never cross the RPC/stream boundary — no new opcode, no field, and nothing the host publishes changes. I checked `hosted-review-localized-copy.ts`, the one place localized copy is composed near a remote concept; none of the five keys appears there. A mixed-version client/host pair is unaffected.

**Agent / integration compatibility.** The approval labels are option labels rendered in the native-chat card only; the underlying option *values* are unchanged, so nothing an agent or integration keys off is affected. Provider-neutral throughout — none of the five strings mentions GitHub, GitLab, or any provider.

**Folder workspaces.** Not implicated; no workspace-shape assumption in any of the five strings.

**Performance.** +2 keyword entries against a 1,673-entry map and +4 override entries against a 12k-entry catalog, all object-keyed lookups at build time. Negligible.

**Backward compatibility of persisted state.** Catalogs are bundled at build time, not persisted. The only user-visible carry-over is the settings-search query noted under Visual Proof.

**Mobile.** No Korean catalog exists under `mobile/`, so there is nothing to mirror. No `max-lines` pressure and no `.oxlintrc.json` change.

**UI quality.** No layout, token, component, or spacing change — `docs/STYLEGUIDE.md` is not engaged. The button labels move from verb infinitives to the noun form the rest of the catalog and every sibling locale already use.

**Security.** No input handling, command execution, path handling, auth, secrets, dependency, or IPC change. Static string literals in a version-controlled catalog. No new user-controlled data path.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Out of scope, worth follow-up issues (deliberately not folded in here, since #14139 is scoped to the Korean catalog):

- The same two semantic defects exist in sibling locales: `sshImportSynced` says "synced" in `ja` (同期しました), `zh` (已同步), and `es` (Se sincronizó); and `unfreeze` is the thaw-ice sense in `ja` (解凍する), `zh` (解冻), and `es` (descongelar). Same root cause (unpinned MT), same remedy shape via each locale's override layer.
- The ~96 pending phrase-fix leaf updates in `ko.json` described under Testing.
- The reporter offers a "round 6" pass for ~37 remaining `검토`→`리뷰` keys the `whenEnIncludes` gates missed — that is a regex-shaped change and should stay separate from this string-only fix.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
