### PR TITLE
fix(secrets): tell Linux users when their secrets are only obfuscated

### DIFF
--- a/config/scripts/vitest-host-ports-setup.ts
+++ b/config/scripts/vitest-host-ports-setup.ts
@@ -62,6 +62,6 @@ beforeEach(() => {
       }
       return text.slice(SEAL_PREFIX.length)
     },
-    describeUnavailable: () => null
+    describeProtectionGap: () => null
   })
 })

--- a/src/main/bitbucket/credential-connection.test.ts
+++ b/src/main/bitbucket/credential-connection.test.ts
@@ -15,7 +15,7 @@ async function loadModule() {
     isEncryptionAvailable: () => true,
     encryptString: (value) => Buffer.from(value),
     decryptString: (value) => value.toString('utf-8'),
-    describeUnavailable: () => null
+    describeProtectionGap: () => null
   })
   vi.doMock('node:os', async () => {
     const actual = await vi.importActual<typeof Os>('node:os')

--- a/src/main/bitbucket/credential-store.test.ts
+++ b/src/main/bitbucket/credential-store.test.ts
@@ -24,7 +24,7 @@ async function loadStore(
     isEncryptionAvailable: () => true,
     encryptString: (value) => Buffer.from(value),
     decryptString: decryptStringMock,
-    describeUnavailable: () => null
+    describeProtectionGap: () => null
   })
   vi.doMock('node:os', async () => {
     const actual = await vi.importActual<typeof Os>('node:os')

--- a/src/main/bitbucket/status-no-decrypt.test.ts
+++ b/src/main/bitbucket/status-no-decrypt.test.ts
@@ -24,7 +24,7 @@ async function loadModules() {
     isEncryptionAvailable: () => true,
     encryptString: (value) => Buffer.from(value),
     decryptString: decryptSpy,
-    describeUnavailable: () => null
+    describeProtectionGap: () => null
   })
   vi.doMock('node:os', async () => {
     const actual = await vi.importActual<typeof Os>('node:os')

--- a/src/main/host/electron-secret-store.test.ts
+++ b/src/main/host/electron-secret-store.test.ts
@@ -3,7 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const safeStorageMock = vi.hoisted(() => ({
   isEncryptionAvailable: vi.fn(() => true),
   encryptString: vi.fn((plainText: string) => Buffer.from(`os-sealed:${plainText}`)),
-  decryptString: vi.fn((cipher: Buffer) => cipher.toString().slice('os-sealed:'.length))
+  decryptString: vi.fn((cipher: Buffer) => cipher.toString().slice('os-sealed:'.length)),
+  getSelectedStorageBackend: vi.fn(() => 'gnome_libsecret')
 }))
 
 vi.mock('electron', () => ({ safeStorage: safeStorageMock }))
@@ -14,6 +15,60 @@ describe('ElectronSecretStore', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     safeStorageMock.isEncryptionAvailable.mockReturnValue(true)
+    safeStorageMock.getSelectedStorageBackend.mockReturnValue('gnome_libsecret')
+  })
+
+  function withPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
+    const original = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+    try {
+      return run()
+    } finally {
+      Object.defineProperty(process, 'platform', { configurable: true, value: original })
+    }
+  }
+
+  describe('at-rest protection reporting', () => {
+    it('reports no gap when a real keyring backend is selected', () => {
+      withPlatform('linux', () => {
+        expect(new ElectronSecretStore().describeProtectionGap()).toBeNull()
+      })
+    })
+
+    it('reports a gap for the Linux basic_text backend, which protects nothing', () => {
+      safeStorageMock.getSelectedStorageBackend.mockReturnValue('basic_text')
+      withPlatform('linux', () => {
+        const gap = new ElectronSecretStore().describeProtectionGap()
+        expect(gap).toMatch(/built-in key/)
+        expect(gap).toMatch(/gnome-keyring|kwallet/)
+      })
+    })
+
+    it('keeps sealing AVAILABLE on basic_text so stored credentials still decrypt', () => {
+      // Why this matters more than the warning: flipping isEncryptionAvailable() would
+      // make decryptWithStatus() stop attempting and return every stored secret as
+      // empty. The gap is a trust signal, never a capability switch.
+      safeStorageMock.getSelectedStorageBackend.mockReturnValue('basic_text')
+      withPlatform('linux', () => {
+        const store = new ElectronSecretStore()
+        expect(store.isEncryptionAvailable()).toBe(true)
+        expect(store.decryptString(store.encryptString('linear-token'))).toBe('linear-token')
+      })
+    })
+
+    it('does not consult the backend on macOS, where basic_text does not exist', () => {
+      withPlatform('darwin', () => {
+        expect(new ElectronSecretStore().describeProtectionGap()).toBeNull()
+      })
+      expect(safeStorageMock.getSelectedStorageBackend).not.toHaveBeenCalled()
+    })
+
+    it('reports the missing-keyring gap before considering the backend', () => {
+      safeStorageMock.isEncryptionAvailable.mockReturnValue(false)
+      withPlatform('linux', () => {
+        expect(new ElectronSecretStore().describeProtectionGap()).toMatch(/keyring is unavailable/)
+      })
+    })
   })
 
   // Why this shape: the whole safety argument for the SecretStore refactor is that the
@@ -47,12 +102,12 @@ describe('ElectronSecretStore', () => {
   })
 
   it('has no reason to give while sealing works', () => {
-    expect(new ElectronSecretStore().describeUnavailable()).toBeNull()
+    expect(new ElectronSecretStore().describeProtectionGap()).toBeNull()
   })
 
   it('names the missing facility when sealing is unavailable, so the plaintext fallback is explainable', () => {
     safeStorageMock.isEncryptionAvailable.mockReturnValue(false)
-    const reason = new ElectronSecretStore().describeUnavailable()
+    const reason = new ElectronSecretStore().describeProtectionGap()
     expect(reason).toContain('unencrypted')
     if (process.platform === 'linux') {
       expect(reason).toContain('keyring')

--- a/src/main/host/electron-secret-store.ts
+++ b/src/main/host/electron-secret-store.ts
@@ -18,14 +18,22 @@ export class ElectronSecretStore implements SecretStore {
     return safeStorage.decryptString(cipher)
   }
 
-  describeUnavailable(): string | null {
-    if (safeStorage.isEncryptionAvailable()) {
-      return null
+  describeProtectionGap(): string | null {
+    if (!safeStorage.isEncryptionAvailable()) {
+      // Why platform-specific: the fix differs, and "encryption unavailable" alone
+      // sends users looking in the wrong place.
+      return process.platform === 'linux'
+        ? 'The OS keyring is unavailable, so secrets are stored unencrypted. Install and unlock gnome-keyring or kwallet to seal them.'
+        : 'The OS keychain is unavailable, so secrets are stored unencrypted.'
     }
-    // Why platform-specific: the fix differs, and "encryption unavailable" alone
-    // sends users looking in the wrong place.
-    return process.platform === 'linux'
-      ? 'The OS keyring is unavailable, so secrets are stored unencrypted. Install and unlock gnome-keyring or kwallet to seal them.'
-      : 'The OS keychain is unavailable, so secrets are stored unencrypted.'
+    // Why this is not folded into isEncryptionAvailable(): on Linux with no keyring,
+    // Electron falls back to `basic_text`, which "encrypts" with a hardcoded password.
+    // It round-trips, so sealing and unsealing genuinely work and must keep working —
+    // reporting it unavailable would strand every credential already stored this way.
+    // But it protects nothing, and reporting it as sealed is the actual lie.
+    if (process.platform === 'linux' && safeStorage.getSelectedStorageBackend() === 'basic_text') {
+      return 'Secrets are obfuscated with a built-in key, not protected by the OS keyring. Install and unlock gnome-keyring or kwallet, then restart Orca, to seal them properly.'
+    }
+    return null
   }
 }

--- a/src/main/host/secret-protection-report.test.ts
+++ b/src/main/host/secret-protection-report.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { setSecretStore, _resetSecretStoreForTests } from '../../shared/secret-store'
+import { reportSecretProtectionGap } from './secret-protection-report'
+
+function installStore(gap: string | null): void {
+  setSecretStore({
+    isEncryptionAvailable: () => true,
+    encryptString: (plainText) => Buffer.from(plainText),
+    decryptString: (cipher) => cipher.toString(),
+    describeProtectionGap: () => gap
+  })
+}
+
+describe('reportSecretProtectionGap', () => {
+  it('logs and returns the gap when protection is weaker than a user would assume', () => {
+    installStore('Secrets are obfuscated with a built-in key.')
+    const logged: string[] = []
+    expect(reportSecretProtectionGap((m) => logged.push(m))).toMatch(/built-in key/)
+    expect(logged).toHaveLength(1)
+    expect(logged[0]).toContain('[secrets]')
+  })
+
+  it('stays silent when secrets are properly sealed', () => {
+    installStore(null)
+    const logged: string[] = []
+    expect(reportSecretProtectionGap((m) => logged.push(m))).toBeNull()
+    expect(logged).toEqual([])
+  })
+
+  it('does not throw startup when no store is installed', () => {
+    // Why: this is diagnostics running early in bootstrap. The useful error is the one
+    // raised by the first real read, not a crash from the thing reporting on it.
+    _resetSecretStoreForTests()
+    const logged: string[] = []
+    expect(() => reportSecretProtectionGap((m) => logged.push(m))).not.toThrow()
+    expect(logged[0]).toContain('could not determine at-rest protection')
+  })
+})

--- a/src/main/host/secret-protection-report.ts
+++ b/src/main/host/secret-protection-report.ts
@@ -1,0 +1,30 @@
+import { getSecretStore } from '../../shared/secret-store'
+
+/**
+ * Report at-rest secret protection once at startup.
+ *
+ * Why this exists: the port has always been able to describe a protection gap, and
+ * nothing read it — so a Linux user whose secrets are obfuscated with a built-in key
+ * was told nothing at all. Reading it here is the difference between the port
+ * documenting a promise and keeping one.
+ *
+ * Deliberately not fatal and not a dialog: sealing still works, so blocking startup
+ * would be worse than the gap it reports.
+ */
+export function reportSecretProtectionGap(
+  log: (message: string) => void = (message) => console.warn(message)
+): string | null {
+  let gap: string | null
+  try {
+    gap = getSecretStore().describeProtectionGap()
+  } catch (error) {
+    // Why swallow: this is diagnostics. An uninstalled store is already a hard failure
+    // at the first real read, and that error is the useful one.
+    log(`[secrets] could not determine at-rest protection: ${String(error)}`)
+    return null
+  }
+  if (gap) {
+    log(`[secrets] ${gap}`)
+  }
+  return gap
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -34,6 +34,7 @@ import { setSpeechServiceFactories } from './speech/speech-runtime-service'
 import { setWorktreeWatcherRemoval } from './ipc/worktree-watcher-removal'
 import { setSecretStore } from '../shared/secret-store'
 import { ElectronSecretStore } from './host/electron-secret-store'
+import { reportSecretProtectionGap } from './host/secret-protection-report'
 import { initSessionParseCachePersistence } from './ai-vault/session-parse-cache-persistence'
 import { ensureActiveOrcaProfile, initOrcaProfilePaths } from './orca-profiles/profile-index-store'
 import { getOrcaCloudAuthConfig } from './orca-profiles/profile-cloud-auth-config'
@@ -883,6 +884,9 @@ if (hasSingleInstanceLock) {
   // the app.setName ordering the userData captures below depend on.
   setAppEnvironment(new ElectronAppEnvironment())
   setSecretStore(new ElectronSecretStore())
+  // Why right after install: this is the first moment the answer is knowable, and a
+  // silent weak backend is the gap users most need told about.
+  reportSecretProtectionGap()
   // Why at process level, not per-window: pty.ts registers against injected surfaces so
   // it can load without electron, and an Electron main process always has ipcMain —
   // whether a window exists is irrelevant. Installing this in attachMainWindowServices

--- a/src/main/ipc/worktree-watcher-removal-binding.test.ts
+++ b/src/main/ipc/worktree-watcher-removal-binding.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { getWorktreeWatcherRemoval, setWorktreeWatcherRemoval } from './worktree-watcher-removal'
+
+/**
+ * Why: the port's default is inert by design — a host with no renderer has no watchers
+ * to close. That is correct for orcad and silently wrong for the desktop, where an
+ * uninstalled port means worktree removal stops releasing the directory and Windows
+ * fails the delete on a locked file. The default is indistinguishable from a working
+ * install at the call site, so it gets asserted here.
+ */
+describe('WorktreeWatcherRemoval port', () => {
+  const METHODS = [
+    'closeLocal',
+    'restoreLocal',
+    'forgetLocal',
+    'closeRemote',
+    'restoreRemote',
+    'forgetRemote'
+  ] as const
+
+  it('defaults to inert so a renderer-less host is honest, not broken', async () => {
+    setWorktreeWatcherRemoval(null)
+    const inert = getWorktreeWatcherRemoval()
+    for (const method of METHODS) {
+      await expect(
+        Promise.resolve(inert[method]('repo::/tmp/w', '/tmp/w' as never))
+      ).resolves.not.toThrow()
+    }
+  })
+
+  it('routes every method to the installed binding', async () => {
+    const calls: string[] = []
+    setWorktreeWatcherRemoval({
+      closeLocal: async () => void calls.push('closeLocal'),
+      restoreLocal: async () => void calls.push('restoreLocal'),
+      forgetLocal: () => void calls.push('forgetLocal'),
+      closeRemote: async () => void calls.push('closeRemote'),
+      restoreRemote: async () => void calls.push('restoreRemote'),
+      forgetRemote: () => void calls.push('forgetRemote')
+    })
+    for (const method of METHODS) {
+      await getWorktreeWatcherRemoval()[method]('conn', '/tmp/w' as never)
+    }
+    expect(calls).toEqual([...METHODS])
+    setWorktreeWatcherRemoval(null)
+  })
+
+  it('exposes a desktop binding that delegates rather than stubbing', async () => {
+    // Why import lazily: filesystem-watcher pulls electron, so it must not load in the
+    // inert-default case above.
+    const { desktopWorktreeWatcherRemoval } = await import('./filesystem-watcher')
+    for (const method of METHODS) {
+      expect(typeof desktopWorktreeWatcherRemoval[method], method).toBe('function')
+      // An inert stub is an empty arrow; a real delegation is not.
+      expect(desktopWorktreeWatcherRemoval[method].toString(), method).not.toMatch(
+        /^\s*(async )?\(\s*\)\s*=>\s*\{?\s*\}?\s*$/
+      )
+    }
+  })
+})

--- a/src/main/jira/client.test.ts
+++ b/src/main/jira/client.test.ts
@@ -114,7 +114,7 @@ async function loadClientModule(options: SafeStorageMockOptions = {}) {
     isEncryptionAvailable: () => options.encryptionAvailable ?? false,
     encryptString: (value) => Buffer.from(value),
     decryptString: options.decryptString ?? ((value) => value.toString('utf-8')),
-    describeUnavailable: () => null
+    describeProtectionGap: () => null
   })
   vi.doMock('os', async () => {
     const actual = await vi.importActual<typeof Os>('os')

--- a/src/main/linear/client.test.ts
+++ b/src/main/linear/client.test.ts
@@ -95,7 +95,7 @@ async function loadClientModule(options: SafeStorageMockOptions = {}) {
     isEncryptionAvailable: () => options.encryptionAvailable ?? false,
     encryptString: (value) => Buffer.from(value),
     decryptString: options.decryptString ?? ((value) => value.toString('utf-8')),
-    describeUnavailable: () => null
+    describeProtectionGap: () => null
   })
   vi.doMock('os', async () => {
     const actual = await vi.importActual<typeof Os>('os')

--- a/src/main/orcad/orcad-entry.ts
+++ b/src/main/orcad/orcad-entry.ts
@@ -63,7 +63,7 @@ function createNodeAppEnvironment(): AppEnvironment {
 /**
  * Why not silently plaintext: `isEncryptionAvailable() === false` already makes every
  * caller fall back to unsealed storage, which is a security posture, not a detail.
- * `describeUnavailable()` gives the reason a client can surface.
+ * `describeProtectionGap()` gives the reason a client can surface.
  */
 function createNodeSecretStore(): SecretStore {
   return {
@@ -74,7 +74,7 @@ function createNodeSecretStore(): SecretStore {
     decryptString: () => {
       throw new Error('orcad_secret_sealing_unavailable')
     },
-    describeUnavailable: () =>
+    describeProtectionGap: () =>
       'This host has no OS keyring, so credentials are stored unencrypted. Pair from a desktop to manage secrets, or install and unlock a keyring.'
   }
 }

--- a/src/main/persistence-protected-secret-fail-closed.test.ts
+++ b/src/main/persistence-protected-secret-fail-closed.test.ts
@@ -54,7 +54,7 @@ async function createStore() {
       }
       return decoded.slice('enc:'.length + 36 + 1)
     },
-    describeUnavailable: () => null
+    describeProtectionGap: () => null
   })
   const { Store, initDataPath } = await import('./persistence')
   // Why here: userData resolves through AppEnvironment, and this must point at this

--- a/src/main/persistence-protected-secret-write-race.test.ts
+++ b/src/main/persistence-protected-secret-write-race.test.ts
@@ -51,7 +51,7 @@ async function createStore() {
     isEncryptionAvailable: () => cipherState.available,
     encryptString: (plaintext) => Buffer.from(`enc:${plaintext}`, 'utf-8'),
     decryptString: (ciphertext) => ciphertext.toString('utf-8').slice('enc:'.length),
-    describeUnavailable: () => null
+    describeProtectionGap: () => null
   })
   const { Store, initDataPath } = await import('./persistence')
   // Why here: userData resolves through AppEnvironment, and this must point at this

--- a/src/main/persistence-proxy-secret-recovery.test.ts
+++ b/src/main/persistence-proxy-secret-recovery.test.ts
@@ -61,7 +61,7 @@ async function createStore() {
       }
       return decoded.slice('enc:'.length + 36 + 1)
     },
-    describeUnavailable: () => null
+    describeProtectionGap: () => null
   })
   const { Store, initDataPath } = await import('./persistence')
   // Why here: userData resolves through AppEnvironment, and this must point at this

--- a/src/main/persistence-single-serialize.test.ts
+++ b/src/main/persistence-single-serialize.test.ts
@@ -56,7 +56,7 @@ async function createStore() {
       }
       return decoded.slice('enc:'.length + 36 + 1)
     },
-    describeUnavailable: () => null
+    describeProtectionGap: () => null
   })
   const { Store, initDataPath } = await import('./persistence')
   // Why here: userData resolves through AppEnvironment, and this must point at this

--- a/src/main/persistence-ui-state.test.ts
+++ b/src/main/persistence-ui-state.test.ts
@@ -48,7 +48,7 @@ async function createStore() {
       }
       return decoded.slice('encrypted:'.length)
     },
-    describeUnavailable: () => null
+    describeProtectionGap: () => null
   })
   const { Store, initDataPath } = await import('./persistence')
   // Why here: userData resolves through AppEnvironment, and this must point at this

