### PR TITLE
fix(status-bar): source rate-limit badges from the Active Server that owns usage

### DIFF
--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -63,6 +63,8 @@ import { ClaudeIcon, GeminiIcon, MiniMaxIcon, OpenAIIcon, OpenCodeGoIcon } from 
 import { AgentIcon } from '@/lib/agent-catalog'
 import { UsageRosterPanel, getTightestUsageSection } from './UsageRosterPanel'
 import { getUsageProviderAccountsSectionId } from './usage-provider-settings-target'
+import type { RateLimitState } from '../../../../shared/rate-limit-types'
+import { resolveStatusBarUsageRateLimits } from './usage-rate-limits-source'
 import { formatRateLimitWindowChipLabel } from '@/lib/window-label-formatter'
 import { useResetCountdownClock } from '@/hooks/useResetCountdownClock'
 import {
@@ -93,8 +95,10 @@ import {
 import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import {
   fetchProviderAccountsSnapshot,
+  hasRemoteProviderAccountOwner,
   selectClaudeProviderAccount,
-  selectCodexProviderAccount
+  selectCodexProviderAccount,
+  watchProviderAccounts
 } from '@/runtime/runtime-provider-accounts-client'
 import { toast } from 'sonner'
 import { translate } from '@/i18n/i18n'
@@ -2045,6 +2049,40 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
   const mountedRef = useRef(true)
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
+  // Why (#15798): with a remote Active Server the usage badges must describe the
+  // machine actually running agents. The provider-accounts snapshot already
+  // carries the server's full RateLimitState; the watcher streams its 5-minute
+  // poll refreshes, and the manual refresh button re-fetches the snapshot.
+  const remoteUsageOwner = hasRemoteProviderAccountOwner(settings)
+  const activeRuntimeEnvironmentId = settings?.activeRuntimeEnvironmentId?.trim() || null
+  const [remoteRateLimits, setRemoteRateLimits] = useState<RateLimitState | null>(null)
+  useEffect(() => {
+    if (!remoteUsageOwner) {
+      setRemoteRateLimits(null)
+      return
+    }
+    const watcher = watchProviderAccounts(
+      { activeRuntimeEnvironmentId },
+      {
+        onSnapshot: (snapshot) => {
+          if (snapshot.rateLimits) {
+            setRemoteRateLimits(snapshot.rateLimits)
+          }
+        },
+        onError: (error) => {
+          console.error('Failed to stream remote usage snapshot:', error)
+        }
+      }
+    )
+    return () => {
+      watcher.close()
+    }
+  }, [remoteUsageOwner, activeRuntimeEnvironmentId])
+  const effectiveRateLimits = resolveStatusBarUsageRateLimits(
+    rateLimits,
+    remoteRateLimits,
+    remoteUsageOwner
+  )
   const [menuPoint, setMenuPoint] = useState({ x: 0, y: 0 })
 
   const [containerWidth, setContainerWidth] = useState(900)
@@ -2093,8 +2131,21 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     }
     setIsRefreshing(true)
     try {
+      // Why (#15798): remote-owned usage refreshes by re-fetching the server's
+      // snapshot; the local poll would describe the wrong machine.
+      const usageRefresh = remoteUsageOwner
+        ? fetchProviderAccountsSnapshot({ activeRuntimeEnvironmentId })
+            .then((snapshot) => {
+              if (snapshot.rateLimits) {
+                setRemoteRateLimits(snapshot.rateLimits)
+              }
+            })
+            .catch((error) => {
+              console.error('Failed to refresh remote usage snapshot:', error)
+            })
+        : refreshRateLimits()
       // Why: re-run PATH detection so a freshly-installed/removed CLI's bar appears/hides without restarting Orca.
-      await Promise.all([refreshRateLimits(), refreshDetectedAgents()])
+      await Promise.all([usageRefresh, refreshDetectedAgents()])
     } finally {
       if (mountedRef.current) {
         setIsRefreshing(false)
@@ -2106,7 +2157,8 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     return null
   }
 
-  const { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok } = rateLimits
+  const { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok } =
+    effectiveRateLimits
 
   // Why: a bar is earned by a live snapshot or durable Settings setup; detection-gating hides per-CLI bars when the agent isn't on PATH.
   // Why: Antigravity has no persisted credential, so a checked status item + detected CLI is the durable "show its slot" signal.
@@ -2118,8 +2170,8 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
   const usageSettings = {
     ...settings,
     antigravityUsageConfigured,
-    minimaxCookieConfigured: rateLimits.minimaxCookieConfigured,
-    grokAuthConfigured: rateLimits.grokAuthConfigured
+    minimaxCookieConfigured: effectiveRateLimits.minimaxCookieConfigured,
+    grokAuthConfigured: effectiveRateLimits.grokAuthConfigured
   }
   const visibleClaude = getVisibleUsageProvider('claude', claude, usageSettings)
   const visibleCodex = getVisibleUsageProvider('codex', codex, usageSettings)

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -63,8 +63,8 @@ import { ClaudeIcon, GeminiIcon, MiniMaxIcon, OpenAIIcon, OpenCodeGoIcon } from 
 import { AgentIcon } from '@/lib/agent-catalog'
 import { UsageRosterPanel, getTightestUsageSection } from './UsageRosterPanel'
 import { getUsageProviderAccountsSectionId } from './usage-provider-settings-target'
-import type { RateLimitState } from '../../../../shared/rate-limit-types'
 import { resolveStatusBarUsageRateLimits } from './usage-rate-limits-source'
+import { useRemoteUsageRateLimits } from './remote-usage-rate-limits'
 import { formatRateLimitWindowChipLabel } from '@/lib/window-label-formatter'
 import { useResetCountdownClock } from '@/hooks/useResetCountdownClock'
 import {
@@ -95,10 +95,8 @@ import {
 import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import {
   fetchProviderAccountsSnapshot,
-  hasRemoteProviderAccountOwner,
   selectClaudeProviderAccount,
-  selectCodexProviderAccount,
-  watchProviderAccounts
+  selectCodexProviderAccount
 } from '@/runtime/runtime-provider-accounts-client'
 import { toast } from 'sonner'
 import { translate } from '@/i18n/i18n'
@@ -2050,39 +2048,10 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
   // Why (#15798): with a remote Active Server the usage badges must describe the
-  // machine actually running agents. The provider-accounts snapshot already
-  // carries the server's full RateLimitState; the watcher streams its 5-minute
-  // poll refreshes, and the manual refresh button re-fetches the snapshot.
-  const remoteUsageOwner = hasRemoteProviderAccountOwner(settings)
-  const activeRuntimeEnvironmentId = settings?.activeRuntimeEnvironmentId?.trim() || null
-  const [remoteRateLimits, setRemoteRateLimits] = useState<RateLimitState | null>(null)
-  useEffect(() => {
-    if (!remoteUsageOwner) {
-      setRemoteRateLimits(null)
-      return
-    }
-    const watcher = watchProviderAccounts(
-      { activeRuntimeEnvironmentId },
-      {
-        onSnapshot: (snapshot) => {
-          if (snapshot.rateLimits) {
-            setRemoteRateLimits(snapshot.rateLimits)
-          }
-        },
-        onError: (error) => {
-          console.error('Failed to stream remote usage snapshot:', error)
-        }
-      }
-    )
-    return () => {
-      watcher.close()
-    }
-  }, [remoteUsageOwner, activeRuntimeEnvironmentId])
-  const effectiveRateLimits = resolveStatusBarUsageRateLimits(
-    rateLimits,
-    remoteRateLimits,
-    remoteUsageOwner
-  )
+  // machine actually running agents, so they read the owning server's snapshot
+  // and say so plainly when that server cannot be reached.
+  const remoteUsage = useRemoteUsageRateLimits(settings)
+  const effectiveRateLimits = resolveStatusBarUsageRateLimits(rateLimits, remoteUsage.state)
   const [menuPoint, setMenuPoint] = useState({ x: 0, y: 0 })
 
   const [containerWidth, setContainerWidth] = useState(900)
@@ -2131,27 +2100,17 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     }
     setIsRefreshing(true)
     try {
-      // Why (#15798): remote-owned usage refreshes by re-fetching the server's
-      // snapshot; the local poll would describe the wrong machine.
-      const usageRefresh = remoteUsageOwner
-        ? fetchProviderAccountsSnapshot({ activeRuntimeEnvironmentId })
-            .then((snapshot) => {
-              if (snapshot.rateLimits) {
-                setRemoteRateLimits(snapshot.rateLimits)
-              }
-            })
-            .catch((error) => {
-              console.error('Failed to refresh remote usage snapshot:', error)
-            })
-        : refreshRateLimits()
+      // Why (#15798): remote-owned usage refreshes on the server that owns it;
+      // the local poll would describe the wrong machine.
+      const usageRefresh = remoteUsage.refresh ?? refreshRateLimits
       // Why: re-run PATH detection so a freshly-installed/removed CLI's bar appears/hides without restarting Orca.
-      await Promise.all([usageRefresh, refreshDetectedAgents()])
+      await Promise.all([usageRefresh(), refreshDetectedAgents()])
     } finally {
       if (mountedRef.current) {
         setIsRefreshing(false)
       }
     }
-  }, [isRefreshing, refreshRateLimits, refreshDetectedAgents])
+  }, [isRefreshing, remoteUsage.refresh, refreshRateLimits, refreshDetectedAgents])
 
   if (!statusBarVisible) {
     return null

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -2119,12 +2119,17 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
   const { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok } =
     effectiveRateLimits
 
+  // Why (#15798): PATH detection describes *this* laptop. When a remote Active
+  // Server owns usage, its own snapshot is the availability signal, so falling
+  // back to the pre-detection value (null) keeps the server's bars from being
+  // hidden on a thin client that has no agent CLIs installed.
+  const usageDetectedAgentIds = remoteUsage.state.kind === 'local' ? detectedAgentIds : null
   // Why: a bar is earned by a live snapshot or durable Settings setup; detection-gating hides per-CLI bars when the agent isn't on PATH.
   // Why: Antigravity has no persisted credential, so a checked status item + detected CLI is the durable "show its slot" signal.
   // Why: Antigravity visibility also requires geminiCliOAuthEnabled because its usage snapshot mirrors the Gemini fetch.
   const antigravityUsageConfigured =
     statusBarItems.includes('antigravity') &&
-    isStatusBarItemAvailable('antigravity', detectedAgentIds)
+    isStatusBarItemAvailable('antigravity', usageDetectedAgentIds)
   // Why: thread non-GlobalSettings durability flags so bars stay visible across reloads and snapshot refreshes.
   const usageSettings = {
     ...settings,
@@ -2142,29 +2147,29 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
   const showClaude =
     visibleClaude !== null &&
     statusBarItems.includes('claude') &&
-    isStatusBarItemAvailable('claude', detectedAgentIds)
+    isStatusBarItemAvailable('claude', usageDetectedAgentIds)
   const showCodex =
     visibleCodex !== null &&
     statusBarItems.includes('codex') &&
-    isStatusBarItemAvailable('codex', detectedAgentIds)
+    isStatusBarItemAvailable('codex', usageDetectedAgentIds)
   const showGemini =
     visibleGemini !== null &&
     statusBarItems.includes('gemini') &&
-    isStatusBarItemAvailable('gemini', detectedAgentIds)
+    isStatusBarItemAvailable('gemini', usageDetectedAgentIds)
   const showKimi =
     visibleKimi !== null &&
     statusBarItems.includes('kimi') &&
-    isStatusBarItemAvailable('kimi', detectedAgentIds)
+    isStatusBarItemAvailable('kimi', usageDetectedAgentIds)
   const showAntigravity =
     visibleAntigravity !== null &&
     statusBarItems.includes('antigravity') &&
-    isStatusBarItemAvailable('antigravity', detectedAgentIds)
+    isStatusBarItemAvailable('antigravity', usageDetectedAgentIds)
   // Why: MiniMax is cookie-auth, not a CLI on PATH, so detection-gating doesn't apply.
   const showMiniMax = visibleMiniMax !== null && statusBarItems.includes('minimax')
   const showGrok =
     visibleGrok !== null &&
     statusBarItems.includes('grok') &&
-    isStatusBarItemAvailable('grok', detectedAgentIds)
+    isStatusBarItemAvailable('grok', usageDetectedAgentIds)
   // Why: OpenCode Go is web/cookie-auth, not a CLI on PATH, so detection-gating doesn't apply.
   const visibleOpencodeGo = getVisibleUsageProvider('opencode-go', opencodeGo, usageSettings)
   const showOpencodeGo = visibleOpencodeGo !== null && statusBarItems.includes('opencode-go')
@@ -2462,7 +2467,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
           />
         </DropdownMenuTrigger>
         <DropdownMenuContent className="min-w-0 w-fit" sideOffset={0} align="start">
-          {isStatusBarItemAvailable('claude', detectedAgentIds) && (
+          {isStatusBarItemAvailable('claude', usageDetectedAgentIds) && (
             <DropdownMenuCheckboxItem
               checked={statusBarItems.includes('claude')}
               onCheckedChange={() => {
@@ -2474,7 +2479,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
               {translate('auto.components.status.bar.StatusBar.3885eb74d8', 'Claude Usage')}
             </DropdownMenuCheckboxItem>
           )}
-          {isStatusBarItemAvailable('codex', detectedAgentIds) && (
+          {isStatusBarItemAvailable('codex', usageDetectedAgentIds) && (
             <DropdownMenuCheckboxItem
               checked={statusBarItems.includes('codex')}
               onCheckedChange={() => {
@@ -2486,7 +2491,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
               {translate('auto.components.status.bar.StatusBar.c0909c686e', 'Codex Usage')}
             </DropdownMenuCheckboxItem>
           )}
-          {isStatusBarItemAvailable('gemini', detectedAgentIds) && (
+          {isStatusBarItemAvailable('gemini', usageDetectedAgentIds) && (
             <DropdownMenuCheckboxItem
               checked={statusBarItems.includes('gemini')}
               onCheckedChange={() => {
@@ -2498,7 +2503,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
               {translate('auto.components.status.bar.StatusBar.c1df0d67ec', 'Gemini Usage')}
             </DropdownMenuCheckboxItem>
           )}
-          {isStatusBarItemAvailable('antigravity', detectedAgentIds) && (
+          {isStatusBarItemAvailable('antigravity', usageDetectedAgentIds) && (
             <DropdownMenuCheckboxItem
               checked={statusBarItems.includes('antigravity')}
               onCheckedChange={() => {
@@ -2523,7 +2528,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
             <OpenCodeGoIcon size={14} />
             {translate('auto.components.status.bar.StatusBar.8c86cd77b0', 'OpenCode Go Usage')}
           </DropdownMenuCheckboxItem>
-          {isStatusBarItemAvailable('kimi', detectedAgentIds) && (
+          {isStatusBarItemAvailable('kimi', usageDetectedAgentIds) && (
             <DropdownMenuCheckboxItem
               checked={statusBarItems.includes('kimi')}
               onCheckedChange={() => {
@@ -2545,7 +2550,7 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
             <MiniMaxIcon size={14} />
             {translate('auto.components.status.bar.StatusBar.3bbf140864', 'MiniMax Usage')}
           </DropdownMenuCheckboxItem>
-          {isStatusBarItemAvailable('grok', detectedAgentIds) && (
+          {isStatusBarItemAvailable('grok', usageDetectedAgentIds) && (
             <DropdownMenuCheckboxItem
               checked={statusBarItems.includes('grok')}
               onCheckedChange={() => {

--- a/src/renderer/src/components/status-bar/remote-usage-rate-limits.test.ts
+++ b/src/renderer/src/components/status-bar/remote-usage-rate-limits.test.ts
@@ -144,13 +144,72 @@ describe('useRemoteUsageRateLimits', () => {
     // Why: swallowing this error left the badge spinning forever, which
     // docs/reference/ssh-execution-boundary.md forbids - loss of contact is
     // 'unverifiable', not 'in progress'.
-    expect(result.current.state).toEqual({ kind: 'remote-unreachable', ownerLabel: 'Mac Mini' })
+    expect(result.current.state).toEqual({
+      kind: 'remote-unverifiable',
+      ownerLabel: 'Mac Mini',
+      reason: 'unreachable',
+      lastKnown: null
+    })
 
     act(() => {
       latestWatcher().onSnapshot({ rateLimits: rateLimits(12, 6_000) })
     })
 
     expect(result.current.state.kind).toBe('remote')
+  })
+
+  it('keeps the last snapshot the owner vouched for when contact is lost', () => {
+    const { result } = renderHook(() =>
+      useRemoteUsageRateLimits({ activeRuntimeEnvironmentId: 'env-a' })
+    )
+
+    act(() => {
+      latestWatcher().onSnapshot({ rateLimits: rateLimits(71, 5_000) })
+    })
+    act(() => {
+      latestWatcher().onError(new Error('Remote provider account subscription closed.'))
+    })
+
+    // Why: the badge blanks those numbers but keeps the server's bars in place;
+    // dropping them would make the bars silently disappear on a thin client.
+    expect(result.current.state).toEqual({
+      kind: 'remote-unverifiable',
+      ownerLabel: 'Mac Mini',
+      reason: 'unreachable',
+      lastKnown: rateLimits(71, 5_000)
+    })
+  })
+
+  it('does not spin forever when the owner answers without usage (older host)', () => {
+    const { result } = renderHook(() =>
+      useRemoteUsageRateLimits({ activeRuntimeEnvironmentId: 'env-a' })
+    )
+
+    // Why: this snapshot disarms the client's first-snapshot timeout, so
+    // ignoring it left the badge on the pulsing placeholder with no recovery.
+    act(() => {
+      latestWatcher().onSnapshot({ rateLimits: null })
+    })
+
+    expect(result.current.state).toEqual({
+      kind: 'remote-unverifiable',
+      ownerLabel: 'Mac Mini',
+      reason: 'usage-not-published',
+      lastKnown: null
+    })
+  })
+
+  it('reports a usage-less manual refresh instead of holding the spinner', async () => {
+    const { result } = renderHook(() =>
+      useRemoteUsageRateLimits({ activeRuntimeEnvironmentId: 'env-a' })
+    )
+    mocks.fetchSnapshot.mockResolvedValue({ rateLimits: null })
+
+    await act(async () => {
+      await result.current.refresh!()
+    })
+
+    expect(result.current.state.kind).toBe('remote-unverifiable')
   })
 
   it('falls back to a generic server label for an unknown environment id', () => {
@@ -164,8 +223,10 @@ describe('useRemoteUsageRateLimits', () => {
     })
 
     expect(result.current.state).toEqual({
-      kind: 'remote-unreachable',
-      ownerLabel: 'Remote server'
+      kind: 'remote-unverifiable',
+      ownerLabel: 'Remote server',
+      reason: 'unreachable',
+      lastKnown: null
     })
   })
 
@@ -235,6 +296,11 @@ describe('useRemoteUsageRateLimits', () => {
       await result.current.refresh!()
     })
 
-    expect(result.current.state).toEqual({ kind: 'remote-unreachable', ownerLabel: 'Mac Mini' })
+    expect(result.current.state).toEqual({
+      kind: 'remote-unverifiable',
+      ownerLabel: 'Mac Mini',
+      reason: 'unreachable',
+      lastKnown: null
+    })
   })
 })

--- a/src/renderer/src/components/status-bar/remote-usage-rate-limits.test.ts
+++ b/src/renderer/src/components/status-bar/remote-usage-rate-limits.test.ts
@@ -1,0 +1,240 @@
+// @vitest-environment happy-dom
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ProviderRateLimits, RateLimitState } from '../../../../shared/rate-limit-types'
+import { useRemoteUsageRateLimits } from './remote-usage-rate-limits'
+
+vi.mock('@/i18n/i18n', () => ({
+  i18n: { language: 'en' },
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+const mocks = vi.hoisted(() => ({
+  runtimeEnvironments: [] as { id: string; name: string }[],
+  watchers: [] as {
+    ownerId: string | null
+    closed: boolean
+    onSnapshot: (snapshot: { rateLimits: RateLimitState | null }) => void
+    onError: (error: unknown) => void
+  }[],
+  fetchSnapshot: vi.fn()
+}))
+
+vi.mock('../../store', () => {
+  const state = (): Record<string, unknown> => ({ runtimeEnvironments: mocks.runtimeEnvironments })
+  const useAppStore = (selector: (value: Record<string, unknown>) => unknown): unknown =>
+    selector(state())
+  useAppStore.getState = state
+  return { useAppStore }
+})
+
+vi.mock('@/runtime/runtime-provider-accounts-client', () => ({
+  hasRemoteProviderAccountOwner: (
+    settings: { activeRuntimeEnvironmentId?: string | null } | null | undefined
+  ) => Boolean(settings?.activeRuntimeEnvironmentId?.trim()),
+  watchProviderAccounts: (
+    settings: { activeRuntimeEnvironmentId: string | null },
+    handlers: {
+      onSnapshot: (snapshot: { rateLimits: RateLimitState | null }) => void
+      onError: (error: unknown) => void
+    }
+  ) => {
+    const watcher = {
+      ownerId: settings.activeRuntimeEnvironmentId,
+      closed: false,
+      onSnapshot: handlers.onSnapshot,
+      onError: handlers.onError
+    }
+    mocks.watchers.push(watcher)
+    return {
+      close: () => {
+        watcher.closed = true
+      }
+    }
+  },
+  fetchProviderAccountsSnapshot: (settings: { activeRuntimeEnvironmentId: string | null }) =>
+    mocks.fetchSnapshot(settings)
+}))
+
+function provider(usedPercent: number, updatedAt: number): ProviderRateLimits {
+  return {
+    provider: 'claude',
+    session: { usedPercent, windowMinutes: 300, resetsAt: null, resetDescription: null },
+    weekly: null,
+    updatedAt,
+    error: null,
+    status: 'ok'
+  }
+}
+
+function rateLimits(usedPercent: number, updatedAt: number): RateLimitState {
+  return {
+    claude: provider(usedPercent, updatedAt),
+    codex: null,
+    gemini: null,
+    opencodeGo: null,
+    kimi: null,
+    antigravity: null,
+    minimax: null,
+    grok: null,
+    minimaxCookieConfigured: false,
+    grokAuthConfigured: false,
+    claudeTarget: { runtime: 'host', wslDistro: null },
+    codexTarget: { runtime: 'host', wslDistro: null },
+    inactiveClaudeAccounts: [],
+    inactiveCodexAccounts: []
+  }
+}
+
+function latestWatcher(): (typeof mocks.watchers)[number] {
+  const watcher = mocks.watchers.at(-1)
+  if (!watcher) {
+    throw new Error('no watcher opened')
+  }
+  return watcher
+}
+
+describe('useRemoteUsageRateLimits', () => {
+  beforeEach(() => {
+    mocks.runtimeEnvironments = [
+      { id: 'env-a', name: 'Mac Mini' },
+      { id: 'env-b', name: 'Studio' }
+    ]
+    mocks.watchers = []
+    mocks.fetchSnapshot.mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('stays local and opens no watcher without a remote Active Server', () => {
+    const { result } = renderHook(() =>
+      useRemoteUsageRateLimits({ activeRuntimeEnvironmentId: null })
+    )
+
+    expect(result.current.state).toEqual({ kind: 'local' })
+    expect(result.current.refresh).toBeNull()
+    expect(mocks.watchers).toHaveLength(0)
+  })
+
+  it('is pending until the owning server sends a snapshot, then reports its numbers', () => {
+    const { result } = renderHook(() =>
+      useRemoteUsageRateLimits({ activeRuntimeEnvironmentId: 'env-a' })
+    )
+
+    expect(result.current.state).toEqual({ kind: 'remote-pending' })
+
+    act(() => {
+      latestWatcher().onSnapshot({ rateLimits: rateLimits(71, 5_000) })
+    })
+
+    expect(result.current.state).toEqual({ kind: 'remote', rateLimits: rateLimits(71, 5_000) })
+  })
+
+  it('reports the owner as unreachable when the watcher fails, and recovers on the next snapshot', () => {
+    const { result } = renderHook(() =>
+      useRemoteUsageRateLimits({ activeRuntimeEnvironmentId: 'env-a' })
+    )
+
+    act(() => {
+      latestWatcher().onError(new Error('Timed out waiting for remote provider accounts.'))
+    })
+
+    // Why: swallowing this error left the badge spinning forever, which
+    // docs/reference/ssh-execution-boundary.md forbids - loss of contact is
+    // 'unverifiable', not 'in progress'.
+    expect(result.current.state).toEqual({ kind: 'remote-unreachable', ownerLabel: 'Mac Mini' })
+
+    act(() => {
+      latestWatcher().onSnapshot({ rateLimits: rateLimits(12, 6_000) })
+    })
+
+    expect(result.current.state.kind).toBe('remote')
+  })
+
+  it('falls back to a generic server label for an unknown environment id', () => {
+    mocks.runtimeEnvironments = []
+    const { result } = renderHook(() =>
+      useRemoteUsageRateLimits({ activeRuntimeEnvironmentId: 'env-a' })
+    )
+
+    act(() => {
+      latestWatcher().onError(new Error('Remote provider account subscription closed.'))
+    })
+
+    expect(result.current.state).toEqual({
+      kind: 'remote-unreachable',
+      ownerLabel: 'Remote server'
+    })
+  })
+
+  it("never renders server A's usage under server B", () => {
+    const { result, rerender } = renderHook(
+      (props: { id: string }) => useRemoteUsageRateLimits({ activeRuntimeEnvironmentId: props.id }),
+      { initialProps: { id: 'env-a' } }
+    )
+
+    const watcherA = latestWatcher()
+    act(() => {
+      watcherA.onSnapshot({ rateLimits: rateLimits(71, 5_000) })
+    })
+    expect(result.current.state.kind).toBe('remote')
+
+    rerender({ id: 'env-b' })
+
+    expect(watcherA.closed).toBe(true)
+    expect(result.current.state).toEqual({ kind: 'remote-pending' })
+
+    // A late in-flight callback from A must not land under B's label.
+    act(() => {
+      watcherA.onSnapshot({ rateLimits: rateLimits(99, 9_000) })
+    })
+    expect(result.current.state).toEqual({ kind: 'remote-pending' })
+  })
+
+  it('keeps the refresh promise open until data newer than the click arrives', async () => {
+    const { result } = renderHook(() =>
+      useRemoteUsageRateLimits({ activeRuntimeEnvironmentId: 'env-a' })
+    )
+    act(() => {
+      latestWatcher().onSnapshot({ rateLimits: rateLimits(71, 5_000) })
+    })
+
+    // Why: fetchProviderAccountsSnapshot resolves off the subscribe-time `ready`
+    // frame, which the host emits *before* it re-reads usage. Resolving there
+    // would stop the spinner before any newer data can exist.
+    let settled = false
+    mocks.fetchSnapshot.mockResolvedValue({ rateLimits: rateLimits(71, 5_000) })
+    const refresh = result.current.refresh
+    expect(refresh).not.toBeNull()
+
+    await act(async () => {
+      const pending = refresh!().then(() => {
+        settled = true
+      })
+      await Promise.resolve()
+      await Promise.resolve()
+      expect(settled).toBe(false)
+      latestWatcher().onSnapshot({ rateLimits: rateLimits(73, 7_000) })
+      await pending
+    })
+
+    expect(settled).toBe(true)
+    expect(mocks.fetchSnapshot).toHaveBeenCalledWith({ activeRuntimeEnvironmentId: 'env-a' })
+    expect(result.current.state).toEqual({ kind: 'remote', rateLimits: rateLimits(73, 7_000) })
+  })
+
+  it('reports the owner as unreachable when a manual refresh cannot reach it', async () => {
+    const { result } = renderHook(() =>
+      useRemoteUsageRateLimits({ activeRuntimeEnvironmentId: 'env-a' })
+    )
+    mocks.fetchSnapshot.mockRejectedValue(new Error('offline'))
+
+    await act(async () => {
+      await result.current.refresh!()
+    })
+
+    expect(result.current.state).toEqual({ kind: 'remote-unreachable', ownerLabel: 'Mac Mini' })
+  })
+})

--- a/src/renderer/src/components/status-bar/remote-usage-rate-limits.ts
+++ b/src/renderer/src/components/status-bar/remote-usage-rate-limits.ts
@@ -8,7 +8,11 @@ import {
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import type { RateLimitState } from '../../../../shared/rate-limit-types'
 import { useAppStore } from '../../store'
-import { latestUsageUpdatedAt, type RemoteUsageState } from './usage-rate-limits-source'
+import {
+  latestUsageUpdatedAt,
+  type RemoteUsageFailureReason,
+  type RemoteUsageState
+} from './usage-rate-limits-source'
 
 type RemoteUsageSettings = Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
 
@@ -29,7 +33,7 @@ export type RemoteUsageRateLimits = {
 type OwnedUsageSnapshot = {
   ownerId: string | null
   rateLimits: RateLimitState | null
-  unreachable: boolean
+  failure: RemoteUsageFailureReason | null
 }
 
 // Why: a fresh accounts.subscribe makes the host run refreshIfStale, but the
@@ -53,9 +57,10 @@ export function resolveRemoteUsageOwnerLabel(
  *
  * The provider-accounts snapshot the accounts roster already consumes carries
  * the server's full RateLimitState, so no new RPC or stream opcode is needed.
- * A watcher error resolves to `remote-unreachable` rather than an endless
- * spinner: per docs/reference/ssh-execution-boundary.md, losing contact with
- * the execution host is its own verdict and must not be rendered as progress.
+ * A watcher error - or a host that answers without usage - resolves to
+ * `remote-unverifiable` rather than an endless spinner: per
+ * docs/reference/ssh-execution-boundary.md, losing contact with the execution
+ * host is its own verdict and must not be rendered as progress.
  */
 export function useRemoteUsageRateLimits(settings: RemoteUsageSettings): RemoteUsageRateLimits {
   const remoteUsageOwner = hasRemoteProviderAccountOwner(settings)
@@ -64,6 +69,13 @@ export function useRemoteUsageRateLimits(settings: RemoteUsageSettings): RemoteU
   const [owned, setOwned] = useState<OwnedUsageSnapshot | null>(null)
   const ownedRef = useRef<OwnedUsageSnapshot | null>(null)
   const pendingRefreshRef = useRef<{ afterUpdatedAt: number; settle: () => void } | null>(null)
+
+  // Why: a failed watcher must not erase the numbers the server already vouched
+  // for; the bars keep their slots and carry the verdict instead of vanishing.
+  const lastKnownFor = useCallback((owner: string | null): RateLimitState | null => {
+    const current = ownedRef.current
+    return current && current.ownerId === owner ? current.rateLimits : null
+  }, [])
 
   const applyOwned = useCallback((next: OwnedUsageSnapshot) => {
     ownedRef.current = next
@@ -86,10 +98,21 @@ export function useRemoteUsageRateLimits(settings: RemoteUsageSettings): RemoteU
       { activeRuntimeEnvironmentId: ownerId },
       {
         onSnapshot: (snapshot) => {
-          if (!active || !snapshot.rateLimits) {
+          if (!active) {
             return
           }
-          applyOwned({ ownerId, rateLimits: snapshot.rateLimits, unreachable: false })
+          if (!snapshot.rateLimits) {
+            // Why: a host too old to publish usage still counts as the watcher's
+            // first snapshot, disarming its timeout. Dropping it would pin the
+            // badge on a spinner with no error path and no recovery.
+            applyOwned({
+              ownerId,
+              rateLimits: lastKnownFor(ownerId),
+              failure: 'usage-not-published'
+            })
+            return
+          }
+          applyOwned({ ownerId, rateLimits: snapshot.rateLimits, failure: null })
         },
         onError: () => {
           if (!active) {
@@ -99,7 +122,7 @@ export function useRemoteUsageRateLimits(settings: RemoteUsageSettings): RemoteU
           // subscription and RPC failures through this one channel. All of them
           // mean the same thing for the badge - the owner cannot be reached, so
           // its usage is unverifiable, not zero and not still loading.
-          applyOwned({ ownerId, rateLimits: null, unreachable: true })
+          applyOwned({ ownerId, rateLimits: lastKnownFor(ownerId), failure: 'unreachable' })
         }
       }
     )
@@ -108,7 +131,7 @@ export function useRemoteUsageRateLimits(settings: RemoteUsageSettings): RemoteU
       watcher.close()
       pendingRefreshRef.current?.settle()
     }
-  }, [remoteUsageOwner, ownerId, applyOwned])
+  }, [remoteUsageOwner, ownerId, applyOwned, lastKnownFor])
 
   const refresh = useCallback(async () => {
     const current = ownedRef.current
@@ -135,14 +158,17 @@ export function useRemoteUsageRateLimits(settings: RemoteUsageSettings): RemoteU
     try {
       const snapshot = await fetchProviderAccountsSnapshot({ activeRuntimeEnvironmentId: ownerId })
       if (snapshot.rateLimits) {
-        applyOwned({ ownerId, rateLimits: snapshot.rateLimits, unreachable: false })
+        applyOwned({ ownerId, rateLimits: snapshot.rateLimits, failure: null })
+      } else {
+        applyOwned({ ownerId, rateLimits: lastKnownFor(ownerId), failure: 'usage-not-published' })
+        entry.settle()
       }
     } catch {
-      applyOwned({ ownerId, rateLimits: null, unreachable: true })
+      applyOwned({ ownerId, rateLimits: lastKnownFor(ownerId), failure: 'unreachable' })
       entry.settle()
     }
     await settled
-  }, [ownerId, applyOwned])
+  }, [ownerId, applyOwned, lastKnownFor])
 
   const ownerLabel = useMemo(
     () => resolveRemoteUsageOwnerLabel(runtimeEnvironments, ownerId),
@@ -158,11 +184,16 @@ export function useRemoteUsageRateLimits(settings: RemoteUsageSettings): RemoteU
     if (!owned || owned.ownerId !== ownerId) {
       return { kind: 'remote-pending' }
     }
-    if (owned.rateLimits) {
-      return { kind: 'remote', rateLimits: owned.rateLimits }
+    if (owned.failure) {
+      return {
+        kind: 'remote-unverifiable',
+        ownerLabel,
+        reason: owned.failure,
+        lastKnown: owned.rateLimits
+      }
     }
-    return owned.unreachable
-      ? { kind: 'remote-unreachable', ownerLabel }
+    return owned.rateLimits
+      ? { kind: 'remote', rateLimits: owned.rateLimits }
       : { kind: 'remote-pending' }
   }, [remoteUsageOwner, owned, ownerId, ownerLabel])
 

--- a/src/renderer/src/components/status-bar/remote-usage-rate-limits.ts
+++ b/src/renderer/src/components/status-bar/remote-usage-rate-limits.ts
@@ -1,0 +1,170 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { translate } from '@/i18n/i18n'
+import {
+  fetchProviderAccountsSnapshot,
+  hasRemoteProviderAccountOwner,
+  watchProviderAccounts
+} from '@/runtime/runtime-provider-accounts-client'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import type { RateLimitState } from '../../../../shared/rate-limit-types'
+import { useAppStore } from '../../store'
+import { latestUsageUpdatedAt, type RemoteUsageState } from './usage-rate-limits-source'
+
+type RemoteUsageSettings = Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
+
+export type RemoteUsageRateLimits = {
+  state: RemoteUsageState
+  /**
+   * Forces the owning server to re-read usage, or null when the local machine
+   * owns it and the caller should run its own refresh instead.
+   */
+  refresh: (() => Promise<void>) | null
+}
+
+/**
+ * A snapshot is only meaningful next to the server it came from: switching
+ * server A -> B closes A's watcher but an in-flight callback can still land,
+ * and the old numbers would render under B's name.
+ */
+type OwnedUsageSnapshot = {
+  ownerId: string | null
+  rateLimits: RateLimitState | null
+  unreachable: boolean
+}
+
+// Why: a fresh accounts.subscribe makes the host run refreshIfStale, but the
+// `ready` frame it answers with is emitted *before* that refresh. Hold the
+// spinner until newer data actually arrives, and cap the wait so a host that
+// throttled the refetch (or has nothing new) still releases the button.
+const REMOTE_USAGE_REFRESH_SETTLE_TIMEOUT_MS = 8_000
+
+export function resolveRemoteUsageOwnerLabel(
+  environments: readonly { id: string; name?: string | null }[] | null | undefined,
+  ownerId: string | null
+): string {
+  const name = environments?.find((environment) => environment.id === ownerId)?.name?.trim()
+  return (
+    name || translate('auto.components.status.bar.StatusBar.remoteServerLabel', 'Remote server')
+  )
+}
+
+/**
+ * Streams the usage numbers of whichever machine owns provider accounts (#15798).
+ *
+ * The provider-accounts snapshot the accounts roster already consumes carries
+ * the server's full RateLimitState, so no new RPC or stream opcode is needed.
+ * A watcher error resolves to `remote-unreachable` rather than an endless
+ * spinner: per docs/reference/ssh-execution-boundary.md, losing contact with
+ * the execution host is its own verdict and must not be rendered as progress.
+ */
+export function useRemoteUsageRateLimits(settings: RemoteUsageSettings): RemoteUsageRateLimits {
+  const remoteUsageOwner = hasRemoteProviderAccountOwner(settings)
+  const ownerId = settings?.activeRuntimeEnvironmentId?.trim() || null
+  const runtimeEnvironments = useAppStore((s) => s.runtimeEnvironments)
+  const [owned, setOwned] = useState<OwnedUsageSnapshot | null>(null)
+  const ownedRef = useRef<OwnedUsageSnapshot | null>(null)
+  const pendingRefreshRef = useRef<{ afterUpdatedAt: number; settle: () => void } | null>(null)
+
+  const applyOwned = useCallback((next: OwnedUsageSnapshot) => {
+    ownedRef.current = next
+    setOwned(next)
+    const pending = pendingRefreshRef.current
+    if (pending && latestUsageUpdatedAt(next.rateLimits) > pending.afterUpdatedAt) {
+      pending.settle()
+    }
+  }, [])
+
+  useEffect(() => {
+    ownedRef.current = null
+    setOwned(null)
+    pendingRefreshRef.current?.settle()
+    if (!remoteUsageOwner) {
+      return
+    }
+    let active = true
+    const watcher = watchProviderAccounts(
+      { activeRuntimeEnvironmentId: ownerId },
+      {
+        onSnapshot: (snapshot) => {
+          if (!active || !snapshot.rateLimits) {
+            return
+          }
+          applyOwned({ ownerId, rateLimits: snapshot.rateLimits, unreachable: false })
+        },
+        onError: () => {
+          if (!active) {
+            return
+          }
+          // Why: the watcher reports a first-snapshot timeout, a closed
+          // subscription and RPC failures through this one channel. All of them
+          // mean the same thing for the badge - the owner cannot be reached, so
+          // its usage is unverifiable, not zero and not still loading.
+          applyOwned({ ownerId, rateLimits: null, unreachable: true })
+        }
+      }
+    )
+    return () => {
+      active = false
+      watcher.close()
+      pendingRefreshRef.current?.settle()
+    }
+  }, [remoteUsageOwner, ownerId, applyOwned])
+
+  const refresh = useCallback(async () => {
+    const current = ownedRef.current
+    const afterUpdatedAt =
+      current?.ownerId === ownerId ? latestUsageUpdatedAt(current.rateLimits) : 0
+    let resolveSettled: () => void = () => {}
+    const settled = new Promise<void>((resolve) => {
+      resolveSettled = resolve
+    })
+    let timer = 0
+    const entry = {
+      afterUpdatedAt,
+      settle: (): void => {
+        window.clearTimeout(timer)
+        if (pendingRefreshRef.current === entry) {
+          pendingRefreshRef.current = null
+        }
+        resolveSettled()
+      }
+    }
+    timer = window.setTimeout(entry.settle, REMOTE_USAGE_REFRESH_SETTLE_TIMEOUT_MS)
+    pendingRefreshRef.current?.settle()
+    pendingRefreshRef.current = entry
+    try {
+      const snapshot = await fetchProviderAccountsSnapshot({ activeRuntimeEnvironmentId: ownerId })
+      if (snapshot.rateLimits) {
+        applyOwned({ ownerId, rateLimits: snapshot.rateLimits, unreachable: false })
+      }
+    } catch {
+      applyOwned({ ownerId, rateLimits: null, unreachable: true })
+      entry.settle()
+    }
+    await settled
+  }, [ownerId, applyOwned])
+
+  const ownerLabel = useMemo(
+    () => resolveRemoteUsageOwnerLabel(runtimeEnvironments, ownerId),
+    [runtimeEnvironments, ownerId]
+  )
+
+  const state = useMemo<RemoteUsageState>(() => {
+    if (!remoteUsageOwner) {
+      return { kind: 'local' }
+    }
+    // Why: a render can run with the new owner before the effect has torn the
+    // old watcher down, so a snapshot is only used under the owner it names.
+    if (!owned || owned.ownerId !== ownerId) {
+      return { kind: 'remote-pending' }
+    }
+    if (owned.rateLimits) {
+      return { kind: 'remote', rateLimits: owned.rateLimits }
+    }
+    return owned.unreachable
+      ? { kind: 'remote-unreachable', ownerLabel }
+      : { kind: 'remote-pending' }
+  }, [remoteUsageOwner, owned, ownerId, ownerLabel])
+
+  return { state, refresh: remoteUsageOwner ? refresh : null }
+}

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
@@ -115,7 +115,7 @@ export function hasUsageProviderSettingsForProvider(
   return false
 }
 
-function createPendingProviderSnapshot(providerId: UsageProviderId): ProviderRateLimits {
+export function createPendingProviderSnapshot(providerId: UsageProviderId): ProviderRateLimits {
   return {
     provider: providerId,
     session: null,

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
@@ -32,7 +32,7 @@ type UsageProviderSnapshots = {
 
 type UsageProviderId = ProviderRateLimits['provider']
 
-function hasUsageData(provider: ProviderRateLimits): boolean {
+export function hasUsageData(provider: ProviderRateLimits): boolean {
   return Boolean(
     provider.session ||
     provider.weekly ||

--- a/src/renderer/src/components/status-bar/usage-error-copy.ts
+++ b/src/renderer/src/components/status-bar/usage-error-copy.ts
@@ -76,6 +76,12 @@ function getDelegatedCliRefreshProvider(
 }
 
 export function getProviderUsageStatusLabel(p: ProviderRateLimits): string {
+  // Why (#15798): nothing about the provider failed — the machine that owns the
+  // numbers is unverifiable, so provider-classified copy such as "Refresh
+  // failed" would blame the wrong thing and imply a retry can fix it.
+  if (p.usageMetadata?.unverifiableUsageOwner) {
+    return translate('auto.components.status.bar.tooltip.f8b8dbed85', 'Usage unavailable')
+  }
   const delegatedCliProvider = getDelegatedCliRefreshProvider(p)
   if (delegatedCliProvider === 'grok') {
     return translate('auto.components.status.bar.tooltip.e2c6a4f917', 'Run Grok to refresh')

--- a/src/renderer/src/components/status-bar/usage-rate-limits-source.test.ts
+++ b/src/renderer/src/components/status-bar/usage-rate-limits-source.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import type { RateLimitState } from '../../../../shared/rate-limit-types'
+import { resolveStatusBarUsageRateLimits } from './usage-rate-limits-source'
+
+function localState(): RateLimitState {
+  return {
+    claude: {
+      provider: 'claude',
+      session: null,
+      weekly: null,
+      updatedAt: 1,
+      error: 'Refresh failed',
+      status: 'error'
+    },
+    codex: null,
+    gemini: null,
+    opencodeGo: null,
+    kimi: null,
+    antigravity: null,
+    minimax: null,
+    grok: null,
+    minimaxCookieConfigured: true,
+    grokAuthConfigured: false,
+    claudeTarget: { runtime: 'host', wslDistro: null },
+    codexTarget: { runtime: 'host', wslDistro: null },
+    inactiveClaudeAccounts: [],
+    inactiveCodexAccounts: []
+  } as RateLimitState
+}
+
+function remoteState(): RateLimitState {
+  return { ...localState(), minimaxCookieConfigured: false }
+}
+
+describe('resolveStatusBarUsageRateLimits', () => {
+  it('shows local usage when no remote Active Server owns accounts', () => {
+    const local = localState()
+    expect(resolveStatusBarUsageRateLimits(local, remoteState(), false)).toBe(local)
+  })
+
+  it('shows the remote snapshot when a remote Active Server owns accounts (#15798)', () => {
+    const local = localState()
+    const remote = remoteState()
+    const resolved = resolveStatusBarUsageRateLimits(local, remote, true)
+    expect(resolved).toBe(remote)
+  })
+
+  it('degrades to a fetching state rather than flashing local numbers before the first snapshot', () => {
+    const local = localState()
+    const resolved = resolveStatusBarUsageRateLimits(local, null, true)
+    expect(resolved.claude).toMatchObject({ status: 'fetching' })
+    // The stale local error must not read as the remote machine's state.
+    expect(resolved.claude).not.toMatchObject({ status: 'error' })
+    // Durability flags stay local so provider bars keep their visibility rules.
+    expect(resolved.minimaxCookieConfigured).toBe(true)
+  })
+
+  it('keeps a null provider null in the fetching degrade', () => {
+    const resolved = resolveStatusBarUsageRateLimits(localState(), null, true)
+    expect(resolved.codex).toBeNull()
+  })
+})

--- a/src/renderer/src/components/status-bar/usage-rate-limits-source.test.ts
+++ b/src/renderer/src/components/status-bar/usage-rate-limits-source.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import type { ProviderRateLimits, RateLimitState } from '../../../../shared/rate-limit-types'
+import { getVisibleUsageProvider, isUsageEmptyState } from './status-bar-provider-visibility'
 import { latestUsageUpdatedAt, resolveStatusBarUsageRateLimits } from './usage-rate-limits-source'
 
 vi.mock('@/i18n/i18n', () => ({
@@ -134,6 +135,85 @@ describe('resolveStatusBarUsageRateLimits', () => {
       expect(provider?.session).toBeNull()
       expect(provider?.weekly).toBeNull()
     }
+  })
+
+  it('does not invent bars for providers the viewer never set up (#15804)', () => {
+    const local = localState()
+    local.minimax = null
+    local.opencodeGo = {
+      provider: 'opencode-go',
+      session: null,
+      weekly: null,
+      monthly: null,
+      updatedAt: 2_000,
+      error: 'Session cookie not configured',
+      status: 'unavailable'
+    }
+    local.minimaxCookieConfigured = false
+
+    const resolved = resolveStatusBarUsageRateLimits(local, {
+      kind: 'remote-unreachable',
+      ownerLabel: 'Mac Mini'
+    })
+    const settings = {
+      antigravityUsageConfigured: false,
+      minimaxCookieConfigured: resolved.minimaxCookieConfigured,
+      grokAuthConfigured: resolved.grokAuthConfigured
+    }
+
+    // Why: an 'error' snapshot reads as "configured" to the visibility gate, so
+    // stamping unconfigured providers pins bars the user never enabled.
+    expect(resolved.minimax).toBeNull()
+    expect(resolved.opencodeGo?.status).toBe('unavailable')
+    expect(getVisibleUsageProvider('minimax', resolved.minimax, settings)).toBeNull()
+    expect(getVisibleUsageProvider('opencode-go', resolved.opencodeGo, settings)).toBeNull()
+    // Grok is configured locally, so its bar survives carrying the honest verdict.
+    expect(getVisibleUsageProvider('grok', resolved.grok, settings)?.error).toBe(
+      'Usage unavailable — cannot reach Mac Mini'
+    )
+  })
+
+  it('leaves the usage setup CTA reachable when nothing is configured (#15804)', () => {
+    const unconfigured = localState()
+    for (const key of PROVIDER_KEYS) {
+      unconfigured[key] = {
+        provider: key === 'opencodeGo' ? 'opencode-go' : key,
+        session: null,
+        weekly: null,
+        updatedAt: 2_000,
+        error: 'Not signed in',
+        status: 'unavailable'
+      }
+    }
+    unconfigured.minimaxCookieConfigured = false
+    unconfigured.grokAuthConfigured = false
+
+    const resolved = resolveStatusBarUsageRateLimits(unconfigured, {
+      kind: 'remote-unreachable',
+      ownerLabel: 'Mac Mini'
+    })
+
+    // Why: synthesized 'error' snapshots count as configured providers, which
+    // would silently swallow the "connect an account" empty state.
+    expect(
+      isUsageEmptyState(
+        {
+          claude: resolved.claude,
+          codex: resolved.codex,
+          gemini: resolved.gemini,
+          opencodeGo: resolved.opencodeGo,
+          kimi: resolved.kimi,
+          antigravity: resolved.antigravity,
+          minimax: resolved.minimax,
+          grok: resolved.grok
+        },
+        {
+          antigravityUsageConfigured: false,
+          minimaxCookieConfigured: false,
+          grokAuthConfigured: false
+        }
+      )
+    ).toBe(true)
   })
 })
 

--- a/src/renderer/src/components/status-bar/usage-rate-limits-source.test.ts
+++ b/src/renderer/src/components/status-bar/usage-rate-limits-source.test.ts
@@ -1,62 +1,178 @@
-import { describe, expect, it } from 'vitest'
-import type { RateLimitState } from '../../../../shared/rate-limit-types'
-import { resolveStatusBarUsageRateLimits } from './usage-rate-limits-source'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import type { ProviderRateLimits, RateLimitState } from '../../../../shared/rate-limit-types'
+import { latestUsageUpdatedAt, resolveStatusBarUsageRateLimits } from './usage-rate-limits-source'
+
+vi.mock('@/i18n/i18n', () => ({
+  i18n: { language: 'en' },
+  translate: (_key: string, fallback: string, values?: Record<string, string>) => {
+    let result = fallback
+    for (const [key, value] of Object.entries(values ?? {})) {
+      result = result.replaceAll(`{{${key}}}`, value)
+    }
+    return result
+  }
+}))
+
+const PROVIDER_KEYS = [
+  'claude',
+  'codex',
+  'gemini',
+  'opencodeGo',
+  'kimi',
+  'antigravity',
+  'minimax',
+  'grok'
+] as const
+
+function providerWithUsage(
+  provider: ProviderRateLimits['provider'],
+  usedPercent: number,
+  updatedAt: number
+): ProviderRateLimits {
+  return {
+    provider,
+    session: { usedPercent, windowMinutes: 300, resetsAt: null, resetDescription: null },
+    weekly: null,
+    updatedAt,
+    // Why: the reported symptom is a *valid-looking* local snapshot leaking, so
+    // the fixture carries both real windows and a stale local error string.
+    error: 'Refresh failed',
+    status: 'error'
+  }
+}
 
 function localState(): RateLimitState {
   return {
-    claude: {
-      provider: 'claude',
-      session: null,
-      weekly: null,
-      updatedAt: 1,
-      error: 'Refresh failed',
-      status: 'error'
-    },
-    codex: null,
-    gemini: null,
-    opencodeGo: null,
-    kimi: null,
-    antigravity: null,
-    minimax: null,
-    grok: null,
+    claude: providerWithUsage('claude', 42, 1_000),
+    codex: providerWithUsage('codex', 43, 1_000),
+    gemini: providerWithUsage('gemini', 44, 1_000),
+    opencodeGo: providerWithUsage('opencode-go', 45, 1_000),
+    kimi: providerWithUsage('kimi', 46, 1_000),
+    antigravity: providerWithUsage('antigravity', 47, 1_000),
+    minimax: providerWithUsage('minimax', 48, 1_000),
+    grok: providerWithUsage('grok', 49, 1_000),
     minimaxCookieConfigured: true,
-    grokAuthConfigured: false,
+    grokAuthConfigured: true,
     claudeTarget: { runtime: 'host', wslDistro: null },
     codexTarget: { runtime: 'host', wslDistro: null },
     inactiveClaudeAccounts: [],
     inactiveCodexAccounts: []
-  } as RateLimitState
+  }
 }
 
 function remoteState(): RateLimitState {
-  return { ...localState(), minimaxCookieConfigured: false }
+  return {
+    ...localState(),
+    claude: providerWithUsage('claude', 71, 5_000),
+    minimaxCookieConfigured: false,
+    grokAuthConfigured: false
+  }
 }
 
 describe('resolveStatusBarUsageRateLimits', () => {
   it('shows local usage when no remote Active Server owns accounts', () => {
     const local = localState()
-    expect(resolveStatusBarUsageRateLimits(local, remoteState(), false)).toBe(local)
+    expect(resolveStatusBarUsageRateLimits(local, { kind: 'local' })).toBe(local)
   })
 
-  it('shows the remote snapshot when a remote Active Server owns accounts (#15798)', () => {
-    const local = localState()
-    const remote = remoteState()
-    const resolved = resolveStatusBarUsageRateLimits(local, remote, true)
-    expect(resolved).toBe(remote)
+  it("shows the owning server's numbers once its snapshot lands (#15798)", () => {
+    const resolved = resolveStatusBarUsageRateLimits(localState(), {
+      kind: 'remote',
+      rateLimits: remoteState()
+    })
+    expect(resolved.claude?.session?.usedPercent).toBe(71)
+    // Why: the server owns sign-in state too, so its flags win when it sends them.
+    expect(resolved.minimaxCookieConfigured).toBe(false)
+    expect(resolved.grokAuthConfigured).toBe(false)
   })
 
-  it('degrades to a fetching state rather than flashing local numbers before the first snapshot', () => {
-    const local = localState()
-    const resolved = resolveStatusBarUsageRateLimits(local, null, true)
-    expect(resolved.claude).toMatchObject({ status: 'fetching' })
-    // The stale local error must not read as the remote machine's state.
-    expect(resolved.claude).not.toMatchObject({ status: 'error' })
-    // Durability flags stay local so provider bars keep their visibility rules.
+  it('falls back to local durability flags when the host predates them', () => {
+    // Why: RateLimitState declares both flags as required, but an older remote
+    // Orca omits them entirely. Reading them raw would hide configured bars.
+    const preFlagHost = remoteState()
+    delete (preFlagHost as Partial<RateLimitState>).minimaxCookieConfigured
+    delete (preFlagHost as Partial<RateLimitState>).grokAuthConfigured
+
+    const resolved = resolveStatusBarUsageRateLimits(localState(), {
+      kind: 'remote',
+      rateLimits: preFlagHost
+    })
+
     expect(resolved.minimaxCookieConfigured).toBe(true)
+    expect(resolved.grokAuthConfigured).toBe(true)
   })
 
-  it('keeps a null provider null in the fetching degrade', () => {
-    const resolved = resolveStatusBarUsageRateLimits(localState(), null, true)
-    expect(resolved.codex).toBeNull()
+  it('never renders local percentages while the first remote snapshot is in flight', () => {
+    const resolved = resolveStatusBarUsageRateLimits(localState(), { kind: 'remote-pending' })
+
+    // Why: #15798 calls valid-looking local numbers "arguably worse than an
+    // error state". Every provider must be blank, not just the null ones.
+    for (const key of PROVIDER_KEYS) {
+      const provider = resolved[key]
+      expect(provider?.status).toBe('fetching')
+      expect(provider?.session).toBeNull()
+      expect(provider?.weekly).toBeNull()
+      expect(provider?.error).toBeNull()
+      expect(provider?.updatedAt).toBe(0)
+    }
+  })
+
+  it('reports an unreachable owner instead of a spinner or a healthy bar', () => {
+    const resolved = resolveStatusBarUsageRateLimits(localState(), {
+      kind: 'remote-unreachable',
+      ownerLabel: 'Mac Mini'
+    })
+
+    for (const key of PROVIDER_KEYS) {
+      const provider = resolved[key]
+      // docs/reference/ssh-execution-boundary.md: loss of contact is its own
+      // verdict — never 0%, never "still loading".
+      expect(provider?.status).toBe('error')
+      expect(provider?.error).toBe('Usage unavailable — cannot reach Mac Mini')
+      expect(provider?.session).toBeNull()
+      expect(provider?.weekly).toBeNull()
+    }
+  })
+})
+
+describe('latestUsageUpdatedAt', () => {
+  it('returns the newest provider timestamp', () => {
+    expect(latestUsageUpdatedAt(remoteState())).toBe(5_000)
+  })
+
+  it('returns 0 when nothing has landed', () => {
+    expect(latestUsageUpdatedAt(null)).toBe(0)
+  })
+})
+
+/**
+ * Why a source assertion: the resolver is pure, so reverting StatusBar back to
+ * the raw `rateLimits` store slice would leave every behavioural test above
+ * green while restoring the reported bug. This pins the one wiring line that
+ * decides which machine the badges describe.
+ */
+describe('StatusBar badge source wiring', () => {
+  const source = readFileSync(resolve(__dirname, 'StatusBar.tsx'), 'utf8')
+
+  it('destructures the rendered providers from the resolved state', () => {
+    expect(source).toMatch(
+      /const \{ claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok \} =\s*\n?\s*effectiveRateLimits/
+    )
+  })
+
+  it('reads the durability flags from the resolved state', () => {
+    expect(source).toContain('minimaxCookieConfigured: effectiveRateLimits.minimaxCookieConfigured')
+    expect(source).toContain('grokAuthConfigured: effectiveRateLimits.grokAuthConfigured')
+  })
+
+  it('rebuilds the refresh callback when the owning server changes', () => {
+    // Why: refreshRateLimits/refreshDetectedAgents are stable store selectors,
+    // so without the hook's owner-keyed refresh in the deps the closure would
+    // keep refreshing the machine that was active when it was first created.
+    expect(source).toContain(
+      '}, [isRefreshing, remoteUsage.refresh, refreshRateLimits, refreshDetectedAgents])'
+    )
   })
 })

--- a/src/renderer/src/components/status-bar/usage-rate-limits-source.test.ts
+++ b/src/renderer/src/components/status-bar/usage-rate-limits-source.test.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import type { ProviderRateLimits, RateLimitState } from '../../../../shared/rate-limit-types'
 import { getVisibleUsageProvider, isUsageEmptyState } from './status-bar-provider-visibility'
+import { getProviderUsageStatusLabel } from './usage-error-copy'
 import { latestUsageUpdatedAt, resolveStatusBarUsageRateLimits } from './usage-rate-limits-source'
 
 vi.mock('@/i18n/i18n', () => ({
@@ -122,8 +123,9 @@ describe('resolveStatusBarUsageRateLimits', () => {
 
   it('reports an unreachable owner instead of a spinner or a healthy bar', () => {
     const resolved = resolveStatusBarUsageRateLimits(localState(), {
-      kind: 'remote-unreachable',
-      ownerLabel: 'Mac Mini'
+      kind: 'remote-unverifiable',
+      ownerLabel: 'Mac Mini',
+      reason: 'unreachable'
     })
 
     for (const key of PROVIDER_KEYS) {
@@ -152,8 +154,9 @@ describe('resolveStatusBarUsageRateLimits', () => {
     local.minimaxCookieConfigured = false
 
     const resolved = resolveStatusBarUsageRateLimits(local, {
-      kind: 'remote-unreachable',
-      ownerLabel: 'Mac Mini'
+      kind: 'remote-unverifiable',
+      ownerLabel: 'Mac Mini',
+      reason: 'unreachable'
     })
     const settings = {
       antigravityUsageConfigured: false,
@@ -173,6 +176,57 @@ describe('resolveStatusBarUsageRateLimits', () => {
     )
   })
 
+  it('says the owner does not report usage instead of claiming it is unreachable', () => {
+    // Why: a host too old to publish rateLimits answered us; "cannot reach" it
+    // would be a false statement about a server that is plainly live.
+    const resolved = resolveStatusBarUsageRateLimits(localState(), {
+      kind: 'remote-unverifiable',
+      ownerLabel: 'Mac Mini',
+      reason: 'usage-not-published'
+    })
+
+    expect(resolved.claude?.error).toBe('Usage unavailable — Mac Mini does not report usage')
+    expect(resolved.claude?.status).toBe('error')
+    expect(resolved.claude?.session).toBeNull()
+  })
+
+  it('labels an unverifiable owner as unavailable rather than "Refresh failed"', () => {
+    const resolved = resolveStatusBarUsageRateLimits(localState(), {
+      kind: 'remote-unverifiable',
+      ownerLabel: 'Mac Mini',
+      reason: 'unreachable'
+    })
+
+    // Why: the inline badge label is the string #15798 complains about; without
+    // the marker it reads "Refresh failed", blaming a fetch that never ran.
+    for (const key of PROVIDER_KEYS) {
+      expect(getProviderUsageStatusLabel(resolved[key]!)).toBe('Usage unavailable')
+    }
+  })
+
+  it('keeps the bars the unreachable server vouched for, blanked (#15798)', () => {
+    // Thin client: nothing configured locally, everything configured on the server.
+    const thinClient = localState()
+    for (const key of PROVIDER_KEYS) {
+      thinClient[key] = null
+    }
+    thinClient.minimaxCookieConfigured = false
+    thinClient.grokAuthConfigured = false
+
+    const resolved = resolveStatusBarUsageRateLimits(thinClient, {
+      kind: 'remote-unverifiable',
+      ownerLabel: 'Mac Mini',
+      reason: 'unreachable',
+      lastKnown: localState()
+    })
+
+    // Why: dropping the last snapshot would make the server's bars vanish on a
+    // viewer that has none of those providers set up locally.
+    expect(resolved.claude?.status).toBe('error')
+    expect(resolved.claude?.session).toBeNull()
+    expect(resolved.claude?.error).toBe('Usage unavailable — cannot reach Mac Mini')
+  })
+
   it('leaves the usage setup CTA reachable when nothing is configured (#15804)', () => {
     const unconfigured = localState()
     for (const key of PROVIDER_KEYS) {
@@ -189,8 +243,9 @@ describe('resolveStatusBarUsageRateLimits', () => {
     unconfigured.grokAuthConfigured = false
 
     const resolved = resolveStatusBarUsageRateLimits(unconfigured, {
-      kind: 'remote-unreachable',
-      ownerLabel: 'Mac Mini'
+      kind: 'remote-unverifiable',
+      ownerLabel: 'Mac Mini',
+      reason: 'unreachable'
     })
 
     // Why: synthesized 'error' snapshots count as configured providers, which
@@ -245,6 +300,15 @@ describe('StatusBar badge source wiring', () => {
   it('reads the durability flags from the resolved state', () => {
     expect(source).toContain('minimaxCookieConfigured: effectiveRateLimits.minimaxCookieConfigured')
     expect(source).toContain('grokAuthConfigured: effectiveRateLimits.grokAuthConfigured')
+  })
+
+  it("does not hide the owning server's bars behind this laptop's PATH detection", () => {
+    // Why: detectedAgentIds is local-only, so gating a remote server's bars on
+    // it hides them entirely on the thin client #15798 is about.
+    expect(source).toContain(
+      "const usageDetectedAgentIds = remoteUsage.state.kind === 'local' ? detectedAgentIds : null"
+    )
+    expect(source).not.toMatch(/isStatusBarItemAvailable\('[a-z-]+', detectedAgentIds\)/)
   })
 
   it('rebuilds the refresh callback when the owning server changes', () => {

--- a/src/renderer/src/components/status-bar/usage-rate-limits-source.ts
+++ b/src/renderer/src/components/status-bar/usage-rate-limits-source.ts
@@ -1,0 +1,33 @@
+import type { RateLimitState } from '../../../../shared/rate-limit-types'
+
+/**
+ * Which machine's usage the status-bar badges describe (#15798).
+ *
+ * With a remote Active Server, agents run there and the provider-accounts
+ * snapshot carries the server's full RateLimitState — the badges must show
+ * those numbers, not the viewer's local poll (which describes a machine that
+ * runs nothing and can look correct while being wrong). While the first
+ * remote snapshot is still in flight, the Claude/Codex rows degrade to a
+ * fetching state rather than flashing local numbers.
+ */
+export function resolveStatusBarUsageRateLimits(
+  localRateLimits: RateLimitState,
+  remoteRateLimits: RateLimitState | null,
+  remoteUsageOwner: boolean
+): RateLimitState {
+  if (!remoteUsageOwner) {
+    return localRateLimits
+  }
+  if (remoteRateLimits) {
+    return remoteRateLimits
+  }
+  return {
+    ...localRateLimits,
+    claude: markProviderFetching(localRateLimits.claude),
+    codex: markProviderFetching(localRateLimits.codex)
+  }
+}
+
+function markProviderFetching<T extends { status: string } | null>(provider: T): T | null {
+  return provider ? { ...provider, status: 'fetching' } : null
+}

--- a/src/renderer/src/components/status-bar/usage-rate-limits-source.ts
+++ b/src/renderer/src/components/status-bar/usage-rate-limits-source.ts
@@ -1,6 +1,10 @@
 import type { ProviderRateLimits, RateLimitState } from '../../../../shared/rate-limit-types'
 import { translate } from '@/i18n/i18n'
-import { createPendingProviderSnapshot } from './status-bar-provider-visibility'
+import {
+  createPendingProviderSnapshot,
+  hasUsageData,
+  isProviderConfigured
+} from './status-bar-provider-visibility'
 
 /**
  * Which machine's usage the status-bar badges describe (#15798).
@@ -71,6 +75,32 @@ function createUnreachableProviderSnapshot(
   }
 }
 
+/**
+ * Blank every bar the unreachable owner can no longer vouch for, without
+ * inventing bars it never had (#15804).
+ *
+ * Why the gate: a locally blank + unconfigured provider has no numbers to leak
+ * and is no evidence the *server* has it set up. Stamping it 'error' reads as
+ * "configured" to `isProviderConfigured`, which would pin MiniMax/OpenCode Go
+ * bars on users who never enabled them and suppress the usage setup CTA.
+ */
+function markProvidersUnreachable(
+  local: RateLimitState,
+  ownerLabel: string
+): Pick<RateLimitState, UsageProviderKey> {
+  const replaced = {} as Pick<RateLimitState, UsageProviderKey>
+  for (const key of USAGE_PROVIDER_KEYS) {
+    const localProvider = local[key]
+    const blankAndUnconfigured =
+      localProvider == null ||
+      (!isProviderConfigured(localProvider) && !hasUsageData(localProvider))
+    replaced[key] = blankAndUnconfigured
+      ? localProvider
+      : createUnreachableProviderSnapshot(USAGE_PROVIDER_IDS[key], ownerLabel)
+  }
+  return replaced
+}
+
 function normalizeFlag(remoteValue: boolean | undefined, localValue: boolean): boolean {
   return typeof remoteValue === 'boolean' ? remoteValue : localValue
 }
@@ -105,14 +135,12 @@ export function resolveStatusBarUsageRateLimits(
   if (remoteUsage.kind === 'remote') {
     return adoptRemoteRateLimits(localRateLimits, remoteUsage.rateLimits)
   }
-  // Why: never spread the local provider here. Keeping any local window would
-  // render the viewer's percentages under the server's name — the exact
-  // "looks correct, is wrong" failure #15798 reports.
+  // Why: never keep a local window here. Rendering the viewer's percentages
+  // under the server's name is the exact "looks correct, is wrong" failure
+  // #15798 reports.
   const providers =
     remoteUsage.kind === 'remote-unreachable'
-      ? replaceProviders((providerId) =>
-          createUnreachableProviderSnapshot(providerId, remoteUsage.ownerLabel)
-        )
+      ? markProvidersUnreachable(localRateLimits, remoteUsage.ownerLabel)
       : replaceProviders(createPendingProviderSnapshot)
   return { ...localRateLimits, ...providers }
 }

--- a/src/renderer/src/components/status-bar/usage-rate-limits-source.ts
+++ b/src/renderer/src/components/status-bar/usage-rate-limits-source.ts
@@ -1,33 +1,133 @@
-import type { RateLimitState } from '../../../../shared/rate-limit-types'
+import type { ProviderRateLimits, RateLimitState } from '../../../../shared/rate-limit-types'
+import { translate } from '@/i18n/i18n'
+import { createPendingProviderSnapshot } from './status-bar-provider-visibility'
 
 /**
  * Which machine's usage the status-bar badges describe (#15798).
  *
- * With a remote Active Server, agents run there and the provider-accounts
- * snapshot carries the server's full RateLimitState — the badges must show
- * those numbers, not the viewer's local poll (which describes a machine that
- * runs nothing and can look correct while being wrong). While the first
- * remote snapshot is still in flight, the Claude/Codex rows degrade to a
- * fetching state rather than flashing local numbers.
+ * With a remote Active Server the agents run there, so the badges must render
+ * that server's numbers — the viewer's local poll describes a machine that runs
+ * nothing and can look perfectly healthy while being wrong. Loss of contact is
+ * its own verdict: per docs/reference/ssh-execution-boundary.md it may not be
+ * collapsed into "still loading" or into a 0%/healthy bar.
  */
-export function resolveStatusBarUsageRateLimits(
-  localRateLimits: RateLimitState,
-  remoteRateLimits: RateLimitState | null,
-  remoteUsageOwner: boolean
-): RateLimitState {
-  if (!remoteUsageOwner) {
-    return localRateLimits
+export type RemoteUsageState =
+  | { kind: 'local' }
+  /** A remote server owns usage and its first snapshot has not landed yet. */
+  | { kind: 'remote-pending' }
+  /** The server that owns usage cannot be reached, so its usage is unverifiable. */
+  | { kind: 'remote-unreachable'; ownerLabel: string }
+  | { kind: 'remote'; rateLimits: RateLimitState }
+
+/**
+ * Keys of RateLimitState that hold a provider snapshot. Derived rather than
+ * listed so a newly added provider is a compile error in the maps below instead
+ * of a silent leak of local numbers under a remote owner.
+ */
+type UsageProviderKey = {
+  [K in keyof RateLimitState]-?: RateLimitState[K] extends ProviderRateLimits | null ? K : never
+}[keyof RateLimitState]
+
+const USAGE_PROVIDER_IDS: Record<UsageProviderKey, ProviderRateLimits['provider']> = {
+  claude: 'claude',
+  codex: 'codex',
+  gemini: 'gemini',
+  opencodeGo: 'opencode-go',
+  kimi: 'kimi',
+  antigravity: 'antigravity',
+  minimax: 'minimax',
+  grok: 'grok'
+}
+
+const USAGE_PROVIDER_KEYS = Object.keys(USAGE_PROVIDER_IDS) as UsageProviderKey[]
+
+// Why: the host may predate a field the client now reads. RateLimitState types
+// these as required, so read the remote copy through a Partial to keep the
+// undefined branch reachable instead of letting a bar silently vanish.
+type PartialRemoteRateLimitState = Partial<RateLimitState>
+
+function replaceProviders(
+  build: (providerId: ProviderRateLimits['provider']) => ProviderRateLimits
+): Pick<RateLimitState, UsageProviderKey> {
+  const replaced = {} as Pick<RateLimitState, UsageProviderKey>
+  for (const key of USAGE_PROVIDER_KEYS) {
+    replaced[key] = build(USAGE_PROVIDER_IDS[key])
   }
-  if (remoteRateLimits) {
-    return remoteRateLimits
-  }
+  return replaced
+}
+
+function createUnreachableProviderSnapshot(
+  providerId: ProviderRateLimits['provider'],
+  ownerLabel: string
+): ProviderRateLimits {
   return {
-    ...localRateLimits,
-    claude: markProviderFetching(localRateLimits.claude),
-    codex: markProviderFetching(localRateLimits.codex)
+    ...createPendingProviderSnapshot(providerId),
+    error: translate(
+      'auto.components.status.bar.usage.remoteOwnerUnreachable',
+      'Usage unavailable — cannot reach {{server}}',
+      { server: ownerLabel }
+    ),
+    status: 'error'
   }
 }
 
-function markProviderFetching<T extends { status: string } | null>(provider: T): T | null {
-  return provider ? { ...provider, status: 'fetching' } : null
+function normalizeFlag(remoteValue: boolean | undefined, localValue: boolean): boolean {
+  return typeof remoteValue === 'boolean' ? remoteValue : localValue
+}
+
+function adoptRemoteRateLimits(local: RateLimitState, remote: RateLimitState): RateLimitState {
+  const partial = remote as PartialRemoteRateLimitState
+  return {
+    ...remote,
+    // Why: MiniMax/Grok sign-in lives on disk, so a host older than those
+    // providers omits the flags entirely; falling back to the local value keeps
+    // a configured bar visible instead of making it disappear on the first
+    // remote snapshot.
+    minimaxCookieConfigured: normalizeFlag(
+      partial.minimaxCookieConfigured,
+      local.minimaxCookieConfigured
+    ),
+    grokAuthConfigured: normalizeFlag(partial.grokAuthConfigured, local.grokAuthConfigured),
+    claudeTarget: partial.claudeTarget ?? local.claudeTarget,
+    codexTarget: partial.codexTarget ?? local.codexTarget,
+    inactiveClaudeAccounts: partial.inactiveClaudeAccounts ?? [],
+    inactiveCodexAccounts: partial.inactiveCodexAccounts ?? []
+  }
+}
+
+export function resolveStatusBarUsageRateLimits(
+  localRateLimits: RateLimitState,
+  remoteUsage: RemoteUsageState
+): RateLimitState {
+  if (remoteUsage.kind === 'local') {
+    return localRateLimits
+  }
+  if (remoteUsage.kind === 'remote') {
+    return adoptRemoteRateLimits(localRateLimits, remoteUsage.rateLimits)
+  }
+  // Why: never spread the local provider here. Keeping any local window would
+  // render the viewer's percentages under the server's name — the exact
+  // "looks correct, is wrong" failure #15798 reports.
+  const providers =
+    remoteUsage.kind === 'remote-unreachable'
+      ? replaceProviders((providerId) =>
+          createUnreachableProviderSnapshot(providerId, remoteUsage.ownerLabel)
+        )
+      : replaceProviders(createPendingProviderSnapshot)
+  return { ...localRateLimits, ...providers }
+}
+
+/** Newest provider snapshot timestamp in a state, or 0 when nothing has landed. */
+export function latestUsageUpdatedAt(rateLimits: RateLimitState | null): number {
+  if (!rateLimits) {
+    return 0
+  }
+  let newest = 0
+  for (const key of USAGE_PROVIDER_KEYS) {
+    const provider = rateLimits[key]
+    if (provider && provider.updatedAt > newest) {
+      newest = provider.updatedAt
+    }
+  }
+  return newest
 }

--- a/src/renderer/src/components/status-bar/usage-rate-limits-source.ts
+++ b/src/renderer/src/components/status-bar/usage-rate-limits-source.ts
@@ -19,9 +19,21 @@ export type RemoteUsageState =
   | { kind: 'local' }
   /** A remote server owns usage and its first snapshot has not landed yet. */
   | { kind: 'remote-pending' }
-  /** The server that owns usage cannot be reached, so its usage is unverifiable. */
-  | { kind: 'remote-unreachable'; ownerLabel: string }
+  /** The owning server's usage cannot be verified, so no bar may claim numbers. */
+  | {
+      kind: 'remote-unverifiable'
+      ownerLabel: string
+      reason: RemoteUsageFailureReason
+      /** Last snapshot that server vouched for, so its bars stay put instead of vanishing. */
+      lastKnown?: RateLimitState | null
+    }
   | { kind: 'remote'; rateLimits: RateLimitState }
+
+/**
+ * Why two reasons: a host that answers but publishes no usage is reachable, so
+ * telling the user we "cannot reach" it would be false.
+ */
+export type RemoteUsageFailureReason = 'unreachable' | 'usage-not-published'
 
 /**
  * Keys of RateLimitState that hold a provider snapshot. Derived rather than
@@ -60,43 +72,55 @@ function replaceProviders(
   return replaced
 }
 
-function createUnreachableProviderSnapshot(
+function describeUnverifiableOwner(ownerLabel: string, reason: RemoteUsageFailureReason): string {
+  return reason === 'usage-not-published'
+    ? translate(
+        'auto.components.status.bar.usage.remoteOwnerNoUsage',
+        'Usage unavailable — {{server}} does not report usage',
+        { server: ownerLabel }
+      )
+    : translate(
+        'auto.components.status.bar.usage.remoteOwnerUnreachable',
+        'Usage unavailable — cannot reach {{server}}',
+        { server: ownerLabel }
+      )
+}
+
+function createUnverifiableProviderSnapshot(
   providerId: ProviderRateLimits['provider'],
-  ownerLabel: string
+  message: string
 ): ProviderRateLimits {
   return {
     ...createPendingProviderSnapshot(providerId),
-    error: translate(
-      'auto.components.status.bar.usage.remoteOwnerUnreachable',
-      'Usage unavailable — cannot reach {{server}}',
-      { server: ownerLabel }
-    ),
+    error: message,
+    // Why: the badge label is provider-classified copy; this flag keeps it from
+    // reading "Refresh failed" for a failure no refresh can fix (#15798).
+    usageMetadata: { unverifiableUsageOwner: true },
     status: 'error'
   }
 }
 
 /**
- * Blank every bar the unreachable owner can no longer vouch for, without
- * inventing bars it never had (#15804).
+ * Blank every bar the owner can no longer vouch for, without inventing bars it
+ * never had (#15804).
  *
- * Why the gate: a locally blank + unconfigured provider has no numbers to leak
- * and is no evidence the *server* has it set up. Stamping it 'error' reads as
- * "configured" to `isProviderConfigured`, which would pin MiniMax/OpenCode Go
- * bars on users who never enabled them and suppress the usage setup CTA.
+ * Why the gate: a blank + unconfigured provider has no numbers to leak and is
+ * no evidence anyone has it set up. Stamping it 'error' reads as "configured"
+ * to `isProviderConfigured`, which would pin MiniMax/OpenCode Go bars on users
+ * who never enabled them and suppress the usage setup CTA.
  */
-function markProvidersUnreachable(
-  local: RateLimitState,
-  ownerLabel: string
+function markProvidersUnverifiable(
+  base: RateLimitState,
+  message: string
 ): Pick<RateLimitState, UsageProviderKey> {
   const replaced = {} as Pick<RateLimitState, UsageProviderKey>
   for (const key of USAGE_PROVIDER_KEYS) {
-    const localProvider = local[key]
+    const provider = base[key]
     const blankAndUnconfigured =
-      localProvider == null ||
-      (!isProviderConfigured(localProvider) && !hasUsageData(localProvider))
+      provider == null || (!isProviderConfigured(provider) && !hasUsageData(provider))
     replaced[key] = blankAndUnconfigured
-      ? localProvider
-      : createUnreachableProviderSnapshot(USAGE_PROVIDER_IDS[key], ownerLabel)
+      ? provider
+      : createUnverifiableProviderSnapshot(USAGE_PROVIDER_IDS[key], message)
   }
   return replaced
 }
@@ -138,10 +162,17 @@ export function resolveStatusBarUsageRateLimits(
   // Why: never keep a local window here. Rendering the viewer's percentages
   // under the server's name is the exact "looks correct, is wrong" failure
   // #15798 reports.
-  const providers =
-    remoteUsage.kind === 'remote-unreachable'
-      ? markProvidersUnreachable(localRateLimits, remoteUsage.ownerLabel)
-      : replaceProviders(createPendingProviderSnapshot)
+  if (remoteUsage.kind === 'remote-pending') {
+    return { ...localRateLimits, ...replaceProviders(createPendingProviderSnapshot) }
+  }
+  // Why the lastKnown base: the bars the server vouched for keep their slots
+  // carrying the verdict, instead of silently disappearing on a thin client
+  // that has none of those providers configured locally.
+  const base = remoteUsage.lastKnown ?? localRateLimits
+  const providers = markProvidersUnverifiable(
+    base,
+    describeUnverifiableOwner(remoteUsage.ownerLabel, remoteUsage.reason)
+  )
   return { ...localRateLimits, ...providers }
 }
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3756,6 +3756,9 @@
             "onDescription": "Keep this computer awake continuously",
             "autoDescription": "Stay awake while an agent is working",
             "offDescription": "Allow normal system sleep behavior"
+          },
+          "usage": {
+            "remoteOwnerUnreachable": "Usage unavailable — cannot reach {{server}}"
           }
         }
       },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3758,7 +3758,8 @@
             "offDescription": "Allow normal system sleep behavior"
           },
           "usage": {
-            "remoteOwnerUnreachable": "Usage unavailable — cannot reach {{server}}"
+            "remoteOwnerUnreachable": "Usage unavailable — cannot reach {{server}}",
+            "remoteOwnerNoUsage": "Usage unavailable — {{server}} does not report usage"
           }
         }
       },

--- a/src/shared/rate-limit-types.ts
+++ b/src/shared/rate-limit-types.ts
@@ -43,6 +43,12 @@ export type UsageRateLimitMetadata = {
   lastSuccessfulSource?: UsageRateLimitSource
   /** Unix ms timestamp before which usage refetches should not be attempted (from HTTP Retry-After). */
   retryAtMs?: number
+  /**
+   * Renderer-only: the machine that owns this usage could not be verified, so
+   * the snapshot carries a verdict rather than a failed provider fetch (#15798).
+   * Hosts never set it.
+   */
+  unverifiableUsageOwner?: boolean
 }
 
 export type ProviderRateLimits = {


### PR DESCRIPTION
> ## 🛑 HELD — do not merge
>
> Held by maintainer decision (2026-08-22). CI is green and the branch merges clean; this is **not** a technical blocker.
> Converted to draft and labelled `wip` so it cannot be merged by accident.
> Superseded fork PR #15804 (@yzxcj797) is still open and should stay open while this is held.

---

<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​628 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​628 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​445 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​425 |

<!-- /orca-pr-loc -->

Supersedes #15804 by @yzxcj797 — carried over so it can run full CI (fork PRs only run `track-community-pr` in this repo). Original authorship preserved in the commit: `5adafcc` is authored by them, and my follow-up commit credits them with `Co-authored-by`.

## ELI5

If your "Active Server" is a remote machine, that machine is the one running Claude/Codex — so the usage percentages in the status bar should be *its* numbers. Today they are the numbers from the laptop you're looking at, which usually runs no agents at all. Worst case that laptop happens to be signed in too, so the badge shows a perfectly believable percentage that describes the wrong computer. This makes the badges read from the server that actually owns the accounts, show nothing (not stale local numbers) while the first answer is on its way, and say "cannot reach &lt;server&gt;" when the server has gone quiet instead of spinning forever. It also stops hiding the server's bars just because the laptop you are looking at has none of those agent CLIs installed — which is the whole point of a thin client.

## What Changed

- **New** `src/renderer/src/components/status-bar/remote-usage-rate-limits.ts` — `useRemoteUsageRateLimits(settings)`. Subscribes to the provider-accounts snapshot of whichever runtime owns accounts, stamps every snapshot with the owner id it came from, and exposes an owner-keyed `refresh()`.
- **Rewritten** `usage-rate-limits-source.ts` — `resolveStatusBarUsageRateLimits(local, remoteUsage)` takes an explicit `RemoteUsageState` (`local` | `remote-pending` | `remote-unverifiable` | `remote`) instead of a boolean plus a nullable snapshot. `remote-unverifiable` carries a `reason` (`unreachable` | `usage-not-published`) and the last snapshot the owner vouched for.
- `StatusBar.tsx` badges, `usageSettings` durability flags, and the manual Refresh button now go through the resolved state.
- `StatusBar.tsx` no longer gates the usage bars (or their context-menu toggles) on *this* machine's agent-CLI PATH detection while a remote server owns usage. `detectedAgentIds` describes the viewer only, so on the thin client this PR is written for it hid every one of the server's bars.
- `usage-error-copy.ts` — an unverifiable owner is labelled `Usage unavailable` instead of the provider-classified `Refresh failed`. The badge's *inline* label is the string #15798 complains about; without this the new copy only appeared once the user opened the popover. The marker is a new renderer-only optional `usageMetadata.unverifiableUsageOwner` flag (hosts never set it).
- `createPendingProviderSnapshot` is exported from `status-bar-provider-visibility.ts` so the pending and unreachable snapshots come from the same factory the rest of the status bar uses.
- Two new English catalog keys: `auto.components.status.bar.usage.remoteOwnerUnreachable` and `…usage.remoteOwnerNoUsage`.

No wire change. `ProviderAccountsSnapshot.rateLimits` has carried the host's full `RateLimitState` since #1467 (2026-05-05), so this needs no new RPC method and no new stream opcode. `rateLimits` is typed `RateLimitState | null`, so a host that publishes an accounts snapshot *without* it is possible; that case is now an explicit verdict (`Usage unavailable — <server> does not report usage`) rather than a permanent silent spinner — see below.

## Why

Root cause, in two parts.

**1. The badges read the wrong store slice.** `StatusBarInner` destructured providers straight out of the local `rateLimits` zustand slice, which is fed by the renderer's local poll. The accounts roster right next to it was already environment-aware ("Showing accounts managed by &lt;server&gt;"), so the two surfaces disagreed. #15798 calls the valid-looking-local-numbers case *"arguably worse than an error state, because it looks correct"*.

**2. The first version of the degrade did not actually degrade.** #15804 replaced only `status` on the local Claude/Codex snapshot while a remote snapshot was in flight. `getTightestUsageSection(p)` still found the preserved `session`/`weekly` windows, so `StatusBar.tsx`'s "Fetching with no prior data" branch never fired and the **local percentage bar kept rendering**. It only looked fixed because the test fixture used `session: null, weekly: null`. It also covered `claude` and `codex` only, so `gemini`, `opencodeGo`, `kimi`, `antigravity`, `minimax` and `grok` leaked local numbers permanently. Both are fixed by replacing every provider key with a genuinely empty snapshot, driven by a `Record<UsageProviderKey, …>` derived from `RateLimitState` so a newly added provider is a **compile error**, not a silent leak.

Beyond the reported symptom, five more problems are fixed on this branch:

- **A host that answers without usage spun the badge forever.** `watchProviderAccounts` marks its first-snapshot timeout as satisfied as soon as *any* snapshot object arrives, so a snapshot with `rateLimits: null` disarmed the 15s guard and its `onClose` error — and the hook then discarded it. The result was the pulsing `···` placeholder with no error path and no recovery. It now resolves to `remote-unverifiable` with `reason: 'usage-not-published'`, whose copy does **not** claim the server is unreachable: it answered, it just publishes no usage.
- **Swallowed watcher errors.** `watchProviderAccounts` raises a 15s first-snapshot timeout, `"Remote provider account subscription closed."`, and `RuntimeRpcCallError` — all through one `onError`. #15804 `console.error`'d them, leaving the badge on `···` and the roster on "Loading usage…" indefinitely. That collapses *loss of contact* into *in progress*, which `docs/reference/ssh-execution-boundary.md` exists to prevent. Errors now resolve to `remote-unverifiable` and render `Usage unavailable — cannot reach <server>` (an `error` status — never 0%, never a permanent spinner), cleared by the next successful snapshot. Losing contact also keeps the last snapshot the owner vouched for (blanked, carrying the verdict) so its bars stay in place instead of silently disappearing on a viewer that has none of those providers configured locally. Only providers someone had actually set up get that verdict (the server's own last snapshot when there was one, the viewer's otherwise): an `error` status reads as *configured* to `isProviderConfigured`, so stamping the null/`unavailable` slots too would pin MiniMax and OpenCode Go bars on users who never set them up and swallow the usage setup CTA. Those slots pass through untouched — they carry no numbers to leak and are no evidence the server has them set up.
- **Server A → server B leaked A's numbers.** The cached snapshot was cleared only on the remote → local transition, so on an A → B switch the badges showed A's usage under B's label. The hook now stamps each snapshot with its owner id and ignores anything whose owner does not match the active one, which also drops late in-flight callbacks from the closed watcher.
- **Stale `useCallback` deps.** `handleRefresh` read `remoteUsageOwner`/`activeRuntimeEnvironmentId` without listing them; `npx oxlint` flagged it at `StatusBar.tsx:2137`, and `exhaustive-deps` is only `warn` in `.oxlintrc.json`, so CI would not have caught it. Because the other deps are stable store selectors, the closure was never rebuilt — clicking Refresh after switching to a remote server still ran the *local* refresh. The hook's owner-keyed `refresh` is now in the dep array.
- **The Refresh button lied.** `fetchProviderAccountsSnapshot` resolves off the subscribe-time `ready` frame, which the host emits *before* `refreshIfStale()` runs, so the spinner stopped before any newer data could exist. Background polling does not cover this either: `shouldBackgroundPoll()` requires the host window to be visible, non-minimized **and** focused, which a machine acting as a server never is. The refresh now holds until the persistent watcher delivers a snapshot newer than the one held at click time, capped at 8s so a throttled host still releases the button.

Durability flags (`minimaxCookieConfigured` / `grokAuthConfigured`) take the host's value when it sends one and fall back to the local value when it does not — a host predating those providers omits them entirely, and reading them raw would make a configured bar silently vanish (`docs/reference/remote-wire-compatibility.md`: what the host publishes reaches old clients).

## Linked Issue

Fixes #15798

## Visual Proof

Not attached — I have no paired remote Orca server in this environment and will not fabricate screenshots. This **is** a UI change, so here is exactly what a reviewer should look at:

1. Pair a remote server and set it as the Active Server. The status-bar Claude/Codex percentages should match the *server's* usage, not the viewer's. Cross-check against the "Showing accounts managed by &lt;server&gt;" roster right beside them — they must now agree.
2. Immediately after switching, before the first snapshot lands, the badges must show the pulsing `···` placeholder — **not** the local machine's percentages. This is the case the original patch got wrong, so it is the one worth watching.
3. Stop or kill the remote server and wait ~15s. Badges must show the warning triangle, the inline label `Usage unavailable` (not `Refresh failed`), and `Usage unavailable — cannot reach <server name>` in the popover — never 0%, never an endless spinner. The bars the server had vouched for stay in place carrying that verdict.
4. Switch from server A to server B. B's badges must go blank first; A's numbers must never appear under B's name.
5. On a client with **no agent CLIs installed** (the thin-client case the issue describes), the server's bars must still appear — before this they were hidden by local PATH detection.
6. Against a remote Orca old enough not to publish `rateLimits`, the badges must read `Usage unavailable — <server> does not report usage` instead of spinning.
7. With a local Active Server (no remote), nothing changes at all — the local PATH gate, the local numbers and the local refresh are all untouched.

## Testing

Run on **macOS only** (Darwin 25.3.0). Everything below passed; no pre-existing unrelated failures were observed in the files touched.

```
npx vitest run --config config/vitest.config.ts \
  src/renderer/src/components/status-bar/usage-rate-limits-source.test.ts \
  src/renderer/src/components/status-bar/remote-usage-rate-limits.test.ts
  -> 2 files, 26 tests passed

npx vitest run --config config/vitest.config.ts src/renderer/src/components/status-bar/
  -> 44 files, 310 tests passed

npx vitest run --config config/vitest.config.ts src/renderer/src/app-startup-routing.test.ts
  -> 23 tests passed

npx oxlint <changed source/test files>                                 -> 0 warnings, exit 0
npx oxlint --config config/oxlint-code-quality-native-plugins.json \
  <changed source files> --deny-warnings                               -> exit 0
npx oxfmt --check <changed files>                                      -> clean
node config/scripts/check-max-lines-ratchet.mjs                        -> OK, no new bypasses
node config/scripts/check-reliability-gates.mjs                        -> 87 gates pass
node config/scripts/verify-localization-catalog.mjs                    -> pass
node config/scripts/verify-localization-extraction.mjs                 -> pass
node config/scripts/audit-localization-coverage.mjs --check            -> pass
```

Project-wide `pnpm typecheck` / `pnpm lint` were deliberately not run locally; CI covers them.

**Regression evidence — every behaviour change is pinned by a test that fails without it.** Each product line was reverted in isolation and the suite re-run:

```
revert usage-error-copy's unverifiable branch
  FAIL labels an unverifiable owner as unavailable rather than "Refresh failed"
       expected 'Refresh failed' to be 'Usage unavailable'

revert the hook's "snapshot without rateLimits" branch, and lastKnown on failure
  FAIL does not spin forever when the owner answers without usage (older host)
  FAIL keeps the last snapshot the owner vouched for when contact is lost

revert `base = remoteUsage.lastKnown ?? localRateLimits`, and the StatusBar PATH gate
  FAIL keeps the bars the unreachable server vouched for, blanked (#15798)
  FAIL does not hide the owning server's bars behind this laptop's PATH detection
```

The earlier round of the same exercise (reverting the degrade so it preserved the local `session`/`weekly` windows, and pointing `StatusBar` back at `rateLimits`) still fails 4 tests, including `never renders local percentages while the first remote snapshot is in flight` — the proof that the original patch did not fix the reported symptom.

Coverage added: `usage-rate-limits-source.test.ts` (local passthrough, remote adoption, pre-flag-host fallback, all eight providers blanked while pending, both unverifiable reasons' copy, the `Usage unavailable` inline label, last-known bars kept on contact loss, never inventing bars for unconfigured providers, usage setup CTA left reachable, `latestUsageUpdatedAt`) and `remote-usage-rate-limits.test.ts` (no watcher without a remote owner, pending → remote, watcher error → unverifiable → recovery, usage-less snapshot → unverifiable, usage-less manual refresh, last-known retention, generic label fallback, A → B never shows A's numbers including a late callback, refresh held open until newer data, refresh failure → unverifiable). Three of the resolver tests are source-level pins on `StatusBar.tsx`, following the existing `worktree-jump-palette-source-context-boundary.test.ts` pattern — the resolver is pure, so without them a revert of the wiring lines would leave the whole suite green.

- [ ] I manually tested these changes locally — **no**, and I am not ticking this. There is no paired remote server in this environment; verification here is automated only. The manual steps are listed under Visual Proof.
- [x] Automated tests added/updated, or explained why not below

## Review

- **Malicious-code scan of the contributor diff:** performed explicitly because @yzxcj797 is not a stablyai member. The full patch (3 files, +152/-5, renderer-only) was read hunk by hunk. No `fetch`/`XMLHttpRequest`/`WebSocket`, no new URL or RPC method, no `eval`/`new Function`/`child_process`/dynamic `import()`, no `process.env`, no credential/keychain/`~/.claude` reads, no writes to disk or settings, no obfuscated or non-ASCII payloads (only em-dashes in English prose), and no edits to `AGENTS.md`/`CLAUDE.md`/`docs/`/`.claude/` or anything an agent later reads as instructions. `RateLimitState` carries usage percentages and error strings only — no tokens. **Clean.** The problems fixed above are ordinary correctness bugs, not hostile behavior.
- **Cross-platform:** pure renderer state. No `fs`, no `path`, no argv, no shell, no line-ending handling, no keyboard shortcuts. Nothing to branch on for macOS/Linux/Windows.
- **SSH / remote:** this is the core of the change. The execution host owns usage data; the client now renders the host's snapshot and never substitutes its own. Loss of contact maps to a distinct `remote-unverifiable` verdict with copy naming the owner, and it is kept separate from a reachable host that simply publishes no usage — no synonym for "healthy", no 0%, no permanent spinner, per `docs/reference/ssh-execution-boundary.md`.
- **Remote wire compatibility:** no new wire field, method or opcode (`usageMetadata.unverifiableUsageOwner` is renderer-synthesized and never published by a host). The consumed payload (`ProviderAccountsSnapshot.rateLimits`) has been on the wire since #1467. Optional fields an older host may omit (`minimaxCookieConfigured`, `grokAuthConfigured`, `claudeTarget`, `codexTarget`, the inactive-account arrays) are normalized instead of read raw, so a new client against an old host degrades rather than blanking bars.
- **Agent / integration compatibility:** no agent, git, or provider-hosting surface touched. The Git 2.25 baseline and GitHub/GitLab neutrality are not implicated. Folder workspaces vs. git worktrees is not implicated either — usage is per runtime environment, not per repo. Mobile is unaffected; `accounts.subscribe` behavior on the host is unchanged.
- **Performance:** one `accounts.subscribe` while a remote server is active, closed on owner change and on unmount. The refresh path still shares `fetchProviderAccountsSnapshot`'s existing in-flight dedupe. The 8s settle cap is a `setTimeout` cleared on settle. Nothing new runs when the Active Server is local.
- **UI quality:** the pending state reuses the existing `···` placeholder and the unreachable state reuses the existing error treatment (warning triangle plus popover message); no new visual vocabulary, no new tokens, sizes or colors. Both new strings are in `en.json` and interpolated, so the other four locales fall back to English until a localization pass. The unverifiable inline label reuses the existing `Usage unavailable` key.
- **Security:** no new capability, no credential handling, no new network sink. The only user-controlled string that reaches the UI is the runtime environment's own name, rendered as React text.

### Known limitations / follow-ups (deliberately out of scope)

- **Settings → Appearance's status-bar toggle list** (`useAvailableStatusBarToggles`) still filters on local PATH detection, so a thin client can toggle the server's usage bars from the status-bar context menu but not from that Settings pane. Same root cause as the gate fixed here; threading remote ownership into that hook reaches a different pane and its tests.
- **The visibility gate's *settings* fallback is still the viewer's.** When a provider has no snapshot from the server, `hasUsageProviderSettingsForProvider` reads the local `GlobalSettings`, so e.g. a viewer with Gemini CLI OAuth enabled locally can see a `--` Gemini slot for a server that has no Gemini. Only the durability flags the host publishes (`minimaxCookieConfigured`, `grokAuthConfigured`) are owner-scoped today.
- **Switcher popovers** — see below.

### Known follow-up (deliberately out of scope)

`ClaudeSwitcherMenu` / `CodexSwitcherMenu` still read `inactiveClaudeAccounts` / `inactiveCodexAccounts` / `claudeTarget` / `codexTarget` from the local store, so the *inactive-account rows and the host/WSL chip inside the popover* still describe the viewer's machine while the active row above them describes the server. The remote snapshot already carries that data. Threading it through means changing both switcher components' props and is a larger diff than this fix warrants; happy to file it as a follow-up issue, or fold it in here if a reviewer prefers.

## Agent skill upstream boundary

- [x] Not applicable — no skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation touched.

## Notes

Renderer-only, in-memory state — nothing persisted, so there is no settings migration or backward-compat risk.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — targeted lint, tests and typecheck run locally (see Testing); the full project runs are left to CI




