### PR TITLE
style(secrets): trim backend probe comments

### DIFF
--- a/src/main/host/electron-secret-store.test.ts
+++ b/src/main/host/electron-secret-store.test.ts
@@ -64,13 +64,7 @@ describe('ElectronSecretStore', () => {
     })
 
     it('does not throw when the Linux-only backend probe is absent', () => {
-      // Why this test exists: getSelectedStorageBackend is @platform linux, so it is
-      // genuinely undefined on macOS and Windows — verified against Electron 43. Every
-      // other test here mocks safeStorage with the method present, so without this the
-      // suite could stay green while the shipped app threw at startup.
-      //
-      // Why delete the key rather than re-mock: the module already holds this object, so
-      // a later vi.doMock is inert and the test would pass against unguarded code.
+      // Delete from the live mock because the imported module retains its object reference.
       const probe = safeStorageMock.getSelectedStorageBackend
       // @ts-expect-error deleting a required member is the condition under test
       delete safeStorageMock.getSelectedStorageBackend

--- a/src/main/host/electron-secret-store.ts
+++ b/src/main/host/electron-secret-store.ts
@@ -35,17 +35,7 @@ export class ElectronSecretStore implements SecretStore {
   }
 }
 
-/**
- * Why probed rather than called directly: `getSelectedStorageBackend` is `@platform
- * linux`, so it is genuinely absent on macOS and Windows — reading it unguarded is a
- * TypeError, and the type declaration does not say so. Tests that mock `safeStorage`
- * supply the method, so a mocked suite cannot catch that; this keeps the runtime honest
- * regardless of platform or Electron version.
- *
- * Returns null when the backend is unknown or unreadable: claiming a gap we cannot
- * prove would be its own kind of lie, and the caller has already established that
- * sealing works.
- */
+// Electron omits getSelectedStorageBackend at runtime outside Linux despite its type declaration.
 function describeLinuxBackendGap(): string | null {
   if (process.platform !== 'linux') {
     return null
@@ -60,8 +50,6 @@ function describeLinuxBackendGap(): string | null {
   } catch {
     return null
   }
-  // Why only basic_text: it "encrypts" with a hardcoded password, so it round-trips and
-  // must keep working — but it protects nothing, and reporting it as sealed is the lie.
   return backend === 'basic_text'
     ? 'Secrets are obfuscated with a built-in key, not protected by the OS keyring. Install and unlock gnome-keyring or kwallet, then restart Orca, to seal them properly.'
     : null


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 |

<!-- /orca-pr-loc -->

## ELI5

Keep the important explanation for the defensive Electron secret-storage probe without making readers parse repeated implementation detail.

## What Changed

- Replaced the backend-probe docblock with one concise comment about the runtime/type mismatch.
- Removed the duplicate `basic_text` explanation.
- Replaced the test setup explanation with one line about mutating the retained live mock.
- Reduced the change from 22 comment lines to 2, with no executable or test-logic changes.

## Why

This addresses the concise-comment review on #16046 while preserving the two non-obvious reasons future maintainers need.

## Linked Issue

Follow-up to #16046 and [discussion_r3837969865](https://github.com/stablyai/orca/pull/16046#discussion_r3837969865).

## Visual Proof

N/A — comments only; there is no visual or interaction change.

## Testing

- [x] Automated tests added/updated, or explained why not below
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/host/electron-secret-store.test.ts` — 14/14 passed
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] `pnpm exec oxfmt --check src/main/host/electron-secret-store.ts src/main/host/electron-secret-store.test.ts`

`pnpm test` completed with 57,557 passing and 11 failures across six untouched files. Four failing files passed alone. Two failures reproduce alone on unchanged `origin/main`: macOS worktree watcher timing and an SSH host-key test mock missing `ssh2.utils`. Neither is imported by or reachable from this comment-only diff; PR CI remains the independent full-suite gate.

## Review

Readiness checklist verdict: clean. No P0, P1, or P2 findings. The diff changes no runtime behavior, authority boundary, validation, persistence, cleanup, network, SSH, relay, mobile, wire, provider, platform, performance, dependency, or packaging surface.

## Agent skill upstream boundary

- [x] Not applicable; no agent-skill source, test, fixture, registry, path table, comment, or documentation is copied or translated.

## Notes

- User-facing regressions introduced: none.
- Mobile-facing surface touched: none.
- SSH/remote behavior touched: none.
- Windows/Linux/macOS executable behavior touched: none.
- Security and supply-chain surface touched: none.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why, including ELI5
- [x] Visual proof is N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, mobile, and compatibility impact considered
- [x] Lint, typecheck, focused tests, and build pass; CI will cover the full suite