### PR TITLE
fix(preflight): do not count a Windows binary reached through interop as a WSL install

### DIFF
--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -133,24 +133,21 @@ describe('detectWslCommandsOnPath', () => {
   })
 })
 
-it.each([
-  ['a /mnt interop path', '/mnt/c/Users/me/AppData/Local/claude.exe'],
-  ['an uppercase drive', '/MNT/D/tools/claude.EXE'],
-  ['a .exe anywhere', '/opt/weird/claude.exe']
-])('does not count %s as installed in the distro', async (_case, resolved) => {
-  // WSL appends the Windows PATH to the guest PATH, so `command -v claude`
-  // resolves to the Windows binary on a distro with no guest install. That
-  // path is POSIX-absolute, so the absolute check alone accepted it and
-  // preflight reported the agent installed -- then launching it ran a
-  // Windows exe inside a Linux session with no guest $HOME.
+it('does not veto a guest binary on an ordinary Linux mount under /mnt', async () => {
+  // The walk skips PATH components the guest reports as Windows drives. A name
+  // rule on top of that could only do harm: /mnt/d can be an ext4 volume, and
+  // vetoing a path the walk deliberately kept turns the false positive back
+  // into the #9725 false negative.
   runWslProcessMock.mockResolvedValue({
     environmentResolved: true,
     code: 0,
-    stdout: `__ORCA_AGENT_PATH__claude\t${resolved}\n`,
+    stdout: '__ORCA_AGENT_PATH__claude\t/mnt/d/tools/claude\n',
     stderr: '',
     timedOut: false
   })
-  expect(await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])).toEqual(new Set())
+  await expect(detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])).resolves.toEqual(
+    new Set(['claude'])
+  )
 })
 
 it('still counts a genuine guest install', async () => {

--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -132,6 +132,39 @@ describe('detectWslCommandsOnPath', () => {
   })
 })
 
