### PR TITLE
feat(dictation): add sound-reactive grape visualizer

### DIFF
--- a/src/renderer/src/components/dictation/DictationController.tsx
+++ b/src/renderer/src/components/dictation/DictationController.tsx
@@ -19,6 +19,7 @@ export function DictationController() {
   const dictationState = useAppStore((s) => s.dictationState)
   const setDictationState = useAppStore((s) => s.setDictationState)
   const setPartialTranscript = useAppStore((s) => s.setPartialTranscript)
+  const setDictationMeter = useAppStore((s) => s.setDictationMeter)
   const recordFeatureInteraction = useAppStore((s) => s.recordFeatureInteraction)
   const settings = useAppStore((s) => s.settings)
   const keybindings = useAppStore((s) => s.keybindings)
@@ -28,7 +29,7 @@ export function DictationController() {
     flushBufferedAudio,
     discardBufferedAudio,
     getCapturedChunkCount
-  } = useAudioCapture()
+  } = useAudioCapture(setDictationMeter)
 
   const dictationStateRef = useRef(dictationState)
   dictationStateRef.current = dictationState

--- a/src/renderer/src/components/dictation/DictationController.tsx
+++ b/src/renderer/src/components/dictation/DictationController.tsx
@@ -14,12 +14,12 @@ import { translate } from '@/i18n/i18n'
 import { showDictationStartErrorToast } from './dictation-start-error-toast'
 import { useHoldDictationGesture } from './use-hold-dictation-gesture'
 import { DICTATION_CONTROL_EVENT, type DictationControlAction } from './dictation-control-events'
+import { publishDictationMeter } from './dictation-meter-store'
 
 export function DictationController() {
   const dictationState = useAppStore((s) => s.dictationState)
   const setDictationState = useAppStore((s) => s.setDictationState)
   const setPartialTranscript = useAppStore((s) => s.setPartialTranscript)
-  const setDictationMeter = useAppStore((s) => s.setDictationMeter)
   const recordFeatureInteraction = useAppStore((s) => s.recordFeatureInteraction)
   const settings = useAppStore((s) => s.settings)
   const keybindings = useAppStore((s) => s.keybindings)
@@ -29,7 +29,7 @@ export function DictationController() {
     flushBufferedAudio,
     discardBufferedAudio,
     getCapturedChunkCount
-  } = useAudioCapture(setDictationMeter)
+  } = useAudioCapture(publishDictationMeter)
 
   const dictationStateRef = useRef(dictationState)
   dictationStateRef.current = dictationState

--- a/src/renderer/src/components/dictation/DictationGrapes.tsx
+++ b/src/renderer/src/components/dictation/DictationGrapes.tsx
@@ -1,0 +1,47 @@
+import { cn } from '@/lib/utils'
+
+const GRAPES = [
+  { base: 0.64, response: 0.45, lift: 1 },
+  { base: 0.76, response: 0.75, lift: -1 },
+  { base: 0.9, response: 1, lift: 1 },
+  { base: 1, response: 1.25, lift: -1 },
+  { base: 0.86, response: 0.9, lift: 1 },
+  { base: 0.72, response: 1.1, lift: -1 },
+  { base: 0.82, response: 0.7, lift: 1 },
+  { base: 0.68, response: 0.55, lift: -1 },
+  { base: 0.58, response: 0.35, lift: 1 }
+] as const
+
+type DictationGrapesProps = {
+  level: number
+  active: boolean
+  transitioning: boolean
+}
+
+export function DictationGrapes({ level, active, transitioning }: DictationGrapesProps) {
+  const normalizedLevel = Math.min(1, Math.max(0, level))
+
+  return (
+    <div
+      data-testid="dictation-grapes"
+      aria-hidden="true"
+      className={cn(
+        'flex h-6 w-11 shrink-0 items-center justify-center gap-px overflow-hidden',
+        transitioning && 'animate-pulse motion-reduce:animate-none'
+      )}
+    >
+      {GRAPES.map((grape, index) => {
+        const energy = active ? normalizedLevel : 0
+        const scale = grape.base + energy * grape.response
+        const verticalOffset = energy * grape.lift * 2
+        return (
+          <span
+            key={index}
+            className="size-1 shrink-0 rounded-full bg-current opacity-80 transition-transform duration-100 ease-out motion-reduce:transition-none"
+            style={{ transform: `translateY(${verticalOffset}px) scale(${scale})` }}
+          />
+        )
+      })}
+    </div>
+  )
+}

