### PR TITLE
Fix renderer starvation blocking settings and worktree switching

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -119,6 +119,7 @@ import {
   TERMINAL_HIDDEN_WORKTREE_RETENTION_TTL_MS,
   countEvictionExemptTabRoutes,
   formatEvictionExemptRouteCounts,
+  getTerminalWorktreeParkingInputsKey,
   hasPendingRetentionSpawnWork,
   selectForceParkEvictableTabIds,
   selectRetentionForceParkedTerminalWorktrees,
@@ -325,6 +326,10 @@ function Terminal(): React.JSX.Element | null {
   )
   const activeView = useAppStore((s) => s.activeView)
   const tabsByWorktree = useAppStore((s) => s.tabsByWorktree)
+  const terminalWorktreeParkingInputsKey = useMemo(
+    () => getTerminalWorktreeParkingInputsKey(tabsByWorktree),
+    [tabsByWorktree]
+  )
   const pendingStartupByTabId = useAppStore((s) => s.pendingStartupByTabId)
   const terminalParkingEnabled = useAppStore((s) => s.settings?.terminalHiddenViewParking !== false)
   const terminalSshParkingEnabled = useAppStore((s) => s.settings?.terminalSshViewParking !== false)
@@ -913,6 +918,7 @@ function Terminal(): React.JSX.Element | null {
   // Worktree cold-park policy: hiddenSince bookkeeping, parked-set selection, and one recheck timer per deadline so React re-renders when hysteresis elapses instead of polling.
   useEffect(() => {
     const parkingTimers = terminalWorktreeParkingTimersRef.current
+    const parkingTabsByWorktree = useAppStore.getState().tabsByWorktree
     for (const timer of parkingTimers.values()) {
       window.clearTimeout(timer)
     }
@@ -975,7 +981,7 @@ function Terminal(): React.JSX.Element | null {
 
       retentionCandidates.push({
         worktreeId,
-        terminalTabs: tabsByWorktree[worktreeId] ?? [],
+        terminalTabs: parkingTabsByWorktree[worktreeId] ?? [],
         isVisible,
         shouldMeasureHiddenWorktree,
         hasActivityTerminalPortal,
@@ -1012,7 +1018,7 @@ function Terminal(): React.JSX.Element | null {
       })
     // Why: a worktree with any watcher-uncoverable tab must never park, or it goes silent for bells/titles/completions (sank the first parking attempt).
     for (const worktreeId of Array.from(nextParkedTerminalWorktreeIds)) {
-      if (!worktreeTabsAreWatcherCovered(worktreeId, tabsByWorktree[worktreeId] ?? [])) {
+      if (!worktreeTabsAreWatcherCovered(worktreeId, parkingTabsByWorktree[worktreeId] ?? [])) {
         nextParkedTerminalWorktreeIds.delete(worktreeId)
       }
     }
@@ -1022,7 +1028,7 @@ function Terminal(): React.JSX.Element | null {
     // is the accepted cost of bounding retention.
     const retentionBudgetCandidates: TerminalWorktreeRetentionCandidate[] = retentionCandidates.map(
       (candidate) => {
-        const tabs = tabsByWorktree[candidate.worktreeId] ?? []
+        const tabs = parkingTabsByWorktree[candidate.worktreeId] ?? []
         const parkEligible = canParkTerminalWorktreeRenderers({
           ...candidate,
           // Why nulled: the post-measure cool-down is a timing gate, not a
@@ -1079,7 +1085,7 @@ function Terminal(): React.JSX.Element | null {
     const repos = useAppStore.getState().repos
     const nextEvictionExemptTabIds = new Set<string>()
     for (const worktreeId of forceParkedWorktreeIds) {
-      const forceParkedTabs = tabsByWorktree[worktreeId] ?? []
+      const forceParkedTabs = parkingTabsByWorktree[worktreeId] ?? []
       const exemptTabIds = selectEvictionExemptTerminalTabIds(worktreeId, forceParkedTabs)
       for (const tabId of exemptTabIds) {
         nextEvictionExemptTabIds.add(tabId)
@@ -1178,7 +1184,7 @@ function Terminal(): React.JSX.Element | null {
     pendingStartupByTabId,
     pairedRuntimeParkingEnvironmentIds,
     renderedActiveWorktreeId,
-    tabsByWorktree,
+    terminalWorktreeParkingInputsKey,
     terminalParkingEnabled,
     terminalParkingRevision,
     terminalProviderSnapshotCapabilityRevision,

--- a/src/renderer/src/components/settings/Settings.tsx
+++ b/src/renderer/src/components/settings/Settings.tsx
@@ -310,7 +310,6 @@ function Settings(): React.JSX.Element {
   const settingsProjectHostSelection = useAppStore((s) => s.settingsProjectHostSelection)
   const settingsProjectSetupSelection = useAppStore((s) => s.settingsProjectSetupSelection)
   const setSettingsProjectHostSelection = useAppStore((s) => s.setSettingsProjectHostSelection)
-  const settingsSearchInputQuery = useAppStore((s) => s.settingsSearchInputQuery)
   const settingsSearchQuery = useAppStore((s) => s.settingsSearchQuery)
   const setSettingsSearchQuery = useAppStore((s) => s.setSettingsSearchQuery)
   const modelStates = useAppStore((s) => s.modelStates)
@@ -1206,12 +1205,10 @@ function Settings(): React.JSX.Element {
         generalGroups={generalNavGroups}
         repoSections={repoNavSections}
         hasRepos={repos.length > 0}
-        searchQuery={settingsSearchInputQuery}
         searchInputRef={searchInputRef}
         // Why: deep-links open panes/modals that own focus; plain entry lands in search.
         searchAutoFocus={settingsNavigationTarget == null}
         onBack={closeSettingsPageWithPromptGuard}
-        onSearchChange={setSettingsSearchQuery}
         onSelectSection={scrollToSection}
       />
 

--- a/src/renderer/src/components/settings/SettingsSidebar.test.tsx
+++ b/src/renderer/src/components/settings/SettingsSidebar.test.tsx
@@ -111,9 +111,7 @@ function renderSidebar(
         ]}
         repoSections={[]}
         hasRepos={false}
-        searchQuery=""
         onBack={vi.fn()}
-        onSearchChange={vi.fn()}
         onSelectSection={vi.fn()}
       />
     </TooltipProvider>

--- a/src/renderer/src/components/settings/SettingsSidebar.tsx
+++ b/src/renderer/src/components/settings/SettingsSidebar.tsx
@@ -18,6 +18,7 @@ import type { SettingsSetupGuideProgress } from './settings-setup-guide-progress
 import { translate } from '@/i18n/i18n'
 import { resolveLeftSidebarStyleVariables } from '@/lib/left-sidebar-appearance'
 import { useSystemPrefersDark } from '../terminal-pane/use-system-prefers-dark'
+import { useAppStore } from '@/store'
 
 type NavSection = {
   id: string
@@ -46,11 +47,9 @@ type SettingsSidebarProps = {
   generalGroups: NavGroup[]
   repoSections: RepoNavSection[]
   hasRepos: boolean
-  searchQuery: string
   searchInputRef?: RefObject<HTMLInputElement | null>
   searchAutoFocus?: boolean
   onBack: () => void
-  onSearchChange: (query: string) => void
   onSelectSection: (
     sectionId: string,
     modifiers: {
@@ -60,6 +59,47 @@ type SettingsSidebarProps = {
       altKey: boolean
     }
   ) => void
+}
+
+function SettingsSearchField({
+  searchInputRef,
+  searchAutoFocus = false
+}: Pick<SettingsSidebarProps, 'searchInputRef' | 'searchAutoFocus'>): React.JSX.Element {
+  const searchQuery = useAppStore((state) => state.settingsSearchInputQuery)
+  const onSearchChange = useAppStore((state) => state.setSettingsSearchQuery)
+  const searchShortcutCombos = useShortcutKeyComboDetails('settings.search')
+
+  return (
+    <div className="border-b border-worktree-sidebar-border px-3 py-3">
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          ref={searchInputRef}
+          autoFocus={searchAutoFocus}
+          value={searchQuery}
+          onChange={(event) => onSearchChange(event.target.value)}
+          placeholder={translate(
+            'auto.components.settings.SettingsSidebar.dbceaa8840',
+            'Search settings'
+          )}
+          className="bg-background/60 pl-9 pr-14 text-[13px]"
+        />
+        {searchQuery === '' ? (
+          <span className="pointer-events-none absolute right-2 top-1/2 flex -translate-y-1/2 items-center">
+            {searchShortcutCombos.map((combo) => (
+              <ShortcutKeyCombo
+                key={combo.keys.join('-')}
+                keys={combo.keys}
+                doubleTap={combo.doubleTap}
+                className="inline-flex gap-0.5"
+                separatorClassName="text-[10px] text-muted-foreground"
+              />
+            ))}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  )
 }
 
 type VisibleInstallStatus = Extract<
@@ -134,11 +174,9 @@ export function SettingsSidebar({
   generalGroups,
   repoSections,
   hasRepos,
-  searchQuery,
   searchInputRef,
   searchAutoFocus = false,
   onBack,
-  onSearchChange,
   onSelectSection
 }: SettingsSidebarProps): React.JSX.Element {
   const setupGuideProgress = useSettingsSetupGuideProgress(true)
@@ -152,7 +190,6 @@ export function SettingsSidebar({
   // Settings should remain a stable place to reopen the checklist.
   const showSetupGuideTopRow =
     setupGuideProgress.ready && setupGuideProgress.doneCount < setupGuideProgress.total
-  const searchShortcutCombos = useShortcutKeyComboDetails('settings.search')
   const navItemClassName = (isActive: boolean): string =>
     cn(
       'flex w-full items-center gap-2 rounded-lg px-3 py-1.5 text-left text-[13px] outline-none transition-colors duration-150 focus-visible:ring-[3px] focus-visible:ring-worktree-sidebar-ring/50',
@@ -194,35 +231,7 @@ export function SettingsSidebar({
         </Button>
       </div>
 
-      <div className="border-b border-worktree-sidebar-border px-3 py-3">
-        <div className="relative">
-          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            ref={searchInputRef}
-            autoFocus={searchAutoFocus}
-            value={searchQuery}
-            onChange={(event) => onSearchChange(event.target.value)}
-            placeholder={translate(
-              'auto.components.settings.SettingsSidebar.dbceaa8840',
-              'Search settings'
-            )}
-            className="bg-background/60 pl-9 pr-14 text-[13px]"
-          />
-          {searchQuery === '' ? (
-            <span className="pointer-events-none absolute right-2 top-1/2 flex -translate-y-1/2 items-center">
-              {searchShortcutCombos.map((combo) => (
-                <ShortcutKeyCombo
-                  key={combo.keys.join('-')}
-                  keys={combo.keys}
-                  doubleTap={combo.doubleTap}
-                  className="inline-flex gap-0.5"
-                  separatorClassName="text-[10px] text-muted-foreground"
-                />
-              ))}
-            </span>
-          ) : null}
-        </div>
-      </div>
+      <SettingsSearchField searchInputRef={searchInputRef} searchAutoFocus={searchAutoFocus} />
 
       {showSetupGuideTopRow ? (
         <div className="border-b border-worktree-sidebar-border px-3 py-3">

--- a/src/renderer/src/components/sidebar/sleep-worktree-activation-race.test.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-activation-race.test.ts
@@ -96,12 +96,14 @@ describe('sleep flow vs slept-workspace activation', () => {
     expect(mocks.activateAndRevealWorktree).toHaveBeenCalledTimes(1)
   })
 
-  it('does not activate a slept worktree when VM resume fails', async () => {
+  it('keeps the slept worktree selected when VM resume fails', async () => {
     mocks.resumeWorkspace.mockRejectedValueOnce(new Error('provider unavailable'))
 
     await activateWorktreeFromSidebar('wt-parent')
 
-    expect(mocks.activateAndRevealWorktree).not.toHaveBeenCalled()
+    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-parent', {
+      revealInSidebar: false
+    })
     expect(mocks.toastError).toHaveBeenCalledWith(
       'Failed to wake ephemeral VM workspace',
       expect.objectContaining({ description: 'provider unavailable' })

--- a/src/renderer/src/components/terminal-pane/terminal-hidden-worktree-retention.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-hidden-worktree-retention.test.ts
@@ -6,12 +6,54 @@ import {
 } from '../terminal/terminal-provider-snapshot-capability'
 import {
   TERMINAL_HIDDEN_WORKTREE_RETENTION_TTL_MS,
+  getTerminalWorktreeParkingInputsKey,
   hasPendingRetentionSpawnWork,
   isEvictionExemptTerminalPty,
   selectForceParkEvictableTabIds,
   selectRetentionForceParkedTerminalWorktrees,
   type TerminalWorktreeRetentionCandidate
 } from './terminal-hidden-worktree-retention'
+
+describe('getTerminalWorktreeParkingInputsKey', () => {
+  const tabs = {
+    'repo::/worktree': [
+      {
+        id: 'tab-1',
+        ptyId: 'repo::/worktree@@pty-1',
+        pendingActivationSpawn: undefined,
+        title: 'Original title'
+      }
+    ]
+  }
+
+  it('ignores display-only tab changes', () => {
+    const retitledTabs = {
+      'repo::/worktree': [{ ...tabs['repo::/worktree'][0], title: 'Updated title' }]
+    }
+    expect(getTerminalWorktreeParkingInputsKey(retitledTabs)).toBe(
+      getTerminalWorktreeParkingInputsKey(tabs)
+    )
+  })
+
+  it('changes for inputs consumed by the parking policy', () => {
+    const original = getTerminalWorktreeParkingInputsKey(tabs)
+    expect(
+      getTerminalWorktreeParkingInputsKey({
+        'repo::/worktree': [{ ...tabs['repo::/worktree'][0], ptyId: null }]
+      })
+    ).not.toBe(original)
+    expect(
+      getTerminalWorktreeParkingInputsKey({
+        'repo::/worktree': [{ ...tabs['repo::/worktree'][0], pendingActivationSpawn: true }]
+      })
+    ).not.toBe(original)
+    expect(
+      getTerminalWorktreeParkingInputsKey({
+        'repo::/worktree': [{ ...tabs['repo::/worktree'][0], id: 'tab-2' }]
+      })
+    ).not.toBe(original)
+  })
+})
 
 describe('hasPendingRetentionSpawnWork', () => {
   const remoteTab = {

--- a/src/renderer/src/components/terminal-pane/terminal-hidden-worktree-retention.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-hidden-worktree-retention.ts
@@ -30,6 +30,19 @@ import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 export const TERMINAL_HIDDEN_WORKTREE_RETENTION_LIMIT = 4
 export const TERMINAL_HIDDEN_WORKTREE_RETENTION_TTL_MS = 15 * 60_000
 
+type TerminalWorktreeParkingTab = Pick<TerminalTab, 'id' | 'ptyId' | 'pendingActivationSpawn'>
+
+export function getTerminalWorktreeParkingInputsKey(
+  tabsByWorktree: Readonly<Record<string, readonly TerminalWorktreeParkingTab[]>>
+): string {
+  return JSON.stringify(
+    Object.entries(tabsByWorktree).map(([worktreeId, tabs]) => [
+      worktreeId,
+      tabs.map((tab) => [tab.id, tab.ptyId, tab.pendingActivationSpawn])
+    ])
+  )
+}
+
 export function hasPendingRetentionSpawnWork(
   tab: Pick<TerminalTab, 'id' | 'ptyId' | 'pendingActivationSpawn'>,
   pendingStartupByTabId: Readonly<Record<string, unknown>>

--- a/src/renderer/src/lib/sidebar-worktree-activation.test.ts
+++ b/src/renderer/src/lib/sidebar-worktree-activation.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   activateAndRevealFolderWorkspace: vi.fn(),
@@ -16,6 +16,10 @@ describe('sidebar worktree activation', () => {
   beforeEach(() => {
     mocks.activateAndRevealWorktree.mockClear()
     mocks.activateAndRevealFolderWorkspace.mockClear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   it('activates a clicked worktree without sidebar reveal', async () => {
@@ -36,6 +40,29 @@ describe('sidebar worktree activation', () => {
     expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-slept', {
       revealInSidebar: false
     })
+  })
+
+  it('switches immediately while an ephemeral runtime wake is pending', async () => {
+    let resolveResume: ((value: null) => void) | undefined
+    const resumeWorkspace = vi.fn(
+      () =>
+        new Promise<null>((resolve) => {
+          resolveResume = resolve
+        })
+    )
+    vi.stubGlobal('window', {
+      api: { ephemeralVm: { resumeWorkspace } }
+    })
+
+    const activation = activateWorktreeFromSidebar('wt-vm')
+
+    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-vm', {
+      revealInSidebar: false
+    })
+    expect(resumeWorkspace).toHaveBeenCalledWith({ workspaceId: 'wt-vm' })
+
+    resolveResume?.(null)
+    await activation
   })
 
   it('routes folder workspace activation through the guarded folder path', async () => {

--- a/src/renderer/src/lib/sidebar-worktree-activation.ts
+++ b/src/renderer/src/lib/sidebar-worktree-activation.ts
@@ -22,6 +22,11 @@ export async function activateWorktreeFromSidebar(
     }
     return
   }
+  // Keep navigation independent from an optional runtime wake IPC.
+  activateAndRevealWorktree(worktreeId, {
+    revealInSidebar: false,
+    ...(executionHostId ? { executionHostId } : {})
+  })
 
   if (typeof window !== 'undefined' && window.api?.ephemeralVm?.resumeWorkspace) {
     try {
@@ -41,14 +46,6 @@ export async function activateWorktreeFromSidebar(
           description: error instanceof Error ? error.message : String(error)
         }
       )
-      return
     }
   }
-
-  // Why: sidebar clicks already happen on a visible row; revealing again can
-  // jump duplicate pinned/canonical entries back to the first mounted copy.
-  activateAndRevealWorktree(worktreeId, {
-    revealInSidebar: false,
-    ...(executionHostId ? { executionHostId } : {})
-  })
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​74 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​69 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​72 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​50 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 |

<!-- /orca-pr-loc -->

## ELI5

Orca had three chores in the path of two simple actions. It repeatedly rechecked every parked terminal when only a terminal label changed, rebuilt most of Settings for every search keystroke, and waited for the backend before showing a workspace switch. With hundreds of worktrees and terminals, those chores could crowd out clicks and delay the search timer. This PR narrows the terminal check to meaningful changes, keeps typing local to the search box, and makes navigation independent from a slow backend wake-up.

## Problem

The live packaged app became intermittently unusable at accumulated-state scale:

- 393 worktrees and 193 terminal sessions
- renderer sampled at 109–111% CPU during the stall
- main sampled at 25% CPU
- Settings accepted text, but the result-driving debounce could not run promptly
- worktree clicks waited on optional VM-resume IPC before changing local navigation state

The app later becoming responsive without a restart is consistent with a burst that eventually drained, rather than a permanently dead process. This PR removes work from the interaction path so the same kind of burst is less able to starve input and navigation.

## What this solution fixes

### 1. Stops display-only terminal churn from starting global parking work

`Terminal` stays mounted across routes and watches terminal tabs for every worktree. The parking effect previously depended on the complete `tabsByWorktree` object, so any immutable tab update—including a title change—could rerun worktree parking, watcher reconciliation, retention, and timer bookkeeping across the mounted terminal fleet.

The effect now depends on a semantic key containing only the fields the parking policy consumes:

- worktree ID
- terminal tab ID
- PTY ID
- pending activation/spawn state

Title-only and other display-only changes therefore do not start the global parking pass. Real lifecycle changes still do.

### 2. Keeps each Settings keystroke out of the full Settings render tree

Settings has an immediate input value and a separately debounced query that drives filtering. The full Settings parent previously subscribed to the immediate value only to pass it back to the search box. Every keystroke could therefore rebuild the large Settings tree before the debounced query applied; under renderer saturation, the trailing timer was delayed repeatedly, producing “text changes but results do not.”

The immediate subscription now lives inside the search-field component. Typing updates the input immediately without rerendering every Settings section. The parent remains subscribed only to the applied query used for filtering.

### 3. Makes worktree navigation local-first instead of backend-gated

A sidebar click previously awaited optional ephemeral-runtime resume IPC before publishing the selected worktree. If the provider or backend was slow, the visible workspace did not change and the click looked ignored.

The click now publishes the local worktree selection first, then wakes and refreshes the runtime asynchronously. A slow backend can leave the selected workspace temporarily disconnected, but it cannot trap navigation on the previous workspace. Wake failures still produce an error toast.

## Expected user-visible result

- Worktree clicks change the selected workspace immediately.
- Settings typing stays responsive and matching sections appear after the existing debounce.
- Routine terminal title/output activity no longer causes unnecessary fleet-wide parking passes.
- Backend wake failures remain visible without making the rest of the UI unclickable.

## Tradeoff

A slow or failed VM wake now shows the selected workspace in a loading/disconnected state instead of keeping the user on the previous workspace until wake succeeds. No terminal is deleted or shut down by this ordering change.

## Scope

This PR targets the renderer interaction paths directly associated with the observed symptoms. It does not claim to eliminate every source of background work: the live profile also has large persisted state, Git activity, and terminal inventory. Those remain separate performance surfaces.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/sleep-worktree-activation-race.test.ts src/renderer/src/lib/sidebar-worktree-activation.test.ts src/renderer/src/store/slices/settings-search-state.test.ts src/renderer/src/components/settings/SettingsSidebar.test.tsx src/renderer/src/components/settings/Settings.load-performance.test.ts src/renderer/src/components/terminal-pane/terminal-hidden-worktree-retention.test.ts`
  - 6 files, 34 tests passed
- `pnpm run typecheck:web`
- Electron/CDP smoke on the branch:
  - attached to `Orca: fix/live-ui-backend-starvation`
  - Settings search visibly changed from no results to the matching General → Editor → Minimap control
  - loaded the repo catalog showing 348 discovered worktrees
  - replaced `ephemeralVm.resumeWorkspace` with a never-settling promise, clicked the real workspace row, and observed `activeWorktreeId` plus the terminal surface update immediately
