### PR TITLE
fix(rate-limits): stop showing Gemini failures as Antigravity "Refresh failed"

### DIFF
--- a/src/main/rate-limits/antigravity-usage-mirror.test.ts
+++ b/src/main/rate-limits/antigravity-usage-mirror.test.ts
@@ -43,13 +43,21 @@ describe('deriveAntigravityRateLimits', () => {
     expect(antigravity.weekly).toBeNull()
   })
 
+  it('does not blame a missing sign-in when the quota read itself failed', () => {
+    const antigravity = deriveAntigravityRateLimits(geminiSnapshot('error', 'Token refresh failed'))
+
+    // Why: the reported symptom is a connected sign-in whose Code Assist read failed.
+    expect(antigravity.error).toContain('could not be read right now')
+    expect(antigravity.error).not.toContain('sign-in is connected')
+  })
+
   it('keeps the Gemini timestamp so activation freshness checks are not forced to refetch', () => {
     const antigravity = deriveAntigravityRateLimits(geminiSnapshot('error', 'Token refresh failed'))
 
     expect(antigravity.updatedAt).toBe(1_700_000_000_000)
   })
 
-  it('uses the same Antigravity copy when the Gemini opt-in is off', () => {
+  it('points at the missing sign-in when the Gemini opt-in is off', () => {
     const antigravity = deriveAntigravityRateLimits(
       geminiSnapshot('unavailable', 'Gemini CLI OAuth is disabled in settings')
     )
@@ -57,5 +65,6 @@ describe('deriveAntigravityRateLimits', () => {
     expect(antigravity.status).toBe('unavailable')
     expect(antigravity.error).not.toContain('Gemini CLI OAuth is disabled in settings')
     expect(antigravity.error).toContain('Antigravity usage is not available')
+    expect(antigravity.error).toContain('Gemini CLI sign-in is connected')
   })
 })

--- a/src/main/rate-limits/antigravity-usage-mirror.test.ts
+++ b/src/main/rate-limits/antigravity-usage-mirror.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import type { ProviderRateLimits, ProviderRateLimitStatus } from '../../shared/rate-limit-types'
+import { deriveAntigravityRateLimits } from './antigravity-usage-mirror'
+
+function geminiSnapshot(
+  status: ProviderRateLimitStatus,
+  error: string | null,
+  usedPercent: number | null = null
+): ProviderRateLimits {
+  return {
+    provider: 'gemini',
+    session:
+      usedPercent === null
+        ? null
+        : { usedPercent, windowMinutes: 300, resetsAt: null, resetDescription: null },
+    weekly: null,
+    updatedAt: 1_700_000_000_000,
+    error,
+    status
+  }
+}
+
+describe('deriveAntigravityRateLimits', () => {
+  it('mirrors a successful Gemini read as shared Code Assist quota', () => {
+    const antigravity = deriveAntigravityRateLimits(geminiSnapshot('ok', null, 42))
+
+    expect(antigravity.provider).toBe('antigravity')
+    expect(antigravity.status).toBe('ok')
+    expect(antigravity.session?.usedPercent).toBe(42)
+    expect(antigravity.error).toBeNull()
+  })
+
+  it('reports unavailable without quoting the Gemini failure', () => {
+    const antigravity = deriveAntigravityRateLimits(
+      geminiSnapshot('error', 'Gemini project ID not found')
+    )
+
+    expect(antigravity.provider).toBe('antigravity')
+    expect(antigravity.status).toBe('unavailable')
+    expect(antigravity.error).not.toContain('Gemini project ID not found')
+    expect(antigravity.error).toContain('Antigravity usage is not available')
+    expect(antigravity.session).toBeNull()
+    expect(antigravity.weekly).toBeNull()
+  })
+
+  it('keeps the Gemini timestamp so activation freshness checks are not forced to refetch', () => {
+    const antigravity = deriveAntigravityRateLimits(geminiSnapshot('error', 'Token refresh failed'))
+
+    expect(antigravity.updatedAt).toBe(1_700_000_000_000)
+  })
+
+  it('uses the same Antigravity copy when the Gemini opt-in is off', () => {
+    const antigravity = deriveAntigravityRateLimits(
+      geminiSnapshot('unavailable', 'Gemini CLI OAuth is disabled in settings')
+    )
+
+    expect(antigravity.status).toBe('unavailable')
+    expect(antigravity.error).not.toContain('Gemini CLI OAuth is disabled in settings')
+    expect(antigravity.error).toContain('Antigravity usage is not available')
+  })
+})

--- a/src/main/rate-limits/antigravity-usage-mirror.ts
+++ b/src/main/rate-limits/antigravity-usage-mirror.ts
@@ -4,8 +4,11 @@ import type { ProviderRateLimits } from '../../shared/rate-limit-types'
 // fetcher reads, so Orca never actually queries Antigravity. Only a *successful* Gemini read
 // describes shared Google Code Assist quota; republishing a Gemini failure under the
 // Antigravity provider id surfaced "Refresh failed" for a request that was never attempted.
-const ANTIGRAVITY_UNAVAILABLE_REASON =
+const ANTIGRAVITY_NO_SIGN_IN_REASON =
   'Antigravity usage is not available. Orca can only show shared Google Code Assist quota while a Gemini CLI sign-in is connected.'
+// Why: a Gemini `error` means the sign-in exists and the quota read failed, so blaming a missing sign-in would misdirect the user.
+const ANTIGRAVITY_QUOTA_UNREADABLE_REASON =
+  'Antigravity usage is not available. Orca reads it from the shared Google Code Assist quota, which could not be read right now.'
 
 export function deriveAntigravityRateLimits(gemini: ProviderRateLimits): ProviderRateLimits {
   if (gemini.status === 'ok') {
@@ -17,7 +20,10 @@ export function deriveAntigravityRateLimits(gemini: ProviderRateLimits): Provide
     weekly: null,
     // Why: reuse the Gemini timestamp so activation freshness checks don't force a refetch every cycle.
     updatedAt: gemini.updatedAt,
-    error: ANTIGRAVITY_UNAVAILABLE_REASON,
+    error:
+      gemini.status === 'unavailable'
+        ? ANTIGRAVITY_NO_SIGN_IN_REASON
+        : ANTIGRAVITY_QUOTA_UNREADABLE_REASON,
     status: 'unavailable'
   }
 }

--- a/src/main/rate-limits/antigravity-usage-mirror.ts
+++ b/src/main/rate-limits/antigravity-usage-mirror.ts
@@ -1,0 +1,23 @@
+import type { ProviderRateLimits } from '../../shared/rate-limit-types'
+
+// Why: the Antigravity CLI keeps its token in the OS keyring, not in the files the Gemini
+// fetcher reads, so Orca never actually queries Antigravity. Only a *successful* Gemini read
+// describes shared Google Code Assist quota; republishing a Gemini failure under the
+// Antigravity provider id surfaced "Refresh failed" for a request that was never attempted.
+const ANTIGRAVITY_UNAVAILABLE_REASON =
+  'Antigravity usage is not available. Orca can only show shared Google Code Assist quota while a Gemini CLI sign-in is connected.'
+
+export function deriveAntigravityRateLimits(gemini: ProviderRateLimits): ProviderRateLimits {
+  if (gemini.status === 'ok') {
+    return { ...gemini, provider: 'antigravity' }
+  }
+  return {
+    provider: 'antigravity',
+    session: null,
+    weekly: null,
+    // Why: reuse the Gemini timestamp so activation freshness checks don't force a refetch every cycle.
+    updatedAt: gemini.updatedAt,
+    error: ANTIGRAVITY_UNAVAILABLE_REASON,
+    status: 'unavailable'
+  }
+}

--- a/src/main/rate-limits/service-antigravity-usage.test.ts
+++ b/src/main/rate-limits/service-antigravity-usage.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { RateLimitService } from './service'
+import { fetchClaudeRateLimits } from './claude-fetcher'
+import { fetchCodexRateLimits } from './codex-fetcher'
+import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
+import {
+  errorProvider,
+  okProvider,
+  resetRateLimitProviderMocks
+} from './rate-limit-service-test-harness'
+
+vi.mock('./claude-fetcher', () => ({
+  fetchClaudeRateLimits: vi.fn(),
+  fetchManagedAccountUsage: vi.fn()
+}))
+
+vi.mock('./codex-fetcher', () => ({
+  consumeCodexRateLimitResetCredit: vi.fn(),
+  fetchCodexRateLimits: vi.fn()
+}))
+
+vi.mock('./gemini-usage-fetcher', () => ({
+  fetchGeminiRateLimits: vi.fn()
+}))
+
+vi.mock('./kimi-fetcher', () => ({
+  fetchKimiRateLimits: vi.fn()
+}))
+
+vi.mock('./opencode-go-usage-fetcher', () => ({
+  fetchOpenCodeGoRateLimits: vi.fn()
+}))
+
+vi.mock('./minimax-fetcher', () => ({
+  fetchMiniMaxRateLimits: vi.fn()
+}))
+
+vi.mock('./grok-fetcher', () => ({
+  fetchGrokRateLimits: vi.fn()
+}))
+
+vi.mock('./grok-auth', () => ({
+  readGrokAuthSession: vi.fn(() => ({ status: 'missing' }))
+}))
+
+vi.mock('../minimax/minimax-cookie-store', () => ({
+  hasMiniMaxSessionCookie: vi.fn(() => false)
+}))
+
+describe('RateLimitService Antigravity usage', () => {
+  beforeEach(() => {
+    resetRateLimitProviderMocks()
+    vi.mocked(fetchClaudeRateLimits).mockResolvedValue(okProvider('claude', 7))
+    vi.mocked(fetchCodexRateLimits).mockResolvedValue(okProvider('codex', 20))
+  })
+
+  it('does not republish a Gemini failure as an Antigravity refresh failure', async () => {
+    vi.mocked(fetchGeminiRateLimits).mockResolvedValue(
+      errorProvider('gemini', 'Gemini project ID not found')
+    )
+    const service = new RateLimitService()
+
+    await service.refresh()
+
+    const state = service.getState()
+    expect(state.antigravity?.status).toBe('unavailable')
+    expect(state.antigravity?.error).not.toContain('Gemini project ID not found')
+    expect(state.antigravity?.session).toBeNull()
+    // Why: the real Gemini failure must still surface under its own provider.
+    expect(state.gemini?.status).toBe('error')
+    expect(state.gemini?.error).toBe('Gemini project ID not found')
+  })
+
+  it('keeps mirroring a successful Gemini read under the Antigravity provider', async () => {
+    vi.mocked(fetchGeminiRateLimits).mockResolvedValue(okProvider('gemini', 42, Date.now()))
+    const service = new RateLimitService()
+
+    await service.refresh()
+
+    const state = service.getState()
+    expect(state.antigravity?.status).toBe('ok')
+    expect(state.antigravity?.provider).toBe('antigravity')
+    expect(state.antigravity?.session?.usedPercent).toBe(42)
+  })
+
+  it('never leaves a cached Antigravity snapshot in the error retry lane', async () => {
+    vi.mocked(fetchGeminiRateLimits).mockResolvedValueOnce(okProvider('gemini', 42, Date.now()))
+    const service = new RateLimitService()
+    await service.refresh()
+
+    vi.mocked(fetchGeminiRateLimits).mockResolvedValue(
+      errorProvider('gemini', 'Token refresh failed')
+    )
+    await service.refresh()
+
+    // Why: stale-retention would otherwise show Gemini numbers as "Refresh failed" Antigravity usage.
+    expect(service.getState().antigravity?.status).toBe('unavailable')
+    expect(service.getState().antigravity?.session).toBeNull()
+  })
+})

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -20,6 +20,7 @@ import {
   type NormalizedClaudeAccountSelectionTarget
 } from '../claude-accounts/runtime-selection'
 import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
+import { deriveAntigravityRateLimits } from './antigravity-usage-mirror'
 import { fetchKimiRateLimits } from './kimi-fetcher'
 import type { KimiHomeResolution } from '../kimi/kimi-runtime-home'
 import { fetchGrokRateLimits } from './grok-fetcher'
@@ -1766,11 +1767,8 @@ export class RateLimitService {
             status: 'error'
           } satisfies ProviderRateLimits)
 
-    // Why: Antigravity shares Gemini credentials today; mirror the Gemini snapshot so its status-bar UI gets a real lifecycle instead of null.
-    const antigravity: ProviderRateLimits = {
-      ...gemini,
-      provider: 'antigravity'
-    }
+    // Why: Antigravity can only borrow a *successful* Gemini read; a Gemini failure is not an Antigravity failure.
+    const antigravity = deriveAntigravityRateLimits(gemini)
 
     const opencodeGo =
       opencodeGoResult.status === 'fulfilled'


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​170 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​170 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​32 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​27 |

<!-- /orca-pr-loc -->

## ELI5

The Antigravity chip in the status bar was showing a red "Refresh failed" for a request Orca never made. Orca doesn't actually talk to Antigravity at all — it was quietly copying whatever the Gemini usage fetch returned and relabelling it as Antigravity. So when a user's Gemini sign-in was broken, Antigravity "failed" too. Now Orca only borrows Gemini's numbers when they actually arrived; otherwise the chip says, honestly, that Antigravity usage isn't available.

## What Changed

- New `src/main/rate-limits/antigravity-usage-mirror.ts` with `deriveAntigravityRateLimits(gemini)`: mirrors the Gemini snapshot only when `gemini.status === 'ok'`, otherwise returns `status: 'unavailable'` with Antigravity-specific copy and no borrowed Gemini error text. The copy branches on the Gemini status so it does not misattribute the cause: a Gemini `unavailable` (opt-in off, or no credentials on disk) says a Gemini CLI sign-in must be connected, while a Gemini `error` (token refresh failed, project ID not found — the reported case, where the sign-in *does* exist) says the shared Code Assist quota could not be read right now. It reuses `gemini.updatedAt` so the window-activation freshness check isn't forced into a refetch every cycle.
- `src/main/rate-limits/service.ts`: replaced the `{ ...gemini, provider: 'antigravity' }` spread in `runFetchAllCycle` with a call to that function (net -5/+3 lines). The `trackActiveFailureStreak` and `applyStalePolicy` calls are untouched — both already behave correctly for an ok-or-unavailable snapshot (`applyStalePolicy` passes `unavailable` through verbatim).
- Two new test files: a pure unit test for the derivation and a service-level regression test that reproduces the reported symptom.

No renderer change. The `unavailable` rendering path already exists and is covered: `StatusBar.tsx:1288` renders a muted `--` chip, `tooltip.tsx:269` renders the reason as muted text, `usage-roster-row-state.ts:61` labels the row "Usage unavailable".

## Why

Root cause is not a missing fetcher registration (as the issue guessed) — it's a fake one. `runFetchAllCycle` never fetched Antigravity; it spread the *Gemini* result and relabelled it, so Gemini's `status: 'error'` and Gemini's raw error string ("Token refresh failed", "Gemini project ID not found") were republished under the Antigravity provider id. The renderer has no way to distinguish that from a real failure, so `getProviderUsageStatusLabel` fell through to "Refresh failed" (KO: "새로 고침 실패") — the exact reported symptom. The inverse was wrong too: a successful Gemini read was presented as Antigravity usage even for a different Google account.

I chose the honest `unavailable` state over building a real Antigravity fetcher, deliberately:

- `fetchGeminiRateLimits` reads only `~/.gemini/oauth_creds.json` and OpenCode's `auth.json` (`gemini-oauth-sources.ts:8,29-52`). The Antigravity CLI (`agy`) writes neither. On a machine with the Antigravity CLI installed and signed in, `~/.gemini/oauth_creds.json` does not exist and `~/.gemini/google_accounts.json` is `{"active": null}`; the CLI's own logs show `ChainedAuth: authenticated via keyring`, and the credential is an OS keyring item (service `gemini`, account `antigravity`).
- A real fetcher would need a new cross-platform keyring dependency, reading another application's credential item (macOS prompts for access), a Code Assist host Orca has never called, and an OAuth refresh Orca cannot perform (no Antigravity client secret; the keyring token is short-lived and refreshed by the CLI itself). That's a feature, not a bug fix — and it collides with the SSH execution boundary, since those credentials live on the execution host, not the client. `gemini-usage-fetcher.ts:207-210` already encodes exactly this caution for Gemini's own opt-in.
- `unavailable` is already the codebase's word for this state, so no new vocabulary or wire surface is introduced.

No fetch-cadence change: Antigravity does drop out of `getActiveWindowRefreshPlan`'s retryable-failure list, but `gemini` itself is still there and is likewise absent from `INDIVIDUALLY_REFRESHABLE_PROVIDERS`, so the plan still falls through `canRefreshIndividually === false` to a full `fetchAll()`. (An earlier draft of this description claimed a refresh-cadence win; it was wrong and has been corrected.)

## Linked Issue

Fixes #14227

## Visual Proof

`N/A` — no renderer code changed. The visible difference is produced entirely by the already-shipped `unavailable` branch. A reviewer can confirm by reading the two existing render paths: with a failing Gemini sign-in the Antigravity chip previously took the error branch (`StatusBar.tsx:1297`, warning styling, "Refresh failed" in the tooltip) and now takes the unavailable branch (`StatusBar.tsx:1288`, muted `--` chip; tooltip shows the Antigravity reason sentence). Reproducing this live requires a Google account with no usable Code Assist project, which I could not stage.

## Testing

Commands run (macOS 15, arm64):

```
npx vitest run --config config/vitest.config.ts \
  src/main/rate-limits/antigravity-usage-mirror.test.ts \
  src/main/rate-limits/service-antigravity-usage.test.ts
# 2 files, 8 tests passed

npx vitest run --config config/vitest.config.ts \
  src/main/rate-limits/service-refresh-orchestration.test.ts \
  src/main/rate-limits/service-minimax-usage.test.ts \
  src/main/rate-limits/service-account-target-selection.test.ts \
  src/main/rate-limits/service-inactive-account-previews.test.ts \
  src/main/rate-limits/service-live-claude-usage.test.ts \
  src/main/rate-limits/service-window-activation.test.ts
# all passed (30 and 58 tests across the two runs)

npx vitest run --config config/vitest.config.ts \
  src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts \
  src/renderer/src/components/status-bar/usage-error-copy.test.ts \
  src/renderer/src/components/status-bar/tooltip.test.ts \
  src/renderer/src/components/status-bar/usage-roster-row-state.test.ts
# 4 files, 80 tests passed

npx vitest run --config config/vitest.config.ts src/main/rate-limits/
# 40 files, 431 tests passed

npx vitest run --config config/vitest.config.ts src/renderer/src/components/status-bar/
# 42 files, 284 tests passed

npx oxlint <the 4 changed files>                                                                   # clean
npx oxlint --config config/oxlint-code-quality-native-plugins.json <the 4 changed files> --deny-warnings  # clean
npx oxfmt --check <the 4 changed files>                                                            # clean
```

Regression proof (mirror vs. `service.ts`): I stashed only `service.ts` (leaving the new tests and the new module in place) and re-ran `service-antigravity-usage.test.ts` — 2 of 3 tests failed with `expected 'error' to be 'unavailable'`, and the mirrored-ok test still passed, confirming the happy path is unchanged. Restoring `service.ts` made all 3 pass.

Regression proof (cause-specific copy): I collapsed the `gemini.status === 'unavailable' ? ... : ...` ternary in `antigravity-usage-mirror.ts` back to the single sign-in sentence and re-ran the unit test — `does not blame a missing sign-in when the quota read itself failed` failed with `expected 'Antigravity usage is not available. O…' to contain 'could not be read right now'`. Restoring the branch made all 5 pass.

Platforms: tests executed on **macOS only**. Linux and Windows are covered by reasoning — the change is a pure function over an already-fetched snapshot, with no filesystem paths, no shell, no process spawn, and no platform branches. SSH/remote is covered by reasoning; no execution-host contact is added or removed.

I did not run `pnpm typecheck` / `pnpm lint` locally (they OOM in this environment); CI covers them.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Cross-platform**: no paths, no keyboard accelerators, no shell, no platform branches. Strictly less platform-specific than the alternative — a keyring-reading fetcher would have needed Keychain / libsecret / wincred backends.
- **SSH / remote execution boundary**: no execution, no process spawn, no host contact added or removed; loss-of-contact vocabulary untouched. A real Antigravity fetcher would have read execution-host credentials, which is what the boundary forbids.
- **Remote wire compatibility**: no new field, no new enum member, no new stream opcode. `'unavailable'` is already in the shipped `ProviderRateLimitStatus` union (`src/shared/rate-limit-types.ts:12`) and in the mobile zod schema (`mobile/src/components/accounts-snapshot.ts:54`). This is the "changing what the host publishes reaches old clients even with no wire change" case from `docs/reference/remote-wire-compatibility.md`, and it is safe because old clients already render `unavailable` as a muted not-configured chip. No capability negotiation needed.
- **Agent / integration compatibility**: no agent, CLI, or provider integration touched. Nothing persisted changes; the `antigravity` status-bar toggle and `_antigravityStatusBarDefaultAdded` keep their meaning. Users who currently see numbers keep seeing them.
- **Folder workspaces vs worktrees**: rate limits are global/per-account, not workspace-scoped — unaffected.
- **Performance**: neutral. The derivation is a pure function over an already-fetched snapshot; no extra fetch, and no change to the window-activation refresh cadence (see Why above).
- **UI quality**: no renderer edits; the change routes into an existing, already-styled state. The chip goes from a false warning to a muted `--` with an explanation.
- **Security**: net reduction in surface — the change removes a code path that published one provider's credential-failure text under another provider's identity, and deliberately avoids adding any credential read. No new dependency, no network sink, no shell/eval. Note that the issue's "Proposed Solution" points at `out/main/index.js`, a build artifact; the fix belongs in `src/main/rate-limits/`.

## Known limitations / follow-ups

Deliberately out of scope:

1. `hasUsageProviderSettingsForProvider` (`status-bar-provider-visibility.ts:107`) still requires `antigravityUsageConfigured && geminiCliOAuthEnabled`, while the "Antigravity Usage" toggle is offered whenever `agy` is on PATH. A user with Antigravity installed and Gemini CLI OAuth off gets no chip at all. Relaxing that gate also means adding the term to `hasUsageProviderSettings`, which would suppress the setup CTA for Antigravity-only users — a deliberate UX call, not a drive-by. The reported symptom requires `geminiCliOAuthEnabled` on, so this fix is complete for the reported case.
2. **The reason sentence is not localized.** It is emitted from main in English (same as `'Gemini CLI OAuth is disabled in settings'` and the MiniMax credential-error path) and rendered raw by `tooltip.tsx:269`, so the detail line stays untranslated on a Korean UI even though the label localizes correctly. Fixing that properly means a provider-keyed unavailable message in `usage-error-copy.ts` driven by `failureKind`, applied to Gemini and MiniMax at the same time — not an Antigravity one-off. Reviewer-flagged and knowingly accepted here: the label above the sentence (`Usage unavailable`) does localize, so a non-English UI still gets a correct status, just an English detail line — the same gap the shipped Gemini and MiniMax unavailable strings already have.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security, cross-platform support, remote SSH, mobile, backwards compatibility, and performance are all addressed in Review above. Mobile needs no edit: the schema already permits `unavailable` and the accounts view treats it as no active usage.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

