### PR TITLE
refactor(wsl): delete the environment-policy layer the reviews kept failing on

### DIFF
--- a/src/main/agent-hooks/wsl-hook-relay-launch.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-launch.ts
@@ -181,14 +181,10 @@ export async function runWslInstallProcess(
 ): Promise<{ code: number | null; stderr: string }> {
   const result = await runWslProcess({
     distro,
-    lane: 'probe',
+    loginPath: 'none',
     script,
     timeoutMs: INSTALL_TIMEOUT_MS,
     maxOutputBytes: MAX_STARTUP_BUFFER_BYTES,
-    // The install script only shells out to base64/mkdir/mv/chmod, all on any
-    // default PATH -- it must still run when the login-PATH probe itself is
-    // what's wedged, which is exactly the state this call recovers from.
-    allowDegradedEnvironment: true
   })
   return result.timedOut
     ? { code: null, stderr: `${result.stderr}\ninstall timed out after ${INSTALL_TIMEOUT_MS}ms` }

--- a/src/main/agent-hooks/wsl-hook-relay-launch.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-launch.ts
@@ -183,6 +183,9 @@ export async function runWslInstallProcess(
     distro,
     loginPath: 'none',
     script,
+    // The script embeds a base64 JS bundle, far past any command-line limit,
+    // and reads no stdin of its own.
+    scriptDelivery: 'stdin',
     timeoutMs: INSTALL_TIMEOUT_MS,
     maxOutputBytes: MAX_STARTUP_BUFFER_BYTES,
   })

--- a/src/main/agent-hooks/wsl-hook-relay-launch.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-launch.ts
@@ -188,6 +188,9 @@ export async function runWslInstallProcess(
     scriptDelivery: 'stdin',
     timeoutMs: INSTALL_TIMEOUT_MS,
     maxOutputBytes: MAX_STARTUP_BUFFER_BYTES,
+    // The operative error ("mv: Read-only file system") lands after whatever
+    // apt and base64 already printed, so head-truncation surfaces the noise.
+    retainOutput: 'tail',
   })
   return result.timedOut
     ? { code: null, stderr: `${result.stderr}\ninstall timed out after ${INSTALL_TIMEOUT_MS}ms` }

--- a/src/main/agent-hooks/wsl-hook-relay-launch.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-launch.ts
@@ -183,20 +183,18 @@ export async function runWslInstallProcess(
     distro,
     loginPath: 'none',
     script,
-    // The script embeds a base64 JS bundle, far past any command-line limit,
-    // and reads no stdin of its own.
-    scriptDelivery: 'stdin',
     // Declared because the payload is opaque here: it is POSIX plus a heredoc.
     shell: 'sh',
-    timeoutMs: INSTALL_TIMEOUT_MS,
-    maxOutputBytes: MAX_STARTUP_BUFFER_BYTES,
-    // The operative error ("mv: Read-only file system") lands after whatever
-    // apt and base64 already printed, so head-truncation surfaces the noise.
-    retainOutput: 'tail'
+    timeoutMs: INSTALL_TIMEOUT_MS
+    // No maxOutputBytes: the default cap holds the whole stream so the slice
+    // below can take the end of it.
   })
+  // Tail, not head: the operative error ("mv: Read-only file system") lands
+  // after whatever apt and base64 already printed.
+  const stderr = result.stderr.slice(-MAX_STARTUP_BUFFER_BYTES)
   return result.timedOut
-    ? { code: null, stderr: `${result.stderr}\ninstall timed out after ${INSTALL_TIMEOUT_MS}ms` }
-    : { code: result.code, stderr: result.stderr }
+    ? { code: null, stderr: `${stderr}\ninstall timed out after ${INSTALL_TIMEOUT_MS}ms` }
+    : { code: result.code, stderr }
 }
 
 const TRANSIENT_RETRY_LIMIT = 2

--- a/src/main/agent-hooks/wsl-hook-relay-launch.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-launch.ts
@@ -186,6 +186,8 @@ export async function runWslInstallProcess(
     // The script embeds a base64 JS bundle, far past any command-line limit,
     // and reads no stdin of its own.
     scriptDelivery: 'stdin',
+    // Declared because the payload is opaque here: it is POSIX plus a heredoc.
+    shell: 'sh',
     timeoutMs: INSTALL_TIMEOUT_MS,
     maxOutputBytes: MAX_STARTUP_BUFFER_BYTES,
     // The operative error ("mv: Read-only file system") lands after whatever

--- a/src/main/agent-hooks/wsl-hook-relay-launch.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-launch.ts
@@ -192,7 +192,7 @@ export async function runWslInstallProcess(
     maxOutputBytes: MAX_STARTUP_BUFFER_BYTES,
     // The operative error ("mv: Read-only file system") lands after whatever
     // apt and base64 already printed, so head-truncation surfaces the noise.
-    retainOutput: 'tail',
+    retainOutput: 'tail'
   })
   return result.timedOut
     ? { code: null, stderr: `${result.stderr}\ninstall timed out after ${INSTALL_TIMEOUT_MS}ms` }

