### PR TITLE
test(e2e): stabilize paired Quick Open large-tree coverage

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -134,7 +134,8 @@ jobs:
       # scripts still need the Linux toolchain even though this shard reuses
       # the prebuilt Electron output.
       - name: Install native build tools
-        run: sudo apt-get update && sudo apt-get install -y build-essential fonts-noto-cjk python3 zsh
+        # Why: paired Quick Open coverage exercises the resource-bounded host search.
+        run: sudo apt-get update && sudo apt-get install -y build-essential fonts-noto-cjk python3 ripgrep zsh
 
       # Why: Electron on Linux needs an X display even when the app
       # suppresses mainWindow.show() via ORCA_E2E_HEADLESS. xvfb provides a

--- a/tests/e2e/paired-quick-open-large-tree.spec.ts
+++ b/tests/e2e/paired-quick-open-large-tree.spec.ts
@@ -10,6 +10,8 @@ import { createPairedQuickOpenLargeTreeFixture } from './helpers/paired-quick-op
 import type { PairedQuickOpenLargeTreeFixture } from './helpers/paired-quick-open-large-tree-fixture'
 import { waitForSessionReady } from './helpers/store'
 
+const QUICK_OPEN_SEARCH_DEBOUNCE_MS = 120
+
 async function activateWorktree(page: Page, repoPath: string, timeout = 60_000): Promise<string> {
   await expect
     .poll(
@@ -57,47 +59,8 @@ async function expectQuickOpenAndRuntimeHealthy(
 ): Promise<void> {
   const dialog = client.page.getByRole('dialog', { name: 'Go to file' })
   const input = dialog.getByPlaceholder('Go to file...')
-  for (const targetPath of [fixture.gitIgnoredTargetPath, fixture.orcaIgnoredTargetPath]) {
-    const filename = targetPath.split('/').at(-1)!
-    const stat = await client.page.evaluate(
-      async ({ environmentId, worktreeId, targetPath }) => {
-        const response = await window.api.runtimeEnvironments.call({
-          selector: environmentId,
-          method: 'files.stat',
-          params: { worktree: `id:${worktreeId}`, relativePath: targetPath }
-        })
-        if (!response.ok) {
-          throw new Error(`files.stat oracle failed: ${JSON.stringify(response)}`)
-        }
-        return response.result
-      },
-      { environmentId: client.environmentId, worktreeId, targetPath }
-    )
-    expect(stat.isDirectory).toBe(false)
-    expect(stat.size).toBeGreaterThanOrEqual(0)
-    await input.fill(filename.slice(0, 8))
-    await input.fill(filename.slice(0, 18))
-    await input.fill(filename)
-    await expect(dialog.getByText('Loading files...')).toHaveCount(0, { timeout: 60_000 })
-    await expect(dialog.getByRole('option').filter({ hasText: filename })).toHaveCount(1)
-    await expect(dialog).not.toContainText('Outbound reply buffer overflow')
-    await expect(dialog).not.toContainText('Remote Orca runtime closed the connection')
-  }
-
-  const response = await client.page.evaluate(
-    async ({ environmentId }) =>
-      window.api.runtimeEnvironments.call({
-        selector: environmentId,
-        method: 'worktree.list',
-        params: { limit: 10_000 }
-      }),
-    { environmentId: client.environmentId }
-  )
-  expect(response.ok).toBe(true)
-  if (response.ok) {
-    expect(response.result.worktrees.some((worktree) => worktree.id === worktreeId)).toBe(true)
-  }
-
+  const loading = dialog.getByText('Loading files...')
+  await client.page.clock.install()
   const queryOracle = async (targetPath: string) =>
     client.page.evaluate(
       async ({ environmentId, worktreeId, targetPath }) => {
@@ -129,10 +92,28 @@ async function expectQuickOpenAndRuntimeHealthy(
       { environmentId: client.environmentId, worktreeId, targetPath }
     )
   for (const targetPath of [fixture.gitIgnoredTargetPath, fixture.orcaIgnoredTargetPath]) {
+    const filename = targetPath.split('/').at(-1)!
+    const stat = await client.page.evaluate(
+      async ({ environmentId, worktreeId, targetPath }) => {
+        const response = await window.api.runtimeEnvironments.call({
+          selector: environmentId,
+          method: 'files.stat',
+          params: { worktree: `id:${worktreeId}`, relativePath: targetPath }
+        })
+        if (!response.ok) {
+          throw new Error(`files.stat oracle failed: ${JSON.stringify(response)}`)
+        }
+        return response.result
+      },
+      { environmentId: client.environmentId, worktreeId, targetPath }
+    )
+    expect(stat.isDirectory).toBe(false)
+    expect(stat.size).toBeGreaterThanOrEqual(0)
+
     const queryResult = await queryOracle(targetPath)
     const repeatedResult = await queryOracle(targetPath)
     console.log(
-      `[STA-4354] query=${targetPath} oracle=${JSON.stringify(queryResult)} repeated=${JSON.stringify(repeatedResult)}`
+      `[STA-5209] query=${targetPath} oracle=${JSON.stringify(queryResult)} repeated=${JSON.stringify(repeatedResult)}`
     )
     expect(queryResult).toEqual(repeatedResult)
     expect(queryResult.files).toEqual([targetPath])
@@ -150,6 +131,36 @@ async function expectQuickOpenAndRuntimeHealthy(
             sha256: '9e7399e32001d443105e0f612f0eb2eee88fba50902dc75c926c547538e93eb5'
           }
     )
+
+    // Why: control only the debounce; RPC deadlines and socket liveness stay on real time.
+    const pauseAt = await client.page.evaluate(() => Date.now() + 1_000)
+    await client.page.clock.pauseAt(pauseAt)
+    await input.fill(filename.slice(0, 8))
+    await input.fill(filename.slice(0, 18))
+    await input.fill(filename)
+    await expect(loading).toBeVisible()
+    await client.page.clock.runFor(QUICK_OPEN_SEARCH_DEBOUNCE_MS)
+    await client.page.clock.resume()
+    await expect(dialog.getByRole('option').filter({ hasText: filename })).toHaveCount(1, {
+      timeout: 60_000
+    })
+    await expect(loading).toHaveCount(0)
+    await expect(dialog).not.toContainText('Outbound reply buffer overflow')
+    await expect(dialog).not.toContainText('Remote Orca runtime closed the connection')
+  }
+
+  const response = await client.page.evaluate(
+    async ({ environmentId }) =>
+      window.api.runtimeEnvironments.call({
+        selector: environmentId,
+        method: 'worktree.list',
+        params: { limit: 10_000 }
+      }),
+    { environmentId: client.environmentId }
+  )
+  expect(response.ok).toBe(true)
+  if (response.ok) {
+    expect(response.result.worktrees.some((worktree) => worktree.id === worktreeId)).toBe(true)
   }
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​53 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​42 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

## ELI5

The reported Quick Open failure was not a product search regression. The affected full Ubuntu E2E lane did not install `ripgrep`, which is the bounded host-search dependency, and the old test hid that error by checking the UI before running its host oracle. This PR provisions the missing CI dependency and makes the test prove host search plus the debounced UI lifecycle in the right order.

## What changed

- Install `ripgrep` in the full Ubuntu E2E job, matching the dependency already present in the changed-spec lane.
- Run the authoritative `files.searchPaths` RPC twice before UI assertions and preserve the complete RPC error.
- Preserve the rapid 8-character, 18-character, and full-filename transitions while the renderer clock is paused.
- Observe loading start, release only the final 120 ms debounce, resume real time, then require the exact DOM option and loading settlement.
- Keep bounded-payload, hash, `files.stat`, `worktree.list`, and paired-connection health assertions.

## Invariant and ownership

After a non-empty paired Quick Open query is committed, the test must observe that query's lifecycle start and settlement before judging the rendered option.

- The workspace-owning host and `files.searchPaths` own search truth.
- The Ubuntu E2E environment owns provisioning the host dependency.
- This spec owns lifecycle observation and synchronization.

No product/runtime/wire behavior changes.

## Reproduction and evidence

Fixture: 88,763 files, including 77,792 ignored files and the nominal 22 GiB sparse file from STA-4354.

- Latest-main snapshot `7a72f341f7`, original spec: 3/3 headless passes locally. During final CI, `main` advanced through `f0c718ecd5` with five commits that touch no Quick Open, search, paired-fixture, or E2E-workflow files. Earlier main checks were also green (`c3a1694b1d` 3/3, `4c984d4c1b` 6/6). The claimed product-level empty search is not reproduced.
- Affected Ubuntu full-E2E topology: run [32663654288](https://github.com/stablyai/orca/actions/runs/32663654288), SHA `9debbe9dc6`. The direct oracle deterministically failed with `Quick Open search requires ripgrep on the host running Quick Open`; the lane had not installed it.
- Current Ubuntu/Xvfb run [32666590080, shard 4](https://github.com/stablyai/orca/actions/runs/32666590080/job/97262015877), SHA `cef2587426`: installed `ripgrep 14.1.0`; both direct RPCs returned each exact target twice with stable hashes; the target headless test passed in 23.6s. The shard's aggregate failure is an unrelated parked-terminal interactivity test (58 passed, 3 skipped, 1 unrelated failure).
- Rebased candidate locally: focused headless 1/1 pass; earlier focused headed and repeated headless runs pass.
- Direct RPC SHA-256 values are stable across macOS and Ubuntu:
  - gitignored: `a6259174bf63bccb04ec461aed9b316f8ef78fe0474a6a101d4f11a383414125`
  - orcaignored: `9e7399e32001d443105e0f612f0eb2eee88fba50902dc75c926c547538e93eb5`
- Strict disabled arm: disabling only `clock.runFor(120)` and `clock.resume()` leaves the same 60-second exact-option oracle and deterministically fails with zero UI options after the direct RPC returned the target. This validates the barrier mechanically; it does not claim the original CI failure was caused only by timing.

## Why this boundary

The full E2E runner is the smallest owner that can supply its required executable. The test barrier is local to the test-only debounce observation problem. Increasing timeouts or waiting only for loading disappearance still omits host evidence; production request IDs/hooks would expand mixed-version product surface; changing the debounce or reverting host-side bounded search would alter healthy product behavior. A broad changed-spec topology rewrite is a separate CI concern.

## Checks

- Latest-main original headless baseline: 3/3 pass
- Candidate focused headless and headed paired runs: pass
- Current Ubuntu/Xvfb headless paired target: pass
- Same-timeout barrier-disabled arm: expected failure at 60 seconds
- Quick Open lifecycle/listing unit suites: 27/27 pass
- E2E workflow contract suites: 17/17 pass
- oxlint touched spec, oxfmt, max-lines ratchet, and `git diff --check`: pass
- `typecheck:e2e`: blocked by unrelated current-main errors; PR CI remains authoritative

## Reviews

Three fresh final Codex reviewers independently audited the current merge-base diff and evidence:

- Architecture/ownership: clean; CI dependency and test lifecycle are the correct owners; no future adjacent product patches should be needed.
- Product/UX: approved; no user-visible policy, platform, SSH/WSL/folder, multi-client, or mixed-version behavior changed.
- Adversarial regression: clean; independently repeated candidate green and disabled-arm red, and found no race, stale state, cleanup, replay, error-loss, or hot-path regression.

Earlier review rounds caused the main rebase, restored rapid-query coverage, stronger disabled-arm proof, and the boundary reset to the missing Ubuntu dependency. Two independent OpenCode boundary reviews also found no product-boundary change was warranted.

## Downsides and gaps

- The direct oracle warms filesystem caches before the UI arm, though each UI query still launches a fresh `rg` process and the first cold host scan must pass.
- Native Windows, WSL, SSH, folder-workspace, multi-client, and mixed-version fixtures were not rerun because no product or wire path changed.
- A mixed spec containing `@headful` is selected only for the headed project in routine changed-spec CI, so the headless case relies on the full E2E lane; broadening that topology is out of scope.

## Linked issue

Related to STA-5209. The product defect is not reproducible on latest main; after this CI/test hardening is reviewed, recommend human-closing STA-5209 as a non-product test-environment failure in the completed STA-4354 lineage.

## CDP visible proof

Playwright CDP attached to an isolated app for this worktree, paired to a fresh headless host with the 88,763-file workspace. The direct host RPC returned the target first; the rendered dialog then showed loading start/settlement and exactly one option without overflow or disconnect text.

![sta5209-cdp-quick-open.png](https://github.com/user-attachments/assets/a90bd535-1128-433a-bcf2-4626f579b57b)

