### PR TITLE
fix(codex-usage): count Codex sessions from running WSL distros

### DIFF
--- a/src/main/codex-usage/codex-session-file-discovery.ts
+++ b/src/main/codex-usage/codex-session-file-discovery.ts
@@ -1,10 +1,13 @@
-import { join } from 'node:path'
+import { join, win32 as pathWin32 } from 'node:path'
 import { existsSync } from 'node:fs'
 import { realpath, readdir, stat } from 'node:fs/promises'
+import { parseWslUncPath } from '../../shared/wsl-paths'
 import { getOrcaManagedCodexHomePath, getSystemCodexHomePath } from '../codex/codex-home-paths'
 import { getCodexAccountHomeSessionDirectories } from '../codex/codex-account-home-discovery'
 import { getLegacyCopiedCodexSessionBridgeScanPreference } from '../codex/codex-session-bridge'
 import { normalizeFsPath } from '../usage/usage-path-comparison'
+import { WSL_CODEX_RUNTIME_HOME_SEGMENTS } from '../pty/codex-home-wsl-env'
+import { getWslHomeAsync, listRunningWslDistrosAsync } from '../wsl'
 
 const YIELD_EVERY_DISCOVERY_ENTRIES = 100
 
@@ -72,20 +75,118 @@ export function getCodexSessionDirectories(): string[] {
   ].filter((dirPath, index, allDirPaths) => allDirPaths.indexOf(dirPath) === index)
 }
 
