### PR TITLE
fix(orchestration): preserve completed prompt dispatches

### DIFF
--- a/src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts
@@ -312,6 +312,29 @@ describe('orchestration RPC methods', () => {
       expect(db.getActiveDispatchForTerminal('term_a')).toBeUndefined()
     })
 
+    it('accepts a completed dispatch when prompt verification races worker_done', async () => {
+      setup()
+      provideInjectIdentity()
+      const task = db.createTask({ spec: 'work' })
+      vi.spyOn(runtime, 'isTerminalRunningAgent').mockResolvedValue(true)
+      vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockImplementation(async () => {
+        const dispatch = db.getDispatchContext(task.id)
+        expect(dispatch).toBeDefined()
+        db.updateTaskStatus(task.id, 'completed')
+        throw new Error('agent_prompt_stalled')
+      })
+
+      const result = (await call('orchestration.dispatch', {
+        task: task.id,
+        to: 'term_a',
+        inject: true
+      })) as { dispatch: { id: string }; injected: boolean }
+
+      expect(result.injected).toBe(true)
+      expect(db.getDispatchContextById(result.dispatch.id)?.status).toBe('completed')
+      expect(db.getTask(task.id)?.status).toBe('completed')
+    })
+
     it('uses caller-provided dev mode for injected preamble', async () => {
       setup()
       provideInjectIdentity()

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -1699,8 +1699,13 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           await runtime.sendTerminalAgentPrompt(to, preamble)
           injected = true
         } catch (err) {
-          db.failDispatch(ctx.id, err instanceof Error ? err.message : String(err))
-          throw err
+          const settled = db.getDispatchContextById(ctx.id)
+          if (settled?.status === 'completed') {
+            injected = true
+          } else {
+            db.failDispatch(ctx.id, err instanceof Error ? err.message : String(err))
+            throw err
+          }
         }
       }
 


### PR DESCRIPTION
## Summary

Prevent `orchestration dispatch --inject` from reporting `agent_prompt_stalled` after the dispatched worker has already completed the task through `worker_done`.

## Problem

Prompt submission verification can time out while the worker has already received the lifecycle preamble, executed the task, and durably completed the Dispatch. The injection catch path currently calls `failDispatch` and rethrows the stale prompt error without re-reading settlement state. This produces a contradictory result: the CLI reports failure even though the Task and Dispatch are completed. A coordinator may then retry work that already ran.

## Approach

- Re-read the Dispatch after prompt submission throws.
- If the Dispatch is already `completed`, treat the durable settlement as authoritative and return `injected: true`.
- Preserve the existing rollback behavior for every unsettled prompt failure.
- Add a regression test for the `worker_done` / prompt-verification race.

## Verification

- `orchestration-tasks-dispatch.test.ts`: 31/31 passed
- New regression test fails with the production change reverted (`agent_prompt_stalled`) and passes with the fix
- `typecheck:node`: passed
- `oxfmt --check` on changed files: passed
- `oxlint` on changed files: passed
- `git diff --check`: passed

## Scope

This change is limited to the low-level local `orchestration.dispatch --inject` settlement race. It does not change agent recognition, prompt submission timing, `worker-start` launch behavior, or terminal ownership/release semantics.

Related: #15920