### PR TITLE
Fix Cmd+J Enter for worktree creation

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -2736,6 +2736,7 @@ function WorktreeJumpPaletteContent({
     if (
       !isWorktreePaletteCreateActivationAllowed({
         hasTaskUrlIntent: taskSourceUrl !== null,
+        hasCreateName: trimmed.length > 0,
         selectionMovedByUser: selectionMovedByUserRef.current
       })
     ) {

--- a/src/renderer/src/lib/worktree-palette-create-action.test.ts
+++ b/src/renderer/src/lib/worktree-palette-create-action.test.ts
@@ -231,27 +231,35 @@ describe('worktree-palette-create-action', () => {
     ).toBe('browser-page:first')
   })
 
-  it('leaves create unarmed for free text until the user moves the selection', () => {
-    // Why: cmdk auto-selects the first row once the controlled value empties, so
-    // with Create alone on screen Enter would fire without any user gesture.
+  it('allows Enter for a typed create name without requiring arrow navigation', () => {
     expect(
       isWorktreePaletteCreateActivationAllowed({
         hasTaskUrlIntent: false,
+        hasCreateName: true,
         selectionMovedByUser: false
       })
-    ).toBe(false)
+    ).toBe(true)
     expect(
       isWorktreePaletteCreateActivationAllowed({
         hasTaskUrlIntent: false,
+        hasCreateName: false,
         selectionMovedByUser: true
       })
     ).toBe(true)
     expect(
       isWorktreePaletteCreateActivationAllowed({
         hasTaskUrlIntent: true,
+        hasCreateName: false,
         selectionMovedByUser: false
       })
     ).toBe(true)
+    expect(
+      isWorktreePaletteCreateActivationAllowed({
+        hasTaskUrlIntent: false,
+        hasCreateName: false,
+        selectionMovedByUser: false
+      })
+    ).toBe(false)
   })
 
   it('counts only navigation keys as a user selection move', () => {

--- a/src/renderer/src/lib/worktree-palette-create-action.ts
+++ b/src/renderer/src/lib/worktree-palette-create-action.ts
@@ -35,9 +35,10 @@ export function getWorktreePaletteCreateActionState({
  */
 export function isWorktreePaletteCreateActivationAllowed(args: {
   hasTaskUrlIntent: boolean
+  hasCreateName: boolean
   selectionMovedByUser: boolean
 }): boolean {
-  return args.hasTaskUrlIntent || args.selectionMovedByUser
+  return args.hasTaskUrlIntent || args.hasCreateName || args.selectionMovedByUser
 }
 
 export const WORKTREE_PALETTE_SELECTION_MOVE_KEYS: ReadonlySet<string> = new Set([

--- a/tests/e2e/worktree-jump-palette-filter.spec.ts
+++ b/tests/e2e/worktree-jump-palette-filter.spec.ts
@@ -180,4 +180,20 @@ test.describe('Worktree jump-palette filters', () => {
     await searchFixtureWorkspaces(orcaPage, fixture)
     await expect(filterTrigger(orcaPage)).not.toContainText('1')
   })
+
+  test('pressing Enter creates a worktree from a typed name', async ({ orcaPage }) => {
+    await openPalette(orcaPage)
+    const input = palette(orcaPage).getByPlaceholder(SEARCH_PLACEHOLDER)
+    await input.fill(`cmd-j-enter-${Date.now()}`)
+    await expect(
+      palette(orcaPage).locator('[cmdk-item][data-value="__create_worktree__"]')
+    ).toBeVisible()
+
+    await input.press('Enter')
+
+    await expect(
+      orcaPage.getByRole('dialog', { name: /Create (Workspace|Worktree)/i })
+    ).toBeVisible()
+    await orcaPage.keyboard.press('Escape')
+  })
 })

--- a/tests/e2e/worktree-jump-palette-filter.spec.ts
+++ b/tests/e2e/worktree-jump-palette-filter.spec.ts
@@ -191,9 +191,9 @@ test.describe('Worktree jump-palette filters', () => {
 
     await input.press('Enter')
 
-    await expect(
-      orcaPage.getByRole('dialog', { name: /Create (Workspace|Worktree)/i })
-    ).toBeVisible()
+    const createDialog = orcaPage.getByRole('dialog', { name: /Create (Workspace|Worktree)/i })
+    await expect(createDialog).toBeVisible()
     await orcaPage.keyboard.press('Escape')
+    await expect(createDialog).toBeHidden()
   })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​28 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## Summary
- allow Enter to activate the selected Cmd+J create-worktree row after typing a name
- preserve the empty-query activation guard
- add a Playwright regression test

## Validation
- focused Vitest suite: 64 passed
- web typecheck
- changed-file oxlint
- Electron Playwright/CDP: 2 passed