### PR TITLE
Fix deleted remote worktree reappearing due to host ID mismatch

### DIFF
--- a/src/main/runtime/rpc/methods/paired-caller-host-id.test.ts
+++ b/src/main/runtime/rpc/methods/paired-caller-host-id.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import type { Repo } from '../../../../shared/repo-types'
+import { resolvePairedCallerHostId } from './paired-caller-host-id'
+
+function repos(...hostIds: (string | undefined)[]): Repo[] {
+  return hostIds.map((executionHostId, index) => ({
+    id: 'repo-1',
+    path: `/repo-${index}`,
+    executionHostId
+  })) as unknown as Repo[]
+}
+
+const SELECTOR = 'id:repo-1::/repo/wt'
+
+describe('resolvePairedCallerHostId', () => {
+  it('passes through our own vocabulary and an absent qualifier', () => {
+    expect(resolvePairedCallerHostId(() => repos('local'), SELECTOR, 'local')).toBe('local')
+    expect(resolvePairedCallerHostId(() => repos('ssh:a'), SELECTOR, 'ssh:a')).toBe('ssh:a')
+    expect(resolvePairedCallerHostId(() => repos('local'), SELECTOR, undefined)).toBeUndefined()
+  })
+
+  it('answers with `local` when nothing carries the client-minted stamp', () => {
+    expect(resolvePairedCallerHostId(() => repos('local'), SELECTOR, 'runtime:env-1')).toBe('local')
+    expect(resolvePairedCallerHostId(() => repos('ssh:a'), SELECTOR, 'runtime:env-1')).toBe('local')
+    expect(resolvePairedCallerHostId(() => [], SELECTOR, 'runtime:env-1')).toBe('local')
+  })
+
+  it('keeps a stamp this store still uses for its own repo', () => {
+    expect(resolvePairedCallerHostId(() => repos('runtime:env-1'), SELECTOR, 'runtime:env-1')).toBe(
+      'runtime:env-1'
+    )
+  })
+
+  it('ignores another repo id carrying the other spelling', () => {
+    const otherRepo = { id: 'repo-2', path: '/other' } as unknown as Repo
+    expect(
+      resolvePairedCallerHostId(
+        () => [...repos('runtime:env-1'), otherRepo],
+        SELECTOR,
+        'runtime:env-1'
+      )
+    ).toBe('runtime:env-1')
+  })
+
+  it('refuses to guess when one repo id carries both spellings', () => {
+    expect(() =>
+      resolvePairedCallerHostId(() => repos('local', 'runtime:env-1'), SELECTOR, 'runtime:env-1')
+    ).toThrow('ambiguous across hosts')
+  })
+
+  it('falls back to every repo when the selector names no repo id', () => {
+    expect(
+      resolvePairedCallerHostId(() => repos('runtime:env-1'), 'feature/x', 'runtime:env-1')
+    ).toBe('runtime:env-1')
+    expect(resolvePairedCallerHostId(() => repos('local'), 'feature/x', 'runtime:env-1')).toBe(
+      'local'
+    )
+  })
+})

--- a/src/main/runtime/rpc/methods/paired-caller-host-id.ts
+++ b/src/main/runtime/rpc/methods/paired-caller-host-id.ts
@@ -1,0 +1,34 @@
+import {
+  getRepoExecutionHostId,
+  LOCAL_EXECUTION_HOST_ID,
+  parseExecutionHostId,
+  type ExecutionHostId
+} from '../../../../shared/execution-host'
+import type { Repo } from '../../../../shared/repo-types'
+import { splitWorktreeId } from '../../../../shared/worktree/id'
+
+/** Maps a paired client's runtime-local host spelling to this host's repo spelling. */
+export function resolvePairedCallerHostId(
+  getRepos: () => readonly Repo[],
+  worktreeSelector: string,
+  callerHostId: ExecutionHostId | undefined
+): ExecutionHostId | undefined {
+  if (!callerHostId || parseExecutionHostId(callerHostId)?.kind !== 'runtime') {
+    return callerHostId
+  }
+  const repoId = splitWorktreeId(
+    worktreeSelector.startsWith('id:') ? worktreeSelector.slice(3) : worktreeSelector
+  )?.repoId
+  const spellings = new Set(
+    getRepos()
+      .filter((repo) => (repoId ? repo.id === repoId : true))
+      .map((repo) => getRepoExecutionHostId(repo))
+      .filter((hostId) => hostId === LOCAL_EXECUTION_HOST_ID || hostId === callerHostId)
+  )
+  if (spellings.size > 1) {
+    throw new Error(
+      `Workspace identity is ambiguous across hosts: ${worktreeSelector}. Retry with an explicit host.`
+    )
+  }
+  return [...spellings][0] ?? LOCAL_EXECUTION_HOST_ID
+}