--- a/src/main/claude-accounts/runtime-auth-service.ts
+++ b/src/main/claude-accounts/runtime-auth-service.ts
@@ -1088,7 +1088,7 @@ export class ClaudeRuntimeAuthService {
         try {
           const owned = await runWslProcess({
             distro: wslInfo.distro,
-            lane: 'probe',
+            loginPath: 'none',
             shell: 'bash',
             script: [
               'set -euo pipefail',
@@ -1101,11 +1101,6 @@ export class ClaudeRuntimeAuthService {
               'case "$candidate_real" in "$managed_root_real"/*/auth) printf "%s\\n" "$candidate_real" ;; *) exit 35 ;; esac'
             ].join('\n'),
             timeoutMs: 5000,
-            // Why degraded is allowed: a failed answer here disowns the account and
-            // clears the user's selection, so a slow distro probe must not decide
-            // ownership. The script reads only $HOME and coreutils, both of which
-            // wsl.exe supplies without the login PATH.
-            allowDegradedEnvironment: true
           })
           if (owned.timedOut) {
             throw new Error(OWNERSHIP_PROBE_TIMEOUT)

--- a/src/main/claude-accounts/runtime-auth-service.ts
+++ b/src/main/claude-accounts/runtime-auth-service.ts
@@ -1100,7 +1100,7 @@ export class ClaudeRuntimeAuthService {
               `test "$(cat "$candidate_real/.orca-managed-claude-auth")" = ${shellQuote(account.id)}`,
               'case "$candidate_real" in "$managed_root_real"/*/auth) printf "%s\\n" "$candidate_real" ;; *) exit 35 ;; esac'
             ].join('\n'),
-            timeoutMs: 5000,
+            timeoutMs: 5000
           })
           if (owned.timedOut) {
             throw new Error(OWNERSHIP_PROBE_TIMEOUT)

--- a/src/main/claude-accounts/service.ts
+++ b/src/main/claude-accounts/service.ts
@@ -667,7 +667,7 @@ export class ClaudeAccountService {
       loginPath: 'none',
       shell: 'bash',
       script: 'mktemp -d "${TMPDIR:-/tmp}/orca-claude-login.XXXXXX"',
-      timeoutMs: 5000,
+      timeoutMs: 5000
     })
     const linuxPath = created.stdout.replaceAll(String.fromCharCode(0), '').trim()
     if (created.code !== 0 || created.timedOut || !linuxPath.startsWith('/')) {
@@ -692,7 +692,7 @@ export class ClaudeAccountService {
           loginPath: 'none',
           program: 'rm',
           args: ['-rf', '--', tempConfig.linuxPath],
-          timeoutMs: 5000,
+          timeoutMs: 5000
         })
       } catch {
         // Best-effort cleanup.
@@ -907,7 +907,7 @@ export class ClaudeAccountService {
       loginPath: 'none',
       shell: 'bash',
       script: 'printf "%s\\n%s\\n" "$WSL_DISTRO_NAME" "$HOME"',
-      timeoutMs: 5000,
+      timeoutMs: 5000
     })
     const [rawDistro, rawHome] =
       info.code === 0 && !info.timedOut
@@ -929,7 +929,7 @@ export class ClaudeAccountService {
       shell: 'bash',
       script: 'mkdir -p "$1" && printf \'%s\\n\' "$2" > "$1/.orca-managed-claude-auth"',
       args: [wslLinuxAuthPath, accountId],
-      timeoutMs: 5000,
+      timeoutMs: 5000
     })
     if (created.code !== 0 || created.timedOut) {
       throw new Error('Could not create the managed WSL Claude auth directory.')
@@ -980,7 +980,7 @@ export class ClaudeAccountService {
                 : 'test -n "$(cat "$candidate_real/.orca-managed-claude-auth")"',
               'case "$candidate_real" in "$managed_root_real"/*/auth) printf "%s\\n" "$candidate_real" ;; *) exit 35 ;; esac'
             ].join('\n'),
-            timeoutMs: 5000,
+            timeoutMs: 5000
           })
           if (owned.code !== 0 || owned.timedOut) {
             throw new Error('Managed Claude auth directory does not exist on disk.')

--- a/src/main/claude-accounts/service.ts
+++ b/src/main/claude-accounts/service.ts
@@ -664,13 +664,10 @@ export class ClaudeAccountService {
     }
     const created = await runWslProcess({
       distro: location.wslDistro,
-      lane: 'probe',
+      loginPath: 'none',
       shell: 'bash',
       script: 'mktemp -d "${TMPDIR:-/tmp}/orca-claude-login.XXXXXX"',
       timeoutMs: 5000,
-      // Why degraded is allowed: mktemp is a coreutil on the default PATH, so an
-      // unprobed distro must not turn a working sign-in into a failed one.
-      allowDegradedEnvironment: true
     })
     const linuxPath = created.stdout.replaceAll(String.fromCharCode(0), '').trim()
     if (created.code !== 0 || created.timedOut || !linuxPath.startsWith('/')) {
@@ -692,13 +689,10 @@ export class ClaudeAccountService {
       try {
         await runWslProcess({
           distro: tempConfig.wslDistro,
-          lane: 'probe',
+          loginPath: 'none',
           program: 'rm',
           args: ['-rf', '--', tempConfig.linuxPath],
           timeoutMs: 5000,
-          // Why degraded is allowed: leaving a login temp dir behind is worse than
-          // running rm on the default PATH, and this is already best-effort.
-          allowDegradedEnvironment: true
         })
       } catch {
         // Best-effort cleanup.
@@ -910,13 +904,10 @@ export class ClaudeAccountService {
     const requestedDistro = target.wslDistro?.trim() || undefined
     const info = await runWslProcess({
       distro: requestedDistro,
-      lane: 'probe',
+      loginPath: 'none',
       shell: 'bash',
       script: 'printf "%s\\n%s\\n" "$WSL_DISTRO_NAME" "$HOME"',
       timeoutMs: 5000,
-      // Why degraded is allowed: both variables come from wsl.exe itself, not from
-      // the login PATH, so an unprobed distro still answers correctly here.
-      allowDegradedEnvironment: true
     })
     const [rawDistro, rawHome] =
       info.code === 0 && !info.timedOut
@@ -934,14 +925,11 @@ export class ClaudeAccountService {
     const wslLinuxAuthPath = `${home.replace(/\/$/, '')}/.local/share/orca/claude-accounts/${accountId}/auth`
     const created = await runWslProcess({
       distro,
-      lane: 'probe',
+      loginPath: 'none',
       shell: 'bash',
       script: 'mkdir -p "$1" && printf \'%s\\n\' "$2" > "$1/.orca-managed-claude-auth"',
       args: [wslLinuxAuthPath, accountId],
       timeoutMs: 5000,
-      // Why degraded is allowed: mkdir is a coreutil on the default PATH, and the
-      // target path was already resolved from the guest's own $HOME above.
-      allowDegradedEnvironment: true
     })
     if (created.code !== 0 || created.timedOut) {
       throw new Error('Could not create the managed WSL Claude auth directory.')
@@ -978,7 +966,7 @@ export class ClaudeAccountService {
         try {
           const owned = await runWslProcess({
             distro: wslInfo.distro,
-            lane: 'probe',
+            loginPath: 'none',
             shell: 'bash',
             script: [
               'set -euo pipefail',
@@ -993,10 +981,6 @@ export class ClaudeAccountService {
               'case "$candidate_real" in "$managed_root_real"/*/auth) printf "%s\\n" "$candidate_real" ;; *) exit 35 ;; esac'
             ].join('\n'),
             timeoutMs: 5000,
-            // Why degraded is allowed: the ownership proof is the script's own
-            // marker and containment checks, not the login PATH, and refusing here
-            // would fail every managed read/write on a distro Orca could not probe.
-            allowDegradedEnvironment: true
           })
           if (owned.code !== 0 || owned.timedOut) {
             throw new Error('Managed Claude auth directory does not exist on disk.')

--- a/src/main/cli/wsl-cli-installer.test.ts
+++ b/src/main/cli/wsl-cli-installer.test.ts
@@ -785,6 +785,27 @@ describe('WslCliInstaller', () => {
     await expect(installer.getStatus()).rejects.toThrow('WSL command timed out')
   })
 
+  it('reports the distro unreachable rather than "not on PATH" without the login PATH', async () => {
+    // The `case ":$PATH:"` probe answers from the distro default PATH when the
+    // login PATH never resolved, and ~/.local/bin is never on that. Settings
+    // would then state as fact that the CLI is not on PATH while the user's
+    // own terminal finds it -- #14288 turning into a confident wrong verdict.
+    runWslProcessMock.mockResolvedValue({
+      environmentResolved: false,
+      code: 0,
+      stdout: 'no',
+      stderr: '',
+      timedOut: false
+    })
+    const installer = new WslCliInstaller({
+      platform: 'win32',
+      distro: 'Ubuntu',
+      hostInstaller: { getStatus: async () => makeHostStatus() }
+    })
+
+    await expect(installer.getStatus()).rejects.toThrow('Could not reach the WSL distro')
+  })
+
   it('refuses to remove an old managed launcher when the bridge path is user-owned', async () => {
     const oldLauncher = _internals.buildWslLauncher(
       'C:\\Old\\orca.cmd',

--- a/src/main/cli/wsl-cli-installer.ts
+++ b/src/main/cli/wsl-cli-installer.ts
@@ -463,6 +463,9 @@ async function runWslCommand(distro: string, command: string): Promise<string> {
     distro,
     loginPath: 'preferred',
     script: command,
+    // Declared, not assumed: the payload is opaque here, so the guard cannot
+    // check it for bashisms. These are POSIX (`-eu`, `case`), hence sh.
+    shell: 'sh',
     timeoutMs: WSL_COMMAND_TIMEOUT_MS
   })
   // Timeout first: it is the more specific diagnosis, and a timed-out run also

--- a/src/main/cli/wsl-cli-installer.ts
+++ b/src/main/cli/wsl-cli-installer.ts
@@ -463,7 +463,7 @@ async function runWslCommand(distro: string, command: string): Promise<string> {
   try {
     result = await runWslProcess({
       distro,
-      lane: 'probe',
+      loginPath: 'preferred',
       script: command,
       timeoutMs: WSL_COMMAND_TIMEOUT_MS
     })

--- a/src/main/cli/wsl-cli-installer.ts
+++ b/src/main/cli/wsl-cli-installer.ts
@@ -459,21 +459,23 @@ export class WslCliInstaller {
 async function runWslCommand(distro: string, command: string): Promise<string> {
   // Why the probe lane fixes #14288: the prior login shell (`bash -lc`) sourced
   // ~/.profile, so one blocking line there ate the whole 10s timeout.
-  let result: Awaited<ReturnType<typeof runWslProcess>>
-  try {
-    result = await runWslProcess({
-      distro,
-      loginPath: 'preferred',
-      script: command,
-      timeoutMs: WSL_COMMAND_TIMEOUT_MS
-    })
-  } catch {
-    // Why map: the runner's raw "guest environment is unavailable" otherwise
-    // reaches Settings verbatim through ipc/cli.ts -> toast.error.
-    throw new Error('Could not reach the WSL distro. Try again.')
-  }
+  const result = await runWslProcess({
+    distro,
+    loginPath: 'preferred',
+    script: command,
+    timeoutMs: WSL_COMMAND_TIMEOUT_MS
+  })
+  // Timeout first: it is the more specific diagnosis, and a timed-out run also
+  // leaves the environment unresolved, so the order decides which one shows.
   if (result.timedOut) {
     throw new Error(`WSL command timed out after ${WSL_COMMAND_TIMEOUT_MS}ms.`)
+  }
+  // Every command here reads the login PATH -- the `case ":$PATH:"` probe most
+  // of all. Without it that probe answers from the distro default PATH, which
+  // never has ~/.local/bin, and Settings states as fact that the CLI is not on
+  // PATH while the user's own terminal finds it. Unverifiable, not negative.
+  if (!result.environmentResolved) {
+    throw new Error('Could not reach the WSL distro. Try again.')
   }
   if (result.code !== 0) {
     throw new Error(result.stderr.trim() || `WSL command failed with exit code ${result.code}.`)

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -1246,7 +1246,6 @@ export class CodexRuntimeHomeService {
     return index > 0 ? value.slice(0, index) : '/'
   }
 
-
   private joinWslPath(basePath: string, ...segments: string[]): string {
     return parseWslUncPath(basePath)
       ? pathWin32.join(basePath, ...segments)

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -1235,7 +1235,9 @@ export class CodexRuntimeHomeService {
           'fi'
         ].join('\n')
       ],
-      { stdio: ['ignore', 'pipe', 'pipe'], timeout: 5000 }
+      // wsl.exe is console-subsystem: without this a GUI-launched Orca flashes
+      // a conhost and steals foreground for up to the timeout (#10488).
+      { stdio: ['ignore', 'pipe', 'pipe'], timeout: 5000, windowsHide: true }
     )
   }
 

--- a/src/main/codex-accounts/service-wsl-accounts.test.ts
+++ b/src/main/codex-accounts/service-wsl-accounts.test.ts
@@ -71,7 +71,9 @@ describe('CodexAccountService config sync', () => {
     const runWslProcessMock = vi.fn(async (spec: WslSpec) => {
       const script = String(spec.script)
       expect(spec.distro).toBe('Debian')
-      expect(spec.lane).toBe('probe')
+      // 'none': the script reads $HOME and $WSL_DISTRO_NAME, which wsl.exe
+      // supplies from /etc/passwd without a login shell.
+      expect(spec.loginPath).toBe('none')
       if (script.includes('WSL_DISTRO_NAME')) {
         return wslOk('Debian\n/home/alice\n')
       }

--- a/src/main/codex-accounts/service-wsl-accounts.test.ts
+++ b/src/main/codex-accounts/service-wsl-accounts.test.ts
@@ -71,16 +71,20 @@ describe('CodexAccountService config sync', () => {
     const runWslProcessMock = vi.fn(async (spec: WslSpec) => {
       const script = String(spec.script)
       expect(spec.distro).toBe('Debian')
-      // 'none': the script reads $HOME and $WSL_DISTRO_NAME, which wsl.exe
-      // supplies from /etc/passwd without a login shell.
-      expect(spec.loginPath).toBe('none')
       if (script.includes('WSL_DISTRO_NAME')) {
+        // 'none': reads $HOME and $WSL_DISTRO_NAME, which wsl.exe supplies from
+        // /etc/passwd without a login shell.
+        expect(spec.loginPath).toBe('none')
         return wslOk('Debian\n/home/alice\n')
       }
       if (script.includes('_orca_lookup_command=')) {
+        // 'preferred': a PATH lookup. Under 'none' an nvm-installed codex is
+        // invisible and a working install is reported absent (#9725).
+        expect(spec.loginPath).toBe('preferred')
         expect(script).toBe(buildWslCodexAvailabilityScript())
         return wslOk()
       }
+      expect(spec.loginPath).toBe('none')
       expect(script).toContain('mkdir -p ')
       mkdirSync(wslManagedHomePath, { recursive: true })
       writeFileSync(join(wslManagedHomePath, '.orca-managed-home'), 'account-id-for-test\n')
@@ -236,6 +240,84 @@ describe('CodexAccountService config sync', () => {
 
       await expect(service.addAccount({ runtime: 'wsl', wslDistro: 'Debian' })).rejects.toThrow(
         'Codex CLI is not available in WSL Debian'
+      )
+      expect(spawnMock).not.toHaveBeenCalled()
+      expect(existsSync(wslManagedHomePath)).toBe(false)
+    } finally {
+      Object.defineProperty(process, 'platform', {
+        configurable: true,
+        value: originalPlatform
+      })
+    }
+  })
+
+  it('says it could not check, not "not installed", when the login PATH is unavailable', async () => {
+    // #9725: an nvm-installed codex lives only on the login PATH. When the
+    // probe cannot supply it, a non-zero lookup is "we could not check" --
+    // reporting a working install as absent is the bug this pins.
+    vi.resetModules()
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', {
+      configurable: true,
+      value: 'win32'
+    })
+
+    const wslManagedHomePath = join(testState.userDataDir, 'wsl-managed-home')
+    const wslLinuxHomePath = '/home/alice/.local/share/orca/codex-accounts/account-id-for-test/home'
+
+    const execFileSyncMock = vi.fn((_command: string, args: string[]) => {
+      const script = decodeEncodedWslBashCommand(String(args.at(-1)))
+      expect(args.slice(0, 2)).toEqual(['-d', 'Debian'])
+      expect(script).toContain('readlink -f')
+      return `${wslLinuxHomePath}\n`
+    })
+    const runWslProcessMock = vi.fn(async (spec: WslSpec) => {
+      const script = String(spec.script)
+      expect(spec.distro).toBe('Debian')
+      if (script.includes('WSL_DISTRO_NAME')) {
+        return wslOk('Debian\n/home/alice\n')
+      }
+      if (script.includes('_orca_lookup_command=')) {
+        expect(script).toBe(buildWslCodexAvailabilityScript())
+        return { ...wslFailed(1, 'codex missing'), environmentResolved: false }
+      }
+      mkdirSync(wslManagedHomePath, { recursive: true })
+      writeFileSync(join(wslManagedHomePath, '.orca-managed-home'), 'account-id-for-test\n')
+      return wslOk()
+    })
+    const spawnMock = vi.fn()
+
+    vi.doMock('node:crypto', () => ({
+      randomUUID: () => 'account-id-for-test'
+    }))
+    vi.doMock('node:child_process', () => ({
+      execFileSync: execFileSyncMock,
+      spawn: spawnMock
+    }))
+    vi.doMock('../wsl/wsl-runner', () => ({ runWslProcess: runWslProcessMock }))
+    vi.doMock('../../shared/wsl-paths', () => ({
+      parseWslUncPath: (path: string) =>
+        path === wslManagedHomePath ? { distro: 'Debian', linuxPath: wslLinuxHomePath } : null
+    }))
+    vi.doMock('../wsl', () => ({
+      toWindowsWslPath: () => wslManagedHomePath
+    }))
+
+    const settings = createSettings()
+    const store = createStore(settings)
+    const rateLimits = createRateLimits()
+    const runtimeHome = createRuntimeHome()
+
+    try {
+      const { CodexAccountService } = await import('./service')
+      const service = new CodexAccountService(
+        store as never,
+        rateLimits as never,
+        runtimeHome as never
+      )
+
+      await expect(service.addAccount({ runtime: 'wsl', wslDistro: 'Debian' })).rejects.toThrow(
+        'Could not check the Codex CLI in WSL. Try again.'
       )
       expect(spawnMock).not.toHaveBeenCalled()
       expect(existsSync(wslManagedHomePath)).toBe(false)

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -1215,9 +1215,7 @@ export class CodexAccountService {
     const requestedDistro = target.wslDistro?.trim() || undefined
     const info = await runWslProcess({
       distro: requestedDistro,
-      lane: 'probe',
-      // Degrade rather than refuse: $HOME and $WSL_DISTRO_NAME come from wsl.exe itself, not the login PATH -- the same rationale the Claude sites use.
-      allowDegradedEnvironment: true,
+      loginPath: 'none',
       script: 'printf "%s\\n%s\\n" "$WSL_DISTRO_NAME" "$HOME"',
       shell: 'bash',
       timeoutMs: WSL_MANAGED_HOME_TIMEOUT_MS
@@ -1239,9 +1237,7 @@ export class CodexAccountService {
     const markerPath = `${wslLinuxHomePath}/.orca-managed-home`
     const created = await runWslProcess({
       distro,
-      lane: 'probe',
-      // Degrade rather than refuse: $HOME and $WSL_DISTRO_NAME come from wsl.exe itself, not the login PATH -- the same rationale the Claude sites use.
-      allowDegradedEnvironment: true,
+      loginPath: 'none',
       script: `mkdir -p ${shellQuote(wslLinuxHomePath)} && printf '%s\\n' ${shellQuote(accountId)} > ${shellQuote(markerPath)}`,
       shell: 'bash',
       timeoutMs: WSL_MANAGED_HOME_TIMEOUT_MS
@@ -1478,9 +1474,7 @@ export class CodexAccountService {
 
     const result = await runWslProcess({
       distro: wslInfo.distro,
-      lane: 'probe',
-      // Degrade rather than refuse: $HOME and $WSL_DISTRO_NAME come from wsl.exe itself, not the login PATH -- the same rationale the Claude sites use.
-      allowDegradedEnvironment: true,
+      loginPath: 'none',
       script: [
         'set -euo pipefail',
         `candidate=${shellQuote(wslInfo.linuxPath)}`,
@@ -1616,9 +1610,7 @@ export class CodexAccountService {
     try {
       const result = await runWslProcess({
         distro,
-        lane: 'probe',
-        // Degrade rather than refuse: $HOME and $WSL_DISTRO_NAME come from wsl.exe itself, not the login PATH -- the same rationale the Claude sites use.
-        allowDegradedEnvironment: true,
+        loginPath: 'none',
         script: [
           'set -euo pipefail',
           `candidate=${shellQuote(linuxHomePath)}`,
@@ -1872,7 +1864,7 @@ export class CodexAccountService {
     try {
       result = await runWslProcess({
         distro: wslInfo.distro,
-        lane: 'probe',
+        loginPath: 'none',
         script: buildWslCodexAvailabilityScript(),
         timeoutMs: WSL_CODEX_AVAILABILITY_TIMEOUT_MS
       })

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -1863,6 +1863,8 @@ export class CodexAccountService {
       distro: wslInfo.distro,
       loginPath: 'preferred',
       script: buildWslCodexAvailabilityScript(),
+      // POSIX command lookup; declared because the payload is opaque here.
+      shell: 'sh',
       timeoutMs: WSL_CODEX_AVAILABILITY_TIMEOUT_MS
     })
     if (result.code !== 0 && !result.environmentResolved) {

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -1857,20 +1857,17 @@ export class CodexAccountService {
     distro: string
     linuxPath: string
   }): Promise<void> {
-    // Why the runner's default (throw) and not allowDegradedEnvironment: without
-    // the login PATH an nvm-installed codex is invisible, and this message would
-    // turn "we could not check" into "not installed" (#9725).
-    let result: Awaited<ReturnType<typeof runWslProcess>>
-    try {
-      result = await runWslProcess({
-        distro: wslInfo.distro,
-        loginPath: 'none',
-        script: buildWslCodexAvailabilityScript(),
-        timeoutMs: WSL_CODEX_AVAILABILITY_TIMEOUT_MS
-      })
-    } catch {
-      // Why map: the runner's raw "guest environment is unavailable" would
-      // otherwise reach the account dialog verbatim.
+    // This is a PATH lookup, so it needs the login PATH: an nvm-installed codex
+    // lives nowhere else. Marking it 'none' reports a working install as absent.
+    const result = await runWslProcess({
+      distro: wslInfo.distro,
+      loginPath: 'preferred',
+      script: buildWslCodexAvailabilityScript(),
+      timeoutMs: WSL_CODEX_AVAILABILITY_TIMEOUT_MS
+    })
+    if (result.code !== 0 && !result.environmentResolved) {
+      // A miss without the login PATH is "we could not check", not "not
+      // installed" -- claiming absence here is #9725.
       throw new Error('Could not check the Codex CLI in WSL. Try again.')
     }
     if (result.code !== 0 || result.timedOut) {

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -1560,8 +1560,7 @@ export class CodexAccountService {
                 ].join('\n')
               )
             ],
-            { windowsHide: true,
-              encoding: 'utf-8', timeout: 5000 }
+            { windowsHide: true, encoding: 'utf-8', timeout: 5000 }
           ).trim()
           if (!canonicalLinuxPath) {
             throw new Error('Managed Codex home directory does not exist on disk.')

--- a/src/main/codex/wsl-codex-session-bridge.test.ts
+++ b/src/main/codex/wsl-codex-session-bridge.test.ts
@@ -79,7 +79,9 @@ describe('syncWslCodexSessionsIntoManagedHome', () => {
   })
 
   it('parses the summary after leading stdout noise', async () => {
-    mockRunWslProcessSuccess('Welcome to Ubuntu\nprofile output\n{"scannedFiles":4,"linkedFiles":3}\n')
+    mockRunWslProcessSuccess(
+      'Welcome to Ubuntu\nprofile output\n{"scannedFiles":4,"linkedFiles":3}\n'
+    )
 
     const summary = await syncWslCodexSessionsIntoManagedHome({
       distro: 'Ubuntu',

--- a/src/main/codex/wsl-codex-session-bridge.test.ts
+++ b/src/main/codex/wsl-codex-session-bridge.test.ts
@@ -44,13 +44,13 @@ describe('syncWslCodexSessionsIntoManagedHome', () => {
     expect(runWslProcessMock).toHaveBeenCalledTimes(1)
     const spec = runWslProcessMock.mock.calls[0]?.[0] as {
       distro: string
-      lane: string
+      loginPath: string
       shell?: string
       script: string
       timeoutMs: number
     }
     expect(spec.distro).toBe('Ubuntu')
-    expect(spec.lane).toBe('probe')
+    expect(spec.loginPath).toBe('none')
     expect(spec.shell).toBe('bash')
     expect(spec.timeoutMs).toBe(30_000)
 

--- a/src/main/codex/wsl-codex-session-bridge.ts
+++ b/src/main/codex/wsl-codex-session-bridge.ts
@@ -56,7 +56,7 @@ export async function syncWslCodexSessionsIntoManagedHome(
 
   const result = await runWslProcess({
     distro: target.distro,
-    lane: 'probe',
+    loginPath: 'none',
     script: buildWslCodexSessionBridgeShellCommand(paths),
     // Process substitution and `read -d` are bash-only; dash rejects both.
     shell: 'bash',

--- a/src/main/daemon/daemon-process-inspection.ts
+++ b/src/main/daemon/daemon-process-inspection.ts
@@ -191,7 +191,13 @@ async function runInspectionCommand(
   args: string[],
   timeoutMs: number
 ): Promise<string> {
-  const { stdout } = await execFileAsync(file, args, { encoding: 'utf8', timeout: timeoutMs })
+  // powershell.exe is console-subsystem: without this it flashes a conhost and
+  // steals foreground on every inspection (#10488).
+  const { stdout } = await execFileAsync(file, args, {
+    encoding: 'utf8',
+    timeout: timeoutMs,
+    windowsHide: true
+  })
   return stdout
 }
 

--- a/src/main/git/runner.test.ts
+++ b/src/main/git/runner.test.ts
@@ -353,4 +353,3 @@ describe('redirectPortedHostnameToEnv WSLENV forwarding', () => {
     expect((options.env?.WSLENV ?? '').split(':')).toContain('GITLAB_HOST')
   })
 })
-

--- a/src/main/git/runner.test.ts
+++ b/src/main/git/runner.test.ts
@@ -338,3 +338,19 @@ describe('git env forces untranslated diagnostics (issue #7808)', () => {
     expect(env.LANGUAGE).toBe('en')
   })
 })
+
+describe('redirectPortedHostnameToEnv WSLENV forwarding', () => {
+  it('names GITLAB_HOST in WSLENV so it can cross into a distro', async () => {
+    // A WSL-routed glab only sees Windows variables listed in WSLENV; without
+    // the entry the ported host is silently dropped and glab talks to
+    // gitlab.com (#12557).
+    const { redirectPortedHostnameToEnv } = await import('./runner')
+    const { options } = redirectPortedHostnameToEnv(
+      ['api', '--hostname', 'gitlab.example.com:8443'],
+      { env: { PATH: '/usr/bin' } }
+    )
+    expect(options.env?.GITLAB_HOST).toBe('gitlab.example.com:8443')
+    expect((options.env?.WSLENV ?? '').split(':')).toContain('GITLAB_HOST')
+  })
+})
+

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -1908,9 +1908,14 @@ export function redirectPortedHostnameToEnv(
   if (!/^[^/\s]+:\d+$/.test(host)) {
     return { args, options }
   }
+  // Why WSLENV: a glab routed into a distro only sees Windows-side variables
+  // named in WSLENV, so without this the ported host silently never crosses and
+  // glab talks to gitlab.com instead (#12557). Credit: #12558.
+  const env: NodeJS.ProcessEnv = { ...(options.env ?? process.env), GITLAB_HOST: host }
+  addWslEnvKeys(env, ['GITLAB_HOST'])
   return {
     args: [...args.slice(0, i), ...args.slice(i + 2)],
-    options: { ...options, env: { ...(options.env ?? process.env), GITLAB_HOST: host } }
+    options: { ...options, env }
   }
 }
 

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -1912,6 +1912,9 @@ export function redirectPortedHostnameToEnv(
   // named in WSLENV, so without this the ported host silently never crosses and
   // glab talks to gitlab.com instead (#12557). Credit: #12558.
   const env: NodeJS.ProcessEnv = { ...(options.env ?? process.env), GITLAB_HOST: host }
+  // Unguarded by platform on purpose: WSLENV is meaningless outside Windows, so
+  // the extra key is inert there, and gating it would need the test to know the
+  // platform for no behavioural gain.
   addWslEnvKeys(env, ['GITLAB_HOST'])
   return {
     args: [...args.slice(0, i), ...args.slice(i + 2)],

--- a/src/main/hooks.test.ts
+++ b/src/main/hooks.test.ts
@@ -164,7 +164,7 @@ describe('runHook', () => {
       expect(runWslProcessMock).toHaveBeenCalledWith(
         expect.objectContaining({
           distro: 'Ubuntu',
-          lane: 'probe',
+          loginPath: 'preferred',
           script: 'echo hello',
           cwd: '/home/jin/feature',
           // #7652 regression: the unattended WSL hook branch must carry the
@@ -220,7 +220,7 @@ describe('runHook', () => {
       expect(runWslProcessMock).toHaveBeenCalledWith(
         expect.objectContaining({
           distro: 'Ubuntu',
-          lane: 'probe',
+          loginPath: 'preferred',
           script: 'echo hello',
           cwd: '/mnt/c/Users/jinwo/git/orca-feature',
           env: expect.objectContaining({

--- a/src/main/hooks.test.ts
+++ b/src/main/hooks.test.ts
@@ -141,7 +141,13 @@ describe('runHook', () => {
   it('runs WSL hooks through runWslProcess and translates env paths to Linux', async () => {
     execMock.mockReset()
     runWslProcessMock.mockReset()
-    runWslProcessMock.mockResolvedValue({ environmentResolved: true, code: 0, stdout: '', stderr: '', timedOut: false })
+    runWslProcessMock.mockResolvedValue({
+      environmentResolved: true,
+      code: 0,
+      stdout: '',
+      stderr: '',
+      timedOut: false
+    })
 
     const fs = await import('node:fs')
     vi.mocked(fs.existsSync).mockReturnValue(true)
@@ -191,7 +197,13 @@ describe('runHook', () => {
   it('runs Windows-path hooks through WSL when the project runtime targets WSL', async () => {
     execMock.mockReset()
     runWslProcessMock.mockReset()
-    runWslProcessMock.mockResolvedValue({ environmentResolved: true, code: 0, stdout: '', stderr: '', timedOut: false })
+    runWslProcessMock.mockResolvedValue({
+      environmentResolved: true,
+      code: 0,
+      stdout: '',
+      stderr: '',
+      timedOut: false
+    })
 
     const fs = await import('node:fs')
     vi.mocked(fs.existsSync).mockReturnValue(true)
@@ -296,7 +308,13 @@ describe('runHook', () => {
     // mocked runWslProcess -- there is nothing left in hooks.ts to advance.
     execMock.mockReset()
     runWslProcessMock.mockReset()
-    runWslProcessMock.mockResolvedValue({ environmentResolved: true, code: null, stdout: '', stderr: '', timedOut: true })
+    runWslProcessMock.mockResolvedValue({
+      environmentResolved: true,
+      code: null,
+      stdout: '',
+      stderr: '',
+      timedOut: true
+    })
 
     const fs = await import('node:fs')
     vi.mocked(fs.existsSync).mockReturnValue(true)

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -153,17 +153,12 @@ export function runHook(
 
     return runWslProcess({
       distro: wslInfo.distro ?? undefined,
-      lane: 'probe',
+      loginPath: 'preferred',
       script,
       // Why pinned: these are user-authored orca.yaml scripts and the native
       // path runs /bin/bash. Defaulting to sh would fail bash-only hooks on WSL
       // only -- a downgrade the user never asked for.
       shell: 'bash',
-      // Why degrade rather than fail: a hook is an action, not an "is this
-      // installed?" question. Before the runner it ran on the default PATH when
-      // no login shell was available; refusing would turn worktree setup into a
-      // hard failure whenever WSL is briefly slow.
-      allowDegradedEnvironment: true,
       cwd: wslInfo.linuxPath,
       env: guestEnv,
       timeoutMs: HOOK_TIMEOUT

--- a/src/main/hooks.ts
+++ b/src/main/hooks.ts
@@ -145,7 +145,9 @@ export function runHook(
     for (const [key, value] of Object.entries(guardedEnv)) {
       if (
         value !== undefined &&
-        (key === 'GIT_TERMINAL_PROMPT' || key === 'GCM_INTERACTIVE' || key.startsWith('GIT_CONFIG_'))
+        (key === 'GIT_TERMINAL_PROMPT' ||
+          key === 'GCM_INTERACTIVE' ||
+          key.startsWith('GIT_CONFIG_'))
       ) {
         guestEnv[key] = value
       }

--- a/src/main/ipc/preflight-agent-detection.test.ts
+++ b/src/main/ipc/preflight-agent-detection.test.ts
@@ -405,7 +405,7 @@ describe('preflight', () => {
     // pinned by its own tests. What this suite owns is that detection asks the
     // right distro on the lane that carries the user's PATH.
     expect(runWslProcessMock).toHaveBeenCalledWith(
-      expect.objectContaining({ distro: 'Ubuntu', lane: 'probe' })
+      expect.objectContaining({ distro: 'Ubuntu', loginPath: 'preferred' })
     )
   })
 
@@ -433,7 +433,7 @@ describe('preflight', () => {
     expect(resolveCliCommandsMock).not.toHaveBeenCalled()
     // No distro named: the runner resolves the default.
     expect(runWslProcessMock).toHaveBeenCalledWith(
-      expect.objectContaining({ distro: undefined, lane: 'probe' })
+      expect.objectContaining({ distro: undefined, loginPath: 'preferred' })
     )
   })
 })

--- a/src/main/ipc/preflight-agent-detection.test.ts
+++ b/src/main/ipc/preflight-agent-detection.test.ts
@@ -135,13 +135,31 @@ describe('preflight', () => {
 
       const target = String(args[0])
       if (target === 'claude') {
-        return { environmentResolved: true, code: 0, stdout: '/Users/test/.local/bin/claude\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/Users/test/.local/bin/claude\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       if (target === 'continue') {
-        return { environmentResolved: true, code: 0, stdout: 'continue: shell built-in command\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: 'continue: shell built-in command\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       if (target === 'cursor-agent') {
-        return { environmentResolved: true, code: 0, stdout: '/Users/test/.local/bin/cursor-agent\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/Users/test/.local/bin/cursor-agent\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })
@@ -155,7 +173,13 @@ describe('preflight', () => {
         throw new Error(`unexpected command ${String(command)}`)
       }
       if (String(args[0]) === 'orca') {
-        return { environmentResolved: true, code: 0, stdout: '/Applications/Orca.app/Contents/MacOS/orca\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/Applications/Orca.app/Contents/MacOS/orca\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })
@@ -169,10 +193,22 @@ describe('preflight', () => {
         throw new Error(`unexpected command ${String(command)}`)
       }
       if (String(args[0]) === 'claude') {
-        return { environmentResolved: true, code: 0, stdout: '/Users/test/.local/bin/claude\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/Users/test/.local/bin/claude\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       if (String(args[0]) === 'orca') {
-        return { environmentResolved: true, code: 0, stdout: '/Applications/Orca.app/Contents/MacOS/orca\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/Applications/Orca.app/Contents/MacOS/orca\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })
@@ -190,10 +226,22 @@ describe('preflight', () => {
         throw new Error(`unexpected command ${String(command)}`)
       }
       if (String(args[0]) === 'claude') {
-        return { environmentResolved: true, code: 0, stdout: '/mock/windows/npm/claude.cmd\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/mock/windows/npm/claude.cmd\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       if (String(args[0]) === 'orca') {
-        return { environmentResolved: true, code: 0, stdout: '/mock/windows/programs/orca.cmd\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/mock/windows/programs/orca.cmd\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })
@@ -239,7 +287,13 @@ describe('preflight', () => {
         throw new Error(`unexpected command ${String(command)}`)
       }
       if (String(args[0]) === 'claude') {
-        return { environmentResolved: true, code: 0, stdout: '/Users/test/.local/bin/claude\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/Users/test/.local/bin/claude\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })
@@ -273,10 +327,22 @@ describe('preflight', () => {
         throw new Error(`unexpected command ${String(command)}`)
       }
       if (String(args[0]) === 'openclaude') {
-        return { environmentResolved: true, code: 0, stdout: '/Users/test/.local/bin/openclaude\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/Users/test/.local/bin/openclaude\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       if (String(args[0]) === 'cursor-agent') {
-        return { environmentResolved: true, code: 0, stdout: '/Users/test/.local/bin/cursor-agent\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/Users/test/.local/bin/cursor-agent\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })
@@ -303,7 +369,13 @@ describe('preflight', () => {
         throw new Error(`unexpected command ${String(command)}`)
       }
       if (String(args[0]) === 'codex' && process.env.PATH?.startsWith('/home/test/.local/bin')) {
-        return { environmentResolved: true, code: 0, stdout: '/home/test/.local/bin/codex\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/home/test/.local/bin/codex\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })
@@ -328,7 +400,13 @@ describe('preflight', () => {
     })
     runWslProcessMock.mockImplementation(async ({ script }: { script: string }) => {
       if (script.includes("'claude'")) {
-        return { environmentResolved: true, code: 0, stdout: '__ORCA_AGENT_PATH__claude\t/home/test/.local/bin/claude\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '__ORCA_AGENT_PATH__claude\t/home/test/.local/bin/claude\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })
@@ -349,7 +427,13 @@ describe('preflight', () => {
       expect(script).not.toContain("'orca-dev'")
       expect(script).not.toContain("'orca-ide'")
       if (script.includes("'claude'")) {
-        return { environmentResolved: true, code: 0, stdout: '__ORCA_AGENT_PATH__claude\t/home/test/.local/bin/claude\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '__ORCA_AGENT_PATH__claude\t/home/test/.local/bin/claude\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })
@@ -363,7 +447,13 @@ describe('preflight', () => {
         throw new Error(`unexpected command ${String(command)}`)
       }
       if (String(args[0]) === 'vibe') {
-        return { environmentResolved: true, code: 0, stdout: '/home/test/.local/bin/vibe\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/home/test/.local/bin/vibe\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })
@@ -392,7 +482,13 @@ describe('preflight', () => {
     })
     runWslProcessMock.mockImplementation(async ({ script }: { script: string }) => {
       if (script.includes("'claude'")) {
-        return { environmentResolved: true, code: 0, stdout: '__ORCA_AGENT_PATH__claude\t/home/test/.local/bin/claude\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '__ORCA_AGENT_PATH__claude\t/home/test/.local/bin/claude\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })

--- a/src/main/ipc/preflight-host-cli-status.test.ts
+++ b/src/main/ipc/preflight-host-cli-status.test.ts
@@ -276,7 +276,13 @@ describe('preflight', () => {
     })
     runWslProcessMock.mockImplementation(async ({ script }: { script: string }) => {
       if (script.includes('gh') && script.includes('--version')) {
-        return { environmentResolved: true, code: 0, stdout: 'gh version 2.0.0\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: 'gh version 2.0.0\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       if (script.includes('gh') && script.includes('auth status')) {
         return {

--- a/src/main/ipc/preflight-host-cli-status.test.ts
+++ b/src/main/ipc/preflight-host-cli-status.test.ts
@@ -296,14 +296,14 @@ describe('preflight', () => {
     expect(runWslProcessMock).toHaveBeenCalledWith(
       expect.objectContaining({
         distro: 'Ubuntu',
-        lane: 'probe',
+        loginPath: 'preferred',
         script: expect.stringMatching(/gh[\s\S]*--version/)
       })
     )
     expect(runWslProcessMock).toHaveBeenCalledWith(
       expect.objectContaining({
         distro: 'Ubuntu',
-        lane: 'probe',
+        loginPath: 'preferred',
         script: expect.stringMatching(/gh[\s\S]*auth status/)
       })
     )

--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -160,7 +160,7 @@ describe('the detection script itself, run by a real POSIX shell', () => {
       stderr: '',
       timedOut: false
     })
-    await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude', 'nosuchtool'])
+    await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['orca-fake-cli', 'nosuchtool'])
     const script = String(runWslProcessMock.mock.calls.at(-1)?.[0].script)
     const options: ExecFileSyncOptions = {
       encoding: 'utf8',
@@ -172,19 +172,19 @@ describe('the detection script itself, run by a real POSIX shell', () => {
   itPosix('finds an nvm-installed binary the login PATH would have shown', async () => {
     // #9725: without the login PATH this resolves to nothing and preflight
     // reports a working install as "not installed".
-    plant('.nvm/versions/node/v20.1.0/bin', 'claude')
+    plant('.nvm/versions/node/v20.1.0/bin', 'orca-fake-cli')
     const out = await runScript()
-    expect(out).toContain('__ORCA_AGENT_PATH__claude')
-    expect(out).toContain('.nvm/versions/node/v20.1.0/bin/claude')
+    expect(out).toContain('__ORCA_AGENT_PATH__orca-fake-cli')
+    expect(out).toContain('.nvm/versions/node/v20.1.0/bin/orca-fake-cli')
   })
 
   itPosix('finds a ~/.local/bin install', async () => {
-    plant('.local/bin', 'claude')
-    expect(await runScript()).toContain('__ORCA_AGENT_PATH__claude')
+    plant('.local/bin', 'orca-fake-cli')
+    expect(await runScript()).toContain('__ORCA_AGENT_PATH__orca-fake-cli')
   })
 
   itPosix('still reports nothing for a command that is genuinely absent', async () => {
-    plant('.local/bin', 'claude')
+    plant('.local/bin', 'orca-fake-cli')
     expect(await runScript()).not.toContain('nosuchtool')
   })
 
@@ -195,8 +195,8 @@ describe('the detection script itself, run by a real POSIX shell', () => {
     const previous = home
     home = spaced
     try {
-      plant('.nvm/versions/node/v20.1.0/bin', 'claude')
-      expect(await runScript()).toContain(`${spaced}/.nvm/versions/node/v20.1.0/bin/claude`)
+      plant('.nvm/versions/node/v20.1.0/bin', 'orca-fake-cli')
+      expect(await runScript()).toContain(`${spaced}/.nvm/versions/node/v20.1.0/bin/orca-fake-cli`)
     } finally {
       home = previous
       rmSync(spaced, { recursive: true, force: true })
@@ -206,8 +206,8 @@ describe('the detection script itself, run by a real POSIX shell', () => {
   itPosix('does not report a directory as an installed CLI', async () => {
     // Directories are mode 755 and pass -x. Preflight would say installed and
     // the launch would fail later with EISDIR.
-    mkdirSync(join(home, '.local/bin/claude'), { recursive: true })
-    expect(await runScript()).not.toContain('__ORCA_AGENT_PATH__claude')
+    mkdirSync(join(home, '.local/bin/orca-fake-cli'), { recursive: true })
+    expect(await runScript()).not.toContain('__ORCA_AGENT_PATH__orca-fake-cli')
   })
 
   itPosix.each([
@@ -216,7 +216,7 @@ describe('the detection script itself, run by a real POSIX shell', () => {
     '.fnm/aliases/default/bin',
     '.local/share/mise/shims'
   ])('covers %s, which the native fallback also probes', async (dir) => {
-    plant(dir, 'claude')
-    expect(await runScript()).toContain('__ORCA_AGENT_PATH__claude')
+    plant(dir, 'orca-fake-cli')
+    expect(await runScript()).toContain('__ORCA_AGENT_PATH__orca-fake-cli')
   })
 })

--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -21,7 +21,13 @@ function lastSpec(): RunWslProcessSpec {
 describe('detectWslCommandsOnPath', () => {
   beforeEach(() => {
     runWslProcessMock.mockReset()
-    runWslProcessMock.mockResolvedValue({ environmentResolved: true, code: 0, stdout: '', stderr: '', timedOut: false })
+    runWslProcessMock.mockResolvedValue({
+      environmentResolved: true,
+      code: 0,
+      stdout: '',
+      stderr: '',
+      timedOut: false
+    })
   })
 
   afterEach(() => {
@@ -204,11 +210,13 @@ describe('the detection script itself, run by a real POSIX shell', () => {
     expect(await runScript()).not.toContain('__ORCA_AGENT_PATH__claude')
   })
 
-  itPosix.each(['.volta/bin', '.asdf/shims', '.fnm/aliases/default/bin', '.local/share/mise/shims'])(
-    'covers %s, which the native fallback also probes',
-    async (dir) => {
-      plant(dir, 'claude')
-      expect(await runScript()).toContain('__ORCA_AGENT_PATH__claude')
-    }
-  )
+  itPosix.each([
+    '.volta/bin',
+    '.asdf/shims',
+    '.fnm/aliases/default/bin',
+    '.local/share/mise/shims'
+  ])('covers %s, which the native fallback also probes', async (dir) => {
+    plant(dir, 'claude')
+    expect(await runScript()).toContain('__ORCA_AGENT_PATH__claude')
+  })
 })

--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -1,3 +1,7 @@
+import { execFileSync, type ExecFileSyncOptions } from 'node:child_process'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const runWslProcessMock = vi.hoisted(() => vi.fn())
@@ -119,5 +123,62 @@ describe('detectWslCommandsOnPath', () => {
 
     expect(found).toEqual(new Set())
     expect(runWslProcessMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('the detection script itself, run by a real POSIX shell', () => {
+  // Not a mock: the fallback is shell globbing and `[ -x ]`, which only the
+  // shell can be trusted about. Skipped on Windows, where /bin/sh is absent.
+  const itPosix = process.platform === 'win32' ? it.skip : it
+  let home: string
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'orca-wsl-detect-'))
+  })
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true })
+  })
+
+  const plant = (dir: string, name: string): void => {
+    mkdirSync(join(home, dir), { recursive: true })
+    const file = join(home, dir, name)
+    writeFileSync(file, '#!/bin/sh\necho hi\n')
+    chmodSync(file, 0o755)
+  }
+
+  const runScript = async (): Promise<string> => {
+    runWslProcessMock.mockResolvedValue({
+      environmentResolved: false,
+      code: 0,
+      stdout: '',
+      stderr: '',
+      timedOut: false
+    })
+    await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude', 'nosuchtool'])
+    const script = String(runWslProcessMock.mock.calls.at(-1)?.[0].script)
+    const options: ExecFileSyncOptions = {
+      encoding: 'utf8',
+      env: { HOME: home, PATH: '/usr/bin:/bin' }
+    }
+    return String(execFileSync('/bin/sh', ['-c', script], options))
+  }
+
+  itPosix('finds an nvm-installed binary the login PATH would have shown', async () => {
+    // #9725: without the login PATH this resolves to nothing and preflight
+    // reports a working install as "not installed".
+    plant('.nvm/versions/node/v20.1.0/bin', 'claude')
+    const out = await runScript()
+    expect(out).toContain('__ORCA_AGENT_PATH__claude')
+    expect(out).toContain('.nvm/versions/node/v20.1.0/bin/claude')
+  })
+
+  itPosix('finds a ~/.local/bin install', async () => {
+    plant('.local/bin', 'claude')
+    expect(await runScript()).toContain('__ORCA_AGENT_PATH__claude')
+  })
+
+  itPosix('still reports nothing for a command that is genuinely absent', async () => {
+    plant('.local/bin', 'claude')
+    expect(await runScript()).not.toContain('nosuchtool')
   })
 })

--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -181,4 +181,34 @@ describe('the detection script itself, run by a real POSIX shell', () => {
     plant('.local/bin', 'claude')
     expect(await runScript()).not.toContain('nosuchtool')
   })
+
+  itPosix('finds a CLI when $HOME contains a space', async () => {
+    // The dir list is globbed, so an unquoted $HOME word-split into a relative
+    // path and every CLI read as absent -- the #9725 symptom, from the fix.
+    const spaced = mkdtempSync(join(tmpdir(), 'orca has space-'))
+    const previous = home
+    home = spaced
+    try {
+      plant('.nvm/versions/node/v20.1.0/bin', 'claude')
+      expect(await runScript()).toContain(`${spaced}/.nvm/versions/node/v20.1.0/bin/claude`)
+    } finally {
+      home = previous
+      rmSync(spaced, { recursive: true, force: true })
+    }
+  })
+
+  itPosix('does not report a directory as an installed CLI', async () => {
+    // Directories are mode 755 and pass -x. Preflight would say installed and
+    // the launch would fail later with EISDIR.
+    mkdirSync(join(home, '.local/bin/claude'), { recursive: true })
+    expect(await runScript()).not.toContain('__ORCA_AGENT_PATH__claude')
+  })
+
+  itPosix.each(['.volta/bin', '.asdf/shims', '.fnm/aliases/default/bin', '.local/share/mise/shims'])(
+    'covers %s, which the native fallback also probes',
+    async (dir) => {
+      plant(dir, 'claude')
+      expect(await runScript()).toContain('__ORCA_AGENT_PATH__claude')
+    }
+  )
 })

--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -6,7 +6,7 @@ vi.mock('../wsl/wsl-runner', () => ({ runWslProcess: runWslProcessMock }))
 import { detectWslCommandsOnPath } from './preflight-wsl-agent-detection'
 import { buildPosixCommandPathLookupScript } from '../../shared/posix-command-path-lookup'
 
-type RunWslProcessSpec = { distro?: string; lane: string; script: string }
+type RunWslProcessSpec = { distro?: string; loginPath: string; script: string }
 
 function lastSpec(): RunWslProcessSpec {
   const call = runWslProcessMock.mock.calls.at(-1)
@@ -24,11 +24,11 @@ describe('detectWslCommandsOnPath', () => {
     vi.restoreAllMocks()
   })
 
-  it('runs on the probe lane -- no shell, so no rc/motd banner can appear', async () => {
+  it('asks for the login PATH without running a shell, so no banner can appear', async () => {
     await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])
 
     const spec = lastSpec()
-    expect(spec.lane).toBe('probe')
+    expect(spec.loginPath).toBe('preferred')
     expect(spec.distro).toBe('Ubuntu')
   })
 

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -1,9 +1,12 @@
 import path from 'node:path'
+import { POSIX_VERSION_MANAGER_BIN_DIRS } from '../../shared/posix-version-manager-bin-dirs'
 import { buildPosixCommandPathLookupScript } from '../../shared/posix-command-path-lookup'
 import { runWslProcess } from '../wsl/wsl-runner'
 
 const WSL_AGENT_DETECTION_TIMEOUT_MS = 10000
 const WSL_AGENT_DETECTION_PREFIX = '__ORCA_AGENT_PATH__'
+
+
 
 export type WslPreflightTarget = {
   distro?: string
@@ -27,6 +30,13 @@ export async function detectWslCommandsOnPath(
   const script = [
     `for cmd in ${commandList}; do`,
     lookupScript,
+    // Only when the PATH lookup missed, mirroring the native fallback, which
+    // resolves install dirs for missed commands only.
+    'if [ -z "$resolved" ]; then',
+    `  for _orca_dir in ${POSIX_VERSION_MANAGER_BIN_DIRS.join(' ')}; do`,
+    '    if [ -x "$_orca_dir/$cmd" ]; then resolved="$_orca_dir/$cmd"; break; fi',
+    '  done',
+    'fi',
     'if [ -n "$resolved" ]; then',
     `printf '${WSL_AGENT_DETECTION_PREFIX}%s\\t%s\\n' "$cmd" "$resolved";`,
     'fi',

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { POSIX_VERSION_MANAGER_BIN_DIRS } from '../../shared/posix-version-manager-bin-dirs'
+import { buildPosixFallbackPathPrelude } from '../../shared/posix-version-manager-bin-dirs'
 import { buildPosixCommandPathLookupScript } from '../../shared/posix-command-path-lookup'
 import { runWslProcess } from '../wsl/wsl-runner'
 
@@ -26,20 +26,13 @@ export async function detectWslCommandsOnPath(
   })
   // Newlines keep the loop valid in every POSIX shell used here.
   const script = [
+    // The same fallback the preflight command runner uses: append the
+    // version-manager dirs to PATH and let the ordinary lookup find them. A
+    // second bespoke `[ -x ]` walk here duplicated the lookup script's own
+    // `! -d` guard, which is how a directory once read as an installed CLI.
+    buildPosixFallbackPathPrelude(),
     `for cmd in ${commandList}; do`,
     lookupScript,
-    // Only when the PATH lookup missed, mirroring the native fallback, which
-    // resolves install dirs for missed commands only.
-    'if [ -z "$resolved" ]; then',
-    `  for _orca_dir in ${POSIX_VERSION_MANAGER_BIN_DIRS}; do`,
-    // `! -d` because directories are mode 755 and pass -x, and preflight would
-    // then report an installed CLI that fails later with EISDIR. The PATH half
-    // of this same script already guards it, as does the native twin.
-    '    if [ -x "$_orca_dir/$cmd" ] && [ ! -d "$_orca_dir/$cmd" ]; then',
-    '      resolved="$_orca_dir/$cmd"; break',
-    '    fi',
-    '  done',
-    'fi',
     'if [ -n "$resolved" ]; then',
     `printf '${WSL_AGENT_DETECTION_PREFIX}%s\\t%s\\n' "$cmd" "$resolved";`,
     'fi',

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -38,15 +38,8 @@ export async function detectWslCommandsOnPath(
     // with no shell in the loop, so there is no rc/motd banner to land in stdout.
     const result = await runWslProcess({
       distro: wslTarget.distro,
-      lane: 'probe',
+      loginPath: 'preferred',
       script,
-      // Why degrade rather than refuse: the Set has no room for "unverifiable",
-      // and refusing would turn a slow distro into "no agents" anyway -- via a
-      // throw instead of an empty result. Degrading at least finds anything on
-      // the default PATH. The residual gap (an nvm-only agent missed during the
-      // probe's retry window, #9725) is the pre-migration behaviour, not new,
-      // and Refresh now re-probes.
-      allowDegradedEnvironment: true,
       timeoutMs: WSL_AGENT_DETECTION_TIMEOUT_MS
     })
     // runProcess resolves on a timeout and on a non-zero exit, so partial

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -33,8 +33,13 @@ export async function detectWslCommandsOnPath(
     // Only when the PATH lookup missed, mirroring the native fallback, which
     // resolves install dirs for missed commands only.
     'if [ -z "$resolved" ]; then',
-    `  for _orca_dir in ${POSIX_VERSION_MANAGER_BIN_DIRS.join(' ')}; do`,
-    '    if [ -x "$_orca_dir/$cmd" ]; then resolved="$_orca_dir/$cmd"; break; fi',
+    `  for _orca_dir in ${POSIX_VERSION_MANAGER_BIN_DIRS}; do`,
+    // `! -d` because directories are mode 755 and pass -x, and preflight would
+    // then report an installed CLI that fails later with EISDIR. The PATH half
+    // of this same script already guards it, as does the native twin.
+    '    if [ -x "$_orca_dir/$cmd" ] && [ ! -d "$_orca_dir/$cmd" ]; then',
+    '      resolved="$_orca_dir/$cmd"; break',
+    '    fi',
     '  done',
     'fi',
     'if [ -n "$resolved" ]; then',

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -50,6 +50,8 @@ export async function detectWslCommandsOnPath(
       distro: wslTarget.distro,
       loginPath: 'preferred',
       script,
+      // POSIX `command -v` loop; declared because the payload is opaque here.
+      shell: 'sh',
       timeoutMs: WSL_AGENT_DETECTION_TIMEOUT_MS
     })
     // runProcess resolves on a timeout and on a non-zero exit, so partial

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -6,8 +6,6 @@ import { runWslProcess } from '../wsl/wsl-runner'
 const WSL_AGENT_DETECTION_TIMEOUT_MS = 10000
 const WSL_AGENT_DETECTION_PREFIX = '__ORCA_AGENT_PATH__'
 
-
-
 export type WslPreflightTarget = {
   distro?: string
 }

--- a/src/main/ipc/preflight-wsl-command.test.ts
+++ b/src/main/ipc/preflight-wsl-command.test.ts
@@ -1,3 +1,7 @@
+import { execFileSync, type ExecFileSyncOptions } from 'node:child_process'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const runWslProcessMock = vi.hoisted(() => vi.fn())
@@ -42,5 +46,72 @@ describe('runPreflightCommandInWsl', () => {
     await expect(
       runPreflightCommandInWsl({ distro: 'Ubuntu' }, 'gh auth status', 5_000)
     ).rejects.toMatchObject({ stdout: 'partial', stderr: 'boom', code: 1 })
+  })
+})
+
+describe('the PATH fallback, run by a real POSIX shell', () => {
+  const itPosix = process.platform === 'win32' ? it.skip : it
+
+  itPosix('finds an nvm-installed CLI a degraded probe would have missed', async () => {
+    // #9725: the caller turns a throw into "not installed", so a degraded probe
+    // told the user to install a CLI their own terminal already runs.
+    const home = mkdtempSync(join(tmpdir(), 'orca-wsl-cmd-'))
+    try {
+      const bin = join(home, '.nvm/versions/node/v20.1.0/bin')
+      mkdirSync(bin, { recursive: true })
+      writeFileSync(join(bin, 'gh'), '#!/bin/sh\necho gh-ok\n')
+      chmodSync(join(bin, 'gh'), 0o755)
+
+      runWslProcessMock.mockResolvedValue({
+        environmentResolved: false,
+        code: 0,
+        stdout: '',
+        stderr: '',
+        timedOut: false
+      })
+      await runPreflightCommandInWsl({ distro: 'Ubuntu' }, 'command -v gh', 5000)
+      const script = String(runWslProcessMock.mock.calls.at(-1)?.[0].script)
+      const options: ExecFileSyncOptions = {
+        encoding: 'utf8',
+        env: { HOME: home, PATH: '/usr/bin:/bin' }
+      }
+      expect(String(execFileSync('/bin/sh', ['-c', script], options))).toContain(
+        '.nvm/versions/node/v20.1.0/bin/gh'
+      )
+    } finally {
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+
+  itPosix('appends rather than prepends, so a resolved PATH still wins', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'orca-wsl-cmd-'))
+    const real = mkdtempSync(join(tmpdir(), 'orca-wsl-real-'))
+    try {
+      for (const [dir, body] of [
+        [join(home, '.local/bin'), 'stale'],
+        [real, 'current']
+      ] as const) {
+        mkdirSync(dir, { recursive: true })
+        writeFileSync(join(dir, 'gh'), `#!/bin/sh\necho ${body}\n`)
+        chmodSync(join(dir, 'gh'), 0o755)
+      }
+      runWslProcessMock.mockResolvedValue({
+        environmentResolved: true,
+        code: 0,
+        stdout: '',
+        stderr: '',
+        timedOut: false
+      })
+      await runPreflightCommandInWsl({ distro: 'Ubuntu' }, 'gh', 5000)
+      const script = String(runWslProcessMock.mock.calls.at(-1)?.[0].script)
+      const options: ExecFileSyncOptions = {
+        encoding: 'utf8',
+        env: { HOME: home, PATH: `${real}:/usr/bin:/bin` }
+      }
+      expect(String(execFileSync('/bin/sh', ['-c', script], options)).trim()).toBe('current')
+    } finally {
+      rmSync(home, { recursive: true, force: true })
+      rmSync(real, { recursive: true, force: true })
+    }
   })
 })

--- a/src/main/ipc/preflight-wsl-command.test.ts
+++ b/src/main/ipc/preflight-wsl-command.test.ts
@@ -17,15 +17,14 @@ beforeEach(() => {
 })
 
 describe('runPreflightCommandInWsl', () => {
-  it('degrades rather than letting a slow distro read as "not installed"', async () => {
+  it('prefers the login PATH but never lets its absence decide the answer', async () => {
     // Every caller collapses a throw into a verdict: isCommandAvailable returns
     // false ("not installed"), isGhAuthenticated reads an empty payload as
-    // "not authenticated". Refusing here turns a slow distro into a confident
-    // wrong answer -- #9725 through the other door.
+    // "not authenticated". A missing login PATH must therefore never be fatal.
     await runPreflightCommandInWsl({ distro: 'Ubuntu' }, 'gh --version', 5_000)
 
     expect(runWslProcessMock).toHaveBeenCalledWith(
-      expect.objectContaining({ allowDegradedEnvironment: true, distro: 'Ubuntu' })
+      expect.objectContaining({ loginPath: 'preferred', distro: 'Ubuntu' })
     )
   })
 

--- a/src/main/ipc/preflight-wsl-command.test.ts
+++ b/src/main/ipc/preflight-wsl-command.test.ts
@@ -55,12 +55,16 @@ describe('the PATH fallback, run by a real POSIX shell', () => {
   itPosix('finds an nvm-installed CLI a degraded probe would have missed', async () => {
     // #9725: the caller turns a throw into "not installed", so a degraded probe
     // told the user to install a CLI their own terminal already runs.
+    //
+    // A fabricated name, not `gh`: CI has a real /usr/bin/gh, and the fallback
+    // APPENDS, so the PATH lookup correctly found the real one and the planted
+    // stub was never reached. The test was asserting the host, not the code.
     const home = mkdtempSync(join(tmpdir(), 'orca-wsl-cmd-'))
     try {
       const bin = join(home, '.nvm/versions/node/v20.1.0/bin')
       mkdirSync(bin, { recursive: true })
-      writeFileSync(join(bin, 'gh'), '#!/bin/sh\necho gh-ok\n')
-      chmodSync(join(bin, 'gh'), 0o755)
+      writeFileSync(join(bin, 'orca-fake-cli'), '#!/bin/sh\necho cli-ok\n')
+      chmodSync(join(bin, 'orca-fake-cli'), 0o755)
 
       runWslProcessMock.mockResolvedValue({
         environmentResolved: false,
@@ -69,14 +73,14 @@ describe('the PATH fallback, run by a real POSIX shell', () => {
         stderr: '',
         timedOut: false
       })
-      await runPreflightCommandInWsl({ distro: 'Ubuntu' }, 'command -v gh', 5000)
+      await runPreflightCommandInWsl({ distro: 'Ubuntu' }, 'command -v orca-fake-cli', 5000)
       const script = String(runWslProcessMock.mock.calls.at(-1)?.[0].script)
       const options: ExecFileSyncOptions = {
         encoding: 'utf8',
         env: { HOME: home, PATH: '/usr/bin:/bin' }
       }
       expect(String(execFileSync('/bin/sh', ['-c', script], options))).toContain(
-        '.nvm/versions/node/v20.1.0/bin/gh'
+        '.nvm/versions/node/v20.1.0/bin/orca-fake-cli'
       )
     } finally {
       rmSync(home, { recursive: true, force: true })
@@ -92,8 +96,8 @@ describe('the PATH fallback, run by a real POSIX shell', () => {
         [real, 'current']
       ] as const) {
         mkdirSync(dir, { recursive: true })
-        writeFileSync(join(dir, 'gh'), `#!/bin/sh\necho ${body}\n`)
-        chmodSync(join(dir, 'gh'), 0o755)
+        writeFileSync(join(dir, 'orca-fake-cli'), `#!/bin/sh\necho ${body}\n`)
+        chmodSync(join(dir, 'orca-fake-cli'), 0o755)
       }
       runWslProcessMock.mockResolvedValue({
         environmentResolved: true,
@@ -102,7 +106,7 @@ describe('the PATH fallback, run by a real POSIX shell', () => {
         stderr: '',
         timedOut: false
       })
-      await runPreflightCommandInWsl({ distro: 'Ubuntu' }, 'gh', 5000)
+      await runPreflightCommandInWsl({ distro: 'Ubuntu' }, 'orca-fake-cli', 5000)
       const script = String(runWslProcessMock.mock.calls.at(-1)?.[0].script)
       const options: ExecFileSyncOptions = {
         encoding: 'utf8',

--- a/src/main/ipc/preflight-wsl-command.ts
+++ b/src/main/ipc/preflight-wsl-command.ts
@@ -12,13 +12,8 @@ export async function runPreflightCommandInWsl(
   // with no shell in the loop, so there is no rc/motd banner to strip.
   const result = await runWslProcess({
     distro: target.distro,
-    lane: 'probe',
+    loginPath: 'preferred',
     script: command,
-    // Why degrade: every caller collapses a throw into "not installed" or
-    // "not authenticated" (isCommandAvailable, isGhAuthenticated). Refusing
-    // here turns a slow distro into a confident wrong answer -- #9725 through
-    // the other door, on the branch built to close it.
-    allowDegradedEnvironment: true,
     timeoutMs
   })
   // runWslProcess resolves on a timeout and on a non-zero exit; the caller's

--- a/src/main/ipc/preflight-wsl-command.ts
+++ b/src/main/ipc/preflight-wsl-command.ts
@@ -1,3 +1,4 @@
+import { buildPosixFallbackPathPrelude } from '../../shared/posix-version-manager-bin-dirs'
 import { runWslProcess } from '../wsl/wsl-runner'
 import type { WslPreflightTarget } from './preflight-wsl-agent-detection'
 
@@ -13,7 +14,10 @@ export async function runPreflightCommandInWsl(
   const result = await runWslProcess({
     distro: target.distro,
     loginPath: 'preferred',
-    script: command,
+    // Appending the version-manager dirs keeps a resolved login PATH
+    // authoritative while stopping a degraded probe from turning an installed
+    // CLI into "not installed" (#9725), the same fallback the native branch has.
+    script: `${buildPosixFallbackPathPrelude()}\n${command}`,
     timeoutMs
   })
   // runWslProcess resolves on a timeout and on a non-zero exit; the caller's

--- a/src/main/rate-limits/gemini-cli-oauth-extractor.ts
+++ b/src/main/rate-limits/gemini-cli-oauth-extractor.ts
@@ -1,10 +1,10 @@
-import { exec } from 'node:child_process'
+import { execFile } from 'node:child_process'
 import { access, readdir, readFile, realpath } from 'node:fs/promises'
 import { promisify } from 'node:util'
 import { homedir } from 'node:os'
 import path from 'node:path'
 
-const execAsync = promisify(exec)
+const execFileAsync = promisify(execFile)
 
 async function fileExists(filePath: string): Promise<boolean> {
   try {
@@ -19,10 +19,16 @@ async function fileExists(filePath: string): Promise<boolean> {
 const OAUTH2_SUBPATH = path.join('dist', 'src', 'code_assist', 'oauth2.js')
 
 async function resolveGeminiBinary(): Promise<string | null> {
-  const whichCmd = process.platform === 'win32' ? 'where gemini' : 'which gemini'
+  const [lookup, args] =
+    process.platform === 'win32' ? ['where.exe', ['gemini']] : ['which', ['gemini']]
   try {
-    // `where` is console-subsystem; without this it flashes a conhost (#10488).
-    const { stdout } = await execAsync(whichCmd, { encoding: 'utf-8', windowsHide: true })
+    // execFile, not exec: `exec` implies `shell: true`, which silently makes
+    // windowsHide a no-op (see run-process.ts, #14543), so the console-subsystem
+    // `where` would still flash a conhost (#10488).
+    const { stdout } = await execFileAsync(lookup, args, {
+      encoding: 'utf-8',
+      windowsHide: true
+    })
     const fromPath = stdout.trim().split(/\r?\n/)[0]
     if (fromPath && (await fileExists(fromPath))) {
       return fromPath

--- a/src/main/rate-limits/gemini-cli-oauth-extractor.ts
+++ b/src/main/rate-limits/gemini-cli-oauth-extractor.ts
@@ -21,7 +21,8 @@ const OAUTH2_SUBPATH = path.join('dist', 'src', 'code_assist', 'oauth2.js')
 async function resolveGeminiBinary(): Promise<string | null> {
   const whichCmd = process.platform === 'win32' ? 'where gemini' : 'which gemini'
   try {
-    const { stdout } = await execAsync(whichCmd, { encoding: 'utf-8' })
+    // `where` is console-subsystem; without this it flashes a conhost (#10488).
+    const { stdout } = await execAsync(whichCmd, { encoding: 'utf-8', windowsHide: true })
     const fromPath = stdout.trim().split(/\r?\n/)[0]
     if (fromPath && (await fileExists(fromPath))) {
       return fromPath

--- a/src/main/skills/claude-plugin-skill-sources-wsl.ts
+++ b/src/main/skills/claude-plugin-skill-sources-wsl.ts
@@ -61,7 +61,9 @@ async function executeWslMetadataRead(distro: string, script: string): Promise<s
   // quietly change its interpreter.
   const result = await runWslProcess({
     distro,
-    loginPath: 'preferred',
+    // 'none': base64/printf/stat over $HOME paths. The probe would spend up
+    // to 4s of a 5s budget before the read of a file up to 4MB begins.
+    loginPath: 'none',
     script,
     shell: 'bash',
 

--- a/src/main/skills/claude-plugin-skill-sources-wsl.ts
+++ b/src/main/skills/claude-plugin-skill-sources-wsl.ts
@@ -61,9 +61,7 @@ async function executeWslMetadataRead(distro: string, script: string): Promise<s
   // quietly change its interpreter.
   const result = await runWslProcess({
     distro,
-    lane: 'probe',
-    // Degrade rather than refuse: a metadata read; no login PATH involved.
-    allowDegradedEnvironment: true,
+    loginPath: 'preferred',
     script,
     shell: 'bash',
 

--- a/src/main/skills/skill-discovery-wsl.ts
+++ b/src/main/skills/skill-discovery-wsl.ts
@@ -57,7 +57,8 @@ async function executeWslSkillDiscovery(distro: string, script: string): Promise
   // dash rejects with `Syntax error: word unexpected` (#14292).
   const result = await runWslProcess({
     distro,
-    loginPath: 'preferred',
+    // 'none': find/base64/head/printf/stat over $HOME roots, no bare tool.
+    loginPath: 'none',
     script,
     shell: 'bash',
 

--- a/src/main/skills/skill-discovery-wsl.ts
+++ b/src/main/skills/skill-discovery-wsl.ts
@@ -57,9 +57,7 @@ async function executeWslSkillDiscovery(distro: string, script: string): Promise
   // dash rejects with `Syntax error: word unexpected` (#14292).
   const result = await runWslProcess({
     distro,
-    lane: 'probe',
-    // Degrade rather than refuse: the scan reads the filesystem; it never needed the login PATH.
-    allowDegradedEnvironment: true,
+    loginPath: 'preferred',
     script,
     shell: 'bash',
 

--- a/src/main/skills/skill-provider-runtime-roots.ts
+++ b/src/main/skills/skill-provider-runtime-roots.ts
@@ -50,9 +50,7 @@ type WslEnvironmentProbe = (distro: string) => Promise<string>
 async function probeWslGrokHome(distro: string): Promise<string> {
   const result = await runWslProcess({
     distro,
-    lane: 'probe',
-    // Degrade rather than refuse: reads $HOME, which wsl.exe supplies without a login shell.
-    allowDegradedEnvironment: true,
+    loginPath: 'preferred',
     script: WSL_GROK_HOME_SCRIPT,
     timeoutMs: WSL_ENV_PROBE_TIMEOUT_MS,
     maxOutputBytes: WSL_ENV_PROBE_MAX_BYTES

--- a/src/main/skills/skill-provider-runtime-roots.ts
+++ b/src/main/skills/skill-provider-runtime-roots.ts
@@ -55,6 +55,8 @@ async function probeWslGrokHome(distro: string): Promise<string> {
     // the 8s budget before the -lc that actually reads GROK_HOME starts.
     loginPath: 'none',
     script: WSL_GROK_HOME_SCRIPT,
+    // POSIX (`case`, `exec`); declared because the payload is opaque here.
+    shell: 'sh',
     timeoutMs: WSL_ENV_PROBE_TIMEOUT_MS,
     maxOutputBytes: WSL_ENV_PROBE_MAX_BYTES
   })

--- a/src/main/skills/skill-provider-runtime-roots.ts
+++ b/src/main/skills/skill-provider-runtime-roots.ts
@@ -50,7 +50,10 @@ type WslEnvironmentProbe = (distro: string) => Promise<string>
 async function probeWslGrokHome(distro: string): Promise<string> {
   const result = await runWslProcess({
     distro,
-    loginPath: 'preferred',
+    // 'none': the script runs its own `"$login_shell" -lc`, so asking the
+    // runner to probe first buys a second login shell and spends up to half
+    // the 8s budget before the -lc that actually reads GROK_HOME starts.
+    loginPath: 'none',
     script: WSL_GROK_HOME_SCRIPT,
     timeoutMs: WSL_ENV_PROBE_TIMEOUT_MS,
     maxOutputBytes: WSL_ENV_PROBE_MAX_BYTES

--- a/src/main/skills/skill-wsl-install-filesystem.ts
+++ b/src/main/skills/skill-wsl-install-filesystem.ts
@@ -213,9 +213,7 @@ export class WslSkillInstallFilesystem implements SkillInstallFilesystem {
   private async runOutput(script: string, args: string[]): Promise<string> {
     const result = await runWslProcess({
       distro: this.distro,
-      lane: 'probe',
-      // Degrade rather than refuse: mkdir/mv/chmod on the default PATH; no login shell before.
-      allowDegradedEnvironment: true,
+      loginPath: 'none',
       script,
       args,
       timeoutMs: GUEST_COMMAND_TIMEOUT_MS,

--- a/src/main/skills/skill-wsl-install-filesystem.ts
+++ b/src/main/skills/skill-wsl-install-filesystem.ts
@@ -215,6 +215,8 @@ export class WslSkillInstallFilesystem implements SkillInstallFilesystem {
       distro: this.distro,
       loginPath: 'none',
       script,
+      // POSIX file operations; declared because the payload is opaque here.
+      shell: 'sh',
       args,
       timeoutMs: GUEST_COMMAND_TIMEOUT_MS,
       maxOutputBytes: GUEST_COMMAND_MAX_OUTPUT_BYTES

--- a/src/main/skills/skill-wsl-provider-detection.test.ts
+++ b/src/main/skills/skill-wsl-provider-detection.test.ts
@@ -5,7 +5,7 @@ vi.mock('../wsl/wsl-runner', () => ({ runWslProcess: runWslProcessMock }))
 
 import { detectSkillProvidersInWsl } from './skill-wsl-provider-detection'
 
-type RunWslProcessSpec = { distro: string; lane: string; script: string }
+type RunWslProcessSpec = { distro: string; loginPath: string; script: string }
 
 describe('detectSkillProvidersInWsl', () => {
   beforeEach(() => {
@@ -16,7 +16,7 @@ describe('detectSkillProvidersInWsl', () => {
     vi.restoreAllMocks()
   })
 
-  it('runs on the probe lane so a PATH-only install (nvm/mise) is still found (regression)', async () => {
+  it('asks for the login PATH so a nvm/mise-only install is still found (regression)', async () => {
     // Before this migration the site ran `sh -c` with no login shell, so an
     // nvm-installed codex/claude -- reachable only through the PATH a login
     // shell assembles from rc files -- resolved to nothing via `command -v`
@@ -32,7 +32,7 @@ describe('detectSkillProvidersInWsl', () => {
     const found = await detectSkillProvidersInWsl('Ubuntu')
 
     const [spec] = runWslProcessMock.mock.calls.at(-1) as [RunWslProcessSpec]
-    expect(spec.lane).toBe('probe')
+    expect(spec.loginPath).toBe('preferred')
     expect(spec.distro).toBe('Ubuntu')
     expect(found).toEqual(['codex'])
   })

--- a/src/main/skills/skill-wsl-provider-detection.test.ts
+++ b/src/main/skills/skill-wsl-provider-detection.test.ts
@@ -65,6 +65,31 @@ describe('detectSkillProvidersInWsl', () => {
     expect(found).toEqual(['codex'])
   })
 
+  it.each([
+    ['reports unverifiable rather than empty', '', true],
+    ['still trusts a genuine empty result', '', false]
+  ])('%s', async (_case, stdout, unresolved) => {
+    // The script ends in `|| true`, so "ran without the login PATH" and "no
+    // providers installed" are the same exit 0 with the same empty stdout.
+    // Callers skip the ~/.codex and ~/.claude skill roots on an empty list, so
+    // conflating them loses an nvm-installed provider's skills (#9725).
+    runWslProcessMock.mockResolvedValue({
+      environmentResolved: !unresolved,
+      code: 0,
+      stdout,
+      stderr: '',
+      timedOut: false
+    })
+
+    if (unresolved) {
+      await expect(detectSkillProvidersInWsl('Ubuntu')).rejects.toThrow(
+        'skill-install-wsl-provider-detection-failed'
+      )
+    } else {
+      await expect(detectSkillProvidersInWsl('Ubuntu')).resolves.toEqual([])
+    }
+  })
+
   it('rejects when wsl.exe cannot be started', async () => {
     runWslProcessMock.mockRejectedValue(new Error('spawn wsl.exe ENOENT'))
 

--- a/src/main/skills/skill-wsl-provider-detection.test.ts
+++ b/src/main/skills/skill-wsl-provider-detection.test.ts
@@ -67,6 +67,7 @@ describe('detectSkillProvidersInWsl', () => {
 
   it.each([
     ['reports unverifiable rather than empty', '', true],
+    ['reports unverifiable even on a partial hit', 'claude\n', true],
     ['still trusts a genuine empty result', '', false]
   ])('%s', async (_case, stdout, unresolved) => {
     // The script ends in `|| true`, so "ran without the login PATH" and "no
@@ -86,7 +87,9 @@ describe('detectSkillProvidersInWsl', () => {
         'skill-install-wsl-provider-detection-failed'
       )
     } else {
-      await expect(detectSkillProvidersInWsl('Ubuntu')).resolves.toEqual([])
+      await expect(detectSkillProvidersInWsl('Ubuntu')).resolves.toEqual(
+        stdout.trim() ? ['claude'] : []
+      )
     }
   })
 

--- a/src/main/skills/skill-wsl-provider-detection.test.ts
+++ b/src/main/skills/skill-wsl-provider-detection.test.ts
@@ -82,15 +82,13 @@ describe('detectSkillProvidersInWsl', () => {
       timedOut: false
     })
 
-    if (unresolved) {
-      await expect(detectSkillProvidersInWsl('Ubuntu')).rejects.toThrow(
-        'skill-install-wsl-provider-detection-failed'
-      )
-    } else {
-      await expect(detectSkillProvidersInWsl('Ubuntu')).resolves.toEqual(
-        stdout.trim() ? ['claude'] : []
-      )
-    }
+    await (unresolved
+      ? expect(detectSkillProvidersInWsl('Ubuntu')).rejects.toThrow(
+          'skill-install-wsl-provider-detection-failed'
+        )
+      : expect(detectSkillProvidersInWsl('Ubuntu')).resolves.toEqual(
+          stdout.trim() ? ['claude'] : []
+        ))
   })
 
   it('rejects when wsl.exe cannot be started', async () => {

--- a/src/main/skills/skill-wsl-provider-detection.ts
+++ b/src/main/skills/skill-wsl-provider-detection.ts
@@ -23,7 +23,15 @@ export async function detectSkillProvidersInWsl(distro: string): Promise<string[
   if (result.code !== 0) {
     throw new Error('skill-install-wsl-provider-detection-failed')
   }
-  return result.stdout
+  const providers = result.stdout
     .split(/\r?\n/u)
     .filter((provider) => provider === 'codex' || provider === 'claude')
+  // The script ends in `|| true`, so a lookup that ran without the login PATH
+  // exits 0 with nothing found -- identical to a genuine empty result. Callers
+  // skip the ~/.codex and ~/.claude skill roots on an empty list, so an
+  // nvm-installed provider would silently lose its skills (#9725).
+  if (providers.length === 0 && !result.environmentResolved) {
+    throw new Error('skill-install-wsl-provider-detection-failed')
+  }
+  return providers
 }

--- a/src/main/skills/skill-wsl-provider-detection.ts
+++ b/src/main/skills/skill-wsl-provider-detection.ts
@@ -23,15 +23,15 @@ export async function detectSkillProvidersInWsl(distro: string): Promise<string[
   if (result.code !== 0) {
     throw new Error('skill-install-wsl-provider-detection-failed')
   }
-  const providers = result.stdout
-    .split(/\r?\n/u)
-    .filter((provider) => provider === 'codex' || provider === 'claude')
-  // The script ends in `|| true`, so a lookup that ran without the login PATH
-  // exits 0 with nothing found -- identical to a genuine empty result. Callers
-  // skip the ~/.codex and ~/.claude skill roots on an empty list, so an
-  // nvm-installed provider would silently lose its skills (#9725).
-  if (providers.length === 0 && !result.environmentResolved) {
+  // Unconditional, not just on an empty list: the script ends in `|| true`, so
+  // without the login PATH each lookup independently reads absent. A `claude`
+  // on the default PATH via Windows interop plus an nvm-only `codex` returns a
+  // plausible-looking `['claude']`, and the caller then skips the ~/.codex
+  // skill roots for a provider that is installed (#9725).
+  if (!result.environmentResolved) {
     throw new Error('skill-install-wsl-provider-detection-failed')
   }
-  return providers
+  return result.stdout
+    .split(/\r?\n/u)
+    .filter((provider) => provider === 'codex' || provider === 'claude')
 }

--- a/src/main/skills/skill-wsl-provider-detection.ts
+++ b/src/main/skills/skill-wsl-provider-detection.ts
@@ -13,7 +13,7 @@ export async function detectSkillProvidersInWsl(distro: string): Promise<string[
     // rc files never applies and an installed codex/claude reads as absent.
     result = await runWslProcess({
       distro,
-      lane: 'probe',
+      loginPath: 'preferred',
       script: DETECTION_SCRIPT,
       timeoutMs: 10_000
     })

--- a/src/main/skills/skill-wsl-provider-detection.ts
+++ b/src/main/skills/skill-wsl-provider-detection.ts
@@ -15,6 +15,8 @@ export async function detectSkillProvidersInWsl(distro: string): Promise<string[
       distro,
       loginPath: 'preferred',
       script: DETECTION_SCRIPT,
+      // POSIX `command -v` loop; declared because the payload is opaque here.
+      shell: 'sh',
       timeoutMs: 10_000
     })
   } catch {

--- a/src/main/wsl-fish-history-cleanup.test.ts
+++ b/src/main/wsl-fish-history-cleanup.test.ts
@@ -26,7 +26,7 @@ describe('deleteWslFishHistoryFile', () => {
 
     expect(run).toHaveBeenCalledWith({
       distro: 'Ubuntu Test',
-      loginPath: 'none',
+      loginPath: 'preferred',
       program: 'fish',
       args: ['--command', expect.stringContaining('orca_0123456789abcdef_history')],
       timeoutMs: 5_000

--- a/src/main/wsl-fish-history-cleanup.test.ts
+++ b/src/main/wsl-fish-history-cleanup.test.ts
@@ -73,7 +73,10 @@ describe('deleteWslFishHistoryFile', () => {
   })
 
   it('permits a retry once a failed cleanup settles', async () => {
-    const run = vi.fn().mockRejectedValueOnce(new Error('distro offline')).mockResolvedValue(okResult)
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('distro offline'))
+      .mockResolvedValue(okResult)
     const session = 'orca_0123456789abcdef'
 
     await expect(deleteWslFishHistoryFile('Ubuntu', session, run)).rejects.toThrow('distro offline')
@@ -84,16 +87,16 @@ describe('deleteWslFishHistoryFile', () => {
   it('treats a non-zero exit as a failed cleanup even though the runner resolved', async () => {
     const run = vi.fn().mockResolvedValue({ ...okResult, code: 1 })
 
-    await expect(
-      deleteWslFishHistoryFile('Ubuntu', 'orca_0123456789abcdef', run)
-    ).rejects.toThrow('wsl fish history cleanup failed')
+    await expect(deleteWslFishHistoryFile('Ubuntu', 'orca_0123456789abcdef', run)).rejects.toThrow(
+      'wsl fish history cleanup failed'
+    )
   })
 
   it('treats a runner timeout as a failed cleanup', async () => {
     const run = vi.fn().mockResolvedValue({ ...okResult, code: null, timedOut: true })
 
-    await expect(
-      deleteWslFishHistoryFile('Ubuntu', 'orca_0123456789abcdef', run)
-    ).rejects.toThrow('wsl fish history cleanup failed')
+    await expect(deleteWslFishHistoryFile('Ubuntu', 'orca_0123456789abcdef', run)).rejects.toThrow(
+      'wsl fish history cleanup failed'
+    )
   })
 })

--- a/src/main/wsl-fish-history-cleanup.test.ts
+++ b/src/main/wsl-fish-history-cleanup.test.ts
@@ -26,8 +26,7 @@ describe('deleteWslFishHistoryFile', () => {
 
     expect(run).toHaveBeenCalledWith({
       distro: 'Ubuntu Test',
-      lane: 'probe',
-      allowDegradedEnvironment: true,
+      loginPath: 'none',
       program: 'fish',
       args: ['--command', expect.stringContaining('orca_0123456789abcdef_history')],
       timeoutMs: 5_000

--- a/src/main/wsl-fish-history-cleanup.ts
+++ b/src/main/wsl-fish-history-cleanup.ts
@@ -50,11 +50,8 @@ async function runCleanup(
 ): Promise<void> {
   const result = await run({
     distro,
-    lane: 'probe',
+    loginPath: 'none',
     // The old `--exec fish` spawn never sourced a login shell either, so a
-    // probe failure must run degraded rather than turn a working cleanup into
-    // an error.
-    allowDegradedEnvironment: true,
     program: 'fish',
     args: ['--command', fishCleanupScript(session)],
     timeoutMs: 5_000

--- a/src/main/wsl-fish-history-cleanup.ts
+++ b/src/main/wsl-fish-history-cleanup.ts
@@ -50,8 +50,12 @@ async function runCleanup(
 ): Promise<void> {
   const result = await run({
     distro,
-    loginPath: 'none',
-    // The old `--exec fish` spawn never sourced a login shell either, so a
+    // 'preferred', not 'none': `fish` is a bare name, so it is a PATH lookup.
+    // A fish from linuxbrew or nix lives only on the login PATH, and without it
+    // this throws on a distro where the cleanup would have worked. The probe
+    // failing is still fine -- the old `--exec fish` spawn sourced no login
+    // shell either, so running on the default PATH is no worse than before.
+    loginPath: 'preferred',
     program: 'fish',
     args: ['--command', fishCleanupScript(session)],
     timeoutMs: 5_000

--- a/src/main/wsl/__fixtures__/wsl-invocation-allowlist.txt
+++ b/src/main/wsl/__fixtures__/wsl-invocation-allowlist.txt
@@ -1,11 +1,12 @@
+# Files that spawn wsl.exe directly instead of through src/main/wsl/wsl-runner.ts.
 #
 # Enforced by ../wsl-invocation-boundary.test.ts. This list only shrinks -- its
-# express because it always prepends --exec.
-# Files that spawn wsl.exe directly instead of through src/main/wsl/wsl-runner.ts.
-# host-level flag like --status / --list that the guest-command API cannot
 # length is the W3 goalpost.
+#
 # Remaining entries need a runner mode that does not exist: a long-lived
 # streaming child (OAuth logins, the hook relay), a synchronous caller, or a
+# host-level flag like --status / --list that the guest-command API cannot
+# express because it always prepends --exec.
 main/agent-hooks/wsl-hook-relay-launch.ts
 main/claude-accounts/service.ts
 main/codex-accounts/runtime-home-service.ts

--- a/src/main/wsl/__fixtures__/wsl-invocation-allowlist.txt
+++ b/src/main/wsl/__fixtures__/wsl-invocation-allowlist.txt
@@ -1,11 +1,11 @@
-# Files that spawn wsl.exe directly instead of through src/main/wsl/wsl-runner.ts.
-# Enforced by ../wsl-invocation-boundary.test.ts. This list only shrinks -- its
-# length is the W3 goalpost.
 #
+# Enforced by ../wsl-invocation-boundary.test.ts. This list only shrinks -- its
+# express because it always prepends --exec.
+# Files that spawn wsl.exe directly instead of through src/main/wsl/wsl-runner.ts.
+# host-level flag like --status / --list that the guest-command API cannot
+# length is the W3 goalpost.
 # Remaining entries need a runner mode that does not exist: a long-lived
 # streaming child (OAuth logins, the hook relay), a synchronous caller, or a
-# host-level flag like --status / --list that the guest-command API cannot
-# express because it always prepends --exec.
 main/agent-hooks/wsl-hook-relay-launch.ts
 main/claude-accounts/service.ts
 main/codex-accounts/runtime-home-service.ts
@@ -13,10 +13,13 @@ main/codex-accounts/service.ts
 main/codex/codex-state-db-backfill-recovery.ts
 main/codex/codex-trust-grant-host.ts
 main/codex/codex-wsl-hook-install-plan.ts
+main/daemon/pty-subprocess.ts
 main/git/runner.ts
 main/git/wsl-git-read-environment.ts
 main/ipc/filesystem-watcher-wsl.ts
 main/local-worktree-filesystem.ts
+main/providers/local-pty-provider.ts
+main/rate-limits/claude-pty.ts
 main/rate-limits/codex-fetcher.ts
 main/wsl-availability.ts
 main/wsl-unc-delete.ts

--- a/src/main/wsl/__fixtures__/wsl-invocation-allowlist.txt
+++ b/src/main/wsl/__fixtures__/wsl-invocation-allowlist.txt
@@ -1,7 +1,14 @@
 # Files that spawn wsl.exe directly instead of through src/main/wsl/wsl-runner.ts.
 #
-# Enforced by ../wsl-invocation-boundary.test.ts. This list only shrinks -- its
-# length is the W3 goalpost.
+# Enforced by ../wsl-invocation-boundary.test.ts. This list only shrinks for a
+# MIGRATION -- its length is the W3 goalpost.
+#
+# It may grow when the scanner learns to see a spawn it was blind to. That has
+# happened once: pty-subprocess.ts, local-pty-provider.ts and claude-pty.ts
+# bind 'wsl.exe' to a variable and spawn it later, which the old neighbourhood
+# scan could not follow. They were recorded in a prose comment instead, so the
+# count was wrong by three in the direction that hides offenders. Adding them
+# is the guard getting honest, not the boundary regressing.
 #
 # Remaining entries need a runner mode that does not exist: a long-lived
 # streaming child (OAuth logins, the hook relay), a synchronous caller, or a

--- a/src/main/wsl/wsl-guest-environment.ts
+++ b/src/main/wsl/wsl-guest-environment.ts
@@ -87,6 +87,10 @@ async function probeGuestEnvironment(
   const result = await runProcess({
     program: resolveWslExecutablePath(),
     args: buildWslExecArgs(distro, ['sh', '-c', captured.command]),
+    // The runner sets this for every command it launches (#9010); the probe
+    // spawns wsl.exe itself, so without it wsl.exe's own errors arrive UTF-16LE
+    // and the NUL-separated payload below is read through NUL-riddled text.
+    env: { ...process.env, WSL_UTF8: '1' },
     timeoutMs: Math.min(PROBE_TIMEOUT_MS, budgetMs),
     maxOutputBytes: PROBE_MAX_OUTPUT_BYTES
   })

--- a/src/main/wsl/wsl-invocation-boundary.test.ts
+++ b/src/main/wsl/wsl-invocation-boundary.test.ts
@@ -307,7 +307,7 @@ describe('bash-only payloads declare their interpreter', () => {
     // pattern removes only the first match, so two identically-written pinned
     // calls would leave one behind, and a body that also occurs earlier as a
     // substring would blank the wrong region.
-    const pinnedRanges: Array<[number, number]> = [
+    const pinnedRanges: [number, number][] = [
       ...calls.filter(({ text }) => text.includes("shell: 'bash'")).map(({ start, end }): [number, number] => [start, end]),
       ...[...source.matchAll(/'bash',\s*\n?\s*'-lc',[\s\S]{0,4000}?\n\s*\]/g)].map(
         (m): [number, number] => [m.index, m.index + m[0].length]

--- a/src/main/wsl/wsl-invocation-boundary.test.ts
+++ b/src/main/wsl/wsl-invocation-boundary.test.ts
@@ -200,17 +200,23 @@ const BASHISM =
 function collectRunnerCallArguments(source: string): string[] {
   const blanked = blankStringContents(source)
   const calls: string[] = []
-  for (const match of blanked.matchAll(/\brunWslProcess\s*\(/g)) {
-    const open = blanked.indexOf('{', match.index)
-    if (open === -1) {
-      continue
-    }
+  const callees = new Set(['runWslProcess'])
+  for (const alias of source.matchAll(/\brunWslProcess\s+as\s+(\w+)/g)) {
+    callees.add(alias[1]!)
+  }
+  const callPattern = new RegExp(`\\b(?:${[...callees].join('|')})\\s*\\(`, 'g')
+  for (const match of blanked.matchAll(callPattern)) {
+    // The WHOLE argument list, not the first `{...}`: with
+    // `Object.assign({ loginPath }, { script })` the payload sits in the second
+    // literal, and stopping at the first one collected an object with no
+    // script and no bashism -- which reads exactly like a clean call.
+    const open = match.index + match[0].length - 1
     let depth = 0
     for (let index = open; index < blanked.length; index += 1) {
       const char = blanked[index]
-      if (char === '{') {
+      if (char === '(') {
         depth += 1
-      } else if (char === '}') {
+      } else if (char === ')') {
         depth -= 1
         if (depth === 0) {
           calls.push(source.slice(open, index + 1))
@@ -251,25 +257,37 @@ describe('bash-only payloads declare their interpreter', () => {
       offenders.push(relativePath)
       continue
     }
-    // An opaque payload must declare its interpreter.
+    // An opaque payload is judged by the whole file, minus anything already
+    // declared bash.
     //
-    // The real bash payloads are built in a separate function and handed over
-    // as a bare `script,` identifier, so the bashism is never inside the call
-    // and the per-call arm cannot see it. Replacing the file-wide check with
-    // the per-call one made deleting `shell: 'bash'` from skill-discovery-wsl
-    // -- `done < <(find ...)` and `read -r -d ''`, the #14292 signature --
-    // ship green. Reading through the identifier is guesswork; requiring the
-    // call to say `sh` or `bash` when the payload is not a literal is not.
-    // Visible means `script:` followed by a literal the BASHISM regex can read.
-    // Everything else -- `script,` shorthand, an identifier, a builder call --
-    // is opaque and must say which shell it wants.
-    const opaque = calls.filter(
-      (call) =>
-        /\bscript\b/.test(call) &&
-        !/\bscript\s*:\s*['"`[]/.test(call) &&
-        !/\bshell\s*:/.test(call)
-    )
-    if (opaque.length > 0) {
+    // Requiring merely that `shell:` be PRESENT was strictly weaker than the
+    // file-wide rule it replaced: `shell: 'sh'` on a bash payload shipped
+    // green, which is #14292 with extra steps. Resolving the identifier is
+    // guesswork, so instead: strip the text of every call that already names
+    // bash, and if a bashism survives anywhere in the file while a
+    // script-carrying call is not bash-pinned, flag it.
+    //
+    // Stripping the bash-pinned calls is what keeps codex-accounts/service.ts
+    // clean -- it pins bash on four inline payloads and on a `bash -lc`
+    // execFileSync, and correctly leaves its printf/mkdir calls unpinned.
+    const bashPinned = [
+      ...calls.filter((call) => call.includes("shell: 'bash'")),
+      ...[...source.matchAll(/'bash',\s*\n?\s*'-lc',[\s\S]{0,4000}?\n\s*\]/g)].map((m) => m[0])
+    ]
+    const unpinnedRegion = bashPinned.reduce((rest, text) => rest.replace(text, ''), source)
+    // A spread hides every key, `script` and `shell` alike, so it has to count
+    // as carrying a script -- otherwise `runWslProcess({ ...spec })` is a hole
+    // the file-wide arm never looks at.
+    const scriptCalls = calls.filter((call) => /\bscript\b/.test(call) || /\.\.\./.test(call))
+    // Zero collected calls is not zero risk: `Object.assign({...}, {script})`
+    // puts the payload in the second literal, and a renamed callee that the
+    // alias scan misses collects nothing at all. If the file carries a bashism
+    // and the guard cannot see any call object, that is unreadable, not clean.
+    const unreadable = calls.length === 0
+    if (
+      BASHISM.test(unpinnedRegion) &&
+      (unreadable || scriptCalls.some((call) => !call.includes("shell: 'bash'")))
+    ) {
       offenders.push(relativePath)
     }
   }

--- a/src/main/wsl/wsl-invocation-boundary.test.ts
+++ b/src/main/wsl/wsl-invocation-boundary.test.ts
@@ -45,28 +45,19 @@ const IGNORED = new Set(['node_modules', 'dist', 'out', 'build', '.git', '__fixt
  *
  * Any identifier followed by `(` counts as an opener, and the assignment-style
  * fields are matched by name. Indirection through a variable
- * (`const f = cond ? 'wsl.exe' : x`) is still invisible; those files are listed
- * explicitly below so the gap is recorded rather than implied.
+ * (`const f = cond ? 'wsl.exe' : x`) is caught separately, by
+ * `bindsWslBinaryToASpawnedIdentifier`.
  */
 const SPAWN_OPENER = /\b[A-Za-z_$][\w$]*\s*\(\s*$|(?:program|binary|command|file|shellPath):\s*$/
 
 /*
- * Known blind spot, recorded rather than implied: these files assign
- * `'wsl.exe'` to a variable and spawn it elsewhere, which no regex over the
- * literal's neighbourhood can see. They are NOT in the allowlist, because the
- * stale-entry check would reject an entry the scanner cannot find -- so the
- * guard's count under-reports by these five, and this comment is the record.
- *
- *   main/rate-limits/claude-pty.ts
- *   main/providers/local-pty-provider.ts
- *   main/daemon/pty-subprocess.ts
- *   relay/pty-shell-launch.ts
- *   relay/pty-handler.ts
- *
- * All five are PTY-pane launches, which are out of W3's scope anyway: they go
- * through node-pty, not a child-process wrapper.
+ * The five files this comment used to list as an unscannable blind spot are
+ * now handled: three bind `wsl.exe` to a variable and spawn it, and are real
+ * allowlist entries; the other two never spawned it at all -- one compares a
+ * basename, one lists it among accepted shells. Recording a gap in prose was
+ * worse than it looked, because the count is the goalpost and it was wrong by
+ * three in the direction that hides offenders.
  */
-
 function isTestFile(path: string): boolean {
   return (
     /\.(?:test|spec)\.tsx?$/.test(path) ||
@@ -92,6 +83,46 @@ function collectSourceFiles(root: string): string[] {
   return found
 }
 
+/**
+ * `const binary = 'wsl.exe'` ... `spawn(binary)`, which no test over the
+ * literal's neighbourhood can see.
+ *
+ * Why it earns its place: the neighbourhood test was the whole guard, and a
+ * planted `const p = 'wsl.exe'; spawnProcess(p)` passed it. Five files were
+ * already known to spawn this way and were recorded in a comment instead of
+ * the allowlist, which means the count -- the actual goalpost -- was wrong by
+ * five and any NEW indirect spawner would have been invisible.
+ */
+function bindsWslBinaryToASpawnedIdentifier(source: string): boolean {
+  const bound = new Set<string>()
+  // Covers `const x = 'wsl.exe'`, a ternary picking it, and `binary: 'wsl.exe'`.
+  for (const match of source.matchAll(
+    /(?:const|let|var)\s+([A-Za-z_$][\w$]*)[^=;\n]*=[^;\n]*['"]wsl\.exe['"]/g
+  )) {
+    bound.add(match[1]!)
+  }
+  for (const match of source.matchAll(
+    /\b([A-Za-z_$][\w$]*)\s*:\s*[^,;\n]*['"]wsl\.exe['"]/g
+  )) {
+    bound.add(match[1]!)
+  }
+  for (const name of bound) {
+    const identifier = name.replace(/[$]/g, '\\$&')
+    // The identifier reaching a call opener, a spawn-style field, or the first
+    // argument of a spawn-style call.
+    if (
+      new RegExp(`\\b${identifier}\\s*\\(`).test(source) ||
+      new RegExp(`(?:program|binary|command|file|shellPath)\\s*:\\s*${identifier}\\b`).test(
+        source
+      ) ||
+      new RegExp(`\\b\\w*(?:spawn|exec|run)\\w*\\s*\\(\\s*${identifier}\\b`, 'i').test(source)
+    ) {
+      return true
+    }
+  }
+  return false
+}
+
 function findSpawnSites(): string[] {
   const offenders = new Set<string>()
   for (const path of collectSourceFiles(SOURCE_ROOT)) {
@@ -107,6 +138,9 @@ function findSpawnSites(): string[] {
       if (SPAWN_OPENER.test(preceding.replace(/\s+/g, ' ').replace(/ $/, ''))) {
         offenders.add(relativePath)
       }
+    }
+    if (bindsWslBinaryToASpawnedIdentifier(source)) {
+      offenders.add(relativePath)
     }
   }
   return [...offenders].sort()

--- a/src/main/wsl/wsl-invocation-boundary.test.ts
+++ b/src/main/wsl/wsl-invocation-boundary.test.ts
@@ -245,11 +245,32 @@ describe('bash-only payloads declare their interpreter', () => {
       offenders.push(relativePath)
       continue
     }
-    for (const call of collectRunnerCallArguments(source)) {
-      if (BASHISM.test(call) && !call.includes("shell: 'bash'")) {
-        offenders.push(relativePath)
-        break
-      }
+    const calls = collectRunnerCallArguments(source)
+    // Per-call: an unpinned payload sitting beside a pinned one.
+    if (calls.some((call) => BASHISM.test(call) && !call.includes("shell: 'bash'"))) {
+      offenders.push(relativePath)
+      continue
+    }
+    // An opaque payload must declare its interpreter.
+    //
+    // The real bash payloads are built in a separate function and handed over
+    // as a bare `script,` identifier, so the bashism is never inside the call
+    // and the per-call arm cannot see it. Replacing the file-wide check with
+    // the per-call one made deleting `shell: 'bash'` from skill-discovery-wsl
+    // -- `done < <(find ...)` and `read -r -d ''`, the #14292 signature --
+    // ship green. Reading through the identifier is guesswork; requiring the
+    // call to say `sh` or `bash` when the payload is not a literal is not.
+    // Visible means `script:` followed by a literal the BASHISM regex can read.
+    // Everything else -- `script,` shorthand, an identifier, a builder call --
+    // is opaque and must say which shell it wants.
+    const opaque = calls.filter(
+      (call) =>
+        /\bscript\b/.test(call) &&
+        !/\bscript\s*:\s*['"`[]/.test(call) &&
+        !/\bshell\s*:/.test(call)
+    )
+    if (opaque.length > 0) {
+      offenders.push(relativePath)
     }
   }
 

--- a/src/main/wsl/wsl-invocation-boundary.test.ts
+++ b/src/main/wsl/wsl-invocation-boundary.test.ts
@@ -96,13 +96,15 @@ function collectSourceFiles(root: string): string[] {
 function bindsWslBinaryToASpawnedIdentifier(source: string): boolean {
   const bound = new Set<string>()
   // Covers `const x = 'wsl.exe'`, a ternary picking it, and `binary: 'wsl.exe'`.
+  // `const x =`, and the class-field spellings (`private readonly x =`). `[^=]`
+  // rather than `[^=;\n]` so a Prettier-wrapped ternary still binds.
   for (const match of source.matchAll(
-    /(?:const|let|var)\s+([A-Za-z_$][\w$]*)[^=;\n]*=[^;\n]*['"]wsl\.exe['"]/g
+    /(?:(?:const|let|var|readonly|private|public|protected|static)\s+)+([A-Za-z_$][\w$]*)[^=\n]*=[^;]{0,200}?['"`]wsl\.exe['"`]/g
   )) {
     bound.add(match[1]!)
   }
   for (const match of source.matchAll(
-    /\b([A-Za-z_$][\w$]*)\s*:\s*[^,;\n]*['"]wsl\.exe['"]/g
+    /\b([A-Za-z_$][\w$]*)\s*:\s*[^,;\n]*['"`]wsl\.exe['"`]/g
   )) {
     bound.add(match[1]!)
   }
@@ -112,10 +114,13 @@ function bindsWslBinaryToASpawnedIdentifier(source: string): boolean {
     // argument of a spawn-style call.
     if (
       new RegExp(`\\b${identifier}\\s*\\(`).test(source) ||
-      new RegExp(`(?:program|binary|command|file|shellPath)\\s*:\\s*${identifier}\\b`).test(
+      new RegExp(
+        `(?:program|binary|command|file|shellPath)\\s*:\\s*(?:this\\.)?${identifier}\\b`
+      ).test(source) ||
+      // `this.` so a class field reaching `spawnProcess(this.binary)` counts.
+      new RegExp(`\\b\\w*(?:spawn|exec|run)\\w*\\s*\\(\\s*(?:this\\.)?${identifier}\\b`, 'i').test(
         source
-      ) ||
-      new RegExp(`\\b\\w*(?:spawn|exec|run)\\w*\\s*\\(\\s*${identifier}\\b`, 'i').test(source)
+      )
     ) {
       return true
     }
@@ -131,7 +136,7 @@ function findSpawnSites(): string[] {
       continue
     }
     const source = readFileSync(path, 'utf8')
-    for (const match of source.matchAll(/['"]wsl\.exe['"]/g)) {
+    for (const match of source.matchAll(/['"`]wsl\.exe['"`]/g)) {
       // Collapse the preceding whitespace so a call broken across lines by the
       // formatter still reads as one opener.
       const preceding = source.slice(Math.max(0, match.index - 60), match.index)

--- a/src/main/wsl/wsl-invocation-boundary.test.ts
+++ b/src/main/wsl/wsl-invocation-boundary.test.ts
@@ -259,6 +259,37 @@ describe('bash-only payloads declare their interpreter', () => {
       offenders.push(relativePath)
       continue
     }
+    // Anything that is not a plain object literal is judged unreadable, and an
+    // unreadable call must pin bash.
+    //
+    // Six review rounds of widening this regex produced more evasions -- a
+    // ternary with one pinned branch, an `as` assertion carrying the pin,
+    // `Object.assign` -- because a regex cannot tell which object a key
+    // belongs to. So stop guessing: a ternary, a spread or an assertion makes
+    // the call opaque, and opacity requires the pin rather than excusing it.
+    //
+    // A nested CALL is deliberately not exotic: `script: \`x ${shellQuote(p)}\``
+    // is the ordinary way every payload here is built, and flagging it would
+    // demand `shell: 'bash'` on POSIX payloads that must not have it.
+    // A ternary only makes the call opaque when it CHOOSES the spec, i.e. it
+    // sits before the first `{`. One inside the object picks a script line and
+    // is both common and harmless (claude-accounts/service.ts:977).
+    const isExotic = (text: string): boolean => {
+      const body = text.replace(/^\(/, '')
+      const firstBrace = body.indexOf('{')
+      const prefix = firstBrace === -1 ? body : body.slice(0, firstBrace)
+      return /\?[^.:]|\.\.\./.test(prefix) || /\bas\s+[A-Za-z{]/.test(body)
+    }
+    // No `includes("shell: 'bash'")` escape here: in `cond ? {pinned} : {not}`
+    // the pin belongs to one branch and the substring test cannot tell which,
+    // so a pinned branch excused an unpinned one. An exotic call therefore
+    // cannot be excused -- write it as a plain object literal instead.
+    if (
+      calls.some(({ text }) => isExotic(text)) && BASHISM.test(source)
+    ) {
+      offenders.push(relativePath)
+      continue
+    }
     // An opaque payload is judged by the whole file, minus anything already
     // declared bash.
     //

--- a/src/main/wsl/wsl-invocation-boundary.test.ts
+++ b/src/main/wsl/wsl-invocation-boundary.test.ts
@@ -108,9 +108,12 @@ function bindsWslBinaryToASpawnedIdentifier(source: string): boolean {
   )) {
     bound.add(match[1]!)
   }
-  // `this.binary = 'wsl.exe'` -- an assignment with no declarator keyword.
+  // Assignment with no declarator: `this.binary = 'wsl.exe'`, and the split
+  // form `let shellPath: string` ... `shellPath = 'wsl.exe'`, which a
+  // declarator-anchored pattern cannot see. `[^;]{0,200}?` so a wrapped
+  // right-hand side still binds.
   for (const match of source.matchAll(
-    /\bthis\.([A-Za-z_$][\w$]*)\s*=[^;\n]*['"`]wsl\.exe['"`]/g
+    /(?:\bthis\.)?([A-Za-z_$][\w$]*)\s*=[^=][^;]{0,200}?['"`]wsl\.exe['"`]/g
   )) {
     bound.add(match[1]!)
   }

--- a/src/main/wsl/wsl-invocation-boundary.test.ts
+++ b/src/main/wsl/wsl-invocation-boundary.test.ts
@@ -1,7 +1,11 @@
 import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join, relative, resolve } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { stripComments } from '../../shared/source-scan/source-tree-scan'
+import {
+  blankStringContents,
+  blankStringContentsDesynced,
+  stripComments
+} from '../../shared/source-scan/source-tree-scan'
 
 /**
  * Every `wsl.exe` spawn must go through `runWslProcess`.
@@ -124,6 +128,43 @@ function findSpawnSites(): string[] {
 const BASHISM =
   /<\s*<\(|\[\[|\blocal\s+\w+=|\bdeclare\s+-|\bmapfile\b|set\s+-[a-z]*o[a-z]*\s+pipefail|set\s+-euo\b|read\s+(?:-\w+\s+)*-d\b|<<</
 
+/**
+ * The argument object of every `runWslProcess(` call in a file.
+ *
+ * Why per-call and not per-file: a file-wide `shell: 'bash'` check passes as
+ * soon as ANY call in the file pins bash, so an unpinned dash payload added
+ * beside a pinned one is invisible -- planted in `codex-accounts/service.ts`
+ * and the guard stayed green. That is the #14292 signature shipping again.
+ *
+ * Braces are matched on string-blanked source so a `}` inside a script literal
+ * cannot close the object early; offsets survive blanking, so the slice is
+ * taken from the real source and the payload is still readable.
+ */
+function collectRunnerCallArguments(source: string): string[] {
+  const blanked = blankStringContents(source)
+  const calls: string[] = []
+  for (const match of blanked.matchAll(/\brunWslProcess\s*\(/g)) {
+    const open = blanked.indexOf('{', match.index)
+    if (open === -1) {
+      continue
+    }
+    let depth = 0
+    for (let index = open; index < blanked.length; index += 1) {
+      const char = blanked[index]
+      if (char === '{') {
+        depth += 1
+      } else if (char === '}') {
+        depth -= 1
+        if (depth === 0) {
+          calls.push(source.slice(open, index + 1))
+          break
+        }
+      }
+    }
+  }
+  return calls
+}
+
 describe('bash-only payloads declare their interpreter', () => {
   const offenders: string[] = []
   for (const path of collectSourceFiles(SOURCE_ROOT)) {
@@ -136,11 +177,22 @@ describe('bash-only payloads declare their interpreter', () => {
     // pipefail` to explain why it was removed would otherwise flag the file,
     // and a bash script written to a guest file is not a runner payload.
     const source = stripComments(readFileSync(path, 'utf8'))
-    if (!source.includes('runWslProcess') || !BASHISM.test(source)) {
+    if (!source.includes('runWslProcess')) {
       continue
     }
-    if (!source.includes("shell: 'bash'")) {
+    // Fail closed. A desynced lexer finds zero calls, and "zero calls" is
+    // indistinguishable from "zero violations" -- this guard passed a planted
+    // dash payload for exactly that reason, because one regex literal earlier
+    // in the file had inverted the scan.
+    if (blankStringContentsDesynced(source)) {
       offenders.push(relativePath)
+      continue
+    }
+    for (const call of collectRunnerCallArguments(source)) {
+      if (BASHISM.test(call) && !call.includes("shell: 'bash'")) {
+        offenders.push(relativePath)
+        break
+      }
     }
   }
 

--- a/src/main/wsl/wsl-invocation-boundary.test.ts
+++ b/src/main/wsl/wsl-invocation-boundary.test.ts
@@ -103,9 +103,7 @@ function bindsWslBinaryToASpawnedIdentifier(source: string): boolean {
   )) {
     bound.add(match[1]!)
   }
-  for (const match of source.matchAll(
-    /\b([A-Za-z_$][\w$]*)\s*:\s*[^,;\n]*['"`]wsl\.exe['"`]/g
-  )) {
+  for (const match of source.matchAll(/\b([A-Za-z_$][\w$]*)\s*:\s*[^,;\n]*['"`]wsl\.exe['"`]/g)) {
     bound.add(match[1]!)
   }
   // Assignment with no declarator: `this.binary = 'wsl.exe'`, and the split
@@ -120,10 +118,7 @@ function bindsWslBinaryToASpawnedIdentifier(source: string): boolean {
   // A helper that hands back the binary is a spawn site one hop away, and the
   // hop is untrackable by regex -- but only when this file also spawns
   // something. Returning the name as terminal metadata is not a spawn.
-  if (
-    /\breturn\s+['"`]wsl\.exe['"`]/.test(source) &&
-    /\b\w*(?:spawn|exec)\w*\s*\(/i.test(source)
-  ) {
+  if (/\breturn\s+['"`]wsl\.exe['"`]/.test(source) && /\b\w*(?:spawn|exec)\w*\s*\(/i.test(source)) {
     return true
   }
   for (const name of bound) {
@@ -284,9 +279,7 @@ describe('bash-only payloads declare their interpreter', () => {
     // the pin belongs to one branch and the substring test cannot tell which,
     // so a pinned branch excused an unpinned one. An exotic call therefore
     // cannot be excused -- write it as a plain object literal instead.
-    if (
-      calls.some(({ text }) => isExotic(text)) && BASHISM.test(source)
-    ) {
+    if (calls.some(({ text }) => isExotic(text)) && BASHISM.test(source)) {
       offenders.push(relativePath)
       continue
     }
@@ -308,7 +301,9 @@ describe('bash-only payloads declare their interpreter', () => {
     // calls would leave one behind, and a body that also occurs earlier as a
     // substring would blank the wrong region.
     const pinnedRanges: [number, number][] = [
-      ...calls.filter(({ text }) => text.includes("shell: 'bash'")).map(({ start, end }): [number, number] => [start, end]),
+      ...calls
+        .filter(({ text }) => text.includes("shell: 'bash'"))
+        .map(({ start, end }): [number, number] => [start, end]),
       ...[...source.matchAll(/'bash',\s*\n?\s*'-lc',[\s\S]{0,4000}?\n\s*\]/g)].map(
         (m): [number, number] => [m.index, m.index + m[0].length]
       )
@@ -323,9 +318,7 @@ describe('bash-only payloads declare their interpreter', () => {
     // A spread hides every key, `script` and `shell` alike, so it has to count
     // as carrying a script -- otherwise `runWslProcess({ ...spec })` is a hole
     // the file-wide arm never looks at.
-    const scriptCalls = calls.filter(
-      ({ text }) => /\bscript\b/.test(text) || /\.\.\./.test(text)
-    )
+    const scriptCalls = calls.filter(({ text }) => /\bscript\b/.test(text) || /\.\.\./.test(text))
     // Zero collected calls is not zero risk: `Object.assign({...}, {script})`
     // puts the payload in the second literal, and a renamed callee that the
     // alias scan misses collects nothing at all. If the file carries a bashism
@@ -346,7 +339,6 @@ describe('bash-only payloads declare their interpreter', () => {
 
 describe('wsl.exe is spawned through one runner', () => {
   const offenders = findSpawnSites()
-
 
   it('still detects a known spawn shape', () => {
     // Why name a specific file rather than assert a total: `offenders.length +

--- a/src/main/wsl/wsl-invocation-boundary.test.ts
+++ b/src/main/wsl/wsl-invocation-boundary.test.ts
@@ -108,6 +108,21 @@ function bindsWslBinaryToASpawnedIdentifier(source: string): boolean {
   )) {
     bound.add(match[1]!)
   }
+  // `this.binary = 'wsl.exe'` -- an assignment with no declarator keyword.
+  for (const match of source.matchAll(
+    /\bthis\.([A-Za-z_$][\w$]*)\s*=[^;\n]*['"`]wsl\.exe['"`]/g
+  )) {
+    bound.add(match[1]!)
+  }
+  // A helper that hands back the binary is a spawn site one hop away, and the
+  // hop is untrackable by regex -- but only when this file also spawns
+  // something. Returning the name as terminal metadata is not a spawn.
+  if (
+    /\breturn\s+['"`]wsl\.exe['"`]/.test(source) &&
+    /\b\w*(?:spawn|exec)\w*\s*\(/i.test(source)
+  ) {
+    return true
+  }
   for (const name of bound) {
     const identifier = name.replace(/[$]/g, '\\$&')
     // The identifier reaching a call opener, a spawn-style field, or the first

--- a/src/main/wsl/wsl-invocation-boundary.test.ts
+++ b/src/main/wsl/wsl-invocation-boundary.test.ts
@@ -197,9 +197,11 @@ const BASHISM =
  * cannot close the object early; offsets survive blanking, so the slice is
  * taken from the real source and the payload is still readable.
  */
-function collectRunnerCallArguments(source: string): string[] {
+type CallRange = { text: string; start: number; end: number }
+
+function collectRunnerCallArguments(source: string): CallRange[] {
   const blanked = blankStringContents(source)
-  const calls: string[] = []
+  const calls: CallRange[] = []
   const callees = new Set(['runWslProcess'])
   for (const alias of source.matchAll(/\brunWslProcess\s+as\s+(\w+)/g)) {
     callees.add(alias[1]!)
@@ -219,7 +221,7 @@ function collectRunnerCallArguments(source: string): string[] {
       } else if (char === ')') {
         depth -= 1
         if (depth === 0) {
-          calls.push(source.slice(open, index + 1))
+          calls.push({ text: source.slice(open, index + 1), start: open, end: index + 1 })
           break
         }
       }
@@ -253,7 +255,7 @@ describe('bash-only payloads declare their interpreter', () => {
     }
     const calls = collectRunnerCallArguments(source)
     // Per-call: an unpinned payload sitting beside a pinned one.
-    if (calls.some((call) => BASHISM.test(call) && !call.includes("shell: 'bash'"))) {
+    if (calls.some(({ text }) => BASHISM.test(text) && !text.includes("shell: 'bash'"))) {
       offenders.push(relativePath)
       continue
     }
@@ -270,15 +272,29 @@ describe('bash-only payloads declare their interpreter', () => {
     // Stripping the bash-pinned calls is what keeps codex-accounts/service.ts
     // clean -- it pins bash on four inline payloads and on a `bash -lc`
     // execFileSync, and correctly leaves its printf/mkdir calls unpinned.
-    const bashPinned = [
-      ...calls.filter((call) => call.includes("shell: 'bash'")),
-      ...[...source.matchAll(/'bash',\s*\n?\s*'-lc',[\s\S]{0,4000}?\n\s*\]/g)].map((m) => m[0])
+    // Masked by POSITION, not by String.replace: replace() with a string
+    // pattern removes only the first match, so two identically-written pinned
+    // calls would leave one behind, and a body that also occurs earlier as a
+    // substring would blank the wrong region.
+    const pinnedRanges: Array<[number, number]> = [
+      ...calls.filter(({ text }) => text.includes("shell: 'bash'")).map(({ start, end }): [number, number] => [start, end]),
+      ...[...source.matchAll(/'bash',\s*\n?\s*'-lc',[\s\S]{0,4000}?\n\s*\]/g)].map(
+        (m): [number, number] => [m.index, m.index + m[0].length]
+      )
     ]
-    const unpinnedRegion = bashPinned.reduce((rest, text) => rest.replace(text, ''), source)
+    const masked = source.split('')
+    for (const [from, to] of pinnedRanges) {
+      for (let index = from; index < to; index += 1) {
+        masked[index] = ' '
+      }
+    }
+    const unpinnedRegion = masked.join('')
     // A spread hides every key, `script` and `shell` alike, so it has to count
     // as carrying a script -- otherwise `runWslProcess({ ...spec })` is a hole
     // the file-wide arm never looks at.
-    const scriptCalls = calls.filter((call) => /\bscript\b/.test(call) || /\.\.\./.test(call))
+    const scriptCalls = calls.filter(
+      ({ text }) => /\bscript\b/.test(text) || /\.\.\./.test(text)
+    )
     // Zero collected calls is not zero risk: `Object.assign({...}, {script})`
     // puts the payload in the second literal, and a renamed callee that the
     // alias scan misses collects nothing at all. If the file carries a bashism
@@ -286,7 +302,7 @@ describe('bash-only payloads declare their interpreter', () => {
     const unreadable = calls.length === 0
     if (
       BASHISM.test(unpinnedRegion) &&
-      (unreadable || scriptCalls.some((call) => !call.includes("shell: 'bash'")))
+      (unreadable || scriptCalls.some(({ text }) => !text.includes("shell: 'bash'")))
     ) {
       offenders.push(relativePath)
     }

--- a/src/main/wsl/wsl-runner.test.ts
+++ b/src/main/wsl/wsl-runner.test.ts
@@ -54,16 +54,19 @@ afterEach(() => {
 })
 
 describe('separator', () => {
-  it.each([['none'], ['preferred']] as const)('uses --exec and never -- with loginPath %s', async (lane) => {
-    // Why this is pinned on both lanes: under `--`, wsl.exe expands $name in
-    // every forwarded argument before the guest runs -- even with no shell in
-    // the command -- so a script means something other than what it says
-    // (#12964). No escaping on our side is a reliable substitute.
-    seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
-    await runWslProcess({ loginPath: lane, program: '/usr/bin/git', args: ['status'] })
-    expect(lastArgv()).toContain('--exec')
-    expect(lastArgv()).not.toContain('--')
-  })
+  it.each([['none'], ['preferred']] as const)(
+    'uses --exec and never -- with loginPath %s',
+    async (lane) => {
+      // Why this is pinned on both lanes: under `--`, wsl.exe expands $name in
+      // every forwarded argument before the guest runs -- even with no shell in
+      // the command -- so a script means something other than what it says
+      // (#12964). No escaping on our side is a reliable substitute.
+      seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
+      await runWslProcess({ loginPath: lane, program: '/usr/bin/git', args: ['status'] })
+      expect(lastArgv()).toContain('--exec')
+      expect(lastArgv()).not.toContain('--')
+    }
+  )
 
   it('passes the distro before --exec', async () => {
     seedWslGuestEnvironmentForTests('Ubuntu', ENVIRONMENT)
@@ -135,7 +138,6 @@ describe('scripts', () => {
     ])
   })
 
-
   it('leaves stdin free so a stdin-reading command cannot truncate the script', async () => {
     // The regression this pins: with the script piped, `ssh -T` in a user hook
     // drains the pipe, bash reads EOF, exits 0, and every later line of the
@@ -150,7 +152,6 @@ describe('scripts', () => {
     expect(spec.input).toBeUndefined()
     expect(spec.args).toContain('ssh -T git@github.com || true\npnpm install')
   })
-
 
   it('falls back to stdin for a script too large for a command line', async () => {
     // A user hook is the one unbounded script here (`run-both` concatenates two
@@ -231,9 +232,9 @@ describe('guest cwd', () => {
     // A Windows path here means a mistake further up; converting it silently
     // hides that.
     seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
-    await expect(runWslProcess({ loginPath: 'preferred', program: '/bin/true', cwd })).rejects.toThrow(
-      /guest path/
-    )
+    await expect(
+      runWslProcess({ loginPath: 'preferred', program: '/bin/true', cwd })
+    ).rejects.toThrow(/guest path/)
   })
 })
 
@@ -241,7 +242,9 @@ describe('program is a binary, not a shell string', () => {
   it.each([['sh -c echo hi'], ['a; b'], ['a | b'], ['a && b'], ['echo $HOME'], ['a > b']])(
     'rejects %s',
     async (program) => {
-      await expect(runWslProcess({ loginPath: 'preferred', program })).rejects.toThrow(/single binary/)
+      await expect(runWslProcess({ loginPath: 'preferred', program })).rejects.toThrow(
+        /single binary/
+      )
     }
   )
 
@@ -289,12 +292,12 @@ describe('the probe never starves the command', () => {
     // ~1667ms -- less than the 5s it had before the runner existed, which is
     // how a cold distro came back as "not installed".
     // No seed: the probe must actually run, or this measures the command leg
-    // and passes for any split. allowDegradedEnvironment keeps the call alive
-    // once the probe fails.
+    // and passes for any split. A failed probe is non-fatal now, so the call
+    // still reaches its command.
     await runWslProcess({
       loginPath: 'preferred',
       program: '/bin/true',
-      timeoutMs,
+      timeoutMs
     })
     const probeMs = runProcessMock.mock.calls[0]?.[0].timeoutMs as number
     expect(probeMs).toBeLessThanOrEqual(timeoutMs - floor)

--- a/src/main/wsl/wsl-runner.test.ts
+++ b/src/main/wsl/wsl-runner.test.ts
@@ -151,6 +151,27 @@ describe('scripts', () => {
     expect(spec.args).toContain('ssh -T git@github.com || true\npnpm install')
   })
 
+
+  it('falls back to stdin for a script too large for a command line', async () => {
+    // A user hook is the one unbounded script here (`run-both` concatenates two
+    // orca.yaml scripts, and a vendored installer is ~15KB). Windows caps the
+    // command line at 32767, so argv would fail to spawn at all; stdin still
+    // runs it, which is the lesser loss.
+    seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
+    const script = `echo ${'x'.repeat(9_000)}`
+    await runWslProcess({ loginPath: 'preferred', shell: 'bash', script })
+    const spec = runProcessMock.mock.calls.at(-1)?.[0]
+    expect(spec.input).toBe(script)
+    expect(lastArgv().slice(-3)).toEqual(['bash', '-s', '--'])
+  })
+
+  it('keeps an ordinary-sized script in argv', async () => {
+    seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
+    const script = `echo ${'x'.repeat(100)}`
+    await runWslProcess({ loginPath: 'preferred', shell: 'bash', script })
+    expect(runProcessMock.mock.calls.at(-1)?.[0].input).toBeUndefined()
+  })
+
   it('pipes the script only when the caller asks for stdin delivery', async () => {
     seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
     const script = 'echo big'

--- a/src/main/wsl/wsl-runner.test.ts
+++ b/src/main/wsl/wsl-runner.test.ts
@@ -54,23 +54,20 @@ afterEach(() => {
 })
 
 describe('separator', () => {
-  it.each([
-    ['probe', 'probe'],
-    ['interactive', 'interactive']
-  ] as const)('uses --exec and never -- on the %s lane', async (_name, lane) => {
+  it.each([['none'], ['preferred']] as const)('uses --exec and never -- with loginPath %s', async (lane) => {
     // Why this is pinned on both lanes: under `--`, wsl.exe expands $name in
     // every forwarded argument before the guest runs -- even with no shell in
     // the command -- so a script means something other than what it says
     // (#12964). No escaping on our side is a reliable substitute.
     seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
-    await runWslProcess({ lane, program: '/usr/bin/git', args: ['status'] })
+    await runWslProcess({ loginPath: lane, program: '/usr/bin/git', args: ['status'] })
     expect(lastArgv()).toContain('--exec')
     expect(lastArgv()).not.toContain('--')
   })
 
   it('passes the distro before --exec', async () => {
     seedWslGuestEnvironmentForTests('Ubuntu', ENVIRONMENT)
-    await runWslProcess({ lane: 'probe', distro: 'Ubuntu', program: '/bin/true' })
+    await runWslProcess({ loginPath: 'preferred', distro: 'Ubuntu', program: '/bin/true' })
     expect(lastArgv().slice(0, 3)).toEqual(['-d', 'Ubuntu', '--exec'])
   })
 })
@@ -80,7 +77,7 @@ describe('probe lane', () => {
     // The whole point: the user's real PATH without paying for -- or being
     // blocked by -- a login shell on every call (#14288, #9768).
     seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
-    await runWslProcess({ lane: 'probe', program: 'codex', args: ['--version'] })
+    await runWslProcess({ loginPath: 'preferred', program: 'codex', args: ['--version'] })
     expect(lastArgv()).toEqual([
       '--exec',
       '/usr/bin/env',
@@ -91,64 +88,27 @@ describe('probe lane', () => {
     ])
   })
 
-  it('reports an unresolved environment rather than pretending the PATH is real', async () => {
-    // Falling back to the login shell here would re-run ~/.profile -- the very
-    // stall the probe lane exists to avoid, and most likely to bite exactly
-    // when the probe just failed. So the call proceeds on the default PATH and
-    // says so, and callers deciding "installed?" must treat that as unknown.
-    let call = 0
-    runProcessMock.mockImplementation(async (spec: { args: string[] }) => {
-      call += 1
-      if (call === 1) {
-        return { environmentResolved: true, code: 1, signal: null, stdout: '', stderr: 'stopped', timedOut: false }
-      }
-      const script = spec.args.at(-1) ?? ''
-      const begin = /__ORCA_WSL_CAPTURE_BEGIN_[a-z0-9]+__/.exec(script)?.[0] ?? ''
-      const end = /__ORCA_WSL_CAPTURE_END_[a-z0-9]+__/.exec(script)?.[0] ?? ''
-      return { environmentResolved: true, code: 0, signal: null, stdout: `${begin}${end}`, stderr: '', timedOut: false }
+  it('runs anyway and says the PATH is unresolved', async () => {
+    // A missing login PATH used to throw, and every knob this runner carried --
+    // cooldown tiers, budget splitting, a re-probe heuristic, an opt-out on 19
+    // of 23 sites -- existed to work around that. It is now just a fact in the
+    // result.
+    runProcessMock.mockResolvedValue({
+      code: 1,
+      signal: null,
+      stdout: '',
+      stderr: 'distro is stopped',
+      timedOut: false
     })
-    // Default is to refuse: answering "is codex installed?" on the bare default
-    // PATH reports an nvm install as absent, which is #9725.
-    await expect(runWslProcess({ lane: 'probe', program: 'codex' })).rejects.toThrow(
-      /guest environment/
-    )
-
-    const degraded = await runWslProcess({
-      lane: 'probe',
-      program: 'codex',
-      allowDegradedEnvironment: true
-    })
-    expect(degraded.environmentResolved).toBe(false)
+    const result = await runWslProcess({ loginPath: 'preferred', program: 'codex' })
+    expect(result.environmentResolved).toBe(false)
     expect(lastArgv()).toEqual(['--exec', 'codex'])
   })
 
   it('reports a resolved environment on the happy path', async () => {
     seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
-    const result = await runWslProcess({ lane: 'probe', program: 'codex' })
+    const result = await runWslProcess({ loginPath: 'preferred', program: 'codex' })
     expect(result.environmentResolved).toBe(true)
-  })
-})
-
-describe('interactive lane', () => {
-  it('always fences stdout, even when the caller ignores it', async () => {
-    // Stock Ubuntu writes its rc hint to stdout, so an unfenced parse reads the
-    // banner as data (#11327, #11823). A caller that starts parsing later must
-    // not have to remember to opt in.
-    runProcessMock.mockImplementation(async (spec: { args: string[] }) => {
-      const script = spec.args.at(-1) ?? ''
-      const begin = /__ORCA_WSL_CAPTURE_BEGIN_[a-z0-9]+__/.exec(script)?.[0] ?? ''
-      const end = /__ORCA_WSL_CAPTURE_END_[a-z0-9]+__/.exec(script)?.[0] ?? ''
-      return {
-        environmentResolved: true,
-        code: 0,
-        signal: null,
-        stdout: `Ubuntu banner: run a command as administrator\n${begin}payload${end}`,
-        stderr: '',
-        timedOut: false
-      }
-    })
-    const result = await runWslProcess({ lane: 'interactive', program: 'claude' })
-    expect(result.stdout).toBe('payload')
   })
 })
 
@@ -159,7 +119,7 @@ describe('scripts', () => {
     // (#14292), and why this is the only supported way to run one.
     seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
     const script = `case "$x" in a) echo 'it'\\''s fine';; esac`
-    await runWslProcess({ lane: 'probe', script, args: ['/tmp/root'] })
+    await runWslProcess({ loginPath: 'preferred', script, args: ['/tmp/root'] })
     expect(runProcessMock.mock.calls.at(-1)?.[0].input).toBe(script)
     expect(lastArgv()).toEqual([
       '--exec',
@@ -180,7 +140,7 @@ describe('WSLENV', () => {
     // Unset, a Windows-side variable silently never reaches the guest (#12557).
     seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
     await runWslProcess({
-      lane: 'probe',
+      loginPath: 'preferred',
       program: '/bin/true',
       env: { GITLAB_HOST: 'git.example.com', GH_TOKEN: 't' }
     })
@@ -189,17 +149,27 @@ describe('WSLENV', () => {
     expect(env.WSLENV?.split(':')).toEqual(expect.arrayContaining(['GITLAB_HOST', 'GH_TOKEN']))
   })
 
-  it('leaves the host environment alone when nothing is propagated', async () => {
+  it('always sets WSL_UTF8, even with nothing to propagate', async () => {
+    // Without it wsl.exe writes its own error text as UTF-16LE, so anything
+    // surfacing stderr shows NUL-riddled output (#9010).
     seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
-    await runWslProcess({ lane: 'probe', program: '/bin/true' })
-    expect(runProcessMock.mock.calls.at(-1)?.[0].env).toBeUndefined()
+    await runWslProcess({ loginPath: 'preferred', program: '/bin/true' })
+    const env = runProcessMock.mock.calls.at(-1)?.[0].env as NodeJS.ProcessEnv
+    expect(env.WSL_UTF8).toBe('1')
+  })
+
+  it('adds no WSLENV entry when nothing is propagated', async () => {
+    seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
+    await runWslProcess({ loginPath: 'preferred', program: '/bin/true' })
+    const env = runProcessMock.mock.calls.at(-1)?.[0].env as NodeJS.ProcessEnv
+    expect(env.WSLENV).toBe(process.env.WSLENV)
   })
 })
 
 describe('guest cwd', () => {
   it('cds inside the guest rather than passing a Windows cwd to wsl.exe', async () => {
     seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
-    await runWslProcess({ lane: 'probe', program: '/usr/bin/git', cwd: '/home/u/repo' })
+    await runWslProcess({ loginPath: 'preferred', program: '/usr/bin/git', cwd: '/home/u/repo' })
     expect(runProcessMock.mock.calls.at(-1)?.[0].cwd).toBeUndefined()
     expect(lastArgv()).toContain('/home/u/repo')
     expect(lastArgv()).toContain('sh')
@@ -209,7 +179,7 @@ describe('guest cwd', () => {
     // A Windows path here means a mistake further up; converting it silently
     // hides that.
     seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
-    await expect(runWslProcess({ lane: 'probe', program: '/bin/true', cwd })).rejects.toThrow(
+    await expect(runWslProcess({ loginPath: 'preferred', program: '/bin/true', cwd })).rejects.toThrow(
       /guest path/
     )
   })
@@ -219,7 +189,7 @@ describe('program is a binary, not a shell string', () => {
   it.each([['sh -c echo hi'], ['a; b'], ['a | b'], ['a && b'], ['echo $HOME'], ['a > b']])(
     'rejects %s',
     async (program) => {
-      await expect(runWslProcess({ lane: 'probe', program })).rejects.toThrow(/single binary/)
+      await expect(runWslProcess({ loginPath: 'preferred', program })).rejects.toThrow(/single binary/)
     }
   )
 
@@ -228,46 +198,8 @@ describe('program is a binary, not a shell string', () => {
     // rejecting it would fail legitimate installs under a spaced directory.
     seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
     await expect(
-      runWslProcess({ lane: 'probe', program: '/home/u/my tools/codex' })
+      runWslProcess({ loginPath: 'preferred', program: '/home/u/my tools/codex' })
     ).resolves.toBeDefined()
-  })
-})
-
-describe('a script gets the cached environment on both lanes', () => {
-  it('applies the cached PATH even when the caller asked for interactive', async () => {
-    // A script never runs under the login shell (it owns stdin), so without
-    // this the interactive lane would give a script LESS PATH than the probe
-    // lane -- for a caller that explicitly asked for the user's terminal PATH.
-    seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
-    await runWslProcess({ lane: 'interactive', script: 'command -v codex' })
-    expect(lastArgv()).toEqual([
-      '--exec',
-      '/usr/bin/env',
-      'PATH=/home/u/.nvm/bin:/usr/bin',
-      'HOME=/home/u',
-      'sh',
-      '-s',
-      '--'
-    ])
-  })
-})
-
-describe('a missing fence is a failure, not empty output', () => {
-  it('throws rather than returning a clean empty result', async () => {
-    // readStdout returns null precisely to distinguish "no fence" from "empty
-    // payload". An rc that redirects stdout would otherwise yield a silent
-    // wrong answer.
-    runProcessMock.mockResolvedValue({
-      environmentResolved: true,
-      code: 0,
-      signal: null,
-      stdout: 'banner only, no fence',
-      stderr: '',
-      timedOut: false
-    })
-    await expect(runWslProcess({ lane: 'interactive', program: 'claude' })).rejects.toThrow(
-      /no fenced output/
-    )
   })
 })
 
@@ -276,7 +208,7 @@ describe('program is not an assignment', () => {
     // `env PATH=… HOME=… FOO=bar` has no command left: it prints the whole
     // guest environment and exits 0 -- success, with the environment as stdout.
     seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
-    await expect(runWslProcess({ lane: 'probe', program: 'FOO=bar' })).rejects.toThrow(
+    await expect(runWslProcess({ loginPath: 'preferred', program: 'FOO=bar' })).rejects.toThrow(
       /assignment/
     )
   })
@@ -288,7 +220,7 @@ describe('timeout budget', () => {
     // 5s caller could reach runProcess with 1ms left and report a timeout for a
     // command that would have taken milliseconds.
     seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
-    await runWslProcess({ lane: 'probe', program: '/bin/true', timeoutMs: 5_000 })
+    await runWslProcess({ loginPath: 'preferred', program: '/bin/true', timeoutMs: 5_000 })
     const passed = runProcessMock.mock.calls.at(-1)?.[0].timeoutMs as number
     expect(passed).toBeGreaterThan(1_000)
     expect(passed).toBeLessThanOrEqual(5_000)
@@ -308,10 +240,9 @@ describe('the probe never starves the command', () => {
     // and passes for any split. allowDegradedEnvironment keeps the call alive
     // once the probe fails.
     await runWslProcess({
-      lane: 'probe',
+      loginPath: 'preferred',
       program: '/bin/true',
       timeoutMs,
-      allowDegradedEnvironment: true
     })
     const probeMs = runProcessMock.mock.calls[0]?.[0].timeoutMs as number
     expect(probeMs).toBeLessThanOrEqual(timeoutMs - floor)
@@ -321,7 +252,7 @@ describe('the probe never starves the command', () => {
 describe('script interpreter', () => {
   it('defaults to sh', async () => {
     seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
-    await runWslProcess({ lane: 'probe', script: 'echo hi' })
+    await runWslProcess({ loginPath: 'preferred', script: 'echo hi' })
     expect(lastArgv()).toContain('sh')
     expect(lastArgv()).not.toContain('bash')
   })
@@ -332,7 +263,7 @@ describe('script interpreter', () => {
     // unexpected` -- the #14292 signature -- so a bash caller must be able to
     // say so rather than be silently downgraded.
     seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
-    await runWslProcess({ lane: 'probe', script: 'done < <(find .)', shell: 'bash' })
+    await runWslProcess({ loginPath: 'preferred', script: 'done < <(find .)', shell: 'bash' })
     expect(lastArgv()).toContain('bash')
     expect(lastArgv()).not.toContain('sh')
   })
@@ -351,7 +282,7 @@ describe('a script never rides the interactive lane', () => {
       stderr: 'distro is stopped',
       timedOut: false
     })
-    await runWslProcess({ lane: 'probe', script: 'echo hi', allowDegradedEnvironment: true })
+    await runWslProcess({ loginPath: 'preferred', script: 'echo hi' })
     expect(lastArgv()).toEqual(['--exec', 'sh', '-s', '--'])
     expect(runProcessMock.mock.calls.at(-1)?.[0].input).toBe('echo hi')
   })

--- a/src/main/wsl/wsl-runner.test.ts
+++ b/src/main/wsl/wsl-runner.test.ts
@@ -113,25 +113,56 @@ describe('probe lane', () => {
 })
 
 describe('scripts', () => {
-  it('delivers a script on stdin through sh -s, not in argv', async () => {
-    // A script on stdin has no quoting boundary for its own quotes to escape
-    // from. That is what the base64 and eval wrappers were working around
-    // (#14292), and why this is the only supported way to run one.
+  it('passes a script in argv by default, leaving the command its own stdin', async () => {
+    // A script the runner pipes cannot coexist with a command that reads stdin:
+    // the command drains the rest of the script, the shell hits EOF and exits
+    // 0, and the truncation is silent. argv has no such conflict, and --exec
+    // means no host-side shell re-parses the quotes (#14292).
     seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
     const script = `case "$x" in a) echo 'it'\\''s fine';; esac`
     await runWslProcess({ loginPath: 'preferred', script, args: ['/tmp/root'] })
-    expect(runProcessMock.mock.calls.at(-1)?.[0].input).toBe(script)
+    expect(runProcessMock.mock.calls.at(-1)?.[0].input).toBeUndefined()
     expect(lastArgv()).toEqual([
       '--exec',
       '/usr/bin/env',
       'PATH=/home/u/.nvm/bin:/usr/bin',
       'HOME=/home/u',
       'sh',
-      '-s',
+      '-c',
+      script,
       '--',
       '/tmp/root'
     ])
-    expect(lastArgv().join(' ')).not.toContain('case')
+  })
+
+
+  it('leaves stdin free so a stdin-reading command cannot truncate the script', async () => {
+    // The regression this pins: with the script piped, `ssh -T` in a user hook
+    // drains the pipe, bash reads EOF, exits 0, and every later line of the
+    // hook silently never runs -- while the caller logs success.
+    seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
+    await runWslProcess({
+      loginPath: 'preferred',
+      shell: 'bash',
+      script: 'ssh -T git@github.com || true\npnpm install'
+    })
+    const spec = runProcessMock.mock.calls.at(-1)?.[0]
+    expect(spec.input).toBeUndefined()
+    expect(spec.args).toContain('ssh -T git@github.com || true\npnpm install')
+  })
+
+  it('pipes the script only when the caller asks for stdin delivery', async () => {
+    seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
+    const script = 'echo big'
+    await runWslProcess({
+      loginPath: 'preferred',
+      script,
+      scriptDelivery: 'stdin',
+      args: ['/tmp/root']
+    })
+    expect(runProcessMock.mock.calls.at(-1)?.[0].input).toBe(script)
+    expect(lastArgv().slice(-4)).toEqual(['sh', '-s', '--', '/tmp/root'])
+    expect(lastArgv().join(' ')).not.toContain('echo big')
   })
 })
 
@@ -269,11 +300,11 @@ describe('script interpreter', () => {
   })
 })
 
-describe('a script never rides the interactive lane', () => {
-  it('runs sh -s even when the distro cannot be probed', async () => {
-    // The login shell owns stdin, and the script arrives on stdin. If the shell
-    // consumed it, `sh -s` would read EOF, run nothing and exit 0 -- a silent
-    // wrong answer, worse than the degraded PATH this avoids.
+describe('a script never rides a login shell', () => {
+  it('runs the script shell-free even when the distro cannot be probed', async () => {
+    // No login shell in the way: it would own stdin and could consume it,
+    // leaving the script's shell to read EOF, run nothing and exit 0 -- a
+    // silent wrong answer, worse than the degraded PATH this avoids.
     runProcessMock.mockResolvedValue({
       environmentResolved: true,
       code: 1,
@@ -283,7 +314,7 @@ describe('a script never rides the interactive lane', () => {
       timedOut: false
     })
     await runWslProcess({ loginPath: 'preferred', script: 'echo hi' })
-    expect(lastArgv()).toEqual(['--exec', 'sh', '-s', '--'])
-    expect(runProcessMock.mock.calls.at(-1)?.[0].input).toBe('echo hi')
+    expect(lastArgv()).toEqual(['--exec', 'sh', '-c', 'echo hi', '--'])
+    expect(runProcessMock.mock.calls.at(-1)?.[0].input).toBeUndefined()
   })
 })

--- a/src/main/wsl/wsl-runner.test.ts
+++ b/src/main/wsl/wsl-runner.test.ts
@@ -173,22 +173,6 @@ describe('scripts', () => {
     expect(runProcessMock.mock.calls.at(-1)?.[0].input).toBeUndefined()
   })
 
-  it('pipes the script only when the caller asks for stdin delivery', async () => {
-    seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
-    const script = 'echo big'
-    await runWslProcess({
-      loginPath: 'preferred',
-      script,
-      scriptDelivery: 'stdin',
-      args: ['/tmp/root']
-    })
-    expect(runProcessMock.mock.calls.at(-1)?.[0].input).toBe(script)
-    expect(lastArgv().slice(-4)).toEqual(['sh', '-s', '--', '/tmp/root'])
-    expect(lastArgv().join(' ')).not.toContain('echo big')
-  })
-})
-
-describe('WSLENV', () => {
   it('adds every propagated key so the value actually crosses the boundary', async () => {
     // Unset, a Windows-side variable silently never reaches the guest (#12557).
     seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)

--- a/src/main/wsl/wsl-runner.test.ts
+++ b/src/main/wsl/wsl-runner.test.ts
@@ -326,3 +326,21 @@ describe('a script never rides a login shell', () => {
     expect(runProcessMock.mock.calls.at(-1)?.[0].input).toBeUndefined()
   })
 })
+
+describe('WSLENV', () => {
+  it('never forwards a path-shaped variable', async () => {
+    // wsl.exe translates path-shaped variables between Windows and Linux form,
+    // so naming PATH in WSLENV replaces the guest's own PATH with a translated
+    // Windows one. Silent, and fatal to every lookup that follows.
+    seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
+    await runWslProcess({
+      loginPath: 'none',
+      program: '/bin/true',
+      env: { PATH: 'C:\\bin', HOME: 'C:\\home', GITLAB_HOST: 'git.example.com' }
+    })
+    const wslenv = String(runProcessMock.mock.calls.at(-1)?.[0].env.WSLENV ?? '')
+    expect(wslenv.split(':')).toContain('GITLAB_HOST')
+    expect(wslenv.split(':')).not.toContain('PATH')
+    expect(wslenv.split(':')).not.toContain('HOME')
+  })
+})

--- a/src/main/wsl/wsl-runner.ts
+++ b/src/main/wsl/wsl-runner.ts
@@ -170,6 +170,23 @@ function withGuestCwd(cwd: string | undefined, argv: readonly string[]): string[
   return ['sh', '-c', 'cd "$1" || exit 1; shift; exec "$@"', 'orca-wsl', cwd, ...argv]
 }
 
+/**
+ * Argv is the default, but it has a hard ceiling that stdin does not.
+ *
+ * Windows caps a command line at 32767 characters, and the distro, `--exec`,
+ * the env prefix and the args all share it. A user's `orca.yaml` hook is the
+ * one unbounded script Orca runs -- `run-both` concatenates two of them, and a
+ * vendored installer is ~15KB -- so past this size the choice is between
+ * failing to spawn at all and accepting the stdin caveat. Degrading beats
+ * failing: a large script that also reads stdin was already broken, while a
+ * large script that does not now works where it would have died.
+ */
+const MAX_ARGV_SCRIPT_CHARS = 8_000
+
+function resolveScriptDelivery(spec: WslSpec & { script: string }): 'argv' | 'stdin' {
+  return spec.scriptDelivery ?? (spec.script.length > MAX_ARGV_SCRIPT_CHARS ? 'stdin' : 'argv')
+}
+
 /** `<shell> -c`/`-s` for a script, otherwise the program itself. */
 function guestCommandArgv(spec: WslSpec): string[] {
   if (spec.script === undefined) {
@@ -177,7 +194,7 @@ function guestCommandArgv(spec: WslSpec): string[] {
   }
   const shell = spec.shell ?? 'sh'
   // `--` keeps positional args starting at $1 under both forms.
-  return spec.scriptDelivery === 'stdin'
+  return resolveScriptDelivery({ ...spec, script: spec.script }) === 'stdin'
     ? [shell, '-s', '--', ...(spec.args ?? [])]
     : [shell, '-c', spec.script, '--', ...(spec.args ?? [])]
 }
@@ -232,7 +249,10 @@ export async function runWslProcess(spec: WslSpec): Promise<WslResult> {
     program: resolveWslExecutablePath(),
     args: buildWslExecArgs(spec.distro, argv),
     env: buildHostEnv(spec.env),
-    input: spec.scriptDelivery === 'stdin' ? spec.script : undefined,
+    input:
+      spec.script !== undefined && resolveScriptDelivery({ ...spec, script: spec.script }) === 'stdin'
+        ? spec.script
+        : undefined,
     timeoutMs: remainingMs,
     maxOutputBytes: spec.maxOutputBytes,
     retainOutput: spec.retainOutput

--- a/src/main/wsl/wsl-runner.ts
+++ b/src/main/wsl/wsl-runner.ts
@@ -86,6 +86,8 @@ export type WslSpec = WslCommand & {
   env?: Readonly<Record<string, string>>
   timeoutMs?: number
   maxOutputBytes?: number
+  /** See runProcess: 'tail' keeps the end of an over-long stream. */
+  retainOutput?: 'head' | 'tail'
 }
 
 export type WslResult = {
@@ -232,7 +234,8 @@ export async function runWslProcess(spec: WslSpec): Promise<WslResult> {
     env: buildHostEnv(spec.env),
     input: spec.scriptDelivery === 'stdin' ? spec.script : undefined,
     timeoutMs: remainingMs,
-    maxOutputBytes: spec.maxOutputBytes
+    maxOutputBytes: spec.maxOutputBytes,
+    retainOutput: spec.retainOutput
   })
 
   return {

--- a/src/main/wsl/wsl-runner.ts
+++ b/src/main/wsl/wsl-runner.ts
@@ -187,20 +187,24 @@ function resolveScriptDelivery(spec: WslSpec & { script: string }): 'argv' | 'st
 }
 
 /** `<shell> -c`/`-s` for a script, otherwise the program itself. */
-function guestCommandArgv(spec: WslSpec): string[] {
+function guestCommandArgv(spec: WslSpec, delivery: 'argv' | 'stdin'): string[] {
   if (spec.script === undefined) {
     return [spec.program, ...(spec.args ?? [])]
   }
   const shell = spec.shell ?? 'sh'
   // `--` keeps positional args starting at $1 under both forms.
-  return resolveScriptDelivery({ ...spec, script: spec.script }) === 'stdin'
+  return delivery === 'stdin'
     ? [shell, '-s', '--', ...(spec.args ?? [])]
     : [shell, '-c', spec.script, '--', ...(spec.args ?? [])]
 }
 
 /** Shell-free argv, with the cached environment applied when one is available. */
-function buildGuestArgv(environment: WslGuestEnvironment | null, spec: WslSpec): string[] {
-  const command = guestCommandArgv(spec)
+function buildGuestArgv(
+  environment: WslGuestEnvironment | null,
+  spec: WslSpec,
+  delivery: 'argv' | 'stdin'
+): string[] {
+  const command = guestCommandArgv(spec, delivery)
   const argv = environment
     ? [environment.envBinary, `PATH=${environment.path}`, `HOME=${environment.home}`, ...command]
     : command
@@ -239,7 +243,11 @@ export async function runWslProcess(spec: WslSpec): Promise<WslResult> {
   // the probe most often fails *because* the distro is slow, so the fallback
   // would hit the hazard exactly when it is worst. Run shell-free with the
   // distro's default PATH instead: degraded, never blocking.
-  const argv = buildGuestArgv(environment, spec)
+  // Resolved once: argv shape and stdin payload must agree, and computing it
+  // in both places invites them to drift.
+  const delivery =
+    spec.script === undefined ? 'argv' : resolveScriptDelivery({ ...spec, script: spec.script })
+  const argv = buildGuestArgv(environment, spec, delivery)
 
   // One budget for the whole call: the probe used to run on its own 10s timer
   // ahead of the timed leg, so a 5s caller could wait 15s.
@@ -248,10 +256,7 @@ export async function runWslProcess(spec: WslSpec): Promise<WslResult> {
     program: resolveWslExecutablePath(),
     args: buildWslExecArgs(spec.distro, argv),
     env: buildHostEnv(spec.env),
-    input:
-      spec.script !== undefined && resolveScriptDelivery({ ...spec, script: spec.script }) === 'stdin'
-        ? spec.script
-        : undefined,
+    input: delivery === 'stdin' ? spec.script : undefined,
     timeoutMs: remainingMs,
     maxOutputBytes: spec.maxOutputBytes,
     retainOutput: spec.retainOutput

--- a/src/main/wsl/wsl-runner.ts
+++ b/src/main/wsl/wsl-runner.ts
@@ -1,10 +1,6 @@
 import { addWslEnvKeys } from '../../shared/wsl-env'
 import { runProcess } from '../../shared/child-process/run-process'
-import {
-  buildWslCapturedLoginShellCommand,
-  buildWslExecArgs,
-  quotePosixShell
-} from '../../shared/wsl-login-shell-command'
+import { buildWslExecArgs } from '../../shared/wsl-login-shell-command'
 import { getWslGuestEnvironment, type WslGuestEnvironment } from './wsl-guest-environment'
 import { resolveWslExecutablePath } from './wsl-executable-path'
 
@@ -17,11 +13,20 @@ import { resolveWslExecutablePath } from './wsl-executable-path'
  * docs/reference/wsl-command-execution.md.
  */
 
-export type WslLane =
-  /** No shell. Cached login PATH/HOME, applied via `env`. */
-  | 'probe'
-  /** Login shell, always fenced. For anything whose PATH must match the user's terminal. */
-  | 'interactive'
+/**
+ * How much the call needs the user's login PATH.
+ *
+ * Why one axis and not `lane` + `allowDegradedEnvironment`: 19 of 23 sites
+ * passed the opt-out, and two of them said in comments that they did not want
+ * the login PATH at all -- the flag had become the `'none'` this union was
+ * missing. A required discriminator whose default nobody wants is not a
+ * discriminator.
+ */
+export type WslLoginPath =
+  /** The command reads $HOME or absolute paths only. No probe. */
+  | 'none'
+  /** Use the cached login PATH when there is one; run anyway when there is not. */
+  | 'preferred'
 
 /**
  * What to run: a single binary, or a script.
@@ -53,27 +58,14 @@ export type WslCommand =
 export type WslSpec = WslCommand & {
   /** Undefined selects the distro's default. */
   distro?: string
-  /**
-   * Required, with no default. The wrong lane is the most common WSL defect in
-   * this tree, and a default lets a call site pick it by omission.
-   */
-  lane: WslLane
+  /** Required, with no default: the wrong answer here is the defect this file exists to prevent. */
+  loginPath: WslLoginPath
   /** Guest (POSIX) path. */
   cwd?: string
   /** Host variables to propagate into the guest; sets WSLENV automatically. */
   env?: Readonly<Record<string, string>>
   timeoutMs?: number
   maxOutputBytes?: number
-  /**
-   * Proceed when the login PATH could not be established.
-   *
-   * Default is to throw. Three separate reviews found the same class of bug --
-   * a call that answers "is this installed?" running on the bare default PATH
-   * and reporting an nvm-installed tool absent (#9725). Making degradation
-   * opt-in puts that decision in the one place a reader will look, instead of
-   * relying on every call site to remember to check `environmentResolved`.
-   */
-  allowDegradedEnvironment?: boolean
 }
 
 export type WslResult = {
@@ -92,21 +84,6 @@ export type WslResult = {
 }
 
 export const DEFAULT_WSL_TIMEOUT_MS = 30_000
-
-/**
- * The guest login PATH could not be established.
- *
- * Typed so a caller answering "is this installed?" can report unverifiable
- * rather than absent -- reporting an nvm-installed tool absent is #9725, and a
- * bare Error would just be swallowed by the same catch that handles real
- * failures.
- */
-export class WslGuestEnvironmentUnavailableError extends Error {
-  constructor(distro: string | undefined) {
-    super(`WSL guest environment for ${distro ?? 'the default distro'} is unavailable`)
-    this.name = 'WslGuestEnvironmentUnavailableError'
-  }
-}
 
 function assertGuestPath(cwd: string): void {
   // Why reject rather than convert: a caller passing a Windows path here has
@@ -131,13 +108,20 @@ function assertNotShellString(program: string): void {
   }
 }
 
-/** Host env plus the WSLENV entries that let it cross the boundary. */
-function buildHostEnv(env: WslSpec['env']): NodeJS.ProcessEnv | undefined {
-  if (!env || Object.keys(env).length === 0) {
-    return undefined
+/**
+ * Host env plus WSL_UTF8 and the WSLENV entries that let values cross.
+ *
+ * Why WSL_UTF8 unconditionally: without it `wsl.exe` writes its OWN messages
+ * ("There is no distribution with the supplied name") as UTF-16LE, so every
+ * caller that surfaces stderr shows NUL-riddled text. Setting it per-call site
+ * is how it got lost -- the relay set it, the migration dropped it, and nothing
+ * noticed because the happy path is pure ASCII. Credit: #9010.
+ */
+function buildHostEnv(env: WslSpec['env']): NodeJS.ProcessEnv {
+  const merged: NodeJS.ProcessEnv = { ...process.env, ...env, WSL_UTF8: '1' }
+  if (env && Object.keys(env).length > 0) {
+    addWslEnvKeys(merged, Object.keys(env))
   }
-  const merged: NodeJS.ProcessEnv = { ...process.env, ...env }
-  addWslEnvKeys(merged, Object.keys(env))
   return merged
 }
 
@@ -177,38 +161,13 @@ function buildGuestArgv(environment: WslGuestEnvironment | null, spec: WslSpec):
   return withGuestCwd(spec.cwd, argv)
 }
 
-function buildInteractiveArgv(spec: WslSpec): {
-  argv: string[]
-  readStdout: (stdout: string) => string
-} {
-  // Why the whole invocation goes through the fence: a caller that does not
-  // parse stdout today may start tomorrow, and the banner is invisible until
-  // then.
-  const quoted = guestCommandArgv(spec).map(quotePosixShell).join(' ')
-  const body = spec.cwd ? `cd ${quotePosixShell(spec.cwd)} || exit 1\n${quoted}` : quoted
-  const captured = buildWslCapturedLoginShellCommand(body)
-  return {
-    argv: ['sh', '-c', captured.command],
-    // Why throw rather than default to '': readStdout returns null precisely to
-    // distinguish "the fence never appeared" from "the payload was empty". An rc
-    // that redirects stdout, or output truncated before the begin marker, would
-    // otherwise return a clean, empty, wrong answer.
-    readStdout: (stdout: string) => {
-      const payload = captured.readStdout(stdout)
-      if (payload === null) {
-        throw new Error('WSL login shell produced no fenced output')
-      }
-      return payload
-    }
-  }
-}
-
 /**
  * Run a program inside WSL.
  *
- * Throws when the guest login PATH cannot be established, unless the caller
- * passes `allowDegradedEnvironment`. Falling back to the login shell here would
- * re-run ~/.profile -- the stall this exists to remove.
+ * A missing login PATH is never fatal: the call runs on the distro's default
+ * PATH and reports `environmentResolved: false`. Every knob this file used to
+ * carry -- cooldown tiers, budget splitting, a re-probe heuristic, an opt-out
+ * flag on 19 of 23 sites -- existed only because that case used to throw.
  */
 export async function runWslProcess(spec: WslSpec): Promise<WslResult> {
   if (spec.program !== undefined) {
@@ -223,7 +182,7 @@ export async function runWslProcess(spec: WslSpec): Promise<WslResult> {
   // shell (see below), so on the interactive lane it would otherwise get no
   // login PATH at all -- strictly less than the probe lane, for a caller that
   // explicitly asked for the user's terminal PATH.
-  const wantsEnvironment = spec.lane === 'probe' || spec.script !== undefined
+  const wantsEnvironment = spec.loginPath === 'preferred'
   // Leave the command at least a third of the budget: a probe that eats it all
   // turns a healthy command into a spurious timeout.
   // Cap the probe at half the budget and at 4s: a 5s caller was giving the
@@ -240,21 +199,14 @@ export async function runWslProcess(spec: WslSpec): Promise<WslResult> {
   // the probe most often fails *because* the distro is slow, so the fallback
   // would hit the hazard exactly when it is worst. Run shell-free with the
   // distro's default PATH instead: degraded, never blocking.
-  if (wantsEnvironment && environment === null && !spec.allowDegradedEnvironment) {
-    throw new WslGuestEnvironmentUnavailableError(spec.distro)
-  }
-
-  const lane =
-    spec.lane === 'interactive' && spec.script === undefined
-      ? ({ kind: 'interactive', ...buildInteractiveArgv(spec) } as const)
-      : ({ kind: 'probe', argv: buildGuestArgv(environment, spec) } as const)
+  const argv = buildGuestArgv(environment, spec)
 
   // One budget for the whole call: the probe used to run on its own 10s timer
   // ahead of the timed leg, so a 5s caller could wait 15s.
   const remainingMs = Math.max(1, deadline - Date.now())
   const result = await runProcess({
     program: resolveWslExecutablePath(),
-    args: buildWslExecArgs(spec.distro, lane.argv),
+    args: buildWslExecArgs(spec.distro, argv),
     env: buildHostEnv(spec.env),
     input: spec.script,
     timeoutMs: remainingMs,
@@ -264,7 +216,7 @@ export async function runWslProcess(spec: WslSpec): Promise<WslResult> {
   return {
     environmentResolved: !wantsEnvironment || environment !== null,
     code: result.code,
-    stdout: lane.kind === 'interactive' ? lane.readStdout(result.stdout) : result.stdout,
+    stdout: result.stdout,
     stderr: result.stderr,
     timedOut: result.timedOut
   }

--- a/src/main/wsl/wsl-runner.ts
+++ b/src/main/wsl/wsl-runner.ts
@@ -41,24 +41,9 @@ export type WslCommand =
       args?: readonly string[]
       script?: never
       shell?: never
-      scriptDelivery?: never
     }
   | {
       script: string
-      /**
-       * How `script` reaches the shell.
-       *
-       * 'argv' (the default) passes it as an argument, which leaves the guest
-       * command's stdin alone. 'stdin' pipes it, which has no length limit but
-       * means anything the script runs that reads stdin eats the rest of the
-       * script -- and the shell then hits EOF and exits 0, so the truncation is
-       * silent. A user-authored hook running `ssh -T` is exactly that.
-       *
-       * Use 'stdin' only for a script Orca wrote, that reads no stdin, and that
-       * is too big for a command line (the hook-relay installer embeds a JS
-       * bundle).
-       */
-      scriptDelivery?: 'argv' | 'stdin'
       args?: readonly string[]
       program?: never
       /**
@@ -85,8 +70,6 @@ export type WslSpec = WslCommand & {
   env?: Readonly<Record<string, string>>
   timeoutMs?: number
   maxOutputBytes?: number
-  /** See runProcess: 'tail' keeps the end of an over-long stream. */
-  retainOutput?: 'head' | 'tail'
 }
 
 export type WslResult = {
@@ -182,10 +165,6 @@ function withGuestCwd(cwd: string | undefined, argv: readonly string[]): string[
  */
 const MAX_ARGV_SCRIPT_CHARS = 8_000
 
-function resolveScriptDelivery(spec: WslSpec & { script: string }): 'argv' | 'stdin' {
-  return spec.scriptDelivery ?? (spec.script.length > MAX_ARGV_SCRIPT_CHARS ? 'stdin' : 'argv')
-}
-
 /** `<shell> -c`/`-s` for a script, otherwise the program itself. */
 function guestCommandArgv(spec: WslSpec, delivery: 'argv' | 'stdin'): string[] {
   if (spec.script === undefined) {
@@ -245,8 +224,8 @@ export async function runWslProcess(spec: WslSpec): Promise<WslResult> {
   // distro's default PATH instead: degraded, never blocking.
   // Resolved once: argv shape and stdin payload must agree, and computing it
   // in both places invites them to drift.
-  const delivery =
-    spec.script === undefined ? 'argv' : resolveScriptDelivery({ ...spec, script: spec.script })
+  const delivery: 'argv' | 'stdin' =
+    spec.script !== undefined && spec.script.length > MAX_ARGV_SCRIPT_CHARS ? 'stdin' : 'argv'
   const argv = buildGuestArgv(environment, spec, delivery)
 
   // One budget for the whole call: the probe used to run on its own 10s timer
@@ -258,8 +237,7 @@ export async function runWslProcess(spec: WslSpec): Promise<WslResult> {
     env: buildHostEnv(spec.env),
     input: delivery === 'stdin' ? spec.script : undefined,
     timeoutMs: remainingMs,
-    maxOutputBytes: spec.maxOutputBytes,
-    retainOutput: spec.retainOutput
+    maxOutputBytes: spec.maxOutputBytes
   })
 
   return {

--- a/src/main/wsl/wsl-runner.ts
+++ b/src/main/wsl/wsl-runner.ts
@@ -126,8 +126,15 @@ function assertNotShellString(program: string): void {
  */
 function buildHostEnv(env: WslSpec['env']): NodeJS.ProcessEnv {
   const merged: NodeJS.ProcessEnv = { ...process.env, ...env, WSL_UTF8: '1' }
-  if (env && Object.keys(env).length > 0) {
-    addWslEnvKeys(merged, Object.keys(env))
+  // Never name a path-shaped variable in WSLENV. wsl.exe translates those
+  // between Windows and Linux form, so forwarding PATH replaces the guest's
+  // own PATH with a translated Windows one -- silently, and this runner exists
+  // to make that class of mistake impossible rather than to document it.
+  const crossable = Object.keys(env ?? {}).filter(
+    (key) => !['PATH', 'HOME', 'TMP', 'TEMP'].includes(key)
+  )
+  if (crossable.length > 0) {
+    addWslEnvKeys(merged, crossable)
   }
   return merged
 }

--- a/src/main/wsl/wsl-runner.ts
+++ b/src/main/wsl/wsl-runner.ts
@@ -37,9 +37,29 @@ export type WslLoginPath =
  * was never made explicit. `script` makes the runner supply `sh -s` itself.
  */
 export type WslCommand =
-  | { program: string; args?: readonly string[]; script?: never; shell?: never }
+  | {
+      program: string
+      args?: readonly string[]
+      script?: never
+      shell?: never
+      scriptDelivery?: never
+    }
   | {
       script: string
+      /**
+       * How `script` reaches the shell.
+       *
+       * 'argv' (the default) passes it as an argument, which leaves the guest
+       * command's stdin alone. 'stdin' pipes it, which has no length limit but
+       * means anything the script runs that reads stdin eats the rest of the
+       * script -- and the shell then hits EOF and exits 0, so the truncation is
+       * silent. A user-authored hook running `ssh -T` is exactly that.
+       *
+       * Use 'stdin' only for a script Orca wrote, that reads no stdin, and that
+       * is too big for a command line (the hook-relay installer embeds a JS
+       * bundle).
+       */
+      scriptDelivery?: 'argv' | 'stdin'
       args?: readonly string[]
       program?: never
       /**
@@ -148,11 +168,16 @@ function withGuestCwd(cwd: string | undefined, argv: readonly string[]): string[
   return ['sh', '-c', 'cd "$1" || exit 1; shift; exec "$@"', 'orca-wsl', cwd, ...argv]
 }
 
-/** `<shell> -s --` for a script on stdin, otherwise the program itself. */
+/** `<shell> -c`/`-s` for a script, otherwise the program itself. */
 function guestCommandArgv(spec: WslSpec): string[] {
-  return spec.script !== undefined
-    ? [spec.shell ?? 'sh', '-s', '--', ...(spec.args ?? [])]
-    : [spec.program, ...(spec.args ?? [])]
+  if (spec.script === undefined) {
+    return [spec.program, ...(spec.args ?? [])]
+  }
+  const shell = spec.shell ?? 'sh'
+  // `--` keeps positional args starting at $1 under both forms.
+  return spec.scriptDelivery === 'stdin'
+    ? [shell, '-s', '--', ...(spec.args ?? [])]
+    : [shell, '-c', spec.script, '--', ...(spec.args ?? [])]
 }
 
 /** Shell-free argv, with the cached environment applied when one is available. */
@@ -205,7 +230,7 @@ export async function runWslProcess(spec: WslSpec): Promise<WslResult> {
     program: resolveWslExecutablePath(),
     args: buildWslExecArgs(spec.distro, argv),
     env: buildHostEnv(spec.env),
-    input: spec.script,
+    input: spec.scriptDelivery === 'stdin' ? spec.script : undefined,
     timeoutMs: remainingMs,
     maxOutputBytes: spec.maxOutputBytes
   })

--- a/src/main/wsl/wsl-runner.ts
+++ b/src/main/wsl/wsl-runner.ts
@@ -70,14 +70,17 @@ export type WslSpec = WslCommand & {
 
 export type WslResult = {
   /**
-   * False when the login PATH could not be established, so the call ran on the
-   * distro's default PATH. A caller deciding "is this tool installed?" must
-   * report unverifiable rather than absent -- an nvm-installed binary is
-   * invisible without the login PATH, which is #9725 exactly.
+   * False when `loginPath: 'preferred'` could not establish the login PATH, so
+   * the call ran on the distro's default PATH. A caller deciding "is this tool
+   * installed?" must then report unverifiable rather than absent -- an
+   * nvm-installed binary is invisible without it, which is #9725 exactly.
+   *
+   * Always true under `loginPath: 'none'`, because such a command asked for no
+   * PATH and cannot be let down by one. A PATH lookup marked 'none' therefore
+   * gets no protection from this field; the value has to be right.
    */
   environmentResolved: boolean
   code: number | null
-  /** Payload only — on the interactive lane the rc banner is removed by the fence. */
   stdout: string
   stderr: string
   timedOut: boolean
@@ -178,13 +181,7 @@ export async function runWslProcess(spec: WslSpec): Promise<WslResult> {
   }
   const deadline = Date.now() + (spec.timeoutMs ?? DEFAULT_WSL_TIMEOUT_MS)
 
-  // Why both lanes when there is a script: a script never runs under the login
-  // shell (see below), so on the interactive lane it would otherwise get no
-  // login PATH at all -- strictly less than the probe lane, for a caller that
-  // explicitly asked for the user's terminal PATH.
   const wantsEnvironment = spec.loginPath === 'preferred'
-  // Leave the command at least a third of the budget: a probe that eats it all
-  // turns a healthy command into a spurious timeout.
   // Cap the probe at half the budget and at 4s: a 5s caller was giving the
   // probe 3333ms and its own command 1667ms, tighter than the 5s it had before
   // the runner existed, which is how a cold distro read as "not installed".

--- a/src/main/wsl/wsl-runner.ts
+++ b/src/main/wsl/wsl-runner.ts
@@ -31,10 +31,9 @@ export type WslLoginPath =
 /**
  * What to run: a single binary, or a script.
  *
- * Why a union rather than an optional `script`: a script has to arrive on
- * stdin, which means the program must be a shell reading stdin. Left to the
- * caller that is a footgun — and the wrappers this replaces exist because it
- * was never made explicit. `script` makes the runner supply `sh -s` itself.
+ * Why a union rather than an optional `script`: a script needs a shell to run
+ * it, and picking one per call site is how the wrappers this replaces drifted
+ * apart. `script` makes the runner supply the shell, and `shell` says which.
  */
 export type WslCommand =
   | {

--- a/src/main/wsl/wsl-runner.wsl.test.ts
+++ b/src/main/wsl/wsl-runner.wsl.test.ts
@@ -50,9 +50,8 @@ describeOnWsl('runWslProcess against a real distro', () => {
     // otherwise refuses an unresolved PATH.
     const started = Date.now()
     const result = await runWslProcess({
-      lane: 'probe',
+      loginPath: 'preferred',
       distro: DISTRO,
-      allowDegradedEnvironment: true,
       program: '/bin/echo',
       args: ['orca-probe-ok'],
       timeoutMs: 15_000
@@ -65,11 +64,10 @@ describeOnWsl('runWslProcess against a real distro', () => {
   it('second probe-lane call does not pay the login shell again', async () => {
     const started = Date.now()
     await runWslProcess({
-      lane: 'probe',
+      loginPath: 'preferred',
       distro: DISTRO,
       program: '/bin/true',
       timeoutMs: 15_000,
-      allowDegradedEnvironment: true
     })
     expect(Date.now() - started).toBeLessThan(5_000)
   }, 30_000)
@@ -78,7 +76,7 @@ describeOnWsl('runWslProcess against a real distro', () => {
     // Stock Ubuntu writes its rc hint to stdout. Anything parsing that stream
     // reads the banner as data unless the fence removes it (#11327, #11823).
     const result = await runWslProcess({
-      lane: 'interactive',
+      loginPath: 'preferred',
       distro: DISTRO,
       program: '/bin/echo',
       args: ['ORCA_PAYLOAD'],
@@ -96,9 +94,8 @@ describeOnWsl('runWslProcess against a real distro', () => {
       `echo "x" | awk '{print $1}'`
     ].join('\n')
     const result = await runWslProcess({
-      lane: 'probe',
+      loginPath: 'preferred',
       distro: DISTRO,
-      allowDegradedEnvironment: true,
       script,
       args: ['ORCA_ARG'],
       timeoutMs: 30_000
@@ -113,9 +110,8 @@ describeOnWsl('runWslProcess against a real distro', () => {
 
   it('propagated env crosses the boundary via WSLENV', async () => {
     const result = await runWslProcess({
-      lane: 'probe',
+      loginPath: 'preferred',
       distro: DISTRO,
-      allowDegradedEnvironment: true,
       script: 'printf %s "$ORCA_WSLENV_PROBE"',
       env: { ORCA_WSLENV_PROBE: 'crossed' },
       timeoutMs: 30_000
@@ -125,9 +121,8 @@ describeOnWsl('runWslProcess against a real distro', () => {
 
   it('runs in the requested guest cwd', async () => {
     const result = await runWslProcess({
-      lane: 'probe',
+      loginPath: 'preferred',
       distro: DISTRO,
-      allowDegradedEnvironment: true,
       program: '/bin/pwd',
       cwd: '/tmp',
       timeoutMs: 30_000

--- a/src/main/wsl/wsl-runner.wsl.test.ts
+++ b/src/main/wsl/wsl-runner.wsl.test.ts
@@ -43,11 +43,10 @@ describeOnWsl('runWslProcess against a real distro', () => {
   }, 120_000)
 
   it('probe lane survives a ~/.profile that blocks for a minute', async () => {
-    // The blocking profile makes the probe time out, so the lane degrades --
-    // that is the point: the call must still answer inside its own budget
-    // rather than inheriting the 60s stall. This is #14288 against a real
-    // distro, and it needs allowDegradedEnvironment because the runner
-    // otherwise refuses an unresolved PATH.
+    // The blocking profile makes the probe time out -- that is the point: the
+    // call must still answer inside its own budget rather than inheriting the
+    // 60s stall. This is #14288 against a real distro, and it relies on a
+    // failed probe being non-fatal.
     const started = Date.now()
     const result = await runWslProcess({
       loginPath: 'preferred',
@@ -67,7 +66,7 @@ describeOnWsl('runWslProcess against a real distro', () => {
       loginPath: 'preferred',
       distro: DISTRO,
       program: '/bin/true',
-      timeoutMs: 15_000,
+      timeoutMs: 15_000
     })
     expect(Date.now() - started).toBeLessThan(5_000)
   }, 30_000)

--- a/src/main/wsl/wsl-w1-w3-contract.test.ts
+++ b/src/main/wsl/wsl-w1-w3-contract.test.ts
@@ -44,27 +44,27 @@ describe('W1: every WSL call inherits the spawn chokepoint', () => {
   it('resolves wsl.exe absolutely, never by bare name', async () => {
     // Bare-name resolution is what a Group Policy or a stripped Electron PATH
     // hijacks (#15749).
-    await runWslProcess({ lane: 'probe', distro: 'Ubuntu', program: '/bin/true' })
+    await runWslProcess({ loginPath: 'preferred', distro: 'Ubuntu', program: '/bin/true' })
     expect(spawnSpec().program).toBe('C:\\Windows\\System32\\wsl.exe')
   })
 
   it('passes argv as an array, never a command string', async () => {
     // A command string would put quoting back in the caller's hands, which is
     // the entire class W1 removed.
-    await runWslProcess({ lane: 'probe', distro: 'Ubuntu', program: '/bin/echo', args: ['a b'] })
+    await runWslProcess({ loginPath: 'preferred', distro: 'Ubuntu', program: '/bin/echo', args: ['a b'] })
     expect(Array.isArray(spawnSpec().args)).toBe(true)
     expect(spawnSpec().args).toContain('a b')
   })
 
   it('always bounds the call', async () => {
-    await runWslProcess({ lane: 'probe', distro: 'Ubuntu', program: '/bin/true' })
+    await runWslProcess({ loginPath: 'preferred', distro: 'Ubuntu', program: '/bin/true' })
     expect(spawnSpec().timeoutMs).toBeGreaterThan(0)
   })
 })
 
 describe('W3: the five per-call decisions are made once', () => {
   it('never uses the -- separator, which expands $name host-side', async () => {
-    await runWslProcess({ lane: 'probe', distro: 'Ubuntu', script: 'echo "$HOME"' })
+    await runWslProcess({ loginPath: 'preferred', distro: 'Ubuntu', script: 'echo "$HOME"' })
     const argv = spawnSpec().args as string[]
     // Only wsl.exe's own separator matters. A later `--` belongs to `sh -s --`
     // and is the guest shell's end-of-options, so check the position rather
@@ -77,14 +77,14 @@ describe('W3: the five per-call decisions are made once', () => {
     // The base64 and eval wrappers existed because argv quoting kept breaking;
     // stdin has no quoting boundary at all (#14292).
     const script = `case "$x" in a) echo 'it'\\''s fine';; esac`
-    await runWslProcess({ lane: 'probe', distro: 'Ubuntu', script })
+    await runWslProcess({ loginPath: 'preferred', distro: 'Ubuntu', script })
     expect(spawnSpec().input).toBe(script)
     expect(JSON.stringify(spawnSpec().args)).not.toContain('case')
   })
 
   it('propagates env only through WSLENV', async () => {
     await runWslProcess({
-      lane: 'probe',
+      loginPath: 'preferred',
       distro: 'Ubuntu',
       program: '/bin/true',
       env: { GITLAB_HOST: 'git.example.com' }
@@ -95,14 +95,14 @@ describe('W3: the five per-call decisions are made once', () => {
 
   it('runs no shell on the probe lane, so ~/.profile cannot stall it', async () => {
     // #14288: one blocking line in ~/.profile ate the whole timeout.
-    await runWslProcess({ lane: 'probe', distro: 'Ubuntu', program: 'codex' })
+    await runWslProcess({ loginPath: 'preferred', distro: 'Ubuntu', program: 'codex' })
     expect(JSON.stringify(spawnSpec().args)).not.toContain('_orca_wsl_shell')
   })
 
   it('applies the user login PATH even with no shell in the loop', async () => {
     // The other half of the same trade: nvm-installed agents must still be
     // found (#9725, #7563, #8366).
-    await runWslProcess({ lane: 'probe', distro: 'Ubuntu', program: 'codex' })
+    await runWslProcess({ loginPath: 'preferred', distro: 'Ubuntu', program: 'codex' })
     expect(spawnSpec().args).toContain('PATH=/home/u/.nvm/bin:/usr/bin')
   })
 })
@@ -118,7 +118,7 @@ describe('failure modes stay distinguishable', () => {
       stderr: '',
       timedOut: false
     })
-    const result = await runWslProcess({ lane: 'probe', distro: 'Ubuntu', program: '/bin/false' })
+    const result = await runWslProcess({ loginPath: 'preferred', distro: 'Ubuntu', program: '/bin/false' })
     expect(result.code).toBe(3)
     expect(result.timedOut).toBe(false)
   })
@@ -131,11 +131,11 @@ describe('failure modes stay distinguishable', () => {
       stderr: '',
       timedOut: true
     })
-    const result = await runWslProcess({ lane: 'probe', distro: 'Ubuntu', program: '/bin/true' })
+    const result = await runWslProcess({ loginPath: 'preferred', distro: 'Ubuntu', program: '/bin/true' })
     expect(result.timedOut).toBe(true)
   })
 
-  it('an unresolved login PATH refuses rather than answering wrongly', async () => {
+  it('an unresolved login PATH is reported, never fatal', async () => {
     invalidateWslGuestEnvironment(undefined, true)
     runProcessMock.mockResolvedValue({
       code: 1,
@@ -144,8 +144,12 @@ describe('failure modes stay distinguishable', () => {
       stderr: 'stopped',
       timedOut: false
     })
-    await expect(
-      runWslProcess({ lane: 'probe', distro: 'Ubuntu', program: 'codex' })
-    ).rejects.toThrow(/guest environment/)
+    // Every knob this runner used to carry existed because this case threw.
+    const result = await runWslProcess({
+      loginPath: 'preferred',
+      distro: 'Ubuntu',
+      program: 'codex'
+    })
+    expect(result.environmentResolved).toBe(false)
   })
 })

--- a/src/main/wsl/wsl-w1-w3-contract.test.ts
+++ b/src/main/wsl/wsl-w1-w3-contract.test.ts
@@ -51,7 +51,12 @@ describe('W1: every WSL call inherits the spawn chokepoint', () => {
   it('passes argv as an array, never a command string', async () => {
     // A command string would put quoting back in the caller's hands, which is
     // the entire class W1 removed.
-    await runWslProcess({ loginPath: 'preferred', distro: 'Ubuntu', program: '/bin/echo', args: ['a b'] })
+    await runWslProcess({
+      loginPath: 'preferred',
+      distro: 'Ubuntu',
+      program: '/bin/echo',
+      args: ['a b']
+    })
     expect(Array.isArray(spawnSpec().args)).toBe(true)
     expect(spawnSpec().args).toContain('a b')
   })
@@ -119,7 +124,11 @@ describe('failure modes stay distinguishable', () => {
       stderr: '',
       timedOut: false
     })
-    const result = await runWslProcess({ loginPath: 'preferred', distro: 'Ubuntu', program: '/bin/false' })
+    const result = await runWslProcess({
+      loginPath: 'preferred',
+      distro: 'Ubuntu',
+      program: '/bin/false'
+    })
     expect(result.code).toBe(3)
     expect(result.timedOut).toBe(false)
   })
@@ -132,7 +141,11 @@ describe('failure modes stay distinguishable', () => {
       stderr: '',
       timedOut: true
     })
-    const result = await runWslProcess({ loginPath: 'preferred', distro: 'Ubuntu', program: '/bin/true' })
+    const result = await runWslProcess({
+      loginPath: 'preferred',
+      distro: 'Ubuntu',
+      program: '/bin/true'
+    })
     expect(result.timedOut).toBe(true)
   })
 

--- a/src/main/wsl/wsl-w1-w3-contract.test.ts
+++ b/src/main/wsl/wsl-w1-w3-contract.test.ts
@@ -74,12 +74,13 @@ describe('W3: the five per-call decisions are made once', () => {
   })
 
   it('keeps a script byte-identical instead of encoding it', async () => {
-    // The base64 and eval wrappers existed because argv quoting kept breaking;
-    // stdin has no quoting boundary at all (#14292).
+    // The base64 and eval wrappers existed because a host-side shell re-parsed
+    // the quotes (#14292). --exec removes that shell, so the script crosses in
+    // argv exactly as written -- no encoding, and stdin stays the command's.
     const script = `case "$x" in a) echo 'it'\\''s fine';; esac`
     await runWslProcess({ loginPath: 'preferred', distro: 'Ubuntu', script })
-    expect(spawnSpec().input).toBe(script)
-    expect(JSON.stringify(spawnSpec().args)).not.toContain('case')
+    expect(spawnSpec().args).toContain(script)
+    expect(spawnSpec().input).toBeUndefined()
   })
 
   it('propagates env only through WSLENV', async () => {

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
@@ -18,7 +18,9 @@ import {
 
 function decodeWslLoginShellScript(command: string): string {
   const encoded =
-    /(?:--|--exec) sh -c 'eval \\"`printf %s ([A-Za-z0-9+/=]+) \| base64 -d`\\"'/.exec(command)?.[1]
+    /(?:--|--exec) sh -c '(?:eval \\"`|sh -c \\"\$\()?printf %s ([A-Za-z0-9+/=]+) \| base64 -d/.exec(
+      command
+    )?.[1]
   expect(encoded).toBeDefined()
   return Buffer.from(encoded!, 'base64').toString('utf8')
 }
@@ -48,7 +50,7 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
 
     expect(command).toBe(skillCommand)
     expect(setupCommand).toBe(
-      `& { $PSNativeCommandArgumentPassing = 'Legacy'; wsl.exe -d 'Ubuntu' --exec sh -c 'eval \\"\`printf %s ${encoded} | base64 -d\`\\"' } # Runs: ${skillCommand}`
+      `& { $PSNativeCommandArgumentPassing = 'Legacy'; wsl.exe -d 'Ubuntu' --exec sh -c 'sh -c \\"$(printf %s ${encoded} | base64 -d)\\"' } # Runs: ${skillCommand}`
     )
     expect(decodeWslLoginShellScript(setupCommand)).toContain(
       'exec "$_orca_wsl_shell" -ilc \'npx skills add orchestration --global\''
@@ -93,9 +95,11 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
     const setupCommand = buildSkillSetupTerminalCommand(command, 'powershell.exe', runtime, 'win32')
 
     expect(setupCommand).toMatch(
-      /^& \{ \$PSNativeCommandArgumentPassing = 'Legacy'; wsl\.exe --exec sh -c 'eval \\"`printf/
+      /^& \{ \$PSNativeCommandArgumentPassing = 'Legacy'; wsl\.exe --exec sh -c 'sh -c/
     )
-    expect(setupCommand).toContain('`\\"\' } # Runs: npx skills update orchestration --global')
+    // The command no longer ends in the eval wrapper's nested quotes; it is a
+    // plain pipe into sh, so the payload has no quoting layer to escape from.
+    expect(setupCommand).toContain('base64 -d)')
   })
 
   it.skipIf(process.platform === 'win32')(

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
@@ -164,7 +164,15 @@ function buildPowerShellWslSkillCommand(command: string, runtime: LocalAgentRunt
   // Why: encoding preserves the user's configured login-shell PATH across the Windows argv boundary.
   const encodedScript = encodeWslLoginShellScript(command)
   const visibleCommand = command.replace(/[\r\n]+/g, ' ')
-  const shellScript = `eval "\`printf %s ${encodedScript} | base64 -d\`"`
+  // Why $(...) and not a backtick eval: PowerShell treats ` as its own escape
+  // character, so the old `eval "\`printf ...\`"` had the payload's quotes
+  // interacting with two escaping layers and dash saw `case  in` -- the
+  // `word unexpected (expecting "in")` in #14292. Credit: #14785.
+  //
+  // Why not a plain pipe into sh: that hands the payload the pipe as its stdin,
+  // so a setup command that reads input gets base64 remnants instead. Command
+  // substitution runs in a subshell and leaves the terminal's stdin intact.
+  const shellScript = `sh -c "$(printf %s ${encodedScript} | base64 -d)"`
   // Why --exec: `--` makes wsl.exe expand $name in the argv it forwards to the guest.
   const wslCommand = `wsl.exe${distroArg} --exec sh -c ${quotePowerShellNativeArgument(shellScript)}`
   return `& { $PSNativeCommandArgumentPassing = 'Legacy'; ${wslCommand} } # Runs: ${visibleCommand}`
@@ -180,7 +188,10 @@ function decodeWslSetupTerminalCommand(command: string): string | null {
 
   // Why both separators: commands persisted before the --exec switch must still decode.
   const encoded =
-    /(?:--|--exec) sh -c 'eval \\"`printf %s ([A-Za-z0-9+/=]+) \| base64 -d`\\"'/.exec(command)?.[1]
+    // Both shapes: commands persisted before the pipe switch still decode.
+    /(?:--|--exec) sh -c '(?:eval \\"`|sh -c \\"\$\()?printf %s ([A-Za-z0-9+/=]+) \| base64 -d/.exec(
+      command
+    )?.[1]
   if (!encoded) {
     return null
   }

--- a/src/shared/child-process/__fixtures__/windows-console-visibility-allowlist.txt
+++ b/src/shared/child-process/__fixtures__/windows-console-visibility-allowlist.txt
@@ -13,7 +13,6 @@ main/automations/precheck-runner.ts
 main/browser/browser-cookie-import.ts
 main/claude-accounts/keychain.ts
 main/cli/cli-installer.ts
-main/codex-accounts/runtime-home-service.ts
 main/computer/macos-computer-use-permission-status.ts
 main/computer/macos-computer-use-permissions.ts
 main/computer/macos-native-provider-transport.ts

--- a/src/shared/child-process/__fixtures__/windows-console-visibility-allowlist.txt
+++ b/src/shared/child-process/__fixtures__/windows-console-visibility-allowlist.txt
@@ -19,7 +19,6 @@ main/computer/macos-computer-use-permissions.ts
 main/computer/macos-native-provider-transport.ts
 main/daemon/daemon-bash-wrapper-osc133-fixture.ts
 main/daemon/daemon-process-identity-query.ts
-main/daemon/daemon-process-inspection.ts
 main/daemon/daemon-process-start-time.ts
 main/emulator/android/android-command-runner.ts
 main/emulator/android/scrcpy-stream-session.ts
@@ -48,7 +47,6 @@ main/pty/posix-pty-foreground-group.ts
 main/pty/posix-pty-process-groups.ts
 main/pty/windows-environment-path.ts
 main/rate-limits/codex-fetcher.ts
-main/rate-limits/gemini-cli-oauth-extractor.ts
 main/runtime/orca-runtime-files.ts
 main/runtime/tls-certificate.ts
 main/ssh/ssh-connection.ts

--- a/src/shared/child-process/__fixtures__/windows-console-visibility-allowlist.txt
+++ b/src/shared/child-process/__fixtures__/windows-console-visibility-allowlist.txt
@@ -12,10 +12,8 @@ main/automations/external-manager.ts
 main/automations/precheck-runner.ts
 main/browser/browser-cookie-import.ts
 main/claude-accounts/keychain.ts
-main/claude-accounts/service.ts
 main/cli/cli-installer.ts
 main/codex-accounts/runtime-home-service.ts
-main/codex-accounts/service.ts
 main/computer/macos-computer-use-permission-status.ts
 main/computer/macos-computer-use-permissions.ts
 main/computer/macos-native-provider-transport.ts
@@ -36,7 +34,6 @@ main/ipc/developer-permissions.ts
 main/ipc/filesystem.ts
 main/ipc/macos-keyboard-layout-snapshot.ts
 main/ipc/notification-authorization-status.ts
-main/ipc/preflight-command-exec.ts
 main/ipc/repos.ts
 main/ipc/worktree-apfs-clone.ts
 main/local-builds/local-build-candidate.ts
@@ -59,7 +56,6 @@ main/startup/appimage-cli-redirect.ts
 main/startup/ensure-virtual-display.ts
 main/startup/packaged-cli-entry-redirect.ts
 main/startup/windows-install-dir-acl-probe.ts
-main/text-generation/commit-message-text-generation.ts
 main/win32-utils.ts
 main/window/clipboard-ipc-handlers.ts
 main/workspace-space-analysis.ts
@@ -73,7 +69,6 @@ relay/fs-handler-git-fallback.ts
 relay/fs-handler-utils.ts
 relay/fs-list-files-fallback-chain.ts
 relay/git-handler.ts
-relay/preflight-handler.ts
 relay/pty-shell-utils.ts
 relay/subprocess-tree-termination.ts
 relay/windows-port-scan.ts

--- a/src/shared/child-process/run-process.test.ts
+++ b/src/shared/child-process/run-process.test.ts
@@ -188,3 +188,13 @@ describe('output truncation', () => {
     expect(result.stderr.length).toBe(64)
   })
 })
+
+describe('runProcessSync', () => {
+  it('refuses retainOutput: tail rather than silently keeping the head', () => {
+    // The spec type is shared, so a caller can copy a runProcess spec across
+    // and lose the late half of the output it was reading for.
+    expect(() =>
+      runProcessSync({ program: process.execPath, args: ['-e', ''], retainOutput: 'tail' })
+    ).toThrow(/use runProcess/)
+  })
+})

--- a/src/shared/child-process/run-process.test.ts
+++ b/src/shared/child-process/run-process.test.ts
@@ -174,27 +174,4 @@ describe('output truncation', () => {
     expect(result.stderr).not.toContain('FAILED')
     expect(result.stderr).toBe('n'.repeat(64))
   })
-
-  it('keeps the tail when asked, so a late failure survives', async () => {
-    // A guest install prints pages of warnings and then the one line that says
-    // why it failed. Head-truncation reports the warnings.
-    const result = await runProcess({
-      program: process.execPath,
-      args: ['-e', emit(200)],
-      maxOutputBytes: 64,
-      retainOutput: 'tail'
-    })
-    expect(result.stderr).toContain('FAILED')
-    expect(result.stderr.length).toBe(64)
-  })
-})
-
-describe('runProcessSync output retention', () => {
-  it('refuses retainOutput: tail rather than silently keeping the head', () => {
-    // The spec type is shared, so a caller can copy a runProcess spec across
-    // and lose the late half of the output it was reading for.
-    expect(() =>
-      runProcessSync({ program: process.execPath, args: ['-e', ''], retainOutput: 'tail' })
-    ).toThrow(/use runProcess/)
-  })
 })

--- a/src/shared/child-process/run-process.test.ts
+++ b/src/shared/child-process/run-process.test.ts
@@ -189,7 +189,7 @@ describe('output truncation', () => {
   })
 })
 
-describe('runProcessSync', () => {
+describe('runProcessSync output retention', () => {
   it('refuses retainOutput: tail rather than silently keeping the head', () => {
     // The spec type is shared, so a caller can copy a runProcess spec across
     // and lose the late half of the output it was reading for.

--- a/src/shared/child-process/run-process.test.ts
+++ b/src/shared/child-process/run-process.test.ts
@@ -160,3 +160,31 @@ describe('a signal that is already aborted', () => {
     expect(Date.now() - startedAt).toBeLessThan(10_000)
   }, 20_000)
 })
+
+describe('output truncation', () => {
+  const emit = (bytes: number): string =>
+    `for (let i = 0; i < ${bytes}; i += 1) process.stderr.write('n'); process.stderr.write('FAILED')`
+
+  it('keeps the head by default', async () => {
+    const result = await runProcess({
+      program: process.execPath,
+      args: ['-e', emit(200)],
+      maxOutputBytes: 64
+    })
+    expect(result.stderr).not.toContain('FAILED')
+    expect(result.stderr).toBe('n'.repeat(64))
+  })
+
+  it('keeps the tail when asked, so a late failure survives', async () => {
+    // A guest install prints pages of warnings and then the one line that says
+    // why it failed. Head-truncation reports the warnings.
+    const result = await runProcess({
+      program: process.execPath,
+      args: ['-e', emit(200)],
+      maxOutputBytes: 64,
+      retainOutput: 'tail'
+    })
+    expect(result.stderr).toContain('FAILED')
+    expect(result.stderr.length).toBe(64)
+  })
+})

--- a/src/shared/child-process/run-process.ts
+++ b/src/shared/child-process/run-process.ts
@@ -37,13 +37,6 @@ export type ProcessSpec = {
   input?: string
   /** Cap on captured stdout/stderr; output past it is discarded. */
   maxOutputBytes?: number
-  /**
-   * Which end of an over-long stream to keep. 'head' (default) matches how the
-   * cap has always behaved; 'tail' is for output whose meaning is at the end --
-   * an install that fails after pages of warnings puts the error last, and
-   * head-truncation reports the noise instead.
-   */
-  retainOutput?: 'head' | 'tail'
   /** Kills the process when aborted; the result still reports the exit. */
   signal?: AbortSignal
 }
@@ -135,10 +128,7 @@ export function spawnProcess(spec: ProcessSpec): ChildProcess {
  * emits strings, and concatenating those as buffers throws inside a `data`
  * handler, where the rejection has nowhere to go and the caller just hangs.
  */
-function createOutputSink(
-  maxBytes: number,
-  retain: 'head' | 'tail'
-): {
+function createOutputSink(maxBytes: number): {
   write: (chunk: Buffer | string) => void
   text: () => string
 } {
@@ -147,23 +137,6 @@ function createOutputSink(
   return {
     write(raw) {
       const chunk = Buffer.isBuffer(raw) ? raw : Buffer.from(raw)
-      if (retain === 'tail') {
-        chunks.push(chunk)
-        bytes += chunk.length
-        // Drop from the front so the newest output survives.
-        while (bytes > maxBytes && chunks.length > 0) {
-          const excess = bytes - maxBytes
-          const first = chunks[0]!
-          if (first.length <= excess) {
-            chunks.shift()
-            bytes -= first.length
-          } else {
-            chunks[0] = first.subarray(excess)
-            bytes -= excess
-          }
-        }
-        return
-      }
       const remaining = maxBytes - bytes
       if (remaining <= 0) {
         return
@@ -193,9 +166,8 @@ export function runProcess(spec: ProcessSpec): Promise<ProcessResult> {
       return
     }
 
-    const retain = spec.retainOutput ?? 'head'
-    const stdout = createOutputSink(maxOutputBytes, retain)
-    const stderr = createOutputSink(maxOutputBytes, retain)
+    const stdout = createOutputSink(maxOutputBytes)
+    const stderr = createOutputSink(maxOutputBytes)
     let timedOut = false
     let settled = false
 
@@ -301,15 +273,8 @@ function terminate(child: ChildProcess, signal?: NodeJS.Signals): void {
  * Prefer `runProcess`. This exists so those callers still get the Windows
  * invariants (hidden console, correct `.cmd` argv) instead of reaching for
  * `execFileSync` and re-deciding them.
- *
- * `retainOutput: 'tail'` throws rather than being ignored: the spec type is
- * shared with runProcess, so a caller can copy one across and silently get
- * head truncation back on output whose meaning is at the end.
  */
 export function runProcessSync(spec: ProcessSpec): ProcessResult {
-  if (spec.retainOutput === 'tail') {
-    throw new Error('runProcessSync cannot retain the tail; use runProcess')
-  }
   const resolved = resolveSpawn(spec, process.platform)
   const result = nodeSpawnSync(resolved.file, [...resolved.args], {
     ...resolved.options,

--- a/src/shared/child-process/run-process.ts
+++ b/src/shared/child-process/run-process.ts
@@ -301,11 +301,10 @@ function terminate(child: ChildProcess, signal?: NodeJS.Signals): void {
  * Prefer `runProcess`. This exists so those callers still get the Windows
  * invariants (hidden console, correct `.cmd` argv) instead of reaching for
  * `execFileSync` and re-deciding them.
- */
-/**
- * Why it throws rather than ignoring: the spec type is shared with runProcess,
- * so a caller can copy one across and silently get head truncation back on
- * output whose meaning is at the end.
+ *
+ * `retainOutput: 'tail'` throws rather than being ignored: the spec type is
+ * shared with runProcess, so a caller can copy one across and silently get
+ * head truncation back on output whose meaning is at the end.
  */
 export function runProcessSync(spec: ProcessSpec): ProcessResult {
   if (spec.retainOutput === 'tail') {

--- a/src/shared/child-process/run-process.ts
+++ b/src/shared/child-process/run-process.ts
@@ -37,6 +37,13 @@ export type ProcessSpec = {
   input?: string
   /** Cap on captured stdout/stderr; output past it is discarded. */
   maxOutputBytes?: number
+  /**
+   * Which end of an over-long stream to keep. 'head' (default) matches how the
+   * cap has always behaved; 'tail' is for output whose meaning is at the end --
+   * an install that fails after pages of warnings puts the error last, and
+   * head-truncation reports the noise instead.
+   */
+  retainOutput?: 'head' | 'tail'
   /** Kills the process when aborted; the result still reports the exit. */
   signal?: AbortSignal
 }
@@ -128,7 +135,10 @@ export function spawnProcess(spec: ProcessSpec): ChildProcess {
  * emits strings, and concatenating those as buffers throws inside a `data`
  * handler, where the rejection has nowhere to go and the caller just hangs.
  */
-function createOutputSink(maxBytes: number): {
+function createOutputSink(
+  maxBytes: number,
+  retain: 'head' | 'tail'
+): {
   write: (chunk: Buffer | string) => void
   text: () => string
 } {
@@ -137,6 +147,23 @@ function createOutputSink(maxBytes: number): {
   return {
     write(raw) {
       const chunk = Buffer.isBuffer(raw) ? raw : Buffer.from(raw)
+      if (retain === 'tail') {
+        chunks.push(chunk)
+        bytes += chunk.length
+        // Drop from the front so the newest output survives.
+        while (bytes > maxBytes && chunks.length > 0) {
+          const excess = bytes - maxBytes
+          const first = chunks[0]!
+          if (first.length <= excess) {
+            chunks.shift()
+            bytes -= first.length
+          } else {
+            chunks[0] = first.subarray(excess)
+            bytes -= excess
+          }
+        }
+        return
+      }
       const remaining = maxBytes - bytes
       if (remaining <= 0) {
         return
@@ -166,8 +193,9 @@ export function runProcess(spec: ProcessSpec): Promise<ProcessResult> {
       return
     }
 
-    const stdout = createOutputSink(maxOutputBytes)
-    const stderr = createOutputSink(maxOutputBytes)
+    const retain = spec.retainOutput ?? 'head'
+    const stdout = createOutputSink(maxOutputBytes, retain)
+    const stderr = createOutputSink(maxOutputBytes, retain)
     let timedOut = false
     let settled = false
 

--- a/src/shared/child-process/run-process.ts
+++ b/src/shared/child-process/run-process.ts
@@ -302,7 +302,15 @@ function terminate(child: ChildProcess, signal?: NodeJS.Signals): void {
  * invariants (hidden console, correct `.cmd` argv) instead of reaching for
  * `execFileSync` and re-deciding them.
  */
+/**
+ * Why it throws rather than ignoring: the spec type is shared with runProcess,
+ * so a caller can copy one across and silently get head truncation back on
+ * output whose meaning is at the end.
+ */
 export function runProcessSync(spec: ProcessSpec): ProcessResult {
+  if (spec.retainOutput === 'tail') {
+    throw new Error('runProcessSync cannot retain the tail; use runProcess')
+  }
   const resolved = resolveSpawn(spec, process.platform)
   const result = nodeSpawnSync(resolved.file, [...resolved.args], {
     ...resolved.options,

--- a/src/shared/child-process/windows-console-visibility.test.ts
+++ b/src/shared/child-process/windows-console-visibility.test.ts
@@ -46,9 +46,6 @@ const SOURCE_ROOT = resolve(__dirname, '../..')
  */
 const OWNER_FILE = 'shared/child-process/run-process.ts'
 
-
-
-
 /** The call's argument text, brace-matched so a nested options literal stays whole. */
 function readCallArguments(source: string, openParenIndex: number): string {
   let depth = 0

--- a/src/shared/child-process/windows-console-visibility.test.ts
+++ b/src/shared/child-process/windows-console-visibility.test.ts
@@ -79,11 +79,17 @@ function findOffenders(): string[] {
         /\b(?:spawn|spawnSync|execFile|execFileSync|exec|execSync|fork)\s+as\s+(\w+)/g
       )
     ].map((match) => match[1]!)
+    // Names that resolve to `exec`/`execSync`, which imply shell: true.
+    const shellImplying = new Set(['exec', 'execSync'])
+    for (const match of decommented.matchAll(/\b(exec|execSync)\s+as\s+(\w+)/g)) {
+      shellImplying.add(match[2]!)
+    }
     // `const run = promisify(execFile)` mints a third name, and it can wrap a
     // renamed binding, so this has to run after the aliases are known. A
     // planted `promisify(renamedExecFile)` spawn passed the guard without it.
     for (const match of decommented.matchAll(
-      /(?:const|let|var)\s+(\w+)\s*=\s*promisify\s*\(\s*(\w+)\s*\)/g
+      // `\w*[Pp]romisify` so `import { promisify as p }` is still seen.
+      /(?:const|let|var)\s+(\w+)\s*=\s*\w*[Pp]romisify\s*\(\s*(\w+)\s*\)/g
     )) {
       const wrapped = match[2]!
       if (
@@ -91,6 +97,9 @@ function findOffenders(): string[] {
         /^(?:spawn|spawnSync|execFile|execFileSync|exec|execSync|fork)$/.test(wrapped)
       ) {
         aliases.push(match[1]!)
+        if (shellImplying.has(wrapped)) {
+          shellImplying.add(match[1]!)
+        }
       }
     }
     // The import test needs the module name, which blanking would erase; the
@@ -115,7 +124,13 @@ function findOffenders(): string[] {
       if (/^\(\s*\w+\s*\??\s*:\s*[A-Za-z{[(]/.test(args)) {
         continue
       }
-      if (!/windowsHide\s*:\s*true/.test(args)) {
+      // `shell: true` silently makes windowsHide a no-op (run-process.ts,
+      // #14543), and `exec`/`execSync` imply it. A site can therefore read as
+      // guarded while still flashing a conhost -- which is exactly how
+      // `execAsync('where gemini', { windowsHide: true })` got un-allowlisted.
+      const called = match[0].replace(/\s*\($/, '').trim()
+      const impliesShell = shellImplying.has(called) || /shell\s*:\s*true/.test(args)
+      if (!/windowsHide\s*:\s*true/.test(args) || impliesShell) {
         offenders.add(file.relativePath)
       }
     }

--- a/src/shared/child-process/windows-console-visibility.test.ts
+++ b/src/shared/child-process/windows-console-visibility.test.ts
@@ -74,9 +74,25 @@ function findOffenders(): string[] {
     const decommented = stripComments(file.source)
     // Resolve `import { spawn as sp }` so a renamed binding is still a spawn.
     // The previous comment claimed this; only three names were hardcoded.
-    const aliases = [...decommented.matchAll(/\b(?:spawn|spawnSync|execFile|execFileSync|exec|execSync|fork)\s+as\s+(\w+)/g)].map(
-      (match) => match[1]
-    )
+    const aliases = [
+      ...decommented.matchAll(
+        /\b(?:spawn|spawnSync|execFile|execFileSync|exec|execSync|fork)\s+as\s+(\w+)/g
+      )
+    ].map((match) => match[1]!)
+    // `const run = promisify(execFile)` mints a third name, and it can wrap a
+    // renamed binding, so this has to run after the aliases are known. A
+    // planted `promisify(renamedExecFile)` spawn passed the guard without it.
+    for (const match of decommented.matchAll(
+      /(?:const|let|var)\s+(\w+)\s*=\s*promisify\s*\(\s*(\w+)\s*\)/g
+    )) {
+      const wrapped = match[2]!
+      if (
+        aliases.includes(wrapped) ||
+        /^(?:spawn|spawnSync|execFile|execFileSync|exec|execSync|fork)$/.test(wrapped)
+      ) {
+        aliases.push(match[1]!)
+      }
+    }
     // The import test needs the module name, which blanking would erase; the
     // call scan needs parens inside strings neutralised. Two views, one file.
     if (!CHILD_PROCESS_IMPORT.test(decommented)) {

--- a/src/shared/child-process/windows-console-visibility.test.ts
+++ b/src/shared/child-process/windows-console-visibility.test.ts
@@ -129,6 +129,17 @@ function findOffenders(): string[] {
       // guarded while still flashing a conhost -- which is exactly how
       // `execAsync('where gemini', { windowsHide: true })` got un-allowlisted.
       const called = match[0].replace(/\s*\($/, '').trim()
+      // Any `shell:` that is not literally `false` counts. `shell:
+      // process.platform === 'win32'` IS shell: true on the platform this
+      // guard is about, and only the literal was being matched.
+      // Recorded gap, not an oversight: `shell: process.platform === 'win32'`
+      // IS shell: true on the platform this guard is about, but matching any
+      // non-`false` value also flags `shell: spawnConfig.shell`
+      // (claude-accounts/service.ts:1086), a pass-through that is false in
+      // every branch. A false positive there costs an allowlist entry, which
+      // disables the guard for that whole file -- worse than the gap. No
+      // computed `shell:` exists in the tree today; if one appears, resolve it
+      // rather than widening this regex.
       const impliesShell = shellImplying.has(called) || /shell\s*:\s*true/.test(args)
       if (!/windowsHide\s*:\s*true/.test(args) || impliesShell) {
         offenders.add(file.relativePath)

--- a/src/shared/posix-version-manager-bin-dirs.ts
+++ b/src/shared/posix-version-manager-bin-dirs.ts
@@ -1,0 +1,36 @@
+/**
+ * Where a version manager puts binaries inside a POSIX guest.
+ *
+ * This is the guest-side twin of `detectCommandsInInstallDirs`, which the
+ * native preflight branch already consults for the same reason -- "PATH may
+ * still be unhydrated on a cold GUI launch". Without it, a WSL probe that
+ * cannot establish the login PATH reports an nvm-installed claude/codex as not
+ * installed, which is #9725.
+ *
+ * Unquoted on purpose: the nvm entry is a glob the guest shell expands.
+ */
+export const POSIX_VERSION_MANAGER_BIN_DIRS = [
+  '$HOME/.local/bin',
+  '$HOME/.local/share/pnpm',
+  '$HOME/.yarn/bin',
+  '$HOME/.bun/bin',
+  '/usr/local/bin',
+  '$HOME/.nvm/versions/node/*/bin'
+]
+
+/**
+ * A prelude that APPENDS those directories to PATH.
+ *
+ * Append, never prepend: when the login PATH did resolve it is authoritative,
+ * and a prepended fallback could shadow the binary the user actually runs with
+ * an older one from a stale nvm version directory.
+ */
+export function buildPosixFallbackPathPrelude(): string {
+  return [
+    `for _orca_dir in ${POSIX_VERSION_MANAGER_BIN_DIRS.join(' ')}; do`,
+    '  if [ -d "$_orca_dir" ]; then PATH="$PATH:$_orca_dir"; fi',
+    'done',
+    'export PATH',
+    'unset _orca_dir'
+  ].join('\n')
+}

--- a/src/shared/posix-version-manager-bin-dirs.ts
+++ b/src/shared/posix-version-manager-bin-dirs.ts
@@ -15,7 +15,7 @@
  * a relative path -- except the nvm glob, where only the prefix is quoted so
  * the `*` still expands.
  */
-export const POSIX_VERSION_MANAGER_BIN_DIRS = [
+const POSIX_VERSION_MANAGER_BIN_DIRS = [
   '"$HOME/.local/bin"',
   '"$HOME/.local/share/pnpm"',
   '"$HOME/.yarn/bin"',

--- a/src/shared/posix-version-manager-bin-dirs.ts
+++ b/src/shared/posix-version-manager-bin-dirs.ts
@@ -1,22 +1,32 @@
 /**
  * Where a version manager puts binaries inside a POSIX guest.
  *
- * This is the guest-side twin of `detectCommandsInInstallDirs`, which the
- * native preflight branch already consults for the same reason -- "PATH may
- * still be unhydrated on a cold GUI launch". Without it, a WSL probe that
- * cannot establish the login PATH reports an nvm-installed claude/codex as not
+ * The guest-side twin of `detectCommandsInInstallDirs`, which the native
+ * preflight branch already consults for the same reason -- "PATH may still be
+ * unhydrated on a cold GUI launch". Without it, a WSL probe that cannot
+ * establish the login PATH reports an nvm-installed claude/codex as not
  * installed, which is #9725.
  *
- * Unquoted on purpose: the nvm entry is a glob the guest shell expands.
+ * Kept in step with `getBaseVersionManagerDirectories` in
+ * node-cli-command-resolution.ts: a WSL user on asdf, mise, volta or fnm would
+ * otherwise still hit #9725 while the same user on native does not.
+ *
+ * Each entry is quoted so a `$HOME` containing a space cannot word-split into
+ * a relative path -- except the nvm glob, where only the prefix is quoted so
+ * the `*` still expands.
  */
 export const POSIX_VERSION_MANAGER_BIN_DIRS = [
-  '$HOME/.local/bin',
-  '$HOME/.local/share/pnpm',
-  '$HOME/.yarn/bin',
-  '$HOME/.bun/bin',
-  '/usr/local/bin',
-  '$HOME/.nvm/versions/node/*/bin'
-]
+  '"$HOME/.local/bin"',
+  '"$HOME/.local/share/pnpm"',
+  '"$HOME/.yarn/bin"',
+  '"$HOME/.bun/bin"',
+  '"$HOME/.volta/bin"',
+  '"$HOME/.asdf/shims"',
+  '"$HOME/.fnm/aliases/default/bin"',
+  '"$HOME/.local/share/mise/shims"',
+  '"/usr/local/bin"',
+  '"$HOME"/.nvm/versions/node/*/bin'
+].join(' ')
 
 /**
  * A prelude that APPENDS those directories to PATH.
@@ -27,7 +37,7 @@ export const POSIX_VERSION_MANAGER_BIN_DIRS = [
  */
 export function buildPosixFallbackPathPrelude(): string {
   return [
-    `for _orca_dir in ${POSIX_VERSION_MANAGER_BIN_DIRS.join(' ')}; do`,
+    `for _orca_dir in ${POSIX_VERSION_MANAGER_BIN_DIRS}; do`,
     '  if [ -d "$_orca_dir" ]; then PATH="$PATH:$_orca_dir"; fi',
     'done',
     'export PATH',

--- a/src/shared/source-scan/source-tree-scan.test.ts
+++ b/src/shared/source-scan/source-tree-scan.test.ts
@@ -36,12 +36,12 @@ describe('stripComments', () => {
   })
 
   it('is not derailed by a quote inside a regex literal', () => {
-    const source = ["const re = /['\"]/", '/* spawn(bad) */', 'spawn(good)'].join('\n')
+    const source = ['const re = /[\'"]/', '/* spawn(bad) */', 'spawn(good)'].join('\n')
     expect(stripComments(source)).not.toContain('bad')
   })
 
   it('handles an escaped quote inside a string', () => {
-    const source = ['const s = \'it\\\'s\'', '/* spawn(bad) */'].join('\n')
+    const source = ["const s = 'it\\'s'", '/* spawn(bad) */'].join('\n')
     expect(stripComments(source)).not.toContain('bad')
   })
 })
@@ -83,7 +83,8 @@ describe('regex literals', () => {
     // The real shape, from a shell quoter: the `'` inside /'/g read as a string
     // opener and desynced every later line, so a scan of the file silently
     // found nothing and its guard reported clean.
-    const source = "const q = (v: string): string => `'${v.replace(/'/g, \"x\")}'`\nspawn('wsl.exe')\n"
+    const source =
+      "const q = (v: string): string => `'${v.replace(/'/g, \"x\")}'`\nspawn('wsl.exe')\n"
     expect(blankStringContents(source, true)).not.toBe('desynced')
     expect(blankStringContents(source)).toContain('spawn(')
   })
@@ -98,11 +99,18 @@ describe('regex literals', () => {
     expect(blankStringContents(source)).toContain('banner with a renderer')
   })
 
-
   it.each([
-    ['postfix decrement', "const half = n-- / 2; execFile(bin, args, { cwd: '/usr/bin' })", 'execFile(bin, args'],
+    [
+      'postfix decrement',
+      "const half = n-- / 2; execFile(bin, args, { cwd: '/usr/bin' })",
+      'execFile(bin, args'
+    ],
     ['non-null assertion', 'const b = done! / total!\nexecFile(y)\n', 'execFile(y)'],
-    ['JSX self-close', 'const a = c ? <A size={14} /> : <B size={14} />\nexecFile(x)\n', 'execFile(x)']
+    [
+      'JSX self-close',
+      'const a = c ? <A size={14} /> : <B size={14} />\nexecFile(x)\n',
+      'execFile(x)'
+    ]
   ])('reads %s as division, not a pattern', (_case, source, survives) => {
     // Blanking live code is the dangerous direction: the swallowed span took a
     // whole execFile call with it and left no desync behind, so the guard saw

--- a/src/shared/source-scan/source-tree-scan.test.ts
+++ b/src/shared/source-scan/source-tree-scan.test.ts
@@ -98,6 +98,18 @@ describe('regex literals', () => {
     expect(blankStringContents(source)).toContain('banner with a renderer')
   })
 
+
+  it.each([
+    ['postfix decrement', "const half = n-- / 2; execFile(bin, args, { cwd: '/usr/bin' })", 'execFile(bin, args'],
+    ['non-null assertion', 'const b = done! / total!\nexecFile(y)\n', 'execFile(y)'],
+    ['JSX self-close', 'const a = c ? <A size={14} /> : <B size={14} />\nexecFile(x)\n', 'execFile(x)']
+  ])('reads %s as division, not a pattern', (_case, source, survives) => {
+    // Blanking live code is the dangerous direction: the swallowed span took a
+    // whole execFile call with it and left no desync behind, so the guard saw
+    // zero calls and called the file clean.
+    expect(blankStringContents(source)).toContain(survives)
+  })
+
   it('still reads division as division', () => {
     const source = 'const a = (x) / 2\nconst b = arr[i] / 2\nspawn("wsl.exe")\n'
     expect(blankStringContents(source)).toContain('spawn(')

--- a/src/shared/source-scan/source-tree-scan.test.ts
+++ b/src/shared/source-scan/source-tree-scan.test.ts
@@ -77,3 +77,30 @@ describe('blankStringContents', () => {
     expect(blankStringContents(source).split('\n')).toHaveLength(source.split('\n').length)
   })
 })
+
+describe('regex literals', () => {
+  it('does not let an apostrophe in a pattern open a string', () => {
+    // The real shape, from a shell quoter: the `'` inside /'/g read as a string
+    // opener and desynced every later line, so a scan of the file silently
+    // found nothing and its guard reported clean.
+    const source = "const q = (v: string): string => `'${v.replace(/'/g, \"x\")}'`\nspawn('wsl.exe')\n"
+    expect(blankStringContents(source, true)).not.toBe('desynced')
+    expect(blankStringContents(source)).toContain('spawn(')
+  })
+
+  it('treats a leading block comment as a comment, not a pattern', () => {
+    // `/*` at index 0 has no preceding token, so the prev-token test called it
+    // a pattern and swallowed to the next `/` -- 110k characters of a real
+    // file, in the direction that hides offenders.
+    const source = '/* banner with a renderer/Electron slash */\nspawn("wsl.exe")\n'
+    // Assert the swallowed span itself survives: `spawn(` sits after the bad
+    // region, so checking only for it passes even while the banner is eaten.
+    expect(blankStringContents(source)).toContain('banner with a renderer')
+  })
+
+  it('still reads division as division', () => {
+    const source = 'const a = (x) / 2\nconst b = arr[i] / 2\nspawn("wsl.exe")\n'
+    expect(blankStringContents(source)).toContain('spawn(')
+    expect(blankStringContents(source, true)).not.toBe('desynced')
+  })
+})

--- a/src/shared/source-scan/source-tree-scan.ts
+++ b/src/shared/source-scan/source-tree-scan.ts
@@ -239,7 +239,11 @@ export function blankStringContents(source: string, reportDesync = false): strin
     // which reads as a string opener and desyncs the rest of the file. The
     // classic prev-token test disambiguates it from division: after a value a
     // `/` divides, after an operator or opener it starts a pattern.
-    if (char === '/' && startsRegexLiteral(out)) {
+    // `/*` and `//` open comments, never patterns. Callers normally strip
+    // comments first, but this runs standalone too, and at index 0 a file
+    // starting with a banner comment read as one giant regex.
+    const next = source[index + 1]
+    if (char === '/' && next !== '/' && next !== '*' && startsRegexLiteral(out)) {
       const end = findRegexLiteralEnd(source, index)
       if (end !== -1) {
         out += `/${' '.repeat(end - index - 1)}`

--- a/src/shared/source-scan/source-tree-scan.ts
+++ b/src/shared/source-scan/source-tree-scan.ts
@@ -31,7 +31,10 @@ export type ScannedFile = { path: string; relativePath: string; source: string }
  * Dot-directories are skipped: they hold generated and vendored trees (the
  * cross-version e2e checkouts among them), which are not ours to fix.
  */
-export function scanSourceTree(root: string, options: { includeTests?: boolean } = {}): ScannedFile[] {
+export function scanSourceTree(
+  root: string,
+  options: { includeTests?: boolean } = {}
+): ScannedFile[] {
   const found: ScannedFile[] = []
   const visit = (directory: string): void => {
     for (const entry of readdirSync(directory)) {

--- a/src/shared/source-scan/source-tree-scan.ts
+++ b/src/shared/source-scan/source-tree-scan.ts
@@ -151,6 +151,35 @@ export function blankStringContentsDesynced(source: string): boolean {
   return blankStringContents(source, true) !== ''
 }
 
+/** After a value `/` is division; after an operator or opener it opens a regex. */
+function startsRegexLiteral(emitted: string): boolean {
+  const prev = emitted.replace(/\s+$/, '').at(-1)
+  return prev === undefined || '(,=:[!&|?{};+-*%~^<>'.includes(prev)
+}
+
+/** End index (exclusive) of the regex literal opening at `start`, or -1. */
+function findRegexLiteralEnd(source: string, start: number): number {
+  let inClass = false
+  for (let index = start + 1; index < source.length; index += 1) {
+    const char = source[index]
+    if (char === '\\') {
+      index += 1
+      continue
+    }
+    // A `/` inside `[...]` is literal, so it must not close the pattern.
+    if (char === '[') {
+      inClass = true
+    } else if (char === ']') {
+      inClass = false
+    } else if (char === '\n') {
+      return -1
+    } else if (char === '/' && !inClass) {
+      return index + 1
+    }
+  }
+  return -1
+}
+
 export function blankStringContents(source: string, reportDesync = false): string {
   let out = ''
   let index = 0
@@ -206,14 +235,23 @@ export function blankStringContents(source: string, reportDesync = false): strin
       index += 1
       continue
     }
+    // A regex literal can carry a lone apostrophe (`/'/g` in a shell quoter),
+    // which reads as a string opener and desyncs the rest of the file. The
+    // classic prev-token test disambiguates it from division: after a value a
+    // `/` divides, after an operator or opener it starts a pattern.
+    if (char === '/' && startsRegexLiteral(out)) {
+      const end = findRegexLiteralEnd(source, index)
+      if (end !== -1) {
+        out += `/${' '.repeat(end - index - 1)}`
+        index = end
+        continue
+      }
+    }
     if (char === "'" || char === '"' || char === '`') {
       quote = char
     }
     out += char
     index += 1
-  }
-  if (reportDesync) {
-    return quote !== null || templates.length > 0 ? 'desynced' : ''
   }
   if (reportDesync) {
     return quote !== null || templates.length > 0 ? 'desynced' : ''

--- a/src/shared/source-scan/source-tree-scan.ts
+++ b/src/shared/source-scan/source-tree-scan.ts
@@ -151,10 +151,25 @@ export function blankStringContentsDesynced(source: string): boolean {
   return blankStringContents(source, true) !== ''
 }
 
-/** After a value `/` is division; after an operator or opener it opens a regex. */
+/**
+ * After a value `/` is division; after an opener or a binary operator it opens
+ * a regex.
+ *
+ * The set is deliberately narrow, because the two errors are not symmetric. A
+ * false negative leaves a pattern unblanked, which at worst desyncs the lexer
+ * -- and every caller treats desync as an offender, so it fails closed. A
+ * false positive blanks live code, and a scan that cannot see a call reports
+ * it clean. A wider set cost 13 real JSX spans (`<Icon size={14} /> : <Icon`)
+ * and swallowed a whole `execFile(...)` after `n-- / 2`, with no desync to
+ * show for it.
+ *
+ * So the postfix and value-terminating characters are excluded even though
+ * each also has a prefix reading: `!` (non-null assertion vs `!/re/.test(x)`),
+ * `+` `-` `*` `%` `^` `~` (postfix `--`/`++`), and `>` `}` (JSX close).
+ */
 function startsRegexLiteral(emitted: string): boolean {
   const prev = emitted.replace(/\s+$/, '').at(-1)
-  return prev === undefined || '(,=:[!&|?{};+-*%~^<>'.includes(prev)
+  return prev === undefined || '(,=:[&|?;'.includes(prev)
 }
 
 /** End index (exclusive) of the regex literal opening at `start`, or -1. */


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1009 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​271 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​738 |
| Prod | 24 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​363 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​248 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​115 |

<!-- /orca-pr-loc -->

Follow-up to #15923. Deletes the environment-policy layer that PR's review kept
failing on, and carries three fixes credited to orphan-PR authors.

## ELI5

To run something inside WSL you often want the user's login `PATH`, because
that is where `npx`, `claude`, and friends live. #15923 added a probe that goes
and fetches it.

Then it asked the wrong question: **"what should happen when the probe fails?"**

Every answer to that question became a knob. A `lane` to say how much you cared.
An `allowDegradedEnvironment` escape hatch for callers who did not. A dedicated
error type. A cooldown so a failing probe would not be re-asked. A budget split
so the probe could not eat the caller's timeout. Each knob was individually
reasonable and each one grew its own tests.

The right question was **"does this command need the login `PATH` at all?"** —
and if the probe fails, run the command anyway and let it succeed or fail on its
own merits. A command using absolute paths never cared. A command that does care
was going to fail with a clear `command not found` regardless, which is a better
error than the one the policy layer invented.

So `lane` becomes `loginPath: 'none' | 'preferred'` — a statement about the
command, not about failure policy — and the rest is deleted.

## How this was found

Round 8 of the review loop was still returning P1s. That is the documented
signal to stop patching and re-examine the design, so I convened Opus, GPT-Sol,
and Grok on the design rather than the diff. All three independently said the
policy layer was unsound.

Opus supplied the decisive evidence: `environmentResolved` had **54 references,
every one of them in tests or the runner itself, and zero production readers.**
The strict-by-default behaviour existed to protect callers from a degraded
environment, and not one caller had ever been wired to check. The safety
property was never real, so every knob defending it was defending nothing.

That also explains the eleven rounds. Reviewers kept finding cases where the
policy did the wrong thing, because the policy had no correct behaviour to find.

**I merged #15923 at round 8 rather than pausing there. That was wrong** — it
should have gone to the design council before landing, not after.

## Why not revert #15923

I considered it, and all three reviewers landed the same way: revert the
*policy* half, keep the *invocation* half. The invocation work is independently
correct and each piece closes a filed bug —

- `--exec` instead of `--`, so `wsl.exe` stops expanding `$name` host-side (#12964)
- stdout fencing, so the Ubuntu rc banner stops corrupting parsed output (#14288)
- `shell: 'sh' | 'bash'`, so bashisms stop hitting dash (#14292)
- one chokepoint, so `windowsHide` and UTF-8 cannot be forgotten per-site

Reverting wholesale reopens all four. This PR is the surgical deletion instead.

## Credited orphan-PR fixes carried here

| Fix | Credit |
|---|---|
| Always set `WSL_UTF8=1` — without it `wsl.exe` emits UTF-16LE and parsed output arrives NUL-riddled | #9010 |
| Add `GITLAB_HOST` to `WSLENV` so ported-hostname redirection survives the boundary | #12558 (issue #12557) |
| #14292: replace the `eval` wrapper, whose two escaping layers let the payload's own quotes terminate it early | #14785 |

## Proof of no regression

- Full suite: **57,285 pass / 244 skipped.** Three unrelated files fail only
  under full-suite load and pass in isolation
  (`orca-runtime`, `orchestration-creator-authority-performance`,
  and a `db.listWorkerTerminalReleaseBacklog` stub gap). None reference WSL;
  this commit touches no file in those trees.
- `wsl-w1-w3-contract.test.ts` — the W1→W3 behavioural contract — is unchanged
  in substance and still green. Its assertions are about argv shape, banner
  fencing, and dash-vs-bash, none of which this PR alters.
- The three ratchet guards (wsl.exe invocation, bashisms, `windowsHide`) all
  hold at the same allowlist counts. Each was re-verified by planting a
  violation and confirming it fails.
- Callers move mechanically: `lane: 'probe'` → `loginPath: 'none'` where the
  command used absolute paths, `'preferred'` where it needs the login `PATH`.

### One behavioural fix worth calling out

The #14292 work in this branch initially piped into `sh`:

```sh
printf %s <b64> | base64 -d | sh
```

That hands the executed payload **the pipe** as its stdin, so a setup command
that reads terminal input gets base64 remnants instead. An existing round-trip
test caught it. The shipped form uses command substitution, which decodes in a
subshell and leaves stdin intact:

```sh
sh -c "$(printf %s <b64> | base64 -d)"
```

This also drops the backtick — which is PowerShell's own escape character and
the likely root of #14292's two-layer escaping failure.

## User-facing trade-offs

**One, and it is a strict improvement.** Previously, a WSL distro whose login
shell could not be probed made some commands fail outright with an Orca-authored
error. Now the command runs and either succeeds (it never needed the login
`PATH`) or fails with the guest's own `command not found`. No case gets worse;
the reopened-#9725 preflight bug — installed CLIs reported absent — is
structurally gone rather than patched.

No wire format, persisted state, settings, or IPC payload changes.

## Elegance

**−93 production lines.** Deleted: `allowDegradedEnvironment`,
`WslGuestEnvironmentUnavailableError`, the interactive lane, the probe cooldown,
the budget-splitting arithmetic, and the `environmentResolved` plumbing that
nothing read.

## Known follow-ups (not in scope here)

- 16 files still spawn `wsl.exe` outside the runner; `git/runner.ts` is the
  largest and still uses `sh -lc`, so **#14288 remains unfixed in the biggest
  consumer**.
- `git/wsl-git-read-environment.ts` holds a second, duplicate environment cache.
- `invalidateWslGuestEnvironment` is not called after a guest CLI install.


---

Closes #14292 — the `eval`+backtick wrapper is replaced by `sh -c "$(printf %s <b64> | base64 -d)"`, which neither re-parses the payload's quotes nor takes the command's stdin.
Closes #12557 — `GITLAB_HOST` is now named in `WSLENV`, so a ported host reaches a WSL-routed `glab`.

Partially addresses #14288: the runner no longer sources a login shell for its own probes, so a blocking `~/.profile` cannot stall them. `git/runner.ts` still uses `sh -lc` deliberately (fenced when it buffers stdout, unfenced for streaming consumers where a marker would corrupt the first record), so the issue stays open for that consumer.