### PR TITLE
Fix Windows Git Bash console-capacity failures

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -102,6 +102,7 @@ import type { AgentSessionContinuationRequest } from '@/lib/agent-session-contin
 import { useNotificationDispatch } from './use-notification-dispatch'
 import { connectPanePty } from './pty-connection'
 import type { PaneProcessExit, PtyConnectionDeps } from './pty-connection-types'
+import { resolveTerminalProcessExitRestartStartup } from './terminal-process-exit-restart'
 import { resolveTerminalLayoutActiveLeafId } from './terminal-layout-leaf-ids'
 import { shouldPreserveTerminalScrollbackBuffers } from '../../../../shared/workspace-session-terminal-buffers'
 import {
@@ -401,9 +402,14 @@ function TerminalPane(
   const [agentSessionContinuation, setAgentSessionContinuation] =
     useState<AgentSessionContinuationRequest | null>(null)
   const [terminalError, setTerminalError] = useState<string | null>(null)
-  const [paneProcessExit, setPaneProcessExit] = useState<PaneProcessExit | null>(null)
+  const [paneProcessExitsByPaneId, setPaneProcessExitsByPaneId] = useState<
+    Record<number, PaneProcessExit>
+  >({})
   const handlePaneProcessDied = useCallback((processExit: PaneProcessExit) => {
-    setPaneProcessExit(processExit)
+    setPaneProcessExitsByPaneId((current) => ({
+      ...current,
+      [processExit.paneId]: processExit
+    }))
   }, [])
   const [ptyRecoveryStatesByPaneId, setPtyRecoveryStatesByPaneId] = useState<
     Record<number, VisiblePtyRecoveryState>
@@ -1639,25 +1645,35 @@ function TerminalPane(
     ]
   )
 
-  const handleRestartExitedPane = useCallback(() => {
-    if (!paneProcessExit) {
-      return
-    }
-    setPaneProcessExit(null)
-    handleRestartCodexPane(
-      paneProcessExit.paneId,
-      paneProcessExit.reason === 'git-bash-console-capacity' ? startup : null
-    )
-  }, [handleRestartCodexPane, paneProcessExit, startup])
+  const clearPaneProcessExit = useCallback((paneId: number) => {
+    setPaneProcessExitsByPaneId((current) => {
+      if (current[paneId] === undefined) {
+        return current
+      }
+      const next = { ...current }
+      delete next[paneId]
+      return next
+    })
+  }, [])
 
-  const handleCloseExitedPane = useCallback(() => {
-    if (!paneProcessExit) {
-      return
-    }
-    const paneId = paneProcessExit.paneId
-    setPaneProcessExit(null)
-    executeClosePane(paneId)
-  }, [executeClosePane, paneProcessExit])
+  const handleRestartExitedPane = useCallback(
+    (processExit: PaneProcessExit) => {
+      clearPaneProcessExit(processExit.paneId)
+      handleRestartCodexPane(
+        processExit.paneId,
+        resolveTerminalProcessExitRestartStartup(processExit)
+      )
+    },
+    [clearPaneProcessExit, handleRestartCodexPane]
+  )
+
+  const handleCloseExitedPane = useCallback(
+    (paneId: number) => {
+      clearPaneProcessExit(paneId)
+      executeClosePane(paneId)
+    },
+    [clearPaneProcessExit, executeClosePane]
+  )
 
   // Why leaf bindings are a dep: a parked or deferred tab mounts with no
   // transport, so a queued restart has no ptyId to match on the mount pass. The
@@ -3063,20 +3079,21 @@ function TerminalPane(
           onRestartDaemon={() => daemonActions.setPending('restart')}
         />
       ) : null}
