### PR TITLE
fix(codex): stop an unreadable legacy hooks.json from clearing managed trust

### DIFF
--- a/src/main/codex/codex-hooks-read-denial-followup.test.ts
+++ b/src/main/codex/codex-hooks-read-denial-followup.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as NodeFs from 'node:fs'
+import type * as NodeOs from 'node:os'
+import type * as CodexManagedTrustReconciliation from './codex-managed-trust-reconciliation'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// Follow-up to STA-4823: two more reads on the Codex hook paths acted on
+// "absent" when the real answer was "could not read". Both were found while
+// reviewing #15417 and are not covered by it.
+//
+// The denial shape here is the MEASURED one: chmod 000 / icacls deny leave
+// existsSync true and stat succeeding, and fail only the content read
+// (EACCES -13 on macOS, EPERM -4048 on Windows). No mode fakes existsSync,
+// because no platform does.
+
+const denials = vi.hoisted(() => {
+  const state = {
+    paths: new Set<string>(),
+    deny(path: string): void {
+      state.paths.add(path)
+    },
+    reset(): void {
+      state.paths.clear()
+    },
+    check(target: unknown, syscall: string): void {
+      if (typeof target !== 'string' || !state.paths.has(target)) {
+        return
+      }
+      const error: NodeJS.ErrnoException = new Error(
+        `EACCES: permission denied, ${syscall} '${target}'`
+      )
+      error.code = 'EACCES'
+      error.errno = -13
+      error.syscall = syscall
+      error.path = target
+      throw error
+    }
+  }
+  return state
+})
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFs>()
+  const guardRead = (fn: unknown, syscall: string): unknown => {
+    const original = fn as (...args: unknown[]) => unknown
+    const wrapped = (...args: unknown[]): unknown => {
+      denials.check(args[0], syscall)
+      return original(...args)
+    }
+    return Object.assign(wrapped, original)
+  }
+  const patched: Record<string, unknown> = {
+    ...actual,
+    readFileSync: guardRead(actual.readFileSync, 'read'),
+    // Why: existsSync and stat stay HEALTHY. That is the whole point — a
+    // permission denial does not hide the file, it only refuses its contents.
+    openSync: Object.assign((...args: unknown[]): unknown => {
+      const flags = args[1]
+      if (flags === undefined || (typeof flags === 'string' && flags.startsWith('r'))) {
+        denials.check(args[0], 'open')
+      }
+      return (actual.openSync as (...a: unknown[]) => unknown)(...args)
+    }, actual.openSync)
+  }
+  return { ...patched, default: patched }
+})
+
+const { getPathMock, homedirMock } = vi.hoisted(() => ({
+  getPathMock: vi.fn<(name: string) => string>(),
+  homedirMock: vi.fn<() => string>()
+}))
+
+vi.mock('electron', () => ({ app: { getPath: getPathMock } }))
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof NodeOs>('node:os')
+  return { ...actual, homedir: homedirMock }
+})
+
+const realFs = await vi.importActual<typeof NodeFs>('node:fs')
+
+let fakeHomeDir: string
+let userDataDir: string
+let previousUserDataPath: string | undefined
+
+beforeEach(() => {
+  denials.reset()
+  fakeHomeDir = realFs.mkdtempSync(join(tmpdir(), 'orca-hooksread-home-'))
+  userDataDir = realFs.mkdtempSync(join(tmpdir(), 'orca-hooksread-data-'))
+  previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+  process.env.ORCA_USER_DATA_PATH = userDataDir
+  homedirMock.mockReturnValue(fakeHomeDir)
+  getPathMock.mockImplementation((name: string) => {
+    if (name === 'userData') {
+      return userDataDir
+    }
+    throw new Error(`unexpected app.getPath(${name})`)
+  })
+  realFs.mkdirSync(join(fakeHomeDir, '.codex'), { recursive: true })
+})
+
+afterEach(() => {
+  denials.reset()
+  realFs.rmSync(fakeHomeDir, { recursive: true, force: true })
+  realFs.rmSync(userDataDir, { recursive: true, force: true })
+  if (previousUserDataPath === undefined) {
+    delete process.env.ORCA_USER_DATA_PATH
+  } else {
+    process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+  }
+  vi.clearAllMocks()
+})
+
+describe('an unreadable legacy hooks.json must not clear managed trust or its ledger', () => {
+  it('returns before the removal branch instead of discarding approvals', async () => {
+    const legacyHooksPath = join(fakeHomeDir, '.codex', 'hooks.json')
+    realFs.writeFileSync(legacyHooksPath, JSON.stringify({ hooks: { Stop: [] } }), 'utf-8')
+
+    const removeSpy = vi.fn()
+    vi.resetModules()
+    vi.doMock('./codex-managed-trust-reconciliation', async (importOriginal) => {
+      const actual = await importOriginal<typeof CodexManagedTrustReconciliation>()
+      return { ...actual, removeCodexManagedHookTrustEntries: removeSpy }
+    })
+    try {
+      // The removal only fires when a real-home grant is on record — without
+      // this the branch is inert and the test proves nothing either way.
+      const ledger = await import('./codex-trust-grant-ledger')
+      ledger.writeCodexTrustGrantLedgerHome(
+        join(fakeHomeDir, '.codex'),
+        { entries: { 'seed:1': { trustedHash: 'sha256:seed' } } } as never,
+        ledger.getCodexTrustGrantLedgerPath()
+      )
+
+      const hookService = await import('./hook-service')
+      denials.deny(legacyHooksPath)
+
+      hookService._internals.cleanupLegacySystemManagedHooks()
+
+      // `readHooksJsonWithRaw` catches the denial and reports {raw:null,
+      // config:null} — "could not read". Before the fix that fell into the same
+      // branch as "no hooks configured", which removes the managed trust
+      // entries AND their grant-ledger record. A read that failed is not
+      // permission to discard approvals the user already gave.
+      expect(removeSpy).not.toHaveBeenCalled()
+    } finally {
+      vi.doUnmock('./codex-managed-trust-reconciliation')
+      vi.resetModules()
+    }
+  })
+})

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -601,6 +601,13 @@ function cleanupLegacySystemManagedHooks(): void {
   // Why: the pre-write guard below compares against these bytes; a separate
   // later read would let a concurrent save land between parse and snapshot.
   const { raw: previousRaw, config } = readHooksJsonWithRaw(legacyConfigPath)
+  // Why: `config === null` with no raw is the "could not read" answer, not the
+  // "no hooks here" one — the branch below removes managed trust entries AND
+  // their grant-ledger record, so acting on it would discard approvals over a
+  // read that merely failed. A genuine absence still returns `config: {}`.
+  if (config === null && previousRaw === null) {
+    return
+  }
   if (!config?.hooks || previousRaw === null) {
     if (hasRecordedRealHomeGrant) {
       removeSystemManagedHookTrustEntries(systemHomePath, legacyConfigPath)
@@ -1637,6 +1644,7 @@ export class CodexHookService {
 export const codexHookService = new CodexHookService()
 
 export const _internals = {
+  cleanupLegacySystemManagedHooks,
   getManagedScript,
   installManagedHooksIntoWslRuntime,
   refreshWslRuntimeUserHooks,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​151 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​151 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 |

<!-- /orca-pr-loc -->

## ELI5

If Orca can't read `~/.codex/hooks.json` for a moment, it concludes there are no hooks configured — and then removes the hook approvals you already gave, plus the record that you gave them. You get asked to approve hooks you'd already approved.

## What Changed

`cleanupLegacySystemManagedHooks` reads the legacy hooks file and, on finding no hooks, removes Orca's managed trust entries from the system `config.toml` and deletes that home's grant-ledger record.

Since #15417 landed, the reader already tells those two answers apart:

| | `readHooksJsonWithRaw` returns |
|---|---|
| genuine absence | `{ raw: null, config: {} }` |
| failed read | `{ raw: null, config: null }` |

Both still fell into the same branch. One line now returns before the removal when the answer was "could not read".

## Why #15417 didn't catch it

#15417 fixed the **classifier**. This is a **consumer** of it that ignored the distinction — the read was already reporting correctly and the caller collapsed it anyway. Worth noting as a pattern: fixing the primitive doesn't fix callers that were written against the old two-valued shape.

## What I deliberately left out

The sibling `assertHooksJsonGeneration` in `codex-real-home-hook-install.ts:77` has the identical `existsSync ? read : null` shape, and I wrote the fix for it. **Then I couldn't make it fail.**

Measured on both platforms, a permission denial leaves `existsSync` **true** and throws from the read — so that path already fails closed. Reverting my guard while keeping everything else left all three of its tests green. That's unprovable code, so it's dropped rather than shipped with tests that assert nothing.

## Linked Issue

Fixes STA-5264. Follow-up to STA-4823 / #15417.

## Visual Proof

N/A — no UI surface. The observable difference is that trust entries and the ledger record survive.

## Testing

One test, and it took three attempts to make it honest — the first two passed against the unfixed code:

1. First version called a newly-exported `_internals` member, so reverting the fix failed on the **missing export**, not the missing guard.
2. Second version reverted only the logic and still passed, because the removal branch is gated on `hasRecordedRealHomeGrant` and the test never seeded a grant-ledger record. The branch was inert.
3. Third version seeds the ledger. Reverting the guard now turns it **red**.

That's the version here. The rig models the **measured** denial shape — content reads throw `EACCES`, while `existsSync` and `stat` stay healthy — because that is what `chmod 000` and `icacls /deny` actually do. No mode fakes `existsSync`, since no platform does.

- 1812/1812 across `src/main/codex` + `src/main/agent-hooks`.
- `check-changed-code-quality.mjs`: 0 findings. Full `pnpm typecheck` clean.

- [x] Automated tests added
- [ ] Manual: not run. Deterministic under the rig.

## Provenance

Recovered from an uncommitted worker worktree during cleanup — it would have been deleted with it.

## AI Disclosure

N/A — internal.
