### PR TITLE
Fix rebase race by fetching to private ref before rebasing

### DIFF
--- a/docs/reference/git-compatibility.md
+++ b/docs/reference/git-compatibility.md
@@ -33,13 +33,14 @@ authority.
 
 ## Current Capabilities
 
-| Capability              | Preferred behavior                                | Compatibility behavior                                                                  |
-| ----------------------- | ------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| `worktree-list-z`       | NUL-delimited worktree paths with `prunable` marks | Line-block parser for Git before `worktree list -z` (2.36); the `prunable`/`locked` annotations still parse on Git 2.31–2.35, and a path-existence probe restores `prunable` detection for Git before 2.31 |
-| `rev-parse-path-format` | Absolute repo metadata paths                      | Resolve legacy relative output against the scanned repo                                 |
-| `for-each-ref-exclude`  | Exclude remote HEAD before the output limit       | Request extra refs, then filter remote HEAD in Orca                                     |
-| `merge-tree-write-tree` | Derive real-merge conflicts and no-op tree proofs | Omit the conflict summary and keep conservative branch cleanup behavior before Git 2.38 |
-| `merge-tree-merge-base` | Supply the already-resolved merge base            | Use the older two-commit `merge-tree --write-tree` form                                 |
+| Capability                  | Preferred behavior                                                      | Compatibility behavior                                                                                                                                                                                     |
+| --------------------------- | ----------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `fetch-no-write-fetch-head` | Fetch a private rebase ref without changing worktree-local `FETCH_HEAD` | Serialize all Orca fetch/pull operations per worktree Git directory before Git 2.29                                                                                                                        |
+| `worktree-list-z`           | NUL-delimited worktree paths with `prunable` marks                      | Line-block parser for Git before `worktree list -z` (2.36); the `prunable`/`locked` annotations still parse on Git 2.31–2.35, and a path-existence probe restores `prunable` detection for Git before 2.31 |
+| `rev-parse-path-format`     | Absolute repo metadata paths                                            | Resolve legacy relative output against the scanned repo                                                                                                                                                    |
+| `for-each-ref-exclude`      | Exclude remote HEAD before the output limit                             | Request extra refs, then filter remote HEAD in Orca                                                                                                                                                        |
+| `merge-tree-write-tree`     | Derive real-merge conflicts and no-op tree proofs                       | Omit the conflict summary and keep conservative branch cleanup behavior before Git 2.38                                                                                                                    |
+| `merge-tree-merge-base`     | Supply the already-resolved merge base                                  | Use the older two-commit `merge-tree --write-tree` form                                                                                                                                                    |
 
 ## Why Not `simple-git`
 
@@ -54,7 +55,7 @@ capability problem.
 ## CI Contract
 
 PR checks run the capability contract against real Git 2.25.5, 2.38.1, and
-2.49.1 binaries. This spans the core-workflow baseline, the transitional
+2.49.1 binaries. This spans the pre-2.29 serialized `FETCH_HEAD` fallback, the transitional
 `merge-tree --write-tree` behavior before `--merge-base`, and current Git.
 
 Keep the unit tests alongside that matrix. They cover concurrent probes,

--- a/src/main/git/remote-rebase.ts
+++ b/src/main/git/remote-rebase.ts
@@ -46,7 +46,11 @@ export async function gitPullRebaseFromBase(
       }
       // Why: concurrent fetches can replace FETCH_HEAD and remote-tracking refs between fetch and rebase.
       rebaseRef = `refs/orca/rebase/${randomUUID()}`
