### PR TITLE
fix(codex): preserve SSH hook launch context (STA-3147)

### DIFF
--- a/src/main/__fixtures__/shell-wrapper-snapshots/relay-bash-rcfile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/relay-bash-rcfile.txt
@@ -2,6 +2,8 @@
 _orca_shell_features=",${ORCA_SHELL_FEATURES:-},"
 builtin unset ORCA_SHELL_FEATURES
 __orca_has_feature() { [[ "$_orca_shell_features" == *",$1,"* ]]; }
+__orca_codex_hooks_enabled=""
+__orca_has_feature codex-hooks && __orca_codex_hooks_enabled=1
 __orca_has_feature identity && printf "\033]777;orca-shell-start:%s\007" "$$"
 # Why a plain variable: the channel is consumed and destroyed in these first
 # lines, so nothing this shell later spawns can see or inherit the selection.
@@ -55,6 +57,86 @@ if [[ -n "${ORCA_OMP_STATUS_EXTENSION:-}" ]]; then
   # an `alias omp` otherwise rewrites at parse time, aborting the rest of the file.
   function omp { __orca_omp "$@"; }
 fi
+
+# Why: a typed alias expands inside the shell, after pane launch prep.
+# Why unalias inside the substitution: an alias named codex makes command -v
+# report the alias text, and the subshell leaves the user's own alias intact.
+# Why || : twice — zsh alone aborts inside the substitution, but every shell's
+# assignment adopts its exit status, so an absent codex trips set -e in bash too.
+__orca_codex_binary="$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)"
+__orca_codex_alias="$(alias codex 2>/dev/null || :)"
+__orca_codex_hooks_enabled="${__orca_codex_hooks_enabled:-}"
+__orca_has_feature codex-hooks 2>/dev/null && __orca_codex_hooks_enabled=1
+__orca_codex_hooks_override() {
+  local value
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --) return 1 ;;
+      --enable|--disable) [[ "${2:-}" == hooks || "${2:-}" == codex_hooks ]] && return 0 ;;
+      --enable=hooks|--disable=hooks|--enable=codex_hooks|--disable=codex_hooks) return 0 ;;
+      -c|--config) value="${2:-}" ;;
+      -c=*|--config=*) value="${1#*=}" ;;
+      -c?*) value="${1#-c}" ;;
+      *) value="" ;;
+    esac
+    case "$value" in
+      features.hooks|features.hooks=*|features.hooks[[:space:]]*=*|features.codex_hooks|features.codex_hooks=*|features.codex_hooks[[:space:]]*=*) return 0 ;;
+    esac
+    shift
+  done
+  return 1
+}
+__orca_codex_hooks_feature() {
+  local __orca_codex_version __orca_codex_major __orca_codex_minor __orca_codex_patch __orca_codex_probe_file __orca_codex_probe_pid __orca_codex_remaining __orca_codex_probe_status
+  __orca_codex_probe_file="$(mktemp "${TMPDIR:-/tmp}/orca-codex-version.XXXXXX" 2>/dev/null)" || return 0
+  command codex --version >"$__orca_codex_probe_file" 2>/dev/null &
+  __orca_codex_probe_pid=$!
+  __orca_codex_remaining=40
+  while kill -0 "$__orca_codex_probe_pid" 2>/dev/null && [[ $__orca_codex_remaining -gt 0 ]]; do
+    sleep 0.05 2>/dev/null || break
+    __orca_codex_remaining=$(( __orca_codex_remaining - 1 ))
+  done
+  if kill -0 "$__orca_codex_probe_pid" 2>/dev/null; then
+    kill "$__orca_codex_probe_pid" 2>/dev/null || :
+    wait "$__orca_codex_probe_pid" 2>/dev/null || :
+    rm -f "$__orca_codex_probe_file"
+    return 0
+  fi
+  if wait "$__orca_codex_probe_pid" 2>/dev/null; then __orca_codex_probe_status=0; else __orca_codex_probe_status=$?; fi
+  __orca_codex_version="$(<"$__orca_codex_probe_file")"
+  rm -f "$__orca_codex_probe_file"
+  [[ "$__orca_codex_probe_status" == 0 ]] || return 0
+  __orca_codex_version="${__orca_codex_version##* }"
+  __orca_codex_major="${__orca_codex_version%%.*}"
+  __orca_codex_minor="${__orca_codex_version#*.}"; __orca_codex_minor="${__orca_codex_minor%%.*}"
+  __orca_codex_patch="${__orca_codex_version#*.*.}"; __orca_codex_patch="${__orca_codex_patch%%[-+]*}"
+  [[ -n "$__orca_codex_major" && -n "$__orca_codex_minor" && -n "$__orca_codex_patch" ]] || return 0
+  [[ "$__orca_codex_major" != *[^0-9]* && "$__orca_codex_minor" != *[^0-9]* && "$__orca_codex_patch" != *[^0-9]* ]] || return 0
+  if (( __orca_codex_major >= 1 )); then
+    printf hooks
+  elif (( __orca_codex_minor >= 129 )); then
+    printf hooks
+  elif (( __orca_codex_minor >= 114 )); then
+    printf codex_hooks
+  fi
+}
+if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}${__orca_codex_hooks_enabled:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" && ! ( -z "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "$__orca_codex_alias" ) ]]; then
+  # Why the function reserved word: it suppresses alias expansion of the name,
+  # which otherwise rewrites this header at parse time and aborts the whole file.
+  function codex {
+    [[ -z "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" ]] || "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+    local __orca_codex_feature=""
+    if [[ -n "${__orca_codex_hooks_enabled:-}" && -n "${ORCA_AGENT_HOOK_PORT:-}" && -n "${ORCA_AGENT_HOOK_TOKEN:-}" && -n "${ORCA_PANE_KEY:-}" ]] && ! __orca_codex_hooks_override "$@"; then
+      __orca_codex_feature="$(__orca_codex_hooks_feature)"
+    fi
+    if [[ -n "$__orca_codex_feature" ]]; then
+      command codex --enable "$__orca_codex_feature" "$@"
+      return $?
+    fi
+    command codex "$@"
+  }
+fi
+unset __orca_codex_binary __orca_codex_alias
 
 if [[ -n "${ORCA_HISTFILE:-}" ]]; then
   HISTFILE="$ORCA_HISTFILE"

--- a/src/main/__fixtures__/shell-wrapper-snapshots/relay-zsh-zshenv.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/relay-zsh-zshenv.txt
@@ -76,6 +76,87 @@ __orca_deferred_init() {
       function omp { __orca_omp "$@"; }
     fi
   fi
+  if __orca_has_feature overlay || __orca_has_feature codex-hooks; then
+    # Why: a typed alias expands inside the shell, after pane launch prep.
+    # Why unalias inside the substitution: an alias named codex makes command -v
+    # report the alias text, and the subshell leaves the user's own alias intact.
+    # Why || : twice — zsh alone aborts inside the substitution, but every shell's
+    # assignment adopts its exit status, so an absent codex trips set -e in bash too.
+    __orca_codex_binary="$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)"
+    __orca_codex_alias="$(alias codex 2>/dev/null || :)"
+    __orca_codex_hooks_enabled="${__orca_codex_hooks_enabled:-}"
+    __orca_has_feature codex-hooks 2>/dev/null && __orca_codex_hooks_enabled=1
+    __orca_codex_hooks_override() {
+      local value
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --) return 1 ;;
+          --enable|--disable) [[ "${2:-}" == hooks || "${2:-}" == codex_hooks ]] && return 0 ;;
+          --enable=hooks|--disable=hooks|--enable=codex_hooks|--disable=codex_hooks) return 0 ;;
+          -c|--config) value="${2:-}" ;;
+          -c=*|--config=*) value="${1#*=}" ;;
+          -c?*) value="${1#-c}" ;;
+          *) value="" ;;
+        esac
+        case "$value" in
+          features.hooks|features.hooks=*|features.hooks[[:space:]]*=*|features.codex_hooks|features.codex_hooks=*|features.codex_hooks[[:space:]]*=*) return 0 ;;
+        esac
+        shift
+      done
+      return 1
+    }
+    __orca_codex_hooks_feature() {
+      local __orca_codex_version __orca_codex_major __orca_codex_minor __orca_codex_patch __orca_codex_probe_file __orca_codex_probe_pid __orca_codex_remaining __orca_codex_probe_status
+      __orca_codex_probe_file="$(mktemp "${TMPDIR:-/tmp}/orca-codex-version.XXXXXX" 2>/dev/null)" || return 0
+      command codex --version >"$__orca_codex_probe_file" 2>/dev/null &
+      __orca_codex_probe_pid=$!
+      __orca_codex_remaining=40
+      while kill -0 "$__orca_codex_probe_pid" 2>/dev/null && [[ $__orca_codex_remaining -gt 0 ]]; do
+        sleep 0.05 2>/dev/null || break
+        __orca_codex_remaining=$(( __orca_codex_remaining - 1 ))
+      done
+      if kill -0 "$__orca_codex_probe_pid" 2>/dev/null; then
+        kill "$__orca_codex_probe_pid" 2>/dev/null || :
+        wait "$__orca_codex_probe_pid" 2>/dev/null || :
+        rm -f "$__orca_codex_probe_file"
+        return 0
+      fi
+      if wait "$__orca_codex_probe_pid" 2>/dev/null; then __orca_codex_probe_status=0; else __orca_codex_probe_status=$?; fi
+      __orca_codex_version="$(<"$__orca_codex_probe_file")"
+      rm -f "$__orca_codex_probe_file"
+      [[ "$__orca_codex_probe_status" == 0 ]] || return 0
+      __orca_codex_version="${__orca_codex_version##* }"
+      __orca_codex_major="${__orca_codex_version%%.*}"
+      __orca_codex_minor="${__orca_codex_version#*.}"; __orca_codex_minor="${__orca_codex_minor%%.*}"
+      __orca_codex_patch="${__orca_codex_version#*.*.}"; __orca_codex_patch="${__orca_codex_patch%%[-+]*}"
+      [[ -n "$__orca_codex_major" && -n "$__orca_codex_minor" && -n "$__orca_codex_patch" ]] || return 0
+      [[ "$__orca_codex_major" != *[^0-9]* && "$__orca_codex_minor" != *[^0-9]* && "$__orca_codex_patch" != *[^0-9]* ]] || return 0
+      if (( __orca_codex_major >= 1 )); then
+        printf hooks
+      elif (( __orca_codex_minor >= 129 )); then
+        printf hooks
+      elif (( __orca_codex_minor >= 114 )); then
+        printf codex_hooks
+      fi
+    }
+    if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}${__orca_codex_hooks_enabled:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" && ! ( -z "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "$__orca_codex_alias" ) ]]; then
+      # Why the function reserved word: it suppresses alias expansion of the name,
+      # which otherwise rewrites this header at parse time and aborts the whole file.
+      function codex {
+        [[ -z "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" ]] || "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+        local __orca_codex_feature=""
+        if [[ -n "${__orca_codex_hooks_enabled:-}" && -n "${ORCA_AGENT_HOOK_PORT:-}" && -n "${ORCA_AGENT_HOOK_TOKEN:-}" && -n "${ORCA_PANE_KEY:-}" ]] && ! __orca_codex_hooks_override "$@"; then
+          __orca_codex_feature="$(__orca_codex_hooks_feature)"
+        fi
+        if [[ -n "$__orca_codex_feature" ]]; then
+          command codex --enable "$__orca_codex_feature" "$@"
+          return $?
+        fi
+        command codex "$@"
+      }
+    fi
+    unset __orca_codex_binary __orca_codex_alias
+  fi
   if [[ -n "${_orca_histfile:-}" ]]; then
     HISTFILE="$_orca_histfile"
   fi

