### PR TITLE
fix(browser): accept an empty --value in fill and select commands

### DIFF
--- a/src/cli/browser-interact-empty-value.test.ts
+++ b/src/cli/browser-interact-empty-value.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const callMock = vi.fn()
+
+vi.mock('./runtime-client', () => {
+  class RuntimeClient {
+    call = callMock
+    getCliStatus = vi.fn()
+    openOrca = vi.fn()
+  }
+
+  class RuntimeClientError extends Error {
+    readonly code: string
+
+    constructor(code: string, message: string) {
+      super(message)
+      this.code = code
+    }
+  }
+
+  class RuntimeRpcFailureError extends RuntimeClientError {
+    readonly response: unknown
+
+    constructor(response: unknown) {
+      super('runtime_error', 'runtime_error')
+      this.response = response
+    }
+  }
+
+  return {
+    RuntimeClient,
+    RuntimeClientError,
+    RuntimeRpcFailureError
+  }
+})
+
+import { main } from './index'
+import { okFixture, queueFixtures } from './test-fixtures'
+
+// Why: the server's Fill schema uses requiredStringAllowingEmpty and Select accepts any
+// string value, empty included. Filling a field with '' clears it and selecting an
+// <option value=""> is a real operation, so `--value ""` must reach the RPC rather than
+// being rejected as missing.
+describe('orca cli browser fill/select preserve an empty value', () => {
+  beforeEach(() => {
+    callMock.mockReset()
+    process.exitCode = undefined
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('passes an empty --value through to browser.fill', async () => {
+    queueFixtures(callMock, okFixture('req_fill', { filled: 'ref_1' }))
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      ['fill', '--element', 'ref_1', '--value', '', '--worktree', 'all', '--json'],
+      '/tmp/not-an-orca-worktree'
+    )
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('browser.fill', {
+      element: 'ref_1',
+      value: '',
+      worktree: undefined
+    })
+  })
+
+  it('passes an empty --value through to browser.select', async () => {
+    queueFixtures(callMock, okFixture('req_select', { selected: 'ref_1' }))
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(
+      ['select', '--element', 'ref_1', '--value', '', '--worktree', 'all', '--json'],
+      '/tmp/not-an-orca-worktree'
+    )
+
+    expect(callMock).toHaveBeenCalledTimes(1)
+    expect(callMock).toHaveBeenCalledWith('browser.select', {
+      element: 'ref_1',
+      value: '',
+      worktree: undefined
+    })
+  })
+
+  it('still rejects a missing --value before RPC dispatch', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(['fill', '--element', 'ref_1', '--worktree', 'all'], '/tmp/not-an-orca-worktree')
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect(errorSpy.mock.calls.flat().join('\n')).toContain('Missing required --value')
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+})

--- a/src/cli/browser-interact-empty-value.test.ts
+++ b/src/cli/browser-interact-empty-value.test.ts
@@ -37,10 +37,6 @@ vi.mock('./runtime-client', () => {
 import { main } from './index'
 import { okFixture, queueFixtures } from './test-fixtures'
 
-// Why: the server's Fill schema uses requiredStringAllowingEmpty and Select accepts any
-// string value, empty included. Filling a field with '' clears it and selecting an
-// <option value=""> is a real operation, so `--value ""` must reach the RPC rather than
-// being rejected as missing.
 describe('orca cli browser fill/select preserve an empty value', () => {
   beforeEach(() => {
     callMock.mockReset()

--- a/src/cli/handlers/browser-interact.ts
+++ b/src/cli/handlers/browser-interact.ts
@@ -18,7 +18,8 @@ import {
   getOptionalNumberFlag,
   getOptionalStringFlag,
   getRequiredFiniteNumber,
-  getRequiredStringFlag
+  getRequiredStringFlag,
+  getRequiredStringFlagAllowingEmpty
 } from '../flags'
 import { getBrowserCommandTarget } from '../selectors'
 
@@ -50,7 +51,9 @@ export const BROWSER_INTERACT_HANDLERS: Record<string, CommandHandler> = {
   },
   fill: async ({ flags, client, cwd, json }) => {
     const element = getRequiredStringFlag(flags, 'element')
-    const value = getRequiredStringFlag(flags, 'value')
+    // Why: the server's Fill schema uses requiredStringAllowingEmpty for value, so
+    // `--value ""` must reach it — filling a field with '' clears it, distinct from missing.
+    const value = getRequiredStringFlagAllowingEmpty(flags, 'value')
     const target = await getBrowserCommandTarget(flags, cwd, client)
     const result = await client.call<BrowserFillResult>('browser.fill', {
       element,
@@ -67,7 +70,9 @@ export const BROWSER_INTERACT_HANDLERS: Record<string, CommandHandler> = {
   },
   select: async ({ flags, client, cwd, json }) => {
     const element = getRequiredStringFlag(flags, 'element')
-    const value = getRequiredStringFlag(flags, 'value')
+    // Why: the server's Select schema accepts any string value, so `--value ""` must reach
+    // it — selecting an <option value=""> (a common placeholder option) is a real operation.
+    const value = getRequiredStringFlagAllowingEmpty(flags, 'value')
     const target = await getBrowserCommandTarget(flags, cwd, client)
     const result = await client.call<BrowserSelectResult>('browser.select', {
       element,

--- a/src/cli/handlers/browser-interact.ts
+++ b/src/cli/handlers/browser-interact.ts
@@ -51,8 +51,7 @@ export const BROWSER_INTERACT_HANDLERS: Record<string, CommandHandler> = {
   },
   fill: async ({ flags, client, cwd, json }) => {
     const element = getRequiredStringFlag(flags, 'element')
-    // Why: the server's Fill schema uses requiredStringAllowingEmpty for value, so
-    // `--value ""` must reach it — filling a field with '' clears it, distinct from missing.
+    // The Fill schema accepts '' (clears the field), so don't treat it as missing.
     const value = getRequiredStringFlagAllowingEmpty(flags, 'value')
     const target = await getBrowserCommandTarget(flags, cwd, client)
     const result = await client.call<BrowserFillResult>('browser.fill', {
@@ -70,8 +69,7 @@ export const BROWSER_INTERACT_HANDLERS: Record<string, CommandHandler> = {
   },
   select: async ({ flags, client, cwd, json }) => {
     const element = getRequiredStringFlag(flags, 'element')
-    // Why: the server's Select schema accepts any string value, so `--value ""` must reach
-    // it — selecting an <option value=""> (a common placeholder option) is a real operation.
+    // The Select schema accepts '' (an <option value=""> placeholder), so don't treat it as missing.
     const value = getRequiredStringFlagAllowingEmpty(flags, 'value')
     const target = await getBrowserCommandTarget(flags, cwd, client)
     const result = await client.call<BrowserSelectResult>('browser.select', {


### PR DESCRIPTION
## ELI5
Typing "nothing" into a webpage box should empty it out. Right now Orca's CLI says "you forgot to type something" and refuses. This teaches `fill` and `select` that an empty value is a real value.

## What Changed
`fill` and `select` in `src/cli/handlers/browser-interact.ts` now read `--value` with `getRequiredStringFlagAllowingEmpty` instead of `getRequiredStringFlag`, so `--value ""` is forwarded to the RPC.

## Why
The server contract already accepts empty — `Fill.value = requiredStringAllowingEmpty(...)` and `Select.value` accepts any string (`browser-schemas.ts`). The CLI was stricter than the schema, so clearing a field and selecting an empty-value option (e.g. an `<option value="">` placeholder) were impossible from the CLI. Mirrors the merged storage-set fix (#15863).

## Linked Issue
Fixes #16029

## Visual Proof
N/A — CLI arg-parsing behavior; covered by tests.

## Testing
New `src/cli/browser-interact-empty-value.test.ts`: asserts `--value ""` reaches `browser.fill`/`browser.select`, and that a *missing* `--value` is still rejected before dispatch. Fails without the fix, passes with it. `browser.test.ts` (33) and `browser-storage-empty-value.test.ts` still pass. `oxlint` + `oxfmt --check` clean; `typecheck:tsc:node/cli/web` all pass.

## AI Disclosure
Written with AI assistance (Claude, model claude-opus-4-8). I reviewed the diff and test before submission.

## Review
Two-line swap to a sibling flag helper already used by the merged storage fix; server-side contract unchanged; no wire/remote-compat impact (CLI only becomes less restrictive on an existing param). `cookie set --value` and `set credentials --pass` share the same mismatch and are noted for a possible follow-up.

## Checklist
- [x] Small and focused, linked issue, tests added, lint/format/typecheck pass locally