### PR TITLE
fix(skills): recover upload admission lifecycle

### DIFF
--- a/src/main/skills/skill-upload-retained-paths.ts
+++ b/src/main/skills/skill-upload-retained-paths.ts
@@ -20,6 +20,12 @@ export class SkillUploadRetainedPaths {
     this.failedCleanup.add(path)
   }
 
+  async removeUnpublished(path: string, close: () => Promise<void>): Promise<void> {
+    this.retainFailedCleanup(path)
+    await close().catch(() => undefined)
+    await this.removeFailedCleanup(path).catch(() => undefined)
+  }
+
   async removeTransferred(path: string): Promise<void> {
     await rm(path, { force: true })
     this.transferred.delete(path)
@@ -32,5 +38,9 @@ export class SkillUploadRetainedPaths {
 
   async removeAllFailedCleanup(): Promise<void> {
     await Promise.all([...this.failedCleanup].map((path) => this.removeFailedCleanup(path)))
+  }
+
+  async retryFailedCleanup(): Promise<void> {
+    await Promise.allSettled([...this.failedCleanup].map((path) => this.removeFailedCleanup(path)))
   }
 }

--- a/src/main/skills/skill-upload-session-admission-regression.test.ts
+++ b/src/main/skills/skill-upload-session-admission-regression.test.ts
@@ -1,0 +1,120 @@
+import { createHash } from 'node:crypto'
+import { mkdtemp, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { SkillUploadSessionService } from './skill-upload-session-service'
+
+const roots: string[] = []
+
+type RetainedPathCleanup = {
+  removeFailedCleanup(path: string): Promise<void>
+}
+
+afterEach(async () => {
+  vi.useRealTimers()
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+function identity(bytes: Buffer) {
+  return {
+    packageId: 'package_1',
+    versionId: 'version_1',
+    packageDigest: 'a'.repeat(64),
+    archiveSha256: createHash('sha256').update(bytes).digest('hex'),
+    compressedBytes: bytes.length
+  }
+}
+
+function retainedPathCleanup(service: SkillUploadSessionService): RetainedPathCleanup {
+  return Reflect.get(service, 'retainedPaths') as RetainedPathCleanup
+}
+
+async function stagedArchiveCount(uploads: string): Promise<number> {
+  const owners = await readdir(uploads, { withFileTypes: true })
+  const archives = await Promise.all(
+    owners
+      .filter((entry) => entry.isDirectory())
+      .map(async (entry) =>
+        (await readdir(join(uploads, entry.name))).filter((name) => name.endsWith('.tar.gz'))
+      )
+  )
+  return archives.flat().length
+}
+
+describe('SkillUploadSessionService admission regressions', () => {
+  it('does not publish a session after disposal starts during pruning', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-23T00:00:00Z'))
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-upload-admission-'))
+    roots.push(root)
+    const uploads = join(root, 'uploads')
+    const service = new SkillUploadSessionService(uploads, { idleMs: 10 })
+    await service.begin({ package: identity(Buffer.from('expired')) })
+    vi.setSystemTime(new Date('2026-08-23T00:00:00.011Z'))
+
+    const retainedPaths = retainedPathCleanup(service)
+    const removeFailedCleanup = retainedPaths.removeFailedCleanup.bind(retainedPaths)
+    let releaseCleanup!: () => void
+    const cleanupReleased = new Promise<void>((resolve) => {
+      releaseCleanup = resolve
+    })
+    let markCleanupStarted!: () => void
+    const cleanupStarted = new Promise<void>((resolve) => {
+      markCleanupStarted = resolve
+    })
+    vi.spyOn(retainedPaths, 'removeFailedCleanup').mockImplementation(async (path) => {
+      markCleanupStarted()
+      await cleanupReleased
+      await removeFailedCleanup(path)
+    })
+
+    const begin = service.begin({ package: identity(Buffer.from('closing')) })
+    await cleanupStarted
+    const disposal = service.dispose()
+    releaseCleanup()
+    const [beginResult] = await Promise.allSettled([begin])
+    await disposal
+
+    expect(beginResult).toMatchObject({
+      status: 'rejected',
+      reason: expect.objectContaining({ message: 'skill-upload-service-disposed' })
+    })
+    expect(await stagedArchiveCount(uploads)).toBe(0)
+  })
+
+  it('retries transient failed cleanup before rejecting recovered capacity', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-upload-admission-'))
+    roots.push(root)
+    const uploads = join(root, 'uploads')
+    const service = new SkillUploadSessionService(uploads)
+    const retainedPaths = retainedPathCleanup(service)
+    const removeFailedCleanup = retainedPaths.removeFailedCleanup.bind(retainedPaths)
+    let failuresRemaining = 4
+    vi.spyOn(retainedPaths, 'removeFailedCleanup').mockImplementation(async (path) => {
+      if (failuresRemaining > 0) {
+        failuresRemaining -= 1
+        throw new Error('injected-transient-rm-failure')
+      }
+      await removeFailedCleanup(path)
+    })
+
+    const sessions = await Promise.all(
+      Array.from({ length: 4 }, (_, index) =>
+        service.begin({ package: identity(Buffer.from(`failed-cleanup-${index}`)) })
+      )
+    )
+    for (const session of sessions) {
+      await expect(service.cancel(session.uploadId)).rejects.toThrow(
+        'injected-transient-rm-failure'
+      )
+    }
+    expect(await stagedArchiveCount(uploads)).toBe(4)
+
+    await expect(
+      service.begin({ package: identity(Buffer.from('recovered-capacity')) })
+    ).resolves.toMatchObject({ acknowledgedOffset: 0 })
+    expect(await stagedArchiveCount(uploads)).toBe(1)
+    await service.dispose()
+  })
+})

--- a/src/main/skills/skill-upload-session-admission-regression.test.ts
+++ b/src/main/skills/skill-upload-session-admission-regression.test.ts
@@ -43,7 +43,7 @@ async function stagedArchiveCount(uploads: string): Promise<number> {
 }
 
 describe('SkillUploadSessionService admission regressions', () => {
-  it('does not publish a session after disposal starts during pruning', async () => {
+  it('does not return a session after disposal starts during pruning', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-08-23T00:00:00Z'))
     const root = await mkdtemp(join(tmpdir(), 'orca-skill-upload-admission-'))
@@ -51,6 +51,12 @@ describe('SkillUploadSessionService admission regressions', () => {
     const uploads = join(root, 'uploads')
     const service = new SkillUploadSessionService(uploads, { idleMs: 10 })
     await service.begin({ package: identity(Buffer.from('expired')) })
+    vi.setSystemTime(new Date('2026-08-23T00:00:00.005Z'))
+    const activeRequest = {
+      package: identity(Buffer.from('active')),
+      transferId: 'active-transfer'
+    }
+    await service.begin(activeRequest)
     vi.setSystemTime(new Date('2026-08-23T00:00:00.011Z'))
 
     const retainedPaths = retainedPathCleanup(service)
@@ -69,7 +75,7 @@ describe('SkillUploadSessionService admission regressions', () => {
       await removeFailedCleanup(path)
     })
 
-    const begin = service.begin({ package: identity(Buffer.from('closing')) })
+    const begin = service.begin(activeRequest)
     await cleanupStarted
     const disposal = service.dispose()
     releaseCleanup()

--- a/src/main/skills/skill-upload-session-admission-regression.test.ts
+++ b/src/main/skills/skill-upload-session-admission-regression.test.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto'
 import { mkdtemp, readdir, rm } from 'node:fs/promises'
+import type * as NodeFsPromises from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -7,12 +8,36 @@ import { SkillUploadSessionService } from './skill-upload-session-service'
 
 const roots: string[] = []
 
+const openGate = vi.hoisted(() => ({
+  release: null as Promise<void> | null,
+  started: null as (() => void) | null
+}))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFsPromises>()
+  return {
+    ...actual,
+    open: async (path: string, flags: string, mode?: number) => {
+      const handle = await actual.open(path, flags, mode)
+      if (openGate.release) {
+        const release = openGate.release
+        openGate.release = null
+        openGate.started?.()
+        await release
+      }
+      return handle
+    }
+  }
+})
+
 type RetainedPathCleanup = {
   removeFailedCleanup(path: string): Promise<void>
 }
 
 afterEach(async () => {
   vi.useRealTimers()
+  openGate.release = null
+  openGate.started = null
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
 })
 
@@ -122,5 +147,34 @@ describe('SkillUploadSessionService admission regressions', () => {
     ).resolves.toMatchObject({ acknowledgedOffset: 0 })
     expect(await stagedArchiveCount(uploads)).toBe(1)
     await service.dispose()
+  })
+
+  it('removes an unpublished archive when disposal starts during open', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-skill-upload-admission-'))
+    roots.push(root)
+    const uploads = join(root, 'uploads')
+    const service = new SkillUploadSessionService(uploads)
+    let releaseOpen!: () => void
+    openGate.release = new Promise<void>((resolve) => {
+      releaseOpen = resolve
+    })
+    let markOpenStarted!: () => void
+    const openStarted = new Promise<void>((resolve) => {
+      markOpenStarted = resolve
+    })
+    openGate.started = markOpenStarted
+
+    const begin = service.begin({ package: identity(Buffer.from('opened-during-disposal')) })
+    await openStarted
+    const disposal = service.dispose()
+    releaseOpen()
+    const [beginResult] = await Promise.allSettled([begin])
+    await disposal
+
+    expect(beginResult).toMatchObject({
+      status: 'rejected',
+      reason: expect.objectContaining({ message: 'skill-upload-service-disposed' })
+    })
+    expect(await stagedArchiveCount(uploads)).toBe(0)
   })
 })

--- a/src/main/skills/skill-upload-session-record.ts
+++ b/src/main/skills/skill-upload-session-record.ts
@@ -17,6 +17,25 @@ export type SkillUploadSessionRecord = {
   committed: boolean
 }
 
+export function createSkillUploadSessionRecord(
+  id: string,
+  path: string,
+  request: SkillUploadBeginRequest,
+  handle: FileHandle
+): SkillUploadSessionRecord {
+  return {
+    id,
+    path,
+    package: request.package,
+    transferId: request.transferId ?? null,
+    handle,
+    idleTimer: null,
+    bytesReceived: 0,
+    touchedAt: Date.now(),
+    committed: false
+  }
+}
+
 export function skillUploadBeginResult(session: SkillUploadSessionRecord): SkillUploadBeginResult {
   return {
     uploadId: session.id,

--- a/src/main/skills/skill-upload-session-service.ts
+++ b/src/main/skills/skill-upload-session-service.ts
@@ -13,6 +13,7 @@ import { SkillUploadOperationLifecycle } from './skill-upload-operation-lifecycl
 import { SkillUploadRetainedPaths } from './skill-upload-retained-paths'
 import type { SkillUploadSessionServiceOptions } from './skill-upload-session-service-options'
 import {
+  createSkillUploadSessionRecord,
   skillUploadBeginResult,
   type SkillUploadSessionRecord
 } from './skill-upload-session-record'
@@ -55,22 +56,22 @@ export class SkillUploadSessionService {
         return skillUploadBeginResult(existing)
       }
       if (this.sessions.size + this.retainedPaths.failedCleanupCount >= MAX_SESSIONS) {
+        await this.retainedPaths.retryFailedCleanup()
+      }
+      this.assertAvailable()
+      if (this.sessions.size + this.retainedPaths.failedCleanupCount >= MAX_SESSIONS) {
         throw new Error('skill-upload-session-limit')
       }
       const id = randomUUID()
       const path = join(this.ownership.directory, `${id}.tar.gz`)
       const handle = await open(path, 'wx+', 0o600)
-      const session: SkillUploadSessionRecord = {
-        id,
-        path,
-        package: request.package,
-        transferId: request.transferId ?? null,
-        handle,
-        idleTimer: null,
-        bytesReceived: 0,
-        touchedAt: Date.now(),
-        committed: false
+      try {
+        this.assertAvailable()
+      } catch (error) {
+        await this.retainedPaths.removeUnpublished(path, () => handle.close())
+        throw error
       }
+      const session = createSkillUploadSessionRecord(id, path, request, handle)
       this.sessions.set(id, session)
       this.touch(session)
       return skillUploadBeginResult(session)

--- a/src/main/skills/skill-upload-session-service.ts
+++ b/src/main/skills/skill-upload-session-service.ts
@@ -43,8 +43,8 @@ export class SkillUploadSessionService {
     const leaveOperation = await this.operations.enterBegin(() => this.assertAvailable())
     try {
       await this.initialize()
-      this.assertAvailable()
       await this.prune()
+      this.assertAvailable()
       const existing = request.transferId
         ? [...this.sessions.values()].find((session) => session.transferId === request.transferId)
         : undefined


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​180 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​180 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​30 |

<!-- /orca-pr-loc -->

## ELI5

Shutdown could let one last upload session escape and then immediately delete it. Separately, four temporary file-removal failures could make the service report "full" until disposal or restart. The upload-session owner now fences admission after awaited cleanup and retries its bounded failed-cleanup set only when capacity is needed.

## Invariant and owner

`SkillUploadSessionService` may return/publish a session only while authoritative and within its four-owned-path budget. Disposal revokes admission before publication. Capacity can reject only after retrying transient failed owned cleanup.

The session service is the sole owner of the disposed flag, session map, four-path policy, and admission serialization; callers and relay transports are not authoritative.

## What changed

- Fence availability immediately after pruning, before resumed-transfer lookup.
- Retry at most four retained cleanup failures only under admission pressure, then recheck availability and capacity.
- Fence again after archive `open()` and roll back an unpublished archive through the retained-path owner.
- Keep persistent failures counted and preserve strict disposal cleanup errors.
- Add deterministic deferred-cleanup and one-shot removal-failure regressions.

## Deterministic topology and independent oracles

STA-5090 uses one expired session plus one live resumable transfer. Expired cleanup is deferred, resumed `begin()` starts, disposal revokes admission and waits, then cleanup is released.

- API oracle: `begin()` rejects `skill-upload-service-disposed`.
- Filesystem oracle: staged `.tar.gz` count is zero after disposal.

STA-5091 creates four sessions whose archive removal fails exactly once, leaving four retained paths, then starts one more `begin()`.

- API oracle: admission resolves at offset zero instead of rejecting `skill-upload-session-limit`.
- Filesystem oracle: staged archive count recovers from four to one.

## Reproduction matrix

| Build | STA-5090 | STA-5091 |
| --- | --- | --- |
| Merged affected commit `1ce2e562b3` | RED: doomed resumed session fulfilled | RED: transient failures exhausted capacity |
| Latest main snapshots `4c984d4c1b`, `b2902cb61e`, and `d1127b9939` | RED | RED |
| Candidate `c7b750e416` | GREEN | GREEN |
| Candidate with the three product files reverted to `d1127b9939` | RED | RED |

Latest-main and product-revert failures are the same public symptoms: fulfilled `begin()` after disposal and `skill-upload-session-limit` after one-shot cleanup failures.

## Design choice

Chosen: a lifecycle fence and capacity-pressure retry in the authoritative session owner.

Rejected:

- caller/relay retries, which duplicate policy across desktop, relay, SSH, and future callers;
- periodic/background cleanup, which adds timers/polling and still leaves false-capacity windows;
- scattered guards around individual return sites, which obscure the admission linearization point.

The retry is idempotent forced removal, serialized by existing begin admission, bounded to four paths, and absent from the common path. Persistent failures remain conservative capacity reservations and are retried again during strict disposal/startup cleanup.

## Compatibility and performance

No RPC, stream opcode, UI, provider, Git, SSH/WSL, folder-workspace, or mixed-version wire contract changes. No new timer, polling, subprocess, or common-path filesystem work. The only extra removal attempts happen when all four owned-path slots are consumed.

## Validation

On rebased head `c7b750e416` over latest main `d1127b9939`:

- focused upload service/regressions: 18 passed;
- `pnpm test:skill-sharing:release`: 592 passed, 38 skipped;
- `pnpm typecheck`;
- `pnpm lint`, including reliability, max-lines, runtime, skill-manifest, and localization gates;
- `git diff --check`;
- product-revert oracle: both regression tests fail for their targeted symptoms.

Current-head CI completed 45 checks successfully with two unchanged E2E-selection skips. The deterministic causal regressions repeated 75/75; the real-process restart topology passed 4/4; and the client/multi-relay topology passed 8 tests with 2 intentional skips. Electron UI validation is not applicable: this is a host filesystem service with no rendered UI or wire change.

## Reviews

- Internal review: two rounds. Fixed one High finding where resumed-transfer lookup bypassed the first fence; second round clean.
- Fresh Codex architecture review: found the same resumed-transfer hole; fixed and strengthened the topology.
- Fresh Codex concurrency/failure review: clean.
- Fresh Codex test/topology review: clean; repeated the oracle 25 times.
- Fresh OpenCode ownership review: upload boundary clean. Its one Low `finally` suggestion was rejected after validation because retained failures make ownership non-empty, so the proposed call cannot remove anything and strict cleanup failure is intentional.
- Fresh OpenCode adversarial concurrency review: upload files clean; independently reproduced red/green/revert and passed 531 skills tests. Its two out-of-scope WSL findings were branch ancestry drift and disappeared when rebased onto `d1127b9939`.\n- Final independent review: the first fresh round found one Low causal-test gap around the post-`open()` disposal fence. Deterministic deferred-open coverage proved the test red with only that fence disabled. The required fresh clean round then returned CLEAN from architecture, product/UX, and adversarial reviewers.

## Linked issues

- STA-5090
- STA-5091

Draft only. Do not merge until human review and the rebased CI run are complete.



