### PR TITLE
fix(codex): accept max/ultra reasoning effort for aliased and dated model ids

### DIFF
--- a/src/main/codex-usage/codex-model-pricing.test.ts
+++ b/src/main/codex-usage/codex-model-pricing.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeModelForPricing } from './codex-model-pricing'
+
+describe('normalizeModelForPricing', () => {
+  it('strips the max and ultra reasoning tiers Codex 0.147 introduced', () => {
+    expect(normalizeModelForPricing('gpt-5.6-sol-ultra')).toBe('gpt-5.6-sol')
+    expect(normalizeModelForPricing('gpt-5.6-sol(ultra)')).toBe('gpt-5.6-sol')
+    expect(normalizeModelForPricing('gpt-5.6-luna-max')).toBe('gpt-5.6-luna')
+    expect(normalizeModelForPricing('gpt-5.6-luna(max)')).toBe('gpt-5.6-luna')
+  })
+
+  it('keeps gpt-5.1-codex-max a family name rather than a stripped reasoning tier', () => {
+    expect(normalizeModelForPricing('gpt-5.1-codex-max')).toBe('gpt-5.1-codex-max')
+    expect(normalizeModelForPricing('gpt-5.1-codex-max-xhigh')).toBe('gpt-5.1-codex-max')
+    expect(normalizeModelForPricing('gpt-5.1-codex-max(high)')).toBe('gpt-5.1-codex-max')
+    expect(normalizeModelForPricing('gpt-5.1-codex-high')).toBe('gpt-5.1-codex')
+  })
+
+  it('still rejects a parenthesized suffix that is not a reasoning tier', () => {
+    expect(normalizeModelForPricing('gpt-5.5(preview)')).toBe(null)
+  })
+})

--- a/src/main/codex-usage/codex-model-pricing.ts
+++ b/src/main/codex-usage/codex-model-pricing.ts
@@ -80,7 +80,17 @@ export const MODEL_PRICING: Record<string, CodexModelPricing> = {
   }
 }
 
