### PR TITLE
Add Artifacts and Skills pages to navigation history

### DIFF
--- a/src/renderer/src/lib/titlebar-worktree-history-controls.test.ts
+++ b/src/renderer/src/lib/titlebar-worktree-history-controls.test.ts
@@ -6,6 +6,8 @@ describe('shouldShowWorktreeHistoryControls', () => {
     expect(shouldShowWorktreeHistoryControls('terminal')).toBe(true)
     expect(shouldShowWorktreeHistoryControls('tasks')).toBe(true)
     expect(shouldShowWorktreeHistoryControls('automations')).toBe(true)
+    expect(shouldShowWorktreeHistoryControls('artifacts')).toBe(true)
+    expect(shouldShowWorktreeHistoryControls('skills')).toBe(true)
   })
 
   it('hides controls on full-page views outside the history stack', () => {

--- a/src/renderer/src/lib/titlebar-worktree-history-controls.ts
+++ b/src/renderer/src/lib/titlebar-worktree-history-controls.ts
@@ -1,5 +1,11 @@
 import type { UISlice } from '@/store/slices/ui'
 
 export function shouldShowWorktreeHistoryControls(activeView: UISlice['activeView']): boolean {
-  return activeView === 'terminal' || activeView === 'tasks' || activeView === 'automations'
+  return (
+    activeView === 'terminal' ||
+    activeView === 'tasks' ||
+    activeView === 'automations' ||
+    activeView === 'artifacts' ||
+    activeView === 'skills'
+  )
 }

--- a/src/renderer/src/lib/worktree-nav-view-history-replay.ts
+++ b/src/renderer/src/lib/worktree-nav-view-history-replay.ts
@@ -3,7 +3,7 @@ import type { WorktreeNavHistoryViewEntry } from '@/store/slices/worktree-nav-hi
 
 // Why: page entries replay via setActiveView (not open*Page) so back/forward doesn't mutate previousViewBefore* or duplicate history (see navigateToIndex).
 export function applyWorktreeNavViewEntry(entry: WorktreeNavHistoryViewEntry): void {
-  if (entry === 'automations') {
+  if (entry === 'automations' || entry === 'artifacts' || entry === 'skills') {
     useAppStore.getState().setActiveView(entry)
     return
   }

--- a/src/renderer/src/store/slices/ui-page-navigation.test.ts
+++ b/src/renderer/src/store/slices/ui-page-navigation.test.ts
@@ -663,6 +663,57 @@ describe('createUISlice space navigation', () => {
     expect(store.getState().activeView).toBe('tasks')
   })
 
+  it('records and rewinds Artifacts visits on close', () => {
+    const store = createUIStore()
+    store.setState({ worktreesByRepo: { 'repo-1': [makeWorktree('a')] } })
+
+    store.getState().recordWorktreeVisit('a')
+    store.getState().openArtifactsPage()
+    expect(store.getState().worktreeNavHistory).toEqual(['a', 'artifacts'])
+    expect(store.getState().worktreeNavHistoryIndex).toBe(1)
+
+    store.getState().closeArtifactsPage()
+    expect(store.getState().activeView).toBe('terminal')
+    expect(store.getState().worktreeNavHistoryIndex).toBe(0)
+  })
+
+  it('records and rewinds Skills visits on close', () => {
+    const store = createUIStore()
+    store.setState({ worktreesByRepo: { 'repo-1': [makeWorktree('a')] } })
+
+    store.getState().recordWorktreeVisit('a')
+    store.getState().openSkillsPage()
+    expect(store.getState().worktreeNavHistory).toEqual(['a', 'skills'])
+    expect(store.getState().worktreeNavHistoryIndex).toBe(1)
+
+    store.getState().closeSkillsPage()
+    expect(store.getState().activeView).toBe('terminal')
+    expect(store.getState().worktreeNavHistoryIndex).toBe(0)
+  })
+
+  it('records Artifacts and Skills as separate back/forward entries', () => {
+    const store = createUIStore()
+    store.setState({ worktreesByRepo: { 'repo-1': [makeWorktree('a')] } })
+
+    store.getState().recordWorktreeVisit('a')
+    store.getState().openArtifactsPage()
+    store.getState().openSkillsPage()
+    store.getState().openSkillsPage()
+
+    expect(store.getState().worktreeNavHistory).toEqual(['a', 'artifacts', 'skills'])
+    expect(store.getState().worktreeNavHistoryIndex).toBe(2)
+  })
+
+  it('records a Skills visit when opening a shared skill link', () => {
+    const store = createUIStore()
+
+    store.getState().openSkillShare('share-1')
+    store.getState().openSkillsSharedLinks()
+
+    expect(store.getState().worktreeNavHistory).toEqual(['skills'])
+    expect(store.getState().worktreeNavHistoryIndex).toBe(0)
+  })
+
   it('opens and restores Artifacts when its sidebar shortcut is hidden', () => {
     const store = createUIStore()
     store.setState({ settings: { ...getDefaultSettings('/tmp'), showArtifactsButton: false } })

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -5,7 +5,7 @@ import { normalizeRightSidebarRoute } from '../right-sidebar-route'
 import { settleEvictedModalData } from './modal-slot-dismissal'
 import {
   findPrevLiveNonTaskStackHistoryIndex,
-  findPrevLiveWorktreeHistoryIndex
+  rewindHistoryIndexPastView
 } from './worktree-nav-history'
 import type { GitHubWorkItem } from '../../../../shared/github/work-item-types'
 import type { JiraIssue } from '../../../../shared/jira-types'
@@ -1483,20 +1483,10 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
     }))
   },
   closeAutomationsPage: () =>
-    set((state) => {
-      const currentEntry = state.worktreeNavHistory[state.worktreeNavHistoryIndex]
-      let nextHistoryIndex = state.worktreeNavHistoryIndex
-      if (currentEntry === 'automations') {
-        const prev = findPrevLiveWorktreeHistoryIndex(state)
-        if (prev !== null) {
-          nextHistoryIndex = prev
-        }
-      }
-      return {
-        activeView: state.previousViewBeforeAutomations,
-        worktreeNavHistoryIndex: nextHistoryIndex
-      }
-    }),
+    set((state) => ({
+      activeView: state.previousViewBeforeAutomations,
+      worktreeNavHistoryIndex: rewindHistoryIndexPastView(state, 'automations')
+    })),
   openSpacePage: () => {
     get().recordFeatureInteraction?.('workspace-cleanup')
     set((state) => ({
@@ -1509,41 +1499,51 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
     set((state) => ({
       activeView: state.previousViewBeforeSpace
     })),
-  openSkillsPage: () =>
+  openSkillsPage: () => {
+    get().recordViewVisit('skills')
     set((state) => ({
       activeView: 'skills',
       previousViewBeforeSkills:
         state.activeView === 'skills' ? state.previousViewBeforeSkills : state.activeView
-    })),
+    }))
+  },
   closeSkillsPage: () =>
     set((state) => ({
-      activeView: state.previousViewBeforeSkills
+      activeView: state.previousViewBeforeSkills,
+      worktreeNavHistoryIndex: rewindHistoryIndexPastView(state, 'skills')
     })),
-  openSkillShare: (shareId) =>
+  openSkillShare: (shareId) => {
+    get().recordViewVisit('skills')
     set((state) => ({
       activeView: 'skills',
       previousViewBeforeSkills:
         state.activeView === 'skills' ? state.previousViewBeforeSkills : state.activeView,
       pendingSkillShareId: shareId
-    })),
+    }))
+  },
   clearPendingSkillShare: () => set({ pendingSkillShareId: null }),
