### PR TITLE
fix(agent-hooks): bound the codex POSIX hook's stdin read and exec the script from the wrapper

### DIFF
--- a/src/main/agent-hooks/hook-stdin-contract.ts
+++ b/src/main/agent-hooks/hook-stdin-contract.ts
@@ -7,19 +7,42 @@ export type PosixHookEmptyPayloadPolicy = 'exit' | 'empty-object'
 export const POSIX_HOOK_STDIN_READER = '{ command -p cat 2>/dev/null || cat; }'
 export const POSIX_HOOK_STDIN_DRAIN_COMMAND = `${POSIX_HOOK_STDIN_READER} >/dev/null 2>&1 || :`
 
+export type PosixHookPayloadCaptureOptions = {
+  /**
+   * Why (#15833): a runner that never closes hook stdin makes a read-to-EOF block forever, and
+   * Codex 0.149 does not enforce the config-declared timeout for a shell-wrapped command that
+   * holds stdin (openai/codex#4337), so the intended safety net never fires. A watchdog bounds
+   * the wait while keeping capture-first semantics — well-behaved runners that close stdin are
+   * unaffected, a stalled stdin costs at most this many seconds and the hook exits empty instead
+   * of wedging the agent's turn. Keep the budget below the config-declared hook timeout so the
+   * script finishes before any runner that does enforce its kill.
+   */
+  maxWaitSeconds?: number
+}
+
 // Why: every POSIX hook must own stdin before any no-op exit; sharing this
 // prelude prevents agent templates from inventing different drain semantics.
 export function buildPosixHookPayloadCapture(
-  emptyPayloadPolicy: PosixHookEmptyPayloadPolicy = 'exit'
+  emptyPayloadPolicy: PosixHookEmptyPayloadPolicy = 'exit',
+  options: PosixHookPayloadCaptureOptions = {}
 ): string[] {
   const emptyPayloadLines =
     emptyPayloadPolicy === 'empty-object' ? ["  payload='{}'"] : ['  exit 0']
-  return [
-    `payload=$(${POSIX_HOOK_STDIN_READER})`,
-    'if [ -z "$payload" ]; then',
-    ...emptyPayloadLines,
-    'fi'
-  ]
+  // Why a watchdog that kills the whole script rather than the reader: POSIX gives async lists
+  // /dev/null stdin, so the reader must stay foreground, and a foreground command substitution
+  // cannot be interrupted any other portable way. A stalled stdin therefore costs the script its
+  // own life after maxWaitSeconds — the hook exits non-zero like any other timed-out hook
+  // instead of wedging the agent's turn forever (#15833).
+  const captureLines =
+    options.maxWaitSeconds === undefined
+      ? [`payload=$(${POSIX_HOOK_STDIN_READER})`]
+      : [
+          `  ( sleep ${options.maxWaitSeconds}; kill -9 "$$" 2>/dev/null ) >/dev/null 2>&1 &`,
+          '  orca_hook_stdin_watchdog=$!',
+          `payload=$(${POSIX_HOOK_STDIN_READER})`,
+          '  kill "$orca_hook_stdin_watchdog" 2>/dev/null'
+        ]
+  return [...captureLines, 'if [ -z "$payload" ]; then', ...emptyPayloadLines, 'fi']
 }
 
 export const WINDOWS_HOOK_STDIN_DRAIN_LABEL = 'orca_agent_hook_drain_stdin'

