### PR TITLE
fix(sidebar): keep the host pill legible on the selected workspace card

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -1210,6 +1210,33 @@ html.native-shell .app-layout {
   background: color-mix(in srgb, var(--sidebar-accent) 40%, transparent);
 }
 
+/* Why: an opaque --accent chip is mixed against the sidebar base, so on a selected
+   card it lands on that card's translucent wash instead — and both resolve to
+   ~foreground 10%, which makes the chip vanish. An alpha fill composites over
+   whatever surface the chip actually sits on, holding the same step on the
+   sidebar, a hovered card and a selected card, in every appearance mode. */
+.worktree-sidebar-chip {
+  /* Transparent, not a tinted ring: the fill alone carried the chip before, and
+     the border slot only stays to keep the box model identical. */
+  border-color: transparent;
+  background: color-mix(in srgb, var(--worktree-sidebar-foreground) 8%, transparent);
+}
+
+.dark .worktree-sidebar-chip {
+  background: color-mix(in srgb, var(--worktree-sidebar-foreground) 12%, transparent);
+}
+
+/* Tracks --muted-foreground's own ratio so the chip label stays level with the
+   branch text beside it, instead of being mixed against the sidebar base and
+   sinking into the lifted fill. */
+.worktree-sidebar-chip-label {
+  color: color-mix(in srgb, var(--worktree-sidebar-foreground) 55%, transparent);
+}
+
+.dark .worktree-sidebar-chip-label {
+  color: color-mix(in srgb, var(--worktree-sidebar-foreground) 62%, transparent);
+}
+
 /* Why: the brighter border carries the selected state; a translucent wash keeps
    card text legible instead of lifting the surface toward the foreground color. */
 [data-worktree-card-surface][data-worktree-card-active='primary'] {

--- a/src/renderer/src/components/sidebar/worktree-card-chip-surface.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-chip-surface.test.ts
@@ -56,6 +56,10 @@ describe('worktree sidebar chip surface', () => {
   it('keeps the meta-row chips off base-mixed surface tokens', () => {
     const source = readFileSync(resolve(testDir, 'worktree-card-meta-row.tsx'), 'utf8')
 
+    // Both chips in the row — the repo badge and the host pill — must carry the class,
+    // so deleting it rather than fixing it can't satisfy the absence checks below.
+    expect(source.match(/worktree-sidebar-chip(?=[\s"'])/g)).toHaveLength(2)
+    expect(source).toMatch(/worktree-sidebar-chip-label(?=[\s"'])/)
     expect(source).not.toMatch(/\bbg-accent\b/)
     expect(source).not.toMatch(/\bborder-border\b/)
   })

--- a/src/renderer/src/components/sidebar/worktree-card-chip-surface.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-chip-surface.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const testDir = import.meta.dirname
+
+function readCss(): string {
+  // Strip comments so a `}` inside prose can't truncate a rule body match.
+  return readFileSync(resolve(testDir, '../../assets/main.css'), 'utf8').replace(
+    /\/\*[\s\S]*?\*\//g,
+    ''
+  )
+}
+
+function readRuleBody(selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const body = readCss().match(new RegExp(`^${escaped}\\s*\\{(?<body>[^}]*)\\}`, 'm'))?.groups?.body
+  expect(body, `missing CSS rule for ${selector}`).toBeTypeOf('string')
+
+  return body ?? ''
+}
+
+function readDeclaration(selector: string, property: string): string {
+  const body = readRuleBody(selector)
+  const value = body.match(new RegExp(`(?:^|;)\\s*${property}:\\s*(?<value>[^;]*)`))?.groups?.value
+
+  return (value ?? '').trim()
+}
+
+const CHIP_SURFACE_SELECTORS = ['.worktree-sidebar-chip', '.dark .worktree-sidebar-chip']
+const CHIP_LABEL_SELECTORS = ['.worktree-sidebar-chip-label', '.dark .worktree-sidebar-chip-label']
+
+describe('worktree sidebar chip surface', () => {
+  // Why: an opaque fill is pre-mixed against the sidebar base, so on a selected card —
+  // itself a foreground-10% wash over that same base — the chip and the card resolve to
+  // the same color and the chip disappears. Mixing toward `transparent` composites over
+  // the chip's real parent, holding one step on every surface and appearance mode.
+  it.each(CHIP_SURFACE_SELECTORS)('fills %s with an alpha overlay', (selector) => {
+    const background = readDeclaration(selector, 'background')
+
+    expect(background).toMatch(/^color-mix\(/)
+    expect(background).toMatch(/transparent\s*\)$/)
+  })
+
+  it.each(CHIP_LABEL_SELECTORS)('tints %s against its own surface', (selector) => {
+    const color = readDeclaration(selector, 'color')
+
+    expect(color).toMatch(/^color-mix\(/)
+    expect(color).toMatch(/transparent\s*\)$/)
+  })
+
+  it('keeps the chip border out of the way instead of tinting it', () => {
+    expect(readDeclaration('.worktree-sidebar-chip', 'border-color')).toBe('transparent')
+  })
+
+  it('keeps the meta-row chips off base-mixed surface tokens', () => {
+    const source = readFileSync(resolve(testDir, 'worktree-card-meta-row.tsx'), 'utf8')
+
+    expect(source).not.toMatch(/\bbg-accent\b/)
+    expect(source).not.toMatch(/\bborder-border\b/)
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-card-meta-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-meta-row.tsx
@@ -47,7 +47,7 @@ export function WorktreeCardMetaRow({
     <div className="flex items-center gap-1.5 min-w-0" data-worktree-card-meta-row="">
       <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
         {showRepoBadgeInMetaRow && repo && (
-          <div className="flex items-center gap-1.5 shrink-0 px-1.5 py-0.5 rounded-[4px] bg-accent border border-border dark:bg-accent/50 dark:border-border/60">
+          <div className="worktree-sidebar-chip flex items-center gap-1.5 shrink-0 px-1.5 py-0.5 rounded-[4px] border">
             <RepoBadgeMark color={repo.badgeColor} />
             <span className="text-[10px] font-semibold text-foreground truncate max-w-[6rem] leading-none lowercase">
               {repo.displayName}
@@ -58,7 +58,7 @@ export function WorktreeCardMetaRow({
         {showHostContextBadge && (
           <Badge
             variant="secondary"
-            className="h-[16px] max-w-[7rem] shrink-0 rounded border border-border bg-accent px-1.5 text-[10px] font-medium leading-none text-muted-foreground dark:bg-accent/80 dark:border-border/50"
+            className="worktree-sidebar-chip worktree-sidebar-chip-label h-[16px] max-w-[7rem] shrink-0 rounded border px-1.5 text-[10px] font-medium leading-none"
           >
             <span className="truncate">{hostContextLabel}</span>
           </Badge>


### PR DESCRIPTION
## ELI5

The little `Local Mac` / `Hetzner VPS` pill in the sidebar was painted a fixed shade of grey chosen to look right against the sidebar's background. But when you select a workspace, that card gets its own slightly lighter background — and the pill's fixed grey turned out to be almost exactly that same shade, so the pill vanished into the card underneath it. Now the pill is painted as a see-through tint instead of a fixed shade, so it always sits one consistent step above whatever is behind it.

## What Changed

- `worktree-card-meta-row.tsx`: the host pill and the repo badge move off `bg-accent` / `border-border` onto a new `worktree-sidebar-chip` class; the host label moves off `text-muted-foreground` onto `worktree-sidebar-chip-label`.
- `main.css`: both classes mix toward `transparent` rather than toward a base surface token, so they composite over the chip's real parent.
- Added `worktree-card-chip-surface.test.ts`, following the existing `sidebar-resize-handle.test.ts` CSS-ratchet pattern.

No markup, layout or sizing change — the border slot stays in place at `transparent`, so the pill keeps its exact box.

## Why

`--accent` is pre-mixed against the sidebar's *base* background:

```
--accent: color-mix(in srgb, <foreground> 9%, <background>)     // left-sidebar-appearance.ts
```

The pill does not sit on that base. On the selected card it sits on that card's own wash:

```
.dark [data-worktree-card-surface][data-worktree-card-active='primary'] {
  background: color-mix(in srgb, var(--worktree-sidebar-foreground) 10%, transparent);
}
```

Both resolve to roughly *foreground 10%* over the same base, so the pill and the card beneath it land on nearly the same color — with **Left sidebar appearance = Match terminal** the pill is actually a shade *darker* than the card it is drawn on. Measured with a `#171717` terminal background in dark mode:

| state | pill fill | surface beneath | contrast |
| --- | --- | --- | --- |
| unselected | `#2c2c2c` | `#171717` | ~1.5:1 |
| **selected** | `#2c2c2c` | `#2e2e2e` | **~1.02:1** |
| **selected, after** | `#444444` | `#2e2e2e` | **~1.49:1** |

Mixing toward `transparent` makes the fill an alpha overlay, which composites over the element's actual parent instead of an assumed one. That holds one step on the sidebar, a hovered card and a selected card alike, and it does so in every appearance mode — Default, Match terminal and Tinted — without any mode needing its own numbers. This is the approach the agent rows directly below the pill already use (`color-mix(in srgb, var(--accent) 70%, transparent)`), which is why they never had this bug; the host pill was the outlier.

The label had the same flaw for the same reason, and would have dropped to ~3.6:1 once the fill lifted. It now tracks `--muted-foreground`'s own ratio against the surface it is really on, keeping it level with the branch text beside it rather than above it.

Values are deliberately conservative — dark fill `foreground 12%`, light `8%` — chosen to restore the pill's original weight rather than make it louder, and the border is `transparent` because the original `dark:border-border/50` was a ~3.5% ring that read as no border at all.

## Linked Issue

Fixes #15971

## Visual Proof

Before and after, dark mode with a `#171717` Match-terminal sidebar. Note the host pill on the selected card:

<img width="1462" height="612" alt="Sidebar host pill before and after, on the selected workspace card" src="https://github.com/user-attachments/assets/c180a001-73a5-4862-bf38-eccede708b7f" />

## Testing

Manually verified in a dev build on macOS across all three sidebar appearance modes (Default, Match terminal with a `#171717` background, and Tinted), checking the pill on unselected, hovered and selected cards, and in both light and dark appearance.

Reviewer steps:

1. Settings → Appearance → **Appearance: Dark**, **Left sidebar appearance: Match terminal**, terminal background around `#171717`.
2. Select a workspace whose card shows a host pill — the pill stays a readable chip.
3. Select a different workspace and confirm the pill looks the same as it did when selected.
4. Repeat with **Tinted** and **Default**, and in light mode.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

`worktree-card-chip-surface.test.ts` asserts the property that actually matters — that the chip's fill and label mix toward `transparent`, i.e. stay layer-relative — rather than pinning literal percentages that a future design tweak would churn. It also guards the meta row against `bg-accent` / `border-border` creeping back in.

`pnpm lint`, `pnpm typecheck` and `pnpm build` pass locally. `pnpm test` passes except for five pre-existing environment/timing-sensitive failures unrelated to this change, all outside `src/renderer/`: `config/scripts/macos-computer-helper-owner-loss-processes.test.mjs`, `src/main/browser/browser-cookie-import-replace-partition-rollback.electron.test.ts`, `src/main/shell-startup-feature-channel.test.ts`, `src/main/updater.startup-scheduling.test.ts`, `src/relay/subprocess.test.ts`. The failing set differs between runs on the same tree, and the ZDOTDIR one reproduces on a single-file run that loads no renderer code at all.

## AI Disclosure

Claude Opus 5 (Claude Code) was used to diagnose the root cause, implement the change, and draft this description. All changes were reviewed and manually verified in a dev build before submission.

## Review

- **Cross-platform (macOS / Linux / Windows):** renderer CSS and class names only; no platform-dependent code, paths, shortcuts or process handling. Identical on all three.
- **Remote SSH:** presentation-only. The host pill's *content* is unchanged — this only affects how it is painted. No RPC, stream frame, or published-content change, so no remote wire-compatibility impact and nothing that differs between a local and an SSH-backed workspace.
- **Folder workspaces:** the meta row is shared by git worktrees and folder workspaces; both take the same styling path, and neither is branched on here.
- **Mobile:** no change to mobile surfaces.
- **Backwards compatibility:** no settings, schema, or persisted-state change. Existing `leftSidebarAppearanceMode` / tint settings are read exactly as before.
- **Performance:** two static CSS rules and fewer utility classes on two elements. `color-mix` toward `transparent` is the same primitive already used by neighbouring sidebar rules, so no new paint cost.
- **Security:** none — no data flow, no user input, no IPC.
- **Accessibility:** a strict improvement. The selected-state pill goes from ~1.02:1 to ~1.49:1 against its surface, and the label holds roughly the contrast it had before.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The same layer-absolute pattern (an opaque `bg-accent` / `--border` fill on an element that can land on a lifted surface) may exist on other sidebar chips. This PR deliberately fixes only the two in the workspace card's meta row to keep the change focused; a broader sweep would be a separate PR.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
