### PR TITLE
fix(test): make the stale terminal artifact grant assertion deterministic

### DIFF
--- a/src/main/runtime/orca-runtime-files-terminal-artifact-io.test.ts
+++ b/src/main/runtime/orca-runtime-files-terminal-artifact-io.test.ts
@@ -341,7 +341,12 @@ describe('RuntimeFileCommands', () => {
       const target = absoluteFileTarget(result)
 
       await rm(artifactPath)
-      await writeFile(artifactPath, 'changed!')
+      // Why: the replacement must differ in SIZE, not just content. Freshness is
+      // decided by dev:ino:nlink:size:mtimeMs, and a delete-and-recreate reuses the
+      // inode while coarse filesystem timestamps often land in the same tick — so a
+      // same-length rewrite is observationally identical to the original and slips
+      // through. See #16002 for the underlying gap.
+      await writeFile(artifactPath, 'changed to a longer body!')
 
       await expect(
         commands.readTerminalArtifactPreview(


### PR DESCRIPTION
## Summary

`orca-runtime-files-terminal-artifact-io.test.ts > rejects stale absolute terminal artifact previews before returning changed content` fails intermittently — **4 of 6 runs** on a clean tree at `5651662494`, with no local changes.

```
AssertionError: promise resolved "{ content: 'Y2hhbmdlZCE=', …(3) }" instead of rejecting
```

Fixes #16002.

## Why it was flaky

Grant freshness is decided by `terminalFileStatIdentity()`, which builds `dev:ino:nlink:size:mtimeMs`. The test wrote `'fake-png'` and replaced it with `'changed!'` — **both exactly 8 bytes** — so `size` could never change and the timestamp was the only component left to move.

A 40-iteration probe of the underlying filesystem behaviour:

| component | identical after delete + recreate |
| --- | --- |
| `ino` (inode reused) | 40/40 |
| `size` | 40/40 (both 8 bytes) |
| `mtimeMs` | 28/40 |
| **whole identity** | **28/40** |

Whenever the rewrite landed inside the same millisecond every component matched, the replacement was invisible to the check, and the read resolved instead of rejecting. The test passed only when it happened to straddle a millisecond boundary.

Every sibling test in the same file replaces `'{"ok":true}'` (11 bytes) with `'{"ok":false}'` or `'{"ok":"ext"}'` (12 bytes). The size change is what makes them deterministic; this was the only test that picked two equal-length strings.

## The fix

Give the replacement a different size, matching what the rest of the file already does, and record at the call site *why* the size has to differ — so the next person does not shorten it back.

Before: 2 passes in 6 runs. After: **10 passes in 10 runs.**

## What this deliberately does not fix

Because the inode is reused and the timestamps are coarse, a delete-and-replace with same-size content inside one timestamp tick is *observationally identical* to the original file. No stat-based identity can distinguish it — nanosecond timestamps do not help either (`mtimeNs` is identical 38/40 on the same filesystem, as tmpfs stores coarse-grained times).

Closing that properly needs either holding the file handle open from grant time or recording a content hash at grant time, both of which have real cost and are design calls for maintainers. #16002 reports the gap; this PR only stops the test lying about it, and the new comment keeps the limit visible rather than silently papered over.

## AI agent review summary

- **Cross-platform:** the fix removes a filesystem-timing dependency rather than adding one. The old assertion was hostage to inode reuse and timestamp granularity, which vary by platform and filesystem; a size change is observable everywhere.
- **SSH / remote:** none. Test-only change; the SSH artifact path (`ssh-filesystem-terminal-artifact.ts`) is untouched.
- **Remote wire compatibility:** no wire surface touched.
- **Agent / integration compat:** no product code changed, so no behaviour change for any client.
- **Performance:** none.
- **UI quality:** not applicable.
- **Security:** no weakening. The assertion still requires the stale grant to be rejected; it just exercises it through a change the mechanism can actually detect. The undetectable case is documented rather than quietly dropped.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 57,013 passed
- [x] `pnpm build`
- [x] Target file run 10× consecutively: 21/21 passing every time (was 2/6 before)
