### PR TITLE
STA-5061: restore Cmd-J host badges

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.test.tsx
@@ -48,11 +48,6 @@ vi.mock('@/components/repo/RepoBadgeLabel', () => ({
   RepoBadgeMark: () => <span data-repo-badge-mark="true" />
 }))
 
-const { getPaletteHostBadge } = vi.hoisted(() => ({
-  getPaletteHostBadge: vi.fn(() => null as { hostId: 'local'; label: string } | null)
-}))
-vi.mock('@/components/cmd-j/palette-host-badge', () => ({ getPaletteHostBadge }))
-
 // Why: activation reaches into window.api and the whole worktree-reveal path; the palette's own
 // contract is which result it hands over, so stub the boundary and assert on that.
 const { activateWorkspaceTabPaletteResult } = vi.hoisted(() => ({
@@ -192,7 +187,6 @@ describe('WorktreeJumpPalette', () => {
     globalThis.IS_REACT_ACT_ENVIRONMENT = true
     setCommandQuery = null
     activateAndRevealWorktree.mockClear()
-    getPaletteHostBadge.mockReturnValue(null)
     useAppStore.setState(initialAppState, true)
     testContainer = document.createElement('div')
     document.body.appendChild(testContainer)
@@ -233,10 +227,16 @@ describe('WorktreeJumpPalette', () => {
   })
 
   it('renders the owning host badge on worktree and tab rows', async () => {
-    getPaletteHostBadge.mockReturnValue({ hostId: 'local', label: 'Local Mac' })
-    await renderPalette(makeRecentTabState())
+    await renderPalette({
+      ...makeRecentTabState(),
+      repos: [makeRepo(), { ...makeRepo(), id: 'ssh-repo', connectionId: 'ssh-1' }],
+      sshTargetLabels: new Map([['ssh-1', 'Builder']]),
+      sshConnectionStates: new Map([
+        ['ssh-1', { targetId: 'ssh-1', status: 'connected', error: null, reconnectAttempt: 0 }]
+      ])
+    })
 
-    const badge = '[aria-label="Host: Local Mac"]'
+    const badge = '[aria-label^="Host:"]'
     expect(testContainer.querySelector(`[data-command-item*="worktree:"] ${badge}`)).not.toBeNull()
     expect(
       testContainer.querySelector(`[data-command-item*="workspace-tab:"] ${badge}`)

--- a/src/renderer/src/components/WorktreeJumpPalette.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.test.tsx
@@ -230,6 +230,10 @@ describe('WorktreeJumpPalette', () => {
   it('renders the owning host badge on worktree and tab rows', async () => {
     await renderPalette({
       ...makeRecentTabState(),
+      worktreesByRepo: {
+        ...makeRecentTabState().worktreesByRepo,
+        folder: [makeWorktree('folder', 'Folder', { repoId: 'folder', hostId: 'ssh:ssh-1' })]
+      },
       repos: [makeRepo(), { ...makeRepo(), id: 'ssh-repo', connectionId: 'ssh-1' }],
       sshTargetLabels: new Map([['ssh-1', 'Builder']]),
       sshConnectionStates: new Map([
@@ -238,7 +242,9 @@ describe('WorktreeJumpPalette', () => {
     })
 
     const badge = `[aria-label="Host: ${getExecutionHostLabel('local')}"]`
-    expect(testContainer.querySelector(`[data-command-item*="worktree:"] ${badge}`)).not.toBeNull()
+    expect(
+      testContainer.querySelector('[data-command-item*="folder"] [aria-label="Host: Builder"]')
+    ).not.toBeNull()
     expect(
       testContainer.querySelector(`[data-command-item*="workspace-tab:"] ${badge}`)
     ).not.toBeNull()

--- a/src/renderer/src/components/WorktreeJumpPalette.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.test.tsx
@@ -8,7 +8,7 @@ import type * as ReactI18Next from 'react-i18next'
 import { useAppStore } from '@/store'
 import type { AppState } from '@/store/types'
 import WorktreeJumpPalette from './WorktreeJumpPalette'
-import { makeRepo, makeWorktree } from './worktree-jump-palette-test-fixtures'
+import { makeRecentTabState, makeRepo, makeWorktree } from './worktree-jump-palette-test-fixtures'
 
 const { activateAndRevealWorktree } = vi.hoisted(() => ({
   activateAndRevealWorktree: vi.fn(() => false)
@@ -48,9 +48,10 @@ vi.mock('@/components/repo/RepoBadgeLabel', () => ({
   RepoBadgeMark: () => <span data-repo-badge-mark="true" />
 }))
 
-vi.mock('@/components/cmd-j/palette-host-badge', () => ({
-  getPaletteHostBadge: () => null
+const { getPaletteHostBadge } = vi.hoisted(() => ({
+  getPaletteHostBadge: vi.fn(() => null as { hostId: 'local'; label: string } | null)
 }))
+vi.mock('@/components/cmd-j/palette-host-badge', () => ({ getPaletteHostBadge }))
 
 // Why: activation reaches into window.api and the whole worktree-reveal path; the palette's own
 // contract is which result it hands over, so stub the boundary and assert on that.
@@ -191,6 +192,7 @@ describe('WorktreeJumpPalette', () => {
     globalThis.IS_REACT_ACT_ENVIRONMENT = true
     setCommandQuery = null
     activateAndRevealWorktree.mockClear()
+    getPaletteHostBadge.mockReturnValue(null)
     useAppStore.setState(initialAppState, true)
     testContainer = document.createElement('div')
     document.body.appendChild(testContainer)
@@ -228,6 +230,17 @@ describe('WorktreeJumpPalette', () => {
     // Why kept: the exemption keys on isMainWorktree, not the branch name, so a
     // branchless folder workspace is the project's entry point too.
     expect(testContainer.textContent).toContain('Folder workspace')
+  })
+
+  it('renders the owning host badge on worktree and tab rows', async () => {
+    getPaletteHostBadge.mockReturnValue({ hostId: 'local', label: 'Local Mac' })
+    await renderPalette(makeRecentTabState())
+
+    const badge = '[aria-label="Host: Local Mac"]'
+    expect(testContainer.querySelector(`[data-command-item*="worktree:"] ${badge}`)).not.toBeNull()
+    expect(
+      testContainer.querySelector(`[data-command-item*="workspace-tab:"] ${badge}`)
+    ).not.toBeNull()
   })
 
   it('keeps the explicit default-branch filter authoritative', async () => {

--- a/src/renderer/src/components/WorktreeJumpPalette.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { fireEvent } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as ReactI18Next from 'react-i18next'
+import { getExecutionHostLabel } from '../../../shared/execution-host'
 import { useAppStore } from '@/store'
 import type { AppState } from '@/store/types'
 import WorktreeJumpPalette from './WorktreeJumpPalette'
@@ -236,7 +237,7 @@ describe('WorktreeJumpPalette', () => {
       ])
     })
 
-    const badge = '[aria-label^="Host:"]'
+    const badge = `[aria-label="Host: ${getExecutionHostLabel('local')}"]`
     expect(testContainer.querySelector(`[data-command-item*="worktree:"] ${badge}`)).not.toBeNull()
     expect(
       testContainer.querySelector(`[data-command-item*="workspace-tab:"] ${badge}`)

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -141,6 +141,7 @@ import {
 import { RepoBadgeMark } from '@/components/repo/RepoBadgeLabel'
 import { buildSidebarHostOptions } from '@/components/sidebar/sidebar-host-options'
 import { getPaletteHostBadge } from '@/components/cmd-j/palette-host-badge'
+import PaletteHostBadgeChip from '@/components/cmd-j/PaletteHostBadgeChip'
 import { getWorktreeHostIdentity } from '../../../shared/worktree/host-qualified-identity'
 import { getRepoHostIdentity } from '@/store/slices/repo-host-identity'
 import type { Repo } from '../../../shared/repo-types'
@@ -3221,6 +3222,7 @@ function WorktreeJumpPaletteContent({
                   : null
                 const isSshDisconnected = sshStatus != null && sshStatus !== 'connected'
                 const sessionAge = formatPaletteSessionAge(worktree.lastActivityAt, paletteNowMs)
+                const hostBadge = getPaletteHostBadge(repo, hostOptions, hostFilterActive)
                 return (
                   <CommandItem
                     key={renderKey}
@@ -3329,6 +3331,7 @@ function WorktreeJumpPaletteContent({
                           )}
                         </div>
                         <div className="flex shrink-0 items-center gap-1.5">
+                          <PaletteHostBadgeChip badge={hostBadge} />
                           {repoName && (
                             <span className="inline-flex max-w-[180px] items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 text-[11px] font-semibold leading-none text-foreground">
                               <RepoBadgeMark color={repo?.badgeColor} />
@@ -3350,6 +3353,9 @@ function WorktreeJumpPaletteContent({
               if (entry.type === 'project-target') {
                 const result = entry.result
                 const isProject = result.kind === 'project'
+                const hostBadge = isProject
+                  ? getPaletteHostBadge(result.repo, hostOptions, hostFilterActive)
+                  : null
                 const badgeLabel = isProject
                   ? translate('auto.components.WorktreeJumpPalette.projectBadge', 'Project')
                   : translate('auto.components.WorktreeJumpPalette.repoGroupBadge', 'Repo group')
@@ -3377,6 +3383,7 @@ function WorktreeJumpPaletteContent({
                         </div>
                         {isProject ? (
                           <div className="flex shrink-0 items-center gap-1.5">
+                            <PaletteHostBadgeChip badge={hostBadge} />
                             <span className="inline-flex max-w-[180px] items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 text-[11px] font-semibold leading-none text-foreground">
                               <RepoBadgeMark color={result.repo.badgeColor} />
                               <span className="truncate">{result.repo.displayName}</span>
@@ -3434,6 +3441,11 @@ function WorktreeJumpPaletteContent({
                   ? resolveRepoForWorktree(workspaceTabWorktree)
                   : undefined
                 const workspaceTabRepoName = workspaceTabRepo?.displayName ?? result.repoName
+                const workspaceTabHostBadge = getPaletteHostBadge(
+                  workspaceTabRepo,
+                  hostOptions,
+                  hostFilterActive
+                )
                 const workspaceTabFallback =
                   result.contentType === 'terminal' && result.occupantAgent ? (
                     <span
@@ -3500,6 +3512,7 @@ function WorktreeJumpPaletteContent({
                             worktree={workspaceTabWorktree}
                             className="max-w-[280px] truncate text-[12px] font-medium text-muted-foreground"
                           />
+                          <PaletteHostBadgeChip badge={workspaceTabHostBadge} />
                           {workspaceTabRepoName && (
                             <span className="inline-flex max-w-[180px] items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 text-[11px] font-semibold leading-none text-foreground">
                               <RepoBadgeMark color={workspaceTabRepo?.badgeColor} />
@@ -3529,6 +3542,11 @@ function WorktreeJumpPaletteContent({
                   ? resolveRepoForWorktree(simulatorWorktree)
                   : undefined
                 const simulatorRepoName = simulatorRepo?.displayName ?? result.repoName
+                const simulatorHostBadge = getPaletteHostBadge(
+                  simulatorRepo,
+                  hostOptions,
+                  hostFilterActive
+                )
                 const sessionAge = formatPaletteSessionAge(
                   result.lastActiveAt ?? null,
                   paletteNowMs
@@ -3582,6 +3600,7 @@ function WorktreeJumpPaletteContent({
                             worktree={simulatorWorktree}
                             className="max-w-[280px] truncate text-[12px] font-medium text-muted-foreground"
                           />
+                          <PaletteHostBadgeChip badge={simulatorHostBadge} />
                           {simulatorRepoName && (
                             <span className="inline-flex max-w-[180px] items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 text-[11px] font-semibold leading-none text-foreground">
                               <RepoBadgeMark color={simulatorRepo?.badgeColor} />
@@ -3610,6 +3629,11 @@ function WorktreeJumpPaletteContent({
                 ? resolveRepoForWorktree(browserWorktree)
                 : undefined
               const browserRepoName = browserRepo?.displayName ?? result.repoName
+              const browserHostBadge = getPaletteHostBadge(
+                browserRepo,
+                hostOptions,
+                hostFilterActive
+              )
               const sessionAge = formatPaletteSessionAge(result.lastActiveAt ?? null, paletteNowMs)
 
               return (
@@ -3660,6 +3684,7 @@ function WorktreeJumpPaletteContent({
                           worktree={browserWorktree}
                           className="max-w-[280px] truncate text-[12px] font-medium text-muted-foreground"
                         />
+                        <PaletteHostBadgeChip badge={browserHostBadge} />
                         {browserRepoName && (
                           <span className="inline-flex max-w-[180px] items-center gap-1.5 rounded-md border border-border bg-muted px-2 py-1 text-[11px] font-semibold leading-none text-foreground">
                             <RepoBadgeMark color={browserRepo?.badgeColor} />

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -154,7 +154,11 @@ import { buildPaletteListEntryRenderKeys } from '@/components/cmd-j/palette-list
 import { formatPaletteSessionAge } from '@/components/cmd-j/palette-session-age'
 import PaletteFilterMenu from '@/components/cmd-j/PaletteFilterMenu'
 import PaletteFilterChips from '@/components/cmd-j/PaletteFilterChips'
-import { buildPaletteFilterModel } from '@/components/cmd-j/palette-filter-options'
+import {
+  buildPaletteFilterModel,
+  resolveRepoFilterHostId,
+  resolveWorktreeFilterHostId
+} from '@/components/cmd-j/palette-filter-options'
 import { getProjectGroupExecutionHostIdForRows } from '@/components/sidebar/worktree-list/listing/host-filtering'
 import {
   buildPaletteFilterPredicate,
@@ -895,6 +899,17 @@ function WorktreeJumpPaletteContent({
   }, [filterModel])
   const filterActive = isPaletteFilterActive(filter)
   const hostFilterActive = filter.hostIds.length > 0
+  const getWorktreeHostBadge = useCallback(
+    (worktree: Worktree | undefined, fallbackHostId?: ExecutionHostId) =>
+      getPaletteHostBadge(
+        worktree
+          ? resolveWorktreeFilterHostId(worktree, filterModel.hostIdByRepoId, defaultHostId)
+          : fallbackHostId,
+        hostOptions,
+        hostFilterActive
+      ),
+    [defaultHostId, filterModel.hostIdByRepoId, hostFilterActive, hostOptions]
+  )
   const filterPredicate = useMemo(
     () => buildPaletteFilterPredicate(filter, filterModel),
     [filter, filterModel]
@@ -1102,17 +1117,13 @@ function WorktreeJumpPaletteContent({
   const hostLabelByWorktreeId = useMemo(() => {
     const labels = new Map<string, string>()
     for (const worktree of allWorktrees) {
-      const badge = getPaletteHostBadge(
-        resolveRepoForWorktree(worktree),
-        hostOptions,
-        hostFilterActive
-      )
+      const badge = getWorktreeHostBadge(worktree)
       if (badge) {
         labels.set(getWorktreeHostIdentity(worktree), badge.label)
       }
     }
     return labels
-  }, [allWorktrees, hostFilterActive, hostOptions, resolveRepoForWorktree])
+  }, [allWorktrees, getWorktreeHostBadge])
 
   // Why keyed on the unsorted list: normalized documents depend only on text
   // inputs, so re-sorting for recency re-ranks without re-normalizing anything.
@@ -3222,7 +3233,7 @@ function WorktreeJumpPaletteContent({
                   : null
                 const isSshDisconnected = sshStatus != null && sshStatus !== 'connected'
                 const sessionAge = formatPaletteSessionAge(worktree.lastActivityAt, paletteNowMs)
-                const hostBadge = getPaletteHostBadge(repo, hostOptions, hostFilterActive)
+                const hostBadge = getWorktreeHostBadge(worktree)
                 return (
                   <CommandItem
                     key={renderKey}
@@ -3354,7 +3365,15 @@ function WorktreeJumpPaletteContent({
                 const result = entry.result
                 const isProject = result.kind === 'project'
                 const hostBadge = isProject
-                  ? getPaletteHostBadge(result.repo, hostOptions, hostFilterActive)
+                  ? getPaletteHostBadge(
+                      resolveRepoFilterHostId(
+                        result.repo.id,
+                        filterModel.hostIdByRepoId,
+                        defaultHostId
+                      ),
+                      hostOptions,
+                      hostFilterActive
+                    )
                   : null
                 const badgeLabel = isProject
                   ? translate('auto.components.WorktreeJumpPalette.projectBadge', 'Project')
@@ -3441,10 +3460,9 @@ function WorktreeJumpPaletteContent({
                   ? resolveRepoForWorktree(workspaceTabWorktree)
                   : undefined
                 const workspaceTabRepoName = workspaceTabRepo?.displayName ?? result.repoName
-                const workspaceTabHostBadge = getPaletteHostBadge(
-                  workspaceTabRepo,
-                  hostOptions,
-                  hostFilterActive
+                const workspaceTabHostBadge = getWorktreeHostBadge(
+                  workspaceTabWorktree,
+                  result.executionHostId
                 )
                 const workspaceTabFallback =
                   result.contentType === 'terminal' && result.occupantAgent ? (
@@ -3542,10 +3560,9 @@ function WorktreeJumpPaletteContent({
                   ? resolveRepoForWorktree(simulatorWorktree)
                   : undefined
                 const simulatorRepoName = simulatorRepo?.displayName ?? result.repoName
-                const simulatorHostBadge = getPaletteHostBadge(
-                  simulatorRepo,
-                  hostOptions,
-                  hostFilterActive
+                const simulatorHostBadge = getWorktreeHostBadge(
+                  simulatorWorktree,
+                  result.executionHostId
                 )
                 const sessionAge = formatPaletteSessionAge(
                   result.lastActiveAt ?? null,
@@ -3629,11 +3646,7 @@ function WorktreeJumpPaletteContent({
                 ? resolveRepoForWorktree(browserWorktree)
                 : undefined
               const browserRepoName = browserRepo?.displayName ?? result.repoName
-              const browserHostBadge = getPaletteHostBadge(
-                browserRepo,
-                hostOptions,
-                hostFilterActive
-              )
+              const browserHostBadge = getWorktreeHostBadge(browserWorktree, result.executionHostId)
               const sessionAge = formatPaletteSessionAge(result.lastActiveAt ?? null, paletteNowMs)
 
               return (

--- a/src/renderer/src/components/cmd-j/PaletteHostBadgeChip.tsx
+++ b/src/renderer/src/components/cmd-j/PaletteHostBadgeChip.tsx
@@ -1,0 +1,25 @@
+import { translate } from '@/i18n/i18n'
+import type { PaletteHostBadge } from './palette-host-badge'
+
+export default function PaletteHostBadgeChip({
+  badge
+}: {
+  badge: PaletteHostBadge | null
+}): React.JSX.Element | null {
+  if (!badge) {
+    return null
+  }
+
+  return (
+    <span
+      aria-label={translate(
+        'auto.components.WorktreeJumpPalette.paletteHostBadge',
+        'Host: {{value0}}',
+        { value0: badge.label }
+      )}
+      className="max-w-[140px] truncate rounded-[6px] border border-border/60 bg-background px-1.5 py-px text-[9px] font-medium leading-normal text-muted-foreground/88"
+    >
+      {badge.label}
+    </span>
+  )
+}

--- a/src/renderer/src/components/cmd-j/palette-host-badge.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-host-badge.test.ts
@@ -20,7 +20,7 @@ describe('getPaletteHostBadge', () => {
       settings: { activeRuntimeEnvironmentId: null }
     })
 
-    expect(getPaletteHostBadge({ connectionId: null }, hosts)).toBeNull()
+    expect(getPaletteHostBadge('local', hosts)).toBeNull()
   })
 
   it('returns null when the only non-local host is configured but disconnected', () => {
@@ -32,7 +32,7 @@ describe('getPaletteHostBadge', () => {
 
     // No connection state -> the SSH host is 'disconnected', so there's nothing
     // live to disambiguate from and rows stay badge-free.
-    expect(getPaletteHostBadge({ connectionId: null }, hosts)).toBeNull()
+    expect(getPaletteHostBadge('local', hosts)).toBeNull()
   })
 
   it('badges a disconnected host anyway when a host filter is applied', () => {
@@ -44,7 +44,7 @@ describe('getPaletteHostBadge', () => {
 
     // Why: with a host filter on, the badge is the only thing explaining which
     // rows survived, so liveness must not suppress it.
-    expect(getPaletteHostBadge({ connectionId: 'ssh-1' }, hosts, true)).toEqual({
+    expect(getPaletteHostBadge('ssh:ssh-1', hosts, true)).toEqual({
       hostId: 'ssh:ssh-1',
       label: 'Builder'
     })
@@ -58,7 +58,7 @@ describe('getPaletteHostBadge', () => {
       settings: { activeRuntimeEnvironmentId: null }
     })
 
-    expect(getPaletteHostBadge({ connectionId: null }, hosts)).toEqual({
+    expect(getPaletteHostBadge('local', hosts)).toEqual({
       hostId: 'local',
       label: LOCAL_HOST_LABEL
     })
@@ -72,7 +72,7 @@ describe('getPaletteHostBadge', () => {
       settings: { activeRuntimeEnvironmentId: null }
     })
 
-    expect(getPaletteHostBadge({ connectionId: 'ssh-1' }, hosts)).toEqual({
+    expect(getPaletteHostBadge('ssh:ssh-1', hosts)).toEqual({
       hostId: 'ssh:ssh-1',
       label: 'Builder'
     })
@@ -104,7 +104,7 @@ describe('getPaletteHostBadge', () => {
       ])
     })
 
-    expect(getPaletteHostBadge({ executionHostId: 'runtime:env-1' }, hosts)).toEqual({
+    expect(getPaletteHostBadge('runtime:env-1', hosts)).toEqual({
       hostId: 'runtime:env-1',
       label: 'env-1'
     })
@@ -117,10 +117,10 @@ describe('getPaletteHostBadge', () => {
       settings: { activeRuntimeEnvironmentId: null }
     })
 
-    expect(getPaletteHostBadge({ connectionId: null }, hosts)).toBeNull()
+    expect(getPaletteHostBadge('local', hosts)).toBeNull()
   })
 
-  it('maps repos with no executionHostId/connectionId to local', () => {
+  it('uses the local host label for local identities', () => {
     const hosts = buildSidebarHostOptions({
       repos: [{ connectionId: 'ssh-1' }],
       sshTargetLabels: new Map([['ssh-1', 'Builder']]),
@@ -128,13 +128,13 @@ describe('getPaletteHostBadge', () => {
       settings: { activeRuntimeEnvironmentId: null }
     })
 
-    expect(getPaletteHostBadge({}, hosts)).toEqual({
+    expect(getPaletteHostBadge('local', hosts)).toEqual({
       hostId: 'local',
       label: LOCAL_HOST_LABEL
     })
   })
 
-  it('returns null when the repo is missing', () => {
+  it('returns null when the host identity is missing', () => {
     const hosts = buildSidebarHostOptions({
       repos: [{ connectionId: 'ssh-1' }],
       sshTargetLabels: new Map([['ssh-1', 'Builder']]),

--- a/src/renderer/src/components/cmd-j/palette-host-badge.ts
+++ b/src/renderer/src/components/cmd-j/palette-host-badge.ts
@@ -1,9 +1,4 @@
-import type { Repo } from '../../../../shared/repo-types'
-import {
-  getRepoExecutionHostId,
-  LOCAL_EXECUTION_HOST_ID,
-  type ExecutionHostId
-} from '../../../../shared/execution-host'
+import { LOCAL_EXECUTION_HOST_ID, type ExecutionHostId } from '../../../../shared/execution-host'
 import type { SidebarHostOption } from '../sidebar/sidebar-host-options'
 
 export type PaletteHostBadge = {
@@ -22,16 +17,15 @@ function hasActiveRemoteHost(hostOptions: readonly SidebarHostOption[]): boolean
 }
 
 export function getPaletteHostBadge(
-  repo: Pick<Repo, 'connectionId' | 'executionHostId'> | null | undefined,
+  hostId: ExecutionHostId | null | undefined,
   hostOptions: readonly SidebarHostOption[],
   // Why: with a host filter applied the badge is the only thing explaining which
   // rows survived, so it must show even when every remote is disconnected.
   alwaysShowHostLabel = false
 ): PaletteHostBadge | null {
-  if (!repo || (!alwaysShowHostLabel && !hasActiveRemoteHost(hostOptions))) {
+  if (!hostId || (!alwaysShowHostLabel && !hasActiveRemoteHost(hostOptions))) {
     return null
   }
-  const hostId = getRepoExecutionHostId(repo)
   const host = hostOptions.find((option) => option.id === hostId)
   if (!host) {
     return null


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​73 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​57 |

<!-- /orca-pr-loc -->

## Summary

- restores the conditional host badge affordance in Cmd-J
- labels worktree, folder-workspace, project, workspace-tab, simulator-tab, and browser-page results
- uses the same explicit execution-host identity as host filtering, so visible ownership cannot diverge from routing/filter authority
- reuses the existing policy: badges appear only when a live remote makes host identity relevant, or when a host filter is active
- keeps the visual primitive out of the already-large palette component

## Reproduction

On latest main, seed one local workspace and one connected SSH workspace with the same display name, then open Cmd-J. Both candidates are present and their backing owners are `local` and `ssh:proof-remote`, but neither row identifies its host.

The rendering contract fails on main because no host badge exists. It passes with this change for repo-backed worktree, folder-workspace, and workspace-tab rows through the real connected-SSH policy. The exact expected owner label is asserted.

## Visual proof

| Before | After |
| --- | --- |
| ![Cmd-J rows without host labels](https://github.com/user-attachments/assets/53ba1428-8064-4c91-8d20-e9d3216b18f7) | ![Cmd-J local, SSH, and folder rows with host labels](https://github.com/user-attachments/assets/f4331b97-e8bd-48df-918a-237ce23a25bb) |

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/WorktreeJumpPalette.test.tsx src/renderer/src/components/cmd-j/palette-host-badge.test.ts src/renderer/src/lib/browser-palette-page-entries.test.ts src/renderer/src/lib/simulator-palette-search.test.ts src/renderer/src/lib/resolved-worktree-execution-host.test.ts` (55 passed)
- `pnpm run typecheck`
- `pnpm lint`
- Electron CDP journey on feature HEAD `7781d6f87d`, before subsequent main rebases, with full-context proof and backing identities `local`, `ssh:proof-remote`, and SSH-owned folder workspace
- three independent same-worktree OpenCode reviews on feature HEAD `948d5c5bf1`: 3/3 `REVIEW CLEAN`
- latest-main rebase HEAD `3d84bde900`: conflict-free; the same 55 focused tests and full typecheck pass

Linear: https://linear.app/stably/issue/STA-5061


