### PR TITLE
Fix Ubuntu release dependency lockfile gate (STA-5109)

### DIFF
--- a/.github/actions/install-node-dependencies/action.yml
+++ b/.github/actions/install-node-dependencies/action.yml
@@ -73,7 +73,8 @@ runs:
       shell: bash
       run: |
         pnpm install --frozen-lockfile --ignore-scripts
-        git diff --exit-code package.json pnpm-lock.yaml
+        # Job containers can run composite steps from a source mirror without .git.
+        git -C "$GITHUB_WORKSPACE" diff --exit-code -- package.json pnpm-lock.yaml
 
     # Why cached: `--ignore-scripts` leaves node-pty without build/Release, so
     # ensure-native-runtime node-gyp-compiles it in every job that asks for a runtime.

--- a/config/scripts/install-node-dependencies-action.test.mjs
+++ b/config/scripts/install-node-dependencies-action.test.mjs
@@ -1,0 +1,69 @@
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { parse } from 'yaml'
+import { describe, expect, it } from 'vitest'
+
+const action = parse(readFileSync('.github/actions/install-node-dependencies/action.yml', 'utf8'))
+const installScript = action.runs.steps.find((step) => step.name === 'Install dependencies').run
+
+function run(command, args, options = {}) {
+  return spawnSync(command, args, { encoding: 'utf8', ...options })
+}
+
+function createFixture() {
+  const root = mkdtempSync(join(tmpdir(), 'orca-install-node-action-'))
+  const workspace = join(root, 'checkout')
+  const detachedCwd = join(root, 'action cwd')
+  const bin = join(root, 'bin')
+  mkdirSync(workspace)
+  mkdirSync(detachedCwd)
+  mkdirSync(bin)
+
+  for (const directory of [workspace, detachedCwd]) {
+    writeFileSync(join(directory, 'package.json'), '{"name":"fixture"}\n')
+    writeFileSync(join(directory, 'pnpm-lock.yaml'), 'lockfileVersion: 9\n')
+  }
+
+  expect(run('git', ['init', '-q'], { cwd: workspace }).status).toBe(0)
+  expect(run('git', ['add', 'package.json', 'pnpm-lock.yaml'], { cwd: workspace }).status).toBe(0)
+
+  const pnpm = join(bin, 'pnpm')
+  writeFileSync(pnpm, '#!/bin/sh\nexit 0\n')
+  chmodSync(pnpm, 0o755)
+  return { bin, detachedCwd, root, workspace }
+}
+
+function executeInstallScript(fixture) {
+  return run('bash', ['-c', installScript], {
+    cwd: fixture.detachedCwd,
+    env: {
+      ...process.env,
+      GITHUB_WORKSPACE: fixture.workspace,
+      PATH: `${fixture.bin}${delimiter}${process.env.PATH}`
+    }
+  })
+}
+
+describe('install-node-dependencies action', () => {
+  it.each([
+    ['package.json', '{"name":"changed"}\n'],
+    ['pnpm-lock.yaml', 'lockfileVersion: 9\nchanged: true\n']
+  ])('rejects a changed %s when the composite step cwd is detached', (file, contents) => {
+    const fixture = createFixture()
+    try {
+      const clean = executeInstallScript(fixture)
+      expect(clean.status, clean.stderr || clean.stdout).toBe(0)
+
+      writeFileSync(join(fixture.workspace, file), contents)
+      const dirty = executeInstallScript(fixture)
+      const output = `${dirty.stdout}\n${dirty.stderr}`
+      expect(dirty.status).toBe(1)
+      expect(output).toContain(`diff --git a/${file} b/${file}`)
+      expect(output).not.toContain('diff --git a/package.json b/pnpm-lock.yaml')
+    } finally {
+      rmSync(fixture.root, { recursive: true, force: true })
+    }
+  })
+})

