### PR TITLE
fix(orchestration): persist the dispatch_input failure cause on the Dispatch

### DIFF
--- a/src/main/runtime/orchestration/db/federation/remote-dispatch-attachment-authority.ts
+++ b/src/main/runtime/orchestration/db/federation/remote-dispatch-attachment-authority.ts
@@ -142,17 +142,20 @@ export function failRemoteAttachment(
   dispatchId: string,
   stage: string,
   reason: string,
-  unknown: boolean
+  unknown: boolean,
+  // Why (#15958): the failing stage's effects are still in memory, so the cause it recorded there
+  // is lost unless this write keeps them.
+  options: { effects?: unknown[] } = {}
 ): RemoteDispatchAttachmentRow {
   const state = unknown ? 'start_unknown' : 'failed'
   const result = this.db
     .prepare(
       `UPDATE remote_dispatch_attachments
        SET state = ?, stage = ?, last_error = ?, capability_hash = NULL,
-           updated_at = datetime('now')
+           effects = COALESCE(?, effects), updated_at = datetime('now')
        WHERE dispatch_id = ? AND state = 'starting'`
     )
-    .run(state, stage, reason, dispatchId)
+    .run(state, stage, reason, options.effects ? JSON.stringify(options.effects) : null, dispatchId)
   if (result.changes !== 1) {
     throw new OrchestrationError(
       'dispatch_inactive',

--- a/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-outcome.ts
+++ b/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-outcome.ts
@@ -55,6 +55,9 @@ export function failWorkerStart(
     retainCapability?: boolean
     /** A start that died before authority attached still owns the terminal it created. */
     adoptResidualTerminal?: FailedStartTerminalAdoption
+    /** Why (#15958): the last stage's effects are still in memory, so a failure cause the
+     *  caller recorded there is lost unless this transition writes them. */
+    effects?: unknown[]
   } = {}
 ): WorkerDispatchRow {
   this.db.exec('BEGIN IMMEDIATE')
@@ -83,7 +86,12 @@ export function failWorkerStart(
       id: dispatchId,
       from: 'starting',
       to: 'failed',
-      projection: { stage, last_error: reason, updated_at: now }
+      projection: {
+        stage,
+        last_error: reason,
+        updated_at: now,
+        effects: options.effects ? JSON.stringify(options.effects) : worker.effects
+      }
     })
     const hasActiveDispatch = Boolean(
       this.db
@@ -121,7 +129,8 @@ export function markWorkerStartUnknown(
   this: OrchestrationDb,
   dispatchId: string,
   stage: string,
-  reason: string
+  reason: string,
+  options: { effects?: unknown[] } = {}
 ): WorkerDispatchRow {
   this.db.exec('BEGIN IMMEDIATE')
   try {
@@ -135,7 +144,12 @@ export function markWorkerStartUnknown(
       id: dispatchId,
       from: 'starting',
       to: 'start_unknown',
-      projection: { stage, last_error: reason, updated_at: new Date().toISOString() }
+      projection: {
+        stage,
+        last_error: reason,
+        updated_at: new Date().toISOString(),
+        effects: options.effects ? JSON.stringify(options.effects) : worker.effects
+      }
     })
     transitionLifecycleWithDb(this.db, {
       entity: 'dispatch',

--- a/src/main/runtime/rpc/methods/orchestration/dispatch-input-verdict.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration/dispatch-input-verdict.test.ts
@@ -1,0 +1,378 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { RpcContext } from '../../core'
+import { createOrchestrationRpcHarness } from './rpc-test-harness'
+import { OrchestrationDb as OrchestrationDbClass } from '../../../orchestration/db'
+import { OrcaRuntimeService as OrcaRuntimeServiceClass } from '../../../orca-runtime'
+import { ORCHESTRATION_METHODS } from '../orchestration'
+import {
+  ORCHESTRATION_CONTRACT_RUNTIME_CAPABILITY,
+  ORCHESTRATION_FEDERATION_RUNTIME_CAPABILITY
+} from '../../../../../shared/protocol-version'
+import { TERMINAL_INPUT_TOO_LARGE_ERROR } from '../../../../../shared/terminal-input'
+import { dispatchInputFailedEffect } from './dispatch-input-verdict'
+import { startFederatedWorker } from './federation/federated-worker-start'
+import type { OrchestrationDb } from '../../../orchestration/db'
+import type { OrcaRuntimeService } from '../../../orca-runtime'
+
+type DispatchInputEffectRow = {
+  kind: string
+  role?: string
+  id?: string
+  state?: string
+  cause?: string
+  detail?: string
+}
+
+describe('dispatch input verdict', () => {
+  const h = createOrchestrationRpcHarness()
+  const { coordinatorPaneKey } = h
+  let db: OrchestrationDb
+  let runtime: OrcaRuntimeService
+  let ctx: RpcContext
+
+  afterEach(() => {
+    h.cleanup()
+  })
+
+  function mockWorkerStart(): void {
+    vi.mocked(runtime.getTerminalPaneKey).mockImplementation((handle) =>
+      handle === 'term_coord'
+        ? coordinatorPaneKey
+        : handle === 'term_worker'
+          ? 'tab_worker:leaf_worker'
+          : null
+    )
+    vi.spyOn(runtime, 'validateOrchestrationAgentLauncher').mockImplementation(() => {})
+    vi.spyOn(runtime, 'showTerminal').mockImplementation(
+      async (handle) => ({ handle, worktreeId: 'repo::worktree', status: 'running' }) as never
+    )
+    vi.spyOn(runtime, 'showManagedWorktree').mockResolvedValue({ id: 'repo::worktree' } as never)
+    vi.spyOn(runtime, 'showManagedTerminalWorkspace').mockResolvedValue({
+      id: 'repo::worktree'
+    } as never)
+    vi.spyOn(runtime, 'createTerminal').mockResolvedValue({
+      handle: 'term_worker',
+      worktreeId: 'repo::worktree',
+      title: 'worker'
+    })
+    vi.spyOn(runtime, 'waitForTerminal').mockResolvedValue({
+      handle: 'term_worker',
+      condition: 'tui-idle',
+      satisfied: true,
+      status: 'running',
+      exitCode: null
+    })
+    vi.mocked(runtime.getTerminalProcessIncarnation).mockImplementation((handle) =>
+      handle === 'term_worker' ? 'runtime_test:term_worker:1' : null
+    )
+    vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
+  }
+
+  async function startWorkerWithPromptError(error: Error) {
+    ;({ db, runtime, ctx } = h.setup())
+    mockWorkerStart()
+    vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockRejectedValue(error)
+    const task = db.createTask({ spec: 'worker whose preamble never submits' })
+    return (await h.call(
+      'orchestration.workerStart',
+      { task: task.id, from: 'term_coord', agent: 'codex' },
+      ctx
+    )) as { dispatchId: string; state: string; failedStage: string; effects: unknown[] }
+  }
+
+  function readPersistedDispatchInput(dispatchId: string): DispatchInputEffectRow | undefined {
+    const stored = JSON.parse(
+      db.getWorkerDispatch(dispatchId)?.effects ?? '[]'
+    ) as DispatchInputEffectRow[]
+    return stored.find((effect) => effect.kind === 'dispatch_input')
+  }
+
+  it('keeps a stalled submission on the Dispatch instead of only throwing', async () => {
+    const result = await startWorkerWithPromptError(new Error('agent_prompt_stalled'))
+
+    expect(result.state).toBe('failed')
+    expect(result.failedStage).toBe('dispatch_input')
+    expect(readPersistedDispatchInput(result.dispatchId)).toEqual({
+      kind: 'dispatch_input',
+      role: 'agent',
+      id: 'term_worker',
+      state: 'failed',
+      cause: 'agent_prompt_stalled',
+      detail: 'agent_prompt_stalled'
+    })
+  })
+
+  it('reports the cause on the receipt the coordinator reads', async () => {
+    const result = await startWorkerWithPromptError(new Error('terminal_not_writable'))
+
+    expect(result.state).toBe('failed')
+    expect(result.effects).toContainEqual(
+      expect.objectContaining({
+        kind: 'dispatch_input',
+        state: 'failed',
+        cause: 'terminal_not_writable'
+      })
+    )
+  })
+
+  it('separates a blocked submission from a never-attempted one', async () => {
+    const blocked = await startWorkerWithPromptError(new Error('agent_prompt_blocked'))
+    expect(readPersistedDispatchInput(blocked.dispatchId)?.cause).toBe('agent_prompt_blocked')
+
+    h.cleanup()
+    ;({ db, runtime, ctx } = h.setup())
+    mockWorkerStart()
+    vi.spyOn(runtime, 'waitForTerminal').mockResolvedValue({
+      handle: 'term_worker',
+      condition: 'tui-idle',
+      satisfied: false,
+      status: 'running',
+      exitCode: null
+    })
+    const task = db.createTask({ spec: 'worker that never reached the preamble' })
+    const neverAttempted = (await h.call(
+      'orchestration.workerStart',
+      { task: task.id, from: 'term_coord', agent: 'codex' },
+      ctx
+    )) as { dispatchId: string; failedStage: string }
+
+    expect(neverAttempted.failedStage).toBe('agent_readiness')
+    expect(readPersistedDispatchInput(neverAttempted.dispatchId)).toBeUndefined()
+  })
+
+  it('classifies a stale handle and keeps unrecognized causes readable', () => {
+    expect(dispatchInputFailedEffect('term_worker', new Error('terminal_handle_stale'))).toEqual({
+      kind: 'dispatch_input',
+      role: 'agent',
+      id: 'term_worker',
+      state: 'failed',
+      cause: 'terminal_handle_stale',
+      detail: 'terminal_handle_stale'
+    })
+    expect(dispatchInputFailedEffect('term_worker', new Error('EPIPE write failed'))).toMatchObject(
+      {
+        cause: 'unknown',
+        detail: 'EPIPE write failed'
+      }
+    )
+  })
+
+  it('names the not-ready renderer graph rather than collapsing it to unknown', () => {
+    expect(
+      dispatchInputFailedEffect('term_worker', new Error('runtime_unavailable'))
+    ).toMatchObject({ cause: 'runtime_unavailable', detail: 'runtime_unavailable' })
+  })
+
+  it('maps the 16 MiB input guard, which throws prose instead of a code', () => {
+    expect(
+      dispatchInputFailedEffect('term_worker', new Error(TERMINAL_INPUT_TOO_LARGE_ERROR))
+    ).toMatchObject({
+      cause: 'terminal_input_too_large',
+      detail: TERMINAL_INPUT_TOO_LARGE_ERROR
+    })
+  })
+})
+
+// Why: the federated attach runs the same preamble submission on the remote host, where the
+// exception never crosses back to the Run home at all.
+describe('federated dispatch input verdict', () => {
+  let db: OrchestrationDbClass | undefined
+
+  afterEach(() => {
+    db?.close()
+    vi.restoreAllMocks()
+  })
+
+  it('keeps the blocked cause on the remote attachment', async () => {
+    db = new OrchestrationDbClass(':memory:')
+    const runtime = new OrcaRuntimeServiceClass()
+    runtime.setOrchestrationDb(db)
+    vi.spyOn(runtime, 'validateOrchestrationAgentLauncher').mockImplementation(() => {})
+    vi.spyOn(runtime, 'showManagedTerminalWorkspace').mockResolvedValue({
+      id: 'folder:remote-workspace'
+    } as never)
+    vi.spyOn(runtime, 'createTerminal').mockResolvedValue({
+      handle: 'term_remote_worker',
+      worktreeId: 'folder:remote-workspace',
+      title: 'worker'
+    })
+    vi.spyOn(runtime, 'waitForTerminal').mockResolvedValue({
+      handle: 'term_remote_worker',
+      condition: 'tui-idle',
+      satisfied: true,
+      status: 'running',
+      exitCode: null
+    })
+    vi.spyOn(runtime, 'getTerminalPaneKey').mockReturnValue('tab_remote:leaf_remote')
+    vi.spyOn(runtime, 'getTerminalProcessIncarnation').mockReturnValue(
+      'runtime_test:term_remote_worker:1'
+    )
+    vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
+    vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockRejectedValue(
+      new Error('agent_prompt_blocked')
+    )
+    const method = ORCHESTRATION_METHODS.find(
+      (candidate) => candidate.name === 'orchestration.federationAttachStart'
+    )
+    if (!method) {
+      throw new Error('federationAttachStart method is not registered')
+    }
+
+    const result = (await method.handler(
+      method.params!.parse({
+        dispatchId: 'ctx_remote',
+        taskId: 'task_remote',
+        taskSpec: 'remote worker whose preamble never submits',
+        protocolVersion: 3,
+        worktree: 'folder:remote-workspace',
+        agent: 'codex'
+      }),
+      {
+        runtime,
+        orchestrationMutation: {
+          callerFingerprint: 'home_peer',
+          requestId: 'request_remote',
+          method: 'orchestration.federationAttachStart',
+          payloadHash: 'remote_payload'
+        }
+      }
+    )) as { state: string; failedStage: string }
+
+    expect(result).toMatchObject({ state: 'failed', failedStage: 'dispatch_input' })
+    const stored = JSON.parse(
+      db.getRemoteDispatchAttachment('ctx_remote')?.effects ?? '[]'
+    ) as DispatchInputEffectRow[]
+    expect(stored.find((effect) => effect.kind === 'dispatch_input')).toMatchObject({
+      state: 'failed',
+      cause: 'agent_prompt_blocked',
+      detail: 'agent_prompt_blocked'
+    })
+  })
+})
+
+// Why: on a federated start the submission happens on the remote host, so the exception never
+// reaches the Run home at all. The remote receipt is the only carrier, and a coordinator that can
+// no longer reach that server has nothing left to read unless the home Dispatch keeps what it was
+// handed.
+describe('federated Run home dispatch input verdict', () => {
+  const databases: OrchestrationDbClass[] = []
+
+  afterEach(() => {
+    for (const database of databases.splice(0)) {
+      database.close()
+    }
+    vi.restoreAllMocks()
+  })
+
+  const REMOTE_FAILURE_EFFECTS = [
+    { kind: 'worktree', action: 'reused', id: 'worktree_remote' },
+    { kind: 'terminal', role: 'agent', action: 'reused', id: 'term_remote_worker' },
+    {
+      kind: 'dispatch_input',
+      role: 'agent',
+      id: 'term_remote_worker',
+      state: 'failed',
+      cause: 'agent_prompt_stalled',
+      detail: 'agent_prompt_stalled'
+    }
+  ]
+
+  async function startRemoteWorker(remoteState: 'failed' | 'outcome_unknown') {
+    const db = new OrchestrationDbClass(':memory:')
+    databases.push(db)
+    const runtime = new OrcaRuntimeServiceClass()
+    runtime.setOrchestrationDb(db)
+    const run = db.createRun({
+      objective: 'federated worker',
+      coordinatorHandle: 'term_coord',
+      coordinatorPaneKey: 'tab_coord:leaf_coord'
+    })
+    const task = db.createTask({
+      spec: 'remote worker whose preamble never submits',
+      runId: run.id
+    })
+    vi.spyOn(runtime, 'resolveOrchestrationWorkerServer').mockReturnValue({
+      environmentId: 'environment_remote',
+      name: 'remote',
+      peerFingerprint: 'remote_peer'
+    })
+    vi.spyOn(runtime, 'callOrchestrationWorkerServer').mockImplementation(
+      async (_environmentId, method, params) => {
+        if (method === 'status.get') {
+          return {
+            capabilities: [
+              ORCHESTRATION_CONTRACT_RUNTIME_CAPABILITY,
+              ORCHESTRATION_FEDERATION_RUNTIME_CAPABILITY
+            ]
+          }
+        }
+        return {
+          dispatchId: (params as { dispatchId: string }).dispatchId,
+          state: remoteState,
+          runtimeEpoch: 'remote_epoch',
+          failedStage: 'dispatch_input',
+          lastError: 'agent_prompt_stalled',
+          effects: REMOTE_FAILURE_EFFECTS,
+          residualResources: [
+            { kind: 'terminal', role: 'agent', action: 'reused', id: 'term_remote_worker' }
+          ]
+        }
+      }
+    )
+    const result = (await startFederatedWorker({
+      params: {
+        task: task.id,
+        from: 'term_coord',
+        on: 'remote',
+        worktree: 'id:worktree_remote',
+        terminal: 'term_remote_worker'
+      },
+      runtime,
+      db,
+      runId: run.id,
+      task,
+      orchestrationMutation: {
+        callerFingerprint: 'caller',
+        requestId: 'remote_start',
+        method: 'orchestration.workerStart',
+        payloadHash: 'payload'
+      }
+    })) as { dispatchId: string; state: string; effects: DispatchInputEffectRow[] }
+    return { db, result }
+  }
+
+  function readPersistedDispatchInput(
+    db: OrchestrationDbClass,
+    dispatchId: string
+  ): DispatchInputEffectRow | undefined {
+    const stored = JSON.parse(
+      db.getWorkerDispatch(dispatchId)?.effects ?? '[]'
+    ) as DispatchInputEffectRow[]
+    return stored.find((effect) => effect.kind === 'dispatch_input')
+  }
+
+  it('persists the remote failure evidence on the home Dispatch', async () => {
+    const { db, result } = await startRemoteWorker('failed')
+
+    expect(result.state).toBe('failed')
+    expect(readPersistedDispatchInput(db, result.dispatchId)).toMatchObject({
+      state: 'failed',
+      cause: 'agent_prompt_stalled',
+      detail: 'agent_prompt_stalled',
+      id: 'term_remote_worker'
+    })
+  })
+
+  it('keeps the remote evidence when the remote outcome is unknown', async () => {
+    const { db, result } = await startRemoteWorker('outcome_unknown')
+
+    expect(result.state).toBe('outcome_unknown')
+    expect(readPersistedDispatchInput(db, result.dispatchId)).toMatchObject({
+      state: 'failed',
+      cause: 'agent_prompt_stalled'
+    })
+    // Why: the unknown receipt used to hard-code effects: [], so the coordinator was told nothing
+    // even when the remote had just described the failure.
+    expect(result.effects).toEqual(REMOTE_FAILURE_EFFECTS)
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration/dispatch-input-verdict.ts
+++ b/src/main/runtime/rpc/methods/orchestration/dispatch-input-verdict.ts
@@ -1,0 +1,68 @@
+import { TERMINAL_INPUT_TOO_LARGE_ERROR } from '../../../../../shared/terminal-input'
+
+// Why: since #14962 an unsubmitted preamble throws instead of being recorded as
+// accepted, so the verdict lived only in the exception. Effects are what the
+// Dispatch keeps, so the cause is written there next to the accepted receipt.
+// The set is every failure the preamble delivery can raise with a stable code:
+// the submission verdicts, the writability/identity gates it reaches through the
+// handle, the 16 MiB input guard, and the not-ready renderer graph.
+const DISPATCH_INPUT_FAILURE_CAUSES = [
+  'agent_prompt_stalled',
+  'agent_prompt_blocked',
+  'terminal_handle_stale',
+  'terminal_not_writable',
+  'terminal_exited',
+  'terminal_gone',
+  'terminal_input_too_large',
+  'runtime_unavailable',
+  'request_aborted'
+] as const
+
+export type DispatchInputFailureCause = (typeof DISPATCH_INPUT_FAILURE_CAUSES)[number] | 'unknown'
+
+export type DispatchInputEffect = {
+  kind: 'dispatch_input'
+  role: 'agent'
+  id: string
+  state: 'accepted' | 'failed'
+  cause?: DispatchInputFailureCause
+  detail?: string
+}
+
+export function dispatchInputAcceptedEffect(terminalHandle: string): DispatchInputEffect {
+  return { kind: 'dispatch_input', role: 'agent', id: terminalHandle, state: 'accepted' }
+}
+
+export function dispatchInputFailedEffect(
+  terminalHandle: string,
+  error: unknown
+): DispatchInputEffect {
+  const detail = error instanceof Error ? error.message : String(error)
+  return {
+    kind: 'dispatch_input',
+    role: 'agent',
+    id: terminalHandle,
+    state: 'failed',
+    cause: classifyDispatchInputFailure(error, detail),
+    detail
+  }
+}
+
+// Why: the runtime throws bare Errors whose message is the stable code, while
+// OrchestrationError carries it on `code`. Read both, and keep anything else —
+// including the structured-session refusals, which throw prose — as 'unknown'
+// with the message on `detail`, so the vocabulary a reader branches on stays closed.
+function classifyDispatchInputFailure(error: unknown, detail: string): DispatchInputFailureCause {
+  // Why: the 16 MiB guard is the one gate that throws prose instead of a code,
+  // so it needs an explicit mapping to stay a token a reader can branch on.
+  if (detail === TERMINAL_INPUT_TOO_LARGE_ERROR) {
+    return 'terminal_input_too_large'
+  }
+  const code =
+    error && typeof error === 'object' && typeof (error as { code?: unknown }).code === 'string'
+      ? (error as { code: string }).code
+      : detail
+  return (DISPATCH_INPUT_FAILURE_CAUSES as readonly string[]).includes(code)
+    ? (code as DispatchInputFailureCause)
+    : 'unknown'
+}

--- a/src/main/runtime/rpc/methods/orchestration/federation/federated-worker-start-receipts.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federated-worker-start-receipts.ts
@@ -29,7 +29,9 @@ export function federatedUnknownReceipt(
   worker: { dispatch_id: string; state: string; stage: string; last_error: string | null },
   taskId: string,
   serverName: string,
-  launch: OrchestrationWorkerLaunchReceipt
+  launch: OrchestrationWorkerLaunchReceipt,
+  /** What the worker server reported before contact was lost; absent when it never answered. */
+  remote?: Pick<RemoteStartReceipt, 'effects' | 'residualResources'>
 ): unknown {
   return {
     taskId,
@@ -40,8 +42,8 @@ export function federatedUnknownReceipt(
     launch,
     failedStage: worker.stage,
     lastError: worker.last_error,
-    effects: [],
-    residualResources: [],
+    effects: remote?.effects ?? [],
+    residualResources: remote?.residualResources ?? [],
     nextCommands: [
       `orca orchestration worker-show --dispatch ${worker.dispatch_id} --json`,
       `orca orchestration worker-abandon --dispatch ${worker.dispatch_id} --json`

--- a/src/main/runtime/rpc/methods/orchestration/federation/federated-worker-start.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federated-worker-start.ts
@@ -241,14 +241,19 @@ export async function startFederatedWorker(args: {
       const worker = db.markWorkerStartUnknown(
         started.dispatch.id,
         remote.failedStage ?? 'remote_attach',
-        remote.lastError ?? 'The worker server reported an unknown start outcome.'
+        remote.lastError ?? 'The worker server reported an unknown start outcome.',
+        { effects: remote.effects }
       )
-      return federatedUnknownReceipt(worker, taskForRemote.id, server.name, launch)
+      return federatedUnknownReceipt(worker, taskForRemote.id, server.name, launch, remote)
     }
+    // Why (#15958): the remote receipt is the only place the dispatch_input verdict exists. Without
+    // persisting it here the home Dispatch keeps nothing, and a coordinator that can no longer
+    // reach the worker server has no way to read why the start failed.
     const worker = db.failWorkerStart(
       started.dispatch.id,
       remote.failedStage ?? 'remote_attach',
-      remote.lastError ?? `The worker server returned ${remote.state}.`
+      remote.lastError ?? `The worker server returned ${remote.state}.`,
+      { effects: remote.effects }
     )
     return {
       runId,

--- a/src/main/runtime/rpc/methods/orchestration/federation/federation-effects.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federation-effects.ts
@@ -12,6 +12,7 @@ export type FederationEffect = {
   hookFound?: boolean
   startupPolicy?: string
   terminalId?: string
+  // A dispatch_input effect also carries `cause`/`detail`; see DispatchInputEffect.
 }
 
 export function appendFederationTerminalEffects(

--- a/src/main/runtime/rpc/methods/orchestration/federation/federation-start-receipt.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federation-start-receipt.ts
@@ -11,6 +11,8 @@ export function failFederatedAttachmentWithReceipt(args: {
   error: unknown
   setup: WorkerSetupReceipt
   launch: OrchestrationWorkerLaunchReceipt
+  /** Effects gathered since the last stage write, including the dispatch_input verdict. */
+  effects?: unknown[]
 }): unknown {
   const reason = args.error instanceof Error ? args.error.message : String(args.error)
   const unknown = isFederationEffectUnknown(args.error, args.failedStage)
@@ -18,7 +20,8 @@ export function failFederatedAttachmentWithReceipt(args: {
     args.dispatchId,
     args.failedStage,
     reason,
-    unknown
+    unknown,
+    { effects: args.effects }
   )
   return {
     dispatchId: args.dispatchId,

--- a/src/main/runtime/rpc/methods/orchestration/federation/federation.ts
+++ b/src/main/runtime/rpc/methods/orchestration/federation/federation.ts
@@ -16,6 +16,7 @@ import {
   persistFederatedSetupWaitOutcome
 } from './federation-setup'
 import { FederationAttachStartParams } from './federation-start-schema'
+import { dispatchInputAcceptedEffect, dispatchInputFailedEffect } from '../dispatch-input-verdict'
 import { failFederatedAttachmentWithReceipt } from './federation-start-receipt'
 import { prepareFederationAttachmentWorkerStart } from '../worker/worker-start-validation'
 import {
@@ -244,33 +245,37 @@ export const ORCHESTRATION_FEDERATION_ATTACH_METHODS: RpcMethod[] = [
           terminalOwnership: params.terminal ? 'external' : 'created'
         })
         failedStage = 'dispatch_input'
-        const prompt = await runtime.sendTerminalAgentPrompt(
-          terminalHandle,
-          buildDispatchPreamble({
-            taskId: params.taskId,
-            dispatchId: params.dispatchId,
-            taskSpec: params.taskSpec,
-            coordinatorHandle: 'Run home (relayed by Orca)',
-            workerHandle: terminalHandle,
-            dispatchCapability: capability,
-            devMode: params.devMode,
-            // Why the worker host's own setting: enforcement runs here, with this
-            // host's code, against this host's cap.
-            canDispatchSubWorkers: (params.depth ?? 1) < runtime.getNestedWorkerMaxDepth(),
-            cliCommand: runtime.getTerminalOrchestrationCliCommand(terminalHandle)
-          }),
-          {
-            acceptQueued: true,
-            observationTimeoutMs: 0,
-            requestId: orchestrationMutation.requestId
-          }
-        )
-        effects.push({
-          kind: 'dispatch_input',
-          role: 'agent',
-          id: terminalHandle,
-          state: 'accepted'
-        })
+        // Captured so the rejection closure keeps the narrowed handle.
+        const agentHandle = terminalHandle
+        const prompt = await runtime
+          .sendTerminalAgentPrompt(
+            agentHandle,
+            buildDispatchPreamble({
+              taskId: params.taskId,
+              dispatchId: params.dispatchId,
+              taskSpec: params.taskSpec,
+              coordinatorHandle: 'Run home (relayed by Orca)',
+              workerHandle: agentHandle,
+              dispatchCapability: capability,
+              devMode: params.devMode,
+              // Why the worker host's own setting: enforcement runs here, with this
+              // host's code, against this host's cap.
+              canDispatchSubWorkers: (params.depth ?? 1) < runtime.getNestedWorkerMaxDepth(),
+              cliCommand: runtime.getTerminalOrchestrationCliCommand(agentHandle)
+            }),
+            {
+              acceptQueued: true,
+              observationTimeoutMs: 0,
+              requestId: orchestrationMutation.requestId
+            }
+          )
+          // Why (#15958): the exception never leaves this host, so the attachment is the only
+          // record the Run home can still read once the relay is gone.
+          .catch((error: unknown) => {
+            effects.push(dispatchInputFailedEffect(agentHandle, error))
+            throw error
+          })
+        effects.push(dispatchInputAcceptedEffect(agentHandle))
         const attachment = db.markRemoteAttachmentReady(params.dispatchId, effects)
         monitorFederatedSetup({ ...setupStage, runtime })
         return {
@@ -294,7 +299,8 @@ export const ORCHESTRATION_FEDERATION_ATTACH_METHODS: RpcMethod[] = [
           failedStage,
           error,
           setup,
-          launch: launch.receipt
+          launch: launch.receipt,
+          effects
         })
       }
     }

--- a/src/main/runtime/rpc/methods/orchestration/worker/deliver-worker-dispatch-preamble.ts
+++ b/src/main/runtime/rpc/methods/orchestration/worker/deliver-worker-dispatch-preamble.ts
@@ -2,7 +2,8 @@ import type { RuntimeTerminalSend } from '../../../../../../shared/runtime-termi
 import type { OrcaRuntimeService } from '../../../../orca-runtime'
 import { buildDispatchPreamble } from '../../../../orchestration/preamble'
 import { sendStructuredWorkerPreamble } from '../../orchestration-structured-worker-session'
-import type { createStructuredWorkerSessionForWorktree } from './worker-topology'
+import { dispatchInputAcceptedEffect, dispatchInputFailedEffect } from '../dispatch-input-verdict'
+import type { WorkerEffect, createStructuredWorkerSessionForWorktree } from './worker-topology'
 
 type StructuredSession = Awaited<ReturnType<typeof createStructuredWorkerSessionForWorktree>> | null
 
@@ -12,6 +13,10 @@ type StructuredSession = Awaited<ReturnType<typeof createStructuredWorkerSession
  * The preamble itself is identical for both: a worker is taught the same verbs whichever mode it
  * runs in, and only the delivery differs — a PTY write returns a queued/accepted receipt, while a
  * structured turn either is acknowledged or throws.
+ *
+ * Why (#15958): the verdict is appended here, on both edges. A delivery that throws leaves the
+ * cause only in the exception, and the Dispatch — the thing a coordinator can still read after the
+ * caller is gone — keeps nothing but a stage and a message.
  */
 export async function deliverWorkerDispatchPreamble(args: {
   runtime: OrcaRuntimeService
@@ -25,6 +30,7 @@ export async function deliverWorkerDispatchPreamble(args: {
   dispatchCapability: string
   devMode: boolean | undefined
   requestId: string
+  effects: WorkerEffect[]
 }): Promise<RuntimeTerminalSend['prompt']> {
   const { runtime, structuredSession, terminalHandle } = args
   const preamble = buildDispatchPreamble({
@@ -41,20 +47,26 @@ export async function deliverWorkerDispatchPreamble(args: {
     devMode: args.devMode,
     cliCommand: runtime.getTerminalOrchestrationCliCommand(terminalHandle)
   })
-  if (structuredSession) {
-    await sendStructuredWorkerPreamble({
-      host: structuredSession.host,
-      sessionId: structuredSession.identity.sessionId,
-      dispatchId: args.dispatchId,
-      preamble
-    })
-    return undefined
-  }
-  return (
-    await runtime.sendTerminalAgentPrompt(terminalHandle, preamble, {
+  try {
+    if (structuredSession) {
+      await sendStructuredWorkerPreamble({
+        host: structuredSession.host,
+        sessionId: structuredSession.identity.sessionId,
+        dispatchId: args.dispatchId,
+        preamble
+      })
+      args.effects.push(dispatchInputAcceptedEffect(terminalHandle))
+      return undefined
+    }
+    const send = await runtime.sendTerminalAgentPrompt(terminalHandle, preamble, {
       acceptQueued: true,
       observationTimeoutMs: 0,
       requestId: args.requestId
     })
-  ).prompt
+    args.effects.push(dispatchInputAcceptedEffect(terminalHandle))
+    return send.prompt
+  } catch (error) {
+    args.effects.push(dispatchInputFailedEffect(terminalHandle, error))
+    throw error
+  }
 }

--- a/src/main/runtime/rpc/methods/orchestration/worker/local-worker-start.ts
+++ b/src/main/runtime/rpc/methods/orchestration/worker/local-worker-start.ts
@@ -252,13 +252,8 @@ export async function startLocalWorker(args: {
       coordinatorHandle: params.from,
       dispatchCapability: capability,
       devMode: params.devMode,
-      requestId: orchestrationMutation?.requestId ?? started.dispatch.id
-    })
-    effects.push({
-      kind: 'dispatch_input',
-      role: 'agent',
-      id: terminalHandle,
-      state: 'accepted'
+      requestId: orchestrationMutation?.requestId ?? started.dispatch.id,
+      effects
     })
     const worker = db.markWorkerDispatchReady(started.dispatch.id, effects)
     monitorWorkerSetup({
@@ -303,6 +298,7 @@ export async function startLocalWorker(args: {
       setup: setupReceipt,
       launch: launch.receipt,
       mode,
+      effects,
       ...(residualAgentTerminal ? { residualAgentTerminal } : {})
     })
   }

--- a/src/main/runtime/rpc/methods/orchestration/worker/worker-start-receipt.ts
+++ b/src/main/runtime/rpc/methods/orchestration/worker/worker-start-receipt.ts
@@ -19,6 +19,8 @@ export function failWorkerStartWithReceipt(args: {
   mode: WorkerStartModeReceipt
   /** The terminal this start created and never handed to an owner. */
   residualAgentTerminal?: FailedStartTerminalAdoption
+  /** Effects gathered since the last stage write, including the dispatch_input verdict. */
+  effects?: unknown[]
 }): unknown {
   const agentSessionRefusal = isAgentSessionPtyWriteRefusedError(args.error)
     ? args.error.refusal
@@ -29,12 +31,17 @@ export function failWorkerStartWithReceipt(args: {
     (args.error instanceof Error ? args.error.message : String(args.error))
   const unknown = isUnknownWorkerStartOutcome(args.error, args.failedStage)
   const worker = unknown
-    ? args.db.markWorkerStartUnknown(args.dispatchId, args.failedStage, reason)
+    ? args.db.markWorkerStartUnknown(args.dispatchId, args.failedStage, reason, {
+        effects: args.effects
+      })
     : args.db.failWorkerStart(args.dispatchId, args.failedStage, reason, {
         // Why (#16095): the preamble is written before submission is verified, so a stalled
         // verdict never means the worker lacks its task — keep the authority its report needs.
         retainCapability: isAgentPromptStalledError(args.error),
-        ...(args.residualAgentTerminal ? { adoptResidualTerminal: args.residualAgentTerminal } : {})
+        ...(args.residualAgentTerminal
+          ? { adoptResidualTerminal: args.residualAgentTerminal }
+          : {}),
+        effects: args.effects
       })
   // Only claim cleanup the ownership table actually accepted; the adoption declines a terminal
   // another resource already accounts for.

--- a/src/main/runtime/rpc/methods/orchestration/worker/worker-topology.ts
+++ b/src/main/runtime/rpc/methods/orchestration/worker/worker-topology.ts
@@ -21,6 +21,7 @@ export type WorkerEffect = {
   terminalId?: string
   surface?: 'visible' | 'background'
   warning?: string
+  // A dispatch_input effect also carries `cause`/`detail`; see DispatchInputEffect.
 }
 
 export type WorkerSetupReceipt = {


### PR DESCRIPTION
## ELI5

When a worker start fails while handing the worker its instructions, Orca writes down *that* it failed, but the machine-readable list of what the start actually did never records that delivering the prompt was attempted at all. On a federated Run that list is the only thing the coordinator's machine keeps, so the evidence stays on the worker server where nobody looks. This records a proper entry, with a cause from a fixed vocabulary, on every path.

## What Changed

Rebased onto `upstream/main` after [#16904](https://github.com/stablyai/orca/pull/16904), which moved the worker-start code into `rpc/methods/orchestration/worker/` and gave `failWorkerStart` an options object. The change was re-implemented on the new shape rather than replayed.

New `src/main/runtime/rpc/methods/orchestration/dispatch-input-verdict.ts` owns the effect:

```ts
{ kind: 'dispatch_input', role: 'agent', id: terminalHandle,
  state: 'failed', cause, detail }
```

`cause` comes from a closed set of the runtime's submission codes — `agent_prompt_stalled`, `agent_prompt_blocked`, `terminal_handle_stale`, `terminal_not_writable`, `terminal_exited`, `terminal_gone`, `terminal_input_too_large`, `runtime_unavailable`, `request_aborted` — read off `Error.message` or `OrchestrationError.code`. Anything unrecognised, including the structured-session refusals that throw prose, collapses to `unknown` with the message kept on `detail`, so the set can grow without breaking a reader that branches on it.

Where the verdict is appended:

- `worker/deliver-worker-dispatch-preamble.ts` — the delivery helper [#16904](https://github.com/stablyai/orca/pull/16904) introduced. It now appends the verdict on both of its edges, which covers the PTY send and the structured-session turn with one implementation. `buildDispatchPreamble` stays outside the guarded block, so failing to *build* a preamble is not reported as an input attempt.
- `federation/federation.ts` — the remote attach submits directly, so it appends the same two effects around its own `sendTerminalAgentPrompt`.

Where it is persisted:

- `failWorkerStart` gained `options.effects`, written through the `transitionLifecycleWithDb` projection that [#16904](https://github.com/stablyai/orca/pull/16904) put in place of the raw `UPDATE`. `markWorkerStartUnknown` gained the same options object. `failWorkerStartWithReceipt` already returns `JSON.parse(worker.effects)`, so persisting is what makes the receipt carry the cause — no receipt shape changed.
- `failRemoteAttachment` gained `options.effects` and writes `effects = COALESCE(?, effects)`, mirroring `markRemoteAttachmentReady`.
- On a federated start the Run home passes `remote.effects` into `failWorkerStart` / `markWorkerStartUnknown`, and `federatedUnknownReceipt` returns the remote effects and residuals instead of hard-coded empty arrays.

## Why

Before this, `failWorkerStart` never touched the effects column, so a Dispatch that died delivering the prompt kept whatever effects array the previous stage had written — one with no `dispatch_input` entry at all.

**The local half is a consistency and typing fix, and I would rather be precise than oversell it.** `stage = 'dispatch_input'` and `last_error = 'agent_prompt_stalled'` already tell a reader that submission was attempted and stalled. What the effect adds locally is a closed-set cause instead of free-form text — `last_error` for the input-too-large case is an English sentence a consumer cannot switch on — plus the target terminal handle, the effect's position in the timeline, and one discrimination `stage` cannot make: `failedStage = 'dispatch_input'` is assigned before the preamble is built, so a build failure and a submission failure are the same stage. The effect exists only when a submission was actually attempted.

**The federated half is the real gap.** The Run home was handed the remote receipt and then dropped its effects on both failure branches, and `outcome_unknown` returned `effects: []`. The evidence existed only on the worker server — precisely the topology where a coordinator is least able to go and look. `orca orchestration worker-start` already prints `Effects: …` for a non-ready receipt, so the cause becomes visible without any CLI change.

## Linked Issue

Fixes #15958

Relates to [#14822](https://github.com/stablyai/orca/issues/14822) and [#14505](https://github.com/stablyai/orca/issues/14505), the submission failure this makes legible, and to [#15920](https://github.com/stablyai/orca/issues/15920), a dispatch failing at `dispatch_input` in the field.

## Visual Proof

`N/A` — no UI surface. The change is a persisted receipt field consumed by CLI and RPC callers.

## Testing

Run on Windows 11, Node 24.19.0 / pnpm 12, on the rebased branch (`18bc675`):

```
pnpm tc:node                       exit 0
pnpm tc:cli                        exit 0
check:code-quality:changed         0 findings across 13 changed files
                                   (ORCA_CODE_QUALITY_BASE=upstream/main)
vitest src/main/runtime/rpc/methods/orchestration
       src/main/runtime/orchestration
                                   185 files passed | 3 skipped
                                   1585 tests passed | 11 skipped
```

New suite `rpc/methods/orchestration/dispatch-input-verdict.test.ts` (9 tests) covers the local worker start, the federated attach on the worker server, and the Run home on both `failed` and `outcome_unknown` remote receipts, plus a negative control that a start failing at `agent_readiness` records no `dispatch_input` effect at all.

Also run: `src/cli/handlers/orchestration`, `orchestration-structured-worker-start-failure`, `orchestration-structured-worker-session`, `orchestration-structured-chat-lease` — 218 passed, with 4 failures in `orchestration-gate-cli`, `orchestration-timeout-cli` and `orchestration-worker-cli`. Those 4 are pre-existing Windows argv-quoting failures: the same 4 fail on a clean `upstream/main` checkout with this branch stashed, checked before touching them.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

Platforms: Windows 11 only, and through automated tests rather than a live run. The federated path is exercised by tests, not by a two-server setup.

## AI Disclosure

Written with Claude Opus 5 at high effort under my direction. The rebase onto the post-[#16904](https://github.com/stablyai/orca/pull/16904) layout was done by re-implementing the intent on the new signatures, not by replaying the old diff.

## Review

- **Cross-platform:** no path handling, no shell, no platform branch.
- **SSH / remote / federation:** the half this change is actually about. The worker server records the verdict on its own attachment row, and the Run home now keeps the effects it was handed instead of discarding them. Both failure branches and the unknown receipt are covered.
- **Wire compatibility:** `effects` is an existing published field on receipts that already cross the client↔host boundary, and nothing validates or re-encodes its entries. This adds two optional keys (`cause`, `detail`) inside one entry and a `state: 'failed'` value for an entry kind that previously only ever appeared as `accepted`. No new RPC param, no new stream opcode, so no capability negotiation is needed. An old client that does not know `failed` renders the entry as opaque JSON, which is what it already does for every effect.
- **Folder workspaces:** untouched; nothing here reads worktree structure.
- **Agent and integration compatibility:** no agent-specific behaviour. The structured-session path and the PTY path share one delivery helper, so both get the verdict.
- **Performance:** one extra JSON serialisation on a failure path that was already writing the row.
- **UI:** none.
- **Security:** `detail` carries runtime error text that `last_error` already carries on the same row. No new data crosses any boundary and no privilege boundary is involved.

Adjacent and deliberately left unfixed, flagged rather than absorbed: `residualResources` are still not persisted to the home row on a failed remote start. Same shape, different column.

## Agent skill upstream boundary

- [x] Not applicable.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] `N/A` with reason for visual proof
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] Typecheck, changed-file lint and the orchestration test suites pass locally; CI covers the rest

## Author

- X / Twitter: @EnricoPin
