### PR TITLE
feat(sidebar): show Cmd/Ctrl+1-9 index badges on workspace cards

### DIFF
--- a/src/renderer/src/components/sidebar/WorkspaceShortcutIndexBadge.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceShortcutIndexBadge.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { ShortcutKeyCombo } from '@/components/ShortcutKeyCombo'
+
+/**
+ * The 1-9 digit that jumps to this card, overlaid while the jump chord is held.
+ *
+ * Decorative on purpose: the shortcut is already announced by the keybindings
+ * settings row, and an overlay that only exists mid-chord has nothing to add to
+ * the accessibility tree.
+ */
+export function WorkspaceShortcutIndexBadge({ index }: { index: number }): React.JSX.Element {
+  return (
+    <span aria-hidden="true" data-workspace-shortcut-index-badge={index}>
+      <ShortcutKeyCombo
+        keys={[String(index)]}
+        // Why the ring-strength border: the chip floats over hover/active card fills, and the plain sidebar border disappears against them.
+        keyCapClassName="min-w-4 rounded-[4px] border-worktree-sidebar-ring/40 bg-worktree-sidebar-accent px-1 py-0 text-[10px] leading-4 text-worktree-sidebar-accent-foreground"
+      />
+    </span>
+  )
+}

--- a/src/renderer/src/components/sidebar/workspace-index-shortcut-badges.ts
+++ b/src/renderer/src/components/sidebar/workspace-index-shortcut-badges.ts
@@ -1,0 +1,117 @@
+import { useEffect, useMemo, useState } from 'react'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
+import { useAppStore } from '@/store'
+import {
+  getDigitIndexModifierChords,
+  keybindingModifierChordsEqual,
+  type KeybindingModifierChord
+} from '../../../../shared/keybindings'
+import type { HostSectionRow } from './host-section-rows'
+import type { PinnedWorktreeDisplayPolicy } from './worktree-list/grouping/row-types'
+import { getRenderedWorktreeEntriesInSidebarOrder } from './worktree-sidebar-row-preference'
+
+const WORKSPACE_INDEX_ACTION_ID = 'workspace.selectByIndex' as const
+/** Only 1-9 are addressable, so deeper cards get no badge. */
+const WORKSPACE_INDEX_SHORTCUT_MAX = 9
+// Why: ordinary chords (Cmd+C, Cmd+S) release well inside this, so the badges don't strobe on every shortcut.
+const BADGE_HOLD_DELAY_MS = 400
+const NO_WORKSPACE_INDEX_BADGES: ReadonlyMap<string, number> = new Map()
+
+function readModifierChord(event: KeyboardEvent): KeybindingModifierChord {
+  return {
+    meta: event.metaKey,
+    control: event.ctrlKey,
+    alt: event.altKey,
+    shift: event.shiftKey
+  }
+}
+
+/** True while the user holds the modifiers of their own workspace.selectByIndex binding, Safari-tab-numbers style. */
+export function useWorkspaceIndexShortcutHeld(): boolean {
+  const keybindings = useAppStore((state) => state.keybindings)
+  const chords = useMemo(
+    () =>
+      getDigitIndexModifierChords(WORKSPACE_INDEX_ACTION_ID, getRendererAppPlatform(), keybindings),
+    [keybindings]
+  )
+  const [held, setHeld] = useState(false)
+
+  useEffect(() => {
+    if (chords.length === 0) {
+      setHeld(false)
+      return
+    }
+    let shown = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+    const hide = (): void => {
+      if (timer) {
+        clearTimeout(timer)
+        timer = null
+      }
+      if (shown) {
+        shown = false
+        setHeld(false)
+      }
+    }
+    const sync = (event: KeyboardEvent): void => {
+      const pressed = readModifierChord(event)
+      if (!chords.some((chord) => keybindingModifierChordsEqual(chord, pressed))) {
+        hide()
+        return
+      }
+      if (shown || timer) {
+        return
+      }
+      timer = setTimeout(() => {
+        timer = null
+        shown = true
+        setHeld(true)
+      }, BADGE_HOLD_DELAY_MS)
+    }
+    window.addEventListener('keydown', sync, true)
+    window.addEventListener('keyup', sync, true)
+    // Why: a chord that moves focus off the window (Cmd+Tab, a browser guest) never delivers its keyup here.
+    window.addEventListener('blur', hide)
+    document.addEventListener('visibilitychange', hide)
+    return () => {
+      window.removeEventListener('keydown', sync, true)
+      window.removeEventListener('keyup', sync, true)
+      window.removeEventListener('blur', hide)
+      document.removeEventListener('visibilitychange', hide)
+      hide()
+    }
+  }, [chords])
+
+  return held
+}
+
+/**
+ * Row key -> the digit that jumps to that card, empty unless the chord is held and can act.
+ *
+ * Why this row walk: it is the one the sidebar's shortcut cache publishes
+ * (`setVisibleWorktreeShortcutTargets`), so a badge can never label a card the
+ * shortcut would not actually activate.
+ */
+export function useWorkspaceShortcutIndexByRowKey(
+  rows: readonly HostSectionRow[],
+  pinnedDisplayPolicy: PinnedWorktreeDisplayPolicy
+): ReadonlyMap<string, number> {
+  const held = useWorkspaceIndexShortcutHeld()
+  // Why: the jump handler ignores the chord outside the terminal view, and hands it to Cmd+J's
+  // rows while the palette is open. Badging cards the digits would not reach is worse than none.
+  const cardsAreAddressable = useAppStore(
+    (state) => state.activeView === 'terminal' && state.activeModal !== 'worktree-palette'
+  )
+  return useMemo(() => {
+    if (!held || !cardsAreAddressable) {
+      return NO_WORKSPACE_INDEX_BADGES
+    }
+    const entries = getRenderedWorktreeEntriesInSidebarOrder(rows, pinnedDisplayPolicy)
+    const byRowKey = new Map<string, number>()
+    const labelled = Math.min(entries.length, WORKSPACE_INDEX_SHORTCUT_MAX)
+    for (let index = 0; index < labelled; index++) {
+      byRowKey.set(entries[index]!.rowKey, index + 1)
+    }
+    return byRowKey
+  }, [cardsAreAddressable, held, pinnedDisplayPolicy, rows])
+}

