### PR TITLE
fix(terminal): drop conda's orphaned CONDA_SHLVL sentinel

### DIFF
--- a/src/main/daemon/pty-subprocess-env-inheritance.test.ts
+++ b/src/main/daemon/pty-subprocess-env-inheritance.test.ts
@@ -312,6 +312,41 @@ describe('createPtySubprocess', () => {
     expect(env.ELECTRON_RUN_AS_NODE).toBeUndefined()
   })
 
+  it('does not forward a half-activated conda env from the daemon process env', async () => {
+    // Why here as well as the main process: the daemon fork composes its own
+    // inherited env, which main never sees, so it is the default terminal's
+    // only chance to drop a CONDA_SHLVL sentinel left without a prefix (#14195).
+    const proc = mockPtyProcess()
+    spawnMock.mockReturnValue(proc)
+    const saved = {
+      CONDA_SHLVL: process.env.CONDA_SHLVL,
+      CONDA_PREFIX: process.env.CONDA_PREFIX,
+      CONDA_DEFAULT_ENV: process.env.CONDA_DEFAULT_ENV,
+      CONDA_EXE: process.env.CONDA_EXE
+    }
+    delete process.env.CONDA_PREFIX
+    process.env.CONDA_SHLVL = '1'
+    process.env.CONDA_DEFAULT_ENV = 'base'
+    process.env.CONDA_EXE = '/opt/miniconda3/bin/conda'
+
+    try {
+      await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+    } finally {
+      for (const [key, value] of Object.entries(saved)) {
+        if (value === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = value
+        }
+      }
+    }
+
+    const env = spawnMock.mock.calls.at(-1)?.[2].env
+    expect(env.CONDA_SHLVL).toBeUndefined()
+    expect(env.CONDA_DEFAULT_ENV).toBeUndefined()
+    expect(env.CONDA_EXE).toBe('/opt/miniconda3/bin/conda')
+  })
+
   it('does not inherit legacy attribution state from a pre-upgrade daemon', async () => {
     const proc = mockPtyProcess()
     spawnMock.mockReturnValue(proc)

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -43,6 +43,7 @@ import { dropInheritedOrcaHistFile } from '../worktree-history-file-path'
 import { removeAppImageRuntimeEnv } from '../pty/appimage-terminal-env'
 import { stripInheritedBuildModeEnv } from '../pty/build-mode-env'
 import { stripLegacyTerminalShimEnv } from '../pty/legacy-terminal-shim-dir'
+import { dropIncoherentCondaActivationEnv } from '../pty/conda-activation-env'
 import { resolvePathEnvKey } from '../pty/windows-environment-path'
 import { parseWslPath } from '../wsl'
 import { addWslEnvKeys } from '../wsl-env'
@@ -902,6 +903,8 @@ export async function createPtySubprocess(opts: PtySubprocessOptions): Promise<S
   promoteAgentTeamsShimPath(env, requestedPath)
   // Why: raw requested PATH promotion runs after the inherited-env scrub.
   stripLegacyTerminalShimEnv(env, process.platform)
+  // Why after every deletion pass: an envToDelete of CONDA_PREFIX must not leave the sentinel behind.
+  dropIncoherentCondaActivationEnv(env, process.platform)
 
   // Why: asar packaging can strip +x from node-pty's spawn-helper; the daemon is a separate forked process from the main-process fix.
   ensureNodePtySpawnHelperExecutable()

--- a/src/main/hooks.test.ts
+++ b/src/main/hooks.test.ts
@@ -87,6 +87,49 @@ describe('runHook', () => {
     }
   })
 
+  it('does not run setup scripts with a half-activated conda env', async () => {
+    // Why: setup scripts source conda exactly like a shell rc does, so the
+    // orphaned CONDA_SHLVL sentinel surfaces as an opaque hook failure (#14195).
+    let capturedEnv: Record<string, string> | undefined
+    execMock.mockImplementation((_script, options, callback) => {
+      capturedEnv = (options as { env: Record<string, string> }).env
+      callback?.(null, '', '')
+      return {} as never
+    })
+
+    const fs = await import('node:fs')
+    vi.mocked(fs.existsSync).mockReturnValue(true)
+    vi.mocked(fs.readFileSync).mockReturnValue('scripts:\n  setup: |\n    echo hello\n')
+
+    const saved = {
+      CONDA_SHLVL: process.env.CONDA_SHLVL,
+      CONDA_PREFIX: process.env.CONDA_PREFIX,
+      CONDA_DEFAULT_ENV: process.env.CONDA_DEFAULT_ENV,
+      CONDA_EXE: process.env.CONDA_EXE
+    }
+    delete process.env.CONDA_PREFIX
+    process.env.CONDA_SHLVL = '1'
+    process.env.CONDA_DEFAULT_ENV = 'base'
+    process.env.CONDA_EXE = '/opt/miniconda3/bin/conda'
+
+    try {
+      const { runHook } = await import('./hooks')
+      await runHook('setup', '/repo/worktree', makeRepo())
+    } finally {
+      for (const [key, value] of Object.entries(saved)) {
+        if (value === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = value
+        }
+      }
+    }
+
+    expect(capturedEnv?.CONDA_SHLVL).toBeUndefined()
+    expect(capturedEnv?.CONDA_DEFAULT_ENV).toBeUndefined()
+    expect(capturedEnv?.CONDA_EXE).toBe('/opt/miniconda3/bin/conda')
+  })
+
   it('keeps bash as the hook shell on non-Windows platforms', async () => {
     execMock.mockImplementation((_script, _options, callback) => {
       callback?.(null, '', '')

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -8,6 +8,7 @@ import { getHookRuntimeTarget, getHookWslContext } from './hook-runtime-target'
 import { getSetupEnvVars } from './setup-hook-env-vars'
 import { iterateLfScriptLines } from './setup-runner-script-text'
 import { promptGuardShellEnv } from './git/runner'
+import { dropIncoherentCondaActivationEnv } from './pty/conda-activation-env'
 import { toLinuxPath } from './wsl'
 import { runWslProcess } from './wsl/wsl-runner'
 import type { HookRuntimeTarget } from './hook-runtime-target'
@@ -186,6 +187,9 @@ export function runHook(
       })
   }
 
+  const shellHookEnv: NodeJS.ProcessEnv = { ...process.env, ...getSetupEnvVars(repo, cwd) }
+  dropIncoherentCondaActivationEnv(shellHookEnv)
+
   return new Promise((resolve) => {
     exec(
       script,
@@ -194,10 +198,7 @@ export function runHook(
         timeout: HOOK_TIMEOUT,
         shell: getHookShell(),
         // Why: hooks run unattended; block Git Credential Manager's interactive prompt while keeping cached auth (issue #7652).
-        env: promptGuardShellEnv({
-          ...process.env,
-          ...getSetupEnvVars(repo, cwd)
-        })
+        env: promptGuardShellEnv(shellHookEnv)
       },
       (error, stdout, stderr) => {
         if (error) {

--- a/src/main/providers/local-pty-provider-spawn-env.test.ts
+++ b/src/main/providers/local-pty-provider-spawn-env.test.ts
@@ -435,6 +435,71 @@ describe('LocalPtyProvider', () => {
       expect(env.LD_LIBRARY_PATH).toBe('/opt/audio/lib')
     })
 
+    it('does not forward a half-activated conda env into the shell', async () => {
+      // Why: CONDA_SHLVL asserts CONDA_PREFIX exists; forwarding the sentinel
+      // alone makes the user's rc-file conda hook raise a TypeError (#14195).
+      const saved = {
+        CONDA_SHLVL: process.env.CONDA_SHLVL,
+        CONDA_PREFIX: process.env.CONDA_PREFIX,
+        CONDA_DEFAULT_ENV: process.env.CONDA_DEFAULT_ENV,
+        CONDA_PROMPT_MODIFIER: process.env.CONDA_PROMPT_MODIFIER,
+        CONDA_EXE: process.env.CONDA_EXE
+      }
+      delete process.env.CONDA_PREFIX
+      process.env.CONDA_SHLVL = '1'
+      process.env.CONDA_DEFAULT_ENV = 'base'
+      process.env.CONDA_PROMPT_MODIFIER = '(base) '
+      process.env.CONDA_EXE = '/opt/miniconda3/bin/conda'
+
+      try {
+        await provider.spawn({ cols: 80, rows: 24 })
+      } finally {
+        for (const [key, value] of Object.entries(saved)) {
+          if (value === undefined) {
+            delete process.env[key]
+          } else {
+            process.env[key] = value
+          }
+        }
+      }
+
+      const env = spawnMock.mock.calls.at(-1)?.[2].env
+      expect(env.CONDA_SHLVL).toBeUndefined()
+      expect(env.CONDA_DEFAULT_ENV).toBeUndefined()
+      expect(env.CONDA_PROMPT_MODIFIER).toBeUndefined()
+      expect(env.CONDA_EXE).toBe('/opt/miniconda3/bin/conda')
+    })
+
+    it('drops the conda sentinel when the client asks to delete CONDA_PREFIX', async () => {
+      // Why: envToDelete runs after the inherited-env scrub, so the coherence
+      // pass must run last or it re-creates the exact broken pair it prevents.
+      const saved = {
+        CONDA_SHLVL: process.env.CONDA_SHLVL,
+        CONDA_PREFIX: process.env.CONDA_PREFIX,
+        CONDA_DEFAULT_ENV: process.env.CONDA_DEFAULT_ENV
+      }
+      process.env.CONDA_SHLVL = '1'
+      process.env.CONDA_PREFIX = '/opt/miniconda3'
+      process.env.CONDA_DEFAULT_ENV = 'base'
+
+      try {
+        await provider.spawn({ cols: 80, rows: 24, envToDelete: ['CONDA_PREFIX'] })
+      } finally {
+        for (const [key, value] of Object.entries(saved)) {
+          if (value === undefined) {
+            delete process.env[key]
+          } else {
+            process.env[key] = value
+          }
+        }
+      }
+
+      const env = spawnMock.mock.calls.at(-1)?.[2].env
+      expect(env.CONDA_PREFIX).toBeUndefined()
+      expect(env.CONDA_SHLVL).toBeUndefined()
+      expect(env.CONDA_DEFAULT_ENV).toBeUndefined()
+    })
+
     it('uses shell wrapper when MiMo home must survive shell startup', async () => {
       provider.configure({
         buildSpawnEnv: (_id, env) => {

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -44,6 +44,7 @@ import { removeInheritedNoColor } from '../pty/terminal-color-env'
 import { removeAppImageRuntimeEnv } from '../pty/appimage-terminal-env'
 import { stripInheritedBuildModeEnv } from '../pty/build-mode-env'
 import { stripLegacyTerminalShimEnv } from '../pty/legacy-terminal-shim-dir'
+import { dropIncoherentCondaActivationEnv } from '../pty/conda-activation-env'
 import { SessionNotFoundError } from '../daemon/daemon-errors'
 import { resolvePathEnvKey } from '../pty/windows-environment-path'
 import { isHostCodexHomeForWsl, isWslCodexHomeForHost } from '../pty/codex-home-wsl-env'
@@ -835,6 +836,8 @@ export class LocalPtyProvider implements IPtyProvider {
     )
     // Why: raw requested PATH promotion runs after the host-env scrub.
     stripLegacyTerminalShimEnv(finalEnv, process.platform)
+    // Why after every deletion pass: an envToDelete of CONDA_PREFIX must not leave the sentinel behind.
+    dropIncoherentCondaActivationEnv(finalEnv, process.platform)
 
     // Why: worktree-scoped HISTFILE — without it worktrees share one global history (terminal-history-scope-design §7–§10).
     const worktreeId = args.worktreeId

--- a/src/main/pty/conda-activation-env.test.ts
+++ b/src/main/pty/conda-activation-env.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import { dropIncoherentCondaActivationEnv } from './conda-activation-env'
+
+describe('dropIncoherentCondaActivationEnv', () => {
+  it('drops the activation group when the sentinel outlived CONDA_PREFIX', () => {
+    // Why: this exact shape is what makes `conda activate` raise
+    // "TypeError: expected str, bytes or os.PathLike object, not NoneType" (#14195).
+    const env: Record<string, string> = {
+      CONDA_SHLVL: '1',
+      CONDA_DEFAULT_ENV: 'base',
+      CONDA_PROMPT_MODIFIER: '(base) ',
+      CONDA_PREFIX_1: '/opt/miniconda3',
+      CONDA_STACKED_2: 'true',
+      CONDA_EXE: '/opt/miniconda3/bin/conda',
+      CONDA_ROOT: '/opt/miniconda3',
+      CONDA_PYTHON_EXE: '/opt/miniconda3/bin/python',
+      CONDA_BAT: 'C:\\miniconda3\\condabin\\conda.bat',
+      _CE_CONDA: '',
+      _CE_M: '',
+      PATH: '/usr/bin'
+    }
+
+    dropIncoherentCondaActivationEnv(env, 'linux')
+
+    expect(env.CONDA_SHLVL).toBeUndefined()
+    expect(env.CONDA_DEFAULT_ENV).toBeUndefined()
+    expect(env.CONDA_PROMPT_MODIFIER).toBeUndefined()
+    expect(env.CONDA_PREFIX_1).toBeUndefined()
+    expect(env.CONDA_STACKED_2).toBeUndefined()
+    // Discovery vars are installation state, not activation state: keeping them
+    // is what lets the shell's conda hook re-activate from a clean slate.
+    expect(env.CONDA_EXE).toBe('/opt/miniconda3/bin/conda')
+    expect(env.CONDA_ROOT).toBe('/opt/miniconda3')
+    expect(env.CONDA_PYTHON_EXE).toBe('/opt/miniconda3/bin/python')
+    expect(env.CONDA_BAT).toBe('C:\\miniconda3\\condabin\\conda.bat')
+    expect(env._CE_CONDA).toBe('')
+    expect(env._CE_M).toBe('')
+    expect(env.PATH).toBe('/usr/bin')
+  })
+
+  it('leaves a genuinely activated environment untouched', () => {
+    const env: Record<string, string> = {
+      CONDA_SHLVL: '2',
+      CONDA_PREFIX: '/opt/miniconda3/envs/ml',
+      CONDA_PREFIX_1: '/opt/miniconda3',
+      CONDA_DEFAULT_ENV: 'ml',
+      CONDA_PROMPT_MODIFIER: '(ml) '
+    }
+
+    dropIncoherentCondaActivationEnv(env, 'darwin')
+
+    expect(env).toEqual({
+      CONDA_SHLVL: '2',
+      CONDA_PREFIX: '/opt/miniconda3/envs/ml',
+      CONDA_PREFIX_1: '/opt/miniconda3',
+      CONDA_DEFAULT_ENV: 'ml',
+      CONDA_PROMPT_MODIFIER: '(ml) '
+    })
+  })
+
+  it("leaves conda's own CONDA_SHLVL=0 hook-ran-nothing state alone", () => {
+    const env: Record<string, string> = { CONDA_SHLVL: '0', CONDA_EXE: '/opt/conda/bin/conda' }
+
+    dropIncoherentCondaActivationEnv(env, 'linux')
+
+    expect(env).toEqual({ CONDA_SHLVL: '0', CONDA_EXE: '/opt/conda/bin/conda' })
+  })
+
+  it('treats an empty CONDA_PREFIX as missing', () => {
+    const env: Record<string, string> = {
+      CONDA_SHLVL: '1',
+      CONDA_PREFIX: '',
+      CONDA_DEFAULT_ENV: 'base'
+    }
+
+    dropIncoherentCondaActivationEnv(env, 'linux')
+
+    expect(env).toEqual({})
+  })
+
+  it('matches case-variant keys on win32 only', () => {
+    const windowsEnv: Record<string, string> = {
+      Conda_Shlvl: '1',
+      CONDA_Default_Env: 'base',
+      Conda_Prefix_1: 'C:\\miniconda3',
+      CONDA_EXE: 'C:\\miniconda3\\Scripts\\conda.exe'
+    }
+
+    dropIncoherentCondaActivationEnv(windowsEnv, 'win32')
+
+    expect(windowsEnv).toEqual({ CONDA_EXE: 'C:\\miniconda3\\Scripts\\conda.exe' })
+
+    // Why the same input is untouched on POSIX: a lowercase name is a different variable there.
+    const posixEnv: Record<string, string> = {
+      Conda_Shlvl: '1',
+      CONDA_Default_Env: 'base',
+      Conda_Prefix_1: '/opt/miniconda3'
+    }
+
+    dropIncoherentCondaActivationEnv(posixEnv, 'linux')
+
+    expect(posixEnv).toEqual({
+      Conda_Shlvl: '1',
+      CONDA_Default_Env: 'base',
+      Conda_Prefix_1: '/opt/miniconda3'
+    })
+  })
+
+  it('leaves an environment with no conda state alone', () => {
+    const env: Record<string, string> = { PATH: '/usr/bin', HOME: '/home/dev' }
+
+    dropIncoherentCondaActivationEnv(env, 'linux')
+
+    expect(env).toEqual({ PATH: '/usr/bin', HOME: '/home/dev' })
+  })
+
+  it('ignores a non-numeric sentinel rather than guessing', () => {
+    const env: Record<string, string> = { CONDA_SHLVL: 'weird', CONDA_DEFAULT_ENV: 'base' }
+
+    dropIncoherentCondaActivationEnv(env, 'linux')
+
+    expect(env).toEqual({ CONDA_SHLVL: 'weird', CONDA_DEFAULT_ENV: 'base' })
+  })
+})

--- a/src/main/pty/conda-activation-env.ts
+++ b/src/main/pty/conda-activation-env.ts
@@ -1,0 +1,71 @@
+// Conda's activation state is a coupled group, not independent keys: CONDA_SHLVL
+// is a sentinel asserting CONDA_PREFIX exists. Every other PTY env scrubber here
+// treats keys one at a time, so a half-activated host env (a client envToDelete,
+// the wsl.exe/WSLENV boundary, a relay launched from a half-activated login
+// shell, a launchd/PAM env reshuffle) is forwarded verbatim and `conda activate`
+// dies in `_get_deactivate_scripts(None)` with a TypeError (#14195).
+
+/** Activation state: meaningful only while CONDA_PREFIX names an active env. */
+const ACTIVATION_STATE_KEYS = [
+  'CONDA_SHLVL',
+  'CONDA_PREFIX',
+  'CONDA_DEFAULT_ENV',
+  'CONDA_PROMPT_MODIFIER'
+] as const
+
+/** Stack depth is unbounded (`CONDA_PREFIX_1`, `CONDA_STACKED_2`, ...). */
+const POSIX_STACK_KEY = /^(?:CONDA_PREFIX|CONDA_STACKED)_\d+$/
+const WINDOWS_STACK_KEY = /^(?:CONDA_PREFIX|CONDA_STACKED)_\d+$/i
+
+/**
+ * Drops conda's activation-state group when the sentinel survived but the prefix
+ * did not, so the shell's conda hook starts from a clean slate instead of
+ * crashing. Installation/discovery vars (CONDA_EXE, CONDA_ROOT, CONDA_BAT,
+ * CONDA_PYTHON_EXE, _CE_CONDA, _CE_M) are preserved so `conda` still resolves.
+ *
+ * Why delete-only, never synthesize: the reverse shape (prefix without sentinel)
+ * does not crash — conda just reads it as inactive — and Orca cannot verify the
+ * prefix directory exists on the executing host (it routinely does not for WSL
+ * and SSH), so inventing activation state would be worse than leaving it.
+ */
+export function dropIncoherentCondaActivationEnv(
+  env: Record<string, string | undefined>,
+  platform: NodeJS.Platform = process.platform
+): void {
+  const windows = platform === 'win32'
+  // Why: PTY spawn is a hot path; one exact-key miss covers every non-conda posix env.
+  if (!windows && env.CONDA_SHLVL === undefined) {
+    return
+  }
+  const keys = Object.keys(env)
+  // Why case-insensitive on win32 only: Windows env names are case-insensitive, so a
+  // conda install or PowerShell profile may spell them `Conda_Shlvl` (same reasoning as
+  // stripLegacyTerminalShimEnv). On POSIX a lowercase name is a different variable.
+  const findKey = (name: string): string | undefined => {
+    if (!windows) {
+      return env[name] === undefined ? undefined : name
+    }
+    const lowered = name.toLowerCase()
+    return keys.find((key) => key.toLowerCase() === lowered)
+  }
+
+  const shlvlKey = findKey('CONDA_SHLVL')
+  // CONDA_SHLVL=0 (or unparsable) is conda's own hook-ran-nothing-active state.
+  if (shlvlKey === undefined || !(Number.parseInt(env[shlvlKey] ?? '', 10) > 0)) {
+    return
+  }
+  const prefixKey = findKey('CONDA_PREFIX')
+  if (prefixKey !== undefined && env[prefixKey] !== '') {
+    return
+  }
+
+  const stateKeys = new Set<string>(
+    windows ? ACTIVATION_STATE_KEYS.map((key) => key.toLowerCase()) : ACTIVATION_STATE_KEYS
+  )
+  const stackKey = windows ? WINDOWS_STACK_KEY : POSIX_STACK_KEY
+  for (const key of keys) {
+    if (stateKeys.has(windows ? key.toLowerCase() : key) || stackKey.test(key)) {
+      delete env[key]
+    }
+  }
+}

--- a/src/relay/pty-handler-spawn-environment.test.ts
+++ b/src/relay/pty-handler-spawn-environment.test.ts
@@ -89,6 +89,84 @@ describe('PtyHandler', () => {
     expect(spawnOptions.env.PATH).toBe(expectedEnv.PATH)
   })
 
+  describe('half-activated conda env (#14195)', () => {
+    const CONDA_KEYS = [
+      'CONDA_SHLVL',
+      'CONDA_PREFIX',
+      'CONDA_DEFAULT_ENV',
+      'CONDA_PROMPT_MODIFIER',
+      'CONDA_EXE'
+    ] as const
+
+    const withRelayCondaEnv = async (
+      relayEnv: Partial<Record<(typeof CONDA_KEYS)[number], string>>,
+      spawnParams: Record<string, unknown>
+    ): Promise<Record<string, string>> => {
+      const saved = Object.fromEntries(CONDA_KEYS.map((key) => [key, process.env[key]]))
+      try {
+        for (const key of CONDA_KEYS) {
+          delete process.env[key]
+        }
+        Object.assign(process.env, relayEnv)
+        await dispatcher.callRequest('pty.spawn', { cols: 80, rows: 24, ...spawnParams })
+      } finally {
+        for (const key of CONDA_KEYS) {
+          const value = saved[key]
+          if (value === undefined) {
+            delete process.env[key]
+          } else {
+            process.env[key] = value
+          }
+        }
+      }
+      return (mockPtySpawn.mock.calls.at(-1)![2] as { env: Record<string, string> }).env
+    }
+
+    it('drops the sentinel the remote relay inherited without a prefix', async () => {
+      // Why the relay owns this: the execution host composes its own env, so a
+      // remote relay launched from a half-activated login shell would otherwise
+      // hand the broken pair to every SSH terminal.
+      const env = await withRelayCondaEnv(
+        {
+          CONDA_SHLVL: '1',
+          CONDA_DEFAULT_ENV: 'base',
+          CONDA_PROMPT_MODIFIER: '(base) ',
+          CONDA_EXE: '/opt/miniconda3/bin/conda'
+        },
+        {}
+      )
+
+      expect(env.CONDA_SHLVL).toBeUndefined()
+      expect(env.CONDA_DEFAULT_ENV).toBeUndefined()
+      expect(env.CONDA_PROMPT_MODIFIER).toBeUndefined()
+      expect(env.CONDA_EXE).toBe('/opt/miniconda3/bin/conda')
+    })
+
+    it('keeps activation state a client explicitly repaired', async () => {
+      const env = await withRelayCondaEnv(
+        { CONDA_SHLVL: '1', CONDA_DEFAULT_ENV: 'base' },
+        { env: { CONDA_PREFIX: '/opt/miniconda3' } }
+      )
+
+      expect(env.CONDA_PREFIX).toBe('/opt/miniconda3')
+      expect(env.CONDA_SHLVL).toBe('1')
+      expect(env.CONDA_DEFAULT_ENV).toBe('base')
+    })
+
+    it('drops the sentinel when the client deletes CONDA_PREFIX', async () => {
+      // Why: the relay's other inherited-env scrubbers run BEFORE envToDelete,
+      // so anchoring the coherence pass beside them would re-create the crash.
+      const env = await withRelayCondaEnv(
+        { CONDA_SHLVL: '1', CONDA_PREFIX: '/opt/miniconda3', CONDA_DEFAULT_ENV: 'base' },
+        { envToDelete: ['CONDA_PREFIX'] }
+      )
+
+      expect(env.CONDA_PREFIX).toBeUndefined()
+      expect(env.CONDA_SHLVL).toBeUndefined()
+      expect(env.CONDA_DEFAULT_ENV).toBeUndefined()
+    })
+  })
+
   it('does not inherit legacy attribution state from the relay process', async () => {
     const keys = ['ORCA_ENABLE_GIT_ATTRIBUTION', 'ORCA_ATTRIBUTION_SHIM_DIR', 'PATH'] as const
     const saved = Object.fromEntries(keys.map((key) => [key, process.env[key]]))

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -50,6 +50,7 @@ import type { TuiAgent } from '../shared/tui-agent'
 import { forceKillPosixPtyProcessGroups } from '../main/pty/posix-pty-process-groups'
 import { stripInheritedBuildModeEnv } from '../main/pty/build-mode-env'
 import { stripLegacyTerminalShimEnv } from '../main/pty/legacy-terminal-shim-dir'
+import { dropIncoherentCondaActivationEnv } from '../main/pty/conda-activation-env'
 import { dropInheritedOrcaFishHistory } from '../main/fish-history-session'
 import { dropInheritedOrcaHistFile } from '../main/worktree-history-file-path'
 import {
@@ -694,6 +695,9 @@ export class PtyHandler {
     if (!result.TERM) {
       result.TERM = 'xterm-256color'
     }
+    // Why last, not beside the scrubbers above: the relay runs those BEFORE envToDelete,
+    // so an envToDelete of CONDA_PREFIX would otherwise re-create the broken pair.
+    dropIncoherentCondaActivationEnv(result, process.platform)
     expandWindowsPathEnvironmentVariables(result)
     return result
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​345 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​345 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​86 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​82 |

<!-- /orca-pr-loc -->

## ELI5

If you launch Orca from a shell where conda got half-uninitialized, the environment says "an env is active" (`CONDA_SHLVL=1`) but doesn't say *which* one (`CONDA_PREFIX` is gone). Orca faithfully passed that broken pair into every new terminal, and the conda hook in your `~/.zshrc` then crashed with a Python `TypeError` before you could even get a prompt. This PR notices that the pair is broken and clears the leftover flag, so conda starts from a clean slate and `conda activate` works again.

## What Changed

- New `src/main/pty/conda-activation-env.ts` exporting `dropIncoherentCondaActivationEnv(env, platform)`. When `CONDA_SHLVL = N > 0` **and** any prefix that sentinel claims is missing/empty — `CONDA_PREFIX` itself, or any stack slot `CONDA_PREFIX_1`..`CONDA_PREFIX_<N-1>` — it deletes the activation-state group only: `CONDA_SHLVL`, `CONDA_PREFIX`, `CONDA_DEFAULT_ENV`, `CONDA_PROMPT_MODIFIER`, and every `CONDA_PREFIX_<n>` / `CONDA_STACKED_<n>` stack entry.
- Installation/discovery vars (`CONDA_EXE`, `CONDA_ROOT`, `CONDA_PYTHON_EXE`, `CONDA_BAT`, `_CE_CONDA`, `_CE_M`) are deliberately preserved, so `conda` still resolves and the rc-file hook re-activates cleanly.
- Called as the **last** env mutation on all three spawn hosts plus the setup-hook runner:
  - `src/main/providers/local-pty-provider.ts` (local + WSL terminals)
  - `src/main/daemon/pty-subprocess.ts` (daemon-hosted terminals — the default for most sessions)
  - `src/relay/pty-handler.ts` `buildSpawnEnv` (SSH/remote terminals, shared by `spawn()` and `revive()`)
  - `src/main/hooks.ts` (setup / issue-command runner, both the WSL and POSIX/Windows branches)

### Why the whole stack, not just `CONDA_PREFIX`

The sentinel does not assert one variable, it asserts a stack. `conda deactivate` at `CONDA_SHLVL=N` reads `CONDA_PREFIX_<N-1>` and, when that slot is gone, dies rather than deactivating cleanly. Both halves verified against real conda installs (24.9.2 on macOS, 26.5.3 on Linux):

```
# missing top prefix -> `conda activate` crashes
env -u CONDA_PREFIX CONDA_SHLVL=1 CONDA_DEFAULT_ENV=base conda shell.posix activate base

# missing stack slot -> `conda deactivate` crashes the same way
env -u CONDA_PREFIX_1 CONDA_SHLVL=2 CONDA_PREFIX=/opt/conda/envs/x conda shell.posix deactivate
```

The missing-`CONDA_PREFIX` half prints `TypeError: expected str, bytes or os.PathLike object, not NoneType` on both conda versions. The stack-hole half is version-dependent: conda 24.9.2 raises the same `TypeError`, while conda 26.5.3 raises `ValueError: This should not happen! You may have non-consecutive CONDA_PREFIX_<number> environment variables.` Either way it exits non-zero and the deactivate fails, and the fix makes it exit 0 — see the real-hardware transcript below. Every upstream mechanism that can lose `CONDA_PREFIX` (a client `envToDelete`, the `WSLENV` boundary, an env reshuffle) can equally lose a stack slot, so the coherence check covers the whole stack rather than only the top. The scan stops at the first hole, so depth is bounded by the keys actually present and a bogus `CONDA_SHLVL=2000000000` costs one lookup.

### Why not a blanket `CONDA_*` strip

The usual shape for scrubbing a whole variable family is "delete the prefix family, name the exceptions" — that is what Orca does for its own `ORCA_*` state, because Orca owns that namespace. `CONDA_` is **not** an owned namespace: every conda setting is settable as `CONDA_<OPTION>` (`CONDA_CHANNELS`, `CONDA_PKGS_DIRS`, `CONDA_SUBDIR`, `CONDA_SOLVER`, ...), so a family-wide strip would silently destroy user configuration. The explicit activation-key list is the correct polarity here, and the module says so, so a later reviewer does not "simplify" it into a regex.

The module follows the shape of the existing single-concern PTY env modules next to it (`build-mode-env.ts`, `appimage-terminal-env.ts`): one exported verb, one concern, mutates in place, imported by every host that composes a spawn env.

## Why

Root cause is **not** an allowlist that names `CONDA_PREFIX` — no such filter exists (a repo-wide grep for `CONDA` had zero product-code hits before this PR). Orca composes every PTY environment by spreading the host process's `process.env` verbatim and then applying narrow, single-purpose scrubbers (`stripInheritedBuildModeEnv`, `stripLegacyTerminalShimEnv`, `removeAppImageRuntimeEnv`, `dropInheritedOrcaHistFile`, the per-key `envToDelete` loops). **Every one of those treats env vars as independent keys.**

Conda's activation state is not independent: `CONDA_SHLVL` is a sentinel that asserts `CONDA_PREFIX` exists. Whenever anything upstream loses `CONDA_PREFIX` while the sentinel survives — a client `envToDelete` entry, the `wsl.exe`/`WSLENV` boundary, a relay launched from a half-activated login shell, or a launchd/PAM/`login(1)` env reshuffle — Orca forwarded the broken pair and conda died in `_get_deactivate_scripts(None)`:

```
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

Repro of the broken shape (matches the issue report):

```
env -u CONDA_PREFIX CONDA_SHLVL=1 CONDA_DEFAULT_ENV=base conda shell.posix activate base
```

Fixing it at the source means one coherence pass shared by all four env compositions rather than a fourth bespoke special case inside one host (`deleteRequestedDaemonEnvKeys` already hand-codes one coupled-variable case for `ORCA_CODEX_HOME`/`CODEX_HOME`).

Two deliberate non-goals, both documented in the module:

1. **Delete-only, never synthesize.** The reverse shape (prefix present, sentinel absent) does not crash — conda just reads the env as inactive — and Orca cannot verify the prefix directory exists on the executing host (it routinely does not for WSL and SSH). Inventing activation state would be worse than leaving it.
2. **Coherent state is untouched.** A user who launches Orca from a genuinely activated env (both vars present) keeps it. Only already-incoherent states are modified.

**Ordering matters and is pinned by tests.** The relay runs its inherited-env scrubbers *before* its `envToDelete` loop, whereas the local provider and daemon run theirs *after*. Placing the coherence pass next to the sibling scrubbers (the visually obvious spot) would let `envToDelete: ['CONDA_PREFIX']` re-create the exact broken state the pass exists to prevent. Each call site is therefore anchored on the last mutation before the env is used, and there is an explicit regression test on both the local and relay paths that passes `envToDelete: ['CONDA_PREFIX']` and asserts the sentinel is dropped too.

## Linked Issue

Fixes #14195

## Visual Proof

`N/A` — this is a process-environment change with no UI surface. The only user-visible difference is the absence of a Python traceback at shell startup in an already-broken environment.

## Testing

Commands actually run, in this worktree, on macOS:

```
npx vitest run --config config/vitest.config.ts \
  src/main/pty/conda-activation-env.test.ts \
  src/main/providers/local-pty-provider-spawn-env.test.ts \
  src/main/daemon/pty-subprocess-env-inheritance.test.ts \
  src/relay/pty-handler-spawn-environment.test.ts \
  src/main/hooks.test.ts
#  Tests  3 failed | 89 passed (92)

npx oxlint <10 changed files>
#  clean

npx oxlint --config config/oxlint-code-quality-native-plugins.json <10 changed files> --deny-warnings
#  clean
```

**About the 3 failures:** they are pre-existing and unrelated to this PR — `drops an inherited Orca ORCA_HISTFILE`, `keeps the path this spawn injected`, `keeps a caller-supplied value` in `pty-subprocess-env-inheritance.test.ts`. I verified they fail identically on a clean `origin/main` checkout with all of my changes removed. They fail because the test process here inherits a real `ORCA_HISTFILE`/`HISTFILE` from the Orca terminal the suite was run in; they pass in a clean environment. All 92 other tests pass.

**Proof the new tests actually catch the bug.** I reverted only the four product files (keeping the new tests and the new module) and re-ran:

```
 Tests  9 failed | 76 passed (85)
```

All six new tests failed, one per code path:

- `local-pty-provider` — `does not forward a half-activated conda env into the shell`
- `local-pty-provider` — `drops the conda sentinel when the client asks to delete CONDA_PREFIX`
- `pty-subprocess` — `does not forward a half-activated conda env from the daemon process env`
- `pty-handler` — `drops the sentinel the remote relay inherited without a prefix`
- `pty-handler` — `drops the sentinel when the client deletes CONDA_PREFIX`
- `hooks` — `does not run setup scripts with a half-activated conda env`

Then restored the product files and confirmed the run returns to `3 failed | 89 passed` (the 3 pre-existing ones).

Test coverage added:

- `src/main/pty/conda-activation-env.test.ts` (new, pure, no mocks): drops the group incl. stack entries while preserving discovery vars; drops the group when a stack slot below the top prefix is missing or empty; a bogus `CONDA_SHLVL` cannot outrun the keys present; no-op for a genuinely activated env (including a complete `CONDA_SHLVL=2` stack, on both POSIX and win32 spellings); no-op for conda's own `CONDA_SHLVL=0` state; treats `CONDA_PREFIX=''` as missing; win32 case-variant keys (`Conda_Shlvl`, `CONDA_Default_Env`, `Conda_Prefix_1`) matched, same input on `linux` left alone; fast path for a conda-free env; non-numeric sentinel left alone.
- One regression test per spawn host plus the ordering guard on the local and relay paths, and a relay case asserting a client-supplied `env: { CONDA_PREFIX: ... }` repair is respected (nothing dropped).

### Real-hardware verification (added after review, on a real Linux host)

Executed on the SSH execution host `openclaw` — Ubuntu 24.04, `Linux 7.0.0-28-generic x86_64`, glibc 2.39, node v26.1.0 — against a freshly installed **Miniconda, conda 26.5.3**, plus **conda 24.9.2** on macOS. Every block below is real output, not a reconstruction.

**1. The bug reproduces against a real conda, at shell-startup time.** In a real Orca terminal on the SSH host (`ptyId ssh:…@@pty-7`), starting from the env Orca actually handed that shell:

```
### orca terminal env, CONDA keys as Orca handed them to this shell:
_CE_CONDA=
_CE_M=
CONDA_DEFAULT_ENV=base
CONDA_EXE=/home/neil/miniconda3/bin/conda
CONDA_PREFIX=/home/neil/miniconda3
CONDA_PROMPT_MODIFIER=(base)
CONDA_PYTHON_EXE=/home/neil/miniconda3/bin/python
CONDA_SHLVL=1

### after the reported upstream loss of CONDA_PREFIX:
CONDA_DEFAULT_ENV=base
CONDA_SHLVL=1

### conda activate under that env (UNFIXED):
    TypeError: expected str, bytes or os.PathLike object, not NoneType
    TypeError: expected str, bytes or os.PathLike object, not NoneType
ACTIVATE_EXIT=1
```

Two tracebacks, not one: `grep -n` on the full transcript puts the first at line 27 and `MARK_RC_DONE` at line 90, i.e. **conda crashes while `~/.bashrc` is being sourced, before the prompt is reached**, and again on the explicit `conda activate base`. Both are `_get_deactivate_scripts` → `os.scandir(join(prefix, ...))` with `prefix=None`, at `conda/activate.py:791` on conda 26.5.3 and `conda/activate.py:827` on conda 24.9.2.

**2. The fix resolves it, running the real module under real node on the host.** `src/main/pty/conda-activation-env.ts` was copied to the host and driven by `node` (native TS type-stripping) over the real terminal env, then `bash -lic` was spawned under both the broken and the repaired env:

```
--- DELETED BY FIX ---
CONDA_DEFAULT_ENV,CONDA_PROMPT_MODIFIER,CONDA_SHLVL
=== WITH BROKEN ENV (unfixed) (bash -lic) ===
MARK_RC_DONE
MARK_ACTIVATE_EXIT=1
MARK_PREFIX= MARK_SHLVL=1
    TypeError: expected str, bytes or os.PathLike object, not NoneType
    TypeError: expected str, bytes or os.PathLike object, not NoneType
=== WITH REPAIRED ENV (fix applied) (bash -lic) ===
MARK_RC_DONE
MARK_ACTIVATE_EXIT=0
MARK_PREFIX=/home/neil/miniconda3 MARK_SHLVL=1
```

Preserved on the host as designed: `CONDA_EXE`, `CONDA_PYTHON_EXE`, `_CE_CONDA`, `_CE_M` — so `conda` still resolved and the rc hook re-activated `base` cleanly.

**3. SSH boundary — local and SSH terminals behave identically.** The same driver was run in a real **local macOS** Orca terminal (`executionHostId local`, `hostPlatform darwin`, conda 24.9.2) and a real **SSH-host** Orca terminal (`executionHostId ssh:…`, `hostPlatform linux`, conda 26.5.3). Both produced the byte-identical delta:

| | deleted | preserved |
| :--- | :--- | :--- |
| local / darwin | `CONDA_DEFAULT_ENV, CONDA_PROMPT_MODIFIER, CONDA_SHLVL` | `CONDA_EXE, CONDA_PYTHON_EXE, _CE_CONDA, _CE_M` |
| ssh / linux | `CONDA_DEFAULT_ENV, CONDA_PROMPT_MODIFIER, CONDA_SHLVL` | `CONDA_EXE, CONDA_PYTHON_EXE, _CE_CONDA, _CE_M` |

and both went from `MARK_ACTIVATE_EXIT=1` + `TypeError` to `MARK_ACTIVATE_EXIT=0` with `CONDA_PREFIX` restored by the rc hook.

**4. Coherent state is genuinely untouched, checked against a real 2-level stack.** A real `conda activate base; conda activate cvenv` on the host was captured and fed through the helper:

```
--- REAL STACKED ENV ---
CONDA_DEFAULT_ENV=cvenv
CONDA_EXE=/home/neil/miniconda3/bin/conda
CONDA_PREFIX=/home/neil/miniconda3/envs/cvenv
CONDA_PREFIX_1=/home/neil/miniconda3
CONDA_PROMPT_MODIFIER=(cvenv)
CONDA_PYTHON_EXE=/home/neil/miniconda3/bin/python
CONDA_SHLVL=2
_CE_CONDA=
_CE_M=

CASE A coherent stack        -> dropped: (none)
CASE B CONDA_PREFIX_1 removed -> dropped: CONDA_DEFAULT_ENV,CONDA_PREFIX,CONDA_PROMPT_MODIFIER,CONDA_SHLVL
CASE B survivors: CONDA_EXE,CONDA_PYTHON_EXE,_CE_CONDA,_CE_M

`conda shell.posix deactivate` with the holed stack:
  BEFORE fix: exit=1 :: raise ValueError(
  AFTER  fix: exit=0 :: (no exception line)
```

**5. The suite passes on real Linux, and the 3 macOS failures were environmental.** A scratch worktree at this branch was created on the host and the same five files run there:

```
$ cd /tmp/orca-conda-check && npx vitest run --config config/vitest.config.ts \
    src/main/pty/conda-activation-env.test.ts \
    src/main/providers/local-pty-provider-spawn-env.test.ts \
    src/main/daemon/pty-subprocess-env-inheritance.test.ts \
    src/relay/pty-handler-spawn-environment.test.ts \
    src/main/hooks.test.ts
 Test Files  5 passed (5)
      Tests  96 passed (96)
```

That confirms the "3 pre-existing failures" claim above: they are inherited-`ORCA_HISTFILE` artifacts of the author's macOS shell, and all 96 pass in a clean environment.

**What real hardware did NOT cover — still open:**

- **No relay binary built from this branch was deployed.** `grep -c CONDA_SHLVL` over all 84 `~/.orca-remote/relay-*/relay.js` bundles on the host returns `0`, so the relay's in-process `buildSpawnEnv` was exercised only by `src/relay/pty-handler-spawn-environment.test.ts` (32 tests, passing on real Linux), not by a running relay. Deploying one would have required restarting the user's live relay and killing other sessions. The helper itself, however, was executed by real node on that host over real Orca terminal envs.
- **Windows and WSL were not run on real hardware.** The `win32` case-insensitive branch is covered only by the platform-parameterized unit tests.
- Host state was restored afterwards: `~/.bashrc` reverted from backup (conda-init block removed) and the scratch git worktree removed.

**Platform coverage — honest split:**

- **macOS**: automated tests executed; real conda 24.9.2 repro and fix confirmed in a real local Orca terminal.
- **Linux / SSH**: full suite (96/96) plus the real conda 26.5.3 repro-and-fix executed on the `openclaw` host, in real Orca SSH terminals.
- **Windows / WSL**: covered by reasoning and by platform-parameterized unit tests. Not run on real hardware. CI covers typecheck/lint/build.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

- **Cross-platform**: Windows env names are case-insensitive, so a Windows conda install or PowerShell profile can spell these `Conda_Shlvl`. The helper takes an explicit `platform` parameter and resolves/deletes keys case-insensitively on `win32` only, mirroring `stripLegacyTerminalShimEnv` and `resolvePathEnvKey`; on POSIX a lowercase name is correctly treated as a different variable. A win32-vs-linux case-variant test pins both halves. `CONDA_BAT` (Windows) is in the preserve list. No path separators, no `metaKey`, no shell quoting introduced.
- **WSL**: the change is delete-only, so it cannot push a Windows conda prefix into the distro, and no conda keys are registered in `WSLENV` (a Windows `CONDA_PREFIX` is meaningless inside the guest). The local-provider call still matters for the Windows-side `wsl.exe` wrapper process.
- **SSH / remote**: per `docs/reference/ssh-execution-boundary.md`, the execution host owns its own env, so the relay gets its own call site rather than relying on a client-side fix — a host-side fix alone would miss every SSH terminal, since the SSH path never goes through `buildPtyHostEnv`. The client's env is not consulted for the remote decision. No liveness/verdict vocabulary is touched.
- **Remote wire compatibility**: no RPC param, no stream opcode, no new field, nothing to capability-negotiate. Mixed versions degrade cleanly — a new client against an old relay simply keeps today's behavior for remote panes (no crash, no protocol error); an old client against a new relay is fully fixed because the relay decides host-side.
- **Agent/integration compatibility**: agent launches inherit the same spawn env, so agents that shell out to conda get the same repair. No agent-specific env key is read or written. `deleteRequestedDaemonEnvKeys`' existing `ORCA_CODEX_HOME`/`CODEX_HOME` special case is untouched.
- **Folder workspaces vs worktrees**: worktree-agnostic — only inherited process env is touched, never a repo/worktree path or git state.
- **Provider neutrality**: no GitHub/GitLab surface involved.
- **Performance**: PTY spawn is a hot path. The helper returns after a single exact-key lookup when `CONDA_SHLVL` is absent (the overwhelmingly common case) and only enumerates keys when the broken shape is actually present. On win32 it does one key scan; there are no regex passes unless the trigger fires.
- **UI quality**: N/A — no renderer changes.
- **Security**: no new process spawn, no shell interpolation, no file or network I/O, no secret handling. The change only deletes env keys, never adds or forwards new ones, so it cannot widen what a child process sees.
- **Backwards compat / persisted state**: spawn env is recomputed on every spawn and on relay revive; nothing conda-related is persisted, so there is no migration and no stale-state path.
- **Blast radius**: only already-incoherent states are modified, which is exactly the property the regression tests pin.

## Known limitations / follow-ups

- **PATH is not repaired.** An orphaned activation also leaves the dead env's `bin` directory on `PATH`. Repairing that would require knowing the prefix, which is exactly the value that went missing, so the pass leaves `PATH` alone and lets the rc-file hook prepend the freshly activated env in front of it. Harmless in practice; unfixable without the prefix.
- **No other variable family has this failure shape today.** `VIRTUAL_ENV_PROMPT` without `VIRTUAL_ENV`, `NVM_BIN` without `NVM_DIR`, `LOADEDMODULES` without `MODULEPATH` all degrade quietly rather than aborting shell startup, because conda is the only one that runs a Python process against the variable. A generic "coupled env group" registry would therefore be speculative generality; if a second family ever crashes, that is the moment to extract one.
- **Orca still inherits `process.env` verbatim rather than re-deriving the shell environment.** The structural fix for this whole class is to resolve the user's login-shell environment once at startup and use *that* as the base for every terminal — which repairs any inherited incoherence for free, since the login shell re-runs `conda init`. That is a much larger change with its own startup-cost and SSH/WSL questions, and is deliberately out of scope here.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No new `max-lines` disables were added. The new module is ~90 lines. `src/main/hooks.ts` gained a named `shellHookEnv` local so the POSIX branch's env can be scrubbed before `promptGuardShellEnv` wraps it — behavior is otherwise identical.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

---

> **Rebase note (post-#15873/#15889):** `main` restructured the WSL setup-hook branch so the guest env is now a *constructed allowlist* built from translated setup vars plus selected git-guard keys — it no longer inherits `process.env` at all. The WSL call site this PR originally added is therefore obsolete and was dropped in the rebase: no orphaned `CONDA_SHLVL` can reach a WSL hook any more. The native/local `runHook` path still inherits `process.env`, so the scrub stays there. Local, daemon and relay call sites are unchanged. Re-verified after the rebase: `hooks.test.ts` + `conda-activation-env.test.ts` 14/14, and the daemon/relay suites 1480 passed / 2 skipped.

