### PR TITLE
fix(secrets): probe the Linux-only storage backend defensively

### DIFF
--- a/src/main/host/electron-secret-store.test.ts
+++ b/src/main/host/electron-secret-store.test.ts
@@ -63,6 +63,43 @@ describe('ElectronSecretStore', () => {
       expect(safeStorageMock.getSelectedStorageBackend).not.toHaveBeenCalled()
     })
 
+    it('does not throw when the Linux-only backend probe is absent', () => {
+      // Why this test exists: getSelectedStorageBackend is @platform linux, so it is
+      // genuinely undefined on macOS and Windows — verified against Electron 43. Every
+      // other test here mocks safeStorage with the method present, so without this the
+      // suite could stay green while the shipped app threw at startup.
+      //
+      // Why delete the key rather than re-mock: the module already holds this object, so
+      // a later vi.doMock is inert and the test would pass against unguarded code.
+      const probe = safeStorageMock.getSelectedStorageBackend
+      // @ts-expect-error deleting a required member is the condition under test
+      delete safeStorageMock.getSelectedStorageBackend
+      try {
+        withPlatform('linux', () => {
+          expect(() => new ElectronSecretStore().describeProtectionGap()).not.toThrow()
+          expect(new ElectronSecretStore().describeProtectionGap()).toBeNull()
+        })
+      } finally {
+        safeStorageMock.getSelectedStorageBackend = probe
+      }
+    })
+
+    it('reports no gap when the backend probe throws', () => {
+      safeStorageMock.getSelectedStorageBackend.mockImplementation(() => {
+        throw new Error('backend unavailable')
+      })
+      withPlatform('linux', () => {
+        expect(new ElectronSecretStore().describeProtectionGap()).toBeNull()
+      })
+    })
+
+    it('reports no gap for an unknown backend rather than guessing', () => {
+      safeStorageMock.getSelectedStorageBackend.mockReturnValue('unknown')
+      withPlatform('linux', () => {
+        expect(new ElectronSecretStore().describeProtectionGap()).toBeNull()
+      })
+    })
+
     it('reports the missing-keyring gap before considering the backend', () => {
       safeStorageMock.isEncryptionAvailable.mockReturnValue(false)
       withPlatform('linux', () => {

--- a/src/main/host/electron-secret-store.ts
+++ b/src/main/host/electron-secret-store.ts
@@ -31,9 +31,38 @@ export class ElectronSecretStore implements SecretStore {
     // It round-trips, so sealing and unsealing genuinely work and must keep working —
     // reporting it unavailable would strand every credential already stored this way.
     // But it protects nothing, and reporting it as sealed is the actual lie.
-    if (process.platform === 'linux' && safeStorage.getSelectedStorageBackend() === 'basic_text') {
-      return 'Secrets are obfuscated with a built-in key, not protected by the OS keyring. Install and unlock gnome-keyring or kwallet, then restart Orca, to seal them properly.'
-    }
+    return describeLinuxBackendGap()
+  }
+}
+
+/**
+ * Why probed rather than called directly: `getSelectedStorageBackend` is `@platform
+ * linux`, so it is genuinely absent on macOS and Windows — reading it unguarded is a
+ * TypeError, and the type declaration does not say so. Tests that mock `safeStorage`
+ * supply the method, so a mocked suite cannot catch that; this keeps the runtime honest
+ * regardless of platform or Electron version.
+ *
+ * Returns null when the backend is unknown or unreadable: claiming a gap we cannot
+ * prove would be its own kind of lie, and the caller has already established that
+ * sealing works.
+ */
+function describeLinuxBackendGap(): string | null {
+  if (process.platform !== 'linux') {
     return null
   }
+  const probe = (safeStorage as Partial<typeof safeStorage>).getSelectedStorageBackend
+  if (typeof probe !== 'function') {
+    return null
+  }
+  let backend: string
+  try {
+    backend = probe.call(safeStorage)
+  } catch {
+    return null
+  }
+  // Why only basic_text: it "encrypts" with a hardcoded password, so it round-trips and
+  // must keep working — but it protects nothing, and reporting it as sealed is the lie.
+  return backend === 'basic_text'
+    ? 'Secrets are obfuscated with a built-in key, not protected by the OS keyring. Install and unlock gnome-keyring or kwallet, then restart Orca, to seal them properly.'
+    : null
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​32 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 |

<!-- /orca-pr-loc -->

## ELI5

`safeStorage.getSelectedStorageBackend()` only exists on Linux. On macOS and Windows it is genuinely `undefined` — calling it there is a `TypeError` at startup.

The shipped code never hit that, because a `process.platform === 'linux'` check sat in front of it. But that one check was the only thing between the call and a crash, and **no test could have caught it if it were wrong.**

## What I actually verified

Against the installed Electron 43.1.0, on real hardware:

| Platform | `typeof getSelectedStorageBackend` |
|---|---|
| macOS (darwin) | `undefined` |
| Linux (Ubuntu, headless) | `function` |

The type declaration promises the method unconditionally; it is annotated `@platform linux` in a doc comment only. So the types will not save you here.

Also confirmed on the Linux box that the real branch logic runs clean:

```
GAP_RESULT: KEYRING_UNAVAILABLE
BACKEND: basic_text
NO_THROW: true
```

## The fix

The platform check now lives *with* the probe, next to a `typeof` check and a `try`/`catch`. An unreadable or `unknown` backend reports **no gap** — claiming one we cannot prove would be its own kind of lie, and the caller has already established that sealing works.

## The real gap was in the tests

Every suite here mocks `safeStorage` with the method present. So the suite could stay green while the shipped app threw — the exact shape of bug that keeps recurring in this area.

The new case deletes the member from the **live mock object** rather than re-mocking, because the module already holds that object and a later `vi.doMock` is inert.

That matters: **my first version of this test passed against the unguarded code.** It was worthless, and I only found that by trying to make it fail. Verified against the expression currently on `main`, three cases now fail:

```
FAIL  reports a gap for the Linux basic_text backend, which protects nothing
FAIL  does not throw when the Linux-only backend probe is absent
FAIL  reports no gap when the backend probe throws
```

## Proof of no regressions

- 14 tests in this file, covering absent / throwing / unknown / `basic_text` / real-keyring
- `pnpm run lint` clean; full suite green apart from one unrelated load flake (`orca-runtime.test.ts`, passes isolated at 1,183, untouched by this branch)

## User-facing trade-offs

**Zero.** No behaviour change on any platform — this hardens a path that currently works by virtue of a single correct guard.