### PR TITLE
fix(github): keep pasted issue images off Windows gh argv (#15832)

### DIFF
--- a/src/main/github/gh-api-json-input.test.ts
+++ b/src/main/github/gh-api-json-input.test.ts
@@ -1,0 +1,39 @@
+import { readFile, stat } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { withGhApiJsonInput } from './gh-api-json-input'
+
+describe('withGhApiJsonInput', () => {
+  it('writes the payload to a temp JSON file and passes --input', async () => {
+    let inputPath = ''
+    const result = await withGhApiJsonInput(
+      { title: 'Bug', body: 'hello\nworld', labels: ['bug'] },
+      async (inputArgs) => {
+        expect(inputArgs[0]).toBe('--input')
+        expect(inputArgs[1]).not.toBe('-')
+        inputPath = inputArgs[1]
+        expect(JSON.parse(await readFile(inputPath, 'utf8'))).toEqual({
+          title: 'Bug',
+          body: 'hello\nworld',
+          labels: ['bug']
+        })
+        return 42
+      }
+    )
+    expect(result).toBe(42)
+    await expect(readFile(inputPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    await expect(stat(dirname(inputPath))).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('deletes the temp JSON file when run throws', async () => {
+    let inputPath = ''
+    await expect(
+      withGhApiJsonInput({ body: 'payload' }, async (inputArgs) => {
+        inputPath = inputArgs[1]
+        expect(JSON.parse(await readFile(inputPath, 'utf8'))).toEqual({ body: 'payload' })
+        throw new Error('gh failed')
+      })
+    ).rejects.toThrow('gh failed')
+    await expect(readFile(inputPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+})

--- a/src/main/github/gh-api-json-input.ts
+++ b/src/main/github/gh-api-json-input.ts
@@ -1,0 +1,26 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+export type GhApiJsonInputArgs = readonly ['--input', string]
+
+/**
+ * Send a `gh api` request body from a temp JSON file via `--input`.
+ *
+ * Why: `--raw-field body=` puts the payload on argv, which exceeds Windows
+ * CreateProcess 32767 (ENAMETOOLONG) for pasted screenshot data-URIs.
+ * `ghExecFileAsync` does not forward stdin, so `--input -` cannot be used.
+ */
+export async function withGhApiJsonInput<T>(
+  payload: Record<string, unknown>,
+  run: (inputArgs: GhApiJsonInputArgs) => Promise<T>
+): Promise<T> {
+  const tempDir = await mkdtemp(join(tmpdir(), 'orca-gh-api-json-'))
+  const inputPath = join(tempDir, 'input.json')
+  try {
+    await writeFile(inputPath, JSON.stringify(payload), 'utf8')
+    return await run(['--input', inputPath])
+  } finally {
+    await rm(tempDir, { recursive: true, force: true }).catch(() => undefined)
+  }
+}

--- a/src/main/github/issue-comment.ts
+++ b/src/main/github/issue-comment.ts
@@ -1,5 +1,6 @@
 import type { GitHubCommentResult, PRComment } from '../../shared/github/comment-types'
 import type { LocalGitExecOptions, OwnerRepo } from './gh-utils'
+import { withGhApiJsonInput } from './gh-api-json-input'
 import { getIssueGitHubApiRepository, resolveGitHubRepoExecution } from './github-api-repository'
 import { acquire, classifyGhError, ghExecFileAsync, release } from './gh-utils'
 
@@ -35,16 +36,17 @@ export async function addIssueComment(
   }
   await acquire()
   try {
-    const { stdout } = await ghExecFileAsync(
-      [
-        'api',
-        '-X',
-        'POST',
-        `repos/${ownerRepo.owner}/${ownerRepo.repo}/issues/${issueNumber}/comments`,
-        '--raw-field',
-        `body=${body}`
-      ],
-      ghOptions
+    const { stdout } = await withGhApiJsonInput({ body }, (inputArgs) =>
+      ghExecFileAsync(
+        [
+          'api',
+          '-X',
+          'POST',
+          `repos/${ownerRepo.owner}/${ownerRepo.repo}/issues/${issueNumber}/comments`,
+          ...inputArgs
+        ],
+        ghOptions
+      )
     )
     const data = JSON.parse(stdout) as {
       id?: number

--- a/src/main/github/issue-create.ts
+++ b/src/main/github/issue-create.ts
@@ -4,6 +4,7 @@ import type {
 } from '../../shared/issue-mutation-types'
 import type { IssueSourcePreference } from '../../shared/repo-types'
 import type { LocalGitExecOptions } from './gh-utils'
+import { withGhApiJsonInput } from './gh-api-json-input'
 import {
   resolveGitHubRepoExecution,
   resolveIssueGitHubApiRepositorySource
@@ -13,6 +14,19 @@ import { acquire, extractExecError, ghExecFileAsync, release } from './gh-utils'
 function githubIssueErrorMessage(error: unknown): string {
   const { stderr, stdout } = extractExecError(error)
   return stderr.trim() || stdout.trim()
+}
+
+function isRecoverableOversizedIssueBodyError(error: unknown): boolean {
+  const message = githubIssueErrorMessage(error)
+  if (/body is too long \(maximum is \d+ characters\)/i.test(message)) {
+    return true
+  }
+  // Why: Windows CreateProcess rejects argv over 32767 before gh can return 422.
+  const code =
+    typeof error === 'object' && error !== null && 'code' in error
+      ? (error as { code?: unknown }).code
+      : undefined
+  return code === 'ENAMETOOLONG' || /ENAMETOOLONG/i.test(message)
 }
 
 /**
@@ -52,58 +66,59 @@ export async function createIssue(
   }
   await acquire()
   try {
-    const createArgs = (issueBody: string) => {
-      const args = [
-        'api',
-        '-X',
-        'POST',
-        `repos/${ownerRepo.owner}/${ownerRepo.repo}/issues`,
-        '--raw-field',
-        `title=${trimmedTitle}`,
-        '--raw-field',
-        `body=${issueBody}`
-      ]
-      for (const label of fields?.labels ?? []) {
-        args.push('--raw-field', `labels[]=${label}`)
-      }
-      for (const assignee of fields?.assignees ?? []) {
-        args.push('--raw-field', `assignees[]=${assignee}`)
-      }
-      return args
-    }
+    const postIssue = (issueBody: string) =>
+      withGhApiJsonInput(
+        {
+          title: trimmedTitle,
+          body: issueBody,
+          ...(fields?.labels?.length ? { labels: fields.labels } : {}),
+          ...(fields?.assignees?.length ? { assignees: fields.assignees } : {})
+        },
+        (inputArgs) =>
+          ghExecFileAsync(
+            [
+              'api',
+              '-X',
+              'POST',
+              `repos/${ownerRepo.owner}/${ownerRepo.repo}/issues`,
+              ...inputArgs
+            ],
+            ghOptions
+          )
+      )
 
     const parseIssue = (stdout: string) =>
       JSON.parse(stdout) as { number?: number; html_url?: string; url?: string }
 
     let data: { number?: number; html_url?: string; url?: string }
     try {
-      const { stdout } = await ghExecFileAsync(createArgs(body), ghOptions)
+      const { stdout } = await postIssue(body)
       data = parseIssue(stdout)
     } catch (err) {
-      const message = githubIssueErrorMessage(err)
-      if (!/body is too long \(maximum is \d+ characters\)/i.test(message)) {
-        return { ok: false, error: message }
+      if (!isRecoverableOversizedIssueBodyError(err)) {
+        return { ok: false, error: githubIssueErrorMessage(err) }
       }
 
       // Why: GitHub rejects oversized bodies on create but accepts the same body
       // on update, so establish the issue before attaching its body.
-      const { stdout } = await ghExecFileAsync(createArgs(''), ghOptions)
+      const { stdout } = await postIssue('')
       data = parseIssue(stdout)
       if (typeof data.number !== 'number') {
         return { ok: false, error: 'Unexpected response from GitHub' }
       }
 
       try {
-        await ghExecFileAsync(
-          [
-            'api',
-            '-X',
-            'PATCH',
-            `repos/${ownerRepo.owner}/${ownerRepo.repo}/issues/${data.number}`,
-            '--raw-field',
-            `body=${body}`
-          ],
-          ghOptions
+        await withGhApiJsonInput({ body }, (inputArgs) =>
+          ghExecFileAsync(
+            [
+              'api',
+              '-X',
+              'PATCH',
+              `repos/${ownerRepo.owner}/${ownerRepo.repo}/issues/${data.number}`,
+              ...inputArgs
+            ],
+            ghOptions
+          )
         )
       } catch (patchErr) {
         const patchMessage = githubIssueErrorMessage(patchErr)

--- a/src/main/github/issue-update.ts
+++ b/src/main/github/issue-update.ts
@@ -1,5 +1,6 @@
 import type { GitHubIssueUpdate } from '../../shared/issue-mutation-types'
 import type { LocalGitExecOptions } from './gh-utils'
+import { withGhApiJsonInput } from './gh-api-json-input'
 import { getIssueGitHubApiRepository, resolveGitHubRepoExecution } from './github-api-repository'
 import { acquire, classifyGhError, ghExecFileAsync, release } from './gh-utils'
 
@@ -67,16 +68,17 @@ export async function updateIssue(
   if (updates.body !== undefined) {
     await acquire()
     try {
-      await ghExecFileAsync(
-        [
-          'api',
-          '-X',
-          'PATCH',
-          `repos/${ownerRepo.owner}/${ownerRepo.repo}/issues/${issueNumber}`,
-          '--raw-field',
-          `body=${updates.body}`
-        ],
-        ghOptions
+      await withGhApiJsonInput({ body: updates.body }, (inputArgs) =>
+        ghExecFileAsync(
+          [
+            'api',
+            '-X',
+            'PATCH',
+            `repos/${ownerRepo.owner}/${ownerRepo.repo}/issues/${issueNumber}`,
+            ...inputArgs
+          ],
+          ghOptions
+        )
       )
     } catch (err) {
       const stderr = err instanceof Error ? err.message : String(err)

--- a/src/main/github/issues.test.ts
+++ b/src/main/github/issues.test.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as GithubApiRepositoryModule from './github-api-repository'
 import type * as GithubEnterpriseRepositoryModule from './github-enterprise-repository'
@@ -75,6 +76,44 @@ import { addIssueComment } from './issue-comment'
 import { listAssignableUsers, listLabels } from './issue-field-options'
 
 import { _resetOriginGitHubApiRepositoryCache } from './github-api-repository'
+
+function expectNoRawBodyField(args: unknown): asserts args is string[] {
+  expect(Array.isArray(args)).toBe(true)
+  const list = args as string[]
+  for (let i = 0; i < list.length; i++) {
+    expect(list[i]).not.toMatch(/^body=/)
+    if (
+      list[i] === '--raw-field' ||
+      list[i] === '-f' ||
+      list[i] === '--field' ||
+      list[i] === '-F'
+    ) {
+      expect(list[i + 1]).not.toMatch(/^body=/)
+    }
+  }
+}
+
+type GhQueuedResult = { stdout: string } | { throw: unknown }
+
+function mockGhExecQueue(results: GhQueuedResult[]): unknown[] {
+  const payloads: unknown[] = []
+  let index = 0
+  ghExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+    expectNoRawBodyField(args)
+    const inputIndex = args.indexOf('--input')
+    expect(inputIndex).toBeGreaterThanOrEqual(0)
+    payloads.push(JSON.parse(await readFile(args[inputIndex + 1]!, 'utf8')))
+    const result = results[index++]
+    if (!result) {
+      throw new Error(`Unexpected extra gh call (${index})`)
+    }
+    if ('throw' in result) {
+      throw result.throw
+    }
+    return { stdout: result.stdout }
+  })
+  return payloads
+}
 
 // The origin-repository cache is module-level state; reset it so slugs
 // resolved by one test cannot leak into the next.
@@ -188,16 +227,18 @@ describe('issue source operations', () => {
   })
 
   it('routes PR conversation comments to the supplied Enterprise host', async () => {
-    ghExecFileAsyncMock.mockResolvedValueOnce({
-      stdout: JSON.stringify({
-        id: 9,
-        node_id: 'IC_enterprise_9',
-        user: { login: 'octo', avatar_url: '', type: 'User' },
-        body: 'Enterprise comment',
-        created_at: '2026-07-16T00:00:00.000Z',
-        html_url: 'https://github.acme-corp.com/team/orca/pull/7#issuecomment-9'
-      })
-    })
+    const payloads = mockGhExecQueue([
+      {
+        stdout: JSON.stringify({
+          id: 9,
+          node_id: 'IC_enterprise_9',
+          user: { login: 'octo', avatar_url: '', type: 'User' },
+          body: 'Enterprise comment',
+          created_at: '2026-07-16T00:00:00.000Z',
+          html_url: 'https://github.acme-corp.com/team/orca/pull/7#issuecomment-9'
+        })
+      }
+    ])
 
     await expect(
       addIssueComment('/remote/repo', 7, 'Enterprise comment', 'ssh-1', {
@@ -211,16 +252,10 @@ describe('issue source operations', () => {
     })
 
     expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
-      [
-        'api',
-        '-X',
-        'POST',
-        'repos/team/orca/issues/7/comments',
-        '--raw-field',
-        'body=Enterprise comment'
-      ],
+      ['api', '-X', 'POST', 'repos/team/orca/issues/7/comments', '--input', expect.any(String)],
       expect.objectContaining({ host: 'github.acme-corp.com' })
     )
+    expect(payloads[0]).toEqual({ body: 'Enterprise comment' })
   })
 
   it('lists issues from the issue owner/repo', async () => {
@@ -257,12 +292,14 @@ describe('issue source operations', () => {
 
   it('creates issues in the issue owner/repo', async () => {
     getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
-    ghExecFileAsyncMock.mockResolvedValueOnce({
-      stdout: JSON.stringify({
-        number: 924,
-        html_url: 'https://github.com/stablyai/orca/issues/924'
-      })
-    })
+    const payloads = mockGhExecQueue([
+      {
+        stdout: JSON.stringify({
+          number: 924,
+          html_url: 'https://github.com/stablyai/orca/issues/924'
+        })
+      }
+    ])
 
     await expect(createIssue('/repo-root', 'New issue', 'Body')).resolves.toEqual({
       ok: true,
@@ -270,28 +307,22 @@ describe('issue source operations', () => {
       url: 'https://github.com/stablyai/orca/issues/924'
     })
     expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
-      [
-        'api',
-        '-X',
-        'POST',
-        'repos/stablyai/orca/issues',
-        '--raw-field',
-        'title=New issue',
-        '--raw-field',
-        'body=Body'
-      ],
+      ['api', '-X', 'POST', 'repos/stablyai/orca/issues', '--input', expect.any(String)],
       { cwd: '/repo-root', host: 'github.com' }
     )
+    expect(payloads[0]).toEqual({ title: 'New issue', body: 'Body' })
   })
 
   it('creates issues with labels and assignees', async () => {
     getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
-    ghExecFileAsyncMock.mockResolvedValueOnce({
-      stdout: JSON.stringify({
-        number: 925,
-        html_url: 'https://github.com/stablyai/orca/issues/925'
-      })
-    })
+    const payloads = mockGhExecQueue([
+      {
+        stdout: JSON.stringify({
+          number: 925,
+          html_url: 'https://github.com/stablyai/orca/issues/925'
+        })
+      }
+    ])
 
     await expect(
       createIssue('/repo-root', 'New issue', 'Body', undefined, undefined, {
@@ -304,24 +335,15 @@ describe('issue source operations', () => {
       url: 'https://github.com/stablyai/orca/issues/925'
     })
     expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
-      [
-        'api',
-        '-X',
-        'POST',
-        'repos/stablyai/orca/issues',
-        '--raw-field',
-        'title=New issue',
-        '--raw-field',
-        'body=Body',
-        '--raw-field',
-        'labels[]=bug',
-        '--raw-field',
-        'labels[]=frontend',
-        '--raw-field',
-        'assignees[]=octo'
-      ],
+      ['api', '-X', 'POST', 'repos/stablyai/orca/issues', '--input', expect.any(String)],
       { cwd: '/repo-root', host: 'github.com' }
     )
+    expect(payloads[0]).toEqual({
+      title: 'New issue',
+      body: 'Body',
+      labels: ['bug', 'frontend'],
+      assignees: ['octo']
+    })
   })
 
   it('recovers issue 7704 oversized inline-image creation', async () => {
@@ -331,15 +353,16 @@ describe('issue source operations', () => {
     expect(body).toHaveLength(133596)
 
     getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
-    ghExecFileAsyncMock
-      .mockRejectedValueOnce(new Error('HTTP 422: body is too long (maximum is 65536 characters)'))
-      .mockResolvedValueOnce({
+    const payloads = mockGhExecQueue([
+      { throw: new Error('HTTP 422: body is too long (maximum is 65536 characters)') },
+      {
         stdout: JSON.stringify({
           number: 926,
           html_url: 'https://github.com/stablyai/orca/issues/926'
         })
-      })
-      .mockResolvedValueOnce({ stdout: '' })
+      },
+      { stdout: '' }
+    ])
 
     await expect(
       createIssue('/repo-root', 'Image issue', body, undefined, undefined, {
@@ -353,24 +376,64 @@ describe('issue source operations', () => {
     })
     expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
       1,
-      expect.arrayContaining([
-        `body=${body}`,
-        'title=Image issue',
-        'labels[]=bug',
-        'assignees[]=octo'
-      ]),
+      ['api', '-X', 'POST', 'repos/stablyai/orca/issues', '--input', expect.any(String)],
       { cwd: '/repo-root', host: 'github.com' }
     )
+    expect(payloads[0]).toEqual({
+      title: 'Image issue',
+      body,
+      labels: ['bug'],
+      assignees: ['octo']
+    })
     expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
       2,
-      expect.arrayContaining(['body=', 'title=Image issue', 'labels[]=bug', 'assignees[]=octo']),
+      ['api', '-X', 'POST', 'repos/stablyai/orca/issues', '--input', expect.any(String)],
       { cwd: '/repo-root', host: 'github.com' }
     )
+    expect(payloads[1]).toEqual({
+      title: 'Image issue',
+      body: '',
+      labels: ['bug'],
+      assignees: ['octo']
+    })
     expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
       3,
-      ['api', '-X', 'PATCH', 'repos/stablyai/orca/issues/926', '--raw-field', `body=${body}`],
+      ['api', '-X', 'PATCH', 'repos/stablyai/orca/issues/926', '--input', expect.any(String)],
       { cwd: '/repo-root', host: 'github.com' }
     )
+    expect(payloads[2]).toEqual({ body })
+  })
+
+  it('recovers spawn ENAMETOOLONG by creating then PATCHing the body from a file', async () => {
+    const imagePrefix = 'data:image/png;base64,'
+    const body = imagePrefix + 'x'.repeat(133596 - imagePrefix.length)
+    expect(body).toHaveLength(133596)
+
+    getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
+    const payloads = mockGhExecQueue([
+      { throw: Object.assign(new Error('spawn ENAMETOOLONG'), { code: 'ENAMETOOLONG' }) },
+      {
+        stdout: JSON.stringify({
+          number: 931,
+          html_url: 'https://github.com/stablyai/orca/issues/931'
+        })
+      },
+      { stdout: '' }
+    ])
+
+    await expect(createIssue('/repo-root', 'Image issue', body)).resolves.toEqual({
+      ok: true,
+      number: 931,
+      url: 'https://github.com/stablyai/orca/issues/931'
+    })
+    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+      3,
+      ['api', '-X', 'PATCH', 'repos/stablyai/orca/issues/931', '--input', expect.any(String)],
+      { cwd: '/repo-root', host: 'github.com' }
+    )
+    expect(payloads[0]).toEqual({ title: 'Image issue', body })
+    expect(payloads[1]).toEqual({ title: 'Image issue', body: '' })
+    expect(payloads[2]).toEqual({ body })
   })
 
   it('recognizes the oversized-body response from structured gh stderr', async () => {
@@ -426,10 +489,11 @@ describe('issue source operations', () => {
     const localGitOptions = { wslDistro: 'Ubuntu' }
     const body = `data:image/png;base64,${'x'.repeat(100)}`
     getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
-    ghExecFileAsyncMock
-      .mockRejectedValueOnce(new Error('body is too long (maximum is 65536 characters)'))
-      .mockResolvedValueOnce({ stdout: JSON.stringify({ number: 927, url: 'issue-url' }) })
-      .mockResolvedValueOnce({ stdout: '' })
+    const payloads = mockGhExecQueue([
+      { throw: new Error('body is too long (maximum is 65536 characters)') },
+      { stdout: JSON.stringify({ number: 927, url: 'issue-url' }) },
+      { stdout: '' }
+    ])
 
     await expect(
       createIssue(
@@ -445,10 +509,23 @@ describe('issue source operations', () => {
         localGitOptions
       )
     ).resolves.toEqual({ ok: true, number: 927, url: 'issue-url' })
-    const firstCreateArgs = [...ghExecFileAsyncMock.mock.calls[0][0]]
-    const fallbackCreateArgs = [...ghExecFileAsyncMock.mock.calls[1][0]]
-    firstCreateArgs[firstCreateArgs.indexOf(`body=${body}`)] = 'body='
-    expect(fallbackCreateArgs).toEqual(firstCreateArgs)
+    const withoutInputPath = (args: string[]) =>
+      args.map((arg, i) => (args[i - 1] === '--input' ? '<input>' : arg))
+    expect(withoutInputPath(ghExecFileAsyncMock.mock.calls[0][0])).toEqual(
+      withoutInputPath(ghExecFileAsyncMock.mock.calls[1][0])
+    )
+    expect(payloads[0]).toEqual({
+      title: 'Fields issue',
+      body,
+      labels: ['bug'],
+      assignees: ['octo']
+    })
+    expect(payloads[1]).toEqual({
+      title: 'Fields issue',
+      body: '',
+      labels: ['bug'],
+      assignees: ['octo']
+    })
     expect(ghExecFileAsyncMock.mock.calls.every((call) => call[1]?.wslDistro === 'Ubuntu')).toBe(
       true
     )
@@ -483,15 +560,16 @@ describe('issue source operations', () => {
 
   it('updates issue body through the REST issue endpoint', async () => {
     getIssueOwnerRepoMock.mockResolvedValueOnce({ owner: 'stablyai', repo: 'orca' })
-    ghExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' })
+    const payloads = mockGhExecQueue([{ stdout: '' }])
 
     await expect(updateIssue('/repo-root', 924, { body: 'Updated body' })).resolves.toEqual({
       ok: true
     })
     expect(ghExecFileAsyncMock).toHaveBeenCalledWith(
-      ['api', '-X', 'PATCH', 'repos/stablyai/orca/issues/924', '--raw-field', 'body=Updated body'],
+      ['api', '-X', 'PATCH', 'repos/stablyai/orca/issues/924', '--input', expect.any(String)],
       { cwd: '/repo-root', host: 'github.com' }
     )
+    expect(payloads[0]).toEqual({ body: 'Updated body' })
   })
 
   it('closes issues with completed, not planned, and duplicate reasons', async () => {

--- a/src/main/github/project-view/issue-comment-mutations.test.ts
+++ b/src/main/github/project-view/issue-comment-mutations.test.ts
@@ -1,0 +1,95 @@
+import { readFile } from 'node:fs/promises'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { runRestMock } = vi.hoisted(() => ({
+  runRestMock: vi.fn()
+}))
+
+vi.mock('./internals', () => ({
+  runRest: runRestMock,
+  projectGhExecOptions: (host?: string) => ({ host: host ?? 'github.com' }),
+  validateSlugArgs: (owner: string, repo: string) =>
+    owner && repo ? { ok: true } : { ok: false, error: { type: 'validation_error' } },
+  assertPositiveInt: (value: number, name: string) =>
+    Number.isInteger(value) && value > 0
+      ? { ok: true, value }
+      : { ok: false, error: { type: 'validation_error', message: `${name} invalid` } }
+}))
+
+import { addIssueCommentBySlug, updateIssueCommentBySlug } from './issue-comment-mutations'
+
+function expectNoRawBodyField(args: unknown): asserts args is string[] {
+  expect(Array.isArray(args)).toBe(true)
+  const list = args as string[]
+  for (let i = 0; i < list.length; i++) {
+    expect(list[i]).not.toMatch(/^body=/)
+    if (
+      list[i] === '--raw-field' ||
+      list[i] === '-f' ||
+      list[i] === '--field' ||
+      list[i] === '-F'
+    ) {
+      expect(list[i + 1]).not.toMatch(/^body=/)
+    }
+  }
+}
+
+function mockRunRestJsonCapture(): unknown[] {
+  const payloads: unknown[] = []
+  runRestMock.mockImplementation(async (args: string[]) => {
+    expectNoRawBodyField(args)
+    const inputIndex = args.indexOf('--input')
+    expect(inputIndex).toBeGreaterThanOrEqual(0)
+    payloads.push(JSON.parse(await readFile(args[inputIndex + 1]!, 'utf8')))
+    return { ok: true, data: { id: 1 } }
+  })
+  return payloads
+}
+
+describe('slug-addressed comment body writes', () => {
+  beforeEach(() => {
+    runRestMock.mockReset()
+  })
+
+  it('addIssueCommentBySlug sends body through --input JSON', async () => {
+    const payloads = mockRunRestJsonCapture()
+
+    await expect(
+      addIssueCommentBySlug({
+        owner: 'acme',
+        repo: 'widgets',
+        number: 12,
+        body: 'A comment'
+      })
+    ).resolves.toMatchObject({ ok: true })
+
+    expect(runRestMock).toHaveBeenCalledWith(
+      ['-X', 'POST', 'repos/acme/widgets/issues/12/comments', '--input', expect.any(String)],
+      undefined,
+      'core',
+      { host: 'github.com' }
+    )
+    expect(payloads[0]).toEqual({ body: 'A comment' })
+  })
+
+  it('updateIssueCommentBySlug sends body through --input JSON', async () => {
+    const payloads = mockRunRestJsonCapture()
+
+    await expect(
+      updateIssueCommentBySlug({
+        owner: 'acme',
+        repo: 'widgets',
+        commentId: 44,
+        body: 'Edited comment'
+      })
+    ).resolves.toEqual({ ok: true })
+
+    expect(runRestMock).toHaveBeenCalledWith(
+      ['-X', 'PATCH', 'repos/acme/widgets/issues/comments/44', '--input', expect.any(String)],
+      undefined,
+      'core',
+      { host: 'github.com' }
+    )
+    expect(payloads[0]).toEqual({ body: 'Edited comment' })
+  })
+})

--- a/src/main/github/project-view/issue-comment-mutations.ts
+++ b/src/main/github/project-view/issue-comment-mutations.ts
@@ -1,4 +1,5 @@
 import { assertPositiveInt, projectGhExecOptions, runRest, validateSlugArgs } from './internals'
+import { withGhApiJsonInput } from '../gh-api-json-input'
 import type { PRComment } from '../../../shared/github/comment-types'
 import type {
   GitHubProjectCommentMutationResult,
@@ -44,17 +45,18 @@ export async function addIssueCommentBySlug(
   if (typeof args.body !== 'string' || !args.body.trim()) {
     return { ok: false, error: { type: 'validation_error', message: 'Comment body required.' } }
   }
-  const result = await runRest<RawIssueCommentResponse>(
-    [
-      '-X',
-      'POST',
-      `repos/${args.owner}/${args.repo}/issues/${args.number}/comments`,
-      '--raw-field',
-      `body=${args.body}`
-    ],
-    undefined,
-    'core',
-    projectGhExecOptions(args.host)
+  const result = await withGhApiJsonInput({ body: args.body }, (inputArgs) =>
+    runRest<RawIssueCommentResponse>(
+      [
+        '-X',
+        'POST',
+        `repos/${args.owner}/${args.repo}/issues/${args.number}/comments`,
+        ...inputArgs
+      ],
+      undefined,
+      'core',
+      projectGhExecOptions(args.host)
+    )
   )
   return result.ok
     ? { ok: true, comment: mapIssueComment(result.data, args.body) }
@@ -75,17 +77,18 @@ export async function updateIssueCommentBySlug(
   if (typeof args.body !== 'string' || !args.body.trim()) {
     return { ok: false, error: { type: 'validation_error', message: 'Comment body required.' } }
   }
-  const result = await runRest<unknown>(
-    [
-      '-X',
-      'PATCH',
-      `repos/${args.owner}/${args.repo}/issues/comments/${args.commentId}`,
-      '--raw-field',
-      `body=${args.body}`
-    ],
-    undefined,
-    'core',
-    projectGhExecOptions(args.host)
+  const result = await withGhApiJsonInput({ body: args.body }, (inputArgs) =>
+    runRest<unknown>(
+      [
+        '-X',
+        'PATCH',
+        `repos/${args.owner}/${args.repo}/issues/comments/${args.commentId}`,
+        ...inputArgs
+      ],
+      undefined,
+      'core',
+      projectGhExecOptions(args.host)
+    )
   )
   return result.ok ? { ok: true } : { ok: false, error: result.error }
 }

--- a/src/main/github/project-view/mutations.test.ts
+++ b/src/main/github/project-view/mutations.test.ts
@@ -1,3 +1,4 @@
+import { readFile } from 'node:fs/promises'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
@@ -48,6 +49,34 @@ vi.mock('./internals', () => ({
 
 import { updateIssueBySlug } from './mutations'
 import { getWorkItemDetailsBySlug } from './work-item-details'
+
+function expectNoRawBodyField(args: unknown): asserts args is string[] {
+  expect(Array.isArray(args)).toBe(true)
+  const list = args as string[]
+  for (let i = 0; i < list.length; i++) {
+    expect(list[i]).not.toMatch(/^body=/)
+    if (
+      list[i] === '--raw-field' ||
+      list[i] === '-f' ||
+      list[i] === '--field' ||
+      list[i] === '-F'
+    ) {
+      expect(list[i + 1]).not.toMatch(/^body=/)
+    }
+  }
+}
+
+function mockRunRestJsonCapture(): unknown[] {
+  const payloads: unknown[] = []
+  runRestMock.mockImplementation(async (args: string[]) => {
+    expectNoRawBodyField(args)
+    const inputIndex = args.indexOf('--input')
+    expect(inputIndex).toBeGreaterThanOrEqual(0)
+    payloads.push(JSON.parse(await readFile(args[inputIndex + 1]!, 'utf8')))
+    return { ok: true, data: { id: 1 } }
+  })
+  return payloads
+}
 
 describe('updateIssueBySlug', () => {
   beforeEach(() => {
@@ -208,11 +237,32 @@ describe('updateIssueBySlug', () => {
       { encoding: 'utf-8', host: 'github.corp.example' }
     )
     expect(runRestMock).toHaveBeenCalledWith(
-      ['-X', 'PATCH', 'repos/acme/widgets/issues/12', '--raw-field', 'title=New title'],
+      ['-X', 'PATCH', 'repos/acme/widgets/issues/12', '--input', expect.any(String)],
       undefined,
       'core',
       { host: 'github.corp.example' }
     )
+  })
+
+  it('sends title and body through --input JSON', async () => {
+    const payloads = mockRunRestJsonCapture()
+
+    await expect(
+      updateIssueBySlug({
+        owner: 'acme',
+        repo: 'widgets',
+        number: 12,
+        updates: { title: 'New title', body: 'Updated body' }
+      })
+    ).resolves.toEqual({ ok: true })
+
+    expect(runRestMock).toHaveBeenCalledWith(
+      ['-X', 'PATCH', 'repos/acme/widgets/issues/12', '--input', expect.any(String)],
+      undefined,
+      'core',
+      { host: 'github.com' }
+    )
+    expect(payloads[0]).toEqual({ title: 'New title', body: 'Updated body' })
   })
 })
 

--- a/src/main/github/project-view/mutations.test.ts
+++ b/src/main/github/project-view/mutations.test.ts
@@ -237,7 +237,7 @@ describe('updateIssueBySlug', () => {
       { encoding: 'utf-8', host: 'github.corp.example' }
     )
     expect(runRestMock).toHaveBeenCalledWith(
-      ['-X', 'PATCH', 'repos/acme/widgets/issues/12', '--input', expect.any(String)],
+      ['-X', 'PATCH', 'repos/acme/widgets/issues/12', '--raw-field', 'title=New title'],
       undefined,
       'core',
       { host: 'github.corp.example' }

--- a/src/main/github/project-view/mutations.ts
+++ b/src/main/github/project-view/mutations.ts
@@ -12,6 +12,7 @@ import {
   validateSlugArgs
 } from './internals'
 import { classifyProjectError, rateLimitedError } from './project-error-classification'
+import { withGhApiJsonInput } from '../gh-api-json-input'
 import type { GitHubProjectMutationResult } from '../../../shared/github/project-result-types'
 import type { UpdateIssueBySlugArgs } from '../../../shared/github/project-request-types'
 
@@ -44,18 +45,20 @@ export async function updateIssueBySlug(
   }
   const { title, body } = args.updates
   if (title !== undefined || body !== undefined) {
-    const patchArgs = ['-X', 'PATCH', base]
+    const payload: Record<string, unknown> = {}
     if (title !== undefined) {
-      patchArgs.push('--raw-field', `title=${title}`)
+      payload.title = title
     }
     if (body !== undefined) {
-      patchArgs.push('--raw-field', `body=${body}`)
+      payload.body = body
     }
-    const result = await runRest<unknown>(
-      patchArgs,
-      undefined,
-      'core',
-      projectGhExecOptions(args.host)
+    const result = await withGhApiJsonInput(payload, (inputArgs) =>
+      runRest<unknown>(
+        ['-X', 'PATCH', base, ...inputArgs],
+        undefined,
+        'core',
+        projectGhExecOptions(args.host)
+      )
     )
     if (!result.ok) {
       return { ok: false, error: result.error }

--- a/src/main/github/project-view/mutations.ts
+++ b/src/main/github/project-view/mutations.ts
@@ -52,14 +52,22 @@ export async function updateIssueBySlug(
     if (body !== undefined) {
       payload.body = body
     }
-    const result = await withGhApiJsonInput(payload, (inputArgs) =>
-      runRest<unknown>(
-        ['-X', 'PATCH', base, ...inputArgs],
-        undefined,
-        'core',
-        projectGhExecOptions(args.host)
-      )
-    )
+    const result =
+      body === undefined
+        ? await runRest<unknown>(
+            ['-X', 'PATCH', base, '--raw-field', `title=${title}`],
+            undefined,
+            'core',
+            projectGhExecOptions(args.host)
+          )
+        : await withGhApiJsonInput(payload, (inputArgs) =>
+            runRest<unknown>(
+              ['-X', 'PATCH', base, ...inputArgs],
+              undefined,
+              'core',
+              projectGhExecOptions(args.host)
+            )
+          )
     if (!result.ok) {
       return { ok: false, error: result.error }
     }

--- a/src/main/github/project-view/pull-request-mutation.test.ts
+++ b/src/main/github/project-view/pull-request-mutation.test.ts
@@ -1,0 +1,95 @@
+import { readFile } from 'node:fs/promises'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { runRestMock } = vi.hoisted(() => ({ runRestMock: vi.fn() }))
+
+vi.mock('./internals', () => ({
+  assertPositiveInt: (value: number) => ({ ok: true, value }),
+  validateSlugArgs: () => ({ ok: true }),
+  projectGhExecOptions: (host?: string) => ({ host: host ?? 'github.com' }),
+  runRest: runRestMock
+}))
+
+import { updatePullRequestBySlug } from './pull-request-mutation'
+
+describe('updatePullRequestBySlug body transport', () => {
+  beforeEach(() => {
+    runRestMock.mockReset().mockResolvedValue({ ok: true, data: {} })
+  })
+
+  it.each([`data:image/png;base64,${'A'.repeat(140_000)}`, ''])(
+    'keeps the body off argv and removes the payload file',
+    async (body) => {
+      let inputPath = ''
+      runRestMock.mockImplementation(async (args: string[]) => {
+        expect(args.slice(0, 3)).toEqual(['-X', 'PATCH', 'repos/acme/widgets/pulls/12'])
+        expect(args).not.toContain(`body=${body}`)
+        expect(args).toContain('--input')
+        inputPath = args[args.indexOf('--input') + 1]!
+        expect(JSON.parse(await readFile(inputPath, 'utf8'))).toEqual({
+          title: 'New title',
+          body,
+          state: 'closed'
+        })
+        return { ok: true, data: {} }
+      })
+
+      await expect(
+        updatePullRequestBySlug({
+          owner: 'acme',
+          repo: 'widgets',
+          number: 12,
+          host: 'github.corp.example',
+          updates: { title: 'New title', body, state: 'closed' }
+        })
+      ).resolves.toEqual({ ok: true })
+
+      expect(runRestMock).toHaveBeenCalledWith(expect.any(Array), undefined, 'core', {
+        host: 'github.corp.example'
+      })
+      await expect(readFile(inputPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    }
+  )
+
+  it('keeps title and state updates without a body on raw fields', async () => {
+    await updatePullRequestBySlug({
+      owner: 'acme',
+      repo: 'widgets',
+      number: 12,
+      updates: { title: 'New title', state: 'closed' }
+    })
+    expect(runRestMock).toHaveBeenCalledWith(
+      [
+        '-X',
+        'PATCH',
+        'repos/acme/widgets/pulls/12',
+        '--raw-field',
+        'title=New title',
+        '--raw-field',
+        'state=closed'
+      ],
+      undefined,
+      'core',
+      { host: 'github.com' }
+    )
+  })
+
+  it('returns REST failures and removes the body file', async () => {
+    let inputPath = ''
+    const error = { type: 'not_found', message: 'Not found' }
+    runRestMock.mockImplementation(async (args: string[]) => {
+      expect(args).toContain('--input')
+      inputPath = args[args.indexOf('--input') + 1]!
+      return { ok: false, error }
+    })
+    await expect(
+      updatePullRequestBySlug({
+        owner: 'acme',
+        repo: 'widgets',
+        number: 12,
+        updates: { body: 'body' }
+      })
+    ).resolves.toEqual({ ok: false, error })
+    await expect(readFile(inputPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+})

--- a/src/main/github/project-view/pull-request-mutation.ts
+++ b/src/main/github/project-view/pull-request-mutation.ts
@@ -1,4 +1,5 @@
 import { assertPositiveInt, projectGhExecOptions, runRest, validateSlugArgs } from './internals'
+import { withGhApiJsonInput } from '../gh-api-json-input'
 import type { GitHubProjectMutationResult } from '../../../shared/github/project-result-types'
 import type { UpdatePullRequestBySlugArgs } from '../../../shared/github/project-request-types'
 
@@ -16,6 +17,18 @@ export async function updatePullRequestBySlug(
   if (!args.updates || typeof args.updates !== 'object') {
     return { ok: false, error: { type: 'validation_error', message: 'Updates required.' } }
   }
+  if (args.updates.body !== undefined) {
+    const { title, body, state } = args.updates
+    const result = await withGhApiJsonInput({ title, body, state }, (inputArgs) =>
+      runRest<unknown>(
+        ['-X', 'PATCH', `repos/${args.owner}/${args.repo}/pulls/${args.number}`, ...inputArgs],
+        undefined,
+        'core',
+        projectGhExecOptions(args.host)
+      )
+    )
+    return result.ok ? { ok: true } : { ok: false, error: result.error }
+  }
   const patchArgs: string[] = [
     '-X',
     'PATCH',
@@ -24,10 +37,6 @@ export async function updatePullRequestBySlug(
   let fieldCount = 0
   if (args.updates.title !== undefined) {
     patchArgs.push('--raw-field', `title=${args.updates.title}`)
-    fieldCount++
-  }
-  if (args.updates.body !== undefined) {
-    patchArgs.push('--raw-field', `body=${args.updates.body}`)
     fieldCount++
   }
   if (args.updates.state !== undefined) {


### PR DESCRIPTION
## ELI5

Pasted screenshots can make issue or PR bodies larger than Windows can pass on a command line. The issue and project-view body-writing calls covered here now read JSON from a temporary file instead of placing the body on argv.

## What Changed

- Reuse `withGhApiJsonInput` for issue creation, edits, comments, project-view issue/comment edits, and PR-slug body edits.
- Keep title-only issue patches and body-free PR title/state patches on their existing raw-field path.
- Preserve empty-body updates, GHES host options, REST errors, temporary-file cleanup, and the existing oversized-body create-then-PATCH recovery.
- Rebased onto `bba68b1bddf1276c8bd27ad4ca41efcbd4260321` and added PR-slug regression coverage.

## Why

The original branch still placed PR-slug bodies on argv and changed title-only transport despite describing it as unchanged. Both paths now match the stated contract. No new dependency or wire change.

## Linked Issue

Fixes #15832

## Visual Proof

N/A — request serialization and subprocess argv only.

## Testing

- [ ] Manually reproduced on Windows
- [x] Automated regression coverage

RED: 4 regression assertions failed before the follow-up fix. GREEN: 35 tests across `issues.test.ts`, `gh-api-json-input.test.ts`, `project-view/mutations.test.ts`, `project-view/issue-comment-mutations.test.ts`, and `project-view/pull-request-mutation.test.ts`; another 10 map-with-concurrency smoke tests passed.

Node, CLI, and Web TypeScript checks passed using the repository's non-composite configuration (`tsc --noEmit -p config/tsconfig.{node,cli,web}.json --composite false`, run separately). Changed-file oxlint, oxfmt, and diff checks passed. Tool versions match package.json.

Default composite typecheck reports TS2883 in unchanged files. Its Node diagnostic set was also reproduced on pristine base `bba68b1bdd`; it is not reported as passing. Full suite/build and live Windows/SSH/GHES execution were not run.

**Existing assertion change:** restored the GHES title-only assertion to `--raw-field title=New title`; the former branch assertion incorrectly required `--input`. Body tests read the real temporary file during mocked network execution; the serialization helper and mutation functions are not mocked.

## AI Disclosure

Original implementation: Grok. Follow-up: Codex; independent Cursor review passed for tree `eda0c0a83aeb6532eaa20e6220e760da48e9e396`, committed unchanged as `cd31c8c137b6a84644f1e2b59822db6778e42ff9`.

## Review

GitHub/GHES-specific API paths only. Folder workspaces use the OS temporary directory; existing execution-host and WSL path translation remain in place. Error propagation and temporary cleanup are covered, including empty and 140 KB bodies.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill-installer material copied.

## Checklist

- [x] Scope and behavioral changes explained
- [x] Regression tests and changed-file checks passed
- [x] Cross-platform, SSH/folder, and provider boundaries considered
- [ ] Full lint/typecheck/test/build matrix passed (limitations above)
