### PR TITLE
feat(orchestration): report heartbeat freshness on worker-list

### DIFF
--- a/src/cli/handlers/orchestration-worker-list-heartbeat-cli.test.ts
+++ b/src/cli/handlers/orchestration-worker-list-heartbeat-cli.test.ts
@@ -26,7 +26,10 @@ type WorkerListResponse = {
   }
 }
 
-function projection(heartbeat?: { state: string }): Record<string, unknown> {
+function projection(heartbeat?: {
+  state: string
+  ageSeconds?: number | null
+}): Record<string, unknown> {
   return {
     provider: { id: 'claude', model: 'opus' },
     host: { id: 'local' },
@@ -53,7 +56,7 @@ async function renderWorkerList(response: WorkerListResponse): Promise<string | 
   return formatter?.(response.result)
 }
 
-function workerRow(heartbeat?: { state: string }): WorkerListResponse {
+function workerRow(heartbeat?: { state: string; ageSeconds?: number | null }): WorkerListResponse {
   return {
     result: {
       workers: [
@@ -86,13 +89,37 @@ describe('orchestration worker-list heartbeat line', () => {
   })
 
   it('prints the freshness beside the liveness verdict, not instead of it', async () => {
-    const output = await renderWorkerList(workerRow({ state: 'stale' }))
-    expect(output).toContain('liveness=unverifiable heartbeat=stale provider=claude/opus')
+    const output = await renderWorkerList(workerRow({ state: 'stale', ageSeconds: 2_580 }))
+    expect(output?.split('\n')[0]).toBe(
+      'ctx_1 task=task_1 [running/working] attention=none liveness=unverifiable heartbeat=stale (43m) provider=claude/opus host=local workspace=ws_1 terminal=active next=none'
+    )
+  })
+
+  // Why: `stale` alone cannot separate a lane 11 minutes quiet from one quiet since yesterday,
+  // which is the whole decision the coordinator reads this line for.
+  it('renders the measured age for a fresh heartbeat too', async () => {
+    const output = await renderWorkerList(workerRow({ state: 'fresh', ageSeconds: 125 }))
+    expect(output).toContain('heartbeat=fresh (2m)')
   })
 
   it('prints none for a Dispatch that has never reported', async () => {
-    const output = await renderWorkerList(workerRow({ state: 'none' }))
+    const output = await renderWorkerList(workerRow({ state: 'none', ageSeconds: null }))
     expect(output).toContain('liveness=unverifiable heartbeat=none provider=claude/opus')
+    expect(output).not.toContain('heartbeat=none (')
+  })
+
+  // Why: a stored arrival stamp nothing can parse is corruption; it measures no age and must not
+  // read as silence.
+  it('prints unreadable without an age', async () => {
+    const output = await renderWorkerList(workerRow({ state: 'unreadable', ageSeconds: null }))
+    expect(output).toContain('liveness=unverifiable heartbeat=unreadable provider=claude/opus')
+  })
+
+  // Why: a paired host that publishes the state but not the age is still telling the truth about
+  // the state; inventing an age there would state a measurement nobody took.
+  it('prints the bare state when the host published no age', async () => {
+    const output = await renderWorkerList(workerRow({ state: 'stale' }))
+    expect(output).toContain('liveness=unverifiable heartbeat=stale provider=claude/opus')
   })
 
   // Why: a paired host that predates the field publishes no heartbeat at all, and inventing a

--- a/src/cli/handlers/orchestration-worker-list-heartbeat-cli.test.ts
+++ b/src/cli/handlers/orchestration-worker-list-heartbeat-cli.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const callMock = vi.fn()
+
+vi.mock('../format', () => ({ printResult: vi.fn() }))
+vi.mock('../selectors', () => ({ getTerminalHandle: vi.fn() }))
+
+import { ORCHESTRATION_HANDLERS } from './orchestration'
+import { printResult } from '../format'
+
+type WorkerListResponse = {
+  result: {
+    workers: {
+      dispatchId: string
+      taskId: string
+      runId: string
+      workerState: string
+      dispatchStatus: string
+      agentTerminalHandle: string | null
+      terminalState: string | null
+      resource: unknown
+      projection?: Record<string, unknown>
+    }[]
+    counts: Record<string, number>
+    page: { total: number; hasMore: boolean; nextCursor: string | null }
+  }
+}
+
+function projection(heartbeat?: { state: string }): Record<string, unknown> {
+  return {
+    provider: { id: 'claude', model: 'opus' },
+    host: { id: 'local' },
+    workspace: { id: 'ws_1' },
+    stage: { activity: 'working' },
+    liveness: { verdict: 'unverifiable' },
+    ...(heartbeat ? { heartbeat } : {}),
+    nextAction: { argv: [] },
+    attention: { categories: [] }
+  }
+}
+
+async function renderWorkerList(response: WorkerListResponse): Promise<string | undefined> {
+  callMock.mockResolvedValue(response)
+  await ORCHESTRATION_HANDLERS['orchestration worker-list']({
+    flags: new Map<string, string | boolean>(),
+    client: { call: callMock },
+    cwd: '/tmp/repo',
+    json: false
+  } as never)
+  const formatter = vi.mocked(printResult).mock.calls[0]?.[2] as
+    | ((result: WorkerListResponse['result']) => string)
+    | undefined
+  return formatter?.(response.result)
+}
+
+function workerRow(heartbeat?: { state: string }): WorkerListResponse {
+  return {
+    result: {
+      workers: [
+        {
+          dispatchId: 'ctx_1',
+          taskId: 'task_1',
+          runId: 'run_1',
+          workerState: 'running',
+          dispatchStatus: 'dispatched',
+          agentTerminalHandle: 'term_1',
+          terminalState: 'active',
+          resource: null,
+          projection: projection(heartbeat)
+        }
+      ],
+      counts: { active: 1 },
+      page: { total: 1, hasMore: false, nextCursor: null }
+    }
+  }
+}
+
+describe('orchestration worker-list heartbeat line', () => {
+  beforeEach(() => {
+    callMock.mockReset()
+    vi.mocked(printResult).mockReset()
+  })
+
+  afterEach(() => {
+    vi.mocked(printResult).mockReset()
+  })
+
+  it('prints the freshness beside the liveness verdict, not instead of it', async () => {
+    const output = await renderWorkerList(workerRow({ state: 'stale' }))
+    expect(output).toContain('liveness=unverifiable heartbeat=stale provider=claude/opus')
+  })
+
+  it('prints none for a Dispatch that has never reported', async () => {
+    const output = await renderWorkerList(workerRow({ state: 'none' }))
+    expect(output).toContain('liveness=unverifiable heartbeat=none provider=claude/opus')
+  })
+
+  // Why: a paired host that predates the field publishes no heartbeat at all, and inventing a
+  // segment there would state a freshness nobody measured.
+  it('omits the segment when the host published no freshness', async () => {
+    const output = await renderWorkerList(workerRow())
+    expect(output).toContain('liveness=unverifiable provider=claude/opus')
+    expect(output).not.toContain('heartbeat=')
+  })
+})

--- a/src/cli/handlers/orchestration/worker-terminal-handlers.ts
+++ b/src/cli/handlers/orchestration/worker-terminal-handlers.ts
@@ -6,6 +6,7 @@ import {
   getRequiredStringFlag
 } from '../../flags'
 import { RuntimeClientError } from '../../runtime-client'
+import { formatDispatchHeartbeatAge } from '../../../shared/orchestration-heartbeat-freshness'
 import { callOrchestrationMutation } from './mutation-request'
 import { formatWorkerRelease, type WorkerReleaseReceipt } from './worker-output'
 import {
@@ -22,6 +23,12 @@ const WORKER_TERMINAL_LIST_STATES = [
   'release_unknown',
   'released'
 ] as const
+
+/** Only a registered heartbeat carries an age: `none` and `unreadable` measure nothing, and a host
+ *  that publishes the state without the age still prints the bare state. */
+function formatHeartbeatAgeSuffix(ageSeconds: number | null | undefined): string {
+  return typeof ageSeconds === 'number' ? ` (${formatDispatchHeartbeatAge(ageSeconds)})` : ''
+}
 
 export const ORCHESTRATION_WORKER_TERMINAL_HANDLERS: Record<string, CommandHandler> = {
   'orchestration worker-stop': async ({ flags, client, json }) => {
@@ -119,7 +126,7 @@ export const ORCHESTRATION_WORKER_TERMINAL_HANDLERS: Record<string, CommandHandl
           workspace: { id: string } | null
           stage: { activity: string }
           liveness: { verdict: string }
-          heartbeat?: { state: string }
+          heartbeat?: { state: string; ageSeconds?: number | null }
           nextAction: { argv: string[] }
           attention?: { categories: string[] }
         }
@@ -164,7 +171,7 @@ export const ORCHESTRATION_WORKER_TERMINAL_HANDLERS: Record<string, CommandHandl
                 // Beside liveness, not instead of it: liveness is the process verdict, heartbeat is
                 // the agent still reporting. A host that does not publish it prints no segment.
                 const heartbeat = projection?.heartbeat
-                  ? ` heartbeat=${projection.heartbeat.state}`
+                  ? ` heartbeat=${projection.heartbeat.state}${formatHeartbeatAgeSuffix(projection.heartbeat.ageSeconds)}`
                   : ''
                 const details = projection
                   ? `/${stage}] attention=${attention} liveness=${liveness}${heartbeat} provider=${provider} host=${projection.host.id} workspace=${workspace}`

--- a/src/cli/handlers/orchestration/worker-terminal-handlers.ts
+++ b/src/cli/handlers/orchestration/worker-terminal-handlers.ts
@@ -119,6 +119,7 @@ export const ORCHESTRATION_WORKER_TERMINAL_HANDLERS: Record<string, CommandHandl
           workspace: { id: string } | null
           stage: { activity: string }
           liveness: { verdict: string }
+          heartbeat?: { state: string }
           nextAction: { argv: string[] }
           attention?: { categories: string[] }
         }
@@ -160,8 +161,13 @@ export const ORCHESTRATION_WORKER_TERMINAL_HANDLERS: Record<string, CommandHandl
                 const stage = projection?.stage.activity ?? worker.dispatchStatus
                 const liveness = projection?.liveness.verdict
                 const attention = projection?.attention?.categories.join(',') || 'none'
+                // Beside liveness, not instead of it: liveness is the process verdict, heartbeat is
+                // the agent still reporting. A host that does not publish it prints no segment.
+                const heartbeat = projection?.heartbeat
+                  ? ` heartbeat=${projection.heartbeat.state}`
+                  : ''
                 const details = projection
-                  ? `/${stage}] attention=${attention} liveness=${liveness} provider=${provider} host=${projection.host.id} workspace=${workspace}`
+                  ? `/${stage}] attention=${attention} liveness=${liveness}${heartbeat} provider=${provider} host=${projection.host.id} workspace=${workspace}`
                   : `]`
                 // Why: the enumerating command owes the literal argv the guides tell callers to run.
                 const next = projection

--- a/src/cli/specs/orchestration-worker-specs.ts
+++ b/src/cli/specs/orchestration-worker-specs.ts
@@ -123,7 +123,8 @@ export const ORCHESTRATION_WORKER_COMMAND_SPECS: CommandSpec[] = [
       'Terminal state is process accounting and is reported separately from Task status; a completed Task can still own a live terminal.',
       'Context-only Dispatches created by orchestration dispatch are included as unsupervised with terminal state retained.',
       'Returns at most 100 local rows by default; --include-remote adds connected-server observations when the host supports fleet listing. Continue with the opaque page.nextCursor value unchanged.',
-      'Without --run the list is scoped to the Run bound to the calling terminal, and to every Run when there is no binding; the receipt reports which in scope.source (flag, bound, or all).'
+      'Without --run the list is scoped to the Run bound to the calling terminal, and to every Run when there is no binding; the receipt reports which in scope.source (flag, bound, or all).',
+      'heartbeat reports whether the Dispatch is still reporting on the orchestration protocol (none, fresh, or stale after 10 minutes) and is independent of liveness, which is the execution host verdict on the process; heartbeat.lastReceivedAt is when this host recorded the heartbeat, so a remote worker clock cannot skew the age.'
     ]
   }
 ]

--- a/src/cli/specs/orchestration-worker-specs.ts
+++ b/src/cli/specs/orchestration-worker-specs.ts
@@ -124,7 +124,7 @@ export const ORCHESTRATION_WORKER_COMMAND_SPECS: CommandSpec[] = [
       'Context-only Dispatches created by orchestration dispatch are included as unsupervised with terminal state retained.',
       'Returns at most 100 local rows by default; --include-remote adds connected-server observations when the host supports fleet listing. Continue with the opaque page.nextCursor value unchanged.',
       'Without --run the list is scoped to the Run bound to the calling terminal, and to every Run when there is no binding; the receipt reports which in scope.source (flag, bound, or all).',
-      'heartbeat reports whether the Dispatch is still reporting on the orchestration protocol (none, fresh, or stale after 10 minutes) and is independent of liveness, which is the execution host verdict on the process; heartbeat.lastReceivedAt is when this host recorded the heartbeat, so a remote worker clock cannot skew the age.'
+      'heartbeat reports whether the Dispatch is still reporting on the orchestration protocol (none, fresh, stale after 10 minutes, or unreadable when a stored arrival stamp cannot be parsed) and is independent of liveness, which is the execution host verdict on the process; heartbeat.lastReceivedAt is when this host recorded the heartbeat, so a remote worker clock cannot skew the age, and the human line prints that age beside the state, as in heartbeat=stale (43m).'
     ]
   }
 ]

--- a/src/main/runtime/orchestration/coordinator-task-dispatch.ts
+++ b/src/main/runtime/orchestration/coordinator-task-dispatch.ts
@@ -8,19 +8,17 @@ import {
   parseAllowStaleBaseFromSpec
 } from './coordinator-stale-base-flag'
 import { isAgentPromptStalledError } from '../agent-prompt-submission-verification'
+import { DISPATCH_HEARTBEAT_STALE_AFTER_MS } from '../../../shared/orchestration-heartbeat-freshness'
 
 /** `dispatched-unobserved`: the preamble landed but the worker's turn start was never observed. */
 export type TaskDispatchResult = 'dispatched' | 'dispatched-unobserved' | 'stale-base-refused'
 
-// Why: 10 min = documented heartbeat cadence (5 min) × 2, so one missed heartbeat is the earliest a dispatch can look stale.
-const HUNG_THRESHOLD_MS = 10 * 60 * 1000
-
 // Why: warn only, never auto-fail — a false positive (slow but correct worker) costs more than a false negative (hung worker holding a slot); see R6 of DESIGN_DOC_PREAMBLE_FIX.md.
 export function warnStaleDispatches(db: OrchestrationDb, onLog: (msg: string) => void): void {
-  const thresholdIso = new Date(Date.now() - HUNG_THRESHOLD_MS).toISOString()
+  const thresholdIso = new Date(Date.now() - DISPATCH_HEARTBEAT_STALE_AFTER_MS).toISOString()
   const stale = db.getStaleDispatches(thresholdIso)
   for (const ctx of stale) {
-    const minutes = Math.round(HUNG_THRESHOLD_MS / 60000)
+    const minutes = Math.round(DISPATCH_HEARTBEAT_STALE_AFTER_MS / 60000)
     onLog(
       `Warning: worker ${ctx.assignee_handle ?? '<unknown>'} on task ${ctx.task_id} has not sent a heartbeat in ~${minutes} min (dispatch ${ctx.id})`
     )

--- a/src/main/runtime/orchestration/db/dispatch-context/dispatch-completion.ts
+++ b/src/main/runtime/orchestration/db/dispatch-context/dispatch-completion.ts
@@ -84,6 +84,9 @@ export function failActiveDispatchForTask(
 }
 
 // Why: only bump status='dispatched' — a zombie heartbeat from a finished dispatch would mask a hung retry from the stale detector (§5.3.4).
+// CONTRACT: `at` is arrival time on this host, never a stamp the worker chose for itself. Both
+// readers (getStaleDispatches and worker-list freshness) subtract it from this host's clock, so a
+// relayed worker stamp would turn a federated lane's age into a measure of clock skew.
 export function recordHeartbeat(this: OrchestrationDb, dispatchId: string, at: string): void {
   this.db
     .prepare(

--- a/src/main/runtime/orchestration/db/utc-timestamp.ts
+++ b/src/main/runtime/orchestration/db/utc-timestamp.ts
@@ -10,14 +10,16 @@ export function exposeUtcTimestamp(timestamp: string | null): string | null {
 }
 
 /** Epoch ms for a stored stamp in either the space format or an explicit-offset one.
- *  `null` for an absent or unparseable value, so a corrupt row cannot become a bogus instant. */
-export function readUtcTimestampMs(timestamp: string | null): number | null {
+ *  `null` = the column holds no value; `'unreadable'` = it holds one no parser accepts. The two
+ *  stay distinct so a corrupt row can neither become a bogus instant nor be reported as "never
+ *  written", and the literal (rather than `NaN`) keeps caller arithmetic type-checked and JSON-safe. */
+export function readUtcTimestampMs(timestamp: string | null): number | null | 'unreadable' {
   const exposed = exposeUtcTimestamp(timestamp)
   if (!exposed) {
     return null
   }
   const parsed = Date.parse(exposed)
-  return Number.isNaN(parsed) ? null : parsed
+  return Number.isNaN(parsed) ? 'unreadable' : parsed
 }
 
 export function exposeMessageTimestamps(message: MessageRow): MessageRow {

--- a/src/main/runtime/orchestration/db/utc-timestamp.ts
+++ b/src/main/runtime/orchestration/db/utc-timestamp.ts
@@ -15,7 +15,9 @@ export function exposeUtcTimestamp(timestamp: string | null): string | null {
  *  written", and the literal (rather than `NaN`) keeps caller arithmetic type-checked and JSON-safe. */
 export function readUtcTimestampMs(timestamp: string | null): number | null | 'unreadable' {
   const exposed = exposeUtcTimestamp(timestamp)
-  if (!exposed) {
+  // Only SQL NULL means "never written". An empty string is a value that was stored and lost its
+  // contents, so it falls through to the parse and is classified as corruption.
+  if (exposed === null) {
     return null
   }
   const parsed = Date.parse(exposed)

--- a/src/main/runtime/orchestration/db/utc-timestamp.ts
+++ b/src/main/runtime/orchestration/db/utc-timestamp.ts
@@ -9,6 +9,17 @@ export function exposeUtcTimestamp(timestamp: string | null): string | null {
   return `${timestamp.replace(' ', 'T')}Z`
 }
 
+/** Epoch ms for a stored stamp in either the space format or an explicit-offset one.
+ *  `null` for an absent or unparseable value, so a corrupt row cannot become a bogus instant. */
+export function readUtcTimestampMs(timestamp: string | null): number | null {
+  const exposed = exposeUtcTimestamp(timestamp)
+  if (!exposed) {
+    return null
+  }
+  const parsed = Date.parse(exposed)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
 export function exposeMessageTimestamps(message: MessageRow): MessageRow {
   // Why: SQLite stores UTC as timezone-less space format for SQL ordering, but RPC/CLI consumers need an explicit offset.
   return {

--- a/src/main/runtime/orchestration/db/worker-terminal/worker-terminal-listing.ts
+++ b/src/main/runtime/orchestration/db/worker-terminal/worker-terminal-listing.ts
@@ -1,5 +1,6 @@
 import type { DispatchStatus } from '../../types'
 import type { TerminalExitCause } from '../../../../../shared/terminal-exit-cause'
+import type { DispatchHeartbeatStamp } from '../../../../../shared/orchestration-heartbeat-freshness'
 import { deriveWorkerTerminalListState } from '../../worker-terminal-ownership'
 import type {
   WorkerDispatchListState,
@@ -102,7 +103,7 @@ export function listWorkerTerminalResources(
   pendingInput: boolean
   pendingApproval: boolean
   terminationReason: TerminalExitCause['kind'] | null
-  lastHeartbeatAt: number | null
+  lastHeartbeatAt: DispatchHeartbeatStamp
   resource: WorkerTerminalResourceRow | null
   createdAt: string
   databaseId: number
@@ -239,6 +240,8 @@ export function listWorkerTerminalResources(
       terminationReason: row.termination_reason,
       // Arrival time on this host — every writer of `last_heartbeat_at` stamps it with this
       // clock — so the reader ages it against the same clock and needs no skew correction.
+      // A stored value nothing can parse stays `'unreadable'` rather than collapsing into the
+      // `null` that means the Dispatch never reported.
       lastHeartbeatAt: readUtcTimestampMs(row.last_heartbeat_at),
       resource,
       createdAt: row.created_at,

--- a/src/main/runtime/orchestration/db/worker-terminal/worker-terminal-listing.ts
+++ b/src/main/runtime/orchestration/db/worker-terminal/worker-terminal-listing.ts
@@ -7,6 +7,7 @@ import type {
   WorkerTerminalListState
 } from '../../worker-terminal-ownership'
 import { OrchestrationError } from '../../orchestration-error'
+import { readUtcTimestampMs } from '../utc-timestamp'
 import type { OrchestrationDb } from '../orchestration-db'
 import {
   getWorkerAttentionFacts,
@@ -101,6 +102,7 @@ export function listWorkerTerminalResources(
   pendingInput: boolean
   pendingApproval: boolean
   terminationReason: TerminalExitCause['kind'] | null
+  lastHeartbeatAt: number | null
   resource: WorkerTerminalResourceRow | null
   createdAt: string
   databaseId: number
@@ -168,6 +170,7 @@ export function listWorkerTerminalResources(
               t.parent_id AS parent_task_id,
               d.task_id, d.run_id, d.status AS dispatch_status,
               d.termination_reason,
+              d.last_heartbeat_at,
               EXISTS (
                 SELECT 1 FROM question_threads q
                  WHERE q.dispatch_id = d.id AND q.status = 'pending'
@@ -195,6 +198,7 @@ export function listWorkerTerminalResources(
     run_id: string
     dispatch_status: DispatchStatus
     termination_reason: TerminalExitCause['kind'] | null
+    last_heartbeat_at: string | null
     pending_input: number
     pending_approval: number
     created_at: string
@@ -233,6 +237,9 @@ export function listWorkerTerminalResources(
       pendingInput: row.pending_input === 1,
       pendingApproval: row.pending_approval === 1,
       terminationReason: row.termination_reason,
+      // Arrival time on this host — every writer of `last_heartbeat_at` stamps it with this
+      // clock — so the reader ages it against the same clock and needs no skew correction.
+      lastHeartbeatAt: readUtcTimestampMs(row.last_heartbeat_at),
       resource,
       createdAt: row.created_at,
       databaseId: row.database_id

--- a/src/main/runtime/orchestration/federation-sync-message.ts
+++ b/src/main/runtime/orchestration/federation-sync-message.ts
@@ -62,6 +62,9 @@ export function parseFederatedLifecycle(
   | { kind: 'worker_report'; taskId: string; outcome: WorkerReportOutcome; result: string }
   | { kind: 'rejected'; code: string; reason: string } {
   if (message.type === 'heartbeat') {
+    // Stamped on the Run home as the relay item is imported: recordHeartbeat's contract is arrival
+    // time, and the relayed payload carries no worker timestamp precisely so a skewed remote clock
+    // cannot become this lane's freshness.
     return { kind: 'heartbeat', at: new Date().toISOString() }
   }
   if (message.type !== 'worker_done') {

--- a/src/main/runtime/rpc/methods/orchestration/worker/worker-list-heartbeat-freshness.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration/worker/worker-list-heartbeat-freshness.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type Database from '../../../../../sqlite/sync-database'
+import { OrchestrationDb } from '../../../../orchestration/db'
+import { OrcaRuntimeService } from '../../../../orca-runtime'
+import { DISPATCH_HEARTBEAT_STALE_AFTER_MS } from '../../../../../../shared/orchestration-heartbeat-freshness'
+import { ORCHESTRATION_WORKER_LIST_METHOD } from './worker-list-method'
+
+type HeartbeatListResult = {
+  workers: {
+    dispatchId: string
+    projection: {
+      liveness: { verdict: string }
+      heartbeat?: { state: string; lastReceivedAt: number | null; ageSeconds: number | null }
+    }
+  }[]
+}
+
+describe('orchestration worker-list heartbeat freshness', () => {
+  let db: OrchestrationDb | undefined
+
+  afterEach(() => db?.close())
+
+  it('ages every Dispatch of one listing against this host clock', async () => {
+    db = new OrchestrationDb(':memory:')
+    const runtime = new OrcaRuntimeService()
+    runtime.setOrchestrationDb(db)
+    const run = db.createRun({
+      objective: 'Heartbeat freshness inventory',
+      coordinatorHandle: 'term-coordinator',
+      coordinatorPaneKey: 'tab-coordinator:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    })
+    insertDispatch(db, run.id, 'ctx_silent')
+    insertDispatch(db, run.id, 'ctx_reporting')
+    insertDispatch(db, run.id, 'ctx_hung')
+    const now = Date.now()
+    db.recordHeartbeat('ctx_reporting', new Date(now - 20_000).toISOString())
+    db.recordHeartbeat(
+      'ctx_hung',
+      new Date(now - DISPATCH_HEARTBEAT_STALE_AFTER_MS - 60_000).toISOString()
+    )
+
+    const result = await callWorkerList(runtime, { run: run.id, paginate: true })
+    const byDispatch = new Map(result.workers.map((worker) => [worker.dispatchId, worker]))
+
+    expect(byDispatch.get('ctx_silent')?.projection.heartbeat).toEqual({
+      state: 'none',
+      lastReceivedAt: null,
+      ageSeconds: null
+    })
+    const reporting = byDispatch.get('ctx_reporting')?.projection.heartbeat
+    expect(reporting?.state).toBe('fresh')
+    expect(reporting?.ageSeconds).toBeGreaterThanOrEqual(20)
+    expect(reporting?.ageSeconds).toBeLessThan(60)
+    expect(byDispatch.get('ctx_hung')?.projection.heartbeat?.state).toBe('stale')
+  })
+
+  // Why: a lane can be reporting on the protocol while nothing certifies its process, and the
+  // reverse. Collapsing the two would let one silence the other.
+  it('keeps the freshness independent of the liveness verdict', async () => {
+    db = new OrchestrationDb(':memory:')
+    const runtime = new OrcaRuntimeService()
+    runtime.setOrchestrationDb(db)
+    const run = db.createRun({
+      objective: 'Heartbeat beside liveness',
+      coordinatorHandle: 'term-coordinator',
+      coordinatorPaneKey: 'tab-coordinator:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+    })
+    insertDispatch(db, run.id, 'ctx_reporting')
+    db.recordHeartbeat('ctx_reporting', new Date().toISOString())
+
+    const result = await callWorkerList(runtime, { run: run.id, paginate: true })
+    const worker = result.workers[0]?.projection
+
+    expect(worker?.liveness.verdict).toBe('unverifiable')
+    expect(worker?.heartbeat?.state).toBe('fresh')
+  })
+
+  // Why: SQLite stores UTC in the timezone-less space format, so a stamp read back raw would
+  // parse as local time and report an age off by the host's offset.
+  it('reads a space-format stamp as UTC', async () => {
+    db = new OrchestrationDb(':memory:')
+    const runtime = new OrcaRuntimeService()
+    runtime.setOrchestrationDb(db)
+    const run = db.createRun({
+      objective: 'Stored stamp format',
+      coordinatorHandle: 'term-coordinator',
+      coordinatorPaneKey: 'tab-coordinator:cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+    })
+    insertDispatch(db, run.id, 'ctx_space_format')
+    const storedAt = new Date(Date.now() - 60_000).toISOString()
+    db.recordHeartbeat('ctx_space_format', `${storedAt.slice(0, 10)} ${storedAt.slice(11, 23)}`)
+
+    const result = await callWorkerList(runtime, { run: run.id, paginate: true })
+    const heartbeat = result.workers[0]?.projection.heartbeat
+
+    expect(heartbeat?.state).toBe('fresh')
+    expect(heartbeat?.ageSeconds).toBeGreaterThanOrEqual(60)
+    expect(heartbeat?.ageSeconds).toBeLessThan(120)
+  })
+})
+
+async function callWorkerList(
+  runtime: OrcaRuntimeService,
+  params: Record<string, unknown>
+): Promise<HeartbeatListResult> {
+  const parsed = ORCHESTRATION_WORKER_LIST_METHOD.params?.parse(params)
+  return (await ORCHESTRATION_WORKER_LIST_METHOD.handler(parsed, {
+    runtime
+  })) as HeartbeatListResult
+}
+
+function insertDispatch(db: OrchestrationDb, runId: string, dispatchId: string): void {
+  const task = db.createTask({ spec: dispatchId, runId })
+  sqliteFor(db)
+    .prepare(
+      `INSERT INTO dispatch_contexts (
+         id, run_id, task_id, assignee_handle, status, created_at
+       ) VALUES (?, ?, ?, ?, 'dispatched', '2026-08-27 00:00:00')`
+    )
+    .run(dispatchId, runId, task.id, `term-${dispatchId}`)
+}
+
+function sqliteFor(db: OrchestrationDb): Database.Database {
+  return (db as unknown as { db: Database.Database }).db
+}

--- a/src/main/runtime/rpc/methods/orchestration/worker/worker-list-heartbeat-freshness.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration/worker/worker-list-heartbeat-freshness.test.ts
@@ -126,6 +126,27 @@ describe('orchestration worker-list heartbeat freshness', () => {
     })
     expect(byDispatch.get('ctx_silent')?.projection.heartbeat?.state).toBe('none')
   })
+
+  // Why: SQL NULL is the only "never written". An empty string is a value that was stored and lost
+  // its contents, and reporting that as `none` would blame the coordinator's own protocol.
+  it('reports an empty stored stamp as unreadable rather than never reported', async () => {
+    db = new OrchestrationDb(':memory:')
+    const runtime = new OrcaRuntimeService()
+    runtime.setOrchestrationDb(db)
+    const run = db.createRun({
+      objective: 'Empty arrival stamp',
+      coordinatorHandle: 'term-coordinator',
+      coordinatorPaneKey: 'tab-coordinator:eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee'
+    })
+    insertDispatch(db, run.id, 'ctx_empty')
+    sqliteFor(db)
+      .prepare('UPDATE dispatch_contexts SET last_heartbeat_at = ? WHERE id = ?')
+      .run('', 'ctx_empty')
+
+    const result = await callWorkerList(runtime, { run: run.id, paginate: true })
+
+    expect(result.workers[0]?.projection.heartbeat?.state).toBe('unreadable')
+  })
 })
 
 async function callWorkerList(

--- a/src/main/runtime/rpc/methods/orchestration/worker/worker-list-heartbeat-freshness.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration/worker/worker-list-heartbeat-freshness.test.ts
@@ -97,6 +97,35 @@ describe('orchestration worker-list heartbeat freshness', () => {
     expect(heartbeat?.ageSeconds).toBeGreaterThanOrEqual(60)
     expect(heartbeat?.ageSeconds).toBeLessThan(120)
   })
+
+  // Why: `Date.parse` failing used to collapse into the same `null` a never-dispatched heartbeat
+  // uses, so a corrupt row was published as "never reported" — the one reading a coordinator
+  // cannot act on. Corruption has to be its own word.
+  it('reports a stored stamp it cannot parse as unreadable, not as never reported', async () => {
+    db = new OrchestrationDb(':memory:')
+    const runtime = new OrcaRuntimeService()
+    runtime.setOrchestrationDb(db)
+    const run = db.createRun({
+      objective: 'Corrupt arrival stamp',
+      coordinatorHandle: 'term-coordinator',
+      coordinatorPaneKey: 'tab-coordinator:dddddddd-dddd-4ddd-8ddd-dddddddddddd'
+    })
+    insertDispatch(db, run.id, 'ctx_silent')
+    insertDispatch(db, run.id, 'ctx_corrupt')
+    sqliteFor(db)
+      .prepare('UPDATE dispatch_contexts SET last_heartbeat_at = ? WHERE id = ?')
+      .run('not-a-timestamp', 'ctx_corrupt')
+
+    const result = await callWorkerList(runtime, { run: run.id, paginate: true })
+    const byDispatch = new Map(result.workers.map((worker) => [worker.dispatchId, worker]))
+
+    expect(byDispatch.get('ctx_corrupt')?.projection.heartbeat).toEqual({
+      state: 'unreadable',
+      lastReceivedAt: null,
+      ageSeconds: null
+    })
+    expect(byDispatch.get('ctx_silent')?.projection.heartbeat?.state).toBe('none')
+  })
 })
 
 async function callWorkerList(

--- a/src/shared/orchestration-fleet-projection.ts
+++ b/src/shared/orchestration-fleet-projection.ts
@@ -6,7 +6,7 @@ import {
   type OrchestrationFleetAttentionCategory
 } from './orchestration-fleet-attention'
 import { projectOrchestrationFleetWorker } from './orchestration-fleet-worker-projection'
-import type { FleetHeartbeat } from './orchestration-heartbeat-freshness'
+import type { DispatchHeartbeatStamp, FleetHeartbeat } from './orchestration-heartbeat-freshness'
 
 export const ORCHESTRATION_FLEET_PAGE_MAX = 100
 
@@ -34,9 +34,10 @@ export type FleetDurableWorker = {
   pendingApproval?: boolean
   terminationReason?: 'operator_close' | 'signaled' | 'exited' | 'unknown' | null
   outcome?: 'in_progress' | 'succeeded' | 'failed' | 'outcome_unknown' | 'finished_unverified'
-  /** Epoch ms this host recorded the last heartbeat; `null` = never, absent = the caller does
-   *  not carry the column, which is why the projected `heartbeat` is omitted rather than `none`. */
-  lastHeartbeatAt?: number | null
+  /** Epoch ms this host recorded the last heartbeat; `null` = never, `'unreadable'` = a stored
+   *  stamp nothing can parse, absent = the caller does not carry the column, which is why the
+   *  projected `heartbeat` is omitted rather than `none`. */
+  lastHeartbeatAt?: DispatchHeartbeatStamp
   resource: {
     id: string
     ownerDispatchId: string

--- a/src/shared/orchestration-fleet-projection.ts
+++ b/src/shared/orchestration-fleet-projection.ts
@@ -6,6 +6,7 @@ import {
   type OrchestrationFleetAttentionCategory
 } from './orchestration-fleet-attention'
 import { projectOrchestrationFleetWorker } from './orchestration-fleet-worker-projection'
+import type { FleetHeartbeat } from './orchestration-heartbeat-freshness'
 
 export const ORCHESTRATION_FLEET_PAGE_MAX = 100
 
@@ -33,6 +34,9 @@ export type FleetDurableWorker = {
   pendingApproval?: boolean
   terminationReason?: 'operator_close' | 'signaled' | 'exited' | 'unknown' | null
   outcome?: 'in_progress' | 'succeeded' | 'failed' | 'outcome_unknown' | 'finished_unverified'
+  /** Epoch ms this host recorded the last heartbeat; `null` = never, absent = the caller does
+   *  not carry the column, which is why the projected `heartbeat` is omitted rather than `none`. */
+  lastHeartbeatAt?: number | null
   resource: {
     id: string
     ownerDispatchId: string
@@ -106,6 +110,9 @@ export type OrchestrationFleetWorker = {
   }
   outcome: 'in_progress' | 'succeeded' | 'failed' | 'outcome_unknown' | 'finished_unverified'
   liveness: FleetLiveness
+  /** Protocol-level proof the agent is still reporting, beside `liveness`'s process verdict.
+   *  Optional: a host that does not carry the arrival stamp omits it entirely. */
+  heartbeat?: FleetHeartbeat
   evidence: {
     durable: true
     liveStatus: 'fresh' | 'stale' | 'unavailable' | 'redacted_restore'

--- a/src/shared/orchestration-fleet-worker-projection.ts
+++ b/src/shared/orchestration-fleet-worker-projection.ts
@@ -5,6 +5,7 @@ import {
   isUnsupervisedSettledDispatch,
   resolveFleetWorkerOutcome
 } from './orchestration-fleet-outcome-resolution'
+import { projectDispatchHeartbeat } from './orchestration-heartbeat-freshness'
 import { readWorkerTerminalHostScope } from './worker-terminal-host-scope'
 import type {
   FleetDurableWorker,
@@ -238,6 +239,11 @@ export function projectOrchestrationFleetWorker(
     },
     outcome,
     liveness,
+    // Absent stamp = a caller that never carried the column; publishing `none` there would
+    // report "never reported" for a lane nobody asked about.
+    ...(worker.lastHeartbeatAt === undefined
+      ? {}
+      : { heartbeat: projectDispatchHeartbeat(worker.lastHeartbeatAt, now) }),
     evidence: {
       durable: true,
       liveStatus: !evidence

--- a/src/shared/orchestration-heartbeat-freshness.test.ts
+++ b/src/shared/orchestration-heartbeat-freshness.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DISPATCH_HEARTBEAT_STALE_AFTER_MS,
+  projectDispatchHeartbeat
+} from './orchestration-heartbeat-freshness'
+import type { FleetDurableWorker } from './orchestration-fleet-projection'
+import { projectOrchestrationFleetWorker } from './orchestration-fleet-worker-projection'
+
+const NOW = Date.parse('2026-09-07T12:00:00.000Z')
+
+function durableWorker(overrides: Partial<FleetDurableWorker> = {}): FleetDurableWorker {
+  return {
+    dispatchId: 'ctx_1',
+    taskId: 'task_1',
+    runId: 'run_1',
+    parentTaskId: 'task_root',
+    workerState: 'ready',
+    dispatchStatus: 'dispatched',
+    workerStage: 'running',
+    agentTerminalHandle: 'term_1',
+    paneKey: 'tab-1:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    worktreeId: 'ws_1',
+    terminalState: 'active',
+    resource: null,
+    ...overrides
+  }
+}
+
+describe('dispatch heartbeat freshness', () => {
+  it('separates never-reported from reported', () => {
+    expect(projectDispatchHeartbeat(null, NOW)).toEqual({
+      state: 'none',
+      lastReceivedAt: null,
+      ageSeconds: null
+    })
+    expect(projectDispatchHeartbeat(NOW - 30_000, NOW)).toEqual({
+      state: 'fresh',
+      lastReceivedAt: NOW - 30_000,
+      ageSeconds: 30
+    })
+  })
+
+  it('turns stale only past the cadence the stale-dispatch warning already uses', () => {
+    expect(projectDispatchHeartbeat(NOW - DISPATCH_HEARTBEAT_STALE_AFTER_MS, NOW).state).toBe(
+      'fresh'
+    )
+    expect(projectDispatchHeartbeat(NOW - DISPATCH_HEARTBEAT_STALE_AFTER_MS - 1_000, NOW)).toEqual({
+      state: 'stale',
+      lastReceivedAt: NOW - DISPATCH_HEARTBEAT_STALE_AFTER_MS - 1_000,
+      ageSeconds: 601
+    })
+  })
+
+  // Why: rounding before the subtraction would publish "just reported" for a stamp this host
+  // cannot explain. The sign has to survive into the receipt.
+  it('keeps a stamp ahead of this host visible as a negative age', () => {
+    expect(projectDispatchHeartbeat(NOW + 4_000, NOW).ageSeconds).toBe(-4)
+  })
+
+  it('omits the field entirely when the caller carries no arrival stamp', () => {
+    expect(projectOrchestrationFleetWorker(durableWorker(), undefined, NOW)).not.toHaveProperty(
+      'heartbeat'
+    )
+  })
+
+  // Why: heartbeat proves the agent still reports; liveness proves the process. A lane whose
+  // process is unverifiable can still be reporting, and the receipt must be able to say both.
+  it('reports freshness beside an independent liveness verdict', () => {
+    const projected = projectOrchestrationFleetWorker(
+      durableWorker({ lastHeartbeatAt: NOW - 5_000 }),
+      undefined,
+      NOW
+    )
+    expect(projected.liveness).toEqual({ verdict: 'unverifiable', reason: 'missing_status' })
+    expect(projected.heartbeat).toEqual({
+      state: 'fresh',
+      lastReceivedAt: NOW - 5_000,
+      ageSeconds: 5
+    })
+  })
+
+  it('reports none for a supplied-but-empty stamp instead of dropping the field', () => {
+    expect(
+      projectOrchestrationFleetWorker(durableWorker({ lastHeartbeatAt: null }), undefined, NOW)
+        .heartbeat
+    ).toEqual({ state: 'none', lastReceivedAt: null, ageSeconds: null })
+  })
+})

--- a/src/shared/orchestration-heartbeat-freshness.test.ts
+++ b/src/shared/orchestration-heartbeat-freshness.test.ts
@@ -58,6 +58,17 @@ describe('dispatch heartbeat freshness', () => {
     expect(projectDispatchHeartbeat(NOW + 4_000, NOW).ageSeconds).toBe(-4)
   })
 
+  // Why: `Math.round(-0.4)` is `-0`, and JSON publishes that as `0`, so anything under half a
+  // second ahead read as "just reported" — the exact reassurance a skewed clock must not buy.
+  it('never publishes a future stamp as a zero age', () => {
+    for (const leadMs of [1, 400, 499, 500]) {
+      const ageSeconds = projectDispatchHeartbeat(NOW + leadMs, NOW).ageSeconds
+      expect(ageSeconds).toBe(-1)
+      expect(JSON.parse(JSON.stringify({ ageSeconds })).ageSeconds).toBe(-1)
+    }
+    expect(projectDispatchHeartbeat(NOW + 1_600, NOW).ageSeconds).toBe(-2)
+  })
+
   it('omits the field entirely when the caller carries no arrival stamp', () => {
     expect(projectOrchestrationFleetWorker(durableWorker(), undefined, NOW)).not.toHaveProperty(
       'heartbeat'

--- a/src/shared/orchestration-heartbeat-freshness.test.ts
+++ b/src/shared/orchestration-heartbeat-freshness.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   DISPATCH_HEARTBEAT_STALE_AFTER_MS,
+  formatDispatchHeartbeatAge,
   projectDispatchHeartbeat
 } from './orchestration-heartbeat-freshness'
 import type { FleetDurableWorker } from './orchestration-fleet-projection'
@@ -84,5 +85,40 @@ describe('dispatch heartbeat freshness', () => {
       projectOrchestrationFleetWorker(durableWorker({ lastHeartbeatAt: null }), undefined, NOW)
         .heartbeat
     ).toEqual({ state: 'none', lastReceivedAt: null, ageSeconds: null })
+  })
+
+  // Why: a stored stamp this host cannot parse is corruption, not silence. Folding it into `none`
+  // would report a Dispatch that heartbeated as one that never did.
+  it('keeps an unparseable stored stamp apart from never-reported', () => {
+    expect(projectDispatchHeartbeat('unreadable', NOW)).toEqual({
+      state: 'unreadable',
+      lastReceivedAt: null,
+      ageSeconds: null
+    })
+    expect(
+      projectOrchestrationFleetWorker(
+        durableWorker({ lastHeartbeatAt: 'unreadable' }),
+        undefined,
+        NOW
+      ).heartbeat?.state
+    ).toBe('unreadable')
+  })
+})
+
+describe('heartbeat age rendering', () => {
+  it('floors to one short unit', () => {
+    expect(formatDispatchHeartbeatAge(0)).toBe('0s')
+    expect(formatDispatchHeartbeatAge(59)).toBe('59s')
+    expect(formatDispatchHeartbeatAge(60)).toBe('1m')
+    expect(formatDispatchHeartbeatAge(2_580)).toBe('43m')
+    expect(formatDispatchHeartbeatAge(3_599)).toBe('59m')
+    expect(formatDispatchHeartbeatAge(7_200)).toBe('2h')
+  })
+
+  // Why: the projection deliberately keeps a stamp ahead of this host negative; flooring the
+  // magnitude alone would print it as an ordinary age.
+  it('keeps a stamp ahead of this host signed', () => {
+    expect(formatDispatchHeartbeatAge(-4)).toBe('-4s')
+    expect(formatDispatchHeartbeatAge(-3_600)).toBe('-1h')
   })
 })

--- a/src/shared/orchestration-heartbeat-freshness.ts
+++ b/src/shared/orchestration-heartbeat-freshness.ts
@@ -7,9 +7,15 @@
 // a Dispatch can look stale. Shared with warnStaleDispatches so both surfaces agree on the word.
 export const DISPATCH_HEARTBEAT_STALE_AFTER_MS = 10 * 60 * 1000
 
+/** What this host holds for the arrival stamp: epoch ms, `null` when the Dispatch never reported,
+ *  or `unreadable` when a value is stored that no parser accepts. The third case is kept apart
+ *  from `null` so a corrupt row cannot be published as silence. */
+export type DispatchHeartbeatStamp = number | null | 'unreadable'
+
 export type FleetHeartbeat = {
-  /** `none` = this Dispatch has never reported; it is not a claim about the process. */
-  state: 'none' | 'fresh' | 'stale'
+  /** `none` = this Dispatch has never reported; `unreadable` = a stored stamp this host cannot
+   *  parse, which is corruption rather than silence. Neither is a claim about the process. */
+  state: 'none' | 'fresh' | 'stale' | 'unreadable'
   /** Epoch ms at which this host recorded the heartbeat, never a stamp the worker chose. */
   lastReceivedAt: number | null
   ageSeconds: number | null
@@ -17,9 +23,12 @@ export type FleetHeartbeat = {
 
 /** `lastReceivedAt` is arrival time on the Run home, so the age is a single-clock subtraction. */
 export function projectDispatchHeartbeat(
-  lastReceivedAt: number | null,
+  lastReceivedAt: DispatchHeartbeatStamp,
   now: number
 ): FleetHeartbeat {
+  if (lastReceivedAt === 'unreadable') {
+    return { state: 'unreadable', lastReceivedAt: null, ageSeconds: null }
+  }
   if (lastReceivedAt === null) {
     return { state: 'none', lastReceivedAt: null, ageSeconds: null }
   }
@@ -31,4 +40,18 @@ export function projectDispatchHeartbeat(
     lastReceivedAt,
     ageSeconds: Math.round(ageMs / 1000)
   }
+}
+
+/** Short age for a projected heartbeat: `43s` / `2m` / `3h`. Floored, and the sign survives, so a
+ *  stamp ahead of this host's clock cannot read as a reassuring "just reported". */
+export function formatDispatchHeartbeatAge(ageSeconds: number): string {
+  const sign = ageSeconds < 0 ? '-' : ''
+  const seconds = Math.abs(ageSeconds)
+  if (seconds < 60) {
+    return `${sign}${seconds}s`
+  }
+  if (seconds < 3_600) {
+    return `${sign}${Math.floor(seconds / 60)}m`
+  }
+  return `${sign}${Math.floor(seconds / 3_600)}h`
 }

--- a/src/shared/orchestration-heartbeat-freshness.ts
+++ b/src/shared/orchestration-heartbeat-freshness.ts
@@ -33,12 +33,14 @@ export function projectDispatchHeartbeat(
     return { state: 'none', lastReceivedAt: null, ageSeconds: null }
   }
   const ageMs = now - lastReceivedAt
+  const rounded = Math.round(ageMs / 1000)
   // Round the subtraction, never the operands: a stamp ahead of this host's clock stays visible
-  // as a negative age instead of collapsing into a reassuring "just reported" zero.
+  // as a negative age instead of collapsing into a reassuring "just reported" zero. A sub-second
+  // lead rounds to `-0`, which JSON publishes as `0`, so the future branch floors at one second.
   return {
     state: ageMs > DISPATCH_HEARTBEAT_STALE_AFTER_MS ? 'stale' : 'fresh',
     lastReceivedAt,
-    ageSeconds: Math.round(ageMs / 1000)
+    ageSeconds: ageMs < 0 ? Math.min(-1, rounded) : rounded
   }
 }
 

--- a/src/shared/orchestration-heartbeat-freshness.ts
+++ b/src/shared/orchestration-heartbeat-freshness.ts
@@ -1,0 +1,34 @@
+/** Dispatch heartbeat freshness: the agent still reporting on the orchestration protocol.
+ *  Complementary to `FleetLiveness`, which reads `agent_status`/the execution host to decide
+ *  whether the *process* is alive. A live process whose agent stopped reporting is exactly the
+ *  lane a coordinator loses, and neither signal can be derived from the other. */
+
+// Why: 10 min = documented heartbeat cadence (5 min) x 2, so one missed heartbeat is the earliest
+// a Dispatch can look stale. Shared with warnStaleDispatches so both surfaces agree on the word.
+export const DISPATCH_HEARTBEAT_STALE_AFTER_MS = 10 * 60 * 1000
+
+export type FleetHeartbeat = {
+  /** `none` = this Dispatch has never reported; it is not a claim about the process. */
+  state: 'none' | 'fresh' | 'stale'
+  /** Epoch ms at which this host recorded the heartbeat, never a stamp the worker chose. */
+  lastReceivedAt: number | null
+  ageSeconds: number | null
+}
+
+/** `lastReceivedAt` is arrival time on the Run home, so the age is a single-clock subtraction. */
+export function projectDispatchHeartbeat(
+  lastReceivedAt: number | null,
+  now: number
+): FleetHeartbeat {
+  if (lastReceivedAt === null) {
+    return { state: 'none', lastReceivedAt: null, ageSeconds: null }
+  }
+  const ageMs = now - lastReceivedAt
+  // Round the subtraction, never the operands: a stamp ahead of this host's clock stays visible
+  // as a negative age instead of collapsing into a reassuring "just reported" zero.
+  return {
+    state: ageMs > DISPATCH_HEARTBEAT_STALE_AFTER_MS ? 'stale' : 'fresh',
+    lastReceivedAt,
+    ageSeconds: Math.round(ageMs / 1000)
+  }
+}


### PR DESCRIPTION
## ELI5

`orca orchestration worker-list` could already tell you whether a lane's *process* looked alive. It could not tell you whether the *agent* was still checking in. This adds that second answer next to the first, so a row reads `liveness=live heartbeat=stale (43m)` when the process is up but the agent went quiet, and the age says whether that silence is minutes or hours old.

## What Changed

- New shared projection `src/shared/orchestration-heartbeat-freshness.ts`: `projectDispatchHeartbeat(lastReceivedAt, now)` returns `{ state: 'none' | 'fresh' | 'stale' | 'unreadable', lastReceivedAt, ageSeconds }`. `unreadable` is a stored arrival stamp this host cannot parse — corruption, kept apart from the `none` that means the Dispatch never reported.
- `listWorkerTerminalResources` now selects `dispatch_contexts.last_heartbeat_at` and exposes it as epoch ms (`lastHeartbeatAt`).
- `readUtcTimestampMs` returns `number | null | 'unreadable'`: `null` = the column holds no value, `'unreadable'` = it holds one no parser accepts. The string literal rather than `NaN` keeps the value JSON-safe (`NaN` serializes to `null`, which would re-create the bug on a wire hop) and makes TypeScript reject arithmetic on it at every call site.
- `OrchestrationFleetWorker` gains an **optional** `heartbeat` field, projected right beside `liveness` in `projectOrchestrationFleetWorker`. The `worker-list` RPC already publishes the whole projection, so no RPC-shape change was needed.
- Human `worker-list` row prints ` heartbeat=<state> (<age>)` after `liveness=`, with the age floored to one short unit (`43s` / `2m` / `3h`) and signed, so a stamp ahead of this host's clock reads `-4s` instead of collapsing into a reassuring "just reported". `none` and `unreadable` measure no age and print bare; a host that publishes the state without the age still prints the bare state.
- The 10-minute staleness threshold moved out of `coordinator-task-dispatch.ts` into the shared module; `warnStaleDispatches` now imports it, so the CLI word `stale` and the coordinator warning cannot drift apart.
- Comments pin the invariant the reader depends on: `recordHeartbeat`'s `at` is **arrival time on this host**, and both writers (the federation relay import and the legacy lifecycle RPC) stamp it locally.

`liveness.verdict` (`live` / `unverifiable` / `exited`) is untouched: it is the execution host's verdict on the *process*, while `heartbeat` is protocol-level proof the *agent* is still reporting — a live process can stop reporting and a reporting agent can have an unverifiable process, so the two are published side by side rather than merged.

## Why

A coordinator loses a lane in two different ways, and until now `worker-list` could only see one of them. `agent_status` / execution-host evidence answers "is the process there"; the heartbeat answers "is the agent still talking to me". Fixing one on top of the other would let a `live` process hide a silent agent — the failure mode behind [#15951](https://github.com/stablyai/orca/issues/15951).

The threshold is not a new number. `warnStaleDispatches` has warned at 10 minutes (the documented 5-minute heartbeat cadence x 2) for a long time; this reuses that constant instead of inventing a second definition of "stale", which is why it moved to a shared module rather than being copied.

Age is a single-clock subtraction. `last_heartbeat_at` is written only by `recordHeartbeat`, whose contract is that `at` is when *this* host received the heartbeat — the federated relay path deliberately stamps on import and the relayed payload carries no worker timestamp. So a federated lane's age measures silence, not clock skew.

## Linked Issue

Fixes #15951

## Visual Proof

`N/A` — CLI-only. The rendered change is one extra segment on the existing `worker-list` row:

```
ctx_1 task=task_1 [running/working] attention=none liveness=unverifiable heartbeat=stale (43m) provider=claude/opus host=local workspace=ws_1 terminal=active next=none
```

That exact line is asserted in `orchestration-worker-list-heartbeat-cli.test.ts`.

## Testing

Rebuilt on top of `upstream/main` after [#16904](https://github.com/stablyai/orca/pull/16904) landed; the previous branch predated the fleet projection and no longer applied.

Gates run locally on Windows 11 (Node 24.19.0, pnpm 12.0.0):

- `pnpm tc:node` — clean
- `pnpm tc:cli` — clean
- `pnpm run check:code-quality:changed` — `0 new finding(s) across 13 changed file(s)` for oxlint, type-aware, and React Doctor
- `vitest run src/main/runtime/rpc/methods/orchestration/worker src/main/runtime/rpc/methods/orchestration/federation` — 50 files, 380 tests passed
- `vitest run src/main/runtime/orchestration` — 109 files, 883 tests passed
- `vitest run src/shared` — 7218 passed; 7 failures in `secure-path-windows-acl.win32`, `git-fetch-head-lock-key-derivation`, `agent-hook-listener-relay-dependency`, and `external-automation-jobs-file`, all of which fail identically on a clean `upstream/main` checkout on this machine and are unrelated to this diff
- `vitest run src/cli/handlers/orchestration*` — 201 passed; 4 failures in argv-quoting assertions (`orchestration-gate-cli`, `orchestration-timeout-cli`, `orchestration-worker-cli`) that also reproduce on clean `upstream/main` here

New tests:

- `src/shared/orchestration-heartbeat-freshness.test.ts` — `none` vs reported, the exact stale boundary, a future stamp staying visible as a negative age, and the field being omitted when the caller carries no stamp.
- `src/main/runtime/rpc/methods/orchestration/worker/worker-list-heartbeat-freshness.test.ts` — DB to RPC: three Dispatches aged in one listing, freshness independent of the liveness verdict, and a SQLite space-format stamp read as UTC.
- `src/cli/handlers/orchestration-worker-list-heartbeat-cli.test.ts` — the segment renders after `liveness=`, and no segment at all when the host published none.

### Review round 2 (commit `7146b0670`)

Addressing the two CodeRabbit findings of 2026-09-07 (render the age; keep an unreadable stamp out of `none`). Re-run on the same machine:

- `pnpm tc:node`, `pnpm tc:cli` — clean
- `ORCA_CODE_QUALITY_BASE=upstream/main pnpm run check:code-quality:changed` — `0 new finding(s) across 13 changed file(s)` for oxlint, type-aware, and React Doctor
- `vitest run src/cli/handlers/orchestration src/main/runtime/rpc/methods/orchestration/worker src/main/runtime/orchestration/db` — 693 passed; the same 4 argv-quoting failures as before, re-confirmed to reproduce with this commit's changes stashed
- `vitest run src/shared/orchestration-*.test.ts` — 12 files, 108 tests passed

Tests added in this round:

- `orchestration-heartbeat-freshness.test.ts` — `'unreadable'` projects `state: 'unreadable'` with a null age, distinct from `none`; the age formatter floors to one unit and keeps the sign.
- `worker-list-heartbeat-freshness.test.ts` — `'not-a-timestamp'` stored in `last_heartbeat_at` publishes `unreadable` over RPC while a sibling Dispatch that never reported still publishes `none`.
- `orchestration-worker-list-heartbeat-cli.test.ts` — the full rendered row asserted exactly, plus fresh-with-age, `none`, `unreadable`, and a host that published the state without the age.

### Review round 3 (commit `ccaaeb11d`)

Two follow-up Minor findings, both about a corrupt or skewed value borrowing a reassuring word:

- `readUtcTimestampMs` guarded with a falsy check, so an empty stored string folded into the `null` that means "never written". The guard is now `exposed === null`, and `''` falls through to the parse and classifies as `unreadable`.
- `Math.round(-0.4)` is `-0` and JSON publishes that as `0`, so a stamp under 500 ms ahead of this host's clock read as `0s`. The future branch now floors at one second, so any lead reports at least `-1s` and survives serialization.

Regression tests: `''` stored in `last_heartbeat_at` publishing `unreadable` over RPC; leads of 1 ms / 400 ms / 499 ms / 500 ms all reporting `-1` after a `JSON.parse(JSON.stringify(...))` round trip, with 1.6 s still reporting `-2`.

Gates re-run: `pnpm tc:node` and `pnpm tc:cli` clean; `check:code-quality:changed` `0 new finding(s) across 13 changed file(s)`; `vitest run src/cli/handlers/orchestration src/main/runtime/rpc/methods/orchestration/worker src/main/runtime/orchestration/db` 694 passed with the same 4 pre-existing argv-quoting failures; `vitest run src/shared/orchestration-*.test.ts` 109 passed.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Not checked: I have not driven a live multi-lane run against a built app for this branch, so the evidence above is the automated suites only.

## AI Disclosure

Written with Claude (Opus) in Claude Code. All commands, gate output, and the pre-existing-failure comparison against `upstream/main` were run and read by me.

## Review

**SSH / federation.** The heartbeat is Run-home state: it lives in the home `dispatch_contexts` table and is written on arrival, whether it came in over the local lifecycle RPC or through the federation relay import. `--include-remote` still asks the execution host only about the *process*, and `applyFederatedFleetObservations` is untouched — a host verdict overrides `liveness` and never rewrites `heartbeat`, which is correct because the remote host has no view of the home's arrival record. A federated lane whose relay is down therefore reports `liveness=unverifiable` with a truthful `heartbeat=stale`, which is exactly the distinction a coordinator needs.

**Wire compatibility.** `heartbeat` is a new optional field on an existing object (`docs/reference/remote-wire-compatibility.md`, Rule 1: additive optional fields are safe). No new stream opcode and no capability negotiation. The follow-up commit widens the published `heartbeat.state` enum with `unreadable`; that reaches older clients, but the CLI renders the state as text rather than switching on it, so an older client prints the new word instead of dropping a frame. Mixed versions were handled explicitly in both directions: a new CLI against an older runtime sees no `heartbeat` and prints no segment (covered by a test), and an older CLI against a new runtime ignores the extra field. The projection deliberately distinguishes *absent* (`lastHeartbeatAt === undefined`, host does not carry the column, omit the field) from *null* (`state: 'none'`, this Dispatch genuinely never reported), so a mixed-version gap can never be misread as a silent worker.

**Cross-platform.** No paths, no shell, no process spawning; SQLite timestamps are normalized through the existing `exposeUtcTimestamp` regex rather than by string slicing, and a stamp that parses to nothing degrades to `unreadable` — never to a bogus instant, and never to the `none` that would describe a reporting Dispatch as one that never reported.

**Performance.** One extra column on a `SELECT` that already reads the same row; no new query, no new join, no extra round trip. The projection is arithmetic on a number.

**Security.** No new authority, no new capability, no new surface. `last_heartbeat_at` was already published raw by `exposeDispatchContext` on `worker-show`.

**UI.** CLI text only; no renderer or mobile surface reads the new field.

**Folder workspaces.** The feature is keyed on the Dispatch, not on a worktree, so folder workspaces behave identically.

**Git providers.** Not applicable; nothing touches source control.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The 10-minute constant now has one home. If a future change re-tunes the heartbeat cadence, `DISPATCH_HEARTBEAT_STALE_AFTER_MS` is the single place both the coordinator warning and the CLI word follow.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Typecheck and the changed-code quality gate pass locally; the full `pnpm test` and `pnpm build` are left to CI, since this machine has pre-existing unrelated failures in `src/shared` and `src/cli/handlers` that reproduce on a clean `upstream/main` checkout.

## Author

- X / Twitter: @EnricoPin



