### PR TITLE
fix(runtime): preserve slow worktree removal responses

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -656,6 +656,7 @@ jobs:
           src/main/cli/wsl-cli-powershell-boundary.test.ts
           src/main/orca-profiles/profile-index-store.test.ts
           src/main/runtime/repo-worktree-admin-fingerprint.test.ts
+          src/main/runtime/runtime-rpc-worktree-rm-liveness.test.ts
           src/main/runtime/worktree-scan-admin-fingerprint-gate.test.ts
           src/shared/secure-file-fsync-flags.test.ts
 

--- a/src/cli/format-recovery.test.ts
+++ b/src/cli/format-recovery.test.ts
@@ -70,4 +70,21 @@ describe('CLI error recovery', () => {
     expect(output).toContain('--retry-request mutation_1')
     expect(output).not.toContain('orca open')
   })
+
+  it('prefers worktree response-loss recovery over runtime startup advice', () => {
+    const error = new RuntimeClientError(
+      'runtime_unavailable',
+      'The workspace removal may still complete.',
+      {
+        requestPhase: 'awaiting_response',
+        method: 'worktree.rm',
+        nextSteps: ['Run: orca worktree list --json and verify state.']
+      }
+    )
+
+    const output = formatCliError(error)
+
+    expect(output).toContain('worktree list --json')
+    expect(output).not.toContain('orca open')
+  })
 })

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -78,6 +78,10 @@ export function printResult<TResult>(
 export function formatCliError(error: unknown, context: CliErrorContext = {}): string {
   const message = error instanceof Error ? error.message : String(error)
   if (error instanceof RuntimeClientError && error.code === 'runtime_unavailable') {
+    const nextSteps = nextStepsFromData(error.data)
+    if (nextSteps.length > 0) {
+      return formatMessageWithNextSteps(message, nextSteps)
+    }
     if (hasOrchestrationRequestId(error.data)) {
       return message
     }

--- a/src/cli/handlers/worktree-remove-response-recovery.test.ts
+++ b/src/cli/handlers/worktree-remove-response-recovery.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { RuntimeClientError, RuntimeRpcFailureError } from '../runtime-client'
+import { addWorktreeRemoveResponseRecovery } from './worktree-remove-response-recovery'
+
+describe('worktree remove response recovery', () => {
+  it.each([
+    new RuntimeClientError('runtime_unavailable', 'Connection closed.', {
+      requestPhase: 'awaiting_response',
+      method: 'worktree.rm'
+    }),
+    new RuntimeRpcFailureError({
+      id: 'slow-rm',
+      ok: false,
+      error: {
+        code: 'runtime_timeout',
+        message: 'Bounded liveness expired.',
+        data: { requestPhase: 'awaiting_response', method: 'worktree.rm' }
+      }
+    })
+  ])('warns that a sent removal may still complete', (error) => {
+    const recovered = addWorktreeRemoveResponseRecovery(error)
+
+    expect(recovered).toBeInstanceOf(error.constructor)
+    expect(recovered).toMatchObject({
+      data: {
+        mutationMayHaveCompleted: true,
+        nextSteps: expect.arrayContaining([expect.stringContaining('worktree list --json')])
+      }
+    })
+    expect((recovered as Error).message).toContain('may still complete')
+  })
+
+  it.each([
+    { requestPhase: 'not_sent', method: 'worktree.rm' },
+    { requestPhase: 'awaiting_response', method: 'status.get' },
+    undefined
+  ])('does not add destructive ambiguity before dispatch acceptance', (data) => {
+    const error = new RuntimeClientError('runtime_unavailable', 'Connection failed.', data)
+
+    expect(addWorktreeRemoveResponseRecovery(error)).toBe(error)
+  })
+})

--- a/src/cli/handlers/worktree-remove-response-recovery.test.ts
+++ b/src/cli/handlers/worktree-remove-response-recovery.test.ts
@@ -8,6 +8,16 @@ describe('worktree remove response recovery', () => {
       requestPhase: 'awaiting_response',
       method: 'worktree.rm'
     }),
+    new RuntimeClientError(
+      'runtime_unavailable',
+      'The Orca runtime closed the connection before responding. Restart Orca and try again.',
+      { requestPhase: 'awaiting_response', method: 'worktree.rm' }
+    ),
+    new RuntimeClientError(
+      'runtime_unavailable',
+      'The Orca runtime changed while the request was in flight. Retry the command.',
+      { requestPhase: 'awaiting_response', method: 'worktree.rm' }
+    ),
     new RuntimeRpcFailureError({
       id: 'slow-rm',
       ok: false,
@@ -28,6 +38,7 @@ describe('worktree remove response recovery', () => {
       }
     })
     expect((recovered as Error).message).toContain('may still complete')
+    expect((recovered as Error).message).not.toMatch(/Restart Orca and try again|Retry the command/)
   })
 
   it.each([

--- a/src/cli/handlers/worktree-remove-response-recovery.ts
+++ b/src/cli/handlers/worktree-remove-response-recovery.ts
@@ -1,0 +1,35 @@
+import { RuntimeClientError, RuntimeRpcFailureError } from '../runtime-client'
+
+const REMOVE_RESPONSE_LOSS_STEPS = [
+  'Run: orca worktree list --json and verify whether the workspace is absent.',
+  'If it is absent, do not retry; the removal completed.',
+  'If it remains, wait for the in-flight removal to settle before retrying.'
+]
+
+export function addWorktreeRemoveResponseRecovery(error: unknown): unknown {
+  if (!(error instanceof RuntimeClientError) || !wasWorktreeRemoveSent(error.data)) {
+    return error
+  }
+  const data = {
+    ...(error.data as Record<string, unknown>),
+    mutationMayHaveCompleted: true,
+    nextSteps: REMOVE_RESPONSE_LOSS_STEPS
+  }
+  const message = `${error.message} The workspace removal may still complete; verify state before retrying.`
+  if (error instanceof RuntimeRpcFailureError) {
+    return new RuntimeRpcFailureError({
+      ...error.response,
+      error: { ...error.response.error, message, data }
+    })
+  }
+  return new RuntimeClientError(error.code, message, data)
+}
+
+function wasWorktreeRemoveSent(data: unknown): boolean {
+  return (
+    data !== null &&
+    typeof data === 'object' &&
+    (data as { requestPhase?: unknown }).requestPhase === 'awaiting_response' &&
+    (data as { method?: unknown }).method === 'worktree.rm'
+  )
+}

--- a/src/cli/handlers/worktree-remove-response-recovery.ts
+++ b/src/cli/handlers/worktree-remove-response-recovery.ts
@@ -1,4 +1,5 @@
 import { RuntimeClientError, RuntimeRpcFailureError } from '../runtime-client'
+import { stripMutationResponseLossRetryAdvice } from '../mutation-response-loss-message'
 
 const REMOVE_RESPONSE_LOSS_STEPS = [
   'Run: orca worktree list --json and verify whether the workspace is absent.',
@@ -15,7 +16,7 @@ export function addWorktreeRemoveResponseRecovery(error: unknown): unknown {
     mutationMayHaveCompleted: true,
     nextSteps: REMOVE_RESPONSE_LOSS_STEPS
   }
-  const message = `${error.message} The workspace removal may still complete; verify state before retrying.`
+  const message = `${stripMutationResponseLossRetryAdvice(error.message)} The workspace removal may still complete; verify state before retrying.`
   if (error instanceof RuntimeRpcFailureError) {
     return new RuntimeRpcFailureError({
       ...error.response,

--- a/src/cli/handlers/worktree.ts
+++ b/src/cli/handlers/worktree.ts
@@ -33,6 +33,7 @@ import {
   resolveCreateParentSelector
 } from './worktree-create-parent-selector'
 import { getOptionalLinearIssueLinkFlag } from './worktree-linear-issue-link'
+import { addWorktreeRemoveResponseRecovery } from './worktree-remove-response-recovery'
 
 type HookWarningResult = {
   warning?: string
@@ -292,14 +293,18 @@ export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
         'Orca cannot tell which host owns this workspace. Refresh projects and try again.'
       )
     }
-    const result = await client.call<RuntimeWorktreeRemoveResult>('worktree.rm', {
-      worktree,
-      hostId,
-      force: flags.get('force') === true,
-      // Why (#11960): --force is explicit here, so it may also waive PTY-stop proof.
-      allowUnverifiedPtyStop: flags.get('force') === true,
-      runHooks: flags.get('run-hooks') === true
-    })
+    const result = await client
+      .call<RuntimeWorktreeRemoveResult>('worktree.rm', {
+        worktree,
+        hostId,
+        force: flags.get('force') === true,
+        // Why (#11960): --force is explicit here, so it may also waive PTY-stop proof.
+        allowUnverifiedPtyStop: flags.get('force') === true,
+        runHooks: flags.get('run-hooks') === true
+      })
+      .catch((error: unknown) => {
+        throw addWorktreeRemoveResponseRecovery(error)
+      })
     printHookWarning(result.result, json)
     printPreservedBranchWarning(result.result, json)
     printResult(result, json, (value) => `removed: ${value.removed}`)

--- a/src/cli/mutation-response-loss-message.ts
+++ b/src/cli/mutation-response-loss-message.ts
@@ -1,0 +1,5 @@
+const GENERIC_RETRY_ADVICE = [' Restart Orca and try again.', ' Retry the command.']
+
+export function stripMutationResponseLossRetryAdvice(message: string): string {
+  return GENERIC_RETRY_ADVICE.reduce((sanitized, advice) => sanitized.replace(advice, ''), message)
+}

--- a/src/cli/orchestration-mutation-recovery.ts
+++ b/src/cli/orchestration-mutation-recovery.ts
@@ -1,4 +1,5 @@
 import { RuntimeClientError } from './runtime-client'
+import { stripMutationResponseLossRetryAdvice } from './mutation-response-loss-message'
 
 export function orchestrationMutationRecoveryError(error: unknown): unknown {
   if (!(error instanceof RuntimeClientError) || !isUnknownMutationOutcomeCode(error.code)) {
@@ -10,7 +11,10 @@ export function orchestrationMutationRecoveryError(error: unknown): unknown {
     return error
   }
   const message = [
-    stripUnsafeRetryAdvice(error.message, requestId),
+    stripMutationResponseLossRetryAdvice(error.message).replace(
+      ` Orchestration mutation request ID: ${requestId}.`,
+      ''
+    ),
     'The orchestration mutation may already have taken effect; do not assume it failed.',
     `Re-issue the same command with --retry-request ${requestId} to recover idempotently. Do not retry this mutation without --retry-request.`,
     typeof data?.failedStage === 'string' ? `Failed stage: ${data.failedStage}.` : undefined,
@@ -34,11 +38,4 @@ function objectRecord(value: unknown): Record<string, unknown> | undefined {
   return value !== null && typeof value === 'object'
     ? (value as Record<string, unknown>)
     : undefined
-}
-
-function stripUnsafeRetryAdvice(message: string, requestId: string): string {
-  return message
-    .replace(' Restart Orca and try again.', '')
-    .replace(' Retry the command.', '')
-    .replace(` Orchestration mutation request ID: ${requestId}.`, '')
 }

--- a/src/cli/runtime-client.test.ts
+++ b/src/cli/runtime-client.test.ts
@@ -441,7 +441,10 @@ describe.skipIf(process.platform === 'win32')('RuntimeClient', () => {
     expect((failure as RuntimeClientError).message).toBe(
       'The Orca runtime closed the connection before responding. Restart Orca and try again.'
     )
-    expect((failure as RuntimeClientError).data).toBeUndefined()
+    expect((failure as RuntimeClientError).data).toEqual({
+      requestPhase: 'awaiting_response',
+      method: 'orchestration.workerShow'
+    })
     expect(request).toMatchObject({ method: 'orchestration.workerShow' })
     expect(request).not.toHaveProperty('orchestrationRequestId')
   })

--- a/src/cli/runtime/transport.test.ts
+++ b/src/cli/runtime/transport.test.ts
@@ -134,7 +134,8 @@ describe.skipIf(process.platform === 'win32')('runtime transport', () => {
     await expect(sendRequest(metadata, 'status.get', undefined, 60000)).rejects.toMatchObject({
       code: 'runtime_unavailable',
       message:
-        'The Orca runtime closed the connection before responding. Restart Orca and try again.'
+        'The Orca runtime closed the connection before responding. Restart Orca and try again.',
+      data: { requestPhase: 'awaiting_response', method: 'status.get' }
     })
     expect(Date.now() - start).toBeLessThan(5000)
   })

--- a/src/cli/runtime/transport.ts
+++ b/src/cli/runtime/transport.ts
@@ -33,7 +33,12 @@ export async function sendRequest<TResult>(
     const socket = createConnection(transport.endpoint)
     let buffer = ''
     let settled = false
+    let requestSent = false
     const requestId = randomUUID()
+    const requestData = (): { requestPhase: 'not_sent' | 'awaiting_response'; method: string } => ({
+      requestPhase: requestSent ? 'awaiting_response' : 'not_sent',
+      method
+    })
 
     const timeout = setTimeout(() => {
       if (settled) {
@@ -44,7 +49,8 @@ export async function sendRequest<TResult>(
       reject(
         new RuntimeClientError(
           'runtime_timeout',
-          'Timed out waiting for the Orca runtime to respond.'
+          'Timed out waiting for the Orca runtime to respond.',
+          requestData()
         )
       )
     }, timeoutMs)
@@ -71,7 +77,8 @@ export async function sendRequest<TResult>(
         ok: false,
         error: new RuntimeClientError(
           'runtime_unavailable',
-          'Could not connect to the running Orca app. Restart Orca and try again.'
+          'Could not connect to the running Orca app. Restart Orca and try again.',
+          requestData()
         )
       })
     })
@@ -84,7 +91,8 @@ export async function sendRequest<TResult>(
         ok: false,
         error: new RuntimeClientError(
           'runtime_unavailable',
-          'The Orca runtime closed the connection before responding. Restart Orca and try again.'
+          'The Orca runtime closed the connection before responding. Restart Orca and try again.',
+          requestData()
         )
       })
     })
@@ -112,7 +120,8 @@ export async function sendRequest<TResult>(
             ok: false,
             error: new RuntimeClientError(
               'invalid_runtime_response',
-              'The Orca runtime returned an invalid response frame.'
+              'The Orca runtime returned an invalid response frame.',
+              requestData()
             )
           })
           return
@@ -139,7 +148,8 @@ export async function sendRequest<TResult>(
             ok: false,
             error: new RuntimeClientError(
               'invalid_runtime_response',
-              'The Orca runtime returned an invalid response frame.'
+              'The Orca runtime returned an invalid response frame.',
+              requestData()
             )
           })
           return
@@ -160,7 +170,8 @@ export async function sendRequest<TResult>(
             ok: false,
             error: new RuntimeClientError(
               'invalid_runtime_response',
-              'The Orca runtime returned a mismatched response id.'
+              'The Orca runtime returned a mismatched response id.',
+              requestData()
             )
           })
           return
@@ -170,7 +181,8 @@ export async function sendRequest<TResult>(
             ok: false,
             error: new RuntimeClientError(
               'runtime_unavailable',
-              'The Orca runtime changed while the request was in flight. Retry the command.'
+              'The Orca runtime changed while the request was in flight. Retry the command.',
+              requestData()
             )
           })
           return
@@ -180,6 +192,7 @@ export async function sendRequest<TResult>(
       }
     })
     socket.on('connect', () => {
+      requestSent = true
       socket.write(
         `${JSON.stringify({
           id: requestId,

--- a/src/main/runtime/rpc/dispatch-liveness-policy.ts
+++ b/src/main/runtime/rpc/dispatch-liveness-policy.ts
@@ -1,0 +1,8 @@
+export const WORKTREE_REMOVE_KEEPALIVE_MAX_MS = 5 * 60_000
+
+export function boundedDispatchKeepaliveMs(
+  method: string,
+  worktreeRemoveMaxMs = WORKTREE_REMOVE_KEEPALIVE_MAX_MS
+): number | null {
+  return method === 'worktree.rm' ? worktreeRemoveMaxMs : null
+}

--- a/src/main/runtime/rpc/transport.ts
+++ b/src/main/runtime/rpc/transport.ts
@@ -9,11 +9,16 @@
 
 // Why: per-message hook bag owned by the Unix transport. `signal` aborts
 // when the underlying connection terminates so long-poll handlers can bail
-// out. `startKeepalive` is opt-in per request — only long-poll dispatches
-// call it, so short RPCs pay no timer overhead. See design doc §3.1.
+// out. `startKeepalive` is opt-in per request; bounded slow dispatches keep
+// admission and abort semantics separate from long polls. See design doc §3.1.
+export type RpcKeepaliveBound = {
+  maxDurationMs: number
+  timeoutResponse: string
+}
+
 export type RpcMessageContext = {
   signal: AbortSignal
-  startKeepalive: (maxDurationMs?: number) => void
+  startKeepalive: (bounded?: RpcKeepaliveBound) => void
 }
 
 export type RpcTransport = {

--- a/src/main/runtime/rpc/transport.ts
+++ b/src/main/runtime/rpc/transport.ts
@@ -13,7 +13,7 @@
 // call it, so short RPCs pay no timer overhead. See design doc §3.1.
 export type RpcMessageContext = {
   signal: AbortSignal
-  startKeepalive: () => void
+  startKeepalive: (maxDurationMs?: number) => void
 }
 
 export type RpcTransport = {

--- a/src/main/runtime/rpc/unix-socket-transport.test.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.test.ts
@@ -74,4 +74,40 @@ describe('UnixSocketTransport', () => {
     vi.advanceTimersByTime(500)
     expect(socket.writes).toHaveLength(1)
   })
+
+  it.each(['unix', 'named-pipe'] as const)(
+    'returns one terminal frame when bounded %s keepalive expires',
+    (kind) => {
+      const transport = new UnixSocketTransport({
+        endpoint: '/tmp/orca-runtime-rpc-test.sock',
+        kind,
+        keepaliveIntervalMs: 10
+      })
+      const socket = new FakeSocket()
+      let reply: ((response: string) => void) | undefined
+
+      transport.onMessage((_msg, respond, context) => {
+        reply = respond
+        context?.startKeepalive(25)
+      })
+      ;(transport as unknown as UnixSocketTransportInternals).handleConnection(
+        socket as unknown as Socket
+      )
+      socket.emit('data', '{"id":"slow-rm","method":"worktree.rm"}\n')
+
+      vi.advanceTimersByTime(25)
+      reply?.('{"id":"slow-rm","ok":true}')
+
+      const terminalWrites = socket.writes.filter((write) => !write.includes('_keepalive'))
+      expect(terminalWrites).toHaveLength(1)
+      expect(JSON.parse(terminalWrites[0]!.trim())).toMatchObject({
+        id: 'slow-rm',
+        ok: false,
+        error: {
+          code: 'runtime_timeout',
+          data: { requestPhase: 'awaiting_response', method: 'worktree.rm' }
+        }
+      })
+    }
+  )
 })

--- a/src/main/runtime/rpc/unix-socket-transport.test.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.test.ts
@@ -75,39 +75,46 @@ describe('UnixSocketTransport', () => {
     expect(socket.writes).toHaveLength(1)
   })
 
-  it.each(['unix', 'named-pipe'] as const)(
-    'returns one terminal frame when bounded %s keepalive expires',
-    (kind) => {
-      const transport = new UnixSocketTransport({
-        endpoint: '/tmp/orca-runtime-rpc-test.sock',
-        kind,
-        keepaliveIntervalMs: 10
-      })
-      const socket = new FakeSocket()
-      let reply: ((response: string) => void) | undefined
+  it('returns one terminal frame when bounded keepalive expires', () => {
+    const transport = new UnixSocketTransport({
+      endpoint: '/tmp/orca-runtime-rpc-test.sock',
+      kind: 'unix',
+      keepaliveIntervalMs: 10
+    })
+    const socket = new FakeSocket()
+    let reply: ((response: string) => void) | undefined
 
-      transport.onMessage((_msg, respond, context) => {
-        reply = respond
-        context?.startKeepalive(25)
+    transport.onMessage((_msg, respond, context) => {
+      reply = respond
+      context?.startKeepalive({
+        maxDurationMs: 25,
+        timeoutResponse: JSON.stringify({
+          id: 'slow-rm',
+          ok: false,
+          error: {
+            code: 'runtime_timeout',
+            data: { requestPhase: 'awaiting_response', method: 'worktree.rm' }
+          }
+        })
       })
-      ;(transport as unknown as UnixSocketTransportInternals).handleConnection(
-        socket as unknown as Socket
-      )
-      socket.emit('data', '{"id":"slow-rm","method":"worktree.rm"}\n')
+    })
+    ;(transport as unknown as UnixSocketTransportInternals).handleConnection(
+      socket as unknown as Socket
+    )
+    socket.emit('data', '{"id":"slow-rm","method":"worktree.rm"}\n')
 
-      vi.advanceTimersByTime(25)
-      reply?.('{"id":"slow-rm","ok":true}')
+    vi.advanceTimersByTime(25)
+    reply?.('{"id":"slow-rm","ok":true}')
 
-      const terminalWrites = socket.writes.filter((write) => !write.includes('_keepalive'))
-      expect(terminalWrites).toHaveLength(1)
-      expect(JSON.parse(terminalWrites[0]!.trim())).toMatchObject({
-        id: 'slow-rm',
-        ok: false,
-        error: {
-          code: 'runtime_timeout',
-          data: { requestPhase: 'awaiting_response', method: 'worktree.rm' }
-        }
-      })
-    }
-  )
+    const terminalWrites = socket.writes.filter((write) => !write.includes('_keepalive'))
+    expect(terminalWrites).toHaveLength(1)
+    expect(JSON.parse(terminalWrites[0]!.trim())).toMatchObject({
+      id: 'slow-rm',
+      ok: false,
+      error: {
+        code: 'runtime_timeout',
+        data: { requestPhase: 'awaiting_response', method: 'worktree.rm' }
+      }
+    })
+  })
 })

--- a/src/main/runtime/rpc/unix-socket-transport.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.ts
@@ -9,7 +9,7 @@ import { chmodSync, existsSync, rmSync } from 'node:fs'
 import type { RpcMessageContext, RpcTransport } from './transport'
 
 const MAX_RUNTIME_RPC_MESSAGE_BYTES = 1024 * 1024
-const RUNTIME_RPC_SOCKET_IDLE_TIMEOUT_MS = 30_000
+export const RUNTIME_RPC_SOCKET_IDLE_TIMEOUT_MS = 30_000
 const MAX_RUNTIME_RPC_CONNECTIONS = 32
 const DEFAULT_KEEPALIVE_INTERVAL_MS = 10_000
 
@@ -21,6 +21,7 @@ export type UnixSocketTransportOptions = {
   // the client honours them, the client-side idle timer. Tests override this
   // to avoid waiting 10 s for a frame.
   keepaliveIntervalMs?: number
+  idleTimeoutMs?: number
 }
 
 type MessageHandler = (
@@ -33,14 +34,16 @@ export class UnixSocketTransport implements RpcTransport {
   private readonly endpoint: string
   private readonly kind: 'unix' | 'named-pipe'
   private readonly keepaliveIntervalMs: number
+  private readonly idleTimeoutMs: number
   private server: Server | null = null
   private messageHandler: MessageHandler | null = null
   private readonly activeSockets = new Set<Socket>()
 
-  constructor({ endpoint, kind, keepaliveIntervalMs }: UnixSocketTransportOptions) {
+  constructor({ endpoint, kind, keepaliveIntervalMs, idleTimeoutMs }: UnixSocketTransportOptions) {
     this.endpoint = endpoint
     this.kind = kind
     this.keepaliveIntervalMs = keepaliveIntervalMs ?? DEFAULT_KEEPALIVE_INTERVAL_MS
+    this.idleTimeoutMs = idleTimeoutMs ?? RUNTIME_RPC_SOCKET_IDLE_TIMEOUT_MS
   }
 
   onMessage(handler: MessageHandler): void {
@@ -116,7 +119,7 @@ export class UnixSocketTransport implements RpcTransport {
 
     socket.setEncoding('utf8')
     socket.setNoDelay(true)
-    socket.setTimeout(RUNTIME_RPC_SOCKET_IDLE_TIMEOUT_MS, () => {
+    socket.setTimeout(this.idleTimeoutMs, () => {
       socket.destroy()
     })
     socket.on('error', () => {
@@ -163,6 +166,20 @@ export class UnixSocketTransport implements RpcTransport {
   private dispatchMessage(socket: Socket, rawMessage: string, inflight: Set<() => void>): void {
     let replied = false
     let keepaliveTimer: NodeJS.Timeout | null = null
+    let keepaliveExpiryTimer: NodeJS.Timeout | null = null
+    let requestId = 'unknown'
+    let requestMethod = 'unknown'
+    try {
+      const request = JSON.parse(rawMessage) as { id?: unknown; method?: unknown }
+      if (typeof request.id === 'string' && request.id.length > 0) {
+        requestId = request.id
+      }
+      if (typeof request.method === 'string' && request.method.length > 0) {
+        requestMethod = request.method
+      }
+    } catch {
+      // Request validation remains owned by the RPC server.
+    }
     // Why: each dispatch needs its own abort signal and keepalive timer
     // cleanup. Socket close runs every cleanup without touching sibling
     // dispatches that already replied on the same connection.
@@ -176,6 +193,10 @@ export class UnixSocketTransport implements RpcTransport {
       if (keepaliveTimer) {
         clearInterval(keepaliveTimer)
         keepaliveTimer = null
+      }
+      if (keepaliveExpiryTimer) {
+        clearTimeout(keepaliveExpiryTimer)
+        keepaliveExpiryTimer = null
       }
       if (abort) {
         abortController.abort()
@@ -196,7 +217,7 @@ export class UnixSocketTransport implements RpcTransport {
       }
     }
 
-    const startKeepalive = (): void => {
+    const startKeepalive = (maxDurationMs?: number): void => {
       if (keepaliveTimer || replied) {
         return
       }
@@ -210,6 +231,23 @@ export class UnixSocketTransport implements RpcTransport {
       // Why: don't hold the process open solely on the keepalive interval.
       if (typeof keepaliveTimer.unref === 'function') {
         keepaliveTimer.unref()
+      }
+      if (maxDurationMs !== undefined) {
+        keepaliveExpiryTimer = setTimeout(() => {
+          keepaliveExpiryTimer = null
+          reply(
+            JSON.stringify({
+              id: requestId,
+              ok: false,
+              error: {
+                code: 'runtime_timeout',
+                message: `The runtime stopped waiting for ${requestMethod} before it completed.`,
+                data: { requestPhase: 'awaiting_response', method: requestMethod }
+              }
+            })
+          )
+        }, maxDurationMs)
+        keepaliveExpiryTimer.unref?.()
       }
     }
 

--- a/src/main/runtime/rpc/unix-socket-transport.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.ts
@@ -6,7 +6,7 @@
 // away. See design doc §3.1.
 import { createServer, type Server, type Socket } from 'node:net'
 import { chmodSync, existsSync, rmSync } from 'node:fs'
-import type { RpcMessageContext, RpcTransport } from './transport'
+import type { RpcKeepaliveBound, RpcMessageContext, RpcTransport } from './transport'
 
 const MAX_RUNTIME_RPC_MESSAGE_BYTES = 1024 * 1024
 export const RUNTIME_RPC_SOCKET_IDLE_TIMEOUT_MS = 30_000
@@ -167,19 +167,6 @@ export class UnixSocketTransport implements RpcTransport {
     let replied = false
     let keepaliveTimer: NodeJS.Timeout | null = null
     let keepaliveExpiryTimer: NodeJS.Timeout | null = null
-    let requestId = 'unknown'
-    let requestMethod = 'unknown'
-    try {
-      const request = JSON.parse(rawMessage) as { id?: unknown; method?: unknown }
-      if (typeof request.id === 'string' && request.id.length > 0) {
-        requestId = request.id
-      }
-      if (typeof request.method === 'string' && request.method.length > 0) {
-        requestMethod = request.method
-      }
-    } catch {
-      // Request validation remains owned by the RPC server.
-    }
     // Why: each dispatch needs its own abort signal and keepalive timer
     // cleanup. Socket close runs every cleanup without touching sibling
     // dispatches that already replied on the same connection.
@@ -217,7 +204,7 @@ export class UnixSocketTransport implements RpcTransport {
       }
     }
 
-    const startKeepalive = (maxDurationMs?: number): void => {
+    const startKeepalive = (bounded?: RpcKeepaliveBound): void => {
       if (keepaliveTimer || replied) {
         return
       }
@@ -232,21 +219,11 @@ export class UnixSocketTransport implements RpcTransport {
       if (typeof keepaliveTimer.unref === 'function') {
         keepaliveTimer.unref()
       }
-      if (maxDurationMs !== undefined) {
+      if (bounded) {
         keepaliveExpiryTimer = setTimeout(() => {
           keepaliveExpiryTimer = null
-          reply(
-            JSON.stringify({
-              id: requestId,
-              ok: false,
-              error: {
-                code: 'runtime_timeout',
-                message: `The runtime stopped waiting for ${requestMethod} before it completed.`,
-                data: { requestPhase: 'awaiting_response', method: requestMethod }
-              }
-            })
-          )
-        }, maxDurationMs)
+          reply(bounded.timeoutResponse)
+        }, bounded.maxDurationMs)
         keepaliveExpiryTimer.unref?.()
       }
     }

--- a/src/main/runtime/rpc/unix-socket-transport.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.ts
@@ -161,8 +161,8 @@ export class UnixSocketTransport implements RpcTransport {
   }
 
   // Why: the keepalive timer is opt-in per request via `startKeepalive()`.
-  // Short RPCs never call it and pay no timer overhead; only long-poll
-  // handlers (e.g. orchestration.check --wait) arm it. See §3.1.
+  // Short RPCs never call it and pay no timer overhead; long polls and
+  // explicitly bounded slow dispatches arm it. See §3.1.
   private dispatchMessage(socket: Socket, rawMessage: string, inflight: Set<() => void>): void {
     let replied = false
     let keepaliveTimer: NodeJS.Timeout | null = null

--- a/src/main/runtime/runtime-rpc-worktree-rm-liveness.test.ts
+++ b/src/main/runtime/runtime-rpc-worktree-rm-liveness.test.ts
@@ -62,24 +62,30 @@ describe('worktree.rm runtime RPC liveness', () => {
       }
       expect(metadata.transports[0].kind).toBe(process.platform === 'win32' ? 'named-pipe' : 'unix')
       const session = startRemoval(metadata.transports[0].endpoint, metadata.authToken)
-      await waitFor(() => session.frames.some((frame) => frame._keepalive === true))
+      await Promise.race([
+        waitFor(() => session.frames.some((frame) => frame._keepalive === true)),
+        session.done
+      ])
       const keepalivesBeforeIdleWindow = session.frames.filter(
         (frame) => frame._keepalive === true
       ).length
-      await sleep(150)
+      if (keepalivesBeforeIdleWindow > 0) {
+        await sleep(150)
+      }
       expect(session.frames.filter((frame) => frame.ok !== undefined)).toHaveLength(0)
+      removal.release()
+      await waitFor(removal.completed)
+      await session.done
+
+      expect(removal.removeManagedWorktree).toHaveBeenCalledTimes(1)
+      expect(session.frames.filter((frame) => frame._keepalive === true).length).toBeGreaterThan(1)
       expect(session.frames.filter((frame) => frame._keepalive === true).length).toBeGreaterThan(
         keepalivesBeforeIdleWindow
       )
-      removal.release()
-      await session.done
-
-      expect(session.frames.filter((frame) => frame._keepalive === true).length).toBeGreaterThan(1)
       expect(session.frames.filter((frame) => frame.ok !== undefined)).toEqual([
         expect.objectContaining({ id: 'slow-rm', ok: true })
       ])
       expect(removal.completed()).toBe(true)
-      expect(removal.removeManagedWorktree).toHaveBeenCalledTimes(1)
     } finally {
       removal.release()
       await server.stop()
@@ -105,9 +111,15 @@ describe('worktree.rm runtime RPC liveness', () => {
         throw new Error('runtime metadata was not written')
       }
       const session = startRemoval(metadata.transports[0].endpoint, metadata.authToken)
-      await waitFor(() => session.frames.filter((frame) => frame.ok !== undefined).length === 1)
+      await Promise.race([
+        waitFor(() => session.frames.filter((frame) => frame.ok !== undefined).length === 1),
+        session.done
+      ])
       await session.done
+      removal.release()
+      await waitFor(removal.completed)
 
+      expect(removal.removeManagedWorktree).toHaveBeenCalledTimes(1)
       expect(session.frames.filter((frame) => frame._keepalive === true).length).toBeGreaterThan(1)
       expect(session.frames.filter((frame) => frame.ok !== undefined)).toEqual([
         expect.objectContaining({
@@ -119,10 +131,6 @@ describe('worktree.rm runtime RPC liveness', () => {
           })
         })
       ])
-
-      removal.release()
-      await waitFor(removal.completed)
-      expect(removal.removeManagedWorktree).toHaveBeenCalledTimes(1)
     } finally {
       removal.release()
       await server.stop()

--- a/src/main/runtime/runtime-rpc-worktree-rm-liveness.test.ts
+++ b/src/main/runtime/runtime-rpc-worktree-rm-liveness.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import { OrcaRuntimeService } from './orca-runtime'
 import { readRuntimeMetadata } from './runtime-metadata'
-import { openFramedSession, waitFor } from './runtime-rpc-test-harness'
+import { openFramedSession, sleep, waitFor } from './runtime-rpc-test-harness'
 import { OrcaRuntimeRpcServer } from './runtime-rpc'
 
 function createRemovalGate(runtime: OrcaRuntimeService) {
@@ -49,9 +49,9 @@ describe('worktree.rm runtime RPC liveness', () => {
     const server = new OrcaRuntimeRpcServer({
       runtime,
       userDataPath,
-      socketIdleTimeoutMs: 50,
+      socketIdleTimeoutMs: 100,
       keepaliveIntervalMs: 10,
-      worktreeRemoveKeepaliveMaxMs: 200
+      worktreeRemoveKeepaliveMaxMs: 400
     })
     await server.start()
 
@@ -62,7 +62,15 @@ describe('worktree.rm runtime RPC liveness', () => {
       }
       expect(metadata.transports[0].kind).toBe(process.platform === 'win32' ? 'named-pipe' : 'unix')
       const session = startRemoval(metadata.transports[0].endpoint, metadata.authToken)
-      await waitFor(() => session.frames.filter((frame) => frame._keepalive === true).length >= 2)
+      await waitFor(() => session.frames.some((frame) => frame._keepalive === true))
+      const keepalivesBeforeIdleWindow = session.frames.filter(
+        (frame) => frame._keepalive === true
+      ).length
+      await sleep(150)
+      expect(session.frames.filter((frame) => frame.ok !== undefined)).toHaveLength(0)
+      expect(session.frames.filter((frame) => frame._keepalive === true).length).toBeGreaterThan(
+        keepalivesBeforeIdleWindow
+      )
       removal.release()
       await session.done
 
@@ -97,6 +105,7 @@ describe('worktree.rm runtime RPC liveness', () => {
         throw new Error('runtime metadata was not written')
       }
       const session = startRemoval(metadata.transports[0].endpoint, metadata.authToken)
+      await waitFor(() => session.frames.filter((frame) => frame.ok !== undefined).length === 1)
       await session.done
 
       expect(session.frames.filter((frame) => frame._keepalive === true).length).toBeGreaterThan(1)

--- a/src/main/runtime/runtime-rpc-worktree-rm-liveness.test.ts
+++ b/src/main/runtime/runtime-rpc-worktree-rm-liveness.test.ts
@@ -1,0 +1,122 @@
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { OrcaRuntimeService } from './orca-runtime'
+import { readRuntimeMetadata } from './runtime-metadata'
+import { openFramedSession, waitFor } from './runtime-rpc-test-harness'
+import { OrcaRuntimeRpcServer } from './runtime-rpc'
+
+function createRemovalGate(runtime: OrcaRuntimeService) {
+  let release: (() => void) | null = null
+  let completed = false
+  const gate = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  const removeManagedWorktree = vi
+    .spyOn(runtime, 'removeManagedWorktree')
+    .mockImplementation(async () => {
+      await gate
+      completed = true
+      return {}
+    })
+  return {
+    release: () => release?.(),
+    completed: () => completed,
+    removeManagedWorktree
+  }
+}
+
+function startRemoval(endpoint: string, authToken: string) {
+  return openFramedSession(endpoint, {
+    id: 'slow-rm',
+    authToken,
+    method: 'worktree.rm',
+    params: {
+      worktree: 'path:/workspace/slow-rm',
+      hostId: 'local',
+      force: true,
+      allowUnverifiedPtyStop: true
+    }
+  })
+}
+
+describe('worktree.rm runtime RPC liveness', () => {
+  it('keeps the local response channel alive until removal returns', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-slow-rm-'))
+    const runtime = new OrcaRuntimeService()
+    const removal = createRemovalGate(runtime)
+    const server = new OrcaRuntimeRpcServer({
+      runtime,
+      userDataPath,
+      socketIdleTimeoutMs: 50,
+      keepaliveIntervalMs: 10,
+      worktreeRemoveKeepaliveMaxMs: 200
+    })
+    await server.start()
+
+    try {
+      const metadata = readRuntimeMetadata(userDataPath)
+      if (!metadata?.authToken || !metadata.transports[0]) {
+        throw new Error('runtime metadata was not written')
+      }
+      expect(metadata.transports[0].kind).toBe(process.platform === 'win32' ? 'named-pipe' : 'unix')
+      const session = startRemoval(metadata.transports[0].endpoint, metadata.authToken)
+      await waitFor(() => session.frames.filter((frame) => frame._keepalive === true).length >= 2)
+      removal.release()
+      await session.done
+
+      expect(session.frames.filter((frame) => frame._keepalive === true).length).toBeGreaterThan(1)
+      expect(session.frames.filter((frame) => frame.ok !== undefined)).toEqual([
+        expect.objectContaining({ id: 'slow-rm', ok: true })
+      ])
+      expect(removal.completed()).toBe(true)
+      expect(removal.removeManagedWorktree).toHaveBeenCalledTimes(1)
+    } finally {
+      removal.release()
+      await server.stop()
+    }
+  })
+
+  it('returns one ambiguous-outcome failure when bounded liveness expires', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-slow-rm-'))
+    const runtime = new OrcaRuntimeService()
+    const removal = createRemovalGate(runtime)
+    const server = new OrcaRuntimeRpcServer({
+      runtime,
+      userDataPath,
+      socketIdleTimeoutMs: 50,
+      keepaliveIntervalMs: 10,
+      worktreeRemoveKeepaliveMaxMs: 60
+    })
+    await server.start()
+
+    try {
+      const metadata = readRuntimeMetadata(userDataPath)
+      if (!metadata?.authToken || !metadata.transports[0]) {
+        throw new Error('runtime metadata was not written')
+      }
+      const session = startRemoval(metadata.transports[0].endpoint, metadata.authToken)
+      await session.done
+
+      expect(session.frames.filter((frame) => frame._keepalive === true).length).toBeGreaterThan(1)
+      expect(session.frames.filter((frame) => frame.ok !== undefined)).toEqual([
+        expect.objectContaining({
+          id: 'slow-rm',
+          ok: false,
+          error: expect.objectContaining({
+            code: 'runtime_timeout',
+            data: { requestPhase: 'awaiting_response', method: 'worktree.rm' }
+          })
+        })
+      ])
+
+      removal.release()
+      await waitFor(removal.completed)
+      expect(removal.removeManagedWorktree).toHaveBeenCalledTimes(1)
+    } finally {
+      removal.release()
+      await server.stop()
+    }
+  })
+})

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -18,6 +18,7 @@ import { errorResponse } from './rpc/errors'
 import { fingerprintAuthenticatedPairingCredential } from './rpc/orchestration-mutation-executor'
 import type { RpcMessageContext, RpcTransport } from './rpc/transport'
 import { UnixSocketTransport } from './rpc/unix-socket-transport'
+import { boundedDispatchKeepaliveMs } from './rpc/dispatch-liveness-policy'
 import { WebSocketTransport } from './rpc/ws-transport'
 import { readWsFallbackPort, writeWsFallbackPort } from './rpc/ws-fallback-port-store'
 import type { WebSocket } from 'ws'
@@ -76,6 +77,8 @@ type OrcaRuntimeRpcServerOptions = {
   webClientRoot?: string
   // Why: test-only overrides for the two constants below; production must not pass these (defaults set by §3.1).
   keepaliveIntervalMs?: number
+  socketIdleTimeoutMs?: number
+  worktreeRemoveKeepaliveMaxMs?: number
   longPollCap?: number
   // Why: test-only override for the ownership reclaim cadence.
   metadataOwnershipPollMs?: number
@@ -498,6 +501,8 @@ export class OrcaRuntimeRpcServer {
   private stopping = false
   private readonly authToken = randomBytes(24).toString('hex')
   private readonly keepaliveIntervalMs: number
+  private readonly socketIdleTimeoutMs: number | undefined
+  private readonly worktreeRemoveKeepaliveMaxMs: number | undefined
   private readonly longPollCap: number
   private readonly metadataOwnershipPollMs: number
   private readonly askLongPollCap: number
@@ -548,6 +553,8 @@ export class OrcaRuntimeRpcServer {
     exposeNetworkByDefault = false,
     webClientRoot,
     keepaliveIntervalMs = KEEPALIVE_INTERVAL_MS,
+    socketIdleTimeoutMs,
+    worktreeRemoveKeepaliveMaxMs,
     longPollCap = LONG_POLL_CAP,
     metadataOwnershipPollMs = RUNTIME_METADATA_OWNERSHIP_POLL_MS
   }: OrcaRuntimeRpcServerOptions) {
@@ -562,6 +569,8 @@ export class OrcaRuntimeRpcServer {
     this.exposeNetworkByDefault = exposeNetworkByDefault
     this.webClientRoot = webClientRoot
     this.keepaliveIntervalMs = keepaliveIntervalMs
+    this.socketIdleTimeoutMs = socketIdleTimeoutMs
+    this.worktreeRemoveKeepaliveMaxMs = worktreeRemoveKeepaliveMaxMs
     this.longPollCap = longPollCap
     this.metadataOwnershipPollMs = metadataOwnershipPollMs
     // Why: derived, not configurable — the reservation must hold for whatever cap a caller picks.
@@ -1140,7 +1149,8 @@ export class OrcaRuntimeRpcServer {
     const socketTransport = new UnixSocketTransport({
       endpoint: transportMeta.endpoint,
       kind: transportMeta.kind as 'unix' | 'named-pipe',
-      keepaliveIntervalMs: this.keepaliveIntervalMs
+      keepaliveIntervalMs: this.keepaliveIntervalMs,
+      idleTimeoutMs: this.socketIdleTimeoutMs
     })
 
     // Why: the `.catch` guarantees reply() always fires so a throw can't strand the client or leak the AbortController.
@@ -1542,6 +1552,14 @@ export class OrcaRuntimeRpcServer {
     if (longPoll) {
       // Why: arm keepalive only for long-polls; short RPCs never create the setInterval. See §3.1.
       context?.startKeepalive()
+    } else {
+      const maxKeepaliveMs = boundedDispatchKeepaliveMs(
+        request.method,
+        this.worktreeRemoveKeepaliveMaxMs
+      )
+      if (maxKeepaliveMs !== null) {
+        context?.startKeepalive(maxKeepaliveMs)
+      }
     }
 
     try {

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -75,7 +75,7 @@ type OrcaRuntimeRpcServerOptions = {
   // Only `orca serve` (explicit remote opt-in) and E2E set this; the desktop app widens lazily on pairing.
   exposeNetworkByDefault?: boolean
   webClientRoot?: string
-  // Why: test-only overrides for the two constants below; production must not pass these (defaults set by §3.1).
+  // Why: test-only timing overrides; production uses the bounded policy defaults.
   keepaliveIntervalMs?: number
   socketIdleTimeoutMs?: number
   worktreeRemoveKeepaliveMaxMs?: number
@@ -1550,7 +1550,6 @@ export class OrcaRuntimeRpcServer {
       return this.buildError(request.id, 'runtime_busy', rejection)
     }
     if (longPoll) {
-      // Why: arm keepalive only for long-polls; short RPCs never create the setInterval. See §3.1.
       context?.startKeepalive()
     } else {
       const maxKeepaliveMs = boundedDispatchKeepaliveMs(
@@ -1558,7 +1557,17 @@ export class OrcaRuntimeRpcServer {
         this.worktreeRemoveKeepaliveMaxMs
       )
       if (maxKeepaliveMs !== null) {
-        context?.startKeepalive(maxKeepaliveMs)
+        context?.startKeepalive({
+          maxDurationMs: maxKeepaliveMs,
+          timeoutResponse: JSON.stringify(
+            this.buildError(
+              request.id,
+              'runtime_timeout',
+              `The runtime stopped waiting for ${request.method} before it completed.`,
+              { requestPhase: 'awaiting_response', method: request.method }
+            )
+          )
+        })
       }
     }
 
@@ -1751,8 +1760,8 @@ export class OrcaRuntimeRpcServer {
     }
   }
 
-  private buildError(id: string, code: string, message: string): RpcResponse {
-    return errorResponse(id, { runtimeId: this.runtime.getRuntimeId() }, code, message)
+  private buildError(id: string, code: string, message: string, data?: unknown): RpcResponse {
+    return errorResponse(id, { runtimeId: this.runtime.getRuntimeId() }, code, message, data)
   }
 
   private writeMetadata(): void {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​258 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​256 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​154 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​38 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​116 |

<!-- /orca-pr-loc -->

## ELI5

A large `orca worktree rm --force` can keep deleting after the local RPC socket decides 30 seconds of silence means the connection is idle. The CLI then reports `runtime_unavailable` even though the destructive operation may finish. This change keeps only that removal RPC alive for a bounded window and tells users to verify state before retrying if the response becomes ambiguous.

## Invariant and ownership

Once the local runtime accepts one `worktree.rm`, the Unix-socket or named-pipe response channel must emit activity before the idle deadline and exactly one terminal response, while `removeManagedWorktree` executes exactly once.

- Runtime dispatch owns the method-specific bounded-liveness policy and timeout RPC envelope.
- The local socket transport owns keepalive/expiry timers, cleanup, and exactly-one terminal framing.
- `removeManagedWorktree` remains authoritative for the destructive operation and in-flight deduplication.
- The CLI owns verify-before-retry guidance after request transmission has begun.

## What changed

- Classify only local `worktree.rm` as a bounded slow dispatch.
- Send existing keepalive frames for at most five minutes without consuming long-poll admission or abort semantics.
- On bound expiry, send one `runtime_timeout` response with `requestPhase: awaiting_response`; the removal may continue and any late handler response is suppressed.
- Track whether local request transmission began and preserve worktree-specific recovery steps in both JSON and human output.
- Remove generic retry directives once a mutation outcome is unknown, using the existing CLI mutation-recovery boundary.
- Run the real liveness integration test in the Windows package lane so named-pipe behavior is exercised, not inferred from a fake socket.

## Deterministic reproduction

The CI-suitable oracle defers `removeManagedWorktree`, scales the actual local socket idle deadline to 100 ms and keepalive cadence to 10 ms, and observes two independent signals:

1. Transport: activity crosses the idle window and exactly one terminal frame arrives.
2. Destructive operation: removal completes and is invoked exactly once.

The reporter baseline `v1.4.185` (`709c3046d0`) and main at reproduction (`4c984d4c1b`) both failed: zero keepalives, the idle socket closed, removal still completed once, and the terminal response was lost. The current merge base is `d1127b9939`; no intervening commit changed the Unix transport, local CLI transport, or dispatch-liveness path. The only relevant-file main change was unrelated worker-restoration logic in `orca-runtime.ts`.

## Negative control

On the rebased current-main head, temporarily changing only `boundedDispatchKeepaliveMs` to return `null` makes both real-IPC tests fail after the removal-call-count assertion passes: zero keepalives and no terminal result. Restoring the policy makes both pass.

## Why this design

This is the smallest fix at the component that owns truth. It preserves the idle reaper for ordinary RPCs, creates no timer or extra parse on their hot path, changes no paired WebSocket frame or RPC parameter, and keeps destructive execution separate from connection lifetime.

Rejected alternatives:

- Mark `worktree.rm` as a long poll: wrong admission and cancellation semantics.
- Global lazy keepalive: every short RPC pays timer overhead and a stuck handler can retain liveness indefinitely.
- Unbounded method keepalive or a global idle-timeout increase: weakens dead-client reaping.
- PR #11932 as a direct template: overlaps the slow-dispatch class but targets `worktree.create` with a larger recovery design.
- An asynchronous removal job/receipt API: stronger reconnect semantics, but disproportionate to this local response-channel defect.

## Downsides

- A stuck removal can keep one local connection open for up to five minutes instead of roughly 30 seconds.
- More than 32 concurrent slow removals can temporarily pressure the local connection cap.
- A removal exceeding five minutes still returns an ambiguous timeout and may continue; the CLI guidance is intentionally verify-before-retry.
- Paired/headless CLI timeout ambiguity is unchanged and remains a separate, unreproduced boundary.

## Validation

- Current focused regression pack: 8 files, 57 tests passed.
- Debian Linux / Node 24 Docker, real Unix socket: 3 files, 16 tests passed.
- Policy-disabled negative control: 2/2 liveness tests failed with zero keepalives after exactly-one removal completed; restored candidate: 2/2 passed.
- `pnpm run typecheck`, focused oxlint/type-aware oxlint, and diff checks: passed.
- Current-head Windows package ran `runtime-rpc-worktree-rm-liveness.test.ts` against an actual named pipe and passed.
- Full exact-head CI passed: 48 successful, 5 intentionally skipped, 0 failed, including Node 24/26 shards, cross-version wire, static analysis, typecheck, package, native smoke, and Windows package.
- Final independent review: the first three-reviewer round found contradictory generic retry guidance and a stale comment; both were fixed structurally. A fresh three-reviewer round found no blocking code issues.

Refs #15663. Related overlap only: #11932 and #15730.

