### PR TITLE
fix(rate-limits): safely surface Codex RPC exit reasons

### DIFF
--- a/src/main/rate-limits/codex-fetcher-rpc-exit-diagnostics.test.ts
+++ b/src/main/rate-limits/codex-fetcher-rpc-exit-diagnostics.test.ts
@@ -1,0 +1,132 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as Win32Utils from '../win32-utils'
+import { isCodexAuthError } from '../../shared/codex-auth-errors'
+
+const { getSpawnArgsForWindowsMock, ptySpawnMock, resolveCodexCommandMock } = vi.hoisted(() => ({
+  getSpawnArgsForWindowsMock: vi.fn(),
+  ptySpawnMock: vi.fn(),
+  resolveCodexCommandMock: vi.fn()
+}))
+
+vi.mock('../win32-utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof Win32Utils>()),
+  getSpawnArgsForWindows: getSpawnArgsForWindowsMock
+}))
+
+vi.mock('../codex-cli/command', () => ({
+  resolveCodexCommand: resolveCodexCommandMock
+}))
+
+vi.mock('node-pty', () => ({
+  spawn: ptySpawnMock
+}))
+
+vi.mock('./codex-auth-presence', () => ({
+  probeCodexAuthPresence: vi.fn(() => 'present')
+}))
+
+vi.mock('../codex/codex-state-db', () => ({
+  isCodexStateDbBackfillPending: vi.fn(() => false)
+}))
+
+vi.mock('../codex/codex-state-db-backfill-recovery', () => ({
+  startCodexStateDbBackfillRecoveryInBackground: vi.fn(() => Promise.resolve(null))
+}))
+
+import { fetchCodexRateLimits } from './codex-fetcher'
+
+// Dies the way a real app-server does: complains on stderr, then exits nonzero
+// once the client has spoken, so the initialize write can never race an EPIPE.
+const STUB_CODEX_SOURCE = `
+process.stdin.on('data', () => {
+  process.stderr.write(process.env.ORCA_STUB_CODEX_STDERR ?? '')
+  process.exit(Number(process.env.ORCA_STUB_CODEX_EXIT_CODE ?? '1'))
+})
+`
+
+let tempRoot: string
+let stubPath: string
+
+function runStub(stderr: string, exitCode: number): Promise<{ error: string | null }> {
+  process.env.ORCA_STUB_CODEX_STDERR = stderr
+  process.env.ORCA_STUB_CODEX_EXIT_CODE = String(exitCode)
+  return fetchCodexRateLimits({ allowPtyFallback: false })
+}
+
+describe('Codex RPC exit diagnostics', () => {
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), 'orca-codex-rpc-exit-'))
+    stubPath = join(tempRoot, 'codex-exit-stub.cjs')
+    writeFileSync(stubPath, STUB_CODEX_SOURCE)
+    resolveCodexCommandMock.mockReturnValue('codex')
+    getSpawnArgsForWindowsMock.mockImplementation((_command: string, args: string[]) => ({
+      spawnCmd: process.execPath,
+      spawnArgs: [stubPath, ...args]
+    }))
+  })
+
+  afterEach(() => {
+    delete process.env.ORCA_STUB_CODEX_STDERR
+    delete process.env.ORCA_STUB_CODEX_EXIT_CODE
+    rmSync(tempRoot, { recursive: true, force: true })
+    vi.clearAllMocks()
+  })
+
+  it('names the exit code and what the child reported', async () => {
+    const result = await runStub(
+      "error: invalid value 'untrusted' for '--ask-for-approval <APPROVAL_POLICY>'\n" +
+        "  [possible values: on-request, never]\n\nFor more information, try '--help'.\n",
+      2
+    )
+
+    expect(result.error).toBe(
+      "Codex RPC process exited (exit code 2): error: invalid value 'untrusted' for '--ask-for-approval <APPROVAL_POLICY>'"
+    )
+  })
+
+  it('names the exit code when the child says nothing', async () => {
+    await expect(runStub('', 1)).resolves.toMatchObject({
+      error: 'Codex RPC process exited (exit code 1)',
+      status: 'error'
+    })
+  })
+
+  it('classifies a dead refresh token so the re-auth warning fires', async () => {
+    const result = await runStub(
+      '2026-08-20T18:04:11.221Z INFO codex_core::auth: refreshing ChatGPT tokens\n' +
+        'ERROR: The ChatGPT access token could not be refreshed; please sign in again.\n',
+      1
+    )
+
+    expect(result.error).toBe(
+      'ERROR: The ChatGPT access token could not be refreshed; please sign in again.'
+    )
+    // The renderer's re-auth warning gates on exactly this predicate;
+    // codex-account-auth-warning.test.ts asserts the surfaced string end-to-end.
+    expect(isCodexAuthError(result.error)).toBe(true)
+  })
+
+  it('keeps the re-auth phrase that path redaction would swallow', async () => {
+    const result = await runStub(
+      `ERROR: /Users/haris/.codex/auth.json is stale — please sign in again.\n`,
+      1
+    )
+
+    expect(isCodexAuthError(result.error)).toBe(true)
+  })
+
+  it('redacts paths and secrets a dying child prints, and bounds the line', async () => {
+    const result = await runStub(
+      `ERROR: could not read /Users/moveoplus/.codex/auth.json (token=sk-${'a'.repeat(40)})\n` +
+        `${'x'.repeat(5_000)}\n`,
+      3
+    )
+
+    expect(result.error).not.toContain('moveoplus')
+    expect(result.error).not.toContain('sk-aaaa')
+    expect(result.error?.length ?? 0).toBeLessThan(500)
+  })
+})

