### PR TITLE
feat(browser): add workspace-scoped browser session profiles (#14559)

### DIFF
--- a/src/main/browser/browser-session-persisted-profile-validation.ts
+++ b/src/main/browser/browser-session-persisted-profile-validation.ts
@@ -4,6 +4,9 @@ import type { BrowserSessionProfile } from '../../shared/browser-workspace-types
 const BROWSER_SESSION_PROFILE_ID_RE =
   /^[\da-f-]{8}-[\da-f-]{4}-[\da-f-]{4}-[\da-f-]{4}-[\da-f-]{12}$/
 
+// Why: workspace profiles use deterministic SHA-256 hex IDs instead of UUIDs.
+const WORKSPACE_PROFILE_ID_RE = /^[\da-f]{32}$/
+
 // Why: validate on-disk profile shape so a tampered JSON file can't inject an arbitrary partition into the will-attach-webview allowlist.
 export function isValidPersistedBrowserSessionProfile(
   profile: unknown,
@@ -22,7 +25,9 @@ export function isValidPersistedBrowserSessionProfile(
     (candidate.userAgentMode === undefined ||
       candidate.userAgentMode === 'clean' ||
       candidate.userAgentMode === 'native') &&
-    isProfileOwnedSessionPartition(candidate.id, candidate.partition, activeOrcaProfileId)
+    (candidate.scope === 'workspace'
+      ? isWorkspaceOwnedSessionPartition(candidate.id, candidate.partition, activeOrcaProfileId)
+      : isProfileOwnedSessionPartition(candidate.id, candidate.partition, activeOrcaProfileId))
   )
 }
 
@@ -33,6 +38,17 @@ function isProfileOwnedSessionPartition(
 ): boolean {
   return (
     BROWSER_SESSION_PROFILE_ID_RE.test(profileId) &&
+    partition === getOrcaProfileBrowserSessionPartition(activeOrcaProfileId, profileId)
+  )
+}
+
+function isWorkspaceOwnedSessionPartition(
+  profileId: string,
+  partition: string,
+  activeOrcaProfileId: string
+): boolean {
+  return (
+    WORKSPACE_PROFILE_ID_RE.test(profileId) &&
     partition === getOrcaProfileBrowserSessionPartition(activeOrcaProfileId, profileId)
   )
 }

--- a/src/main/browser/browser-session-registry.test.ts
+++ b/src/main/browser/browser-session-registry.test.ts
@@ -226,6 +226,21 @@ describe('BrowserSessionRegistry', () => {
     expect(browserSessionRegistry.isAllowedPartition(claimedPartition)).toBe(false)
   })
 
+  it('hydrates workspace-scoped profiles from persisted data', () => {
+    const hexId = '0123456789abcdef0123456789abcdef'
+    const fakeWorkspaceProfile = {
+      id: hexId,
+      scope: 'workspace' as const,
+      partition: `persist:orca-browser-session-${hexId}`,
+      label: 'my-project',
+      source: null,
+      folderPath: '/Users/dev/my-project'
+    }
+    browserSessionRegistry.hydrateFromPersisted([fakeWorkspaceProfile])
+    expect(browserSessionRegistry.getProfile(hexId)).not.toBeNull()
+    expect(browserSessionRegistry.isAllowedPartition(fakeWorkspaceProfile.partition)).toBe(true)
+  })
+
   it('sets up session policies for new partitions', () => {
     browserSessionRegistry.createProfile('isolated', 'Policy Test')
     expect(sessionFromPartitionMock).toHaveBeenCalled()
@@ -585,6 +600,85 @@ describe('BrowserSessionRegistry', () => {
       const modified = callback.mock.calls[0][0].requestHeaders
       expect(modified.Cookie).toBe('abc=123')
       expect(modified.Accept).toBe('text/html')
+    })
+  })
+
+  describe('workspace-scoped profiles', () => {
+    it('creates a workspace profile for a folder path', () => {
+      const profile = browserSessionRegistry.resolveOrCreateWorkspaceProfile('/Users/dev/my-app')
+      expect(profile).not.toBeNull()
+      expect(profile.scope).toBe('workspace')
+      expect(profile.partition).toMatch(/^persist:orca-browser-session-/)
+      expect(profile.folderPath).toBe('/Users/dev/my-app')
+    })
+
+    it('returns the same profile for the same folder path', () => {
+      const first = browserSessionRegistry.resolveOrCreateWorkspaceProfile('/Users/dev/project-a')
+      const second = browserSessionRegistry.resolveOrCreateWorkspaceProfile('/Users/dev/project-a')
+      expect(first.id).toBe(second.id)
+      expect(first.partition).toBe(second.partition)
+    })
+
+    it('returns different profiles for different folders', () => {
+      const profileA = browserSessionRegistry.resolveOrCreateWorkspaceProfile('/Users/dev/app-a')
+      const profileB = browserSessionRegistry.resolveOrCreateWorkspaceProfile('/Users/dev/app-b')
+      expect(profileA.id).not.toBe(profileB.id)
+      expect(profileA.partition).not.toBe(profileB.partition)
+    })
+
+    it('allows the workspace partition', () => {
+      const profile = browserSessionRegistry.resolveOrCreateWorkspaceProfile('/Users/dev/allowed')
+      expect(browserSessionRegistry.isAllowedPartition(profile.partition)).toBe(true)
+    })
+
+    it('finds a profile by folder path', () => {
+      browserSessionRegistry.resolveOrCreateWorkspaceProfile('/Users/dev/find-me')
+      const found = browserSessionRegistry.findProfileByFolderPath('/Users/dev/find-me')
+      expect(found).not.toBeNull()
+      expect(found!.scope).toBe('workspace')
+    })
+
+    it('returns null for unknown folder path', () => {
+      const found = browserSessionRegistry.findProfileByFolderPath('/Users/dev/nonexistent')
+      expect(found).toBeNull()
+    })
+
+    it('deletes a workspace profile', async () => {
+      const profile = browserSessionRegistry.resolveOrCreateWorkspaceProfile('/Users/dev/delete-me')
+      expect(browserSessionRegistry.isAllowedPartition(profile.partition)).toBe(true)
+      const deleted = await browserSessionRegistry.deleteProfile(profile.id)
+      expect(deleted).toBe(true)
+      expect(browserSessionRegistry.isAllowedPartition(profile.partition)).toBe(false)
+    })
+
+    it('accepts workspace scope in createProfile', () => {
+      const profile = browserSessionRegistry.createProfile('workspace', 'Manual Workspace')
+      expect(profile).not.toBeNull()
+      expect(profile!.scope).toBe('workspace')
+    })
+
+    it('uses folder basename as label', () => {
+      const profile = browserSessionRegistry.resolveOrCreateWorkspaceProfile(
+        '/Users/dev/my-cool-project'
+      )
+      expect(profile.label).toBe('my-cool-project')
+    })
+
+    it('clears storage data for a specific profile without deleting it', async () => {
+      const profile = browserSessionRegistry.resolveOrCreateWorkspaceProfile('/Users/dev/clear-storage')
+      const mockSession = sessionFromPartitionMock.mock.results.find(
+        (_, i) => sessionFromPartitionMock.mock.calls[i]?.[0] === profile.partition
+      )?.value
+      const cleared = await browserSessionRegistry.clearProfileStorage(profile.id)
+      expect(cleared).toBe(true)
+      expect(mockSession?.clearStorageData).toHaveBeenCalled()
+      expect(mockSession?.clearCache).toHaveBeenCalled()
+      expect(browserSessionRegistry.getProfile(profile.id)).not.toBeNull()
+    })
+
+    it('returns false when clearing storage for a non-existent profile', async () => {
+      const cleared = await browserSessionRegistry.clearProfileStorage('non-existent-id')
+      expect(cleared).toBe(false)
     })
   })
 })

