### PR TITLE
test(remote): preserve HTML inventory RPC failures (STA-5210)

### DIFF
--- a/src/renderer/src/lib/file-preview.ts
+++ b/src/renderer/src/lib/file-preview.ts
@@ -7,6 +7,7 @@ import { getConnectionIdForFile } from '@/lib/connection-context'
 import { getConnectionIdForFileFromState } from '@/lib/connection-owner-resolution'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { createWebRuntimeSessionBrowserTab } from '@/runtime/web-runtime-session'
+import { observeE2eWebRuntimeBrowserCreation } from '@/runtime/web-runtime-browser-creation-e2e-fault'
 import { useAppStore } from '@/store'
 import type { AppState } from '@/store/types'
 import { findSiblingGroupId } from '@/store/slices/tabs'
@@ -64,6 +65,7 @@ export function useWorkspaceFileBrowserActionPredicate(
 }
 
 function reportRemoteFileBrowserOpen(result: Promise<boolean>): void {
+  observeE2eWebRuntimeBrowserCreation(result)
   void result
     .then((created) => {
       if (!created) {

--- a/src/renderer/src/runtime/web-runtime-browser-creation-e2e-fault.ts
+++ b/src/renderer/src/runtime/web-runtime-browser-creation-e2e-fault.ts
@@ -8,12 +8,20 @@ type BrowserCreationFaultSnapshot = {
   suppressedPageIds: string[]
 }
 
+type BrowserCreationSettlement =
+  | { status: 'fulfilled'; created: boolean }
+  | { status: 'rejected'; error: string }
+
 type BrowserCreationFaultApi = {
   arm: () => void
   armCapabilityRejection: () => void
+  armInventoryRpcFailure: () => void
+  armSettlement: () => void
   release: () => boolean
   reset: () => void
   snapshot: () => BrowserCreationFaultSnapshot
+  takeInventoryRpcFailure: () => string | null
+  waitForSettlement: () => Promise<BrowserCreationSettlement>
 }
 
 type BrowserCreationFaultWindow = Window & {
@@ -24,8 +32,11 @@ let armed = false
 let capabilityRejectionArmed = false
 let createdPageId: string | null = null
 let failNextReconciliation = false
+let failNextInventoryRpc = false
 let releaseCreatedPage: (() => void) | null = null
 let createdPageBarrier: Promise<void> | null = null
+let settleCreation: ((settlement: BrowserCreationSettlement) => void) | null = null
+let creationSettlement: Promise<BrowserCreationSettlement> | null = null
 const suppressedPageIds = new Set<string>()
 const MAX_SUPPRESSED_PAGE_IDS = 128
 
@@ -35,8 +46,12 @@ function resetFault(): void {
   capabilityRejectionArmed = false
   createdPageId = null
   failNextReconciliation = false
+  failNextInventoryRpc = false
   releaseCreatedPage = null
   createdPageBarrier = null
+  settleCreation?.({ status: 'rejected', error: 'E2E browser creation settlement reset' })
+  settleCreation = null
+  creationSettlement = null
   suppressedPageIds.clear()
 }
 
@@ -57,6 +72,15 @@ function exposeFaultApi(): void {
       resetFault()
       capabilityRejectionArmed = true
     },
+    armInventoryRpcFailure: () => {
+      failNextInventoryRpc = true
+    },
+    armSettlement: () => {
+      settleCreation?.({ status: 'rejected', error: 'E2E browser creation settlement superseded' })
+      creationSettlement = new Promise<BrowserCreationSettlement>((resolve) => {
+        settleCreation = resolve
+      })
+    },
     release: () => {
       if (!armed || !createdPageId || !releaseCreatedPage) {
         return false
@@ -73,11 +97,40 @@ function exposeFaultApi(): void {
       capabilityRejectionArmed,
       createdPageId,
       suppressedPageIds: [...suppressedPageIds]
-    })
+    }),
+    takeInventoryRpcFailure: () => {
+      if (!failNextInventoryRpc) {
+        return null
+      }
+      failNextInventoryRpc = false
+      return 'e2e_forced_inventory_rpc_failure'
+    },
+    waitForSettlement: async () => {
+      if (!creationSettlement) {
+        throw new Error('E2E browser creation settlement was not armed')
+      }
+      return creationSettlement
+    }
   }
 }
 
 exposeFaultApi()
+
+export function observeE2eWebRuntimeBrowserCreation(result: Promise<boolean>): void {
+  if (!e2eConfig.exposeStore || !settleCreation) {
+    return
+  }
+  const settle = settleCreation
+  settleCreation = null
+  void result.then(
+    (created) => settle({ status: 'fulfilled', created }),
+    (error) =>
+      settle({
+        status: 'rejected',
+        error: error instanceof Error ? error.message : String(error)
+      })
+  )
+}
 
 export function throwIfE2eWebRuntimeBrowserCapabilityUnavailable(): void {
   if (!e2eConfig.exposeStore || !capabilityRejectionArmed) {

--- a/src/renderer/src/runtime/web-runtime-browser-creation-e2e-fault.ts
+++ b/src/renderer/src/runtime/web-runtime-browser-creation-e2e-fault.ts
@@ -40,6 +40,10 @@ let creationSettlement: Promise<BrowserCreationSettlement> | null = null
 const suppressedPageIds = new Set<string>()
 const MAX_SUPPRESSED_PAGE_IDS = 128
 
+function rejectPendingCreationSettlement(error: string): void {
+  settleCreation?.({ status: 'rejected', error })
+}
+
 function resetFault(): void {
   releaseCreatedPage?.()
   armed = false
@@ -49,7 +53,7 @@ function resetFault(): void {
   failNextInventoryRpc = false
   releaseCreatedPage = null
   createdPageBarrier = null
-  settleCreation?.({ status: 'rejected', error: 'E2E browser creation settlement reset' })
+  rejectPendingCreationSettlement('E2E browser creation settlement reset')
   settleCreation = null
   creationSettlement = null
   suppressedPageIds.clear()
@@ -76,7 +80,7 @@ function exposeFaultApi(): void {
       failNextInventoryRpc = true
     },
     armSettlement: () => {
-      settleCreation?.({ status: 'rejected', error: 'E2E browser creation settlement superseded' })
+      rejectPendingCreationSettlement('E2E browser creation settlement superseded')
       creationSettlement = new Promise<BrowserCreationSettlement>((resolve) => {
         settleCreation = resolve
       })

--- a/tests/e2e/helpers/paired-html-preview-inventory.ts
+++ b/tests/e2e/helpers/paired-html-preview-inventory.ts
@@ -1,0 +1,134 @@
+import type { Page } from '@stablyai/playwright-test'
+
+export type PairedHtmlPreviewInventory = {
+  clientRemotePageIds: string[]
+  clientUnifiedTabs: { groupId: string; id: string }[]
+  clientWorkspaceIds: string[]
+  hostPageIds: string[]
+  hostTabs: { browserPageId: string | null; id: string }[]
+  hostResponseError: string | null
+  hostResponseOk: boolean
+  hostTabGroups: { id: string; tabOrder: string[] }[]
+  hostTabIds: string[]
+  totalClientUnified: number
+  totalClientWorkspaces: number
+  totalHost: number
+}
+
+export async function readPairedHtmlPreviewInventory(
+  page: Page,
+  args: {
+    environmentId: string
+    fixtureName: string
+    worktreeId: string
+  }
+): Promise<PairedHtmlPreviewInventory> {
+  return page.evaluate(async ({ environmentId, fixtureName, worktreeId }) => {
+    const fault = (
+      window as Window & {
+        __webRuntimeBrowserCreationFault?: { takeInventoryRpcFailure: () => string | null }
+      }
+    ).__webRuntimeBrowserCreationFault?.takeInventoryRpcFailure()
+    const response = fault
+      ? ({
+          ok: false,
+          error: { code: fault, message: 'E2E forced inventory RPC failure' }
+        } as const)
+      : await window.api.runtimeEnvironments.call({
+          selector: environmentId,
+          method: 'session.tabs.list',
+          params: { worktree: `id:${worktreeId}` },
+          timeoutMs: 15_000
+        })
+    const state = window.__store?.getState()
+    const hostResponseOk = response.ok
+    const hostResponseError = response.ok ? null : JSON.stringify(response.error)
+    const clientWorkspaces = (state?.browserTabsByWorktree[worktreeId] ?? []).filter((tab) =>
+      tab.url.endsWith(`/${fixtureName}`)
+    )
+    const clientWorkspaceIds = clientWorkspaces.map((tab) => tab.id)
+    const clientPages = clientWorkspaces.flatMap(
+      (workspace) => state?.browserPagesByWorkspace[workspace.id] ?? []
+    )
+    const hostTabs = hostResponseOk
+      ? response.result.tabs.filter(
+          (tab) => tab.type === 'browser' && tab.url.endsWith(`/${fixtureName}`)
+        )
+      : []
+    return {
+      clientRemotePageIds: clientPages.flatMap((browserPage) => {
+        const remotePageId = state?.remoteBrowserPageHandlesByPageId[browserPage.id]?.remotePageId
+        return remotePageId ? [remotePageId] : []
+      }),
+      clientUnifiedTabs: (state?.unifiedTabsByWorktree[worktreeId] ?? [])
+        .filter((tab) => tab.contentType === 'browser' && clientWorkspaceIds.includes(tab.entityId))
+        .map((tab) => ({ groupId: tab.groupId, id: tab.id })),
+      clientWorkspaceIds,
+      hostPageIds: hostTabs.flatMap((tab) =>
+        tab.type === 'browser' && tab.browserPageId ? [tab.browserPageId] : []
+      ),
+      hostTabs: hostTabs.map((tab) => ({
+        browserPageId: tab.type === 'browser' ? (tab.browserPageId ?? null) : null,
+        id: tab.id
+      })),
+      hostResponseError,
+      hostResponseOk,
+      hostTabGroups: hostResponseOk ? (response.result.tabGroups ?? []) : [],
+      hostTabIds: hostTabs.map((tab) => tab.id),
+      totalClientUnified: (state?.unifiedTabsByWorktree[worktreeId] ?? []).filter(
+        (tab) => tab.contentType === 'browser'
+      ).length,
+      totalClientWorkspaces: (state?.browserTabsByWorktree[worktreeId] ?? []).length,
+      totalHost: hostResponseOk
+        ? response.result.tabs.filter((tab) => tab.type === 'browser').length
+        : -1
+    }
+  }, args)
+}
+
+type BrowserCreationFaultWindow = Window & {
+  __webRuntimeBrowserCreationFault?: {
+    armInventoryRpcFailure: () => void
+    armSettlement: () => void
+    waitForSettlement: () => Promise<
+      { status: 'fulfilled'; created: boolean } | { status: 'rejected'; error: string }
+    >
+  }
+}
+
+export async function armPairedHtmlPreviewCreationObservation(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const fault = (window as BrowserCreationFaultWindow).__webRuntimeBrowserCreationFault
+    if (!fault) {
+      throw new Error('Browser creation E2E observation seam unavailable')
+    }
+    fault.armSettlement()
+  })
+}
+
+export async function armPairedHtmlPreviewInventoryRpcFailure(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const fault = (window as BrowserCreationFaultWindow).__webRuntimeBrowserCreationFault
+    if (!fault) {
+      throw new Error('Browser inventory E2E fault seam unavailable')
+    }
+    fault.armInventoryRpcFailure()
+  })
+}
+
+export async function waitForPairedHtmlPreviewCreationSettlement(page: Page): Promise<void> {
+  const settlement = await page.evaluate(async () => {
+    const fault = (window as BrowserCreationFaultWindow).__webRuntimeBrowserCreationFault
+    if (!fault) {
+      throw new Error('Browser creation E2E observation seam unavailable')
+    }
+    return fault.waitForSettlement()
+  })
+  if (settlement.status !== 'fulfilled' || !settlement.created) {
+    throw new Error(
+      settlement.status === 'rejected'
+        ? `Remote HTML preview creation rejected: ${settlement.error}`
+        : 'Remote HTML preview creation did not succeed'
+    )
+  }
+}

--- a/tests/e2e/paired-remote-html-browser-focus.spec.ts
+++ b/tests/e2e/paired-remote-html-browser-focus.spec.ts
@@ -7,6 +7,13 @@ import {
   launchPairedElectronClient,
   type PairedElectronClient
 } from './helpers/paired-electron-client'
+import {
+  armPairedHtmlPreviewCreationObservation,
+  armPairedHtmlPreviewInventoryRpcFailure,
+  readPairedHtmlPreviewInventory,
+  type PairedHtmlPreviewInventory,
+  waitForPairedHtmlPreviewCreationSettlement
+} from './helpers/paired-html-preview-inventory'
 import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 
 const FIXTURE_NAME = 'paired-html-focus.html'
@@ -77,28 +84,26 @@ test('keeps remote HTML preview placement and focuses it only after a click', as
       throw new Error('paired client editor had no source identity before side preview')
     }
     const sourceGroupId = sourceEditor.groupId
-    const browserBaseline = await page.evaluate(
-      async ({ environmentId, worktreeId }) => {
-        const state = window.__store?.getState()
-        const response = await window.api.runtimeEnvironments.call({
-          selector: environmentId,
-          method: 'session.tabs.list',
-          params: { worktree: `id:${worktreeId}` },
-          timeoutMs: 15_000
-        })
-        return {
-          clientUnified: (state?.unifiedTabsByWorktree[worktreeId] ?? []).filter(
-            (tab) => tab.contentType === 'browser'
-          ).length,
-          clientWorkspaces: (state?.browserTabsByWorktree[worktreeId] ?? []).length,
-          host: response.ok
-            ? response.result.tabs.filter((tab) => tab.type === 'browser').length
-            : -1
-        }
-      },
-      { environmentId: client.environmentId, worktreeId }
-    )
+    let browserBaseline: PairedHtmlPreviewInventory | null = null
+    await expect
+      .poll(
+        async () => {
+          browserBaseline = await readPairedHtmlPreviewInventory(page, {
+            environmentId: client!.environmentId,
+            fixtureName: FIXTURE_NAME,
+            worktreeId
+          })
+          return browserBaseline
+        },
+        { timeout: 30_000, message: 'host browser baseline was never successfully observed' }
+      )
+      .toMatchObject({ hostResponseError: null, hostResponseOk: true })
+    if (!browserBaseline?.hostResponseOk) {
+      throw new Error(`host browser baseline failed: ${browserBaseline.hostResponseError}`)
+    }
+    await armPairedHtmlPreviewCreationObservation(page)
     await openPreviewToSide.click()
+    await waitForPairedHtmlPreviewCreationSettlement(page)
 
     await expect
       .poll(
@@ -145,48 +150,59 @@ test('keeps remote HTML preview placement and focuses it only after a click', as
         handleEnvironmentId: client.environmentId,
         hostHasHtml: true
       })
-    const htmlTabInventory = await page.evaluate(
-      async ({ environmentId, fixtureName, worktreeId }) => {
-        const state = window.__store?.getState()
-        const response = await window.api.runtimeEnvironments.call({
-          selector: environmentId,
-          method: 'session.tabs.list',
-          params: { worktree: `id:${worktreeId}` },
-          timeoutMs: 15_000
-        })
-        const clientWorkspaceIds = (state?.browserTabsByWorktree[worktreeId] ?? [])
-          .filter((tab) => tab.url.endsWith(`/${fixtureName}`))
-          .map((tab) => tab.id)
-        return {
-          clientWorkspaceIds,
-          clientUnifiedTabs: (state?.unifiedTabsByWorktree[worktreeId] ?? [])
-            .filter(
-              (tab) => tab.contentType === 'browser' && clientWorkspaceIds.includes(tab.entityId)
-            )
-            .map((tab) => ({ groupId: tab.groupId, id: tab.id })),
-          hostTabIds: response.ok
-            ? response.result.tabs
-                .filter((tab) => tab.type === 'browser' && tab.url.endsWith(`/${fixtureName}`))
-                .map((tab) => tab.id)
-            : [],
-          hostTabGroups: response.ok ? (response.result.tabGroups ?? []) : [],
-          totalClientUnified: (state?.unifiedTabsByWorktree[worktreeId] ?? []).filter(
-            (tab) => tab.contentType === 'browser'
-          ).length,
-          totalClientWorkspaces: (state?.browserTabsByWorktree[worktreeId] ?? []).length,
-          totalHost: response.ok
-            ? response.result.tabs.filter((tab) => tab.type === 'browser').length
-            : -1
-        }
-      },
-      { environmentId: client.environmentId, fixtureName: FIXTURE_NAME, worktreeId }
-    )
+    let htmlTabInventory: PairedHtmlPreviewInventory | null = null
+    let injectedInventoryErrorObserved = false
+    let inventoryFailureArmed = false
+    let previousSuccessfulInventory: string | null = null
+    let stableSuccessfulSnapshots = 0
+    await expect
+      .poll(
+        async () => {
+          htmlTabInventory = await readPairedHtmlPreviewInventory(page, {
+            environmentId: client!.environmentId,
+            fixtureName: FIXTURE_NAME,
+            worktreeId
+          })
+          if (!htmlTabInventory.hostResponseOk) {
+            injectedInventoryErrorObserved ||=
+              htmlTabInventory.hostResponseError?.includes('e2e_forced_inventory_rpc_failure') ===
+              true
+            previousSuccessfulInventory = null
+            stableSuccessfulSnapshots = 0
+          } else {
+            if (!inventoryFailureArmed) {
+              await armPairedHtmlPreviewInventoryRpcFailure(page)
+              inventoryFailureArmed = true
+            }
+            const fingerprint = JSON.stringify([
+              htmlTabInventory.hostPageIds,
+              htmlTabInventory.hostTabIds,
+              htmlTabInventory.totalHost
+            ])
+            stableSuccessfulSnapshots =
+              fingerprint === previousSuccessfulInventory ? stableSuccessfulSnapshots + 1 : 1
+            previousSuccessfulInventory = fingerprint
+          }
+          return { ...htmlTabInventory, stableSuccessfulSnapshots }
+        },
+        { timeout: 60_000, message: 'host HTML inventory did not settle successfully' }
+      )
+      .toMatchObject({
+        hostResponseError: null,
+        hostResponseOk: true,
+        stableSuccessfulSnapshots: 2
+      })
+    expect(injectedInventoryErrorObserved).toBe(true)
+    if (!htmlTabInventory) {
+      throw new Error('host HTML inventory disappeared after successful settlement')
+    }
     expect(htmlTabInventory.clientWorkspaceIds).toHaveLength(1)
     expect(htmlTabInventory.clientUnifiedTabs).toHaveLength(1)
     expect(htmlTabInventory.hostTabIds).toHaveLength(1)
-    expect(htmlTabInventory.totalClientUnified).toBe(browserBaseline.clientUnified + 1)
-    expect(htmlTabInventory.totalClientWorkspaces).toBe(browserBaseline.clientWorkspaces + 1)
-    expect(htmlTabInventory.totalHost).toBe(browserBaseline.host + 1)
+    expect(htmlTabInventory.clientRemotePageIds).toEqual(htmlTabInventory.hostPageIds)
+    expect(htmlTabInventory.totalClientUnified).toBe(browserBaseline.totalClientUnified + 1)
+    expect(htmlTabInventory.totalClientWorkspaces).toBe(browserBaseline.totalClientWorkspaces + 1)
+    expect(htmlTabInventory.totalHost).toBe(browserBaseline.totalHost + 1)
     expect(htmlTabInventory.clientUnifiedTabs[0]?.groupId).not.toBe(sourceGroupId)
     expect(
       htmlTabInventory.hostTabGroups.some(
@@ -279,24 +295,7 @@ test('keeps remote HTML preview placement and focuses it only after a click', as
         { timeout: 30_000, message: 'host never accepted terminal activation' }
       )
       .toBe(true)
-    const hostBrowserTab = await page.evaluate(
-      async ({ environmentId, fixtureName, worktreeId }) => {
-        const response = await window.api.runtimeEnvironments.call({
-          selector: environmentId,
-          method: 'session.tabs.list',
-          params: { worktree: `id:${worktreeId}` },
-          timeoutMs: 15_000
-        })
-        const tab = response.ok
-          ? response.result.tabs.find(
-              (candidate) =>
-                candidate.type === 'browser' && candidate.url.endsWith(`/${fixtureName}`)
-            )
-          : null
-        return tab?.type === 'browser' ? { browserPageId: tab.browserPageId, id: tab.id } : null
-      },
-      { environmentId: client.environmentId, fixtureName: FIXTURE_NAME, worktreeId }
-    )
+    const hostBrowserTab = htmlTabInventory.hostTabs[0]
     if (!hostBrowserTab?.browserPageId) {
       throw new Error('host HTML browser tab disappeared before activation')
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​211 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​78 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​133 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​60 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​59 |

<!-- /orca-pr-loc -->

## ELI5

The failing E2E had already seen the remote HTML page on the host and client. It then made another host inventory request and converted either an RPC failure or a successful empty snapshot into the same `[]` result. The archived trace does not preserve that final response, so the reported failure is ambiguous and does not prove synchronization retracted.

This hardens the E2E oracle. It awaits the exact preview-creation promise, requires one real successful post-settlement host inventory, injects an explicit error-shaped observation and treats it as unknown, then requires two matching successful host snapshots plus exact host/client page identity before continuing.

## Evidence

- Affected CI run `32601364123`, SHA `02bee48e1d`: the trace proves earlier client materialization and a host inventory with `hostHasHtml=true`; the later derived `hostTabIds=[]` cannot distinguish RPC failure from an authoritative empty snapshot.
- Exact latest main `d1127b9939`: the original unmodified, freshly built journey passes in the headed desktop-host plus separate paired Electron-client topology (21.4s test body, 26.4s overall).
- Candidate `b5c3abee3b`: the hardened headed journey passes (19.8s test body, 24.6s overall); the hidden-window topology also passes (21.8s test body).
- Counterfactual with unknown-as-empty handling restored: deterministically fails with `Expected length: 1`, `Received array: []` on the injected `{ok:false,error}` observation after a real successful post-settlement host snapshot.
- Visible/runtime proof: editor and remote preview split render together; the oracle also verifies exact remote page identity, browser content, activation, focus, and ID-specific close convergence.

No successful authoritative host snapshot has demonstrated retraction or rollback.

## Scope and authority

- Host `session.tabs.list` remains authoritative for creation and publication.
- The client store plus rendered remote-browser frame independently prove materialization.
- Product behavior, wire formats, runtime retry policy, and remote ownership are unchanged. The only production-file touch extends the existing `e2eConfig.exposeStore`-gated fault/observation seam so the otherwise fire-and-forget creation promise can be awaited by E2E.
- Polling and the forced inventory error are bounded to this single E2E journey; there is no production polling, fanout, timer, or retained listener.

A helper-local injected-error option was considered, but it would move the test below the real response boundary. Product retries, rollback guards, and call-site defenses were rejected because current main does not reproduce an authoritative state defect.

## Validation

- `pnpm typecheck`
- `pnpm run verify:localization-coverage`
- `node config/scripts/check-changed-code-quality.mjs`
- `pnpm exec oxfmt --check` on all four changed files
- 32 focused unit contracts passed
- Fresh-build and isolated headed paired Electron journeys passed
- Final independent reviews: architecture clean; product/UX requested evidence wording only; adversarial regression clean
- PR CI green: 45 passed, 2 expected skips

Known limits: the settlement observer can wait until the 240s spec timeout if the action is never reached. The exact journey was not separately run on Windows, folder workspaces, multiple simultaneous clients, mixed client/server versions, or fully headless parity; the patch is E2E-gated and does not change their product or wire behavior.

Known unrelated E2E infrastructure noise was kept separate: repeated invocations intermittently failed while loading seeded worktrees, initializing the paired client, or retaining activation. The same repeat-only failures reproduced on unmodified main.

## Linked issue

STA-5210
