### PR TITLE
refactor(renderer): use canonical attachment labels

### DIFF
--- a/src/renderer/src/components/LinearIssueWorkspace.tsx
+++ b/src/renderer/src/components/LinearIssueWorkspace.tsx
@@ -46,11 +46,9 @@ import { Sheet, SheetContent, SheetDescription, SheetTitle } from '@/components/
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { createBrowserUuid } from '@/lib/browser-uuid'
 import { buildLinearIssueContextSnapshot } from '@/lib/linear-issue-context-snapshot'
-import {
-  findLinearIssueWorkspaceAttachment,
-  getLinearIssueWorkspaceAttachmentLabel
-} from '@/lib/linear-issue-workspace-attachment'
+import { findLinearIssueWorkspaceAttachment } from '@/lib/linear-issue-workspace-attachment'
 import { openLinearIssueWorkspaceOrStart } from '@/lib/linear-issue-workspace-open'
+import { getWorktreeAttachmentLabel } from '@/lib/worktree-attachment-label'
 import { folderWorkspaceToWorktree } from '../../../shared/folder-workspace-worktree'
 import { buildContainedLinkedContextBlock } from '@/lib/linked-work-item-context'
 import { useMountedRef } from '@/hooks/useMountedRef'
@@ -674,7 +672,7 @@ export default function LinearIssueWorkspace({
     [attachmentWorkspaces, displayed]
   )
   const attachedWorkspaceLabel = attachedWorkspace
-    ? getLinearIssueWorkspaceAttachmentLabel(attachedWorkspace)
+    ? getWorktreeAttachmentLabel(attachedWorkspace)
     : null
 
   const handleUseIssue = useCallback((): void => {

--- a/src/renderer/src/components/LinearItemDrawer.tsx
+++ b/src/renderer/src/components/LinearItemDrawer.tsx
@@ -36,11 +36,9 @@ import {
   getCommentBodySubmitState,
   hasBoundedCommentBodyText
 } from '@/lib/comment-body-submit-state'
-import {
-  findLinearIssueWorkspaceAttachment,
-  getLinearIssueWorkspaceAttachmentLabel
-} from '@/lib/linear-issue-workspace-attachment'
+import { findLinearIssueWorkspaceAttachment } from '@/lib/linear-issue-workspace-attachment'
 import { openLinearIssueWorkspaceOrStart } from '@/lib/linear-issue-workspace-open'
+import { getWorktreeAttachmentLabel } from '@/lib/worktree-attachment-label'
 import { folderWorkspaceToWorktree } from '../../../shared/folder-workspace-worktree'
 import { useAppStore } from '@/store'
 import { useAllWorktrees } from '@/store/selectors'
@@ -1384,7 +1382,7 @@ export default function LinearItemDrawer({
     [attachmentWorkspaces, displayed]
   )
   const attachedWorkspaceLabel = attachedWorkspace
-    ? getLinearIssueWorkspaceAttachmentLabel(attachedWorkspace)
+    ? getWorktreeAttachmentLabel(attachedWorkspace)
     : null
 
   const handleOpenOrUseIssue = useCallback((): void => {

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -136,16 +136,13 @@ import PRFilterDropdowns, { type PRFilterChange } from '@/components/github/PRFi
 import { GitHubMarkdownComposer } from '@/components/github/GitHubMarkdownComposer'
 import { GitHubUserAvatar } from '@/components/github/github-user-avatar'
 import { buildGitHubRepoUrl, parseGitHubIssueOrPRLink } from '@/lib/github-links'
-import {
-  findGithubWorkItemWorkspaceAttachment,
-  getGithubWorkItemWorkspaceAttachmentLabel
-} from '@/lib/github-work-item-workspace-attachment'
+import { findGithubWorkItemWorkspaceAttachment } from '@/lib/github-work-item-workspace-attachment'
 import {
   buildLinearIssueWorkspaceAttachmentIndex,
-  findLinearIssueWorkspaceAttachmentInIndex,
-  getLinearIssueWorkspaceAttachmentLabel
+  findLinearIssueWorkspaceAttachmentInIndex
 } from '@/lib/linear-issue-workspace-attachment'
 import { openLinearIssueWorkspaceOrStart } from '@/lib/linear-issue-workspace-open'
+import { getWorktreeAttachmentLabel } from '@/lib/worktree-attachment-label'
 import { folderWorkspaceToWorktree } from '../../../shared/folder-workspace-worktree'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { useRepoAssigneesBySlug } from '@/hooks/useGitHubSlugMetadata'
@@ -10272,7 +10269,7 @@ export default function TaskPage(): React.JSX.Element {
                         item.number
                       )
                       const attachedWorkspaceLabel = attachedWorkspace
-                        ? getGithubWorkItemWorkspaceAttachmentLabel(attachedWorkspace)
+                        ? getWorktreeAttachmentLabel(attachedWorkspace)
                         : null
                       const prDelta = item.type === 'pr' ? formatPRDelta(item) : null
                       const githubTaskIdPill = (
@@ -11569,7 +11566,7 @@ export default function TaskPage(): React.JSX.Element {
                               issue
                             )
                             const attachedWorkspaceLabel = attachedWorkspace
-                              ? getLinearIssueWorkspaceAttachmentLabel(attachedWorkspace)
+                              ? getWorktreeAttachmentLabel(attachedWorkspace)
                               : null
                             return (
                               <div
@@ -11768,7 +11765,7 @@ export default function TaskPage(): React.JSX.Element {
                         issue
                       )
                       const attachedWorkspaceLabel = attachedWorkspace
-                        ? getLinearIssueWorkspaceAttachmentLabel(attachedWorkspace)
+                        ? getWorktreeAttachmentLabel(attachedWorkspace)
                         : null
                       return (
                         <div

--- a/src/renderer/src/components/github-item-dialog/open-dialog/github-item-dialog.tsx
+++ b/src/renderer/src/components/github-item-dialog/open-dialog/github-item-dialog.tsx
@@ -2,11 +2,9 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { useAllWorktrees } from '@/store/selectors'
 import { useAppStore } from '@/store'
-import {
-  findGithubIssueWorkspaceAttachment,
-  getGithubWorkItemWorkspaceAttachmentLabel
-} from '@/lib/github-work-item-workspace-attachment'
+import { findGithubIssueWorkspaceAttachment } from '@/lib/github-work-item-workspace-attachment'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { getWorktreeAttachmentLabel } from '@/lib/worktree-attachment-label'
 import { translate } from '@/i18n/i18n'
 import type { GitHubWorkItem } from '../../../../../shared/github/work-item-types'
 import type { GitHubItemDialogProps } from '../load-item-details/github-item-dialog-types'
@@ -45,7 +43,7 @@ export default function GitHubItemDialog({
     [allWorktrees, effectiveRepoId, workItem]
   )
   const issueAttachedWorkspaceLabel = issueAttachedWorkspace
-    ? getGithubWorkItemWorkspaceAttachmentLabel(issueAttachedWorkspace)
+    ? getWorktreeAttachmentLabel(issueAttachedWorkspace)
     : null
 
   const handleOpenOrUseIssueWorkspace = useCallback(

--- a/src/renderer/src/components/pull-request-page/page/surface.tsx
+++ b/src/renderer/src/components/pull-request-page/page/surface.tsx
@@ -10,11 +10,9 @@ import { toast } from 'sonner'
 import { useAppStore } from '@/store'
 import { useAllWorktrees } from '@/store/selectors'
 import { canUseGitHubRepoContext } from '@/lib/github-source-runtime-context'
-import {
-  findGithubPrWorkspaceAttachment,
-  getGithubPrWorkspaceAttachmentLabel
-} from '@/lib/github-work-item-workspace-attachment'
+import { findGithubPrWorkspaceAttachment } from '@/lib/github-work-item-workspace-attachment'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { getWorktreeAttachmentLabel } from '@/lib/worktree-attachment-label'
 import {
   clearGitHubLinkCopied,
   createGitHubLinkCopyState,
@@ -72,7 +70,7 @@ export default function PullRequestPage({
     [allWorktrees, effectiveRepoId, workItem]
   )
   const attachedWorkspaceLabel = attachedWorkspace
-    ? getGithubPrWorkspaceAttachmentLabel(attachedWorkspace)
+    ? getWorktreeAttachmentLabel(attachedWorkspace)
     : null
 
   // Why: key must include issue source preference so origin/upstream toggles for the same issue number don't read back the wrong repo's details.

--- a/src/renderer/src/lib/github-work-item-workspace-attachment.test.ts
+++ b/src/renderer/src/lib/github-work-item-workspace-attachment.test.ts
@@ -3,9 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   findGithubIssueWorkspaceAttachment,
   findGithubPrWorkspaceAttachment,
-  findGithubWorkItemWorkspaceAttachment,
-  getGithubWorkItemWorkspaceAttachmentLabel,
-  getGithubPrWorkspaceAttachmentLabel
+  findGithubWorkItemWorkspaceAttachment
 } from './github-work-item-workspace-attachment'
 import type { Worktree } from '../../../shared/worktree/types'
 
@@ -94,21 +92,5 @@ describe('GitHub work-item workspace attachment', () => {
 
     expect(findGithubPrWorkspaceAttachment([gitlabOnly], 'repo-1', 42)).toBeNull()
     expect(findGithubIssueWorkspaceAttachment([gitlabOnly], 'repo-1', 42)).toBeNull()
-  })
-
-  it('labels attachments without exposing a full path when display or branch is available', () => {
-    expect(
-      getGithubWorkItemWorkspaceAttachmentLabel(worktree({ displayName: '  Named GH  ' }))
-    ).toBe('Named GH')
-    expect(
-      getGithubWorkItemWorkspaceAttachmentLabel(
-        worktree({ displayName: '', branch: 'refs/heads/fix-ci' })
-      )
-    ).toBe('fix-ci')
-    expect(
-      getGithubPrWorkspaceAttachmentLabel(
-        worktree({ displayName: '', branch: '', path: 'C:\\repo\\workspace-tail' })
-      )
-    ).toBe('workspace-tail')
   })
 })

--- a/src/renderer/src/lib/github-work-item-workspace-attachment.ts
+++ b/src/renderer/src/lib/github-work-item-workspace-attachment.ts
@@ -1,6 +1,5 @@
 import type { GitHubWorkItem } from '../../../shared/github/work-item-types'
 import type { Worktree } from '../../../shared/worktree/types'
-import { getWorktreeAttachmentLabel } from './worktree-attachment-label'
 
 type GitHubWorkItemType = GitHubWorkItem['type']
 
@@ -39,12 +38,4 @@ export function findGithubIssueWorkspaceAttachment(
   issueNumber: number
 ): Worktree | null {
   return findGithubWorkItemWorkspaceAttachment(worktrees, repoId, 'issue', issueNumber)
-}
-
-export function getGithubWorkItemWorkspaceAttachmentLabel(worktree: Worktree): string {
-  return getWorktreeAttachmentLabel(worktree)
-}
-
-export function getGithubPrWorkspaceAttachmentLabel(worktree: Worktree): string {
-  return getWorktreeAttachmentLabel(worktree)
 }

--- a/src/renderer/src/lib/linear-issue-workspace-attachment.test.ts
+++ b/src/renderer/src/lib/linear-issue-workspace-attachment.test.ts
@@ -3,8 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   buildLinearIssueWorkspaceAttachmentIndex,
   findLinearIssueWorkspaceAttachment,
-  findLinearIssueWorkspaceAttachmentInIndex,
-  getLinearIssueWorkspaceAttachmentLabel
+  findLinearIssueWorkspaceAttachmentInIndex
 } from './linear-issue-workspace-attachment'
 import type { Worktree } from '../../../shared/worktree/types'
 
@@ -180,21 +179,5 @@ describe('Linear issue workspace attachment', () => {
     )
     expect(findLinearIssueWorkspaceAttachmentInIndex(index, issue)?.id).toBe('match')
     expect(findLinearIssueWorkspaceAttachmentInIndex(index, { identifier: 'STA-9999' })).toBeNull()
-  })
-
-  it('labels attachments without exposing a full path when display or branch is available', () => {
-    expect(
-      getLinearIssueWorkspaceAttachmentLabel(worktree({ displayName: '  Named Linear  ' }))
-    ).toBe('Named Linear')
-    expect(
-      getLinearIssueWorkspaceAttachmentLabel(
-        worktree({ displayName: '', branch: 'refs/heads/fix-ci' })
-      )
-    ).toBe('fix-ci')
-    expect(
-      getLinearIssueWorkspaceAttachmentLabel(
-        worktree({ displayName: '', branch: '', path: 'C:\\repo\\workspace-tail' })
-      )
-    ).toBe('workspace-tail')
   })
 })

--- a/src/renderer/src/lib/linear-issue-workspace-attachment.ts
+++ b/src/renderer/src/lib/linear-issue-workspace-attachment.ts
@@ -4,7 +4,6 @@ import {
   getLinearOrganizationUrlKeyFromIssueUrl,
   parseLinearIssueInput
 } from '../../../shared/linear/links'
-import { getWorktreeAttachmentLabel } from './worktree-attachment-label'
 
 export type LinearIssueAttachmentRef = Pick<LinearIssue, 'identifier'> &
   Partial<Pick<LinearIssue, 'workspaceId' | 'url'>>
@@ -124,8 +123,4 @@ export function findLinearIssueWorkspaceAttachmentInIndex(
   }
   const candidates = index.get(identifier)
   return candidates ? findScopedAttachment(candidates, issue) : null
-}
-
-export function getLinearIssueWorkspaceAttachmentLabel(worktree: Worktree): string {
-  return getWorktreeAttachmentLabel(worktree)
 }

--- a/src/renderer/src/lib/worktree-attachment-label.test.ts
+++ b/src/renderer/src/lib/worktree-attachment-label.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import type { Worktree } from '../../../shared/worktree/types'
+import { getWorktreeAttachmentLabel } from './worktree-attachment-label'
+
+function worktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'wt-1',
+    repoId: 'repo-1',
+    path: '/tmp/repo-1/wt-1',
+    head: 'abc123',
+    branch: 'refs/heads/feature/workspace-attachment',
+    isBare: false,
+    isMainWorktree: false,
+    displayName: 'Workspace',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+describe('getWorktreeAttachmentLabel', () => {
+  it('prefers a trimmed display name', () => {
+    expect(getWorktreeAttachmentLabel(worktree({ displayName: '  Named workspace  ' }))).toBe(
+      'Named workspace'
+    )
+  })
+
+  it('falls back to a branch without the local ref prefix', () => {
+    expect(
+      getWorktreeAttachmentLabel(worktree({ displayName: '', branch: 'refs/heads/fix-ci' }))
+    ).toBe('fix-ci')
+  })
+
+  it('falls back to the cross-platform path basename', () => {
+    expect(
+      getWorktreeAttachmentLabel(
+        worktree({ displayName: '', branch: '', path: 'C:\\repo\\workspace-tail' })
+      )
+    ).toBe('workspace-tail')
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​37 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​43 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​25 |

<!-- /orca-pr-loc -->

## ELI5

Call the one workspace-label function directly instead of routing identical labels through provider-named forwarding functions.

## What Changed

- Migrated seven GitHub/PR/Linear UI callsites to `getWorktreeAttachmentLabel`.
- Removed three forwarding exports and their now-unused imports.
- Moved the shared display-name, branch, and cross-platform basename assertions to the canonical module's test.
- Retained provider-specific attachment lookup coverage.

## Why

The forwarding functions contained no provider behavior; each only returned the canonical helper result. Direct calls make ownership explicit, prevent provider aliases from drifting, and remove one JavaScript call without adding work or allocations.

## Linked Issue

N/A — opportunistic zero-behavior-change cleanup requested directly.

## Visual Proof

N/A — rendered labels are produced by the same implementation with identical inputs.

## Testing

- [x] Focused Vitest: 3 files, 21 tests passed
- [x] `pnpm run typecheck:web`
- [x] Narrow oxlint with zero warnings
- [x] oxfmt check, diff check, and pre-commit hooks
- [x] Exhaustive exact-symbol search found zero obsolete references

## Review

All seven calls migrated one-for-one. No remote-wire, SSH, Git/provider identity, path behavior, platform output, or UI interaction changes; Windows basename coverage now lives with the canonical helper.

## Agent skill upstream boundary

- [x] Not applicable.

## Checklist

- [x] Small and focused
- [x] Behavior and performance self-reviewed
- [x] Cross-platform/remote impact considered
- [ ] Full repository lint/typecheck/test/build deferred to CI; focused checks passed