--- a/src/main/protected-secret-persistence.test.ts
+++ b/src/main/protected-secret-persistence.test.ts
@@ -10,7 +10,7 @@ describe('ProtectedSecretPersistence', () => {
       isEncryptionAvailable: () => cipherState.available,
       encryptString: (plaintext) => Buffer.from(`encrypted:${plaintext}`),
       decryptString: (ciphertext) => ciphertext.toString().slice('encrypted:'.length),
-      describeUnavailable: () => null
+      describeProtectionGap: () => null
     })
   })
 

--- a/src/main/speech/openai-api-key-store.test.ts
+++ b/src/main/speech/openai-api-key-store.test.ts
@@ -17,7 +17,7 @@ async function loadStoreModule() {
   const { setSecretStore } = await import('../../shared/secret-store')
   setSecretStore({
     ...safeStorageMock,
-    describeUnavailable: () => null
+    describeProtectionGap: () => null
   })
   vi.doMock('os', async () => {
     const actual = await vi.importActual<typeof Os>('os')

--- a/src/main/startup/host-port-bootstrap-wiring.test.ts
+++ b/src/main/startup/host-port-bootstrap-wiring.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Guards the single point of failure for every host port.
+ *
+ * The ports deliberately split two ways when uninstalled: AppEnvironment and SecretStore
+ * throw, because a silent default writes real user state to the wrong place; the rest
+ * default to no-ops or inert stubs, because a host with no renderer legitimately has
+ * nothing to register. That asymmetry is only safe while the desktop installs all of
+ * them before anything reads state — a dropped or reordered line here does not fail a
+ * unit test, it silently degrades the shipped app (worktree removal stops closing
+ * watchers, notifications stop firing, browser panes start rejecting).
+ *
+ * Source-level because that is the property: these run once at module scope during
+ * startup, so there is no seam to assert against at runtime.
+ */
+describe('host port bootstrap wiring', () => {
+  const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+
+  const INSTALLS = [
+    'setAppEnvironment(new ElectronAppEnvironment())',
+    'setSecretStore(new ElectronSecretStore())',
+    'setPtyHostBindings({',
+    'setRuntimeDesktopSurface(electronRuntimeDesktopSurface)',
+    'setRuntimeBrowserCommandsFactory(electronRuntimeBrowserCommandsFactory)',
+    'setDefaultProxySessionResolver(',
+    'setMainHttpClient(electronHttpClient)',
+    'setSpeechServiceFactories(electronSpeechServiceFactories)',
+    'setWorktreeWatcherRemoval(desktopWorktreeWatcherRemoval)'
+  ]
+
+  it('installs every host port exactly once', () => {
+    for (const install of INSTALLS) {
+      expect(source.split(install).length - 1, `${install} should appear exactly once`).toBe(1)
+    }
+  })
+
+  it('installs every port before the runtime, the PTY handlers, or any window exists', () => {
+    // Why these three: they are the first things that resolve a path, seal a credential,
+    // or register against an injected surface.
+    const firstUse = Math.min(
+      ...['new OrcaRuntimeService(', 'registerHeadlessPtyRuntime(', 'function openMainWindow(']
+        .map((marker) => source.indexOf(marker))
+        .filter((index) => index >= 0)
+    )
+    expect(firstUse).toBeGreaterThan(0)
+
+    for (const install of INSTALLS) {
+      expect(source.indexOf(install), `${install} must run before first use`).toBeLessThan(firstUse)
+    }
+  })
+
+  it('installs the ports at process level, not per window', () => {
+    // Why: installing per window registered the PTY surfaces against no-ops on the
+    // serve path, where no window ever opens. Caught in CI by the SSH docker E2E.
+    const openWindow = source.indexOf('function openMainWindow(')
+    for (const install of INSTALLS) {
+      expect(
+        source.indexOf(install, openWindow),
+        `${install} must not be re-installed per window`
+      ).toBe(-1)
+    }
+  })
+})

--- a/src/shared/secret-store.test.ts
+++ b/src/shared/secret-store.test.ts
@@ -12,7 +12,7 @@ function fakeStore(overrides: Partial<SecretStore> = {}): SecretStore {
     isEncryptionAvailable: () => true,
     encryptString: (plainText) => Buffer.from(`sealed:${plainText}`),
     decryptString: (cipher) => cipher.toString().slice('sealed:'.length),
-    describeUnavailable: () => null,
+    describeProtectionGap: () => null,
     ...overrides
   }
 }
@@ -45,9 +45,9 @@ describe('SecretStore registry', () => {
     setSecretStore(
       fakeStore({
         isEncryptionAvailable: () => false,
-        describeUnavailable: () => 'The OS keyring is unavailable.'
+        describeProtectionGap: () => 'The OS keyring is unavailable.'
       })
     )
-    expect(getSecretStore().describeUnavailable()).toBe('The OS keyring is unavailable.')
+    expect(getSecretStore().describeProtectionGap()).toBe('The OS keyring is unavailable.')
   })
 })

