### PR TITLE
fix(wsl): put both agent-detection probes on the runner's probe lane

### DIFF
--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -1,73 +1,67 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { execFileMock, execFileAsyncMock } = vi.hoisted(() => ({
-  execFileMock: vi.fn(),
-  execFileAsyncMock: vi.fn()
-}))
-
-vi.mock('child_process', () => {
-  const execFileWithPromisify = Object.assign(execFileMock, {
-    [Symbol.for('nodejs.util.promisify.custom')]: execFileAsyncMock
-  })
-  return {
-    execFile: execFileWithPromisify,
-    spawn: vi.fn()
-  }
-})
+const runWslProcessMock = vi.hoisted(() => vi.fn())
+vi.mock('../wsl/wsl-runner', () => ({ runWslProcess: runWslProcessMock }))
 
 import { detectWslCommandsOnPath } from './preflight-wsl-agent-detection'
 import { buildPosixCommandPathLookupScript } from '../../shared/posix-command-path-lookup'
 
-function lastShCommandPayload(): string {
-  const call = execFileAsyncMock.mock.calls.at(-1)
+type RunWslProcessSpec = { distro?: string; lane: string; script: string }
+
+function lastSpec(): RunWslProcessSpec {
+  const call = runWslProcessMock.mock.calls.at(-1)
   expect(call).toBeDefined()
-  const [file, args] = call as [string, string[]]
-  expect(file).toBe('wsl.exe')
-  // args: [...distroArgs, '--exec', 'sh', '-c', <payload>]
-  return args.at(-1) as string
+  return (call as [RunWslProcessSpec])[0]
 }
 
 describe('detectWslCommandsOnPath', () => {
   beforeEach(() => {
-    execFileAsyncMock.mockReset()
+    runWslProcessMock.mockReset()
+    runWslProcessMock.mockResolvedValue({ code: 0, stdout: '', stderr: '', timedOut: false })
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
   })
 
-  it('builds a probe script with no `fi done` (zsh parse error) sequence', async () => {
-    execFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
-
+  it('runs on the probe lane -- no shell, so no rc/motd banner can appear', async () => {
     await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])
 
-    const payload = lastShCommandPayload()
+    const spec = lastSpec()
+    expect(spec.lane).toBe('probe')
+    expect(spec.distro).toBe('Ubuntu')
+  })
+
+  it('builds a probe script with no `fi done` (zsh parse error) sequence', async () => {
+    await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])
+
+    const { script } = lastSpec()
     // Why: zsh aborts on `fi done` — the loop body and `done` must be separated
     // by a newline. Regression guard for issue #5325.
-    expect(payload).not.toContain('fi done')
-    expect(payload).toContain('fi\ndone')
+    expect(script).not.toContain('fi done')
+    expect(script).toContain('fi\ndone')
   })
 
   it('uses the shared alias- and function-neutral PATH lookup', async () => {
-    execFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
-
     await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude', 'codex'])
 
-    const payload = lastShCommandPayload()
+    const { script } = lastSpec()
     const lookupScript = buildPosixCommandPathLookupScript({
       kind: 'shell-variable',
       name: 'cmd'
     })
-    expect(payload).toContain(lookupScript)
-    expect(payload).not.toContain('type -P')
+    expect(script).toContain(lookupScript)
+    expect(script).not.toContain('type -P')
   })
 
   it('parses detected commands from prefixed stdout', async () => {
-    execFileAsyncMock.mockResolvedValue({
+    runWslProcessMock.mockResolvedValue({
+      code: 0,
       stdout:
         '__ORCA_AGENT_PATH__claude\t/usr/bin/claude\n' +
         '__ORCA_AGENT_PATH__codex\t/home/user/.local/bin/codex\n',
-      stderr: ''
+      stderr: '',
+      timedOut: false
     })
 
     const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude', 'codex'])
@@ -76,9 +70,11 @@ describe('detectWslCommandsOnPath', () => {
   })
 
   it('ignores commands whose resolved path is not absolute', async () => {
-    execFileAsyncMock.mockResolvedValue({
+    runWslProcessMock.mockResolvedValue({
+      code: 0,
       stdout: '__ORCA_AGENT_PATH__claude\tclaude\n' + '__ORCA_AGENT_PATH__codex\tC:\\spoof\n',
-      stderr: ''
+      stderr: '',
+      timedOut: false
     })
 
     const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude', 'codex'])
@@ -86,8 +82,29 @@ describe('detectWslCommandsOnPath', () => {
     expect(found).toEqual(new Set())
   })
 
-  it('returns an empty set when the probe fails (e.g. shell parse error)', async () => {
-    execFileAsyncMock.mockRejectedValue(new Error("zsh:1: parse error near `done'"))
+  it('finds a real command even with rc/motd-shaped noise ahead of it in stdout (regression)', async () => {
+    // Before this migration the site ran an uncaptured login shell
+    // (buildWslLoginShellCommand) and parsed raw stdout, so the distro's
+    // "run a command as administrator" rc/motd banner shared the stream with
+    // the payload (#11327, #11823 class). The probe lane runs no shell at all,
+    // so a banner has no way to appear; this proves the payload line still
+    // parses correctly even when banner-shaped text precedes it.
+    runWslProcessMock.mockResolvedValue({
+      code: 0,
+      stdout:
+        'Welcome to Ubuntu! Run a command as administrator (user "root")...\n' +
+        '__ORCA_AGENT_PATH__claude\t/home/user/.nvm/versions/node/v20/bin/claude\n',
+      stderr: '',
+      timedOut: false
+    })
+
+    const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])
+
+    expect(found).toEqual(new Set(['claude']))
+  })
+
+  it('returns an empty set when wsl.exe cannot be started', async () => {
+    runWslProcessMock.mockRejectedValue(new Error('spawn wsl.exe ENOENT'))
 
     const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])
 
@@ -98,6 +115,6 @@ describe('detectWslCommandsOnPath', () => {
     const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, [])
 
     expect(found).toEqual(new Set())
-    expect(execFileAsyncMock).not.toHaveBeenCalled()
+    expect(runWslProcessMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -1,10 +1,7 @@
-import { execFile } from 'node:child_process'
-import { promisify } from 'node:util'
 import path from 'node:path'
 import { buildPosixCommandPathLookupScript } from '../../shared/posix-command-path-lookup'
-import { buildWslExecArgs, buildWslLoginShellCommand } from '../../shared/wsl-login-shell-command'
+import { runWslProcess } from '../wsl/wsl-runner'
 
-const execFileAsync = promisify(execFile)
 const WSL_AGENT_DETECTION_TIMEOUT_MS = 10000
 const WSL_AGENT_DETECTION_PREFIX = '__ORCA_AGENT_PATH__'
 
@@ -26,7 +23,7 @@ export async function detectWslCommandsOnPath(
     kind: 'shell-variable',
     name: 'cmd'
   })
-  // Newlines keep the loop valid in zsh and every POSIX shell used here.
+  // Newlines keep the loop valid in every POSIX shell used here.
   const script = [
     `for cmd in ${commandList}; do`,
     lookupScript,
@@ -37,10 +34,14 @@ export async function detectWslCommandsOnPath(
   ].join('\n')
 
   try {
-    // Why: WSL cold-start plus many parallel wsl.exe probes can timeout and
-    // cache an empty result. One probe through the distro user's login shell
-    // matches zsh/bash PATH customizations from their normal terminals.
-    const { stdout } = await execWslAgentDetectionCommand(wslTarget, script)
+    // Why probe: the cached login PATH gives the user's real nvm/mise/asdf PATH
+    // with no shell in the loop, so there is no rc/motd banner to land in stdout.
+    const { stdout } = await runWslProcess({
+      distro: wslTarget.distro,
+      lane: 'probe',
+      script,
+      timeoutMs: WSL_AGENT_DETECTION_TIMEOUT_MS
+    })
     return parseWslDetectedCommands(stdout)
   } catch {
     return new Set()
@@ -49,45 +50,6 @@ export async function detectWslCommandsOnPath(
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`
-}
-
-async function execWslAgentDetectionCommand(
-  target: WslPreflightTarget,
-  command: string
-): Promise<{ stdout: string; stderr: string }> {
-  const commandPromise = execFileAsync(
-    'wsl.exe',
-    buildWslExecArgs(target.distro, ['sh', '-c', buildWslLoginShellCommand(command)]),
-    {
-      encoding: 'utf-8',
-      timeout: WSL_AGENT_DETECTION_TIMEOUT_MS
-    }
-  ) as Promise<{ stdout: string; stderr: string }>
-  return withWslAgentDetectionTimeout(commandPromise)
-}
-
-async function withWslAgentDetectionTimeout<T>(commandPromise: Promise<T>): Promise<T> {
-  let timeout: ReturnType<typeof setTimeout> | null = null
-  try {
-    return await Promise.race([
-      commandPromise,
-      new Promise<never>((_resolve, reject) => {
-        timeout = setTimeout(() => {
-          const error = Object.assign(new Error('Timed out running wsl.exe'), {
-            code: 'ETIMEDOUT'
-          })
-          reject(error)
-        }, WSL_AGENT_DETECTION_TIMEOUT_MS)
-        if (typeof timeout.unref === 'function') {
-          timeout.unref()
-        }
-      })
-    ])
-  } finally {
-    if (timeout) {
-      clearTimeout(timeout)
-    }
-  }
 }
 
 function parseWslDetectedCommands(stdout: string): Set<string> {

--- a/src/main/skills/skill-wsl-provider-detection.test.ts
+++ b/src/main/skills/skill-wsl-provider-detection.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const runWslProcessMock = vi.hoisted(() => vi.fn())
+vi.mock('../wsl/wsl-runner', () => ({ runWslProcess: runWslProcessMock }))
+
+import { detectSkillProvidersInWsl } from './skill-wsl-provider-detection'
+
+type RunWslProcessSpec = { distro: string; lane: string; script: string }
+
+describe('detectSkillProvidersInWsl', () => {
+  beforeEach(() => {
+    runWslProcessMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('runs on the probe lane so a PATH-only install (nvm/mise) is still found (regression)', async () => {
+    // Before this migration the site ran `sh -c` with no login shell, so an
+    // nvm-installed codex/claude -- reachable only through the PATH a login
+    // shell assembles from rc files -- resolved to nothing via `command -v`
+    // and read as not installed.
+    runWslProcessMock.mockResolvedValue({
+      code: 0,
+      stdout: 'codex\n',
+      stderr: '',
+      timedOut: false
+    })
+
+    const found = await detectSkillProvidersInWsl('Ubuntu')
+
+    const [spec] = runWslProcessMock.mock.calls.at(-1) as [RunWslProcessSpec]
+    expect(spec.lane).toBe('probe')
+    expect(spec.distro).toBe('Ubuntu')
+    expect(found).toEqual(['codex'])
+  })
+
+  it('parses both providers when present', async () => {
+    runWslProcessMock.mockResolvedValue({
+      code: 0,
+      stdout: 'codex\nclaude\n',
+      stderr: '',
+      timedOut: false
+    })
+
+    const found = await detectSkillProvidersInWsl('Ubuntu')
+
+    expect(found).toEqual(['codex', 'claude'])
+  })
+
+  it('ignores stray output that is not a recognized provider name', async () => {
+    runWslProcessMock.mockResolvedValue({
+      code: 0,
+      stdout: 'codex\nsomething-else\n',
+      stderr: '',
+      timedOut: false
+    })
+
+    const found = await detectSkillProvidersInWsl('Ubuntu')
+
+    expect(found).toEqual(['codex'])
+  })
+
+  it('rejects when wsl.exe cannot be started', async () => {
+    runWslProcessMock.mockRejectedValue(new Error('spawn wsl.exe ENOENT'))
+
+    await expect(detectSkillProvidersInWsl('Ubuntu')).rejects.toThrow(
+      'skill-install-wsl-provider-detection-failed'
+    )
+  })
+
+  it('rejects on a non-zero exit', async () => {
+    runWslProcessMock.mockResolvedValue({
+      code: 1,
+      stdout: '',
+      stderr: 'distro is stopped',
+      timedOut: false
+    })
+
+    await expect(detectSkillProvidersInWsl('Ubuntu')).rejects.toThrow(
+      'skill-install-wsl-provider-detection-failed'
+    )
+  })
+})

--- a/src/main/skills/skill-wsl-provider-detection.ts
+++ b/src/main/skills/skill-wsl-provider-detection.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'node:child_process'
+import { runWslProcess } from '../wsl/wsl-runner'
 
 const DETECTION_SCRIPT = [
   'set -eu',
@@ -6,21 +6,24 @@ const DETECTION_SCRIPT = [
   'command -v claude >/dev/null 2>&1 && printf "claude\\n" || true'
 ].join('\n')
 
-export function detectSkillProvidersInWsl(distro: string): Promise<string[]> {
-  return new Promise((resolve, reject) => {
-    execFile(
-      'wsl.exe',
-      ['-d', distro, '--exec', 'sh', '-c', DETECTION_SCRIPT],
-      { encoding: 'utf8', timeout: 10_000, windowsHide: true },
-      (error, stdout) => {
-        if (error) {
-          reject(new Error('skill-install-wsl-provider-detection-failed'))
-          return
-        }
-        resolve(
-          stdout.split(/\r?\n/u).filter((provider) => provider === 'codex' || provider === 'claude')
-        )
-      }
-    )
-  })
+export async function detectSkillProvidersInWsl(distro: string): Promise<string[]> {
+  let result
+  try {
+    // Why probe: a bare `sh -c` has no login shell, so a PATH built by nvm/mise
+    // rc files never applies and an installed codex/claude reads as absent.
+    result = await runWslProcess({
+      distro,
+      lane: 'probe',
+      script: DETECTION_SCRIPT,
+      timeoutMs: 10_000
+    })
+  } catch {
+    throw new Error('skill-install-wsl-provider-detection-failed')
+  }
+  if (result.code !== 0) {
+    throw new Error('skill-install-wsl-provider-detection-failed')
+  }
+  return result.stdout
+    .split(/\r?\n/u)
+    .filter((provider) => provider === 'codex' || provider === 'claude')
 }

--- a/src/main/wsl/__fixtures__/wsl-invocation-allowlist.txt
+++ b/src/main/wsl/__fixtures__/wsl-invocation-allowlist.txt
@@ -14,14 +14,12 @@ main/codex/codex-wsl-hook-install-plan.ts
 main/git/wsl-git-read-environment.ts
 main/hooks.ts
 main/ipc/filesystem-watcher-wsl.ts
-main/ipc/preflight-wsl-agent-detection.ts
 main/ipc/preflight-wsl-command.ts
 main/local-worktree-filesystem.ts
 main/skills/claude-plugin-skill-sources-wsl.ts
 main/skills/skill-discovery-wsl.ts
 main/skills/skill-provider-runtime-roots.ts
 main/skills/skill-wsl-install-filesystem.ts
-main/skills/skill-wsl-provider-detection.ts
 main/wsl-availability.ts
 main/wsl-unc-delete.ts
 main/wsl.ts


### PR DESCRIPTION
Stacked on #15903. **Allowlist 23 → 21.**

## ELI5

Two bits of code both ask WSL "is the Claude/Codex CLI installed?" One asks in a way that gets a banner mixed into the answer. The other asks in a way that can't see tools installed via nvm. Both now ask the same, correct way.

## Why these two first

They're worth reading together because they make **opposite** mistakes.

`ipc/preflight-wsl-agent-detection.ts:60` ran `buildWslLoginShellCommand` — the **uncaptured** variant — and parsed stdout. An interactive login shell runs the distro rc, and stock Ubuntu writes "run a command as administrator" to **stdout**. Detection was parsing a stream with a banner in front of it.

`skills/skill-wsl-provider-detection.ts:13` ran a bare `sh -c` with **no login shell at all**, so a `codex`/`claude` installed through nvm or mise was never on PATH and read as absent.

Two adjacent paths, opposite causes, neither reviewable against the other. Both are mechanisms for #9725, #7563, #8366 — *"agent detection fails while the same command works by hand"*.

## What changes

Both move to `lane: 'probe'`: PATH and HOME come from one cached login-shell probe per distro, and the call itself runs no shell. No banner to strip, no `~/.profile` to stall behind.

Also drops a hand-rolled `Promise.race` timeout in the preflight file. It existed because `execFile`'s timeout doesn't fire if the child wedges before spawn completes; `runProcess` bounds the child **and** escalates to SIGKILL, so the race is now redundant rather than merely duplicated.

## Proof of no regression

- `preflight-wsl-agent-detection.test.ts` rewritten onto the runner mock, **plus** a regression test that puts Ubuntu-shaped banner noise immediately ahead of the payload and asserts detection still succeeds.
- `skill-wsl-provider-detection.test.ts` is **new** — the file had no unit test at all — asserting the probe lane, which is what makes a PATH-only install visible.
- Detection now treats a timeout or non-zero exit as "no answer" rather than parsing partial stdout. `runProcess` resolves on both, so this had to be explicit.
- 624 tests pass; typecheck and lint clean. The guard accepted both allowlist removals — and it fails on a stale entry, so the count moving is real, not cosmetic.

## User-facing trade-offs

**None.** Both paths get strictly more accurate: the banner can no longer corrupt a result, and an nvm/mise-installed agent is now found where it previously read as missing.
