### PR TITLE
fix(remote): keep locally opened file tabs in their own slots

### DIFF
--- a/src/renderer/src/runtime/web-session-tabs-sync-local-file-tab-order.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync-local-file-tab-order.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { toWebTerminalSurfaceTabId } from '../../../shared/terminal-surface-id'
+import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-types'
+import type { Tab } from '../../../shared/tab-types'
+import { applyWebSessionTabsSnapshot, type WebSessionTabsSyncState } from './web-session-tabs-sync'
+import {
+  ENV,
+  LEAF_ID,
+  NOW,
+  SECOND_LEAF_ID,
+  THIRD_LEAF_ID,
+  WT,
+  makeSnapshot,
+  makeState,
+  resetWebSessionTabsSyncTestState
+} from './web-session-tabs-sync-test-harness'
+
+vi.mock('../store', () => ({
+  useAppStore: {
+    setState: vi.fn()
+  }
+}))
+
+const AGENT_TAB_ID = toWebTerminalSurfaceTabId('host-agent')
+const SHELL_TAB_ID = toWebTerminalSurfaceTabId('host-shell')
+const EXTRA_TAB_ID = toWebTerminalSurfaceTabId('host-extra')
+const FILE_TAB_ID = 'local-file-tab'
+
+const LOCAL_FILE_TAB: Tab = {
+  id: FILE_TAB_ID,
+  entityId: 'local-file-agents-md',
+  groupId: 'host-group-1',
+  worktreeId: WT,
+  contentType: 'editor',
+  label: 'AGENTS.md',
+  customLabel: null,
+  color: null,
+  sortOrder: 2,
+  createdAt: NOW + 1,
+  isPreview: false,
+  isPinned: false
+}
+
+function hostSurface(
+  parentTabId: string,
+  leafId: string,
+  isActive: boolean
+): RuntimeMobileSessionTabsResult['tabs'][number] {
+  return {
+    type: 'terminal',
+    id: `${parentTabId}::${leafId}`,
+    title: parentTabId,
+    parentTabId,
+    leafId,
+    isActive,
+    status: 'ready',
+    terminal: `terminal-${parentTabId}`
+  }
+}
+
+const AGENT_SURFACE = hostSurface('host-agent', LEAF_ID, true)
+const SHELL_SURFACE = hostSurface('host-shell', SECOND_LEAF_ID, false)
+const EXTRA_SURFACE = hostSurface('host-extra', THIRD_LEAF_ID, false)
+
+/** Applies one host snapshot on top of a group whose tab order the client already holds. */
+function syncTabOrder(args: {
+  currentTabOrder: string[]
+  hostSurfaces: RuntimeMobileSessionTabsResult['tabs']
+  hostTabOrder?: string[]
+}): string[] | undefined {
+  const patch = applyWebSessionTabsSnapshot(
+    makeState({
+      unifiedTabsByWorktree: { [WT]: [LOCAL_FILE_TAB] },
+      groupsByWorktree: {
+        [WT]: [
+          {
+            id: 'host-group-1',
+            worktreeId: WT,
+            activeTabId: FILE_TAB_ID,
+            tabOrder: args.currentTabOrder
+          }
+        ]
+      }
+    }),
+    makeSnapshot(args.hostSurfaces, {
+      activeGroupId: 'host-group-1',
+      activeTabId: `host-agent::${LEAF_ID}`,
+      ...(args.hostTabOrder
+        ? {
+            tabGroups: [
+              { id: 'host-group-1', activeTabId: 'host-agent', tabOrder: args.hostTabOrder }
+            ]
+          }
+        : {})
+    }),
+    ENV,
+    NOW
+  ) as Partial<WebSessionTabsSyncState>
+  return patch.groupsByWorktree?.[WT]?.[0]?.tabOrder
+}
+
+describe('local file tab order on a remote host', () => {
+  beforeEach(resetWebSessionTabsSyncTestState)
+
+  it('keeps a Cmd-clicked file tab where it was opened instead of hoisting it to the front', () => {
+    expect(
+      syncTabOrder({
+        currentTabOrder: [AGENT_TAB_ID, SHELL_TAB_ID, FILE_TAB_ID],
+        hostSurfaces: [AGENT_SURFACE, SHELL_SURFACE],
+        hostTabOrder: ['host-agent', 'host-shell']
+      })
+    ).toEqual([AGENT_TAB_ID, SHELL_TAB_ID, FILE_TAB_ID])
+  })
+
+  it('keeps a file tab opened between two host tabs in its slot', () => {
+    expect(
+      syncTabOrder({
+        currentTabOrder: [AGENT_TAB_ID, FILE_TAB_ID, SHELL_TAB_ID],
+        hostSurfaces: [AGENT_SURFACE, SHELL_SURFACE],
+        hostTabOrder: ['host-agent', 'host-shell']
+      })
+    ).toEqual([AGENT_TAB_ID, FILE_TAB_ID, SHELL_TAB_ID])
+  })
+
+  it('still adopts a host reorder of the host-owned tabs', () => {
+    expect(
+      syncTabOrder({
+        currentTabOrder: [AGENT_TAB_ID, FILE_TAB_ID, SHELL_TAB_ID],
+        hostSurfaces: [AGENT_SURFACE, SHELL_SURFACE],
+        hostTabOrder: ['host-shell', 'host-agent']
+      })
+    ).toEqual([SHELL_TAB_ID, FILE_TAB_ID, AGENT_TAB_ID])
+  })
+
+  it('appends a newly published host tab after the existing order', () => {
+    expect(
+      syncTabOrder({
+        currentTabOrder: [AGENT_TAB_ID, FILE_TAB_ID, SHELL_TAB_ID],
+        hostSurfaces: [AGENT_SURFACE, SHELL_SURFACE, EXTRA_SURFACE],
+        hostTabOrder: ['host-agent', 'host-shell', 'host-extra']
+      })
+    ).toEqual([AGENT_TAB_ID, FILE_TAB_ID, SHELL_TAB_ID, EXTRA_TAB_ID])
+  })
+
+  it('does not let a retracted host tab consume a live host tab slot', () => {
+    expect(
+      syncTabOrder({
+        currentTabOrder: [EXTRA_TAB_ID, AGENT_TAB_ID, FILE_TAB_ID, SHELL_TAB_ID],
+        hostSurfaces: [AGENT_SURFACE, SHELL_SURFACE],
+        hostTabOrder: ['host-agent', 'host-shell']
+      })
+    ).toEqual([AGENT_TAB_ID, FILE_TAB_ID, SHELL_TAB_ID])
+  })
+
+  it('keeps the file tab in place on a host that publishes no tab groups', () => {
+    expect(
+      syncTabOrder({
+        currentTabOrder: [AGENT_TAB_ID, FILE_TAB_ID, SHELL_TAB_ID],
+        hostSurfaces: [AGENT_SURFACE, SHELL_SURFACE]
+      })
+    ).toEqual([AGENT_TAB_ID, FILE_TAB_ID, SHELL_TAB_ID])
+  })
+})