--- a/src/main/runtime/rpc/methods/worktree-rm-host-qualification.test.ts
+++ b/src/main/runtime/rpc/methods/worktree-rm-host-qualification.test.ts
@@ -4,13 +4,17 @@ import type { RpcRequest } from '../core'
 import { RpcDispatcher } from '../dispatcher'
 import { WORKTREE_METHODS } from './worktree'
 
-function makeRuntime(): OrcaRuntimeService {
+function makeRuntime(repoHostIds: (string | undefined)[] = ['local']): OrcaRuntimeService {
   return {
     getRuntimeId: () => 'test-runtime',
+    listRepos: () =>
+      repoHostIds.map((executionHostId) => ({ id: 'repo-1', path: '/repo', executionHostId })),
     showManagedWorktree: vi.fn().mockResolvedValue({ id: 'wt-1', hostId: 'local' }),
     removeManagedWorktree: vi.fn().mockResolvedValue({})
   } as unknown as OrcaRuntimeService
 }
+
+const WORKTREE_ID = 'repo-1::/repo/wt'
 
 function makeRequest(params: unknown): RpcRequest {
   return { id: 'req-1', authToken: 'tok', method: 'worktree.rm', params }
@@ -33,6 +37,93 @@ describe('worktree.rm host qualification', () => {
       'local'
     )
     expect(response).toMatchObject({ ok: true, result: { removed: true } })
+  })
+
+  it("resolves a paired client's own name for this host to our spelling", async () => {
+    const runtime = makeRuntime(['local'])
+    const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest({
+        worktree: `id:${WORKTREE_ID}`,
+        hostId: 'runtime:env-1',
+        force: true,
+        runHooks: false
+      })
+    )
+
+    expect(runtime.removeManagedWorktree).toHaveBeenCalledWith(
+      `id:${WORKTREE_ID}`,
+      true,
+      false,
+      false,
+      'local'
+    )
+    expect(response).toMatchObject({ ok: true, result: { removed: true } })
+  })
+
+  it('keeps a client-minted stamp this store still uses for its own repo', async () => {
+    const runtime = makeRuntime(['runtime:env-1'])
+    const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })
+
+    await dispatcher.dispatch(
+      makeRequest({
+        worktree: `id:${WORKTREE_ID}`,
+        hostId: 'runtime:env-1',
+        force: true,
+        runHooks: false
+      })
+    )
+
+    expect(runtime.removeManagedWorktree).toHaveBeenCalledWith(
+      `id:${WORKTREE_ID}`,
+      true,
+      false,
+      false,
+      'runtime:env-1'
+    )
+  })
+
+  it('fails closed when the repo id carries both spellings', async () => {
+    const runtime = makeRuntime(['local', 'runtime:env-1'])
+    const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest({
+        worktree: `id:${WORKTREE_ID}`,
+        hostId: 'runtime:env-1',
+        force: true,
+        runHooks: false
+      })
+    )
+
+    expect(response).toMatchObject({
+      ok: false,
+      error: { message: expect.stringContaining('ambiguous across hosts') }
+    })
+    expect(runtime.removeManagedWorktree).not.toHaveBeenCalled()
+  })
+
+  it('leaves an ssh qualifier alone, since we do proxy those onward', async () => {
+    const runtime = makeRuntime(['ssh:target-a'])
+    const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })
+
+    await dispatcher.dispatch(
+      makeRequest({
+        worktree: `id:${WORKTREE_ID}`,
+        hostId: 'ssh:target-a',
+        force: true,
+        runHooks: false
+      })
+    )
+
+    expect(runtime.removeManagedWorktree).toHaveBeenCalledWith(
+      `id:${WORKTREE_ID}`,
+      true,
+      false,
+      false,
+      'ssh:target-a'
+    )
   })
 
   it.each([['bogus'], ['ssh:'], ['runtime:'], [''], [null], [42]])(

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -174,7 +174,7 @@ export const WorktreeRemove = WorktreeSelector.extend({
 })
 
 export const WorktreeForceDeleteBranch = WorktreeSelector.extend({
-  hostId: OptionalString,
+  hostId: OptionalExecutionHostId,
   branchName: z
     .unknown()
     .transform((v) => (typeof v === 'string' ? v : ''))

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -6,6 +6,7 @@ import {
 import { buildCliWorkspaceProvenance } from '../../../../shared/cli-workspace-provenance'
 import { defineMethod, type RpcMethod } from '../core'
 import { buildManagedWorktreeCreateArgs } from './worktree-create-args'
+import { resolvePairedCallerHostId } from './paired-caller-host-id'
 import { resolveRuntimeNavigationTarget } from '../../../../shared/runtime-navigation'
 import { resolveRpcWorkspaceCreatorProvenance } from '../workspace-creator-context'
 import { WorktreeCreate, WorktreePrefetchCreateBase } from './worktree-create-schemas'
@@ -204,10 +205,15 @@ export const WORKTREE_METHODS: RpcMethod[] = [
     name: 'worktree.rm',
     params: WorktreeRemove,
     handler: async (params, { runtime }) => {
+      // Translate a paired client's runtime-local host spelling before host-qualified reads.
+      let resolvedHostId = resolvePairedCallerHostId(
+        () => runtime.listRepos(),
+        params.worktree,
+        params.hostId
+      )
       // Older mobile clients omit hostId, so resolve through the ambiguity gate
       // before pinning removal. An ambiguous selector still fails closed: two
       // hosts own the id and an unqualified client cannot say which it meant.
-      let resolvedHostId = params.hostId
       if (!resolvedHostId) {
         try {
           resolvedHostId = (await runtime.showManagedWorktree(params.worktree)).hostId
@@ -237,18 +243,24 @@ export const WORKTREE_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'worktree.forceDeleteBranch',
     params: WorktreeForceDeleteBranch,
-    handler: async (params, { runtime }) =>
-      params.hostId
+    handler: async (params, { runtime }) => {
+      const hostId = resolvePairedCallerHostId(
+        () => runtime.listRepos(),
+        params.worktree,
+        params.hostId
+      )
+      return hostId
         ? runtime.forceDeletePreservedBranch(
             params.worktree,
             params.branchName,
             params.expectedHead,
-            params.hostId
+            hostId
           )
         : runtime.forceDeletePreservedBranch(
             params.worktree,
             params.branchName,
             params.expectedHead
           )
+    }
   })
 ]

--- a/src/renderer/src/store/slices/worktrees-remote-runtime-removal.test.ts
+++ b/src/renderer/src/store/slices/worktrees-remote-runtime-removal.test.ts
@@ -60,7 +60,6 @@ describe('worktree remote runtime mutations', () => {
       method: 'worktree.rm',
       params: {
         worktree: `id:${wt.id}`,
-        hostId: 'runtime:env-1',
         force: false,
         allowUnverifiedPtyStop: false,
         runHooks: true
@@ -80,6 +79,68 @@ describe('worktree remote runtime mutations', () => {
       backendOwnsPtyTeardown: true
     })
     expect(store.getState().worktreesByRepo.repo1).toEqual([])
+  })
+
+  it('cleans up a preserved branch through the same host qualifier the removal used', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({
+      id: 'repo1::/path/wt1',
+      repoId: 'repo1',
+      path: '/path/wt1',
+      hostId: 'runtime:env-1'
+    })
+    runtimeEnvironmentCall
+      .mockResolvedValueOnce({
+        id: 'rpc-rm',
+        ok: true,
+        result: { preservedBranch: { branchName: 'feature/x', head: 'saved-head' } },
+        _meta: { runtimeId: 'runtime-remote' }
+      })
+      .mockResolvedValueOnce({
+        id: 'rpc-force-delete-branch',
+        ok: true,
+        result: { deleted: true },
+        _meta: { runtimeId: 'runtime-remote' }
+      })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      trustedOrcaHooks: { repo1: { all: { approvedAt: 1 } } },
+      worktreesByRepo: { repo1: [wt] }
+    } as Partial<AppState>)
+
+    await store.getState().removeWorktree({ id: wt.id, executionHostId: 'runtime:env-1' })
+
+    const forceResult = await store
+      .getState()
+      .forceDeletePreservedBranch(wt.id, 'feature/x', 'saved-head', {
+        hostId: 'runtime:env-1',
+        runtimeEnvironmentId: 'env-1'
+      })
+
+    expect(forceResult).toEqual({ ok: true, deleted: true })
+    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(1, {
+      selector: 'env-1',
+      method: 'worktree.rm',
+      params: {
+        worktree: `id:${wt.id}`,
+        force: undefined,
+        allowUnverifiedPtyStop: false,
+        runHooks: true
+      },
+      timeoutMs: 60_000,
+      expectedEnvironmentPairingRevision: undefined,
+      expectedRuntimeId: undefined
+    })
+    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(2, {
+      selector: 'env-1',
+      method: 'worktree.forceDeleteBranch',
+      params: {
+        worktree: `id:${wt.id}`,
+        branchName: 'feature/x',
+        expectedHead: 'saved-head'
+      },
+      timeoutMs: 15_000
+    })
   })
 
   it('does not clean up a hidden same-id VM owned by another host', async () => {

--- a/src/renderer/src/store/slices/worktrees/teardown/dispatch-worktree-removal.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/dispatch-worktree-removal.ts
@@ -1,4 +1,4 @@
-import type { ExecutionHostId } from '../../../../../../shared/execution-host'
+import { parseExecutionHostId, type ExecutionHostId } from '../../../../../../shared/execution-host'
 import type { RemoveWorktreeResult } from '../../../../../../shared/worktree/create-types'
 import { callRuntimeRpc, type getActiveRuntimeTarget } from '../../../../runtime/runtime-rpc-client'
 import { toRuntimeWorktreeSelector } from '../../../../runtime/runtime-worktree-selector'
@@ -40,16 +40,30 @@ export async function dispatchWorktreeRemoval(args: {
       ...snapshotPruneBatch
     })
   }
+  const effectiveHostId = qualifyRuntimeCallHost(target, hostId)
   return callRuntimeRpc<RemoveWorktreeResult>(
     target,
     'worktree.rm',
     {
       worktree: toRuntimeWorktreeSelector(worktreeId),
-      ...(hostId ? { hostId } : {}),
+      ...(effectiveHostId ? { hostId: effectiveHostId } : {}),
       force,
       allowUnverifiedPtyStop: options?.allowUnverifiedPtyStop === true,
       runHooks: !skipArchive
     },
     { timeoutMs: 60_000 }
   )
+}
+
+function qualifyRuntimeCallHost(
+  target: ReturnType<typeof getActiveRuntimeTarget>,
+  hostId: ExecutionHostId | undefined
+): ExecutionHostId | undefined {
+  if (
+    target.kind === 'environment' &&
+    parseExecutionHostId(hostId)?.environmentId === target.environmentId
+  ) {
+    return undefined
+  }
+  return hostId
 }

--- a/src/renderer/src/store/slices/worktrees/teardown/dispatch-worktree-removal.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/dispatch-worktree-removal.ts
@@ -59,9 +59,11 @@ function qualifyRuntimeCallHost(
   target: ReturnType<typeof getActiveRuntimeTarget>,
   hostId: ExecutionHostId | undefined
 ): ExecutionHostId | undefined {
+  const parsedHost = parseExecutionHostId(hostId)
   if (
     target.kind === 'environment' &&
-    parseExecutionHostId(hostId)?.environmentId === target.environmentId
+    parsedHost?.kind === 'runtime' &&
+    parsedHost.environmentId === target.environmentId
   ) {
     return undefined
   }

--- a/src/renderer/src/store/slices/worktrees/teardown/dispatch-worktree-removal.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/dispatch-worktree-removal.ts
@@ -40,7 +40,8 @@ export async function dispatchWorktreeRemoval(args: {
       ...snapshotPruneBatch
     })
   }
-  const effectiveHostId = qualifyRuntimeCallHost(target, hostId)
+  const effectiveHostId =
+    options?.sameIdSurvivingHostId != null ? hostId : qualifyRuntimeCallHost(target, hostId)
   return callRuntimeRpc<RemoveWorktreeResult>(
     target,
     'worktree.rm',

--- a/src/renderer/src/store/slices/worktrees/teardown/force-delete-preserved-branch.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/force-delete-preserved-branch.ts
@@ -1,4 +1,5 @@
 import type { WorktreeSlice } from '../../worktree-helpers'
+import { parseExecutionHostId } from '../../../../../../shared/execution-host'
 import type { WorktreeSliceGet, WorktreeSliceSet } from '../listing/worktree-slice-types'
 import { toast } from 'sonner'
 import { translate } from '@/i18n/i18n'
@@ -60,12 +61,17 @@ export function createForceDeletePreservedBranch(
       const target =
         retainedTarget?.target ??
         getActiveRuntimeTarget(settingsForWorktreeOwner(get(), worktreeId))
+      const effectiveHostId =
+        target.kind === 'environment' &&
+        parseExecutionHostId(cleanupHostId)?.environmentId === target.environmentId
+          ? undefined
+          : cleanupHostId
       const result = await (target.kind === 'local'
         ? window.api.worktrees.forceDeletePreservedBranch({
             worktreeId,
             branchName,
             expectedHead,
-            ...(cleanupHostId ? { hostId: cleanupHostId } : {})
+            ...(effectiveHostId ? { hostId: effectiveHostId } : {})
           })
         : callRuntimeRpc<ForceDeleteWorktreeBranchResult>(
             target,
@@ -74,7 +80,7 @@ export function createForceDeletePreservedBranch(
               worktree: toRuntimeWorktreeSelector(worktreeId),
               branchName,
               expectedHead,
-              ...(cleanupHostId ? { hostId: cleanupHostId } : {})
+              ...(effectiveHostId ? { hostId: effectiveHostId } : {})
             },
             { timeoutMs: 15_000 }
           ))

--- a/src/renderer/src/store/slices/worktrees/teardown/force-delete-preserved-branch.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/force-delete-preserved-branch.ts
@@ -61,9 +61,11 @@ export function createForceDeletePreservedBranch(
       const target =
         retainedTarget?.target ??
         getActiveRuntimeTarget(settingsForWorktreeOwner(get(), worktreeId))
+      const parsedCleanupHost = parseExecutionHostId(cleanupHostId)
       const effectiveHostId =
         target.kind === 'environment' &&
-        parseExecutionHostId(cleanupHostId)?.environmentId === target.environmentId
+        parsedCleanupHost?.kind === 'runtime' &&
+        parsedCleanupHost.environmentId === target.environmentId
           ? undefined
           : cleanupHostId
       const result = await (target.kind === 'local'


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​213 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​211 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​80 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​71 |

<!-- /orca-pr-loc -->

## Problem

When a paired client (e.g., running in a remote environment) deletes a worktree, it passes its own host ID spelling (like `runtime:env-1`). The host machine may store the same worktree under a different host ID spelling (like `local`). This mismatch prevented cleanup from finding and removing the worktree, causing deleted worktrees to reappear.

## Solution

Added `resolvePairedCallerHostId()` to translate the client's host ID to what the host actually uses for that repo. Worktree removal and branch deletion now resolve the host ID before cleanup operations. When there's ambiguity (same repo stored under multiple host IDs), the call fails safely rather than removing the wrong worktree.

Also optimized: omit host ID from RPC calls when the target environment already matches, reducing unnecessary qualifiers.

## Testing

- Added comprehensive tests for host ID resolution logic covering: passthrough of non-runtime IDs, translation to local when no runtime spelling exists, preservation of stamps still in use, rejection of ambiguous cases
- Added integration tests for worktree removal with runtime host ID translation
- Test coverage for preserved branch cleanup using consistent host qualifiers

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered

## Notes

Fixes worktrees reappearing after deletion due to host ID mismatch in paired environments.