+type WslCodexSessionLanePair = {
+  managedSessionsRoot: string
+  systemSessionsRoot: string
+}
+
+// Why: WSL Codex transcripts are invisible to the Windows lanes, so usage shows
+// zero whenever Codex runs inside a distro. Reachable only as UNC paths, so the
+// lanes are emitted per running distro from the distro home.
+export async function getWslCodexSessionDirectories(): Promise<string[]> {
+  const lanePairs = await getWslCodexSessionLanePairs()
+  return lanePairs
+    .flatMap((lanePair) => [lanePair.managedSessionsRoot, lanePair.systemSessionsRoot])
+    .filter((dirPath, index, allDirPaths) => allDirPaths.indexOf(dirPath) === index)
+}
+
+async function getWslCodexSessionLanePairs(): Promise<WslCodexSessionLanePair[]> {
+  if (process.platform !== 'win32') {
+    return []
+  }
+  const lanePairs: WslCodexSessionLanePair[] = []
+  for (const distro of await listRunningWslDistrosAsync()) {
+    const home = await getWslHomeAsync(distro)
+    if (!home) {
+      continue
+    }
+    lanePairs.push({
+      managedSessionsRoot: joinWslHomePath(home, ...WSL_CODEX_RUNTIME_HOME_SEGMENTS, 'sessions'),
+      systemSessionsRoot: joinWslHomePath(home, '.codex', 'sessions')
+    })
+  }
+  return lanePairs
+}
+
+// Why: mirrors runtime-home-service joinWslPath; UNC homes need win32 join semantics.
+function joinWslHomePath(basePath: string, ...segments: string[]): string {
+  return parseWslUncPath(basePath)
+    ? pathWin32.join(basePath, ...segments)
+    : join(basePath, ...segments)
+}
+
 function hasLegacyCopiedSessionBridgeMarkers(): boolean {
   return existsSync(join(getOrcaManagedCodexHomePath(), '.orca-session-copies'))
 }
 
 export async function listCodexSessionFiles(): Promise<string[]> {
   const files: string[] = []
-  for (const dirPath of getCodexSessionDirectories()) {
+  const wslLanePairs = await getWslCodexSessionLanePairs()
+  const directories = [
+    ...getCodexSessionDirectories(),
+    ...wslLanePairs.flatMap((lanePair) => [
+      lanePair.managedSessionsRoot,
+      lanePair.systemSessionsRoot
+    ])
+  ]
+  for (const dirPath of directories) {
     try {
       appendDiscoveredFiles(files, await walkJsonlFiles(dirPath))
     } catch {
       // Missing or unreadable history in one home should not hide the other.
     }
   }
-  return dedupeCodexSessionFileAliases(files, hasLegacyCopiedSessionBridgeMarkers())
+  return dedupeCodexSessionFileAliases(
+    dropWslHardLinkTwinFiles(files, wslLanePairs),
+    hasLegacyCopiedSessionBridgeMarkers()
+  )
+}
+
+function getWslLaneRelativePath(filePath: string, sessionsRoot: string): string | null {
+  // Why: walkJsonlFiles joins with the host path module, so separators can mix
+  // inside UNC spellings; compare separator-insensitively but case-sensitively
+  // (Linux paths inside a distro are case-sensitive).
+  const normalizedFilePath = filePath.replaceAll('\\', '/')
+  const normalizedRoot = `${sessionsRoot.replaceAll('\\', '/').replace(/\/+$/, '')}/`
+  return normalizedFilePath.startsWith(normalizedRoot)
+    ? normalizedFilePath.slice(normalizedRoot.length)
+    : null
+}
+
+function dropWslHardLinkTwinFiles(
+  files: readonly string[],
+  lanePairs: readonly WslCodexSessionLanePair[]
+): string[] {
+  if (lanePairs.length === 0) {
+    return [...files]
+  }
+  // Why: wsl-codex-session-bridge hard-links system rollouts into the managed
+  // root, so one rollout appears in both lanes of a distro. UNC stat inode
+  // identity is unreliable over the WSL 9p filesystem, so twins match by
+  // relative path instead and the managed copy wins.
+  const systemTwinPaths = new Set<string>()
+  for (const lanePair of lanePairs) {
+    const managedRelativePaths = new Set<string>()
+    for (const filePath of files) {
+      const relativePath = getWslLaneRelativePath(filePath, lanePair.managedSessionsRoot)
+      if (relativePath !== null) {
+        managedRelativePaths.add(relativePath)
+      }
+    }
+    if (managedRelativePaths.size === 0) {
+      continue
+    }
+    for (const filePath of files) {
+      const relativePath = getWslLaneRelativePath(filePath, lanePair.systemSessionsRoot)
+      if (relativePath !== null && managedRelativePaths.has(relativePath)) {
+        systemTwinPaths.add(filePath)
+      }
+    }
+  }
+  if (systemTwinPaths.size === 0) {
+    return [...files]
+  }
+  return files.filter((filePath) => !systemTwinPaths.has(filePath))
 }
 
 async function dedupeCodexSessionFileAliases(

--- a/src/main/codex-usage/codex-session-file-discovery.wsl.test.ts
+++ b/src/main/codex-usage/codex-session-file-discovery.wsl.test.ts
@@ -1,0 +1,345 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import type * as NodeOs from 'node:os'
+import type * as NodeFsPromisesModule from 'node:fs/promises'
+import { join } from 'node:path'
+
+const WSL_UNC_PREFIX = '\\\\wsl.localhost\\'
+const UBUNTU_HOME = '\\\\wsl.localhost\\Ubuntu\\home\\ada'
+const DEBIAN_HOME = '\\\\wsl.localhost\\Debian\\home\\leo'
+const UBUNTU_MANAGED_SESSIONS =
+  '\\\\wsl.localhost\\Ubuntu\\home\\ada\\.local\\share\\orca\\codex-runtime-home\\home\\sessions'
+const UBUNTU_SYSTEM_SESSIONS = '\\\\wsl.localhost\\Ubuntu\\home\\ada\\.codex\\sessions'
+const DEBIAN_MANAGED_SESSIONS =
+  '\\\\wsl.localhost\\Debian\\home\\leo\\.local\\share\\orca\\codex-runtime-home\\home\\sessions'
+const DEBIAN_SYSTEM_SESSIONS = '\\\\wsl.localhost\\Debian\\home\\leo\\.codex\\sessions'
+
+const { homedirMock } = vi.hoisted(() => ({
+  homedirMock: vi.fn<() => string>()
+}))
+
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof NodeOs>('node:os')
+  return {
+    ...actual,
+    homedir: homedirMock
+  }
+})
+
+const wslMocks = vi.hoisted(() => ({
+  runningDistros: [] as string[],
+  homesByDistro: new Map<string, string>(),
+  attemptedReadDirs: [] as string[],
+  failingReadDirs: new Set<string>()
+}))
+
+vi.mock('../wsl', () => ({
+  listRunningWslDistrosAsync: vi.fn(),
+  getWslHomeAsync: vi.fn()
+}))
+
+// Why: UNC fixtures have no backing distro, so WSL reads come from an in-memory
+// tree; every other path goes to the real filesystem untouched.
+type FakeWslNode = FakeWslDir | 'file'
+type FakeWslDir = {
+  entries: Map<string, FakeWslNode>
+}
+const fakeWslDirs = new Map<string, FakeWslDir>()
+
+function normalizeFakeWslPath(pathValue: string): string {
+  return pathValue.replaceAll('\\', '/')
+}
+
+function registerFakeWslDir(dirPath: string): FakeWslDir {
+  const key = normalizeFakeWslPath(dirPath)
+  let dir = fakeWslDirs.get(key)
+  if (!dir) {
+    dir = { entries: new Map<string, FakeWslNode>() }
+    fakeWslDirs.set(key, dir)
+  }
+  return dir
+}
+
+function addFakeWslFile(sessionsRoot: string, relativePath: string): void {
+  const segments = relativePath.split('/')
+  const fileName = segments.pop()
+  if (!fileName) {
+    throw new Error(`empty relative path: ${relativePath}`)
+  }
+  let currentPath = sessionsRoot
+  let dir = registerFakeWslDir(currentPath)
+  for (const segment of segments) {
+    currentPath = `${currentPath}\\${segment}`
+    const next = dir.entries.get(segment)
+    if (next && next !== 'file') {
+      dir = next
+      continue
+    }
+    // Why: intermediate directories must be resolvable from the top-level
+    // registry too, or a readdir of them rejects and voids the whole lane.
+    const created = registerFakeWslDir(currentPath)
+    dir.entries.set(segment, created)
+    dir = created
+  }
+  dir.entries.set(fileName, 'file')
+}
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFsPromisesModule>()
+  const actualReaddir = actual.readdir.bind(actual) as (
+    pathValue: string,
+    options?: { withFileTypes?: boolean }
+  ) => Promise<unknown>
+  return {
+    ...actual,
+    readdir: (async (pathValue: string, options?: { withFileTypes?: boolean }) => {
+      if (!pathValue.startsWith(WSL_UNC_PREFIX)) {
+        return actualReaddir(pathValue, options)
+      }
+      const key = normalizeFakeWslPath(pathValue)
+      wslMocks.attemptedReadDirs.push(pathValue)
+      if (wslMocks.failingReadDirs.has(key)) {
+        throw Object.assign(new Error(`EACCES: ${pathValue}`), { code: 'EACCES' })
+      }
+      const dir = fakeWslDirs.get(key)
+      if (!dir) {
+        throw Object.assign(new Error(`ENOENT: ${pathValue}`), { code: 'ENOENT' })
+      }
+      if (options?.withFileTypes) {
+        return [...dir.entries.entries()].map(([name, node]) => ({
+          name,
+          isDirectory: () => node !== 'file',
+          isFile: () => node === 'file',
+          isSymbolicLink: () => false
+        }))
+      }
+      return [...dir.entries.keys()]
+    }) as unknown as typeof actual.readdir,
+    // Why: stat and realpath must never reach the real WSL 9p provider for
+    // fixtures; on a host that actually has the distro they would stall or boot
+    // it. ino 0 pushes alias identity onto the normalized-path fallback.
+    stat: (async (pathValue: string) => {
+      const node = pathValue.startsWith(WSL_UNC_PREFIX) ? resolveFakeWslNode(pathValue) : undefined
+      if (node !== 'file') {
+        return actual.stat(pathValue)
+      }
+      return {
+        dev: 0,
+        ino: 0,
+        isFile: () => true,
+        isDirectory: () => false,
+        isSymbolicLink: () => false,
+        size: 2,
+        mtimeMs: 0
+      }
+    }) as unknown as typeof actual.stat,
+    realpath: (async (pathValue: string) => {
+      throw Object.assign(new Error(`ENOENT: ${pathValue}`), { code: 'ENOENT' })
+    }) as unknown as typeof actual.realpath
+  }
+})
+
+function resolveFakeWslNode(pathValue: string): FakeWslNode | undefined {
+  const segments = normalizeFakeWslPath(pathValue).split('/')
+  const fileName = segments.pop()
+  if (!fileName || segments.length === 0) {
+    return undefined
+  }
+  return fakeWslDirs.get(segments.join('/'))?.entries.get(fileName)
+}
+
+import {
+  getWslCodexSessionDirectories,
+  listCodexSessionFiles
+} from './codex-session-file-discovery'
+import { getWslHomeAsync, listRunningWslDistrosAsync } from '../wsl'
+
+const realPlatform = process.platform
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+}
+
+function useDistro(distro: string, home: string | null): void {
+  wslMocks.runningDistros.push(distro)
+  if (home !== null) {
+    wslMocks.homesByDistro.set(distro, home)
+  }
+}
+
+let fakeHomeDir: string
+let userDataDir: string
+let previousUserDataPath: string | undefined
+let runtimeSessionsDir: string
+let systemSessionsDir: string
+
+beforeEach(() => {
+  fakeHomeDir = mkdtempSync(join(tmpdir(), 'orca-codex-wsl-home-'))
+  userDataDir = mkdtempSync(join(tmpdir(), 'orca-codex-wsl-user-data-'))
+  previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+  process.env.ORCA_USER_DATA_PATH = userDataDir
+  homedirMock.mockReturnValue(fakeHomeDir)
+  runtimeSessionsDir = join(userDataDir, 'codex-runtime-home', 'home', 'sessions')
+  systemSessionsDir = join(fakeHomeDir, '.codex', 'sessions')
+  wslMocks.runningDistros = []
+  wslMocks.homesByDistro.clear()
+  wslMocks.attemptedReadDirs.length = 0
+  wslMocks.failingReadDirs.clear()
+  fakeWslDirs.clear()
+  vi.mocked(listRunningWslDistrosAsync).mockImplementation(async () => [...wslMocks.runningDistros])
+  vi.mocked(getWslHomeAsync).mockImplementation(
+    async (distro: string) => wslMocks.homesByDistro.get(distro) ?? null
+  )
+  setPlatform('win32')
+})
+
+afterEach(() => {
+  rmSync(fakeHomeDir, { recursive: true, force: true })
+  rmSync(userDataDir, { recursive: true, force: true })
+  if (previousUserDataPath === undefined) {
+    delete process.env.ORCA_USER_DATA_PATH
+  } else {
+    process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+  }
+  setPlatform(realPlatform)
+  vi.clearAllMocks()
+})
+
+describe('getWslCodexSessionDirectories', () => {
+  it('returns no WSL directories on a non-windows host', async () => {
+    setPlatform('darwin')
+
+    await expect(getWslCodexSessionDirectories()).resolves.toEqual([])
+    expect(listRunningWslDistrosAsync).not.toHaveBeenCalled()
+    expect(getWslHomeAsync).not.toHaveBeenCalled()
+  })
+
+  it('returns no WSL directories when no distro is running', async () => {
+    await expect(getWslCodexSessionDirectories()).resolves.toEqual([])
+    expect(listRunningWslDistrosAsync).toHaveBeenCalledTimes(1)
+    expect(getWslHomeAsync).not.toHaveBeenCalled()
+  })
+
+  it('skips a running distro whose home cannot be resolved', async () => {
+    useDistro('Ubuntu', null)
+
+    await expect(getWslCodexSessionDirectories()).resolves.toEqual([])
+    expect(getWslHomeAsync).toHaveBeenCalledWith('Ubuntu')
+  })
+
+  it('emits the managed lane before the system lane per running distro', async () => {
+    useDistro('Ubuntu', UBUNTU_HOME)
+    useDistro('Debian', DEBIAN_HOME)
+
+    await expect(getWslCodexSessionDirectories()).resolves.toEqual([
+      UBUNTU_MANAGED_SESSIONS,
+      UBUNTU_SYSTEM_SESSIONS,
+      DEBIAN_MANAGED_SESSIONS,
+      DEBIAN_SYSTEM_SESSIONS
+    ])
+  })
+
+  it('dedupes identical lanes resolved from different distros', async () => {
+    useDistro('Ubuntu', UBUNTU_HOME)
+    useDistro('Ubuntu-22.04', UBUNTU_HOME)
+
+    await expect(getWslCodexSessionDirectories()).resolves.toEqual([
+      UBUNTU_MANAGED_SESSIONS,
+      UBUNTU_SYSTEM_SESSIONS
+    ])
+  })
+})
+
+describe('listCodexSessionFiles across windows and wsl lanes', () => {
+  it('walks the wsl lanes alongside the windows lanes', async () => {
+    mkdirSync(runtimeSessionsDir, { recursive: true })
+    mkdirSync(systemSessionsDir, { recursive: true })
+    const runtimeSessionPath = join(runtimeSessionsDir, 'runtime.jsonl')
+    const systemSessionPath = join(systemSessionsDir, 'system.jsonl')
+    writeFileSync(runtimeSessionPath, '{}\n', 'utf-8')
+    writeFileSync(systemSessionPath, '{}\n', 'utf-8')
+    useDistro('Ubuntu', UBUNTU_HOME)
+    useDistro('Debian', DEBIAN_HOME)
+    addFakeWslFile(UBUNTU_MANAGED_SESSIONS, 'rollout-ubuntu.jsonl')
+    addFakeWslFile(DEBIAN_MANAGED_SESSIONS, 'rollout-debian.jsonl')
+    addFakeWslFile(DEBIAN_SYSTEM_SESSIONS, 'rollout-debian-system.jsonl')
+
+    const files = await listCodexSessionFiles()
+
+    expect(files).toEqual(
+      [
+        runtimeSessionPath,
+        systemSessionPath,
+        join(UBUNTU_MANAGED_SESSIONS, 'rollout-ubuntu.jsonl'),
+        join(DEBIAN_MANAGED_SESSIONS, 'rollout-debian.jsonl'),
+        join(DEBIAN_SYSTEM_SESSIONS, 'rollout-debian-system.jsonl')
+      ].sort()
+    )
+  })
+
+  it('keeps scanning other lanes when one wsl lane fails to read', async () => {
+    useDistro('Ubuntu', UBUNTU_HOME)
+    useDistro('Debian', DEBIAN_HOME)
+    addFakeWslFile(UBUNTU_MANAGED_SESSIONS, 'rollout-ubuntu.jsonl')
+    addFakeWslFile(DEBIAN_MANAGED_SESSIONS, 'rollout-debian.jsonl')
+    addFakeWslFile(DEBIAN_SYSTEM_SESSIONS, 'rollout-debian-system.jsonl')
+    wslMocks.failingReadDirs.add(normalizeFakeWslPath(UBUNTU_SYSTEM_SESSIONS))
+
+    const files = await listCodexSessionFiles()
+
+    // Both failing Ubuntu lanes were attempted, yet Debian survived intact.
+    expect(wslMocks.attemptedReadDirs).toContain(UBUNTU_MANAGED_SESSIONS)
+    expect(wslMocks.attemptedReadDirs).toContain(UBUNTU_SYSTEM_SESSIONS)
+    expect(wslMocks.attemptedReadDirs).toContain(DEBIAN_SYSTEM_SESSIONS)
+    expect(files).toEqual(
+      [
+        join(UBUNTU_MANAGED_SESSIONS, 'rollout-ubuntu.jsonl'),
+        join(DEBIAN_MANAGED_SESSIONS, 'rollout-debian.jsonl'),
+        join(DEBIAN_SYSTEM_SESSIONS, 'rollout-debian-system.jsonl')
+      ].sort()
+    )
+  })
+
+  it('counts a hard-linked rollout once with the managed copy winning', async () => {
+    useDistro('Ubuntu', UBUNTU_HOME)
+    addFakeWslFile(UBUNTU_MANAGED_SESSIONS, 'twin.jsonl')
+    addFakeWslFile(UBUNTU_MANAGED_SESSIONS, 'nested/twin-deep.jsonl')
+    addFakeWslFile(UBUNTU_SYSTEM_SESSIONS, 'twin.jsonl')
+    addFakeWslFile(UBUNTU_SYSTEM_SESSIONS, 'nested/twin-deep.jsonl')
+    addFakeWslFile(UBUNTU_SYSTEM_SESSIONS, 'only-system.jsonl')
+
+    const files = await listCodexSessionFiles()
+
+    expect(files).toEqual(
+      [
+        join(UBUNTU_MANAGED_SESSIONS, 'twin.jsonl'),
+        join(UBUNTU_MANAGED_SESSIONS, 'nested', 'twin-deep.jsonl'),
+        join(UBUNTU_SYSTEM_SESSIONS, 'only-system.jsonl')
+      ].sort()
+    )
+    const survivingTwin = files.find((filePath) => filePath.endsWith('twin.jsonl'))
+    expect(survivingTwin).toBeDefined()
+    expect(survivingTwin!.startsWith(UBUNTU_MANAGED_SESSIONS)).toBe(true)
+  })
+
+  it('keeps same-named rollouts across different distros out of each dedupe scope', async () => {
+    useDistro('Ubuntu', UBUNTU_HOME)
+    useDistro('Debian', DEBIAN_HOME)
+    addFakeWslFile(UBUNTU_MANAGED_SESSIONS, 'shared-name.jsonl')
+    addFakeWslFile(UBUNTU_SYSTEM_SESSIONS, 'unique-ubuntu.jsonl')
+    addFakeWslFile(DEBIAN_MANAGED_SESSIONS, 'shared-name.jsonl')
+    addFakeWslFile(DEBIAN_SYSTEM_SESSIONS, 'unique-debian.jsonl')
+
+    const files = await listCodexSessionFiles()
+
+    expect(files).toEqual(
+      [
+        join(UBUNTU_MANAGED_SESSIONS, 'shared-name.jsonl'),
+        join(UBUNTU_SYSTEM_SESSIONS, 'unique-ubuntu.jsonl'),
+        join(DEBIAN_MANAGED_SESSIONS, 'shared-name.jsonl'),
+        join(DEBIAN_SYSTEM_SESSIONS, 'unique-debian.jsonl')
+      ].sort()
+    )
+  })
+})

