### PR TITLE
fix(project-groups): route rename and delete to the group's owning host

### DIFF
--- a/src/renderer/src/components/sidebar/project-group-header-dom.test.ts
+++ b/src/renderer/src/components/sidebar/project-group-header-dom.test.ts
@@ -30,7 +30,10 @@ describe('Project Group header drag DOM source', () => {
     const source = readHeaderDragSource()
 
     expect(source).toContain('const updateProjectGroup = useAppStore((s) => s.updateProjectGroup)')
-    expect(source).toContain('void updateProjectGroup(groupId, { tabOrder })')
+    // Why: the commit must carry the group's owner host so a non-focused host still persists the order.
+    expect(source).toContain(
+      'void updateProjectGroup(groupId, { tabOrder }, { hostId: ownerHostId ?? undefined })'
+    )
   })
 
   it('keeps grab cursor on the title surface and dual handle attrs on row + surface', () => {

--- a/src/renderer/src/components/sidebar/worktree-list/drag/use-header-drag.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/drag/use-header-drag.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo } from 'react'
 import type React from 'react'
 import { useAppStore } from '@/store'
+import { getProjectGroupHostId } from '@/store/slices/project-group-owner-routing'
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import type { ProjectOrderBy } from '../../../../../../shared/ui-chrome-types'
 import type { Repo } from '../../../../../../shared/repo-types'
@@ -83,6 +84,16 @@ export function useWorktreeSidebarHeaderDrag(args: {
     () => new Map(projectGroups.map((group) => [group.id, group])),
     [projectGroups]
   )
+  // Why: an id shared by two hosts has no single owner, so leave it unrouted rather than guess.
+  const projectGroupOwnerHostIdByGroupId = useMemo(() => {
+    const byGroupId = new Map<string, ExecutionHostId | null>()
+    for (const group of projectGroups) {
+      const hostId = getProjectGroupHostId(group)
+      const existing = byGroupId.get(group.id)
+      byGroupId.set(group.id, existing === undefined || existing === hostId ? hostId : null)
+    }
+    return byGroupId
+  }, [projectGroups])
 
   // Why: reorder keeps scrollTop stable; flag direct scroll input so anchor-restore won't chase the moved row (jumpy drop).
   const suppressScrollCorrectionForHeaderCommit = useCallback(() => {
@@ -157,9 +168,11 @@ export function useWorktreeSidebarHeaderDrag(args: {
         return
       }
       suppressScrollCorrectionForHeaderCommit()
-      void updateProjectGroup(groupId, { tabOrder })
+      // Why: manual order persists on the group's own host; the focused host may not hold this row.
+      const ownerHostId = projectGroupOwnerHostIdByGroupId.get(groupId)
+      void updateProjectGroup(groupId, { tabOrder }, { hostId: ownerHostId ?? undefined })
     },
-    [suppressScrollCorrectionForHeaderCommit, updateProjectGroup]
+    [projectGroupOwnerHostIdByGroupId, suppressScrollCorrectionForHeaderCommit, updateProjectGroup]
   )
   // Drag applies only in manual order; still construct the controller inert for stable hook order.
   const repoDrag = useRepoHeaderDrag({

--- a/src/renderer/src/components/sidebar/worktree-list/rows/SectionHeader.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/SectionHeader.tsx
@@ -8,6 +8,8 @@ import { RepoForkIndicator } from '@/components/repo/repo-fork-indicator'
 import type { FolderWorkspacePathStatus } from '../../../../../../shared/folder-workspace-path-status'
 import { isConfirmedStaleFolderPathStatus } from '../../../../../../shared/folder-workspace-path-status'
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
+import type { ExecutionHostId } from '../../../../../../shared/execution-host'
+import { getProjectGroupHostId } from '@/store/slices/project-group-owner-routing'
 import type {
   WorkspaceStatus,
   WorkspaceStatusDefinition
@@ -56,8 +58,8 @@ export type SectionHeaderRowContext = {
   }) => FolderWorkspacePathStatus | null
   toggleGroupWithScrollAnchor: (groupKey: string) => void
   projectActions: RepoHeaderProjectActions
-  onRenameProjectGroup: (groupId: string, currentName: string) => void
-  onDeleteProjectGroup: (groupId: string, groupName: string) => void
+  onRenameProjectGroup: (groupId: string, currentName: string, hostId?: ExecutionHostId) => void
+  onDeleteProjectGroup: (groupId: string, groupName: string, hostId?: ExecutionHostId) => void
   onCreateFolderWorkspace: (projectGroup: ProjectGroup) => void
   onWorkspaceStatusDragOver: (event: React.DragEvent, status: WorkspaceStatus) => void
   onWorkspaceStatusDragLeave: (event: React.DragEvent) => void
@@ -91,6 +93,11 @@ export function renderWorktreeSectionHeaderRow(args: {
   const projectGroupIdForHeader =
     isProjectGroupHeader && !row.repo && typeof row.projectGroup?.id === 'string'
       ? row.projectGroup.id
+      : undefined
+  // Why: rename/delete must route to the host that owns this row, not to whichever host has focus.
+  const projectGroupHostIdForHeader =
+    row.projectGroup && 'createdFrom' in row.projectGroup
+      ? getProjectGroupHostId(row.projectGroup)
       : undefined
   const repoHeaderIndex =
     projectIdForHeader !== undefined
@@ -353,6 +360,7 @@ export function renderWorktreeSectionHeaderRow(args: {
           {isProjectGroupHeader && !row.repo && projectGroupIdForHeader ? (
             <ProjectGroupHeaderMenu
               groupId={projectGroupIdForHeader}
+              hostId={projectGroupHostIdForHeader}
               label={row.label}
               onRename={ctx.onRenameProjectGroup}
               onDelete={ctx.onDeleteProjectGroup}

--- a/src/renderer/src/components/sidebar/worktree-list/rows/project-group-header-actions.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/project-group-header-actions.tsx
@@ -13,6 +13,7 @@ import { translate } from '@/i18n/i18n'
 import { getFolderWorkspacePathStatusDescription } from '@/lib/folder-workspace-path-status'
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import type { FolderWorkspacePathStatus } from '../../../../../../shared/folder-workspace-path-status'
+import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 import { REPO_HEADER_ACTION_BUTTON_CLASS } from '../../repo-header-action-button-class'
 import {
   handleRepoHeaderActionPointerDown,
@@ -22,14 +23,17 @@ import {
 
 export function ProjectGroupHeaderMenu({
   groupId,
+  hostId,
   label,
   onRename,
   onDelete
 }: {
   groupId: string
+  /** Owner host of the group row, so rename/delete route to the host that holds it. */
+  hostId?: ExecutionHostId
   label: string
-  onRename: (groupId: string, currentName: string) => void
-  onDelete: (groupId: string, groupName: string) => void
+  onRename: (groupId: string, currentName: string, hostId?: ExecutionHostId) => void
+  onDelete: (groupId: string, groupName: string, hostId?: ExecutionHostId) => void
 }): React.JSX.Element {
   return (
     <DropdownMenu modal={false}>
@@ -64,10 +68,10 @@ export function ProjectGroupHeaderMenu({
         onClick={stopRepoHeaderMenuEvent}
         onKeyDown={stopRepoHeaderMenuEvent}
       >
-        <DropdownMenuItem onSelect={() => onRename(groupId, label)}>
+        <DropdownMenuItem onSelect={() => onRename(groupId, label, hostId)}>
           {translate('auto.components.sidebar.WorktreeList.4d7b73658c', 'Rename group')}
         </DropdownMenuItem>
-        <DropdownMenuItem variant="destructive" onSelect={() => onDelete(groupId, label)}>
+        <DropdownMenuItem variant="destructive" onSelect={() => onDelete(groupId, label, hostId)}>
           {translate('auto.components.sidebar.WorktreeList.902115cdbe', 'Delete group')}
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/src/renderer/src/components/sidebar/worktree-list/rows/use-project-group-dialogs-owner-host.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/use-project-group-dialogs-owner-host.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useProjectGroupDialogs, type ProjectGroupDialogs } from './use-project-group-dialogs'
+import type { ProjectGroup } from '../../../../../../shared/project-group-types'
+
+const mocks = vi.hoisted(() => ({
+  moveProjectToGroup: vi.fn(),
+  createProjectGroup: vi.fn(),
+  updateProjectGroup: vi.fn(),
+  deleteProjectGroupWithContainedProjects: vi.fn(),
+  toastError: vi.fn()
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      moveProjectToGroup: mocks.moveProjectToGroup,
+      createProjectGroup: mocks.createProjectGroup,
+      updateProjectGroup: mocks.updateProjectGroup,
+      deleteProjectGroupWithContainedProjects: mocks.deleteProjectGroupWithContainedProjects
+    })
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: mocks.toastError }
+}))
+
+const remoteGroup: ProjectGroup = {
+  id: 'group-1',
+  name: 'Projects',
+  parentPath: '/srv/projects',
+  parentGroupId: null,
+  createdFrom: 'folder-scan',
+  executionHostId: 'runtime:env-1',
+  tabOrder: 0,
+  isCollapsed: false,
+  color: null,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+let latest: ProjectGroupDialogs | null = null
+const roots: Root[] = []
+
+function HookProbe(): null {
+  latest = useProjectGroupDialogs({
+    repos: [],
+    repoMap: new Map(),
+    projectGroups: [remoteGroup]
+  })
+  return null
+}
+
+async function renderHookProbe(): Promise<void> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  roots.push(root)
+  await act(async () => {
+    root.render(<HookProbe />)
+  })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.updateProjectGroup.mockResolvedValue(true)
+  mocks.deleteProjectGroupWithContainedProjects.mockResolvedValue({
+    status: 'deleted-group',
+    groupId: remoteGroup.id,
+    requestedProjectIds: [],
+    removedProjectIds: [],
+    failedProjectRemovals: []
+  })
+})
+
+afterEach(async () => {
+  await act(async () => {
+    for (const root of roots.splice(0)) {
+      root.unmount()
+    }
+  })
+  latest = null
+})
+
+describe('project group dialogs carry the owner host', () => {
+  it('renames through the host that owns the group row', async () => {
+    await renderHookProbe()
+    await act(async () => {
+      latest!.handleRenameProjectGroup(remoteGroup.id, remoteGroup.name, 'runtime:env-1')
+    })
+    await act(async () => {
+      await latest!.handleSubmitProjectGroupName('Renamed')
+    })
+
+    expect(mocks.updateProjectGroup).toHaveBeenCalledWith(
+      remoteGroup.id,
+      { name: 'Renamed' },
+      { hostId: 'runtime:env-1' }
+    )
+    expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a toast when the owner host does not apply the rename', async () => {
+    mocks.updateProjectGroup.mockResolvedValue(false)
+    await renderHookProbe()
+    await act(async () => {
+      latest!.handleRenameProjectGroup(remoteGroup.id, remoteGroup.name, 'runtime:env-1')
+    })
+    await act(async () => {
+      await latest!.handleSubmitProjectGroupName('Renamed')
+    })
+
+    expect(mocks.toastError).toHaveBeenCalledWith('Failed to rename group', {
+      description: "The group's host did not apply the new name."
+    })
+  })
+
+  it('deletes through the host that owns the group row', async () => {
+    await renderHookProbe()
+    await act(async () => {
+      latest!.handleDeleteProjectGroup(remoteGroup.id, remoteGroup.name, 'runtime:env-1')
+    })
+    await act(async () => {
+      await latest!.handleConfirmDeleteProjectGroup()
+    })
+
+    expect(mocks.deleteProjectGroupWithContainedProjects).toHaveBeenCalledWith(remoteGroup.id, {
+      removeContainedProjects: false,
+      hostId: 'runtime:env-1'
+    })
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list/rows/use-project-group-dialogs-owner-host.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/use-project-group-dialogs-owner-host.test.tsx
@@ -103,7 +103,7 @@ describe('project group dialogs carry the owner host', () => {
     expect(mocks.toastError).not.toHaveBeenCalled()
   })
 
-  it('surfaces a toast when the owner host does not apply the rename', async () => {
+  it('surfaces an unconfirmed-rename toast when the owner host does not answer', async () => {
     mocks.updateProjectGroup.mockResolvedValue(false)
     await renderHookProbe()
     await act(async () => {
@@ -114,7 +114,8 @@ describe('project group dialogs carry the owner host', () => {
     })
 
     expect(mocks.toastError).toHaveBeenCalledWith('Failed to rename group', {
-      description: "The group's host did not apply the new name."
+      description:
+        "Orca could not confirm the new name with the group's host. Recheck the group after reconnecting."
     })
   })
 

--- a/src/renderer/src/components/sidebar/worktree-list/rows/use-project-group-dialogs.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/use-project-group-dialogs.ts
@@ -5,15 +5,18 @@ import { translate } from '@/i18n/i18n'
 import { selectProjectGroupRemovalTargets } from '@/store/slices/project-group-removal-targets'
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import type { Repo } from '../../../../../../shared/repo-types'
+import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 
 export type ProjectGroupNameDialogState =
   | { type: 'create-from-repo'; repo: Repo }
-  | { type: 'rename'; groupId: string; currentName: string }
+  // hostId is the group row's owner host, so the mutation is not routed to whichever host has focus.
+  | { type: 'rename'; groupId: string; currentName: string; hostId?: ExecutionHostId }
 
 export type ProjectGroupDeleteDialogState = {
   groupId: string
   groupName: string
   removeContainedProjects: boolean
+  hostId?: ExecutionHostId
 }
 
 export type ProjectGroupDialogs = ReturnType<typeof useProjectGroupDialogs>
@@ -95,9 +98,12 @@ export function useProjectGroupDialogs(args: {
     [moveProjectToGroup]
   )
 
-  const handleRenameProjectGroup = useCallback((groupId: string, currentName: string) => {
-    setNameDialog({ type: 'rename', groupId, currentName })
-  }, [])
+  const handleRenameProjectGroup = useCallback(
+    (groupId: string, currentName: string, hostId?: ExecutionHostId) => {
+      setNameDialog({ type: 'rename', groupId, currentName, hostId })
+    },
+    []
+  )
 
   const handleSubmitProjectGroupName = useCallback(
     async (name: string) => {
@@ -111,7 +117,25 @@ export function useProjectGroupDialogs(args: {
         }
         return
       }
-      await updateProjectGroup(nameDialog.groupId, { name })
+      const renamed = await updateProjectGroup(
+        nameDialog.groupId,
+        { name },
+        { hostId: nameDialog.hostId }
+      )
+      if (!renamed) {
+        toast.error(
+          translate(
+            'auto.components.sidebar.WorktreeList.groupRenameFailed',
+            'Failed to rename group'
+          ),
+          {
+            description: translate(
+              'auto.components.sidebar.WorktreeList.groupRenameFailedDesc',
+              "The group's host did not apply the new name."
+            )
+          }
+        )
+      }
     },
     [createProjectGroup, moveProjectToGroup, nameDialog, updateProjectGroup]
   )
@@ -120,7 +144,12 @@ export function useProjectGroupDialogs(args: {
     if (!deleteDialog) {
       return null
     }
-    return selectProjectGroupRemovalTargets(projectGroups, repos, deleteDialog.groupId)
+    return selectProjectGroupRemovalTargets(
+      projectGroups,
+      repos,
+      deleteDialog.groupId,
+      deleteDialog.hostId
+    )
   }, [deleteDialog, projectGroups, repos])
   const deleteProjectCount = deleteTargets?.projectIds.length ?? 0
   const deleteProjectNames = useMemo(
@@ -133,9 +162,12 @@ export function useProjectGroupDialogs(args: {
   const removeContainedProjects =
     deleteProjectCount > 0 && deleteDialog?.removeContainedProjects === true
 
-  const handleDeleteProjectGroup = useCallback((groupId: string, groupName: string) => {
-    setDeleteDialog({ groupId, groupName, removeContainedProjects: false })
-  }, [])
+  const handleDeleteProjectGroup = useCallback(
+    (groupId: string, groupName: string, hostId?: ExecutionHostId) => {
+      setDeleteDialog({ groupId, groupName, removeContainedProjects: false, hostId })
+    },
+    []
+  )
 
   const handleConfirmDeleteProjectGroup = useCallback(async () => {
     if (!deleteDialog) {
@@ -144,7 +176,8 @@ export function useProjectGroupDialogs(args: {
     try {
       reportProjectGroupDeleteFailures(
         await deleteProjectGroupWithContainedProjects(deleteDialog.groupId, {
-          removeContainedProjects
+          removeContainedProjects,
+          hostId: deleteDialog.hostId
         })
       )
     } finally {

--- a/src/renderer/src/components/sidebar/worktree-list/rows/use-project-group-dialogs.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/use-project-group-dialogs.ts
@@ -131,7 +131,8 @@ export function useProjectGroupDialogs(args: {
           {
             description: translate(
               'auto.components.sidebar.WorktreeList.groupRenameFailedDesc',
-              "The group's host did not apply the new name."
+              // Why: a falsy result also covers RPC timeout/disconnect, so the copy must not assert the host refused.
+              "Orca could not confirm the new name with the group's host. Recheck the group after reconnecting."
             )
           }
         )

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/viewport-props.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/viewport-props.ts
@@ -47,8 +47,8 @@ export type VirtualizedWorktreeViewportProps = {
   handleCreateGroupFromRepo: (repo: Repo) => void
   handleMoveProjectToGroup: (repo: Repo, groupId: string) => void
   handleRemoveProjectFromGroup: (repo: Repo) => void
-  handleRenameProjectGroup: (groupId: string, currentName: string) => void
-  handleDeleteProjectGroup: (groupId: string, groupName: string) => void
+  handleRenameProjectGroup: (groupId: string, currentName: string, hostId?: ExecutionHostId) => void
+  handleDeleteProjectGroup: (groupId: string, groupName: string, hostId?: ExecutionHostId) => void
   handleCreateFolderWorkspace: (projectGroup: ProjectGroup) => void
   activeModal: string
   pendingRevealWorktree: PendingSidebarWorktreeReveal | null

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5334,7 +5334,7 @@
           "groupDeleteFailed": "Failed to delete group",
           "groupDeleteFailedDesc": "Something went wrong while deleting the group. No projects were removed.",
           "groupRenameFailed": "Failed to rename group",
-          "groupRenameFailedDesc": "The group's host did not apply the new name.",
+          "groupRenameFailedDesc": "Orca could not confirm the new name with the group's host. Recheck the group after reconnecting.",
           "failedNestWorkspace": "Failed to nest workspace",
           "sidebarRowMissing": "Target no longer exists",
           "failedUnnestWorkspace": "Failed to unnest workspace"

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5333,6 +5333,8 @@
           "f94466bc39": "{{value0}} of {{value1}} contained project{{value2}} remained after deleting the group.",
           "groupDeleteFailed": "Failed to delete group",
           "groupDeleteFailedDesc": "Something went wrong while deleting the group. No projects were removed.",
+          "groupRenameFailed": "Failed to rename group",
+          "groupRenameFailedDesc": "The group's host did not apply the new name.",
           "failedNestWorkspace": "Failed to nest workspace",
           "sidebarRowMissing": "Target no longer exists",
           "failedUnnestWorkspace": "Failed to unnest workspace"

--- a/src/renderer/src/store/slices/project-group-owner-routing.ts
+++ b/src/renderer/src/store/slices/project-group-owner-routing.ts
@@ -1,0 +1,94 @@
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import type { ProjectGroup } from '../../../../shared/project-group-types'
+import {
+  LOCAL_EXECUTION_HOST_ID,
+  normalizeExecutionHostId,
+  parseExecutionHostId,
+  toSshExecutionHostId,
+  type ExecutionHostId
+} from '../../../../shared/execution-host'
+import { findIndexedProjectGroupOwner } from '@/lib/worktree-runtime-owner-index'
+
+type ProjectGroupHostParts = Pick<ProjectGroup, 'connectionId' | 'executionHostId'>
+type ProjectGroupOwnerRecord = Pick<ProjectGroup, 'id' | 'connectionId' | 'executionHostId'>
+type RoutingSettings = Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
+
+type ProjectGroupOwnerRoutingState = {
+  projectGroups: readonly ProjectGroupOwnerRecord[]
+  settings: RoutingSettings
+}
+
+// Why: persisted rows predate host stamping and may carry padded/unparseable ids; normalize so
+// routing and catalog identity agree on the same owner host.
+export function getProjectGroupHostId(group: ProjectGroupHostParts): ExecutionHostId {
+  const executionHostId = normalizeExecutionHostId(group.executionHostId)
+  if (executionHostId) {
+    return executionHostId
+  }
+  const connectionId = group.connectionId?.trim()
+  return connectionId ? toSshExecutionHostId(connectionId) : LOCAL_EXECUTION_HOST_ID
+}
+
+export function catalogOwnsHost(catalogHostId: string, rowHostId: string): boolean {
+  if (catalogHostId !== LOCAL_EXECUTION_HOST_ID) {
+    return catalogHostId === rowHostId
+  }
+  return parseExecutionHostId(rowHostId)?.kind !== 'runtime'
+}
+
+export function projectGroupMatchesOwnerHost(
+  group: ProjectGroupOwnerRecord,
+  groupId: string,
+  ownerHostId: ExecutionHostId | null
+): boolean {
+  if (group.id !== groupId) {
+    return false
+  }
+  return ownerHostId ? catalogOwnsHost(ownerHostId, getProjectGroupHostId(group)) : true
+}
+
+export function resolveProjectGroupOwnerHostId(
+  state: ProjectGroupOwnerRoutingState,
+  groupId: string,
+  hostId?: ExecutionHostId
+): ExecutionHostId | null {
+  const owner = findIndexedProjectGroupOwner(state.projectGroups, groupId, hostId)
+  if (!owner) {
+    return null
+  }
+  if (hostId) {
+    return hostId
+  }
+  // Why: an unstamped row carries no owner, so keep the focused-host behavior instead of assuming local.
+  if (!owner.executionHostId && !owner.connectionId) {
+    return null
+  }
+  return getProjectGroupHostId(owner)
+}
+
+// Why: the sidebar lists groups from every host, so mutations must route to the row's owner
+// instead of whichever host currently has focus. Mirrors settingsForRepoOwner.
+export function settingsForProjectGroupOwner(
+  state: ProjectGroupOwnerRoutingState,
+  groupId: string,
+  hostId?: ExecutionHostId
+): RoutingSettings {
+  const ownerHostId = resolveProjectGroupOwnerHostId(state, groupId, hostId)
+  if (!ownerHostId) {
+    return state.settings
+  }
+  const parsed = parseExecutionHostId(ownerHostId)
+  if (parsed?.kind === 'runtime') {
+    return state.settings
+      ? { ...state.settings, activeRuntimeEnvironmentId: parsed.environmentId }
+      : { activeRuntimeEnvironmentId: parsed.environmentId }
+  }
+  // Why: direct-SSH groups live in the local main process catalog, so they route through window.api.
+  if (
+    (parsed?.kind === 'local' || parsed?.kind === 'ssh') &&
+    state.settings?.activeRuntimeEnvironmentId
+  ) {
+    return { ...state.settings, activeRuntimeEnvironmentId: null }
+  }
+  return state.settings
+}

--- a/src/renderer/src/store/slices/project-group-removal-targets.ts
+++ b/src/renderer/src/store/slices/project-group-removal-targets.ts
@@ -1,6 +1,8 @@
 import type { ProjectGroup } from '../../../../shared/project-group-types'
 import type { Repo } from '../../../../shared/repo-types'
 import { getProjectGroupSubtreeIds } from '../../../../shared/project-groups'
+import { getRepoExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
+import { catalogOwnsHost, getProjectGroupHostId } from './project-group-owner-routing'
 
 export type ProjectGroupRemovalTargets = {
   groupExists: boolean
@@ -11,9 +13,16 @@ export type ProjectGroupRemovalTargets = {
 export function selectProjectGroupRemovalTargets(
   projectGroups: readonly ProjectGroup[],
   repos: readonly Repo[],
-  groupId: string
+  groupId: string,
+  // Why: ids repeat across hosts; without an owner host the caller would target another host's rows.
+  hostId?: ExecutionHostId | null
 ): ProjectGroupRemovalTargets {
-  const groupExists = projectGroups.some((group) => group.id === groupId)
+  const ownsRowHost = (rowHostId: string): boolean =>
+    hostId ? catalogOwnsHost(hostId, rowHostId) : true
+  const ownerGroups = hostId
+    ? projectGroups.filter((group) => ownsRowHost(getProjectGroupHostId(group)))
+    : projectGroups
+  const groupExists = ownerGroups.some((group) => group.id === groupId)
   if (!groupExists) {
     return {
       groupExists: false,
@@ -22,10 +31,14 @@ export function selectProjectGroupRemovalTargets(
     }
   }
 
-  const deletedGroupIds = getProjectGroupSubtreeIds(projectGroups, groupId)
+  const deletedGroupIds = getProjectGroupSubtreeIds(ownerGroups, groupId)
   const projectIds: string[] = []
   for (const repo of repos) {
-    if (repo.projectGroupId && deletedGroupIds.has(repo.projectGroupId)) {
+    if (
+      repo.projectGroupId &&
+      deletedGroupIds.has(repo.projectGroupId) &&
+      ownsRowHost(getRepoExecutionHostId(repo))
+    ) {
       projectIds.push(repo.id)
     }
   }

--- a/src/renderer/src/store/slices/repos-project-groups-owner-routing.test.ts
+++ b/src/renderer/src/store/slices/repos-project-groups-owner-routing.test.ts
@@ -1,0 +1,303 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
+import type { ProjectGroup } from '../../../../shared/project-group-types'
+import type { Repo } from '../../../../shared/repo-types'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from '../../runtime/runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+import { createTestStore } from './store-test-helpers'
+
+const folderScanGroup: ProjectGroup = {
+  id: 'group-1',
+  name: 'Projects',
+  parentPath: '/srv/projects',
+  parentGroupId: null,
+  createdFrom: 'folder-scan',
+  tabOrder: 0,
+  isCollapsed: false,
+  color: null,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+const baseRepo: Repo = {
+  id: 'repo',
+  path: '/repo',
+  displayName: 'Repo',
+  badgeColor: '#111',
+  addedAt: 1
+}
+
+const baseFolderWorkspace: FolderWorkspace = {
+  id: 'folder-workspace-1',
+  projectGroupId: folderScanGroup.id,
+  name: 'Notes',
+  folderPath: '/srv/projects/notes',
+  linkedTask: null,
+  comment: '',
+  isArchived: false,
+  isUnread: false,
+  isPinned: false,
+  sortOrder: 1,
+  lastActivityAt: 0,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+const projectGroupsUpdate = vi.fn()
+const projectGroupsDelete = vi.fn()
+const runtimeEnvironmentCall = vi.fn()
+const runtimeEnvironmentTransportCall = vi.fn()
+
+beforeEach(() => {
+  clearRuntimeCompatibilityCacheForTests()
+  vi.clearAllMocks()
+  projectGroupsUpdate.mockResolvedValue(null)
+  projectGroupsDelete.mockResolvedValue(false)
+  runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+    return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
+  })
+  vi.stubGlobal('window', {
+    api: {
+      repos: { remove: vi.fn() },
+      projectGroups: { update: projectGroupsUpdate, delete: projectGroupsDelete },
+      runtimeEnvironments: { call: runtimeEnvironmentTransportCall }
+    }
+  })
+})
+
+function runtimeRpcResponse(result: unknown) {
+  return { id: 'rpc-1', ok: true, result, _meta: { runtimeId: 'runtime-remote' } }
+}
+
+describe('project group mutations route to the owning host', () => {
+  it('renames a runtime-owned folder-scan group while the local host is focused', async () => {
+    const runtimeGroup: ProjectGroup = { ...folderScanGroup, executionHostId: 'runtime:env-1' }
+    runtimeEnvironmentCall.mockResolvedValue(
+      runtimeRpcResponse({ group: { ...runtimeGroup, name: 'Renamed' } })
+    )
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: null } as never,
+      projectGroups: [runtimeGroup]
+    })
+
+    await expect(
+      store.getState().updateProjectGroup(runtimeGroup.id, { name: 'Renamed' })
+    ).resolves.toBe(true)
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'projectGroup.update',
+      params: { groupId: runtimeGroup.id, updates: { name: 'Renamed' } },
+      timeoutMs: 15_000
+    })
+    expect(projectGroupsUpdate).not.toHaveBeenCalled()
+    expect(store.getState().projectGroups[0]).toMatchObject({
+      name: 'Renamed',
+      executionHostId: 'runtime:env-1'
+    })
+  })
+
+  it('deletes a local folder-scan group while a runtime host is focused', async () => {
+    projectGroupsDelete.mockResolvedValue(true)
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      projectGroups: [{ ...folderScanGroup, executionHostId: 'local' }]
+    })
+
+    await expect(store.getState().deleteProjectGroup(folderScanGroup.id)).resolves.toBe(true)
+
+    expect(projectGroupsDelete).toHaveBeenCalledWith({ groupId: folderScanGroup.id })
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
+    expect(store.getState().projectGroups).toEqual([])
+  })
+
+  it('routes a direct-SSH group through the local catalog, not the focused runtime', async () => {
+    projectGroupsDelete.mockResolvedValue(true)
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      projectGroups: [{ ...folderScanGroup, connectionId: 'conn-1' }]
+    })
+
+    await expect(store.getState().deleteProjectGroup(folderScanGroup.id)).resolves.toBe(true)
+
+    expect(projectGroupsDelete).toHaveBeenCalledWith({ groupId: folderScanGroup.id })
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
+  })
+
+  it('prefers an explicit hostId over both the focused host and a colliding row', async () => {
+    runtimeEnvironmentCall.mockResolvedValue(runtimeRpcResponse({ deleted: true }))
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: null } as never,
+      projectGroups: [
+        { ...folderScanGroup, executionHostId: 'local' },
+        { ...folderScanGroup, executionHostId: 'runtime:env-1' }
+      ]
+    })
+
+    await expect(
+      store.getState().deleteProjectGroup(folderScanGroup.id, { hostId: 'runtime:env-1' })
+    ).resolves.toBe(true)
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'projectGroup.delete',
+      params: { groupId: folderScanGroup.id },
+      timeoutMs: 15_000
+    })
+    expect(projectGroupsDelete).not.toHaveBeenCalled()
+    expect(store.getState().projectGroups).toMatchObject([{ executionHostId: 'local' }])
+  })
+
+  it('keeps the focused host when a colliding id has no unambiguous owner', async () => {
+    projectGroupsDelete.mockResolvedValue(true)
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: null } as never,
+      projectGroups: [
+        { ...folderScanGroup, executionHostId: 'local' },
+        { ...folderScanGroup, executionHostId: 'runtime:env-1' }
+      ]
+    })
+
+    await expect(store.getState().deleteProjectGroup(folderScanGroup.id)).resolves.toBe(true)
+
+    expect(projectGroupsDelete).toHaveBeenCalledWith({ groupId: folderScanGroup.id })
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
+  })
+})
+
+describe('project group state cascades stay scoped to the owner host', () => {
+  it('leaves another host rows intact when deleting a colliding local group', async () => {
+    projectGroupsDelete.mockResolvedValue(true)
+    const runtimeChild: ProjectGroup = {
+      ...folderScanGroup,
+      id: 'child',
+      parentGroupId: folderScanGroup.id,
+      executionHostId: 'runtime:env-1'
+    }
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: null } as never,
+      projectGroups: [
+        { ...folderScanGroup, executionHostId: 'local' },
+        { ...folderScanGroup, name: 'Remote projects', executionHostId: 'runtime:env-1' },
+        runtimeChild
+      ],
+      folderWorkspaces: [
+        { ...baseFolderWorkspace, executionHostId: 'local' },
+        {
+          ...baseFolderWorkspace,
+          id: 'folder-workspace-remote',
+          executionHostId: 'runtime:env-1'
+        }
+      ],
+      repos: [
+        { ...baseRepo, id: 'local-repo', projectGroupId: folderScanGroup.id },
+        {
+          ...baseRepo,
+          id: 'remote-repo',
+          projectGroupId: folderScanGroup.id,
+          executionHostId: 'runtime:env-1'
+        }
+      ]
+    })
+
+    await expect(
+      store.getState().deleteProjectGroup(folderScanGroup.id, { hostId: 'local' })
+    ).resolves.toBe(true)
+
+    expect(store.getState().projectGroups).toMatchObject([
+      { id: folderScanGroup.id, executionHostId: 'runtime:env-1' },
+      { id: 'child', executionHostId: 'runtime:env-1' }
+    ])
+    expect(store.getState().folderWorkspaces.map((workspace) => workspace.id)).toEqual([
+      'folder-workspace-remote'
+    ])
+    expect(store.getState().repos).toMatchObject([
+      { id: 'local-repo', projectGroupId: null },
+      { id: 'remote-repo', projectGroupId: folderScanGroup.id }
+    ])
+  })
+
+  it('renames only the owner host row when the id exists on two hosts', async () => {
+    projectGroupsUpdate.mockResolvedValue({
+      ...folderScanGroup,
+      executionHostId: 'local',
+      name: 'Renamed'
+    })
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: null } as never,
+      projectGroups: [
+        { ...folderScanGroup, executionHostId: 'local' },
+        { ...folderScanGroup, name: 'Remote projects', executionHostId: 'runtime:env-1' }
+      ]
+    })
+
+    await expect(
+      store.getState().updateProjectGroup(
+        folderScanGroup.id,
+        { name: 'Renamed' },
+        {
+          hostId: 'local'
+        }
+      )
+    ).resolves.toBe(true)
+
+    expect(store.getState().projectGroups).toMatchObject([
+      { name: 'Renamed', executionHostId: 'local' },
+      { name: 'Remote projects', executionHostId: 'runtime:env-1' }
+    ])
+  })
+
+  it('removes contained projects only from the owner host', async () => {
+    projectGroupsDelete.mockResolvedValue(true)
+    const reposRemove = vi.fn().mockResolvedValue(undefined)
+    const reposRemoveForHost = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('window', {
+      api: {
+        repos: { remove: reposRemove, removeForHost: reposRemoveForHost },
+        projectGroups: { update: projectGroupsUpdate, delete: projectGroupsDelete },
+        runtimeEnvironments: { call: runtimeEnvironmentTransportCall }
+      }
+    })
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: null } as never,
+      projectGroups: [
+        { ...folderScanGroup, executionHostId: 'local' },
+        { ...folderScanGroup, executionHostId: 'runtime:env-1' }
+      ],
+      repos: [
+        { ...baseRepo, id: 'local-repo', projectGroupId: folderScanGroup.id },
+        {
+          ...baseRepo,
+          id: 'remote-repo',
+          projectGroupId: folderScanGroup.id,
+          executionHostId: 'runtime:env-1'
+        }
+      ]
+    })
+
+    const result = await store
+      .getState()
+      .deleteProjectGroupWithContainedProjects(folderScanGroup.id, {
+        removeContainedProjects: true,
+        hostId: 'local'
+      })
+
+    expect(result).toMatchObject({
+      status: 'deleted-group',
+      requestedProjectIds: ['local-repo'],
+      removedProjectIds: ['local-repo']
+    })
+    expect(store.getState().repos.map((repo) => repo.id)).toEqual(['remote-repo'])
+  })
+})

--- a/src/renderer/src/store/slices/repos-project-groups-owner-routing.test.ts
+++ b/src/renderer/src/store/slices/repos-project-groups-owner-routing.test.ts
@@ -171,6 +171,27 @@ describe('project group mutations route to the owning host', () => {
     expect(projectGroupsDelete).toHaveBeenCalledWith({ groupId: folderScanGroup.id })
     expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
   })
+
+  // Why: a lost connection is unverifiable, not a refusal - the failure toast copy must stay non-asserting.
+  it('reports an unreachable owner as failure without touching local state', async () => {
+    const runtimeGroup: ProjectGroup = { ...folderScanGroup, executionHostId: 'runtime:env-1' }
+    runtimeEnvironmentCall.mockRejectedValue(new Error('runtime rpc timed out'))
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: null } as never,
+      projectGroups: [runtimeGroup],
+      folderWorkspaces: [baseFolderWorkspace]
+    })
+
+    await expect(
+      store.getState().updateProjectGroup(runtimeGroup.id, { name: 'Renamed' })
+    ).resolves.toBe(false)
+    await expect(store.getState().deleteProjectGroup(runtimeGroup.id)).resolves.toBe(false)
+
+    expect(projectGroupsUpdate).not.toHaveBeenCalled()
+    expect(store.getState().projectGroups).toEqual([runtimeGroup])
+    expect(store.getState().folderWorkspaces).toEqual([baseFolderWorkspace])
+  })
 })
 
 describe('project group state cascades stay scoped to the owner host', () => {

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -52,6 +52,13 @@ import { isPathInsideOrEqual } from '../../../../shared/cross-platform-path'
 import { getRepoIdFromWorktreeId } from '../../../../shared/worktree/id'
 import { structuralValuesEqual } from '../../../../shared/structural-value-equality'
 import { selectProjectGroupRemovalTargets } from './project-group-removal-targets'
+import {
+  catalogOwnsHost,
+  getProjectGroupHostId,
+  projectGroupMatchesOwnerHost,
+  resolveProjectGroupOwnerHostId,
+  settingsForProjectGroupOwner
+} from './project-group-owner-routing'
 import { reconcileCatalogRows, reconcileFetchedRepos } from './repo-identity-reconcile'
 import { retainValidFilterRepoIds } from './repo-filter-selection'
 import { readRuntimeWorktreeVisibilitySnapshot } from './worktree-visibility-owner-settings'
@@ -218,6 +225,8 @@ export type FolderWorkspacePathStatusCacheEntry = {
 
 export type DeleteProjectGroupWithContainedProjectsOptions = {
   removeContainedProjects: boolean
+  // hostId disambiguates which host's group row to delete when the id exists on multiple hosts.
+  hostId?: ExecutionHostId
 }
 
 type AllHostCatalogFetchOptions = {
@@ -1120,22 +1129,8 @@ function mergeProjectCompatibilityForHostRepoChange({
   })
 }
 
-function getProjectGroupHostId(group: Pick<ProjectGroup, 'connectionId' | 'executionHostId'>) {
-  if (group.executionHostId) {
-    return group.executionHostId
-  }
-  return group.connectionId ? toSshExecutionHostId(group.connectionId) : LOCAL_EXECUTION_HOST_ID
-}
-
 function getProjectGroupHostIdentity(group: ProjectGroup): string {
   return JSON.stringify([getProjectGroupHostId(group), group.id])
-}
-
-function catalogOwnsHost(catalogHostId: string, rowHostId: string): boolean {
-  if (catalogHostId !== LOCAL_EXECUTION_HOST_ID) {
-    return catalogHostId === rowHostId
-  }
-  return parseExecutionHostId(rowHostId)?.kind !== 'runtime'
 }
 
 function mergeFetchedProjectGroupsForHost(
@@ -1184,6 +1179,37 @@ function getFolderWorkspaceHostIdentity(
   projectGroups: readonly ProjectGroup[]
 ): string {
   return JSON.stringify([getFolderWorkspaceHostId(workspace, projectGroups), workspace.id])
+}
+
+// Why: a group id can exist on several hosts; only the deleted owner's rows may be cascaded away.
+function applyProjectGroupDeleteCascade(
+  s: Pick<RepoSlice, 'projectGroups' | 'folderWorkspaces' | 'repos'>,
+  groupId: string,
+  ownerHostId: ExecutionHostId | null
+): Pick<RepoSlice, 'projectGroups' | 'folderWorkspaces' | 'repos' | 'folderWorkspacePathStatuses'> {
+  const ownsRowHost = (rowHostId: string): boolean =>
+    ownerHostId ? catalogOwnsHost(ownerHostId, rowHostId) : true
+  const ownerGroups = s.projectGroups.filter((group) => ownsRowHost(getProjectGroupHostId(group)))
+  const deletedGroupIds = getProjectGroupSubtreeIds(ownerGroups, groupId)
+  const isDeletedGroup = (group: ProjectGroup): boolean =>
+    deletedGroupIds.has(group.id) && ownsRowHost(getProjectGroupHostId(group))
+  return {
+    projectGroups: s.projectGroups.filter((group) => !isDeletedGroup(group)),
+    folderWorkspaces: s.folderWorkspaces.filter(
+      (workspace) =>
+        !deletedGroupIds.has(workspace.projectGroupId) ||
+        // Why: resolve the workspace's host against the pre-delete group list, which still holds its owner row.
+        !ownsRowHost(getFolderWorkspaceHostId(workspace, s.projectGroups))
+    ),
+    repos: s.repos.map((repo) =>
+      repo.projectGroupId &&
+      deletedGroupIds.has(repo.projectGroupId) &&
+      ownsRowHost(getRepoExecutionHostId(repo))
+        ? { ...repo, projectGroupId: null }
+        : repo
+    ),
+    folderWorkspacePathStatuses: {}
+  }
 }
 
 function getFolderWorkspaceUpdateIdentity(
@@ -1883,11 +1909,13 @@ export type RepoSlice = {
     options?: { executionHostId?: ExecutionHostId }
   ) => Promise<boolean>
   deleteFolderWorkspace: (folderWorkspaceId: string) => Promise<boolean>
+  // options.hostId targets a specific host's row + RPC target when the id exists on multiple hosts; else the group's own host owns the call.
   updateProjectGroup: (
     groupId: string,
-    updates: Partial<Pick<ProjectGroup, 'name' | 'isCollapsed' | 'tabOrder' | 'color'>>
+    updates: Partial<Pick<ProjectGroup, 'name' | 'isCollapsed' | 'tabOrder' | 'color'>>,
+    options?: { hostId?: ExecutionHostId }
   ) => Promise<boolean>
-  deleteProjectGroup: (groupId: string) => Promise<boolean>
+  deleteProjectGroup: (groupId: string, options?: { hostId?: ExecutionHostId }) => Promise<boolean>
   deleteProjectGroupWithContainedProjects: (
     groupId: string,
     options: DeleteProjectGroupWithContainedProjectsOptions
@@ -2990,10 +3018,13 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     }
   },
 
-  updateProjectGroup: async (groupId, updates) => {
+  updateProjectGroup: async (groupId, updates, options) => {
     try {
-      // Why: project groups are focused-host-scoped by design; all CRUD routes by the focused host and the list is replaced, not merged.
-      const target = getActiveRuntimeTarget(get().settings)
+      // Why: the sidebar lists groups from every host, so the mutation follows the group's owner, not the focused host.
+      const ownerHostId = resolveProjectGroupOwnerHostId(get(), groupId, options?.hostId)
+      const target = getActiveRuntimeTarget(
+        settingsForProjectGroupOwner(get(), groupId, options?.hostId)
+      )
       const updated =
         target.kind === 'local'
           ? await window.api.projectGroups.update({ groupId, updates })
@@ -3010,7 +3041,9 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       }
       const ownedGroup = projectGroupWithFetchedOwner(updated, target)
       set((s) => ({
-        projectGroups: s.projectGroups.map((group) => (group.id === groupId ? ownedGroup : group)),
+        projectGroups: s.projectGroups.map((group) =>
+          projectGroupMatchesOwnerHost(group, groupId, ownerHostId) ? ownedGroup : group
+        ),
         folderWorkspacePathStatuses: {}
       }))
       return true
@@ -3020,10 +3053,13 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     }
   },
 
-  deleteProjectGroup: async (groupId) => {
+  deleteProjectGroup: async (groupId, options) => {
     try {
-      // Why: project groups are focused-host-scoped by design (see updateProjectGroup).
-      const target = getActiveRuntimeTarget(get().settings)
+      // Why: deletion targets the group's owner host (see updateProjectGroup); focus may be elsewhere.
+      const ownerHostId = resolveProjectGroupOwnerHostId(get(), groupId, options?.hostId)
+      const target = getActiveRuntimeTarget(
+        settingsForProjectGroupOwner(get(), groupId, options?.hostId)
+      )
       const deleted =
         target.kind === 'local'
           ? await window.api.projectGroups.delete({ groupId })
@@ -3038,21 +3074,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       if (!deleted) {
         return false
       }
-      set((s) => {
-        const deletedGroupIds = getProjectGroupSubtreeIds(s.projectGroups, groupId)
-        return {
-          projectGroups: s.projectGroups.filter((group) => !deletedGroupIds.has(group.id)),
-          folderWorkspaces: s.folderWorkspaces.filter(
-            (workspace) => !deletedGroupIds.has(workspace.projectGroupId)
-          ),
-          repos: s.repos.map((repo) =>
-            repo.projectGroupId && deletedGroupIds.has(repo.projectGroupId)
-              ? { ...repo, projectGroupId: null }
-              : repo
-          ),
-          folderWorkspacePathStatuses: {}
-        }
-      })
+      set((s) => applyProjectGroupDeleteCascade(s, groupId, ownerHostId))
       return true
     } catch (err) {
       console.error('Failed to delete project group:', err)
@@ -3061,7 +3083,13 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
   },
 
   deleteProjectGroupWithContainedProjects: async (groupId, options) => {
-    const targets = selectProjectGroupRemovalTargets(get().projectGroups, get().repos, groupId)
+    const ownerHostId = resolveProjectGroupOwnerHostId(get(), groupId, options.hostId)
+    const targets = selectProjectGroupRemovalTargets(
+      get().projectGroups,
+      get().repos,
+      groupId,
+      ownerHostId
+    )
     const requestedProjectIds = options.removeContainedProjects ? targets.projectIds : []
     if (!targets.groupExists) {
       return {
@@ -3073,7 +3101,9 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       }
     }
 
-    const deleted = await get().deleteProjectGroup(groupId)
+    const deleted = await get().deleteProjectGroup(groupId, {
+      hostId: ownerHostId ?? undefined
+    })
     if (!deleted) {
       return {
         status: 'group-delete-failed',
@@ -3096,16 +3126,26 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
 
     const removedProjectIds: string[] = []
     const failedProjectRemovals: ProjectRemovalFailure[] = []
+    // Why: the group's catalog can hold rows from several hosts (a local catalog also owns SSH rows),
+    // so each project is removed on its own host rather than on the group's.
+    const findOwnedProjects = (projectId: string): Repo[] =>
+      get().repos.filter(
+        (repo) =>
+          repo.id === projectId &&
+          (!ownerHostId || catalogOwnsHost(ownerHostId, getRepoExecutionHostId(repo)))
+      )
     for (const projectId of targets.projectIds) {
-      const existedBeforeRemoval = get().repos.some((repo) => repo.id === projectId)
+      const ownedProjects = findOwnedProjects(projectId)
+      const projectHostId =
+        ownedProjects.length === 1 ? getRepoExecutionHostId(ownedProjects[0]) : undefined
       try {
-        if (existedBeforeRemoval) {
-          await get().removeProject(projectId)
+        if (ownedProjects.length > 0) {
+          await get().removeProject(projectId, { hostId: projectHostId })
         }
       } catch (err) {
         console.error('Failed to remove contained project:', err)
       }
-      const stillExists = get().repos.some((repo) => repo.id === projectId)
+      const stillExists = findOwnedProjects(projectId).length > 0
       if (stillExists) {
         failedProjectRemovals.push({
           projectId,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​464 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​463 |
| Prod | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​276 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​68 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​208 |

<!-- /orca-pr-loc -->

## ELI5

If you have Orca connected to more than one machine (say your desktop plus a Linux box running `orca serve`), the sidebar shows the project groups from **all** of them in one list. But when you hit "Rename group" or "Delete group", Orca sent that request to whichever machine you happened to have focused at that moment — not to the machine that actually owns the group. The other machine says "I don't have that group", so the rename quietly did nothing and the delete popped an error. Folder-scan groups got hit the hardest, because they are the one kind of group you can create on a machine other than the focused one. This PR makes rename/delete/reorder go to the machine that owns the group.

## What Changed

- New `src/renderer/src/store/slices/project-group-owner-routing.ts`: `getProjectGroupHostId`, `catalogOwnsHost` (moved out of `repos.ts`, which is already 4k lines), plus `resolveProjectGroupOwnerHostId` / `settingsForProjectGroupOwner` / `projectGroupMatchesOwnerHost`. `settingsForProjectGroupOwner` is a structural mirror of the existing `settingsForRepoOwner`, and owner lookup reuses the existing WeakMap-cached `findIndexedProjectGroupOwner`, which already fails closed (`ambiguous`) on cross-host id collisions.
- `repos.ts`: `updateProjectGroup` and `deleteProjectGroup` take an optional `{ hostId }` (same convention as `updateRepo` / `removeProject`) and route with `getActiveRuntimeTarget(settingsForProjectGroupOwner(...))` instead of `getActiveRuntimeTarget(get().settings)`.
- `repos.ts`: the post-mutation state reconciliation is now owner-scoped. The rename `set` replaces only the owner row instead of every host's row with that id; the delete cascade (`applyProjectGroupDeleteCascade`) computes the subtree over the owner-host slice and scopes group / folder-workspace / repo updates by host.
- `deleteProjectGroupWithContainedProjects` resolves the owner once and threads it into `selectProjectGroupRemovalTargets`, `deleteProjectGroup`, and `removeProject` (each contained project is removed on its own host, since a local catalog also holds SSH rows).
- Sidebar: the group row's owner host is carried through `ProjectGroupHeaderMenu` -> `handleRenameProjectGroup` / `handleDeleteProjectGroup` -> dialog state -> store, so the owner is known rather than guessed. Manual header reorder (`updateProjectGroup(..., { tabOrder })`) carries it too, and declines to guess when an id exists on two hosts.
- The rename result is no longer discarded: a failed rename now raises a toast (`groupRenameFailed` / `groupRenameFailedDesc` added to `en.json`; `translate()` defaults cover the other locales until translated). The copy is deliberately non-asserting — `updateProjectGroup` returns `false` both when the host answered "no such group" and when the RPC threw or timed out, so the toast says Orca *could not confirm* the new name rather than claiming the host refused it (`docs/reference/ssh-execution-boundary.md`: loss of contact is `unverifiable`, never a positive negative).

## Why

Root cause is a read/write host asymmetry in the renderer store, not anything specific to `createdFrom: 'folder-scan'`. The sidebar reads groups from every host — `fetchProjectGroupsForAllHosts` merges rows keyed by `[executionHostId, groupId]` — but `updateProjectGroup` and `deleteProjectGroup` threw the owner away and routed by `getActiveRuntimeTarget(get().settings)`, the focused runtime. When the focused host does not hold the group, the main-process op returns `null` / `false`; the rename dialog discarded that boolean (silent no-op) and delete surfaced `groupDeleteFailed`. Folder-scan groups are the visible victims because `importNestedRepos` is the only creation path that routes to an explicitly selected host, so their owner routinely differs from the focus — exactly the reporter's Windows desktop + Linux `orca serve` setup.

Two follow-on defects made renderer state wrong even when the RPC succeeded: the post-update `map` overwrote every host's row sharing the id (stamping them with the owner's `executionHostId`), and the post-delete cascade computed the subtree across all hosts, so deleting a local group could strip another host's group, its folder workspaces, and its repos' `projectGroupId`. Both are fixed here.

Unstamped legacy rows (no `executionHostId`, no `connectionId`) intentionally keep today's focused-host behavior rather than being assumed local, matching `settingsForRepoOwner`.

## Linked Issue

Fixes #14007

## Visual Proof

N/A — no pixels change. Every rendered element, class, and label is identical; only the destination host of an already-existing IPC/RPC call changes, plus one new error toast on a path that previously failed silently.

Checked by hand on two machines (see Testing): with a Linux `orca serve` host paired as a runtime environment, a folder was imported as a project group onto that host and the group header's "..." menu was driven from the macOS client while local had focus. Before: rename closed with no change, delete showed "Failed to delete group". After: both applied on the owning host.

## Testing

Ran on **macOS only** (Darwin 25.3.0). Linux/Windows coverage is by reasoning: this change is renderer store + sidebar callbacks with no `metaKey`, no path separators, and no OS branches.

```
npx vitest run --config config/vitest.config.ts \
  src/renderer/src/store/slices/repos-project-groups-owner-routing.test.ts \
  src/renderer/src/store/slices/repos-project-groups-delete.test.ts \
  src/renderer/src/store/slices/repos-project-groups.test.ts \
  src/renderer/src/store/slices/repos-selected-owner-routing.test.ts \
  src/renderer/src/store/slices/project-group-removal-targets.test.ts \
  src/renderer/src/components/sidebar/worktree-list/rows/use-project-group-dialogs-owner-host.test.tsx \
  src/renderer/src/components/sidebar/project-group-header-dom.test.ts \
  src/renderer/src/store/slices/repos-runtime-project-groups.test.ts \
  src/renderer/src/store/slices/repos-cross-host-project-collisions.test.ts
  -> 9 files, 63 tests passed

npx vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-list
  -> 31 files, 269 tests passed

npx vitest run --config config/vitest.config.ts src/renderer/src/i18n
  -> 17 files, 138 tests passed

npx vitest run --config config/vitest.config.ts \
  src/renderer/src/store/slices/repos-all-hosts.test.ts \
  src/renderer/src/store/slices/repos-all-hosts-folder-workspaces.test.ts \
  src/renderer/src/store/slices/repos-catalog-merge-identity.test.ts \
  src/renderer/src/store/slices/repos-cross-host-refresh-identity.test.ts \
  src/renderer/src/store/slices/repos-host-identity-routing.test.ts
  -> passed

npx vitest run --config config/vitest.config.ts \
  src/main/persistence-repo-lifecycle.test.ts src/main/persistence-folder-workspace-notes.test.ts
  -> 2 files, 49 tests passed (main-process ops deliberately untouched)

npx oxlint <all 12 changed files>                                            -> clean
npx oxlint --config config/oxlint-code-quality-native-plugins.json <same> --deny-warnings -> clean
npx oxfmt --check <same>                                                     -> clean
```

**Regression evidence (the tests fail without the product change).** With `repos.ts` + `project-group-removal-targets.ts` reverted to `origin/main` (new module left on disk, so the failure is behavioral, not an import error), `repos-project-groups-owner-routing.test.ts` went **7 failed / 1 passed**; restored, **8 passed**. With `use-project-group-dialogs.ts` reverted, `use-project-group-dialogs-owner-host.test.tsx` went **3 failed / 0 passed**; restored, **3 passed**.

For the follow-up commit: with the owner-routing target in `updateProjectGroup` / `deleteProjectGroup` swapped back to `getActiveRuntimeTarget(get().settings)`, the new `reports an unreachable owner as failure without touching local state` case **failed** (the focused local catalog got the call); restored, it passes. With the new `groupRenameFailedDesc` string reverted in `en.json`, `use-project-group-dialogs-owner-host.test.tsx` went **1 failed / 2 passed**; restored, **3 passed**.

One existing assertion changed: `project-group-header-dom.test.ts` pins the header-drag commit as a source string, and that call now carries `{ hostId: ownerHostId ?? undefined }`.

`pnpm typecheck` / full `pnpm lint` were not run locally (they OOM in this environment when several agents share the machine); CI covers them.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Note on the first box: the two-host repro below was executed on real hardware (macOS client + Linux `openclaw` host), in addition to the automated runs above and the revert-and-rerun experiment.

### Two-host manual repro on real hardware (retires the "nobody has run it" caveat)

Run on **2026-08-22** across two physical machines:

- **Client:** macOS 15 (Darwin 25.3.0), Orca dev build from this worktree, isolated profile
  (`ORCA_DEV_USER_DATA_PATH=/tmp/orca-pr15889-ud`), CDP on `127.0.0.1:9478`.
- **Owning host:** `openclaw` — Ubuntu 24.04 / `Linux neil-ubuntu 7.0.0-28-generic x86_64`, reached over
  Tailscale (`100.76.32.125`), running the packaged Linux build `orca-ide 1.4.182~rc.1`:

```
ssh openclaw 'DISPLAY=:77 /opt/Orca/resources/bin/orca-ide serve --port 16788 --pairing-address 100.76.32.125 --json'
-> {"type":"orca_server_ready","runtimeId":"7d31c815-...","advertisedEndpoint":"ws://100.76.32.125:16788", ...}
```

Paired from the client via `window.api.runtimeEnvironments.addFromPairingCode` + `connect`, which returned
`hostPlatform: "linux"`, `appVersion: "1.4.182-rc.1"`, `runtimeProtocolVersion: 3`. Note the host is an
**older** build than the client — the routing change needs no host-side change, which this confirms in practice.

**Setup — a real folder-scan group owned by the remote host, focus on local.** Two git repos and two plain
folders created on openclaw under `/home/neil/pr15889-scan`, then scanned and imported *from* the macOS client
*onto* openclaw:

```
scanNestedRepos('/home/neil/pr15889-scan', … { runtimeEnvironmentId: <openclaw> })
-> selectedPathKind "non_git_folder", repos alpha + bravo, durationMs 39   (scan ran on the Linux box)

importNestedRepos({ parentPath:'/home/neil/pr15889-scan', groupName:'pr15889-scan', mode:'group',
                    runtimeEnvironmentId:<openclaw> })
-> group c0b85574… createdFrom "folder-scan", executionHostId "runtime:30b2358a-…", importedCount 2
   store focus (activeRuntimeEnvironmentId) = null  ->  owner host != focused host
```

Two **folder workspaces** (`plainfolder1`, `plainfolder2`, non-git dirs) were then created inside that group on
openclaw, plus a second, **local** folder-scan group `pr15889-local` (repo `charlie` + folder workspace
`localplain`) so both hosts' rows are live in one sidebar.

**Step 2 — the original dead end, reproduced on `origin/main` (6b51ef4e2c4).** Same two hosts, same group,
dev build from `origin/main`:

```
updateProjectGroup('c0b85574-…', { name: 'RENAMED-FROM-LOCAL-FOCUS' })
-> false                                          # discarded by the rename dialog: silent no-op
   renderer row name: unchanged
   openclaw `projectGroup.list`: name "pr15889-scan", updatedAt == createdAt (1787390154460)
                                                   # the rename never reached the owning host

deleteProjectGroupWithContainedProjects('c0b85574-…', { removeContainedProjects: true })
-> { status: 'group-delete-failed', removedProjectIds: [], … }   # toast "Failed to delete group"
   openclaw `projectGroup.list`: group still present
```

**Step 3 — same hardware, same state, this branch (7532f86).** Driven through the **real sidebar UI** with CDP
mouse/key input (hover group header -> "..." -> menu item -> dialog -> button), not by calling the store:

```
Rename group -> "renamed-on-openclaw"
  HOST BEFORE: [{"name":"pr15889-scan",      "updatedAt":1787390154460}]
  HOST AFTER : [{"name":"renamed-on-openclaw","updatedAt":1787390537453}]
  RENDERER   : [{"name":"pr15889-local","host":"local"},
                {"name":"renamed-on-openclaw","host":"runtime:30b2358a-…"}]
  TOASTS     : []   (no error)

Delete group (+ "Remove 2 contained projects")
  openclaw projectGroup.list    : ["renamed-on-openclaw","pr15889-scan-b"] -> ["pr15889-scan-b"]
  openclaw folderWorkspace.list : ["plainfolder2","plainfolder1"]          -> []
  openclaw repo.list            : alpha, bravo, delta                      -> ["/home/neil/pr15889-scan-b/delta"]
  local group "pr15889-local", its folder workspace "localplain" and its repo: all still present
  TOASTS: []
```

**Mirror direction (focused host = openclaw, group owner = local).** With
`setActiveRuntimeEnvironmentPreference(<openclaw>)`:

```
rename local group -> "local-renamed-under-remote-focus"
  window.api.projectGroups.list()      -> [{"name":"local-renamed-under-remote-focus"}]
  openclaw projectGroup.list           -> ["pr15889-scan-b"]        (untouched)
delete that local group
  local  projectGroups / folderWorkspaces -> [] / []
  openclaw projectGroups                  -> ["pr15889-scan-b"]     (untouched, repo delta intact)
```

**Step 4 — the failure path the review flagged (`false` also means "RPC threw / timed out").** The host was
killed (`ssh openclaw 'pkill -u neil -f orca-ide'`; port 16788 closed) and the same rename re-driven through
the dialog:

```
[t+1429ms] TOAST: "Failed to rename group
                   Orca could not confirm the new name with the group's host. Recheck the group after reconnecting."
renderer group name: unchanged
renderer folder workspaces / repos: unchanged
```

Delete against the dead host, same run:

```
[t+1429ms] TOAST: "Failed to delete group
                   Something went wrong while deleting the group. No projects were removed."
renderer groups/workspaces/repos: unchanged — the remote group row and its repo survive
```

Both messages are accurate for an unverifiable outcome: neither asserts the host refused, and loss of contact
destroyed no local state. **No copy change was needed.**

A first attempt killed the host 469 ms *after* the click; the rename had already been applied and acknowledged
by the host, so the toast (correctly) never fired. On restart the host's catalog showed the pre-kill name —
the write had not been flushed before `pkill` — and the client's all-hosts refetch converged the sidebar to the
host's value rather than keeping its own. Client follows host, which is the intended direction.

**Step 5 — folder workspaces, not just git worktrees.** Covered above by construction: the deleted remote group
contained two non-git folder workspaces (removed on openclaw) and the deleted local group contained one
(`localplain`, removed locally), while each host's *other* workspaces were untouched in the same operations.

Reconnect after restarting `orca serve` succeeded with the saved device token (`reconnectOk: true`,
`hostPlatform: "linux"`), and the sidebar reconciled to the host's catalog.

**What was NOT run on hardware:** Windows. `awin` was available but the repro was done Linux-only; nothing in
this diff is OS-conditional. The mirror direction (local group, remote focus) was verified on this branch only —
its `origin/main` failure was not re-measured, since the primary direction already reproduces the same
focused-host routing bug.

CI on 7532f86: 46 success, 1 skipped (`e2e`), 0 failures.

## Review

- **Cross-platform (macOS/Linux/Windows):** renderer store + sidebar callbacks only. No `metaKey`, no accelerators, no path separators, no `process.platform` branch added or touched. The reporter's mixed-OS setup (Windows client, Linux host) is the target case and nothing here is OS-conditional.
- **SSH / remote execution boundary:** the execution host owns the mutation — that is the point of the change. Direct-SSH groups stay in the local main-process catalog and route through `window.api`, asserted by a dedicated test. An unreachable host still returns `false`; that is reported as a failure toast and is never reinterpreted as "the group is gone" — the local cascade runs only after a truthy response, so no local state is destroyed on loss of contact (asserted directly by `reports an unreachable owner as failure without touching local state`). The toast wording follows the same rule: an unverifiable outcome is described as unconfirmed, not as a host refusal.
- **Folder workspaces as well as git worktrees:** the delete cascade explicitly covers `folderWorkspaces` and resolves their owner with the same `getFolderWorkspaceHostId` that `deleteFolderWorkspace` uses; the reported group's members are folder workspaces, and the cross-host cascade test asserts the remote host's workspace survives.
- **Agent / integration compatibility (remote wire):** none affected. No RPC method, param, or response shape changes; no new stream opcode; no change to what a host publishes. `projectGroup.update` / `projectGroup.delete` and the `projectGroups:update` / `projectGroups:delete` IPC channels are byte-identical — only the destination changes. Old client + new host and new client + old host behave the same. `orca-data.json` schema is unchanged; `executionHostId` remains optional and renderer-derived, and it is now normalized through `parseExecutionHostId` so a whitespace-padded legacy value resolves instead of poisoning catalog identity.
- **Provider neutrality:** no GitHub/GitLab surface touched.
- **Performance:** owner resolution goes through the existing WeakMap-cached index keyed on the `projectGroups` array identity, so it is O(1) after first build and adds no scan to hot selectors. The cascade stays single passes over the same arrays it already walked. The one added `useMemo` in `use-header-drag` is a single pass over `projectGroups`, already a dependency there.
- **Mobile:** no mobile surface mutates project groups (`projectGroups.update`/`delete` appear only in the renderer store, preload, and main IPC/RPC), so there is no mobile client or `mobile/.oxlintrc.json` impact.
- **UI quality:** no layout, token, or component change. The one new surface is an error toast that reuses the existing `toast.error` + `translate(key, default)` pattern directly adjacent to `groupDeleteFailed`.
- **Security:** no new IPC channel, no new privilege, no user input reaching a shell or a path join. Host ids are parsed and normalized by the existing shared validator rather than string-concatenated.
- **Backward compatibility:** `{ hostId }` is optional everywhere, so every existing caller compiles and behaves as before. When no unambiguous owner exists (id present on two hosts with no explicit host), routing deliberately falls back to today's focused-host behavior rather than guessing.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Known limitations / follow-ups

- The store still collapses "host answered, group not found" and "RPC threw / timed out" into a single `false` from `updateProjectGroup` / `deleteProjectGroup`. This PR resolves that by keeping the user-facing copy non-asserting; giving these two calls a discriminated result (the way `removeProject` splits thrown-vs-null via `hasRuntimeRpcErrorCode`) would change the store's public signature and every caller, which is out of scope for this focused fix. Follow-up candidate if we want definitive "the host rejected it" copy.
- Non-English catalogs (`es` / `ja` / `ko` / `zh`) do not yet carry `groupRenameFailed*`; they fall back to the English `translate()` defaults until the normal translation pass picks them up. `verify:localization-catalog`, `verify:localization-extraction`, and `audit-localization-coverage --check` all pass with that state.

## Notes

Two PRs from contributors are open against this issue (#14043, #15101); this is an independent maintainer-authored implementation. It takes the owner-carrying dialog approach that #15101 uses (the only version that handles ambiguous cross-host ids rather than papering over them) and the owner-scoped state reconciliation that #14043 covered first, while avoiding #14043's `find((entry) => entry.id === groupId)` lookup over a `[host, id]`-keyed catalog, which can still pick the wrong host's row.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)


