### PR TITLE
fix(mobile): stop duplicating pinned workspaces in grouped lists

### DIFF
--- a/mobile/app/h/[hostId]/index.tsx
+++ b/mobile/app/h/[hostId]/index.tsx
@@ -94,6 +94,7 @@ import {
   type Worktree
 } from '../../../src/worktree/workspace-list-sections'
 import { useWorkspaceSections } from '../../../src/worktree/use-workspace-sections'
+import { usePinnedWorkspaceDisplayPolicy } from '../../../src/worktree/use-pinned-workspace-display-policy'
 import { getMobileWorkspaceLineageGroupKey } from '../../../src/worktree/mobile-workspace-lineage'
 import { areWorktreeListsEqual } from '../../../src/worktree/worktree-list-snapshot'
 import { WorktreeCatalogSnapshotClient } from '../../../src/worktree/worktree-catalog-snapshot-client'
@@ -757,6 +758,7 @@ export function HostScreen({
     (item: Worktree) => toggleCollapsed(getMobileWorkspaceLineageGroupKey(item)),
     [toggleCollapsed]
   )
+  const pinnedDisplayPolicy = usePinnedWorkspaceDisplayPolicy(client, connState)
   const { sections, rawSections, uniqueRepos, uniqueRepoColors } = useWorkspaceSections({
     displayWorktrees,
     sortMode,
@@ -767,7 +769,8 @@ export function HostScreen({
     repoIdsByName,
     repoColorsByName,
     collapsedGroups,
-    workspaceStatuses
+    workspaceStatuses,
+    pinnedDisplayPolicy
   })
   const existingWorktreePaths = useMemo(() => worktrees.map((w) => w.path), [worktrees])
 

--- a/mobile/src/worktree/mobile-workspace-lineage.ts
+++ b/mobile/src/worktree/mobile-workspace-lineage.ts
@@ -22,11 +22,30 @@ function hasValidLineageParent(worktree: Worktree, parent: Worktree): boolean {
   )
 }
 
+/** Row identity of the row's nesting parent, or null when it must render as a lineage root. */
+export function getMobileLineageParentIdentity(
+  worktree: Worktree,
+  worktreeByIdentity: ReadonlyMap<string, Worktree>
+): string | null {
+  const parentId = worktree.parentWorktreeId
+  if (!parentId) {
+    return null
+  }
+  const parentIdentity = getWorktreeRowIdentity({ worktreeId: parentId, hostId: worktree.hostId })
+  if (parentIdentity === getWorktreeRowIdentity(worktree)) {
+    return null
+  }
+  const parent = worktreeByIdentity.get(parentIdentity)
+  if (!parent || !hasValidLineageParent(worktree, parent)) {
+    return null
+  }
+  return parentIdentity
+}
+
 export function applyMobileWorkspaceLineage(
   worktrees: readonly Worktree[],
   collapsedGroups: ReadonlySet<string> = new Set()
 ): Worktree[] {
-  const visibleIds = new Set(worktrees.map((worktree) => getWorktreeRowIdentity(worktree)))
   const worktreeById = new Map(
     worktrees.map((worktree) => [getWorktreeRowIdentity(worktree), worktree])
   )
@@ -35,18 +54,8 @@ export function applyMobileWorkspaceLineage(
 
   for (const worktree of worktrees) {
     const worktreeId = getWorktreeRowIdentity(worktree)
-    const parentId = worktree.parentWorktreeId
-    const parentIdentity = parentId
-      ? getWorktreeRowIdentity({ worktreeId: parentId, hostId: worktree.hostId })
-      : null
-    const parent = parentIdentity ? worktreeById.get(parentIdentity) : undefined
-    if (
-      !parentIdentity ||
-      parentIdentity === worktreeId ||
-      !visibleIds.has(parentIdentity) ||
-      !parent ||
-      !hasValidLineageParent(worktree, parent)
-    ) {
+    const parentIdentity = getMobileLineageParentIdentity(worktree, worktreeById)
+    if (!parentIdentity) {
       continue
     }
     childIds.add(worktreeId)

--- a/mobile/src/worktree/pinned-section-worktrees.ts
+++ b/mobile/src/worktree/pinned-section-worktrees.ts
@@ -1,0 +1,54 @@
+import type { Worktree } from './workspace-list-types'
+import { getMobileLineageParentIdentity } from './mobile-workspace-lineage'
+import { getWorktreeRowIdentity } from './worktree-host-row-identity'
+
+/** Host-side pin flag OR a device-local pin, which is keyed on the bare worktreeId. */
+export function isWorktreePinned(w: Worktree, localPins: Set<string>): boolean {
+  return w.isPinned || localPins.has(w.worktreeId)
+}
+
+/**
+ * Rows the Pinned section owns: the pinned rows plus their visible lineage descendants,
+ * mirroring desktop's getPinnedSectionWorktrees. Pin is placement of the clicked row, so a
+ * pinned parent must take its subtree along — otherwise single-location strips the parent
+ * out of its group and orphans the children there at depth 0.
+ */
+export function getPinnedSectionWorktrees(
+  worktrees: readonly Worktree[],
+  pinnedIds: Set<string>
+): Worktree[] {
+  const included = new Set(
+    worktrees.filter((w) => isWorktreePinned(w, pinnedIds)).map(getWorktreeRowIdentity)
+  )
+  if (included.size === 0) {
+    return []
+  }
+  const worktreeByIdentity = new Map(worktrees.map((w) => [getWorktreeRowIdentity(w), w]))
+  const childrenByParentIdentity = new Map<string, Worktree[]>()
+  for (const worktree of worktrees) {
+    const parentIdentity = getMobileLineageParentIdentity(worktree, worktreeByIdentity)
+    if (!parentIdentity) {
+      continue
+    }
+    const children = childrenByParentIdentity.get(parentIdentity) ?? []
+    children.push(worktree)
+    childrenByParentIdentity.set(parentIdentity, children)
+  }
+
+  const pending = [...included]
+  while (pending.length > 0) {
+    const identity = pending.pop()
+    if (identity === undefined) {
+      continue
+    }
+    for (const child of childrenByParentIdentity.get(identity) ?? []) {
+      const childIdentity = getWorktreeRowIdentity(child)
+      if (!included.has(childIdentity)) {
+        included.add(childIdentity)
+        pending.push(childIdentity)
+      }
+    }
+  }
+
+  return worktrees.filter((w) => included.has(getWorktreeRowIdentity(w)))
+}

--- a/mobile/src/worktree/use-pinned-workspace-display-policy.test.tsx
+++ b/mobile/src/worktree/use-pinned-workspace-display-policy.test.tsx
@@ -26,8 +26,9 @@ function mountPolicy(connState: ConnectionState = 'connected') {
     return null
   }
 
+  let renderer!: ReturnType<typeof create>
   act(() => {
-    create(createElement(Probe, { state: connState }))
+    renderer = create(createElement(Probe, { state: connState }))
   })
 
   return {
@@ -35,6 +36,11 @@ function mountPolicy(connState: ConnectionState = 'connected') {
       return latest
     },
     requests,
+    setConnState(next: ConnectionState) {
+      act(() => {
+        renderer.update(createElement(Probe, { state: next }))
+      })
+    },
     async settle(settings: unknown) {
       await act(async () => {
         pending[0]!.resolve({ ok: true, result: { settings } })
@@ -95,5 +101,19 @@ describe('usePinnedWorkspaceDisplayPolicy', () => {
 
   it('issues no request while disconnected', () => {
     expect(mountPolicy('reconnecting').requests).toEqual([])
+  })
+
+  // The host screen keeps rendering the pre-reconnect list while amber, so dropping back to the
+  // default here would silently reflow a frozen list for an opted-in user (#15494).
+  it('keeps the opted-in policy across a reconnect blip', async () => {
+    const probe = mountPolicy()
+    await probe.settle({ showPinnedWorktreesInGroups: true })
+
+    probe.setConnState('reconnecting')
+    expect(probe.policy).toBe('duplicate-in-groups')
+
+    probe.setConnState('disconnected')
+    expect(probe.policy).toBe('duplicate-in-groups')
+    expect(probe.requests).toEqual(['settings.get'])
   })
 })

--- a/mobile/src/worktree/use-pinned-workspace-display-policy.test.tsx
+++ b/mobile/src/worktree/use-pinned-workspace-display-policy.test.tsx
@@ -1,0 +1,99 @@
+import { createElement } from 'react'
+import { act, create } from 'react-test-renderer'
+import { describe, expect, it } from 'vitest'
+import type { RpcClient } from '../transport/rpc-client'
+import type { ConnectionState } from '../transport/types'
+import type { PinnedWorktreeDisplayPolicy } from '../../../src/shared/worktree/pinned-display-policy'
+import { usePinnedWorkspaceDisplayPolicy } from './use-pinned-workspace-display-policy'
+
+type Pending = { resolve: (response: unknown) => void; reject: (err: Error) => void }
+
+/** Mounts the hook against a deferred settings.get so a test decides what the host answers. */
+function mountPolicy(connState: ConnectionState = 'connected') {
+  const pending: Pending[] = []
+  const requests: string[] = []
+  let latest: PinnedWorktreeDisplayPolicy = 'single-location'
+
+  const client = {
+    sendRequest: (method: string) => {
+      requests.push(method)
+      return new Promise<unknown>((resolve, reject) => pending.push({ resolve, reject }))
+    }
+  } as unknown as RpcClient
+
+  function Probe({ state }: { state: ConnectionState }) {
+    latest = usePinnedWorkspaceDisplayPolicy(client, state)
+    return null
+  }
+
+  act(() => {
+    create(createElement(Probe, { state: connState }))
+  })
+
+  return {
+    get policy(): PinnedWorktreeDisplayPolicy {
+      return latest
+    },
+    requests,
+    async settle(settings: unknown) {
+      await act(async () => {
+        pending[0]!.resolve({ ok: true, result: { settings } })
+        await Promise.resolve()
+      })
+    },
+    async settleRaw(response: unknown) {
+      await act(async () => {
+        pending[0]!.resolve(response)
+        await Promise.resolve()
+      })
+    },
+    async fail() {
+      await act(async () => {
+        pending[0]!.reject(new Error('host unreachable'))
+        await Promise.resolve()
+      })
+    }
+  }
+}
+
+describe('usePinnedWorkspaceDisplayPolicy', () => {
+  it('duplicates in groups when the desktop opted in', async () => {
+    const probe = mountPolicy()
+    await probe.settle({ showPinnedWorktreesInGroups: true })
+    expect(probe.policy).toBe('duplicate-in-groups')
+  })
+
+  it('stays single-location when the setting is false', async () => {
+    const probe = mountPolicy()
+    await probe.settle({ showPinnedWorktreesInGroups: false })
+    expect(probe.policy).toBe('single-location')
+  })
+
+  it('stays single-location when an older host omits the field', async () => {
+    const probe = mountPolicy()
+    await probe.settle({ compactWorktreeCards: true })
+    expect(probe.policy).toBe('single-location')
+  })
+
+  it('stays single-location for a non-boolean value', async () => {
+    const probe = mountPolicy()
+    await probe.settle({ showPinnedWorktreesInGroups: 'yes' })
+    expect(probe.policy).toBe('single-location')
+  })
+
+  it('stays single-location when the request fails', async () => {
+    const probe = mountPolicy()
+    await probe.fail()
+    expect(probe.policy).toBe('single-location')
+  })
+
+  it('stays single-location when the host reports an error response', async () => {
+    const probe = mountPolicy()
+    await probe.settleRaw({ ok: false, error: { code: 'unavailable' } })
+    expect(probe.policy).toBe('single-location')
+  })
+
+  it('issues no request while disconnected', () => {
+    expect(mountPolicy('reconnecting').requests).toEqual([])
+  })
+})

--- a/mobile/src/worktree/use-pinned-workspace-display-policy.ts
+++ b/mobile/src/worktree/use-pinned-workspace-display-policy.ts
@@ -1,0 +1,52 @@
+import { useEffect, useRef, useState } from 'react'
+import type { ConnectionState, RpcSuccess } from '../transport/types'
+import type { RpcClient } from '../transport/rpc-client'
+import {
+  getPinnedWorktreeDisplayPolicy,
+  type PinnedWorktreeDisplayPolicy
+} from '../../../src/shared/worktree/pinned-display-policy'
+
+// Fetches the desktop's GlobalSettings.showPinnedWorktreesInGroups so the mobile list duplicates
+// pinned workspaces into their natural groups only when the user opted in on desktop (#15494).
+// There is no settings-change stream over the mobile RPC, so this is a per-connection snapshot.
+export function usePinnedWorkspaceDisplayPolicy(
+  client: RpcClient | null,
+  connState: ConnectionState
+): PinnedWorktreeDisplayPolicy {
+  const [policy, setPolicy] = useState<PinnedWorktreeDisplayPolicy>('single-location')
+  const sourceClientRef = useRef<RpcClient | null>(null)
+
+  useEffect(() => {
+    if (!client || connState !== 'connected') {
+      sourceClientRef.current = null
+      setPolicy('single-location')
+      return
+    }
+    if (sourceClientRef.current !== client) {
+      // Why: the setting belongs to the connected runtime; never render a prior host's
+      // policy while the replacement host is still loading.
+      sourceClientRef.current = client
+      setPolicy('single-location')
+    }
+    let stale = false
+    void client
+      .sendRequest('settings.get')
+      .then((response) => {
+        if (stale || !response.ok) {
+          return
+        }
+        const result = (response as RpcSuccess).result as {
+          settings?: { showPinnedWorktreesInGroups?: boolean }
+        } | null
+        setPolicy(getPinnedWorktreeDisplayPolicy(result?.settings))
+      })
+      .catch(() => {
+        // Best-effort: single-location is desktop's default, and older hosts omit the field.
+      })
+    return () => {
+      stale = true
+    }
+  }, [client, connState])
+
+  return policy
+}

--- a/mobile/src/worktree/use-pinned-workspace-display-policy.ts
+++ b/mobile/src/worktree/use-pinned-workspace-display-policy.ts
@@ -17,9 +17,7 @@ export function usePinnedWorkspaceDisplayPolicy(
   const sourceClientRef = useRef<RpcClient | null>(null)
 
   useEffect(() => {
-    if (!client || connState !== 'connected') {
-      sourceClientRef.current = null
-      setPolicy('single-location')
+    if (!client) {
       return
     }
     if (sourceClientRef.current !== client) {
@@ -27,6 +25,11 @@ export function usePinnedWorkspaceDisplayPolicy(
       // policy while the replacement host is still loading.
       sourceClientRef.current = client
       setPolicy('single-location')
+    }
+    // Why keep the policy while not connected: the screen deliberately keeps rendering the
+    // pre-reconnect list, so a blip must not reflow it out of the opted-in shape (#15494).
+    if (connState !== 'connected') {
+      return
     }
     let stale = false
     void client

--- a/mobile/src/worktree/use-workspace-sections.ts
+++ b/mobile/src/worktree/use-workspace-sections.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import type { WorkspaceStatusDefinition } from '../../../src/shared/worktree/types'
+import type { PinnedWorktreeDisplayPolicy } from '../../../src/shared/worktree/pinned-display-policy'
 import type { MobileGroupMode, MobileSortMode } from './workspace-view-settings'
 import {
   buildSections,
@@ -26,6 +27,7 @@ export function useWorkspaceSections(args: {
   repoColorsByName: Map<string, string>
   collapsedGroups: Set<string>
   workspaceStatuses: readonly WorkspaceStatusDefinition[]
+  pinnedDisplayPolicy: PinnedWorktreeDisplayPolicy
 }): {
   sections: Section[]
   rawSections: Section[]
@@ -42,7 +44,8 @@ export function useWorkspaceSections(args: {
     repoIdsByName,
     repoColorsByName,
     collapsedGroups,
-    workspaceStatuses
+    workspaceStatuses,
+    pinnedDisplayPolicy
   } = args
 
   const uniqueRepos = useMemo(() => {
@@ -74,7 +77,8 @@ export function useWorkspaceSections(args: {
         pinnedIds,
         repoIdsByName,
         workspaceStatuses,
-        collapsedGroups
+        collapsedGroups,
+        pinnedDisplayPolicy
       ),
     [
       displayWorktrees,
@@ -85,7 +89,8 @@ export function useWorkspaceSections(args: {
       pinnedIds,
       repoIdsByName,
       workspaceStatuses,
-      collapsedGroups
+      collapsedGroups,
+      pinnedDisplayPolicy
     ]
   )
 

--- a/mobile/src/worktree/workspace-list-pinned-display-policy.test.ts
+++ b/mobile/src/worktree/workspace-list-pinned-display-policy.test.ts
@@ -3,6 +3,7 @@ import type { PinnedWorktreeDisplayPolicy } from '../../../src/shared/worktree/p
 import type { MobileGroupMode } from './workspace-view-settings'
 import { buildSections, type Section, type Worktree } from './workspace-list-sections'
 import { DEFAULT_MOBILE_WORKSPACE_STATUSES } from './mobile-workspace-statuses'
+import { getMobileWorkspaceLineageGroupKey } from './mobile-workspace-lineage'
 
 function worktree(overrides: Partial<Worktree> = {}): Worktree {
   return {
@@ -95,31 +96,65 @@ describe('buildSections pinned display policy', () => {
     ).toEqual(['host-b'])
   })
 
-  // Desktop pulls the pinned lineage subtree into Pinned via getPinnedSectionWorktrees; mobile's
-  // Pinned section is flat, so the child stays in its natural group at depth 0 — visible once.
-  it('keeps an unpinned child of a pinned parent visible exactly once', () => {
-    const parent = worktree({
-      worktreeId: 'parent',
-      displayName: 'parent',
-      isPinned: true,
-      worktreeInstanceId: 'parent-instance'
-    })
-    const child = worktree({
-      worktreeId: 'child',
-      displayName: 'child',
-      parentWorktreeId: 'parent',
-      worktreeInstanceId: 'child-instance',
-      lineageWorktreeInstanceId: 'child-instance',
-      parentWorktreeInstanceId: 'parent-instance'
+  const lineageParent = worktree({
+    worktreeId: 'parent',
+    displayName: 'parent',
+    isPinned: true,
+    worktreeInstanceId: 'parent-instance'
+  })
+  const lineageChild = worktree({
+    worktreeId: 'child',
+    displayName: 'child',
+    parentWorktreeId: 'parent',
+    worktreeInstanceId: 'child-instance',
+    lineageWorktreeInstanceId: 'child-instance',
+    parentWorktreeInstanceId: 'parent-instance'
+  })
+
+  // Desktop pulls the pinned lineage subtree into Pinned (getPinnedSectionWorktrees). Without
+  // that, single-location strips the parent out of its group and orphans the child there.
+  it('follows a pinned parent into Pinned and keeps the child nested under it', () => {
+    const sections = sectionsFor([lineageParent, lineageChild], 'none')
+
+    expect(sectionKeysContaining(sections, 'child')).toEqual(['pinned'])
+    expect(sectionKeysContaining(sections, 'parent')).toEqual(['pinned'])
+    const pinnedRows = sections.find((section) => section.key === 'pinned')?.data ?? []
+    expect(pinnedRows.map((row) => [row.worktreeId, row.lineageDepth])).toEqual([
+      ['parent', 0],
+      ['child', 1]
+    ])
+    expect(pinnedRows[0]?.lineageChildCount).toBe(1)
+    expect(sections.some((section) => section.key === 'all')).toBe(false)
+  })
+
+  it('collapses the pinned subtree when its lineage group is collapsed', () => {
+    const sections = buildSections(
+      [lineageParent, lineageChild],
+      'manual',
+      { filterRepoIds: new Set(), hideSleeping: false, hideDefaultBranch: false },
+      '',
+      'none',
+      new Set(),
+      new Map(),
+      DEFAULT_MOBILE_WORKSPACE_STATUSES,
+      new Set([getMobileWorkspaceLineageGroupKey(lineageParent)])
+    )
+
+    expect(sectionKeysContaining(sections, 'child')).toEqual([])
+    const pinnedRows = sections.find((section) => section.key === 'pinned')?.data ?? []
+    expect(pinnedRows.map((row) => row.worktreeId)).toEqual(['parent'])
+    expect(pinnedRows[0]?.lineageCollapsed).toBe(true)
+  })
+
+  it('leaves a stale-instance child in its natural group', () => {
+    const staleChild = worktree({
+      ...lineageChild,
+      parentWorktreeInstanceId: 'recycled-parent-instance'
     })
 
-    const sections = sectionsFor([parent, child], 'none')
+    const sections = sectionsFor([lineageParent, staleChild], 'none')
 
     expect(sectionKeysContaining(sections, 'child')).toEqual(['all'])
     expect(sectionKeysContaining(sections, 'parent')).toEqual(['pinned'])
-    const childRow = sections
-      .flatMap((section) => section.data)
-      .find((row) => row.worktreeId === 'child')
-    expect(childRow?.lineageDepth ?? 0).toBe(0)
   })
 })

--- a/mobile/src/worktree/workspace-list-pinned-display-policy.test.ts
+++ b/mobile/src/worktree/workspace-list-pinned-display-policy.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+import type { PinnedWorktreeDisplayPolicy } from '../../../src/shared/worktree/pinned-display-policy'
+import type { MobileGroupMode } from './workspace-view-settings'
+import { buildSections, type Section, type Worktree } from './workspace-list-sections'
+import { DEFAULT_MOBILE_WORKSPACE_STATUSES } from './mobile-workspace-statuses'
+
+function worktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    workspaceKind: 'git',
+    worktreeId: 'worktree',
+    repoId: 'repo-1',
+    repo: 'orca',
+    branch: 'feature/pinned',
+    displayName: 'worktree',
+    path: '/tmp/worktree',
+    liveTerminalCount: 0,
+    hasAttachedPty: false,
+    preview: '',
+    unread: false,
+    isPinned: false,
+    linkedPR: null,
+    status: 'inactive',
+    agents: [],
+    ...overrides
+  }
+}
+
+function sectionsFor(
+  worktrees: Worktree[],
+  groupMode: MobileGroupMode,
+  policy?: PinnedWorktreeDisplayPolicy
+): Section[] {
+  return buildSections(
+    worktrees,
+    'manual',
+    { filterRepoIds: new Set(), hideSleeping: false, hideDefaultBranch: false },
+    '',
+    groupMode,
+    new Set(),
+    new Map(),
+    DEFAULT_MOBILE_WORKSPACE_STATUSES,
+    new Set(),
+    policy
+  )
+}
+
+function sectionKeysContaining(sections: Section[], worktreeId: string): string[] {
+  return sections.flatMap((section) =>
+    section.data.filter((row) => row.worktreeId === worktreeId).map(() => section.key)
+  )
+}
+
+const GROUP_MODES: MobileGroupMode[] = ['none', 'repo', 'workspaceStatus', 'prStatus']
+
+describe('buildSections pinned display policy', () => {
+  const pinned = worktree({ worktreeId: 'pinned', displayName: 'pinned', isPinned: true })
+
+  it.each(GROUP_MODES)('renders a pinned workspace once by default in %s grouping', (groupMode) => {
+    expect(sectionKeysContaining(sectionsFor([pinned], groupMode), 'pinned')).toEqual(['pinned'])
+  })
+
+  it.each(GROUP_MODES)('renders a pinned workspace once for single-location in %s', (groupMode) => {
+    const sections = sectionsFor([pinned], groupMode, 'single-location')
+    expect(sectionKeysContaining(sections, 'pinned')).toEqual(['pinned'])
+  })
+
+  it.each(GROUP_MODES)('duplicates into the natural group when opted in for %s', (groupMode) => {
+    const keys = sectionKeysContaining(
+      sectionsFor([pinned], groupMode, 'duplicate-in-groups'),
+      'pinned'
+    )
+    expect(keys).toHaveLength(2)
+    expect(keys[0]).toBe('pinned')
+    expect(keys[1]).not.toBe('pinned')
+  })
+
+  it('keeps a pinned folder workspace out of its repo group', () => {
+    const folder = worktree({
+      worktreeId: 'folder',
+      workspaceKind: 'folder-workspace',
+      isPinned: true
+    })
+    expect(sectionKeysContaining(sectionsFor([folder], 'repo'), 'folder')).toEqual(['pinned'])
+  })
+
+  it('leaves a same-id workspace on another host in its natural group', () => {
+    const pinnedOnHostA = worktree({ worktreeId: 'shared', hostId: 'host-a', isPinned: true })
+    const unpinnedOnHostB = worktree({ worktreeId: 'shared', hostId: 'host-b' })
+
+    const sections = sectionsFor([pinnedOnHostA, unpinnedOnHostB], 'none')
+
+    expect(sections.find((section) => section.key === 'pinned')?.data).toHaveLength(1)
+    expect(
+      sections.find((section) => section.key === 'all')?.data.map((row) => row.hostId)
+    ).toEqual(['host-b'])
+  })
+
+  // Desktop pulls the pinned lineage subtree into Pinned via getPinnedSectionWorktrees; mobile's
+  // Pinned section is flat, so the child stays in its natural group at depth 0 — visible once.
+  it('keeps an unpinned child of a pinned parent visible exactly once', () => {
+    const parent = worktree({
+      worktreeId: 'parent',
+      displayName: 'parent',
+      isPinned: true,
+      worktreeInstanceId: 'parent-instance'
+    })
+    const child = worktree({
+      worktreeId: 'child',
+      displayName: 'child',
+      parentWorktreeId: 'parent',
+      worktreeInstanceId: 'child-instance',
+      lineageWorktreeInstanceId: 'child-instance',
+      parentWorktreeInstanceId: 'parent-instance'
+    })
+
+    const sections = sectionsFor([parent, child], 'none')
+
+    expect(sectionKeysContaining(sections, 'child')).toEqual(['all'])
+    expect(sectionKeysContaining(sections, 'parent')).toEqual(['pinned'])
+    const childRow = sections
+      .flatMap((section) => section.data)
+      .find((row) => row.worktreeId === 'child')
+    expect(childRow?.lineageDepth ?? 0).toBe(0)
+  })
+})

--- a/mobile/src/worktree/workspace-list-sections.test.ts
+++ b/mobile/src/worktree/workspace-list-sections.test.ts
@@ -689,7 +689,7 @@ describe('buildSections', () => {
     expect(sections[0]?.data.map((worktree) => worktree.worktreeId)).toEqual(['progress'])
   })
 
-  it('keeps pinned worktrees in their canonical status group like desktop', () => {
+  it('keeps pinned worktrees out of their canonical status group by default like desktop', () => {
     const pinned = worktree({
       worktreeId: 'pinned',
       workspaceStatus: 'in-progress',
@@ -708,8 +708,7 @@ describe('buildSections', () => {
     )
 
     expect(withoutSectionListKeys(sections)).toEqual([
-      { key: 'pinned', title: 'Pinned', icon: 'pin', data: [pinned] },
-      { key: 'workspace-status:in-progress', title: 'In progress', data: [pinned] }
+      { key: 'pinned', title: 'Pinned', icon: 'pin', data: [pinned] }
     ])
   })
 

--- a/mobile/src/worktree/workspace-list-sections.ts
+++ b/mobile/src/worktree/workspace-list-sections.ts
@@ -12,9 +12,11 @@ import type { FilterState, Section, Worktree } from './workspace-list-types'
 import type { MobileGroupMode, MobileSortMode } from './workspace-view-settings'
 import { sortWorktrees } from './workspace-list-ordering'
 import { getWorktreeRowIdentity } from './worktree-host-row-identity'
+import { getPinnedSectionWorktrees } from './pinned-section-worktrees'
 
 export type { FilterState, Section, Worktree } from './workspace-list-types'
 export { CREATE_GRACE_MS, getWorktreeStatus, sortWorktrees } from './workspace-list-ordering'
+export { isWorktreePinned } from './pinned-section-worktrees'
 
 function makeSection(
   key: string,
@@ -117,10 +119,6 @@ export function filterWorktrees(
   return result
 }
 
-export function isWorktreePinned(w: Worktree, localPins: Set<string>): boolean {
-  return w.isPinned || localPins.has(w.worktreeId)
-}
-
 export function buildSections(
   worktrees: Worktree[],
   sortMode: MobileSortMode,
@@ -136,7 +134,7 @@ export function buildSections(
   const filtered = filterWorktrees(worktrees, filters, search)
   const sorted = sortWorktrees(filtered, sortMode)
 
-  const pinned = sorted.filter((w) => isWorktreePinned(w, pinnedIds))
+  const pinned = getPinnedSectionWorktrees(sorted, pinnedIds)
   // Why single-location by default: hosts predating showPinnedWorktreesInGroups omit it (#15494).
   // Why row identity and not pinnedIds: a device-local pin is keyed on the bare worktreeId, which
   // would also strip a same-id workspace on another host out of its group.
@@ -148,7 +146,7 @@ export function buildSections(
 
   const sections: Section[] = []
   if (pinned.length > 0) {
-    sections.push(makeSection('pinned', 'Pinned', pinned, 'pin'))
+    sections.push(makeSection('pinned', 'Pinned', pinned, 'pin', collapsedGroups))
   }
 
   if (groupMode === 'none') {

--- a/mobile/src/worktree/workspace-list-sections.ts
+++ b/mobile/src/worktree/workspace-list-sections.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceStatusDefinition } from '../../../src/shared/worktree/types'
+import type { PinnedWorktreeDisplayPolicy } from '../../../src/shared/worktree/pinned-display-policy'
 import {
   DEFAULT_MOBILE_WORKSPACE_STATUSES,
   coerceMobileWorkspaceStatuses,
@@ -129,15 +130,21 @@ export function buildSections(
   pinnedIds: Set<string>,
   repoIdsByName: ReadonlyMap<string, string> = new Map(),
   workspaceStatuses: readonly WorkspaceStatusDefinition[] = DEFAULT_MOBILE_WORKSPACE_STATUSES,
-  collapsedGroups: ReadonlySet<string> = new Set()
+  collapsedGroups: ReadonlySet<string> = new Set(),
+  pinnedDisplayPolicy: PinnedWorktreeDisplayPolicy = 'single-location'
 ): Section[] {
   const filtered = filterWorktrees(worktrees, filters, search)
   const sorted = sortWorktrees(filtered, sortMode)
 
   const pinned = sorted.filter((w) => isWorktreePinned(w, pinnedIds))
-  // Why: desktop treats Pinned as an overlay. Keeping pinned rows in canonical
-  // groups preserves exact cross-surface order and literal section counts.
-  const canonicalGroupWorktrees = sorted
+  // Why single-location by default: hosts predating showPinnedWorktreesInGroups omit it (#15494).
+  // Why row identity and not pinnedIds: a device-local pin is keyed on the bare worktreeId, which
+  // would also strip a same-id workspace on another host out of its group.
+  const pinnedRowIdentities = new Set(pinned.map(getWorktreeRowIdentity))
+  const canonicalGroupWorktrees =
+    pinnedDisplayPolicy === 'duplicate-in-groups'
+      ? sorted
+      : sorted.filter((w) => !pinnedRowIdentities.has(getWorktreeRowIdentity(w)))
 
   const sections: Section[] = []
   if (pinned.length > 0) {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1790,6 +1790,17 @@ describe('OrcaRuntimeService', () => {
     expect(runtime.getClientTerminalQuickCommands()).toEqual(terminalQuickCommands)
   })
 
+  it('projects the pinned-duplication policy so paired clients match desktop grouping', () => {
+    const defaults = new OrcaRuntimeService(store as never)
+    expect(defaults.getClientSettings()).toMatchObject({ showPinnedWorktreesInGroups: false })
+
+    const optedIn = new OrcaRuntimeService({
+      ...store,
+      getSettings: () => ({ ...store.getSettings(), showPinnedWorktreesInGroups: true })
+    } as never)
+    expect(optedIn.getClientSettings()).toMatchObject({ showPinnedWorktreesInGroups: true })
+  })
+
   it('updates quick commands without widening general paired settings payloads', () => {
     const existing = {
       id: 'review',

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1349,6 +1349,7 @@ type RuntimeStore = {
     githubProjects?: GlobalSettings['githubProjects']
     experimentalNewWorktreeCardStyle?: GlobalSettings['experimentalNewWorktreeCardStyle']
     compactWorktreeCards?: GlobalSettings['compactWorktreeCards']
+    showPinnedWorktreesInGroups?: GlobalSettings['showPinnedWorktreesInGroups']
     minimaxGroupId?: GlobalSettings['minimaxGroupId']
     minimaxUsageModels?: GlobalSettings['minimaxUsageModels']
     prBotAuthorOverrides?: GlobalSettings['prBotAuthorOverrides']

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3874,6 +3874,9 @@ export class OrcaRuntimeService {
     | 'githubProjects'
     | 'experimentalNewWorktreeCardStyle'
     | 'compactWorktreeCards'
+    // Read-only: clients render the pinned-duplication policy, but SettingsUpdate omits the key
+    // so no RPC caller can flip a desktop appearance preference.
+    | 'showPinnedWorktreesInGroups'
     | 'minimaxGroupId'
     | 'minimaxUsageModels'
     | 'prBotAuthorOverrides'
@@ -3902,6 +3905,7 @@ export class OrcaRuntimeService {
       githubProjects: settings.githubProjects,
       experimentalNewWorktreeCardStyle: settings.experimentalNewWorktreeCardStyle === true,
       compactWorktreeCards: settings.compactWorktreeCards === true,
+      showPinnedWorktreesInGroups: settings.showPinnedWorktreesInGroups === true,
       minimaxGroupId: settings.minimaxGroupId ?? '',
       minimaxUsageModels: settings.minimaxUsageModels ?? 'general',
       prBotAuthorOverrides: settings.prBotAuthorOverrides ?? [],

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/row-types.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/row-types.ts
@@ -6,13 +6,11 @@ import type { DetectedWorktree, Worktree } from '../../../../../../shared/worktr
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 
 export type WorktreeGroupBy = 'none' | 'workspace-status' | 'repo' | 'pr-status'
-export type PinnedWorktreeDisplayPolicy = 'single-location' | 'duplicate-in-groups'
-
-export function getPinnedWorktreeDisplayPolicy(
-  settings?: { showPinnedWorktreesInGroups?: boolean } | null
-): PinnedWorktreeDisplayPolicy {
-  return settings?.showPinnedWorktreesInGroups === true ? 'duplicate-in-groups' : 'single-location'
-}
+// Re-exported so mobile shares the same default rule without importing from src/renderer.
+export {
+  getPinnedWorktreeDisplayPolicy,
+  type PinnedWorktreeDisplayPolicy
+} from '../../../../../../shared/worktree/pinned-display-policy'
 
 export type GroupHeaderRow = {
   type: 'header'

--- a/src/shared/worktree/pinned-display-policy.ts
+++ b/src/shared/worktree/pinned-display-policy.ts
@@ -1,0 +1,8 @@
+export type PinnedWorktreeDisplayPolicy = 'single-location' | 'duplicate-in-groups'
+
+/** Absent/false is the single-location default, so hosts predating the setting fall back to it. */
+export function getPinnedWorktreeDisplayPolicy(
+  settings?: { showPinnedWorktreesInGroups?: boolean } | null
+): PinnedWorktreeDisplayPolicy {
+  return settings?.showPinnedWorktreesInGroups === true ? 'duplicate-in-groups' : 'single-location'
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​292 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​289 |
| Prod | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​176 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​34 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​142 |

<!-- /orca-pr-loc -->

## ELI5

On the phone, a workspace you pinned showed up twice: once in the **Pinned** section at the top, and again down in its normal group (All / repo / status / PR). The desktop app stopped doing that a while back — it only duplicates pinned rows if you explicitly turn on the "show pinned worktrees in groups" setting. Mobile never learned about that setting, so it always duplicated. Now mobile asks the desktop what the setting says and matches it, defaulting to showing each pinned workspace exactly once.

## What Changed

- `src/shared/worktree/pinned-display-policy.ts` (new): `PinnedWorktreeDisplayPolicy` and `getPinnedWorktreeDisplayPolicy` moved verbatim out of the renderer sidebar tree so both surfaces encode the "absent/false → `single-location`" default rule once. `grouping/row-types.ts` re-exports both, so all 14 existing desktop import sites are untouched (15 files reference the two symbols, counting `row-types.ts` itself).
- `src/main/runtime/orca-runtime.ts`: `getClientSettings()` now projects `showPinnedWorktreesInGroups` (normalized to a boolean at the host). **Read-only** — deliberately *not* added to `SettingsUpdate`/`updateClientSettings`, so no paired client can flip a desktop appearance preference.
- `mobile/src/worktree/workspace-list-sections.ts`: `buildSections` takes a trailing `pinnedDisplayPolicy` parameter (mirroring desktop `buildRows`) and, unless the policy is `duplicate-in-groups`, filters pinned rows out of the canonical group list. The exclusion set is built from the **resolved** `pinned` rows via `getWorktreeRowIdentity` (host-qualified), never from the raw `pinnedIds` set.
- `mobile/src/worktree/pinned-section-worktrees.ts` (new): `getPinnedSectionWorktrees` — the mobile counterpart of the desktop helper of the same name. The Pinned section owns the pinned rows **plus their visible lineage descendants**, so removing a pinned parent from its natural group cannot orphan its children there. `isWorktreePinned` moved here alongside it (re-exported from `workspace-list-sections.ts`, so no call site changed). The Pinned section is now built with `collapsedGroups`, so it nests and collapses like every other section.
- `mobile/src/worktree/mobile-workspace-lineage.ts`: the parent-resolution rules (parent present, not self, visible, instance ids not stale) are extracted into `getMobileLineageParentIdentity` so the Pinned subtree walk and `applyMobileWorkspaceLineage` cannot drift apart. Pure extraction — no rule changed.
- `mobile/src/worktree/use-pinned-workspace-display-policy.ts` (new): one-shot per-connection `settings.get` read, modeled on the existing `usePRBotAuthorOverrides` hook. Fetches only while `connState === 'connected'` and resets on client identity change, but **keeps the last fetched policy while amber** — the host screen deliberately keeps rendering the pre-reconnect list, so a background/network blip must not silently reflow it. Degrades to `single-location` on failure or an absent field.
- `src/main/runtime/orca-runtime.ts`: `RuntimeStore['getSettings']` declares `showPinnedWorktreesInGroups` (its structural type is a hand-maintained subset of `GlobalSettings`; without the key the `typecheck` job failed).
- `mobile/src/worktree/use-workspace-sections.ts` + `mobile/app/h/[hostId]/index.tsx`: wire the policy through (including the `useMemo` dep, so a late-arriving `settings.get` rebuilds the sections).

## Why

Root cause is two-layered, which is why a plain unconditional dedupe would have been wrong:

1. `mobile/src/worktree/workspace-list-sections.ts` hard-coded `const canonicalGroupWorktrees = sorted`, with a comment claiming this was desktop parity. That comment predates the desktop opt-in: `buildRows` computes `pinnedSectionIds` and filters those identities out of `naturalWorktrees` unless the policy is `duplicate-in-groups` (`src/renderer/.../grouping/build-rows.ts`). So every pinned workspace rendered twice on mobile.
2. Mobile had no way to learn the policy — `getClientSettings()` omitted `showPinnedWorktreesInGroups` from its `Pick<GlobalSettings, ...>`, so `settings.get` never carried it. Deduping unconditionally would have silently broken users who deliberately enabled the desktop toggle.

Using the *resolved* pinned rows for the exclusion set matters: `isWorktreePinned` matches device-local pins on the bare `worktreeId`, while row identity everywhere else is host-qualified. Keying the filter on `pinnedIds` would have stripped a same-id workspace on a *different* host out of its natural group while only the pinned host's row appeared under Pinned — the workspace would have vanished entirely.

## Linked Issue

Fixes #15494

## Visual Proof

Not attached — I do not have a paired mobile device/simulator in this environment, so any "before/after" I produced would be fabricated. This *is* a UI change, so here is precisely what a reviewer should look at:

1. On desktop, leave **Show pinned worktrees in groups** off (the default). Pin a workspace.
2. Open that host in the mobile app, workspaces list. Cycle grouping through All / Repo / Workspace status / PR status.
3. **Expected after this PR:** the pinned workspace appears only under **Pinned** in every grouping. Before this PR it appeared under Pinned *and* in its natural group in all four.
4. Turn the desktop setting on, reconnect the phone (the read is a per-connection snapshot; there is no settings-change stream over the mobile RPC), and confirm the duplicate row comes back — that is the intentional opt-in.

5. Lineage worth eyeballing: pin a **parent** workspace that has children. Expected — parent and children both move under **Pinned**, still nested, and the parent keeps its expand/collapse chevron. (Under `duplicate-in-groups` the descendants show in both places, which is what desktop does.)

## Testing

Ran on **macOS only** (Darwin 25.3.0). Everything below passed.

Regression evidence — I stashed the two product hunks (`mobile/src/worktree/workspace-list-sections.ts`, `src/main/runtime/orca-runtime.ts`) and re-ran the tests:

```
# WITHOUT the product change:
mobile$ npx vitest run --config vitest.config.ts \
    src/worktree/workspace-list-pinned-display-policy.test.ts \
    src/worktree/workspace-list-sections.test.ts
  Tests  12 failed | 40 passed (52)

$ npx vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t "pinned-duplication"
  AssertionError: expected { …(20) } to match object { showPinnedWorktreesInGroups: false }
  Tests  1 failed | 1184 skipped
```

Follow-up commit (pinned lineage subtree + policy across blips) — same method, product lines reverted:

```
# WITHOUT the two product hunks (getPinnedSectionWorktrees + the connState guard):
mobile$ npx vitest run --config vitest.config.ts \
    src/worktree/workspace-list-pinned-display-policy.test.ts \
    src/worktree/use-pinned-workspace-display-policy.test.tsx
  × keeps the opted-in policy across a reconnect blip
      AssertionError: expected 'single-location' to be 'duplicate-in-groups'
  × follows a pinned parent into Pinned and keeps the child nested under it
      AssertionError: expected [ 'all' ] to deeply equal [ 'pinned' ]
  × collapses the pinned subtree when its lineage group is collapsed
      AssertionError: expected [ 'all' ] to deeply equal []
  Tests  3 failed | 22 passed (25)
```

With the change restored:

```
mobile$ npx vitest run --config vitest.config.ts src/worktree/
  Test Files  24 passed (24)   Tests  197 passed (197)

$ npx vitest run --config config/vitest.config.ts \
    src/main/runtime/orca-runtime.test.ts \
    src/main/runtime/runtime-rpc-mobile-method-allowlist.test.ts \
    src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.test.ts
  Test Files  3 passed (3)   Tests  1212 passed | 1 skipped

$ npx vitest run --config config/vitest.config.ts \
    src/main/runtime/rpc/methods/client-ui.test.ts \
    src/renderer/src/components/sidebar/rendered-sidebar-worktree-order.test.ts
  Test Files  2 passed (2)   Tests  52 passed (52)

$ npx vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts -t "pinned-duplication"
  Test Files  1 passed (1)   Tests  1 passed | 1184 skipped

$ npx oxfmt --check <all changed files>                                               # exit 0
$ npx oxlint --deny-warnings <changed root files>                                     # exit 0
$ npx oxlint --config config/oxlint-code-quality-native-plugins.json --deny-warnings <all changed files>  # exit 0
mobile$ npx oxlint --deny-warnings src/worktree/ 'app/h/[hostId]/index.tsx'           # exit 0 (max-lines gate)
```

`pnpm typecheck` / full `pnpm lint` were **not** run locally (they OOM in this environment); CI covers them. The first push's `typecheck` job was red on exactly one error — `RuntimeStore['getSettings']` did not declare `showPinnedWorktreesInGroups` — which the follow-up commit fixes; `verify` was red only because it gates on `typecheck`.

New/changed tests:
- `mobile/src/worktree/workspace-list-pinned-display-policy.test.ts` (new) — the policy matrix across all four group modes (default / explicit `single-location` / `duplicate-in-groups`), a pinned **folder workspace**, the same-`worktreeId`-on-two-hosts case, and three lineage cases: a pinned parent taking its child into Pinned at depth 1, that subtree collapsing under the parent's lineage key, and a stale-instance child correctly *not* following its parent.
- `mobile/src/worktree/use-pinned-workspace-display-policy.test.tsx` (new) — `true` / `false` / field absent (old host) / non-boolean junk / rejected request / `ok: false` / not connected, plus the policy surviving a `connected → reconnecting → disconnected` blip with no re-request.
- `mobile/src/worktree/workspace-list-sections.test.ts` — the one existing case that asserted the buggy duplicated output was rewritten in place (the file is near its `max-lines` budget, so no cases were added there).
- `src/main/runtime/orca-runtime.test.ts` — asserts `getClientSettings()` projects the field, default `false` and opted-in `true`.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

**Cross-platform:** No keyboard handling, no `metaKey`, no path construction, no OS branch. The mobile side is React Native (identical on iOS/Android); the desktop side is main-process TypeScript.

**SSH / remote:** Nothing here reports on, stops, or lists remote *work* — it is list presentation only. No `live`/`unverifiable`/`exited` verdict is produced or consumed. The boundary is honored the right way round: the execution host owns the setting, mobile only reads it, and a failed or absent read degrades to the documented default rather than guessing.

**Remote wire compatibility:** Rule 1 of `docs/reference/remote-wire-compatibility.md` — a new **optional** field on an existing `settings.get` response. No new opcode, no `RUNTIME_PROTOCOL_VERSION` bump, no capability negotiation needed. New mobile + old host → field absent → `single-location`, which is desktop's default and exactly what the issue asks for. Old mobile + new host → extra key ignored. `settings.get` is already on the mobile allowlist, so no allowlist change. Existing assertions use `toMatchObject`, so the added key breaks nothing.

**Folder workspaces:** `buildSections` operates on the mobile `Worktree` view model, which covers `workspaceKind: 'folder-workspace'`. The filter keys on host-qualified row identity, not git-ness — covered by an explicit test.

**Provider neutrality:** The `prStatus` path is provider-agnostic (`getPRGroupKey` over the mobile `linkedPR` shape); no GitHub/GitLab branch or naming was added.

**Multi-host:** Exclusion uses `getWorktreeRowIdentity` (shared `composeWorktreeHostIdentity`, same primitive desktop uses), derived from resolved pinned rows so a `worktreeId`-keyed device-local pin cannot strip another host's row. Dedicated test.

**Performance:** One extra `Set` build, one parent-index build and one `Array.filter`, all O(n) over an already-sorted list, inside the existing `useMemo`. The pinned subtree walk visits each row at most once. The `settings.get` fetch is one request per connection (guarded by `connState` and a client-identity ref), not per render. Net render cost goes *down* in `single-location` mode — fewer rows are emitted.

**UI quality:** No new colors, sizes, spacing, or components; this only changes which rows land in which section.

**Security:** The field is projected read-only. It is not in `SettingsUpdate`, so no RPC caller can grant itself the ability to change a desktop preference — same posture as the neighbouring `artifactSharingEnabled`. No new network sink, no dependency change, no persisted state, no secret material.

**max-lines:** `mobile/.oxlintrc.json` is untouched and no `oxlint-disable max-lines` was added — that is exactly why the RPC logic lives in its own hook module instead of inline in `app/h/[hostId]/index.tsx` (which is ~1589 of its 1603 budget after this change).

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Known limitations / follow-ups

- The policy is still a **per-connection snapshot**: there is no settings-change stream on the mobile RPC, so toggling **Show pinned worktrees in groups** on desktop reaches an already-connected phone only on the next connect. Deliberate — a push channel for settings is a separate change.
- Repo grouping drops a project's section header when *every* visible workspace in it is pinned: under `single-location` those rows move to **Pinned**, and the empty-project backfill only creates a header for a repo with no workspaces at all. Desktop does exactly the same — `buildOrderedGroups` buckets `naturalWorktrees` (pinned already removed) and `getEmptyProjectPlaceholderRepoIds` only marks repos whose `worktreesByRepo` entry is empty, so a pinned-only repo gets no section there either. Verified against `buildRows` directly; making mobile render a count-0 header would be a mobile-only divergence, so it is left as is.
- A `forceReconnect` that swaps the underlying `RpcClient` object resets the policy to `single-location` until the new connection's `settings.get` lands. That path already re-fetches immediately; only the identity-change guard (which exists to avoid rendering a prior host's policy) can produce that momentary default.

## Notes

`mobile/node_modules` was empty in this worktree, so `pnpm --dir mobile install --frozen-lockfile` was run to execute the mobile test suite. No `package.json` or lockfile was modified.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)


