### PR TITLE
feat(runtime): per-file progress and cancel for files dropped onto a remote workspace

### DIFF
--- a/src/main/ipc/filesystem-import-result-types.ts
+++ b/src/main/ipc/filesystem-import-result-types.ts
@@ -48,4 +48,6 @@ export type StagedExternalImportSource =
 
 export type StagedExternalImportEntry =
   | { relativePath: string; kind: 'directory' }
-  | { relativePath: string; kind: 'file'; contentBase64: string }
+  // Why: file bodies are streamed in slices at upload time, so staging carries
+  // only the size the uploader reports and validates against.
+  | { relativePath: string; kind: 'file'; byteLength: number }

--- a/src/main/ipc/filesystem-import.test.ts
+++ b/src/main/ipc/filesystem-import.test.ts
@@ -514,11 +514,12 @@ describe('fs:importExternalPaths', () => {
         status: 'staged',
         name: 'logo.png',
         kind: 'file',
-        entries: [{ relativePath: '', kind: 'file', contentBase64: 'cG5n' }]
+        entries: [{ relativePath: '', kind: 'file', byteLength: 4 }]
       }
     ])
     expect(copyFileMock).not.toHaveBeenCalled()
-    expect(readFileHandleMock).toHaveBeenCalled()
+    // Why: bodies stream at upload time, so staging must never read the file.
+    expect(readFileHandleMock).not.toHaveBeenCalled()
     expect(closeMock).toHaveBeenCalled()
   })
 
@@ -597,7 +598,7 @@ describe('fs:importExternalPaths', () => {
         entries: [
           { relativePath: '', kind: 'directory' },
           { relativePath: '..assets', kind: 'directory' },
-          { relativePath: '..assets/icon.txt', kind: 'file', contentBase64: 'aWNvbg==' }
+          { relativePath: '..assets/icon.txt', kind: 'file', byteLength: 4 }
         ]
       }
     ])
@@ -637,14 +638,15 @@ describe('fs:importExternalPaths', () => {
     expect(openMock).not.toHaveBeenCalled()
   })
 
-  it('checks runtime upload directory byte budget before reading a file that exceeds the total cap', async () => {
+  it('checks runtime upload directory byte budget before opening a file that exceeds the total cap', async () => {
     const sourcePath = '/tmp/dropped/project'
     const resolvedPath = path.resolve(sourcePath)
     const filePaths = ['one.bin', 'two.bin', 'three.bin', 'four.bin', 'overflow.bin'].map((name) =>
       path.join(resolvedPath, name)
     )
     const mib = 1024 * 1024
-    const regularSize = 25 * mib
+    // Four files exactly fill the 8 GB total ceiling; the fifth pushes past it.
+    const regularSize = 2 * 1024 * mib
     const overflowSize = Number(mib)
     const readFileMock = vi.fn().mockResolvedValue(Buffer.from('chunk'))
 
@@ -702,11 +704,9 @@ describe('fs:importExternalPaths', () => {
       sourcePaths: [sourcePath]
     })) as { sources: { status: string; reason?: string }[] }
 
-    expect(result.sources[0]).toMatchObject({
-      status: 'failed',
-      reason: 'Remote import is too large'
-    })
-    expect(readFileMock).toHaveBeenCalledTimes(4)
+    expect(result.sources[0]).toMatchObject({ status: 'failed' })
+    expect(result.sources[0]?.reason).toContain('total remote import limit')
+    expect(readFileMock).not.toHaveBeenCalled()
     expect(openMock).not.toHaveBeenCalledWith(filePaths.at(-1), expect.anything())
   })
 

--- a/src/main/ipc/filesystem-mutations.ts
+++ b/src/main/ipc/filesystem-mutations.ts
@@ -20,6 +20,10 @@ import type {
 import { importOneSource } from './filesystem-import-local'
 import { stageOneSourceForRuntimeUpload } from './filesystem-runtime-upload-staging'
 import { streamExternalFileToRuntime } from './runtime-upload-file-stream'
+import {
+  RUNTIME_UPLOAD_PROGRESS_CHANNEL,
+  throttleRuntimeUploadProgress
+} from './runtime-upload-progress'
 
 /**
  * IPC handlers for file/folder creation and renaming.
@@ -210,17 +214,28 @@ export function registerFilesystemMutationHandlers(store: Store): void {
   ipcMain.handle(
     'fs:uploadExternalFileToRuntime',
     async (
-      _event,
+      event,
       args: {
         environmentId: string
         sourceRootPath: string
         entryRelativePath: string
         worktree: string
         relativePath: string
+        uploadId?: string
         expectedEnvironmentPairingRevision?: number
       } & SshMutationExpectation
-    ): Promise<{ byteLength: number }> =>
-      streamExternalFileToRuntime({
+    ): Promise<{ byteLength: number }> => {
+      const uploadId = args.uploadId
+      // Why: replies to the frame that asked, so a second window's drop cannot
+      // move this one's progress bar.
+      const emit = uploadId
+        ? throttleRuntimeUploadProgress((progress) => {
+            if (!event.sender.isDestroyed()) {
+              event.sender.send(RUNTIME_UPLOAD_PROGRESS_CHANNEL, progress)
+            }
+          })
+        : null
+      return streamExternalFileToRuntime({
         userDataPath: app.getPath('userData'),
         environmentId: args.environmentId,
         sourceRootPath: args.sourceRootPath,
@@ -230,8 +245,13 @@ export function registerFilesystemMutationHandlers(store: Store): void {
         expectedExecutionHostId: args.expectedExecutionHostId,
         expectedSshTargetId: args.expectedSshTargetId,
         expectedSshConnectionGeneration: args.expectedSshConnectionGeneration,
-        expectedEnvironmentPairingRevision: args.expectedEnvironmentPairingRevision
+        expectedEnvironmentPairingRevision: args.expectedEnvironmentPairingRevision,
+        onProgress:
+          emit && uploadId
+            ? ({ sentBytes, totalBytes }) => emit({ uploadId, sentBytes, totalBytes })
+            : undefined
       })
+    }
   )
 
   // Why: terminal drag-and-drop resolver. Local worktrees pass paths through

--- a/src/main/ipc/filesystem-mutations.ts
+++ b/src/main/ipc/filesystem-mutations.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron'
+import { app, ipcMain } from 'electron'
 import { constants } from 'node:fs'
 import { copyFile, mkdir, writeFile } from 'node:fs/promises'
 import { basename, dirname } from 'node:path'
@@ -19,6 +19,7 @@ import type {
 } from './filesystem-import-result-types'
 import { importOneSource } from './filesystem-import-local'
 import { stageOneSourceForRuntimeUpload } from './filesystem-runtime-upload-staging'
+import { streamExternalFileToRuntime } from './runtime-upload-file-stream'
 
 /**
  * IPC handlers for file/folder creation and renaming.
@@ -201,6 +202,36 @@ export function registerFilesystemMutationHandlers(store: Store): void {
       }
       return { sources }
     }
+  )
+
+  // Why: the file handle and the runtime socket both live in main, so the byte
+  // pump runs here. The renderer keeps deconflict/commit/rollback orchestration
+  // and never sees file contents.
+  ipcMain.handle(
+    'fs:uploadExternalFileToRuntime',
+    async (
+      _event,
+      args: {
+        environmentId: string
+        sourceRootPath: string
+        entryRelativePath: string
+        worktree: string
+        relativePath: string
+        expectedEnvironmentPairingRevision?: number
+      } & SshMutationExpectation
+    ): Promise<{ byteLength: number }> =>
+      streamExternalFileToRuntime({
+        userDataPath: app.getPath('userData'),
+        environmentId: args.environmentId,
+        sourceRootPath: args.sourceRootPath,
+        entryRelativePath: args.entryRelativePath,
+        worktree: args.worktree,
+        relativePath: args.relativePath,
+        expectedExecutionHostId: args.expectedExecutionHostId,
+        expectedSshTargetId: args.expectedSshTargetId,
+        expectedSshConnectionGeneration: args.expectedSshConnectionGeneration,
+        expectedEnvironmentPairingRevision: args.expectedEnvironmentPairingRevision
+      })
   )
 
   // Why: terminal drag-and-drop resolver. Local worktrees pass paths through

--- a/src/main/ipc/filesystem-mutations.ts
+++ b/src/main/ipc/filesystem-mutations.ts
@@ -24,6 +24,11 @@ import {
   RUNTIME_UPLOAD_PROGRESS_CHANNEL,
   throttleRuntimeUploadProgress
 } from './runtime-upload-progress'
+import {
+  cancelRuntimeUpload,
+  forgetRuntimeUploadCancellation,
+  registerCancellableUpload
+} from './runtime-upload-cancellation'
 
 /**
  * IPC handlers for file/folder creation and renaming.
@@ -235,24 +240,42 @@ export function registerFilesystemMutationHandlers(store: Store): void {
             }
           })
         : null
-      return streamExternalFileToRuntime({
-        userDataPath: app.getPath('userData'),
-        environmentId: args.environmentId,
-        sourceRootPath: args.sourceRootPath,
-        entryRelativePath: args.entryRelativePath,
-        worktree: args.worktree,
-        relativePath: args.relativePath,
-        expectedExecutionHostId: args.expectedExecutionHostId,
-        expectedSshTargetId: args.expectedSshTargetId,
-        expectedSshConnectionGeneration: args.expectedSshConnectionGeneration,
-        expectedEnvironmentPairingRevision: args.expectedEnvironmentPairingRevision,
-        onProgress:
-          emit && uploadId
-            ? ({ sentBytes, totalBytes }) => emit({ uploadId, sentBytes, totalBytes })
-            : undefined
-      })
+      const cancellation = uploadId ? registerCancellableUpload(uploadId) : null
+      try {
+        return await streamExternalFileToRuntime({
+          userDataPath: app.getPath('userData'),
+          environmentId: args.environmentId,
+          sourceRootPath: args.sourceRootPath,
+          entryRelativePath: args.entryRelativePath,
+          worktree: args.worktree,
+          relativePath: args.relativePath,
+          expectedExecutionHostId: args.expectedExecutionHostId,
+          expectedSshTargetId: args.expectedSshTargetId,
+          expectedSshConnectionGeneration: args.expectedSshConnectionGeneration,
+          expectedEnvironmentPairingRevision: args.expectedEnvironmentPairingRevision,
+          signal: cancellation?.signal,
+          onProgress:
+            emit && uploadId
+              ? ({ sentBytes, totalBytes }) => emit({ uploadId, sentBytes, totalBytes })
+              : undefined
+        })
+      } finally {
+        cancellation?.release()
+      }
     }
   )
+
+  // Why: the drop UI cancels a whole dropped source, so the id it sends is the
+  // one every file of that source streams under.
+  ipcMain.handle('fs:cancelRuntimeUpload', (_event, args: { uploadId: string }): void => {
+    cancelRuntimeUpload(args.uploadId)
+  })
+
+  // Why: ids are minted per drop, but a cancel recorded for one must not outlive
+  // it and abort a later upload that happens to reuse the id.
+  ipcMain.handle('fs:releaseRuntimeUpload', (_event, args: { uploadId: string }): void => {
+    forgetRuntimeUploadCancellation(args.uploadId)
+  })
 
   // Why: terminal drag-and-drop resolver. Local worktrees pass paths through
   // unchanged (reference-in-place; preserves zero-latency drop). SSH worktrees

--- a/src/main/ipc/filesystem-mutations.ts
+++ b/src/main/ipc/filesystem-mutations.ts
@@ -217,6 +217,7 @@ export function registerFilesystemMutationHandlers(store: Store): void {
         entryRelativePath: string
         worktree: string
         relativePath: string
+        expectedByteLength?: number
         expectedEnvironmentPairingRevision?: number
       } & SshMutationExpectation
     ): Promise<{ byteLength: number }> =>
@@ -225,6 +226,7 @@ export function registerFilesystemMutationHandlers(store: Store): void {
         environmentId: args.environmentId,
         sourceRootPath: args.sourceRootPath,
         entryRelativePath: args.entryRelativePath,
+        expectedByteLength: args.expectedByteLength,
         worktree: args.worktree,
         relativePath: args.relativePath,
         expectedExecutionHostId: args.expectedExecutionHostId,

--- a/src/main/ipc/filesystem-mutations.ts
+++ b/src/main/ipc/filesystem-mutations.ts
@@ -226,6 +226,7 @@ export function registerFilesystemMutationHandlers(store: Store): void {
         entryRelativePath: string
         worktree: string
         relativePath: string
+        expectedByteLength?: number
         uploadId?: string
         expectedEnvironmentPairingRevision?: number
       } & SshMutationExpectation
@@ -247,6 +248,7 @@ export function registerFilesystemMutationHandlers(store: Store): void {
           environmentId: args.environmentId,
           sourceRootPath: args.sourceRootPath,
           entryRelativePath: args.entryRelativePath,
+          expectedByteLength: args.expectedByteLength,
           worktree: args.worktree,
           relativePath: args.relativePath,
           expectedExecutionHostId: args.expectedExecutionHostId,

--- a/src/main/ipc/filesystem-runtime-upload-staging.test.ts
+++ b/src/main/ipc/filesystem-runtime-upload-staging.test.ts
@@ -1,0 +1,91 @@
+import { mkdtemp, mkdir, rm, symlink, truncate, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./filesystem-auth', () => ({ authorizeExternalPath: () => {} }))
+
+const { stageOneSourceForRuntimeUpload } = await import('./filesystem-runtime-upload-staging')
+
+let workDir: string
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), 'orca-upload-staging-'))
+})
+
+afterEach(async () => {
+  await rm(workDir, { force: true, recursive: true })
+})
+
+describe('stageOneSourceForRuntimeUpload', () => {
+  it('records size instead of file contents so staging never holds the body', async () => {
+    const filePath = join(workDir, 'note.txt')
+    await writeFile(filePath, 'hello world')
+
+    const staged = await stageOneSourceForRuntimeUpload(filePath)
+
+    expect(staged).toMatchObject({
+      status: 'staged',
+      kind: 'file',
+      name: 'note.txt',
+      entries: [{ relativePath: '', kind: 'file', byteLength: 11 }]
+    })
+    expect(JSON.stringify(staged)).not.toContain('contentBase64')
+  })
+
+  it('stages a file far larger than the former 25 MB cap', async () => {
+    const filePath = join(workDir, 'big.bin')
+    await writeFile(filePath, '')
+    await truncate(filePath, 64 * 1024 * 1024)
+
+    await expect(stageOneSourceForRuntimeUpload(filePath)).resolves.toMatchObject({
+      status: 'staged',
+      entries: [{ kind: 'file', byteLength: 64 * 1024 * 1024 }]
+    })
+  })
+
+  it('names the limit and the actual size when a file is over the ceiling', async () => {
+    const filePath = join(workDir, 'huge.bin')
+    await writeFile(filePath, '')
+    // Sparse: the ceiling is checked from stat(), so no real bytes are written.
+    await truncate(filePath, 3 * 1024 * 1024 * 1024)
+
+    const staged = await stageOneSourceForRuntimeUpload(filePath)
+
+    expect(staged).toMatchObject({ status: 'failed' })
+    expect(staged.status === 'failed' && staged.reason).toContain('3 GB')
+    expect(staged.status === 'failed' && staged.reason).toContain('2 GB')
+  })
+
+  it('keeps rejecting symlinked sources', async () => {
+    const targetPath = join(workDir, 'target.txt')
+    await writeFile(targetPath, 'data')
+    const linkPath = join(workDir, 'link.txt')
+    await symlink(targetPath, linkPath)
+
+    await expect(stageOneSourceForRuntimeUpload(linkPath)).resolves.toMatchObject({
+      status: 'skipped',
+      reason: 'symlink'
+    })
+  })
+
+  it('stages directory trees as metadata for every entry', async () => {
+    const rootPath = join(workDir, 'assets')
+    await mkdir(join(rootPath, 'nested'), { recursive: true })
+    await writeFile(join(rootPath, 'a.txt'), 'aa')
+    await writeFile(join(rootPath, 'nested', 'b.txt'), 'bbb')
+
+    const staged = await stageOneSourceForRuntimeUpload(rootPath)
+
+    expect(staged.status).toBe('staged')
+    const entries = staged.status === 'staged' ? staged.entries : []
+    expect(entries).toEqual(
+      expect.arrayContaining([
+        { relativePath: '', kind: 'directory' },
+        { relativePath: 'a.txt', kind: 'file', byteLength: 2 },
+        { relativePath: 'nested', kind: 'directory' },
+        { relativePath: 'nested/b.txt', kind: 'file', byteLength: 3 }
+      ])
+    )
+  })
+})

--- a/src/main/ipc/filesystem-runtime-upload-staging.test.ts
+++ b/src/main/ipc/filesystem-runtime-upload-staging.test.ts
@@ -1,9 +1,19 @@
-import { mkdtemp, mkdir, rm, symlink, truncate, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as RuntimeImportLimits from './runtime-import-limits'
+
+type RuntimeImportLimitsModule = typeof RuntimeImportLimits
 
 vi.mock('./filesystem-auth', () => ({ authorizeExternalPath: () => {} }))
+// Why: real ceilings are gigabytes, and truncate() is not sparse on NTFS, so a
+// literal over-limit fixture would allocate that much on Windows CI.
+vi.mock('./runtime-import-limits', async (importOriginal) => ({
+  ...(await importOriginal<RuntimeImportLimitsModule>()),
+  REMOTE_IMPORT_MAX_FILE_BYTES: 4 * 1024,
+  REMOTE_IMPORT_MAX_TOTAL_BYTES: 16 * 1024
+}))
 
 const { stageOneSourceForRuntimeUpload } = await import('./filesystem-runtime-upload-staging')
 
@@ -33,43 +43,28 @@ describe('stageOneSourceForRuntimeUpload', () => {
     expect(JSON.stringify(staged)).not.toContain('contentBase64')
   })
 
-  it('stages a file far larger than the former 25 MB cap', async () => {
+  it('stages a file with no cap error, where the old buffering path refused', async () => {
     const filePath = join(workDir, 'big.bin')
-    await writeFile(filePath, '')
-    await truncate(filePath, 64 * 1024 * 1024)
+    await writeFile(filePath, Buffer.alloc(3 * 1024))
 
     await expect(stageOneSourceForRuntimeUpload(filePath)).resolves.toMatchObject({
       status: 'staged',
-      entries: [{ kind: 'file', byteLength: 64 * 1024 * 1024 }]
+      entries: [{ kind: 'file', byteLength: 3 * 1024 }]
     })
   })
 
   it('names the limit and the actual size when a file is over the ceiling', async () => {
     const filePath = join(workDir, 'huge.bin')
-    await writeFile(filePath, '')
-    // Sparse: the ceiling is checked from stat(), so no real bytes are written.
-    await truncate(filePath, 3 * 1024 * 1024 * 1024)
+    await writeFile(filePath, Buffer.alloc(6 * 1024))
 
     const staged = await stageOneSourceForRuntimeUpload(filePath)
 
     expect(staged).toMatchObject({ status: 'failed' })
-    expect(staged.status === 'failed' && staged.reason).toContain('3 GB')
-    expect(staged.status === 'failed' && staged.reason).toContain('2 GB')
+    expect(staged.status === 'failed' && staged.reason).toContain('6 KB')
+    expect(staged.status === 'failed' && staged.reason).toContain('4 KB')
   })
 
   // symlink() needs privileges or Developer Mode on Windows.
-  it('renders a size just over the ceiling as larger than the ceiling', async () => {
-    const filePath = join(workDir, 'edge.bin')
-    await writeFile(filePath, '')
-    await truncate(filePath, 2 * 1024 * 1024 * 1024 + 1)
-
-    const staged = await stageOneSourceForRuntimeUpload(filePath)
-
-    expect(staged).toMatchObject({ status: 'failed' })
-    // "is 2 GB, over the 2 GB limit" reads like a broken check.
-    expect(staged.status === 'failed' && staged.reason).toContain('2.1 GB')
-  })
-
   it.skipIf(process.platform === 'win32')('keeps rejecting symlinked sources', async () => {
     const targetPath = join(workDir, 'target.txt')
     await writeFile(targetPath, 'data')

--- a/src/main/ipc/filesystem-runtime-upload-staging.test.ts
+++ b/src/main/ipc/filesystem-runtime-upload-staging.test.ts
@@ -57,7 +57,20 @@ describe('stageOneSourceForRuntimeUpload', () => {
     expect(staged.status === 'failed' && staged.reason).toContain('2 GB')
   })
 
-  it('keeps rejecting symlinked sources', async () => {
+  // symlink() needs privileges or Developer Mode on Windows.
+  it('renders a size just over the ceiling as larger than the ceiling', async () => {
+    const filePath = join(workDir, 'edge.bin')
+    await writeFile(filePath, '')
+    await truncate(filePath, 2 * 1024 * 1024 * 1024 + 1)
+
+    const staged = await stageOneSourceForRuntimeUpload(filePath)
+
+    expect(staged).toMatchObject({ status: 'failed' })
+    // "is 2 GB, over the 2 GB limit" reads like a broken check.
+    expect(staged.status === 'failed' && staged.reason).toContain('2.1 GB')
+  })
+
+  it.skipIf(process.platform === 'win32')('keeps rejecting symlinked sources', async () => {
     const targetPath = join(workDir, 'target.txt')
     await writeFile(targetPath, 'data')
     const linkPath = join(workDir, 'link.txt')

--- a/src/main/ipc/filesystem-runtime-upload-staging.ts
+++ b/src/main/ipc/filesystem-runtime-upload-staging.ts
@@ -1,3 +1,8 @@
+import {
+  formatByteCeiling,
+  REMOTE_IMPORT_MAX_FILE_BYTES,
+  REMOTE_IMPORT_MAX_TOTAL_BYTES
+} from './runtime-import-limits'
 import { constants } from 'node:fs'
 import { lstat, open, readdir, realpath } from 'node:fs/promises'
 import { basename, isAbsolute, join, relative, resolve, sep } from 'node:path'
@@ -7,12 +12,6 @@ import type {
   StagedExternalImportEntry,
   StagedExternalImportSource
 } from './filesystem-import-result-types'
-
-// Why: staging streams slices at upload time and never holds a whole file, so
-// these are user-safety ceilings on an unattended transfer, not memory guards.
-// They stay until the drop UI can show progress and cancel a running upload.
-const REMOTE_IMPORT_MAX_FILE_BYTES = 2 * 1024 * 1024 * 1024
-const REMOTE_IMPORT_MAX_TOTAL_BYTES = 8 * 1024 * 1024 * 1024
 
 class RuntimeUploadSymlinkError extends Error {}
 
@@ -213,21 +212,6 @@ function assertRemoteUploadBudget(
         `${formatByteCeiling(REMOTE_IMPORT_MAX_TOTAL_BYTES)} total remote import limit`
     )
   }
-}
-
-function formatByteCeiling(bytes: number): string {
-  const units = ['B', 'KB', 'MB', 'GB', 'TB']
-  let value = bytes
-  let unit = 0
-  while (value >= 1024 && unit < units.length - 1) {
-    value /= 1024
-    unit += 1
-  }
-  // Why: rounds up, so a file one byte over the ceiling never renders as the
-  // same figure as the ceiling itself — "is 2 GB, over the 2 GB limit" reads
-  // like a bug in the check rather than an oversized file.
-  const rounded = Math.ceil(value * 10) / 10
-  return `${Number.isInteger(rounded) ? rounded : rounded.toFixed(1)} ${units[unit]}`
 }
 
 function normalizeRelativeUploadPath(path: string): string {

--- a/src/main/ipc/filesystem-runtime-upload-staging.ts
+++ b/src/main/ipc/filesystem-runtime-upload-staging.ts
@@ -223,7 +223,11 @@ function formatByteCeiling(bytes: number): string {
     value /= 1024
     unit += 1
   }
-  return `${value >= 10 || Number.isInteger(value) ? Math.round(value) : value.toFixed(1)} ${units[unit]}`
+  // Why: rounds up, so a file one byte over the ceiling never renders as the
+  // same figure as the ceiling itself — "is 2 GB, over the 2 GB limit" reads
+  // like a bug in the check rather than an oversized file.
+  const rounded = Math.ceil(value * 10) / 10
+  return `${Number.isInteger(rounded) ? rounded : rounded.toFixed(1)} ${units[unit]}`
 }
 
 function normalizeRelativeUploadPath(path: string): string {

--- a/src/main/ipc/filesystem-runtime-upload-staging.ts
+++ b/src/main/ipc/filesystem-runtime-upload-staging.ts
@@ -8,8 +8,11 @@ import type {
   StagedExternalImportSource
 } from './filesystem-import-result-types'
 
-const REMOTE_IMPORT_MAX_FILE_BYTES = 25 * 1024 * 1024
-const REMOTE_IMPORT_MAX_TOTAL_BYTES = 100 * 1024 * 1024
+// Why: staging streams slices at upload time and never holds a whole file, so
+// these are user-safety ceilings on an unattended transfer, not memory guards.
+// They stay until the drop UI can show progress and cancel a running upload.
+const REMOTE_IMPORT_MAX_FILE_BYTES = 2 * 1024 * 1024 * 1024
+const REMOTE_IMPORT_MAX_TOTAL_BYTES = 8 * 1024 * 1024 * 1024
 
 class RuntimeUploadSymlinkError extends Error {}
 
@@ -19,7 +22,7 @@ export async function stageOneSourceForRuntimeUpload(
   const resolvedSource = resolve(sourcePath)
 
   // Why: runtime uploads read client-local paths in the client main process;
-  // authorize before lstat/readFile just like local copy imports.
+  // authorize before lstat just like local copy imports.
   authorizeExternalPath(resolvedSource)
 
   let sourceStat: Awaited<ReturnType<typeof lstat>>
@@ -162,16 +165,13 @@ async function stageFileEntry(
         ? openedStat.size
         : options.totalBytesBefore + openedStat.size
     assertRemoteUploadBudget(relativePath, openedStat.size, totalBytes)
-    const buffer = await fileHandle.readFile()
-    const afterReadStat = await fileHandle.stat()
-    if (afterReadStat.size !== openedStat.size) {
-      throw new Error(`File changed during upload staging: '${displayPath}'`)
-    }
+    // Why: bytes are read slice-by-slice at upload time, so staging only
+    // records what the uploader needs to find and size each entry.
     return {
       entry: {
         relativePath: displayPath,
         kind: 'file',
-        contentBase64: buffer.toString('base64')
+        byteLength: openedStat.size
       },
       byteLength: openedStat.size
     }
@@ -202,11 +202,28 @@ function assertRemoteUploadBudget(
   totalBytes: number
 ): void {
   if (fileBytes > REMOTE_IMPORT_MAX_FILE_BYTES) {
-    throw new Error(`'${relativePath}' is too large for remote import`)
+    throw new Error(
+      `'${relativePath}' is ${formatByteCeiling(fileBytes)}, over the ` +
+        `${formatByteCeiling(REMOTE_IMPORT_MAX_FILE_BYTES)} per-file remote import limit`
+    )
   }
   if (totalBytes > REMOTE_IMPORT_MAX_TOTAL_BYTES) {
-    throw new Error('Remote import is too large')
+    throw new Error(
+      `This import is ${formatByteCeiling(totalBytes)}, over the ` +
+        `${formatByteCeiling(REMOTE_IMPORT_MAX_TOTAL_BYTES)} total remote import limit`
+    )
   }
+}
+
+function formatByteCeiling(bytes: number): string {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let value = bytes
+  let unit = 0
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024
+    unit += 1
+  }
+  return `${value >= 10 || Number.isInteger(value) ? Math.round(value) : value.toFixed(1)} ${units[unit]}`
 }
 
 function normalizeRelativeUploadPath(path: string): string {

--- a/src/main/ipc/preflight-agent-detection.test.ts
+++ b/src/main/ipc/preflight-agent-detection.test.ts
@@ -135,13 +135,31 @@ describe('preflight', () => {
 
       const target = String(args[0])
       if (target === 'claude') {
-        return { environmentResolved: true, code: 0, stdout: '/Users/test/.local/bin/claude\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/Users/test/.local/bin/claude\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       if (target === 'continue') {
-        return { environmentResolved: true, code: 0, stdout: 'continue: shell built-in command\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: 'continue: shell built-in command\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       if (target === 'cursor-agent') {
-        return { environmentResolved: true, code: 0, stdout: '/Users/test/.local/bin/cursor-agent\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/Users/test/.local/bin/cursor-agent\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })
@@ -155,7 +173,13 @@ describe('preflight', () => {
         throw new Error(`unexpected command ${String(command)}`)
       }
       if (String(args[0]) === 'orca') {
-        return { environmentResolved: true, code: 0, stdout: '/Applications/Orca.app/Contents/MacOS/orca\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/Applications/Orca.app/Contents/MacOS/orca\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })
@@ -169,10 +193,22 @@ describe('preflight', () => {
         throw new Error(`unexpected command ${String(command)}`)
       }
       if (String(args[0]) === 'claude') {
-        return { environmentResolved: true, code: 0, stdout: '/Users/test/.local/bin/claude\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/Users/test/.local/bin/claude\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       if (String(args[0]) === 'orca') {
-        return { environmentResolved: true, code: 0, stdout: '/Applications/Orca.app/Contents/MacOS/orca\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/Applications/Orca.app/Contents/MacOS/orca\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })
@@ -190,10 +226,22 @@ describe('preflight', () => {
         throw new Error(`unexpected command ${String(command)}`)
       }
       if (String(args[0]) === 'claude') {
-        return { environmentResolved: true, code: 0, stdout: '/mock/windows/npm/claude.cmd\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/mock/windows/npm/claude.cmd\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       if (String(args[0]) === 'orca') {
-        return { environmentResolved: true, code: 0, stdout: '/mock/windows/programs/orca.cmd\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/mock/windows/programs/orca.cmd\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })
@@ -239,7 +287,13 @@ describe('preflight', () => {
         throw new Error(`unexpected command ${String(command)}`)
       }
       if (String(args[0]) === 'claude') {
-        return { environmentResolved: true, code: 0, stdout: '/Users/test/.local/bin/claude\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/Users/test/.local/bin/claude\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })
@@ -273,10 +327,22 @@ describe('preflight', () => {
         throw new Error(`unexpected command ${String(command)}`)
       }
       if (String(args[0]) === 'openclaude') {
-        return { environmentResolved: true, code: 0, stdout: '/Users/test/.local/bin/openclaude\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/Users/test/.local/bin/openclaude\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       if (String(args[0]) === 'cursor-agent') {
-        return { environmentResolved: true, code: 0, stdout: '/Users/test/.local/bin/cursor-agent\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/Users/test/.local/bin/cursor-agent\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })
@@ -303,7 +369,13 @@ describe('preflight', () => {
         throw new Error(`unexpected command ${String(command)}`)
       }
       if (String(args[0]) === 'codex' && process.env.PATH?.startsWith('/home/test/.local/bin')) {
-        return { environmentResolved: true, code: 0, stdout: '/home/test/.local/bin/codex\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/home/test/.local/bin/codex\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })
@@ -328,7 +400,13 @@ describe('preflight', () => {
     })
     runWslProcessMock.mockImplementation(async ({ script }: { script: string }) => {
       if (script.includes("'claude'")) {
-        return { environmentResolved: true, code: 0, stdout: '__ORCA_AGENT_PATH__claude\t/home/test/.local/bin/claude\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '__ORCA_AGENT_PATH__claude\t/home/test/.local/bin/claude\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })
@@ -349,7 +427,13 @@ describe('preflight', () => {
       expect(script).not.toContain("'orca-dev'")
       expect(script).not.toContain("'orca-ide'")
       if (script.includes("'claude'")) {
-        return { environmentResolved: true, code: 0, stdout: '__ORCA_AGENT_PATH__claude\t/home/test/.local/bin/claude\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '__ORCA_AGENT_PATH__claude\t/home/test/.local/bin/claude\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })
@@ -363,7 +447,13 @@ describe('preflight', () => {
         throw new Error(`unexpected command ${String(command)}`)
       }
       if (String(args[0]) === 'vibe') {
-        return { environmentResolved: true, code: 0, stdout: '/home/test/.local/bin/vibe\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/home/test/.local/bin/vibe\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })
@@ -392,7 +482,13 @@ describe('preflight', () => {
     })
     runWslProcessMock.mockImplementation(async ({ script }: { script: string }) => {
       if (script.includes("'claude'")) {
-        return { environmentResolved: true, code: 0, stdout: '__ORCA_AGENT_PATH__claude\t/home/test/.local/bin/claude\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '__ORCA_AGENT_PATH__claude\t/home/test/.local/bin/claude\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })

--- a/src/main/ipc/preflight-agent-refresh.test.ts
+++ b/src/main/ipc/preflight-agent-refresh.test.ts
@@ -130,7 +130,13 @@ describe('preflight', () => {
     })
     runWslProcessMock.mockImplementation(async ({ script }: { script: string }) => {
       if (script.includes("'claude'")) {
-        return { environmentResolved: true, code: 0, stdout: '__ORCA_AGENT_PATH__claude\t/home/test/.local/bin/claude\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '__ORCA_AGENT_PATH__claude\t/home/test/.local/bin/claude\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })
@@ -183,7 +189,13 @@ describe('preflight', () => {
         throw new Error(`unexpected command ${String(command)}`)
       }
       if (String(args[0]) === 'opencode') {
-        return { environmentResolved: true, code: 0, stdout: '/Users/test/.opencode/bin/opencode\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/Users/test/.opencode/bin/opencode\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })
@@ -219,7 +231,13 @@ describe('preflight', () => {
         throw new Error(`unexpected command ${String(command)}`)
       }
       if (String(args[0]) === 'claude') {
-        return { environmentResolved: true, code: 0, stdout: '/Users/test/.local/bin/claude\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: '/Users/test/.local/bin/claude\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       throw new Error('not found')
     })

--- a/src/main/ipc/preflight-host-cli-status.test.ts
+++ b/src/main/ipc/preflight-host-cli-status.test.ts
@@ -276,7 +276,13 @@ describe('preflight', () => {
     })
     runWslProcessMock.mockImplementation(async ({ script }: { script: string }) => {
       if (script.includes('gh') && script.includes('--version')) {
-        return { environmentResolved: true, code: 0, stdout: 'gh version 2.0.0\n', stderr: '', timedOut: false }
+        return {
+          environmentResolved: true,
+          code: 0,
+          stdout: 'gh version 2.0.0\n',
+          stderr: '',
+          timedOut: false
+        }
       }
       if (script.includes('gh') && script.includes('auth status')) {
         return {

--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -17,7 +17,13 @@ function lastSpec(): RunWslProcessSpec {
 describe('detectWslCommandsOnPath', () => {
   beforeEach(() => {
     runWslProcessMock.mockReset()
-    runWslProcessMock.mockResolvedValue({ environmentResolved: true, code: 0, stdout: '', stderr: '', timedOut: false })
+    runWslProcessMock.mockResolvedValue({
+      environmentResolved: true,
+      code: 0,
+      stdout: '',
+      stderr: '',
+      timedOut: false
+    })
   })
 
   afterEach(() => {

--- a/src/main/ipc/runtime-import-limits.test.ts
+++ b/src/main/ipc/runtime-import-limits.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formatByteCeiling,
+  REMOTE_IMPORT_MAX_FILE_BYTES,
+  REMOTE_IMPORT_MAX_TOTAL_BYTES
+} from './runtime-import-limits'
+
+describe('formatByteCeiling', () => {
+  it('renders a size one byte over a ceiling as larger than the ceiling', () => {
+    // "is 2 GB, over the 2 GB limit" reads like a broken check, not a big file.
+    expect(formatByteCeiling(REMOTE_IMPORT_MAX_FILE_BYTES)).toBe('2 GB')
+    expect(formatByteCeiling(REMOTE_IMPORT_MAX_FILE_BYTES + 1)).toBe('2.1 GB')
+  })
+
+  it('leaves an exact ceiling as a whole number', () => {
+    expect(formatByteCeiling(REMOTE_IMPORT_MAX_TOTAL_BYTES)).toBe('8 GB')
+    expect(formatByteCeiling(1024)).toBe('1 KB')
+  })
+
+  it('scales through the units', () => {
+    expect(formatByteCeiling(512)).toBe('512 B')
+    expect(formatByteCeiling(1024 * 1024)).toBe('1 MB')
+    expect(formatByteCeiling(1024 ** 4)).toBe('1 TB')
+  })
+
+  it('rounds up rather than to nearest', () => {
+    expect(formatByteCeiling(1024 * 1024 + 1)).toBe('1.1 MB')
+  })
+
+  it('does not crash on zero', () => {
+    expect(formatByteCeiling(0)).toBe('0 B')
+  })
+})

--- a/src/main/ipc/runtime-import-limits.ts
+++ b/src/main/ipc/runtime-import-limits.ts
@@ -1,0 +1,18 @@
+// Why: staging streams slices at upload time and never holds a whole file, so
+// these are user-safety ceilings on an unattended transfer, not memory guards.
+// They stay until the drop UI can show progress and cancel a running upload.
+export const REMOTE_IMPORT_MAX_FILE_BYTES = 2 * 1024 * 1024 * 1024
+export const REMOTE_IMPORT_MAX_TOTAL_BYTES = 8 * 1024 * 1024 * 1024
+
+/** Rounds up, so a size over a ceiling never renders as the ceiling itself. */
+export function formatByteCeiling(bytes: number): string {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let value = bytes
+  let unit = 0
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024
+    unit += 1
+  }
+  const rounded = Math.ceil(value * 10) / 10
+  return `${Number.isInteger(rounded) ? rounded : rounded.toFixed(1)} ${units[unit]}`
+}

--- a/src/main/ipc/runtime-upload-cancellation.test.ts
+++ b/src/main/ipc/runtime-upload-cancellation.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  cancelRuntimeUpload,
+  forgetRuntimeUploadCancellation,
+  isRuntimeUploadCancelled,
+  isUploadCancelled,
+  registerCancellableUpload,
+  RuntimeUploadCancelledError
+} from './runtime-upload-cancellation'
+
+afterEach(() => {
+  forgetRuntimeUploadCancellation('u')
+  forgetRuntimeUploadCancellation('v')
+})
+
+describe('runtime upload cancellation', () => {
+  it('aborts an upload that is already running', () => {
+    const { signal } = registerCancellableUpload('u')
+    expect(signal.aborted).toBe(false)
+
+    cancelRuntimeUpload('u')
+
+    expect(signal.aborted).toBe(true)
+  })
+
+  it('aborts the next file when cancel lands between two files of one drop', () => {
+    const first = registerCancellableUpload('u')
+    first.release()
+    cancelRuntimeUpload('u')
+
+    const second = registerCancellableUpload('u')
+
+    expect(second.signal.aborted).toBe(true)
+  })
+
+  it('leaves other uploads running', () => {
+    const target = registerCancellableUpload('u')
+    const bystander = registerCancellableUpload('v')
+
+    cancelRuntimeUpload('u')
+
+    expect(target.signal.aborted).toBe(true)
+    expect(bystander.signal.aborted).toBe(false)
+  })
+
+  it('stops applying a cancel once the drop is forgotten', () => {
+    cancelRuntimeUpload('u')
+    forgetRuntimeUploadCancellation('u')
+
+    expect(isUploadCancelled('u')).toBe(false)
+    expect(registerCancellableUpload('u').signal.aborted).toBe(false)
+  })
+
+  it('releasing a superseded registration does not evict the live one', () => {
+    const stale = registerCancellableUpload('u')
+    const live = registerCancellableUpload('u')
+    stale.release()
+
+    cancelRuntimeUpload('u')
+
+    expect(live.signal.aborted).toBe(true)
+  })
+
+  it('recognises its own error and nothing else', () => {
+    expect(isRuntimeUploadCancelled(new RuntimeUploadCancelledError())).toBe(true)
+    expect(isRuntimeUploadCancelled(new Error('disk full'))).toBe(false)
+    expect(isRuntimeUploadCancelled('cancelled')).toBe(false)
+  })
+})

