### PR TITLE
UX: denser workspace/task composer

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -659,7 +659,7 @@ export default function NewWorkspaceComposerCard({
         containerClassName
       )}
     >
-      <div className="min-w-0 space-y-4 pt-3">
+      <div className="min-w-0 space-y-3 pt-2">
         <div className="space-y-1" data-contextual-tour-target="workspace-creation-project">
           <div className="flex items-center justify-between gap-2">
             <label className="text-xs font-medium text-muted-foreground">
@@ -700,7 +700,7 @@ export default function NewWorkspaceComposerCard({
               translate('auto.components.NewWorkspaceComposerCard.dccd26d4e4', 'Choose project')
             }
             // Why: programmatic .focus() doesn't reliably trigger :focus-visible in Chromium, so mirror the Input ring onto :focus.
-            triggerClassName="h-9 w-full border-input text-sm focus:border-ring focus:ring-[3px] focus:ring-ring/50"
+            triggerClassName="h-8 w-full border-input text-sm focus:border-ring focus:ring-[3px] focus:ring-ring/50"
             invalid={Boolean(projectError)}
             describedBy={projectDescriptionId}
           />
@@ -721,7 +721,7 @@ export default function NewWorkspaceComposerCard({
             // Why: Run on is nested in the Project block (so they share the
             // error/empty states), which put it on the block's 4px rhythm. It's
             // its own field, so give it the 16px other fields get.
-            <div className="space-y-1 pt-3">
+            <div className="space-y-1 pt-1">
               <label className="block min-w-0 truncate text-xs font-medium text-muted-foreground">
                 {translate('auto.components.NewWorkspaceComposerCard.runOn', 'Run on')}
               </label>
@@ -933,7 +933,7 @@ export default function NewWorkspaceComposerCard({
             onSetDefault={handleSetDefaultAgent}
             // Why: match Project/Run-on — full-width form row, no 260px min that can overflow the dialog column.
             allowNarrowTrigger
-            triggerClassName="h-9 w-full min-w-0 border-input text-sm focus:border-ring focus:ring-[3px] focus:ring-ring/50"
+            triggerClassName="h-8 w-full min-w-0 border-input text-sm focus:border-ring focus:ring-[3px] focus:ring-ring/50"
             onTriggerEnter={createDisabled ? undefined : onCreate}
           />
         </div>


### PR DESCRIPTION
## Workspace composer: tighter field rhythm

Fourth PR in the UX-density series — the create-workspace/task composer internals.

### Changes (`NewWorkspaceComposerCard.tsx`)
- Field-group rhythm `space-y-4` → **`space-y-3`** (16px → 12px); header offset `pt-3`→`pt-2`
- Combobox triggers `h-9` → **`h-8`** (36px → 32px controls, matches `Button sm`)
- Nested "Run on" block divider aligned to the new rhythm (`pt-3`→`pt-1` inside the Project group)
- Submit row untouched (already compact)

### Visual proof (521px → 489px total; −32px vs original)
**Before:**
![before-composer.png](https://github.com/user-attachments/assets/5e199dad-bcfa-44c4-b1a8-d75ec0d3d69a)

**After:**
![after-d-composer.png](https://github.com/user-attachments/assets/5f90d937-5f9e-4bed-92ee-237ddbf899cd)

Advanced disclosure fields keep their existing compact spacing; all creation entry points (sidebar +, kanban card add, ⌘J palette, task-page handoffs) inherit this.

Draft PR — part of a multi-direction density pass.
