### PR TITLE
fix(composer): close the Create Workspace dialog on the first Escape

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerModal.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerModal.tsx
@@ -97,7 +97,6 @@ function ComposerModalBody({
         <QuickTabBody
           modalData={modalData}
           onClose={onClose}
-          onDismiss={handleDismiss}
           isSubmissionCancelled={isSubmissionCancelled}
           active
         />
@@ -109,13 +108,11 @@ function ComposerModalBody({
 function QuickTabBody({
   modalData,
   onClose,
-  onDismiss,
   isSubmissionCancelled,
   active
 }: {
   modalData: ComposerModalData
   onClose: () => void
-  onDismiss: () => void
   isSubmissionCancelled: () => boolean
   active: boolean
 }): React.JSX.Element {
@@ -238,43 +235,27 @@ function QuickTabBody({
       ? translate('auto.components.NewWorkspaceComposerModal.createWorktree', 'Create worktree')
       : translate('auto.components.NewWorkspaceComposerModal.createWorkspace', 'Create workspace')
 
-  // Cmd/Ctrl+Enter submits, Esc first blurs the focused input (like the full page).
+  // Cmd/Ctrl+Enter submits. Escape belongs to the dialog's dismissable layer:
+  // the page-style "blur the focused field first" rule assumes the user chose
+  // that field, but this dialog auto-focuses the name input on open, so handling
+  // Escape here swallowed every first press and left the composer stuck open.
+  // Radix also closes only the topmost layer, so nested popovers/selects/dialogs
+  // keep their own Escape without needing a guard here.
   const nestedDialogOpen = agentSettingsOpen || addProjectOpen || setLocationOpen
   useEffect(() => {
     if (!active || nestedDialogOpen) {
-      // Why: while a nested dialog (Add Project / Agents / Set location) is layered on top,
-      // this capture-phase handler must not steal its Escape (which should
-      // close only the nested dialog) or fire composer submit underneath it.
+      // Why: while a nested dialog (Add Project / Agents / Set location) is layered
+      // on top, this capture-phase handler must not fire composer submit underneath it.
       return
     }
     const onKeyDown = (event: KeyboardEvent): void => {
-      if (event.key !== 'Enter' && event.key !== 'Escape') {
+      // Why: workspace creation is screen-local submit behavior, not a
+      // user-configurable app command.
+      if (!isScreenSubmitShortcut(event)) {
         return
       }
       const target = event.target
       if (!(target instanceof HTMLElement)) {
-        return
-      }
-
-      if (event.key === 'Escape') {
-        if (
-          target instanceof HTMLInputElement ||
-          target instanceof HTMLTextAreaElement ||
-          target instanceof HTMLSelectElement ||
-          target.isContentEditable
-        ) {
-          event.preventDefault()
-          target.blur()
-          return
-        }
-        event.preventDefault()
-        onDismiss()
-        return
-      }
-
-      // Why: workspace creation is screen-local submit behavior, not a
-      // user-configurable app command.
-      if (!isScreenSubmitShortcut(event)) {
         return
       }
       if (!shouldAllowComposerEnterSubmitTarget(target, composerRef.current)) {
@@ -288,7 +269,7 @@ function QuickTabBody({
     }
     window.addEventListener('keydown', onKeyDown, { capture: true })
     return () => window.removeEventListener('keydown', onKeyDown, { capture: true })
-  }, [active, composerRef, createDisabled, handleCreate, nestedDialogOpen, onDismiss])
+  }, [active, composerRef, createDisabled, handleCreate, nestedDialogOpen])
 
   return (
     <>

--- a/tests/e2e/worktree-jump-palette-filter.spec.ts
+++ b/tests/e2e/worktree-jump-palette-filter.spec.ts
@@ -193,6 +193,10 @@ test.describe('Worktree jump-palette filters', () => {
 
     const createDialog = orcaPage.getByRole('dialog', { name: /Create (Workspace|Worktree)/i })
     await expect(createDialog).toBeVisible()
+    // Why assert focus first: the composer auto-focuses the name field, so Escape
+    // always lands on an input the user never chose. A page-style "blur the field
+    // first" handler here would silently cost a second press.
+    await expect(createDialog.locator('[data-workspace-name-input="true"]')).toBeFocused()
     await orcaPage.keyboard.press('Escape')
     await expect(createDialog).toBeHidden()
   })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​31 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​19 |

<!-- /orca-pr-loc -->

## Summary

Fixes the reproducible failure of `tests/e2e/worktree-jump-palette-filter.spec.ts:184` — *"pressing Enter creates a worktree from a typed name"* — on `main`:

```
Error: expect(locator).toBeHidden() failed
Locator:  getByRole('dialog', { name: /Create (Workspace|Worktree)/i })
Expected: hidden / Received: visible
```

## Root cause

Not the Cmd+J palette path — the Create Workspace dialog needed **two** Escape presses to close, from every entry point.

`NewWorkspaceComposerModal` installed a capture-phase `keydown` listener on `window` that copied the page-level rule used by `TaskPage` / `AutomationsPage` / `ArtifactsPage`: *Esc first blurs the focused field, and only closes once focus is outside an input.* On a page that rule protects a focus the user chose. This dialog, however, auto-focuses the name input on mount (`onOpenAutoFocus` → `getWorkspaceComposerInitialFocusTarget`), so the very first Escape always landed on an input the user never focused:

1. The window capture listener runs before Radix's `document` capture listener, blurs the input and calls `event.preventDefault()`.
2. Radix `DismissableLayer` then bails, because it only dismisses when `!event.defaultPrevented`.

So Escape #1 blurred, Escape #2 closed. Instrumented run against `main`:

```
ACTIVE BEFORE ESC: INPUT data-workspace-name-input=true value=cmd-j-enter-…
ACTIVE AFTER ESC1: DIV role=dialog data-state=open   modal="new-workspace-composer"
AFTER ESC2:        modal="none"
```

The nested Add Project / Agents / Set-location dialogs already stood the handler down so Radix could close them on a single Escape — the composer itself was the odd one out.

## Fix

Delete the Escape branch and let the dialog's dismissable layer own Escape. `handleDismiss` still runs via `onOpenChange`, so the submit-cancellation semantics are unchanged. Radix dismisses only the **topmost** layer, so nested popovers, selects and dialogs (the source popover and emoji suggestions in `SmartWorkspaceNameField`, Add Project, Agent Settings, Set location) still consume their own Escape first — previously the capture-phase handler could reach past an open popover. The `Cmd/Ctrl+Enter` submit path and its nested-dialog guard are untouched.

No behavior change for the full-page composers; they keep their own blur-first handlers.

## Validation

- `tests/e2e/worktree-jump-palette-filter.spec.ts` (electron-headless): **2 passed** — including the previously failing `pressing Enter creates a worktree from a typed name`. Verified failing before the change, passing after.
- `tests/e2e/worktree.spec.ts` + `tests/e2e/new-workspace-linked-item-project-switch.spec.ts` (the composer-driving e2e specs): **8 passed** — Cmd+J / quick-create behavior from #15970 intact.
- Vitest across the palette, composer and hooks suites: **893 passed**.
- `pnpm typecheck:web`, `oxlint`, and `oxlint --config config/oxlint-react-doctor.json` on the changed file: clean.


- Follow-up commit adds a focus assertion to the spec (the auto-focused name field is what made the page-style handler swallow the press) so the PR touches `tests/e2e/`, which is what makes CI actually run this spec rather than skipping it.

- Follow-up commit adds a focus assertion to the spec (the auto-focused name field is what made the page-style handler swallow the press). It also puts the PR inside tests/e2e/, which is what makes CI actually run this spec instead of skipping it - the same gate let the original assertion land untested.
