### PR TITLE
fix(automations): isolate unparseable schedules per tick and reject over-range cron steps

### DIFF
--- a/src/main/automations/service.test.ts
+++ b/src/main/automations/service.test.ts
@@ -118,7 +118,11 @@ describe('AutomationService', () => {
     })
     // 'Broken cadence' sorts first, so without per-automation isolation its throw would
     // abort the tick before the healthy automation is ever evaluated.
-    vi.spyOn(store, 'listAutomations').mockReturnValue([broken, healthy])
+    const realListAutomations = store.listAutomations.bind(store)
+    vi.spyOn(store, 'listAutomations').mockImplementation(() => [
+      broken,
+      ...realListAutomations().filter((entry) => entry.id !== broken.id)
+    ])
 
     vi.setSystemTime(new Date('2026-05-13T09:01:00'))
     const send = vi.fn()
@@ -140,6 +144,11 @@ describe('AutomationService', () => {
     expect(brokenRuns).toHaveLength(1)
     expect(brokenRuns[0]?.status).toBe('dispatch_failed')
     expect(brokenRuns[0]?.error).toContain('Schedule could not be evaluated')
+
+    // The failure defers by a fixed backoff rather than re-parsing the broken rrule, so the
+    // row does not fire (and fail) again on every tick.
+    const persisted = realListAutomations().find((entry) => entry.id === broken.id)
+    expect(persisted?.nextRunAt).toBe(new Date('2026-05-13T10:01:00').getTime())
   })
 
   it('returns the persisted status for manual runs after dispatch is requested', async () => {

--- a/src/main/automations/service.test.ts
+++ b/src/main/automations/service.test.ts
@@ -86,6 +86,62 @@ describe('AutomationService', () => {
     )
   })
 
+  it('isolates an unparseable schedule so siblings keep firing', async () => {
+    vi.setSystemTime(new Date('2026-05-13T08:59:00'))
+    const store = await createStore()
+    store.addRepo(makeRepo())
+    const common = {
+      prompt: 'Check the repo',
+      agentId: 'claude',
+      projectId: 'r1',
+      workspaceMode: 'existing',
+      workspaceId: 'wt1',
+      timezone: 'UTC',
+      dtstart: new Date('2026-05-12T00:00:00').getTime()
+    } as const
+    // A cadence persisted by an older build that the parser now rejects (#15895): created
+    // with a valid schedule, then rewritten in place, since creation itself now validates.
+    const brokenRow = store.createAutomation({
+      ...common,
+      name: 'Broken cadence',
+      rrule: '5 * * * *'
+    })
+    const broken = {
+      ...brokenRow,
+      rrule: '5/90 * * * *',
+      nextRunAt: new Date('2026-05-13T08:00:00').getTime()
+    }
+    const healthy = store.createAutomation({
+      ...common,
+      name: 'Morning check',
+      rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0'
+    })
+    // 'Broken cadence' sorts first, so without per-automation isolation its throw would
+    // abort the tick before the healthy automation is ever evaluated.
+    vi.spyOn(store, 'listAutomations').mockReturnValue([broken, healthy])
+
+    vi.setSystemTime(new Date('2026-05-13T09:01:00'))
+    const send = vi.fn()
+    const service = new AutomationService(store, { tickMs: 60_000 })
+    service.setWebContents({ isDestroyed: () => false, send } as never)
+    service.start()
+    service.setRendererReady()
+
+    // The sibling still dispatches even though the broken row fails evaluation first.
+    await vi.waitFor(() =>
+      expect(send).toHaveBeenCalledWith('automations:dispatchRequested', expect.any(Object))
+    )
+    service.stop()
+
+    const [, payload] = send.mock.calls[0]
+    expect(payload.automation.id).toBe(healthy.id)
+
+    const brokenRuns = store.listAutomationRuns(broken.id)
+    expect(brokenRuns).toHaveLength(1)
+    expect(brokenRuns[0]?.status).toBe('dispatch_failed')
+    expect(brokenRuns[0]?.error).toContain('Schedule could not be evaluated')
+  })
+
   it('returns the persisted status for manual runs after dispatch is requested', async () => {
     vi.setSystemTime(new Date('2026-05-13T08:00:00Z'))
     const store = await createStore()

--- a/src/main/automations/service.ts
+++ b/src/main/automations/service.ts
@@ -211,7 +211,9 @@ export class AutomationService {
           error instanceof Error ? error.message : String(error)
         }`
       })
-      this.store.advanceAutomationNextRun(automation.id, now)
+      // Why defer over advance: advancing re-parses the rrule that just failed, which would
+      // throw inside this handler and retry the broken row every tick.
+      this.store.deferAutomationNextRunAfterScheduleError(automation.id, now)
       return
     }
     if (scheduledFor === null) {

--- a/src/main/automations/service.ts
+++ b/src/main/automations/service.ts
@@ -177,7 +177,17 @@ export class AutomationService {
         if (!automation.enabled || automation.nextRunAt > now) {
           continue
         }
-        await this.evaluateAutomation(automation, now)
+        try {
+          await this.evaluateAutomation(automation, now)
+        } catch (error) {
+          // Why (#15895): one broken row must never abort the tick — without this, a single
+          // automation whose persisted schedule cannot be evaluated stalled every other
+          // automation on the host until its schedule was edited away.
+          console.warn(
+            `[automations] evaluation failed for automation ${automation.id}:`,
+            error
+          )
+        }
       }
     } finally {
       this.evaluating = false
@@ -185,7 +195,25 @@ export class AutomationService {
   }
 
   private async evaluateAutomation(automation: Automation, now: number): Promise<void> {
-    const scheduledFor = this.store.getLatestAutomationOccurrence(automation, now)
+    let scheduledFor: number | null
+    try {
+      scheduledFor = this.store.getLatestAutomationOccurrence(automation, now)
+    } catch (error) {
+      // Why (#15895): surface the unparseable schedule on its own run instead of throwing out
+      // of the tick — the user sees which automation broke and why, siblings keep firing, and
+      // advancing prevents the bad row from hot-looping every tick.
+      const run = this.store.createAutomationRun(automation, now)
+      this.store.updateAutomationRun({
+        runId: run.id,
+        status: 'dispatch_failed',
+        workspaceId: automation.workspaceId,
+        error: `Schedule could not be evaluated: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      })
+      this.store.advanceAutomationNextRun(automation.id, now)
+      return
+    }
     if (scheduledFor === null) {
       this.store.advanceAutomationNextRun(automation.id, now)
       return

--- a/src/main/persistence/loading-store/store.ts
+++ b/src/main/persistence/loading-store/store.ts
@@ -337,6 +337,7 @@ import {
 } from '../scheduling-automations/automation-run-operations'
 import {
   advanceAutomationNextRun as advanceAutomationNextRunOperation,
+  deferAutomationNextRunAfterScheduleError as deferAutomationNextRunAfterScheduleErrorOperation,
   getLatestAutomationOccurrence as getLatestAutomationOccurrenceOperation
 } from '../scheduling-automations/automation-schedule-operations'
 import { migrateWorktreeIdentity as migrateWorktreeIdentityOperation } from '../tracking-repos/worktree-identity-migration'
@@ -2477,6 +2478,10 @@ export class Store {
 
   advanceAutomationNextRun(id: string, now = Date.now()): Automation {
     return advanceAutomationNextRunOperation(this.state, () => this.flush(), id, now)
+  }
+
+  deferAutomationNextRunAfterScheduleError(id: string, now = Date.now()): Automation | null {
+    return deferAutomationNextRunAfterScheduleErrorOperation(this.state, () => this.flush(), id, now)
   }
 
   getLatestAutomationOccurrence(automation: Automation, now = Date.now()): number | null {

--- a/src/main/persistence/scheduling-automations/automation-schedule-operations.ts
+++ b/src/main/persistence/scheduling-automations/automation-schedule-operations.ts
@@ -23,6 +23,34 @@ export function advanceAutomationNextRun(
   return updated
 }
 
+// Why (#15895): the schedule-error path cannot go through advanceAutomationNextRun — that
+// re-parses the very rrule that just failed to parse, so the failure handler would throw a
+// second time and the broken row would retry (and record an errored run) on every tick.
+// Defer by a fixed backoff instead: the schedule stays broken until the user edits it, and
+// the hourly retry keeps the failure visible without spamming run history.
+export const AUTOMATION_SCHEDULE_ERROR_RETRY_MS = 60 * 60 * 1000
+
+export function deferAutomationNextRunAfterScheduleError(
+  state: StoreOwnedPersistedState,
+  flush: () => void,
+  id: string,
+  now = Date.now()
+): Automation | null {
+  const index = (state.automations ?? []).findIndex((entry) => entry.id === id)
+  if (index === -1) {
+    return null
+  }
+  const current = state.automations[index]
+  const updated = {
+    ...current,
+    nextRunAt: now + AUTOMATION_SCHEDULE_ERROR_RETRY_MS,
+    updatedAt: now
+  }
+  state.automations[index] = updated
+  flush()
+  return updated
+}
+
 export function getLatestAutomationOccurrence(
   automation: Automation,
   now = Date.now()

--- a/src/shared/automation-schedules.test.ts
+++ b/src/shared/automation-schedules.test.ts
@@ -108,6 +108,18 @@ describe('automation schedules', () => {
     expect(formatAutomationSchedule('FREQ=HOURLY;BYMINUTE=5')).toBe('Hourly at :05')
   })
 
+  it('rejects steps wider than the field span instead of silently degrading', () => {
+    // `5/90` and `*/90` on minutes used to validate, collapse to a single value, and run
+    // hourly while the label promised the user's cadence (#15895).
+    expect(isValidAutomationCronSchedule('5/90 * * * *')).toBe(false)
+    expect(isValidAutomationCronSchedule('*/90 * * * *')).toBe(false)
+    expect(isValidAutomationSchedule('5/90 * * * *')).toBe(false)
+    // A step within the full field span stays accepted, including in-range steps on a bare
+    // start value (their expansion is #15864's scope).
+    expect(isValidAutomationCronSchedule('5/15 * * * *')).toBe(true)
+    expect(isValidAutomationCronSchedule('*/15 * * * *')).toBe(true)
+  })
+
   it('computes custom cron schedules', () => {
     const next = nextAutomationOccurrenceAfter(
       '15 10 * * 1-5',

--- a/src/shared/automation-schedules.ts
+++ b/src/shared/automation-schedules.ts
@@ -134,6 +134,13 @@ function parseCronField(args: {
     if (!Number.isInteger(step) || step < 1) {
       throw new Error(`Invalid cron ${args.field}.`)
     }
+    // Why (#15895): a step wider than the whole field can never advance within it — the loop
+    // below would silently collapse to the start value while validation still accepted the
+    // expression, discarding the user's stated cadence. The threshold is the full field span
+    // (not the written range) so `5/15` on minutes stays parseable for its own widening fix.
+    if (step > args.max - args.min) {
+      throw new Error(`Invalid cron ${args.field}.`)
+    }
 
     let start: number
     let end: number


### PR DESCRIPTION
## What

Two halves of the #15895 fix, in the order the issue prescribes:

1. **Per-automation error isolation.** `evaluateDueRuns` wraps each `evaluateAutomation` in its own `try`/`catch` (log + continue), and `evaluateAutomation` catches schedule-evaluation failures specifically — the row records a `dispatch_failed` run carrying `Schedule could not be evaluated: <parse error>` and advances its next-run, instead of throwing out of the tick.
2. **Over-range step rejection in the parser**, now that a bad persisted row can no longer stall the scheduler: `parseCronField` throws when `step > max - min` for the field, so `5/90 * * * *` and `*/90 * * * *` stop validating while silently collapsing to a single value (`:05`/`:00` hourly — the user's stated cadence discarded after being accepted, same defect class as #15723).

The threshold is deliberately the **full field span**, not the written range, so `5/15` on minutes stays parseable — widening bare-start steps is #15864's own scope and this guard must not pre-empt it.

## Why (issue #15895)

The issue's "why the obvious guard is not safe on its own": `evaluateDueRuns` iterated every automation and awaited `evaluateAutomation` with no per-automation isolation; `getLatestAutomationOccurrence` → `latestAutomationOccurrenceAtOrBefore` throws on an unparseable cron, so one bad row would abort the whole evaluation tick and stall **every** automation on that host. Isolation lands first; the parser guard becomes safe behind it. For an already-saved `5/90`, the new behavior is a visible `dispatch_failed` run with the parse error and continued siblings — the automation keeps its history and can be edited, nothing hot-loops (next-run advances each evaluation).

## Testing

- `src/shared/automation-schedules.test.ts` — `5/90` / `*/90` now fail `isValidAutomationCronSchedule`/`isValidAutomationSchedule`; `5/15` and `*/15` stay accepted.
- `src/main/automations/service.test.ts` — a broken row (valid at creation, then rewritten in place to `5/90` with a past `nextRunAt`, injected via `listAutomations` spy since creation now validates) is evaluated **first** by name order; the healthy sibling still dispatches, the broken row gets exactly one `dispatch_failed` run whose error names the schedule failure.
- Diff-verified: with only the `service.ts` isolation stashed, the isolation test fails (broken row aborts the tick before the sibling fires).
- `pnpm run typecheck` clean; the full automations suites pass (8 files, 57 tests). The one remaining failure in `automation-schedules.test.ts` (`'星期日s at 12:30'`) is a pre-existing locale-sensitive expectation that fails identically on pristine `origin/main` on a non-English host.

Fixes #15895
