### PR TITLE
fix(rate-limits): stop reporting Grok usage as 0% when the API omits the percent

### DIFF
--- a/src/main/rate-limits/grok-fetcher.test.ts
+++ b/src/main/rate-limits/grok-fetcher.test.ts
@@ -170,7 +170,9 @@ describe('fetchGrokRateLimits', () => {
     expect(netFetchMock).toHaveBeenCalledTimes(2)
   })
 
-  it('computes the weekly percentage from used and limit when the percent is omitted', async () => {
+  // Why: the monthly budget pair is a monthly window wherever it arrives — the
+  // credits view must not relabel it 'Weekly credits'.
+  it('publishes a credits-view monthly budget pair as a monthly window without a second request', async () => {
     authState.file = freshAuthJson()
     netFetchMock.mockResolvedValueOnce(
       jsonResponse({
@@ -190,7 +192,36 @@ describe('fetchGrokRateLimits', () => {
 
     const result = await fetchGrokRateLimits()
     expect(result.status).toBe('ok')
-    expect(result.weekly?.usedPercent).toBe(25)
+    expect(result.weekly).toBeNull()
+    expect(result.monthly?.usedPercent).toBe(25)
+    expect(result.monthly?.windowMinutes).toBe(43_200)
+    expect(netFetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  // Why: #9214/#9219 — non-zero money fields never prove the encoder emits
+  // default zeros, so the omitted percent still reads as the dropped zero.
+  it('still reads an omitted percentage as zero when the payload carries only non-zero money fields', async () => {
+    authState.file = freshAuthJson()
+    netFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        config: {
+          currentPeriod: {
+            type: 'USAGE_PERIOD_TYPE_WEEKLY',
+            start: '2026-07-17T19:38:56.948570+00:00',
+            end: '2026-07-24T19:38:56.948570+00:00'
+          },
+          billingPeriodStart: '2026-07-17T19:38:56.948570+00:00',
+          billingPeriodEnd: '2026-07-24T19:38:56.948570+00:00',
+          onDemandCap: { val: 100 },
+          prepaidBalance: { val: 25 },
+          isUnifiedBillingUser: true
+        }
+      })
+    )
+
+    const result = await fetchGrokRateLimits()
+    expect(result.status).toBe('ok')
+    expect(result.weekly?.usedPercent).toBe(0)
     expect(result.weekly?.windowMinutes).toBe(10_080)
     expect(netFetchMock).toHaveBeenCalledTimes(1)
   })
@@ -223,7 +254,9 @@ describe('fetchGrokRateLimits', () => {
 
     const result = await fetchGrokRateLimits()
     expect(result.status).toBe('ok')
-    expect(result.weekly?.usedPercent).toBe(25)
+    expect(result.weekly).toBeNull()
+    expect(result.monthly?.usedPercent).toBe(25)
+    expect(result.monthly?.windowMinutes).toBe(43_200)
     expect(netFetchMock).toHaveBeenCalledTimes(1)
   })
 

--- a/src/main/rate-limits/grok-fetcher.test.ts
+++ b/src/main/rate-limits/grok-fetcher.test.ts
@@ -100,6 +100,9 @@ describe('fetchGrokRateLimits', () => {
     )
   })
 
+  // Why: this payload emits NO usage scalars, so the omitted percent really is
+  // the dropped protobuf zero (#9214/#9219). #15740's payload does emit them —
+  // keep the two shapes apart.
   it('maps an omitted protobuf percentage as zero for a weekly credits period', async () => {
     authState.file = freshAuthJson()
     netFetchMock.mockResolvedValueOnce(
@@ -122,6 +125,105 @@ describe('fetchGrokRateLimits', () => {
     expect(result.weekly?.usedPercent).toBe(0)
     expect(result.weekly?.resetsAt).toBe(Date.parse('2026-07-24T19:38:56.948570+00:00'))
     expect(result.monthly).toBeUndefined()
+    expect(netFetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  // Why: #15740 — an absent creditUsagePercent alongside explicitly-emitted zero
+  // credit fields means "not reported", never 0%.
+  it('reports usage as unavailable when the credits view omits the percent but emits explicit zero credit fields', async () => {
+    authState.file = freshAuthJson()
+    netFetchMock
+      .mockResolvedValueOnce(
+        jsonResponse({
+          config: {
+            currentPeriod: {
+              type: 'USAGE_PERIOD_TYPE_WEEKLY',
+              start: '2026-08-16T12:54:39.515635+00:00',
+              end: '2026-08-23T12:54:39.515635+00:00'
+            },
+            onDemandCap: { val: 100 },
+            onDemandUsed: { val: 0 },
+            isUnifiedBillingUser: true,
+            prepaidBalance: { val: 0 },
+            topUpMethod: 'TOP_UP_METHOD_SAVED_PAYMENT_METHOD',
+            billingPeriodStart: '2026-08-16T12:54:39.515635+00:00',
+            billingPeriodEnd: '2026-08-23T12:54:39.515635+00:00'
+          }
+        })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          config: {
+            monthlyLimit: { val: 0 },
+            used: { val: 37.5 },
+            billingPeriodStart: '2026-08-16T12:54:39.515635+00:00',
+            billingPeriodEnd: '2026-08-23T12:54:39.515635+00:00'
+          }
+        })
+      )
+
+    const result = await fetchGrokRateLimits()
+    expect(result.status).toBe('unavailable')
+    expect(result.weekly).toBeNull()
+    expect(result.monthly).toBeUndefined()
+    expect(result.error).toMatch(/did not report a usage percentage/i)
+    expect(netFetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('computes the weekly percentage from used and limit when the percent is omitted', async () => {
+    authState.file = freshAuthJson()
+    netFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        config: {
+          currentPeriod: {
+            type: 'USAGE_PERIOD_TYPE_WEEKLY',
+            start: '2026-08-16T12:54:39.515635+00:00',
+            end: '2026-08-23T12:54:39.515635+00:00'
+          },
+          billingPeriodStart: '2026-08-16T12:54:39.515635+00:00',
+          billingPeriodEnd: '2026-08-23T12:54:39.515635+00:00',
+          monthlyLimit: { val: 100 },
+          used: { val: 25 }
+        }
+      })
+    )
+
+    const result = await fetchGrokRateLimits()
+    expect(result.status).toBe('ok')
+    expect(result.weekly?.usedPercent).toBe(25)
+    expect(result.weekly?.windowMinutes).toBe(10_080)
+    expect(netFetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([{ val: 0 }, { val: '0' }])(
+    'does not divide by a zero monthly limit (%o)',
+    async (monthlyLimit) => {
+      authState.file = freshAuthJson()
+      netFetchMock
+        .mockResolvedValueOnce(jsonResponse({ config: { isUnifiedBillingUser: true } }))
+        .mockResolvedValueOnce(jsonResponse({ config: { monthlyLimit, used: { val: 12 } } }))
+
+      const result = await fetchGrokRateLimits()
+      expect(result.status).toBe('unavailable')
+      expect(result.weekly).toBeNull()
+      expect(result.monthly).toBeUndefined()
+      expect(result.error).toMatch(/did not report a usage percentage/i)
+    }
+  )
+
+  it('reads a flat billing payload that carries usage fields but no percent', async () => {
+    authState.file = freshAuthJson()
+    netFetchMock.mockResolvedValueOnce(
+      jsonResponse({
+        monthlyLimit: { val: 200 },
+        used: { val: 50 },
+        billingPeriodEnd: '2026-09-01T00:00:00+00:00'
+      })
+    )
+
+    const result = await fetchGrokRateLimits()
+    expect(result.status).toBe('ok')
+    expect(result.weekly?.usedPercent).toBe(25)
     expect(netFetchMock).toHaveBeenCalledTimes(1)
   })
 

--- a/src/main/rate-limits/grok-fetcher.ts
+++ b/src/main/rate-limits/grok-fetcher.ts
@@ -90,8 +90,8 @@ function timestampsMatch(left: string | undefined, right: string | undefined): b
 function hasConfirmedWeeklyPeriod(config: GrokBillingConfig): boolean {
   const period = config.currentPeriod
   // Why: matching billing bounds only prove the current period IS the billing
-  // period; they say nothing about consumption (#15740). The omission reads as
-  // zero only when the payload emits no usage scalars at all.
+  // period; they say nothing about consumption (#15740), so resolveWeeklyPercent
+  // rules out the other consumption evidence before trusting this.
   return (
     period?.type === 'USAGE_PERIOD_TYPE_WEEKLY' &&
     timestampsMatch(period.start, config.billingPeriodStart) &&
@@ -99,19 +99,27 @@ function hasConfirmedWeeklyPeriod(config: GrokBillingConfig): boolean {
   )
 }
 
-// Why: proto3 JSON drops default zeros, so an omitted percent can mean zero —
-// but only in a payload that emits no usage scalars at all. #15740 ships
-// `onDemandUsed: {val: 0}`, proving this encoder does keep zeros, so there the
-// omission means "not reported" and must never render as 0%.
-function emitsExplicitUsageScalar(config: GrokBillingConfig): boolean {
-  const scalars = [
+function usageScalars(config: GrokBillingConfig): (GrokMoneyVal | undefined)[] {
+  return [
     config.onDemandCap,
     config.onDemandUsed,
     config.prepaidBalance,
     config.monthlyLimit,
     config.used
   ]
-  return scalars.some((value) => parseMoneyVal(value) !== null)
+}
+
+// Why: proto3 JSON drops default zeros, so an omitted percent can mean zero —
+// but only an explicitly-emitted zero proves this encoder keeps them. #15740
+// ships `onDemandUsed: {val: 0}`, so there the omission means "not reported"
+// and must never render as 0%. Non-zero money fields prove nothing either way,
+// so #9214/#9219 accounts that carry only those keep their genuine 0%.
+function emitsExplicitZeroScalar(config: GrokBillingConfig): boolean {
+  return usageScalars(config).some((value) => parseMoneyVal(value) === 0)
+}
+
+function reportsAnyUsageScalar(config: GrokBillingConfig): boolean {
+  return usageScalars(config).some((value) => parseMoneyVal(value) !== null)
 }
 
 function resolveWeeklyPercent(config: GrokBillingConfig): number | null {
@@ -122,11 +130,13 @@ function resolveWeeklyPercent(config: GrokBillingConfig): number | null {
   if (reported !== undefined) {
     return null
   }
-  const computed = percentOfLimit(config.used, config.monthlyLimit)
-  if (computed !== null) {
-    return computed
+  // Why: infer the dropped zero only when nothing else in the payload speaks
+  // for consumption — an explicit zero proves the encoder keeps defaults, and a
+  // computable budget pair is a real monthly number this must not shadow.
+  if (emitsExplicitZeroScalar(config) || mapMonthlyUsage(config) !== null) {
+    return null
   }
-  return !emitsExplicitUsageScalar(config) && hasConfirmedWeeklyPeriod(config) ? 0 : null
+  return hasConfirmedWeeklyPeriod(config) ? 0 : null
 }
 
 function mapWeeklyCredits(config: GrokBillingConfig): RateLimitWindow | null {
@@ -150,25 +160,15 @@ function parseMoneyVal(value: GrokMoneyVal | undefined): number | null {
   return typeof num === 'number' && Number.isFinite(num) ? num : null
 }
 
-// Why: the fetcher's only division — a zero, missing or unparseable denominator
-// yields no percentage rather than NaN/Infinity or a fabricated 0%.
-function percentOfLimit(
-  usedVal: GrokMoneyVal | undefined,
-  limitVal: GrokMoneyVal | undefined
-): number | null {
-  const used = parseMoneyVal(usedVal)
-  const limit = parseMoneyVal(limitVal)
-  if (used === null || limit === null || limit <= 0) {
-    return null
-  }
-  return Math.min(100, Math.max(0, (used / limit) * 100))
-}
-
 function mapMonthlyUsage(config: GrokBillingConfig): RateLimitWindow | null {
-  const usedPercent = percentOfLimit(config.used, config.monthlyLimit)
-  if (usedPercent === null) {
+  const limit = parseMoneyVal(config.monthlyLimit)
+  const used = parseMoneyVal(config.used)
+  // Why: a zero, missing or unparseable denominator yields no window rather
+  // than NaN/Infinity or a fabricated 0%.
+  if (limit === null || used === null || limit <= 0) {
     return null
   }
+  const usedPercent = Math.min(100, Math.max(0, (used / limit) * 100))
   const periodEnd = config.currentPeriod?.end ?? config.billingPeriodEnd
   const resetsAt = periodEnd ? Date.parse(periodEnd) : null
   return {
@@ -330,6 +330,13 @@ export async function fetchGrokRateLimits(
     if (weekly) {
       return billingUsageResult({ weekly }, config, session)
     }
+    // Why: the credits view can already carry the monthly budget pair; that pair
+    // is a monthly window, so publish it as one rather than mislabelling it
+    // weekly — and skip the redundant second request.
+    const creditsMonthly = mapMonthlyUsage(config)
+    if (creditsMonthly) {
+      return billingUsageResult({ monthly: creditsMonthly }, config, session)
+    }
     // Why: some unified-billing accounts expose only a monthly included budget;
     // their credits view omits creditUsagePercent, so read the default view.
     const fallback = await fetchMonthlyUsageFallback(session, options.signal)
@@ -341,7 +348,7 @@ export async function fetchGrokRateLimits(
     }
     // Why: an account that reports spend fields but no computable percentage is
     // not a quota-less plan — say the usage is unknown instead of implying zero.
-    return emitsExplicitUsageScalar(config) || emitsExplicitUsageScalar(fallback.config)
+    return reportsAnyUsageScalar(config) || reportsAnyUsageScalar(fallback.config)
       ? result('unavailable', 'Grok did not report a usage percentage for this account')
       : result('unavailable', 'Grok billing response did not include credit usage')
   } catch (err) {

--- a/src/main/rate-limits/grok-fetcher.ts
+++ b/src/main/rate-limits/grok-fetcher.ts
@@ -89,8 +89,9 @@ function timestampsMatch(left: string | undefined, right: string | undefined): b
 
 function hasConfirmedWeeklyPeriod(config: GrokBillingConfig): boolean {
   const period = config.currentPeriod
-  // Why: monthly unified-billing responses can also carry a weekly currentPeriod;
-  // matching billing bounds identify Grok's omitted protobuf zero unambiguously.
+  // Why: matching billing bounds only prove the current period IS the billing
+  // period; they say nothing about consumption (#15740). The omission reads as
+  // zero only when the payload emits no usage scalars at all.
   return (
     period?.type === 'USAGE_PERIOD_TYPE_WEEKLY' &&
     timestampsMatch(period.start, config.billingPeriodStart) &&
@@ -98,12 +99,39 @@ function hasConfirmedWeeklyPeriod(config: GrokBillingConfig): boolean {
   )
 }
 
+// Why: proto3 JSON drops default zeros, so an omitted percent can mean zero —
+// but only in a payload that emits no usage scalars at all. #15740 ships
+// `onDemandUsed: {val: 0}`, proving this encoder does keep zeros, so there the
+// omission means "not reported" and must never render as 0%.
+function emitsExplicitUsageScalar(config: GrokBillingConfig): boolean {
+  const scalars = [
+    config.onDemandCap,
+    config.onDemandUsed,
+    config.prepaidBalance,
+    config.monthlyLimit,
+    config.used
+  ]
+  return scalars.some((value) => parseMoneyVal(value) !== null)
+}
+
+function resolveWeeklyPercent(config: GrokBillingConfig): number | null {
+  const reported = config.creditUsagePercent
+  if (typeof reported === 'number' && Number.isFinite(reported)) {
+    return reported
+  }
+  if (reported !== undefined) {
+    return null
+  }
+  const computed = percentOfLimit(config.used, config.monthlyLimit)
+  if (computed !== null) {
+    return computed
+  }
+  return !emitsExplicitUsageScalar(config) && hasConfirmedWeeklyPeriod(config) ? 0 : null
+}
+
 function mapWeeklyCredits(config: GrokBillingConfig): RateLimitWindow | null {
-  const usedPercent =
-    config.creditUsagePercent === undefined && hasConfirmedWeeklyPeriod(config)
-      ? 0
-      : config.creditUsagePercent
-  if (typeof usedPercent !== 'number' || !Number.isFinite(usedPercent)) {
+  const usedPercent = resolveWeeklyPercent(config)
+  if (usedPercent === null) {
     return null
   }
   const periodEnd = config.currentPeriod?.end ?? config.billingPeriodEnd
@@ -122,16 +150,29 @@ function parseMoneyVal(value: GrokMoneyVal | undefined): number | null {
   return typeof num === 'number' && Number.isFinite(num) ? num : null
 }
 
+// Why: the fetcher's only division — a zero, missing or unparseable denominator
+// yields no percentage rather than NaN/Infinity or a fabricated 0%.
+function percentOfLimit(
+  usedVal: GrokMoneyVal | undefined,
+  limitVal: GrokMoneyVal | undefined
+): number | null {
+  const used = parseMoneyVal(usedVal)
+  const limit = parseMoneyVal(limitVal)
+  if (used === null || limit === null || limit <= 0) {
+    return null
+  }
+  return Math.min(100, Math.max(0, (used / limit) * 100))
+}
+
 function mapMonthlyUsage(config: GrokBillingConfig): RateLimitWindow | null {
-  const limit = parseMoneyVal(config.monthlyLimit)
-  const used = parseMoneyVal(config.used)
-  if (limit === null || used === null || limit <= 0) {
+  const usedPercent = percentOfLimit(config.used, config.monthlyLimit)
+  if (usedPercent === null) {
     return null
   }
   const periodEnd = config.currentPeriod?.end ?? config.billingPeriodEnd
   const resetsAt = periodEnd ? Date.parse(periodEnd) : null
   return {
-    usedPercent: Math.min(100, Math.max(0, (used / limit) * 100)),
+    usedPercent,
     windowMinutes: MONTHLY_WINDOW_MINUTES,
     resetsAt: resetsAt !== null && Number.isFinite(resetsAt) ? resetsAt : null,
     resetDescription: parseResetDescription(periodEnd)
@@ -150,14 +191,26 @@ function grokRequestHeaders(session: GrokAuthSession): Record<string, string> {
   return headers
 }
 
+// Why: a flat response can carry monthly/on-demand fields and no percent at all
+// (#15740); keying only on creditUsagePercent misreported those as "no config".
+const FLAT_BILLING_FIELDS: readonly (keyof GrokBillingConfig)[] = [
+  'creditUsagePercent',
+  'currentPeriod',
+  'billingPeriodStart',
+  'billingPeriodEnd',
+  'subscriptionTier',
+  'monthlyLimit',
+  'used',
+  'onDemandCap',
+  'onDemandUsed',
+  'prepaidBalance'
+]
+
 function resolveBillingConfig(data: GrokBillingResponse): GrokBillingConfig | null {
   if (data.config) {
     return data.config
   }
-  if (typeof data.creditUsagePercent === 'number') {
-    return data
-  }
-  return null
+  return FLAT_BILLING_FIELDS.some((field) => data[field] !== undefined) ? data : null
 }
 
 function billingUsageResult(
@@ -219,7 +272,7 @@ async function fetchBillingData(
 }
 
 type GrokMonthlyFallbackOutcome =
-  | { kind: 'window'; window: RateLimitWindow | null }
+  | { kind: 'window'; window: RateLimitWindow | null; config: GrokBillingConfig }
   | { kind: 'result'; result: ProviderRateLimits }
 
 // Why: request failures propagate as 'error' (thrown errors reach the caller's
@@ -235,7 +288,7 @@ async function fetchMonthlyUsageFallback(
     return outcome
   }
   const config = outcome.data.config ?? outcome.data
-  return { kind: 'window', window: mapMonthlyUsage(config) }
+  return { kind: 'window', window: mapMonthlyUsage(config), config }
 }
 
 // Why: Orca never runs grok login; it only reads the session file the CLI updates.
@@ -286,7 +339,11 @@ export async function fetchGrokRateLimits(
     if (fallback.window) {
       return billingUsageResult({ monthly: fallback.window }, config, session)
     }
-    return result('unavailable', 'Grok billing response did not include credit usage')
+    // Why: an account that reports spend fields but no computable percentage is
+    // not a quota-less plan — say the usage is unknown instead of implying zero.
+    return emitsExplicitUsageScalar(config) || emitsExplicitUsageScalar(fallback.config)
+      ? result('unavailable', 'Grok did not report a usage percentage for this account')
+      : result('unavailable', 'Grok billing response did not include credit usage')
   } catch (err) {
     return result('error', err instanceof Error ? err.message : 'Grok usage request failed')
   }

--- a/src/renderer/src/components/settings/GrokAccountsSection.test.tsx
+++ b/src/renderer/src/components/settings/GrokAccountsSection.test.tsx
@@ -8,7 +8,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   getStatus: vi.fn(),
-  refreshGrokRateLimits: vi.fn()
+  refreshGrokRateLimits: vi.fn(),
+  grokUsage: vi.fn<() => unknown>(() => null)
 }))
 
 vi.mock('@/lib/agent-catalog', () => ({
@@ -29,7 +30,8 @@ vi.mock('../../store', () => ({
   useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
     selector({
       refreshGrokRateLimits: mocks.refreshGrokRateLimits,
-      rateLimits: { grok: null }
+      settingsSearchQuery: '',
+      rateLimits: { grok: mocks.grokUsage() }
     })
 }))
 
@@ -45,6 +47,7 @@ describe('GrokAccountsSection', () => {
       error: null
     })
     mocks.refreshGrokRateLimits.mockResolvedValue(undefined)
+    mocks.grokUsage.mockReturnValue(null)
     Object.defineProperty(window, 'api', {
       configurable: true,
       value: { grokAccounts: { getStatus: mocks.getStatus } }
@@ -65,5 +68,24 @@ describe('GrokAccountsSection', () => {
       )
     ).toBeInTheDocument()
     expect(screen.queryByText(/grok login/i)).not.toBeInTheDocument()
+  })
+
+  // Why: #15740 — an unreported percentage must be stated, never shown as 0%.
+  it('shows why usage is unknown instead of hiding the row', async () => {
+    mocks.grokUsage.mockReturnValue({
+      provider: 'grok',
+      session: null,
+      weekly: null,
+      updatedAt: Date.now(),
+      error: 'Grok did not report a usage percentage for this account',
+      status: 'unavailable'
+    })
+
+    render(<GrokAccountsSection />)
+
+    expect(
+      await screen.findByText('Grok did not report a usage percentage for this account')
+    ).toBeInTheDocument()
+    expect(screen.queryByText('0%')).not.toBeInTheDocument()
   })
 })

--- a/src/renderer/src/components/settings/GrokAccountsSection.tsx
+++ b/src/renderer/src/components/settings/GrokAccountsSection.tsx
@@ -56,6 +56,12 @@ export function GrokAccountsSection(): React.JSX.Element {
   // monthly included usage instead of hiding the usage row entirely.
   const usageIsWeekly = Boolean(grokUsage?.weekly)
   const usageWindow = grokUsage?.weekly ?? grokUsage?.monthly ?? null
+  // Why: hiding the row entirely left signed-in users with no explanation when
+  // Grok reports no percentage — never let unknown usage read as healthy (#15740).
+  const unavailableReason =
+    signedIn && !usageWindow && grokUsage?.status === 'unavailable'
+      ? (grokUsage.error ?? null)
+      : null
 
   return (
     <section id="accounts-grok" className="space-y-4 scroll-mt-6">
@@ -197,6 +203,17 @@ export function GrokAccountsSection(): React.JSX.Element {
               </span>
             ) : null}
           </div>
+        </SearchableSetting>
+      ) : unavailableReason ? (
+        <SearchableSetting
+          title={translate('auto.components.settings.GrokAccountsSection.0bb18642b7', 'Usage')}
+          description={translate(
+            'auto.components.settings.GrokAccountsSection.a8f4139350',
+            'Grok reported no usage percentage for this account.'
+          )}
+          keywords={['grok', 'xai', 'usage', 'credits', 'oauth']}
+        >
+          <p className="text-xs text-muted-foreground">{unavailableReason}</p>
         </SearchableSetting>
       ) : null}
     </section>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10557,7 +10557,9 @@
           "e6dadc1e2b": "Monthly usage",
           "75e396bf42": "Included monthly usage for Grok unified-billing accounts.",
           "b36fa2c908": "Signed in. Orca reads the Grok CLI session stored on disk.",
-          "f08c41de73": "Session expired — run grok on the computer running Orca and wait for it to start. If prompted, complete sign-in, then click Refresh usage. No chat message is needed."
+          "f08c41de73": "Session expired — run grok on the computer running Orca and wait for it to start. If prompted, complete sign-in, then click Refresh usage. No chat message is needed.",
+          "0bb18642b7": "Usage",
+          "a8f4139350": "Grok reported no usage percentage for this account."
         },
         "AppearanceWindowSidebarSection": {
           "usagePercentageDisplayUsed": "Used",


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​159 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​157 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​99 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​83 |

<!-- /orca-pr-loc -->

## ELI5

Grok's billing API sometimes just doesn't tell us how much of your plan you've used. Orca was reading that silence as "you've used 0%" and showing a confident green `0%` chip forever. Now Orca only shows a number when it can actually derive one, and otherwise says out loud that Grok didn't report usage for this account.

## What Changed

`src/main/rate-limits/grok-fetcher.ts`:

- `mapWeeklyCredits()` no longer treats an absent `creditUsagePercent` as a confirmed zero by default. Resolution order is now: reported percent → `0` only when nothing else in the payload speaks for consumption (no explicitly-emitted zero money field, no computable `used`/`monthlyLimit` pair) and the weekly period is confirmed, preserving #9214 / PR #9219 → `null` (unknown).
- New `emitsExplicitZeroScalar()` encodes the narrowed invariant: an omitted percent only reads as a dropped proto3 zero when the payload emits **no** explicit zero. Only an emitted zero proves the encoder keeps defaults; a non-zero money field proves nothing, so #9214-cohort accounts carrying only non-zero fields keep their genuine `0%`. A separate `reportsAnyUsageScalar()` (any parseable money field) is used solely to pick the terminal error wording.
- When the credits view already carries the `used` / `monthlyLimit` pair, it is now published through `mapMonthlyUsage()` into the **monthly** slot (43,200-minute window), not divided into a "weekly" percent. That pair is a monthly budget, and `mapMonthlyUsage()` already maps the identical pair as monthly — labelling the same number "Weekly credits"/`wk` would have been a straight contradiction. This also skips the redundant second request for those accounts.
- `mapMonthlyUsage()` keeps the guarded division: a missing, unparseable, or `<= 0` denominator yields no window, so no path can produce `NaN`, `Infinity`, or a fabricated `0`.
- `resolveBillingConfig()` accepts a flat (un-nested) payload carrying any recognised billing field, not only `creditUsagePercent`. Previously such a response was reported as "did not include config".
- Terminal message split: accounts that report spend fields but no computable percentage now get `Grok did not report a usage percentage for this account`; the old "did not include credit usage" wording is kept only for a genuinely empty response.
- The stale WHY comment on `hasConfirmedWeeklyPeriod()` (which claimed matching billing bounds identify the omitted zero "unambiguously") is corrected.

`src/renderer/src/components/settings/GrokAccountsSection.tsx`: when a signed-in account has no usage window and the status is `unavailable`, the pane now renders the reason as muted `text-xs text-muted-foreground` text instead of hiding the usage row entirely. Two new auto i18n keys in `en.json`.

## Why

Root cause, from #15740: `mapWeeklyCredits()` conflated *field absent* with *confirmed protobuf zero* whenever `hasConfirmedWeeklyPeriod()` held. For the reporter's unified-billing account the weekly `currentPeriod` matches `billingPeriodStart/End`, so the mapper fabricated `usedPercent: 0` with `status: 'ok'` and `error: null` — and because `fetchGrokRateLimits()` returns on the first non-null weekly window, the monthly fallback was never reached. There was no path by which real consumption could surface.

The reporter's payload disproves the premise the synthetic zero rested on: it emits `onDemandUsed: { val: 0 }` and `prepaidBalance: { val: 0 }`. If this encoder dropped default zeros it would have dropped those too, so an omitted `creditUsagePercent` there means "not reported", not "zero". Their only numerator/denominator pair (`used` / `monthlyLimit`) has a zero denominator, so no percentage is computable at all — the honest result is the existing explicit-unknown state.

The narrowing is deliberately keyed on an emitted **zero**, not on any emitted money field. Proto3 JSON's `emitDefaultValues` is a serializer-wide setting: seeing one explicit `0` proves defaults are being emitted (so the absent percent is genuinely absent), while a payload carrying only non-zero values is evidence for neither reading and must keep main's behaviour.

I deliberately did **not** derive the displayed percentage from `onDemandUsed` / `onDemandCap` (0 / 100 for this reporter). The on-demand cap is an overflow spend limit, not the account's consumption window, so a `0%` derived from it would reproduce the exact reported symptom: a confident, healthy-looking zero while real included-plan usage is unknown.

## Linked Issue

Fixes #15740

## Visual Proof

N/A for the main-process fix (pure JSON mapping, covered by unit tests). The renderer change is one added muted text line and has no before-image worth attaching, but a reviewer can check it by eye: **Settings → Accounts → Grok**, with an account whose usage is `unavailable`. Before this PR that pane showed a Grok header and a Refresh button with no usage row and no explanation; after, it shows a single muted line with the reason (e.g. "Grok did not report a usage percentage for this account"). The status-bar chip already rendered a greyed `--` with the reason in its tooltip for `unavailable`, and is unchanged.

## Testing

Run on macOS only (Darwin 25.3.0), targeted vitest + oxlint. Project-wide `pnpm typecheck` / `pnpm lint` were not run locally (CI covers them).

```
npx vitest run --config config/vitest.config.ts \
  src/main/rate-limits/grok-fetcher.test.ts \
  src/renderer/src/components/settings/GrokAccountsSection.test.tsx \
  src/renderer/src/components/status-bar/tooltip.test.ts
# 3 files, 61 tests passed

npx vitest run --config config/vitest.config.ts src/main/rate-limits
# 38 files, 429 tests passed

npx oxfmt --check <changed files>   # clean

npx oxlint src/main/rate-limits/grok-fetcher.ts src/main/rate-limits/grok-fetcher.test.ts \
  src/renderer/src/components/settings/GrokAccountsSection.tsx \
  src/renderer/src/components/settings/GrokAccountsSection.test.tsx
# clean

npx oxlint --config config/oxlint-code-quality-native-plugins.json <same files> --deny-warnings
# clean

node config/scripts/verify-localization-catalog.mjs   # passes
node config/scripts/check-max-lines-ratchet.mjs       # OK, no new bypasses
```

**Regression evidence** — with the two product files reverted to `origin/main` and only the new tests applied, all six new cases fail; with the fix they pass:

```
× reports usage as unavailable when the credits view omits the percent but emits explicit zero credit fields
× publishes a credits-view monthly budget pair as a monthly window without a second request
× does not divide by a zero monthly limit ({ val: +0 })
× does not divide by a zero monthly limit ({ val: '0' })
× reads a flat billing payload that carries usage fields but no percent
× shows why usage is unknown instead of hiding the row
Tests  6 failed | 14 passed (20)
```

A seventh new case — `still reads an omitted percentage as zero when the payload carries only non-zero money fields` — passes on both base and branch by design: it pins the #9214/#9219 behaviour the narrowed predicate must not regress. It fails if `emitsExplicitZeroScalar()` is widened back to "any parseable money field" (verified by making that one-line change and watching it go red).

The first of those replays #15740's exact payload and asserts `status === 'unavailable'`, `weekly === null`, no monthly window, the new reason string, and that the default billing view **is** requested (`netFetch` called twice) — so a future re-introduction of a synthetic window can't silently re-break it. The existing #9214 zero-percent test stays green and now carries a WHY comment tying the two shapes apart.

Platforms: reported on Windows, but this code is pure JSON mapping over Electron `net.fetch` — no paths, shells, accelerators, or platform branches — so Linux/Windows are covered by reasoning, not execution.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Cross-platform**: no platform-dependent code added. No `path` usage, no `metaKey`, no shell invocation. macOS executed; Linux/Windows by inspection.
- **SSH / remote**: unchanged boundary. The Grok session file and the billing request both belong to the machine running main, so remote workspaces still show the Orca host's account. This change is the data-layer expression of that doc's core rule — absence of information is never evidence of a value — and the new copy says usage was *not reported*, never that it is zero.
- **Remote wire compatibility**: no new field, no new stream opcode, no RPC param change. But per `docs/reference/remote-wire-compatibility.md` this *does* change what the host publishes, and that reaches old clients: an affected account that used to send a `0%` weekly window now sends none plus `status: 'unavailable'`. Both existing consumers already handle that shape (desktop `StatusBar` greyed `--` chip + tooltip reason; mobile `AccountUsage` `unavailable` branch, and `accounts-snapshot` already accepts nullable windows), so the degrade is safe and strictly more honest.
- **Backward compat / persistence**: `ProviderRateLimits` snapshots are in-memory only, no schema migration. Note `applyStalePolicy` discards a previous good snapshot on `unavailable` — correct here, since a stale real number must not outlive the discovery that usage is unreported. The existing tests pinning transient HTTP failures to `'error'` (so stale data survives network blips) are untouched and still green.
- **Performance**: accounts that report neither a percent nor a credits-view budget pair now issue 2 billing requests per refresh instead of 1 (credits + default view), bounded by the existing refresh cadence and the 10s timeout. Unchanged for accounts that report a percent, and unchanged for accounts whose credits view already carries `used`/`monthlyLimit` (those are answered from the first response). The "does not request the default billing view when weekly credits are present" test keeps that budget pinned.
- **UI quality**: one muted `text-xs text-muted-foreground` line inside the existing `SearchableSetting`, reusing documented tokens. No new colors, font sizes, or shadow tiers. Strings go through `translate` with auto keys like the surrounding code.
- **Provider neutrality**: xAI-specific fetcher; nothing GitHub/GitLab-shaped, no generic concept gains a vendor name.
- **Security**: no new network sinks, no shell/eval, no dependency or lockfile change. Auth handling stays in `grok-auth.ts`, untouched.
- **Git binary compatibility**: N/A, no git commands.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

`src/main/rate-limits/grok-fetcher.ts` is now 294 non-blank/non-comment lines against the 300 `max-lines` budget. The ratchet check passes and no suppression was added, but the next edit to this file should probably split the pure mappers into `grok-billing-mapping.ts` rather than squeeze.

## Known limitations / follow-ups

- The credits view is only consulted for the `used`/`monthlyLimit` pair after `creditUsagePercent` is exhausted; if a future payload carried both and they disagreed, the reported percent still wins. That is the intended precedence (the server's own number beats a derived one), but it is not something this PR can validate against a live account.
- No percentage is derived from `onDemandUsed` / `onDemandCap`. See the "Why" section — deriving one would reproduce the reported symptom. If xAI later confirms on-demand spend is the right consumption signal for these accounts, that is a follow-up with its own window semantics, not a silent addition here.
- The fetcher is at 294/300 `max-lines`. The next edit should split the pure mappers into `grok-billing-mapping.ts` rather than squeeze (no suppression added here).

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

