### PR TITLE
refactor(host): route secret storage through a SecretStore port

### DIFF
--- a/config/scripts/vitest-secret-store-setup.ts
+++ b/config/scripts/vitest-secret-store-setup.ts
@@ -1,0 +1,29 @@
+import { beforeEach } from 'vitest'
+import { setSecretStore } from '../../src/shared/secret-store'
+
+/**
+ * Why: `getSecretStore()` throws until an entrypoint installs a store, which is the
+ * right production behaviour but would fail ~67 suites that only ever cared that
+ * *some* store existed. Install a reversible in-memory one before every test so
+ * those suites stay unchanged; a suite that asserts on sealing behaviour calls
+ * `setSecretStore()` itself and wins, because this runs first.
+ *
+ * Deliberately not a plaintext passthrough: encryptString must return something a
+ * test can tell apart from the input, or a test that forgot to seal would pass.
+ */
+const SEAL_PREFIX = 'vitest-sealed:'
+
+beforeEach(() => {
+  setSecretStore({
+    isEncryptionAvailable: () => true,
+    encryptString: (plainText) => Buffer.from(`${SEAL_PREFIX}${plainText}`),
+    decryptString: (cipher) => {
+      const text = cipher.toString()
+      if (!text.startsWith(SEAL_PREFIX)) {
+        throw new Error('vitest secret store: ciphertext was not produced by this store')
+      }
+      return text.slice(SEAL_PREFIX.length)
+    },
+    describeUnavailable: () => null
+  })
+})