-      {paneProcessExit && isActive
-        ? managedPanes.map((pane) =>
-            pane.id === paneProcessExit.paneId
+      {isActive
+        ? managedPanes.map((pane) => {
+            const processExit = paneProcessExitsByPaneId[pane.id]
+            return processExit
               ? createPortal(
                   <TerminalProcessExitOverlay
-                    processExit={paneProcessExit}
-                    onRestart={handleRestartExitedPane}
-                    onClose={handleCloseExitedPane}
+                    processExit={processExit}
+                    onRestart={() => handleRestartExitedPane(processExit)}
+                    onClose={() => handleCloseExitedPane(pane.id)}
                   />,
                   pane.container,
                   `process-exit-${pane.id}`
                 )
               : null
-          )
+          })
         : null}
       {/* Why: portal into the pane so the banner stacks above the xterm canvas (sibling mount painted under WebGL). */}
       {showSshReconnectOverlay && sshReconnectTargetId && sshReconnectStatus

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -60,6 +60,7 @@ import { RUNNING_CLOSE_PROBE_TIMEOUT_MS } from '../terminal/running-terminal-clo
 import CodexRestartChip from '../CodexRestartChip'
 import { MobileDriverOverlay } from './MobileDriverOverlay'
 import { stripSshReconnectOwnedErrorLines, TerminalErrorToast } from './TerminalErrorToast'
+import { TerminalProcessExitOverlay } from './TerminalProcessExitOverlay'
 import { TerminalSessionStateSaveFailureDialog } from './TerminalSessionStateSaveFailureDialog'
 import TerminalContextMenu from './TerminalContextMenu'
 import TerminalPaneHeaderOverlay, { type PaneTitleOverlayRect } from './TerminalPaneHeaderOverlay'
@@ -100,6 +101,7 @@ import type { PreparedAgentSessionFork } from './terminal-agent-session-fork'
 import type { AgentSessionContinuationRequest } from '@/lib/agent-session-continuation'
 import { useNotificationDispatch } from './use-notification-dispatch'
 import { connectPanePty } from './pty-connection'
+import type { PaneProcessExit, PtyConnectionDeps } from './pty-connection-types'
 import { resolveTerminalLayoutActiveLeafId } from './terminal-layout-leaf-ids'
 import { shouldPreserveTerminalScrollbackBuffers } from '../../../../shared/workspace-session-terminal-buffers'
 import {
@@ -399,6 +401,10 @@ function TerminalPane(
   const [agentSessionContinuation, setAgentSessionContinuation] =
     useState<AgentSessionContinuationRequest | null>(null)
   const [terminalError, setTerminalError] = useState<string | null>(null)
+  const [paneProcessExit, setPaneProcessExit] = useState<PaneProcessExit | null>(null)
+  const handlePaneProcessDied = useCallback((processExit: PaneProcessExit) => {
+    setPaneProcessExit(processExit)
+  }, [])
   const [ptyRecoveryStatesByPaneId, setPtyRecoveryStatesByPaneId] = useState<
     Record<number, VisiblePtyRecoveryState>
   >({})
@@ -1368,6 +1374,7 @@ function TerminalPane(
     onPtyExitRef,
     onAgentExitedRef,
     onPtyErrorRef,
+    onPaneProcessDied: handlePaneProcessDied,
     onPtyRecoveryStateRef,
     clearTabPtyId,
     consumeSuppressedPtyExit: useAppStore((store) => store.consumeSuppressedPtyExit),
@@ -1535,7 +1542,10 @@ function TerminalPane(
   }, [])
 
   const handleRestartCodexPane = useCallback(
-    (paneId: number) => {
+    (
+      paneId: number,
+      restartStartup: PtyConnectionDeps['startup'] = CODEX_ACCOUNT_RESTART_STARTUP
+    ) => {
       const manager = managerRef.current
       const pane = manager?.getPanes().find((candidate) => candidate.id === paneId)
       if (!manager || !pane) {
@@ -1565,7 +1575,7 @@ function TerminalPane(
         tabId,
         worktreeId,
         cwd,
-        startup: CODEX_ACCOUNT_RESTART_STARTUP,
+        startup: restartStartup,
         mountFollowsTerminalPark: false,
         paneTransportsRef,
         paneMode2031Ref,
@@ -1577,6 +1587,7 @@ function TerminalPane(
         onPtyExitRef,
         onAgentExitedRef,
         onPtyErrorRef,
+        onPaneProcessDied: handlePaneProcessDied,
         onPtyRecoveryStateRef,
         clearTabPtyId,
         consumeSuppressedPtyExit: useAppStore.getState().consumeSuppressedPtyExit,
@@ -1607,6 +1618,7 @@ function TerminalPane(
       clearTabPtyId,
       cwd,
       dispatchNotification,
+      handlePaneProcessDied,
       markWorktreeUnread,
       markTerminalTabUnread,
       markTerminalPaneUnread,
@@ -1626,6 +1638,26 @@ function TerminalPane(
       worktreeId
     ]
   )
+
+  const handleRestartExitedPane = useCallback(() => {
+    if (!paneProcessExit) {
+      return
+    }
+    setPaneProcessExit(null)
+    handleRestartCodexPane(
+      paneProcessExit.paneId,
+      paneProcessExit.reason === 'git-bash-console-capacity' ? startup : null
+    )
+  }, [handleRestartCodexPane, paneProcessExit, startup])
+
+  const handleCloseExitedPane = useCallback(() => {
+    if (!paneProcessExit) {
+      return
+    }
+    const paneId = paneProcessExit.paneId
+    setPaneProcessExit(null)
+    executeClosePane(paneId)
+  }, [executeClosePane, paneProcessExit])
 
   // Why leaf bindings are a dep: a parked or deferred tab mounts with no
   // transport, so a queued restart has no ptyId to match on the mount pass. The
@@ -3031,6 +3063,21 @@ function TerminalPane(
           onRestartDaemon={() => daemonActions.setPending('restart')}
         />
       ) : null}
+      {paneProcessExit && isActive
+        ? managedPanes.map((pane) =>
+            pane.id === paneProcessExit.paneId
+              ? createPortal(
+                  <TerminalProcessExitOverlay
+                    processExit={paneProcessExit}
+                    onRestart={handleRestartExitedPane}
+                    onClose={handleCloseExitedPane}
+                  />,
+                  pane.container,
+                  `process-exit-${pane.id}`
+                )
+              : null
+          )
+        : null}
       {/* Why: portal into the pane so the banner stacks above the xterm canvas (sibling mount painted under WebGL). */}
       {showSshReconnectOverlay && sshReconnectTargetId && sshReconnectStatus
         ? managedPanes.map((pane) =>

--- a/src/renderer/src/components/terminal-pane/TerminalProcessExitOverlay.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalProcessExitOverlay.test.tsx
@@ -15,7 +15,8 @@ describe('TerminalProcessExitOverlay', () => {
         processExit={{
           paneId: 1,
           exitCode: 1,
-          reason: 'git-bash-console-capacity'
+          reason: 'git-bash-console-capacity',
+          startup: null
         }}
         onRestart={onRestart}
         onClose={onClose}
@@ -33,7 +34,7 @@ describe('TerminalProcessExitOverlay', () => {
   it('preserves the exit code for other shell failures', () => {
     render(
       <TerminalProcessExitOverlay
-        processExit={{ paneId: 1, exitCode: 7, reason: 'process-failed' }}
+        processExit={{ paneId: 1, exitCode: 7, reason: 'process-failed', startup: null }}
         onRestart={vi.fn()}
         onClose={vi.fn()}
       />

--- a/src/renderer/src/components/terminal-pane/TerminalProcessExitOverlay.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalProcessExitOverlay.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { TerminalProcessExitOverlay } from './TerminalProcessExitOverlay'
+
+describe('TerminalProcessExitOverlay', () => {
+  afterEach(cleanup)
+
+  it('explains the Git Bash limit and exposes recovery actions', () => {
+    const onRestart = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <TerminalProcessExitOverlay
+        processExit={{
+          paneId: 1,
+          exitCode: 1,
+          reason: 'git-bash-console-capacity'
+        }}
+        onRestart={onRestart}
+        onClose={onClose}
+      />
+    )
+
+    expect(screen.getByRole('alert').textContent).toContain('128-console limit')
+    fireEvent.click(screen.getByRole('button', { name: 'Restart' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Close' }))
+
+    expect(onRestart).toHaveBeenCalledOnce()
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('preserves the exit code for other shell failures', () => {
+    render(
+      <TerminalProcessExitOverlay
+        processExit={{ paneId: 1, exitCode: 7, reason: 'process-failed' }}
+        onRestart={vi.fn()}
+        onClose={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('alert').textContent).toContain('exit code 7')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/TerminalProcessExitOverlay.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalProcessExitOverlay.tsx
@@ -1,0 +1,61 @@
+import { RotateCw, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { translate } from '@/i18n/i18n'
+import type { PaneProcessExit } from './pty-connection-types'
+
+export function TerminalProcessExitOverlay({
+  processExit,
+  onRestart,
+  onClose
+}: {
+  processExit: PaneProcessExit
+  onRestart: () => void
+  onClose: () => void
+}): React.JSX.Element {
+  const capacityError = processExit.reason === 'git-bash-console-capacity'
+  const title = capacityError
+    ? translate(
+        'auto.components.terminal.pane.TerminalProcessExitOverlay.capacityTitle',
+        'Git Bash console limit reached'
+      )
+    : translate(
+        'auto.components.terminal.pane.TerminalProcessExitOverlay.failedTitle',
+        'Terminal exited'
+      )
+  const detail = capacityError
+    ? translate(
+        'auto.components.terminal.pane.TerminalProcessExitOverlay.capacityDetail',
+        'Git Bash reached its 128-console limit. Close unused Git Bash terminals, then restart this terminal.'
+      )
+    : translate(
+        'auto.components.terminal.pane.TerminalProcessExitOverlay.failedDetail',
+        'The shell process ended with exit code {{code}}. Its output is preserved.'
+      ).replace('{{code}}', String(processExit.exitCode))
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-40 flex items-end justify-center p-4">
+      <div
+        role="alert"
+        className="pointer-events-auto flex w-full max-w-md flex-col gap-3 rounded-lg border border-border bg-card p-4 text-card-foreground shadow-xs"
+      >
+        <div className="space-y-1">
+          <div className="text-sm font-medium text-foreground">{title}</div>
+          <div className="text-xs text-muted-foreground">{detail}</div>
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="ghost" size="sm" onClick={onClose}>
+            <X />
+            {translate('auto.components.terminal.pane.TerminalProcessExitOverlay.close', 'Close')}
+          </Button>
+          <Button type="button" size="sm" onClick={onRestart}>
+            <RotateCw />
+            {translate(
+              'auto.components.terminal.pane.TerminalProcessExitOverlay.restart',
+              'Restart'
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/terminal-pane/git-bash-console-capacity.test.ts
+++ b/src/renderer/src/components/terminal-pane/git-bash-console-capacity.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+import { createGitBashConsoleCapacityDetector } from './git-bash-console-capacity'
+
+describe('Git Bash console capacity detection', () => {
+  it('recognizes the MSYS fatal message across PTY chunks', () => {
+    const detector = createGitBashConsoleCapacityDetector()
+
+    detector.observe('console device allocation failure - too many consoles ')
+    detector.observe('in use, max consoles is 128')
+
+    expect(detector.detected()).toBe(true)
+  })
+
+  it('ignores unrelated shell failures', () => {
+    const detector = createGitBashConsoleCapacityDetector()
+    detector.observe('bash: command not found')
+
+    expect(detector.detected()).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/git-bash-console-capacity.ts
+++ b/src/renderer/src/components/terminal-pane/git-bash-console-capacity.ts
@@ -1,0 +1,23 @@
+const GIT_BASH_CONSOLE_CAPACITY_MARKER = 'too many consoles in use, max consoles is 128'
+
+export type GitBashConsoleCapacityDetector = {
+  observe: (data: string) => void
+  detected: () => boolean
+}
+
+export function createGitBashConsoleCapacityDetector(): GitBashConsoleCapacityDetector {
+  let tail = ''
+  let matched = false
+
+  return {
+    observe(data) {
+      if (matched || data.length === 0) {
+        return
+      }
+      const candidate = (tail + data).toLowerCase()
+      matched = candidate.includes(GIT_BASH_CONSOLE_CAPACITY_MARKER)
+      tail = candidate.slice(-(GIT_BASH_CONSOLE_CAPACITY_MARKER.length - 1))
+    },
+    detected: () => matched
+  }
+}

--- a/src/renderer/src/components/terminal-pane/pty-connection-pty-exit-teardown.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-pty-exit-teardown.test.ts
@@ -1,6 +1,8 @@
 import type * as React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { sendTerminalInputThroughPane } from './pty-connection-test-dom'
+import { flushAsyncTicks } from './pty-connection-test-async'
 import {
   LEAF_1,
   LEAF_2,
@@ -127,6 +129,38 @@ vi.mock('./pty-dispatcher', async (importOriginal) => {
 
 function createDeps(overrides: Record<string, unknown> = {}) {
   return buildPaneConnectionDeps(() => mockStoreState, overrides)
+}
+
+function installSleepingCodexResumeState(restoredPtyId?: string) {
+  const paneKey = makePaneKey('tab-1', LEAF_1)
+  const launchConfig = {
+    agentCommand: "codex '--model' 'gpt-5'",
+    agentArgs: '--model gpt-5',
+    agentEnv: { CODEX_PROFILE: 'captured' }
+  }
+  mockStoreState = {
+    ...mockStoreState,
+    tabsByWorktree: {
+      'wt-1': [{ id: 'tab-1', ...(restoredPtyId ? { ptyId: restoredPtyId } : {}) }]
+    },
+    settings: { ...mockStoreState.settings, agentCmdOverrides: {} },
+    agentStatusByPaneKey: {},
+    sleepingAgentSessionsByPaneKey: {
+      [paneKey]: {
+        paneKey,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        agent: 'codex',
+        providerSession: { key: 'session_id', id: 'codex-session-1' },
+        prompt: 'finish the task',
+        state: 'working',
+        capturedAt: 1,
+        updatedAt: 1,
+        launchConfig
+      }
+    }
+  } as StoreState
+  return launchConfig
 }
 
 describe('connectPanePty', () => {
@@ -466,6 +500,84 @@ describe('connectPanePty', () => {
       reason: 'git-bash-console-capacity'
     })
     expect(deps.onPtyExitRef.current).not.toHaveBeenCalled()
+  })
+
+  it('retains the cold-restore resume startup when its replacement hits capacity', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const callbacks: ConnectCallbacks[] = []
+    const transport = createMockTransport('resume-pty')
+    transport.connect.mockImplementation(async (options: { callbacks: ConnectCallbacks }) => {
+      callbacks.push(options.callbacks)
+      return 'resume-pty'
+    })
+    transportFactoryQueue.push(transport)
+    const launchConfig = installSleepingCodexResumeState()
+    const deps = createDeps({
+      startup: { command: 'codex stale-startup' },
+      onPaneProcessDied: vi.fn()
+    })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(20)
+    callbacks[0]?.onData?.('too many consoles in use, max consoles is 128')
+    const onPtyExit = createdTransportOptions[0]?.onPtyExit as
+      | ((ptyId: string, exitCode?: number) => void)
+      | undefined
+    onPtyExit?.('resume-pty', 1)
+
+    expect(deps.onPaneProcessDied).toHaveBeenCalledWith({
+      paneId: 1,
+      exitCode: 1,
+      startup: expect.objectContaining({
+        command: expect.stringContaining("'resume' 'codex-session-1'"),
+        launchConfig,
+        resumeProviderSession: { key: 'session_id', id: 'codex-session-1' },
+        launchAgent: 'codex',
+        showSessionRestoredBanner: true
+      }),
+      reason: 'git-bash-console-capacity'
+    })
+  })
+
+  it('does not carry capacity detection into a cold-restore replacement', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const callbacks: ConnectCallbacks[] = []
+    let currentPtyId = 'lost-pty'
+    const transport = createMockTransport(currentPtyId)
+    transport.getPtyId.mockImplementation(() => currentPtyId)
+    transport.connect.mockImplementation(
+      async (options: { sessionId?: string; callbacks: ConnectCallbacks }) => {
+        callbacks.push(options.callbacks)
+        if (options.sessionId) {
+          options.callbacks.onData?.('too many consoles in use, max consoles is 128')
+          return { id: currentPtyId, sessionExpired: true }
+        }
+        currentPtyId = 'resume-pty'
+        return currentPtyId
+      }
+    )
+    transportFactoryQueue.push(transport)
+    installSleepingCodexResumeState('lost-pty')
+    const deps = createDeps({
+      onPaneProcessDied: vi.fn(),
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: 'lost-pty' }
+    })
+
+    connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(30)
+    expect(callbacks).toHaveLength(2)
+    const onPtyExit = createdTransportOptions[0]?.onPtyExit as
+      | ((ptyId: string, exitCode?: number) => void)
+      | undefined
+    onPtyExit?.('resume-pty', 1)
+
+    expect(deps.onPaneProcessDied).toHaveBeenCalledWith({
+      paneId: 1,
+      exitCode: 1,
+      startup: null,
+      reason: 'process-failed'
+    })
   })
 
   it('does not retain a failed direct-SSH terminal locally', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection-pty-exit-teardown.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-pty-exit-teardown.test.ts
@@ -388,6 +388,82 @@ describe('connectPanePty', () => {
     expect(manager.closePane).not.toHaveBeenCalled()
   })
 
+  it('keeps a failed local terminal visible after user input', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const pane = createPane(1)
+    const transport = createMockTransport('tab-pty')
+    transportFactoryQueue.push(transport)
+    const manager = createManager(1)
+    const deps = createDeps({ onPaneProcessDied: vi.fn() })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    const onPtyExit = createdTransportOptions[0]?.onPtyExit as
+      | ((ptyId: string, exitCode?: number) => void)
+      | undefined
+
+    sendTerminalInputThroughPane(pane, 'agent startup\r')
+    onPtyExit?.('tab-pty', 1)
+
+    expect(deps.onPaneProcessDied).toHaveBeenCalledWith({
+      paneId: 1,
+      exitCode: 1,
+      reason: 'process-failed'
+    })
+    expect(deps.onPtyExitRef.current).not.toHaveBeenCalled()
+    expect(manager.closePane).not.toHaveBeenCalled()
+  })
+
+  it('classifies the Git Bash capacity failure before retaining its pane', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    const transport = createMockTransport('tab-pty')
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'tab-pty'
+    })
+    transportFactoryQueue.push(transport)
+    const manager = createManager(1)
+    const deps = createDeps({ onPaneProcessDied: vi.fn() })
+
+    connectPanePty(createPane(1) as never, manager as never, deps as never)
+    const onPtyExit = createdTransportOptions[0]?.onPtyExit as
+      | ((ptyId: string, exitCode?: number) => void)
+      | undefined
+
+    capturedDataCallback.current?.(
+      'console device allocation failure - too many consoles in use, max consoles is 128'
+    )
+    onPtyExit?.('tab-pty', 1)
+
+    expect(deps.onPaneProcessDied).toHaveBeenCalledWith({
+      paneId: 1,
+      exitCode: 1,
+      reason: 'git-bash-console-capacity'
+    })
+    expect(deps.onPtyExitRef.current).not.toHaveBeenCalled()
+  })
+
+  it('does not retain a failed direct-SSH terminal locally', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    mockStoreState = {
+      ...mockStoreState,
+      repos: [{ ...mockStoreState.repos[0], connectionId: 'ssh-1' }]
+    } as StoreState
+    const transport = createMockTransport('tab-pty')
+    transportFactoryQueue.push(transport)
+    const manager = createManager(1)
+    const deps = createDeps({ onPaneProcessDied: vi.fn() })
+
+    connectPanePty(createPane(1) as never, manager as never, deps as never)
+    const onPtyExit = createdTransportOptions[0]?.onPtyExit as
+      | ((ptyId: string, exitCode?: number) => void)
+      | undefined
+    onPtyExit?.('tab-pty', 1)
+
+    expect(deps.onPaneProcessDied).not.toHaveBeenCalled()
+    expect(deps.onPtyExitRef.current).toHaveBeenCalledWith('tab-pty')
+  })
+
   it('tears down the sole terminal when a reattached (not freshly spawned) PTY exits', async () => {
     // Why: reattach/coldRestore skip onPtySpawn, so a now-dead previously-live session must still route through onPtyExitRef; the keep-mounted guard is only for brand-new shells.
     const { connectPanePty } = await import('./pty-connection')

--- a/src/renderer/src/components/terminal-pane/pty-connection-pty-exit-teardown.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-pty-exit-teardown.test.ts
@@ -407,9 +407,32 @@ describe('connectPanePty', () => {
     expect(deps.onPaneProcessDied).toHaveBeenCalledWith({
       paneId: 1,
       exitCode: 1,
+      startup: null,
       reason: 'process-failed'
     })
     expect(deps.onPtyExitRef.current).not.toHaveBeenCalled()
+    expect(manager.closePane).not.toHaveBeenCalled()
+  })
+
+  it('keeps a failed local split pane visible', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('tab-pty')
+    transportFactoryQueue.push(transport)
+    const manager = createManager(2)
+    const deps = createDeps({ onPaneProcessDied: vi.fn() })
+
+    connectPanePty(createPane(1) as never, manager as never, deps as never)
+    const onPtyExit = createdTransportOptions[0]?.onPtyExit as
+      | ((ptyId: string, exitCode?: number) => void)
+      | undefined
+    onPtyExit?.('tab-pty', 1)
+
+    expect(deps.onPaneProcessDied).toHaveBeenCalledWith({
+      paneId: 1,
+      exitCode: 1,
+      startup: null,
+      reason: 'process-failed'
+    })
     expect(manager.closePane).not.toHaveBeenCalled()
   })
 
@@ -423,7 +446,8 @@ describe('connectPanePty', () => {
     })
     transportFactoryQueue.push(transport)
     const manager = createManager(1)
-    const deps = createDeps({ onPaneProcessDied: vi.fn() })
+    const startup = { command: 'codex --resume session-1' }
+    const deps = createDeps({ onPaneProcessDied: vi.fn(), startup })
 
     connectPanePty(createPane(1) as never, manager as never, deps as never)
     const onPtyExit = createdTransportOptions[0]?.onPtyExit as
@@ -438,6 +462,7 @@ describe('connectPanePty', () => {
     expect(deps.onPaneProcessDied).toHaveBeenCalledWith({
       paneId: 1,
       exitCode: 1,
+      startup,
       reason: 'git-bash-console-capacity'
     })
     expect(deps.onPtyExitRef.current).not.toHaveBeenCalled()

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -17,42 +17,45 @@ import type { PtyTransportRecoveryState } from './pty-transport-types'
 import type { SessionOptionValue } from '../../../../shared/native-chat-session-options'
 import type { DirectSshPaneRetryAttemptId } from '@/store/slices/direct-ssh-terminal-recovery'
 
+export type PtyPaneStartup = {
+  command: string
+  /** Renderer-delivered startup input for callers that need xterm paste
+   *  semantics before the submit Enter. */
+  delivery?: 'terminal-paste'
+  startupCommandDelivery?: StartupCommandDelivery
+  env?: Record<string, string>
+  envToDelete?: string[]
+  launchConfig?: SleepingAgentLaunchConfig
+  resumeProviderSession?: AgentProviderSessionMetadata
+  launchToken?: string
+  launchAgent?: TuiAgent
+  /** Explicit CLI override for host-owned agent launches; omission uses host settings. */
+  agentArgsOverride?: string | null
+  draftPrompt?: string
+  sessionOptions?: Record<string, SessionOptionValue>
+  /** Telemetry payload for `agent_started`. Forwarded to `pty:spawn`
+   *  so main fires the event only after the spawn succeeds. */
+  telemetry?: EventProps<'agent_started'>
+  /** Initial prompt-start status for agents that lack native prompt hooks. */
+  initialAgentStatus?: { agent: TuiAgent; prompt: string }
+  /** Show the restored-session banner when this startup command mounts. */
+  showSessionRestoredBanner?: boolean
+  /** Initial startup may be paired with a setup split that changes its grid. */
+  waitForSetupSplitDirection?: SetupSplitDirection
+} | null
+
 export type PaneProcessExit = {
   paneId: number
   exitCode: number
   reason: 'git-bash-console-capacity' | 'process-failed'
+  startup: PtyPaneStartup
 }
 
 export type PtyConnectionDeps = {
   tabId: string
   worktreeId: string
   cwd?: string
-  startup?: {
-    command: string
-    /** Renderer-delivered startup input for callers that need xterm paste
-     *  semantics before the submit Enter. */
-    delivery?: 'terminal-paste'
-    startupCommandDelivery?: StartupCommandDelivery
-    env?: Record<string, string>
-    envToDelete?: string[]
-    launchConfig?: SleepingAgentLaunchConfig
-    resumeProviderSession?: AgentProviderSessionMetadata
-    launchToken?: string
-    launchAgent?: TuiAgent
-    /** Explicit CLI override for host-owned agent launches; omission uses host settings. */
-    agentArgsOverride?: string | null
-    draftPrompt?: string
-    sessionOptions?: Record<string, SessionOptionValue>
-    /** Telemetry payload for `agent_started`. Forwarded to `pty:spawn`
-     *  so main fires the event only after the spawn succeeds. */
-    telemetry?: EventProps<'agent_started'>
-    /** Initial prompt-start status for agents that lack native prompt hooks. */
-    initialAgentStatus?: { agent: TuiAgent; prompt: string }
-    /** Show the restored-session banner when this startup command mounts. */
-    showSessionRestoredBanner?: boolean
-    /** Initial startup may be paired with a setup split that changes its grid. */
-    waitForSetupSplitDirection?: SetupSplitDirection
-  } | null
+  startup?: PtyPaneStartup
   restoredLeafId?: string | null
   restoredPtyIdByLeafId?: Record<string, string>
   /** Park intent sampled at render time, before the host disposes the tab's

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -17,6 +17,12 @@ import type { PtyTransportRecoveryState } from './pty-transport-types'
 import type { SessionOptionValue } from '../../../../shared/native-chat-session-options'
 import type { DirectSshPaneRetryAttemptId } from '@/store/slices/direct-ssh-terminal-recovery'
 
+export type PaneProcessExit = {
+  paneId: number
+  exitCode: number
+  reason: 'git-bash-console-capacity' | 'process-failed'
+}
+
 export type PtyConnectionDeps = {
   tabId: string
   worktreeId: string
@@ -66,6 +72,7 @@ export type PtyConnectionDeps = {
   onPtyExitRef: React.RefObject<(ptyId: string) => void>
   onAgentExitedRef: React.RefObject<(leafId: string) => void>
   onPtyErrorRef?: React.RefObject<(paneId: number, message: string) => void>
+  onPaneProcessDied?: (processExit: PaneProcessExit) => void
   onPtyRecoveryStateRef?: React.RefObject<
     (paneId: number, state: PtyTransportRecoveryState | null) => void
   >

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -59,8 +59,11 @@ import {
   shouldReconcileMissingSession,
   type HasPty
 } from './terminal-dead-session-reconcile'
-import type { PtyConnectionDeps } from './pty-connection-types'
-import { createGitBashConsoleCapacityDetector } from './git-bash-console-capacity'
+import type { PtyConnectionDeps, PtyPaneStartup } from './pty-connection-types'
+import {
+  createGitBashConsoleCapacityDetector,
+  type GitBashConsoleCapacityDetector
+} from './git-bash-console-capacity'
 import type { SessionRestoredBannerReason } from './session-restored-banner-pane-state'
 import {
   consumeCommittedPtyShutdownExit,
@@ -2686,6 +2689,7 @@ export function connectPanePty(
       // Why: an old transport can deliver a late exit after this pane has
       // rebound to a replacement PTY; only clear ownership for the exited id.
       handledExitPtyId = ptyId
+      processExitStateByPtyId.delete(ptyId)
       if (!preserveRendererBinding) {
         deps.clearTabPtyId(deps.tabId, ptyId)
       }
@@ -2694,6 +2698,8 @@ export function connectPanePty(
       return
     }
     handledExitPtyId = ptyId
+    const processExitState = processExitStateByPtyId.get(ptyId) ?? currentProcessExitState
+    processExitStateByPtyId.delete(ptyId)
     agentCompletionCoordinator.dispose()
     dropSideEffectFactConsumer()
     // Why: main clears gate state on PTY exit too; this only resets the
@@ -2772,11 +2778,11 @@ export function connectPanePty(
     manager.setPaneGpuRendering(pane.id, true)
     const failedLocalProcess = !connectionId && runtimeEnvironmentId === null && exitCode !== 0
     if (failedLocalProcess && deps.onPaneProcessDied) {
-      const gitBashConsoleCapacityFailure = gitBashConsoleCapacityDetector.detected()
+      const gitBashConsoleCapacityFailure = processExitState.detector.detected()
       deps.onPaneProcessDied({
         paneId: pane.id,
         exitCode,
-        startup: gitBashConsoleCapacityFailure ? paneStartup : null,
+        startup: gitBashConsoleCapacityFailure ? processExitState.startup : null,
         reason: gitBashConsoleCapacityFailure ? 'git-bash-console-capacity' : 'process-failed'
       })
       return
@@ -3046,6 +3052,25 @@ export function connectPanePty(
   }
 
   const observeTerminalGitHubPRLink = createTerminalGitHubPRLinkDetector()
+  type ProcessExitState = {
+    startup: PtyPaneStartup
+    detector: GitBashConsoleCapacityDetector
+  }
+  const createProcessExitState = (startup: PtyPaneStartup): ProcessExitState => ({
+    startup,
+    detector: createGitBashConsoleCapacityDetector()
+  })
+  let currentProcessExitState = createProcessExitState(paneStartup)
+  const processExitStateByPtyId = new Map<string, ProcessExitState>()
+  const bindProcessExitState = (ptyId: string, replacedPtyId?: string): void => {
+    const state =
+      (replacedPtyId ? processExitStateByPtyId.get(replacedPtyId) : undefined) ??
+      currentProcessExitState
+    processExitStateByPtyId.set(ptyId, state)
+    if (replacedPtyId && replacedPtyId !== ptyId) {
+      processExitStateByPtyId.delete(replacedPtyId)
+    }
+  }
   const reportPanePtyVisibility = (ptyId: string | null | undefined, visible: boolean): void => {
     if (!ptyId || isRemoteRuntimePtyId(ptyId)) {
       // Why: remote-runtime PTYs use a relay path outside main's local
@@ -3063,6 +3088,7 @@ export function connectPanePty(
       sampleVisibleForegroundAgent?: boolean
     } = {}
   ): void => {
+    bindProcessExitState(ptyId, options.replacePtyId)
     if (activePanePtyBinding && activePanePtyBinding !== ptyId) {
       reportPanePtyVisibility(activePanePtyBinding, false)
     }
@@ -3876,7 +3902,6 @@ export function connectPanePty(
   // Captured shortcuts must open the redraw window without arming that teardown.
   let lastInteractiveRedrawInputAt = Number.NEGATIVE_INFINITY
   let hasReceivedPtyOutput = false
-  const gitBashConsoleCapacityDetector = createGitBashConsoleCapacityDetector()
   let deferredReattachLiveData: DeferredReattachLiveDataQueue | null = null
   let reattachLiveDataDeferralDepth = 0
   let deferredReattachLiveDataOwners = new Map<number, { failed: boolean }>()
@@ -5222,6 +5247,20 @@ export function connectPanePty(
               : {})
           }
         : undefined
+    const toProcessExitStartup = (
+      startup: PendingStartupCommand | ColdRestoreAgentResumeStartup | null
+    ): PtyPaneStartup =>
+      startup && 'launchConfig' in startup && 'agent' in startup
+        ? {
+            command: startup.command,
+            env: startup.env,
+            launchConfig: startup.launchConfig,
+            resumeProviderSession: startup.resumeProviderSession,
+            launchToken: startup.launchToken,
+            launchAgent: startup.agent,
+            showSessionRestoredBanner: true
+          }
+        : startup
     const startFreshColdRestoreAgentResume = (
       startup: ColdRestoreAgentResumeStartup | null = buildColdRestoreAgentResumeStartup(),
       options: FreshSpawnOptions = {}
@@ -5385,7 +5424,11 @@ export function connectPanePty(
         : window.api.pty.declarePendingPaneSerializer(cacheKey).catch(() => null)
 
       transportConnectInFlightSince = Date.now()
-      const outputCallbacks = captureTransportOutputCallbacks(reportError)
+      const effectiveStartup = startupOverride === undefined ? paneStartup : startupOverride
+      const outputCallbacks = captureTransportOutputCallbacks(
+        reportError,
+        toProcessExitStartup(coldRestoreOverride ?? effectiveStartup)
+      )
       const spawnedRaw = transport.connect({
         url: '',
         cols,
@@ -5890,7 +5933,10 @@ export function connectPanePty(
       scheduleReplayDataDrain()
     }
 
-    const captureTransportOutputCallbacks = (onError: (message: string) => void) => {
+    const captureTransportOutputCallbacks = (
+      onError: (message: string) => void,
+      startup: PtyPaneStartup
+    ) => {
       // Why: a new stream generation cannot inherit an old replay's pending
       // destination-grid fit or keep its live-data waiter open.
       pendingHiddenSnapshotFit?.cancel()
@@ -5898,6 +5944,8 @@ export function connectPanePty(
       pendingReattachFit?.cancel()
       pendingReattachFit = null
       const generation = (transportStreamGeneration += 1)
+      const processExitState = createProcessExitState(startup)
+      currentProcessExitState = processExitState
       const isCurrent = (): boolean => !disposed && generation === transportStreamGeneration
       return {
         generation,
@@ -5924,6 +5972,7 @@ export function connectPanePty(
           },
           onData: (data: string, meta?: PtyDataMeta): void => {
             if (isCurrent()) {
+              processExitState.detector.observe(data)
               dataCallback(data, meta, generation)
             }
           },
@@ -7864,7 +7913,6 @@ export function connectPanePty(
       if (streamGeneration !== transportStreamGeneration) {
         return
       }
-      gitBashConsoleCapacityDetector.observe(data)
       if (deferredReattachLiveData !== null) {
         const ackCredit = takeCurrentTerminalDeliveryCredit()
         deferredReattachLiveData.enqueue({
@@ -8330,6 +8378,7 @@ export function connectPanePty(
         })
         return false
       }
+      bindProcessExitState(ptyId)
       setPanePtyFitBinding(ptyId)
       reportPanePtyVisibility(ptyId, deps.isVisibleRef.current)
       registerSideEffectFactConsumerForPty(ptyId)
@@ -8740,7 +8789,7 @@ export function connectPanePty(
         authoritativeReattachGeneration += 1
         clearPaneMode2031State()
         clearHiddenOutputRestoreState()
-        const outputCallbacks = captureTransportOutputCallbacks(reportError)
+        const outputCallbacks = captureTransportOutputCallbacks(reportError, null)
         transport.attach({
           existingPtyId: ptyId,
           callbacks: outputCallbacks.callbacks
@@ -8923,16 +8972,19 @@ export function connectPanePty(
             const coldRestoreStartup = buildColdRestoreAgentResumeStartup()
             clearPaneMode2031State()
             clearHiddenOutputRestoreState()
-            const outputCallbacks = captureTransportOutputCallbacks((message) => {
-              if (isSshSessionExpiredError(message)) {
-                expiredReattachError = true
-                return
-              }
-              if (!isCapturedDirectSshReattachCurrent(pendingSessionId)) {
-                return
-              }
-              reportError(message)
-            })
+            const outputCallbacks = captureTransportOutputCallbacks(
+              (message) => {
+                if (isSshSessionExpiredError(message)) {
+                  expiredReattachError = true
+                  return
+                }
+                if (!isCapturedDirectSshReattachCurrent(pendingSessionId)) {
+                  return
+                }
+                reportError(message)
+              },
+              toProcessExitStartup(coldRestoreStartup ?? paneStartup)
+            )
             beginReattachLiveDataDeferral(outputCallbacks.generation)
             transportConnectInFlightSince = Date.now()
             const reattachPromise = transport.connect({
@@ -9170,16 +9222,19 @@ export function connectPanePty(
 
       let expiredReattachError = false
       const coldRestoreStartup = buildColdRestoreAgentResumeStartup()
-      const outputCallbacks = captureTransportOutputCallbacks((message) => {
-        if (isSshSessionExpiredError(message)) {
-          expiredReattachError = true
-          return
-        }
-        if (!isCapturedDirectSshReattachCurrent(deferredReattachSessionId)) {
-          return
-        }
-        reportError(message)
-      })
+      const outputCallbacks = captureTransportOutputCallbacks(
+        (message) => {
+          if (isSshSessionExpiredError(message)) {
+            expiredReattachError = true
+            return
+          }
+          if (!isCapturedDirectSshReattachCurrent(deferredReattachSessionId)) {
+            return
+          }
+          reportError(message)
+        },
+        toProcessExitStartup(coldRestoreStartup ?? paneStartup)
+      )
       beginReattachLiveDataDeferral(outputCallbacks.generation)
       transportConnectInFlightSince = Date.now()
       const reattachPromise = transport.connect({
@@ -9321,7 +9376,7 @@ export function connectPanePty(
         try {
           clearPaneMode2031State()
           clearHiddenOutputRestoreState()
-          const outputCallbacks = captureTransportOutputCallbacks(reportError)
+          const outputCallbacks = captureTransportOutputCallbacks(reportError, null)
           transport.attach({
             existingPtyId: attachPtyId,
             cols,
@@ -9376,7 +9431,7 @@ export function connectPanePty(
             }
             clearPaneMode2031State()
             clearHiddenOutputRestoreState()
-            const outputCallbacks = captureTransportOutputCallbacks(reportError)
+            const outputCallbacks = captureTransportOutputCallbacks(reportError, null)
             transport.attach({
               existingPtyId: spawnedPtyId,
               cols,

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2770,19 +2770,19 @@ export function connectPanePty(
       return
     }
     manager.setPaneGpuRendering(pane.id, true)
+    const failedLocalProcess = !connectionId && runtimeEnvironmentId === null && exitCode !== 0
+    if (failedLocalProcess && deps.onPaneProcessDied) {
+      const gitBashConsoleCapacityFailure = gitBashConsoleCapacityDetector.detected()
+      deps.onPaneProcessDied({
+        paneId: pane.id,
+        exitCode,
+        startup: gitBashConsoleCapacityFailure ? paneStartup : null,
+        reason: gitBashConsoleCapacityFailure ? 'git-bash-console-capacity' : 'process-failed'
+      })
+      return
+    }
     const panes = manager.getPanes()
     if (panes.length <= 1) {
-      const failedLocalProcess = !connectionId && runtimeEnvironmentId === null && exitCode !== 0
-      if (failedLocalProcess) {
-        deps.onPaneProcessDied?.({
-          paneId: pane.id,
-          exitCode,
-          reason: gitBashConsoleCapacityDetector.detected()
-            ? 'git-bash-console-capacity'
-            : 'process-failed'
-        })
-        return
-      }
       // Why: a worktree's sole newborn terminal can die on shell startup — e.g.
       // a PR branch ships an .envrc whose direnv command fails, so the login
       // shell exits non-zero immediately. Routing that through onPtyExitRef
@@ -9433,7 +9433,7 @@ export function connectPanePty(
     ) {
       return
     }
-    onExit(currentPtyId, 1)
+    onExit(currentPtyId)
   }
 
   const reconcileIfSessionMissing = (
@@ -9477,7 +9477,7 @@ export function connectPanePty(
         ) {
           return
         }
-        onExit(currentPtyId, 1)
+        onExit(currentPtyId)
       })
       .catch(() => {})
   }

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -60,6 +60,7 @@ import {
   type HasPty
 } from './terminal-dead-session-reconcile'
 import type { PtyConnectionDeps } from './pty-connection-types'
+import { createGitBashConsoleCapacityDetector } from './git-bash-console-capacity'
 import type { SessionRestoredBannerReason } from './session-restored-banner-pane-state'
 import {
   consumeCommittedPtyShutdownExit,
@@ -2659,7 +2660,11 @@ export function connectPanePty(
       })
     return claimKey
   }
-  const onExit = (ptyId: string, opts: { preserveRendererBinding?: boolean } = {}): void => {
+  const onExit = (
+    ptyId: string,
+    exitCode = 0,
+    opts: { preserveRendererBinding?: boolean } = {}
+  ): void => {
     if (handledExitPtyId === ptyId) {
       return
     }
@@ -2667,7 +2672,7 @@ export function connectPanePty(
       // Why: the transport emits exit once; replay it only after a verified commit so rollback keeps renderer state retryable.
       deferPtyShutdownExit(ptyId, (settlement) => {
         if (settlement === 'committed') {
-          onExit(ptyId, { preserveRendererBinding: true })
+          onExit(ptyId, exitCode, { preserveRendererBinding: true })
         }
       })
       return
@@ -2767,6 +2772,17 @@ export function connectPanePty(
     manager.setPaneGpuRendering(pane.id, true)
     const panes = manager.getPanes()
     if (panes.length <= 1) {
+      const failedLocalProcess = !connectionId && runtimeEnvironmentId === null && exitCode !== 0
+      if (failedLocalProcess) {
+        deps.onPaneProcessDied?.({
+          paneId: pane.id,
+          exitCode,
+          reason: gitBashConsoleCapacityDetector.detected()
+            ? 'git-bash-console-capacity'
+            : 'process-failed'
+        })
+        return
+      }
       // Why: a worktree's sole newborn terminal can die on shell startup — e.g.
       // a PR branch ships an .envrc whose direnv command fails, so the login
       // shell exits non-zero immediately. Routing that through onPtyExitRef
@@ -3860,6 +3876,7 @@ export function connectPanePty(
   // Captured shortcuts must open the redraw window without arming that teardown.
   let lastInteractiveRedrawInputAt = Number.NEGATIVE_INFINITY
   let hasReceivedPtyOutput = false
+  const gitBashConsoleCapacityDetector = createGitBashConsoleCapacityDetector()
   let deferredReattachLiveData: DeferredReattachLiveDataQueue | null = null
   let reattachLiveDataDeferralDepth = 0
   let deferredReattachLiveDataOwners = new Map<number, { failed: boolean }>()
@@ -7847,6 +7864,7 @@ export function connectPanePty(
       if (streamGeneration !== transportStreamGeneration) {
         return
       }
+      gitBashConsoleCapacityDetector.observe(data)
       if (deferredReattachLiveData !== null) {
         const ackCredit = takeCurrentTerminalDeliveryCredit()
         deferredReattachLiveData.enqueue({
@@ -9415,7 +9433,7 @@ export function connectPanePty(
     ) {
       return
     }
-    onExit(currentPtyId)
+    onExit(currentPtyId, 1)
   }
 
   const reconcileIfSessionMissing = (
@@ -9459,7 +9477,7 @@ export function connectPanePty(
         ) {
           return
         }
-        onExit(currentPtyId)
+        onExit(currentPtyId, 1)
       })
       .catch(() => {})
   }

--- a/src/renderer/src/components/terminal-pane/pty-transport-detach-attach-handoff.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-detach-attach-handoff.test.ts
@@ -165,7 +165,7 @@ describe('createIpcPtyTransport', () => {
 
     onExit?.({ id: 'pty-detached', code: 0 })
 
-    expect(onPtyExit).toHaveBeenCalledWith('pty-detached')
+    expect(onPtyExit).toHaveBeenCalledWith('pty-detached', 0)
     expect(transport.getPtyId()).toBeNull()
   })
 

--- a/src/renderer/src/components/terminal-pane/pty-transport-handler-suspension.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-handler-suspension.test.ts
@@ -54,7 +54,7 @@ describe('createIpcPtyTransport', () => {
 
     onExit?.({ id: 'pty-new', code: 0 })
 
-    expect(onPtyExit).toHaveBeenCalledWith('pty-new')
+    expect(onPtyExit).toHaveBeenCalledWith('pty-new', 0)
     expect(transport.getPtyId()).toBeNull()
     expect(transport.isConnected()).toBe(false)
   })
@@ -127,7 +127,7 @@ describe('createIpcPtyTransport', () => {
 
     // Exit handler should still work (exit handlers are kept alive)
     onExit?.({ id: 'pty-1', code: -1 })
-    expect(onPtyExit).toHaveBeenCalledWith('pty-1')
+    expect(onPtyExit).toHaveBeenCalledWith('pty-1', -1)
   })
 
   it('marks a host reversible-stop exit before delivering it to the pane', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-transport-reattach-admission.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-reattach-admission.test.ts
@@ -254,7 +254,7 @@ describe('createIpcPtyTransport', () => {
     expect(onDataCallback).toHaveBeenCalledWith('final output')
     expect(onExitCallback).toHaveBeenCalledWith(17)
     expect(onDisconnect).toHaveBeenCalledTimes(1)
-    expect(onPtyExit).toHaveBeenCalledWith(sessionId)
+    expect(onPtyExit).toHaveBeenCalledWith(sessionId, 17)
     expect(transport.isConnected()).toBe(false)
   })
 

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -245,7 +245,7 @@ export type IpcPtyTransportOptions = {
   projectRuntime?: ProjectExecutionRuntimeResolution
   terminalColorQueryReplies?: TerminalOscColorQueryReplyColors
   telemetry?: EventProps<'agent_started'>
-  onPtyExit?: (ptyId: string) => void
+  onPtyExit?: (ptyId: string, exitCode?: number) => void
   onTitleChange?: (title: string, rawTitle: string) => void
   onPtySpawn?: (ptyId: string) => void
   /** Rebind an existing pane after its provider replaces the PTY identity. */

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -756,7 +756,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       unregisterPtyHandlers(id)
       storedCallbacks.onExit?.(code)
       storedCallbacks.onDisconnect?.()
-      onPtyExit?.(id)
+      onPtyExit?.(id, code)
     }
     ptyExitHandlers.set(id, exitHandler)
     ownedExitHandlers.set(id, exitHandler)

--- a/src/renderer/src/components/terminal-pane/terminal-process-exit-restart.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-process-exit-restart.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { resolveTerminalProcessExitRestartStartup } from './terminal-process-exit-restart'
+
+describe('terminal process exit restart', () => {
+  it('retries the original startup after a Git Bash capacity failure', () => {
+    const startup = { command: 'codex --resume session-1' }
+
+    expect(
+      resolveTerminalProcessExitRestartStartup({
+        paneId: 1,
+        exitCode: 1,
+        reason: 'git-bash-console-capacity',
+        startup
+      })
+    ).toBe(startup)
+  })
+
+  it('restarts a shell when a capacity failure had no startup request', () => {
+    expect(
+      resolveTerminalProcessExitRestartStartup({
+        paneId: 1,
+        exitCode: 1,
+        reason: 'git-bash-console-capacity',
+        startup: null
+      })
+    ).toBeNull()
+  })
+
+  it('restarts other process failures as a shell', () => {
+    expect(
+      resolveTerminalProcessExitRestartStartup({
+        paneId: 1,
+        exitCode: 7,
+        reason: 'process-failed',
+        startup: { command: 'codex' }
+      })
+    ).toBeNull()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-process-exit-restart.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-process-exit-restart.ts
@@ -1,0 +1,7 @@
+import type { PaneProcessExit, PtyPaneStartup } from './pty-connection-types'
+
+export function resolveTerminalProcessExitRestartStartup(
+  processExit: PaneProcessExit
+): PtyPaneStartup {
+  return processExit.reason === 'git-bash-console-capacity' ? processExit.startup : null
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -26,6 +26,7 @@ import { buildTerminalKeyboardProtocolOptions } from '@/lib/pane-manager/termina
 import { resolvePaneKeyboardProtocolAgent } from './terminal-keyboard-protocol-pane-agent'
 import { useAppStore } from '@/store'
 import type { DirectSshPaneRetryAttemptId } from '@/store/slices/direct-ssh-terminal-recovery'
+import type { PaneProcessExit } from './pty-connection-types'
 import {
   createFilePathLinkProvider,
   getTerminalFileOpenHint,
@@ -292,6 +293,7 @@ type UseTerminalPaneLifecycleDeps = {
   onPtyExitRef: React.RefObject<(ptyId: string) => void>
   onAgentExitedRef: React.RefObject<(leafId: string) => void>
   onPtyErrorRef?: React.RefObject<(paneId: number, message: string) => void>
+  onPaneProcessDied?: (processExit: PaneProcessExit) => void
   onPtyRecoveryStateRef?: React.RefObject<
     (paneId: number, state: PtyTransportRecoveryState | null) => void
   >
@@ -698,6 +700,7 @@ export function useTerminalPaneLifecycle({
   onPtyExitRef,
   onAgentExitedRef,
   onPtyErrorRef,
+  onPaneProcessDied,
   onPtyRecoveryStateRef,
   clearTabPtyId,
   consumeSuppressedPtyExit,
@@ -940,6 +943,7 @@ export function useTerminalPaneLifecycle({
       onPtyExitRef,
       onAgentExitedRef,
       onPtyErrorRef,
+      onPaneProcessDied,
       onPtyRecoveryStateRef,
       clearTabPtyId,
       consumeSuppressedPtyExit,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2934,6 +2934,14 @@
             "e16012e31e": "The terminal daemon that owned this session exited, so the session and its scrollback could not be recovered. Open a new terminal to continue.",
             "sessionUnavailable": "Orca couldn't reattach to this pane's terminal session on the host. Open a new terminal to continue."
           },
+          "TerminalProcessExitOverlay": {
+            "capacityTitle": "Git Bash console limit reached",
+            "capacityDetail": "Git Bash reached its 128-console limit. Close unused Git Bash terminals, then restart this terminal.",
+            "failedTitle": "Terminal exited",
+            "failedDetail": "The shell process ended with exit code {{code}}. Its output is preserved.",
+            "close": "Close",
+            "restart": "Restart"
+          },
           "TerminalPane": {
             "ac112e9036": "Remove title",
             "f984ab2a30": "Remove pane title: {{value0}}",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -2740,6 +2740,14 @@
             "5c8ce20be6": "Si esto persiste, por favor",
             "cc6d997c65": "Reinicia el servicio del terminal desde aquí para borrar el estado obsoleto."
           },
+          "TerminalProcessExitOverlay": {
+            "capacityTitle": "Se alcanzó el límite de consolas de Git Bash",
+            "capacityDetail": "Git Bash alcanzó su límite de 128 consolas. Cierra las terminales de Git Bash que no uses y reinicia esta terminal.",
+            "failedTitle": "La terminal se cerró",
+            "failedDetail": "El proceso del shell terminó con el código de salida {{code}}. Se conservó su salida.",
+            "close": "Cerrar",
+            "restart": "Reiniciar"
+          },
           "TerminalPane": {
             "ac112e9036": "Quitar título",
             "f984ab2a30": "Eliminar título del panel: {{value0}}",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -2740,6 +2740,14 @@
             "5c8ce20be6": "この状態が続く場合は、",
             "cc6d997c65": "ここからターミナルデーモンを再起動して、古いデーモン状態をクリアします。"
           },
+          "TerminalProcessExitOverlay": {
+            "capacityTitle": "Git Bash のコンソール上限に達しました",
+            "capacityDetail": "Git Bash が 128 個のコンソール上限に達しました。不要な Git Bash ターミナルを閉じてから、このターミナルを再起動してください。",
+            "failedTitle": "ターミナルが終了しました",
+            "failedDetail": "シェルプロセスが終了コード {{code}} で終了しました。出力は保持されています。",
+            "close": "閉じる",
+            "restart": "再起動"
+          },
           "TerminalPane": {
             "ac112e9036": "タイトルを削除",
             "f984ab2a30": "ペインのタイトルを削除: {{value0}}",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -2742,6 +2742,14 @@
             "5c8ce20be6": "문제가 계속되면",
             "cc6d997c65": "오래된 데몬 상태를 지우려면 여기에서 terminal 데몬을 다시 시작하세요."
           },
+          "TerminalProcessExitOverlay": {
+            "capacityTitle": "Git Bash 콘솔 한도에 도달했습니다",
+            "capacityDetail": "Git Bash가 128개 콘솔 한도에 도달했습니다. 사용하지 않는 Git Bash 터미널을 닫은 후 이 터미널을 다시 시작하세요.",
+            "failedTitle": "터미널이 종료되었습니다",
+            "failedDetail": "셸 프로세스가 종료 코드 {{code}}로 끝났습니다. 출력은 보존됩니다.",
+            "close": "닫기",
+            "restart": "다시 시작"
+          },
           "TerminalPane": {
             "ac112e9036": "제목 삭제",
             "f984ab2a30": "창 제목 제거: {{value0}}",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -2752,6 +2752,14 @@
             "5c8ce20be6": "如果这种情况持续存在，请",
             "cc6d997c65": "从此处重新启动终端守护进程以清除失效的守护进程状态。"
           },
+          "TerminalProcessExitOverlay": {
+            "capacityTitle": "已达到 Git Bash 控制台上限",
+            "capacityDetail": "Git Bash 已达到 128 个控制台的上限。关闭未使用的 Git Bash 终端，然后重新启动此终端。",
+            "failedTitle": "终端已退出",
+            "failedDetail": "Shell 进程以退出代码 {{code}} 结束。输出已保留。",
+            "close": "关闭",
+            "restart": "重新启动"
+          },
           "TerminalPane": {
             "ac112e9036": "删除标题",
             "f984ab2a30": "删除窗格标题：{{value0}}",


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​321 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​317 |
| Prod | 14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​340 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​58 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​282 |

<!-- /orca-pr-loc -->

## ELI5

When Git Bash cannot allocate another console, Orca now keeps the failed terminal and its error on screen. The user can close unused terminals, then restart the failed pane in place.

## What Changed

- Propagate real PTY exit codes into pane lifecycle handling.
- Preserve failed local terminal panes—including split panes—and their scrollback.
- Detect Git Bash's exact 128-console MSYS failure across PTY chunks.
- Show localized Restart / Close recovery actions.
- Retry capacity failures with the original startup request, including coding agents; restart other failures as a shell.
- Track failures per pane so simultaneous split-pane failures remain independently recoverable.
- Keep clean exits and SSH/remote teardown behavior unchanged.

## Why

Git for Windows hardcodes `MAX_CONS_DEV` to 128 in its MSYS2 runtime. This is not a Windows ConPTY, CPU, or RAM limit and Orca cannot safely tune it per user. Raising it requires a forked `msys-2.0.dll`, with shared-runtime layout and Git-for-Windows update compatibility risk. Preserving the failure and providing recovery is the safe product behavior.

## Linked Issue

[STA-4903](https://linear.app/stably/issue/STA-4903)

## Visual Proof

Prior behavior: the failed terminal disappeared immediately, so there was no durable failure state to capture.

Failure retained with recovery actions:

![Failed terminal retained with Restart and Close actions](https://github.com/user-attachments/assets/cff52997-a6bf-4985-9cde-443188042b47)

After in-place restart and a successful `echo ORCA_RESTART_OK`:

![Terminal working after in-place restart](https://github.com/user-attachments/assets/afb8af06-909a-41a7-aa29-133b57be74fd)

## Testing

- [x] Manually tested on Windows through Electron/CDP: `exit 7` retained output, Restart spawned a working shell in place, and `ORCA_RESTART_OK` rendered.
- [x] Automated coverage added for chunked capacity detection, sole and split-pane failure retention, exit-code propagation, overlay actions, startup selection, clean exits, and SSH behavior.
- [x] 75 focused tests pass locally.
- [x] Full `pnpm typecheck` and `pnpm build` pass locally.
- [x] `pnpm run typecheck:web`, max-lines, localization, and direct normal/type-aware/React Doctor Oxlint scans pass.
- [x] Cross-platform CI covers the broader suite; any failures will be resolved before merge.

## AI Disclosure

## Review

Please focus on local-vs-remote exit ownership, split-pane recovery, and original startup preservation.

## Agent skill upstream boundary

- [x] Not applicable; this change contains no skill-installer or upstream skill content.

## Notes

- Renderer-local behavior only; no RPC params, stream frames, opcodes, or host-published wire content changed.
- No new filesystem, command-construction, credential, or network surface.
- Local cleanup closed 24 stale/orphaned Orca Git Bash sessions through lifecycle APIs: `OpenConsole.exe` dropped from 133 to 109 (112 after validation spawned three consoles). No worktrees or files were removed.
- `pnpm run check:code-quality:changed` hits the repository's Windows wrapper bug `spawnSync pnpm.cmd EINVAL`; its three underlying Oxlint scans pass directly.

## Checklist

- [x] This PR is small and focused.
- [x] I explained what changed and why, including ELI5.
- [x] Before/after interaction proof is attached.
- [x] Self-reviewed for correctness, security, performance, and concurrent split-pane failures.
- [x] Cross-platform, SSH/remote, folder-workspace, and backwards-compatibility impact considered.
- [x] Local focused tests and typecheck pass; full lint/test/package gates are covered by CI and must be green before merge.