### PR TITLE
fix(terminal): arm the restore baseline only on a snapshot that painted content

### DIFF
--- a/src/main/runtime/headless-terminal-dispose-write-ordering.test.ts
+++ b/src/main/runtime/headless-terminal-dispose-write-ordering.test.ts
@@ -1,0 +1,106 @@
+/**
+ * disposeHeadlessTerminal's unwritten contract: no model write is ever dropped.
+ *
+ * Two halves, both load-bearing and both silently reversible:
+ *   1. `headlessTerminals.delete(ptyId)` runs BEFORE disposal, so a write
+ *      issued after the call lazily creates a fresh emulator instead of
+ *      landing on the disposing one.
+ *   2. `dispose()` is registered on the CURRENT writeChain, so links already
+ *      queued behind it parse before the emulator goes away.
+ * Swapping either ordering loses output with no error anywhere.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+import { HeadlessEmulator } from '../daemon/headless-emulator'
+
+const store = {
+  getRepo: () => undefined,
+  getRepos: () => [],
+  addRepo: () => {},
+  updateRepo: () => undefined as never,
+  getAllWorktreeMeta: () => ({}),
+  getWorktreeMeta: () => undefined,
+  setWorktreeMeta: () => undefined as never,
+  removeWorktreeMeta: () => {},
+  getRetiredWorktreeNameRegistry: () => ({ exhaustedTiers: 0, names: [] }),
+  addRetiredWorktreeName: () => {},
+  mergeRetiredWorktreeNames: () => false,
+  getGitHubCache: () => ({ pr: {}, issue: {} }) as never,
+  getSettings: () => ({
+    workspaceDir: '/tmp/workspaces',
+    nestWorkspaces: false,
+    refreshLocalBaseRefOnWorktreeCreate: false,
+    branchPrefix: 'none',
+    branchPrefixCustom: '',
+    terminalMainSideEffectAuthority: true
+  })
+}
+
+const PTY_ID = 'pty-dispose-ordering'
+
+function createRuntime(): OrcaRuntimeService {
+  const runtime = new OrcaRuntimeService(store)
+  runtime.setPtyController({
+    write: () => true,
+    kill: () => true,
+    getForegroundProcess: async () => null,
+    getSize: () => ({ cols: 80, rows: 24 }),
+    resize: () => true
+  })
+  return runtime
+}
+
+describe('disposeHeadlessTerminal write ordering', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('parses a write queued before disposal, then routes later writes to a fresh emulator', async () => {
+    const events: string[] = []
+    const emulators: HeadlessEmulator[] = []
+    const write = HeadlessEmulator.prototype.write
+    const dispose = HeadlessEmulator.prototype.dispose
+    vi.spyOn(HeadlessEmulator.prototype, 'write').mockImplementation(async function (
+      this: HeadlessEmulator,
+      data: string,
+      opts
+    ) {
+      if (!emulators.includes(this)) {
+        emulators.push(this)
+      }
+      events.push(`write:${emulators.indexOf(this)}:${data.trim()}`)
+      return write.call(this, data, opts)
+    })
+    vi.spyOn(HeadlessEmulator.prototype, 'dispose').mockImplementation(
+      function (this: HeadlessEmulator) {
+        events.push(`dispose:${emulators.indexOf(this)}`)
+        return dispose.call(this)
+      }
+    )
+
+    const runtime = createRuntime()
+    // Queued but not yet parsed: the chain link is still pending here.
+    runtime.onPtyData(PTY_ID, 'QUEUED-BEFORE-DISPOSE\r\n', 1)
+    runtime.resetPtyModelAfterMigrationFailure(PTY_ID)
+    runtime.onPtyData(PTY_ID, 'ISSUED-AFTER-DISPOSE\r\n', 2)
+    await runtime.serializeHiddenOutputRecoveryBuffer(PTY_ID)
+
+    expect(events).toEqual([
+      'write:0:QUEUED-BEFORE-DISPOSE',
+      'write:1:ISSUED-AFTER-DISPOSE',
+      'dispose:0'
+    ])
+  })
+
+  it('leaves the post-disposal emulator holding only post-disposal output', async () => {
+    const runtime = createRuntime()
+    runtime.onPtyData(PTY_ID, 'QUEUED-BEFORE-DISPOSE\r\n', 1)
+    runtime.resetPtyModelAfterMigrationFailure(PTY_ID)
+    runtime.onPtyData(PTY_ID, 'ISSUED-AFTER-DISPOSE\r\n', 2)
+
+    const snapshot = await runtime.serializeHiddenOutputRecoveryBuffer(PTY_ID)
+    const painted = `${snapshot?.scrollbackAnsi ?? ''}${snapshot?.data ?? ''}`
+    expect(painted).toContain('ISSUED-AFTER-DISPOSE')
+    expect(painted).not.toContain('QUEUED-BEFORE-DISPOSE')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-connection-restored-baseline-shortfall.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-restored-baseline-shortfall.test.ts
@@ -1,0 +1,263 @@
+import type * as React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { flushAsyncTicks } from './pty-connection-test-async'
+import {
+  createMockTransport,
+  createPane,
+  createManager,
+  type ConnectCallbacks,
+  type MockTransport
+} from './pty-connection-test-pane-fixtures'
+import { buildPaneConnectionDeps } from './pty-connection-test-deps'
+import { createInitialStoreState } from './pty-connection-test-store-fixtures'
+import type { StoreState } from './pty-connection-test-store-state'
+import {
+  installTerminalTestGlobals,
+  restoreTerminalTestGlobals
+} from './pty-connection-test-environment'
+
+const {
+  resetAndRefreshAllTerminalWebglAtlases,
+  scheduleTerminalWebglAtlasRecovery,
+  scheduleRuntimeGraphSync,
+  shouldSeedCacheTimerOnInitialTitle,
+  toastInfo,
+  notifyCodexPaneBoundForStaleSweep
+} = vi.hoisted(() => ({
+  resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
+  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleRuntimeGraphSync: vi.fn(),
+  shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
+  toastInfo: vi.fn(),
+  notifyCodexPaneBoundForStaleSweep: vi.fn()
+}))
+
+let mockStoreState: StoreState
+let transportFactoryQueue: MockTransport[] = []
+let createdTransportOptions: Record<string, unknown>[] = []
+let storeSubscribers: ((state: StoreState) => void)[] = []
+
+vi.mock('@/runtime/sync-runtime-graph', () => ({ scheduleRuntimeGraphSync }))
+
+vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  resetAndRefreshAllTerminalWebglAtlases
+}))
+
+vi.mock('./terminal-webgl-atlas-recovery', () => ({
+  scheduleTerminalWebglAtlasRecovery
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => mockStoreState,
+    subscribe: (listener: (state: StoreState) => void) => {
+      storeSubscribers.push(listener)
+      return () => {
+        storeSubscribers = storeSubscribers.filter((candidate) => candidate !== listener)
+      }
+    }
+  }
+}))
+
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const { buildAgentStatusModuleMock } = await import('./pty-connection-test-environment')
+  return buildAgentStatusModuleMock(await importOriginal<Record<string, unknown>>())
+})
+
+vi.mock('./cache-timer-seeding', () => ({
+  shouldSeedCacheTimerOnInitialTitle
+}))
+
+vi.mock('sonner', () => ({ toast: { info: toastInfo } }))
+
+vi.mock('@/lib/codex-stale-pane-sweep', () => ({
+  notifyCodexPaneBoundForStaleSweep
+}))
+
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof React>()
+  return {
+    ...actual,
+    useCallback: <T extends (...args: unknown[]) => unknown>(fn: T): T => fn
+  }
+})
+
+vi.mock('./pty-transport', () => ({
+  createIpcPtyTransport: vi.fn((options: Record<string, unknown>) => {
+    createdTransportOptions.push(options)
+    const nextTransport = transportFactoryQueue.shift()
+    if (!nextTransport) {
+      throw new Error('No mock transport queued')
+    }
+    return nextTransport
+  })
+}))
+
+vi.mock('./remote-runtime-pty-transport', () => ({
+  createRemoteRuntimePtyTransport: vi.fn(
+    (_environmentId: string, options: Record<string, unknown>) => {
+      createdTransportOptions.push(options)
+      const nextTransport = transportFactoryQueue.shift()
+      if (!nextTransport) {
+        throw new Error('No mock transport queued')
+      }
+      return nextTransport
+    }
+  )
+}))
+
+vi.mock('./pty-dispatcher', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, getEagerPtyBufferHandle: vi.fn(() => undefined) }
+})
+
+/** Mode/attribute rehydration only — the shape a model emulator serializes when
+ *  a seed or hydration write never landed and it holds no cell content. */
+const BLANK_MODEL_IMAGE = '\x1b[0m\x1b[?25h\x1b[?7h'
+
+describe('restored snapshot baseline shortfall (STA-5179)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    transportFactoryQueue = []
+    createdTransportOptions = []
+    storeSubscribers = []
+    mockStoreState = createInitialStoreState(() => mockStoreState)
+    installTerminalTestGlobals()
+  })
+
+  afterEach(async () => {
+    await restoreTerminalTestGlobals()
+  })
+
+  function createDeps(overrides: Record<string, unknown> = {}) {
+    return buildPaneConnectionDeps(() => mockStoreState, overrides)
+  }
+
+  function writtenData(pane: ReturnType<typeof createPane>): string {
+    return pane.terminal.write.mock.calls.map((call) => String(call[0])).join('')
+  }
+
+  async function revealPaneWithModelSnapshot(snapshot: {
+    data: string
+    seq: number
+    pendingDeliveryStartSeq?: number
+    scrollbackAnsi?: string
+  }): Promise<{
+    pane: ReturnType<typeof createPane>
+    dataCallback: (data: string, meta?: { seq?: number; rawLength?: number }) => void
+    getMainBufferSnapshot: ReturnType<typeof vi.fn>
+  }> {
+    mockStoreState.settings = {
+      ...mockStoreState.settings,
+      terminalMainSideEffectAuthority: true
+    } as StoreState['settings']
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('pty-id')
+    const capturedDataCallback: {
+      current: ((data: string, meta?: { seq?: number; rawLength?: number }) => void) | null
+    } = { current: null }
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+    const pane = createPane(1)
+    connectPanePty(
+      pane as never,
+      createManager(1) as never,
+      createDeps({
+        isVisibleRef: { current: true }
+      }) as never
+    )
+    await flushAsyncTicks(6)
+    const transportOptions = createdTransportOptions.at(-1) as {
+      onPtySpawn?: (ptyId: string) => void
+    }
+    transportOptions.onPtySpawn?.('pty-id')
+
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+    getMainBufferSnapshot.mockResolvedValue({
+      cols: 100,
+      rows: 30,
+      ...snapshot
+    })
+    const { _dispatchPtyModelRestoreNeededForTest } = await import('./pty-model-restore-channel')
+    _dispatchPtyModelRestoreNeededForTest({
+      id: 'pty-id',
+      reason: 'pending-cap',
+      markerSeq: snapshot.seq
+    })
+    await flushAsyncTicks(20)
+    expect(getMainBufferSnapshot).toHaveBeenCalledTimes(1)
+    pane.terminal.write.mockClear()
+    return {
+      pane,
+      dataCallback: capturedDataCallback.current!,
+      getMainBufferSnapshot
+    }
+  }
+
+  it('recovers the backlog a blank snapshot claimed to have painted', async () => {
+    // The model over-reports: seq 2_472 with no cell content behind it. Every
+    // chunk carrying the missing tail sits at or below that seq, so the old
+    // baseline dropped all of it as duplicates with nothing left to re-send.
+    const { pane, dataCallback } = await revealPaneWithModelSnapshot({
+      data: BLANK_MODEL_IMAGE,
+      seq: 2_472,
+      pendingDeliveryStartSeq: 2_400
+    })
+
+    dataCallback('TAIL-INSIDE-WINDOW', { seq: 2_460, rawLength: 18 })
+    await flushAsyncTicks(8)
+    expect(writtenData(pane)).toContain('TAIL-INSIDE-WINDOW')
+
+    // Straddling the claimed baseline: the whole chunk is recovered, not sliced.
+    dataCallback('TAIL-STRADDLING', { seq: 2_475, rawLength: 15 })
+    await flushAsyncTicks(8)
+    expect(writtenData(pane)).toContain('TAIL-STRADDLING')
+
+    // An idle shell never re-sends: no further restore is needed to heal.
+    dataCallback('LIVE-AFTER-BASELINE', { seq: 2_494, rawLength: 19 })
+    await flushAsyncTicks(8)
+    expect(writtenData(pane)).toContain('LIVE-AFTER-BASELINE')
+  })
+
+  it('recovers the backlog when only scrollback-less blank content was painted', async () => {
+    const { pane, dataCallback } = await revealPaneWithModelSnapshot({
+      data: '\x1b[H\x1b[2J',
+      scrollbackAnsi: '   \r\n',
+      seq: 900
+    })
+
+    dataCallback('BLANK-WITH-WHITESPACE-SCROLLBACK', {
+      seq: 880,
+      rawLength: 32
+    })
+    await flushAsyncTicks(8)
+    expect(writtenData(pane)).toContain('BLANK-WITH-WHITESPACE-SCROLLBACK')
+  })
+
+  it('still suppresses backlog duplicates behind a snapshot that painted content', async () => {
+    // Regression guard for the normal path: a snapshot with real cell content
+    // keeps its drop-everything baseline, so the ACK backlog stays suppressed.
+    const { pane, dataCallback } = await revealPaneWithModelSnapshot({
+      data: 'restored snapshot\r\n',
+      seq: 2_472,
+      pendingDeliveryStartSeq: 2_400
+    })
+
+    dataCallback('COVERED-DUPLICATE', { seq: 2_460, rawLength: 17 })
+    await flushAsyncTicks(8)
+    expect(writtenData(pane)).not.toContain('COVERED-DUPLICATE')
+
+    // Only the post-baseline remainder of a straddling chunk is written.
+    dataCallback('ABCDEFGHIJKLMNOPQRSTU', { seq: 2_478, rawLength: 21 })
+    await flushAsyncTicks(8)
+    expect(writtenData(pane)).toContain('PQRSTU')
+    expect(writtenData(pane)).not.toContain('ABCDEF')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -19,6 +19,7 @@ import { isEphemeralSetupTerminalWorktreeId } from '../../../../shared/ephemeral
 import { TERMINAL_PAIRED_PARKING_RUNTIME_CAPABILITY } from '../../../../shared/protocol-version'
 import { TerminalKittyKeyboardModeTracker } from '../../../../shared/terminal-kitty-keyboard-mode-tracker'
 import { parseTerminalKittyKeyboardFlags } from '../../../../shared/terminal-kitty-keyboard-flags'
+import { restoredSnapshotPaintsPrintableContent } from './restored-snapshot-coverage'
 import { isRuntimeOwnedSshTargetId, parseExecutionHostId } from '../../../../shared/execution-host'
 import { createTerminalZeroDimensionsMessage } from '../../../../shared/terminal-zero-dimensions-diagnostic'
 import { isWorktreeRemovalFenceError } from '../../../../shared/worktree/removal-fence-error'
@@ -5982,6 +5983,7 @@ export function connectPanePty(
     let hiddenOutputRestoreReplayingSnapshot: {
       seq?: number
       pendingDeliveryStartSeq?: number
+      paintsContent?: boolean
     } | null = null
     let hiddenOutputRestoreFloodRepaintTimer: ReturnType<typeof setTimeout> | null = null
     let cancelHiddenOutputRestoreFloodRepaintPark: (() => void) | null = null
@@ -6001,9 +6003,16 @@ export function connectPanePty(
 
     function setRestoredSnapshotBaseline(
       ptyId: string,
-      snapshot: { seq?: number; pendingDeliveryStartSeq?: number }
+      snapshot: { seq?: number; pendingDeliveryStartSeq?: number },
+      paintsContent: boolean
     ): void {
       if (typeof snapshot.seq !== 'number') {
+        clearRestoredSnapshotBaseline()
+        return
+      }
+      // Why: arming drops the redelivery permanently, so the snapshot's painted
+      // content must be able to back the seq it claims; a blank image cannot (STA-5179).
+      if (snapshot.seq > 0 && !paintsContent) {
         clearRestoredSnapshotBaseline()
         return
       }
@@ -7220,7 +7229,11 @@ export function connectPanePty(
         pendingData += sliced ?? chunk.data
       }
       if (replayingSnapshot && replayedSeq !== null) {
-        setRestoredSnapshotBaseline(expectedPtyId, replayingSnapshot)
+        setRestoredSnapshotBaseline(
+          expectedPtyId,
+          replayingSnapshot,
+          replayingSnapshot.paintsContent === true
+        )
         for (const chunk of pendingChunks) {
           if (typeof chunk.seq === 'number' && restoredSnapshotExpectedStartSeq !== null) {
             restoredSnapshotExpectedStartSeq = Math.max(restoredSnapshotExpectedStartSeq, chunk.seq)
@@ -7403,6 +7416,7 @@ export function connectPanePty(
             if (typeof snapshot.seq === 'number') {
               hiddenOutputRestoreReplayingSnapshot = {
                 seq: snapshot.seq,
+                paintsContent: restoredSnapshotPaintsPrintableContent(snapshot),
                 ...(typeof snapshot.pendingDeliveryStartSeq === 'number'
                   ? { pendingDeliveryStartSeq: snapshot.pendingDeliveryStartSeq }
                   : {})
@@ -7726,7 +7740,11 @@ export function connectPanePty(
             return
           }
           // Why: everything at/before snapshot.seq is now painted; chunks still draining from main's ACK backlog below it are duplicates to suppress.
-          setRestoredSnapshotBaseline(currentPtyId, snapshot)
+          setRestoredSnapshotBaseline(
+            currentPtyId,
+            snapshot,
+            restoredSnapshotPaintsPrintableContent(snapshot)
+          )
           hiddenOutputRestoreReplayingSnapshot = null
           const needsFreshSnapshot = hiddenOutputRestoreFreshSnapshotNeeded
           hiddenOutputRestoreFreshSnapshotNeeded = false
@@ -8537,7 +8555,11 @@ export function connectPanePty(
               writeReplayData(modelSnapshot.pendingEscapeTailAnsi)
             }
             // Why: main sampled its delivery backlog with the snapshot; the baseline drops/slices deferred and live chunks the snapshot already covers.
-            setRestoredSnapshotBaseline(ptyId, modelSnapshot)
+            setRestoredSnapshotBaseline(
+              ptyId,
+              modelSnapshot,
+              restoredSnapshotPaintsPrintableContent(modelSnapshot)
+            )
             recordRendererOrderedSeq(modelSnapshot)
             sendFocusedReattachFocusInAfterReplay(ptyId, attemptGeneration)
             if (connectResult?.coldRestore && !isRemoteRuntimePtyId(ptyId)) {

--- a/src/renderer/src/components/terminal-pane/restored-snapshot-coverage.test.ts
+++ b/src/renderer/src/components/terminal-pane/restored-snapshot-coverage.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { restoredSnapshotPaintsPrintableContent } from './restored-snapshot-coverage'
+
+describe('restoredSnapshotPaintsPrintableContent', () => {
+  it('accepts a snapshot with cell content in the frame or the scrollback', () => {
+    expect(restoredSnapshotPaintsPrintableContent({ data: '\x1b[0m$ ls\r\n' })).toBe(true)
+    expect(
+      restoredSnapshotPaintsPrintableContent({
+        data: '\x1b[H\x1b[2J',
+        scrollbackAnsi: 'older\r\n'
+      })
+    ).toBe(true)
+  })
+
+  it('rejects a mode-rehydration-only image, which no amount of output renders to', () => {
+    expect(
+      restoredSnapshotPaintsPrintableContent({
+        data: '\x1b[0m\x1b[?25h\x1b[?7h'
+      })
+    ).toBe(false)
+    expect(restoredSnapshotPaintsPrintableContent({ data: '\x1b]0;title\x07' })).toBe(false)
+    expect(restoredSnapshotPaintsPrintableContent({})).toBe(false)
+    expect(
+      restoredSnapshotPaintsPrintableContent({
+        data: '\x1b[2J',
+        scrollbackAnsi: '  \r\n\t'
+      })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/restored-snapshot-coverage.ts
+++ b/src/renderer/src/components/terminal-pane/restored-snapshot-coverage.ts
@@ -1,0 +1,32 @@
+import {
+  stripAnsiEscapeSequences,
+  TERMINAL_CONTROL_CHARACTER_PATTERN
+} from '../../../../shared/ansi-escape-sequences'
+
+/**
+ * Whether a restored model snapshot painted any printable cell content.
+ *
+ * Why this gates the restore baseline (STA-5179): the baseline makes every
+ * chunk at or below the snapshot's `seq` unrecoverable, on the model's word
+ * that those bytes are already painted. An image with no printable characters
+ * cannot be the rendering of the output it claims to cover, so the claim is
+ * disproven and the redelivery is the only remaining copy of those bytes.
+ * Replaying it into the blank screen the snapshot just produced also cannot
+ * duplicate visible output, so refusing to arm is the safe direction.
+ */
+export function restoredSnapshotPaintsPrintableContent(snapshot: {
+  data?: string
+  scrollbackAnsi?: string
+}): boolean {
+  return hasPrintableContent(snapshot.data) || hasPrintableContent(snapshot.scrollbackAnsi)
+}
+
+function hasPrintableContent(value: string | undefined): boolean {
+  if (!value) {
+    return false
+  }
+  return (
+    stripAnsiEscapeSequences(value).replace(TERMINAL_CONTROL_CHARACTER_PATTERN, '').trim().length >
+    0
+  )
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​399 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​399 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​58 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​54 |

<!-- /orca-pr-loc -->

## What

`setRestoredSnapshotBaseline` arms a baseline that permanently drops every delivery chunk at or below the snapshot's `seq`, on the model's claim that those bytes are already painted.

`reconcileChunkAgainstRestoredSnapshot` has recovery for a baseline that **under**-reports — a gap ahead triggers `force-fresh-restore`, and a `rawLength` mismatch re-restores. It has no path for a baseline that **over**-reports. Those chunks hit `if (meta.seq <= restoredSnapshotBaselineSeq) return { action: 'drop-duplicate' }` forever, and an idle shell never re-sends them, so the hole never heals.

This gates arming on whether the snapshot actually painted printable cells. A snapshot claiming `seq > 0` while painting nothing cannot be the rendering of the output it claims to cover, so the claim is disproven and the redelivery is the only remaining copy of those bytes.

Also adds `headless-terminal-dispose-write-ordering.test.ts`, pinning both halves of `disposeHeadlessTerminal`'s contract (a write queued before disposal still parses; a write issued after lands on a fresh emulator). Both halves were previously unpinned and silently reversible — the test is mutation-verified.

## Honest scope — please read before approving

- **This does not fix STA-4999.** That bug's pane shows a *truncated* buffer that ends mid-pad, not a blank one. Truncated is not blank, so this guard would not have caught it. STA-4999 stays open.
- **No field evidence that blank-with-`seq > 0` actually occurs.** This is a reachable-by-inspection hole in a function with a proven recovery asymmetry, hardened defensively. It is not a reproduction of an observed failure.
- **Known false positive.** The predicate is `stripAnsiEscapeSequences(...).trim()`, so a screen painted entirely as spaces on a colored background reads as blank. Such a snapshot would decline to arm and replay a bounded backlog instead. The trade is deliberate — replaying a bounded backlog is recoverable, dropping bytes permanently is not — but it is a real behavior change on that path.

## Testing

- `pty-connection-restored-baseline-shortfall.test.ts` — integration through `connectPanePty`: the inverse case recovered (chunk inside the window, chunk straddling the baseline, live chunk after it), plus a regression guard that a content-bearing snapshot still suppresses duplicates *and* still trims a straddling chunk.
- `restored-snapshot-coverage.test.ts` — predicate units.
- **Mutation-verified**: removing the guard fails both recovery tests and leaves the regression guard passing.
- 3,724 terminal-pane tests, 2 dispose-ordering tests, `typecheck:web`, `typecheck:node`, `oxlint` — all green.

Refs STA-5179
