### PR TITLE
refactor(skills): centralize observation matching

### DIFF
--- a/src/main/skills/skill-bundle-creation.ts
+++ b/src/main/skills/skill-bundle-creation.ts
@@ -20,7 +20,11 @@ import {
 import { summarizeSkillMarkdown } from '../../shared/skill-metadata'
 import { renameSkillPathWithWindowsRetry } from './skill-filesystem-retry'
 import { extractSkillBundleArchive } from './skill-bundle-extraction'
-import { observeSkillPackage, type ObservedSkillPackage } from './skill-package-identity'
+import {
+  observedSkillPackagesMatch,
+  observeSkillPackage,
+  type ObservedSkillPackage
+} from './skill-package-identity'
 import { writeSkillTarGzip, type SkillTarWriteEntry } from './skill-package-tar'
 import { startSkillPhaseOperation } from './skill-operation-observability'
 
@@ -41,23 +45,6 @@ export type CreatedSkillBundle = {
 export type SkillBundleCreationDependencies = { afterSourcesObserved?: () => Promise<void> }
 
 const SOURCE_OBSERVATION_CONCURRENCY = 4
-
-function observationsMatch(left: ObservedSkillPackage, right: ObservedSkillPackage): boolean {
-  return (
-    left.files.length === right.files.length &&
-    left.files.every((file, index) => {
-      const other = right.files[index]
-      return (
-        file.path === other.path &&
-        file.size === other.size &&
-        file.executable === other.executable &&
-        file.classification === other.classification &&
-        file.exactSha256 === other.exactSha256 &&
-        file.identitySha256 === other.identitySha256
-      )
-    })
-  )
-}
 
 function bundleEntry(input: {
   id: string
@@ -104,7 +91,7 @@ async function stageSkill(input: {
     process.platform,
     process.platform === 'win32'
   )
-  if (!observationsMatch(input.sourceObservation, stagedObservation)) {
+  if (!observedSkillPackagesMatch(input.sourceObservation, stagedObservation)) {
     throw new Error('skill-package-source-changed-during-staging')
   }
   const stagedSummary = summarizeSkillMarkdown(

--- a/src/main/skills/skill-package-creation.ts
+++ b/src/main/skills/skill-package-creation.ts
@@ -11,7 +11,11 @@ import {
 import { summarizeSkillMarkdown } from '../../shared/skill-metadata'
 import { renameSkillPathWithWindowsRetry } from './skill-filesystem-retry'
 import { startSkillPhaseOperation } from './skill-operation-observability'
-import { observeSkillPackage, type ObservedSkillPackage } from './skill-package-identity'
+import {
+  observedSkillPackagesMatch,
+  observeSkillPackage,
+  type ObservedSkillPackage
+} from './skill-package-identity'
 import { extractSkillPackageArchive } from './skill-package-extraction'
 import { writeSkillTarGzip, type SkillTarWriteEntry } from './skill-package-tar'
 
@@ -24,23 +28,6 @@ export type CreatedSkillPackage = {
 
 export type SkillPackageCreationDependencies = {
   afterSourceObserved?: () => Promise<void>
-}
-
-function observationsMatch(left: ObservedSkillPackage, right: ObservedSkillPackage): boolean {
-  return (
-    left.files.length === right.files.length &&
-    left.files.every((file, index) => {
-      const other = right.files[index]
-      return (
-        file.path === other.path &&
-        file.size === other.size &&
-        file.executable === other.executable &&
-        file.classification === other.classification &&
-        file.exactSha256 === other.exactSha256 &&
-        file.identitySha256 === other.identitySha256
-      )
-    })
-  )
 }
 
 function packageManifest(input: {
@@ -98,7 +85,7 @@ async function createSkillPackageArchiveUnobserved(
       errorOnExist: true
     })
     const stagedObservation = await observeSkillPackage(stagedSkill)
-    if (!observationsMatch(sourceObservation, stagedObservation)) {
+    if (!observedSkillPackagesMatch(sourceObservation, stagedObservation)) {
       throw new Error('skill-package-source-changed-during-staging')
     }
     const summary = summarizeSkillMarkdown(await readFile(join(stagedSkill, 'SKILL.md'), 'utf8'))

--- a/src/main/skills/skill-package-identity.ts
+++ b/src/main/skills/skill-package-identity.ts
@@ -23,6 +23,26 @@ export type ObservedSkillPackage = {
   treeEntries: SkillGitTreeFileEntry[]
 }
 
+export function observedSkillPackagesMatch(
+  left: ObservedSkillPackage,
+  right: ObservedSkillPackage
+): boolean {
+  return (
+    left.files.length === right.files.length &&
+    left.files.every((file, index) => {
+      const other = right.files[index]
+      return (
+        file.path === other.path &&
+        file.size === other.size &&
+        file.executable === other.executable &&
+        file.classification === other.classification &&
+        file.exactSha256 === other.exactSha256 &&
+        file.identitySha256 === other.identitySha256
+      )
+    })
+  )
+}
+
 // Why: package identity compares a live user directory against a tree the generator read
 // from a clean checkout, so anything the OS deposits on its own counts as drift the user
 // never caused. One Finder visit writes .DS_Store, and that alone made the copy


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​32 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​38 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 |

<!-- /orca-pr-loc -->

## ELI5

Use one exact comparison for staged skill snapshots instead of maintaining identical copies in package and bundle creation.

## What Changed

- Added `observedSkillPackagesMatch` beside `ObservedSkillPackage` in the identity module.
- Migrated package and bundle archive creation to the shared predicate.
- Removed both duplicated local predicates.

## Why

The two implementations were identical. Centralizing them in the module that owns the compared type prevents drift while preserving the exact length guard, ordered scan, early exit, property reads, and allocation behavior.

## Linked Issue

N/A — opportunistic zero-behavior-change cleanup requested directly.

## Visual Proof

N/A — no UI or interaction output changes.

## Testing

- [x] Focused Vitest: 3 files, 33 tests passed
- [x] `pnpm run typecheck:node`
- [x] File-scoped oxlint
- [x] Commit hooks: oxlint, React Doctor, formatting

## Review

The predicate still compares only `path`, `size`, `executable`, `classification`, `exactSha256`, and `identitySha256` in file order. It deliberately does not compare additional observation fields. No remote-wire, SSH, Git, provider, path, or platform behavior changes.

## Agent skill upstream boundary

- [x] Not applicable.

## Checklist

- [x] Small and focused
- [x] Behavior and performance self-reviewed
- [x] Cross-platform/remote impact considered: none
- [ ] Full repository lint/typecheck/test/build deferred to CI; focused checks passed