### PR TITLE
fix(ssh): recover oversized workspace updates

### DIFF
--- a/src/main/ipc/remote-workspace-refresh-notification.test.ts
+++ b/src/main/ipc/remote-workspace-refresh-notification.test.ts
@@ -1,0 +1,276 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ipcMain } from 'electron'
+import type { Store } from '../persistence'
+import type {
+  RemoteWorkspaceSession,
+  RemoteWorkspaceSnapshot
+} from '../../shared/remote-workspace-types'
+import type { SshTarget } from '../../shared/ssh-types'
+
+const { getActiveMultiplexerMock, getSshConnectionStoreMock } = vi.hoisted(() => ({
+  getActiveMultiplexerMock: vi.fn(),
+  getSshConnectionStoreMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn(),
+    removeHandler: vi.fn()
+  }
+}))
+
+vi.mock('./ssh', () => ({
+  getActiveMultiplexer: getActiveMultiplexerMock,
+  getSshConnectionStore: getSshConnectionStoreMock
+}))
+
+vi.mock('./remote-workspace-events', () => ({
+  registerRemoteWorkspaceNotificationHandler: vi.fn(() => vi.fn())
+}))
+
+import {
+  _resetRemoteWorkspaceCachesForTests,
+  handleRemoteWorkspaceNotification,
+  registerRemoteWorkspaceHandlers
+} from './remote-workspace'
+import { CLIENT_ID } from './remote-workspace-client-identity'
+import { getCachedRemoteWorkspaceSnapshot } from './remote-workspace-snapshot-cache'
+
+const target: SshTarget = {
+  id: 'target-1',
+  label: 'Target 1',
+  host: 'one.example.com',
+  port: 22,
+  username: 'alice'
+}
+
+function snapshot(path: string, revision: number): RemoteWorkspaceSnapshot {
+  const session: RemoteWorkspaceSession = {
+    activeWorktreePath: path,
+    activeTabId: null,
+    tabsByWorktreePath: {},
+    terminalLayoutsByTabId: {}
+  }
+  return {
+    namespace: 'target',
+    revision,
+    updatedAt: 123,
+    schemaVersion: 1,
+    session
+  }
+}
+
+describe('workspace.refreshRequired notifications', () => {
+  const send = vi.fn()
+  const request = vi.fn()
+  const store = {} as Store
+
+  beforeEach(() => {
+    _resetRemoteWorkspaceCachesForTests()
+    send.mockReset()
+    request.mockReset()
+    request.mockResolvedValue(snapshot('/latest', 7))
+    getActiveMultiplexerMock.mockReset()
+    getActiveMultiplexerMock.mockReturnValue({ request })
+    getSshConnectionStoreMock.mockReset()
+    getSshConnectionStoreMock.mockReturnValue({
+      getTarget: (targetId: string) => (targetId === target.id ? target : undefined),
+      listTargets: () => [target]
+    })
+    vi.mocked(ipcMain.handle).mockReset()
+    vi.mocked(ipcMain.removeHandler).mockReset()
+    registerRemoteWorkspaceHandlers(
+      store,
+      () =>
+        ({
+          isDestroyed: () => false,
+          webContents: { send }
+        }) as never
+    )
+  })
+
+  it('pulls and publishes a snapshot after an oversized notification fallback', async () => {
+    handleRemoteWorkspaceNotification(target.id, 'workspace.refreshRequired', {
+      revision: 7,
+      sourceClientId: 'client-b'
+    })
+
+    await vi.waitFor(() => {
+      expect(request).toHaveBeenCalledWith('workspace.get', { namespace: expect.any(String) })
+      expect(send).toHaveBeenCalledWith(
+        'remoteWorkspace:changed',
+        expect.objectContaining({
+          targetId: target.id,
+          snapshot: expect.objectContaining({ revision: 7 })
+        })
+      )
+    })
+  })
+
+  it('does not pull a fallback produced by this client', async () => {
+    handleRemoteWorkspaceNotification(target.id, 'workspace.refreshRequired', {
+      revision: 7,
+      sourceClientId: CLIENT_ID
+    })
+    await Promise.resolve()
+
+    expect(getActiveMultiplexerMock).not.toHaveBeenCalled()
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('retries when the first snapshot is below the requested revision', async () => {
+    request
+      .mockResolvedValueOnce(snapshot('/stale', 6))
+      .mockResolvedValueOnce(snapshot('/latest', 7))
+
+    handleRemoteWorkspaceNotification(target.id, 'workspace.refreshRequired', {
+      revision: 7,
+      sourceClientId: 'client-b'
+    })
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(1))
+    expect(send).toHaveBeenCalledWith(
+      'remoteWorkspace:changed',
+      expect.objectContaining({ snapshot: expect.objectContaining({ revision: 7 }) })
+    )
+  })
+
+  it('stops retrying when snapshots remain below the requested revision', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    request.mockResolvedValue(snapshot('/stale', 6))
+
+    handleRemoteWorkspaceNotification(target.id, 'workspace.refreshRequired', {
+      revision: 7,
+      sourceClientId: 'client-b'
+    })
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(4))
+    await vi.waitFor(() =>
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Snapshot for target-1 remained at revision 6 below required revision 7 after 3 retries'
+        )
+      )
+    )
+    expect(send).not.toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it('resets the retry budget when a newer revision is requested', async () => {
+    request
+      .mockResolvedValueOnce(snapshot('/stale-1', 6))
+      .mockResolvedValueOnce(snapshot('/stale-2', 6))
+      .mockResolvedValueOnce(snapshot('/stale-3', 6))
+      .mockResolvedValueOnce(snapshot('/revision-7', 7))
+      .mockResolvedValueOnce(snapshot('/revision-8', 8))
+
+    handleRemoteWorkspaceNotification(target.id, 'workspace.refreshRequired', {
+      revision: 7,
+      sourceClientId: 'client-b'
+    })
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(3))
+
+    handleRemoteWorkspaceNotification(target.id, 'workspace.refreshRequired', {
+      revision: 8,
+      sourceClientId: 'client-b'
+    })
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(5))
+    await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(1))
+    expect(send).toHaveBeenCalledWith(
+      'remoteWorkspace:changed',
+      expect.objectContaining({ snapshot: expect.objectContaining({ revision: 8 }) })
+    )
+  })
+
+  it('does not let an in-flight refresh overwrite a newer direct snapshot', async () => {
+    let resolveRefresh: ((value: RemoteWorkspaceSnapshot) => void) | undefined
+    request.mockReturnValueOnce(
+      new Promise<RemoteWorkspaceSnapshot>((resolve) => {
+        resolveRefresh = resolve
+      })
+    )
+
+    handleRemoteWorkspaceNotification(target.id, 'workspace.refreshRequired', {
+      revision: 7,
+      sourceClientId: 'client-b'
+    })
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1))
+
+    handleRemoteWorkspaceNotification(target.id, 'workspace.changed', {
+      snapshot: snapshot('/direct', 8),
+      sourceClientId: 'client-c'
+    })
+    resolveRefresh?.(snapshot('/stale', 7))
+
+    await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(1))
+    expect(send).toHaveBeenCalledWith(
+      'remoteWorkspace:changed',
+      expect.objectContaining({ snapshot: expect.objectContaining({ revision: 8 }) })
+    )
+    await vi.waitFor(() => expect(getCachedRemoteWorkspaceSnapshot(target.id)?.revision).toBe(8))
+  })
+
+  it('coalesces a newer revision that arrives while a refresh is in flight', async () => {
+    let resolveFirst: ((value: RemoteWorkspaceSnapshot) => void) | undefined
+    request
+      .mockReturnValueOnce(
+        new Promise<RemoteWorkspaceSnapshot>((resolve) => {
+          resolveFirst = resolve
+        })
+      )
+      .mockResolvedValueOnce(snapshot('/latest', 9))
+
+    handleRemoteWorkspaceNotification(target.id, 'workspace.refreshRequired', {
+      revision: 8,
+      sourceClientId: 'client-b'
+    })
+    handleRemoteWorkspaceNotification(target.id, 'workspace.refreshRequired', {
+      revision: 9,
+      sourceClientId: 'client-b'
+    })
+    resolveFirst?.(snapshot('/stale', 8))
+
+    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2))
+    await vi.waitFor(() => expect(send).toHaveBeenCalledTimes(1))
+    expect(send).toHaveBeenCalledWith(
+      'remoteWorkspace:changed',
+      expect.objectContaining({ snapshot: expect.objectContaining({ revision: 9 }) })
+    )
+  })
+
+  it('stops a fallback refresh when the target is gone', async () => {
+    getSshConnectionStoreMock.mockReturnValue({
+      getTarget: () => undefined,
+      listTargets: () => [target]
+    })
+
+    handleRemoteWorkspaceNotification(target.id, 'workspace.refreshRequired', {
+      revision: 7,
+      sourceClientId: 'client-b'
+    })
+    await Promise.resolve()
+
+    expect(getActiveMultiplexerMock).not.toHaveBeenCalled()
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('logs a failed fallback refresh without publishing stale state', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    request.mockRejectedValue(new Error('connection lost'))
+
+    handleRemoteWorkspaceNotification(target.id, 'workspace.refreshRequired', {
+      revision: 7,
+      sourceClientId: 'client-b'
+    })
+
+    await vi.waitFor(() =>
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to refresh target-1 after revision 7: connection lost')
+      )
+    )
+    expect(send).not.toHaveBeenCalled()
+    warn.mockRestore()
+  })
+})