--- a/src/main/ipc/runtime-upload-cancellation.ts
+++ b/src/main/ipc/runtime-upload-cancellation.ts
@@ -1,0 +1,51 @@
+export class RuntimeUploadCancelledError extends Error {
+  constructor() {
+    super('Upload cancelled')
+    this.name = 'RuntimeUploadCancelledError'
+  }
+}
+
+export function isRuntimeUploadCancelled(error: unknown): boolean {
+  return error instanceof Error && error.name === 'RuntimeUploadCancelledError'
+}
+
+const controllers = new Map<string, AbortController>()
+// Why: a drop's files stream one at a time, so cancel can land between two of
+// them. Remembering the id means the next file aborts instead of the click
+// silently doing nothing.
+const cancelled = new Set<string>()
+
+/** Registers an upload so it can be cancelled; returns its release callback. */
+export function registerCancellableUpload(uploadId: string): {
+  signal: AbortSignal
+  release: () => void
+} {
+  const controller = new AbortController()
+  if (cancelled.has(uploadId)) {
+    controller.abort()
+  }
+  controllers.set(uploadId, controller)
+  return {
+    signal: controller.signal,
+    release: () => {
+      if (controllers.get(uploadId) === controller) {
+        controllers.delete(uploadId)
+      }
+    }
+  }
+}
+
+export function cancelRuntimeUpload(uploadId: string): void {
+  cancelled.add(uploadId)
+  controllers.get(uploadId)?.abort()
+}
+
+/** Called once a drop is finished so a reused id cannot inherit a stale cancel. */
+export function forgetRuntimeUploadCancellation(uploadId: string): void {
+  cancelled.delete(uploadId)
+  controllers.delete(uploadId)
+}
+
+export function isUploadCancelled(uploadId: string): boolean {
+  return cancelled.has(uploadId)
+}

--- a/src/main/ipc/runtime-upload-file-stream.test.ts
+++ b/src/main/ipc/runtime-upload-file-stream.test.ts
@@ -122,6 +122,60 @@ describe('streamExternalFileToRuntime', () => {
     expect(chunkCalls()).toHaveLength(2)
   })
 
