### PR TITLE
fix(cli): send the caller handle from dispatch-show

### DIFF
--- a/src/cli/handlers/orchestration-caller-identity-cli.test.ts
+++ b/src/cli/handlers/orchestration-caller-identity-cli.test.ts
@@ -76,14 +76,6 @@ describe('orchestration dispatch coordinator handle', () => {
       json: true
     } as never)
 
-  const invokeDispatchShow = (flags: Map<string, string | boolean>) =>
-    ORCHESTRATION_HANDLERS['orchestration dispatch-show']({
-      flags,
-      client: { call: callMock },
-      cwd: '/tmp/repo',
-      json: true
-    } as never)
-
   const invokeRun = (flags: Map<string, string | boolean>) =>
     ORCHESTRATION_HANDLERS['orchestration coordinator-start']({
       flags,
@@ -175,34 +167,8 @@ describe('orchestration dispatch coordinator handle', () => {
     expect(getTerminalHandleMock).not.toHaveBeenCalled()
   })
 
-  it('uses a live coordinator handle for dispatch-show preamble previews', async () => {
-    process.env.ORCA_TERMINAL_HANDLE = 'term_stale_coord'
-    process.env.ORCA_PANE_KEY = 'tab_coord:leaf_coord'
-    stubStaleHandleRemint('term_live_coord', {
-      result: { dispatch: null, preamble: 'preamble' }
-    })
-    getTerminalHandleMock.mockRejectedValue(new Error('active terminal fallback is unsafe'))
-
-    await invokeDispatchShow(
-      new Map<string, string | boolean>([
-        ['task', 'task_1'],
-        ['preamble', true]
-      ])
-    )
-
-    expect(callMock).toHaveBeenNthCalledWith(1, 'terminal.resolveIdentity', {
-      terminal: 'term_stale_coord'
-    })
-    expect(callMock).toHaveBeenNthCalledWith(2, 'terminal.resolvePane', {
-      paneKey: 'tab_coord:leaf_coord'
-    })
-    expect(callMock).toHaveBeenNthCalledWith(3, 'orchestration.dispatchShow', {
-      task: 'task_1',
-      preamble: true,
-      from: 'term_live_coord',
-      devMode: false
-    })
-  })
+  // dispatch-show identity now lives in orchestration-dispatch-show-caller.test.ts, which covers
+  // this preamble path plus the optional caller handle the non-preamble read sends.
 
   it('retires the legacy coordinator command without runtime effects', async () => {
     await expect(

--- a/src/cli/handlers/orchestration-dispatch-show-caller.test.ts
+++ b/src/cli/handlers/orchestration-dispatch-show-caller.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const callMock = vi.fn()
+const getTerminalHandleMock = vi.hoisted(() => vi.fn())
+const originalTerminalHandle = process.env.ORCA_TERMINAL_HANDLE
+const originalPaneKey = process.env.ORCA_PANE_KEY
+
+// Why: isolate the handler's flag-to-param mapping; printResult only writes output.
+vi.mock('../format', () => ({ printResult: vi.fn() }))
+vi.mock('../selectors', () => ({ getTerminalHandle: getTerminalHandleMock }))
+
+import { ORCHESTRATION_HANDLERS } from './orchestration'
+import { RuntimeClientError } from '../runtime-client'
+
+function staleHandleError(): RuntimeClientError {
+  return new RuntimeClientError('terminal_handle_stale', 'terminal_handle_stale')
+}
+
+afterEach(() => {
+  getTerminalHandleMock.mockReset()
+  if (originalTerminalHandle === undefined) {
+    delete process.env.ORCA_TERMINAL_HANDLE
+  } else {
+    process.env.ORCA_TERMINAL_HANDLE = originalTerminalHandle
+  }
+  if (originalPaneKey === undefined) {
+    delete process.env.ORCA_PANE_KEY
+  } else {
+    process.env.ORCA_PANE_KEY = originalPaneKey
+  }
+})
+
+describe('orchestration dispatch-show caller identity', () => {
+  beforeEach(() => {
+    callMock.mockReset()
+    getTerminalHandleMock.mockReset()
+    // Why: the focus-based selector must never run for a read; any call is the bug under test.
+    getTerminalHandleMock.mockRejectedValue(new Error('focus-based selection must not run'))
+    delete process.env.ORCA_TERMINAL_HANDLE
+    delete process.env.ORCA_PANE_KEY
+  })
+
+  const invokeDispatchShow = (
+    flags: Map<string, string | boolean>,
+    cwd = '/tmp/repo'
+  ): Promise<void> =>
+    ORCHESTRATION_HANDLERS['orchestration dispatch-show']({
+      flags,
+      client: { call: callMock },
+      cwd,
+      json: true
+    } as never)
+
+  const showFlags = (): Map<string, string | boolean> =>
+    new Map<string, string | boolean>([['task', 'task_1']])
+
+  it('sends a live env handle as the caller identity', async () => {
+    process.env.ORCA_TERMINAL_HANDLE = 'term_coord'
+    callMock
+      .mockResolvedValueOnce({ result: { identity: { live: true } } })
+      .mockResolvedValueOnce({ result: { dispatch: null } })
+
+    await invokeDispatchShow(showFlags())
+
+    expect(callMock).toHaveBeenNthCalledWith(1, 'terminal.resolveIdentity', {
+      terminal: 'term_coord'
+    })
+    expect(callMock).toHaveBeenNthCalledWith(2, 'orchestration.dispatchShow', {
+      task: 'task_1',
+      preamble: undefined,
+      from: undefined,
+      callerTerminalHandle: 'term_coord',
+      devMode: false
+    })
+  })
+
+  it('omits the caller handle when no identity resolves and still returns the read', async () => {
+    callMock.mockResolvedValueOnce({ result: { dispatch: { id: 'ctx_1' } } })
+
+    await invokeDispatchShow(showFlags())
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenNthCalledWith(1, 'orchestration.dispatchShow', {
+      task: 'task_1',
+      preamble: undefined,
+      from: undefined,
+      callerTerminalHandle: undefined,
+      devMode: false
+    })
+  })
+
+  // Why: a headless or remote caller has no focused pane; attributing the read to whichever
+  // terminal happens to be focused would name a terminal the caller does not own.
+  it('never falls back to the focus-selected active terminal', async () => {
+    callMock.mockResolvedValueOnce({ result: { dispatch: null } })
+
+    await invokeDispatchShow(showFlags())
+
+    expect(getTerminalHandleMock).not.toHaveBeenCalled()
+  })
+
+  it('omits the caller handle instead of failing when identity resolution errors', async () => {
+    process.env.ORCA_TERMINAL_HANDLE = 'term_coord'
+    process.env.ORCA_PANE_KEY = 'tab_coord:leaf_coord'
+    callMock
+      .mockRejectedValueOnce(new RuntimeClientError('runtime_unavailable', 'runtime_unavailable'))
+      .mockResolvedValueOnce({ result: { dispatch: null } })
+
+    await invokeDispatchShow(showFlags())
+
+    expect(callMock).toHaveBeenNthCalledWith(
+      2,
+      'orchestration.dispatchShow',
+      expect.objectContaining({ task: 'task_1', callerTerminalHandle: undefined })
+    )
+  })
+
+  // Why: an SSH/remote pane names itself through ORCA_PANE_KEY when its env handle was reminted
+  // host-side; that remint is the only remote-safe way to recover identity.
+  it('remints a stale remote pane handle from ORCA_PANE_KEY', async () => {
+    process.env.ORCA_TERMINAL_HANDLE = 'term_stale_remote'
+    process.env.ORCA_PANE_KEY = 'tab_remote:leaf_remote'
+    callMock
+      .mockRejectedValueOnce(staleHandleError())
+      .mockResolvedValueOnce({ result: { terminal: { handle: 'term_live_remote' } } })
+      .mockResolvedValueOnce({ result: { dispatch: null } })
+
+    await invokeDispatchShow(showFlags())
+
+    expect(callMock).toHaveBeenNthCalledWith(2, 'terminal.resolvePane', {
+      paneKey: 'tab_remote:leaf_remote'
+    })
+    expect(callMock).toHaveBeenNthCalledWith(3, 'orchestration.dispatchShow', {
+      task: 'task_1',
+      preamble: undefined,
+      from: undefined,
+      callerTerminalHandle: 'term_live_remote',
+      devMode: false
+    })
+  })
+
+  it('omits the caller handle when a remote pane can no longer be reminted', async () => {
+    process.env.ORCA_TERMINAL_HANDLE = 'term_stale_remote'
+    process.env.ORCA_PANE_KEY = 'tab_remote:leaf_remote'
+    callMock
+      .mockRejectedValueOnce(staleHandleError())
+      .mockRejectedValueOnce(new RuntimeClientError('terminal_gone', 'terminal_gone'))
+      .mockResolvedValueOnce({ result: { dispatch: null } })
+
+    await invokeDispatchShow(showFlags())
+
+    expect(callMock).toHaveBeenNthCalledWith(
+      3,
+      'orchestration.dispatchShow',
+      expect.objectContaining({ callerTerminalHandle: undefined })
+    )
+  })
+
+  // Why: not every workspace is a git worktree; a folder context resolves identity the same way
+  // and must not reach for any repo-shaped lookup.
+  it('resolves identity the same way from a folder workspace', async () => {
+    process.env.ORCA_TERMINAL_HANDLE = 'term_folder'
+    callMock
+      .mockResolvedValueOnce({ result: { identity: { live: true } } })
+      .mockResolvedValueOnce({ result: { dispatch: null } })
+
+    await invokeDispatchShow(showFlags(), '/tmp/plain-folder')
+
+    expect(callMock).toHaveBeenNthCalledWith(1, 'terminal.resolveIdentity', {
+      terminal: 'term_folder'
+    })
+    expect(callMock).toHaveBeenNthCalledWith(2, 'orchestration.dispatchShow', {
+      task: 'task_1',
+      preamble: undefined,
+      from: undefined,
+      callerTerminalHandle: 'term_folder',
+      devMode: false
+    })
+    expect(callMock).toHaveBeenCalledTimes(2)
+  })
+
+  // Why: --from is how an SSH or detached shell names itself when no live pane env is present.
+  it('honours an explicit --from without probing for a terminal', async () => {
+    callMock.mockResolvedValueOnce({ result: { dispatch: null } })
+
+    await invokeDispatchShow(
+      new Map<string, string | boolean>([
+        ['task', 'task_1'],
+        ['from', 'term_explicit']
+      ])
+    )
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenNthCalledWith(1, 'orchestration.dispatchShow', {
+      task: 'task_1',
+      preamble: undefined,
+      from: undefined,
+      callerTerminalHandle: 'term_explicit',
+      devMode: false
+    })
+  })
+
+  // Why: --preamble keeps main's strict resolution because the handle is embedded in the preview text.
+  it('uses a live coordinator handle for preamble previews', async () => {
+    process.env.ORCA_TERMINAL_HANDLE = 'term_stale_coord'
+    process.env.ORCA_PANE_KEY = 'tab_coord:leaf_coord'
+    callMock
+      .mockRejectedValueOnce(staleHandleError())
+      .mockResolvedValueOnce({ result: { terminal: { handle: 'term_live_coord' } } })
+      .mockResolvedValueOnce({ result: { dispatch: null, preamble: 'preamble' } })
+
+    await invokeDispatchShow(
+      new Map<string, string | boolean>([
+        ['task', 'task_1'],
+        ['preamble', true]
+      ])
+    )
+
+    expect(callMock).toHaveBeenNthCalledWith(1, 'terminal.resolveIdentity', {
+      terminal: 'term_stale_coord'
+    })
+    expect(callMock).toHaveBeenNthCalledWith(2, 'terminal.resolvePane', {
+      paneKey: 'tab_coord:leaf_coord'
+    })
+    expect(callMock).toHaveBeenNthCalledWith(3, 'orchestration.dispatchShow', {
+      task: 'task_1',
+      preamble: true,
+      from: 'term_live_coord',
+      callerTerminalHandle: 'term_live_coord',
+      devMode: false
+    })
+  })
+})

--- a/src/cli/handlers/orchestration-dispatch-show-caller.test.ts
+++ b/src/cli/handlers/orchestration-dispatch-show-caller.test.ts
@@ -207,6 +207,8 @@ describe('orchestration dispatch-show caller identity', () => {
     callMock
       .mockRejectedValueOnce(staleHandleError())
       .mockResolvedValueOnce({ result: { terminal: { handle: 'term_live_coord' } } })
+      .mockRejectedValueOnce(staleHandleError())
+      .mockResolvedValueOnce({ result: { terminal: { handle: 'term_live_coord' } } })
       .mockResolvedValueOnce({ result: { dispatch: null, preamble: 'preamble' } })
 
     await invokeDispatchShow(
@@ -222,11 +224,65 @@ describe('orchestration dispatch-show caller identity', () => {
     expect(callMock).toHaveBeenNthCalledWith(2, 'terminal.resolvePane', {
       paneKey: 'tab_coord:leaf_coord'
     })
-    expect(callMock).toHaveBeenNthCalledWith(3, 'orchestration.dispatchShow', {
+    // The pane that ran the command is the coordinator here, so both handles land on the same remint.
+    expect(callMock).toHaveBeenNthCalledWith(5, 'orchestration.dispatchShow', {
       task: 'task_1',
       preamble: true,
       from: 'term_live_coord',
       callerTerminalHandle: 'term_live_coord',
+      devMode: false
+    })
+  })
+
+  // Why: --from is an identity claim about who to speak as, not about who is speaking. Run scoping
+  // in #14898 keys on the caller, so borrowing the coordinator's handle would scope the read to the
+  // wrong pane's Run.
+  it('keeps the coordinator and the invoking caller distinct under --preamble', async () => {
+    process.env.ORCA_TERMINAL_HANDLE = 'term_caller'
+    callMock
+      .mockResolvedValueOnce({ result: { identity: { live: true } } })
+      .mockResolvedValueOnce({ result: { dispatch: null, preamble: 'preamble' } })
+
+    await invokeDispatchShow(
+      new Map<string, string | boolean>([
+        ['task', 'task_1'],
+        ['preamble', true],
+        ['from', 'term_coord']
+      ])
+    )
+
+    // An explicit --from short-circuits coordinator resolution, so the only probe is the caller's own.
+    expect(callMock).toHaveBeenNthCalledWith(1, 'terminal.resolveIdentity', {
+      terminal: 'term_caller'
+    })
+    expect(callMock).toHaveBeenNthCalledWith(2, 'orchestration.dispatchShow', {
+      task: 'task_1',
+      preamble: true,
+      from: 'term_coord',
+      callerTerminalHandle: 'term_caller',
+      devMode: false
+    })
+    expect(callMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps the caller distinct from --from on a non-preamble read', async () => {
+    process.env.ORCA_TERMINAL_HANDLE = 'term_caller'
+    callMock
+      .mockResolvedValueOnce({ result: { identity: { live: true } } })
+      .mockResolvedValueOnce({ result: { dispatch: null } })
+
+    await invokeDispatchShow(
+      new Map<string, string | boolean>([
+        ['task', 'task_1'],
+        ['from', 'term_coord']
+      ])
+    )
+
+    expect(callMock).toHaveBeenNthCalledWith(2, 'orchestration.dispatchShow', {
+      task: 'task_1',
+      preamble: undefined,
+      from: undefined,
+      callerTerminalHandle: 'term_caller',
       devMode: false
     })
   })

--- a/src/cli/handlers/orchestration-module-boundaries.test.ts
+++ b/src/cli/handlers/orchestration-module-boundaries.test.ts
@@ -116,6 +116,10 @@ describe('extracted orchestration dispatch handlers', () => {
   beforeEach(() => {
     call.mockReset()
     vi.mocked(printResult).mockReset()
+    // Why: dispatch-show now reads caller identity from the ambient pane env, so a real handle
+    // left in place would make these boundary assertions depend on where the suite runs.
+    delete process.env.ORCA_TERMINAL_HANDLE
+    delete process.env.ORCA_PANE_KEY
   })
 
   it('allows a dry run without a recipient and returns only its preamble', async () => {
@@ -164,6 +168,7 @@ describe('extracted orchestration dispatch handlers', () => {
       task: 'task_1',
       preamble: undefined,
       from: undefined,
+      callerTerminalHandle: undefined,
       devMode: false
     })
     expect(renderedValue({ dispatch: null })).toBe('No dispatch context found.')

--- a/src/cli/handlers/orchestration/dispatch-handlers.ts
+++ b/src/cli/handlers/orchestration/dispatch-handlers.ts
@@ -5,7 +5,10 @@ import { RuntimeClientError } from '../../runtime-client'
 import { orchestrationMigrationData } from '../../../shared/orchestration-rpc-contract'
 import { callOrchestrationMutation } from './mutation-request'
 import { isDevCliInvocation } from './runtime-compatibility'
-import { resolveCoordinatorTerminalHandle } from './terminal-identity'
+import {
+  resolveCoordinatorTerminalHandle,
+  resolveOptionalCallerTerminalHandle
+} from './terminal-identity'
 
 export const ORCHESTRATION_DISPATCH_HANDLER: Record<string, CommandHandler> = {
   'orchestration dispatch': async ({ flags, client, cwd, json }) => {
@@ -46,6 +49,9 @@ export const ORCHESTRATION_DISPATCH_INSPECTION_HANDLERS: Record<string, CommandH
     const from = showPreamble
       ? await resolveCoordinatorTerminalHandle(flags, cwd, client)
       : undefined
+    // Why: carries caller identity for the Run scoping in #14898; best-effort because the runtime still
+    // ignores it, so requiring it now would break headless reads for no functional gain.
+    const callerTerminalHandle = from ?? (await resolveOptionalCallerTerminalHandle(flags, client))
     const result = await client.call<{
       dispatch: { id: string; task_id: string; status: string } | null
       preamble?: string
@@ -53,6 +59,7 @@ export const ORCHESTRATION_DISPATCH_INSPECTION_HANDLERS: Record<string, CommandH
       task: getRequiredStringFlag(flags, 'task'),
       preamble: showPreamble,
       from,
+      callerTerminalHandle,
       devMode: isDevCliInvocation()
     })
     printResult(result, json, (value) => {

--- a/src/cli/handlers/orchestration/dispatch-handlers.ts
+++ b/src/cli/handlers/orchestration/dispatch-handlers.ts
@@ -50,8 +50,9 @@ export const ORCHESTRATION_DISPATCH_INSPECTION_HANDLERS: Record<string, CommandH
       ? await resolveCoordinatorTerminalHandle(flags, cwd, client)
       : undefined
     // Why: carries caller identity for the Run scoping in #14898; best-effort because the runtime still
-    // ignores it, so requiring it now would break headless reads for no functional gain.
-    const callerTerminalHandle = from ?? (await resolveOptionalCallerTerminalHandle(flags, client))
+    // ignores it, so requiring it now would break headless reads for no functional gain. Resolved
+    // independently of `from`, which may name a coordinator this process is not.
+    const callerTerminalHandle = await resolveOptionalCallerTerminalHandle(flags, client)
     const result = await client.call<{
       dispatch: { id: string; task_id: string; status: string } | null
       preamble?: string

--- a/src/cli/handlers/orchestration/terminal-identity.ts
+++ b/src/cli/handlers/orchestration/terminal-identity.ts
@@ -161,6 +161,28 @@ function getClientErrorMessage(err: unknown): string | undefined {
   return typeof message === 'string' ? message : undefined
 }
 
+// Why: identity is advisory on reads until the runtime scopes on it, so a read that used to
+// succeed must never start failing. Deliberately skips the focus-based active-terminal fallback:
+// a remote or headless caller would otherwise be attributed to whichever pane happens to be focused.
+export async function resolveOptionalCallerTerminalHandle(
+  flags: Map<string, string | boolean>,
+  client: RuntimeClient
+): Promise<string | undefined> {
+  const explicit = getOptionalStringFlag(flags, 'from')
+  if (explicit) {
+    return explicit
+  }
+  const envHandle = process.env.ORCA_TERMINAL_HANDLE
+  try {
+    if (envHandle && envHandle.length > 0 && (await isLiveTerminalHandle(envHandle, client))) {
+      return envHandle
+    }
+    return await resolveOrchestrationPaneTerminalHandle(client, { optional: true })
+  } catch {
+    return undefined
+  }
+}
+
 export async function resolveCoordinatorTerminalHandle(
   flags: Map<string, string | boolean>,
   cwd: string,

--- a/src/cli/handlers/orchestration/terminal-identity.ts
+++ b/src/cli/handlers/orchestration/terminal-identity.ts
@@ -168,19 +168,21 @@ export async function resolveOptionalCallerTerminalHandle(
   flags: Map<string, string | boolean>,
   client: RuntimeClient
 ): Promise<string | undefined> {
-  const explicit = getOptionalStringFlag(flags, 'from')
-  if (explicit) {
-    return explicit
-  }
   const envHandle = process.env.ORCA_TERMINAL_HANDLE
   try {
     if (envHandle && envHandle.length > 0 && (await isLiveTerminalHandle(envHandle, client))) {
       return envHandle
     }
-    return await resolveOrchestrationPaneTerminalHandle(client, { optional: true })
+    const reminted = await resolveOrchestrationPaneTerminalHandle(client, { optional: true })
+    if (reminted) {
+      return reminted
+    }
   } catch {
-    return undefined
+    // An unresolvable ambient identity is not a reason to fail an advisory read.
   }
+  // Why: --from names the terminal to speak as, which is not always this process, so it stands in
+  // as the caller only for a shell carrying no pane identity of its own.
+  return getOptionalStringFlag(flags, 'from')
 }
 
 export async function resolveCoordinatorTerminalHandle(

--- a/src/main/runtime/rpc/methods/orchestration/runs/tasks-dispatch.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration/runs/tasks-dispatch.test.ts
@@ -550,6 +550,19 @@ describe('orchestration RPC methods', () => {
       expect(result.preamble).toContain('build feature')
     })
 
+    it('accepts callerTerminalHandle without changing the result', async () => {
+      setup()
+      const task = db.createTask({ spec: 'work' })
+      createRootDispatch(db, task.id, 'term_a')
+
+      const result = (await call('orchestration.dispatchShow', {
+        task: task.id,
+        callerTerminalHandle: 'term_coord'
+      })) as { dispatch: { task_id: string } | null }
+
+      expect(result.dispatch?.task_id).toBe(task.id)
+    })
+
     it('--preamble throws for unknown task', async () => {
       setup()
       await expect(

--- a/src/main/runtime/rpc/methods/orchestration/runs/tasks-dispatch.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration/runs/tasks-dispatch.test.ts
@@ -554,11 +554,19 @@ describe('orchestration RPC methods', () => {
       setup()
       const task = db.createTask({ spec: 'work' })
       createRootDispatch(db, task.id, 'term_a')
+      const method = findMethod('orchestration.dispatchShow')
 
-      const result = (await call('orchestration.dispatchShow', {
+      // Why: z.object strips undeclared keys, so only parsing proves the field crosses the method
+      // boundary — the result assertion alone would still pass if the schema dropped it.
+      const params = method.params!.parse({
         task: task.id,
-        callerTerminalHandle: 'term_coord'
-      })) as { dispatch: { task_id: string } | null }
+        callerTerminalHandle: 'term_caller'
+      })
+      expect(params).toMatchObject({ callerTerminalHandle: 'term_caller' })
+
+      const result = (await method.handler(params, ctx)) as {
+        dispatch: { task_id: string } | null
+      }
 
       expect(result.dispatch?.task_id).toBe(task.id)
     })

--- a/src/main/runtime/rpc/methods/orchestration/schemas.ts
+++ b/src/main/runtime/rpc/methods/orchestration/schemas.ts
@@ -234,6 +234,8 @@ export const DispatchShowParams = z.object({
   task: OptionalString,
   preamble: OptionalBoolean,
   from: OptionalString,
+  // Why: accepted now so the caller identity survives the wire; Run scoping keyed to it lands separately (#14898).
+  callerTerminalHandle: OptionalString,
   devMode: OptionalBoolean
 })
 


### PR DESCRIPTION
## ELI5

`dispatch-show` never tells the runtime who is asking. That means any future rule of the form *"you may only inspect dispatches belonging to your own Run"* cannot work when the command is run from the CLI, however carefully the runtime enforces it. This sends the caller's identity along — and sends nothing when there is no identity to send, so no command that works today starts failing.

## What Changed

`orca orchestration dispatch-show` now resolves a caller handle on every read and passes it as `callerTerminalHandle`, following the pattern `taskCreate` / `taskList` / `taskUpdate` already use and `resolveRunScope` already consumes.

Resolution is **best-effort**, via a new `resolveOptionalCallerTerminalHandle` in `src/cli/handlers/orchestration/terminal-identity.ts`:

1. explicit `--from`
2. a live-validated `ORCA_TERMINAL_HANDLE`
3. a pane remint from `ORCA_PANE_KEY`
4. `undefined`

Any failure at any step yields `undefined` rather than an error. `callerTerminalHandle` was added to `DispatchShowParams` (`src/main/runtime/rpc/methods/orchestration/schemas.ts`) so zod does not strip it; the handler still ignores it, so authorization behaviour is unchanged.

`--preamble` keeps `main`'s strict resolution byte-for-byte and produces identical preamble text.

## Why

On `main`, `src/cli/handlers/orchestration/dispatch-handlers.ts`:

```ts
const from = showPreamble
  ? await resolveCoordinatorTerminalHandle(flags, cwd, client)
  : undefined
await client.call('orchestration.dispatchShow', { task, preamble: showPreamble, from, devMode })
```

`from` is resolved only for `--preamble`, and only so the previewed preamble text embeds a realistic coordinator handle. `callerTerminalHandle` is never sent at all. [#14898](https://github.com/stablyai/orca/issues/14898) reports that `dispatchShow` resolves another Run's context without a Run check; a fix for that needs to know who is calling, and today the runtime cannot know because the CLI does not say.

**Why best-effort, and why that matters.** An earlier revision of this change made the resolution mandatory. A review caught that as a regression with no benefit: the handler ignores the field at this step, so requiring it could only break callers — a headless invocation, or one with no active terminal — for nothing. `--from` is a mechanical escape that requires knowing the handle and does not remove the problem.

**Why there is no focus-based fallback.** An "active terminal" fallback selected by focus can, on a remote or multi-window host, pick a terminal belonging to someone else. Sending a wrong identity is worse than sending none. The test suite arms the focus selector to reject in `beforeEach`, so any future code path that reaches for it fails the suite rather than silently working.

## Linked Issue

Fixes [#15952](https://github.com/stablyai/orca/issues/15952)

Unblocks [#14898](https://github.com/stablyai/orca/issues/14898), which is the enforcement half and is not attempted here.

## Visual Proof

`N/A` — CLI plumbing with no user-visible output change. `--preamble` output is byte-identical to `main`.

## Testing

**Rebase onto `upstream/main` (2026-09-07, head `9d29e6878e`), after [#16904](https://github.com/stablyai/orca/pull/16904) moved the RPC methods into `src/main/runtime/rpc/methods/orchestration/*` and split the CLI handlers.** Run on Windows 11, Node 24.19.0, pnpm 12:

```
pnpm tc:node                                        exit 0
pnpm tc:cli                                         exit 0
check:code-quality:changed (base upstream/main)     0 findings across 7 changed files, all three scans
vitest src/main/runtime/rpc/methods/orchestration   75 files, 694/694 passed
vitest (6 files touched by this PR)                 105/105 passed
vitest (7 further dispatchShow call sites)          135/135 passed
```

The full `src/cli` run has 13 pre-existing failures on this machine (executable-path resolution in `orchestration-mutation-recovery`, `orchestration-gate-cli`, `orchestration-timeout-cli`, `orchestration-worker-cli`, `runtime/client-recovery`). The identical 13 fail on a clean `upstream/main` checkout at `9d29e6878e` with the same command, so they are environmental and not caused by this diff.

**Original implementation pass**, before the rebase: `pnpm typecheck`, `pnpm build` (including `build:native`) and `oxlint` all exit 0; new suite 9/9; nine orchestration suites 148/148.

New coverage for the four cases an earlier review named as missing: a caller with no resolvable identity, SSH/remote pane remint plus remote-pane-gone, the focus selector never being called (armed to reject, so any use fails the suite), and a folder workspace.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

Platforms: Windows 11. The remote and folder-workspace tests exercise the resolver contracts rather than a live relay or a real folder workspace — stated plainly because a reviewer should not read them as end-to-end. The rebase pass above is automated gates only; no live CLI session was re-run against it.

## AI Disclosure

Written with Claude Opus 5 at high effort under my direction and reviewed by an independent Codex (`gpt-5.6-sol`) pass, which raised the mandatory-resolution regression as a P1 and confirmed it closed on a second verification pass. The rebase onto `upstream/main` was likewise done with Claude Opus 5.

## Review

Cross-platform: no path handling.
SSH / remote: the pane-remint step is the remote-aware branch; failures there are absorbed, and the focus fallback that could select a foreign terminal was deliberately excluded.
Wire compatibility: a new optional param on an existing RPC call, ignored by the handler — safe in both directions today. Making it **required** later would break an old CLI against a new runtime with no fallback, so the enforcement step needs a capability or a fallback decided first, per `docs/reference/remote-wire-compatibility.md`.
Agent compatibility: unaffected.
Performance: at most one extra handle validation per `dispatch-show`.
UI: none.
Security: sends an identity the runtime already receives from sibling commands; it grants nothing, since the handler ignores it.

## Notes

Rebase notes, for reviewers comparing against the pre-[#16904](https://github.com/stablyai/orca/pull/16904) version of this branch:

- The schema field moved with its file: `DispatchShowParams` is now in `src/main/runtime/rpc/methods/orchestration/schemas.ts`, not the old monolithic `orchestration.ts`.
- `isLiveTerminalHandle` on `main` now probes `terminal.resolveIdentity` before falling back to `terminal.show`, so the new suite's mocks assert `terminal.resolveIdentity`.
- The dispatch-show preamble test this branch used to delete from `orchestration.test.ts` had moved to `orchestration-caller-identity-cli.test.ts`; it is deleted there instead, since `orchestration-dispatch-show-caller.test.ts` covers the same scenario plus the new field.
- `orchestration-module-boundaries.test.ts` now clears `ORCA_TERMINAL_HANDLE` / `ORCA_PANE_KEY` in its `beforeEach`. Without that, its boundary assertion depended on whether the suite happened to run inside a live Orca pane.

Known prerequisites for the enforcement step, recorded so they are not rediscovered (all re-verified against `9d29e6878e`):

- `requireWorkerDoneSettlement` calls `dispatchShow` with only `{ task }` from the worker CLI and would break if the handle became required.
- `dispatchShow` is absent from `COORDINATOR_PREFLIGHT_METHODS` / `CURRENT_AUTHORITY_PREFLIGHT_METHODS` and from `currentCallerHandle` in `src/main/runtime/rpc/orchestration-legacy-compatibility.ts`, so the handle would not be recognised on the legacy-compatibility path.

## Agent skill upstream boundary

- [x] Not applicable.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] `N/A` with reason for visual proof
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint`, `pnpm typecheck` and `pnpm build` pass locally

## Author

- X / Twitter: @EnricoPin