--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -19,7 +19,10 @@ export default defineConfig({
     // Why --expose-gc: retention tests need a deterministic collection point to measure what a queue really holds.
     execArgv: ['--no-experimental-webstorage', '--expose-gc'],
     // Why: happy-dom drops MutationObserver callbacks on GC; keep them alive like a browser does.
-    setupFiles: [resolve('config/scripts/happy-dom-mutation-observer-retention.ts')],
+    setupFiles: [
+      resolve('config/scripts/happy-dom-mutation-observer-retention.ts'),
+      resolve('config/scripts/vitest-secret-store-setup.ts')
+    ],
     include: [
       'src/**/*.test.ts',
       'src/**/*.test.tsx',

--- a/src/main/bitbucket/credential-connection.test.ts
+++ b/src/main/bitbucket/credential-connection.test.ts
@@ -10,13 +10,13 @@ let tempHome = ''
 
 async function loadModule() {
   vi.resetModules()
-  vi.doMock('electron', () => ({
-    safeStorage: {
-      isEncryptionAvailable: () => true,
-      encryptString: (value: string) => Buffer.from(value),
-      decryptString: (value: Buffer) => value.toString('utf-8')
-    }
-  }))
+  const { setSecretStore } = await import('../../shared/secret-store')
+  setSecretStore({
+    isEncryptionAvailable: () => true,
+    encryptString: (value) => Buffer.from(value),
+    decryptString: (value) => value.toString('utf-8'),
+    describeUnavailable: () => null
+  })
   vi.doMock('node:os', async () => {
     const actual = await vi.importActual<typeof Os>('node:os')
     return { ...actual, homedir: () => tempHome }

--- a/src/main/bitbucket/credential-store.test.ts
+++ b/src/main/bitbucket/credential-store.test.ts
@@ -19,13 +19,13 @@ async function loadStore(
   // Why: doMock registrations outlive resetModules, so an injected failure from
   // one case would leak into every later one in this file.
   vi.doUnmock('node:fs')
-  vi.doMock('electron', () => ({
-    safeStorage: {
-      isEncryptionAvailable: () => true,
-      encryptString: (value: string) => Buffer.from(value),
-      decryptString: decryptStringMock
-    }
-  }))
+  const { setSecretStore } = await import('../../shared/secret-store')
+  setSecretStore({
+    isEncryptionAvailable: () => true,
+    encryptString: (value) => Buffer.from(value),
+    decryptString: decryptStringMock,
+    describeUnavailable: () => null
+  })
   vi.doMock('node:os', async () => {
     const actual = await vi.importActual<typeof Os>('node:os')
     return { ...actual, homedir: () => tempHome }

--- a/src/main/bitbucket/status-no-decrypt.test.ts
+++ b/src/main/bitbucket/status-no-decrypt.test.ts
@@ -19,13 +19,13 @@ vi.mock('../git/runner', () => ({ gitExecFileAsync: vi.fn() }))
 
 async function loadModules() {
   vi.resetModules()
-  vi.doMock('electron', () => ({
-    safeStorage: {
-      isEncryptionAvailable: () => true,
-      encryptString: (value: string) => Buffer.from(value),
-      decryptString: decryptSpy
-    }
-  }))
+  const { setSecretStore } = await import('../../shared/secret-store')
+  setSecretStore({
+    isEncryptionAvailable: () => true,
+    encryptString: (value) => Buffer.from(value),
+    decryptString: decryptSpy,
+    describeUnavailable: () => null
+  })
   vi.doMock('node:os', async () => {
     const actual = await vi.importActual<typeof Os>('node:os')
     return { ...actual, homedir: () => tempHome }

--- a/src/main/host/electron-secret-store.test.ts
+++ b/src/main/host/electron-secret-store.test.ts
@@ -31,7 +31,10 @@ describe('ElectronSecretStore', () => {
     expect(safeStorageMock.decryptString).toHaveBeenCalledExactlyOnceWith(cipher)
   })
 
-  it('round-trips through the real safeStorage pair, so previously sealed credentials still open', () => {
+  // Why the narrower claim: safeStorage is mocked here, so this proves the adapter
+  // pairs encrypt/decrypt without mangling the buffer — NOT that credentials sealed by
+  // a previous build still open. Real-ciphertext compatibility needs a captured fixture.
+  it('pairs encryptString and decryptString without altering the payload', () => {
     const store = new ElectronSecretStore()
     expect(store.decryptString(store.encryptString('linear-token'))).toBe('linear-token')
   })

--- a/src/main/host/electron-secret-store.test.ts
+++ b/src/main/host/electron-secret-store.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const safeStorageMock = vi.hoisted(() => ({
+  isEncryptionAvailable: vi.fn(() => true),
+  encryptString: vi.fn((plainText: string) => Buffer.from(`os-sealed:${plainText}`)),
+  decryptString: vi.fn((cipher: Buffer) => cipher.toString().slice('os-sealed:'.length))
+}))
+
+vi.mock('electron', () => ({ safeStorage: safeStorageMock }))
+
+const { ElectronSecretStore } = await import('./electron-secret-store')
+
+describe('ElectronSecretStore', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(true)
+  })
+
+  // Why this shape: the whole safety argument for the SecretStore refactor is that the
+  // desktop byte path did not change. That is only true if this adapter forwards
+  // verbatim — same argument, same return value, no re-encoding.
+  it('forwards encryptString to safeStorage and returns its buffer unchanged', () => {
+    const sealed = new ElectronSecretStore().encryptString('token')
+    expect(safeStorageMock.encryptString).toHaveBeenCalledExactlyOnceWith('token')
+    expect(sealed).toBe(safeStorageMock.encryptString.mock.results[0]!.value)
+  })
+
+  it('forwards decryptString to safeStorage and returns its string unchanged', () => {
+    const cipher = Buffer.from('os-sealed:token')
+    expect(new ElectronSecretStore().decryptString(cipher)).toBe('token')
+    expect(safeStorageMock.decryptString).toHaveBeenCalledExactlyOnceWith(cipher)
+  })
+
+  it('round-trips through the real safeStorage pair, so previously sealed credentials still open', () => {
+    const store = new ElectronSecretStore()
+    expect(store.decryptString(store.encryptString('linear-token'))).toBe('linear-token')
+  })
+
+  it('reports availability from safeStorage rather than caching it', () => {
+    const store = new ElectronSecretStore()
+    expect(store.isEncryptionAvailable()).toBe(true)
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(false)
+    expect(store.isEncryptionAvailable()).toBe(false)
+  })
+
+  it('has no reason to give while sealing works', () => {
+    expect(new ElectronSecretStore().describeUnavailable()).toBeNull()
+  })
+
+  it('names the missing facility when sealing is unavailable, so the plaintext fallback is explainable', () => {
+    safeStorageMock.isEncryptionAvailable.mockReturnValue(false)
+    const reason = new ElectronSecretStore().describeUnavailable()
+    expect(reason).toContain('unencrypted')
+    if (process.platform === 'linux') {
+      expect(reason).toContain('keyring')
+    }
+  })
+})

--- a/src/main/host/electron-secret-store.ts
+++ b/src/main/host/electron-secret-store.ts
@@ -1,0 +1,31 @@
+import { safeStorage } from 'electron'
+import type { SecretStore } from '../../shared/secret-store'
+
+/**
+ * Electron-backed SecretStore for the desktop app: a pass-through to
+ * `electron.safeStorage`, which seals against the OS keychain.
+ */
+export class ElectronSecretStore implements SecretStore {
+  isEncryptionAvailable(): boolean {
+    return safeStorage.isEncryptionAvailable()
+  }
+
+  encryptString(plainText: string): Buffer {
+    return safeStorage.encryptString(plainText)
+  }
+
+  decryptString(cipher: Buffer): string {
+    return safeStorage.decryptString(cipher)
+  }
+
+  describeUnavailable(): string | null {
+    if (safeStorage.isEncryptionAvailable()) {
+      return null
+    }
+    // Why platform-specific: the fix differs, and "encryption unavailable" alone
+    // sends users looking in the wrong place.
+    return process.platform === 'linux'
+      ? 'The OS keyring is unavailable, so secrets are stored unencrypted. Install and unlock gnome-keyring or kwallet to seal them.'
+      : 'The OS keychain is unavailable, so secrets are stored unencrypted.'
+  }
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,6 +11,8 @@ import {
   getCanonicalUserDataPath,
   migrateMobilePairingDataToCanonicalUserDataPath
 } from './persistence'
+import { setSecretStore } from '../shared/secret-store'
+import { ElectronSecretStore } from './host/electron-secret-store'
 import { initSessionParseCachePersistence } from './ai-vault/session-parse-cache-persistence'
 import { ensureActiveOrcaProfile, initOrcaProfilePaths } from './orca-profiles/profile-index-store'
 import { getOrcaCloudAuthConfig } from './orca-profiles/profile-cloud-auth-config'
@@ -850,6 +852,11 @@ if (!hasSingleInstanceLock) {
 
 // Why: when another process holds the lock we've already exited; skip file-writing side effects so this transient process never touches userData.
 if (hasSingleInstanceLock) {
+  // Why: every secret read resolves through this port, and getSecretStore() throws
+  // until it is installed — so install before any other bootstrap step can touch a
+  // credential. Constructing it does not call safeStorage, so this stays clear of the
+  // pre-ready Keychain service-name resolution the setName block below depends on.
+  setSecretStore(new ElectronSecretStore())
   // Why: couple to dev-parent only for electron-vite desktop runs; `orca serve`'s parent (CLI shim/background shell) isn't the intended server lifetime.
   const shouldCoupleToDevParent = is.dev && !isServeMode
   installDevParentDisconnectQuit(shouldCoupleToDevParent)

--- a/src/main/integration-credential-file.ts
+++ b/src/main/integration-credential-file.ts
@@ -8,7 +8,7 @@ import {
   unlinkSync,
   writeSync
 } from 'node:fs'
-import { safeStorage } from 'electron'
+import { getSecretStore } from '../shared/secret-store'
 import {
   credentialDecryptionMessage,
   type IntegrationCredentialService
@@ -31,12 +31,12 @@ export function writeEncryptedCredential(
   path: string,
   value: string
 ): void {
-  if (safeStorage.isEncryptionAvailable()) {
-    writeCredentialFileAtomic(path, safeStorage.encryptString(value))
+  if (getSecretStore().isEncryptionAvailable()) {
+    writeCredentialFileAtomic(path, getSecretStore().encryptString(value))
     return
   }
   console.warn(
-    `[${service.toLowerCase()}] safeStorage encryption unavailable — storing credential in plaintext`
+    `[${service.toLowerCase()}] secret encryption unavailable — storing credential in plaintext`
   )
   writeCredentialFileAtomic(path, Buffer.from(value, 'utf-8'))
 }
@@ -111,9 +111,9 @@ export function readStoredCredentialToken(
     return null
   }
 
-  if (safeStorage.isEncryptionAvailable()) {
+  if (getSecretStore().isEncryptionAvailable()) {
     try {
-      return usableToken(safeStorage.decryptString(raw))
+      return usableToken(getSecretStore().decryptString(raw))
     } catch {
       return readPlaintextLegacyCredential(service, raw)
     }
@@ -127,7 +127,7 @@ function readPlaintextLegacyCredential(
   raw: Buffer
 ): string | null {
   const plaintext = decodeUtf8(raw)
-  // Why: legacy plaintext tokens are printable UTF-8; safeStorage ciphertext
+  // Why: legacy plaintext tokens are printable UTF-8; sealed ciphertext
   // such as macOS v10 blobs must not be decoded into auth-header junk.
   if (plaintext === null || hasControlCharacter(plaintext)) {
     throw new CredentialDecryptionError(service)

--- a/src/main/jira/client.test.ts
+++ b/src/main/jira/client.test.ts
@@ -93,11 +93,6 @@ async function loadClientModule(options: SafeStorageMockOptions = {}) {
   vi.resetModules()
   vi.doMock('electron', () => ({
     net: { fetch: netFetchMock },
-    safeStorage: {
-      isEncryptionAvailable: () => options.encryptionAvailable ?? false,
-      encryptString: (value: string) => Buffer.from(value),
-      decryptString: options.decryptString ?? ((value: Buffer) => value.toString('utf-8'))
-    },
     session: {
       defaultSession: {
         closeAllConnections: closeAllConnectionsMock,
@@ -106,6 +101,13 @@ async function loadClientModule(options: SafeStorageMockOptions = {}) {
       }
     }
   }))
+  const { setSecretStore } = await import('../../shared/secret-store')
+  setSecretStore({
+    isEncryptionAvailable: () => options.encryptionAvailable ?? false,
+    encryptString: (value) => Buffer.from(value),
+    decryptString: options.decryptString ?? ((value) => value.toString('utf-8')),
+    describeUnavailable: () => null
+  })
   vi.doMock('os', async () => {
     const actual = await vi.importActual<typeof Os>('os')
     return { ...actual, homedir: () => tempHome }

--- a/src/main/jira/site-credential-store.ts
+++ b/src/main/jira/site-credential-store.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import { safeStorage } from 'electron'
+import { getSecretStore } from '../../shared/secret-store'
 import {
   CredentialDecryptionError,
   credentialFileHasContent,
@@ -157,11 +157,11 @@ export function writeSiteFile(file: JiraSiteFile): void {
 }
 
 function writeEncryptedToken(path: string, apiToken: string): void {
-  if (safeStorage.isEncryptionAvailable()) {
-    writeFileSync(path, safeStorage.encryptString(apiToken), { mode: 0o600 })
+  if (getSecretStore().isEncryptionAvailable()) {
+    writeFileSync(path, getSecretStore().encryptString(apiToken), { mode: 0o600 })
     return
   }
-  console.warn('[jira] safeStorage encryption unavailable — storing token in plaintext')
+  console.warn('[jira] secret encryption unavailable — storing token in plaintext')
   writeFileSync(path, apiToken, { encoding: 'utf-8', mode: 0o600 })
 }
 

--- a/src/main/linear/client.test.ts
+++ b/src/main/linear/client.test.ts
@@ -90,13 +90,13 @@ async function loadClientModule(options: SafeStorageMockOptions = {}) {
       })
     })
   })
-  vi.doMock('electron', () => ({
-    safeStorage: {
-      isEncryptionAvailable: () => options.encryptionAvailable ?? false,
-      encryptString: (value: string) => Buffer.from(value),
-      decryptString: options.decryptString ?? ((value: Buffer) => value.toString('utf-8'))
-    }
-  }))
+  const { setSecretStore } = await import('../../shared/secret-store')
+  setSecretStore({
+    isEncryptionAvailable: () => options.encryptionAvailable ?? false,
+    encryptString: (value) => Buffer.from(value),
+    decryptString: options.decryptString ?? ((value) => value.toString('utf-8')),
+    describeUnavailable: () => null
+  })
   vi.doMock('os', async () => {
     const actual = await vi.importActual<typeof Os>('os')
     return { ...actual, homedir: () => tempHome }

--- a/src/main/linear/linear-token-store.ts
+++ b/src/main/linear/linear-token-store.ts
@@ -1,4 +1,4 @@
-import { safeStorage } from 'electron'
+import { getSecretStore } from '../../shared/secret-store'
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
 import {
   LEGACY_WORKSPACE_ID,
@@ -33,13 +33,13 @@ import {
 import type { LinearWorkspace } from '../../shared/linear/workspace-types'
 
 function writeEncryptedToken(path: string, apiKey: string): void {
-  if (safeStorage.isEncryptionAvailable()) {
-    const encrypted = safeStorage.encryptString(apiKey)
+  if (getSecretStore().isEncryptionAvailable()) {
+    const encrypted = getSecretStore().encryptString(apiKey)
     writeFileSync(path, encrypted, { mode: 0o600 })
     return
   }
 
-  console.warn('[linear] safeStorage encryption unavailable — storing token in plaintext')
+  console.warn('[linear] secret encryption unavailable — storing token in plaintext')
   writeFileSync(path, apiKey, { encoding: 'utf-8', mode: 0o600 })
 }
 

--- a/src/main/persistence-protected-secret-fail-closed.test.ts
+++ b/src/main/persistence-protected-secret-fail-closed.test.ts
@@ -19,31 +19,7 @@ vi.mock('./ssh/ssh-config-parser', () => ({
 }))
 
 vi.mock('electron', () => ({
-  app: { getPath: () => testState.dir },
-  safeStorage: {
-    isEncryptionAvailable: () => {
-      if (cipherState.availability === 'throws') {
-        throw new Error('keychain access denied')
-      }
-      return cipherState.availability === 'available'
-    },
-    encryptString: (plaintext: string) => {
-      if (cipherState.encryptionThrows) {
-        throw new Error('keychain encryption failed')
-      }
-      return Buffer.from(`enc:${randomUUID()}:${plaintext}`, 'utf-8')
-    },
-    decryptString: (ciphertext: Buffer) => {
-      if (cipherState.decryptionThrows) {
-        throw new Error('keychain decryption failed')
-      }
-      const decoded = ciphertext.toString('utf-8')
-      if (!decoded.startsWith('enc:')) {
-        throw new Error('invalid ciphertext')
-      }
-      return decoded.slice('enc:'.length + 36 + 1)
-    }
-  }
+  app: { getPath: () => testState.dir }
 }))
 
 vi.mock('./telemetry/client', () => ({ track: vi.fn() }))
@@ -53,6 +29,32 @@ vi.mock('./telemetry/cohort-classifier', () => ({
 
 async function createStore() {
   vi.resetModules()
+  const { setSecretStore } = await import('../shared/secret-store')
+  setSecretStore({
+    isEncryptionAvailable: () => {
+      if (cipherState.availability === 'throws') {
+        throw new Error('keychain access denied')
+      }
+      return cipherState.availability === 'available'
+    },
+    encryptString: (plaintext) => {
+      if (cipherState.encryptionThrows) {
+        throw new Error('keychain encryption failed')
+      }
+      return Buffer.from(`enc:${randomUUID()}:${plaintext}`, 'utf-8')
+    },
+    decryptString: (ciphertext) => {
+      if (cipherState.decryptionThrows) {
+        throw new Error('keychain decryption failed')
+      }
+      const decoded = ciphertext.toString('utf-8')
+      if (!decoded.startsWith('enc:')) {
+        throw new Error('invalid ciphertext')
+      }
+      return decoded.slice('enc:'.length + 36 + 1)
+    },
+    describeUnavailable: () => null
+  })
   const { Store, initDataPath } = await import('./persistence')
   initDataPath()
   return new Store()

--- a/src/main/persistence-protected-secret-write-race.test.ts
+++ b/src/main/persistence-protected-secret-write-race.test.ts
@@ -40,16 +40,18 @@ vi.mock('./telemetry/cohort-classifier', () => ({
 }))
 
 vi.mock('electron', () => ({
-  app: { getPath: () => testState.dir },
-  safeStorage: {
-    isEncryptionAvailable: () => cipherState.available,
-    encryptString: (plaintext: string) => Buffer.from(`enc:${plaintext}`, 'utf-8'),
-    decryptString: (ciphertext: Buffer) => ciphertext.toString('utf-8').slice('enc:'.length)
-  }
+  app: { getPath: () => testState.dir }
 }))
 
 async function createStore() {
   vi.resetModules()
+  const { setSecretStore } = await import('../shared/secret-store')
+  setSecretStore({
+    isEncryptionAvailable: () => cipherState.available,
+    encryptString: (plaintext) => Buffer.from(`enc:${plaintext}`, 'utf-8'),
+    decryptString: (ciphertext) => ciphertext.toString('utf-8').slice('enc:'.length),
+    describeUnavailable: () => null
+  })
   const { Store, initDataPath } = await import('./persistence')
   initDataPath()
   return new Store()

--- a/src/main/persistence-proxy-secret-recovery.test.ts
+++ b/src/main/persistence-proxy-secret-recovery.test.ts
@@ -28,26 +28,7 @@ vi.mock('electron', () => ({
   app: {
     getPath: () => testState.dir
   },
-  session: { defaultSession: undefined },
-  safeStorage: {
-    isEncryptionAvailable: () => {
-      if (cipherState.availabilityThrows) {
-        throw new Error('safeStorage cannot be used before the app is ready')
-      }
-      return cipherState.encryptionAvailable
-    },
-    encryptString: (plaintext: string) => Buffer.from(`enc:${randomUUID()}:${plaintext}`, 'utf-8'),
-    decryptString: (ciphertext: Buffer) => {
-      if (cipherState.decryptAlwaysThrows) {
-        throw new Error('keychain access denied')
-      }
-      const decoded = ciphertext.toString('utf-8')
-      if (!decoded.startsWith('enc:')) {
-        throw new Error('invalid ciphertext')
-      }
-      return decoded.slice('enc:'.length + 36 + 1)
-    }
-  }
+  session: { defaultSession: undefined }
 }))
 
 vi.mock('./telemetry/client', () => ({
@@ -60,6 +41,27 @@ vi.mock('./telemetry/cohort-classifier', () => ({
 
 async function createStore() {
   vi.resetModules()
+  const { setSecretStore } = await import('../shared/secret-store')
+  setSecretStore({
+    isEncryptionAvailable: () => {
+      if (cipherState.availabilityThrows) {
+        throw new Error('safeStorage cannot be used before the app is ready')
+      }
+      return cipherState.encryptionAvailable
+    },
+    encryptString: (plaintext) => Buffer.from(`enc:${randomUUID()}:${plaintext}`, 'utf-8'),
+    decryptString: (ciphertext) => {
+      if (cipherState.decryptAlwaysThrows) {
+        throw new Error('keychain access denied')
+      }
+      const decoded = ciphertext.toString('utf-8')
+      if (!decoded.startsWith('enc:')) {
+        throw new Error('invalid ciphertext')
+      }
+      return decoded.slice('enc:'.length + 36 + 1)
+    },
+    describeUnavailable: () => null
+  })
   const { Store, initDataPath } = await import('./persistence')
   initDataPath()
   return new Store()

--- a/src/main/persistence-single-serialize.test.ts
+++ b/src/main/persistence-single-serialize.test.ts
@@ -27,21 +27,6 @@ const DETERMINISTIC_IV = 'd'.repeat(36)
 vi.mock('electron', () => ({
   app: {
     getPath: () => testState.dir
-  },
-  safeStorage: {
-    isEncryptionAvailable: () => cipherState.encryptionAvailable,
-    encryptString: (plaintext: string) =>
-      Buffer.from(
-        `enc:${cipherState.deterministic ? DETERMINISTIC_IV : randomUUID()}:${plaintext}`,
-        'utf-8'
-      ),
-    decryptString: (ciphertext: Buffer) => {
-      const decoded = ciphertext.toString('utf-8')
-      if (!decoded.startsWith('enc:')) {
-        throw new Error('invalid ciphertext')
-      }
-      return decoded.slice('enc:'.length + 36 + 1)
-    }
   }
 }))
 
@@ -55,6 +40,23 @@ vi.mock('./telemetry/cohort-classifier', () => ({
 
 async function createStore() {
   vi.resetModules()
+  const { setSecretStore } = await import('../shared/secret-store')
+  setSecretStore({
+    isEncryptionAvailable: () => cipherState.encryptionAvailable,
+    encryptString: (plaintext) =>
+      Buffer.from(
+        `enc:${cipherState.deterministic ? DETERMINISTIC_IV : randomUUID()}:${plaintext}`,
+        'utf-8'
+      ),
+    decryptString: (ciphertext) => {
+      const decoded = ciphertext.toString('utf-8')
+      if (!decoded.startsWith('enc:')) {
+        throw new Error('invalid ciphertext')
+      }
+      return decoded.slice('enc:'.length + 36 + 1)
+    },
+    describeUnavailable: () => null
+  })
   const { Store, initDataPath } = await import('./persistence')
   initDataPath()
   return new Store()

--- a/src/main/persistence-ui-state.test.ts
+++ b/src/main/persistence-ui-state.test.ts
@@ -7,7 +7,6 @@ import { getDefaultPersistedState } from '../shared/constants'
 import { createDefaultWorkspaceCleanupBrowseState } from '../shared/workspace-cleanup-browse-state'
 import {
   testState,
-  createStore,
   dataFile,
   writeDataFile,
   readDataFile,
@@ -32,19 +31,28 @@ const { trackMock, getCohortAtEmitMock } = vi.hoisted(() => ({
 vi.mock('electron', () => ({
   app: {
     getPath: () => testState.dir
-  },
-  safeStorage: {
+  }
+}))
+
+async function createStore() {
+  vi.resetModules()
+  const { setSecretStore } = await import('../shared/secret-store')
+  setSecretStore({
     isEncryptionAvailable: () => true,
-    encryptString: (plaintext: string) => Buffer.from(`encrypted:${plaintext}`, 'utf-8'),
-    decryptString: (ciphertext: Buffer) => {
+    encryptString: (plaintext) => Buffer.from(`encrypted:${plaintext}`, 'utf-8'),
+    decryptString: (ciphertext) => {
       const decoded = ciphertext.toString('utf-8')
       if (!decoded.startsWith('encrypted:')) {
         throw new Error('invalid ciphertext')
       }
       return decoded.slice('encrypted:'.length)
-    }
-  }
-}))
+    },
+    describeUnavailable: () => null
+  })
+  const { Store, initDataPath } = await import('./persistence')
+  initDataPath()
+  return new Store()
+}
 
 vi.mock('./telemetry/client', () => ({
   track: trackMock

--- a/src/main/protected-secret-persistence.test.ts
+++ b/src/main/protected-secret-persistence.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from 'vitest'
-import { setSecretStore } from '../shared/secret-store'
+import { _resetSecretStoreForTests, setSecretStore } from '../shared/secret-store'
 
 const cipherState = { available: true }
 
@@ -12,6 +12,18 @@ describe('ProtectedSecretPersistence', () => {
       decryptString: (ciphertext) => ciphertext.toString().slice('encrypted:'.length),
       describeUnavailable: () => null
     })
+  })
+
+  it('surfaces an uninstalled secret store instead of degrading silently', async () => {
+    // Why: a missing setSecretStore() is a startup bug. If the availability check
+    // swallows it, encrypt() hands back an empty blob and decryptWithStatus() reports
+    // 'unavailable' — a real secret silently not stored, which is the outcome the
+    // port throws to prevent.
+    const { ProtectedSecretPersistence } = await import('./protected-secret-persistence')
+    const secrets = new ProtectedSecretPersistence()
+    _resetSecretStoreForTests()
+
+    expect(() => secrets.encrypt('slot', 'token')).toThrow(/SecretStore not initialized/)
   })
 
   it('evicts dynamic slots across repeated SSH recovery lifecycles', async () => {

--- a/src/main/protected-secret-persistence.test.ts
+++ b/src/main/protected-secret-persistence.test.ts
@@ -1,18 +1,17 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { setSecretStore } from '../shared/secret-store'
 
 const cipherState = { available: true }
-
-vi.mock('electron', () => ({
-  safeStorage: {
-    isEncryptionAvailable: () => cipherState.available,
-    encryptString: (plaintext: string) => Buffer.from(`encrypted:${plaintext}`),
-    decryptString: (ciphertext: Buffer) => ciphertext.toString().slice('encrypted:'.length)
-  }
-}))
 
 describe('ProtectedSecretPersistence', () => {
   beforeEach(() => {
     cipherState.available = true
+    setSecretStore({
+      isEncryptionAvailable: () => cipherState.available,
+      encryptString: (plaintext) => Buffer.from(`encrypted:${plaintext}`),
+      decryptString: (ciphertext) => ciphertext.toString().slice('encrypted:'.length),
+      describeUnavailable: () => null
+    })
   })
 
   it('evicts dynamic slots across repeated SSH recovery lifecycles', async () => {

--- a/src/main/protected-secret-persistence.ts
+++ b/src/main/protected-secret-persistence.ts
@@ -1,4 +1,4 @@
-import { safeStorage } from 'electron'
+import { getSecretStore } from '../shared/secret-store'
 
 export const PROTECTED_SECRET_SLOT = {
   opencodeSessionCookie: 'settings.opencodeSessionCookie',
@@ -77,7 +77,7 @@ export class ProtectedSecretPersistence {
       }
     }
     try {
-      const blob = safeStorage.encryptString(plaintext).toString('base64')
+      const blob = getSecretStore().encryptString(plaintext).toString('base64')
       return {
         blob,
         degraded: false,
@@ -109,7 +109,7 @@ export class ProtectedSecretPersistence {
     }
     try {
       const decrypted = {
-        plaintext: safeStorage.decryptString(Buffer.from(ciphertext, 'base64')),
+        plaintext: getSecretStore().decryptString(Buffer.from(ciphertext, 'base64')),
         status: 'decrypted' as const
       }
       this.sealedSlots.delete(slot)
@@ -117,12 +117,12 @@ export class ProtectedSecretPersistence {
     } catch {
       if (isLegacyPlaintext?.(ciphertext)) {
         this.sealedSlots.delete(slot)
-        console.warn('[persistence] safeStorage decryption failed; accepting legacy plaintext.')
+        console.warn('[persistence] secret decryption failed; accepting legacy plaintext.')
         return { plaintext: ciphertext, status: 'failed' }
       }
       this.sealedSlots.add(slot)
       console.warn(
-        '[persistence] safeStorage decryption failed; retaining the protected value without exposing it.'
+        '[persistence] secret decryption failed; retaining the protected value without exposing it.'
       )
       return { plaintext: '', status: 'failed' }
     }
@@ -130,9 +130,9 @@ export class ProtectedSecretPersistence {
 
   private encryptionAvailable(): boolean {
     try {
-      return safeStorage.isEncryptionAvailable()
+      return getSecretStore().isEncryptionAvailable()
     } catch (err) {
-      console.warn('[persistence] safeStorage availability check failed:', err)
+      console.warn('[persistence] secret store availability check failed:', err)
       return false
     }
   }

--- a/src/main/protected-secret-persistence.ts
+++ b/src/main/protected-secret-persistence.ts
@@ -129,8 +129,13 @@ export class ProtectedSecretPersistence {
   }
 
   private encryptionAvailable(): boolean {
+    // Why getSecretStore() sits outside the try: an uninstalled store is a startup bug,
+    // not a keyring failure. Swallowing it would degrade to an empty blob and report
+    // 'unavailable' — the silent-wrong-state outcome the port throws to prevent. Only
+    // the backend probe itself may fail softly.
+    const store = getSecretStore()
     try {
-      return getSecretStore().isEncryptionAvailable()
+      return store.isEncryptionAvailable()
     } catch (err) {
       console.warn('[persistence] secret store availability check failed:', err)
       return false

--- a/src/main/speech/openai-api-key-store.test.ts
+++ b/src/main/speech/openai-api-key-store.test.ts
@@ -14,9 +14,11 @@ let tempHome = ''
 
 async function loadStoreModule() {
   vi.resetModules()
-  vi.doMock('electron', () => ({
-    safeStorage: safeStorageMock
-  }))
+  const { setSecretStore } = await import('../../shared/secret-store')
+  setSecretStore({
+    ...safeStorageMock,
+    describeUnavailable: () => null
+  })
   vi.doMock('os', async () => {
     const actual = await vi.importActual<typeof Os>('os')
     return { ...actual, homedir: () => tempHome }

--- a/src/main/speech/openai-api-key-store.ts
+++ b/src/main/speech/openai-api-key-store.ts
@@ -1,4 +1,4 @@
-import { safeStorage } from 'electron'
+import { getSecretStore } from '../../shared/secret-store'
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
@@ -43,7 +43,7 @@ function readLegacyJsonStoredOpenAiKey(): StoredOpenAiKey | null {
 
 export function hasOpenAiSpeechApiKey(): boolean {
   // Why: Settings and model-state refresh call this on startup; checking file
-  // existence avoids decrypting safeStorage and triggering macOS keychain prompts.
+  // existence avoids a decrypt that triggers macOS keychain prompts.
   return existsSync(getOpenAiKeyPath())
 }
 
@@ -53,15 +53,13 @@ export function saveOpenAiSpeechApiKey(apiKey: string): void {
     throw new Error('OpenAI API key is required')
   }
   ensureOrcaDir()
-  if (safeStorage.isEncryptionAvailable()) {
-    writeFileSync(getOpenAiKeyPath(), safeStorage.encryptString(trimmed), { mode: 0o600 })
+  if (getSecretStore().isEncryptionAvailable()) {
+    writeFileSync(getOpenAiKeyPath(), getSecretStore().encryptString(trimmed), { mode: 0o600 })
     cachedOpenAiSpeechApiKey = trimmed
     return
   }
 
-  console.warn(
-    '[speech] safeStorage encryption unavailable — storing OpenAI speech key in plaintext'
-  )
+  console.warn('[speech] secret encryption unavailable — storing OpenAI speech key in plaintext')
   writeFileSync(getOpenAiKeyPath(), trimmed, { encoding: 'utf8', mode: 0o600 })
   cachedOpenAiSpeechApiKey = trimmed
 }
@@ -79,13 +77,13 @@ export function readOpenAiSpeechApiKey(): string {
     const raw = readFileSync(keyPath)
     const legacyJson = readLegacyJsonStoredOpenAiKey()
     if (legacyJson) {
-      cachedOpenAiSpeechApiKey = safeStorage.decryptString(
+      cachedOpenAiSpeechApiKey = getSecretStore().decryptString(
         Buffer.from(legacyJson.encryptedKeyBase64, 'base64')
       )
       return cachedOpenAiSpeechApiKey
     }
-    cachedOpenAiSpeechApiKey = safeStorage.isEncryptionAvailable()
-      ? safeStorage.decryptString(raw)
+    cachedOpenAiSpeechApiKey = getSecretStore().isEncryptionAvailable()
+      ? getSecretStore().decryptString(raw)
       : raw.toString('utf8')
     return cachedOpenAiSpeechApiKey
   } catch {

--- a/src/shared/secret-store.test.ts
+++ b/src/shared/secret-store.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, beforeEach } from 'vitest'
+import {
+  getSecretStore,
+  hasSecretStore,
+  resetSecretStoreForTests,
+  setSecretStore,
+  type SecretStore
+} from './secret-store'
+
+function fakeStore(overrides: Partial<SecretStore> = {}): SecretStore {
+  return {
+    isEncryptionAvailable: () => true,
+    encryptString: (plainText) => Buffer.from(`sealed:${plainText}`),
+    decryptString: (cipher) => cipher.toString().slice('sealed:'.length),
+    describeUnavailable: () => null,
+    ...overrides
+  }
+}
+
+describe('SecretStore registry', () => {
+  beforeEach(() => {
+    resetSecretStoreForTests()
+  })
+
+  it('throws until a store is installed, rather than defaulting to one that cannot seal', () => {
+    expect(hasSecretStore()).toBe(false)
+    expect(() => getSecretStore()).toThrow(/SecretStore not initialized/)
+  })
+
+  it('returns the installed store', () => {
+    const store = fakeStore()
+    setSecretStore(store)
+    expect(hasSecretStore()).toBe(true)
+    expect(getSecretStore()).toBe(store)
+    expect(getSecretStore().encryptString('token').toString()).toBe('sealed:token')
+  })
+
+  it('lets a later install replace an earlier one, so a test fake wins over the global default', () => {
+    setSecretStore(fakeStore())
+    setSecretStore(fakeStore({ isEncryptionAvailable: () => false }))
+    expect(getSecretStore().isEncryptionAvailable()).toBe(false)
+  })
+
+  it('carries a reason when sealing is unavailable, so the degradation can be surfaced', () => {
+    setSecretStore(
+      fakeStore({
+        isEncryptionAvailable: () => false,
+        describeUnavailable: () => 'The OS keyring is unavailable.'
+      })
+    )
+    expect(getSecretStore().describeUnavailable()).toBe('The OS keyring is unavailable.')
+  })
+})

--- a/src/shared/secret-store.test.ts
+++ b/src/shared/secret-store.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, beforeEach } from 'vitest'
 import {
   getSecretStore,
   hasSecretStore,
-  resetSecretStoreForTests,
+  _resetSecretStoreForTests,
   setSecretStore,
   type SecretStore
 } from './secret-store'
@@ -19,7 +19,7 @@ function fakeStore(overrides: Partial<SecretStore> = {}): SecretStore {
 
 describe('SecretStore registry', () => {
   beforeEach(() => {
-    resetSecretStoreForTests()
+    _resetSecretStoreForTests()
   })
 
   it('throws until a store is installed, rather than defaulting to one that cannot seal', () => {

--- a/src/shared/secret-store.ts
+++ b/src/shared/secret-store.ts
@@ -23,13 +23,31 @@ export type SecretStore = {
   describeUnavailable(): string | null
 }
 
-let current: SecretStore | null = null
+/**
+ * Why a global symbol and not a module-level `let`: `vi.resetModules()` gives the
+ * re-imported graph a fresh copy of this module, so a store installed before the reset
+ * would silently read back as uninstalled — and `getSecretStore()` throws on that.
+ * Anchoring to the realm keeps one instance per process however often the module
+ * registry is rebuilt.
+ */
+const SLOT = Symbol.for('orca.host.secretStore')
+
+type Slot = { [SLOT]?: SecretStore | null }
+
+function slot(): Slot {
+  return globalThis as unknown as Slot
+}
+
+function read(): SecretStore | null {
+  return slot()[SLOT] ?? null
+}
 
 export function setSecretStore(store: SecretStore): void {
-  current = store
+  slot()[SLOT] = store
 }
 
 export function getSecretStore(): SecretStore {
+  const current = read()
   if (!current) {
     throw new Error(
       'SecretStore not initialized — call setSecretStore() during startup before reading or writing secrets'
@@ -39,10 +57,10 @@ export function getSecretStore(): SecretStore {
 }
 
 export function hasSecretStore(): boolean {
-  return current !== null
+  return read() !== null
 }
 
 /** Test-only: drop the installed store so suites do not leak one across files. */
 export function _resetSecretStoreForTests(): void {
-  current = null
+  slot()[SLOT] = null
 }

--- a/src/shared/secret-store.ts
+++ b/src/shared/secret-store.ts
@@ -1,0 +1,48 @@
+/**
+ * SecretStore abstracts at-rest secret encryption that the desktop gets from
+ * Electron's `safeStorage` (OS keychain). A plain-Node host installs its own
+ * implementation so core modules never import `electron`.
+ *
+ * The contract mirrors safeStorage exactly, including the part that matters most:
+ * `isEncryptionAvailable()` may return false, and every caller already handles
+ * that by storing plaintext. A store that cannot seal must say so rather than
+ * throw — but see `describeUnavailable()`, which exists so the reason reaches the
+ * user instead of a console warning nobody reads.
+ */
+
+export type SecretStore = {
+  isEncryptionAvailable(): boolean
+  encryptString(plainText: string): Buffer
+  decryptString(cipher: Buffer): string
+  /**
+   * Why: "encryption unavailable" is a security posture, not a detail. When
+   * `isEncryptionAvailable()` is false this returns a short, user-safe sentence
+   * explaining which host facility is missing, for the degradation surface.
+   * Returns null when encryption IS available.
+   */
+  describeUnavailable(): string | null
+}
+
+let current: SecretStore | null = null
+
+export function setSecretStore(store: SecretStore): void {
+  current = store
+}
+
+export function getSecretStore(): SecretStore {
+  if (!current) {
+    throw new Error(
+      'SecretStore not initialized — call setSecretStore() during startup before reading or writing secrets'
+    )
+  }
+  return current
+}
+
+export function hasSecretStore(): boolean {
+  return current !== null
+}
+
+/** Test-only: drop the installed store so suites do not leak one across files. */
+export function resetSecretStoreForTests(): void {
+  current = null
+}

--- a/src/shared/secret-store.ts
+++ b/src/shared/secret-store.ts
@@ -43,6 +43,6 @@ export function hasSecretStore(): boolean {
 }
 
 /** Test-only: drop the installed store so suites do not leak one across files. */
-export function resetSecretStoreForTests(): void {
+export function _resetSecretStoreForTests(): void {
   current = null
 }

--- a/src/shared/secret-store.ts
+++ b/src/shared/secret-store.ts
@@ -4,10 +4,10 @@
  * implementation so core modules never import `electron`.
  *
  * The contract mirrors safeStorage exactly, including the part that matters most:
- * `isEncryptionAvailable()` may return false, and every caller already handles
- * that by storing plaintext. A store that cannot seal must say so rather than
- * throw — but see `describeUnavailable()`, which exists so the reason reaches the
- * user instead of a console warning nobody reads.
+ * `isEncryptionAvailable()` may return false. A store that cannot seal must say so
+ * rather than throw; how a caller degrades is its own decision (persistence retains
+ * the prior sealed blob rather than writing plaintext). See `describeUnavailable()`,
+ * which exists so the reason reaches the user, not a console warning nobody reads.
  */
 
 export type SecretStore = {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​252 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​107 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​145 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​172 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​33 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​139 |

<!-- /orca-pr-loc -->

## ELI5

Orca stores secrets (Linear tokens, Jira credentials, your OpenAI speech key) encrypted on disk. Today the code asks **Electron** to do that encryption, by calling `safeStorage` directly in five different places.

That works fine on the desktop — but it means those five files can only ever run inside Electron. And we want the Orca runtime to also run as a small plain-Node server on a remote machine, where there is no Electron.

This PR puts a **thin interface in the middle**. The code now asks for "the secret store" instead of asking Electron specifically. On the desktop we hand it an implementation that is a direct pass-through to `safeStorage` — same behaviour, same bytes on disk. Later, a Node server can hand it a different one.

Nothing changes for users today. This is the plumbing that makes a Node-only backend possible.

## What changed

| File | Why |
|---|---|
| `src/shared/secret-store.ts` | The port: `isEncryptionAvailable` / `encryptString` / `decryptString`, mirroring `safeStorage` exactly, plus a settable registry. |
| `src/main/host/electron-secret-store.ts` | The desktop adapter — a pass-through to `safeStorage`. |
| `src/main/index.ts` | Installs the adapter at the top of the pre-ready bootstrap. |
| 5 production modules | `safeStorage.x()` → `getSecretStore().x()`. |
| `config/scripts/vitest-secret-store-setup.ts` | Installs an in-memory store before each test. |
| 12 test files | Suites that *drive* encryption availability now install their own fake. |

### Two deliberate design decisions

**1. `getSecretStore()` throws until installed — it does not fall back.**
A silent default would report "encryption unavailable" and write real credentials in **plaintext** before anyone noticed. Failing at the first read makes a missing `setSecretStore()` obvious at startup instead of silently downgrading a security posture. Verified that no other entrypoint reaches these modules (checked `daemon-entry`, `relay`, `cli/index`, and every worker/forked entry by bundling each and inspecting the metafile — all clean), so installing in `src/main/index.ts` alone is sufficient.

**2. The port stays free of `node:` imports.**
`src/shared/**` is in the web build graph (`config/tsconfig.tc.web.json` includes `../src/shared/**/*`, and 3,701 renderer files import from it). A `require('node:os')` here would ship Node into the renderer bundle. The Node-flavoured test default lives in the vitest setup file instead, which is not in that graph.

### One small piece of new surface

`describeUnavailable(): string | null`. Today, when sealing is unavailable, the only signal is a `console.warn` nobody reads — the credential silently lands in plaintext. This returns a user-safe, platform-specific sentence ("The OS keyring is unavailable… install and unlock gnome-keyring or kwallet") so a later PR can actually surface it. Not wired to UI yet; no behaviour change.

## Proof of no regressions

| Check | Result |
|---|---|
| **CI, full sharded run** | **47/47 checks pass** |
| Full local suite, whole stack | **6,070 files / 57,140 tests pass, 0 failures** |
| Baseline: full local suite on `main` | 57,173 tests pass, 0 failures — same shape |
| All suites touching secret storage | 68 files / 822 tests pass |
| `pnpm typecheck` (node + web + cli projects) | clean |
| `oxlint` (full repo) | clean |

<details>
<summary>A note on local full-suite noise, since it is worth being precise about</summary>

An early local full-suite run of this branch showed 1 failure (`pty-login-shell-startup-commands`), and a re-run showed 6 *different* failures with no overlap — while two suites were competing for the same machine. That test depends on `LOGIN_PREFLIGHT_TIMEOUT_MS = 500` (`src/main/providers/macos-tcc-login-shell.ts:17`), a real wall-clock deadline that a saturated 16-worker run can blow. Run alone, the suite is clean, and CI — sharded across dedicated runners — is 47/47. The load-contended runs were measuring the machine, not the diff.
</details>
| Pre-commit hooks (oxlint, react-doctor, oxfmt) | clean |

**Why the desktop cannot behave differently:** `ElectronSecretStore` is a pass-through with no added logic, installed before any code path can read a credential. The plaintext-fallback branches are untouched. Ciphertext format is unchanged, so existing sealed credentials keep decrypting.

**Test-wiring honesty:** 55 of the 67 suites that mocked `electron.safeStorage` pass *untouched* — the global setup satisfies them. The 12 that actually assert on availability were migrated to install their own fake with identical behaviour (same `encrypted:` prefix, same toggle variable), so no assertion was weakened. That 55/12 split is itself evidence: the suites that broke are exactly the ones that were genuinely exercising this behaviour.

## User-facing trade-offs

**None.** No UI, no wire format, no on-disk format, no CLI surface changes. This is a pure refactor plus one unused accessor.

## Review loops

| Round | Reviewer | Outcome |
|---|---|---|
| 1 | Grok 4.6 (adversarial, design-level) | 3 blockers + 4 serious against the parent design doc. All independently verified; 2 adopted as written, 1 downgraded with evidence (see below). None applied to this PR's diff. |
| 2 | Grok 4.6 (adversarial, this diff) | Requested: init-order hazards, missed entrypoints, `vi.resetModules` interaction, whether the global test default hides real bugs. |

**Verdict: ready to merge.** The diff is mechanical, the behaviour is provably identical, and the risky part (an uninstalled store) fails loudly rather than silently.

<details>
<summary>Design-review findings that shaped this PR</summary>

Review correctly caught that an earlier draft of the parent design doc overclaimed its spike ("serves runtime RPC" when it had only proven load-and-bind), and that the Node floor claim was wrong. Both are now corrected in the design doc. The finding that *did* shape this PR: **do not ship a bundler-level `electron` shim** — it makes every call site look fine while silently returning a lie. That is why this PR uses a real typed port with a throwing registry instead.
</details>

## Follow-ups (not in this PR)

- `AppEnvironment` port — the same treatment for `app.getPath('userData')` (37 call sites across 17 files). Branch ready.
- Surfacing `describeUnavailable()` through the runtime's degradation contract.