--- a/config/scripts/pr-workflow-parallelism.test.mjs
+++ b/config/scripts/pr-workflow-parallelism.test.mjs
@@ -256,7 +256,9 @@ describe('PR workflow parallelism', () => {
     // resolution can never legitimately change anything.
     expect(dependencyInstall.run).toContain('--frozen-lockfile')
     expect(dependencyInstall.run).not.toContain('--no-frozen-lockfile')
-    expect(dependencyInstall.run).toContain('git diff --exit-code package.json pnpm-lock.yaml')
+    expect(dependencyInstall.run).toContain(
+      'git -C "$GITHUB_WORKSPACE" diff --exit-code -- package.json pnpm-lock.yaml'
+    )
     expect(dependencyInstall.run).toContain('--ignore-scripts')
     expect(dependencyInstall.run).not.toContain('--os=')
     expect(dependencyInstall.run).not.toContain('--cpu=')


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​72 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​71 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

## ELI5

The Ubuntu 20.04 release job installed dependencies successfully, then accidentally compared `package.json` to `pnpm-lock.yaml` as two unrelated files because the reusable action's shell was not inside Git's checkout. The action now tells Git exactly which checkout owns the files.

## What Changed

- Anchor the manifest cleanliness check at `$GITHUB_WORKSPACE` and terminate Git revision parsing with `--`.
- Add a behavioral action test that runs the parsed install step from a detached cwd.
- Prove both `package.json` and `pnpm-lock.yaml` changes still fail the gate.

## Why

The reusable composite action owns the cleanliness verdict. Fixing it there protects every caller; setting a cwd only in the Ubuntu release job or adding only `--` would leave the action dependent on caller/container cwd.

## Linked Issue

[STA-5109](https://linear.app/stably/issue/STA-5109)

## Visual Proof

N/A — CI-only behavior; no UI or interaction change.

## Testing

- [x] Affected release commit `4c484f09` and latest main `d1127b99`: Ubuntu 20.04 / Git 2.25.1 detached-cwd harness reports authoritative checkout clean but original action exit 1 with the cross-file no-index signature.
- [x] Candidate on Ubuntu 20.04 / Git 2.25.1: clean exits 0; dirty `package.json` and dirty `pnpm-lock.yaml` independently exit 1 with index-based same-file diffs.
- [x] Production-line revert: both regression cases fail at the clean assertion with the original cross-file signature.
- [x] `pnpm exec vitest run --config config/vitest.config.ts config/scripts/install-node-dependencies-action.test.mjs config/scripts/pr-workflow-parallelism.test.mjs config/scripts/skill-sharing-release-workflow.test.mjs config/scripts/git-binary-compatibility-workflow.test.mjs` — 25 passed.
- [x] `ORCA_REAL_PROCESS_SKILL_TEST=1 pnpm test:skill-sharing:release --reporter=dot` — 612 passed, 15 skipped.
- [x] Targeted oxlint/format checks passed.
- [x] Full PR CI passed: 32 Node 24/26 shards, Linux and Windows packaging, Git compatibility, typecheck, static analysis, shell contracts, wire compatibility, and aggregate verify.
- [x] I manually tested these changes locally.
- [x] Automated tests added/updated.

## Review

- `internal-review-until-clean`: clean after round 1; no in-scope findings.
- Three fresh Codex reviews (architecture/ownership, failure semantics, test/topology): clean.
- Two fresh OpenCode boundary reviews in this worktree: `REVIEW COMPLETE: CLEAN` from both.
- Final independent Codex round: architecture and product reviews clean; adversarial review found one PR evidence-label overclaim, corrected to Linux/Windows packaging; no code findings.
- Performance audit: no added production subprocess or hot-path work; the existing Git process receives only `-C` and `--`.

## Agent skill upstream boundary

- [x] Not applicable; no agent skill implementation or upstream source is changed.

## Notes

No product, SSH/remote, wire, provider, workspace, or runtime behavior changes. The Git command uses `-C` and `--`, both supported by the Git 2.25 baseline; `$GITHUB_WORKSPACE` is quoted for paths containing spaces. Linear was intentionally not mutated.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (covered by full green PR CI plus focused local checks)