--- a/src/renderer/src/components/dictation/DictationIndicator.test.tsx
+++ b/src/renderer/src/components/dictation/DictationIndicator.test.tsx
@@ -12,10 +12,8 @@ const storeState = {
   partialTranscript: '',
   dictationMeter: {
     level: 0,
-    peak: 0,
     isSpeaking: false,
-    isClipping: false,
-    lastUpdatedAt: 0
+    isClipping: false
   },
   settings: { voice: { dictationMode: 'toggle' } } as {
     voice?: { dictationMode?: 'toggle' | 'hold' }
@@ -26,6 +24,10 @@ vi.mock('@/store', () => {
   const useAppStore = (selector: (value: typeof storeState) => unknown) => selector(storeState)
   return { useAppStore }
 })
+
+vi.mock('./dictation-meter-store', () => ({
+  useDictationMeter: () => storeState.dictationMeter
+}))
 
 vi.mock('@/i18n/i18n', () => ({
   translate: (_key: string, fallback: string) => fallback
@@ -53,10 +55,8 @@ beforeEach(() => {
   storeState.partialTranscript = ''
   storeState.dictationMeter = {
     level: 0,
-    peak: 0,
     isSpeaking: false,
-    isClipping: false,
-    lastUpdatedAt: 0
+    isClipping: false
   }
   storeState.settings = { voice: { dictationMode: 'toggle' } }
   setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
@@ -118,7 +118,7 @@ describe('DictationIndicator', () => {
     storeState.dictationState = 'stopping'
     render(<DictationIndicator />)
 
-    expect(screen.getByText('Processing…')).toBeTruthy()
+    expect(screen.getByText('Processing…', { selector: '[aria-hidden="true"]' })).toBeTruthy()
     expect(screen.queryByRole('button', { name: 'Stop dictation' })).toBeNull()
   })
 
@@ -132,28 +132,25 @@ describe('DictationIndicator', () => {
   it('reacts to speaking audio and exposes the semantic state', () => {
     storeState.dictationMeter = {
       level: 0.72,
-      peak: 0.8,
       isSpeaking: true,
-      isClipping: false,
-      lastUpdatedAt: 100
+      isClipping: false
     }
     render(<DictationIndicator />)
 
     expect(screen.getByText('Speaking')).toBeTruthy()
+    expect(screen.getByRole('status').textContent).toBe('Listening')
     expect(screen.getByTestId('dictation-grapes').children).toHaveLength(9)
   })
 
   it('uses the destructive role only while clipping', () => {
     storeState.dictationMeter = {
       level: 1,
-      peak: 1,
       isSpeaking: true,
-      isClipping: true,
-      lastUpdatedAt: 100
+      isClipping: true
     }
     const { container } = render(<DictationIndicator />)
 
-    expect(screen.getByText('Too loud')).toBeTruthy()
+    expect(screen.getByText('Too loud', { selector: '[aria-hidden="true"]' })).toBeTruthy()
     expect((container.firstChild as HTMLElement).className).toContain('text-destructive')
   })
 
@@ -161,7 +158,8 @@ describe('DictationIndicator', () => {
     storeState.partialTranscript = 'A polished voice visualizer'
     render(<DictationIndicator />)
 
-    expect(screen.getByText('Listening')).toBeTruthy()
+    expect(screen.getByText('Listening', { selector: '[aria-hidden="true"]' })).toBeTruthy()
     expect(screen.getByText('A polished voice visualizer')).toBeTruthy()
+    expect(screen.getByRole('status').textContent).toBe('Listening')
   })
 })

--- a/src/renderer/src/components/dictation/DictationIndicator.test.tsx
+++ b/src/renderer/src/components/dictation/DictationIndicator.test.tsx
@@ -10,6 +10,13 @@ import { DICTATION_CONTROL_EVENT, type DictationControlAction } from './dictatio
 const storeState = {
   dictationState: 'listening' as DictationState,
   partialTranscript: '',
+  dictationMeter: {
+    level: 0,
+    peak: 0,
+    isSpeaking: false,
+    isClipping: false,
+    lastUpdatedAt: 0
+  },
   settings: { voice: { dictationMode: 'toggle' } } as {
     voice?: { dictationMode?: 'toggle' | 'hold' }
   } | null
@@ -44,6 +51,13 @@ const originalUserAgent = navigator.userAgent
 beforeEach(() => {
   storeState.dictationState = 'listening'
   storeState.partialTranscript = ''
+  storeState.dictationMeter = {
+    level: 0,
+    peak: 0,
+    isSpeaking: false,
+    isClipping: false,
+    lastUpdatedAt: 0
+  }
   storeState.settings = { voice: { dictationMode: 'toggle' } }
   setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
 })
@@ -88,7 +102,7 @@ describe('DictationIndicator', () => {
     const { container } = render(<DictationIndicator />)
     const pill = container.firstChild as HTMLElement
 
-    expect(pill.textContent).toContain('Listening...')
+    expect(pill.textContent).toContain('Listening')
     expect(pill.textContent).not.toContain('⌘')
   })
 
@@ -104,7 +118,7 @@ describe('DictationIndicator', () => {
     storeState.dictationState = 'stopping'
     render(<DictationIndicator />)
 
-    expect(screen.getByText('Processing...')).toBeTruthy()
+    expect(screen.getByText('Processing…')).toBeTruthy()
     expect(screen.queryByRole('button', { name: 'Stop dictation' })).toBeNull()
   })
 
@@ -113,5 +127,41 @@ describe('DictationIndicator', () => {
     const { container } = render(<DictationIndicator />)
 
     expect(container.firstChild).toBeNull()
+  })
+
+  it('reacts to speaking audio and exposes the semantic state', () => {
+    storeState.dictationMeter = {
+      level: 0.72,
+      peak: 0.8,
+      isSpeaking: true,
+      isClipping: false,
+      lastUpdatedAt: 100
+    }
+    render(<DictationIndicator />)
+
+    expect(screen.getByText('Speaking')).toBeTruthy()
+    expect(screen.getByTestId('dictation-grapes').children).toHaveLength(9)
+  })
+
+  it('uses the destructive role only while clipping', () => {
+    storeState.dictationMeter = {
+      level: 1,
+      peak: 1,
+      isSpeaking: true,
+      isClipping: true,
+      lastUpdatedAt: 100
+    }
+    const { container } = render(<DictationIndicator />)
+
+    expect(screen.getByText('Too loud')).toBeTruthy()
+    expect((container.firstChild as HTMLElement).className).toContain('text-destructive')
+  })
+
+  it('keeps streaming transcript separate from the listening state', () => {
+    storeState.partialTranscript = 'A polished voice visualizer'
+    render(<DictationIndicator />)
+
+    expect(screen.getByText('Listening')).toBeTruthy()
+    expect(screen.getByText('A polished voice visualizer')).toBeTruthy()
   })
 })

--- a/src/renderer/src/components/dictation/DictationIndicator.tsx
+++ b/src/renderer/src/components/dictation/DictationIndicator.tsx
@@ -8,11 +8,12 @@ import { useAppStore } from '@/store'
 import { Square } from 'lucide-react'
 import { dispatchDictationControl } from './dictation-control-events'
 import { DictationGrapes } from './DictationGrapes'
+import { useDictationMeter } from './dictation-meter-store'
 
 export function DictationIndicator() {
   const dictationState = useAppStore((state) => state.dictationState)
   const partialTranscript = useAppStore((state) => state.partialTranscript)
-  const dictationMeter = useAppStore((state) => state.dictationMeter)
+  const dictationMeter = useDictationMeter()
   const isHoldMode = useAppStore((state) => state.settings?.voice?.dictationMode === 'hold')
   const shortcut = useShortcutKeyDetails('voice.dictation')
 
@@ -24,15 +25,18 @@ export function DictationIndicator() {
   const isListening = dictationState === 'listening'
   const isClipping = isListening && dictationMeter.isClipping
   const isSpeaking = isListening && dictationMeter.isSpeaking && !isClipping
+  const lifecycleLabel =
+    dictationState === 'starting'
+      ? translate('auto.components.dictation.DictationIndicator.starting', 'Starting mic…')
+      : dictationState === 'stopping'
+        ? translate('auto.components.dictation.DictationIndicator.processing', 'Processing…')
+        : translate('auto.components.dictation.DictationIndicator.listening', 'Listening')
   const label = isClipping
     ? translate('auto.components.dictation.DictationIndicator.tooLoud', 'Too loud')
     : isSpeaking
       ? translate('auto.components.dictation.DictationIndicator.speaking', 'Speaking')
-      : dictationState === 'starting'
-        ? translate('auto.components.dictation.DictationIndicator.starting', 'Starting mic…')
-        : dictationState === 'stopping'
-          ? translate('auto.components.dictation.DictationIndicator.processing', 'Processing…')
-          : translate('auto.components.dictation.DictationIndicator.listening', 'Listening')
+      : lifecycleLabel
+  const announcedLabel = isClipping ? label : lifecycleLabel
   const canStop = dictationState !== 'stopping'
   const showShortcut = !isHoldMode && shortcut.keys.length > 0
   const transcript = partialTranscript.trim()
@@ -43,8 +47,7 @@ export function DictationIndicator() {
 
   return (
     <div
-      role="status"
-      aria-live="polite"
+      data-testid="dictation-indicator"
       className={cn(
         'fixed bottom-12 left-1/2 z-50 -translate-x-1/2 overflow-hidden',
         'border border-border bg-popover/95 text-sm text-popover-foreground shadow-[0_10px_24px_rgba(0,0,0,0.18)] backdrop-blur',
@@ -61,7 +64,12 @@ export function DictationIndicator() {
           active={dictationState !== 'stopping'}
           transitioning={dictationState !== 'listening'}
         />
-        <span className="min-w-0 truncate font-medium">{label}</span>
+        <span aria-hidden className="min-w-0 truncate font-medium">
+          {label}
+        </span>
+        <span role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+          {announcedLabel}
+        </span>
         {canStop ? (
           <>
             <span aria-hidden className="ml-0.5 h-4 w-px shrink-0 bg-border" />

--- a/src/renderer/src/components/dictation/DictationIndicator.tsx
+++ b/src/renderer/src/components/dictation/DictationIndicator.tsx
@@ -1,79 +1,98 @@
-import { useAppStore } from '@/store'
-import { Mic, Square } from 'lucide-react'
-import { Button } from '@/components/ui/button'
 import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
+import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useShortcutKeyDetails } from '@/hooks/useShortcutLabel'
 import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
+import { useAppStore } from '@/store'
+import { Square } from 'lucide-react'
 import { dispatchDictationControl } from './dictation-control-events'
+import { DictationGrapes } from './DictationGrapes'
 
 export function DictationIndicator() {
-  const dictationState = useAppStore((s) => s.dictationState)
-  const partialTranscript = useAppStore((s) => s.partialTranscript)
-  const isHoldMode = useAppStore((s) => s.settings?.voice?.dictationMode === 'hold')
+  const dictationState = useAppStore((state) => state.dictationState)
+  const partialTranscript = useAppStore((state) => state.partialTranscript)
+  const dictationMeter = useAppStore((state) => state.dictationMeter)
+  const isHoldMode = useAppStore((state) => state.settings?.voice?.dictationMode === 'hold')
   const shortcut = useShortcutKeyDetails('voice.dictation')
 
-  if (
-    dictationState !== 'listening' &&
-    dictationState !== 'starting' &&
-    dictationState !== 'stopping'
-  ) {
+  const isVisible = ['listening', 'starting', 'stopping'].includes(dictationState)
+  if (!isVisible) {
     return null
   }
 
-  const label =
-    dictationState === 'starting'
-      ? 'Starting...'
-      : dictationState === 'stopping'
-        ? 'Processing...'
-        : partialTranscript || 'Listening...'
-
-  // Why: the stop path is a no-op once the session is already tearing down.
+  const isListening = dictationState === 'listening'
+  const isClipping = isListening && dictationMeter.isClipping
+  const isSpeaking = isListening && dictationMeter.isSpeaking && !isClipping
+  const label = isClipping
+    ? translate('auto.components.dictation.DictationIndicator.tooLoud', 'Too loud')
+    : isSpeaking
+      ? translate('auto.components.dictation.DictationIndicator.speaking', 'Speaking')
+      : dictationState === 'starting'
+        ? translate('auto.components.dictation.DictationIndicator.starting', 'Starting mic…')
+        : dictationState === 'stopping'
+          ? translate('auto.components.dictation.DictationIndicator.processing', 'Processing…')
+          : translate('auto.components.dictation.DictationIndicator.listening', 'Listening')
   const canStop = dictationState !== 'stopping'
-  // Hold mode stops on key release, so a "press ⌘E" chip would misstate the binding.
   const showShortcut = !isHoldMode && shortcut.keys.length > 0
+  const transcript = partialTranscript.trim()
   const stopLabel = translate(
     'auto.components.dictation.DictationIndicator.335e1bc6cb',
     'Stop dictation'
   )
 
   return (
-    <div className="fixed bottom-12 left-1/2 z-50 flex max-w-[min(36rem,calc(100vw-3rem))] -translate-x-1/2 items-center gap-2 rounded-lg bg-foreground/90 px-3 py-1.5 text-background text-sm shadow-lg">
-      <Mic className={`size-4 shrink-0 ${dictationState === 'listening' ? 'animate-pulse' : ''}`} />
-      <span className="min-w-0 truncate">{label}</span>
-      {canStop ? (
-        <>
-          <span aria-hidden className="h-3.5 w-px shrink-0 bg-background/25" />
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-xs"
-                aria-label={stopLabel}
-                className="shrink-0 text-background/55 hover:bg-background/15 hover:text-background/85"
-                // Why: dictation inserts into the element focused when it started;
-                // taking focus on click would drop the final transcript.
-                onMouseDown={(event) => event.preventDefault()}
-                onClick={() => dispatchDictationControl('stop')}
-              >
-                <Square className="size-3 fill-current" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent side="top" sideOffset={6} className="flex items-center gap-1.5">
-              {stopLabel}
-              {showShortcut ? (
-                <ShortcutKeyCombo
-                  keys={shortcut.keys}
-                  doubleTap={shortcut.doubleTap}
-                  className="gap-0.5"
-                  keyCapClassName="min-w-0 border-background/20 bg-background/10 px-1 py-0 text-[10px] text-background shadow-none"
-                  separatorClassName="text-[10px] text-background/70"
-                />
-              ) : null}
-            </TooltipContent>
-          </Tooltip>
-        </>
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        'fixed bottom-12 left-1/2 z-50 -translate-x-1/2 overflow-hidden',
+        'border border-border bg-popover/95 text-sm text-popover-foreground shadow-[0_10px_24px_rgba(0,0,0,0.18)] backdrop-blur',
+        'transition-[width,border-radius,opacity] duration-200 ease-out motion-reduce:transition-none',
+        transcript
+          ? 'w-[min(28rem,calc(100vw-2rem))] rounded-xl'
+          : 'max-w-[min(28rem,calc(100vw-2rem))] rounded-full',
+        isClipping && 'border-destructive/40 text-destructive'
+      )}
+    >
+      <div className="flex h-10 items-center gap-2 px-2">
+        <DictationGrapes
+          level={dictationMeter.level}
+          active={dictationState !== 'stopping'}
+          transitioning={dictationState !== 'listening'}
+        />
+        <span className="min-w-0 truncate font-medium">{label}</span>
+        {canStop ? (
+          <>
+            <span aria-hidden className="ml-0.5 h-4 w-px shrink-0 bg-border" />
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  aria-label={stopLabel}
+                  className="shrink-0 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                  onMouseDown={(event) => event.preventDefault()}
+                  onClick={() => dispatchDictationControl('stop')}
+                >
+                  <Square className="size-3 fill-current" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="top" sideOffset={6} className="flex items-center gap-1.5">
+                {stopLabel}
+                {showShortcut ? (
+                  <ShortcutKeyCombo keys={shortcut.keys} doubleTap={shortcut.doubleTap} />
+                ) : null}
+              </TooltipContent>
+            </Tooltip>
+          </>
+        ) : null}
+      </div>
+      {transcript ? (
+        <p className="truncate border-t border-border px-3 py-2 text-xs text-muted-foreground">
+          {transcript}
+        </p>
       ) : null}
     </div>
   )

--- a/src/renderer/src/components/dictation/dictation-audio-meter.test.ts
+++ b/src/renderer/src/components/dictation/dictation-audio-meter.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import {
+  analyzeDictationAudioChunk,
+  createDictationMeterAnalyzerState,
+  measureDictationAudioChunk,
+  toPublicDictationMeterState
+} from './dictation-audio-meter'
+
+describe('dictation audio meter', () => {
+  it('measures RMS and clamps peaks from copied audio samples', () => {
+    expect(measureDictationAudioChunk(new Float32Array([0.5, -0.5]))).toEqual({
+      rms: 0.5,
+      peak: 0.5
+    })
+    expect(measureDictationAudioChunk(new Float32Array([2]))).toEqual({ rms: 2, peak: 1 })
+  })
+
+  it('uses a fast attack and slower release for a stable voice envelope', () => {
+    const initial = createDictationMeterAnalyzerState()
+    const loud = analyzeDictationAudioChunk(new Float32Array(128).fill(0.3), 100, initial)
+    const quiet = analyzeDictationAudioChunk(new Float32Array(128), 200, loud)
+
+    expect(loud.level).toBeGreaterThan(0.5)
+    expect(loud.isSpeaking).toBe(true)
+    expect(quiet.level).toBeGreaterThan(0.3)
+    expect(quiet.level).toBeLessThan(loud.level)
+  })
+
+  it('holds clipping briefly so a single peak does not flicker', () => {
+    const initial = createDictationMeterAnalyzerState()
+    const clipped = analyzeDictationAudioChunk(new Float32Array([1]), 1_000, initial)
+    const held = analyzeDictationAudioChunk(new Float32Array([0]), 1_400, clipped)
+    const released = analyzeDictationAudioChunk(new Float32Array([0]), 1_600, held)
+
+    expect(clipped.isClipping).toBe(true)
+    expect(held.isClipping).toBe(true)
+    expect(released.isClipping).toBe(false)
+  })
+
+  it('publishes only presentation-safe meter fields', () => {
+    const analyzed = analyzeDictationAudioChunk(
+      new Float32Array(128).fill(0.25),
+      250,
+      createDictationMeterAnalyzerState()
+    )
+
+    expect(toPublicDictationMeterState(analyzed)).toEqual({
+      level: analyzed.level,
+      peak: analyzed.peak,
+      isSpeaking: analyzed.isSpeaking,
+      isClipping: analyzed.isClipping,
+      lastUpdatedAt: 250
+    })
+  })
+})

--- a/src/renderer/src/components/dictation/dictation-audio-meter.test.ts
+++ b/src/renderer/src/components/dictation/dictation-audio-meter.test.ts
@@ -45,11 +45,9 @@ describe('dictation audio meter', () => {
     )
 
     expect(toPublicDictationMeterState(analyzed)).toEqual({
-      level: analyzed.level,
-      peak: analyzed.peak,
+      level: Math.round(analyzed.level * 100) / 100,
       isSpeaking: analyzed.isSpeaking,
-      isClipping: analyzed.isClipping,
-      lastUpdatedAt: 250
+      isClipping: analyzed.isClipping
     })
   })
 })

--- a/src/renderer/src/components/dictation/dictation-audio-meter.ts
+++ b/src/renderer/src/components/dictation/dictation-audio-meter.ts
@@ -1,0 +1,97 @@
+export type DictationMeterState = {
+  level: number
+  peak: number
+  isSpeaking: boolean
+  isClipping: boolean
+  lastUpdatedAt: number
+}
+
+export type DictationMeterAnalyzerState = DictationMeterState & {
+  noiseFloor: number
+  smoothedLevel: number
+  clippingUntil: number
+}
+
+export const DEFAULT_DICTATION_METER: DictationMeterState = {
+  level: 0,
+  peak: 0,
+  isSpeaking: false,
+  isClipping: false,
+  lastUpdatedAt: 0
+}
+
+const CLIPPING_THRESHOLD = 0.98
+const CLIPPING_HOLD_MS = 500
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+export function createDictationMeterAnalyzerState(): DictationMeterAnalyzerState {
+  return {
+    ...DEFAULT_DICTATION_METER,
+    noiseFloor: 0.008,
+    smoothedLevel: 0,
+    clippingUntil: Number.NEGATIVE_INFINITY
+  }
+}
+
+export function measureDictationAudioChunk(samples: Float32Array): {
+  rms: number
+  peak: number
+} {
+  if (samples.length === 0) {
+    return { rms: 0, peak: 0 }
+  }
+
+  let sumSquares = 0
+  let peak = 0
+  for (const sample of samples) {
+    const absoluteSample = Math.abs(sample)
+    sumSquares += sample * sample
+    peak = Math.max(peak, absoluteSample)
+  }
+  return {
+    rms: Math.sqrt(sumSquares / samples.length),
+    peak: clamp(peak, 0, 1)
+  }
+}
+
+export function analyzeDictationAudioChunk(
+  samples: Float32Array,
+  now: number,
+  previous: DictationMeterAnalyzerState
+): DictationMeterAnalyzerState {
+  const { rms, peak } = measureDictationAudioChunk(samples)
+  const noiseFloor = Math.max(
+    0.004,
+    previous.noiseFloor * 0.96 + Math.min(rms, previous.noiseFloor * 2) * 0.04
+  )
+  const rawLevel = clamp((rms - noiseFloor) / 0.16, 0, 1)
+  const smoothing = rawLevel > previous.smoothedLevel ? 0.58 : 0.2
+  const smoothedLevel = previous.smoothedLevel + (rawLevel - previous.smoothedLevel) * smoothing
+  const clippingUntil = peak >= CLIPPING_THRESHOLD ? now + CLIPPING_HOLD_MS : previous.clippingUntil
+
+  return {
+    level: smoothedLevel,
+    peak,
+    isSpeaking: smoothedLevel >= 0.1 || peak >= 0.18,
+    isClipping: now <= clippingUntil,
+    lastUpdatedAt: now,
+    noiseFloor,
+    smoothedLevel,
+    clippingUntil
+  }
+}
+
+export function toPublicDictationMeterState(
+  state: DictationMeterAnalyzerState
+): DictationMeterState {
+  return {
+    level: state.level,
+    peak: state.peak,
+    isSpeaking: state.isSpeaking,
+    isClipping: state.isClipping,
+    lastUpdatedAt: state.lastUpdatedAt
+  }
+}

--- a/src/renderer/src/components/dictation/dictation-audio-meter.ts
+++ b/src/renderer/src/components/dictation/dictation-audio-meter.ts
@@ -1,12 +1,12 @@
 export type DictationMeterState = {
   level: number
-  peak: number
   isSpeaking: boolean
   isClipping: boolean
-  lastUpdatedAt: number
 }
 
 export type DictationMeterAnalyzerState = DictationMeterState & {
+  peak: number
+  lastUpdatedAt: number
   noiseFloor: number
   smoothedLevel: number
   clippingUntil: number
@@ -14,10 +14,8 @@ export type DictationMeterAnalyzerState = DictationMeterState & {
 
 export const DEFAULT_DICTATION_METER: DictationMeterState = {
   level: 0,
-  peak: 0,
   isSpeaking: false,
-  isClipping: false,
-  lastUpdatedAt: 0
+  isClipping: false
 }
 
 const CLIPPING_THRESHOLD = 0.98
@@ -30,6 +28,8 @@ function clamp(value: number, min: number, max: number): number {
 export function createDictationMeterAnalyzerState(): DictationMeterAnalyzerState {
   return {
     ...DEFAULT_DICTATION_METER,
+    peak: 0,
+    lastUpdatedAt: 0,
     noiseFloor: 0.008,
     smoothedLevel: 0,
     clippingUntil: Number.NEGATIVE_INFINITY
@@ -88,10 +88,19 @@ export function toPublicDictationMeterState(
   state: DictationMeterAnalyzerState
 ): DictationMeterState {
   return {
-    level: state.level,
-    peak: state.peak,
+    level: Math.round(state.level * 100) / 100,
     isSpeaking: state.isSpeaking,
-    isClipping: state.isClipping,
-    lastUpdatedAt: state.lastUpdatedAt
+    isClipping: state.isClipping
   }
+}
+
+export function dictationMeterStatesEqual(
+  left: DictationMeterState,
+  right: DictationMeterState
+): boolean {
+  return (
+    left.level === right.level &&
+    left.isSpeaking === right.isSpeaking &&
+    left.isClipping === right.isClipping
+  )
 }

--- a/src/renderer/src/components/dictation/dictation-meter-store.test.tsx
+++ b/src/renderer/src/components/dictation/dictation-meter-store.test.tsx
@@ -1,0 +1,28 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, expect, it } from 'vitest'
+import {
+  publishDictationMeter,
+  resetDictationMeter,
+  useDictationMeter
+} from './dictation-meter-store'
+
+beforeEach(resetDictationMeter)
+afterEach(resetDictationMeter)
+
+it('notifies only the scoped meter consumer when presentation state changes', () => {
+  let renders = 0
+  const { result } = renderHook(() => {
+    renders += 1
+    return useDictationMeter()
+  })
+  const speaking = { level: 0.72, isSpeaking: true, isClipping: false }
+
+  act(() => publishDictationMeter(speaking))
+  expect(result.current).toEqual(speaking)
+  expect(renders).toBe(2)
+
+  act(() => publishDictationMeter({ ...speaking }))
+  expect(renders).toBe(2)
+})

--- a/src/renderer/src/components/dictation/dictation-meter-store.ts
+++ b/src/renderer/src/components/dictation/dictation-meter-store.ts
@@ -1,0 +1,29 @@
+import { e2eConfig } from '@/lib/e2e-config'
+import { useStore } from 'zustand'
+import { createStore } from 'zustand/vanilla'
+import {
+  DEFAULT_DICTATION_METER,
+  dictationMeterStatesEqual,
+  type DictationMeterState
+} from './dictation-audio-meter'
+
+const dictationMeterStore = createStore<DictationMeterState>(() => DEFAULT_DICTATION_METER)
+
+export function publishDictationMeter(meter: DictationMeterState): void {
+  if (!dictationMeterStatesEqual(dictationMeterStore.getState(), meter)) {
+    dictationMeterStore.setState(meter, true)
+  }
+}
+
+export function resetDictationMeter(): void {
+  dictationMeterStore.setState(DEFAULT_DICTATION_METER, true)
+}
+
+export function useDictationMeter(): DictationMeterState {
+  return useStore(dictationMeterStore, (state) => state)
+}
+
+if (e2eConfig.exposeStore && typeof window !== 'undefined') {
+  const testWindow = window as unknown as Record<string, unknown>
+  testWindow.__dictationMeterE2E = { publish: publishDictationMeter }
+}

--- a/src/renderer/src/hooks/use-audio-capture.capture-loss.test.ts
+++ b/src/renderer/src/hooks/use-audio-capture.capture-loss.test.ts
@@ -65,6 +65,7 @@ describe('useAudioCapture device loss', () => {
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     vi.unstubAllGlobals()
   })
 
@@ -99,12 +100,74 @@ describe('useAudioCapture device loss', () => {
     } as unknown as AudioProcessingEvent)
 
     expect(publishMeter).toHaveBeenLastCalledWith(
-      expect.objectContaining({ isSpeaking: true, peak: expect.closeTo(0.3, 5) })
+      expect.objectContaining({ isSpeaking: true, level: expect.any(Number) })
     )
     expect(window.api.speech.feedAudio).toHaveBeenCalledWith(
       expect.any(Float32Array),
       48_000,
       'meter-session'
     )
+  })
+
+  it('caps visual publications and deduplicates steady silence', async () => {
+    let now = 0
+    vi.spyOn(performance, 'now').mockImplementation(() => now)
+    const publishMeter = vi.fn()
+    const { result } = renderHook(() => useAudioCapture(publishMeter))
+    await result.current.start()
+
+    const process = (sample: number): void => {
+      processor.onaudioprocess?.({
+        inputBuffer: { getChannelData: () => new Float32Array(128).fill(sample) }
+      } as unknown as AudioProcessingEvent)
+    }
+
+    process(0)
+    expect(publishMeter).toHaveBeenCalledTimes(1)
+
+    now = 70
+    process(0.3)
+    now = 90
+    process(0)
+    expect(publishMeter).toHaveBeenCalledTimes(2)
+
+    now = 140
+    process(0)
+    expect(publishMeter).toHaveBeenCalledTimes(3)
+  })
+
+  it('skips hidden updates, resumes promptly, and resets immediately on stop', async () => {
+    let now = 0
+    let hidden = true
+    vi.spyOn(performance, 'now').mockImplementation(() => now)
+    vi.spyOn(document, 'hidden', 'get').mockImplementation(() => hidden)
+    const publishMeter = vi.fn()
+    const { result } = renderHook(() => useAudioCapture(publishMeter))
+    await result.current.start()
+
+    const process = (): void => {
+      processor.onaudioprocess?.({
+        inputBuffer: { getChannelData: () => new Float32Array(128).fill(0.3) }
+      } as unknown as AudioProcessingEvent)
+    }
+
+    process()
+    expect(publishMeter).toHaveBeenCalledTimes(1)
+    expect(window.api.speech.feedAudio).toHaveBeenCalledTimes(1)
+
+    hidden = false
+    now = 10
+    process()
+    expect(publishMeter).toHaveBeenCalledTimes(2)
+
+    hidden = true
+    now = 20
+    result.current.stop()
+    expect(publishMeter).toHaveBeenLastCalledWith({
+      level: 0,
+      isSpeaking: false,
+      isClipping: false
+    })
+    expect(publishMeter).toHaveBeenCalledTimes(3)
   })
 })

--- a/src/renderer/src/hooks/use-audio-capture.capture-loss.test.ts
+++ b/src/renderer/src/hooks/use-audio-capture.capture-loss.test.ts
@@ -8,6 +8,12 @@ class FakeTrack extends EventTarget {
   stop = vi.fn()
 }
 
+type FakeAudioProcessor = {
+  connect: ReturnType<typeof vi.fn>
+  disconnect: ReturnType<typeof vi.fn>
+  onaudioprocess: ((event: AudioProcessingEvent) => void) | null
+}
+
 function makeStream(track: FakeTrack): MediaStream {
   return {
     getTracks: () => [track],
@@ -15,8 +21,8 @@ function makeStream(track: FakeTrack): MediaStream {
   } as unknown as MediaStream
 }
 
-function installAudioContext(): void {
-  const processor = {
+function installAudioContext(): FakeAudioProcessor {
+  const processor: FakeAudioProcessor = {
     connect: vi.fn(),
     disconnect: vi.fn(),
     onaudioprocess: null
@@ -34,14 +40,16 @@ function installAudioContext(): void {
       close = vi.fn(async () => undefined)
     }
   )
+  return processor
 }
 
 describe('useAudioCapture device loss', () => {
   let track: FakeTrack
+  let processor: FakeAudioProcessor
 
   beforeEach(() => {
     track = new FakeTrack()
-    installAudioContext()
+    processor = installAudioContext()
     vi.stubGlobal('navigator', {
       mediaDevices: {
         getUserMedia: vi.fn(async () => makeStream(track)),
@@ -79,5 +87,24 @@ describe('useAudioCapture device loss', () => {
     track.dispatchEvent(new Event('ended'))
 
     expect(onCaptureLost).not.toHaveBeenCalled()
+  })
+
+  it('publishes the copied audio envelope without suppressing speech input', async () => {
+    const publishMeter = vi.fn()
+    const { result } = renderHook(() => useAudioCapture(publishMeter))
+    await result.current.start({ sessionId: 'meter-session' })
+
+    processor.onaudioprocess?.({
+      inputBuffer: { getChannelData: () => new Float32Array(128).fill(0.3) }
+    } as unknown as AudioProcessingEvent)
+
+    expect(publishMeter).toHaveBeenLastCalledWith(
+      expect.objectContaining({ isSpeaking: true, peak: expect.closeTo(0.3, 5) })
+    )
+    expect(window.api.speech.feedAudio).toHaveBeenCalledWith(
+      expect.any(Float32Array),
+      48_000,
+      'meter-session'
+    )
   })
 })

--- a/src/renderer/src/hooks/use-audio-capture.ts
+++ b/src/renderer/src/hooks/use-audio-capture.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_DICTATION_METER,
   analyzeDictationAudioChunk,
   createDictationMeterAnalyzerState,
+  dictationMeterStatesEqual,
   toPublicDictationMeterState,
   type DictationMeterState
 } from '@/components/dictation/dictation-audio-meter'
@@ -35,6 +36,7 @@ type StopAudioCaptureOptions = {
 
 const MAX_BUFFERED_AUDIO_SECONDS = 30
 const MAX_BUFFERED_AUDIO_BYTES = 8 * 1024 * 1024
+const METER_PUBLISH_INTERVAL_MS = 1000 / 15
 
 type DictationMeterPublisher = (meter: DictationMeterState) => void
 
@@ -54,6 +56,8 @@ export function useAudioCapture(publishMeter?: DictationMeterPublisher) {
   const sessionIdRef = useRef('desktop')
   const trackLostCleanupRef = useRef<(() => void) | null>(null)
   const meterAnalyzerRef = useRef(createDictationMeterAnalyzerState())
+  const publishedMeterRef = useRef(DEFAULT_DICTATION_METER)
+  const lastMeterPublishedAtRef = useRef(Number.NEGATIVE_INFINITY)
 
   const cleanupCaptureResources = useCallback(() => {
     trackLostCleanupRef.current?.()
@@ -82,6 +86,8 @@ export function useAudioCapture(publishMeter?: DictationMeterPublisher) {
 
   const resetMeter = useCallback(() => {
     meterAnalyzerRef.current = createDictationMeterAnalyzerState()
+    publishedMeterRef.current = DEFAULT_DICTATION_METER
+    lastMeterPublishedAtRef.current = Number.NEGATIVE_INFINITY
     publishMeter?.(DEFAULT_DICTATION_METER)
   }, [publishMeter])
 
@@ -191,12 +197,23 @@ export function useAudioCapture(publishMeter?: DictationMeterPublisher) {
             return
           }
           const samples = new Float32Array(e.inputBuffer.getChannelData(0))
+          const now = performance.now()
           meterAnalyzerRef.current = analyzeDictationAudioChunk(
             samples,
-            performance.now(),
+            now,
             meterAnalyzerRef.current
           )
-          publishMeter?.(toPublicDictationMeterState(meterAnalyzerRef.current))
+          if (
+            !document.hidden &&
+            now - lastMeterPublishedAtRef.current >= METER_PUBLISH_INTERVAL_MS
+          ) {
+            lastMeterPublishedAtRef.current = now
+            const meter = toPublicDictationMeterState(meterAnalyzerRef.current)
+            if (!dictationMeterStatesEqual(publishedMeterRef.current, meter)) {
+              publishedMeterRef.current = meter
+              publishMeter?.(meter)
+            }
+          }
           capturedChunkCountRef.current += 1
           if (bufferAudioRef.current) {
             appendBufferedAudioChunk({

--- a/src/renderer/src/hooks/use-audio-capture.ts
+++ b/src/renderer/src/hooks/use-audio-capture.ts
@@ -1,5 +1,12 @@
 import { useRef, useCallback } from 'react'
 import { openMicrophoneCaptureStream } from '@/components/dictation/microphone-devices'
+import {
+  DEFAULT_DICTATION_METER,
+  analyzeDictationAudioChunk,
+  createDictationMeterAnalyzerState,
+  toPublicDictationMeterState,
+  type DictationMeterState
+} from '@/components/dictation/dictation-audio-meter'
 
 type BufferedAudioChunk = {
   samples: Float32Array
@@ -29,7 +36,9 @@ type StopAudioCaptureOptions = {
 const MAX_BUFFERED_AUDIO_SECONDS = 30
 const MAX_BUFFERED_AUDIO_BYTES = 8 * 1024 * 1024
 
-export function useAudioCapture() {
+type DictationMeterPublisher = (meter: DictationMeterState) => void
+
+export function useAudioCapture(publishMeter?: DictationMeterPublisher) {
   const streamRef = useRef<MediaStream | null>(null)
   const contextRef = useRef<AudioContext | null>(null)
   const processorRef = useRef<ScriptProcessorNode | null>(null)
@@ -44,6 +53,7 @@ export function useAudioCapture() {
   const capturedChunkCountRef = useRef(0)
   const sessionIdRef = useRef('desktop')
   const trackLostCleanupRef = useRef<(() => void) | null>(null)
+  const meterAnalyzerRef = useRef(createDictationMeterAnalyzerState())
 
   const cleanupCaptureResources = useCallback(() => {
     trackLostCleanupRef.current?.()
@@ -69,6 +79,11 @@ export function useAudioCapture() {
     bufferedAudioBytesRef.current = 0
     bufferedAudioSecondsRef.current = 0
   }, [])
+
+  const resetMeter = useCallback(() => {
+    meterAnalyzerRef.current = createDictationMeterAnalyzerState()
+    publishMeter?.(DEFAULT_DICTATION_METER)
+  }, [publishMeter])
 
   const removeOldestBufferedAudioChunk = useCallback(() => {
     const chunk = bufferedAudioRef.current.shift()
@@ -112,6 +127,7 @@ export function useAudioCapture() {
       bufferAudioRef.current = options.bufferAudio ?? false
       resetBufferedAudio()
       capturedChunkCountRef.current = 0
+      resetMeter()
 
       const { stream, fellBackToDefaultMicrophone } = await openMicrophoneCaptureStream({
         preferredDeviceId: options.microphoneDeviceId,
@@ -175,6 +191,12 @@ export function useAudioCapture() {
             return
           }
           const samples = new Float32Array(e.inputBuffer.getChannelData(0))
+          meterAnalyzerRef.current = analyzeDictationAudioChunk(
+            samples,
+            performance.now(),
+            meterAnalyzerRef.current
+          )
+          publishMeter?.(toPublicDictationMeterState(meterAnalyzerRef.current))
           capturedChunkCountRef.current += 1
           if (bufferAudioRef.current) {
             appendBufferedAudioChunk({
@@ -242,7 +264,13 @@ export function useAudioCapture() {
         throw err
       }
     },
-    [appendBufferedAudioChunk, cleanupCaptureResources, resetBufferedAudio]
+    [
+      appendBufferedAudioChunk,
+      cleanupCaptureResources,
+      publishMeter,
+      resetBufferedAudio,
+      resetMeter
+    ]
   )
 
   const flushBufferedAudio = useCallback(async () => {
@@ -285,8 +313,9 @@ export function useAudioCapture() {
         resetBufferedAudio()
       }
       cleanupCaptureResources()
+      resetMeter()
     },
-    [cleanupCaptureResources, resetBufferedAudio]
+    [cleanupCaptureResources, resetBufferedAudio, resetMeter]
   )
 
   return {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14608,7 +14608,12 @@
           "micDisconnected": "Microphone disconnected. Dictation stopped."
         },
         "DictationIndicator": {
-          "335e1bc6cb": "Stop dictation"
+          "335e1bc6cb": "Stop dictation",
+          "tooLoud": "Too loud",
+          "speaking": "Speaking",
+          "starting": "Starting mic…",
+          "processing": "Processing…",
+          "listening": "Listening"
         }
       },
       "dashboard": {

--- a/src/renderer/src/store/slices/dictation.ts
+++ b/src/renderer/src/store/slices/dictation.ts
@@ -1,16 +1,22 @@
 import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
 import type { DictationState, SpeechModelState } from '../../../../shared/speech-types'
+import {
+  DEFAULT_DICTATION_METER,
+  type DictationMeterState
+} from '../../components/dictation/dictation-audio-meter'
 
 export type DictationSlice = {
   dictationState: DictationState
   partialTranscript: string
   activeModelId: string | null
   modelStates: SpeechModelState[]
+  dictationMeter: DictationMeterState
   setDictationState: (state: DictationState) => void
   setPartialTranscript: (text: string) => void
   setActiveModelId: (id: string | null) => void
   setModelStates: (states: SpeechModelState[]) => void
+  setDictationMeter: (meter: DictationMeterState) => void
   refreshModelStates: () => Promise<void>
 }
 
@@ -45,11 +51,13 @@ export const createDictationSlice: StateCreator<AppState, [], [], DictationSlice
     partialTranscript: '',
     activeModelId: null,
     modelStates: [],
+    dictationMeter: DEFAULT_DICTATION_METER,
 
     setDictationState: (state) => set({ dictationState: state }),
     setPartialTranscript: (text) => set({ partialTranscript: text }),
     setActiveModelId: (id) => set({ activeModelId: id }),
     setModelStates,
+    setDictationMeter: (meter) => set({ dictationMeter: meter }),
 
     refreshModelStates: async () => {
       try {

--- a/src/renderer/src/store/slices/dictation.ts
+++ b/src/renderer/src/store/slices/dictation.ts
@@ -1,22 +1,16 @@
 import type { StateCreator } from 'zustand'
 import type { AppState } from '../types'
 import type { DictationState, SpeechModelState } from '../../../../shared/speech-types'
-import {
-  DEFAULT_DICTATION_METER,
-  type DictationMeterState
-} from '../../components/dictation/dictation-audio-meter'
 
 export type DictationSlice = {
   dictationState: DictationState
   partialTranscript: string
   activeModelId: string | null
   modelStates: SpeechModelState[]
-  dictationMeter: DictationMeterState
   setDictationState: (state: DictationState) => void
   setPartialTranscript: (text: string) => void
   setActiveModelId: (id: string | null) => void
   setModelStates: (states: SpeechModelState[]) => void
-  setDictationMeter: (meter: DictationMeterState) => void
   refreshModelStates: () => Promise<void>
 }
 
@@ -51,13 +45,11 @@ export const createDictationSlice: StateCreator<AppState, [], [], DictationSlice
     partialTranscript: '',
     activeModelId: null,
     modelStates: [],
-    dictationMeter: DEFAULT_DICTATION_METER,
 
     setDictationState: (state) => set({ dictationState: state }),
     setPartialTranscript: (text) => set({ partialTranscript: text }),
     setActiveModelId: (id) => set({ activeModelId: id }),
     setModelStates,
-    setDictationMeter: (meter) => set({ dictationMeter: meter }),
 
     refreshModelStates: async () => {
       try {

--- a/tests/e2e/dictation-indicator.spec.ts
+++ b/tests/e2e/dictation-indicator.spec.ts
@@ -1,0 +1,90 @@
+import { expect, test } from './helpers/orca-app'
+import type { Page } from '@stablyai/playwright-test'
+
+type MeterFixture = {
+  level: number
+  peak: number
+  isSpeaking: boolean
+  isClipping: boolean
+  lastUpdatedAt: number
+}
+
+async function setDictationVisualState(
+  page: Page,
+  state: 'listening' | 'stopping',
+  meter: MeterFixture,
+  partialTranscript = ''
+): Promise<void> {
+  await page.evaluate(
+    ({ dictationState, dictationMeter, transcript }) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('Expected the E2E store to be exposed')
+      }
+      store.setState({
+        dictationState,
+        dictationMeter,
+        partialTranscript: transcript
+      })
+    },
+    { dictationState: state, dictationMeter: meter, transcript: partialTranscript }
+  )
+}
+
+async function pauseForRecordedProof(page: Page): Promise<void> {
+  if (process.env.ORCA_E2E_RECORD_VIDEO === '1') {
+    await page.waitForTimeout(700)
+  }
+}
+
+test('dictation grapes react across the visible recording lifecycle', async ({ orcaPage }) => {
+  const quiet = { level: 0, peak: 0, isSpeaking: false, isClipping: false, lastUpdatedAt: 1 }
+  await setDictationVisualState(orcaPage, 'listening', quiet)
+
+  const status = orcaPage.getByRole('status').filter({ has: orcaPage.getByText('Listening') })
+  await expect(status).toBeVisible()
+  await expect(status.getByTestId('dictation-grapes').locator('span')).toHaveCount(9)
+  await expect(status.getByRole('button', { name: 'Stop dictation' })).toBeVisible()
+  await orcaPage.emulateMedia({ reducedMotion: 'reduce' })
+  await expect(status.getByTestId('dictation-grapes').locator('span').first()).toHaveCSS(
+    'transition-property',
+    'none'
+  )
+  await orcaPage.emulateMedia({ reducedMotion: 'no-preference' })
+  await pauseForRecordedProof(orcaPage)
+
+  const speaking = {
+    level: 0.76,
+    peak: 0.84,
+    isSpeaking: true,
+    isClipping: false,
+    lastUpdatedAt: 2
+  }
+  await setDictationVisualState(orcaPage, 'listening', speaking)
+  await expect(orcaPage.getByRole('status').filter({ hasText: 'Speaking' })).toBeVisible()
+  await pauseForRecordedProof(orcaPage)
+
+  const clipping = { ...speaking, level: 1, peak: 1, isClipping: true, lastUpdatedAt: 3 }
+  await setDictationVisualState(orcaPage, 'listening', clipping)
+  const clippingStatus = orcaPage.getByRole('status').filter({ hasText: 'Too loud' })
+  await expect(clippingStatus).toBeVisible()
+  await expect(clippingStatus).toHaveClass(/text-destructive/)
+  await pauseForRecordedProof(orcaPage)
+
+  await setDictationVisualState(
+    orcaPage,
+    'listening',
+    speaking,
+    'The visualizer follows every word without covering the workspace.'
+  )
+  await expect(
+    orcaPage.getByText('The visualizer follows every word without covering the workspace.')
+  ).toBeVisible()
+  await pauseForRecordedProof(orcaPage)
+
+  await setDictationVisualState(orcaPage, 'stopping', quiet)
+  const processing = orcaPage.getByRole('status').filter({ hasText: 'Processing…' })
+  await expect(processing).toBeVisible()
+  await expect(processing.getByRole('button', { name: 'Stop dictation' })).toHaveCount(0)
+  await pauseForRecordedProof(orcaPage)
+})

--- a/tests/e2e/dictation-indicator.spec.ts
+++ b/tests/e2e/dictation-indicator.spec.ts
@@ -3,10 +3,8 @@ import type { Page } from '@stablyai/playwright-test'
 
 type MeterFixture = {
   level: number
-  peak: number
   isSpeaking: boolean
   isClipping: boolean
-  lastUpdatedAt: number
 }
 
 async function setDictationVisualState(
@@ -16,19 +14,22 @@ async function setDictationVisualState(
   partialTranscript = ''
 ): Promise<void> {
   await page.evaluate(
-    ({ dictationState, dictationMeter, transcript }) => {
+    ({ dictationState, transcript }) => {
       const store = window.__store
       if (!store) {
         throw new Error('Expected the E2E store to be exposed')
       }
       store.setState({
         dictationState,
-        dictationMeter,
         partialTranscript: transcript
       })
     },
-    { dictationState: state, dictationMeter: meter, transcript: partialTranscript }
+    { dictationState: state, transcript: partialTranscript }
   )
+  await page.waitForFunction(() => Boolean(window.__dictationMeterE2E))
+  await page.evaluate((dictationMeter) => {
+    window.__dictationMeterE2E?.publish(dictationMeter)
+  }, meter)
 }
 
 async function pauseForRecordedProof(page: Page): Promise<void> {
@@ -38,15 +39,17 @@ async function pauseForRecordedProof(page: Page): Promise<void> {
 }
 
 test('dictation grapes react across the visible recording lifecycle', async ({ orcaPage }) => {
-  const quiet = { level: 0, peak: 0, isSpeaking: false, isClipping: false, lastUpdatedAt: 1 }
+  const quiet = { level: 0, isSpeaking: false, isClipping: false }
   await setDictationVisualState(orcaPage, 'listening', quiet)
 
-  const status = orcaPage.getByRole('status').filter({ has: orcaPage.getByText('Listening') })
-  await expect(status).toBeVisible()
-  await expect(status.getByTestId('dictation-grapes').locator('span')).toHaveCount(9)
-  await expect(status.getByRole('button', { name: 'Stop dictation' })).toBeVisible()
+  const indicator = orcaPage.getByTestId('dictation-indicator')
+  const status = indicator.getByRole('status')
+  await expect(indicator).toBeVisible()
+  await expect(status).toHaveText('Listening')
+  await expect(indicator.getByTestId('dictation-grapes').locator('span')).toHaveCount(9)
+  await expect(indicator.getByRole('button', { name: 'Stop dictation' })).toBeVisible()
   await orcaPage.emulateMedia({ reducedMotion: 'reduce' })
-  await expect(status.getByTestId('dictation-grapes').locator('span').first()).toHaveCSS(
+  await expect(indicator.getByTestId('dictation-grapes').locator('span').first()).toHaveCSS(
     'transition-property',
     'none'
   )
@@ -55,20 +58,18 @@ test('dictation grapes react across the visible recording lifecycle', async ({ o
 
   const speaking = {
     level: 0.76,
-    peak: 0.84,
     isSpeaking: true,
-    isClipping: false,
-    lastUpdatedAt: 2
+    isClipping: false
   }
   await setDictationVisualState(orcaPage, 'listening', speaking)
-  await expect(orcaPage.getByRole('status').filter({ hasText: 'Speaking' })).toBeVisible()
+  await expect(indicator.getByText('Speaking')).toBeVisible()
+  await expect(status).toHaveText('Listening')
   await pauseForRecordedProof(orcaPage)
 
-  const clipping = { ...speaking, level: 1, peak: 1, isClipping: true, lastUpdatedAt: 3 }
+  const clipping = { ...speaking, level: 1, isClipping: true }
   await setDictationVisualState(orcaPage, 'listening', clipping)
-  const clippingStatus = orcaPage.getByRole('status').filter({ hasText: 'Too loud' })
-  await expect(clippingStatus).toBeVisible()
-  await expect(clippingStatus).toHaveClass(/text-destructive/)
+  await expect(status).toHaveText('Too loud')
+  await expect(indicator).toHaveClass(/text-destructive/)
   await pauseForRecordedProof(orcaPage)
 
   await setDictationVisualState(
@@ -80,11 +81,11 @@ test('dictation grapes react across the visible recording lifecycle', async ({ o
   await expect(
     orcaPage.getByText('The visualizer follows every word without covering the workspace.')
   ).toBeVisible()
+  await expect(status).toHaveText('Listening')
   await pauseForRecordedProof(orcaPage)
 
   await setDictationVisualState(orcaPage, 'stopping', quiet)
-  const processing = orcaPage.getByRole('status').filter({ hasText: 'Processing…' })
-  await expect(processing).toBeVisible()
-  await expect(processing.getByRole('button', { name: 'Stop dictation' })).toHaveCount(0)
+  await expect(status).toHaveText('Processing…')
+  await expect(indicator.getByRole('button', { name: 'Stop dictation' })).toHaveCount(0)
   await pauseForRecordedProof(orcaPage)
 })

--- a/tests/e2e/helpers/runtime-types.ts
+++ b/tests/e2e/helpers/runtime-types.ts
@@ -11,6 +11,7 @@ import type { Repo } from '../../../src/shared/repo-types'
 import type { WorkspaceVisibleTabType } from '../../../src/shared/tab-types'
 import type { TerminalTab } from '../../../src/shared/terminal-tab-types'
 import type { Worktree } from '../../../src/shared/worktree/types'
+import type { DictationMeterState } from '../../../src/renderer/src/components/dictation/dictation-audio-meter'
 
 // Why: window.__store is the Zustand bound store itself, so specs get the whole StoreApi.
 export type AppStore = {
@@ -63,6 +64,7 @@ declare global {
   // oxlint-disable-next-line typescript-eslint/consistent-type-definitions -- declaration merging requires interface
   interface Window {
     __store?: AppStore
+    __dictationMeterE2E?: { publish(meter: DictationMeterState): void }
     __paneManagers?: Map<string, PaneManagerLike>
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​317 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​312 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​320 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​59 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​261 |

<!-- /orca-pr-loc -->

## Summary

- add a sound-reactive nine-dot “grape” visualizer to the existing dictation pill
- derive a stable voice envelope from the audio samples already copied for STT, with adaptive noise-floor tracking, fast attack/slow release, speaking detection, and 500 ms clipping hysteresis
- make the recording lifecycle explicit: `Starting mic…`, `Listening`, `Speaking`, `Too loud`, and `Processing…`
- keep partial transcripts on a separate row when the selected model emits them, while preserving the existing stop control, shortcut tooltip, toggle/hold behavior, and focus-safe insertion flow
- add semantic live status and reduced-motion behavior

This revisits the useful audio-envelope direction from #6496 while fitting the current mic-selection, capture-loss, stop-control, and Orca design-system behavior. The nine-sample rhythm is inspired by the current Codex desktop dictation orb, rendered here with Orca’s tokenized monochrome floating-surface treatment.

## Visual proof

### Before

![Previous dictation indicator](https://github.com/user-attachments/assets/a0f5489f-52f7-450b-8569-03bb2ddc9816)

### After — speaking, dark theme

![Sound-reactive grape visualizer in the Orca workspace](https://github.com/user-attachments/assets/16bb172a-5195-47fe-bd77-22c0710d55d8)

### Responsive layout — narrow window, light theme

![Narrow-window transcript treatment](https://github.com/user-attachments/assets/3b5572a2-6aad-4289-9350-be38ade9a8ac)

### Transcript and processing details

![Partial transcript remains separate from semantic recording status](https://github.com/user-attachments/assets/8c6db368-0a05-4294-b614-82b5c6b1bbe2)

![Processing state removes the stop control](https://github.com/user-attachments/assets/aa376442-e251-4e56-9388-a311e76340d3)

### Full lifecycle video

The recorded E2E ran successfully three consecutive times. This attached run shows listening → speaking → clipping → transcript → processing.

https://github.com/user-attachments/assets/f015b156-1158-45fa-9def-36fc3831c3d0

## Implementation notes

- meter analysis is one O(samples) pass over the existing 4096-sample callback; it neither suppresses nor mutates the STT samples
- presentation updates use a scoped transient store, are capped at 15 Hz, quantized and deduplicated, and pause while the document is hidden
- the meter resets on capture start and stop, and the capture-loss path continues through the existing teardown
- no RPC, IPC, remote-wire, persisted-state, mobile, dependency, or native-module contract changed

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts …` — 43 focused tests passed
- `SKIP_BUILD=1 pnpm exec playwright test tests/e2e/dictation-indicator.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1` — passed
- visual-proof recorder with `--repeat-each=3` — 3/3 passed
- `pnpm run typecheck` — passed
- `pnpm run tc:web` — passed
- `pnpm run check:code-quality:changed` — 0 findings
- `pnpm run verify:localization-catalog` — passed
- `pnpm exec electron-vite build --mode e2e` — passed
- `git diff --check` — passed

`pnpm run typecheck:e2e` remains non-clean because of existing repository-wide E2E type errors. The new spec’s initially reported optional `window.__store` access was fixed with an explicit runtime guard.

## Readiness review

Verdict: ready; no P0, P1, or P2 findings in the changed span.

- performance: a 12,000-chunk benchmark measured ~0.018 ms per 4096-sample analysis chunk (~0.021% of one core at 48 kHz); no timers, polling, unbounded buffers, extra subprocesses, or broad scans were added
- mobile/backcompat: no mobile-facing surface, protocol, persisted key, schema, route, or handshake changed
- Windows/Linux/SSH: renderer-only, platform-neutral layout and input behavior; no paths, shells, process APIs, native modules, or execution-host assumptions changed
- security/supply chain: no dependency, lockfile, network sink, secret, dynamic evaluation, or packaging change
- accessibility: a polite live region limited to stable lifecycle and clipping warnings, visible lifecycle labels, retained accessible stop action, and reduced-motion coverage

The Electron visual proof uses deterministic renderer state for repeatability; the real audio callback → meter → unchanged STT feed boundary is covered by the focused hook test.
