### PR TITLE
UX: unified filter-menu density

### DIFF
--- a/src/renderer/src/components/github/PRFilterSections.tsx
+++ b/src/renderer/src/components/github/PRFilterSections.tsx
@@ -90,7 +90,7 @@ function StatusSection({
             type="button"
             onClick={() => onSelect({ state: s.key })}
             className={cn(
-              'flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left transition hover:bg-muted/50',
+              'flex w-full items-center justify-between gap-2 px-3 py-1 text-left transition hover:bg-muted/50',
               active && 'bg-muted/40 font-medium'
             )}
           >
@@ -122,7 +122,7 @@ function DraftToggle({
         type="button"
         onClick={() => onSelect({ draft: !parsed.draft })}
         className={cn(
-          'flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left transition hover:bg-muted/50',
+          'flex w-full items-center justify-between gap-2 px-3 py-1 text-left transition hover:bg-muted/50',
           parsed.draft && 'bg-muted/40 font-medium'
         )}
       >
@@ -207,7 +207,7 @@ export function SectionMenu({
   const subject = kind === 'prs' ? 'pull requests' : 'issues'
   return (
     <div className="py-1 text-xs">
-      <div className="px-3 py-1.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+      <div className="px-3 py-1 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
         {translate('auto.components.github.PRFilterSections.8177eda37e', 'Filter')}{' '}
         <span>{subject}</span>
       </div>
@@ -216,7 +216,7 @@ export function SectionMenu({
           key={row.key}
           type="button"
           onClick={() => onPick(row.key)}
-          className="flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left transition hover:bg-muted/50"
+          className="flex w-full items-center justify-between gap-2 px-3 py-1 text-left transition hover:bg-muted/50"
         >
           <span>{row.label}</span>
           <span className="flex items-center gap-1 text-muted-foreground">
@@ -231,7 +231,7 @@ export function SectionMenu({
           <button
             type="button"
             onClick={onClearAll}
-            className="w-full px-3 py-1.5 text-left text-muted-foreground transition hover:bg-muted/50 hover:text-foreground"
+            className="w-full px-3 py-1 text-left text-muted-foreground transition hover:bg-muted/50 hover:text-foreground"
           >
             {translate('auto.components.github.PRFilterSections.30ebb6ca44', 'Clear all filters')}
           </button>
@@ -277,7 +277,7 @@ export function SectionDetail({
       <button
         type="button"
         onClick={onBack}
-        className="flex w-full items-center gap-1 border-b border-border px-3 py-1.5 text-[11px] text-muted-foreground transition hover:bg-muted/50 hover:text-foreground"
+        className="flex w-full items-center gap-1 border-b border-border px-3 py-1 text-[11px] text-muted-foreground transition hover:bg-muted/50 hover:text-foreground"
       >
         <ChevronRight className="size-3 rotate-180" />
         {translate('auto.components.github.PRFilterSections.b69fa4fa20', 'Back')}

--- a/src/renderer/src/components/linear-issue-attribute-filter-sections.tsx
+++ b/src/renderer/src/components/linear-issue-attribute-filter-sections.tsx
@@ -176,7 +176,7 @@ export function LinearIssueFilterSectionMenu({
           key={section.key}
           type="button"
           onClick={() => onOpenSection(section.key)}
-          className="flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left transition hover:bg-muted/50"
+          className="flex w-full items-center justify-between gap-2 px-3 py-1 text-left transition hover:bg-muted/50"
         >
           <span className="font-medium">{section.label}</span>
           <span className="inline-flex items-center gap-1 text-muted-foreground">
@@ -369,7 +369,7 @@ function SectionBack({ onBack }: { onBack: () => void }): React.JSX.Element {
     <button
       type="button"
       onClick={onBack}
-      className="flex w-full items-center gap-1 border-b border-border/50 px-3 py-1.5 text-left text-xs text-muted-foreground transition hover:bg-muted/40 hover:text-foreground"
+      className="flex w-full items-center gap-1 border-b border-border/50 px-3 py-1 text-left text-xs text-muted-foreground transition hover:bg-muted/40 hover:text-foreground"
     >
       {translate('auto.components.linear-issue-attribute-filter-sections.back', 'Back')}
     </button>

--- a/src/renderer/src/components/sidebar/FilterToggleRow.tsx
+++ b/src/renderer/src/components/sidebar/FilterToggleRow.tsx
@@ -37,7 +37,7 @@ export function FilterToggleRow({
       className={cn(
         // Why pl-* and not px-2 + pl-6: Tailwind v4 emits px as padding-inline,
         // which outranks a physical pl-6 override and flattens the indent.
-        'flex w-full items-center justify-between gap-2 rounded-[5px] py-1.5 pr-2 text-[12px] font-medium hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+        'flex w-full items-center justify-between gap-2 rounded-[5px] py-1 pr-2 text-[12px] font-medium hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
         indented ? 'pl-7' : 'pl-2'
       )}
     >

--- a/src/renderer/src/components/sidebar/SidebarFilter.tsx
+++ b/src/renderer/src/components/sidebar/SidebarFilter.tsx
@@ -216,7 +216,7 @@ const SidebarFilter = React.memo(function SidebarFilter({
         side={contentSide}
         align="start"
         sideOffset={8}
-        className="w-72"
+        className="w-64"
         data-workspace-board-preserve-open={preserveWorkspaceBoardOpen ? '' : undefined}
       >
         <FilterToggleRow

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
@@ -168,7 +168,7 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
         side="right"
         align="start"
         sideOffset={8}
-        className="w-72 pb-2"
+        className="w-64 pb-2"
         data-workspace-board-preserve-open={preserveWorkspaceBoardOpen ? '' : undefined}
       >
         {/* Why: host + project filters share one section and the same single-row


### PR DESCRIPTION
## Filter menus: unified density

Fifth PR in the UX-density series — every filter surface shares one row recipe; this tightens them together.

### Changes
- `sidebar/FilterToggleRow.tsx` (shared by sidebar filter + workspace options): `py-1.5` → `py-1` → **26px rows** (was 30px)
- `sidebar/SidebarFilter.tsx`: surface `w-72` → `w-64`
- `sidebar/SidebarWorkspaceOptionsMenu.tsx`: surface `w-72` → `w-64`
- `github/PRFilterSections.tsx` + `linear-issue-attribute-filter-sections.tsx`: menu/back/label rows `px-3 py-1.5` → `px-3 py-1`; search inputs inside pickers untouched (form controls)

### Visual proof — workspace options / filter menu (288×435 → 256×415)
**Before:**
![before-filter.png](https://github.com/user-attachments/assets/7137bf3b-fa41-4f15-86b1-153f20ac7e5f)

**After:**
![after-e-filter.png](https://github.com/user-attachments/assets/8780dcbb-458a-408c-b160-f0a7aeed49d2)

Same recipe now holds across: sidebar workspace options, sidebar filter, GitHub PR status/author filters, Linear issue attribute filters.

Draft PR — part of a multi-direction density pass.
