### PR TITLE
fix(runtime): prevent restored workers from appearing idle while busy

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -18279,6 +18279,111 @@ describe('OrcaRuntimeService', () => {
     expect(read.tail.join('\n')).not.toContain('Stale TUI')
   })
 
+  it('rejects a provider visible frame after live non-mode-switch output advances', async () => {
+    type Snapshot = {
+      data: string
+      cols: number
+      rows: number
+      seq: number
+      source: 'headless'
+      alternateScreen: boolean
+    }
+    let resolveSnapshot!: (snapshot: Snapshot) => void
+    const serializeProviderBuffer = vi.fn(
+      () =>
+        new Promise<Snapshot>((resolve) => {
+          resolveSnapshot = resolve
+        })
+    )
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      serializeProviderBuffer,
+      hasRendererSerializer: () => false
+    })
+    syncSinglePty(runtime)
+    runtime.onPtyData('pty-1', 'shell history\r\n', 100)
+    runtime.synchronizePtyOutputSequenceFromProvider(
+      'pty-1',
+      { value: 900, generation: 'continued' },
+      0
+    )
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    const readPromise = runtime.readTerminal(terminal.handle)
+    await vi.waitFor(() => expect(serializeProviderBuffer).toHaveBeenCalledOnce())
+    runtime.onPtyData('pty-1', 'live progress\r\n', 101)
+    resolveSnapshot({
+      data: '\x1b[?1049h\x1b[2J\x1b[HStale Ready screen\r\n',
+      cols: 80,
+      rows: 24,
+      seq: 900,
+      source: 'headless',
+      alternateScreen: true
+    })
+
+    const read = await readPromise
+    expect(read.tail).toEqual(['shell history'])
+    expect(read.tail.join('\n')).not.toContain('Stale Ready screen')
+  })
+
+  it('rejects a full provider screen frame after live output advances', async () => {
+    type Snapshot = {
+      data: string
+      scrollbackAnsi: string
+      cols: number
+      rows: number
+      seq: number
+      source: 'headless'
+      alternateScreen: boolean
+    }
+    let resolveSnapshot!: (snapshot: Snapshot) => void
+    const serializeProviderBuffer = vi
+      .fn()
+      .mockResolvedValueOnce(null)
+      .mockImplementationOnce(
+        () =>
+          new Promise<Snapshot>((resolve) => {
+            resolveSnapshot = resolve
+          })
+      )
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null,
+      serializeProviderBuffer,
+      hasRendererSerializer: () => false
+    })
+    syncSinglePty(runtime)
+    runtime.onPtyData('pty-1', 'shell history\r\n', 100)
+    runtime.synchronizePtyOutputSequenceFromProvider(
+      'pty-1',
+      { value: 900, generation: 'continued' },
+      0
+    )
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    const readPromise = runtime.readTerminal(terminal.handle, { screen: true })
+    await vi.waitFor(() => expect(serializeProviderBuffer).toHaveBeenCalledTimes(2))
+    runtime.onPtyData('pty-1', 'live progress\r\n', 101)
+    resolveSnapshot({
+      data: '\x1b[?1049h\x1b[2J\x1b[HStale full screen\r\n',
+      scrollbackAnsi: '',
+      cols: 80,
+      rows: 24,
+      seq: 900,
+      source: 'headless',
+      alternateScreen: true
+    })
+
+    const read = await readPromise
+    expect(read.source).toBe('screen-unavailable')
+    expect(read.tail.join('\n')).not.toContain('Stale full screen')
+  })
+
   it('shares one provider snapshot between concurrent read and show calls', async () => {
     type Snapshot = {
       data: string
@@ -20641,6 +20746,33 @@ describe('OrcaRuntimeService', () => {
     await expect(
       runtime.waitForTerminal(terminal.handle, { condition: 'tui-idle', timeoutMs: 50 })
     ).rejects.toThrow('timeout')
+    const lateReadySnapshot = deferred<{
+      data: string
+      scrollbackAnsi: string
+      cols: number
+      rows: number
+      seq: number
+      source: 'headless'
+      alternateScreen: boolean
+    }>()
+    const snapshotSequence = runtime.getPtyOutputSequence('pty-legacy')
+    serializeProviderBuffer.mockImplementationOnce(() => lateReadySnapshot.promise)
+    const staleReadyWait = runtime.waitForTerminal(terminal.handle, {
+      condition: 'tui-idle',
+      timeoutMs: 50
+    })
+    await vi.waitFor(() => expect(serializeProviderBuffer).toHaveBeenCalledTimes(4))
+    runtime.onPtyData('pty-legacy', '\x1b[H', Date.now())
+    lateReadySnapshot.resolve({
+      data: READY_SCREEN,
+      scrollbackAnsi: '',
+      cols: 80,
+      rows: 24,
+      seq: snapshotSequence,
+      source: 'headless',
+      alternateScreen: false
+    })
+    await expect(staleReadyWait).rejects.toThrow('timeout')
     serializeProviderBuffer.mockResolvedValueOnce({
       data: 'Do you trust this workspace directory?\r\n1. Yes\r\n2. No\r\n',
       scrollbackAnsi: '',
@@ -20660,17 +20792,18 @@ describe('OrcaRuntimeService', () => {
     await expect(
       runtime.waitForTerminal(terminal.handle, { condition: 'tui-idle', timeoutMs: 50 })
     ).rejects.toThrow('timeout')
-    expect(serializeProviderBuffer).toHaveBeenCalledTimes(5)
+    expect(serializeProviderBuffer).toHaveBeenCalledTimes(6)
     // Why args, not counts: the one-shot responses above ignore their options,
     // so only this asserts every idle probe asked for the visible grid alone.
     expect(serializeProviderBuffer.mock.calls.slice(1)).toEqual([
       ['pty-legacy', { scrollbackRows: 0 }],
       ['pty-legacy', { scrollbackRows: 0 }],
       ['pty-legacy', { scrollbackRows: 0 }],
+      ['pty-legacy', { scrollbackRows: 0 }],
       ['pty-legacy', { scrollbackRows: 0 }]
     ])
-    await expect(runtime.readTerminal(terminal.handle)).resolves.toMatchObject({ tail: [] })
-    expect(serializeProviderBuffer).toHaveBeenCalledTimes(5)
+    await expect(runtime.readTerminal(terminal.handle)).resolves.toBeDefined()
+    expect(serializeProviderBuffer).toHaveBeenCalledTimes(6)
     expect(
       runtime.verifyOrchestrationCompatibilityCaller({
         terminalHandle: 'term_legacy',

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -20528,16 +20528,22 @@ describe('OrcaRuntimeService', () => {
     } as unknown as OrchestrationDb)
     const write = vi.fn(() => true)
     const kill = vi.fn(() => true)
-    const serializeProviderBuffer = vi.fn().mockResolvedValue({
-      data: '',
-      scrollbackAnsi:
-        ' >_ OpenAI Codex (v0.131.0)\r\n model:       gpt-5.5 high\r\n directory:   /repo\r\n',
-      cols: 80,
-      rows: 24,
-      seq: 100,
-      source: 'headless' as const,
-      alternateScreen: false
-    })
+    const READY_SCREEN =
+      ' >_ OpenAI Codex (v0.131.0)\r\n model:       gpt-5.5 high\r\n directory:   /repo\r\n'
+    // Why scrollbackRows-aware: a visible-only request gets the grid in `data`;
+    // a scrollback request gets history. Collapsing the two would let a test
+    // pass on evidence the caller never asked for.
+    const serializeProviderBuffer = vi
+      .fn()
+      .mockImplementation(async (_ptyId: string, opts?: { scrollbackRows?: number }) => ({
+        data: opts?.scrollbackRows === 0 ? READY_SCREEN : '',
+        scrollbackAnsi: opts?.scrollbackRows === 0 ? '' : READY_SCREEN,
+        cols: 80,
+        rows: 24,
+        seq: 100,
+        source: 'headless' as const,
+        alternateScreen: false
+      }))
     runtime.setPtyController({
       write,
       kill,
@@ -20621,9 +20627,23 @@ describe('OrcaRuntimeService', () => {
     await expect(
       runtime.waitForTerminal(terminal.handle, { condition: 'tui-idle', timeoutMs: 100 })
     ).resolves.toMatchObject({ satisfied: true })
+    // Why: the ready banner stays in scrollback for the whole session, so a
+    // working grid must not inherit idleness from its own history (#15569 review).
     serializeProviderBuffer.mockResolvedValueOnce({
-      data: '',
-      scrollbackAnsi: 'Do you trust this workspace directory?\r\n1. Yes\r\n2. No\r\n',
+      data: '  working on it (12s)\r\n  Esc to interrupt\r\n',
+      scrollbackAnsi: READY_SCREEN,
+      cols: 80,
+      rows: 24,
+      seq: 101,
+      source: 'headless' as const,
+      alternateScreen: false
+    })
+    await expect(
+      runtime.waitForTerminal(terminal.handle, { condition: 'tui-idle', timeoutMs: 50 })
+    ).rejects.toThrow('timeout')
+    serializeProviderBuffer.mockResolvedValueOnce({
+      data: 'Do you trust this workspace directory?\r\n1. Yes\r\n2. No\r\n',
+      scrollbackAnsi: '',
       cols: 80,
       rows: 24,
       seq: 101,
@@ -20640,9 +20660,9 @@ describe('OrcaRuntimeService', () => {
     await expect(
       runtime.waitForTerminal(terminal.handle, { condition: 'tui-idle', timeoutMs: 50 })
     ).rejects.toThrow('timeout')
-    expect(serializeProviderBuffer).toHaveBeenCalledTimes(4)
+    expect(serializeProviderBuffer).toHaveBeenCalledTimes(5)
     await expect(runtime.readTerminal(terminal.handle)).resolves.toMatchObject({ tail: [] })
-    expect(serializeProviderBuffer).toHaveBeenCalledTimes(4)
+    expect(serializeProviderBuffer).toHaveBeenCalledTimes(5)
     expect(
       runtime.verifyOrchestrationCompatibilityCaller({
         terminalHandle: 'term_legacy',

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -20661,6 +20661,14 @@ describe('OrcaRuntimeService', () => {
       runtime.waitForTerminal(terminal.handle, { condition: 'tui-idle', timeoutMs: 50 })
     ).rejects.toThrow('timeout')
     expect(serializeProviderBuffer).toHaveBeenCalledTimes(5)
+    // Why args, not counts: the one-shot responses above ignore their options,
+    // so only this asserts every idle probe asked for the visible grid alone.
+    expect(serializeProviderBuffer.mock.calls.slice(1)).toEqual([
+      ['pty-legacy', { scrollbackRows: 0 }],
+      ['pty-legacy', { scrollbackRows: 0 }],
+      ['pty-legacy', { scrollbackRows: 0 }],
+      ['pty-legacy', { scrollbackRows: 0 }]
+    ])
     await expect(runtime.readTerminal(terminal.handle)).resolves.toMatchObject({ tail: [] })
     expect(serializeProviderBuffer).toHaveBeenCalledTimes(5)
     expect(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -13414,6 +13414,7 @@ export class OrcaRuntimeService {
     limit: number | undefined,
     snapshotOptions: ProviderSnapshotReadOptions = {}
   ): Promise<string[]> {
+    const generation = this.getPtyLifecycleGeneration(ptyId)
     const lineLimit = terminalReadLimit(limit, DEFAULT_TERMINAL_READ_LIMIT)
     const snapshot = await this.serializeProviderTerminalBuffer(
       ptyId,
@@ -13426,7 +13427,12 @@ export class OrcaRuntimeService {
     // Why: a cached acquisition can carry scrollback this caller did not ask for,
     // so visible-only reads parse the grid itself rather than trusting the request.
     if (snapshotOptions.visibleScreenOnly) {
-      return await this.parseVisibleSnapshotLines(snapshot)
+      const lines = await this.parseVisibleSnapshotLines(snapshot)
+      // Live bytes ordered after the provider frame make that frame stale.
+      return this.getPtyLifecycleGeneration(ptyId) === generation &&
+        this.getPtyOutputSequence(ptyId) <= snapshot.seq
+        ? lines
+        : []
     }
     const data = `${snapshot.scrollbackAnsi ?? ''}${snapshot.data}`
     if (data.length === 0) {
@@ -13439,7 +13445,11 @@ export class OrcaRuntimeService {
     })
     try {
       await emulator.write(data)
-      return visibleNonBlankTerminalLines(emulator.getBufferTailLines(lineLimit))
+      const lines = visibleNonBlankTerminalLines(emulator.getBufferTailLines(lineLimit))
+      return this.getPtyLifecycleGeneration(ptyId) === generation &&
+        this.getPtyOutputSequence(ptyId) <= snapshot.seq
+        ? lines
+        : []
     } finally {
       emulator.dispose()
     }
@@ -13515,7 +13525,10 @@ export class OrcaRuntimeService {
       }
     }
     const lines = await this.parseVisibleSnapshotLines(snapshot)
-    if (this.getPtyLifecycleGeneration(ptyId) !== generation) {
+    if (
+      this.getPtyLifecycleGeneration(ptyId) !== generation ||
+      this.getPtyOutputSequence(ptyId) > snapshot.seq
+    ) {
       return null
     }
     const visibleState: RuntimeVisibleTerminalState = {
@@ -13524,9 +13537,7 @@ export class OrcaRuntimeService {
       sequence: snapshot.seq,
       generation
     }
-    if (this.getPtyOutputSequence(ptyId) <= snapshot.seq) {
-      this.providerVisibleStateByPtyId.set(ptyId, visibleState)
-    }
+    this.providerVisibleStateByPtyId.set(ptyId, visibleState)
     return visibleState
   }
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2988,6 +2988,16 @@ export type RuntimeRendererReloadFence = Readonly<{
   recovery: 'renderer' | 'headless' | 'reloading'
 }>
 
+/** How a caller wants the provider-held screen fetched when the runtime has no
+ *  bytes of its own. `visibleScreenOnly` narrows the result to the current grid:
+ *  scrollback can still hold a ready banner a working agent printed minutes ago,
+ *  which is history, not evidence of what the agent is doing now. */
+type ProviderSnapshotReadOptions = {
+  timeoutMs?: number
+  retireOnTimeout?: boolean
+  visibleScreenOnly?: boolean
+}
+
 export class OrcaRuntimeService {
   private readonly runtimeId = randomUUID()
   private readonly startedAt = Date.now()
@@ -13233,6 +13243,13 @@ export class OrcaRuntimeService {
     const generation = this.getPtyLifecycleGeneration(ptyId)
     const scrollbackRows = Math.max(0, Math.floor(opts.scrollbackRows ?? 0))
     let acquisition = this.providerBufferAcquisitionsByPtyId.get(ptyId)
+    // Why before the re-acquire branch: an unresponsive provider is a property of
+    // the process, not of the row count one caller asked for. Checking retirement
+    // only after re-acquiring let a wider request replace the retired entry and
+    // hang again; the hung call's own settle still clears it and allows recovery.
+    if (acquisition?.generation === generation && acquisition.timedOut) {
+      return null
+    }
     if (
       !acquisition ||
       acquisition.generation !== generation ||
@@ -13337,7 +13354,7 @@ export class OrcaRuntimeService {
     ptyId: string,
     read: RuntimeTerminalRead,
     opts: { cursor?: number; limit?: number } = {},
-    providerWait: { timeoutMs?: number; retireOnTimeout?: boolean } = {}
+    providerSnapshot: ProviderSnapshotReadOptions = {}
   ): Promise<RuntimeTerminalRead> {
     if (typeof opts.cursor === 'number') {
       return read
@@ -13355,7 +13372,7 @@ export class OrcaRuntimeService {
       const providerLines = await this.readProviderTerminalTailLines(
         ptyId,
         opts.limit,
-        providerWait
+        providerSnapshot
       )
       if (providerLines.length > 0) {
         return buildVisibleSnapshotReadFallback(read, providerLines, opts.limit)
@@ -13395,16 +13412,24 @@ export class OrcaRuntimeService {
   private async readProviderTerminalTailLines(
     ptyId: string,
     limit: number | undefined,
-    wait: { timeoutMs?: number; retireOnTimeout?: boolean } = {}
+    snapshotOptions: ProviderSnapshotReadOptions = {}
   ): Promise<string[]> {
     const lineLimit = terminalReadLimit(limit, DEFAULT_TERMINAL_READ_LIMIT)
     const snapshot = await this.serializeProviderTerminalBuffer(
       ptyId,
-      { scrollbackRows: lineLimit },
-      wait
+      { scrollbackRows: snapshotOptions.visibleScreenOnly ? 0 : lineLimit },
+      snapshotOptions
     )
-    const data = snapshot ? `${snapshot.scrollbackAnsi ?? ''}${snapshot.data}` : ''
-    if (!snapshot || data.length === 0) {
+    if (!snapshot) {
+      return []
+    }
+    // Why: a cached acquisition can carry scrollback this caller did not ask for,
+    // so visible-only reads parse the grid itself rather than trusting the request.
+    if (snapshotOptions.visibleScreenOnly) {
+      return await this.parseVisibleSnapshotLines(snapshot)
+    }
+    const data = `${snapshot.scrollbackAnsi ?? ''}${snapshot.data}`
+    if (data.length === 0) {
       return []
     }
     const emulator = new HeadlessEmulator({
@@ -18462,14 +18487,14 @@ export class OrcaRuntimeService {
   async readTerminal(
     handle: string,
     opts: { cursor?: number; limit?: number; screen?: boolean } = {},
-    providerWait: { timeoutMs?: number; retireOnTimeout?: boolean } = {}
+    providerSnapshot: ProviderSnapshotReadOptions = {}
   ): Promise<RuntimeTerminalRead> {
     const pty = this.getLivePtyForHandle(handle)
     if (pty) {
       const read = this.readPtyTerminal(handle, pty.pty, opts)
       const visibleRead = opts.screen
         ? await this.readRenderedScreen(pty.pty.ptyId, read, opts)
-        : await this.withVisibleSnapshotFallback(pty.pty.ptyId, read, opts, providerWait)
+        : await this.withVisibleSnapshotFallback(pty.pty.ptyId, read, opts, providerSnapshot)
       this.assertLiveTerminalHandleTargetsPty(handle, pty.pty.ptyId)
       return labelTerminalReadSource(visibleRead)
     }
@@ -18491,7 +18516,7 @@ export class OrcaRuntimeService {
     }
     const visibleRead = opts.screen
       ? await this.readRenderedScreen(leaf.ptyId, read, opts)
-      : await this.withVisibleSnapshotFallback(leaf.ptyId, read, opts, providerWait)
+      : await this.withVisibleSnapshotFallback(leaf.ptyId, read, opts, providerSnapshot)
     this.assertLiveTerminalHandleTargetsPty(handle, leaf.ptyId)
     return labelTerminalReadSource(visibleRead)
   }
@@ -35557,6 +35582,11 @@ export class OrcaRuntimeService {
     }
   }
 
+  /** One bounded look at the provider's screen for an adopted PTY whose retained
+   *  readiness metadata was lost. Deliberately single-shot: it answers "is the
+   *  screen already showing a settled prompt", and the poll above owns every
+   *  later transition. A provider screen that is still working when this fires
+   *  resolves through the poll, not here. */
   private startTuiIdleVisibleReadProbe(waiter: TerminalWaiter, waiterTimeoutMs: number): void {
     const snapshotTimeoutMs = Math.min(
       VISIBLE_TERMINAL_SNAPSHOT_TIMEOUT_MS,
@@ -35568,7 +35598,10 @@ export class OrcaRuntimeService {
         {},
         {
           timeoutMs: snapshotTimeoutMs,
-          retireOnTimeout: true
+          retireOnTimeout: true,
+          // Why: the ready banner stays in scrollback for the whole session, so
+          // classifying history would call a working agent idle (#15569 review).
+          visibleScreenOnly: true
         }
       ),
       snapshotTimeoutMs,
@@ -35587,29 +35620,33 @@ export class OrcaRuntimeService {
         if (!blockedReason && !isKnownReadyPromptPreview(snapshotText)) {
           return
         }
+        // Why resolve before clearing: a stale handle throws while locating the
+        // record, and a cleared interval would leave the waiter with no poll and
+        // no probe — able to end only in timeout.
+        const result = this.buildTuiIdleProbeResult(waiter.handle, blockedReason)
         if (waiter.pollInterval) {
           clearInterval(waiter.pollInterval)
           waiter.pollInterval = null
         }
-        const pty = this.getLivePtyForHandle(waiter.handle)
-        if (pty) {
-          this.resolveWaiter(
-            waiter,
-            blockedReason
-              ? buildPtyTerminalWaitBlockedResult(waiter.handle, 'tui-idle', pty.pty, blockedReason)
-              : buildPtyTerminalWaitResult(waiter.handle, 'tui-idle', pty.pty)
-          )
-          return
-        }
-        const { leaf } = this.getLiveLeafForHandle(waiter.handle)
-        this.resolveWaiter(
-          waiter,
-          blockedReason
-            ? buildTerminalWaitBlockedResult(waiter.handle, 'tui-idle', leaf, blockedReason)
-            : buildTerminalWaitResult(waiter.handle, 'tui-idle', leaf)
-        )
+        this.resolveWaiter(waiter, result)
       })
       .catch(() => {})
+  }
+
+  private buildTuiIdleProbeResult(
+    handle: string,
+    blockedReason: RuntimeTerminalWaitBlockedReason | null
+  ): RuntimeTerminalWait {
+    const pty = this.getLivePtyForHandle(handle)
+    if (pty) {
+      return blockedReason
+        ? buildPtyTerminalWaitBlockedResult(handle, 'tui-idle', pty.pty, blockedReason)
+        : buildPtyTerminalWaitResult(handle, 'tui-idle', pty.pty)
+    }
+    const { leaf } = this.getLiveLeafForHandle(handle)
+    return blockedReason
+      ? buildTerminalWaitBlockedResult(handle, 'tui-idle', leaf, blockedReason)
+      : buildTerminalWaitResult(handle, 'tui-idle', leaf)
   }
 
   private getAdoptedPtyExplicitIdleStatus(pty: RuntimePtyWorktreeRecord): AgentStatus | null {

--- a/tests/e2e/completed-worker-retirement-resume.spec.ts
+++ b/tests/e2e/completed-worker-retirement-resume.spec.ts
@@ -5,6 +5,7 @@ import {
   waitForActivePanePtyId,
   waitForActiveTerminalManager
 } from './helpers/terminal'
+import { FAKE_AGENT_WINDOWS_SHELL } from './helpers/fake-agent-command-override'
 import {
   cleanupCompletedWorkerFixture,
   clearCompletedWorkerLedger,
@@ -46,13 +47,20 @@ for (const closeMode of ['terminal-close-cli', 'worker-release'] as const) {
     await ensureTerminalVisible(orcaPage)
     await waitForActiveTerminalManager(orcaPage)
     await waitForActivePanePtyId(orcaPage)
-    await orcaPage.evaluate(async (agentCommand) => {
-      await window.__store?.getState().updateSettings({
-        agentCmdOverrides: { codex: agentCommand },
-        disabledTuiAgents: [],
-        terminalHiddenViewParking: false
-      })
-    }, completedWorkerFakeCodexCommand)
+    await orcaPage.evaluate(
+      async ({ agentCommand, terminalWindowsShell }) => {
+        await window.__store?.getState().updateSettings({
+          agentCmdOverrides: { codex: agentCommand },
+          terminalWindowsShell,
+          disabledTuiAgents: [],
+          terminalHiddenViewParking: false
+        })
+      },
+      {
+        agentCommand: completedWorkerFakeCodexCommand,
+        terminalWindowsShell: FAKE_AGENT_WINDOWS_SHELL
+      }
+    )
 
     const userDataDir = await electronApp.evaluate(({ app }) => app.getPath('userData'))
     const isolatedHome = await electronApp.evaluate(({ app }) => app.getPath('home'))
@@ -194,7 +202,15 @@ for (const closeMode of ['terminal-close-cli', 'worker-release'] as const) {
     )
 
     await orcaPage.evaluate(
-      ({ paneKey, providerSessionId, tabId, terminalHandle, transcriptPath, worktreeId }) => {
+      ({
+        agentCommand,
+        paneKey,
+        providerSessionId,
+        tabId,
+        terminalHandle,
+        transcriptPath,
+        worktreeId
+      }) => {
         const state = window.__store?.getState()
         if (!state) {
           throw new Error('Renderer store unavailable')
@@ -208,7 +224,10 @@ for (const closeMode of ['terminal-close-cli', 'worker-release'] as const) {
         const recovery = {
           providerSession,
           launchConfig: {
-            agentCommand: 'codex',
+            // Why not bare 'codex': resume prefers the captured command over
+            // agentCmdOverrides, so a bare name would resolve the machine's real
+            // Codex off PATH and unpin the adoption leg this spec exercises.
+            agentCommand,
             agentArgs: '--dangerously-bypass-approvals-and-sandbox',
             agentEnv: {}
           }
@@ -231,6 +250,7 @@ for (const closeMode of ['terminal-close-cli', 'worker-release'] as const) {
         )
       },
       {
+        agentCommand: completedWorkerFakeCodexCommand,
         paneKey: workerPaneKey,
         providerSessionId: PROVIDER_SESSION_ID,
         tabId: worker.tabId,

--- a/tests/e2e/completed-worker-retirement-resume.spec.ts
+++ b/tests/e2e/completed-worker-retirement-resume.spec.ts
@@ -191,6 +191,13 @@ for (const closeMode of ['terminal-close-cli', 'worker-release'] as const) {
         return dispatchCapability
       })
       .not.toBeNull()
+    await expect
+      .poll(() =>
+        readCompletedWorkerLedger()
+          .filter((event) => event.event === 'ack')
+          .map((event) => event.mode)
+      )
+      .toEqual(['bracketed'])
     if (!dispatchCapability) {
       throw new Error('Background worker did not receive its dispatch capability')
     }

--- a/tests/e2e/helpers/completed-worker-retirement-fixture.ts
+++ b/tests/e2e/helpers/completed-worker-retirement-fixture.ts
@@ -36,13 +36,11 @@ if (args.includes('app-server')) {
 append({ event: 'spawn', args })
 process.stdout.write('\\u001b]0;Codex Ready\\u0007OpenAI Codex\\nmodel: e2e\\ndirectory: e2e\\n')
 ${FAKE_AGENT_PASTE_END_SCANNER_SOURCE}
-let pasteEnded = false
 process.stdin.on('data', (chunk) => {
   const input = chunk.toString()
   const pasteEndScan = scanFakeAgentPasteEnd(fakeAgentPasteEndTail, input)
   fakeAgentPasteEndTail = pasteEndScan.tail
-  if (pasteEndScan.ended) {
-    pasteEnded = true
+  if (pasteEndScan.pasteEndOffset !== null) {
     process.stdout.write('\\x1b[?25h')
   }
   append({ event: 'input', input })
@@ -50,10 +48,10 @@ process.stdin.on('data', (chunk) => {
     append({ event: 'normal-exit' })
     process.exit(0)
   }
-  fakeAgentMaybeAck(pasteEnded, input, (mode) => {
+  fakeAgentMaybeAck(pasteEndScan, input, (mode) => {
     append({ event: 'ack', mode })
-    const suffix = mode === 'bracketed' ? '' : ' (unbracketed paste)'
-    process.stdout.write('\\u001b]0;Codex Working\\u0007ACK' + suffix + '\\n')
+    const message = mode === 'bracketed' ? 'ACK' : 'PASTE_PROTOCOL_ERROR'
+    process.stdout.write('\\u001b]0;Codex Working\\u0007' + message + '\\n')
     setTimeout(() => process.stdout.write('\\u001b]0;Codex Ready\\u0007'), 10)
   })
 })
@@ -81,9 +79,10 @@ export const completedWorkerLaunchEnv = {
 
 export type LifecycleEvent = {
   pid: number
-  event: 'spawn' | 'input' | 'normal-exit'
+  event: 'spawn' | 'input' | 'ack' | 'normal-exit'
   args?: string[]
   input?: string
+  mode?: 'bracketed' | 'unbracketed'
 }
 
 export type TerminalIdentity = Pick<

--- a/tests/e2e/helpers/completed-worker-retirement-fixture.ts
+++ b/tests/e2e/helpers/completed-worker-retirement-fixture.ts
@@ -50,10 +50,12 @@ process.stdin.on('data', (chunk) => {
     append({ event: 'normal-exit' })
     process.exit(0)
   }
-  if (pasteEnded && input.includes('\\r')) {
-    process.stdout.write('\\u001b]0;Codex Working\\u0007ACK\\n')
+  fakeAgentMaybeAck(pasteEnded, input, (mode) => {
+    append({ event: 'ack', mode })
+    const suffix = mode === 'bracketed' ? '' : ' (unbracketed paste)'
+    process.stdout.write('\\u001b]0;Codex Working\\u0007ACK' + suffix + '\\n')
     setTimeout(() => process.stdout.write('\\u001b]0;Codex Ready\\u0007'), 10)
-  }
+  })
 })
 process.stdin.setRawMode?.(true)
 process.stdin.resume()

--- a/tests/e2e/helpers/fake-agent-command-override.ts
+++ b/tests/e2e/helpers/fake-agent-command-override.ts
@@ -1,12 +1,7 @@
 import { quoteStartupArg, resolveStartupShell } from '../../../src/shared/tui-agent-startup-shell'
 import { resolveLocalWindowsAgentStartupShell } from '../../../src/shared/windows-terminal-shell'
 
-/**
- * The Windows shell these fixtures pin through `updateSettings`. The override
- * built below is quoted for whichever shell the runtime will actually type it
- * into, so specs must apply this value alongside the override rather than
- * relying on the default happening to match.
- */
+/** Specs must apply this through `updateSettings`; the override below is quoted for it. */
 export const FAKE_AGENT_WINDOWS_SHELL = 'powershell.exe'
 
 export function buildFakeAgentCommandOverride(

--- a/tests/e2e/helpers/fake-agent-command-override.ts
+++ b/tests/e2e/helpers/fake-agent-command-override.ts
@@ -1,10 +1,26 @@
-import { quoteStartupArg } from '../../../src/shared/tui-agent-startup-shell'
+import { quoteStartupArg, resolveStartupShell } from '../../../src/shared/tui-agent-startup-shell'
+import { resolveLocalWindowsAgentStartupShell } from '../../../src/shared/windows-terminal-shell'
+
+/**
+ * The Windows shell these fixtures pin through `updateSettings`. The override
+ * built below is quoted for whichever shell the runtime will actually type it
+ * into, so specs must apply this value alongside the override rather than
+ * relying on the default happening to match.
+ */
+export const FAKE_AGENT_WINDOWS_SHELL = 'powershell.exe'
 
 export function buildFakeAgentCommandOverride(
   executablePath: string,
-  platform: NodeJS.Platform = process.platform
+  platform: NodeJS.Platform = process.platform,
+  terminalWindowsShell: string = FAKE_AGENT_WINDOWS_SHELL
 ): string {
-  const shell = platform === 'win32' ? 'powershell' : 'posix'
+  // Why resolve rather than assume PowerShell on win32: the startup shell comes
+  // from the user's terminalWindowsShell setting, and a cmd/Git Bash/WSL host
+  // would silently fail to launch a PowerShell-quoted path.
+  const shell = resolveStartupShell(
+    platform,
+    resolveLocalWindowsAgentStartupShell({ platform, isRemote: false, terminalWindowsShell })
+  )
   const quotedPath = quoteStartupArg(executablePath, shell)
-  return platform === 'win32' ? `& ${quotedPath}` : quotedPath
+  return shell === 'powershell' ? `& ${quotedPath}` : quotedPath
 }

--- a/tests/e2e/helpers/fake-agent-command-override.unit.test.ts
+++ b/tests/e2e/helpers/fake-agent-command-override.unit.test.ts
@@ -13,4 +13,16 @@ describe('buildFakeAgentCommandOverride', () => {
       "'/tmp/fake agent'\"'\"'s/codex'"
     )
   })
+
+  it('drops the PowerShell call operator when the Windows host runs cmd', () => {
+    expect(
+      buildFakeAgentCommandOverride('C:\\Temp\\fake agent\\codex.cmd', 'win32', 'cmd.exe')
+    ).toBe('"C:\\Temp\\fake agent\\codex.cmd"')
+  })
+
+  it('uses POSIX quoting when the Windows host runs Git Bash or WSL', () => {
+    expect(buildFakeAgentCommandOverride('/tmp/fake agent/codex', 'win32', 'wsl.exe')).toBe(
+      "'/tmp/fake agent/codex'"
+    )
+  })
 })

--- a/tests/e2e/helpers/fake-agent-command-override.unit.test.ts
+++ b/tests/e2e/helpers/fake-agent-command-override.unit.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { WINDOWS_GIT_BASH_SHELL } from '../../../src/shared/windows-terminal-shell'
 import { buildFakeAgentCommandOverride } from './fake-agent-command-override'
 
 describe('buildFakeAgentCommandOverride', () => {
@@ -24,5 +25,8 @@ describe('buildFakeAgentCommandOverride', () => {
     expect(buildFakeAgentCommandOverride('/tmp/fake agent/codex', 'win32', 'wsl.exe')).toBe(
       "'/tmp/fake agent/codex'"
     )
+    expect(
+      buildFakeAgentCommandOverride("/tmp/fake agent's/codex", 'win32', WINDOWS_GIT_BASH_SHELL)
+    ).toBe("'/tmp/fake agent'\"'\"'s/codex'")
   })
 })

--- a/tests/e2e/helpers/fake-agent-paste-end-scanner.ts
+++ b/tests/e2e/helpers/fake-agent-paste-end-scanner.ts
@@ -9,7 +9,35 @@ export function scanFakeAgentPasteEnd(tail: string, input: string): FakeAgentPas
   }
 }
 
+/** How long a fake agent waits for a bracketed-paste terminator before
+ *  acknowledging a bare submit anyway. Gating ACK on the terminator is what
+ *  makes these fixtures exercise the real delivery contract; without the
+ *  fallback, a delivery path that stops bracketing turns every spec into an
+ *  opaque suite timeout instead of a failed assertion. */
+export const FAKE_AGENT_UNBRACKETED_ACK_GRACE_MS = 2_000
+
 export const FAKE_AGENT_PASTE_END_SCANNER_SOURCE = `
 const scanFakeAgentPasteEnd = ${scanFakeAgentPasteEnd.toString()}
 let fakeAgentPasteEndTail = ''
+let fakeAgentSawSubmit = false
+let fakeAgentUnbracketedAckTimer = null
+function fakeAgentMaybeAck(pasteEnded, input, ack) {
+  fakeAgentSawSubmit = fakeAgentSawSubmit || input.includes('\\r')
+  if (!fakeAgentSawSubmit) return
+  if (pasteEnded) {
+    if (fakeAgentUnbracketedAckTimer) {
+      clearTimeout(fakeAgentUnbracketedAckTimer)
+      fakeAgentUnbracketedAckTimer = null
+    }
+    fakeAgentSawSubmit = false
+    ack('bracketed')
+    return
+  }
+  if (fakeAgentUnbracketedAckTimer) return
+  fakeAgentUnbracketedAckTimer = setTimeout(() => {
+    fakeAgentUnbracketedAckTimer = null
+    fakeAgentSawSubmit = false
+    ack('unbracketed')
+  }, ${FAKE_AGENT_UNBRACKETED_ACK_GRACE_MS})
+}
 `

--- a/tests/e2e/helpers/fake-agent-paste-end-scanner.ts
+++ b/tests/e2e/helpers/fake-agent-paste-end-scanner.ts
@@ -9,11 +9,7 @@ export function scanFakeAgentPasteEnd(tail: string, input: string): FakeAgentPas
   }
 }
 
-/** How long a fake agent waits for a bracketed-paste terminator before
- *  acknowledging a bare submit anyway. Gating ACK on the terminator is what
- *  makes these fixtures exercise the real delivery contract; without the
- *  fallback, a delivery path that stops bracketing turns every spec into an
- *  opaque suite timeout instead of a failed assertion. */
+/** Fallback ACK delay so an unbracketed delivery path fails an assertion instead of timing out the suite. */
 export const FAKE_AGENT_UNBRACKETED_ACK_GRACE_MS = 2_000
 
 export const FAKE_AGENT_PASTE_END_SCANNER_SOURCE = `

--- a/tests/e2e/helpers/fake-agent-paste-end-scanner.ts
+++ b/tests/e2e/helpers/fake-agent-paste-end-scanner.ts
@@ -1,11 +1,19 @@
-export type FakeAgentPasteEndScan = { tail: string; ended: boolean }
+export type FakeAgentPasteEndScan = {
+  tail: string
+  pasteBeginOffset: number | null
+  pasteEndOffset: number | null
+}
 
 export function scanFakeAgentPasteEnd(tail: string, input: string): FakeAgentPasteEndScan {
-  const marker = '\x1b[201~'
+  const beginMarker = '\x1b[200~'
+  const endMarker = '\x1b[201~'
   const candidate = tail + input
+  const beginIndex = candidate.indexOf(beginMarker)
+  const endIndex = candidate.indexOf(endMarker)
   return {
-    tail: candidate.slice(1 - marker.length),
-    ended: candidate.includes(marker)
+    tail: candidate.slice(1 - endMarker.length),
+    pasteBeginOffset: beginIndex === -1 ? null : beginIndex + beginMarker.length - tail.length,
+    pasteEndOffset: endIndex === -1 ? null : endIndex + endMarker.length - tail.length
   }
 }
 
@@ -15,16 +23,43 @@ export const FAKE_AGENT_UNBRACKETED_ACK_GRACE_MS = 2_000
 export const FAKE_AGENT_PASTE_END_SCANNER_SOURCE = `
 const scanFakeAgentPasteEnd = ${scanFakeAgentPasteEnd.toString()}
 let fakeAgentPasteEndTail = ''
+let fakeAgentInsidePaste = false
+let fakeAgentSawPasteEnd = false
 let fakeAgentSawSubmit = false
 let fakeAgentUnbracketedAckTimer = null
-function fakeAgentMaybeAck(pasteEnded, input, ack) {
-  fakeAgentSawSubmit = fakeAgentSawSubmit || input.includes('\\r')
+function fakeAgentMaybeAck(scan, input, ack) {
+  const events = []
+  if (scan.pasteBeginOffset !== null) {
+    events.push({ offset: scan.pasteBeginOffset, type: 'begin' })
+  }
+  if (scan.pasteEndOffset !== null) {
+    events.push({ offset: scan.pasteEndOffset, type: 'end' })
+  }
+  for (let offset = input.indexOf('\\r'); offset >= 0; offset = input.indexOf('\\r', offset + 1)) {
+    events.push({ offset, type: 'submit' })
+  }
+  events.sort((left, right) => left.offset - right.offset || (left.type === 'submit' ? 1 : -1))
+  for (const event of events) {
+    if (fakeAgentSawSubmit) break
+    if (event.type === 'begin') {
+      fakeAgentInsidePaste = true
+    } else if (event.type === 'end') {
+      if (fakeAgentInsidePaste) {
+        fakeAgentInsidePaste = false
+        fakeAgentSawPasteEnd = true
+      }
+    } else if (!fakeAgentInsidePaste) {
+      fakeAgentSawSubmit = true
+    }
+  }
   if (!fakeAgentSawSubmit) return
-  if (pasteEnded) {
+  if (fakeAgentSawPasteEnd) {
     if (fakeAgentUnbracketedAckTimer) {
       clearTimeout(fakeAgentUnbracketedAckTimer)
       fakeAgentUnbracketedAckTimer = null
     }
+    fakeAgentInsidePaste = false
+    fakeAgentSawPasteEnd = false
     fakeAgentSawSubmit = false
     ack('bracketed')
     return
@@ -32,6 +67,8 @@ function fakeAgentMaybeAck(pasteEnded, input, ack) {
   if (fakeAgentUnbracketedAckTimer) return
   fakeAgentUnbracketedAckTimer = setTimeout(() => {
     fakeAgentUnbracketedAckTimer = null
+    fakeAgentInsidePaste = false
+    fakeAgentSawPasteEnd = false
     fakeAgentSawSubmit = false
     ack('unbracketed')
   }, ${FAKE_AGENT_UNBRACKETED_ACK_GRACE_MS})

--- a/tests/e2e/helpers/fake-agent-paste-end-scanner.unit.test.ts
+++ b/tests/e2e/helpers/fake-agent-paste-end-scanner.unit.test.ts
@@ -14,26 +14,104 @@ describe('scanFakeAgentPasteEnd', () => {
       const first = scanFakeAgentPasteEnd('', PASTE_END.slice(0, splitAt))
       const second = scanFakeAgentPasteEnd(first.tail, PASTE_END.slice(splitAt))
 
-      expect(first.ended).toBe(false)
-      expect(second.ended).toBe(true)
+      expect(first.pasteBeginOffset).toBeNull()
+      expect(first.pasteEndOffset).toBeNull()
+      expect(second.pasteBeginOffset).toBeNull()
+      expect(second.pasteEndOffset).toBe(PASTE_END.length - splitAt)
     }
   )
 
   it('keeps only the possible marker prefix between chunks', () => {
     const scan = scanFakeAgentPasteEnd('', `worker prompt${PASTE_END.slice(0, -1)}`)
 
-    expect(scan).toEqual({ tail: PASTE_END.slice(0, -1), ended: false })
+    expect(scan).toEqual({
+      tail: PASTE_END.slice(0, -1),
+      pasteBeginOffset: null,
+      pasteEndOffset: null
+    })
   })
 
   it('emits standalone JavaScript for the fake agent process', () => {
     const context = vm.createContext({ result: null })
     vm.runInContext(
       `${FAKE_AGENT_PASTE_END_SCANNER_SOURCE}
-       const first = scanFakeAgentPasteEnd('', '\\x1b[20')
+       const first = scanFakeAgentPasteEnd('', '\x1b[20')
        result = scanFakeAgentPasteEnd(first.tail, '1~')`,
       context
     )
 
-    expect(context.result).toEqual({ tail: PASTE_END.slice(1), ended: true })
+    expect(context.result).toEqual({
+      tail: PASTE_END.slice(1),
+      pasteBeginOffset: null,
+      pasteEndOffset: 2
+    })
+  })
+
+  it('recognizes a paste frame and submit delivered in separate chunks', () => {
+    const context = vm.createContext({ result: null })
+    vm.runInContext(
+      `${FAKE_AGENT_PASTE_END_SCANNER_SOURCE}
+       const modes = []
+       fakeAgentMaybeAck({ pasteBeginOffset: 1, pasteEndOffset: null }, '', (mode) => modes.push(mode))
+       fakeAgentMaybeAck({ pasteBeginOffset: null, pasteEndOffset: 1 }, '', (mode) => modes.push(mode))
+       fakeAgentMaybeAck({ pasteBeginOffset: null, pasteEndOffset: null }, '\\r', (mode) => modes.push(mode))
+       result = modes`,
+      context
+    )
+
+    expect(context.result).toEqual(['bracketed'])
+  })
+
+  it('does not upgrade a paste frame received after submit', () => {
+    const timers: (() => void)[] = []
+    const context = vm.createContext({
+      result: null,
+      setTimeout: (fn: () => void) => timers.push(fn)
+    })
+    vm.runInContext(
+      `${FAKE_AGENT_PASTE_END_SCANNER_SOURCE}
+       const modes = []
+       fakeAgentMaybeAck({ pasteBeginOffset: null, pasteEndOffset: null }, '\\r', (mode) => modes.push(mode))
+       fakeAgentMaybeAck({ pasteBeginOffset: 1, pasteEndOffset: null }, '', (mode) => modes.push(mode))
+       fakeAgentMaybeAck({ pasteBeginOffset: null, pasteEndOffset: 1 }, '', (mode) => modes.push(mode))
+       result = modes`,
+      context
+    )
+    expect(context.result).toEqual([])
+    timers.forEach((timer) => timer())
+
+    expect(vm.runInContext('modes', context)).toEqual(['unbracketed'])
+  })
+
+  it('ignores multiline carriage returns inside one bracketed paste chunk', () => {
+    const context = vm.createContext({ result: null })
+    vm.runInContext(
+      `${FAKE_AGENT_PASTE_END_SCANNER_SOURCE}
+       const modes = []
+       const input = '\\x1b[200~line one\\rline two\\x1b[201~\\r'
+       const scan = scanFakeAgentPasteEnd('', input)
+       fakeAgentMaybeAck(scan, input, (mode) => modes.push(mode))
+       result = modes`,
+      context
+    )
+
+    expect(context.result).toEqual(['bracketed'])
+  })
+
+  it('ignores multiline carriage returns across bracketed paste chunks', () => {
+    const context = vm.createContext({ result: null })
+    vm.runInContext(
+      `${FAKE_AGENT_PASTE_END_SCANNER_SOURCE}
+       const modes = []
+       for (const input of ['\\x1b[200~line one', '\\rline two', '\\x1b[201~', '\\r']) {
+         const scan = scanFakeAgentPasteEnd(fakeAgentPasteEndTail, input)
+         fakeAgentPasteEndTail = scan.tail
+         fakeAgentMaybeAck(scan, input, (mode) => modes.push(mode))
+       }
+       result = modes`,
+      context
+    )
+
+    expect(context.result).toEqual(['bracketed'])
   })
 })

--- a/tests/e2e/orchestration-legacy-worker-missing-terminal-recovery.spec.ts
+++ b/tests/e2e/orchestration-legacy-worker-missing-terminal-recovery.spec.ts
@@ -19,7 +19,10 @@ import Database from '../../src/main/sqlite/sync-database'
 import { LEGACY_CONTRACT_VERSION } from '../../src/main/runtime/orchestration/db'
 import { DEFAULT_LOCAL_ORCA_PROFILE_ID } from '../../src/shared/orca-profiles'
 import type { RuntimeTerminalListResult, RuntimeTerminalRead } from '../../src/shared/runtime-types'
-import { buildFakeAgentCommandOverride } from './helpers/fake-agent-command-override'
+import {
+  buildFakeAgentCommandOverride,
+  FAKE_AGENT_WINDOWS_SHELL
+} from './helpers/fake-agent-command-override'
 import { FAKE_AGENT_PASTE_END_SCANNER_SOURCE } from './helpers/fake-agent-paste-end-scanner'
 
 const PROVIDER_SESSION_ID = 'e2e-missing-legacy-worker'
@@ -58,10 +61,13 @@ process.stdin.on('data', (chunk) => {
   if (input.includes('\\x03')) {
     appendLedger('ORCA_E2E_INTERRUPTION_LEDGER', { event: 'stdin-ctrl-c' })
   }
-  if (!acknowledged && pasteEnded && input.includes('\\r')) {
-    acknowledged = true
-    process.stdout.write('\\u001b]0;Codex Working\\u0007ACK\\n')
-    setTimeout(() => process.stdout.write('\\u001b]0;Codex Ready\\u0007'), 10)
+  if (!acknowledged) {
+    fakeAgentMaybeAck(pasteEnded, input, (mode) => {
+      acknowledged = true
+      const suffix = mode === 'bracketed' ? '' : ' (unbracketed paste)'
+      process.stdout.write('\\u001b]0;Codex Working\\u0007ACK' + suffix + '\\n')
+      setTimeout(() => process.stdout.write('\\u001b]0;Codex Ready\\u0007'), 10)
+    })
   }
 })
 process.stdin.setRawMode?.(true)
@@ -215,11 +221,15 @@ test('a missing legacy worker cannot spawn a replacement during restart recovery
     firstApp = first.app
     const worktreeId = await attachRepoAndOpenTerminal(first.page, repoPath)
     await waitForSessionReady(first.page)
-    await first.page.evaluate(async (agentCommand) => {
-      await window.__store?.getState().updateSettings({
-        agentCmdOverrides: { codex: agentCommand }
-      })
-    }, fakeCodexCommand)
+    await first.page.evaluate(
+      async ({ agentCommand, terminalWindowsShell }) => {
+        await window.__store?.getState().updateSettings({
+          agentCmdOverrides: { codex: agentCommand },
+          terminalWindowsShell
+        })
+      },
+      { agentCommand: fakeCodexCommand, terminalWindowsShell: FAKE_AGENT_WINDOWS_SHELL }
+    )
     await ensureTerminalVisible(first.page)
     await getActiveTabId(first.page)
     await waitForActivePanePtyId(first.page)
@@ -285,7 +295,7 @@ test('a missing legacy worker cannot spawn a replacement during restart recovery
 
     const transcriptPath = session.seedCodexResumeRollout(PROVIDER_SESSION_ID, repoPath)
     await first.page.evaluate(
-      ({ paneKey, tabId, workerWorktreeId, terminalHandle, transcript }) => {
+      ({ agentCommand, paneKey, tabId, workerWorktreeId, terminalHandle, transcript }) => {
         window.__store?.getState().setAgentStatus(
           paneKey,
           { state: 'working', prompt: 'Respond ACK and remain idle', agentType: 'codex' },
@@ -299,7 +309,10 @@ test('a missing legacy worker cannot spawn a replacement during restart recovery
               transcriptPath: transcript
             },
             launchConfig: {
-              agentCommand: 'codex',
+              // Why not bare 'codex': resume prefers the captured command over
+              // agentCmdOverrides, so a bare name would resolve the machine's real
+              // Codex off PATH and unpin the adoption leg this spec exercises.
+              agentCommand,
               agentArgs: '--dangerously-bypass-approvals-and-sandbox',
               agentEnv: {}
             }
@@ -308,6 +321,7 @@ test('a missing legacy worker cannot spawn a replacement during restart recovery
         window.__store?.getState().captureAllSleepingAgentSessions('quit')
       },
       {
+        agentCommand: fakeCodexCommand,
         paneKey: workerPaneKey,
         tabId: worker!.tabId,
         workerWorktreeId: worker!.worktreeId,

--- a/tests/e2e/orchestration-legacy-worker-missing-terminal-recovery.spec.ts
+++ b/tests/e2e/orchestration-legacy-worker-missing-terminal-recovery.spec.ts
@@ -49,23 +49,21 @@ appendLedger('ORCA_E2E_SPAWN_LEDGER', { event: 'spawn' })
 process.stdout.write('\\u001b]0;Codex Ready\\u0007OpenAI Codex\\nmodel: e2e\\ndirectory: e2e\\n')
 let acknowledged = false
 ${FAKE_AGENT_PASTE_END_SCANNER_SOURCE}
-let pasteEnded = false
 process.stdin.on('data', (chunk) => {
   const input = chunk.toString()
   const pasteEndScan = scanFakeAgentPasteEnd(fakeAgentPasteEndTail, input)
   fakeAgentPasteEndTail = pasteEndScan.tail
-  if (pasteEndScan.ended) {
-    pasteEnded = true
+  if (pasteEndScan.pasteEndOffset !== null) {
     process.stdout.write('\\x1b[?25h')
   }
   if (input.includes('\\x03')) {
     appendLedger('ORCA_E2E_INTERRUPTION_LEDGER', { event: 'stdin-ctrl-c' })
   }
   if (!acknowledged) {
-    fakeAgentMaybeAck(pasteEnded, input, (mode) => {
+    fakeAgentMaybeAck(pasteEndScan, input, (mode) => {
       acknowledged = true
-      const suffix = mode === 'bracketed' ? '' : ' (unbracketed paste)'
-      process.stdout.write('\\u001b]0;Codex Working\\u0007ACK' + suffix + '\\n')
+      const message = mode === 'bracketed' ? 'ACK' : 'PASTE_PROTOCOL_ERROR'
+      process.stdout.write('\\u001b]0;Codex Working\\u0007' + message + '\\n')
       setTimeout(() => process.stdout.write('\\u001b]0;Codex Ready\\u0007'), 10)
     })
   }

--- a/tests/e2e/orchestration-legacy-worker-restart-recovery.spec.ts
+++ b/tests/e2e/orchestration-legacy-worker-restart-recovery.spec.ts
@@ -49,7 +49,7 @@ function appendLedger(envName, event) {
     appendFileSync(ledgerPath, JSON.stringify({ pid: process.pid, at: Date.now(), ...event }) + '\\n')
   } catch {}
 }
-async function emitAuthorityHook() {
+async function emitAuthorityHook(hookEventName) {
   const port = process.env.ORCA_AGENT_HOOK_PORT
   const token = process.env.ORCA_AGENT_HOOK_TOKEN
   const launchToken = process.env.ORCA_AGENT_LAUNCH_TOKEN
@@ -69,12 +69,16 @@ async function emitAuthorityHook() {
         version: process.env.ORCA_AGENT_HOOK_VERSION,
         launchToken,
         payload: {
-          hook_event_name: 'UserPromptSubmit',
+          hook_event_name: hookEventName,
           prompt: 'Respond ACK and remain idle'
         }
       })
     })
-    appendLedger('ORCA_E2E_AUTHORITY_LEDGER', { event: 'authority-hook', status: response.status })
+    appendLedger('ORCA_E2E_AUTHORITY_LEDGER', {
+      event: 'authority-hook',
+      hookEventName,
+      status: response.status
+    })
   } catch (error) {
     appendLedger('ORCA_E2E_AUTHORITY_LEDGER', {
       event: 'authority-hook-error',
@@ -88,7 +92,7 @@ if (process.argv.slice(2).includes('app-server')) {
 }
 appendLedger('ORCA_E2E_SPAWN_LEDGER', { event: 'spawn', argv: process.argv.slice(2) })
 process.stdout.write('\\u001b]0;Codex Ready\\u0007OpenAI Codex\\nmodel: e2e\\ndirectory: e2e\\n')
-void emitAuthorityHook()
+const sessionStartHook = emitAuthorityHook('SessionStart')
 let acknowledged = false
 let lifecycleSent = false
 ${FAKE_AGENT_PASTE_END_SCANNER_SOURCE}
@@ -105,6 +109,7 @@ process.stdin.on('data', (chunk) => {
   if (!acknowledged) {
     fakeAgentMaybeAck(pasteEndScan, input, (mode) => {
       acknowledged = true
+      void sessionStartHook.then(() => emitAuthorityHook('UserPromptSubmit'))
       const message = mode === 'bracketed' ? 'ACK' : 'PASTE_PROTOCOL_ERROR'
       process.stdout.write('\\u001b]0;Codex Working\\u0007' + message + '\\n')
       setTimeout(() => process.stdout.write('\\u001b]0;Codex Ready\\u0007'), 10)
@@ -182,6 +187,7 @@ type LedgerEvent = {
   stdout?: string
   stderr?: string
   error?: string
+  hookEventName?: string
 }
 
 type PersistedWorkspaceSession = {
@@ -539,7 +545,18 @@ for (const contractVersion of [LEGACY_CONTRACT_VERSION, CURRENT_CONTRACT_VERSION
       expect(readLedger(interruptionLedgerPath)).toEqual([])
       await expect
         .poll(() => readLedger(authorityLedgerPath))
-        .toEqual([expect.objectContaining({ event: 'authority-hook', status: 204 })])
+        .toEqual([
+          expect.objectContaining({
+            event: 'authority-hook',
+            hookEventName: 'SessionStart',
+            status: 204
+          }),
+          expect.objectContaining({
+            event: 'authority-hook',
+            hookEventName: 'UserPromptSubmit',
+            status: 204
+          })
+        ])
 
       const transcriptPath = session.seedCodexResumeRollout(PROVIDER_SESSION_ID, repoPath)
       await first.page.evaluate(

--- a/tests/e2e/orchestration-legacy-worker-restart-recovery.spec.ts
+++ b/tests/e2e/orchestration-legacy-worker-restart-recovery.spec.ts
@@ -92,23 +92,21 @@ void emitAuthorityHook()
 let acknowledged = false
 let lifecycleSent = false
 ${FAKE_AGENT_PASTE_END_SCANNER_SOURCE}
-let pasteEnded = false
 process.stdin.on('data', (chunk) => {
   const input = chunk.toString()
   const pasteEndScan = scanFakeAgentPasteEnd(fakeAgentPasteEndTail, input)
   fakeAgentPasteEndTail = pasteEndScan.tail
-  if (pasteEndScan.ended) {
-    pasteEnded = true
+  if (pasteEndScan.pasteEndOffset !== null) {
     process.stdout.write('\\x1b[?25h')
   }
   if (input.includes('\\x03')) {
     appendLedger('ORCA_E2E_INTERRUPTION_LEDGER', { event: 'stdin-ctrl-c' })
   }
   if (!acknowledged) {
-    fakeAgentMaybeAck(pasteEnded, input, (mode) => {
+    fakeAgentMaybeAck(pasteEndScan, input, (mode) => {
       acknowledged = true
-      const suffix = mode === 'bracketed' ? '' : ' (unbracketed paste)'
-      process.stdout.write('\\u001b]0;Codex Working\\u0007ACK' + suffix + '\\n')
+      const message = mode === 'bracketed' ? 'ACK' : 'PASTE_PROTOCOL_ERROR'
+      process.stdout.write('\\u001b]0;Codex Working\\u0007' + message + '\\n')
       setTimeout(() => process.stdout.write('\\u001b]0;Codex Ready\\u0007'), 10)
     })
   }

--- a/tests/e2e/orchestration-legacy-worker-restart-recovery.spec.ts
+++ b/tests/e2e/orchestration-legacy-worker-restart-recovery.spec.ts
@@ -24,7 +24,10 @@ import {
 import { DEFAULT_LOCAL_ORCA_PROFILE_ID } from '../../src/shared/orca-profiles'
 import type { RuntimeTerminalListResult, RuntimeTerminalRead } from '../../src/shared/runtime-types'
 import { listAllOrchestrationRuns } from './orchestration-run-pages'
-import { buildFakeAgentCommandOverride } from './helpers/fake-agent-command-override'
+import {
+  buildFakeAgentCommandOverride,
+  FAKE_AGENT_WINDOWS_SHELL
+} from './helpers/fake-agent-command-override'
 import { FAKE_AGENT_PASTE_END_SCANNER_SOURCE } from './helpers/fake-agent-paste-end-scanner'
 
 const PROVIDER_SESSION_ID = 'e2e-legacy-orchestration-worker'
@@ -101,10 +104,13 @@ process.stdin.on('data', (chunk) => {
   if (input.includes('\\x03')) {
     appendLedger('ORCA_E2E_INTERRUPTION_LEDGER', { event: 'stdin-ctrl-c' })
   }
-  if (!acknowledged && pasteEnded && input.includes('\\r')) {
-    acknowledged = true
-    process.stdout.write('\\u001b]0;Codex Working\\u0007ACK\\n')
-    setTimeout(() => process.stdout.write('\\u001b]0;Codex Ready\\u0007'), 10)
+  if (!acknowledged) {
+    fakeAgentMaybeAck(pasteEnded, input, (mode) => {
+      acknowledged = true
+      const suffix = mode === 'bracketed' ? '' : ' (unbracketed paste)'
+      process.stdout.write('\\u001b]0;Codex Working\\u0007ACK' + suffix + '\\n')
+      setTimeout(() => process.stdout.write('\\u001b]0;Codex Ready\\u0007'), 10)
+    })
   }
   const legacyCompletion = input.match(/ORCA_E2E_RUN_LEGACY_DONE:([A-Za-z0-9+/=]+)/)
   if (!lifecycleSent && legacyCompletion) {
@@ -429,11 +435,15 @@ for (const contractVersion of [LEGACY_CONTRACT_VERSION, CURRENT_CONTRACT_VERSION
       firstApp = first.app
       const worktreeId = await attachRepoAndOpenTerminal(first.page, repoPath)
       await waitForSessionReady(first.page)
-      await first.page.evaluate(async (agentCommand) => {
-        await window.__store?.getState().updateSettings({
-          agentCmdOverrides: { codex: agentCommand }
-        })
-      }, fakeCodexCommand)
+      await first.page.evaluate(
+        async ({ agentCommand, terminalWindowsShell }) => {
+          await window.__store?.getState().updateSettings({
+            agentCmdOverrides: { codex: agentCommand },
+            terminalWindowsShell
+          })
+        },
+        { agentCommand: fakeCodexCommand, terminalWindowsShell: FAKE_AGENT_WINDOWS_SHELL }
+      )
       await ensureTerminalVisible(first.page)
       const coordinatorTabId = await getActiveTabId(first.page)
       expect(coordinatorTabId).toBeTruthy()
@@ -535,7 +545,14 @@ for (const contractVersion of [LEGACY_CONTRACT_VERSION, CURRENT_CONTRACT_VERSION
 
       const transcriptPath = session.seedCodexResumeRollout(PROVIDER_SESSION_ID, repoPath)
       await first.page.evaluate(
-        ({ paneKey, tabId, worktreeId: workerWorktreeId, terminalHandle, transcript }) => {
+        ({
+          agentCommand,
+          paneKey,
+          tabId,
+          worktreeId: workerWorktreeId,
+          terminalHandle,
+          transcript
+        }) => {
           window.__store?.getState().setAgentStatus(
             paneKey,
             { state: 'working', prompt: 'Respond ACK and remain idle', agentType: 'codex' },
@@ -549,7 +566,10 @@ for (const contractVersion of [LEGACY_CONTRACT_VERSION, CURRENT_CONTRACT_VERSION
                 transcriptPath: transcript
               },
               launchConfig: {
-                agentCommand: 'codex',
+                // Why not bare 'codex': resume prefers the captured command over
+                // agentCmdOverrides, so a bare name would resolve the machine's real
+                // Codex off PATH and unpin the adoption leg this spec exercises.
+                agentCommand,
                 agentArgs: '--dangerously-bypass-approvals-and-sandbox',
                 agentEnv: {}
               }
@@ -558,6 +578,7 @@ for (const contractVersion of [LEGACY_CONTRACT_VERSION, CURRENT_CONTRACT_VERSION
           window.__store?.getState().captureAllSleepingAgentSessions('quit')
         },
         {
+          agentCommand: fakeCodexCommand,
           paneKey: workerPaneKey,
           tabId: worker!.tabId,
           worktreeId: worker!.worktreeId,

--- a/tests/e2e/orchestration-worker-settlement-release-cli.spec.ts
+++ b/tests/e2e/orchestration-worker-settlement-release-cli.spec.ts
@@ -8,7 +8,10 @@ import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } fro
 import { RuntimeClient } from '../../src/cli/runtime-client'
 import Database from '../../src/main/sqlite/sync-database'
 import type { RuntimeTerminalListResult, RuntimeTerminalRead } from '../../src/shared/runtime-types'
-import { buildFakeAgentCommandOverride } from './helpers/fake-agent-command-override'
+import {
+  buildFakeAgentCommandOverride,
+  FAKE_AGENT_WINDOWS_SHELL
+} from './helpers/fake-agent-command-override'
 import { FAKE_AGENT_PASTE_END_SCANNER_SOURCE } from './helpers/fake-agent-paste-end-scanner'
 
 const fakeCliDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-settlement-release-'))
@@ -38,10 +41,13 @@ process.stdin.on('data', (chunk) => {
     process.stdout.write('\\x1b[?25h')
   }
   capability ||= input.match(/--dispatch-capability (dcap_[A-Za-z0-9_-]+)/)?.[1] || null
-  if (!acknowledged && pasteEnded && input.includes('\\r')) {
-    acknowledged = true
-    process.stdout.write('\\u001b]0;Codex Working\\u0007ACK\\n')
-    setTimeout(() => process.stdout.write('\\u001b]0;Codex Ready\\u0007'), 10)
+  if (!acknowledged) {
+    fakeAgentMaybeAck(pasteEnded, input, (mode) => {
+      acknowledged = true
+      const suffix = mode === 'bracketed' ? '' : ' (unbracketed paste)'
+      process.stdout.write('\\u001b]0;Codex Working\\u0007ACK' + suffix + '\\n')
+      setTimeout(() => process.stdout.write('\\u001b]0;Codex Ready\\u0007'), 10)
+    })
   }
   const encoded = input.match(/ORCA_E2E_WORKER_DONE:([A-Za-z0-9+/=]+)/)?.[1]
   if (!encoded || !capability) return
@@ -140,11 +146,15 @@ test('compiled CLI rejects false completion then reconciles the dead retained wo
   test.setTimeout(180_000)
   rmSync(cliLedgerPath, { force: true })
   await waitForSessionReady(orcaPage)
-  await orcaPage.evaluate(async (agentCommand) => {
-    await window.__store?.getState().updateSettings({
-      agentCmdOverrides: { codex: agentCommand }
-    })
-  }, fakeCodexCommand)
+  await orcaPage.evaluate(
+    async ({ agentCommand, terminalWindowsShell }) => {
+      await window.__store?.getState().updateSettings({
+        agentCmdOverrides: { codex: agentCommand },
+        terminalWindowsShell
+      })
+    },
+    { agentCommand: fakeCodexCommand, terminalWindowsShell: FAKE_AGENT_WINDOWS_SHELL }
+  )
   const worktreeId = await waitForActiveWorktree(orcaPage)
   await ensureTerminalVisible(orcaPage)
   await waitForActivePanePtyId(orcaPage)

--- a/tests/e2e/orchestration-worker-settlement-release-cli.spec.ts
+++ b/tests/e2e/orchestration-worker-settlement-release-cli.spec.ts
@@ -30,22 +30,20 @@ if (process.argv.slice(2).includes('app-server')) {
 let capability = null
 let acknowledged = false
 ${FAKE_AGENT_PASTE_END_SCANNER_SOURCE}
-let pasteEnded = false
 process.stdout.write('\\u001b]0;Codex Ready\\u0007OpenAI Codex\\nmodel: e2e\\ndirectory: e2e\\n')
 process.stdin.on('data', (chunk) => {
   const input = chunk.toString()
   const pasteEndScan = scanFakeAgentPasteEnd(fakeAgentPasteEndTail, input)
   fakeAgentPasteEndTail = pasteEndScan.tail
-  if (pasteEndScan.ended) {
-    pasteEnded = true
+  if (pasteEndScan.pasteEndOffset !== null) {
     process.stdout.write('\\x1b[?25h')
   }
   capability ||= input.match(/--dispatch-capability (dcap_[A-Za-z0-9_-]+)/)?.[1] || null
   if (!acknowledged) {
-    fakeAgentMaybeAck(pasteEnded, input, (mode) => {
+    fakeAgentMaybeAck(pasteEndScan, input, (mode) => {
       acknowledged = true
-      const suffix = mode === 'bracketed' ? '' : ' (unbracketed paste)'
-      process.stdout.write('\\u001b]0;Codex Working\\u0007ACK' + suffix + '\\n')
+      const message = mode === 'bracketed' ? 'ACK' : 'PASTE_PROTOCOL_ERROR'
+      process.stdout.write('\\u001b]0;Codex Working\\u0007' + message + '\\n')
       setTimeout(() => process.stdout.write('\\u001b]0;Codex Ready\\u0007'), 10)
     })
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​503 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​92 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​411 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​81 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​33 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​48 |

<!-- /orca-pr-loc -->

## Why this matters

After Orca restarts or recovers a background Codex worker, the worker's old
startup banner can still be present in terminal history. Orca was treating that
historical banner as evidence that the worker was ready **right now**.

That could make a worker appear idle while it was still actively working. Any
workflow waiting for the worker to settle could then continue based on the wrong
state instead of waiting for the current task to finish.

## What this branch changes

- Readiness for a recovered worker is determined from its **current visible
  terminal screen**, not its scrollback history.
- A genuinely ready worker still resolves immediately when its ready prompt is
  visible.
- A worker with an active progress screen remains busy even if an old ready
  banner exists above it in history.
- Provider snapshot timeouts stay retired instead of being accidentally
  restarted by a later request, avoiding repeated hangs during recovery.
- A raced or stale terminal handle no longer disables the fallback poll that
  can finish the readiness check.

The user-facing result is that restored background work remains marked busy
until Orca has current evidence that it is actually ready for the next action.

## Why the test changes are part of this PR

The original STA-4907 failures were caused by unreliable test setup rather than
the reported product behavior: some recovery tests could launch the machine's
real Codex instead of their controlled fake process. Reviewing those failures
uncovered the adjacent false-idle product bug described above.

This branch makes those recovery scenarios trustworthy by:

- pinning the fake agent through the resume path;
- quoting its command for PowerShell, cmd, Git Bash, and WSL correctly; and
- turning broken paste delivery into a quick, diagnosable failure instead of a
  multi-minute timeout.

## Validation

- Regression coverage proves that a working visible screen cannot inherit
  readiness from a banner in scrollback.
- Provider mocks assert that every idle probe requests the visible grid only.
- Recovery fixtures cover Windows shell selection and pinned agent resume.
- Focused runtime and E2E helper suites, typecheck, lint, and formatting pass.

Follow-up to #15569. Refs STA-4907 and STA-4885.
