### PR TITLE
refactor(mobile): reuse repository color helper

### DIFF
--- a/mobile/src/components/NewWorktreeModal.tsx
+++ b/mobile/src/components/NewWorktreeModal.tsx
@@ -21,6 +21,7 @@ import { PickerListDrawer } from './PickerListDrawer'
 import { MobileAgentIcon } from './MobileAgentIcon'
 import { getSuggestedCreatureName } from './worktree-name-suggestion'
 import { useRetiredWorktreeNames } from '../worktree/use-retired-worktree-names'
+import { repoColor } from '../worktree/repo-color'
 import { deriveWorkspaceSshGate, workspaceSshStatusLabel } from '../tasks/workspace-ssh-gate'
 import {
   isSetupHookTrusted,
@@ -118,15 +119,6 @@ type DetectedAgentIdsState = {
 type CreateOptions = {
   setupOverride?: Exclude<SetupDecision, 'inherit'>
   approvedSetupContentHash?: string
-}
-
-function repoColor(name: string): string {
-  const palette = ['#f97316', '#8b5cf6', '#06b6d4', '#ec4899', '#84cc16', '#f59e0b', '#6366f1']
-  let hash = 0
-  for (let i = 0; i < name.length; i += 1) {
-    hash = (hash * 31 + name.charCodeAt(i)) | 0
-  }
-  return palette[Math.abs(hash) % palette.length]!
 }
 
 function repoBadgeColor(repo: Repo | null): string {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 |

<!-- /orca-pr-loc -->

## ELI5

Use the same repository-color function everywhere instead of keeping a second copy in the mobile workspace dialog.

## What Changed

- Imported the canonical `repoColor` helper in `NewWorktreeModal`.
- Removed the identical component-local implementation.
- Kept explicit `badgeColor` precedence and the fallback input unchanged.

## Why

The local copy recreated its seven-color palette on every fallback call. Reusing the existing leaf helper removes duplicate code and moves the palette to its existing module-scope allocation, with identical hashing and output.

## Linked Issue

N/A — opportunistic zero-behavior-change cleanup requested directly.

## Visual Proof

N/A — generated colors and UI behavior are unchanged.

## Testing

- [x] `cd mobile && pnpm exec vitest run src/components/NewWorktreeModal.test.tsx` — 2 tests passed
- [x] `cd mobile && pnpm typecheck`
- [x] Commit hooks: oxlint, React Doctor lint, formatting

## Review

No remote-wire, SSH, Git, provider, path, or platform behavior changes. One import replaces an identical local function; runtime allocation is weakly improved.

## Agent skill upstream boundary

- [x] Not applicable.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Visual proof is not applicable because output is unchanged
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform and remote impact considered: none
- [ ] Full repository lint/typecheck/test/build deferred to CI; focused checks passed