### PR TITLE
fix(settings): an empty agent detection must not erase the saved default

### DIFF
--- a/src/renderer/src/components/settings/AgentsPane.test.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.test.tsx
@@ -630,3 +630,50 @@ describe('AgentsPane', () => {
     await secondWrite
   })
 })
+
+describe('empty agent detection must not cost the saved default (#15256)', () => {
+  const withEmptyDetection = <T,>(run: () => T): T => {
+    const previous = detectedAgentsMock.detectedIds
+    detectedAgentsMock.detectedIds = []
+    try {
+      return run()
+    } finally {
+      detectedAgentsMock.detectedIds = previous
+    }
+  }
+
+  /** The rendered `<button>` whose label contains `label`. */
+  const pillMarkup = (markup: string, label: string): string => {
+    const chunk = markup.split('<button').find((part) => part.includes(label))
+    expect(chunk, `no pill labelled ${label}`).toBeDefined()
+    return String(chunk)
+  }
+
+  it('does not present Auto as the active choice while an agent is stored', () => {
+    // The Auto pill's handler writes null. Rendering it pressed while
+    // `defaultTuiAgent: "claude"` is stored made the already-selected pill
+    // destructive: one click erased the setting, and later successful
+    // detection did not bring it back.
+    const markup = withEmptyDetection(() =>
+      renderPane({ ...getDefaultSettings('/tmp'), defaultTuiAgent: 'claude' })
+    )
+    expect(pillMarkup(markup, 'Auto')).toContain('aria-pressed="false"')
+  })
+
+  it('still offers the stored agent so the choice can be kept', () => {
+    // With zero detected there were no agent pills at all, so the stored value
+    // was invisible and unrecoverable through the UI.
+    const markup = withEmptyDetection(() =>
+      renderPane({ ...getDefaultSettings('/tmp'), defaultTuiAgent: 'claude' })
+    )
+    expect(markup).toContain('Saved as your default, but not detected right now')
+  })
+
+  it('keeps a Refresh control reachable when nothing is detected', () => {
+    // Refresh lived inside the Installed section, which only renders when at
+    // least one agent was found -- gone in exactly the state needing a retry.
+    const markup = withEmptyDetection(() => renderPane(getDefaultSettings('/tmp')))
+    expect(markup).toContain('No agents detected')
+    expect(markup).toContain('Refresh')
+  })
+})

--- a/src/renderer/src/components/settings/AgentsPane.tsx
+++ b/src/renderer/src/components/settings/AgentsPane.tsx
@@ -661,14 +661,21 @@ type DefaultAgentPillProps = {
   active: boolean
   onClick: () => void
   children: React.ReactNode
+  title?: string
 }
 
