### PR TITLE
fix(mobile): show SSH labels in Run on picker

### DIFF
--- a/mobile/src/components/NewWorktreeModal.test.tsx
+++ b/mobile/src/components/NewWorktreeModal.test.tsx
@@ -87,6 +87,9 @@ describe('NewWorktreeModal project targets', () => {
       if (method === 'status.get') {
         return Promise.resolve({ ok: true, result: { hostPlatform: 'darwin' } })
       }
+      if (method === 'ssh.listTargetSummaries') {
+        return Promise.resolve({ ok: true, result: { targets: [] } })
+      }
       return new Promise(() => {})
     })
     const client = { sendRequest } as unknown as RpcClient
@@ -136,6 +139,12 @@ describe('NewWorktreeModal project targets', () => {
         if (method === 'status.get') {
           return Promise.resolve({ ok: true, result: { hostPlatform: 'darwin' } })
         }
+        if (method === 'ssh.listTargetSummaries') {
+          return Promise.resolve({
+            ok: true,
+            result: { targets: [{ id: 'build-server', label: 'devbox' }] }
+          })
+        }
         return new Promise(() => {})
       })
     } as unknown as RpcClient
@@ -159,7 +168,7 @@ describe('NewWorktreeModal project targets', () => {
     expect(pickerItems(renderer, 'Run on')).toEqual([
       expect.objectContaining({ label: LOCAL_HOST_LABEL, detail: '/src/orca' }),
       expect.objectContaining({
-        label: 'SSH · build-server',
+        label: 'SSH · devbox',
         detail: '/home/dev/orca'
       })
     ])

--- a/mobile/src/components/NewWorktreeModal.tsx
+++ b/mobile/src/components/NewWorktreeModal.tsx
@@ -68,6 +68,7 @@ import { SmartWorkspaceSourceDrawer } from './SmartWorkspaceSourceDrawer'
 import { SmartWorkspaceAdvancedFields } from './SmartWorkspaceAdvancedFields'
 import { SetupHookTrustDrawer, type SetupTrustPrompt } from './SetupHookTrustDrawer'
 import { NewWorktreeProjectTargetFields } from './NewWorktreeProjectTargetFields'
+import { useMobileSshTargetLabels } from './use-mobile-ssh-target-labels'
 import {
   buildNewWorkspaceProjectOptions,
   buildNewWorkspaceRunTargetOptions,
@@ -227,6 +228,7 @@ function NewWorktreeModalContent({
   const [availableProviders, setAvailableProviders] = useState<TaskProvider[]>([])
   const { tasksSupported, hostPlatform, getWorktreeCreateCutoverSupport } =
     useNewWorktreeRuntimeCapabilities(client, visible)
+  const sshTargetLabels = useMobileSshTargetLabels(client, visible)
   const [showAdvanced, setShowAdvanced] = useState(false)
   const [setupHookDetails, setSetupHookDetails] = useState<SetupHookDetails | null>(null)
   const [trustedOrcaHooks, setTrustedOrcaHooks] = useState<PersistedTrustedOrcaHooks>({})
@@ -727,11 +729,12 @@ function NewWorktreeModalContent({
   const selectedProject =
     projectPickerItems.find((project) => project.id === selectedProjectId) ?? null
   const runTargetPickerItems = useMemo(
-    () => buildNewWorkspaceRunTargetOptions(repos, selectedProjectId, hostPlatform),
-    [hostPlatform, repos, selectedProjectId]
+    () =>
+      buildNewWorkspaceRunTargetOptions(repos, selectedProjectId, hostPlatform, sshTargetLabels),
+    [hostPlatform, repos, selectedProjectId, sshTargetLabels]
   )
   const selectedRunTarget = selectedRepo
-    ? getNewWorkspaceRunTarget(selectedRepo, hostPlatform)
+    ? getNewWorkspaceRunTarget(selectedRepo, hostPlatform, sshTargetLabels)
     : null
 
   function prepareSelectionPickerOpen(): void {

--- a/mobile/src/components/new-workspace-project-targets.test.ts
+++ b/mobile/src/components/new-workspace-project-targets.test.ts
@@ -54,12 +54,16 @@ describe('new workspace project targets', () => {
       getNewWorkspaceRunTarget({ id: 'local', displayName: 'orca', path: 'C:\\src\\orca' }, 'win32')
     ).toEqual({ label: 'Local Windows', detail: 'C:\\src\\orca' })
     expect(
-      getNewWorkspaceRunTarget({
-        id: 'ssh',
-        displayName: 'orca',
-        path: 'C:\\src\\orca',
-        executionHostId: 'ssh:Windows%20VM'
-      })
+      getNewWorkspaceRunTarget(
+        {
+          id: 'ssh',
+          displayName: 'orca',
+          path: 'C:\\src\\orca',
+          executionHostId: 'ssh:ssh-1724000000000-abc123'
+        },
+        null,
+        new Map([['ssh-1724000000000-abc123', 'Windows VM']])
+      )
     ).toEqual({ label: 'SSH · Windows VM', detail: 'C:\\src\\orca' })
     expect(
       getNewWorkspaceRunTarget({
@@ -69,6 +73,17 @@ describe('new workspace project targets', () => {
         executionHostId: 'runtime:devbox'
       })
     ).toEqual({ label: 'Remote · devbox', detail: '/src/orca' })
+  })
+
+  it('falls back to the SSH target id when its label is unavailable', () => {
+    expect(
+      getNewWorkspaceRunTarget({
+        id: 'ssh',
+        displayName: 'orca',
+        path: '/home/dev/orca',
+        connectionId: 'ssh-1724000000000-abc123'
+      })
+    ).toEqual({ label: 'SSH · ssh-1724000000000-abc123', detail: '/home/dev/orca' })
   })
 
   it('shows one target per host when the project has multiple local worktrees', () => {

--- a/mobile/src/components/new-workspace-project-targets.ts
+++ b/mobile/src/components/new-workspace-project-targets.ts
@@ -60,19 +60,20 @@ export function buildNewWorkspaceProjectOptions<TRepo extends WorkspaceRepo>(
 
 export function getNewWorkspaceRunTarget(
   repo: WorkspaceRepo,
-  localPlatform: NodeJS.Platform | null = null
+  localPlatform: NodeJS.Platform | null = null,
+  sshTargetLabels: ReadonlyMap<string, string> = new Map()
 ): {
   label: string
   detail: string
 } {
   const hostId = getRepoExecutionHostId(repo)
   const host = parseExecutionHostId(hostId)
-  const hostLabel = getExecutionHostLabel(hostId)
   if (host?.kind === 'ssh') {
-    return { label: `SSH · ${hostLabel}`, detail: repo.path }
+    const label = sshTargetLabels.get(host.targetId) || getExecutionHostLabel(hostId)
+    return { label: `SSH · ${label}`, detail: repo.path }
   }
   if (host?.kind === 'runtime') {
-    return { label: `Remote · ${hostLabel}`, detail: repo.path }
+    return { label: `Remote · ${getExecutionHostLabel(hostId)}`, detail: repo.path }
   }
   return {
     label: localPlatform ? getLocalExecutionHostLabel(localPlatform) : 'This computer',
@@ -83,7 +84,8 @@ export function getNewWorkspaceRunTarget(
 export function buildNewWorkspaceRunTargetOptions<TRepo extends WorkspaceRepo>(
   repos: readonly TRepo[],
   projectId: string | null,
-  localPlatform: NodeJS.Platform | null = null
+  localPlatform: NodeJS.Platform | null = null,
+  sshTargetLabels: ReadonlyMap<string, string> = new Map()
 ): NewWorkspaceRunTargetOption<TRepo>[] {
   if (!projectId) {
     return []
@@ -97,7 +99,7 @@ export function buildNewWorkspaceRunTargetOptions<TRepo extends WorkspaceRepo>(
     if (!options.has(hostId)) {
       options.set(hostId, {
         id: repo.id,
-        ...getNewWorkspaceRunTarget(repo, localPlatform),
+        ...getNewWorkspaceRunTarget(repo, localPlatform, sshTargetLabels),
         repo
       })
     }

--- a/mobile/src/components/use-mobile-ssh-target-labels.test.ts
+++ b/mobile/src/components/use-mobile-ssh-target-labels.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RpcClient } from '../transport/rpc-client'
+import { readMobileSshTargetLabels } from './use-mobile-ssh-target-labels'
+
+describe('readMobileSshTargetLabels', () => {
+  it('maps target ids to the display labels published by the host', async () => {
+    const client = {
+      sendRequest: vi.fn().mockResolvedValue({
+        ok: true,
+        result: { targets: [{ id: 'ssh-1724000000000-abc123', label: 'devbox' }] }
+      })
+    } as unknown as RpcClient
+
+    await expect(readMobileSshTargetLabels(client)).resolves.toEqual(
+      new Map([['ssh-1724000000000-abc123', 'devbox']])
+    )
+  })
+
+  it('returns an empty map when an older host rejects the method', async () => {
+    const client = {
+      sendRequest: vi.fn().mockRejectedValue(new Error('method not found'))
+    } as unknown as RpcClient
+
+    await expect(readMobileSshTargetLabels(client)).resolves.toEqual(new Map())
+  })
+})

--- a/mobile/src/components/use-mobile-ssh-target-labels.ts
+++ b/mobile/src/components/use-mobile-ssh-target-labels.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react'
+import type { SshTargetSummary } from '../../../src/shared/ssh-types'
+import type { RpcClient } from '../transport/rpc-client'
+import type { RpcSuccess } from '../transport/types'
+
+const EMPTY_SSH_TARGET_LABELS: ReadonlyMap<string, string> = new Map()
+
+export async function readMobileSshTargetLabels(
+  client: RpcClient
+): Promise<ReadonlyMap<string, string>> {
+  try {
+    const response = await client.sendRequest('ssh.listTargetSummaries')
+    if (!response.ok) {
+      return EMPTY_SSH_TARGET_LABELS
+    }
+    const { targets } = (response as RpcSuccess).result as { targets?: SshTargetSummary[] }
+    return new Map(
+      (targets ?? [])
+        .map(({ id, label }) => [id.trim(), label.trim()] as const)
+        .filter(([id, label]) => id.length > 0 && label.length > 0)
+    )
+  } catch {
+    return EMPTY_SSH_TARGET_LABELS
+  }
+}
+
+export function useMobileSshTargetLabels(
+  client: RpcClient | null,
+  enabled: boolean
+): ReadonlyMap<string, string> {
+  const [loaded, setLoaded] = useState<{
+    client: RpcClient
+    labels: ReadonlyMap<string, string>
+  } | null>(null)
+
+  useEffect(() => {
+    if (!client || !enabled) {
+      return
+    }
+    let stale = false
+    void readMobileSshTargetLabels(client).then((nextLabels) => {
+      if (!stale) {
+        setLoaded({ client, labels: nextLabels })
+      }
+    })
+    return () => {
+      stale = true
+    }
+  }, [client, enabled])
+
+  return enabled && loaded?.client === client ? loaded.labels : EMPTY_SSH_TARGET_LABELS
+}


### PR DESCRIPTION
## ELI5

Mobile now shows the recognizable SSH name from the user's SSH configuration in the Create Workspace `Run on` picker, matching desktop, instead of exposing Orca's generated target ID.

## What Changed

- Load the host-published SSH target summaries when the mobile Create Workspace modal is open.
- Resolve SSH execution target IDs to their display labels in both the picker options and selected value.
- Keep the existing target-ID fallback when an older host does not support the summary RPC or the lookup fails.
- Add unit and component coverage for label resolution and compatibility fallback.

## Why

SSH config imports keep the `Host` alias as the target label, but mobile previously formatted only the generated target ID. Reusing the existing safe summary RPC makes mobile consistent with desktop without exposing full SSH target configuration or changing the remote wire contract.

## Linked Issue

Fixes #16114

## Visual Proof

Captured on the same Dora Android 12 (API 31, ARM64) device with the same project and execution-target fixtures. Only the server's `ssh.listTargetSummaries` response changes between captures.

| Before: generated target ID | After: SSH config alias |
| --- | --- |
| ![Before: Run on shows SSH internal target ID](https://github.com/user-attachments/assets/affbb865-57c4-4e7a-bdd8-82dfbb8d31fd) | ![After: Run on shows devbox SSH alias](https://github.com/user-attachments/assets/10f9746e-d60a-4735-8d38-34d69db5677b) |

## Testing

- Live Dora Android 12 / API 31 / ARM64 verification with a self-contained release APK: before showed `SSH · ssh-1724000000000-abc123`; after showed `SSH · devbox`; both resolved the same `/home/dev/orca` execution path.
- `pnpm --dir mobile exec vitest run --root .. mobile/src/components/new-workspace-project-targets.test.ts mobile/src/components/use-mobile-ssh-target-labels.test.ts mobile/src/components/NewWorktreeModal.test.tsx` — 3 files, 9 tests passed.
- Full mobile test suite — 459 files passed; 3,676 tests passed and 3 skipped.
- Mobile typecheck passed.
- `pnpm run check:code-quality:changed -- upstream/main` — passed with 0 findings across 6 files.
- `pnpm run check:react-doctor:changed -- upstream/main` — passed with 0 issues across 6 files.
- `pnpm run check:max-lines-ratchet -- upstream/main` — passed.
- `git diff --check` — passed.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- No RPC/schema changes. The implementation uses the existing host-safe `ssh.listTargetSummaries` method.
- Mixed-version behavior is preserved: unsupported/failed summary requests fall back to the existing target ID.
- No OS-specific logic or path handling changed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
