### PR TITLE
fix(usage): fetch native Antigravity quotas via Agy

### DIFF
--- a/src/main/rate-limits/antigravity-usage-fetcher.test.ts
+++ b/src/main/rate-limits/antigravity-usage-fetcher.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { runProcess } from '../../shared/child-process/run-process'
+import { resolveCliCommand } from '../../shared/node-cli-command-resolution'
+import {
+  fetchAntigravityRateLimits,
+  parseAntigravityUsageOutput
+} from './antigravity-usage-fetcher'
+
+vi.mock('../../shared/child-process/run-process', () => ({ runProcess: vi.fn() }))
+vi.mock('../../shared/node-cli-command-resolution', () => ({ resolveCliCommand: vi.fn() }))
+
+const usagePayload = JSON.stringify({
+  status: 'SUCCESS',
+  command: {
+    name: 'usage',
+    data: {
+      groups: [
+        {
+          name: 'Gemini Models',
+          buckets: [
+            {
+              id: 'gemini-weekly',
+              remaining_fraction: 0.98,
+              reset_time: '2026-08-29T12:00:00Z'
+            },
+            {
+              id: 'gemini-5h',
+              remaining_fraction: 0.91,
+              reset_time: '2026-08-22T16:00:00Z'
+            }
+          ]
+        },
+        {
+          name: 'Claude and GPT models',
+          buckets: [
+            {
+              id: '3p-weekly',
+              remaining_fraction: 1,
+              reset_time: '2026-08-29T13:00:00Z'
+            },
+            {
+              id: '3p-5h',
+              remaining_fraction: 0.995,
+              reset_time: '2026-08-22T17:00:00Z'
+            }
+          ]
+        }
+      ]
+    }
+  }
+})
+
+describe('parseAntigravityUsageOutput', () => {
+  it('preserves all four native quota identities', () => {
+    expect(parseAntigravityUsageOutput(usagePayload)).toEqual([
+      {
+        name: 'Gemini weekly',
+        usedPercent: 2,
+        windowMinutes: 10_080,
+        resetsAt: Date.parse('2026-08-29T12:00:00Z'),
+        resetDescription: null
+      },
+      {
+        name: 'Gemini 5h',
+        usedPercent: 9,
+        windowMinutes: 300,
+        resetsAt: Date.parse('2026-08-22T16:00:00Z'),
+        resetDescription: null
+      },
+      {
+        name: 'Claude/GPT weekly',
+        usedPercent: 0,
+        windowMinutes: 10_080,
+        resetsAt: Date.parse('2026-08-29T13:00:00Z'),
+        resetDescription: null
+      },
+      {
+        name: 'Claude/GPT 5h',
+        usedPercent: 1,
+        windowMinutes: 300,
+        resetsAt: Date.parse('2026-08-22T17:00:00Z'),
+        resetDescription: null
+      }
+    ])
+  })
+
+  it('ignores unknown buckets and keeps partial recognized data', () => {
+    const payload = JSON.stringify({
+      status: 'SUCCESS',
+      command: {
+        name: 'usage',
+        data: {
+          groups: [
+            {
+              buckets: [
+                { id: 'future-window', remaining_fraction: 0.5 },
+                { id: 'gemini-5h', remaining_fraction: 0.4, reset_time: 'invalid' }
+              ]
+            }
+          ]
+        }
+      }
+    })
+
+    expect(parseAntigravityUsageOutput(payload)).toEqual([
+      {
+        name: 'Gemini 5h',
+        usedPercent: 60,
+        windowMinutes: 300,
+        resetsAt: null,
+        resetDescription: null
+      }
+    ])
+  })
+
+  it.each([
+    ['non-JSON output', 'not JSON'],
+    ['a non-usage command', JSON.stringify({ status: 'SUCCESS', command: { name: 'models' } })],
+    [
+      'no recognized buckets',
+      JSON.stringify({
+        status: 'SUCCESS',
+        command: { name: 'usage', data: { groups: [{ buckets: [] }] } }
+      })
+    ]
+  ])('rejects %s', (_name, output) => {
+    expect(() => parseAntigravityUsageOutput(output)).toThrow()
+  })
+})
+
+describe('fetchAntigravityRateLimits', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(resolveCliCommand).mockReturnValue('C:\\Agy\\agy.exe')
+  })
+
+  it('runs Agy print mode and returns native quota summaries', async () => {
+    vi.mocked(runProcess).mockResolvedValue({
+      code: 0,
+      signal: null,
+      stdout: usagePayload,
+      stderr: '',
+      timedOut: false
+    })
+    const controller = new AbortController()
+
+    const result = await fetchAntigravityRateLimits({ signal: controller.signal })
+
+    expect(resolveCliCommand).toHaveBeenCalledWith('agy')
+    expect(runProcess).toHaveBeenCalledWith({
+      program: 'C:\\Agy\\agy.exe',
+      args: ['-p', '/usage', '--output-format', 'json', '--print-timeout', '20s'],
+      timeoutMs: 25_000,
+      maxOutputBytes: 1024 * 1024,
+      signal: controller.signal
+    })
+    expect(result).toMatchObject({
+      provider: 'antigravity',
+      status: 'ok',
+      error: null,
+      session: { usedPercent: 9, windowMinutes: 300 },
+      weekly: null,
+      usageMetadata: { source: 'cli', attemptedSources: ['cli'] }
+    })
+    expect(result.buckets).toHaveLength(4)
+  })
+
+  it('reports a missing Agy executable as unavailable', async () => {
+    vi.mocked(runProcess).mockRejectedValue(
+      Object.assign(new Error('spawn ENOENT'), { code: 'ENOENT' })
+    )
+
+    await expect(fetchAntigravityRateLimits()).resolves.toMatchObject({
+      provider: 'antigravity',
+      status: 'unavailable',
+      error: 'Antigravity CLI not found',
+      usageMetadata: { failureKind: 'cli-unavailable' }
+    })
+  })
+
+  it('reports command timeouts without parsing partial output', async () => {
+    vi.mocked(runProcess).mockResolvedValue({
+      code: null,
+      signal: 'SIGTERM',
+      stdout: usagePayload,
+      stderr: '',
+      timedOut: true
+    })
+
+    await expect(fetchAntigravityRateLimits()).resolves.toMatchObject({
+      status: 'error',
+      error: 'Agy usage request timed out',
+      usageMetadata: { failureKind: 'usage-unavailable' }
+    })
+  })
+
+  it('classifies malformed successful output as a parse failure', async () => {
+    vi.mocked(runProcess).mockResolvedValue({
+      code: 0,
+      signal: null,
+      stdout: '{}',
+      stderr: '',
+      timedOut: false
+    })
+
+    await expect(fetchAntigravityRateLimits()).resolves.toMatchObject({
+      status: 'error',
+      usageMetadata: { failureKind: 'parse' }
+    })
+  })
+})

