### PR TITLE
fix(notifications): bound the custom sound's dedupe window so a stalled element cannot silence every later notification

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -332,6 +332,7 @@ import type {
 } from '../shared/crash-reporting'
 import type { RendererHeapStatistics } from '../shared/renderer-heap-statistics'
 import { readRendererHeapStatistics } from './renderer-heap-statistics-reader'
+import { createNotificationSoundPlayback } from './notification-sound-playback'
 import { createUpdaterQuitAbortRelay } from '../shared/renderer-restart-preparation'
 import {
   prepareAndInvokeAppRestart,
@@ -406,14 +407,10 @@ let cachedNotificationSound: {
   blobUrl: string
   audio: HTMLAudioElement
 } | null = null
-let isNotificationSoundPlaying = false
-// Why: audio.play() can reject before ended/error fires — cleanup hook prevents leaked listeners on the cached Audio.
-let cleanupNotificationSoundPlayback: (() => void) | null = null
+const notificationSoundPlayback = createNotificationSoundPlayback()
 
 function clearNotificationSoundPlaybackState(): void {
-  cleanupNotificationSoundPlayback?.()
-  cleanupNotificationSoundPlayback = null
-  isNotificationSoundPlaying = false
+  notificationSoundPlayback.forceRelease()
 }
 
 function disposeCachedNotificationSound(): void {
@@ -2336,7 +2333,7 @@ const api = {
     }): Promise<NotificationSoundResult> => {
       try {
         // Why: drop replays while still ringing; the test button passes force to always confirm.
-        if (!options?.force && isNotificationSoundPlaying) {
+        if (!options?.force && notificationSoundPlayback.isPlaying()) {
           return { played: false, reason: 'deduped' }
         }
 
@@ -2374,22 +2371,7 @@ const api = {
         if (typeof options?.volume === 'number' && Number.isFinite(options.volume)) {
           audio.volume = Math.min(1, Math.max(0, options.volume / 100))
         }
-        isNotificationSoundPlaying = true
-        cleanupNotificationSoundPlayback?.()
-        const release = (): void => {
-          cleanup()
-          if (cleanupNotificationSoundPlayback === cleanup) {
-            cleanupNotificationSoundPlayback = null
-          }
-          isNotificationSoundPlaying = false
-        }
-        const cleanup = (): void => {
-          audio.removeEventListener('ended', release)
-          audio.removeEventListener('error', release)
-        }
-        cleanupNotificationSoundPlayback = cleanup
-        audio.addEventListener('ended', release)
-        audio.addEventListener('error', release)
+        const release = notificationSoundPlayback.begin(audio)
         try {
           await audio.play()
         } catch {

--- a/src/preload/notification-sound-playback.test.ts
+++ b/src/preload/notification-sound-playback.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  createNotificationSoundPlayback,
+  MAX_NOTIFICATION_SOUND_PLAYBACK_MS
+} from './notification-sound-playback'
+
+type Listener = (...args: unknown[]) => void
+
+function fakeAudio(): {
+  audio: Pick<HTMLAudioElement, 'addEventListener' | 'removeEventListener'>
+  emit: (event: 'ended' | 'error') => void
+  listeners: Map<string, Listener[]>
+} {
+  const listeners = new Map<string, Listener[]>()
+  return {
+    audio: {
+      addEventListener: (event, listener) => {
+        listeners.set(event, [...(listeners.get(event) ?? []), listener as Listener])
+      },
+      removeEventListener: (event, listener) => {
+        listeners.set(
+          event,
+          (listeners.get(event) ?? []).filter((candidate) => candidate !== listener)
+        )
+      }
+    },
+    emit: (event) => {
+      for (const listener of listeners.get(event) ?? []) {
+        listener()
+      }
+    },
+    listeners
+  }
+}
+
+describe('createNotificationSoundPlayback', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('releases the dedupe window when playback ends normally', () => {
+    const playback = createNotificationSoundPlayback()
+    const { audio, emit } = fakeAudio()
+
+    playback.begin(audio)
+    expect(playback.isPlaying()).toBe(true)
+
+    emit('ended')
+    expect(playback.isPlaying()).toBe(false)
+  })
+
+  it('releases the dedupe window on playback error', () => {
+    const playback = createNotificationSoundPlayback()
+    const { audio, emit } = fakeAudio()
+
+    playback.begin(audio)
+    emit('error')
+    expect(playback.isPlaying()).toBe(false)
+  })
+
+  // Regression (#15933): an OS audio route change or device sleep mid-play stalls the
+  // element so neither ended nor error ever fires; the flag used to stay latched true and
+  // every later completion notification silently returned 'deduped'.
+  it('releases the dedupe window when the element stalls without any event', () => {
+    const playback = createNotificationSoundPlayback()
+    const { audio } = fakeAudio()
+
+    playback.begin(audio)
+    expect(playback.isPlaying()).toBe(true)
+
+    vi.advanceTimersByTime(MAX_NOTIFICATION_SOUND_PLAYBACK_MS - 1)
+    expect(playback.isPlaying()).toBe(true)
+
+    vi.advanceTimersByTime(1)
+    expect(playback.isPlaying()).toBe(false)
+  })
+
+  it('stops the fallback timer once ended fires, and a late timer fires nothing', () => {
+    const playback = createNotificationSoundPlayback()
+    const first = fakeAudio()
+    playback.begin(first.audio)
+    first.emit('ended')
+
+    // The timer for the finished playback must not release the NEXT one early.
+    const second = fakeAudio()
+    playback.begin(second.audio)
+    vi.advanceTimersByTime(MAX_NOTIFICATION_SOUND_PLAYBACK_MS + 5)
+    expect(playback.isPlaying()).toBe(false)
+
+    second.emit('ended')
+    expect(playback.isPlaying()).toBe(false)
+  })
+
+  it('accepts a new playback while one is stuck, releasing the previous', () => {
+    const playback = createNotificationSoundPlayback()
+    const stuck = fakeAudio()
+    playback.begin(stuck.audio)
+
+    const fresh = fakeAudio()
+    playback.begin(fresh.audio)
+    expect(playback.isPlaying()).toBe(true)
+
+    // The stuck playback's late ended must not release the fresh window.
+    stuck.emit('ended')
+    expect(playback.isPlaying()).toBe(true)
+
+    fresh.emit('ended')
+    expect(playback.isPlaying()).toBe(false)
+  })
+
+  it('forceRelease drops an in-flight window and listeners are unhooked', () => {
+    const playback = createNotificationSoundPlayback()
+    const { audio, listeners } = fakeAudio()
+
+    const release = playback.begin(audio)
+    playback.forceRelease()
+    expect(playback.isPlaying()).toBe(false)
+
+    // Idempotent: a later release() (audio.play() rejection path) is a no-op.
+    release()
+    expect(playback.isPlaying()).toBe(false)
+    expect(listeners.get('ended')).toHaveLength(0)
+    expect(listeners.get('error')).toHaveLength(0)
+  })
+})

--- a/src/preload/notification-sound-playback.test.ts
+++ b/src/preload/notification-sound-playback.test.ts
@@ -79,19 +79,23 @@ describe('createNotificationSoundPlayback', () => {
     expect(playback.isPlaying()).toBe(false)
   })
 
-  it('stops the fallback timer once ended fires, and a late timer fires nothing', () => {
+  it("a finished playback's fallback timer cannot release the next window early", () => {
     const playback = createNotificationSoundPlayback()
     const first = fakeAudio()
     playback.begin(first.audio)
-    first.emit('ended')
-
-    // The timer for the finished playback must not release the NEXT one early.
+    // Stagger the windows so their deadlines differ: the first began at t=0, the second at
+    // t=half-bound, so the first timer's deadline must not still the second's flag.
+    vi.advanceTimersByTime(MAX_NOTIFICATION_SOUND_PLAYBACK_MS / 2)
     const second = fakeAudio()
     playback.begin(second.audio)
-    vi.advanceTimersByTime(MAX_NOTIFICATION_SOUND_PLAYBACK_MS + 5)
-    expect(playback.isPlaying()).toBe(false)
+    first.emit('ended')
 
-    second.emit('ended')
+    // Past the FIRST window's deadline (t=10000) but before the second's (t=15000): the
+    // second window must survive the first timer's firing.
+    vi.advanceTimersByTime(MAX_NOTIFICATION_SOUND_PLAYBACK_MS - 1)
+    expect(playback.isPlaying()).toBe(true)
+
+    vi.advanceTimersByTime(1)
     expect(playback.isPlaying()).toBe(false)
   })
 

--- a/src/preload/notification-sound-playback.ts
+++ b/src/preload/notification-sound-playback.ts
@@ -1,0 +1,55 @@
+// Why (#15933): a stalled Audio element — an OS audio route change, a device sleep
+// mid-play, a decode stall — fires neither `ended` nor `error`. The dedupe flag used to
+// clear only on those events, so one stall latched it true forever and every later
+// completion notification silently returned 'deduped' (the renderer treats that reason
+// as expected burst coalescing and does not warn). A time bound releases the window so
+// one stall costs at most one miss, not all subsequent sounds.
+export const MAX_NOTIFICATION_SOUND_PLAYBACK_MS = 10_000
+
+type AudioElementLike = Pick<HTMLAudioElement, 'addEventListener' | 'removeEventListener'>
+
+export type NotificationSoundPlayback = {
+  isPlaying: () => boolean
+  /** Marks playback in flight against the given element; returns the release function. */
+  begin: (audio: AudioElementLike) => () => void
+  /** Releases an in-flight playback, if any (dispose/reload paths). */
+  forceRelease: () => void
+}
+
+export function createNotificationSoundPlayback(): NotificationSoundPlayback {
+  let playing = false
+  let finishCurrent: (() => void) | null = null
+
+  function begin(audio: AudioElementLike): () => void {
+    finishCurrent?.()
+    playing = true
+    let done = false
+    let fallbackTimer: ReturnType<typeof setTimeout> | null = null
+    const finish = (): void => {
+      if (done) {
+        return
+      }
+      done = true
+      if (fallbackTimer !== null) {
+        clearTimeout(fallbackTimer)
+        fallbackTimer = null
+      }
+      audio.removeEventListener('ended', finish)
+      audio.removeEventListener('error', finish)
+      playing = false
+    }
+    fallbackTimer = setTimeout(finish, MAX_NOTIFICATION_SOUND_PLAYBACK_MS)
+    audio.addEventListener('ended', finish)
+    audio.addEventListener('error', finish)
+    finishCurrent = finish
+    return finish
+  }
+
+  return {
+    isPlaying: () => playing,
+    begin,
+    forceRelease: () => {
+      finishCurrent?.()
+    }
+  }
+}


### PR DESCRIPTION
## What

The custom notification sound's dedupe window is now bounded in time. A small `createNotificationSoundPlayback` module (`src/preload/notification-sound-playback.ts`) owns the in-flight flag and releases it on **`ended`, `error`, or a 10-second time bound, whichever comes first** — replacing the inline pair of module-level variables in the preload whose flag cleared only on the two events.

## Why (issue #15933)

`playSound`'s dedupe gate (`if (!options?.force && isNotificationSoundPlaying) return { played: false, reason: 'deduped' }`) existed to drop replays while a sound was still ringing. But the flag was released **only** by the `Audio` element's `ended`/`error` listeners. An element that stalls — an OS audio route change (Bluetooth/HDMI disconnect), a device sleep mid-play, a decode stall — fires **neither** event, so the flag latched `true` forever. Every subsequent completion notification then short-circuited to `'deduped'`, a reason the renderer wrapper deliberately does not warn about (it means expected burst coalescing) — so the failure was both permanent-until-restart and completely silent. That matches the report's "intermittent, timing/state dependent" exactly: one stall event, and sounds stop from then on.

The time bound makes one stall cost at most one missed sound. Normal sounds end well under 10s; `force` (the settings test button) bypasses the gate entirely and is unaffected; intentionally muted/suppressed notifications never reach `playSound` at all.

## How

- `begin(audio)` marks playback, wires `ended`/`error`, and arms `setTimeout(finish, MAX_NOTIFICATION_SOUND_PLAYBACK_MS)`; `finish` is idempotent and unhooks everything.
- A later `begin` releases the previous window first, so a stuck element cannot leak into the next notification; `forceRelease()` covers the dispose/reload paths (sound file change).
- The preload's `playSound` flow is otherwise unchanged — same results, same IPC, same cache.

## Testing

New `src/preload/notification-sound-playback.test.ts` (fake timers + fake audio element):

- releases on `ended`; releases on `error`;
- **the regression**: a stalled element (no events ever) releases the window at exactly the bound — one tick before it is still playing, at the bound it is not;
- a finished playback's late fallback timer cannot release the next window early;
- `begin` while one is stuck releases the previous, and the stuck element's late `ended` cannot release the fresh window;
- `forceRelease` drops the window, unhooks listeners, and the later `release()` from the `audio.play()` rejection path is a safe no-op.

Full typecheck clean; the preload/dispatch suites pass. (Two unrelated failures visible in a full `src/renderer/src/lib` run — a cmd.exe quoting case and the activation-surface census — are load flakes: both pass in isolation on a tree with these changes present.)

Fixes #15933