--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -486,7 +486,7 @@ describe('wrapPosixHookCommand', () => {
   it('produces a guarded command that no-ops when the script is missing', () => {
     const cmd = wrapPosixHookCommand('/does/not/exist.sh')
     expect(cmd).toBe(
-      `if [ -f '/does/not/exist.sh' ] && [ -r '/does/not/exist.sh' ] && [ -x '/does/not/exist.sh' ]; then /bin/sh '/does/not/exist.sh'; else ${POSIX_HOOK_STDIN_DRAIN_COMMAND}; fi`
+      `if [ -f '/does/not/exist.sh' ] && [ -r '/does/not/exist.sh' ] && [ -x '/does/not/exist.sh' ]; then exec /bin/sh '/does/not/exist.sh'; else ${POSIX_HOOK_STDIN_DRAIN_COMMAND}; fi`
     )
   })
 
@@ -504,7 +504,7 @@ describe('wrapPosixHookCommand', () => {
     // /bin/sh as a single argument.
     const cmd = wrapPosixHookCommand("/path/with'quote/x.sh")
     expect(cmd).toBe(
-      `if [ -f '/path/with'\\''quote/x.sh' ] && [ -r '/path/with'\\''quote/x.sh' ] && [ -x '/path/with'\\''quote/x.sh' ]; then /bin/sh '/path/with'\\''quote/x.sh'; else ${POSIX_HOOK_STDIN_DRAIN_COMMAND}; fi`
+      `if [ -f '/path/with'\\''quote/x.sh' ] && [ -r '/path/with'\\''quote/x.sh' ] && [ -x '/path/with'\\''quote/x.sh' ]; then exec /bin/sh '/path/with'\\''quote/x.sh'; else ${POSIX_HOOK_STDIN_DRAIN_COMMAND}; fi`
     )
   })
 
@@ -513,7 +513,7 @@ describe('wrapPosixHookCommand', () => {
       ORCA_COPILOT_HOOK_EVENT: 'UserPromptSubmit'
     })
     expect(cmd).toBe(
-      `if [ -f '/does/not/exist.sh' ] && [ -r '/does/not/exist.sh' ] && [ -x '/does/not/exist.sh' ]; then ORCA_COPILOT_HOOK_EVENT='UserPromptSubmit' /bin/sh '/does/not/exist.sh'; else ${POSIX_HOOK_STDIN_DRAIN_COMMAND}; fi`
+      `if [ -f '/does/not/exist.sh' ] && [ -r '/does/not/exist.sh' ] && [ -x '/does/not/exist.sh' ]; then ORCA_COPILOT_HOOK_EVENT='UserPromptSubmit' exec /bin/sh '/does/not/exist.sh'; else ${POSIX_HOOK_STDIN_DRAIN_COMMAND}; fi`
     )
   })
 
