### PR TITLE
ci(windows): run the PTY IPC suites on the Windows runner

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -658,6 +658,8 @@ jobs:
           src/main/runtime/repo-worktree-admin-fingerprint.test.ts
           src/main/runtime/worktree-scan-admin-fingerprint-gate.test.ts
           src/shared/secure-file-fsync-flags.test.ts
+          src/main/ipc/pty-codex-account-attribution.test.ts
+          src/main/ipc/pty-spawn-env-codex-resume-provenance.test.ts
 
       # Why the :parallel variant: identical to build:release except the three
       # electron-vite targets overlap instead of running back to back. The Linux package

--- a/src/main/ipc/pty-codex-account-attribution.test.ts
+++ b/src/main/ipc/pty-codex-account-attribution.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
+import { join } from 'node:path'
 import {
   readFileSyncMock,
   recordCodexPaneAccountMock,
   forgetCodexPaneAccountMock
 } from './pty-ipc-mock-registry'
-import { TEST_CODEX_HOME, TEST_CODEX_AUTH_JSON } from './pty-ipc-test-constants'
+import { TEST_CODEX_HOME, TEST_CODEX_AUTH_JSON, TEST_MANAGED_ROOT } from './pty-ipc-test-constants'
 import { setupPtyIpcSuite } from './pty-ipc-test-harness'
 import { registerPtyHandlers, setLocalPtyProvider } from './pty'
 