--- a/src/main/rate-limits/codex-fetcher-rpc-exit-diagnostics.test.ts
+++ b/src/main/rate-limits/codex-fetcher-rpc-exit-diagnostics.test.ts
@@ -82,9 +82,9 @@ describe('Codex RPC exit diagnostics', () => {
       2
     )
 
-    expect(result.error).toBe(
-      "Codex RPC process exited (exit code 2): error: invalid value 'untrusted' for '--ask-for-approval <APPROVAL_POLICY>'"
-    )
+    expect(result.error).toContain('Codex RPC process exited (exit code 2)')
+    expect(result.error).toContain("invalid value 'untrusted'")
+    expect(result.error).toContain("try '--help'")
   })
 
   it('names the exit code when the child says nothing', async () => {
@@ -101,9 +101,7 @@ describe('Codex RPC exit diagnostics', () => {
       1
     )
 
-    expect(result.error).toBe(
-      'ERROR: The ChatGPT access token could not be refreshed; please sign in again.'
-    )
+    expect(result.error).toBe('Your ChatGPT session could not be refreshed. Please sign in again.')
     // The renderer's re-auth warning gates on exactly this predicate;
     // codex-account-auth-warning.test.ts asserts the surfaced string end-to-end.
     expect(isCodexAuthError(result.error)).toBe(true)
@@ -128,5 +126,15 @@ describe('Codex RPC exit diagnostics', () => {
     expect(result.error).not.toContain('moveoplus')
     expect(result.error).not.toContain('sk-aaaa')
     expect(result.error?.length ?? 0).toBeLessThan(500)
+  })
+
+  it('keeps the final failure after startup banners', async () => {
+    const result = await runStub(
+      'Welcome to WSL\nLoading shell profile\nERROR: unknown option --obsolete\n',
+      2
+    )
+
+    expect(result.error).toContain('Welcome to WSL')
+    expect(result.error).toContain('ERROR: unknown option --obsolete')
   })
 })

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -25,6 +25,9 @@ import { getCmdExePath, getSpawnArgsForWindows } from '../win32-utils'
 import { cleanupHiddenRateLimitPty, registerHiddenRateLimitPty } from './hidden-pty-cleanup'
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import { extractCodexAuthError, isCodexAuthError } from '../../shared/codex-auth-errors'
+import { stripAnsiControlSequences } from '../../shared/commit-message-agent-output'
+import { sanitizeCrashReportString } from '../../shared/crash-reporting'
+import { redactString } from '../observability/redactor'
 import { buildWslExecArgs, buildWslLoginShellCommand } from '../../shared/wsl-login-shell-command'
 import {
   getHiddenRateLimitWslCwdSetupCommands,
@@ -63,6 +66,8 @@ const BACKEND_TIMEOUT_MS = 10_000
 // Why: redeeming a reset credit is an explicit user action, not a poll — allow more time for a slow backend.
 const REDEEM_BACKEND_TIMEOUT_MS = 30_000
 const MAX_DIAGNOSTIC_OUTPUT_LENGTH = 100_000
+// Why: one surfaced line, not a log dump — the full capture stays in-process.
+const MAX_EXIT_DETAIL_LENGTH = 200
 
 export type FetchCodexRateLimitsOptions = {
   codexHomePath?: string | null
@@ -863,17 +868,64 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
       child.stdin.off('error', onStdinError)
     }
 
-    function onClose(): void {
+    function onClose(code: number | null, signal: NodeJS.Signals | null): void {
       settle({
         provider: 'codex',
         session: null,
         weekly: null,
         updatedAt: Date.now(),
-        error: withMacTailscaleDnsHint('RPC process exited unexpectedly', stderr),
+        error: describeCodexRpcExit(code, signal, stderr),
         status: 'error'
       })
     }
   })
+}
+
+// Why: this string is the whole diagnosis the user gets, and a hardcoded one
+// hid both the exit status and the child's own auth complaint — so an
+// app-server that quit on a dead refresh token never classified as
+// re-authenticable and never prompted sign-in (worst on Windows, which has no
+// PTY fallback to recover the reason).
+function describeCodexRpcExit(
+  code: number | null,
+  signal: NodeJS.Signals | null,
+  stderr: string
+): string {
+  const authError = extractCodexAuthError(stderr)
+  if (authError) {
+    return redactCodexChildOutput(authError)
+  }
+  const reason =
+    code !== null ? `exit code ${code}` : signal ? `signal ${signal}` : 'no exit status'
+  const detail = firstReportedStderrLine(stderr)
+  return withMacTailscaleDnsHint(
+    detail
+      ? `Codex RPC process exited (${reason}): ${detail}`
+      : `Codex RPC process exited (${reason})`,
+    stderr
+  )
+}
+
+function firstReportedStderrLine(stderr: string): string | null {
+  for (const rawLine of stripAnsiControlSequences(stderr).split(/\r\n|\n|\r/)) {
+    const line = rawLine.trim()
+    if (line) {
+      return redactCodexChildOutput(line)
+    }
+  }
+  return null
+}
+
+// Why: redactString kills token shapes without eating prose, while the
+// crash-report pass adds path scrubbing but is greedy enough to swallow the
+// rest of a line — so it is dropped when it would erase the auth phrase the
+// re-auth warning classifies on.
+function redactCodexChildOutput(text: string): string {
+  const withoutSecrets = redactString(text)
+  const withoutPaths = sanitizeCrashReportString(withoutSecrets, MAX_EXIT_DETAIL_LENGTH)
+  return isCodexAuthError(withoutSecrets) && !isCodexAuthError(withoutPaths)
+    ? withoutSecrets.slice(0, MAX_EXIT_DETAIL_LENGTH)
+    : withoutPaths
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -25,8 +25,10 @@ import { getCmdExePath, getSpawnArgsForWindows } from '../win32-utils'
 import { cleanupHiddenRateLimitPty, registerHiddenRateLimitPty } from './hidden-pty-cleanup'
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import { extractCodexAuthError, isCodexAuthError } from '../../shared/codex-auth-errors'
-import { stripAnsiControlSequences } from '../../shared/commit-message-agent-output'
-import { sanitizeCrashReportString } from '../../shared/crash-reporting'
+import {
+  excerptAgentFailureOutput,
+  sanitizeAgentFailureDetail
+} from '../../shared/commit-message-agent-output'
 import { redactString } from '../observability/redactor'
 import { buildWslExecArgs, buildWslLoginShellCommand } from '../../shared/wsl-login-shell-command'
 import {
@@ -66,8 +68,6 @@ const BACKEND_TIMEOUT_MS = 10_000
 // Why: redeeming a reset credit is an explicit user action, not a poll — allow more time for a slow backend.
 const REDEEM_BACKEND_TIMEOUT_MS = 30_000
 const MAX_DIAGNOSTIC_OUTPUT_LENGTH = 100_000
-// Why: one surfaced line, not a log dump — the full capture stays in-process.
-const MAX_EXIT_DETAIL_LENGTH = 200
 
 export type FetchCodexRateLimitsOptions = {
   codexHomePath?: string | null
@@ -881,51 +881,27 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
   })
 }
 