--- a/src/main/providers/ssh-pty-provider-spawn.test.ts
+++ b/src/main/providers/ssh-pty-provider-spawn.test.ts
@@ -417,13 +417,15 @@ describe('spawn', () => {
 
   it('forwards provider command delivery to the relay', async () => {
     mux.request.mockResolvedValue({ id: 'pty-provider-command' })
+    provider = new SshPtyProvider('conn-1', mux as never, undefined, 1, () => true)
 
     await provider.spawn({
       cols: 120,
       rows: 40,
       command: 'echo from-runtime',
       commandDelivery: 'provider',
-      startupCommandDelivery: 'shell-ready'
+      startupCommandDelivery: 'shell-ready',
+      launchAgent: 'codex'
     })
 
     expectRequest(mux.request, 'pty.spawn', {
@@ -432,9 +434,25 @@ describe('spawn', () => {
       cwd: undefined,
       env: { [POWERLEVEL10K_WIZARD_DISABLE_ENV]: 'true' },
       command: 'echo from-runtime',
+      launchAgent: 'codex',
       commandDelivery: 'provider',
-      startupCommandDelivery: 'shell-ready'
+      startupCommandDelivery: 'shell-ready',
+      codexHooksEnabled: true
     })
+  })
+
+  it('fails closed when remote Codex hooks are disabled', async () => {
+    mux.request.mockResolvedValue({ id: 'pty-disabled-hooks' })
+
+    await provider.spawn({
+      cols: 120,
+      rows: 40,
+      launchAgent: 'codex',
+      env: { ORCA_AGENT_HOOK_PORT: '43117' }
+    })
+
+    const spawnCall = mux.request.mock.calls.find((call) => call[0] === 'pty.spawn')
+    expect(spawnCall?.[1]).not.toHaveProperty('codexHooksEnabled')
   })
 
   it('injects the relay-backed Orca CLI bridge into remote PTY env', async () => {

--- a/src/main/providers/ssh-pty-provider.ts
+++ b/src/main/providers/ssh-pty-provider.ts
@@ -46,7 +46,8 @@ export class SshPtyProvider implements IPtyProvider {
     connectionId: string,
     mux: SshChannelMultiplexer,
     private readonly remoteCliBridgeEnv?: RemoteCliBridgeEnv,
-    readonly providerGeneration = 1
+    readonly providerGeneration = 1,
+    private readonly areRemoteCodexHooksEnabled: () => boolean = () => false
   ) {
     this.connectionId = connectionId
     this.mux = mux
@@ -120,7 +121,8 @@ export class SshPtyProvider implements IPtyProvider {
       params: buildSshPtySpawnRequest({
         options: opts,
         remoteCliBridgeEnv: this.remoteCliBridgeEnv,
-        supportsCreateOperation
+        supportsCreateOperation,
+        codexHooksEnabled: opts.launchAgent === 'codex' && this.areRemoteCodexHooksEnabled()
       }),
       exitRaceTracker: this.spawnExitRaces,
       installSourceActivation: (id, activation) =>

--- a/src/main/providers/ssh-pty-spawn-request.ts
+++ b/src/main/providers/ssh-pty-spawn-request.ts
@@ -7,6 +7,7 @@ export function buildSshPtySpawnRequest(args: {
   options: PtySpawnOptions
   remoteCliBridgeEnv?: RemoteCliBridgeEnv
   supportsCreateOperation: boolean
+  codexHooksEnabled?: boolean
 }): Record<string, unknown> {
   const { options } = args
   return {
@@ -34,6 +35,7 @@ export function buildSshPtySpawnRequest(args: {
     ...(options.startupCommandDelivery
       ? { startupCommandDelivery: options.startupCommandDelivery }
       : {}),
+    ...(args.codexHooksEnabled === true ? { codexHooksEnabled: true } : {}),
     // Why: attach identity must survive even when hook variables are stripped from the shell env.
     ...(options.paneKey ? { paneKey: options.paneKey } : {}),
     ...(options.tabId ? { tabId: options.tabId } : {}),

--- a/src/main/pty/codex-shell-launch-preflight.test.ts
+++ b/src/main/pty/codex-shell-launch-preflight.test.ts
@@ -188,6 +188,53 @@ function expectNamedAliasSurvives(shell: string, enableAliases: string): void {
   expect(readFileSync(preflightMarker, 'utf-8')).toBe('agent hooks prepare-codex')
 }
 
+function runRemoteHookLaunch(shell: string, version: string, args = '', alias = false): string {
+  const root = mkdtempSync(join(tmpdir(), 'orca-codex-remote-hook-alias-'))
+  roots.push(root)
+  const bin = join(root, 'bin')
+  mkdirSync(bin)
+  writeExecutable(
+    join(bin, 'codex'),
+    `#!/bin/sh\nif [ "\${1-}" = --version ]; then printf 'codex-cli %s\\n' ${JSON.stringify(version)}; exit 0; fi\nprintf '%s\\n' "$*"\n`
+  )
+  const isZsh = shell.endsWith('/zsh')
+  const preflight = getPosixCodexShellLaunchPreflight()
+  const setup = isZsh
+    ? [
+        '__orca_deferred_init() {',
+        '__orca_has_feature() { [[ "$1" == codex-hooks ]]; }',
+        preflight,
+        '}',
+        ...(alias ? ["alias codex='GIT_AUTHOR_NAME=Codex codex --alias-flag'"] : []),
+        '__orca_deferred_init'
+      ]
+    : [
+        ...(alias ? ["alias codex='GIT_AUTHOR_NAME=Codex codex --alias-flag'"] : []),
+        '__orca_has_feature() { [[ "$1" == codex-hooks ]]; }',
+        preflight
+      ]
+  return execFileSync(
+    shell,
+    [
+      ...(isZsh ? ['-f'] : ['--noprofile', '--norc']),
+      '-c',
+      [isZsh ? 'setopt aliases' : 'shopt -s expand_aliases', ...setup, `eval 'codex ${args}'`].join(
+        '\n'
+      )
+    ],
+    {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${bin}${delimiter}${process.env.PATH ?? ''}`,
+        ORCA_AGENT_HOOK_PORT: '43117',
+        ORCA_AGENT_HOOK_TOKEN: 'token-1',
+        ORCA_PANE_KEY: 'tab-1:11111111-1111-4111-8111-111111111111'
+      }
+    }
+  ).trim()
+}
+
 afterEach(() => {
   for (const root of roots.splice(0)) {
     rmSync(root, { recursive: true, force: true })
@@ -217,6 +264,31 @@ describe.skipIf(process.platform === 'win32')('Codex shell launch preflight', ()
 
   it.skipIf(!bashAvailable)('keeps a user alias named codex working in bash', () => {
     expectNamedAliasSurvives('/bin/bash', 'shopt -s expand_aliases')
+  })
+
+  it.each([
+    ['/bin/bash', '0.113.0', ''],
+    ['/bin/bash', '0.114.0', '--enable codex_hooks'],
+    ['/bin/bash', '0.129.0', '--enable hooks'],
+    ['/bin/bash', '1.beta.0', ''],
+    ['/bin/bash', '10.x.y', ''],
+    ['/bin/zsh', '0.129.0', '--enable hooks']
+  ])('selects hook argv in %s for Codex %s', (shell, version, expected) => {
+    if (!existsSync(shell)) {
+      return
+    }
+    expect(runRemoteHookLaunch(shell, version)).toBe(expected)
+  })
+
+  it('preserves an explicit launch hook override after alias expansion', () => {
+    expect(runRemoteHookLaunch('/bin/bash', '0.149.0', '--disable hooks')).toBe('--disable hooks')
+  })
+
+  it.each(['/bin/bash', '/bin/zsh'])('fails open without replacing a user alias in %s', (shell) => {
+    if (!existsSync(shell)) {
+      return
+    }
+    expect(runRemoteHookLaunch(shell, '0.149.0', '', true)).toBe('--alias-flag')
   })
 
   it('still launches Codex when the best-effort preflight fails', () => {

--- a/src/main/pty/codex-shell-launch-preflight.ts
+++ b/src/main/pty/codex-shell-launch-preflight.ts
@@ -4,6 +4,8 @@ import { getBundledLauncherPath } from '../cli/bundled-cli-launcher-path'
 
 const DEV_LAUNCHER_DIR = ['cli', 'bin']
 const DEV_COMMAND_NAME = 'orca-dev'
+const CODEX_VERSION_PROBE_ATTEMPTS = 40
+const CODEX_VERSION_PROBE_INTERVAL_SECONDS = '0.05'
 
 export type CodexShellLaunchPreflightCommandOptions = {
   hooksEnabled: boolean
@@ -72,26 +74,157 @@ export function getPosixCodexShellLaunchPreflight(): string {
 # Why || : twice — zsh alone aborts inside the substitution, but every shell's
 # assignment adopts its exit status, so an absent codex trips set -e in bash too.
 __orca_codex_binary="$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)"
-if [[ -n "\${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -x "\${ORCA_CODEX_LAUNCH_PREFLIGHT}" && -n "\${__orca_codex_binary:-}" && -x "\${__orca_codex_binary}" ]]; then
+__orca_codex_alias="$(alias codex 2>/dev/null || :)"
+__orca_codex_hooks_enabled="\${__orca_codex_hooks_enabled:-}"
+__orca_has_feature codex-hooks 2>/dev/null && __orca_codex_hooks_enabled=1
+__orca_codex_hooks_override() {
+  local value
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --) return 1 ;;
+      --enable|--disable) [[ "\${2:-}" == hooks || "\${2:-}" == codex_hooks ]] && return 0 ;;
+      --enable=hooks|--disable=hooks|--enable=codex_hooks|--disable=codex_hooks) return 0 ;;
+      -c|--config) value="\${2:-}" ;;
+      -c=*|--config=*) value="\${1#*=}" ;;
+      -c?*) value="\${1#-c}" ;;
+      *) value="" ;;
+    esac
+    case "$value" in
+      features.hooks|features.hooks=*|features.hooks[[:space:]]*=*|features.codex_hooks|features.codex_hooks=*|features.codex_hooks[[:space:]]*=*) return 0 ;;
+    esac
+    shift
+  done
+  return 1
+}
+__orca_codex_hooks_feature() {
+  local __orca_codex_version __orca_codex_major __orca_codex_minor __orca_codex_patch __orca_codex_probe_file __orca_codex_probe_pid __orca_codex_remaining __orca_codex_probe_status
+  __orca_codex_probe_file="$(mktemp "\${TMPDIR:-/tmp}/orca-codex-version.XXXXXX" 2>/dev/null)" || return 0
+  command codex --version >"$__orca_codex_probe_file" 2>/dev/null &
+  __orca_codex_probe_pid=$!
+  __orca_codex_remaining=${CODEX_VERSION_PROBE_ATTEMPTS}
+  while kill -0 "$__orca_codex_probe_pid" 2>/dev/null && [[ $__orca_codex_remaining -gt 0 ]]; do
+    sleep ${CODEX_VERSION_PROBE_INTERVAL_SECONDS} 2>/dev/null || break
+    __orca_codex_remaining=$(( __orca_codex_remaining - 1 ))
+  done
+  if kill -0 "$__orca_codex_probe_pid" 2>/dev/null; then
+    kill -KILL "$__orca_codex_probe_pid" 2>/dev/null || :
+    wait "$__orca_codex_probe_pid" 2>/dev/null || :
+    rm -f "$__orca_codex_probe_file"
+    return 0
+  fi
+  if wait "$__orca_codex_probe_pid" 2>/dev/null; then __orca_codex_probe_status=0; else __orca_codex_probe_status=$?; fi
+  __orca_codex_version="$(<"$__orca_codex_probe_file")"
+  rm -f "$__orca_codex_probe_file"
+  [[ "$__orca_codex_probe_status" == 0 ]] || return 0
+  __orca_codex_version="\${__orca_codex_version##* }"
+  __orca_codex_major="\${__orca_codex_version%%.*}"
+  __orca_codex_minor="\${__orca_codex_version#*.}"; __orca_codex_minor="\${__orca_codex_minor%%.*}"
+  __orca_codex_patch="\${__orca_codex_version#*.*.}"; __orca_codex_patch="\${__orca_codex_patch%%[-+]*}"
+  [[ -n "$__orca_codex_major" && -n "$__orca_codex_minor" && -n "$__orca_codex_patch" ]] || return 0
+  [[ "$__orca_codex_major" != *[^0-9]* && "$__orca_codex_minor" != *[^0-9]* && "$__orca_codex_patch" != *[^0-9]* ]] || return 0
+  if (( __orca_codex_major >= 1 )); then
+    printf hooks
+  elif (( __orca_codex_minor >= 129 )); then
+    printf hooks
+  elif (( __orca_codex_minor >= 114 )); then
+    printf codex_hooks
+  fi
+}
+if [[ -n "\${ORCA_CODEX_LAUNCH_PREFLIGHT:-}\${__orca_codex_hooks_enabled:-}" && -n "\${__orca_codex_binary:-}" && -x "\${__orca_codex_binary}" && ( -z "\${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" || -x "\${ORCA_CODEX_LAUNCH_PREFLIGHT}" ) && ! ( -z "\${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "$__orca_codex_alias" ) ]]; then
   # Why the function reserved word: it suppresses alias expansion of the name,
   # which otherwise rewrites this header at parse time and aborts the whole file.
   function codex {
-    "\${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+    [[ -z "\${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" ]] || "\${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+    local __orca_codex_feature=""
+    if [[ -n "\${__orca_codex_hooks_enabled:-}" && -n "\${ORCA_AGENT_HOOK_PORT:-}" && -n "\${ORCA_AGENT_HOOK_TOKEN:-}" && -n "\${ORCA_PANE_KEY:-}" ]] && ! __orca_codex_hooks_override "$@"; then
+      __orca_codex_feature="$(__orca_codex_hooks_feature)"
+    fi
+    if [[ -n "$__orca_codex_feature" ]]; then
+      command codex --enable "$__orca_codex_feature" "$@"
+      return $?
+    fi
     command codex "$@"
   }
 fi
-unset __orca_codex_binary
+unset __orca_codex_binary __orca_codex_alias
 `
 }
 
-export function getFishCodexShellLaunchPreflight(): string {
-  return `# Why captured: an unquoted (type -t codex) expands to zero words when codex is
-# absent, leaving "test = file" — fish then errors instead of failing closed.
-# Quoting in place is not the fix; fish never substitutes inside double quotes.
+export function getFishCodexShellLaunchPreflight(options: { hooksEnabled?: boolean } = {}): string {
+  const hookSetup = options.hooksEnabled
+    ? `set -g __orca_codex_hooks_enabled 1
+function __orca_codex_hooks_override
+  set index 1
+  while test $index -le (count $argv)
+    set value $argv[$index]
+    switch $value
+      case --
+        return 1
+      case --enable --disable
+        set next $argv[(math $index + 1)]
+        if test "$next" = hooks; or test "$next" = codex_hooks; return 0; end
+      case '--enable=hooks' '--disable=hooks' '--enable=codex_hooks' '--disable=codex_hooks'
+        return 0
+      case '-c' '--config'
+        set value $argv[(math $index + 1)]
+      case '-c=*' '--config=*'
+        set value (string split -m1 = $value)[2]
+      case '-c?*'
+        set value (string sub -s 3 $value)
+    end
+    if string match -qr '^features\\.(hooks|codex_hooks)([[:space:]]*=|=|$)' -- $value; return 0; end
+    set index (math $index + 1)
+  end
+  return 1
+end
+function __orca_codex_hooks_feature
+  set temp_root /tmp
+  if set -q TMPDIR; and test -n "$TMPDIR"; set temp_root $TMPDIR; end
+  set probe_file (command mktemp "$temp_root/orca-codex-version.XXXXXX" 2>/dev/null); or return
+  command codex --version >$probe_file 2>/dev/null &
+  set probe_pid $last_pid
+  set remaining ${CODEX_VERSION_PROBE_ATTEMPTS}
+  while command kill -0 $probe_pid 2>/dev/null; and test $remaining -gt 0
+    command sleep ${CODEX_VERSION_PROBE_INTERVAL_SECONDS} 2>/dev/null; or break
+    set remaining (math $remaining - 1)
+  end
+  if command kill -0 $probe_pid 2>/dev/null
+    command kill -KILL $probe_pid 2>/dev/null
+    wait $probe_pid 2>/dev/null
+    command rm -f $probe_file
+    return
+  end
+  wait $probe_pid 2>/dev/null
+  set probe_status $status
+  set version (string collect <$probe_file)
+  command rm -f $probe_file
+  if test "$probe_status" != 0; return; end
+  set version (string split ' ' -- $version)[-1]
+  if not string match -qr '^[0-9]+\\.[0-9]+\\.[0-9]+([-+].*)?$' -- $version; return; end
+  set parts (string split . -- $version)
+  if test $parts[1] -ge 1; or test $parts[2] -ge 129
+    printf hooks
+  else if test $parts[2] -ge 114
+    printf codex_hooks
+  end
+end`
+    : ''
+  return `${hookSetup}
+# Why captured: an absent codex expands to zero words and makes fish parse an invalid test.
 set -l __orca_codex_type (type -t codex 2>/dev/null)
-if test -x "$ORCA_CODEX_LAUNCH_PREFLIGHT"; and test "$__orca_codex_type" = file
+if test -n "$ORCA_CODEX_LAUNCH_PREFLIGHT$__orca_codex_hooks_enabled"; and test "$__orca_codex_type" = file; and begin; test -z "$ORCA_CODEX_LAUNCH_PREFLIGHT"; or test -x "$ORCA_CODEX_LAUNCH_PREFLIGHT"; end
   function codex
-    command "$ORCA_CODEX_LAUNCH_PREFLIGHT" agent hooks prepare-codex >/dev/null 2>&1; or true
+    if test -n "$ORCA_CODEX_LAUNCH_PREFLIGHT"
+      command "$ORCA_CODEX_LAUNCH_PREFLIGHT" agent hooks prepare-codex >/dev/null 2>&1; or true
+    end
+    set feature
+    if test -n "$__orca_codex_hooks_enabled"; and test -n "$ORCA_AGENT_HOOK_PORT"; and test -n "$ORCA_AGENT_HOOK_TOKEN"; and test -n "$ORCA_PANE_KEY"; and not __orca_codex_hooks_override $argv
+      set feature (__orca_codex_hooks_feature)
+    end
+    if test -n "$feature"
+      command codex --enable "$feature" $argv
+      return $status
+    end
     command codex $argv
   end
 end

--- a/src/main/shell-startup-features.ts
+++ b/src/main/shell-startup-features.ts
@@ -15,6 +15,7 @@ export const SHELL_STARTUP_FEATURE_ENV = 'ORCA_SHELL_FEATURES'
 
 export const SHELL_STARTUP_FEATURES = [
   'overlay',
+  'codex-hooks',
   'history',
   'markers',
   'ready',
@@ -44,6 +45,8 @@ export type ShellStartupFeatureInput = {
   waitsForShellReady: boolean
   /** True when Orca needs the shell to announce its PID at startup. */
   emitsStartupIdentity: boolean
+  /** True when this host-recognized launch needs Codex hook argv injection. */
+  codexHooksEnabled?: boolean
 }
 
 function shellName(shellPath: string): string {
@@ -72,6 +75,9 @@ export function selectShellStartupFeatures(input: ShellStartupFeatureInput): She
   const features: ShellStartupFeature[] = []
   if (overlay) {
     features.push('overlay')
+  }
+  if (input.codexHooksEnabled) {
+    features.push('codex-hooks')
   }
   if (history) {
     features.push('history')

--- a/src/main/shell-templates.ts
+++ b/src/main/shell-templates.ts
@@ -34,7 +34,9 @@ __orca_has_feature() { (( \${_orca_shell_features[(Ie)$1]} )) }`
 /** The bash rcfile equivalent of ZSH_FEATURE_CHANNEL_BLOCK. */
 export const BASH_FEATURE_CHANNEL_BLOCK = `_orca_shell_features=",\${${SHELL_STARTUP_FEATURE_ENV}:-},"
 builtin unset ${SHELL_STARTUP_FEATURE_ENV}
-__orca_has_feature() { [[ "$_orca_shell_features" == *",$1,"* ]]; }`
+__orca_has_feature() { [[ "$_orca_shell_features" == *",$1,"* ]]; }
+__orca_codex_hooks_enabled=""
+__orca_has_feature codex-hooks && __orca_codex_hooks_enabled=1`
 
 // Why one line usable by both languages: __orca_has_feature is defined with the
 // same name and semantics in the zsh and bash channel blocks above.

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -110,6 +110,7 @@ import {
 } from '../../shared/ssh-ai-vault-relay'
 import { isTerminalLeafId, makePaneKey } from '../../shared/stable-pane-id'
 import { isValidTerminalTabId } from '../../shared/terminal-tab-id'
+import { isTuiAgentEnabled } from '../../shared/tui-agent-selection'
 import {
   openSshPtyConsumerSession,
   type OpenSshPtyConsumerSessionOptions,
@@ -1018,7 +1019,8 @@ export class SshRelaySession {
       this.targetId,
       mux,
       this.remoteCliBridgeEnv ?? undefined,
-      providerGeneration
+      providerGeneration,
+      () => this.areRemoteCodexHooksEnabled()
     )
     const consumerOwnerState = this.activePtyConsumerOwner()
     if (consumerOwnerState) {
@@ -1473,6 +1475,16 @@ export class SshRelaySession {
   private areAgentStatusHooksEnabled(): boolean {
     const store = this.store as { getSettings?: Store['getSettings'] }
     return isAgentStatusHooksEnabled(store.getSettings?.())
+  }
+
+  private areRemoteCodexHooksEnabled(): boolean {
+    const store = this.store as { getSettings?: Store['getSettings'] }
+    const settings = store.getSettings?.()
+    return (
+      isRemoteAgentHooksEnabled() &&
+      isAgentStatusHooksEnabled(settings) &&
+      isTuiAgentEnabled('codex', settings?.disabledTuiAgents)
+    )
   }
 
   private wireUpRemoteWorkspaceEvents(mux: SshChannelMultiplexer): void {

--- a/src/main/zsh-startup-wrapper-builder.ts
+++ b/src/main/zsh-startup-wrapper-builder.ts
@@ -122,8 +122,7 @@ function getOverlayRestoreBlocks(spec: ZshStartupHookSpec): (string | null)[] {
     MIMOCODE_HOME_RESTORE,
     spec.restores.remoteCliBinDir ? REMOTE_CLI_BIN_DIR_RESTORE : null,
     getPosixOmpShellWrapper(),
-    spec.restores.codexHome ? CODEX_HOME_RESTORE : null,
-    spec.restores.codexLaunchPreflight ? getPosixCodexShellLaunchPreflight() : null
+    spec.restores.codexHome ? CODEX_HOME_RESTORE : null
   ]
 }
 
@@ -160,6 +159,11 @@ function buildDeferredInit(spec: ZshStartupHookSpec): string {
 ${permanentPrecmd}
 ${joinBlocks([
   featureGuard('overlay', getOverlayRestoreBlocks(spec)),
+  spec.restores.codexLaunchPreflight
+    ? `  if __orca_has_feature overlay || __orca_has_feature codex-hooks; then
+${indentBlock(getPosixCodexShellLaunchPreflight().replace(/\n$/, ''), '    ')}
+  fi`
+    : null,
   // Why no /etc/zshrc repair branch: ZDOTDIR was handed back before that file
   // ran, so the value it derives is the user's own path. #11044 is unreachable.
   `  if [[ -n "\${_orca_histfile:-}" ]]; then

--- a/src/relay/agent-hook-endpoint-coordinates.ts
+++ b/src/relay/agent-hook-endpoint-coordinates.ts
@@ -9,6 +9,14 @@ import {
   ORCA_HOOK_RAW_JSON_TRANSPORT
 } from '../shared/agent-hook-types'
 
+export const RELAY_OWNED_AGENT_HOOK_ENV_KEYS = [
+  'ORCA_AGENT_HOOK_PORT',
+  'ORCA_AGENT_HOOK_TOKEN',
+  'ORCA_AGENT_HOOK_ENV',
+  'ORCA_AGENT_HOOK_VERSION',
+  'ORCA_AGENT_HOOK_ENDPOINT'
+] as const
+
 // Why: relay's userData equivalent under $HOME so each user on a shared dev box gets their own 0o700 dir.
 const RELAY_HOOKS_DIR_NAME = '.orca-relay'
 const RELAY_HOOKS_SUBDIR = 'agent-hooks'

--- a/src/relay/codex-hook-launch-policy.ts
+++ b/src/relay/codex-hook-launch-policy.ts
@@ -1,0 +1,56 @@
+import { parsePaneKey } from '../shared/stable-pane-id'
+import { tokenizeStartupCommand } from '../shared/tui-agent-startup-shell'
+
+function isPosixEnvAssignment(
+  command: string,
+  span: { start: number; end: number; divergesFromShell: boolean }
+): boolean {
+  return (
+    !span.divergesFromShell && /^[A-Za-z_][A-Za-z0-9_]*=/.test(command.slice(span.start, span.end))
+  )
+}
+
+function hasOnlyHorizontalWhitespaceGaps(
+  command: string,
+  spans: readonly { start: number; end: number }[]
+): boolean {
+  let previousEnd = 0
+  for (const span of spans) {
+    if (!/^[\t ]*$/.test(command.slice(previousEnd, span.start))) {
+      return false
+    }
+    previousEnd = span.end
+  }
+  return /^[\t ]*$/.test(command.slice(previousEnd))
+}
+
+export function hasCompleteRemoteAgentHookContext(args: {
+  env: Record<string, string>
+  paneKey: unknown
+}): boolean {
+  const paneKey = typeof args.paneKey === 'string' ? args.paneKey : ''
+  return Boolean(
+    args.env.ORCA_AGENT_HOOK_PORT?.trim() &&
+    args.env.ORCA_AGENT_HOOK_TOKEN?.trim() &&
+    paneKey &&
+    args.env.ORCA_PANE_KEY === paneKey &&
+    parsePaneKey(paneKey)
+  )
+}
+
+export function isDirectPosixCodexCommand(command: string): boolean {
+  const tokenized = tokenizeStartupCommand(command, 'posix')
+  if (!tokenized.ok) {
+    return false
+  }
+  const codexIndex = tokenized.tokens.indexOf('codex')
+  const codexSpan = tokenized.spans[codexIndex]
+  return Boolean(
+    codexIndex !== -1 &&
+    codexSpan &&
+    command.slice(codexSpan.start, codexSpan.end) === 'codex' &&
+    tokenized.spans.slice(0, codexIndex).every((span) => isPosixEnvAssignment(command, span)) &&
+    tokenized.spans.every((span) => !span.divergesFromShell) &&
+    hasOnlyHorizontalWhitespaceGaps(command, tokenized.spans)
+  )
+}

--- a/src/relay/pty-handler-spawn-environment.test.ts
+++ b/src/relay/pty-handler-spawn-environment.test.ts
@@ -9,6 +9,7 @@ import {
 import { stripLegacyTerminalShimEnv } from '../main/pty/legacy-terminal-shim-dir'
 import { fishHistorySessionName, relayFishHistorySessionName } from '../main/fish-history-session'
 import { hashWorktreeId } from '../main/terminal-history-id'
+import { buildRelayHookPtyEnv } from './agent-hook-endpoint-coordinates'
 
 const { mockPtySpawn, mockPtyInstance, mockCreateShellPromptReadinessProbe } = vi.hoisted(() => ({
   mockPtySpawn: vi.fn(),
@@ -532,6 +533,56 @@ describe('PtyHandler', () => {
     expect(callArgs.env.ORCA_PANE_KEY).toBe('augmenter-wins')
     // Renderer-supplied keys not in augmenter map flow through:
     expect(callArgs.env.ORCA_TAB_ID).toBe('tab-1')
+  })
+
+  it('drops stale hook coordinates when the relay hook server is unavailable', async () => {
+    const keys = [
+      'ORCA_AGENT_HOOK_PORT',
+      'ORCA_AGENT_HOOK_TOKEN',
+      'ORCA_AGENT_HOOK_ENV',
+      'ORCA_AGENT_HOOK_VERSION',
+      'ORCA_AGENT_HOOK_ENDPOINT'
+    ] as const
+    const saved = Object.fromEntries(keys.map((key) => [key, process.env[key]]))
+    Object.assign(process.env, {
+      ORCA_AGENT_HOOK_PORT: '43117',
+      ORCA_AGENT_HOOK_TOKEN: 'stale-token',
+      ORCA_AGENT_HOOK_ENV: 'stale',
+      ORCA_AGENT_HOOK_VERSION: '1',
+      ORCA_AGENT_HOOK_ENDPOINT: '/tmp/stale.env'
+    })
+    handler.addEnvAugmenter(() =>
+      buildRelayHookPtyEnv({
+        port: 0,
+        token: '',
+        env: 'remote',
+        endpointFilePath: '/tmp/current.env',
+        endpointFileWritten: false
+      })
+    )
+
+    try {
+      await dispatcher.callRequest('pty.spawn', {
+        env: {
+          ORCA_AGENT_HOOK_PORT: '54321',
+          ORCA_AGENT_HOOK_TOKEN: 'renderer-token'
+        }
+      })
+    } finally {
+      for (const key of keys) {
+        const value = saved[key]
+        if (value === undefined) {
+          delete process.env[key]
+        } else {
+          process.env[key] = value
+        }
+      }
+    }
+
+    const env = mockPtySpawn.mock.calls.at(-1)?.[2]?.env as Record<string, string>
+    for (const key of keys) {
+      expect(env[key]).toBeUndefined()
+    }
   })
 
   it('passes PTY and explicit launch identity to env augmenters', async () => {

--- a/src/relay/pty-handler-startup-command-delivery.test.ts
+++ b/src/relay/pty-handler-startup-command-delivery.test.ts
@@ -44,6 +44,12 @@ import {
 } from './pty-handler-test-harness'
 import type { MockDispatcher } from './pty-handler-test-harness'
 
+const PANE_KEY = 'tab-1:11111111-1111-4111-8111-111111111111'
+const HOOK_SERVER_ENV = {
+  ORCA_AGENT_HOOK_PORT: '43117',
+  ORCA_AGENT_HOOK_TOKEN: 'token-1'
+}
+
 describe('PtyHandler', () => {
   let dispatcher: MockDispatcher
   let handler: PtyHandler
@@ -165,6 +171,95 @@ describe('PtyHandler', () => {
       expect(handler.retainedStartupCommandCount).toBe(1)
     }
   )
+
+  it.skipIf(process.platform === 'win32')(
+    'selects Codex hooks from the authoritative relay launch context',
+    async () => {
+      const oldShell = process.env.SHELL
+      const oldHome = process.env.HOME
+      const homeDir = mkdtempSync(join(tmpdir(), 'relay-codex-hook-feature-'))
+
+      process.env.SHELL = '/bin/bash'
+      process.env.HOME = homeDir
+      handler.addEnvAugmenter(() => HOOK_SERVER_ENV)
+      try {
+        await dispatcher.callRequest('pty.spawn', {
+          env: { HOME: homeDir, ORCA_PANE_KEY: PANE_KEY },
+          paneKey: PANE_KEY,
+          command: 'codex',
+          launchAgent: 'codex',
+          codexHooksEnabled: true
+        })
+      } finally {
+        if (oldShell === undefined) {
+          delete process.env.SHELL
+        } else {
+          process.env.SHELL = oldShell
+        }
+        if (oldHome === undefined) {
+          delete process.env.HOME
+        } else {
+          process.env.HOME = oldHome
+        }
+        rmSync(homeDir, { recursive: true, force: true })
+      }
+
+      const spawnEnv = mockPtySpawn.mock.calls[0]?.[2]?.env as Record<string, string>
+      expect(spawnEnv.ORCA_SHELL_FEATURES).toContain('codex-hooks')
+    }
+  )
+
+  it.skipIf(process.platform === 'win32').each([
+    ['another agent', { launchAgent: 'claude', command: 'codex', codexHooksEnabled: true }],
+    [
+      'an opaque launcher',
+      { launchAgent: 'codex', command: 'mise exec -- codex', codexHooksEnabled: true }
+    ],
+    [
+      'an absolute executable',
+      { launchAgent: 'codex', command: '/opt/codex/bin/codex', codexHooksEnabled: true }
+    ],
+    ['an old-client request', { launchAgent: 'codex', command: 'codex' }],
+    [
+      'an incomplete pane context',
+      { launchAgent: 'codex', command: 'codex', codexHooksEnabled: true, missingPane: true }
+    ]
+  ])('does not select Codex hooks for %s', async (_label, launch) => {
+    const oldShell = process.env.SHELL
+    const oldHome = process.env.HOME
+    const homeDir = mkdtempSync(join(tmpdir(), 'relay-codex-hook-negative-'))
+
+    process.env.SHELL = '/bin/bash'
+    process.env.HOME = homeDir
+    handler.addEnvAugmenter(() => HOOK_SERVER_ENV)
+    try {
+      await dispatcher.callRequest('pty.spawn', {
+        env: {
+          HOME: homeDir,
+          ...(!('missingPane' in launch) ? { ORCA_PANE_KEY: PANE_KEY } : {})
+        },
+        ...(!('missingPane' in launch) ? { paneKey: PANE_KEY } : {}),
+        launchAgent: launch.launchAgent,
+        command: launch.command,
+        ...('codexHooksEnabled' in launch ? { codexHooksEnabled: launch.codexHooksEnabled } : {})
+      })
+    } finally {
+      if (oldShell === undefined) {
+        delete process.env.SHELL
+      } else {
+        process.env.SHELL = oldShell
+      }
+      if (oldHome === undefined) {
+        delete process.env.HOME
+      } else {
+        process.env.HOME = oldHome
+      }
+      rmSync(homeDir, { recursive: true, force: true })
+    }
+
+    const spawnEnv = mockPtySpawn.mock.calls[0]?.[2]?.env as Record<string, string>
+    expect(spawnEnv.ORCA_SHELL_FEATURES).not.toContain('codex-hooks')
+  })
 
   it.skipIf(process.platform === 'win32')(
     'enables shell-ready marker env for provider-delivered startup commands',

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -22,6 +22,10 @@ import { addWslEnvKeys } from '../shared/wsl-env'
 import { SHELL_STARTUP_FEATURE_ENV } from '../main/shell-startup-features'
 import { DEFAULT_SSH_RELAY_GRACE_PERIOD_SECONDS } from '../shared/ssh-types'
 import { shouldUseShellReadyStartupDelivery } from '../shared/codex-startup-delivery'
+import {
+  hasCompleteRemoteAgentHookContext,
+  isDirectPosixCodexCommand
+} from './codex-hook-launch-policy'
 import { buildStartupCommandSubmission } from '../shared/startup-command-submission'
 import { resolveSetupAgentSequenceLaunchCommand } from '../shared/setup-agent-sequencing'
 import {
@@ -90,6 +94,7 @@ import {
   injectRelayFishHistoryEnv,
   injectRelayHistoryEnv
 } from './terminal-history'
+import { RELAY_OWNED_AGENT_HOOK_ENV_KEYS } from './agent-hook-endpoint-coordinates'
 
 // Why: only Linux compiles node-pty (no prebuilt), so the build-tools remedy is a closable setup gap
 // there and wrong advice anywhere node-pty ships one. The relay only sees an unloadable binding, never
@@ -684,6 +689,9 @@ export class PtyHandler {
       },
       rendererEnv
     ) as Record<string, string>
+    for (const key of RELAY_OWNED_AGENT_HOOK_ENV_KEYS) {
+      delete baseEnv[key]
+    }
     const augmented: Record<string, string> = {}
     for (const augmenter of this.envAugmenters) {
       try {
@@ -1652,6 +1660,15 @@ export class PtyHandler {
       }
     }
     const launchCommandHint = resolveSetupAgentSequenceLaunchCommand(spawnEnv, command)
+    const remoteCodexHookLaunch = Boolean(
+      launchCommandHint &&
+      launchAgent &&
+      params.codexHooksEnabled === true &&
+      hasCompleteRemoteAgentHookContext({ env: spawnEnv, paneKey: params.paneKey }) &&
+      launchAgent === 'codex' &&
+      process.platform !== 'win32' &&
+      isDirectPosixCodexCommand(launchCommandHint)
+    )
     // Why: SSH PTYs bypass main's host-env builder, so apply the guard after the relay merges its authoritative env.
     const gitCredentialPromptGuarded = applyTerminalGitCredentialPromptGuard(spawnEnv, {
       launchCommand: launchCommandHint,
@@ -1660,17 +1677,19 @@ export class PtyHandler {
     })
     const shouldEmitShellReadyMarker =
       launchCommandHint !== undefined &&
-      shouldUseShellReadyStartupDelivery({
-        command: launchCommandHint,
-        startupCommandDelivery:
-          params.startupCommandDelivery === 'shell-ready' ? 'shell-ready' : undefined
-      })
+      (remoteCodexHookLaunch ||
+        shouldUseShellReadyStartupDelivery({
+          command: launchCommandHint,
+          startupCommandDelivery:
+            params.startupCommandDelivery === 'shell-ready' ? 'shell-ready' : undefined
+        }))
     const managedStartupCommand = shouldProviderDeliverCommand ? command : launchCommandHint
     // Why: both renderer- and provider-delivered startup commands use this marker; the delivering side strips it from output.
     const shellLaunch = getRelayShellLaunchConfig(shell, spawnEnv, process.platform, {
       terminalWindowsWslDistro,
       emitReadyMarker: shouldEmitShellReadyMarker,
-      emitStartupIdentity: shouldEmitShellReadyMarker
+      emitStartupIdentity: shouldEmitShellReadyMarker,
+      codexHooksEnabled: remoteCodexHookLaunch
     })
     const rendererShellReadySupported =
       !shouldProviderDeliverCommand && shellLaunch.supportsReadyMarker

--- a/src/relay/pty-shell-codex-hooks.live-shell.test.ts
+++ b/src/relay/pty-shell-codex-hooks.live-shell.test.ts
@@ -1,0 +1,183 @@
+import { spawnSync } from 'node:child_process'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { basename, join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { resolveFishBinary } from '../shared/fish-binary-requirement'
+import { getRelayShellLaunchConfig } from './pty-shell-launch'
+
+type TestShell = { name: 'bash' | 'zsh' | 'fish'; path: string }
+type HookCoordinate = 'ORCA_AGENT_HOOK_PORT' | 'ORCA_AGENT_HOOK_TOKEN' | 'ORCA_PANE_KEY'
+
+const PANE_KEY = 'tab-1:11111111-1111-4111-8111-111111111111'
+
+const roots: string[] = []
+
+function discoverShells(): TestShell[] {
+  const shells: TestShell[] = []
+  for (const path of ['/bin/bash', '/bin/zsh']) {
+    if (existsSync(path)) {
+      shells.push({ name: basename(path) as 'bash' | 'zsh', path })
+    }
+  }
+  const fish = resolveFishBinary(4)
+  if (fish.available) {
+    const resolved = fish.path.includes('/')
+      ? fish.path
+      : spawnSync('sh', ['-c', `command -v ${fish.path}`], { encoding: 'utf8' }).stdout.trim()
+    if (resolved) {
+      shells.push({ name: 'fish', path: resolved })
+    }
+  }
+  return shells
+}
+
+function writeUserConfig(shell: TestShell, root: string, bin: string, opaque: boolean): void {
+  const pathLine =
+    shell.name === 'fish'
+      ? `set -gx PATH ${JSON.stringify(bin)} /usr/bin /bin /usr/sbin /sbin`
+      : `export PATH=${JSON.stringify(`${bin}:/usr/bin:/bin:/usr/sbin:/sbin`)}`
+  const customCommand =
+    shell.name === 'fish'
+      ? 'function codex; command codex --alias-flag $argv; end'
+      : "alias codex='codex --alias-flag'"
+  const content = [pathLine, ...(opaque ? [customCommand] : [])].join('\n')
+  if (shell.name === 'fish') {
+    const configDir = join(root, '.config', 'fish')
+    mkdirSync(configDir, { recursive: true })
+    writeFileSync(join(configDir, 'config.fish'), content)
+  } else {
+    writeFileSync(join(root, shell.name === 'zsh' ? '.zshrc' : '.bash_profile'), content)
+  }
+}
+
+function runRelayCodex(
+  shell: TestShell,
+  options: {
+    version?: string
+    coordinates?: Partial<Record<HookCoordinate, string>>
+    args?: string
+    opaque?: boolean
+  } = {}
+): { argv: string[] } {
+  const root = mkdtempSync(join(tmpdir(), `orca-relay-codex-${shell.name}-`))
+  roots.push(root)
+  const bin = join(root, 'bin')
+  const output = join(root, 'codex-output')
+  mkdirSync(bin)
+  writeFileSync(
+    join(bin, 'codex'),
+    `#!/bin/sh
+if [ "\${1-}" = --version ]; then
+  if [ "\${ORCA_CODEX_TEST_VERSION:-}" = hang ]; then while :; do :; done; fi
+  printf 'codex-cli %s\\n' "\${ORCA_CODEX_TEST_VERSION:-0.149.0}"
+  exit 0
+fi
+for arg do printf '%s\\037' "$arg"; done > "$ORCA_CODEX_TEST_OUTPUT"
+`
+  )
+  chmodSync(join(bin, 'codex'), 0o755)
+  writeUserConfig(shell, root, bin, options.opaque === true)
+
+  const env: Record<string, string> = {
+    HOME: root,
+    PATH: `${bin}:/usr/bin:/bin:/usr/sbin:/sbin`,
+    TERM: 'xterm-256color',
+    XDG_CONFIG_HOME: join(root, '.config'),
+    ORCA_CODEX_TEST_OUTPUT: output,
+    ORCA_CODEX_TEST_VERSION: options.version ?? '0.149.0',
+    ...options.coordinates
+  }
+  const config = getRelayShellLaunchConfig(shell.path, env, 'linux', {
+    emitReadyMarker: true,
+    emitStartupIdentity: true,
+    codexHooksEnabled: true
+  })
+  const childEnv = { ...env, ...config.env }
+  const result = spawnSync(shell.path, [...config.args, '-i'], {
+    encoding: 'utf8',
+    env: childEnv,
+    input: `codex${options.args ? ` ${options.args}` : ''}\nexit\n`,
+    timeout: 15_000
+  })
+
+  expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(0)
+  expect(existsSync(output), `${result.stderr}\n${result.stdout}`).toBe(true)
+  return { argv: readFileSync(output, 'utf8').split('\x1f').slice(0, -1) }
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+const SHELLS = discoverShells()
+
+describe.skipIf(process.platform === 'win32')('relay Codex hook launch in real shells', () => {
+  it('finds at least one supported shell', () => {
+    expect(SHELLS.length).toBeGreaterThan(0)
+  })
+
+  describe.each(SHELLS)('$name', (shell) => {
+    const coordinates = {
+      ORCA_AGENT_HOOK_PORT: '43117',
+      ORCA_AGENT_HOOK_TOKEN: 'token-1',
+      ORCA_PANE_KEY: PANE_KEY
+    }
+
+    it.each([
+      ['0.113.0', []],
+      ['0.114.0', ['--enable', 'codex_hooks']],
+      ['0.128.0', ['--enable', 'codex_hooks']],
+      ['0.129.0', ['--enable', 'hooks']],
+      ['1.0.0', ['--enable', 'hooks']],
+      ['1.beta.0', []],
+      ['10.x.y', []]
+    ])('selects the supported feature for Codex %s', (version, expected) => {
+      expect(runRelayCodex(shell, { version, coordinates }).argv).toEqual(expected)
+    })
+
+    it('requires final hook server coordinates', () => {
+      expect(runRelayCodex(shell, { coordinates: { ORCA_AGENT_HOOK_PORT: '43117' } }).argv).toEqual(
+        []
+      )
+    })
+
+    it('requires final pane identity', () => {
+      expect(
+        runRelayCodex(shell, {
+          coordinates: {
+            ORCA_AGENT_HOOK_PORT: '43117',
+            ORCA_AGENT_HOOK_TOKEN: 'token-1'
+          }
+        }).argv
+      ).toEqual([])
+    })
+
+    it('preserves an explicit launch override', () => {
+      expect(runRelayCodex(shell, { coordinates, args: '--disable hooks' }).argv).toEqual([
+        '--disable',
+        'hooks'
+      ])
+    })
+
+    it('leaves a user alias or function opaque', () => {
+      expect(runRelayCodex(shell, { coordinates, opaque: true }).argv).toEqual(['--alias-flag'])
+    })
+
+    it('fails open when version discovery hangs', () => {
+      const startedAt = Date.now()
+      expect(runRelayCodex(shell, { version: 'hang', coordinates }).argv).toEqual([])
+      expect(Date.now() - startedAt).toBeLessThan(5_000)
+    })
+  })
+})

--- a/src/relay/pty-shell-launch.test.ts
+++ b/src/relay/pty-shell-launch.test.ts
@@ -189,6 +189,29 @@ describe('getRelayShellLaunchConfig', () => {
     }
   )
 
+  it.skipIf(process.platform === 'win32')(
+    'installs the post-profile Codex hook wrapper only when the relay selects the feature',
+    () => {
+      const config = getRelayShellLaunchConfig(
+        '/bin/zsh',
+        {
+          HOME: homeDir
+        },
+        'linux',
+        {
+          codexHooksEnabled: true
+        }
+      )
+      const zshenv = readFileSync(
+        join(homeDir, '.orca-relay', 'shell-ready', 'zsh', '.zshenv'),
+        'utf8'
+      )
+
+      expect(config.env.ORCA_SHELL_FEATURES).toContain('codex-hooks')
+      expect(zshenv).toContain('__orca_codex_hooks_feature')
+    }
+  )
+
   it('keeps PowerShell Core on POSIX remotes as a login shell', () => {
     expect(getRelayShellLaunchConfig('/usr/bin/pwsh', { HOME: homeDir }, 'linux')).toEqual({
       args: ['-l'],

--- a/src/relay/pty-shell-launch.ts
+++ b/src/relay/pty-shell-launch.ts
@@ -8,6 +8,9 @@ import {
 } from '../main/shell-startup-features'
 import { inheritedZdotdirEnv, resolveInheritedZdotdir } from '../main/zsh-wrapper-dir-ownership'
 import { ensureOverlayRestoreWrappers } from './pty-shell-overlay-wrappers'
+import { getFishCodexShellLaunchPreflight } from '../main/pty/codex-shell-launch-preflight'
+import { getFishShellReadyInitCommand } from '../main/shell-templates'
+import { SHELL_READY_MARKER_ESCAPED } from '../main/providers/local-pty-shell-ready-marker'
 const RELAY_SHELL_READY_DIR = '.orca-relay/shell-ready'
 const POSIX_LOGIN_ARGS = ['-l']
 
@@ -65,6 +68,7 @@ export function getRelayShellLaunchConfig(
   options: {
     emitReadyMarker?: boolean
     emitStartupIdentity?: boolean
+    codexHooksEnabled?: boolean
     terminalWindowsWslDistro?: string | null
   } = {}
 ): RelayShellLaunchConfig {
@@ -87,6 +91,17 @@ export function getRelayShellLaunchConfig(
     }
   }
 
+  if (shellName === 'fish' && options.emitReadyMarker === true) {
+    return {
+      args: [
+        '-l',
+        '-C',
+        `${getFishShellReadyInitCommand(SHELL_READY_MARKER_ESCAPED)}\n${getFishCodexShellLaunchPreflight({ hooksEnabled: options.codexHooksEnabled })}`
+      ],
+      env: {},
+      supportsReadyMarker: true
+    }
+  }
   if (shellName !== 'zsh' && shellName !== 'bash') {
     return unwrapped
   }
@@ -100,7 +115,8 @@ export function getRelayShellLaunchConfig(
     env,
     hasStartupCommand: startupCommandRequested,
     waitsForShellReady: options.emitReadyMarker === true,
-    emitsStartupIdentity: options.emitStartupIdentity === true
+    emitsStartupIdentity: options.emitStartupIdentity === true,
+    codexHooksEnabled: options.codexHooksEnabled === true
   })
   // Why bash is always wrapped: its rcfile carries the OSC 133 command-lifecycle
   // hooks unconditionally today, and dropping them would strand agent rows on

--- a/src/relay/pty-shell-overlay-wrappers.ts
+++ b/src/relay/pty-shell-overlay-wrappers.ts
@@ -1,6 +1,7 @@
 import { readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { getPosixOmpShellWrapper } from '../main/pty/omp-shell-wrapper'
+import { getPosixCodexShellLaunchPreflight } from '../main/pty/codex-shell-launch-preflight'
 import {
   BASH_FEATURE_CHANNEL_BLOCK,
   BASH_PROMPT_COMMAND_COMPOSITION_BLOCK,
@@ -34,7 +35,7 @@ function getRelayZshWrapperSpec(): ZshStartupHookSpec {
       agentTeamsPath: false,
       remoteCliBinDir: true,
       codexHome: false,
-      codexLaunchPreflight: false
+      codexLaunchPreflight: true
     }
   }
 }
@@ -72,6 +73,7 @@ fi
 [[ -n "\${ORCA_MIMOCODE_HOME:-}" ]] && export MIMOCODE_HOME="\${ORCA_MIMOCODE_HOME}"
 [[ -n "\${ORCA_REMOTE_CLI_BIN_DIR:-}" ]] && case ":$PATH:" in *:"\${ORCA_REMOTE_CLI_BIN_DIR}":*) ;; *) export PATH="\${ORCA_REMOTE_CLI_BIN_DIR}:$PATH" ;; esac
 ${getPosixOmpShellWrapper()}
+${getPosixCodexShellLaunchPreflight()}
 ${BASH_HISTFILE_RESTORE_BLOCK}
 # Why: SSH bash sessions need the same command lifecycle markers as local
 # bash so agent rows stop showing "working" when the foreground command exits.

--- a/src/renderer/src/lib/launch-agent-background-session.ts
+++ b/src/renderer/src/lib/launch-agent-background-session.ts
@@ -115,10 +115,11 @@ export async function launchAgentBackgroundSession(
     command: sshConnectionId ? startupPlan.launchCommand : null,
     waitForShellReady:
       Boolean(sshConnectionId) &&
-      shouldUseShellReadyStartupDelivery({
-        command: startupPlan.launchCommand,
-        startupCommandDelivery: startupPlan.startupCommandDelivery
-      }),
+      (agent === 'codex' ||
+        shouldUseShellReadyStartupDelivery({
+          command: startupPlan.launchCommand,
+          startupCommandDelivery: startupPlan.startupCommandDelivery
+        })),
     write: (ptyId, data) => window.api.pty.write(ptyId, data)
   })
   // Route by the worktree's owner host, not the focused runtime.

--- a/src/renderer/src/lib/launch-ai-vault-session.test.ts
+++ b/src/renderer/src/lib/launch-ai-vault-session.test.ts
@@ -82,6 +82,7 @@ describe('launchAiVaultSessionInNewTab', () => {
     expect(mockCreateTab).toHaveBeenCalledWith('wt-1', 'group-1')
     expect(mockQueueTabStartupCommand).toHaveBeenCalledWith('tab-1', {
       command: 'claude --resume session-1',
+      launchAgent: 'claude',
       telemetry: {
         agent_kind: 'claude',
         launch_source: 'sidebar',

--- a/src/renderer/src/lib/launch-ai-vault-session.ts
+++ b/src/renderer/src/lib/launch-ai-vault-session.ts
@@ -73,9 +73,10 @@ export function launchAiVaultSessionInNewTab(args: {
     : store.createTab(args.worktreeId, targetGroupId)
   store.queueTabStartupCommand(tab.id, {
     command: args.command,
+    launchAgent: args.agent,
     ...(args.env ? { env: args.env } : {}),
     ...(args.envToDelete ? { envToDelete: args.envToDelete } : {}),
-    ...(args.launchConfig ? { launchConfig: args.launchConfig, launchAgent: args.agent } : {}),
+    ...(args.launchConfig ? { launchConfig: args.launchConfig } : {}),
     ...(args.providerSession ? { resumeProviderSession: args.providerSession } : {}),
     telemetry: {
       agent_kind: tuiAgentToAgentKind(args.agent),

--- a/src/shared/startup-shell-portability.live-shell.test.ts
+++ b/src/shared/startup-shell-portability.live-shell.test.ts
@@ -14,12 +14,21 @@
  * binaries only, so it cannot run a builtin.
  */
 import { execFileSync } from 'node:child_process'
-import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterAll, describe, expect, it } from 'vitest'
 import { fishRequirementViolation, resolveFishBinary } from './fish-binary-requirement'
 import { clearEnvCommand, quoteStartupArg, withoutEnvCommand } from './tui-agent-startup-shell'
+import { buildAgentStartupPlan } from './tui-agent-startup'
 
 const FISH = resolveFishBinary(4)
 
@@ -57,11 +66,19 @@ function basename(path: string): string {
 // Why a real (empty) HOME rather than a bogus one: fish needs a writable config
 // dir to hold universal variables, and warns loudly on every launch without it.
 const SANDBOX_HOME = mkdtempSync(path.join(tmpdir(), 'orca-shell-portability-'))
+const SANDBOX_BIN = path.join(SANDBOX_HOME, 'bin')
+const CODEX_PROBE_OUTPUT = path.join(SANDBOX_HOME, 'codex-argv')
+mkdirSync(SANDBOX_BIN)
+writeFileSync(
+  path.join(SANDBOX_BIN, 'codex'),
+  '#!/bin/sh\n: > "$ORCA_CODEX_TEST_OUTPUT"\nfor orca_arg do printf \'%s\\037\' "$orca_arg" >> "$ORCA_CODEX_TEST_OUTPUT"; done\n'
+)
+chmodSync(path.join(SANDBOX_BIN, 'codex'), 0o755)
 
 /** Env with no user shell config reachable, so only Orca's own text is exercised. */
 function sandboxEnv(): NodeJS.ProcessEnv {
   return {
-    PATH: '/usr/bin:/bin:/usr/sbin:/sbin',
+    PATH: `${SANDBOX_BIN}:/usr/bin:/bin:/usr/sbin:/sbin`,
     HOME: SANDBOX_HOME,
     XDG_CONFIG_HOME: path.join(SANDBOX_HOME, 'config'),
     XDG_DATA_HOME: path.join(SANDBOX_HOME, 'data')
@@ -69,11 +86,15 @@ function sandboxEnv(): NodeJS.ProcessEnv {
 }
 
 /** Runs one line in a real shell with no user config reachable. */
-function runInShell(shell: LiveShell, script: string): string {
+function runInShell(
+  shell: LiveShell,
+  script: string,
+  extraEnv: Record<string, string> = {}
+): string {
   return execFileSync(shell.path, ['-c', script], {
     encoding: 'utf8',
     timeout: 20_000,
-    env: sandboxEnv()
+    env: { ...sandboxEnv(), ...extraEnv }
   })
 }
 
@@ -139,6 +160,24 @@ describe.skipIf(process.platform === 'win32')(
         // forged by a value that was mis-split into two arguments.
         const output = runInShell(shell, `printf '%s\\0' ${quoted}`)
         expect(output.split('\0').slice(0, -1)).toEqual(argv)
+      })
+
+      it('runs a persisted remote Codex launch under nounset without coordinates', () => {
+        const nounset = shell.name === 'fish' ? '' : 'set -u; '
+        const plan = buildAgentStartupPlan({
+          agent: 'codex',
+          prompt: '',
+          cmdOverrides: {},
+          platform: 'linux',
+          shell: 'posix',
+          isRemote: true,
+          allowEmptyPromptLaunch: true
+        })
+        writeFileSync(CODEX_PROBE_OUTPUT, '')
+        runInShell(shell, `${nounset}${plan?.launchConfig.agentCommand}`, {
+          ORCA_CODEX_TEST_OUTPUT: CODEX_PROBE_OUTPUT
+        })
+        expect(readFileSync(CODEX_PROBE_OUTPUT, 'utf8')).toBe('')
       })
 
       // Why `set -u` gets its own case: the copied resume command puts the clear


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​651 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​645 |
| Prod | 14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​292 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​28 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​264 |

<!-- /orca-pr-loc -->

## Summary

Fixes #11941 / STA-3147.

A direct Codex TUI launched on a POSIX SSH host receives Orca's pane hook coordinates, but current main does not activate Codex's hook feature. When Codex reuses a pre-existing app-server without Orca environment, the TUI answers normally while Orca receives no authoritative `working` / `done` lifecycle for the pane.

This replacement preserves the authored command byte-for-byte. The client conveys hook-policy intent as an optional SSH spawn field; the SSH relay combines that intent with the final command, platform, shell, and complete hook context; and the existing post-profile preflight selects the version-compatible Codex flag.

## Invariant and authority

For a direct Orca-launched Codex TUI on a POSIX SSH host:

1. Client main sends `agentStatusHooksEnabled: true` only when the remote-hooks feature and user setting are enabled. Absence means off.
2. The owning SSH relay activates its existing `codex-hooks` startup feature only when all of these are true:
   - explicit client intent;
   - trusted `launchAgent: 'codex'` identity;
   - a strictly direct POSIX `codex` command, optionally preceded only by assignments;
   - final relay port/token;
   - a valid top-level pane key that exactly matches `ORCA_PANE_KEY` in the spawned environment.
3. The post-profile bash/zsh/Fish preflight revalidates port, token, and pane identity against the actual invocation and injects exactly:
   - `<0.114`: nothing;
   - `0.114–0.128`: `--enable codex_hooks`;
   - `>=0.129`: `--enable hooks`.
4. Absent policy, missing or mismatched context, malformed/unknown versions, a timed-out probe, explicit hook arguments, aliases/functions, compound commands, and opaque launchers execute unchanged.

Local, WSL, Windows-shell, paired-runtime, and other-agent launches remain on their existing paths. Host-qualified worktree/repo/folder ownership is resolved once and fails closed when ambiguous, including colliding IDs across local and SSH hosts.

## Why this boundary

The client main process owns the user's hook setting. The SSH relay is the first component that owns the final process request, execution platform, shell, and authoritative hook coordinates together. Its post-profile startup feature is the safe place to preserve user shell resolution while selecting a Codex-version-compatible flag.

Rejected alternatives:

- Caller-side `--enable` patches duplicate policy across New Tab, resume, folder workspace, background, and AI Vault surfaces and cannot see final provider coordinates.
- Relay inference without explicit policy lets an older client/newer relay enable hooks against the client's setting.
- An inline `/bin/sh -c` wrapper or PATH shim adds quoting, resolution, state, and cleanup boundaries.
- Recognizing compound or opaque commands risks changing authored shell semantics; they deliberately fail open unchanged.
- Feature-list probing adds a less stable parser; official binaries ratify the bounded `--version` boundaries.

## Deterministic evidence

Topology: macOS Electron → current Orca SSH relay → fresh Linux Docker SSH target → authenticated Codex 0.149.0 → pre-existing `codex app-server --listen unix://` scrubbed of every `ORCA_*` variable → real New Tab → Codex prompt.

- literal `origin/main@5bcbafff`: complete PTY hook coordinates and rendered answer, but no separate `--enable hooks` argv and no exact-pane `working` / `done` lifecycle;
- candidate: separate `--enable hooks`, complete coordinates, rendered answer, exact-pane `working → done`;
- recognition disabled with app and relay rebuilt: coordinates and rendered answer remained, but the flag and every exact-pane hook transition disappeared;
- restored candidate: identical journey returned to green.

The focused causal suite passed 98/98, lost ten planner/relay/real-shell assertions when recognition was disabled, and returned to 97/97 after restoration.

## Validation

- focused client-policy/provider/relay/real-shell boundary: 97 passed
- shell/preflight matrix: 257 passed, 20 expected skips across available POSIX shells and Fish 4
- renderer ownership and launch paths: 129 passed
- neighboring final-environment, local New Tab, and paired web-runtime paths: 38 passed
- shared startup planner: 70 passed
- SSH hook policy/background/runtime ownership: 1,206 passed, 1 expected skip
- `pnpm typecheck`
- changed-file oxlint and oxfmt
- reliability manifest, max-lines ratchet, and `git diff --check`
- relay builds for Linux/macOS/Windows x64+arm64 and WSL
- rendered latest-main / candidate / disabled / restored Docker SSH journeys

## Compatibility, product policy, and gaps

When Orca status hooks are enabled, Orca intentionally supplies a launch-scoped override to persistent `config.toml hooks=false`; an explicit launch hook argument remains the per-launch opt-out. This matches the managed-hook convention but can activate other already-trusted user hook groups for that launch.

The SSH spawn request adds one optional boolean. A new client with an older relay is wire-safe because the relay ignores unknown fields and retains ordinary behavior. An old client with a newer relay omits the field, which defaults off, so hooks are never enabled without explicit client policy.

Remaining gaps: physical Windows-client SSH was not run; headed/headless paired runtimes are contract-tested rather than exercised live; opaque package/shell wrappers intentionally remain unchanged; each enabled remote TUI may use an embedded Codex app-server, and concurrent-pane resource cost remains unmeasured.

