### PR TITLE
UX: quieter, denser dialog chrome

### DIFF
--- a/src/renderer/src/components/ui/dialog.tsx
+++ b/src/renderer/src/components/ui/dialog.tsx
@@ -67,7 +67,7 @@ function DialogContent({
         // unbreakable token (long filename in the title) widens the column past the
         // panel and pushes justify-end footers outside the visible surface.
         className={cn(
-          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] grid-cols-[minmax(0,1fr)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border border-black/14 bg-background/96 p-6 text-foreground shadow-[0_20px_60px_rgba(0,0,0,0.28),inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur-2xl duration-200 outline-none dark:border-white/14 dark:bg-[rgba(23,23,23,0.96)] dark:shadow-[0_24px_72px_rgba(0,0,0,0.55),inset_0_1px_0_rgba(255,255,255,0.06)] data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
+          'fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] grid-cols-[minmax(0,1fr)] translate-x-[-50%] translate-y-[-50%] gap-3 rounded-lg border border-black/14 bg-background/96 p-5 text-foreground shadow-[0_16px_44px_rgba(0,0,0,0.26),inset_0_1px_0_rgba(255,255,255,0.08)] backdrop-blur-2xl duration-200 outline-none dark:border-white/14 dark:bg-[rgba(23,23,23,0.96)] dark:shadow-[0_18px_52px_rgba(0,0,0,0.5),inset_0_1px_0_rgba(255,255,255,0.06)] data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg',
           className
         )}
         {...props}
@@ -129,7 +129,7 @@ function DialogTitle({ className, ...props }: React.ComponentProps<typeof Dialog
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn('text-lg leading-snug font-semibold break-words', className)}
+      className={cn('text-base leading-snug font-semibold break-words', className)}
       {...props}
     />
   )
@@ -142,7 +142,7 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn('text-sm text-muted-foreground', className)}
+      className={cn('text-[13px] leading-[18px] text-muted-foreground', className)}
       {...props}
     />
   )


### PR DESCRIPTION
## Dialog chrome: quieter, denser

Second PR in the UX-density series. The Dialog primitive is the shell for every modal in Orca (creation flows, confirms, editors) — this single change tightens every modal at once.

### Changes (`ui/dialog.tsx`)
- Padding `p-6` → `p-5`; stack gap `gap-4` → `gap-3`
- Title `text-lg` → `text-base` (16px, matches the composer's existing title override)
- Description `text-sm` → `text-[13px]` with tighter line-height
- Shadow softened: `0_20px_60px/.28` → `0_16px_44px/.26` (dark: `0_24px_72px/.55` → `0_18px_52px/.50`) — less "floating billboard", more anchored surface
- Close button position unchanged; footer untouched

### Visual proof — Add-a-project dialog (512×355 → 512×340)
**Before:**
![before-addrepo.png](https://github.com/user-attachments/assets/04dfe08b-985d-4adf-aa08-da93daa145e1)

**After:**
![after-addrepo.png](https://github.com/user-attachments/assets/a170a82d-b136-42eb-bfaa-cc183ef4bdab)

### Visual proof — Create-workspace composer (512×521 → 512×509)
**Before:**
![before-composer.png](https://github.com/user-attachments/assets/03b9109a-df71-4bf1-9385-d325096e2af4)

**After:**
![after-composer.png](https://github.com/user-attachments/assets/b5745a77-1b69-4bc5-acfb-9ef83d91ee8c)

Affects all dialogs app-wide — confirm dialogs, task-page issue forms, and settings modals inherit the tighter chrome automatically.

Draft PR — part of a multi-direction density pass.
