### PR TITLE
fix(agent-resume): restore Kimi Code sessions after restart

### DIFF
--- a/mobile/src/session/ai-vault-resume-launch.test.ts
+++ b/mobile/src/session/ai-vault-resume-launch.test.ts
@@ -121,6 +121,25 @@ describe('buildMobileAiVaultResumeCommand', () => {
 })
 
 describe('buildMobileAiVaultResumeLaunch', () => {
+  it('routes Kimi through the resumable-agent startup plan', () => {
+    // Why: kimi joining RESUMABLE_TUI_AGENTS moves it off the plain command fallback, so the
+    // cd prefix Kimi needs (sessions are work-dir-scoped) must survive the new branch.
+    const launch = buildMobileAiVaultResumeLaunch({
+      session: session({
+        agent: 'kimi',
+        sessionId: 'session_431324d7-2165-42f0-9ecd-9f93437b3201'
+      }),
+      hostPlatform: 'darwin'
+    })
+
+    expect(launch).toMatchObject({
+      command:
+        "cd '/Users/ada/repo' && kimi '--yolo' '--session' 'session_431324d7-2165-42f0-9ecd-9f93437b3201'",
+      launchConfig: { agentCommand: "kimi '--yolo'" },
+      launchAgent: 'kimi'
+    })
+  })
+
   it('preserves an arbitrary OMP transcript locator for later cold resume', () => {
     const launch = buildMobileAiVaultResumeLaunch({
       session: session({

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-host-session-launch.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-host-session-launch.test.ts
@@ -348,6 +348,89 @@ describe('createRemoteRuntimePtyTransport', () => {
     )
   })
 
+  it('degrades a Kimi resume to a legacy launch when the host predates the resume capability', async () => {
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'repo1::/remote/wt',
+      command: "kimi '--session' 'session_431324d7'",
+      launchAgent: 'kimi',
+      resumeProviderSession: { key: 'session_id', id: 'session_431324d7' },
+      tabId: 'tab-1',
+      leafId: '11111111-1111-4111-8111-111111111111'
+    })
+
+    await transport.connect({ url: '', callbacks: {} })
+
+    // Why: the beforeEach host advertises host-authority.v1 but not the Kimi gate, and it answers
+    // the widened ensureAgentSession enum with invalid_argument — not a fallback code. Only the
+    // per-agent probe keeps the pane alive.
+    expect(runtimeCall).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'terminal.ensureAgentSession' })
+    )
+    expect(runtimeCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'terminal.create',
+        params: expect.objectContaining({ command: "kimi '--session' 'session_431324d7'" })
+      })
+    )
+  })
+
+  it('claims the Kimi provider session on a host that advertises the resume capability', async () => {
+    runtimeCall.mockImplementation(async (args: { method?: string }) =>
+      args.method === 'status.get'
+        ? {
+            id: 'rpc-status',
+            ok: true,
+            result: {
+              runtimeProtocolVersion: 3,
+              minCompatibleRuntimeClientVersion: 2,
+              capabilities: ['agent-session.host-authority.v1', 'agent-session.kimi-resume.v1']
+            },
+            _meta: { runtimeId: 'runtime-remote' }
+          }
+        : {
+            id: 'rpc-create',
+            ok: true,
+            result: {
+              terminal: {
+                handle: 'term-remote',
+                worktreeId: 'repo1::/remote/wt',
+                title: null,
+                surface: 'background'
+              }
+            },
+            _meta: { runtimeId: 'runtime-remote' }
+          }
+    )
+    const { createRemoteRuntimePtyTransport } = await import('./remote-runtime-pty-transport')
+    const transport = createRemoteRuntimePtyTransport('env-1', {
+      worktreeId: 'repo1::/remote/wt',
+      command: "kimi '--session' 'session_431324d7'",
+      launchAgent: 'kimi',
+      resumeProviderSession: { key: 'session_id', id: 'session_431324d7' },
+      tabId: 'tab-1',
+      leafId: '11111111-1111-4111-8111-111111111111'
+    })
+
+    await transport.connect({ url: '', callbacks: {} })
+
+    expect(runtimeCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'terminal.ensureAgentSession',
+        params: expect.objectContaining({
+          agent: 'kimi',
+          providerSession: { key: 'session_id', id: 'session_431324d7' }
+        })
+      })
+    )
+    expect(runtimeCall).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'terminal.create',
+        params: expect.objectContaining({ command: expect.any(String) })
+      })
+    )
+  })
+
   it('treats an explicitly killed remote session as normal retirement', async () => {
     runtimeCall.mockImplementation(async (args: { method?: string }) =>
       args.method === 'terminal.create'

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -19,10 +19,8 @@ import type {
   RuntimeTerminalResolvePane,
   RuntimeTerminalSend
 } from '../../../../shared/runtime-types'
-import {
-  AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
-  TERMINAL_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY
-} from '../../../../shared/protocol-version'
+import { TERMINAL_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY } from '../../../../shared/protocol-version'
+import { agentResumeHostAuthorityCapability } from '../../runtime/agent-resume-host-authority-capability'
 import {
   isTerminalInputTooLargeWithDeferredMeasurement,
   iterateTerminalInputChunks
@@ -2104,14 +2102,17 @@ export function createRemoteRuntimePtyTransport(
             createEnvironmentId,
             connectLifecycleEpoch
           )
+        const resumeHostAuthorityCapability = resumeProviderSessionToSend
+          ? agentResumeHostAuthorityCapability(launchAgentToSend)
+          : undefined
         const created = launchAgentToSend
           ? agentSessionRequiresHostAuthorityReplay
             ? await hostAuthorityCreate()
             : await runRemoteAgentSessionLaunch<RemoteAgentSessionLaunchResult | null>({
                 environmentId: createEnvironmentId,
                 hostAuthority: hostAuthorityCreate,
-                ...(resumeProviderSessionToSend && launchAgentToSend === 'omp'
-                  ? { hostAuthorityCapability: AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY }
+                ...(resumeHostAuthorityCapability
+                  ? { hostAuthorityCapability: resumeHostAuthorityCapability }
                   : {}),
                 legacy: legacyCreate
               })

--- a/src/renderer/src/lib/ai-vault-resume-command.resumable-agent.test.ts
+++ b/src/renderer/src/lib/ai-vault-resume-command.resumable-agent.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AppState } from '@/store/types'
+import {
+  buildAiVaultResumeCopyCommandForWorktree,
+  buildAiVaultResumeStartupForWorktree
+} from './ai-vault-resume-command'
+
+vi.mock('@/lib/new-workspace', () => ({
+  CLIENT_PLATFORM: 'darwin'
+}))
+
+type ResumableAgentState = Pick<
+  AppState,
+  | 'activeRepoId'
+  | 'activeWorktreeId'
+  | 'folderWorkspaces'
+  | 'projectGroups'
+  | 'projects'
+  | 'repos'
+  | 'settings'
+  | 'worktreesByRepo'
+>
+
+function makeState(): ResumableAgentState {
+  return {
+    activeRepoId: 'repo-1',
+    activeWorktreeId: 'repo-1::worktree-1',
+    folderWorkspaces: [],
+    projectGroups: [],
+    repos: [{ id: 'repo-1', path: '/Users/ada/repo' }],
+    projects: [{ id: 'repo-1', sourceRepoIds: ['repo-1'] }],
+    settings: {
+      agentDefaultArgs: { claude: '', codex: '' },
+      agentDefaultEnv: { claude: {}, codex: {} }
+    },
+    worktreesByRepo: {
+      'repo-1': [{ id: 'repo-1::worktree-1', repoId: 'repo-1', path: '/Users/ada/repo' }]
+    }
+  } as unknown as ResumableAgentState
+}
+
+const KIMI_SESSION = {
+  agent: 'kimi' as const,
+  sessionId: 'session_431324d7-2165-42f0-9ecd-9f93437b3201',
+  cwd: '/Users/ada/repo/packages/api',
+  codexHome: null
+}
+
+describe('AI Vault resume for Kimi', () => {
+  it('keeps the cd prefix on the copied resume line', () => {
+    // Why: Kimi sessions are work-dir-scoped — resuming from the worktree root instead of the
+    // session's own cwd fails with "created under a different directory".
+    expect(
+      buildAiVaultResumeCopyCommandForWorktree({
+        state: makeState(),
+        worktreeId: 'repo-1::worktree-1',
+        session: KIMI_SESSION
+      })
+    ).toBe(
+      "cd '/Users/ada/repo/packages/api' && kimi '--yolo' '--session' 'session_431324d7-2165-42f0-9ecd-9f93437b3201'"
+    )
+  })
+
+  it('takes the resumable-agent startup plan so the pane claims the provider session', () => {
+    // Why: the plan branch applies Kimi's default launch args, so a resumed pane starts with the
+    // same permission flag Orca gives a fresh one.
+    expect(
+      buildAiVaultResumeStartupForWorktree({
+        state: makeState(),
+        worktreeId: 'repo-1::worktree-1',
+        session: KIMI_SESSION
+      })
+    ).toMatchObject({
+      command: "kimi '--yolo' '--session' 'session_431324d7-2165-42f0-9ecd-9f93437b3201'",
+      cwd: '/Users/ada/repo/packages/api',
+      launchConfig: { agentCommand: "kimi '--yolo'" },
+      providerSession: {
+        key: 'session_id',
+        id: 'session_431324d7-2165-42f0-9ecd-9f93437b3201'
+      }
+    })
+  })
+})

--- a/src/renderer/src/runtime/agent-resume-host-authority-capability.test.ts
+++ b/src/renderer/src/runtime/agent-resume-host-authority-capability.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY,
+  AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
+  RUNTIME_CAPABILITIES
+} from '../../../shared/protocol-version'
+import { agentResumeHostAuthorityCapability } from './agent-resume-host-authority-capability'
+
+describe('agentResumeHostAuthorityCapability', () => {
+  it('gates Kimi resume behind its own capability', () => {
+    expect(agentResumeHostAuthorityCapability('kimi')).toBe(
+      AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY
+    )
+  })
+
+  it('keeps the OMP resume-path gate', () => {
+    expect(agentResumeHostAuthorityCapability('omp')).toBe(
+      AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY
+    )
+  })
+
+  it('leaves agents shipped with host authority on the generic probe', () => {
+    expect(agentResumeHostAuthorityCapability('codex')).toBeUndefined()
+    expect(agentResumeHostAuthorityCapability(null)).toBeUndefined()
+    expect(agentResumeHostAuthorityCapability(undefined)).toBeUndefined()
+  })
+
+  it('advertises the Kimi resume capability from the host', () => {
+    expect(RUNTIME_CAPABILITIES).toContain(AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY)
+  })
+})

--- a/src/renderer/src/runtime/agent-resume-host-authority-capability.test.ts
+++ b/src/renderer/src/runtime/agent-resume-host-authority-capability.test.ts
@@ -49,6 +49,7 @@ describe('agentResumeHostAuthorityCapability', () => {
       grok: undefined,
       devin: undefined,
       'prime-agent': undefined,
+      copilot: undefined,
       omp: AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
       kimi: AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY
     })

--- a/src/renderer/src/runtime/agent-resume-host-authority-capability.test.ts
+++ b/src/renderer/src/runtime/agent-resume-host-authority-capability.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { RESUMABLE_TUI_AGENTS } from '../../../shared/agent-session-resume'
 import {
   AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY,
   AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
@@ -27,5 +28,29 @@ describe('agentResumeHostAuthorityCapability', () => {
 
   it('advertises the Kimi resume capability from the host', () => {
     expect(RUNTIME_CAPABILITIES).toContain(AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY)
+  })
+
+  it('pins the gate for every resumable agent so a new member is a deliberate decision', () => {
+    // Why: silently defaulting a newly resumable agent to the generic probe is the exact skew
+    // failure this module exists to prevent — the mapping must be reviewed, not inherited.
+    expect(
+      Object.fromEntries(
+        RESUMABLE_TUI_AGENTS.map((agent) => [agent, agentResumeHostAuthorityCapability(agent)])
+      )
+    ).toEqual({
+      claude: undefined,
+      codex: undefined,
+      gemini: undefined,
+      antigravity: undefined,
+      opencode: undefined,
+      pi: undefined,
+      'mimo-code': undefined,
+      droid: undefined,
+      grok: undefined,
+      devin: undefined,
+      'prime-agent': undefined,
+      omp: AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
+      kimi: AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY
+    })
   })
 })

--- a/src/renderer/src/runtime/agent-resume-host-authority-capability.ts
+++ b/src/renderer/src/runtime/agent-resume-host-authority-capability.ts
@@ -1,3 +1,5 @@
+import type { ResumableTuiAgent } from '../../../shared/agent-session-resume'
+import type { TuiAgent } from '../../../shared/tui-agent'
 import {
   AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY,
   AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
@@ -8,14 +10,34 @@ import {
 // host's ensureAgentSession enum. An older host answers the unknown member with invalid_argument,
 // which runRemoteAgentSessionLaunch does not treat as a fallback signal, so the pane dies instead
 // of degrading to a legacy launch. Probing the agent's own capability keeps version skew safe.
+// The exhaustive Record makes the next RESUMABLE_TUI_AGENTS entry a compile error until its own
+// gate — or a deliberate `undefined` — is declared here.
+const RESUME_HOST_AUTHORITY_CAPABILITY_BY_AGENT = {
+  // These shipped inside agent-session.host-authority.v1's enum, so the generic probe covers them.
+  claude: undefined,
+  codex: undefined,
+  gemini: undefined,
+  antigravity: undefined,
+  opencode: undefined,
+  pi: undefined,
+  'mimo-code': undefined,
+  droid: undefined,
+  grok: undefined,
+  devin: undefined,
+  // Pre-existing gap: prime-agent joined the enum after host-authority.v1 and was never gated.
+  // Left as-is here so this change stays a Kimi fix; tracked for a follow-up.
+  'prime-agent': undefined,
+  omp: AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
+  kimi: AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY
+} satisfies Record<ResumableTuiAgent, RuntimeCapability | undefined>
+
 export function agentResumeHostAuthorityCapability(
-  agent: string | null | undefined
+  agent: TuiAgent | null | undefined
 ): RuntimeCapability | undefined {
-  if (agent === 'omp') {
-    return AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY
+  if (!agent) {
+    return undefined
   }
-  if (agent === 'kimi') {
-    return AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY
-  }
-  return undefined
+  return (
+    RESUME_HOST_AUTHORITY_CAPABILITY_BY_AGENT as Partial<Record<TuiAgent, RuntimeCapability>>
+  )[agent]
 }

--- a/src/renderer/src/runtime/agent-resume-host-authority-capability.ts
+++ b/src/renderer/src/runtime/agent-resume-host-authority-capability.ts
@@ -1,0 +1,21 @@
+import {
+  AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY,
+  AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
+  type RuntimeCapability
+} from '../../../shared/protocol-version'
+
+// Why: every agent added to RESUMABLE_TUI_AGENTS after agent-session.host-authority.v1 widens the
+// host's ensureAgentSession enum. An older host answers the unknown member with invalid_argument,
+// which runRemoteAgentSessionLaunch does not treat as a fallback signal, so the pane dies instead
+// of degrading to a legacy launch. Probing the agent's own capability keeps version skew safe.
+export function agentResumeHostAuthorityCapability(
+  agent: string | null | undefined
+): RuntimeCapability | undefined {
+  if (agent === 'omp') {
+    return AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY
+  }
+  if (agent === 'kimi') {
+    return AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY
+  }
+  return undefined
+}

--- a/src/renderer/src/runtime/agent-resume-host-authority-capability.ts
+++ b/src/renderer/src/runtime/agent-resume-host-authority-capability.ts
@@ -27,6 +27,8 @@ const RESUME_HOST_AUTHORITY_CAPABILITY_BY_AGENT = {
   // Ungated on purpose: prime-agent's host-side status hooks and its enum entry both shipped in
   // a1f61ef, so no host emits a prime-agent provider session without also accepting the member.
   'prime-agent': undefined,
+  // Ungated to match how main shipped copilot resume; gating it is its own change.
+  copilot: undefined,
   omp: AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
   kimi: AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY
 } satisfies Record<ResumableTuiAgent, RuntimeCapability | undefined>

--- a/src/renderer/src/runtime/agent-resume-host-authority-capability.ts
+++ b/src/renderer/src/runtime/agent-resume-host-authority-capability.ts
@@ -24,8 +24,8 @@ const RESUME_HOST_AUTHORITY_CAPABILITY_BY_AGENT = {
   droid: undefined,
   grok: undefined,
   devin: undefined,
-  // Pre-existing gap: prime-agent joined the enum after host-authority.v1 and was never gated.
-  // Left as-is here so this change stays a Kimi fix; tracked for a follow-up.
+  // Ungated on purpose: prime-agent's host-side status hooks and its enum entry both shipped in
+  // a1f61ef, so no host emits a prime-agent provider session without also accepting the member.
   'prime-agent': undefined,
   omp: AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
   kimi: AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY

--- a/src/renderer/src/runtime/remote-agent-session-launch.test.ts
+++ b/src/renderer/src/runtime/remote-agent-session-launch.test.ts
@@ -17,6 +17,7 @@ vi.mock('./runtime-rpc-client', () => ({
 
 import { RuntimeRpcCallError } from './runtime-rpc-client'
 import { runRemoteAgentSessionLaunch } from './remote-agent-session-launch'
+import { agentResumeHostAuthorityCapability } from './agent-resume-host-authority-capability'
 
 describe('remote agent-session launch routing', () => {
   beforeEach(() => {
@@ -42,6 +43,25 @@ describe('remote agent-session launch routing', () => {
     )
     expect(hostAuthority).toHaveBeenCalledOnce()
     expect(legacy).not.toHaveBeenCalled()
+  })
+
+  it('falls back to legacy when an older host lacks the Kimi resume capability', async () => {
+    const hostAuthority = vi.fn().mockResolvedValue('structured')
+    const legacy = vi.fn().mockResolvedValue('legacy')
+    mocks.supportsCapability.mockResolvedValue(false)
+
+    // Why: an old host rejects the widened agent enum with invalid_argument, which is not a
+    // fallback code — so the probe, not the error handler, has to keep the pane alive.
+    await expect(
+      runRemoteAgentSessionLaunch({
+        environmentId: 'env-1',
+        hostAuthority,
+        hostAuthorityCapability: agentResumeHostAuthorityCapability('kimi'),
+        legacy
+      })
+    ).resolves.toBe('legacy')
+    expect(mocks.supportsCapability).toHaveBeenCalledWith('env-1', 'agent-session.kimi-resume.v1')
+    expect(hostAuthority).not.toHaveBeenCalled()
   })
 
   it('preserves the exact legacy path when the capability is absent', async () => {

--- a/src/renderer/src/runtime/web-runtime-session-terminal-host-authority.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session-terminal-host-authority.test.ts
@@ -191,6 +191,76 @@ describe('createWebRuntimeSessionTerminal', () => {
     }
   )
 
+  it.each([
+    { gated: false, authority: false },
+    { gated: true, authority: true }
+  ])(
+    'routes a Kimi resume by capability (advertised=$gated) instead of the generic host-authority probe',
+    async ({ gated, authority }) => {
+      // Why: an old host answers the widened ensureAgentSession enum with invalid_argument, which
+      // runRemoteAgentSessionLaunch does not retry on — the per-agent probe is the only thing
+      // keeping a remote Kimi resume from dying instead of degrading to a legacy launch.
+      const runtimeCall = vi.fn(async (request: { method: string }) => {
+        if (request.method === 'status.get') {
+          return {
+            id: 'status',
+            ok: true,
+            result: {
+              runtimeId: 'runtime-1',
+              graphStatus: 'ready',
+              runtimeProtocolVersion: 3,
+              minCompatibleRuntimeClientVersion: 2,
+              capabilities: [
+                'agent-session.host-authority.v1',
+                ...(gated ? ['agent-session.kimi-resume.v1'] : [])
+              ]
+            }
+          }
+        }
+        if (request.method === 'terminal.ensureAgentSession') {
+          return {
+            id: 'ensure',
+            ok: true,
+            result: {
+              terminal: {
+                handle: 'term-kimi',
+                worktreeId: WORKTREE_ID,
+                tabId: 'host-tab-kimi',
+                paneKey: `host-tab-kimi:${FOCUS_LEAF_ID}`
+              },
+              disposition: 'created'
+            }
+          }
+        }
+        if (request.method === 'session.tabs.createTerminal') {
+          return {
+            id: 'legacy-create',
+            ok: true,
+            result: { tab: { id: 'host-tab-kimi', leafId: FOCUS_LEAF_ID } }
+          }
+        }
+        return { id: 'list', ok: true, result: makeSnapshot() }
+      })
+      vi.stubGlobal('window', {
+        api: { runtimeEnvironments: { call: runtimeCall } }
+      })
+
+      await expect(
+        createWebRuntimeSessionTerminal({
+          worktreeId: WORKTREE_ID,
+          agentSessionKind: 'resume',
+          launchAgent: 'kimi',
+          command: "kimi '--session' 'session_431324d7'",
+          providerSession: { key: 'session_id', id: 'session_431324d7' }
+        })
+      ).resolves.toEqual({ status: 'created' })
+
+      const methods = runtimeCall.mock.calls.map(([request]) => request.method)
+      expect(methods.includes('terminal.ensureAgentSession')).toBe(authority)
+      expect(methods.includes('session.tabs.createTerminal')).toBe(!authority)
+    }
+  )
+
   it('creates paired web agents through host authority so activation is mirrored', async () => {
     const snapshot = {
       ...makeSnapshot(),

--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -19,10 +19,8 @@ import type {
   SleepingAgentLaunchConfig,
   AgentProviderSessionMetadata
 } from '../../../shared/agent-session-resume'
-import {
-  AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
-  BROWSER_TAB_CREATE_KNOWN_ID_RUNTIME_CAPABILITY
-} from '../../../shared/protocol-version'
+import { BROWSER_TAB_CREATE_KNOWN_ID_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
+import { agentResumeHostAuthorityCapability } from './agent-resume-host-authority-capability'
 import type {
   AgentLaunchPreferences,
   AgentPromptDelivery,
@@ -337,13 +335,15 @@ async function createWebRuntimeSessionTerminalResult(
                   })) as RuntimeRpcResponse<RuntimeCreateAgentSessionResult>
                 )
               )
+      const resumeHostAuthorityCapability =
+        args.agentSessionKind === 'resume' ? agentResumeHostAuthorityCapability(agent) : undefined
       const created = await runRemoteAgentSessionLaunch<{
         terminal: CreatedAgentTerminalIdentity
       }>({
         environmentId,
         ...(hostAuthority ? { hostAuthority } : {}),
-        ...(args.agentSessionKind === 'resume' && agent === 'omp'
-          ? { hostAuthorityCapability: AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY }
+        ...(resumeHostAuthorityCapability
+          ? { hostAuthorityCapability: resumeHostAuthorityCapability }
           : {}),
         legacy: async () => {
           const response = await callEnvironment({

--- a/src/renderer/src/store/slices/agent-status-quit-capture-resumable-agents.test.ts
+++ b/src/renderer/src/store/slices/agent-status-quit-capture-resumable-agents.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import type { AppState } from '../types'
+import { createTestStore, makeTab } from './store-test-helpers'
+
+describe('quit-time capture for newly resumable agents', () => {
+  it('checkpoints a live Kimi provider session before quit-time capture', () => {
+    const store = createTestStore()
+    store.setState({
+      tabsByWorktree: {
+        'wt-1': [makeTab({ id: 'tab-1', worktreeId: 'wt-1' })]
+      }
+    } as Partial<AppState>)
+
+    store.getState().setAgentStatus(
+      'tab-1:leaf-1',
+      {
+        state: 'working',
+        prompt: 'finish the task',
+        agentType: 'kimi'
+      },
+      'Kimi',
+      { updatedAt: 10, stateStartedAt: 10 },
+      { tabId: 'tab-1', worktreeId: 'wt-1' },
+      {
+        providerSession: {
+          key: 'session_id',
+          id: 'session_431324d7-2165-42f0-9ecd-9f93437b3201'
+        }
+      }
+    )
+
+    // Why: this is the #15155 regression — without kimi in RESUMABLE_TUI_AGENTS no sleeping
+    // record is ever captured, so restart drops the session instead of resuming it.
+    expect(store.getState().sleepingAgentSessionsByPaneKey['tab-1:leaf-1']).toMatchObject({
+      agent: 'kimi',
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      providerSession: { key: 'session_id', id: 'session_431324d7-2165-42f0-9ecd-9f93437b3201' },
+      origin: 'live'
+    })
+  })
+})

--- a/src/shared/agent-session-resume.test.ts
+++ b/src/shared/agent-session-resume.test.ts
@@ -24,6 +24,10 @@ describe('agent session resume metadata', () => {
     expect(isResumableTuiAgent('copilot')).toBe(true)
   })
 
+  it('treats Kimi Code as a resumable TUI agent', () => {
+    expect(isResumableTuiAgent('kimi')).toBe(true)
+  })
+
   it.each([
     ['claude', { session_id: 'claude-session' }, { key: 'session_id', id: 'claude-session' }],
     ['codex', { session_id: 'codex-session' }, { key: 'session_id', id: 'codex-session' }],
@@ -54,7 +58,12 @@ describe('agent session resume metadata', () => {
       { session_id: '940237d9-c712-48e8-bca1-fd75fc4a8d4b' },
       { key: 'session_id', id: '940237d9-c712-48e8-bca1-fd75fc4a8d4b' }
     ],
-    ['copilot', { sessionId: 'copilot-camel' }, { key: 'session_id', id: 'copilot-camel' }]
+    ['copilot', { sessionId: 'copilot-camel' }, { key: 'session_id', id: 'copilot-camel' }],
+    [
+      'kimi',
+      { session_id: 'session_431324d7-2165-42f0-9ecd-9f93437b3201' },
+      { key: 'session_id', id: 'session_431324d7-2165-42f0-9ecd-9f93437b3201' }
+    ]
   ] as const)('extracts %s provider session ids', (source, payload, expected) => {
     expect(extractAgentProviderSession(source, payload)).toEqual(expected)
   })
@@ -80,7 +89,12 @@ describe('agent session resume metadata', () => {
       { key: 'session_id', id: 's1', transcriptPath: '/tmp/prime-session.jsonl' },
       ['prime-agent', '--resume', '/tmp/prime-session.jsonl']
     ],
-    ['copilot', { key: 'session_id', id: 's1' }, ['copilot', '--resume=s1']]
+    ['copilot', { key: 'session_id', id: 's1' }, ['copilot', '--resume=s1']],
+    [
+      'kimi',
+      { key: 'session_id', id: 'session_431324d7' },
+      ['kimi', '--session', 'session_431324d7']
+    ]
   ] as const)('builds %s resume argv', (agent, providerSession, expected) => {
     expect(getAgentResumeArgv(agent, providerSession)).toEqual(expected)
   })

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -15,7 +15,8 @@ export const RESUMABLE_TUI_AGENTS = [
   'devin',
   'omp',
   'prime-agent',
-  'copilot'
+  'copilot',
+  'kimi'
 ] as const satisfies readonly TuiAgent[]
 
 export type ResumableTuiAgent = (typeof RESUMABLE_TUI_AGENTS)[number]
@@ -287,5 +288,9 @@ export function getAgentResumeArgv(
     // resume commands, so local and remote resumes agree on one spelling.
     case 'copilot':
       return providerSession.key === 'session_id' ? ['copilot', `--resume=${id}`] : null
+    // Why: Kimi sessions are work-dir-scoped, so this only resumes from the pane's
+    // own cwd — which is where restore relaunches it.
+    case 'kimi':
+      return providerSession.key === 'session_id' ? ['kimi', '--session', id] : null
   }
 }

--- a/src/shared/agent-session-resume.ts
+++ b/src/shared/agent-session-resume.ts
@@ -288,8 +288,7 @@ export function getAgentResumeArgv(
     // resume commands, so local and remote resumes agree on one spelling.
     case 'copilot':
       return providerSession.key === 'session_id' ? ['copilot', `--resume=${id}`] : null
-    // Why: Kimi sessions are work-dir-scoped, so this only resumes from the pane's
-    // own cwd — which is where restore relaunches it.
+    // Why: Kimi resumes by id with --session; sessions are work-dir-scoped (enforced by callers).
     case 'kimi':
       return providerSession.key === 'session_id' ? ['kimi', '--session', id] : null
   }

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -101,6 +101,10 @@ export const AGENT_SESSION_HOST_AUTHORITY_RUNTIME_CAPABILITY =
   'agent-session.host-authority.v1' as const
 export const AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY =
   'agent-session.omp-resume-path.v1' as const
+// Why: adding kimi to RESUMABLE_TUI_AGENTS grows terminal.ensureAgentSession's enum, and an
+// older host answers the unknown member with invalid_argument — a code the launch fallback does
+// not retry on — so clients must probe before taking the host-authority path.
+export const AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY = 'agent-session.kimi-resume.v1' as const
 // Why: older runtimes strip mutation owner fields, so clients must fence writes before RPC.
 export const FILE_MUTATION_OWNERSHIP_RUNTIME_CAPABILITY = 'files.mutation-ownership.v1' as const
 export const FILE_MUTATION_OWNERSHIP_UPDATE_REQUIRED_MESSAGE =
@@ -144,6 +148,7 @@ export const RUNTIME_CAPABILITIES = [
   REMOTE_SERVER_UPDATE_CAPABILITY,
   AGENT_SESSION_HOST_AUTHORITY_RUNTIME_CAPABILITY,
   AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
+  AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY,
   FILE_MUTATION_OWNERSHIP_RUNTIME_CAPABILITY,
   WORKTREE_VISIBILITY_DEFAULTS_RUNTIME_CAPABILITY,
   WORKTREE_VISIBILITY_SOURCE_DEFAULTS_RUNTIME_CAPABILITY,

--- a/src/shared/workspace-session-schema.sleeping-agent.test.ts
+++ b/src/shared/workspace-session-schema.sleeping-agent.test.ts
@@ -41,6 +41,42 @@ describe('parseWorkspaceSession sleeping agents', () => {
     }
   })
 
+  it('hydrates a persisted Kimi sleeping agent record', () => {
+    const result = parseWorkspaceSession({
+      activeRepoId: null,
+      activeWorktreeId: null,
+      activeTabId: null,
+      tabsByWorktree: {},
+      terminalLayoutsByTabId: {},
+      sleepingAgentSessionsByPaneKey: {
+        'tab1:pane-1': {
+          paneKey: 'tab1:pane-1',
+          tabId: 'tab1',
+          worktreeId: 'wt',
+          agent: 'kimi',
+          providerSession: {
+            key: 'session_id',
+            id: 'session_431324d7-2165-42f0-9ecd-9f93437b3201'
+          },
+          prompt: 'continue',
+          state: 'working',
+          capturedAt: 10,
+          updatedAt: 9,
+          terminalTitle: 'Kimi',
+          origin: 'live'
+        }
+      }
+    })
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      // Why: the record must survive the resumable-agent refine, or restore silently drops it.
+      expect(result.value.sleepingAgentSessionsByPaneKey?.['tab1:pane-1']).toMatchObject({
+        agent: 'kimi',
+        providerSession: { key: 'session_id', id: 'session_431324d7-2165-42f0-9ecd-9f93437b3201' }
+      })
+    }
+  })
+
   it('preserves the authoritative Pi session file through hydration', () => {
     const result = parseWorkspaceSession({
       activeRepoId: null,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​426 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​424 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​68 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​55 |

<!-- /orca-pr-loc -->

Supersedes #15157 by @mberatsanli — carried over so it can run full CI (fork PRs only run `track-community-pr` in this repo). Original authorship is preserved in the commit (`ab065ad` is authored by Melih <mberatsanli@gmail.com>).

## ELI5

If you had a Kimi Code pane open and quit Orca, Kimi was gone when you came back — you got a brand new, empty session instead of the conversation you were in the middle of. Orca keeps a list of agents it knows how to "wake up" after a restart, and Kimi simply wasn't on that list, so Orca never bothered to write down the session id before shutting down. This puts Kimi on the list and teaches Orca the command to reattach (`kimi --session <id>`), the same way it already does for Claude, Codex, OMP and friends. It also makes sure a newer Orca client talking to an older remote Orca server falls back to a fresh pane instead of showing a dead one.

## What Changed

- `src/shared/agent-session-resume.ts` — `kimi` added to `RESUMABLE_TUI_AGENTS`, and `getAgentResumeArgv` now returns `['kimi', '--session', id]` for a `session_id` provider session. (Contributor's commit, unmodified apart from trimming a two-line comment to one.)
- `src/shared/protocol-version.ts` — new `AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY = 'agent-session.kimi-resume.v1'`, added to `RUNTIME_CAPABILITIES`. `RUNTIME_PROTOCOL_VERSION` is deliberately **not** bumped — an added capability is not an envelope change.
- `src/renderer/src/runtime/agent-resume-host-authority-capability.ts` (new) — one place that maps a resume agent to the capability its host-authority launch needs. Replaces the duplicated `agent === 'omp'` ternary at both call sites.
- `remote-runtime-pty-transport.ts` / `web-runtime-session.ts` — both host-authority resume launches now go through that resolver.
- Tests: quit-time capture, persisted-record hydration, the wire gate at **both call sites**, and the AI Vault resume path (desktop + mobile).

## Why

Three gates all have to agree before a sleeping agent record is captured on quit and hydrated on restore:

1. `extractAgentProviderSession()` must recognize the agent's provider session — this **already** worked for `kimi` (`agent-session-resume.ts:199`, sharing the `session_id` branch with gemini/droid).
2. `sleepingRecordFromEntry()` (`agent-status.ts:601-605`) requires `isResumableTuiAgent(agent)`.
3. The persisted-state refine in `workspace-session-sleeping-agents.ts:106` requires the same.

`kimi` was missing from `RESUMABLE_TUI_AGENTS`, so gates 2 and 3 always failed: no record was ever written at quit, and nothing was there to hydrate at restore. Root cause, not a symptom. `--session` matches the spelling the repo already uses for Kimi in `buildAgentResumeInvocation` (`ai-vault-resume-command.ts:205-210`).

**The maintainer-side addition (the capability gate).** Growing `RESUMABLE_TUI_AGENTS` also grows the wire enum `z.enum(RESUMABLE_TUI_AGENTS)` behind `terminal.ensureAgentSession` (`src/main/runtime/rpc/methods/agent-session.ts:130`). Per `docs/reference/remote-wire-compatibility.md`, mixed client/host versions are the normal state. Without a gate: an updated client paired to a remote host that predates this PR captures a remote Kimi pane on quit, sends `{kind:'explicit', agent:'kimi'}` on restart, and the old host's zod enum rejects it. `dispatcher.ts:294-298` answers with `invalidArgumentResponse` — which is neither `agent_session_legacy_required` nor `method_not_found`, the only two codes `remote-agent-session-launch.ts:37-44` falls back on. The error propagates to `surfaceErrorMessage()` and the pane never attaches: strictly worse than the fresh session users get today. Probing `agent-session.kimi-resume.v1` before taking the host-authority path makes an old host fall through to the legacy `terminal.create`, which is exactly the OMP precedent (`e3adb209172`).

## Linked Issue

Fixes #15155

## Visual Proof

`N/A` — no rendered UI changes. This is session-restore plumbing (which argv Orca spawns on restore, and which RPC path the client picks). The user-visible effect is that a Kimi pane comes back with its conversation instead of empty; there is nothing new to render or lay out.

## Testing

All commands run on **macOS only**. Linux/Windows are covered by reasoning, not execution (see Review).

```
npx vitest run --config config/vitest.config.ts \
  src/shared/agent-session-resume.test.ts \
  src/shared/workspace-session-schema.sleeping-agent.test.ts \
  src/renderer/src/store/slices/agent-status-quit-capture-resumable-agents.test.ts \
  src/renderer/src/store/slices/agent-status-quit-capture.test.ts \
  src/renderer/src/runtime/remote-agent-session-launch.test.ts \
  src/renderer/src/runtime/agent-resume-host-authority-capability.test.ts \
  src/renderer/src/lib/ai-vault-resume-command.resumable-agent.test.ts \
  src/renderer/src/lib/ai-vault-resume-command.test.ts \
  src/main/runtime/rpc/methods/agent-session.test.ts
→ 9 files passed, 147 tests passed
```

Transport/runtime regression sweep around the two refactored call sites:

```
npx vitest run --config config/vitest.config.ts \
  src/renderer/src/runtime/web-runtime-session-terminal-host-authority.test.ts \
  src/renderer/src/runtime/web-runtime-session-terminal-legacy-create.test.ts \
  src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-host-session-launch.test.ts \
  src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-create-handoff.test.ts \
  src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-create-outcome-recovery.test.ts
→ 5 files passed, 40 tests passed
```

Lint (changed files only):

```
npx oxlint <11 changed files>                                                          → clean
npx oxlint --config config/oxlint-code-quality-native-plugins.json ... --deny-warnings → clean
```

**Regression proof.** With `'kimi'` temporarily removed from `RESUMABLE_TUI_AGENTS` and everything else in place, 5 tests fail:

```
× agent-session-resume.test.ts                       › treats Kimi Code as a resumable TUI agent
× workspace-session-schema.sleeping-agent.test.ts    › hydrates a persisted Kimi sleeping agent record
× ai-vault-resume-command.resumable-agent.test.ts    › keeps the cd prefix on the copied resume line
× ai-vault-resume-command.resumable-agent.test.ts    › takes the resumable-agent startup plan …
× agent-status-quit-capture-resumable-agents.test.ts › checkpoints a live Kimi provider session before quit-time capture
Test Files 4 failed | Tests 5 failed | 75 passed
```

Restoring the line returns all to green. The quit-capture one is the direct reproduction of #15155.

**Call-site regression proof (the wire gate).** The capability resolver alone was only covered in isolation, so reverting either call site to the old `agent === 'omp'` predicate left the suite green. Two call-site tests now close that:

- `remote-runtime-pty-transport-host-session-launch.test.ts` — a Kimi resume against a host advertising only `agent-session.host-authority.v1` must use legacy `terminal.create`; the same resume against a host that also advertises `agent-session.kimi-resume.v1` must use `terminal.ensureAgentSession`.
- `web-runtime-session-terminal-host-authority.test.ts` — same two cases across `session.tabs.createTerminal` vs `terminal.ensureAgentSession`.

Verified by reverting each product line in turn:

```
# remote-runtime-pty-transport.ts back to `launchAgentToSend === 'omp'`
→ 1 failed | 9 passed  (degrades a Kimi resume to a legacy launch …)
# web-runtime-session.ts back to `agent === 'omp'`
→ 1 failed | 12 passed (routes a Kimi resume by capability (advertised=false) …)
```

Restoring both returns green.

**Exhaustiveness proof.** `RESUME_HOST_AUTHORITY_CAPABILITY_BY_AGENT` is now `satisfies Record<ResumableTuiAgent, RuntimeCapability | undefined>`, so appending a member to `RESUMABLE_TUI_AGENTS` without declaring its gate is a compile error rather than a silent ungated launch. Confirmed by temporarily appending `'aider'`:

```
error TS2741: Property 'aider' is missing in type '{ claude: undefined; … }'
  but required in type 'Record<"aider" | … | "prime-agent", RuntimeCapability | undefined>'.
```

A companion test iterates `RESUMABLE_TUI_AGENTS` and pins the expected gate per member.

**Not run locally:** `mobile/src/session/ai-vault-resume-launch.test.ts` — mobile deps (`expo`) are not installed in this workspace, so `mobile/vitest.config.ts` cannot resolve `expo/tsconfig.base.json`. The added mobile case mirrors the desktop one; I verified the exact expected string by first exercising the shared `buildAgentResumeStartupPlan` + `buildAiVaultResumeShellCommand` builders under the desktop config. CI runs the mobile suite.

**Manual check still owed (the CLI was exercised standalone — see below — but no authenticated Kimi account is available here for a full round trip):** open a Kimi pane, converse, quit Orca, reopen — the pane should relaunch as `kimi '--yolo' '--session' '<id>'` and reattach. Also worth exercising the documented negative: a Kimi session started in a *subdirectory* of the worktree resumes only from that same cwd, otherwise Kimi errors with "Session … was created under a different directory". Same class as `claude --resume` against an unknown id, so it should not block.


**Upstream verification of the resume flag (the load-bearing claim).** Executed against the *published* artifact, not just the repo, so it reflects what lands on a user's PATH:

```
$ npm pack @moonshot-ai/kimi-code@0.38.0     # package.json bin: { "kimi": "dist/main.mjs" }
$ node package/dist/main.mjs --help
Usage: kimi [options] [command]
Options:
  -S, --session [id]            Resume a session. With ID: resume that session. Without ID:
                                interactively pick.
  -c, --continue                Continue the previous session for the working directory.
  -y, --yolo                    Auto-approve regular tool calls; ...

$ node package/dist/main.mjs --session session_00000000-0000-4000-8000-000000000000 -p hi
kimi version 0.38.0
error: failed to run prompt: Session "session_00000000-0000-4000-8000-000000000000" not found.
```

The second run is the important one: `--session` is *parsed* (not an unknown-flag error), it is resolved *by id*, and a `session_<uuid>` string is a well-formed selector. `-r/--resume [id]` exists as a hidden alias (`apps/kimi-code/src/cli/commands.ts:46`), so `--session` is the canonical spelling to emit. The id shape matches what Orca captures: `packages/agent-core-v2/src/workspace/sessionLifecycle/sessionLifecycleService.ts:748` mints `` `session_${randomUUID()}` ``, and the external-hook envelope snake-cases `sessionId` → `session_id` (`features/externalHooks/internal/matchHooks.ts:62,124-134`) — exactly the key `extractAgentProviderSession` reads for `kimi`. The cwd-scoped caveat above is upstream's own error string (`apps/kimi-code/src/cli/run-prompt.ts:311`, `src/tui/kimi-tui.ts:888`), not a guess.

- [x] Automated tests added/updated
- [ ] I manually tested these changes locally (the real `kimi` CLI was run standalone to verify the `--session` contract; the full quit/restore round trip needs an authenticated Kimi account, which is not available here)

## Review

**Malicious-code scan of the contributor diff:** I read the full patch (2 files, +20/-1, single commit `7e34657a`). No network sinks, no `exec`/`eval`/`child_process`/dynamic import, no `process.env` reads, no credential or token handling, no `package.json`/lockfile/`config/` edits, no postinstall hooks, no new dependencies, no obfuscation, nothing under build/updater/signing paths, and no edits to `AGENTS.md`/`CLAUDE.md`/docs/skills that a later agent would read as instructions. The only added runtime code returns a static `['kimi','--session', id]` that flows through the same `buildAgentResumeLaunchCommand` + `quoteStartupArg` every other agent uses, and `id` is already sanitized upstream by `normalizeSessionId` (rejects control chars, >512 bytes, leading `-`). **Clean.**

- **Cross-platform:** no new path handling and no keyboard/accelerator code. Quoting goes through `quoteStartupArg` with the tab's effective shell, so PowerShell / cmd / Git Bash / POSIX all keep their existing quoting. The Kimi session id is `[A-Za-z0-9_-]` only and introduces no path separators. macOS/Linux/Windows behave identically; only macOS was executed.
- **SSH / remote:** this is the substantive maintainer addition, described above. The execution host still owns the launch; the client only decides *which* RPC shape it may send, and it now proves the host understands it before sending. An old host degrades to a fresh Kimi pane (today's behavior) rather than a dead one.
- **Agent / integration compatibility:** I traced every consumer of the two changed symbols — `pty-connection.ts:5104`, `agent-hibernation-planner.ts:162`, `agent-status.ts:601/744/1982/2283`, `agent-session-claim-identity.ts:60`, `agent-resume-argv-drop.ts:49`, `tui-agent-startup.ts:202`, the host-authority `isAgentSessionExecutionClaim`, and both `z.enum(RESUMABLE_TUI_AGENTS)` schemas. No exhaustive map keyed on `ResumableTuiAgent` goes stale, and `dropAgentResumeArgvFromCommand` strips `--session <id>` correctly. **Persisted-state downgrade:** an older build reading a workspace session containing a `kimi` record drops only that entry via `salvagingRecord` (`zod-salvage.ts:82-96`) — the workspace session is not corrupted. Mobile does not call `ensureAgentSession` (it goes through `terminal.create` + `launchConfig`), so no mobile wire gate is needed.
- **Performance:** none. No hot path, no polling, no unbounded growth; one array entry, one switch case, and two string comparisons on a launch that already does an RPC round trip.
- **UI quality:** N/A — no renderer components, styles, tokens, or layout touched.
- **Security:** no new injection surface (argv is static plus an already-sanitized id, quoted by the existing shell quoter). No secrets, no env reads, no filesystem writes, no new IPC/RPC method. The capability string is additive and does not weaken any existing check.
- **Behavior shift worth a reviewer's eye:** making `isResumableTuiAgent('kimi')` true reroutes the manual **AI Vault** resume for Kimi from the `buildAiVaultResumeCommand` fallback into the `buildAgentResumeStartupPlan` branch. Practical consequences: (a) the resumed line now carries Kimi's default launch args, so it reads `kimi '--yolo' '--session' '<id>'` rather than `kimi --session '<id>'` — i.e. a resumed pane gets the same permission flag Orca gives a fresh Kimi pane, which I believe is correct; (b) the spawned pane now registers a provider-session claim. The author flagged this in the original PR and shipped no test for it; `ai-vault-resume-command.resumable-agent.test.ts` and the mobile case now pin both the `cd '<cwd>' &&` prefix (Kimi is work-dir-scoped) and the returned `launchConfig` + `providerSession`.
- **Pre-existing hole, deliberately NOT fixed here:** `buildAgentResumeLaunchCommand` (`agent-resume-launch-command.ts:59-71`) runs its stale-selector strip only for `claude`; every other agent plain-appends. Kimi joins `opencode`/`mimo-code`/`droid` in that bucket, so a user with an `agentCmdOverrides.kimi` that already carries a selector (e.g. `kimi -r <old-id>`) would get `kimi -r <old-id> --session <new-id>` and the CLI decides which wins. This predates the PR and is identical for the other `--session` agents; fixing it belongs in a separate change that generalizes the guard rather than adding a kimi-specific branch.

## Known limitations / follow-ups

- **`prime-agent` is ungated, and that is correct — verified, not assumed.** `prime-agent` did join `RESUMABLE_TUI_AGENTS` after `agent-session.host-authority.v1` (`a1f61ef`, 2026-08-09 vs `b232df7`, 2026-07-21), which looks like the same wire-skew hole. It is not, because the host-side plumbing that *produces* a `prime-agent` provider session shipped in the **same commit**: `git log -S"prime-agent" -- src/relay/plugin-overlay.ts src/shared/pi-agent-kind.ts src/shared/agent-hook-relay.ts` returns only `a1f61ef`, and the AI Vault source (`session-scanner-agent-sources.ts`) came a day later in `63af0bd`. A host older than `a1f61ef` therefore never emits a `prime-agent` `session_id`/`session_file`, so no sleeping record exists for a newer client to replay into that host's narrower `z.enum`. Kimi is different: its host-side hooks shipped `4eb3e75` (2026-06-19), a month *before* host-authority.v1, so every host built between then and this PR emits Kimi provider sessions while rejecting `agent:'kimi'` — a real, wide skew window. The only residual `prime-agent` exposure is a host **downgrade** below `a1f61ef` after a record was already persisted client-side; that is not worth a wire capability. Upstream side is real either way: `PrimeIntellect-ai/prime-agent` has `-r, --resume [path|id]` in `packages/coding-agent/src/cli/args.ts` in every tag from `v0.3.2` to `v0.8.0`, and Orca passes the session file path, which upstream accepts.
- **Cwd-scoped resume on cold restore.** Kimi (like `opencode`/`pi`) is work-dir-scoped. Cold restore relaunches in the pane's own cwd, which is the session's cwd in the normal case; a pane whose cwd moved after the session was created will get Kimi's "created under a different directory" error rather than a resumed conversation. Same behavior as the other `--session` agents, so no kimi-specific handling was added.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

Git binary compatibility and git-provider neutrality (GitHub/GitLab) are not implicated — no git or forge code is touched. Folder workspaces are unaffected: cold restore launches in the pane's own cwd whether the workspace is a git worktree or a plain folder.

Merge-queue note: #15157 and the author's sibling PR family (#15150/#15154) both edit the `RESUMABLE_TUI_AGENTS` array and the same test tables in `agent-session-resume.test.ts`, so whichever lands second needs a trivial textual rebase.

## Rebase note (2026-08-22)

Rebased onto `main` after `copilot` resume landed upstream. Three conflicts, all in `src/shared/agent-session-resume.ts` / its test:

- **`RESUMABLE_TUI_AGENTS`** — main appended `'copilot'`, this PR appended `'kimi'`. Kept both (`…, 'prime-agent', 'copilot', 'kimi'`); neither side reorders the other.
- **`getAgentResumeArgv` switch** — main added the `copilot` case, this PR added the `kimi` case at the same spot. Kept both cases.
- **`agent-session-resume.test.ts` tables** — same additive shape; kept both sides' rows.

One adjustment worth flagging: `RESUME_HOST_AUTHORITY_CAPABILITY_BY_AGENT` is `satisfies Record<ResumableTuiAgent, …>`, so main's new `copilot` member made the map non-exhaustive and the branch stopped type-checking. Added `copilot: undefined` (plus the matching row in the exhaustive test). **Ungated on purpose** — main shipped copilot's host-authority resume with no capability probe, and `copilot: undefined` reproduces that exactly. Whether copilot needs its own gate is a real question but a separate change; this PR does not silently alter behavior main just shipped. That compile error is the guard doing its job (verified: removing the entry reproduces `TS2741`).

CI on the rebased head: **50 success / 1 skipped / 0 failures**, `mergeStateStatus: CLEAN`. `e2e / ssh docker watcher isolation` failed once on attempt 1 in `paired-startup-exec-readiness.spec.ts` with `runtime_error: terminal_liveness_unavailable`; it passed on re-run. That spec never enters a resume path (no `kimi`, `agentSessionKind`, or `hostAuthorityCapability` reference in it or its oracle), and this PR's transport change is a no-op for every non-Kimi agent, so the failure was infrastructure flake rather than a regression.

Nothing was dropped — main did not restructure either host-authority call site, so both `hostAuthorityCapability` hunks (`web-runtime-session.ts`, `remote-runtime-pty-transport.ts`) are still live.

Verified after rebase: targeted vitest across `src/shared/agent-session*`, `src/renderer/src/runtime/`, `src/renderer/src/components/terminal-pane/`, `src/renderer/src/store/slices/agent-status*`, `src/renderer/src/lib/ai-vault-resume-command*`, and `src/main/runtime/rpc/methods/agent-session*` — all green; `npx oxlint` and `npx oxfmt --check` clean on every changed file. The mobile test (`mobile/src/session/ai-vault-resume-launch.test.ts`) could not run locally — `mobile/node_modules` is not installed in this checkout — so it is left to CI.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass locally (targeted vitest + oxlint run locally; full suites left to CI)






