### PR TITLE
Retry transient ripgrep spawn failures instead of demanding install

### DIFF
--- a/src/main/ipc/filesystem-search-file-paths.test.ts
+++ b/src/main/ipc/filesystem-search-file-paths.test.ts
@@ -4,6 +4,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Store } from '../persistence'
 import type * as GitRunner from '../git/runner'
 import { isFileListingCancellation } from '../../shared/file-listing-cancellation'
+import {
+  RipgrepLaunchFailureError,
+  RipgrepUnavailableError
+} from '../../shared/ripgrep-process-availability'
 
 const {
   checkRgAvailableMock,
@@ -36,7 +40,7 @@ vi.mock('./local-worktree-runtime-options', () => ({
 
 import { searchQuickOpenFilePaths } from './filesystem-search-file-paths'
 
-function createMockProcess(): ChildProcess {
+function createMockProcess(spawned = true): ChildProcess {
   const child = new EventEmitter() as ChildProcess
   ;(child as unknown as Record<string, unknown>).stdout = new EventEmitter()
   ;(
@@ -48,8 +52,12 @@ function createMockProcess(): ChildProcess {
   ;(child as unknown as Record<string, unknown>).kill = vi.fn()
   ;(child as unknown as Record<string, unknown>).exitCode = null
   ;(child as unknown as Record<string, unknown>).signalCode = null
-  Object.defineProperty(child, 'pid', { configurable: true, value: 1 })
+  Object.defineProperty(child, 'pid', { configurable: true, value: spawned ? 1 : undefined })
   return child
+}
+
+function createSpawnError(code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(`spawn rg ${code}`), { code })
 }
 
 async function flushMicrotasks(): Promise<void> {
@@ -120,6 +128,122 @@ describe('searchQuickOpenFilePaths', () => {
       searchQuickOpenFilePaths('C:\\repo', {} as Store, { query: 'target', limit: 32 })
     ).rejects.toThrow('Quick Open search requires ripgrep')
     expect(wslAwareSpawnMock).not.toHaveBeenCalled()
+  })
+
+  it('retries transient WSL rg availability pressure before showing install guidance', async () => {
+    getLocalGitOptionsForRegisteredWorktreeMock.mockReturnValue({ wslDistro: 'Ubuntu' })
+    checkRgAvailableMock
+      .mockRejectedValueOnce(new RipgrepLaunchFailureError('rg check failed (EAGAIN)'))
+      .mockResolvedValueOnce(true)
+    const child = createMockProcess()
+    wslAwareSpawnMock.mockReturnValue(child)
+
+    const promise = searchQuickOpenFilePaths('C:\\repo', {} as Store, {
+      query: 'target',
+      limit: 32
+    })
+    await flushMicrotasks()
+    ;(child.stdout as unknown as EventEmitter).emit('data', 'src/target.ts\n')
+    child.emit('close', 0, null)
+
+    await expect(promise).resolves.toMatchObject({ paths: ['src/target.ts'] })
+    expect(checkRgAvailableMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('retries a transient rg spawn failure instead of demanding a ripgrep install', async () => {
+    const failed = createMockProcess(false)
+    const succeeded = createMockProcess()
+    wslAwareSpawnMock.mockReturnValueOnce(failed).mockReturnValueOnce(succeeded)
+    const promise = searchQuickOpenFilePaths('/repo', {} as Store, {
+      query: 'sta4354gitignored',
+      limit: 32
+    })
+    await flushMicrotasks()
+
+    failed.emit('error', createSpawnError('EAGAIN'))
+    await flushMicrotasks()
+
+    expect(wslAwareSpawnMock).toHaveBeenCalledTimes(2)
+    ;(succeeded.stdout as unknown as EventEmitter).emit(
+      'data',
+      'data/chunk-077568/sta-4354-gitignored-target.bin\n'
+    )
+    succeeded.emit('close', 0, null)
+
+    await expect(promise).resolves.toEqual({
+      paths: ['data/chunk-077568/sta-4354-gitignored-target.bin'],
+      totalCount: 1,
+      truncated: false
+    })
+  })
+
+  it('retries a synchronous transient rg spawn failure', async () => {
+    const succeeded = createMockProcess()
+    wslAwareSpawnMock.mockImplementationOnce(() => {
+      throw createSpawnError('ENOMEM')
+    })
+    wslAwareSpawnMock.mockReturnValueOnce(succeeded)
+
+    const promise = searchQuickOpenFilePaths('/repo', {} as Store, {
+      query: 'target',
+      limit: 32
+    })
+    await flushMicrotasks()
+    ;(succeeded.stdout as unknown as EventEmitter).emit('data', 'src/target.ts\n')
+    succeeded.emit('close', 0, null)
+
+    await expect(promise).resolves.toMatchObject({ paths: ['src/target.ts'] })
+    expect(wslAwareSpawnMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('still reports a missing ripgrep binary when rg is genuinely absent', async () => {
+    const child = createMockProcess(false)
+    wslAwareSpawnMock.mockReturnValue(child)
+    const promise = searchQuickOpenFilePaths('/repo', {} as Store, {
+      query: 'target',
+      limit: 32
+    })
+    await flushMicrotasks()
+
+    child.emit('error', createSpawnError('ENOENT'))
+
+    await expect(promise).rejects.toThrow('Quick Open search requires ripgrep')
+    expect(wslAwareSpawnMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports install guidance when ripgrep is unavailable on the retry', async () => {
+    const failed = createMockProcess(false)
+    wslAwareSpawnMock.mockReturnValueOnce(failed).mockImplementationOnce(() => {
+      throw new RipgrepUnavailableError()
+    })
+    const promise = searchQuickOpenFilePaths('/repo', {} as Store, {
+      query: 'target',
+      limit: 32
+    })
+    await flushMicrotasks()
+
+    failed.emit('error', createSpawnError('EAGAIN'))
+
+    await expect(promise).rejects.toThrow('Quick Open search requires ripgrep')
+    expect(wslAwareSpawnMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not retry a transient spawn failure after the query was superseded', async () => {
+    const child = createMockProcess(false)
+    wslAwareSpawnMock.mockReturnValue(child)
+    const controller = new AbortController()
+    const promise = searchQuickOpenFilePaths('/repo', {} as Store, {
+      query: 'target',
+      limit: 32,
+      signal: controller.signal
+    })
+    await flushMicrotasks()
+
+    controller.abort()
+    child.emit('error', createSpawnError('EAGAIN'))
+
+    await expect(promise).rejects.toSatisfy(isFileListingCancellation)
+    expect(wslAwareSpawnMock).toHaveBeenCalledTimes(1)
   })
 
   it('does not start a host scan for empty or oversized queries', async () => {

--- a/src/main/ipc/filesystem-search-file-paths.test.ts
+++ b/src/main/ipc/filesystem-search-file-paths.test.ts
@@ -246,6 +246,25 @@ describe('searchQuickOpenFilePaths', () => {
     expect(wslAwareSpawnMock).toHaveBeenCalledTimes(1)
   })
 
+  it('reports cancellation when the query is superseded after a transient spawn failure', async () => {
+    const child = createMockProcess(false)
+    wslAwareSpawnMock.mockReturnValue(child)
+    const controller = new AbortController()
+    const promise = searchQuickOpenFilePaths('/repo', {} as Store, {
+      query: 'target',
+      limit: 32,
+      signal: controller.signal
+    })
+    await flushMicrotasks()
+
+    // Abort lands after the scan rejected but before the retry decision resumes.
+    child.emit('error', createSpawnError('EAGAIN'))
+    controller.abort()
+
+    await expect(promise).rejects.toSatisfy(isFileListingCancellation)
+    expect(wslAwareSpawnMock).toHaveBeenCalledTimes(1)
+  })
+
   it('does not start a host scan for empty or oversized queries', async () => {
     await expect(
       searchQuickOpenFilePaths('/repo', {} as Store, { query: '   ', limit: 32 })

--- a/src/main/ipc/filesystem-search-file-paths.ts
+++ b/src/main/ipc/filesystem-search-file-paths.ts
@@ -92,8 +92,12 @@ export async function searchQuickOpenFilePaths(
       if (error instanceof RipgrepUnavailableError) {
         return fallback()
       }
+      // Why: a supersede that lands after the scan rejected still owes the caller a cancellation.
+      if (args.signal?.aborted) {
+        throw fileListingCancellationError(args.signal)
+      }
       // Why: one-off fork/exec pressure should not blank Quick Open until the query changes.
-      if (!(error instanceof RipgrepLaunchFailureError) || args.signal?.aborted || attempt > 0) {
+      if (!(error instanceof RipgrepLaunchFailureError) || attempt > 0) {
         throw error
       }
     }

--- a/src/main/ipc/filesystem-search-file-paths.ts
+++ b/src/main/ipc/filesystem-search-file-paths.ts
@@ -13,7 +13,9 @@ import { isQuickOpenQueryTooLarge, QuickOpenPathRanker } from '../../shared/quic
 import {
   absorbPendingRipgrepSpawnError,
   isRipgrepUnavailableExit,
+  isTransientRipgrepSpawnError,
   killSpawnedRipgrepProcess,
+  RipgrepLaunchFailureError,
   RipgrepUnavailableError
 } from '../../shared/ripgrep-process-availability'
 import { wslAwareSpawn } from '../git/runner'
@@ -54,21 +56,15 @@ export async function searchQuickOpenFilePaths(
   const fallback = async (): Promise<QuickOpenFilePathSearchResult> => {
     throw new Error(await buildRipgrepRequiredMessage())
   }
-  if (
-    wslDistroForOutput &&
-    !(await checkRgAvailable(authorizedRootPath, localGitOptions.wslDistro))
-  ) {
-    return fallback()
-  }
-
   const excludePathPrefixes = buildExcludePathPrefixes(authorizedRootPath, args.excludePaths)
   const { ignoredPass } = buildRgArgsForQuickOpen({
     searchRoot: '.',
     excludePathPrefixes,
     forceSlashSeparator: sep === '\\'
   })
-  const ranker = new QuickOpenPathRanker(args.query, args.limit)
-  try {
+  // Fresh ranker per attempt so a retry cannot double-count paths from the aborted scan.
+  const scanOnce = async (): Promise<QuickOpenFilePathSearchResult> => {
+    const ranker = new QuickOpenPathRanker(args.query, args.limit)
     await scanRipgrepPaths({
       args: ignoredPass,
       authorizedRootPath,
@@ -78,14 +74,31 @@ export async function searchQuickOpenFilePaths(
       signal: args.signal,
       wslDistroForOutput
     })
-  } catch (error) {
-    if (error instanceof RipgrepUnavailableError) {
-      return fallback()
-    }
-    throw error
+    const result = ranker.result()
+    return { ...result, truncated: result.totalCount > args.limit }
   }
-  const result = ranker.result()
-  return { ...result, truncated: result.totalCount > args.limit }
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      if (
+        wslDistroForOutput &&
+        !(await checkRgAvailable(authorizedRootPath, localGitOptions.wslDistro, {
+          rejectTransientLaunchFailure: true
+        }))
+      ) {
+        return fallback()
+      }
+      return await scanOnce()
+    } catch (error) {
+      if (error instanceof RipgrepUnavailableError) {
+        return fallback()
+      }
+      // Why: one-off fork/exec pressure should not blank Quick Open until the query changes.
+      if (!(error instanceof RipgrepLaunchFailureError) || args.signal?.aborted || attempt > 0) {
+        throw error
+      }
+    }
+  }
+  throw new Error('unreachable Quick Open retry state')
 }
 
 function scanRipgrepPaths(args: {
@@ -106,11 +119,20 @@ function scanRipgrepPaths(args: {
     let parseablePathCount = 0
     let processErrorObserved = false
     let unavailableExitObserved = false
-    const child = wslAwareSpawn('rg', args.args, {
-      cwd: args.authorizedRootPath,
-      ...(args.localGitOptions.wslDistro ? { wslDistro: args.localGitOptions.wslDistro } : {}),
-      stdio: ['ignore', 'pipe', 'pipe']
-    })
+    let child: ReturnType<typeof wslAwareSpawn>
+    try {
+      child = wslAwareSpawn('rg', args.args, {
+        cwd: args.authorizedRootPath,
+        ...(args.localGitOptions.wslDistro ? { wslDistro: args.localGitOptions.wslDistro } : {}),
+        stdio: ['ignore', 'pipe', 'pipe']
+      })
+    } catch (error) {
+      throw isTransientRipgrepSpawnError(error)
+        ? new RipgrepLaunchFailureError(
+            `rg failed to start (${(error as NodeJS.ErrnoException).code})`
+          )
+        : error
+    }
     let timer: ReturnType<typeof setTimeout>
 
     const processLine = (rawLine: string): void => {
@@ -166,12 +188,16 @@ function scanRipgrepPaths(args: {
     const handleStderrData = (): void => {
       /* drain */
     }
-    const handleError = (): void => {
+    const handleError = (error: NodeJS.ErrnoException): void => {
       processErrorObserved = true
+      if (isTransientRipgrepSpawnError(error)) {
+        finish(new RipgrepLaunchFailureError(`rg failed to start (${error.code})`))
+        return
+      }
       finish(
         isRipgrepUnavailableExit(child, null, null)
           ? new RipgrepUnavailableError()
-          : new Error('rg failed to start')
+          : new Error(`rg failed to start${error.code ? ` (${error.code})` : ''}`)
       )
     }
     const handleClose = (code: number | null, signal: NodeJS.Signals | null): void => {

--- a/src/main/ipc/rg-availability.test.ts
+++ b/src/main/ipc/rg-availability.test.ts
@@ -11,6 +11,7 @@ vi.mock('../git/runner', () => ({
 }))
 
 import { checkRgAvailable } from './rg-availability'
+import { RipgrepLaunchFailureError } from '../../shared/ripgrep-process-availability'
 
 function createMockProcess(): ChildProcess {
   const child = new EventEmitter() as unknown as ChildProcess
@@ -35,6 +36,28 @@ describe('checkRgAvailable', () => {
       cwd: '/repo',
       stdio: 'ignore'
     })
+  })
+
+  it('rejects transient synchronous launch pressure when requested', async () => {
+    wslAwareSpawnMock.mockImplementationOnce(() => {
+      throw Object.assign(new Error('spawn rg ENOMEM'), { code: 'ENOMEM' })
+    })
+
+    await expect(
+      checkRgAvailable('/repo', 'Ubuntu', { rejectTransientLaunchFailure: true })
+    ).rejects.toBeInstanceOf(RipgrepLaunchFailureError)
+  })
+
+  it('rejects transient asynchronous launch pressure when requested', async () => {
+    const child = createMockProcess()
+    wslAwareSpawnMock.mockReturnValue(child)
+    const promise = checkRgAvailable('/repo', 'Ubuntu', {
+      rejectTransientLaunchFailure: true
+    })
+
+    child.emit('error', Object.assign(new Error('spawn rg EAGAIN'), { code: 'EAGAIN' }))
+
+    await expect(promise).rejects.toBeInstanceOf(RipgrepLaunchFailureError)
   })
 
   it('settles and detaches when rg availability check ignores timeout kills', async () => {

--- a/src/main/ipc/rg-availability.ts
+++ b/src/main/ipc/rg-availability.ts
@@ -1,4 +1,8 @@
 import { wslAwareSpawn } from '../git/runner'
+import {
+  isTransientRipgrepSpawnError,
+  RipgrepLaunchFailureError
+} from '../../shared/ripgrep-process-availability'
 
 const RG_AVAILABILITY_TIMEOUT_MS = 5000
 
@@ -14,16 +18,34 @@ const RG_AVAILABILITY_TIMEOUT_MS = 5000
 // while a positive cache could mask an rg that was uninstalled or broken
 // mid-session.
 
-export function checkRgAvailable(searchPath?: string, wslDistro?: string): Promise<boolean> {
-  return new Promise((resolve) => {
+export function checkRgAvailable(
+  searchPath?: string,
+  wslDistro?: string,
+  options: { rejectTransientLaunchFailure?: boolean } = {}
+): Promise<boolean> {
+  return new Promise((resolve, reject) => {
     let settled = false
     // Why: pass cwd plus project-runtime distro so WSL projects are checked
     // inside their distro even when the search root is a Windows path.
-    const child = wslAwareSpawn('rg', ['--version'], {
-      ...(searchPath ? { cwd: searchPath } : {}),
-      ...(wslDistro ? { wslDistro } : {}),
-      stdio: 'ignore'
-    })
+    let child: ReturnType<typeof wslAwareSpawn>
+    try {
+      child = wslAwareSpawn('rg', ['--version'], {
+        ...(searchPath ? { cwd: searchPath } : {}),
+        ...(wslDistro ? { wslDistro } : {}),
+        stdio: 'ignore'
+      })
+    } catch (error) {
+      if (options.rejectTransientLaunchFailure && isTransientRipgrepSpawnError(error)) {
+        reject(
+          new RipgrepLaunchFailureError(
+            `rg availability check failed to start (${(error as NodeJS.ErrnoException).code})`
+          )
+        )
+      } else {
+        resolve(false)
+      }
+      return
+    }
     let timeout: ReturnType<typeof setTimeout>
 
     const cleanup = (): void => {
@@ -44,7 +66,22 @@ export function checkRgAvailable(searchPath?: string, wslDistro?: string): Promi
       resolve(available)
     }
 
-    const onError = (): void => settle(false)
+    const rejectLaunchFailure = (error: NodeJS.ErrnoException): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      reject(new RipgrepLaunchFailureError(`rg availability check failed to start (${error.code})`))
+    }
+
+    const onError = (error: NodeJS.ErrnoException): void => {
+      if (options.rejectTransientLaunchFailure && isTransientRipgrepSpawnError(error)) {
+        rejectLaunchFailure(error)
+        return
+      }
+      settle(false)
+    }
     const onClose = (code: number | null): void => settle(code === 0)
 
     child.once('error', onError)

--- a/src/relay/fs-handler-list-files-ignored.test.ts
+++ b/src/relay/fs-handler-list-files-ignored.test.ts
@@ -145,6 +145,71 @@ describe('relay quick open ignored file listing', () => {
     await expect(promise).resolves.toEqual(['scripts/check-target.ts', 'src/components/target.ts'])
   })
 
+  it('retries a transient remote rg spawn failure without reporting ripgrep as missing', async () => {
+    const failed = createMockProcess()
+    const succeeded = createMockProcess()
+    Object.defineProperty(failed, 'pid', { value: undefined })
+    spawnMock.mockReturnValueOnce(failed).mockReturnValueOnce(succeeded)
+
+    const promise = listFilesWithRg('/remote/root', [], {
+      maxResults: 32,
+      searchQuery: 'target'
+    })
+    ;(failed.stdout as unknown as EventEmitter).emit('data', 'src/target.ts\n')
+    failed.emit('error', Object.assign(new Error('spawn rg EAGAIN'), { code: 'EAGAIN' }))
+
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2))
+    ;(succeeded.stdout as unknown as EventEmitter).emit(
+      'data',
+      'src/target.ts\nsrc/another-target.ts\n'
+    )
+    succeeded.emit('close', 0, null)
+
+    await expect(promise).resolves.toEqual(['src/target.ts', 'src/another-target.ts'])
+  })
+
+  it('retries a synchronous transient remote rg spawn failure', async () => {
+    const succeeded = createMockProcess()
+    spawnMock.mockImplementationOnce(() => {
+      throw Object.assign(new Error('spawn rg ETXTBSY'), { code: 'ETXTBSY' })
+    })
+    spawnMock.mockReturnValueOnce(succeeded)
+
+    const promise = listFilesWithRg('/remote/root', [], {
+      maxResults: 32,
+      searchQuery: 'target'
+    })
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2))
+    ;(succeeded.stdout as unknown as EventEmitter).emit('data', 'src/target.ts\n')
+    succeeded.emit('close', 0, null)
+
+    await expect(promise).resolves.toEqual(['src/target.ts'])
+  })
+
+  it('runs the ignored pass after an unbounded primary listing retry succeeds', async () => {
+    const failedPrimary = createMockProcess()
+    const succeededPrimary = createMockProcess()
+    const ignored = createMockProcess()
+    Object.defineProperty(failedPrimary, 'pid', { value: undefined })
+    spawnMock
+      .mockReturnValueOnce(failedPrimary)
+      .mockReturnValueOnce(succeededPrimary)
+      .mockReturnValueOnce(ignored)
+
+    const promise = listFilesWithRg('/remote/root')
+    failedPrimary.emit('error', Object.assign(new Error('spawn rg EAGAIN'), { code: 'EAGAIN' }))
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(2))
+
+    ;(succeededPrimary.stdout as unknown as EventEmitter).emit('data', 'src/index.ts\n')
+    succeededPrimary.emit('close', 0, null)
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(3))
+    ;(ignored.stdout as unknown as EventEmitter).emit('data', 'dist/generated.js\n')
+    ignored.emit('close', 0, null)
+
+    await expect(promise).resolves.toEqual(['src/index.ts', 'dist/generated.js'])
+    expect(spawnMock.mock.calls[2][1]).toContain('--no-ignore-vcs')
+  })
+
   it.each(['error-first', 'close-first'] as const)(
     'tags a %s pre-spawn listing failure without starting the ignored pass',
     async (order) => {

--- a/src/relay/fs-handler-list-files.ts
+++ b/src/relay/fs-handler-list-files.ts
@@ -25,7 +25,9 @@ import {
   absorbPendingRipgrepSpawnError,
   isRipgrepUnavailableAfterLaunchFailure,
   isRipgrepUnavailableExit,
+  isTransientRipgrepSpawnError,
   killSpawnedRipgrepProcess,
+  RipgrepLaunchFailureError,
   RipgrepUnavailableError
 } from '../shared/ripgrep-process-availability'
 import { QuickOpenPathRanker } from '../shared/quick-open-path-search'
@@ -43,8 +45,7 @@ export function listFilesWithRg(
   }
   return new Promise((resolve, reject) => {
     const files = new Set<string>()
-    const ranker =
-      searchQuery === undefined ? null : new QuickOpenPathRanker(searchQuery, maxResults ?? 16)
+    let rankedPaths: string[] | null = null
     let done = false
     const children: {
       child: ChildProcess
@@ -61,7 +62,7 @@ export function listFilesWithRg(
       forceSlashSeparator: true
     })
 
-    const processLine = (rawLine: string): boolean => {
+    const processLine = (rawLine: string, attemptRanker: QuickOpenPathRanker | null): boolean => {
       const relPath = normalizeQuickOpenRgLine(rawLine, { kind: 'cwd-relative' })
       if (relPath === null) {
         return false
@@ -74,8 +75,8 @@ export function listFilesWithRg(
       if (shouldExcludeQuickOpenRelPath(relPath, excludePathPrefixes)) {
         return true
       }
-      if (ranker) {
-        ranker.consider(relPath)
+      if (attemptRanker) {
+        attemptRanker.consider(relPath)
         return true
       }
       files.add(relPath)
@@ -85,8 +86,10 @@ export function listFilesWithRg(
       return true
     }
 
-    const runPass = (args: string[]): Promise<void> =>
+    const runPassOnce = (args: string[]): Promise<void> =>
       new Promise((passResolve, passReject) => {
+        const attemptRanker =
+          searchQuery === undefined ? null : new QuickOpenPathRanker(searchQuery, maxResults ?? 16)
         let passBuf = ''
         let passDone = false
         let passFileCount = 0
@@ -99,11 +102,20 @@ export function listFilesWithRg(
         // are evaluated against rg's working directory, not the absolute
         // search target. Without cwd, nested-worktree exclusions silently
         // stop working.
-        const child = spawn('rg', ['--no-messages', ...args], {
-          cwd: rootPath,
-          stdio: ['ignore', 'pipe', 'pipe'],
-          windowsHide: true
-        })
+        let child: ChildProcess
+        try {
+          child = spawn('rg', ['--no-messages', ...args], {
+            cwd: rootPath,
+            stdio: ['ignore', 'pipe', 'pipe'],
+            windowsHide: true
+          })
+        } catch (error) {
+          throw isTransientRipgrepSpawnError(error)
+            ? new RipgrepLaunchFailureError(
+                `rg failed to start (${(error as NodeJS.ErrnoException).code})`
+              )
+            : error
+        }
         let timer: ReturnType<typeof setTimeout> | null = null
         const cleanup = (): void => {
           if (timer) {
@@ -134,6 +146,9 @@ export function listFilesWithRg(
           }
           passDone = true
           cleanup()
+          if (attemptRanker) {
+            rankedPaths = attemptRanker.result().paths
+          }
           passResolve()
         }
         const rejectLaunchFailure = (error: Error): void => {
@@ -164,7 +179,7 @@ export function listFilesWithRg(
           let start = 0
           let idx = passBuf.indexOf('\n', start)
           while (idx !== -1) {
-            if (processLine(passBuf.substring(start, idx))) {
+            if (processLine(passBuf.substring(start, idx), attemptRanker)) {
               passFileCount++
             }
             if (done) {
@@ -178,8 +193,12 @@ export function listFilesWithRg(
         function handleStderrData(): void {
           /* drain to prevent backpressure stalls */
         }
-        function handleError(err: Error): void {
+        function handleError(err: NodeJS.ErrnoException): void {
           processErrorObserved = true
+          if (isTransientRipgrepSpawnError(err)) {
+            rejectPass(new RipgrepLaunchFailureError(`rg failed to start (${err.code})`))
+            return
+          }
           if (isRipgrepUnavailableExit(child, null, null)) {
             passBuf = ''
             rejectLaunchFailure(err)
@@ -210,7 +229,7 @@ export function listFilesWithRg(
           }
           // Flush residual line only on clean exit.
           if (passBuf) {
-            if (processLine(passBuf)) {
+            if (processLine(passBuf, attemptRanker)) {
               passFileCount++
             }
           }
@@ -233,6 +252,14 @@ export function listFilesWithRg(
         child.stderr!.on('data', handleStderrData)
         child.once('error', handleError)
         child.once('close', handleClose)
+      })
+
+    const runPass = (args: string[]): Promise<void> =>
+      runPassOnce(args).catch((error: unknown) => {
+        if (!(error instanceof RipgrepLaunchFailureError) || signal?.aborted || done) {
+          throw error
+        }
+        return runPassOnce(args)
       })
 
     const killSurvivors = (reason: string): void => {
@@ -274,20 +301,21 @@ export function listFilesWithRg(
     }
     signal?.addEventListener('abort', onAbort, { once: true })
 
-    const passes = ranker
-      ? runPass(ignoredPass)
-      : (() => {
-          const primaryPass = runPass(primary)
-          return maxResults === undefined
-            ? children[0]?.child.pid === undefined
-              ? primaryPass
-              : Promise.all([primaryPass, runPass(ignoredPass)])
-            : // Why: deterministic primary-first budgeting prevents a large ignored
-              // tree from starving ordinary source paths on a remote host.
-              primaryPass.then(() =>
-                files.size < maxResults ? runPass(ignoredPass) : Promise.resolve()
-              )
-        })()
+    const passes =
+      searchQuery !== undefined
+        ? runPass(ignoredPass)
+        : (() => {
+            const primaryPass = runPass(primary)
+            return maxResults === undefined
+              ? children[0]?.child.pid === undefined
+                ? primaryPass.then(() => runPass(ignoredPass))
+                : Promise.all([primaryPass, runPass(ignoredPass)])
+              : // Why: deterministic primary-first budgeting prevents a large ignored
+                // tree from starving ordinary source paths on a remote host.
+                primaryPass.then(() =>
+                  files.size < maxResults ? runPass(ignoredPass) : Promise.resolve()
+                )
+          })()
 
     passes
       .then(() => {
@@ -296,7 +324,7 @@ export function listFilesWithRg(
         }
         done = true
         signal?.removeEventListener('abort', onAbort)
-        resolve(ranker ? ranker.result().paths : Array.from(files))
+        resolve(rankedPaths ?? Array.from(files))
       })
       .catch((err) => {
         if (done) {

--- a/src/shared/ripgrep-process-availability.test.ts
+++ b/src/shared/ripgrep-process-availability.test.ts
@@ -6,6 +6,7 @@ import {
   absorbPendingRipgrepSpawnError,
   isRipgrepUnavailableExit,
   isRipgrepSpawnCwdUsable,
+  isTransientRipgrepSpawnError,
   killSpawnedRipgrepProcess
 } from './ripgrep-process-availability'
 
@@ -86,5 +87,21 @@ describe('ripgrep process availability', () => {
 
     expect(started.listenerCount('error')).toBe(0)
     expect(observed.listenerCount('error')).toBe(0)
+  })
+
+  it('separates transient fork/exec pressure from a missing ripgrep binary', () => {
+    for (const code of ['EAGAIN', 'EMFILE', 'ENFILE', 'ENOMEM', 'ETXTBSY']) {
+      expect(isTransientRipgrepSpawnError(Object.assign(new Error('spawn rg'), { code }))).toBe(
+        true
+      )
+    }
+    for (const error of [
+      Object.assign(new Error('spawn rg ENOENT'), { code: 'ENOENT' }),
+      Object.assign(new Error('spawn rg EACCES'), { code: 'EACCES' }),
+      new Error('spawn rg'),
+      null
+    ]) {
+      expect(isTransientRipgrepSpawnError(error)).toBe(false)
+    }
   })
 })

--- a/src/shared/ripgrep-process-availability.ts
+++ b/src/shared/ripgrep-process-availability.ts
@@ -12,6 +12,28 @@ export class RipgrepUnavailableError extends Error {
   }
 }
 
+/** rg could not be launched even though ripgrep itself is installed; retryable, never install guidance. */
+export class RipgrepLaunchFailureError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'RipgrepLaunchFailureError'
+  }
+}
+
+// Why: fork/exec pressure (out of processes, fds, or memory) is not evidence that ripgrep is missing.
+const TRANSIENT_SPAWN_ERROR_CODES: ReadonlySet<string> = new Set([
+  'EAGAIN',
+  'EMFILE',
+  'ENFILE',
+  'ENOMEM',
+  'ETXTBSY'
+])
+
+export function isTransientRipgrepSpawnError(error: unknown): boolean {
+  const code = (error as { code?: unknown } | null | undefined)?.code
+  return typeof code === 'string' && TRANSIENT_SPAWN_ERROR_CODES.has(code)
+}
+
 function ignoreRipgrepSpawnError(): void {}
 
 export function killSpawnedRipgrepProcess(child: ChildProcess): boolean {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​250 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​248 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​176 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​59 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​117 |

<!-- /orca-pr-loc -->

## Problem

When Quick Open or file listing hit temporary fork/exec pressure (out of file descriptors, processes, or memory), ripgrep would fail to spawn. The code treated all spawn errors equally, incorrectly telling users "install ripgrep" when it was already installed — the system just couldn't fork another process at that moment.

## Solution

Distinguish transient resource errors (EAGAIN, EMFILE, ENFILE, ENOMEM, ETXTBSY) from permanent ones (ENOENT, EACCES). On a transient error, retry once before surfacing any error. Only show install guidance if the retry fails or the error is genuinely permanent.

## ELI5

When your computer is too busy to start a new process, Quick Open used to say "ripgrep is missing" even though it was installed. Now it retries once, and only shows the install message if ripgrep is actually missing.

## What Changed

- Added `RipgrepLaunchFailureError` to mark retryable launch failures (distinct from missing binary).
- Added `isTransientRipgrepSpawnError()` to identify fork/exec pressure vs permanent errors.
- `searchQuickOpenFilePaths()` and `listFilesWithRg()` retry transient spawn failures once, respecting abort signals so superseded queries don't retry.
- `checkRgAvailable()` gains optional rejection of transient failures instead of silently returning false.

## Why

One-off fork/exec pressure should not blank Quick Open or demand ripgrep installation. Transient errors are survivable with a retry — the user's system likely recovers by the next keystroke. This prevents false "install ripgrep" messages and improves experience during system load.

## Linked Issue

Fixes #

## Visual Proof

N/A — Internal error handling improvement; no user-visible UI changes under normal conditions. Only affects error messages in edge cases.

## Testing

Automated tests added covering: transient error retry success, permanent ENOENT/EACCES errors, abort-signal cancellation, WSL-specific retries, and both local and remote paths. Tests verify install guidance only appears on genuine unavailability, not fork/exec pressure.

- [x] Automated tests added/updated, or explained why not below
- [ ] I manually tested these changes locally

## AI Disclosure

N/A

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Cross-platform**: Retry logic handles native, WSL, and SSH hosts (tested via relay tests).
- **Remote wire compatibility**: No RPC or stream frame changes.
- **Performance**: Adds one retry on transient errors only; no regression in normal cases.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)