### PR TITLE
fix(automations): reveal full prompt from detail view

### DIFF
--- a/src/renderer/src/components/automations/AutomationDetail.tsx
+++ b/src/renderer/src/components/automations/AutomationDetail.tsx
@@ -16,6 +16,7 @@ import {
 import type { AutomationTargetAvailability } from './automation-target-availability'
 import { getAutomationSourceDisplay } from './automation-source-display'
 import { translate } from '@/i18n/i18n'
+import { AutomationPromptDisclosure } from './AutomationPromptDisclosure'
 
 type AutomationDetailProps = {
   automation: Automation | null
@@ -301,21 +302,10 @@ export function AutomationDetail({
         />
       </div>
 
-      <div className="rounded-md border border-border/50 bg-muted/20 shadow-sm">
-        <div className="border-b border-border/50 px-3 py-2 text-sm font-medium">
-          {translate('auto.components.automations.AutomationDetail.007c8ad874', 'Prompt')}
-        </div>
-        <div className="px-3 py-3">
-          <div className="min-w-0">
-            <div className="text-[11px] font-medium uppercase text-muted-foreground">
-              {translate('auto.components.automations.AutomationDetail.007c8ad874', 'Prompt')}
-            </div>
-            <p className="mt-1 line-clamp-4 whitespace-pre-wrap text-sm text-foreground">
-              {automation.prompt}
-            </p>
-          </div>
-        </div>
-      </div>
+      <AutomationPromptDisclosure
+        key={`${automation.id}:${automation.prompt}`}
+        prompt={automation.prompt}
+      />
     </div>
   )
 }

--- a/src/renderer/src/components/automations/AutomationPromptDisclosure.test.tsx
+++ b/src/renderer/src/components/automations/AutomationPromptDisclosure.test.tsx
@@ -1,0 +1,205 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+import type React from 'react'
+import { act, cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Automation } from '../../../../shared/automations-types'
+import { AutomationDetail } from './AutomationDetail'
+import { AutomationPromptDisclosure } from './AutomationPromptDisclosure'
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+let promptNaturalHeight = 0
+let resizeCallback: ResizeObserverCallback | null = null
+
+class PromptResizeObserver implements ResizeObserver {
+  constructor(callback: ResizeObserverCallback) {
+    resizeCallback = callback
+  }
+
+  disconnect(): void {}
+  observe(): void {}
+  unobserve(): void {}
+}
+
+function makeAutomation(
+  updatedAt: number,
+  prompt = `Synthetic opening.\n${'Synthetic detail. '.repeat(80)}`
+): Automation {
+  return {
+    id: 'synthetic-automation',
+    name: 'Synthetic automation',
+    prompt,
+    precheck: null,
+    agentId: 'codex',
+    projectId: 'synthetic-project',
+    executionTargetType: 'local',
+    executionTargetId: 'local',
+    schedulerOwner: 'local_host_service',
+    workspaceMode: 'existing',
+    workspaceId: 'synthetic-workspace',
+    baseBranch: null,
+    reuseSession: false,
+    timezone: 'UTC',
+    rrule: 'FREQ=DAILY',
+    dtstart: 1,
+    enabled: false,
+    nextRunAt: 2,
+    missedRunPolicy: 'run_once_within_grace',
+    missedRunGraceMinutes: 720,
+    createdAt: 1,
+    updatedAt
+  }
+}
+
+const detailCallbacks = {
+  onRunNow: vi.fn(),
+  onEdit: vi.fn(),
+  onToggle: vi.fn(),
+  onDelete: vi.fn()
+}
+
+describe('AutomationPromptDisclosure', () => {
+  beforeEach(() => {
+    vi.stubGlobal('ResizeObserver', PromptResizeObserver)
+    vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockImplementation(
+      function (this: HTMLElement) {
+        if (this.tagName !== 'P') {
+          return 0
+        }
+        return this.classList.contains('line-clamp-4')
+          ? Math.min(promptNaturalHeight, 80)
+          : promptNaturalHeight
+      }
+    )
+    vi.spyOn(HTMLElement.prototype, 'scrollHeight', 'get').mockImplementation(
+      function (this: HTMLElement) {
+        return this.tagName === 'P' ? promptNaturalHeight : 0
+      }
+    )
+  })
+
+  afterEach(() => {
+    cleanup()
+    resizeCallback = null
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it('leaves a short prompt fully readable without a disclosure control', () => {
+    promptNaturalHeight = 40
+    render(<AutomationPromptDisclosure prompt="Synthetic short prompt." />)
+
+    expect(screen.getByText('Synthetic short prompt.')).toBeVisible()
+    expect(screen.queryByRole('button', { name: 'Show more' })).not.toBeInTheDocument()
+  })
+
+  it('reveals the complete long prompt from the keyboard and keeps it selectable', async () => {
+    promptNaturalHeight = 240
+    const prompt = `Synthetic opening.\n${'Synthetic detail. '.repeat(80)}\nSYNTHETIC-END-MARKER`
+    const user = userEvent.setup()
+    render(<AutomationPromptDisclosure prompt={prompt} />)
+
+    const content = screen.getByText(/SYNTHETIC-END-MARKER/)
+    const toggle = screen.getByRole('button', { name: 'Show more' })
+    expect(content).toHaveClass('line-clamp-4', 'select-text', '[overflow-wrap:anywhere]')
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(toggle).toHaveAttribute('aria-controls', content.id)
+
+    await user.tab()
+    expect(toggle).toHaveFocus()
+    await user.keyboard('{Enter}')
+
+    expect(screen.getByRole('button', { name: 'Show less' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    )
+    expect(content).not.toHaveClass('line-clamp-4')
+    expect(content).toHaveTextContent('SYNTHETIC-END-MARKER')
+
+    await user.click(screen.getByRole('button', { name: 'Show less' }))
+    expect(screen.getByRole('button', { name: 'Show more' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    )
+    expect(content).toHaveClass('line-clamp-4')
+
+    await user.click(screen.getByRole('button', { name: 'Show more' }))
+    act(() => resizeCallback?.([], {} as ResizeObserver))
+    expect(screen.getByRole('button', { name: 'Show less' })).toHaveFocus()
+
+    await user.click(screen.getByRole('button', { name: 'Show less' }))
+    expect(screen.getByRole('button', { name: 'Show more' })).toHaveFocus()
+    expect(content).toHaveClass('line-clamp-4')
+  })
+
+  it('offers disclosure after a narrow resize makes the prompt overflow', () => {
+    promptNaturalHeight = 60
+    render(<AutomationPromptDisclosure prompt="Synthetic prompt that reflows at narrow widths." />)
+    expect(screen.queryByRole('button', { name: 'Show more' })).not.toBeInTheDocument()
+
+    promptNaturalHeight = 180
+    act(() => resizeCallback?.([], {} as ResizeObserver))
+
+    expect(screen.getByRole('button', { name: 'Show more' })).toBeVisible()
+  })
+
+  it('preserves expansion and focus across unrelated automation updates', async () => {
+    promptNaturalHeight = 240
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <AutomationDetail
+        automation={makeAutomation(1)}
+        runs={[]}
+        projectName="Synthetic project"
+        workspaceName="Synthetic workspace"
+        projectDefaultBaseRef={null}
+        runNowAvailability={null}
+        now={1}
+        {...detailCallbacks}
+      />
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Show more' }))
+    const showLess = screen.getByRole('button', { name: 'Show less' })
+    showLess.focus()
+
+    rerender(
+      <AutomationDetail
+        automation={makeAutomation(2)}
+        runs={[]}
+        projectName="Synthetic project"
+        workspaceName="Synthetic workspace"
+        projectDefaultBaseRef={null}
+        runNowAvailability={null}
+        now={2}
+        {...detailCallbacks}
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Show less' })).toHaveFocus()
+
+    promptNaturalHeight = 40
+    rerender(
+      <AutomationDetail
+        automation={makeAutomation(3, 'Synthetic replacement prompt.')}
+        runs={[]}
+        projectName="Synthetic project"
+        workspaceName="Synthetic workspace"
+        projectDefaultBaseRef={null}
+        runNowAvailability={null}
+        now={3}
+        {...detailCallbacks}
+      />
+    )
+
+    expect(screen.getByText('Synthetic replacement prompt.')).toBeVisible()
+    expect(screen.queryByRole('button', { name: 'Show less' })).not.toBeInTheDocument()
+  })
+})

--- a/src/renderer/src/components/automations/AutomationPromptDisclosure.test.tsx
+++ b/src/renderer/src/components/automations/AutomationPromptDisclosure.test.tsx
@@ -6,6 +6,7 @@ import { act, cleanup, render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Automation } from '../../../../shared/automations-types'
+import { i18n } from '@/i18n/i18n'
 import { AutomationDetail } from './AutomationDetail'
 import { AutomationPromptDisclosure } from './AutomationPromptDisclosure'
 
@@ -66,7 +67,8 @@ const detailCallbacks = {
 }
 
 describe('AutomationPromptDisclosure', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    await i18n.changeLanguage('en')
     vi.stubGlobal('ResizeObserver', PromptResizeObserver)
     vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockImplementation(
       function (this: HTMLElement) {
@@ -85,11 +87,12 @@ describe('AutomationPromptDisclosure', () => {
     )
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     cleanup()
     resizeCallback = null
     vi.restoreAllMocks()
     vi.unstubAllGlobals()
+    await i18n.changeLanguage('en')
   })
 
   it('leaves a short prompt fully readable without a disclosure control', () => {
@@ -98,6 +101,15 @@ describe('AutomationPromptDisclosure', () => {
 
     expect(screen.getByText('Synthetic short prompt.')).toBeVisible()
     expect(screen.queryByRole('button', { name: 'Show more' })).not.toBeInTheDocument()
+  })
+
+  it('labels the prompt correctly in Spanish', async () => {
+    promptNaturalHeight = 40
+    await i18n.changeLanguage('es')
+    render(<AutomationPromptDisclosure prompt="Synthetic short prompt." />)
+
+    expect(screen.getByText('Prompt')).toBeVisible()
+    expect(screen.queryByText('Inmediato')).not.toBeInTheDocument()
   })
 
   it('reveals the complete long prompt from the keyboard and keeps it selectable', async () => {

--- a/src/renderer/src/components/automations/AutomationPromptDisclosure.test.tsx
+++ b/src/renderer/src/components/automations/AutomationPromptDisclosure.test.tsx
@@ -108,6 +108,7 @@ describe('AutomationPromptDisclosure', () => {
 
     const content = screen.getByText(/SYNTHETIC-END-MARKER/)
     const toggle = screen.getByRole('button', { name: 'Show more' })
+    expect(screen.getAllByText('Prompt')).toHaveLength(1)
     expect(content).toHaveClass('line-clamp-4', 'select-text', '[overflow-wrap:anywhere]')
     expect(toggle).toHaveAttribute('aria-expanded', 'false')
     expect(toggle).toHaveAttribute('aria-controls', content.id)

--- a/src/renderer/src/components/automations/AutomationPromptDisclosure.test.tsx
+++ b/src/renderer/src/components/automations/AutomationPromptDisclosure.test.tsx
@@ -150,6 +150,19 @@ describe('AutomationPromptDisclosure', () => {
     expect(screen.getByRole('button', { name: 'Show more' })).toBeVisible()
   })
 
+  it('moves focus to the fully visible prompt when resizing removes the disclosure', () => {
+    promptNaturalHeight = 180
+    render(<AutomationPromptDisclosure prompt="Synthetic prompt that fits after widening." />)
+    const content = screen.getByText('Synthetic prompt that fits after widening.')
+    screen.getByRole('button', { name: 'Show more' }).focus()
+
+    promptNaturalHeight = 60
+    act(() => resizeCallback?.([], {} as ResizeObserver))
+
+    expect(screen.queryByRole('button', { name: 'Show more' })).not.toBeInTheDocument()
+    expect(content).toHaveFocus()
+  })
+
   it('preserves expansion and focus across unrelated automation updates', async () => {
     promptNaturalHeight = 240
     const user = userEvent.setup()

--- a/src/renderer/src/components/automations/AutomationPromptDisclosure.test.tsx
+++ b/src/renderer/src/components/automations/AutomationPromptDisclosure.test.tsx
@@ -111,6 +111,9 @@ describe('AutomationPromptDisclosure', () => {
     expect(content).toHaveClass('line-clamp-4', 'select-text', '[overflow-wrap:anywhere]')
     expect(toggle).toHaveAttribute('aria-expanded', 'false')
     expect(toggle).toHaveAttribute('aria-controls', content.id)
+    expect(toggle).toHaveAttribute('data-variant', 'ghost')
+    expect(toggle).toHaveAttribute('data-size', 'xs')
+    expect(toggle).not.toHaveClass('h-auto', 'p-0')
 
     await user.tab()
     expect(toggle).toHaveFocus()

--- a/src/renderer/src/components/automations/AutomationPromptDisclosure.tsx
+++ b/src/renderer/src/components/automations/AutomationPromptDisclosure.tsx
@@ -1,0 +1,92 @@
+import React, { useCallback, useEffect, useId, useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+
+export function AutomationPromptDisclosure({ prompt }: { prompt: string }): React.JSX.Element {
+  const contentId = useId()
+  const expandedRef = useRef(false)
+  const [promptElement, setPromptElement] = useState<HTMLParagraphElement | null>(null)
+  const [expanded, setExpanded] = useState(false)
+  const [overflows, setOverflows] = useState(false)
+
+  const measureOverflow = useCallback((element: HTMLParagraphElement) => {
+    const nextOverflows = element.scrollHeight > element.clientHeight + 1
+    setOverflows((current) => (current === nextOverflows ? current : nextOverflows))
+  }, [])
+
+  useEffect(() => {
+    if (!promptElement || expanded) {
+      return
+    }
+
+    const updateOverflow = () => {
+      if (!expandedRef.current) {
+        measureOverflow(promptElement)
+      }
+    }
+    updateOverflow()
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', updateOverflow)
+      return () => window.removeEventListener('resize', updateOverflow)
+    }
+
+    const observer = new ResizeObserver(updateOverflow)
+    observer.observe(promptElement)
+    return () => observer.disconnect()
+  }, [expanded, measureOverflow, promptElement])
+
+  const toggleExpanded = (): void => {
+    const nextExpanded = !expanded
+    expandedRef.current = nextExpanded
+    setExpanded(nextExpanded)
+  }
+
+  return (
+    <div className="rounded-md border border-border/50 bg-muted/20 shadow-sm">
+      <div className="flex items-center justify-between gap-3 border-b border-border/50 px-3 py-2">
+        <div className="text-sm font-medium">
+          {translate('auto.components.automations.AutomationDetail.007c8ad874', 'Prompt')}
+        </div>
+        {overflows || expanded ? (
+          <Button
+            type="button"
+            variant="link"
+            size="xs"
+            className="h-auto shrink-0 p-0 text-xs font-normal text-muted-foreground no-underline hover:text-foreground hover:no-underline"
+            aria-expanded={expanded}
+            aria-controls={contentId}
+            onClick={toggleExpanded}
+          >
+            {expanded
+              ? translate(
+                  'auto.components.automations.AutomationPromptDisclosure.showLess',
+                  'Show less'
+                )
+              : translate(
+                  'auto.components.automations.AutomationPromptDisclosure.showMore',
+                  'Show more'
+                )}
+          </Button>
+        ) : null}
+      </div>
+      <div className="px-3 py-3">
+        <div className="min-w-0">
+          <div className="text-[11px] font-medium uppercase text-muted-foreground">
+            {translate('auto.components.automations.AutomationDetail.007c8ad874', 'Prompt')}
+          </div>
+          <p
+            ref={setPromptElement}
+            id={contentId}
+            className={cn(
+              'mt-1 select-text whitespace-pre-wrap text-sm text-foreground [overflow-wrap:anywhere]',
+              !expanded && 'line-clamp-4'
+            )}
+          >
+            {prompt}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/automations/AutomationPromptDisclosure.tsx
+++ b/src/renderer/src/components/automations/AutomationPromptDisclosure.tsx
@@ -56,9 +56,9 @@ export function AutomationPromptDisclosure({ prompt }: { prompt: string }): Reac
           <Button
             ref={toggleRef}
             type="button"
-            variant="link"
+            variant="ghost"
             size="xs"
-            className="h-auto shrink-0 p-0 text-xs font-normal text-muted-foreground no-underline hover:text-foreground hover:no-underline"
+            className="-mr-2 text-muted-foreground hover:text-foreground"
             aria-expanded={expanded}
             aria-controls={contentId}
             onClick={toggleExpanded}

--- a/src/renderer/src/components/automations/AutomationPromptDisclosure.tsx
+++ b/src/renderer/src/components/automations/AutomationPromptDisclosure.tsx
@@ -50,7 +50,7 @@ export function AutomationPromptDisclosure({ prompt }: { prompt: string }): Reac
     <div className="rounded-md border border-border/50 bg-muted/20 shadow-sm">
       <div className="flex items-center justify-between gap-3 border-b border-border/50 px-3 py-2">
         <div className="text-sm font-medium">
-          {translate('auto.components.automations.AutomationDetail.007c8ad874', 'Prompt')}
+          {translate('auto.components.automations.AutomationEditorDialog.058c23cb3f', 'Prompt')}
         </div>
         {overflows || expanded ? (
           <Button

--- a/src/renderer/src/components/automations/AutomationPromptDisclosure.tsx
+++ b/src/renderer/src/components/automations/AutomationPromptDisclosure.tsx
@@ -75,23 +75,18 @@ export function AutomationPromptDisclosure({ prompt }: { prompt: string }): Reac
           </Button>
         ) : null}
       </div>
-      <div className="px-3 py-3">
-        <div className="min-w-0">
-          <div className="text-[11px] font-medium uppercase text-muted-foreground">
-            {translate('auto.components.automations.AutomationDetail.007c8ad874', 'Prompt')}
-          </div>
-          <p
-            ref={setPromptElement}
-            id={contentId}
-            tabIndex={-1}
-            className={cn(
-              'mt-1 select-text whitespace-pre-wrap text-sm text-foreground [overflow-wrap:anywhere]',
-              !expanded && 'line-clamp-4'
-            )}
-          >
-            {prompt}
-          </p>
-        </div>
+      <div className="min-w-0 px-3 py-3">
+        <p
+          ref={setPromptElement}
+          id={contentId}
+          tabIndex={-1}
+          className={cn(
+            'select-text whitespace-pre-wrap text-sm text-foreground [overflow-wrap:anywhere]',
+            !expanded && 'line-clamp-4'
+          )}
+        >
+          {prompt}
+        </p>
       </div>
     </div>
   )

--- a/src/renderer/src/components/automations/AutomationPromptDisclosure.tsx
+++ b/src/renderer/src/components/automations/AutomationPromptDisclosure.tsx
@@ -6,12 +6,16 @@ import { translate } from '@/i18n/i18n'
 export function AutomationPromptDisclosure({ prompt }: { prompt: string }): React.JSX.Element {
   const contentId = useId()
   const expandedRef = useRef(false)
+  const toggleRef = useRef<HTMLButtonElement>(null)
   const [promptElement, setPromptElement] = useState<HTMLParagraphElement | null>(null)
   const [expanded, setExpanded] = useState(false)
   const [overflows, setOverflows] = useState(false)
 
   const measureOverflow = useCallback((element: HTMLParagraphElement) => {
     const nextOverflows = element.scrollHeight > element.clientHeight + 1
+    if (!nextOverflows && document.activeElement === toggleRef.current) {
+      element.focus({ preventScroll: true })
+    }
     setOverflows((current) => (current === nextOverflows ? current : nextOverflows))
   }, [])
 
@@ -50,6 +54,7 @@ export function AutomationPromptDisclosure({ prompt }: { prompt: string }): Reac
         </div>
         {overflows || expanded ? (
           <Button
+            ref={toggleRef}
             type="button"
             variant="link"
             size="xs"
@@ -78,6 +83,7 @@ export function AutomationPromptDisclosure({ prompt }: { prompt: string }): Reac
           <p
             ref={setPromptElement}
             id={contentId}
+            tabIndex={-1}
             className={cn(
               'mt-1 select-text whitespace-pre-wrap text-sm text-foreground [overflow-wrap:anywhere]',
               !expanded && 'line-clamp-4'

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -15008,6 +15008,10 @@
           "0e1de0358b": "Month",
           "77e96bded6": "Weekday"
         },
+        "AutomationPromptDisclosure": {
+          "showLess": "Show less",
+          "showMore": "Show more"
+        },
         "AutomationDetail": {
           "007c8ad874": "Prompt",
           "a1d52c2189": "Usage coverage",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -13612,6 +13612,10 @@
           "0e1de0358b": "Mes",
           "77e96bded6": "Día de la semana"
         },
+        "AutomationPromptDisclosure": {
+          "showLess": "Mostrar menos",
+          "showMore": "Mostrar más"
+        },
         "AutomationDetail": {
           "007c8ad874": "Inmediato",
           "a1d52c2189": "Cobertura de uso",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -13612,6 +13612,10 @@
           "0e1de0358b": "月",
           "77e96bded6": "曜日"
         },
+        "AutomationPromptDisclosure": {
+          "showLess": "折りたたむ",
+          "showMore": "さらに表示"
+        },
         "AutomationDetail": {
           "007c8ad874": "プロンプト",
           "a1d52c2189": "使用範囲",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -13641,6 +13641,10 @@
           "0e1de0358b": "월",
           "77e96bded6": "요일"
         },
+        "AutomationPromptDisclosure": {
+          "showLess": "접기",
+          "showMore": "더 보기"
+        },
         "AutomationDetail": {
           "007c8ad874": "프롬프트",
           "a1d52c2189": "사용 범위",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -13632,6 +13632,10 @@
           "0e1de0358b": "月",
           "77e96bded6": "星期"
         },
+        "AutomationPromptDisclosure": {
+          "showLess": "收起",
+          "showMore": "显示更多"
+        },
         "AutomationDetail": {
           "007c8ad874": "提示词",
           "a1d52c2189": "使用范围",

--- a/tests/e2e/automation-prompt-disclosure.spec.ts
+++ b/tests/e2e/automation-prompt-disclosure.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from './helpers/orca-app'
+import { waitForSessionReady } from './helpers/store'
+
+const SHORT_NAME = 'synthetic-short-prompt-demo'
+const LONG_NAME = 'visual-proof-long-prompt-demo'
+const END_MARKER = 'SYNTHETIC-END-MARKER'
+
+test('automation detail keeps short prompts readable and reveals a very long prompt at narrow width', async ({
+  orcaPage
+}) => {
+  await waitForSessionReady(orcaPage)
+  await orcaPage.setViewportSize({ width: 820, height: 700 })
+
+  await orcaPage.evaluate(
+    async ({ shortName, longName, endMarker }) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('window.__store is not available')
+      }
+      const repo = store.getState().repos[0]
+      if (!repo) {
+        throw new Error('Seeded test repo is not available')
+      }
+      const base = {
+        agentId: 'codex' as const,
+        projectId: repo.id,
+        workspaceMode: 'new_per_run' as const,
+        reuseSession: false,
+        timezone: 'UTC',
+        rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+        dtstart: Date.now(),
+        enabled: false,
+        missedRunGraceMinutes: 720
+      }
+      await window.api.automations.create({
+        ...base,
+        name: shortName,
+        prompt: 'Synthetic short prompt.'
+      })
+      await window.api.automations.create({
+        ...base,
+        name: longName,
+        prompt: [
+          'Synthetic prompt preview validation only.',
+          '',
+          ...Array.from(
+            { length: 20 },
+            (_, index) =>
+              `Synthetic step ${index + 1}: inspect placeholder input and summarize placeholder output.`
+          ),
+          '',
+          `UNBROKEN_SYNTHETIC_${'X'.repeat(240)}`,
+          '',
+          endMarker
+        ].join('\n')
+      })
+      store.getState().openAutomationsPage()
+    },
+    { shortName: SHORT_NAME, longName: LONG_NAME, endMarker: END_MARKER }
+  )
+
+  await orcaPage.getByRole('button', { name: new RegExp(`^${SHORT_NAME}`) }).click()
+  await expect(orcaPage.getByText('Synthetic short prompt.')).toBeVisible()
+  await expect(orcaPage.getByRole('button', { name: 'Show more' })).toHaveCount(0)
+
+  await orcaPage.getByRole('button', { name: 'All automations' }).click()
+  await orcaPage.getByRole('button', { name: new RegExp(`^${LONG_NAME}`) }).click()
+
+  const prompt = orcaPage.getByText(new RegExp(END_MARKER))
+  const showMore = orcaPage.getByRole('button', { name: 'Show more' })
+  await expect(showMore).toBeVisible()
+  expect(await showMore.getAttribute('aria-controls')).toBe(await prompt.getAttribute('id'))
+  const collapsedMetrics = await prompt.evaluate((element) => ({
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+    lineClamp: getComputedStyle(element).webkitLineClamp
+  }))
+  expect(collapsedMetrics.scrollHeight).toBeGreaterThan(collapsedMetrics.clientHeight)
+  expect(collapsedMetrics.lineClamp).toBe('4')
+
+  await showMore.focus()
+  await orcaPage.keyboard.press('Enter')
+  await expect(orcaPage.getByRole('button', { name: 'Show less' })).toBeFocused()
+
+  const expandedMetrics = await prompt.evaluate((element) => ({
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+    scrollWidth: element.scrollWidth,
+    clientWidth: element.clientWidth,
+    lineClamp: getComputedStyle(element).webkitLineClamp,
+    overflowWrap: getComputedStyle(element).overflowWrap
+  }))
+  expect(expandedMetrics.clientHeight).toBeGreaterThan(80)
+  expect(expandedMetrics.scrollHeight).toBeLessThanOrEqual(expandedMetrics.clientHeight + 1)
+  expect(expandedMetrics.scrollWidth).toBeLessThanOrEqual(expandedMetrics.clientWidth + 1)
+  expect(expandedMetrics.lineClamp).toBe('none')
+  expect(expandedMetrics.overflowWrap).toBe('anywhere')
+
+  const markerProof = await prompt.evaluate(async (element, marker) => {
+    const text = element.firstChild
+    if (!(text instanceof Text)) {
+      throw new Error('Prompt text node is unavailable')
+    }
+    const start = text.data.indexOf(marker)
+    if (start === -1) {
+      throw new Error('Prompt end marker is unavailable')
+    }
+    const range = document.createRange()
+    range.setStart(text, start)
+    range.setEnd(text, start + marker.length)
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+    const scrollContainer = element.closest('[role="tabpanel"]')
+    if (!(scrollContainer instanceof HTMLElement)) {
+      throw new Error('Automation overview scroll container is unavailable')
+    }
+    scrollContainer.scrollTop +=
+      range.getBoundingClientRect().bottom - scrollContainer.getBoundingClientRect().bottom + 16
+    await new Promise(requestAnimationFrame)
+    const markerRect = range.getBoundingClientRect()
+    const containerRect = scrollContainer.getBoundingClientRect()
+    return {
+      selectedText: selection?.toString(),
+      markerTop: markerRect.top,
+      markerBottom: markerRect.bottom,
+      visibleTop: containerRect.top,
+      visibleBottom: containerRect.bottom
+    }
+  }, END_MARKER)
+  expect(markerProof.selectedText).toBe(END_MARKER)
+  expect(markerProof.markerTop).toBeGreaterThanOrEqual(markerProof.visibleTop)
+  expect(markerProof.markerBottom).toBeLessThanOrEqual(markerProof.visibleBottom)
+})

--- a/tests/e2e/automation-prompt-disclosure.spec.ts
+++ b/tests/e2e/automation-prompt-disclosure.spec.ts
@@ -2,8 +2,10 @@ import { test, expect } from './helpers/orca-app'
 import { waitForSessionReady } from './helpers/store'
 
 const SHORT_NAME = 'synthetic-short-prompt-demo'
+const RESIZE_NAME = 'synthetic-resize-prompt-demo'
 const LONG_NAME = 'visual-proof-long-prompt-demo'
 const END_MARKER = 'SYNTHETIC-END-MARKER'
+const RESIZE_PROMPT = `Synthetic resize focus validation. ${'placeholder '.repeat(24)}`
 
 test('automation detail keeps short prompts readable and reveals a very long prompt at narrow width', async ({
   orcaPage
@@ -12,7 +14,7 @@ test('automation detail keeps short prompts readable and reveals a very long pro
   await orcaPage.setViewportSize({ width: 820, height: 700 })
 
   await orcaPage.evaluate(
-    async ({ shortName, longName, endMarker }) => {
+    async ({ shortName, resizeName, resizePrompt, longName, endMarker }) => {
       const store = window.__store
       if (!store) {
         throw new Error('window.__store is not available')
@@ -54,15 +56,37 @@ test('automation detail keeps short prompts readable and reveals a very long pro
           endMarker
         ].join('\n')
       })
+      await window.api.automations.create({
+        ...base,
+        name: resizeName,
+        prompt: resizePrompt
+      })
       store.getState().openAutomationsPage()
     },
-    { shortName: SHORT_NAME, longName: LONG_NAME, endMarker: END_MARKER }
+    {
+      shortName: SHORT_NAME,
+      resizeName: RESIZE_NAME,
+      resizePrompt: RESIZE_PROMPT,
+      longName: LONG_NAME,
+      endMarker: END_MARKER
+    }
   )
 
   await orcaPage.getByRole('button', { name: new RegExp(`^${SHORT_NAME}`) }).click()
   await expect(orcaPage.getByText('Synthetic short prompt.')).toBeVisible()
   await expect(orcaPage.getByRole('button', { name: 'Show more' })).toHaveCount(0)
 
+  await orcaPage.getByRole('button', { name: 'All automations' }).click()
+  await orcaPage.getByRole('button', { name: new RegExp(`^${RESIZE_NAME}`) }).click()
+  const resizePrompt = orcaPage.getByText(RESIZE_PROMPT)
+  const resizeToggle = orcaPage.getByRole('button', { name: 'Show more' })
+  await expect(resizeToggle).toBeVisible()
+  await resizeToggle.focus()
+  await orcaPage.setViewportSize({ width: 1400, height: 700 })
+  await expect(resizeToggle).toHaveCount(0)
+  await expect(resizePrompt).toBeFocused()
+
+  await orcaPage.setViewportSize({ width: 820, height: 700 })
   await orcaPage.getByRole('button', { name: 'All automations' }).click()
   await orcaPage.getByRole('button', { name: new RegExp(`^${LONG_NAME}`) }).click()
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​392 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​392 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​118 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​103 |

<!-- /orca-pr-loc -->

## Summary

- replace the Automation detail prompt's unconditional four-line truncation with a measured Show more / Show less disclosure
- keep short prompts fully readable without an unnecessary control
- expand long prompts into the existing Overview page scroll flow, with selectable text and unbroken-token wrapping
- preserve expansion across unrelated automation refreshes while resetting it when the automation or prompt changes
- add localized disclosure labels for all shipped UI locales

## UX decision

The detail view now starts long prompts at the existing four-line compact height and offers an explicit disclosure in the Prompt card header. A larger fixed preview still truncates sufficiently long prompts, while an internal scroll area adds nested scrolling and makes selection/copying harder. Expansion in document flow keeps the Overview pane as the single scrollbar and leaves the collapse control at the top of the card.

## Validation

- `pnpm run lint`
- `pnpm run typecheck:web`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/automations/AutomationPromptDisclosure.test.tsx` (6/6)
- `pnpm exec electron-vite build --mode e2e`
- `SKIP_BUILD=1 pnpm exec playwright test tests/e2e/automation-prompt-disclosure.spec.ts --config tests/playwright.config.ts --project=electron-headless --workers=1`
- React Doctor changed-file audit: 0 issues
- localization catalog, extraction, and coverage gates
- isolated Electron CDP validation at wide and 820×700 viewports
- regression-red check: the focused E2E fails when the disclosure integration is reverted because `Show more` is absent
- Spanish localization regression: the Prompt header uses the existing Prompt-specific key and does not render the unrelated `Inmediato` schedule label

The full repository `typecheck:e2e` remains red on unrelated pre-existing errors; the new spec has no remaining type error.

## Sanitized visual proof

All proof uses one disabled synthetic automation named `visual-proof-long-prompt-demo` in an isolated development profile. No production profile or real automation data was captured. The dummy automation and isolated profile were deleted after capture.

### Before: prompt permanently clipped

![automation-prompt-preview-red-sanitized.png](https://github.com/user-attachments/assets/a320bf06-591f-4dce-81db-e0a93b90d1f2)

### After: current collapsed disclosure

![automation-prompt-preview-green-current.png](https://github.com/user-attachments/assets/3849c2bd-ce06-4dae-afed-e2e2a94790d9)

### After: expanded in the page flow

![automation-prompt-preview-green-expanded-wide-clean.png](https://github.com/user-attachments/assets/5472eaa0-a1c3-4c56-8e4f-858d3b972c26)

### After: complete prompt end marker reachable

![automation-prompt-preview-green-end-marker-clean.png](https://github.com/user-attachments/assets/062684b8-b124-4f66-972f-e4adc6785c7a)

### After: narrow layout wraps safely

![automation-prompt-preview-green-expanded-narrow-clean.png](https://github.com/user-attachments/assets/e631805f-c5e4-481a-b424-0f61b812f484)

### After: single Prompt label and complete synthetic prompt

![automation-prompt-coderabbit-after-clean.png](https://github.com/user-attachments/assets/c3eebb9d-5319-4ab6-bf40-572534f6954c)

## Review

- fresh UX/architecture review approved the prompt-owned disclosure and existing page-scroll boundary
- fresh adversarial accessibility/layout review is clean after preserving focus across refresh and stale observer delivery
- two fresh OpenCode reviews confirmed this is a component-boundary fix, not layered CSS overrides
- internal review-until-clean completed clean
- post-CodeRabbit fresh architecture, product/UX, and adversarial reviews approved after resolving the duplicate-label and Spanish-key findings

## ELI5

The detail card used to hide everything after four lines, so this change adds a measured Show more / Show less control for long prompts. The prompt remains in the page's normal scroll flow, so reading, selecting, copying, wrapping, and resizing continue to work without a second scrollbar. A larger fixed preview and an internal scroll area were rejected because they either still hide content or make navigation and copying harder. The CodeRabbit follow-up removes the redundant inner Prompt label and uses the existing Prompt-specific translation key so Spanish does not display the unrelated “Inmediato” schedule label.

## Linked Issue

This change comes from a private user report; no public issue exists to link, so no `Fixes #…` reference is claimed.

## Testing

- [x] Manually validated the rendered card through Electron CDP using an isolated development profile and disabled synthetic automation only.
- [x] Automated regression coverage covers short prompts, very long prompts, narrow layout, keyboard expansion, focus preservation, wrapping, and state persistence.
- [x] The duplicate-label assertion passes on the candidate and fails when the old body label is restored.
- [x] The Spanish label assertion passes with the Prompt-specific catalog key.

## Agent skill upstream boundary

- [x] Not applicable; this UI change does not copy or translate skill-installer sources.

## Notes

The change is renderer-local and does not alter automation data, RPC payloads, execution hosts, SSH/WSL behavior, filesystem paths, or platform-specific shortcuts. Existing Orca design tokens and the shadcn Button primitive remain in use.

## Checklist

- [x] This PR is small and focused.
- [x] The change, rationale, alternatives, and ELI5 explanation are documented above.
- [x] Sanitized before/after visual proof is attached; all captured data is synthetic and isolated.
- [x] Self-reviewed for correctness, accessibility, privacy, and performance.
- [x] Cross-platform and remote impact considered; no relevant boundary changes.
- [x] Lint, web typecheck, focused unit/E2E tests, and the E2E build pass locally; repository CI is green.
