### PR TITLE
fix(windows): reach the pty job on the teardown path that actually runs

### DIFF
--- a/src/main/daemon/daemon-endpoint-ownership.test.ts
+++ b/src/main/daemon/daemon-endpoint-ownership.test.ts
@@ -40,6 +40,7 @@ function createMockSubprocess(): SubprocessHandle {
     write() {},
     resize() {},
     kill() {},
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill() {},
     signal() {},
     onData() {},

--- a/src/main/daemon/daemon-health.test.ts
+++ b/src/main/daemon/daemon-health.test.ts
@@ -32,6 +32,7 @@ function createMockSubprocess(): SubprocessHandle {
     write() {},
     resize() {},
     kill() {},
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill() {},
     signal() {},
     onData() {},

--- a/src/main/daemon/daemon-idle-shutdown.test.ts
+++ b/src/main/daemon/daemon-idle-shutdown.test.ts
@@ -67,6 +67,7 @@ function createMockSubprocess(): SubprocessHandle & { exit(code: number): void }
     write: vi.fn(),
     resize: vi.fn(),
     kill: vi.fn(),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: vi.fn(),
     signal: vi.fn(),
     onData: vi.fn(),

--- a/src/main/daemon/daemon-main.test.ts
+++ b/src/main/daemon/daemon-main.test.ts
@@ -98,6 +98,7 @@ function createMockSubprocess() {
     write: vi.fn(),
     resize: vi.fn(),
     kill: vi.fn(() => setTimeout(() => onExitCb?.(0), 5)),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: vi.fn(() => setTimeout(() => onExitCb?.(137), 5)),
     signal: vi.fn(),
     onData(_cb: (data: string) => void) {},

--- a/src/main/daemon/daemon-preflight-client-replacement.test.ts
+++ b/src/main/daemon/daemon-preflight-client-replacement.test.ts
@@ -23,6 +23,7 @@ function createMockSubprocess(): SubprocessHandle {
     write: vi.fn(),
     resize: vi.fn(),
     kill: vi.fn(() => setTimeout(() => onExitCb?.(0), 0)),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: vi.fn(() => onExitCb?.(137)),
     signal: vi.fn(),
     onData: vi.fn(),

--- a/src/main/daemon/daemon-pty-adapter-history-recovery.test.ts
+++ b/src/main/daemon/daemon-pty-adapter-history-recovery.test.ts
@@ -16,6 +16,7 @@ import {
   statSync,
   writeFileSync
 } from 'node:fs'
+import { createMockSubprocess, waitFor } from './daemon-pty-adapter-test-harness'
 import { DaemonPtyAdapter } from './daemon-pty-adapter'
 import { DaemonServer } from './daemon-server'
 import { HistoryManager } from './history-manager'
@@ -30,7 +31,6 @@ import {
 } from './terminal-history-recovery-quarantine'
 import { encodeLogBatch, encodeLogHeader } from './terminal-history-log'
 import type { HistoryReader } from './history-reader'
-import type { SubprocessHandle } from './session-subprocess-handle'
 import type { DaemonFileLog } from './daemon-file-log'
 import type * as DaemonHealthModule from './daemon-health'
 import { getDaemonSocketPath } from './daemon-spawner'
@@ -79,54 +79,6 @@ async function leaveFailedQuarantineProtection(
     quarantineUnreadableRecovery: true
   })
   expect(manager.isSessionDisabled(sessionId)).toBe(true)
-}
-
-function createMockSubprocess(dataOnSubscribe?: string): SubprocessHandle & {
-  pause: ReturnType<typeof vi.fn<() => void>>
-  resume: ReturnType<typeof vi.fn<() => void>>
-  _simulateData: (data: string) => void
-  _simulateExit: (code: number) => void
-} {
-  let onDataCb: ((data: string) => void) | null = null
-  let onExitCb: ((code: number) => void) | null = null
-  return {
-    // Why: getCwd falls back to OS pid lookup; an implausibly-high fake pid can't collide with a real process' cwd.
-    pid: 999_999_999,
-    getForegroundProcess: vi.fn(() => null),
-    write: vi.fn(),
-    resize: vi.fn(),
-    pause: vi.fn<() => void>(),
-    resume: vi.fn<() => void>(),
-    kill: vi.fn(() => setTimeout(() => onExitCb?.(0), 5)),
-    forceKill: vi.fn(() => setTimeout(() => onExitCb?.(137), 5)),
-    signal: vi.fn(),
-    onData(cb) {
-      onDataCb = cb
-      if (dataOnSubscribe) {
-        cb(dataOnSubscribe)
-      }
-    },
-    onExit(cb) {
-      onExitCb = cb
-    },
-    dispose: vi.fn(),
-    _simulateData(data: string) {
-      onDataCb?.(data)
-    },
-    _simulateExit(code: number) {
-      onExitCb?.(code)
-    }
-  }
-}
-
-async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
-  const start = Date.now()
-  while (!predicate()) {
-    if (Date.now() - start > timeoutMs) {
-      throw new Error('waitFor timed out')
-    }
-    await new Promise((r) => setTimeout(r, 10))
-  }
 }
 
 describe('DaemonPtyAdapter history recovery', () => {

--- a/src/main/daemon/daemon-pty-adapter-test-harness.ts
+++ b/src/main/daemon/daemon-pty-adapter-test-harness.ts
@@ -43,6 +43,7 @@ export function createMockSubprocess(dataOnSubscribe?: string): SubprocessHandle
     pause: vi.fn<() => void>(),
     resume: vi.fn<() => void>(),
     kill: vi.fn(() => setTimeout(() => onExitCb?.(0), 5)),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: vi.fn(() => setTimeout(() => onExitCb?.(137), 5)),
     signal: vi.fn(),
     onData(cb) {

--- a/src/main/daemon/daemon-pty-router-history-handoff.test.ts
+++ b/src/main/daemon/daemon-pty-router-history-handoff.test.ts
@@ -24,6 +24,7 @@ function createMockSubprocess(): SubprocessHandle & {
     pause: vi.fn(),
     resume: vi.fn(),
     kill: vi.fn(() => setTimeout(() => onExit?.(0), 0)),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: vi.fn(() => setTimeout(() => onExit?.(137), 0)),
     signal: vi.fn(),
     onData(callback) {

--- a/src/main/daemon/daemon-pty-upgrade-adoption.test.ts
+++ b/src/main/daemon/daemon-pty-upgrade-adoption.test.ts
@@ -23,6 +23,7 @@ function createFixtureSubprocess(pid: number): FixtureSubprocess {
     pause: vi.fn(),
     resume: vi.fn(),
     kill: vi.fn(() => onExit?.(0)),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: vi.fn(() => onExit?.(137)),
     signal: vi.fn(),
     onData: vi.fn((callback) => {

--- a/src/main/daemon/daemon-reattach-checkpoint-isolation.test.ts
+++ b/src/main/daemon/daemon-reattach-checkpoint-isolation.test.ts
@@ -25,6 +25,7 @@ function createMockSubprocess(): SubprocessHandle & { emitData: (data: string) =
     write: vi.fn(),
     resize: vi.fn(),
     kill: vi.fn(() => setTimeout(() => onExit?.(0), 1)),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: vi.fn(() => onExit?.(137)),
     signal: vi.fn(),
     onData(callback) {

--- a/src/main/daemon/daemon-restore-scrollback-depth.test.ts
+++ b/src/main/daemon/daemon-restore-scrollback-depth.test.ts
@@ -46,6 +46,7 @@ function createMockSubprocess(): SubprocessHandle & {
     write: vi.fn(),
     resize: vi.fn(),
     kill: vi.fn(() => setTimeout(() => onExit?.(0), 1)),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: vi.fn(() => onExit?.(137)),
     signal: vi.fn(),
     onData(callback) {

--- a/src/main/daemon/daemon-self-retirement-respawn.test.ts
+++ b/src/main/daemon/daemon-self-retirement-respawn.test.ts
@@ -15,6 +15,7 @@ function fixtureSubprocess(): SubprocessHandle {
     write: () => {},
     resize: () => {},
     kill: () => queueMicrotask(() => onExit?.(0)),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: () => queueMicrotask(() => onExit?.(137)),
     signal: () => {},
     onData: () => {},

--- a/src/main/daemon/daemon-server-attach-only.test.ts
+++ b/src/main/daemon/daemon-server-attach-only.test.ts
@@ -15,6 +15,7 @@ function createMockSubprocess(): SubprocessHandle {
     write: vi.fn(),
     resize: vi.fn(),
     kill: vi.fn(() => onExit?.(0)),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: vi.fn(() => onExit?.(137)),
     signal: vi.fn(),
     onData: vi.fn(),

--- a/src/main/daemon/daemon-server-attachment-lifecycle.test.ts
+++ b/src/main/daemon/daemon-server-attachment-lifecycle.test.ts
@@ -17,6 +17,7 @@ function createMockSubprocess(): SubprocessHandle {
     write: vi.fn(),
     resize: vi.fn(),
     kill: vi.fn(() => onExit?.(0)),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: vi.fn(() => onExit?.(137)),
     signal: vi.fn(),
     onData: vi.fn(),

--- a/src/main/daemon/daemon-server-error-handling.test.ts
+++ b/src/main/daemon/daemon-server-error-handling.test.ts
@@ -22,6 +22,7 @@ function createMockSubprocess(): SubprocessHandle {
     write() {},
     resize() {},
     kill: exit,
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: exit,
     signal() {},
     onData() {},

--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -30,6 +30,7 @@ function createMockSubprocess(): SubprocessHandle & {
     write: vi.fn(),
     resize: vi.fn(),
     kill: vi.fn(() => setTimeout(() => onExitCb?.(0), 5)),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: vi.fn(() => onExitCb?.(137)),
     signal: vi.fn(),
     onData(cb) {

--- a/src/main/daemon/daemon-session-scrollback-window.test.ts
+++ b/src/main/daemon/daemon-session-scrollback-window.test.ts
@@ -47,6 +47,7 @@ describe('daemon session scrollback window', () => {
       kill: vi.fn(() => {
         setTimeout(() => onExitCb?.(0), 1)
       }),
+      terminateOwnedTree: () => 'unavailable' as const,
       forceKill: vi.fn(() => onExitCb?.(137)),
       signal: vi.fn(),
       onData(cb) {

--- a/src/main/daemon/daemon-shutdown-final-checkpoint-caller-deadline.test.ts
+++ b/src/main/daemon/daemon-shutdown-final-checkpoint-caller-deadline.test.ts
@@ -26,6 +26,7 @@ function createMockSubprocess(): SubprocessHandle & { emitData: (data: string) =
     write: vi.fn(),
     resize: vi.fn(),
     kill: vi.fn(() => setTimeout(() => onExit?.(0), 1)),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: vi.fn(() => onExit?.(137)),
     signal: vi.fn(),
     onData(callback) {

--- a/src/main/daemon/daemon-spawner.test.ts
+++ b/src/main/daemon/daemon-spawner.test.ts
@@ -37,6 +37,7 @@ function createMockSubprocess(): SubprocessHandle {
     write: vi.fn(),
     resize: vi.fn(),
     kill: vi.fn(() => setTimeout(() => onExitCb?.(0), 5)),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: vi.fn(() => setTimeout(() => onExitCb?.(137), 5)),
     signal: vi.fn(),
     onData(_cb: (data: string) => void) {},

--- a/src/main/daemon/daemon-stream-droppability-lifecycle.test.ts
+++ b/src/main/daemon/daemon-stream-droppability-lifecycle.test.ts
@@ -43,6 +43,7 @@ function createMockSubprocess(): MockSubprocess {
     write: vi.fn(),
     resize: vi.fn(),
     kill: vi.fn(() => onExit?.(0)),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: vi.fn(() => onExit?.(137)),
     signal: vi.fn(),
     onData(callback) {

--- a/src/main/daemon/daemon-transport-attachment-release.test.ts
+++ b/src/main/daemon/daemon-transport-attachment-release.test.ts
@@ -24,6 +24,7 @@ function fixtureSubprocess(): SubprocessHandle {
     kill: () => {
       setTimeout(() => onExitCb?.(0), 1)
     },
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: () => onExitCb?.(137),
     signal: () => {},
     onData: () => {},

--- a/src/main/daemon/issue-6814-daemon-failure-classification.test.ts
+++ b/src/main/daemon/issue-6814-daemon-failure-classification.test.ts
@@ -25,6 +25,7 @@ function createMockSubprocess(): SubprocessHandle {
     write() {},
     resize() {},
     kill() {},
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill() {},
     signal() {},
     onData() {},

--- a/src/main/daemon/pty-subprocess-handle-lifecycle.test.ts
+++ b/src/main/daemon/pty-subprocess-handle-lifecycle.test.ts
@@ -75,6 +75,7 @@ vi.mock('../providers/windows-conpty-process-membership', () => ({
 
 import { createPtySubprocess } from './pty-subprocess'
 import { mockPtyProcess, useDaemonPtySubprocessEnv } from './pty-subprocess-test-harness'
+import { __setConptyJobNativeForTests } from '../windows/windows-pty-job'
 
 describe('createPtySubprocess', () => {
   useDaemonPtySubprocessEnv({
@@ -408,6 +409,36 @@ describe('createPtySubprocess', () => {
         expect(proc.destroy).not.toHaveBeenCalled()
       } finally {
         killSpy.mockRestore()
+        restorePlatform(origPlatform)
+      }
+    })
+
+    it('forceKill after a Windows kill() escalates to the job instead of giving up', async () => {
+      // Why: skipping the second native kill is right (it double-closes ConPTY),
+      // but it made forceKill a permanent no-op, so a wedged ConPTY -- which
+      // never fires onExit -- could not be escalated at all (#9854). The job
+      // terminates the tree without touching the handle node-pty owns.
+      const terminateJob = vi.fn().mockReturnValue(true)
+      __setConptyJobNativeForTests(() => ({
+        terminateJob,
+        listJobProcessIds: vi.fn(),
+        assignCurrentProcessToJob: vi.fn().mockReturnValue(true)
+      }))
+      const proc = mockPtyProcess(123456) as ReturnType<typeof mockPtyProcess> & { _pty: number }
+      proc._pty = 11
+      spawnMock.mockReturnValue(proc)
+      const origPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+      Object.defineProperty(process, 'platform', { value: 'win32' })
+      try {
+        const handle = await createPtySubprocess({ sessionId: 'test', cols: 80, rows: 24 })
+        handle.kill()
+        handle.forceKill()
+
+        expect(terminateJob).toHaveBeenCalledWith(11, 123456)
+        // Still exactly one native kill: the escalation must not double-close.
+        expect(proc.kill).toHaveBeenCalledOnce()
+      } finally {
+        __setConptyJobNativeForTests()
         restorePlatform(origPlatform)
       }
     })

--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -61,7 +61,7 @@ import { isWindowsGitBashShellPath, resolveWindowsGitBashShellPath } from '../gi
 import { WINDOWS_GIT_BASH_SHELL } from '../../shared/windows-terminal-shell'
 import { resolveAgentForegroundProcessWithAvailability } from '../providers/agent-foreground-process'
 import { readWindowsConptyProcessIds } from '../providers/windows-conpty-process-membership'
-import { assignHostProcessToKillOnCloseJob } from '../windows/windows-pty-job'
+import { assignHostProcessToKillOnCloseJob, terminatePtyJob } from '../windows/windows-pty-job'
 import {
   isAgentForegroundWrapperProcess,
   recognizeAgentProcess,
@@ -1321,10 +1321,18 @@ export async function createPtySubprocess(opts: PtySubprocessOptions): Promise<S
         throw error
       }
     },
+    terminateOwnedTree: () => terminatePtyJob(proc),
     forceKill: () => {
       // Why: after reap/dispose proc.pid is a recycled pid, so SIGKILL would hit an unrelated process (forceKill only signals a live child).
+      if (dead) {
+        return
+      }
       // Why: Windows node-pty kill already closed ConPTY; forcing again can double-close the native handle.
-      if (dead || (process.platform === 'win32' && nodePtyKillIssued)) {
+      // That left forceKill a permanent no-op after any kill(), so a wedged ConPTY -- which
+      // never fires onExit -- had no escalation at all (#9854). The job is that escalation:
+      // it terminates the tree without touching the shell handle node-pty owns.
+      if (process.platform === 'win32' && nodePtyKillIssued) {
+        terminatePtyJob(proc)
         return
       }
       try {

--- a/src/main/daemon/reattach-snapshot.test.ts
+++ b/src/main/daemon/reattach-snapshot.test.ts
@@ -15,6 +15,7 @@ function createMockSubprocess(): SubprocessHandle & {
     write: vi.fn(),
     resize: vi.fn(),
     kill: vi.fn(() => setTimeout(() => onExitCb?.(0), 5)),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: vi.fn(),
     signal: vi.fn(),
     onData(cb) {

--- a/src/main/daemon/repro-12101-mouse-tracking-survives-agent-death.test.ts
+++ b/src/main/daemon/repro-12101-mouse-tracking-survives-agent-death.test.ts
@@ -53,6 +53,7 @@ function createFakeSubprocess(foregroundProcess: string) {
     write: (data: string) => void written.push(data),
     resize: () => {},
     kill: () => {},
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill(this: { forceKilled: boolean }) {
       this.forceKilled = true
     },

--- a/src/main/daemon/session-ingest-throughput.bench.test.ts
+++ b/src/main/daemon/session-ingest-throughput.bench.test.ts
@@ -69,6 +69,7 @@ function makeSubprocess(): SubprocessHandle & { emit: (data: string) => void } {
     write: () => {},
     resize: () => {},
     kill: () => {},
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: () => {},
     signal: () => {},
     onData: (cb) => {

--- a/src/main/daemon/session-pending-output.test.ts
+++ b/src/main/daemon/session-pending-output.test.ts
@@ -13,6 +13,7 @@ function createMockSubprocess() {
     write(_data: string) {},
     resize(_cols: number, _rows: number) {},
     kill() {},
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill() {},
     signal(_sig: string) {},
     onData(cb: (data: string) => void) {

--- a/src/main/daemon/session-subprocess-handle.ts
+++ b/src/main/daemon/session-subprocess-handle.ts
@@ -1,5 +1,7 @@
 import type { TerminalExitCause } from '../../shared/terminal-exit-cause'
 
+import type { JobTerminationOutcome } from '../windows/windows-pty-job'
+
 export type SubprocessHandle = {
   pid: number
   /** Live foreground process name of the PTY (node-pty's `.process`), e.g.
@@ -28,6 +30,12 @@ export type SubprocessHandle = {
   clear?(): void
   kill(): void
   forceKill(): void
+  /**
+   * Terminate this pty's job object, covering descendants that detached or
+   * reparented. `unavailable` when the pty has no job -- never a false
+   * `terminated`, so callers must fall back rather than assume the tree is gone.
+   */
+  terminateOwnedTree(): JobTerminationOutcome
   signal(sig: string): void
   onData(cb: (data: string) => void): void
   onExit(cb: (code: number, cause?: TerminalExitCause) => void): void

--- a/src/main/daemon/session-terminal-control.test.ts
+++ b/src/main/daemon/session-terminal-control.test.ts
@@ -46,6 +46,7 @@ function createRecordingSubprocess() {
     kill() {
       killed = true
     },
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill() {
       killed = true
     },

--- a/src/main/daemon/session-termination-controller.ts
+++ b/src/main/daemon/session-termination-controller.ts
@@ -67,7 +67,8 @@ export class SessionTerminationController {
           },
           {
             // Why: if the root exits during ps its PID can be recycled; never apply that stale snapshot to a different process tree.
-            ownsRoot: () => !this.deps.isExited()
+            ownsRoot: () => !this.deps.isExited(),
+            terminateOwnedTree: () => this.deps.subprocess.terminateOwnedTree()
           }
         )
       ).catch((error) => {

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -62,6 +62,7 @@ function createMockSubprocess() {
       // Simulate async exit
       setTimeout(() => onExit?.(0), 5)
     },
+    terminateOwnedTree: () => 'terminated' as const,
     forceKill() {
       killed = true
     },
@@ -674,6 +675,17 @@ describe('Session', () => {
       const killRoot = killWithDescendantSweepMock.mock.calls[0][1] as () => void
       killRoot()
       expect(subprocess.killed).toBe(true)
+    })
+
+    it('agent kill hands the sweep the pty job, which outlives a reparented child', () => {
+      // A grandchild that detached leaves the shell's console and reparents, so
+      // the pid walk behind the sweep's fallback cannot see it. Only the job can.
+      createSession({ launchAgent: 'claude' })
+      session.kill()
+      const deps = killWithDescendantSweepMock.mock.calls[0][2] as {
+        terminateOwnedTree?: () => string
+      }
+      expect(deps.terminateOwnedTree?.()).toBe('terminated')
     })
 
     it('agent kill root callback is a no-op after the session already exited', () => {

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -8,6 +8,7 @@ import {
 } from './session-termination-controller'
 import { nudgePowerShellPromptRepaint } from './session-powershell-prompt-repaint'
 import type { SubprocessHandle } from './session-subprocess-handle'
+import type { JobTerminationOutcome } from '../windows/windows-pty-job'
 import type { SessionOptions } from './session-options'
 import type { TuiAgent } from '../../shared/tui-agent'
 import { randomUUID } from 'node:crypto'
@@ -121,6 +122,11 @@ export class Session {
 
   get pid(): number {
     return this.subprocess.pid
+  }
+
+  /** Terminate this session's pty job object. `unavailable` is not proof of death. */
+  terminateOwnedTree(): JobTerminationOutcome {
+    return this.subprocess.terminateOwnedTree()
   }
 
   write(data: string): void {

--- a/src/main/daemon/slow-daemon-session-verification.test.ts
+++ b/src/main/daemon/slow-daemon-session-verification.test.ts
@@ -28,6 +28,7 @@ function createMockSubprocess(): SubprocessHandle {
     write: vi.fn(),
     resize: vi.fn(),
     kill: vi.fn(() => setTimeout(() => onExitCb?.(0), 5)),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: vi.fn(() => setTimeout(() => onExitCb?.(137), 5)),
     signal: vi.fn(),
     onData: vi.fn(),

--- a/src/main/daemon/terminal-host-agent-session.test.ts
+++ b/src/main/daemon/terminal-host-agent-session.test.ts
@@ -14,6 +14,7 @@ function createClaimedSubprocess(): SubprocessHandle & {
     write: vi.fn(),
     resize: vi.fn(),
     kill: vi.fn(),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: vi.fn(),
     signal: vi.fn(),
     onData: (listener) => {

--- a/src/main/daemon/terminal-host-attach-only.test.ts
+++ b/src/main/daemon/terminal-host-attach-only.test.ts
@@ -17,6 +17,7 @@ describe('TerminalHost attach-only sessions', () => {
         write: vi.fn(),
         resize: vi.fn(),
         kill: vi.fn(() => onExit?.(0)),
+        terminateOwnedTree: () => 'unavailable' as const,
         forceKill: vi.fn(() => onExit?.(137)),
         signal: vi.fn(),
         onData: vi.fn(),

--- a/src/main/daemon/terminal-host-pty-owner-backend.test.ts
+++ b/src/main/daemon/terminal-host-pty-owner-backend.test.ts
@@ -21,6 +21,7 @@ function createSubprocess(shellPath: string): TestSubprocess {
     write: vi.fn(),
     resize: vi.fn(),
     kill: vi.fn(() => onExit?.(0)),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: vi.fn(() => onExit?.(137)),
     signal: vi.fn(),
     onData: (callback) => {

--- a/src/main/daemon/terminal-host-readiness-reporting.test.ts
+++ b/src/main/daemon/terminal-host-readiness-reporting.test.ts
@@ -18,6 +18,7 @@ function createSubprocess(): SubprocessHandle & { exit: () => void } {
     write: vi.fn(),
     resize: vi.fn(),
     kill: vi.fn(),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: vi.fn(),
     signal: vi.fn(),
     onData: () => {},

--- a/src/main/daemon/terminal-host-session-reaping-leak.test.ts
+++ b/src/main/daemon/terminal-host-session-reaping-leak.test.ts
@@ -33,6 +33,7 @@ function createMockSubprocess(): SubprocessHandle & {
     kill: vi.fn(() => {
       setTimeout(() => onExitCb?.(0), 5)
     }),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: vi.fn(() => onExitCb?.(137)),
     signal: vi.fn(),
     onData(cb) {

--- a/src/main/daemon/terminal-host-startup.test.ts
+++ b/src/main/daemon/terminal-host-startup.test.ts
@@ -9,6 +9,7 @@ function mockSubprocess(): SubprocessHandle {
     write: vi.fn(),
     resize: vi.fn(),
     kill: vi.fn(),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: vi.fn(),
     signal: vi.fn(),
     onData: () => {},

--- a/src/main/daemon/terminal-host-wsl-context.test.ts
+++ b/src/main/daemon/terminal-host-wsl-context.test.ts
@@ -18,6 +18,7 @@ function createSubprocess(): SubprocessHandle {
     write: vi.fn(),
     resize: vi.fn(),
     kill: vi.fn(() => onExit?.(0)),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: vi.fn(() => onExit?.(137)),
     signal: vi.fn(),
     onData: vi.fn(),

--- a/src/main/daemon/terminal-host.test.ts
+++ b/src/main/daemon/terminal-host.test.ts
@@ -30,6 +30,7 @@ function createMockSubprocess(
     kill: vi.fn(() => {
       setTimeout(() => onExitCb?.(0), 5)
     }),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: vi.fn(() => onExitCb?.(137)),
     signal: vi.fn(),
     onData(cb) {

--- a/src/main/daemon/terminal-session-teardown.test.ts
+++ b/src/main/daemon/terminal-session-teardown.test.ts
@@ -15,6 +15,9 @@ function createPlainShellSession(overrides: Partial<Session> = {}): Session {
     forceKillAndWaitForExit: vi.fn(async () => {}),
     beginTermination: vi.fn(() => true),
     kill: vi.fn(),
+    terminateOwnedTree: vi.fn(() => 'terminated' as const),
+    scheduleForceDisposeFallback: vi.fn(),
+    signalTerminationRoot: vi.fn(),
     ...overrides
   } as unknown as Session
 }
@@ -115,5 +118,46 @@ describe('TerminalSessionTeardown plain-shell teardown', () => {
     expect(killWithDescendantSweepMock).not.toHaveBeenCalled()
     expect(session.forceKillAndWaitForExit).not.toHaveBeenCalled()
     expect(session.kill).toHaveBeenCalled()
+  })
+})
+
+describe('pty job ownership reaches the daemon teardown path', () => {
+  // Why this test exists: worktree delete runs here, not in local-pty-provider
+  // (measured in #11047). A job wired only into the provider would never engage,
+  // so the detached grandchild that holds the worktree cwd survives the delete.
+  let platformDescriptor: PropertyDescriptor | undefined
+
+  beforeEach(() => {
+    platformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    killWithDescendantSweepMock.mockReset()
+    killWithDescendantSweepMock.mockResolvedValue(undefined)
+  })
+
+  afterEach(() => {
+    if (platformDescriptor) {
+      Object.defineProperty(process, 'platform', platformDescriptor)
+    }
+  })
+
+  function sweepTerminateOwnedTree(): () => string {
+    const deps = killWithDescendantSweepMock.mock.calls[0][2] as {
+      terminateOwnedTree?: () => string
+    }
+    expect(deps.terminateOwnedTree, 'sweep ran without job ownership').toBeTypeOf('function')
+    return deps.terminateOwnedTree!
+  }
+
+  it.each([
+    ['plain shell', undefined],
+    ['agent session', { agent: 'claude' } as unknown as Session['launchAgent']]
+  ])("hands the sweep this session's job on %s teardown", async (_case, launchAgent) => {
+    const session = createPlainShellSession({ launchAgent })
+    const teardown = new TerminalSessionTeardown(new Map([['s1', session]]))
+
+    await teardown.killSession('s1', session, true)
+
+    expect(sweepTerminateOwnedTree()()).toBe('terminated')
+    expect(session.terminateOwnedTree).toHaveBeenCalled()
   })
 })

--- a/src/main/daemon/terminal-session-teardown.ts
+++ b/src/main/daemon/terminal-session-teardown.ts
@@ -60,7 +60,8 @@ export class TerminalSessionTeardown {
       session.beginTermination()
       await killWithDescendantSweep(session.pid, () => {}, {
         // Why: the descendant tree is only ours while this Session still owns the live root PID.
-        ownsRoot: () => this.sessions.get(sessionId) === session && session.isAlive
+        ownsRoot: () => this.sessions.get(sessionId) === session && session.isAlive,
+        terminateOwnedTree: () => session.terminateOwnedTree()
       })
     }
     await session.forceKillAndWaitForExit()
@@ -117,7 +118,8 @@ export class TerminalSessionTeardown {
         {
           // Why: the descendant rows are only authoritative while this exact
           // Session still owns the root PID captured by ps.
-          ownsRoot: () => this.sessions.get(sessionId) === session && session.isAlive
+          ownsRoot: () => this.sessions.get(sessionId) === session && session.isAlive,
+          terminateOwnedTree: () => session.terminateOwnedTree()
         }
       )
     )

--- a/src/main/pty-descendant-termination-job-coverage.test.ts
+++ b/src/main/pty-descendant-termination-job-coverage.test.ts
@@ -1,0 +1,81 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Every production `killWithDescendantSweep` call must pass `terminateOwnedTree`.
+ *
+ * Why a scan and not a type: the option is optional by design — a POSIX-only
+ * caller has no job to offer — so nothing makes omitting it an error. And the
+ * cost of omitting it is invisible in review: the sweep silently falls back to
+ * a parent-pid walk that a detached, reparented grandchild is not in, so the
+ * process holding the worktree cwd survives the delete (#9045, #10475, #10897).
+ * That is exactly the shape #11047 measured: the job was wired into
+ * `local-pty-provider.ts`, worktree delete ran through the daemon instead, and
+ * the fix engaged on neither of the paths that actually execute.
+ */
+const SRC_DIR = join(__dirname, '..')
+const CALL = 'killWithDescendantSweep('
+const EXPECTED_MINIMUM_SITES = 5
+
+function collectTypeScriptFiles(dir: string): string[] {
+  const found: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules') {
+        continue
+      }
+      found.push(...collectTypeScriptFiles(path))
+      continue
+    }
+    if (entry.name.endsWith('.ts') && !entry.name.includes('.test.')) {
+      found.push(path)
+    }
+  }
+  return found
+}
+
+/** The call's argument text, brace-matched so a nested object literal stays whole. */
+function readCallArguments(source: string, callIndex: number): string {
+  let depth = 0
+  for (let index = callIndex + CALL.length - 1; index < source.length; index += 1) {
+    const char = source[index]
+    if (char === '(') {
+      depth += 1
+    } else if (char === ')') {
+      depth -= 1
+      if (depth === 0) {
+        return source.slice(callIndex, index)
+      }
+    }
+  }
+  return source.slice(callIndex)
+}
+
+describe('pty job ownership covers every descendant sweep', () => {
+  const sites: { file: string; args: string }[] = []
+  for (const file of collectTypeScriptFiles(SRC_DIR)) {
+    const source = readFileSync(file, 'utf8')
+    if (file.endsWith('pty-descendant-termination.ts')) {
+      continue // the implementation itself
+    }
+    let index = source.indexOf(CALL)
+    while (index !== -1) {
+      sites.push({ file: relative(SRC_DIR, file), args: readCallArguments(source, index) })
+      index = source.indexOf(CALL, index + CALL.length)
+    }
+  }
+
+  it('scans a realistic number of call sites', () => {
+    // Guards against a rename quietly turning every assertion below vacuous.
+    expect(sites.length).toBeGreaterThanOrEqual(EXPECTED_MINIMUM_SITES)
+  })
+
+  it.each(sites.map((site, index) => [`${site.file} #${index}`, site] as const))(
+    '%s passes terminateOwnedTree',
+    (_label, site) => {
+      expect(site.args).toContain('terminateOwnedTree')
+    }
+  )
+})

--- a/src/main/runtime/remote-agent-session-host-authority.integration.test.ts
+++ b/src/main/runtime/remote-agent-session-host-authority.integration.test.ts
@@ -36,6 +36,7 @@ function createControlledSubprocess(): ControlledSubprocess {
     write: vi.fn(),
     resize: vi.fn(),
     kill: () => exit(0),
+    terminateOwnedTree: () => 'unavailable' as const,
     forceKill: () => exit(137),
     signal: vi.fn(),
     onData: vi.fn(),


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 40 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​204 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​49 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​155 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 |

<!-- /orca-pr-loc -->

## Problem

W2 (#15755) gave every ConPTY pane a Win32 job object and wired `terminateOwnedTree` into `src/main/providers/local-pty-provider.ts`.

**That is not the code worktree delete runs.** @OrcaWin measured it in #11047:

> The executing path is the terminal daemon, not the in-process local provider — `src/main/daemon/terminal-session-teardown.ts` (`daemon-agent`). `local-pty-provider.ts` never ran during any delete. Anything fixed only there would not engage.

Verified against merged `main` — three production `killWithDescendantSweep` call sites had no job:

| site | wired before |
|---|---|
| `providers/local-pty-provider.ts:1286,1295` | yes |
| `daemon/terminal-session-teardown.ts:61,102` | **no** — the worktree-delete path |
| `daemon/session-termination-controller.ts:63` | **no** |

Without the job the sweep falls back to a parent-pid walk. A grandchild spawned `detached` has left the pane's console and reparented, so it is not in that walk — and it is exactly the process that holds the worktree cwd open (#9045, #10475, #10897).

## Change

- `SubprocessHandle` exposes `terminateOwnedTree()`, implemented in `pty-subprocess.ts` where the `IPty` lives.
- The three daemon call sites pass it, matching the provider.
- Windows `forceKill()` used to return early after any `kill()` so it could not double-close the ConPTY handle node-pty owns. Correct, but it made force-kill a **permanent no-op** — and a wedged ConPTY never fires `onExit`, so such a session had no escalation at all (@hanbong5938, #9854). Terminating the job is that escalation and does not touch node-pty's handle.
- New tree-walking guard: any production `killWithDescendantSweep` call that omits `terminateOwnedTree` fails the build. The option is optional by design (POSIX callers have no job), so its absence is invisible in review — which is precisely how this gap survived W2. Verified non-vacuous by removing a wiring and watching it fail.
- Drive-by: `daemon-pty-adapter-history-recovery.test.ts` had its own copies of `createMockSubprocess` and `waitFor`; both already exist in `daemon-pty-adapter-test-harness.ts`. Deduped (−49 lines).

## Verification

- Full unit suite, typecheck, lint.
- Windows behaviour is covered by the existing `windows-pty-job.win32.test.ts` on the PR CI Windows runner (real ConPTY, real detached grandchild).

## Risk

`Session.kill()` on Windows now terminates the job rather than only signalling the shell. Windows has no SIGTERM — node-pty's `kill()` already closes the ConPTY — so no graceful path is lost. `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` is still deliberately unset, so a clean `exit` still leaves backgrounded work alone (pinned by `windows-pty-job.win32.test.ts`).

Credit: @OrcaWin (#11047) for the measured path finding, @hanbong5938 (#9854) for the wedged-ConPTY escalation.