-      const fetchArgs = [source.remoteName, `+refs/heads/${source.branchName}:${rebaseRef}`]
+      const fetchArgs = [
+        source.remoteName,
+        `+refs/heads/${source.branchName}:${rebaseRef}`,
+        `+refs/heads/${source.branchName}:refs/remotes/${source.displayName}`
+      ]
       await withLocalGitCapabilityCacheForExecution(
         { cwd: worktreePath, ...options },
         (capabilities) =>

--- a/src/main/git/remote-rebase.ts
+++ b/src/main/git/remote-rebase.ts
@@ -1,11 +1,13 @@
 import { randomUUID } from 'node:crypto'
 import { normalizeGitErrorMessage } from '../../shared/git-remote-error'
+import { isNoWriteFetchHeadUnsupportedError } from '../../shared/git-fetch-head-capability'
 import {
   REBASE_SOURCE_FETCH_TIMEOUT_MS,
   resolveGitRemoteRebaseSource
 } from '../../shared/git-rebase-source'
 import type { GitRuntimeOptions } from './git-runtime-options'
 import { gitOptionsForWorktree } from './git-runtime-options'
+import { withLocalGitCapabilityCacheForExecution } from './git-capability-state'
 import { gitExecFileAsync } from './runner'
 import { runWithGitReadCacheInvalidation } from './status'
 
@@ -15,41 +17,72 @@ export async function gitPullRebaseFromBase(
   options: GitRuntimeOptions = {}
 ): Promise<void> {
   await runWithGitReadCacheInvalidation(async () => {
+    const operationOptions = {
+      ...gitOptionsForWorktree(worktreePath, options),
+      terminationBarrier: true,
+      captureWslLoginShellOutput: true
+    }
     let rebaseRef: string | null = null
     try {
       const source = await resolveGitRemoteRebaseSource(
-        (args) => gitExecFileAsync(args, gitOptionsForWorktree(worktreePath, options)),
+        (args) => gitExecFileAsync(args, operationOptions),
         baseRef
       )
       let forkPoint: string | null = null
+      let hasHead = true
       try {
         const { stdout } = await gitExecFileAsync(
           ['merge-base', '--fork-point', `refs/remotes/${source.displayName}`, 'HEAD'],
-          gitOptionsForWorktree(worktreePath, options)
+          operationOptions
         )
         forkPoint = stdout.trim() || null
       } catch {
         // A first fetch or an unhelpful reflog falls back to Git's merge-base behavior.
+        try {
+          await gitExecFileAsync(['rev-parse', '--verify', 'HEAD'], operationOptions)
+        } catch {
+          hasHead = false
+        }
       }
       // Why: concurrent fetches can replace FETCH_HEAD and remote-tracking refs between fetch and rebase.
       rebaseRef = `refs/orca/rebase/${randomUUID()}`
-      await gitExecFileAsync(
-        ['fetch', source.remoteName, `+refs/heads/${source.branchName}:${rebaseRef}`],
-        { ...gitOptionsForWorktree(worktreePath, options), timeout: REBASE_SOURCE_FETCH_TIMEOUT_MS }
+      const fetchArgs = [source.remoteName, `+refs/heads/${source.branchName}:${rebaseRef}`]
+      await withLocalGitCapabilityCacheForExecution(
+        { cwd: worktreePath, ...options },
+        (capabilities) =>
+          capabilities.runWithFallback(
+            'fetch-no-write-fetch-head',
+            () =>
+              gitExecFileAsync(['fetch', '--no-write-fetch-head', ...fetchArgs], {
+                ...operationOptions,
+                timeout: REBASE_SOURCE_FETCH_TIMEOUT_MS
+              }),
+            () =>
+              gitExecFileAsync(['fetch', ...fetchArgs], {
+                ...operationOptions,
+                timeout: REBASE_SOURCE_FETCH_TIMEOUT_MS
+              }),
+            isNoWriteFetchHeadUnsupportedError
+          )
       )
       await gitExecFileAsync(
-        forkPoint ? ['rebase', '--onto', rebaseRef, forkPoint] : ['rebase', rebaseRef],
-        gitOptionsForWorktree(worktreePath, options)
+        hasHead
+          ? forkPoint
+            ? ['rebase', '--onto', rebaseRef, forkPoint]
+            : ['rebase', rebaseRef]
+          : ['merge', '--ff-only', rebaseRef],
+        operationOptions
       )
     } catch (error) {
       throw new Error(normalizeGitErrorMessage(error, 'pull'))
     } finally {
       if (rebaseRef) {
         try {
-          await gitExecFileAsync(
-            ['update-ref', '-d', rebaseRef],
-            gitOptionsForWorktree(worktreePath, options)
+          const { signal: _abortedSignal, ...cleanupOptions } = gitOptionsForWorktree(
+            worktreePath,
+            options
           )
+          await gitExecFileAsync(['update-ref', '-d', rebaseRef], cleanupOptions)
         } catch {
           // Cleanup must not hide the fetch or rebase result.
         }

--- a/src/main/git/remote-rebase.ts
+++ b/src/main/git/remote-rebase.ts
@@ -1,0 +1,59 @@
+import { randomUUID } from 'node:crypto'
+import { normalizeGitErrorMessage } from '../../shared/git-remote-error'
+import {
+  REBASE_SOURCE_FETCH_TIMEOUT_MS,
+  resolveGitRemoteRebaseSource
+} from '../../shared/git-rebase-source'
+import type { GitRuntimeOptions } from './git-runtime-options'
+import { gitOptionsForWorktree } from './git-runtime-options'
+import { gitExecFileAsync } from './runner'
+import { runWithGitReadCacheInvalidation } from './status'
+
+export async function gitPullRebaseFromBase(
+  worktreePath: string,
+  baseRef: string,
+  options: GitRuntimeOptions = {}
+): Promise<void> {
+  await runWithGitReadCacheInvalidation(async () => {
+    let rebaseRef: string | null = null
+    try {
+      const source = await resolveGitRemoteRebaseSource(
+        (args) => gitExecFileAsync(args, gitOptionsForWorktree(worktreePath, options)),
+        baseRef
+      )
+      let forkPoint: string | null = null
+      try {
+        const { stdout } = await gitExecFileAsync(
+          ['merge-base', '--fork-point', `refs/remotes/${source.displayName}`, 'HEAD'],
+          gitOptionsForWorktree(worktreePath, options)
+        )
+        forkPoint = stdout.trim() || null
+      } catch {
+        // A first fetch or an unhelpful reflog falls back to Git's merge-base behavior.
+      }
+      // Why: concurrent fetches can replace FETCH_HEAD and remote-tracking refs between fetch and rebase.
+      rebaseRef = `refs/orca/rebase/${randomUUID()}`
+      await gitExecFileAsync(
+        ['fetch', source.remoteName, `+refs/heads/${source.branchName}:${rebaseRef}`],
+        { ...gitOptionsForWorktree(worktreePath, options), timeout: REBASE_SOURCE_FETCH_TIMEOUT_MS }
+      )
+      await gitExecFileAsync(
+        forkPoint ? ['rebase', '--onto', rebaseRef, forkPoint] : ['rebase', rebaseRef],
+        gitOptionsForWorktree(worktreePath, options)
+      )
+    } catch (error) {
+      throw new Error(normalizeGitErrorMessage(error, 'pull'))
+    } finally {
+      if (rebaseRef) {
+        try {
+          await gitExecFileAsync(
+            ['update-ref', '-d', rebaseRef],
+            gitOptionsForWorktree(worktreePath, options)
+          )
+        } catch {
+          // Cleanup must not hide the fetch or rebase result.
+        }
+      }
+    }
+  })
+}

--- a/src/main/git/remote-rebase.ts
+++ b/src/main/git/remote-rebase.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import { normalizeGitErrorMessage } from '../../shared/git-remote-error'
 import { isNoWriteFetchHeadUnsupportedError } from '../../shared/git-fetch-head-capability'
+import { runWithGitWorktreeOperationLock } from '../../shared/git-worktree-operation-lock'
 import {
   REBASE_SOURCE_FETCH_TIMEOUT_MS,
   resolveGitRemoteRebaseSource
@@ -15,6 +16,16 @@ export async function gitPullRebaseFromBase(
   worktreePath: string,
   baseRef: string,
   options: GitRuntimeOptions = {}
+): Promise<void> {
+  await runWithGitWorktreeOperationLock(worktreePath, options.signal, () =>
+    gitPullRebaseFromBaseUnlocked(worktreePath, baseRef, options)
+  )
+}
+
+async function gitPullRebaseFromBaseUnlocked(
+  worktreePath: string,
+  baseRef: string,
+  options: GitRuntimeOptions
 ): Promise<void> {
   await runWithGitReadCacheInvalidation(async () => {
     const operationOptions = {

--- a/src/main/git/remote.test.ts
+++ b/src/main/git/remote.test.ts
@@ -543,7 +543,8 @@ describe('git remote operations', () => {
           'fetch',
           '--no-write-fetch-head',
           'upstream',
-          expect.stringMatching(/^\+refs\/heads\/main:refs\/orca\/rebase\//)
+          expect.stringMatching(/^\+refs\/heads\/main:refs\/orca\/rebase\//),
+          '+refs/heads/main:refs/remotes/upstream/main'
         ],
         { ...REBASE_OPERATION_OPTIONS, timeout: REBASE_SOURCE_FETCH_TIMEOUT_MS }
       ],
@@ -558,6 +559,9 @@ describe('git remote operations', () => {
     const rebasedRef = gitExecFileAsyncMock.mock.calls[4][0][2]
     const deletedRef = gitExecFileAsyncMock.mock.calls[5][0][2]
     expect(fetchRefspec).toBe(`+refs/heads/main:${rebasedRef}`)
+    expect(gitExecFileAsyncMock.mock.calls[3][0][4]).toBe(
+      '+refs/heads/main:refs/remotes/upstream/main'
+    )
     expect(deletedRef).toBe(rebasedRef)
   })
 
@@ -597,7 +601,8 @@ describe('git remote operations', () => {
         'fetch',
         '--no-write-fetch-head',
         'upstream',
-        expect.stringMatching(/^\+refs\/heads\/main:refs\/orca\/rebase\//)
+        expect.stringMatching(/^\+refs\/heads\/main:refs\/orca\/rebase\//),
+        '+refs/heads/main:refs/remotes/upstream/main'
       ],
       { ...REBASE_OPERATION_OPTIONS, timeout: REBASE_SOURCE_FETCH_TIMEOUT_MS }
     )
@@ -658,10 +663,10 @@ describe('git remote operations', () => {
 
     await gitPullRebaseFromBase('/repo', 'upstream/main')
 
-    const preferredRefspec = gitExecFileAsyncMock.mock.calls[3][0][3]
+    const preferredRefspecs = gitExecFileAsyncMock.mock.calls[3][0].slice(3)
     expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(
       5,
-      ['fetch', 'upstream', preferredRefspec],
+      ['fetch', 'upstream', ...preferredRefspecs],
       { ...REBASE_OPERATION_OPTIONS, timeout: REBASE_SOURCE_FETCH_TIMEOUT_MS }
     )
   })

--- a/src/main/git/remote.test.ts
+++ b/src/main/git/remote.test.ts
@@ -8,6 +8,7 @@ vi.mock('./runner', () => ({
   gitExecFileAsync: gitExecFileAsyncMock
 }))
 
+import { REBASE_SOURCE_FETCH_TIMEOUT_MS } from '../../shared/git-rebase-source'
 import { gitFastForward, gitFetch, gitPull, gitPullRebaseFromBase, gitPush } from './remote'
 
 describe('git remote operations', () => {
@@ -527,12 +528,8 @@ describe('git remote operations', () => {
       [['check-ref-format', '--branch', 'main'], { cwd: '/repo' }],
       [['merge-base', '--fork-point', 'refs/remotes/upstream/main', 'HEAD'], { cwd: '/repo' }],
       [
-        [
-          'fetch',
-          'upstream',
-          expect.stringMatching(/^\+refs\/heads\/main:refs\/orca\/rebase\//)
-        ],
-        { cwd: '/repo' }
+        ['fetch', 'upstream', expect.stringMatching(/^\+refs\/heads\/main:refs\/orca\/rebase\//)],
+        { cwd: '/repo', timeout: REBASE_SOURCE_FETCH_TIMEOUT_MS }
       ],
       [
         ['rebase', '--onto', expect.stringMatching(/^refs\/orca\/rebase\//), 'fork-point'],
@@ -579,12 +576,8 @@ describe('git remote operations', () => {
 
     expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(
       4,
-      [
-        'fetch',
-        'upstream',
-        expect.stringMatching(/^\+refs\/heads\/main:refs\/orca\/rebase\//)
-      ],
-      { cwd: '/repo' }
+      ['fetch', 'upstream', expect.stringMatching(/^\+refs\/heads\/main:refs\/orca\/rebase\//)],
+      { cwd: '/repo', timeout: REBASE_SOURCE_FETCH_TIMEOUT_MS }
     )
   })
 
@@ -602,11 +595,9 @@ describe('git remote operations', () => {
     )
 
     const rebasedRef = gitExecFileAsyncMock.mock.calls[4][0][2]
-    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(
-      6,
-      ['update-ref', '-d', rebasedRef],
-      { cwd: '/repo' }
-    )
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(6, ['update-ref', '-d', rebasedRef], {
+      cwd: '/repo'
+    })
   })
 
   it('normalizes pull authentication errors to a friendly message', async () => {

--- a/src/main/git/remote.test.ts
+++ b/src/main/git/remote.test.ts
@@ -9,11 +9,19 @@ vi.mock('./runner', () => ({
 }))
 
 import { REBASE_SOURCE_FETCH_TIMEOUT_MS } from '../../shared/git-rebase-source'
+import { clearGitCapabilityStateForTests } from './git-capability-state'
 import { gitFastForward, gitFetch, gitPull, gitPullRebaseFromBase, gitPush } from './remote'
+
+const REBASE_OPERATION_OPTIONS = {
+  cwd: '/repo',
+  terminationBarrier: true,
+  captureWslLoginShellOutput: true
+}
 
 describe('git remote operations', () => {
   beforeEach(() => {
     gitExecFileAsyncMock.mockReset()
+    clearGitCapabilityStateForTests()
   })
 
   it('pushes to origin when no upstream is configured', async () => {
@@ -524,21 +532,29 @@ describe('git remote operations', () => {
     await gitPullRebaseFromBase('/repo', 'upstream/main')
 
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
-      [['remote'], { cwd: '/repo' }],
-      [['check-ref-format', '--branch', 'main'], { cwd: '/repo' }],
-      [['merge-base', '--fork-point', 'refs/remotes/upstream/main', 'HEAD'], { cwd: '/repo' }],
+      [['remote'], REBASE_OPERATION_OPTIONS],
+      [['check-ref-format', '--branch', 'main'], REBASE_OPERATION_OPTIONS],
       [
-        ['fetch', 'upstream', expect.stringMatching(/^\+refs\/heads\/main:refs\/orca\/rebase\//)],
-        { cwd: '/repo', timeout: REBASE_SOURCE_FETCH_TIMEOUT_MS }
+        ['merge-base', '--fork-point', 'refs/remotes/upstream/main', 'HEAD'],
+        REBASE_OPERATION_OPTIONS
+      ],
+      [
+        [
+          'fetch',
+          '--no-write-fetch-head',
+          'upstream',
+          expect.stringMatching(/^\+refs\/heads\/main:refs\/orca\/rebase\//)
+        ],
+        { ...REBASE_OPERATION_OPTIONS, timeout: REBASE_SOURCE_FETCH_TIMEOUT_MS }
       ],
       [
         ['rebase', '--onto', expect.stringMatching(/^refs\/orca\/rebase\//), 'fork-point'],
-        { cwd: '/repo' }
+        REBASE_OPERATION_OPTIONS
       ],
       [['update-ref', '-d', expect.stringMatching(/^refs\/orca\/rebase\//)], { cwd: '/repo' }]
     ])
 
-    const fetchRefspec = gitExecFileAsyncMock.mock.calls[3][0][2]
+    const fetchRefspec = gitExecFileAsyncMock.mock.calls[3][0][3]
     const rebasedRef = gitExecFileAsyncMock.mock.calls[4][0][2]
     const deletedRef = gitExecFileAsyncMock.mock.calls[5][0][2]
     expect(fetchRefspec).toBe(`+refs/heads/main:${rebasedRef}`)
@@ -559,7 +575,7 @@ describe('git remote operations', () => {
     expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(
       5,
       ['rebase', '--onto', expect.stringMatching(/^refs\/orca\/rebase\//), 'fork-point'],
-      { cwd: '/repo' }
+      REBASE_OPERATION_OPTIONS
     )
   })
 
@@ -568,6 +584,7 @@ describe('git remote operations', () => {
       .mockResolvedValueOnce({ stdout: 'upstream\n', stderr: '' })
       .mockResolvedValueOnce({ stdout: '', stderr: '' })
       .mockRejectedValueOnce(new Error('missing remote-tracking ref'))
+      .mockResolvedValueOnce({ stdout: 'head\n', stderr: '' })
       .mockResolvedValueOnce({ stdout: '', stderr: '' })
       .mockResolvedValueOnce({ stdout: '', stderr: '' })
       .mockResolvedValueOnce({ stdout: '', stderr: '' })
@@ -575,29 +592,78 @@ describe('git remote operations', () => {
     await expect(gitPullRebaseFromBase('/repo', 'upstream/main')).resolves.toBeUndefined()
 
     expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(
-      4,
-      ['fetch', 'upstream', expect.stringMatching(/^\+refs\/heads\/main:refs\/orca\/rebase\//)],
-      { cwd: '/repo', timeout: REBASE_SOURCE_FETCH_TIMEOUT_MS }
+      5,
+      [
+        'fetch',
+        '--no-write-fetch-head',
+        'upstream',
+        expect.stringMatching(/^\+refs\/heads\/main:refs\/orca\/rebase\//)
+      ],
+      { ...REBASE_OPERATION_OPTIONS, timeout: REBASE_SOURCE_FETCH_TIMEOUT_MS }
+    )
+  })
+
+  it('fast-forwards an unborn branch from the fetched private ref', async () => {
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'upstream\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockRejectedValueOnce(new Error('unborn HEAD'))
+      .mockRejectedValueOnce(new Error('unborn HEAD'))
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+    await gitPullRebaseFromBase('/repo', 'upstream/main')
+
+    const fetchedRef = gitExecFileAsyncMock.mock.calls[4][0][3]
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(
+      6,
+      ['merge', '--ff-only', fetchedRef.slice(fetchedRef.indexOf(':') + 1)],
+      REBASE_OPERATION_OPTIONS
     )
   })
 
   it('removes the private ref when rebase fails', async () => {
+    const controller = new AbortController()
     gitExecFileAsyncMock
       .mockResolvedValueOnce({ stdout: 'upstream\n', stderr: '' })
       .mockResolvedValueOnce({ stdout: '', stderr: '' })
       .mockResolvedValueOnce({ stdout: 'fork-point\n', stderr: '' })
       .mockResolvedValueOnce({ stdout: '', stderr: '' })
-      .mockRejectedValueOnce(new Error('fatal: rebase conflict'))
+      .mockImplementationOnce(async () => {
+        controller.abort()
+        throw new Error('fatal: rebase conflict')
+      })
       .mockResolvedValueOnce({ stdout: '', stderr: '' })
 
-    await expect(gitPullRebaseFromBase('/repo', 'upstream/main')).rejects.toThrow(
-      'fatal: rebase conflict'
-    )
+    await expect(
+      gitPullRebaseFromBase('/repo', 'upstream/main', { signal: controller.signal })
+    ).rejects.toThrow('fatal: rebase conflict')
 
     const rebasedRef = gitExecFileAsyncMock.mock.calls[4][0][2]
     expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(6, ['update-ref', '-d', rebasedRef], {
       cwd: '/repo'
     })
+  })
+
+  it('serializes the private fetch when Git cannot avoid writing FETCH_HEAD', async () => {
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'upstream\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'fork-point\n', stderr: '' })
+      .mockRejectedValueOnce(new Error("error: unknown option `no-write-fetch-head'"))
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+    await gitPullRebaseFromBase('/repo', 'upstream/main')
+
+    const preferredRefspec = gitExecFileAsyncMock.mock.calls[3][0][3]
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(
+      5,
+      ['fetch', 'upstream', preferredRefspec],
+      { ...REBASE_OPERATION_OPTIONS, timeout: REBASE_SOURCE_FETCH_TIMEOUT_MS }
+    )
   })
 
   it('normalizes pull authentication errors to a friendly message', async () => {

--- a/src/main/git/remote.test.ts
+++ b/src/main/git/remote.test.ts
@@ -511,9 +511,12 @@ describe('git remote operations', () => {
     ])
   })
 
-  it('rebases from the selected remote base ref', async () => {
+  it('fetches to a private ref then rebases from the selected remote base ref', async () => {
     gitExecFileAsyncMock
       .mockResolvedValueOnce({ stdout: 'origin\nupstream\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'fork-point\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
       .mockResolvedValueOnce({ stdout: '', stderr: '' })
       .mockResolvedValueOnce({ stdout: '', stderr: '' })
 
@@ -522,20 +525,86 @@ describe('git remote operations', () => {
     expect(gitExecFileAsyncMock.mock.calls).toEqual([
       [['remote'], { cwd: '/repo' }],
       [['check-ref-format', '--branch', 'main'], { cwd: '/repo' }],
-      [['pull', '--rebase', 'upstream', 'main'], { cwd: '/repo' }]
+      [['merge-base', '--fork-point', 'refs/remotes/upstream/main', 'HEAD'], { cwd: '/repo' }],
+      [
+        [
+          'fetch',
+          'upstream',
+          expect.stringMatching(/^\+refs\/heads\/main:refs\/orca\/rebase\//)
+        ],
+        { cwd: '/repo' }
+      ],
+      [
+        ['rebase', '--onto', expect.stringMatching(/^refs\/orca\/rebase\//), 'fork-point'],
+        { cwd: '/repo' }
+      ],
+      [['update-ref', '-d', expect.stringMatching(/^refs\/orca\/rebase\//)], { cwd: '/repo' }]
     ])
+
+    const fetchRefspec = gitExecFileAsyncMock.mock.calls[3][0][2]
+    const rebasedRef = gitExecFileAsyncMock.mock.calls[4][0][2]
+    const deletedRef = gitExecFileAsyncMock.mock.calls[5][0][2]
+    expect(fetchRefspec).toBe(`+refs/heads/main:${rebasedRef}`)
+    expect(deletedRef).toBe(rebasedRef)
   })
 
   it('uses the longest configured remote name when rebasing from a base ref', async () => {
     gitExecFileAsyncMock
       .mockResolvedValueOnce({ stdout: 'fork\nfork/team\n', stderr: '' })
       .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'fork-point\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
       .mockResolvedValueOnce({ stdout: '', stderr: '' })
 
     await gitPullRebaseFromBase('/repo', 'fork/team/feature/base')
 
-    expect(gitExecFileAsyncMock).toHaveBeenLastCalledWith(
-      ['pull', '--rebase', 'fork/team', 'feature/base'],
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(
+      5,
+      ['rebase', '--onto', expect.stringMatching(/^refs\/orca\/rebase\//), 'fork-point'],
+      { cwd: '/repo' }
+    )
+  })
+
+  it('rebases when the selected remote has not been fetched before', async () => {
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'upstream\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockRejectedValueOnce(new Error('missing remote-tracking ref'))
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+    await expect(gitPullRebaseFromBase('/repo', 'upstream/main')).resolves.toBeUndefined()
+
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(
+      4,
+      [
+        'fetch',
+        'upstream',
+        expect.stringMatching(/^\+refs\/heads\/main:refs\/orca\/rebase\//)
+      ],
+      { cwd: '/repo' }
+    )
+  })
+
+  it('removes the private ref when rebase fails', async () => {
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'upstream\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({ stdout: 'fork-point\n', stderr: '' })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockRejectedValueOnce(new Error('fatal: rebase conflict'))
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+    await expect(gitPullRebaseFromBase('/repo', 'upstream/main')).rejects.toThrow(
+      'fatal: rebase conflict'
+    )
+
+    const rebasedRef = gitExecFileAsyncMock.mock.calls[4][0][2]
+    expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(
+      6,
+      ['update-ref', '-d', rebasedRef],
       { cwd: '/repo' }
     )
   })

--- a/src/main/git/remote.ts
+++ b/src/main/git/remote.ts
@@ -1,17 +1,17 @@
-import { randomUUID } from 'node:crypto'
 import {
   normalizeGitErrorMessage,
   runPullWithDivergenceFallback
 } from '../../shared/git-remote-error'
 import { resolveEffectiveGitUpstream } from '../../shared/git-effective-upstream'
 import { gitRefTargetsBranchOnRemote } from '../../shared/git-remote-branch-name'
-import { resolveGitRemoteRebaseSource } from '../../shared/git-rebase-source'
 import type { GitPushTarget } from '../../shared/worktree/types'
 import type { GitRuntimeOptions } from './git-runtime-options'
 import { gitOptionsForWorktree } from './git-runtime-options'
 import { validateGitPushTarget } from './push-target-validation'
 import { gitExecFileAsync } from './runner'
 import { runWithGitReadCacheInvalidation } from './status'
+
+export { gitPullRebaseFromBase } from './remote-rebase'
 
 async function getConfiguredPushTarget(
   worktreePath: string,
@@ -271,59 +271,6 @@ export async function gitFastForward(
   await runWithGitReadCacheInvalidation(() =>
     gitPullWithArgs(worktreePath, ['--ff-only'], pushTarget, options)
   )
-}
-
-export async function gitPullRebaseFromBase(
-  worktreePath: string,
-  baseRef: string,
-  options: GitRuntimeOptions = {}
-): Promise<void> {
-  await runWithGitReadCacheInvalidation(async () => {
-    let rebaseRef: string | null = null
-    try {
-      const source = await resolveGitRemoteRebaseSource(
-        (args) => gitExecFileAsync(args, gitOptionsForWorktree(worktreePath, options)),
-        baseRef
-      )
-      let forkPoint: string | null = null
-      try {
-        const { stdout } = await gitExecFileAsync(
-          ['merge-base', '--fork-point', `refs/remotes/${source.displayName}`, 'HEAD'],
-          gitOptionsForWorktree(worktreePath, options)
-        )
-        forkPoint = stdout.trim() || null
-      } catch {
-        // A first fetch or an unhelpful reflog falls back to Git's merge-base behavior.
-      }
-      // Why: concurrent fetches can replace FETCH_HEAD and remote-tracking refs between fetch and rebase.
-      rebaseRef = `refs/orca/rebase/${randomUUID()}`
-      await gitExecFileAsync(
-        [
-          'fetch',
-          source.remoteName,
-          `+refs/heads/${source.branchName}:${rebaseRef}`
-        ],
-        gitOptionsForWorktree(worktreePath, options)
-      )
-      await gitExecFileAsync(
-        forkPoint ? ['rebase', '--onto', rebaseRef, forkPoint] : ['rebase', rebaseRef],
-        gitOptionsForWorktree(worktreePath, options)
-      )
-    } catch (error) {
-      throw new Error(normalizeGitErrorMessage(error, 'pull'))
-    } finally {
-      if (rebaseRef) {
-        try {
-          await gitExecFileAsync(
-            ['update-ref', '-d', rebaseRef],
-            gitOptionsForWorktree(worktreePath, options)
-          )
-        } catch {
-          // Cleanup must not hide the fetch or rebase result.
-        }
-      }
-    }
-  })
 }
 
 export async function gitFetch(

--- a/src/main/git/remote.ts
+++ b/src/main/git/remote.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto'
 import {
   normalizeGitErrorMessage,
   runPullWithDivergenceFallback
@@ -278,17 +279,49 @@ export async function gitPullRebaseFromBase(
   options: GitRuntimeOptions = {}
 ): Promise<void> {
   await runWithGitReadCacheInvalidation(async () => {
+    let rebaseRef: string | null = null
     try {
       const source = await resolveGitRemoteRebaseSource(
         (args) => gitExecFileAsync(args, gitOptionsForWorktree(worktreePath, options)),
         baseRef
       )
+      let forkPoint: string | null = null
+      try {
+        const { stdout } = await gitExecFileAsync(
+          ['merge-base', '--fork-point', `refs/remotes/${source.displayName}`, 'HEAD'],
+          gitOptionsForWorktree(worktreePath, options)
+        )
+        forkPoint = stdout.trim() || null
+      } catch {
+        // A first fetch or an unhelpful reflog falls back to Git's merge-base behavior.
+      }
+      // Why: concurrent fetches can replace FETCH_HEAD and remote-tracking refs between fetch and rebase.
+      rebaseRef = `refs/orca/rebase/${randomUUID()}`
       await gitExecFileAsync(
-        ['pull', '--rebase', source.remoteName, source.branchName],
+        [
+          'fetch',
+          source.remoteName,
+          `+refs/heads/${source.branchName}:${rebaseRef}`
+        ],
+        gitOptionsForWorktree(worktreePath, options)
+      )
+      await gitExecFileAsync(
+        forkPoint ? ['rebase', '--onto', rebaseRef, forkPoint] : ['rebase', rebaseRef],
         gitOptionsForWorktree(worktreePath, options)
       )
     } catch (error) {
       throw new Error(normalizeGitErrorMessage(error, 'pull'))
+    } finally {
+      if (rebaseRef) {
+        try {
+          await gitExecFileAsync(
+            ['update-ref', '-d', rebaseRef],
+            gitOptionsForWorktree(worktreePath, options)
+          )
+        } catch {
+          // Cleanup must not hide the fetch or rebase result.
+        }
+      }
     }
   })
 }

--- a/src/main/git/remote.ts
+++ b/src/main/git/remote.ts
@@ -10,6 +10,7 @@ import { gitOptionsForWorktree } from './git-runtime-options'
 import { validateGitPushTarget } from './push-target-validation'
 import { gitExecFileAsync } from './runner'
 import { runWithGitReadCacheInvalidation } from './status'
+import { runWithGitWorktreeOperationLock } from '../../shared/git-worktree-operation-lock'
 
 export { gitPullRebaseFromBase } from './remote-rebase'
 
@@ -258,8 +259,8 @@ export async function gitPull(
   // Why: plain `git pull` uses the user's configured pull strategy (merge by
   // default) so diverged branches reconcile instead of erroring out. Conflicts
   // surface through the existing conflict-resolution flow.
-  await runWithGitReadCacheInvalidation(() =>
-    gitPullWithArgs(worktreePath, [], pushTarget, options)
+  await runWithGitWorktreeOperationLock(worktreePath, options.signal, () =>
+    runWithGitReadCacheInvalidation(() => gitPullWithArgs(worktreePath, [], pushTarget, options))
   )
 }
 
@@ -268,8 +269,10 @@ export async function gitFastForward(
   pushTarget?: GitPushTarget,
   options: GitRuntimeOptions = {}
 ): Promise<void> {
-  await runWithGitReadCacheInvalidation(() =>
-    gitPullWithArgs(worktreePath, ['--ff-only'], pushTarget, options)
+  await runWithGitWorktreeOperationLock(worktreePath, options.signal, () =>
+    runWithGitReadCacheInvalidation(() =>
+      gitPullWithArgs(worktreePath, ['--ff-only'], pushTarget, options)
+    )
   )
 }
 

--- a/src/main/git/runner-command-exec.test.ts
+++ b/src/main/git/runner-command-exec.test.ts
@@ -218,6 +218,50 @@ describe('runner execFile timeout handling', () => {
     expect(child.kill).toHaveBeenCalled()
   })
 
+  it.skipIf(process.platform === 'win32')(
+    'keeps a barrier Git abort pending until the process group closes',
+    async () => {
+      const child = createMockChildProcess(1234)
+      spawnMock.mockImplementation((command: string) => {
+        if (command !== 'ps') {
+          return child
+        }
+        const probe = createMockChildProcess(4321)
+        queueMicrotask(() => probe.emit('close', 0, null))
+        return probe
+      })
+      const processKill = vi.spyOn(process, 'kill').mockImplementation(() => true)
+      const controller = new AbortController()
+      try {
+        const pending = gitExecFileAsync(['status'], {
+          cwd: '/repo',
+          signal: controller.signal,
+          terminationBarrier: true
+        })
+        let settled = false
+        void pending.then(
+          () => {
+            settled = true
+          },
+          () => {
+            settled = true
+          }
+        )
+
+        controller.abort()
+        child.emit('close', 0, null)
+        await vi.advanceTimersByTimeAsync(1_999)
+        expect(settled).toBe(false)
+        await vi.advanceTimersByTimeAsync(1)
+        expect(processKill).toHaveBeenCalledWith(-1234, 'SIGKILL')
+
+        await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+      } finally {
+        processKill.mockRestore()
+      }
+    }
+  )
+
   it('rejects gh executions that never call back using the default timeout', async () => {
     const child = createMockChildProcess(1234)
     execFileMock.mockReturnValue(child)

--- a/src/main/git/runner-wsl-direct-read.test.ts
+++ b/src/main/git/runner-wsl-direct-read.test.ts
@@ -253,6 +253,34 @@ describe('WSL direct Git reads', () => {
     })
   })
 
+  it('fences parsed output from a barrier Git login-shell fallback', async () => {
+    await withPlatform('win32', async () => {
+      seedWslGitReadEnvironmentForTests(DISTRO, LOGIN_ENVIRONMENT)
+      spawnMock.mockImplementation((_command, args) => {
+        const child = createMockChild()
+        queueMicrotask(() => {
+          const fenced = fencedProbeStdout(args?.[5], 'fork-point\n')
+          const echoedMarker = fenced.match(/__ORCA_WSL_CAPTURE_BEGIN_[^_]+__/)?.[0] ?? ''
+          child.stdout.emit('data', Buffer.from(`${echoedMarker}shell trace\n${fenced}`))
+          child.emit('close', 0, null)
+        })
+        return child
+      })
+
+      await expect(
+        gitExecFileAsync(['merge-base', '--fork-point', 'upstream/main', 'HEAD'], {
+          cwd: String.raw`C:\repo`,
+          env: { GIT_CONFIG_GLOBAL: '/home/user/custom.gitconfig' },
+          wslDistro: DISTRO,
+          captureWslLoginShellOutput: true,
+          terminationBarrier: true
+        })
+      ).resolves.toEqual({ stdout: 'fork-point\n', stderr: '' })
+
+      expect(spawnMock.mock.calls[0]?.[1]?.[5]).toContain('__ORCA_WSL_CAPTURE_BEGIN_')
+    })
+  })
+
   it('ignores unchanged ambient host Git variables when selecting the direct path', async () => {
     await withPlatform('win32', async () => {
       const originalAskpass = process.env.GIT_ASKPASS

--- a/src/main/git/runner-wsl-direct-read.test.ts
+++ b/src/main/git/runner-wsl-direct-read.test.ts
@@ -259,7 +259,10 @@ describe('WSL direct Git reads', () => {
       spawnMock.mockImplementation((_command, args) => {
         const child = createMockChild()
         queueMicrotask(() => {
-          const fenced = fencedProbeStdout(args?.[5], 'fork-point\n')
+          const capturedCommand = args?.find((arg) =>
+            String(arg).includes('__ORCA_WSL_CAPTURE_BEGIN_')
+          )
+          const fenced = fencedProbeStdout(capturedCommand, 'fork-point\n')
           const echoedMarker = fenced.match(/__ORCA_WSL_CAPTURE_BEGIN_[^_]+__/)?.[0] ?? ''
           child.stdout.emit('data', Buffer.from(`${echoedMarker}shell trace\n${fenced}`))
           child.emit('close', 0, null)
@@ -277,7 +280,46 @@ describe('WSL direct Git reads', () => {
         })
       ).resolves.toEqual({ stdout: 'fork-point\n', stderr: '' })
 
-      expect(spawnMock.mock.calls[0]?.[1]?.[5]).toContain('__ORCA_WSL_CAPTURE_BEGIN_')
+      expect(spawnMock.mock.calls[0]?.[1]).toContain('setsid')
+      expect(spawnMock.mock.calls[0]?.[1]?.join(' ')).toContain('__ORCA_WSL_CAPTURE_BEGIN_')
+    })
+  })
+
+  it('verifies the WSL guest process group before settling an abort', async () => {
+    await withPlatform('win32', async () => {
+      seedWslGitReadEnvironmentForTests(DISTRO, LOGIN_ENVIRONMENT)
+      const command = createMockChild()
+      spawnMock.mockImplementation((_program, args) => {
+        if (spawnMock.mock.calls.length === 1) {
+          queueMicrotask(() => {
+            const marker = String(args?.join(' ')).match(
+              /(__ORCA_WSL_PROCESS_GROUP_[0-9a-f-]+__=)/
+            )?.[1]
+            command.stderr.emit('data', Buffer.from(`${marker}4321\n`))
+          })
+          return command
+        }
+        const terminator = createMockChild()
+        queueMicrotask(() => terminator.emit('close', 0, null))
+        return terminator
+      })
+      const controller = new AbortController()
+      const pending = gitExecFileAsync(['status'], {
+        cwd: String.raw`C:\repo`,
+        env: { GIT_CONFIG_GLOBAL: '/home/user/custom.gitconfig' },
+        wslDistro: DISTRO,
+        signal: controller.signal,
+        terminationBarrier: true
+      })
+      await vi.waitFor(() => expect(spawnMock).toHaveBeenCalledTimes(1))
+      await Promise.resolve()
+
+      controller.abort()
+
+      await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+      expect(command.kill).not.toHaveBeenCalled()
+      expect(spawnMock.mock.calls[1]?.[1]?.join(' ')).toContain('kill -TERM')
+      expect(spawnMock.mock.calls[1]?.[1]).toContain('4321')
     })
   })
 

--- a/src/main/git/runner-wsl-direct-read.test.ts
+++ b/src/main/git/runner-wsl-direct-read.test.ts
@@ -280,7 +280,7 @@ describe('WSL direct Git reads', () => {
         })
       ).resolves.toEqual({ stdout: 'fork-point\n', stderr: '' })
 
-      expect(spawnMock.mock.calls[0]?.[1]).toContain('setsid')
+      expect(spawnMock.mock.calls[0]?.[1]?.join(' ')).toContain('setsid --wait')
       expect(spawnMock.mock.calls[0]?.[1]?.join(' ')).toContain('__ORCA_WSL_CAPTURE_BEGIN_')
     })
   })

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -61,6 +61,10 @@ import {
   prepareWslLinkedWorktreeGitRouting,
   usesHostGitForWslLinkedWorktree
 } from './wsl-linked-worktree-git-routing'
+import {
+  createWslProcessGroupTermination,
+  type WslProcessGroupTermination
+} from './wsl-process-group-termination'
 // Re-exported for existing importers; lightweight consumers should import from './exec-error' to avoid this heavy module.
 import { extractExecError, parseRetryAfterMs } from './exec-error'
 export { extractExecError, parseRetryAfterMs }
@@ -84,6 +88,7 @@ type ResolvedCommand = {
   wslMode: 'direct-git' | 'login-shell' | 'non-login-shell' | null
   /** Present only when the caller opted into a fenced login-shell read. */
   captured?: WslCapturedLoginShellCommand
+  termination?: WslProcessGroupTermination
 }
 
 /**
@@ -322,6 +327,7 @@ function resolveCommand(
     captureLoginShellOutput?: boolean
     wslGitReadEnvironment?: WslGitReadEnvironment
     env?: NodeJS.ProcessEnv
+    terminationBarrier?: boolean
   } = {}
 ): ResolvedCommand {
   if (process.platform !== 'win32') {
@@ -351,25 +357,28 @@ function resolveCommand(
 
   if (command === 'git' && options.wslGitReadEnvironment) {
     const optionalLocks = options.env?.GIT_OPTIONAL_LOCKS
-    return {
-      binary: 'wsl.exe',
-      args: [
-        '-d',
-        wsl.distro,
-        '--exec',
-        '/usr/bin/env',
-        `PATH=${options.wslGitReadEnvironment.path}`,
-        `HOME=${options.wslGitReadEnvironment.home}`,
-        ...GIT_OUTPUT_LOCALE_ENV_ARGS,
-        ...(optionalLocks !== undefined ? [`GIT_OPTIONAL_LOCKS=${optionalLocks}`] : []),
-        options.wslGitReadEnvironment.gitPath,
-        ...(linuxCwd ? ['-C', linuxCwd] : []),
-        ...translatedArgs
-      ],
-      cwd: undefined,
-      wsl,
-      wslMode: 'direct-git'
-    }
+    return withWslProcessGroupTermination(
+      {
+        binary: 'wsl.exe',
+        args: [
+          '-d',
+          wsl.distro,
+          '--exec',
+          '/usr/bin/env',
+          `PATH=${options.wslGitReadEnvironment.path}`,
+          `HOME=${options.wslGitReadEnvironment.home}`,
+          ...GIT_OUTPUT_LOCALE_ENV_ARGS,
+          ...(optionalLocks !== undefined ? [`GIT_OPTIONAL_LOCKS=${optionalLocks}`] : []),
+          options.wslGitReadEnvironment.gitPath,
+          ...(linuxCwd ? ['-C', linuxCwd] : []),
+          ...translatedArgs
+        ],
+        cwd: undefined,
+        wsl,
+        wslMode: 'direct-git'
+      },
+      options.terminationBarrier
+    )
   }
 
   if (options.useWslLoginShell) {
@@ -379,31 +388,62 @@ function resolveCommand(
     // marker would be glued onto their first record.
     if (options.captureLoginShellOutput) {
       const captured = buildWslCapturedLoginShellCommand(shellCmd)
-      return {
+      return withWslProcessGroupTermination(
+        {
+          binary: 'wsl.exe',
+          args: buildWslExecArgs(wsl.distro, ['sh', '-lc', captured.command]),
+          cwd: undefined,
+          wsl,
+          wslMode: 'login-shell',
+          captured
+        },
+        options.terminationBarrier
+      )
+    }
+    return withWslProcessGroupTermination(
+      {
         binary: 'wsl.exe',
-        args: buildWslExecArgs(wsl.distro, ['sh', '-lc', captured.command]),
+        args: buildWslExecArgs(wsl.distro, ['sh', '-lc', buildWslLoginShellCommand(shellCmd)]),
         cwd: undefined,
         wsl,
-        wslMode: 'login-shell',
-        captured
-      }
-    }
-    return {
-      binary: 'wsl.exe',
-      args: buildWslExecArgs(wsl.distro, ['sh', '-lc', buildWslLoginShellCommand(shellCmd)]),
-      cwd: undefined,
-      wsl,
-      wslMode: 'login-shell'
-    }
+        wslMode: 'login-shell'
+      },
+      options.terminationBarrier
+    )
   }
 
+  return withWslProcessGroupTermination(
+    {
+      binary: 'wsl.exe',
+      args: buildWslExecArgs(wsl.distro, ['bash', '-c', shellCmd]),
+      // Why: the `cd` inside bash -c handles the directory; a UNC cwd on the Node process is redundant and can break Node internals.
+      cwd: undefined,
+      wsl,
+      wslMode: 'non-login-shell'
+    },
+    options.terminationBarrier
+  )
+}
+
+function withWslProcessGroupTermination(
+  command: ResolvedCommand,
+  enabled: boolean | undefined
+): ResolvedCommand {
+  if (!enabled || !command.wsl) {
+    return command
+  }
+  const execIndex = command.args.indexOf('--exec')
+  if (execIndex === -1) {
+    return command
+  }
+  const termination = createWslProcessGroupTermination(command.wsl.distro)
   return {
-    binary: 'wsl.exe',
-    args: buildWslExecArgs(wsl.distro, ['bash', '-c', shellCmd]),
-    // Why: the `cd` inside bash -c handles the directory; a UNC cwd on the Node process is redundant and can break Node internals.
-    cwd: undefined,
-    wsl,
-    wslMode: 'non-login-shell'
+    ...command,
+    args: [
+      ...command.args.slice(0, execIndex + 1),
+      ...termination.wrapGuestArgs(command.args.slice(execIndex + 1))
+    ],
+    termination
   }
 }
 
@@ -460,7 +500,8 @@ function resolveGitCommand(
     if (environment) {
       return resolveCommand('git', args, options.cwd, options.wslDistro, {
         wslGitReadEnvironment: environment,
-        env: options.env
+        env: options.env,
+        terminationBarrier: options.terminationBarrier
       })
     }
     if (distro) {
@@ -493,7 +534,8 @@ function resolveGitCommandWithoutProbe(
 ): ResolvedCommand {
   return resolveCommand('git', args, options.cwd, options.wslDistro, {
     useWslLoginShell: Boolean(options.wslDistro),
-    captureLoginShellOutput
+    captureLoginShellOutput,
+    terminationBarrier: options.terminationBarrier
   })
 }
 
@@ -620,7 +662,8 @@ const GIT_TERMINATION_BARRIER_FALLBACK_TIMEOUT_MS = 2_147_000_000
 async function execFileCaptureToTermination(
   command: string,
   args: string[],
-  options: ExecFileCaptureOptions
+  options: ExecFileCaptureOptions,
+  termination?: WslProcessGroupTermination
 ): Promise<{ stdout: string | Buffer; stderr: string | Buffer }> {
   const result = await runProcess({
     program: command,
@@ -630,11 +673,12 @@ async function execFileCaptureToTermination(
     timeoutMs: options.timeout ?? GIT_TERMINATION_BARRIER_FALLBACK_TIMEOUT_MS,
     maxOutputBytes: options.maxBuffer ?? DEFAULT_GIT_MAX_BUFFER,
     signal: options.signal,
-    terminationBarrier: true,
+    terminationBarrier: termination ?? true,
     ...(options.stdin === undefined ? {} : { input: options.stdin })
   })
   const stdout = options.encoding === 'buffer' ? Buffer.from(result.stdout) : result.stdout
-  const stderr = options.encoding === 'buffer' ? Buffer.from(result.stderr) : result.stderr
+  const cleanStderr = termination?.stripControlOutput(result.stderr) ?? result.stderr
+  const stderr = options.encoding === 'buffer' ? Buffer.from(cleanStderr) : cleanStderr
   if (result.code === 0 && !result.timedOut && !options.signal?.aborted) {
     return { stdout, stderr }
   }
@@ -1159,21 +1203,26 @@ async function gitExecFileAsyncUnlocked(
         : { env: nonInteractiveGitEnv(effectiveOptions.env), mode: 'default' as const }
       const capture = (
         command: ResolvedCommand
-      ): Promise<{ stdout: string | Buffer; stderr: string | Buffer }> =>
-        (options.terminationBarrier ? execFileCaptureToTermination : execFileCapture)(
-          command.binary,
-          command.args,
-          {
-            cwd: command.cwd,
-            encoding: (options.encoding ?? 'utf-8') as BufferEncoding,
-            maxBuffer: options.maxBuffer,
-            timeout: options.timeout,
-            stdin: options.stdin,
-            env: policy.env,
-            signal: options.signal,
-            terminationBarrier: options.terminationBarrier
-          }
-        )
+      ): Promise<{ stdout: string | Buffer; stderr: string | Buffer }> => {
+        const captureOptions = {
+          cwd: command.cwd,
+          encoding: (options.encoding ?? 'utf-8') as BufferEncoding,
+          maxBuffer: options.maxBuffer,
+          timeout: options.timeout,
+          stdin: options.stdin,
+          env: policy.env,
+          signal: options.signal,
+          terminationBarrier: options.terminationBarrier
+        }
+        return options.terminationBarrier
+          ? execFileCaptureToTermination(
+              command.binary,
+              command.args,
+              captureOptions,
+              command.termination
+            )
+          : execFileCapture(command.binary, command.args, captureOptions)
+      }
       let result: { stdout: string | Buffer; stderr: string | Buffer }
       try {
         result = await capture(resolved)

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -44,6 +44,11 @@ import {
 } from '../../shared/wsl-login-shell-command'
 import { UNTRANSLATED_GIT_OUTPUT_ENV } from '../../shared/git-output-locale'
 import { endSubprocessStdin } from '../../shared/subprocess-stdin-write'
+import { runProcess } from '../../shared/child-process/run-process'
+import {
+  resolveGitFetchHeadCommand,
+  runWithGitFetchHeadLock
+} from '../../shared/git-fetch-head-lock'
 import {
   disableWslGitReadEnvironment,
   getWslGitReadEnvironment,
@@ -418,6 +423,8 @@ type GitExecOptions = {
   wslDistro?: string
   preferWslDirectGit?: boolean
   useConfiguredSshCommandForNetwork?: boolean
+  terminationBarrier?: boolean
+  captureWslLoginShellOutput?: boolean
 }
 
 type CommandExecOptions = {
@@ -605,6 +612,49 @@ function killSpawnedCommandTree(child: ChildProcess): Promise<void> {
 type ExecFileCaptureOptions = Omit<ExecFileOptions, 'timeout'> & {
   timeout?: number
   stdin?: string
+  terminationBarrier?: boolean
+}
+
+const GIT_TERMINATION_BARRIER_FALLBACK_TIMEOUT_MS = 2_147_000_000
+
+async function execFileCaptureToTermination(
+  command: string,
+  args: string[],
+  options: ExecFileCaptureOptions
+): Promise<{ stdout: string | Buffer; stderr: string | Buffer }> {
+  const result = await runProcess({
+    program: command,
+    args,
+    cwd: typeof options.cwd === 'string' ? options.cwd : undefined,
+    env: options.env,
+    timeoutMs: options.timeout ?? GIT_TERMINATION_BARRIER_FALLBACK_TIMEOUT_MS,
+    maxOutputBytes: options.maxBuffer ?? DEFAULT_GIT_MAX_BUFFER,
+    signal: options.signal,
+    terminationBarrier: true,
+    ...(options.stdin === undefined ? {} : { input: options.stdin })
+  })
+  const stdout = options.encoding === 'buffer' ? Buffer.from(result.stdout) : result.stdout
+  const stderr = options.encoding === 'buffer' ? Buffer.from(result.stderr) : result.stderr
+  if (result.code === 0 && !result.timedOut && !options.signal?.aborted) {
+    return { stdout, stderr }
+  }
+  const error = new Error(
+    result.timedOut
+      ? `${command} timed out.`
+      : options.signal?.aborted
+        ? 'The operation was aborted.'
+        : result.stderr.trim() || `${command} exited with ${result.code}.`
+  )
+  if (options.signal?.aborted) {
+    error.name = 'AbortError'
+  }
+  throw Object.assign(error, {
+    code: result.code,
+    killed: result.timedOut || result.signal !== null || options.signal?.aborted === true,
+    signal: result.signal,
+    stdout,
+    stderr
+  })
 }
 
 function emptyExecFileOutput(options: ExecFileCaptureOptions): string | Buffer {
@@ -1077,7 +1127,7 @@ async function buildNetworkSshPolicyEnv(options: GitExecOptions): Promise<{
  * Async git command execution. Drop-in replacement for
  * `execFileAsync('git', args, { cwd, encoding, ... })`.
  */
-export async function gitExecFileAsync(
+async function gitExecFileAsyncUnlocked(
   args: string[],
   options: GitExecOptions
 ): Promise<{ stdout: string; stderr: string }> {
@@ -1090,7 +1140,7 @@ export async function gitExecFileAsync(
           signal: options.signal
         })
       }
-      let resolved = resolveGitCommand(args, options)
+      let resolved = resolveGitCommand(args, options, false, options.captureWslLoginShellOutput)
       const environmentReady = prepareWindowsHostGitEnvironment(
         resolved,
         options.env,
@@ -1098,33 +1148,52 @@ export async function gitExecFileAsync(
       )
       const env = environmentReady ? await environmentReady : options.env
       const effectiveOptions = env === options.env ? options : { ...options, env }
-      resolved = resolveGitCommand(args, effectiveOptions)
+      resolved = resolveGitCommand(
+        args,
+        effectiveOptions,
+        false,
+        effectiveOptions.captureWslLoginShellOutput
+      )
       const policy = effectiveOptions.useConfiguredSshCommandForNetwork
         ? await buildNetworkSshPolicyEnv(effectiveOptions)
         : { env: nonInteractiveGitEnv(effectiveOptions.env), mode: 'default' as const }
       const capture = (
         command: ResolvedCommand
       ): Promise<{ stdout: string | Buffer; stderr: string | Buffer }> =>
-        execFileCapture(command.binary, command.args, {
-          cwd: command.cwd,
-          encoding: (options.encoding ?? 'utf-8') as BufferEncoding,
-          maxBuffer: options.maxBuffer,
-          timeout: options.timeout,
-          stdin: options.stdin,
-          env: policy.env,
-          signal: options.signal
-        })
+        (options.terminationBarrier ? execFileCaptureToTermination : execFileCapture)(
+          command.binary,
+          command.args,
+          {
+            cwd: command.cwd,
+            encoding: (options.encoding ?? 'utf-8') as BufferEncoding,
+            maxBuffer: options.maxBuffer,
+            timeout: options.timeout,
+            stdin: options.stdin,
+            env: policy.env,
+            signal: options.signal,
+            terminationBarrier: options.terminationBarrier
+          }
+        )
       let result: { stdout: string | Buffer; stderr: string | Buffer }
       try {
         result = await capture(resolved)
       } catch (error) {
         if (directWslGitExitCode(error, resolved) !== null && !options.signal?.aborted) {
           const wasMissing = invalidateMissingDirectWslGit(error, resolved)
-          result = await capture(resolveGitCommand(args, effectiveOptions, true))
+          const fallback = resolveGitCommand(
+            args,
+            effectiveOptions,
+            true,
+            effectiveOptions.captureWslLoginShellOutput
+          )
+          result = await capture(fallback)
           // Why: matching failures can be normal Git control flow; only a successful login retry proves the direct environment was insufficient.
           disableDirectWslGitAfterSuccessfulFallback(wasMissing, resolved)
           const { stdout, stderr } = result
-          return { stdout: stdout as string, stderr: stderr as string }
+          return {
+            stdout: readCapturedGitString(stdout as string, fallback),
+            stderr: stderr as string
+          }
         }
         if (options.useConfiguredSshCommandForNetwork && error && typeof error === 'object') {
           Object.assign(error, { gitSshPolicyMode: policy.mode })
@@ -1132,9 +1201,20 @@ export async function gitExecFileAsync(
         throw error
       }
       const { stdout, stderr } = result
-      return { stdout: stdout as string, stderr: stderr as string }
+      return { stdout: readCapturedGitString(stdout as string, resolved), stderr: stderr as string }
     }
   )
+}
+
+export function gitExecFileAsync(
+  args: string[],
+  options: GitExecOptions
+): Promise<{ stdout: string; stderr: string }> {
+  const run = () => gitExecFileAsyncUnlocked(args, options)
+  const command = resolveGitFetchHeadCommand(args, options.cwd)
+  return command.needsLock
+    ? runWithGitFetchHeadLock(command.cwd, options.signal, run, command.gitDir)
+    : run()
 }
 
 /**
@@ -1222,13 +1302,27 @@ function readCapturedGitBuffer(stdout: Buffer, resolved: ResolvedCommand): Buffe
   if (!captured) {
     return stdout
   }
-  const beginIndex = stdout.indexOf(captured.beginMarker, 0, 'utf8')
+  const beginIndex = stdout.lastIndexOf(captured.beginMarker, undefined, 'utf8')
   if (beginIndex === -1) {
     return stdout
   }
   const payloadStart = beginIndex + Buffer.byteLength(captured.beginMarker, 'utf8')
   const endIndex = stdout.indexOf(captured.endMarker, payloadStart, 'utf8')
   return endIndex === -1 ? stdout.subarray(payloadStart) : stdout.subarray(payloadStart, endIndex)
+}
+
+function readCapturedGitString(stdout: string, resolved: ResolvedCommand): string {
+  const captured = resolved.captured
+  if (!captured) {
+    return stdout
+  }
+  const beginIndex = stdout.lastIndexOf(captured.beginMarker)
+  if (beginIndex === -1) {
+    return stdout
+  }
+  const payloadStart = beginIndex + captured.beginMarker.length
+  const endIndex = stdout.indexOf(captured.endMarker, payloadStart)
+  return endIndex === -1 ? stdout.slice(payloadStart) : stdout.slice(payloadStart, endIndex)
 }
 
 /** Result of a streamed git command; `stoppedEarly` is true when onStdout asked to stop before the child exited. */

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -687,7 +687,7 @@ async function execFileCaptureToTermination(
       ? `${command} timed out.`
       : options.signal?.aborted
         ? 'The operation was aborted.'
-        : result.stderr.trim() || `${command} exited with ${result.code}.`
+        : cleanStderr.trim() || `${command} exited with ${result.code}.`
   )
   if (options.signal?.aborted) {
     error.name = 'AbortError'

--- a/src/main/git/status-submodule-path-cache.test.ts
+++ b/src/main/git/status-submodule-path-cache.test.ts
@@ -148,7 +148,7 @@ describe('submodule path cache', () => {
       if (args[0] === 'remote') {
         return Promise.resolve({ stdout: 'origin\n' })
       }
-      if (args[0] === 'pull') {
+      if (args[0] === 'pull' || args[0] === 'fetch') {
         modulePath = 'fresh-lib'
         return Promise.resolve({ stdout: '' })
       }

--- a/src/main/git/wsl-process-group-termination.test.ts
+++ b/src/main/git/wsl-process-group-termination.test.ts
@@ -1,0 +1,56 @@
+import type { ChildProcess } from 'node:child_process'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { runProcessMock } = vi.hoisted(() => ({ runProcessMock: vi.fn() }))
+
+vi.mock('../../shared/child-process/run-process', () => ({ runProcess: runProcessMock }))
+
+import { createWslProcessGroupTermination } from './wsl-process-group-termination'
+
+describe('WSL process-group termination', () => {
+  beforeEach(() => {
+    runProcessMock.mockReset()
+    runProcessMock.mockResolvedValue({ code: 0, timedOut: false })
+  })
+
+  it('wraps the guest command in a reported process group', () => {
+    const termination = createWslProcessGroupTermination('Ubuntu')
+    const args = termination.wrapGuestArgs(['git', 'fetch'])
+
+    expect(args.slice(0, 3)).toEqual(['setsid', '--wait', 'sh'])
+    expect(args.slice(-2)).toEqual(['git', 'fetch'])
+    expect(args.join(' ')).toContain('__ORCA_WSL_PROCESS_GROUP_')
+  })
+
+  it('forces and verifies the reported guest process group', async () => {
+    const termination = createWslProcessGroupTermination('Ubuntu')
+    const wrapped = termination.wrapGuestArgs(['git', 'fetch']).join(' ')
+    const marker = wrapped.match(/(__ORCA_WSL_PROCESS_GROUP_[0-9a-f-]+__=)/)?.[1]
+    termination.observeStderr?.(Buffer.from(`${marker}43`))
+    termination.observeStderr?.(Buffer.from('21\n'))
+
+    await expect(termination.force({} as ChildProcess)).resolves.toBe(true)
+
+    const spec = runProcessMock.mock.calls[0]?.[0]
+    expect(spec.program).toBe('wsl.exe')
+    expect(spec.args).toContain('4321')
+    expect(spec.args.join(' ')).toContain('kill -KILL')
+  })
+
+  it('does not claim termination before the guest reports its identity', async () => {
+    const termination = createWslProcessGroupTermination('Ubuntu')
+
+    await expect(termination.signal({} as ChildProcess)).resolves.toBe(false)
+    expect(runProcessMock).not.toHaveBeenCalled()
+  })
+
+  it('retains the guest identity from a large coalesced stderr chunk', async () => {
+    const termination = createWslProcessGroupTermination('Ubuntu')
+    const wrapped = termination.wrapGuestArgs(['git', 'fetch']).join(' ')
+    const marker = wrapped.match(/(__ORCA_WSL_PROCESS_GROUP_[0-9a-f-]+__=)/)?.[1]
+    termination.observeStderr?.(Buffer.from(`${marker}4321\n${'x'.repeat(1_024)}`))
+
+    await expect(termination.signal({} as ChildProcess)).resolves.toBe(true)
+    expect(runProcessMock.mock.calls[0]?.[0]?.args).toContain('4321')
+  })
+})

--- a/src/main/git/wsl-process-group-termination.test.ts
+++ b/src/main/git/wsl-process-group-termination.test.ts
@@ -17,9 +17,18 @@ describe('WSL process-group termination', () => {
     const termination = createWslProcessGroupTermination('Ubuntu')
     const args = termination.wrapGuestArgs(['git', 'fetch'])
 
-    expect(args.slice(0, 3)).toEqual(['setsid', '--wait', 'sh'])
+    expect(args.slice(0, 2)).toEqual(['sh', '-c'])
     expect(args.slice(-2)).toEqual(['git', 'fetch'])
     expect(args.join(' ')).toContain('__ORCA_WSL_PROCESS_GROUP_')
+    expect(args[2]).toContain('setsid --wait sh -c')
+  })
+
+  it('runs the guest command unwrapped where setsid --wait is unsupported', () => {
+    const termination = createWslProcessGroupTermination('Ubuntu')
+    const script = termination.wrapGuestArgs(['git', 'fetch'])[2] ?? ''
+
+    expect(script).toContain('if setsid --wait true 2>/dev/null; then')
+    expect(script.trimEnd().endsWith('exec "$@"')).toBe(true)
   })
 
   it('forces and verifies the reported guest process group', async () => {
@@ -27,6 +36,8 @@ describe('WSL process-group termination', () => {
     const wrapped = termination.wrapGuestArgs(['git', 'fetch']).join(' ')
     const marker = wrapped.match(/(__ORCA_WSL_PROCESS_GROUP_[0-9a-f-]+__=)/)?.[1]
     termination.observeStderr?.(Buffer.from(`${marker}43`))
+    // The marker line is still truncated; committing 43 would target a stranger.
+    await expect(termination.signal({} as ChildProcess)).resolves.toBe(false)
     termination.observeStderr?.(Buffer.from('21\n'))
 
     await expect(termination.force({} as ChildProcess)).resolves.toBe(true)

--- a/src/main/git/wsl-process-group-termination.test.ts
+++ b/src/main/git/wsl-process-group-termination.test.ts
@@ -1,16 +1,16 @@
 import type { ChildProcess } from 'node:child_process'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { runProcessMock } = vi.hoisted(() => ({ runProcessMock: vi.fn() }))
+const { runWslProcessMock } = vi.hoisted(() => ({ runWslProcessMock: vi.fn() }))
 
-vi.mock('../../shared/child-process/run-process', () => ({ runProcess: runProcessMock }))
+vi.mock('../wsl/wsl-runner', () => ({ runWslProcess: runWslProcessMock }))
 
 import { createWslProcessGroupTermination } from './wsl-process-group-termination'
 
 describe('WSL process-group termination', () => {
   beforeEach(() => {
-    runProcessMock.mockReset()
-    runProcessMock.mockResolvedValue({ code: 0, timedOut: false })
+    runWslProcessMock.mockReset()
+    runWslProcessMock.mockResolvedValue({ code: 0, timedOut: false })
   })
 
   it('wraps the guest command in a reported process group', () => {
@@ -42,17 +42,45 @@ describe('WSL process-group termination', () => {
 
     await expect(termination.force({} as ChildProcess)).resolves.toBe(true)
 
-    const spec = runProcessMock.mock.calls[0]?.[0]
-    expect(spec.program).toBe('wsl.exe')
-    expect(spec.args).toContain('4321')
-    expect(spec.args.join(' ')).toContain('kill -KILL')
+    const spec = runWslProcessMock.mock.calls[0]?.[0]
+    expect(spec.script).toContain('kill -KILL')
+    expect(spec.args).toEqual(['4321'])
+  })
+
+  it('kills the group through the WSL runner, never a raw wsl.exe spawn', async () => {
+    const termination = createWslProcessGroupTermination('Ubuntu')
+    const wrapped = termination.wrapGuestArgs(['git', 'fetch']).join(' ')
+    const marker = wrapped.match(/(__ORCA_WSL_PROCESS_GROUP_[0-9a-f-]+__=)/)?.[1]
+    termination.observeStderr?.(Buffer.from(`${marker}4321\n`))
+
+    await termination.signal({} as ChildProcess)
+
+    const spec = runWslProcessMock.mock.calls[0]?.[0]
+    expect(spec.distro).toBe('Ubuntu')
+    // The runner picks the shell; a payload of plain POSIX must not pin bash.
+    expect(spec.program).toBeUndefined()
+    expect(spec.shell).toBeUndefined()
+    // The kill reads no login environment, so it must not pay the probe.
+    expect(spec.loginPath).toBe('none')
+    expect(spec.timeoutMs).toBeGreaterThan(0)
+    expect(spec.script).toContain('kill -TERM')
   })
 
   it('does not claim termination before the guest reports its identity', async () => {
     const termination = createWslProcessGroupTermination('Ubuntu')
 
     await expect(termination.signal({} as ChildProcess)).resolves.toBe(false)
-    expect(runProcessMock).not.toHaveBeenCalled()
+    expect(runWslProcessMock).not.toHaveBeenCalled()
+  })
+
+  it('reports failure when the guest kill times out', async () => {
+    runWslProcessMock.mockResolvedValue({ code: null, timedOut: true })
+    const termination = createWslProcessGroupTermination('Ubuntu')
+    const wrapped = termination.wrapGuestArgs(['git', 'fetch']).join(' ')
+    const marker = wrapped.match(/(__ORCA_WSL_PROCESS_GROUP_[0-9a-f-]+__=)/)?.[1]
+    termination.observeStderr?.(Buffer.from(`${marker}4321\n`))
+
+    await expect(termination.force({} as ChildProcess)).resolves.toBe(false)
   })
 
   it('retains the guest identity from a large coalesced stderr chunk', async () => {
@@ -62,6 +90,6 @@ describe('WSL process-group termination', () => {
     termination.observeStderr?.(Buffer.from(`${marker}4321\n${'x'.repeat(1_024)}`))
 
     await expect(termination.signal({} as ChildProcess)).resolves.toBe(true)
-    expect(runProcessMock.mock.calls[0]?.[0]?.args).toContain('4321')
+    expect(runWslProcessMock.mock.calls[0]?.[0]?.args).toEqual(['4321'])
   })
 })

--- a/src/main/git/wsl-process-group-termination.ts
+++ b/src/main/git/wsl-process-group-termination.ts
@@ -1,0 +1,71 @@
+import { randomUUID } from 'node:crypto'
+import type { ProcessTerminationBarrier } from '../../shared/child-process/run-process'
+import { runProcess } from '../../shared/child-process/run-process'
+import { buildWslExecArgs, quotePosixShell } from '../../shared/wsl-login-shell-command'
+
+const GUEST_TERMINATION_ATTEMPTS = 40
+const GUEST_TERMINATION_INTERVAL_SECONDS = '0.025'
+const GUEST_TERMINATION_COMMAND_TIMEOUT_MS = 1_500
+
+export type WslProcessGroupTermination = ProcessTerminationBarrier & {
+  wrapGuestArgs: (args: readonly string[]) => string[]
+  stripControlOutput: (stderr: string) => string
+}
+
+export function createWslProcessGroupTermination(distro: string): WslProcessGroupTermination {
+  const marker = `__ORCA_WSL_PROCESS_GROUP_${randomUUID()}__=`
+  let processGroupId: number | null = null
+  let stderrTail = ''
+
+  const observeStderr = (chunk: Buffer | string): void => {
+    const combined = `${stderrTail}${chunk.toString()}`
+    const match = combined.match(new RegExp(`${marker}(\\d+)`))
+    stderrTail = combined.slice(-512)
+    const parsed = match ? Number(match[1]) : 0
+    if (Number.isSafeInteger(parsed) && parsed > 1) {
+      processGroupId = parsed
+    }
+  }
+
+  const terminate = async (signal: 'TERM' | 'KILL'): Promise<boolean> => {
+    if (processGroupId === null) {
+      return false
+    }
+    const script = [
+      '_orca_group=$1',
+      `kill -${signal} "-$_orca_group" 2>/dev/null || :`,
+      '_orca_attempt=0',
+      'while kill -0 "-$_orca_group" 2>/dev/null; do',
+      `  [ "$_orca_attempt" -ge ${GUEST_TERMINATION_ATTEMPTS} ] && exit 1`,
+      '  _orca_attempt=$((_orca_attempt + 1))',
+      `  sleep ${GUEST_TERMINATION_INTERVAL_SECONDS}`,
+      'done'
+    ].join('\n')
+    const result = await runProcess({
+      program: 'wsl.exe',
+      args: buildWslExecArgs(distro, [
+        'sh',
+        '-c',
+        script,
+        'orca-wsl-process-group-termination',
+        String(processGroupId)
+      ]),
+      timeoutMs: GUEST_TERMINATION_COMMAND_TIMEOUT_MS,
+      maxOutputBytes: 1_024
+    })
+    return result.code === 0 && !result.timedOut
+  }
+
+  return {
+    observeStderr,
+    signal: () => terminate('TERM'),
+    force: () => terminate('KILL'),
+    wrapGuestArgs: (args) => {
+      const wrapper = [`printf '%s%s\\n' ${quotePosixShell(marker)} "$$" >&2`, 'exec "$@"'].join(
+        '\n'
+      )
+      return ['setsid', '--wait', 'sh', '-c', wrapper, 'orca-wsl-process-group', ...args]
+    },
+    stripControlOutput: (stderr) => stderr.replace(new RegExp(`${marker}\\d+\\r?\\n?`, 'g'), '')
+  }
+}

--- a/src/main/git/wsl-process-group-termination.ts
+++ b/src/main/git/wsl-process-group-termination.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
 import type { ProcessTerminationBarrier } from '../../shared/child-process/run-process'
-import { runProcess } from '../../shared/child-process/run-process'
-import { buildWslExecArgs, quotePosixShell } from '../../shared/wsl-login-shell-command'
+import { quotePosixShell } from '../../shared/wsl-login-shell-command'
+import { runWslProcess } from '../wsl/wsl-runner'
 
 const GUEST_TERMINATION_ATTEMPTS = 40
 const GUEST_TERMINATION_INTERVAL_SECONDS = '0.025'
@@ -41,15 +41,13 @@ export function createWslProcessGroupTermination(distro: string): WslProcessGrou
       `  sleep ${GUEST_TERMINATION_INTERVAL_SECONDS}`,
       'done'
     ].join('\n')
-    const result = await runProcess({
-      program: 'wsl.exe',
-      args: buildWslExecArgs(distro, [
-        'sh',
-        '-c',
-        script,
-        'orca-wsl-process-group-termination',
-        String(processGroupId)
-      ]),
+    // loginPath 'none': the payload is builtins and coreutils on the default
+    // PATH, so a login probe would only add latency to a kill.
+    const result = await runWslProcess({
+      script,
+      args: [String(processGroupId)],
+      distro,
+      loginPath: 'none',
       timeoutMs: GUEST_TERMINATION_COMMAND_TIMEOUT_MS,
       maxOutputBytes: 1_024
     })

--- a/src/main/git/wsl-process-group-termination.ts
+++ b/src/main/git/wsl-process-group-termination.ts
@@ -5,7 +5,7 @@ import { buildWslExecArgs, quotePosixShell } from '../../shared/wsl-login-shell-
 
 const GUEST_TERMINATION_ATTEMPTS = 40
 const GUEST_TERMINATION_INTERVAL_SECONDS = '0.025'
-const GUEST_TERMINATION_COMMAND_TIMEOUT_MS = 1_500
+const GUEST_TERMINATION_COMMAND_TIMEOUT_MS = 5_000
 
 export type WslProcessGroupTermination = ProcessTerminationBarrier & {
   wrapGuestArgs: (args: readonly string[]) => string[]
@@ -19,7 +19,7 @@ export function createWslProcessGroupTermination(distro: string): WslProcessGrou
 
   const observeStderr = (chunk: Buffer | string): void => {
     const combined = `${stderrTail}${chunk.toString()}`
-    const match = combined.match(new RegExp(`${marker}(\\d+)`))
+    const match = combined.match(new RegExp(`${marker}(\\d+)\\r?\\n`))
     stderrTail = combined.slice(-512)
     const parsed = match ? Number(match[1]) : 0
     if (Number.isSafeInteger(parsed) && parsed > 1) {
@@ -61,10 +61,21 @@ export function createWslProcessGroupTermination(distro: string): WslProcessGrou
     signal: () => terminate('TERM'),
     force: () => terminate('KILL'),
     wrapGuestArgs: (args) => {
-      const wrapper = [`printf '%s%s\\n' ${quotePosixShell(marker)} "$$" >&2`, 'exec "$@"'].join(
-        '\n'
-      )
-      return ['setsid', '--wait', 'sh', '-c', wrapper, 'orca-wsl-process-group', ...args]
+      const reportGroup = [
+        `printf '%s%s\\n' ${quotePosixShell(marker)} "$$" >&2`,
+        'exec "$@"'
+      ].join('\n')
+      // Why probe rather than assume: BusyBox `setsid` has no `--wait`, so there
+      // the wrapper would fail the Git command outright. Without a new session the
+      // reported group is not ours to kill, so the fallback reports no identity
+      // and the caller falls back to waiting for the root exit.
+      const script = [
+        'if setsid --wait true 2>/dev/null; then',
+        `  exec setsid --wait sh -c ${quotePosixShell(reportGroup)} orca-wsl-process-group "$@"`,
+        'fi',
+        'exec "$@"'
+      ].join('\n')
+      return ['sh', '-c', script, 'orca-wsl-process-group', ...args]
     },
     stripControlOutput: (stderr) => stderr.replace(new RegExp(`${marker}\\d+\\r?\\n?`, 'g'), '')
   }

--- a/src/main/providers/ssh-git-provider-remote-sync.test.ts
+++ b/src/main/providers/ssh-git-provider-remote-sync.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, beforeEach } from 'vitest'
 import { SshGitProvider } from './ssh-git-provider'
 import { createMockMux, type MockMultiplexer } from './ssh-git-provider-test-harness'
+import { REBASE_FROM_BASE_RPC_TIMEOUT_MS } from '../../shared/git-rebase-source'
 
 describe('SshGitProvider', () => {
   let mux: MockMultiplexer
@@ -101,10 +102,14 @@ describe('SshGitProvider', () => {
   it('rebaseFromBase sends git.rebaseFromBase request', async () => {
     await provider.rebaseFromBase('/home/user/repo', 'upstream/main')
 
-    expect(mux.request).toHaveBeenCalledWith('git.rebaseFromBase', {
-      worktreePath: '/home/user/repo',
-      baseRef: 'upstream/main'
-    })
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.rebaseFromBase',
+      {
+        worktreePath: '/home/user/repo',
+        baseRef: 'upstream/main'
+      },
+      { timeoutMs: REBASE_FROM_BASE_RPC_TIMEOUT_MS }
+    )
   })
 
   it('fetchRemote sends git.fetch request', async () => {

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -33,6 +33,7 @@ import {
 import { InFlightPromiseDedupe, stableInFlightKey } from '../../shared/in-flight-promise-dedupe'
 import { gitExecMutatesRepository } from '../../shared/git-exec-mutation'
 import { GitStatusReadLeaseOwner } from '../git/git-status-read-lease-owner'
+import { REBASE_FROM_BASE_RPC_TIMEOUT_MS } from '../../shared/git-rebase-source'
 import { GitUpstreamStatusReadOwner } from '../git/git-upstream-status-read-owner'
 
 type NonInteractiveExecQueueEntry = {
@@ -565,7 +566,11 @@ export class SshGitProvider implements IGitProvider {
 
   async rebaseFromBase(worktreePath: string, baseRef: string): Promise<void> {
     await this.runWithGitReadInvalidation(async () => {
-      await this.mux.request('git.rebaseFromBase', { worktreePath, baseRef })
+      await this.mux.request(
+        'git.rebaseFromBase',
+        { worktreePath, baseRef },
+        { timeoutMs: REBASE_FROM_BASE_RPC_TIMEOUT_MS }
+      )
     })
   }
 

--- a/src/main/wsl/__fixtures__/wsl-invocation-allowlist.txt
+++ b/src/main/wsl/__fixtures__/wsl-invocation-allowlist.txt
@@ -23,7 +23,6 @@ main/codex/codex-trust-grant-host.ts
 main/codex/codex-wsl-hook-install-plan.ts
 main/daemon/pty-subprocess.ts
 main/git/runner.ts
-main/git/wsl-process-group-termination.ts
 main/git/wsl-git-read-environment.ts
 main/ipc/filesystem-watcher-wsl.ts
 main/local-worktree-filesystem.ts

--- a/src/main/wsl/__fixtures__/wsl-invocation-allowlist.txt
+++ b/src/main/wsl/__fixtures__/wsl-invocation-allowlist.txt
@@ -23,6 +23,7 @@ main/codex/codex-trust-grant-host.ts
 main/codex/codex-wsl-hook-install-plan.ts
 main/daemon/pty-subprocess.ts
 main/git/runner.ts
+main/git/wsl-process-group-termination.ts
 main/git/wsl-git-read-environment.ts
 main/ipc/filesystem-watcher-wsl.ts
 main/local-worktree-filesystem.ts

--- a/src/relay/git-handler-remote-sync.test.ts
+++ b/src/relay/git-handler-remote-sync.test.ts
@@ -154,6 +154,75 @@ describe('GitHandler', () => {
       }
     })
 
+    it('rebases from the original fork point after a remote force-push', async () => {
+      const bareDir = mkdtempSync(path.join(tmpdir(), 'relay-git-rebase-bare-'))
+      const producerParent = mkdtempSync(path.join(tmpdir(), 'relay-git-rebase-producer-'))
+      const producerDir = path.join(producerParent, 'repo')
+      try {
+        execFileSync('git', ['init', '--bare'], { cwd: bareDir, stdio: 'pipe' })
+        gitInit(tmpDir)
+        writeFileSync(path.join(tmpDir, 'base.txt'), 'base')
+        gitCommit(tmpDir, 'base')
+        const branch = execFileSync('git', ['branch', '--show-current'], {
+          cwd: tmpDir,
+          encoding: 'utf-8'
+        }).trim()
+        const forkPoint = execFileSync('git', ['rev-parse', 'HEAD'], {
+          cwd: tmpDir,
+          encoding: 'utf-8'
+        }).trim()
+        execFileSync('git', ['remote', 'add', 'origin', bareDir], { cwd: tmpDir, stdio: 'pipe' })
+        execFileSync('git', ['push', '--set-upstream', 'origin', branch], {
+          cwd: tmpDir,
+          stdio: 'pipe'
+        })
+
+        execFileSync('git', ['clone', bareDir, producerDir], { stdio: 'pipe' })
+        execFileSync('git', ['checkout', branch], { cwd: producerDir, stdio: 'pipe' })
+        execFileSync('git', ['config', 'user.email', 'test@test.com'], {
+          cwd: producerDir,
+          stdio: 'pipe'
+        })
+        execFileSync('git', ['config', 'user.name', 'Test'], { cwd: producerDir, stdio: 'pipe' })
+        writeFileSync(path.join(producerDir, 'discarded.txt'), 'discarded')
+        gitCommit(producerDir, 'discarded remote commit')
+        execFileSync('git', ['push'], { cwd: producerDir, stdio: 'pipe' })
+        execFileSync('git', ['fetch', 'origin'], { cwd: tmpDir, stdio: 'pipe' })
+
+        execFileSync('git', ['checkout', '-b', 'feature', `origin/${branch}`], {
+          cwd: tmpDir,
+          stdio: 'pipe'
+        })
+        writeFileSync(path.join(tmpDir, 'topic.txt'), 'topic')
+        gitCommit(tmpDir, 'topic commit')
+
+        execFileSync('git', ['reset', '--hard', forkPoint], { cwd: producerDir, stdio: 'pipe' })
+        writeFileSync(path.join(producerDir, 'replacement.txt'), 'replacement')
+        gitCommit(producerDir, 'replacement remote commit')
+        execFileSync('git', ['push', '--force', 'origin', branch], { cwd: producerDir, stdio: 'pipe' })
+
+        await dispatcher.callRequest('git.rebaseFromBase', {
+          worktreePath: tmpDir,
+          baseRef: `origin/${branch}`
+        })
+
+        await expect(fs.access(path.join(tmpDir, 'replacement.txt'))).resolves.toBeUndefined()
+        await expect(fs.access(path.join(tmpDir, 'topic.txt'))).resolves.toBeUndefined()
+        await expect(fs.access(path.join(tmpDir, 'discarded.txt'))).rejects.toThrow()
+        expect(
+          execFileSync('git', ['for-each-ref', '--format=%(refname)', 'refs/orca/rebase'], {
+            cwd: tmpDir,
+            encoding: 'utf-8'
+          }).trim()
+        ).toBe('')
+      } finally {
+        await Promise.all([
+          fs.rm(bareDir, { recursive: true, force: true }),
+          fs.rm(producerParent, { recursive: true, force: true })
+        ])
+      }
+    }, 15_000)
+
     it('fetches the explicit publish target remote', async () => {
       const bareDir = mkdtempSync(path.join(tmpdir(), 'relay-git-fork-bare-'))
       try {

--- a/src/relay/git-handler-remote-sync.test.ts
+++ b/src/relay/git-handler-remote-sync.test.ts
@@ -3,7 +3,7 @@
  * sync, fast-forward, and the narrow review-head fetches for GitHub pull
  * requests and GitLab merge requests.
  */
-import { describe, expect, it, beforeEach, afterEach } from 'vitest'
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
 import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import { mkdtempSync, writeFileSync } from 'node:fs'
@@ -14,16 +14,20 @@ import { gitInit, gitCommit, type MockDispatcher } from './git-handler-test-setu
 import {
   createGitHandlerRelay,
   createGitTempDir,
-  removeGitTempDir
+  removeGitTempDir,
+  type GitSpyTarget
 } from './git-handler-test-harness'
 
 describe('GitHandler', () => {
   let dispatcher: MockDispatcher
   let tmpDir: string
+  let gitTarget: GitSpyTarget
 
   beforeEach(() => {
     tmpDir = createGitTempDir()
-    ;({ dispatcher } = createGitHandlerRelay())
+    const relay = createGitHandlerRelay()
+    dispatcher = relay.dispatcher
+    gitTarget = relay.handler as unknown as GitSpyTarget
   })
 
   afterEach(async () => {
@@ -199,7 +203,10 @@ describe('GitHandler', () => {
         execFileSync('git', ['reset', '--hard', forkPoint], { cwd: producerDir, stdio: 'pipe' })
         writeFileSync(path.join(producerDir, 'replacement.txt'), 'replacement')
         gitCommit(producerDir, 'replacement remote commit')
-        execFileSync('git', ['push', '--force', 'origin', branch], { cwd: producerDir, stdio: 'pipe' })
+        execFileSync('git', ['push', '--force', 'origin', branch], {
+          cwd: producerDir,
+          stdio: 'pipe'
+        })
 
         await dispatcher.callRequest('git.rebaseFromBase', {
           worktreePath: tmpDir,
@@ -222,6 +229,82 @@ describe('GitHandler', () => {
         ])
       }
     }, 15_000)
+
+    it('fast-forwards an unborn branch from the selected remote base', async () => {
+      const bareDir = mkdtempSync(path.join(tmpdir(), 'relay-git-unborn-bare-'))
+      const producerDir = mkdtempSync(path.join(tmpdir(), 'relay-git-unborn-producer-'))
+      try {
+        execFileSync('git', ['init', '--bare'], { cwd: bareDir, stdio: 'pipe' })
+        gitInit(producerDir)
+        writeFileSync(path.join(producerDir, 'base.txt'), 'base')
+        gitCommit(producerDir, 'base')
+        const branch = execFileSync('git', ['branch', '--show-current'], {
+          cwd: producerDir,
+          encoding: 'utf-8'
+        }).trim()
+        execFileSync('git', ['remote', 'add', 'origin', bareDir], {
+          cwd: producerDir,
+          stdio: 'pipe'
+        })
+        execFileSync('git', ['push', 'origin', branch], { cwd: producerDir, stdio: 'pipe' })
+
+        gitInit(tmpDir)
+        execFileSync('git', ['remote', 'add', 'origin', bareDir], { cwd: tmpDir, stdio: 'pipe' })
+
+        await dispatcher.callRequest('git.rebaseFromBase', {
+          worktreePath: tmpDir,
+          baseRef: `origin/${branch}`
+        })
+
+        await expect(fs.access(path.join(tmpDir, 'base.txt'))).resolves.toBeUndefined()
+        expect(execFileSync('git', ['rev-parse', '--verify', 'HEAD'], { cwd: tmpDir })).toBeTruthy()
+      } finally {
+        await Promise.all([
+          fs.rm(bareDir, { recursive: true, force: true }),
+          fs.rm(producerDir, { recursive: true, force: true })
+        ])
+      }
+    })
+
+    it('cancels the active rebase fetch and still removes its private ref', async () => {
+      const controller = new AbortController()
+      let rejectFetch!: (error: Error) => void
+      const fetchStarted = new Promise<void>((resolve) => {
+        vi.spyOn(gitTarget, 'git').mockImplementation(async (args, _cwd, options) => {
+          if (args[0] === 'remote') {
+            return { stdout: 'origin\n', stderr: '' }
+          }
+          if (args[0] === 'merge-base') {
+            return { stdout: 'fork-point\n', stderr: '' }
+          }
+          if (args[0] === 'fetch') {
+            resolve()
+            return new Promise((_resolve, reject) => {
+              rejectFetch = reject
+              options?.signal?.addEventListener('abort', () => reject(new Error('aborted')), {
+                once: true
+              })
+            })
+          }
+          return { stdout: '', stderr: '' }
+        })
+      })
+
+      const request = dispatcher.callRequest(
+        'git.rebaseFromBase',
+        { worktreePath: tmpDir, baseRef: 'origin/main' },
+        { isStale: () => false, signal: controller.signal }
+      )
+      await fetchStarted
+      controller.abort()
+      await expect(request).rejects.toThrow('aborted')
+
+      const calls = vi.mocked(gitTarget.git).mock.calls
+      expect(calls.some(([args]) => args[0] === 'rebase')).toBe(false)
+      const cleanup = calls.find(([args]) => args[0] === 'update-ref')
+      expect(cleanup?.[2]?.signal).toBeUndefined()
+      expect(rejectFetch).toBeTypeOf('function')
+    })
 
     it('fetches the explicit publish target remote', async () => {
       const bareDir = mkdtempSync(path.join(tmpdir(), 'relay-git-fork-bare-'))

--- a/src/relay/git-handler-remote-sync.test.ts
+++ b/src/relay/git-handler-remote-sync.test.ts
@@ -217,6 +217,17 @@ describe('GitHandler', () => {
         await expect(fs.access(path.join(tmpDir, 'topic.txt'))).resolves.toBeUndefined()
         await expect(fs.access(path.join(tmpDir, 'discarded.txt'))).rejects.toThrow()
         expect(
+          execFileSync('git', ['rev-parse', `origin/${branch}`], {
+            cwd: tmpDir,
+            encoding: 'utf-8'
+          }).trim()
+        ).toBe(
+          execFileSync('git', ['rev-parse', branch], {
+            cwd: producerDir,
+            encoding: 'utf-8'
+          }).trim()
+        )
+        expect(
           execFileSync('git', ['for-each-ref', '--format=%(refname)', 'refs/orca/rebase'], {
             cwd: tmpDir,
             encoding: 'utf-8'

--- a/src/relay/git-handler-remote-sync.test.ts
+++ b/src/relay/git-handler-remote-sync.test.ts
@@ -241,6 +241,92 @@ describe('GitHandler', () => {
       }
     }, 15_000)
 
+    it('rebases the selected linked worktree without moving the source worktree', async () => {
+      const bareDir = mkdtempSync(path.join(tmpdir(), 'relay-git-linked-rebase-bare-'))
+      const producerParent = mkdtempSync(path.join(tmpdir(), 'relay-git-linked-rebase-producer-'))
+      const producerDir = path.join(producerParent, 'repo')
+      const targetParent = mkdtempSync(path.join(tmpdir(), 'relay-git-linked-rebase-target-'))
+      const targetDir = path.join(targetParent, 'feature')
+      try {
+        execFileSync('git', ['init', '--bare'], { cwd: bareDir, stdio: 'pipe' })
+        gitInit(tmpDir)
+        writeFileSync(path.join(tmpDir, 'base.txt'), 'base')
+        gitCommit(tmpDir, 'base')
+        const baseBranch = execFileSync('git', ['branch', '--show-current'], {
+          cwd: tmpDir,
+          encoding: 'utf-8'
+        }).trim()
+        execFileSync('git', ['remote', 'add', 'origin', bareDir], { cwd: tmpDir, stdio: 'pipe' })
+        execFileSync('git', ['push', '--set-upstream', 'origin', baseBranch], {
+          cwd: tmpDir,
+          stdio: 'pipe'
+        })
+        execFileSync('git', ['worktree', 'add', '-b', 'feature', targetDir, 'HEAD'], {
+          cwd: tmpDir,
+          stdio: 'pipe'
+        })
+        writeFileSync(path.join(targetDir, 'topic.txt'), 'topic')
+        gitCommit(targetDir, 'topic')
+        writeFileSync(path.join(tmpDir, 'source-dirty.txt'), 'leave me alone')
+        const sourceHeadBefore = execFileSync('git', ['rev-parse', 'HEAD'], {
+          cwd: tmpDir,
+          encoding: 'utf-8'
+        }).trim()
+        const sourceStatusBefore = execFileSync('git', ['status', '--short'], {
+          cwd: tmpDir,
+          encoding: 'utf-8'
+        })
+
+        execFileSync('git', ['clone', bareDir, producerDir], { stdio: 'pipe' })
+        execFileSync('git', ['config', 'user.email', 'test@test.com'], {
+          cwd: producerDir,
+          stdio: 'pipe'
+        })
+        execFileSync('git', ['config', 'user.name', 'Test'], { cwd: producerDir, stdio: 'pipe' })
+        execFileSync('git', ['checkout', baseBranch], { cwd: producerDir, stdio: 'pipe' })
+        writeFileSync(path.join(producerDir, 'latest.txt'), 'latest')
+        gitCommit(producerDir, 'latest base')
+        const latestBaseOid = execFileSync('git', ['rev-parse', 'HEAD'], {
+          cwd: producerDir,
+          encoding: 'utf-8'
+        }).trim()
+        execFileSync('git', ['push', 'origin', baseBranch], { cwd: producerDir, stdio: 'pipe' })
+
+        await dispatcher.callRequest('git.rebaseFromBase', {
+          worktreePath: targetDir,
+          baseRef: `origin/${baseBranch}`
+        })
+
+        expect(execFileSync('git', ['rev-parse', 'HEAD'], { cwd: tmpDir }).toString().trim()).toBe(
+          sourceHeadBefore
+        )
+        expect(execFileSync('git', ['status', '--short'], { cwd: tmpDir, encoding: 'utf-8' })).toBe(
+          sourceStatusBefore
+        )
+        expect(
+          execFileSync('git', ['rev-parse', 'HEAD~1'], { cwd: targetDir, encoding: 'utf-8' }).trim()
+        ).toBe(latestBaseOid)
+        expect(
+          execFileSync('git', ['reflog', '-1', '--format=%gs'], {
+            cwd: targetDir,
+            encoding: 'utf-8'
+          })
+        ).toContain('rebase (finish)')
+        expect(
+          execFileSync('git', ['for-each-ref', '--format=%(refname)', 'refs/orca/rebase'], {
+            cwd: targetDir,
+            encoding: 'utf-8'
+          }).trim()
+        ).toBe('')
+      } finally {
+        await Promise.all([
+          fs.rm(bareDir, { recursive: true, force: true }),
+          fs.rm(producerParent, { recursive: true, force: true }),
+          fs.rm(targetParent, { recursive: true, force: true })
+        ])
+      }
+    }, 15_000)
+
     it('fast-forwards an unborn branch from the selected remote base', async () => {
       const bareDir = mkdtempSync(path.join(tmpdir(), 'relay-git-unborn-bare-'))
       const producerDir = mkdtempSync(path.join(tmpdir(), 'relay-git-unborn-producer-'))

--- a/src/relay/git-handler-remote-sync.test.ts
+++ b/src/relay/git-handler-remote-sync.test.ts
@@ -399,6 +399,7 @@ describe('GitHandler', () => {
       const calls = vi.mocked(gitTarget.git).mock.calls
       expect(calls.some(([args]) => args[0] === 'rebase')).toBe(false)
       const cleanup = calls.find(([args]) => args[0] === 'update-ref')
+      expect(cleanup).toBeDefined()
       expect(cleanup?.[2]?.signal).toBeUndefined()
       expect(rejectFetch).toBeTypeOf('function')
     })

--- a/src/relay/git-handler-termination.test.ts
+++ b/src/relay/git-handler-termination.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { runProcessMock } = vi.hoisted(() => ({ runProcessMock: vi.fn() }))
+
+vi.mock('../shared/child-process/run-process', () => ({ runProcess: runProcessMock }))
+
+import { createGitHandlerRelay } from './git-handler-test-harness'
+
+type GitTerminationTarget = {
+  git(
+    args: string[],
+    cwd: string,
+    options: { signal?: AbortSignal; terminationBarrier: true; timeout?: number }
+  ): Promise<{ stdout: string; stderr: string }>
+}
+
+describe('GitHandler termination barrier', () => {
+  beforeEach(() => runProcessMock.mockReset())
+
+  it('rejects a zero-exit result that crossed its timeout', async () => {
+    runProcessMock.mockResolvedValue({
+      code: 0,
+      signal: null,
+      stdout: '',
+      stderr: '',
+      timedOut: true
+    })
+    const { handler } = createGitHandlerRelay()
+    const target = handler as unknown as GitTerminationTarget
+
+    await expect(
+      target.git(['status'], '/repo', { terminationBarrier: true, timeout: 1 })
+    ).rejects.toThrow('git status timed out.')
+  })
+
+  it('rejects a zero-exit result after caller cancellation', async () => {
+    runProcessMock.mockResolvedValue({
+      code: 0,
+      signal: null,
+      stdout: '',
+      stderr: '',
+      timedOut: false
+    })
+    const controller = new AbortController()
+    controller.abort()
+    const { handler } = createGitHandlerRelay()
+    const target = handler as unknown as GitTerminationTarget
+
+    await expect(
+      target.git(['status'], '/repo', {
+        signal: controller.signal,
+        terminationBarrier: true
+      })
+    ).rejects.toMatchObject({ name: 'AbortError' })
+  })
+})

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines -- Why: centralizes the git RPC protocol surface so local and SSH git behavior stay in one dispatch table. */
+import { randomUUID } from 'node:crypto'
 import { execFile, spawn, type ExecFileOptions } from 'node:child_process'
 import { promisify } from 'node:util'
 import * as path from 'node:path'
@@ -1132,17 +1133,48 @@ export class GitHandler {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
     const baseRef = params.baseRef as string
+    let rebaseRef: string | null = null
     try {
       try {
         const source = await resolveGitRemoteRebaseSource(
           ((args) => this.git(args, worktreePath)) as GitCommandRunner,
           baseRef
         )
-        await this.git(['pull', '--rebase', source.remoteName, source.branchName], worktreePath)
+        let forkPoint: string | null = null
+        try {
+          const { stdout } = await this.git(
+            ['merge-base', '--fork-point', `refs/remotes/${source.displayName}`, 'HEAD'],
+            worktreePath
+          )
+          forkPoint = stdout.trim() || null
+        } catch {
+          // A first fetch or an unhelpful reflog falls back to Git's merge-base behavior.
+        }
+        // Why: concurrent fetches can replace FETCH_HEAD and remote-tracking refs between fetch and rebase.
+        rebaseRef = `refs/orca/rebase/${randomUUID()}`
+        await this.git(
+          [
+            'fetch',
+            source.remoteName,
+            `+refs/heads/${source.branchName}:${rebaseRef}`
+          ],
+          worktreePath
+        )
+        await this.git(
+          forkPoint ? ['rebase', '--onto', rebaseRef, forkPoint] : ['rebase', rebaseRef],
+          worktreePath
+        )
       } catch (error) {
         throw new Error(normalizeGitErrorMessage(error, 'pull'))
       }
     } finally {
+      if (rebaseRef) {
+        try {
+          await this.git(['update-ref', '-d', rebaseRef], worktreePath)
+        } catch {
+          // Cleanup must not hide the fetch or rebase result.
+        }
+      }
       this.clearGitMutationReadCaches()
     }
   }

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -61,7 +61,10 @@ import {
 import { upstreamOnlyCommitsArePatchEquivalent } from '../shared/git-upstream-status'
 import { assertGitPushTargetShape } from '../shared/git-push-target-validation'
 import { getPublishTargetStatus, type GitCommandRunner } from '../shared/git-publish-target-status'
-import { resolveGitRemoteRebaseSource } from '../shared/git-rebase-source'
+import {
+  REBASE_SOURCE_FETCH_TIMEOUT_MS,
+  resolveGitRemoteRebaseSource
+} from '../shared/git-rebase-source'
 import type { GitPushTarget } from '../shared/worktree/types'
 import {
   getEffectiveGitUpstreamStatus,
@@ -1153,12 +1156,9 @@ export class GitHandler {
         // Why: concurrent fetches can replace FETCH_HEAD and remote-tracking refs between fetch and rebase.
         rebaseRef = `refs/orca/rebase/${randomUUID()}`
         await this.git(
-          [
-            'fetch',
-            source.remoteName,
-            `+refs/heads/${source.branchName}:${rebaseRef}`
-          ],
-          worktreePath
+          ['fetch', source.remoteName, `+refs/heads/${source.branchName}:${rebaseRef}`],
+          worktreePath,
+          { timeout: REBASE_SOURCE_FETCH_TIMEOUT_MS }
         )
         await this.git(
           forkPoint ? ['rebase', '--onto', rebaseRef, forkPoint] : ['rebase', rebaseRef],

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -61,7 +61,10 @@ import {
 import { upstreamOnlyCommitsArePatchEquivalent } from '../shared/git-upstream-status'
 import { assertGitPushTargetShape } from '../shared/git-push-target-validation'
 import { getPublishTargetStatus, type GitCommandRunner } from '../shared/git-publish-target-status'
+import { isNoWriteFetchHeadUnsupportedError } from '../shared/git-fetch-head-capability'
+import { resolveGitFetchHeadCommand, runWithGitFetchHeadLock } from '../shared/git-fetch-head-lock'
 import {
+  REBASE_FROM_BASE_OPERATION_TIMEOUT_MS,
   REBASE_SOURCE_FETCH_TIMEOUT_MS,
   resolveGitRemoteRebaseSource
 } from '../shared/git-rebase-source'
@@ -100,10 +103,12 @@ import { endSubprocessStdin } from '../shared/subprocess-stdin-write'
 import { clearGitStatusLineStatsCache } from '../shared/git-status-line-stats-cache'
 import { invalidateGitBranchLineTotalInFlight } from '../shared/git-branch-line-total'
 import { streamRelayGitStdout } from './git-stdout-stream'
+import { runProcess } from '../shared/child-process/run-process'
 
 const execFileAsync = promisify(execFile)
 const MAX_GIT_BUFFER = 10 * 1024 * 1024
 const BULK_CHUNK_SIZE = 100
+const GIT_REBASE_PROCESS_FALLBACK_TIMEOUT_MS = 2_147_000_000
 
 function resolveSubmoduleStatusArea(
   params: Record<string, unknown>
@@ -182,6 +187,47 @@ function execFileWithStdin(
   })
 }
 
+async function runGitToTermination(
+  args: string[],
+  options: ExecFileOptions,
+  stdin: string | undefined
+): Promise<{ stdout: string; stderr: string }> {
+  const result = await runProcess({
+    program: 'git',
+    args,
+    cwd: typeof options.cwd === 'string' ? options.cwd : undefined,
+    env: options.env,
+    timeoutMs:
+      typeof options.timeout === 'number'
+        ? options.timeout
+        : GIT_REBASE_PROCESS_FALLBACK_TIMEOUT_MS,
+    maxOutputBytes: typeof options.maxBuffer === 'number' ? options.maxBuffer : MAX_GIT_BUFFER,
+    signal: options.signal,
+    terminationBarrier: true,
+    ...(stdin === undefined ? {} : { input: stdin })
+  })
+  if (result.code === 0 && !result.timedOut && !options.signal?.aborted) {
+    return { stdout: result.stdout, stderr: result.stderr }
+  }
+  const error = new Error(
+    result.timedOut
+      ? `git ${args[0] ?? 'command'} timed out.`
+      : options.signal?.aborted
+        ? 'The operation was aborted.'
+        : result.stderr.trim() || `git ${args[0] ?? 'command'} failed.`
+  )
+  if (options.signal?.aborted) {
+    error.name = 'AbortError'
+  }
+  throw Object.assign(error, {
+    code: result.code,
+    killed: result.timedOut || result.signal !== null || options.signal?.aborted === true,
+    signal: result.signal,
+    stdout: result.stdout,
+    stderr: result.stderr
+  })
+}
+
 export class GitHandler {
   private dispatcher: RelayDispatcher
   private readonly gitDiffReadDedupe = new InFlightPromiseDedupe<unknown>()
@@ -252,7 +298,7 @@ export class GitHandler {
     this.dispatcher.onRequest('git.push', (p) => this.push(p))
     this.dispatcher.onRequest('git.pull', (p) => this.pull(p))
     this.dispatcher.onRequest('git.fastForward', (p) => this.fastForward(p))
-    this.dispatcher.onRequest('git.rebaseFromBase', (p) => this.rebaseFromBase(p))
+    this.dispatcher.onRequest('git.rebaseFromBase', (p, context) => this.rebaseFromBase(p, context))
     this.dispatcher.onRequest('git.branchDiff', (p, context) => this.branchDiff(p, context))
     this.dispatcher.onRequest('git.commitDiff', (p, context) => this.commitDiff(p, context))
     this.dispatcher.onRequest('git.listWorktrees', (p, context) => this.listWorktrees(p, context))
@@ -333,25 +379,36 @@ export class GitHandler {
       nonInteractive?: boolean
       stdin?: string
       timeout?: number
+      terminationBarrier?: boolean
     }
   ): Promise<{ stdout: string; stderr: string }> {
-    const env = opts?.nonInteractive ? buildRelayUnattendedGitEnv() : buildRelayGitEnv()
-    if (opts?.disableOptionalLocks) {
-      env.GIT_OPTIONAL_LOCKS = '0'
+    const expandedCwd = expandTilde(cwd)
+    const run = async (): Promise<{ stdout: string; stderr: string }> => {
+      const env = opts?.nonInteractive ? buildRelayUnattendedGitEnv() : buildRelayGitEnv()
+      if (opts?.disableOptionalLocks) {
+        env.GIT_OPTIONAL_LOCKS = '0'
+      }
+      const execOptions = {
+        cwd: expandedCwd,
+        env,
+        encoding: 'utf-8',
+        maxBuffer: opts?.maxBuffer ?? MAX_GIT_BUFFER,
+        timeout: opts?.timeout,
+        signal: opts?.signal
+      } satisfies ExecFileOptions
+      if (opts?.terminationBarrier) {
+        return runGitToTermination(args, execOptions, opts.stdin)
+      }
+      if (opts?.stdin !== undefined) {
+        return execFileWithStdin('git', args, execOptions, opts.stdin)
+      }
+      const { stdout, stderr } = await execFileAsync('git', args, execOptions)
+      return { stdout: String(stdout), stderr: String(stderr) }
     }
-    const execOptions = {
-      cwd: expandTilde(cwd),
-      env,
-      encoding: 'utf-8',
-      maxBuffer: opts?.maxBuffer ?? MAX_GIT_BUFFER,
-      timeout: opts?.timeout,
-      signal: opts?.signal
-    } satisfies ExecFileOptions
-    if (opts?.stdin !== undefined) {
-      return execFileWithStdin('git', args, execOptions, opts.stdin)
-    }
-    const { stdout, stderr } = await execFileAsync('git', args, execOptions)
-    return { stdout: String(stdout), stderr: String(stderr) }
+    const command = resolveGitFetchHeadCommand(args, expandedCwd)
+    return command.needsLock
+      ? runWithGitFetchHeadLock(command.cwd, opts?.signal, run, command.gitDir)
+      : run()
   }
 
   private async gitBuffer(args: string[], cwd: string): Promise<Buffer> {
@@ -1132,37 +1189,76 @@ export class GitHandler {
     await this.pullWithArgs(params, ['--ff-only'])
   }
 
-  private async rebaseFromBase(params: Record<string, unknown>) {
+  private async rebaseFromBase(params: Record<string, unknown>, context?: RequestContext) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
     const baseRef = params.baseRef as string
     let rebaseRef: string | null = null
+    const controller = new AbortController()
+    const abortFromContext = () => controller.abort()
+    if (context?.signal?.aborted) {
+      controller.abort()
+    } else {
+      context?.signal?.addEventListener('abort', abortFromContext, { once: true })
+    }
+    const timeout = setTimeout(() => controller.abort(), REBASE_FROM_BASE_OPERATION_TIMEOUT_MS)
     try {
       try {
         const source = await resolveGitRemoteRebaseSource(
-          ((args) => this.git(args, worktreePath)) as GitCommandRunner,
+          ((args) =>
+            this.git(args, worktreePath, {
+              signal: controller.signal,
+              terminationBarrier: true
+            })) as GitCommandRunner,
           baseRef
         )
         let forkPoint: string | null = null
+        let hasHead = true
         try {
           const { stdout } = await this.git(
             ['merge-base', '--fork-point', `refs/remotes/${source.displayName}`, 'HEAD'],
-            worktreePath
+            worktreePath,
+            { signal: controller.signal, terminationBarrier: true }
           )
           forkPoint = stdout.trim() || null
         } catch {
           // A first fetch or an unhelpful reflog falls back to Git's merge-base behavior.
+          try {
+            await this.git(['rev-parse', '--verify', 'HEAD'], worktreePath, {
+              signal: controller.signal,
+              terminationBarrier: true
+            })
+          } catch {
+            hasHead = false
+          }
         }
         // Why: concurrent fetches can replace FETCH_HEAD and remote-tracking refs between fetch and rebase.
         rebaseRef = `refs/orca/rebase/${randomUUID()}`
-        await this.git(
-          ['fetch', source.remoteName, `+refs/heads/${source.branchName}:${rebaseRef}`],
-          worktreePath,
-          { timeout: REBASE_SOURCE_FETCH_TIMEOUT_MS }
+        const fetchArgs = [source.remoteName, `+refs/heads/${source.branchName}:${rebaseRef}`]
+        await this.gitCapabilities.runWithFallback(
+          'fetch-no-write-fetch-head',
+          () =>
+            this.git(['fetch', '--no-write-fetch-head', ...fetchArgs], worktreePath, {
+              timeout: REBASE_SOURCE_FETCH_TIMEOUT_MS,
+              signal: controller.signal,
+              terminationBarrier: true
+            }),
+          () =>
+            this.git(['fetch', ...fetchArgs], worktreePath, {
+              timeout: REBASE_SOURCE_FETCH_TIMEOUT_MS,
+              signal: controller.signal,
+              terminationBarrier: true
+            }),
+          isNoWriteFetchHeadUnsupportedError
         )
         await this.git(
-          forkPoint ? ['rebase', '--onto', rebaseRef, forkPoint] : ['rebase', rebaseRef],
-          worktreePath
+          hasHead
+            ? forkPoint
+              ? ['rebase', '--onto', rebaseRef, forkPoint]
+              : ['rebase', rebaseRef]
+            : ['merge', '--ff-only', rebaseRef],
+          worktreePath,
+          { signal: controller.signal, terminationBarrier: true }
         )
       } catch (error) {
         throw new Error(normalizeGitErrorMessage(error, 'pull'))
@@ -1175,6 +1271,8 @@ export class GitHandler {
           // Cleanup must not hide the fetch or rebase result.
         }
       }
+      clearTimeout(timeout)
+      context?.signal?.removeEventListener('abort', abortFromContext)
       this.clearGitMutationReadCaches()
     }
   }

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -1234,7 +1234,11 @@ export class GitHandler {
         }
         // Why: concurrent fetches can replace FETCH_HEAD and remote-tracking refs between fetch and rebase.
         rebaseRef = `refs/orca/rebase/${randomUUID()}`
-        const fetchArgs = [source.remoteName, `+refs/heads/${source.branchName}:${rebaseRef}`]
+        const fetchArgs = [
+          source.remoteName,
+          `+refs/heads/${source.branchName}:${rebaseRef}`,
+          `+refs/heads/${source.branchName}:refs/remotes/${source.displayName}`
+        ]
         await this.gitCapabilities.runWithFallback(
           'fetch-no-write-fetch-head',
           () =>

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -62,6 +62,7 @@ import { upstreamOnlyCommitsArePatchEquivalent } from '../shared/git-upstream-st
 import { assertGitPushTargetShape } from '../shared/git-push-target-validation'
 import { getPublishTargetStatus, type GitCommandRunner } from '../shared/git-publish-target-status'
 import { isNoWriteFetchHeadUnsupportedError } from '../shared/git-fetch-head-capability'
+import { runWithGitWorktreeOperationLock } from '../shared/git-worktree-operation-lock'
 import { resolveGitFetchHeadCommand, runWithGitFetchHeadLock } from '../shared/git-fetch-head-lock'
 import {
   REBASE_FROM_BASE_OPERATION_TIMEOUT_MS,
@@ -1190,6 +1191,12 @@ export class GitHandler {
   }
 
   private async rebaseFromBase(params: Record<string, unknown>, context?: RequestContext) {
+    return runWithGitWorktreeOperationLock(params.worktreePath as string, context?.signal, () =>
+      this.runRebaseFromBase(params, context)
+    )
+  }
+
+  private async runRebaseFromBase(params: Record<string, unknown>, context?: RequestContext) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
     const baseRef = params.baseRef as string

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -297,8 +297,8 @@ export class GitHandler {
       this.fetchGitLabMergeRequestHead(p)
     )
     this.dispatcher.onRequest('git.push', (p) => this.push(p))
-    this.dispatcher.onRequest('git.pull', (p) => this.pull(p))
-    this.dispatcher.onRequest('git.fastForward', (p) => this.fastForward(p))
+    this.dispatcher.onRequest('git.pull', (p, context) => this.pull(p, context))
+    this.dispatcher.onRequest('git.fastForward', (p, context) => this.fastForward(p, context))
     this.dispatcher.onRequest('git.rebaseFromBase', (p, context) => this.rebaseFromBase(p, context))
     this.dispatcher.onRequest('git.branchDiff', (p, context) => this.branchDiff(p, context))
     this.dispatcher.onRequest('git.commitDiff', (p, context) => this.commitDiff(p, context))
@@ -1143,7 +1143,21 @@ export class GitHandler {
     }
   }
 
-  private async pullWithArgs(params: Record<string, unknown>, pullArgs: string[]) {
+  private async pullWithArgs(
+    params: Record<string, unknown>,
+    pullArgs: string[],
+    signal?: AbortSignal
+  ) {
+    const worktreePath = params.worktreePath as string
+    return runWithGitWorktreeOperationLock(worktreePath, signal, () =>
+      this.runPullWithArgsUnlocked(params, pullArgs)
+    )
+  }
+
+  private async runPullWithArgsUnlocked(
+    params: Record<string, unknown>,
+    pullArgs: string[]
+  ): Promise<void> {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
     const runPull = async (effectiveArgs: string[]): Promise<void> => {
@@ -1181,13 +1195,13 @@ export class GitHandler {
     }
   }
 
-  private async pull(params: Record<string, unknown>) {
+  private async pull(params: Record<string, unknown>, context?: RequestContext) {
     // Why: plain `git pull` honors user merge/rebase/ff policy.
-    await this.pullWithArgs(params, [])
+    await this.pullWithArgs(params, [], context?.signal)
   }
 
-  private async fastForward(params: Record<string, unknown>) {
-    await this.pullWithArgs(params, ['--ff-only'])
+  private async fastForward(params: Record<string, unknown>, context?: RequestContext) {
+    await this.pullWithArgs(params, ['--ff-only'], context?.signal)
   }
 
   private async rebaseFromBase(params: Record<string, unknown>, context?: RequestContext) {

--- a/src/renderer/src/runtime/runtime-git-client.test.ts
+++ b/src/renderer/src/runtime/runtime-git-client.test.ts
@@ -22,6 +22,7 @@ import {
   type RuntimeEnvironmentCallRequest
 } from './runtime-compatibility-test-fixture'
 import { clearRuntimeCompatibilityCacheForTests } from './runtime-rpc-client'
+import { REBASE_FROM_BASE_RPC_TIMEOUT_MS } from '../../../shared/git-rebase-source'
 
 const gitStatus = vi.fn()
 const gitCancelStatus = vi.fn()
@@ -616,7 +617,7 @@ describe('runtime git client', () => {
       selector: 'env-1',
       method: 'git.rebaseFromBase',
       params: { worktree: 'id:wt-1', baseRef: 'origin/main' },
-      timeoutMs: 30_000
+      timeoutMs: REBASE_FROM_BASE_RPC_TIMEOUT_MS
     })
   })
 

--- a/src/renderer/src/runtime/runtime-git-client.ts
+++ b/src/renderer/src/runtime/runtime-git-client.ts
@@ -23,6 +23,7 @@ import type { HostedReviewProvider } from '../../../shared/hosted-review'
 import type { ResolvedSourceControlAiGenerationParams } from '../../../shared/source-control-ai'
 import { getCommitMessageModelDiscoveryHostKeyForScope } from '../../../shared/commit-message-host-key'
 import type { GitHistoryOptions, GitHistoryResult } from '../../../shared/git-history'
+import { REBASE_FROM_BASE_RPC_TIMEOUT_MS } from '../../../shared/git-rebase-source'
 import { getRepoIdFromWorktreeId, splitWorktreeIdForFilesystem } from '../../../shared/worktree/id'
 import { callRuntimeRpc, getActiveRuntimeTarget } from './runtime-rpc-client'
 import { toRuntimeWorktreeSelector } from './runtime-worktree-selector'
@@ -548,7 +549,7 @@ export async function rebaseRuntimeGitFromBase(
     target,
     'git.rebaseFromBase',
     { worktree: toRuntimeWorktreeSelector(context.worktreeId), baseRef },
-    { timeoutMs: 30_000 }
+    { timeoutMs: REBASE_FROM_BASE_RPC_TIMEOUT_MS }
   )
 }
 

--- a/src/shared/child-process/process-tree-termination.test.ts
+++ b/src/shared/child-process/process-tree-termination.test.ts
@@ -1,0 +1,74 @@
+import { EventEmitter } from 'node:events'
+import type { ChildProcess } from 'node:child_process'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }))
+
+vi.mock('node:child_process', () => ({ spawn: spawnMock }))
+
+import { forceTerminateProcessTree } from './process-tree-termination'
+
+function mockProcess(pid: number): ChildProcess {
+  const child = new EventEmitter() as EventEmitter & {
+    pid: number
+    kill: ReturnType<typeof vi.fn>
+  }
+  child.pid = pid
+  child.kill = vi.fn((_signal?: NodeJS.Signals | number) => true)
+  return child as unknown as ChildProcess
+}
+
+async function withWindows(run: () => Promise<void>): Promise<void> {
+  const original = process.platform
+  Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+  try {
+    await run()
+  } finally {
+    Object.defineProperty(process, 'platform', { configurable: true, value: original })
+  }
+}
+
+describe('forceTerminateProcessTree', () => {
+  afterEach(() => {
+    spawnMock.mockReset()
+    vi.useRealTimers()
+  })
+
+  it('waits for Windows taskkill tree completion', async () => {
+    await withWindows(async () => {
+      const child = mockProcess(1234)
+      const taskkill = mockProcess(5678)
+      spawnMock.mockReturnValue(taskkill)
+      let settled = false
+      const pending = forceTerminateProcessTree(child)
+      void pending.then(() => {
+        settled = true
+      })
+
+      await Promise.resolve()
+      expect(settled).toBe(false)
+      expect(spawnMock).toHaveBeenCalledWith(
+        'taskkill',
+        ['/pid', '1234', '/t', '/f'],
+        expect.objectContaining({ shell: false, windowsHide: true })
+      )
+
+      taskkill.emit('close', 0)
+      await expect(pending).resolves.toBe(true)
+      expect(child.kill).not.toHaveBeenCalled()
+    })
+  })
+
+  it('falls back to the root when Windows tree termination fails', async () => {
+    await withWindows(async () => {
+      const child = mockProcess(1234)
+      const taskkill = mockProcess(5678)
+      spawnMock.mockReturnValue(taskkill)
+      const pending = forceTerminateProcessTree(child)
+
+      taskkill.emit('close', 1)
+      await expect(pending).resolves.toBe(false)
+      expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+    })
+  })
+})

--- a/src/shared/child-process/process-tree-termination.test.ts
+++ b/src/shared/child-process/process-tree-termination.test.ts
@@ -31,6 +31,7 @@ async function withWindows(run: () => Promise<void>): Promise<void> {
 describe('forceTerminateProcessTree', () => {
   afterEach(() => {
     spawnMock.mockReset()
+    vi.restoreAllMocks()
     vi.useRealTimers()
   })
 
@@ -71,4 +72,27 @@ describe('forceTerminateProcessTree', () => {
       expect(child.kill).toHaveBeenCalledWith('SIGKILL')
     })
   })
+
+  it.skipIf(process.platform === 'win32')(
+    'stops waiting when a POSIX process group cannot become quiescent',
+    async () => {
+      vi.useFakeTimers()
+      vi.spyOn(process, 'kill').mockImplementation(() => true)
+      spawnMock.mockImplementation(() => {
+        const probe = mockProcess(5678)
+        const stdout = new EventEmitter()
+        Object.defineProperty(probe, 'stdout', { value: stdout })
+        queueMicrotask(() => {
+          stdout.emit('data', Buffer.from('1234 D\n'))
+          probe.emit('close', 0)
+        })
+        return probe
+      })
+
+      const pending = forceTerminateProcessTree(mockProcess(1234))
+      await vi.advanceTimersByTimeAsync(2_100)
+
+      await expect(pending).resolves.toBe(false)
+    }
+  )
 })

--- a/src/shared/child-process/process-tree-termination.ts
+++ b/src/shared/child-process/process-tree-termination.ts
@@ -1,0 +1,150 @@
+import { spawn as nodeSpawn, type ChildProcess } from 'node:child_process'
+
+const PROBE_INTERVAL_MS = 25
+const SUBPROCESS_TIMEOUT_MS = 2_000
+const MAX_PS_OUTPUT_BYTES = 8 * 1024 * 1024
+
+export function signalProcessTree(child: ChildProcess, signal?: NodeJS.Signals): Promise<boolean> {
+  if (!child.pid) {
+    killRoot(child, signal)
+    return Promise.resolve(true)
+  }
+  if (process.platform === 'win32') {
+    return taskkillTree(child, signal)
+  }
+  try {
+    process.kill(-child.pid, signal)
+    return Promise.resolve(true)
+  } catch {
+    return Promise.resolve(!processGroupExists(child.pid))
+  }
+}
+
+export async function forceTerminateProcessTree(child: ChildProcess): Promise<boolean> {
+  const signaled = await signalProcessTree(child, 'SIGKILL')
+  if (!signaled) {
+    return false
+  }
+  if (process.platform !== 'win32' && child.pid) {
+    await waitForPosixProcessGroupQuiescence(child.pid)
+  }
+  return true
+}
+
+function taskkillTree(child: ChildProcess, signal?: NodeJS.Signals): Promise<boolean> {
+  return new Promise((resolve) => {
+    let killer: ChildProcess
+    try {
+      killer = nodeSpawn('taskkill', ['/pid', String(child.pid), '/t', '/f'], {
+        stdio: 'ignore',
+        windowsHide: true,
+        shell: false
+      })
+    } catch {
+      killRoot(child, signal)
+      resolve(false)
+      return
+    }
+    let settled = false
+    const finish = (fallback: boolean): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      if (fallback) {
+        killRoot(child, signal)
+      }
+      resolve(!fallback)
+    }
+    killer.once('error', () => finish(true))
+    killer.once('close', (code) => finish(code !== 0))
+    const timer = setTimeout(() => {
+      killer.kill()
+      finish(true)
+    }, SUBPROCESS_TIMEOUT_MS)
+    timer.unref?.()
+  })
+}
+
+async function waitForPosixProcessGroupQuiescence(processGroupId: number): Promise<void> {
+  while (true) {
+    const states = await readPosixProcessGroupStates(processGroupId)
+    if (
+      states ? states.every((state) => state.startsWith('Z')) : !processGroupExists(processGroupId)
+    ) {
+      return
+    }
+    await new Promise<void>((resolve) => setTimeout(resolve, PROBE_INTERVAL_MS))
+  }
+}
+
+function readPosixProcessGroupStates(processGroupId: number): Promise<string[] | null> {
+  return new Promise((resolve) => {
+    let probe: ChildProcess
+    try {
+      probe = nodeSpawn('ps', ['-axo', 'pgid=,state='], {
+        stdio: ['ignore', 'pipe', 'ignore'],
+        windowsHide: true,
+        shell: false
+      })
+    } catch {
+      resolve(null)
+      return
+    }
+    let output = ''
+    let truncated = false
+    let settled = false
+    const finish = (states: string[] | null): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      resolve(states)
+    }
+    probe.stdout?.on('data', (chunk: Buffer | string) => {
+      const text = chunk.toString()
+      if (output.length + text.length > MAX_PS_OUTPUT_BYTES) {
+        truncated = true
+        return
+      }
+      output += text
+    })
+    probe.stdout?.on('error', () => {})
+    probe.once('error', () => finish(null))
+    probe.once('close', (code) => {
+      if (code !== 0 || truncated) {
+        finish(null)
+        return
+      }
+      const states = output.split('\n').flatMap((line) => {
+        const match = line.trim().match(/^(\d+)\s+(\S+)/)
+        return match && Number(match[1]) === processGroupId ? [match[2]] : []
+      })
+      finish(states)
+    })
+    const timer = setTimeout(() => {
+      probe.kill()
+      finish(null)
+    }, SUBPROCESS_TIMEOUT_MS)
+    timer.unref?.()
+  })
+}
+
+function processGroupExists(processGroupId: number): boolean {
+  try {
+    process.kill(-processGroupId, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== 'ESRCH'
+  }
+}
+
+function killRoot(child: ChildProcess, signal?: NodeJS.Signals): void {
+  try {
+    child.kill(signal)
+  } catch {
+    /* already gone */
+  }
+}

--- a/src/shared/child-process/process-tree-termination.ts
+++ b/src/shared/child-process/process-tree-termination.ts
@@ -26,7 +26,7 @@ export async function forceTerminateProcessTree(child: ChildProcess): Promise<bo
     return false
   }
   if (process.platform !== 'win32' && child.pid) {
-    await waitForPosixProcessGroupQuiescence(child.pid)
+    return waitForPosixProcessGroupQuiescence(child.pid)
   }
   return true
 }
@@ -67,13 +67,17 @@ function taskkillTree(child: ChildProcess, signal?: NodeJS.Signals): Promise<boo
   })
 }
 
-async function waitForPosixProcessGroupQuiescence(processGroupId: number): Promise<void> {
+async function waitForPosixProcessGroupQuiescence(processGroupId: number): Promise<boolean> {
+  const deadline = Date.now() + SUBPROCESS_TIMEOUT_MS
   while (true) {
     const states = await readPosixProcessGroupStates(processGroupId)
     if (
       states ? states.every((state) => state.startsWith('Z')) : !processGroupExists(processGroupId)
     ) {
-      return
+      return true
+    }
+    if (Date.now() >= deadline) {
+      return false
     }
     await new Promise<void>((resolve) => setTimeout(resolve, PROBE_INTERVAL_MS))
   }

--- a/src/shared/child-process/process-tree-termination.ts
+++ b/src/shared/child-process/process-tree-termination.ts
@@ -4,6 +4,13 @@ const PROBE_INTERVAL_MS = 25
 const SUBPROCESS_TIMEOUT_MS = 2_000
 const MAX_PS_OUTPUT_BYTES = 8 * 1024 * 1024
 
+/**
+ * Signal the child's whole tree.
+ *
+ * POSIX precondition: the child must have been spawned `detached`. The signal
+ * goes to the process group `-child.pid`, so a child that is not its own group
+ * leader would hand it to whatever group it inherited instead.
+ */
 export function signalProcessTree(child: ChildProcess, signal?: NodeJS.Signals): Promise<boolean> {
   if (!child.pid) {
     killRoot(child, signal)

--- a/src/shared/child-process/run-process-termination-failure.test.ts
+++ b/src/shared/child-process/run-process-termination-failure.test.ts
@@ -1,0 +1,104 @@
+import { EventEmitter } from 'node:events'
+import type { ChildProcess } from 'node:child_process'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { forceTerminateProcessTreeMock, signalProcessTreeMock, spawnMock } = vi.hoisted(() => ({
+  forceTerminateProcessTreeMock: vi.fn(),
+  signalProcessTreeMock: vi.fn(),
+  spawnMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({ spawn: spawnMock, spawnSync: vi.fn() }))
+vi.mock('./process-tree-termination', () => ({
+  forceTerminateProcessTree: forceTerminateProcessTreeMock,
+  signalProcessTree: signalProcessTreeMock
+}))
+
+import { runProcess } from './run-process'
+
+function mockChild(): ChildProcess {
+  const child = new EventEmitter() as EventEmitter & Record<string, unknown>
+  child.pid = 1234
+  child.kill = vi.fn(() => true)
+  child.stdin = Object.assign(new EventEmitter(), { end: vi.fn() })
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  return child as unknown as ChildProcess
+}
+
+describe('runProcess termination failure', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    signalProcessTreeMock.mockResolvedValue(false)
+    forceTerminateProcessTreeMock.mockResolvedValue(false)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.clearAllMocks()
+  })
+
+  it('waits for root exit when bounded tree termination cannot be verified', async () => {
+    const child = mockChild()
+    spawnMock.mockReturnValue(child)
+    const pending = runProcess({ program: 'git', timeoutMs: 10, terminationBarrier: true })
+    let settled = false
+    void pending.then(() => {
+      settled = true
+    })
+
+    await vi.advanceTimersByTimeAsync(10)
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(settled).toBe(false)
+    child.emit('exit', null, 'SIGKILL')
+
+    await expect(pending).resolves.toMatchObject({ timedOut: true })
+  })
+
+  it('settles without close after forced tree termination is verified', async () => {
+    forceTerminateProcessTreeMock.mockResolvedValue(true)
+    spawnMock.mockReturnValue(mockChild())
+    const pending = runProcess({ program: 'git', timeoutMs: 10, terminationBarrier: true })
+
+    await vi.advanceTimersByTimeAsync(2_010)
+
+    await expect(pending).resolves.toMatchObject({ timedOut: true })
+  })
+
+  it('retains a root exit observed before barrier shutdown', async () => {
+    const controller = new AbortController()
+    const child = mockChild()
+    spawnMock.mockReturnValue(child)
+    const pending = runProcess({
+      program: 'git',
+      timeoutMs: 60_000,
+      signal: controller.signal,
+      terminationBarrier: true
+    })
+
+    child.emit('exit', 0, null)
+    controller.abort()
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    await expect(pending).resolves.toMatchObject({ code: 0, timedOut: false })
+  })
+
+  it('defers a shutdown error until root exit is confirmed', async () => {
+    const child = mockChild()
+    spawnMock.mockReturnValue(child)
+    const pending = runProcess({ program: 'git', timeoutMs: 10, terminationBarrier: true })
+    const rejection = expect(pending).rejects.toThrow('kill failed')
+    let settled = false
+    void pending.catch(() => {
+      settled = true
+    })
+
+    await vi.advanceTimersByTimeAsync(10)
+    child.emit('error', new Error('kill failed'))
+    await vi.advanceTimersByTimeAsync(2_000)
+    expect(settled).toBe(false)
+    child.emit('exit', null, 'SIGKILL')
+
+    await rejection
+  })
+})

--- a/src/shared/child-process/run-process-termination-failure.test.ts
+++ b/src/shared/child-process/run-process-termination-failure.test.ts
@@ -38,7 +38,7 @@ describe('runProcess termination failure', () => {
     vi.clearAllMocks()
   })
 
-  it('waits for root exit when bounded tree termination cannot be verified', async () => {
+  it('holds the result until the barrier deadline when tree termination cannot be verified', async () => {
     const child = mockChild()
     spawnMock.mockReturnValue(child)
     const pending = runProcess({ program: 'git', timeoutMs: 10, terminationBarrier: true })
@@ -52,6 +52,8 @@ describe('runProcess termination failure', () => {
     expect(settled).toBe(false)
     child.emit('exit', null, 'SIGKILL')
 
+    expect(settled).toBe(false)
+    await vi.advanceTimersByTimeAsync(10_000)
     await expect(pending).resolves.toMatchObject({ timedOut: true })
   })
 
@@ -118,6 +120,28 @@ describe('runProcess termination failure', () => {
     expect(settled).toBe(false)
     child.emit('exit', null, 'SIGKILL')
 
+    await vi.advanceTimersByTimeAsync(10_000)
     await rejection
+  })
+
+  it('kills the root when an object barrier cannot verify tree termination', async () => {
+    const child = mockChild()
+    spawnMock.mockReturnValue(child)
+    const pending = runProcess({
+      program: 'wsl.exe',
+      timeoutMs: 10,
+      terminationBarrier: {
+        signal: vi.fn().mockResolvedValue(false),
+        force: vi.fn().mockResolvedValue(false)
+      }
+    })
+    void pending.catch(() => {})
+
+    await vi.advanceTimersByTimeAsync(2_010)
+
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL')
+    child.emit('exit', null, 'SIGKILL')
+    await vi.advanceTimersByTimeAsync(10_000)
+    await expect(pending).resolves.toMatchObject({ timedOut: true })
   })
 })

--- a/src/shared/child-process/run-process-termination-failure.test.ts
+++ b/src/shared/child-process/run-process-termination-failure.test.ts
@@ -55,14 +55,33 @@ describe('runProcess termination failure', () => {
     await expect(pending).resolves.toMatchObject({ timedOut: true })
   })
 
-  it('settles without close after forced tree termination is verified', async () => {
-    forceTerminateProcessTreeMock.mockResolvedValue(true)
+  // Windows takes the taskkill branch, which never consults forceTerminateProcessTree.
+  it.skipIf(process.platform === 'win32')(
+    'settles without close after forced tree termination is verified',
+    async () => {
+      forceTerminateProcessTreeMock.mockResolvedValue(true)
+      spawnMock.mockReturnValue(mockChild())
+      const pending = runProcess({ program: 'git', timeoutMs: 10, terminationBarrier: true })
+
+      await vi.advanceTimersByTimeAsync(2_010)
+
+      await expect(pending).resolves.toMatchObject({ timedOut: true })
+    }
+  )
+
+  it('settles on the barrier deadline when the root never reports', async () => {
     spawnMock.mockReturnValue(mockChild())
     const pending = runProcess({ program: 'git', timeoutMs: 10, terminationBarrier: true })
+    let settled = false
+    void pending.then(() => {
+      settled = true
+    })
 
     await vi.advanceTimersByTimeAsync(2_010)
+    expect(settled).toBe(false)
+    await vi.advanceTimersByTimeAsync(10_000)
 
-    await expect(pending).resolves.toMatchObject({ timedOut: true })
+    await expect(pending).resolves.toMatchObject({ code: null, timedOut: true })
   })
 
   it('retains a root exit observed before barrier shutdown', async () => {

--- a/src/shared/child-process/run-process.test.ts
+++ b/src/shared/child-process/run-process.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'vitest'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import * as path from 'node:path'
 import { resolveSpawn, runProcess, runProcessSync } from './run-process'
 import { WINDOWS_ARGUMENT_CORPUS } from './__fixtures__/windows-argument-corpus'
 
@@ -126,6 +129,42 @@ describe('abort', () => {
     // Not a timeout: the caller asked it to stop.
     expect(result.timedOut).toBe(false)
   }, 20_000)
+
+  it.skipIf(process.platform === 'win32')(
+    'kills the process group and waits for confirmed root exit with a termination barrier',
+    async () => {
+      const root = await mkdtemp(path.join(tmpdir(), 'run-process-barrier-'))
+      const marker = path.join(root, 'descendant-state')
+      const descendantScript =
+        `printf ready > "$1";trap 'printf signaled > "$1"' TERM;` + `while :;do sleep 1;done`
+      const controller = new AbortController()
+      const pending = runProcess({
+        program: process.execPath,
+        args: [
+          '-e',
+          `const {spawn}=require('node:child_process');` +
+            `spawn('/bin/sh',${JSON.stringify(['-c', descendantScript, 'sh', marker])},{stdio:'ignore'});` +
+            `setInterval(()=>{},1000)`
+        ],
+        timeoutMs: 60_000,
+        signal: controller.signal,
+        terminationBarrier: true
+      })
+      try {
+        await expect
+          .poll(() => readFile(marker, 'utf8').catch(() => ''), { timeout: 10_000 })
+          .toBe('ready')
+        controller.abort()
+        await pending
+        await expect.poll(() => readFile(marker, 'utf8')).toBe('signaled')
+      } finally {
+        controller.abort()
+        await pending
+        await rm(root, { recursive: true, force: true })
+      }
+    },
+    30_000
+  )
 })
 
 describe('stdin delivery failures', () => {
@@ -151,8 +190,7 @@ describe('a signal that is already aborted', () => {
     controller.abort()
     const startedAt = Date.now()
     const result = await runProcess({
-      program: process.execPath,
-      args: ['-e', 'setInterval(() => {}, 1000)'],
+      program: path.join(tmpdir(), 'orca-must-not-spawn'),
       timeoutMs: 30_000,
       signal: controller.signal
     })

--- a/src/shared/child-process/run-process.ts
+++ b/src/shared/child-process/run-process.ts
@@ -5,6 +5,7 @@ import {
   type SpawnOptions as NodeSpawnOptions
 } from 'node:child_process'
 import { buildWindowsCmdShimCommandLine, isCmdInterpretedProgram } from './windows-command-line'
+import { forceTerminateProcessTree, signalProcessTree } from './process-tree-termination'
 
 /**
  * The single place Orca starts a child process.
@@ -39,6 +40,8 @@ export type ProcessSpec = {
   maxOutputBytes?: number
   /** Kills the process when aborted; the result still reports the exit. */
   signal?: AbortSignal
+  /** Kill the whole process tree and do not settle until the root confirms exit. */
+  terminationBarrier?: boolean
 }
 
 export type ProcessResult = {
@@ -89,7 +92,8 @@ export function resolveSpawn(spec: ProcessSpec, platform: NodeJS.Platform): Reso
     windowsHide: true,
     // Why never `shell: true`: it concatenates arguments without escaping (Node
     // itself warns DEP0190) and it silently makes windowsHide a no-op.
-    shell: false
+    shell: false,
+    ...(spec.terminationBarrier && platform !== 'win32' ? { detached: true } : {})
   }
 
   if (platform !== 'win32' || !isCmdInterpretedProgram(spec.program)) {
@@ -155,6 +159,9 @@ function createOutputSink(maxBytes: number): {
  * the process could not be started at all.
  */
 export function runProcess(spec: ProcessSpec): Promise<ProcessResult> {
+  if (spec.signal?.aborted) {
+    return Promise.resolve({ code: null, signal: null, stdout: '', stderr: '', timedOut: false })
+  }
   const maxOutputBytes = spec.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES
 
   return new Promise<ProcessResult>((resolve, reject) => {
@@ -170,6 +177,10 @@ export function runProcess(spec: ProcessSpec): Promise<ProcessResult> {
     const stderr = createOutputSink(maxOutputBytes)
     let timedOut = false
     let settled = false
+    let barrierStopping = false
+    let barrierReady = false
+    let initialBarrierTermination: Promise<boolean> | undefined
+    let deferredClose: { code: number | null; signal: NodeJS.Signals | null } | null = null
 
     const settle = (act: () => void): void => {
       if (settled) {
@@ -196,6 +207,11 @@ export function runProcess(spec: ProcessSpec): Promise<ProcessResult> {
 
     let graceTimer: ReturnType<typeof setTimeout> | undefined
 
+    const resolveFromClose = (code: number | null, signal: NodeJS.Signals | null): void =>
+      settle(() =>
+        resolve({ code, signal, stdout: stdout.text(), stderr: stderr.text(), timedOut })
+      )
+
     /**
      * Stop the child, then settle whether or not it complies.
      *
@@ -205,18 +221,53 @@ export function runProcess(spec: ProcessSpec): Promise<ProcessResult> {
      * promise, so a single unkillable child would wedge every one of them.
      */
     const stopAndSettle = (): void => {
-      terminate(child)
-      graceTimer ??= setTimeout(() => {
-        terminate(child, 'SIGKILL')
-        settle(() =>
-          resolve({
-            code: null,
-            signal: null,
-            stdout: stdout.text(),
-            stderr: stderr.text(),
-            timedOut
+      if (spec.terminationBarrier) {
+        barrierStopping = true
+        initialBarrierTermination ??= signalProcessTree(child)
+        if (process.platform === 'win32') {
+          void initialBarrierTermination.then((terminated) => {
+            if (!terminated) {
+              return
+            }
+            barrierReady = true
+            if (deferredClose) {
+              resolveFromClose(deferredClose.code, deferredClose.signal)
+            }
           })
-        )
+        }
+      } else {
+        terminate(child)
+      }
+      graceTimer ??= setTimeout(() => {
+        if (spec.terminationBarrier) {
+          const initialTermination = initialBarrierTermination ?? Promise.resolve(false)
+          if (process.platform === 'win32') {
+            void initialTermination.then((terminated) => {
+              if (!terminated) {
+                terminate(child, 'SIGKILL')
+              }
+              barrierReady = true
+              if (deferredClose) {
+                resolveFromClose(deferredClose.code, deferredClose.signal)
+              }
+            })
+            return
+          }
+          void Promise.all([initialTermination, forceTerminateProcessTree(child)]).then(
+            ([initialTerminated, forceTerminated]) => {
+              if (!initialTerminated || !forceTerminated) {
+                return
+              }
+              barrierReady = true
+              if (deferredClose) {
+                resolveFromClose(deferredClose.code, deferredClose.signal)
+              }
+            }
+          )
+          return
+        }
+        terminate(child, 'SIGKILL')
+        resolveFromClose(null, null)
       }, PROCESS_EXIT_GRACE_MS)
       graceTimer.unref?.()
     }
@@ -239,11 +290,13 @@ export function runProcess(spec: ProcessSpec): Promise<ProcessResult> {
     }
 
     child.once('error', (error) => settle(() => reject(error)))
-    child.once('close', (code, signal) =>
-      settle(() =>
-        resolve({ code, signal, stdout: stdout.text(), stderr: stderr.text(), timedOut })
-      )
-    )
+    child.once('close', (code, signal) => {
+      if (barrierStopping && !barrierReady) {
+        deferredClose = { code, signal }
+        return
+      }
+      resolveFromClose(code, signal)
+    })
 
     // Why close rather than leave open: a child that reads stdin (a hook
     // draining its payload, a CLI probing for a TTY) otherwise blocks until the
@@ -252,12 +305,7 @@ export function runProcess(spec: ProcessSpec): Promise<ProcessResult> {
   })
 }
 
-/**
- * Best-effort termination of a captured child.
- *
- * Deliberately root-only: descendant reaping is the job-object owner's
- * responsibility, not every caller's.
- */
+/** Best-effort root termination, or whole-tree termination for barrier callers. */
 function terminate(child: ChildProcess, signal?: NodeJS.Signals): void {
   try {
     child.kill(signal)

--- a/src/shared/child-process/run-process.ts
+++ b/src/shared/child-process/run-process.ts
@@ -40,8 +40,14 @@ export type ProcessSpec = {
   maxOutputBytes?: number
   /** Kills the process when aborted; the result still reports the exit. */
   signal?: AbortSignal
-  /** Kill the whole process tree and do not settle until the root confirms exit. */
-  terminationBarrier?: boolean
+  /** Kill the whole process tree and do not settle until termination is verified. */
+  terminationBarrier?: boolean | ProcessTerminationBarrier
+}
+
+export type ProcessTerminationBarrier = {
+  observeStderr?: (chunk: Buffer | string) => void
+  signal: (child: ChildProcess, signal?: NodeJS.Signals) => Promise<boolean>
+  force: (child: ChildProcess) => Promise<boolean>
 }
 
 export type ProcessResult = {
@@ -178,9 +184,12 @@ export function runProcess(spec: ProcessSpec): Promise<ProcessResult> {
     let timedOut = false
     let settled = false
     let barrierStopping = false
-    let barrierReady = false
+    let barrierAttemptComplete = false
+    let barrierTerminationVerified = false
     let initialBarrierTermination: Promise<boolean> | undefined
+    let deferredExit: { code: number | null; signal: NodeJS.Signals | null } | null = null
     let deferredClose: { code: number | null; signal: NodeJS.Signals | null } | null = null
+    let deferredError: Error | null = null
 
     const settle = (act: () => void): void => {
       if (settled) {
@@ -194,7 +203,12 @@ export function runProcess(spec: ProcessSpec): Promise<ProcessResult> {
     }
 
     child.stdout?.on('data', (chunk: Buffer | string) => stdout.write(chunk))
-    child.stderr?.on('data', (chunk: Buffer | string) => stderr.write(chunk))
+    child.stderr?.on('data', (chunk: Buffer | string) => {
+      stderr.write(chunk)
+      if (typeof spec.terminationBarrier === 'object') {
+        spec.terminationBarrier.observeStderr?.(chunk)
+      }
+    })
     // Why listeners that do nothing: an unhandled `error` on a stream is an
     // uncaught exception, and that takes the whole main process down. A child
     // that exits without reading makes the queued stdin write fail with EPIPE,
@@ -206,33 +220,51 @@ export function runProcess(spec: ProcessSpec): Promise<ProcessResult> {
     }
 
     let graceTimer: ReturnType<typeof setTimeout> | undefined
+    const signalBarrierTree = (signal?: NodeJS.Signals): Promise<boolean> =>
+      (typeof spec.terminationBarrier === 'object'
+        ? spec.terminationBarrier.signal(child, signal)
+        : signalProcessTree(child, signal)
+      ).catch(() => false)
+    const forceBarrierTree = (): Promise<boolean> =>
+      (typeof spec.terminationBarrier === 'object'
+        ? spec.terminationBarrier.force(child)
+        : forceTerminateProcessTree(child)
+      ).catch(() => false)
 
     const resolveFromClose = (code: number | null, signal: NodeJS.Signals | null): void =>
       settle(() =>
         resolve({ code, signal, stdout: stdout.text(), stderr: stderr.text(), timedOut })
       )
 
+    const resolveBarrierIfSafe = (): void => {
+      const rootExit = deferredClose ?? deferredExit
+      if (barrierTerminationVerified || (barrierAttemptComplete && rootExit)) {
+        if (deferredError) {
+          settle(() => reject(deferredError))
+        } else {
+          resolveFromClose(rootExit?.code ?? null, rootExit?.signal ?? null)
+        }
+      }
+    }
+
     /**
      * Stop the child, then settle whether or not it complies.
      *
-     * Why settle regardless: `close` only fires once the child is really gone,
-     * so one that traps the signal would hold the caller forever -- and both
-     * the pwsh cache and the snapshot reader hand later callers their in-flight
-     * promise, so a single unkillable child would wedge every one of them.
+     * Why bounded: a descendant can keep `close` pending after the root exits,
+     * but failed termination verification must not let callers mutate shared state.
      */
     const stopAndSettle = (): void => {
       if (spec.terminationBarrier) {
         barrierStopping = true
-        initialBarrierTermination ??= signalProcessTree(child)
+        initialBarrierTermination ??= signalBarrierTree()
         if (process.platform === 'win32') {
           void initialBarrierTermination.then((terminated) => {
             if (!terminated) {
               return
             }
-            barrierReady = true
-            if (deferredClose) {
-              resolveFromClose(deferredClose.code, deferredClose.signal)
-            }
+            barrierAttemptComplete = true
+            barrierTerminationVerified = true
+            resolveBarrierIfSafe()
           })
         }
       } else {
@@ -242,26 +274,31 @@ export function runProcess(spec: ProcessSpec): Promise<ProcessResult> {
         if (spec.terminationBarrier) {
           const initialTermination = initialBarrierTermination ?? Promise.resolve(false)
           if (process.platform === 'win32') {
+            if (typeof spec.terminationBarrier === 'object') {
+              void Promise.all([initialTermination, forceBarrierTree()]).then(
+                ([initialTerminated, forceTerminated]) => {
+                  barrierAttemptComplete = true
+                  barrierTerminationVerified = initialTerminated || forceTerminated
+                  resolveBarrierIfSafe()
+                }
+              )
+              return
+            }
             void initialTermination.then((terminated) => {
               if (!terminated) {
                 terminate(child, 'SIGKILL')
               }
-              barrierReady = true
-              if (deferredClose) {
-                resolveFromClose(deferredClose.code, deferredClose.signal)
-              }
+              barrierAttemptComplete = true
+              barrierTerminationVerified = terminated
+              resolveBarrierIfSafe()
             })
             return
           }
-          void Promise.all([initialTermination, forceTerminateProcessTree(child)]).then(
-            ([initialTerminated, forceTerminated]) => {
-              if (!initialTerminated || !forceTerminated) {
-                return
-              }
-              barrierReady = true
-              if (deferredClose) {
-                resolveFromClose(deferredClose.code, deferredClose.signal)
-              }
+          void Promise.all([initialTermination, forceBarrierTree()]).then(
+            ([_initialTerminated, forceTerminated]) => {
+              barrierAttemptComplete = true
+              barrierTerminationVerified = forceTerminated
+              resolveBarrierIfSafe()
             }
           )
           return
@@ -289,10 +326,24 @@ export function runProcess(spec: ProcessSpec): Promise<ProcessResult> {
       onAbort()
     }
 
-    child.once('error', (error) => settle(() => reject(error)))
+    child.once('error', (error) => {
+      if (barrierStopping) {
+        deferredError = error
+        resolveBarrierIfSafe()
+        return
+      }
+      settle(() => reject(error))
+    })
+    child.once('exit', (code, signal) => {
+      deferredExit = { code, signal }
+      if (barrierStopping) {
+        resolveBarrierIfSafe()
+      }
+    })
     child.once('close', (code, signal) => {
-      if (barrierStopping && !barrierReady) {
+      if (barrierStopping) {
         deferredClose = { code, signal }
+        resolveBarrierIfSafe()
         return
       }
       resolveFromClose(code, signal)

--- a/src/shared/child-process/run-process.ts
+++ b/src/shared/child-process/run-process.ts
@@ -198,6 +198,7 @@ export function runProcess(spec: ProcessSpec): Promise<ProcessResult> {
     let deferredExit: { code: number | null; signal: NodeJS.Signals | null } | null = null
     let deferredClose: { code: number | null; signal: NodeJS.Signals | null } | null = null
     let deferredError: Error | null = null
+    let rootExitedBeforeBarrier = false
 
     const settle = (act: () => void): void => {
       if (settled) {
@@ -257,7 +258,7 @@ export function runProcess(spec: ProcessSpec): Promise<ProcessResult> {
 
     const resolveBarrierIfSafe = (): void => {
       const rootExit = deferredClose ?? deferredExit
-      if (barrierTerminationVerified || (barrierAttemptComplete && rootExit)) {
+      if (barrierTerminationVerified || (rootExitedBeforeBarrier && rootExit)) {
         settleBarrierOutcome()
         return
       }
@@ -304,6 +305,11 @@ export function runProcess(spec: ProcessSpec): Promise<ProcessResult> {
                 ([initialTerminated, forceTerminated]) => {
                   barrierAttemptComplete = true
                   barrierTerminationVerified = initialTerminated || forceTerminated
+                  if (!barrierTerminationVerified) {
+                    // The barrier never confirmed the tree died, so the root
+                    // would otherwise outlive the abort or timeout.
+                    terminate(child, 'SIGKILL')
+                  }
                   resolveBarrierIfSafe()
                 }
               )
@@ -323,6 +329,9 @@ export function runProcess(spec: ProcessSpec): Promise<ProcessResult> {
             ([_initialTerminated, forceTerminated]) => {
               barrierAttemptComplete = true
               barrierTerminationVerified = forceTerminated
+              if (!barrierTerminationVerified) {
+                terminate(child, 'SIGKILL')
+              }
               resolveBarrierIfSafe()
             }
           )
@@ -360,12 +369,18 @@ export function runProcess(spec: ProcessSpec): Promise<ProcessResult> {
       settle(() => reject(error))
     })
     child.once('exit', (code, signal) => {
+      if (!barrierStopping) {
+        rootExitedBeforeBarrier = true
+      }
       deferredExit = { code, signal }
       if (barrierStopping) {
         resolveBarrierIfSafe()
       }
     })
     child.once('close', (code, signal) => {
+      if (!barrierStopping) {
+        rootExitedBeforeBarrier = true
+      }
       if (barrierStopping) {
         deferredClose = { code, signal }
         resolveBarrierIfSafe()

--- a/src/shared/child-process/run-process.ts
+++ b/src/shared/child-process/run-process.ts
@@ -71,6 +71,14 @@ export const DEFAULT_MAX_OUTPUT_BYTES = 8 * 1024 * 1024
  * caller the same dead promise.
  */
 const PROCESS_EXIT_GRACE_MS = 2_000
+/**
+ * Last resort for a barrier caller once tree termination could not be verified.
+ *
+ * Why bounded: waiting for the root's exit is what stops an unverified caller
+ * mutating shared state under a live child, but a tree that neither dies nor
+ * reports would otherwise leave the promise pending for the app's lifetime.
+ */
+const BARRIER_UNVERIFIED_EXIT_GRACE_MS = 10_000
 
 export type ResolvedSpawn = {
   file: string
@@ -198,6 +206,7 @@ export function runProcess(spec: ProcessSpec): Promise<ProcessResult> {
       settled = true
       clearTimeout(timer)
       clearTimeout(graceTimer)
+      clearTimeout(barrierDeadlineTimer)
       spec.signal?.removeEventListener('abort', onAbort)
       act()
     }
@@ -220,6 +229,7 @@ export function runProcess(spec: ProcessSpec): Promise<ProcessResult> {
     }
 
     let graceTimer: ReturnType<typeof setTimeout> | undefined
+    let barrierDeadlineTimer: ReturnType<typeof setTimeout> | undefined
     const signalBarrierTree = (signal?: NodeJS.Signals): Promise<boolean> =>
       (typeof spec.terminationBarrier === 'object'
         ? spec.terminationBarrier.signal(child, signal)
@@ -236,22 +246,37 @@ export function runProcess(spec: ProcessSpec): Promise<ProcessResult> {
         resolve({ code, signal, stdout: stdout.text(), stderr: stderr.text(), timedOut })
       )
 
+    const settleBarrierOutcome = (): void => {
+      const rootExit = deferredClose ?? deferredExit
+      if (deferredError) {
+        settle(() => reject(deferredError))
+        return
+      }
+      resolveFromClose(rootExit?.code ?? null, rootExit?.signal ?? null)
+    }
+
     const resolveBarrierIfSafe = (): void => {
       const rootExit = deferredClose ?? deferredExit
       if (barrierTerminationVerified || (barrierAttemptComplete && rootExit)) {
-        if (deferredError) {
-          settle(() => reject(deferredError))
-        } else {
-          resolveFromClose(rootExit?.code ?? null, rootExit?.signal ?? null)
-        }
+        settleBarrierOutcome()
+        return
       }
+      if (!barrierAttemptComplete) {
+        return
+      }
+      // Why a second deadline: the tree survived every attempt and the root has
+      // gone silent, so nothing else will ever settle this promise.
+      barrierDeadlineTimer ??= setTimeout(settleBarrierOutcome, BARRIER_UNVERIFIED_EXIT_GRACE_MS)
+      barrierDeadlineTimer.unref?.()
     }
 
     /**
-     * Stop the child, then settle whether or not it complies.
+     * Stop the child, then settle.
      *
-     * Why bounded: a descendant can keep `close` pending after the root exits,
-     * but failed termination verification must not let callers mutate shared state.
+     * Without a barrier, settle whether or not the child complies. With one, wait
+     * for verified tree termination or a root exit first — a descendant can keep
+     * `close` pending after the root exits, but failed verification must not let
+     * callers mutate shared state — then settle on the deadline regardless.
      */
     const stopAndSettle = (): void => {
       if (spec.terminationBarrier) {

--- a/src/shared/git-binary-compatibility.test.ts
+++ b/src/shared/git-binary-compatibility.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process'
-import { mkdtemp, rename, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { promisify } from 'node:util'
@@ -9,6 +9,7 @@ import {
   isUnsupportedMergeTreeWriteTreeError
 } from './git-merge-tree-capability'
 import { isForEachRefExcludeUnsupportedError } from './git-ref-command-capabilities'
+import { isNoWriteFetchHeadUnsupportedError } from './git-fetch-head-capability'
 import {
   hasUnsupportedRevParsePathFormatEcho,
   isUnsupportedWorktreeListZError
@@ -151,6 +152,14 @@ describeBinaryCompatibility('real Git binary compatibility', () => {
   })
 
   it('recognizes ref and merge-tree compatibility boundaries', async () => {
+    const fetchHeadPath = join(repoPath, '.git', 'FETCH_HEAD')
+    await writeFile(fetchHeadPath, 'sentinel\n')
+    await expectPreferredOrRecognizedFallback(
+      ['fetch', '--no-write-fetch-head', '.', '+HEAD:refs/orca/compat/no-write-fetch-head'],
+      supports(2, 29),
+      isNoWriteFetchHeadUnsupportedError
+    )
+    await expect(readFile(fetchHeadPath, 'utf-8')).resolves.toBe('sentinel\n')
     await expectPreferredOrRecognizedFallback(
       ['for-each-ref', '--format=%(refname)', '--exclude=refs/remotes/**/HEAD', '--count=10'],
       supports(2, 42),

--- a/src/shared/git-capability-cache.ts
+++ b/src/shared/git-capability-cache.ts
@@ -3,6 +3,7 @@
 export const GIT_CAPABILITY_RETRY_INTERVAL_MS = 30 * 60_000
 
 export type GitCapability =
+  | 'fetch-no-write-fetch-head'
   | 'for-each-ref-exclude'
   | 'merge-tree-merge-base'
   | 'merge-tree-write-tree'

--- a/src/shared/git-fetch-head-capability.test.ts
+++ b/src/shared/git-fetch-head-capability.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+import { isNoWriteFetchHeadUnsupportedError } from './git-fetch-head-capability'
+
+describe('isNoWriteFetchHeadUnsupportedError', () => {
+  it.each([
+    new Error("error: unknown option `no-write-fetch-head'"),
+    { stderr: "error: unrecognized option '--no-write-fetch-head'" },
+    { stdout: "fatal: invalid option: 'no-write-fetch-head'" }
+  ])('recognizes old-Git option rejection shapes', (error) => {
+    expect(isNoWriteFetchHeadUnsupportedError(error)).toBe(true)
+  })
+
+  it('does not classify an ordinary fetch failure as unsupported', () => {
+    expect(
+      isNoWriteFetchHeadUnsupportedError({ stderr: 'fatal: could not read from remote repository' })
+    ).toBe(false)
+  })
+})

--- a/src/shared/git-fetch-head-capability.ts
+++ b/src/shared/git-fetch-head-capability.ts
@@ -1,0 +1,16 @@
+function gitErrorText(error: unknown): string {
+  if (typeof error !== 'object' || error === null) {
+    return error instanceof Error ? error.message : String(error)
+  }
+  return ['message', 'stderr', 'stdout']
+    .map((key) => (error as Record<string, unknown>)[key])
+    .filter((value): value is string => typeof value === 'string')
+    .join('\n')
+}
+
+export function isNoWriteFetchHeadUnsupportedError(error: unknown): boolean {
+  const output = gitErrorText(error)
+  return /(?:unknown|invalid|unrecognized) option(?::\s*|\s+)[`']?(?:--?)?no-write-fetch-head[`']?(?:\s|$)/i.test(
+    output
+  )
+}

--- a/src/shared/git-fetch-head-lock.test.ts
+++ b/src/shared/git-fetch-head-lock.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
-import { mkdtemp, mkdir, rm, symlink } from 'node:fs/promises'
+import { describe, expect, it, vi } from 'vitest'
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import * as path from 'node:path'
 import { resolveGitFetchHeadCommand, runWithGitFetchHeadLock } from './git-fetch-head-lock'
@@ -10,6 +10,16 @@ describe('runWithGitFetchHeadLock', () => {
     { args: ['pull', '--rebase'], expected: true },
     { args: ['-c', 'maintenance.auto=false', 'fetch', 'origin'], expected: true },
     { args: ['fetch', '--no-write-fetch-head', 'origin'], expected: false },
+    {
+      args: [
+        'fetch',
+        '--no-write-fetch-head',
+        'origin',
+        '+refs/heads/main:refs/orca/rebase/one',
+        '+refs/heads/main:refs/remotes/origin/main'
+      ],
+      expected: true
+    },
     { args: ['fetch', '--no-write-fetch-head', '--write-fetch-head'], expected: true },
     { args: ['rev-parse', 'fetch'], expected: false }
   ])('classifies FETCH_HEAD operations: $args', ({ args, expected }) => {
@@ -139,6 +149,44 @@ describe('runWithGitFetchHeadLock', () => {
       expect(order[0]).toBe('root')
       expect(new Set(order.slice(1))).toEqual(new Set(['nested', 'alias']))
     } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('serializes linked worktrees through their shared Git directory', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'fetch-head-linked-lock-'))
+    const main = path.join(root, 'main')
+    const linked = path.join(root, 'linked')
+    const commonGitDir = path.join(main, '.git')
+    const linkedGitDir = path.join(commonGitDir, 'worktrees', 'linked')
+    await Promise.all([mkdir(linkedGitDir, { recursive: true }), mkdir(linked)])
+    await Promise.all([
+      writeFile(path.join(linked, '.git'), `gitdir: ${linkedGitDir}\n`),
+      writeFile(path.join(linkedGitDir, 'commondir'), '../..\n')
+    ])
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const order: string[] = []
+    const first = runWithGitFetchHeadLock(main, undefined, async () => {
+      order.push('main')
+      await gate
+    })
+    await vi.waitFor(() => expect(order).toEqual(['main']))
+    const second = runWithGitFetchHeadLock(linked, undefined, async () => {
+      order.push('linked')
+    })
+
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      expect(order).toEqual(['main'])
+      release()
+      await Promise.all([first, second])
+      expect(order).toEqual(['main', 'linked'])
+    } finally {
+      release()
+      await Promise.allSettled([first, second])
       await rm(root, { recursive: true, force: true })
     }
   })

--- a/src/shared/git-fetch-head-lock.test.ts
+++ b/src/shared/git-fetch-head-lock.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest'
+import { mkdtemp, mkdir, rm, symlink } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import * as path from 'node:path'
+import { resolveGitFetchHeadCommand, runWithGitFetchHeadLock } from './git-fetch-head-lock'
+
+describe('runWithGitFetchHeadLock', () => {
+  it.each([
+    { args: ['fetch', 'origin'], expected: true },
+    { args: ['pull', '--rebase'], expected: true },
+    { args: ['-c', 'maintenance.auto=false', 'fetch', 'origin'], expected: true },
+    { args: ['fetch', '--no-write-fetch-head', 'origin'], expected: false },
+    { args: ['fetch', '--no-write-fetch-head', '--write-fetch-head'], expected: true },
+    { args: ['rev-parse', 'fetch'], expected: false }
+  ])('classifies FETCH_HEAD operations: $args', ({ args, expected }) => {
+    expect(resolveGitFetchHeadCommand(args, '/repo').needsLock).toBe(expected)
+  })
+
+  it('resolves -C and --git-dir before deriving the lock identity', () => {
+    expect(resolveGitFetchHeadCommand(['-C', 'repo', 'fetch'], '/tmp')).toMatchObject({
+      cwd: '/tmp/repo',
+      needsLock: true
+    })
+    expect(resolveGitFetchHeadCommand(['--git-dir=/repo/.git', 'fetch'], '/tmp')).toMatchObject({
+      gitDir: '/repo/.git',
+      needsLock: true
+    })
+  })
+
+  it('serializes FETCH_HEAD users in one worktree without blocking another', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'fetch-head-lock-isolation-'))
+    const repo = path.join(root, 'repo')
+    const otherRepo = path.join(root, 'other')
+    await Promise.all([
+      mkdir(path.join(repo, '.git'), { recursive: true }),
+      mkdir(path.join(otherRepo, '.git'), { recursive: true })
+    ])
+    let releaseFirst!: () => void
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    let markFirstStarted!: () => void
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve
+    })
+    const order: string[] = []
+
+    const first = runWithGitFetchHeadLock(repo, undefined, async () => {
+      order.push('first:start')
+      markFirstStarted()
+      await firstGate
+      order.push('first:end')
+    })
+    await firstStarted
+    const second = runWithGitFetchHeadLock(repo, undefined, async () => {
+      order.push('second')
+    })
+    const other = runWithGitFetchHeadLock(otherRepo, undefined, async () => {
+      order.push('other')
+    })
+
+    try {
+      await other
+      expect(order).toEqual(['first:start', 'other'])
+      releaseFirst()
+      await Promise.all([first, second])
+      expect(order).toEqual(['first:start', 'other', 'first:end', 'second'])
+    } finally {
+      releaseFirst()
+      await Promise.allSettled([first, second, other])
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not run a queued operation after cancellation', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'fetch-head-lock-cancel-'))
+    const repo = path.join(root, 'repo')
+    await mkdir(path.join(repo, '.git'), { recursive: true })
+    let releaseFirst!: () => void
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    let markFirstStarted!: () => void
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve
+    })
+    const first = runWithGitFetchHeadLock(repo, undefined, async () => {
+      markFirstStarted()
+      await firstGate
+    })
+    await firstStarted
+    const controller = new AbortController()
+    const queued = runWithGitFetchHeadLock(repo, controller.signal, async () => 'ran')
+
+    try {
+      controller.abort()
+      await expect(queued).rejects.toMatchObject({ name: 'AbortError' })
+    } finally {
+      releaseFirst()
+      await Promise.allSettled([first, queued])
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('serializes root, nested, and symlink aliases of one worktree', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'fetch-head-lock-'))
+    const repo = path.join(root, 'repo')
+    const nested = path.join(repo, 'nested')
+    const alias = path.join(root, 'alias')
+    await mkdir(path.join(repo, '.git'), { recursive: true })
+    await mkdir(nested)
+    await symlink(repo, alias)
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    let markFirstStarted!: () => void
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve
+    })
+    const order: string[] = []
+    try {
+      const first = runWithGitFetchHeadLock(repo, undefined, async () => {
+        order.push('root')
+        markFirstStarted()
+        await gate
+      })
+      await firstStarted
+      const nestedRun = runWithGitFetchHeadLock(nested, undefined, async () => {
+        order.push('nested')
+      })
+      const aliasRun = runWithGitFetchHeadLock(alias, undefined, async () => {
+        order.push('alias')
+      })
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      expect(order).toEqual(['root'])
+      release()
+      await Promise.all([first, nestedRun, aliasRun])
+      expect(order[0]).toBe('root')
+      expect(new Set(order.slice(1))).toEqual(new Set(['nested', 'alias']))
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/shared/git-fetch-head-lock.test.ts
+++ b/src/shared/git-fetch-head-lock.test.ts
@@ -112,46 +112,50 @@ describe('runWithGitFetchHeadLock', () => {
     }
   })
 
-  it('serializes root, nested, and symlink aliases of one worktree', async () => {
-    const root = await mkdtemp(path.join(tmpdir(), 'fetch-head-lock-'))
-    const repo = path.join(root, 'repo')
-    const nested = path.join(repo, 'nested')
-    const alias = path.join(root, 'alias')
-    await mkdir(path.join(repo, '.git'), { recursive: true })
-    await mkdir(nested)
-    await symlink(repo, alias)
-    let release!: () => void
-    const gate = new Promise<void>((resolve) => {
-      release = resolve
-    })
-    let markFirstStarted!: () => void
-    const firstStarted = new Promise<void>((resolve) => {
-      markFirstStarted = resolve
-    })
-    const order: string[] = []
-    try {
-      const first = runWithGitFetchHeadLock(repo, undefined, async () => {
-        order.push('root')
-        markFirstStarted()
-        await gate
+  // Windows CI agents usually lack the elevation `symlink` needs.
+  it.skipIf(process.platform === 'win32')(
+    'serializes root, nested, and symlink aliases of one worktree',
+    async () => {
+      const root = await mkdtemp(path.join(tmpdir(), 'fetch-head-lock-'))
+      const repo = path.join(root, 'repo')
+      const nested = path.join(repo, 'nested')
+      const alias = path.join(root, 'alias')
+      await mkdir(path.join(repo, '.git'), { recursive: true })
+      await mkdir(nested)
+      await symlink(repo, alias)
+      let release!: () => void
+      const gate = new Promise<void>((resolve) => {
+        release = resolve
       })
-      await firstStarted
-      const nestedRun = runWithGitFetchHeadLock(nested, undefined, async () => {
-        order.push('nested')
+      let markFirstStarted!: () => void
+      const firstStarted = new Promise<void>((resolve) => {
+        markFirstStarted = resolve
       })
-      const aliasRun = runWithGitFetchHeadLock(alias, undefined, async () => {
-        order.push('alias')
-      })
-      await new Promise((resolve) => setTimeout(resolve, 20))
-      expect(order).toEqual(['root'])
-      release()
-      await Promise.all([first, nestedRun, aliasRun])
-      expect(order[0]).toBe('root')
-      expect(new Set(order.slice(1))).toEqual(new Set(['nested', 'alias']))
-    } finally {
-      await rm(root, { recursive: true, force: true })
+      const order: string[] = []
+      try {
+        const first = runWithGitFetchHeadLock(repo, undefined, async () => {
+          order.push('root')
+          markFirstStarted()
+          await gate
+        })
+        await firstStarted
+        const nestedRun = runWithGitFetchHeadLock(nested, undefined, async () => {
+          order.push('nested')
+        })
+        const aliasRun = runWithGitFetchHeadLock(alias, undefined, async () => {
+          order.push('alias')
+        })
+        await new Promise((resolve) => setTimeout(resolve, 20))
+        expect(order).toEqual(['root'])
+        release()
+        await Promise.all([first, nestedRun, aliasRun])
+        expect(order[0]).toBe('root')
+        expect(new Set(order.slice(1))).toEqual(new Set(['nested', 'alias']))
+      } finally {
+        await rm(root, { recursive: true, force: true })
+      }
     }
-  })
+  )
 
   it('serializes linked worktrees through their shared Git directory', async () => {
     const root = await mkdtemp(path.join(tmpdir(), 'fetch-head-linked-lock-'))

--- a/src/shared/git-fetch-head-lock.ts
+++ b/src/shared/git-fetch-head-lock.ts
@@ -1,0 +1,171 @@
+import * as path from 'node:path'
+import { readFile, realpath, stat } from 'node:fs/promises'
+
+type GitFetchHeadLockLane = {
+  tail: Promise<void>
+  release: () => void
+}
+
+const lanes = new Map<string, GitFetchHeadLockLane>()
+const GLOBAL_OPTIONS_WITH_VALUE = new Set([
+  '-c',
+  '-C',
+  '--git-dir',
+  '--work-tree',
+  '--namespace',
+  '--super-prefix',
+  '--config-env',
+  '--exec-path'
+])
+
+type GitFetchHeadCommand = { needsLock: boolean; cwd: string; gitDir?: string }
+
+export function resolveGitFetchHeadCommand(
+  args: readonly string[],
+  initialCwd: string
+): GitFetchHeadCommand {
+  let cwd = initialCwd
+  let gitDir: string | undefined
+  let subcommandIndex = -1
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (arg === '-C' && args[index + 1]) {
+      cwd = path.resolve(cwd, args[index + 1])
+      index += 1
+      continue
+    }
+    if (arg.startsWith('-C') && arg.length > 2) {
+      cwd = path.resolve(cwd, arg.slice(2))
+      continue
+    }
+    if (arg === '--git-dir' && args[index + 1]) {
+      gitDir = path.resolve(cwd, args[index + 1])
+      index += 1
+      continue
+    }
+    if (arg.startsWith('--git-dir=')) {
+      gitDir = path.resolve(cwd, arg.slice('--git-dir='.length))
+      continue
+    }
+    if (GLOBAL_OPTIONS_WITH_VALUE.has(arg)) {
+      index += 1
+      continue
+    }
+    if (arg.startsWith('-')) {
+      continue
+    }
+    subcommandIndex = index
+    break
+  }
+  const subcommand = args[subcommandIndex]
+  if (subcommand === 'pull') {
+    return { needsLock: true, cwd, gitDir }
+  }
+  if (subcommand !== 'fetch') {
+    return { needsLock: false, cwd, gitDir }
+  }
+  let writesFetchHead = true
+  for (const arg of args.slice(subcommandIndex + 1)) {
+    if (arg === '--no-write-fetch-head') {
+      writesFetchHead = false
+    } else if (arg === '--write-fetch-head') {
+      writesFetchHead = true
+    }
+  }
+  return { needsLock: writesFetchHead, cwd, gitDir }
+}
+
+async function fetchHeadPath(
+  worktreePath: string,
+  signal: AbortSignal | undefined,
+  explicitGitDir?: string
+): Promise<string> {
+  let current = await realpath(worktreePath).catch(() => path.resolve(worktreePath))
+  let gitDir = explicitGitDir
+  while (!gitDir) {
+    const dotGitPath = path.join(current, '.git')
+    try {
+      const metadata = await stat(dotGitPath)
+      if (metadata.isDirectory()) {
+        gitDir = dotGitPath
+        break
+      }
+      const contents = await readFile(dotGitPath, { encoding: 'utf-8', signal })
+      const match = contents.match(/^gitdir:\s*(.+)\s*$/m)
+      if (match) {
+        gitDir = path.resolve(current, match[1])
+        break
+      }
+    } catch {
+      if (signal?.aborted) {
+        throw abortError()
+      }
+    }
+    const parent = path.dirname(current)
+    if (parent === current) {
+      gitDir = path.join(current, '.git')
+      break
+    }
+    current = parent
+  }
+  const canonicalGitDir = await realpath(gitDir).catch(() => path.resolve(gitDir))
+  return path.join(canonicalGitDir, 'FETCH_HEAD')
+}
+
+function abortError(): Error {
+  const error = new Error('The operation was aborted.')
+  error.name = 'AbortError'
+  return error
+}
+
+async function waitForPredecessor(
+  predecessor: Promise<void>,
+  signal: AbortSignal | undefined
+): Promise<void> {
+  if (!signal) {
+    await predecessor.catch(() => undefined)
+    return
+  }
+  if (signal.aborted) {
+    throw abortError()
+  }
+  let rejectAbort!: (error: Error) => void
+  const aborted = new Promise<never>((_resolve, reject) => {
+    rejectAbort = reject
+  })
+  const onAbort = () => rejectAbort(abortError())
+  signal.addEventListener('abort', onAbort, { once: true })
+  try {
+    await Promise.race([predecessor.catch(() => undefined), aborted])
+  } finally {
+    signal.removeEventListener('abort', onAbort)
+  }
+}
+
+export async function runWithGitFetchHeadLock<T>(
+  worktreePath: string,
+  signal: AbortSignal | undefined,
+  run: () => Promise<T>,
+  explicitGitDir?: string
+): Promise<T> {
+  const key = await fetchHeadPath(worktreePath, signal, explicitGitDir)
+  const predecessor = lanes.get(key)?.tail ?? Promise.resolve()
+  let release!: () => void
+  const current = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const lane = { tail: predecessor.catch(() => undefined).then(() => current), release }
+  lanes.set(key, lane)
+  void lane.tail.then(() => {
+    if (lanes.get(key) === lane) {
+      lanes.delete(key)
+    }
+  })
+
+  try {
+    await waitForPredecessor(predecessor, signal)
+    return await run()
+  } finally {
+    lane.release()
+  }
+}

--- a/src/shared/git-fetch-head-lock.ts
+++ b/src/shared/git-fetch-head-lock.ts
@@ -65,17 +65,21 @@ export function resolveGitFetchHeadCommand(
     return { needsLock: false, cwd, gitDir }
   }
   let writesFetchHead = true
+  let updatesRemoteTrackingRef = false
   for (const arg of args.slice(subcommandIndex + 1)) {
     if (arg === '--no-write-fetch-head') {
       writesFetchHead = false
     } else if (arg === '--write-fetch-head') {
       writesFetchHead = true
+    } else if (arg.includes(':refs/remotes/')) {
+      updatesRemoteTrackingRef = true
     }
   }
-  return { needsLock: writesFetchHead, cwd, gitDir }
+  // Why: explicit tracking-ref updates race sibling-worktree fetch transactions even without FETCH_HEAD.
+  return { needsLock: writesFetchHead || updatesRemoteTrackingRef, cwd, gitDir }
 }
 
-async function fetchHeadPath(
+async function fetchLockPath(
   worktreePath: string,
   signal: AbortSignal | undefined,
   explicitGitDir?: string
@@ -108,7 +112,18 @@ async function fetchHeadPath(
     }
     current = parent
   }
-  const canonicalGitDir = await realpath(gitDir).catch(() => path.resolve(gitDir))
+  let commonGitDir = gitDir
+  try {
+    const contents = await readFile(path.join(gitDir, 'commondir'), { encoding: 'utf-8', signal })
+    if (contents.trim()) {
+      commonGitDir = path.resolve(gitDir, contents.trim())
+    }
+  } catch {
+    if (signal?.aborted) {
+      throw abortError()
+    }
+  }
+  const canonicalGitDir = await realpath(commonGitDir).catch(() => path.resolve(commonGitDir))
   return path.join(canonicalGitDir, 'FETCH_HEAD')
 }
 
@@ -148,7 +163,7 @@ export async function runWithGitFetchHeadLock<T>(
   run: () => Promise<T>,
   explicitGitDir?: string
 ): Promise<T> {
-  const key = await fetchHeadPath(worktreePath, signal, explicitGitDir)
+  const key = await fetchLockPath(worktreePath, signal, explicitGitDir)
   const predecessor = lanes.get(key)?.tail ?? Promise.resolve()
   let release!: () => void
   const current = new Promise<void>((resolve) => {

--- a/src/shared/git-fetch-head-lock.ts
+++ b/src/shared/git-fetch-head-lock.ts
@@ -1,12 +1,12 @@
 import * as path from 'node:path'
 import { readFile, realpath, stat } from 'node:fs/promises'
+import { runWithGitOperationLock } from './git-operation-lock'
 
-type GitFetchHeadLockLane = {
-  tail: Promise<void>
-  release: () => void
+function abortError(): Error {
+  const error = new Error('The operation was aborted.')
+  error.name = 'AbortError'
+  return error
 }
-
-const lanes = new Map<string, GitFetchHeadLockLane>()
 const GLOBAL_OPTIONS_WITH_VALUE = new Set([
   '-c',
   '-C',
@@ -127,36 +127,6 @@ async function fetchLockPath(
   return path.join(canonicalGitDir, 'FETCH_HEAD')
 }
 
-function abortError(): Error {
-  const error = new Error('The operation was aborted.')
-  error.name = 'AbortError'
-  return error
-}
-
-async function waitForPredecessor(
-  predecessor: Promise<void>,
-  signal: AbortSignal | undefined
-): Promise<void> {
-  if (!signal) {
-    await predecessor.catch(() => undefined)
-    return
-  }
-  if (signal.aborted) {
-    throw abortError()
-  }
-  let rejectAbort!: (error: Error) => void
-  const aborted = new Promise<never>((_resolve, reject) => {
-    rejectAbort = reject
-  })
-  const onAbort = () => rejectAbort(abortError())
-  signal.addEventListener('abort', onAbort, { once: true })
-  try {
-    await Promise.race([predecessor.catch(() => undefined), aborted])
-  } finally {
-    signal.removeEventListener('abort', onAbort)
-  }
-}
-
 export async function runWithGitFetchHeadLock<T>(
   worktreePath: string,
   signal: AbortSignal | undefined,
@@ -164,23 +134,5 @@ export async function runWithGitFetchHeadLock<T>(
   explicitGitDir?: string
 ): Promise<T> {
   const key = await fetchLockPath(worktreePath, signal, explicitGitDir)
-  const predecessor = lanes.get(key)?.tail ?? Promise.resolve()
-  let release!: () => void
-  const current = new Promise<void>((resolve) => {
-    release = resolve
-  })
-  const lane = { tail: predecessor.catch(() => undefined).then(() => current), release }
-  lanes.set(key, lane)
-  void lane.tail.then(() => {
-    if (lanes.get(key) === lane) {
-      lanes.delete(key)
-    }
-  })
-
-  try {
-    await waitForPredecessor(predecessor, signal)
-    return await run()
-  } finally {
-    lane.release()
-  }
+  return runWithGitOperationLock(key, signal, run)
 }

--- a/src/shared/git-operation-lock.ts
+++ b/src/shared/git-operation-lock.ts
@@ -1,0 +1,62 @@
+type GitOperationLane = {
+  tail: Promise<void>
+  release: () => void
+}
+
+const lanes = new Map<string, GitOperationLane>()
+
+function abortError(): Error {
+  const error = new Error('The operation was aborted.')
+  error.name = 'AbortError'
+  return error
+}
+
+async function waitForPredecessor(
+  predecessor: Promise<void>,
+  signal: AbortSignal | undefined
+): Promise<void> {
+  if (!signal) {
+    await predecessor.catch(() => undefined)
+    return
+  }
+  if (signal.aborted) {
+    throw abortError()
+  }
+  let rejectAbort!: (error: Error) => void
+  const aborted = new Promise<never>((_resolve, reject) => {
+    rejectAbort = reject
+  })
+  const onAbort = () => rejectAbort(abortError())
+  signal.addEventListener('abort', onAbort, { once: true })
+  try {
+    await Promise.race([predecessor.catch(() => undefined), aborted])
+  } finally {
+    signal.removeEventListener('abort', onAbort)
+  }
+}
+
+export async function runWithGitOperationLock<T>(
+  key: string,
+  signal: AbortSignal | undefined,
+  run: () => Promise<T>
+): Promise<T> {
+  const predecessor = lanes.get(key)?.tail ?? Promise.resolve()
+  let release!: () => void
+  const current = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const lane = { tail: predecessor.catch(() => undefined).then(() => current), release }
+  lanes.set(key, lane)
+  void lane.tail.then(() => {
+    if (lanes.get(key) === lane) {
+      lanes.delete(key)
+    }
+  })
+
+  try {
+    await waitForPredecessor(predecessor, signal)
+    return await run()
+  } finally {
+    lane.release()
+  }
+}

--- a/src/shared/git-rebase-source.ts
+++ b/src/shared/git-rebase-source.ts
@@ -1,3 +1,6 @@
+// Why: a stalled remote must fail the rebase fetch, not hang the rebase; client and relay share one bound.
+export const REBASE_SOURCE_FETCH_TIMEOUT_MS = 60_000
+
 export type GitCommandRunner = (args: string[]) => Promise<{ stdout: string }>
 
 export type GitRemoteRebaseSource = {

--- a/src/shared/git-rebase-source.ts
+++ b/src/shared/git-rebase-source.ts
@@ -1,5 +1,7 @@
 // Why: a stalled remote must fail the rebase fetch, not hang the rebase; client and relay share one bound.
 export const REBASE_SOURCE_FETCH_TIMEOUT_MS = 60_000
+export const REBASE_FROM_BASE_OPERATION_TIMEOUT_MS = REBASE_SOURCE_FETCH_TIMEOUT_MS + 60_000
+export const REBASE_FROM_BASE_RPC_TIMEOUT_MS = REBASE_FROM_BASE_OPERATION_TIMEOUT_MS + 5_000
 
 export type GitCommandRunner = (args: string[]) => Promise<{ stdout: string }>
 

--- a/src/shared/git-rebase-source.ts
+++ b/src/shared/git-rebase-source.ts
@@ -1,7 +1,8 @@
 // Why: a stalled remote must fail the rebase fetch, not hang the rebase; client and relay share one bound.
 export const REBASE_SOURCE_FETCH_TIMEOUT_MS = 60_000
 export const REBASE_FROM_BASE_OPERATION_TIMEOUT_MS = REBASE_SOURCE_FETCH_TIMEOUT_MS + 60_000
-export const REBASE_FROM_BASE_RPC_TIMEOUT_MS = REBASE_FROM_BASE_OPERATION_TIMEOUT_MS + 5_000
+// Include the process barrier's 2s grace plus its 10s unverified-tree deadline.
+export const REBASE_FROM_BASE_RPC_TIMEOUT_MS = REBASE_FROM_BASE_OPERATION_TIMEOUT_MS + 15_000
 
 export type GitCommandRunner = (args: string[]) => Promise<{ stdout: string }>
 

--- a/src/shared/git-worktree-operation-lock.test.ts
+++ b/src/shared/git-worktree-operation-lock.test.ts
@@ -1,0 +1,48 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { runWithGitWorktreeOperationLock } from './git-worktree-operation-lock'
+
+describe('git worktree operation lock', () => {
+  let root: string | undefined
+
+  afterEach(async () => {
+    if (root) {
+      await rm(root, { recursive: true, force: true })
+      root = undefined
+    }
+  })
+
+  it('serializes mutations for the same linked worktree path', async () => {
+    root = await mkdtemp(join(tmpdir(), 'git-worktree-operation-lock-'))
+    const worktreePath = join(root, 'worktree')
+    const events: string[] = []
+    let releaseFirst!: () => void
+    let markFirstStarted!: () => void
+    const firstStarted = new Promise<void>((resolve) => {
+      markFirstStarted = resolve
+    })
+    const firstRelease = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+
+    const first = runWithGitWorktreeOperationLock(worktreePath, undefined, async () => {
+      events.push('first:start')
+      markFirstStarted()
+      await firstRelease
+      events.push('first:end')
+    })
+    await firstStarted
+
+    const second = runWithGitWorktreeOperationLock(worktreePath, undefined, async () => {
+      events.push('second:start')
+    })
+    await Promise.resolve()
+    expect(events).toEqual(['first:start'])
+
+    releaseFirst()
+    await Promise.all([first, second])
+    expect(events).toEqual(['first:start', 'first:end', 'second:start'])
+  })
+})

--- a/src/shared/git-worktree-operation-lock.ts
+++ b/src/shared/git-worktree-operation-lock.ts
@@ -1,0 +1,69 @@
+import { realpath } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+type OperationLane = {
+  tail: Promise<void>
+  release: () => void
+}
+const lanes = new Map<string, OperationLane>()
+
+function abortError(): Error {
+  const error = new Error('The operation was aborted.')
+  error.name = 'AbortError'
+  return error
+}
+
+async function waitForPredecessor(
+  predecessor: Promise<void>,
+  signal: AbortSignal | undefined
+): Promise<void> {
+  if (!signal) {
+    await predecessor.catch(() => undefined)
+    return
+  }
+  if (signal.aborted) {
+    throw abortError()
+  }
+  let rejectAbort!: (error: Error) => void
+  const aborted = new Promise<never>((_resolve, reject) => {
+    rejectAbort = reject
+  })
+  const onAbort = () => rejectAbort(abortError())
+  signal.addEventListener('abort', onAbort, { once: true })
+  try {
+    await Promise.race([predecessor.catch(() => undefined), aborted])
+  } finally {
+    signal.removeEventListener('abort', onAbort)
+  }
+}
+
+/** Serialize mutations that leave per-worktree state in progress (for example, rebase). */
+export async function runWithGitWorktreeOperationLock<T>(
+  worktreePath: string,
+  signal: AbortSignal | undefined,
+  run: () => Promise<T>
+): Promise<T> {
+  const key = await realpath(worktreePath).catch(() => resolve(worktreePath))
+  const predecessor = lanes.get(key)?.tail ?? Promise.resolve()
+  let release!: () => void
+  const current = new Promise<void>((resolveCurrent) => {
+    release = resolveCurrent
+  })
+  const lane = {
+    tail: predecessor.catch(() => undefined).then(() => current),
+    release
+  }
+  lanes.set(key, lane)
+  void lane.tail.then(() => {
+    if (lanes.get(key) === lane) {
+      lanes.delete(key)
+    }
+  })
+
+  try {
+    await waitForPredecessor(predecessor, signal)
+    return await run()
+  } finally {
+    lane.release()
+  }
+}

--- a/src/shared/git-worktree-operation-lock.ts
+++ b/src/shared/git-worktree-operation-lock.ts
@@ -1,41 +1,6 @@
 import { realpath } from 'node:fs/promises'
 import { resolve } from 'node:path'
-
-type OperationLane = {
-  tail: Promise<void>
-  release: () => void
-}
-const lanes = new Map<string, OperationLane>()
-
-function abortError(): Error {
-  const error = new Error('The operation was aborted.')
-  error.name = 'AbortError'
-  return error
-}
-
-async function waitForPredecessor(
-  predecessor: Promise<void>,
-  signal: AbortSignal | undefined
-): Promise<void> {
-  if (!signal) {
-    await predecessor.catch(() => undefined)
-    return
-  }
-  if (signal.aborted) {
-    throw abortError()
-  }
-  let rejectAbort!: (error: Error) => void
-  const aborted = new Promise<never>((_resolve, reject) => {
-    rejectAbort = reject
-  })
-  const onAbort = () => rejectAbort(abortError())
-  signal.addEventListener('abort', onAbort, { once: true })
-  try {
-    await Promise.race([predecessor.catch(() => undefined), aborted])
-  } finally {
-    signal.removeEventListener('abort', onAbort)
-  }
-}
+import { runWithGitOperationLock } from './git-operation-lock'
 
 /** Serialize mutations that leave per-worktree state in progress (for example, rebase). */
 export async function runWithGitWorktreeOperationLock<T>(
@@ -44,26 +9,5 @@ export async function runWithGitWorktreeOperationLock<T>(
   run: () => Promise<T>
 ): Promise<T> {
   const key = await realpath(worktreePath).catch(() => resolve(worktreePath))
-  const predecessor = lanes.get(key)?.tail ?? Promise.resolve()
-  let release!: () => void
-  const current = new Promise<void>((resolveCurrent) => {
-    release = resolveCurrent
-  })
-  const lane = {
-    tail: predecessor.catch(() => undefined).then(() => current),
-    release
-  }
-  lanes.set(key, lane)
-  void lane.tail.then(() => {
-    if (lanes.get(key) === lane) {
-      lanes.delete(key)
-    }
-  })
-
-  try {
-    await waitForPredecessor(predecessor, signal)
-    return await run()
-  } finally {
-    lane.release()
-  }
+  return runWithGitOperationLock(key, signal, run)
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1226 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​19 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1207 |
| Prod | 16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1153 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​142 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1011 |

<!-- /orca-pr-loc -->

## Problem

Concurrent fetches can replace `FETCH_HEAD` and remote-tracking refs between when `git pull --rebase` starts and when it reads the commit to rebase onto. If the remote is force-pushed during this window, the rebase may operate on the wrong commit.

## Solution

Instead of `git pull --rebase`, atomically capture the commit to rebase onto by:
1. Finding the fork point with `git merge-base --fork-point`
2. Fetching the branch to a private ref (`refs/orca/rebase/<uuid>`)
3. Rebasing onto that ref from the fork point
4. Cleaning up the private ref when done (even on failure)

This ensures concurrent operations cannot affect which commit is rebased, and the fork point is preserved even if the remote is force-pushed.

## What Changed

- Replaced `git pull --rebase` with explicit fetch-then-rebase in both native (`remote.ts`) and relay (`git-handler.ts`) code paths
- Added `merge-base --fork-point` to preserve the original merge base across force-pushes
- Private refs are scoped to `refs/orca/rebase/` and always cleaned up

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added: new test scenarios for force-push race and missing remote-tracking refs

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover)