### PR TITLE
fix(terminal): fill OpenCode block glyphs in the DOM renderer

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
+++ b/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
@@ -139,6 +139,7 @@ export function createPaneDOM(
     paneDragCleanup,
     compositionHandler: null,
     focusClassSyncCleanup: null,
+    domBlockFillCleanup: null,
     terminalScrollIntentDisposable: null,
     linkifierMouseLeaveResetDisposable: null,
     arabicShapingJoinerCleanup: null,

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -46,6 +46,7 @@ function createPane(): ManagedPaneInternal {
       loadAddon: vi.fn(),
       attachCustomWheelEventHandler: vi.fn(),
       refresh: vi.fn(),
+      onRender: vi.fn(() => ({ dispose: vi.fn() })),
       cols: 80,
       rows: 24
     } as never,

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -15,6 +15,7 @@ import {
 } from './terminal-linkifier-hover-reset-on-mouseleave'
 import { installTerminalLinkifierHoverResetOnWrite } from './terminal-linkifier-hover-reset-on-write'
 import { attachDomRendererFocusClassSync } from './pane-dom-focus-class-sync'
+import { attachDomBlockFill } from './terminal-dom-block-fill'
 import { attachWebgl, cancelPendingWebglRefresh, disposeWebgl } from './pane-webgl-renderer'
 import { rebuildAttachedWebgl } from './pane-webgl-reattach'
 import { configureLazyArabicShapingJoiner } from './terminal-arabic-shaping-joiner'
@@ -99,6 +100,7 @@ export function openTerminal(pane: ManagedPaneInternal): void {
   pane.compositionHandler = installTerminalImeCandidateAnchor(terminal)
 
   pane.focusClassSyncCleanup = attachDomRendererFocusClassSync(terminal.element)
+  pane.domBlockFillCleanup = attachDomBlockFill(terminal)
 
   if (pane.gpuRenderingEnabled) {
     attachWebgl(pane)
@@ -188,6 +190,8 @@ export function disposePane(
   pane.paneDragCleanup = null
   pane.focusClassSyncCleanup?.()
   pane.focusClassSyncCleanup = null
+  pane.domBlockFillCleanup?.()
+  pane.domBlockFillCleanup = null
   pane.terminalScrollIntentDisposable?.dispose()
   pane.terminalScrollIntentDisposable = null
   pane.linkifierHoverResetDisposable?.dispose()

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -176,6 +176,8 @@ export type ManagedPaneInternal = {
   compositionHandler: (() => void) | null
   // Stored so disposePane() can remove DOM-renderer focus synchronization.
   focusClassSyncCleanup?: (() => void) | null
+  // GPU-off DOM renderer: fill uniform ▀/█ runs so OpenCode's composer is flush.
+  domBlockFillCleanup?: (() => void) | null
   // Stored so disposePane() can remove user-scroll intent listeners.
   terminalScrollIntentDisposable?: IDisposable | null
   // Stored so disposePane() can detach the streamed-output hover-cache reset

--- a/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.ts
@@ -6,6 +6,7 @@ import {
   shouldUseTerminalWebgl
 } from './pane-webgl-renderer'
 import { safeFit } from './pane-tree-ops'
+import { applyDomBlockFills } from './terminal-dom-block-fill'
 
 export function applyTerminalGpuAcceleration(
   panes: Iterable<ManagedPaneInternal>,
@@ -30,6 +31,13 @@ export function applyTerminalGpuAcceleration(
     }
     if (!shouldUseTerminalWebgl(pane)) {
       disposeWebgl(pane, { refreshDimensions: true })
+      const root = pane.terminal.element
+      if (root) {
+        applyDomBlockFills(root)
+        if (typeof requestAnimationFrame === 'function') {
+          requestAnimationFrame(() => applyDomBlockFills(root))
+        }
+      }
       continue
     }
     if (

--- a/src/renderer/src/lib/pane-manager/terminal-dom-block-fill.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-dom-block-fill.test.ts
@@ -1,0 +1,119 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  applyDomBlockFills,
+  attachDomBlockFill,
+  backgroundImageForUniformBlockRun
+} from './terminal-dom-block-fill'
+
+describe('backgroundImageForUniformBlockRun', () => {
+  it('fills the top half of the cell for a run of upper-half blocks', () => {
+    expect(backgroundImageForUniformBlockRun('▀▀▀')).toBe(
+      'linear-gradient(to bottom, var(--orca-block-fg) 50%, transparent 50%)'
+    )
+  })
+
+  it('fills the bottom half of the cell for lower-half blocks', () => {
+    expect(backgroundImageForUniformBlockRun('▄▄')).toBe(
+      'linear-gradient(to bottom, transparent 50%, var(--orca-block-fg) 50%)'
+    )
+  })
+
+  it('fills the whole cell for full blocks', () => {
+    expect(backgroundImageForUniformBlockRun('█')).toBe(
+      'linear-gradient(to bottom, transparent 0%, var(--orca-block-fg) 0%)'
+    )
+  })
+
+  it('fills the left half for left-half blocks', () => {
+    expect(backgroundImageForUniformBlockRun('▌')).toBe(
+      'linear-gradient(to right, var(--orca-block-fg) 50%, transparent 50%)'
+    )
+  })
+
+  it('fills the right half for right-half blocks', () => {
+    expect(backgroundImageForUniformBlockRun('▐')).toBe(
+      'linear-gradient(to right, transparent 50%, var(--orca-block-fg) 50%)'
+    )
+  })
+
+  it('skips mixed runs, spaces, and ASCII', () => {
+    expect(backgroundImageForUniformBlockRun('▀█')).toBeNull()
+    expect(backgroundImageForUniformBlockRun('▀ ▀')).toBeNull()
+    expect(backgroundImageForUniformBlockRun('Ask')).toBeNull()
+    expect(backgroundImageForUniformBlockRun('')).toBeNull()
+  })
+})
+
+describe('applyDomBlockFills', () => {
+  afterEach(() => {
+    document.body.replaceChildren()
+  })
+
+  function mountSpan(text: string, color = 'rgb(30, 30, 30)'): HTMLSpanElement {
+    const rows = document.createElement('div')
+    rows.className = 'xterm-rows'
+    const span = document.createElement('span')
+    span.textContent = text
+    span.style.color = color
+    span.style.backgroundColor = 'rgb(10, 10, 10)'
+    rows.appendChild(span)
+    document.body.appendChild(rows)
+    return span
+  }
+
+  it('paints a uniform ▀ composer border with a cell-filling gradient', () => {
+    const span = mountSpan('▀'.repeat(12))
+
+    applyDomBlockFills(document)
+
+    expect(span.style.color).toBe('transparent')
+    expect(span.style.backgroundImage).toContain('linear-gradient(to bottom')
+    expect(span.style.getPropertyValue('--orca-block-fg')).toBe('rgb(30, 30, 30)')
+  })
+
+  it('does not restyle mixed block/letter spans', () => {
+    const span = mountSpan('▀▀█ Ask')
+    applyDomBlockFills(document)
+    expect(span.style.color).toBe('rgb(30, 30, 30)')
+    expect(span.style.backgroundImage).toBe('')
+  })
+
+  it('clears a previous fill when the span is reused for ordinary text', () => {
+    const span = mountSpan('▀▀▀')
+    applyDomBlockFills(document)
+    span.textContent = 'tab agents'
+    applyDomBlockFills(document)
+    expect(span.style.backgroundImage).toBe('')
+    expect(span.style.color).toBe('rgb(30, 30, 30)')
+  })
+})
+
+describe('attachDomBlockFill', () => {
+  it('applies fills after onRender and disposes the listener', () => {
+    const rows = document.createElement('div')
+    rows.className = 'xterm-rows'
+    const span = document.createElement('span')
+    span.textContent = '▀▀'
+    span.style.color = 'rgb(1, 2, 3)'
+    rows.appendChild(span)
+    const element = document.createElement('div')
+    element.appendChild(rows)
+
+    let render: (() => void) | undefined
+    const dispose = vi.fn()
+    const terminal = {
+      element,
+      onRender: (cb: () => void) => {
+        render = cb
+        return { dispose }
+      }
+    }
+
+    const detach = attachDomBlockFill(terminal)
+    render?.()
+    expect(span.style.color).toBe('transparent')
+    detach()
+    expect(dispose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/lib/pane-manager/terminal-dom-block-fill.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-dom-block-fill.test.ts
@@ -37,6 +37,18 @@ describe('backgroundImageForUniformBlockRun', () => {
     )
   })
 
+  it('fills the top eighth for upper one-eighth blocks', () => {
+    expect(backgroundImageForUniformBlockRun('▔')).toBe(
+      'linear-gradient(to bottom, var(--orca-block-fg) 12.5%, transparent 12.5%)'
+    )
+  })
+
+  it('fills the right eighth for right one-eighth blocks', () => {
+    expect(backgroundImageForUniformBlockRun('▕')).toBe(
+      'linear-gradient(to right, transparent 87.5%, var(--orca-block-fg) 87.5%)'
+    )
+  })
+
   it('skips mixed runs, spaces, and ASCII', () => {
     expect(backgroundImageForUniformBlockRun('▀█')).toBeNull()
     expect(backgroundImageForUniformBlockRun('▀ ▀')).toBeNull()
@@ -69,7 +81,31 @@ describe('applyDomBlockFills', () => {
 
     expect(span.style.color).toBe('transparent')
     expect(span.style.backgroundImage).toContain('linear-gradient(to bottom')
+    expect(span.style.backgroundSize).toBe(`${100 / 12}% 100%`)
+    expect(span.style.backgroundRepeat).toBe('repeat-x')
     expect(span.style.getPropertyValue('--orca-block-fg')).toBe('rgb(30, 30, 30)')
+  })
+
+  it('repeats a per-cell horizontal fill across a multi-cell left-half run', () => {
+    const span = mountSpan('▌▌')
+
+    applyDomBlockFills(document)
+
+    expect(span.style.backgroundImage).toContain('linear-gradient(to right')
+    expect(span.style.backgroundSize).toBe('50% 100%')
+    expect(span.style.backgroundRepeat).toBe('repeat-x')
+  })
+
+  it('repeats a per-cell horizontal fill across a multi-cell right-half run', () => {
+    const span = mountSpan('▐▐')
+
+    applyDomBlockFills(document)
+
+    expect(span.style.backgroundImage).toBe(
+      'linear-gradient(to right, transparent 50%, var(--orca-block-fg) 50%)'
+    )
+    expect(span.style.backgroundSize).toBe('50% 100%')
+    expect(span.style.backgroundRepeat).toBe('repeat-x')
   })
 
   it('does not restyle mixed block/letter spans', () => {
@@ -85,6 +121,8 @@ describe('applyDomBlockFills', () => {
     span.textContent = 'tab agents'
     applyDomBlockFills(document)
     expect(span.style.backgroundImage).toBe('')
+    expect(span.style.backgroundSize).toBe('')
+    expect(span.style.backgroundRepeat).toBe('')
     expect(span.style.color).toBe('rgb(30, 30, 30)')
   })
 })

--- a/src/renderer/src/lib/pane-manager/terminal-dom-block-fill.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-dom-block-fill.ts
@@ -46,6 +46,12 @@ export function backgroundImageForUniformBlockRun(text: string): string | null {
   if (code === 0x2590) {
     return gradient('right', 50, false)
   }
+  if (code === 0x2594) {
+    return gradient('bottom', 12.5, true)
+  }
+  if (code === 0x2595) {
+    return gradient('right', 12.5, false)
+  }
   return null
 }
 
@@ -57,6 +63,8 @@ function clearBlockFill(span: HTMLElement): void {
   span.removeAttribute(FILL_ATTR)
   span.removeAttribute(FG_ATTR)
   span.style.removeProperty('background-image')
+  span.style.removeProperty('background-size')
+  span.style.removeProperty('background-repeat')
   span.style.removeProperty(BLOCK_FG_VAR)
   if (originalColor) {
     span.style.color = originalColor
@@ -93,6 +101,8 @@ export function applyDomBlockFills(root: ParentNode): void {
     span.style.setProperty(BLOCK_FG_VAR, fg)
     span.style.color = 'transparent'
     span.style.backgroundImage = fill
+    span.style.backgroundSize = `${100 / text.length}% 100%`
+    span.style.backgroundRepeat = 'repeat-x'
   }
 }
 

--- a/src/renderer/src/lib/pane-manager/terminal-dom-block-fill.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-dom-block-fill.ts
@@ -66,6 +66,9 @@ function clearBlockFill(span: HTMLElement): void {
 }
 
 export function applyDomBlockFills(root: ParentNode): void {
+  if (typeof root.querySelectorAll !== 'function') {
+    return
+  }
   const spans = root.querySelectorAll('.xterm-rows span')
   for (const node of spans) {
     const span = node as HTMLElement
@@ -97,15 +100,37 @@ export function attachDomBlockFill(terminal: {
   onRender?: (cb: () => void) => { dispose: () => void }
   element?: HTMLElement | undefined
 }): () => void {
-  if (typeof terminal.onRender !== 'function') {
-    return () => undefined
-  }
-  const listener = terminal.onRender(() => {
+  const run = (): void => {
     const root = terminal.element
-    if (!root) {
-      return
+    if (root) {
+      applyDomBlockFills(root)
     }
-    applyDomBlockFills(root)
-  })
-  return () => listener.dispose()
+  }
+  const schedule = (): void => {
+    run()
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(run)
+    }
+  }
+  schedule()
+  const renderDisposable =
+    typeof terminal.onRender === 'function'
+      ? terminal.onRender(schedule)
+      : { dispose: () => undefined }
+
+  let observer: MutationObserver | null = null
+  const root = terminal.element
+  if (
+    typeof Node !== 'undefined' &&
+    root instanceof Node &&
+    typeof MutationObserver === 'function'
+  ) {
+    observer = new MutationObserver(schedule)
+    observer.observe(root, { childList: true, subtree: true })
+  }
+
+  return () => {
+    renderDisposable.dispose()
+    observer?.disconnect()
+  }
 }

--- a/src/renderer/src/lib/pane-manager/terminal-dom-block-fill.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-dom-block-fill.ts
@@ -1,0 +1,111 @@
+/**
+ * GPU Off uses xterm's DOM renderer, which paints box/block glyphs from the
+ * font. OpenCode's composer bottom is a run of ▀; the font glyph does not fill
+ * the cell, so a 1px terminal-background hairline shows through. WebGL custom
+ * glyphs fill the cell. Approximate that for uniform block runs with a CSS
+ * gradient on the span (height: 100% of the row).
+ */
+
+const BLOCK_FG_VAR = '--orca-block-fg'
+const FILL_ATTR = 'data-orca-block-fill'
+const FG_ATTR = 'data-orca-block-fg'
+
+function gradient(axis: 'bottom' | 'right', solidPercent: number, fromStart: boolean): string {
+  const dir = axis === 'bottom' ? 'to bottom' : 'to right'
+  const fg = `var(${BLOCK_FG_VAR})`
+  if (fromStart) {
+    return `linear-gradient(${dir}, ${fg} ${solidPercent}%, transparent ${solidPercent}%)`
+  }
+  const gap = 100 - solidPercent
+  return `linear-gradient(${dir}, transparent ${gap}%, ${fg} ${gap}%)`
+}
+
+/** CSS background-image that fills the cell the way WebGL custom glyphs do. */
+export function backgroundImageForUniformBlockRun(text: string): string | null {
+  if (text.length === 0) {
+    return null
+  }
+  const ch = text[0]!
+  for (let i = 1; i < text.length; i++) {
+    if (text[i] !== ch) {
+      return null
+    }
+  }
+  const code = ch.codePointAt(0) ?? 0
+  if (code === 0x2580) {
+    return gradient('bottom', 50, true)
+  }
+  if (code >= 0x2581 && code <= 0x2588) {
+    const eighths = code - 0x2580
+    return gradient('bottom', eighths * 12.5, false)
+  }
+  if (code >= 0x2589 && code <= 0x258f) {
+    const eighths = 8 - (code - 0x2588)
+    return gradient('right', eighths * 12.5, true)
+  }
+  if (code === 0x2590) {
+    return gradient('right', 50, false)
+  }
+  return null
+}
+
+function clearBlockFill(span: HTMLElement): void {
+  if (!span.hasAttribute(FILL_ATTR)) {
+    return
+  }
+  const originalColor = span.getAttribute(FG_ATTR)
+  span.removeAttribute(FILL_ATTR)
+  span.removeAttribute(FG_ATTR)
+  span.style.removeProperty('background-image')
+  span.style.removeProperty(BLOCK_FG_VAR)
+  if (originalColor) {
+    span.style.color = originalColor
+  } else {
+    span.style.removeProperty('color')
+  }
+}
+
+export function applyDomBlockFills(root: ParentNode): void {
+  const spans = root.querySelectorAll('.xterm-rows span')
+  for (const node of spans) {
+    const span = node as HTMLElement
+    const text = span.textContent ?? ''
+    const fill = backgroundImageForUniformBlockRun(text)
+    if (!fill) {
+      clearBlockFill(span)
+      continue
+    }
+    if (span.getAttribute(FILL_ATTR) === text) {
+      continue
+    }
+    const fg =
+      span.getAttribute(FG_ATTR) ||
+      span.style.color ||
+      (typeof getComputedStyle === 'function' ? getComputedStyle(span).color : '')
+    if (!fg) {
+      continue
+    }
+    span.setAttribute(FG_ATTR, fg)
+    span.setAttribute(FILL_ATTR, text)
+    span.style.setProperty(BLOCK_FG_VAR, fg)
+    span.style.color = 'transparent'
+    span.style.backgroundImage = fill
+  }
+}
+
+export function attachDomBlockFill(terminal: {
+  onRender?: (cb: () => void) => { dispose: () => void }
+  element?: HTMLElement | undefined
+}): () => void {
+  if (typeof terminal.onRender !== 'function') {
+    return () => undefined
+  }
+  const listener = terminal.onRender(() => {
+    const root = terminal.element
+    if (!root) {
+      return
+    }
+    applyDomBlockFills(root)
+  })
+  return () => listener.dispose()
+}


### PR DESCRIPTION
## ELI5

With GPU acceleration off, OpenCode’s composer box has a 1px dark line under it. The DOM renderer was drawing `▀` from the font, which does not fill the cell. This paints those block characters as a CSS fill that matches the cell, the way WebGL already does.

## What Changed

After each xterm DOM render, uniform runs of block elements (`▀` `▄` `█` `▌` `▐` and the eighths) get a cell-sized CSS gradient in the glyph color. Mixed runs and normal text are left alone. WebGL panes have no `.xterm-rows span` cells, so this is a no-op there.

## Why

OpenCode draws the composer bottom as a row of `▀` in composer gray on terminal black. WebGL custom glyphs fill the top half of the **cell**. The DOM renderer uses the font glyph inside a `height: 100%` span; SF Mono’s `▀` does not reach the edges, so the terminal background shows through.

xterm’s `customGlyphs` option exists only on the WebGL addon. Filling the span with a gradient uses the same box the renderer already sizes to the cell.

Not part of #15813 (WebGL leftover pixels after hide/reveal). Default GPU is Auto, so most users never see this; GPU Off and WebGL-attach failure still do.

## Linked Issue

Fixes #15953

## Visual Proof

GPU Acceleration Off, OpenCode composer after this change — flush gray rectangle, no 1px hairline:

<img width="1450" height="1024" alt="Orca Dev GPU Off OpenCode composer after fill" src="https://github.com/user-attachments/assets/1e2fb631-93a2-4693-b75b-e8abb5a78894" />

Repro: GPU Acceleration Off → new OpenCode tab. Related live diagnosis is on #15953.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Unit tests cover uniform `▀`/`▄`/`█`/`▌`/`▐` fills, mixed runs left alone, span reuse back to ASCII, and `onRender` attach/dispose.

`pnpm lint`, `pnpm typecheck`, and `pnpm build` passed locally. Related pane-lifecycle tests pass with the new `onRender` hook.

Manual GPU Off vs Auto in the Dev app is the visual check: Settings → Terminal → Rendering → Off → new OpenCode tab.

Cross-platform: DOM renderer path, no PTY/SSH/wire change. Linux/Windows GPU Off and WebGL fallback should get the same fill.

## Review

- **Cross-platform:** Any OS on the DOM renderer (GPU Off or failed WebGL attach).
- **SSH / remote:** Renderer-only. No RPC or execution-host change.
- **Performance:** Walks `.xterm-rows span` after DOM renders; skips spans that are not a uniform block run. WebGL has no cell spans.
- **UI:** Does not force a WebGL present (that caused a 1px gutter on first splash in #15813).
- **Security:** No new IPC. Mutates span `color` / `background-image` only for uniform block runs, restored if the span is reused for text.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

