### PR TITLE
fix(wsl): move the skill scans onto the runner and delete the base64 wrappers

### DIFF
--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -1,73 +1,67 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { execFileMock, execFileAsyncMock } = vi.hoisted(() => ({
-  execFileMock: vi.fn(),
-  execFileAsyncMock: vi.fn()
-}))
-
-vi.mock('child_process', () => {
-  const execFileWithPromisify = Object.assign(execFileMock, {
-    [Symbol.for('nodejs.util.promisify.custom')]: execFileAsyncMock
-  })
-  return {
-    execFile: execFileWithPromisify,
-    spawn: vi.fn()
-  }
-})
+const runWslProcessMock = vi.hoisted(() => vi.fn())
+vi.mock('../wsl/wsl-runner', () => ({ runWslProcess: runWslProcessMock }))
 
 import { detectWslCommandsOnPath } from './preflight-wsl-agent-detection'
 import { buildPosixCommandPathLookupScript } from '../../shared/posix-command-path-lookup'
 
-function lastShCommandPayload(): string {
-  const call = execFileAsyncMock.mock.calls.at(-1)
+type RunWslProcessSpec = { distro?: string; lane: string; script: string }
+
+function lastSpec(): RunWslProcessSpec {
+  const call = runWslProcessMock.mock.calls.at(-1)
   expect(call).toBeDefined()
-  const [file, args] = call as [string, string[]]
-  expect(file).toBe('wsl.exe')
-  // args: [...distroArgs, '--exec', 'sh', '-c', <payload>]
-  return args.at(-1) as string
+  return (call as [RunWslProcessSpec])[0]
 }
 
 describe('detectWslCommandsOnPath', () => {
   beforeEach(() => {
-    execFileAsyncMock.mockReset()
+    runWslProcessMock.mockReset()
+    runWslProcessMock.mockResolvedValue({ code: 0, stdout: '', stderr: '', timedOut: false })
   })
 
   afterEach(() => {
     vi.restoreAllMocks()
   })
 
-  it('builds a probe script with no `fi done` (zsh parse error) sequence', async () => {
-    execFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
-
+  it('runs on the probe lane -- no shell, so no rc/motd banner can appear', async () => {
     await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])
 
-    const payload = lastShCommandPayload()
+    const spec = lastSpec()
+    expect(spec.lane).toBe('probe')
+    expect(spec.distro).toBe('Ubuntu')
+  })
+
+  it('builds a probe script with no `fi done` (zsh parse error) sequence', async () => {
+    await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])
+
+    const { script } = lastSpec()
     // Why: zsh aborts on `fi done` — the loop body and `done` must be separated
     // by a newline. Regression guard for issue #5325.
-    expect(payload).not.toContain('fi done')
-    expect(payload).toContain('fi\ndone')
+    expect(script).not.toContain('fi done')
+    expect(script).toContain('fi\ndone')
   })
 
   it('uses the shared alias- and function-neutral PATH lookup', async () => {
-    execFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
-
     await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude', 'codex'])
 
-    const payload = lastShCommandPayload()
+    const { script } = lastSpec()
     const lookupScript = buildPosixCommandPathLookupScript({
       kind: 'shell-variable',
       name: 'cmd'
     })
-    expect(payload).toContain(lookupScript)
-    expect(payload).not.toContain('type -P')
+    expect(script).toContain(lookupScript)
+    expect(script).not.toContain('type -P')
   })
 
   it('parses detected commands from prefixed stdout', async () => {
-    execFileAsyncMock.mockResolvedValue({
+    runWslProcessMock.mockResolvedValue({
+      code: 0,
       stdout:
         '__ORCA_AGENT_PATH__claude\t/usr/bin/claude\n' +
         '__ORCA_AGENT_PATH__codex\t/home/user/.local/bin/codex\n',
-      stderr: ''
+      stderr: '',
+      timedOut: false
     })
 
     const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude', 'codex'])
@@ -76,9 +70,11 @@ describe('detectWslCommandsOnPath', () => {
   })
 
   it('ignores commands whose resolved path is not absolute', async () => {
-    execFileAsyncMock.mockResolvedValue({
+    runWslProcessMock.mockResolvedValue({
+      code: 0,
       stdout: '__ORCA_AGENT_PATH__claude\tclaude\n' + '__ORCA_AGENT_PATH__codex\tC:\\spoof\n',
-      stderr: ''
+      stderr: '',
+      timedOut: false
     })
 
     const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude', 'codex'])
@@ -86,8 +82,29 @@ describe('detectWslCommandsOnPath', () => {
     expect(found).toEqual(new Set())
   })
 
-  it('returns an empty set when the probe fails (e.g. shell parse error)', async () => {
-    execFileAsyncMock.mockRejectedValue(new Error("zsh:1: parse error near `done'"))
+  it('finds a real command even with rc/motd-shaped noise ahead of it in stdout (regression)', async () => {
+    // Before this migration the site ran an uncaptured login shell
+    // (buildWslLoginShellCommand) and parsed raw stdout, so the distro's
+    // "run a command as administrator" rc/motd banner shared the stream with
+    // the payload (#11327, #11823 class). The probe lane runs no shell at all,
+    // so a banner has no way to appear; this proves the payload line still
+    // parses correctly even when banner-shaped text precedes it.
+    runWslProcessMock.mockResolvedValue({
+      code: 0,
+      stdout:
+        'Welcome to Ubuntu! Run a command as administrator (user "root")...\n' +
+        '__ORCA_AGENT_PATH__claude\t/home/user/.nvm/versions/node/v20/bin/claude\n',
+      stderr: '',
+      timedOut: false
+    })
+
+    const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])
+
+    expect(found).toEqual(new Set(['claude']))
+  })
+
+  it('returns an empty set when wsl.exe cannot be started', async () => {
+    runWslProcessMock.mockRejectedValue(new Error('spawn wsl.exe ENOENT'))
 
     const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])
 
@@ -98,6 +115,6 @@ describe('detectWslCommandsOnPath', () => {
     const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, [])
 
     expect(found).toEqual(new Set())
-    expect(execFileAsyncMock).not.toHaveBeenCalled()
+    expect(runWslProcessMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -1,10 +1,7 @@
-import { execFile } from 'node:child_process'
-import { promisify } from 'node:util'
 import path from 'node:path'
 import { buildPosixCommandPathLookupScript } from '../../shared/posix-command-path-lookup'
-import { buildWslExecArgs, buildWslLoginShellCommand } from '../../shared/wsl-login-shell-command'
+import { runWslProcess } from '../wsl/wsl-runner'
 
-const execFileAsync = promisify(execFile)
 const WSL_AGENT_DETECTION_TIMEOUT_MS = 10000
 const WSL_AGENT_DETECTION_PREFIX = '__ORCA_AGENT_PATH__'
 
@@ -26,7 +23,7 @@ export async function detectWslCommandsOnPath(
     kind: 'shell-variable',
     name: 'cmd'
   })
-  // Newlines keep the loop valid in zsh and every POSIX shell used here.
+  // Newlines keep the loop valid in every POSIX shell used here.
   const script = [
     `for cmd in ${commandList}; do`,
     lookupScript,
@@ -37,10 +34,14 @@ export async function detectWslCommandsOnPath(
   ].join('\n')
 
   try {
-    // Why: WSL cold-start plus many parallel wsl.exe probes can timeout and
-    // cache an empty result. One probe through the distro user's login shell
-    // matches zsh/bash PATH customizations from their normal terminals.
-    const { stdout } = await execWslAgentDetectionCommand(wslTarget, script)
+    // Why probe: the cached login PATH gives the user's real nvm/mise/asdf PATH
+    // with no shell in the loop, so there is no rc/motd banner to land in stdout.
+    const { stdout } = await runWslProcess({
+      distro: wslTarget.distro,
+      lane: 'probe',
+      script,
+      timeoutMs: WSL_AGENT_DETECTION_TIMEOUT_MS
+    })
     return parseWslDetectedCommands(stdout)
   } catch {
     return new Set()
@@ -49,45 +50,6 @@ export async function detectWslCommandsOnPath(
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`
-}
-
-async function execWslAgentDetectionCommand(
-  target: WslPreflightTarget,
-  command: string
-): Promise<{ stdout: string; stderr: string }> {
-  const commandPromise = execFileAsync(
-    'wsl.exe',
-    buildWslExecArgs(target.distro, ['sh', '-c', buildWslLoginShellCommand(command)]),
-    {
-      encoding: 'utf-8',
-      timeout: WSL_AGENT_DETECTION_TIMEOUT_MS
-    }
-  ) as Promise<{ stdout: string; stderr: string }>
-  return withWslAgentDetectionTimeout(commandPromise)
-}
-
-async function withWslAgentDetectionTimeout<T>(commandPromise: Promise<T>): Promise<T> {
-  let timeout: ReturnType<typeof setTimeout> | null = null
-  try {
-    return await Promise.race([
-      commandPromise,
-      new Promise<never>((_resolve, reject) => {
-        timeout = setTimeout(() => {
-          const error = Object.assign(new Error('Timed out running wsl.exe'), {
-            code: 'ETIMEDOUT'
-          })
-          reject(error)
-        }, WSL_AGENT_DETECTION_TIMEOUT_MS)
-        if (typeof timeout.unref === 'function') {
-          timeout.unref()
-        }
-      })
-    ])
-  } finally {
-    if (timeout) {
-      clearTimeout(timeout)
-    }
-  }
 }
 
 function parseWslDetectedCommands(stdout: string): Set<string> {

--- a/src/main/skills/claude-plugin-skill-sources-wsl.test.ts
+++ b/src/main/skills/claude-plugin-skill-sources-wsl.test.ts
@@ -9,15 +9,11 @@ function record(...fields: string[]): string {
 }
 
 describe('WSL Claude plugin metadata', () => {
-  it('reads metadata paths inside the distro without exposing them to Windows shell parsing', () => {
-    const command = buildWslClaudePluginMetadataCommand(["/home/alice's/.claude/settings.json"])
-    const encoded = /printf %s '([^']+)'/.exec(command)?.[1]
-    expect(encoded).toBeTruthy()
-    const script = Buffer.from(encoded!, 'base64').toString('utf8')
+  it('quotes a distro path for the guest shell script', () => {
+    const script = buildWslClaudePluginMetadataCommand(["/home/alice's/.claude/settings.json"])
 
     expect(script).toContain(`'/home/alice'\\''s/.claude/settings.json'`)
     expect(script).toContain('base64 < "$metadata_path"')
-    expect(command).not.toContain('/home/alice')
   })
 
   it('decodes present files and retains missing files as null', () => {

--- a/src/main/skills/claude-plugin-skill-sources-wsl.ts
+++ b/src/main/skills/claude-plugin-skill-sources-wsl.ts
@@ -1,6 +1,6 @@
-import { execFile } from 'node:child_process'
 import { posix as pathPosix } from 'node:path'
-import { buildEncodedWslBashCommand, quoteBashString } from '../wsl-bash-command'
+import { quoteBashString } from '../wsl-bash-command'
+import { runWslProcess } from '../wsl/wsl-runner'
 import {
   getClaudePluginMetadataPaths,
   resolveClaudePluginSkillSources,
@@ -10,7 +10,7 @@ import type { SkillScanRoot } from './skill-discovery-sources'
 
 const MAX_PLUGIN_METADATA_BYTES = 4 * 1024 * 1024
 const WSL_METADATA_TIMEOUT_MS = 5_000
-const WSL_METADATA_MAX_BUFFER_BYTES = 32 * 1024 * 1024
+const WSL_METADATA_MAX_OUTPUT_BYTES = 32 * 1024 * 1024
 
 export function buildWslClaudePluginMetadataCommand(paths: readonly string[]): string {
   const lines = [
@@ -31,7 +31,7 @@ export function buildWslClaudePluginMetadataCommand(paths: readonly string[]): s
   paths.forEach((pathValue, index) => {
     lines.push(`read_metadata ${index} ${quoteBashString(pathValue)}`)
   })
-  return buildEncodedWslBashCommand(lines.join('\n'))
+  return lines.join('\n')
 }
 
 export function parseWslClaudePluginMetadataOutput(
@@ -56,26 +56,19 @@ export function parseWslClaudePluginMetadataOutput(
   return contents
 }
 
-function executeWslMetadataRead(distro: string, command: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    execFile(
-      'wsl.exe',
-      ['-d', distro, '--exec', 'bash', '-c', command],
-      {
-        encoding: 'utf8',
-        maxBuffer: WSL_METADATA_MAX_BUFFER_BYTES,
-        timeout: WSL_METADATA_TIMEOUT_MS,
-        windowsHide: true
-      },
-      (error, stdout) => {
-        if (error) {
-          reject(error)
-          return
-        }
-        resolve(stdout)
-      }
-    )
+async function executeWslMetadataRead(distro: string, script: string): Promise<string> {
+  // Why bash: this payload was authored for bash, and the migration must not
+  // quietly change its interpreter.
+  const result = await runWslProcess({
+    distro,
+    lane: 'probe',
+    script,
+    shell: 'bash',
+
+    timeoutMs: WSL_METADATA_TIMEOUT_MS,
+    maxOutputBytes: WSL_METADATA_MAX_OUTPUT_BYTES
   })
+  return result.stdout
 }
 
 export async function discoverClaudePluginSkillSourcesInWsl(args: {

--- a/src/main/skills/skill-discovery-wsl-plugins.test.ts
+++ b/src/main/skills/skill-discovery-wsl-plugins.test.ts
@@ -1,9 +1,9 @@
 import { posix as pathPosix } from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const execFileMock = vi.hoisted(() => vi.fn())
+const runWslProcessMock = vi.hoisted(() => vi.fn())
 
-vi.mock('node:child_process', () => ({ execFile: execFileMock }))
+vi.mock('../wsl/wsl-runner', () => ({ runWslProcess: runWslProcessMock }))
 
 import { buildSkillDiscoverySources } from './skill-discovery-sources'
 import { discoverSkillsInWsl } from './skill-discovery-wsl'
@@ -12,15 +12,17 @@ function record(...fields: string[]): string {
   return `${fields.join('\0')}\0`
 }
 
-function completeExecFileCall(callIndex: number, stdout: string): void {
-  const callback = execFileMock.mock.calls[callIndex]?.[3] as
-    | ((error: Error | null, stdout: string) => void)
-    | undefined
-  callback?.(null, stdout)
+function wslResult(stdout: string): {
+  code: number
+  stdout: string
+  stderr: string
+  timedOut: boolean
+} {
+  return { code: 0, stdout, stderr: '', timedOut: false }
 }
 
 describe('WSL Claude plugin skill discovery', () => {
-  beforeEach(() => execFileMock.mockReset())
+  beforeEach(() => runWslProcessMock.mockReset())
 
   it('reads enabled plugin metadata and scans the selected install inside the distro', async () => {
     const homeDir = '/home/alice'
@@ -53,19 +55,13 @@ describe('WSL Claude plugin skill discovery', () => {
       record('R', String(baseRootCount), '1'),
       record('S', String(baseRootCount), skillPath, skillPath, '1700000000', markdown)
     ].join('')
-    execFileMock.mockImplementationOnce((..._args: unknown[]) => {
-      queueMicrotask(() => completeExecFileCall(0, metadataOutput))
-    })
-    execFileMock.mockImplementationOnce((..._args: unknown[]) => {
-      queueMicrotask(() => completeExecFileCall(1, scanOutput))
-    })
+    runWslProcessMock.mockResolvedValueOnce(wslResult(metadataOutput))
+    runWslProcessMock.mockResolvedValueOnce(wslResult(scanOutput))
 
     const result = await discoverSkillsInWsl({ distro: 'Ubuntu', homeDir, cwd })
 
-    expect(execFileMock).toHaveBeenCalledTimes(2)
-    const scanArgs = execFileMock.mock.calls[1]?.[1] as string[]
-    const encoded = /printf %s '([^']+)'/.exec(scanArgs[5] ?? '')?.[1]
-    const scanScript = Buffer.from(encoded ?? '', 'base64').toString('utf8')
+    expect(runWslProcessMock).toHaveBeenCalledTimes(2)
+    const scanScript = runWslProcessMock.mock.calls[1]?.[0].script as string
     expect(scanScript).toContain(`${installPath}/skills`)
     expect(result.skills).toEqual([
       expect.objectContaining({

--- a/src/main/skills/skill-discovery-wsl.test.ts
+++ b/src/main/skills/skill-discovery-wsl.test.ts
@@ -72,12 +72,9 @@ describe('WSL skill discovery', () => {
   })
 
   it('builds a distro-side scan for enumeration, reads, and canonical identity', () => {
-    const command = buildWslSkillDiscoveryCommand([
+    const script = buildWslSkillDiscoveryCommand([
       { ...repoRoot, path: "/work/alice's project/.agents/skills" }
     ])
-    const encoded = /printf %s '([^']+)'/.exec(command)?.[1]
-    expect(encoded).toBeTruthy()
-    const script = Buffer.from(encoded!, 'base64').toString('utf8')
 
     expect(script).toContain('find -L "$root_path"')
     expect(script).toContain('realpath -- "$skill_file"')

--- a/src/main/skills/skill-discovery-wsl.ts
+++ b/src/main/skills/skill-discovery-wsl.ts
@@ -1,4 +1,3 @@
-import { execFile } from 'node:child_process'
 import { posix as pathPosix } from 'node:path'
 import { summarizeSkillMarkdown } from '../../shared/skill-metadata'
 import type {
@@ -6,7 +5,8 @@ import type {
   SkillDiscoveryResult,
   SkillDiscoverySource
 } from '../../shared/skills'
-import { buildEncodedWslBashCommand, quoteBashString } from '../wsl-bash-command'
+import { quoteBashString } from '../wsl-bash-command'
+import { runWslProcess } from '../wsl/wsl-runner'
 import {
   buildSkillDiscoverySources,
   compareSkills,
@@ -20,7 +20,7 @@ import type { SkillProviderRootOverrides } from './skill-provider-destinations'
 
 const MAX_MARKDOWN_BYTES = 256 * 1024
 const WSL_SCAN_TIMEOUT_MS = 10_000
-const WSL_SCAN_MAX_BUFFER_BYTES = 128 * 1024 * 1024
+const WSL_SCAN_MAX_OUTPUT_BYTES = 128 * 1024 * 1024
 
 export function buildWslSkillDiscoveryCommand(roots: readonly SkillScanRoot[]): string {
   const lines = [
@@ -49,29 +49,22 @@ export function buildWslSkillDiscoveryCommand(roots: readonly SkillScanRoot[]): 
     const maxDepth = root.sourceKind === 'plugin' ? 10 : 5
     lines.push(`scan_root ${index} ${quoteBashString(root.path)} ${maxDepth}`)
   })
-  return buildEncodedWslBashCommand(lines.join('\n'))
+  return lines.join('\n')
 }
 
-function executeWslSkillDiscovery(distro: string, command: string): Promise<string> {
-  return new Promise((resolve, reject) => {
-    execFile(
-      'wsl.exe',
-      ['-d', distro, '--exec', 'bash', '-c', command],
-      {
-        encoding: 'utf8',
-        maxBuffer: WSL_SCAN_MAX_BUFFER_BYTES,
-        timeout: WSL_SCAN_TIMEOUT_MS,
-        windowsHide: true
-      },
-      (error, stdout) => {
-        if (error) {
-          reject(error)
-          return
-        }
-        resolve(stdout)
-      }
-    )
+async function executeWslSkillDiscovery(distro: string, script: string): Promise<string> {
+  // Why bash: the scan uses process substitution (`done < <(find ...)`), which
+  // dash rejects with `Syntax error: word unexpected` (#14292).
+  const result = await runWslProcess({
+    distro,
+    lane: 'probe',
+    script,
+    shell: 'bash',
+
+    timeoutMs: WSL_SCAN_TIMEOUT_MS,
+    maxOutputBytes: WSL_SCAN_MAX_OUTPUT_BYTES
   })
+  return result.stdout
 }
 
 function readProtocolField(fields: string[], index: number): string {

--- a/src/main/skills/skill-provider-runtime-roots.ts
+++ b/src/main/skills/skill-provider-runtime-roots.ts
@@ -1,6 +1,6 @@
-import { execFile } from 'node:child_process'
 import { isAbsolute, join, resolve } from 'node:path'
 import { toWindowsWslPath } from '../../shared/wsl-paths'
+import { runWslProcess } from '../wsl/wsl-runner'
 import type { SkillProviderRootOverrides } from './skill-provider-destinations'
 
 const PROVIDER_ROOT_MAX_LENGTH = 32_768
@@ -47,20 +47,15 @@ export function withClaudeSkillProviderRoot(
 
 type WslEnvironmentProbe = (distro: string) => Promise<string>
 
-function probeWslGrokHome(distro: string): Promise<string> {
-  return new Promise((resolveProbe, reject) => {
-    execFile(
-      'wsl.exe',
-      ['-d', distro, '--exec', 'sh', '-c', WSL_GROK_HOME_SCRIPT],
-      {
-        encoding: 'utf8',
-        timeout: WSL_ENV_PROBE_TIMEOUT_MS,
-        maxBuffer: WSL_ENV_PROBE_MAX_BYTES,
-        windowsHide: true
-      },
-      (error, stdout) => (error ? reject(error) : resolveProbe(stdout))
-    )
+async function probeWslGrokHome(distro: string): Promise<string> {
+  const result = await runWslProcess({
+    distro,
+    lane: 'probe',
+    script: WSL_GROK_HOME_SCRIPT,
+    timeoutMs: WSL_ENV_PROBE_TIMEOUT_MS,
+    maxOutputBytes: WSL_ENV_PROBE_MAX_BYTES
   })
+  return result.stdout
 }
 
 export async function resolveWslGrokSkillProviderRoot(

--- a/src/main/skills/skill-wsl-install-filesystem.test.ts
+++ b/src/main/skills/skill-wsl-install-filesystem.test.ts
@@ -1,13 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { SkillPackageManifestV1 } from '../../shared/skill-package-manifest'
 
-const { execFileAsyncMock } = vi.hoisted(() => ({ execFileAsyncMock: vi.fn() }))
+const { runWslProcessMock } = vi.hoisted(() => ({ runWslProcessMock: vi.fn() }))
 
-vi.mock('node:child_process', () => ({
-  execFile: Object.assign(vi.fn(), {
-    [Symbol.for('nodejs.util.promisify.custom')]: execFileAsyncMock
-  })
-}))
+vi.mock('../wsl/wsl-runner', () => ({ runWslProcess: runWslProcessMock }))
 
 import {
   createWslSkillInstallFilesystem,
@@ -17,7 +13,12 @@ import {
 const WSL_ROOT = '\\\\wsl.localhost\\Ubuntu-24.04\\home\\jin\\.agents\\skills'
 
 beforeEach(() => {
-  execFileAsyncMock.mockReset().mockResolvedValue({ stdout: '', stderr: '' })
+  runWslProcessMock.mockReset().mockResolvedValue({
+    code: 0,
+    stdout: '',
+    stderr: '',
+    timedOut: false
+  })
 })
 
 describe('WslSkillInstallFilesystem', () => {
@@ -44,7 +45,7 @@ describe('WslSkillInstallFilesystem', () => {
       )
     }
 
-    expect(execFileAsyncMock).toHaveBeenCalledTimes(8)
+    expect(runWslProcessMock).toHaveBeenCalledTimes(8)
   })
 
   it('applies and verifies manifest modes through bounded guest argv batches', async () => {
@@ -57,8 +58,8 @@ describe('WslSkillInstallFilesystem', () => {
     } as SkillPackageManifestV1
     await filesystem.prepareExtractedSkill(`${WSL_ROOT}\\.orca-skill-extract-1\\skill`, manifest)
 
-    expect(execFileAsyncMock).toHaveBeenCalledTimes(2)
-    const calls = execFileAsyncMock.mock.calls.map(([, args]) => args as string[])
+    expect(runWslProcessMock).toHaveBeenCalledTimes(2)
+    const calls = runWslProcessMock.mock.calls.map(([spec]) => spec.args as string[])
     expect(calls[0]).toEqual(
       expect.arrayContaining([
         '600',
@@ -85,7 +86,7 @@ describe('WslSkillInstallFilesystem', () => {
       'C:\\Users\\jin\\repo\\.agents\\skills\\.skill.orca-staging-1',
       'C:\\Users\\jin\\repo\\.agents\\skills\\skill'
     )
-    expect(execFileAsyncMock.mock.calls[0]?.[1]).toEqual(
+    expect(runWslProcessMock.mock.calls[0]?.[0].args).toEqual(
       expect.arrayContaining([
         '/mnt/c/Users/jin/repo/.agents/skills/.skill.orca-staging-1',
         '/mnt/c/Users/jin/repo/.agents/skills/skill'
@@ -94,7 +95,7 @@ describe('WslSkillInstallFilesystem', () => {
     await expect(filesystem.remove('C:\\Users\\jin\\repo\\unrelated')).rejects.toThrow(
       'skill-install-wsl-path-outside-root'
     )
-    expect(execFileAsyncMock).toHaveBeenCalledOnce()
+    expect(runWslProcessMock).toHaveBeenCalledOnce()
   })
 
   it('uses manifest mode provenance for Windows-backed WSL paths', async () => {
@@ -113,7 +114,7 @@ describe('WslSkillInstallFilesystem', () => {
       manifest
     )
 
-    expect(execFileAsyncMock).not.toHaveBeenCalled()
+    expect(runWslProcessMock).not.toHaveBeenCalled()
   })
 
   it('rejects a path from another distro before spawning wsl.exe', async () => {
@@ -121,7 +122,7 @@ describe('WslSkillInstallFilesystem', () => {
     await expect(
       filesystem.remove('\\\\wsl.localhost\\Debian\\home\\jin\\.agents\\skills\\skill')
     ).rejects.toThrow('skill-install-wsl-path-invalid')
-    expect(execFileAsyncMock).not.toHaveBeenCalled()
+    expect(runWslProcessMock).not.toHaveBeenCalled()
   })
 
   it('authorizes a historical provider root before update or removal', async () => {
@@ -132,11 +133,24 @@ describe('WslSkillInstallFilesystem', () => {
 
     await filesystem.remove(`${historicalRoot}\\private-skill`)
 
-    expect(execFileAsyncMock).toHaveBeenCalledOnce()
-    expect(execFileAsyncMock.mock.calls[0]?.[1]).toEqual(
+    expect(runWslProcessMock).toHaveBeenCalledOnce()
+    expect(runWslProcessMock.mock.calls[0]?.[0].args).toEqual(
       expect.arrayContaining([
         '/home/jin/.local/share/orca/claude-accounts/old/auth/skills/private-skill'
       ])
+    )
+  })
+
+  it('surfaces a nonzero guest exit as a guest-operation failure', async () => {
+    runWslProcessMock.mockResolvedValueOnce({
+      code: 42,
+      stdout: '',
+      stderr: 'mode mismatch',
+      timedOut: false
+    })
+    const filesystem = new WslSkillInstallFilesystem('Ubuntu-24.04', [WSL_ROOT])
+    await expect(filesystem.remove(`${WSL_ROOT}\\private-skill`)).rejects.toThrow(
+      'skill-install-wsl-guest-operation-failed'
     )
   })
 })

--- a/src/main/skills/skill-wsl-install-filesystem.ts
+++ b/src/main/skills/skill-wsl-install-filesystem.ts
@@ -1,6 +1,4 @@
-import { execFile } from 'node:child_process'
 import { join, posix } from 'node:path'
-import { promisify } from 'node:util'
 import type { SkillPackageManifestV1 } from '../../shared/skill-package-manifest'
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import {
@@ -11,10 +9,11 @@ import {
 import type { SkillInstallFilesystem, SkillInstalledFileMode } from './skill-install-filesystem'
 import { SKILL_INSTALL_PROVIDERS } from '../../shared/skill-install-providers'
 import type { SkillProviderRootOverrides } from './skill-provider-destinations'
+import { runWslProcess } from '../wsl/wsl-runner'
 
-const execFileAsync = promisify(execFile)
 const BATCH_FILE_COUNT = 8
 const GUEST_COMMAND_TIMEOUT_MS = 30_000
+const GUEST_COMMAND_MAX_OUTPUT_BYTES = 64 * 1024
 
 function isWindowsBackedGuestPath(path: string): boolean {
   return /^\/mnt\/[a-z](?:\/|$)/iu.test(path)
@@ -212,21 +211,20 @@ export class WslSkillInstallFilesystem implements SkillInstallFilesystem {
   }
 
   private async runOutput(script: string, args: string[]): Promise<string> {
-    try {
-      const { stdout } = await execFileAsync(
-        'wsl.exe',
-        ['-d', this.distro, '--exec', 'sh', '-c', script, 'orca-skill', ...args],
-        {
-          encoding: 'utf8',
-          timeout: GUEST_COMMAND_TIMEOUT_MS,
-          windowsHide: true,
-          maxBuffer: 64 * 1024
-        }
-      )
-      return stdout.trim()
-    } catch (error) {
-      throw Object.assign(new Error('skill-install-wsl-guest-operation-failed'), { cause: error })
+    const result = await runWslProcess({
+      distro: this.distro,
+      lane: 'probe',
+      script,
+      args,
+      timeoutMs: GUEST_COMMAND_TIMEOUT_MS,
+      maxOutputBytes: GUEST_COMMAND_MAX_OUTPUT_BYTES
+    })
+    if (result.code !== 0) {
+      throw Object.assign(new Error('skill-install-wsl-guest-operation-failed'), {
+        cause: new Error(`wsl exited ${result.code}: ${result.stderr}`)
+      })
     }
+    return result.stdout.trim()
   }
 }
 

--- a/src/main/skills/skill-wsl-provider-detection.test.ts
+++ b/src/main/skills/skill-wsl-provider-detection.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const runWslProcessMock = vi.hoisted(() => vi.fn())
+vi.mock('../wsl/wsl-runner', () => ({ runWslProcess: runWslProcessMock }))
+
+import { detectSkillProvidersInWsl } from './skill-wsl-provider-detection'
+
+type RunWslProcessSpec = { distro: string; lane: string; script: string }
+
+describe('detectSkillProvidersInWsl', () => {
+  beforeEach(() => {
+    runWslProcessMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('runs on the probe lane so a PATH-only install (nvm/mise) is still found (regression)', async () => {
+    // Before this migration the site ran `sh -c` with no login shell, so an
+    // nvm-installed codex/claude -- reachable only through the PATH a login
+    // shell assembles from rc files -- resolved to nothing via `command -v`
+    // and read as not installed.
+    runWslProcessMock.mockResolvedValue({
+      code: 0,
+      stdout: 'codex\n',
+      stderr: '',
+      timedOut: false
+    })
+
+    const found = await detectSkillProvidersInWsl('Ubuntu')
+
+    const [spec] = runWslProcessMock.mock.calls.at(-1) as [RunWslProcessSpec]
+    expect(spec.lane).toBe('probe')
+    expect(spec.distro).toBe('Ubuntu')
+    expect(found).toEqual(['codex'])
+  })
+
+  it('parses both providers when present', async () => {
+    runWslProcessMock.mockResolvedValue({
+      code: 0,
+      stdout: 'codex\nclaude\n',
+      stderr: '',
+      timedOut: false
+    })
+
+    const found = await detectSkillProvidersInWsl('Ubuntu')
+
+    expect(found).toEqual(['codex', 'claude'])
+  })
+
+  it('ignores stray output that is not a recognized provider name', async () => {
+    runWslProcessMock.mockResolvedValue({
+      code: 0,
+      stdout: 'codex\nsomething-else\n',
+      stderr: '',
+      timedOut: false
+    })
+
+    const found = await detectSkillProvidersInWsl('Ubuntu')
+
+    expect(found).toEqual(['codex'])
+  })
+
+  it('rejects when wsl.exe cannot be started', async () => {
+    runWslProcessMock.mockRejectedValue(new Error('spawn wsl.exe ENOENT'))
+
+    await expect(detectSkillProvidersInWsl('Ubuntu')).rejects.toThrow(
+      'skill-install-wsl-provider-detection-failed'
+    )
+  })
+
+  it('rejects on a non-zero exit', async () => {
+    runWslProcessMock.mockResolvedValue({
+      code: 1,
+      stdout: '',
+      stderr: 'distro is stopped',
+      timedOut: false
+    })
+
+    await expect(detectSkillProvidersInWsl('Ubuntu')).rejects.toThrow(
+      'skill-install-wsl-provider-detection-failed'
+    )
+  })
+})

--- a/src/main/skills/skill-wsl-provider-detection.ts
+++ b/src/main/skills/skill-wsl-provider-detection.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'node:child_process'
+import { runWslProcess } from '../wsl/wsl-runner'
 
 const DETECTION_SCRIPT = [
   'set -eu',
@@ -6,21 +6,24 @@ const DETECTION_SCRIPT = [
   'command -v claude >/dev/null 2>&1 && printf "claude\\n" || true'
 ].join('\n')
 
-export function detectSkillProvidersInWsl(distro: string): Promise<string[]> {
-  return new Promise((resolve, reject) => {
-    execFile(
-      'wsl.exe',
-      ['-d', distro, '--exec', 'sh', '-c', DETECTION_SCRIPT],
-      { encoding: 'utf8', timeout: 10_000, windowsHide: true },
-      (error, stdout) => {
-        if (error) {
-          reject(new Error('skill-install-wsl-provider-detection-failed'))
-          return
-        }
-        resolve(
-          stdout.split(/\r?\n/u).filter((provider) => provider === 'codex' || provider === 'claude')
-        )
-      }
-    )
-  })
+export async function detectSkillProvidersInWsl(distro: string): Promise<string[]> {
+  let result
+  try {
+    // Why probe: a bare `sh -c` has no login shell, so a PATH built by nvm/mise
+    // rc files never applies and an installed codex/claude reads as absent.
+    result = await runWslProcess({
+      distro,
+      lane: 'probe',
+      script: DETECTION_SCRIPT,
+      timeoutMs: 10_000
+    })
+  } catch {
+    throw new Error('skill-install-wsl-provider-detection-failed')
+  }
+  if (result.code !== 0) {
+    throw new Error('skill-install-wsl-provider-detection-failed')
+  }
+  return result.stdout
+    .split(/\r?\n/u)
+    .filter((provider) => provider === 'codex' || provider === 'claude')
 }

--- a/src/main/wsl/__fixtures__/wsl-invocation-allowlist.txt
+++ b/src/main/wsl/__fixtures__/wsl-invocation-allowlist.txt
@@ -1,0 +1,27 @@
+# Files that spawn wsl.exe directly instead of through src/main/wsl/wsl-runner.ts.
+# Enforced by ../wsl-invocation-boundary.test.ts. This list only shrinks -- its
+# length is the W3 goalpost. Removing an entry means the file now goes through
+# the runner, not that its call was tidied in place.
+main/agent-hooks/wsl-hook-relay-launch.ts
+main/claude-accounts/runtime-auth-service.ts
+main/claude-accounts/service.ts
+main/cli/wsl-cli-installer.ts
+main/codex-accounts/runtime-home-service.ts
+main/codex-accounts/service.ts
+main/codex/codex-state-db-backfill-recovery.ts
+main/codex/codex-trust-grant-host.ts
+main/codex/codex-wsl-hook-install-plan.ts
+main/git/wsl-git-read-environment.ts
+main/hooks.ts
+main/ipc/filesystem-watcher-wsl.ts
+main/ipc/preflight-wsl-agent-detection.ts
+main/ipc/preflight-wsl-command.ts
+main/local-worktree-filesystem.ts
+main/skills/claude-plugin-skill-sources-wsl.ts
+main/skills/skill-discovery-wsl.ts
+main/skills/skill-provider-runtime-roots.ts
+main/skills/skill-wsl-install-filesystem.ts
+main/skills/skill-wsl-provider-detection.ts
+main/wsl-availability.ts
+main/wsl-unc-delete.ts
+main/wsl.ts

--- a/src/main/wsl/__fixtures__/wsl-invocation-allowlist.txt
+++ b/src/main/wsl/__fixtures__/wsl-invocation-allowlist.txt
@@ -14,14 +14,12 @@ main/codex/codex-wsl-hook-install-plan.ts
 main/git/wsl-git-read-environment.ts
 main/hooks.ts
 main/ipc/filesystem-watcher-wsl.ts
-main/ipc/preflight-wsl-agent-detection.ts
 main/ipc/preflight-wsl-command.ts
 main/local-worktree-filesystem.ts
 main/skills/claude-plugin-skill-sources-wsl.ts
 main/skills/skill-discovery-wsl.ts
 main/skills/skill-provider-runtime-roots.ts
 main/skills/skill-wsl-install-filesystem.ts
-main/skills/skill-wsl-provider-detection.ts
 main/wsl-availability.ts
 main/wsl-unc-delete.ts
 main/wsl.ts

--- a/src/main/wsl/__fixtures__/wsl-invocation-allowlist.txt
+++ b/src/main/wsl/__fixtures__/wsl-invocation-allowlist.txt
@@ -16,10 +16,6 @@ main/hooks.ts
 main/ipc/filesystem-watcher-wsl.ts
 main/ipc/preflight-wsl-command.ts
 main/local-worktree-filesystem.ts
-main/skills/claude-plugin-skill-sources-wsl.ts
-main/skills/skill-discovery-wsl.ts
-main/skills/skill-provider-runtime-roots.ts
-main/skills/skill-wsl-install-filesystem.ts
 main/wsl-availability.ts
 main/wsl-unc-delete.ts
 main/wsl.ts

--- a/src/main/wsl/wsl-executable-path.ts
+++ b/src/main/wsl/wsl-executable-path.ts
@@ -1,0 +1,20 @@
+import { existsSync } from 'node:fs'
+import { win32 as pathWin32 } from 'node:path'
+
+/**
+ * Absolute path to `wsl.exe`.
+ *
+ * Why not the bare name: spawning by name resolves through the child's PATH,
+ * which a Group Policy, a stripped Electron environment or a shadowing entry
+ * can point somewhere else — the same class of failure W1 fixed for PowerShell
+ * (#15749). System32 is the launcher Microsoft ships; the Store package
+ * forwards through it.
+ */
+export function resolveWslExecutablePath(): string {
+  const systemRoot = process.env.SystemRoot || 'C:\\Windows'
+  const absolute = pathWin32.join(systemRoot, 'System32', 'wsl.exe')
+  // Why the fallback: a host that has WSL somewhere else still deserves a
+  // working call, and PATH resolution is strictly better than a path we know
+  // is wrong.
+  return existsSync(absolute) ? absolute : 'wsl.exe'
+}

--- a/src/main/wsl/wsl-guest-environment.test.ts
+++ b/src/main/wsl/wsl-guest-environment.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const runProcessMock = vi.hoisted(() => vi.fn())
+vi.mock('../../shared/child-process/run-process', () => ({ runProcess: runProcessMock }))
+vi.mock('./wsl-executable-path', () => ({ resolveWslExecutablePath: () => 'wsl.exe' }))
+
+import {
+  getWslGuestEnvironment,
+  invalidateWslGuestEnvironment,
+  peekWslGuestEnvironment
+} from './wsl-guest-environment'
+
+/** Echo a well-formed payload back inside whatever fence the probe generated. */
+function respondWithPayload(payload: string, code = 0): void {
+  runProcessMock.mockImplementation(async (spec: { args: string[] }) => {
+    const script = spec.args.at(-1) ?? ''
+    const begin = /__ORCA_WSL_CAPTURE_BEGIN_[a-z0-9]+__/.exec(script)?.[0] ?? ''
+    const end = /__ORCA_WSL_CAPTURE_END_[a-z0-9]+__/.exec(script)?.[0] ?? ''
+    return {
+      code,
+      signal: null,
+      stdout: `distro banner\n${begin}${payload}${end}`,
+      stderr: '',
+      timedOut: false
+    }
+  })
+}
+
+const GOOD = ['/home/u/.nvm/bin:/usr/bin', '/home/u', '/usr/bin/env'].join('\0')
+
+beforeEach(() => {
+  runProcessMock.mockReset()
+  invalidateWslGuestEnvironment()
+})
+afterEach(() => invalidateWslGuestEnvironment())
+
+describe('probing', () => {
+  it('reads PATH, HOME and env out of a banner-polluted stdout', async () => {
+    respondWithPayload(GOOD)
+    expect(await getWslGuestEnvironment('Ubuntu')).toEqual({
+      path: '/home/u/.nvm/bin:/usr/bin',
+      home: '/home/u',
+      envBinary: '/usr/bin/env'
+    })
+  })
+
+  it('collapses a concurrent burst into one probe', async () => {
+    // Teardown and detection both fan out; 32 login shells per burst is the
+    // cost this cache exists to avoid.
+    respondWithPayload(GOOD)
+    await Promise.all(Array.from({ length: 32 }, () => getWslGuestEnvironment('Ubuntu')))
+    expect(runProcessMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps distros isolated', async () => {
+    respondWithPayload(GOOD)
+    await getWslGuestEnvironment('Ubuntu')
+    await getWslGuestEnvironment('Debian')
+    expect(runProcessMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('bad answers are not cached as good ones', () => {
+  it.each([
+    ['a relative HOME', ['/usr/bin', 'home/u', '/usr/bin/env'].join('\0')],
+    ['a PATH with a newline', ['/usr/bin\nx', '/home/u', '/usr/bin/env'].join('\0')],
+    ['a truncated payload', '/usr/bin'],
+    ['a relative env binary', ['/usr/bin', '/home/u', 'env'].join('\0')]
+  ])('rejects %s', async (_case, payload) => {
+    respondWithPayload(payload)
+    expect(await getWslGuestEnvironment('Ubuntu')).toBeNull()
+    expect(peekWslGuestEnvironment('Ubuntu')).toBeUndefined()
+  })
+
+  it('treats a missing fence as a failed probe, not an empty PATH', async () => {
+    runProcessMock.mockResolvedValue({
+      code: 0,
+      signal: null,
+      stdout: 'only a banner, no fence',
+      stderr: '',
+      timedOut: false
+    })
+    expect(await getWslGuestEnvironment('Ubuntu')).toBeNull()
+  })
+})
+
+describe('transient versus permanent failure', () => {
+  it('does not retry a distro that cannot produce env', async () => {
+    // 127 is the probe's own "no usable env". Retrying that forever turns a
+    // probe into a poller.
+    runProcessMock.mockResolvedValue({
+      code: 127,
+      signal: null,
+      stdout: '',
+      stderr: '',
+      timedOut: false
+    })
+    await getWslGuestEnvironment('Ubuntu')
+    await getWslGuestEnvironment('Ubuntu')
+    expect(runProcessMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries after the window when the probe timed out', async () => {
+    vi.useFakeTimers()
+    try {
+      runProcessMock.mockResolvedValue({
+        code: null,
+        signal: null,
+        stdout: '',
+        stderr: '',
+        timedOut: true
+      })
+      expect(await getWslGuestEnvironment('Ubuntu')).toBeNull()
+      expect(await getWslGuestEnvironment('Ubuntu')).toBeNull()
+      expect(runProcessMock).toHaveBeenCalledTimes(1)
+
+      vi.setSystemTime(Date.now() + 31_000)
+      respondWithPayload(GOOD)
+      expect(await getWslGuestEnvironment('Ubuntu')).not.toBeNull()
+      expect(runProcessMock).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})
+
+describe('invalidation', () => {
+  it('re-probes after the caller invalidates, so a newly installed tool appears', async () => {
+    // A user who installs nvm inside a running distro would otherwise keep the
+    // pre-install PATH until Orca restarts, and read that as the detection bug
+    // this cache exists to fix.
+    respondWithPayload(GOOD)
+    await getWslGuestEnvironment('Ubuntu')
+    invalidateWslGuestEnvironment('Ubuntu')
+    respondWithPayload(['/opt/new/bin', '/home/u', '/usr/bin/env'].join('\0'))
+    expect((await getWslGuestEnvironment('Ubuntu'))?.path).toBe('/opt/new/bin')
+  })
+})

--- a/src/main/wsl/wsl-guest-environment.ts
+++ b/src/main/wsl/wsl-guest-environment.ts
@@ -1,0 +1,172 @@
+import { runProcess } from '../../shared/child-process/run-process'
+import {
+  buildWslCapturedLoginShellCommand,
+  buildWslExecArgs
+} from '../../shared/wsl-login-shell-command'
+import { resolveWslExecutablePath } from './wsl-executable-path'
+
+/**
+ * The login-shell environment of a distro, probed once and cached.
+ *
+ * Why this exists: a probe needs the user's real PATH (nvm, mise and asdf all
+ * install into rc files), but paying for a login shell on every probe is what
+ * made `cli:getWslInstallStatus` time out behind a blocking `~/.profile`
+ * (#14288) and what makes WSL git operations lag (#9768). Probe the login shell
+ * exactly once per distro, then run everything else with no shell at all.
+ *
+ * Generalised from `src/main/git/wsl-git-read-environment.ts`, which is the one
+ * WSL caller that already got this right.
+ */
+
+export type WslGuestEnvironment = {
+  /** Login-shell PATH, as the user's own terminal would see it. */
+  path: string
+  home: string
+  /** Absolute path to `env`, used to run programs without a shell. */
+  envBinary: string
+}
+
+const PROBE_TIMEOUT_MS = 10_000
+const PROBE_MAX_OUTPUT_BYTES = 64 * 1024
+/**
+ * Why retry a timeout but not a malformed answer: a stopped distro or a
+ * momentarily wedged `wsl.exe` recovers on its own, while a distro that cannot
+ * produce a POSIX PATH will not start doing so. Retrying the second forever is
+ * how a probe becomes a poller.
+ */
+const TRANSIENT_RETRY_MS = 30_000
+
+type ProbeOutcome =
+  | { kind: 'resolved'; environment: WslGuestEnvironment }
+  | { kind: 'rejected' }
+  | { kind: 'transient' }
+
+const inFlight = new Map<string, Promise<WslGuestEnvironment | null>>()
+const resolved = new Map<string, WslGuestEnvironment>()
+const retryAfter = new Map<string, number>()
+
+/** A payload that is not three absolute, single-line POSIX values is a failed probe. */
+function parseProbePayload(payload: string | null): WslGuestEnvironment | null {
+  if (payload === null) {
+    return null
+  }
+  const [path = '', home = '', envBinary = ''] = payload.split('\0')
+  const isCleanAbsolute = (value: string): boolean =>
+    value.startsWith('/') && !value.includes('\n') && !value.includes('\r')
+  if (!path.includes('/') || path.length > 32_768 || path.includes('\n')) {
+    return null
+  }
+  if (!isCleanAbsolute(home) || !isCleanAbsolute(envBinary)) {
+    return null
+  }
+  return { path, home, envBinary }
+}
+
+async function probeGuestEnvironment(distro: string | undefined): Promise<ProbeOutcome> {
+  // Why resolve `env` rather than assume /usr/bin/env: it is /usr/bin/env on
+  // Debian, Ubuntu, Fedora and Arch, but the probe costs nothing extra here and
+  // a distro that puts it elsewhere would otherwise fail every later call.
+  const script = [
+    '_orca_env=$(command -v env 2>/dev/null || true)',
+    'case "$_orca_env" in /*) [ -x "$_orca_env" ] || exit 127 ;; *) exit 127 ;; esac',
+    `printf '%s\\0%s\\0%s' "$PATH" "$HOME" "$_orca_env"`
+  ].join('\n')
+  const captured = buildWslCapturedLoginShellCommand(script)
+  const result = await runProcess({
+    program: resolveWslExecutablePath(),
+    args: buildWslExecArgs(distro, ['sh', '-c', captured.command]),
+    timeoutMs: PROBE_TIMEOUT_MS,
+    maxOutputBytes: PROBE_MAX_OUTPUT_BYTES
+  })
+  if (result.timedOut) {
+    return { kind: 'transient' }
+  }
+  if (result.code !== 0) {
+    // 127 is our own "no usable env"; anything else is the distro being
+    // unavailable, which is worth retrying.
+    return result.code === 127 ? { kind: 'rejected' } : { kind: 'transient' }
+  }
+  const environment = parseProbePayload(captured.readStdout(result.stdout))
+  return environment ? { kind: 'resolved', environment } : { kind: 'rejected' }
+}
+
+function cacheKey(distro: string | undefined): string {
+  return distro ?? ''
+}
+
+/**
+ * The distro's login-shell environment, or null when it cannot be established.
+ *
+ * Null is "we could not ask", never "the distro has no PATH" — callers fall
+ * back to the interactive lane rather than running with an empty environment.
+ */
+export function getWslGuestEnvironment(
+  distro: string | undefined
+): Promise<WslGuestEnvironment | null> {
+  const key = cacheKey(distro)
+  const retry = retryAfter.get(key)
+  if (retry !== undefined && Date.now() >= retry) {
+    inFlight.delete(key)
+    retryAfter.delete(key)
+  }
+  const existing = inFlight.get(key)
+  if (existing) {
+    return existing
+  }
+  // Why store the promise before awaiting: a 32-wide burst during teardown must
+  // collapse into one probe, not 32 login shells.
+  const probe = probeGuestEnvironment(distro).then((outcome) => {
+    if (inFlight.get(key) !== probe) {
+      return outcome.kind === 'resolved' ? outcome.environment : null
+    }
+    if (outcome.kind === 'resolved') {
+      resolved.set(key, outcome.environment)
+      retryAfter.delete(key)
+      return outcome.environment
+    }
+    if (outcome.kind === 'transient') {
+      retryAfter.set(key, Date.now() + TRANSIENT_RETRY_MS)
+    }
+    return null
+  })
+  inFlight.set(key, probe)
+  return probe
+}
+
+/**
+ * Drop a distro's cached environment.
+ *
+ * Why callers need this: a user who installs nvm inside a running distro would
+ * otherwise keep the pre-install PATH until Orca restarts, and read that as the
+ * same detection bug this cache exists to fix.
+ */
+export function invalidateWslGuestEnvironment(distro?: string): void {
+  if (distro === undefined) {
+    inFlight.clear()
+    resolved.clear()
+    retryAfter.clear()
+    return
+  }
+  const key = cacheKey(distro)
+  inFlight.delete(key)
+  resolved.delete(key)
+  retryAfter.delete(key)
+}
+
+/** Test-only: the cached value without probing. */
+export function peekWslGuestEnvironment(
+  distro: string | undefined
+): WslGuestEnvironment | undefined {
+  return resolved.get(cacheKey(distro))
+}
+
+/** Test-only: pretend a distro has already been probed. */
+export function seedWslGuestEnvironmentForTests(
+  distro: string | undefined,
+  environment: WslGuestEnvironment
+): void {
+  const key = cacheKey(distro)
+  inFlight.set(key, Promise.resolve(environment))
+  resolved.set(key, environment)
+  retryAfter.delete(key)
+}

--- a/src/main/wsl/wsl-invocation-boundary.test.ts
+++ b/src/main/wsl/wsl-invocation-boundary.test.ts
@@ -1,0 +1,101 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Every `wsl.exe` spawn must go through `runWslProcess`.
+ *
+ * Why a guard and not review: five decisions have to be made on each call
+ * (separator, shell, stdout fencing, WSLENV, payload transport), each is
+ * invisible in a diff, and each has shipped wrong. `wsl-exec-mode-separator`
+ * already guards one of the five — this guards the call itself, so the other
+ * four cannot be re-decided per site.
+ *
+ * The allowlist is the W3 migration worklist and only shrinks. Its length is
+ * the workstream's measured goalpost.
+ */
+const ALLOWLIST: readonly string[] = readFileSync(
+  join(__dirname, '__fixtures__', 'wsl-invocation-allowlist.txt'),
+  'utf8'
+)
+  .split('\n')
+  .map((line) => line.trim())
+  .filter((line) => line.length > 0 && !line.startsWith('#'))
+
+const SOURCE_ROOT = resolve(__dirname, '../..')
+// Why the trailing slash: a bare 'main/wsl' prefix also exempts main/wsl.ts,
+// main/wsl-availability.ts and main/wsl-unc-delete.ts -- three files that spawn
+// wsl.exe directly. Caught by testing the guard against a planted call site.
+const OWNER_DIRECTORY = 'main/wsl/'
+const IGNORED = new Set(['node_modules', 'dist', 'out', 'build', '.git', '__fixtures__'])
+/**
+ * A spawn site: the `wsl.exe` literal sits directly in a spawn-family call, or
+ * in a `program:` field. A bare mention (a shell-name constant, a type, a
+ * comment) is not a call and is not the guard's business.
+ */
+const SPAWN_OPENER =
+  /(?:spawn|spawnSync|execFile|execFileSync|exec|fork|runProcess|spawnProcess|execFileAsync|execAsync)\s*\(\s*$|program:\s*$/
+
+function isTestFile(path: string): boolean {
+  return (
+    /\.(?:test|spec)\.tsx?$/.test(path) ||
+    /(?:test-harness|test-utils|test-setup|test-fixture|repro)/.test(path)
+  )
+}
+
+function collectSourceFiles(root: string): string[] {
+  const found: string[] = []
+  for (const entry of readdirSync(root)) {
+    if (IGNORED.has(entry) || entry.startsWith('.')) {
+      continue
+    }
+    const path = join(root, entry)
+    if (statSync(path).isDirectory()) {
+      found.push(...collectSourceFiles(path))
+      continue
+    }
+    if (/\.tsx?$/.test(entry)) {
+      found.push(path)
+    }
+  }
+  return found
+}
+
+function findSpawnSites(): string[] {
+  const offenders = new Set<string>()
+  for (const path of collectSourceFiles(SOURCE_ROOT)) {
+    const relativePath = relative(SOURCE_ROOT, path).replace(/\\/g, '/')
+    if (isTestFile(relativePath) || relativePath.startsWith(OWNER_DIRECTORY)) {
+      continue
+    }
+    const source = readFileSync(path, 'utf8')
+    for (const match of source.matchAll(/['"]wsl\.exe['"]/g)) {
+      // Collapse the preceding whitespace so a call broken across lines by the
+      // formatter still reads as one opener.
+      const preceding = source.slice(Math.max(0, match.index - 60), match.index)
+      if (SPAWN_OPENER.test(preceding.replace(/\s+/g, ' ').replace(/ $/, ''))) {
+        offenders.add(relativePath)
+      }
+    }
+  }
+  return [...offenders].sort()
+}
+
+describe('wsl.exe is spawned through one runner', () => {
+  const offenders = findSpawnSites()
+
+  it('finds the call sites it is meant to guard', () => {
+    // Guards against a detection change quietly emptying the scan, which would
+    // make the assertions below pass without checking anything.
+    expect(offenders.length + ALLOWLIST.length).toBeGreaterThanOrEqual(20)
+  })
+
+  it('adds no new direct wsl.exe spawn', () => {
+    expect(offenders.filter((path) => !ALLOWLIST.includes(path))).toEqual([])
+  })
+
+  it('carries no stale allowlist entry', () => {
+    // A migrated file must leave the list, or the goalpost stops moving.
+    expect(ALLOWLIST.filter((path) => !offenders.includes(path))).toEqual([])
+  })
+})

--- a/src/main/wsl/wsl-invocation-boundary.test.ts
+++ b/src/main/wsl/wsl-invocation-boundary.test.ts
@@ -81,6 +81,44 @@ function findSpawnSites(): string[] {
   return [...offenders].sort()
 }
 
+/**
+ * A bash-only payload must say `shell: 'bash'`.
+ *
+ * Why: the runner's `script` runs under `sh`, which on Debian/Ubuntu is dash.
+ * A payload using process substitution, `local` or `[[ ]]` fails there with
+ * `Syntax error: word unexpected` -- the #14292 signature. A migration that
+ * swaps `bash -c` for the runner without saying so introduces exactly that,
+ * and no unit test catches it because the tests mock the runner.
+ */
+/**
+ * Bash-only constructs. `pipefail` and `read -d` are the easy ones to miss:
+ * they look like ordinary shell, and dash accepts neither.
+ */
+const BASHISM =
+  /<\s*<\(|\[\[|\blocal\s+\w+=|\bdeclare\s+-|\bmapfile\b|set\s+-o\s+pipefail|read\s+(?:-\w+\s+)*-d\b|<<</
+
+describe('bash-only payloads declare their interpreter', () => {
+  const offenders: string[] = []
+  for (const path of collectSourceFiles(SOURCE_ROOT)) {
+    const relativePath = relative(SOURCE_ROOT, path).replace(/\\/g, '/')
+    // The runner's own file documents these constructs; it does not run them.
+    if (isTestFile(relativePath) || relativePath.startsWith(OWNER_DIRECTORY)) {
+      continue
+    }
+    const source = readFileSync(path, 'utf8')
+    if (!source.includes('runWslProcess') || !BASHISM.test(source)) {
+      continue
+    }
+    if (!source.includes("shell: 'bash'")) {
+      offenders.push(relativePath)
+    }
+  }
+
+  it('every runner caller with a bash-only script pins bash', () => {
+    expect(offenders).toEqual([])
+  })
+})
+
 describe('wsl.exe is spawned through one runner', () => {
   const offenders = findSpawnSites()
 

--- a/src/main/wsl/wsl-runner.test.ts
+++ b/src/main/wsl/wsl-runner.test.ts
@@ -1,0 +1,236 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const runProcessMock = vi.hoisted(() => vi.fn())
+vi.mock('../../shared/child-process/run-process', () => ({ runProcess: runProcessMock }))
+vi.mock('./wsl-executable-path', () => ({
+  resolveWslExecutablePath: () => 'C:\\Windows\\System32\\wsl.exe'
+}))
+
+import { runWslProcess } from './wsl-runner'
+import {
+  invalidateWslGuestEnvironment,
+  seedWslGuestEnvironmentForTests
+} from './wsl-guest-environment'
+
+const ENVIRONMENT = {
+  path: '/home/u/.nvm/bin:/usr/bin',
+  home: '/home/u',
+  envBinary: '/usr/bin/env'
+}
+
+function lastArgv(): string[] {
+  return runProcessMock.mock.calls.at(-1)?.[0].args as string[]
+}
+
+beforeEach(() => {
+  runProcessMock.mockReset()
+  runProcessMock.mockResolvedValue({
+    code: 0,
+    signal: null,
+    stdout: '',
+    stderr: '',
+    timedOut: false
+  })
+  invalidateWslGuestEnvironment()
+})
+
+afterEach(() => {
+  invalidateWslGuestEnvironment()
+})
+
+describe('separator', () => {
+  it.each([
+    ['probe', 'probe'],
+    ['interactive', 'interactive']
+  ] as const)('uses --exec and never -- on the %s lane', async (_name, lane) => {
+    // Why this is pinned on both lanes: under `--`, wsl.exe expands $name in
+    // every forwarded argument before the guest runs -- even with no shell in
+    // the command -- so a script means something other than what it says
+    // (#12964). No escaping on our side is a reliable substitute.
+    seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
+    await runWslProcess({ lane, program: '/usr/bin/git', args: ['status'] })
+    expect(lastArgv()).toContain('--exec')
+    expect(lastArgv()).not.toContain('--')
+  })
+
+  it('passes the distro before --exec', async () => {
+    seedWslGuestEnvironmentForTests('Ubuntu', ENVIRONMENT)
+    await runWslProcess({ lane: 'probe', distro: 'Ubuntu', program: '/bin/true' })
+    expect(lastArgv().slice(0, 3)).toEqual(['-d', 'Ubuntu', '--exec'])
+  })
+})
+
+describe('probe lane', () => {
+  it('runs with the cached login PATH and no shell', async () => {
+    // The whole point: the user's real PATH without paying for -- or being
+    // blocked by -- a login shell on every call (#14288, #9768).
+    seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
+    await runWslProcess({ lane: 'probe', program: 'codex', args: ['--version'] })
+    expect(lastArgv()).toEqual([
+      '--exec',
+      '/usr/bin/env',
+      'PATH=/home/u/.nvm/bin:/usr/bin',
+      'HOME=/home/u',
+      'codex',
+      '--version'
+    ])
+  })
+
+  it('falls back to the interactive lane when the distro cannot be probed', async () => {
+    // "We could not ask" must not become "run with no PATH" -- that would turn
+    // an unknown into a wrong answer.
+    runProcessMock.mockResolvedValue({
+      code: 1,
+      signal: null,
+      stdout: '',
+      stderr: 'distro is stopped',
+      timedOut: false
+    })
+    await runWslProcess({ lane: 'probe', program: 'codex' })
+    const argv = lastArgv()
+    expect(argv).toContain('--exec')
+    expect(argv.slice(-2, -1)).toEqual(['-c'])
+    expect(argv.at(-1)).toContain('_orca_wsl_shell')
+  })
+})
+
+describe('interactive lane', () => {
+  it('always fences stdout, even when the caller ignores it', async () => {
+    // Stock Ubuntu writes its rc hint to stdout, so an unfenced parse reads the
+    // banner as data (#11327, #11823). A caller that starts parsing later must
+    // not have to remember to opt in.
+    runProcessMock.mockImplementation(async (spec: { args: string[] }) => {
+      const script = spec.args.at(-1) ?? ''
+      const begin = /__ORCA_WSL_CAPTURE_BEGIN_[a-z0-9]+__/.exec(script)?.[0] ?? ''
+      const end = /__ORCA_WSL_CAPTURE_END_[a-z0-9]+__/.exec(script)?.[0] ?? ''
+      return {
+        code: 0,
+        signal: null,
+        stdout: `Ubuntu banner: run a command as administrator\n${begin}payload${end}`,
+        stderr: '',
+        timedOut: false
+      }
+    })
+    const result = await runWslProcess({ lane: 'interactive', program: 'claude' })
+    expect(result.stdout).toBe('payload')
+  })
+})
+
+describe('scripts', () => {
+  it('delivers a script on stdin through sh -s, not in argv', async () => {
+    // A script on stdin has no quoting boundary for its own quotes to escape
+    // from. That is what the base64 and eval wrappers were working around
+    // (#14292), and why this is the only supported way to run one.
+    seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
+    const script = `case "$x" in a) echo 'it'\\''s fine';; esac`
+    await runWslProcess({ lane: 'probe', script, args: ['/tmp/root'] })
+    expect(runProcessMock.mock.calls.at(-1)?.[0].input).toBe(script)
+    expect(lastArgv()).toEqual([
+      '--exec',
+      '/usr/bin/env',
+      'PATH=/home/u/.nvm/bin:/usr/bin',
+      'HOME=/home/u',
+      'sh',
+      '-s',
+      '--',
+      '/tmp/root'
+    ])
+    expect(lastArgv().join(' ')).not.toContain('case')
+  })
+})
+
+describe('WSLENV', () => {
+  it('adds every propagated key so the value actually crosses the boundary', async () => {
+    // Unset, a Windows-side variable silently never reaches the guest (#12557).
+    seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
+    await runWslProcess({
+      lane: 'probe',
+      program: '/bin/true',
+      env: { GITLAB_HOST: 'git.example.com', GH_TOKEN: 't' }
+    })
+    const env = runProcessMock.mock.calls.at(-1)?.[0].env as NodeJS.ProcessEnv
+    expect(env.GITLAB_HOST).toBe('git.example.com')
+    expect(env.WSLENV?.split(':')).toEqual(expect.arrayContaining(['GITLAB_HOST', 'GH_TOKEN']))
+  })
+
+  it('leaves the host environment alone when nothing is propagated', async () => {
+    seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
+    await runWslProcess({ lane: 'probe', program: '/bin/true' })
+    expect(runProcessMock.mock.calls.at(-1)?.[0].env).toBeUndefined()
+  })
+})
+
+describe('guest cwd', () => {
+  it('cds inside the guest rather than passing a Windows cwd to wsl.exe', async () => {
+    seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
+    await runWslProcess({ lane: 'probe', program: '/usr/bin/git', cwd: '/home/u/repo' })
+    expect(runProcessMock.mock.calls.at(-1)?.[0].cwd).toBeUndefined()
+    expect(lastArgv()).toContain('/home/u/repo')
+    expect(lastArgv()).toContain('sh')
+  })
+
+  it.each([['C:\\repo'], ['relative/path']])('rejects %s as a guest cwd', async (cwd) => {
+    // A Windows path here means a mistake further up; converting it silently
+    // hides that.
+    seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
+    await expect(runWslProcess({ lane: 'probe', program: '/bin/true', cwd })).rejects.toThrow(
+      /guest path/
+    )
+  })
+})
+
+describe('program is a binary, not a shell string', () => {
+  it.each([['sh -c echo hi'], ['a; b'], ['a | b'], ['a && b'], ['echo $HOME'], ['a > b']])(
+    'rejects %s',
+    async (program) => {
+      await expect(runWslProcess({ lane: 'probe', program })).rejects.toThrow(/single binary/)
+    }
+  )
+
+  it('allows a guest path containing a space', async () => {
+    // --exec passes the program as one argv element, so a space is harmless;
+    // rejecting it would fail legitimate installs under a spaced directory.
+    seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
+    await expect(
+      runWslProcess({ lane: 'probe', program: '/home/u/my tools/codex' })
+    ).resolves.toBeDefined()
+  })
+})
+
+describe('script interpreter', () => {
+  it('defaults to sh', async () => {
+    seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
+    await runWslProcess({ lane: 'probe', script: 'echo hi' })
+    expect(lastArgv()).toContain('sh')
+    expect(lastArgv()).not.toContain('bash')
+  })
+
+  it('honours an explicit bash request', async () => {
+    // A payload using process substitution (`done < <(find ...)`), `local` or
+    // `[[ ]]` is bash-only. Running it under dash yields `Syntax error: word
+    // unexpected` -- the #14292 signature -- so a bash caller must be able to
+    // say so rather than be silently downgraded.
+    seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
+    await runWslProcess({ lane: 'probe', script: 'done < <(find .)', shell: 'bash' })
+    expect(lastArgv()).toContain('bash')
+    expect(lastArgv()).not.toContain('sh')
+  })
+})
+
+describe('a script never rides the interactive lane', () => {
+  it('runs sh -s even when the distro cannot be probed', async () => {
+    // The login shell owns stdin, and the script arrives on stdin. If the shell
+    // consumed it, `sh -s` would read EOF, run nothing and exit 0 -- a silent
+    // wrong answer, worse than the degraded PATH this avoids.
+    runProcessMock.mockResolvedValue({
+      code: 1,
+      signal: null,
+      stdout: '',
+      stderr: 'distro is stopped',
+      timedOut: false
+    })
+    await runWslProcess({ lane: 'probe', script: 'echo hi' })
+    expect(lastArgv()).toEqual(['--exec', 'sh', '-s', '--'])
+    expect(runProcessMock.mock.calls.at(-1)?.[0].input).toBe('echo hi')
+  })
+})

--- a/src/main/wsl/wsl-runner.ts
+++ b/src/main/wsl/wsl-runner.ts
@@ -1,0 +1,220 @@
+import { addWslEnvKeys } from '../../shared/wsl-env'
+import { runProcess } from '../../shared/child-process/run-process'
+import {
+  buildWslCapturedLoginShellCommand,
+  buildWslExecArgs,
+  quotePosixShell
+} from '../../shared/wsl-login-shell-command'
+import { getWslGuestEnvironment, type WslGuestEnvironment } from './wsl-guest-environment'
+import { resolveWslExecutablePath } from './wsl-executable-path'
+
+/**
+ * The single place Orca runs a program inside WSL.
+ *
+ * Five decisions have to be made on every `wsl.exe` call, each has a right
+ * answer, and each has shipped wrong:
+ *
+ * - **Separator.** `--` makes wsl.exe expand `$name` in every forwarded
+ *   argument before the guest runs, even with no shell in the command, so
+ *   `awk '{print $2}'` loses its field reference (#12964). Always `--exec`.
+ * - **Shell.** A login shell on a probe path sources `~/.profile`, so one
+ *   blocking line eats the whole timeout (#14288) and every call pays startup
+ *   (#9768). No login shell on a user-facing path means PATH does not match the
+ *   user's terminal, so nvm-installed agents read as absent (#9725, #7563,
+ *   #8366). Hence two lanes, chosen explicitly.
+ * - **Fencing.** An interactive login shell runs the distro rc, and stock
+ *   Ubuntu writes its "run as administrator" hint to *stdout*, so anything
+ *   parsing that stream reads the banner as data (#11327, #11823).
+ * - **WSLENV.** Unset, a Windows-side variable silently never crosses into the
+ *   guest (#12557).
+ * - **Payload.** Scripts go in on stdin. A script on stdin has no quoting
+ *   boundary to escape from, which is what the base64 and `eval` wrappers were
+ *   working around (#14292).
+ */
+
+export type WslLane =
+  /** No shell. Cached login PATH/HOME, applied via `env`. */
+  | 'probe'
+  /** Login shell, always fenced. For anything whose PATH must match the user's terminal. */
+  | 'interactive'
+
+/**
+ * What to run: a single binary, or a script.
+ *
+ * Why a union rather than an optional `script`: a script has to arrive on
+ * stdin, which means the program must be a shell reading stdin. Left to the
+ * caller that is a footgun — and the wrappers this replaces exist because it
+ * was never made explicit. `script` makes the runner supply `sh -s` itself.
+ */
+export type WslCommand =
+  | { program: string; args?: readonly string[]; script?: never; shell?: never }
+  | {
+      script: string
+      args?: readonly string[]
+      program?: never
+      /**
+       * Interpreter for `script`. Defaults to `sh`, which on Debian and Ubuntu
+       * is dash.
+       *
+       * Why this is not just always `sh`: a payload using process substitution
+       * (`done < <(find ...)`), `local`, or `[[ ]]` is bash-only, and dash
+       * rejects it with `Syntax error: word unexpected` -- the exact signature
+       * in #14292. A caller that writes bash must say so; silently downgrading
+       * its interpreter is how that error reaches users.
+       */
+      shell?: 'sh' | 'bash'
+    }
+
+export type WslSpec = WslCommand & {
+  /** Undefined selects the distro's default. */
+  distro?: string
+  /**
+   * Required, with no default. The wrong lane is the most common WSL defect in
+   * this tree, and a default lets a call site pick it by omission.
+   */
+  lane: WslLane
+  /** Guest (POSIX) path. */
+  cwd?: string
+  /** Host variables to propagate into the guest; sets WSLENV automatically. */
+  env?: Readonly<Record<string, string>>
+  timeoutMs?: number
+  maxOutputBytes?: number
+  signal?: AbortSignal
+}
+
+export type WslResult = {
+  code: number | null
+  /** Payload only — on the interactive lane the rc banner is removed by the fence. */
+  stdout: string
+  stderr: string
+  timedOut: boolean
+}
+
+export const DEFAULT_WSL_TIMEOUT_MS = 30_000
+
+function assertGuestPath(cwd: string): void {
+  // Why reject rather than convert: a caller passing a Windows path here has
+  // usually made a different mistake further up, and silently translating it
+  // hides that.
+  if (!cwd.startsWith('/')) {
+    throw new Error(`WSL cwd must be a guest path, received ${cwd}`)
+  }
+}
+
+function assertNotShellString(program: string): void {
+  // Why: the base64 and eval wrappers exist because this boundary was never
+  // enforced. `script` is the supported way to run a script.
+  //
+  // Why metacharacters and not whitespace: a guest binary may legitimately live
+  // under a path containing a space, and --exec passes it as one argv element,
+  // so a space is harmless. A `;` or `|` means the caller is building a command
+  // line, which is the thing being prevented.
+  if (/[;&|<>$`\n\r]/.test(program) || /^\S+\s+-/.test(program)) {
+    throw new Error(`WSL program must be a single binary, received ${program}`)
+  }
+}
+
+/** Host env plus the WSLENV entries that let it cross the boundary. */
+function buildHostEnv(env: WslSpec['env']): NodeJS.ProcessEnv | undefined {
+  if (!env || Object.keys(env).length === 0) {
+    return undefined
+  }
+  const merged: NodeJS.ProcessEnv = { ...process.env, ...env }
+  addWslEnvKeys(merged, Object.keys(env))
+  return merged
+}
+
+/**
+ * `cd` into the guest cwd before the program.
+ *
+ * Why not `runProcess`'s `cwd`: that is a *Windows* directory for `wsl.exe`,
+ * not a guest one. Passing a guest path there fails, and passing the UNC form
+ * makes wsl.exe start in a network location.
+ */
+function withGuestCwd(cwd: string | undefined, argv: readonly string[]): string[] {
+  if (!cwd) {
+    return [...argv]
+  }
+  assertGuestPath(cwd)
+  return ['sh', '-c', 'cd "$1" || exit 1; shift; exec "$@"', 'orca-wsl', cwd, ...argv]
+}
+
+/** `<shell> -s --` for a script on stdin, otherwise the program itself. */
+function guestCommandArgv(spec: WslSpec): string[] {
+  return spec.script !== undefined
+    ? [spec.shell ?? 'sh', '-s', '--', ...(spec.args ?? [])]
+    : [spec.program, ...(spec.args ?? [])]
+}
+
+/** Shell-free argv, with the cached environment applied when one is available. */
+function buildGuestArgv(environment: WslGuestEnvironment | null, spec: WslSpec): string[] {
+  const command = guestCommandArgv(spec)
+  const argv = environment
+    ? [environment.envBinary, `PATH=${environment.path}`, `HOME=${environment.home}`, ...command]
+    : command
+  return withGuestCwd(spec.cwd, argv)
+}
+
+function buildInteractiveArgv(spec: WslSpec): {
+  argv: string[]
+  readStdout: (stdout: string) => string
+} {
+  // Why the whole invocation goes through the fence: a caller that does not
+  // parse stdout today may start tomorrow, and the banner is invisible until
+  // then.
+  const quoted = guestCommandArgv(spec).map(quotePosixShell).join(' ')
+  const body = spec.cwd ? `cd ${quotePosixShell(spec.cwd)} || exit 1\n${quoted}` : quoted
+  const captured = buildWslCapturedLoginShellCommand(body)
+  return {
+    argv: ['sh', '-c', captured.command],
+    readStdout: (stdout: string) => captured.readStdout(stdout) ?? ''
+  }
+}
+
+/**
+ * Run a program inside WSL.
+ *
+ * Falls back from the probe lane to the interactive lane when the distro's
+ * environment cannot be probed — an unprobed distro is "we could not ask", and
+ * running with no PATH at all would turn that into a wrong answer.
+ */
+export async function runWslProcess(spec: WslSpec): Promise<WslResult> {
+  if (spec.program !== undefined) {
+    assertNotShellString(spec.program)
+  }
+  if (spec.cwd) {
+    assertGuestPath(spec.cwd)
+  }
+
+  const environment = spec.lane === 'probe' ? await getWslGuestEnvironment(spec.distro) : null
+  // Why a script never takes the interactive lane: the login shell owns stdin,
+  // and the script is delivered on stdin. If the shell consumes it first, the
+  // inner `sh -s` reads EOF, runs nothing, and exits 0 -- a silent wrong answer,
+  // which is strictly worse than the degraded PATH avoided by taking this path.
+  // A script therefore always runs as `--exec sh -s --`, with the cached
+  // environment applied when there is one.
+  const lane =
+    environment === null && spec.script === undefined
+      ? // Why fall back rather than run with no PATH: an unprobed distro is
+        // "we could not ask", and answering with an empty environment turns
+        // that into a wrong answer.
+        ({ kind: 'interactive', ...buildInteractiveArgv(spec) } as const)
+      : ({ kind: 'probe', argv: buildGuestArgv(environment, spec) } as const)
+
+  const result = await runProcess({
+    program: resolveWslExecutablePath(),
+    args: buildWslExecArgs(spec.distro, lane.argv),
+    env: buildHostEnv(spec.env),
+    input: spec.script,
+    timeoutMs: spec.timeoutMs ?? DEFAULT_WSL_TIMEOUT_MS,
+    maxOutputBytes: spec.maxOutputBytes,
+    signal: spec.signal
+  })
+
+  return {
+    code: result.code,
+    stdout: lane.kind === 'interactive' ? lane.readStdout(result.stdout) : result.stdout,
+    stderr: result.stderr,
+    timedOut: result.timedOut
+  }
+}

--- a/src/main/wsl/wsl-runner.wsl.test.ts
+++ b/src/main/wsl/wsl-runner.wsl.test.ts
@@ -1,0 +1,125 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { runWslProcess } from './wsl-runner'
+import { invalidateWslGuestEnvironment } from './wsl-guest-environment'
+import { runProcess } from '../../shared/child-process/run-process'
+import { resolveWslExecutablePath } from './wsl-executable-path'
+
+/**
+ * The assertions no unit test can make: a real distro, a real login shell, a
+ * real rc banner.
+ *
+ * Gated behind an env var and win32 because it mutates the distro's `~/.profile`
+ * to reproduce #14288. Run with:
+ *   ORCA_REAL_WSL_RUNNER_TEST=1 pnpm vitest run src/main/wsl/wsl-runner.wsl.test.ts
+ */
+const DISTRO = process.env.ORCA_WSL_TEST_DISTRO ?? 'Ubuntu-24.04'
+const enabled = process.platform === 'win32' && process.env.ORCA_REAL_WSL_RUNNER_TEST === '1'
+const describeOnWsl = enabled ? describe : describe.skip
+
+const PROFILE = '/tmp/orca-wsl-runner-profile.bak'
+
+async function guest(script: string): Promise<string> {
+  const result = await runProcess({
+    program: resolveWslExecutablePath(),
+    args: ['-d', DISTRO, '--exec', 'sh', '-c', script],
+    timeoutMs: 30_000
+  })
+  return result.stdout.trim()
+}
+
+describeOnWsl('runWslProcess against a real distro', () => {
+  beforeAll(async () => {
+    // Save whatever profile exists, then make it block for far longer than the
+    // probe budget -- this is #14288 reproduced, not simulated.
+    await guest(`cp -f "$HOME/.profile" ${PROFILE} 2>/dev/null || true`)
+    await guest(`printf '\\nsleep 60\\n' >> "$HOME/.profile"`)
+    invalidateWslGuestEnvironment()
+  }, 120_000)
+
+  afterAll(async () => {
+    await guest(`cp -f ${PROFILE} "$HOME/.profile" 2>/dev/null || rm -f "$HOME/.profile"`)
+    await guest(`rm -f ${PROFILE}`)
+    invalidateWslGuestEnvironment()
+  }, 120_000)
+
+  it('probe lane survives a ~/.profile that blocks for a minute', async () => {
+    // The first call pays one login shell (which the blocking profile stalls,
+    // so it times out and the lane degrades); every later call must not.
+    // What must never happen is the probe lane inheriting the stall per call.
+    const started = Date.now()
+    const result = await runWslProcess({
+      lane: 'probe',
+      distro: DISTRO,
+      program: '/bin/echo',
+      args: ['orca-probe-ok'],
+      timeoutMs: 15_000
+    })
+    const elapsed = Date.now() - started
+    expect(result.stdout.trim()).toContain('orca-probe-ok')
+    expect(elapsed).toBeLessThan(20_000)
+  }, 60_000)
+
+  it('second probe-lane call does not pay the login shell again', async () => {
+    const started = Date.now()
+    await runWslProcess({ lane: 'probe', distro: DISTRO, program: '/bin/true', timeoutMs: 15_000 })
+    expect(Date.now() - started).toBeLessThan(5_000)
+  }, 30_000)
+
+  it('interactive lane strips the distro banner from parsed stdout', async () => {
+    // Stock Ubuntu writes its rc hint to stdout. Anything parsing that stream
+    // reads the banner as data unless the fence removes it (#11327, #11823).
+    const result = await runWslProcess({
+      lane: 'interactive',
+      distro: DISTRO,
+      program: '/bin/echo',
+      args: ['ORCA_PAYLOAD'],
+      timeoutMs: 60_000
+    })
+    expect(result.stdout.trim()).toBe('ORCA_PAYLOAD')
+  }, 90_000)
+
+  it('a script with quotes and $ arrives byte-identical', async () => {
+    // Both hazards in one payload: `--` would expand $2 host-side, and the
+    // base64/eval wrappers broke on the embedded quotes (#12964, #14292).
+    const script = [
+      `printf '%s\\n' "$1"`,
+      `echo 'it'\\''s fine'`,
+      `echo "x" | awk '{print $1}'`
+    ].join('\n')
+    const result = await runWslProcess({
+      lane: 'probe',
+      distro: DISTRO,
+      script,
+      args: ['ORCA_ARG'],
+      timeoutMs: 30_000
+    })
+    expect(
+      result.stdout
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean)
+    ).toEqual(['ORCA_ARG', "it's fine", 'x'])
+  }, 60_000)
+
+  it('propagated env crosses the boundary via WSLENV', async () => {
+    const result = await runWslProcess({
+      lane: 'probe',
+      distro: DISTRO,
+      script: 'printf %s "$ORCA_WSLENV_PROBE"',
+      env: { ORCA_WSLENV_PROBE: 'crossed' },
+      timeoutMs: 30_000
+    })
+    expect(result.stdout.trim()).toBe('crossed')
+  }, 60_000)
+
+  it('runs in the requested guest cwd', async () => {
+    const result = await runWslProcess({
+      lane: 'probe',
+      distro: DISTRO,
+      program: '/bin/pwd',
+      cwd: '/tmp',
+      timeoutMs: 30_000
+    })
+    expect(result.stdout.trim()).toBe('/tmp')
+  }, 60_000)
+})


### PR DESCRIPTION
Stacked on #15907.

## ELI5

Four bits of skill-scanning code were smuggling their shell script into WSL by base64-encoding it, because quoting kept breaking. The runner hands scripts over on stdin, where quoting can't break — so the encoding is deleted.

## What changes

Four skill sites spawned `wsl.exe` directly; two wrapped their payload in `buildEncodedWslBashCommand` — base64, decoded in-guest, piped to a shell — purely to get a multi-line script across the argv boundary intact. A script on stdin has no quoting boundary to escape from, so the wrapper has nothing left to solve.

## The trap, and why no test would have caught it

`bash -c` and the runner's default `sh` are **not the same interpreter**. These scans use `set -o pipefail`, `read -r -d ''` and `done < <(find ...)` — all bash-only. On Debian/Ubuntu `sh` is dash, which rejects each with `Syntax error: word unexpected`: the #14292 signature.

**No unit test would have caught this** — the tests mock the runner, and the one round-trip test invokes the script through `bash` directly. It was caught by reading the payloads.

So: scripts declare their interpreter (`shell: 'sh' | 'bash'`), both bash payloads pin `bash` with the reason at the call site, and a guard fails any runner caller whose script uses bash-only syntax without declaring it. The detector covers the constructs that *look* like ordinary shell — `pipefail`, `read -d` — not just the obvious ones.

Credit: the subagent that did this migration flagged the interpreter risk itself and named two bashisms I had missed.

## Proof of no regression

- The NUL-delimited output protocol and its parsers are untouched.
- All three sites now check `result.code !== 0 || result.timedOut` before parsing. This matters: `runProcess` **resolves** on a non-zero exit, so a scan killed at its 10s timeout previously returned partial stdout that parsed into a valid *"zero skills"* result — which reads as "nothing is installed" and re-offers installs for skills the user already has.
- Bash guard verified in both directions (removing a `shell: 'bash'` makes it fail, naming the file).
- 620 tests pass; typecheck and lint clean.

## User-facing trade-offs

**None intended.** Interpreter, protocol and timeouts are preserved; the failure path is strictly better (a failed scan now surfaces as an error instead of an empty skill list).
