### PR TITLE
test(serve): characterize renderer death containment

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2379,8 +2379,8 @@
         "https://github.com/stablyai/orca/issues/16084",
         "https://github.com/stablyai/orca/pull/16120"
       ],
-      "invariant": "Killing one exact offscreen Chromium renderer cannot replace or terminate the headless main process, runtime, daemon, or unrelated daemon-backed PTYs during the immediate fault or the reported nine-second incident interval. The complete host terminal tab-to-PTY inventory remains identical to baseline, and both original PTY processes continue accepting input.",
-      "oracle": "Start an isolated headless serve runtime with zero initial BrowserWindows, create two daemon-backed terminal fixtures, and record main, runtime, daemon, complete terminal tab-to-PTY inventory, fixture-process, WebContents, and renderer-process identities. Fence one marked offscreen page by WebContents, URL, and OS process, force that renderer to crash, and require its original process to die. Observe beyond the reported nine-second renderer-victim-to-unit-failure interval while repeatedly requiring no main-process close, unchanged main/runtime/daemon identities, an unchanged complete host terminal inventory, and I/O through both original fixture processes.",
+      "invariant": "Killing one exact offscreen Chromium renderer cannot replace or terminate the headless main process, runtime, daemon, or unrelated daemon-backed PTYs during the immediate fault or the reported nine-second incident interval. Every terminal surface binding in the isolated fixture worktree remains identical to baseline by surface, parent-tab, leaf, and PTY identity, and both original PTY processes continue accepting input.",
+      "oracle": "Start an isolated headless serve runtime with zero initial BrowserWindows, create two daemon-backed terminal fixtures, and record main, runtime, daemon, every fixture-worktree terminal surface binding, fixture-process, WebContents, and renderer-process identities. Fence one marked offscreen page by WebContents, URL, and OS process, force that renderer to crash, and require its original process to die. Observe beyond the reported nine-second renderer-victim-to-unit-failure interval while repeatedly requiring no main-process close, unchanged main/runtime/daemon identities, unchanged exact surface-parent-leaf-PTY tuples in the fixture worktree, and I/O through both original fixture processes.",
       "commands": [
         "pnpm exec electron-vite build --mode e2e",
         "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/headless-serve-renderer-kill-retention.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1"
@@ -2392,7 +2392,7 @@
           "assertions": [
             "the exact original renderer process dies after the fenced WebContents fault",
             "main, runtime, and daemon identities remain unchanged and reachable",
-            "the complete host terminal tab-to-PTY inventory remains identical to baseline",
+            "every fixture-worktree terminal surface-parent-leaf-PTY binding remains identical to baseline",
             "both original PTY processes accept post-fault input"
           ]
         }
@@ -2404,8 +2404,8 @@
           "platform": "macos",
           "command": "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/headless-serve-renderer-kill-retention.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
           "result": "passed",
-          "durationSeconds": 33,
-          "summary": "The exact offscreen renderer process died while the headless main process, runtime, daemon, complete baseline terminal tab-to-PTY inventory, and both original PTY processes remained live; repeated stability checkpoints beyond the reported nine-second interval retained post-fault I/O."
+          "durationSeconds": 34,
+          "summary": "The exact offscreen renderer process died while the headless main process, runtime, daemon, every baseline terminal surface binding in the fixture worktree, and both original PTY processes remained live; repeated stability checkpoints beyond the reported nine-second interval retained post-fault I/O."
         }
       ],
       "runtimeBudget": {
@@ -2418,7 +2418,7 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "The earlier immediate-containment oracle passed on reported v1.4.184 and then-current main e3327c2f31: renderer-only death did not reproduce runtime or session loss in the isolated host topology. The final candidate, rebased onto main ab3b1d07cd, adds complete-inventory checks through a 12-second stability window; that extension has candidate evidence only. The process or event that ended the reported unit remains unidentified. Reverting the candidate removes the characterization coverage without changing product behavior."
+        "evidence": "The earlier immediate-containment oracle passed on reported v1.4.184 and then-current main e3327c2f31: renderer-only death did not reproduce runtime or session loss in the isolated host topology. The final candidate, rebased onto main 0926c25854, adds exact fixture-worktree surface-binding checks through a 12-second stability window; that extension has candidate evidence only. The process or event that ended the reported unit remains unidentified. Reverting the candidate removes the characterization coverage without changing product behavior."
       },
       "performanceBudget": {
         "required": false,
@@ -2435,7 +2435,7 @@
         "The test does not require the crashed browser surface to recover; browser-page recovery is a separate lifecycle contract.",
         "SSH, WSL, folder-workspace, multi-client, mixed-version, and whole-service restart journeys are uncollected; no production or wire behavior changes in this gate."
       ],
-      "demotionRule": "Demote if the exact renderer fault changes main/runtime/daemon identity, changes the complete terminal tab-to-PTY inventory, replaces either fixture process, loses post-fault PTY I/O, or cannot identify the killed renderer unambiguously."
+      "demotionRule": "Demote if the exact renderer fault changes main/runtime/daemon identity, changes any terminal surface-parent-leaf-PTY tuple in the fixture worktree, replaces either fixture process, loses post-fault PTY I/O, or cannot identify the killed renderer unambiguously."
     },
     {
       "id": "runtime.websocket-heartbeat-cadence",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2418,7 +2418,7 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "The byte-identical oracle passes on reported v1.4.184 and current main: renderer-only death did not reproduce runtime or session loss in the isolated host topology. The process or event that ended the reported unit remains unidentified. The candidate adds characterization coverage only; reverting it removes the oracle without changing product behavior."
+        "evidence": "The earlier immediate-containment oracle passed on reported v1.4.184 and current main: renderer-only death did not reproduce runtime or session loss in the isolated host topology. The final candidate adds repeated checks through a 12-second stability window; that extension has candidate evidence only. The process or event that ended the reported unit remains unidentified. Reverting the candidate removes the characterization coverage without changing product behavior."
       },
       "performanceBudget": {
         "required": false,

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2379,8 +2379,8 @@
         "https://github.com/stablyai/orca/issues/16084",
         "https://github.com/stablyai/orca/pull/16120"
       ],
