### PR TITLE
fix(relay): gate relay control work on proven broker liveness

### DIFF
--- a/src/main/runtime/relay/desktop-relay-service-broker-liveness.test.ts
+++ b/src/main/runtime/relay/desktop-relay-service-broker-liveness.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { OrcaCloudAuthConfig } from '../../orca-profiles/profile-cloud-auth-config'
+import type { OrcaRuntimeRpcServer } from '../runtime-rpc'
+
+const fakes = vi.hoisted(() => ({
+  readRelayAuthContext: vi.fn(),
+  brokers: [] as { live: boolean }[]
+}))
+
+vi.mock('./relay-auth-context', () => ({ readRelayAuthContext: fakes.readRelayAuthContext }))
+
+vi.mock('./relay-session-broker', () => {
+  // Mirrors the real broker: a control that died rejects with relay_control_not_active.
+  class RelaySessionBroker {
+    live = true
+    readonly hostId = 'relay-host-1'
+    readonly ownerIdentityKey = 'user-1\0profile-1\0org-1'
+    readonly endpoint = { v: 1 as const, relayHostId: 'relay-host-1' }
+    isLive(): boolean {
+      return this.live
+    }
+    closeNow(): void {
+      this.live = false
+    }
+    async createPairingRelay(relayDeviceId: string): Promise<unknown> {
+      if (!this.live) {
+        throw new Error('relay_control_not_active')
+      }
+      return { v: 1, relayHostId: this.hostId, relayDeviceId, inviteExpiresAt: 0 }
+    }
+    static connect = vi.fn(async () => {
+      const broker = new RelaySessionBroker()
+      fakes.brokers.push(broker)
+      return broker
+    })
+  }
+  return { RelaySessionBroker }
+})
+
+import { DesktopRelayService } from './desktop-relay-service'
+
+function service(): DesktopRelayService {
+  fakes.brokers.length = 0
+  fakes.readRelayAuthContext.mockResolvedValue({
+    identity: { userId: 'user-1', profileId: 'profile-1', organizationId: 'org-1' },
+    accessToken: 'access-1',
+    relayEntitled: true
+  })
+  const runtimeRpc = {
+    getE2EEKeypair: () => ({
+      publicKey: new Uint8Array(32).fill(7),
+      secretKey: new Uint8Array(32).fill(9),
+      publicKeyB64: 'x'
+    }),
+    getMobileSocketWiring: () => ({ attachTransport: () => () => {} }),
+    getRelayRevokeOutbox: () => ({ pendingFor: () => [], remove: vi.fn() }),
+    getDeviceRegistry: () => ({
+      listDevices: () => [],
+      getDevice: () => ({ deviceId: 'device-1', scope: 'mobile' }),
+      getMobilePairingConnectionMode: () => 'automatic'
+    })
+  } as unknown as OrcaRuntimeRpcServer
+  return new DesktopRelayService({
+    authConfig: {
+      relayDirectorUrl: 'https://relay.example.test',
+      relayTokenEndpoint: 'https://login.example.test/relay-token'
+    } as OrcaCloudAuthConfig,
+    userDataPath: '/tmp/orca-relay-liveness-test',
+    appVersion: '1.4.188',
+    runtimeRpc,
+    onStatus: () => {}
+  })
+}
+
+describe('DesktopRelayService broker liveness', () => {
+  it('pairs through a replacement when the owned broker control died', async () => {
+    // Why: ownership stays 'valid' after a control socket dies, so the stale
+    // handle otherwise reaches create_pairing_relay and fails the pairing.
+    const relayService = service()
+    try {
+      await expect(relayService.createPairingRelay('device-1')).resolves.toMatchObject({
+        binding: { relayDeviceId: 'device-1' }
+      })
+      expect(fakes.brokers).toHaveLength(1)
+
+      fakes.brokers[0]!.live = false
+
+      await expect(relayService.createPairingRelay('device-2')).resolves.toMatchObject({
+        binding: { relayDeviceId: 'device-2' }
+      })
+      expect(fakes.brokers).toHaveLength(2)
+      expect(fakes.brokers[1]!.live).toBe(true)
+    } finally {
+      relayService.stop()
+    }
+  })
+
+  it('keeps using a live broker instead of replacing it', async () => {
+    const relayService = service()
+    try {
+      await relayService.createPairingRelay('device-1')
+      await relayService.createPairingRelay('device-2')
+      expect(fakes.brokers).toHaveLength(1)
+    } finally {
+      relayService.stop()
+    }
+  })
+})