--- a/src/renderer/src/components/sidebar/worktree-list/rows/folder-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/folder-row.tsx
@@ -12,6 +12,7 @@ import type { FolderWorkspacePathStatus } from '../../../../../../shared/folder-
 import { isConfirmedStaleFolderPathStatus } from '../../../../../../shared/folder-workspace-path-status'
 import { folderWorkspaceToWorktree } from '../../../../../../shared/folder-workspace-worktree'
 import WorktreeCard from '../../WorktreeCard'
+import { WorkspaceShortcutIndexBadge } from '../../WorkspaceShortcutIndexBadge'
 import type { WorktreeGroupBy } from '../grouping/row-types'
 import { getVirtualRowTransform } from '../viewport/virtual-rows'
 import { getFolderWorkspaceRowGeometry } from './indentation'
@@ -27,6 +28,7 @@ export type FolderWorkspaceRowContext = {
   activeWorktreeId: string | null
   currentWorktreeId: string | null
   selectedWorktreeIds: ReadonlySet<string>
+  workspaceShortcutIndexByRowKey: ReadonlyMap<string, number>
   repoMap: Map<string, Repo>
   worktreeMap: Map<string, Worktree>
   worktreeLineageById: Record<string, WorktreeLineage>
@@ -58,6 +60,7 @@ export function renderFolderWorkspaceVirtualRow(args: {
   measureVirtualRowElement: (element: HTMLDivElement | null) => void
 }): React.JSX.Element {
   const { ctx, row, vItem } = args
+  const workspaceShortcutIndex = ctx.workspaceShortcutIndexByRowKey.get(row.key)
   const folderWorktree = folderWorkspaceToWorktree(row.folderWorkspace)
   const folderWorktreeIdentity = getWorktreeHostIdentity(folderWorktree)
   const pathStatus = ctx.getCachedFolderWorkspacePathStatus({
@@ -123,7 +126,10 @@ export function renderFolderWorkspaceVirtualRow(args: {
           onContextMenuSelect={ctx.onContextMenuSelect}
           statusPrDisplay={folderPrDisplay}
         />
-        <div className="pointer-events-auto absolute right-3 top-1.5">
+        <div className="pointer-events-auto absolute right-3 top-1.5 flex items-center gap-1">
+          {workspaceShortcutIndex ? (
+            <WorkspaceShortcutIndexBadge index={workspaceShortcutIndex} />
+          ) : null}
           <FolderPathStatusIndicator status={pathStatus} />
         </div>
       </div>

--- a/src/renderer/src/components/sidebar/worktree-list/rows/item-row.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/item-row.tsx
@@ -8,6 +8,7 @@ import {
   getWorktreeHostIdentity
 } from '../../../../../../shared/worktree/host-qualified-identity'
 import WorktreeCard, { type ActiveSurfaceVariant } from '../../WorktreeCard'
+import { WorkspaceShortcutIndexBadge } from '../../WorkspaceShortcutIndexBadge'
 import { PINNED_GROUP_KEY } from '../grouping/group-keys'
 import type { WorktreeGroupBy } from '../grouping/row-types'
 import {
@@ -31,6 +32,7 @@ export type WorktreeItemRowContext = {
   folderBackedProjectGroupIds: ReadonlySet<string>
   groupKeyByRowKey: ReadonlyMap<string, string>
   groupIndexByRowKey: ReadonlyMap<string, number>
+  workspaceShortcutIndexByRowKey: ReadonlyMap<string, number>
   agentSendTargetWorktreeId: string | null
   worktreeDragState: WorktreeRowDragState
   worktreePointerDragRef: React.MutableRefObject<WorktreePointerDrag | null>
@@ -142,6 +144,7 @@ export function renderWorktreeItemRow(
     (ctx.worktreePointerDragRef.current?.latestStatusDropTarget?.target.lineageParentId ===
       itemRow.worktree.id ||
       ctx.nativeLineageDropTargetId === itemRow.worktree.id)
+  const workspaceShortcutIndex = ctx.workspaceShortcutIndexByRowKey.get(itemRow.rowKey)
   const isActiveWorktree =
     ctx.activeWorktreeId === itemRow.worktree.id &&
     (!ctx.activeWorkspaceExecutionHostId ||
@@ -225,6 +228,11 @@ export function renderWorktreeItemRow(
           itemRow.lineageGroupKey ? ctx.getLineageToggleHandler(itemRow.lineageGroupKey) : undefined
         }
       />
+      {workspaceShortcutIndex ? (
+        <div className="pointer-events-none absolute right-3 top-1.5 z-10">
+          <WorkspaceShortcutIndexBadge index={workspaceShortcutIndex} />
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/VirtualizedWorktreeViewport.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/VirtualizedWorktreeViewport.tsx
@@ -27,6 +27,7 @@ import { useWorktreeSidebarScrollSuppression } from './use-scroll-suppression'
 import { EMPTY_PROJECT_GROUPS, type VirtualizedWorktreeViewportProps } from './viewport-props'
 import { useWorktreeDropCommitContext } from '../drag/use-drop-commit-context'
 import { buildWorktreeVirtualRowContext } from './virtual-row-context'
+import { useWorkspaceShortcutIndexByRowKey } from '../../workspace-index-shortcut-badges'
 import { renderWorktreeVirtualRow } from '../rows/virtual-row-dispatch'
 
 const WORKTREE_SIDEBAR_SCROLL_STYLE: React.CSSProperties = {
@@ -64,6 +65,10 @@ export const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktr
   const scrollSuppression = useWorktreeSidebarScrollSuppression(scrollRef)
   const { markDirectScrollInput, markScrollMovement } = scrollSuppression
 
+  const workspaceShortcutIndexByRowKey = useWorkspaceShortcutIndexByRowKey(
+    rows,
+    pinnedDisplayPolicy
+  )
   const renderRows = useMemo(() => buildRenderableRows(rows), [rows])
   const firstHeaderIndex = useMemo(
     () => renderRows.findIndex((row) => row.type === 'header' || row.type === 'host-header'),
@@ -295,6 +300,7 @@ export const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktr
 
   const rowContext = buildWorktreeVirtualRowContext({
     props,
+    workspaceShortcutIndexByRowKey,
     renderRows,
     firstHeaderIndex,
     virtualization,

--- a/src/renderer/src/components/sidebar/worktree-list/viewport/virtual-row-context.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/viewport/virtual-row-context.ts
@@ -29,6 +29,7 @@ type BuildArgs = {
   sshConnectionStates: AppState['sshConnectionStates']
   newCardStyle: boolean
   folderBackedProjectGroupIds: ReadonlySet<string>
+  workspaceShortcutIndexByRowKey: ReadonlyMap<string, number>
   session: WorktreeDragSession
   runtime: WorktreeDragRuntime
   primaryActive: ReturnType<typeof usePrimaryActiveWorktreeRow>
@@ -115,6 +116,7 @@ export function buildWorktreeVirtualRowContext(args: BuildArgs): WorktreeVirtual
       folderBackedProjectGroupIds: args.folderBackedProjectGroupIds,
       groupKeyByRowKey: session.groupKeyByRowKey,
       groupIndexByRowKey: session.groupIndexByRowKey,
+      workspaceShortcutIndexByRowKey: args.workspaceShortcutIndexByRowKey,
       agentSendTargetWorktreeId: props.agentSendTargetWorktreeId,
       worktreeDragState: runtime.worktreeDragState,
       worktreePointerDragRef: runtime.worktreePointerDragRef,
@@ -142,6 +144,7 @@ export function buildWorktreeVirtualRowContext(args: BuildArgs): WorktreeVirtual
       activeWorktreeId: props.activeWorktreeId,
       currentWorktreeId: props.currentWorktreeId,
       selectedWorktreeIds: props.selectedWorktreeIds,
+      workspaceShortcutIndexByRowKey: args.workspaceShortcutIndexByRowKey,
       repoMap: props.repoMap,
       worktreeMap: props.worktreeMap,
       worktreeLineageById: props.worktreeLineageById,

--- a/src/renderer/src/components/sidebar/worktree-sidebar-row-preference.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-row-preference.test.ts
@@ -4,7 +4,10 @@ import type { ProjectGroup } from '../../../../shared/project-group-types'
 import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import type { HostSectionRow } from './host-section-rows'
-import { getRenderedWorktreesInSidebarOrder } from './worktree-sidebar-row-preference'
+import {
+  getRenderedWorktreeEntriesInSidebarOrder,
+  getRenderedWorktreesInSidebarOrder
+} from './worktree-sidebar-row-preference'
 
 const repo: Repo = {
   id: 'repo-1',
@@ -101,5 +104,31 @@ describe('getRenderedWorktreesInSidebarOrder', () => {
     expect(
       getRenderedWorktreesInSidebarOrder(rows, 'duplicate-in-groups').map(({ id }) => id)
     ).toEqual(['folder:folder-1', 'pinned', 'after-folder'])
+  })
+})
+
+describe('getRenderedWorktreeEntriesInSidebarOrder', () => {
+  it('reports the row key each card renders under, so Cmd+1-9 badges can address it', () => {
+    const pinned = worktree('pinned', true)
+    const rows: HostSectionRow[] = [
+      item(pinned, 'pinned'),
+      {
+        type: 'folder-workspace',
+        key: 'folder-workspace:folder-1',
+        folderWorkspace,
+        projectGroup,
+        depth: 0,
+        groupDepth: 0
+      },
+      item(pinned, 'repo:repo-1')
+    ]
+
+    expect(getRenderedWorktreeEntriesInSidebarOrder(rows, 'duplicate-in-groups')).toEqual([
+      {
+        rowKey: 'folder-workspace:folder-1',
+        worktree: expect.objectContaining({ id: 'folder:folder-1' })
+      },
+      { rowKey: 'repo:repo-1:pinned', worktree: pinned }
+    ])
   })
 })

--- a/src/renderer/src/components/sidebar/worktree-sidebar-row-preference.ts
+++ b/src/renderer/src/components/sidebar/worktree-sidebar-row-preference.ts
@@ -44,22 +44,34 @@ export function getPreferredWorktreeRows(
   return preferredRows
 }
 
-export function getRenderedWorktreesInSidebarOrder(
+/** One rendered workspace card: the key of the row that draws it plus the workspace it stands for. */
+export type RenderedSidebarWorktreeEntry = { rowKey: string; worktree: Worktree }
+
+export function getRenderedWorktreeEntriesInSidebarOrder(
   rows: readonly HostSectionRow[],
   pinnedDisplayPolicy: PinnedWorktreeDisplayPolicy
-): Worktree[] {
+): RenderedSidebarWorktreeEntry[] {
   const itemRows = rows.filter((row): row is WorktreeRow => row.type === 'item')
   const preferredRowKeys = new Set(
     getPreferredWorktreeRows(itemRows, pinnedDisplayPolicy).map((row) => row.rowKey)
   )
-  const renderedWorktrees: Worktree[] = []
+  const entries: RenderedSidebarWorktreeEntry[] = []
 
   for (const row of rows) {
     if (row.type === 'item' && preferredRowKeys.has(row.rowKey)) {
-      renderedWorktrees.push(row.worktree)
+      entries.push({ rowKey: row.rowKey, worktree: row.worktree })
     } else if (row.type === 'folder-workspace') {
-      renderedWorktrees.push(folderWorkspaceToWorktree(row.folderWorkspace))
+      entries.push({ rowKey: row.key, worktree: folderWorkspaceToWorktree(row.folderWorkspace) })
     }
   }
-  return renderedWorktrees
+  return entries
+}
+
+export function getRenderedWorktreesInSidebarOrder(
+  rows: readonly HostSectionRow[],
+  pinnedDisplayPolicy: PinnedWorktreeDisplayPolicy
+): Worktree[] {
+  return getRenderedWorktreeEntriesInSidebarOrder(rows, pinnedDisplayPolicy).map(
+    (entry) => entry.worktree
+  )
 }

--- a/src/shared/keybindings-digit-index.test.ts
+++ b/src/shared/keybindings-digit-index.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   findKeybindingConflicts,
+  getDigitIndexModifierChords,
   isDigitIndexActionId,
   keybindingFromInputForAction,
   matchKeybindingDigitIndex,
@@ -185,6 +186,26 @@ describe('digit-index shortcuts', () => {
     expect(normalizeKeybindingListForAction('tab.selectByIndex', 'Mod+P')).toMatchObject({
       ok: false
     })
+  })
+
+  it('resolves the modifiers that arm a range, for UI that reveals the digits while they are held', () => {
+    expect(getDigitIndexModifierChords('workspace.selectByIndex', 'darwin')).toEqual([
+      { meta: true, control: false, alt: false, shift: false }
+    ])
+    expect(getDigitIndexModifierChords('workspace.selectByIndex', 'win32')).toEqual([
+      { meta: false, control: true, alt: false, shift: false }
+    ])
+    expect(
+      getDigitIndexModifierChords('workspace.selectByIndex', 'darwin', {
+        'workspace.selectByIndex': ['Ctrl+Shift+1']
+      })
+    ).toEqual([{ meta: false, control: true, alt: false, shift: true }])
+    // An unbound row arms nothing, so no card gets a badge.
+    expect(
+      getDigitIndexModifierChords('workspace.selectByIndex', 'darwin', {
+        'workspace.selectByIndex': []
+      })
+    ).toEqual([])
   })
 
   it('lets the two ranges swap modifiers without a false conflict', () => {

--- a/src/shared/keybindings-digit-index.test.ts
+++ b/src/shared/keybindings-digit-index.test.ts
@@ -195,15 +195,23 @@ describe('digit-index shortcuts', () => {
     expect(getDigitIndexModifierChords('workspace.selectByIndex', 'win32')).toEqual([
       { meta: false, control: true, alt: false, shift: false }
     ])
+    // Why not a Shift example: matchKeybindingDigitIndex cannot match Shift+digit on macOS
+    // (the OS reports '!', not '1'), so a Shift binding is not a chord this can honestly arm.
     expect(
       getDigitIndexModifierChords('workspace.selectByIndex', 'darwin', {
-        'workspace.selectByIndex': ['Ctrl+Shift+1']
+        'workspace.selectByIndex': ['Alt+1']
       })
-    ).toEqual([{ meta: false, control: true, alt: false, shift: true }])
+    ).toEqual([{ meta: false, control: false, alt: true, shift: false }])
     // An unbound row arms nothing, so no card gets a badge.
     expect(
       getDigitIndexModifierChords('workspace.selectByIndex', 'darwin', {
         'workspace.selectByIndex': []
+      })
+    ).toEqual([])
+    // A hand-edited bare digit must not arm: an empty chord would match every ordinary keystroke.
+    expect(
+      getDigitIndexModifierChords('workspace.selectByIndex', 'darwin', {
+        'workspace.selectByIndex': ['1']
       })
     ).toEqual([])
   })

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -2260,6 +2260,11 @@ export function getDigitIndexModifierChords(
       continue
     }
     const chord = platformModifiers(parsed, platform)
+    // Why: canonicalizeDigitIndexBinding accepts a bare "1", so a hand-edited file can reach here
+    // with no modifier at all. An empty chord would arm on every ordinary keystroke.
+    if (!chord.meta && !chord.control && !chord.alt && !chord.shift) {
+      continue
+    }
     if (!chords.some((existing) => keybindingModifierChordsEqual(existing, chord))) {
       chords.push(chord)
     }

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -2240,6 +2240,40 @@ export function matchKeybindingDigitIndex(
   return null
 }
 
+export type KeybindingModifierChord = {
+  meta: boolean
+  control: boolean
+  alt: boolean
+  shift: boolean
+}
+
+/** Platform-resolved modifier combos that arm a digit-index action, so UI can reveal the 1-9 labels while one is held. */
+export function getDigitIndexModifierChords(
+  actionId: KeybindingActionId,
+  platform: NodeJS.Platform,
+  overrides?: KeybindingOverrides
+): KeybindingModifierChord[] {
+  const chords: KeybindingModifierChord[] = []
+  for (const binding of getEffectiveKeybindingsForAction(actionId, platform, overrides)) {
+    const parsed = parseKeybinding(binding)
+    if (!parsed || parsed.doubleTapModifier || !DIGIT_INDEX_KEY_PATTERN.test(parsed.key)) {
+      continue
+    }
+    const chord = platformModifiers(parsed, platform)
+    if (!chords.some((existing) => keybindingModifierChordsEqual(existing, chord))) {
+      chords.push(chord)
+    }
+  }
+  return chords
+}
+
+export function keybindingModifierChordsEqual(
+  a: KeybindingModifierChord,
+  b: KeybindingModifierChord
+): boolean {
+  return a.meta === b.meta && a.control === b.control && a.alt === b.alt && a.shift === b.shift
+}
+
 function formatModifierGlyph(modifier: ModifierToken, isMac: boolean): string {
   switch (modifier) {
     case 'Mod':


### PR DESCRIPTION
## What

Hold **⌘** (Ctrl on Windows/Linux) and each of the first nine workspace cards in the sidebar overlays the digit that jumps to it — the way Safari numbers tabs. Release the key, or move focus off the window, and the badges go away.

Before this, `workspace.selectByIndex` ("Select Workspace 1–9") was invisible: nothing told you which card a given number would land on.

## How the numbering stays honest

The jump handler resolves its target from the row order the sidebar publishes through `setVisibleWorktreeShortcutTargets`. The badges read the row keys out of that **same** walk (`getRenderedWorktreeEntriesInSidebarOrder`) instead of a second copy, so a badge can never label a card the chord would not activate. Pinned-row de-duping, folder workspaces, grouping and lineage nesting all follow from that one function.

Badges stay hidden whenever the chord would not act:

- outside the terminal view — the handler returns early there
- while Cmd+J is open — the digits address palette rows then
- when the user has unbound the action

## Cross-platform

The armed modifiers come from the user's *effective* binding, not a hardcoded `metaKey`: `getDigitIndexModifierChords()` resolves `Mod` to Meta on darwin and Control elsewhere, and honours overrides — remap the row to `Ctrl+Shift+1` and the badges arm on that chord instead.

A 400 ms hold delay keeps ordinary chords (⌘C, ⌘S) from strobing the sidebar.

## Files

| File | Change |
| --- | --- |
| `src/shared/keybindings.ts` | new `getDigitIndexModifierChords()` + chord equality helper |
| `src/renderer/src/components/sidebar/workspace-index-shortcut-badges.ts` | hold detection and the row-key → digit map |
| `src/renderer/src/components/sidebar/WorkspaceShortcutIndexBadge.tsx` | the chip, built on `ShortcutKeyCombo` with sidebar tokens |
| `worktree-sidebar-row-preference.ts` | order walk now also reports row keys |
| `item-row.tsx`, `folder-row.tsx`, `virtual-row-context.ts`, `VirtualizedWorktreeViewport.tsx` | wiring |

## Test plan

- `pnpm typecheck` and `pnpm lint` pass (lint covers the max-lines ratchet, localization and code-quality audits).
- `vitest src/renderer/src/components/sidebar src/shared/keybindings` — 276 files / 2386 tests pass, including two new cases: the row-key entries walk, and the platform/override resolution of the armed modifiers.
- Full suite: 13 files fail in `src/main/claude-accounts`, `src/main/skills`, `src/relay` (keychain / filesystem / subprocess). Nothing in this diff reaches those areas, but I did not confirm they fail on a clean tree.

**Not done:** no rendered check in the running app — badge placement (card top-right) and light/dark contrast are reasoned from the tokens, not seen. Worth an eye during review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SdXFcR11WcqQXiSRo4Jj1G
