### PR TITLE
fix(agents): detect Homebrew-installed CLIs in the install-dir fallback

### DIFF
--- a/src/shared/node-cli-command-resolution.test.ts
+++ b/src/shared/node-cli-command-resolution.test.ts
@@ -1,0 +1,70 @@
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { resolveCliCommand, resolveCliCommands } from './node-cli-command-resolution'
+
+function writeExecutable(directory: string, name: string): string {
+  mkdirSync(directory, { recursive: true })
+  const filePath = join(directory, name)
+  writeFileSync(filePath, '#!/bin/sh\n')
+  chmodSync(filePath, 0o755)
+  return filePath
+}
+
+describe('node-cli-command-resolution Homebrew fallback', () => {
+  let homePath: string
+
+  beforeEach(() => {
+    homePath = mkdtempSync(join(tmpdir(), 'orca-cli-resolution-'))
+  })
+
+  afterEach(() => {
+    rmSync(homePath, { recursive: true, force: true })
+  })
+
+  // Why: the user-home Linuxbrew prefix is the one brew directory a test can
+  // create; the absolute darwin/linuxbrew prefixes share the same lookup path.
+  const linuxbrewBin = (): string => join(homePath, '.linuxbrew', 'bin')
+
+  it('resolves a CLI from the Linuxbrew bin directory when it is not on PATH', () => {
+    const claudePath = writeExecutable(linuxbrewBin(), 'claude')
+    expect(resolveCliCommand('claude', { platform: 'linux', homePath, pathEnv: '' })).toBe(
+      claudePath
+    )
+  })
+
+  it('prefers a PATH entry over the Homebrew fallback', () => {
+    writeExecutable(linuxbrewBin(), 'claude')
+    const pathBin = join(homePath, 'path-bin')
+    const pathClaude = writeExecutable(pathBin, 'claude')
+    expect(resolveCliCommand('claude', { platform: 'linux', homePath, pathEnv: pathBin })).toBe(
+      pathClaude
+    )
+  })
+
+  it('prefers version-manager directories over the Homebrew fallback', () => {
+    writeExecutable(linuxbrewBin(), 'claude')
+    const localBinClaude = writeExecutable(join(homePath, '.local', 'bin'), 'claude')
+    expect(resolveCliCommand('claude', { platform: 'linux', homePath, pathEnv: '' })).toBe(
+      localBinClaude
+    )
+  })
+
+  it('finds brew-installed CLIs during bulk resolution', () => {
+    const claudePath = writeExecutable(linuxbrewBin(), 'claude')
+    const resolved = resolveCliCommands(['claude', 'codex'], {
+      platform: 'linux',
+      homePath,
+      pathEnv: ''
+    })
+    expect(resolved.get('claude')).toBe(claudePath)
+    // Why: an unresolved command stays a bare name so callers can tell it apart.
+    expect(resolved.get('codex')).toBe('codex')
+  })
+
+  it('does not probe brew directories on Windows', () => {
+    writeExecutable(linuxbrewBin(), 'claude')
+    expect(resolveCliCommand('claude', { platform: 'win32', homePath, pathEnv: '' })).toBe('claude')
+  })
+})

--- a/src/shared/node-cli-command-resolution.ts
+++ b/src/shared/node-cli-command-resolution.ts
@@ -118,6 +118,18 @@ function getBaseVersionManagerDirectories(platform: NodeJS.Platform, homePath: s
   return directories
 }
 