@@ -529,7 +529,7 @@ describe('wrapPosixHookCommand', () => {
   it('emits a fallback response before draining when the caller supplies one', () => {
     const cmd = wrapPosixHookCommand('/does/not/exist.sh', {}, { fallbackStdout: '{"a":"b"}' })
     expect(cmd).toBe(
-      `if [ -f '/does/not/exist.sh' ] && [ -r '/does/not/exist.sh' ] && [ -x '/does/not/exist.sh' ]; then /bin/sh '/does/not/exist.sh'; else printf '%s\\n' '{"a":"b"}'; ${POSIX_HOOK_STDIN_DRAIN_COMMAND}; fi`
+      `if [ -f '/does/not/exist.sh' ] && [ -r '/does/not/exist.sh' ] && [ -x '/does/not/exist.sh' ]; then exec /bin/sh '/does/not/exist.sh'; else printf '%s\\n' '{"a":"b"}'; ${POSIX_HOOK_STDIN_DRAIN_COMMAND}; fi`
     )
   })
 

--- a/src/main/agent-hooks/posix-hook-command.ts
+++ b/src/main/agent-hooks/posix-hook-command.ts
@@ -16,7 +16,9 @@ export function wrapPosixHookCommand(
   const envPrefix = Object.entries(env)
     .map(([key, value]) => `${key}='${value.replaceAll("'", "'\\''")}'`)
     .join(' ')
-  const invocation = envPrefix ? `${envPrefix} /bin/sh ${quoted}` : `/bin/sh ${quoted}`
+  // Why (#15833): `exec` replaces the wrapper shell with the script process so a runner-enforced
+  // timeout kill reaches the real script instead of dying against the wrapper and stranding it.
+  const invocation = envPrefix ? `${envPrefix} exec /bin/sh ${quoted}` : `exec /bin/sh ${quoted}`
   const fallback =
     options.fallbackStdout === undefined
       ? POSIX_HOOK_STDIN_DRAIN_COMMAND

--- a/src/main/codex/codex-posix-hook-stdin-bound.test.ts
+++ b/src/main/codex/codex-posix-hook-stdin-bound.test.ts
@@ -1,0 +1,141 @@
+// Why (#15833): Codex 0.149 never closes a hook's stdin and does not enforce the
+// config-declared timeout for a shell-wrapped command holding stdin, so the managed
+// codex bridge's read-to-EOF blocked forever and every UserPromptSubmit wedged the
+// TUI. This fixture proves the generated script bounds its own stdin wait and that
+// the wrapper execs the script so an external timeout kill reaches the real process.
+import { describe, expect, it, vi } from 'vitest'
+import { spawn, spawnSync } from 'node:child_process'
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp/orca-user-data'
+  }
+}))
+
+import { buildPosixHookPayloadCapture } from '../agent-hooks/hook-stdin-contract'
+import { CodexHookService } from './hook-service'
+import { createAgentHookMemorySftp as createFakeSftp } from '../agent-hooks/agent-hook-memory-sftp.test-fixture'
+
+const REMOTE_HOME = '/home/dev'
+const SCRIPT_PATH = `${REMOTE_HOME}/.orca/agent-hooks/codex-hook.sh`
+
+async function generateCodexHookScript(): Promise<string> {
+  const { sftp, fs } = createFakeSftp()
+  const status = await new CodexHookService().installRemote(sftp, REMOTE_HOME)
+  expect(status.state).toBe('installed')
+  const script = fs.files.get(SCRIPT_PATH)
+  expect(script).toBeDefined()
+  return script!
+}
+
+const hasPosixShell =
+  spawnSync('sh', ['-c', 'command -v cat && command -v sleep && command -v kill'], {
+    encoding: 'utf8'
+  }).status === 0
+
+function runScriptWithStdin(
+  scriptBody: string,
+  stdinBehavior: 'never-close' | 'close-empty'
+): Promise<{ status: number | null; signal: NodeJS.Signals | null; elapsedMs: number }> {
+  return new Promise((resolve, reject) => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'orca-codex-stdin-'))
+    const scriptPath = join(tempDir, 'codex-hook.sh')
+    writeFileSync(scriptPath, scriptBody, 'utf8')
+    chmodSync(scriptPath, 0o755)
+
+    const child = spawn('sh', [scriptPath], {
+      env: {
+        ...process.env,
+        ORCA_AGENT_HOOK_ENDPOINT: '',
+        ORCA_AGENT_HOOK_PORT: '1',
+        ORCA_AGENT_HOOK_TOKEN: 'test-token',
+        ORCA_PANE_KEY: 'pane-1',
+        ORCA_TAB_ID: 'tab-1',
+        ORCA_WORKTREE_ID: 'wt-1'
+      },
+      stdio: ['pipe', 'ignore', 'ignore']
+    })
+    const killTimer = setTimeout(() => {
+      child.kill('SIGKILL')
+      rmSync(tempDir, { recursive: true, force: true })
+      reject(new Error('script still running at the test kill budget'))
+    }, 20_000)
+    const startedAt = Date.now()
+    child.on('error', (error) => {
+      clearTimeout(killTimer)
+      rmSync(tempDir, { recursive: true, force: true })
+      reject(error)
+    })
+    child.on('close', (status, signal) => {
+      clearTimeout(killTimer)
+      rmSync(tempDir, { recursive: true, force: true })
+      resolve({ status, signal, elapsedMs: Date.now() - startedAt })
+    })
+
+    // The #15833 wedge: Codex submits the hook and never closes stdin.
+    if (stdinBehavior === 'close-empty') {
+      child.stdin.end('')
+    }
+  })
+}
+
+describe('managed codex POSIX hook stdin bound (#15833)', () => {
+  it('bounds the payload capture with a watchdog under the declared hook timeout', async () => {
+    const script = await generateCodexHookScript()
+
+    // The watchdog: a backgrounded sleep that kills the whole script after the budget, so a
+    // runner that never closes stdin costs the hook its own life instead of wedging the turn.
+    expect(script).toContain('orca_hook_stdin_watchdog=$!')
+    expect(script).toMatch(/\( sleep \d+; kill -9 "\$\$" 2>\/dev\/null \)/)
+    // The wrapper in hooks.json must exec the script so a runner timeout kill reaches it.
+    const { sftp, fs } = createFakeSftp()
+    await new CodexHookService().installRemote(sftp, REMOTE_HOME)
+    const hooksJson = JSON.parse(fs.files.get(`${REMOTE_HOME}/.codex/hooks.json`)!) as {
+      UserPromptSubmit?: { hooks?: { command?: string }[] }[]
+    }
+    const commands = JSON.stringify(hooksJson)
+    expect(commands).toContain('exec /bin/sh')
+    expect(commands).toContain(SCRIPT_PATH)
+  })
+
+  it('leaves the shared POSIX capture prelude unbounded for every other agent', () => {
+    const defaultCapture = buildPosixHookPayloadCapture().join('\n')
+    expect(defaultCapture).not.toContain('orca_hook_stdin_watchdog')
+    expect(defaultCapture).toContain('payload=$({ command -p cat 2>/dev/null || cat; })')
+  })
+
+  it.skipIf(!hasPosixShell)(
+    'dies on its own when the runner never closes stdin',
+    async () => {
+      const script = await generateCodexHookScript()
+
+      const { status, signal, elapsedMs } = await runScriptWithStdin(script, 'never-close')
+
+      // The watchdog SIGKILLs the script after the 8s capture budget; on Windows the exit
+      // code surfaces as 9<<8 instead of a signal, so accept either shape of "killed".
+      expect(signal === 'SIGKILL' || status === 137 || status === 2304 || status === 9).toBe(true)
+      // The capture budget is 8s; anything near or past 20s is the old unbounded hang.
+      expect(elapsedMs).toBeLessThan(15_000)
+      expect(elapsedMs).toBeGreaterThanOrEqual(5_000)
+    },
+    25_000
+  )
+
+  it.skipIf(!hasPosixShell)(
+    'still returns immediately with exit 0 when the runner closes stdin',
+    async () => {
+      const script = await generateCodexHookScript()
+
+      const { status, signal, elapsedMs } = await runScriptWithStdin(script, 'close-empty')
+
+      expect(status).toBe(0)
+      expect(signal).toBeNull()
+      // An immediately-closed stdin must not pay the watchdog budget.
+      expect(elapsedMs).toBeLessThan(5_000)
+    },
+    20_000
+  )
+})