--- a/src/main/rate-limits/antigravity-usage-fetcher.ts
+++ b/src/main/rate-limits/antigravity-usage-fetcher.ts
@@ -1,0 +1,195 @@
+import type {
+  ProviderRateLimits,
+  RateLimitBucket,
+  RateLimitWindow
+} from '../../shared/rate-limit-types'
+import { runProcess } from '../../shared/child-process/run-process'
+import { resolveCliCommand } from '../../shared/node-cli-command-resolution'
+
+const AGY_USAGE_ARGS = [
+  '-p',
+  '/usage',
+  '--output-format',
+  'json',
+  '--print-timeout',
+  '20s'
+] as const
+const AGY_PROCESS_TIMEOUT_MS = 25_000
+
+const AGY_BUCKETS = {
+  'gemini-weekly': { name: 'Gemini weekly', windowMinutes: 10_080 },
+  'gemini-5h': { name: 'Gemini 5h', windowMinutes: 300 },
+  '3p-weekly': { name: 'Claude/GPT weekly', windowMinutes: 10_080 },
+  '3p-5h': { name: 'Claude/GPT 5h', windowMinutes: 300 }
+} as const
+
+type AgyBucketId = keyof typeof AGY_BUCKETS
+
+type AgyUsageBucket = {
+  id: AgyBucketId
+  remainingFraction: number
+  resetTime: string | null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function parseResetTime(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null
+}
+
+function parseAgyBucket(value: unknown): AgyUsageBucket | null {
+  if (!isRecord(value) || typeof value.id !== 'string' || !(value.id in AGY_BUCKETS)) {
+    return null
+  }
+  if (typeof value.remaining_fraction !== 'number' || !Number.isFinite(value.remaining_fraction)) {
+    return null
+  }
+  return {
+    id: value.id as AgyBucketId,
+    remainingFraction: value.remaining_fraction,
+    resetTime: parseResetTime(value.reset_time)
+  }
+}
+
+function toRateLimitBucket(bucket: AgyUsageBucket): RateLimitBucket {
+  const definition = AGY_BUCKETS[bucket.id]
+  const remainingFraction = Math.min(1, Math.max(0, bucket.remainingFraction))
+  const resetsAt = bucket.resetTime ? Date.parse(bucket.resetTime) : Number.NaN
+  return {
+    name: definition.name,
+    usedPercent: Math.round((1 - remainingFraction) * 100),
+    windowMinutes: definition.windowMinutes,
+    resetsAt: Number.isFinite(resetsAt) ? resetsAt : null,
+    resetDescription: null
+  }
+}
+
+function tightestWindow(buckets: RateLimitBucket[], windowMinutes: number): RateLimitWindow | null {
+  const matches = buckets.filter((bucket) => bucket.windowMinutes === windowMinutes)
+  if (matches.length === 0) {
+    return null
+  }
+  const tightest = matches.reduce((current, candidate) =>
+    candidate.usedPercent > current.usedPercent ? candidate : current
+  )
+  const { name: _name, ...window } = tightest
+  return window
+}
+
+export function parseAntigravityUsageOutput(output: string): RateLimitBucket[] {
+  const parsed: unknown = JSON.parse(output)
+  if (!isRecord(parsed) || parsed.status !== 'SUCCESS' || !isRecord(parsed.command)) {
+    throw new Error('Agy returned an invalid usage response')
+  }
+  if (parsed.command.name !== 'usage' || !isRecord(parsed.command.data)) {
+    throw new Error('Agy did not return usage data')
+  }
+  const groups = parsed.command.data.groups
+  if (!Array.isArray(groups)) {
+    throw new Error('Agy usage groups are missing')
+  }
+
+  const discovered = new Map<AgyBucketId, AgyUsageBucket>()
+  for (const group of groups) {
+    if (!isRecord(group) || !Array.isArray(group.buckets)) {
+      continue
+    }
+    for (const rawBucket of group.buckets) {
+      const bucket = parseAgyBucket(rawBucket)
+      if (bucket && !discovered.has(bucket.id)) {
+        discovered.set(bucket.id, bucket)
+      }
+    }
+  }
+
+  const buckets = (Object.keys(AGY_BUCKETS) as AgyBucketId[])
+    .map((id) => discovered.get(id))
+    .filter((bucket): bucket is AgyUsageBucket => bucket !== undefined)
+    .map(toRateLimitBucket)
+  if (buckets.length === 0) {
+    throw new Error('Agy returned no recognized usage buckets')
+  }
+  return buckets
+}
+
+function makeResult(
+  status: ProviderRateLimits['status'],
+  error: string,
+  failureKind: NonNullable<ProviderRateLimits['usageMetadata']>['failureKind']
+): ProviderRateLimits {
+  return {
+    provider: 'antigravity',
+    session: null,
+    weekly: null,
+    buckets: [],
+    updatedAt: Date.now(),
+    error,
+    status,
+    usageMetadata: {
+      source: 'cli',
+      attemptedSources: ['cli'],
+      failureKind
+    }
+  }
+}
+
+export async function fetchAntigravityRateLimits(options?: {
+  signal?: AbortSignal
+}): Promise<ProviderRateLimits> {
+  let result
+  try {
+    result = await runProcess({
+      program: resolveCliCommand('agy'),
+      args: AGY_USAGE_ARGS,
+      timeoutMs: AGY_PROCESS_TIMEOUT_MS,
+      maxOutputBytes: 1024 * 1024,
+      signal: options?.signal
+    })
+  } catch (error) {
+    const unavailable = isRecord(error) && error.code === 'ENOENT'
+    return makeResult(
+      unavailable ? 'unavailable' : 'error',
+      unavailable ? 'Antigravity CLI not found' : 'Agy usage command could not start',
+      unavailable ? 'cli-unavailable' : 'unknown'
+    )
+  }
+
+  if (result.timedOut) {
+    return makeResult('error', 'Agy usage request timed out', 'usage-unavailable')
+  }
+  if (result.code !== 0) {
+    return makeResult(
+      'error',
+      `Agy usage command failed (exit code ${result.code ?? 'unknown'})`,
+      'usage-unavailable'
+    )
+  }
+
+  let buckets: RateLimitBucket[]
+  try {
+    buckets = parseAntigravityUsageOutput(result.stdout)
+  } catch (error) {
+    return makeResult(
+      'error',
+      error instanceof Error ? error.message : 'Agy returned invalid usage data',
+      'parse'
+    )
+  }
+
+  return {
+    provider: 'antigravity',
+    session: tightestWindow(buckets, 300),
+    // Detailed views read the independent weekly identities from buckets.
+    weekly: null,
+    buckets,
+    updatedAt: Date.now(),
+    error: null,
+    status: 'ok',
+    usageMetadata: {
+      source: 'cli',
+      attemptedSources: ['cli']
+    }
+  }
+}

--- a/src/main/rate-limits/rate-limit-service-test-harness.ts
+++ b/src/main/rate-limits/rate-limit-service-test-harness.ts
@@ -4,6 +4,7 @@ import type { ProviderRateLimits } from '../../shared/rate-limit-types'
 import type { RateLimitService } from './service'
 import { fetchCodexRateLimits } from './codex-fetcher'
 import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
+import { fetchAntigravityRateLimits } from './antigravity-usage-fetcher'
 import { fetchKimiRateLimits } from './kimi-fetcher'
 import { fetchMiniMaxRateLimits } from './minimax-fetcher'
 import { fetchGrokRateLimits } from './grok-fetcher'
@@ -85,6 +86,7 @@ export function unavailableProvider(
 export function mockFreshBackgroundProviderFetches(): void {
   vi.mocked(fetchCodexRateLimits).mockImplementation(async () => okProvider('codex', 24))
   vi.mocked(fetchGeminiRateLimits).mockImplementation(async () => okProvider('gemini', 0))
+  vi.mocked(fetchAntigravityRateLimits).mockImplementation(async () => okProvider('antigravity', 0))
   vi.mocked(fetchOpenCodeGoRateLimits).mockImplementation(async () => okProvider('opencode-go', 0))
   vi.mocked(fetchKimiRateLimits).mockImplementation(async () => okProvider('kimi', 0))
   vi.mocked(fetchMiniMaxRateLimits).mockImplementation(async () => okProvider('minimax', 0))
@@ -95,6 +97,7 @@ export function mockFreshBackgroundProviderFetches(): void {
 export function resetRateLimitProviderMocks(): void {
   vi.clearAllMocks()
   vi.mocked(fetchGeminiRateLimits).mockResolvedValue(okProvider('gemini', 0, Date.now()))
+  vi.mocked(fetchAntigravityRateLimits).mockResolvedValue(okProvider('antigravity', 0, Date.now()))
   vi.mocked(fetchOpenCodeGoRateLimits).mockResolvedValue(okProvider('opencode-go', 0, Date.now()))
   vi.mocked(fetchKimiRateLimits).mockResolvedValue(okProvider('kimi', 0, Date.now()))
   vi.mocked(fetchMiniMaxRateLimits).mockResolvedValue(okProvider('minimax', 0, Date.now()))

--- a/src/main/rate-limits/service-account-target-selection.test.ts
+++ b/src/main/rate-limits/service-account-target-selection.test.ts
@@ -24,6 +24,10 @@ vi.mock('./gemini-usage-fetcher', () => ({
   fetchGeminiRateLimits: vi.fn()
 }))
 
+vi.mock('./antigravity-usage-fetcher', () => ({
+  fetchAntigravityRateLimits: vi.fn()
+}))
+
 vi.mock('./kimi-fetcher', () => ({
   fetchKimiRateLimits: vi.fn()
 }))

--- a/src/main/rate-limits/service-inactive-account-previews.test.ts
+++ b/src/main/rate-limits/service-inactive-account-previews.test.ts
@@ -31,6 +31,10 @@ vi.mock('./gemini-usage-fetcher', () => ({
   fetchGeminiRateLimits: vi.fn()
 }))
 
+vi.mock('./antigravity-usage-fetcher', () => ({
+  fetchAntigravityRateLimits: vi.fn()
+}))
+
 vi.mock('./kimi-fetcher', () => ({
   fetchKimiRateLimits: vi.fn()
 }))

--- a/src/main/rate-limits/service-live-claude-usage.test.ts
+++ b/src/main/rate-limits/service-live-claude-usage.test.ts
@@ -28,6 +28,10 @@ vi.mock('./gemini-usage-fetcher', () => ({
   fetchGeminiRateLimits: vi.fn()
 }))
 
+vi.mock('./antigravity-usage-fetcher', () => ({
+  fetchAntigravityRateLimits: vi.fn()
+}))
+
 vi.mock('./kimi-fetcher', () => ({
   fetchKimiRateLimits: vi.fn()
 }))

--- a/src/main/rate-limits/service-minimax-usage.test.ts
+++ b/src/main/rate-limits/service-minimax-usage.test.ts
@@ -25,6 +25,10 @@ vi.mock('./gemini-usage-fetcher', () => ({
   fetchGeminiRateLimits: vi.fn()
 }))
 
+vi.mock('./antigravity-usage-fetcher', () => ({
+  fetchAntigravityRateLimits: vi.fn()
+}))
+
 vi.mock('./kimi-fetcher', () => ({
   fetchKimiRateLimits: vi.fn()
 }))

--- a/src/main/rate-limits/service-refresh-orchestration.test.ts
+++ b/src/main/rate-limits/service-refresh-orchestration.test.ts
@@ -4,6 +4,7 @@ import { RateLimitService } from './service'
 import { fetchClaudeRateLimits } from './claude-fetcher'
 import { fetchCodexRateLimits } from './codex-fetcher'
 import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
+import { fetchAntigravityRateLimits } from './antigravity-usage-fetcher'
 import { fetchKimiRateLimits } from './kimi-fetcher'
 import { fetchMiniMaxRateLimits } from './minimax-fetcher'
 import { fetchGrokRateLimits } from './grok-fetcher'
@@ -30,6 +31,10 @@ vi.mock('./codex-fetcher', () => ({
 
 vi.mock('./gemini-usage-fetcher', () => ({
   fetchGeminiRateLimits: vi.fn()
+}))
+
+vi.mock('./antigravity-usage-fetcher', () => ({
+  fetchAntigravityRateLimits: vi.fn()
 }))
 
 vi.mock('./kimi-fetcher', () => ({
@@ -361,7 +366,7 @@ describe('RateLimitService', () => {
     expect(fetchGrokRateLimits).toHaveBeenCalledTimes(1)
   })
 
-  it('fetches Gemini and OpenCode Go alongside Claude and Codex', async () => {
+  it('fetches Gemini, Antigravity, and OpenCode Go alongside Claude and Codex', async () => {
     const service = new RateLimitService()
     service.setOpenCodeGoConfigResolver(() => ({
       sessionCookie: 'session=abc123',
@@ -377,6 +382,9 @@ describe('RateLimitService', () => {
     vi.mocked(fetchClaudeRateLimits).mockResolvedValueOnce(okProvider('claude', 10, Date.now()))
     vi.mocked(fetchCodexRateLimits).mockResolvedValueOnce(okProvider('codex', 20, Date.now()))
     vi.mocked(fetchGeminiRateLimits).mockResolvedValueOnce(okProvider('gemini', 30, Date.now()))
+    vi.mocked(fetchAntigravityRateLimits).mockResolvedValueOnce(
+      okProvider('antigravity', 35, Date.now())
+    )
     vi.mocked(fetchOpenCodeGoRateLimits).mockResolvedValueOnce(
       okProvider('opencode-go', 40, Date.now())
     )
@@ -388,13 +396,17 @@ describe('RateLimitService', () => {
       expect.objectContaining({
         authPreparation: undefined,
         allowPtyFallback: false,
-        allowUsagePanelSupplement: true,
+        allowUsagePanelSupplement: process.platform !== 'win32',
         signal: expect.any(AbortSignal)
       })
     )
     expect(fetchCodexRateLimits).toHaveBeenCalledTimes(1)
     expect(fetchGeminiRateLimits).toHaveBeenCalledTimes(1)
     expect(fetchGeminiRateLimits).toHaveBeenCalledWith(true)
+    expect(fetchAntigravityRateLimits).toHaveBeenCalledTimes(1)
+    expect(fetchAntigravityRateLimits).toHaveBeenCalledWith({
+      signal: expect.any(AbortSignal)
+    })
     expect(fetchOpenCodeGoRateLimits).toHaveBeenCalledTimes(1)
     expect(fetchOpenCodeGoRateLimits).toHaveBeenCalledWith(
       'session=abc123',
@@ -413,6 +425,8 @@ describe('RateLimitService', () => {
     expect(state.codex?.session?.usedPercent).toBe(20)
     expect(state.gemini?.status).toBe('ok')
     expect(state.gemini?.session?.usedPercent).toBe(30)
+    expect(state.antigravity?.status).toBe('ok')
+    expect(state.antigravity?.session?.usedPercent).toBe(35)
     expect(state.opencodeGo?.status).toBe('ok')
     expect(state.opencodeGo?.session?.usedPercent).toBe(40)
   })

--- a/src/main/rate-limits/service-window-activation.test.ts
+++ b/src/main/rate-limits/service-window-activation.test.ts
@@ -33,6 +33,10 @@ vi.mock('./gemini-usage-fetcher', () => ({
   fetchGeminiRateLimits: vi.fn()
 }))
 
+vi.mock('./antigravity-usage-fetcher', () => ({
+  fetchAntigravityRateLimits: vi.fn()
+}))
+
 vi.mock('./kimi-fetcher', () => ({
   fetchKimiRateLimits: vi.fn()
 }))

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -20,6 +20,7 @@ import {
   type NormalizedClaudeAccountSelectionTarget
 } from '../claude-accounts/runtime-selection'
 import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
+import { fetchAntigravityRateLimits } from './antigravity-usage-fetcher'
 import { fetchKimiRateLimits } from './kimi-fetcher'
 import type { KimiHomeResolution } from '../kimi/kimi-runtime-home'
 import { fetchGrokRateLimits } from './grok-fetcher'
@@ -1688,40 +1689,48 @@ export class RateLimitService {
     const claudeFetchGated =
       !options?.force && this.shouldSkipAutomatedClaudeFetch(previousState.claude)
 
-    const [claudeResult, codexResult, geminiResult, opencodeGoResult, kimiResult, miniMaxResult] =
-      await Promise.allSettled([
-        claudeFetchGated
-          ? Promise.resolve(previousState.claude as ProviderRateLimits)
-          : fetchClaudeRateLimits({
-              authPreparation: claudeAuthPreparation,
-              allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation),
-              allowUsagePanelSupplement: this.shouldAllowClaudeUsagePanelSupplement(),
-              networkProxySettings: this.networkProxySettingsResolver?.(),
-              signal
-            }),
-        codexFetchGated
-          ? Promise.resolve(previousState.codex as ProviderRateLimits)
-          : (missingWslCodexHome ??
-            fetchCodexRateLimits({
-              codexHomePath,
-              allowPtyFallback: this.shouldAllowCodexPtyFallback(),
-              signal
-            })),
-        fetchGeminiRateLimits(geminiCliOAuthEnabled),
-        fetchOpenCodeGoRateLimits(
-          cookie,
-          workspaceIdOverride || undefined,
-          this.networkProxySettingsResolver?.()
-        ),
-        this.fetchKimiWithResolvedHome(),
-        miniMaxConfigResult.error
-          ? Promise.resolve(this.getMiniMaxCredentialError(miniMaxConfigResult.error))
-          : fetchMiniMaxRateLimits({
-              cookie: miniMaxCookie,
-              groupId: miniMaxGroupId,
-              models: miniMaxModels
-            })
-      ])
+    const [
+      claudeResult,
+      codexResult,
+      geminiResult,
+      antigravityResult,
+      opencodeGoResult,
+      kimiResult,
+      miniMaxResult
+    ] = await Promise.allSettled([
+      claudeFetchGated
+        ? Promise.resolve(previousState.claude as ProviderRateLimits)
+        : fetchClaudeRateLimits({
+            authPreparation: claudeAuthPreparation,
+            allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation),
+            allowUsagePanelSupplement: this.shouldAllowClaudeUsagePanelSupplement(),
+            networkProxySettings: this.networkProxySettingsResolver?.(),
+            signal
+          }),
+      codexFetchGated
+        ? Promise.resolve(previousState.codex as ProviderRateLimits)
+        : (missingWslCodexHome ??
+          fetchCodexRateLimits({
+            codexHomePath,
+            allowPtyFallback: this.shouldAllowCodexPtyFallback(),
+            signal
+          })),
+      fetchGeminiRateLimits(geminiCliOAuthEnabled),
+      fetchAntigravityRateLimits({ signal }),
+      fetchOpenCodeGoRateLimits(
+        cookie,
+        workspaceIdOverride || undefined,
+        this.networkProxySettingsResolver?.()
+      ),
+      this.fetchKimiWithResolvedHome(),
+      miniMaxConfigResult.error
+        ? Promise.resolve(this.getMiniMaxCredentialError(miniMaxConfigResult.error))
+        : fetchMiniMaxRateLimits({
+            cookie: miniMaxCookie,
+            groupId: miniMaxGroupId,
+            models: miniMaxModels
+          })
+    ])
 
     if (signal.aborted) {
       return
@@ -1766,11 +1775,21 @@ export class RateLimitService {
             status: 'error'
           } satisfies ProviderRateLimits)
 
-    // Why: Antigravity shares Gemini credentials today; mirror the Gemini snapshot so its status-bar UI gets a real lifecycle instead of null.
-    const antigravity: ProviderRateLimits = {
-      ...gemini,
-      provider: 'antigravity'
-    }
+    const antigravity =
+      antigravityResult.status === 'fulfilled'
+        ? antigravityResult.value
+        : ({
+            provider: 'antigravity',
+            session: null,
+            weekly: null,
+            buckets: [],
+            updatedAt: Date.now(),
+            error:
+              antigravityResult.reason instanceof Error
+                ? antigravityResult.reason.message
+                : 'Unknown error',
+            status: 'error'
+          } satisfies ProviderRateLimits)
 
     const opencodeGo =
       opencodeGoResult.status === 'fulfilled'

--- a/src/renderer/src/components/status-bar/UsageRosterPanel.test.tsx
+++ b/src/renderer/src/components/status-bar/UsageRosterPanel.test.tsx
@@ -247,6 +247,44 @@ describe('UsageRow', () => {
     expect(markup).toContain('25%')
     expect(markup).toContain('60%')
   })
+
+  it('renders all four independent Antigravity quota buckets', () => {
+    const bucket = (name: string, usedPercent: number, windowMinutes: number) => ({
+      name,
+      usedPercent,
+      windowMinutes,
+      resetsAt: null,
+      resetDescription: null
+    })
+    const markup = renderToStaticMarkup(
+      <UsageRow
+        p={{
+          provider: 'antigravity',
+          session: bucket('summary', 9, 300),
+          weekly: null,
+          buckets: [
+            bucket('Gemini weekly', 2, 10_080),
+            bucket('Gemini 5h', 9, 300),
+            bucket('Claude/GPT weekly', 0, 10_080),
+            bucket('Claude/GPT 5h', 1, 300)
+          ],
+          updatedAt: 0,
+          status: 'ok',
+          error: null
+        }}
+        display="used"
+        state={{ kind: 'usage', statusLabel: null }}
+        showSignInAction={false}
+        now={mocks.now}
+      />
+    )
+
+    expect(markup.match(/data-usage-window=/g)).toHaveLength(4)
+    expect(markup).toContain('Gemini weekly')
+    expect(markup).toContain('Gemini 5h')
+    expect(markup).toContain('Claude/GPT weekly')
+    expect(markup).toContain('Claude/GPT 5h')
+  })
 })
 
 describe('UsageRosterPanel density picker', () => {

--- a/src/renderer/src/components/status-bar/UsageRosterPanel.tsx
+++ b/src/renderer/src/components/status-bar/UsageRosterPanel.tsx
@@ -35,7 +35,7 @@ function providerMaxUsed(sections: UsageSection[]): number {
     : 0
 }
 
-// Buckets (Gemini Flash/Pro) keep their model name; windows use their duration.
+// Named buckets keep their provider label; fixed windows use their duration.
 function shortLabel(
   p: ProviderRateLimits,
   section: UsageSection,

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.test.ts
@@ -121,11 +121,7 @@ describe('hasUsageProviderSettings', () => {
     expect(
       hasUsageProviderSettings(usageSettings({ opencodeSessionCookie: ' session=abc ' }))
     ).toBe(true)
-    // Why: antigravity durability requires the Gemini OAuth opt-in; the
-    // checked item alone must not suppress the usage setup CTA.
-    expect(hasUsageProviderSettings(usageSettings({ antigravityUsageConfigured: true }))).toBe(
-      false
-    )
+    expect(hasUsageProviderSettings(usageSettings({ antigravityUsageConfigured: true }))).toBe(true)
     expect(hasUsageProviderSettings(usageSettings({ minimaxCookieConfigured: true }))).toBe(true)
     expect(hasUsageProviderSettings(usageSettings({ grokAuthConfigured: true }))).toBe(true)
   })
@@ -160,21 +156,19 @@ describe('hasUsageProviderSettingsForProvider', () => {
     expect(hasUsageProviderSettingsForProvider('grok', usageSettings())).toBe(false)
   })
 
-  it('requires both a checked Antigravity item and Gemini OAuth as the durable Antigravity signal', () => {
+  it('uses the checked Antigravity item as its durable signal', () => {
     expect(
       hasUsageProviderSettingsForProvider(
         'antigravity',
         usageSettings({ antigravityUsageConfigured: true, geminiCliOAuthEnabled: true })
       )
     ).toBe(true)
-    // Why: the snapshot mirrors the Gemini fetch — without the OAuth opt-in it
-    // is permanently unavailable, so the checked item alone is not durable.
     expect(
       hasUsageProviderSettingsForProvider(
         'antigravity',
         usageSettings({ antigravityUsageConfigured: true })
       )
-    ).toBe(false)
+    ).toBe(true)
     expect(
       hasUsageProviderSettingsForProvider(
         'antigravity',
@@ -338,26 +332,24 @@ describe('getVisibleUsageProvider', () => {
     })
   })
 
-  it('hides Antigravity while Gemini OAuth is off even when its status item is checked', () => {
-    // Why: without the OAuth opt-in the mirrored snapshot is permanently
-    // 'unavailable'; the default-on item must not pin a dead bar.
+  it('keeps Antigravity visible without Gemini OAuth when its status item is checked', () => {
     expect(
       getVisibleUsageProvider(
         'antigravity',
         null,
         usageSettings({ antigravityUsageConfigured: true })
       )
-    ).toBe(null)
+    ).toMatchObject({ provider: 'antigravity', status: 'fetching' })
     expect(
       getVisibleUsageProvider(
         'antigravity',
         provider('unavailable', {
           provider: 'antigravity',
-          error: 'Gemini CLI OAuth is disabled in settings'
+          error: 'Antigravity CLI not found'
         }),
         usageSettings({ antigravityUsageConfigured: true })
       )
-    ).toBe(null)
+    ).toMatchObject({ provider: 'antigravity', status: 'unavailable' })
   })
 })
 
@@ -499,9 +491,7 @@ describe('isUsageEmptyState', () => {
     ).toBe(false)
   })
 
-  it('still shows the setup CTA when Antigravity is checked but Gemini OAuth is off', () => {
-    // Why: the default-on Antigravity item is not configured usage on its own;
-    // it must not hide the teaching CTA from users who set nothing up.
+  it('waits for checked Antigravity usage without requiring Gemini OAuth', () => {
     expect(
       isUsageEmptyState(
         {
@@ -516,6 +506,6 @@ describe('isUsageEmptyState', () => {
         },
         usageSettings({ antigravityUsageConfigured: true })
       )
-    ).toBe(true)
+    ).toBe(false)
   })
 })

--- a/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
+++ b/src/renderer/src/components/status-bar/status-bar-provider-visibility.ts
@@ -8,11 +8,7 @@ export type UsageProviderSettings = Pick<
   | 'opencodeSessionCookie'
   | 'geminiCliOAuthEnabled'
 > & {
-  // Why: Antigravity has no separate persisted usage credential in Orca. The
-  // checked status-bar item is the durable user signal; StatusBar only sets
-  // this after PATH detection says the agent is available. Durability further
-  // requires geminiCliOAuthEnabled — the snapshot mirrors the Gemini fetch,
-  // which never yields data while that opt-in is off.
+  // Why: the checked item is durable after PATH detection confirms Agy exists.
   antigravityUsageConfigured: boolean
   // Why: MiniMax/Grok sign-in live on disk, not in settings; main sets these each poll.
   minimaxCookieConfigured: boolean
@@ -74,8 +70,7 @@ export function hasUsageProviderSettings(
     (settings?.claudeManagedAccounts?.length ?? 0) > 0 ||
     settings?.geminiCliOAuthEnabled === true ||
     Boolean(settings?.opencodeSessionCookie?.trim()) ||
-    // Antigravity's durable signal requires geminiCliOAuthEnabled, so it is
-    // already covered by the gemini term above.
+    settings?.antigravityUsageConfigured === true ||
     settings?.minimaxCookieConfigured === true ||
     settings?.grokAuthConfigured === true
   )
@@ -101,10 +96,7 @@ export function hasUsageProviderSettingsForProvider(
     return Boolean(settings.opencodeSessionCookie?.trim())
   }
   if (providerId === 'antigravity') {
-    // Why: the Antigravity snapshot mirrors the Gemini fetch, which stays
-    // 'unavailable' until the user opts into Gemini CLI OAuth. Without that
-    // gate the default-on checked item would pin a permanently dead bar.
-    return settings.antigravityUsageConfigured === true && settings.geminiCliOAuthEnabled === true
+    return settings.antigravityUsageConfigured === true
   }
   if (providerId === 'minimax') {
     return settings.minimaxCookieConfigured === true

--- a/src/shared/rate-limit-types.ts
+++ b/src/shared/rate-limit-types.ts
@@ -63,7 +63,7 @@ export type ProviderRateLimits = {
   fableWeekly?: RateLimitWindow | null
   /** 30-day monthly window (OpenCode Go, Grok unified billing), null if not available. */
   monthly?: RateLimitWindow | null
-  /** Named per-model buckets (Gemini only). */
+  /** Named provider-specific quota buckets. */
   buckets?: RateLimitBucket[]
   /** Available earned Codex rate-limit reset credits, if reported. */
   rateLimitResetCredits?: {


### PR DESCRIPTION
## ELI5

Orca currently labels a copy of Gemini CLI usage as Antigravity usage. This change asks the installed Antigravity CLI for its own quota report instead, so Orca shows the real Gemini and Claude/GPT five-hour and weekly limits without needing Gemini CLI OAuth.

## What Changed

- Added an Antigravity usage fetcher that runs the public Agy print-mode interface:

  ```text
  agy -p /usage --output-format json --print-timeout 20s
  ```

- Strictly parses the four native Agy quota identities: Gemini 5h/weekly and Claude/GPT 5h/weekly.
- Converts each `remaining_fraction` into Orca's used percentage and preserves each independent reset timestamp.
- Fetches Antigravity independently from Gemini in the rate-limit service.
- Removes Gemini OAuth as a visibility prerequisite for the Antigravity usage row.
- Keeps the existing Gemini usage integration unchanged for users who still configure it.
- Uses the tightest five-hour bucket as the existing compact/session summary while Detailed mode renders all four named buckets.

## Why

The current implementation copies the Gemini provider snapshot and changes only its provider ID, so the Antigravity row can show the wrong product's quotas or fail when legacy Gemini OAuth credentials are absent.

Agy 1.1.18 exposes its native usage payload through public non-interactive print mode. This is smaller and less coupled than the older open implementations in #11536, #12095, and #14571: it does not inspect credentials or keychains and does not discover or call a private local LanguageServer through logs, process tables, ports, TLS exceptions, or CSRF tokens.

The live command completed in about 6.5 seconds on Windows, reported zero input/output tokens, and did not change Agy history or create a conversation. Orca bounds it with cancellation, a 25-second process timeout, and a 1 MiB output cap.

## Linked Issue

Fixes #9122

## Visual Proof

N/A — no layout or interaction component changed. The existing named-bucket renderer is reused; a render regression test verifies all four Antigravity labels and percentages are present.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

Validated on Windows 11 with Antigravity CLI 1.1.18:

- `agy -p /usage --output-format json --print-timeout 1m`: success, two groups/four buckets, zero model tokens, no history/conversation mutation
- Focused Vitest: 4 files / 64 tests passed
- `pnpm typecheck`: passed
- Changed-file oxlint: passed
- Full lint source-quality, type-aware quality, reliability, and max-lines stages: passed
- Localization catalog, extraction, and coverage checks: passed
- `pnpm run build:desktop`: passed
- `pnpm run build:native`: passed
- Standard `pnpm test` preflight is unavailable on this machine because the optional `windows-native-registry` package requires a Visual Studio C++ toolchain. A direct aggregate Vitest attempt encountered unrelated existing Windows failures in symlink, watcher, SSH, relay, and daemon suites; the affected Antigravity suites pass.
- Full `pnpm lint` reaches the existing generated-skill-manifest check, which reports stale skill artifacts on current `main`; this PR does not touch skill artifacts.

## AI Disclosure

OpenAI Codex (GPT-5) assisted with implementation, tests, validation, and review.

## Review

- Cross-platform: resolves `agy` through Orca's shared CLI resolver and starts it through the shared no-shell process wrapper, including Windows `.cmd`/`.bat` handling and hidden-console behavior.
- SSH/remote/local: usage remains explicitly host-local, matching the current host-level Antigravity provider boundary; it does not silently run against or infer state from a remote SSH workspace.
- Agent/integration compatibility: Gemini agent support and the existing Gemini usage provider remain unchanged. Unknown future Agy buckets are ignored while recognized buckets remain usable.
- Performance: one cancellable process runs alongside other provider fetches, with a 20-second Agy deadline, 25-second hard process timeout, and bounded output.
- UI: reuses the existing provider and named-bucket components; Detailed mode shows four independent buckets and compact/session surfaces retain one summary.
- Security: fixed argument array, no shell interpolation, no credential/keychain reads, no account identifiers logged, strict JSON shape checks, and known bucket allowlisting.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Author X handle: @mikeascendx

The CLI-backed approach requires an Agy version that supports structured print-mode slash-command output. Older versions fail safely as unavailable/parse errors rather than falling back to Gemini data.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` all pass (see Testing for passed checks and environment/baseline blockers)
