### PR TITLE
refactor(runtime): share agent prompt delay

### DIFF
--- a/src/main/runtime/agent-prompt-request-delay.ts
+++ b/src/main/runtime/agent-prompt-request-delay.ts
@@ -1,0 +1,23 @@
+export async function waitForAgentPromptDelay(
+  delayMs: number,
+  signal?: AbortSignal
+): Promise<void> {
+  if (!signal) {
+    await new Promise((resolve) => setTimeout(resolve, delayMs))
+    return
+  }
+  await new Promise<void>((resolve, reject) => {
+    const onAbort = (): void => {
+      clearTimeout(timer)
+      reject(new Error('request_aborted'))
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort)
+      resolve()
+    }, delayMs)
+    signal.addEventListener('abort', onAbort, { once: true })
+    if (signal.aborted) {
+      onAbort()
+    }
+  })
+}

--- a/src/main/runtime/agent-prompt-submission-verification.ts
+++ b/src/main/runtime/agent-prompt-submission-verification.ts
@@ -1,3 +1,5 @@
+import { waitForAgentPromptDelay } from './agent-prompt-request-delay'
+
 export const AGENT_PROMPT_EFFECT_TIMEOUT_MS = 5_000
 const AGENT_PROMPT_EFFECT_POLL_MS = 50
 
@@ -28,7 +30,7 @@ export async function verifyAgentPromptSubmission(
     if (agentPromptLifecycleChanged(options.baseline, current)) {
       return
     }
-    await waitForAgentPromptPoll(options.signal)
+    await waitForAgentPromptDelay(AGENT_PROMPT_EFFECT_POLL_MS, options.signal)
   }
 
   const current = options.readActivity()
@@ -66,25 +68,4 @@ function throwIfAgentPromptAborted(signal?: AbortSignal): void {
   if (signal?.aborted) {
     throw new Error('request_aborted')
   }
-}
-
-async function waitForAgentPromptPoll(signal?: AbortSignal): Promise<void> {
-  if (!signal) {
-    await new Promise((resolve) => setTimeout(resolve, AGENT_PROMPT_EFFECT_POLL_MS))
-    return
-  }
-  await new Promise<void>((resolve, reject) => {
-    const onAbort = (): void => {
-      clearTimeout(timer)
-      reject(new Error('request_aborted'))
-    }
-    const timer = setTimeout(() => {
-      signal.removeEventListener('abort', onAbort)
-      resolve()
-    }, AGENT_PROMPT_EFFECT_POLL_MS)
-    signal.addEventListener('abort', onAbort, { once: true })
-    if (signal.aborted) {
-      onAbort()
-    }
-  })
 }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -105,6 +105,7 @@ import {
   type AgentPromptActivity,
   verifyAgentPromptSubmission
 } from './agent-prompt-submission-verification'
+import { waitForAgentPromptDelay } from './agent-prompt-request-delay'
 import {
   awaitWindowsHostGitEnvironmentReady,
   gitExecFileAsync,
@@ -2065,28 +2066,6 @@ async function waitForAgentPromptPromise<T>(promise: Promise<T>, signal?: AbortS
       (value) => finish({ value }),
       (error: unknown) => finish({ error })
     )
-  })
-}
-
-async function waitForAgentPromptDelay(delayMs: number, signal?: AbortSignal): Promise<void> {
-  if (!signal) {
-    await new Promise((resolve) => setTimeout(resolve, delayMs))
-    return
-  }
-  assertAgentPromptRequestActive(signal)
-  await new Promise<void>((resolve, reject) => {
-    const onAbort = (): void => {
-      clearTimeout(timer)
-      reject(new Error('request_aborted'))
-    }
-    const timer = setTimeout(() => {
-      signal.removeEventListener('abort', onAbort)
-      resolve()
-    }, delayMs)
-    signal.addEventListener('abort', onAbort, { once: true })
-    if (signal.aborted) {
-      onAbort()
-    }
   })
 }
 
@@ -19455,6 +19434,7 @@ export class OrcaRuntimeService {
         renderGate.dispose()
       }
     } else {
+      assertAgentPromptRequestActive(options.signal)
       await waitForAgentPromptDelay(AGENT_PROMPT_SUBMIT_DELAY_MS, options.signal)
     }
     assertAgentPromptRequestActive(options.signal)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​28 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​44 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 |

<!-- /orca-pr-loc -->

## ELI5

Keep one implementation of the agent-prompt wait instead of two matching timer/abort implementations.

## What Changed

- Added `agent-prompt-request-delay.ts` with the shared referenced timer wait.
- Migrated prompt submission verification and runtime submit delay to it.
- Preserved the runtime pre-abort assertion at the callsite; the shared helper retains listener cleanup and the post-registration abort-race check.

## Why

Both paths used the same Promise, timer, listener, cleanup, and `Error('request_aborted')` behavior. A domain-specific shared implementation prevents abort semantics from drifting without adding work, allocations, or call depth.

## Linked Issue

N/A — opportunistic zero-behavior-change cleanup requested directly.

## Visual Proof

N/A — no UI or interaction output changes.

## Testing

- [x] Focused Vitest: 3 files, 43 tests passed
- [x] `pnpm run typecheck:node`
- [x] File-scoped oxlint
- [x] Commit lint/format hooks and diff check

## Review

Referenced timers remain referenced. Abort still clears the timer and rejects with exact `request_aborted`; normal expiry removes the listener; the registration race check remains. No remote-wire schema, SSH, Git, provider, path, or platform behavior changes.

## Agent skill upstream boundary

- [x] Not applicable.

## Checklist

- [x] Small and focused
- [x] Behavior and performance self-reviewed
- [x] Cross-platform/remote impact considered: none
- [ ] Full repository lint/typecheck/test/build deferred to CI; focused checks passed