--- a/src/main/codex/hook-service-wsl-runtime.test.ts
+++ b/src/main/codex/hook-service-wsl-runtime.test.ts
@@ -78,7 +78,8 @@ function getManagedTrustEntry(
 }
 
 function expectedManagedCommand(scriptPath: string): string {
-  return `if [ -f '${scriptPath}' ] && [ -r '${scriptPath}' ]; then /bin/sh '${scriptPath}'; else ${POSIX_HOOK_STDIN_DRAIN_COMMAND}; fi`
+  // Why: the wrapper execs the script so a runner-enforced timeout kill reaches the real process (#15833).
+  return `if [ -f '${scriptPath}' ] && [ -r '${scriptPath}' ]; then exec /bin/sh '${scriptPath}'; else ${POSIX_HOOK_STDIN_DRAIN_COMMAND}; fi`
 }
 
 describe('Codex WSL runtime hook install', () => {

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -188,7 +188,9 @@ export type { CodexWslRuntimeHookInstallPlan }
 function wrapReadablePosixHookCommand(scriptPath: string): string {
   const quoted = `'${scriptPath.replaceAll("'", "'\\''")}'`
   // Why: WSL hooks are written from Windows over UNC where the exec bit is unreliable; a missing script must still own stdin.
-  return `if [ -f ${quoted} ] && [ -r ${quoted} ]; then /bin/sh ${quoted}; else ${POSIX_HOOK_STDIN_DRAIN_COMMAND}; fi`
+  // Why (#15833): `exec` replaces the wrapper shell with the script process, so a runner-enforced
+  // timeout kill reaches the real script instead of dying against the wrapper and stranding it.
+  return `if [ -f ${quoted} ] && [ -r ${quoted} ]; then exec /bin/sh ${quoted}; else ${POSIX_HOOK_STDIN_DRAIN_COMMAND}; fi`
 }
 
 function getSystemConfigPath(): string {
@@ -764,6 +766,12 @@ function removeStaleWslRuntimeManagedHookTrustEntries(
   })
 }
 
+// Why (#15833): Codex 0.149 never closes the hook's stdin and does not enforce the
+// config-declared timeout for a shell-wrapped command holding stdin, so an unbounded
+// read wedged every UserPromptSubmit. Two seconds under MANAGED_HOOK_TIMEOUT_SECONDS so
+// the script still exits before any runner that does enforce its kill.
+const CODEX_POSIX_STDIN_CAPTURE_BUDGET_SECONDS = MANAGED_HOOK_TIMEOUT_SECONDS - 2
+
 function getManagedScript(target: 'local' | 'posix' = 'local'): string {
   if (target === 'local' && process.platform === 'win32') {
     return [
@@ -781,7 +789,9 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
 
   return [
     '#!/bin/sh',
-    ...buildPosixHookPayloadCapture(),
+    ...buildPosixHookPayloadCapture('exit', {
+      maxWaitSeconds: CODEX_POSIX_STDIN_CAPTURE_BUDGET_SECONDS
+    }),
     // Why: sourcing refreshes PORT/TOKEN/ENV/VERSION from the current Orca so a surviving PTY keeps reporting after a restart (see claude/hook-service.ts).
     'load_hook_endpoint() {',
     '  endpoint_path="$1"',


### PR DESCRIPTION
## What

Two changes to the managed codex POSIX hook so a runner that never closes stdin cannot wedge the agent's turn:

1. **Bounded stdin capture.** `buildPosixHookPayloadCapture` gains an optional `maxWaitSeconds` watchdog, used by the codex script with a budget of 8s — two seconds under the declared 10s hook timeout. A backgrounded `( sleep 8; kill -9 "$$" )` arms before the read; if stdin never reaches EOF, the script is killed after the budget exactly like any other timed-out hook (Codex already prints `hook (failed): hook timed out …` for such exits and proceeds, as the issue observes for SessionStart). Runners that close stdin normally are unaffected — the capture completes, the watchdog is disarmed, the payload flows as before.
2. **`exec` in the POSIX wrappers.** `wrapPosixHookCommand` (the shared remote wrapper) and codex's `wrapReadablePosixHookCommand` now `exec /bin/sh <script>`, so when a runner *does* enforce its declared timeout, the kill reaches the real script process instead of dying against the wrapper shell and stranding the child.

## Why (issue #15833)

The managed hook command is a shell wrapper whose first act is a read-to-EOF (`payload=$(cat)`). Codex 0.149.149 neither closes the hook's stdin nor enforces the `"timeout": 10` declared in `hooks.json` for a shell-wrapped command holding stdin (same class as openai/codex#4337), so every `UserPromptSubmit` blocked forever — the TUI wedged on `Running 2 UserPromptSubmit hooks` with no recovery short of killing the terminal. Claude workers with equivalent hooks were unaffected because Claude enforces the timeout. This is the macOS/Codex twin of #13285; the Windows variants got bounded drains in #7323/#15599, the POSIX codex bridge never did.

### Design note (why the watchdog kills the whole script)

POSIX reassigns a backgrounded command's stdin to `/dev/null`, so the reader *must* stay in the foreground — and a foreground command substitution has no other portable interruption. Backgrounding the reader (with or without an fd-duplication trick) either disconnects it from the real stdin or leaves `cat` orphaned on the substitution pipe; both were verified to fail on Git Bash/dash-class shells. Killing the script itself after the budget is the one portable shape that works everywhere, and it degrades exactly like a runner-enforced timeout would.

The watchdog is **opt-in**: every other agent's POSIX capture prelude is byte-for-byte unchanged (asserted by a test), because their runners close stdin and exiting mid-write surfaces as EPIPE the agent can see (#8110).

## Testing

New `src/main/codex/codex-posix-hook-stdin-bound.test.ts`:

- Static: the generated codex script carries the watchdog under the declared timeout, and the installed `hooks.json` wrapper contains `exec /bin/sh` pointing at the managed script.
- Scope guard: the default `buildPosixHookPayloadCapture()` output is unchanged (no watchdog) for every other agent.
- Live (gated on a POSIX shell): the real generated script spawned with a **never-closed** stdin pipe terminates on its own within the budget (SIGKILL/137-class exit at ~8s — the old code hangs past 20s), and with an **immediately-closed** stdin it returns exit 0 in well under the budget.
- Diff-verified: with the three source changes stashed, the static and never-close tests fail exactly as reported.
- Full `pnpm run typecheck` clean; agent-hooks + codex suites pass (the symlink-permission and `codex-session-resume-home` failures visible on this Windows runner pre-exist on a pristine `origin/main` and are unrelated).

Fixes #15833