--- a/src/main/runtime/relay/desktop-relay-service.ts
+++ b/src/main/runtime/relay/desktop-relay-service.ts
@@ -297,8 +297,7 @@ export class DesktopRelayService {
   }
 
   private async activeBrokerForDemand(): Promise<RelaySessionBroker | null> {
-    const broker =
-      this.coordinator.getActiveBroker() ?? (await this.coordinator.waitForActiveBroker())
+    const broker = this.coordinator.getLiveBroker() ?? (await this.coordinator.waitForLiveBroker())
     return broker instanceof RelaySessionBroker ? broker : null
   }
 

--- a/src/main/runtime/relay/relay-auth-coordinator-recovery.test.ts
+++ b/src/main/runtime/relay/relay-auth-coordinator-recovery.test.ts
@@ -259,6 +259,40 @@ describe('RelayAuthCoordinator transient recovery', () => {
 })
 
 describe('RelayAuthCoordinator liveness safety net', () => {
+  it('withholds a dead broker from control work while identity matching still sees it', async () => {
+    vi.useFakeTimers()
+    const dead = { closeNow: vi.fn(), isLive: () => false }
+    const coordinator = new RelayAuthCoordinator({
+      readContext: async () => context,
+      openBroker: vi.fn().mockResolvedValue(dead),
+      onStatus: vi.fn(),
+      random: () => 0.5
+    })
+
+    coordinator.reconcile()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(coordinator.getActiveBroker()).toBe(dead)
+    expect(coordinator.getLiveBroker()).toBeNull()
+  })
+
+  it('treats a broker that cannot report liveness as usable, not dead', async () => {
+    // Why: unverifiable is not exited — only a broker that proves its control
+    // died is withheld; silence must never cost a working relay.
+    vi.useFakeTimers()
+    const unverifiable = { closeNow: vi.fn() }
+    const coordinator = new RelayAuthCoordinator({
+      readContext: async () => context,
+      openBroker: vi.fn().mockResolvedValue(unverifiable),
+      onStatus: vi.fn(),
+      random: () => 0.5
+    })
+
+    coordinator.reconcile()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(coordinator.getLiveBroker()).toBe(unverifiable)
+    await expect(coordinator.waitForLiveBroker()).resolves.toBe(unverifiable)
+  })
+
   it('reopens a broker that died leaving no retry timer behind', async () => {
     // Why: an auth refresh failing past token expiry closes the broker with
     // no timer; only ensureLive (periodic/power-resume) can revive it.

--- a/src/main/runtime/relay/relay-auth-coordinator.test.ts
+++ b/src/main/runtime/relay/relay-auth-coordinator.test.ts
@@ -26,7 +26,7 @@ describe('RelayAuthCoordinator', () => {
       onStatus: (status) => statuses.push(status)
     })
     coordinator.reconcile()
-    await coordinator.waitForActiveBroker()
+    await coordinator.waitForLiveBroker()
     expect(openBroker).not.toHaveBeenCalled()
     expect(statuses.at(-1)).toBe('standby')
   })
@@ -43,10 +43,10 @@ describe('RelayAuthCoordinator', () => {
       lingerMs: 250
     })
     coordinator.reconcile()
-    await coordinator.waitForActiveBroker()
+    await coordinator.waitForLiveBroker()
     demanded = true
     coordinator.reconcile()
-    await expect(coordinator.waitForActiveBroker()).resolves.toBe(broker)
+    await expect(coordinator.waitForLiveBroker()).resolves.toBe(broker)
     demanded = false
     coordinator.reconcile()
     await vi.waitFor(() => expect(statuses.at(-1)).toBe('standby'))
@@ -65,7 +65,7 @@ describe('RelayAuthCoordinator', () => {
       lingerMs: 20
     })
     coordinator.reconcile()
-    await expect(coordinator.waitForActiveBroker()).resolves.toBe(broker)
+    await expect(coordinator.waitForLiveBroker()).resolves.toBe(broker)
     demanded = false
     coordinator.reconcile()
     demanded = true
@@ -85,10 +85,10 @@ describe('RelayAuthCoordinator', () => {
       lingerMs: 10_000
     })
     coordinator.reconcile()
-    await expect(coordinator.waitForActiveBroker()).resolves.toBe(broker)
+    await expect(coordinator.waitForLiveBroker()).resolves.toBe(broker)
     current = { ...context, identity: { ...context.identity, profileId: 'profile-2' } }
     coordinator.reconcile()
-    await coordinator.waitForActiveBroker()
+    await coordinator.waitForLiveBroker()
     expect(broker.closeNow).toHaveBeenCalledOnce()
   })
 

