### PR TITLE
fix(ports): report a Stop as succeeded when the listener already exited

### DIFF
--- a/src/main/ports/port-scan-command-execution.test.ts
+++ b/src/main/ports/port-scan-command-execution.test.ts
@@ -42,7 +42,10 @@ describe('runPortScanCommandInProcess', () => {
 
     expect(result.stdout).toBe(LSOF_OUTPUT)
     expect(result.spawnMs).toBeGreaterThanOrEqual(SPAWN_STALL_MS - 100)
-  })
+    // Why the explicit budget: the stall is deliberately longer than the whole
+    // watchdog budget (5.2s), so on vitest's 5s default this test could never
+    // pass -- it has been red since #12217 landed.
+  }, 15_000)
 
   it('kills the child and times out when the callback never arrives', async () => {
     vi.useFakeTimers()

--- a/src/main/ports/workspace-port-ownership.test.ts
+++ b/src/main/ports/workspace-port-ownership.test.ts
@@ -7,12 +7,66 @@ vi.mock('./local-workspace-port-scanner', () => ({
   scanWorkspacePorts: scanWorkspacePortsMock
 }))
 
+function workspacePortScan(pid: number, port: number) {
+  return {
+    platform: 'win32' as const,
+    scannedAt: 0,
+    ports: [
+      {
+        id: `127.0.0.1:${port}:${pid}`,
+        bindHost: '127.0.0.1',
+        connectHost: '127.0.0.1',
+        port,
+        pid,
+        protocol: 'http' as const,
+        kind: 'workspace' as const,
+        worktreeId: worktrees[0]!.id
+      }
+    ]
+  }
+}
+
 const worktrees = [{ id: 'repo::/repo', repoId: 'repo', displayName: 'main', path: '/repo' }]
 
 describe('killWorkspacePort', () => {
   afterEach(() => {
     scanWorkspacePortsMock.mockReset()
     vi.restoreAllMocks()
+  })
+
+  it('reports success when the listener exited before the signal landed', async () => {
+    // Why: the re-scan authorizes the pid, then the dev server exits on its own
+    // before `kill` runs. The port is free -- which is what Stop asked for --
+    // but the raw ESRCH surfaced as "Stop failed" on a port that was gone.
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('kill ESRCH'), { code: 'ESRCH' })
+    })
+    scanWorkspacePortsMock.mockResolvedValue(workspacePortScan(123, 5173))
+
+    expect(await killWorkspacePort(worktrees, { pid: 123, port: 5173 })).toEqual({ ok: true })
+  })
+
+  it('still reports a real failure to stop', async () => {
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      throw Object.assign(new Error('kill EPERM'), { code: 'EPERM' })
+    })
+    scanWorkspacePortsMock.mockResolvedValue(workspacePortScan(123, 5173))
+
+    expect(await killWorkspacePort(worktrees, { pid: 123, port: 5173 })).toEqual({
+      ok: false,
+      reason: 'kill EPERM'
+    })
+  })
+
+  it('signals the pid the socket scan named, which is the listener itself', async () => {
+    // Why pinned: netstat -ano / lsof report the process that owns the socket,
+    // not a supervising wrapper, so escalating this to a tree kill would reach
+    // descendants nobody asked to stop without freeing anything extra.
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    scanWorkspacePortsMock.mockResolvedValue(workspacePortScan(123, 5173))
+
+    expect(await killWorkspacePort(worktrees, { pid: 123, port: 5173 })).toEqual({ ok: true })
+    expect(killSpy).toHaveBeenCalledExactlyOnceWith(123, 'SIGTERM')
   })
 
   // Regression for #11161 review: on an EDR-hooked host the background poller

--- a/src/main/ports/workspace-port-ownership.ts
+++ b/src/main/ports/workspace-port-ownership.ts
@@ -109,6 +109,13 @@ export async function killWorkspacePort(
     process.kill(pid, 'SIGTERM')
     return { ok: true }
   } catch (error) {
+    // Why ESRCH is success: the pid exited between the authorizing re-scan and
+    // this signal, so the listener is gone and the port is free -- which is
+    // what Stop was asked for. Surfacing the raw `kill ESRCH` made a Stop that
+    // had already succeeded read as a failure.
+    if ((error as NodeJS.ErrnoException)?.code === 'ESRCH') {
+      return { ok: true }
+    }
     const message = error instanceof Error ? error.message : String(error)
     return { ok: false, reason: message || 'Failed to stop the process.' }
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​58 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​57 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |

<!-- /orca-pr-loc -->

> **Rewritten.** This PR originally escalated the Windows Stop to a `taskkill /T /F` tree kill, adopting the mechanism proposed in #10346. **That mechanism is wrong** — I checked it before merging and it does not survive contact with the scanner. What remains is the one defect I can actually prove.

## What #10346 claimed, and why it is not right

> the listener is a child of the `npm run dev` wrapper the scan attributed the port to, so terminating the wrapper orphans the child that holds the socket

The scan does not attribute the port to a wrapper. `scanWindowsNetstatPorts` reads `netstat -ano` and takes the PID column (`local-workspace-port-scanner.ts:245-263`), and that column is the process **owning the TCP endpoint** — the listener itself. The POSIX path takes the same field from `lsof`. So `process.kill(pid, 'SIGTERM')` already targets the right process, and a tree kill would only add descendants nobody asked to stop.

**#10150 is also not this code path.** It reports a dev server surviving *project close / terminal exit*, not the Resource Manager Stop button. That is PTY teardown, and it is what the job objects in #15755 / #15886 address.

## The real defect

```ts
process.kill(pid, 'SIGTERM')
return { ok: true }
} catch (error) {
  return { ok: false, reason: message }   // `kill ESRCH` shown as a Stop failure
}
```

The authorizing re-scan runs first, then the signal. If the listener exits in between — common for a dev server the user just Ctrl-C'd elsewhere — `process.kill` throws `ESRCH` and the UI reports failure **for a port that is now free**, which is exactly the outcome Stop asked for.

`ESRCH` is now success. Every other error still fails, with its message.

## Tests

- `ESRCH` → `{ ok: true }`
- `EPERM` → still `{ ok: false, reason }`
- The pid we signal is the scanned pid, once — pinned so a future change does not quietly escalate this to a tree.
- Restored the #11161 metadata-authorization regression test that the first draft displaced.

## Drive-by

`src/main/ports/port-scan-command-execution.test.ts` blocks the calling thread for the full watchdog budget plus margin (5.2s) and asserts against vitest's 5s default. It has been failing deterministically since #12217; given a real budget it passes.

## Risk

None identified. One error code changes classification; no process that was not already being signalled is signalled now.

Credit to @innocarpe (#10346) for surfacing the Stop path, with the correction above.