--- a/src/main/codex-usage/scanner-paths.test.ts
+++ b/src/main/codex-usage/scanner-paths.test.ts
@@ -12,6 +12,7 @@ import {
 import { tmpdir } from 'node:os'
 import type * as NodeOs from 'node:os'
 import { join } from 'node:path'
+import type * as WslModule from '../wsl'
 
 const { getPathMock, homedirMock } = vi.hoisted(() => ({
   getPathMock: vi.fn<(name: string) => string>(),
@@ -29,6 +30,17 @@ vi.mock('node:os', async () => {
   return {
     ...actual,
     homedir: homedirMock
+  }
+})
+
+// Why: listCodexSessionFiles consults running WSL distros, and a live distro
+// holding real Codex sessions would leak files into these exact-set
+// assertions; pinning the probe empty keeps the suite hermetic on any host.
+vi.mock('../wsl', async () => {
+  const actual = await vi.importActual<typeof WslModule>('../wsl')
+  return {
+    ...actual,
+    listRunningWslDistrosAsync: async () => []
   }
 })
 


### PR DESCRIPTION
## ELI5

Run Codex inside WSL and Stats & Usage stays at zero forever. The usage scanner only looks at Windows-side folders, but WSL transcripts live inside the distro. This teaches the scanner to look there too, without booting stopped distros and without counting the session bridge's hard-links twice.

## What Changed

- `src/main/wsl.ts`: new `listRunningWslDistrosAsync()` (`wsl.exe --list --running --quiet`), 15s TTL cache with a single-flight probe so concurrent scans share one wsl.exe call.
- `src/main/codex-usage/codex-session-file-discovery.ts`: per running distro, adds two UNC scan lanes: the managed runtime home (`~/.local/share/orca/codex-runtime-home/home/sessions`) and `~/.codex/sessions`. Hard-link twins created by `wsl-codex-session-bridge` (same relative path in both lanes) count once, managed copy wins. Twins match by relative path because inode identity is unreliable over the 9p filesystem.
- `src/main/codex-usage/scanner-paths.test.ts`: pins the running-distro probe empty so the suite stays hermetic on machines that have a live distro with real sessions.
- `src/main/codex-usage/codex-session-file-discovery.wsl.test.ts`: new suite (9 tests) against an in-memory UNC fake; tests never touch or boot a real distro.

Only running distros are scanned, on purpose: touching `\\wsl.localhost\<distro>\...` boots the distro, and a periodic usage scan should never start VMs as a side effect. A stopped distro's sessions get picked up on a later scan while it runs.

## Why

`getCodexSessionDirectories()` already documents that missing a lane silently undercounts usage. WSL was a missing lane: transcripts are created and bridged inside the distro, but the usage scanner never looked there, so WSL users get a successful scan with `processedFiles: []` (the exact symptom in the issue).

## Linked Issue

Fixes #15978

## Visual Proof

No UI code changed; the fix feeds the data the existing Stats & Usage page renders. Data-level before/after on Windows 11 + WSL2 (Ubuntu 24.04), with three transcripts planted inside the distro and one hard-linked into both lanes (link count 2):

Before: the scan finds no WSL files, `sessions: []`.

After, real `scanCodexUsageFiles`, no mocks:

```json
{"day":"2026-08-22","model":"gpt-5.2-codex","projectKey":"cwd:/root/proj","eventCount":3,"inputTokens":9000,"outputTokens":600,"totalTokens":9600}
```

`eventCount` 3 rather than 4 shows the hard-link twin aggregated once, and the totals match the planted per-file values exactly. 38 real Windows-side sessions on the same machine aggregated unchanged next to it. With the distro stopped, no WSL lanes are added and nothing boots.

## Testing

- New suite: 9 passed. Adjacent `scanner.test.ts` + `scanner-paths.test.ts`: 24 passed. Both re-run with a distro running and stopped.
- `pnpm typecheck` clean. Lint code-quality steps clean (including the max-lines cap on `wsl.ts`).
- Full suite on this machine has ~300 pre-existing Windows-checkout failures (CRLF snapshots and similar); verified unrelated by re-running the same failing files on a clean tree without this change, which fails identically. Zero failures in `codex-usage` or `wsl` either way.
- Platforms actually tested: Windows 11 + WSL2. Non-Windows is gated (`process.platform !== 'win32'` returns no WSL lanes) and unit-tested.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

## AI Disclosure

Drafted with opencode (x-preview-f-free), reviewed and verified with Claude Code; all test results above were run and observed locally.

## Review

- Cross-platform: WSL lanes are win32-gated; macOS/Linux behavior unchanged.
- SSH/remote/local: main-process scanner only; no PTY, relay, or SSH paths touched.
- Agents/integrations: Codex usage scanning only; nothing provider-generic changed.
- Performance: probe cached (15s TTL, single-flight); UNC walks only for running distros; per-lane try/catch keeps one bad lane from hiding the others.
- Security: the only new subprocess is `wsl.exe --list --running --quiet` with fixed args, no interpolation.
- Backwards compatibility: exported sync `getCodexSessionDirectories()` unchanged; legacy copied-session dedupe untouched.

## Agent skill upstream boundary

- [x] Not applicable

## Notes

Scanning only running distros means a stopped distro's history appears once that distro runs again; that felt like the right trade against a background scan booting VMs. Happy to adjust if you'd rather gate it differently.

## Author

X: @Sahir_S

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after included above; no UI code changed, or `N/A`
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
