### PR TITLE
fix(notifications): replay completion sounds reliably

### DIFF
--- a/src/preload/api/notification-sound-playback.test.ts
+++ b/src/preload/api/notification-sound-playback.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { notificationsApi } from './notifications-bridge'
+
+const SOUND_PATH = join(tmpdir(), 'notification.mp3')
+
+const { construct, invoke, play } = vi.hoisted(() => ({
+  construct: vi.fn(),
+  invoke: vi.fn(),
+  play: vi.fn(() => Promise.resolve())
+}))
+
+vi.mock('electron', () => ({ ipcRenderer: { invoke } }))
+
+async function loadNotificationsApi(): Promise<typeof notificationsApi> {
+  vi.resetModules()
+  return (await import('./notifications-bridge')).notificationsApi
+}
+
+describe('notificationsApi.playSound', () => {
+  beforeEach(() => {
+    construct.mockClear()
+    play.mockClear()
+    vi.stubGlobal(
+      'Audio',
+      class extends EventTarget {
+        currentTime = 0
+        volume = 1
+        src = ''
+        pause = vi.fn()
+        play = play
+
+        constructor() {
+          super()
+          construct()
+        }
+      }
+    )
+    invoke.mockReset()
+    invoke.mockImplementation((channel: string) => {
+      if (channel === 'notifications:resolveSoundPath') {
+        return Promise.resolve({ ok: true, path: SOUND_PATH })
+      }
+      if (channel === 'notifications:loadSound') {
+        return Promise.resolve({
+          ok: true,
+          data: new Uint8Array([1]),
+          mimeType: 'audio/mpeg',
+          path: SOUND_PATH
+        })
+      }
+      return Promise.resolve(undefined)
+    })
+  })
+
+  it('replays the cached sound for each notification instead of deduping mid-playback', async () => {
+    const notificationsApi = await loadNotificationsApi()
+
+    await expect(notificationsApi.playSound()).resolves.toEqual({ played: true })
+    await expect(notificationsApi.playSound()).resolves.toEqual({ played: true })
+
+    expect(construct).toHaveBeenCalledOnce()
+    expect(play).toHaveBeenCalledTimes(2)
+  })
+
+  it('shares one cached Audio across concurrent first playback', async () => {
+    const notificationsApi = await loadNotificationsApi()
+
+    await expect(
+      Promise.all([notificationsApi.playSound(), notificationsApi.playSound()])
+    ).resolves.toEqual([{ played: true }, { played: true }])
+
+    expect(construct).toHaveBeenCalledOnce()
+    expect(play).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/preload/api/notifications-bridge.ts
+++ b/src/preload/api/notifications-bridge.ts
@@ -16,14 +16,12 @@ let cachedNotificationSound: {
   blobUrl: string
   audio: HTMLAudioElement
 } | null = null
-let isNotificationSoundPlaying = false
 // Why: audio.play() can reject before ended/error fires; cleanup prevents leaked listeners.
 let cleanupNotificationSoundPlayback: (() => void) | null = null
 
 function clearNotificationSoundPlaybackState(): void {
   cleanupNotificationSoundPlayback?.()
   cleanupNotificationSoundPlayback = null
-  isNotificationSoundPlaying = false
 }
 
 function disposeCachedNotificationSound(): void {
@@ -51,11 +49,6 @@ export const notificationsApi = {
     volume?: number
   }): Promise<NotificationSoundResult> => {
     try {
-      // Why: drop replays while still ringing; the test button passes force to always confirm.
-      if (!options?.force && isNotificationSoundPlaying) {
-        return { played: false, reason: 'deduped' }
-      }
-
       const resolved = (await ipcRenderer.invoke(
         'notifications:resolveSoundPath'
       )) as NotificationSoundPathResult
@@ -75,13 +68,19 @@ export const notificationsApi = {
           disposeCachedNotificationSound()
           return { played: false, reason: sound.reason }
         }
-        const arrayBuffer = new ArrayBuffer(sound.data.byteLength)
-        new Uint8Array(arrayBuffer).set(sound.data)
-        const blob = new Blob([arrayBuffer], { type: sound.mimeType })
-        disposeCachedNotificationSound()
-        const blobUrl = URL.createObjectURL(blob)
-        entry = { path: sound.path, blobUrl, audio: new Audio(blobUrl) }
-        cachedNotificationSound = entry
+        // Why: a concurrent playSound may have cached the same path while this load was in flight.
+        const latestEntry = cachedNotificationSound
+        if (latestEntry?.path === sound.path) {
+          entry = latestEntry
+        } else {
+          const arrayBuffer = new ArrayBuffer(sound.data.byteLength)
+          new Uint8Array(arrayBuffer).set(sound.data)
+          const blob = new Blob([arrayBuffer], { type: sound.mimeType })
+          disposeCachedNotificationSound()
+          const blobUrl = URL.createObjectURL(blob)
+          entry = { path: sound.path, blobUrl, audio: new Audio(blobUrl) }
+          cachedNotificationSound = entry
+        }
       }
 
       const audio = entry.audio
@@ -90,14 +89,12 @@ export const notificationsApi = {
       if (typeof options?.volume === 'number' && Number.isFinite(options.volume)) {
         audio.volume = Math.min(1, Math.max(0, options.volume / 100))
       }
-      isNotificationSoundPlaying = true
       cleanupNotificationSoundPlayback?.()
       const release = (): void => {
         cleanup()
         if (cleanupNotificationSoundPlayback === cleanup) {
           cleanupNotificationSoundPlayback = null
         }
-        isNotificationSoundPlaying = false
       }
       const cleanup = (): void => {
         audio.removeEventListener('ended', release)


### PR DESCRIPTION
## ELI5

Orca could show two completion notifications close together but play only the first sound. The shared notification sound now restarts for every delivered notification, so later completions are not silently missed.

## What Changed

- Removed the global in-flight sound guard that dropped later notification playback.
- Reused the cached audio element and restarted it instead of creating overlapping players.
- Reused a cache entry installed while concurrent first playback was loading the sound.
- Added regression tests for sequential and concurrent playback.

## Why

The previous guard treated sound already playing as a duplicate globally, including a second notification from another worktree. Concurrent first playback could also create two audio elements and pause the first. Restarting one cached player keeps resource use bounded while making every delivered notification audible.

## Linked Issue

Fixes #15933

## Visual Proof

N/A

Audio-only playback behavior changed; there is no visual UI change.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 57,148 passed, 241 skipped
- `pnpm build` — passed with ad-hoc local macOS signing
- Focused regression test: 2 passed
- Actual platform tested: macOS arm64. Shared preload code and cross-platform mocks cover Linux and Windows; no OS-specific branch changed.

## AI Disclosure

Codex was used to diagnose, implement, test, and review this change.

## Review

- Security: no input or trust-boundary changes; existing main-process sound-path validation remains.
- Cross-platform: shared HTML audio behavior only; the test uses Node path utilities.
- Local, SSH, and remote: playback remains client-local after desktop delivery; no RPC, wire, or execution-host behavior changed.
- Agents, integrations, providers, and mobile: untouched.
- Performance: one audio/blob remains cached per sound path; concurrent cold-cache playback no longer creates duplicate audio elements.
- UI quality: no visual change.
- Independent review found no remaining critical or important issues.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No security, remote-wire, mobile, Git-provider, or backward-compatibility surface changed. The existing notification sound result contract is retained.

Author: GitHub @DEOWL-kan. X/Twitter is not configured on the GitHub profile.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)