### PR TITLE
Fix paired web skill commands to use host platform

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -5075,7 +5075,7 @@
           "platform": "macos",
           "command": "ORCA_E2E_WEB_CLIENT=1 SKIP_BUILD=1 pnpm exec playwright test tests/e2e/remote-agent-session-focus-authority.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1",
           "result": "passed",
-          "durationSeconds": 5.8,
+          "durationSeconds": 5.92,
           "summary": "After fresh Electron E2E and exposed-store web builds, the isolated headed desktop host plus separate paired web client passed fresh/resume activate true/false, exact non-tail legacy placement in host/mirror/DOM, host focus isolation, requester-only exact focus, writable agent and unrelated shell markers, unrelated survival, and terminal/tab/PTY/process cleanup."
         },
         {
@@ -14107,22 +14107,43 @@
       "providers": ["local", "remote-runtime"],
       "coveredPlatforms": ["macos", "linux"],
       "coveredProviders": ["local", "remote-runtime"],
-      "coverageNotes": "Renderer contracts simulate mismatched viewer and host platforms, exact remote-environment selection, local desktop behavior, and a legacy host with no published platform. A Windows-user-agent web viewer paired to a real Linux Orca host passes the same visible command oracle with both headed desktop-server and headless serve topologies. Physical Windows-host and mixed-version binary journeys remain uncollected.",
+      "coverageNotes": "Renderer contracts simulate mismatched viewer and host platforms, exact remote-environment selection, unresolved-catalog execution gating, local desktop behavior, paired-web suppression of viewer-owned Windows runtime settings, WSL repair fallback, execution-host Windows shell metadata, click-time terminal ownership, paired-runtime tab shell isolation, General, Linear, mobile-emulator, onboarding, and feature-tip command propagation, disconnected status, and a legacy host with no published platform. A Windows-user-agent web viewer paired to a real Linux Orca host passes the same visible command oracle with both headed desktop-server and headless serve topologies. Physical Windows-host and mixed-version binary journeys remain uncollected.",
       "motivatingLinks": [
         "https://linear.app/stably/issue/STA-3279",
         "https://github.com/stablyai/orca/issues/12252"
       ],
-      "invariant": "For a terminal owned by runtime R, skill command and setup-shell selection use R's published RuntimeStatus.hostPlatform; changing only the viewer user agent cannot change those commands. Viewer-local keyboard and UI platform behavior remains viewer-owned.",
-      "oracle": "Pair a Windows-user-agent web viewer to a Linux Orca host, independently require runtime status to publish linux, open the real Orchestration settings copy dialog, and require the visible install command to remain the bare POSIX npx command rather than a cmd.exe wrapper. Repeat against headed desktop-server and headless serve hosts. Renderer contracts separately pin exact environment selection, Windows-host inversion, local desktop behavior, and viewer-platform fallback when an old host omits hostPlatform.",
+      "invariant": "For a terminal owned by runtime R, skill command, setup-shell selection, preflight, and spawn use R's published host metadata and exact owner identity; changing only the viewer user agent or focus cannot change them. Unresolved ownership stays non-executable, and unavailable host platform stays neutral instead of borrowing viewer truth. Viewer-local keyboard and UI platform behavior remains viewer-owned.",
+      "oracle": "Pair a Windows-user-agent web viewer to a Linux Orca host, independently require both host RPC status and the consumed renderer mirror to publish linux, open the real Orchestration settings copy dialog, and require the visible install command to remain the bare POSIX npx command rather than a cmd.exe wrapper. Open its real setup terminal and separately require the tab to pin that Linux environment with no Windows shell override. Repeat against headed desktop-server and headless serve hosts. Renderer contracts separately pin exact environment selection, reject setup preflight and terminal creation while ownership is unresolved without borrowing the first saved web environment, preserve legacy omitted routing, and cover Windows-host inversion, paired-web suppression of viewer-owned WSL defaults, execution-host shell metadata, WSL repair fallback, General and Linear propagation, local desktop behavior, and platform-neutral disconnected and legacy states.",
       "commands": [
-        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/useActiveProjectSkillRuntime.test.tsx src/renderer/src/lib/project-skill-runtime.test.ts src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx",
-        "ORCA_E2E_WEB_CLIENT=1 pnpm exec playwright test tests/e2e/paired-web-skill-command-host-platform.spec.ts --config tests/playwright.config.ts --project electron-headful --project electron-headless --workers=1 --reporter=line",
-        "docker exec sta3279-linux-e2e bash -lc \"cd /workspace && xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 ORCA_E2E_WEB_CLIENT=1 pnpm exec playwright test tests/e2e/paired-web-skill-command-host-platform.spec.ts --config tests/playwright.config.ts --project electron-headful --project electron-headless --workers=1 --reporter=line\""
+        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/CliSection.test.tsx src/renderer/src/components/settings/GeneralPane.test.ts src/renderer/src/components/settings/GeneralPane.cli-platform.test.tsx src/renderer/src/hooks/useActiveProjectSkillRuntime.test.tsx src/renderer/src/lib/project-skill-runtime.test.ts src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts src/renderer/src/components/settings/MobileEmulatorAgentControlRow.test.tsx src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.test.tsx src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.command-finished.test.tsx src/renderer/src/components/feature-wall/skill-setup-runtime-authority.test.tsx src/renderer/src/lib/terminal-worktree-route.test.ts src/renderer/src/store/slices/store-active-worktree-terminal-creation.test.ts src/renderer/src/lib/session-write-subscriber.test.ts src/renderer/src/lib/workspace-session-patch.test.ts src/shared/remote-workspace-session-projection.test.ts src/renderer/src/components/feature-tips/CliSkillSetupTerminal.test.tsx src/renderer/src/components/sidebar/linear-agent-skill-runtime.shell-override.test.ts src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.test.tsx src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.update-command.test.tsx src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.reminder-toast.test.tsx src/renderer/src/components/settings/linear-agent-skill-install-cta.test.tsx",
+        "ORCA_E2E_WEB_CLIENT=1 pnpm exec playwright test tests/e2e/paired-web-skill-command-host-platform.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1 --reporter=line && ORCA_E2E_WEB_CLIENT=1 pnpm exec playwright test tests/e2e/paired-web-skill-command-host-platform.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=line",
+        "docker exec sta3279-linux-e2e bash -lc \"cd /workspace && xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=0 ORCA_E2E_WEB_CLIENT=1 pnpm exec playwright test tests/e2e/paired-web-skill-command-host-platform.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1 --reporter=line && xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=0 ORCA_E2E_WEB_CLIENT=1 pnpm exec playwright test tests/e2e/paired-web-skill-command-host-platform.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=line\""
       ],
       "testFiles": [
         "src/renderer/src/hooks/useActiveProjectSkillRuntime.test.tsx",
         "src/renderer/src/lib/project-skill-runtime.test.ts",
         "src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx",
+        "src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx",
+        "src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.command-finished.test.tsx",
+        "src/renderer/src/lib/terminal-worktree-route.test.ts",
+        "src/renderer/src/store/slices/store-active-worktree-terminal-creation.test.ts",
+        "src/renderer/src/lib/session-write-subscriber.test.ts",
+        "src/renderer/src/lib/workspace-session-patch.test.ts",
+        "src/shared/remote-workspace-session-projection.test.ts",
+        "src/renderer/src/components/settings/CliSection.test.tsx",
+        "src/renderer/src/components/settings/GeneralPane.test.ts",
+        "src/renderer/src/components/settings/GeneralPane.cli-platform.test.tsx",
+        "src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts",
+        "src/renderer/src/components/settings/MobileEmulatorAgentControlRow.test.tsx",
+        "src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts",
+        "src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.test.tsx",
+        "src/renderer/src/components/feature-wall/skill-setup-runtime-authority.test.tsx",
+        "src/renderer/src/components/feature-tips/CliSkillSetupTerminal.test.tsx",
+        "src/renderer/src/components/sidebar/linear-agent-skill-runtime.shell-override.test.ts",
+        "src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.test.tsx",
+        "src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.update-command.test.tsx",
+        "src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.reminder-toast.test.tsx",
+        "src/renderer/src/components/settings/linear-agent-skill-install-cta.test.tsx",
         "tests/e2e/paired-web-skill-command-host-platform.spec.ts"
       ],
       "assertionRefs": [
@@ -14130,8 +14151,29 @@
           "file": "src/renderer/src/hooks/useActiveProjectSkillRuntime.test.tsx",
           "assertions": [
             "paired web and saved remote runtimes prefer the exact host status platform over viewer platform",
-            "local desktop retains viewer-platform behavior and old hosts fall back compatibly",
-            "non-Windows execution hosts do not trigger the Windows setup-shell override"
+            "an unresolved paired web target does not borrow the first saved runtime's owner or platform",
+            "local desktop retains viewer-platform behavior while loading, disconnected, and old hosts remain platform-neutral",
+            "non-Windows execution hosts do not trigger the Windows setup-shell override",
+            "paired web does not borrow viewer-owned WSL or shell defaults"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/settings/CliSection.test.tsx",
+          "assertions": [
+            "General CLI carries its execution-host platform into host and WSL terminal runtimes",
+            "unknown execution-host platform emits a neutral install command"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/settings/GeneralPane.test.ts",
+          "assertions": [
+            "General settings retains viewer-local platform classification outside paired web"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/settings/GeneralPane.cli-platform.test.tsx",
+          "assertions": [
+            "GeneralPane keeps registration UI viewer-owned while passing complete execution-host runtime authority to skill setup"
           ]
         },
         {
@@ -14144,14 +14186,106 @@
           "file": "src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx",
           "assertions": [
             "skill command and setup-terminal builders prefer runtime hostPlatform",
-            "Windows and WSL command behavior remains unchanged"
+            "authoritative Windows hosts and WSL runtimes retain their required Windows command behavior",
+            "copied Windows commands prefer execution-host terminalWindowsShell and stay neutral when old hosts omit it"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx",
+          "assertions": [
+            "WSL runtimes without optional host metadata retain their intrinsic Windows-parent shell contract",
+            "click-time runtime snapshots keep command preparation and exact execution-host ownership pinned together across asynchronous preflight",
+            "unresolved runtime ownership cannot start setup or collapse into a focused or local owner"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.command-finished.test.tsx",
+          "assertions": [
+            "the exact snapshotted runtime environment id reaches terminal creation with host-runtime routing"
+          ]
+        },
+        {
+          "file": "src/renderer/src/lib/terminal-worktree-route.test.ts",
+          "assertions": [
+            "an explicit setup-terminal owner outranks later runtime focus changes, including a pinned local owner"
+          ]
+        },
+        {
+          "file": "src/renderer/src/store/slices/store-active-worktree-terminal-creation.test.ts",
+          "assertions": [
+            "pinned paired-runtime terminals never inherit viewer Windows shell settings, including legacy hosts with unknown platform"
+          ]
+        },
+        {
+          "file": "src/renderer/src/lib/session-write-subscriber.test.ts",
+          "assertions": [
+            "transient runtime spawn ownership does not trigger durable session writes"
+          ]
+        },
+        {
+          "file": "src/renderer/src/lib/workspace-session-patch.test.ts",
+          "assertions": [
+            "runtime spawn ownership is stripped from persisted terminal tabs"
+          ]
+        },
+        {
+          "file": "src/shared/remote-workspace-session-projection.test.ts",
+          "assertions": [
+            "runtime spawn ownership is not published in remote workspace session content"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts",
+          "assertions": [
+            "repair-required feature-tip setup retains host fallback command construction",
+            "host-only mobile emulator setup callers still carry the focused execution-host platform"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/settings/MobileEmulatorAgentControlRow.test.tsx",
+          "assertions": [
+            "mobile emulator host-only setup distinguishes Windows and Linux execution-host commands"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts",
+          "assertions": [
+            "WSL repair fallback retains the authoritative Windows parent for copied commands"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.test.tsx",
+          "assertions": [
+            "feature-wall setup passes the captured execution-host environment into terminal spawn"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/feature-wall/skill-setup-runtime-authority.test.tsx",
+          "assertions": [
+            "feature-wall actions cannot run host-scoped setup before runtime ownership resolves",
+            "settled local and paired owners enable setup with null and exact environment identity"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/feature-tips/CliSkillSetupTerminal.test.tsx",
+          "assertions": [
+            "feature-tip repair fallback keeps command platform and terminal spawn on the same execution host"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/sidebar/linear-agent-skill-runtime.shell-override.test.ts",
+          "assertions": [
+            "Linear command runtimes carry the selected execution platform for host and WSL targets",
+            "paired web and saved runtimes use execution-host truth while local Linear UI remains viewer-owned",
+            "an explicit project WSL target outranks ambient execution-host metadata"
           ]
         },
         {
           "file": "tests/e2e/paired-web-skill-command-host-platform.spec.ts",
           "assertions": [
-            "host status and viewer platform disagree by construction",
-            "the real visible copy dialog uses the Linux host command in headed and headless paired topologies"
+            "direct host RPC status and the renderer's consumed mirror report Linux while the viewer reports Windows",
+            "the real visible copy dialog uses the Linux host command in headed and headless paired topologies",
+            "the real setup terminal pins the Linux environment without inheriting a viewer Windows shell"
           ]
         }
       ],
@@ -14161,18 +14295,18 @@
           "runner": "local",
           "platform": "macos",
           "result": "passed",
-          "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/useActiveProjectSkillRuntime.test.tsx src/renderer/src/lib/project-skill-runtime.test.ts src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx",
-          "durationSeconds": 2.8,
-          "summary": "Three focused files passed 44 tests covering host/viewer inversion, exact environment selection, legacy fallback, command construction, setup-shell behavior, WSL, and local desktop preservation."
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/CliSection.test.tsx src/renderer/src/components/settings/GeneralPane.test.ts src/renderer/src/components/settings/GeneralPane.cli-platform.test.tsx src/renderer/src/hooks/useActiveProjectSkillRuntime.test.tsx src/renderer/src/lib/project-skill-runtime.test.ts src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts src/renderer/src/components/settings/MobileEmulatorAgentControlRow.test.tsx src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.test.tsx src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.command-finished.test.tsx src/renderer/src/components/feature-wall/skill-setup-runtime-authority.test.tsx src/renderer/src/lib/terminal-worktree-route.test.ts src/renderer/src/store/slices/store-active-worktree-terminal-creation.test.ts src/renderer/src/lib/session-write-subscriber.test.ts src/renderer/src/lib/workspace-session-patch.test.ts src/shared/remote-workspace-session-projection.test.ts src/renderer/src/components/feature-tips/CliSkillSetupTerminal.test.tsx src/renderer/src/components/sidebar/linear-agent-skill-runtime.shell-override.test.ts src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.test.tsx src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.update-command.test.tsx src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.reminder-toast.test.tsx src/renderer/src/components/settings/linear-agent-skill-install-cta.test.tsx",
+          "durationSeconds": 5.8,
+          "summary": "Twenty-four focused files passed 269 tests covering host/viewer inversion, exact environment selection, unresolved-catalog execution and prerequisite-mutation gating, neutral unavailable and ambiguous ownership, General, Linear, mobile emulator, onboarding, feature wall, and feature-tip propagation, command construction and caller ratchets, click-time exact terminal ownership across preflight, paired-runtime tab shell isolation, transient-owner persistence and publication exclusion, setup-shell behavior, paired-web suppression of viewer-owned Windows runtime settings, execution-host shell authority including legacy host neutrality, legacy WSL precedence and repair fallback, and local desktop preservation."
         },
         {
           "date": "2026-08-23",
           "runner": "local",
           "platform": "linux",
           "result": "passed",
-          "command": "docker exec sta3279-linux-e2e bash -lc \"cd /workspace && xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 ORCA_E2E_WEB_CLIENT=1 pnpm exec playwright test tests/e2e/paired-web-skill-command-host-platform.spec.ts --config tests/playwright.config.ts --project electron-headful --project electron-headless --workers=1 --reporter=line\"",
-          "durationSeconds": 24.1,
-          "summary": "Both live paired Linux-host journeys passed: runtime status reported linux while the Windows-UA viewer reported win32, and the visible Orchestration dialog showed the bare npx install command."
+          "command": "docker exec sta3279-linux-e2e bash -lc \"cd /workspace && xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=0 ORCA_E2E_WEB_CLIENT=1 pnpm exec playwright test tests/e2e/paired-web-skill-command-host-platform.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1 --reporter=line && xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=0 ORCA_E2E_WEB_CLIENT=1 pnpm exec playwright test tests/e2e/paired-web-skill-command-host-platform.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1 --reporter=line\"",
+          "durationSeconds": 34.9,
+          "summary": "Both strengthened live paired Linux-host journeys passed after a bounded mirrored-status readiness barrier: headed desktop-server in 15.4 seconds and headless serve in 19.5 seconds. Host RPC status and the renderer mirror reported linux while the Windows-UA viewer reported win32, the visible Orchestration dialog showed the bare npx install command, and the real setup-terminal tab was pinned to the Linux runtime without a viewer Windows shell override."
         }
       ],
       "runtimeBudget": {
@@ -14185,24 +14319,25 @@
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "On current main, the byte-identical headed and headless Linux-host oracle observed hostPlatform linux but rendered a cmd.exe install command from the Windows viewer UA. The candidate passed both topologies. Reversing only the three product-source changes, rebuilding the same E2E artifacts, and rerunning the identical headed oracle restored the cmd.exe failure; restoring the candidate returned both journeys to green."
+        "evidence": "The identical strengthened headed and headless projects were rebuilt against origin/main product sources while retaining only the candidate test harness. Both reported hostPlatform linux but failed at the visible command oracle with the Windows viewer's cmd.exe wrapper before terminal creation. Rebuilding the same projects from the candidate product sources passed both the visible POSIX command and exact setup-terminal owner/shell assertions. Because origin/main is the candidate with the complete product fix disabled, this is also the revert control."
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "The hook selects one scalar from the already-mirrored runtimeStatusByEnvironmentId map. It adds no RPC, polling, timer, subprocess, whole-map subscription, or remote fanout. Windows capability discovery remains gated to a Windows execution platform with local skill authority, so a Linux paired host causes no Windows probe."
+        "evidence": "The hook selects scalars from the already-mirrored runtimeStatusByEnvironmentId map and adds no platform RPC, polling, timer, subprocess, whole-map subscription, or remote fanout. A Linux paired host causes no Windows probe. Existing Windows capability discovery remains gated to a proven Windows execution platform with local project authority; paired web does not probe viewer-local WSL capabilities."
       },
       "promotionCriteria": [
         "Collect 100 consecutive focused CI passes or 14 days without an unexplained flake.",
         "Run a physical Windows execution host with a non-Windows viewer and retain the inverse command oracle.",
         "Exercise an old viewer against a new host and a new viewer against an old host binary.",
-        "Keep the no-RPC and no-Windows-probe budget plus local desktop viewer behavior green."
+        "Keep the no-extra-platform-RPC and no-Linux-host-Windows-probe budget plus local desktop viewer behavior green."
       ],
       "knownGaps": [
         "The live cross-OS topology used a Linux container for the paired Orca host; physical Windows-host inversion remains uncollected.",
         "Legacy omission is covered as a renderer contract, but mixed-version packaged binaries were not paired live.",
-        "The regression protects skill command and setup-terminal consumers only; viewer-local platform consumers intentionally remain UA-owned."
+        "The live journey exercises Orchestration copy UI; setup-terminal, WSL, and General CLI boundaries are deterministic renderer contracts rather than separate live journeys.",
+        "Viewer-local shortcut and feedback platform consumers intentionally remain UA-owned."
       ],
-      "demotionRule": "Demote if viewer UA can alter an execution-host skill command, exact runtime selection borrows another host's platform, old-host omission stops falling back compatibly, or the boundary adds runtime-status RPC or Windows capability fanout."
+      "demotionRule": "Demote if viewer UA can alter an execution-host skill command, exact runtime selection borrows another host's platform or capability cache, unavailable host truth becomes viewer truth, WSL loses its Windows parent, or the boundary adds redundant runtime-status RPC or Windows capability fanout."
     }
   ]
 }

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-20",
+  "updatedAt": "2026-08-23",
   "policy": {
     "maturityLevels": ["experimental", "soak", "blocking", "accepted-gap", "deprecated"],
     "blockingPromotion": {
@@ -14089,6 +14089,120 @@
         "The legacy remote-uploads root is intentionally not reclaimed while a mixed-version relay may still own bytes there; eventual legacy-root retirement requires a separate compatibility decision."
       ],
       "demotionRule": "Demote if one live owner can remove another owner's bytes, cleanup exceeds 64 inspected entries per attempt, a lifecycle path retains its exact owned archive after settlement, or the process oracle flakes without an identified harness or product defect."
+    },
+    {
+      "id": "skill-setup.execution-host-platform",
+      "title": "Skill setup commands follow execution-host platform authority",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "renderer-skill-runtime",
+      "layer": "renderer-runtime-authority",
+      "surfaces": [
+        "skill install and update command builders",
+        "skill setup terminal",
+        "paired web settings dialog",
+        "saved remote runtime environments"
+      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "remote-runtime"],
+      "coveredPlatforms": ["macos", "linux"],
+      "coveredProviders": ["local", "remote-runtime"],
+      "coverageNotes": "Renderer contracts simulate mismatched viewer and host platforms, exact remote-environment selection, local desktop behavior, and a legacy host with no published platform. A Windows-user-agent web viewer paired to a real Linux Orca host passes the same visible command oracle with both headed desktop-server and headless serve topologies. Physical Windows-host and mixed-version binary journeys remain uncollected.",
+      "motivatingLinks": [
+        "https://linear.app/stably/issue/STA-3279",
+        "https://github.com/stablyai/orca/issues/12252"
+      ],
+      "invariant": "For a terminal owned by runtime R, skill command and setup-shell selection use R's published RuntimeStatus.hostPlatform; changing only the viewer user agent cannot change those commands. Viewer-local keyboard and UI platform behavior remains viewer-owned.",
+      "oracle": "Pair a Windows-user-agent web viewer to a Linux Orca host, independently require runtime status to publish linux, open the real Orchestration settings copy dialog, and require the visible install command to remain the bare POSIX npx command rather than a cmd.exe wrapper. Repeat against headed desktop-server and headless serve hosts. Renderer contracts separately pin exact environment selection, Windows-host inversion, local desktop behavior, and viewer-platform fallback when an old host omits hostPlatform.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/useActiveProjectSkillRuntime.test.tsx src/renderer/src/lib/project-skill-runtime.test.ts src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx",
+        "ORCA_E2E_WEB_CLIENT=1 pnpm exec playwright test tests/e2e/paired-web-skill-command-host-platform.spec.ts --config tests/playwright.config.ts --project electron-headful --project electron-headless --workers=1 --reporter=line",
+        "docker exec sta3279-linux-e2e bash -lc \"cd /workspace && xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 ORCA_E2E_WEB_CLIENT=1 pnpm exec playwright test tests/e2e/paired-web-skill-command-host-platform.spec.ts --config tests/playwright.config.ts --project electron-headful --project electron-headless --workers=1 --reporter=line\""
+      ],
+      "testFiles": [
+        "src/renderer/src/hooks/useActiveProjectSkillRuntime.test.tsx",
+        "src/renderer/src/lib/project-skill-runtime.test.ts",
+        "src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx",
+        "tests/e2e/paired-web-skill-command-host-platform.spec.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/renderer/src/hooks/useActiveProjectSkillRuntime.test.tsx",
+          "assertions": [
+            "paired web and saved remote runtimes prefer the exact host status platform over viewer platform",
+            "local desktop retains viewer-platform behavior and old hosts fall back compatibly",
+            "non-Windows execution hosts do not trigger the Windows setup-shell override"
+          ]
+        },
+        {
+          "file": "src/renderer/src/lib/project-skill-runtime.test.ts",
+          "assertions": [
+            "host runtime metadata carries the resolved execution-host platform"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx",
+          "assertions": [
+            "skill command and setup-terminal builders prefer runtime hostPlatform",
+            "Windows and WSL command behavior remains unchanged"
+          ]
+        },
+        {
+          "file": "tests/e2e/paired-web-skill-command-host-platform.spec.ts",
+          "assertions": [
+            "host status and viewer platform disagree by construction",
+            "the real visible copy dialog uses the Linux host command in headed and headless paired topologies"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-08-23",
+          "runner": "local",
+          "platform": "macos",
+          "result": "passed",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/useActiveProjectSkillRuntime.test.tsx src/renderer/src/lib/project-skill-runtime.test.ts src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx",
+          "durationSeconds": 2.8,
+          "summary": "Three focused files passed 44 tests covering host/viewer inversion, exact environment selection, legacy fallback, command construction, setup-shell behavior, WSL, and local desktop preservation."
+        },
+        {
+          "date": "2026-08-23",
+          "runner": "local",
+          "platform": "linux",
+          "result": "passed",
+          "command": "docker exec sta3279-linux-e2e bash -lc \"cd /workspace && xvfb-run --auto-servernum env SKIP_BUILD=1 ORCA_E2E_FORWARD_APP_LOGS=1 ORCA_E2E_WEB_CLIENT=1 pnpm exec playwright test tests/e2e/paired-web-skill-command-host-platform.spec.ts --config tests/playwright.config.ts --project electron-headful --project electron-headless --workers=1 --reporter=line\"",
+          "durationSeconds": 24.1,
+          "summary": "Both live paired Linux-host journeys passed: runtime status reported linux while the Windows-UA viewer reported win32, and the visible Orchestration dialog showed the bare npx install command."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 45,
+        "scope": "focused renderer contracts plus sequential headed and headless paired web journeys"
+      },
+      "flakeHistory": {
+        "status": "not-started",
+        "evidence": "The unit contracts and live journeys use status and UI readiness barriers rather than timing as the oracle; CI and soak history have not started."
+      },
+      "redGreenEvidence": {
+        "status": "complete",
+        "evidence": "On current main, the byte-identical headed and headless Linux-host oracle observed hostPlatform linux but rendered a cmd.exe install command from the Windows viewer UA. The candidate passed both topologies. Reversing only the three product-source changes, rebuilding the same E2E artifacts, and rerunning the identical headed oracle restored the cmd.exe failure; restoring the candidate returned both journeys to green."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "The hook selects one scalar from the already-mirrored runtimeStatusByEnvironmentId map. It adds no RPC, polling, timer, subprocess, whole-map subscription, or remote fanout. Windows capability discovery remains gated to a Windows execution platform with local skill authority, so a Linux paired host causes no Windows probe."
+      },
+      "promotionCriteria": [
+        "Collect 100 consecutive focused CI passes or 14 days without an unexplained flake.",
+        "Run a physical Windows execution host with a non-Windows viewer and retain the inverse command oracle.",
+        "Exercise an old viewer against a new host and a new viewer against an old host binary.",
+        "Keep the no-RPC and no-Windows-probe budget plus local desktop viewer behavior green."
+      ],
+      "knownGaps": [
+        "The live cross-OS topology used a Linux container for the paired Orca host; physical Windows-host inversion remains uncollected.",
+        "Legacy omission is covered as a renderer contract, but mixed-version packaged binaries were not paired live.",
+        "The regression protects skill command and setup-terminal consumers only; viewer-local platform consumers intentionally remain UA-owned."
+      ],
+      "demotionRule": "Demote if viewer UA can alter an execution-host skill command, exact runtime selection borrows another host's platform, old-host omission stops falling back compatibly, or the boundary adds runtime-status RPC or Windows capability fanout."
     }
   ]
 }

--- a/src/renderer/src/components/emulator-pane/MobileEmulatorAgentSetupGuideSteps.tsx
+++ b/src/renderer/src/components/emulator-pane/MobileEmulatorAgentSetupGuideSteps.tsx
@@ -3,6 +3,7 @@ import { cn } from '@/lib/utils'
 import { useAppStore } from '@/store'
 import { ORCA_CLI_SKILL_INSTALL_COMMAND } from '@/lib/agent-feature-install-commands'
 import { useActiveProjectSkillRuntime } from '@/hooks/useActiveProjectSkillRuntime'
+import { getHostFallbackAgentSkillRuntime } from '@/lib/project-skill-runtime'
 import {
   AGENT_SKILL_CLI_PREREQUISITE_NOTICE,
   ensureOrcaCliAvailableForAgentSkillTerminal
@@ -30,9 +31,16 @@ export function MobileEmulatorAgentSetupGuideSteps({
 }: MobileEmulatorAgentSetupGuideStepsProps): React.JSX.Element {
   const recordFeatureInteraction = useAppStore((s) => s.recordFeatureInteraction)
   const activeSkillRuntime = useActiveProjectSkillRuntime()
-  // Why: skill detection here scans the local host only, so keep building host
-  // commands; routing them to a WSL runtime would install where we never look.
-  const skillInstallCommand = buildSkillCommandForRuntime(ORCA_CLI_SKILL_INSTALL_COMMAND)
+  // Why: detection scans the host rather than WSL, but a focused remote host
+  // still owns the terminal command platform.
+  const commandRuntime =
+    activeSkillRuntime.agentRuntime?.runtime === 'wsl'
+      ? getHostFallbackAgentSkillRuntime(activeSkillRuntime.agentRuntime)
+      : activeSkillRuntime.agentRuntime
+  const skillInstallCommand = buildSkillCommandForRuntime(
+    ORCA_CLI_SKILL_INSTALL_COMMAND,
+    commandRuntime
+  )
   const terminalWorktreeId = `mobile-emulator-${worktreeId}-orca-cli-skill-terminal`
   const showSkillPreInstallNotice = shouldShowMobileEmulatorSkillPreInstallNotice({
     cliEnabled: setup.cliEnabled,
@@ -166,6 +174,7 @@ export function MobileEmulatorAgentSetupGuideSteps({
             )}
             terminalWorktreeId={terminalWorktreeId}
             terminalShellOverride={activeSkillRuntime.terminalShellOverride}
+            terminalRuntime={commandRuntime}
             installed={setup.cliSkillInstalled}
             loading={setup.cliSkillLoading || setup.setupRechecking}
             error={setup.cliSkillError}

--- a/src/renderer/src/components/feature-tips/CliSkillSetupTerminal.test.tsx
+++ b/src/renderer/src/components/feature-tips/CliSkillSetupTerminal.test.tsx
@@ -7,11 +7,19 @@ import { CliSkillSetupTerminal } from './CliSkillSetupTerminal'
 
 const mocks = vi.hoisted(() => ({
   runtime: {
-    agentRuntime: { runtime: 'wsl' as const, wslDistro: 'Missing', label: 'WSL Missing' },
-    installDisabledReason: 'The selected WSL distro is unavailable.',
+    agentRuntime: {
+      runtime: 'wsl' as const,
+      wslDistro: 'Missing',
+      hostPlatform: 'win32' as const,
+      runtimeEnvironmentId: 'hub-a',
+      runtimeOwnershipResolved: true,
+      label: 'WSL Missing'
+    },
+    installDisabledReason: 'The selected WSL distro is unavailable.' as string | null,
     terminalShellOverride: 'powershell.exe'
   },
-  terminalCommand: ''
+  terminalCommand: '',
+  runtimeEnvironmentId: undefined as string | null | undefined
 }))
 
 vi.mock('@/hooks/useActiveProjectSkillRuntime', () => ({
@@ -22,13 +30,16 @@ vi.mock('@/components/onboarding/OnboardingInlineCommandTerminal', () => ({
   OnboardingInlineCommandTerminal: ({
     command,
     prepareCommandForShell,
+    runtimeEnvironmentId,
     shellOverride
   }: {
     command: string
     prepareCommandForShell?: (command: string, shellOverride?: string) => string
+    runtimeEnvironmentId?: string | null
     shellOverride?: string
   }) => {
     mocks.terminalCommand = prepareCommandForShell?.(command, shellOverride) ?? command
+    mocks.runtimeEnvironmentId = runtimeEnvironmentId
     return null
   }
 }))
@@ -36,10 +47,13 @@ vi.mock('@/components/onboarding/OnboardingInlineCommandTerminal', () => ({
 describe('CliSkillSetupTerminal', () => {
   beforeEach(() => {
     mocks.terminalCommand = ''
+    mocks.runtimeEnvironmentId = undefined
+    mocks.runtime.installDisabledReason = 'The selected WSL distro is unavailable.'
+    mocks.runtime.agentRuntime.runtimeOwnershipResolved = true
     Object.defineProperty(window, 'api', {
       configurable: true,
       value: {
-        platform: { get: () => ({ platform: 'win32' }) }
+        platform: { get: () => ({ platform: 'darwin' }) }
       }
     })
   })
@@ -58,5 +72,20 @@ describe('CliSkillSetupTerminal', () => {
 
     expect(mocks.terminalCommand).toMatch(/^cmd\.exe \/d \/s \/c /)
     expect(mocks.terminalCommand).not.toContain('wsl.exe')
+    expect(mocks.runtimeEnvironmentId).toBe('hub-a')
+  })
+
+  it('does not mount a terminal while runtime ownership is unresolved', () => {
+    mocks.runtime.installDisabledReason = null
+    mocks.runtime.agentRuntime.runtimeOwnershipResolved = false
+
+    const rendered = render(
+      <TooltipProvider>
+        <CliSkillSetupTerminal />
+      </TooltipProvider>
+    )
+
+    expect(rendered.getByText('Preparing setup terminal.')).toBeTruthy()
+    expect(mocks.terminalCommand).toBe('')
   })
 })

--- a/src/renderer/src/components/feature-tips/CliSkillSetupTerminal.tsx
+++ b/src/renderer/src/components/feature-tips/CliSkillSetupTerminal.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/settings/CliSkillRuntimeSetup'
 import { ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND } from '@/lib/agent-feature-install-commands'
 import { useActiveProjectSkillRuntime } from '@/hooks/useActiveProjectSkillRuntime'
+import { getHostFallbackAgentSkillRuntime } from '@/lib/project-skill-runtime'
 import { translate } from '@/i18n/i18n'
 
 export function CliSkillSetupTerminal(): React.JSX.Element {
@@ -17,13 +18,23 @@ export function CliSkillSetupTerminal(): React.JSX.Element {
   // drop back to the host runtime. This terminal auto-pastes with no install
   // gate, and repair-required only happens on Windows, so it still needs the
   // npx preflight.
+  const terminalRuntime = activeSkillRuntime.installDisabledReason
+    ? getHostFallbackAgentSkillRuntime(activeSkillRuntime.agentRuntime)
+    : activeSkillRuntime.agentRuntime
+  if (terminalRuntime?.runtimeOwnershipResolved === false) {
+    return (
+      <p className="text-[12px] leading-snug text-muted-foreground">
+        {translate(
+          'auto.components.feature.tips.CliSkillSetupTerminal.preparingRuntime',
+          'Preparing setup terminal.'
+        )}
+      </p>
+    )
+  }
   const skillCommand = buildSkillCommandForRuntime(
     ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND,
-    activeSkillRuntime.installDisabledReason ? undefined : activeSkillRuntime.agentRuntime
+    terminalRuntime
   )
-  const terminalRuntime = activeSkillRuntime.installDisabledReason
-    ? undefined
-    : activeSkillRuntime.agentRuntime
   const prepareCommandForShell = (command: string, effectiveShell: string | undefined): string =>
     buildSkillSetupTerminalCommand(command, effectiveShell, terminalRuntime)
   const handleCopySkillCommand = async (): Promise<void> => {
@@ -98,6 +109,7 @@ export function CliSkillSetupTerminal(): React.JSX.Element {
         worktreeId="feature-tip-cli-skills-terminal"
         shellOverride={activeSkillRuntime.terminalShellOverride}
         forceHostRuntime={Boolean(activeSkillRuntime.installDisabledReason)}
+        runtimeEnvironmentId={terminalRuntime?.runtimeEnvironmentId}
       />
     </div>
   )

--- a/src/renderer/src/components/feature-wall/AgentCapabilitiesSetupAction.tsx
+++ b/src/renderer/src/components/feature-wall/AgentCapabilitiesSetupAction.tsx
@@ -44,6 +44,8 @@ export function AgentCapabilitiesSetupAction(props: {
   const [setupBusyLabel, setSetupBusyLabel] = useState<string | null>(null)
   const recordFeatureInteraction = useAppStore((s) => s.recordFeatureInteraction)
   const activeSkillRuntime = useActiveProjectSkillRuntime()
+  const runtimeOwnershipUnresolved =
+    activeSkillRuntime.agentRuntime?.runtimeOwnershipResolved === false
   useEffect(() => {
     onBrowserUseSkillInstalledChange(readiness.browserUseSkillInstalled)
   }, [onBrowserUseSkillInstalledChange, readiness.browserUseSkillInstalled])
@@ -65,7 +67,7 @@ export function AgentCapabilitiesSetupAction(props: {
     setFeatureSetup(value)
   }, [])
   const handleStartFeatureSetup = useCallback(async (): Promise<void> => {
-    if (setupBusyLabel !== null || featureSetupCommand !== null) {
+    if (setupBusyLabel !== null || featureSetupCommand !== null || runtimeOwnershipUnresolved) {
       return
     }
     setSetupBusyLabel('Setting up capabilities...')
@@ -127,6 +129,7 @@ export function AgentCapabilitiesSetupAction(props: {
     featureSetup,
     featureSetupCommand,
     recordFeatureInteraction,
+    runtimeOwnershipUnresolved,
     setupBusyLabel
   ])
 
@@ -138,6 +141,7 @@ export function AgentCapabilitiesSetupAction(props: {
         featureSetupCommand={featureSetupCommand}
         featureSetupCommandSelection={featureSetupCommandSelection}
         featureSetupRuntime={featureSetupRuntime}
+        runtimeOwnershipUnresolved={runtimeOwnershipUnresolved}
         setupBusyLabel={setupBusyLabel}
         onStartFeatureSetup={() => void handleStartFeatureSetup()}
         installStatus={capabilitySetupStatus.installStatus}
@@ -210,6 +214,7 @@ function AgentCapabilitySetupControls(props: {
   featureSetupCommand: string | null
   featureSetupCommandSelection: OnboardingFeatureSetupSelection | null
   featureSetupRuntime: OnboardingFeatureSetupRuntimeContext | null
+  runtimeOwnershipUnresolved: boolean
   setupBusyLabel: string | null
   onStartFeatureSetup: () => void
   installStatus: Record<OnboardingFeatureSetupId, AgentCapabilityInstallStatus>
@@ -231,7 +236,11 @@ function AgentCapabilitySetupControls(props: {
             type="button"
             variant="default"
             className="shrink-0"
-            disabled={!hasSelectedFeatures || Boolean(props.setupBusyLabel)}
+            disabled={
+              !hasSelectedFeatures ||
+              Boolean(props.setupBusyLabel) ||
+              props.runtimeOwnershipUnresolved
+            }
             onClick={props.onStartFeatureSetup}
           >
             {props.setupBusyLabel ? (

--- a/src/renderer/src/components/feature-wall/FeatureWallBrowserAction.tsx
+++ b/src/renderer/src/components/feature-wall/FeatureWallBrowserAction.tsx
@@ -99,9 +99,11 @@ function BrowserSkillInstallButton(): React.JSX.Element {
   )
   const [busy, setBusy] = useState(false)
   const activeSkillRuntime = useActiveProjectSkillRuntime()
+  const runtimeOwnershipUnresolved =
+    activeSkillRuntime.agentRuntime?.runtimeOwnershipResolved === false
 
   const handleInstall = useCallback(async () => {
-    if (busy || command !== null) {
+    if (busy || command !== null || runtimeOwnershipUnresolved) {
       return
     }
     setBusy(true)
@@ -159,7 +161,7 @@ function BrowserSkillInstallButton(): React.JSX.Element {
     } finally {
       setBusy(false)
     }
-  }, [activeSkillRuntime, busy, command, recordFeatureInteraction])
+  }, [activeSkillRuntime, busy, command, recordFeatureInteraction, runtimeOwnershipUnresolved])
 
   if (command) {
     return (
@@ -177,7 +179,7 @@ function BrowserSkillInstallButton(): React.JSX.Element {
       size="sm"
       variant="outline"
       className="w-fit gap-2"
-      disabled={busy}
+      disabled={busy || runtimeOwnershipUnresolved}
       onClick={() => void handleInstall()}
     >
       {busy ? <Loader2 className="size-3.5 animate-spin" /> : <Terminal className="size-3.5" />}

--- a/src/renderer/src/components/feature-wall/skill-setup-runtime-authority.test.tsx
+++ b/src/renderer/src/components/feature-wall/skill-setup-runtime-authority.test.tsx
@@ -1,0 +1,151 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { BrowserAction } from './FeatureWallBrowserAction'
+import { AgentCapabilitiesSetupAction } from './AgentCapabilitiesSetupAction'
+import type * as AgentCapabilitySetupStatusModule from './agent-capability-setup-status'
+import type * as OnboardingFeatureSetupModule from '../onboarding/onboarding-feature-setup'
+
+const mocks = vi.hoisted(() => ({
+  runSetup: vi.fn(),
+  runtime: {
+    agentRuntime: {
+      runtime: 'host' as const,
+      runtimeOwnershipResolved: false,
+      label: 'This device'
+    },
+    installDisabledReason: null,
+    canUseLocalSkillFreshness: false
+  }
+}))
+
+vi.mock('@/hooks/useActiveProjectSkillRuntime', () => ({
+  useActiveProjectSkillRuntime: () => mocks.runtime
+}))
+
+vi.mock('../onboarding/onboarding-feature-setup', async (importOriginal) => ({
+  ...(await importOriginal<typeof OnboardingFeatureSetupModule>()),
+  runOnboardingFeatureSetup: mocks.runSetup
+}))
+
+vi.mock('./agent-capability-setup-status', async (importOriginal) => ({
+  ...(await importOriginal<typeof AgentCapabilitySetupStatusModule>()),
+  useAgentCapabilitySetupStatus: () => ({
+    readiness: {
+      browserUseSkillInstalled: false,
+      browserUseSkillLoading: false,
+      computerUseSkillInstalled: false,
+      computerUseSkillLoading: false,
+      computerUseReady: false,
+      computerUseChecking: false,
+      computerUseUnavailable: false,
+      orchestrationSkillInstalled: false,
+      orchestrationSkillLoading: false
+    },
+    installStatus: {
+      browserUse: { label: 'Pending', tone: 'pending' },
+      computerUse: { label: 'Pending', tone: 'pending' },
+      orchestration: { label: 'Pending', tone: 'pending' },
+      linearTickets: { label: '', tone: 'pending' }
+    }
+  })
+}))
+
+vi.mock('./FeatureWallSetupWorkflowActions', () => ({
+  promptForSetupGuideProject: vi.fn(),
+  useSetupTargetWorktree: () => null
+}))
+
+vi.mock('./FullDiskAccessSetupPrompt', () => ({
+  FullDiskAccessSetupPrompt: () => null
+}))
+
+vi.mock('../onboarding/FeatureSetupInlineTerminal', () => ({
+  FeatureSetupInlineTerminal: () => null
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorktree: vi.fn()
+}))
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), message: vi.fn(), success: vi.fn(), warning: vi.fn() }
+}))
+
+describe('feature-wall skill setup runtime authority', () => {
+  beforeEach(() => {
+    mocks.runSetup.mockReset()
+    mocks.runSetup.mockResolvedValue({
+      computerUsePermissionsOpened: false,
+      skillCommandsCopied: false,
+      skillInstallCommand: null,
+      warnings: []
+    })
+    Object.assign(mocks.runtime.agentRuntime, {
+      runtimeEnvironmentId: undefined,
+      runtimeOwnershipResolved: false
+    })
+  })
+
+  afterEach(() => cleanup())
+
+  it('defers browser setup until an exact paired owner resolves', async () => {
+    const rendered = render(<BrowserAction done />)
+    const button = screen.getByRole('button', { name: 'Install CLI & Skill' })
+
+    expect((button as HTMLButtonElement).disabled).toBe(true)
+    button.click()
+    expect(mocks.runSetup).not.toHaveBeenCalled()
+
+    Object.assign(mocks.runtime.agentRuntime, {
+      runtimeEnvironmentId: 'linux-host',
+      runtimeOwnershipResolved: true
+    })
+    rendered.rerender(<BrowserAction done />)
+    await act(async () => screen.getByRole('button', { name: 'Install CLI & Skill' }).click())
+
+    expect(mocks.runSetup).toHaveBeenCalledWith(
+      expect.any(Object),
+      undefined,
+      expect.objectContaining({
+        agentRuntime: expect.objectContaining({ runtimeEnvironmentId: 'linux-host' })
+      })
+    )
+  })
+
+  it('defers capability setup until the local owner resolves', async () => {
+    const rendered = render(
+      <AgentCapabilitiesSetupAction
+        onBrowserUseSkillInstalledChange={vi.fn()}
+        onOrchestrationSkillInstalledChange={vi.fn()}
+      />
+    )
+    const button = screen.getByRole('button', { name: 'Install CLI & Skills' })
+
+    expect((button as HTMLButtonElement).disabled).toBe(true)
+    button.click()
+    expect(mocks.runSetup).not.toHaveBeenCalled()
+
+    Object.assign(mocks.runtime.agentRuntime, {
+      runtimeEnvironmentId: null,
+      runtimeOwnershipResolved: true
+    })
+    rendered.rerender(
+      <AgentCapabilitiesSetupAction
+        onBrowserUseSkillInstalledChange={vi.fn()}
+        onOrchestrationSkillInstalledChange={vi.fn()}
+      />
+    )
+    await act(async () => screen.getByRole('button', { name: 'Install CLI & Skills' }).click())
+
+    expect(mocks.runSetup).toHaveBeenCalledWith(
+      expect.any(Object),
+      undefined,
+      expect.objectContaining({
+        agentRuntime: expect.objectContaining({ runtimeEnvironmentId: null })
+      })
+    )
+  })
+})

--- a/src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.test.tsx
+++ b/src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.test.tsx
@@ -5,7 +5,14 @@ import { FeatureSetupInlineTerminal } from './FeatureSetupInlineTerminal'
 
 const mocks = vi.hoisted(() => ({
   runtime: {
-    agentRuntime: { runtime: 'wsl' as const, wslDistro: 'Ubuntu', label: 'WSL Ubuntu' },
+    agentRuntime: {
+      runtime: 'wsl' as const,
+      wslDistro: 'Ubuntu',
+      hostPlatform: 'win32' as const,
+      runtimeEnvironmentId: null,
+      runtimeOwnershipResolved: true,
+      label: 'WSL Ubuntu'
+    },
     installDisabledReason: null as string | null,
     terminalShellOverride: 'powershell.exe'
   },
@@ -21,6 +28,7 @@ const mocks = vi.hoisted(() => ({
     command: string
     forceHostRuntime?: boolean
     prepareCommandForShell?: (command: string, shellOverride?: string) => string
+    runtimeEnvironmentId?: string | null
     shellOverride?: string
   } | null
 }))
@@ -39,6 +47,7 @@ vi.mock('./OnboardingInlineCommandTerminal', () => ({
     command: string
     forceHostRuntime?: boolean
     prepareCommandForShell?: (command: string, shellOverride?: string) => string
+    runtimeEnvironmentId?: string | null
     shellOverride?: string
   }) => {
     mocks.terminalProps = props
@@ -56,6 +65,7 @@ const SELECTION = {
 describe('FeatureSetupInlineTerminal', () => {
   beforeEach(() => {
     mocks.runtime.installDisabledReason = null
+    mocks.runtime.agentRuntime.runtimeOwnershipResolved = true
     mocks.terminalProps = null
     mocks.buildCommand.mockClear()
     mocks.buildSetupCommand.mockClear()
@@ -69,11 +79,15 @@ describe('FeatureSetupInlineTerminal', () => {
     expect(mocks.buildCommand).toHaveBeenCalledWith('npx skills add orchestration', {
       runtime: 'wsl',
       wslDistro: 'Ubuntu',
+      hostPlatform: 'win32',
+      runtimeEnvironmentId: null,
+      runtimeOwnershipResolved: true,
       label: 'WSL Ubuntu'
     })
     expect(mocks.terminalProps).toMatchObject({
       command: 'wsl:npx skills add orchestration',
       forceHostRuntime: false,
+      runtimeEnvironmentId: null,
       shellOverride: 'powershell.exe'
     })
     expect(
@@ -88,10 +102,17 @@ describe('FeatureSetupInlineTerminal', () => {
       <FeatureSetupInlineTerminal command="npx skills add orchestration" selection={SELECTION} />
     )
 
-    expect(mocks.buildCommand).toHaveBeenCalledWith('npx skills add orchestration', undefined)
+    expect(mocks.buildCommand).toHaveBeenCalledWith('npx skills add orchestration', {
+      runtime: 'host',
+      hostPlatform: 'win32',
+      runtimeEnvironmentId: null,
+      runtimeOwnershipResolved: true,
+      label: 'Windows'
+    })
     expect(mocks.terminalProps).toMatchObject({
       command: 'host:npx skills add orchestration',
       forceHostRuntime: true,
+      runtimeEnvironmentId: null,
       shellOverride: 'powershell.exe'
     })
     expect(
@@ -104,7 +125,7 @@ describe('FeatureSetupInlineTerminal', () => {
       <FeatureSetupInlineTerminal
         command="npx skills add orchestration"
         runtimeContext={{
-          agentRuntime: { runtime: 'host', label: 'Windows' },
+          agentRuntime: { runtime: 'host', runtimeEnvironmentId: 'hub-a', label: 'Windows' },
           installDisabledReason: null,
           terminalShellOverride: 'cmd.exe'
         }}
@@ -114,14 +135,27 @@ describe('FeatureSetupInlineTerminal', () => {
 
     expect(mocks.buildCommand).toHaveBeenCalledWith('npx skills add orchestration', {
       runtime: 'host',
+      runtimeEnvironmentId: 'hub-a',
       label: 'Windows'
     })
     expect(mocks.terminalProps).toMatchObject({
       command: 'host:npx skills add orchestration',
+      runtimeEnvironmentId: 'hub-a',
       shellOverride: 'cmd.exe'
     })
     expect(
       mocks.terminalProps?.prepareCommandForShell?.('host:npx skills add orchestration', 'cmd.exe')
     ).toBe('host-cmd.exe:host:npx skills add orchestration')
+  })
+
+  it('does not mount a terminal while runtime ownership is unresolved', () => {
+    mocks.runtime.agentRuntime.runtimeOwnershipResolved = false
+
+    const rendered = render(
+      <FeatureSetupInlineTerminal command="npx skills add orchestration" selection={SELECTION} />
+    )
+
+    expect(rendered.getByText('Preparing setup terminal.')).toBeTruthy()
+    expect(mocks.terminalProps).toBeNull()
   })
 })

--- a/src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.tsx
+++ b/src/renderer/src/components/onboarding/FeatureSetupInlineTerminal.tsx
@@ -74,12 +74,24 @@ export function FeatureSetupInlineTerminal({
     [selectionTelemetry]
   )
 
+  if (agentRuntime?.runtimeOwnershipResolved === false) {
+    return (
+      <p className="text-[12px] leading-snug text-muted-foreground">
+        {translate(
+          'auto.components.onboarding.FeatureSetupInlineTerminal.preparingRuntime',
+          'Preparing setup terminal.'
+        )}
+      </p>
+    )
+  }
+
   return (
     <OnboardingInlineCommandTerminal
       command={copiedCommand}
       prepareCommandForShell={prepareCommandForShell}
       shellOverride={setupRuntime.terminalShellOverride}
       forceHostRuntime={Boolean(setupRuntime.installDisabledReason)}
+      runtimeEnvironmentId={agentRuntime?.runtimeEnvironmentId}
       title={translate(
         'auto.components.onboarding.FeatureSetupInlineTerminal.c767ab7061',
         'Skill setup'

--- a/src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.command-finished.test.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.command-finished.test.tsx
@@ -11,7 +11,7 @@ import {
 import { PASTE_TERMINAL_TEXT_EVENT, type PasteTerminalTextDetail } from '@/constants/terminal'
 
 const mocks = vi.hoisted(() => ({
-  createTab: vi.fn(() => ({ id: 'tab-1', shellOverride: 'wsl.exe' })),
+  createTab: vi.fn((..._args: unknown[]) => ({ id: 'tab-1', shellOverride: 'wsl.exe' })),
   closeTab: vi.fn(),
   setActiveTabForWorktree: vi.fn(),
   setTabCustomTitle: vi.fn()
@@ -116,6 +116,7 @@ describe('OnboardingInlineCommandTerminal command-finished forwarding', () => {
           <OnboardingInlineCommandTerminal
             command="npx skills add orchestration"
             forceHostRuntime
+            runtimeEnvironmentId="linux-host"
             prepareCommandForShell={prepareCommandForShell}
             shellOverride="powershell.exe"
             title="Skill setup"
@@ -137,7 +138,10 @@ describe('OnboardingInlineCommandTerminal command-finished forwarding', () => {
         'ephemeral-setup-terminal:onboarding-inline-terminal',
         undefined,
         'powershell.exe',
-        expect.objectContaining({ forceHostRuntime: true })
+        expect.objectContaining({
+          forceHostRuntime: true,
+          runtimeEnvironmentId: 'linux-host'
+        })
       )
       expect(pasted).toContainEqual({
         tabId: 'tab-1',
@@ -169,6 +173,7 @@ describe('OnboardingInlineCommandTerminal command-finished forwarding', () => {
       )
     })
     await act(async () => {})
+    expect(mocks.createTab.mock.calls.at(-1)?.[3]).not.toHaveProperty('runtimeEnvironmentId')
 
     await act(async () => {
       dispatchCommandFinished('some-other-worktree', 1)

--- a/src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.tsx
+++ b/src/renderer/src/components/onboarding/OnboardingInlineCommandTerminal.tsx
@@ -32,6 +32,7 @@ type OnboardingInlineCommandTerminalProps = {
   worktreeId?: string
   shellOverride?: string
   forceHostRuntime?: boolean
+  runtimeEnvironmentId?: string | null
   onOpened?: () => void
   onInteracted?: (method: 'keyboard' | 'pointer', event?: KeyboardEvent<HTMLElement>) => void
   onTerminalExit?: () => void
@@ -56,6 +57,7 @@ export function OnboardingInlineCommandTerminal({
   worktreeId: worktreeIdProp = ONBOARDING_INLINE_TERMINAL_WORKTREE_ID,
   shellOverride,
   forceHostRuntime = false,
+  runtimeEnvironmentId,
   onOpened,
   onInteracted,
   onTerminalExit,
@@ -129,7 +131,8 @@ export function OnboardingInlineCommandTerminal({
     const tab = createTab(worktreeId, undefined, shellOverride, {
       activate: false,
       recordInteraction: false,
-      forceHostRuntime
+      forceHostRuntime,
+      ...(runtimeEnvironmentId !== undefined ? { runtimeEnvironmentId } : {})
     })
     setActiveTabForWorktree(worktreeId, tab.id)
     setTabCustomTitle(tab.id, title, { recordInteraction: false })
@@ -143,6 +146,7 @@ export function OnboardingInlineCommandTerminal({
     closeTab,
     createTab,
     forceHostRuntime,
+    runtimeEnvironmentId,
     setActiveTabForWorktree,
     setTabCustomTitle,
     shellOverride,

--- a/src/renderer/src/components/onboarding/onboarding-feature-setup-runtime.ts
+++ b/src/renderer/src/components/onboarding/onboarding-feature-setup-runtime.ts
@@ -1,4 +1,5 @@
 import type { ProjectAgentSkillRuntime } from '@/lib/project-skill-runtime'
+import { getHostFallbackAgentSkillRuntime } from '@/lib/project-skill-runtime'
 
 export type OnboardingFeatureSetupRuntimeContext = {
   agentRuntime?: ProjectAgentSkillRuntime
@@ -9,5 +10,7 @@ export type OnboardingFeatureSetupRuntimeContext = {
 export function getOnboardingFeatureSetupAgentRuntime(
   context: OnboardingFeatureSetupRuntimeContext
 ): ProjectAgentSkillRuntime | undefined {
-  return context.installDisabledReason ? undefined : context.agentRuntime
+  return context.installDisabledReason
+    ? getHostFallbackAgentSkillRuntime(context.agentRuntime)
+    : context.agentRuntime
 }

--- a/src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts
+++ b/src/renderer/src/components/onboarding/onboarding-feature-setup.test.ts
@@ -150,10 +150,21 @@ describe('onboarding feature setup runner', () => {
   it('falls back to the host when the selected runtime needs repair', () => {
     expect(
       getOnboardingFeatureSetupAgentRuntime({
-        agentRuntime: { runtime: 'wsl', wslDistro: 'Missing', label: 'WSL Missing' },
+        agentRuntime: {
+          runtime: 'wsl',
+          wslDistro: 'Missing',
+          hostPlatform: 'win32',
+          label: 'WSL Missing'
+        },
         installDisabledReason: 'The selected WSL distro is unavailable.'
       })
-    ).toBeUndefined()
+    ).toEqual({
+      runtime: 'host',
+      hostPlatform: 'win32',
+      runtimeEnvironmentId: null,
+      runtimeOwnershipResolved: true,
+      label: 'Windows'
+    })
   })
 
   it('uses the WSL CLI APIs for the selected distro', async () => {
@@ -186,12 +197,18 @@ describe('onboarding feature setup runner', () => {
       { browserUse: false, computerUse: false, orchestration: true, linearTickets: false },
       deps,
       {
-        agentRuntime: { runtime: 'wsl', wslDistro: 'Missing', label: 'WSL Missing' },
+        agentRuntime: {
+          runtime: 'wsl',
+          wslDistro: 'Missing',
+          hostPlatform: 'win32',
+          label: 'WSL Missing'
+        },
         installDisabledReason: 'The selected WSL distro is unavailable.'
       }
     )
 
-    expect(deps.clipboardWrites).toEqual([ORCHESTRATION_ONLY_SKILL_INSTALL_COMMAND])
+    expect(deps.clipboardWrites).toHaveLength(1)
+    expect(deps.clipboardWrites[0]).toMatch(/^cmd\.exe \/d \/s \/c /)
   })
 
   it('builds privacy-safe telemetry payloads for selected feature setup items', () => {

--- a/src/renderer/src/components/onboarding/onboarding-feature-setup.ts
+++ b/src/renderer/src/components/onboarding/onboarding-feature-setup.ts
@@ -15,6 +15,7 @@ import { e2eConfig } from '@/lib/e2e-config'
 import { showOrcaCliRegistrationPromptToast } from '@/lib/agent-skill-cli-prerequisite'
 import type { ProjectAgentSkillRuntime } from '@/lib/project-skill-runtime'
 import type { OnboardingFeatureSetupRuntimeContext } from './onboarding-feature-setup-runtime'
+import { getOnboardingFeatureSetupAgentRuntime } from './onboarding-feature-setup-runtime'
 import {
   buildSkillCommandForRuntime,
   getWslCliDistroRequest
@@ -213,9 +214,9 @@ export async function runOnboardingFeatureSetup(
   explicitDeps?: OnboardingFeatureSetupDeps,
   runtimeContext?: OnboardingFeatureSetupRuntimeContext
 ): Promise<OnboardingFeatureSetupResult> {
-  const agentRuntime = runtimeContext?.installDisabledReason
-    ? undefined
-    : runtimeContext?.agentRuntime
+  const agentRuntime = runtimeContext
+    ? getOnboardingFeatureSetupAgentRuntime(runtimeContext)
+    : undefined
   const deps = explicitDeps ?? createOnboardingFeatureSetupDeps(agentRuntime)
   const selectedIds = selectedOnboardingFeatureSetupIds(selection)
   const warnings: OnboardingFeatureSetupWarning[] = []

--- a/src/renderer/src/components/settings/AgentSkillSetupCommandTerminal.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupCommandTerminal.tsx
@@ -1,0 +1,91 @@
+import { Copy } from 'lucide-react'
+import { OnboardingInlineCommandTerminal } from '../onboarding/OnboardingInlineCommandTerminal'
+import { Button } from '../ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
+import type { SkillTerminalSnapshot } from './agent-skill-terminal-snapshot'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+
+type AgentSkillSetupCommandTerminalProps = {
+  command: string
+  onCommandFinished: (exitCode: number | null) => void
+  onCopy: () => void
+  onTerminalExit: () => void
+  snapshot: SkillTerminalSnapshot
+  terminalAriaLabel: string
+  terminalAttempt: number
+  terminalHeightPx?: number
+  terminalTitle: string
+  terminalWorktreeId: string
+  variant: 'card' | 'inline'
+}
+
+export function AgentSkillSetupCommandTerminal({
+  command,
+  onCommandFinished,
+  onCopy,
+  onTerminalExit,
+  snapshot,
+  terminalAriaLabel,
+  terminalAttempt,
+  terminalHeightPx,
+  terminalTitle,
+  terminalWorktreeId,
+  variant
+}: AgentSkillSetupCommandTerminalProps): React.JSX.Element {
+  return (
+    <div
+      className={cn(
+        'min-w-0 max-w-full overflow-hidden',
+        variant === 'card' ? 'px-5 pb-5' : 'mt-2'
+      )}
+    >
+      <div className="flex min-w-0 max-w-full items-center gap-2 overflow-hidden rounded-md border border-border bg-muted/35 px-3 py-2">
+        <code className="scrollbar-sleek min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-mono text-xs text-muted-foreground">
+          {command}
+        </code>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              className="shrink-0"
+              aria-label={translate(
+                'auto.components.settings.AgentSkillSetupPanel.copyCommandAria',
+                'Copy command'
+              )}
+              onClick={onCopy}
+            >
+              <Copy className="size-4" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="top" sideOffset={4}>
+            {translate('auto.components.settings.AgentSkillSetupPanel.ed197f59a2', 'Copy command')}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+      <OnboardingInlineCommandTerminal
+        key={terminalAttempt}
+        worktreeId={terminalWorktreeId}
+        command={command}
+        prepareCommandForShell={snapshot.prepareCommandForShell}
+        title={terminalTitle}
+        description={translate(
+          'auto.components.settings.AgentSkillSetupPanel.runCommandDescription',
+          'Press Enter to run the command.'
+        )}
+        ariaLabel={terminalAriaLabel}
+        terminalHeightPx={terminalHeightPx}
+        shellOverride={snapshot.shellOverride}
+        forceHostRuntime={snapshot.forceHostRuntime}
+        runtimeEnvironmentId={snapshot.runtimeEnvironmentId}
+        terminalTopMarginPx={8}
+        descriptionPaddingClassName="px-4 py-2"
+        autoScrollIntoView={false}
+        onTerminalExit={onTerminalExit}
+        onCommandFinished={onCommandFinished}
+      />
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.test.tsx
@@ -6,6 +6,7 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AgentSkillSetupPanel } from './AgentSkillSetupPanel'
 import { TooltipProvider } from '../ui/tooltip'
+import { useAppStore } from '@/store'
 
 const INSTALL_COMMAND = 'npx skills add https://github.com/stablyai/orca --skill orca-cli --global'
 const UPDATE_COMMAND = 'npx skills update orca-cli --global'
@@ -16,6 +17,8 @@ const mocks = vi.hoisted(() => ({
     command: string
     description: string
     shellOverride?: string
+    forceHostRuntime?: boolean
+    runtimeEnvironmentId?: string | null
     prepareCommandForShell?: (command: string, shellOverride?: string) => string
     onTerminalExit?: () => void
     onCommandFinished?: (bestEffortExitCode: number | null) => void
@@ -49,6 +52,8 @@ vi.mock('../onboarding/OnboardingInlineCommandTerminal', () => ({
     command: string
     description: string
     shellOverride?: string
+    forceHostRuntime?: boolean
+    runtimeEnvironmentId?: string | null
     prepareCommandForShell?: (command: string, shellOverride?: string) => string
     onTerminalExit?: () => void
     onCommandFinished?: (bestEffortExitCode: number | null) => void
@@ -167,6 +172,11 @@ describe('AgentSkillSetupPanel', () => {
     mocks.freshnessRefresh.mockReset()
     mocks.freshnessRefresh.mockResolvedValue(undefined)
     mocks.terminalInstanceCount = 0
+    useAppStore.setState({
+      settings: { activeRuntimeEnvironmentId: null } as never,
+      runtimeEnvironments: [],
+      runtimeEnvironmentCatalogSettled: true
+    })
     Object.defineProperty(window, 'api', {
       configurable: true,
       value: {
@@ -462,13 +472,75 @@ describe('AgentSkillSetupPanel', () => {
     )
 
     await rerenderInteractivePanel({
-      terminalRuntime: { runtime: 'host', label: 'Windows' }
+      terminalRuntime: { runtime: 'host', hostPlatform: 'win32', label: 'Windows' }
     })
 
     expect(mocks.terminalProps.at(-1)).toMatchObject({
       command: openedCommand,
+      forceHostRuntime: false,
       shellOverride: 'powershell.exe'
     })
+  })
+
+  it('pins host terminal ownership when the terminal opens', async () => {
+    await renderInteractivePanel({
+      terminalRuntime: { runtime: 'host', hostPlatform: 'win32', label: 'Windows' }
+    })
+    await clickButton('Install')
+
+    expect(mocks.terminalProps.at(-1)?.forceHostRuntime).toBe(true)
+
+    await rerenderInteractivePanel({
+      terminalRuntime: { runtime: 'wsl', wslDistro: 'Ubuntu', label: 'WSL Ubuntu' }
+    })
+
+    expect(mocks.terminalProps.at(-1)?.forceHostRuntime).toBe(true)
+  })
+
+  it('pins the exact runtime owner while setup preflight is pending', async () => {
+    let resolvePreflight: (() => void) | undefined
+    const preflight = new Promise<void>((resolve) => {
+      resolvePreflight = resolve
+    })
+    await renderInteractivePanel({
+      terminalRuntime: {
+        runtime: 'host',
+        hostPlatform: 'linux',
+        runtimeEnvironmentId: 'linux-host',
+        label: 'This device'
+      },
+      onBeforeOpenTerminal: () => preflight
+    })
+
+    await clickButton('Install')
+    useAppStore.setState({
+      settings: { activeRuntimeEnvironmentId: 'windows-host' } as never,
+      runtimeEnvironments: [{ id: 'windows-host' }] as never
+    })
+    await act(async () => {
+      resolvePreflight?.()
+      await preflight
+    })
+
+    expect(mocks.terminalProps.at(-1)?.runtimeEnvironmentId).toBe('linux-host')
+  })
+
+  it('does not start setup while runtime ownership is unresolved', async () => {
+    const onBeforeOpenTerminal = vi.fn()
+    await renderInteractivePanel({
+      terminalRuntime: {
+        runtime: 'host',
+        runtimeOwnershipResolved: false,
+        label: 'This device'
+      },
+      onBeforeOpenTerminal
+    })
+
+    expect(findButton('Install').disabled).toBe(true)
+    await clickButton('Install')
+
+    expect(onBeforeOpenTerminal).not.toHaveBeenCalled()
+    expect(mocks.terminalProps).toHaveLength(0)
   })
 
   it('captures the current runtime when retrying a failed command', async () => {
@@ -500,7 +572,7 @@ describe('AgentSkillSetupPanel', () => {
     })
     await rerenderInteractivePanel({
       terminalShellOverride: 'powershell.exe',
-      terminalRuntime: { runtime: 'host', label: 'Windows' }
+      terminalRuntime: { runtime: 'host', hostPlatform: 'win32', label: 'Windows' }
     })
 
     await clickButton('Retry')

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
@@ -1,14 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { Copy, Loader2, RefreshCw, Terminal } from 'lucide-react'
+import { Loader2, RefreshCw, Terminal } from 'lucide-react'
 import { toast } from 'sonner'
 import { IntegrationStatusPill } from '../integration-status-pill'
 import { SkillFreshnessStatusPill } from '../skills/SkillFreshnessStatusPill'
-import { OnboardingInlineCommandTerminal } from '../onboarding/OnboardingInlineCommandTerminal'
 import { AgentSkillSetupFailureNotice } from './AgentSkillSetupFailureNotice'
 import { createTerminalSnapshot, type SkillTerminalSnapshot } from './agent-skill-terminal-snapshot'
 import type { AgentSkillSetupPanelProps } from './agent-skill-setup-panel-props'
 import { Button } from '../ui/button'
-import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip'
+import { AgentSkillSetupCommandTerminal } from './AgentSkillSetupCommandTerminal'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import {
   recheckSurfacesAfterAgentSkillTerminal,
@@ -75,12 +74,13 @@ export function AgentSkillSetupPanel({
     [getPrerequisiteStatus]
   )
   const activeCommand = installed ? (installedCommand ?? command) : command
+  const runtimeOwnershipUnresolved = runtime?.runtimeOwnershipResolved === false
   // Why: the inline terminal auto-inserts when its command changes, so keep the
   // already-open terminal pinned to the command and runtime selected at click.
   const openTerminalCommand = terminalSnapshot?.copiedCommand ?? activeCommand
 
   const openSetupTerminal = (): void => {
-    if (terminalOpening || setupAttemptRunning) {
+    if (terminalOpening || setupAttemptRunning || runtimeOwnershipUnresolved) {
       return
     }
     const nextSnapshot = createTerminalSnapshot(activeCommand, shellOverride, runtime)
@@ -208,7 +208,9 @@ export function AgentSkillSetupPanel({
           variant={installVariant}
           size="sm"
           onClick={openSetupTerminal}
-          disabled={terminalOpen || installDisabled || terminalOpening}
+          disabled={
+            terminalOpen || installDisabled || terminalOpening || runtimeOwnershipUnresolved
+          }
         >
           {terminalOpening ? (
             <Loader2 className="size-3.5 animate-spin" />
@@ -239,7 +241,10 @@ export function AgentSkillSetupPanel({
           }}
           disabled={
             setupCommandFailedCode !== null
-              ? installDisabled || terminalOpening || setupAttemptRunning
+              ? installDisabled ||
+                terminalOpening ||
+                setupAttemptRunning ||
+                runtimeOwnershipUnresolved
               : loading
           }
         >
@@ -353,60 +358,19 @@ export function AgentSkillSetupPanel({
         ) : null}
       </div>
       {terminalOpen && terminalSnapshot ? (
-        <div
-          className={cn(
-            'min-w-0 max-w-full overflow-hidden',
-            variant === 'card' ? 'px-5 pb-5' : 'mt-2'
-          )}
-        >
-          <div className="flex min-w-0 max-w-full items-center gap-2 overflow-hidden rounded-md border border-border bg-muted/35 px-3 py-2">
-            <code className="scrollbar-sleek min-w-0 flex-1 overflow-x-auto whitespace-nowrap font-mono text-xs text-muted-foreground">
-              {openTerminalCommand}
-            </code>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-sm"
-                  className="shrink-0"
-                  aria-label={translate(
-                    'auto.components.settings.AgentSkillSetupPanel.copyCommandAria',
-                    'Copy command'
-                  )}
-                  onClick={() => void copyActiveCommand()}
-                >
-                  <Copy className="size-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="top" sideOffset={4}>
-                {translate(
-                  'auto.components.settings.AgentSkillSetupPanel.ed197f59a2',
-                  'Copy command'
-                )}
-              </TooltipContent>
-            </Tooltip>
-          </div>
-          <OnboardingInlineCommandTerminal
-            key={terminalAttempt}
-            worktreeId={terminalWorktreeId}
-            command={openTerminalCommand}
-            prepareCommandForShell={terminalSnapshot.prepareCommandForShell}
-            title={terminalTitle}
-            description={translate(
-              'auto.components.settings.AgentSkillSetupPanel.runCommandDescription',
-              'Press Enter to run the command.'
-            )}
-            ariaLabel={terminalAriaLabel}
-            terminalHeightPx={terminalHeightPx}
-            shellOverride={terminalSnapshot.shellOverride}
-            terminalTopMarginPx={8}
-            descriptionPaddingClassName="px-4 py-2"
-            autoScrollIntoView={false}
-            onTerminalExit={handleTerminalExit}
-            onCommandFinished={handleSetupCommandFinished}
-          />
-        </div>
+        <AgentSkillSetupCommandTerminal
+          command={openTerminalCommand}
+          onCommandFinished={handleSetupCommandFinished}
+          onCopy={() => void copyActiveCommand()}
+          onTerminalExit={handleTerminalExit}
+          snapshot={terminalSnapshot}
+          terminalAriaLabel={terminalAriaLabel}
+          terminalAttempt={terminalAttempt}
+          terminalHeightPx={terminalHeightPx}
+          terminalTitle={terminalTitle}
+          terminalWorktreeId={terminalWorktreeId}
+          variant={variant}
+        />
       ) : null}
     </div>
   )

--- a/src/renderer/src/components/settings/CliSection.test.tsx
+++ b/src/renderer/src/components/settings/CliSection.test.tsx
@@ -12,10 +12,17 @@ import { CliSection } from './CliSection'
 
 const capturedPanel = vi.hoisted(() => ({
   canUseLocalSkillFreshness: true,
+  wslRegistrationPlatforms: [] as string[],
   props: null as null | {
     command: string
     installedCommand: string
-    terminalRuntime?: { runtime: 'host' | 'wsl'; wslDistro?: string | null; label: string }
+    terminalRuntime?: {
+      runtime: 'host' | 'wsl'
+      wslDistro?: string | null
+      hostPlatform?: NodeJS.Platform
+      terminalWindowsShell?: string | null
+      label: string
+    }
     freshnessSkillName?: string
     getPrerequisiteStatus: () => Promise<unknown>
     onBeforeOpenTerminal: () => Promise<void>
@@ -47,6 +54,7 @@ capturedPanel.useInstalledAgentSkill.mockReturnValue({
 afterEach(() => {
   cleanup()
   capturedPanel.canUseLocalSkillFreshness = true
+  capturedPanel.wslRegistrationPlatforms.length = 0
   toastError.mockReset()
   vi.unstubAllGlobals()
 })
@@ -71,7 +79,8 @@ vi.mock('./CliRegistrationDialog', () => ({
 }))
 
 vi.mock('./WslCliRegistration', () => ({
-  WslCliRegistration: function WslCliRegistration() {
+  WslCliRegistration: function WslCliRegistration(props: { currentPlatform: string }) {
+    capturedPanel.wslRegistrationPlatforms.push(props.currentPlatform)
     return null
   }
 }))
@@ -81,6 +90,14 @@ describe('CliSection project runtime defaults', () => {
     const settings = getDefaultSettings('/tmp')
     renderToStaticMarkup(<CliSection currentPlatform="darwin" settings={settings} />)
     expect(capturedPanel.props?.freshnessSkillName).toBe('orca-cli')
+    expect(capturedPanel.props?.terminalRuntime).toMatchObject({
+      runtime: 'host',
+      hostPlatform: 'darwin'
+    })
+
+    renderToStaticMarkup(<CliSection settings={settings} />)
+    expect(capturedPanel.props?.terminalRuntime?.hostPlatform).toBeUndefined()
+    expect(capturedPanel.props?.command).toBe(ORCA_CLI_SKILL_INSTALL_COMMAND)
 
     capturedPanel.canUseLocalSkillFreshness = false
     renderToStaticMarkup(<CliSection currentPlatform="darwin" settings={settings} />)
@@ -145,10 +162,61 @@ describe('CliSection project runtime defaults', () => {
     expect(capturedPanel.props?.terminalRuntime).toEqual({
       runtime: 'wsl',
       wslDistro: 'Ubuntu',
+      hostPlatform: 'win32',
       label: 'WSL Ubuntu'
     })
     expect(getWslInstallStatus).toHaveBeenCalledWith({ distro: 'Ubuntu' })
     expect(getWslInstallStatus).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps registration viewer-owned and skill commands execution-host-owned', () => {
+    const settings = { ...getDefaultSettings('/tmp'), terminalWindowsShell: 'powershell.exe' }
+    renderToStaticMarkup(
+      <CliSection
+        currentPlatform="linux"
+        settings={settings}
+        executionHostRuntime={{
+          runtime: 'host',
+          hostPlatform: 'win32',
+          terminalWindowsShell: 'git-bash',
+          label: 'Windows'
+        }}
+      />
+    )
+    expect(capturedPanel.props?.command).toBe(ORCA_CLI_SKILL_INSTALL_COMMAND)
+    expect(capturedPanel.props?.terminalRuntime).toMatchObject({
+      hostPlatform: 'win32',
+      terminalWindowsShell: 'git-bash'
+    })
+    expect(capturedPanel.wslRegistrationPlatforms).toEqual([])
+
+    renderToStaticMarkup(
+      <CliSection
+        currentPlatform="win32"
+        settings={settings}
+        wslSupportedPlatform
+        executionHostRuntime={{ runtime: 'host', hostPlatform: 'linux', label: 'This device' }}
+      />
+    )
+    expect(capturedPanel.wslRegistrationPlatforms).toContain('win32')
+
+    for (const terminalWindowsShell of ['powershell.exe', undefined]) {
+      renderToStaticMarkup(
+        <CliSection
+          currentPlatform="linux"
+          settings={{ ...settings, terminalWindowsShell: 'git-bash' }}
+          executionHostRuntime={{
+            runtime: 'host',
+            hostPlatform: 'win32',
+            terminalWindowsShell,
+            label: 'Windows'
+          }}
+        />
+      )
+      expect(capturedPanel.props?.command?.startsWith('cmd.exe')).toBe(
+        terminalWindowsShell === 'powershell.exe'
+      )
+    }
   })
 
   it('renders an inline unknown PATH state without offering a mutation', async () => {

--- a/src/renderer/src/components/settings/CliSection.tsx
+++ b/src/renderer/src/components/settings/CliSection.tsx
@@ -30,49 +30,30 @@ import {
   getAgentSkillTerminalShellOverride,
   getSelectedAgentRuntime,
   getSkillDiscoveryTargetForRuntime,
-  getWslCliDistroRequest
+  getWslCliDistroRequest,
+  type LocalAgentRuntime
 } from './CliSkillRuntimeSetup'
 import { WslCliRegistration } from './WslCliRegistration'
 import { useLocalCliSkillFreshnessName } from './use-local-cli-skill-freshness-name'
 import { translate } from '@/i18n/i18n'
+import {
+  getCliFallbackCommandName,
+  getCliInstallDescription,
+  getCliRevealLabel
+} from './cli-registration-platform-copy'
 
 type CliSectionProps = {
-  currentPlatform: string
+  currentPlatform?: NodeJS.Platform
+  executionHostRuntime?: LocalAgentRuntime
   settings: GlobalSettings
   wslSupportedPlatform?: boolean
   wslAvailable?: boolean
   wslCapabilitiesLoading?: boolean
 }
 
-function getRevealLabel(platform: string): string {
-  if (platform === 'darwin') {
-    return 'Show in Finder'
-  }
-  if (platform === 'win32') {
-    return 'Show in Explorer'
-  }
-  return 'Show in File Manager'
-}
-
-function getInstallDescription(platform: string): string {
-  if (platform === 'darwin') {
-    return 'Register `orca` in /usr/local/bin.'
-  }
-  if (platform === 'linux') {
-    return 'Register `orca-ide` in ~/.local/bin.'
-  }
-  if (platform === 'win32') {
-    return 'Register `orca` in your user PATH.'
-  }
-  return 'CLI registration is not yet available on this platform.'
-}
-
-function getFallbackCommandName(platform: string): string {
-  return platform === 'linux' ? 'orca-ide' : 'orca'
-}
-
 export function CliSection({
   currentPlatform,
+  executionHostRuntime,
   settings,
   wslSupportedPlatform = false,
   wslAvailable = false,
@@ -85,8 +66,22 @@ export function CliSection({
   const mountedRef = useMountedRef()
   const agentRuntime = useMemo(
     () =>
-      getSelectedAgentRuntime(settings, wslSupportedPlatform, wslAvailable, wslCapabilitiesLoading),
-    [settings, wslAvailable, wslCapabilitiesLoading, wslSupportedPlatform]
+      executionHostRuntime ??
+      getSelectedAgentRuntime(
+        settings,
+        wslSupportedPlatform,
+        wslAvailable,
+        wslCapabilitiesLoading,
+        currentPlatform ?? null
+      ),
+    [
+      currentPlatform,
+      executionHostRuntime,
+      settings,
+      wslAvailable,
+      wslCapabilitiesLoading,
+      wslSupportedPlatform
+    ]
   )
   const cliSkillFreshnessName = useLocalCliSkillFreshnessName(agentRuntime)
   const cliSkillDiscoveryTarget = useMemo(
@@ -111,7 +106,7 @@ export function CliSection({
     agentRuntime
   )
   const cliSkillTerminalShellOverride = getAgentSkillTerminalShellOverride(
-    currentPlatform,
+    agentRuntime.hostPlatform,
     settings,
     agentRuntime
   )
@@ -162,8 +157,8 @@ export function CliSection({
   const isEnabled = status?.state === 'installed' && !pathStatusUnknown
   const isSupported = status?.supported ?? false
   const isBrowserManaged = status?.unsupportedReason === 'launch_mode_unavailable'
-  const revealLabel = getRevealLabel(currentPlatform)
-  const commandName = status?.commandName ?? getFallbackCommandName(currentPlatform)
+  const revealLabel = getCliRevealLabel(currentPlatform)
+  const commandName = status?.commandName ?? getCliFallbackCommandName(currentPlatform)
   const canRevealCommandPath =
     status?.commandPath != null && ['installed', 'stale', 'conflict'].includes(status.state)
 
@@ -263,7 +258,7 @@ export function CliSection({
                     'auto.components.settings.CliSection.d363e5929b',
                     'Checking CLI registration…'
                   )
-                : (status?.detail ?? getInstallDescription(currentPlatform))}
+                : (status?.detail ?? getCliInstallDescription(currentPlatform))}
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -400,7 +395,9 @@ export function CliSection({
         ) : null}
       </div>
 
-      <WslCliRegistration currentPlatform={currentPlatform} />
+      {wslSupportedPlatform ? (
+        <WslCliRegistration currentPlatform={currentPlatform ?? 'other'} />
+      ) : null}
 
       <CliRegistrationDialog
         busyAction={busyAction}

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
@@ -248,7 +248,7 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
     ).toBe(`${windowsNpxPreflightPrefix}${windowsNpxGuidance}) else (${installCommand})"`)
   })
 
-  it('skips the Windows preflight while a remote runtime environment is focused', () => {
+  it('keeps the Windows preflight for an authoritative remote Windows host', () => {
     const installCommand = buildAgentFeatureSkillInstallCommand(['orchestration'])
     const windowsHost = { runtime: 'host', label: 'Windows' } as const
     const previous = useAppStore.getState()
@@ -258,14 +258,17 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
     })
 
     try {
-      // Setup terminals can spawn on the focused runtime, so cmd.exe may not exist there.
-      expect(buildSkillCommandForRuntime(installCommand, windowsHost, 'win32')).toBe(installCommand)
+      expect(buildSkillCommandForRuntime(installCommand, windowsHost, 'win32')).toBe(
+        `${windowsNpxPreflightPrefix}${windowsNpxGuidance}) else (${installCommand})"`
+      )
 
-      // Extra saved environments must not reintroduce the wrapper either.
+      // Extra saved environments cannot override the selected host's platform.
       useAppStore.setState({
         runtimeEnvironments: [{ id: 'remote-linux' }, { id: 'other' }] as never
       })
-      expect(buildSkillCommandForRuntime(installCommand, windowsHost, 'win32')).toBe(installCommand)
+      expect(buildSkillCommandForRuntime(installCommand, windowsHost, 'win32')).toBe(
+        `${windowsNpxPreflightPrefix}${windowsNpxGuidance}) else (${installCommand})"`
+      )
     } finally {
       useAppStore.setState({
         settings: previous.settings,
@@ -347,17 +350,20 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
   })
 
   it('adapts bare WSL setup commands to the shell that Orca created', () => {
-    const runtime = { runtime: 'wsl', wslDistro: 'Ubuntu', label: 'WSL Ubuntu' } as const
+    const runtime = {
+      runtime: 'wsl',
+      wslDistro: 'Ubuntu',
+      hostPlatform: 'win32',
+      label: 'WSL Ubuntu'
+    } as const
     const skillCommand = 'npx skills add orchestration --global'
-    const copiedCommand = buildSkillCommandForRuntime(skillCommand, runtime, 'win32')
+    const copiedCommand = buildSkillCommandForRuntime(skillCommand, runtime)
 
     expect(copiedCommand).toBe(skillCommand)
-    expect(
-      buildSkillSetupTerminalCommand(copiedCommand, 'powershell.exe', runtime, 'win32')
-    ).toContain("wsl.exe -d 'Ubuntu'")
-    expect(buildSkillSetupTerminalCommand(copiedCommand, 'wsl.exe', runtime, 'win32')).toBe(
-      skillCommand
+    expect(buildSkillSetupTerminalCommand(copiedCommand, 'powershell.exe', runtime)).toContain(
+      "wsl.exe -d 'Ubuntu'"
     )
+    expect(buildSkillSetupTerminalCommand(copiedCommand, 'wsl.exe', runtime)).toBe(skillCommand)
     expect(
       buildSkillSetupTerminalCommand(
         'npx skills add orchestration --global',
@@ -373,6 +379,7 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
     const runtime = {
       runtime: 'wsl',
       wslDistro: 'Ubuntu',
+      hostPlatform: 'win32',
       label: 'WSL Ubuntu'
     } as const
     const copiedCommand = buildSkillCommandForRuntime(skillCommand, runtime)
@@ -386,6 +393,58 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
     expect(buildSkillSetupTerminalCommand(powershellCommand, 'wsl.exe', runtime, 'win32')).toBe(
       buildWslLoginShellCommand(skillCommand)
     )
+  })
+
+  it('uses runtime metadata for setup-terminal host platform selection', () => {
+    const installCommand = buildAgentFeatureSkillInstallCommand(['orchestration'])
+    const windowsHost = {
+      runtime: 'host',
+      hostPlatform: 'win32',
+      label: 'Windows'
+    } as const
+
+    expect(buildSkillSetupTerminalCommand(installCommand, 'powershell.exe', windowsHost)).toBe(
+      `${windowsNpxPreflightPrefix}${windowsNpxGuidance}) else (${installCommand})"`
+    )
+    expect(
+      buildSkillSetupTerminalCommand(installCommand, 'powershell.exe', {
+        runtime: 'host',
+        hostPlatform: 'linux',
+        label: 'Linux'
+      })
+    ).toBe(installCommand)
+  })
+
+  it('keeps an unknown remote host command platform-neutral', () => {
+    const installCommand = buildAgentFeatureSkillInstallCommand(['orchestration'])
+    expect(
+      buildSkillCommandForRuntime(installCommand, { runtime: 'host', label: 'Remote host' })
+    ).toBe(installCommand)
+  })
+
+  it('uses the execution host shell instead of the viewer shell', () => {
+    const installCommand = buildAgentFeatureSkillInstallCommand(['orchestration'])
+    const previous = useAppStore.getState().settings
+    useAppStore.setState({ settings: { ...previous!, terminalWindowsShell: 'git-bash' } })
+    expect(
+      buildSkillCommandForRuntime(installCommand, {
+        runtime: 'host',
+        hostPlatform: 'win32',
+        terminalWindowsShell: 'powershell.exe',
+        label: 'Windows'
+      })
+    ).toContain('cmd.exe /d /s /c')
+
+    useAppStore.setState({ settings: { ...previous!, terminalWindowsShell: 'powershell.exe' } })
+    expect(
+      buildSkillCommandForRuntime(installCommand, {
+        runtime: 'host',
+        hostPlatform: 'win32',
+        terminalWindowsShell: 'git-bash',
+        label: 'Windows'
+      })
+    ).toBe(installCommand)
+    useAppStore.setState({ settings: previous })
   })
 
   it('keeps the bare reinstall rewrite for POSIX-family Windows skill updates', () => {
@@ -495,6 +554,29 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
         true,
         false
       )
-    ).toEqual({ runtime: 'wsl', wslDistro: 'Ubuntu', label: 'WSL Ubuntu' })
+    ).toEqual({
+      runtime: 'wsl',
+      wslDistro: 'Ubuntu',
+      hostPlatform: 'win32',
+      label: 'WSL Ubuntu'
+    })
+  })
+
+  it('carries the General CLI execution-host platform into host command selection', () => {
+    const settings = {
+      ...getDefaultSettings('/tmp'),
+      localWindowsRuntimeDefault: { kind: 'windows-host' as const }
+    }
+    expect(getSelectedAgentRuntime(settings, false, false, false, 'linux')).toMatchObject({
+      runtime: 'host',
+      hostPlatform: 'linux'
+    })
+    expect(getSelectedAgentRuntime(settings, true, true, false, 'win32')).toMatchObject({
+      runtime: 'host',
+      hostPlatform: 'win32'
+    })
+    expect(
+      getSelectedAgentRuntime(settings, false, false, false, null).hostPlatform
+    ).toBeUndefined()
   })
 })

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.test.tsx
@@ -229,6 +229,25 @@ describe('CliSkillRuntimeSetup runtime helpers', () => {
     ).toBe('npx skills update orchestration --global')
   })
 
+  it('uses the selected host platform instead of the viewer platform', () => {
+    const installCommand = buildAgentFeatureSkillInstallCommand(['orchestration'])
+
+    expect(
+      buildSkillCommandForRuntime(installCommand, {
+        runtime: 'host',
+        hostPlatform: 'linux',
+        label: 'This device'
+      })
+    ).toBe(installCommand)
+    expect(
+      buildSkillCommandForRuntime(installCommand, {
+        runtime: 'host',
+        hostPlatform: 'win32',
+        label: 'Windows'
+      })
+    ).toBe(`${windowsNpxPreflightPrefix}${windowsNpxGuidance}) else (${installCommand})"`)
+  })
+
   it('skips the Windows preflight while a remote runtime environment is focused', () => {
     const installCommand = buildAgentFeatureSkillInstallCommand(['orchestration'])
     const windowsHost = { runtime: 'host', label: 'Windows' } as const

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
@@ -24,6 +24,7 @@ import { translate } from '@/i18n/i18n'
 export type LocalAgentRuntime = {
   runtime: 'host' | 'wsl'
   wslDistro?: string | null
+  hostPlatform?: NodeJS.Platform
   label: string
 }
 
@@ -81,7 +82,7 @@ export function getWslCliDistroRequest(
 export function buildSkillCommandForRuntime(
   command: string,
   runtime?: LocalAgentRuntime,
-  currentPlatform = getSkillCommandPlatform()
+  currentPlatform = getRuntimeHostPlatform(runtime)
 ): string {
   const resolvedRuntime = runtime ?? LOCAL_HOST_AGENT_RUNTIME
   const normalizedCommand = normalizeWindowsSkillUpdateCommand(
@@ -135,7 +136,7 @@ export function buildSkillSetupTerminalCommand(
   copiedCommand: string,
   effectiveShell: string | undefined,
   runtime?: LocalAgentRuntime,
-  currentPlatform = getSkillCommandPlatform()
+  currentPlatform = getRuntimeHostPlatform(runtime)
 ): string {
   // Why: the created tab is authoritative when project runtime replaces the requested shell.
   const wslNative = isWslShellName(effectiveShell)
@@ -210,6 +211,12 @@ function isSetupTerminalForcedToPowerShell(terminalShellOverride: string | undef
   return (
     Boolean(trimmedOverride) && resolveWindowsShellStartupFamily(trimmedOverride) === 'powershell'
   )
+}
+
+function getRuntimeHostPlatform(runtime?: LocalAgentRuntime): NodeJS.Platform {
+  return runtime?.runtime === 'host' && runtime.hostPlatform
+    ? runtime.hostPlatform
+    : getSkillCommandPlatform()
 }
 
 function wrapWindowsSkillCommandWithNpxPrerequisite(

--- a/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
+++ b/src/renderer/src/components/settings/CliSkillRuntimeSetup.tsx
@@ -25,6 +25,9 @@ export type LocalAgentRuntime = {
   runtime: 'host' | 'wsl'
   wslDistro?: string | null
   hostPlatform?: NodeJS.Platform
+  terminalWindowsShell?: string | null
+  runtimeEnvironmentId?: string | null
+  runtimeOwnershipResolved?: boolean
   label: string
 }
 
@@ -33,15 +36,16 @@ const LOCAL_HOST_AGENT_RUNTIME: LocalAgentRuntime = {
   label: ''
 }
 
-export function getHostRuntimeLabel(): string {
-  return navigator.userAgent.includes('Windows') ? 'Windows' : 'This device'
+export function getHostRuntimeLabel(hostPlatform?: NodeJS.Platform): string {
+  return hostPlatform === 'win32' ? 'Windows' : 'This device'
 }
 
 export function getSelectedAgentRuntime(
   settings: GlobalSettings,
   wslSupportedPlatform: boolean,
   wslAvailable: boolean,
-  wslCapabilitiesLoading: boolean
+  wslCapabilitiesLoading: boolean,
+  hostPlatform: NodeJS.Platform | null = getSkillCommandPlatform()
 ): LocalAgentRuntime {
   const defaultRuntime = normalizeGlobalWindowsRuntimeDefault(
     settings.localWindowsRuntimeDefault ??
@@ -54,12 +58,17 @@ export function getSelectedAgentRuntime(
     return {
       runtime: 'wsl',
       wslDistro: selectedDistro,
+      hostPlatform: 'win32',
       label: selectedDistro
         ? `WSL ${selectedDistro}`
         : translate('auto.components.settings.CliSkillRuntimeSetup.c47127f222', 'WSL default')
     }
   }
-  return { runtime: 'host', label: getHostRuntimeLabel() }
+  return {
+    runtime: 'host',
+    hostPlatform: hostPlatform ?? undefined,
+    label: getHostRuntimeLabel(hostPlatform ?? undefined)
+  }
 }
 
 function encodeWslLoginShellScript(command: string): string {
@@ -94,7 +103,8 @@ export function buildSkillCommandForRuntime(
     return wrapWindowsSkillCommandWithNpxPrerequisite(
       normalizedCommand,
       currentPlatform,
-      'copied-command'
+      'copied-command',
+      resolvedRuntime
     )
   }
   return normalizedCommand
@@ -103,7 +113,7 @@ export function buildSkillCommandForRuntime(
 function normalizeWindowsSkillUpdateCommand(
   command: string,
   runtime: LocalAgentRuntime,
-  currentPlatform: NodeJS.Platform
+  currentPlatform: NodeJS.Platform | undefined
 ): string {
   if (runtime.runtime === 'wsl' || currentPlatform !== 'win32') {
     return command
@@ -154,7 +164,8 @@ export function buildSkillSetupTerminalCommand(
   return wrapWindowsSkillCommandWithNpxPrerequisite(
     copiedCommand,
     currentPlatform,
-    'orca-setup-terminal'
+    'orca-setup-terminal',
+    runtime ?? LOCAL_HOST_AGENT_RUNTIME
   )
 }
 
@@ -213,27 +224,26 @@ function isSetupTerminalForcedToPowerShell(terminalShellOverride: string | undef
   )
 }
 
-function getRuntimeHostPlatform(runtime?: LocalAgentRuntime): NodeJS.Platform {
-  return runtime?.runtime === 'host' && runtime.hostPlatform
-    ? runtime.hostPlatform
-    : getSkillCommandPlatform()
+function getRuntimeHostPlatform(runtime?: LocalAgentRuntime): NodeJS.Platform | undefined {
+  if (!runtime) {
+    return getSkillCommandPlatform()
+  }
+  return runtime.hostPlatform ?? (runtime.runtime === 'wsl' ? 'win32' : undefined)
 }
 
 function wrapWindowsSkillCommandWithNpxPrerequisite(
   command: string,
-  currentPlatform: NodeJS.Platform,
-  target: SkillCommandTarget
+  currentPlatform: NodeJS.Platform | undefined,
+  target: SkillCommandTarget,
+  runtime: LocalAgentRuntime
 ): string {
   const trimmedCommand = command.trim()
   if (
     currentPlatform !== 'win32' ||
-    // Why: skill setup terminals spawn on the focused runtime environment, so a
-    // Windows client must not hand a cmd.exe command to a remote host.
-    isRemoteRuntimeEnvironmentFocused() ||
     // Why: the copied command lands in the user's configured shell, and MSYS
     // shells rewrite cmd.exe's leading /d /s /c switches into drive paths,
     // starting an interactive cmd session instead of running the payload.
-    (target === 'copied-command' && isPosixFamilyWindowsShellConfigured()) ||
+    (target === 'copied-command' && isPosixFamilyWindowsShellConfigured(runtime)) ||
     !/^npx\s+skills\s+(?:add|update)\b/i.test(trimmedCommand)
   ) {
     return command
@@ -247,18 +257,15 @@ function wrapWindowsSkillCommandWithNpxPrerequisite(
   return `cmd.exe /d /s /c "where.exe npx >nul 2>nul & if errorlevel 1 (${missingNpxGuidance}) else (${trimmedCommand})"`
 }
 
-function isPosixFamilyWindowsShellConfigured(): boolean {
+function isPosixFamilyWindowsShellConfigured(runtime: LocalAgentRuntime): boolean {
+  if ('terminalWindowsShell' in runtime) {
+    return runtime.terminalWindowsShell === undefined
+      ? true
+      : ['posix', 'unix'].includes(resolveWindowsShellStartupFamily(runtime.terminalWindowsShell))
+  }
   return ['posix', 'unix'].includes(
     resolveWindowsShellStartupFamily(useAppStore.getState().settings?.terminalWindowsShell)
   )
-}
-
-function isRemoteRuntimeEnvironmentFocused(): boolean {
-  // Why: the terminal router also weighs how many environments are saved, but
-  // that slice has no subscriber here. Read only the focused id, which every
-  // caller re-renders on: it over-skips rather than ever handing a cmd.exe
-  // command to a remote shell.
-  return Boolean(useAppStore.getState().settings?.activeRuntimeEnvironmentId?.trim())
 }
 
 function getSkillCommandPlatform(): NodeJS.Platform {
@@ -294,15 +301,14 @@ export function getSkillDiscoveryTargetForRuntime(
 }
 
 export function getAgentSkillTerminalShellOverride(
-  currentPlatform: string,
+  currentPlatform: NodeJS.Platform | undefined,
   settings: GlobalSettings,
   runtime: LocalAgentRuntime
 ): string | undefined {
-  return getProjectAgentSkillTerminalShellOverride(
-    currentPlatform as NodeJS.Platform,
-    settings,
-    runtime
-  )
+  if (!currentPlatform) {
+    return undefined
+  }
+  return getProjectAgentSkillTerminalShellOverride(currentPlatform, settings, runtime)
 }
 
 export async function ensureWslCliAvailableForAgentSkillTerminal(

--- a/src/renderer/src/components/settings/GeneralPane.cli-platform.test.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.cli-platform.test.tsx
@@ -1,0 +1,73 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultSettings } from '../../../../shared/constants'
+import { GeneralPane } from './GeneralPane'
+
+const mocks = vi.hoisted(() => ({ cliProps: [] as Record<string, unknown>[] }))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      settingsSearchQuery: '',
+      worktreeVisibilityDefaultsSupportedRuntimeEnvironmentId: undefined,
+      worktreeVisibilitySourceDefaultsSupportedRuntimeEnvironmentId: undefined
+    })
+}))
+
+vi.mock('./CliSection', () => ({
+  CliSection: (props: Record<string, unknown>) => {
+    mocks.cliProps.push(props)
+    return null
+  }
+}))
+
+vi.mock('./GeneralEditorSettingsSection', () => ({ GeneralEditorSettingsSection: () => null }))
+vi.mock('./GeneralSupportSection', () => ({ GeneralSupportSection: () => null }))
+vi.mock('./GeneralUpdateSettingsSection', () => ({ GeneralUpdateSettingsSection: () => null }))
+vi.mock('./GeneralWorkspaceSettingsSection', () => ({
+  GeneralWorkspaceSettingsSection: () => null
+}))
+vi.mock('./RecentTabOrderControl', () => ({ RecentTabOrderControl: () => null }))
+vi.mock('./SearchableSetting', () => ({ SearchableSetting: () => null }))
+vi.mock('./SettingsFormControls', () => ({
+  SettingsSubsectionHeader: () => null,
+  SettingsSwitchRow: () => null
+}))
+vi.mock('./DefaultWindowsProjectRuntimeSetting', () => ({
+  DefaultWindowsProjectRuntimeSetting: () => null
+}))
+
+describe('GeneralPane CLI platform propagation', () => {
+  beforeEach(() => {
+    mocks.cliProps.length = 0
+  })
+
+  it('keeps registration viewer-owned while skill setup receives the execution host', () => {
+    renderToStaticMarkup(
+      <GeneralPane
+        settings={getDefaultSettings('/tmp')}
+        updateSettings={vi.fn()}
+        fontSuggestions={[]}
+        viewerPlatform="win32"
+        executionHostRuntime={{
+          runtime: 'host',
+          hostPlatform: 'linux',
+          terminalWindowsShell: undefined,
+          label: 'This device'
+        }}
+        wslSupportedPlatform={false}
+      />
+    )
+
+    expect(mocks.cliProps).toContainEqual(
+      expect.objectContaining({
+        currentPlatform: 'win32',
+        executionHostRuntime: expect.objectContaining({
+          hostPlatform: 'linux',
+          terminalWindowsShell: undefined
+        }),
+        wslSupportedPlatform: false
+      })
+    )
+  })
+})

--- a/src/renderer/src/components/settings/GeneralPane.test.ts
+++ b/src/renderer/src/components/settings/GeneralPane.test.ts
@@ -9,6 +9,7 @@ import {
   updateAutoSaveDelayDraftState
 } from './GeneralPane'
 import { matchesSettingsSearch } from './settings-search'
+import { canUseViewerWindowsRuntimeSettings } from '@/lib/execution-host-command-platform'
 
 describe('GeneralPane auto-save delay drafts', () => {
   it('keeps a committed draft tied to the current persisted source while settings save is pending', () => {
@@ -71,6 +72,13 @@ describe('GeneralPane desktop platform detection', () => {
       'darwin'
     )
     expect(getDesktopPlatformFromUserAgent('Mozilla/5.0 (X11; Linux x86_64)')).toBe('other')
+  })
+})
+
+describe('General CLI platform ownership', () => {
+  it('suppresses viewer-owned Windows runtime settings only in paired web', () => {
+    expect(canUseViewerWindowsRuntimeSettings(true, true)).toBe(false)
+    expect(canUseViewerWindowsRuntimeSettings(false, true)).toBe(true)
   })
 })
 

--- a/src/renderer/src/components/settings/GeneralPane.tsx
+++ b/src/renderer/src/components/settings/GeneralPane.tsx
@@ -24,6 +24,7 @@ import { SettingsSubsectionHeader, SettingsSwitchRow } from './SettingsFormContr
 import { translate } from '@/i18n/i18n'
 import { DefaultWindowsProjectRuntimeSetting } from './DefaultWindowsProjectRuntimeSetting'
 import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
+import type { LocalAgentRuntime } from './CliSkillRuntimeSetup'
 
 export {
   createAutoSaveDelayDraftState,
@@ -87,6 +88,8 @@ type GeneralPaneProps = {
   wslAvailable?: boolean
   wslDistros?: string[]
   wslCapabilitiesLoading?: boolean
+  viewerPlatform: NodeJS.Platform
+  executionHostRuntime?: LocalAgentRuntime
 }
 
 export function GeneralPane({
@@ -98,7 +101,9 @@ export function GeneralPane({
   wslSupportedPlatform,
   wslAvailable,
   wslDistros = EMPTY_WSL_DISTROS,
-  wslCapabilitiesLoading
+  wslCapabilitiesLoading,
+  viewerPlatform,
+  executionHostRuntime
 }: GeneralPaneProps): React.JSX.Element {
   const searchQuery = useAppStore((s) => s.settingsSearchQuery)
   const sourceDefaultsSupportedRuntimeEnvironmentId = useAppStore(
@@ -208,7 +213,8 @@ export function GeneralPane({
     matchesSettingsSearch(searchQuery, getGeneralCliSearchEntries()) ? (
       <CliSection
         key="cli"
-        currentPlatform={getDesktopPlatformFromUserAgent(navigator.userAgent)}
+        currentPlatform={viewerPlatform}
+        executionHostRuntime={executionHostRuntime}
         settings={settings}
         wslSupportedPlatform={wslSupportedPlatform}
         wslAvailable={wslAvailable}

--- a/src/renderer/src/components/settings/MobileEmulatorAgentControlRow.test.tsx
+++ b/src/renderer/src/components/settings/MobileEmulatorAgentControlRow.test.tsx
@@ -1,14 +1,20 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ORCA_CLI_SKILL_INSTALL_COMMAND } from '@/lib/agent-feature-install-commands'
+import type { ProjectAgentSkillRuntime } from '@/lib/project-skill-runtime'
 import { MobileEmulatorAgentControlRow } from './MobileEmulatorAgentControlRow'
 
 const mocks = vi.hoisted(() => ({
+  agentRuntime: undefined as ProjectAgentSkillRuntime | undefined,
   canUseLocalSkillFreshness: true,
-  freshnessSkillName: undefined as string | undefined
+  command: '',
+  freshnessSkillName: undefined as string | undefined,
+  terminalRuntime: undefined as ProjectAgentSkillRuntime | undefined
 }))
 
 vi.mock('@/hooks/useActiveProjectSkillRuntime', () => ({
   useActiveProjectSkillRuntime: () => ({
+    agentRuntime: mocks.agentRuntime,
     canUseLocalSkillFreshness: mocks.canUseLocalSkillFreshness,
     terminalShellOverride: undefined
   })
@@ -33,8 +39,18 @@ vi.mock('../emulator-pane/use-mobile-emulator-agent-setup-state', () => ({
 }))
 
 vi.mock('./AgentSkillSetupPanel', () => ({
-  AgentSkillSetupPanel: ({ freshnessSkillName }: { freshnessSkillName?: string }) => {
+  AgentSkillSetupPanel: ({
+    command,
+    freshnessSkillName,
+    terminalRuntime
+  }: {
+    command: string
+    freshnessSkillName?: string
+    terminalRuntime?: ProjectAgentSkillRuntime
+  }) => {
+    mocks.command = command
     mocks.freshnessSkillName = freshnessSkillName
+    mocks.terminalRuntime = terminalRuntime
     return null
   }
 }))
@@ -44,8 +60,11 @@ vi.mock('./MobileEmulatorExamples', () => ({ MobileEmulatorExamples: () => null 
 
 describe('MobileEmulatorAgentControlRow freshness authority', () => {
   beforeEach(() => {
+    mocks.agentRuntime = undefined
     mocks.canUseLocalSkillFreshness = true
+    mocks.command = ''
     mocks.freshnessSkillName = undefined
+    mocks.terminalRuntime = undefined
   })
 
   it('exposes local freshness only for a resolved local non-WSL runtime', () => {
@@ -55,5 +74,46 @@ describe('MobileEmulatorAgentControlRow freshness authority', () => {
     mocks.canUseLocalSkillFreshness = false
     renderToStaticMarkup(<MobileEmulatorAgentControlRow />)
     expect(mocks.freshnessSkillName).toBeUndefined()
+  })
+
+  it('builds the install command for the focused execution host', () => {
+    mocks.agentRuntime = {
+      runtime: 'host',
+      hostPlatform: 'win32',
+      runtimeEnvironmentId: null,
+      runtimeOwnershipResolved: true,
+      terminalWindowsShell: 'powershell.exe',
+      label: 'Windows'
+    }
+    renderToStaticMarkup(<MobileEmulatorAgentControlRow />)
+    expect(mocks.command).toContain('cmd.exe /d /s /c')
+    expect(mocks.terminalRuntime).toMatchObject({ runtime: 'host', hostPlatform: 'win32' })
+
+    mocks.agentRuntime = { runtime: 'host', hostPlatform: 'linux', label: 'This device' }
+    renderToStaticMarkup(<MobileEmulatorAgentControlRow />)
+    expect(mocks.command).toBe(ORCA_CLI_SKILL_INSTALL_COMMAND)
+    expect(mocks.terminalRuntime).toEqual(mocks.agentRuntime)
+  })
+
+  it('routes a project WSL skill install through its Windows host', () => {
+    mocks.agentRuntime = {
+      runtime: 'wsl',
+      wslDistro: 'Ubuntu',
+      hostPlatform: 'win32',
+      terminalWindowsShell: 'powershell.exe',
+      label: 'WSL Ubuntu'
+    }
+
+    renderToStaticMarkup(<MobileEmulatorAgentControlRow />)
+
+    expect(mocks.command).toContain('cmd.exe /d /s /c')
+    expect(mocks.terminalRuntime).toEqual({
+      runtime: 'host',
+      hostPlatform: 'win32',
+      runtimeEnvironmentId: null,
+      runtimeOwnershipResolved: true,
+      terminalWindowsShell: 'powershell.exe',
+      label: 'Windows'
+    })
   })
 })

--- a/src/renderer/src/components/settings/MobileEmulatorAgentControlRow.tsx
+++ b/src/renderer/src/components/settings/MobileEmulatorAgentControlRow.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/lib/agent-skill-cli-prerequisite'
 import { cn } from '@/lib/utils'
 import { useActiveProjectSkillRuntime } from '@/hooks/useActiveProjectSkillRuntime'
+import { getHostFallbackAgentSkillRuntime } from '@/lib/project-skill-runtime'
 import { useMobileEmulatorAgentSetupState } from '../emulator-pane/use-mobile-emulator-agent-setup-state'
 import { AgentSkillSetupPanel } from './AgentSkillSetupPanel'
 import { buildSkillCommandForRuntime } from './CliSkillRuntimeSetup'
@@ -29,10 +30,20 @@ const EMULATOR_CLI_COMMANDS = [
 export function MobileEmulatorAgentControlRow(): React.JSX.Element {
   const setup = useMobileEmulatorAgentSetupState(true)
   const activeSkillRuntime = useActiveProjectSkillRuntime()
-  // Why: skill detection here scans the local host only, so keep building host
-  // commands; routing them to a WSL runtime would install where we never look.
-  const cliSkillInstallCommand = buildSkillCommandForRuntime(ORCA_CLI_SKILL_INSTALL_COMMAND)
-  const cliSkillUpdateCommand = buildSkillCommandForRuntime(ORCA_CLI_SKILL_UPDATE_COMMAND)
+  // Why: detection scans the host rather than WSL, but a focused remote host
+  // still owns the terminal command platform.
+  const commandRuntime =
+    activeSkillRuntime.agentRuntime?.runtime === 'wsl'
+      ? getHostFallbackAgentSkillRuntime(activeSkillRuntime.agentRuntime)
+      : activeSkillRuntime.agentRuntime
+  const cliSkillInstallCommand = buildSkillCommandForRuntime(
+    ORCA_CLI_SKILL_INSTALL_COMMAND,
+    commandRuntime
+  )
+  const cliSkillUpdateCommand = buildSkillCommandForRuntime(
+    ORCA_CLI_SKILL_UPDATE_COMMAND,
+    commandRuntime
+  )
 
   const handleEnableCli = async (): Promise<void> => {
     await setup.handleEnableCli()
@@ -163,6 +174,7 @@ export function MobileEmulatorAgentControlRow(): React.JSX.Element {
             terminalAriaLabel="Orca CLI skill install terminal"
             terminalWorktreeId="settings-mobile-emulator-orca-cli-skill-terminal"
             terminalShellOverride={activeSkillRuntime.terminalShellOverride}
+            terminalRuntime={commandRuntime}
             installed={setup.cliSkillInstalled}
             loading={setup.cliSkillLoading}
             error={setup.cliSkillError}

--- a/src/renderer/src/components/settings/OrchestrationPane.test.tsx
+++ b/src/renderer/src/components/settings/OrchestrationPane.test.tsx
@@ -19,6 +19,21 @@ const mocks = vi.hoisted(() => ({
   skillInstalled: true
 }))
 
+vi.mock('@/hooks/useActiveProjectSkillRuntime', () => ({
+  useActiveProjectSkillRuntime: () => ({
+    agentRuntime: {
+      hostPlatform: 'win32',
+      label: 'Windows',
+      runtime: 'host',
+      runtimeEnvironmentId: null,
+      runtimeOwnershipResolved: true
+    },
+    canUseLocalSkillFreshness: true,
+    executionHostPlatform: 'win32',
+    installDisabledReason: null
+  })
+}))
+
 vi.mock('./AgentSkillSetupPanel', () => ({
   AgentSkillSetupPanel: (
     props: Record<string, unknown> & { actionHint?: ReactNode; footer?: ReactNode }

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -38,6 +38,7 @@ import {
   parseExecutionHostId
 } from '../../../../shared/execution-host'
 import { GeneralPane } from './GeneralPane'
+import { canUseViewerWindowsRuntimeSettings } from '@/lib/execution-host-command-platform'
 import { BrowserPane } from './BrowserPane'
 import { AppearancePane } from './AppearancePane'
 import { InputPane } from './InputPane'
@@ -1254,7 +1255,10 @@ function Settings(): React.JSX.Element {
                     <AgentsPane
                       settings={settings}
                       updateSettings={updateSettings}
-                      wslSupportedPlatform={localWslSupportedPlatform}
+                      wslSupportedPlatform={canUseViewerWindowsRuntimeSettings(
+                        isWebClient,
+                        localWslSupportedPlatform
+                      )}
                       wslAvailable={localWindowsRuntimeCapabilities.wslAvailable}
                       wslDistros={localWindowsRuntimeCapabilities.wslDistros}
                       wslCapabilitiesLoading={localWindowsRuntimeCapabilities.isLoading}
@@ -1396,10 +1400,15 @@ function Settings(): React.JSX.Element {
                       updateSettingsOrThrow={updateSettingsOrThrow}
                       fontSuggestions={terminalFontSuggestions}
                       onRequestFontSuggestions={requestFontSuggestions}
-                      wslSupportedPlatform={localWslSupportedPlatform}
+                      wslSupportedPlatform={canUseViewerWindowsRuntimeSettings(
+                        isWebClient,
+                        localWslSupportedPlatform
+                      )}
                       wslAvailable={localWindowsRuntimeCapabilities.wslAvailable}
                       wslDistros={localWindowsRuntimeCapabilities.wslDistros}
                       wslCapabilitiesLoading={localWindowsRuntimeCapabilities.isLoading}
+                      viewerPlatform={isWindows ? 'win32' : isMac ? 'darwin' : 'linux'}
+                      executionHostRuntime={activeSkillRuntime.agentRuntime}
                     />
                   ) : null}
                 </SettingsSection>

--- a/src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts
+++ b/src/renderer/src/components/settings/agent-skill-installed-command-callers.test.ts
@@ -85,9 +85,10 @@ const updateCapableCallers = new Map<string, readonly string[]>([
       'ORCA_CLI_SKILL_UPDATE_COMMAND',
       'installedCommand={cliSkillUpdateCommand}',
       'terminalShellOverride={activeSkillRuntime.terminalShellOverride}',
-      // Detection here scans the local host only, so the command must stay host-built.
-      'buildSkillCommandForRuntime(ORCA_CLI_SKILL_INSTALL_COMMAND)',
-      'buildSkillCommandForRuntime(ORCA_CLI_SKILL_UPDATE_COMMAND)'
+      'terminalRuntime={commandRuntime}',
+      'getHostFallbackAgentSkillRuntime(activeSkillRuntime.agentRuntime)',
+      'ORCA_CLI_SKILL_INSTALL_COMMAND,',
+      'ORCA_CLI_SKILL_UPDATE_COMMAND,'
     ]
   ]
 ])
@@ -96,10 +97,11 @@ const installOnlyCallers = new Map<string, readonly string[]>([
   [
     'src/renderer/src/components/emulator-pane/MobileEmulatorAgentSetupGuideSteps.tsx',
     [
-      // Detection here scans the local host only, so the command must stay host-built.
-      'buildSkillCommandForRuntime(ORCA_CLI_SKILL_INSTALL_COMMAND)',
+      'getHostFallbackAgentSkillRuntime(activeSkillRuntime.agentRuntime)',
+      'ORCA_CLI_SKILL_INSTALL_COMMAND,',
       'command={skillInstallCommand}',
       'terminalShellOverride={activeSkillRuntime.terminalShellOverride}',
+      'terminalRuntime={commandRuntime}',
       'showInstallWhenInstalled={!setup.cliSkillInstalled}'
     ]
   ]
@@ -179,9 +181,7 @@ describe('AgentSkillSetupPanel installed-command call sites', () => {
     expect(source).not.toContain('command={ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND}')
     // This terminal auto-pastes with no install gate, so a repair-required runtime
     // must fall back to the host rather than skip the Windows npx preflight.
-    expect(source).toContain(
-      'activeSkillRuntime.installDisabledReason ? undefined : activeSkillRuntime.agentRuntime'
-    )
+    expect(source).toContain('getHostFallbackAgentSkillRuntime(activeSkillRuntime.agentRuntime)')
   })
 
   it('keeps client freshness behind resolved local runtime authority', () => {

--- a/src/renderer/src/components/settings/agent-skill-terminal-snapshot.ts
+++ b/src/renderer/src/components/settings/agent-skill-terminal-snapshot.ts
@@ -3,6 +3,8 @@ import { buildSkillSetupTerminalCommand } from './CliSkillRuntimeSetup'
 
 export type SkillTerminalSnapshot = {
   copiedCommand: string
+  forceHostRuntime: boolean
+  runtimeEnvironmentId?: string | null
   prepareCommandForShell: (command: string, effectiveShell: string | undefined) => string
   shellOverride: string | undefined
 }
@@ -15,6 +17,10 @@ export function createTerminalSnapshot(
   const pinnedRuntime = runtime ? { ...runtime } : undefined
   return {
     copiedCommand,
+    forceHostRuntime: pinnedRuntime?.runtime === 'host',
+    ...(pinnedRuntime?.runtimeEnvironmentId !== undefined
+      ? { runtimeEnvironmentId: pinnedRuntime.runtimeEnvironmentId }
+      : {}),
     prepareCommandForShell: (command, effectiveShell) =>
       buildSkillSetupTerminalCommand(command, effectiveShell, pinnedRuntime),
     shellOverride

--- a/src/renderer/src/components/settings/cli-registration-platform-copy.ts
+++ b/src/renderer/src/components/settings/cli-registration-platform-copy.ts
@@ -1,0 +1,26 @@
+export function getCliRevealLabel(platform?: string): string {
+  if (platform === 'darwin') {
+    return 'Show in Finder'
+  }
+  if (platform === 'win32') {
+    return 'Show in Explorer'
+  }
+  return 'Show in File Manager'
+}
+
+export function getCliInstallDescription(platform?: string): string {
+  if (platform === 'darwin') {
+    return 'Register `orca` in /usr/local/bin.'
+  }
+  if (platform === 'linux') {
+    return 'Register `orca-ide` in ~/.local/bin.'
+  }
+  if (platform === 'win32') {
+    return 'Register `orca` in your user PATH.'
+  }
+  return 'CLI registration is not yet available on this platform.'
+}
+
+export function getCliFallbackCommandName(platform?: string): string {
+  return platform === 'linux' ? 'orca-ide' : 'orca'
+}

--- a/src/renderer/src/components/settings/linear-agent-skill-install-cta.test.tsx
+++ b/src/renderer/src/components/settings/linear-agent-skill-install-cta.test.tsx
@@ -6,6 +6,10 @@ import type { DiscoveredSkill } from '../../../../shared/skills'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TooltipProvider } from '../ui/tooltip'
 import { LinearAgentSkillInstallCta } from './linear-agent-skill-install-cta'
+import type {
+  LocalAgentRuntime,
+  buildSkillCommandForRuntime as BuildSkillCommandForRuntime
+} from './CliSkillRuntimeSetup'
 
 const mocks = vi.hoisted(() => ({
   skillState: {
@@ -18,7 +22,25 @@ const mocks = vi.hoisted(() => ({
   useInstalledAgentSkillNames: vi.fn(),
   clipboardWrite: vi.fn(async () => {}),
   toastSuccess: vi.fn(),
-  toastError: vi.fn()
+  toastError: vi.fn(),
+  viewerPlatform: 'linux' as NodeJS.Platform,
+  activeSkillRuntime: {
+    executionHostPlatform: 'linux' as NodeJS.Platform | undefined,
+    agentRuntime: {
+      runtime: 'host' as const,
+      hostPlatform: 'linux' as NodeJS.Platform | undefined,
+      terminalWindowsShell: undefined as string | null | undefined,
+      label: 'This device'
+    }
+  },
+  commandRuntimes: [] as (
+    | { hostPlatform?: NodeJS.Platform; terminalWindowsShell?: string | null }
+    | undefined
+  )[]
+}))
+
+vi.mock('@/hooks/useActiveProjectSkillRuntime', () => ({
+  useActiveProjectSkillRuntime: () => mocks.activeSkillRuntime
 }))
 
 vi.mock('@/hooks/useInstalledAgentSkills', async (importOriginal) => ({
@@ -26,9 +48,18 @@ vi.mock('@/hooks/useInstalledAgentSkills', async (importOriginal) => ({
   useInstalledAgentSkillNames: mocks.useInstalledAgentSkillNames
 }))
 
-vi.mock('./CliSkillRuntimeSetup', () => ({
-  buildSkillCommandForRuntime: (command: string) => command
-}))
+vi.mock('./CliSkillRuntimeSetup', async (importOriginal) => {
+  const actual = await importOriginal<{
+    buildSkillCommandForRuntime: typeof BuildSkillCommandForRuntime
+  }>()
+  return {
+    ...actual,
+    buildSkillCommandForRuntime: (command: string, runtime?: LocalAgentRuntime) => {
+      mocks.commandRuntimes.push(runtime)
+      return actual.buildSkillCommandForRuntime(command, runtime)
+    }
+  }
+})
 
 vi.mock('sonner', () => ({
   toast: { success: mocks.toastSuccess, error: mocks.toastError }
@@ -88,9 +119,17 @@ describe('LinearAgentSkillInstallCta', () => {
     mocks.clipboardWrite.mockClear()
     mocks.toastSuccess.mockClear()
     mocks.toastError.mockClear()
+    mocks.commandRuntimes.length = 0
+    mocks.viewerPlatform = 'linux'
+    mocks.activeSkillRuntime.executionHostPlatform = 'linux'
+    mocks.activeSkillRuntime.agentRuntime.hostPlatform = 'linux'
+    mocks.activeSkillRuntime.agentRuntime.terminalWindowsShell = undefined
     Object.defineProperty(window, 'api', {
       configurable: true,
-      value: { ui: { writeClipboardText: mocks.clipboardWrite } }
+      value: {
+        platform: { get: () => ({ platform: mocks.viewerPlatform }) },
+        ui: { writeClipboardText: mocks.clipboardWrite }
+      }
     })
   })
 
@@ -104,6 +143,7 @@ describe('LinearAgentSkillInstallCta', () => {
     container?.remove()
     container = null
     Reflect.deleteProperty(window, 'api')
+    delete (window as unknown as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__
   })
 
   it('shows the install command and explanation when the skill is missing', async () => {
@@ -118,6 +158,74 @@ describe('LinearAgentSkillInstallCta', () => {
     expect(rendered.textContent).toContain(
       'npx skills add https://github.com/stablyai/orca --skill orca-linear --global'
     )
+  })
+
+  it('uses paired host platform rather than viewer platform', async () => {
+    mocks.viewerPlatform = 'win32'
+    ;(window as unknown as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = true
+    await renderCta()
+
+    expect(mocks.commandRuntimes.at(-1)).toMatchObject({ hostPlatform: 'linux' })
+  })
+
+  it('uses saved runtime platform rather than viewer platform', async () => {
+    mocks.viewerPlatform = 'win32'
+    await renderCta({
+      settings: { activeRuntimeEnvironmentId: 'linux-host', terminalWindowsShell: '' }
+    })
+
+    expect(mocks.commandRuntimes.at(-1)).toMatchObject({ hostPlatform: 'linux' })
+  })
+
+  it('uses saved Windows host shell truth instead of the viewer shell', async () => {
+    mocks.viewerPlatform = 'win32'
+    mocks.activeSkillRuntime.executionHostPlatform = 'win32'
+    mocks.activeSkillRuntime.agentRuntime.hostPlatform = 'win32'
+    mocks.activeSkillRuntime.agentRuntime.terminalWindowsShell = 'git-bash'
+
+    const rendered = await renderCta({
+      settings: {
+        activeRuntimeEnvironmentId: 'windows-host',
+        terminalWindowsShell: 'powershell.exe'
+      }
+    })
+
+    expect(rendered.textContent).toContain('npx skills add')
+    expect(rendered.textContent).not.toContain('cmd.exe')
+    expect(mocks.commandRuntimes.at(-1)).toMatchObject({ terminalWindowsShell: 'git-bash' })
+  })
+
+  it('keeps old Windows host shell truth neutral', async () => {
+    mocks.viewerPlatform = 'win32'
+    mocks.activeSkillRuntime.executionHostPlatform = 'win32'
+    mocks.activeSkillRuntime.agentRuntime.hostPlatform = 'win32'
+    mocks.activeSkillRuntime.agentRuntime.terminalWindowsShell = undefined
+
+    const rendered = await renderCta({
+      settings: {
+        activeRuntimeEnvironmentId: 'windows-host',
+        terminalWindowsShell: 'powershell.exe'
+      }
+    })
+
+    expect(rendered.textContent).toContain('npx skills add')
+    expect(rendered.textContent).not.toContain('cmd.exe')
+  })
+
+  it('wraps for the saved Windows host PowerShell despite viewer Git Bash', async () => {
+    mocks.viewerPlatform = 'win32'
+    mocks.activeSkillRuntime.executionHostPlatform = 'win32'
+    mocks.activeSkillRuntime.agentRuntime.hostPlatform = 'win32'
+    mocks.activeSkillRuntime.agentRuntime.terminalWindowsShell = 'powershell.exe'
+
+    const rendered = await renderCta({
+      settings: {
+        activeRuntimeEnvironmentId: 'windows-host',
+        terminalWindowsShell: 'git-bash'
+      }
+    })
+
+    expect(rendered.textContent).toContain('cmd.exe /d /s /c')
   })
 
   it('copies the install command to the clipboard', async () => {

--- a/src/renderer/src/components/settings/linear-agent-skill-install-cta.tsx
+++ b/src/renderer/src/components/settings/linear-agent-skill-install-cta.tsx
@@ -17,8 +17,6 @@ import { getLinearAgentSkillUpdateCommand } from '@/lib/linear-agent-skill-updat
 import { cn } from '@/lib/utils'
 import { getLinearAgentSkillSetupInlineRuntimeCopy } from '../sidebar/linear-agent-skill-setup-copy'
 import {
-  getCurrentPlatform,
-  getLinearPromptAgentRuntime,
   getLinearPromptSkillDiscoveryTarget,
   type LinearAgentSkillPromptSettings
 } from '../sidebar/linear-agent-skill-runtime'
@@ -28,6 +26,7 @@ import {
   useIntegrationSubordinateRowClass
 } from './integration-card-presentation'
 import { translate } from '@/i18n/i18n'
+import { useLinearSkillCommandRuntime } from '../sidebar/use-linear-skill-command-runtime'
 
 type LinearAgentSkillInstallCtaProps = {
   settings: LinearAgentSkillPromptSettings | null | undefined
@@ -42,10 +41,10 @@ export function LinearAgentSkillInstallCta({
   // Why: mirror the sidebar setup prompt's runtime resolution so both surfaces
   // agree on which machine (host vs. WSL distro) is scanned and installed to.
   const remote = Boolean(settings?.activeRuntimeEnvironmentId?.trim())
-  const agentRuntime = useMemo(
-    () => getLinearPromptAgentRuntime(settings, getCurrentPlatform(), remote),
-    [remote, settings]
-  )
+  const { agentRuntime } = useLinearSkillCommandRuntime({
+    remote,
+    settings
+  })
   const skillDiscoveryTarget = useMemo(
     () => getLinearPromptSkillDiscoveryTarget(agentRuntime),
     [agentRuntime]

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.test.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.test.tsx
@@ -50,7 +50,12 @@ const mocks = vi.hoisted(() => ({
   getWslCliStatus: vi.fn(),
   ensureCli: vi.fn(async () => null as CliInstallStatus | null),
   ensureWslCli: vi.fn(async () => null as CliInstallStatus | null),
-  panelProps: [] as Record<string, unknown>[]
+  panelProps: [] as Record<string, unknown>[],
+  activeSkillRuntime: { executionHostPlatform: 'linux' as NodeJS.Platform | undefined }
+}))
+
+vi.mock('@/hooks/useActiveProjectSkillRuntime', () => ({
+  useActiveProjectSkillRuntime: () => mocks.activeSkillRuntime
 }))
 
 vi.mock('@/hooks/useInstalledAgentSkills', async (importOriginal) => ({
@@ -66,10 +71,7 @@ vi.mock('@/lib/agent-skill-cli-prerequisite', () => ({
 }))
 
 vi.mock('../settings/CliSkillRuntimeSetup', () => ({
-  buildSkillCommandForRuntime: (
-    command: string,
-    _runtime: { runtime: string; wslDistro?: string | null }
-  ) => command,
+  buildSkillCommandForRuntime: (command: string) => command,
   ensureWslCliAvailableForAgentSkillTerminal: mocks.ensureWslCli,
   getWslCliDistroRequest: (runtime?: { runtime: string; wslDistro?: string | null }) =>
     runtime?.runtime === 'wsl' && runtime.wslDistro?.trim()
@@ -211,8 +213,7 @@ describe('LinearAgentSkillSetupPrompt', () => {
     mocks.getWslCliStatus.mockResolvedValue(
       cliStatus({ state: 'not_installed', pathConfigured: false })
     )
-    mocks.ensureCli.mockClear()
-    mocks.ensureWslCli.mockClear()
+    ;[mocks.ensureCli, mocks.ensureWslCli].forEach((ensureCli) => ensureCli.mockClear())
     mocks.panelProps.length = 0
     installLocalStorageShim()
     window.localStorage.clear()
@@ -916,7 +917,6 @@ describe('LinearAgentSkillSetupPrompt', () => {
   it('permanently dismisses the modal-only prompt when requested', async () => {
     await renderPrompt({ linked: true, remote: false, surface: 'modal' })
 
-    // Why: permanent dismiss is now an EyeOff icon button (aria-label, no text).
     const dismissButton = document.body.querySelector<HTMLButtonElement>(
       'button[aria-label="Don\'t show again"]'
     )

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.tsx
@@ -37,8 +37,6 @@ import {
   useLinearAgentSkillSetupReminderToast
 } from './linear-agent-skill-setup-reminder-toast'
 import {
-  getCurrentPlatform,
-  getLinearPromptAgentRuntime,
   getLinearPromptSetupCheckIdentity,
   getLinearPromptSkillDiscoveryTarget,
   getLinearPromptTerminalShellOverride,
@@ -47,6 +45,7 @@ import {
   type LinearAgentSkillPromptSettings
 } from './linear-agent-skill-runtime'
 import { translate } from '@/i18n/i18n'
+import { useLinearSkillCommandRuntime } from './use-linear-skill-command-runtime'
 
 const LinearAgentSkillSetupDialog = lazyWithRetry(() => import('./LinearAgentSkillSetupDialog'), {
   reloadKey: 'linear-agent-skill-setup-dialog'
@@ -76,18 +75,20 @@ export function LinearAgentSkillSetupPrompt({
   surface = 'inline',
   settings,
   projectRuntime,
-  currentPlatform = getCurrentPlatform(),
+  currentPlatform,
   className
 }: LinearAgentSkillSetupPromptProps): React.JSX.Element | null {
+  const { agentRuntime, executionHostPlatform } = useLinearSkillCommandRuntime({
+    currentPlatform,
+    projectRuntime,
+    remote,
+    settings
+  })
   const [cliStatus, setCliStatus] = useState<CliInstallStatus | null>(null)
   const [cliLoading, setCliLoading] = useState(linked)
   const [setupDialogOpen, setSetupDialogOpen] = useState(false)
   const [setupCheckResult, setSetupCheckResult] = useState<SetupCheckResult>('idle')
   const [activeSetupCheckIdentity, setActiveSetupCheckIdentity] = useState<string | null>(null)
-  const agentRuntime = useMemo(
-    () => getLinearPromptAgentRuntime(settings, currentPlatform, remote, projectRuntime),
-    [currentPlatform, projectRuntime, remote, settings]
-  )
   const setupCheckIdentity = useMemo(
     () =>
       getLinearPromptSetupCheckIdentity({
@@ -134,7 +135,7 @@ export function LinearAgentSkillSetupPrompt({
     [agentRuntime, skill.installed, skill.skills]
   )
   const terminalShellOverride = getLinearPromptTerminalShellOverride(
-    currentPlatform,
+    executionHostPlatform,
     settings,
     agentRuntime
   )

--- a/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.update-command.test.tsx
+++ b/src/renderer/src/components/sidebar/LinearAgentSkillSetupPrompt.update-command.test.tsx
@@ -21,7 +21,20 @@ const mocks = vi.hoisted(() => ({
   },
   useInstalledAgentSkillNames: vi.fn(),
   getCliStatus: vi.fn(),
-  panelProps: [] as Record<string, unknown>[]
+  panelProps: [] as Record<string, unknown>[],
+  activeSkillRuntime: {
+    executionHostPlatform: 'linux' as NodeJS.Platform | undefined,
+    agentRuntime: {
+      runtime: 'host' as const,
+      hostPlatform: 'linux' as NodeJS.Platform | undefined,
+      terminalWindowsShell: undefined as string | null | undefined,
+      label: 'This device'
+    }
+  }
+}))
+
+vi.mock('@/hooks/useActiveProjectSkillRuntime', () => ({
+  useActiveProjectSkillRuntime: () => mocks.activeSkillRuntime
 }))
 
 vi.mock('@/hooks/useInstalledAgentSkills', async (importOriginal) => ({
@@ -122,9 +135,15 @@ describe('LinearAgentSkillSetupPrompt update command', () => {
     mocks.getCliStatus.mockReset()
     mocks.getCliStatus.mockResolvedValue(cliStatus())
     mocks.panelProps.length = 0
+    mocks.activeSkillRuntime.executionHostPlatform = 'linux'
+    mocks.activeSkillRuntime.agentRuntime.hostPlatform = 'linux'
+    mocks.activeSkillRuntime.agentRuntime.terminalWindowsShell = undefined
     Object.defineProperty(window, 'api', {
       configurable: true,
-      value: { cli: { getInstallStatus: mocks.getCliStatus } }
+      value: {
+        cli: { getInstallStatus: mocks.getCliStatus },
+        platform: { get: () => ({ platform: 'win32' }) }
+      }
     })
     Object.defineProperty(window, 'localStorage', {
       configurable: true,
@@ -178,5 +197,20 @@ describe('LinearAgentSkillSetupPrompt update command', () => {
     expect(mocks.panelProps.at(-1)).toEqual(
       expect.objectContaining({ installedCommand: 'npx skills update orca-linear --global' })
     )
+  })
+
+  it('uses the paired execution-host platform for the setup terminal', async () => {
+    ;(window as unknown as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = true
+
+    await renderPrompt()
+
+    expect(mocks.panelProps.at(-1)?.terminalRuntime).toEqual(
+      expect.objectContaining({
+        hostPlatform: 'linux',
+        runtime: 'host',
+        terminalWindowsShell: undefined
+      })
+    )
+    delete (window as unknown as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__
   })
 })

--- a/src/renderer/src/components/sidebar/linear-agent-skill-runtime.shell-override.test.ts
+++ b/src/renderer/src/components/sidebar/linear-agent-skill-runtime.shell-override.test.ts
@@ -1,7 +1,49 @@
 import { describe, expect, it } from 'vitest'
-import { getLinearPromptTerminalShellOverride } from './linear-agent-skill-runtime'
+import {
+  getLinearPromptAgentRuntime,
+  getLinearPromptTerminalShellOverride,
+  resolveLinearSkillCommandPlatform
+} from './linear-agent-skill-runtime'
 
 const hostRuntime = { runtime: 'host', label: 'Windows' } as const
+
+describe('resolveLinearSkillCommandPlatform', () => {
+  it('keeps local UI viewer-owned and remote commands execution-host-owned', () => {
+    expect(
+      resolveLinearSkillCommandPlatform({
+        executionHostPlatform: 'linux',
+        remote: false,
+        webClient: false,
+        viewerPlatform: 'win32'
+      })
+    ).toBe('win32')
+    for (const remote of [false, true]) {
+      expect(
+        resolveLinearSkillCommandPlatform({
+          executionHostPlatform: 'linux',
+          remote,
+          webClient: !remote,
+          viewerPlatform: 'win32'
+        })
+      ).toBe('linux')
+    }
+  })
+
+  it('keeps unknown remote truth neutral and respects explicit test/platform ownership', () => {
+    expect(
+      resolveLinearSkillCommandPlatform({ remote: true, webClient: false, viewerPlatform: 'win32' })
+    ).toBeUndefined()
+    expect(
+      resolveLinearSkillCommandPlatform({
+        explicitPlatform: 'darwin',
+        executionHostPlatform: 'linux',
+        remote: true,
+        webClient: false,
+        viewerPlatform: 'win32'
+      })
+    ).toBe('darwin')
+  })
+})
 
 describe('getLinearPromptTerminalShellOverride', () => {
   // Why: this prompt pastes the same generated Windows command as the settings
@@ -29,5 +71,59 @@ describe('getLinearPromptTerminalShellOverride', () => {
         hostRuntime
       )
     ).toBeUndefined()
+  })
+})
+
+describe('getLinearPromptAgentRuntime', () => {
+  it('carries the command owner platform for host and WSL runtimes', () => {
+    expect(getLinearPromptAgentRuntime(null, 'linux', true)).toMatchObject({
+      runtime: 'host',
+      hostPlatform: 'linux'
+    })
+    expect(
+      getLinearPromptAgentRuntime(
+        { localAgentRuntime: 'wsl', terminalWindowsShell: 'powershell.exe' },
+        'win32',
+        false
+      )
+    ).toMatchObject({
+      runtime: 'wsl',
+      hostPlatform: 'win32'
+    })
+  })
+
+  it('preserves complete execution-host shell authority', () => {
+    const executionHostRuntime = {
+      runtime: 'host' as const,
+      hostPlatform: 'win32' as const,
+      terminalWindowsShell: 'git-bash',
+      label: 'Windows'
+    }
+
+    expect(getLinearPromptAgentRuntime(null, 'linux', true, undefined, executionHostRuntime)).toBe(
+      executionHostRuntime
+    )
+  })
+
+  it('keeps an explicit project WSL target ahead of active host metadata', () => {
+    expect(
+      getLinearPromptAgentRuntime(
+        null,
+        'win32',
+        false,
+        {
+          status: 'resolved',
+          runtime: {
+            kind: 'wsl',
+            hostPlatform: 'wsl',
+            projectId: 'project-1',
+            distro: 'Fedora',
+            reason: 'project-override',
+            cacheKey: 'wsl:Fedora'
+          }
+        },
+        { runtime: 'host', hostPlatform: 'linux', label: 'This device' }
+      )
+    ).toMatchObject({ runtime: 'wsl', wslDistro: 'Fedora', hostPlatform: 'win32' })
   })
 })

--- a/src/renderer/src/components/sidebar/linear-agent-skill-runtime.ts
+++ b/src/renderer/src/components/sidebar/linear-agent-skill-runtime.ts
@@ -16,29 +16,45 @@ export type LinearAgentSkillPromptSettings = Pick<
 >
 
 export function getCurrentPlatform(): NodeJS.Platform {
-  if (navigator.userAgent.includes('Windows')) {
-    return 'win32'
-  }
-  return navigator.userAgent.includes('Linux') ? 'linux' : 'darwin'
+  const platform = window.api?.platform?.get?.()?.platform
+  return platform === 'win32' || platform === 'linux' ? platform : 'darwin'
+}
+
+export function resolveLinearSkillCommandPlatform(args: {
+  explicitPlatform?: NodeJS.Platform
+  executionHostPlatform?: NodeJS.Platform
+  remote: boolean
+  webClient: boolean
+  viewerPlatform: NodeJS.Platform
+}): NodeJS.Platform | undefined {
+  return (
+    args.explicitPlatform ??
+    (args.remote || args.webClient ? args.executionHostPlatform : args.viewerPlatform)
+  )
 }
 
 export function getLinearPromptAgentRuntime(
   settings: LinearAgentSkillPromptSettings | null | undefined,
-  currentPlatform: NodeJS.Platform,
+  currentPlatform: NodeJS.Platform | undefined,
   remote: boolean,
-  projectRuntime?: ProjectExecutionRuntimeResolution
+  projectRuntime?: ProjectExecutionRuntimeResolution,
+  executionHostRuntime?: LocalAgentRuntime
 ): LocalAgentRuntime {
+  const resolvedProjectRuntime = getProjectAgentRuntime(projectRuntime, currentPlatform)
+  if (resolvedProjectRuntime) {
+    return resolvedProjectRuntime
+  }
+  if (executionHostRuntime) {
+    return executionHostRuntime
+  }
   if (remote) {
     // Why: this prompt opens a local terminal; remote environments need their
     // own setup even when local agent discovery prefers WSL.
     return {
       runtime: 'host',
+      hostPlatform: currentPlatform,
       label: currentPlatform === 'win32' ? 'Windows' : 'This device'
     }
-  }
-  const resolvedProjectRuntime = getProjectAgentRuntime(projectRuntime, currentPlatform)
-  if (resolvedProjectRuntime) {
-    return resolvedProjectRuntime
   }
   const selectedRuntime = settings?.localAgentRuntime ?? 'host'
   if (currentPlatform === 'win32' && selectedRuntime === 'wsl') {
@@ -46,6 +62,7 @@ export function getLinearPromptAgentRuntime(
     return {
       runtime: 'wsl',
       wslDistro: selectedDistro,
+      hostPlatform: 'win32',
       label: selectedDistro
         ? `WSL ${selectedDistro}`
         : translate('auto.components.sidebar.LinearAgentSkillSetupPrompt.wslLabel', 'WSL default')
@@ -53,13 +70,14 @@ export function getLinearPromptAgentRuntime(
   }
   return {
     runtime: 'host',
+    hostPlatform: currentPlatform,
     label: currentPlatform === 'win32' ? 'Windows' : 'This device'
   }
 }
 
 function getProjectAgentRuntime(
   projectRuntime: ProjectExecutionRuntimeResolution | undefined,
-  currentPlatform: NodeJS.Platform
+  currentPlatform: NodeJS.Platform | undefined
 ): LocalAgentRuntime | null {
   if (!projectRuntime) {
     return null
@@ -74,6 +92,7 @@ function getProjectAgentRuntime(
   }
   return {
     runtime: 'host',
+    hostPlatform: currentPlatform,
     label: currentPlatform === 'win32' ? 'Windows' : 'This device'
   }
 }
@@ -82,6 +101,7 @@ function getWslAgentRuntime(distro: string | null): LocalAgentRuntime {
   return {
     runtime: 'wsl',
     wslDistro: distro,
+    hostPlatform: 'win32',
     label: distro
       ? `WSL ${distro}`
       : translate('auto.components.sidebar.LinearAgentSkillSetupPrompt.wslLabel', 'WSL default')
@@ -89,10 +109,13 @@ function getWslAgentRuntime(distro: string | null): LocalAgentRuntime {
 }
 
 export function getLinearPromptTerminalShellOverride(
-  currentPlatform: NodeJS.Platform,
+  currentPlatform: NodeJS.Platform | undefined,
   settings: LinearAgentSkillPromptSettings | null | undefined,
   runtime: LocalAgentRuntime
 ): string | undefined {
+  if (!currentPlatform) {
+    return undefined
+  }
   return getProjectAgentSkillTerminalShellOverride(currentPlatform, settings, runtime)
 }
 
@@ -106,6 +129,7 @@ export function getLinearPromptSetupCheckIdentity(args: {
     remote: args.remote,
     runtime: args.runtime.runtime,
     wslDistro: args.runtime.wslDistro ?? null,
+    hostPlatform: args.runtime.hostPlatform ?? null,
     projectRuntime: getProjectRuntimeIdentity(args.projectRuntime),
     activeRuntimeEnvironmentId: args.activeRuntimeEnvironmentId ?? null
   })

--- a/src/renderer/src/components/sidebar/use-linear-skill-command-runtime.ts
+++ b/src/renderer/src/components/sidebar/use-linear-skill-command-runtime.ts
@@ -1,0 +1,43 @@
+import { useMemo } from 'react'
+import type { ProjectExecutionRuntimeResolution } from '../../../../shared/project-execution-runtime'
+import { useActiveProjectSkillRuntime } from '@/hooks/useActiveProjectSkillRuntime'
+import { isWebClientLocation } from '@/lib/web-client-location'
+import {
+  getCurrentPlatform,
+  getLinearPromptAgentRuntime,
+  resolveLinearSkillCommandPlatform,
+  type LinearAgentSkillPromptSettings
+} from './linear-agent-skill-runtime'
+
+export function useLinearSkillCommandRuntime(args: {
+  currentPlatform?: NodeJS.Platform
+  projectRuntime?: ProjectExecutionRuntimeResolution
+  remote: boolean
+  settings?: LinearAgentSkillPromptSettings | null
+}): {
+  agentRuntime: ReturnType<typeof getLinearPromptAgentRuntime>
+  executionHostPlatform?: NodeJS.Platform
+} {
+  const activeSkillRuntime = useActiveProjectSkillRuntime()
+  const webClient = isWebClientLocation()
+  const executionHostPlatform = resolveLinearSkillCommandPlatform({
+    explicitPlatform: args.currentPlatform,
+    executionHostPlatform: activeSkillRuntime.executionHostPlatform,
+    remote: args.remote,
+    webClient,
+    viewerPlatform: getCurrentPlatform()
+  })
+  const executionHostRuntime = args.currentPlatform ? undefined : activeSkillRuntime.agentRuntime
+  const agentRuntime = useMemo(
+    () =>
+      getLinearPromptAgentRuntime(
+        args.settings,
+        executionHostPlatform,
+        args.remote,
+        args.projectRuntime,
+        executionHostRuntime
+      ),
+    [args.projectRuntime, args.remote, args.settings, executionHostPlatform, executionHostRuntime]
+  )
+  return { agentRuntime, executionHostPlatform }
+}

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -3535,7 +3535,11 @@ export function connectPanePty(
   // shared terminal router scopes them to their floating owner (local for the floating terminal,
   // the active runtime for setup terminals so remote skill installs land there) and returns null
   // only for a genuinely unknown/stale worktree that must fail closed (#9994).
-  const terminalWorktreeRoute = resolveTerminalWorktreeRoute(state, deps.worktreeId)
+  const terminalWorktreeRoute = resolveTerminalWorktreeRoute(
+    state,
+    deps.worktreeId,
+    tab && 'runtimeEnvironmentId' in tab ? tab.runtimeEnvironmentId : undefined
+  )
   const explicitRuntimeEnvironmentId = terminalWorktreeRoute?.runtimeEnvironmentId ?? null
   // Why: paired-web worktrees retain HUB execution identity; their runtime-scoped mirrored pane is the session-level transport owner.
   const mirroredRuntimeOwners = new Set(

--- a/src/renderer/src/hooks/useActiveProjectSkillRuntime.test.tsx
+++ b/src/renderer/src/hooks/useActiveProjectSkillRuntime.test.tsx
@@ -5,6 +5,7 @@ import { getDefaultSettings } from '../../../shared/constants'
 import { useAppStore } from '@/store'
 import {
   hasLocalSkillRuntimeAuthority,
+  resolveSkillExecutionHostPlatform,
   shouldUseLocalSkillFreshness,
   useActiveProjectSkillRuntime
 } from './useActiveProjectSkillRuntime'
@@ -34,7 +35,11 @@ describe('useActiveProjectSkillRuntime', () => {
   beforeEach(() => {
     setPlatform('win32')
     setWindowsShell('git-bash')
-    useAppStore.setState({ runtimeEnvironmentCatalogSettled: true, runtimeEnvironments: [] })
+    useAppStore.setState({
+      runtimeEnvironmentCatalogSettled: true,
+      runtimeEnvironments: [],
+      runtimeStatusByEnvironmentId: new Map()
+    })
   })
 
   afterEach(() => {
@@ -68,6 +73,96 @@ describe('useActiveProjectSkillRuntime', () => {
     expect(result.current.discoveryTarget).toBeUndefined()
   })
 
+  it('uses a remote Linux host instead of the Windows viewer platform', () => {
+    useAppStore.setState({
+      settings: {
+        ...useAppStore.getState().settings!,
+        activeRuntimeEnvironmentId: 'linux-host'
+      },
+      runtimeEnvironments: [{ id: 'linux-host' }] as never,
+      runtimeStatusByEnvironmentId: new Map([
+        ['linux-host', { checkedAt: 1, status: { hostPlatform: 'linux' } as never }]
+      ])
+    })
+    const { result } = renderHook(() => useActiveProjectSkillRuntime())
+
+    expect(result.current.agentRuntime).toMatchObject({ runtime: 'host', hostPlatform: 'linux' })
+    expect(result.current.terminalShellOverride).toBeUndefined()
+  })
+
+  it('uses a remote Windows host instead of the non-Windows viewer platform', () => {
+    setPlatform('darwin')
+    useAppStore.setState({
+      settings: {
+        ...useAppStore.getState().settings!,
+        activeRuntimeEnvironmentId: 'windows-host'
+      },
+      runtimeEnvironments: [{ id: 'windows-host' }] as never,
+      runtimeStatusByEnvironmentId: new Map([
+        ['windows-host', { checkedAt: 1, status: { hostPlatform: 'win32' } as never }]
+      ])
+    })
+    const { result } = renderHook(() => useActiveProjectSkillRuntime())
+
+    expect(result.current.agentRuntime).toMatchObject({ runtime: 'host', hostPlatform: 'win32' })
+  })
+
+  it('falls back to the viewer platform when an old remote host omits hostPlatform', () => {
+    setPlatform('darwin')
+    useAppStore.setState({
+      settings: {
+        ...useAppStore.getState().settings!,
+        activeRuntimeEnvironmentId: 'old-host'
+      },
+      runtimeEnvironments: [{ id: 'old-host' }] as never,
+      runtimeStatusByEnvironmentId: new Map([['old-host', { checkedAt: 1, status: {} as never }]])
+    })
+    const { result } = renderHook(() => useActiveProjectSkillRuntime())
+
+    expect(result.current.agentRuntime).toMatchObject({ runtime: 'host', hostPlatform: 'darwin' })
+  })
+
+  it('isolates the platform to the exact selected remote host', () => {
+    expect(
+      resolveSkillExecutionHostPlatform({
+        viewerPlatform: 'darwin',
+        runtimeTarget: { kind: 'environment', environmentId: 'linux-host' },
+        executionHostPlatform: 'linux',
+        isWebClient: false
+      })
+    ).toBe('linux')
+    expect(
+      resolveSkillExecutionHostPlatform({
+        viewerPlatform: 'darwin',
+        runtimeTarget: { kind: 'environment', environmentId: 'windows-host' },
+        executionHostPlatform: 'win32',
+        isWebClient: false
+      })
+    ).toBe('win32')
+  })
+
+  it('keeps local desktop behavior on the viewer platform', () => {
+    expect(
+      resolveSkillExecutionHostPlatform({
+        viewerPlatform: 'darwin',
+        runtimeTarget: { kind: 'local' },
+        executionHostPlatform: 'linux',
+        isWebClient: false
+      })
+    ).toBe('darwin')
+  })
+
+  it('uses the paired web host platform instead of the viewer platform', () => {
+    expect(
+      resolveSkillExecutionHostPlatform({
+        viewerPlatform: 'win32',
+        runtimeTarget: { kind: 'local' },
+        executionHostPlatform: 'linux',
+        isWebClient: true
+      })
+    ).toBe('linux')
+  })
+
   it('does not adopt the global default once a project is active', () => {
     setGlobalWslDefault('Ubuntu')
     useAppStore.setState({ activeRepoId: 'repo-1' })
@@ -88,7 +183,7 @@ describe('useActiveProjectSkillRuntime', () => {
     })
     const { result } = renderHook(() => useActiveProjectSkillRuntime())
 
-    expect(result.current.agentRuntime).toBeUndefined()
+    expect(result.current.agentRuntime).toMatchObject({ runtime: 'host', hostPlatform: 'win32' })
     expect(result.current.terminalShellOverride).toBeUndefined()
   })
 

--- a/src/renderer/src/hooks/useActiveProjectSkillRuntime.test.tsx
+++ b/src/renderer/src/hooks/useActiveProjectSkillRuntime.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { renderHook } from '@testing-library/react'
 import { getDefaultSettings } from '../../../shared/constants'
 import { useAppStore } from '@/store'
+import { buildSkillCommandForRuntime } from '@/components/settings/CliSkillRuntimeSetup'
 import {
   hasLocalSkillRuntimeAuthority,
   resolveSkillExecutionHostPlatform,
@@ -36,14 +37,20 @@ describe('useActiveProjectSkillRuntime', () => {
     setPlatform('win32')
     setWindowsShell('git-bash')
     useAppStore.setState({
+      activeRepoId: null,
+      activeWorktreeId: null,
+      projects: [],
+      repos: [],
       runtimeEnvironmentCatalogSettled: true,
       runtimeEnvironments: [],
-      runtimeStatusByEnvironmentId: new Map()
+      runtimeStatusByEnvironmentId: new Map(),
+      worktreesByRepo: {}
     })
   })
 
   afterEach(() => {
     delete (window as unknown as { api?: unknown }).api
+    delete (window as unknown as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__
   })
 
   // Why: with no local project runtime, buildSkillCommandForRuntime still emits the
@@ -62,6 +69,9 @@ describe('useActiveProjectSkillRuntime', () => {
     expect(result.current.agentRuntime).toEqual({
       runtime: 'wsl',
       wslDistro: 'Ubuntu',
+      hostPlatform: 'win32',
+      runtimeEnvironmentId: null,
+      runtimeOwnershipResolved: true,
       label: 'WSL Ubuntu'
     })
   })
@@ -86,7 +96,11 @@ describe('useActiveProjectSkillRuntime', () => {
     })
     const { result } = renderHook(() => useActiveProjectSkillRuntime())
 
-    expect(result.current.agentRuntime).toMatchObject({ runtime: 'host', hostPlatform: 'linux' })
+    expect(result.current.agentRuntime).toMatchObject({
+      runtime: 'host',
+      hostPlatform: 'linux',
+      runtimeEnvironmentId: 'linux-host'
+    })
     expect(result.current.terminalShellOverride).toBeUndefined()
   })
 
@@ -104,10 +118,34 @@ describe('useActiveProjectSkillRuntime', () => {
     })
     const { result } = renderHook(() => useActiveProjectSkillRuntime())
 
-    expect(result.current.agentRuntime).toMatchObject({ runtime: 'host', hostPlatform: 'win32' })
+    expect(result.current.agentRuntime).toMatchObject({
+      runtime: 'host',
+      hostPlatform: 'win32',
+      runtimeEnvironmentId: 'windows-host'
+    })
   })
 
-  it('falls back to the viewer platform when an old remote host omits hostPlatform', () => {
+  it('keeps a legacy Windows host shell neutral instead of borrowing viewer settings', () => {
+    setWindowsShell('git-bash')
+    useAppStore.setState({
+      settings: {
+        ...useAppStore.getState().settings!,
+        activeRuntimeEnvironmentId: 'windows-host'
+      },
+      runtimeEnvironments: [{ id: 'windows-host' }] as never,
+      runtimeStatusByEnvironmentId: new Map([
+        ['windows-host', { checkedAt: 1, status: { hostPlatform: 'win32' } as never }]
+      ])
+    })
+    const { result } = renderHook(() => useActiveProjectSkillRuntime())
+
+    expect(result.current.agentRuntime).toHaveProperty('terminalWindowsShell', undefined)
+    expect(
+      buildSkillCommandForRuntime('npx skills add owner/repo', result.current.agentRuntime)
+    ).toBe('npx skills add owner/repo')
+  })
+
+  it('keeps an old remote host platform unknown instead of borrowing the viewer', () => {
     setPlatform('darwin')
     useAppStore.setState({
       settings: {
@@ -119,7 +157,9 @@ describe('useActiveProjectSkillRuntime', () => {
     })
     const { result } = renderHook(() => useActiveProjectSkillRuntime())
 
-    expect(result.current.agentRuntime).toMatchObject({ runtime: 'host', hostPlatform: 'darwin' })
+    expect(result.current.agentRuntime).toMatchObject({ runtime: 'host' })
+    expect(result.current.agentRuntime?.hostPlatform).toBeUndefined()
+    expect(result.current.executionHostPlatform).toBeUndefined()
   })
 
   it('isolates the platform to the exact selected remote host', () => {
@@ -139,6 +179,13 @@ describe('useActiveProjectSkillRuntime', () => {
         isWebClient: false
       })
     ).toBe('win32')
+    expect(
+      resolveSkillExecutionHostPlatform({
+        viewerPlatform: 'darwin',
+        runtimeTarget: { kind: 'environment', environmentId: 'old-host' },
+        isWebClient: false
+      })
+    ).toBeUndefined()
   })
 
   it('keeps local desktop behavior on the viewer platform', () => {
@@ -161,6 +208,114 @@ describe('useActiveProjectSkillRuntime', () => {
         isWebClient: true
       })
     ).toBe('linux')
+    expect(
+      resolveSkillExecutionHostPlatform({
+        viewerPlatform: 'win32',
+        runtimeTarget: null,
+        executionHostPlatform: 'linux',
+        isWebClient: true
+      })
+    ).toBeUndefined()
+  })
+
+  it('keeps unresolved desktop ownership platform-neutral', () => {
+    expect(
+      resolveSkillExecutionHostPlatform({
+        viewerPlatform: 'darwin',
+        runtimeTarget: null,
+        executionHostPlatform: 'linux',
+        isWebClient: false
+      })
+    ).toBeUndefined()
+  })
+
+  it('publishes explicit neutral runtime metadata while ownership is unresolved', () => {
+    useAppStore.setState({ runtimeEnvironmentCatalogSettled: false })
+    const { result } = renderHook(() => useActiveProjectSkillRuntime())
+
+    expect(result.current.agentRuntime).toEqual({
+      runtime: 'host',
+      hostPlatform: undefined,
+      terminalWindowsShell: undefined,
+      runtimeOwnershipResolved: false,
+      label: 'This device'
+    })
+    expect(
+      buildSkillCommandForRuntime('npx skills add owner/repo', result.current.agentRuntime)
+    ).toBe('npx skills add owner/repo')
+  })
+
+  it('does not borrow a saved web runtime before ownership resolves', () => {
+    ;(window as unknown as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = true
+    useAppStore.setState({
+      runtimeEnvironmentCatalogSettled: false,
+      runtimeEnvironments: [{ id: 'stale-host' }] as never,
+      runtimeStatusByEnvironmentId: new Map([
+        ['stale-host', { checkedAt: 1, status: { hostPlatform: 'linux' } as never }]
+      ])
+    })
+
+    const { result } = renderHook(() => useActiveProjectSkillRuntime())
+
+    expect(result.current.executionHostPlatform).toBeUndefined()
+    expect(result.current.agentRuntime).toMatchObject({ runtimeOwnershipResolved: false })
+    expect(result.current.agentRuntime).not.toHaveProperty('runtimeEnvironmentId')
+  })
+
+  it('does not borrow viewer WSL defaults for a paired Windows host', () => {
+    ;(window as unknown as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__ = true
+    setGlobalWslDefault('Ubuntu')
+    setPlatform('darwin')
+    useAppStore.setState({
+      activeRepoId: 'repo-1',
+      activeWorktreeId: 'worktree-1',
+      projects: [] as never,
+      repos: [
+        {
+          id: 'repo-1',
+          path: 'C:\\repo',
+          executionHostId: 'runtime:windows-host'
+        }
+      ] as never,
+      settings: {
+        ...useAppStore.getState().settings!,
+        activeRuntimeEnvironmentId: 'windows-host'
+      },
+      runtimeEnvironments: [{ id: 'windows-host' }] as never,
+      runtimeStatusByEnvironmentId: new Map([
+        ['windows-host', { checkedAt: 1, status: { hostPlatform: 'win32' } as never }]
+      ]),
+      worktreesByRepo: {
+        'repo-1': [
+          {
+            id: 'worktree-1',
+            repoId: 'repo-1',
+            path: 'C:\\repo',
+            hostId: 'runtime:windows-host'
+          }
+        ]
+      } as never
+    })
+    const { result } = renderHook(() => useActiveProjectSkillRuntime())
+
+    expect(result.current.agentRuntime).toMatchObject({ runtime: 'host', hostPlatform: 'win32' })
+  })
+
+  it('keeps a disconnected remote host platform unknown', () => {
+    useAppStore.setState({
+      settings: {
+        ...useAppStore.getState().settings!,
+        activeRuntimeEnvironmentId: 'offline-host'
+      },
+      runtimeEnvironments: [{ id: 'offline-host' }] as never,
+      runtimeStatusByEnvironmentId: new Map([
+        ['offline-host', { checkedAt: 1, status: null } as never]
+      ])
+    })
+    const { result } = renderHook(() => useActiveProjectSkillRuntime())
+
+    expect(result.current.agentRuntime).toMatchObject({ runtime: 'host' })
+    expect(result.current.agentRuntime?.hostPlatform).toBeUndefined()
   })
 
   it('does not adopt the global default once a project is active', () => {
@@ -168,7 +323,10 @@ describe('useActiveProjectSkillRuntime', () => {
     useAppStore.setState({ activeRepoId: 'repo-1' })
     const { result } = renderHook(() => useActiveProjectSkillRuntime())
 
-    expect(result.current.agentRuntime).toBeUndefined()
+    expect(result.current.agentRuntime).toMatchObject({
+      runtime: 'host',
+      runtimeEnvironmentId: null
+    })
     useAppStore.setState({ activeRepoId: null })
   })
 
@@ -183,7 +341,8 @@ describe('useActiveProjectSkillRuntime', () => {
     })
     const { result } = renderHook(() => useActiveProjectSkillRuntime())
 
-    expect(result.current.agentRuntime).toMatchObject({ runtime: 'host', hostPlatform: 'win32' })
+    expect(result.current.agentRuntime).toMatchObject({ runtime: 'host' })
+    expect(result.current.agentRuntime?.hostPlatform).toBeUndefined()
     expect(result.current.terminalShellOverride).toBeUndefined()
   })
 

--- a/src/renderer/src/hooks/useActiveProjectSkillRuntime.ts
+++ b/src/renderer/src/hooks/useActiveProjectSkillRuntime.ts
@@ -9,6 +9,7 @@ import {
   getLocalProjectExecutionRuntimeContext
 } from '@/lib/local-preflight-context'
 import {
+  getHostAgentSkillRuntime,
   getProjectAgentSkillRuntime,
   getProjectAgentSkillTerminalShellOverride,
   getProjectSkillDiscoveryTarget,
@@ -16,6 +17,7 @@ import {
   type ProjectAgentSkillRuntime
 } from '@/lib/project-skill-runtime'
 import { useWindowsTerminalCapabilities } from '@/lib/windows-terminal-capabilities'
+import { isWebClientLocation } from '@/lib/web-client-location'
 import { useAppStore } from '@/store'
 
 type ActiveProjectSkillRuntime = {
@@ -27,11 +29,6 @@ type ActiveProjectSkillRuntime = {
   canUseLocalSkillFreshness: boolean
 }
 
-const EMPTY_ACTIVE_PROJECT_SKILL_RUNTIME: ActiveProjectSkillRuntime = Object.freeze({
-  installDisabledReason: null,
-  canUseLocalSkillFreshness: false
-})
-
 export function shouldUseLocalSkillFreshness(
   runtimeTarget: RuntimeClientTarget | null,
   agentRuntime?: ProjectAgentSkillRuntime
@@ -41,6 +38,21 @@ export function shouldUseLocalSkillFreshness(
 
 export function hasLocalSkillRuntimeAuthority(runtimeTarget: RuntimeClientTarget | null): boolean {
   return runtimeTarget?.kind === 'local'
+}
+
+export function resolveSkillExecutionHostPlatform(args: {
+  viewerPlatform: NodeJS.Platform
+  runtimeTarget: RuntimeClientTarget | null
+  executionHostPlatform?: NodeJS.Platform
+  isWebClient: boolean
+}): NodeJS.Platform {
+  if (args.runtimeTarget?.kind === 'environment') {
+    return args.executionHostPlatform ?? args.viewerPlatform
+  }
+  if (args.runtimeTarget?.kind === 'local' && args.isWebClient) {
+    return args.executionHostPlatform ?? args.viewerPlatform
+  }
+  return args.viewerPlatform
 }
 
 // Why: on Windows the runtime resolution is rebuilt from scratch on every
@@ -75,9 +87,29 @@ export function useActiveProjectSkillRuntime(): ActiveProjectSkillRuntime {
       worktreesByRepo: state.worktreesByRepo
     }))
   )
-  const currentPlatform = getCurrentPlatform()
-  const windowsCapabilities = useWindowsTerminalCapabilities(currentPlatform === 'win32')
   const runtimeTarget = useActiveSkillDiscoveryRuntimeTarget()
+  const viewerPlatform = getCurrentPlatform()
+  const isWebClient = isWebClientLocation()
+  const executionHostPlatform = useAppStore((state) => {
+    const environmentId =
+      runtimeTarget?.kind === 'environment'
+        ? runtimeTarget.environmentId
+        : isWebClient
+          ? state.runtimeEnvironments[0]?.id
+          : undefined
+    return environmentId
+      ? state.runtimeStatusByEnvironmentId.get(environmentId)?.status?.hostPlatform
+      : undefined
+  })
+  const currentPlatform = resolveSkillExecutionHostPlatform({
+    viewerPlatform,
+    runtimeTarget,
+    executionHostPlatform,
+    isWebClient
+  })
+  const windowsCapabilities = useWindowsTerminalCapabilities(
+    currentPlatform === 'win32' && hasLocalSkillRuntimeAuthority(runtimeTarget)
+  )
 
   const resolved = useMemo(() => {
     const wslContext = {
@@ -113,10 +145,15 @@ export function useActiveProjectSkillRuntime(): ActiveProjectSkillRuntime {
           )
         : undefined
       const canUseLocalSkillFreshness = shouldUseLocalSkillFreshness(runtimeTarget)
-      if (!terminalShellOverride && !canUseLocalSkillFreshness) {
-        return EMPTY_ACTIVE_PROJECT_SKILL_RUNTIME
+      return {
+        installDisabledReason: null,
+        agentRuntime:
+          runtimeTarget?.kind === 'environment' || isWebClient
+            ? getHostAgentSkillRuntime(currentPlatform)
+            : undefined,
+        terminalShellOverride,
+        canUseLocalSkillFreshness
       }
-      return { installDisabledReason: null, terminalShellOverride, canUseLocalSkillFreshness }
     }
 
     const agentRuntime = getProjectAgentSkillRuntime(projectRuntime, currentPlatform)

--- a/src/renderer/src/hooks/useActiveProjectSkillRuntime.ts
+++ b/src/renderer/src/hooks/useActiveProjectSkillRuntime.ts
@@ -19,6 +19,7 @@ import {
 import { useWindowsTerminalCapabilities } from '@/lib/windows-terminal-capabilities'
 import { isWebClientLocation } from '@/lib/web-client-location'
 import { useAppStore } from '@/store'
+import { useWindowsTerminalCapabilityOwnerKey } from './useWindowsTerminalCapabilityOwnerKey'
 
 type ActiveProjectSkillRuntime = {
   projectRuntime?: ProjectExecutionRuntimeResolution
@@ -27,6 +28,7 @@ type ActiveProjectSkillRuntime = {
   terminalShellOverride?: string
   installDisabledReason: string | null
   canUseLocalSkillFreshness: boolean
+  executionHostPlatform?: NodeJS.Platform
 }
 
 export function shouldUseLocalSkillFreshness(
@@ -45,12 +47,15 @@ export function resolveSkillExecutionHostPlatform(args: {
   runtimeTarget: RuntimeClientTarget | null
   executionHostPlatform?: NodeJS.Platform
   isWebClient: boolean
-}): NodeJS.Platform {
-  if (args.runtimeTarget?.kind === 'environment') {
-    return args.executionHostPlatform ?? args.viewerPlatform
+}): NodeJS.Platform | undefined {
+  if (!args.runtimeTarget) {
+    return undefined
   }
-  if (args.runtimeTarget?.kind === 'local' && args.isWebClient) {
-    return args.executionHostPlatform ?? args.viewerPlatform
+  if (args.runtimeTarget?.kind === 'environment') {
+    return args.executionHostPlatform
+  }
+  if (args.isWebClient) {
+    return args.executionHostPlatform
   }
   return args.viewerPlatform
 }
@@ -90,25 +95,34 @@ export function useActiveProjectSkillRuntime(): ActiveProjectSkillRuntime {
   const runtimeTarget = useActiveSkillDiscoveryRuntimeTarget()
   const viewerPlatform = getCurrentPlatform()
   const isWebClient = isWebClientLocation()
-  const executionHostPlatform = useAppStore((state) => {
-    const environmentId =
-      runtimeTarget?.kind === 'environment'
-        ? runtimeTarget.environmentId
-        : isWebClient
-          ? state.runtimeEnvironments[0]?.id
-          : undefined
-    return environmentId
-      ? state.runtimeStatusByEnvironmentId.get(environmentId)?.status?.hostPlatform
+  const executionHostEnvironmentId = useAppStore((state) =>
+    runtimeTarget?.kind === 'environment'
+      ? runtimeTarget.environmentId
+      : isWebClient && runtimeTarget?.kind === 'local'
+        ? state.runtimeEnvironments[0]?.id
+        : undefined
+  )
+  const executionHostStatus = useAppStore((state) =>
+    executionHostEnvironmentId
+      ? state.runtimeStatusByEnvironmentId.get(executionHostEnvironmentId)?.status
       : undefined
-  })
+  )
+  const executionHostPlatform = executionHostStatus?.hostPlatform
   const currentPlatform = resolveSkillExecutionHostPlatform({
     viewerPlatform,
     runtimeTarget,
     executionHostPlatform,
     isWebClient
   })
+  const windowsCapabilityOwnerKey = useWindowsTerminalCapabilityOwnerKey(
+    runtimeTarget?.kind === 'environment' ? runtimeTarget.environmentId : undefined
+  )
+  const hasProjectRuntimeAuthority = !isWebClient && hasLocalSkillRuntimeAuthority(runtimeTarget)
   const windowsCapabilities = useWindowsTerminalCapabilities(
-    currentPlatform === 'win32' && hasLocalSkillRuntimeAuthority(runtimeTarget)
+    currentPlatform === 'win32' && hasProjectRuntimeAuthority,
+    false,
+    windowsCapabilityOwnerKey,
+    isWebClient ? { kind: 'local' } : (runtimeTarget ?? { kind: 'local' })
   )
 
   const resolved = useMemo(() => {
@@ -117,42 +131,53 @@ export function useActiveProjectSkillRuntime(): ActiveProjectSkillRuntime {
       availableWslDistros: windowsCapabilities.isLoading ? null : windowsCapabilities.wslDistros
     }
     const projectRuntime =
-      getLocalProjectExecutionRuntimeContext(
-        runtimeState,
-        undefined,
-        currentPlatform,
-        wslContext
-      ) ??
-      // Global WSL is the only no-project default that changes the install target (#12103).
-      (hasLocalSkillRuntimeAuthority(runtimeTarget)
-        ? wslOnly(
-            getGlobalWindowsExecutionRuntimeContext(
-              runtimeState,
-              undefined,
-              currentPlatform,
-              wslContext
-            )
-          )
-        : undefined)
-    if (!projectRuntime) {
+      currentPlatform && hasProjectRuntimeAuthority
+        ? (getLocalProjectExecutionRuntimeContext(
+            runtimeState,
+            undefined,
+            currentPlatform,
+            wslContext
+          ) ??
+          // Global WSL is the only no-project default that changes the install target (#12103).
+          (hasProjectRuntimeAuthority
+            ? wslOnly(
+                getGlobalWindowsExecutionRuntimeContext(
+                  runtimeState,
+                  undefined,
+                  currentPlatform,
+                  wslContext
+                )
+              )
+            : undefined))
+        : undefined
+    if (!projectRuntime || !currentPlatform) {
       // Why: buildSkillCommandForRuntime still builds a Windows host command
       // without a project runtime, so the terminal has to match that shell.
-      const terminalShellOverride = hasLocalSkillRuntimeAuthority(runtimeTarget)
-        ? getProjectAgentSkillTerminalShellOverride(
-            currentPlatform,
-            runtimeState.settings,
-            undefined
-          )
-        : undefined
+      const terminalShellOverride =
+        currentPlatform && hasProjectRuntimeAuthority
+          ? getProjectAgentSkillTerminalShellOverride(
+              currentPlatform,
+              runtimeState.settings,
+              undefined
+            )
+          : undefined
       const canUseLocalSkillFreshness = shouldUseLocalSkillFreshness(runtimeTarget)
       return {
         installDisabledReason: null,
         agentRuntime:
-          runtimeTarget?.kind === 'environment' || isWebClient
-            ? getHostAgentSkillRuntime(currentPlatform)
-            : undefined,
+          runtimeTarget?.kind !== 'local' || isWebClient
+            ? {
+                ...getHostAgentSkillRuntime(
+                  currentPlatform,
+                  executionHostStatus?.terminalWindowsShell,
+                  executionHostEnvironmentId
+                ),
+                terminalWindowsShell: executionHostStatus?.terminalWindowsShell
+              }
+            : getHostAgentSkillRuntime(currentPlatform, undefined, null),
         terminalShellOverride,
-        canUseLocalSkillFreshness
+        canUseLocalSkillFreshness,
+        executionHostPlatform: currentPlatform
       }
     }
 
@@ -167,9 +192,19 @@ export function useActiveProjectSkillRuntime(): ActiveProjectSkillRuntime {
         agentRuntime
       ),
       installDisabledReason: getProjectSkillInstallDisabledReason(projectRuntime),
-      canUseLocalSkillFreshness: shouldUseLocalSkillFreshness(runtimeTarget, agentRuntime)
+      canUseLocalSkillFreshness: shouldUseLocalSkillFreshness(runtimeTarget, agentRuntime),
+      executionHostPlatform: currentPlatform
     }
-  }, [currentPlatform, runtimeState, runtimeTarget, windowsCapabilities])
+  }, [
+    currentPlatform,
+    executionHostStatus?.terminalWindowsShell,
+    executionHostEnvironmentId,
+    hasProjectRuntimeAuthority,
+    isWebClient,
+    runtimeState,
+    runtimeTarget,
+    windowsCapabilities
+  ])
 
   // Content-equal runtimes keep one reference so effect keys do not thrash.
   // Adjust during render (not a ref write) when serialized identity changes.

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -12854,7 +12854,8 @@
         "FeatureSetupInlineTerminal": {
           "789b59936e": "Press Enter to run the command and confirm npx if asked. You can also set this up later in Settings.",
           "47fc6cc6dc": "Skill setup command",
-          "c767ab7061": "Skill setup"
+          "c767ab7061": "Skill setup",
+          "preparingRuntime": "Preparing setup terminal."
         },
         "IntegrationsStep": {
           "277f30eb34": "Linear, GitLab, Bitbucket, Azure DevOps, Gitea, and Jira live in Settings > Integrations.",
@@ -13787,7 +13788,8 @@
             "5c3aee22c0": "Copy command",
             "5eca672aac": "Copy skill install command",
             "6ff813fc1d": "Failed to copy skill command.",
-            "b8ad063571": "Copied the skill install command."
+            "b8ad063571": "Copied the skill install command.",
+            "preparingRuntime": "Preparing setup terminal."
           },
           "CmdJPaletteTipDialog": {
             "c0bb9f869b": "Settings → Shortcuts",

--- a/src/renderer/src/lib/execution-host-command-platform.ts
+++ b/src/renderer/src/lib/execution-host-command-platform.ts
@@ -1,0 +1,6 @@
+export function canUseViewerWindowsRuntimeSettings(
+  isWebClient: boolean,
+  wslSupportedPlatform: boolean
+): boolean {
+  return !isWebClient && wslSupportedPlatform
+}

--- a/src/renderer/src/lib/project-skill-runtime.test.ts
+++ b/src/renderer/src/lib/project-skill-runtime.test.ts
@@ -50,6 +50,7 @@ describe('project skill runtime helpers', () => {
   it('maps resolved host and WSL project runtimes into setup runtimes', () => {
     expect(getProjectAgentSkillRuntime(hostRuntime, 'win32')).toEqual({
       runtime: 'host',
+      hostPlatform: 'win32',
       label: 'Windows'
     })
     expect(getProjectAgentSkillRuntime(wslRuntime, 'win32')).toEqual({

--- a/src/renderer/src/lib/project-skill-runtime.test.ts
+++ b/src/renderer/src/lib/project-skill-runtime.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { ProjectExecutionRuntimeResolution } from '../../../shared/project-execution-runtime'
 import {
+  getHostFallbackAgentSkillRuntime,
   getProjectAgentSkillRuntime,
   getProjectAgentSkillTerminalShellOverride,
   getProjectSkillDiscoveryTarget,
@@ -42,6 +43,18 @@ const repairRuntime: ProjectExecutionRuntimeResolution = {
 }
 
 describe('project skill runtime helpers', () => {
+  it('keeps a legacy WSL runtime on its intrinsic Windows parent host', () => {
+    expect(
+      getHostFallbackAgentSkillRuntime({ runtime: 'wsl', wslDistro: 'Ubuntu', label: 'WSL' })
+    ).toEqual({
+      runtime: 'host',
+      hostPlatform: 'win32',
+      runtimeEnvironmentId: null,
+      runtimeOwnershipResolved: true,
+      label: 'Windows'
+    })
+  })
+
   it('passes the resolved project runtime through the discovery target', () => {
     expect(getProjectSkillDiscoveryTarget(wslRuntime)).toEqual({ projectRuntime: wslRuntime })
     expect(getProjectSkillDiscoveryTarget(undefined)).toBeUndefined()
@@ -51,11 +64,16 @@ describe('project skill runtime helpers', () => {
     expect(getProjectAgentSkillRuntime(hostRuntime, 'win32')).toEqual({
       runtime: 'host',
       hostPlatform: 'win32',
+      runtimeEnvironmentId: null,
+      runtimeOwnershipResolved: true,
       label: 'Windows'
     })
     expect(getProjectAgentSkillRuntime(wslRuntime, 'win32')).toEqual({
       runtime: 'wsl',
       wslDistro: 'Ubuntu-24.04',
+      hostPlatform: 'win32',
+      runtimeEnvironmentId: null,
+      runtimeOwnershipResolved: true,
       label: 'WSL Ubuntu-24.04'
     })
   })
@@ -64,6 +82,9 @@ describe('project skill runtime helpers', () => {
     expect(getProjectAgentSkillRuntime(repairRuntime, 'win32')).toEqual({
       runtime: 'wsl',
       wslDistro: 'Missing',
+      hostPlatform: 'win32',
+      runtimeEnvironmentId: null,
+      runtimeOwnershipResolved: true,
       label: 'WSL Missing'
     })
     expect(getProjectSkillInstallDisabledReason(repairRuntime)).toContain('unavailable')
@@ -102,5 +123,29 @@ describe('project skill runtime helpers', () => {
         getProjectAgentSkillRuntime(hostRuntime, 'win32')
       )
     ).toBeUndefined()
+  })
+
+  it('uses execution-host shell metadata before viewer settings', () => {
+    expect(
+      getProjectAgentSkillTerminalShellOverride(
+        'win32',
+        { terminalWindowsShell: 'powershell.exe' },
+        {
+          runtime: 'host',
+          hostPlatform: 'win32',
+          terminalWindowsShell: 'git-bash',
+          label: 'Windows'
+        }
+      )
+    ).toBe('powershell.exe')
+    for (const terminalWindowsShell of ['powershell.exe', undefined]) {
+      expect(
+        getProjectAgentSkillTerminalShellOverride(
+          'win32',
+          { terminalWindowsShell: 'git-bash' },
+          { runtime: 'host', hostPlatform: 'win32', terminalWindowsShell, label: 'Windows' }
+        )
+      ).toBeUndefined()
+    }
   })
 })

--- a/src/renderer/src/lib/project-skill-runtime.ts
+++ b/src/renderer/src/lib/project-skill-runtime.ts
@@ -8,6 +8,9 @@ export type ProjectAgentSkillRuntime = {
   runtime: 'host' | 'wsl'
   wslDistro?: string | null
   hostPlatform?: NodeJS.Platform
+  terminalWindowsShell?: string | null
+  runtimeEnvironmentId?: string | null
+  runtimeOwnershipResolved?: boolean
   label: string
 }
 
@@ -36,16 +39,45 @@ export function getProjectAgentSkillRuntime(
   return {
     runtime: 'host',
     hostPlatform: currentPlatform,
+    runtimeEnvironmentId: null,
+    runtimeOwnershipResolved: true,
     label: currentPlatform === 'win32' ? 'Windows' : 'This device'
   }
 }
 
-export function getHostAgentSkillRuntime(hostPlatform: NodeJS.Platform): ProjectAgentSkillRuntime {
+export function getHostAgentSkillRuntime(
+  hostPlatform?: NodeJS.Platform,
+  terminalWindowsShell?: string | null,
+  runtimeEnvironmentId?: string | null
+): ProjectAgentSkillRuntime {
   return {
     runtime: 'host',
     hostPlatform,
+    ...(terminalWindowsShell !== undefined ? { terminalWindowsShell } : {}),
+    ...(runtimeEnvironmentId !== undefined ? { runtimeEnvironmentId } : {}),
+    runtimeOwnershipResolved: runtimeEnvironmentId !== undefined,
     label: hostPlatform === 'win32' ? 'Windows' : 'This device'
   }
+}
+
+export function getHostFallbackAgentSkillRuntime(
+  runtime?: ProjectAgentSkillRuntime
+): ProjectAgentSkillRuntime {
+  const hostPlatform = runtime?.hostPlatform ?? (runtime?.runtime === 'wsl' ? 'win32' : undefined)
+  const runtimeEnvironmentId =
+    runtime?.runtimeEnvironmentId !== undefined
+      ? runtime.runtimeEnvironmentId
+      : runtime?.runtime === 'wsl'
+        ? null
+        : undefined
+  const fallback = getHostAgentSkillRuntime(
+    hostPlatform,
+    runtime?.terminalWindowsShell,
+    runtimeEnvironmentId
+  )
+  return runtime && 'terminalWindowsShell' in runtime
+    ? { ...fallback, terminalWindowsShell: runtime.terminalWindowsShell }
+    : fallback
 }
 
 export function getProjectAgentSkillTerminalShellOverride(
@@ -61,7 +93,11 @@ export function getProjectAgentSkillTerminalShellOverride(
   }
   // Why: generated skill commands are PowerShell/cmd syntax, so a POSIX-family
   // Windows shell (wsl.exe, Git Bash) would mangle the wrapper we hand it.
-  return resolveWindowsShellStartupFamily(settings?.terminalWindowsShell) === 'posix'
+  const terminalWindowsShell =
+    runtime && 'terminalWindowsShell' in runtime
+      ? runtime.terminalWindowsShell
+      : settings?.terminalWindowsShell
+  return resolveWindowsShellStartupFamily(terminalWindowsShell) === 'posix'
     ? 'powershell.exe'
     : undefined
 }
@@ -96,6 +132,9 @@ function getWslAgentSkillRuntime(distro: string | null): ProjectAgentSkillRuntim
   return {
     runtime: 'wsl',
     wslDistro: distro,
+    hostPlatform: 'win32',
+    runtimeEnvironmentId: null,
+    runtimeOwnershipResolved: true,
     label: distro
       ? `WSL ${distro}`
       : translate('auto.lib.projectSkillRuntime.wslDefault', 'WSL default')

--- a/src/renderer/src/lib/project-skill-runtime.ts
+++ b/src/renderer/src/lib/project-skill-runtime.ts
@@ -7,6 +7,7 @@ import { translate } from '@/i18n/i18n'
 export type ProjectAgentSkillRuntime = {
   runtime: 'host' | 'wsl'
   wslDistro?: string | null
+  hostPlatform?: NodeJS.Platform
   label: string
 }
 
@@ -34,7 +35,16 @@ export function getProjectAgentSkillRuntime(
 
   return {
     runtime: 'host',
+    hostPlatform: currentPlatform,
     label: currentPlatform === 'win32' ? 'Windows' : 'This device'
+  }
+}
+
+export function getHostAgentSkillRuntime(hostPlatform: NodeJS.Platform): ProjectAgentSkillRuntime {
+  return {
+    runtime: 'host',
+    hostPlatform,
+    label: hostPlatform === 'win32' ? 'Windows' : 'This device'
   }
 }
 

--- a/src/renderer/src/lib/session-write-subscriber.test.ts
+++ b/src/renderer/src/lib/session-write-subscriber.test.ts
@@ -308,7 +308,7 @@ describe('createSessionWriteSubscriber', () => {
     cleanup()
   })
 
-  it('ignores pendingActivationSpawn-only changes', () => {
+  it('ignores transient terminal-spawn-only changes', () => {
     const persist = vi.fn<(payload: WorkspaceSessionWrite) => void>()
     const cleanup = createSessionWriteSubscriber({ store: useAppStore, persist })
 
@@ -325,7 +325,8 @@ describe('createSessionWriteSubscriber', () => {
         'wt-1': [
           {
             ...useAppStore.getState().tabsByWorktree['wt-1'][0],
-            pendingActivationSpawn: true
+            pendingActivationSpawn: true,
+            runtimeEnvironmentId: 'runtime-a'
           }
         ]
       }

--- a/src/renderer/src/lib/session-write-subscriber.ts
+++ b/src/renderer/src/lib/session-write-subscriber.ts
@@ -13,7 +13,10 @@ type UnifiedTab = UnifiedTabsByWorktree[string][number]
 const TERMINAL_TAB_LIVE_TITLE_KEYS = new Set<keyof TerminalTab>(['title'])
 // Why: this handoff flag is stripped from workspace sessions, so toggling it
 // alone should not rebuild and rewrite the durable session payload.
-const TERMINAL_TAB_TRANSIENT_SESSION_KEYS = new Set<keyof TerminalTab>(['pendingActivationSpawn'])
+const TERMINAL_TAB_TRANSIENT_SESSION_KEYS = new Set<keyof TerminalTab>([
+  'pendingActivationSpawn',
+  'runtimeEnvironmentId'
+])
 
 function terminalTabChangedForSession(prev: TerminalTab, next: TerminalTab): boolean {
   if (prev === next) {

--- a/src/renderer/src/lib/terminal-worktree-route.test.ts
+++ b/src/renderer/src/lib/terminal-worktree-route.test.ts
@@ -19,6 +19,7 @@ function localState(overrides: Partial<AppState> = {}): AppState {
     worktreesByRepo: { 'repo-1': [{ id: 'repo-1::/w', repoId: 'repo-1', hostId: 'local' }] },
     runtimeEnvironments: [],
     runtimeEnvironmentCatalogHydrated: true,
+    runtimeEnvironmentCatalogSettled: true,
     removedRuntimeEnvironmentIds: new Set<string>(),
     ...overrides
   } as unknown as AppState
@@ -46,6 +47,30 @@ describe('resolveTerminalWorktreeRoute', () => {
     } as unknown as Partial<AppState>)
     expect(resolveTerminalWorktreeRoute(state, EPHEMERAL_ID)).toEqual({
       runtimeEnvironmentId: 'hub-a'
+    })
+  })
+
+  it('keeps ephemeral setup ownership unresolved until the runtime catalog settles', () => {
+    const state = localState({
+      settings: { activeRuntimeEnvironmentId: 'hub-a' },
+      runtimeEnvironments: [{ id: 'hub-a' }],
+      runtimeEnvironmentCatalogSettled: false
+    } as unknown as Partial<AppState>)
+
+    expect(resolveTerminalWorktreeRoute(state, EPHEMERAL_ID)).toBeNull()
+  })
+
+  it('keeps an explicitly pinned setup runtime after focus changes', () => {
+    const state = localState({
+      settings: { activeRuntimeEnvironmentId: 'hub-b' },
+      runtimeEnvironments: [{ id: 'hub-a' }, { id: 'hub-b' }]
+    } as unknown as Partial<AppState>)
+
+    expect(resolveTerminalWorktreeRoute(state, EPHEMERAL_ID, 'hub-a')).toEqual({
+      runtimeEnvironmentId: 'hub-a'
+    })
+    expect(resolveTerminalWorktreeRoute(state, EPHEMERAL_ID, null)).toEqual({
+      runtimeEnvironmentId: null
     })
   })
 

--- a/src/renderer/src/lib/terminal-worktree-route.ts
+++ b/src/renderer/src/lib/terminal-worktree-route.ts
@@ -74,6 +74,9 @@ export function resolveTerminalHostOwnership(
   // the active runtime — so a remote skill install lands on that runtime — falling back to local
   // when none is focused, instead of failing them closed.
   if (isEphemeralSetupTerminalWorktreeId(worktreeId)) {
+    if (state.runtimeEnvironmentCatalogSettled === false) {
+      return UNRESOLVED_TERMINAL_HOST
+    }
     return resolveFloatingScopeOwnership(
       state,
       worktreeId,
@@ -132,8 +135,12 @@ function resolveFloatingScopeOwnership(
 
 export function resolveTerminalWorktreeRoute(
   state: AppState,
-  worktreeId: string | null | undefined
+  worktreeId: string | null | undefined,
+  runtimeEnvironmentId?: string | null
 ): TerminalWorktreeRoute | null {
+  if (runtimeEnvironmentId !== undefined) {
+    return { runtimeEnvironmentId: runtimeEnvironmentId?.trim() || null }
+  }
   const ownership = resolveTerminalHostOwnership(state, worktreeId, 'spawn')
   return ownership.kind === 'unresolved'
     ? null

--- a/src/renderer/src/lib/web-client-location.test.ts
+++ b/src/renderer/src/lib/web-client-location.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+import { isWebClientLocation } from './web-client-location'
+
+describe('isWebClientLocation', () => {
+  it('treats a window without location as a non-web environment', () => {
+    Object.defineProperty(globalThis, 'window', { configurable: true, value: {} })
+
+    try {
+      expect(isWebClientLocation()).toBe(false)
+    } finally {
+      Reflect.deleteProperty(globalThis, 'window')
+    }
+  })
+})

--- a/src/renderer/src/lib/web-client-location.ts
+++ b/src/renderer/src/lib/web-client-location.ts
@@ -2,8 +2,9 @@ export function isWebClientLocation(): boolean {
   if (typeof window === 'undefined') {
     return false
   }
+  const pathname = window.location?.pathname
   return (
     Boolean((window as unknown as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__) ||
-    window.location.pathname.endsWith('/web-index.html')
+    Boolean(pathname?.endsWith('/web-index.html'))
   )
 }

--- a/src/renderer/src/lib/workspace-session-patch.test.ts
+++ b/src/renderer/src/lib/workspace-session-patch.test.ts
@@ -181,7 +181,8 @@ describe('buildWorkspaceSessionPatch', () => {
               title: 'shell',
               ptyId: 'pty-1',
               worktreeId: localWorktreeId,
-              pendingActivationSpawn: true
+              pendingActivationSpawn: true,
+              runtimeEnvironmentId: 'runtime-a'
             } as never
           ]
         },
@@ -216,6 +217,7 @@ describe('buildWorkspaceSessionPatch', () => {
       ].sort()
     )
     expect('pendingActivationSpawn' in patch.tabsByWorktree![localWorktreeId][0]).toBe(false)
+    expect('runtimeEnvironmentId' in patch.tabsByWorktree![localWorktreeId][0]).toBe(false)
     expect(patch.terminalLayoutsByTabId?.['tab-local'].buffersByLeafId).toBeUndefined()
     expect(patch.terminalLayoutsByTabId?.['tab-local'].scrollbackRefsByLeafId).toBeUndefined()
   })

--- a/src/renderer/src/lib/workspace-session.ts
+++ b/src/renderer/src/lib/workspace-session.ts
@@ -225,13 +225,14 @@ export function buildPersistedBrowserPagesByWorkspace(
 export function buildSanitizedTabsByWorktree(
   tabsByWorktree: WorkspaceSessionSnapshot['tabsByWorktree']
 ): WorkspaceSessionState['tabsByWorktree'] {
-  // Why: strip transient pendingActivationSpawn — session:set persists without Zod re-parse, so a stale flag would drop the first PTY spawn on restart.
+  // Why: session:set persists without Zod re-parse; transient spawn authority must not survive restart.
   return Object.fromEntries(
     Object.entries(tabsByWorktree).map(([worktreeId, tabs]) => [
       worktreeId,
       tabs.map((tab) => {
-        const { pendingActivationSpawn: _unused, ...rest } = tab
-        void _unused
+        const { pendingActivationSpawn: _pending, runtimeEnvironmentId: _runtime, ...rest } = tab
+        void _pending
+        void _runtime
         return rest
       })
     ])

--- a/src/renderer/src/lib/worktree-runtime-owner-state.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner-state.ts
@@ -28,5 +28,6 @@ export type WorktreeRuntimeOwnerState = {
   activeWorkspaceExecutionHostId?: ExecutionHostId | null
   runtimeEnvironments?: readonly { id: string }[]
   runtimeEnvironmentCatalogHydrated?: boolean
+  runtimeEnvironmentCatalogSettled?: boolean
   removedRuntimeEnvironmentIds?: ReadonlySet<string>
 }

--- a/src/renderer/src/store/slices/store-active-worktree-terminal-creation.test.ts
+++ b/src/renderer/src/store/slices/store-active-worktree-terminal-creation.test.ts
@@ -699,4 +699,43 @@ describe('setActiveWorktree', () => {
       })
     }
   })
+
+  it('does not stamp viewer Windows shells onto pinned paired-runtime tabs', () => {
+    const originalNavigator = globalThis.navigator
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)' },
+      configurable: true
+    })
+    try {
+      const store = createTestStore()
+      const wt = 'repo1::/path/wt1'
+      seedStore(store, {
+        settings: { ...getDefaultSettings('/tmp'), terminalWindowsShell: 'wsl.exe' },
+        worktreesByRepo: {
+          repo1: [makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
+        },
+        runtimeStatusByEnvironmentId: new Map([
+          ['linux-host', { status: { hostPlatform: 'linux' }, checkedAt: 1 }],
+          ['legacy-host', { status: {}, checkedAt: 1 }]
+        ]) as ReturnType<typeof store.getState>['runtimeStatusByEnvironmentId']
+      })
+
+      const linuxTab = store
+        .getState()
+        .createTab(wt, undefined, undefined, { runtimeEnvironmentId: 'linux-host' })
+      const legacyTab = store
+        .getState()
+        .createTab(wt, undefined, 'powershell.exe', { runtimeEnvironmentId: 'legacy-host' })
+
+      expect(linuxTab).toMatchObject({ runtimeEnvironmentId: 'linux-host' })
+      expect(linuxTab.shellOverride).toBeUndefined()
+      expect(legacyTab).toMatchObject({ runtimeEnvironmentId: 'legacy-host' })
+      expect(legacyTab.shellOverride).toBeUndefined()
+    } finally {
+      Object.defineProperty(globalThis, 'navigator', {
+        value: originalNavigator,
+        configurable: true
+      })
+    }
+  })
 })

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -631,6 +631,7 @@ export type TerminalSlice = {
       viewMode?: Tab['viewMode']
       startupCwd?: string
       forceHostRuntime?: boolean
+      runtimeEnvironmentId?: string | null
     }
   ) => TerminalTab
   openNewTerminalTabInActiveWorkspace: (groupId: string) => Promise<void>
@@ -1329,20 +1330,25 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       const quickCommandLabel = options?.quickCommandLabel?.trim()
       const startupCwd = options?.startupCwd
       const remoteConnectionId = getRemoteConnectionIdForWorktree(s, worktreeId)
-      const isRemoteWorktree = Boolean(remoteConnectionId)
+      const pinnedRuntimeEnvironmentId = options?.runtimeEnvironmentId ?? null
+      const isRemoteExecutionOwner = Boolean(remoteConnectionId || pinnedRuntimeEnvironmentId)
       const isWslWorktree = worktreeUsesWslPath(s, worktreeId)
+      const remotePlatform = remoteConnectionId
+        ? ((s.sshConnectionStates.get(remoteConnectionId)
+            ?.remotePlatform as NodeJS.Platform | null) ?? null)
+        : pinnedRuntimeEnvironmentId
+          ? (s.runtimeStatusByEnvironmentId.get(pinnedRuntimeEnvironmentId)?.status?.hostPlatform ??
+            null)
+          : null
       const createdShellOverride = resolveCreatedTabShellOverride(
         shellOverride,
         s.settings?.terminalWindowsShell,
-        // Why: SSH PTYs ignore local Windows shell selection; a local shell icon would mislabel a remote terminal.
-        isRemoteWorktree,
-        remoteConnectionId
-          ? ((s.sshConnectionStates.get(remoteConnectionId)
-              ?.remotePlatform as NodeJS.Platform | null) ?? null)
-          : null,
+        // Why: SSH and paired PTYs ignore viewer Windows shell selection.
+        isRemoteExecutionOwner,
+        remotePlatform,
         // Why: new terminals enter the worktree's repo-scoped WSL distro even when the global Windows shell is PowerShell/cmd.exe.
         isWslWorktree,
-        isRemoteWorktree || options?.forceHostRuntime
+        isRemoteExecutionOwner || options?.forceHostRuntime
           ? undefined
           : getLocalProjectExecutionRuntimeContext(s, worktreeId)
       )
@@ -1362,6 +1368,9 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         ...(createdShellOverride !== undefined ? { shellOverride: createdShellOverride } : {}),
         ...(startupCwd && startupCwd.length > 0 ? { startupCwd } : {}),
         ...(options?.forceHostRuntime ? { forceHostRuntime: true } : {}),
+        ...(options && 'runtimeEnvironmentId' in options
+          ? { runtimeEnvironmentId: options.runtimeEnvironmentId ?? null }
+          : {}),
         ...(options?.launchAgent ? { launchAgent: options.launchAgent } : {}),
         // Why: mark click-caused (not work-caused) spawns so updateTabPtyId skips the activity/sortEpoch bump that would reorder Recent/Smart on click.
         ...(options?.pendingActivationSpawn ? { pendingActivationSpawn: true } : {})

--- a/src/shared/remote-workspace-session-projection.test.ts
+++ b/src/shared/remote-workspace-session-projection.test.ts
@@ -22,7 +22,8 @@ describe('remote workspace session projection', () => {
             customTitle: null,
             color: null,
             sortOrder: 0,
-            createdAt: 1
+            createdAt: 1,
+            runtimeEnvironmentId: 'runtime-a'
           }
         ],
         'repo-local::/tmp/local': [
@@ -61,6 +62,7 @@ describe('remote workspace session projection', () => {
       id: 'tab-1',
       worktreePath: '/srv/app'
     })
+    expect('runtimeEnvironmentId' in projected.tabsByWorktreePath['/srv/app'][0]).toBe(false)
     expect(projected.terminalLayoutsByTabId).toEqual({
       'tab-1': { root: null, activeLeafId: null, expandedLeafId: null }
     })

--- a/src/shared/remote-workspace-session-projection.ts
+++ b/src/shared/remote-workspace-session-projection.ts
@@ -17,9 +17,15 @@ function worktreePathFromId(worktreeId: string): string | null {
 }
 
 function tabToRemote(tab: TerminalTab, worktreePath: string): RemoteWorkspaceTerminalTab {
-  const { worktreeId: _worktreeId, pendingActivationSpawn: _pendingActivationSpawn, ...rest } = tab
+  const {
+    worktreeId: _worktreeId,
+    pendingActivationSpawn: _pendingActivationSpawn,
+    runtimeEnvironmentId: _runtimeEnvironmentId,
+    ...rest
+  } = tab
   void _worktreeId
   void _pendingActivationSpawn
+  void _runtimeEnvironmentId
   return { ...rest, worktreePath }
 }
 

--- a/src/shared/terminal-tab-types.ts
+++ b/src/shared/terminal-tab-types.ts
@@ -34,6 +34,8 @@ export type TerminalTab = {
   shellOverride?: string
   /** Keeps an ephemeral host fallback out of the active project's runtime. */
   forceHostRuntime?: boolean
+  /** Transient: pins an ephemeral spawn to the setup owner; never persist or publish. */
+  runtimeEnvironmentId?: string | null
   /** Why: explorer-created terminals can start below the workspace root while
    *  still belonging to that workspace for tab/session ownership. */
   startupCwd?: string

--- a/tests/e2e/helpers/paired-electron-client.ts
+++ b/tests/e2e/helpers/paired-electron-client.ts
@@ -1,5 +1,4 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
-import { randomUUID } from 'node:crypto'
 import os from 'node:os'
 import path from 'node:path'
 import {
@@ -21,9 +20,14 @@ import {
   replaceRuntimePairingInPlace,
   type SameIdPairingReplacement
 } from './nested-runtime-same-id-pairing'
-import { createPairedWebClientUrl, type PairedWebClientOptions } from './paired-web-client-url'
+import type { RuntimeDesktopPairingOffer } from './paired-web-client'
 
 export type { SameIdPairingReplacement } from './nested-runtime-same-id-pairing'
+export {
+  launchPairedWebClient,
+  type PairedWebClient,
+  type RuntimeDesktopPairingOffer
+} from './paired-web-client'
 
 export type PairedElectronClient = {
   app: ElectronApplication
@@ -34,16 +38,6 @@ export type PairedElectronClient = {
   getDirectSshAttemptTargetIds: () => Promise<string[]>
   installDirectSshAttemptProbe: () => Promise<void>
   replacePairingInPlace: (offer: RuntimeDesktopPairingOffer) => Promise<SameIdPairingReplacement>
-}
-
-export type RuntimeDesktopPairingOffer = {
-  pairingUrl: string
-  webClientUrl?: string
-}
-
-export type PairedWebClient = {
-  page: Page
-  dispose: () => Promise<void>
 }
 
 const DIRECT_SSH_PROBE_CANARY_TARGET_ID = '__orca_e2e_direct_ssh_probe_canary__'
@@ -89,53 +83,6 @@ export async function createRuntimeDesktopPairingOffer(
       ...(offer.webClientUrl ? { webClientUrl: offer.webClientUrl } : {})
     }
   })
-}
-
-export async function launchPairedWebClient(
-  hubApp: ElectronApplication,
-  offer: RuntimeDesktopPairingOffer,
-  options: PairedWebClientOptions = {}
-): Promise<PairedWebClient> {
-  if (!offer.webClientUrl) {
-    throw new Error('HUB runtime did not provide a paired web client URL')
-  }
-  const clientUrl = createPairedWebClientUrl(offer.webClientUrl, options)
-  let page: Page | undefined
-  const pagePromise = hubApp.waitForEvent('window').then((candidate) => (page = candidate))
-  try {
-    await hubApp.evaluate(
-      async ({ BrowserWindow }, { partition, url }) => {
-        const clientWindow = new BrowserWindow({
-          height: 1200,
-          show: false,
-          width: 1440,
-          webPreferences: {
-            contextIsolation: true,
-            nodeIntegration: false,
-            partition,
-            sandbox: true
-          }
-        })
-        await clientWindow.loadURL(url).catch((error) => {
-          clientWindow.destroy()
-          throw error
-        })
-      },
-      {
-        partition: `e2e-nested-runtime-web-${randomUUID()}`,
-        url: clientUrl
-      }
-    )
-    page = await pagePromise
-    if (options.waitForWorkspace !== false) {
-      await page.locator('[data-worktree-sidebar]').waitFor({ state: 'visible', timeout: 30_000 })
-    }
-    return { page, dispose: () => page?.close() ?? Promise.resolve() }
-  } catch (error) {
-    void pagePromise.catch(() => undefined)
-    await page?.close().catch(() => undefined)
-    throw error
-  }
 }
 
 export async function launchPairedElectronClient(

--- a/tests/e2e/helpers/paired-web-client-url.ts
+++ b/tests/e2e/helpers/paired-web-client-url.ts
@@ -1,7 +1,9 @@
 export type PairedWebClientOptions = {
   disableRemoteTerminalStallRecovery?: boolean
+  show?: boolean
   terminalParkingDelayMs?: number
   terminalRetentionLimit?: number
+  userAgent?: string
   waitForWorkspace?: boolean
 }
 

--- a/tests/e2e/helpers/paired-web-client.ts
+++ b/tests/e2e/helpers/paired-web-client.ts
@@ -1,0 +1,65 @@
+import { randomUUID } from 'node:crypto'
+import type { ElectronApplication, Page } from '@stablyai/playwright-test'
+import { createPairedWebClientUrl, type PairedWebClientOptions } from './paired-web-client-url'
+
+export type RuntimeDesktopPairingOffer = {
+  pairingUrl: string
+  webClientUrl?: string
+}
+
+export type PairedWebClient = {
+  page: Page
+  dispose: () => Promise<void>
+}
+
+export async function launchPairedWebClient(
+  hubApp: ElectronApplication,
+  offer: RuntimeDesktopPairingOffer,
+  options: PairedWebClientOptions = {}
+): Promise<PairedWebClient> {
+  if (!offer.webClientUrl) {
+    throw new Error('HUB runtime did not provide a paired web client URL')
+  }
+  const clientUrl = createPairedWebClientUrl(offer.webClientUrl, options)
+  let page: Page | undefined
+  const pagePromise = hubApp.waitForEvent('window').then((candidate) => (page = candidate))
+  try {
+    await hubApp.evaluate(
+      async ({ BrowserWindow }, { partition, show, url, userAgent }) => {
+        const clientWindow = new BrowserWindow({
+          height: 1200,
+          show,
+          width: 1440,
+          webPreferences: {
+            contextIsolation: true,
+            nodeIntegration: false,
+            partition,
+            sandbox: true
+          }
+        })
+        if (userAgent) {
+          clientWindow.webContents.setUserAgent(userAgent)
+        }
+        await clientWindow.loadURL(url).catch((error) => {
+          clientWindow.destroy()
+          throw error
+        })
+      },
+      {
+        partition: `e2e-nested-runtime-web-${randomUUID()}`,
+        show: options.show ?? false,
+        userAgent: options.userAgent ?? null,
+        url: clientUrl
+      }
+    )
+    page = await pagePromise
+    if (options.waitForWorkspace !== false) {
+      await page.locator('[data-worktree-sidebar]').waitFor({ state: 'visible', timeout: 30_000 })
+    }
+    return { page, dispose: () => page?.close() ?? Promise.resolve() }
+  } catch (error) {
+    void pagePromise.catch(() => undefined)
+    await page?.close().catch(() => undefined)
+    throw error
+  }
+}

--- a/tests/e2e/paired-web-skill-command-host-platform.spec.ts
+++ b/tests/e2e/paired-web-skill-command-host-platform.spec.ts
@@ -12,6 +12,9 @@ const WINDOWS_USER_AGENT =
 const ORCHESTRATION_INSTALL_COMMAND =
   'npx skills add https://github.com/stablyai/orca --skill orchestration --global'
 
+test.skip(process.env.ORCA_E2E_WEB_CLIENT !== '1', 'requires the paired web client build')
+test.skip(process.platform !== 'linux', 'requires a Linux paired execution host')
+
 async function expectHostPlatformCommand(
   app: ElectronApplication,
   offer: RuntimeDesktopPairingOffer,
@@ -24,21 +27,60 @@ async function expectHostPlatformCommand(
   })
   try {
     await client.page.waitForFunction(
-      () => window.__store?.getState().workspaceSessionReady === true,
+      () => {
+        const state = window.__store?.getState()
+        const environmentId = state?.runtimeEnvironments[0]?.id
+        return (
+          environmentId !== undefined &&
+          state?.runtimeStatusByEnvironmentId.get(environmentId)?.status?.hostPlatform === 'linux'
+        )
+      },
       null,
       { timeout: 30_000 }
     )
-    const platforms = await client.page.evaluate(async () => ({
-      host: (await window.api.runtime.getStatus()).hostPlatform,
-      viewer: window.api.platform.get().platform
-    }))
-    expect(platforms).toEqual({ host: process.platform, viewer: 'win32' })
-
+    const platforms = await client.page.evaluate(async () => {
+      const state = window.__store?.getState()
+      const environmentId = state?.runtimeEnvironments[0]?.id
+      return {
+        environmentId,
+        host: (await window.api.runtime.getStatus()).hostPlatform,
+        mirrored: environmentId
+          ? state?.runtimeStatusByEnvironmentId.get(environmentId)?.status?.hostPlatform
+          : undefined,
+        viewer: window.api.platform.get().platform
+      }
+    })
+    expect(platforms).toEqual({
+      environmentId: expect.any(String),
+      host: 'linux',
+      mirrored: 'linux',
+      viewer: 'win32'
+    })
     await openOrchestrationSettings(client.page)
     await client.page.getByRole('button', { name: 'Copy install command' }).click()
     const command = client.page.getByRole('dialog').locator('p.font-mono')
     await expect(command).toBeVisible()
     await expect(command).toHaveText(ORCHESTRATION_INSTALL_COMMAND)
+    await client.page.getByRole('button', { name: 'Done' }).click()
+
+    await client.page.getByRole('button', { name: 'Install', exact: true }).click()
+    await expect(
+      client.page.getByRole('region', { name: 'Orchestration skill install terminal' })
+    ).toBeVisible({ timeout: 30_000 })
+    const terminalOwner = await client.page.evaluate(() => {
+      const state = window.__store?.getState()
+      const tab = Object.values(state?.tabsByWorktree ?? {})
+        .flat()
+        .find((entry) => entry.customTitle === 'Orchestration setup')
+      return {
+        runtimeEnvironmentId: tab?.runtimeEnvironmentId ?? null,
+        shellOverride: tab?.shellOverride ?? null
+      }
+    })
+    expect(terminalOwner).toEqual({
+      runtimeEnvironmentId: platforms.environmentId,
+      shellOverride: null
+    })
   } finally {
     await client.dispose()
   }

--- a/tests/e2e/paired-web-skill-command-host-platform.spec.ts
+++ b/tests/e2e/paired-web-skill-command-host-platform.spec.ts
@@ -1,0 +1,69 @@
+import type { ElectronApplication, Page } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import { launchHeadlessPairedRuntimeHost } from './helpers/headless-paired-runtime-host'
+import {
+  createRuntimeDesktopPairingOffer,
+  launchPairedWebClient,
+  type RuntimeDesktopPairingOffer
+} from './helpers/paired-electron-client'
+
+const WINDOWS_USER_AGENT =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/140.0.0.0 Safari/537.36'
+const ORCHESTRATION_INSTALL_COMMAND =
+  'npx skills add https://github.com/stablyai/orca --skill orchestration --global'
+
+async function expectHostPlatformCommand(
+  app: ElectronApplication,
+  offer: RuntimeDesktopPairingOffer,
+  show: boolean
+): Promise<void> {
+  const client = await launchPairedWebClient(app, offer, {
+    show,
+    userAgent: WINDOWS_USER_AGENT,
+    waitForWorkspace: false
+  })
+  try {
+    await client.page.waitForFunction(
+      () => window.__store?.getState().workspaceSessionReady === true,
+      null,
+      { timeout: 30_000 }
+    )
+    const platforms = await client.page.evaluate(async () => ({
+      host: (await window.api.runtime.getStatus()).hostPlatform,
+      viewer: window.api.platform.get().platform
+    }))
+    expect(platforms).toEqual({ host: process.platform, viewer: 'win32' })
+
+    await openOrchestrationSettings(client.page)
+    await client.page.getByRole('button', { name: 'Copy install command' }).click()
+    const command = client.page.getByRole('dialog').locator('p.font-mono')
+    await expect(command).toBeVisible()
+    await expect(command).toHaveText(ORCHESTRATION_INSTALL_COMMAND)
+  } finally {
+    await client.dispose()
+  }
+}
+
+async function openOrchestrationSettings(page: Page): Promise<void> {
+  await page.getByRole('button', { name: 'Settings' }).click()
+  await expect(page.getByPlaceholder('Search settings')).toBeVisible()
+  await page.getByRole('button', { name: 'Orchestration', exact: true }).click()
+  await expect(page.getByRole('button', { name: 'Copy install command' })).toBeVisible()
+}
+
+test('uses headed paired host platform for skill commands @headful', async ({
+  electronApp,
+  orcaPage
+}) => {
+  const offer = await createRuntimeDesktopPairingOffer(orcaPage)
+  await expectHostPlatformCommand(electronApp, offer, true)
+})
+
+test('uses headless paired host platform for skill commands', async () => {
+  const host = await launchHeadlessPairedRuntimeHost()
+  try {
+    await expectHostPlatformCommand(host.app, host.offer, false)
+  } finally {
+    await host.dispose()
+  }
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 29 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1501 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​122 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1379 |
| Prod | 35 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​890 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​235 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​655 |

<!-- /orca-pr-loc -->

## What

Fixes #12252 and [STA-3279](https://linear.app/stably/issue/STA-3279).

A paired web viewer now keeps two platform concepts separate:

- viewer platform owns keyboard shortcuts, shortcut labels, registration UI, and browser-local feedback;
- execution-host authority owns skill commands, shell preparation, prerequisite setup, and terminal spawn.

The execution path now carries one coherent runtime snapshot through General/CLI, Orchestration, Linear, Browser Use, Computer Use, mobile-emulator, feature-wall, feature-tip, onboarding, and WSL repair/host-fallback surfaces.

## Authority model

Runtime identity is deliberately tri-state:

- `runtimeEnvironmentId: "…"` — exact paired execution environment;
- `runtimeEnvironmentId: null` — exact local or WSL owner;
- field absent — unresolved or legacy routing; authoritative setup surfaces do not execute while unresolved.

The command platform and Windows-shell metadata come from the selected environment's existing mirrored `RuntimeStatus`. Explicit project WSL/repair runtime remains authoritative and keeps its Windows parent. A legacy host that omits platform or shell metadata stays neutral; it never borrows the viewer browser's platform or terminal settings.

The click-time snapshot freezes command, shell preparation, shell override, host-runtime intent, and exact owner before asynchronous preflight. A renderer-local terminal-tab pin carries that owner to PTY routing, then is stripped from persistence, session writes, and remote publication. No RPC field, stream opcode, protocol version, or host publication shape changed.

## Visual proof

Current `origin/main`, Windows-UA viewer paired to Linux host:

![Baseline: Windows command on Linux host](https://github.com/user-attachments/assets/9c2d7fbb-ce5b-4389-8241-97d404ed326a)

Candidate, identical topology:

![Candidate: Linux command on Linux host](https://github.com/user-attachments/assets/321a09d6-ab1d-40da-b678-e39b2ee44671)

## Reproduction and red/green evidence

Invariant: skill command, shell preparation, prerequisite setup, and terminal spawn for runtime R use R's authoritative host metadata and exact identity; viewer UA/focus cannot alter them, and unknown ownership stays non-executable.

Topology:

- viewer: paired web client with Windows user agent;
- host: real Linux paired Orca runtime;
- primary: headed desktop server;
- parity: headless `orca serve`;
- Docker supplies the isolated Linux host environment but is not treated as SSH/relay coverage.

The identical oracle independently checks:

1. host RPC reports `hostPlatform: linux`;
2. renderer mirror reports `hostPlatform: linux`;
3. viewer reports `win32`;
4. visible Orchestration dialog shows the bare POSIX `npx skills add …` command;
5. real Install opens the real setup terminal;
6. backing tab pins the exact paired environment;
7. backing tab has no viewer Windows shell override.

Results:

- latest `origin/main` `c3a1694b1d`: headed and headless both red at the visible command with the original `cmd.exe` wrapper;
- candidate `aee7ff709b`: headed green in 15.4s; headless green in 19.5s;
- fix-disabled/revert control: the same `origin/main` product sources under the unchanged candidate harness, red in both topologies.

## Tests

- 24 focused files / 269 tests passed, including:
  - host/viewer inversion and exact selected-environment isolation;
  - unresolved catalog cannot borrow the first saved host;
  - setup/preflight cannot run while ownership is unresolved;
  - exact local/WSL `null` and paired string ownership across async preflight/focus changes;
  - General, Linear, mobile-emulator, onboarding, feature-wall, and feature-tip propagation;
  - paired terminal shell isolation, including legacy hosts;
  - WSL precedence and repair fallback;
  - legacy generic omitted routing;
  - transient owner excluded from persistence and remote publication.
- full `pnpm run typecheck`: passed;
- full `pnpm exec oxlint`: passed;
- changed-code quality and React Doctor: 0 findings across 59 files;
- reliability manifest: 89 gates passed;
- max-lines ratchet and `git diff --check`: passed.

## Design alternatives rejected

- Global replacement of `window.api.platform`: would break viewer-local shortcuts, labels, and registration UI.
- Viewer fallback for missing remote host truth: recreates the authority bug for old/disconnected hosts.
- Per-consumer patches: allow command, shell, and spawn ownership to diverge.
- New RPC/opcode: unnecessary; existing optional host status already owns the truth and a new wire dependency would complicate mixed versions.
- Reading mutable focus after async preflight: can route the command to a different host than the one that produced it.
- Treating Docker SSH as paired-server proof: wrong topology; the live harness runs actual headed and headless paired Orca servers.

## Reviews

Final clean read-only rounds completed after the unresolved-owner boundary reset:

- Codex: architecture/authority;
- Codex: adversarial concurrency/failure;
- Codex: test/topology;
- OpenCode: authority/design;
- OpenCode: topology/design.

Review first exposed the unresolved snapshot collapse, then the upstream feature-wall preflight bypass. Both were fixed at the ownership boundary; the final rounds found no new failure class.

## Remaining gaps / downsides

- physical Windows execution host with a non-Windows viewer was not exercised;
- mixed-version packaged binaries were not paired live (legacy omission is covered deterministically);
- the live UI journey covers Orchestration; the other consumers are covered by deterministic renderer contracts;
- unresolved setup actions are briefly disabled/deferred while the runtime catalog settles;
- transient tab ownership is intentionally not restorable/publishable, so restored legacy tabs use the existing routing contract.

## Checklist

- [x] Draft PR only; never merged
- [x] Reproduced on latest main before product changes
- [x] Same baseline/candidate/revert oracle
- [x] Headed paired server first, headless parity second
- [x] Regression tests fail when the product fix is disabled
- [x] Cross-platform, SSH, WSL, folder-workspace, and mixed-version boundaries considered
- [x] Independent final reviews clean
- [x] CI green on final pushed commit

