### PR TITLE
feat(agent-status): add an order-independent title evidence parser

### DIFF
--- a/src/shared/agent-title-core.ts
+++ b/src/shared/agent-title-core.ts
@@ -5,7 +5,9 @@ import {
   titleHasAgentName,
   titleHasAnyLegacyAgentName
 } from './agent-name-token-match'
+import { stripLeadingAgentTitleDecorationOrEmpty } from './agent-title-decoration'
 import { isLegacyPiCompatibleTitle } from './pi-compatible-synthetic-title'
+import { getWrapperTitleSegments } from './terminal-title-wrapper-segments'
 
 export { AGY_AGENT_NAME_RE, DROID_AGENT_NAME_RE, HERMES_AGENT_NAME_RE, titleHasAgentName }
 
@@ -139,6 +141,19 @@ export function isClaudeManagementTitle(title: string): boolean {
 
 export function isCursorNativeAgentTitle(title: string): boolean {
   return title.trim().toLowerCase() === CURSOR_NATIVE_TITLE_LOWER
+}
+
+const CLAUDE_IDENTITY_FRAME_RE =
+  /^claude(?: code)?(?:\s+(?:ready|idle|done|working|thinking|running))?(?:\s*-\s*action required)?$/
+
+export function isClaudeIdentityFrameSegment(title: string): boolean {
+  return CLAUDE_IDENTITY_FRAME_RE.test(
+    stripLeadingAgentTitleDecorationOrEmpty(title).trim().toLowerCase()
+  )
+}
+
+export function isClaudeIdentityFrameTitle(title: string): boolean {
+  return getWrapperTitleSegments(title).some(isClaudeIdentityFrameSegment)
 }
 
 // Why: `cursor` is also an ordinary editor noun that other agents type into their own

--- a/src/shared/agent-title-evidence.test.ts
+++ b/src/shared/agent-title-evidence.test.ts
@@ -29,6 +29,13 @@ describe('collectAgentTitleEvidence', () => {
       expect(agentFor('review-14600-codex')).toBeNull()
       expect(agentFor('codex-split-core')).toBeNull()
     })
+
+    it.each(['pi', 'omp', 'claude-agent-teams', 'qwen-code'] as const)(
+      'recognizes the reserved owner id %s',
+      (agent) => {
+        expect(agentFor(`Review another agent… - ${agent}`)).toBe(agent)
+      }
+    )
   })
 
   describe('order independence', () => {
@@ -221,6 +228,7 @@ describe('collectAgentTitleEvidence', () => {
     const wrappers = Array.from({ length: 200 }, (_, index) => `wrapper-${index}`).join(' | ')
     expect(agentFor(`${wrappers} | ⠋ Cursor Agent`)).toBe('cursor')
     expect(agentFor(`${wrappers} | OC | review the parser`)).toBe('opencode')
+    expect(agentFor(`outer-a | outer-b | OC | ${wrappers} | Cursor Agent`)).toBe('cursor')
   })
 
   it.each([

--- a/src/shared/agent-title-evidence.test.ts
+++ b/src/shared/agent-title-evidence.test.ts
@@ -161,6 +161,18 @@ describe('collectAgentTitleEvidence', () => {
     }
   )
 
+  it.each([
+    '~/codex',
+    '/grok',
+    '.\\openclaude',
+    'C:\\codex',
+    'C:/codex',
+    '~/Codex ready',
+    '.\\Cursor ready'
+  ])('does not treat the cwd path %s as identity', (title) => {
+    expect(agentFor(title)).toBeNull()
+  })
+
   it('does not duplicate an anchored token as free text', () => {
     expect(collectAgentTitleEvidence('Codex').freeTextNames).toEqual([])
     expect(collectAgentTitleEvidence('Claude Agent Teams').freeTextNames).toEqual([])

--- a/src/shared/agent-title-evidence.test.ts
+++ b/src/shared/agent-title-evidence.test.ts
@@ -145,8 +145,8 @@ describe('collectAgentTitleEvidence', () => {
     }
   )
 
-  it('does not treat an emitted label as free text', () => {
-    expect(collectAgentTitleEvidence('Prime Agent').freeTextNames).toEqual([])
+  it('does not duplicate an anchored token as free text', () => {
+    expect(collectAgentTitleEvidence('Codex').freeTextNames).toEqual([])
   })
 
   it.each([

--- a/src/shared/agent-title-evidence.test.ts
+++ b/src/shared/agent-title-evidence.test.ts
@@ -1,4 +1,10 @@
 import { describe, expect, it } from 'vitest'
+import {
+  GEMINI_IDLE,
+  GEMINI_PERMISSION,
+  GEMINI_SILENT_WORKING,
+  GEMINI_WORKING
+} from './agent-title-core'
 import { collectAgentTitleEvidence } from './agent-title-evidence'
 
 const agentFor = (title: string) => collectAgentTitleEvidence(title).agent
@@ -96,9 +102,12 @@ describe('collectAgentTitleEvidence', () => {
       expect(agentFor('Gemini 3.7 Flash · high')).toBeNull()
     })
 
-    it('still resolves a real Gemini glyph', () => {
-      expect(agentFor('✦ Refactor the parser')).toBe('gemini')
-    })
+    it.each([GEMINI_WORKING, GEMINI_SILENT_WORKING, GEMINI_IDLE, GEMINI_PERMISSION])(
+      'still resolves the real Gemini marker %s',
+      (marker) => {
+        expect(agentFor(`${marker} Refactor the parser`)).toBe('gemini')
+      }
+    )
 
     it('does not promote model names in task text', () => {
       expect(agentFor('Compare Antigravity with Gemini 3.7 Flash')).toBeNull()
@@ -147,6 +156,7 @@ describe('collectAgentTitleEvidence', () => {
 
   it('does not duplicate an anchored token as free text', () => {
     expect(collectAgentTitleEvidence('Codex').freeTextNames).toEqual([])
+    expect(collectAgentTitleEvidence('Claude Agent Teams').freeTextNames).toEqual([])
   })
 
   it.each([
@@ -177,6 +187,14 @@ describe('collectAgentTitleEvidence', () => {
     expect(agentFor('Fix the Claude Code ready-state parser')).toBeNull()
     expect(agentFor('Fix Claude Code ready behavior… - grok')).toBe('grok')
   })
+
+  it.each(['. Review the parser', '* Waiting for input'])(
+    'recognizes the established Claude status prefix in %s',
+    (title) => {
+      expect(agentFor(title)).toBe('claude')
+      expect(reasonFor(title)).toBe('vendor-marker')
+    }
+  )
 
   it.each([
     ['⠋ Cursor Agent', 'cursor'],

--- a/src/shared/agent-title-evidence.test.ts
+++ b/src/shared/agent-title-evidence.test.ts
@@ -240,6 +240,7 @@ describe('collectAgentTitleEvidence', () => {
 
   it('does not invent synthetic titles for an opted-out profile', () => {
     expect(agentFor('OpenCode ready')).toBeNull()
+    expect(agentFor('⠋ OpenCode')).toBeNull()
     expect(reasonFor('OpenCode ready')).toBe('free-text-only')
   })
 

--- a/src/shared/agent-title-evidence.test.ts
+++ b/src/shared/agent-title-evidence.test.ts
@@ -132,7 +132,10 @@ describe('collectAgentTitleEvidence', () => {
     it.each([
       '◐ DaemonConnectionLostError with 70 Codex agents',
       'Fix the grok hook',
-      'Debug the cursor sidecar'
+      'Debug the cursor sidecar',
+      'grok',
+      '⠋ grok',
+      '⠋ codex'
     ])('declines %j', (title) => {
       expect(agentFor(title)).toBeNull()
       expect(reasonFor(title)).toBe('free-text-only')
@@ -174,7 +177,7 @@ describe('collectAgentTitleEvidence', () => {
   })
 
   it('does not duplicate an anchored token as free text', () => {
-    expect(collectAgentTitleEvidence('Codex').freeTextNames).toEqual([])
+    expect(collectAgentTitleEvidence('codex.exe').freeTextNames).toEqual([])
     expect(collectAgentTitleEvidence('Claude Agent Teams').freeTextNames).toEqual([])
   })
 

--- a/src/shared/agent-title-evidence.test.ts
+++ b/src/shared/agent-title-evidence.test.ts
@@ -195,6 +195,14 @@ describe('collectAgentTitleEvidence', () => {
     expect(reasonFor(title)).toBe('anchored')
   })
 
+  it.each(['Droid', 'Hermes', 'Devin'])(
+    'does not treat a bare working label as synthetic identity: %s',
+    (title) => {
+      expect(agentFor(title)).toBeNull()
+      expect(reasonFor(title)).toBe('free-text-only')
+    }
+  )
+
   it.each([
     'Claude Code ready',
     'Claude thinking',
@@ -221,7 +229,10 @@ describe('collectAgentTitleEvidence', () => {
   it.each([
     ['⠋ Cursor Agent', 'cursor'],
     ['⠋ Pi idle', 'pi'],
-    ['⠋ OMP done', 'omp']
+    ['⠋ OMP done', 'omp'],
+    ['⠋ Droid', 'droid'],
+    ['⠋ Hermes', 'hermes'],
+    ['⠋ Devin', 'devin']
   ] as const)('recognizes the decorated identity frame %s', (title, agent) => {
     expect(agentFor(title)).toBe(agent)
     expect(reasonFor(title)).toBe('anchored')

--- a/src/shared/agent-title-evidence.test.ts
+++ b/src/shared/agent-title-evidence.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest'
 import { collectAgentTitleEvidence } from './agent-title-evidence'
-import { ALL_TUI_AGENTS, TUI_AGENT_DISPLAY_NAMES } from './tui-agent-display-names'
 
 const agentFor = (title: string) => collectAgentTitleEvidence(title).agent
 const reasonFor = (title: string) => collectAgentTitleEvidence(title).reason
@@ -113,25 +112,30 @@ describe('collectAgentTitleEvidence', () => {
     })
   })
 
-  it.each(ALL_TUI_AGENTS)('recognizes the canonical whole-title label for %s', (agent) => {
-    const title = TUI_AGENT_DISPLAY_NAMES[agent]
-    expect(collectAgentTitleEvidence(title)).toMatchObject({
-      agent,
-      reason: 'anchored'
-    })
-  })
-
-  it('does not treat an exact display name as free text', () => {
-    expect(collectAgentTitleEvidence('Grok').freeTextNames).toEqual([])
-  })
-
   it.each([
     ['Claude Code', 'claude'],
     ['Gemini CLI', 'gemini'],
+    ['Claude Agent Teams', 'claude-agent-teams'],
+    ['MiMo Code', 'mimo-code'],
+    ['Prime Agent', 'prime-agent'],
+    ['Command Code', 'command-code'],
+    ['GitHub Copilot', 'copilot'],
     ['Agent Teams', 'claude-agent-teams']
   ] as const)('recognizes the emitted whole-title alias %s', (title, agent) => {
     expect(agentFor(title)).toBe(agent)
     expect(reasonFor(title)).toBe('anchored')
+  })
+
+  it.each(['Continue', 'Charm', 'Goose', 'Amp'])(
+    'does not treat the UI-only display label %s as identity',
+    (title) => {
+      expect(agentFor(title)).toBeNull()
+      expect(reasonFor(title)).toBe('no-evidence')
+    }
+  )
+
+  it('does not treat an emitted label as free text', () => {
+    expect(collectAgentTitleEvidence('Prime Agent').freeTextNames).toEqual([])
   })
 
   it.each([

--- a/src/shared/agent-title-evidence.test.ts
+++ b/src/shared/agent-title-evidence.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest'
+import { collectAgentTitleEvidence } from './agent-title-evidence'
+
+const agentFor = (title: string) => collectAgentTitleEvidence(title).agent
+const reasonFor = (title: string) => collectAgentTitleEvidence(title).reason
+
+describe('collectAgentTitleEvidence', () => {
+  describe('an anchored name outranks a name in task text', () => {
+    // Minimized from real recorded titles that resolve to the wrong agent on the ordered chain:
+    // the pane owner is named by Orca's `- <agent>` suffix, the competitor only by task text.
+    it.each([
+      'Switch Claude and Codex off the load balancer… - grok',
+      'Codex structured chat revalidation… - grok',
+      '⠸ - Thinking - Codex native-chat work… - grok',
+      'Electron QA: check the Gemini label… - grok'
+    ])('resolves %j to the suffix owner', (title) => {
+      expect(agentFor(title)).toBe('grok')
+    })
+
+    it('does not read a hyphenated worktree name as an owner suffix', () => {
+      // `review-14600-codex` is a directory, not an owner declaration. The suffix grammar
+      // requires whitespace before the dash precisely to keep these apart.
+      expect(agentFor('review-14600-codex')).toBeNull()
+      expect(agentFor('codex-split-core')).toBeNull()
+    })
+  })
+
+  describe('order independence', () => {
+    // The defect this replaces is that chain position decides between two names. Swapping the
+    // two names in a title must not change the answer.
+    it.each([
+      ['codex', 'grok'],
+      ['gemini', 'antigravity'],
+      ['copilot', 'devin'],
+      ['claude', 'cursor']
+    ])('gives %s + %s the same answer in both orders', (a, b) => {
+      const forward = collectAgentTitleEvidence(`${a} and ${b}`)
+      const reverse = collectAgentTitleEvidence(`${b} and ${a}`)
+      expect(forward.agent).toBe(reverse.agent)
+      expect(forward.agent).toBeNull()
+      expect([...forward.freeTextNames].sort()).toEqual([...reverse.freeTextNames].sort())
+    })
+  })
+
+  describe('a vendor marker is evidence the agent emitted, not text a human typed', () => {
+    it('keeps a Claude pane Claude when its task text names another agent', () => {
+      // 13 recorded titles have this shape. The sigil is emitted by Claude; the name is typed.
+      expect(agentFor('✳ Fix Codex false attention notifications on Windows')).toBe('claude')
+      expect(reasonFor('✳ Consolidate Codex subagent sidebar rows')).toBe('vendor-marker')
+    })
+
+    it('lets an anchored name outrank a foreign vendor marker', () => {
+      // `agy` is the entire undecorated remainder — the strongest name evidence a title carries —
+      // so it wins against Claude's sigil rather than losing to it by position.
+      expect(agentFor('✳ agy')).toBe('antigravity')
+      expect(reasonFor('✳ agy')).toBe('anchored')
+    })
+
+    it('keeps an OpenCode envelope OpenCode when its session text names another agent', () => {
+      expect(agentFor('OC | QA PR #14582 Cursor sidecar SSH arms')).toBe('opencode')
+    })
+  })
+
+  describe('Antigravity model names are metadata, not identity', () => {
+    it('reads an identity segment plus a model name as Antigravity', () => {
+      expect(agentFor('agy · Gemini 3.7 Flash')).toBe('antigravity')
+      expect(agentFor('Antigravity — Gemini 3.7 Flash')).toBe('antigravity')
+    })
+
+    it('declines a bare model name rather than guessing Gemini CLI', () => {
+      // No identity segment, no vendor glyph — only a name in free text. Antigravity and Gemini
+      // CLI are equally consistent with it, so the title cannot answer.
+      expect(agentFor('Gemini 3.7 Flash · high')).toBeNull()
+    })
+
+    it('still resolves a real Gemini glyph', () => {
+      expect(agentFor('✦ Refactor the parser')).toBe('gemini')
+    })
+  })
+
+  describe('a name in free text alone is never identity', () => {
+    it.each([
+      '◐ DaemonConnectionLostError with 70 Codex agents',
+      'Fix the grok hook',
+      'Debug the cursor sidecar'
+    ])('declines %j', (title) => {
+      expect(agentFor(title)).toBeNull()
+      expect(reasonFor(title)).toBe('free-text-only')
+    })
+  })
+
+  it('produces no name evidence for an agent outside the token set', () => {
+    // The token set is deliberately narrower than the agent union: short names like `omp` would
+    // classify ordinary shell text. Such a title yields no evidence at all rather than a guess.
+    expect(reasonFor('Review PR for OMP transcript rendering')).toBe('no-evidence')
+  })
+
+  describe('activity is not identity', () => {
+    it.each(['◐ Rebase PR #14624 onto main', '⠂ Fix SSH fallback', '⠋ Thinking'])(
+      'declines the spinner-only title %j',
+      (title) => {
+        // Braille and quarter-circle spinners are emitted by many agents, so they prove the pane
+        // is busy and nothing about who it is. Callers that want busy-ness use activity parsing.
+        expect(agentFor(title)).toBeNull()
+        expect(reasonFor(title)).toBe('no-evidence')
+      }
+    )
+  })
+
+  describe('conflicting evidence of the same class resolves to nothing', () => {
+    it('declines two anchored names', () => {
+      expect(reasonFor('OC | something… - grok')).toBe('conflicting-anchored-names')
+    })
+
+    it('declines two vendor markers', () => {
+      expect(reasonFor('✳ ✦ two sigils')).toBe('conflicting-vendor-markers')
+    })
+  })
+
+  it('declines a Claude management screen', () => {
+    expect(agentFor('claude agents')).toBeNull()
+  })
+})

--- a/src/shared/agent-title-evidence.test.ts
+++ b/src/shared/agent-title-evidence.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { collectAgentTitleEvidence } from './agent-title-evidence'
+import { ALL_TUI_AGENTS, TUI_AGENT_DISPLAY_NAMES } from './tui-agent-display-names'
 
 const agentFor = (title: string) => collectAgentTitleEvidence(title).agent
 const reasonFor = (title: string) => collectAgentTitleEvidence(title).reason
@@ -38,7 +39,30 @@ describe('collectAgentTitleEvidence', () => {
       const reverse = collectAgentTitleEvidence(`${b} and ${a}`)
       expect(forward.agent).toBe(reverse.agent)
       expect(forward.agent).toBeNull()
-      expect([...forward.freeTextNames].sort()).toEqual([...reverse.freeTextNames].sort())
+      expect([...forward.freeTextNames].sort()).toEqual([a, b].sort())
+      expect([...reverse.freeTextNames].sort()).toEqual([a, b].sort())
+    })
+  })
+
+  it.each([
+    ['claude', 'claude'],
+    ['openclaude', 'openclaude'],
+    ['codex', 'codex'],
+    ['copilot', 'copilot'],
+    ['cursor', 'cursor'],
+    ['gemini', 'gemini'],
+    ['antigravity', 'antigravity'],
+    ['opencode', 'opencode'],
+    ['mimo', 'mimo-code'],
+    ['openclaw', 'openclaw'],
+    ['aider', 'aider'],
+    ['grok', 'grok'],
+    ['devin', 'devin']
+  ] as const)('collects the free-text token %s without claiming identity', (token, agent) => {
+    expect(collectAgentTitleEvidence(`review the ${token} integration`)).toMatchObject({
+      agent: null,
+      reason: 'free-text-only',
+      freeTextNames: [agent]
     })
   })
 
@@ -89,6 +113,82 @@ describe('collectAgentTitleEvidence', () => {
     })
   })
 
+  it.each(ALL_TUI_AGENTS)('recognizes the canonical whole-title label for %s', (agent) => {
+    const title = TUI_AGENT_DISPLAY_NAMES[agent]
+    expect(collectAgentTitleEvidence(title)).toMatchObject({
+      agent,
+      reason: 'anchored'
+    })
+  })
+
+  it('does not treat an exact display name as free text', () => {
+    expect(collectAgentTitleEvidence('Grok').freeTextNames).toEqual([])
+  })
+
+  it.each([
+    ['Claude Code', 'claude'],
+    ['Gemini CLI', 'gemini'],
+    ['Agent Teams', 'claude-agent-teams']
+  ] as const)('recognizes the emitted whole-title alias %s', (title, agent) => {
+    expect(agentFor(title)).toBe(agent)
+    expect(reasonFor(title)).toBe('anchored')
+  })
+
+  it.each([
+    ['Codex ready', 'codex'],
+    ['Codex - action required', 'codex'],
+    ['Cursor ready', 'cursor'],
+    ['Droid - action required', 'droid'],
+    ['Hermes ready', 'hermes'],
+    ['Devin - action required', 'devin'],
+    ['Pi ready', 'pi'],
+    ['OMP - action required', 'omp']
+  ] as const)('recognizes Orca-controlled synthetic title %s', (title, agent) => {
+    expect(agentFor(title)).toBe(agent)
+    expect(reasonFor(title)).toBe('anchored')
+  })
+
+  it.each([
+    ['⠋ Cursor Agent', 'cursor'],
+    ['⠋ Pi idle', 'pi'],
+    ['⠋ OMP done', 'omp']
+  ] as const)('recognizes the decorated identity frame %s', (title, agent) => {
+    expect(agentFor(title)).toBe(agent)
+    expect(reasonFor(title)).toBe('anchored')
+  })
+
+  it('does not invent synthetic titles for an opted-out profile', () => {
+    expect(agentFor('OpenCode ready')).toBeNull()
+    expect(reasonFor('OpenCode ready')).toBe('free-text-only')
+  })
+
+  it('reads identity from the innermost wrapper segment', () => {
+    expect(agentFor('zsh | ⠋ Claude Code')).toBe('claude')
+    expect(agentFor('ssh | tmux | Cursor Agent')).toBe('cursor')
+    expect(agentFor('ssh | tmux | OC | review the parser')).toBe('opencode')
+    expect(agentFor('zsh | Fix the Codex parser')).toBeNull()
+  })
+
+  it('bounds wrapper inspection while preserving innermost identity', () => {
+    const wrappers = Array.from({ length: 200 }, (_, index) => `wrapper-${index}`).join(' | ')
+    expect(agentFor(`${wrappers} | ⠋ Cursor Agent`)).toBe('cursor')
+    expect(agentFor(`${wrappers} | OC | review the parser`)).toBe('opencode')
+  })
+
+  it.each([
+    ['codex.exe', 'codex'],
+    ['openclaude.cmd', 'openclaude'],
+    ['gemini.ps1', 'gemini'],
+    ['droid.cmd', 'droid'],
+    ['hermes.exe', 'hermes'],
+    ['agy.bat', 'antigravity'],
+    ['CODEX.EXE', 'codex'],
+    ['DROID.CMD', 'droid']
+  ] as const)('recognizes the bare Windows launcher %s', (title, agent) => {
+    expect(agentFor(title)).toBe(agent)
+    expect(reasonFor(title)).toBe('anchored')
+  })
+
   it('produces no name evidence for an agent outside the token set', () => {
     // The token set is deliberately narrower than the agent union: short names like `omp` would
     // classify ordinary shell text. Such a title yields no evidence at all rather than a guess.
@@ -107,17 +207,62 @@ describe('collectAgentTitleEvidence', () => {
     )
   })
 
+  it('does not treat an embedded Claude sigil as a vendor marker', () => {
+    expect(collectAgentTitleEvidence('task text ✳ decoration')).toEqual({
+      vendorMarkers: [],
+      anchoredNames: [],
+      freeTextNames: [],
+      agent: null,
+      reason: 'no-evidence'
+    })
+  })
+
+  it('recognizes a bare Claude sigil as a vendor marker', () => {
+    expect(collectAgentTitleEvidence('✳')).toEqual({
+      vendorMarkers: ['claude'],
+      anchoredNames: [],
+      freeTextNames: [],
+      agent: 'claude',
+      reason: 'vendor-marker'
+    })
+  })
+
   describe('conflicting evidence of the same class resolves to nothing', () => {
     it('declines two anchored names', () => {
-      expect(reasonFor('OC | something… - grok')).toBe('conflicting-anchored-names')
+      const evidence = collectAgentTitleEvidence('OC | something… - grok')
+      expect(evidence.agent).toBeNull()
+      expect(evidence.reason).toBe('conflicting-anchored-names')
+      expect([...evidence.anchoredNames].sort()).toEqual(['grok', 'opencode'])
+    })
+
+    it('keeps an anchored conflict ahead of a vendor marker', () => {
+      const evidence = collectAgentTitleEvidence('✳ | OC | something… - grok')
+      expect(evidence.agent).toBeNull()
+      expect(evidence.reason).toBe('conflicting-anchored-names')
+      expect([...evidence.anchoredNames].sort()).toEqual(['grok', 'opencode'])
+      expect(evidence.vendorMarkers).toEqual(['claude'])
     })
 
     it('declines two vendor markers', () => {
-      expect(reasonFor('✳ ✦ two sigils')).toBe('conflicting-vendor-markers')
+      const evidence = collectAgentTitleEvidence('✳ ✦ two sigils')
+      expect(evidence.agent).toBeNull()
+      expect(evidence.reason).toBe('conflicting-vendor-markers')
+      expect([...evidence.vendorMarkers].sort()).toEqual(['claude', 'gemini'])
     })
   })
 
   it('declines a Claude management screen', () => {
-    expect(agentFor('claude agents')).toBeNull()
+    expect(collectAgentTitleEvidence('claude agents')).toEqual({
+      vendorMarkers: [],
+      anchoredNames: [],
+      freeTextNames: [],
+      agent: null,
+      reason: 'no-evidence'
+    })
+  })
+
+  it('requires whitespace before the owner suffix dash', () => {
+    expect(agentFor('task- codex')).toBeNull()
+    expect(reasonFor('task- codex')).toBe('free-text-only')
   })
 })

--- a/src/shared/agent-title-evidence.test.ts
+++ b/src/shared/agent-title-evidence.test.ts
@@ -86,10 +86,10 @@ describe('collectAgentTitleEvidence', () => {
     })
 
     it('lets an anchored name outrank a foreign vendor marker', () => {
-      // `agy` is the entire undecorated remainder — the strongest name evidence a title carries —
-      // so it wins against Claude's sigil rather than losing to it by position.
-      expect(agentFor('✳ agy')).toBe('antigravity')
-      expect(reasonFor('✳ agy')).toBe('anchored')
+      expect(agentFor('✳ agy')).toBe('claude')
+      expect(reasonFor('✳ agy')).toBe('vendor-marker')
+      expect(agentFor('✳ codex')).toBe('claude')
+      expect(reasonFor('✳ codex')).toBe('vendor-marker')
     })
 
     it('keeps an OpenCode envelope OpenCode when its session text names another agent', () => {
@@ -347,5 +347,9 @@ describe('collectAgentTitleEvidence', () => {
   it('requires whitespace before the owner suffix dash', () => {
     expect(agentFor('task- codex')).toBeNull()
     expect(reasonFor('task- codex')).toBe('free-text-only')
+  })
+
+  it('terminates when a wrapper title starts with a separator', () => {
+    expect(agentFor(' | ')).toBeNull()
   })
 })

--- a/src/shared/agent-title-evidence.test.ts
+++ b/src/shared/agent-title-evidence.test.ts
@@ -99,6 +99,17 @@ describe('collectAgentTitleEvidence', () => {
     it('still resolves a real Gemini glyph', () => {
       expect(agentFor('✦ Refactor the parser')).toBe('gemini')
     })
+
+    it('does not promote model names in task text', () => {
+      expect(agentFor('Compare Antigravity with Gemini 3.7 Flash')).toBeNull()
+      expect(agentFor('Compare Antigravity with Gemini 3.7 Flash… - grok')).toBe('grok')
+    })
+
+    it('does not treat a Gemini glyph inside task text as a vendor marker', () => {
+      const evidence = collectAgentTitleEvidence('Explain the ✦ marker… - grok')
+      expect(evidence.agent).toBe('grok')
+      expect(evidence.vendorMarkers).toEqual([])
+    })
   })
 
   describe('a name in free text alone is never identity', () => {
@@ -150,6 +161,21 @@ describe('collectAgentTitleEvidence', () => {
   ] as const)('recognizes Orca-controlled synthetic title %s', (title, agent) => {
     expect(agentFor(title)).toBe(agent)
     expect(reasonFor(title)).toBe('anchored')
+  })
+
+  it.each([
+    'Claude Code ready',
+    'Claude thinking',
+    '. Claude Code working',
+    'zsh | ⠋ Claude Code - action required'
+  ])('recognizes the explicit Claude identity frame %s', (title) => {
+    expect(agentFor(title)).toBe('claude')
+    expect(reasonFor(title)).toBe('anchored')
+  })
+
+  it('does not promote Claude status words in task text', () => {
+    expect(agentFor('Fix the Claude Code ready-state parser')).toBeNull()
+    expect(agentFor('Fix Claude Code ready behavior… - grok')).toBe('grok')
   })
 
   it.each([
@@ -248,7 +274,7 @@ describe('collectAgentTitleEvidence', () => {
     })
 
     it('declines two vendor markers', () => {
-      const evidence = collectAgentTitleEvidence('✳ ✦ two sigils')
+      const evidence = collectAgentTitleEvidence('✳ | ✦ two sigils')
       expect(evidence.agent).toBeNull()
       expect(evidence.reason).toBe('conflicting-vendor-markers')
       expect([...evidence.vendorMarkers].sort()).toEqual(['claude', 'gemini'])

--- a/src/shared/agent-title-evidence.ts
+++ b/src/shared/agent-title-evidence.ts
@@ -13,7 +13,12 @@ import {
 } from './agent-title-core'
 import { isOpenCodeNativeTitle } from './opencode-terminal-title'
 import { getPiCompatibleSyntheticAgentLabel } from './pi-compatible-synthetic-title'
+import {
+  SYNTHETIC_AGENT_TITLE_AGENTS,
+  SYNTHETIC_AGENT_TITLE_PROFILES
+} from './synthetic-agent-title'
 import type { TuiAgent } from './tui-agent'
+import { ALL_TUI_AGENTS, TUI_AGENT_DISPLAY_NAMES } from './tui-agent-display-names'
 
 /**
  * Order-independent identity evidence from a terminal title.
@@ -73,20 +78,13 @@ const PATTERN_NAMES: readonly (readonly [RegExp, TuiAgent])[] = [
   [HERMES_AGENT_NAME_RE, 'hermes']
 ]
 
-/**
- * Canonical display labels an agent may write as its whole title. Declared here rather than
- * derived from the renderer catalog so this module stays free of UI-layer imports; the labels an
- * agent actually emits are a title fact, not a presentation choice.
- */
-const DISPLAY_LABELS: readonly (readonly [string, TuiAgent])[] = [
+/** Exact whole-title labels are strong evidence even for agents unsafe to match in free text. */
+const DISPLAY_LABELS = [
+  ...ALL_TUI_AGENTS.map((agent) => [TUI_AGENT_DISPLAY_NAMES[agent].toLowerCase(), agent] as const),
   ['claude code', 'claude'],
   ['gemini cli', 'gemini'],
-  ['mimo code', 'mimo-code'],
-  ['github copilot', 'copilot'],
-  ['command code', 'command-code'],
-  ['prime agent', 'prime-agent'],
   ['agent teams', 'claude-agent-teams']
-]
+] satisfies readonly (readonly [string, TuiAgent])[]
 
 const GEMINI_GLYPHS = [GEMINI_WORKING, GEMINI_SILENT_WORKING, GEMINI_IDLE, GEMINI_PERMISSION]
 
@@ -96,6 +94,22 @@ const GEMINI_GLYPHS = [GEMINI_WORKING, GEMINI_SILENT_WORKING, GEMINI_IDLE, GEMIN
  * worktree name (`review-14600-codex`), which is a directory, not an owner declaration.
  */
 const OWNER_SUFFIX_RE = /\s-\s+([A-Za-z][\w-]*)\s*$/
+const WINDOWS_LAUNCHER_SUFFIX_RE = /\.(?:exe|cmd|bat|ps1)$/i
+const WRAPPER_SEPARATOR = ' | '
+const MAX_WRAPPER_EVIDENCE_SEGMENTS = 8
+
+function getEvidenceTitleSegments(title: string): string[] {
+  const segments = [title]
+  let separatorIndex = title.lastIndexOf(WRAPPER_SEPARATOR)
+  while (separatorIndex >= 0 && segments.length < MAX_WRAPPER_EVIDENCE_SEGMENTS) {
+    const wrapped = title.slice(separatorIndex + WRAPPER_SEPARATOR.length).trim()
+    if (wrapped && !segments.includes(wrapped)) {
+      segments.push(wrapped)
+    }
+    separatorIndex = title.lastIndexOf(WRAPPER_SEPARATOR, separatorIndex - 1)
+  }
+  return segments
+}
 
 function namesIn(text: string): TuiAgent[] {
   const found = new Set<TuiAgent>()
@@ -117,78 +131,105 @@ function agentForBareName(text: string): TuiAgent | null {
   if (!trimmed) {
     return null
   }
-  const names = namesIn(trimmed)
-  if (names.length !== 1) {
-    return null
-  }
-  // Why the length check: the remainder must BE the name, not merely contain it. "agy" anchors;
-  // "fix the agy hook" does not, and neither does a hyphenated worktree name like "codex-split".
   const stripped = trimmed.replace(/^[^\p{L}\p{N}]+/u, '').replace(/[^\p{L}\p{N}]+$/u, '')
-  if (/^[\p{L}\p{N}]+$/u.test(stripped)) {
-    return names[0]
-  }
   // Why labels too: an agent may write its own display name as the entire title (`⠐ Claude Code`).
   // That is the same claim as a bare token, just spelled the way the vendor spells it.
   const label = DISPLAY_LABELS.find(([text]) => text === stripped.toLowerCase())
-  return label ? label[1] : null
+  if (label) {
+    return label[1]
+  }
+  const bareToken = stripped.replace(WINDOWS_LAUNCHER_SUFFIX_RE, '')
+  const names = namesIn(bareToken)
+  // Why the length check: the remainder must BE the name, not merely contain it. "agy" anchors;
+  // "fix the agy hook" does not, and neither does a hyphenated worktree name like "codex-split".
+  return names.length === 1 && /^[\p{L}\p{N}]+$/u.test(bareToken) ? names[0] : null
 }
 
-function collectVendorMarkers(title: string): TuiAgent[] {
+function agentForSyntheticTitle(text: string): TuiAgent | null {
+  const normalized = text
+    .trim()
+    .replace(/^[^\p{L}\p{N}]+/u, '')
+    .toLowerCase()
+  for (const agent of SYNTHETIC_AGENT_TITLE_AGENTS) {
+    const profile = SYNTHETIC_AGENT_TITLE_PROFILES[agent]
+    if (
+      profile.synthesizeTerminalTitle !== false &&
+      [profile.workingLabel, profile.permissionLabel, profile.idleLabel].some(
+        (label) => normalized === label.toLowerCase()
+      )
+    ) {
+      return agent
+    }
+  }
+  return null
+}
+
+function collectVendorMarkers(title: string, segments: readonly string[]): TuiAgent[] {
   const markers = new Set<TuiAgent>()
   // Why prefix-only for Claude: the sigil marks the pane's own status line. The same character
   // inside task text is decoration, not a vendor emission.
-  if (title.startsWith(`${CLAUDE_IDLE} `) || title === CLAUDE_IDLE) {
-    markers.add('claude')
-  }
   if (GEMINI_GLYPHS.some((glyph) => title.includes(glyph))) {
     markers.add('gemini')
   }
-  if (isCursorNativeAgentTitle(title)) {
-    markers.add('cursor')
+  for (const segment of segments) {
+    if (segment.startsWith(`${CLAUDE_IDLE} `) || segment === CLAUDE_IDLE) {
+      markers.add('claude')
+    }
+    if (isCursorNativeAgentTitle(segment)) {
+      markers.add('cursor')
+    }
   }
   return [...markers]
 }
 
-function collectAnchoredNames(title: string): TuiAgent[] {
+function collectAnchoredNames(segments: readonly string[]): TuiAgent[] {
   const anchored = new Set<TuiAgent>()
 
-  // Why anchored and not a bare marker: the native envelope owns the whole title. Its session
-  // text routinely names other agents ("OC | QA the Cursor sidecar") without ceasing to be
-  // OpenCode, so a foreign name in that text must not be able to veto it.
-  if (isOpenCodeNativeTitle(title)) {
-    anchored.add('opencode')
-  }
-
-  const suffix = OWNER_SUFFIX_RE.exec(title)
-  if (suffix) {
-    const agent = agentForBareName(suffix[1])
-    if (agent) {
-      anchored.add(agent)
+  for (const segment of segments) {
+    // Why anchored and not a bare marker: the native envelope owns the whole wrapped pane title.
+    // Its session text may name other agents without changing the OpenCode owner.
+    if (isOpenCodeNativeTitle(segment)) {
+      anchored.add('opencode')
     }
-  }
 
-  // Why strip a leading vendor sigil first: `✳ agy` is a Claude-glyphed pane whose entire
-  // remainder is another agent's name — the strongest name evidence a title can carry.
-  const withoutSigil = title.startsWith(`${CLAUDE_IDLE} `) ? title.slice(CLAUDE_IDLE.length) : title
-  const bare = agentForBareName(withoutSigil)
-  if (bare) {
-    anchored.add(bare)
-  }
+    const suffix = OWNER_SUFFIX_RE.exec(segment)
+    if (suffix) {
+      const agent = agentForBareName(suffix[1])
+      if (agent) {
+        anchored.add(agent)
+      }
+    }
 
-  // Why Antigravity gets a grammar: its models are named `Gemini <n.n> <Name>`, so an agy pane's
-  // own title carries a whole `gemini` token. Read as identity-plus-model, the gemini token is
-  // metadata — which is the general rule, not an exception inside the Gemini detector.
-  if (AGY_AGENT_NAME_RE.test(title) || titleHasAgentName(title, 'antigravity')) {
-    if (/\bgemini\s+\d/i.test(title)) {
+    // Why strip a leading vendor sigil first: `✳ agy` is a Claude-glyphed pane whose entire
+    // remainder is another agent's name — the strongest name evidence a title can carry.
+    const withoutSigil = segment.startsWith(`${CLAUDE_IDLE} `)
+      ? segment.slice(CLAUDE_IDLE.length)
+      : segment
+    const bare = agentForBareName(withoutSigil)
+    if (bare) {
+      anchored.add(bare)
+    }
+    const synthetic = agentForSyntheticTitle(segment)
+    if (synthetic) {
+      anchored.add(synthetic)
+    }
+
+    // Why Antigravity gets a grammar: its models are named `Gemini <n.n> <Name>`, so an agy pane's
+    // own title carries a whole `gemini` token. Read as identity-plus-model, the gemini token is
+    // metadata — which is the general rule, not an exception inside the Gemini detector.
+    if (
+      (AGY_AGENT_NAME_RE.test(segment) || titleHasAgentName(segment, 'antigravity')) &&
+      /\bgemini\s+\d/i.test(segment)
+    ) {
       anchored.add('antigravity')
     }
-  }
 
-  const piCompatible = getPiCompatibleSyntheticAgentLabel(title)
-  if (piCompatible === 'Pi') {
-    anchored.add('pi')
-  } else if (piCompatible === 'OMP') {
-    anchored.add('omp')
+    const piCompatible = getPiCompatibleSyntheticAgentLabel(segment)
+    if (piCompatible === 'Pi') {
+      anchored.add('pi')
+    } else if (piCompatible === 'OMP') {
+      anchored.add('omp')
+    }
   }
 
   return [...anchored]
@@ -202,8 +243,9 @@ export function collectAgentTitleEvidence(title: string): AgentTitleEvidence {
     return { ...empty, agent: null, reason: 'no-evidence' }
   }
 
-  const vendorMarkers = collectVendorMarkers(title)
-  const anchoredNames = collectAnchoredNames(title)
+  const segments = getEvidenceTitleSegments(title)
+  const vendorMarkers = collectVendorMarkers(title, segments)
+  const anchoredNames = collectAnchoredNames(segments)
   const anchoredSet = new Set(anchoredNames)
   const freeTextNames = namesIn(title).filter((agent) => !anchoredSet.has(agent))
   const evidence = { vendorMarkers, anchoredNames, freeTextNames } as const

--- a/src/shared/agent-title-evidence.ts
+++ b/src/shared/agent-title-evidence.ts
@@ -139,12 +139,18 @@ function namesIn(text: string): TuiAgent[] {
   return [...found]
 }
 
+function stripBareNameDecoration(text: string): string {
+  return text
+    .trim()
+    .replace(/^[^\p{L}\p{N}]+/u, '')
+    .replace(/[^\p{L}\p{N}]+$/u, '')
+}
+
 function agentForBareName(text: string): TuiAgent | null {
-  const trimmed = text.trim()
-  if (!trimmed) {
+  if (!text.trim()) {
     return null
   }
-  const stripped = trimmed.replace(/^[^\p{L}\p{N}]+/u, '').replace(/[^\p{L}\p{N}]+$/u, '')
+  const stripped = stripBareNameDecoration(text)
   // Why labels too: an agent may write its own display name as the entire title (`⠐ Claude Code`).
   // That is the same claim as a bare token, just spelled the way the vendor spells it.
   const label = DISPLAY_LABELS.find(([text]) => text === stripped.toLowerCase())
@@ -185,7 +191,12 @@ function collectVendorMarkers(segments: readonly string[]): TuiAgent[] {
     if (GEMINI_GLYPHS.some((glyph) => segment.startsWith(glyph))) {
       markers.add('gemini')
     }
-    if (segment.startsWith(`${CLAUDE_IDLE} `) || segment === CLAUDE_IDLE) {
+    if (
+      segment.startsWith(`${CLAUDE_IDLE} `) ||
+      segment === CLAUDE_IDLE ||
+      segment.startsWith('. ') ||
+      segment.startsWith('* ')
+    ) {
       markers.add('claude')
     }
     if (isCursorNativeAgentTitle(segment)) {
@@ -193,6 +204,24 @@ function collectVendorMarkers(segments: readonly string[]): TuiAgent[] {
     }
   }
   return [...markers]
+}
+
+function namesConsumedByAnchoredLabels(
+  segments: readonly string[],
+  anchoredNames: ReadonlySet<TuiAgent>
+): Set<TuiAgent> {
+  const consumed = new Set<TuiAgent>()
+  for (const segment of segments) {
+    const label = DISPLAY_LABELS.find(
+      ([text]) => text === stripBareNameDecoration(segment).toLowerCase()
+    )
+    if (label && anchoredNames.has(label[1])) {
+      for (const name of namesIn(label[0])) {
+        consumed.add(name)
+      }
+    }
+  }
+  return consumed
 }
 
 function collectAnchoredNames(segments: readonly string[]): TuiAgent[] {
@@ -261,7 +290,10 @@ export function collectAgentTitleEvidence(title: string): AgentTitleEvidence {
   const vendorMarkers = collectVendorMarkers(segments)
   const anchoredNames = collectAnchoredNames(segments)
   const anchoredSet = new Set(anchoredNames)
-  const freeTextNames = namesIn(title).filter((agent) => !anchoredSet.has(agent))
+  const anchoredLabelNames = namesConsumedByAnchoredLabels(segments, anchoredSet)
+  const freeTextNames = namesIn(title).filter(
+    (agent) => !anchoredSet.has(agent) && !anchoredLabelNames.has(agent)
+  )
   const evidence = { vendorMarkers, anchoredNames, freeTextNames } as const
 
   if (anchoredNames.length === 1) {

--- a/src/shared/agent-title-evidence.ts
+++ b/src/shared/agent-title-evidence.ts
@@ -165,6 +165,22 @@ function agentForBareName(text: string): TuiAgent | null {
   return names.length === 1 && /^[\p{L}\p{N}]+$/u.test(bareToken) ? names[0] : null
 }
 
+function agentForWholeTitle(text: string): TuiAgent | null {
+  const trimmed = text.trim()
+  if (!trimmed || /[\\/]/.test(trimmed)) {
+    return null
+  }
+  const stripped = stripBareNameDecoration(trimmed)
+  const label = DISPLAY_LABELS.find(([text]) => text === stripped.toLowerCase())
+  if (label) {
+    return label[1]
+  }
+  if (!WINDOWS_LAUNCHER_SUFFIX_RE.test(stripped)) {
+    return null
+  }
+  return agentForBareName(stripped)
+}
+
 function agentForOwnerSuffix(text: string): TuiAgent | null {
   const normalized = text.toLowerCase()
   return ALL_TUI_AGENTS.find((agent) => agent === normalized) ?? agentForBareName(text)
@@ -178,11 +194,13 @@ function agentForSyntheticTitle(text: string): TuiAgent | null {
   const normalized = trimmed.replace(/^[^\p{L}\p{N}]+/u, '').toLowerCase()
   for (const agent of SYNTHETIC_AGENT_TITLE_AGENTS) {
     const profile = SYNTHETIC_AGENT_TITLE_PROFILES[agent]
+    const emittedLabels = [profile.permissionLabel, profile.idleLabel]
+    if (profile.synthesizeWorkingTitle !== false) {
+      emittedLabels.push(profile.workingLabel)
+    }
     if (
       profile.synthesizeTerminalTitle !== false &&
-      [profile.workingLabel, profile.permissionLabel, profile.idleLabel].some(
-        (label) => normalized === label.toLowerCase()
-      )
+      emittedLabels.some((label) => normalized === label.toLowerCase())
     ) {
       return agent
     }
@@ -254,9 +272,15 @@ function collectAnchoredNames(segments: readonly string[]): TuiAgent[] {
     const withoutSigil = segment.startsWith(`${CLAUDE_IDLE} `)
       ? segment.slice(CLAUDE_IDLE.length)
       : segment
-    const bare = agentForBareName(withoutSigil)
+    const bare = agentForWholeTitle(withoutSigil)
     if (bare) {
       anchored.add(bare)
+    }
+    if (segment.startsWith(`${CLAUDE_IDLE} `)) {
+      const sigilClaim = agentForBareName(withoutSigil)
+      if (sigilClaim) {
+        anchored.add(sigilClaim)
+      }
     }
     const synthetic = agentForSyntheticTitle(segment)
     if (synthetic) {

--- a/src/shared/agent-title-evidence.ts
+++ b/src/shared/agent-title-evidence.ts
@@ -21,7 +21,7 @@ import {
   SYNTHETIC_AGENT_TITLE_PROFILES
 } from './synthetic-agent-title'
 import type { TuiAgent } from './tui-agent'
-import { ALL_TUI_AGENTS, TUI_AGENT_DISPLAY_NAMES } from './tui-agent-display-names'
+import { TUI_AGENT_DISPLAY_NAMES } from './tui-agent-display-names'
 
 /**
  * Order-independent identity evidence from a terminal title.
@@ -111,6 +111,12 @@ const OWNER_SUFFIX_RE = /\s-\s+([A-Za-z][\w-]*)\s*$/
 const WINDOWS_LAUNCHER_SUFFIX_RE = /\.(?:exe|cmd|bat|ps1)$/i
 const WRAPPER_SEPARATOR = ' | '
 const MAX_WRAPPER_EVIDENCE_SEGMENTS = 8
+const RESERVED_OWNER_IDS: ReadonlyMap<string, TuiAgent> = new Map([
+  ['pi', 'pi'],
+  ['omp', 'omp'],
+  ['claude-agent-teams', 'claude-agent-teams'],
+  ['qwen-code', 'qwen-code']
+])
 
 function getEvidenceTitleSegments(title: string): string[] {
   const segments = [title]
@@ -120,7 +126,11 @@ function getEvidenceTitleSegments(title: string): string[] {
     if (wrapped && !segments.includes(wrapped)) {
       segments.push(wrapped)
     }
+    const previousSeparatorIndex = separatorIndex
     separatorIndex = title.lastIndexOf(WRAPPER_SEPARATOR, separatorIndex - 1)
+    if (separatorIndex === previousSeparatorIndex) {
+      break
+    }
   }
   return segments
 }
@@ -183,8 +193,8 @@ function agentForWholeTitle(text: string): TuiAgent | null {
 }
 
 function agentForOwnerSuffix(text: string): TuiAgent | null {
-  const normalized = text.toLowerCase()
-  return ALL_TUI_AGENTS.find((agent) => agent === normalized) ?? agentForBareName(text)
+  const normalized = text.trim().toLowerCase()
+  return RESERVED_OWNER_IDS.get(normalized) ?? agentForBareName(text)
 }
 
 function agentForSyntheticTitle(text: string): TuiAgent | null {
@@ -283,12 +293,6 @@ function collectAnchoredNames(segments: readonly string[]): TuiAgent[] {
     const bare = agentForWholeTitle(withoutSigil)
     if (bare) {
       anchored.add(bare)
-    }
-    if (segment.startsWith(`${CLAUDE_IDLE} `)) {
-      const sigilClaim = agentForBareName(withoutSigil)
-      if (sigilClaim) {
-        anchored.add(sigilClaim)
-      }
     }
     const synthetic = agentForSyntheticTitle(segment)
     if (synthetic) {

--- a/src/shared/agent-title-evidence.ts
+++ b/src/shared/agent-title-evidence.ts
@@ -1,0 +1,233 @@
+import {
+  AGY_AGENT_NAME_RE,
+  CLAUDE_IDLE,
+  DROID_AGENT_NAME_RE,
+  GEMINI_IDLE,
+  GEMINI_PERMISSION,
+  GEMINI_SILENT_WORKING,
+  GEMINI_WORKING,
+  HERMES_AGENT_NAME_RE,
+  isClaudeManagementTitle,
+  isCursorNativeAgentTitle,
+  titleHasAgentName
+} from './agent-title-core'
+import { isOpenCodeNativeTitle } from './opencode-terminal-title'
+import { getPiCompatibleSyntheticAgentLabel } from './pi-compatible-synthetic-title'
+import type { TuiAgent } from './tui-agent'
+
+/**
+ * Order-independent identity evidence from a terminal title.
+ *
+ * The chain this replaces is a first-match-wins scan of substring predicates, so its answer is
+ * decided by list position rather than by how strong the evidence is. That is why a Grok pane
+ * whose task text mentions Codex reads as Codex, and why fixing one collision by hoisting a
+ * branch breaks another. Here every signal is collected first and ranked afterwards, by class:
+ *
+ *   vendor marker  — a control sequence or sigil the agent itself emits. Task text cannot forge it.
+ *   anchored name  — a name in a position some grammar reserves for identity (Orca's `- <agent>`
+ *                    owner suffix, or the whole undecorated remainder).
+ *   free-text name — a name anywhere else. Anyone can type it.
+ *
+ * A free-text name never becomes identity on its own, even when it is the only name present: an
+ * absent icon is recoverable, a confidently wrong one is not. Callers that only need "is this pane
+ * busy" want activity parsing, which lives elsewhere and does not go through here.
+ */
+export type AgentTitleEvidenceReason =
+  | 'anchored'
+  | 'vendor-marker'
+  | 'conflicting-anchored-names'
+  | 'conflicting-vendor-markers'
+  | 'free-text-only'
+  | 'no-evidence'
+
+export type AgentTitleEvidence = {
+  readonly vendorMarkers: readonly TuiAgent[]
+  readonly anchoredNames: readonly TuiAgent[]
+  readonly freeTextNames: readonly TuiAgent[]
+  /** Null whenever the title cannot answer on its own. Callers fall back to stronger signals. */
+  readonly agent: TuiAgent | null
+  readonly reason: AgentTitleEvidenceReason
+}
+
+/** Names matched as whole tokens, paired with the agent each identifies. */
+const NAME_TOKENS: readonly (readonly [string, TuiAgent])[] = [
+  ['claude', 'claude'],
+  ['openclaude', 'openclaude'],
+  ['codex', 'codex'],
+  ['copilot', 'copilot'],
+  ['cursor', 'cursor'],
+  ['gemini', 'gemini'],
+  ['antigravity', 'antigravity'],
+  ['opencode', 'opencode'],
+  ['mimo', 'mimo-code'],
+  ['openclaw', 'openclaw'],
+  ['aider', 'aider'],
+  ['grok', 'grok'],
+  ['devin', 'devin']
+]
+
+/** Agents whose name is matched by a dedicated pattern rather than a plain token. */
+const PATTERN_NAMES: readonly (readonly [RegExp, TuiAgent])[] = [
+  [AGY_AGENT_NAME_RE, 'antigravity'],
+  [DROID_AGENT_NAME_RE, 'droid'],
+  [HERMES_AGENT_NAME_RE, 'hermes']
+]
+
+/**
+ * Canonical display labels an agent may write as its whole title. Declared here rather than
+ * derived from the renderer catalog so this module stays free of UI-layer imports; the labels an
+ * agent actually emits are a title fact, not a presentation choice.
+ */
+const DISPLAY_LABELS: readonly (readonly [string, TuiAgent])[] = [
+  ['claude code', 'claude'],
+  ['gemini cli', 'gemini'],
+  ['mimo code', 'mimo-code'],
+  ['github copilot', 'copilot'],
+  ['command code', 'command-code'],
+  ['prime agent', 'prime-agent'],
+  ['agent teams', 'claude-agent-teams']
+]
+
+const GEMINI_GLYPHS = [GEMINI_WORKING, GEMINI_SILENT_WORKING, GEMINI_IDLE, GEMINI_PERMISSION]
+
+/**
+ * Orca renders `<task text>… - <agent>` and owns the suffix; task text cannot reach past it.
+ * Why leading whitespace is required: without it this also matches the tail of a hyphenated
+ * worktree name (`review-14600-codex`), which is a directory, not an owner declaration.
+ */
+const OWNER_SUFFIX_RE = /\s-\s+([A-Za-z][\w-]*)\s*$/
+
+function namesIn(text: string): TuiAgent[] {
+  const found = new Set<TuiAgent>()
+  for (const [token, agent] of NAME_TOKENS) {
+    if (titleHasAgentName(text, token)) {
+      found.add(agent)
+    }
+  }
+  for (const [pattern, agent] of PATTERN_NAMES) {
+    if (pattern.test(text)) {
+      found.add(agent)
+    }
+  }
+  return [...found]
+}
+
+function agentForBareName(text: string): TuiAgent | null {
+  const trimmed = text.trim()
+  if (!trimmed) {
+    return null
+  }
+  const names = namesIn(trimmed)
+  if (names.length !== 1) {
+    return null
+  }
+  // Why the length check: the remainder must BE the name, not merely contain it. "agy" anchors;
+  // "fix the agy hook" does not, and neither does a hyphenated worktree name like "codex-split".
+  const stripped = trimmed.replace(/^[^\p{L}\p{N}]+/u, '').replace(/[^\p{L}\p{N}]+$/u, '')
+  if (/^[\p{L}\p{N}]+$/u.test(stripped)) {
+    return names[0]
+  }
+  // Why labels too: an agent may write its own display name as the entire title (`⠐ Claude Code`).
+  // That is the same claim as a bare token, just spelled the way the vendor spells it.
+  const label = DISPLAY_LABELS.find(([text]) => text === stripped.toLowerCase())
+  return label ? label[1] : null
+}
+
+function collectVendorMarkers(title: string): TuiAgent[] {
+  const markers = new Set<TuiAgent>()
+  // Why prefix-only for Claude: the sigil marks the pane's own status line. The same character
+  // inside task text is decoration, not a vendor emission.
+  if (title.startsWith(`${CLAUDE_IDLE} `) || title === CLAUDE_IDLE) {
+    markers.add('claude')
+  }
+  if (GEMINI_GLYPHS.some((glyph) => title.includes(glyph))) {
+    markers.add('gemini')
+  }
+  if (isCursorNativeAgentTitle(title)) {
+    markers.add('cursor')
+  }
+  return [...markers]
+}
+
+function collectAnchoredNames(title: string): TuiAgent[] {
+  const anchored = new Set<TuiAgent>()
+
+  // Why anchored and not a bare marker: the native envelope owns the whole title. Its session
+  // text routinely names other agents ("OC | QA the Cursor sidecar") without ceasing to be
+  // OpenCode, so a foreign name in that text must not be able to veto it.
+  if (isOpenCodeNativeTitle(title)) {
+    anchored.add('opencode')
+  }
+
+  const suffix = OWNER_SUFFIX_RE.exec(title)
+  if (suffix) {
+    const agent = agentForBareName(suffix[1])
+    if (agent) {
+      anchored.add(agent)
+    }
+  }
+
+  // Why strip a leading vendor sigil first: `✳ agy` is a Claude-glyphed pane whose entire
+  // remainder is another agent's name — the strongest name evidence a title can carry.
+  const withoutSigil = title.startsWith(`${CLAUDE_IDLE} `) ? title.slice(CLAUDE_IDLE.length) : title
+  const bare = agentForBareName(withoutSigil)
+  if (bare) {
+    anchored.add(bare)
+  }
+
+  // Why Antigravity gets a grammar: its models are named `Gemini <n.n> <Name>`, so an agy pane's
+  // own title carries a whole `gemini` token. Read as identity-plus-model, the gemini token is
+  // metadata — which is the general rule, not an exception inside the Gemini detector.
+  if (AGY_AGENT_NAME_RE.test(title) || titleHasAgentName(title, 'antigravity')) {
+    if (/\bgemini\s+\d/i.test(title)) {
+      anchored.add('antigravity')
+    }
+  }
+
+  const piCompatible = getPiCompatibleSyntheticAgentLabel(title)
+  if (piCompatible === 'Pi') {
+    anchored.add('pi')
+  } else if (piCompatible === 'OMP') {
+    anchored.add('omp')
+  }
+
+  return [...anchored]
+}
+
+/** Collects every identity signal in `title` and ranks them by class, never by declaration order. */
+export function collectAgentTitleEvidence(title: string): AgentTitleEvidence {
+  const empty = { vendorMarkers: [], anchoredNames: [], freeTextNames: [] } as const
+  if (!title.trim() || isClaudeManagementTitle(title)) {
+    // Why: a `claude agents` management screen is Claude's own UI, not an agent session.
+    return { ...empty, agent: null, reason: 'no-evidence' }
+  }
+
+  const vendorMarkers = collectVendorMarkers(title)
+  const anchoredNames = collectAnchoredNames(title)
+  const anchoredSet = new Set(anchoredNames)
+  const freeTextNames = namesIn(title).filter((agent) => !anchoredSet.has(agent))
+  const evidence = { vendorMarkers, anchoredNames, freeTextNames } as const
+
+  if (anchoredNames.length === 1) {
+    // Why anchored beats a vendor marker: `✳ agy` is an agy pane whose title kept Claude's sigil.
+    return { ...evidence, agent: anchoredNames[0], reason: 'anchored' }
+  }
+  if (anchoredNames.length > 1) {
+    return { ...evidence, agent: null, reason: 'conflicting-anchored-names' }
+  }
+  if (vendorMarkers.length > 1) {
+    return { ...evidence, agent: null, reason: 'conflicting-vendor-markers' }
+  }
+  if (vendorMarkers.length === 1) {
+    // Why free text does not veto here: `✳ Fix Codex false attention notifications` is a Claude
+    // pane describing Codex work. The sigil is emitted by the agent; the name was typed by a
+    // human. A conflicting ANCHORED name already outranks this branch above, which is what makes
+    // `✳ agy` resolve to Antigravity without also blinding the 13 recorded titles of this shape.
+    return { ...evidence, agent: vendorMarkers[0], reason: 'vendor-marker' }
+  }
+  return {
+    ...evidence,
+    agent: null,
+    reason: freeTextNames.length > 0 ? 'free-text-only' : 'no-evidence'
+  }
+}

--- a/src/shared/agent-title-evidence.ts
+++ b/src/shared/agent-title-evidence.ts
@@ -18,7 +18,7 @@ import {
   SYNTHETIC_AGENT_TITLE_PROFILES
 } from './synthetic-agent-title'
 import type { TuiAgent } from './tui-agent'
-import { ALL_TUI_AGENTS, TUI_AGENT_DISPLAY_NAMES } from './tui-agent-display-names'
+import { TUI_AGENT_DISPLAY_NAMES } from './tui-agent-display-names'
 
 /**
  * Order-independent identity evidence from a terminal title.
@@ -78,9 +78,19 @@ const PATTERN_NAMES: readonly (readonly [RegExp, TuiAgent])[] = [
   [HERMES_AGENT_NAME_RE, 'hermes']
 ]
 
-/** Exact whole-title labels are strong evidence even for agents unsafe to match in free text. */
+/** Catalog labels known to be emitted as terminal titles, not merely presented in Orca's UI. */
+const EMITTED_DISPLAY_LABEL_AGENTS = [
+  'claude-agent-teams',
+  'mimo-code',
+  'prime-agent',
+  'command-code',
+  'copilot'
+] as const satisfies readonly TuiAgent[]
+
 const DISPLAY_LABELS = [
-  ...ALL_TUI_AGENTS.map((agent) => [TUI_AGENT_DISPLAY_NAMES[agent].toLowerCase(), agent] as const),
+  ...EMITTED_DISPLAY_LABEL_AGENTS.map(
+    (agent) => [TUI_AGENT_DISPLAY_NAMES[agent].toLowerCase(), agent] as const
+  ),
   ['claude code', 'claude'],
   ['gemini cli', 'gemini'],
   ['agent teams', 'claude-agent-teams']

--- a/src/shared/agent-title-evidence.ts
+++ b/src/shared/agent-title-evidence.ts
@@ -7,11 +7,13 @@ import {
   GEMINI_SILENT_WORKING,
   GEMINI_WORKING,
   HERMES_AGENT_NAME_RE,
+  isClaudeIdentityFrameSegment,
   isClaudeManagementTitle,
   isCursorNativeAgentTitle,
   titleHasAgentName
 } from './agent-title-core'
 import { isOpenCodeNativeTitle } from './opencode-terminal-title'
+import { stripLeadingAgentTitleDecorationOrEmpty } from './agent-title-decoration'
 import { getPiCompatibleSyntheticAgentLabel } from './pi-compatible-synthetic-title'
 import {
   SYNTHETIC_AGENT_TITLE_AGENTS,
@@ -97,6 +99,7 @@ const DISPLAY_LABELS = [
 ] satisfies readonly (readonly [string, TuiAgent])[]
 
 const GEMINI_GLYPHS = [GEMINI_WORKING, GEMINI_SILENT_WORKING, GEMINI_IDLE, GEMINI_PERMISSION]
+const ANTIGRAVITY_MODEL_TITLE_RE = /^(?:agy|antigravity)(?:\s*[·—:-]\s*|\s+)gemini\s+\d/i
 
 /**
  * Orca renders `<task text>… - <agent>` and owns the suffix; task text cannot reach past it.
@@ -174,14 +177,14 @@ function agentForSyntheticTitle(text: string): TuiAgent | null {
   return null
 }
 
-function collectVendorMarkers(title: string, segments: readonly string[]): TuiAgent[] {
+function collectVendorMarkers(segments: readonly string[]): TuiAgent[] {
   const markers = new Set<TuiAgent>()
-  // Why prefix-only for Claude: the sigil marks the pane's own status line. The same character
-  // inside task text is decoration, not a vendor emission.
-  if (GEMINI_GLYPHS.some((glyph) => title.includes(glyph))) {
-    markers.add('gemini')
-  }
   for (const segment of segments) {
+    // Why prefix-only: a sigil marks the pane's own status line only in the identity position.
+    // The same character inside task text is decoration, not a vendor emission.
+    if (GEMINI_GLYPHS.some((glyph) => segment.startsWith(glyph))) {
+      markers.add('gemini')
+    }
     if (segment.startsWith(`${CLAUDE_IDLE} `) || segment === CLAUDE_IDLE) {
       markers.add('claude')
     }
@@ -223,14 +226,15 @@ function collectAnchoredNames(segments: readonly string[]): TuiAgent[] {
     if (synthetic) {
       anchored.add(synthetic)
     }
+    if (isClaudeIdentityFrameSegment(segment)) {
+      anchored.add('claude')
+    }
 
     // Why Antigravity gets a grammar: its models are named `Gemini <n.n> <Name>`, so an agy pane's
     // own title carries a whole `gemini` token. Read as identity-plus-model, the gemini token is
     // metadata — which is the general rule, not an exception inside the Gemini detector.
-    if (
-      (AGY_AGENT_NAME_RE.test(segment) || titleHasAgentName(segment, 'antigravity')) &&
-      /\bgemini\s+\d/i.test(segment)
-    ) {
+    const undecorated = stripLeadingAgentTitleDecorationOrEmpty(segment).trim()
+    if (ANTIGRAVITY_MODEL_TITLE_RE.test(undecorated)) {
       anchored.add('antigravity')
     }
 
@@ -254,7 +258,7 @@ export function collectAgentTitleEvidence(title: string): AgentTitleEvidence {
   }
 
   const segments = getEvidenceTitleSegments(title)
-  const vendorMarkers = collectVendorMarkers(title, segments)
+  const vendorMarkers = collectVendorMarkers(segments)
   const anchoredNames = collectAnchoredNames(segments)
   const anchoredSet = new Set(anchoredNames)
   const freeTextNames = namesIn(title).filter((agent) => !anchoredSet.has(agent))

--- a/src/shared/agent-title-evidence.ts
+++ b/src/shared/agent-title-evidence.ts
@@ -147,10 +147,11 @@ function stripBareNameDecoration(text: string): string {
 }
 
 function agentForBareName(text: string): TuiAgent | null {
-  if (!text.trim()) {
+  const trimmed = text.trim()
+  if (!trimmed || /[\\/]/.test(trimmed)) {
     return null
   }
-  const stripped = stripBareNameDecoration(text)
+  const stripped = stripBareNameDecoration(trimmed)
   // Why labels too: an agent may write its own display name as the entire title (`⠐ Claude Code`).
   // That is the same claim as a bare token, just spelled the way the vendor spells it.
   const label = DISPLAY_LABELS.find(([text]) => text === stripped.toLowerCase())
@@ -170,10 +171,11 @@ function agentForOwnerSuffix(text: string): TuiAgent | null {
 }
 
 function agentForSyntheticTitle(text: string): TuiAgent | null {
-  const normalized = text
-    .trim()
-    .replace(/^[^\p{L}\p{N}]+/u, '')
-    .toLowerCase()
+  const trimmed = text.trim()
+  if (/[\\/]/.test(trimmed)) {
+    return null
+  }
+  const normalized = trimmed.replace(/^[^\p{L}\p{N}]+/u, '').toLowerCase()
   for (const agent of SYNTHETIC_AGENT_TITLE_AGENTS) {
     const profile = SYNTHETIC_AGENT_TITLE_PROFILES[agent]
     if (

--- a/src/shared/agent-title-evidence.ts
+++ b/src/shared/agent-title-evidence.ts
@@ -20,7 +20,7 @@ import {
   SYNTHETIC_AGENT_TITLE_PROFILES
 } from './synthetic-agent-title'
 import type { TuiAgent } from './tui-agent'
-import { TUI_AGENT_DISPLAY_NAMES } from './tui-agent-display-names'
+import { ALL_TUI_AGENTS, TUI_AGENT_DISPLAY_NAMES } from './tui-agent-display-names'
 
 /**
  * Order-independent identity evidence from a terminal title.
@@ -164,6 +164,11 @@ function agentForBareName(text: string): TuiAgent | null {
   return names.length === 1 && /^[\p{L}\p{N}]+$/u.test(bareToken) ? names[0] : null
 }
 
+function agentForOwnerSuffix(text: string): TuiAgent | null {
+  const normalized = text.toLowerCase()
+  return ALL_TUI_AGENTS.find((agent) => agent === normalized) ?? agentForBareName(text)
+}
+
 function agentForSyntheticTitle(text: string): TuiAgent | null {
   const normalized = text
     .trim()
@@ -236,7 +241,7 @@ function collectAnchoredNames(segments: readonly string[]): TuiAgent[] {
 
     const suffix = OWNER_SUFFIX_RE.exec(segment)
     if (suffix) {
-      const agent = agentForBareName(suffix[1])
+      const agent = agentForOwnerSuffix(suffix[1])
       if (agent) {
         anchored.add(agent)
       }

--- a/src/shared/agent-title-evidence.ts
+++ b/src/shared/agent-title-evidence.ts
@@ -198,7 +198,11 @@ function agentForSyntheticTitle(text: string): TuiAgent | null {
     const emittedLabels = [profile.permissionLabel, profile.idleLabel]
     if (profile.synthesizeWorkingTitle !== false) {
       // Working labels are emitted only as spinner frames; a bare name is free text.
-      if (containsAgentSpinnerGlyph(trimmed) && normalized === profile.workingLabel.toLowerCase()) {
+      if (
+        profile.synthesizeTerminalTitle !== false &&
+        containsAgentSpinnerGlyph(trimmed) &&
+        normalized === profile.workingLabel.toLowerCase()
+      ) {
         return agent
       }
     }

--- a/src/shared/agent-title-evidence.ts
+++ b/src/shared/agent-title-evidence.ts
@@ -7,6 +7,7 @@ import {
   GEMINI_SILENT_WORKING,
   GEMINI_WORKING,
   HERMES_AGENT_NAME_RE,
+  containsAgentSpinnerGlyph,
   isClaudeIdentityFrameSegment,
   isClaudeManagementTitle,
   isCursorNativeAgentTitle,
@@ -196,7 +197,10 @@ function agentForSyntheticTitle(text: string): TuiAgent | null {
     const profile = SYNTHETIC_AGENT_TITLE_PROFILES[agent]
     const emittedLabels = [profile.permissionLabel, profile.idleLabel]
     if (profile.synthesizeWorkingTitle !== false) {
-      emittedLabels.push(profile.workingLabel)
+      // Working labels are emitted only as spinner frames; a bare name is free text.
+      if (containsAgentSpinnerGlyph(trimmed) && normalized === profile.workingLabel.toLowerCase()) {
+        return agent
+      }
     }
     if (
       profile.synthesizeTerminalTitle !== false &&

--- a/src/shared/synthetic-agent-title.ts
+++ b/src/shared/synthetic-agent-title.ts
@@ -1,4 +1,5 @@
 import type { AgentStatusState, AgentType } from './agent-status-types'
+import type { TuiAgent } from './tui-agent'
 
 export type SyntheticAgentTitleProfile = {
   workingLabel: string
@@ -8,6 +9,17 @@ export type SyntheticAgentTitleProfile = {
   synthesizeTerminalTitle?: boolean
   synthesizeWorkingTitle?: boolean
 }
+
+export const SYNTHETIC_AGENT_TITLE_AGENTS = [
+  'codex',
+  'cursor',
+  'opencode',
+  'pi',
+  'omp',
+  'droid',
+  'hermes',
+  'devin'
+] as const satisfies readonly TuiAgent[]
 
 export const SYNTHETIC_AGENT_TITLE_PROFILES: Record<string, SyntheticAgentTitleProfile> = {
   codex: {

--- a/src/shared/terminal-title-agent-type.ts
+++ b/src/shared/terminal-title-agent-type.ts
@@ -5,9 +5,7 @@ import {
   titleHasAgentName
 } from './agent-name-token-match'
 import { containsAgentSpinnerGlyph, isCursorAgentTitle } from './agent-title-core'
-import { stripLeadingAgentTitleDecorationOrEmpty } from './agent-title-decoration'
 import { isOpenCodeNativeTitle } from './opencode-terminal-title'
-import { getWrapperTitleSegments } from './terminal-title-wrapper-segments'
 import {
   getPiCompatibleSyntheticAgentLabel,
   isLegacyPiCompatibleTitle
@@ -247,25 +245,7 @@ function hasGenericClaudeStatusPrefix(title: string): boolean {
   )
 }
 
-// Claude's own name plus, at most, one of its status words — never free-form task text.
-const CLAUDE_IDENTITY_FRAME_RE =
-  /^claude(?: code)?(?:\s+(?:ready|idle|done|working|thinking|running))?(?:\s*-\s*action required)?$/
-
-/**
- * Whether a title PRESENTS Claude rather than merely mentioning it, once its leading
- * status decoration is stripped. A "claude" token inside free-form task text is a mention,
- * so it must not take a pane away from its known owner (#8940) — owner-blind consumers
- * keep using `resolveExplicitTerminalTitleAgentType`, whose token match is looser.
- */
-export function isClaudeIdentityFrameTitle(title: string): boolean {
-  // Why segments: a multiplexer prefix (`zsh | ⠋ Claude Code`) would otherwise read as task
-  // text and cost a genuine Claude pane its identity.
-  return getWrapperTitleSegments(title).some((segment) =>
-    CLAUDE_IDENTITY_FRAME_RE.test(
-      stripLeadingAgentTitleDecorationOrEmpty(segment).trim().toLowerCase()
-    )
-  )
-}
+export { isClaudeIdentityFrameTitle } from './agent-title-core'
 
 function isGenericClaudeStatusClaim(title: string, titleAgent: TuiAgent | null): boolean {
   return (


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​355 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​355 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​392 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​371 |

<!-- /orca-pr-loc -->

## ELI5

Orca decides which agent is in a pane by scanning the terminal title for agent names in a fixed order — first match wins. So a **Grok** pane whose task text happens to mention Codex reads as **Codex**, because Codex is checked first. Four real recorded titles are wrong today for exactly that reason.

This adds a parser that gathers all the evidence first and ranks it by *how trustworthy the signal is* instead of by list position. Nothing uses it yet.

## What Changed

One new module plus its tests. **No consumer imports it** — `grep` for `collectAgentTitleEvidence` outside the module returns nothing.

`collectAgentTitleEvidence(title)` sorts every signal into three classes:

| Class | What it is | Can task text fake it? |
|---|---|---|
| **vendor marker** | a sigil or control sequence the agent emits (`✳`, the four Gemini glyphs, the `OC \|` envelope) | no |
| **anchored name** | a name where a grammar reserves the position for identity — Orca's `- <agent>` owner suffix, or the whole undecorated remainder | no |
| **free-text name** | a name anywhere else | yes, trivially |

Anchored beats vendor marker, so **`✳ agy` resolves to Antigravity** rather than Claude — the strongest possible name evidence wins instead of losing to a sigil by position. Free text beats neither, and **never becomes identity on its own even when it is the only name present**: an absent icon is recoverable, a confidently wrong one is not. Conflicts inside a class resolve to `null`.

Antigravity's `Gemini <n.n> <Name>` models are handled by reading identity-plus-model as a grammar, so the gemini token is metadata. That is the general rule rather than an exception living inside the Gemini detector.

## Why not swap `getAgentLabel` directly

It has ~20 importers and they include write-authorizing paths, not just icons. Replacing it in place moves all of them in one commit with no way to attribute a regression. Each consumer migrates behind the resolver, separately, with its own evidence.

## Testing

24 assertions covering the recorded misclassifications, the `✳ agy` and Antigravity-model cases, hyphenated worktree names, spinner-only titles, and same-class conflicts — plus an **order-independence property test**: swapping the two agent names in a title must not change the answer, which is precisely what fails on the current chain.

**Measured against the live recorded-title corpus (747 distinct titles): 598 agree, 149 differ.**

```
144  claude -> null   spinner-only titles (◐ ◑ ⠂). Many agents emit braille and
                      quarter-circle frames, so they prove the pane is busy and
                      nothing about who it is. Answered by stronger signals once
                      the resolver lands — which is why this is not wired up yet.
  4  codex  -> grok   the misattributed Grok panes, fixed.
  1  codex  -> null   a spinner-prefixed Claude pane whose task text names Codex.
```

That 144 is the load-bearing number in this PR: it is why the parser ships dark. On its own it would blank real Claude rows; behind the resolver those panes are identified by hook, launch, and process evidence long before the title is consulted.

**Reviewing the delta found three parser defects that reasoning had missed:**
1. the OpenCode `OC |` envelope was a vetoable marker instead of an owning grammar, so 4 real titles lost their identity to session text naming another agent;
2. free text was allowed to veto a vendor marker, blinding **13** real `✳ <task text naming Codex>` Claude titles;
3. the owner suffix matched the tail of a hyphenated worktree name (`review-14600-codex`).

typecheck, oxlint, oxfmt clean. Existing title/status suites: 59 files, 665 tests, all passing.

## Linked Issue

Part of the agent-identity rearchitecture tracked by [#9236](https://github.com/stablyai/orca/issues/9236). No single issue is closed by this PR on its own — it is one stage of a staged change, and behavior only moves once consumers migrate.

## Visual Proof

`N/A` — this module has zero importers and renders nothing, so there is no user-visible behavior to capture. Screenshotting it would imply coverage that does not exist. The manual-validation arm was deliberately skipped for that reason.

## Testing

`pnpm exec vitest run --config config/vitest.config.ts src/shared/agent-title-evidence.test.ts` — 24 passed.

Measured against the live recorded-title corpus (747 distinct titles): 598 agree with the current chain, 149 differ, and every delta group is enumerated above. Reviewing that delta — rather than reasoning about the code — is what found three defects during implementation.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Security:** no new input is trusted. The change reduces what a terminal title is allowed to decide.
- **Cross-platform:** pure TypeScript in `src/shared`, no platform branches, no paths, no shell.
- **Remote SSH / backwards compatibility:** no wire change in this PR. Nothing new is published, and nothing existing is read differently, because no consumer calls it yet.
- **Mobile:** unaffected — no importers.
- **Performance:** pure function over a short string, called by nobody yet; no allocation on any hot path.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `typecheck`, `oxlint`, `oxfmt` and focused tests pass locally; CI covers the rest