@@ -51,6 +52,12 @@ vi.mock('../codex/codex-pane-account-registry', () =>
 vi.mock('../codex/codex-state-db-backfill-recovery', () =>
   import('./pty-ipc-mock-registry').then((m) => m.codexBackfillRecoveryModuleMock())
 )
+
+const MANAGED_ORIGIN_HOME = join(TEST_MANAGED_ROOT, 'origin', 'home')
+const MANAGED_CURRENT_HOME = join(TEST_MANAGED_ROOT, 'current', 'home')
+const MANAGED_SHARED_HOME = join(TEST_MANAGED_ROOT, 'shared-mirror', 'home')
+const ORIGIN_ROLLOUT = join(MANAGED_ORIGIN_HOME, 'sessions', '2026', '07', '20', 'rollout-a.jsonl')
+const SHARED_ROLLOUT = join(MANAGED_SHARED_HOME, 'sessions', '2026', '07', '20', 'rollout-a.jsonl')
 
 describe('registerPtyHandlers', () => {
   const { handlers, mainWindow } = setupPtyIpcSuite()
@@ -145,15 +152,15 @@ describe('registerPtyHandlers', () => {
       }
       return ''
     })
-    const resolveHome = vi.fn(() => '/managed/current/home')
+    const resolveHome = vi.fn(() => MANAGED_CURRENT_HOME)
     registerPtyHandlers(
       mainWindow as never,
       undefined,
       resolveHome,
       (() => ({
         codexManagedAccounts: [
-          { id: 'account-a', managedHomePath: '/managed/origin/home' },
-          { id: 'account-b', managedHomePath: '/managed/current/home' }
+          { id: 'account-a', managedHomePath: MANAGED_ORIGIN_HOME },
+          { id: 'account-b', managedHomePath: MANAGED_CURRENT_HOME }
         ]
       })) as never,
       undefined,
@@ -161,7 +168,7 @@ describe('registerPtyHandlers', () => {
       {
         prepareCodexSessionResume: async () => ({
           outcome: 'resume' as const,
-          codexHomePath: '/managed/origin/home'
+          codexHomePath: MANAGED_ORIGIN_HOME
         })
       }
     )
@@ -175,7 +182,7 @@ describe('registerPtyHandlers', () => {
       resumeProviderSession: {
         key: 'session_id',
         id: 'session-a',
-        transcriptPath: '/managed/origin/home/sessions/2026/07/20/rollout-a.jsonl'
+        transcriptPath: ORIGIN_ROLLOUT
       }
     })
     const rejection = expect(launch).rejects.toThrow(
@@ -203,21 +210,21 @@ describe('registerPtyHandlers', () => {
     const getSettings = vi.fn().mockReturnValue({
       activeCodexManagedAccountId: 'account-b',
       codexManagedAccounts: [
-        { id: 'account-a', managedHomePath: '/managed/origin/home' },
-        { id: 'account-b', managedHomePath: '/managed/current/home' }
+        { id: 'account-a', managedHomePath: MANAGED_ORIGIN_HOME },
+        { id: 'account-b', managedHomePath: MANAGED_CURRENT_HOME }
       ]
     })
     registerPtyHandlers(
       mainWindow as never,
       undefined,
-      vi.fn(() => '/managed/current/home'),
+      vi.fn(() => MANAGED_CURRENT_HOME),
       getSettings as never,
       undefined,
       undefined,
       {
         prepareCodexSessionResume: async () => ({
           outcome: 'resume' as const,
-          codexHomePath: '/managed/origin/home'
+          codexHomePath: MANAGED_ORIGIN_HOME
         })
       }
     )
@@ -231,7 +238,7 @@ describe('registerPtyHandlers', () => {
       resumeProviderSession: {
         key: 'session_id',
         id: 'session-a',
-        transcriptPath: '/managed/origin/home/sessions/2026/07/20/rollout-a.jsonl'
+        transcriptPath: ORIGIN_ROLLOUT
       }
     })
 
@@ -240,7 +247,7 @@ describe('registerPtyHandlers', () => {
     expect(recordCodexPaneAccountMock.mock.calls).toEqual([
       ['pty-resumed', { selectionKey: 'host', accountId: 'account-a', homeRoute: 'account-home' }]
     ])
-    expect(readFileSyncMock).toHaveBeenCalledWith('/managed/origin/home/auth.json', 'utf8')
+    expect(readFileSyncMock).toHaveBeenCalledWith(join(MANAGED_ORIGIN_HOME, 'auth.json'), 'utf8')
     expect(forgetCodexPaneAccountMock).not.toHaveBeenCalled()
   })
   it('leaves a resumed Codex pane unattributed when no account owns its home', async () => {
@@ -257,19 +264,19 @@ describe('registerPtyHandlers', () => {
     } as never)
     const getSettings = vi.fn().mockReturnValue({
       activeCodexManagedAccountId: 'account-b',
-      codexManagedAccounts: [{ id: 'account-b', managedHomePath: '/managed/current/home' }]
+      codexManagedAccounts: [{ id: 'account-b', managedHomePath: MANAGED_CURRENT_HOME }]
     })
     registerPtyHandlers(
       mainWindow as never,
       undefined,
-      vi.fn(() => '/managed/current/home'),
+      vi.fn(() => MANAGED_CURRENT_HOME),
       getSettings as never,
       undefined,
       undefined,
       {
         prepareCodexSessionResume: async () => ({
           outcome: 'resume' as const,
-          codexHomePath: '/managed/shared-mirror/home'
+          codexHomePath: MANAGED_SHARED_HOME
         })
       }
     )
@@ -282,7 +289,7 @@ describe('registerPtyHandlers', () => {
       resumeProviderSession: {
         key: 'session_id',
         id: 'session-a',
-        transcriptPath: '/managed/shared-mirror/home/sessions/2026/07/20/rollout-a.jsonl'
+        transcriptPath: SHARED_ROLLOUT
       }
     })
 
@@ -320,22 +327,22 @@ describe('registerPtyHandlers', () => {
     const getSettings = vi.fn().mockReturnValue({
       activeCodexManagedAccountId: 'account-b',
       codexManagedAccounts: [
-        { id: 'account-a', managedHomePath: '/managed/origin/home' },
-        { id: 'account-b', managedHomePath: '/managed/current/home' }
+        { id: 'account-a', managedHomePath: MANAGED_ORIGIN_HOME },
+        { id: 'account-b', managedHomePath: MANAGED_CURRENT_HOME }
       ]
     })
     handlers.clear()
     registerPtyHandlers(
       mainWindow as never,
       runtime as never,
-      vi.fn(() => '/managed/current/home'),
+      vi.fn(() => MANAGED_CURRENT_HOME),
       getSettings as never,
       undefined,
       undefined,
       {
         prepareCodexSessionResume: async () => ({
           outcome: 'resume' as const,
-          codexHomePath: '/managed/origin/home'
+          codexHomePath: MANAGED_ORIGIN_HOME
         })
       }
     )
@@ -351,7 +358,7 @@ describe('registerPtyHandlers', () => {
       resumeProviderSession: {
         key: 'session_id',
         id: 'session-a',
-        transcriptPath: '/managed/origin/home/sessions/2026/07/20/rollout-a.jsonl'
+        transcriptPath: ORIGIN_ROLLOUT
       }
     })
 
@@ -361,7 +368,7 @@ describe('registerPtyHandlers', () => {
         { selectionKey: 'host', accountId: 'account-a', homeRoute: 'account-home' }
       ]
     ])
-    expect(readFileSyncMock).toHaveBeenCalledWith('/managed/origin/home/auth.json', 'utf8')
+    expect(readFileSyncMock).toHaveBeenCalledWith(join(MANAGED_ORIGIN_HOME, 'auth.json'), 'utf8')
     expect(forgetCodexPaneAccountMock).not.toHaveBeenCalled()
   })
   it('leaves a runtime-controller resumed Codex pane unattributed when no account owns its home', async () => {
@@ -389,10 +396,10 @@ describe('registerPtyHandlers', () => {
     }
     const getSettings = vi.fn().mockReturnValue({
       activeCodexManagedAccountId: 'account-b',
-      codexManagedAccounts: [{ id: 'account-b', managedHomePath: '/managed/current/home' }]
+      codexManagedAccounts: [{ id: 'account-b', managedHomePath: MANAGED_CURRENT_HOME }]
     })
     handlers.clear()
-    const resolveHome = vi.fn(() => '/managed/shared-mirror/home')
+    const resolveHome = vi.fn(() => MANAGED_SHARED_HOME)
     registerPtyHandlers(
       mainWindow as never,
       runtime as never,
@@ -403,7 +410,7 @@ describe('registerPtyHandlers', () => {
       {
         prepareCodexSessionResume: async () => ({
           outcome: 'resume' as const,
-          codexHomePath: '/managed/shared-mirror/home',
+          codexHomePath: MANAGED_SHARED_HOME,
           reconcileSharedRuntimeAuth: true
         })
       }
@@ -419,7 +426,7 @@ describe('registerPtyHandlers', () => {
       resumeProviderSession: {
         key: 'session_id',
         id: 'session-a',
-        transcriptPath: '/managed/shared-mirror/home/sessions/2026/07/20/rollout-a.jsonl'
+        transcriptPath: SHARED_ROLLOUT
       }
     })
 

--- a/src/main/ipc/pty-ipc-test-constants.ts
+++ b/src/main/ipc/pty-ipc-test-constants.ts
@@ -13,6 +13,7 @@ export type PlatformGatedTest = (
 
 export const isWindowsHost = process.platform === 'win32'
 export const posixOnlyIt: PlatformGatedTest = isWindowsHost ? it.skip : it
+export const TEST_MANAGED_ROOT = isWindowsHost ? 'C:\\managed' : '/managed'
 export const BUNDLED_RESOURCES_PATH = join('/tmp', 'orca-bundled-resources')
 // Why: this suite forces darwin before every test, including on Linux CI.
 export const BUNDLED_CLI_PATH = getBundledLauncherPath('darwin', BUNDLED_RESOURCES_PATH) as string

--- a/src/main/ipc/pty-spawn-env-codex-resume-provenance.test.ts
+++ b/src/main/ipc/pty-spawn-env-codex-resume-provenance.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
+import { join } from 'node:path'
 import { spawnMock } from './pty-ipc-mock-registry'
-import { posixOnlyIt } from './pty-ipc-test-constants'
+import { posixOnlyIt, TEST_MANAGED_ROOT } from './pty-ipc-test-constants'
 import { setupPtyIpcSuite } from './pty-ipc-test-harness'
 import { prepareCodexSessionResume } from '../codex/codex-session-resume-preparation'
 import { registerPtyHandlers, setLocalPtyProvider, type PrepareCodexSessionResume } from './pty'
@@ -55,9 +56,16 @@ describe('registerPtyHandlers', () => {
   describe('spawn environment', () => {
     describe('unverifiable Codex resume provenance', () => {
       const RESUME_SESSION_ID = '019f81b9-19a9-7651-a8d1-352d9420bd11'
-      const ORIGIN_HOME = '/managed/origin/home'
-      const OTHER_HOME = '/managed/other/home'
-      const ORIGIN_ROLLOUT = `${ORIGIN_HOME}/sessions/2026/07/20/rollout-2026-07-20T12-00-00-${RESUME_SESSION_ID}.jsonl`
+      const ORIGIN_HOME = join(TEST_MANAGED_ROOT, 'origin', 'home')
+      const OTHER_HOME = join(TEST_MANAGED_ROOT, 'other', 'home')
+      const ORIGIN_ROLLOUT = join(
+        ORIGIN_HOME,
+        'sessions',
+        '2026',
+        '07',
+        '20',
+        `rollout-2026-07-20T12-00-00-${RESUME_SESSION_ID}.jsonl`
+      )
 
       // Why: main's real provenance rule via the same prepareCodexSessionResume that
       // index.ts calls, so the outcome wiring is exercised rather than restated. This


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​30 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​15 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

Refs #12437.

## What changed

The merge-blocking Windows package lane already runs a curated set of Windows boundaries after preparing `node-pty`. This PR adds the two PTY IPC suites that were missing:

```text
src/main/ipc/pty-codex-account-attribution.test.ts
src/main/ipc/pty-spawn-env-codex-resume-provenance.test.ts
```

The first Windows run did exactly what this coverage change was meant to do: it exposed three POSIX-only test fixtures. Two expected `/managed/.../auth.json` while production correctly used Windows separators; the third represented a Codex home as a root-relative path, so Orca correctly refused to trust it as a Windows absolute home and stripped an automatic resume.

The fixtures now build from a genuinely absolute platform root (`C:\\managed` on Windows, `/managed` elsewhere) and use `node:path` for homes, rollouts, and auth-file assertions.

## Why keep the curated list

A broad `pty-*.test.ts` glob would add unrelated, previously unrun Windows suites to a required job in the same change. The explicit list keeps this PR scoped to the two suites requested by #12437. `src/shared/secure-file-fsync-flags.test.ts` was already present.

## Proof

- Paired Windows runtime `awin`, head `794854a507c`: 2 files passed, 14 tests passed, 6 explicitly POSIX-only tests skipped, `WIN_PTY_IPC_OK`.
- Before the absolute-root correction, the same Windows command reproduced the verified-provenance failure (`Received: codex`); after it, the suite passes.
- macOS/local: both files pass, 20/20.
- Typecheck, focused oxlint, formatting, diff checks, and max-lines ratchet pass.

The older explicit whole-package `pnpm rebuild node-pty` can hang in a long pnpm worktree on the paired machine; that native packaging problem is separate from these mocked IPC suites. #16064 independently proves the repaired ConPTY source build and packaged ownership exports.

## Compatibility

This changes CI coverage and cross-platform test fixtures only. There are no runtime, UI, mobile, SSH, RPC, schema, or remote-wire changes.
