### PR TITLE
feat(notifications): open the originating session on click

### DIFF
--- a/src/main/ipc/native-notification-delivery.ts
+++ b/src/main/ipc/native-notification-delivery.ts
@@ -7,7 +7,6 @@ import type {
 import { safelyRevealWindow } from '../window/focus-existing-window'
 import { isBackgroundLaunch } from '../window/foreground-activation-policy'
 import { getRepoIdFromWorktreeId } from '../../shared/worktree/id'
-import { parsePaneKey } from '../../shared/stable-pane-id'
 import type { buildNotificationOptions } from './notification-options'
 import { getEffectiveNotificationSoundId } from './notification-sound-selection'
 import {
@@ -72,9 +71,11 @@ export function deliverNativeNotification(
   }
   notification.on('failed', failedHandler)
 
-  // Why: worktreeId is formatted "repoId::worktreePath"; without the separator we can't extract a repoId, so skip the click-to-navigate binding.
-  if (args.worktreeId && args.worktreeId.includes('::')) {
-    const repoId = getRepoIdFromWorktreeId(args.worktreeId)
+  if (args.worktreeId) {
+    // Why: worktreeId is formatted "repoId::worktreePath"; folder workspaces carry no repo, so activate by workspace id alone.
+    const repoId = args.worktreeId.includes('::')
+      ? getRepoIdFromWorktreeId(args.worktreeId)
+      : undefined
     clickHandler = () => {
       release()
       const win = getTrustedUIRendererWindow()
@@ -85,22 +86,13 @@ export function deliverNativeNotification(
         app.focus({ steal: true })
       }
       safelyRevealWindow(win)
+      // Why: one ordered intent — activation may load asynchronously, so the renderer focuses the pane itself once the workspace resolves.
       win.webContents.send('ui:activateWorktree', {
-        repoId,
-        worktreeId: args.worktreeId
+        ...(repoId ? { repoId } : {}),
+        worktreeId: args.worktreeId,
+        notificationPaneKey: args.paneKey ?? null,
+        ...(args.executionHostId ? { executionHostId: args.executionHostId } : {})
       })
-      // Why: focusTerminal targets the pane by stable leafId so split-pane notifications land on the exact pane.
-      const paneTarget = args.paneKey ? parsePaneKey(args.paneKey) : null
-      if (paneTarget) {
-        win.webContents.send('ui:focusTerminal', {
-          tabId: paneTarget.tabId,
-          worktreeId: args.worktreeId,
-          leafId: paneTarget.leafId,
-          ackPaneKeyOnSuccess: args.paneKey,
-          flashFocusedPane: true,
-          scrollToBottomIfOutputSinceLastView: true
-        })
-      }
     }
     notification.on('click', clickHandler)
   }

--- a/src/main/ipc/notifications-retention-lifecycle.test.ts
+++ b/src/main/ipc/notifications-retention-lifecycle.test.ts
@@ -37,7 +37,7 @@ describe('registerNotificationHandlers', () => {
     resetNotificationDispatchMocks()
   })
 
-  it('focuses the originating terminal pane in the main window when a dashboard popout is open', async () => {
+  it('sends an originating-pane navigation intent to the main window when a dashboard popout is open', async () => {
     const popoutSend = vi.fn()
     const popoutFocus = vi.fn()
     const webContentsSend = vi.fn()
@@ -77,7 +77,15 @@ describe('registerNotificationHandlers', () => {
     const paneKey = 'tab-1:11111111-1111-4111-8111-111111111111'
     const handler = getDispatchHandler()
     expect(
-      await handler({}, { source: 'agent-task-complete', worktreeId: 'repo::wt1', paneKey })
+      await handler(
+        {},
+        {
+          source: 'agent-task-complete',
+          worktreeId: 'repo::wt1',
+          paneKey,
+          executionHostId: 'ssh:build-box'
+        }
+      )
     ).toEqual({ delivered: true })
     expect(vi.getTimerCount()).toBe(1)
 
@@ -93,16 +101,59 @@ describe('registerNotificationHandlers', () => {
     expect(notificationRemoveListenerMock).toHaveBeenCalledWith('click', expect.any(Function))
     expect(webContentsSend).toHaveBeenCalledWith('ui:activateWorktree', {
       repoId: 'repo',
-      worktreeId: 'repo::wt1'
-    })
-    expect(webContentsSend).toHaveBeenCalledWith('ui:focusTerminal', {
-      tabId: 'tab-1',
       worktreeId: 'repo::wt1',
-      leafId: '11111111-1111-4111-8111-111111111111',
-      ackPaneKeyOnSuccess: paneKey,
-      flashFocusedPane: true,
-      scrollToBottomIfOutputSinceLastView: true
+      notificationPaneKey: paneKey,
+      executionHostId: 'ssh:build-box'
     })
+    // Why: the split focus event is what raced workspace activation; one intent replaces it.
+    expect(webContentsSend).not.toHaveBeenCalledWith('ui:focusTerminal', expect.anything())
+  })
+
+  it('binds folder-workspace notifications to one navigation intent', async () => {
+    const webContentsSend = vi.fn()
+    const mainWindow = {
+      isDestroyed: () => false,
+      isMinimized: () => false,
+      restore: vi.fn(),
+      show: vi.fn(),
+      focus: vi.fn(),
+      webContents: { send: webContentsSend }
+    }
+    getTrustedUIRendererWindowMock.mockReturnValue(mainWindow)
+    registerNotificationHandlers({
+      getSettings: () => ({
+        notifications: {
+          enabled: true,
+          agentTaskComplete: true,
+          terminalBell: true,
+          suppressWhenFocused: true
+        }
+      })
+    } as never)
+
+    const paneKey = 'tab-1:11111111-1111-4111-8111-111111111111'
+    const handler = getDispatchHandler()
+    expect(
+      await handler(
+        {},
+        {
+          source: 'agent-task-complete',
+          worktreeId: 'folder:folder-1',
+          paneKey,
+          executionHostId: 'runtime:folder-host'
+        }
+      )
+    ).toEqual({ delivered: true })
+
+    getNotificationEventHandler('click')()
+
+    // Why: a folder workspace has no repoId to extract, and must still bind click-to-navigate.
+    expect(webContentsSend).toHaveBeenCalledWith('ui:activateWorktree', {
+      worktreeId: 'folder:folder-1',
+      notificationPaneKey: paneKey,
+      executionHostId: 'runtime:folder-host'
+    })
+    expect(webContentsSend).toHaveBeenCalledTimes(1)
   })
 
   it('clears the retained notification fallback timer when the native notification closes', async () => {

--- a/src/preload/api/ui-bridge-tab-and-browser-commands.ts
+++ b/src/preload/api/ui-bridge-tab-and-browser-commands.ts
@@ -1,10 +1,6 @@
 import { ipcRenderer } from 'electron'
 import { admitCloseActiveTabPayload } from '../close-active-tab-payload-admission'
-import type { CloseActiveTabPayload } from '../api/ui-command-event-api'
-import type {
-  WorktreeDefaultTabsLaunch,
-  WorktreeSetupLaunch
-} from '../../shared/worktree/launch-types'
+import type { CloseActiveTabPayload, UiActivateWorktreePayload } from '../api/ui-command-event-api'
 import { browserFindSubscriptions } from '../preload-runtime-support'
 import type { PreloadApi } from '../api-types'
 
@@ -179,25 +175,9 @@ export const uiTabAndBrowserCommandsApi = {
     ipcRenderer.on('ui:dictationKeyDown', listener)
     return () => ipcRenderer.removeListener('ui:dictationKeyDown', listener)
   },
-  onActivateWorktree: (
-    callback: (data: {
-      repoId: string
-      worktreeId: string
-      setup?: WorktreeSetupLaunch
-      startup?: { command: string; env?: Record<string, string> }
-      defaultTabs?: WorktreeDefaultTabsLaunch
-    }) => void
-  ): (() => void) => {
-    const listener = (
-      _event: Electron.IpcRendererEvent,
-      data: {
-        repoId: string
-        worktreeId: string
-        setup?: WorktreeSetupLaunch
-        startup?: { command: string; env?: Record<string, string> }
-        defaultTabs?: WorktreeDefaultTabsLaunch
-      }
-    ) => callback(data)
+  onActivateWorktree: (callback: (data: UiActivateWorktreePayload) => void): (() => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, data: UiActivateWorktreePayload) =>
+      callback(data)
     ipcRenderer.on('ui:activateWorktree', listener)
     return () => ipcRenderer.removeListener('ui:activateWorktree', listener)
   }

--- a/src/preload/api/ui-command-event-api.ts
+++ b/src/preload/api/ui-command-event-api.ts
@@ -1,5 +1,6 @@
 import type { MarkdownDocument } from '../../shared/filesystem-entry-types'
 import type { PersistedUIState } from '../../shared/persisted-ui-state-types'
+import type { ExecutionHostId } from '../../shared/execution-host'
 import type { TuiAgent } from '../../shared/tui-agent'
 import type {
   WorktreeDefaultTabsLaunch,
@@ -34,6 +35,18 @@ import type {
 } from '../../shared/session-tab-close'
 
 export type CloseActiveTabPayload = { sourceId: string }
+
+export type UiActivateWorktreePayload = {
+  repoId?: string
+  worktreeId: string
+  setup?: WorktreeSetupLaunch
+  startup?: WorktreeStartupLaunch
+  defaultTabs?: WorktreeDefaultTabsLaunch
+  /** Present only for native-notification navigation; null means project-only fallback. */
+  notificationPaneKey?: string | null
+  /** Captured native-notification owner; absent for legacy and ordinary CLI intents. */
+  executionHostId?: ExecutionHostId
+}
 
 export type UiCommandEventApi = {
   get: () => Promise<PersistedUIState>
@@ -130,15 +143,7 @@ export type UiCommandEventApi = {
   onAppMenuPaste: (callback: () => void) => () => void
   onAppMenuSelectionAction: (callback: (action: 'copy' | 'select-all') => void) => () => void
   onEditableContextPaste: (callback: (data: { plainTextOnly: boolean }) => void) => () => void
-  onActivateWorktree: (
-    callback: (data: {
-      repoId: string
-      worktreeId: string
-      setup?: WorktreeSetupLaunch
-      startup?: WorktreeStartupLaunch
-      defaultTabs?: WorktreeDefaultTabsLaunch
-    }) => void
-  ) => () => void
+  onActivateWorktree: (callback: (data: UiActivateWorktreePayload) => void) => () => void
   onCreateTerminal: (
     callback: (data: {
       requestId?: string

--- a/src/renderer/src/components/terminal-pane/notification-navigation-target.test.ts
+++ b/src/renderer/src/components/terminal-pane/notification-navigation-target.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { toRemoteRuntimePtyId } from '../../../../shared/remote-runtime-pty-id'
+import { getNotificationNavigationTarget } from './notification-navigation-target'
+
+const paneKey = 'tab-1:11111111-1111-4111-8111-111111111111'
+
+function targetFor(
+  ptyId: string,
+  worktrees: { id: string; repoId: string; hostId?: string }[]
+): ReturnType<typeof getNotificationNavigationTarget> {
+  return getNotificationNavigationTarget(
+    {
+      activeWorktreeId: null,
+      tabsByWorktree: { 'wt-primary': [{ id: 'tab-1', ptyId }] },
+      terminalLayoutsByTabId: {},
+      worktreesByRepo: { repo1: worktrees },
+      repos: [{ id: 'repo1', connectionId: null }]
+    } as never,
+    'wt-primary',
+    paneKey
+  )
+}
+
+describe('getNotificationNavigationTarget', () => {
+  it.each([
+    [
+      'runtime pane',
+      toRemoteRuntimePtyId('pty-1', 'runtime-a'),
+      [{ id: 'wt-primary', repoId: 'repo1' }],
+      { executionHostId: 'runtime:runtime-a', paneKey }
+    ],
+    [
+      'local pane with duplicate owners',
+      'pty-1',
+      [
+        { id: 'wt-primary', repoId: 'repo1' },
+        { id: 'wt-primary', repoId: 'repo1', hostId: 'ssh:other' }
+      ],
+      { executionHostId: 'local', paneKey }
+    ],
+    [
+      'foreign PTY with known owner',
+      'remote:unscoped',
+      [{ id: 'wt-primary', repoId: 'repo1', hostId: 'ssh:known' }],
+      { executionHostId: 'ssh:known' }
+    ],
+    [
+      'foreign PTY without remote owner',
+      'remote:unscoped',
+      [{ id: 'wt-primary', repoId: 'repo1' }],
+      {}
+    ]
+  ] as const)('builds a safe %s target', (_, ptyId, worktrees, expected) => {
+    expect(targetFor(ptyId, [...worktrees])).toEqual(expected)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/notification-navigation-target.ts
+++ b/src/renderer/src/components/terminal-pane/notification-navigation-target.ts
@@ -1,0 +1,31 @@
+import type { useAppStore } from '@/store'
+import { LOCAL_EXECUTION_HOST_ID, type ExecutionHostId } from '../../../../shared/execution-host'
+import { parsePaneKey } from '../../../../shared/stable-pane-id'
+import { getPtyExecutionHost } from '../../../../shared/terminal-execution-host'
+import { getResolvedExecutionHostIdForWorktree } from '@/lib/resolved-worktree-execution-host'
+
+export function getNotificationNavigationTarget(
+  state: ReturnType<typeof useAppStore.getState>,
+  worktreeId: string,
+  paneKey: string | undefined
+): { executionHostId?: ExecutionHostId; paneKey?: string } {
+  const pane = paneKey ? parsePaneKey(paneKey) : null
+  const tab = pane
+    ? (state.tabsByWorktree[worktreeId] ?? []).find((candidate) => candidate.id === pane.tabId)
+    : undefined
+  const ptyId = pane
+    ? (state.terminalLayoutsByTabId[pane.tabId]?.ptyIdsByLeafId?.[pane.leafId] ?? tab?.ptyId)
+    : null
+  if (ptyId) {
+    const ptyHost = getPtyExecutionHost(ptyId)
+    if (ptyHost === 'foreign') {
+      const fallbackHost = getResolvedExecutionHostIdForWorktree(state, worktreeId)
+      return fallbackHost && fallbackHost !== LOCAL_EXECUTION_HOST_ID
+        ? { executionHostId: fallbackHost }
+        : {}
+    }
+    return { executionHostId: ptyHost ?? LOCAL_EXECUTION_HOST_ID, ...(paneKey ? { paneKey } : {}) }
+  }
+  const executionHostId = getResolvedExecutionHostIdForWorktree(state, worktreeId)
+  return executionHostId ? { executionHostId, ...(paneKey ? { paneKey } : {}) } : {}
+}

--- a/src/renderer/src/components/terminal-pane/terminal-notification-state-host.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-notification-state-host.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { toRemoteRuntimePtyId } from '../../../../shared/remote-runtime-pty-id'
+import { isCurrentKnownPaneKey } from './terminal-notification-state'
+
+describe('notification pane host ownership', () => {
+  it('rejects a current pane owned by a different runtime host', () => {
+    const paneKey = 'tab-1:11111111-1111-4111-8111-111111111111'
+    const state = {
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-1', ptyId: toRemoteRuntimePtyId('pty-1', 'env-other') }]
+      },
+      terminalLayoutsByTabId: {},
+      suppressedPtyExitIds: {}
+    } as never
+
+    expect(isCurrentKnownPaneKey(state, 'wt-1', paneKey, 'runtime:env-1')).toBe(false)
+    expect(isCurrentKnownPaneKey(state, 'wt-1', paneKey, 'runtime:env-other')).toBe(true)
+  })
+
+  it('rejects an exact target whose host cannot be proven from a PTY', () => {
+    const state = {
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
+      terminalLayoutsByTabId: {},
+      suppressedPtyExitIds: {}
+    } as never
+
+    expect(
+      isCurrentKnownPaneKey(
+        state,
+        'wt-1',
+        'tab-1:11111111-1111-4111-8111-111111111111',
+        'runtime:env-1'
+      )
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-notification-state.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-notification-state.ts
@@ -2,8 +2,10 @@ import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
 import type { useAppStore } from '@/store'
 import { getWorktreeMapFromState } from '@/store/selectors'
 import { AGENT_STATUS_STALE_AFTER_MS } from '../../../../shared/agent-status-types'
+import { LOCAL_EXECUTION_HOST_ID, type ExecutionHostId } from '../../../../shared/execution-host'
 import { parsePaneKey } from '../../../../shared/stable-pane-id'
 import type { TerminalPaneLayoutNode } from '../../../../shared/terminal-tab-types'
+import { getPtyExecutionHost } from '../../../../shared/terminal-execution-host'
 
 type StoreSnapshot = ReturnType<typeof useAppStore.getState>
 
@@ -109,7 +111,8 @@ export function isCurrentLivePaneKey(
 export function isCurrentKnownPaneKey(
   state: StoreSnapshot,
   worktreeId: string,
-  paneKey: string
+  paneKey: string,
+  executionHostId?: ExecutionHostId
 ): boolean {
   const parsed = parsePaneKey(paneKey)
   if (!parsed) {
@@ -137,6 +140,16 @@ export function isCurrentKnownPaneKey(
   }
 
   const leafPtyId = layout?.ptyIdsByLeafId?.[parsed.leafId]
+  const ownerPtyId = leafPtyId ?? targetTabPtyId
+  if (executionHostId) {
+    if (!ownerPtyId) {
+      return false
+    }
+    const paneHost = getPtyExecutionHost(ownerPtyId)
+    if (paneHost === 'foreign' || (paneHost ?? LOCAL_EXECUTION_HOST_ID) !== executionHostId) {
+      return false
+    }
+  }
   // Why: when there is no live PTY map yet, a tab/leaf PTY hint proves this is
   // an inactive-but-current pane. If hydration has no hint yet, keep accepting
   // known-tab hook snapshots; only explicit suppressed hints mean teardown.

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -175,6 +175,7 @@ describe('dispatchTerminalNotification', () => {
         }),
         worktreeId: 'wt-primary',
         paneKey,
+        executionHostId: 'local',
         repoLabel: 'orca',
         worktreeLabel: 'master',
         terminalTitle: 'codex',

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -26,6 +26,7 @@ import {
   isOrcaWindowForegroundFocused,
   isVisibleForegroundPaneKey
 } from './terminal-notification-pane-visibility'
+import { getNotificationNavigationTarget } from './notification-navigation-target'
 
 const AGENT_NOTIFICATION_SNAPSHOT_MAX_AGE_MS = 10_000
 
@@ -185,6 +186,7 @@ export function dispatchTerminalNotification(
   // itself is the source of truth for its owning repo.
   const worktree = getWorktreeMapFromState(state).get(worktreeId)
   const repo = worktree ? getRepoMapFromState(state).get(worktree.repoId) : null
+  const notificationTarget = getNotificationNavigationTarget(state, worktreeId, event.paneKey)
   const customSoundId = state.settings?.notifications?.customSoundId ?? 'system'
   const customSoundVolume = state.settings?.notifications?.customSoundVolume ?? null
   // Why: pane keys are reused across turns. A rich OS notification must not
@@ -217,7 +219,7 @@ export function dispatchTerminalNotification(
       source: event.source,
       ...(notificationId ? { notificationId } : {}),
       worktreeId,
-      paneKey: event.paneKey,
+      ...notificationTarget,
       repoLabel: repo?.displayName,
       worktreeLabel: worktree?.displayName || worktree?.branch || worktreeId,
       hasMultipleActiveRepos: countReposNeedingNotificationDisambiguation(state) > 1,

--- a/src/renderer/src/hooks/ipc-events/app-lifetime-ipc-bridge.ts
+++ b/src/renderer/src/hooks/ipc-events/app-lifetime-ipc-bridge.ts
@@ -4,6 +4,8 @@ import { createBackgroundSleepingAgentWakeDispatcher } from '@/lib/wake-sleeping
 import { attachMobileMarkdownBridge } from '@/runtime/mobile-markdown-bridge'
 import { resetAgentHookCompletionNotificationCoordinators } from '../agent-hook-completion-notifications'
 import { useAppStore } from '../../store'
+import { normalizeExecutionHostId } from '../../../../shared/execution-host'
+import { focusNotificationPaneAfterActivation } from './notification-pane-focus'
 import { registerAgentStatusIpcBridge } from './agent-status-ipc-bridge'
 import { registerBrowserRequestIpcBridge } from './browser-request-ipc-bridge'
 import { registerBrowserStateIpcBridge } from './browser-state-ipc-bridge'
@@ -80,22 +82,55 @@ export function installAppLifetimeIpcEvents(
   registerSettingsAndSidebarIpcBridge(unsubs)
   registerWorkspaceShortcutIpcBridge(unsubs)
   registerOsMarkdownFileOpenBridge(unsubs)
+  // Why: latest click wins — an earlier intent must not steal focus after a newer one resolves.
+  let latestActivateWorktreeIntent = 0
   unsubs.push(
-    window.api.ui.onActivateWorktree(({ repoId, worktreeId, setup, startup, defaultTabs }) => {
-      void worktreeRuntime
-        .activateNotifiedWorktree(
-          {
-            type: 'activateWorktree',
-            repoId,
-            worktreeId,
-            ...(setup ? { setup } : {}),
-            ...(startup ? { startup } : {}),
-            ...(defaultTabs ? { defaultTabs } : {})
-          },
-          { allowRuntimeEnvironment: false }
-        )
-        .catch((error) => console.error('Failed to activate CLI-created worktree:', error))
-    })
+    window.api.ui.onActivateWorktree(
+      ({
+        repoId,
+        worktreeId,
+        setup,
+        startup,
+        defaultTabs,
+        notificationPaneKey,
+        executionHostId
+      }) => {
+        const intent = ++latestActivateWorktreeIntent
+        const notificationExecutionHostId = normalizeExecutionHostId(executionHostId)
+        void worktreeRuntime
+          .activateNotifiedWorktree(
+            {
+              type: 'activateWorktree',
+              worktreeId,
+              ...(repoId ? { repoId } : {}),
+              ...(setup ? { setup } : {}),
+              ...(startup ? { startup } : {}),
+              ...(defaultTabs ? { defaultTabs } : {}),
+              ...(notificationPaneKey !== undefined ? { notificationPaneKey } : {}),
+              ...(notificationExecutionHostId
+                ? { executionHostId: notificationExecutionHostId }
+                : {})
+            },
+            {
+              // Why: a notification click names its own host, so it may target a runtime workspace.
+              allowRuntimeEnvironment: notificationPaneKey !== undefined,
+              isCurrentLocalIntent: () => intent === latestActivateWorktreeIntent
+            }
+          )
+          .then(async (activated) => {
+            if (!activated || intent !== latestActivateWorktreeIntent) {
+              return
+            }
+            await focusNotificationPaneAfterActivation({
+              worktreeId,
+              notificationPaneKey,
+              executionHostId: notificationExecutionHostId,
+              isCurrentIntent: () => intent === latestActivateWorktreeIntent
+            })
+          })
+          .catch((error) => console.error('Failed to activate CLI-created worktree:', error))
+      }
+    )
   )
 
   registerTerminalPresentationIpcBridge(unsubs)

--- a/src/renderer/src/hooks/ipc-events/notification-pane-focus.ts
+++ b/src/renderer/src/hooks/ipc-events/notification-pane-focus.ts
@@ -1,0 +1,61 @@
+import { useAppStore } from '../../store'
+import { isCurrentKnownPaneKey } from '@/components/terminal-pane/terminal-notification-state'
+import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
+import { parsePaneKey } from '../../../../shared/stable-pane-id'
+import { activateNotificationRuntimeTarget } from './notification-runtime-navigation'
+
+/**
+ * Second half of a notification click: activation has resolved the workspace, so select and focus
+ * the pane that produced the notification. A pane that has since closed leaves the workspace
+ * activated with its current session selected — the closed session is never recreated.
+ */
+export async function focusNotificationPaneAfterActivation(args: {
+  worktreeId: string
+  notificationPaneKey?: string | null
+  executionHostId: ExecutionHostId | null
+  isCurrentIntent: () => boolean
+}): Promise<void> {
+  const { worktreeId, notificationPaneKey, executionHostId, isCurrentIntent } = args
+  const activateWorkspaceOnly = async (): Promise<void> => {
+    if (executionHostId) {
+      await activateNotificationRuntimeTarget({ executionHostId, worktreeId })
+    }
+  }
+
+  const pane = notificationPaneKey ? parsePaneKey(notificationPaneKey) : null
+  if (
+    !notificationPaneKey ||
+    !pane ||
+    !isCurrentKnownPaneKey(
+      useAppStore.getState(),
+      worktreeId,
+      notificationPaneKey,
+      executionHostId ?? undefined
+    )
+  ) {
+    await activateWorkspaceOnly()
+    return
+  }
+
+  // Why: re-check the pane after the runtime round-trip — it can close, or a newer click can win, while in flight.
+  if (
+    !executionHostId ||
+    !(await activateNotificationRuntimeTarget({
+      executionHostId,
+      worktreeId,
+      tabId: pane.tabId,
+      leafId: pane.leafId
+    })) ||
+    !isCurrentIntent() ||
+    !isCurrentKnownPaneKey(useAppStore.getState(), worktreeId, notificationPaneKey, executionHostId)
+  ) {
+    return
+  }
+
+  activateTabAndFocusPane(pane.tabId, pane.leafId, {
+    ackPaneKeyOnSuccess: notificationPaneKey,
+    flashFocusedPane: true,
+    scrollToBottomIfOutputSinceLastView: true
+  })
+}

--- a/src/renderer/src/hooks/ipc-events/notification-runtime-navigation.test.ts
+++ b/src/renderer/src/hooks/ipc-events/notification-runtime-navigation.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { activateNotificationRuntimeTarget } from './notification-runtime-navigation'
+
+const runtimeMocks = vi.hoisted(() => ({
+  activateTab: vi.fn(),
+  activateWorktree: vi.fn()
+}))
+
+vi.mock('@/runtime/web-runtime-session', () => ({
+  activateWebRuntimeSessionTab: runtimeMocks.activateTab,
+  activateWebRuntimeSessionWorktree: runtimeMocks.activateWorktree
+}))
+
+describe('activateNotificationRuntimeTarget', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('activates the exact runtime leaf when it is still known', async () => {
+    runtimeMocks.activateTab.mockResolvedValueOnce(true)
+
+    await expect(
+      activateNotificationRuntimeTarget({
+        executionHostId: 'runtime:env-1',
+        worktreeId: 'wt-1',
+        tabId: 'tab-1',
+        leafId: 'leaf-1'
+      })
+    ).resolves.toBe(true)
+
+    expect(runtimeMocks.activateTab).toHaveBeenCalledWith({
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: 'leaf-1',
+      environmentId: 'env-1'
+    })
+    expect(runtimeMocks.activateWorktree).not.toHaveBeenCalled()
+  })
+
+  it('activates only the runtime worktree when no target tab remains', async () => {
+    runtimeMocks.activateWorktree.mockResolvedValueOnce(true)
+
+    await expect(
+      activateNotificationRuntimeTarget({
+        executionHostId: 'runtime:env-1',
+        worktreeId: 'wt-1'
+      })
+    ).resolves.toBe(true)
+
+    expect(runtimeMocks.activateWorktree).toHaveBeenCalledWith({
+      worktreeId: 'wt-1',
+      environmentId: 'env-1'
+    })
+    expect(runtimeMocks.activateTab).not.toHaveBeenCalled()
+  })
+
+  it('reports a stale runtime tab without falling through to worktree activation', async () => {
+    runtimeMocks.activateTab.mockResolvedValueOnce(false)
+
+    await expect(
+      activateNotificationRuntimeTarget({
+        executionHostId: 'runtime:env-1',
+        worktreeId: 'wt-1',
+        tabId: 'tab-stale',
+        leafId: 'leaf-stale'
+      })
+    ).resolves.toBe(false)
+    expect(runtimeMocks.activateWorktree).not.toHaveBeenCalled()
+  })
+
+  it('keeps runtime folder fallback local instead of sending an invalid worktree selector', async () => {
+    await expect(
+      activateNotificationRuntimeTarget({
+        executionHostId: 'runtime:env-1',
+        worktreeId: 'folder:folder-1'
+      })
+    ).resolves.toBe(true)
+
+    expect(runtimeMocks.activateTab).not.toHaveBeenCalled()
+    expect(runtimeMocks.activateWorktree).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/hooks/ipc-events/notification-runtime-navigation.ts
+++ b/src/renderer/src/hooks/ipc-events/notification-runtime-navigation.ts
@@ -1,0 +1,33 @@
+import { parseExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
+import {
+  activateWebRuntimeSessionTab,
+  activateWebRuntimeSessionWorktree
+} from '@/runtime/web-runtime-session'
+import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
+
+export async function activateNotificationRuntimeTarget(args: {
+  executionHostId: ExecutionHostId
+  worktreeId: string
+  tabId?: string
+  leafId?: string
+}): Promise<boolean> {
+  const host = parseExecutionHostId(args.executionHostId)
+  if (host?.kind !== 'runtime') {
+    return true
+  }
+  if (args.tabId) {
+    return await activateWebRuntimeSessionTab({
+      worktreeId: args.worktreeId,
+      tabId: args.tabId,
+      ...(args.leafId ? { leafId: args.leafId } : {}),
+      environmentId: host.environmentId
+    })
+  }
+  if (parseWorkspaceKey(args.worktreeId)?.type === 'folder') {
+    return true
+  }
+  return await activateWebRuntimeSessionWorktree({
+    worktreeId: args.worktreeId,
+    environmentId: host.environmentId
+  })
+}

--- a/src/renderer/src/hooks/ipc-events/worktree-event-runtime.ts
+++ b/src/renderer/src/hooks/ipc-events/worktree-event-runtime.ts
@@ -1,4 +1,4 @@
-import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { activateAndRevealWorkspace, activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { LOCAL_EXECUTION_HOST_ID, type ExecutionHostId } from '../../../../shared/execution-host'
 import type { RuntimeClientEvent } from '../../../../shared/runtime-client-events'
 import type { AppState } from '../../store/types'
@@ -21,12 +21,22 @@ function getVisibleWorktreeIdsForRepo(state: AppState, repoId: string): Set<stri
   return new Set((state.worktreesByRepo[repoId] ?? []).map((worktree) => worktree.id))
 }
 
+/** A notification click carries no repoId for folder workspaces, and names its execution owner. */
+export type NotifiedWorktreeActivation = Omit<
+  Extract<RuntimeClientEvent, { type: 'activateWorktree' }>,
+  'repoId'
+> & {
+  repoId?: string
+  notificationPaneKey?: string | null
+  executionHostId?: ExecutionHostId
+}
+
 export type WorktreeEventRuntime = {
   worktreeChangeRefreshQueue: WorktreeChangeRefreshQueue
   activateNotifiedWorktree: (
-    event: Extract<RuntimeClientEvent, { type: 'activateWorktree' }>,
-    options: { allowRuntimeEnvironment: boolean }
-  ) => Promise<void>
+    event: NotifiedWorktreeActivation,
+    options: { allowRuntimeEnvironment: boolean; isCurrentLocalIntent?: () => boolean }
+  ) => Promise<boolean>
 }
 
 export function createWorktreeEventRuntime(
@@ -138,27 +148,58 @@ export function createWorktreeEventRuntime(
       worktreeId,
       setup,
       startup,
-      defaultTabs
-    }: Extract<RuntimeClientEvent, { type: 'activateWorktree' }>,
-    options: { allowRuntimeEnvironment: boolean }
-  ): Promise<void> => {
+      defaultTabs,
+      notificationPaneKey,
+      executionHostId
+    }: NotifiedWorktreeActivation,
+    options: { allowRuntimeEnvironment: boolean; isCurrentLocalIntent?: () => boolean }
+  ): Promise<boolean> => {
     if (!options.allowRuntimeEnvironment && isRuntimeEnvironmentActive()) {
       // Why: local CLI worktree events carry local ids; runtime activation comes via the remote stream, allowed separately.
-      return
+      return false
     }
-    const existedBeforeFetch = Boolean(useAppStore.getState().getKnownWorktreeById(worktreeId))
+    if (notificationPaneKey !== undefined && !executionHostId) {
+      // Why: notifications must name their owner; an unscoped fetch can select a same-id workspace on another host.
+      return false
+    }
+    if (!repoId) {
+      // Why: folder workspaces have no repo to fetch, so activate the workspace id directly.
+      return (
+        activateAndRevealWorkspace(worktreeId, {
+          ...(executionHostId ? { executionHostId } : {}),
+          ...(notificationPaneKey !== undefined ? { providesInitialSurface: true } : {})
+        }) !== false
+      )
+    }
+    const getKnownWorktree = (): boolean =>
+      Boolean(
+        executionHostId
+          ? useAppStore.getState().getKnownWorktreeById(worktreeId, executionHostId)
+          : useAppStore.getState().getKnownWorktreeById(worktreeId)
+      )
+    const existedBeforeFetch = getKnownWorktree()
     // Why: fetch first so activation can resolve the CLI-created worktree; it arrived from main, not yet in renderer state.
-    await useAppStore.getState().fetchWorktrees(repoId)
-    const existsAfterFetch = Boolean(useAppStore.getState().getKnownWorktreeById(worktreeId))
+    await (executionHostId
+      ? useAppStore.getState().fetchWorktrees(repoId, { executionHostId })
+      : useAppStore.getState().fetchWorktrees(repoId))
+    if (options.isCurrentLocalIntent && !options.isCurrentLocalIntent()) {
+      // Why: a newer click superseded this one while the fetch was in flight.
+      return false
+    }
+    const existsAfterFetch = getKnownWorktree()
     // Why: use the canonical activation path so the CLI switch records a back/forward visit, or the nav buttons ignore it.
-    activateAndRevealWorktree(worktreeId, {
-      ...(setup ? { setup } : {}),
-      ...(startup ? { startup } : {}),
-      ...(defaultTabs ? { defaultTabs } : {}),
-      ...(!existedBeforeFetch && existsAfterFetch ? { sidebarRevealBehavior: 'auto' } : {}),
-      // Why: this activation came from the host runtime stream; echoing it back can create a selection loop.
-      notifyHostRuntime: false
-    })
+    return (
+      activateAndRevealWorktree(worktreeId, {
+        ...(setup ? { setup } : {}),
+        ...(startup ? { startup } : {}),
+        ...(defaultTabs ? { defaultTabs } : {}),
+        ...(!existedBeforeFetch && existsAfterFetch ? { sidebarRevealBehavior: 'auto' } : {}),
+        ...(executionHostId ? { executionHostId } : {}),
+        ...(notificationPaneKey !== undefined ? { providesInitialSurface: true } : {}),
+        // Why: this activation came from the host runtime stream; echoing it back can create a selection loop.
+        notifyHostRuntime: false
+      }) !== false
+    )
   }
 
   return { worktreeChangeRefreshQueue, activateNotifiedWorktree }

--- a/src/renderer/src/hooks/useIpcEvents-cli-worktree-activation.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents-cli-worktree-activation.test.ts
@@ -1,5 +1,6 @@
 import type * as ReactModule from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toRemoteRuntimePtyId } from '../../../shared/remote-runtime-pty-id'
 
 describe('useIpcEvents CLI-created worktree activation', () => {
   beforeEach(() => {
@@ -15,18 +16,39 @@ describe('useIpcEvents CLI-created worktree activation', () => {
   // the back/forward buttons ignoring the CLI-driven switch. This test pins
   // the handler to the canonical `activateAndRevealWorktree` helper, which
   // is the single place that records the visit in history.
-  it('uses immediate reveal only for newly fetched ui:activateWorktree targets', async () => {
-    const activateAndRevealWorktree = vi.fn()
+  it('routes ui:activateWorktree intents through their workspace activation paths', async () => {
+    const callOrder: string[] = []
+    const activateAndRevealWorktree = vi.fn(() => {
+      callOrder.push('activate project')
+      return { primaryTabId: 'tab-native' }
+    })
+    const activateAndRevealWorkspace = vi.fn((): { primaryTabId: string } | false => {
+      callOrder.push('activate workspace')
+      return { primaryTabId: 'tab-folder' }
+    })
+    const activateTabAndFocusPane = vi.fn(() => {
+      callOrder.push('focus pane')
+    })
+    const activateNotificationRuntimeTarget = vi.fn().mockResolvedValue(true)
+    const settings = { activeRuntimeEnvironmentId: null as string | null, terminalFontSize: 13 }
+    const nativeChatTab = { id: 'tab-native', ptyId: 'pty-native', viewMode: 'chat' }
+    let tabsByWorktree: Record<string, (typeof nativeChatTab)[]> = {
+      'wt-existing': [nativeChatTab]
+    }
+    let terminalLayoutsByTabId: Record<string, unknown> = {}
     let worktreeKnown = false
     const fetchWorktrees = vi.fn().mockImplementation(async () => {
+      callOrder.push('fetch')
       worktreeKnown = true
     })
     const activateWorktreeListenerRef: {
       current:
         | ((data: {
-            repoId: string
+            repoId?: string
             worktreeId: string
             setup?: { runnerScriptPath: string; envVars: Record<string, string> }
+            notificationPaneKey?: string | null
+            executionHostId?: 'local' | `ssh:${string}` | `runtime:${string}`
           }) => void)
         | null
     } = { current: null }
@@ -77,7 +99,10 @@ describe('useIpcEvents CLI-created worktree activation', () => {
           enqueueSshCredentialRequest: vi.fn(),
           removeSshCredentialRequest: vi.fn(),
           clearTabPtyId: vi.fn(),
-          settings: { terminalFontSize: 13 }
+          tabsByWorktree,
+          terminalLayoutsByTabId,
+          suppressedPtyExitIds: {},
+          settings
         })
       }
     }))
@@ -87,7 +112,18 @@ describe('useIpcEvents CLI-created worktree activation', () => {
     }))
     vi.doMock('@/lib/worktree-activation', () => ({
       activateAndRevealWorktree,
+      activateAndRevealWorkspace,
       ensureWorktreeHasInitialTerminal: vi.fn()
+    }))
+    vi.doMock('@/lib/activate-tab-and-focus-pane', () => ({ activateTabAndFocusPane }))
+    vi.doMock('./ipc-events/notification-runtime-navigation', () => ({
+      activateNotificationRuntimeTarget
+    }))
+    vi.doMock('@/runtime/web-runtime-session', () => ({
+      closeWebRuntimeSessionTab: vi.fn(),
+      createWebRuntimeSessionTerminal: vi.fn(),
+      isWebRuntimeSessionActive: (environmentId: string | null | undefined) =>
+        Boolean(environmentId?.trim())
     }))
     vi.doMock('@/components/sidebar/visible-worktrees', () => ({
       getVisibleWorktreeIds: () => []
@@ -132,9 +168,11 @@ describe('useIpcEvents CLI-created worktree activation', () => {
           onWorktreeHistoryNavigate: () => () => {},
           onActivateWorktree: (
             listener: (data: {
-              repoId: string
+              repoId?: string
               worktreeId: string
               setup?: { runnerScriptPath: string; envVars: Record<string, string> }
+              notificationPaneKey?: string | null
+              executionHostId?: 'local' | `ssh:${string}` | `runtime:${string}`
             }) => void
           ) => {
             activateWorktreeListenerRef.current = listener
@@ -274,6 +312,293 @@ describe('useIpcEvents CLI-created worktree activation', () => {
     expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-existing', {
       notifyHostRuntime: false
     })
+
+    // Why: a folder workspace has no repo to fetch — it activates by workspace id alone.
+    activateAndRevealWorktree.mockClear()
+    fetchWorktrees.mockClear()
+    activateWorktreeListenerRef.current({ worktreeId: 'folder:folder-1' })
+
+    expect(fetchWorktrees).not.toHaveBeenCalled()
+    expect(activateAndRevealWorktree).not.toHaveBeenCalled()
+    expect(activateAndRevealWorkspace).toHaveBeenCalledWith('folder:folder-1', {})
+
+    // Why: the ordering this feature exists for — pane focus lands only after activation resolves.
+    activateAndRevealWorktree.mockClear()
+    fetchWorktrees.mockClear()
+    callOrder.length = 0
+    const paneKey = 'tab-native:123e4567-e89b-42d3-a456-426614174000'
+    activateWorktreeListenerRef.current({
+      repoId: 'repo-1',
+      worktreeId: 'wt-existing',
+      notificationPaneKey: paneKey,
+      executionHostId: 'local'
+    })
+
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(callOrder).toEqual(['fetch', 'activate project', 'focus pane'])
+    expect(activateAndRevealWorktree).toHaveBeenLastCalledWith('wt-existing', {
+      executionHostId: 'local',
+      notifyHostRuntime: false,
+      providesInitialSurface: true
+    })
+    expect(activateTabAndFocusPane).toHaveBeenCalledWith(
+      'tab-native',
+      '123e4567-e89b-42d3-a456-426614174000',
+      {
+        ackPaneKeyOnSuccess: paneKey,
+        flashFocusedPane: true,
+        scrollToBottomIfOutputSinceLastView: true
+      }
+    )
+
+    // Why: a null pane key is the project-only fallback — activate, never focus.
+    activateAndRevealWorktree.mockClear()
+    activateTabAndFocusPane.mockClear()
+    activateWorktreeListenerRef.current({
+      repoId: 'repo-1',
+      worktreeId: 'wt-existing',
+      notificationPaneKey: null,
+      executionHostId: 'local'
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(activateAndRevealWorktree).toHaveBeenCalledOnce()
+    expect(activateAndRevealWorktree).toHaveBeenLastCalledWith('wt-existing', {
+      executionHostId: 'local',
+      notifyHostRuntime: false,
+      providesInitialSurface: true
+    })
+    expect(activateTabAndFocusPane).not.toHaveBeenCalled()
+
+    // Why: a closed session keeps its project open — it is never recreated.
+    activateAndRevealWorktree.mockClear()
+    tabsByWorktree = { 'wt-existing': [] }
+    terminalLayoutsByTabId = {}
+    activateWorktreeListenerRef.current({
+      repoId: 'repo-1',
+      worktreeId: 'wt-existing',
+      notificationPaneKey: paneKey,
+      executionHostId: 'local'
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(activateAndRevealWorktree).toHaveBeenCalledOnce()
+    expect(activateTabAndFocusPane).not.toHaveBeenCalled()
+
+    // Why: the tab survived but the notifying leaf did not.
+    activateAndRevealWorktree.mockClear()
+    tabsByWorktree = { 'wt-existing': [nativeChatTab] }
+    terminalLayoutsByTabId = {
+      'tab-native': {
+        root: { type: 'leaf', leafId: '123e4567-e89b-42d3-a456-426614174001' }
+      }
+    }
+    activateWorktreeListenerRef.current({
+      repoId: 'repo-1',
+      worktreeId: 'wt-existing',
+      notificationPaneKey: paneKey,
+      executionHostId: 'local'
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(activateAndRevealWorktree).toHaveBeenCalledOnce()
+    expect(activateTabAndFocusPane).not.toHaveBeenCalled()
+
+    // Why: the pane must belong to the notifying workspace, not merely exist somewhere.
+    activateAndRevealWorktree.mockClear()
+    tabsByWorktree = { 'wt-other': [nativeChatTab] }
+    terminalLayoutsByTabId = {}
+    activateWorktreeListenerRef.current({
+      repoId: 'repo-1',
+      worktreeId: 'wt-existing',
+      notificationPaneKey: paneKey,
+      executionHostId: 'local'
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(activateAndRevealWorktree).toHaveBeenCalledOnce()
+    expect(activateTabAndFocusPane).not.toHaveBeenCalled()
+
+    // Why: folder workspaces get the same ordered focus, without a fetch.
+    activateAndRevealWorkspace.mockClear()
+    activateTabAndFocusPane.mockClear()
+    fetchWorktrees.mockClear()
+    callOrder.length = 0
+    tabsByWorktree = { 'folder:folder-1': [nativeChatTab] }
+    activateWorktreeListenerRef.current({
+      worktreeId: 'folder:folder-1',
+      notificationPaneKey: paneKey,
+      executionHostId: 'local'
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(fetchWorktrees).not.toHaveBeenCalled()
+    expect(callOrder).toEqual(['activate workspace', 'focus pane'])
+    expect(activateAndRevealWorkspace).toHaveBeenLastCalledWith('folder:folder-1', {
+      executionHostId: 'local',
+      providesInitialSurface: true
+    })
+    expect(activateTabAndFocusPane).toHaveBeenCalledWith(
+      'tab-native',
+      '123e4567-e89b-42d3-a456-426614174000',
+      expect.anything()
+    )
+
+    // Why: a refused activation (missing/unmounted path) must not focus anything.
+    activateAndRevealWorkspace.mockReturnValueOnce(false)
+    activateTabAndFocusPane.mockClear()
+    activateWorktreeListenerRef.current({
+      worktreeId: 'folder:folder-1',
+      notificationPaneKey: paneKey,
+      executionHostId: 'local'
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(activateTabAndFocusPane).not.toHaveBeenCalled()
+
+    // Why: fail closed — a notification intent without a resolvable owner is dropped.
+    activateAndRevealWorktree.mockClear()
+    fetchWorktrees.mockClear()
+    activateWorktreeListenerRef.current({
+      repoId: 'repo-1',
+      worktreeId: 'wt-existing',
+      notificationPaneKey: null
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(fetchWorktrees).not.toHaveBeenCalled()
+    expect(activateAndRevealWorktree).not.toHaveBeenCalled()
+
+    activateWorktreeListenerRef.current({
+      repoId: 'repo-1',
+      worktreeId: 'wt-existing',
+      notificationPaneKey: null,
+      executionHostId: 'bogus' as 'local'
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(fetchWorktrees).not.toHaveBeenCalled()
+    expect(activateAndRevealWorktree).not.toHaveBeenCalled()
+
+    // Why: an ordinary CLI intent stays blocked while a runtime environment owns the window.
+    settings.activeRuntimeEnvironmentId = 'env-1'
+    activateAndRevealWorktree.mockClear()
+    activateWorktreeListenerRef.current({ repoId: 'repo-1', worktreeId: 'wt-existing' })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(activateAndRevealWorktree).not.toHaveBeenCalled()
+
+    activateWorktreeListenerRef.current({
+      repoId: 'repo-1',
+      worktreeId: 'wt-existing',
+      notificationPaneKey: null
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(activateAndRevealWorktree).not.toHaveBeenCalled()
+
+    // Why: a host-qualified notification may cross that gate, and scopes its own fetch.
+    activateAndRevealWorktree.mockClear()
+    fetchWorktrees.mockClear()
+    activateWorktreeListenerRef.current({
+      repoId: 'repo-1',
+      worktreeId: 'wt-existing',
+      notificationPaneKey: null,
+      executionHostId: 'local'
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(fetchWorktrees).toHaveBeenCalledWith('repo-1', { executionHostId: 'local' })
+    expect(activateAndRevealWorktree).toHaveBeenLastCalledWith('wt-existing', {
+      executionHostId: 'local',
+      notifyHostRuntime: false,
+      providesInitialSurface: true
+    })
+
+    activateAndRevealWorktree.mockClear()
+    fetchWorktrees.mockClear()
+    activateWorktreeListenerRef.current({
+      repoId: 'repo-1',
+      worktreeId: 'wt-existing',
+      notificationPaneKey: null,
+      executionHostId: 'ssh:notification-origin'
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(fetchWorktrees).toHaveBeenCalledWith('repo-1', {
+      executionHostId: 'ssh:notification-origin'
+    })
+    expect(activateAndRevealWorktree).toHaveBeenLastCalledWith('wt-existing', {
+      executionHostId: 'ssh:notification-origin',
+      notifyHostRuntime: false,
+      providesInitialSurface: true
+    })
+
+    activateAndRevealWorkspace.mockClear()
+    activateWorktreeListenerRef.current({
+      worktreeId: 'folder:folder-1',
+      notificationPaneKey: null,
+      executionHostId: 'ssh:folder-origin'
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(activateAndRevealWorkspace).toHaveBeenLastCalledWith('folder:folder-1', {
+      executionHostId: 'ssh:folder-origin',
+      providesInitialSurface: true
+    })
+
+    // Why: a runtime pane is selected on the host before the client focuses it.
+    tabsByWorktree = { 'wt-existing': [nativeChatTab] }
+    const runtimeIntent = {
+      repoId: 'repo-1',
+      worktreeId: 'wt-existing',
+      notificationPaneKey: paneKey,
+      executionHostId: 'runtime:env-1' as const
+    }
+    nativeChatTab.ptyId = toRemoteRuntimePtyId('pty-native', 'env-1')
+    vi.clearAllMocks()
+    activateWorktreeListenerRef.current(runtimeIntent)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(activateNotificationRuntimeTarget).toHaveBeenCalledWith({
+      executionHostId: 'runtime:env-1',
+      worktreeId: 'wt-existing',
+      tabId: 'tab-native',
+      leafId: '123e4567-e89b-42d3-a456-426614174000'
+    })
+
+    vi.clearAllMocks()
+    activateNotificationRuntimeTarget.mockResolvedValueOnce(false)
+    activateWorktreeListenerRef.current(runtimeIntent)
+    await vi.waitFor(() => expect(activateNotificationRuntimeTarget).toHaveBeenCalledTimes(1))
+    expect(activateTabAndFocusPane).not.toHaveBeenCalled()
+
+    // Why: latest click wins — a slower earlier intent must not steal focus when it lands.
+    const oldFetch = Promise.withResolvers<void>()
+    const newFetch = Promise.withResolvers<void>()
+    nativeChatTab.ptyId = 'pty-native'
+    tabsByWorktree = { 'wt-new-intent': [nativeChatTab] }
+    fetchWorktrees.mockImplementation((repoId: string) =>
+      repoId === 'repo-old' ? oldFetch.promise : newFetch.promise
+    )
+    activateAndRevealWorktree.mockClear()
+    activateTabAndFocusPane.mockClear()
+    activateWorktreeListenerRef.current({
+      repoId: 'repo-old',
+      worktreeId: 'wt-old-intent',
+      notificationPaneKey: paneKey,
+      executionHostId: 'local'
+    })
+    activateWorktreeListenerRef.current({
+      repoId: 'repo-new',
+      worktreeId: 'wt-new-intent',
+      notificationPaneKey: paneKey,
+      executionHostId: 'local'
+    })
+    newFetch.resolve()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    oldFetch.resolve()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    expect(activateAndRevealWorktree).toHaveBeenCalledTimes(1)
+    expect(activateAndRevealWorktree).toHaveBeenCalledWith('wt-new-intent', {
+      executionHostId: 'local',
+      notifyHostRuntime: false,
+      providesInitialSurface: true
+    })
+    expect(activateTabAndFocusPane).toHaveBeenCalledTimes(1)
+    expect(activateTabAndFocusPane).toHaveBeenCalledWith(
+      'tab-native',
+      '123e4567-e89b-42d3-a456-426614174000',
+      expect.anything()
+    )
   })
 
   it('routes local and runtime worktree events to their owning hosts', async () => {

--- a/src/renderer/src/lib/activate-tab-and-focus-pane.test.ts
+++ b/src/renderer/src/lib/activate-tab-and-focus-pane.test.ts
@@ -1,14 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { activateTabAndFocusPane } from './activate-tab-and-focus-pane'
+import { FOCUS_TERMINAL_PANE_EVENT } from '@/constants/terminal'
 
 const setActiveTab = vi.hoisted(() => vi.fn())
 const setActiveTabType = vi.hoisted(() => vi.fn())
+const setTabViewMode = vi.hoisted(() => vi.fn())
 
 vi.mock('@/store', () => ({
   useAppStore: {
     getState: () => ({
       setActiveTab,
-      setActiveTabType
+      setActiveTabType,
+      setTabViewMode
     })
   }
 }))
@@ -17,6 +20,7 @@ describe('activateTabAndFocusPane', () => {
   beforeEach(() => {
     setActiveTab.mockImplementation(() => undefined)
     setActiveTabType.mockImplementation(() => undefined)
+    setTabViewMode.mockImplementation(() => undefined)
   })
 
   afterEach(() => {
@@ -63,6 +67,27 @@ describe('activateTabAndFocusPane', () => {
     activateTabAndFocusPane('tab-1', 'leaf-1')
 
     expect(callOrder).toEqual(['type:terminal', 'tab:tab-1'])
+  })
+
+  it('focuses a chat tab without changing its view mode', () => {
+    const dispatchEvent = vi.fn()
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => callback(0))
+    )
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    vi.stubGlobal('window', { dispatchEvent })
+
+    activateTabAndFocusPane('chat-tab', 'chat-leaf')
+
+    expect(setActiveTab).toHaveBeenCalledWith('chat-tab')
+    expect(dispatchEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: FOCUS_TERMINAL_PANE_EVENT,
+        detail: { tabId: 'chat-tab', leafId: 'chat-leaf' }
+      })
+    )
+    expect(setTabViewMode).not.toHaveBeenCalled()
   })
 
   it('reveals the terminal surface for tab-only activation without dispatching pane focus', () => {

--- a/src/renderer/src/lib/worktree-activation-surface-caller-wiring.test.ts
+++ b/src/renderer/src/lib/worktree-activation-surface-caller-wiring.test.ts
@@ -15,6 +15,7 @@ const SURFACE_PROVIDING_CALLERS = [
   'src/renderer/src/components/sidebar/run-worktree-delete-with-toast.ts',
   'src/renderer/src/components/terminal-pane/terminal-file-open-routing.ts',
   'src/renderer/src/hooks/composer-state/full-creation-execution.ts',
+  'src/renderer/src/hooks/ipc-events/worktree-event-runtime.ts',
   'src/renderer/src/lib/fix-checks-agent-launch.ts',
   'src/renderer/src/lib/launch-work-item-direct.ts',
   'src/renderer/src/lib/worktree-creation-flow-execute.ts',

--- a/src/renderer/src/runtime/web-runtime-session-tab-activate-close.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session-tab-activate-close.test.ts
@@ -138,7 +138,8 @@ describe('web runtime session tab actions', () => {
     await expect(
       activateWebRuntimeSessionTab({
         worktreeId: WORKTREE_ID,
-        tabId: 'local-browser-unified'
+        tabId: 'local-browser-unified',
+        leafId: 'leaf-1'
       })
     ).resolves.toBe(true)
     await expect(
@@ -156,6 +157,7 @@ describe('web runtime session tab actions', () => {
         worktree: `id:${WORKTREE_ID}`,
         tabId: 'host-browser-unified',
         notifyClients: false,
+        leafId: 'leaf-1',
         navigation: 'caller',
         intent: 'user'
       },

--- a/src/renderer/src/runtime/web-runtime-session-tab-lifecycle.ts
+++ b/src/renderer/src/runtime/web-runtime-session-tab-lifecycle.ts
@@ -27,6 +27,7 @@ import { refreshWebRuntimeSessionTabsSnapshot } from './web-runtime-session-snap
 export async function activateWebRuntimeSessionTab(args: {
   worktreeId: string
   tabId: string
+  leafId?: string
   environmentId?: string | null
 }): Promise<boolean> {
   return (await callWebRuntimeSessionTabMethod('session.tabs.activate', args)) === 'applied'
@@ -56,6 +57,7 @@ async function callWebRuntimeSessionTabMethod(
   args: {
     worktreeId: string
     tabId: string
+    leafId?: string
     environmentId?: string | null
     reason?: RuntimeSessionTabCloseReason
     publicationEpoch?: string | null
@@ -124,6 +126,8 @@ async function callWebRuntimeSessionTabMethod(
               // Why: the additive navigation target protects new hosts while notifyClients:false protects old hosts.
               notifyClients: false,
               navigation: 'caller' as const,
+              // Why: additive — old hosts ignore it and still activate the tab, new hosts land on the exact pane.
+              ...(args.leafId ? { leafId: args.leafId } : {}),
               // Why: every caller here is a tab click, shortcut, or palette pick —
               // the gesture that is supposed to wake a slept pane.
               intent: 'user' as const

--- a/src/shared/notification-settings-types.ts
+++ b/src/shared/notification-settings-types.ts
@@ -1,4 +1,5 @@
 import type { AgentStatusState, AgentType } from './agent-status-types'
+import type { ExecutionHostId } from './execution-host'
 
 export type NotificationSettings = {
   enabled: boolean
@@ -31,6 +32,8 @@ export type NotificationDispatchRequest = {
   worktreeId?: string
   /** Stable `${tabId}:${leafId}` terminal pane key for click-to-focus routing. */
   paneKey?: string
+  /** Execution owner captured with the pane so duplicate workspace ids stay unambiguous. */
+  executionHostId?: ExecutionHostId
   repoLabel?: string
   worktreeLabel?: string
   hasMultipleActiveRepos?: boolean


### PR DESCRIPTION
## ELI5

When Orca says a session finished, clicking that notification now takes you back to the exact terminal or native-chat session that produced it. If that session has already closed, Orca opens the project without recreating the missing session.

## What Changed

- Routed a native notification click through one ordered worktree/session navigation intent.
- Preserved the originating execution host so local, SSH, runtime, and folder workspaces resolve against the right host.
- Selected and focused the exact terminal or native-chat pane after workspace activation.
- Added stale-target fallback and latest-click-wins behavior without auto-recreating closed sessions.
- Added regression coverage across dispatch, preload IPC, workspace activation, pane focus, host validation, and folder workspaces.

## Why

The old click path could activate Orca without entering the session that produced the completion, and split focus events could race workspace activation. A single host-qualified intent makes the click deterministic while keeping closed sessions closed.

## Linked Issue

Fixes #15943

## Visual Proof

N/A — the system notification and Orca UI are visually unchanged; only the destination selected after clicking changes, and that routing is covered by automated interaction tests.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- `pnpm lint`
- `pnpm typecheck`
- Focused notification/navigation suite: 56 passed
- `pnpm test`: 57,197 passed; four unrelated resource-sensitive shell/PTY/port tests timed out under a pseudo-TTY, then all four passed immediately without a pseudo-TTY (231 passed, 16 skipped)
- `ORCA_COMPUTER_MACOS_SIGN_IDENTITY=- pnpm build`
- Actual platform tested: macOS arm64. No OS-specific path or shortcut behavior changed; platform-neutral IPC/tests cover the shared behavior.

## AI Disclosure

Codex was used to design, implement, test, and review this change.

## Review

- Security: notification targets are normalized at the local IPC boundary; missing, malformed, or foreign execution hosts fail closed.
- Cross-platform: no platform-specific APIs, paths, or shortcuts were added.
- Local, SSH, and remote: host-qualified lookup covers local, SSH, runtime, worktree, and folder workspace activation; the remote wire contract is unchanged.
- Agents, integrations, Git providers, and mobile: generic pane keys are used; provider behavior and the mobile notification payload are unchanged.
- Performance: each click performs one bounded navigation flow and only fetches the named workspace when absent.
- UI quality: no visual change; existing activation/focus primitives are reused.
- Independent final review found no remaining critical, important, or minor issues.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No remote-wire opcode or RPC payload changed. Closed notification targets are not recreated.

Author: GitHub @DEOWL-kan. X/Twitter is not configured on the GitHub profile.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
