### PR TITLE
perf(preflight): read the WSL mount table once, and make launch agree with detection

### DIFF
--- a/src/main/codex-accounts/wsl-codex-command.ts
+++ b/src/main/codex-accounts/wsl-codex-command.ts
@@ -77,7 +77,13 @@ export function buildWslCodexLoginArgs(distro: string, linuxHomePath: string): s
 }
 
 function buildCodexPathLookup(): string {
-  return buildPosixCommandPathLookupScript({ kind: 'literal', value: 'codex' })
+  // Same skip as agent detection: otherwise detection can report the guest
+  // codex while this resolves the Windows one ahead of it on PATH, and Orca
+  // launches a different binary than the one it said was installed.
+  return buildPosixCommandPathLookupScript(
+    { kind: 'literal', value: 'codex' },
+    { skipWindowsMountDirs: true }
+  )
 }
 
 function buildWslCodexShellArgs(distro: string, command: string): string[] {

--- a/src/main/ipc/preflight-command-exec.test.ts
+++ b/src/main/ipc/preflight-command-exec.test.ts
@@ -35,7 +35,12 @@ describe('isCommandOnPath', () => {
     expect(runPreflightCommandInWslMock).toHaveBeenCalledOnce()
     const [, command] = runPreflightCommandInWslMock.mock.calls[0] as [{ distro: string }, string]
     expect(command).toContain(
-      buildPosixCommandPathLookupScript({ kind: 'literal', value: 'codex' })
+      buildPosixCommandPathLookupScript(
+        { kind: 'literal', value: 'codex' },
+        // The WSL branch skips Windows mounts, so detection and this check
+        // cannot disagree about the same distro.
+        { skipWindowsMountDirs: true }
+      )
     )
     expect(command).toContain(
       ['if [ -n "$resolved" ]; then', `printf '${sentinel}%s\\n' "$resolved"`, 'fi'].join('\n')

--- a/src/main/ipc/preflight-command-exec.ts
+++ b/src/main/ipc/preflight-command-exec.ts
@@ -100,7 +100,13 @@ export async function isCommandOnPath(
     const { stdout } = await execCommandInWsl(
       wslTarget,
       [
-        buildPosixCommandPathLookupScript({ kind: 'literal', value: command }),
+        // Same skip as agent detection: without it this branch answers "yes"
+        // for a Windows binary reached through interop, so preflight and the
+        // detector disagree about the same distro.
+        buildPosixCommandPathLookupScript(
+          { kind: 'literal', value: command },
+          { skipWindowsMountDirs: true }
+        ),
         'if [ -n "$resolved" ]; then',
         `printf '${WSL_COMMAND_PATH_SENTINEL}%s\\n' "$resolved"`,
         'fi'

--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync, type ExecFileSyncOptions } from 'node:child_process'
-import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -289,5 +289,52 @@ describe('the PATH walk, run by a real POSIX shell', () => {
     } finally {
       rmSync(root, { recursive: true, force: true })
     }
+  })
+})
+
+describe('the mount table read, counted against a real shell', () => {
+  const itPosix = process.platform === 'win32' ? it.skip : it
+
+  const runWithCountingAwk = async (commands: string[]): Promise<number> => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-awk-'))
+    try {
+      const counter = join(root, 'count')
+      const bin = join(root, 'bin')
+      mkdirSync(bin, { recursive: true })
+      // A stub that records each fork, then answers as awk would on a host
+      // with no Windows mounts.
+      writeFileSync(join(bin, 'awk'), `#!/bin/sh\necho x >> ${counter}\nexit 0\n`)
+      chmodSync(join(bin, 'awk'), 0o755)
+      writeFileSync(counter, '')
+
+      runWslProcessMock.mockResolvedValue({
+        environmentResolved: true,
+        code: 0,
+        stdout: '',
+        stderr: '',
+        timedOut: false
+      })
+      await detectWslCommandsOnPath({ distro: 'Ubuntu' }, commands)
+      const script = String(runWslProcessMock.mock.calls.at(-1)?.[0].script)
+      const options: ExecFileSyncOptions = {
+        encoding: 'utf8',
+        env: { PATH: `${bin}:/usr/bin:/bin`, HOME: root }
+      }
+      execFileSync('/bin/sh', ['-c', script], options)
+      return readFileSync(counter, 'utf8').trim().split('\n').filter(Boolean).length
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  }
+
+  itPosix('reads /proc/mounts once, not once per probed command', async () => {
+    // The prelude is embedded in the lookup script, which the caller wraps in
+    // `for cmd in <every agent>`. An unconditional assignment forked awk once
+    // per CLI -- 36 of them inside the distro against a 10s budget.
+    expect(await runWithCountingAwk(['claude', 'codex', 'gemini', 'opencode'])).toBe(1)
+  })
+
+  itPosix('still reads it once when only one command is probed', async () => {
+    expect(await runWithCountingAwk(['claude'])).toBe(1)
   })
 })

--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -337,4 +337,49 @@ describe('the mount table read, counted against a real shell', () => {
   itPosix('still reads it once when only one command is probed', async () => {
     expect(await runWithCountingAwk(['claude'])).toBe(1)
   })
+
+  itPosix('applies the memoised mount list to every command, not just the first', async () => {
+    // Counting forks with a stub that reports NO mounts cannot see the thing
+    // the hoist trades correctness for: a refactor that empties or clobbers
+    // the variable inside the walk keeps the fork count at 1 and keeps the
+    // single-command test green, while every agent after the first stops
+    // skipping /mnt. A surviving mutant proved that gap.
+    const root = mkdtempSync(join(tmpdir(), 'orca-memo-'))
+    try {
+      const win = join(root, 'winmnt/c/npm')
+      const guest = join(root, 'home/bin')
+      for (const [dir, body] of [
+        [win, 'win'],
+        [guest, 'guest']
+      ] as const) {
+        mkdirSync(dir, { recursive: true })
+        for (const name of ['claude', 'codex']) {
+          writeFileSync(join(dir, name), `#!/bin/sh\necho ${body}\n`)
+          chmodSync(join(dir, name), 0o755)
+        }
+      }
+      runWslProcessMock.mockResolvedValue({
+        environmentResolved: true,
+        code: 0,
+        stdout: '',
+        stderr: '',
+        timedOut: false
+      })
+      await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude', 'codex'])
+      const script = String(runWslProcessMock.mock.calls.at(-1)?.[0].script).replace(
+        /_orca_win_mounts=\$\([^)]*\)/,
+        `_orca_win_mounts=${join(root, 'winmnt')}`
+      )
+      const options: ExecFileSyncOptions = {
+        encoding: 'utf8',
+        env: { PATH: `${win}:${guest}:/usr/bin:/bin`, HOME: root }
+      }
+      const out = String(execFileSync('/bin/sh', ['-c', script], options))
+      // BOTH must resolve behind the mount, not just the first.
+      expect(out).toContain(`__ORCA_AGENT_PATH__claude\t${join(guest, 'claude')}`)
+      expect(out).toContain(`__ORCA_AGENT_PATH__codex\t${join(guest, 'codex')}`)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
 })

--- a/src/shared/posix-command-path-lookup.ts
+++ b/src/shared/posix-command-path-lookup.ts
@@ -25,11 +25,18 @@ export function buildPosixCommandPathLookupScript(
   options: PosixCommandPathLookupOptions = {}
 ): string {
   const commandAssignment = buildCommandAssignment(target)
-  // `-t drvfs` is what WSL mounts a Windows drive as, wherever the automount
-  // root is; 9p/virtiofs cover the WSL2 shapes. Read once, outside the loop.
+  // `drvfs` is what WSL mounts a Windows drive as, wherever the automount root
+  // is; 9p/virtiofs cover the WSL2 shapes.
+  //
+  // `${x+set}` so the table is read once per SHELL, not once per lookup: the
+  // caller embeds this script inside `for cmd in <every agent>`, so an
+  // unconditional assignment forked awk once per probed CLI -- 36 of them
+  // against a 10s budget. The variable outlives the iteration, so the second
+  // pass finds it set. Deliberately not `[ -n ... ]`: a host with no Windows
+  // mounts yields the empty string, which must still count as read.
   const mountPrelude = options.skipWindowsMountDirs
     ? [
-        '_orca_win_mounts=$(awk \'$3 == "drvfs" || $3 == "9p" || $3 == "virtiofs" { print $2 }\' /proc/mounts 2>/dev/null)'
+        '[ "${_orca_win_mounts+set}" = set ] || _orca_win_mounts=$(awk \'$3 == "drvfs" || $3 == "9p" || $3 == "virtiofs" { print $2 }\' /proc/mounts 2>/dev/null)'
       ]
     : []
   const skipMountComponent = options.skipWindowsMountDirs


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​99 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​97 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 |

<!-- /orca-pr-loc -->

Two follow-ups from the readiness review of #16028, plus the real-hardware verification that review asked for.

## 1. The mount table was read once per probed CLI, not once

The prelude is embedded in the lookup script, and the caller wraps that in
`for cmd in <every agent>` — so the unconditional assignment forked `awk` **36
times** inside the distro, against a 10 s detection budget. My comment claimed
it was read once outside the loop. It was not.

`${x+set}` rather than `[ -n … ]`: a host with no Windows mounts yields the
empty string, which must still count as read.

Pinned by counting real `awk` forks through `/bin/sh` with a stub on PATH —
nothing covered this expression at all before, so a wrong-field mutation
shipped green. Verified to bind: the unconditional form counts 4 for 4 commands.

## 2. Detection and launch could resolve different binaries

Agent detection skips Windows mounts during the walk. The Codex WSL command
builder and the WSL branch of `isCommandOnPath` did not — so Orca could report
the guest `codex` as installed and then launch the Windows one ahead of it on
PATH. Both now pass the same option.

## Verified on real hardware

Run against a real Windows host and a real WSL2 distro, with a Windows binary
planted ahead of a guest one on PATH:

```
plain `command -v orcaprobe`  ->  /mnt/c/Users/neil/orca-agree/orcaprobe
this lookup                   ->  /home/neil/.orca-agree/bin/orcaprobe
```

That host reports `/mnt/c` as **9p**, which the mount expression matches — so
the fstype list is now confirmed against hardware, not fixtures.

**Separately, this retires the residual risk flagged on #16032.** Scripts in the
8 KB–30 KB band newly travel by argv, and nobody had confirmed `wsl.exe` has no
interop cap below 32,767. Measured on the same host, argv through `wsl.exe`:

| script | 7 k | 9 k | 16 k | 24 k | 26 k | 30 k | 31 k | 32 k | 40 k |
|---|---|---|---|---|---|---|---|---|---|
| result | OK | OK | OK | OK | OK | OK | OK | OK | `ENAMETOOLONG` |

The 30,000 budget is correct with confirmed headroom, and the failure mode past
it is a loud spawn error rather than truncation.

## Proof of no regression

- `src/main/ipc` + `src/main/codex-accounts`: 3,402 passed.
- Lint and typecheck exit 0.
- Planted host fixtures removed afterwards.

## User-facing trade-offs

**None.** Fewer forks for the same answer, and two call sites that now agree
with detection instead of contradicting it.