+  it('reports monotonic progress that ends on the file size', async () => {
+    const size = RUNTIME_UPLOAD_SLICE_BYTES * 2 + 500
+    const filePath = join(workDir, 'tracked.bin')
+    await writeFile(filePath, Buffer.alloc(size))
+    const seen: { sentBytes: number; totalBytes: number }[] = []
+
+    await streamExternalFileToRuntime({
+      ...baseArgs(filePath),
+      onProgress: (progress) => seen.push(progress)
+    })
+
+    expect(seen).toHaveLength(3)
+    expect(seen.every((p) => p.totalBytes === size)).toBe(true)
+    expect(seen.map((p) => p.sentBytes)).toEqual([
+      RUNTIME_UPLOAD_SLICE_BYTES,
+      RUNTIME_UPLOAD_SLICE_BYTES * 2,
+      size
+    ])
+  })
+
+  it('reports a zero-byte file as complete rather than never reporting', async () => {
+    const filePath = join(workDir, 'nothing.txt')
+    await writeFile(filePath, '')
+    const seen: { sentBytes: number; totalBytes: number }[] = []
+
+    await streamExternalFileToRuntime({
+      ...baseArgs(filePath),
+      onProgress: (progress) => seen.push(progress)
+    })
+
+    expect(seen).toEqual([{ sentBytes: 0, totalBytes: 0 }])
+  })
+
+  it('stops reporting progress at the chunk that failed', async () => {
+    const filePath = join(workDir, 'halts.bin')
+    await writeFile(filePath, Buffer.alloc(RUNTIME_UPLOAD_SLICE_BYTES * 3))
+    const seen: number[] = []
+    callRuntimeEnvironment.mockResolvedValueOnce({ id: 'x', ok: true, result: {}, _meta: {} })
+    callRuntimeEnvironment.mockResolvedValueOnce({
+      id: 'x',
+      ok: false,
+      error: { code: 'write_failed', message: 'disk full' }
+    })
+
+    await expect(
+      streamExternalFileToRuntime({
+        ...baseArgs(filePath),
+        onProgress: (progress) => seen.push(progress.sentBytes)
+      })
+    ).rejects.toThrow('disk full')
+
+    expect(seen).toEqual([RUNTIME_UPLOAD_SLICE_BYTES])
+  })
+
   it('refuses a symlinked source', async () => {
     const targetPath = join(workDir, 'secret.txt')
     await writeFile(targetPath, 'secret')

--- a/src/main/ipc/runtime-upload-file-stream.test.ts
+++ b/src/main/ipc/runtime-upload-file-stream.test.ts
@@ -1,0 +1,152 @@
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const callRuntimeEnvironment = vi.fn()
+
+vi.mock('./runtime-environment-transport-routing', () => ({
+  callRuntimeEnvironment: (...args: unknown[]) => callRuntimeEnvironment(...args)
+}))
+vi.mock('./filesystem-auth', () => ({ authorizeExternalPath: () => {} }))
+
+const { RUNTIME_UPLOAD_SLICE_BYTES, streamExternalFileToRuntime } =
+  await import('./runtime-upload-file-stream')
+
+let workDir: string
+
+type ChunkCall = { relativePath: string; contentBase64: string; append: boolean }
+
+function chunkCalls(): ChunkCall[] {
+  return callRuntimeEnvironment.mock.calls
+    .filter(([, , method]) => method === 'files.writeBase64Chunk')
+    .map(([, , , params]) => params as ChunkCall)
+}
+
+function uploadedBytes(): Buffer {
+  return Buffer.concat(chunkCalls().map((call) => Buffer.from(call.contentBase64, 'base64')))
+}
+
+function baseArgs(sourceRootPath: string) {
+  return {
+    userDataPath: '/user-data',
+    environmentId: 'env-1',
+    sourceRootPath,
+    entryRelativePath: '',
+    worktree: 'wt-1',
+    relativePath: '.upload.tmp'
+  }
+}
+
+beforeEach(async () => {
+  workDir = await mkdtemp(join(tmpdir(), 'orca-upload-stream-'))
+  callRuntimeEnvironment.mockReset()
+  callRuntimeEnvironment.mockResolvedValue({ id: 'x', ok: true, result: {}, _meta: {} })
+})
+
+afterEach(async () => {
+  await rm(workDir, { force: true, recursive: true })
+})
+
+describe('streamExternalFileToRuntime', () => {
+  it('sends a file larger than the old 25 MB cap as ordered append-only slices', async () => {
+    const size = RUNTIME_UPLOAD_SLICE_BYTES * 2 + 1234
+    const contents = Buffer.alloc(size)
+    for (let index = 0; index < size; index += 1) {
+      contents[index] = index % 251
+    }
+    const filePath = join(workDir, 'big.bin')
+    await writeFile(filePath, contents)
+
+    await expect(streamExternalFileToRuntime(baseArgs(filePath))).resolves.toEqual({
+      byteLength: size
+    })
+
+    const calls = chunkCalls()
+    expect(calls).toHaveLength(3)
+    expect(calls.map((call) => call.append)).toEqual([false, true, true])
+    expect(uploadedBytes().equals(contents)).toBe(true)
+  })
+
+  it('never buffers more than one slice per chunk', async () => {
+    const filePath = join(workDir, 'sliced.bin')
+    await writeFile(filePath, Buffer.alloc(RUNTIME_UPLOAD_SLICE_BYTES * 2))
+
+    await streamExternalFileToRuntime(baseArgs(filePath))
+
+    for (const call of chunkCalls()) {
+      expect(Buffer.from(call.contentBase64, 'base64').byteLength).toBeLessThanOrEqual(
+        RUNTIME_UPLOAD_SLICE_BYTES
+      )
+    }
+  })
+
+  it('creates an empty destination for a zero-byte source', async () => {
+    const filePath = join(workDir, 'empty.txt')
+    await writeFile(filePath, '')
+
+    await expect(streamExternalFileToRuntime(baseArgs(filePath))).resolves.toEqual({
+      byteLength: 0
+    })
+
+    expect(chunkCalls()).toEqual([expect.objectContaining({ append: false, contentBase64: '' })])
+  })
+
+  it('carries the pairing revision on every chunk so a re-pair cannot finish the file', async () => {
+    const filePath = join(workDir, 'guarded.bin')
+    await writeFile(filePath, Buffer.alloc(RUNTIME_UPLOAD_SLICE_BYTES + 10))
+
+    await streamExternalFileToRuntime({
+      ...baseArgs(filePath),
+      expectedEnvironmentPairingRevision: 41
+    })
+
+    const revisions = callRuntimeEnvironment.mock.calls
+      .filter(([, , method]) => method === 'files.writeBase64Chunk')
+      .map(([, , , , , revision]) => revision)
+    expect(revisions).toHaveLength(2)
+    expect(revisions).toEqual([41, 41])
+  })
+
+  it('stops at the failing chunk instead of sending the rest of the file', async () => {
+    const filePath = join(workDir, 'fails.bin')
+    await writeFile(filePath, Buffer.alloc(RUNTIME_UPLOAD_SLICE_BYTES * 3))
+    callRuntimeEnvironment.mockResolvedValueOnce({ id: 'x', ok: true, result: {}, _meta: {} })
+    callRuntimeEnvironment.mockResolvedValueOnce({
+      id: 'x',
+      ok: false,
+      error: { code: 'write_failed', message: 'disk full' }
+    })
+
+    await expect(streamExternalFileToRuntime(baseArgs(filePath))).rejects.toThrow('disk full')
+    expect(chunkCalls()).toHaveLength(2)
+  })
+
+  it('refuses a symlinked source', async () => {
+    const targetPath = join(workDir, 'secret.txt')
+    await writeFile(targetPath, 'secret')
+    const linkPath = join(workDir, 'link.txt')
+    await symlink(targetPath, linkPath)
+
+    await expect(streamExternalFileToRuntime(baseArgs(linkPath))).rejects.toThrow(
+      'Symlink not allowed'
+    )
+    expect(chunkCalls()).toHaveLength(0)
+  })
+
+  it('refuses a directory entry whose real path escapes the dropped root', async () => {
+    const outsidePath = join(workDir, 'outside.txt')
+    await writeFile(outsidePath, 'outside')
+    const rootPath = join(workDir, 'root')
+    await mkdir(rootPath)
+    await symlink(outsidePath, join(rootPath, 'escape.txt'))
+
+    await expect(
+      streamExternalFileToRuntime({
+        ...baseArgs(rootPath),
+        entryRelativePath: 'escape.txt'
+      })
+    ).rejects.toThrow('Symlink not allowed')
+    expect(chunkCalls()).toHaveLength(0)
+  })
+})

--- a/src/main/ipc/runtime-upload-file-stream.test.ts
+++ b/src/main/ipc/runtime-upload-file-stream.test.ts
@@ -122,6 +122,25 @@ describe('streamExternalFileToRuntime', () => {
     expect(chunkCalls()).toHaveLength(2)
   })
 
+  it('refuses a source whose size no longer matches what staging measured', async () => {
+    const filePath = join(workDir, 'grown.bin')
+    await writeFile(filePath, Buffer.alloc(2048))
+
+    await expect(
+      streamExternalFileToRuntime({ ...baseArgs(filePath), expectedByteLength: 1024 })
+    ).rejects.toThrow('File changed since it was staged')
+    expect(chunkCalls()).toHaveLength(0)
+  })
+
+  it('accepts a source that still matches its staged size', async () => {
+    const filePath = join(workDir, 'same.bin')
+    await writeFile(filePath, Buffer.alloc(2048))
+
+    await expect(
+      streamExternalFileToRuntime({ ...baseArgs(filePath), expectedByteLength: 2048 })
+    ).resolves.toEqual({ byteLength: 2048 })
+  })
+
   it('reports monotonic progress that ends on the file size', async () => {
     const size = RUNTIME_UPLOAD_SLICE_BYTES * 2 + 500
     const filePath = join(workDir, 'tracked.bin')
@@ -204,7 +223,8 @@ describe('streamExternalFileToRuntime', () => {
     expect(chunkCalls()).toHaveLength(1)
   })
 
-  it('refuses a symlinked source', async () => {
+  // symlink() needs privileges or Developer Mode on Windows.
+  it.skipIf(process.platform === 'win32')('refuses a symlinked source', async () => {
     const targetPath = join(workDir, 'secret.txt')
     await writeFile(targetPath, 'secret')
     const linkPath = join(workDir, 'link.txt')
@@ -216,19 +236,22 @@ describe('streamExternalFileToRuntime', () => {
     expect(chunkCalls()).toHaveLength(0)
   })
 
-  it('refuses a directory entry whose real path escapes the dropped root', async () => {
-    const outsidePath = join(workDir, 'outside.txt')
-    await writeFile(outsidePath, 'outside')
-    const rootPath = join(workDir, 'root')
-    await mkdir(rootPath)
-    await symlink(outsidePath, join(rootPath, 'escape.txt'))
+  it.skipIf(process.platform === 'win32')(
+    'refuses a directory entry whose real path escapes the dropped root',
+    async () => {
+      const outsidePath = join(workDir, 'outside.txt')
+      await writeFile(outsidePath, 'outside')
+      const rootPath = join(workDir, 'root')
+      await mkdir(rootPath)
+      await symlink(outsidePath, join(rootPath, 'escape.txt'))
 
-    await expect(
-      streamExternalFileToRuntime({
-        ...baseArgs(rootPath),
-        entryRelativePath: 'escape.txt'
-      })
-    ).rejects.toThrow('Symlink not allowed')
-    expect(chunkCalls()).toHaveLength(0)
-  })
+      await expect(
+        streamExternalFileToRuntime({
+          ...baseArgs(rootPath),
+          entryRelativePath: 'escape.txt'
+        })
+      ).rejects.toThrow('Symlink not allowed')
+      expect(chunkCalls()).toHaveLength(0)
+    }
+  )
 })

--- a/src/main/ipc/runtime-upload-file-stream.test.ts
+++ b/src/main/ipc/runtime-upload-file-stream.test.ts
@@ -1,7 +1,10 @@
-import { mkdtemp, mkdir, rm, symlink, truncate, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as RuntimeImportLimits from './runtime-import-limits'
+
+type RuntimeImportLimitsModule = typeof RuntimeImportLimits
 
 const callRuntimeEnvironment = vi.fn()
 
@@ -9,6 +12,12 @@ vi.mock('./runtime-environment-transport-routing', () => ({
   callRuntimeEnvironment: (...args: unknown[]) => callRuntimeEnvironment(...args)
 }))
 vi.mock('./filesystem-auth', () => ({ authorizeExternalPath: () => {} }))
+// Why: see filesystem-runtime-upload-staging.test.ts — a real over-limit fixture
+// would allocate gigabytes on Windows.
+vi.mock('./runtime-import-limits', async (importOriginal) => ({
+  ...(await importOriginal<RuntimeImportLimitsModule>()),
+  REMOTE_IMPORT_MAX_FILE_BYTES: 2 * 1024 * 1024
+}))
 
 const { RUNTIME_UPLOAD_SLICE_BYTES, streamExternalFileToRuntime } =
   await import('./runtime-upload-file-stream')
@@ -89,12 +98,10 @@ describe('streamExternalFileToRuntime', () => {
 
   it('refuses a file over the ceiling even when no staged size is supplied', async () => {
     const filePath = join(workDir, 'huge.bin')
-    await writeFile(filePath, '')
-    // Sparse: the ceiling is read from stat(), so no real bytes are written.
-    await truncate(filePath, 3 * 1024 * 1024 * 1024)
+    await writeFile(filePath, Buffer.alloc(3 * 1024 * 1024))
 
     await expect(streamExternalFileToRuntime(baseArgs(filePath))).rejects.toThrow(
-      'over the 2 GB per-file remote import limit'
+      'over the 2 MB per-file remote import limit'
     )
     expect(chunkCalls()).toHaveLength(0)
   })

--- a/src/main/ipc/runtime-upload-file-stream.test.ts
+++ b/src/main/ipc/runtime-upload-file-stream.test.ts
@@ -176,6 +176,34 @@ describe('streamExternalFileToRuntime', () => {
     expect(seen).toEqual([RUNTIME_UPLOAD_SLICE_BYTES])
   })
 
+  it('stops between slices when the signal is already aborted', async () => {
+    const filePath = join(workDir, 'aborted.bin')
+    await writeFile(filePath, Buffer.alloc(RUNTIME_UPLOAD_SLICE_BYTES * 2))
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(
+      streamExternalFileToRuntime({ ...baseArgs(filePath), signal: controller.signal })
+    ).rejects.toThrow('Upload cancelled')
+    expect(chunkCalls()).toHaveLength(0)
+  })
+
+  it('stops mid-file when the signal aborts after the first slice', async () => {
+    const filePath = join(workDir, 'midway.bin')
+    await writeFile(filePath, Buffer.alloc(RUNTIME_UPLOAD_SLICE_BYTES * 4))
+    const controller = new AbortController()
+    callRuntimeEnvironment.mockImplementation(async () => {
+      controller.abort()
+      return { id: 'x', ok: true, result: {}, _meta: {} }
+    })
+
+    await expect(
+      streamExternalFileToRuntime({ ...baseArgs(filePath), signal: controller.signal })
+    ).rejects.toThrow('Upload cancelled')
+    // The first slice was already in flight; the loop stops before the second.
+    expect(chunkCalls()).toHaveLength(1)
+  })
+
   it('refuses a symlinked source', async () => {
     const targetPath = join(workDir, 'secret.txt')
     await writeFile(targetPath, 'secret')

--- a/src/main/ipc/runtime-upload-file-stream.test.ts
+++ b/src/main/ipc/runtime-upload-file-stream.test.ts
@@ -68,6 +68,25 @@ describe('streamExternalFileToRuntime', () => {
     expect(uploadedBytes().equals(contents)).toBe(true)
   })
 
+  it('refuses a source whose size no longer matches what staging measured', async () => {
+    const filePath = join(workDir, 'grown.bin')
+    await writeFile(filePath, Buffer.alloc(2048))
+
+    await expect(
+      streamExternalFileToRuntime({ ...baseArgs(filePath), expectedByteLength: 1024 })
+    ).rejects.toThrow('File changed since it was staged')
+    expect(chunkCalls()).toHaveLength(0)
+  })
+
+  it('accepts a source that still matches its staged size', async () => {
+    const filePath = join(workDir, 'same.bin')
+    await writeFile(filePath, Buffer.alloc(2048))
+
+    await expect(
+      streamExternalFileToRuntime({ ...baseArgs(filePath), expectedByteLength: 2048 })
+    ).resolves.toEqual({ byteLength: 2048 })
+  })
+
   it('never buffers more than one slice per chunk', async () => {
     const filePath = join(workDir, 'sliced.bin')
     await writeFile(filePath, Buffer.alloc(RUNTIME_UPLOAD_SLICE_BYTES * 2))
@@ -122,7 +141,8 @@ describe('streamExternalFileToRuntime', () => {
     expect(chunkCalls()).toHaveLength(2)
   })
 
-  it('refuses a symlinked source', async () => {
+  // symlink() needs privileges or Developer Mode on Windows.
+  it.skipIf(process.platform === 'win32')('refuses a symlinked source', async () => {
     const targetPath = join(workDir, 'secret.txt')
     await writeFile(targetPath, 'secret')
     const linkPath = join(workDir, 'link.txt')
@@ -134,19 +154,22 @@ describe('streamExternalFileToRuntime', () => {
     expect(chunkCalls()).toHaveLength(0)
   })
 
-  it('refuses a directory entry whose real path escapes the dropped root', async () => {
-    const outsidePath = join(workDir, 'outside.txt')
-    await writeFile(outsidePath, 'outside')
-    const rootPath = join(workDir, 'root')
-    await mkdir(rootPath)
-    await symlink(outsidePath, join(rootPath, 'escape.txt'))
+  it.skipIf(process.platform === 'win32')(
+    'refuses a directory entry whose real path escapes the dropped root',
+    async () => {
+      const outsidePath = join(workDir, 'outside.txt')
+      await writeFile(outsidePath, 'outside')
+      const rootPath = join(workDir, 'root')
+      await mkdir(rootPath)
+      await symlink(outsidePath, join(rootPath, 'escape.txt'))
 
-    await expect(
-      streamExternalFileToRuntime({
-        ...baseArgs(rootPath),
-        entryRelativePath: 'escape.txt'
-      })
-    ).rejects.toThrow('Symlink not allowed')
-    expect(chunkCalls()).toHaveLength(0)
-  })
+      await expect(
+        streamExternalFileToRuntime({
+          ...baseArgs(rootPath),
+          entryRelativePath: 'escape.txt'
+        })
+      ).rejects.toThrow('Symlink not allowed')
+      expect(chunkCalls()).toHaveLength(0)
+    }
+  )
 })

--- a/src/main/ipc/runtime-upload-file-stream.test.ts
+++ b/src/main/ipc/runtime-upload-file-stream.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, rm, symlink, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, rm, symlink, truncate, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -85,6 +85,18 @@ describe('streamExternalFileToRuntime', () => {
     await expect(
       streamExternalFileToRuntime({ ...baseArgs(filePath), expectedByteLength: 2048 })
     ).resolves.toEqual({ byteLength: 2048 })
+  })
+
+  it('refuses a file over the ceiling even when no staged size is supplied', async () => {
+    const filePath = join(workDir, 'huge.bin')
+    await writeFile(filePath, '')
+    // Sparse: the ceiling is read from stat(), so no real bytes are written.
+    await truncate(filePath, 3 * 1024 * 1024 * 1024)
+
+    await expect(streamExternalFileToRuntime(baseArgs(filePath))).rejects.toThrow(
+      'over the 2 GB per-file remote import limit'
+    )
+    expect(chunkCalls()).toHaveLength(0)
   })
 
   it('never buffers more than one slice per chunk', async () => {

--- a/src/main/ipc/runtime-upload-file-stream.ts
+++ b/src/main/ipc/runtime-upload-file-stream.ts
@@ -1,0 +1,148 @@
+import { constants } from 'node:fs'
+import { lstat, open, realpath } from 'node:fs/promises'
+import { isAbsolute, join, relative, sep } from 'node:path'
+import { authorizeExternalPath } from './filesystem-auth'
+import { callRuntimeEnvironment } from './runtime-environment-transport-routing'
+
+// Why: base64 turns 3 bytes into 4 chars, so a 384 KiB slice lands on the wire
+// as exactly 512 KiB — the chunk size the renderer used before streaming.
+export const RUNTIME_UPLOAD_SLICE_BYTES = 384 * 1024
+
+const RUNTIME_UPLOAD_CHUNK_TIMEOUT_MS = 30_000
+
+export type RuntimeUploadFileStreamArgs = {
+  userDataPath: string
+  environmentId: string
+  /** Client-local path of the dropped source (file, or root of a dropped directory). */
+  sourceRootPath: string
+  /** Path of this file within the dropped directory; empty when the source is a file. */
+  entryRelativePath: string
+  worktree: string
+  /** Destination path on the runtime, relative to the worktree. */
+  relativePath: string
+  expectedExecutionHostId?: string
+  expectedSshTargetId?: string
+  expectedSshConnectionGeneration?: number
+  expectedEnvironmentPairingRevision?: number
+}
+
+/**
+ * Stream one client-local file to a runtime environment in slices.
+ *
+ * Replaces reading the whole file into memory and base64-encoding it before the
+ * first byte moves. Peak memory is one slice, so imports are no longer bounded
+ * by main-process heap.
+ */
+export async function streamExternalFileToRuntime(
+  args: RuntimeUploadFileStreamArgs
+): Promise<{ byteLength: number }> {
+  const sourcePath = resolveEntrySourcePath(args.sourceRootPath, args.entryRelativePath)
+
+  // Why: parity with staging — an OS drop authorizes the paths it hands over.
+  authorizeExternalPath(sourcePath)
+
+  const displayPath = args.entryRelativePath || args.relativePath
+  const lstatResult = await lstat(sourcePath)
+  if (lstatResult.isSymbolicLink()) {
+    throw new Error(`Symlink not allowed in '${displayPath}'`)
+  }
+  if (!lstatResult.isFile()) {
+    throw new Error(`Unsupported file type in '${displayPath}'`)
+  }
+  if (args.entryRelativePath) {
+    await assertEntryInsideRoot(args.sourceRootPath, sourcePath, displayPath)
+  }
+
+  const handle = await open(sourcePath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0))
+  try {
+    const openedStat = await handle.stat()
+    if (!openedStat.isFile()) {
+      throw new Error(`Unsupported file type in '${displayPath}'`)
+    }
+    if (
+      openedStat.size !== lstatResult.size ||
+      (lstatResult.ino !== 0 && openedStat.ino !== 0 && openedStat.ino !== lstatResult.ino) ||
+      (lstatResult.dev !== 0 && openedStat.dev !== 0 && openedStat.dev !== lstatResult.dev)
+    ) {
+      throw new Error(`File changed during upload: '${displayPath}'`)
+    }
+
+    const totalBytes = openedStat.size
+    // Why: a zero-byte source produces no slices, but the destination still has
+    // to exist before commitUpload renames it into place.
+    if (totalBytes === 0) {
+      await sendChunk(args, '', false)
+      return { byteLength: 0 }
+    }
+
+    const buffer = Buffer.allocUnsafe(Math.min(RUNTIME_UPLOAD_SLICE_BYTES, totalBytes))
+    let offset = 0
+    while (offset < totalBytes) {
+      const { bytesRead } = await handle.read(buffer, 0, buffer.byteLength, offset)
+      if (bytesRead === 0) {
+        throw new Error(`File truncated during upload: '${displayPath}'`)
+      }
+      await sendChunk(args, buffer.subarray(0, bytesRead).toString('base64'), offset > 0)
+      offset += bytesRead
+    }
+
+    // Why: the destination is a temp path the caller commits, so a source that
+    // changed mid-read is caught before anything lands at the final path.
+    const afterReadStat = await handle.stat()
+    if (afterReadStat.size !== totalBytes) {
+      throw new Error(`File changed during upload: '${displayPath}'`)
+    }
+    return { byteLength: totalBytes }
+  } finally {
+    await handle.close()
+  }
+}
+
+async function sendChunk(
+  args: RuntimeUploadFileStreamArgs,
+  contentBase64: string,
+  append: boolean
+): Promise<void> {
+  const response = await callRuntimeEnvironment(
+    args.userDataPath,
+    args.environmentId,
+    'files.writeBase64Chunk',
+    {
+      worktree: args.worktree,
+      relativePath: args.relativePath,
+      contentBase64,
+      append,
+      expectedSshTargetId: args.expectedSshTargetId,
+      expectedSshConnectionGeneration: args.expectedSshConnectionGeneration,
+      expectedExecutionHostId: args.expectedExecutionHostId
+    },
+    RUNTIME_UPLOAD_CHUNK_TIMEOUT_MS,
+    // Why: re-checked per chunk, so a re-pair mid-upload aborts instead of
+    // appending the rest of the file on a different host.
+    args.expectedEnvironmentPairingRevision
+  )
+  if (response.ok !== true) {
+    throw new Error(response.error.message || response.error.code)
+  }
+}
+
+function resolveEntrySourcePath(sourceRootPath: string, entryRelativePath: string): string {
+  return entryRelativePath ? join(sourceRootPath, entryRelativePath) : sourceRootPath
+}
+
+async function assertEntryInsideRoot(
+  sourceRootPath: string,
+  candidatePath: string,
+  displayPath: string
+): Promise<void> {
+  const rootRealPath = await realpath(sourceRootPath)
+  const candidateRealPath = await realpath(candidatePath)
+  const relativeToRoot = relative(rootRealPath, candidateRealPath)
+  // Why: `..name` is a valid child path; only `..` and `../...` escape.
+  if (
+    relativeToRoot !== '' &&
+    (relativeToRoot === '..' || relativeToRoot.startsWith(`..${sep}`) || isAbsolute(relativeToRoot))
+  ) {
+    throw new Error(`Path escaped upload root during upload: '${displayPath}'`)
+  }
+}

--- a/src/main/ipc/runtime-upload-file-stream.ts
+++ b/src/main/ipc/runtime-upload-file-stream.ts
@@ -18,6 +18,14 @@ export type RuntimeUploadFileStreamArgs = {
   sourceRootPath: string
   /** Path of this file within the dropped directory; empty when the source is a file. */
   entryRelativePath: string
+  /**
+   * Size staging measured and validated against the import ceilings.
+   *
+   * Staging and upload are separate IPC calls, so a source can be replaced or
+   * grown in between. Without this the streamer would take the current size as
+   * authoritative and happily move a file the ceilings had already rejected.
+   */
+  expectedByteLength?: number
   worktree: string
   /** Destination path on the runtime, relative to the worktree. */
   relativePath: string
@@ -73,6 +81,9 @@ export async function streamExternalFileToRuntime(
     }
 
     const totalBytes = openedStat.size
+    if (args.expectedByteLength !== undefined && totalBytes !== args.expectedByteLength) {
+      throw new Error(`File changed since it was staged: '${displayPath}'`)
+    }
     throwIfCancelled(args.signal)
     // Why: a zero-byte source produces no slices, but the destination still has
     // to exist before commitUpload renames it into place.

--- a/src/main/ipc/runtime-upload-file-stream.ts
+++ b/src/main/ipc/runtime-upload-file-stream.ts
@@ -17,6 +17,8 @@ export type RuntimeUploadFileStreamArgs = {
   sourceRootPath: string
   /** Path of this file within the dropped directory; empty when the source is a file. */
   entryRelativePath: string
+  /** Size staging measured; a source replaced since then is refused, not streamed. */
+  expectedByteLength?: number
   worktree: string
   /** Destination path on the runtime, relative to the worktree. */
   relativePath: string
@@ -68,6 +70,9 @@ export async function streamExternalFileToRuntime(
     }
 
     const totalBytes = openedStat.size
+    if (args.expectedByteLength !== undefined && totalBytes !== args.expectedByteLength) {
+      throw new Error(`File changed since it was staged: '${displayPath}'`)
+    }
     // Why: a zero-byte source produces no slices, but the destination still has
     // to exist before commitUpload renames it into place.
     if (totalBytes === 0) {

--- a/src/main/ipc/runtime-upload-file-stream.ts
+++ b/src/main/ipc/runtime-upload-file-stream.ts
@@ -2,6 +2,7 @@ import { constants } from 'node:fs'
 import { lstat, open, realpath } from 'node:fs/promises'
 import { isAbsolute, join, relative, sep } from 'node:path'
 import { authorizeExternalPath } from './filesystem-auth'
+import { formatByteCeiling, REMOTE_IMPORT_MAX_FILE_BYTES } from './runtime-import-limits'
 import { callRuntimeEnvironment } from './runtime-environment-transport-routing'
 
 // Why: base64 turns 3 bytes into 4 chars, so a 384 KiB slice lands on the wire
@@ -72,6 +73,14 @@ export async function streamExternalFileToRuntime(
     const totalBytes = openedStat.size
     if (args.expectedByteLength !== undefined && totalBytes !== args.expectedByteLength) {
       throw new Error(`File changed since it was staged: '${displayPath}'`)
+    }
+    // Why: enforced again where the bytes actually move. Staging is a separate
+    // call, so the ceiling only holds here if this boundary checks it too.
+    if (totalBytes > REMOTE_IMPORT_MAX_FILE_BYTES) {
+      throw new Error(
+        `'${displayPath}' is ${formatByteCeiling(totalBytes)}, over the ` +
+          `${formatByteCeiling(REMOTE_IMPORT_MAX_FILE_BYTES)} per-file remote import limit`
+      )
     }
     // Why: a zero-byte source produces no slices, but the destination still has
     // to exist before commitUpload renames it into place.

--- a/src/main/ipc/runtime-upload-file-stream.ts
+++ b/src/main/ipc/runtime-upload-file-stream.ts
@@ -24,6 +24,8 @@ export type RuntimeUploadFileStreamArgs = {
   expectedSshTargetId?: string
   expectedSshConnectionGeneration?: number
   expectedEnvironmentPairingRevision?: number
+  /** Called after each slice lands, so the drop UI can show how far along the file is. */
+  onProgress?: (progress: { sentBytes: number; totalBytes: number }) => void
 }
 
 /**
@@ -72,6 +74,7 @@ export async function streamExternalFileToRuntime(
     // to exist before commitUpload renames it into place.
     if (totalBytes === 0) {
       await sendChunk(args, '', false)
+      args.onProgress?.({ sentBytes: 0, totalBytes: 0 })
       return { byteLength: 0 }
     }
 
@@ -84,6 +87,9 @@ export async function streamExternalFileToRuntime(
       }
       await sendChunk(args, buffer.subarray(0, bytesRead).toString('base64'), offset > 0)
       offset += bytesRead
+      // Why: reported after the chunk is acknowledged, so the bar tracks bytes the
+      // runtime actually has rather than bytes handed to the socket.
+      args.onProgress?.({ sentBytes: offset, totalBytes })
     }
 
     // Why: the destination is a temp path the caller commits, so a source that

--- a/src/main/ipc/runtime-upload-file-stream.ts
+++ b/src/main/ipc/runtime-upload-file-stream.ts
@@ -2,6 +2,7 @@ import { constants } from 'node:fs'
 import { lstat, open, realpath } from 'node:fs/promises'
 import { isAbsolute, join, relative, sep } from 'node:path'
 import { authorizeExternalPath } from './filesystem-auth'
+import { RuntimeUploadCancelledError } from './runtime-upload-cancellation'
 import { callRuntimeEnvironment } from './runtime-environment-transport-routing'
 
 // Why: base64 turns 3 bytes into 4 chars, so a 384 KiB slice lands on the wire
@@ -26,6 +27,8 @@ export type RuntimeUploadFileStreamArgs = {
   expectedEnvironmentPairingRevision?: number
   /** Called after each slice lands, so the drop UI can show how far along the file is. */
   onProgress?: (progress: { sentBytes: number; totalBytes: number }) => void
+  /** Aborts between slices; the destination is a temp path the caller removes. */
+  signal?: AbortSignal
 }
 
 /**
@@ -70,6 +73,7 @@ export async function streamExternalFileToRuntime(
     }
 
     const totalBytes = openedStat.size
+    throwIfCancelled(args.signal)
     // Why: a zero-byte source produces no slices, but the destination still has
     // to exist before commitUpload renames it into place.
     if (totalBytes === 0) {
@@ -81,6 +85,9 @@ export async function streamExternalFileToRuntime(
     const buffer = Buffer.allocUnsafe(Math.min(RUNTIME_UPLOAD_SLICE_BYTES, totalBytes))
     let offset = 0
     while (offset < totalBytes) {
+      // Why: checked between slices rather than mid-flight, so a cancelled upload
+      // still leaves a well-formed partial temp file for the caller to delete.
+      throwIfCancelled(args.signal)
       const { bytesRead } = await handle.read(buffer, 0, buffer.byteLength, offset)
       if (bytesRead === 0) {
         throw new Error(`File truncated during upload: '${displayPath}'`)
@@ -150,5 +157,11 @@ async function assertEntryInsideRoot(
     (relativeToRoot === '..' || relativeToRoot.startsWith(`..${sep}`) || isAbsolute(relativeToRoot))
   ) {
     throw new Error(`Path escaped upload root during upload: '${displayPath}'`)
+  }
+}
+
+function throwIfCancelled(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    throw new RuntimeUploadCancelledError()
   }
 }

--- a/src/main/ipc/runtime-upload-progress.test.ts
+++ b/src/main/ipc/runtime-upload-progress.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from 'vitest'
+import { throttleRuntimeUploadProgress } from './runtime-upload-progress'
+
+const MB = 1024 * 1024
+
+function collector(now: () => number) {
+  const seen: number[] = []
+  const emit = throttleRuntimeUploadProgress((progress) => seen.push(progress.sentBytes), now)
+  return { seen, emit }
+}
+
+describe('throttleRuntimeUploadProgress', () => {
+  it('drops updates that are neither big enough nor old enough', () => {
+    let clock = 0
+    const { seen, emit } = collector(() => clock)
+    const total = 100 * MB
+
+    emit({ uploadId: 'u', sentBytes: 512 * 1024, totalBytes: total })
+    for (let sent = 768 * 1024; sent <= 1408 * 1024; sent += 256 * 1024) {
+      clock += 10
+      emit({ uploadId: 'u', sentBytes: sent, totalBytes: total })
+    }
+
+    // Only the first: every follow-up is under 1 MB apart and inside 100ms.
+    expect(seen).toEqual([512 * 1024])
+  })
+
+  it('lets an update through once a megabyte has moved', () => {
+    let clock = 0
+    const { seen, emit } = collector(() => clock)
+    const total = 100 * MB
+
+    emit({ uploadId: 'u', sentBytes: 1, totalBytes: total })
+    clock += 5
+    emit({ uploadId: 'u', sentBytes: 2 * MB, totalBytes: total })
+
+    expect(seen).toEqual([1, 2 * MB])
+  })
+
+  it('lets an update through once the interval has passed on a slow link', () => {
+    let clock = 0
+    const { seen, emit } = collector(() => clock)
+    const total = 100 * MB
+
+    emit({ uploadId: 'u', sentBytes: 1, totalBytes: total })
+    clock += 250
+    emit({ uploadId: 'u', sentBytes: 1024, totalBytes: total })
+
+    expect(seen).toEqual([1, 1024])
+  })
+
+  it('always emits the final byte count so the bar lands on full', () => {
+    let clock = 0
+    const { seen, emit } = collector(() => clock)
+    const total = 4 * MB
+
+    emit({ uploadId: 'u', sentBytes: 1, totalBytes: total })
+    clock += 1
+    emit({ uploadId: 'u', sentBytes: total, totalBytes: total })
+
+    expect(seen).toEqual([1, total])
+  })
+
+  it('emits a zero-byte file exactly once', () => {
+    const { seen, emit } = collector(() => 0)
+
+    emit({ uploadId: 'u', sentBytes: 0, totalBytes: 0 })
+    emit({ uploadId: 'u', sentBytes: 0, totalBytes: 0 })
+
+    expect(seen).toEqual([0])
+  })
+
+  it('never moves the reported count backwards', () => {
+    let clock = 0
+    const { seen, emit } = collector(() => clock)
+    const total = 100 * MB
+
+    emit({ uploadId: 'u', sentBytes: 10 * MB, totalBytes: total })
+    clock += 500
+    emit({ uploadId: 'u', sentBytes: 4 * MB, totalBytes: total })
+
+    expect(seen).toEqual([10 * MB])
+  })
+
+  it('keeps a separate baseline per throttle so two files do not interfere', () => {
+    const first = collector(() => 0)
+    const second = collector(() => 0)
+
+    first.emit({ uploadId: 'a', sentBytes: 8 * MB, totalBytes: 100 * MB })
+    second.emit({ uploadId: 'b', sentBytes: 1, totalBytes: 100 * MB })
+
+    expect(first.seen).toEqual([8 * MB])
+    expect(second.seen).toEqual([1])
+  })
+
+  it('uses a real clock by default', () => {
+    const spy = vi.fn()
+    const emit = throttleRuntimeUploadProgress(spy)
+    emit({ uploadId: 'u', sentBytes: 1, totalBytes: 10 })
+    expect(spy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/ipc/runtime-upload-progress.ts
+++ b/src/main/ipc/runtime-upload-progress.ts
@@ -1,0 +1,49 @@
+export const RUNTIME_UPLOAD_PROGRESS_CHANNEL = 'fs:uploadProgress'
+
+/** Bytes of one file that have reached the runtime, and how many there are in total. */
+export type RuntimeUploadProgress = {
+  uploadId: string
+  sentBytes: number
+  totalBytes: number
+}
+
+export type RuntimeUploadProgressSink = (progress: RuntimeUploadProgress) => void
+
+const PROGRESS_MIN_INTERVAL_MS = 100
+const PROGRESS_MIN_BYTES = 1024 * 1024
+
+/**
+ * Coalesce per-slice progress into something a renderer can keep up with.
+ *
+ * A 2 GB file is ~5,400 slices; forwarding each one would spend more time in IPC
+ * than in the transfer. First and last are always emitted so a bar starts at a
+ * known point and lands exactly on full.
+ */
+export function throttleRuntimeUploadProgress(
+  sink: RuntimeUploadProgressSink,
+  now: () => number = Date.now
+): RuntimeUploadProgressSink {
+  let lastSentBytes = -1
+  let lastEmittedAt = -Infinity
+  return (progress) => {
+    const isTerminal = progress.sentBytes >= progress.totalBytes
+    const isFirst = lastSentBytes < 0
+    const currentTime = now()
+    if (
+      !isTerminal &&
+      !isFirst &&
+      progress.sentBytes - lastSentBytes < PROGRESS_MIN_BYTES &&
+      currentTime - lastEmittedAt < PROGRESS_MIN_INTERVAL_MS
+    ) {
+      return
+    }
+    // Why: slices land in order, so a late duplicate would only ever move the bar
+    // backwards.
+    if (progress.sentBytes <= lastSentBytes) {
+      return
+    }
+    lastSentBytes = progress.sentBytes
+    lastEmittedAt = currentTime
+    sink(progress)
+  }
+}

--- a/src/preload/api/filesystem-api.ts
+++ b/src/preload/api/filesystem-api.ts
@@ -188,6 +188,8 @@ export type FilesystemApi = {
     onUploadProgress: (
       callback: (progress: { uploadId: string; sentBytes: number; totalBytes: number }) => void
     ) => () => void
+    cancelRuntimeUpload: (args: { uploadId: string }) => Promise<void>
+    releaseRuntimeUpload: (args: { uploadId: string }) => Promise<void>
     resolveDroppedPathsForAgent: (
       args: {
         paths: string[]

--- a/src/preload/api/filesystem-api.ts
+++ b/src/preload/api/filesystem-api.ts
@@ -159,7 +159,7 @@ export type FilesystemApi = {
             kind: 'file' | 'directory'
             entries: (
               | { relativePath: string; kind: 'directory' }
-              | { relativePath: string; kind: 'file'; contentBase64: string }
+              | { relativePath: string; kind: 'file'; byteLength: number }
             )[]
           }
         | {
@@ -174,6 +174,16 @@ export type FilesystemApi = {
           }
       )[]
     }>
+    uploadExternalFileToRuntime: (
+      args: {
+        environmentId: string
+        sourceRootPath: string
+        entryRelativePath: string
+        worktree: string
+        relativePath: string
+        expectedEnvironmentPairingRevision?: number
+      } & SshMutationExpectation
+    ) => Promise<{ byteLength: number }>
     resolveDroppedPathsForAgent: (
       args: {
         paths: string[]

--- a/src/preload/api/filesystem-api.ts
+++ b/src/preload/api/filesystem-api.ts
@@ -181,6 +181,7 @@ export type FilesystemApi = {
         entryRelativePath: string
         worktree: string
         relativePath: string
+        expectedByteLength?: number
         uploadId?: string
         expectedEnvironmentPairingRevision?: number
       } & SshMutationExpectation

--- a/src/preload/api/filesystem-api.ts
+++ b/src/preload/api/filesystem-api.ts
@@ -181,9 +181,13 @@ export type FilesystemApi = {
         entryRelativePath: string
         worktree: string
         relativePath: string
+        uploadId?: string
         expectedEnvironmentPairingRevision?: number
       } & SshMutationExpectation
     ) => Promise<{ byteLength: number }>
+    onUploadProgress: (
+      callback: (progress: { uploadId: string; sentBytes: number; totalBytes: number }) => void
+    ) => () => void
     resolveDroppedPathsForAgent: (
       args: {
         paths: string[]

--- a/src/preload/api/filesystem-api.ts
+++ b/src/preload/api/filesystem-api.ts
@@ -181,6 +181,7 @@ export type FilesystemApi = {
         entryRelativePath: string
         worktree: string
         relativePath: string
+        expectedByteLength?: number
         expectedEnvironmentPairingRevision?: number
       } & SshMutationExpectation
     ) => Promise<{ byteLength: number }>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3440,7 +3440,7 @@ const api = {
             kind: 'file' | 'directory'
             entries: (
               | { relativePath: string; kind: 'directory' }
-              | { relativePath: string; kind: 'file'; contentBase64: string }
+              | { relativePath: string; kind: 'file'; byteLength: number }
             )[]
           }
         | {
@@ -3455,6 +3455,17 @@ const api = {
           }
       )[]
     }> => ipcRenderer.invoke('fs:stageExternalPathsForRuntimeUpload', args),
+    uploadExternalFileToRuntime: (
+      args: {
+        environmentId: string
+        sourceRootPath: string
+        entryRelativePath: string
+        worktree: string
+        relativePath: string
+        expectedEnvironmentPairingRevision?: number
+      } & SshMutationExpectation
+    ): Promise<{ byteLength: number }> =>
+      ipcRenderer.invoke('fs:uploadExternalFileToRuntime', args),
     resolveDroppedPathsForAgent: (
       args: {
         paths: string[]

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3462,6 +3462,7 @@ const api = {
         entryRelativePath: string
         worktree: string
         relativePath: string
+        expectedByteLength?: number
         uploadId?: string
         expectedEnvironmentPairingRevision?: number
       } & SshMutationExpectation

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3477,6 +3477,10 @@ const api = {
       ipcRenderer.on('fs:uploadProgress', listener)
       return () => ipcRenderer.removeListener('fs:uploadProgress', listener)
     },
+    cancelRuntimeUpload: (args: { uploadId: string }): Promise<void> =>
+      ipcRenderer.invoke('fs:cancelRuntimeUpload', args),
+    releaseRuntimeUpload: (args: { uploadId: string }): Promise<void> =>
+      ipcRenderer.invoke('fs:releaseRuntimeUpload', args),
     resolveDroppedPathsForAgent: (
       args: {
         paths: string[]

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3462,6 +3462,7 @@ const api = {
         entryRelativePath: string
         worktree: string
         relativePath: string
+        expectedByteLength?: number
         expectedEnvironmentPairingRevision?: number
       } & SshMutationExpectation
     ): Promise<{ byteLength: number }> =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3462,10 +3462,21 @@ const api = {
         entryRelativePath: string
         worktree: string
         relativePath: string
+        uploadId?: string
         expectedEnvironmentPairingRevision?: number
       } & SshMutationExpectation
     ): Promise<{ byteLength: number }> =>
       ipcRenderer.invoke('fs:uploadExternalFileToRuntime', args),
+    onUploadProgress: (
+      callback: (progress: { uploadId: string; sentBytes: number; totalBytes: number }) => void
+    ): (() => void) => {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        data: { uploadId: string; sentBytes: number; totalBytes: number }
+      ) => callback(data)
+      ipcRenderer.on('fs:uploadProgress', listener)
+      return () => ipcRenderer.removeListener('fs:uploadProgress', listener)
+    },
     resolveDroppedPathsForAgent: (
       args: {
         paths: string[]

--- a/src/renderer/src/components/terminal-pane/TerminalDropUploadToast.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalDropUploadToast.tsx
@@ -1,0 +1,134 @@
+import { useState, useSyncExternalStore } from 'react'
+import { ChevronDownIcon, ChevronUpIcon, FileIcon, UploadIcon, XIcon } from 'lucide-react'
+import { Progress } from '@/components/ui/progress'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import {
+  getRuntimeUploadSession,
+  subscribeToRuntimeUploadSessions,
+  summarizeRuntimeUploadSession,
+  type RuntimeUploadRow
+} from '@/runtime/runtime-upload-session-state'
+import { formatTransferredOfTotal, toPercent } from './terminal-drop-upload-progress'
+
+type Props = {
+  sessionId: string
+  onCancel: (uploadId: string) => void
+}
+
+export function TerminalDropUploadToast({ sessionId, onCancel }: Props): React.JSX.Element | null {
+  const session = useSyncExternalStore(subscribeToRuntimeUploadSessions, () =>
+    getRuntimeUploadSession(sessionId)
+  )
+  const [collapsed, setCollapsed] = useState(false)
+
+  // createElement at the call site still yields a valid element, so rendering
+  // nothing here is safe once the session has ended.
+  if (!session) {
+    return null
+  }
+  const summary = summarizeRuntimeUploadSession(session)
+  const heading = translate(
+    'auto.components.terminal.pane.terminal.drop.upload.heading',
+    'Uploading {{value0}} file{{value1}}',
+    { value0: session.rows.length, value1: session.rows.length === 1 ? '' : 's' }
+  )
+
+  return (
+    <div className="w-full overflow-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-[0_10px_24px_rgba(0,0,0,0.18)]">
+      <div className="flex items-center gap-3 px-3 py-2.5">
+        <span className="flex size-7 shrink-0 items-center justify-center rounded-full border border-border">
+          <UploadIcon className="size-3.5" aria-hidden />
+        </span>
+        <span className="min-w-0 flex-1 truncate text-sm">{heading}</span>
+        {/* Fixed width so the row never reflows as the number gains digits. */}
+        <span className="w-9 shrink-0 text-right text-sm tabular-nums text-muted-foreground">
+          {summary.percent}%
+        </span>
+        <button
+          type="button"
+          onClick={() => setCollapsed((value) => !value)}
+          aria-expanded={!collapsed}
+          aria-label={
+            collapsed
+              ? translate('auto.components.terminal.pane.terminal.drop.upload.expand', 'Show files')
+              : translate(
+                  'auto.components.terminal.pane.terminal.drop.upload.collapse',
+                  'Hide files'
+                )
+          }
+          className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {collapsed ? (
+            <ChevronDownIcon className="size-4" />
+          ) : (
+            <ChevronUpIcon className="size-4" />
+          )}
+        </button>
+      </div>
+      {!collapsed && (
+        <ul className="border-t border-border">
+          {session.rows.map((row) => (
+            <UploadRowItem key={row.uploadId} row={row} onCancel={onCancel} />
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+function UploadRowItem({
+  row,
+  onCancel
+}: {
+  row: RuntimeUploadRow
+  onCancel: (uploadId: string) => void
+}): React.JSX.Element {
+  const percent = toPercent(row.sentBytes, row.totalBytes)
+  const inactive = row.status !== 'uploading'
+
+  return (
+    <li className="flex items-center gap-3 px-3 py-2.5">
+      <FileIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span className={cn('truncate text-[13px]', inactive && 'text-muted-foreground')}>
+          {row.name}
+        </span>
+        <span className="truncate text-xs text-muted-foreground tabular-nums">
+          {rowSubLabel(row)}
+        </span>
+      </span>
+      <Progress
+        value={percent}
+        aria-label={row.name}
+        className={cn('h-1.5 w-24 shrink-0', inactive && 'opacity-40')}
+      />
+      <span className="w-9 shrink-0 text-right text-[13px] tabular-nums text-muted-foreground">
+        {percent}%
+      </span>
+      {/* Cancel is a back-out, not a destructive action: ghost, no color. */}
+      <button
+        type="button"
+        disabled={inactive}
+        onClick={() => onCancel(row.uploadId)}
+        aria-label={translate(
+          'auto.components.terminal.pane.terminal.drop.upload.cancel',
+          'Cancel upload'
+        )}
+        className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-0"
+      >
+        <XIcon className="size-4" />
+      </button>
+    </li>
+  )
+}
+
+function rowSubLabel(row: RuntimeUploadRow): string {
+  if (row.status === 'cancelled') {
+    return translate('auto.components.terminal.pane.terminal.drop.upload.cancelled', 'Cancelled')
+  }
+  if (row.status === 'failed') {
+    return translate('auto.components.terminal.pane.terminal.drop.upload.failed', 'Failed')
+  }
+  return formatTransferredOfTotal(row.sentBytes, row.totalBytes)
+}

--- a/src/renderer/src/components/terminal-pane/TerminalDropUploadToast.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalDropUploadToast.tsx
@@ -7,6 +7,7 @@ import {
   getRuntimeUploadSession,
   subscribeToRuntimeUploadSessions,
   summarizeRuntimeUploadSession,
+  toggleRuntimeUploadCollapsed,
   type RuntimeUploadRow
 } from '@/runtime/runtime-upload-session-state'
 import { formatTransferredOfTotal, toPercent } from './terminal-drop-upload-progress'
@@ -21,17 +22,26 @@ type Props = {
   onCancel: (uploadId: string) => void
   /** Closes the toast; the panel owns the timing so the exit is not cut short. */
   onDismiss: () => void
+  /**
+   * Re-issues the toast so its host re-measures.
+   *
+   * Sonner caches a toast's height and only recomputes it when the element
+   * identity changes, so a panel that shrinks in place keeps the old height and
+   * ends up top-aligned inside it — the collapsed header appears to hang where
+   * the expanded panel started instead of sitting at the bottom.
+   */
+  onLayoutChange: () => void
 }
 
 export function TerminalDropUploadToast({
   sessionId,
   onCancel,
-  onDismiss
+  onDismiss,
+  onLayoutChange
 }: Props): React.JSX.Element | null {
   const session = useSyncExternalStore(subscribeToRuntimeUploadSessions, () =>
     getRuntimeUploadSession(sessionId)
   )
-  const [collapsed, setCollapsed] = useState(false)
   const [leaving, setLeaving] = useState(false)
   const settled = session?.settled === true
 
@@ -56,6 +66,7 @@ export function TerminalDropUploadToast({
   if (!session) {
     return null
   }
+  const collapsed = session.collapsed
   const summary = summarizeRuntimeUploadSession(session)
   const heading = formatTerminalDropUploadHeading({
     rowCount: session.rows.length,
@@ -83,7 +94,10 @@ export function TerminalDropUploadToast({
         <button
           type="button"
           hidden={session.settled}
-          onClick={() => setCollapsed((value) => !value)}
+          onClick={() => {
+            toggleRuntimeUploadCollapsed(sessionId)
+            onLayoutChange()
+          }}
           aria-expanded={!collapsed}
           aria-label={
             collapsed

--- a/src/renderer/src/components/terminal-pane/TerminalDropUploadToast.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalDropUploadToast.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useSyncExternalStore } from 'react'
-import { ChevronDownIcon, ChevronUpIcon, FileIcon, UploadIcon, XIcon } from 'lucide-react'
+import { ChevronDownIcon, FileIcon, UploadIcon, XIcon } from 'lucide-react'
 import { Progress } from '@/components/ui/progress'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
@@ -112,11 +112,14 @@ export function TerminalDropUploadToast({
           }
           className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
-          {collapsed ? (
-            <ChevronDownIcon className="size-4" />
-          ) : (
-            <ChevronUpIcon className="size-4" />
-          )}
+          {/* Why: one icon rotated, not two swapped — swapping replaces the node, so
+              there is nothing to tween and the arrow flips in a single frame. */}
+          <ChevronDownIcon
+            className={cn(
+              'size-4 transition-transform duration-200 ease-out motion-reduce:transition-none',
+              !collapsed && 'rotate-180'
+            )}
+          />
         </button>
       </div>
       {!collapsed && (

--- a/src/renderer/src/components/terminal-pane/TerminalDropUploadToast.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalDropUploadToast.tsx
@@ -1,4 +1,4 @@
-import { useState, useSyncExternalStore } from 'react'
+import { useEffect, useState, useSyncExternalStore } from 'react'
 import { ChevronDownIcon, ChevronUpIcon, FileIcon, UploadIcon, XIcon } from 'lucide-react'
 import { Progress } from '@/components/ui/progress'
 import { cn } from '@/lib/utils'
@@ -10,17 +10,46 @@ import {
   type RuntimeUploadRow
 } from '@/runtime/runtime-upload-session-state'
 import { formatTransferredOfTotal, toPercent } from './terminal-drop-upload-progress'
+import { formatTerminalDropUploadHeading } from './terminal-drop-upload-heading'
+
+// Long enough to read the outcome, short enough not to linger over the terminal.
+const SETTLED_HOLD_MS = 1200
+const EXIT_ANIMATION_MS = 200
 
 type Props = {
   sessionId: string
   onCancel: (uploadId: string) => void
+  /** Closes the toast; the panel owns the timing so the exit is not cut short. */
+  onDismiss: () => void
 }
 
-export function TerminalDropUploadToast({ sessionId, onCancel }: Props): React.JSX.Element | null {
+export function TerminalDropUploadToast({
+  sessionId,
+  onCancel,
+  onDismiss
+}: Props): React.JSX.Element | null {
   const session = useSyncExternalStore(subscribeToRuntimeUploadSessions, () =>
     getRuntimeUploadSession(sessionId)
   )
   const [collapsed, setCollapsed] = useState(false)
+  const [leaving, setLeaving] = useState(false)
+  const settled = session?.settled === true
+
+  useEffect(() => {
+    if (!settled) {
+      return
+    }
+    const reducedMotion =
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    const exitMs = reducedMotion ? 0 : EXIT_ANIMATION_MS
+    const startExit = window.setTimeout(() => setLeaving(true), SETTLED_HOLD_MS)
+    const close = window.setTimeout(onDismiss, SETTLED_HOLD_MS + exitMs)
+    return () => {
+      window.clearTimeout(startExit)
+      window.clearTimeout(close)
+    }
+  }, [settled, onDismiss])
 
   // createElement at the call site still yields a valid element, so rendering
   // nothing here is safe once the session has ended.
@@ -28,14 +57,20 @@ export function TerminalDropUploadToast({ sessionId, onCancel }: Props): React.J
     return null
   }
   const summary = summarizeRuntimeUploadSession(session)
-  const heading = translate(
-    'auto.components.terminal.pane.terminal.drop.upload.heading',
-    'Uploading {{value0}} file{{value1}}',
-    { value0: session.rows.length, value1: session.rows.length === 1 ? '' : 's' }
-  )
+  const heading = formatTerminalDropUploadHeading({
+    rowCount: session.rows.length,
+    settled: session.settled,
+    doneCount: summary.doneCount,
+    cancelledCount: summary.cancelledCount
+  })
 
   return (
-    <div className="w-full overflow-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-[0_10px_24px_rgba(0,0,0,0.18)]">
+    <div
+      className={cn(
+        'w-full overflow-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-[0_10px_24px_rgba(0,0,0,0.18)]',
+        leaving && 'animate-out fade-out-0 zoom-out-95 duration-200 fill-mode-forwards'
+      )}
+    >
       <div className="flex items-center gap-3 px-3 py-2.5">
         <span className="flex size-7 shrink-0 items-center justify-center rounded-full border border-border">
           <UploadIcon className="size-3.5" aria-hidden />
@@ -43,10 +78,11 @@ export function TerminalDropUploadToast({ sessionId, onCancel }: Props): React.J
         <span className="min-w-0 flex-1 truncate text-sm">{heading}</span>
         {/* Fixed width so the row never reflows as the number gains digits. */}
         <span className="w-9 shrink-0 text-right text-sm tabular-nums text-muted-foreground">
-          {summary.percent}%
+          {session.settled ? '' : `${summary.percent}%`}
         </span>
         <button
           type="button"
+          hidden={session.settled}
           onClick={() => setCollapsed((value) => !value)}
           aria-expanded={!collapsed}
           aria-label={

--- a/src/renderer/src/components/terminal-pane/TerminalDropUploadToast.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalDropUploadToast.tsx
@@ -22,14 +22,7 @@ type Props = {
   onCancel: (uploadId: string) => void
   /** Closes the toast; the panel owns the timing so the exit is not cut short. */
   onDismiss: () => void
-  /**
-   * Re-issues the toast so its host re-measures.
-   *
-   * Sonner caches a toast's height and only recomputes it when the element
-   * identity changes, so a panel that shrinks in place keeps the old height and
-   * ends up top-aligned inside it — the collapsed header appears to hang where
-   * the expanded panel started instead of sitting at the bottom.
-   */
+  /** Re-issues the toast: sonner re-measures height only on a new element identity. */
   onLayoutChange: () => void
 }
 

--- a/src/renderer/src/components/terminal-pane/TerminalDropUploadToast.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalDropUploadToast.tsx
@@ -78,7 +78,10 @@ export function TerminalDropUploadToast({
   return (
     <div
       className={cn(
-        'w-full overflow-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-[0_10px_24px_rgba(0,0,0,0.18)]',
+        // Why: an unstyled toast is content-sized, so collapsing the list shrank the
+        // panel horizontally too and it appeared to jump. Pinned to the Toaster's
+        // own width so both states occupy the same box.
+        'w-[var(--width,26rem)] overflow-hidden rounded-lg border border-border bg-popover text-popover-foreground shadow-[0_10px_24px_rgba(0,0,0,0.18)]',
         leaving && 'animate-out fade-out-0 zoom-out-95 duration-200 fill-mode-forwards'
       )}
     >
@@ -140,7 +143,7 @@ function UploadRowItem({
   return (
     <li className="flex items-center gap-3 px-3 py-2.5">
       <FileIcon className="size-4 shrink-0 text-muted-foreground" aria-hidden />
-      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5 overflow-hidden">
         <span className={cn('truncate text-[13px]', inactive && 'text-muted-foreground')}>
           {row.name}
         </span>

--- a/src/renderer/src/components/terminal-pane/terminal-drop-handler.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-handler.test.ts
@@ -192,7 +192,10 @@ describe('handleTerminalFileDrop', () => {
     expect(focus).toHaveBeenCalled()
     expect(mocks.recordTerminalUserInputForLeaf).toHaveBeenCalledWith('tab-1', 'leaf-1')
     expect(mocks.toastError).not.toHaveBeenCalled()
-    expect(mocks.toastDismiss).toHaveBeenCalledWith('toast-1')
+    expect(mocks.toastCustom).toHaveBeenCalled()
+    // The panel holds briefly to show the outcome and dismisses itself; cutting
+    // that short here is what made a cancelled drop vanish with nothing to read.
+    expect(mocks.toastDismiss).not.toHaveBeenCalled()
   })
 
   it('does not paste runtime-uploaded paths when the target PTY changed', async () => {
@@ -236,7 +239,30 @@ describe('handleTerminalFileDrop', () => {
     expect(sendInput).not.toHaveBeenCalled()
     expect(focus).not.toHaveBeenCalled()
     expect(mocks.recordTerminalUserInputForLeaf).not.toHaveBeenCalled()
+    expect(mocks.toastDismiss).not.toHaveBeenCalled()
+  })
+
+  it('tears the upload panel down immediately when the import throws', async () => {
+    mocks.importExternalPathsToRuntime.mockImplementation(
+      async (_context: unknown, _paths: unknown, _dest: unknown, options: never) => {
+        startAndFinishRow(options)
+        throw new Error('runtime unreachable')
+      }
+    )
+    const pane = { id: 1, leafId: 'leaf-1', terminal: { focus: vi.fn() } }
+    const manager = { getActivePane: () => pane, getPanes: () => [pane] }
+
+    await handleTerminalFileDrop({
+      manager: manager as never,
+      paneTransports: new Map([[1, createTerminalTransport(vi.fn(() => true))]]) as never,
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      cwd: undefined,
+      data: { paths: ['/Users/me/logo.png'], target: 'terminal' }
+    })
+
     expect(mocks.toastDismiss).toHaveBeenCalledWith('toast-1')
+    expect(mocks.toastError).toHaveBeenCalled()
   })
 
   it('uses Windows shell paths for forward-slash UNC runtime worktrees', async () => {

--- a/src/renderer/src/components/terminal-pane/terminal-drop-handler.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-handler.test.ts
@@ -153,7 +153,7 @@ describe('handleTerminalFileDrop', () => {
       },
       ['/Users/me/logo.png'],
       '/remote/repo/.orca/drops',
-      { assertCurrent: expect.any(Function) }
+      { assertCurrent: expect.any(Function), onProgress: expect.any(Function) }
     )
     expect(sendInput).toHaveBeenCalledWith(
       wrapTerminalBracketedPasteText('/remote/repo/.orca/drops/logo.png')
@@ -249,7 +249,7 @@ describe('handleTerminalFileDrop', () => {
       },
       ['/Users/me/logo.png'],
       '\\\\server\\share\\repo\\.orca\\drops',
-      { assertCurrent: expect.any(Function) }
+      { assertCurrent: expect.any(Function), onProgress: expect.any(Function) }
     )
     expect(sendInput).toHaveBeenCalledWith(
       wrapTerminalBracketedPasteText('\\\\server\\share\\repo\\.orca\\drops\\logo.png')
@@ -306,7 +306,7 @@ describe('handleTerminalFileDrop', () => {
       },
       ['/Users/me/spec.pdf'],
       '/remote/repo/.orca/drops',
-      { assertCurrent: expect.any(Function) }
+      { assertCurrent: expect.any(Function), onProgress: expect.any(Function) }
     )
     expect(sendInput).toHaveBeenCalledWith('/remote/repo/.orca/drops/spec.pdf ')
   })

--- a/src/renderer/src/components/terminal-pane/terminal-drop-handler.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-handler.test.ts
@@ -242,6 +242,31 @@ describe('handleTerminalFileDrop', () => {
     expect(mocks.toastDismiss).not.toHaveBeenCalled()
   })
 
+  it('publishes the upload panel without an explicit undefined id', async () => {
+    mocks.importExternalPathsToRuntime.mockImplementation(announceRowThenResolve({ results: [] }))
+    const pane = { id: 1, leafId: 'leaf-1', terminal: { focus: vi.fn() } }
+    const manager = { getActivePane: () => pane, getPanes: () => [pane] }
+
+    await handleTerminalFileDrop({
+      manager: manager as never,
+      paneTransports: new Map([[1, createTerminalTransport(vi.fn(() => true))]]) as never,
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      cwd: undefined,
+      data: { paths: ['/Users/me/logo.png'], target: 'terminal' }
+    })
+
+    // Why: sonner spreads these options over the id it just minted, so passing
+    // `id: undefined` registers the toast under an id it never returns and every
+    // re-issue stacks another panel instead of updating the first.
+    expect(mocks.toastCustom).toHaveBeenCalledTimes(1)
+    const options = (mocks.toastCustom.mock.calls as unknown as unknown[][])[0]?.[1] as Record<
+      string,
+      unknown
+    >
+    expect(Object.hasOwn(options, 'id')).toBe(false)
+  })
+
   it('tears the upload panel down immediately when the import throws', async () => {
     mocks.importExternalPathsToRuntime.mockImplementation(
       async (_context: unknown, _paths: unknown, _dest: unknown, options: never) => {

--- a/src/renderer/src/components/terminal-pane/terminal-drop-handler.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-handler.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   toastLoading: vi.fn(() => 'toast-1'),
+  toastCustom: vi.fn(() => 'toast-1'),
   toastDismiss: vi.fn(),
   toastError: vi.fn(),
   importExternalPathsToRuntime: vi.fn(),
@@ -44,6 +45,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock('sonner', () => ({
   toast: {
     loading: mocks.toastLoading,
+    custom: mocks.toastCustom,
     dismiss: mocks.toastDismiss,
     error: mocks.toastError,
     message: vi.fn()
@@ -84,6 +86,25 @@ function createTerminalTransport(
   }
 }
 
+// Why: the drop panel is only created once rows exist, so a mock that never
+// announces a row leaves nothing for the dismissal assertions to observe.
+function startAndFinishRow(options: never): void {
+  const progress = (
+    options as { progress?: { onStart: (r: unknown[]) => void; onFinish: () => void } }
+  )?.progress
+  progress?.onStart([
+    { uploadId: 'u-1', name: 'logo.png', totalBytes: 10, sourcePath: '/Users/me/logo.png' }
+  ])
+  progress?.onFinish()
+}
+
+function announceRowThenResolve(value: unknown) {
+  return async (_context: unknown, _paths: unknown, _dest: unknown, options: never) => {
+    startAndFinishRow(options)
+    return value
+  }
+}
+
 describe('handleTerminalFileDrop', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -113,17 +134,19 @@ describe('handleTerminalFileDrop', () => {
   })
 
   it('uploads client-local drops into the active runtime before pasting paths', async () => {
-    mocks.importExternalPathsToRuntime.mockResolvedValue({
-      results: [
-        {
-          sourcePath: '/Users/me/logo.png',
-          status: 'imported',
-          destPath: '/remote/repo/.orca/drops/logo.png',
-          kind: 'file',
-          renamed: false
-        }
-      ]
-    })
+    mocks.importExternalPathsToRuntime.mockImplementation(
+      announceRowThenResolve({
+        results: [
+          {
+            sourcePath: '/Users/me/logo.png',
+            status: 'imported',
+            destPath: '/remote/repo/.orca/drops/logo.png',
+            kind: 'file',
+            renamed: false
+          }
+        ]
+      })
+    )
     const sendInput = vi.fn(() => true)
     const focus = vi.fn()
     const pane = { id: 1, leafId: 'leaf-1', terminal: { focus } }
@@ -153,7 +176,15 @@ describe('handleTerminalFileDrop', () => {
       },
       ['/Users/me/logo.png'],
       '/remote/repo/.orca/drops',
-      { assertCurrent: expect.any(Function), onProgress: expect.any(Function) }
+      {
+        assertCurrent: expect.any(Function),
+        progress: {
+          onStart: expect.any(Function),
+          onRowProgress: expect.any(Function),
+          onRowSettled: expect.any(Function),
+          onFinish: expect.any(Function)
+        }
+      }
     )
     expect(sendInput).toHaveBeenCalledWith(
       wrapTerminalBracketedPasteText('/remote/repo/.orca/drops/logo.png')
@@ -166,20 +197,23 @@ describe('handleTerminalFileDrop', () => {
 
   it('does not paste runtime-uploaded paths when the target PTY changed', async () => {
     let ptyId = 'pty-1'
-    mocks.importExternalPathsToRuntime.mockImplementation(async () => {
-      ptyId = 'pty-2'
-      return {
-        results: [
-          {
-            sourcePath: '/Users/me/logo.png',
-            status: 'imported',
-            destPath: '/remote/repo/.orca/drops/logo.png',
-            kind: 'file',
-            renamed: false
-          }
-        ]
+    mocks.importExternalPathsToRuntime.mockImplementation(
+      async (_context: unknown, _paths: unknown, _dest: unknown, options: never) => {
+        ptyId = 'pty-2'
+        startAndFinishRow(options)
+        return {
+          results: [
+            {
+              sourcePath: '/Users/me/logo.png',
+              status: 'imported',
+              destPath: '/remote/repo/.orca/drops/logo.png',
+              kind: 'file',
+              renamed: false
+            }
+          ]
+        }
       }
-    })
+    )
     const sendInput = vi.fn(() => true)
     const focus = vi.fn()
     const pane = { id: 1, leafId: 'leaf-1', terminal: { focus } }
@@ -249,7 +283,15 @@ describe('handleTerminalFileDrop', () => {
       },
       ['/Users/me/logo.png'],
       '\\\\server\\share\\repo\\.orca\\drops',
-      { assertCurrent: expect.any(Function), onProgress: expect.any(Function) }
+      {
+        assertCurrent: expect.any(Function),
+        progress: {
+          onStart: expect.any(Function),
+          onRowProgress: expect.any(Function),
+          onRowSettled: expect.any(Function),
+          onFinish: expect.any(Function)
+        }
+      }
     )
     expect(sendInput).toHaveBeenCalledWith(
       wrapTerminalBracketedPasteText('\\\\server\\share\\repo\\.orca\\drops\\logo.png')
@@ -306,7 +348,15 @@ describe('handleTerminalFileDrop', () => {
       },
       ['/Users/me/spec.pdf'],
       '/remote/repo/.orca/drops',
-      { assertCurrent: expect.any(Function), onProgress: expect.any(Function) }
+      {
+        assertCurrent: expect.any(Function),
+        progress: {
+          onStart: expect.any(Function),
+          onRowProgress: expect.any(Function),
+          onRowSettled: expect.any(Function),
+          onFinish: expect.any(Function)
+        }
+      }
     )
     expect(sendInput).toHaveBeenCalledWith('/remote/repo/.orca/drops/spec.pdf ')
   })

--- a/src/renderer/src/components/terminal-pane/terminal-drop-paste.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-paste.ts
@@ -1,0 +1,53 @@
+import type { PaneManager } from '@/lib/pane-manager/pane-manager'
+import type { PtyTransport } from './pty-transport'
+import type { captureTerminalDropTarget } from './terminal-drop-target'
+import { getCurrentTerminalDropTransport } from './terminal-drop-target'
+import type { resolveNativeTerminalDropPane } from './terminal-drop-pane-resolution'
+import { writeTerminalDropPathsToCapturedTarget } from './terminal-drop-path-writer'
+import { showTerminalDropWriteFailure } from './terminal-drop-write-failure'
+import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
+
+/** Everything a drop flow needs to reach the terminal it was dropped on. */
+export type NativeDropFlowArgs = {
+  dataPaths: string[]
+  dropTarget: ReturnType<typeof captureTerminalDropTarget>
+  manager: PaneManager
+  paneTransports: Map<number, PtyTransport>
+  pane: ReturnType<typeof resolveNativeTerminalDropPane> & {}
+  tabId: string
+  worktreePath: string
+  expectedSshTargetId?: string
+  expectedSshConnectionGeneration?: number
+  expectedExecutionHostId?: 'local' | `ssh:${string}`
+  assertCurrent?: () => void
+}
+
+export async function pasteResolvedDropPaths(
+  args: NativeDropFlowArgs & { paths: string[]; targetShell: 'posix' | 'windows' }
+): Promise<void> {
+  // Why: pane may have unmounted during upload/resolution (tab closed,
+  // worktree switched). Re-check before writing so we do not call sendInput
+  // on a torn-down PTY.
+  const liveTransport = getCurrentTerminalDropTransport(
+    args.manager,
+    args.paneTransports,
+    args.dropTarget
+  )
+  if (!liveTransport) {
+    return
+  }
+  const writeResult = await writeTerminalDropPathsToCapturedTarget({
+    dropTarget: args.dropTarget,
+    manager: args.manager,
+    paneTransports: args.paneTransports,
+    paths: args.paths,
+    targetShell: args.targetShell
+  })
+  showTerminalDropWriteFailure(writeResult.failureReason)
+  if (writeResult.sentAnyPath) {
+    recordTerminalUserInputForLeaf(args.tabId, args.pane.leafId)
+  }
+  if (writeResult.targetCurrent) {
+    args.pane.terminal.focus()
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-drop-upload-heading.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-upload-heading.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { formatTerminalDropUploadHeading } from './terminal-drop-upload-heading'
+
+describe('formatTerminalDropUploadHeading', () => {
+  it('counts files while the drop is running', () => {
+    expect(
+      formatTerminalDropUploadHeading({
+        rowCount: 2,
+        settled: false,
+        doneCount: 0,
+        cancelledCount: 1
+      })
+    ).toBe('Uploading 2 files')
+  })
+
+  it('says cancelled once everything stopped and nothing landed', () => {
+    expect(
+      formatTerminalDropUploadHeading({
+        rowCount: 2,
+        settled: true,
+        doneCount: 0,
+        cancelledCount: 2
+      })
+    ).toBe('Upload cancelled')
+  })
+
+  it('reports a partial drop by count', () => {
+    expect(
+      formatTerminalDropUploadHeading({
+        rowCount: 3,
+        settled: true,
+        doneCount: 1,
+        cancelledCount: 2
+      })
+    ).toBe('Uploaded 1 of 3')
+  })
+
+  it('reports a clean finish', () => {
+    expect(
+      formatTerminalDropUploadHeading({
+        rowCount: 2,
+        settled: true,
+        doneCount: 2,
+        cancelledCount: 0
+      })
+    ).toBe('Uploaded 2 files')
+  })
+
+  it('distinguishes a failure from a cancel', () => {
+    expect(
+      formatTerminalDropUploadHeading({
+        rowCount: 1,
+        settled: true,
+        doneCount: 0,
+        cancelledCount: 0
+      })
+    ).toBe('Upload failed')
+  })
+
+  it('uses the singular for one file', () => {
+    expect(
+      formatTerminalDropUploadHeading({
+        rowCount: 1,
+        settled: false,
+        doneCount: 0,
+        cancelledCount: 0
+      })
+    ).toBe('Uploading 1 file')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-drop-upload-heading.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-upload-heading.test.ts
@@ -10,7 +10,7 @@ describe('formatTerminalDropUploadHeading', () => {
         doneCount: 0,
         cancelledCount: 1
       })
-    ).toBe('Uploading 2 files')
+    ).toBe('Uploading 2 files to runtime')
   })
 
   it('says cancelled once everything stopped and nothing landed', () => {
@@ -32,7 +32,7 @@ describe('formatTerminalDropUploadHeading', () => {
         doneCount: 1,
         cancelledCount: 2
       })
-    ).toBe('Uploaded 1 of 3')
+    ).toBe('Uploaded 1 of 3 to runtime')
   })
 
   it('reports a clean finish', () => {
@@ -43,7 +43,7 @@ describe('formatTerminalDropUploadHeading', () => {
         doneCount: 2,
         cancelledCount: 0
       })
-    ).toBe('Uploaded 2 files')
+    ).toBe('Uploaded 2 files to runtime')
   })
 
   it('distinguishes a failure from a cancel', () => {
@@ -65,6 +65,6 @@ describe('formatTerminalDropUploadHeading', () => {
         doneCount: 0,
         cancelledCount: 0
       })
-    ).toBe('Uploading 1 file')
+    ).toBe('Uploading 1 file to runtime')
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-drop-upload-heading.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-upload-heading.ts
@@ -13,6 +13,11 @@ type HeadingInput = {
  * While the drop is running it counts files; once everything has stopped it
  * states the outcome instead, so a cancelled upload leaves something to read
  * rather than closing on "Uploading 2 files".
+ *
+ * Names the destination, because a drop onto a remote workspace is the only
+ * case that shows this panel and "Uploading 2 files" alone reads local.
+ * The cancelled and failed lines stay short: the destination no longer matters
+ * once nothing landed there.
  */
 export function formatTerminalDropUploadHeading({
   rowCount,
@@ -24,7 +29,7 @@ export function formatTerminalDropUploadHeading({
   if (!settled) {
     return translate(
       'auto.components.terminal.pane.terminal.drop.upload.heading',
-      'Uploading {{value0}} file{{value1}}',
+      'Uploading {{value0}} file{{value1}} to runtime',
       { value0: rowCount, value1: plural }
     )
   }
@@ -43,13 +48,13 @@ export function formatTerminalDropUploadHeading({
   if (doneCount < rowCount) {
     return translate(
       'auto.components.terminal.pane.terminal.drop.upload.heading.partial',
-      'Uploaded {{value0}} of {{value1}}',
+      'Uploaded {{value0}} of {{value1}} to runtime',
       { value0: doneCount, value1: rowCount }
     )
   }
   return translate(
     'auto.components.terminal.pane.terminal.drop.upload.heading.done',
-    'Uploaded {{value0}} file{{value1}}',
+    'Uploaded {{value0}} file{{value1}} to runtime',
     { value0: rowCount, value1: plural }
   )
 }

--- a/src/renderer/src/components/terminal-pane/terminal-drop-upload-heading.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-upload-heading.ts
@@ -1,0 +1,55 @@
+import { translate } from '@/i18n/i18n'
+
+type HeadingInput = {
+  rowCount: number
+  settled: boolean
+  doneCount: number
+  cancelledCount: number
+}
+
+/**
+ * What the panel's header says.
+ *
+ * While the drop is running it counts files; once everything has stopped it
+ * states the outcome instead, so a cancelled upload leaves something to read
+ * rather than closing on "Uploading 2 files".
+ */
+export function formatTerminalDropUploadHeading({
+  rowCount,
+  settled,
+  doneCount,
+  cancelledCount
+}: HeadingInput): string {
+  const plural = rowCount === 1 ? '' : 's'
+  if (!settled) {
+    return translate(
+      'auto.components.terminal.pane.terminal.drop.upload.heading',
+      'Uploading {{value0}} file{{value1}}',
+      { value0: rowCount, value1: plural }
+    )
+  }
+  if (doneCount === 0 && cancelledCount > 0) {
+    return translate(
+      'auto.components.terminal.pane.terminal.drop.upload.heading.cancelled',
+      'Upload cancelled'
+    )
+  }
+  if (doneCount === 0) {
+    return translate(
+      'auto.components.terminal.pane.terminal.drop.upload.heading.failed',
+      'Upload failed'
+    )
+  }
+  if (doneCount < rowCount) {
+    return translate(
+      'auto.components.terminal.pane.terminal.drop.upload.heading.partial',
+      'Uploaded {{value0}} of {{value1}}',
+      { value0: doneCount, value1: rowCount }
+    )
+  }
+  return translate(
+    'auto.components.terminal.pane.terminal.drop.upload.heading.done',
+    'Uploaded {{value0}} file{{value1}}',
+    { value0: rowCount, value1: plural }
+  )
+}

--- a/src/renderer/src/components/terminal-pane/terminal-drop-upload-heading.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-upload-heading.ts
@@ -7,18 +7,7 @@ type HeadingInput = {
   cancelledCount: number
 }
 
-/**
- * What the panel's header says.
- *
- * While the drop is running it counts files; once everything has stopped it
- * states the outcome instead, so a cancelled upload leaves something to read
- * rather than closing on "Uploading 2 files".
- *
- * Names the destination, because a drop onto a remote workspace is the only
- * case that shows this panel and "Uploading 2 files" alone reads local.
- * The cancelled and failed lines stay short: the destination no longer matters
- * once nothing landed there.
- */
+/** Counts files while running, states the outcome once everything has stopped. */
 export function formatTerminalDropUploadHeading({
   rowCount,
   settled,

--- a/src/renderer/src/components/terminal-pane/terminal-drop-upload-progress.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-upload-progress.test.ts
@@ -1,30 +1,46 @@
 import { describe, expect, it } from 'vitest'
-import { formatTerminalDropUploadProgress } from './terminal-drop-upload-progress'
+import { formatTransferredOfTotal, toPercent } from './terminal-drop-upload-progress'
 
-describe('formatTerminalDropUploadProgress', () => {
-  it('shows moved bytes, total and percent', () => {
-    const label = formatTerminalDropUploadProgress(1, 10 * 1024 * 1024, 40 * 1024 * 1024)
-    expect(label).toContain('10.0 MB')
-    expect(label).toContain('40.0 MB')
-    expect(label).toContain('25%')
+const MB = 1024 * 1024
+
+describe('formatTransferredOfTotal', () => {
+  it('scales both figures to the total unit', () => {
+    expect(formatTransferredOfTotal(8.63 * MB, 32.5 * MB)).toBe('8.6 / 32.5 MB')
   })
 
-  it('pluralises the file count', () => {
-    expect(formatTerminalDropUploadProgress(1, 0, 100)).toContain('1 file')
-    expect(formatTerminalDropUploadProgress(3, 0, 100)).toContain('3 files')
+  it('keeps the smaller figure on the total scale instead of its own', () => {
+    // 900 KB of 32.5 MB must not render as "900 / 32.5".
+    expect(formatTransferredOfTotal(900 * 1024, 32.5 * MB)).toBe('0.9 / 32.5 MB')
   })
 
-  it('omits the byte figures for a drop with no measurable size', () => {
-    const label = formatTerminalDropUploadProgress(1, 0, 0)
-    expect(label).not.toContain('0 B')
-    expect(label).not.toContain('%')
+  it('uses whole bytes without decimals', () => {
+    expect(formatTransferredOfTotal(120, 900)).toBe('120 / 900 B')
   })
 
-  it('never rounds up to 100% before the last byte lands', () => {
-    expect(formatTerminalDropUploadProgress(1, 999_999, 1_000_000)).toContain('99%')
+  it('drops to no decimals once the total is large in its unit', () => {
+    expect(formatTransferredOfTotal(150 * MB, 300 * MB)).toBe('150 / 300 MB')
   })
 
-  it('reaches 100% when everything has moved', () => {
-    expect(formatTerminalDropUploadProgress(1, 1_000, 1_000)).toContain('100%')
+  it('never shows more sent than the total', () => {
+    expect(formatTransferredOfTotal(50 * MB, 10 * MB)).toBe('10.0 / 10.0 MB')
+  })
+
+  it('handles a zero-byte drop without dividing by zero', () => {
+    expect(formatTransferredOfTotal(0, 0)).toBe('0 B')
+  })
+})
+
+describe('toPercent', () => {
+  it('floors so it only reads 100 when everything landed', () => {
+    expect(toPercent(999_999, 1_000_000)).toBe(99)
+    expect(toPercent(1_000_000, 1_000_000)).toBe(100)
+  })
+
+  it('is zero when nothing is measurable', () => {
+    expect(toPercent(0, 0)).toBe(0)
+  })
+
+  it('clamps a source that grew past its staged size', () => {
+    expect(toPercent(200, 100)).toBe(100)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-drop-upload-progress.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-upload-progress.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { formatTerminalDropUploadProgress } from './terminal-drop-upload-progress'
+
+describe('formatTerminalDropUploadProgress', () => {
+  it('shows moved bytes, total and percent', () => {
+    const label = formatTerminalDropUploadProgress(1, 10 * 1024 * 1024, 40 * 1024 * 1024)
+    expect(label).toContain('10.0 MB')
+    expect(label).toContain('40.0 MB')
+    expect(label).toContain('25%')
+  })
+
+  it('pluralises the file count', () => {
+    expect(formatTerminalDropUploadProgress(1, 0, 100)).toContain('1 file')
+    expect(formatTerminalDropUploadProgress(3, 0, 100)).toContain('3 files')
+  })
+
+  it('omits the byte figures for a drop with no measurable size', () => {
+    const label = formatTerminalDropUploadProgress(1, 0, 0)
+    expect(label).not.toContain('0 B')
+    expect(label).not.toContain('%')
+  })
+
+  it('never rounds up to 100% before the last byte lands', () => {
+    expect(formatTerminalDropUploadProgress(1, 999_999, 1_000_000)).toContain('99%')
+  })
+
+  it('reaches 100% when everything has moved', () => {
+    expect(formatTerminalDropUploadProgress(1, 1_000, 1_000)).toContain('100%')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-drop-upload-progress.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-upload-progress.ts
@@ -1,26 +1,32 @@
-import { formatBytes } from '../status-bar/workspace-space-format'
-import { translate } from '@/i18n/i18n'
+const BYTE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'] as const
 
 /**
- * Label for the in-place drop toast while bytes are moving.
+ * "8.6 / 32.5 MB" — both figures scaled to the total's unit.
  *
- * Falls back to the plain "uploading" wording when the drop has no measurable
- * size — an empty file, or a folder of empty files — because "0 B of 0 B" reads
- * like a failure rather than a fast success.
+ * Formatting each side independently reads as a bug the moment they land in
+ * different units: 900 KB of a 32.5 MB file would render "900 / 32.5" with the
+ * two numbers on different scales.
  */
-export function formatTerminalDropUploadProgress(
-  fileCount: number,
-  sentBytes: number,
-  totalBytes: number
-): string {
-  const uploading = translate(
-    'auto.components.terminal.pane.terminal.drop.handler.29c031b49a',
-    'Uploading {{value0}} file{{value1}} to runtime…',
-    { value0: fileCount, value1: fileCount === 1 ? '' : 's' }
-  )
-  if (totalBytes <= 0) {
-    return uploading
+export function formatTransferredOfTotal(sentBytes: number, totalBytes: number): string {
+  if (!Number.isFinite(totalBytes) || totalBytes <= 0) {
+    return `0 ${BYTE_UNITS[0]}`
   }
-  const percent = Math.min(100, Math.floor((sentBytes / totalBytes) * 100))
-  return `${uploading} ${formatBytes(sentBytes)} / ${formatBytes(totalBytes)} (${percent}%)`
+  let unitIndex = 0
+  let divisor = 1
+  while (totalBytes / divisor >= 1024 && unitIndex < BYTE_UNITS.length - 1) {
+    divisor *= 1024
+    unitIndex += 1
+  }
+  const scaledTotal = totalBytes / divisor
+  const scaledSent = Math.min(Math.max(sentBytes, 0), totalBytes) / divisor
+  const precision = scaledTotal >= 100 || unitIndex === 0 ? 0 : scaledTotal >= 10 ? 1 : 2
+  return `${scaledSent.toFixed(precision)} / ${scaledTotal.toFixed(precision)} ${BYTE_UNITS[unitIndex]}`
+}
+
+export function toPercent(sentBytes: number, totalBytes: number): number {
+  if (totalBytes <= 0) {
+    return 0
+  }
+  // Why: floor, so a bar only reads 100% once the last byte has actually landed.
+  return Math.min(100, Math.max(0, Math.floor((sentBytes / totalBytes) * 100)))
 }

--- a/src/renderer/src/components/terminal-pane/terminal-drop-upload-progress.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-upload-progress.ts
@@ -1,0 +1,26 @@
+import { formatBytes } from '../status-bar/workspace-space-format'
+import { translate } from '@/i18n/i18n'
+
+/**
+ * Label for the in-place drop toast while bytes are moving.
+ *
+ * Falls back to the plain "uploading" wording when the drop has no measurable
+ * size — an empty file, or a folder of empty files — because "0 B of 0 B" reads
+ * like a failure rather than a fast success.
+ */
+export function formatTerminalDropUploadProgress(
+  fileCount: number,
+  sentBytes: number,
+  totalBytes: number
+): string {
+  const uploading = translate(
+    'auto.components.terminal.pane.terminal.drop.handler.29c031b49a',
+    'Uploading {{value0}} file{{value1}} to runtime…',
+    { value0: fileCount, value1: fileCount === 1 ? '' : 's' }
+  )
+  if (totalBytes <= 0) {
+    return uploading
+  }
+  const percent = Math.min(100, Math.floor((sentBytes / totalBytes) * 100))
+  return `${uploading} ${formatBytes(sentBytes)} / ${formatBytes(totalBytes)} (${percent}%)`
+}

--- a/src/renderer/src/components/terminal-pane/terminal-drop-upload-progress.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-drop-upload-progress.ts
@@ -1,12 +1,6 @@
 const BYTE_UNITS = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'] as const
 
-/**
- * "8.6 / 32.5 MB" — both figures scaled to the total's unit.
- *
- * Formatting each side independently reads as a bug the moment they land in
- * different units: 900 KB of a 32.5 MB file would render "900 / 32.5" with the
- * two numbers on different scales.
- */
+/** Both figures share the total's unit; scaling each alone renders "900 / 32.5". */
 export function formatTransferredOfTotal(sentBytes: number, totalBytes: number): string {
   if (!Number.isFinite(totalBytes) || totalBytes <= 0) {
     return `0 ${BYTE_UNITS[0]}`

--- a/src/renderer/src/components/terminal-pane/terminal-native-file-drop.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-native-file-drop.ts
@@ -4,30 +4,21 @@ import { extractIpcErrorMessage } from '@/lib/ipc-error'
 import { getLocalProjectExecutionRuntimeContext } from '@/lib/local-preflight-context'
 import { CLIENT_PLATFORM } from '@/lib/new-workspace'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
-import { importExternalPathsToRuntime } from '@/runtime/runtime-file-client'
 import { useAppStore } from '@/store'
 import { translate } from '@/i18n/i18n'
 import { isWindowsAbsolutePathLike } from '../../../../shared/cross-platform-path'
 import { isWslUncPath, parseWslUncPath } from '../../../../shared/wsl-paths'
 import type { PtyTransport } from './pty-transport'
-import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
 import { reportTerminalDropUploadSkipsAndFailures } from './terminal-drop-upload-report'
-import { formatTerminalDropUploadProgress } from './terminal-drop-upload-progress'
-import { captureTerminalDropTarget, getCurrentTerminalDropTransport } from './terminal-drop-target'
-import {
-  getTerminalTargetShellForWorktreePath,
-  isTerminalDropWindowsPathLike,
-  resolveTerminalDropTargetShell
-} from './terminal-drop-shell'
-import { writeTerminalDropPathsToCapturedTarget } from './terminal-drop-path-writer'
+import type { NativeDropFlowArgs } from './terminal-drop-paste'
+import { pasteResolvedDropPaths } from './terminal-drop-paste'
+import { uploadRuntimeDropPaths } from './terminal-runtime-drop-upload'
+import { captureTerminalDropTarget } from './terminal-drop-target'
+import { resolveTerminalDropTargetShell } from './terminal-drop-shell'
 import { resolveNativeTerminalDropPane } from './terminal-drop-pane-resolution'
 import { getTerminalPasteSshRemotePlatform } from './terminal-paste-ssh-platform'
-import { showTerminalDropWriteFailure } from './terminal-drop-write-failure'
 import { captureDirectSshMutationExpectation } from '@/lib/ssh-mutation-expectation'
-import {
-  joinRuntimeTerminalDropDir,
-  resolveTerminalDropWorktreePath
-} from './terminal-drop-worktree-path'
+import { resolveTerminalDropWorktreePath } from './terminal-drop-worktree-path'
 import { captureRuntimeTerminalDropOwner } from './terminal-drop-runtime-owner'
 
 export type NativeTerminalFileDropArgs = {
@@ -156,74 +147,6 @@ async function handleNativeTerminalFileDropWithCapturedOwner(
   })
 }
 
-type NativeDropFlowArgs = {
-  dataPaths: string[]
-  dropTarget: ReturnType<typeof captureTerminalDropTarget>
-  manager: PaneManager
-  paneTransports: Map<number, PtyTransport>
-  pane: ReturnType<typeof resolveNativeTerminalDropPane> & {}
-  tabId: string
-  worktreePath: string
-  expectedSshTargetId?: string
-  expectedSshConnectionGeneration?: number
-  expectedExecutionHostId?: 'local' | `ssh:${string}`
-  assertCurrent?: () => void
-}
-
-async function uploadRuntimeDropPaths(
-  args: NativeDropFlowArgs & {
-    runtimeEnvironmentId: string
-    settings: ReturnType<typeof useAppStore.getState>['settings']
-    worktreeId: string
-  }
-): Promise<void> {
-  const targetShell = getTerminalTargetShellForWorktreePath(args.worktreePath)
-  const destinationDir = joinRuntimeTerminalDropDir(args.worktreePath)
-  const pending = toast.loading(formatTerminalDropUploadProgress(args.dataPaths.length, 0, 0))
-  try {
-    const { results } = await importExternalPathsToRuntime(
-      {
-        // Why: drops into existing worktrees must follow the worktree owner,
-        // not the currently focused host in the sidebar.
-        settings: { ...args.settings, activeRuntimeEnvironmentId: args.runtimeEnvironmentId },
-        worktreeId: args.worktreeId,
-        worktreePath: args.worktreePath,
-        expectedExecutionHostId: args.expectedExecutionHostId,
-        expectedSshTargetId: args.expectedSshTargetId,
-        expectedSshConnectionGeneration: args.expectedSshConnectionGeneration
-      },
-      args.dataPaths,
-      destinationDir,
-      {
-        assertCurrent: args.assertCurrent,
-        // Why: reuses the pending toast's id so the drop keeps one row instead of
-        // stacking a new toast per update.
-        onProgress: ({ sentBytes, totalBytes }) => {
-          toast.loading(
-            formatTerminalDropUploadProgress(args.dataPaths.length, sentBytes, totalBytes),
-            { id: pending }
-          )
-        }
-      }
-    )
-    const imported = results.filter((result) => result.status === 'imported')
-    const importedPaths = imported.map((result) =>
-      isTerminalDropWindowsPathLike(args.worktreePath)
-        ? result.destPath.replace(/\//g, '\\')
-        : result.destPath
-    )
-    await pasteResolvedDropPaths({ ...args, paths: importedPaths, targetShell })
-    reportTerminalDropUploadSkipsAndFailures(
-      results.filter((result) => result.status === 'skipped'),
-      results.filter((result) => result.status === 'failed')
-    )
-  } catch (err) {
-    toast.error(extractIpcErrorMessage(err, 'Failed to upload files.'))
-  } finally {
-    toast.dismiss(pending)
-  }
-}
-
 async function pasteLocalDropPaths(
   args: NativeDropFlowArgs & { localWslDrop: boolean; targetShell: 'posix' | 'windows' }
 ): Promise<void> {
@@ -277,36 +200,6 @@ async function uploadRemoteDropPaths(
     toast.error(extractIpcErrorMessage(err, 'Failed to upload files.'))
   } finally {
     toast.dismiss(pending)
-  }
-}
-
-async function pasteResolvedDropPaths(
-  args: NativeDropFlowArgs & { paths: string[]; targetShell: 'posix' | 'windows' }
-): Promise<void> {
-  // Why: pane may have unmounted during upload/resolution (tab closed,
-  // worktree switched). Re-check before writing so we do not call sendInput
-  // on a torn-down PTY.
-  const liveTransport = getCurrentTerminalDropTransport(
-    args.manager,
-    args.paneTransports,
-    args.dropTarget
-  )
-  if (!liveTransport) {
-    return
-  }
-  const writeResult = await writeTerminalDropPathsToCapturedTarget({
-    dropTarget: args.dropTarget,
-    manager: args.manager,
-    paneTransports: args.paneTransports,
-    paths: args.paths,
-    targetShell: args.targetShell
-  })
-  showTerminalDropWriteFailure(writeResult.failureReason)
-  if (writeResult.sentAnyPath) {
-    recordTerminalUserInputForLeaf(args.tabId, args.pane.leafId)
-  }
-  if (writeResult.targetCurrent) {
-    args.pane.terminal.focus()
   }
 }
 

--- a/src/renderer/src/components/terminal-pane/terminal-native-file-drop.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-native-file-drop.ts
@@ -12,6 +12,7 @@ import { isWslUncPath, parseWslUncPath } from '../../../../shared/wsl-paths'
 import type { PtyTransport } from './pty-transport'
 import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
 import { reportTerminalDropUploadSkipsAndFailures } from './terminal-drop-upload-report'
+import { formatTerminalDropUploadProgress } from './terminal-drop-upload-progress'
 import { captureTerminalDropTarget, getCurrentTerminalDropTransport } from './terminal-drop-target'
 import {
   getTerminalTargetShellForWorktreePath,
@@ -178,13 +179,7 @@ async function uploadRuntimeDropPaths(
 ): Promise<void> {
   const targetShell = getTerminalTargetShellForWorktreePath(args.worktreePath)
   const destinationDir = joinRuntimeTerminalDropDir(args.worktreePath)
-  const pending = toast.loading(
-    translate(
-      'auto.components.terminal.pane.terminal.drop.handler.29c031b49a',
-      'Uploading {{value0}} file{{value1}} to runtime…',
-      { value0: args.dataPaths.length, value1: args.dataPaths.length === 1 ? '' : 's' }
-    )
-  )
+  const pending = toast.loading(formatTerminalDropUploadProgress(args.dataPaths.length, 0, 0))
   try {
     const { results } = await importExternalPathsToRuntime(
       {
@@ -199,7 +194,17 @@ async function uploadRuntimeDropPaths(
       },
       args.dataPaths,
       destinationDir,
-      { assertCurrent: args.assertCurrent }
+      {
+        assertCurrent: args.assertCurrent,
+        // Why: reuses the pending toast's id so the drop keeps one row instead of
+        // stacking a new toast per update.
+        onProgress: ({ sentBytes, totalBytes }) => {
+          toast.loading(
+            formatTerminalDropUploadProgress(args.dataPaths.length, sentBytes, totalBytes),
+            { id: pending }
+          )
+        }
+      }
     )
     const imported = results.filter((result) => result.status === 'imported')
     const importedPaths = imported.map((result) =>

--- a/src/renderer/src/components/terminal-pane/terminal-runtime-drop-upload.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-runtime-drop-upload.ts
@@ -59,6 +59,10 @@ export async function uploadRuntimeDropPaths(
         assertCurrent: args.assertCurrent,
         progress: {
           onStart: (rows) => {
+            // A drop where every source was skipped still reports a start.
+            if (rows.length === 0) {
+              return
+            }
             for (const row of rows) {
               sourcePathsByUploadId.set(row.uploadId, row.sourcePath)
             }

--- a/src/renderer/src/components/terminal-pane/terminal-runtime-drop-upload.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-runtime-drop-upload.ts
@@ -86,13 +86,16 @@ export async function uploadRuntimeDropPaths(
                 },
                 onLayoutChange: () => showPanel()
               })
+            const panelOptions = { duration: Infinity, dismissible: false, unstyled: true }
             const showPanel = (): void => {
-              pending = toast.custom(renderPanel, {
-                id: pending ?? undefined,
-                duration: Infinity,
-                dismissible: false,
-                unstyled: true
-              })
+              // Why: the id key is omitted, not set to undefined. sonner spreads these
+              // options over the id it just minted, so an explicit `id: undefined`
+              // makes it register the toast under a different id than it returns —
+              // and the next re-issue then adds a second panel instead of updating.
+              pending =
+                pending === null
+                  ? toast.custom(renderPanel, panelOptions)
+                  : toast.custom(renderPanel, { ...panelOptions, id: pending })
             }
             showPanel()
           },

--- a/src/renderer/src/components/terminal-pane/terminal-runtime-drop-upload.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-runtime-drop-upload.ts
@@ -74,20 +74,27 @@ export async function uploadRuntimeDropPaths(
             )
             // Why: created only once rows exist, so a drop that stages nothing
             // never flashes an empty panel.
-            pending = toast.custom(
-              // Why: createElement, not a direct call — the toast body must be its
-              // own component or its hooks run outside a component boundary.
-              (toastId) =>
-                createElement(TerminalDropUploadToast, {
-                  sessionId,
-                  onCancel: cancelRow,
-                  onDismiss: () => {
-                    toast.dismiss(toastId)
-                    endRuntimeUploadSession(sessionId)
-                  }
-                }),
-              { duration: Infinity, dismissible: false, unstyled: true }
-            )
+            // Why: createElement, not a direct call — the toast body must be its
+            // own component or its hooks run outside a component boundary.
+            const renderPanel = (toastId: string | number) =>
+              createElement(TerminalDropUploadToast, {
+                sessionId,
+                onCancel: cancelRow,
+                onDismiss: () => {
+                  toast.dismiss(toastId)
+                  endRuntimeUploadSession(sessionId)
+                },
+                onLayoutChange: () => showPanel()
+              })
+            const showPanel = (): void => {
+              pending = toast.custom(renderPanel, {
+                id: pending ?? undefined,
+                duration: Infinity,
+                dismissible: false,
+                unstyled: true
+              })
+            }
+            showPanel()
           },
           onRowProgress: (uploadId, sentBytes) =>
             updateRuntimeUploadRow(sessionId, uploadId, { sentBytes }),

--- a/src/renderer/src/components/terminal-pane/terminal-runtime-drop-upload.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-runtime-drop-upload.ts
@@ -1,0 +1,113 @@
+import { createElement } from 'react'
+import { toast } from 'sonner'
+import { createBrowserUuid } from '@/lib/browser-uuid'
+import { extractIpcErrorMessage } from '@/lib/ipc-error'
+import { importExternalPathsToRuntime } from '@/runtime/runtime-file-client'
+import {
+  endRuntimeUploadSession,
+  startRuntimeUploadSession,
+  updateRuntimeUploadRow
+} from '@/runtime/runtime-upload-session-state'
+import type { useAppStore } from '@/store'
+import { TerminalDropUploadToast } from './TerminalDropUploadToast'
+import type { NativeDropFlowArgs } from './terminal-drop-paste'
+import { pasteResolvedDropPaths } from './terminal-drop-paste'
+import { reportTerminalDropUploadSkipsAndFailures } from './terminal-drop-upload-report'
+import {
+  getTerminalTargetShellForWorktreePath,
+  isTerminalDropWindowsPathLike
+} from './terminal-drop-shell'
+import { joinRuntimeTerminalDropDir } from './terminal-drop-worktree-path'
+
+export async function uploadRuntimeDropPaths(
+  args: NativeDropFlowArgs & {
+    runtimeEnvironmentId: string
+    settings: ReturnType<typeof useAppStore.getState>['settings']
+    worktreeId: string
+  }
+): Promise<void> {
+  const targetShell = getTerminalTargetShellForWorktreePath(args.worktreePath)
+  const destinationDir = joinRuntimeTerminalDropDir(args.worktreePath)
+  const sessionId = createBrowserUuid()
+  const cancelledSourcePaths = new Set<string>()
+  const sourcePathsByUploadId = new Map<string, string>()
+  let pending: string | number | null = null
+  const cancelRow = (uploadId: string): void => {
+    const sourcePath = sourcePathsByUploadId.get(uploadId)
+    if (sourcePath) {
+      cancelledSourcePaths.add(sourcePath)
+    }
+    updateRuntimeUploadRow(sessionId, uploadId, { status: 'cancelled' })
+    void window.api.fs.cancelRuntimeUpload({ uploadId })
+  }
+  try {
+    const { results } = await importExternalPathsToRuntime(
+      {
+        // Why: drops into existing worktrees must follow the worktree owner,
+        // not the currently focused host in the sidebar.
+        settings: { ...args.settings, activeRuntimeEnvironmentId: args.runtimeEnvironmentId },
+        worktreeId: args.worktreeId,
+        worktreePath: args.worktreePath,
+        expectedExecutionHostId: args.expectedExecutionHostId,
+        expectedSshTargetId: args.expectedSshTargetId,
+        expectedSshConnectionGeneration: args.expectedSshConnectionGeneration
+      },
+      args.dataPaths,
+      destinationDir,
+      {
+        assertCurrent: args.assertCurrent,
+        progress: {
+          onStart: (rows) => {
+            for (const row of rows) {
+              sourcePathsByUploadId.set(row.uploadId, row.sourcePath)
+            }
+            startRuntimeUploadSession(
+              sessionId,
+              rows.map((row) => ({
+                uploadId: row.uploadId,
+                name: row.name,
+                sentBytes: 0,
+                totalBytes: row.totalBytes,
+                status: 'uploading' as const
+              }))
+            )
+            // Why: created only once rows exist, so a drop that stages nothing
+            // never flashes an empty panel.
+            pending = toast.custom(
+              // Why: createElement, not a direct call — the toast body must be its
+              // own component or its hooks run outside a component boundary.
+              () => createElement(TerminalDropUploadToast, { sessionId, onCancel: cancelRow }),
+              { duration: Infinity, dismissible: false, unstyled: true }
+            )
+          },
+          onRowProgress: (uploadId, sentBytes) =>
+            updateRuntimeUploadRow(sessionId, uploadId, { sentBytes }),
+          onRowSettled: (uploadId, status) =>
+            updateRuntimeUploadRow(sessionId, uploadId, { status }),
+          onFinish: () => endRuntimeUploadSession(sessionId)
+        }
+      }
+    )
+    const imported = results.filter((result) => result.status === 'imported')
+    const importedPaths = imported.map((result) =>
+      isTerminalDropWindowsPathLike(args.worktreePath)
+        ? result.destPath.replace(/\//g, '\\')
+        : result.destPath
+    )
+    await pasteResolvedDropPaths({ ...args, paths: importedPaths, targetShell })
+    reportTerminalDropUploadSkipsAndFailures(
+      results.filter((result) => result.status === 'skipped'),
+      // Why: a cancel is the user's own decision, not a failure to report back.
+      results
+        .filter((result) => result.status === 'failed')
+        .filter((result) => !cancelledSourcePaths.has(result.sourcePath))
+    )
+  } catch (err) {
+    toast.error(extractIpcErrorMessage(err, 'Failed to upload files.'))
+  } finally {
+    endRuntimeUploadSession(sessionId)
+    if (pending !== null) {
+      toast.dismiss(pending)
+    }
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-runtime-drop-upload.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-runtime-drop-upload.ts
@@ -5,6 +5,7 @@ import { extractIpcErrorMessage } from '@/lib/ipc-error'
 import { importExternalPathsToRuntime } from '@/runtime/runtime-file-client'
 import {
   endRuntimeUploadSession,
+  settleRuntimeUploadSession,
   startRuntimeUploadSession,
   updateRuntimeUploadRow
 } from '@/runtime/runtime-upload-session-state'
@@ -76,7 +77,15 @@ export async function uploadRuntimeDropPaths(
             pending = toast.custom(
               // Why: createElement, not a direct call — the toast body must be its
               // own component or its hooks run outside a component boundary.
-              () => createElement(TerminalDropUploadToast, { sessionId, onCancel: cancelRow }),
+              (toastId) =>
+                createElement(TerminalDropUploadToast, {
+                  sessionId,
+                  onCancel: cancelRow,
+                  onDismiss: () => {
+                    toast.dismiss(toastId)
+                    endRuntimeUploadSession(sessionId)
+                  }
+                }),
               { duration: Infinity, dismissible: false, unstyled: true }
             )
           },
@@ -84,7 +93,7 @@ export async function uploadRuntimeDropPaths(
             updateRuntimeUploadRow(sessionId, uploadId, { sentBytes }),
           onRowSettled: (uploadId, status) =>
             updateRuntimeUploadRow(sessionId, uploadId, { status }),
-          onFinish: () => endRuntimeUploadSession(sessionId)
+          onFinish: () => settleRuntimeUploadSession(sessionId)
         }
       }
     )
@@ -103,11 +112,12 @@ export async function uploadRuntimeDropPaths(
         .filter((result) => !cancelledSourcePaths.has(result.sourcePath))
     )
   } catch (err) {
-    toast.error(extractIpcErrorMessage(err, 'Failed to upload files.'))
-  } finally {
+    // Why: only the error path tears the panel down immediately. On success it
+    // owns its own exit, holding long enough to show how the drop ended.
     endRuntimeUploadSession(sessionId)
     if (pending !== null) {
       toast.dismiss(pending)
     }
+    toast.error(extractIpcErrorMessage(err, 'Failed to upload files.'))
   }
 }

--- a/src/renderer/src/runtime/runtime-file-client-external-import.test.ts
+++ b/src/renderer/src/runtime/runtime-file-client-external-import.test.ts
@@ -3,6 +3,7 @@ import { importExternalPathsToRuntime } from './runtime-file-client'
 import {
   fsImportExternalPaths,
   fsStageExternalPathsForRuntimeUpload,
+  fsUploadExternalFileToRuntime,
   runtimeEnvironmentCall,
   installRuntimeFileClientEnvironment
 } from './runtime-file-client-test-harness'
@@ -20,7 +21,7 @@ describe('runtime file client', () => {
           kind: 'directory',
           entries: [
             { relativePath: '', kind: 'directory' },
-            { relativePath: 'logo.png', kind: 'file', contentBase64: 'cG5n' }
+            { relativePath: 'logo.png', kind: 'file', byteLength: 3 }
           ]
         }
       ]
@@ -46,12 +47,6 @@ describe('runtime file client', () => {
       })
       .mockResolvedValueOnce({
         id: 'create-dir',
-        ok: true,
-        result: { ok: true },
-        _meta: { runtimeId: 'remote-runtime' }
-      })
-      .mockResolvedValueOnce({
-        id: 'write-file',
         ok: true,
         result: { ok: true },
         _meta: { runtimeId: 'remote-runtime' }
@@ -132,19 +127,26 @@ describe('runtime file client', () => {
       },
       timeoutMs: 15_000
     })
-    const smallWriteCall = runtimeEnvironmentCall.mock.calls[4]?.[0] as {
-      params: { relativePath: string }
+    // Why: main streams the body, so the renderer hands over a source locator
+    // and never issues a write RPC of its own.
+    const uploadArgs = fsUploadExternalFileToRuntime.mock.calls[0]?.[0] as {
+      relativePath: string
     }
-    expect(smallWriteCall.params.relativePath).toMatch(
-      /^uploads\/assets\/\.logo\.png\.orca-upload-/
-    )
+    expect(uploadArgs.relativePath).toMatch(/^uploads\/assets\/\.logo\.png\.orca-upload-/)
+    expect(uploadArgs).toMatchObject({
+      environmentId: 'env-1',
+      sourceRootPath: '/Users/me/assets',
+      entryRelativePath: 'logo.png',
+      worktree: 'id:wt-1',
+      expectedExecutionHostId: 'local'
+    })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(5, {
       selector: 'env-1',
-      method: 'files.writeBase64',
+      method: 'files.commitUpload',
       params: {
         worktree: 'id:wt-1',
-        relativePath: smallWriteCall.params.relativePath,
-        contentBase64: 'cG5n',
+        tempRelativePath: uploadArgs.relativePath,
+        finalRelativePath: 'uploads/assets/logo.png',
         expectedExecutionHostId: 'local',
         expectedSshTargetId: undefined,
         expectedSshConnectionGeneration: undefined
@@ -153,23 +155,10 @@ describe('runtime file client', () => {
     })
     expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(6, {
       selector: 'env-1',
-      method: 'files.commitUpload',
-      params: {
-        worktree: 'id:wt-1',
-        tempRelativePath: smallWriteCall.params.relativePath,
-        finalRelativePath: 'uploads/assets/logo.png',
-        expectedExecutionHostId: 'local',
-        expectedSshTargetId: undefined,
-        expectedSshConnectionGeneration: undefined
-      },
-      timeoutMs: 30_000
-    })
-    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(7, {
-      selector: 'env-1',
       method: 'files.delete',
       params: {
         worktree: 'id:wt-1',
-        relativePath: smallWriteCall.params.relativePath,
+        relativePath: uploadArgs.relativePath,
         recursive: false,
         expectedExecutionHostId: 'local',
         expectedSshTargetId: undefined,
@@ -180,9 +169,7 @@ describe('runtime file client', () => {
     expect(fsImportExternalPaths).not.toHaveBeenCalled()
   })
 
-  it('chunks large staged runtime uploads below the WebSocket frame budget', async () => {
-    const firstChunk = 'A'.repeat(512 * 1024)
-    const secondChunk = 'BBBBBBBB'
+  it('delegates the whole body to main instead of chunking it in the renderer', async () => {
     fsStageExternalPathsForRuntimeUpload.mockResolvedValue({
       sources: [
         {
@@ -190,9 +177,7 @@ describe('runtime file client', () => {
           status: 'staged',
           name: 'large.bin',
           kind: 'file',
-          entries: [
-            { relativePath: '', kind: 'file', contentBase64: `${firstChunk}${secondChunk}` }
-          ]
+          entries: [{ relativePath: '', kind: 'file', byteLength: 64 * 1024 * 1024 }]
         }
       ]
     })
@@ -213,18 +198,6 @@ describe('runtime file client', () => {
         id: 'stat-miss',
         ok: false,
         error: { code: 'not_found', message: 'not found' },
-        _meta: { runtimeId: 'remote-runtime' }
-      })
-      .mockResolvedValueOnce({
-        id: 'write-chunk-1',
-        ok: true,
-        result: { ok: true },
-        _meta: { runtimeId: 'remote-runtime' }
-      })
-      .mockResolvedValueOnce({
-        id: 'write-chunk-2',
-        ok: true,
-        result: { ok: true },
         _meta: { runtimeId: 'remote-runtime' }
       })
       .mockResolvedValueOnce({
@@ -262,72 +235,26 @@ describe('runtime file client', () => {
       ]
     })
 
-    const chunkWriteCall = runtimeEnvironmentCall.mock.calls[3]?.[0] as {
-      params: { relativePath: string }
+    // Why: a file far over the former 25 MB cap imports with one upload call and
+    // no renderer-held content; slicing is covered in runtime-upload-file-stream.
+    expect(fsUploadExternalFileToRuntime).toHaveBeenCalledTimes(1)
+    const uploadArgs = fsUploadExternalFileToRuntime.mock.calls[0]?.[0] as {
+      relativePath: string
     }
-    expect(chunkWriteCall.params.relativePath).toMatch(/^uploads\/\.large\.bin\.orca-upload-/)
-    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(4, {
-      selector: 'env-1',
-      method: 'files.writeBase64Chunk',
-      params: {
-        worktree: 'id:wt-1',
-        relativePath: chunkWriteCall.params.relativePath,
-        contentBase64: firstChunk,
-        append: false,
-        expectedExecutionHostId: 'local',
-        expectedSshTargetId: undefined,
-        expectedSshConnectionGeneration: undefined
-      },
-      timeoutMs: 30_000
-    })
-    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(5, {
-      selector: 'env-1',
-      method: 'files.writeBase64Chunk',
-      params: {
-        worktree: 'id:wt-1',
-        relativePath: chunkWriteCall.params.relativePath,
-        contentBase64: secondChunk,
-        append: true,
-        expectedExecutionHostId: 'local',
-        expectedSshTargetId: undefined,
-        expectedSshConnectionGeneration: undefined
-      },
-      timeoutMs: 30_000
-    })
-    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(6, {
-      selector: 'env-1',
-      method: 'files.commitUpload',
-      params: {
-        worktree: 'id:wt-1',
-        tempRelativePath: chunkWriteCall.params.relativePath,
-        finalRelativePath: 'uploads/large.bin',
-        expectedExecutionHostId: 'local',
-        expectedSshTargetId: undefined,
-        expectedSshConnectionGeneration: undefined
-      },
-      timeoutMs: 30_000
-    })
-    expect(runtimeEnvironmentCall).toHaveBeenNthCalledWith(7, {
-      selector: 'env-1',
-      method: 'files.delete',
-      expectedEnvironmentPairingRevision: undefined,
-      params: {
-        worktree: 'id:wt-1',
-        relativePath: chunkWriteCall.params.relativePath,
-        recursive: false,
-        expectedExecutionHostId: 'local',
-        expectedSshTargetId: undefined,
-        expectedSshConnectionGeneration: undefined
-      },
-      timeoutMs: 15_000
+    expect(uploadArgs.relativePath).toMatch(/^uploads\/\.large\.bin\.orca-upload-/)
+    expect(uploadArgs).toMatchObject({
+      sourceRootPath: '/Users/me/large.bin',
+      entryRelativePath: ''
     })
     expect(runtimeEnvironmentCall).not.toHaveBeenCalledWith(
       expect.objectContaining({ method: 'files.writeBase64' })
     )
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'files.writeBase64Chunk' })
+    )
   })
 
-  it('stops a chunked upload when its owner generation changes between writes', async () => {
-    const firstChunk = 'A'.repeat(512 * 1024)
+  it('stops an upload when its owner generation changes during the transfer', async () => {
     fsStageExternalPathsForRuntimeUpload.mockResolvedValue({
       sources: [
         {
@@ -335,7 +262,7 @@ describe('runtime file client', () => {
           status: 'staged',
           name: 'large.bin',
           kind: 'file',
-          entries: [{ relativePath: '', kind: 'file', contentBase64: `${firstChunk}BBBBBBBB` }]
+          entries: [{ relativePath: '', kind: 'file', byteLength: 512 * 1024 }]
         }
       ]
     })
@@ -352,16 +279,11 @@ describe('runtime file client', () => {
         error: { code: 'not_found', message: 'not found' },
         _meta: { runtimeId: 'remote-runtime' }
       })
-      .mockImplementationOnce(async () => {
-        ownerChanged = true
-        return {
-          id: 'write-chunk-1',
-          ok: true,
-          result: { ok: true },
-          _meta: { runtimeId: 'remote-runtime' }
-        }
-      })
     let ownerChanged = false
+    fsUploadExternalFileToRuntime.mockImplementation(async () => {
+      ownerChanged = true
+      return { byteLength: 512 * 1024 }
+    })
     const assertCurrent = vi.fn(() => {
       if (ownerChanged) {
         throw new Error('runtime owner generation changed')
@@ -383,10 +305,11 @@ describe('runtime file client', () => {
       results: [{ status: 'failed', reason: 'runtime owner generation changed' }]
     })
 
+    // Why: the owner is re-checked after the transfer, so a changed owner never
+    // reaches commit or cleanup.
     expect(runtimeEnvironmentCall.mock.calls.map((call) => call[0].method)).toEqual([
       'files.stat',
-      'files.stat',
-      'files.writeBase64Chunk'
+      'files.stat'
     ])
     expect(runtimeEnvironmentCall).not.toHaveBeenCalledWith(
       expect.objectContaining({ method: 'files.commitUpload' })
@@ -396,9 +319,7 @@ describe('runtime file client', () => {
     )
   })
 
-  it('cleans up staged runtime upload temp files when a later chunk fails', async () => {
-    const firstChunk = 'A'.repeat(512 * 1024)
-    const secondChunk = 'BBBBBBBB'
+  it('cleans up the staged runtime upload temp file when the transfer fails', async () => {
     fsStageExternalPathsForRuntimeUpload.mockResolvedValue({
       sources: [
         {
@@ -406,12 +327,11 @@ describe('runtime file client', () => {
           status: 'staged',
           name: 'large.bin',
           kind: 'file',
-          entries: [
-            { relativePath: '', kind: 'file', contentBase64: `${firstChunk}${secondChunk}` }
-          ]
+          entries: [{ relativePath: '', kind: 'file', byteLength: 512 * 1024 }]
         }
       ]
     })
+    fsUploadExternalFileToRuntime.mockRejectedValue(new Error('disk full'))
     runtimeEnvironmentCall
       .mockResolvedValueOnce({
         id: 'stat-destination-miss',
@@ -429,18 +349,6 @@ describe('runtime file client', () => {
         id: 'stat-miss',
         ok: false,
         error: { code: 'not_found', message: 'not found' },
-        _meta: { runtimeId: 'remote-runtime' }
-      })
-      .mockResolvedValueOnce({
-        id: 'write-chunk-1',
-        ok: true,
-        result: { ok: true },
-        _meta: { runtimeId: 'remote-runtime' }
-      })
-      .mockResolvedValueOnce({
-        id: 'write-chunk-2',
-        ok: false,
-        error: { code: 'write_failed', message: 'disk full' },
         _meta: { runtimeId: 'remote-runtime' }
       })
       .mockResolvedValueOnce({
@@ -464,13 +372,12 @@ describe('runtime file client', () => {
       results: [{ status: 'failed', reason: 'disk full' }]
     })
 
-    const chunkCall = runtimeEnvironmentCall.mock.calls[3]?.[0] as
-      | { params: { relativePath: string } }
+    const uploadArgs = fsUploadExternalFileToRuntime.mock.calls[0]?.[0] as
+      | { relativePath: string }
       | undefined
-    if (!chunkCall) {
-      throw new Error('missing first chunk call')
+    if (!uploadArgs) {
+      throw new Error('missing upload call')
     }
-    const tempRelativePath = chunkCall.params.relativePath
     expect(runtimeEnvironmentCall).not.toHaveBeenCalledWith(
       expect.objectContaining({ method: 'files.commitUpload' })
     )
@@ -479,7 +386,7 @@ describe('runtime file client', () => {
       method: 'files.delete',
       params: {
         worktree: 'id:wt-1',
-        relativePath: tempRelativePath,
+        relativePath: uploadArgs.relativePath,
         recursive: false,
         expectedExecutionHostId: 'local',
         expectedSshTargetId: undefined,
@@ -499,11 +406,12 @@ describe('runtime file client', () => {
           kind: 'directory',
           entries: [
             { relativePath: '', kind: 'directory' },
-            { relativePath: 'logo.png', kind: 'file', contentBase64: 'cG5n' }
+            { relativePath: 'logo.png', kind: 'file', byteLength: 3 }
           ]
         }
       ]
     })
+    fsUploadExternalFileToRuntime.mockRejectedValue(new Error('disk full'))
     runtimeEnvironmentCall
       .mockResolvedValueOnce({
         id: 'stat-destination',
@@ -521,12 +429,6 @@ describe('runtime file client', () => {
         id: 'create-import-root',
         ok: true,
         result: { ok: true },
-        _meta: { runtimeId: 'remote-runtime' }
-      })
-      .mockResolvedValueOnce({
-        id: 'write-file',
-        ok: false,
-        error: { code: 'write_failed', message: 'disk full' },
         _meta: { runtimeId: 'remote-runtime' }
       })
       .mockResolvedValueOnce({
@@ -556,13 +458,13 @@ describe('runtime file client', () => {
       results: [{ status: 'failed', reason: 'disk full' }]
     })
 
-    const writeCall = runtimeEnvironmentCall.mock.calls[3]?.[0] as
-      | { params: { relativePath: string } }
+    const uploadArgs = fsUploadExternalFileToRuntime.mock.calls[0]?.[0] as
+      | { relativePath: string }
       | undefined
-    if (!writeCall) {
-      throw new Error('missing failed file write call')
+    if (!uploadArgs) {
+      throw new Error('missing failed file upload call')
     }
-    expect(writeCall.params.relativePath).toMatch(/^uploads\/assets\/\.logo\.png\.orca-upload-/)
+    expect(uploadArgs.relativePath).toMatch(/^uploads\/assets\/\.logo\.png\.orca-upload-/)
     expect(runtimeEnvironmentCall).toHaveBeenLastCalledWith({
       selector: 'env-1',
       method: 'files.delete',

--- a/src/renderer/src/runtime/runtime-file-client-test-harness.ts
+++ b/src/renderer/src/runtime/runtime-file-client-test-harness.ts
@@ -53,6 +53,7 @@ export const fsFinishDownloadedFile: PreloadStub = vi.fn()
 export const fsCancelDownloadedFile: PreloadStub = vi.fn()
 export const fsImportExternalPaths: PreloadStub = vi.fn()
 export const fsStageExternalPathsForRuntimeUpload: PreloadStub = vi.fn()
+export const fsUploadExternalFileToRuntime: PreloadStub = vi.fn()
 export const runtimeEnvironmentCall: RuntimeRpcStub = vi.fn()
 export const runtimeEnvironmentTransportCall: RuntimeRpcStub = vi.fn()
 export const runtimeEnvironmentSubscribe: RuntimeSubscribeStub = vi.fn()
@@ -87,6 +88,8 @@ export function installRuntimeFileClientEnvironment(): void {
     fsCancelDownloadedFile.mockReset()
     fsImportExternalPaths.mockReset()
     fsStageExternalPathsForRuntimeUpload.mockReset()
+    fsUploadExternalFileToRuntime.mockReset()
+    fsUploadExternalFileToRuntime.mockResolvedValue({ byteLength: 0 })
     runtimeEnvironmentCall.mockReset()
     runtimeEnvironmentTransportCall.mockReset()
     runtimeEnvironmentSubscribe.mockReset()
@@ -129,7 +132,8 @@ export function installRuntimeFileClientEnvironment(): void {
           finishDownloadedFile: fsFinishDownloadedFile,
           cancelDownloadedFile: fsCancelDownloadedFile,
           importExternalPaths: fsImportExternalPaths,
-          stageExternalPathsForRuntimeUpload: fsStageExternalPathsForRuntimeUpload
+          stageExternalPathsForRuntimeUpload: fsStageExternalPathsForRuntimeUpload,
+          uploadExternalFileToRuntime: fsUploadExternalFileToRuntime
         },
         runtime: { call: runtimeCall },
         runtimeEnvironments: {

--- a/src/renderer/src/runtime/runtime-file-client-test-harness.ts
+++ b/src/renderer/src/runtime/runtime-file-client-test-harness.ts
@@ -54,6 +54,8 @@ export const fsCancelDownloadedFile: PreloadStub = vi.fn()
 export const fsImportExternalPaths: PreloadStub = vi.fn()
 export const fsStageExternalPathsForRuntimeUpload: PreloadStub = vi.fn()
 export const fsUploadExternalFileToRuntime: PreloadStub = vi.fn()
+/** Returns the unsubscribe the import loop calls in its finally. */
+export const fsOnUploadProgress: PreloadStub = vi.fn()
 export const runtimeEnvironmentCall: RuntimeRpcStub = vi.fn()
 export const runtimeEnvironmentTransportCall: RuntimeRpcStub = vi.fn()
 export const runtimeEnvironmentSubscribe: RuntimeSubscribeStub = vi.fn()
@@ -90,6 +92,8 @@ export function installRuntimeFileClientEnvironment(): void {
     fsStageExternalPathsForRuntimeUpload.mockReset()
     fsUploadExternalFileToRuntime.mockReset()
     fsUploadExternalFileToRuntime.mockResolvedValue({ byteLength: 0 })
+    fsOnUploadProgress.mockReset()
+    fsOnUploadProgress.mockReturnValue(() => {})
     runtimeEnvironmentCall.mockReset()
     runtimeEnvironmentTransportCall.mockReset()
     runtimeEnvironmentSubscribe.mockReset()
@@ -133,7 +137,8 @@ export function installRuntimeFileClientEnvironment(): void {
           cancelDownloadedFile: fsCancelDownloadedFile,
           importExternalPaths: fsImportExternalPaths,
           stageExternalPathsForRuntimeUpload: fsStageExternalPathsForRuntimeUpload,
-          uploadExternalFileToRuntime: fsUploadExternalFileToRuntime
+          uploadExternalFileToRuntime: fsUploadExternalFileToRuntime,
+          onUploadProgress: fsOnUploadProgress
         },
         runtime: { call: runtimeCall },
         runtimeEnvironments: {

--- a/src/renderer/src/runtime/runtime-file-client.ts
+++ b/src/renderer/src/runtime/runtime-file-client.ts
@@ -31,8 +31,9 @@ import { toRuntimeWorktreeSelector } from './runtime-worktree-selector'
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import {
   createRuntimeUploadProgressTracker,
-  sumStagedUploadBytes,
-  type RuntimeUploadProgressReport
+  sumSourceUploadBytes,
+  type RuntimeImportProgressHandlers,
+  type RuntimeImportProgressRow
 } from './runtime-upload-progress-tracker'
 import {
   createEmptyRuntimeFileSearchResult,
@@ -673,7 +674,7 @@ export async function importExternalPathsToRuntime(
   options?: {
     ensureDestinationDir?: boolean
     assertCurrent?: () => void
-    onProgress?: (progress: RuntimeUploadProgressReport) => void
+    progress?: RuntimeImportProgressHandlers
   }
 ): Promise<{ results: RuntimeImportResult[] }> {
   const target = getActiveRuntimeTarget(context.settings)
@@ -705,22 +706,41 @@ export async function importExternalPathsToRuntime(
   assertImportSessionCurrent()
   const staged = await window.api.fs.stageExternalPathsForRuntimeUpload({ sourcePaths })
   assertImportSessionCurrent()
-  const uploadId = options?.onProgress ? createBrowserUuid() : undefined
-  const progress = options?.onProgress
-    ? createRuntimeUploadProgressTracker(
-        sumStagedUploadBytes(staged.sources as StagedRuntimeImportSource[]),
-        options.onProgress
+  const handlers = options?.progress
+  // One id per dropped source: it is both the progress key and the cancel handle,
+  // so cancelling a row stops that source and leaves the rest of the drop running.
+  const uploadIdsBySourcePath = new Map<string, string>()
+  const trackers = new Map<string, ReturnType<typeof createRuntimeUploadProgressTracker>>()
+  if (handlers) {
+    const rows: RuntimeImportProgressRow[] = []
+    for (const source of staged.sources as StagedRuntimeImportSource[]) {
+      if (source.status !== 'staged') {
+        continue
+      }
+      const rowUploadId = createBrowserUuid()
+      uploadIdsBySourcePath.set(source.sourcePath, rowUploadId)
+      const totalBytes = sumSourceUploadBytes(source)
+      trackers.set(
+        rowUploadId,
+        createRuntimeUploadProgressTracker(totalBytes, ({ sentBytes }) =>
+          handlers.onRowProgress(rowUploadId, sentBytes)
+        )
       )
+      rows.push({
+        uploadId: rowUploadId,
+        name: source.name,
+        totalBytes,
+        sourcePath: source.sourcePath
+      })
+    }
+    handlers.onStart(rows)
+  }
+  const unsubscribeProgress = handlers
+    ? window.api.fs.onUploadProgress((event) => {
+        // Why: a concurrent drop in another pane shares this channel.
+        trackers.get(event.uploadId)?.reportFileProgress(event.sentBytes)
+      })
     : null
-  const unsubscribeProgress =
-    progress && uploadId
-      ? window.api.fs.onUploadProgress((event) => {
-          // Why: a concurrent drop in another pane shares this channel.
-          if (event.uploadId === uploadId) {
-            progress.reportFileProgress(event.sentBytes)
-          }
-        })
-      : null
   const results: RuntimeImportResult[] = []
   const reservedNames = new Set<string>()
 
@@ -738,6 +758,7 @@ export async function importExternalPathsToRuntime(
         continue
       }
       let createdDirectoryImportRoot: string | null = null
+      const sourceUploadId = uploadIdsBySourcePath.get(source.sourcePath)
       try {
         const finalName = await deconflictRuntimeImportName(
           context,
@@ -780,9 +801,11 @@ export async function importExternalPathsToRuntime(
                 ? `ssh:${encodeURIComponent(context.expectedSshTargetId)}`
                 : 'local'),
             expectedEnvironmentPairingRevision,
-            uploadId
+            sourceUploadId
           )
-          progress?.completeFile(entry.byteLength)
+          if (sourceUploadId) {
+            trackers.get(sourceUploadId)?.completeFile(entry.byteLength)
+          }
         }
         reservedNames.add(finalName)
         results.push({
@@ -792,6 +815,9 @@ export async function importExternalPathsToRuntime(
           kind: source.kind,
           renamed: finalName !== source.name
         })
+        if (sourceUploadId) {
+          handlers?.onRowSettled(sourceUploadId, 'done')
+        }
       } catch (error) {
         if (createdDirectoryImportRoot) {
           // Why: match local directory imports by removing the no-clobber root
@@ -814,12 +840,21 @@ export async function importExternalPathsToRuntime(
           status: 'failed',
           reason: error instanceof Error ? error.message : String(error)
         })
+        // Why: reported as failed even for a cancel — the store keeps the row's
+        // already-set 'cancelled' state, so the user's own action is not relabelled.
+        if (sourceUploadId) {
+          handlers?.onRowSettled(sourceUploadId, 'failed')
+        }
       }
     }
 
     return { results }
   } finally {
     unsubscribeProgress?.()
+    for (const releasedId of uploadIdsBySourcePath.values()) {
+      void window.api.fs.releaseRuntimeUpload({ uploadId: releasedId })
+    }
+    handlers?.onFinish()
   }
 }
 

--- a/src/renderer/src/runtime/runtime-file-client.ts
+++ b/src/renderer/src/runtime/runtime-file-client.ts
@@ -142,6 +142,8 @@ type StagedRuntimeImportEntry =
 type RuntimeUploadSource = {
   sourceRootPath: string
   entryRelativePath: string
+  /** What staging measured; main refuses the upload if the file no longer matches. */
+  byteLength: number
 }
 
 type RuntimeImportResult =
@@ -744,7 +746,11 @@ export async function importExternalPathsToRuntime(
           target,
           context.worktreeId,
           entryRelativePath,
-          { sourceRootPath: source.sourcePath, entryRelativePath: entry.relativePath },
+          {
+            sourceRootPath: source.sourcePath,
+            entryRelativePath: entry.relativePath,
+            byteLength: entry.byteLength
+          },
           assertImportSessionCurrent,
           context.expectedSshConnectionGeneration,
           context.expectedSshTargetId,
@@ -811,6 +817,7 @@ async function uploadRuntimeFileWithoutClobber(
       environmentId: target.environmentId,
       sourceRootPath: source.sourceRootPath,
       entryRelativePath: source.entryRelativePath,
+      expectedByteLength: source.byteLength,
       worktree: toRuntimeWorktreeSelector(worktreeId),
       relativePath: tempRelativePath,
       expectedSshTargetId,

--- a/src/renderer/src/runtime/runtime-file-client.ts
+++ b/src/renderer/src/runtime/runtime-file-client.ts
@@ -149,6 +149,8 @@ type StagedRuntimeImportEntry =
 type RuntimeUploadSource = {
   sourceRootPath: string
   entryRelativePath: string
+  /** What staging measured; main refuses the upload if the file no longer matches. */
+  byteLength: number
 }
 
 type RuntimeImportResult =
@@ -788,11 +790,18 @@ export async function importExternalPathsToRuntime(
             }
             continue
           }
+          if (sourceUploadId) {
+            trackers.get(sourceUploadId)?.beginFile()
+          }
           await uploadRuntimeFileWithoutClobber(
             target,
             context.worktreeId,
             entryRelativePath,
-            { sourceRootPath: source.sourcePath, entryRelativePath: entry.relativePath },
+            {
+              sourceRootPath: source.sourcePath,
+              entryRelativePath: entry.relativePath,
+              byteLength: entry.byteLength
+            },
             assertImportSessionCurrent,
             context.expectedSshConnectionGeneration,
             context.expectedSshTargetId,
@@ -852,7 +861,7 @@ export async function importExternalPathsToRuntime(
   } finally {
     unsubscribeProgress?.()
     for (const releasedId of uploadIdsBySourcePath.values()) {
-      void window.api.fs.releaseRuntimeUpload({ uploadId: releasedId })
+      void window.api.fs.releaseRuntimeUpload({ uploadId: releasedId }).catch(() => {})
     }
     handlers?.onFinish()
   }
@@ -879,6 +888,7 @@ async function uploadRuntimeFileWithoutClobber(
       environmentId: target.environmentId,
       sourceRootPath: source.sourceRootPath,
       entryRelativePath: source.entryRelativePath,
+      expectedByteLength: source.byteLength,
       worktree: toRuntimeWorktreeSelector(worktreeId),
       relativePath: tempRelativePath,
       uploadId,

--- a/src/renderer/src/runtime/runtime-file-client.ts
+++ b/src/renderer/src/runtime/runtime-file-client.ts
@@ -136,7 +136,13 @@ type StagedRuntimeImportSource =
 
 type StagedRuntimeImportEntry =
   | { relativePath: string; kind: 'directory' }
-  | { relativePath: string; kind: 'file'; contentBase64: string }
+  | { relativePath: string; kind: 'file'; byteLength: number }
+
+/** Locates a staged file on the client so main can stream it without the renderer reading it. */
+type RuntimeUploadSource = {
+  sourceRootPath: string
+  entryRelativePath: string
+}
 
 type RuntimeImportResult =
   | {
@@ -164,7 +170,6 @@ type RuntimeFileWatchEvent =
   | { type: 'error'; message: string }
   | { type: 'end' }
 
-const REMOTE_UPLOAD_BASE64_CHUNK_CHARS = 512 * 1024
 const REMOTE_DOWNLOAD_CHUNK_BYTES = 384 * 1024
 const REMOTE_DOWNLOAD_UPDATE_REQUIRED_MESSAGE =
   'Remote file download requires a newer Orca server. Update the headless server and try again.'
@@ -739,7 +744,7 @@ export async function importExternalPathsToRuntime(
           target,
           context.worktreeId,
           entryRelativePath,
-          entry.contentBase64,
+          { sourceRootPath: source.sourcePath, entryRelativePath: entry.relativePath },
           assertImportSessionCurrent,
           context.expectedSshConnectionGeneration,
           context.expectedSshTargetId,
@@ -790,7 +795,7 @@ async function uploadRuntimeFileWithoutClobber(
   target: { kind: 'environment'; environmentId: string },
   worktreeId: string,
   relativePath: string,
-  contentBase64: string,
+  source: RuntimeUploadSource,
   assertCurrent?: () => void,
   expectedSshConnectionGeneration?: number,
   expectedSshTargetId?: string,
@@ -799,17 +804,20 @@ async function uploadRuntimeFileWithoutClobber(
 ): Promise<void> {
   const tempRelativePath = makeRuntimeUploadTempPath(relativePath)
   try {
-    await writeRuntimeBase64File(
-      target,
-      worktreeId,
-      tempRelativePath,
-      contentBase64,
-      assertCurrent,
-      expectedSshConnectionGeneration,
+    assertCurrent?.()
+    // Why: main owns the file handle and the runtime socket, so it streams the
+    // body in slices; the renderer never holds the whole file.
+    await window.api.fs.uploadExternalFileToRuntime({
+      environmentId: target.environmentId,
+      sourceRootPath: source.sourceRootPath,
+      entryRelativePath: source.entryRelativePath,
+      worktree: toRuntimeWorktreeSelector(worktreeId),
+      relativePath: tempRelativePath,
       expectedSshTargetId,
+      expectedSshConnectionGeneration,
       expectedExecutionHostId,
       expectedEnvironmentPairingRevision
-    )
+    })
     assertCurrent?.()
     await callRuntimeFileMutation(
       target,
@@ -841,56 +849,6 @@ async function uploadRuntimeFileWithoutClobber(
       15_000,
       expectedEnvironmentPairingRevision
     ).catch(() => {})
-  }
-}
-
-async function writeRuntimeBase64File(
-  target: { kind: 'environment'; environmentId: string },
-  worktreeId: string,
-  relativePath: string,
-  contentBase64: string,
-  assertCurrent?: () => void,
-  expectedSshConnectionGeneration?: number,
-  expectedSshTargetId?: string,
-  expectedExecutionHostId?: 'local' | `ssh:${string}`,
-  expectedEnvironmentPairingRevision?: number
-): Promise<void> {
-  if (contentBase64.length <= REMOTE_UPLOAD_BASE64_CHUNK_CHARS) {
-    assertCurrent?.()
-    await callRuntimeFileMutation(
-      target,
-      'files.writeBase64',
-      {
-        worktree: toRuntimeWorktreeSelector(worktreeId),
-        relativePath,
-        contentBase64,
-        expectedSshTargetId,
-        expectedSshConnectionGeneration,
-        expectedExecutionHostId
-      },
-      30_000,
-      expectedEnvironmentPairingRevision
-    )
-    return
-  }
-
-  for (let offset = 0; offset < contentBase64.length; offset += REMOTE_UPLOAD_BASE64_CHUNK_CHARS) {
-    assertCurrent?.()
-    await callRuntimeFileMutation(
-      target,
-      'files.writeBase64Chunk',
-      {
-        worktree: toRuntimeWorktreeSelector(worktreeId),
-        relativePath,
-        contentBase64: contentBase64.slice(offset, offset + REMOTE_UPLOAD_BASE64_CHUNK_CHARS),
-        append: offset > 0,
-        expectedSshTargetId,
-        expectedSshConnectionGeneration,
-        expectedExecutionHostId
-      },
-      30_000,
-      expectedEnvironmentPairingRevision
-    )
   }
 }
 

--- a/src/renderer/src/runtime/runtime-file-client.ts
+++ b/src/renderer/src/runtime/runtime-file-client.ts
@@ -28,6 +28,12 @@ import {
   relativePathInsideRoot
 } from '../../../shared/cross-platform-path'
 import { toRuntimeWorktreeSelector } from './runtime-worktree-selector'
+import { createBrowserUuid } from '@/lib/browser-uuid'
+import {
+  createRuntimeUploadProgressTracker,
+  sumStagedUploadBytes,
+  type RuntimeUploadProgressReport
+} from './runtime-upload-progress-tracker'
 import {
   createEmptyRuntimeFileSearchResult,
   getRuntimeFileSearchRejectedField
@@ -664,7 +670,11 @@ export async function importExternalPathsToRuntime(
   context: RuntimeFileOperationArgs,
   sourcePaths: string[],
   destinationDir: string,
-  options?: { ensureDestinationDir?: boolean; assertCurrent?: () => void }
+  options?: {
+    ensureDestinationDir?: boolean
+    assertCurrent?: () => void
+    onProgress?: (progress: RuntimeUploadProgressReport) => void
+  }
 ): Promise<{ results: RuntimeImportResult[] }> {
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind !== 'environment' || !context.worktreeId || !context.worktreePath) {
@@ -695,100 +705,122 @@ export async function importExternalPathsToRuntime(
   assertImportSessionCurrent()
   const staged = await window.api.fs.stageExternalPathsForRuntimeUpload({ sourcePaths })
   assertImportSessionCurrent()
+  const uploadId = options?.onProgress ? createBrowserUuid() : undefined
+  const progress = options?.onProgress
+    ? createRuntimeUploadProgressTracker(
+        sumStagedUploadBytes(staged.sources as StagedRuntimeImportSource[]),
+        options.onProgress
+      )
+    : null
+  const unsubscribeProgress =
+    progress && uploadId
+      ? window.api.fs.onUploadProgress((event) => {
+          // Why: a concurrent drop in another pane shares this channel.
+          if (event.uploadId === uploadId) {
+            progress.reportFileProgress(event.sentBytes)
+          }
+        })
+      : null
   const results: RuntimeImportResult[] = []
   const reservedNames = new Set<string>()
 
-  await ensureRuntimeDirectory(
-    context,
-    destinationDir,
-    assertImportSessionCurrent,
-    expectedEnvironmentPairingRevision
-  )
+  try {
+    await ensureRuntimeDirectory(
+      context,
+      destinationDir,
+      assertImportSessionCurrent,
+      expectedEnvironmentPairingRevision
+    )
 
-  for (const source of staged.sources as StagedRuntimeImportSource[]) {
-    if (source.status !== 'staged') {
-      results.push(source)
-      continue
-    }
-    let createdDirectoryImportRoot: string | null = null
-    try {
-      const finalName = await deconflictRuntimeImportName(
-        context,
-        destinationDir,
-        source.name,
-        reservedNames,
-        expectedEnvironmentPairingRevision
-      )
-      const destPath = joinPath(destinationDir, finalName)
-      const destRelativePath = joinRuntimeRelativePath(destinationArgs.relativePath, finalName)
-      for (const entry of source.entries) {
-        const entryRelativePath = joinRuntimeRelativePath(destRelativePath, entry.relativePath)
-        if (entry.kind === 'directory') {
+    for (const source of staged.sources as StagedRuntimeImportSource[]) {
+      if (source.status !== 'staged') {
+        results.push(source)
+        continue
+      }
+      let createdDirectoryImportRoot: string | null = null
+      try {
+        const finalName = await deconflictRuntimeImportName(
+          context,
+          destinationDir,
+          source.name,
+          reservedNames,
+          expectedEnvironmentPairingRevision
+        )
+        const destPath = joinPath(destinationDir, finalName)
+        const destRelativePath = joinRuntimeRelativePath(destinationArgs.relativePath, finalName)
+        for (const entry of source.entries) {
+          const entryRelativePath = joinRuntimeRelativePath(destRelativePath, entry.relativePath)
+          if (entry.kind === 'directory') {
+            assertImportSessionCurrent()
+            await callRuntimeFileMutation(
+              target,
+              'files.createDirNoClobber',
+              withSshMutationExpectation(context, {
+                worktree: toRuntimeWorktreeSelector(context.worktreeId),
+                relativePath: entryRelativePath
+              }),
+              15_000,
+              expectedEnvironmentPairingRevision
+            )
+            if (source.kind === 'directory' && entry.relativePath === '') {
+              createdDirectoryImportRoot = entryRelativePath
+            }
+            continue
+          }
+          await uploadRuntimeFileWithoutClobber(
+            target,
+            context.worktreeId,
+            entryRelativePath,
+            { sourceRootPath: source.sourcePath, entryRelativePath: entry.relativePath },
+            assertImportSessionCurrent,
+            context.expectedSshConnectionGeneration,
+            context.expectedSshTargetId,
+            context.expectedExecutionHostId ??
+              (context.expectedSshTargetId
+                ? `ssh:${encodeURIComponent(context.expectedSshTargetId)}`
+                : 'local'),
+            expectedEnvironmentPairingRevision,
+            uploadId
+          )
+          progress?.completeFile(entry.byteLength)
+        }
+        reservedNames.add(finalName)
+        results.push({
+          sourcePath: source.sourcePath,
+          status: 'imported',
+          destPath,
+          kind: source.kind,
+          renamed: finalName !== source.name
+        })
+      } catch (error) {
+        if (createdDirectoryImportRoot) {
+          // Why: match local directory imports by removing the no-clobber root
+          // Orca created when a nested runtime upload fails halfway through.
           assertImportSessionCurrent()
           await callRuntimeFileMutation(
             target,
-            'files.createDirNoClobber',
+            'files.delete',
             withSshMutationExpectation(context, {
               worktree: toRuntimeWorktreeSelector(context.worktreeId),
-              relativePath: entryRelativePath
+              relativePath: createdDirectoryImportRoot,
+              recursive: true
             }),
             15_000,
             expectedEnvironmentPairingRevision
-          )
-          if (source.kind === 'directory' && entry.relativePath === '') {
-            createdDirectoryImportRoot = entryRelativePath
-          }
-          continue
+          ).catch(() => {})
         }
-        await uploadRuntimeFileWithoutClobber(
-          target,
-          context.worktreeId,
-          entryRelativePath,
-          { sourceRootPath: source.sourcePath, entryRelativePath: entry.relativePath },
-          assertImportSessionCurrent,
-          context.expectedSshConnectionGeneration,
-          context.expectedSshTargetId,
-          context.expectedExecutionHostId ??
-            (context.expectedSshTargetId
-              ? `ssh:${encodeURIComponent(context.expectedSshTargetId)}`
-              : 'local'),
-          expectedEnvironmentPairingRevision
-        )
+        results.push({
+          sourcePath: source.sourcePath,
+          status: 'failed',
+          reason: error instanceof Error ? error.message : String(error)
+        })
       }
-      reservedNames.add(finalName)
-      results.push({
-        sourcePath: source.sourcePath,
-        status: 'imported',
-        destPath,
-        kind: source.kind,
-        renamed: finalName !== source.name
-      })
-    } catch (error) {
-      if (createdDirectoryImportRoot) {
-        // Why: match local directory imports by removing the no-clobber root
-        // Orca created when a nested runtime upload fails halfway through.
-        assertImportSessionCurrent()
-        await callRuntimeFileMutation(
-          target,
-          'files.delete',
-          withSshMutationExpectation(context, {
-            worktree: toRuntimeWorktreeSelector(context.worktreeId),
-            relativePath: createdDirectoryImportRoot,
-            recursive: true
-          }),
-          15_000,
-          expectedEnvironmentPairingRevision
-        ).catch(() => {})
-      }
-      results.push({
-        sourcePath: source.sourcePath,
-        status: 'failed',
-        reason: error instanceof Error ? error.message : String(error)
-      })
     }
-  }
 
-  return { results }
+    return { results }
+  } finally {
+    unsubscribeProgress?.()
+  }
 }
 
 async function uploadRuntimeFileWithoutClobber(
@@ -800,7 +832,8 @@ async function uploadRuntimeFileWithoutClobber(
   expectedSshConnectionGeneration?: number,
   expectedSshTargetId?: string,
   expectedExecutionHostId?: 'local' | `ssh:${string}`,
-  expectedEnvironmentPairingRevision?: number
+  expectedEnvironmentPairingRevision?: number,
+  uploadId?: string
 ): Promise<void> {
   const tempRelativePath = makeRuntimeUploadTempPath(relativePath)
   try {
@@ -813,6 +846,7 @@ async function uploadRuntimeFileWithoutClobber(
       entryRelativePath: source.entryRelativePath,
       worktree: toRuntimeWorktreeSelector(worktreeId),
       relativePath: tempRelativePath,
+      uploadId,
       expectedSshTargetId,
       expectedSshConnectionGeneration,
       expectedExecutionHostId,

--- a/src/renderer/src/runtime/runtime-file-import-pairing-revision.test.ts
+++ b/src/renderer/src/runtime/runtime-file-import-pairing-revision.test.ts
@@ -16,6 +16,7 @@ const CAPTURED_REVISION = 41
 const REPLACEMENT_REVISION = 42
 const runtimeEnvironmentCall = vi.fn()
 const stageExternalPathsForRuntimeUpload = vi.fn()
+const uploadExternalFileToRuntime = vi.fn()
 const importExternalPaths = vi.fn()
 
 type RuntimeCallArgs = {
@@ -90,7 +91,7 @@ function repairedRuntimeResponse(method: string) {
   }
 }
 
-function mockStagedFile(sourcePath: string, name: string, contentBase64: string): void {
+function mockStagedFile(sourcePath: string, name: string, byteLength: number): void {
   stageExternalPathsForRuntimeUpload.mockResolvedValue({
     sources: [
       {
@@ -98,7 +99,7 @@ function mockStagedFile(sourcePath: string, name: string, contentBase64: string)
         status: 'staged',
         name,
         kind: 'file',
-        entries: [{ relativePath: '', kind: 'file', contentBase64 }]
+        entries: [{ relativePath: '', kind: 'file', byteLength }]
       }
     ]
   })
@@ -118,12 +119,15 @@ beforeEach(() => {
   markRuntimeEnvironmentCompatible(ENVIRONMENT_ID)
   runtimeEnvironmentCall.mockReset()
   stageExternalPathsForRuntimeUpload.mockReset()
+  uploadExternalFileToRuntime.mockReset()
+  uploadExternalFileToRuntime.mockResolvedValue({ byteLength: 0 })
   importExternalPaths.mockReset()
   vi.stubGlobal('window', {
     api: {
       fs: {
         importExternalPaths,
-        stageExternalPathsForRuntimeUpload
+        stageExternalPathsForRuntimeUpload,
+        uploadExternalFileToRuntime
       },
       runtimeEnvironments: {
         call: runtimeEnvironmentCall
@@ -149,17 +153,20 @@ describe('runtime file import pairing revision', () => {
     expect(importExternalPaths).not.toHaveBeenCalled()
   })
 
-  it('stops a rich-markdown upload between chunks without contacting the replacement HUB', async () => {
-    mockStagedFile('/client/screenshot.png', 'screenshot.png', `${'A'.repeat(512 * 1024)}BBBBBBBB`)
+  it('stops a streamed upload mid-file without contacting the replacement HUB', async () => {
+    mockStagedFile('/client/screenshot.png', 'screenshot.png', 512 * 1024 + 8)
+    // Why: main re-checks the pairing revision per chunk, so a re-pair surfaces
+    // here as a rejected upload rather than a renderer-issued chunk RPC.
+    uploadExternalFileToRuntime.mockImplementation(async () => {
+      setEnvironmentRevision(REPLACEMENT_REVISION)
+      throw new Error('Runtime environment was re-paired during the import.')
+    })
     runtimeEnvironmentCall.mockImplementation(async (args: RuntimeCallArgs) => {
       if (args.method === 'status.get') {
         return runtimeStatusResponse()
       }
       if (args.method === 'files.stat') {
         return missingRuntimePathResponse()
-      }
-      if (args.method === 'files.writeBase64Chunk') {
-        setEnvironmentRevision(REPLACEMENT_REVISION)
       }
       return successfulRuntimeResponse(args.method)
     })
@@ -172,9 +179,7 @@ describe('runtime file import pairing revision', () => {
 
     expect(runtimeEnvironmentCall.mock.calls.map(([args]) => args.method)).toEqual([
       'status.get',
-      'files.stat',
-      'status.get',
-      'files.writeBase64Chunk'
+      'files.stat'
     ])
     expectEveryRuntimeCallBoundToCapturedRevision()
     expect(runtimeEnvironmentCall).not.toHaveBeenCalledWith(
@@ -186,23 +191,21 @@ describe('runtime file import pairing revision', () => {
   })
 
   it('keeps a HUB-local composer commit on its entry revision when re-paired mid-call', async () => {
-    mockStagedFile('/client/note.txt', 'note.txt', 'bm90ZQ==')
-    let statusCalls = 0
+    mockStagedFile('/client/note.txt', 'note.txt', 4)
     runtimeEnvironmentCall.mockImplementation(async (args: RuntimeCallArgs) => {
       if (args.expectedEnvironmentPairingRevision !== CAPTURED_REVISION) {
         throw new Error('replacement HUB received an import RPC')
       }
       if (args.method === 'status.get') {
-        statusCalls += 1
-        if (statusCalls === 3) {
-          setEnvironmentRevision(REPLACEMENT_REVISION)
-        }
         return runtimeStatusResponse()
       }
       if (args.method === 'files.stat') {
         return missingRuntimePathResponse()
       }
       if (args.method === 'files.commitUpload') {
+        // Why: re-paired while the commit was in flight — cleanup must not run
+        // against the replacement HUB.
+        setEnvironmentRevision(REPLACEMENT_REVISION)
         return repairedRuntimeResponse(args.method)
       }
       return successfulRuntimeResponse(args.method)
@@ -221,7 +224,7 @@ describe('runtime file import pairing revision', () => {
   })
 
   it('does not clean up against a replacement HUB after commit', async () => {
-    mockStagedFile('/client/drop.txt', 'drop.txt', 'ZHJvcA==')
+    mockStagedFile('/client/drop.txt', 'drop.txt', 4)
     runtimeEnvironmentCall.mockImplementation(async (args: RuntimeCallArgs) => {
       if (args.method === 'status.get') {
         return runtimeStatusResponse()
@@ -260,25 +263,18 @@ describe('runtime file import pairing revision', () => {
           kind: 'directory',
           entries: [
             { relativePath: '', kind: 'directory' },
-            { relativePath: 'broken.txt', kind: 'file', contentBase64: 'YnJva2Vu' }
+            { relativePath: 'broken.txt', kind: 'file', byteLength: 6 }
           ]
         }
       ]
     })
+    uploadExternalFileToRuntime.mockRejectedValue(new Error('disk full'))
     runtimeEnvironmentCall.mockImplementation(async (args: RuntimeCallArgs) => {
       if (args.method === 'status.get') {
         return runtimeStatusResponse()
       }
       if (args.method === 'files.stat') {
         return missingRuntimePathResponse()
-      }
-      if (args.method === 'files.writeBase64') {
-        return {
-          id: args.method,
-          ok: false,
-          error: { code: 'write_failed', message: 'disk full' },
-          _meta: { runtimeId: 'hub-runtime' }
-        }
       }
       return successfulRuntimeResponse(args.method)
     })

--- a/src/renderer/src/runtime/runtime-upload-progress-tracker.test.ts
+++ b/src/renderer/src/runtime/runtime-upload-progress-tracker.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createRuntimeUploadProgressTracker,
+  sumStagedUploadBytes
+} from './runtime-upload-progress-tracker'
+
+describe('sumStagedUploadBytes', () => {
+  it('counts file bytes and ignores directory entries', () => {
+    expect(
+      sumStagedUploadBytes([
+        {
+          status: 'staged',
+          entries: [
+            { kind: 'directory' },
+            { kind: 'file', byteLength: 10 },
+            { kind: 'directory' },
+            { kind: 'file', byteLength: 32 }
+          ]
+        }
+      ])
+    ).toBe(42)
+  })
+
+  it('ignores sources that never staged', () => {
+    expect(
+      sumStagedUploadBytes([
+        { status: 'skipped' },
+        { status: 'failed', entries: [{ kind: 'file', byteLength: 999 }] },
+        { status: 'staged', entries: [{ kind: 'file', byteLength: 7 }] }
+      ])
+    ).toBe(7)
+  })
+
+  it('is zero for a drop of only empty files', () => {
+    expect(
+      sumStagedUploadBytes([{ status: 'staged', entries: [{ kind: 'file', byteLength: 0 }] }])
+    ).toBe(0)
+  })
+})
+
+describe('createRuntimeUploadProgressTracker', () => {
+  it('carries completed files into the running total', () => {
+    const seen: number[] = []
+    const tracker = createRuntimeUploadProgressTracker(300, (p) => seen.push(p.sentBytes))
+
+    tracker.reportFileProgress(50)
+    tracker.reportFileProgress(100)
+    tracker.completeFile(100)
+    tracker.reportFileProgress(75)
+
+    expect(seen).toEqual([50, 100, 175])
+  })
+
+  it('reports the same total on every update', () => {
+    const totals: number[] = []
+    const tracker = createRuntimeUploadProgressTracker(500, (p) => totals.push(p.totalBytes))
+
+    tracker.reportFileProgress(10)
+    // completeFile does not re-emit: the figure has not moved.
+    tracker.completeFile(10)
+    tracker.reportFileProgress(20)
+
+    expect(totals).toEqual([500, 500])
+  })
+
+  it('does not repeat a figure that has not moved', () => {
+    const seen: number[] = []
+    const tracker = createRuntimeUploadProgressTracker(100, (p) => seen.push(p.sentBytes))
+
+    tracker.reportFileProgress(40)
+    tracker.reportFileProgress(40)
+    tracker.completeFile(40)
+
+    expect(seen).toEqual([40])
+  })
+
+  it('clamps to the staged total when a source grew after staging', () => {
+    const seen: number[] = []
+    const tracker = createRuntimeUploadProgressTracker(100, (p) => seen.push(p.sentBytes))
+
+    tracker.reportFileProgress(250)
+
+    expect(seen).toEqual([100])
+  })
+
+  it('advances across a directory of several files', () => {
+    const seen: number[] = []
+    const tracker = createRuntimeUploadProgressTracker(30, (p) => seen.push(p.sentBytes))
+
+    for (const size of [10, 10, 10]) {
+      tracker.reportFileProgress(size)
+      tracker.completeFile(size)
+    }
+
+    expect(seen).toEqual([10, 20, 30])
+  })
+
+  it('emits nothing until bytes move', () => {
+    const seen: number[] = []
+    createRuntimeUploadProgressTracker(100, (p) => seen.push(p.sentBytes))
+
+    expect(seen).toEqual([])
+  })
+})

--- a/src/renderer/src/runtime/runtime-upload-progress-tracker.test.ts
+++ b/src/renderer/src/runtime/runtime-upload-progress-tracker.test.ts
@@ -1,40 +1,29 @@
 import { describe, expect, it } from 'vitest'
 import {
   createRuntimeUploadProgressTracker,
-  sumStagedUploadBytes
+  sumSourceUploadBytes
 } from './runtime-upload-progress-tracker'
 
-describe('sumStagedUploadBytes', () => {
+describe('sumSourceUploadBytes', () => {
   it('counts file bytes and ignores directory entries', () => {
     expect(
-      sumStagedUploadBytes([
-        {
-          status: 'staged',
-          entries: [
-            { kind: 'directory' },
-            { kind: 'file', byteLength: 10 },
-            { kind: 'directory' },
-            { kind: 'file', byteLength: 32 }
-          ]
-        }
-      ])
+      sumSourceUploadBytes({
+        entries: [
+          { kind: 'directory' },
+          { kind: 'file', byteLength: 10 },
+          { kind: 'directory' },
+          { kind: 'file', byteLength: 32 }
+        ]
+      })
     ).toBe(42)
   })
 
-  it('ignores sources that never staged', () => {
-    expect(
-      sumStagedUploadBytes([
-        { status: 'skipped' },
-        { status: 'failed', entries: [{ kind: 'file', byteLength: 999 }] },
-        { status: 'staged', entries: [{ kind: 'file', byteLength: 7 }] }
-      ])
-    ).toBe(7)
+  it('is zero for a source of only empty files', () => {
+    expect(sumSourceUploadBytes({ entries: [{ kind: 'file', byteLength: 0 }] })).toBe(0)
   })
 
-  it('is zero for a drop of only empty files', () => {
-    expect(
-      sumStagedUploadBytes([{ status: 'staged', entries: [{ kind: 'file', byteLength: 0 }] }])
-    ).toBe(0)
+  it('is zero for a source with no entries at all', () => {
+    expect(sumSourceUploadBytes({})).toBe(0)
   })
 })
 

--- a/src/renderer/src/runtime/runtime-upload-progress-tracker.test.ts
+++ b/src/renderer/src/runtime/runtime-upload-progress-tracker.test.ts
@@ -32,9 +32,11 @@ describe('createRuntimeUploadProgressTracker', () => {
     const seen: number[] = []
     const tracker = createRuntimeUploadProgressTracker(300, (p) => seen.push(p.sentBytes))
 
+    tracker.beginFile()
     tracker.reportFileProgress(50)
     tracker.reportFileProgress(100)
     tracker.completeFile(100)
+    tracker.beginFile()
     tracker.reportFileProgress(75)
 
     expect(seen).toEqual([50, 100, 175])
@@ -44,9 +46,11 @@ describe('createRuntimeUploadProgressTracker', () => {
     const totals: number[] = []
     const tracker = createRuntimeUploadProgressTracker(500, (p) => totals.push(p.totalBytes))
 
+    tracker.beginFile()
     tracker.reportFileProgress(10)
     // completeFile does not re-emit: the figure has not moved.
     tracker.completeFile(10)
+    tracker.beginFile()
     tracker.reportFileProgress(20)
 
     expect(totals).toEqual([500, 500])
@@ -56,6 +60,7 @@ describe('createRuntimeUploadProgressTracker', () => {
     const seen: number[] = []
     const tracker = createRuntimeUploadProgressTracker(100, (p) => seen.push(p.sentBytes))
 
+    tracker.beginFile()
     tracker.reportFileProgress(40)
     tracker.reportFileProgress(40)
     tracker.completeFile(40)
@@ -67,6 +72,7 @@ describe('createRuntimeUploadProgressTracker', () => {
     const seen: number[] = []
     const tracker = createRuntimeUploadProgressTracker(100, (p) => seen.push(p.sentBytes))
 
+    tracker.beginFile()
     tracker.reportFileProgress(250)
 
     expect(seen).toEqual([100])
@@ -77,11 +83,35 @@ describe('createRuntimeUploadProgressTracker', () => {
     const tracker = createRuntimeUploadProgressTracker(30, (p) => seen.push(p.sentBytes))
 
     for (const size of [10, 10, 10]) {
+      tracker.beginFile()
       tracker.reportFileProgress(size)
       tracker.completeFile(size)
     }
 
     expect(seen).toEqual([10, 20, 30])
+  })
+
+  it('ignores a progress event that lands after the file completed', () => {
+    const seen: number[] = []
+    const tracker = createRuntimeUploadProgressTracker(100, (p) => seen.push(p.sentBytes))
+
+    tracker.beginFile()
+    tracker.reportFileProgress(40)
+    tracker.completeFile(40)
+    // Electron does not order webContents.send against the invoke reply, so the
+    // last chunk's event can arrive here; counting it would double the file.
+    tracker.reportFileProgress(40)
+
+    expect(seen).toEqual([40])
+  })
+
+  it('emits nothing before the first file begins', () => {
+    const seen: number[] = []
+    const tracker = createRuntimeUploadProgressTracker(100, (p) => seen.push(p.sentBytes))
+
+    tracker.reportFileProgress(50)
+
+    expect(seen).toEqual([])
   })
 
   it('emits nothing until bytes move', () => {

--- a/src/renderer/src/runtime/runtime-upload-progress-tracker.ts
+++ b/src/renderer/src/runtime/runtime-upload-progress-tracker.ts
@@ -1,0 +1,66 @@
+export type RuntimeUploadProgressReport = { sentBytes: number; totalBytes: number }
+
+export type RuntimeUploadProgressTracker = {
+  /** Bytes of the file currently in flight that have reached the runtime. */
+  reportFileProgress: (sentBytes: number) => void
+  /** Called once a file is committed, so its bytes move from in-flight to done. */
+  completeFile: (byteLength: number) => void
+}
+
+/**
+ * Turn per-file byte counts into one figure for a whole drop.
+ *
+ * Files upload strictly one at a time, so "in flight" is always a single file and
+ * the running total is simply the committed files plus that file's progress.
+ * Directory entries carry no bytes and are deliberately absent from the total —
+ * they would otherwise stall the bar at each `createDirNoClobber`.
+ */
+export function createRuntimeUploadProgressTracker(
+  totalBytes: number,
+  report: (progress: RuntimeUploadProgressReport) => void
+): RuntimeUploadProgressTracker {
+  let completedBytes = 0
+  let inFlightBytes = 0
+  let lastReported = -1
+
+  const emit = (): void => {
+    // Why: a source can grow between staging and upload, so the sum of what
+    // actually moved may exceed the total staging measured.
+    const sentBytes = Math.min(completedBytes + inFlightBytes, totalBytes)
+    if (sentBytes === lastReported) {
+      return
+    }
+    lastReported = sentBytes
+    report({ sentBytes, totalBytes })
+  }
+
+  return {
+    reportFileProgress: (sentBytes) => {
+      inFlightBytes = sentBytes
+      emit()
+    },
+    completeFile: (byteLength) => {
+      completedBytes += byteLength
+      inFlightBytes = 0
+      emit()
+    }
+  }
+}
+
+/** Total bytes a staged drop will move; directory entries contribute nothing. */
+export function sumStagedUploadBytes(
+  sources: { status: string; entries?: { kind: string; byteLength?: number }[] }[]
+): number {
+  let total = 0
+  for (const source of sources) {
+    if (source.status !== 'staged') {
+      continue
+    }
+    for (const entry of source.entries ?? []) {
+      if (entry.kind === 'file') {
+        total += entry.byteLength ?? 0
+      }
+    }
+  }
+  return total
+}

--- a/src/renderer/src/runtime/runtime-upload-progress-tracker.ts
+++ b/src/renderer/src/runtime/runtime-upload-progress-tracker.ts
@@ -47,19 +47,29 @@ export function createRuntimeUploadProgressTracker(
   }
 }
 
-/** Total bytes a staged drop will move; directory entries contribute nothing. */
-export function sumStagedUploadBytes(
-  sources: { status: string; entries?: { kind: string; byteLength?: number }[] }[]
-): number {
+/** One row in the drop UI: everything the user dropped becomes exactly one. */
+export type RuntimeImportProgressRow = {
+  uploadId: string
+  name: string
+  totalBytes: number
+  sourcePath: string
+}
+
+export type RuntimeImportProgressHandlers = {
+  onStart: (rows: RuntimeImportProgressRow[]) => void
+  onRowProgress: (uploadId: string, sentBytes: number) => void
+  onRowSettled: (uploadId: string, status: 'done' | 'failed') => void
+  onFinish: () => void
+}
+
+/** Bytes one dropped source will move; directory entries contribute nothing. */
+export function sumSourceUploadBytes(source: {
+  entries?: { kind: string; byteLength?: number }[]
+}): number {
   let total = 0
-  for (const source of sources) {
-    if (source.status !== 'staged') {
-      continue
-    }
-    for (const entry of source.entries ?? []) {
-      if (entry.kind === 'file') {
-        total += entry.byteLength ?? 0
-      }
+  for (const entry of source.entries ?? []) {
+    if (entry.kind === 'file') {
+      total += entry.byteLength ?? 0
     }
   }
   return total

--- a/src/renderer/src/runtime/runtime-upload-progress-tracker.ts
+++ b/src/renderer/src/runtime/runtime-upload-progress-tracker.ts
@@ -1,20 +1,15 @@
 export type RuntimeUploadProgressReport = { sentBytes: number; totalBytes: number }
 
 export type RuntimeUploadProgressTracker = {
+  /** Opens the window in which progress for the next file is accepted. */
+  beginFile: () => void
   /** Bytes of the file currently in flight that have reached the runtime. */
   reportFileProgress: (sentBytes: number) => void
   /** Called once a file is committed, so its bytes move from in-flight to done. */
   completeFile: (byteLength: number) => void
 }
 
-/**
- * Turn per-file byte counts into one figure for a whole drop.
- *
- * Files upload strictly one at a time, so "in flight" is always a single file and
- * the running total is simply the committed files plus that file's progress.
- * Directory entries carry no bytes and are deliberately absent from the total —
- * they would otherwise stall the bar at each `createDirNoClobber`.
- */
+/** Committed files plus the one in flight; uploads are strictly sequential. */
 export function createRuntimeUploadProgressTracker(
   totalBytes: number,
   report: (progress: RuntimeUploadProgressReport) => void
@@ -22,6 +17,9 @@ export function createRuntimeUploadProgressTracker(
   let completedBytes = 0
   let inFlightBytes = 0
   let lastReported = -1
+  // Electron does not order webContents.send against an invoke reply, so a final
+  // progress event can land after completeFile and be counted twice.
+  let acceptingProgress = false
 
   const emit = (): void => {
     // Why: a source can grow between staging and upload, so the sum of what
@@ -35,11 +33,19 @@ export function createRuntimeUploadProgressTracker(
   }
 
   return {
+    beginFile: () => {
+      acceptingProgress = true
+      inFlightBytes = 0
+    },
     reportFileProgress: (sentBytes) => {
+      if (!acceptingProgress) {
+        return
+      }
       inFlightBytes = sentBytes
       emit()
     },
     completeFile: (byteLength) => {
+      acceptingProgress = false
       completedBytes += byteLength
       inFlightBytes = 0
       emit()

--- a/src/renderer/src/runtime/runtime-upload-session-state.test.ts
+++ b/src/renderer/src/runtime/runtime-upload-session-state.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   endRuntimeUploadSession,
   getRuntimeUploadSession,
+  settleRuntimeUploadSession,
   startRuntimeUploadSession,
   subscribeToRuntimeUploadSessions,
   summarizeRuntimeUploadSession,
@@ -79,6 +80,26 @@ describe('runtime upload session state', () => {
     expect(getRuntimeUploadSession('s')).toBeUndefined()
   })
 
+  it('keeps rows when settled so the panel can state the outcome', () => {
+    startRuntimeUploadSession('s', [row({ status: 'cancelled' })])
+    settleRuntimeUploadSession('s')
+
+    const session = getRuntimeUploadSession('s')
+    expect(session?.settled).toBe(true)
+    expect(session?.rows).toHaveLength(1)
+  })
+
+  it('settles only once', () => {
+    startRuntimeUploadSession('s', [row()])
+    settleRuntimeUploadSession('s')
+    const listener = vi.fn()
+    const unsubscribe = subscribeToRuntimeUploadSessions(listener)
+    settleRuntimeUploadSession('s')
+
+    expect(listener).not.toHaveBeenCalled()
+    unsubscribe()
+  })
+
   it('does not notify when nothing actually changed', () => {
     startRuntimeUploadSession('s', [row({ status: 'done' })])
     const listener = vi.fn()
@@ -94,6 +115,7 @@ describe('summarizeRuntimeUploadSession', () => {
   it('averages across rows by bytes, not by row count', () => {
     const summary = summarizeRuntimeUploadSession({
       sessionId: 's',
+      settled: true,
       rows: [
         row({ uploadId: 'a', sentBytes: 10, totalBytes: 10 }),
         row({ uploadId: 'b', sentBytes: 0, totalBytes: 90 })
@@ -106,6 +128,7 @@ describe('summarizeRuntimeUploadSession', () => {
   it('drops cancelled rows from the denominator so the bar can still finish', () => {
     const summary = summarizeRuntimeUploadSession({
       sessionId: 's',
+      settled: true,
       rows: [
         row({ uploadId: 'a', sentBytes: 100, totalBytes: 100, status: 'done' }),
         row({ uploadId: 'b', sentBytes: 20, totalBytes: 900, status: 'cancelled' })
@@ -119,6 +142,7 @@ describe('summarizeRuntimeUploadSession', () => {
   it('counts only rows still moving as active', () => {
     const summary = summarizeRuntimeUploadSession({
       sessionId: 's',
+      settled: true,
       rows: [
         row({ uploadId: 'a', status: 'done' }),
         row({ uploadId: 'b', status: 'uploading' }),
@@ -132,6 +156,7 @@ describe('summarizeRuntimeUploadSession', () => {
   it('is zero percent rather than NaN for an all-empty drop', () => {
     const summary = summarizeRuntimeUploadSession({
       sessionId: 's',
+      settled: true,
       rows: [row({ sentBytes: 0, totalBytes: 0 })]
     })
 

--- a/src/renderer/src/runtime/runtime-upload-session-state.test.ts
+++ b/src/renderer/src/runtime/runtime-upload-session-state.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  endRuntimeUploadSession,
+  getRuntimeUploadSession,
+  startRuntimeUploadSession,
+  subscribeToRuntimeUploadSessions,
+  summarizeRuntimeUploadSession,
+  updateRuntimeUploadRow,
+  type RuntimeUploadRow
+} from './runtime-upload-session-state'
+
+function row(overrides: Partial<RuntimeUploadRow> = {}): RuntimeUploadRow {
+  return {
+    uploadId: 'a',
+    name: 'a.bin',
+    sentBytes: 0,
+    totalBytes: 100,
+    status: 'uploading',
+    ...overrides
+  }
+}
+
+afterEach(() => {
+  endRuntimeUploadSession('s')
+  endRuntimeUploadSession('other')
+})
+
+describe('runtime upload session state', () => {
+  it('notifies subscribers when a row advances', () => {
+    const listener = vi.fn()
+    const unsubscribe = subscribeToRuntimeUploadSessions(listener)
+    startRuntimeUploadSession('s', [row()])
+    updateRuntimeUploadRow('s', 'a', { sentBytes: 25 })
+
+    expect(listener).toHaveBeenCalledTimes(2)
+    expect(getRuntimeUploadSession('s')?.rows[0]?.sentBytes).toBe(25)
+    unsubscribe()
+  })
+
+  it('replaces the row object so a memoized bar re-renders', () => {
+    startRuntimeUploadSession('s', [row()])
+    const before = getRuntimeUploadSession('s')?.rows[0]
+    updateRuntimeUploadRow('s', 'a', { sentBytes: 10 })
+
+    expect(getRuntimeUploadSession('s')?.rows[0]).not.toBe(before)
+  })
+
+  it('refuses to drag a cancelled row back into uploading', () => {
+    startRuntimeUploadSession('s', [row()])
+    updateRuntimeUploadRow('s', 'a', { status: 'cancelled' })
+    updateRuntimeUploadRow('s', 'a', { sentBytes: 90, status: 'uploading' })
+
+    const settled = getRuntimeUploadSession('s')?.rows[0]
+    expect(settled?.status).toBe('cancelled')
+    expect(settled?.sentBytes).toBe(0)
+  })
+
+  it('keeps a cancelled row cancelled when the import later reports it failed', () => {
+    startRuntimeUploadSession('s', [row()])
+    updateRuntimeUploadRow('s', 'a', { status: 'cancelled' })
+    updateRuntimeUploadRow('s', 'a', { status: 'failed' })
+
+    expect(getRuntimeUploadSession('s')?.rows[0]?.status).toBe('cancelled')
+  })
+
+  it('leaves other sessions untouched', () => {
+    startRuntimeUploadSession('s', [row()])
+    startRuntimeUploadSession('other', [row({ uploadId: 'b' })])
+    updateRuntimeUploadRow('s', 'a', { sentBytes: 50 })
+
+    expect(getRuntimeUploadSession('other')?.rows[0]?.sentBytes).toBe(0)
+  })
+
+  it('ignores updates for a session that already ended', () => {
+    startRuntimeUploadSession('s', [row()])
+    endRuntimeUploadSession('s')
+
+    expect(() => updateRuntimeUploadRow('s', 'a', { sentBytes: 10 })).not.toThrow()
+    expect(getRuntimeUploadSession('s')).toBeUndefined()
+  })
+
+  it('does not notify when nothing actually changed', () => {
+    startRuntimeUploadSession('s', [row({ status: 'done' })])
+    const listener = vi.fn()
+    const unsubscribe = subscribeToRuntimeUploadSessions(listener)
+    updateRuntimeUploadRow('s', 'a', { sentBytes: 10 })
+
+    expect(listener).not.toHaveBeenCalled()
+    unsubscribe()
+  })
+})
+
+describe('summarizeRuntimeUploadSession', () => {
+  it('averages across rows by bytes, not by row count', () => {
+    const summary = summarizeRuntimeUploadSession({
+      sessionId: 's',
+      rows: [
+        row({ uploadId: 'a', sentBytes: 10, totalBytes: 10 }),
+        row({ uploadId: 'b', sentBytes: 0, totalBytes: 90 })
+      ]
+    })
+
+    expect(summary.percent).toBe(10)
+  })
+
+  it('drops cancelled rows from the denominator so the bar can still finish', () => {
+    const summary = summarizeRuntimeUploadSession({
+      sessionId: 's',
+      rows: [
+        row({ uploadId: 'a', sentBytes: 100, totalBytes: 100, status: 'done' }),
+        row({ uploadId: 'b', sentBytes: 20, totalBytes: 900, status: 'cancelled' })
+      ]
+    })
+
+    expect(summary.percent).toBe(100)
+    expect(summary.totalBytes).toBe(100)
+  })
+
+  it('counts only rows still moving as active', () => {
+    const summary = summarizeRuntimeUploadSession({
+      sessionId: 's',
+      rows: [
+        row({ uploadId: 'a', status: 'done' }),
+        row({ uploadId: 'b', status: 'uploading' }),
+        row({ uploadId: 'c', status: 'cancelled' })
+      ]
+    })
+
+    expect(summary.activeCount).toBe(1)
+  })
+
+  it('is zero percent rather than NaN for an all-empty drop', () => {
+    const summary = summarizeRuntimeUploadSession({
+      sessionId: 's',
+      rows: [row({ sentBytes: 0, totalBytes: 0 })]
+    })
+
+    expect(summary.percent).toBe(0)
+  })
+})

--- a/src/renderer/src/runtime/runtime-upload-session-state.test.ts
+++ b/src/renderer/src/runtime/runtime-upload-session-state.test.ts
@@ -6,6 +6,7 @@ import {
   startRuntimeUploadSession,
   subscribeToRuntimeUploadSessions,
   summarizeRuntimeUploadSession,
+  toggleRuntimeUploadCollapsed,
   updateRuntimeUploadRow,
   type RuntimeUploadRow
 } from './runtime-upload-session-state'
@@ -89,6 +90,21 @@ describe('runtime upload session state', () => {
     expect(session?.rows).toHaveLength(1)
   })
 
+  it('toggles collapse in the store so the panel can be remounted to re-measure', () => {
+    startRuntimeUploadSession('s', [row()])
+    expect(getRuntimeUploadSession('s')?.collapsed).toBe(false)
+
+    toggleRuntimeUploadCollapsed('s')
+    expect(getRuntimeUploadSession('s')?.collapsed).toBe(true)
+
+    toggleRuntimeUploadCollapsed('s')
+    expect(getRuntimeUploadSession('s')?.collapsed).toBe(false)
+  })
+
+  it('survives a collapse toggle on a session that already ended', () => {
+    expect(() => toggleRuntimeUploadCollapsed('gone')).not.toThrow()
+  })
+
   it('settles only once', () => {
     startRuntimeUploadSession('s', [row()])
     settleRuntimeUploadSession('s')
@@ -116,6 +132,7 @@ describe('summarizeRuntimeUploadSession', () => {
     const summary = summarizeRuntimeUploadSession({
       sessionId: 's',
       settled: true,
+      collapsed: false,
       rows: [
         row({ uploadId: 'a', sentBytes: 10, totalBytes: 10 }),
         row({ uploadId: 'b', sentBytes: 0, totalBytes: 90 })
@@ -129,6 +146,7 @@ describe('summarizeRuntimeUploadSession', () => {
     const summary = summarizeRuntimeUploadSession({
       sessionId: 's',
       settled: true,
+      collapsed: false,
       rows: [
         row({ uploadId: 'a', sentBytes: 100, totalBytes: 100, status: 'done' }),
         row({ uploadId: 'b', sentBytes: 20, totalBytes: 900, status: 'cancelled' })
@@ -143,6 +161,7 @@ describe('summarizeRuntimeUploadSession', () => {
     const summary = summarizeRuntimeUploadSession({
       sessionId: 's',
       settled: true,
+      collapsed: false,
       rows: [
         row({ uploadId: 'a', status: 'done' }),
         row({ uploadId: 'b', status: 'uploading' }),
@@ -157,6 +176,7 @@ describe('summarizeRuntimeUploadSession', () => {
     const summary = summarizeRuntimeUploadSession({
       sessionId: 's',
       settled: true,
+      collapsed: false,
       rows: [row({ sentBytes: 0, totalBytes: 0 })]
     })
 

--- a/src/renderer/src/runtime/runtime-upload-session-state.ts
+++ b/src/renderer/src/runtime/runtime-upload-session-state.ts
@@ -45,13 +45,7 @@ export function startRuntimeUploadSession(sessionId: string, rows: RuntimeUpload
   emit()
 }
 
-/**
- * Mark the drop finished without removing it.
- *
- * The panel has to outlive the transfer long enough to say how it ended —
- * deleting the session here is what made a cancelled upload vanish mid-gesture
- * with nothing to read.
- */
+/** Keeps the rows so the panel can state how the drop ended before it closes. */
 export function settleRuntimeUploadSession(sessionId: string): void {
   const session = sessions.get(sessionId)
   if (!session || session.settled) {

--- a/src/renderer/src/runtime/runtime-upload-session-state.ts
+++ b/src/renderer/src/runtime/runtime-upload-session-state.ts
@@ -14,6 +14,8 @@ export type RuntimeUploadSession = {
   rows: RuntimeUploadRow[]
   /** Every row has stopped moving; the panel shows its outcome, then leaves. */
   settled: boolean
+  /** Kept here, not in the panel: toggling it remounts the panel to re-measure. */
+  collapsed: boolean
 }
 
 type Listener = () => void
@@ -39,7 +41,7 @@ export function getRuntimeUploadSession(sessionId: string): RuntimeUploadSession
 }
 
 export function startRuntimeUploadSession(sessionId: string, rows: RuntimeUploadRow[]): void {
-  sessions.set(sessionId, { sessionId, rows, settled: false })
+  sessions.set(sessionId, { sessionId, rows, settled: false, collapsed: false })
   emit()
 }
 
@@ -56,6 +58,15 @@ export function settleRuntimeUploadSession(sessionId: string): void {
     return
   }
   sessions.set(sessionId, { ...session, settled: true })
+  emit()
+}
+
+export function toggleRuntimeUploadCollapsed(sessionId: string): void {
+  const session = sessions.get(sessionId)
+  if (!session) {
+    return
+  }
+  sessions.set(sessionId, { ...session, collapsed: !session.collapsed })
   emit()
 }
 

--- a/src/renderer/src/runtime/runtime-upload-session-state.ts
+++ b/src/renderer/src/runtime/runtime-upload-session-state.ts
@@ -1,0 +1,111 @@
+export type RuntimeUploadRowStatus = 'uploading' | 'done' | 'cancelled' | 'failed'
+
+export type RuntimeUploadRow = {
+  /** Id every file of one dropped source streams under; also the cancel handle. */
+  uploadId: string
+  name: string
+  sentBytes: number
+  totalBytes: number
+  status: RuntimeUploadRowStatus
+}
+
+export type RuntimeUploadSession = {
+  sessionId: string
+  rows: RuntimeUploadRow[]
+}
+
+type Listener = () => void
+
+const sessions = new Map<string, RuntimeUploadSession>()
+const listeners = new Set<Listener>()
+
+function emit(): void {
+  for (const listener of listeners) {
+    listener()
+  }
+}
+
+export function subscribeToRuntimeUploadSessions(listener: Listener): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+export function getRuntimeUploadSession(sessionId: string): RuntimeUploadSession | undefined {
+  return sessions.get(sessionId)
+}
+
+export function startRuntimeUploadSession(sessionId: string, rows: RuntimeUploadRow[]): void {
+  sessions.set(sessionId, { sessionId, rows })
+  emit()
+}
+
+export function endRuntimeUploadSession(sessionId: string): void {
+  sessions.delete(sessionId)
+  emit()
+}
+
+/**
+ * Replace one row.
+ *
+ * Rows are swapped rather than mutated so `useSyncExternalStore` sees a new
+ * reference; mutating in place renders a stale bar that never moves.
+ */
+export function updateRuntimeUploadRow(
+  sessionId: string,
+  uploadId: string,
+  patch: Partial<Omit<RuntimeUploadRow, 'uploadId'>>
+): void {
+  const session = sessions.get(sessionId)
+  if (!session) {
+    return
+  }
+  let changed = false
+  const rows = session.rows.map((row) => {
+    if (row.uploadId !== uploadId) {
+      return row
+    }
+    // Why: a cancelled or failed row must not be dragged back to 'uploading' by
+    // a progress event that was already in flight when the user clicked.
+    if (row.status !== 'uploading') {
+      return row
+    }
+    changed = true
+    return { ...row, ...patch }
+  })
+  if (!changed) {
+    return
+  }
+  sessions.set(sessionId, { sessionId, rows })
+  emit()
+}
+
+export function summarizeRuntimeUploadSession(session: RuntimeUploadSession): {
+  sentBytes: number
+  totalBytes: number
+  percent: number
+  activeCount: number
+} {
+  let sentBytes = 0
+  let totalBytes = 0
+  let activeCount = 0
+  for (const row of session.rows) {
+    // Why: a cancelled row's remaining bytes are never going to move, so leaving
+    // them in the denominator would strand the overall bar below 100%.
+    if (row.status === 'cancelled' || row.status === 'failed') {
+      continue
+    }
+    sentBytes += Math.min(row.sentBytes, row.totalBytes)
+    totalBytes += row.totalBytes
+    if (row.status === 'uploading') {
+      activeCount += 1
+    }
+  }
+  return {
+    sentBytes,
+    totalBytes,
+    percent: totalBytes > 0 ? Math.min(100, Math.floor((sentBytes / totalBytes) * 100)) : 0,
+    activeCount
+  }
+}

--- a/src/renderer/src/runtime/runtime-upload-session-state.ts
+++ b/src/renderer/src/runtime/runtime-upload-session-state.ts
@@ -12,6 +12,8 @@ export type RuntimeUploadRow = {
 export type RuntimeUploadSession = {
   sessionId: string
   rows: RuntimeUploadRow[]
+  /** Every row has stopped moving; the panel shows its outcome, then leaves. */
+  settled: boolean
 }
 
 type Listener = () => void
@@ -37,7 +39,23 @@ export function getRuntimeUploadSession(sessionId: string): RuntimeUploadSession
 }
 
 export function startRuntimeUploadSession(sessionId: string, rows: RuntimeUploadRow[]): void {
-  sessions.set(sessionId, { sessionId, rows })
+  sessions.set(sessionId, { sessionId, rows, settled: false })
+  emit()
+}
+
+/**
+ * Mark the drop finished without removing it.
+ *
+ * The panel has to outlive the transfer long enough to say how it ended —
+ * deleting the session here is what made a cancelled upload vanish mid-gesture
+ * with nothing to read.
+ */
+export function settleRuntimeUploadSession(sessionId: string): void {
+  const session = sessions.get(sessionId)
+  if (!session || session.settled) {
+    return
+  }
+  sessions.set(sessionId, { ...session, settled: true })
   emit()
 }
 
@@ -77,7 +95,7 @@ export function updateRuntimeUploadRow(
   if (!changed) {
     return
   }
-  sessions.set(sessionId, { sessionId, rows })
+  sessions.set(sessionId, { ...session, rows })
   emit()
 }
 
@@ -86,11 +104,21 @@ export function summarizeRuntimeUploadSession(session: RuntimeUploadSession): {
   totalBytes: number
   percent: number
   activeCount: number
+  doneCount: number
+  cancelledCount: number
 } {
   let sentBytes = 0
   let totalBytes = 0
   let activeCount = 0
+  let doneCount = 0
+  let cancelledCount = 0
   for (const row of session.rows) {
+    if (row.status === 'done') {
+      doneCount += 1
+    }
+    if (row.status === 'cancelled') {
+      cancelledCount += 1
+    }
     // Why: a cancelled row's remaining bytes are never going to move, so leaving
     // them in the denominator would strand the overall bar below 100%.
     if (row.status === 'cancelled' || row.status === 'failed') {
@@ -106,6 +134,8 @@ export function summarizeRuntimeUploadSession(session: RuntimeUploadSession): {
     sentBytes,
     totalBytes,
     percent: totalBytes > 0 ? Math.min(100, Math.floor((sentBytes / totalBytes) * 100)) : 0,
-    activeCount
+    activeCount,
+    doneCount,
+    cancelledCount
   }
 }

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2076,6 +2076,7 @@ function createFileApi(): NonNullable<Partial<PreloadApi>['fs']> {
     uploadExternalFileToRuntime: async () => {
       throw new Error('Uploading local files is not supported in the web client')
     },
+    onUploadProgress: () => noopUnsubscribe,
     resolveDroppedPathsForAgent: async () => ({ resolvedPaths: [], skipped: [], failed: [] }),
     watchWorktree: () => Promise.resolve(),
     unwatchWorktree: () => Promise.resolve(),

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2071,6 +2071,11 @@ function createFileApi(): NonNullable<Partial<PreloadApi>['fs']> {
     },
     importExternalPaths: async () => ({ results: [] }),
     stageExternalPathsForRuntimeUpload: async () => ({ sources: [] }),
+    // Why: the web client has no local filesystem to stream from, so staging
+    // never yields a source for this to upload.
+    uploadExternalFileToRuntime: async () => {
+      throw new Error('Uploading local files is not supported in the web client')
+    },
     resolveDroppedPathsForAgent: async () => ({ resolvedPaths: [], skipped: [], failed: [] }),
     watchWorktree: () => Promise.resolve(),
     unwatchWorktree: () => Promise.resolve(),

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2077,6 +2077,8 @@ function createFileApi(): NonNullable<Partial<PreloadApi>['fs']> {
       throw new Error('Uploading local files is not supported in the web client')
     },
     onUploadProgress: () => noopUnsubscribe,
+    cancelRuntimeUpload: async () => {},
+    releaseRuntimeUpload: async () => {},
     resolveDroppedPathsForAgent: async () => ({ resolvedPaths: [], skipped: [], failed: [] }),
     watchWorktree: () => Promise.resolve(),
     unwatchWorktree: () => Promise.resolve(),


### PR DESCRIPTION
Fixes #16077

> Stacked on #16106 (`feat/stream-runtime-upload-staging`). Please merge that first — this branch is based on it, so the diff here will shrink to just the progress/cancel work once it lands.

## The problem

Dropping a file onto a terminal in a remote workspace gave no feedback while the transfer ran: one static "Uploading 1 file to runtime…" toast until it either finished or failed. A large file looked identical to a hung one, and there was no way to stop it.

That mattered more once #15987 removed the 25 MB cap, because multi-hundred-megabyte drops became a normal thing to do.

## The change

A per-file panel replaces the static toast:

- **Header** — aggregate percent, a collapse toggle, and on completion the outcome ("Upload cancelled", "Uploaded 1 of 3 to runtime").
- **One row per dropped source** — name, transferred-of-total, a bar, percent, and a cancel control.
- **Cancel is real.** Each dropped source streams under one id that doubles as its abort handle, so cancelling a row stops that source and leaves the rest of the drop running.

### Progress

The chunk loop reports bytes **after each chunk is acknowledged by the runtime**, so the bar tracks what actually landed rather than what was handed to the socket. Updates are coalesced to at most one per megabyte or 100 ms — a 2 GB file is ~5,400 slices, and forwarding each would cost more in IPC than the transfer.

The renderer sums staged byte counts before the first byte moves, which is possible only because #15987 made staging record sizes. Directory entries are excluded from the total; they carry no bytes and would otherwise stall the bar at every `createDirNoClobber`.

### Cancel

The streamer checks its abort signal **between slices**, so a cancelled upload leaves a well-formed partial file at the temp path, which the existing cleanup removes. Nothing ever lands at the destination.

A cancel that arrives between two files of one source is remembered, so the next file aborts rather than the click silently doing nothing. Cancelled sources are excluded from the failure summary — a cancel is not a failure — and the session store refuses to relabel a cancelled row when the import later reports it as failed.

## Demo

Two files dropped onto a terminal in a remote workspace: both rows track their own bytes, one is cancelled mid-transfer while the other carries on, and the list collapses to a single header.

<img width="2000" height="1176" alt="Per-file upload progress panel with cancel" src="https://github.com/user-attachments/assets/174324d1-c30b-4ac0-aea8-cadcd63d0091" />

## Design

Per `docs/STYLEGUIDE.md`, cancel is a back-out rather than a destructive action, so the control is a quiet ghost with no colour. The bar uses the existing `Progress` primitive's `primary` fill (near-black in light, near-white in dark) rather than a new hue. Percentages are fixed-width and `tabular-nums` so the row does not reflow as digits change, per the guide's rule about pre-reserving space.

## Bugs found and fixed while building this

Four of these were only visible in a real window, and each has a non-obvious cause worth recording:

1. **Both figures in a row must scale to the total's unit.** Formatting them independently rendered `900 / 32.5 MB` when a file crossed a unit boundary — two numbers on different scales.
2. **Sonner only re-measures a toast when its `jsx` identity changes.** Our panel re-renders from its own store, so collapsing left the header hanging inside the cached expanded height. Collapse state moved into the store and toggling re-issues `toast.custom` under the same id.
3. **`toast.custom` mints an id, then spreads the caller's options over it** (`this.create({ jsx: jsx(id), id, ...data })`). Passing `id: undefined` therefore registers the toast under an id `custom()` never returns, so the re-issue added a second panel instead of updating the first. The id key is now omitted entirely on first publish.
4. **An unstyled sonner toast is content-sized**, so collapsing changed the panel's width as well as its height and it appeared to jump sideways. The panel now takes the Toaster's own `--width`.

Plus two smaller ones: the panel used to vanish the instant everything settled, so a cancelled drop closed on "Uploading 2 files" with nothing to read (it now holds 1.2s, states the outcome, then fades — `motion-reduce` keeps the hold and drops the fade); and the collapse chevron swapped between two icon components, which replaces the DOM node so there was nothing to tween (one chevron now rotates 180°).

## Compatibility

- **Wire:** none. Progress is main → renderer only; no RPC params, stream frames, or published content change, so there is no capability negotiation to do and mixed versions are unaffected.
- **SSH:** the SSH drop path keeps its existing toast and is untouched.
- **Web client:** progress subscribe and cancel are no-ops in the shim.
- **Cross-platform:** no platform branches; no new child processes.
- **Reduced motion:** honoured for both the exit fade and the chevron rotation.

## Tests

38 new tests:

- `runtime-upload-progress.test.ts` — throttling drops updates that are neither big enough nor old enough, always emits the first and last, never moves backwards, and keeps a separate baseline per file.
- `runtime-upload-cancellation.test.ts` — aborts a running upload, aborts the *next* file when cancel lands between two, leaves other uploads alone, stops applying after the drop is forgotten, and does not let a superseded registration evict the live one.
- `runtime-upload-session-state.test.ts` — aggregation by bytes rather than row count, cancelled rows leaving the denominator so the bar can still reach 100%, and a cancelled row surviving a later "failed" report.
- `terminal-drop-upload-progress.test.ts` / `terminal-drop-upload-heading.test.ts` — unit scaling, percent flooring, and every header state.
- `runtime-upload-file-stream.test.ts` — progress is monotonic and ends on the file size; a zero-byte file reports complete; an aborted signal stops before and mid-file.
- `terminal-drop-handler.test.ts` — the panel is published without an explicit `undefined` id, and only the error path tears it down.

## Not in this PR

Pipelined chunks (needs an additive optional `offset` on `files.writeBase64Chunk`), remote free-space preflight, and the terminal half of #9896.

## AI agent review

- **Cross-platform:** no platform-specific code; reduced-motion respected; light and dark both use tokens rather than literals.
- **SSH / remote:** SSH drop path untouched; cancellation aborts locally and never infers remote process state from loss of contact.
- **Agent / integration:** no agent-facing API or CLI change.
- **Performance:** progress events coalesced; no added RPCs; peak memory unchanged from #15987.
- **UI quality:** follows `docs/STYLEGUIDE.md` for colour roles, cancel-is-not-destructive, fixed-width numerics, and elevation; verified in a real Orca window across several rounds of feedback.
- **Security:** cancel only aborts an upload the same client started; a cancelled transfer leaves nothing at the destination because commit happens only after a complete read.

