### PR TITLE
fix(cli): attach a reclaim command to each residual resource in mutation recovery

### DIFF
--- a/src/cli/handlers/orchestration-gate-cli.test.ts
+++ b/src/cli/handlers/orchestration-gate-cli.test.ts
@@ -230,11 +230,13 @@ describe('orchestration gate commands carry caller identity', () => {
     expect(output.error.message).toMatch(/Residual resources:.*repo::child.*term_worker/)
     // Why (#15944): the residue is actionable, not just named — each resource gets its
     // reclaim command, after the --retry-request line it must not preempt.
+    // The ids are shell-quoted inside the pasted command ("term_worker" on win32,
+    // 'term_worker' elsewhere), so match with optional quotes around them.
     expect(output.error.message).toMatch(
-      /--retry-request mutation_1[\s\S]*orca terminal close --terminal term_worker --json/
+      /--retry-request mutation_1[\s\S]*orca terminal close --terminal ['"]?term_worker['"]? --json/
     )
     expect(output.error.message).toMatch(
-      /orca worktree rm --worktree id:repo::child --force --json/
+      /orca worktree rm --worktree ['"]?id:repo::child['"]? --force --json/
     )
     expect(output.error.message).not.toMatch(/restart Orca/i)
     expect(output.error.data).toMatchObject({

--- a/src/cli/handlers/orchestration-gate-cli.test.ts
+++ b/src/cli/handlers/orchestration-gate-cli.test.ts
@@ -228,6 +228,14 @@ describe('orchestration gate commands carry caller identity', () => {
     expect(output.error.message).toContain('may already have taken effect')
     expect(output.error.message).toContain('Failed stage: dispatch_input')
     expect(output.error.message).toMatch(/Residual resources:.*repo::child.*term_worker/)
+    // Why (#15944): the residue is actionable, not just named — each resource gets its
+    // reclaim command, after the --retry-request line it must not preempt.
+    expect(output.error.message).toMatch(
+      /--retry-request mutation_1[\s\S]*orca terminal close --terminal term_worker --json/
+    )
+    expect(output.error.message).toMatch(
+      /orca worktree rm --worktree id:repo::child --force --json/
+    )
     expect(output.error.message).not.toMatch(/restart Orca/i)
     expect(output.error.data).toMatchObject({
       orchestrationRequestId: 'mutation_1',

--- a/src/cli/orchestration-mutation-recovery.test.ts
+++ b/src/cli/orchestration-mutation-recovery.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { quoteShellToken } from '../shared/ephemeral-vm-recipe-process'
 import { residualResourceRecoveryLines } from './orchestration-mutation-recovery'
 
 describe('residualResourceRecoveryLines', () => {
@@ -12,10 +13,14 @@ describe('residualResourceRecoveryLines', () => {
 
     expect(lines).toHaveLength(2)
     expect(lines[0]).toBe(
-      'If terminal term_worker is still residual after the outcome is settled: orca terminal close --terminal term_worker --json.'
+      `If terminal term_worker is still residual after the outcome is settled: orca terminal close --terminal ${quoteShellToken(
+        'term_worker'
+      )} --json.`
     )
     expect(lines[1]).toBe(
-      'If worktree repo::child is still residual after the outcome is settled: orca worktree rm --worktree id:repo::child --force --json (verify nothing valuable was written first).'
+      `If worktree repo::child is still residual after the outcome is settled: orca worktree rm --worktree ${quoteShellToken(
+        'id:repo::child'
+      )} --force --json (verify nothing valuable was written first).`
     )
   })
 
@@ -33,20 +38,21 @@ describe('residualResourceRecoveryLines', () => {
   it('quotes ids shell-safely so copied commands survive spaces and metacharacters', () => {
     const lines = residualResourceRecoveryLines([
       { kind: 'worktree', id: 'repo::D:/workspaces/my work/child; rm -rf /' },
-      { kind: 'terminal', id: "term_ev'il" }
+      { kind: 'terminal', id: "term_ev" + "'" + "il" }
     ])
 
-    // The displayed name stays raw; the pasted command quotes the id (posix form when
-    // not on win32 — the win32 branch double-quotes, also covered by quoteShellToken's
-    // own tests).
+    // The displayed name stays raw; the pasted command quotes the id (posix
+    // single-quoting off win32, cmd.exe double-quoting on it).
     if (process.platform !== 'win32') {
       expect(lines[0]).toContain(
-        `orca worktree rm --worktree 'id:repo::D:/workspaces/my work/child; rm -rf /' --force --json`
+        "orca worktree rm --worktree " + "'" + "id:repo::D:/workspaces/my work/child; rm -rf /" + "'" + " --force --json"
       )
-      expect(lines[1]).toContain(`orca terminal close --terminal 'term_ev'''il' --json`)
+      expect(lines[1]).toContain(
+        "orca terminal close --terminal " + "'" + "term_ev" + "'\\''" + "il" + "'" + " --json"
+      )
     } else {
       expect(lines[0]).toContain('--worktree "id:repo::D:/workspaces/my work/child; rm -rf /"')
-      expect(lines[1]).toContain('--terminal "term_ev'il"')
+      expect(lines[1]).toContain('--terminal "term_ev' + "'" + 'il"')
     }
   })
 

--- a/src/cli/orchestration-mutation-recovery.test.ts
+++ b/src/cli/orchestration-mutation-recovery.test.ts
@@ -30,6 +30,26 @@ describe('residualResourceRecoveryLines', () => {
     ).toEqual([])
   })
 
+  it('quotes ids shell-safely so copied commands survive spaces and metacharacters', () => {
+    const lines = residualResourceRecoveryLines([
+      { kind: 'worktree', id: 'repo::D:/workspaces/my work/child; rm -rf /' },
+      { kind: 'terminal', id: "term_ev'il" }
+    ])
+
+    // The displayed name stays raw; the pasted command quotes the id (posix form when
+    // not on win32 — the win32 branch double-quotes, also covered by quoteShellToken's
+    // own tests).
+    if (process.platform !== 'win32') {
+      expect(lines[0]).toContain(
+        `orca worktree rm --worktree 'id:repo::D:/workspaces/my work/child; rm -rf /' --force --json`
+      )
+      expect(lines[1]).toContain(`orca terminal close --terminal 'term_ev'''il' --json`)
+    } else {
+      expect(lines[0]).toContain('--worktree "id:repo::D:/workspaces/my work/child; rm -rf /"')
+      expect(lines[1]).toContain('--terminal "term_ev'il"')
+    }
+  })
+
   it('returns nothing for absent or non-array residue', () => {
     expect(residualResourceRecoveryLines(undefined)).toEqual([])
     expect(residualResourceRecoveryLines(null)).toEqual([])

--- a/src/cli/orchestration-mutation-recovery.test.ts
+++ b/src/cli/orchestration-mutation-recovery.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { residualResourceRecoveryLines } from './orchestration-mutation-recovery'
+
+describe('residualResourceRecoveryLines', () => {
+  // Why (#15944): the receipt used to name residual resources without any action for them,
+  // and the orchestration guide ends at "inspect" — the reclaim command must ride along.
+  it('maps terminal and worktree residue to their reclaim commands', () => {
+    const lines = residualResourceRecoveryLines([
+      { kind: 'terminal', role: 'agent', id: 'term_worker', surface: 'visible' },
+      { kind: 'worktree', action: 'created_child', id: 'repo::child' }
+    ])
+
+    expect(lines).toHaveLength(2)
+    expect(lines[0]).toBe(
+      'If terminal term_worker is still residual after the outcome is settled: orca terminal close --terminal term_worker --json.'
+    )
+    expect(lines[1]).toBe(
+      'If worktree repo::child is still residual after the outcome is settled: orca worktree rm --worktree id:repo::child --force --json (verify nothing valuable was written first).'
+    )
+  })
+
+  it('skips resources without an id and kinds it cannot advise on', () => {
+    expect(
+      residualResourceRecoveryLines([
+        { kind: 'terminal' },
+        { kind: 'setup', id: 'term_setup' },
+        { id: 'term_orphan' },
+        null
+      ])
+    ).toEqual([])
+  })
+
+  it('returns nothing for absent or non-array residue', () => {
+    expect(residualResourceRecoveryLines(undefined)).toEqual([])
+    expect(residualResourceRecoveryLines(null)).toEqual([])
+    expect(residualResourceRecoveryLines('terminal')).toEqual([])
+    expect(residualResourceRecoveryLines({})).toEqual([])
+  })
+})

--- a/src/cli/orchestration-mutation-recovery.ts
+++ b/src/cli/orchestration-mutation-recovery.ts
@@ -16,9 +16,44 @@ export function orchestrationMutationRecoveryError(error: unknown): unknown {
     typeof data?.failedStage === 'string' ? `Failed stage: ${data.failedStage}.` : undefined,
     Array.isArray(data?.residualResources)
       ? `Residual resources: ${JSON.stringify(data.residualResources)}.`
-      : undefined
-  ].filter((line): line is string => line !== undefined)
+      : undefined,
+    ...residualResourceRecoveryLines(data?.residualResources)
+  ]
+    .filter((line): line is string => line !== undefined)
   return new RuntimeClientError(error.code, message.join('\n'), error.data)
+}
+
+/**
+ * Why (#15944): the receipt names what a failed mutation left behind but not what to do with
+ * it — the mutation got a recovery command (`--retry-request`), the residue got nothing, and
+ * the orchestration guide ends at "inspect residualResources". Attach the reclaim command per
+ * kind so a coordinator can clear the residue without reading source.
+ *
+ * The commands intentionally come AFTER the `--retry-request` line: a retried mutation may
+ * adopt the same resources, so they are only for residue that survives the settled outcome.
+ */
+export function residualResourceRecoveryLines(residualResources: unknown): string[] {
+  if (!Array.isArray(residualResources)) {
+    return []
+  }
+  const lines: string[] = []
+  for (const resource of residualResources) {
+    const record = objectRecord(resource)
+    const id = typeof record?.id === 'string' && record.id.length > 0 ? record.id : null
+    if (!id) {
+      continue
+    }
+    if (record?.kind === 'terminal') {
+      lines.push(
+        `If terminal ${id} is still residual after the outcome is settled: orca terminal close --terminal ${id} --json.`
+      )
+    } else if (record?.kind === 'worktree') {
+      lines.push(
+        `If worktree ${id} is still residual after the outcome is settled: orca worktree rm --worktree id:${id} --force --json (verify nothing valuable was written first).`
+      )
+    }
+  }
+  return lines
 }
 
 function isUnknownMutationOutcomeCode(code: string): boolean {

--- a/src/cli/orchestration-mutation-recovery.ts
+++ b/src/cli/orchestration-mutation-recovery.ts
@@ -1,3 +1,4 @@
+import { quoteShellToken } from '../shared/ephemeral-vm-recipe-process'
 import { RuntimeClientError } from './runtime-client'
 
 export function orchestrationMutationRecoveryError(error: unknown): unknown {
@@ -43,13 +44,17 @@ export function residualResourceRecoveryLines(residualResources: unknown): strin
     if (!id) {
       continue
     }
+    // Why quoting: the id is interpolated into a command meant to be copied and pasted —
+    // a worktree id embeds a path, which can carry spaces or shell metacharacters.
+    const quotedId = quoteShellToken(id)
     if (record?.kind === 'terminal') {
       lines.push(
-        `If terminal ${id} is still residual after the outcome is settled: orca terminal close --terminal ${id} --json.`
+        `If terminal ${id} is still residual after the outcome is settled: orca terminal close --terminal ${quotedId} --json.`
       )
     } else if (record?.kind === 'worktree') {
+      const quotedSelector = quoteShellToken(`id:${id}`)
       lines.push(
-        `If worktree ${id} is still residual after the outcome is settled: orca worktree rm --worktree id:${id} --force --json (verify nothing valuable was written first).`
+        `If worktree ${id} is still residual after the outcome is settled: orca worktree rm --worktree ${quotedSelector} --force --json (verify nothing valuable was written first).`
       )
     }
   }


### PR DESCRIPTION
## What

`orchestrationMutationRecoveryError` now appends a reclaim command for each residual resource after the `--retry-request` advice:

- `kind: "terminal"` → `If terminal <handle> is still residual after the outcome is settled: orca terminal close --terminal <handle> --json.`
- `kind: "worktree"` → `If worktree <id> is still residual after the outcome is settled: orca worktree rm --worktree id:<id> --force --json (verify nothing valuable was written first).`

Resources without an id, or of kinds there is no safe blanket advice for, are skipped rather than guessed at.

## Why (issue #15944)

The unknown-outcome receipt names what a failed mutation left behind but attaches no action to it: the mutation itself gets the `--retry-request` recovery command while the residue gets a bare `JSON.stringify`, and the orchestration guide's instruction ends at "inspect its `stage`, `effects`, and `residualResources`". The commands that would clear the residue exist in the CLI (`terminal close` since well before v1.4.186; `worktree rm`) but a coordinator reading the receipt would never learn them — the guide's only mention of `terminal close` is the prohibition against substituting it for `worker-release`.

The commands are deliberately placed **after** the retry advice and phrased conditionally ("if still residual after the outcome is settled"): a replayed mutation may adopt the same resources, so the residue should only be reclaimed once `--retry-request` (or a deliberate fresh attempt) has settled the outcome. That also keeps the receipt consistent with the guide's release discipline.

## Testing

- New `src/cli/orchestration-mutation-recovery.test.ts`: terminal + worktree residue map to their exact reclaim lines; id-less / unknown-kind / non-array inputs yield no lines.
- The existing end-to-end recovery test (`orchestration-gate-cli.test.ts`) now also asserts the reclaim commands appear in the printed error message, after the `--retry-request` line.
- Diff-verified: with only `orchestration-mutation-recovery.ts` stashed, the extended e2e assertions fail (no reclaim commands in the message); with it applied, both files pass and `pnpm run typecheck` is clean.

Fixes #15944