-function DefaultAgentPill({ active, onClick, children }: DefaultAgentPillProps): React.JSX.Element {
+function DefaultAgentPill({
+  active,
+  onClick,
+  children,
+  title
+}: DefaultAgentPillProps): React.JSX.Element {
   return (
     <button
       type="button"
       onClick={onClick}
       aria-pressed={active}
+      title={title}
       className={cn(
         'inline-flex items-center gap-2 rounded-md border px-3 py-1.5 text-sm outline-none transition-colors focus-visible:ring-[3px] focus-visible:ring-ring/50',
         active
@@ -800,14 +807,26 @@ export function AgentsPane({
     (a) => detectedIds !== null && !detectedIds.has(a.id)
   )
 
-  // Why: 'blank' is an explicit no-agent preference, not an auto fallback,
-  // so the Auto pill should only light up when the default is null OR when a
-  // selected agent id is no longer detected on PATH.
-  const isAutoDefault =
-    defaultAgent === null ||
-    (defaultAgent !== 'blank' &&
-      (!detectedIds?.has(defaultAgent) || !isTuiAgentEnabled(defaultAgent, disabledAgents)))
+  // Why only `=== null`: the pill's own handler writes null, so lighting it up
+  // for a *stored* agent that merely is not detected right now made the
+  // already-checked pill destructive -- one click on it erased
+  // `defaultTuiAgent` (#15256). Detection is a transient fact; the stored value
+  // is not, and this control reports the stored value.
+  const isAutoDefault = defaultAgent === null
   const isBlankDefault = defaultAgent === 'blank'
+
+  // Why show an undetected default: when detection comes back empty there were
+  // no agent pills at all, so the stored choice was invisible AND unrecoverable
+  // -- nothing to click to put it back. Keeping it listed means a failed or
+  // slow probe cannot quietly cost the user their setting.
+  const storedDefaultAgent =
+    defaultAgent !== null && defaultAgent !== 'blank'
+      ? getAgentCatalog().find((agent) => agent.id === defaultAgent)
+      : undefined
+  const defaultAgentPills =
+    storedDefaultAgent && !enabledDetectedAgents.some((agent) => agent.id === storedDefaultAgent.id)
+      ? [...enabledDetectedAgents, storedDefaultAgent]
+      : enabledDetectedAgents
 
   return (
     <div className="space-y-8">
@@ -836,13 +855,22 @@ export function AgentsPane({
             {isBlankDefault && <Check className="size-3.5" />}
           </DefaultAgentPill>
 
-          {enabledDetectedAgents.map((agent) => {
+          {defaultAgentPills.map((agent) => {
             const isActive = defaultAgent === agent.id
+            const isUndetected = detectedIds !== null && !detectedIds.has(agent.id)
             return (
               <DefaultAgentPill
                 key={agent.id}
                 active={isActive}
                 onClick={() => setDefault(agent.id)}
+                title={
+                  isUndetected
+                    ? translate(
+                        'auto.components.settings.AgentsPane.storedDefaultUndetected',
+                        'Saved as your default, but not detected right now'
+                      )
+                    : undefined
+                }
               >
                 <AgentIcon agent={agent.id} size={14} />
                 {agent.label}
@@ -876,6 +904,33 @@ export function AgentsPane({
       <AgentCacheTimerSection settings={settings} updateSettings={updateSettings} />
 
       <AgentPermissionsSetting mode={agentPermissionMode} onChange={saveAgentPermissionMode} />
+
+      {detectedAgents.length === 0 && detectedIds !== null && !detectionFailed && (
+        <div className="flex items-center justify-between gap-3 rounded-md border border-dashed border-border/50 px-3 py-3 text-sm text-muted-foreground">
+          {/* Why here and not only inside Installed: that section renders under
+              `detectedAgents.length > 0`, so the only Refresh control vanished
+              in precisely the state that needs a retry (#15256). */}
+          <span>
+            {translate(
+              'auto.components.settings.AgentsPane.noAgentsDetected',
+              'No agents detected. If one is installed, the probe may have timed out.'
+            )}
+          </span>
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            onClick={handleRefresh}
+            disabled={isRefreshing}
+            className="h-7 shrink-0 gap-1.5 text-xs"
+          >
+            <RefreshCw className={cn('size-3', isRefreshing && 'animate-spin')} />
+            {isRefreshing
+              ? translate('auto.components.settings.AgentsPane.c9b33eb5c0', 'Refreshing…')
+              : translate('auto.components.settings.AgentsPane.0d9e293a02', 'Refresh')}
+          </Button>
+        </div>
+      )}
 
       {detectedAgents.length > 0 && (
         <section className="space-y-3">

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6240,7 +6240,9 @@
           "3f1bdf3cb4": "Environment text is too large to parse safely.",
           "codexSessionSource": "Codex home to import from",
           "codexSessionSourceInfo": "About importing Codex history",
-          "codexSessionSourceTooltip": "Orca runs Codex in an isolated home. Point this at your existing Codex home to import that session history. Empty uses ~/.codex."
+          "codexSessionSourceTooltip": "Orca runs Codex in an isolated home. Point this at your existing Codex home to import that session history. Empty uses ~/.codex.",
+          "storedDefaultUndetected": "Saved as your default, but not detected right now",
+          "noAgentsDetected": "No agents detected. If one is installed, the probe may have timed out."
         },
         "AppIconSelector": {
           "d5a112dc9b": "Next icon",


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​67 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​57 |

<!-- /orca-pr-loc -->

Closes #15256.

## ELI5

Settings → Agents asks the machine "which agents are installed?". When that
question comes back empty, the screen treated the answer as authoritative — and
three things went wrong at once.

The worst is silent data loss. The **Auto** pill's click handler writes
`defaultTuiAgent: null`. But Auto was rendered as the *already-selected* option
whenever the stored agent merely wasn't detected on this run. So the user sees
Auto check-marked, clicks it — the pill that already looked active — and their
saved default is gone. Later successful detection does not bring it back.

The reporter caught it by diffing `orca-data.json` against the hourly backups:
`defaultTuiAgent` went `"claude"` → `null`, and it was the **only** key that
changed.

## The three fixes

1. **Auto is active only when `null` is actually stored.** Detection is a
   transient fact; the stored value is not, and this control reports the stored
   value. This is what stops the data loss.
2. **The stored agent is always offered**, labelled *"Saved as your default, but
   not detected right now"*. With zero detected there were no agent pills at
   all, so the choice was invisible **and** unrecoverable — nothing to click to
   put it back.
3. **An empty result gets its own Refresh.** The only Refresh lived inside the
   *Installed* section, which renders under `detectedAgents.length > 0`, so the
   retry control disappeared in exactly the state that needs it. The reporter's
   workaround was toggling the runtime setting to WSL and back, because that was
   the only reachable re-detect trigger.

## Why now

#16028 makes WSL detection legitimately return an empty set on machines where
the only `claude` was a Windows binary reached through interop. That is the
correct answer, but it routes more users down this exact path — so this should
land first.

## Proof of no regression

- Existing `AgentsPane` suite unchanged and green (31 passed).
- Three new tests, one per bug: Auto is not pressed while an agent is stored;
  the stored agent is still offered; a Refresh control exists with nothing
  detected.
- **Each verified to bind**: reverting its own fix makes that test — and only
  that test — fail.
- Lint (including the localization catalog/extraction/coverage gates) and
  typecheck exit 0.

## User-facing trade-offs

**One, and it is the point.** A user whose stored default is not currently
detected now sees Auto *unchecked* and their agent listed as saved-but-not-found,
where before they saw Auto checked. That is a more accurate report of what is
stored, and it is what makes the setting survivable — but it does mean the
pane's appearance changes for anyone in that state.

No wire, persisted state shape, or IPC change; the only new persisted behaviour
is that a click no longer destroys a value.
