### PR TITLE
fix(mobile): remove close tabs to the right action

### DIFF
--- a/mobile/src/session/mobile-bulk-close-sheet-actions.ts
+++ b/mobile/src/session/mobile-bulk-close-sheet-actions.ts
@@ -16,7 +16,7 @@ type BulkCloseSheetDeps = {
 }
 
 /**
- * Builds the long-press bulk-close entries (Close Others / Left / Right) shared
+ * Builds the long-press bulk-close entries (Close Others / Left) shared
  * by every session tab sheet. Lives outside the session route to keep the
  * orchestration out of its max-lines budget; anchors are passed by tab id so
  * sheets never need the full tab object.

--- a/mobile/src/session/mobile-tab-close-selection.test.ts
+++ b/mobile/src/session/mobile-tab-close-selection.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { selectBulkCloseTabs } from './mobile-tab-close-selection'
+import { BULK_TAB_CLOSE_ACTIONS, selectBulkCloseTabs } from './mobile-tab-close-selection'
 
 const tab = (id: string, isDirty?: boolean, isPinned?: boolean) => ({
   id,
@@ -10,6 +10,13 @@ const tab = (id: string, isDirty?: boolean, isPinned?: boolean) => ({
 describe('selectBulkCloseTabs', () => {
   const tabs = [tab('a'), tab('b'), tab('c'), tab('d')]
 
+  it('offers only close-others and close-left actions', () => {
+    expect(BULK_TAB_CLOSE_ACTIONS).toEqual([
+      { mode: 'others', label: 'Close Other Tabs' },
+      { mode: 'left', label: 'Close Tabs to the Left' }
+    ])
+  })
+
   it('selects every tab except the anchor for mode "others"', () => {
     expect(selectBulkCloseTabs(tabs, 'b', 'others').map((t) => t.id)).toEqual(['a', 'c', 'd'])
   })
@@ -18,13 +25,8 @@ describe('selectBulkCloseTabs', () => {
     expect(selectBulkCloseTabs(tabs, 'c', 'left').map((t) => t.id)).toEqual(['a', 'b'])
   })
 
-  it('selects tabs after the anchor for mode "right"', () => {
-    expect(selectBulkCloseTabs(tabs, 'b', 'right').map((t) => t.id)).toEqual(['c', 'd'])
-  })
-
-  it('returns empty when the anchor is at the edge', () => {
+  it('returns empty when the anchor is at the left edge', () => {
     expect(selectBulkCloseTabs(tabs, 'a', 'left')).toEqual([])
-    expect(selectBulkCloseTabs(tabs, 'd', 'right')).toEqual([])
   })
 
   it('returns empty when the anchor is not in the list', () => {

--- a/mobile/src/session/mobile-tab-close-selection.ts
+++ b/mobile/src/session/mobile-tab-close-selection.ts
@@ -1,10 +1,9 @@
-export type BulkTabCloseMode = 'others' | 'left' | 'right'
+export type BulkTabCloseMode = 'others' | 'left'
 
 /** Long-press sheet entries, in display order. */
 export const BULK_TAB_CLOSE_ACTIONS: { mode: BulkTabCloseMode; label: string }[] = [
   { mode: 'others', label: 'Close Other Tabs' },
-  { mode: 'left', label: 'Close Tabs to the Left' },
-  { mode: 'right', label: 'Close Tabs to the Right' }
+  { mode: 'left', label: 'Close Tabs to the Left' }
 ]
 
 type BulkClosableTab = {
@@ -15,7 +14,7 @@ type BulkClosableTab = {
 
 /**
  * Pick the tabs a long-press bulk close ("Close Other Tabs" / "Close Tabs to
- * the Left/Right") should target, in strip order relative to the pressed tab.
+ * the Left") should target, in strip order relative to the pressed tab.
  * Dirty documents are skipped — mobile has no save prompt on close, so bulk
  * closing must never silently discard unsaved edits.
  */
@@ -31,8 +30,6 @@ export function selectBulkCloseTabs<T extends BulkClosableTab>(
   const candidates =
     mode === 'others'
       ? tabs.filter((_, index) => index !== anchorIndex)
-      : mode === 'left'
-        ? tabs.slice(0, anchorIndex)
-        : tabs.slice(anchorIndex + 1)
+      : tabs.slice(0, anchorIndex)
   return candidates.filter((tab) => tab.isDirty !== true && tab.isPinned !== true)
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 |

<!-- /orca-pr-loc -->

## ELI5

Removes the unnecessary Close Tabs to the Right entry from mobile tab long-press menus.

## What Changed

- Removed the mobile close-to-right bulk action and its unreachable selection mode.
- Added an exact action-list regression assertion for the remaining Close Other Tabs and Close Tabs to the Left entries.
- Left desktop close-to-right behavior unchanged.

## Why

The action duplicates behavior already covered by Close Other Tabs and adds clutter to the compact mobile action sheet.

## Linked Issue

N/A — no linked issue was provided.

## Visual Proof

Not attached: mobile emulator UI-control tooling was unavailable in this session. The exact visible action list is covered by an automated regression assertion.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Validated from mobile/:
- pnpm test: 458 files passed; 3,672 tests passed; 3 skipped
- pnpm typecheck
- pnpm lint
- pnpm format:check
- git diff --check

## Review

Self-reviewed the complete diff. No security, performance, cross-platform, SSH/remote, wire-compatibility, or desktop behavior impact found.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows docs/reference/agent-skill-sharing-upstream-boundary.md and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

This is a mobile-local action-list change with no file paths, keyboard shortcuts, process behavior, remote protocol, or provider integration changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] pnpm lint, pnpm typecheck, pnpm test, and pnpm build pass (mobile lint/typecheck/test pass; build left to CI)