### PR TITLE
fix(cli): scope the unverifiable-PATH failure to commands that need the PATH

### DIFF
--- a/src/main/cli/wsl-cli-installer.test.ts
+++ b/src/main/cli/wsl-cli-installer.test.ts
@@ -155,6 +155,17 @@ function createWslRunner(
   }
 }
 
+/** What a healthy distro answers for the commands that need no login PATH. */
+function answerWithoutLoginPath(script: string): string {
+  if (script.includes('printf %s "$HOME"')) {
+    return '/home/alice'
+  }
+  if (script.includes('command -v powershell.exe')) {
+    return 'yes'
+  }
+  return ''
+}
+
 describe('WslCliInstaller', () => {
   beforeEach(() => {
     runWslProcessMock.mockReset()
@@ -790,12 +801,12 @@ describe('WslCliInstaller', () => {
     // login PATH never resolved, and ~/.local/bin is never on that. Settings
     // would then state as fact that the CLI is not on PATH while the user's
     // own terminal finds it -- #14288 turning into a confident wrong verdict.
-    runWslProcessMock.mockResolvedValue({
-      environmentResolved: false,
-      code: 0,
-      stdout: 'no',
-      stderr: '',
-      timedOut: false
+    // Answer the earlier commands normally: they do not need the login PATH and
+    // must keep working, so the run has to reach the `case ":$PATH:"` probe.
+    runWslProcessMock.mockImplementation(async (spec: { script?: unknown }) => {
+      const script = String(spec.script)
+      const stdout = answerWithoutLoginPath(script)
+      return { environmentResolved: false, code: 0, stdout, stderr: '', timedOut: false }
     })
     const installer = new WslCliInstaller({
       platform: 'win32',
@@ -804,6 +815,35 @@ describe('WslCliInstaller', () => {
     })
 
     await expect(installer.getStatus()).rejects.toThrow('Could not reach the WSL distro')
+  })
+
+  it('still answers commands that do not need the login PATH', async () => {
+    // Failing every command closed took the whole installer down on a distro
+    // with a slow login shell: `printf %s "$HOME"` is correct on the default
+    // PATH and used to answer fine.
+    const seen: string[] = []
+    runWslProcessMock.mockImplementation(async (spec: { script?: unknown }) => {
+      const script = String(spec.script)
+      seen.push(script)
+      return {
+        environmentResolved: false,
+        code: 0,
+        stdout: answerWithoutLoginPath(script),
+        stderr: '',
+        timedOut: false
+      }
+    })
+    const installer = new WslCliInstaller({
+      platform: 'win32',
+      distro: 'Ubuntu',
+      hostInstaller: { getStatus: async () => makeHostStatus() }
+    })
+
+    await expect(installer.getStatus()).rejects.toThrow('Could not reach the WSL distro')
+    // Assert on a LATER command: the interop probe only runs if the HOME read
+    // returned a value instead of throwing. Asserting that HOME was attempted
+    // proves nothing -- it is attempted either way.
+    expect(seen.some((script) => script.includes('command -v powershell.exe'))).toBe(true)
   })
 
   it('refuses to remove an old managed launcher when the bridge path is user-owned', async () => {

--- a/src/main/cli/wsl-cli-installer.ts
+++ b/src/main/cli/wsl-cli-installer.ts
@@ -37,7 +37,7 @@ type WslCliInstallerOptions = {
   platform?: NodeJS.Platform
   distro?: string | null
   hostInstaller?: Pick<CliInstaller, 'getStatus'>
-  wslRunner?: (distro: string, command: string) => Promise<string>
+  wslRunner?: (distro: string, command: string, requiresLoginPath?: boolean) => Promise<string>
 }
 
 export type ManagedWslCliRepairResult = {
@@ -50,7 +50,11 @@ export class WslCliInstaller {
   private readonly platform: NodeJS.Platform
   private readonly distro: string | null
   private readonly hostInstaller: Pick<CliInstaller, 'getStatus'>
-  private readonly wslRunner: (distro: string, command: string) => Promise<string>
+  private readonly wslRunner: (
+    distro: string,
+    command: string,
+    requiresLoginPath?: boolean
+  ) => Promise<string>
 
   constructor(options: WslCliInstallerOptions = {}) {
     this.platform = options.platform ?? process.platform
@@ -363,7 +367,8 @@ export class WslCliInstaller {
       (
         await this.run(
           this.distro,
-          `case ":$PATH:" in *:${quoteShell(pathDirectory)}:*) printf yes ;; *) printf no ;; esac`
+          `case ":$PATH:" in *:${quoteShell(pathDirectory)}:*) printf yes ;; *) printf no ;; esac`,
+          true
         )
       ).trim() === 'yes'
 
@@ -451,12 +456,23 @@ export class WslCliInstaller {
     }
   }
 
-  private async run(distro: string, command: string): Promise<string> {
-    return this.wslRunner(distro, command)
+  /**
+   * `requiresLoginPath` marks the commands whose ANSWER depends on the user's
+   * login PATH. Only those may be failed closed when the probe cannot resolve
+   * it; `printf %s "$HOME"` and the file-writing commands are correct on the
+   * distro default PATH and must keep working on a distro whose login shell is
+   * slow or blocked.
+   */
+  private async run(distro: string, command: string, requiresLoginPath = false): Promise<string> {
+    return this.wslRunner(distro, command, requiresLoginPath)
   }
 }
 
-async function runWslCommand(distro: string, command: string): Promise<string> {
+async function runWslCommand(
+  distro: string,
+  command: string,
+  requiresLoginPath = false
+): Promise<string> {
   // Why the probe lane fixes #14288: the prior login shell (`bash -lc`) sourced
   // ~/.profile, so one blocking line there ate the whole 10s timeout.
   const result = await runWslProcess({
@@ -473,11 +489,15 @@ async function runWslCommand(distro: string, command: string): Promise<string> {
   if (result.timedOut) {
     throw new Error(`WSL command timed out after ${WSL_COMMAND_TIMEOUT_MS}ms.`)
   }
-  // Every command here reads the login PATH -- the `case ":$PATH:"` probe most
-  // of all. Without it that probe answers from the distro default PATH, which
+  // Only for commands whose answer depends on the login PATH. The `case
+  // ":$PATH:"` probe otherwise answers from the distro default PATH, which
   // never has ~/.local/bin, and Settings states as fact that the CLI is not on
-  // PATH while the user's own terminal finds it. Unverifiable, not negative.
-  if (!result.environmentResolved) {
+  // PATH while the user's own terminal finds it -- unverifiable, not negative.
+  //
+  // Scoped, because failing every command closed took the whole installer down
+  // on a distro with a slow login shell: `printf %s "$HOME"` needs no login
+  // PATH and used to answer fine.
+  if (requiresLoginPath && !result.environmentResolved) {
     throw new Error('Could not reach the WSL distro. Try again.')
   }
   if (result.code !== 0) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​40 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 |

<!-- /orca-pr-loc -->

## ELI5

W3 taught the WSL CLI installer to say "Could not reach the WSL distro" when it
could not work out the user's login `PATH`. That was right for one command and
wrong for the rest.

I wrote the comment `// Every command here reads the login PATH`. It was false.
`printf %s "$HOME"`, the interop probe, and the file-writing commands are all
correct on the distro's default `PATH` and need no login shell at all.

So on a distro with a slow or blocked `~/.profile`, the whole installer went
down: Settings showed "Could not reach the WSL distro" instead of a status, for
commands that would have answered fine a moment earlier.

That is the same over-reach the unverifiable signal exists to prevent, aimed
the other way. Before: claiming a fact we could not check. After my change:
refusing to report facts we *could* check.

## What changed

`run()` takes `requiresLoginPath`, default `false`. Exactly one caller passes
`true` — the `case ":$PATH:"` probe, whose answer genuinely depends on the
login PATH. Without it that probe reads the default PATH, never finds
`~/.local/bin`, and Settings states as fact that the CLI is not on PATH while
the user's own terminal finds it.

## Proof of no regression

- The existing test — unresolved PATH must report the distro unreachable rather
  than "not on PATH" — still passes. Its mock now answers the earlier commands
  normally so the run actually reaches the PATH probe; previously it returned
  `'no'` to everything and the flow exited early at the interop check, meaning
  it was passing without exercising the probe.
- New test: a command needing no login PATH still answers. It asserts on a
  command that runs **after** the `$HOME` read, because asserting that the
  `$HOME` read was *attempted* proves nothing — it is attempted either way.
  Verified to bind: with the scoping reverted, it fails.
- `src/main/cli`: 25 passed. Lint and typecheck exit 0.

## User-facing trade-offs

**None negative.** A distro that could not resolve its login PATH previously
returned no status at all; it now returns everything except the PATH-configured
flag, and still reports unreachable for that one question. Strictly more
information, never less.

No wire, persisted state, settings, or IPC change.