-      "invariant": "Killing one exact offscreen Chromium renderer cannot replace or terminate the headless main process, runtime, daemon, or unrelated daemon-backed PTYs during the immediate fault or the reported nine-second incident interval. The host session inventory retains each original tab-to-PTY binding, and both original PTY processes continue accepting input.",
-      "oracle": "Start an isolated headless serve runtime with zero initial BrowserWindows, create two daemon-backed terminal fixtures, and record main, runtime, daemon, tab, PTY, fixture-process, WebContents, and renderer-process identities. Fence one marked offscreen page by WebContents, URL, and OS process, force that renderer to crash, and require its original process to die. Observe beyond the reported nine-second renderer-victim-to-unit-failure interval while repeatedly requiring no main-process close, unchanged main/runtime/daemon identities, both host tab-to-PTY bindings, and I/O through both original fixture processes.",
+      "invariant": "Killing one exact offscreen Chromium renderer cannot replace or terminate the headless main process, runtime, daemon, or unrelated daemon-backed PTYs during the immediate fault or the reported nine-second incident interval. The complete host terminal tab-to-PTY inventory remains identical to baseline, and both original PTY processes continue accepting input.",
+      "oracle": "Start an isolated headless serve runtime with zero initial BrowserWindows, create two daemon-backed terminal fixtures, and record main, runtime, daemon, complete terminal tab-to-PTY inventory, fixture-process, WebContents, and renderer-process identities. Fence one marked offscreen page by WebContents, URL, and OS process, force that renderer to crash, and require its original process to die. Observe beyond the reported nine-second renderer-victim-to-unit-failure interval while repeatedly requiring no main-process close, unchanged main/runtime/daemon identities, an unchanged complete host terminal inventory, and I/O through both original fixture processes.",
       "commands": [
         "pnpm exec electron-vite build --mode e2e",
         "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/headless-serve-renderer-kill-retention.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1"
@@ -2392,7 +2392,7 @@
           "assertions": [
             "the exact original renderer process dies after the fenced WebContents fault",
             "main, runtime, and daemon identities remain unchanged and reachable",
-            "both original host tab-to-PTY bindings remain published",
+            "the complete host terminal tab-to-PTY inventory remains identical to baseline",
             "both original PTY processes accept post-fault input"
           ]
         }
@@ -2405,7 +2405,7 @@
           "command": "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/headless-serve-renderer-kill-retention.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
           "result": "passed",
           "durationSeconds": 33,
-          "summary": "The exact offscreen renderer process died while the headless main process, runtime, daemon, both original host tab-to-PTY bindings, and both original PTY processes remained live; repeated stability checkpoints beyond the reported nine-second interval retained post-fault I/O."
+          "summary": "The exact offscreen renderer process died while the headless main process, runtime, daemon, complete baseline terminal tab-to-PTY inventory, and both original PTY processes remained live; repeated stability checkpoints beyond the reported nine-second interval retained post-fault I/O."
         }
       ],
       "runtimeBudget": {
@@ -2418,7 +2418,7 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "The earlier immediate-containment oracle passed on reported v1.4.184 and current main: renderer-only death did not reproduce runtime or session loss in the isolated host topology. The final candidate adds repeated checks through a 12-second stability window; that extension has candidate evidence only. The process or event that ended the reported unit remains unidentified. Reverting the candidate removes the characterization coverage without changing product behavior."
+        "evidence": "The earlier immediate-containment oracle passed on reported v1.4.184 and then-current main e3327c2f31: renderer-only death did not reproduce runtime or session loss in the isolated host topology. The final candidate, rebased onto main ab3b1d07cd, adds complete-inventory checks through a 12-second stability window; that extension has candidate evidence only. The process or event that ended the reported unit remains unidentified. Reverting the candidate removes the characterization coverage without changing product behavior."
       },
       "performanceBudget": {
         "required": false,
@@ -2435,7 +2435,7 @@
         "The test does not require the crashed browser surface to recover; browser-page recovery is a separate lifecycle contract.",
         "SSH, WSL, folder-workspace, multi-client, mixed-version, and whole-service restart journeys are uncollected; no production or wire behavior changes in this gate."
       ],
