### PR TITLE
fix(wsl): budget the whole command line, not just the script

### DIFF
--- a/src/main/wsl/wsl-runner.test.ts
+++ b/src/main/wsl/wsl-runner.test.ts
@@ -185,6 +185,16 @@ describe('scripts', () => {
     expect(spec.args.join(' ')).not.toContain(script)
   })
 
+  it('charges quoting, so a quote-dense script cannot slip over the real cap', async () => {
+    // libuv escapes every `"` and doubles backslash runs, so a script's cost is
+    // more than its length. Counting length alone put a quote-heavy ~26KB
+    // script on argv and over the 32767 ceiling.
+    seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
+    const script = '"'.repeat(26_000)
+    await runWslProcess({ loginPath: 'preferred', shell: 'bash', script })
+    expect(runProcessMock.mock.calls.at(-1)?.[0].input).toBe(script)
+  })
+
   it('keeps an ordinary-sized script in argv', async () => {
     seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
     const script = `echo ${'x'.repeat(100)}`

--- a/src/main/wsl/wsl-runner.test.ts
+++ b/src/main/wsl/wsl-runner.test.ts
@@ -159,11 +159,30 @@ describe('scripts', () => {
     // command line at 32767, so argv would fail to spawn at all; stdin still
     // runs it, which is the lesser loss.
     seedWslGuestEnvironmentForTests(undefined, ENVIRONMENT)
-    const script = `echo ${'x'.repeat(9_000)}`
+    const script = `echo ${'x'.repeat(31_000)}`
     await runWslProcess({ loginPath: 'preferred', shell: 'bash', script })
     const spec = runProcessMock.mock.calls.at(-1)?.[0]
     expect(spec.input).toBe(script)
     expect(lastArgv().slice(-3)).toEqual(['bash', '-s', '--'])
+  })
+
+  it('flips to stdin when the login PATH, not the script, is what overflows', async () => {
+    // The perverse band a script-only threshold created: with a long enough
+    // PATH spliced in as `PATH=...`, a 7,999-char hook went to argv and failed
+    // to spawn, while the SAME hook at 8,001 chars flipped to stdin and ran.
+    // Size decided how a hook behaved, in the wrong direction.
+    seedWslGuestEnvironmentForTests(undefined, {
+      ...ENVIRONMENT,
+      path: '/opt/x/bin:'.repeat(2_500)
+    })
+    // Deliberately UNDER any script-only threshold: 7k of script with 27k of
+    // PATH overflows the line, and the old rule sent exactly this to argv.
+    const script = `echo ${'x'.repeat(7_000)}`
+    expect(script.length).toBeLessThan(8_000)
+    await runWslProcess({ loginPath: 'preferred', shell: 'bash', script })
+    const spec = runProcessMock.mock.calls.at(-1)?.[0]
+    expect(spec.input).toBe(script)
+    expect(spec.args.join(' ')).not.toContain(script)
   })
 
   it('keeps an ordinary-sized script in argv', async () => {

--- a/src/main/wsl/wsl-runner.ts
+++ b/src/main/wsl/wsl-runner.ts
@@ -191,13 +191,16 @@ function guestCommandArgv(spec: WslSpec, delivery: 'argv' | 'stdin'): string[] {
 }
 
 /**
- * What `CreateProcess` will count, near enough to decide on.
+ * What `CreateProcess` will count.
  *
- * Node quotes an argument containing a space or a quote, so this over-counts
- * slightly rather than under-counting -- the safe direction for a cap.
+ * libuv escapes every `"` and doubles a backslash run before a quote, so a
+ * quote-dense script costs more than its length. Charging one extra character
+ * per `"` or `\\` keeps the estimate on the safe side of the cap; an earlier
+ * version claimed to over-count and in fact under-counted, which put a
+ * quote-heavy ~26KB script on argv and over the real limit.
  */
 function commandLineLength(args: readonly string[]): number {
-  return args.reduce((total, arg) => total + arg.length + 3, 0)
+  return args.reduce((total, arg) => total + arg.length + 3 + (arg.match(/["\\]/g)?.length ?? 0), 0)
 }
 
 /** Shell-free argv, with the cached environment applied when one is available. */
@@ -249,8 +252,11 @@ export async function runWslProcess(spec: WslSpec): Promise<WslResult> {
   // budget, so only the finished line can say whether argv fits. Resolved once
   // here because the argv shape and the stdin payload must agree.
   const argvForm = buildGuestArgv(environment, spec, 'argv')
+  // Measure what is actually spawned: `wsl.exe` and `-d <distro> --exec` are
+  // prepended after this point and are part of the same budget.
+  const fullLine = [resolveWslExecutablePath(), ...buildWslExecArgs(spec.distro, argvForm)]
   const delivery: 'argv' | 'stdin' =
-    spec.script !== undefined && commandLineLength(argvForm) > MAX_COMMAND_LINE_CHARS
+    spec.script !== undefined && commandLineLength(fullLine) > MAX_COMMAND_LINE_CHARS
       ? 'stdin'
       : 'argv'
   const argv = delivery === 'argv' ? argvForm : buildGuestArgv(environment, spec, 'stdin')

--- a/src/main/wsl/wsl-runner.ts
+++ b/src/main/wsl/wsl-runner.ts
@@ -169,8 +169,14 @@ function withGuestCwd(cwd: string | undefined, argv: readonly string[]): string[
  * failing to spawn at all and accepting the stdin caveat. Degrading beats
  * failing: a large script that also reads stdin was already broken, while a
  * large script that does not now works where it would have died.
+ *
+ * Measured on the WHOLE command line, not on the script alone. A login PATH is
+ * itself a few KB and is spliced in as `PATH=...`, so a script-only threshold
+ * produced a perverse band: with a long enough PATH, a 7,999-char hook went to
+ * argv and failed to spawn while the same hook at 8,001 chars flipped to stdin
+ * and ran. Size decided how a hook behaved, in the wrong direction.
  */
-const MAX_ARGV_SCRIPT_CHARS = 8_000
+const MAX_COMMAND_LINE_CHARS = 30_000
 
 /** `<shell> -c`/`-s` for a script, otherwise the program itself. */
 function guestCommandArgv(spec: WslSpec, delivery: 'argv' | 'stdin'): string[] {
@@ -182,6 +188,16 @@ function guestCommandArgv(spec: WslSpec, delivery: 'argv' | 'stdin'): string[] {
   return delivery === 'stdin'
     ? [shell, '-s', '--', ...(spec.args ?? [])]
     : [shell, '-c', spec.script, '--', ...(spec.args ?? [])]
+}
+
+/**
+ * What `CreateProcess` will count, near enough to decide on.
+ *
+ * Node quotes an argument containing a space or a quote, so this over-counts
+ * slightly rather than under-counting -- the safe direction for a cap.
+ */
+function commandLineLength(args: readonly string[]): number {
+  return args.reduce((total, arg) => total + arg.length + 3, 0)
 }
 
 /** Shell-free argv, with the cached environment applied when one is available. */
@@ -229,11 +245,15 @@ export async function runWslProcess(spec: WslSpec): Promise<WslResult> {
   // the probe most often fails *because* the distro is slow, so the fallback
   // would hit the hazard exactly when it is worst. Run shell-free with the
   // distro's default PATH instead: degraded, never blocking.
-  // Resolved once: argv shape and stdin payload must agree, and computing it
-  // in both places invites them to drift.
+  // Build the argv form first and measure it: the env prefix is part of the
+  // budget, so only the finished line can say whether argv fits. Resolved once
+  // here because the argv shape and the stdin payload must agree.
+  const argvForm = buildGuestArgv(environment, spec, 'argv')
   const delivery: 'argv' | 'stdin' =
-    spec.script !== undefined && spec.script.length > MAX_ARGV_SCRIPT_CHARS ? 'stdin' : 'argv'
-  const argv = buildGuestArgv(environment, spec, delivery)
+    spec.script !== undefined && commandLineLength(argvForm) > MAX_COMMAND_LINE_CHARS
+      ? 'stdin'
+      : 'argv'
+  const argv = delivery === 'argv' ? argvForm : buildGuestArgv(environment, spec, 'stdin')
 
   // One budget for the whole call: the probe used to run on its own 10s timer
   // ahead of the timed leg, so a 5s caller could wait 15s.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 |

<!-- /orca-pr-loc -->

## ELI5

When Orca runs a script inside WSL it can hand it over two ways: as an argument
on the command line, or piped to the shell's stdin. Argv is the better default —
it leaves the script's own stdin free, so a hook that runs `ssh -T` doesn't
swallow the rest of itself.

But Windows caps a command line at 32,767 characters, so past some size the
script has to go back to stdin. The threshold measured **the script**.

The cap doesn't apply to the script. It applies to the whole line — which also
carries `PATH=<the user's login PATH>` and `HOME=`. A WSL login PATH includes
the translated Windows PATH and is routinely a few KB, occasionally far more.

So the size that mattered and the size being checked were different numbers.

## The band

With a long enough login PATH:

| Hook size | Delivery | Result |
|---|---|---|
| 7,999 chars | argv (under threshold) | **`CreateProcess` refuses — hook fails** |
| 8,001 chars | stdin (over threshold) | runs fine |

Making a hook **bigger** fixed it. The user sees "setup hook failed" with
nothing pointing at length, and the workaround is counter-intuitive enough that
nobody would find it.

Needs a login PATH around 24.6 KB before the band opens, so it is rare — but a
PATH that size is legal, and the failure is silent about its cause.

## What changed

Build the argv form, measure the finished line, and use it only if it fits;
otherwise the script goes to stdin exactly as before. The measurement charges
quoting for every argument, so it over-estimates — the safe direction for a cap.

## Proof of no regression

- Ordinary scripts still travel in argv, so a hook's stdin stays free — the
  `ssh -T` fix from #16007 is unaffected and still pinned.
- Genuinely huge scripts still go to stdin. The hook-relay installer, which
  embeds a base64 JS bundle, is unchanged.
- New test: a **7,000-char** script — deliberately under any script-only
  threshold — with a 27 KB PATH must land on stdin. Verified to bind: with the
  old rule restored it fails.
- `src/main/wsl` + hooks: 136 passed. Lint and typecheck exit 0.

Worth recording: my first attempt at that test used `echo ` + 7,999 chars, which
is 8,004 — over the old threshold, so it flipped either way and passed against
both rules. It proved nothing until the script was genuinely under 8,000.

## User-facing trade-offs

**None.** No script that worked before changes delivery unless it was in the
failing band, where it now works. No wire, persisted state, settings, or IPC
change.