--- a/src/main/ipc/remote-workspace-relay-sync.ts
+++ b/src/main/ipc/remote-workspace-relay-sync.ts
@@ -17,7 +17,8 @@ import {
 } from './remote-workspace-snapshot-normalization'
 
 export async function getRemoteSnapshot(
-  target: SshTarget
+  target: SshTarget,
+  options: { remember?: boolean } = {}
 ): Promise<RemoteWorkspaceSnapshot | null> {
   const mux = getActiveMultiplexer(target.id)
   if (!mux) {
@@ -27,7 +28,9 @@ export async function getRemoteSnapshot(
   try {
     const raw = await mux.request('workspace.get', { namespace })
     const snapshot = normalizeSnapshot(raw, namespace)
-    rememberRemoteWorkspaceSnapshot(target.id, snapshot)
+    if (options.remember !== false) {
+      rememberRemoteWorkspaceSnapshot(target.id, snapshot)
+    }
     return snapshot
   } catch (err) {
     if ((err as { code?: unknown })?.code === -32601) {

--- a/src/main/ipc/remote-workspace.ts
+++ b/src/main/ipc/remote-workspace.ts
@@ -1,3 +1,4 @@
+import { setTimeout as delay } from 'node:timers/promises'
 import { ipcMain, type BrowserWindow } from 'electron'
 import type { Store } from '../persistence'
 import { getActiveMultiplexer, getSshConnectionStore } from './ssh'
@@ -28,10 +29,17 @@ import { normalizeSnapshot } from './remote-workspace-snapshot-normalization'
 
 let mainWindowGetter: (() => BrowserWindow | null) | null = null
 let unregisterRemoteWorkspaceNotifications: (() => void) | null = null
+type RemoteWorkspaceRefresh = {
+  requestedRevision: number
+  staleRetryCount: number
+}
+const remoteWorkspaceRefreshes = new Map<string, RemoteWorkspaceRefresh>()
+const REMOTE_WORKSPACE_STALE_RETRY_DELAYS_MS = [25, 100, 250] as const
 
 export function _resetRemoteWorkspaceCachesForTests(): void {
   clearRemoteWorkspaceSnapshotCache()
   clearRemoteWorkspacePatchTails()
+  remoteWorkspaceRefreshes.clear()
 }
 
 export function _getRemoteWorkspaceCacheSizesForTests(): {
@@ -70,11 +78,111 @@ function exportSessionForTarget(
   })
 }
 
+function publishRemoteWorkspaceSnapshot(
+  targetId: string,
+  snapshot: ReturnType<typeof normalizeSnapshot>,
+  sourceClientId?: string
+): void {
+  rememberRemoteWorkspaceSnapshot(targetId, snapshot)
+  const event: RemoteWorkspaceChangedEvent = {
+    targetId,
+    snapshot,
+    ...(sourceClientId ? { sourceClientId } : {})
+  }
+  const win = mainWindowGetter?.()
+  if (win && !win.isDestroyed()) {
+    win.webContents.send('remoteWorkspace:changed', event)
+  }
+}
+
+async function refreshRemoteWorkspaceSnapshot(
+  targetId: string,
+  refresh: RemoteWorkspaceRefresh
+): Promise<void> {
+  try {
+    while (remoteWorkspaceRefreshes.get(targetId) === refresh) {
+      const target = getSshConnectionStore()?.getTarget(targetId)
+      if (!target) {
+        return
+      }
+      const snapshot = await getRemoteSnapshot(target, { remember: false })
+      if (!snapshot || remoteWorkspaceRefreshes.get(targetId) !== refresh) {
+        return
+      }
+      if (snapshot.revision < refresh.requestedRevision) {
+        const retryDelay = REMOTE_WORKSPACE_STALE_RETRY_DELAYS_MS[refresh.staleRetryCount]
+        if (retryDelay === undefined) {
+          console.warn(
+            `[remote-workspace] Snapshot for ${targetId} remained at revision ${snapshot.revision} below required revision ${refresh.requestedRevision} after ${refresh.staleRetryCount} retries`
+          )
+          return
+        }
+        refresh.staleRetryCount++
+        await delay(retryDelay)
+        continue
+      }
+      publishRemoteWorkspaceSnapshot(targetId, snapshot)
+      return
+    }
+  } catch (err) {
+    console.warn(
+      `[remote-workspace] Failed to refresh ${targetId} after revision ${refresh.requestedRevision}: ${
+        err instanceof Error ? err.message : String(err)
+      }`
+    )
+  }
+}
+
+function reconcileRemoteWorkspaceRefreshWithSnapshot(targetId: string, revision: number): void {
+  const refresh = remoteWorkspaceRefreshes.get(targetId)
+  if (!refresh) {
+    return
+  }
+  refresh.requestedRevision = Math.max(refresh.requestedRevision, revision)
+  if (revision === refresh.requestedRevision) {
+    remoteWorkspaceRefreshes.delete(targetId)
+  }
+}
+
+function queueRemoteWorkspaceRefresh(targetId: string, revision: number): void {
+  const existing = remoteWorkspaceRefreshes.get(targetId)
+  if (existing) {
+    if (revision > existing.requestedRevision) {
+      existing.requestedRevision = revision
+      existing.staleRetryCount = 0
+    }
+    return
+  }
+  const refresh: RemoteWorkspaceRefresh = {
+    requestedRevision: revision,
+    staleRetryCount: 0
+  }
+  remoteWorkspaceRefreshes.set(targetId, refresh)
+  void refreshRemoteWorkspaceSnapshot(targetId, refresh).finally(() => {
+    if (remoteWorkspaceRefreshes.get(targetId) === refresh) {
+      remoteWorkspaceRefreshes.delete(targetId)
+    }
+  })
+}
+
 export function handleRemoteWorkspaceNotification(
   targetId: string,
   method: string,
   params: Record<string, unknown>
 ): void {
+  if (method === 'workspace.refreshRequired') {
+    const revision = params.revision
+    const sourceClientId = params.sourceClientId
+    if (
+      typeof revision === 'number' &&
+      Number.isSafeInteger(revision) &&
+      revision >= 0 &&
+      sourceClientId !== CLIENT_ID
+    ) {
+      queueRemoteWorkspaceRefresh(targetId, revision)
+    }
+    return
+  }
   if (method !== 'workspace.changed') {
     return
   }
@@ -84,16 +192,12 @@ export function handleRemoteWorkspaceNotification(
   }
   const namespace = getRemoteWorkspaceNamespace(target)
   const snapshot = normalizeSnapshot(params.snapshot, namespace)
-  rememberRemoteWorkspaceSnapshot(targetId, snapshot)
-  const event: RemoteWorkspaceChangedEvent = {
+  reconcileRemoteWorkspaceRefreshWithSnapshot(targetId, snapshot.revision)
+  publishRemoteWorkspaceSnapshot(
     targetId,
     snapshot,
-    sourceClientId: typeof params.sourceClientId === 'string' ? params.sourceClientId : undefined
-  }
-  const win = mainWindowGetter?.()
-  if (win && !win.isDestroyed()) {
-    win.webContents.send('remoteWorkspace:changed', event)
-  }
+    typeof params.sourceClientId === 'string' ? params.sourceClientId : undefined
+  )
 }
 
 export function registerRemoteWorkspaceHandlers(

--- a/src/relay/workspace-session-handler.test.ts
+++ b/src/relay/workspace-session-handler.test.ts
@@ -1,10 +1,13 @@
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { RelayDispatcher } from './dispatcher'
+import { DISPATCHER_CONTROL_QUEUE_MAX_FRAMES } from './dispatcher-writer-admission'
 import { WorkspaceSessionHandler } from './workspace-session-handler'
 import { encodeJsonRpcFrame, MessageType, type JsonRpcRequest } from './protocol'
+
+const NODE_21_HIGH_WATER_MARK = 16 * 1024
 
 function decodeJsonFrames(written: Buffer[]): unknown[] {
   return written
@@ -36,13 +39,39 @@ describe('WorkspaceSessionHandler', () => {
   let dispatcher: RelayDispatcher
   let written: Buffer[]
 
+  function installDispatcher(
+    write: ConstructorParameters<typeof RelayDispatcher>[0] = (data) => {
+      written.push(Buffer.from(data))
+    },
+    sinkOptions?: ConstructorParameters<typeof RelayDispatcher>[1]
+  ): void {
+    dispatcher?.dispose()
+    written = []
+    dispatcher = new RelayDispatcher(write, sinkOptions)
+    new WorkspaceSessionHandler(dispatcher, baseDir)
+  }
+
+  async function patchSession(
+    session: Record<string, unknown>,
+    id = 1,
+    baseRevision = 0
+  ): Promise<void> {
+    await sendRequest(
+      dispatcher,
+      'workspace.patch',
+      {
+        namespace: 'ssh target/path',
+        baseRevision,
+        clientId: 'client-a',
+        patch: { kind: 'replace-session', session }
+      },
+      id
+    )
+  }
+
   beforeEach(() => {
     baseDir = mkdtempSync(join(tmpdir(), 'orca-workspace-session-'))
-    written = []
-    dispatcher = new RelayDispatcher((data) => {
-      written.push(Buffer.from(data))
-    })
-    new WorkspaceSessionHandler(dispatcher, baseDir)
+    installDispatcher()
   })
 
   afterEach(() => {
@@ -82,6 +111,9 @@ describe('WorkspaceSessionHandler', () => {
     expect(
       frames.some((frame) => (frame as { method?: string }).method === 'workspace.changed')
     ).toBe(true)
+    expect(
+      frames.some((frame) => (frame as { method?: string }).method === 'workspace.refreshRequired')
+    ).toBe(false)
 
     written = []
     await sendRequest(
@@ -102,6 +134,139 @@ describe('WorkspaceSessionHandler', () => {
     expect(staleResponse.result.ok).toBe(false)
     expect(staleResponse.result.reason).toBe('stale-revision')
     expect(staleResponse.result.snapshot.revision).toBe(1)
+  })
+
+  it('falls back to a refresh notification when the snapshot exceeds producer capacity', async () => {
+    installDispatcher(
+      (data) => {
+        written.push(Buffer.from(data))
+      },
+      {
+        writableLength: () => 0,
+        writableHighWaterMark: () => NODE_21_HIGH_WATER_MARK
+      }
+    )
+    const session = {
+      activeWorktreePath: '/repo/worktree',
+      activeTabId: 'tab-1',
+      tabsByWorktreePath: {
+        '/repo/worktree': [{ id: 'tab-1', title: 'x'.repeat(20_000) }]
+      },
+      terminalLayoutsByTabId: {}
+    }
+
+    await patchSession(session)
+
+    const frames = decodeJsonFrames(written) as {
+      id?: number
+      method?: string
+      params?: Record<string, unknown>
+      result?: { ok?: boolean; snapshot?: { revision?: number } }
+    }[]
+    expect(frames.some((frame) => frame.method === 'workspace.changed')).toBe(false)
+    expect(frames.find((frame) => frame.method === 'workspace.refreshRequired')?.params).toEqual({
+      namespace: 'ssh_target_path',
+      revision: 1,
+      sourceClientId: 'client-a'
+    })
+    expect(frames.find((frame) => frame.id === 1)?.result).toMatchObject({
+      ok: true,
+      snapshot: { revision: 1 }
+    })
+
+    await sendRequest(dispatcher, 'workspace.get', { namespace: 'ssh target/path' }, 2)
+    expect(
+      (decodeJsonFrames(written) as { id?: number; result?: { revision?: number } }[]).find(
+        (frame) => frame.id === 2
+      )?.result?.revision
+    ).toBe(1)
+  })
+
+  it('uses the control fallback when the producer queue is full', async () => {
+    const secondaryWritten: Buffer[] = []
+    const drainListeners = new Set<() => void>()
+    let blocked = true
+    const secondaryId = dispatcher.attachClient(
+      (data) => {
+        secondaryWritten.push(Buffer.from(data))
+        return !blocked
+      },
+      {
+        writableLength: () => 0,
+        writableHighWaterMark: () => 4 * 1024 * 1024,
+        waitWriteDrain: (callback) => {
+          drainListeners.add(callback)
+          return () => drainListeners.delete(callback)
+        }
+      }
+    )
+    for (const size of [40_000, 1_000, 1]) {
+      while (
+        dispatcher.publishProducerNotification(
+          secondaryId,
+          'test.blocker',
+          { data: 'x'.repeat(size) },
+          { logDrop: false }
+        )
+      ) {
+        // Shrinking frames leave less headroom than workspace.changed needs.
+      }
+    }
+
+    const publish = vi.spyOn(dispatcher, 'publishProducerNotification')
+    await patchSession({ activeTabId: null, tabsByWorktreePath: {}, terminalLayoutsByTabId: {} })
+    await vi.waitFor(() =>
+      expect(
+        publish.mock.calls.some(
+          ([clientId, method]) => clientId === secondaryId && method === 'workspace.changed'
+        )
+      ).toBe(true)
+    )
+    blocked = false
+    for (const listener of Array.from(drainListeners)) {
+      drainListeners.delete(listener)
+      listener()
+    }
+
+    await vi.waitFor(() =>
+      expect(
+        (decodeJsonFrames(secondaryWritten) as { method?: string }[]).some(
+          (frame) => frame.method === 'workspace.refreshRequired'
+        )
+      ).toBe(true)
+    )
+    expect(
+      (decodeJsonFrames(secondaryWritten) as { method?: string }[]).some(
+        (frame) => frame.method === 'workspace.changed'
+      )
+    ).toBe(false)
+  })
+
+  it('closes the client when even the control fallback cannot be admitted', async () => {
+    let secondaryCloses = 0
+    const secondaryId = dispatcher.attachClient(
+      (data) => {
+        void data
+        return false
+      },
+      {
+        writableLength: () => NODE_21_HIGH_WATER_MARK,
+        writableHighWaterMark: () => NODE_21_HIGH_WATER_MARK,
+        waitWriteDrain: () => {},
+        close: () => {
+          secondaryCloses++
+        }
+      }
+    )
+    for (let index = 0; index < DISPATCHER_CONTROL_QUEUE_MAX_FRAMES; index++) {
+      dispatcher.notifyClient(secondaryId, 'test.control', { index })
+    }
+    expect(secondaryCloses).toBe(0)
+
+    await patchSession({ title: 'x'.repeat(20_000) })
+
+    await vi.waitFor(() => expect(secondaryCloses).toBe(1))
+    expect(dispatcher.activeClientIds()).not.toContain(secondaryId)
   })
 
   it('tracks presence per namespace', async () => {

--- a/src/relay/workspace-session-handler.ts
+++ b/src/relay/workspace-session-handler.ts
@@ -151,11 +151,26 @@ export class WorkspaceSessionHandler {
       session: patch.session as Record<string, unknown>
     }
     this.write(snapshot)
-    this.dispatcher.notify('workspace.changed', {
+    const sourceClientId = typeof params.clientId === 'string' ? params.clientId : undefined
+    const changedParams = {
       namespace,
       snapshot,
-      sourceClientId: typeof params.clientId === 'string' ? params.clientId : undefined
-    })
+      sourceClientId
+    }
+    const refreshParams = {
+      namespace,
+      revision: snapshot.revision,
+      sourceClientId
+    }
+    for (const clientId of this.dispatcher.activeClientIds()) {
+      if (
+        !this.dispatcher.publishProducerNotification(clientId, 'workspace.changed', changedParams)
+      ) {
+        // Why: the full snapshot can exceed the producer frame capacity; a control-lane
+        // invalidation lets the client pull it through the larger response lane instead.
+        this.dispatcher.notifyClient(clientId, 'workspace.refreshRequired', refreshParams)
+      }
+    }
     return { ok: true, snapshot }
   }
 


### PR DESCRIPTION
## ELI5

Large SSH workspace updates could be too big for the relay's notification lane. The relay persisted the update but silently dropped the notification, so the desktop kept showing stale tabs. This change sends a small "refresh required" signal instead, and the desktop pulls the current snapshot through the request/response path.

## What Changed

- Keep the existing `workspace.changed` fast path for notifications that fit the producer lane.
- Fall back per client to a control-lane `workspace.refreshRequired` notification when the full snapshot exceeds frame capacity or producer backpressure rejects it.
- Fail closed through the dispatcher's existing control-overflow behavior if even the small fallback cannot be queued.
- Coalesce refreshes per SSH target in the main process, fetch the latest snapshot with `workspace.get`, and publish it through the existing cache and renderer IPC path.
- Ignore a fallback sourced by this client because the successful patch response already contains the latest snapshot.
- Add relay backpressure and main-process refresh convergence coverage.

## Why

`workspace.patch` persisted the new revision before broadcasting `workspace.changed`. When that full notification exceeded the 12,288-byte producer-frame budget or hit a full producer queue, the relay rejected it while leaving the connection alive. The client then had no signal that its cached session list was stale. A bounded control-lane invalidation keeps normal updates unchanged while letting oversized updates converge through the existing larger response lane.

## Linked Issue

Fixes #15238

## Visual Proof

N/A - there is no UI change; this restores the existing workspace snapshot flow after an oversized SSH notification.

## Testing

Validated on smallbox Linux x86_64 in a disposable Debian 12 Docker container limited to 16 CPUs, 32 GiB RAM, and 4096 PIDs, with no ports, Docker socket, credentials, home directory, or Orca data mounted. Docker Hub timed out while pulling `node:24-bookworm`, so the container used a locally cached Debian 12 base with a read-only Node.js 24.19.0 toolchain mount and project-pinned pnpm 10.24.0.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below
- Targeted Vitest: 5 files, 26 tests passed.
- `pnpm lint`: passed.
- `pnpm typecheck`: passed.
- `pnpm build`: passed, including relay bundles for Linux/macOS/Windows x64/arm64, Electron/Vite, CLI, web projection, and the Linux native build gate.
- Full `pnpm test`: 6,055 files / 56,934 tests passed; 14 files / 20 tests failed; 44 files / 358 tests skipped. The failures were outside the changed paths and came from the container baseline: GitHub release-asset timeouts in cold 7za tests, a shallow clone with no release tags, missing `xauth` for Electron fixtures, and root-only permission semantics. The five less-obvious failing files were rerun at both this commit and unmodified base `6b51ef4e2` in the same container and reproduced the identical 7 failures (104 passed, 1 skipped), confirming they are not introduced by this change.

Local Electron, Playwright, live relay installation, and live SSH E2E were intentionally not run to avoid restarting or replacing the active Orca client.

## AI Disclosure

OpenAI Codex (GPT-5) was used to investigate, implement, test, and self-review this change. The existing repository Git identity remains the sole commit author; no AI co-author was added.

## Review

Author: @GhostFlying

The change was self-reviewed for producer/control backpressure, revision convergence, bounded state, disconnect behavior, SSH isolation, and security. The refresh map is bounded to one entry per configured target and stores only the highest pending revision; no workspace contents are copied into the control fallback.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Wire scope is intentionally new client + new relay only. There is no protocol-version or capability-negotiation change.
- Existing `workspace.changed` payloads and renderer snapshot arbitration are unchanged.
- No changes to #12339, historical tab cleanup, multi-client retirement, mobile behavior, paths, shortcuts, or Git-provider behavior.
- Cross-platform relay bundles were built for Linux, macOS, and Windows; runtime validation was Linux x86_64 only.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)