--- a/src/main/runtime/relay/relay-auth-coordinator.ts
+++ b/src/main/runtime/relay/relay-auth-coordinator.ts
@@ -88,8 +88,16 @@ export class RelayAuthCoordinator {
     this.options.onStatus('offline')
   }
 
+  // Raw ownership handle for identity matching (revoke routing); control work uses getLiveBroker.
   getActiveBroker(): CoordinatedRelayBroker | null {
     return this.ownership?.valid ? this.ownership.broker : null
+  }
+
+  // Why: ownership stays valid across a control death, so control work must
+  // apply the same liveness gate reconcile does; unprovable liveness stays usable.
+  getLiveBroker(): CoordinatedRelayBroker | null {
+    const broker = this.getActiveBroker()
+    return broker && (broker.isLive?.() ?? true) ? broker : null
   }
 
   // Why: some broker deaths end with no retry timer — an auth refresh that
@@ -108,16 +116,16 @@ export class RelayAuthCoordinator {
     this.beginReconcile(false)
   }
 
-  async waitForActiveBroker(): Promise<CoordinatedRelayBroker | null> {
+  async waitForLiveBroker(): Promise<CoordinatedRelayBroker | null> {
     while (!this.stopped) {
-      const broker = this.getActiveBroker()
+      const broker = this.getLiveBroker()
       if (broker) {
         return broker
       }
       const pending = this.latestReconcile
       await pending
       if (pending === this.latestReconcile) {
-        return this.getActiveBroker()
+        return this.getLiveBroker()
       }
     }
     return null


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​148 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​142 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |

<!-- /orca-pr-loc -->

## Description

After a relay control socket died, broker ownership could remain valid while the control itself was unusable. Pairing and endpoint work read that stale ownership handle and failed with `relay_control_not_active` instead of waiting for the reconcile already replacing it.

Control work now uses a liveness-gated broker accessor and wait path. The raw ownership accessor remains available only for revoke identity matching, where retaining the original owner is required for durable retry.

## ELI5

Orca remembered which relay phone line belonged to it, but sometimes that line had already gone dead. Pairing grabbed the remembered-but-dead line while Orca was already connecting a replacement. Now pairing waits for the working replacement; revocation still remembers the old line long enough to finish its bookkeeping.

## Reliability contract

- A broker is withheld only when it proves `isLive() === false`.
- Missing liveness evidence remains `unverifiable`, not `exited`, and stays usable.
- A failed reconcile preserves the existing bounded retry/backoff behavior and the existing `relay_control_not_active` terminal error.
- Revoke routing retains raw ownership identity and its durable outbox semantics.

## Readiness review

- **SSH / remote / network:** uses locally observed control state; loss of contact alone is never treated as process death. Reconnect and retry ownership are unchanged.
- **Crash / retry / growth:** no new timers, loops, queues, casts, or unbounded collections; the wait path terminates on the existing reconcile generation.
- **Security / supply chain:** no dependency, credential, shell, persistence, or network-sink changes.
- **Performance / resources:** one constant-time liveness predicate on a demand path that already reconciles; no polling or subprocess changes.
- **Functional correctness:** real coordinator + service coverage proves dead-broker replacement, live-broker reuse, and unverifiable-broker retention.
- **Backward compatibility / data loss:** no persisted state, RPC, stream, mobile, or protocol surface changed.
- **Cross-platform / remoting:** platform-neutral TypeScript; the original report was Windows, and no path/shell/process assumptions were added.

## Validation

- `src/main/runtime/relay`: **12 files / 84 tests passed**
- `pnpm run typecheck:node`: passed
- `pnpm run check:code-quality:changed`: passed with 0 findings
- GitHub required checks: passed, including Node 24/26 shards, Windows packaging, wire compatibility, static analysis, and typecheck

## Review verdict

- **P0:** none
- **P1:** none
- **P2:** none

Ready to land.
