### PR TITLE
fix(ui): align multiline filter toggle row text and icons to top-left

### DIFF
--- a/src/renderer/src/components/sidebar/FilterToggleRow.tsx
+++ b/src/renderer/src/components/sidebar/FilterToggleRow.tsx
@@ -37,20 +37,20 @@ export function FilterToggleRow({
       className={cn(
         // Why pl-* and not px-2 + pl-6: Tailwind v4 emits px as padding-inline,
         // which outranks a physical pl-6 override and flattens the indent.
-        'flex w-full items-center justify-between gap-2 rounded-[5px] py-1.5 pr-2 text-[12px] font-medium hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+        'flex w-full items-start justify-between gap-2 rounded-[5px] py-1.5 pr-2 text-left text-[12px] font-medium hover:bg-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
         indented ? 'pl-7' : 'pl-2'
       )}
     >
       <span
         className={cn(
-          'inline-flex items-center gap-2',
+          'inline-flex items-start gap-2',
           indented ? 'text-muted-foreground' : 'text-foreground'
         )}
       >
-        <span className="text-muted-foreground">{icon}</span>
+        <span className="text-muted-foreground mt-0.5">{icon}</span>
         {label}
       </span>
-      <span className="inline-flex items-center gap-2">
+      <span className="inline-flex items-center gap-2 mt-0.5">
         {shortcutLabel ? <DropdownMenuShortcut>{shortcutLabel}</DropdownMenuShortcut> : null}
         <SwitchIndicator
           checked={checked}


### PR DESCRIPTION

## ELI5

When filter toggle labels in the sidebar wrap across multiple lines (such as under Korean, Japanese, or Spanish localizations), the text was displayed center-aligned and the icon and switch were awkwardly placed in the vertical middle between the lines. This PR aligns multiline text to the left and aligns the icon and switch cleanly with the first line.


## What Changed

Updated `src/renderer/src/components/sidebar/FilterToggleRow.tsx` with a minimal 4-line CSS adjustment:
- Replaced `items-center` with `items-start` and added `text-left` on the toggle row `<button>`.
- Replaced `items-center` with `items-start` on the label container `<span>`.
- Added `mt-0.5` top margin to the leading icon and trailing switch indicator container for optical alignment against the first line of text.

No localization translation strings or other files were modified, keeping the change strictly minimal and focused.

## Why

1. `<button>` elements in standard browser stylesheets default to center alignment. When label text wraps across multiple lines, missing `text-left` causes the text to look awkwardly centered.
2. `items-center` vertically centers child elements across the full height of the multiline block, leaving the icon and switch toggle floating between lines.
3. **Alternative considered**: Truncating text with an ellipsis (`truncate`) was considered, but rejected because filter options should be fully visible and readable at a glance without requiring hover tooltips.

## Linked Issue

Fixes #16052

## Visual Proof

| Item | Before (Multiline Issue) | After (Top-Left Aligned) |
|---|---|---|
| English. (Same) |<img width="555" height="476" alt="image" src="https://github.com/user-attachments/assets/8d329c5c-ba00-4abe-b86e-5e110a1a7902" />|<img width="505" height="467" alt="image" src="https://github.com/user-attachments/assets/adfc3baf-315f-4858-9806-8417103b6078" />|
| Korean |<img width="557" height="489" alt="image" src="https://github.com/user-attachments/assets/8e5fbc45-29fa-4525-93b9-f5fac21a7f42" />|<img width="507" height="485" alt="image" src="https://github.com/user-attachments/assets/405d034e-13ca-4464-afa0-55f2ec98e12a" />|
| Japanese |<img width="557" height="495" alt="image" src="https://github.com/user-attachments/assets/905e7172-d426-4398-8a30-48045b04ff43" />|<img width="503" height="494" alt="image" src="https://github.com/user-attachments/assets/9d86d402-f83c-48bf-8da5-a93d6de29d7b" />|
| Spanish |<img width="560" height="495" alt="image" src="https://github.com/user-attachments/assets/d86a9e5f-9fcd-44a9-9fae-b717da9513cd" />|<img width="501" height="489" alt="image" src="https://github.com/user-attachments/assets/5b55c8e3-4e2a-4e28-b626-e093491bcd16" />|

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Developed and validated with Gemini 3.7 Flash via Antigravity pair-programming agent.

## Review

- **Cross-platform**: Pure CSS/Tailwind utility adjustments in a shared renderer component. Behave identically on macOS, Linux, and Windows.
- **SSH / Remote / Local**: Pure renderer UI component with zero execution or backend impact.
- **Scope**: Minimal 4-line CSS change in a single shared component (`FilterToggleRow.tsx`).


## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security**: No security risk — pure UI layout CSS change. No user inputs, network requests, child processes, or IPC channels touched.
- **Truncation Decision**: Truncation was intentionally avoided to preserve accessibility and immediate readability of filter toggle labels across all locales.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
