### PR TITLE
fix(terminal): advance the headless model sequence only for parsed writes

### DIFF
--- a/src/main/daemon/headless-emulator.test.ts
+++ b/src/main/daemon/headless-emulator.test.ts
@@ -723,5 +723,21 @@ describe('HeadlessEmulator', () => {
       emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
       expect(() => emulator.dispose()).not.toThrow()
     })
+
+    // Why this is load-bearing: main advances a PTY's snapshot sequence only for
+    // writes that actually parsed. A silent drop reported as applied would make
+    // pty:getMainBufferSnapshot claim bytes the model never saw, and the
+    // renderer's post-restore baseline drops their redelivery as duplicates —
+    // the revealed SSH tab then keeps a scrollback hole forever (STA-4999).
+    it('reports an unparsed write once disposed', async () => {
+      emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+      expect(await emulator.write('applied')).toBe(true)
+      expect(emulator.isDisposed).toBe(false)
+
+      emulator.dispose()
+
+      expect(await emulator.write('dropped')).toBe(false)
+      expect(emulator.isDisposed).toBe(true)
+    })
   })
 })

--- a/src/main/daemon/headless-emulator.ts
+++ b/src/main/daemon/headless-emulator.ts
@@ -151,7 +151,7 @@ export class HeadlessEmulator {
     if (!Number.isInteger(flags) || flags <= 0) {
       return Promise.resolve()
     }
-    return this.write(`\x1b[=${flags};1u`)
+    return this.write(`\x1b[=${flags};1u`).then(() => undefined)
   }
 
   private emitQueryReply(reply: string): void {
@@ -165,14 +165,15 @@ export class HeadlessEmulator {
     this.onQueryReply = null
   }
 
-  write(data: string, opts: HeadlessEmulatorWriteOptions = {}): Promise<void> {
+  /** Resolves true only when the bytes were parsed; a disposed emulator drops them. */
+  write(data: string, opts: HeadlessEmulatorWriteOptions = {}): Promise<boolean> {
     if (this.disposed) {
-      return Promise.resolve()
+      return Promise.resolve(false)
     }
 
     const forwardQueryReplies = opts.forwardQueryReplies === true
     if (this.tryWriteSync(data, { forwardQueryReplies })) {
-      return Promise.resolve()
+      return Promise.resolve(true)
     }
     this.oscText.scan(data)
     // Why the sentinel: xterm parses writes async, so its zero-byte callback fires in FIFO order to open the window at exactly this chunk.
@@ -181,7 +182,7 @@ export class HeadlessEmulator {
         this.queryReplyForwardingDepth += 1
       })
     }
-    return new Promise<void>((resolve) => {
+    return new Promise<boolean>((resolve) => {
       this.terminal.write(data, () => {
         if (forwardQueryReplies) {
           this.queryReplyForwardingDepth -= 1
@@ -189,7 +190,7 @@ export class HeadlessEmulator {
         // Why: commit the mouse-mode mirror only after xterm has parsed the same bytes (snapshots combine both).
         this.mouseModes.scan(data)
         this.partialEscapeTail = advancePartialEscapeTail(this.partialEscapeTail, data)
-        resolve()
+        resolve(true)
       })
     })
   }
@@ -331,6 +332,10 @@ export class HeadlessEmulator {
   clearScrollback(): void {
     this.restoredOscLinks = []
     this.terminal.clear()
+  }
+
+  get isDisposed(): boolean {
+    return this.disposed
   }
 
   dispose(): void {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -10970,10 +10970,10 @@ describe('OrcaRuntimeService', () => {
     const originalWrite = headless!.emulator.write.bind(headless!.emulator)
     const queuedWriteStarted = makeDeferred()
     const releaseQueuedWrite = makeDeferred()
-    headless!.emulator.write = async (data: string): Promise<void> => {
+    headless!.emulator.write = async (data: string): Promise<boolean> => {
       queuedWriteStarted.resolve()
       await releaseQueuedWrite.promise
-      await originalWrite(data)
+      return await originalWrite(data)
     }
 
     try {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -12970,8 +12970,14 @@ export class OrcaRuntimeService {
     const completion = state.writeChain.then(async () => {
       // Why: the ingestion-time ownership decision is closed over this
       // chain link; async scheduling cannot retroactively change it.
-      await state.emulator.write(data, { forwardQueryReplies })
-      state.outputSequence = outputSequence
+      const applied = await state.emulator.write(data, { forwardQueryReplies })
+      // Why gated: a disposed emulator drops the write silently. Advancing the
+      // sequence anyway makes the next snapshot claim bytes the model never
+      // parsed, and the renderer's restore baseline then drops their
+      // redelivery as duplicates — a permanent hole an idle shell never heals.
+      if (applied) {
+        state.outputSequence = outputSequence
+      }
     })
     // Legacy callers remain best-effort; bounded SSH admission observes the raw receipt.
     state.writeChain = completion.catch(() => {})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /orca-pr-loc -->

## What

`HeadlessEmulator.write()` resolved `void` and silently discarded the data when the emulator was already disposed, while `trackHeadlessTerminalData` advanced `state.outputSequence` regardless.

That counter is what `pty:getMainBufferSnapshot` reports as `seq`. The renderer's restore path treats it as proof the snapshot already covers every byte up to it — `setRestoredSnapshotBaseline` then drops or slices any deferred/live chunk at or below that seq as a duplicate. So a silently-dropped write lets a snapshot claim content the model never parsed, and the redelivery that would have healed it gets discarded.

This makes the counter honest:

- `write()` resolves `true`/`false` for whether the bytes actually parsed
- `isDisposed` getter added
- the runtime advances `state.outputSequence` only for applied writes

## Scope / honesty

**This does not fix STA-4999**, and the ticket should stay open. The disposal path was found while tracing that bug, but I never demonstrated it is what the failing e2e (`tests/e2e/ssh-terminal-parking.spec.ts`) actually hits — and tracing `disposeHeadlessTerminal` suggests it is hard to reach, since it removes the state from the map before the emulator disposes. Treat this as closing a real invariant hole, not as a verified bug fix.

Investigation notes for STA-4999 are on the ticket.

## Verification

- `tsc --noEmit -p config/tsconfig.node.json`
- `oxlint` clean on touched files
- vitest: `headless-emulator`, `orca-runtime`, `pty-connection-parked-ssh-snapshot`, `pty-buffer-snapshot-dispatch` — 1266 passing
- New regression case in `headless-emulator.test.ts` pinning that a post-dispose write reports unparsed

No local Docker SSH e2e run was performed.