+// Why: Homebrew installs agent CLIs (e.g. the claude-code cask) outside every
+// version-manager directory, and GUI/headless launches may lack brew on PATH.
+function getHomebrewBinDirectories(platform: NodeJS.Platform, homePath: string): string[] {
+  if (platform === 'darwin') {
+    return ['/opt/homebrew/bin', '/usr/local/bin']
+  }
+  if (platform === 'linux') {
+    return ['/home/linuxbrew/.linuxbrew/bin', join(homePath, '.linuxbrew', 'bin')]
+  }
+  return []
+}
+
 function getNvmVersionDirectories(homePath: string): string[] {
   const nvmVersionsDir = join(homePath, '.nvm', 'versions', 'node')
   if (!existsSync(nvmVersionsDir)) {
@@ -166,14 +178,15 @@ export function resolveCliCommand(
     getNvmVersionDirectories(homePath),
     executableNames
   )
-  const versionManagerCandidate =
+  const installCandidate =
     nvmCandidate ??
     findFirstExecutable(
       platform,
       getBaseVersionManagerDirectories(platform, homePath),
       executableNames
-    )
-  return versionManagerCandidate ?? commandName
+    ) ??
+    findFirstExecutable(platform, getHomebrewBinDirectories(platform, homePath), executableNames)
+  return installCandidate ?? commandName
 }
 
 export function resolveCliCommands(
@@ -186,7 +199,8 @@ export function resolveCliCommands(
   const homePath = options.homePath ?? homedir()
   const installDirectories = [
     ...getNvmVersionDirectories(homePath),
-    ...getBaseVersionManagerDirectories(platform, homePath)
+    ...getBaseVersionManagerDirectories(platform, homePath),
+    ...getHomebrewBinDirectories(platform, homePath)
   ]
   const resolved = new Map<string, string>()
 


### PR DESCRIPTION
## ELI5

If you installed Claude Code (or another agent CLI) with Homebrew, Orca could fail to notice it exists whenever brew's bin folder wasn't on `PATH` yet — so skill installs silently skipped Claude Code and the skill never became usable there. Orca now also looks in Homebrew's standard folders, the same way it already looks in nvm/volta/pnpm/bun directories.

## What Changed

- `src/shared/node-cli-command-resolution.ts`: added `getHomebrewBinDirectories` (`/opt/homebrew/bin` + `/usr/local/bin` on macOS, `/home/linuxbrew/.linuxbrew/bin` + `~/.linuxbrew/bin` on Linux, nothing on Windows) and probe it in `resolveCliCommand` / `resolveCliCommands` as the last fallback, after `PATH`, nvm, and the version-manager directories, so existing resolution order is unchanged.
- `src/shared/node-cli-command-resolution.test.ts` (new): covers brew-dir resolution, `PATH` and version-manager precedence over the brew fallback, bulk resolution, and that Windows never probes brew directories.

This feeds `detectCommandsInInstallDirs`, so both `orca skills install` agent targeting and preflight agent detection now see brew-installed CLIs. PATH-hydration behavior (`getVersionManagerBinPaths`, `patchPackagedProcessPath`) is untouched.

## Why

The bounded install-dir fallback used when a CLI is missing from `PATH` covered every major version manager and user bin directory but no Homebrew prefix, while `patchPackagedProcessPath` seeds brew paths only in the packaged GUI process. On a host where Claude Code came from the `claude-code` cask, skill installs targeted every detected agent except `claude-code`, so the skill landed only in `~/.agents/skills` — which Claude Code never reads. Probing brew's well-known prefixes in the same bounded fallback fixes that without unbounding the scan.

## Linked Issue

Fixes #15959

## Visual Proof

N/A — no UI change; this alters CLI/agent detection only. Behavior change is shown by the before/after resolution check in Testing.

## Testing

On the affected macOS host (Claude Code installed via `brew install --cask claude-code@latest`):

- `vitest run src/shared/node-cli-command-resolution.test.ts` — 5 new tests pass.
- Existing coverage around the changed module: `vitest run src/cli/skills.test.ts src/cli/handlers/account.test.ts src/main/ipc/preflight-agent-detection.test.ts src/main/ipc/preflight-agent-detection-no-subprocess.test.ts src/main/ipc/preflight-agent-refresh.test.ts src/main/ipc/preflight-host-cli-status.test.ts` — 113 tests pass.
- `tsc --noEmit -p config/tsconfig.node.json` and `-p config/tsconfig.tc.cli.json` — clean. `oxlint` on both changed files — clean.
- Manual before/after on macOS: `resolveCliCommand('claude', { pathEnv: '/usr/bin:/bin' })` returned bare `claude` (undetected) before this change and `/opt/homebrew/bin/claude` after. Linux covered by the Linuxbrew unit tests; Windows covered by the no-brew-probe unit test.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below