-  openSkillsSharedLinks: () =>
+  openSkillsSharedLinks: () => {
+    get().recordViewVisit('skills')
     set((state) => ({
       activeView: 'skills',
       previousViewBeforeSkills:
         state.activeView === 'skills' ? state.previousViewBeforeSkills : state.activeView,
       pendingSkillsSharedView: true
-    })),
+    }))
+  },
   clearPendingSkillsSharedView: () => set({ pendingSkillsSharedView: false }),
-  openArtifactsPage: () =>
+  openArtifactsPage: () => {
+    get().recordViewVisit('artifacts')
     set((state) => ({
       activeView: 'artifacts',
       previousViewBeforeArtifacts:
         state.activeView === 'artifacts' ? state.previousViewBeforeArtifacts : state.activeView
-    })),
+    }))
+  },
   closeArtifactsPage: () =>
     set((state) => ({
-      activeView: state.previousViewBeforeArtifacts
+      activeView: state.previousViewBeforeArtifacts,
+      worktreeNavHistoryIndex: rewindHistoryIndexPastView(state, 'artifacts')
     })),
   openMobilePage: () =>
     set((state) => ({

--- a/src/renderer/src/store/slices/worktree-nav-history-view-entries.test.ts
+++ b/src/renderer/src/store/slices/worktree-nav-history-view-entries.test.ts
@@ -46,7 +46,9 @@ function createHistoryStore(worktreeIds: string[] = []): StoreApi<MinimalState> 
 
 const viewCases: { entry: WorktreeNavHistorySimpleViewEntry; label: string }[] = [
   { entry: 'tasks', label: 'Tasks' },
-  { entry: 'automations', label: 'Automations' }
+  { entry: 'automations', label: 'Automations' },
+  { entry: 'artifacts', label: 'Artifacts' },
+  { entry: 'skills', label: 'Skills' }
 ]
 
 function makeGitHubWorkItem(overrides: Partial<GitHubWorkItem> = {}): GitHubWorkItem {

--- a/src/renderer/src/store/slices/worktree-nav-history.ts
+++ b/src/renderer/src/store/slices/worktree-nav-history.ts
@@ -15,7 +15,13 @@ import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 const MAX_HISTORY = 50
 
 // Why: entries may be page sentinels, not just worktree IDs; names keep the "worktree" prefix for call-site stability.
-export type WorktreeNavHistorySimpleViewEntry = 'tasks' | 'automations'
+export type WorktreeNavHistorySimpleViewEntry = 'tasks' | 'automations' | 'artifacts' | 'skills'
+const SIMPLE_VIEW_ENTRIES: readonly WorktreeNavHistorySimpleViewEntry[] = [
+  'tasks',
+  'automations',
+  'artifacts',
+  'skills'
+]
 export type WorktreeNavHistoryTaskDetailEntry =
   | {
       kind: 'task-detail'
@@ -77,9 +83,18 @@ export function setWorktreeNavViewActivator(fn: ViewActivateFn | null): void {
   viewActivator = fn
 }
 
+function isSimpleViewEntry(
+  entry: WorktreeNavHistoryEntry
+): entry is WorktreeNavHistorySimpleViewEntry {
+  return (
+    typeof entry === 'string' &&
+    SIMPLE_VIEW_ENTRIES.includes(entry as WorktreeNavHistorySimpleViewEntry)
+  )
+}
+
 // Why: view entries count as live unconditionally — findWorktreeById can't resolve page sentinels.
 function isViewEntry(entry: WorktreeNavHistoryEntry): entry is WorktreeNavHistoryViewEntry {
-  return entry === 'tasks' || entry === 'automations' || typeof entry === 'object'
+  return isSimpleViewEntry(entry) || typeof entry === 'object'
 }
 
 function isTaskStackEntry(entry: WorktreeNavHistoryEntry): boolean {
@@ -88,7 +103,7 @@ function isTaskStackEntry(entry: WorktreeNavHistoryEntry): boolean {
 
 function getHistoryEntryKey(entry: WorktreeNavHistoryEntry): string {
   if (typeof entry === 'string') {
-    return entry === 'tasks' || entry === 'automations' ? `view:${entry}` : `worktree:${entry}`
+    return isSimpleViewEntry(entry) ? `view:${entry}` : `worktree:${entry}`
   }
   if (entry.source === 'github') {
     const sourceScope =
@@ -185,6 +200,17 @@ export function findNextLiveWorktreeHistoryIndex(state: AppState): number | null
     }
   }
   return null
+}
+
+/** Index to park on after closing `view`'s page: the nearest live prior entry, or the current index when there is none. */
+export function rewindHistoryIndexPastView(
+  state: AppState,
+  view: WorktreeNavHistorySimpleViewEntry
+): number {
+  if (state.worktreeNavHistory[state.worktreeNavHistoryIndex] !== view) {
+    return state.worktreeNavHistoryIndex
+  }
+  return findPrevLiveWorktreeHistoryIndex(state) ?? state.worktreeNavHistoryIndex
 }
 
 export function canGoBackWorktreeHistory(state: AppState): boolean {

--- a/tests/e2e/workspace-back-forward-navigation.spec.ts
+++ b/tests/e2e/workspace-back-forward-navigation.spec.ts
@@ -95,9 +95,8 @@ test.describe('Workspace Back/Forward Navigation', () => {
     await expect(await getBackButton(orcaPage)).toBeVisible()
     await expect(await getForwardButton(orcaPage)).toBeVisible()
 
-    // Why: the Back/Forward pair is conditional on `activeView === 'terminal'`.
-    // Settings, Tasks, and Landing must not render the buttons at all (not just
-    // disable them) so the titlebar stays compact and the semantics unambiguous.
+    // Why: Settings and other views outside the navigation history stack must
+    // not render the buttons at all, rather than merely disabling them.
     await orcaPage.evaluate(() => {
       window.__store!.getState().openSettingsPage()
     })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​58 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​54 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​62 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​30 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​32 |

<!-- /orca-pr-loc -->

## Problem

Artifacts and Skills pages weren't tracked in the navigation history, so users couldn't use back/forward to navigate between these pages and other views.

## Solution

Extended the navigation history system to track Artifacts and Skills pages the same way Automations pages already work.

## What Changed

- Added `'artifacts'` and `'skills'` to `WorktreeNavHistorySimpleViewEntry` type
- Updated `openArtifactsPage()`, `openSkillsPage()`, `openSkillShare()`, and `openSkillsSharedLinks()` to call `recordViewVisit()` when entered
- Updated `closeArtifactsPage()` and `closeSkillsPage()` to properly rewind navigation history when closed
- Extracted common history-rewinding logic into `rewindHistoryIndexPastView()` helper and refactored `closeAutomationsPage()` to use it
- Updated `applyWorktreeNavViewEntry()` to recognize all three page types
- Added test cases for Artifacts and Skills page navigation (visit recording, history rewinding, separate history entries, shared link handling)

## Testing

- Added 4 test cases covering Artifacts and Skills navigation:
  - Recording and rewinding visits on close
  - Recording as separate back/forward entries
  - Recording Skills visits from shared links
- Updated existing test cases to include new page types