### PR TITLE
fix(agent-resume): restore Copilot sessions after restart

### DIFF
--- a/src/main/agent-hooks/server-copilot-normalization.test.ts
+++ b/src/main/agent-hooks/server-copilot-normalization.test.ts
@@ -51,6 +51,33 @@ describe('Copilot hook normalization', () => {
     expect(result?.payload.prompt).toBe('camel event')
   })
 
+  it('captures the Copilot provider session from SessionStart and Stop', () => {
+    const sessionId = '940237d9-c712-48e8-bca1-fd75fc4a8d4b'
+    const started = _internals.normalizeHookPayload(
+      'copilot',
+      buildBody({ hook_event_name: 'SessionStart', session_id: sessionId }),
+      'production'
+    )
+    expect(started?.providerSession).toEqual({ key: 'session_id', id: sessionId })
+
+    const stopped = _internals.normalizeHookPayload(
+      'copilot',
+      buildBody({ hook_event_name: 'Stop', session_id: sessionId }),
+      'production'
+    )
+    expect(stopped?.payload.state).toBe('done')
+    expect(stopped?.providerSession).toEqual({ key: 'session_id', id: sessionId })
+  })
+
+  it('captures the Copilot provider session from a camelCase sessionId', () => {
+    const result = _internals.normalizeHookPayload(
+      'copilot',
+      buildBody({ hookEventName: 'agentStop', sessionId: 'copilot-camel' }),
+      'production'
+    )
+    expect(result?.providerSession).toEqual({ key: 'session_id', id: 'copilot-camel' })
+  })
+
   it('infers Copilot user prompt payloads that omit hook_event_name', () => {
     const result = _internals.normalizeHookPayload(
       'copilot',

--- a/src/renderer/src/lib/agent-hibernation-planner.test.ts
+++ b/src/renderer/src/lib/agent-hibernation-planner.test.ts
@@ -134,6 +134,16 @@ describe('agent sleep planner', () => {
     ).toEqual([])
   })
 
+  it('treats an idle done copilot pane as a hibernation candidate', () => {
+    const copilot = entry({
+      agentType: 'copilot',
+      providerSession: { key: 'session_id', id: '940237d9-c712-48e8-bca1-fd75fc4a8d4b' }
+    })
+    expect(
+      plannedPaneKeys(snapshot({ agentStatusByPaneKey: { [copilot.paneKey]: copilot } }))
+    ).toEqual([copilot.paneKey])
+  })
+
   it('blocks done panes until their live subagent roster clears', () => {
     const withIdleTeammate = entry({
       subagents: [

--- a/src/renderer/src/lib/ai-vault-resume-command.test.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.test.ts
@@ -650,6 +650,44 @@ describe('ai vault resume command runtime', () => {
     ).toBe("$env:CODEX_HOME='C:/Users/alice/.codex'; my-codex 'resume' 'session one'")
   })
 
+  it('applies the user default args to local Copilot AI Vault resumes', () => {
+    const state = makeState({ worktreePath: '/home/alice/repo' })
+    state.settings = { ...state.settings, agentDefaultArgs: { copilot: '--yolo' } } as never
+
+    expect(
+      buildQueuedAiVaultResumeCommand({
+        state,
+        worktreeId: 'repo-1::worktree-1',
+        session: {
+          agent: 'copilot',
+          sessionId: '940237d9-c712-48e8-bca1-fd75fc4a8d4b',
+          cwd: '/home/alice/repo',
+          codexHome: null
+        }
+      })
+    ).toBe("copilot '--yolo' '--resume=940237d9-c712-48e8-bca1-fd75fc4a8d4b'")
+  })
+
+  it('keeps the scanner resume command for remote Copilot sessions', () => {
+    const state = makeState({ worktreePath: '/home/alice/repo' })
+    state.repos = [{ id: 'repo-1', path: '/home/alice/repo', connectionId: 'ssh-1' }] as never
+
+    expect(
+      buildQueuedAiVaultResumeCommand({
+        state,
+        worktreeId: 'repo-1::worktree-1',
+        session: {
+          agent: 'copilot',
+          sessionId: '940237d9-c712-48e8-bca1-fd75fc4a8d4b',
+          cwd: '/home/alice/repo',
+          codexHome: null,
+          executionHostId: 'ssh:dev-box',
+          resumeCommand: "copilot --resume='940237d9-c712-48e8-bca1-fd75fc4a8d4b'"
+        }
+      })
+    ).toBe("copilot --resume='940237d9-c712-48e8-bca1-fd75fc4a8d4b'")
+  })
+
   it('ignores a stored resume command for local-host sessions', () => {
     const state = makeState({ worktreePath: '/home/alice/repo' })
     state.repos = [{ id: 'repo-1', path: '/home/alice/repo', connectionId: 'ssh-1' }] as never

--- a/src/shared/agent-resume-argv-drop.test.ts
+++ b/src/shared/agent-resume-argv-drop.test.ts
@@ -56,6 +56,27 @@ describe('dropAgentResumeArgvFromCommand', () => {
     ).toEqual({ status: 'dropped', command: 'codex' })
   })
 
+  it('drops the joined Copilot resume token and keeps the user args', () => {
+    const providerSession = {
+      key: 'session_id' as const,
+      id: '940237d9-c712-48e8-bca1-fd75fc4a8d4b'
+    }
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'copilot',
+      providerSession,
+      cmdOverrides: {},
+      agentArgs: '--yolo',
+      platform: 'darwin'
+    })
+    expect(
+      dropAgentResumeArgvFromCommand({
+        command: plan?.launchCommand ?? '',
+        agent: 'copilot',
+        providerSession
+      })
+    ).toEqual({ status: 'dropped', command: "copilot '--yolo'" })
+  })
+
   it('reports absent when the command never carried the resume locator', () => {
     expect(
       dropAgentResumeArgvFromCommand({

--- a/src/shared/agent-session-resume.test.ts
+++ b/src/shared/agent-session-resume.test.ts
@@ -20,6 +20,10 @@ describe('agent session resume metadata', () => {
     expect(isResumableTuiAgent('prime-agent')).toBe(true)
   })
 
+  it('treats copilot as a resumable TUI agent', () => {
+    expect(isResumableTuiAgent('copilot')).toBe(true)
+  })
+
   it.each([
     ['claude', { session_id: 'claude-session' }, { key: 'session_id', id: 'claude-session' }],
     ['codex', { session_id: 'codex-session' }, { key: 'session_id', id: 'codex-session' }],
@@ -44,7 +48,13 @@ describe('agent session resume metadata', () => {
       'prime-agent',
       { session_id: 'prime-session', session_file: '/tmp/prime-session.jsonl' },
       { key: 'session_id', id: 'prime-session', transcriptPath: '/tmp/prime-session.jsonl' }
-    ]
+    ],
+    [
+      'copilot',
+      { session_id: '940237d9-c712-48e8-bca1-fd75fc4a8d4b' },
+      { key: 'session_id', id: '940237d9-c712-48e8-bca1-fd75fc4a8d4b' }
+    ],
+    ['copilot', { sessionId: 'copilot-camel' }, { key: 'session_id', id: 'copilot-camel' }]
   ] as const)('extracts %s provider session ids', (source, payload, expected) => {
     expect(extractAgentProviderSession(source, payload)).toEqual(expected)
   })
@@ -69,7 +79,8 @@ describe('agent session resume metadata', () => {
       'prime-agent',
       { key: 'session_id', id: 's1', transcriptPath: '/tmp/prime-session.jsonl' },
       ['prime-agent', '--resume', '/tmp/prime-session.jsonl']
-    ]
+    ],
+    ['copilot', { key: 'session_id', id: 's1' }, ['copilot', '--resume', 's1']]
   ] as const)('builds %s resume argv', (agent, providerSession, expected) => {
     expect(getAgentResumeArgv(agent, providerSession)).toEqual(expected)
   })

--- a/src/shared/agent-session-resume.test.ts
+++ b/src/shared/agent-session-resume.test.ts
@@ -80,7 +80,7 @@ describe('agent session resume metadata', () => {
       { key: 'session_id', id: 's1', transcriptPath: '/tmp/prime-session.jsonl' },
       ['prime-agent', '--resume', '/tmp/prime-session.jsonl']
     ],
-    ['copilot', { key: 'session_id', id: 's1' }, ['copilot', '--resume', 's1']]
+    ['copilot', { key: 'session_id', id: 's1' }, ['copilot', '--resume=s1']]
   ] as const)('builds %s resume argv', (agent, providerSession, expected) => {
     expect(getAgentResumeArgv(agent, providerSession)).toEqual(expected)
   })

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -14,7 +14,8 @@ export const RESUMABLE_TUI_AGENTS = [
   'grok',
   'devin',
   'omp',
-  'prime-agent'
+  'prime-agent',
+  'copilot'
 ] as const satisfies readonly TuiAgent[]
 
 export type ResumableTuiAgent = (typeof RESUMABLE_TUI_AGENTS)[number]
@@ -230,10 +231,15 @@ export function extractAgentProviderSession(
       const id = readSessionId(payload, ['session_id'])
       return id ? { key: 'session_id', id } : null
     }
+    // Why: Copilot's hook `session_id` is also its `~/.copilot/session-state/<id>/`
+    // directory name, so the same id is the CLI's resume locator.
+    case 'copilot': {
+      const id = readSessionId(payload, ['session_id', 'sessionId'])
+      return id ? { key: 'session_id', id } : null
+    }
     case 'amp':
     case 'cursor':
     case 'command-code':
-    case 'copilot':
     case 'hermes':
       return null
   }
@@ -276,5 +282,9 @@ export function getAgentResumeArgv(
       return providerSession.key === 'session_id'
         ? ['omp', '--resume', ompResumeFilePath?.trim() || id]
         : null
+    // Why: Copilot documents `--resume=<id>`, but the space form resumes the same
+    // session and keeps the locator its own argv entry for the resume-argv drop.
+    case 'copilot':
+      return providerSession.key === 'session_id' ? ['copilot', '--resume', id] : null
   }
 }

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -282,9 +282,9 @@ export function getAgentResumeArgv(
       return providerSession.key === 'session_id'
         ? ['omp', '--resume', ompResumeFilePath?.trim() || id]
         : null
-    // Why: Copilot documents `--resume=<id>`, but the space form resumes the same
-    // session and keeps the locator its own argv entry for the resume-argv drop.
+    // Why: the joined form is the only one Copilot documents, and it keeps this
+    // argv byte-identical to buildAgentResumeInvocation's AI Vault command.
     case 'copilot':
-      return providerSession.key === 'session_id' ? ['copilot', '--resume', id] : null
+      return providerSession.key === 'session_id' ? ['copilot', `--resume=${id}`] : null
   }
 }

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -282,8 +282,9 @@ export function getAgentResumeArgv(
       return providerSession.key === 'session_id'
         ? ['omp', '--resume', ompResumeFilePath?.trim() || id]
         : null
-    // Why: the joined form is the only one Copilot documents, and it keeps this
-    // argv byte-identical to buildAgentResumeInvocation's AI Vault command.
+    // Why: the joined form is the only one Copilot documents, and it matches the
+    // flag spelling buildAgentResumeInvocation bakes into persisted AI Vault
+    // resume commands, so local and remote resumes agree on one spelling.
     case 'copilot':
       return providerSession.key === 'session_id' ? ['copilot', `--resume=${id}`] : null
   }

--- a/src/shared/tui-agent-startup-copilot-resume.test.ts
+++ b/src/shared/tui-agent-startup-copilot-resume.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { buildAgentResumeStartupPlan } from './tui-agent-startup'
+
+const SESSION = { key: 'session_id' as const, id: '940237d9-c712-48e8-bca1-fd75fc4a8d4b' }
+
+describe('Copilot resume startup plan', () => {
+  it('uses the documented joined --resume form', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'copilot',
+      providerSession: SESSION,
+      cmdOverrides: {},
+      agentArgs: '--yolo',
+      platform: 'darwin'
+    })
+
+    expect(plan?.launchCommand).toBe(`copilot '--yolo' '--resume=${SESSION.id}'`)
+  })
+
+  it('quotes the resume argv for cmd.exe', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'copilot',
+      providerSession: SESSION,
+      cmdOverrides: {},
+      agentArgs: '--yolo',
+      platform: 'win32',
+      shell: 'cmd'
+    })
+
+    // Why: cmd.exe treats single quotes as literal characters.
+    expect(plan?.launchCommand).toBe(`copilot "--yolo" "--resume=${SESSION.id}"`)
+  })
+
+  it('honors a command override', () => {
+    const plan = buildAgentResumeStartupPlan({
+      agent: 'copilot',
+      providerSession: SESSION,
+      cmdOverrides: { copilot: 'copilot --banner' },
+      platform: 'linux'
+    })
+
+    expect(plan?.launchCommand).toBe(`copilot --banner '--resume=${SESSION.id}'`)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​152 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​150 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /orca-pr-loc -->

Supersedes #15154 by @mberatsanli — carried over so it can run full CI (fork PRs only run `track-community-pr` in this repo). Original authorship is preserved in the first commit.

## ELI5

Close Orca with a GitHub Copilot pane open, reopen it, and Copilot came back as a brand-new empty chat while Claude and Codex panes picked up right where they left off. Orca keeps a list of "agents we know how to resume" and Copilot was simply never on it, so Orca never even wrote down which Copilot conversation the pane was in. This adds Copilot to that list and teaches Orca the one flag Copilot needs to reattach to an existing conversation.

## What Changed

`src/shared/agent-session-resume.ts` — three gates, all of which must hold before `sleepingRecordFromEntry` (`src/renderer/src/store/slices/agent-status.ts:591`) will persist a resume record:

1. `'copilot'` added to `RESUMABLE_TUI_AGENTS`.
2. `extractAgentProviderSession` now returns `{ key: 'session_id', id }` for `copilot`, reading `session_id` first and `sessionId` as a defensive fallback. The snake_case key is what Copilot's hook body carries today; the camelCase read is belt-and-braces (Copilot's docs use camelCase for its event names and the vault transcript stores `data.sessionId`), not a documented dual-emission guarantee. Both branches are covered by tests.
3. `getAgentResumeArgv` gained a `copilot` case returning `['copilot', '--resume=<id>']`.

Maintainer changes on top of the contributor commit:

- **Flag form.** The original commit used the space form `--resume <id>`. Switched to the joined `--resume=<id>`, because it is the only form Copilot documents and because it makes the auto-resume argv use the same flag spelling as `buildAgentResumeInvocation` in `src/shared/ai-vault-resume-command.ts:211` — which is what the main-process session scanner bakes into each session's persisted `resumeCommand`, and what a remote host replays verbatim. Without this, a local Copilot session would resume with `--resume <id>` and an SSH-hosted one with `--resume=<id>`. The two commands are not byte-identical — `buildAgentResumeInvocation` quotes only the id (`copilot --resume='<id>'`) while `buildAgentResumeStartupPlan` quotes the whole token and prepends the user's default args (`copilot '--yolo' '--resume=<id>'`) — but they are equivalent after word splitting, which is what the CLI sees. The joined token strips cleanly through `stripSuffix` in `src/shared/agent-resume-argv-drop.ts` and quotes correctly in posix/PowerShell/cmd, so nothing downstream needed the token split.
- **Inline comment corrected.** The original rationale — that the joined form would break the resume-argv drop or the startup quoting — is not true. Its replacement was corrected once more in the latest commit: the joined argv matches the AI Vault command's *flag spelling*, not its full command string.
- **Tests broadened past pure-function coverage** (see Testing).

No wire schema, persistence schema, dependency, or config changes.

## Why

Root cause: Copilot panes never produced a sleeping-agent record. `sleepingRecordFromEntry` requires `isResumableTuiAgent(agent)`, a non-null `providerSession`, and a non-null `getAgentResumeArgv(...)`; Copilot failed all three, so quit-time capture had nothing to write and restore had nothing to relaunch. The pane fell back to a cold `copilot --yolo`.

The id is safe as the resume locator: Copilot's hook `session_id` is the same id as the `~/.copilot/session-state/<id>/` directory the AI Vault scanner already resolves, so the resume catalog and the vault agree on session identity.

Three behavior notes a reviewer should know:

- **AI Vault behavior shift (intentional).** Making `isResumableTuiAgent('copilot')` true reroutes the manual Agent Session History / AI Vault resume for *local* Copilot sessions from the `buildAiVaultResumeCommand` fallback to the `buildAgentResumeStartupPlan` branch (`src/renderer/src/lib/ai-vault-resume-command.ts:163`). That branch injects `resolveTuiAgentLaunchArgs` / `resolveTuiAgentLaunchEnv`, which the old fallback did not. A user whose Copilot permission toggle is YOLO has `--yolo` in `agentDefaultArgs`, so a hand-resumed local Copilot session now starts with that flag. This is deliberate — it makes Copilot behave like claude/codex/grok, and the args come from the user's own settings — and there is a regression test pinning it.
- **Agent hibernation eligibility (new, experimental-flag-gated).** The hibernation planner's only agent gate is the same `isResumableTuiAgent` + `providerSession` + `getAgentResumeArgv` triple (`src/renderer/src/lib/agent-hibernation-planner.ts:162-166`), so an idle, done Copilot pane now becomes an `AgentHibernationCandidate` and Orca will kill its live PTY and relaunch it with `--resume=` later. This only happens when `settings.experimentalAgentHibernation === true` (`agent-hibernation-planner.ts:254`), which is off by default, and the capture path throws `agent_hibernation_capture_missing` rather than killing a pane it has no persisted record for. A new test (`treats an idle done copilot pane as a hibernation candidate`) pins it so it is not silent. A reviewer running the live end-to-end check below should flip the experimental flag on for one pass.
- **Remote wire compatibility.** `RESUMABLE_TUI_AGENTS` is embedded in the `terminal.ensureAgentSession` param enum (`src/main/runtime/rpc/methods/agent-session.ts:130`). A client on this build asking an *older* remote Orca host to resume a Copilot session gets an RPC param-validation rejection — loud, non-corrupting, and the same precedent set when `prime-agent` / `omp` were added. The same list also gates `isAgentSessionExecutionClaim` (`src/shared/agent-session-host-authority.ts:163`), which the relay (`src/relay/pty-handler.ts:1472`) and the remote daemon (`src/main/daemon/daemon-server.ts:1103`) validate, so an older host rejects the claim there too — same loud, non-corrupting failure. Persisted state is safe in both directions: `sleepingAgentSessionsByPaneKeySchema` is built on `salvagingRecord`, so a downgrade drops only the Copilot entry rather than the whole map.

## Linked Issue

Fixes #15150

## Visual Proof

`N/A` — no UI surface changes. The only user-visible difference is that a restored Copilot pane relaunches with a resume flag instead of cold; there is no new or altered pixel.

## Testing

Run on **macOS only** (Apple Silicon). Windows/Linux/cmd/PowerShell behavior is covered by reasoning plus platform-parameterized unit tests (the quoting tests drive `platform: 'win32'` and `shell: 'cmd'` explicitly), not by execution on those OSes.

```
npx vitest run --config config/vitest.config.ts \
  src/shared/agent-session-resume.test.ts \
  src/shared/agent-resume-argv-drop.test.ts \
  src/shared/tui-agent-startup.test.ts \
  src/shared/tui-agent-startup-copilot-resume.test.ts \
  src/shared/ai-vault-resume-command.test.ts \
  src/main/agent-hooks/server-copilot-normalization.test.ts \
  src/main/ai-vault/session-scanner.test.ts \
  src/renderer/src/lib/ai-vault-resume-command.test.ts \
  src/renderer/src/lib/resume-sleeping-agent-session.test.ts \
  src/renderer/src/lib/agent-hibernation-planner.test.ts
# 10 files passed, 255 tests passed, 0 failed
```

```
npx oxlint <7 changed files>                                            # clean
npx oxlint --config config/oxlint-code-quality-native-plugins.json \
  <7 changed files> --deny-warnings                                     # clean
npx oxfmt --check <7 changed files>                                     # clean
```

**Regression proof.** I reverted the three product-code gates in `src/shared/agent-session-resume.ts` (removed `'copilot'` from `RESUMABLE_TUI_AGENTS`, put `copilot` back on the null branch of `extractAgentProviderSession`, deleted the `getAgentResumeArgv` case) and re-ran: **12 tests failed across 6 files**; all passed again with the change restored. The tests that fail without the fix:

- `treats copilot as a resumable TUI agent`
- `extracts copilot provider session ids` (x2 — snake_case and camelCase)
- `builds copilot resume argv`
- `captures the Copilot provider session from SessionStart and Stop` — drives the real `_internals.normalizeHookPayload('copilot', ...)` hook path, so a future change to Copilot event normalization that stops capturing session ids fails here. The pure-function tests alone could not catch that, and it is the exact shape of the original regression.
- `captures the Copilot provider session from a camelCase sessionId`
- `uses the documented joined --resume form` and `quotes the resume argv for cmd.exe` — assert the full built launch command: `copilot '--yolo' '--resume=<id>'` and `copilot "--yolo" "--resume=<id>"`
- `drops the joined Copilot resume token and keeps the user args` — pins the flag form against the account-unverified relaunch path
- `honors a command override` — the override path also depends on the new argv case
- `applies the user default args to local Copilot AI Vault resumes` — documents the AI Vault shift above
- `treats an idle done copilot pane as a hibernation candidate` — pins the hibernation eligibility noted above

Also added (passes either way; guards the remote path): `keeps the scanner resume command for remote Copilot sessions`.

Not run locally, per this repo's policy for shared build machines: project-wide `pnpm typecheck` / `pnpm lint` / `pnpm build`. CI covers them. Note that `getAgentResumeArgv` is an exhaustive switch over `ResumableTuiAgent`, so a missing Copilot case is a compile error (TS2366), not a silent gap.

**Manual end-to-end not performed by me.** I did not have a live Copilot CLI session to quit-and-restore. The contributor reports verifying against Copilot CLI 1.0.24 that both `--resume=<id>` and `--resume <id>` reattach; the review stage independently reproduced that against 1.0.80 in an isolated `HOME`. A reviewer with Copilot installed should: open a Copilot pane in a worktree, converse, quit Orca, reopen, and confirm the pane relaunches as `copilot '--yolo' '--resume=<id>'` with the prior conversation present, and that `~/.copilot/session-state/<id>/` matches the hook session id. Worth repeating once over an SSH worktree.

- [ ] I manually tested these changes locally <!-- automated + revert-and-fail proof only; live Copilot CLI restore not exercised, see above -->
- [x] Automated tests added/updated, or explained why not below

## Review

- **Cross-platform:** no path or modifier-key logic touched. The resume argv is a plain token list; quoting is delegated to the existing `quoteStartupArg` for posix/PowerShell/cmd. New tests assert the cmd.exe double-quoted form (`copilot "--yolo" "--resume=<id>"`) alongside the posix single-quoted one, since cmd treats `'` literally.
- **SSH / remote:** the joined flag form is the change that matters here — local and remote Copilot resumes now spell the flag the same way, and the remote branch that replays the scanner's persisted `resumeCommand` verbatim is covered by a new test. The relay-side extractor is content-hash-versioned and redeployed by the client, so no host-side action is needed. The mixed-version note (older host rejects `agent: 'copilot'` on `terminal.ensureAgentSession`) is called out above per `docs/reference/remote-wire-compatibility.md`.
- **Agent / integration compatibility:** Copilot's `SubagentStart` / `SubagentStop` events fall through `normalizeCopilotEvent`'s `stateName` switch and are dropped entirely, so there is no child-session-id leak of the class the Codex `agent_id` guard exists for. Copilot is not in `NATIVE_CHAT_SUPPORTED_AGENTS`, so native chat is unaffected. Persisted records salvage per-entry on downgrade. Folder workspaces and git worktrees take the identical path — nothing here is worktree-specific. No Git command surface touched.
- **Performance:** two switch cases in a function that does no I/O. No new allocation, polling, or subprocess work.
- **UI quality:** N/A — no UI code touched.
- **Security:** the new id flows through the existing `readSessionId` → `normalizeSessionId` gate (rejects non-strings, empty values, >512 chars, a leading `-`, and any char ≤ 0x1f or 0x7f), arrives only over the token-authenticated 127.0.0.1 hook endpoint, and lands in an argv entry that is shell-quoted downstream. No new trust boundary.
- **Contributor diff scan:** I read both hunks of the contributor commit in full (+25/-4, 2 files, both in `src/shared`) looking for network sinks, shell/eval injection, download-and-execute, filesystem or credential reads, embedded secrets, dependency/lockfile/binary edits, install hooks, obfuscated payloads, signing/updater bypass, and prompt-injection text aimed at later agent readers. **Found none** — the diff is plain TypeScript entirely within the stated scope, and the two added comments are ordinary technical notes (I corrected one because it was factually wrong, not because it was suspicious).

## Known limitations / follow-ups

- **`dropAgentResumeArgvFromCommand` does not recognize the AI-Vault-quoted Copilot form.** That helper locates the resume token by `resumeArgs.at(-1)` (`--resume=<id>`) as a literal substring, so the scanner-persisted shape `copilot --resume='<id>'` — where only the id is quoted — reports `absent` instead of `dropped`. **Not reachable today:** both callers hardcode `agent: 'codex'` (`src/main/ipc/pty.ts:4433`, `src/main/codex/codex-unverified-resume-launch.ts:25`), and the shape this PR actually produces (`copilot '--resume=<id>'`) drops correctly, which the new `drops the joined Copilot resume token and keeps the user args` test pins. If the account-unverified drop path is ever generalized past Codex, `resumeArgvSuffixCandidates` needs to also emit the value-only-quoted spelling; fixing it now would touch a Codex-only path this PR has no other reason to enter.
- **No live Copilot CLI end-to-end run by me** — see the Testing section.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security, cross-platform (Linux/Windows/macOS), remote SSH, backwards compatibility, and performance are each addressed in the Review section above. Mobile is unaffected — no mobile code path consumes the TUI resume catalog.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — targeted lint/format/test run locally; full suite left to CI


