### PR TITLE
fix(secrets): report the protection gap on change, not on every launch

### DIFF
--- a/src/main/host/secret-protection-report.test.ts
+++ b/src/main/host/secret-protection-report.test.ts
@@ -1,38 +1,97 @@
-import { describe, expect, it } from 'vitest'
-import { setSecretStore, _resetSecretStoreForTests } from '../../shared/secret-store'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { _resetSecretStoreForTests, setSecretStore } from '../../shared/secret-store'
 import { reportSecretProtectionGap } from './secret-protection-report'
 
-function installStore(gap: string | null): void {
-  setSecretStore({
-    isEncryptionAvailable: () => true,
-    encryptString: (plainText) => Buffer.from(plainText),
-    decryptString: (cipher) => cipher.toString(),
-    describeProtectionGap: () => gap
-  })
-}
+const WEAK = 'Secrets are obfuscated with a built-in key.'
 
 describe('reportSecretProtectionGap', () => {
-  it('logs and returns the gap when protection is weaker than a user would assume', () => {
-    installStore('Secrets are obfuscated with a built-in key.')
-    const logged: string[] = []
-    expect(reportSecretProtectionGap((m) => logged.push(m))).toMatch(/built-in key/)
-    expect(logged).toHaveLength(1)
-    expect(logged[0]).toContain('[secrets]')
+  let dir: string
+  let dataFile: string
+  let logged: string[]
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'orca-secret-report-'))
+    dataFile = join(dir, 'orca-data.json')
+    logged = []
   })
 
-  it('stays silent when secrets are properly sealed', () => {
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  function installStore(gap: string | null): void {
+    setSecretStore({
+      isEncryptionAvailable: () => true,
+      encryptString: (plainText) => Buffer.from(plainText),
+      decryptString: (cipher) => cipher.toString(),
+      describeProtectionGap: () => gap
+    })
+  }
+
+  const report = (force = false): string | null =>
+    reportSecretProtectionGap({ dataFile, log: (m) => void logged.push(m), force })
+
+  it('reports a new gap once, then stays quiet on every later launch', () => {
+    // Why this is the point: the gap usually needs a keyring install to fix, so
+    // repeating it every start is nagging the user cannot act on.
+    installStore(WEAK)
+    expect(report()).toBe(WEAK)
+    expect(logged).toHaveLength(1)
+
+    report()
+    report()
+    expect(logged).toHaveLength(1)
+  })
+
+  it('reports again when the gap changes to a different reason', () => {
+    installStore(WEAK)
+    report()
+    installStore('The OS keyring is unavailable.')
+    report()
+    expect(logged).toHaveLength(2)
+    expect(logged[1]).toContain('keyring is unavailable')
+  })
+
+  it('announces recovery, so an earlier warning is not left standing', () => {
+    installStore(WEAK)
+    report()
     installStore(null)
-    const logged: string[] = []
-    expect(reportSecretProtectionGap((m) => logged.push(m))).toBeNull()
+    report()
+    expect(logged).toHaveLength(2)
+    expect(logged[1]).toMatch(/now provided by the OS keyring/)
+
+    report()
+    expect(logged).toHaveLength(2)
+  })
+
+  it('stays silent from a clean start when secrets are properly sealed', () => {
+    installStore(null)
+    expect(report()).toBeNull()
     expect(logged).toEqual([])
   })
 
+  it('re-reports on demand for support, without disturbing stored state', () => {
+    installStore(WEAK)
+    report()
+    expect(report(true)).toBe(WEAK)
+    expect(logged).toHaveLength(2)
+    report()
+    expect(logged).toHaveLength(2)
+  })
+
+  it('re-reports when the stored state is corrupt rather than trusting it', () => {
+    installStore(WEAK)
+    writeFileSync(join(dir, 'orca-secret-protection.json'), '{ not json', 'utf-8')
+    expect(report()).toBe(WEAK)
+    expect(logged).toHaveLength(1)
+  })
+
   it('does not throw startup when no store is installed', () => {
-    // Why: this is diagnostics running early in bootstrap. The useful error is the one
-    // raised by the first real read, not a crash from the thing reporting on it.
     _resetSecretStoreForTests()
-    const logged: string[] = []
-    expect(() => reportSecretProtectionGap((m) => logged.push(m))).not.toThrow()
+    expect(() => report()).not.toThrow()
     expect(logged[0]).toContain('could not determine at-rest protection')
   })
 })

--- a/src/main/host/secret-protection-report.ts
+++ b/src/main/host/secret-protection-report.ts
@@ -1,19 +1,53 @@
+import { dirname, join } from 'node:path'
+import { readFileSync, writeFileSync } from 'node:fs'
 import { getSecretStore } from '../../shared/secret-store'
 
 /**
- * Report at-rest secret protection once at startup.
+ * Report at-rest secret protection, but only when the answer changes.
  *
  * Why this exists: the port has always been able to describe a protection gap, and
  * nothing read it — so a Linux user whose secrets are obfuscated with a built-in key
- * was told nothing at all. Reading it here is the difference between the port
- * documenting a promise and keeping one.
+ * was told nothing at all.
+ *
+ * Why not every launch: the gap is usually not something the user can fix right now
+ * (it needs a keyring installed and unlocked), so repeating it every start is nagging
+ * they cannot act on and will learn to ignore. Reporting on change means they hear it
+ * when it starts being true, hear it again if it becomes true for a different reason,
+ * and are told once when it is fixed.
  *
  * Deliberately not fatal and not a dialog: sealing still works, so blocking startup
  * would be worse than the gap it reports.
  */
