### PR TITLE
fix(sidebar): stop Hide sleeping dropping a remote workspace row on a transient PTY gap

### DIFF
--- a/src/renderer/src/components/sidebar/hide-sleeping-transient-pty-gap.test.ts
+++ b/src/renderer/src/components/sidebar/hide-sleeping-transient-pty-gap.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest'
+import { computeVisibleWorktreeIds } from './visible-worktrees'
+import {
+  createSleepingSweepRetentionState,
+  updateSleepingSweepRetention
+} from './sleeping-sweep-retention'
+import { hasActiveWorkspaceActivity } from '@/lib/worktree-activity-state'
+import { LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
+import type { Repo } from '../../../../shared/repo-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+
+/**
+ * Repro for #15996 — a remote workspace's sidebar row blinks out for one frame
+ * when another workspace is activated.
+ *
+ * A remote pane rebinding its PTY empties `ptyIdsByTabId[tabId]` for a commit.
+ * The workspace's agent finished its turn long ago, so `worktreeIdsWithLiveAgent`
+ * does not hold the row either, and "Hide sleeping" sweeps it out and back in
+ * consecutive renders — the list jumps a full row height and snaps back.
+ */
+
+function makeRepo(id: string): Repo {
+  return { id, path: `/${id}`, displayName: id, badgeColor: '#000', addedAt: 0 }
+}
+
+function makeWorktree(id: string): Worktree {
+  return {
+    id,
+    repoId: 'repo1',
+    path: `/tmp/${id}`,
+    head: 'abc123',
+    branch: `refs/heads/${id}`,
+    isBare: false,
+    isMainWorktree: false,
+    displayName: id,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0
+  }
+}
+
+const REMOTE = 'wt-dragfiles-remote'
+const OTHER = 'wt-resources-remote'
+const worktrees = [makeWorktree(REMOTE), makeWorktree(OTHER)]
+const sortedIds = worktrees.map((w) => w.id)
+const repoMap = new Map<string, Repo>([['repo1', makeRepo('repo1')]])
+
+type VisibleOptions = Parameters<typeof computeVisibleWorktreeIds>[2]
+
+/** Both workspaces hold one open terminal tab; neither has a fresh agent. */
+const tabsByWorktree = {
+  [REMOTE]: [{ id: 'tab-remote' }],
+  [OTHER]: [{ id: 'tab-other' }]
+}
+
+function visibleOptions(overrides: Partial<VisibleOptions> = {}): VisibleOptions {
+  return {
+    filterRepoIds: [],
+    showSleepingWorkspaces: false,
+    tabsByWorktree,
+    ptyIdsByTabId: { 'tab-remote': ['remote:pty-1'], 'tab-other': ['remote:pty-2'] },
+    browserTabsByWorktree: {},
+    worktreeIdsWithLiveAgent: new Set<string>(),
+    hideDefaultBranchWorkspace: false,
+    hideAutomationGeneratedWorkspaces: false,
+    hideCliCreatedWorkspaces: false,
+    hideDetachedHeadWorkspaces: false,
+    hideWorkspacesFromOtherDevices: false,
+    pairedDeviceIdsByEnvironment: new Map(),
+    repoMap,
+    workspaceHostScope: 'all',
+    defaultHostId: LOCAL_EXECUTION_HOST_ID,
+    worktreeLineageById: {},
+    ...overrides
+  }
+}
+
+/** Mirrors what useVisibleSidebarWorktrees does per pass. */
+function sweepPass(
+  state: ReturnType<typeof createSleepingSweepRetentionState>,
+  ptyIdsByTabId: Record<string, string[]>,
+  nowMs: number
+): string[] {
+  const worktreeIdsWithLiveAgent = new Set<string>()
+  const { retainedIds } = updateSleepingSweepRetention({
+    state,
+    candidateWorktreeIds: sortedIds,
+    isActive: (worktreeId) =>
+      hasActiveWorkspaceActivity(
+        worktreeId,
+        tabsByWorktree,
+        ptyIdsByTabId,
+        {},
+        worktreeIdsWithLiveAgent
+      ),
+    nowMs
+  })
+  return computeVisibleWorktreeIds(
+    { repo1: worktrees },
+    sortedIds,
+    visibleOptions({ ptyIdsByTabId, sleepingSweepExemptWorktreeIds: retainedIds })
+  )
+}
+
+describe('#15996 transient PTY gap under "Hide sleeping"', () => {
+  it('keeps the row through a one-commit gap in ptyIdsByTabId', () => {
+    const state = createSleepingSweepRetentionState()
+    const bound = { 'tab-remote': ['remote:pty-1'], 'tab-other': ['remote:pty-2'] }
+    // The rebind commit — clearPtyBinding sets the tab's live PTY list to [].
+    const rebinding = { 'tab-remote': [], 'tab-other': ['remote:pty-2'] }
+
+    expect(sweepPass(state, bound, 1_000)).toEqual([REMOTE, OTHER])
+    expect(sweepPass(state, rebinding, 1_016)).toEqual([REMOTE, OTHER])
+    expect(sweepPass(state, bound, 1_032)).toEqual([REMOTE, OTHER])
+  })
+
+  it('still sweeps the row once the workspace is genuinely asleep', () => {
+    const state = createSleepingSweepRetentionState()
+    const bound = { 'tab-remote': ['remote:pty-1'], 'tab-other': ['remote:pty-2'] }
+    const closed = { 'tab-remote': [], 'tab-other': ['remote:pty-2'] }
+
+    expect(sweepPass(state, bound, 1_000)).toEqual([REMOTE, OTHER])
+    expect(sweepPass(state, closed, 1_100)).toEqual([REMOTE, OTHER])
+    expect(sweepPass(state, closed, 10_000)).toEqual([OTHER])
+  })
+
+  it('does not let a grace window outrank the repo filter', () => {
+    const state = createSleepingSweepRetentionState()
+    const bound = { 'tab-remote': ['remote:pty-1'], 'tab-other': ['remote:pty-2'] }
+    const rebinding = { 'tab-remote': [], 'tab-other': ['remote:pty-2'] }
+
+    sweepPass(state, bound, 1_000)
+    const { retainedIds } = updateSleepingSweepRetention({
+      state,
+      candidateWorktreeIds: sortedIds,
+      isActive: (worktreeId) =>
+        hasActiveWorkspaceActivity(worktreeId, tabsByWorktree, rebinding, {}, new Set()),
+      nowMs: 1_016
+    })
+    expect([...retainedIds]).toEqual([REMOTE])
+
+    const visible = computeVisibleWorktreeIds(
+      { repo1: worktrees },
+      sortedIds,
+      visibleOptions({
+        ptyIdsByTabId: rebinding,
+        sleepingSweepExemptWorktreeIds: retainedIds,
+        filterRepoIds: ['repo-other']
+      })
+    )
+    expect(visible).toEqual([])
+  })
+})

--- a/src/renderer/src/components/sidebar/sleeping-sweep-retention.test.ts
+++ b/src/renderer/src/components/sidebar/sleeping-sweep-retention.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createSleepingSweepRetentionState,
+  SLEEPING_SWEEP_SETTLE_MS,
+  updateSleepingSweepRetention
+} from './sleeping-sweep-retention'
+
+function runPass(
+  state: ReturnType<typeof createSleepingSweepRetentionState>,
+  activeIds: readonly string[],
+  nowMs: number,
+  candidates: readonly string[] = ['wt-a', 'wt-b']
+): ReturnType<typeof updateSleepingSweepRetention> {
+  const active = new Set(activeIds)
+  return updateSleepingSweepRetention({
+    state,
+    candidateWorktreeIds: candidates,
+    isActive: (id) => active.has(id),
+    nowMs
+  })
+}
+
+describe('sleeping sweep retention', () => {
+  it('retains a workspace whose liveness drops for a single pass', () => {
+    const state = createSleepingSweepRetentionState()
+    runPass(state, ['wt-a', 'wt-b'], 1_000)
+
+    // The PTY rebind commit: wt-a reads inactive for one pass.
+    const dropped = runPass(state, ['wt-b'], 1_016)
+    expect([...dropped.retainedIds]).toEqual(['wt-a'])
+
+    // Rebind settles; the grace window closes with no visible change.
+    const recovered = runPass(state, ['wt-a', 'wt-b'], 1_032)
+    expect([...recovered.retainedIds]).toEqual([])
+    expect(recovered.nextExpiryInMs).toBeNull()
+  })
+
+  it('sweeps once the workspace stays inactive past the settle window', () => {
+    const state = createSleepingSweepRetentionState()
+    runPass(state, ['wt-a'], 1_000)
+
+    // The grace clock starts when the workspace first reads inactive, not when
+    // it was last active — a quiet gap between passes must not eat the window.
+    const during = runPass(state, [], 1_000)
+    expect([...during.retainedIds]).toEqual(['wt-a'])
+    expect(during.nextExpiryInMs).toBe(SLEEPING_SWEEP_SETTLE_MS)
+
+    const after = runPass(state, [], 1_000 + SLEEPING_SWEEP_SETTLE_MS)
+    expect([...after.retainedIds]).toEqual([])
+    expect(after.nextExpiryInMs).toBeNull()
+  })
+
+  it('grants no grace to a workspace that was already asleep when first seen', () => {
+    const state = createSleepingSweepRetentionState()
+    const first = runPass(state, [], 1_000)
+    expect([...first.retainedIds]).toEqual([])
+    expect(first.nextExpiryInMs).toBeNull()
+  })
+
+  it('is idempotent across a double-invoked render at the same instant', () => {
+    const state = createSleepingSweepRetentionState()
+    runPass(state, ['wt-a'], 1_000)
+    runPass(state, [], 2_000)
+    const second = runPass(state, [], 2_000)
+
+    expect([...second.retainedIds]).toEqual(['wt-a'])
+    expect(second.nextExpiryInMs).toBe(SLEEPING_SWEEP_SETTLE_MS)
+  })
+
+  it('reports the soonest expiry when several windows are open', () => {
+    const state = createSleepingSweepRetentionState()
+    runPass(state, ['wt-a', 'wt-b'], 1_000)
+    runPass(state, ['wt-b'], 1_100)
+    const result = runPass(state, [], 1_200)
+
+    expect([...result.retainedIds].sort()).toEqual(['wt-a', 'wt-b'])
+    expect(result.nextExpiryInMs).toBe(SLEEPING_SWEEP_SETTLE_MS - 100)
+  })
+
+  it('drops grace state for a workspace that leaves the candidate set', () => {
+    const state = createSleepingSweepRetentionState()
+    runPass(state, ['wt-a'], 1_000)
+    // wt-a is deleted; a later id reuse must not inherit its grace window.
+    runPass(state, [], 1_100, ['wt-b'])
+    const reused = runPass(state, [], 1_200, ['wt-a', 'wt-b'])
+
+    expect([...reused.retainedIds]).toEqual([])
+  })
+})

