### PR TITLE
fix(terminal): repaint OpenCode WebGL after hide/reveal

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -164,7 +164,7 @@ import {
   resolveWindowsShellOverride
 } from '@/lib/pane-manager/windows-pty-compatibility'
 import { recordTerminalOutput } from '@/lib/pane-manager/pane-scroll'
-import { forceFullViewportPresent } from '@/lib/pane-manager/terminal-render-pause-release'
+import { presentPaneViewport } from '@/lib/pane-manager/pane-webgl-renderer'
 import { ensureArabicShapingJoinerForText } from '@/lib/pane-manager/terminal-arabic-shaping-joiner'
 import { clearTerminalScrollbackAndFollowOutput } from '@/lib/pane-manager/terminal-scrollback-clear'
 import {
@@ -7471,7 +7471,7 @@ export function connectPanePty(
             // buffer. After replay parses, one full present so OpenCode's
             // alt-screen footer cannot composite on the stale framebuffer.
             if (deps.isVisibleRef.current) {
-              forceFullViewportPresent(pane.terminal)
+              presentPaneViewport(pane)
               recordTerminalFreezeBreadcrumb('stale-pixel-restore-present', {
                 paneId: pane.id
               })

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -164,6 +164,7 @@ import {
   resolveWindowsShellOverride
 } from '@/lib/pane-manager/windows-pty-compatibility'
 import { recordTerminalOutput } from '@/lib/pane-manager/pane-scroll'
+import { forceFullViewportPresent } from '@/lib/pane-manager/terminal-render-pause-release'
 import { ensureArabicShapingJoinerForText } from '@/lib/pane-manager/terminal-arabic-shaping-joiner'
 import { clearTerminalScrollbackAndFollowOutput } from '@/lib/pane-manager/terminal-scrollback-clear'
 import {
@@ -7466,6 +7467,15 @@ export function connectPanePty(
             recordRendererOrderedSeq(snapshot)
             recordTerminalOutput(pane.terminal)
             await waitForTerminalReplayWritesParsed(pane.terminal)
+            // Why: visibility-resume's atlas wipe can paint the pre-restore
+            // buffer. After replay parses, one full present so OpenCode's
+            // alt-screen footer cannot composite on the stale framebuffer.
+            if (deps.isVisibleRef.current) {
+              forceFullViewportPresent(pane.terminal)
+              recordTerminalFreezeBreadcrumb('stale-pixel-restore-present', {
+                paneId: pane.id
+              })
+            }
           },
           {
             shouldRestore: () =>

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.test.ts
@@ -87,6 +87,7 @@ describe('resumeTerminalVisibility reveal repaint', () => {
     resumeTerminalVisibility(resumeArgs(manager, true))
 
     expect(manager.scheduleRevealRepaint).toHaveBeenCalledTimes(1)
+    expect(manager.scheduleRevealPresent).toHaveBeenCalledTimes(1)
     expect(manager.resumeRendering).not.toHaveBeenCalled()
     expect(scheduleTabRevealWebglAtlasRecovery).toHaveBeenCalledTimes(1)
   })
@@ -191,6 +192,25 @@ describe('resumeTerminalVisibility reveal repaint', () => {
 
     expect(manager.fitAllRevealedPanes).toHaveBeenCalledTimes(1)
     expect(manager.fitAllPanes).not.toHaveBeenCalled()
+  })
+
+  it('repairs WebGL canvas backing-store dpr on window wake', () => {
+    // Clamshell undock: dpr changes while the pane stayed "visible" with a
+    // stale backing store; tab-reveal is not in the path.
+    const first = { terminal: { name: 'pane-a' } }
+    const second = { terminal: { name: 'pane-b' } }
+    const manager = createManager()
+    manager.getPanes.mockReturnValue([first, second])
+
+    recoverVisibleTerminalWindowWake({
+      manager: manager as never as PaneManager,
+      isActive: true,
+      clearGlyphAtlases: false
+    })
+
+    expect(repairPaneWebglCanvasDprMismatch).toHaveBeenCalledTimes(2)
+    expect(repairPaneWebglCanvasDprMismatch).toHaveBeenNthCalledWith(1, first)
+    expect(repairPaneWebglCanvasDprMismatch).toHaveBeenNthCalledWith(2, second)
   })
 
   it('latches viewport intent before refocus recovery flushes streaming output', async () => {

--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -17,6 +17,7 @@ import { focusActivePane } from './pane-helpers'
 import { scheduleTabRevealWebglAtlasRecovery } from './terminal-webgl-atlas-recovery'
 import { flushDeferredPaneMetricOptionsIfMeasurable } from '@/lib/pane-manager/pane-fit'
 import { repairPaneWebglCanvasDprMismatch } from '@/lib/pane-manager/terminal-canvas-dpr-repair'
+import { presentPaneViewport } from '@/lib/pane-manager/pane-webgl-renderer'
 
 const VISIBLE_RESUME_FLUSH_CHARS = 256 * 1024
 const WINDOW_WAKE_FLUSH_CHARS = 64 * 1024
@@ -90,6 +91,10 @@ export function resumeTerminalVisibility({
       requestLightTabBacklogRecovery(manager)
       // Why: reveal is the lifecycle boundary that owns hidden renderer repair.
       scheduleTabRevealWebglAtlasRecovery()
+      // Why: the atlas burst often runs while this tab is still display:none
+      // (paused=true needFull=true in the Dev repro). A present-only pass after
+      // overlay layout rebuilds the WebGL model without a second atlas wipe.
+      manager.scheduleRevealPresent()
       if (flushedDeferredMetrics) {
         // Why: the light path normally skips fitting, but flushed metrics changed
         // cell size — refit so cols/rows match before the overlay settles.
@@ -161,6 +166,13 @@ export function recoverVisibleTerminalWindowWake({
   // Why: backlog writes can expose transient viewport geometry while parsing.
   syncTerminalViewportIntents(manager)
   for (const pane of manager.getPanes()) {
+    // Why: clamshell undock / monitor move changes devicePixelRatio while the
+    // pane can stay "visible" with a stale WebGL backing store. The addon's
+    // device-pixel observer misses that (no CSS-box change, or no box while
+    // the lid was closed). Repair here — not only on tab reveal.
+    if (repairPaneWebglCanvasDprMismatch(pane)) {
+      presentPaneViewport(pane)
+    }
     requestTerminalBacklogRecovery(pane.terminal)
     flushTerminalOutput(pane.terminal, { maxChars: WINDOW_WAKE_FLUSH_CHARS })
     // Why: window blur fires mouseleave, clearing xterm's current link but not

--- a/src/renderer/src/components/terminal-pane/use-terminal-window-wake-recovery.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-window-wake-recovery.test.ts
@@ -3,12 +3,26 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { renderHook } from '@testing-library/react'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 
-const { recoverVisibleTerminalWindowWakeMock } = vi.hoisted(() => ({
-  recoverVisibleTerminalWindowWakeMock: vi.fn()
+const {
+  recoverVisibleTerminalWindowWakeMock,
+  repairPaneWebglCanvasDprMismatchMock,
+  presentPaneViewportMock
+} = vi.hoisted(() => ({
+  recoverVisibleTerminalWindowWakeMock: vi.fn(),
+  repairPaneWebglCanvasDprMismatchMock: vi.fn(() => false),
+  presentPaneViewportMock: vi.fn()
 }))
 
 vi.mock('./terminal-visibility-resume', () => ({
   recoverVisibleTerminalWindowWake: recoverVisibleTerminalWindowWakeMock
+}))
+
+vi.mock('@/lib/pane-manager/terminal-canvas-dpr-repair', () => ({
+  repairPaneWebglCanvasDprMismatch: repairPaneWebglCanvasDprMismatchMock
+}))
+
+vi.mock('@/lib/pane-manager/pane-webgl-renderer', () => ({
+  presentPaneViewport: presentPaneViewportMock
 }))
 
 import { useTerminalWindowWakeRecovery } from './use-terminal-window-wake-recovery'
@@ -29,6 +43,9 @@ describe('useTerminalWindowWakeRecovery', () => {
   beforeEach(() => {
     systemResumedCallback = null
     recoverVisibleTerminalWindowWakeMock.mockClear()
+    repairPaneWebglCanvasDprMismatchMock.mockClear()
+    presentPaneViewportMock.mockClear()
+    repairPaneWebglCanvasDprMismatchMock.mockReturnValue(false)
     unsubscribeSystemResumed.mockClear()
     onSystemResumed.mockClear()
     resetTerminalFreezeBreadcrumbsForTesting()
@@ -179,5 +196,27 @@ describe('useTerminalWindowWakeRecovery', () => {
     renderWakeRecoveryHook(false)
 
     expect(onSystemResumed).not.toHaveBeenCalled()
+  })
+
+  it('repairs WebGL canvas dpr on window resize without wiping the glyph atlas', () => {
+    // Chromium emits resize when devicePixelRatio changes (undock / monitor
+    // move) even if the CSS box is unchanged.
+    const pane = { id: 1, terminal: {} }
+    const resizeManager = { getPanes: () => [pane] } as unknown as PaneManager
+    repairPaneWebglCanvasDprMismatchMock.mockReturnValue(true)
+    renderHook(() =>
+      useTerminalWindowWakeRecovery({
+        isVisible: true,
+        managerRef: { current: resizeManager },
+        isActiveRef: { current: true },
+        isVisibleRef: { current: true }
+      })
+    )
+
+    window.dispatchEvent(new Event('resize'))
+
+    expect(repairPaneWebglCanvasDprMismatchMock).toHaveBeenCalledWith(pane)
+    expect(presentPaneViewportMock).toHaveBeenCalledWith(pane)
+    expect(recoverVisibleTerminalWindowWakeMock).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/terminal-pane/use-terminal-window-wake-recovery.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-window-wake-recovery.ts
@@ -1,6 +1,8 @@
 import { useEffect } from 'react'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
 import { recoverVisibleTerminalWindowWake } from './terminal-visibility-resume'
+import { repairPaneWebglCanvasDprMismatch } from '@/lib/pane-manager/terminal-canvas-dpr-repair'
+import { presentPaneViewport } from '@/lib/pane-manager/pane-webgl-renderer'
 import { recordTerminalFreezeBreadcrumb } from './terminal-freeze-breadcrumbs'
 import type { IDisposable } from '@xterm/xterm'
 
@@ -111,7 +113,22 @@ export function useTerminalWindowWakeRecovery({
         recoverVisibleWake(true, 'system-resumed')
       }
     }
+    const onWindowResize = (): void => {
+      // Why: Chromium emits window resize on devicePixelRatio changes even when
+      // the CSS box is unchanged (monitor move / undock). xterm's own observer
+      // misses that while the canvas had no box (laptop lid closed).
+      const manager = managerRef.current
+      if (!manager || !isVisibleRef.current) {
+        return
+      }
+      for (const pane of manager.getPanes?.() ?? []) {
+        if (repairPaneWebglCanvasDprMismatch(pane)) {
+          presentPaneViewport(pane)
+        }
+      }
+    }
     window.addEventListener('focus', onFocus)
+    window.addEventListener('resize', onWindowResize)
     if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') {
       document.addEventListener('visibilitychange', onVisibilityChange)
     }
@@ -126,6 +143,7 @@ export function useTerminalWindowWakeRecovery({
     return () => {
       cancelScheduledWakeRecovery()
       window.removeEventListener('focus', onFocus)
+      window.removeEventListener('resize', onWindowResize)
       if (typeof document !== 'undefined' && typeof document.removeEventListener === 'function') {
         document.removeEventListener('visibilitychange', onVisibilityChange)
       }

--- a/src/renderer/src/lib/pane-manager/pane-manager-registry.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-registry.test.ts
@@ -85,6 +85,38 @@ describe('pane manager registry', () => {
     expect(order).toEqual(['first-reset', 'second-reset', 'first-refresh', 'second-refresh'])
   })
 
+  it('clears every recovered atlas before presenting any pane', () => {
+    // Why: per-pane clear+present interleaves a present against atlas generation
+    // N with the next pane's wipe to N+1. The first OpenCode column then keeps
+    // pre-hide footer pixels (#15813). Wipe first, present once the generation
+    // is final.
+    const order: string[] = []
+    const first = {
+      resetWebglTextureAtlases: vi.fn<() => void>(() => order.push('first-reset')),
+      clearWebglTextureAtlases: vi.fn<() => void>(() => order.push('first-clear')),
+      presentForcedViewports: vi.fn<() => void>(() => order.push('first-present')),
+      refreshAllPanes: vi.fn<() => void>(() => order.push('first-refresh')),
+      isVisibleForAtlasRecovery: () => true
+    }
+    const second = {
+      resetWebglTextureAtlases: vi.fn<() => void>(() => order.push('second-reset')),
+      clearWebglTextureAtlases: vi.fn<() => void>(() => order.push('second-clear')),
+      presentForcedViewports: vi.fn<() => void>(() => order.push('second-present')),
+      refreshAllPanes: vi.fn<() => void>(() => order.push('second-refresh')),
+      isVisibleForAtlasRecovery: () => true
+    }
+    registerLivePaneManager(first)
+    registeredManagers.push(first)
+    registerLivePaneManager(second)
+    registeredManagers.push(second)
+
+    resetAndRefreshAllTerminalWebglAtlases()
+
+    expect(order).toEqual(['first-clear', 'second-clear', 'first-present', 'second-present'])
+    expect(first.resetWebglTextureAtlases).not.toHaveBeenCalled()
+    expect(second.refreshAllPanes).not.toHaveBeenCalled()
+  })
+
   it('bounds atlas recovery to visible managers', () => {
     const visible = {
       resetWebglTextureAtlases: vi.fn<() => void>(),
@@ -111,6 +143,41 @@ describe('pane manager registry', () => {
       hidden.every((manager) => manager.resetWebglTextureAtlases.mock.calls.length === 0)
     ).toBe(true)
     expect(hidden.every((manager) => manager.refreshAllPanes.mock.calls.length === 0)).toBe(true)
+  })
+
+  it('rebuilds hidden managers that still hold a retained WebGL atlas', () => {
+    // Why: clearTextureAtlas() is module-global. Skipping hidden retained
+    // renderers leaves their vertex model pointing at evicted glyph pages
+    // until reveal, which is the OpenCode stale-footer class (#15813).
+    const visible = {
+      resetWebglTextureAtlases: vi.fn<() => void>(),
+      refreshAllPanes: vi.fn<() => void>(),
+      isVisibleForAtlasRecovery: () => true
+    }
+    const hiddenRetained = {
+      resetWebglTextureAtlases: vi.fn<() => void>(),
+      refreshAllPanes: vi.fn<() => void>(),
+      isVisibleForAtlasRecovery: () => false,
+      hasRetainedWebgl: () => true
+    }
+    const hiddenDisposed = {
+      resetWebglTextureAtlases: vi.fn<() => void>(),
+      refreshAllPanes: vi.fn<() => void>(),
+      isVisibleForAtlasRecovery: () => false,
+      hasRetainedWebgl: () => false
+    }
+    registerLivePaneManager(visible)
+    registeredManagers.push(visible)
+    registerLivePaneManager(hiddenRetained)
+    registeredManagers.push(hiddenRetained)
+    registerLivePaneManager(hiddenDisposed)
+    registeredManagers.push(hiddenDisposed)
+
+    resetAndRefreshAllTerminalWebglAtlases()
+
+    expect(visible.resetWebglTextureAtlases).toHaveBeenCalledOnce()
+    expect(hiddenRetained.resetWebglTextureAtlases).toHaveBeenCalledOnce()
+    expect(hiddenDisposed.resetWebglTextureAtlases).not.toHaveBeenCalled()
   })
 
   it('continues reset-and-refresh recovery when one manager throws', () => {

--- a/src/renderer/src/lib/pane-manager/pane-manager-registry.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-registry.ts
@@ -4,12 +4,15 @@ import type { PaneRenderingDiagnostics } from './pane-manager-types'
 
 type RegisteredPaneManager = {
   resetWebglTextureAtlases(): void
+  clearWebglTextureAtlases?: () => void
+  presentForcedViewports?: () => void
   fitAllPanes?: () => void
   refreshAllPanes?: () => void
   getRenderingDiagnostics?: () => PaneRenderingDiagnostics[]
   getPanes?: (limit?: number) => { id: number; terminal: unknown }[]
   getPaneCount?: () => number
   isVisibleForAtlasRecovery?: () => boolean
+  hasRetainedWebgl?: () => boolean
   scheduleRevealPresent?: () => void
 }
 
@@ -48,21 +51,42 @@ export function resetAllTerminalWebglAtlases(): void {
   }
 }
 
+function shouldRebuildSharedAtlas(manager: RegisteredPaneManager): boolean {
+  if (manager.isVisibleForAtlasRecovery?.() !== false) {
+    return true
+  }
+  // Why: clearTextureAtlas() is module-global. Hidden worktrees that kept
+  // their WebGL addon still hold a vertex model into those pages; skipping
+  // them is the OpenCode stale-footer class after a workspace switch (#15813).
+  return manager.hasRetainedWebgl?.() === true
+}
+
 export function resetAndRefreshAllTerminalWebglAtlases(reason?: string): void {
   // Why: the atlas wipe is the heavy recovery path; recording it lets a freeze
   // report show whether a post-wake repaint actually ran. Silent breadcrumb.
-  const recoveryManagers = Array.from(liveManagers).filter(
-    (manager) => manager.isVisibleForAtlasRecovery?.() !== false
-  )
+  const recoveryManagers = Array.from(liveManagers).filter(shouldRebuildSharedAtlas)
+  const retainedHidden = Array.from(liveManagers).filter(
+    (manager) =>
+      manager.isVisibleForAtlasRecovery?.() === false && manager.hasRetainedWebgl?.() === true
+  ).length
   recordTerminalWebglDiagnostic('webgl-atlas-reset', {
     managers: recoveryManagers.length,
     mountedManagers: liveManagers.size,
+    retainedHidden,
     ...(reason ? { reason } : {})
   })
   const resetManagers: RegisteredPaneManager[] = []
+  // Why: clearTextureAtlas() is module-global. Clearing then presenting per
+  // pane interleaves a present against generation N with the next pane's wipe
+  // to N+1, so the first OpenCode column keeps pre-hide footer pixels (#15813).
+  // Wipe every recovered atlas first; present only once the generation is final.
   for (const manager of recoveryManagers) {
     try {
-      manager.resetWebglTextureAtlases()
+      if (manager.clearWebglTextureAtlases) {
+        manager.clearWebglTextureAtlases()
+      } else {
+        manager.resetWebglTextureAtlases()
+      }
       resetManagers.push(manager)
     } catch {
       // Why: recovery is best-effort during pane teardown; a disposed manager
@@ -71,7 +95,11 @@ export function resetAndRefreshAllTerminalWebglAtlases(reason?: string): void {
   }
   for (const manager of resetManagers) {
     try {
-      manager.refreshAllPanes?.()
+      if (manager.presentForcedViewports) {
+        manager.presentForcedViewports()
+      } else {
+        manager.refreshAllPanes?.()
+      }
     } catch {
       // Why: a pane can unmount between atlas reset and repaint; later
       // managers still need to repaint from their xterm buffers.

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -26,6 +26,8 @@ import { applyTerminalGpuAcceleration } from './pane-terminal-gpu-acceleration'
 import { rebuildAttachedWebgl } from './pane-webgl-reattach'
 import {
   markPaneComplexScriptOutput,
+  clearPaneWebglTextureAtlases,
+  presentPaneViewports,
   resetPaneWebglTextureAtlases,
   resumePaneRendering,
   setPaneGpuRenderingState,
@@ -280,12 +282,26 @@ export class PaneManager {
     resetPaneWebglTextureAtlases(this.panes.values())
   }
 
+  clearWebglTextureAtlases(): void {
+    clearPaneWebglTextureAtlases(this.panes.values())
+  }
+
+  presentForcedViewports(): void {
+    presentPaneViewports(this.panes.values())
+  }
+
   setAtlasRecoveryVisible(visible: boolean): void {
     this.atlasRecoveryVisible = visible
   }
 
   isVisibleForAtlasRecovery(): boolean {
     return this.atlasRecoveryVisible && !this.destroyed
+  }
+
+  hasRetainedWebgl(): boolean {
+    return (
+      !this.destroyed && Array.from(this.panes.values()).some((pane) => pane.webglAddon != null)
+    )
   }
 
   scheduleRevealRepaint(): void {

--- a/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
+++ b/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
@@ -6,6 +6,8 @@ import {
   disposeWebgl,
   isPaneWebglContextLost,
   markComplexScriptOutput,
+  clearWebglTextureAtlas,
+  presentPaneViewport,
   resetWebglTextureAtlas
 } from './pane-webgl-renderer'
 import { rebuildAttachedWebgl, reattachWebglIfNeeded } from './pane-webgl-reattach'
@@ -99,5 +101,17 @@ export function resumePaneRendering(
 export function resetPaneWebglTextureAtlases(panes: Iterable<ManagedPaneInternal>): void {
   for (const pane of panes) {
     resetWebglTextureAtlas(pane)
+  }
+}
+
+export function clearPaneWebglTextureAtlases(panes: Iterable<ManagedPaneInternal>): void {
+  for (const pane of panes) {
+    clearWebglTextureAtlas(pane)
+  }
+}
+
+export function presentPaneViewports(panes: Iterable<ManagedPaneInternal>): void {
+  for (const pane of panes) {
+    presentPaneViewport(pane)
   }
 }

--- a/src/renderer/src/lib/pane-manager/pane-reveal-repaint.ts
+++ b/src/renderer/src/lib/pane-manager/pane-reveal-repaint.ts
@@ -1,5 +1,6 @@
 import type { ManagedPaneInternal } from './pane-manager-types'
 import { reattachWebglIfNeeded } from './pane-webgl-reattach'
+import { presentPaneViewport } from './pane-webgl-renderer'
 import { resetAndRefreshAllTerminalWebglAtlases } from './pane-manager-registry'
 
 type PaneGetter = () => Iterable<ManagedPaneInternal>
@@ -96,8 +97,6 @@ export function schedulePaneRevealRepaint(getPanes: () => Iterable<ManagedPaneIn
 export function schedulePaneRevealPresent(getPanes: () => Iterable<ManagedPaneInternal>): void {
   forEachPaneOnSettledFrame(getPanes, (pane) => {
     reattachWebglIfNeeded(pane)
-    if (pane.terminal.rows > 0) {
-      pane.terminal.refresh(0, pane.terminal.rows - 1)
-    }
+    presentPaneViewport(pane)
   })
 }

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts
@@ -180,11 +180,28 @@ describe('terminal WebGL addon lifecycle', () => {
   it('falls back to terminal.refresh on an unpaused, unsynchronized pane', () => {
     // Restore-after-replay and other callers use presentPaneViewport even when
     // forceFullViewportPresent is a no-op (not paused, no DEC 2026).
+    const refreshRows = vi.fn()
+    const renderRows = vi.fn()
     const pane = createPane()
+    pane.terminal = {
+      ...pane.terminal,
+      refresh: vi.fn(),
+      _core: {
+        _renderService: {
+          _isPaused: false,
+          _needsFullRefresh: false,
+          refreshRows,
+          _renderer: { value: { renderRows } }
+        },
+        _coreService: { decPrivateModes: { synchronizedOutput: false } }
+      }
+    } as never
 
     presentPaneViewport(pane)
 
     expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 23)
+    expect(refreshRows).not.toHaveBeenCalled()
+    expect(renderRows).not.toHaveBeenCalled()
   })
 
   it('keeps the render pause latched when resetting a pane that has no layout box', () => {

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts
@@ -4,6 +4,7 @@ import type { ManagedPaneInternal } from './pane-manager-types'
 import {
   attachWebgl,
   clearTerminalWebglAttachBackoff,
+  presentPaneViewport,
   resetTerminalWebglSuggestion,
   resetWebglTextureAtlas
 } from './pane-webgl-renderer'
@@ -75,6 +76,7 @@ type FakeRenderService = {
 function createPausedPane(display: 'block' | 'none'): {
   pane: ManagedPaneInternal
   renderService: FakeRenderService
+  setDisplay: (next: 'block' | 'none') => void
 } {
   const pane = createPane()
   const renderService: FakeRenderService = {
@@ -87,7 +89,8 @@ function createPausedPane(display: 'block' | 'none'): {
       }
     })
   }
-  const view = { getComputedStyle: () => ({ display }) }
+  let currentDisplay = display
+  const view = { getComputedStyle: () => ({ display: currentDisplay }) }
   const element = { ownerDocument: { defaultView: view }, parentElement: null }
   pane.container = element as never
   pane.xtermContainer = element as never
@@ -96,7 +99,13 @@ function createPausedPane(display: 'block' | 'none'): {
     refresh: vi.fn(() => renderService.refreshRows(0, pane.terminal.rows - 1)),
     _core: { _renderService: renderService }
   } as never
-  return { pane, renderService }
+  return {
+    pane,
+    renderService,
+    setDisplay: (next) => {
+      currentDisplay = next
+    }
+  }
 }
 
 describe('terminal WebGL addon lifecycle', () => {
@@ -183,6 +192,30 @@ describe('terminal WebGL addon lifecycle', () => {
     expect(renderService._isPaused).toBe(true)
     expect(renderService._needsFullRefresh).toBe(true)
     expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 23)
+  })
+
+  it('retries a display:none present after the overlay actually shows a box', () => {
+    // Dev #15813: light tab reveal traces paused=true needFull=true because the
+    // first present ran while the overlay was still display:none. Selection
+    // later healed the inner rows; only a resize cleared the sides. Flush the
+    // retry after the box exists so the full present actually runs.
+    const queued: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      queued.push(callback)
+      return queued.length
+    })
+    const { pane, renderService, setDisplay } = createPausedPane('none')
+
+    presentPaneViewport(pane)
+
+    expect(renderService._isPaused).toBe(true)
+    expect(queued).toHaveLength(1)
+
+    setDisplay('block')
+    queued.shift()?.(16)
+
+    expect(renderService._isPaused).toBe(false)
+    expect(renderService.refreshRows).toHaveBeenCalledWith(0, 23, true)
   })
 
   it('still forces the paused render through for a pane that has a layout box', () => {

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts
@@ -177,6 +177,16 @@ describe('terminal WebGL addon lifecycle', () => {
     expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 23)
   })
 
+  it('falls back to terminal.refresh on an unpaused, unsynchronized pane', () => {
+    // Restore-after-replay and other callers use presentPaneViewport even when
+    // forceFullViewportPresent is a no-op (not paused, no DEC 2026).
+    const pane = createPane()
+
+    presentPaneViewport(pane)
+
+    expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 23)
+  })
+
   it('keeps the render pause latched when resetting a pane that has no layout box', () => {
     // Regression: the atlas reset released xterm's pause for every pane of a
     // visible manager, including a collapsed sibling of an expanded pane. That

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -1,9 +1,9 @@
 import { WebglAddon } from '@xterm/addon-webgl'
-import type { ManagedPaneInternal } from './pane-manager-types'
+import type { ManagedPane, ManagedPaneInternal } from './pane-manager-types'
 import { recordTerminalWebglDiagnostic } from '../../../../shared/terminal-webgl-diagnostics'
 import { getLivePaneCensus } from './pane-manager-registry'
 import { isManagedPaneDisplayNone } from './pane-display-visibility'
-import { forceRepaintThroughRenderPause } from './terminal-render-pause-release'
+import { forceFullViewportPresent } from './terminal-render-pause-release'
 import {
   getTerminalWebglAutoDecision,
   resetTerminalWebglAutoDecision
@@ -138,7 +138,7 @@ export function markComplexScriptOutput(pane: ManagedPaneInternal): void {
   pane.hasComplexScriptOutput = true
 }
 
-export function resetWebglTextureAtlas(pane: ManagedPaneInternal): void {
+export function clearWebglTextureAtlas(pane: ManagedPaneInternal): void {
   if (pane.webglDisabledAfterContextLoss) {
     return
   }
@@ -147,11 +147,51 @@ export function resetWebglTextureAtlas(pane: ManagedPaneInternal): void {
     // context-loss event. Clearing the atlas preserves GPU rendering and forces
     // a fresh paint when the pane becomes visible/focused again.
     pane.webglAddon?.clearTextureAtlas()
+  } catch {
+    /* ignore — pane may have been disposed in the meantime */
+  }
+}
+
+const DISPLAYED_PRESENT_RETRY_FRAMES = 16
+const pendingDisplayedPresentRetries = new WeakMap<ManagedPaneInternal, number>()
+
+function schedulePresentWhenDisplayed(pane: ManagedPaneInternal): void {
+  if (typeof globalThis.requestAnimationFrame !== 'function') {
+    return
+  }
+  if (pendingDisplayedPresentRetries.has(pane)) {
+    return
+  }
+  pendingDisplayedPresentRetries.set(pane, DISPLAYED_PRESENT_RETRY_FRAMES)
+  const tick = (): void => {
+    const remaining = pendingDisplayedPresentRetries.get(pane) ?? 0
+    if (remaining <= 0 || !pane.terminal) {
+      pendingDisplayedPresentRetries.delete(pane)
+      return
+    }
+    if (isManagedPaneDisplayNone(pane)) {
+      pendingDisplayedPresentRetries.set(pane, remaining - 1)
+      globalThis.requestAnimationFrame(tick)
+      return
+    }
+    pendingDisplayedPresentRetries.delete(pane)
+    presentPaneViewport(pane)
+  }
+  globalThis.requestAnimationFrame(tick)
+}
+
+export function presentPaneViewport(pane: ManagedPane): void {
+  const internal = pane as ManagedPaneInternal
+  if (internal.webglDisabledAfterContextLoss) {
+    return
+  }
+  try {
     // Why: on reveal xterm's IntersectionObserver can still report the pane as
     // not intersecting, so a plain refresh() is swallowed by RenderService's
     // paused-render gate and the cleared model never repaints (stale bottom rows
-    // until a drag-select forces a redraw). Force the paused render through
-    // first; only fall back to refresh() when the terminal was not gated.
+    // until a drag-select forces a redraw). Drive one synchronous full present
+    // even if the observer already unpaused; only fall back to refresh() when
+    // internals are unavailable.
     //
     // Why the display check: that release is only right for a pane that is
     // DOM-visible. A pane with no box at all (collapsed sibling of an expanded
@@ -162,7 +202,17 @@ export function resetWebglTextureAtlas(pane: ManagedPaneInternal): void {
     // it also drops the full repaint the observer owes the pane on reveal, and
     // the deferred _pausedResizeTask that flushes alongside it. Latching is what
     // xterm's own gate does, and the reveal repaints from the latch.
-    if (isManagedPaneDisplayNone(pane) || !forceRepaintThroughRenderPause(pane.terminal)) {
+    if (isManagedPaneDisplayNone(pane)) {
+      pane.terminal.refresh(0, pane.terminal.rows - 1)
+      // Why: light tab reveal runs while the overlay is still display:none
+      // (Dev #15813: paused=true needFull=true at click). A plain refresh only
+      // latches _needsFullRefresh; if IntersectionObserver never fires, the
+      // canvas keeps pre-hide pixels until a user resize. Retry once the box
+      // exists so the full present actually runs.
+      schedulePresentWhenDisplayed(internal)
+      return
+    }
+    if (!forceFullViewportPresent(pane.terminal)) {
       // Why: refresh even without a WebGL addon so recovery never silently
       // no-ops — a DOM-rendered pane can hold stale pixels after reveal too.
       pane.terminal.refresh(0, pane.terminal.rows - 1)
@@ -170,6 +220,11 @@ export function resetWebglTextureAtlas(pane: ManagedPaneInternal): void {
   } catch {
     /* ignore — pane may have been disposed in the meantime */
   }
+}
+
+export function resetWebglTextureAtlas(pane: ManagedPaneInternal): void {
+  clearWebglTextureAtlas(pane)
+  presentPaneViewport(pane)
 }
 
 function refitAfterFitAnchoredWebglAttach(pane: ManagedPaneInternal): void {

--- a/src/renderer/src/lib/pane-manager/terminal-render-pause-release.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-render-pause-release.test.ts
@@ -1,24 +1,34 @@
 import { describe, expect, it, vi } from 'vitest'
-import { forceRepaintThroughRenderPause } from './terminal-render-pause-release'
+import {
+  forceFullViewportPresent,
+  forceRepaintThroughRenderPause
+} from './terminal-render-pause-release'
 
 type FakeRenderService = {
   _isPaused?: boolean
   _needsFullRefresh?: boolean
   refreshRows?: ReturnType<typeof vi.fn>
+  _renderer?: {
+    value?: { clear?: ReturnType<typeof vi.fn>; renderRows?: ReturnType<typeof vi.fn> }
+  }
 }
 
 function createTerminal(options: {
   rows?: number
   renderService?: FakeRenderService | null
   withoutCore?: boolean
+  synchronizedOutput?: boolean
 }): unknown {
-  const { rows = 24, renderService, withoutCore } = options
+  const { rows = 24, renderService, withoutCore, synchronizedOutput } = options
   if (withoutCore) {
     return { rows }
   }
   return {
     rows,
-    _core: { _renderService: renderService ?? null }
+    _core: {
+      _renderService: renderService ?? null,
+      _coreService: { decPrivateModes: { synchronizedOutput: synchronizedOutput === true } }
+    }
   }
 }
 
@@ -82,6 +92,65 @@ describe('forceRepaintThroughRenderPause', () => {
     expect(forceRepaintThroughRenderPause(terminal)).toBe(false)
     // Latch is still cleared — the observer reasserts authority on its next
     // callback, and we must not leave a half-serviced full-refresh queued.
+    expect(renderService._isPaused).toBe(false)
+  })
+})
+
+describe('forceFullViewportPresent', () => {
+  it('leaves an unpaused, unsynchronized terminal to the normal refresh path', () => {
+    // A forced sync renderRows on first splash paints before cell metrics
+    // settle and shows a 1px black gutter under OpenCode's composer.
+    const refreshRows = vi.fn()
+    const renderRows = vi.fn()
+    const terminal = createTerminal({
+      rows: 24,
+      renderService: {
+        _isPaused: false,
+        _needsFullRefresh: false,
+        refreshRows,
+        _renderer: { value: { renderRows } }
+      }
+    })
+
+    expect(forceFullViewportPresent(terminal)).toBe(false)
+    expect(renderRows).not.toHaveBeenCalled()
+    expect(refreshRows).not.toHaveBeenCalled()
+  })
+
+  it('paints through the renderer so DEC 2026 cannot swallow the reveal present', () => {
+    const refreshRows = vi.fn()
+    const renderRows = vi.fn()
+    const renderService = {
+      _isPaused: false,
+      _needsFullRefresh: false,
+      refreshRows,
+      _renderer: { value: { renderRows } }
+    }
+    const terminal = createTerminal({
+      rows: 24,
+      renderService,
+      synchronizedOutput: true
+    })
+
+    expect(forceFullViewportPresent(terminal)).toBe(true)
+    expect(renderRows).toHaveBeenCalledWith(0, 23)
+    expect(refreshRows).not.toHaveBeenCalled()
+  })
+
+  it('uses RenderService refreshRows when paused without DEC 2026, matching production splash', () => {
+    const refreshRows = vi.fn()
+    const renderRows = vi.fn()
+    const renderService = {
+      _isPaused: true,
+      _needsFullRefresh: true,
+      refreshRows,
+      _renderer: { value: { renderRows } }
+    }
+    const terminal = createTerminal({ rows: 24, renderService })
+
+    expect(forceFullViewportPresent(terminal)).toBe(true)
+    expect(refreshRows).toHaveBeenCalledWith(0, 23, true)
+    expect(renderRows).not.toHaveBeenCalled()
     expect(renderService._isPaused).toBe(false)
   })
 })

--- a/src/renderer/src/lib/pane-manager/terminal-render-pause-release.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-render-pause-release.test.ts
@@ -153,4 +153,20 @@ describe('forceFullViewportPresent', () => {
     expect(renderRows).not.toHaveBeenCalled()
     expect(renderService._isPaused).toBe(false)
   })
+
+  it('leaves pause cleared when the forced render throws so callers can refresh()', () => {
+    const renderService = {
+      _isPaused: true,
+      _needsFullRefresh: true,
+      refreshRows: vi.fn(() => {
+        throw new Error('terminal disposed')
+      }),
+      _renderer: { value: { renderRows: vi.fn() } }
+    }
+    const terminal = createTerminal({ rows: 24, renderService })
+
+    expect(forceFullViewportPresent(terminal)).toBe(false)
+    expect(renderService._isPaused).toBe(false)
+    expect(renderService._needsFullRefresh).toBe(false)
+  })
 })

--- a/src/renderer/src/lib/pane-manager/terminal-render-pause-release.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-render-pause-release.ts
@@ -137,6 +137,9 @@ export function forceFullViewportPresent(terminal: unknown): boolean {
     service.refreshRows(0, rows - 1, true)
     return true
   } catch {
+    // Why: same as forceRepaintThroughRenderPause — leave the latch cleared so
+    // the caller's terminal.refresh() fallback can still paint. Restoring
+    // _isPaused would swallow that refresh until IntersectionObserver fires.
     return false
   }
 }

--- a/src/renderer/src/lib/pane-manager/terminal-render-pause-release.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-render-pause-release.ts
@@ -17,10 +17,15 @@
  * never throws into a render frame.
  */
 
+type MaybeWebglRenderer = {
+  renderRows?: (start: number, end: number) => void
+}
+
 type MaybePausableRenderService = {
   _isPaused?: boolean
   _needsFullRefresh?: boolean
   refreshRows?: (start: number, end: number, sync?: boolean) => void
+  _renderer?: { value?: MaybeWebglRenderer | null } | MaybeWebglRenderer | null
 }
 
 type PausableRenderService = MaybePausableRenderService & {
@@ -31,6 +36,7 @@ type TerminalWithRenderService = {
   rows?: number
   _core?: {
     _renderService?: MaybePausableRenderService
+    _coreService?: { decPrivateModes?: { synchronizedOutput?: boolean } }
   }
 }
 
@@ -65,6 +71,69 @@ export function forceRepaintThroughRenderPause(terminal: unknown): boolean {
   service._isPaused = false
   service._needsFullRefresh = false
   try {
+    service.refreshRows(0, rows - 1, true)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function getRenderer(service: MaybePausableRenderService): MaybeWebglRenderer | null {
+  const holder = service._renderer
+  if (!holder) {
+    return null
+  }
+  if (typeof (holder as MaybeWebglRenderer).renderRows === 'function') {
+    return holder as MaybeWebglRenderer
+  }
+  const wrapped = (holder as { value?: MaybeWebglRenderer | null }).value
+  return wrapped ?? null
+}
+
+function isSynchronizedOutputHeld(terminal: unknown): boolean {
+  return (
+    (terminal as TerminalWithRenderService)._core?._coreService?.decPrivateModes
+      ?.synchronizedOutput === true
+  )
+}
+
+/**
+ * One synchronous full-viewport present when xterm would otherwise swallow it:
+ * IntersectionObserver pause, or DEC 2026 synchronized output (OpenCode TUI).
+ *
+ * Why not on every paint: a forced renderer.renderRows on a fresh, unpaused
+ * splash paints before cell metrics settle and leaves a 1px black gutter under
+ * OpenCode's composer — production never does that. Callers fall back to
+ * terminal.refresh() for the normal path.
+ */
+export function forceFullViewportPresent(terminal: unknown): boolean {
+  const service = getRenderService(terminal)
+  const rows = (terminal as TerminalWithRenderService).rows
+  if (!service || typeof rows !== 'number' || rows < 1) {
+    return false
+  }
+
+  const paused = service._isPaused === true
+  const syncHeld = isSynchronizedOutputHeld(terminal)
+  if (!paused && !syncHeld) {
+    return false
+  }
+
+  if (paused) {
+    service._isPaused = false
+    service._needsFullRefresh = false
+  }
+
+  const renderer = getRenderer(service)
+  try {
+    // Why: a new OpenCode tab is often still paused (observer lag). Painting
+    // via renderer.renderRows skips RenderService's dimension clamp and draws
+    // 1px short of the composer box. Production uses refreshRows here.
+    // renderer.renderRows is only for DEC 2026, which swallows refreshRows.
+    if (syncHeld && typeof renderer?.renderRows === 'function') {
+      renderer.renderRows(0, rows - 1)
+      return true
+    }
     service.refreshRows(0, rows - 1, true)
     return true
   } catch {


### PR DESCRIPTION
## ELI5

OpenCode in an Orca terminal could look destroyed after you switched workspaces or tabs — gray blocks, doubled footers, two token counts at once — even though copy/paste from that same pane was still the real session. The pixels on the WebGL canvas were leftover from *before* the hide. This PR forces a full, honest repaint on reveal (and on a visible undock/DPR change) so the canvas matches the buffer again.

## What Changed

On workspace/tab reveal, Orca now:

1. **Presents the full viewport even when xterm would swallow the paint.** OpenCode holds DEC 2026 synchronized output, which makes `refreshRows` a no-op. IntersectionObserver pause does the same. Reveal now drives a synchronous present: `refreshRows` when only paused (same path production uses on first splash), `renderer.renderRows` only when DEC 2026 is held.
2. **Wipes every recovered glyph atlas before presenting any pane.** The WebGL addon’s atlas is module-global. Clearing-then-presenting per pane left the first OpenCode column pointing at evicted pages.
3. **Includes hidden worktrees that still hold a WebGL renderer** in that atlas rebuild, instead of skipping them until later reveal.
4. **Retries a present that ran while the overlay was still `display:none`.** Light tab reveal often fires one frame too early (`paused=true needFull=true`); a plain `refresh()` only latches a flag that the observer may never flush.
5. **Rebuilds a stale canvas backing store on `window` `resize`.** Chromium emits resize on devicePixelRatio change (undock / monitor move) even when the CSS box is unchanged. Upstream already repaired this on tab reveal/fit; visible tabs never hit that path.

## Why

### Troubleshooting

The reporter’s screenshot (and our live repros) showed **two token counts** and a duplicated `ctrl+p` footer in one pane. That is leftover *pixels*, not lost PTY bytes.

We proved the data path was clean:

- Round-tripping real OpenCode bytes through Orca’s snapshot → serialize → replay machinery matched a live reference terminal cell-by-cell (including styles and cursor).
- `orca terminal read --screen` / copy-from-pane of a garbled view returned the *current* TUI, not the garbage on screen.
- Playwright e2e without WebGL attached was a false negative (`webgl: false` in those runs).

So the buffer was right; the WebGL canvas was not.

### Narrowing

Live traces on hide/reveal of a garbled OpenCode tab showed:

| Observation | Meaning |
|---|---|
| `copy`/`serialize` clean, canvas garbled | WebGL leftover pixels, not a PTY or snapshot bug |
| `paused=true needFull=true` at light tab click | Present ran while the overlay was still `display:none` |
| `syncOut=true` (DEC 2026) | `refreshRows` / `_renderRows` no-op until OpenCode releases the frame |
| Two visible OpenCode columns, first column still stale after per-pane `clearTextureAtlas` | Shared atlas generation N vs N+1 interleave |
| Resize “fixes it” | Canvas recreate + SIGWINCH, which is why #15493 felt related |
| Drag-select heals inner rows, not the sides | Selection forces a partial model update, not a full present |

Three cooperating causes, all required for the reporter’s workspace-switch case:

1. OpenCode holds DEC 2026, so the reveal `refresh()` never paints.
2. The next TUI frame only dirties the footer/composer; WebGL blends that onto the pre-hide framebuffer.
3. Two visible terminals share one glyph atlas; per-pane clear-then-present leaves the first column on evicted pages.

A **visible undock** is the same leftover-pixel class with a different trigger: `devicePixelRatio` changes, xterm’s device-pixel observer misses it, and the canvas keeps the old backing-store size. We hit it while testing this issue in Dev (external monitor → laptop). Release 1.4.188 already repairs that on reveal/fit (`#13159`); it does not run if the OpenCode tab stays selected. The `window` `resize` repair is included here because it is the same present path, not a separate product bug.

Out of scope (not this PR): GPU Acceleration **Off** uses the DOM renderer, which draws OpenCode’s composer `▀` border from the font instead of WebGL custom glyphs, so a 1px hairline can appear under the composer. That is not #15813 and is not fixed here.

### Approach

Do not bump xterm in this PR. Defense-in-depth on Orca’s reveal/present choreography is enough for the reported bug, and an xterm bump is a separate compatibility project.

We deliberately **do not** force `renderer.renderRows` on every unpaused splash — that painted before cell metrics settled and left a 1px black gutter under OpenCode’s composer that production does not have.

## Linked Issue

Fixes #15813

## Visual Proof

Before: OpenCode after a workspace switch (or clicking the unfocused streaming tab) showed gray blocks, a doubled footer, and two token counts. Copy from that pane was the real session. Screenshot is on #15813.

After: same recipe in the Dev app on this branch — two OpenCode tabs, leave B unfocused and streaming, switch worktree, click B — the TUI matches the buffer with no leftover footer/composer pixels. Confirmed by the reporter on this branch.

No images committed (template: do not add attachments to the PR files).

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

### Manual (macOS, Dev app, GPU Auto)

Reporter’s recipe, confirmed fixed:

1. Two OpenCode tabs in one worktree.
2. Leave B unfocused and streaming.
3. Switch worktree.
4. Click B while it is still working.

Also exercised:

- Light intra-worktree tab hide/reveal (present retry after `display:none`).
- Copy-is-clean vs visual-garbled (buffer was always right).
- GPU Auto vs Off: Auto is the #15813 path; Off never hits this WebGL bug.
- Visible undock / DPR: window `resize` rebuilds the backing store without wiping the glyph atlas.

Not re-run on Linux/Windows/SSH in this change. The present/atlas logic is renderer-local (no PTY, no SSH execution host). SSH/folder workspaces keep the same WebGL panes.

### Automated

New/updated unit tests for: DEC 2026 vs pause present paths; wipe-all-atlases-then-present order; hidden retained WebGL included in atlas recovery; `display:none` present retry; light-tab `scheduleRevealPresent`; window-resize DPR repair without atlas wipe.

`pnpm lint`, `pnpm typecheck`, and `pnpm build` passed locally.

`pnpm test`: all tests in this diff passed (80/80 in the touched files). Full suite was 57118 passed / 13 failed; the failures are unrelated to this change (missing optional `@vscode/windows-process-tree` in this checkout, lint-staged worktree-backup isolation against existing stashes, inherited `ZDOTDIR`, live WSL hook relay). CI should be the authority for those.

## Review

- **Cross-platform:** WebGL addon is used on macOS/Linux/Windows when GPU is Auto/On. DOM fallback (GPU Off) is unchanged and cannot hit this leftover-pixel class.
- **SSH / remote:** No wire, RPC, or execution-host change. Hidden remote OpenCode tabs use the same renderer present path.
- **Folder workspaces:** Same pane manager; not git-worktree-specific.
- **Performance:** Atlas wipe is still the existing heavy reveal path. New work is one synchronous full present per revealed pane, a bounded rAF retry while `display:none`, and a no-op-if-matched DPR check on window resize. No atlas wipe on plain undock.
- **UI quality:** First-splash OpenCode composer is not forced through `renderer.renderRows` (that was a 1px gutter regression we caught and backed out).
- **Security:** No new IPC surface. Internals (`_isPaused`, `renderRows`, `synchronizedOutput`) are behind typeof guards and degrade to `terminal.refresh()`.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

