### PR TITLE
fix(runtime): retire terminal snapshot probes before waiter timeout

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -35600,23 +35600,32 @@ export class OrcaRuntimeService {
    *  later transition. A provider screen that is still working when this fires
    *  resolves through the poll, not here. */
   private startTuiIdleVisibleReadProbe(waiter: TerminalWaiter, waiterTimeoutMs: number): void {
-    const snapshotTimeoutMs = Math.min(
-      VISIBLE_TERMINAL_SNAPSHOT_TIMEOUT_MS,
-      Math.max(0, waiterTimeoutMs - 1)
+    const settleMarginMs = Math.min(
+      TUI_IDLE_VISIBLE_PROBE_SETTLE_MARGIN_MS,
+      Math.max(1, Math.floor(waiterTimeoutMs / 3))
     )
+    const probeTimeoutMs = Math.min(
+      VISIBLE_TERMINAL_SNAPSHOT_TIMEOUT_MS + settleMarginMs,
+      Math.max(0, waiterTimeoutMs - settleMarginMs)
+    )
+    const providerTimeoutMs = Math.min(
+      VISIBLE_TERMINAL_SNAPSHOT_TIMEOUT_MS,
+      Math.max(0, probeTimeoutMs - settleMarginMs)
+    )
+    // Retire the provider before the detached probe and waiter can settle.
     void withTimeout(
       this.readTerminal(
         waiter.handle,
         {},
         {
-          timeoutMs: snapshotTimeoutMs,
+          timeoutMs: providerTimeoutMs,
           retireOnTimeout: true,
           // Why: the ready banner stays in scrollback for the whole session, so
           // classifying history would call a working agent idle (#15569 review).
           visibleScreenOnly: true
         }
       ),
-      snapshotTimeoutMs,
+      probeTimeoutMs,
       null
     )
       .then((read) => {
@@ -38641,6 +38650,7 @@ const MAX_TERMINAL_PREVIEW_CHARS = 32 * 1024
 export const AUTHORITATIVE_TERMINAL_SNAPSHOT_TIMEOUT_MS = 8_000
 const VISIBLE_TERMINAL_SNAPSHOT_TIMEOUT_MS = 750
 const VISIBLE_TERMINAL_SNAPSHOT_RETRY_MS = 1_000
+const TUI_IDLE_VISIBLE_PROBE_SETTLE_MARGIN_MS = 10
 const MAX_PREVIEW_LINES = 6
 const MAX_PREVIEW_CHARS = 300
 const WORKTREE_STATUS_PRIORITY: Record<RuntimeWorktreeStatus, number> = {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -35612,6 +35612,10 @@ export class OrcaRuntimeService {
       VISIBLE_TERMINAL_SNAPSHOT_TIMEOUT_MS,
       Math.max(0, probeTimeoutMs - settleMarginMs)
     )
+    // Node clamps sub-millisecond timers to 1ms, so no distinct retirement deadline exists.
+    if (providerTimeoutMs < 1) {
+      return
+    }
     // Retire the provider before the detached probe and waiter can settle.
     void withTimeout(
       this.readTerminal(

--- a/src/renderer/src/lib/active-agent-note-send.ts
+++ b/src/renderer/src/lib/active-agent-note-send.ts
@@ -1,4 +1,5 @@
 import type { RuntimeTerminalSend, RuntimeTerminalWait } from '../../../shared/runtime-types'
+import { sanitizeTerminalPasteText } from '@/components/terminal-pane/terminal-bracketed-paste'
 import { useAppStore } from '@/store'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { getSettingsForWorktreeRuntimeOwner } from '@/lib/worktree-runtime-owner'
@@ -10,8 +11,7 @@ import {
 import {
   BRACKETED_PASTE_BEGIN,
   BRACKETED_PASTE_END,
-  POST_PASTE_SUBMIT_DELAY_MS,
-  sanitizeBracketedPasteContent
+  POST_PASTE_SUBMIT_DELAY_MS
 } from './agent-paste-draft'
 import type { ActiveAgentNotesSendResult } from './active-agent-note-send-result'
 import {
@@ -182,7 +182,7 @@ async function sendPromptWithGuardedPasteAndEnter(
     return { status: initialAgentStatus.status }
   }
 
-  const pastePayload = `${BRACKETED_PASTE_BEGIN}${sanitizeBracketedPasteContent(prompt)}${BRACKETED_PASTE_END}`
+  const pastePayload = `${BRACKETED_PASTE_BEGIN}${sanitizeTerminalPasteText(prompt)}${BRACKETED_PASTE_END}`
   try {
     const { send } = await callRuntimeRpc<{ send: RuntimeTerminalSend }>(
       runtimeTarget,

--- a/src/renderer/src/lib/agent-paste-draft.ts
+++ b/src/renderer/src/lib/agent-paste-draft.ts
@@ -9,8 +9,7 @@ import {
 } from '@/runtime/runtime-terminal-inspection'
 import {
   BRACKETED_PASTE_END,
-  BRACKETED_PASTE_START,
-  sanitizeTerminalPasteText
+  BRACKETED_PASTE_START
 } from '@/components/terminal-pane/terminal-bracketed-paste'
 import { runTerminalPtyInputTransaction } from '@/components/terminal-pane/terminal-pty-input-transaction'
 import { waitForAgentReady } from './agent-ready-wait'
@@ -35,10 +34,6 @@ export {
 export const BRACKETED_PASTE_BEGIN = BRACKETED_PASTE_START
 export { BRACKETED_PASTE_END }
 export const POST_PASTE_SUBMIT_DELAY_MS = 50
-
-export function sanitizeBracketedPasteContent(content: string): string {
-  return sanitizeTerminalPasteText(content)
-}
 
 // Why: "the tab has a PTY" and "the agent's composer accepts input" are separate
 // states with separate failure modes, so they get separate budgets. A PTY that


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 |

<!-- /orca-pr-loc -->

## ELI5

Retire a stalled terminal-screen snapshot before the surrounding readiness wait can finish, so the next terminal read cannot accidentally start the hung request again. Also call the canonical terminal paste sanitizer directly instead of routing through a one-line forwarding function.

## What Changed

- Separated the provider acquisition deadline, detached probe deadline, and caller waiter deadline.
- Preserved the normal 750ms provider acquisition budget; the detached guard settles 10ms later.
- Bounded short waits in the same order: a 50ms wait now uses 30ms provider / 40ms probe / 50ms waiter deadlines.
- Skip the probe when a sub-3ms caller budget cannot establish distinct deadlines above Node's 1ms timer floor.
- Removed `sanitizeBracketedPasteContent` and migrated its sole caller to `sanitizeTerminalPasteText`.

## Why

Node 26 CI twice reproduced a timeout-ordering race in `OrcaRuntimeService`: the waiter rejected while the visible-only provider acquisition had not yet been marked retired, and the following wider read replaced it, producing a seventh provider call. Equal nested deadlines made cleanup order scheduler-dependent.

The sanitizer export only returned the canonical sanitizer result. Direct use preserves every payload byte while removing one function call and an unnecessary ownership layer.

## Linked Issue

N/A — CI repair plus opportunistic zero-behavior-change cleanup requested directly.

## Visual Proof

N/A — no rendered UI change.

## Reliability Contract

- **Invariant:** `terminal-session.provider-snapshot-retirement` — a timed-out visible-screen probe retires before its detached guard or terminal waiter settles.
- **Failure source:** PR CI run `32669430511`, Node 26 shard 4/16, reproduced twice as 6 expected provider calls versus 7.
- **Oracle:** the existing runtime test keeps its exact six-call count and five `{ scrollbackRows: 0 }` probe-argument assertions unchanged.
- **Gate:** no exact manifest entry; focused runtime coverage plus the full Node 24/26 CI matrix is the accepted gate for this correction.
- **Providers/platforms:** provider-agnostic main-runtime timing only; no RPC, stream, path, process, SSH, WSL, relay, or mobile wire change. CI covers Linux Node 24/26; deterministic focused checks passed on macOS Node 24/26.
- **Performance:** default provider work remains capped at 750ms and one acquisition. The detached guard moves from 750ms to 760ms without blocking the caller or adding polling/provider calls.
- **Diagnostics:** exact provider call count and option assertions identify retirement regressions.
- **Residual gap:** local full-shard runs hit unrelated renderer-terminal timeouts under contention; required hosted CI is pending.

## Testing

- [x] Exact runtime regression on Node 24.18.0: 1/1 passed
- [x] Exact runtime regression on Node 26.7.0: 1/1 passed after both timeout commits
- [x] Exact local Node 26 shard: runtime regression passed; unrelated renderer-terminal cases timed out under local contention
- [x] Paste-focused Vitest: 6 files, 91/91 tests passed
- [x] `pnpm run typecheck:web`
- [x] File-scoped oxlint with zero warnings
- [x] File-scoped oxfmt check
- [x] Independent timeout review: timer-floor finding fixed; re-review found no remaining issues
- [ ] Required hosted CI

## Review

The timeout correction adds no polling, provider calls, scans, subprocesses, allocations on steady-state paths, or wire changes. The exact prompt still flows through the same ESC-to-U+241B sanitizer and identical bracketed-paste markers. The canonical sanitizer module has no runtime import back to either renderer module.

## Agent skill upstream boundary

- [x] Not applicable.

## Checklist

- [x] Root cause and changed behavior documented
- [x] Behavior and performance independently reviewed
- [x] Cross-platform and remote impact considered
- [ ] Required hosted CI green