--- a/src/renderer/src/components/sidebar/sleeping-sweep-retention.ts
+++ b/src/renderer/src/components/sidebar/sleeping-sweep-retention.ts
@@ -1,0 +1,105 @@
+/**
+ * Removal hysteresis for the "Hide sleeping" sidebar sweep (#15996).
+ *
+ * Why: the sweep's liveness inputs are volatile. `ptyIdsByTabId` is emptied and
+ * refilled whenever a pane rebinds its PTY — an SSH reconnect, a remote-runtime
+ * pane re-attaching after a workspace switch — and `worktreeIdsWithLiveAgent`
+ * only holds a row while its agent status is fresh and non-done. A workspace
+ * with an open-but-idle session therefore hangs on `ptyIdsByTabId` alone, and a
+ * single-commit gap in that map sweeps the row out and back in one frame: the
+ * list jumps by a full row height and snaps back.
+ *
+ * Why hysteresis and not an in-flight flag: direct-SSH panes expose one
+ * (`directSshPaneRetryByTabId`), but remote-runtime panes keep their recovery
+ * state in `RemoteRuntimePtyRecoveryState`, outside the store, so no sidebar
+ * selector can see it. Delaying *removal* covers every rebind path without
+ * needing the producer to advertise itself.
+ *
+ * Only removal is delayed. Appearing stays immediate, and a workspace that was
+ * already asleep when the sidebar first saw it is swept with no grace at all,
+ * so this never resurrects a row that should have been hidden from the start.
+ */
+
+/**
+ * Why 1.5s: long enough to cover a remote pane rebinding its PTY over a slow
+ * link, short enough that genuinely closing a workspace's last session still
+ * reads as immediate. The cost of overshooting is a row that lingers a beat;
+ * the cost of undershooting is the jitter this exists to stop.
+ */
+export const SLEEPING_SWEEP_SETTLE_MS = 1_500
+
+export type SleepingSweepRetentionState = {
+  /** Workspaces observed active at least once; only these earn a grace window. */
+  seenActiveIds: Set<string>
+  /** worktreeId → epoch ms it first read inactive after having been active. */
+  inactiveSinceById: Map<string, number>
+}
+
+export function createSleepingSweepRetentionState(): SleepingSweepRetentionState {
+  return { seenActiveIds: new Set(), inactiveSinceById: new Map() }
+}
+
+export type SleepingSweepRetentionResult = {
+  /** Ids to exempt from this pass's sweep. */
+  retainedIds: ReadonlySet<string>
+  /** ms until the soonest grace window expires, or null when none is open. */
+  nextExpiryInMs: number | null
+}
+
+const EMPTY_RETAINED_IDS: ReadonlySet<string> = new Set()
+
+/**
+ * Advance the grace bookkeeping one pass and report which workspaces the sweep
+ * must skip. Mutates `state`, but is idempotent for a given (nowMs, isActive)
+ * pair so a double-invoked render cannot double-count a grace window.
+ */
+export function updateSleepingSweepRetention(args: {
+  state: SleepingSweepRetentionState
+  candidateWorktreeIds: readonly string[]
+  isActive: (worktreeId: string) => boolean
+  nowMs: number
+  settleMs?: number
+}): SleepingSweepRetentionResult {
+  const { state, candidateWorktreeIds, isActive, nowMs } = args
+  const settleMs = args.settleMs ?? SLEEPING_SWEEP_SETTLE_MS
+  const candidates = new Set(candidateWorktreeIds)
+
+  // Why prune first: ids that left worktreesByRepo (deleted, archived, repo
+  // removed) must not keep a grace window alive against a future id reuse.
+  for (const id of state.seenActiveIds) {
+    if (!candidates.has(id)) {
+      state.seenActiveIds.delete(id)
+      state.inactiveSinceById.delete(id)
+    }
+  }
+
+  let retainedIds: Set<string> | null = null
+  let nextExpiryInMs: number | null = null
+
+  for (const worktreeId of candidates) {
+    if (isActive(worktreeId)) {
+      state.seenActiveIds.add(worktreeId)
+      state.inactiveSinceById.delete(worktreeId)
+      continue
+    }
+    if (!state.seenActiveIds.has(worktreeId)) {
+      continue
+    }
+    let inactiveSince = state.inactiveSinceById.get(worktreeId)
+    if (inactiveSince === undefined) {
+      inactiveSince = nowMs
+      state.inactiveSinceById.set(worktreeId, inactiveSince)
+    }
+    const remainingMs = settleMs - (nowMs - inactiveSince)
+    if (remainingMs <= 0) {
+      state.seenActiveIds.delete(worktreeId)
+      state.inactiveSinceById.delete(worktreeId)
+      continue
+    }
+    retainedIds ??= new Set()
+    retainedIds.add(worktreeId)
+    nextExpiryInMs = nextExpiryInMs === null ? remainingMs : Math.min(nextExpiryInMs, remainingMs)
+  }
+
+  return { retainedIds: retainedIds ?? EMPTY_RETAINED_IDS, nextExpiryInMs }
+}

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -82,6 +82,12 @@ type VisibleWorktreeOptions = {
   worktreeLineageById: Record<string, WorktreeLineage>
   injectLineageAncestors?: boolean
   forcedVisibleWorktreeIds?: readonly string[]
+  /**
+   * Scoped exemption from the sleeping sweep only — unlike
+   * forcedVisibleWorktreeIds these still answer to the repo, host and kind
+   * filters, so a grace window can never resurrect a row the user filtered out.
+   */
+  sleepingSweepExemptWorktreeIds?: ReadonlySet<string>
 }
 
 export function computeVisibleWorktrees(
@@ -147,6 +153,7 @@ export function computeVisibleWorktrees(
     all = all.filter(
       (w) =>
         isSleepingSweepExemptWorkspace(w, opts.alwaysShowDefaultBranchWorkspace) ||
+        opts.sleepingSweepExemptWorktreeIds?.has(w.id) === true ||
         !isInactiveWorkspace(
           w.id,
           opts.tabsByWorktree,

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-visible-worktrees.ts
@@ -1,11 +1,18 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useAppStore } from '@/store'
-import { getWorktreeIdsWithLiveAgent } from '@/lib/worktree-activity-state'
+import {
+  getWorktreeIdsWithLiveAgent,
+  hasActiveWorkspaceActivity
+} from '@/lib/worktree-activity-state'
 import type { AppState } from '@/store/types'
 import type { Repo } from '../../../../../../shared/repo-types'
 import type { WorktreeLineage } from '../../../../../../shared/worktree/lineage-types'
 import { getSettingsFocusedExecutionHostId } from '../../../../../../shared/execution-host'
 import { computeVisibleWorktrees } from '../../visible-worktrees'
+import {
+  createSleepingSweepRetentionState,
+  updateSleepingSweepRetention
+} from '../../sleeping-sweep-retention'
 import {
   EMPTY_PAIRED_DEVICE_IDS_BY_ENVIRONMENT,
   getPairedDeviceIdsByEnvironment
@@ -66,22 +73,77 @@ export function useVisibleSidebarWorktrees(args: {
     !showSleepingWorkspaces ? getVisibleWorktreeBrowserActivityTabs(s.browserTabsByWorktree) : null
   )
 
-  const recomputedVisibleWorktrees = useMemo(() => {
+  const retentionStateRef = useRef(createSleepingSweepRetentionState())
+  const [sweepGraceTick, setSweepGraceTick] = useState(0)
+
+  // Why snapshot on agentStatusEpoch: update membership immediately without repainting on every hook ping.
+  const sweepInputs = useMemo(() => {
     void agentStatusEpoch
+    void sweepGraceTick
+    if (showSleepingWorkspaces) {
+      retentionStateRef.current = createSleepingSweepRetentionState()
+      return {
+        worktreeIdsWithLiveAgent: EMPTY_WORKTREE_ID_SET,
+        sleepingSweepExemptWorktreeIds: undefined,
+        nextExpiryInMs: null
+      }
+    }
+    const nowMs = Date.now()
+    const worktreeIdsWithLiveAgent = getWorktreeIdsWithLiveAgent(
+      useAppStore.getState().agentStatusByPaneKey,
+      tabsByWorktree,
+      nowMs
+    )
+    // Why: a PTY rebind empties ptyIdsByTabId for a commit, which would sweep an
+    // open remote workspace out and back in one frame (#15996).
+    const { retainedIds, nextExpiryInMs } = updateSleepingSweepRetention({
+      state: retentionStateRef.current,
+      candidateWorktreeIds: sortedIds,
+      isActive: (worktreeId) =>
+        hasActiveWorkspaceActivity(
+          worktreeId,
+          tabsByWorktree,
+          ptyIdsByTabId,
+          browserTabsByWorktree,
+          worktreeIdsWithLiveAgent
+        ),
+      nowMs
+    })
+    return {
+      worktreeIdsWithLiveAgent,
+      sleepingSweepExemptWorktreeIds: retainedIds,
+      nextExpiryInMs
+    }
+  }, [
+    agentStatusEpoch,
+    sweepGraceTick,
+    showSleepingWorkspaces,
+    tabsByWorktree,
+    ptyIdsByTabId,
+    browserTabsByWorktree,
+    sortedIds
+  ])
+
+  // Why: without a wake the last grace window would hold its row until some
+  // unrelated store change happened to recompute the sweep.
+  const { nextExpiryInMs } = sweepInputs
+  useEffect(() => {
+    if (nextExpiryInMs === null) {
+      return
+    }
+    const timer = setTimeout(() => setSweepGraceTick((tick) => tick + 1), nextExpiryInMs)
+    return () => clearTimeout(timer)
+  }, [nextExpiryInMs])
+
+  const recomputedVisibleWorktrees = useMemo(() => {
     return computeVisibleWorktrees(worktreesByRepo, sortedIds, {
       filterRepoIds,
       showSleepingWorkspaces,
       tabsByWorktree,
       ptyIdsByTabId,
       browserTabsByWorktree,
-      // Why snapshot on agentStatusEpoch: update membership immediately without repainting on every hook ping.
-      worktreeIdsWithLiveAgent: showSleepingWorkspaces
-        ? EMPTY_WORKTREE_ID_SET
-        : getWorktreeIdsWithLiveAgent(
-            useAppStore.getState().agentStatusByPaneKey,
-            tabsByWorktree,
-            Date.now()
-          ),
+      worktreeIdsWithLiveAgent: sweepInputs.worktreeIdsWithLiveAgent,
+      sleepingSweepExemptWorktreeIds: sweepInputs.sleepingSweepExemptWorktreeIds,
       hideDefaultBranchWorkspace,
       hideAutomationGeneratedWorkspaces,
       hideCliCreatedWorkspaces,
@@ -100,7 +162,7 @@ export function useVisibleSidebarWorktrees(args: {
     })
   }, [
     args.agentSendTargetWorktreeId,
-    agentStatusEpoch,
+    sweepInputs,
     filterRepoIds,
     showSleepingWorkspaces,
     hideDefaultBranchWorkspace,


### PR DESCRIPTION
Fixes #15996.

## What this changes

With **Hide sleeping workspaces** on, a remote workspace's sidebar row could vanish for a single frame when a *different* workspace was activated. Every row below it — including the next project group header — jumped up by one row height and snapped back. The reporter measured it frame by frame on a 30 fps capture: seven workspace rows on every frame except one, where the row count read six and the `msn-studio` header moved 750 px → 659 px → 750 px.

After this change the row stays put.

## Why it happened

The hide-sleeping sweep is the only sidebar membership filter that reads volatile runtime state; every other filter is static configuration. It keeps a row visible when `hasActiveWorkspaceActivity` holds, which needs one of a live PTY (`tabHasLivePty(ptyIdsByTabId, tab.id)`), an open browser tab, or an agent whose status is *fresh and non-done*.

A workspace with an open-but-idle session satisfies none of those except the first, so it hangs on `ptyIdsByTabId` alone. That map is emptied and refilled whenever a pane rebinds its PTY, and a single commit where the entry is empty is enough to sweep the row out and back.

`worktree-activity-state.ts` already anticipates this class of gap:

```
// Why: a running agent keeps the workspace visible through brief PTY gaps
// such as an SSH reconnect or an unmounted remote pane. #7197
```

…but that mitigation only covers workspaces whose agent is *currently* working. An idle session falls through.

## Approach

Removal hysteresis, not an in-flight flag.

Direct-SSH panes do expose an in-flight signal (`directSshPaneRetryByTabId`), but remote-runtime panes keep their recovery state in `RemoteRuntimePtyRecoveryState`, a class held outside the zustand store, so no sidebar selector can observe a rebind in progress. Since the reported case is a runtime host rather than direct SSH, keying on a flag would not have covered it. Delaying *removal* covers every rebind path without requiring the producer to advertise itself.

- `sidebar/sleeping-sweep-retention.ts` — a pure state machine. A workspace that was observed active and now reads inactive gets a `SLEEPING_SWEEP_SETTLE_MS` (1.5 s) grace window; a workspace that was already asleep when the sidebar first saw it gets none, so this never resurrects a row that should have been hidden from the start. It reports the soonest expiry so the caller can wake.
- `visible-worktrees.ts` — new `sleepingSweepExemptWorktreeIds` option, applied **only** inside the `!showSleepingWorkspaces` block. Deliberately not folded into the existing `forcedVisibleWorktreeIds`, which bypasses the repo, host and kind filters as well — a grace window must never outrank a filter the user set. Pinned by a test.
- `worktree-list/listing/use-visible-worktrees.ts` — derives the retained set from the same `hasActiveWorkspaceActivity` predicate the sweep uses, so there is no second copy of the liveness logic to drift. A timer wakes the sweep at expiry; without it the final grace window would hold its row until some unrelated store change happened to recompute.

Only removal is delayed. A workspace appearing is still immediate.

## Trade-off

Closing a workspace's last session now leaves its row visible for up to 1.5 s before it sweeps. That direction was chosen deliberately: overshooting costs a row that lingers a beat, undershooting reproduces the jitter this fixes. It is a single exported constant if it wants tuning.

## Tests

- `sleeping-sweep-retention.test.ts` — the state machine: single-pass drop is retained; a sustained drop sweeps at the deadline; a workspace asleep on first sight gets no grace; the update is idempotent across a double-invoked render; the soonest of several open windows is reported; grace state is dropped when a workspace leaves the candidate set.
- `hide-sleeping-transient-pty-gap.test.ts` — the issue's scenario end to end through `computeVisibleWorktrees`: the row survives a one-commit gap in `ptyIdsByTabId`, still sweeps once the workspace is genuinely asleep, and a grace window does not survive the repo filter.

Both new tests were confirmed to fail against the unpatched sweep before being committed.

`pnpm lint`, `pnpm typecheck`, `pnpm test` and `pnpm build` all pass.

## Agent review notes

- **Cross-platform** — renderer-only, no platform branches, no path or shell handling. No `metaKey`/`ctrlKey` or accelerator surface is touched.
- **SSH / remote** — this is the remote-facing half of the change. The bug is only reachable when a pane rebinds its PTY, which in practice means SSH reconnects and remote-runtime pane re-attach; the fix is host-agnostic and does not read or assume a host type. Nothing here reports on, stops or lists remote work, so the `live` / `unverifiable` / `exited` verdict vocabulary is not involved: an empty `ptyIdsByTabId` entry is explicitly *not* treated as evidence the session died — that is precisely the misreading being corrected.
- **Folder workspaces** — the sweep operates on worktree ids without assuming a git worktree; folder workspaces flow through the same path and the existing `isSleepingSweepExemptWorkspace` entry-point exemption is untouched.
- **Wire compatibility** — no RPC params, stream frames or published content change. Renderer-local state only, so a mixed client/host pair is unaffected.
- **Git compatibility** — no Git commands added or changed.
- **Git provider** — no provider-specific code; nothing GitHub-shaped.
- **Agent / integration compat** — the `forcedVisibleWorktreeIds` path used by the agent send target is untouched and composes with the new option rather than replacing it.
- **Performance** — one `Set` and one `Map` keyed by worktree id, both pruned to the candidate set each pass, so memory is bounded by workspace count. The retention pass is O(workspaces) and runs inside the memo that already recomputes on the same inputs. The wake timer is at most one outstanding `setTimeout`, cleared on change and on unmount, and it stops arming as soon as no grace window is open.
- **UI quality** — the user-visible effect is the *absence* of a one-frame reflow, which a static screenshot cannot show and which does not reproduce on demand; it is covered by unit tests instead. No markup, layout, token or styling change, so `docs/STYLEGUIDE.md` has no bearing here.
- **Security** — no new inputs, IPC surface, persistence or external calls.

## Follow-up

#15999 tracks the producer side — identifying which commit empties `ptyIdsByTabId` for a remote pane mid-session. This PR makes the sidebar robust to it; it does not explain it.