--- a/src/main/browser/browser-session-registry.test.ts
+++ b/src/main/browser/browser-session-registry.test.ts
@@ -651,10 +651,9 @@ describe('BrowserSessionRegistry', () => {
       expect(browserSessionRegistry.isAllowedPartition(profile.partition)).toBe(false)
     })
 
-    it('accepts workspace scope in createProfile', () => {
-      const profile = browserSessionRegistry.createProfile('workspace', 'Manual Workspace')
-      expect(profile).not.toBeNull()
-      expect(profile!.scope).toBe('workspace')
+    it('rejects creating a workspace profile via generic createProfile', () => {
+      const profile = browserSessionRegistry.createProfile('workspace' as never, 'Manual Workspace')
+      expect(profile).toBeNull()
     })
 
     it('uses folder basename as label', () => {

--- a/src/main/browser/browser-session-registry.ts
+++ b/src/main/browser/browser-session-registry.ts
@@ -1,6 +1,6 @@
 import { app, session } from 'electron'
 import { createHash, randomUUID } from 'node:crypto'
-import { join, resolve } from 'node:path'
+import { basename, join, resolve } from 'node:path'
 import { ORCA_BROWSER_PARTITION } from '../../shared/constants'
 import {
   DEFAULT_LOCAL_ORCA_PROFILE_ID,
@@ -183,8 +183,9 @@ class BrowserSessionRegistry {
     options: BrowserSessionProfileCreateOptions = {}
   ): BrowserSessionProfile | null {
     // Why: the registry is also an IPC boundary, so runtime types alone cannot keep invalid values out of persisted metadata.
+    // Why: workspace profiles must only be created through resolveOrCreateWorkspaceProfile with deterministic IDs and folderPath.
     if (
-      (scope !== 'isolated' && scope !== 'imported' && scope !== 'workspace') ||
+      (scope !== 'isolated' && scope !== 'imported') ||
       (options.userAgentMode !== undefined &&
         options.userAgentMode !== 'clean' &&
         options.userAgentMode !== 'native')
@@ -233,7 +234,7 @@ class BrowserSessionRegistry {
 
     const id = BrowserSessionRegistry.workspaceProfileId(normalized)
     const partition = getOrcaProfileBrowserSessionPartition(this.activeOrcaProfileId, id)
-    const folderName = normalized.split('/').pop() ?? normalized.split('\\').pop() ?? 'Workspace'
+    const folderName = basename(normalized) || 'Workspace'
     const profile: BrowserSessionProfile = {
       id,
       scope: 'workspace',

--- a/src/main/browser/browser-session-registry.ts
+++ b/src/main/browser/browser-session-registry.ts
@@ -1,6 +1,6 @@
 import { app, session } from 'electron'
-import { randomUUID } from 'node:crypto'
-import { join } from 'node:path'
+import { createHash, randomUUID } from 'node:crypto'
+import { join, resolve } from 'node:path'
 import { ORCA_BROWSER_PARTITION } from '../../shared/constants'
 import {
   DEFAULT_LOCAL_ORCA_PROFILE_ID,
@@ -184,7 +184,7 @@ class BrowserSessionRegistry {
   ): BrowserSessionProfile | null {
     // Why: the registry is also an IPC boundary, so runtime types alone cannot keep invalid values out of persisted metadata.
     if (
-      (scope !== 'isolated' && scope !== 'imported') ||
+      (scope !== 'isolated' && scope !== 'imported' && scope !== 'workspace') ||
       (options.userAgentMode !== undefined &&
         options.userAgentMode !== 'clean' &&
         options.userAgentMode !== 'native')
@@ -201,6 +201,46 @@ class BrowserSessionRegistry {
       label,
       source: null,
       ...(options.userAgentMode ? { userAgentMode: options.userAgentMode } : {})
+    }
+    this.profiles.set(id, profile)
+    installBrowserSessionPartitionPolicies(profile)
+    this.persistProfiles()
+    return profile
+  }
+
+  // Why: deterministic hash gives a stable profile ID for any folder path, surviving restarts and re-creation.
+  private static workspaceProfileId(folderPath: string): string {
+    return createHash('sha256').update(resolve(folderPath)).digest('hex').slice(0, 32)
+  }
+
+  findProfileByFolderPath(folderPath: string): BrowserSessionProfile | null {
+    const normalized = resolve(folderPath)
+    for (const profile of this.profiles.values()) {
+      if (profile.scope === 'workspace' && profile.folderPath === normalized) {
+        return profile
+      }
+    }
+    return null
+  }
+
+  // Why: auto-creates a workspace-scoped profile the first time a folder's browser tab is opened; subsequent calls return the same profile.
+  resolveOrCreateWorkspaceProfile(folderPath: string): BrowserSessionProfile {
+    const normalized = resolve(folderPath)
+    const existing = this.findProfileByFolderPath(normalized)
+    if (existing) {
+      return existing
+    }
+
+    const id = BrowserSessionRegistry.workspaceProfileId(normalized)
+    const partition = getOrcaProfileBrowserSessionPartition(this.activeOrcaProfileId, id)
+    const folderName = normalized.split('/').pop() ?? normalized.split('\\').pop() ?? 'Workspace'
+    const profile: BrowserSessionProfile = {
+      id,
+      scope: 'workspace',
+      partition,
+      label: folderName,
+      source: null,
+      folderPath: normalized
     }
     this.profiles.set(id, profile)
     installBrowserSessionPartitionPolicies(profile)
@@ -274,6 +314,22 @@ class BrowserSessionRegistry {
 
       const sess = session.fromPartition(this.defaultPartition)
       await sess.clearStorageData({ storages: ['cookies'] })
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  // Why: clears cookies and storage data for a specific profile without deleting the profile metadata itself.
+  async clearProfileStorage(profileId: string): Promise<boolean> {
+    const profile = this.profiles.get(profileId)
+    if (!profile) {
+      return false
+    }
+    try {
+      const sess = session.fromPartition(profile.partition)
+      await sess.clearStorageData()
+      await sess.clearCache()
       return true
     } catch {
       return false

--- a/src/main/ipc/browser-session-profile-ipc.ts
+++ b/src/main/ipc/browser-session-profile-ipc.ts
@@ -21,6 +21,8 @@ export function registerBrowserSessionProfileHandlers(): void {
   ipcMain.removeHandler('browser:session:deleteProfile')
   ipcMain.removeHandler('browser:session:importCookies')
   ipcMain.removeHandler('browser:session:resolvePartition')
+  ipcMain.removeHandler('browser:session:resolveWorkspaceProfile')
+  ipcMain.removeHandler('browser:session:clearProfileStorage')
 
   ipcMain.handle('browser:session:listProfiles', (event): BrowserSessionProfile[] => {
     if (!isTrustedBrowserRenderer(event.sender)) {
@@ -96,6 +98,20 @@ export function registerBrowserSessionProfileHandlers(): void {
     }
   )
 
+  ipcMain.handle(
+    'browser:session:resolveWorkspaceProfile',
+    (event, args: { folderPath: string }): BrowserSessionProfile | null => {
+      if (!isTrustedBrowserRenderer(event.sender)) {
+        return null
+      }
+      // Why: folderPath comes from the renderer; reject traversal patterns.
+      if (!args.folderPath || args.folderPath.includes('..')) {
+        return null
+      }
+      return browserSessionRegistry.resolveOrCreateWorkspaceProfile(args.folderPath)
+    }
+  )
+
   ipcMain.removeHandler('browser:session:clearDefaultCookies')
 
   ipcMain.handle('browser:session:clearDefaultCookies', async (event): Promise<boolean> => {
@@ -104,6 +120,16 @@ export function registerBrowserSessionProfileHandlers(): void {
     }
     return browserSessionRegistry.clearDefaultSessionCookies()
   })
+
+  ipcMain.handle(
+    'browser:session:clearProfileStorage',
+    async (event, args: { profileId: string }): Promise<boolean> => {
+      if (!isTrustedBrowserRenderer(event.sender)) {
+        return false
+      }
+      return browserSessionRegistry.clearProfileStorage(args.profileId)
+    }
+  )
 
   ipcMain.removeHandler('browser:session:detectBrowsers')
   ipcMain.removeHandler('browser:session:importFromBrowser')

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -1517,7 +1517,7 @@ export class RuntimeBrowserCommands {
 
   async browserProfileCreate(params: {
     label: string
-    scope: 'isolated' | 'imported' | 'workspace'
+    scope: 'isolated' | 'imported'
     userAgentMode?: BrowserSessionUserAgentMode
   }): Promise<BrowserProfileCreateResult> {
     return {

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -1517,7 +1517,7 @@ export class RuntimeBrowserCommands {
 
   async browserProfileCreate(params: {
     label: string
-    scope: 'isolated' | 'imported'
+    scope: 'isolated' | 'imported' | 'workspace'
     userAgentMode?: BrowserSessionUserAgentMode
   }): Promise<BrowserProfileCreateResult> {
     return {

--- a/src/preload/api/browser-api.ts
+++ b/src/preload/api/browser-api.ts
@@ -118,6 +118,9 @@ export type BrowserApi = {
   sessionDeleteProfile: (args: { profileId: string }) => Promise<boolean>
   sessionImportCookies: (args: { profileId: string }) => Promise<BrowserCookieImportResult>
   sessionResolvePartition: (args: { profileId: string | null }) => Promise<string | null>
+  sessionResolveWorkspaceProfile: (args: {
+    folderPath: string
+  }) => Promise<BrowserSessionProfile | null>
   sessionDetectBrowsers: () => Promise<DetectedBrowserInfo[]>
   sessionImportFromBrowser: (args: {
     profileId: string
@@ -125,6 +128,7 @@ export type BrowserApi = {
     browserProfile?: string
   }) => Promise<BrowserCookieImportResult>
   sessionClearDefaultCookies: () => Promise<boolean>
+  sessionClearProfileStorage: (args: { profileId: string }) => Promise<boolean>
   notifyActiveTabChanged: (args: { browserPageId: string }) => Promise<boolean>
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3015,6 +3015,9 @@ const api = {
     sessionResolvePartition: (args: { profileId: string | null }): Promise<string | null> =>
       ipcRenderer.invoke('browser:session:resolvePartition', args),
 
+    sessionResolveWorkspaceProfile: (args: { folderPath: string }): Promise<unknown> =>
+      ipcRenderer.invoke('browser:session:resolveWorkspaceProfile', args),
+
     sessionDetectBrowsers: (): Promise<unknown[]> =>
       ipcRenderer.invoke('browser:session:detectBrowsers'),
 
@@ -3027,6 +3030,9 @@ const api = {
 
     sessionClearDefaultCookies: (): Promise<boolean> =>
       ipcRenderer.invoke('browser:session:clearDefaultCookies'),
+
+    sessionClearProfileStorage: (args: { profileId: string }): Promise<boolean> =>
+      ipcRenderer.invoke('browser:session:clearProfileStorage', args),
 
     notifyActiveTabChanged: (args: { browserPageId: string }): Promise<boolean> =>
       ipcRenderer.invoke('browser:activeTabChanged', args)

--- a/src/shared/browser-workspace-types.ts
+++ b/src/shared/browser-workspace-types.ts
@@ -105,7 +105,7 @@ export type BrowserWorkspace = {
 
 export type BrowserTab = BrowserWorkspace
 
-export type BrowserSessionProfileScope = 'default' | 'isolated' | 'imported'
+export type BrowserSessionProfileScope = 'default' | 'isolated' | 'imported' | 'workspace'
 
 export type BrowserSessionUserAgentMode = 'clean' | 'native'
 
@@ -135,6 +135,8 @@ export type BrowserSessionProfile = {
   label: string
   source: BrowserSessionProfileSource | null
   userAgentMode?: BrowserSessionUserAgentMode
+  /** Normalized folder path for workspace-scoped profiles. */
+  folderPath?: string
 }
 
 export type BrowserCookieImportSummary = {


### PR DESCRIPTION
## ELI5

When working across multiple workspace folders that run local dev servers (e.g. `localhost:3000`), their cookies, authentication, and localStorage previously collided because all workspaces shared the default browser session. This change adds automatic workspace-scoped browser session profiles derived deterministically from the workspace folder path, giving each project folder its own isolated browser storage partition.

## What Changed

- **Types (`src/shared/browser-workspace-types.ts`)**: Added `'workspace'` scope to `BrowserSessionProfileScope` and optional `folderPath?: string` to `BrowserSessionProfile`.
- **Registry (`src/main/browser/browser-session-registry.ts`)**:
  - Added `resolveOrCreateWorkspaceProfile(folderPath)` to lazily instantiate and register folder-bound sessions.
  - Added `findProfileByFolderPath(folderPath)` for lookup.
  - Derived stable 32-character hex profile IDs using SHA-256 over normalized folder paths, ensuring deterministic partition naming across app restarts.
  - Added `clearProfileStorage(profileId)` to clear cookies and cache for a workspace session without destroying profile metadata.
- **Persisted Profile Validation (`src/main/browser/browser-session-persisted-profile-validation.ts`)**: Added support for validating persisted workspace-scoped profiles and their deterministic hex IDs alongside UUID profiles.
- **IPC & Runtime (`src/main/ipc/browser-session-profile-ipc.ts`, `src/main/runtime/orca-runtime-browser.ts`)**: Added `browser:session:resolveWorkspaceProfile` (with path-traversal validation) and `browser:session:clearProfileStorage` handlers.
- **Preload API (`src/preload/api/browser-api.ts`, `src/preload/index.ts`)**: Exposed `sessionResolveWorkspaceProfile` and `sessionClearProfileStorage` to the context bridge.
- **Tests (`src/main/browser/browser-session-registry.test.ts`)**: Added comprehensive unit tests covering creation, deduplication, folder lookup, partition allowlist checks, storage clearance, and hydration from persisted disk metadata.

## Why

Multi-project workflows and agent runs frequently collide when projects share local ports and domains. Integrating folder-scoped sessions directly into the existing `BrowserSessionRegistry` maintains Orca's security boundary (including the `will-attach-webview` guard and per-partition security policies) while enabling zero-friction session isolation.

## Linked Issue

Fixes #14559

## Visual Proof

`N/A` — backend session registry and IPC infrastructure addition with no UI changes.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Unit tests added to `src/main/browser/browser-session-registry.test.ts`:
- `creates a workspace profile for a folder path`
- `returns the same profile for the same folder path`
- `returns different profiles for different folders`
- `allows the workspace partition in allowlist`
- `finds a profile by folder path`
- `deletes a workspace profile`
- `clears storage data for a specific profile without deleting it`
- `hydrates workspace-scoped profiles from persisted data`

## AI Disclosure

Assisted with architecture analysis, implementation, and test creation using Gemini 3.7 Flash.

## Review

### Code review summary
- **Cross-platform**: Uses Node `crypto.createHash`, `path.resolve`, and Electron's platform-neutral `session.fromPartition` API.
- **SSH / Remote**: Partition IDs are deterministic strings that serialize cleanly and work across runtime environments.
- **Security**: All partitions are registered through `BrowserSessionRegistry` and pass the `will-attach-webview` guard. Folder paths from IPC are validated against path traversal.
- **Backward compatibility**: Existing profiles (`'default'`, `'isolated'`, `'imported'`) and legacy unpartitioned tabs remain untouched.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)