### PR TITLE
test(agent-status): characterize title-derived agent identity before the resolver change

### DIFF
--- a/src/shared/agent-title-identity-characterization.test.ts
+++ b/src/shared/agent-title-identity-characterization.test.ts
@@ -38,12 +38,20 @@ describe('getAgentLabel — characterization (pre-refactor)', () => {
       )
     })
 
-    it('reads a Grok pane as Gemini CLI when its task text names two other agents', () => {
-      // DEFECT, and the inverse of the reported Antigravity bug: the pane is Grok, the task
-      // text mentions Antigravity and Gemini, and Gemini CLI is checked earliest of the three.
+    it('resolves a Grok pane naming two other agents, but only by a targeted exception', () => {
+      // Fixed by #15535, which teaches the Gemini token branch to decline when an Antigravity
+      // name is present. Correct here only because that exception happens to clear the path to
+      // Grok — drop the word "Antigravity" and it reads as Gemini CLI again (next case).
       expect(
         getAgentLabel(ownerSuffix('Electron QA: Antigravity tab vs Gemini label', 'grok'))
-      ).toBe('Gemini CLI')
+      ).toBe('Grok')
+    })
+
+    it('still reads a Grok pane as Gemini CLI when no exception covers the pair', () => {
+      // DEFECT, and the general form of the case above: one narrowing fixes one collision.
+      expect(getAgentLabel(ownerSuffix('Electron QA: check the Gemini label', 'grok'))).toBe(
+        'Gemini CLI'
+      )
     })
 
     it('resolves the owner suffix correctly only when no earlier agent is named', () => {
@@ -69,8 +77,8 @@ describe('getAgentLabel — characterization (pre-refactor)', () => {
     it.each([
       ['codex', 'grok', 'Codex'],
       ['grok', 'codex', 'Codex'],
-      ['gemini', 'antigravity', 'Gemini CLI'],
-      ['antigravity', 'gemini', 'Gemini CLI'],
+      ['gemini', 'antigravity', 'Antigravity'],
+      ['antigravity', 'gemini', 'Antigravity'],
       ['copilot', 'devin', 'GitHub Copilot'],
       ['devin', 'copilot', 'GitHub Copilot']
     ])('%s + %s both resolve to %s', (first, second, winner) => {
@@ -94,19 +102,18 @@ describe('getAgentLabel — characterization (pre-refactor)', () => {
     })
   })
 
-  describe('Antigravity model names are read as Gemini CLI', () => {
-    it('reads an Antigravity model title as Gemini CLI', () => {
+  describe('Antigravity model names', () => {
+    it('reads a bare Antigravity model title as Gemini CLI', () => {
       // DEFECT. Antigravity models are named `Gemini <n.n> <Name>`, so an agy pane's own title
       // carries a whole `gemini` token, and Gemini CLI is checked first.
       expect(getAgentLabel('Gemini 3.7 Flash · high')).toBe('Gemini CLI')
     })
 
-    it('still reads Gemini CLI even when the Antigravity name is also present', () => {
-      // DEFECT. `AGY_AGENT_NAME_RE` is checked in the Antigravity branch at position 12, so an
-      // explicit `agy` identity segment cannot outrank the model name at position 4. This is the
-      // case PR #15535 patches by teaching the Gemini detector to decline; the resolver instead
-      // treats the agy segment as the anchored identity and `Gemini <n.n> <Name>` as metadata.
-      expect(getAgentLabel('agy · Gemini 3.7 Flash')).toBe('Gemini CLI')
+    it('resolves once the Antigravity name is also present', () => {
+      // Fixed by #15535. The resolver reaches the same answer structurally — the agy segment is
+      // the anchored identity and `Gemini <n.n> <Name>` is model metadata — rather than by
+      // teaching one detector about one competitor.
+      expect(getAgentLabel('agy · Gemini 3.7 Flash')).toBe('Antigravity')
     })
   })
 })

--- a/src/shared/agent-title-identity-characterization.test.ts
+++ b/src/shared/agent-title-identity-characterization.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest'
+import { getAgentLabel } from './agent-title-identity'
+
+/**
+ * Characterization of `getAgentLabel` before the identity refactor.
+ *
+ * `getAgentLabel` is an ordered first-match-wins scan of substring predicates over a display
+ * title, so chain position — not evidence strength — decides identity. These tests pin the
+ * current answers, including the wrong ones, so the resolver change shows up as a reviewable
+ * diff of assertions rather than as silent behavior drift.
+ *
+ * Cases marked DEFECT are minimized from real recorded pane titles
+ * (`terminal-history/<id>/checkpoint.json` -> `lastTitle`). At the time of writing the live
+ * corpus held 2,846 checkpoints / 1,084 populated titles / 747 distinct, of which 5 real titles
+ * resolved to the wrong agent. Task text is minimized here; the corpus stays local.
+ */
+
+/** Orca's own owner suffix: the agent that owns the pane is named after the final `- `. */
+const ownerSuffix = (task: string, agent: string): string => `${task}… - ${agent}`
+
+describe('getAgentLabel — characterization (pre-refactor)', () => {
+  describe('the owner suffix loses to a foreign name in task text', () => {
+    // DEFECT. In each case the pane owner is Grok, named by Orca's own `- grok` suffix
+    // grammar, while the competing agent appears only inside free-form task text. Codex is
+    // checked before Grok, so the weaker evidence wins.
+    it.each([
+      ['Switch Claude and Codex off the load balancer', 'Codex'],
+      ['Codex structured chat revalidation', 'Codex'],
+      ['Swap Codex off the load balancer', 'Codex']
+    ])('reads %j as %s instead of Grok', (task, current) => {
+      expect(getAgentLabel(ownerSuffix(task, 'grok'))).toBe(current)
+    })
+
+    it('reads a spinner-prefixed Grok pane as Codex', () => {
+      // DEFECT. Real shape: a status spinner and phase precede the task text.
+      expect(getAgentLabel(`⠸ - Thinking - ${ownerSuffix('Codex native-chat work', 'grok')}`)).toBe(
+        'Codex'
+      )
+    })
+
+    it('reads a Grok pane as Gemini CLI when its task text names two other agents', () => {
+      // DEFECT, and the inverse of the reported Antigravity bug: the pane is Grok, the task
+      // text mentions Antigravity and Gemini, and Gemini CLI is checked earliest of the three.
+      expect(
+        getAgentLabel(ownerSuffix('Electron QA: Antigravity tab vs Gemini label', 'grok'))
+      ).toBe('Gemini CLI')
+    })
+
+    it('resolves the owner suffix correctly only when no earlier agent is named', () => {
+      // Why this passes today: nothing earlier in the chain matches, so position never comes up.
+      expect(getAgentLabel(ownerSuffix('Fix the sidebar row', 'grok'))).toBe('Grok')
+    })
+  })
+
+  describe('a hyphenated worktree name is correctly not identity', () => {
+    // Not a defect — pinned so the resolver does not start claiming these.
+    it.each(['review-14600-codex', 'sta4779-review-codex', 'codex-split-core'])(
+      'declines %j',
+      (title) => {
+        expect(getAgentLabel(title)).toBeNull()
+      }
+    )
+  })
+
+  describe('chain position, not evidence strength, decides between two names', () => {
+    // The pairwise property: whichever agent is checked first wins, regardless of which one
+    // the title's grammar actually identifies. Both orderings of the same pair agree, which is
+    // the tell — the title carries no signal that distinguishes them.
+    it.each([
+      ['codex', 'grok', 'Codex'],
+      ['grok', 'codex', 'Codex'],
+      ['gemini', 'antigravity', 'Gemini CLI'],
+      ['antigravity', 'gemini', 'Gemini CLI'],
+      ['copilot', 'devin', 'GitHub Copilot'],
+      ['devin', 'copilot', 'GitHub Copilot']
+    ])('%s + %s both resolve to %s', (first, second, winner) => {
+      expect(getAgentLabel(`${first} and ${second}`)).toBe(winner)
+    })
+  })
+
+  describe('a vendor glyph is claimed by whichever check sits earliest', () => {
+    it('claims a Claude glyph even when the task text names another agent', () => {
+      // Correct today (the pane really is Claude) but for the wrong reason: the glyph is not
+      // consulted as vendor evidence, the `✳ ` prefix branch simply sits first.
+      expect(getAgentLabel('✳ Fix Codex false attention notifications on Windows')).toBe(
+        'Claude Code'
+      )
+    })
+
+    it('gives a bare agent name no way to outrank an earlier glyph check', () => {
+      // DEFECT. `agy` is the entire undecorated remainder — the strongest possible name
+      // evidence — and still loses to Claude's prefix glyph.
+      expect(getAgentLabel('✳ agy')).toBe('Claude Code')
+    })
+  })
+
+  describe('Antigravity model names are read as Gemini CLI', () => {
+    it('reads an Antigravity model title as Gemini CLI', () => {
+      // DEFECT. Antigravity models are named `Gemini <n.n> <Name>`, so an agy pane's own title
+      // carries a whole `gemini` token, and Gemini CLI is checked first.
+      expect(getAgentLabel('Gemini 3.7 Flash · high')).toBe('Gemini CLI')
+    })
+
+    it('still reads Gemini CLI even when the Antigravity name is also present', () => {
+      // DEFECT. `AGY_AGENT_NAME_RE` is checked in the Antigravity branch at position 12, so an
+      // explicit `agy` identity segment cannot outrank the model name at position 4. This is the
+      // case PR #15535 patches by teaching the Gemini detector to decline; the resolver instead
+      // treats the agy segment as the anchored identity and `Gemini <n.n> <Name>` as metadata.
+      expect(getAgentLabel('agy · Gemini 3.7 Flash')).toBe('Gemini CLI')
+    })
+  })
+})

--- a/src/shared/agent-title-identity-characterization.test.ts
+++ b/src/shared/agent-title-identity-characterization.test.ts
@@ -4,10 +4,10 @@ import { getAgentLabel } from './agent-title-identity'
 /**
  * Characterization of `getAgentLabel` before the identity refactor.
  *
- * `getAgentLabel` is an ordered first-match-wins scan of substring predicates over a display
- * title, so chain position — not evidence strength — decides identity. These tests pin the
- * current answers, including the wrong ones, so the resolver change shows up as a reviewable
- * diff of assertions rather than as silent behavior drift.
+ * `getAgentLabel` is an ordered first-match-wins scan of title predicates. Detector precedence
+ * and targeted exceptions — not a unified evidence model — decide identity. These tests pin
+ * the current answers, including the wrong ones, so the resolver change shows up as a
+ * reviewable diff of assertions rather than as silent behavior drift.
  *
  * Cases marked DEFECT are minimized from real recorded pane titles
  * (`terminal-history/<id>/checkpoint.json` -> `lastTitle`). At the time of writing the live
@@ -70,10 +70,9 @@ describe('getAgentLabel — characterization (pre-refactor)', () => {
     )
   })
 
-  describe('chain position, not evidence strength, decides between two names', () => {
-    // The pairwise property: whichever agent is checked first wins, regardless of which one
-    // the title's grammar actually identifies. Both orderings of the same pair agree, which is
-    // the tell — the title carries no signal that distinguishes them.
+  describe('title order does not decide between two names', () => {
+    // Both orderings of each pair agree: detector precedence and its targeted exceptions,
+    // rather than name order within the title, choose the label.
     it.each([
       ['codex', 'grok', 'Codex'],
       ['grok', 'codex', 'Codex'],


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​118 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​118 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## ELI5

Orca works out which agent is in a pane by scanning its terminal title for agent names, in a fixed order, first match wins. Whoever is checked first wins — even when the title's own grammar names someone else. This PR adds no product code; it writes down exactly what that scan answers today, including the answers that are wrong, so the upcoming resolver change shows up as a reviewable diff of assertions instead of silent drift.

## What Changed

One new test file, 19 assertions, no production change.

**8 assertions record defects.** Five are minimized from **real recorded pane titles** — four Grok panes that resolve to `Codex` and one that resolves to `Gemini CLI`. In each case the pane owner is named by Orca's own `- <agent>` suffix, and a foreign agent name sitting in free-form task text is checked earlier in the chain, so the weaker evidence wins.

The last one is the reported Antigravity bug in reverse: a **Grok** pane whose task text mentions Antigravity and Gemini resolves to `Gemini CLI`.

**The pairwise property behind them is pinned too.** For a title naming two agents, both orderings resolve to the same agent (`codex and grok` and `grok and codex` are both `Codex`). That symmetry is the tell: the title carries no signal that distinguishes the two, so the answer is coming from chain position alone.

**Correct behavior is pinned as well**, so the resolver does not regress it: hyphenated worktree names (`review-14600-codex`, `codex-split-core`) stay unclassified, and a Claude vendor glyph still beats foreign task text.

## Why

The identity chain is an ordered scan of substring predicates over a display string, where list position *is* the semantics. That makes it fragile against text users type into task titles, and it cannot be fixed by reordering: hoisting any branch to fix one collision breaks another. Before replacing it, the current answers need to be written down — a refactor of ordering semantics is exactly the kind that regresses quietly, because every wrong answer still looks like a plausible agent name.

The 5 real cases came from scanning the local recorded-title corpus (2,846 checkpoints / 1,084 populated titles / 747 distinct at time of writing). The corpus contains task text and stays local; only minimized cases are committed.

## Testing

`pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-title-identity-characterization.test.ts` — 19 passed.

**Proven non-vacuous.** A characterization suite is only worth having if it fails when the implementation moves, so that was checked rather than assumed: applying #15535's narrowing to `isGeminiTerminalTitle` flips exactly 4 assertions — including one of the real corpus titles — and the suite is green again on revert.

That result is also worth flagging on its own: **#15535 fixes one of the 5 real misclassifications**, not just the synthetic Antigravity case it was opened for.

typecheck, oxlint and oxfmt clean.

## Linked Issue

Fixes #