-// Why: this string is the whole diagnosis the user gets, and a hardcoded one
-// hid both the exit status and the child's own auth complaint — so an
-// app-server that quit on a dead refresh token never classified as
-// re-authenticable and never prompted sign-in (worst on Windows, which has no
-// PTY fallback to recover the reason).
+// Why: surfaced text drives re-auth classification, so diagnosis and classification must use the same sanitized value.
 function describeCodexRpcExit(
   code: number | null,
   signal: NodeJS.Signals | null,
   stderr: string
 ): string {
-  const authError = extractCodexAuthError(stderr)
-  if (authError) {
-    return redactCodexChildOutput(authError)
+  if (extractCodexAuthError(stderr)) {
+    // Fixed copy cannot leak paths/tokens and is exactly what the renderer classifies.
+    return 'Your ChatGPT session could not be refreshed. Please sign in again.'
   }
   const reason =
     code !== null ? `exit code ${code}` : signal ? `signal ${signal}` : 'no exit status'
-  const detail = firstReportedStderrLine(stderr)
+  const detail = sanitizeAgentFailureDetail(
+    redactString(excerptAgentFailureOutput('', stderr) ?? '')
+  )
   return withMacTailscaleDnsHint(
     detail
       ? `Codex RPC process exited (${reason}): ${detail}`
       : `Codex RPC process exited (${reason})`,
     stderr
   )
-}
-
-function firstReportedStderrLine(stderr: string): string | null {
-  for (const rawLine of stripAnsiControlSequences(stderr).split(/\r\n|\n|\r/)) {
-    const line = rawLine.trim()
-    if (line) {
-      return redactCodexChildOutput(line)
-    }
-  }
-  return null
-}
-
-// Why: redactString kills token shapes without eating prose, while the
-// crash-report pass adds path scrubbing but is greedy enough to swallow the
-// rest of a line — so it is dropped when it would erase the auth phrase the
-// re-auth warning classifies on.
-function redactCodexChildOutput(text: string): string {
-  const withoutSecrets = redactString(text)
-  const withoutPaths = sanitizeCrashReportString(withoutSecrets, MAX_EXIT_DETAIL_LENGTH)
-  return isCodexAuthError(withoutSecrets) && !isCodexAuthError(withoutPaths)
-    ? withoutSecrets.slice(0, MAX_EXIT_DETAIL_LENGTH)
-    : withoutPaths
 }
 
 // ---------------------------------------------------------------------------

--- a/src/main/text-generation/commit-message-text-generation.ts
+++ b/src/main/text-generation/commit-message-text-generation.ts
@@ -19,7 +19,8 @@ import {
 } from '../../shared/pull-request-generation'
 import {
   cleanGeneratedCommitMessage,
-  excerptAgentFailureOutput
+  excerptAgentFailureOutput,
+  sanitizeAgentFailureDetail
 } from '../../shared/commit-message-prompt'
 import {
   captureAgentGenerationFailureOutput,
@@ -194,40 +195,6 @@ function formatAgentCliFailureMessage(
   return options?.includeLocalMacDnsHint === false
     ? message
     : withMacTailscaleDnsHint(message, detail)
-}
-
-function sanitizeAgentFailureDetail(detail: string | null): string | null {
-  // Cf covers bidi overrides (U+202E etc.) that could visually reorder the
-  // persisted, client-synced detail.
-  const trimmed = detail
-    ?.replace(/[\p{Cc}\p{Cf}]+/gu, ' ')
-    .replace(/\s+/g, ' ')
-    .trim()
-  if (!trimmed) {
-    return null
-  }
-  // Why: agent stderr often includes local or SSH repo paths. Persisting those
-  // into worktree metadata leaks environment details into synced renderer state.
-  const redacted = trimmed
-    .replace(
-      /\\\\[^\s"'`<>\\]+\\(?:[^\s"'`<>\\]+(?:\s+[^\s"'`<>\\]+)*(?=\\)\\)*[^\s"'`<>\\]+/g,
-      '[path]'
-    )
-    // Only backslashes may repeat: JSON provider bodies double them
-    // (`C:\\Users\\name\\…`), while a URL's `://` must stay single so remedy
-    // links like `https://…` survive redaction.
-    .replace(
-      /[A-Za-z]:(?:\\+|\/)(?:[^\s"'`<>\\/|:*?]+(?:\s+[^\s"'`<>\\/|:*?]+)*(?=[\\/])(?:\\+|\/))*[^\s"'`<>\\/|:*?]+/g,
-      '[path]'
-    )
-    // Why: require ≥2 segments (one internal `/`) so provider remedy tokens like
-    // `/login` survive while multi-segment paths (`/Users/name/repo`) still redact.
-    // `=:,` prefixes catch key=/path value:/path list,/path shapes in provider bodies.
-    .replace(
-      /(^|[\s"'`(=:,])\/(?:[^\s"'`<>/]+(?:\s+[^\s"'`<>/]+)*(?=\/)\/)+[^\s"'`<>/]+/g,
-      '$1[path]'
-    )
-  return redacted.length > 240 ? `${redacted.slice(0, 240).trimEnd()}...` : redacted
 }
 
 function userFacingUnsafeWindowsBatchArgs(label: string): string {

--- a/src/renderer/src/components/settings/codex-account-auth-warning.test.ts
+++ b/src/renderer/src/components/settings/codex-account-auth-warning.test.ts
@@ -38,14 +38,10 @@ describe('codex account auth warning', () => {
     ).toBe(false)
   })
 
-  // Strings produced verbatim by the RPC-exit path in
-  // codex-fetcher-rpc-exit-diagnostics.test.ts.
   it('warns re-auth when the app-server quits over a dead refresh token', () => {
     expect(
       getCodexAccountAuthWarning({
-        limits: codexLimits(
-          'ERROR: The ChatGPT access token could not be refreshed; please sign in again.'
-        ),
+        limits: codexLimits('Your ChatGPT session could not be refreshed. Please sign in again.'),
         target: { runtime: 'host', wslDistro: null },
         runtime: { runtime: 'host' },
         activeAccountId: 'account-1',

--- a/src/renderer/src/components/settings/codex-account-auth-warning.test.ts
+++ b/src/renderer/src/components/settings/codex-account-auth-warning.test.ts
@@ -38,6 +38,36 @@ describe('codex account auth warning', () => {
     ).toBe(false)
   })
 
+  // Strings produced verbatim by the RPC-exit path in
+  // codex-fetcher-rpc-exit-diagnostics.test.ts.
+  it('warns re-auth when the app-server quits over a dead refresh token', () => {
+    expect(
+      getCodexAccountAuthWarning({
+        limits: codexLimits(
+          'ERROR: The ChatGPT access token could not be refreshed; please sign in again.'
+        ),
+        target: { runtime: 'host', wslDistro: null },
+        runtime: { runtime: 'host' },
+        activeAccountId: 'account-1',
+        accountId: 'account-1'
+      })
+    ).toBe('stale-sign-in')
+  })
+
+  it('does not warn re-auth when the app-server quits over bad argv', () => {
+    expect(
+      getCodexAccountAuthWarning({
+        limits: codexLimits(
+          "Codex RPC process exited (exit code 2): error: invalid value 'untrusted' for '--ask-for-approval <APPROVAL_POLICY>'"
+        ),
+        target: { runtime: 'host', wslDistro: null },
+        runtime: { runtime: 'host' },
+        activeAccountId: 'account-1',
+        accountId: 'account-1'
+      })
+    ).toBeNull()
+  })
+
   it('matches the active host account on the current rate-limit target', () => {
     expect(
       getCodexAccountAuthWarning({

--- a/src/shared/commit-message-agent-output.ts
+++ b/src/shared/commit-message-agent-output.ts
@@ -158,6 +158,33 @@ export function excerptAgentFailureOutput(stdout: string, stderr: string): strin
   return composeTwoEndExcerpt(headLines, tailLine)
 }
 
+export function sanitizeAgentFailureDetail(detail: string | null): string | null {
+  // Cf covers bidi overrides that could visually reorder persisted, client-synced text.
+  const trimmed = detail
+    ?.replace(/[\p{Cc}\p{Cf}]+/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+  if (!trimmed) {
+    return null
+  }
+  const redacted = trimmed
+    .replace(
+      /\\\\[^\s"'`<>\\]+\\(?:[^\s"'`<>\\]+(?:\s+[^\s"'`<>\\]+)*(?=\\)\\)*[^\s"'`<>\\]+/g,
+      '[path]'
+    )
+    // JSON may double Windows separators; URL separators must remain single.
+    .replace(
+      /[A-Za-z]:(?:\\+|\/)(?:[^\s"'`<>\\/|:*?]+(?:\s+[^\s"'`<>\\/|:*?]+)*(?=[\\/])(?:\\+|\/))*[^\s"'`<>\\/|:*?]+/g,
+      '[path]'
+    )
+    // Keep single-segment remedies such as /login while redacting filesystem paths.
+    .replace(
+      /(^|[\s"'`(=:,])\/(?:[^\s"'`<>/]+(?:\s+[^\s"'`<>/]+)*(?=\/)\/)+[^\s"'`<>/]+/g,
+      '$1[path]'
+    )
+  return redacted.length > 240 ? `${redacted.slice(0, 240).trimEnd()}...` : redacted
+}
+
 function composeTwoEndExcerpt(headLines: string[], tailLine: string | null): string {
   const headPart = truncateExcerptPart(headLines.join(' '), FAILURE_EXCERPT_HEAD_BUDGET)
   // Repeated lines (spinner/retry frames) would otherwise show twice.

--- a/src/shared/commit-message-prompt.ts
+++ b/src/shared/commit-message-prompt.ts
@@ -19,7 +19,8 @@ Staged diff:
 
 export {
   cleanGeneratedCommitMessage,
-  excerptAgentFailureOutput
+  excerptAgentFailureOutput,
+  sanitizeAgentFailureDetail
 } from './commit-message-agent-output'
 
 /** Builds the final prompt sent to the agent. The custom suffix is appended verbatim


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​166 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​166 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​61 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​38 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​23 |

<!-- /orca-pr-loc -->

## Description

The Codex app-server close handler discarded the exit code, signal, and stderr, replacing every failure with `RPC process exited unexpectedly`. That also prevented refresh-token failures from reaching the renderer's existing re-sign-in classification.

The originally reported 1.4.187 bad-argv trigger was already fixed and shipped by #15823. This PR fixes the still-live diagnostic gap:

- known refresh-token exits become one fixed, non-secret re-sign-in message that the renderer classifies verbatim;
- other exits include the exit code or signal plus a bounded first-and-tail stderr excerpt;
- ANSI/control characters, secrets, macOS/Linux paths, Windows drive paths, and UNC paths are removed before renderer state sees the text;
- the existing user-facing agent failure sanitizer is shared instead of reusing the crash-bundle scrubber.

## ELI5

Codex could close and hand Orca a note explaining why, but Orca threw the note away and displayed “something went wrong.” Now Orca keeps a short, scrubbed version of the useful part. If the note says the login expired, Orca shows a safe “sign in again” message; otherwise it shows the exit status and useful error lines without exposing local paths or tokens.

## Safety and elegance

- Classification runs on the exact fixed auth message returned to the UI, so it cannot match hidden or truncated text.
- Generic diagnostics reuse the existing bounded first/tail excerpt, which keeps WSL/Windows startup banners from hiding the final error.
- The path sanitizer moved to its existing shared agent-output module, deleting the duplicate private implementation from text generation.
- Stderr remains capped at the existing 100 KB; generic formatting examines bounded excerpt windows and only runs after an unexpected child exit.

## Readiness review

- **SSH / remote / network:** host and WSL child exits use the same formatter; no connection, retry, or remote-wire behavior changed.
- **Crash / retry / growth:** no new retry, timer, listener, queue, or unbounded capture; close settlement remains single-shot.
- **Security / supply chain:** common secret shapes and cross-platform paths are redacted; no dependency or executable changes.
- **Performance / resources:** work occurs only on child failure and is bounded; no polling or subprocess fanout added.
- **Functional correctness:** real child-process tests cover exit code, empty stderr, refresh-token classification, path/secret redaction, output bounds, and banner-plus-tail diagnostics.
- **Backward compatibility / data loss:** no persisted schema, RPC, IPC, mobile, or protocol surface changed; no mobile-facing surface touched.
- **Cross-platform / remoting:** CRLF/ANSI handling and macOS/Linux, Windows drive, UNC, WSL-banner cases are covered by the formatter and existing sanitizer suites.

## Validation

- affected rate-limit + settings suites: **195 files / 1,478 tests passed**
- shared excerpt/path-sanitizer suites: **2 files / 64 tests passed**
- `pnpm run typecheck:node` and `pnpm run typecheck:web`: passed
- lint, formatting, changed-code quality, and max-lines ratchet: passed

## Review verdict

- **P0:** none
- **P1:** none
- **P2:** none

Ready to land.