-      "demotionRule": "Demote if the exact renderer fault changes main/runtime/daemon identity, removes either tab-to-PTY binding, replaces either fixture process, loses post-fault PTY I/O, or cannot identify the killed renderer unambiguously."
+      "demotionRule": "Demote if the exact renderer fault changes main/runtime/daemon identity, changes the complete terminal tab-to-PTY inventory, replaces either fixture process, loses post-fault PTY I/O, or cannot identify the killed renderer unambiguously."
     },
     {
       "id": "runtime.websocket-heartbeat-cadence",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -2370,17 +2370,17 @@
       "layer": "electron-process-containment",
       "surfaces": ["headless orca serve", "offscreen browser page", "daemon-backed PTYs"],
       "platforms": ["macos", "linux", "windows"],
-      "providers": ["local", "daemon"],
+      "providers": ["daemon"],
       "coveredPlatforms": ["macos"],
-      "coveredProviders": ["local", "daemon"],
+      "coveredProviders": ["daemon"],
       "coverageNotes": "An isolated headless serve host creates two daemon-backed terminal sessions and one offscreen browser renderer. Exact WebContents and OS-process fencing prevents a fault from reaching an unrelated process. The oracle is host-local and does not claim paired-viewer continuity, renderer reload, systemd cgroup restart persistence, SSH or WSL coverage, or aggregate memory policy.",
       "motivatingLinks": [
         "https://linear.app/stably/issue/STA-5228",
         "https://github.com/stablyai/orca/issues/16084",
         "https://github.com/stablyai/orca/pull/16120"
       ],
-      "invariant": "Killing one exact offscreen Chromium renderer cannot replace or terminate the headless main process, runtime, daemon, or unrelated daemon-backed PTYs. The host session inventory retains each original tab-to-PTY binding, and both original PTY processes continue accepting input.",
-      "oracle": "Start an isolated headless serve runtime with zero initial BrowserWindows, create two daemon-backed terminal fixtures, and record main, runtime, daemon, tab, PTY, fixture-process, WebContents, and renderer-process identities. Fence one marked offscreen page by WebContents, URL, and OS process, force that renderer to crash, and require its original process to die while main/runtime/daemon identities, both host tab-to-PTY bindings, and I/O through both original fixture processes remain unchanged.",
+      "invariant": "Killing one exact offscreen Chromium renderer cannot replace or terminate the headless main process, runtime, daemon, or unrelated daemon-backed PTYs during the immediate fault or the reported nine-second incident interval. The host session inventory retains each original tab-to-PTY binding, and both original PTY processes continue accepting input.",
+      "oracle": "Start an isolated headless serve runtime with zero initial BrowserWindows, create two daemon-backed terminal fixtures, and record main, runtime, daemon, tab, PTY, fixture-process, WebContents, and renderer-process identities. Fence one marked offscreen page by WebContents, URL, and OS process, force that renderer to crash, and require its original process to die. Observe beyond the reported nine-second renderer-victim-to-unit-failure interval while repeatedly requiring no main-process close, unchanged main/runtime/daemon identities, both host tab-to-PTY bindings, and I/O through both original fixture processes.",
       "commands": [
         "pnpm exec electron-vite build --mode e2e",
         "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/headless-serve-renderer-kill-retention.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1"
@@ -2404,13 +2404,13 @@
           "platform": "macos",
           "command": "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/headless-serve-renderer-kill-retention.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
           "result": "passed",
-          "durationSeconds": 31,
-          "summary": "The exact offscreen renderer process died while the headless main process, runtime, daemon, both original host tab-to-PTY bindings, and both original PTY processes remained live; both PTYs accepted post-fault input."
+          "durationSeconds": 33,
+          "summary": "The exact offscreen renderer process died while the headless main process, runtime, daemon, both original host tab-to-PTY bindings, and both original PTY processes remained live; repeated stability checkpoints beyond the reported nine-second interval retained post-fault I/O."
         }
       ],
       "runtimeBudget": {
         "p95Seconds": 60,
-        "scope": "one isolated headless Electron host, one offscreen renderer fault, and two daemon-backed PTY fixtures"
+        "scope": "one isolated headless Electron host, one offscreen renderer fault, two daemon-backed PTY fixtures, and a 12-second stability window"
       },
       "flakeHistory": {
         "status": "unknown",
@@ -2418,7 +2418,7 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "The byte-identical oracle passes on reported v1.4.184 and current main, falsifying renderer-only death as the cause of runtime/session loss. The candidate adds characterization coverage only; reverting it removes the oracle without changing product behavior."
+        "evidence": "The byte-identical oracle passes on reported v1.4.184 and current main: renderer-only death did not reproduce runtime or session loss in the isolated host topology. The process or event that ended the reported unit remains unidentified. The candidate adds characterization coverage only; reverting it removes the oracle without changing product behavior."
       },
       "performanceBudget": {
         "required": false,

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-20",
+  "updatedAt": "2026-08-23",
   "policy": {
     "maturityLevels": ["experimental", "soak", "blocking", "accepted-gap", "deprecated"],
     "blockingPromotion": {
@@ -2360,6 +2360,82 @@
         "No mixed-version live run is required because rendererGeneration is confined to same-version preload/main Electron IPC and the remote runtime wire is unchanged."
       ],
       "demotionRule": "Demote if a reload revision settles more than once, a stale document or competing window can publish, a timer survives settlement, desktop failure stays indefinitely reloading, headless fallback returns after successful promotion, or either isolated Electron journey loses runtime or PTY identity."
+    },
+    {
+      "id": "runtime.headless-renderer-process-containment",
+      "title": "Headless renderer process death stays isolated from runtime-owned PTYs",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "runtime-platform",
+      "layer": "electron-process-containment",
+      "surfaces": ["headless orca serve", "offscreen browser page", "daemon-backed PTYs"],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["local", "daemon"],
+      "coverageNotes": "An isolated headless serve host creates two daemon-backed terminal sessions and one offscreen browser renderer. Exact WebContents and OS-process fencing prevents a fault from reaching an unrelated process. The oracle is host-local and does not claim paired-viewer continuity, renderer reload, systemd cgroup restart persistence, SSH or WSL coverage, or aggregate memory policy.",
+      "motivatingLinks": [
+        "https://linear.app/stably/issue/STA-5228",
+        "https://github.com/stablyai/orca/issues/16084",
+        "https://github.com/stablyai/orca/pull/16120"
+      ],
+      "invariant": "Killing one exact offscreen Chromium renderer cannot replace or terminate the headless main process, runtime, daemon, or unrelated daemon-backed PTYs. The host session inventory retains each original tab-to-PTY binding, and both original PTY processes continue accepting input.",
+      "oracle": "Start an isolated headless serve runtime with zero initial BrowserWindows, create two daemon-backed terminal fixtures, and record main, runtime, daemon, tab, PTY, fixture-process, WebContents, and renderer-process identities. Fence one marked offscreen page by WebContents, URL, and OS process, force that renderer to crash, and require its original process to die while main/runtime/daemon identities, both host tab-to-PTY bindings, and I/O through both original fixture processes remain unchanged.",
+      "commands": [
+        "pnpm exec electron-vite build --mode e2e",
+        "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/headless-serve-renderer-kill-retention.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1"
+      ],
+      "testFiles": ["tests/e2e/headless-serve-renderer-kill-retention.spec.ts"],
+      "assertionRefs": [
+        {
+          "file": "tests/e2e/headless-serve-renderer-kill-retention.spec.ts",
+          "assertions": [
+            "the exact original renderer process dies after the fenced WebContents fault",
+            "main, runtime, and daemon identities remain unchanged and reachable",
+            "both original host tab-to-PTY bindings remain published",
+            "both original PTY processes accept post-fault input"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-08-23",
+          "runner": "local",
+          "platform": "macos",
+          "command": "SKIP_BUILD=1 pnpm exec playwright test tests/e2e/headless-serve-renderer-kill-retention.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
+          "result": "passed",
+          "durationSeconds": 31,
+          "summary": "The exact offscreen renderer process died while the headless main process, runtime, daemon, both original host tab-to-PTY bindings, and both original PTY processes remained live; both PTYs accepted post-fault input."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 60,
+        "scope": "one isolated headless Electron host, one offscreen renderer fault, and two daemon-backed PTY fixtures"
+      },
+      "flakeHistory": {
+        "status": "unknown",
+        "evidence": "Fresh local macOS runs are green; CI and cross-platform soak history are not yet available."
+      },
+      "redGreenEvidence": {
+        "status": "partial",
+        "evidence": "The byte-identical oracle passes on reported v1.4.184 and current main, falsifying renderer-only death as the cause of runtime/session loss. The candidate adds characterization coverage only; reverting it removes the oracle without changing product behavior."
+      },
+      "performanceBudget": {
+        "required": false,
+        "evidence": "The change adds test and gate metadata only. Production startup, fault handling, session inventory, and PTY hot paths are unchanged."
+      },
+      "promotionCriteria": [
+        "Pass the changed-spec Ubuntu/Xvfb PR lane.",
+        "Collect at least 100 consecutive CI or soak passes or 14 days without an unexplained flake.",
+        "Add Windows containment evidence if Electron process behavior diverges."
+      ],
+      "knownGaps": [
+        "The fault is an exact WebContents renderer crash, not kernel OOM victim selection or systemd cgroup failure.",
+        "The host-local runtime client proves control-plane reachability but not a separate paired viewer, reconnect, or replay path.",
+        "The test does not require the crashed browser surface to recover; browser-page recovery is a separate lifecycle contract.",
+        "SSH, WSL, folder-workspace, multi-client, mixed-version, and whole-service restart journeys are uncollected; no production or wire behavior changes in this gate."
+      ],
+      "demotionRule": "Demote if the exact renderer fault changes main/runtime/daemon identity, removes either tab-to-PTY binding, replaces either fixture process, loses post-fault PTY I/O, or cannot identify the killed renderer unambiguously."
     },
     {
       "id": "runtime.websocket-heartbeat-cadence",

--- a/tests/e2e/headless-serve-renderer-kill-retention.spec.ts
+++ b/tests/e2e/headless-serve-renderer-kill-retention.spec.ts
@@ -13,6 +13,7 @@ import {
 import { launchHeadlessPairedRuntimeHost } from './helpers/headless-paired-runtime-host'
 import {
   processIdentityIsAlive,
+  processIdentityLiveness,
   recordProcessIdentity
 } from './helpers/daemon-generation-processes'
 
@@ -118,11 +119,12 @@ test('STA-5228 renderer death keeps headless runtime and PTYs alive', async ({ t
     )
     const proveHostState = async (marker: string): Promise<void> => {
       const status = await launchedHost.client.call<RuntimeStatus>('status.get')
+      const processLiveness = await processIdentityLiveness([mainIdentity, daemonIdentity])
       expect(await launchedHost.app.evaluate(() => process.pid)).toBe(mainPid)
-      expect(await processIdentityIsAlive(mainIdentity)).toBe(true)
+      expect(processLiveness.get(mainPid)).toBe(true)
       expect(status.result.runtimeId).toBe(beforeStatus.result.runtimeId)
       expect(readDaemonPid(userDataDir)).toBe(daemonPid)
-      expect(await processIdentityIsAlive(daemonIdentity)).toBe(true)
+      expect(processLiveness.get(daemonPid)).toBe(true)
       const inventory = await readHostTerminalInventory(call, worktreeId)
       expect(inventory.ptyIdByTabId[terminalA.tabId]).toBe(terminalA.ptyId)
       expect(inventory.ptyIdByTabId[terminalB.tabId]).toBe(terminalB.ptyId)

--- a/tests/e2e/headless-serve-renderer-kill-retention.spec.ts
+++ b/tests/e2e/headless-serve-renderer-kill-retention.spec.ts
@@ -25,6 +25,9 @@ type RendererIdentity = {
   webContentsId: number
 }
 
+const INCIDENT_OBSERVATION_MS = 12_000
+const INCIDENT_CHECKPOINT_MS = 3_000
+
 function readDaemonPid(userDataDir: string): number {
   const raw = readFileSync(
     path.join(userDataDir, 'daemon', `daemon-v${PROTOCOL_VERSION}.pid`),
@@ -113,11 +116,20 @@ test('STA-5228 renderer death keeps headless runtime and PTYs alive', async ({ t
       fixturePath,
       path.join(scratch, 'pty-b.log')
     )
-    await proveSameLivePty(call, terminalA, 'BEFORE_RENDERER_KILL_A')
-    await proveSameLivePty(call, terminalB, 'BEFORE_RENDERER_KILL_B')
-    const beforeInventory = await readHostTerminalInventory(call, worktreeId)
-    expect(beforeInventory.ptyIdByTabId[terminalA.tabId]).toBe(terminalA.ptyId)
-    expect(beforeInventory.ptyIdByTabId[terminalB.tabId]).toBe(terminalB.ptyId)
+    const proveHostState = async (marker: string): Promise<void> => {
+      const status = await launchedHost.client.call<RuntimeStatus>('status.get')
+      expect(await launchedHost.app.evaluate(() => process.pid)).toBe(mainPid)
+      expect(await processIdentityIsAlive(mainIdentity)).toBe(true)
+      expect(status.result.runtimeId).toBe(beforeStatus.result.runtimeId)
+      expect(readDaemonPid(userDataDir)).toBe(daemonPid)
+      expect(await processIdentityIsAlive(daemonIdentity)).toBe(true)
+      const inventory = await readHostTerminalInventory(call, worktreeId)
+      expect(inventory.ptyIdByTabId[terminalA.tabId]).toBe(terminalA.ptyId)
+      expect(inventory.ptyIdByTabId[terminalB.tabId]).toBe(terminalB.ptyId)
+      await proveSameLivePty(call, terminalA, `${marker}_A`)
+      await proveSameLivePty(call, terminalB, `${marker}_B`)
+    }
+    await proveHostState('BEFORE_RENDERER_KILL')
 
     const pageId = `sta-5228-${Date.now()}`
     const markerUrl = `data:text/html,${encodeURIComponent(
@@ -161,6 +173,10 @@ test('STA-5228 renderer death keeps headless runtime and PTYs alive', async ({ t
         '--type=renderer'
       )
     }
+    let hostClosed = false
+    launchedHost.app.once('close', () => {
+      hostClosed = true
+    })
     await launchedHost.app.evaluate(
       ({ BrowserWindow }, expected) => {
         const win = BrowserWindow.getAllWindows().find(
@@ -208,17 +224,17 @@ test('STA-5228 renderer death keeps headless runtime and PTYs alive', async ({ t
       })
       .toBe(false)
 
-    const afterStatus = await launchedHost.client.call<RuntimeStatus>('status.get')
-    expect(await launchedHost.app.evaluate(() => process.pid)).toBe(mainPid)
-    expect(await processIdentityIsAlive(mainIdentity)).toBe(true)
-    expect(afterStatus.result.runtimeId).toBe(beforeStatus.result.runtimeId)
-    expect(readDaemonPid(userDataDir)).toBe(daemonPid)
-    expect(await processIdentityIsAlive(daemonIdentity)).toBe(true)
-    await proveSameLivePty(call, terminalA, 'AFTER_RENDERER_KILL_A')
-    await proveSameLivePty(call, terminalB, 'AFTER_RENDERER_KILL_B')
-    const afterInventory = await readHostTerminalInventory(call, worktreeId)
-    expect(afterInventory.ptyIdByTabId[terminalA.tabId]).toBe(terminalA.ptyId)
-    expect(afterInventory.ptyIdByTabId[terminalB.tabId]).toBe(terminalB.ptyId)
+    await proveHostState('AFTER_RENDERER_KILL')
+    const observationDeadline = Date.now() + INCIDENT_OBSERVATION_MS
+    let checkpoint = 0
+    do {
+      await new Promise((resolve) => setTimeout(resolve, INCIDENT_CHECKPOINT_MS))
+      expect(
+        hostClosed,
+        'headless main exited during the incident-derived observation window'
+      ).toBe(false)
+      await proveHostState(`STABILITY_${checkpoint++}`)
+    } while (Date.now() < observationDeadline)
 
     const afterRenderer = await readOffscreenRenderer(launchedHost.app, pageId, false)
     console.log('[STA-5228] renderer lifecycle snapshot', {
@@ -227,7 +243,8 @@ test('STA-5228 renderer death keeps headless runtime and PTYs alive', async ({ t
       daemonPid,
       mainPid,
       ptyIds: [terminalA.ptyId, terminalB.ptyId],
-      runtimeId: beforeStatus.result.runtimeId
+      runtimeId: beforeStatus.result.runtimeId,
+      stabilityCheckpoints: checkpoint
     })
   } finally {
     try {

--- a/tests/e2e/headless-serve-renderer-kill-retention.spec.ts
+++ b/tests/e2e/headless-serve-renderer-kill-retention.spec.ts
@@ -129,8 +129,7 @@ test('STA-5228 renderer death keeps headless runtime and PTYs alive', async ({ t
       expect(readDaemonPid(userDataDir)).toBe(daemonPid)
       expect(processLiveness.get(daemonPid)).toBe(true)
       const inventory = await readHostTerminalInventory(call, worktreeId)
-      expect(inventory.tabIds.toSorted()).toEqual(baselineInventory.tabIds.toSorted())
-      expect(inventory.ptyIdByTabId).toEqual(baselineInventory.ptyIdByTabId)
+      expect(inventory.terminalSurfaces).toEqual(baselineInventory.terminalSurfaces)
       await proveSameLivePty(call, terminalA, `${marker}_A`)
       await proveSameLivePty(call, terminalB, `${marker}_B`)
     }

--- a/tests/e2e/headless-serve-renderer-kill-retention.spec.ts
+++ b/tests/e2e/headless-serve-renderer-kill-retention.spec.ts
@@ -7,6 +7,7 @@ import { expect, test } from './helpers/orca-app'
 import {
   createHostCliTerminal,
   proveSameLivePty,
+  readHostTerminalInventory,
   writeRetentionFixture
 } from './helpers/host-created-terminal-retention-oracle'
 import { launchHeadlessPairedRuntimeHost } from './helpers/headless-paired-runtime-host'
@@ -114,6 +115,9 @@ test('STA-5228 renderer death keeps headless runtime and PTYs alive', async ({ t
     )
     await proveSameLivePty(call, terminalA, 'BEFORE_RENDERER_KILL_A')
     await proveSameLivePty(call, terminalB, 'BEFORE_RENDERER_KILL_B')
+    const beforeInventory = await readHostTerminalInventory(call, worktreeId)
+    expect(beforeInventory.ptyIdByTabId[terminalA.tabId]).toBe(terminalA.ptyId)
+    expect(beforeInventory.ptyIdByTabId[terminalB.tabId]).toBe(terminalB.ptyId)
 
     const pageId = `sta-5228-${Date.now()}`
     const markerUrl = `data:text/html,${encodeURIComponent(
@@ -212,13 +216,11 @@ test('STA-5228 renderer death keeps headless runtime and PTYs alive', async ({ t
     expect(await processIdentityIsAlive(daemonIdentity)).toBe(true)
     await proveSameLivePty(call, terminalA, 'AFTER_RENDERER_KILL_A')
     await proveSameLivePty(call, terminalB, 'AFTER_RENDERER_KILL_B')
+    const afterInventory = await readHostTerminalInventory(call, worktreeId)
+    expect(afterInventory.ptyIdByTabId[terminalA.tabId]).toBe(terminalA.ptyId)
+    expect(afterInventory.ptyIdByTabId[terminalB.tabId]).toBe(terminalB.ptyId)
 
     const afterRenderer = await readOffscreenRenderer(launchedHost.app, pageId, false)
-    expect(afterRenderer).toMatchObject({
-      crashed: true,
-      pid: 0,
-      webContentsId: renderer.webContentsId
-    })
     console.log('[STA-5228] renderer lifecycle snapshot', {
       afterRenderer,
       beforeRenderer: renderer,

--- a/tests/e2e/headless-serve-renderer-kill-retention.spec.ts
+++ b/tests/e2e/headless-serve-renderer-kill-retention.spec.ts
@@ -117,6 +117,9 @@ test('STA-5228 renderer death keeps headless runtime and PTYs alive', async ({ t
       fixturePath,
       path.join(scratch, 'pty-b.log')
     )
+    const baselineInventory = await readHostTerminalInventory(call, worktreeId)
+    expect(baselineInventory.ptyIdByTabId[terminalA.tabId]).toBe(terminalA.ptyId)
+    expect(baselineInventory.ptyIdByTabId[terminalB.tabId]).toBe(terminalB.ptyId)
     const proveHostState = async (marker: string): Promise<void> => {
       const status = await launchedHost.client.call<RuntimeStatus>('status.get')
       const processLiveness = await processIdentityLiveness([mainIdentity, daemonIdentity])
@@ -126,8 +129,8 @@ test('STA-5228 renderer death keeps headless runtime and PTYs alive', async ({ t
       expect(readDaemonPid(userDataDir)).toBe(daemonPid)
       expect(processLiveness.get(daemonPid)).toBe(true)
       const inventory = await readHostTerminalInventory(call, worktreeId)
-      expect(inventory.ptyIdByTabId[terminalA.tabId]).toBe(terminalA.ptyId)
-      expect(inventory.ptyIdByTabId[terminalB.tabId]).toBe(terminalB.ptyId)
+      expect(inventory.tabIds.toSorted()).toEqual(baselineInventory.tabIds.toSorted())
+      expect(inventory.ptyIdByTabId).toEqual(baselineInventory.ptyIdByTabId)
       await proveSameLivePty(call, terminalA, `${marker}_A`)
       await proveSameLivePty(call, terminalB, `${marker}_B`)
     }

--- a/tests/e2e/headless-serve-renderer-kill-retention.spec.ts
+++ b/tests/e2e/headless-serve-renderer-kill-retention.spec.ts
@@ -1,0 +1,237 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { PROTOCOL_VERSION } from '../../src/main/daemon/types'
+import type { RuntimeStatus } from '../../src/shared/runtime-types'
+import { expect, test } from './helpers/orca-app'
+import {
+  createHostCliTerminal,
+  proveSameLivePty,
+  writeRetentionFixture
+} from './helpers/host-created-terminal-retention-oracle'
+import { launchHeadlessPairedRuntimeHost } from './helpers/headless-paired-runtime-host'
+import {
+  processIdentityIsAlive,
+  recordProcessIdentity
+} from './helpers/daemon-generation-processes'
+
+type RendererIdentity = {
+  crashed: boolean
+  destroyed: boolean
+  marker: string | null
+  pid: number
+  url: string
+  webContentsId: number
+}
+
+function readDaemonPid(userDataDir: string): number {
+  const raw = readFileSync(
+    path.join(userDataDir, 'daemon', `daemon-v${PROTOCOL_VERSION}.pid`),
+    'utf8'
+  )
+  const parsed = JSON.parse(raw) as { pid?: unknown }
+  if (typeof parsed.pid !== 'number') {
+    throw new Error(`Daemon pid file did not contain a numeric pid: ${raw}`)
+  }
+  return parsed.pid
+}
+
+async function readOffscreenRenderer(
+  app: Awaited<ReturnType<typeof launchHeadlessPairedRuntimeHost>>['app'],
+  pageId: string,
+  readMarker = true
+): Promise<RendererIdentity | null> {
+  return app.evaluate(
+    async ({ BrowserWindow }, { readMarker, targetPageId }) => {
+      const win = BrowserWindow.getAllWindows().find((candidate) =>
+        candidate.webContents.getURL().includes(targetPageId)
+      )
+      if (!win) {
+        return null
+      }
+      let marker: string | null = null
+      if (readMarker && !win.webContents.isCrashed() && !win.webContents.isDestroyed()) {
+        try {
+          marker = (await win.webContents.executeJavaScript(
+            "document.querySelector('#sta-5228-marker')?.textContent ?? null"
+          )) as string | null
+        } catch {}
+      }
+      return {
+        crashed: win.webContents.isCrashed(),
+        destroyed: win.webContents.isDestroyed(),
+        marker,
+        pid: win.webContents.getOSProcessId(),
+        url: win.webContents.getURL(),
+        webContentsId: win.webContents.id
+      }
+    },
+    { readMarker, targetPageId: pageId }
+  )
+}
+
+test('STA-5228 renderer death keeps headless runtime and PTYs alive', async ({ testRepoPath }) => {
+  test.setTimeout(180_000)
+
+  const scratch = mkdtempSync(path.join(os.tmpdir(), 'orca-sta-5228-'))
+  const fixturePath = writeRetentionFixture(scratch)
+  const sinkPath = path.join(scratch, 'pty.log')
+  let host: Awaited<ReturnType<typeof launchHeadlessPairedRuntimeHost>> | null = null
+  try {
+    const launchedHost = await launchHeadlessPairedRuntimeHost()
+    host = launchedHost
+    const userDataDir = await launchedHost.app.evaluate(({ app }) => app.getPath('userData'))
+    const mainPid = await launchedHost.app.evaluate(() => process.pid)
+    const daemonPid = readDaemonPid(userDataDir)
+    const mainIdentity = await recordProcessIdentity(mainPid)
+    const daemonIdentity = await recordProcessIdentity(daemonPid)
+    expect(
+      await launchedHost.app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows().length)
+    ).toBe(0)
+    const beforeStatus = await launchedHost.client.call<RuntimeStatus>('status.get')
+    const added = await launchedHost.client.call<{ repo: { id: string } }>('repo.add', {
+      path: testRepoPath,
+      kind: 'git'
+    })
+    const listed = await launchedHost.client.call<{ worktrees: { id: string }[] }>(
+      'worktree.list',
+      {
+        repo: `id:${added.result.repo.id}`
+      }
+    )
+    const worktreeId = listed.result.worktrees[0]?.id
+    if (!worktreeId) {
+      throw new Error('Headless host did not list the seeded worktree')
+    }
+    const call = async <TResult>(method: string, params: unknown): Promise<TResult> =>
+      (await launchedHost.client.call<TResult>(method, params)).result
+    const terminalA = await createHostCliTerminal(call, worktreeId, fixturePath, sinkPath)
+    const terminalB = await createHostCliTerminal(
+      call,
+      worktreeId,
+      fixturePath,
+      path.join(scratch, 'pty-b.log')
+    )
+    await proveSameLivePty(call, terminalA, 'BEFORE_RENDERER_KILL_A')
+    await proveSameLivePty(call, terminalB, 'BEFORE_RENDERER_KILL_B')
+
+    const pageId = `sta-5228-${Date.now()}`
+    const markerUrl = `data:text/html,${encodeURIComponent(
+      `<p id="sta-5228-marker">${pageId}</p>`
+    )}`
+    await launchedHost.client.call<{ browserPageId: string }>('browser.tabCreate', {
+      url: markerUrl,
+      worktree: `id:${worktreeId}`
+    })
+    const rendererObservation = { value: null as RendererIdentity | null }
+    await expect
+      .poll(
+        async () => {
+          rendererObservation.value = await readOffscreenRenderer(launchedHost.app, pageId)
+          return rendererObservation.value
+        },
+        {
+          timeout: 30_000,
+          message: 'Headless offscreen renderer never loaded the marker page'
+        }
+      )
+      .toMatchObject({ marker: pageId, crashed: false, destroyed: false })
+    const renderer = rendererObservation.value
+    if (!renderer || renderer.pid <= 0) {
+      throw new Error('Headless offscreen renderer did not expose an OS process identity')
+    }
+    expect(renderer.pid).not.toBe(mainPid)
+    expect(renderer.pid).not.toBe(daemonPid)
+    const rendererIdentity = await recordProcessIdentity(renderer.pid)
+
+    const fencedRenderer = await readOffscreenRenderer(launchedHost.app, pageId)
+    expect(fencedRenderer).toMatchObject({
+      crashed: false,
+      marker: pageId,
+      pid: renderer.pid,
+      webContentsId: renderer.webContentsId
+    })
+    expect(await processIdentityIsAlive(rendererIdentity)).toBe(true)
+    if (process.platform === 'linux') {
+      expect(readFileSync(path.join('/proc', String(renderer.pid), 'cmdline'), 'utf8')).toContain(
+        '--type=renderer'
+      )
+    }
+    await launchedHost.app.evaluate(
+      ({ BrowserWindow }, expected) => {
+        const win = BrowserWindow.getAllWindows().find(
+          (candidate) => candidate.webContents.id === expected.webContentsId
+        )
+        if (
+          !win ||
+          !win.webContents.getURL().includes(expected.pageId) ||
+          win.webContents.getOSProcessId() !== expected.pid
+        ) {
+          throw new Error('Offscreen renderer identity changed before the fault')
+        }
+        const probe = { details: null as Electron.RenderProcessGoneDetails | null }
+        ;(globalThis as typeof globalThis & { __sta5228Probe?: typeof probe }).__sta5228Probe =
+          probe
+        win.webContents.once('render-process-gone', (_event, details) => {
+          probe.details = details
+        })
+        setTimeout(() => win.webContents.forcefullyCrashRenderer(), 0)
+      },
+      { pageId, pid: renderer.pid, webContentsId: renderer.webContentsId }
+    )
+
+    await expect
+      .poll(
+        () =>
+          launchedHost.app.evaluate(
+            () =>
+              (
+                globalThis as typeof globalThis & {
+                  __sta5228Probe?: { details: Electron.RenderProcessGoneDetails | null }
+                }
+              ).__sta5228Probe?.details ?? null
+          ),
+        {
+          timeout: 15_000,
+          message: 'Exact offscreen renderer fault produced no process-gone event'
+        }
+      )
+      .toMatchObject({ reason: 'killed' })
+
+    await expect
+      .poll(() => processIdentityIsAlive(rendererIdentity), {
+        message: 'The exact renderer process remained alive after its WebContents crashed'
+      })
+      .toBe(false)
+
+    const afterStatus = await launchedHost.client.call<RuntimeStatus>('status.get')
+    expect(await launchedHost.app.evaluate(() => process.pid)).toBe(mainPid)
+    expect(await processIdentityIsAlive(mainIdentity)).toBe(true)
+    expect(afterStatus.result.runtimeId).toBe(beforeStatus.result.runtimeId)
+    expect(readDaemonPid(userDataDir)).toBe(daemonPid)
+    expect(await processIdentityIsAlive(daemonIdentity)).toBe(true)
+    await proveSameLivePty(call, terminalA, 'AFTER_RENDERER_KILL_A')
+    await proveSameLivePty(call, terminalB, 'AFTER_RENDERER_KILL_B')
+
+    const afterRenderer = await readOffscreenRenderer(launchedHost.app, pageId, false)
+    expect(afterRenderer).toMatchObject({
+      crashed: true,
+      pid: 0,
+      webContentsId: renderer.webContentsId
+    })
+    console.log('[STA-5228] renderer lifecycle snapshot', {
+      afterRenderer,
+      beforeRenderer: renderer,
+      daemonPid,
+      mainPid,
+      ptyIds: [terminalA.ptyId, terminalB.ptyId],
+      runtimeId: beforeStatus.result.runtimeId
+    })
+  } finally {
+    try {
+      await host?.dispose()
+    } finally {
+      rmSync(scratch, { recursive: true, force: true })
+    }
+  }
+})

--- a/tests/e2e/helpers/host-created-terminal-retention-oracle.ts
+++ b/tests/e2e/helpers/host-created-terminal-retention-oracle.ts
@@ -31,6 +31,12 @@ export type HostTerminalInventory = {
   publicationEpoch: string
   tabIds: string[]
   ptyIdByTabId: Record<string, string | null>
+  terminalSurfaces: {
+    id: string
+    leafId: string
+    parentTabId: string
+    ptyId: string | null
+  }[]
 }
 
 type SessionTabsListResult = {
@@ -38,6 +44,7 @@ type SessionTabsListResult = {
   tabs: {
     id: string
     type: string
+    leafId?: string
     parentTabId?: string
     ptyId?: string | null
   }[]
@@ -182,6 +189,19 @@ export async function readHostTerminalInventory(
     worktree: `id:${worktreeId}`
   })
   const terminals = snapshot.tabs.filter((tab) => tab.type === 'terminal')
+  const terminalSurfaces = terminals
+    .map((tab) => {
+      if (!tab.parentTabId || !tab.leafId) {
+        throw new Error(`Terminal surface ${tab.id} has no parent-tab or leaf identity`)
+      }
+      return {
+        id: tab.id,
+        leafId: tab.leafId,
+        parentTabId: tab.parentTabId,
+        ptyId: tab.ptyId ?? null
+      }
+    })
+    .toSorted((left, right) => left.id.localeCompare(right.id))
   const ptyIdByTabId: Record<string, string | null> = {}
   for (const tab of terminals) {
     const parentTabId = tab.parentTabId ?? tab.id.split(HOST_TERMINAL_SURFACE_SEPARATOR)[0]!
@@ -190,7 +210,8 @@ export async function readHostTerminalInventory(
   return {
     publicationEpoch: snapshot.publicationEpoch,
     tabIds: Object.keys(ptyIdByTabId),
-    ptyIdByTabId
+    ptyIdByTabId,
+    terminalSurfaces
   }
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​282 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​281 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​77 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​76 |

<!-- /orca-pr-loc -->

## ELI5

A Chromium tab inside headless Orca can die without killing the Orca server or unrelated terminal sessions. The production report showed both a renderer OOM and a later service failure, but the available logs do not prove that the first event caused the second.

## What Changed

- Added an isolated headless `orca serve` characterization test.
- Kills one exact marked offscreen WebContents after fencing its WebContents ID, URL, and OS renderer PID.
- Proves the original renderer process died.
- Repeatedly proves the same main process, runtime, daemon, every exact terminal surface/parent-tab/leaf/PTY binding in the isolated fixture worktree, and two original PTY processes remain reachable and accept I/O through a 12-second window.
- Batches main and daemon start-identity checks into one process-table snapshot per checkpoint.
- Registered the contract as experimental and partial, with explicit topology and incident gaps.
- Added no production behavior or wire changes.

## Why

STA-5228 combines three causal boundaries: renderer-only death, whole-runtime or systemd-cgroup persistence, and aggregate fleet memory. Renderer-only death did not reproduce runtime or session loss on the reported release, the tested main revision, or the candidate rebased onto the then-latest validated main, so a product recovery patch would target an unproved cause. The smallest durable response is to preserve that containment invariant and keep the other two investigations separate.

## Linked Issue

Refs #16084 and STA-5228. This characterization PR must not close either issue.

## Visual Proof

N/A — this changes no UI or interaction behavior.

## Testing

Evidence scopes differ intentionally:

| Version | Fault and observation | Result |
| --- | --- | --- |
| v1.4.184 | earlier immediate exact-renderer containment oracle | pass |
| then-current main `e3327c2f31` | earlier immediate exact-renderer containment oracle | pass |
| candidate rebased on validated main `0926c25854` | exact-renderer oracle, exact fixture-worktree surface-binding checks, and repeated 12-second stability checks | pass |
| candidate reverted | production behavior unchanged; characterization coverage absent | no manufactured red result |

Additional validation:

- Final macOS headless Electron E2E on validated main plus candidate: pass, 1/1 in 33.6 seconds (37.1 seconds including setup and cleanup).
- Current desktop renderer-recovery control: pass, 1/1 in 18.7 seconds (22.4 seconds total) across two forced crash/reload cycles with the same PTY retaining I/O.
- Separate runtime-restart investigation does not establish whole-cgroup persistence or preservation of the same runtime/session identity; it remains outside this PR.
- Reliability manifest, focused oxlint, typecheck, max-lines ratchet, and diff checks: pass.
- Ubuntu changed-spec E2E: required before merge and currently queued.
- After validation, `origin/main` advanced to `6989c92b16` through two commits limited to crash-report attribution and skill-upload lifecycle. Merge-tree is conflict-free; this exact newer tip was not rerun.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## Review

Independent review tracks covered architecture and ownership, product and compatibility, and adversarial regression behavior. Findings were independently validated and resolved by recording raw surface/parent/leaf/PTY tuples, batching process-identity scans, removing the unrelated crashed-page postcondition, narrowing provider/evidence claims, adding the reliability gate, observing beyond the reported nine-second delay, and rebasing plus rerunning against the then-latest main.

The supplied journal proves a renderer OOM victim at 14:43:00 and a unit oom-kill failure at 14:43:09. It does not identify what ended the unit during that interval. Full kernel and unit logs plus main PID evidence are still required.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or translates no upstream skill-installer material.

## Notes

The final oracle is host-local, daemon-backed, and scoped to one isolated fixture worktree. It does not claim separate paired-viewer reconnect/replay, offscreen page recovery, systemd cgroup restart persistence, SSH, WSL, folder-workspace, multi-worktree, multi-client, mixed-version lifecycle, or fleet memory-policy coverage. No product or remote-wire path changed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why, including ELI5
- [x] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered or N/A
- [ ] Full PR CI passes on the final commit; queued at the time of this update