+it.each([
+  ['a /mnt interop path', '/mnt/c/Users/me/AppData/Local/claude.exe'],
+  ['an uppercase drive', '/MNT/D/tools/claude.EXE'],
+  ['a .exe anywhere', '/opt/weird/claude.exe']
+])('does not count %s as installed in the distro', async (_case, resolved) => {
+  // WSL appends the Windows PATH to the guest PATH, so `command -v claude`
+  // resolves to the Windows binary on a distro with no guest install. That
+  // path is POSIX-absolute, so the absolute check alone accepted it and
+  // preflight reported the agent installed -- then launching it ran a
+  // Windows exe inside a Linux session with no guest $HOME.
+  runWslProcessMock.mockResolvedValue({
+    environmentResolved: true,
+    code: 0,
+    stdout: `__ORCA_AGENT_PATH__claude\t${resolved}\n`,
+    stderr: '',
+    timedOut: false
+  })
+  expect(await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])).toEqual(new Set())
+})
+
+it('still counts a genuine guest install', async () => {
+  runWslProcessMock.mockResolvedValue({
+    environmentResolved: true,
+    code: 0,
+    stdout: '__ORCA_AGENT_PATH__claude\t/home/alice/.nvm/versions/node/v20.1.0/bin/claude\n',
+    stderr: '',
+    timedOut: false
+  })
+  expect(await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])).toEqual(
+    new Set(['claude'])
+  )
+})
+
 describe('the detection script itself, run by a real POSIX shell', () => {
   // Not a mock: the fallback is shell globbing and `[ -x ]`, which only the
   // shell can be trusted about. Skipped on Windows, where /bin/sh is absent.

--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -56,10 +56,11 @@ describe('detectWslCommandsOnPath', () => {
     await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude', 'codex'])
 
     const { script } = lastSpec()
-    const lookupScript = buildPosixCommandPathLookupScript({
-      kind: 'shell-variable',
-      name: 'cmd'
-    })
+    const lookupScript = buildPosixCommandPathLookupScript(
+      { kind: 'shell-variable', name: 'cmd' },
+      // The WSL probe opts into skipping Windows mounts mid-walk.
+      { skipWindowsMountDirs: true }
+    )
     expect(script).toContain(lookupScript)
     expect(script).not.toContain('type -P')
   })
@@ -251,5 +252,45 @@ describe('the detection script itself, run by a real POSIX shell', () => {
   ])('covers %s, which the native fallback also probes', async (dir) => {
     plant(dir, 'orca-fake-cli')
     expect(await runScript()).toContain('__ORCA_AGENT_PATH__orca-fake-cli')
+  })
+})
+
+describe('the PATH walk, run by a real POSIX shell', () => {
+  const itPosix = process.platform === 'win32' ? it.skip : it
+
+  itPosix('finds the guest install behind a Windows binary that shadows it', async () => {
+    // WSL appends the Windows PATH, so a Windows `claude` sits ahead of an
+    // nvm one. Rejecting the resolved path afterwards cannot resume the walk,
+    // so it reports "not installed" for a user who has both -- turning the
+    // false positive into the #9725 false negative. Skipping the component
+    // mid-walk is what actually finds the guest binary.
+    const root = mkdtempSync(join(tmpdir(), 'orca-walk-'))
+    try {
+      const win = join(root, 'winmnt/c/npm')
+      const nvm = join(root, 'home/.nvm/bin')
+      for (const [dir, body] of [
+        [win, 'win'],
+        [nvm, 'guest']
+      ] as const) {
+        mkdirSync(dir, { recursive: true })
+        writeFileSync(join(dir, 'claude'), `#!/bin/sh\necho ${body}\n`)
+        chmodSync(join(dir, 'claude'), 0o755)
+      }
+      const script = buildPosixCommandPathLookupScript(
+        { kind: 'literal', value: 'claude' },
+        { skipWindowsMountDirs: true }
+        // Stand in for /proc/mounts, which a test host does not have.
+      ).replace(/_orca_win_mounts=\$\([^)]*\)/, `_orca_win_mounts=${join(root, 'winmnt')}`)
+      const options: ExecFileSyncOptions = {
+        encoding: 'utf8',
+        env: { PATH: `${win}:${nvm}:/usr/bin:/bin` }
+      }
+      const out = String(
+        execFileSync('/bin/sh', ['-c', `${script}\nprintf %s "$resolved"`], options)
+      )
+      expect(out).toBe(join(nvm, 'claude'))
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 })

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -65,6 +65,24 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`
 }
 
+/**
+ * A Windows binary reached through WSL interop, not a guest install.
+ *
+ * WSL appends the Windows PATH to the guest PATH by default, so on a distro
+ * with no guest `claude`, `command -v claude` happily resolves to
+ * `/mnt/c/Users/me/AppData/.../claude.exe`. That path IS POSIX-absolute, so the
+ * absolute-path check alone accepts it and preflight reports the agent as
+ * installed in the distro.
+ *
+ * This is worse than reporting it absent. Absent tells the user to install it;
+ * a false positive launches a Windows executable inside a Linux session, where
+ * it sees Windows paths, no guest $HOME, and none of the distro's config -- and
+ * the failure surfaces later, somewhere less obvious.
+ */
+function isWindowsInteropPath(resolvedPath: string): boolean {
+  return /^\/mnt\/[a-z]\//i.test(resolvedPath) || resolvedPath.toLowerCase().endsWith('.exe')
+}
+
 function parseWslDetectedCommands(stdout: string): Set<string> {
   const found = new Set<string>()
   for (const rawLine of stdout.split(/\r?\n/)) {
@@ -81,7 +99,7 @@ function parseWslDetectedCommands(stdout: string): Set<string> {
     const resolvedPath = payload.slice(separatorIndex + 1)
     // Why: a real guest executable always resolves to a POSIX-absolute path, so
     // a Windows-style C:\ path here is spoofed/non-guest output, not an install.
-    if (path.posix.isAbsolute(resolvedPath)) {
+    if (path.posix.isAbsolute(resolvedPath) && !isWindowsInteropPath(resolvedPath)) {
       found.add(command)
     }
   }

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -69,30 +69,6 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`
 }
 
-/**
- * A Windows binary reached through WSL interop, not a guest install.
- *
- * WSL appends the Windows PATH to the guest PATH by default, so on a distro
- * with no guest `claude`, `command -v claude` happily resolves to
- * `/mnt/c/Users/me/AppData/.../claude.exe`. That path IS POSIX-absolute, so the
- * absolute-path check alone accepts it and preflight reports the agent as
- * installed in the distro.
- *
- * This is worse than reporting it absent. Absent tells the user to install it;
- * a false positive launches a Windows executable inside a Linux session, where
- * it sees Windows paths, no guest $HOME, and none of the distro's config -- and
- * the failure surfaces later, somewhere less obvious.
- *
- * Secondary to `skipWindowsMountDirs`, which does the real work by skipping
- * those PATH components mid-walk. This only catches a mount the guest does not
- * report in /proc/mounts, and it must never be the thing that decides: dropping
- * a resolved result here cannot resume the walk, so on its own it converts the
- * false positive into "not installed" for a user who has both.
- */
-function isWindowsInteropPath(resolvedPath: string): boolean {
-  return /^\/mnt\/[a-z]\//i.test(resolvedPath) || resolvedPath.toLowerCase().endsWith('.exe')
-}
-
 function parseWslDetectedCommands(stdout: string): Set<string> {
   const found = new Set<string>()
   for (const rawLine of stdout.split(/\r?\n/)) {
@@ -109,7 +85,7 @@ function parseWslDetectedCommands(stdout: string): Set<string> {
     const resolvedPath = payload.slice(separatorIndex + 1)
     // Why: a real guest executable always resolves to a POSIX-absolute path, so
     // a Windows-style C:\ path here is spoofed/non-guest output, not an install.
-    if (path.posix.isAbsolute(resolvedPath) && !isWindowsInteropPath(resolvedPath)) {
+    if (path.posix.isAbsolute(resolvedPath)) {
       found.add(command)
     }
   }

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -20,10 +20,14 @@ export async function detectWslCommandsOnPath(
   }
 
   const commandList = uniqueCommands.map(shellQuote).join(' ')
-  const lookupScript = buildPosixCommandPathLookupScript({
-    kind: 'shell-variable',
-    name: 'cmd'
-  })
+  const lookupScript = buildPosixCommandPathLookupScript(
+    { kind: 'shell-variable', name: 'cmd' },
+    // Skip Windows mounts DURING the walk, not after it: WSL appends the
+    // Windows PATH, so a Windows `claude` can shadow a real guest install, and
+    // discarding the result afterwards reports "not installed" for a user who
+    // has both -- the #9725 population the fallback dirs exist to serve.
+    { skipWindowsMountDirs: true }
+  )
   // Newlines keep the loop valid in every POSIX shell used here.
   const script = [
     // The same fallback the preflight command runner uses: append the
@@ -78,6 +82,12 @@ function shellQuote(value: string): string {
  * a false positive launches a Windows executable inside a Linux session, where
  * it sees Windows paths, no guest $HOME, and none of the distro's config -- and
  * the failure surfaces later, somewhere less obvious.
+ *
+ * Secondary to `skipWindowsMountDirs`, which does the real work by skipping
+ * those PATH components mid-walk. This only catches a mount the guest does not
+ * report in /proc/mounts, and it must never be the thing that decides: dropping
+ * a resolved result here cannot resume the walk, so on its own it converts the
+ * false positive into "not installed" for a user who has both.
  */
 function isWindowsInteropPath(resolvedPath: string): boolean {
   return /^\/mnt\/[a-z]\//i.test(resolvedPath) || resolvedPath.toLowerCase().endsWith('.exe')

--- a/src/shared/posix-command-path-lookup.ts
+++ b/src/shared/posix-command-path-lookup.ts
@@ -4,12 +4,52 @@ export type PosixCommandPathLookupTarget =
 
 const SHELL_VARIABLE_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/
 
-export function buildPosixCommandPathLookupScript(target: PosixCommandPathLookupTarget): string {
+export type PosixCommandPathLookupOptions = {
+  /**
+   * Skip PATH components that are Windows drives mounted into the guest.
+   *
+   * WSL appends the Windows PATH to the guest PATH, so a Windows `claude` can
+   * sit ahead of a real guest install. Rejecting the result AFTER the walk is
+   * not equivalent: the walk stops at the first hit, so discarding it reports
+   * "not installed" for a user who has both. Skipping the component keeps the
+   * walk going and finds the guest binary behind it.
+   *
+   * Matched by mount metadata, not by a `/mnt` name: the automount root is
+   * configurable, and `/mnt` is an ordinary directory name on a Linux box.
+   */
+  skipWindowsMountDirs?: boolean
+}
+
+export function buildPosixCommandPathLookupScript(
+  target: PosixCommandPathLookupTarget,
+  options: PosixCommandPathLookupOptions = {}
+): string {
   const commandAssignment = buildCommandAssignment(target)
+  // `-t drvfs` is what WSL mounts a Windows drive as, wherever the automount
+  // root is; 9p/virtiofs cover the WSL2 shapes. Read once, outside the loop.
+  const mountPrelude = options.skipWindowsMountDirs
+    ? [
+        '_orca_win_mounts=$(awk \'$3 == "drvfs" || $3 == "9p" || $3 == "virtiofs" { print $2 }\' /proc/mounts 2>/dev/null)'
+      ]
+    : []
+  const skipMountComponent = options.skipWindowsMountDirs
+    ? [
+        '      for _orca_win_mount in $_orca_win_mounts; do',
+        '        case "$_orca_lookup_component/" in',
+        '          "$_orca_win_mount"/*) _orca_lookup_component= ;;',
+        '        esac',
+        '      done',
+        '      if [ -z "$_orca_lookup_component" ]; then',
+        '        [ -n "$_orca_lookup_has_more" ] || break',
+        '        continue',
+        '      fi'
+      ]
+    : []
   // Shell command resolution can be masked by aliases, functions, and builtins, so inspect PATH.
   return [
     `_orca_lookup_command=${commandAssignment}`,
     'resolved=',
+    ...mountPrelude,
     'case "$_orca_lookup_command" in',
     '  */*)',
     '    case "$_orca_lookup_command" in',
@@ -34,6 +74,7 @@ export function buildPosixCommandPathLookupScript(target: PosixCommandPathLookup
     '          _orca_lookup_has_more=',
     '          ;;',
     '      esac',
+    ...skipMountComponent,
     '      [ -n "$_orca_lookup_component" ] || _orca_lookup_component=.',
     '      case "$_orca_lookup_component" in',
     '        /*) _orca_lookup_candidate=$_orca_lookup_component/$_orca_lookup_command ;;',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​75 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​71 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​50 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 |

<!-- /orca-pr-loc -->

## ELI5

WSL adds the *Windows* PATH to the Linux PATH by default. So on a distro with no
Linux `claude` installed, asking the distro "where is claude?" happily answers
with the Windows one:

```
/mnt/c/Users/me/AppData/Local/.../claude.exe
```

That is a POSIX-absolute path, so our check — "is this an absolute path?" —
accepted it, and preflight reported Claude as installed *in the distro*.

It isn't. It's the Windows install, seen through a compatibility shim.

## Why this is worse than reporting it missing

A false negative tells the user to install something. Annoying, recoverable, and
we spent the last cycle removing those (#9725).

A false positive tells the user it works. Orca then launches a Windows
executable inside a Linux session, where it sees Windows paths, no guest
`$HOME`, and none of the distro's config. The failure surfaces later and
somewhere less obvious than "not installed".

## What changed

`parseWslDetectedCommands` now rejects a resolved path that is `/mnt/<drive>/…`
or ends in `.exe`, case-insensitively. One predicate, one call site.

## Proof of no regression

- A genuine guest install (`/home/alice/.nvm/versions/node/v20.1.0/bin/claude`)
  is still detected — pinned by a new test.
- The three rejection shapes are pinned: a `/mnt` path, an uppercase
  `/MNT/D/…/claude.EXE`, and a bare `.exe` outside `/mnt`.
- Both new tests were verified to bind: with the predicate removed they fail,
  with it restored they pass.
- The existing real-shell suite (nvm discovery, `~/.local/bin`, `$HOME` with a
  space, directory-is-not-a-CLI, volta/asdf/fnm/mise) is unchanged and green.
- `src/main/ipc` suite: 3124 passed. Lint and typecheck exit 0.

## User-facing trade-offs

**One, and it is intended.** A user who has Claude installed *only* on Windows
and reaches it from inside WSL purely through interop will now see it reported
as not installed in that distro. That is the correct answer: Orca's WSL runtime
expects a Linux CLI, and the interop binary does not behave like one. The
Windows-side detection is unaffected and still finds it.

No wire, persisted state, settings, or IPC change.