-export function reportSecretProtectionGap(
-  log: (message: string) => void = (message) => console.warn(message)
-): string | null {
+
+type ReportOptions = {
+  /** Profile data file; the report state lives beside it. */
+  dataFile: string
+  log?: (message: string) => void
+  /** Escape hatch for support: re-report even if unchanged. */
+  force?: boolean
+}
+
+type ReportState = { lastReportedGap: string | null }
+
+function stateFile(dataFile: string): string {
+  return join(dirname(dataFile), 'orca-secret-protection.json')
+}
+
+function readState(path: string): ReportState | null {
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as unknown
+    if (parsed && typeof parsed === 'object' && 'lastReportedGap' in parsed) {
+      const value = (parsed as ReportState).lastReportedGap
+      return { lastReportedGap: typeof value === 'string' ? value : null }
+    }
+  } catch {
+    // Missing or corrupt: treat as never reported and report again.
+  }
+  return null
+}
+
+export function reportSecretProtectionGap(options: ReportOptions): string | null {
+  const log = options.log ?? ((message: string) => console.warn(message))
   let gap: string | null
   try {
     gap = getSecretStore().describeProtectionGap()
@@ -23,8 +57,28 @@ export function reportSecretProtectionGap(
     log(`[secrets] could not determine at-rest protection: ${String(error)}`)
     return null
   }
-  if (gap) {
-    log(`[secrets] ${gap}`)
+
+  const path = stateFile(options.dataFile)
+  const previous = readState(path)
+  const changed = previous === null || previous.lastReportedGap !== gap
+
+  if (changed || options.force) {
+    if (gap) {
+      log(`[secrets] ${gap}`)
+    } else if (previous?.lastReportedGap) {
+      // Why announce the recovery: the previous warning said secrets were not protected,
+      // so silence would leave the user assuming that is still true.
+      log('[secrets] At-rest protection is now provided by the OS keyring.')
+    }
+  }
+
+  if (changed) {
+    try {
+      writeFileSync(path, JSON.stringify({ lastReportedGap: gap }), 'utf-8')
+    } catch (error) {
+      // Best effort: re-reporting next launch is strictly better than failing startup.
+      log(`[secrets] could not persist the protection report state: ${String(error)}`)
+    }
   }
   return gap
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -884,9 +884,6 @@ if (hasSingleInstanceLock) {
   // the app.setName ordering the userData captures below depend on.
   setAppEnvironment(new ElectronAppEnvironment())
   setSecretStore(new ElectronSecretStore())
-  // Why right after install: this is the first moment the answer is knowable, and a
-  // silent weak backend is the gap users most need told about.
-  reportSecretProtectionGap()
   // Why at process level, not per-window: pty.ts registers against injected surfaces so
   // it can load without electron, and an Electron main process always has ipcMain —
   // whether a window exists is irrelevant. Installing this in attachMainWindowServices
@@ -2310,6 +2307,12 @@ void app.whenReady().then(async () => {
 
   const activeOrcaProfile = ensureActiveOrcaProfile()
   store = new Store({ dataFile: activeOrcaProfile.dataFile })
+  // Why here and not at install time: the report remembers what it last said, and that
+  // state lives beside the profile data file, which does not exist until now.
+  reportSecretProtectionGap({
+    dataFile: activeOrcaProfile.dataFile,
+    force: process.env.ORCA_ALWAYS_REPORT_SECRET_PROTECTION === '1'
+  })
   // Why here: the host key store is a sidecar of the same profile, and every SSH connect consults
   // it. Left unbound it reports nothing trusted, which is safe but silently discards our own
   // accept records on every launch.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​81 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​22 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​59 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​68 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​57 |

<!-- /orca-pr-loc -->

## ELI5

The warning I added in #16033 fired on **every single startup**, and there was no way to turn it off.

For a Linux user on the weak `basic_text` backend, fixing it means installing and unlocking a keyring — not something you can do right now, mid-launch. So a warning every start is nagging you can't act on, and the reliable outcome is that you learn to ignore it. Which defeats the point of adding it.

Now Orca tells you when the answer **changes**.

## Behaviour

| Situation | Before | Now |
|---|---|---|
| Gap appears (fresh install on `basic_text`) | warns | warns |
| Same gap, every later launch | **warns again, forever** | silent |
| Gap changes to a different reason | warns | warns |
| Gap fixed (keyring installed) | silent | **says so once** |

The recovery message matters: the previous warning said secrets were not protected. Going silent would leave the user assuming that's still true.

## Why the call moved

It ran inside the host-port bootstrap, which is before the profile exists — and the report now has to remember what it last said. That state lives beside the profile data file, so the call moved to just after `new Store(...)`. Still early, still before any secret-dependent work.

The bootstrap wiring guard from #16033 is unaffected: it guards the nine `setX` port installs, and this was never one of them.

## Failure handling

- **Corrupt state file** → re-reports rather than trusting it
- **Failed write** → logs and continues; re-reporting next launch is the safe direction, failing startup is not
- **No store installed** → logs and returns null, does not throw (this is diagnostics; the useful error is the one from the first real read)

`ORCA_ALWAYS_REPORT_SECRET_PROTECTION=1` forces a re-report for support, without disturbing the stored state.

## Proof

7 tests covering exactly this contract, including the one that matters most — *reports once, then stays quiet on every later launch*. Full suite green (57,490 passed; one unrelated timing-sensitive perf test flaked under parallel load and passes in isolation — it's in `palette-match`, which this branch does not touch). `pnpm run lint` clean.

## User-facing trade-offs

Strictly better than #16033: same information, delivered once instead of forever, plus a recovery notice that did not exist.