--- a/src/renderer/src/runtime/web-session-tabs-sync-local-file-tab-order.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync-local-file-tab-order.test.ts
@@ -67,6 +67,7 @@ function syncTabOrder(args: {
   currentTabOrder: string[]
   hostSurfaces: RuntimeMobileSessionTabsResult['tabs']
   hostTabOrder?: string[]
+  otherHostGroups?: { id: string; tabOrder: string[] }[]
 }): string[] | undefined {
   const patch = applyWebSessionTabsSnapshot(
     makeState({
@@ -88,7 +89,12 @@ function syncTabOrder(args: {
       ...(args.hostTabOrder
         ? {
             tabGroups: [
-              { id: 'host-group-1', activeTabId: 'host-agent', tabOrder: args.hostTabOrder }
+              { id: 'host-group-1', activeTabId: 'host-agent', tabOrder: args.hostTabOrder },
+              ...(args.otherHostGroups ?? []).map((group) => ({
+                id: group.id,
+                activeTabId: group.tabOrder[0] ?? null,
+                tabOrder: group.tabOrder
+              }))
             ]
           }
         : {})
@@ -96,7 +102,7 @@ function syncTabOrder(args: {
     ENV,
     NOW
   ) as Partial<WebSessionTabsSyncState>
-  return patch.groupsByWorktree?.[WT]?.[0]?.tabOrder
+  return patch.groupsByWorktree?.[WT]?.find((group) => group.id === 'host-group-1')?.tabOrder
 }
 
 describe('local file tab order on a remote host', () => {
@@ -150,6 +156,17 @@ describe('local file tab order on a remote host', () => {
         hostTabOrder: ['host-agent', 'host-shell']
       })
     ).toEqual([AGENT_TAB_ID, FILE_TAB_ID, SHELL_TAB_ID])
+  })
+
+  it('does not let a host tab that moved to another group pull a live tab past the file tab', () => {
+    expect(
+      syncTabOrder({
+        currentTabOrder: [SHELL_TAB_ID, FILE_TAB_ID, AGENT_TAB_ID],
+        hostSurfaces: [AGENT_SURFACE, SHELL_SURFACE],
+        hostTabOrder: ['host-agent'],
+        otherHostGroups: [{ id: 'host-group-2', tabOrder: ['host-shell'] }]
+      })
+    ).toEqual([FILE_TAB_ID, AGENT_TAB_ID])
   })
 
   it('keeps the file tab in place on a host that publishes no tab groups', () => {

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -2013,9 +2013,9 @@ function mergeHostTabOrderIntoLocalSlots(args: {
   currentTabOrder: readonly string[]
   localTabOrder: readonly string[]
   hostTabOrder: readonly string[]
-  mirroredUnifiedIds: ReadonlySet<string>
 }): string[] {
   const localTabIds = new Set(args.localTabOrder)
+  const hostTabIds = new Set(args.hostTabOrder)
   const merged: string[] = []
   const seen = new Set<string>()
   const push = (tabId: string | undefined): void => {
@@ -2028,8 +2028,8 @@ function mergeHostTabOrderIntoLocalSlots(args: {
   for (const tabId of args.currentTabOrder) {
     if (localTabIds.has(tabId)) {
       push(tabId)
-    } else if (args.mirroredUnifiedIds.has(tabId)) {
-      // Why: a slot that already held a mirrored tab absorbs the host's reorder; stale ids consume nothing.
+    } else if (hostTabIds.has(tabId)) {
+      // Why: only a slot the host still owns absorbs its reorder — a retracted or regrouped tab consumes nothing.
       push(args.hostTabOrder[hostIndex++])
     }
   }
@@ -2092,8 +2092,7 @@ function buildMirroredHostGroups({
     const mergedTabOrder = mergeHostTabOrderIntoLocalSlots({
       currentTabOrder: currentTabOrderByGroupId.get(hostGroup.id) ?? existing?.tabOrder ?? [],
       localTabOrder: existing?.tabOrder ?? [],
-      hostTabOrder: localHostOrder,
-      mirroredUnifiedIds
+      hostTabOrder: localHostOrder
     })
     // Why: a pending client reorder wins over a stale pre-move host order until the host echoes the move (or membership changes).
     const tabOrder = resolveWebSessionReorderedOrder(
@@ -3044,8 +3043,7 @@ function applyWebSessionTabsSnapshotWithContext(
       localTabOrder: target.tabOrder.filter((tabId) => validUnifiedTabIds.has(tabId)),
       hostTabOrder: mirroredUnifiedTabs
         .filter((tab) => !clientGroupIdByLocalTabId.has(tab.id))
-        .map((tab) => tab.id),
-      mirroredUnifiedIds
+        .map((tab) => tab.id)
     })
     const targetActiveTabId =
       nextActiveUnifiedTabId && targetOrder.includes(nextActiveUnifiedTabId)

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -2005,6 +2005,43 @@ function retainClientPlacedMirroredTabs(args: {
   })
 }
 
+/**
+ * Why: the host only owns the relative order of its own tabs, so local tabs keep the slots the
+ * client gave them instead of being hoisted ahead of every mirrored tab on each snapshot (#13055).
+ */
+function mergeHostTabOrderIntoLocalSlots(args: {
+  currentTabOrder: readonly string[]
+  localTabOrder: readonly string[]
+  hostTabOrder: readonly string[]
+  mirroredUnifiedIds: ReadonlySet<string>
+}): string[] {
+  const localTabIds = new Set(args.localTabOrder)
+  const merged: string[] = []
+  const seen = new Set<string>()
+  const push = (tabId: string | undefined): void => {
+    if (tabId !== undefined && !seen.has(tabId)) {
+      merged.push(tabId)
+      seen.add(tabId)
+    }
+  }
+  let hostIndex = 0
+  for (const tabId of args.currentTabOrder) {
+    if (localTabIds.has(tabId)) {
+      push(tabId)
+    } else if (args.mirroredUnifiedIds.has(tabId)) {
+      // Why: a slot that already held a mirrored tab absorbs the host's reorder; stale ids consume nothing.
+      push(args.hostTabOrder[hostIndex++])
+    }
+  }
+  for (const tabId of args.localTabOrder) {
+    push(tabId)
+  }
+  for (; hostIndex < args.hostTabOrder.length; hostIndex += 1) {
+    push(args.hostTabOrder[hostIndex])
+  }
+  return merged
+}
+
 function buildMirroredHostGroups({
   currentGroups,
   hostGroups,
@@ -2036,6 +2073,9 @@ function buildMirroredHostGroups({
     nextActiveUnifiedTabId
   })
   const groupsById = new Map(strippedGroups.map((group) => [group.id, group]))
+  const currentTabOrderByGroupId = new Map(
+    currentGroups.map((group) => [group.id, group.tabOrder] as const)
+  )
   const orderedGroups: TabGroup[] = []
   const seen = new Set<string>()
 
@@ -2049,17 +2089,18 @@ function buildMirroredHostGroups({
           validUnifiedTabIds.has(tabId) &&
           !clientGroupIdByLocalTabId.has(tabId)
       )
-    const localHostOrderIds = new Set(localHostOrder)
-    const hostTabOrder = [
-      ...(existing?.tabOrder.filter((tabId) => !localHostOrderIds.has(tabId)) ?? []),
-      ...localHostOrder
-    ]
+    const mergedTabOrder = mergeHostTabOrderIntoLocalSlots({
+      currentTabOrder: currentTabOrderByGroupId.get(hostGroup.id) ?? existing?.tabOrder ?? [],
+      localTabOrder: existing?.tabOrder ?? [],
+      hostTabOrder: localHostOrder,
+      mirroredUnifiedIds
+    })
     // Why: a pending client reorder wins over a stale pre-move host order until the host echoes the move (or membership changes).
     const tabOrder = resolveWebSessionReorderedOrder(
       { environmentId },
       worktreeId,
       hostGroup.id,
-      hostTabOrder,
+      mergedTabOrder,
       now
     )
     if (tabOrder.length === 0) {
@@ -2998,12 +3039,14 @@ function applyWebSessionTabsSnapshotWithContext(
       tabOrder: [],
       recentTabIds: []
     }
-    const targetOrder = [
-      ...target.tabOrder.filter((tabId) => validUnifiedTabIds.has(tabId)),
-      ...mirroredUnifiedTabs
+    const targetOrder = mergeHostTabOrderIntoLocalSlots({
+      currentTabOrder: currentGroups.find((group) => group.id === targetGroupId)?.tabOrder ?? [],
+      localTabOrder: target.tabOrder.filter((tabId) => validUnifiedTabIds.has(tabId)),
+      hostTabOrder: mirroredUnifiedTabs
         .filter((tab) => !clientGroupIdByLocalTabId.has(tab.id))
-        .map((tab) => tab.id)
-    ]
+        .map((tab) => tab.id),
+      mirroredUnifiedIds
+    })
     const targetActiveTabId =
       nextActiveUnifiedTabId && targetOrder.includes(nextActiveUnifiedTabId)
         ? nextActiveUnifiedTabId


### PR DESCRIPTION
## ELI5

On a remote host, opening a file from an agent's output shoved that file to the front of the tab bar and pushed your agent and terminals to the right. Now the file tab stays where it was opened.

## What Changed

Both places that rebuild a tab group after a host snapshot arrives composed the order as `[...local tabs, ...host tabs]`. That is the bug: it hoists every client-owned tab ahead of every mirrored one on *every* snapshot, so a freshly opened file tab lands at index 0.

`mergeHostTabOrderIntoLocalSlots` replaces both. It walks the order the client already holds and treats it as the slot layout:

- a local tab keeps its slot,
- a slot the host still owns absorbs the next tab from the host's order,
- leftover host tabs append at the end.

A slot only counts as host-owned if the tab sitting in it is still in *this* group's published host order. Keying it off "was mirrored at some point" instead would also match a tab the host had since retracted or moved to another group, and that vacated slot would pull a live tab ahead of the local tabs beside it — the same jump this PR removes.

Applied at both call sites:

- `buildMirroredHostGroups` — hosts that publish `tabGroups`.
- the fallback in `applyWebSessionTabsSnapshotWithContext` — hosts that don't, so an older host on the other end of the wire gets the same fix.

The host still owns the relative order of its own tabs; it just no longer owns where local tabs sit.

## Why

The client and the host each own part of the tab strip. The host owns its terminals, agents, and mirrored editors and is authoritative about their order relative to each other. It knows nothing about a file tab the client opened locally, so the reconcile had no position to restore for it and fell back to "put local tabs first" — which reads to the user as the tab jumping to the front, repeatedly, for as long as the session lives.

Positional substitution is the smallest change that expresses that split: the host supplies a *sequence*, the client supplies the *slots*.

## Linked Issue

Fixes #13055

Supersedes #13233 by @innocarpe, which is a month stale and now conflicts with `main`; this builds on that PR's slot-substitution idea, rebased onto current `main` (`main` has since added the `clientGroupIdByLocalTabId` filter to `localHostOrder`, which is preserved), extended to the no-`tabGroups` fallback path, and covered by end-to-end regression tests instead of a test-only export.

## Visual Proof

N/A — I have no remote host set up to record against, so I did not want to attach a staged local mock as if it were the real repro. The reported symptom and its screenshot are in #13055. The behavior is pinned instead by seven regression tests that drive `applyWebSessionTabsSnapshot` end to end; all fail on `main` and pass here:

```
× keeps a Cmd-clicked file tab where it was opened instead of hoisting it to the front
× keeps a file tab opened between two host tabs in its slot
× still adopts a host reorder of the host-owned tabs
× appends a newly published host tab after the existing order
× does not let a retracted host tab consume a live host tab slot
× does not let a host tab that moved to another group pull a live tab past the file tab
× keeps the file tab in place on a host that publishes no tab groups
```

Happy to record a before/after if a maintainer can point me at a remote host setup worth using.

## Testing

New file: `src/renderer/src/runtime/web-session-tabs-sync-local-file-tab-order.test.ts` (7 tests). Verified each one fails on unpatched `main` and passes with the fix — including the two that guard against over-correcting (the host reorder must still be adopted; a new host tab must still append).

Reviewer repro for the original bug:

1. Connect a client to an Orca remote server and open a workspace with an agent and a terminal tab.
2. Let the agent print a file path; Cmd-click it.
3. Before: the file tab appears at index 0, ahead of the agent. After: it appears where it was opened.

Ran locally on Linux: `pnpm lint`, `pnpm typecheck`, `pnpm test` (57,330 passed / 341 skipped), `pnpm build` — all pass.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with Claude Code (Claude Opus 5). I reviewed the diff and ran every gate locally.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Remote wire compatibility** — no wire change. No RPC param, stream frame, or published-content change; this is purely how the client reconciles a snapshot it already receives. Both host shapes are handled: the `tabGroups` path and the pre-`tabGroups` fallback, so a new client against an old host and an old client against a new host both behave as before except for the fixed ordering. An old client is unaffected because nothing the host publishes changed.
- **SSH / remote** — this is the remote path; local sessions never reach these builders (no host snapshot to reconcile). Per `docs/reference/ssh-execution-boundary.md` nothing here reports on, stops, or lists remote work — it only orders tabs the host already published.
- **Cross-platform** — pure renderer-side array logic. No paths, no shell, no keyboard shortcuts, no platform branches.
- **Folder workspaces** — nothing here reads git state; worktree and folder workspaces are treated identically.
- **Mobile** — the same builders serve the mobile session path; the mobile behavior change is the same fix (local tabs stop jumping to the front). Note #15219 is a separate mobile tab bug and is not addressed here.
- **Performance** — one extra `Map` over the group list per snapshot and one linear pass per group, replacing a `filter` that did an `O(n)` `Set` lookup per element. Same order of complexity, marginally less allocation.
- **Security** — no new inputs, no I/O, no serialization, no privilege boundary touched.
- **Backwards compatibility** — when the client holds no prior order for a group (first sync), the merge degrades to exactly the old `[...local, ...host]` composition, so hydration from cold is byte-identical to before.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