--- a/src/shared/secret-store.ts
+++ b/src/shared/secret-store.ts
@@ -6,7 +6,7 @@
  * The contract mirrors safeStorage exactly, including the part that matters most:
  * `isEncryptionAvailable()` may return false. A store that cannot seal must say so
  * rather than throw; how a caller degrades is its own decision (persistence retains
- * the prior sealed blob rather than writing plaintext). See `describeUnavailable()`,
+ * the prior sealed blob rather than writing plaintext). See `describeProtectionGap()`,
  * which exists so the reason reaches the user, not a console warning nobody reads.
  */
 
@@ -15,12 +15,16 @@ export type SecretStore = {
   encryptString(plainText: string): Buffer
   decryptString(cipher: Buffer): string
   /**
-   * Why: "encryption unavailable" is a security posture, not a detail. When
-   * `isEncryptionAvailable()` is false this returns a short, user-safe sentence
-   * explaining which host facility is missing, for the degradation surface.
-   * Returns null when encryption IS available.
+   * Why separate from `isEncryptionAvailable()`: that answers "can this host seal and
+   * unseal at all", which must stay true for a backend that seals weakly — flipping it
+   * would stop `decryptWithStatus()` even attempting, and every already-stored
+   * credential would read back empty. This answers the different question a user cares
+   * about: "is my data actually protected at rest?"
+   *
+   * Non-null means the protection is not what a user would assume — either no sealing,
+   * or sealing with a backend that does not meaningfully protect. Null means sealed.
    */
-  describeUnavailable(): string | null
+  describeProtectionGap(): string | null
 }
 
 /**


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​237 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​219 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​63 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 |

<!-- /orca-pr-loc -->

## ELI5

On Linux with no keyring installed, Electron quietly falls back to a mode that "encrypts" your secrets with a password baked into the source code. Anyone with the file can read them. Orca reported those secrets as **sealed**.

This makes Orca say so instead. It also adds a guard so the host ports the last stack introduced can't silently stop being installed.

## The bug

`safeStorage.isEncryptionAvailable()` returns `true` for Linux's `basic_text` backend, which encrypts with a hardcoded password — obfuscation, not protection. Orca reported those secrets as protected.

## Why the obvious fix would have been a credential regression

Review on #15916 suggested returning `false` for `basic_text`. That is wrong, and I checked before acting:

```ts
if (!this.encryptionAvailable()) {
  this.sealedSlots.add(slot)
  return { plaintext: '', status: 'unavailable' }   // decryption never attempted
}
```

`decryptWithStatus()` skips decryption entirely when encryption is unavailable. Flipping the flag would make **every credential an existing Linux user already stored read back empty**. Sealing genuinely works on `basic_text` and has to keep working.

## The fix: separate capability from trust

They were always two questions collapsed into one flag.

- `isEncryptionAvailable()` — "can this host seal and unseal?" `basic_text`: **yes**, unchanged, so stored secrets keep decrypting.
- `describeProtectionGap()` (renamed from `describeUnavailable`) — "is my data actually protected?" `basic_text`: **no**, and it now says why and how to fix it.

`describeUnavailable()` had **zero production callers** — the port documented a promise nothing kept, so a Linux user was told nothing at all. `reportSecretProtectionGap()` reads it at startup, right after install, the first moment the answer is knowable.

A user-visible surface (settings/diagnostics) is follow-up work. This stops the silence; it does not yet put it in front of you.

## Host port bootstrap guard

The nine host ports split deliberately: two throw when uninstalled, the rest default to no-ops because a renderer-less host legitimately has nothing to register. That asymmetry is only safe while the desktop installs all of them before anything reads state — and **a dropped or reordered install fails no existing test**. It silently degrades the shipped app: worktree removal stops closing watchers (Windows then fails the delete on a locked file), notifications stop firing, browser panes start rejecting.

`host-port-bootstrap-wiring.test.ts` asserts all nine install exactly once, before the runtime / PTY handlers / any window, and never per-window (the per-window version was a real bug the SSH docker E2E caught).

Verified in both directions — it is not a test that cannot fail:
- Remove an install → fails `installs every host port exactly once`
- Move one after `new OrcaRuntimeService(` → fails with `expected 115784 to be less than 64403`

Also covers the `WorktreeWatcherRemoval` port: inert default stays inert, every method routes to the installed binding, and the desktop binding delegates rather than stubbing.

## Proof of no regressions

- Full suite **57,426 passed / 0 failed**
- `pnpm run lint` clean, ratchet **0 entries**
- `orcad` builds (4.44 MB, zero electron) and passes the full acceptance
- Boots on Linux (Ubuntu, Node 26) after the rename

## User-facing trade-offs

**One, deliberate:** Linux users on `basic_text` now get a startup warning that they previously did not. Their secrets keep working exactly as before — same sealing, same decryption. The only change is that Orca stops claiming protection it isn't providing.

Everything else is behaviour-identical.