-const REASONING_TIER_SUFFIXES = ['minimal', 'low', 'medium', 'high', 'xhigh', 'auto', 'none']
+const REASONING_TIER_SUFFIXES = [
+  'minimal',
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+  'ultra',
+  'auto',
+  'none'
+]
 
 function stripParenthesizedReasoningTier(model: string): string | null {
   const match = model.match(/^(.*)\(([^()]*)\)$/)
@@ -116,12 +126,16 @@ export function normalizeModelForPricing(model: string | null): string | null {
     return null
   }
 
+  // Why: `max` is both a reasoning tier and the tail of the `gpt-5.1-codex-max` family
+  // name, so this family must resolve before dash-suffix stripping eats it and reprices
+  // the rows as plain `gpt-5.1-codex`.
+  if (lower === 'gpt-5.1-codex-max' || lower.startsWith('gpt-5.1-codex-max-')) {
+    return 'gpt-5.1-codex-max'
+  }
+
   const normalized = stripDashReasoningTiers(lower)
   if (normalized === 'gpt-5' || normalized === 'gpt-5-codex') {
     return 'gpt-5'
-  }
-  if (normalized === 'gpt-5.1-codex-max' || normalized.startsWith('gpt-5.1-codex-max-')) {
-    return 'gpt-5.1-codex-max'
   }
   if (normalized === 'gpt-5.1-codex' || normalized.startsWith('gpt-5.1-codex-')) {
     return 'gpt-5.1-codex'

--- a/src/main/codex-usage/store-model-pricing.test.ts
+++ b/src/main/codex-usage/store-model-pricing.test.ts
@@ -160,7 +160,12 @@ describe('CodexUsageStore', () => {
 
   it('normalizes GPT-5.6 reasoning suffixes before pricing', async () => {
     const store = createStoreWithState({
-      dailyAggregates: ['gpt-5.6-terra-high', 'gpt-5.6-luna(medium)'].map((model) => ({
+      dailyAggregates: [
+        'gpt-5.6-terra-high',
+        'gpt-5.6-luna(medium)',
+        'gpt-5.6-sol-ultra',
+        'gpt-5.6-luna(max)'
+      ].map((model) => ({
         day: '2026-04-09',
         model,
         projectKey: 'worktree:repo-1::/workspace/repo',
@@ -185,6 +190,13 @@ describe('CodexUsageStore', () => {
     expect(
       breakdown.find((row) => row.key === 'gpt-5.6-luna(medium)')?.estimatedCostUsd
     ).toBeCloseTo(0.205)
+    // Codex 0.147 tiers: an unrecognized suffix drops the row's cost entirely.
+    expect(breakdown.find((row) => row.key === 'gpt-5.6-sol-ultra')?.estimatedCostUsd).toBeCloseTo(
+      1.025
+    )
+    expect(breakdown.find((row) => row.key === 'gpt-5.6-luna(max)')?.estimatedCostUsd).toBeCloseTo(
+      0.205
+    )
   })
 
   it('prices the bare gpt-5.6 alias at Sol rates without shadowing the tier IDs', async () => {

--- a/src/main/runtime/rpc/methods/orchestration-worker-launch-preferences.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-launch-preferences.test.ts
@@ -97,6 +97,12 @@ describe('orchestration worker launch preferences', () => {
       rejected: ['future-effort']
     },
     {
+      // Bare version alias; OpenAI routes it to Sol.
+      model: 'gpt-5.6',
+      accepted: ['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
+      rejected: ['future-effort']
+    },
+    {
       // Dated variant published after this Orca build.
       model: 'gpt-5.6-luna-2026-08-01',
       accepted: ['minimal', 'low', 'medium', 'high', 'xhigh', 'max'],

--- a/src/main/runtime/rpc/methods/orchestration-worker-launch-preferences.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-launch-preferences.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { getAgentSessionOptionCatalog } from '../../../../shared/agent-session-option-catalog'
+import {
+  findCatalogModelByRequestedId,
+  getAgentSessionOptionCatalog
+} from '../../../../shared/agent-session-option-catalog'
 import { ORCHESTRATION_WORKER_LAUNCH_PREFERENCES_RUNTIME_CAPABILITY } from '../../../../shared/protocol-version'
 import {
   assertWorkerLaunchPreferencesCreateTerminal,
@@ -75,17 +78,36 @@ describe('orchestration worker launch preferences', () => {
       rejected: ['max', 'ultra', 'future-effort']
     },
     {
+      // Why: an id no seed row explains means unknown host capability, so the menu stops at
+      // the last tier every supported Codex build accepts. Raising this fallback would hand
+      // `max`/`ultra` to a binary that predates them; per-model ceilings lift it instead.
       model: 'future-codex-model',
       accepted: ['minimal', 'low', 'medium', 'high', 'xhigh'],
       rejected: ['max', 'ultra', 'future-effort']
+    },
+    {
+      // Bare family alias, as accepted by `codex -m luna`.
+      model: 'luna',
+      accepted: ['minimal', 'low', 'medium', 'high', 'xhigh', 'max'],
+      rejected: ['ultra', 'future-effort']
+    },
+    {
+      model: 'sol',
+      accepted: ['minimal', 'low', 'medium', 'high', 'xhigh', 'max', 'ultra'],
+      rejected: ['future-effort']
+    },
+    {
+      // Dated variant published after this Orca build.
+      model: 'gpt-5.6-luna-2026-08-01',
+      accepted: ['minimal', 'low', 'medium', 'high', 'xhigh', 'max'],
+      rejected: ['ultra', 'future-effort']
     }
   ])('enforces the Codex effort ceiling for $model', ({ model, accepted, rejected }) => {
     const catalog = getAgentSessionOptionCatalog('codex')!
     const effort =
-      catalog.models
-        .find((candidate) => candidate.id === model)
-        ?.options.find((option) => option.id === 'effort') ??
-      catalog.unknownModelOptions?.find((option) => option.id === 'effort')
+      findCatalogModelByRequestedId(catalog, model)?.options.find(
+        (option) => option.id === 'effort'
+      ) ?? catalog.unknownModelOptions?.find((option) => option.id === 'effort')
 
     expect(effort?.kind.type).toBe('select')
     expect(

--- a/src/main/runtime/rpc/methods/orchestration-worker-launch-preferences.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-launch-preferences.ts
@@ -1,6 +1,6 @@
 import type { AgentLaunchPreferences } from '../../../../shared/agent-session-host-authority'
 import {
-  findCatalogModel,
+  findCatalogModelByRequestedId,
   findCatalogOption,
   getAgentSessionOptionCatalog
 } from '../../../../shared/agent-session-option-catalog'
@@ -75,7 +75,7 @@ export function resolveWorkerLaunchPreferences(args: {
   }
 
   if (args.effort) {
-    const model = findCatalogModel(catalog, args.model)
+    const model = findCatalogModelByRequestedId(catalog, args.model)
     const option =
       findCatalogOption(model, 'effort') ??
       (!model

--- a/src/shared/agent-session-option-catalog-claude-codex.ts
+++ b/src/shared/agent-session-option-catalog-claude-codex.ts
@@ -245,7 +245,9 @@ export const CODEX_SESSION_OPTION_CATALOG: AgentSessionOptionCatalog = {
 // Why: a bare version routes to one tier of its family, which no prefix or suffix rule can
 // derive (`gpt-5.6` is a prefix of all three 5.6 rows). Same routing the usage pricing table
 // encodes; match exactly, since a `gpt-5.6-` prefix rule would swallow the tier ids.
-const CODEX_BARE_VERSION_ALIASES: Record<string, string> = { 'gpt-5.6': 'gpt-5.6-sol' }
+// Map, not a plain object: the key is user-supplied, and `Object.prototype` keys would
+// otherwise resolve to inherited members.
+const CODEX_BARE_VERSION_ALIASES = new Map([['gpt-5.6', 'gpt-5.6-sol']])
 
 /** Why: Codex effort validity is keyed on exact seed ids, so a dated id
  * (`gpt-5.6-luna-2026-08-01`) or the bare family alias (`luna`) would silently fall back
@@ -256,7 +258,7 @@ function resolveCodexCatalogModelId(modelId: string): string | undefined {
   if (ids.includes(modelId)) {
     return modelId
   }
-  const bareVersionOf = CODEX_BARE_VERSION_ALIASES[modelId]
+  const bareVersionOf = CODEX_BARE_VERSION_ALIASES.get(modelId)
   if (bareVersionOf) {
     return bareVersionOf
   }

--- a/src/shared/agent-session-option-catalog-claude-codex.ts
+++ b/src/shared/agent-session-option-catalog-claude-codex.ts
@@ -234,5 +234,34 @@ export const CODEX_SESSION_OPTION_CATALOG: AgentSessionOptionCatalog = {
     // command and let its own picker apply the account-supported model.
     midSession: { kind: 'agent-picker', command: '/model', delivery: 'type' }
   },
-  unknownModelOptions: [codexEffort('xhigh')]
+  // Why: an id absent from the seed means unknown host capability, so the menu stops
+  // at the last tier every supported Codex build accepts. The higher ceilings stay
+  // model-scoped because a Codex older than 0.147 cannot run gpt-5.6 at all, which is
+  // what keeps `max`/`ultra` from ever reaching a binary that would reject them.
+  unknownModelOptions: [codexEffort('xhigh')],
+  resolveModelId: resolveCodexCatalogModelId
+}
+
+/** Why: Codex effort validity is keyed on exact seed ids, so a dated id
+ * (`gpt-5.6-luna-2026-08-01`) or the bare family alias (`luna`) would silently fall back
+ * to the `xhigh` ceiling and reject `max`/`ultra` that the host actually supports.
+ * Validation only — launch args must keep the id the caller asked for. */
+function resolveCodexCatalogModelId(modelId: string): string | undefined {
+  const ids = CODEX_SESSION_OPTION_CATALOG.models.map((model) => model.id)
+  if (ids.includes(modelId)) {
+    return modelId
+  }
+  // Longest prefix wins so `gpt-5.6-luna-2026-08-01` resolves to Luna, not a shorter family.
+  const variantOf = ids
+    .filter((id) => modelId.startsWith(`${id}-`))
+    .reduce<string | undefined>(
+      (best, id) => (!best || id.length > best.length ? id : best),
+      undefined
+    )
+  if (variantOf) {
+    return variantOf
+  }
+  const aliasOf = ids.filter((id) => id.endsWith(`-${modelId}`))
+  // An ambiguous alias must not guess a family; leaving it unresolved keeps the safe ceiling.
+  return aliasOf.length === 1 ? aliasOf[0] : undefined
 }

--- a/src/shared/agent-session-option-catalog-claude-codex.ts
+++ b/src/shared/agent-session-option-catalog-claude-codex.ts
@@ -242,6 +242,11 @@ export const CODEX_SESSION_OPTION_CATALOG: AgentSessionOptionCatalog = {
   resolveModelId: resolveCodexCatalogModelId
 }
 
+// Why: a bare version routes to one tier of its family, which no prefix or suffix rule can
+// derive (`gpt-5.6` is a prefix of all three 5.6 rows). Same routing the usage pricing table
+// encodes; match exactly, since a `gpt-5.6-` prefix rule would swallow the tier ids.
+const CODEX_BARE_VERSION_ALIASES: Record<string, string> = { 'gpt-5.6': 'gpt-5.6-sol' }
+
 /** Why: Codex effort validity is keyed on exact seed ids, so a dated id
  * (`gpt-5.6-luna-2026-08-01`) or the bare family alias (`luna`) would silently fall back
  * to the `xhigh` ceiling and reject `max`/`ultra` that the host actually supports.
@@ -250,6 +255,10 @@ function resolveCodexCatalogModelId(modelId: string): string | undefined {
   const ids = CODEX_SESSION_OPTION_CATALOG.models.map((model) => model.id)
   if (ids.includes(modelId)) {
     return modelId
+  }
+  const bareVersionOf = CODEX_BARE_VERSION_ALIASES[modelId]
+  if (bareVersionOf) {
+    return bareVersionOf
   }
   // Longest prefix wins so `gpt-5.6-luna-2026-08-01` resolves to Luna, not a shorter family.
   const variantOf = ids

--- a/src/shared/agent-session-option-catalog-types.ts
+++ b/src/shared/agent-session-option-catalog-types.ts
@@ -60,6 +60,10 @@ export type AgentSessionOptionCatalog = {
   supportsWorkerLaunchPreferences?: true
   /** Launch-safe options for opaque model ids that are absent from the static catalog. */
   unknownModelOptions?: CatalogOption[]
+  /** Maps a requested id onto the seed row that describes its capabilities (dated ids,
+   * family aliases). Why: validation-only — resolving during launch would inject the
+   * seed's option defaults over the user's own agent config. */
+  resolveModelId?: (modelId: string) => string | undefined
   composeModelValue?: (modelId: string, values: Record<string, SessionOptionValue>) => string
   /** Why: a seeded id the CLI has retired is a fatal launch, so a successful probe
    * must be able to drop it rather than only add. Membership only — option menus

--- a/src/shared/agent-session-option-catalog.test.ts
+++ b/src/shared/agent-session-option-catalog.test.ts
@@ -30,6 +30,8 @@ describe('agent session option catalog', () => {
     expect(findCatalogModelByRequestedId(codex, 'sol')?.id).toBe('gpt-5.6-sol')
     expect(findCatalogModelByRequestedId(codex, 'gpt-5.6-luna-2026-08-01')?.id).toBe('gpt-5.6-luna')
     expect(findCatalogModelByRequestedId(codex, 'gpt-5.6-sol')?.id).toBe('gpt-5.6-sol')
+    // The bare version routes to Sol, matching the usage pricing table.
+    expect(findCatalogModelByRequestedId(codex, 'gpt-5.6')?.id).toBe('gpt-5.6-sol')
     // An id that matches no family keeps the conservative unknown-model ceiling.
     expect(findCatalogModelByRequestedId(codex, 'future-codex-model')).toBeUndefined()
     // Exact matching must stay exact: it also gates launch-arg defaulting.

--- a/src/shared/agent-session-option-catalog.test.ts
+++ b/src/shared/agent-session-option-catalog.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { getAgentSessionOptionCatalog, mergeCatalogModels } from './agent-session-option-catalog'
+import {
+  findCatalogModel,
+  findCatalogModelByRequestedId,
+  getAgentSessionOptionCatalog,
+  mergeCatalogModels
+} from './agent-session-option-catalog'
 import { resolveAgentSessionOptionLaunch } from './agent-session-option-launch'
 import {
   resolveNativeChatSessionOptionDefaults,
@@ -17,6 +22,31 @@ describe('agent session option catalog', () => {
       catalog?.models.find((model) => model.id === 'opus')?.options.map(({ id }) => id)
     ).toEqual(['effort', 'fastMode'])
     expect(catalog?.models.find((model) => model.id === 'haiku')?.options).toEqual([])
+  })
+
+  it('resolves Codex family aliases and dated variants onto their seed capabilities', () => {
+    const codex = getAgentSessionOptionCatalog('codex')!
+    expect(findCatalogModelByRequestedId(codex, 'luna')?.id).toBe('gpt-5.6-luna')
+    expect(findCatalogModelByRequestedId(codex, 'sol')?.id).toBe('gpt-5.6-sol')
+    expect(findCatalogModelByRequestedId(codex, 'gpt-5.6-luna-2026-08-01')?.id).toBe('gpt-5.6-luna')
+    expect(findCatalogModelByRequestedId(codex, 'gpt-5.6-sol')?.id).toBe('gpt-5.6-sol')
+    // An id that matches no family keeps the conservative unknown-model ceiling.
+    expect(findCatalogModelByRequestedId(codex, 'future-codex-model')).toBeUndefined()
+    // Exact matching must stay exact: it also gates launch-arg defaulting.
+    expect(findCatalogModel(codex, 'luna')).toBeUndefined()
+  })
+
+  it('never injects a catalog effort default for an aliased Codex model', () => {
+    // Why: the user's ~/.codex/config.toml owns model_reasoning_effort unless they picked one.
+    expect(resolveAgentSessionOptionLaunch('codex', { model: 'luna' }).args).toEqual(['-m', 'luna'])
+    expect(resolveAgentSessionOptionLaunch('codex', { model: 'luna', effort: 'max' })).toEqual({
+      args: ['-m', 'luna', '-c', 'model_reasoning_effort=max'],
+      appliedValues: { model: 'luna', effort: 'max' }
+    })
+    // Luna tops out at max, so ultra is still dropped rather than sent to the CLI.
+    expect(
+      resolveAgentSessionOptionLaunch('codex', { model: 'luna', effort: 'ultra' }).args
+    ).toEqual(['-m', 'luna'])
   })
 
   it('merges discovered labels while preserving cataloged option shapes', () => {

--- a/src/shared/agent-session-option-catalog.ts
+++ b/src/shared/agent-session-option-catalog.ts
@@ -47,6 +47,21 @@ export function findCatalogModel(
   return catalog.models.find((model) => model.id === modelId)
 }
 
+/** Resolves aliases and dated variants onto their seed row for capability checks.
+ *  Why: kept separate from `findCatalogModel` because that lookup also gates launch-arg
+ *  injection — a fuzzy match there would override the user's own agent config. */
+export function findCatalogModelByRequestedId(
+  catalog: AgentSessionOptionCatalog,
+  modelId: string
+): CatalogModel | undefined {
+  const exact = findCatalogModel(catalog, modelId)
+  if (exact) {
+    return exact
+  }
+  const resolved = catalog.resolveModelId?.(modelId)
+  return resolved ? findCatalogModel(catalog, resolved) : undefined
+}
+
 export function findCatalogOption(
   model: CatalogModel | undefined,
   optionId: string

--- a/src/shared/agent-session-option-launch.ts
+++ b/src/shared/agent-session-option-launch.ts
@@ -1,5 +1,9 @@
 import type { AgentType } from './agent-status-types'
-import { findCatalogModel, getAgentSessionOptionCatalog } from './agent-session-option-catalog'
+import {
+  findCatalogModel,
+  findCatalogModelByRequestedId,
+  getAgentSessionOptionCatalog
+} from './agent-session-option-catalog'
 import type { SessionOptionValue } from './native-chat-session-options'
 
 export type ResolvedSessionOptionLaunch = {
@@ -43,7 +47,13 @@ export function resolveAgentSessionOptionLaunch(
   const model = findCatalogModel(catalog, modelId)
   const appliedValues: Record<string, SessionOptionValue> = {}
   const args: string[] = []
-  const modelOptions = model?.options ?? catalog.unknownModelOptions ?? []
+  // Why: the menu comes from the alias-resolved row so a dated or aliased id keeps its real
+  // ceiling, while `model` stays an exact match — an alias must not gain catalog defaults,
+  // which would override the effort the user set in their own agent config.
+  const modelOptions =
+    (model ?? findCatalogModelByRequestedId(catalog, modelId))?.options ??
+    catalog.unknownModelOptions ??
+    []
   const modelValues = Object.fromEntries(
     modelOptions.flatMap((option) => {
       const explicitValue = values[option.id]

--- a/src/shared/commit-message-agent-spec.test.ts
+++ b/src/shared/commit-message-agent-spec.test.ts
@@ -168,6 +168,9 @@ describe('COMMIT_MESSAGE_AGENT_SPECS', () => {
   it('orders Codex models by version descending to match the official picker', () => {
     const ids = COMMIT_MESSAGE_AGENT_SPECS.codex?.models.map((m) => m.id)
     expect(ids).toEqual([
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
       'gpt-5.5',
       'gpt-5.4',
       'gpt-5.4-mini',

--- a/src/shared/commit-message-agent-spec.ts
+++ b/src/shared/commit-message-agent-spec.ts
@@ -99,6 +99,18 @@ const OPENAI_THINKING_LEVELS: ThinkingLevel[] = [
   { id: 'xhigh', label: 'Extra High' }
 ]
 
+// Why: only the gpt-5.6 family accepts these; pre-5.6 Codex models reject them, and a
+// Codex older than 0.147 cannot run gpt-5.6 at all, so the higher tiers stay model-scoped.
+const OPENAI_MAX_THINKING_LEVELS: ThinkingLevel[] = [
+  ...OPENAI_THINKING_LEVELS,
+  { id: 'max', label: 'Max' }
+]
+
+const OPENAI_ULTRA_THINKING_LEVELS: ThinkingLevel[] = [
+  ...OPENAI_MAX_THINKING_LEVELS,
+  { id: 'ultra', label: 'Ultra' }
+]
+
 const CLAUDE_THINKING_LEVELS: ThinkingLevel[] = [
   { id: 'low', label: 'Low' },
   { id: 'medium', label: 'Medium' },
@@ -407,6 +419,24 @@ export const COMMIT_MESSAGE_AGENT_SPECS: Partial<Record<TuiAgent, CommitMessageA
     // Why: ordered to match the official `codex` model picker — descending
     // by version so the frontier model lands on top and legacy models trail.
     models: [
+      {
+        id: 'gpt-5.6-sol',
+        label: 'GPT-5.6 Sol',
+        thinkingLevels: OPENAI_ULTRA_THINKING_LEVELS,
+        defaultThinkingLevel: 'low'
+      },
+      {
+        id: 'gpt-5.6-terra',
+        label: 'GPT-5.6 Terra',
+        thinkingLevels: OPENAI_ULTRA_THINKING_LEVELS,
+        defaultThinkingLevel: 'low'
+      },
+      {
+        id: 'gpt-5.6-luna',
+        label: 'GPT-5.6 Luna',
+        thinkingLevels: OPENAI_MAX_THINKING_LEVELS,
+        defaultThinkingLevel: 'low'
+      },
       {
         id: 'gpt-5.5',
         label: 'GPT-5.5',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​104 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​97 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​122 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​113 |

<!-- /orca-pr-loc -->

## ELI5

Codex 0.147 added two new reasoning-effort levels, `max` and `ultra`. Orca already knew about them for the three model names it ships in its built-in list (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`), but it matched those names with exact string equality. So if you asked for the same model by its short alias (`luna`) or by a dated id that OpenAI published after this Orca build (`gpt-5.6-luna-2026-08-01`), Orca did not recognise it, quietly fell back to its lowest-common-denominator list, and told you `Agent codex model luna does not support effort max.` even though your installed Codex supports it perfectly well.

This PR teaches Orca that `luna` and `gpt-5.6-luna-<date>` are the same family as `gpt-5.6-luna` when it is checking *what a model can do*, without changing *what it actually launches*. It also fixes two downstream places that still stopped at `xhigh`: the Codex usage-cost normalizer (an `(ultra)` row got no cost at all) and the Source Control AI fallback model list.

## What Changed

- `src/shared/agent-session-option-catalog-claude-codex.ts` — new `resolveCodexCatalogModelId`, wired onto the Codex catalog as `resolveModelId`. Exact id wins; otherwise the bare-version alias table (`gpt-5.6` -> `gpt-5.6-sol`); otherwise the longest seed id that is a `<seed>-` prefix of the request (dated/suffixed variants); otherwise the single seed id ending in `-<request>` (bare family alias). Ambiguous or no match returns `undefined`, so the conservative `xhigh` fallback still applies. Added the load-bearing WHY comment on `unknownModelOptions` explaining why the ceiling is model-scoped.
  - Bare version alias: `gpt-5.6` is a prefix of *all three* 5.6 rows, so no prefix or suffix rule can derive it; it is mapped explicitly to Sol, matching the routing `codex-model-pricing.ts` already encodes for the same id. Without this it kept the `xhigh` fallback and dropped `max`/`ultra` — the exact bug this PR fixes for `sol`/`luna`.
- `src/shared/agent-session-option-catalog-types.ts` / `agent-session-option-catalog.ts` — optional `resolveModelId` on the catalog plus `findCatalogModelByRequestedId`. **`findCatalogModel` is deliberately untouched.**
- `src/shared/agent-session-option-launch.ts` — the *option menu* is now read off the alias-resolved row, while `model` stays an exact match. That distinction is the whole safety story (see Why).
- `src/main/runtime/rpc/methods/orchestration-worker-launch-preferences.ts` — one-line swap to `findCatalogModelByRequestedId` for the effort-capability check.
- `src/main/codex-usage/codex-model-pricing.ts` — `max` and `ultra` added to `REASONING_TIER_SUFFIXES`, and the `gpt-5.1-codex-max` family branch moved *ahead* of dash-suffix stripping.
- `src/shared/commit-message-agent-spec.ts` — gpt-5.6 Sol/Terra/Luna rows added to the static Codex seed with their real ceilings (`ultra`, `ultra`, `max`). Pre-5.6 rows stay at `xhigh`, which is correct for them.

## Why

Root cause: Codex reasoning-effort validity is decided solely by a hand-maintained table matched with **exact string equality** (`models.find(m => m.id === modelId)`), with one global fallback of `xhigh`. #14281 already raised the per-model ceilings for the three seeded gpt-5.6 rows, but any id that is not *literally* one of the seeded strings — a bare alias, a dated id, an account-scoped id, or anything Codex ships after this Orca build — never reaches those rows. So `orca orchestration worker-start --agent codex --model luna --effort max` still failed on `main` with the reporter's exact message.

Backward compatibility with older Codex binaries is preserved and is the reason this fix is shaped the way it is:

- The higher ceilings remain **model-scoped**, never global. A Codex older than 0.147 cannot run gpt-5.6 at all, so it can never be handed `max`/`ultra`. That coupling was previously undocumented and is now written down next to `unknownModelOptions`.
- An id that resolves to no family keeps the `xhigh` fallback. Unknown id means unknown host capability, so the menu stays at the last universally-supported tier. The existing `future-codex-model` test case that asserts this is preserved and now carries a WHY comment so nobody "fixes" it later.
- Alias resolution never widens a ceiling. `luna` gets Luna's `max` ceiling, not Sol's `ultra` — `resolveWorkerLaunchPreferences({ model: 'luna', effort: 'ultra' })` still rejects.

The `findCatalogModel` / `findCatalogModelByRequestedId` split matters: `findCatalogModel`'s truthiness also gates catalog *default* injection in `resolveAgentSessionOptionLaunch`. Making that lookup fuzzy would turn `codex -m luna` into `codex -m luna -c model_reasoning_effort=medium`, silently overriding the user's own `~/.codex/config.toml`. The alias-resolved row is therefore used only to pick the option *menu*; `model` (exact) still decides whether defaults are injected. There is a regression test that fails if someone collapses the two.

The pricing branch reorder is required, not cosmetic: naively adding `max` to the tier list makes `stripDashReasoningTiers` turn `gpt-5.1-codex-max` into `gpt-5.1-codex` and reprice it, because dash-stripping ran before family matching.

## Linked Issue

Fixes #14506

## Visual Proof

`N/A` — no rendered UI changes. The effort choices themselves are unchanged (`max`/`ultra` were already in `CODEX_EFFORT_CHOICES` and already have `en.json` labels); this only changes which model ids are matched to which existing menu, plus a usage-cost normalizer and a non-visual fallback data list. The user-visible symptom is a CLI error string, reproduced and asserted in tests below.

## Testing

Run on **macOS only** (darwin 25.3.0). Linux and Windows are covered by reasoning, not execution: every change here is pure string/data manipulation with no path joins, no shell invocation, no `metaKey`, and no platform branches, so there is nothing platform-dependent to diverge.

Commands run:

```
npx vitest run --config config/vitest.config.ts \
  src/shared/ src/main/codex-usage/ src/main/runtime/rpc/methods/ \
  src/renderer/src/components/native-chat/ src/main/text-generation/ \
  src/main/persistence-settings-ui-defaults.test.ts
=> Test Files 695 passed | 4 skipped (699); Tests 7214 passed | 66 skipped (7280)

npx oxlint <12 changed files>                                    => clean
npx oxlint --config config/oxlint-code-quality-native-plugins.json \
  <12 changed files> --deny-warnings                             => clean
npx oxfmt --check <12 changed files>                             => clean
```

**Non-vacuity proof.** With all five product files reverse-applied and only the tests kept, 8 tests go RED:

```
x strips the max and ultra reasoning tiers Codex 0.147 introduced
x normalizes GPT-5.6 reasoning suffixes before pricing
x resolves Codex family aliases and dated variants onto their seed capabilities
x never injects a catalog effort default for an aliased Codex model
x enforces the Codex effort ceiling for 'luna'
x enforces the Codex effort ceiling for 'sol'
x enforces the Codex effort ceiling for 'gpt-5.6-luna-2026-08-01'
x orders Codex models by version descending to match the official picker
```

Reverting **only** the one-line call-site change in `orchestration-worker-launch-preferences.ts` reproduces the reporter's exact string:

```
OrchestrationError: Agent codex model luna does not support effort max.
OrchestrationError: Agent codex model sol does not support effort max.
OrchestrationError: Agent codex model gpt-5.6-luna-2026-08-01 does not support effort max.
```

New/extended tests:
- `src/main/codex-usage/codex-model-pricing.test.ts` (new) — `max`/`ultra` suffix stripping in both dash and parenthesized shapes, plus a guard that `gpt-5.1-codex-max` and `gpt-5.1-codex-max-xhigh` still price as `gpt-5.1-codex-max`.
- `src/shared/agent-session-option-catalog.test.ts` — alias/variant/ambiguity resolution, `findCatalogModel` staying exact, and the anti-regression assertion that `-m luna` injects no `-c model_reasoning_effort=...`.
- `orchestration-worker-launch-preferences.test.ts` — `luna`, `sol`, `gpt-5.6`, `gpt-5.6-luna-2026-08-01` rows added to the ceiling table; `future-codex-model` kept at `xhigh` with a WHY comment.
- `store-model-pricing.test.ts` — `gpt-5.6-sol-ultra` and `gpt-5.6-luna(max)` now produce costs identical to their base models (previously `null`, i.e. no cost row at all).

Non-vacuity for the bare-alias follow-up commit, proven separately: with only the `CODEX_BARE_VERSION_ALIASES` hunk reverse-applied, 2 tests go RED — `resolves Codex family aliases and dated variants onto their seed capabilities` (`expected undefined to be 'gpt-5.6-sol'`) and `enforces the Codex effort ceiling for 'gpt-5.6'` (menu stops at `xhigh`, so `max`/`ultra` are rejected). Restored, both pass.

One caveat worth flagging honestly: in one earlier run of the ~700-file combined suite, 2 tests failed transiently under heavy parallel load. They did not reproduce on re-run of the identical command, nor in isolation. Unrelated to this change.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

**Cross-platform** — no risk. Pure data/string work: no `path` usage, no shell/argv construction, no `metaKey`, no platform branches added or touched. Behaves identically on macOS, Linux, Windows, and WSL.

**SSH / remote execution** — no risk, and the execution boundary is respected. `resolveWorkerLaunchPreferences` runs host-side, so the host continues to own effort validation, exactly as before. Nothing here reads or infers remote process state, so the `live`/`unverifiable`/`exited` vocabulary is untouched. Note the honest scope limit: this PR does **not** make the effort menu track the *installed* Codex binary — a client asking an older remote host for `--effort ultra` will still, correctly, be rejected by that host. That is the intended behavior since the host owns validation.

**Remote wire compatibility** — no wire change. No new RPC param, no new stream opcode, no change to what either side publishes. `effort` is already an optional string on `WorkerStartParams`, and the feature's existence is already gated by `ORCHESTRATION_WORKER_LAUNCH_PREFERENCES_RUNTIME_CAPABILITY`. Mixed old/new versions behave exactly as they do today.

**Agent / integration compatibility** — the load-bearing concern, addressed above: ceilings stay model-scoped, unresolvable ids keep the conservative `xhigh` fallback, and alias resolution can only match a ceiling that a seeded row already declares. No provider-specific (GitHub/GitLab) surface is touched. Folder workspaces are unaffected — nothing reads worktree or git state. Persisted `valuesByModel.effort` values are unaffected; a persisted `ultra` on a model whose menu no longer offers it is still retained by the existing snapshot logic.

**Performance** — negligible. Alias resolution is a bounded scan of a 5-element array, only on the non-hot validation and launch-resolution paths, and only after an exact match misses. No new I/O, no new subprocess, no new caching.

**UI quality** — `N/A`, no rendered surface changes. The one adjacent effect is that Source Control AI's Codex fallback list now shows the three gpt-5.6 rows above gpt-5.5 (matching the official picker's descending order and the native-chat catalog seed). `defaultModelId` is deliberately left at `gpt-5.5` — moving the default is a separate product/cost decision, not a bug fix.

**Security** — no risk. No new process spawn, no new network call, no filesystem access, no credential handling, no user-controlled string reaching a shell. Model ids are compared, never interpolated into a command; the launch args still carry the exact id the caller supplied.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Known limitations / follow-ups

- The bare `gpt-5.6` alias is mapped to Sol because that is the routing this repo already asserts in `src/main/codex-usage/codex-model-pricing.ts`. If OpenAI ever reroutes the bare alias to a lower tier, both that table and this one must move together; there is no host probe that would catch it automatically (see the `listModels` follow-up below).
- The renderer's native-chat option menu (`native-chat-session-option-apply.ts`) still resolves with exact `findCatalogModel` against the merged seed + discovered model list. That path is fed by per-host discovery rather than raw user input, and widening it touches the native-chat surface, so it is intentionally left to the `listModels` follow-up below rather than expanded here.

## Notes

Known follow-up, deliberately **not** in this PR: the Codex catalog still has no `listModels` host probe (unlike Claude, Grok and Cursor), so the effort menu cannot track the installed binary and correctness still depends on shipping an Orca release per Codex release. Adding it means threading `supported_reasoning_levels` from `codex debug models` through the per-host enrichment pipeline and making probed option menus authoritative — a cross-cutting renderer change with real UI impact that deserves its own PR and its own visual validation. This PR fixes the reported failure and its downstream fallout without that surface area.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)


