### PR TITLE
feat(worktree): seed the default agent when activating an empty worktree

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -85,6 +85,7 @@ import {
 import TabGroupSplitLayout from './tab-group/TabGroupSplitLayout'
 import AiVaultSessionDropLayer from './tab-group/AiVaultSessionDropLayer'
 import { shouldAutoCreateInitialTerminal } from './terminal/initial-terminal'
+import { ensureWorktreeHasInitialTerminal } from '@/lib/worktree-initial-terminal-seeding'
 import { useActiveTerminalRepair } from './terminal/use-active-terminal-repair'
 import { scheduleBackgroundTerminalWorktreeMeasure } from './terminal/background-terminal-worktree-visibility'
 import {
@@ -1516,13 +1517,13 @@ function Terminal(): React.JSX.Element | null {
     if (!shouldAutoCreateInitialTerminal(renderableTabCount, activeWorktreeHasTerminalState)) {
       return
     }
-    // Why: tag this never-visited-worktree tab so its PTY spawn doesn't count as activity and reshuffle the sidebar (explicit New Tab still bumps).
-    createTab(activeWorktreeId, undefined, undefined, { pendingActivationSpawn: true })
+    // Why: same seeding as sidebar activation so a never-visited worktree opens
+    // the default agent instead of a bare shell when Settings has one.
+    ensureWorktreeHasInitialTerminal(useAppStore.getState(), activeWorktreeId)
   }, [
     workspaceSessionReady,
     activeWorktreeId,
     activeWorktreeHasTerminalState,
-    createTab,
     reconcileWorktreeTabModel
   ])
 

--- a/src/renderer/src/components/terminal/initial-terminal-wiring.test.ts
+++ b/src/renderer/src/components/terminal/initial-terminal-wiring.test.ts
@@ -31,6 +31,9 @@ describe('Terminal auto-create wiring', () => {
     expect(source).toContain(
       'shouldAutoCreateInitialTerminal(renderableTabCount, activeWorktreeHasTerminalState)'
     )
+    expect(source).toContain(
+      'ensureWorktreeHasInitialTerminal(useAppStore.getState(), activeWorktreeId)'
+    )
   })
 
   it('keeps that derivation in the effect dependencies', () => {

--- a/src/renderer/src/lib/default-agent-startup-payload.ts
+++ b/src/renderer/src/lib/default-agent-startup-payload.ts
@@ -1,0 +1,81 @@
+import { buildAgentStartupPlan } from '../../../shared/tui-agent-startup'
+import { tuiAgentToAgentKind } from '../../../shared/agent-kind'
+import { isTuiAgentEnabled, pickTuiAgent } from '../../../shared/tui-agent-selection'
+import {
+  resolveTuiAgentLaunchArgs,
+  resolveTuiAgentLaunchEnv
+} from '../../../shared/tui-agent-launch-defaults'
+import type { AgentStartupShell } from '../../../shared/tui-agent-startup-shell'
+import type { LaunchSource } from '../../../shared/telemetry-events'
+import type { GlobalSettings } from '../../../shared/global-settings-types'
+import type { TuiAgent } from '../../../shared/tui-agent'
+import { resolveInitialNativeChatSessionOptions } from '@/components/native-chat/native-chat-launch-session-options'
+import type { WorktreeStartupPayload } from '@/lib/worktree-startup-payload'
+
+export function resolveEmptyWorktreeDefaultAgent(args: {
+  settings: Pick<GlobalSettings, 'defaultTuiAgent' | 'disabledTuiAgents'> | null | undefined
+  detectedAgentIds: readonly TuiAgent[] | null | undefined
+}): TuiAgent | null {
+  const preferred = args.settings?.defaultTuiAgent
+  if (preferred === 'blank') {
+    return null
+  }
+  if (preferred) {
+    return isTuiAgentEnabled(preferred, args.settings?.disabledTuiAgents) ? preferred : null
+  }
+  return pickTuiAgent(null, args.detectedAgentIds ?? [], args.settings?.disabledTuiAgents)
+}
+
+export function buildDefaultAgentStartupPayload(args: {
+  agent: TuiAgent
+  settings: GlobalSettings
+  launchSource: LaunchSource
+  platform: NodeJS.Platform
+  nativeChatTranscriptIsLocalReadable?: boolean
+  isRemote?: boolean
+  shell?: AgentStartupShell
+}): WorktreeStartupPayload | undefined {
+  const {
+    agent,
+    settings,
+    launchSource,
+    platform,
+    nativeChatTranscriptIsLocalReadable = true,
+    isRemote,
+    shell
+  } = args
+  const startupPlan = buildAgentStartupPlan({
+    agent,
+    prompt: '',
+    cmdOverrides: settings.agentCmdOverrides ?? {},
+    agentArgs: resolveTuiAgentLaunchArgs(agent, settings.agentDefaultArgs),
+    agentEnv: resolveTuiAgentLaunchEnv(agent, settings.agentDefaultEnv),
+    sessionOptions: resolveInitialNativeChatSessionOptions(settings, {
+      agent,
+      nativeChatTranscriptIsLocalReadable
+    }),
+    platform,
+    ...(shell ? { shell } : {}),
+    ...(isRemote !== undefined ? { isRemote } : {}),
+    allowEmptyPromptLaunch: true
+  })
+  if (!startupPlan) {
+    return undefined
+  }
+
+  return {
+    command: startupPlan.launchCommand,
+    ...(startupPlan.env ? { env: startupPlan.env } : {}),
+    launchConfig: startupPlan.launchConfig,
+    launchAgent: agent,
+    ...(startupPlan.sessionOptions ? { sessionOptions: startupPlan.sessionOptions } : {}),
+    ...(startupPlan.startupCommandDelivery
+      ? { startupCommandDelivery: startupPlan.startupCommandDelivery }
+      : {}),
+    telemetry: {
+      agent_kind: tuiAgentToAgentKind(agent),
+      launch_source: launchSource,
+      request_kind: 'new'
+    }
+  }
+}

--- a/src/renderer/src/lib/onboarding-folder-agent-startup.ts
+++ b/src/renderer/src/lib/onboarding-folder-agent-startup.ts
@@ -1,18 +1,12 @@
-import { buildAgentStartupPlan } from '@/lib/tui-agent-startup'
-import { tuiAgentToAgentKind } from '@/lib/telemetry'
 import { isTuiAgentEnabled } from '../../../shared/tui-agent-selection'
-import {
-  resolveTuiAgentLaunchArgs,
-  resolveTuiAgentLaunchEnv
-} from '../../../shared/tui-agent-launch-defaults'
 import type { AgentStartedTelemetry } from '@/lib/worktree-startup-payload'
 import type { StartupCommandDelivery } from '../../../shared/codex-startup-delivery'
 import type { SleepingAgentLaunchConfig } from '../../../shared/agent-session-resume'
 import type { GlobalSettings } from '../../../shared/global-settings-types'
 import type { OnboardingState } from '../../../shared/onboarding-state-types'
 import type { TuiAgent } from '../../../shared/tui-agent'
-import { resolveInitialNativeChatSessionOptions } from '@/components/native-chat/native-chat-launch-session-options'
 import type { SessionOptionValue } from '../../../shared/native-chat-session-options'
+import { buildDefaultAgentStartupPayload } from '@/lib/default-agent-startup-payload'
 
 export type OnboardingFolderAgentStartup = {
   command: string
@@ -45,38 +39,17 @@ export function buildOnboardingFolderAgentStartup(
     return undefined
   }
 
-  const startupPlan = buildAgentStartupPlan({
+  const startup = buildDefaultAgentStartupPayload({
     agent,
-    prompt: '',
-    cmdOverrides: settings.agentCmdOverrides ?? {},
-    agentArgs: resolveTuiAgentLaunchArgs(agent, settings.agentDefaultArgs),
-    agentEnv: resolveTuiAgentLaunchEnv(agent, settings.agentDefaultEnv),
-    sessionOptions: resolveInitialNativeChatSessionOptions(settings, {
-      agent,
-      nativeChatTranscriptIsLocalReadable
-    }),
-    platform: getClientPlatform(),
-    allowEmptyPromptLaunch: true
+    settings,
+    launchSource: 'onboarding',
+    nativeChatTranscriptIsLocalReadable,
+    platform: getClientPlatform()
   })
-  if (!startupPlan) {
+  if (!startup?.telemetry) {
     return undefined
   }
-
-  return {
-    command: startupPlan.launchCommand,
-    ...(startupPlan.env ? { env: startupPlan.env } : {}),
-    launchConfig: startupPlan.launchConfig,
-    launchAgent: agent,
-    ...(startupPlan.sessionOptions ? { sessionOptions: startupPlan.sessionOptions } : {}),
-    ...(startupPlan.startupCommandDelivery
-      ? { startupCommandDelivery: startupPlan.startupCommandDelivery }
-      : {}),
-    telemetry: {
-      agent_kind: tuiAgentToAgentKind(agent),
-      launch_source: 'onboarding',
-      request_kind: 'new'
-    }
-  }
+  return { ...startup, telemetry: startup.telemetry }
 }
 
 export function shouldSeedFolderAgentAfterDismissedOnboarding(

--- a/src/renderer/src/lib/worktree-activation-agent-startup.test.ts
+++ b/src/renderer/src/lib/worktree-activation-agent-startup.test.ts
@@ -4,6 +4,7 @@ import {
   createMockStore,
   registerWorktreeActivationReset
 } from './worktree-activation-test-harness'
+import { useAppStore } from '@/store'
 
 registerWorktreeActivationReset()
 
@@ -245,5 +246,49 @@ describe('ensureWorktreeHasInitialTerminal', () => {
       command: 'codex',
       launchAgent: 'codex'
     })
+  })
+
+  it('seeds the global default agent when activation has no startup payload', () => {
+    useAppStore.setState((state) => ({
+      settings: state.settings
+        ? { ...state.settings, defaultTuiAgent: 'codex' }
+        : ({ defaultTuiAgent: 'codex' } as unknown as typeof state.settings)
+    }))
+    const store = createMockStore()
+
+    ensureWorktreeHasInitialTerminal(store, 'wt-1')
+
+    expect(store.createTab).toHaveBeenCalledWith('wt-1', undefined, undefined, {
+      pendingActivationSpawn: true,
+      launchAgent: 'codex'
+    })
+    expect(store.queueTabStartupCommand).toHaveBeenCalledWith(
+      'tab-1',
+      expect.objectContaining({
+        command: expect.stringContaining('codex'),
+        launchAgent: 'codex',
+        telemetry: expect.objectContaining({
+          agent_kind: 'codex',
+          launch_source: 'sidebar',
+          request_kind: 'new'
+        })
+      })
+    )
+  })
+
+  it('keeps a blank terminal when the default agent is blank', () => {
+    useAppStore.setState((state) => ({
+      settings: state.settings
+        ? { ...state.settings, defaultTuiAgent: 'blank' }
+        : ({ defaultTuiAgent: 'blank' } as unknown as typeof state.settings)
+    }))
+    const store = createMockStore()
+
+    ensureWorktreeHasInitialTerminal(store, 'wt-1')
+
+    expect(store.createTab).toHaveBeenCalledWith('wt-1', undefined, undefined, {
+      pendingActivationSpawn: true
+    })
+    expect(store.queueTabStartupCommand).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/lib/worktree-activation-default-tabs.test.ts
+++ b/src/renderer/src/lib/worktree-activation-default-tabs.test.ts
@@ -4,6 +4,7 @@ import {
   createMockStore,
   registerWorktreeActivationReset
 } from './worktree-activation-test-harness'
+import { useAppStore } from '@/store'
 
 registerWorktreeActivationReset()
 
@@ -188,5 +189,32 @@ describe('ensureWorktreeHasInitialTerminal', () => {
 
     expect(store.createTab).not.toHaveBeenCalled()
     expect(store.setActiveTab).not.toHaveBeenCalled()
+  })
+
+  it('does not replace configured default tabs with the global default agent', () => {
+    useAppStore.setState((state) => ({
+      settings: state.settings
+        ? { ...state.settings, defaultTuiAgent: 'codex' }
+        : ({ defaultTuiAgent: 'codex' } as unknown as typeof state.settings)
+    }))
+    let createdIndex = 0
+    const createTab = vi.fn(() => ({ id: `tab-${++createdIndex}` }))
+    const store = createMockStore({ createTab })
+
+    ensureWorktreeHasInitialTerminal(store, 'wt-1', undefined, undefined, undefined, {
+      runCommands: true,
+      tabs: [{ title: 'Dev', command: 'pnpm dev' }]
+    })
+
+    expect(createTab).toHaveBeenCalledTimes(1)
+    expect(createTab).toHaveBeenCalledWith('wt-1', undefined, undefined, {
+      pendingActivationSpawn: true,
+      recordInteraction: false
+    })
+    expect(store.queueTabStartupCommand).toHaveBeenCalledWith('tab-1', { command: 'pnpm dev' })
+    expect(store.queueTabStartupCommand).not.toHaveBeenCalledWith(
+      'tab-1',
+      expect.objectContaining({ launchAgent: 'codex' })
+    )
   })
 })

--- a/src/renderer/src/lib/worktree-activation-test-harness.ts
+++ b/src/renderer/src/lib/worktree-activation-test-harness.ts
@@ -11,6 +11,8 @@ const initialWorktreesByRepo = useAppStore.getState().worktreesByRepo
 const initialGetKnownWorktreeById = useAppStore.getState().getKnownWorktreeById
 const initialPendingIssueCommandSplitByTabId =
   useAppStore.getState().pendingIssueCommandSplitByTabId
+const initialDefaultTuiAgent = useAppStore.getState().settings?.defaultTuiAgent
+const initialDetectedAgentIds = useAppStore.getState().detectedAgentIds
 
 export function setSetupScriptLaunchMode(mode: SetupScriptLaunchMode | null): void {
   useAppStore.setState((state) => ({
@@ -28,8 +30,16 @@ export function registerWorktreeActivationReset(): void {
     delete (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__
     useAppStore.setState((state) => ({
       settings: state.settings
-        ? { ...state.settings, activeRuntimeEnvironmentId: null }
-        : ({ activeRuntimeEnvironmentId: null } as unknown as typeof state.settings)
+        ? {
+            ...state.settings,
+            activeRuntimeEnvironmentId: null,
+            defaultTuiAgent: initialDefaultTuiAgent ?? null
+          }
+        : ({
+            activeRuntimeEnvironmentId: null,
+            defaultTuiAgent: initialDefaultTuiAgent ?? null
+          } as unknown as typeof state.settings),
+      detectedAgentIds: initialDetectedAgentIds
     }))
     setSetupScriptLaunchMode('new-tab')
     resetHookCommandDelayedDeliveryForTests()

--- a/src/renderer/src/lib/worktree-default-agent-startup.test.ts
+++ b/src/renderer/src/lib/worktree-default-agent-startup.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { getDefaultSettings } from '../../../shared/constants'
+import {
+  buildDefaultAgentStartupPayload,
+  resolveEmptyWorktreeDefaultAgent
+} from '@/lib/default-agent-startup-payload'
+
+describe('resolveEmptyWorktreeDefaultAgent', () => {
+  it('uses a pinned default even when it is not in the detected list', () => {
+    expect(
+      resolveEmptyWorktreeDefaultAgent({
+        settings: { defaultTuiAgent: 'codex', disabledTuiAgents: [] },
+        detectedAgentIds: ['claude']
+      })
+    ).toBe('codex')
+  })
+
+  it('does not launch when the default is a blank terminal', () => {
+    expect(
+      resolveEmptyWorktreeDefaultAgent({
+        settings: { defaultTuiAgent: 'blank', disabledTuiAgents: [] },
+        detectedAgentIds: ['claude', 'codex']
+      })
+    ).toBeNull()
+  })
+
+  it('does not launch a disabled pinned default', () => {
+    expect(
+      resolveEmptyWorktreeDefaultAgent({
+        settings: { defaultTuiAgent: 'codex', disabledTuiAgents: ['codex'] },
+        detectedAgentIds: ['claude', 'codex']
+      })
+    ).toBeNull()
+  })
+
+  it('auto-picks from detected agents when no default is set', () => {
+    expect(
+      resolveEmptyWorktreeDefaultAgent({
+        settings: { defaultTuiAgent: null, disabledTuiAgents: [] },
+        detectedAgentIds: ['codex', 'claude']
+      })
+    ).toBe('claude')
+  })
+
+  it('does not infer an agent when auto mode has no detections yet', () => {
+    expect(
+      resolveEmptyWorktreeDefaultAgent({
+        settings: { defaultTuiAgent: null, disabledTuiAgents: [] },
+        detectedAgentIds: null
+      })
+    ).toBeNull()
+  })
+})
+
+describe('buildDefaultAgentStartupPayload', () => {
+  it('queues the pinned agent with sidebar telemetry', () => {
+    const startup = buildDefaultAgentStartupPayload({
+      agent: 'codex',
+      settings: {
+        ...getDefaultSettings('/tmp/orca-workspaces'),
+        defaultTuiAgent: 'codex'
+      },
+      launchSource: 'sidebar',
+      platform: 'darwin'
+    })
+
+    expect(startup).toEqual({
+      command: "codex '--dangerously-bypass-approvals-and-sandbox'",
+      env: {},
+      launchAgent: 'codex',
+      launchConfig: {
+        agentCommand: "codex '--dangerously-bypass-approvals-and-sandbox'",
+        agentArgs: '--dangerously-bypass-approvals-and-sandbox',
+        agentEnv: {}
+      },
+      telemetry: {
+        agent_kind: 'codex',
+        launch_source: 'sidebar',
+        request_kind: 'new'
+      }
+    })
+  })
+})

--- a/src/renderer/src/lib/worktree-default-agent-startup.ts
+++ b/src/renderer/src/lib/worktree-default-agent-startup.ts
@@ -1,0 +1,61 @@
+import { getAgentLaunchPlatformForRepo } from '@/lib/agent-launch-platform'
+import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
+import { getConnectionIdFromState } from '@/lib/connection-context'
+import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
+import { useAppStore } from '@/store'
+import { repoIsRemote } from '../../../shared/agent-launch-remote'
+import { resolveLocalWindowsAgentStartupShell } from '../../../shared/windows-terminal-shell'
+import {
+  buildDefaultAgentStartupPayload,
+  resolveEmptyWorktreeDefaultAgent
+} from '@/lib/default-agent-startup-payload'
+import type { WorktreeStartupPayload } from '@/lib/worktree-startup-payload'
+
+export { buildDefaultAgentStartupPayload, resolveEmptyWorktreeDefaultAgent }
+
+export function buildEmptyWorktreeDefaultAgentStartup(
+  worktreeId: string
+): WorktreeStartupPayload | undefined {
+  const state = useAppStore.getState()
+  const settings = state.settings
+  if (!settings) {
+    return undefined
+  }
+  const connectionId = getConnectionIdFromState(state, worktreeId)
+  const detectedAgentIds =
+    typeof connectionId === 'string'
+      ? state.remoteDetectedAgentIds[connectionId]
+      : state.detectedAgentIds
+  const agent = resolveEmptyWorktreeDefaultAgent({ settings, detectedAgentIds })
+  if (!agent) {
+    return undefined
+  }
+
+  const worktree = state.getKnownWorktreeById(worktreeId)
+  const repo = worktree ? state.repos.find((entry) => entry.id === worktree.repoId) : undefined
+  const isRemote = repo ? repoIsRemote(repo) : Boolean(connectionId)
+  const platform = repo
+    ? getAgentLaunchPlatformForRepo(
+        repo,
+        repo.connectionId ? undefined : getLocalProjectExecutionRuntimeContext(state, worktreeId)
+      )
+    : isRemote
+      ? 'linux'
+      : getRendererAppPlatform()
+  const shell = resolveLocalWindowsAgentStartupShell({
+    platform,
+    isRemote,
+    terminalWindowsShell: settings.terminalWindowsShell
+  })
+
+  return buildDefaultAgentStartupPayload({
+    agent,
+    settings,
+    launchSource: 'sidebar',
+    nativeChatTranscriptIsLocalReadable: isNativeChatTranscriptLocalReadable(connectionId),
+    platform,
+    isRemote,
+    shell
+  })
+}

--- a/src/renderer/src/lib/worktree-initial-terminal-seeding.ts
+++ b/src/renderer/src/lib/worktree-initial-terminal-seeding.ts
@@ -28,6 +28,7 @@ import {
   type IssueCommandLaunch
 } from '@/lib/worktree-setup-issue-command-queue'
 import { applyDefaultTerminalTabs } from '@/lib/worktree-default-terminal-tabs'
+import { buildEmptyWorktreeDefaultAgentStartup } from '@/lib/worktree-default-agent-startup'
 
 function getSetupRunnerCommandPlatformForLaunch(setup: WorktreeSetupLaunch): 'windows' | 'posix' {
   return getSetupRunnerCommandPlatformForPath(
@@ -159,6 +160,12 @@ export function ensureWorktreeHasInitialTerminal(
   )
   if (templatedTabId) {
     return templatedTabId
+  }
+
+  // Why: an empty activation used to seed a bare shell; follow the global default
+  // agent so clicking a worktree with no tabs matches Settings → Agents.
+  if (!sequencedStartup && !setup && !issueCommand) {
+    sequencedStartup = buildEmptyWorktreeDefaultAgentStartup(worktreeId)
   }
 
   // Why: tag this activation-created tab so its PTY spawn doesn't count as activity and reshuffle the Recent sort.


### PR DESCRIPTION
## ELI5

Clicking a worktree that has no tabs used to open a blank terminal. It now opens the same default agent you already picked in Settings → Agents, unless you set that default to a blank terminal.

## What Changed

- Empty worktree/folder activation (sidebar click and the first-visit Terminal path) seeds the global default TUI agent instead of a bare shell.
- `Settings → Agents → Default Agent = blank` still opens a blank terminal.
- Explicit startup commands, setup runners, issue-command splits, persisted empty tab state, and configured default tabs are unchanged.
- Onboarding folder-agent launch now shares `buildDefaultAgentStartupPayload` with this path.

## Why

The default agent already applied to new agent tabs and onboarding. Activating an empty workspace ignored it, so the first click felt like a different product from Settings. This makes the empty-workspace first tab follow the same setting.

## Linked Issue

No existing issue.

## Visual Proof

N/A — no layout, chrome, or copy change. The only interaction change is which process the first tab launches:

- **Before:** empty worktree click → blank shell
- **After:** empty worktree click → `defaultTuiAgent` (or auto-pick from detected agents when unset); `blank` keeps a shell

## Testing

- [x] Automated tests added/updated, or explained why not below
- [ ] I manually tested these changes locally

Covered in unit tests:

- pinned default seeds even when it is not in the detected list
- `blank` / disabled default / no detections → no agent launch
- configured default tabs are not replaced by the global default agent
- onboarding folder startup still builds from the same payload helper

Platforms exercised by tests: launch plan is built with host platform, remote `isRemote`, and Windows shell resolution. I did not run a packaged macOS/Linux/Windows/SSH smoke in this PR.

```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/lib/worktree-default-agent-startup.test.ts \
  src/renderer/src/components/terminal/initial-terminal-wiring.test.ts \
  src/renderer/src/lib/worktree-activation-agent-startup.test.ts \
  src/renderer/src/lib/worktree-activation-default-tabs.test.ts \
  src/renderer/src/components/onboarding/onboarding-folder-agent-startup.test.ts
```

44 tests passed.

## AI Disclosure

Cursor Grok 4.6 authored the implementation, tests, and this PR description.

## Review

- **Cross-platform:** launch platform comes from the repo (`getAgentLaunchPlatformForRepo`) or renderer platform; Windows shell goes through `resolveLocalWindowsAgentStartupShell`.
- **SSH / remote / folder:** remote worktrees use `connectionId` + `remoteDetectedAgentIds` and pass `isRemote` into the existing startup plan. Folder workspaces share `ensureWorktreeHasInitialTerminal`; onboarding folders share the payload builder.
- **Agents:** uses `defaultTuiAgent` / `disabledTuiAgents` / `pickTuiAgent` and existing `buildAgentStartupPlan` (cmd overrides, default args/env, native-chat session options). No GitHub-only naming.
- **Performance:** extra work is one store read + startup-plan build, and only on first empty activation.
- **Security:** no new network, credentials, or process APIs; reuses the current agent launch path.
- **UI:** no STYLEGUIDE / token changes.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Summary

- Empty worktree activation now launches Settings → Agents default agent instead of a blank terminal.
- Explicit launches, setup, issue commands, persisted empty state, and default-tab templates stay as they are.

## Test plan

- [ ] Click a never-visited git worktree with Default Agent = Codex → Codex tab, not a blank shell
- [ ] Same with Default Agent = blank → blank terminal
- [ ] Click a folder workspace with no tabs → same default-agent behavior
- [ ] Open a worktree that already has tabs / persisted empty state → no extra tab
- [ ] Worktree with configured default tabs → those tabs, not the default agent
- [ ] Remote/SSH worktree uses the remote detected-agent list

Made with [Cursor](https://cursor.com)