### PR TITLE
refactor: reuse canonical regex escaping

### DIFF
--- a/src/main/kimi/kimi-hook-config-toml.ts
+++ b/src/main/kimi/kimi-hook-config-toml.ts
@@ -7,6 +7,7 @@
 // at the end of any existing file.
 
 import { MANAGED_HOOK_TIMEOUT_SECONDS } from '../agent-hooks/installer-utils'
+import { escapeRegex } from '../../shared/string-utils'
 
 // Why: mirror the Claude-compatible events Orca normalizes for status. Kimi uses
 // these exact event names (see normalizeKimiEvent), so each maps to a
@@ -24,10 +25,6 @@ export const KIMI_HOOK_EVENTS = [
 const BLOCK_START = '# >>> orca-managed-kimi-hooks (managed by Orca; do not edit) >>>'
 const BLOCK_END = '# <<< orca-managed-kimi-hooks <<<'
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-}
-
 // Matches the managed block plus any blank lines immediately preceding it so
 // repeated install/remove cycles do not accumulate whitespace. The `|$`
 // fallback also matches from BLOCK_START to end-of-file when the trailing
@@ -35,7 +32,7 @@ function escapeRegExp(value: string): string {
 // is always written last, so this recovers orphaned hook tables and lets
 // install re-converge in one step instead of appending a duplicate block.
 const MANAGED_BLOCK_RE = new RegExp(
-  `\\n*${escapeRegExp(BLOCK_START)}[\\s\\S]*?(?:${escapeRegExp(BLOCK_END)}[^\\n]*|$)`,
+  `\\n*${escapeRegex(BLOCK_START)}[\\s\\S]*?(?:${escapeRegex(BLOCK_END)}[^\\n]*|$)`,
   'g'
 )
 

--- a/src/main/workspace-space-analysis.ts
+++ b/src/main/workspace-space-analysis.ts
@@ -21,6 +21,7 @@ import type {
 } from '../shared/workspace-space-types'
 import { compactWorkspaceSpaceItems } from '../shared/workspace-space-compaction'
 import { mapWithConcurrency } from '../shared/map-with-concurrency'
+import { escapeRegex } from '../shared/string-utils'
 import {
   scanWorkspaceSpaceEntryTree,
   type WorkspaceSpaceEntryScan
@@ -167,13 +168,9 @@ function joinFilesystemPath(parent: string, child: string): string {
   return looksLikeWindowsPath(parent) ? win32.join(parent, child) : posix.join(parent, child)
 }
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-}
-
 function normalizeLocalDuPath(pathValue: string): string {
   const separator = platform === 'win32' ? '\\' : '/'
-  const trimmed = pathValue.replace(new RegExp(`${escapeRegExp(separator)}+$`), '')
+  const trimmed = pathValue.replace(new RegExp(`${escapeRegex(separator)}+$`), '')
   return trimmed.length > 0 ? trimmed : pathValue
 }
 

--- a/src/renderer/src/components/sidebar/worktree-list-card-markup-queries.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-card-markup-queries.ts
@@ -1,7 +1,9 @@
+import { escapeRegex } from '../../../../shared/string-utils'
+
 export function getCardOpeningTag(markup: string, worktreeId: string): string {
   return (
     markup.match(
-      new RegExp(`<section[^>]*data-worktree-card-id="${escapeRegExp(worktreeId)}"[^>]*>`)
+      new RegExp(`<section[^>]*data-worktree-card-id="${escapeRegex(worktreeId)}"[^>]*>`)
     )?.[0] ?? ''
   )
 }
@@ -12,7 +14,7 @@ export function getOptionOpeningTag(markup: string, worktreeId: string): string 
   // The worktree id is the suffix after the encoded host separator (STA-4343).
   return (
     markup.match(
-      new RegExp(`<div[^>]*id="worktree-list-option-[^"]*%7C${escapeRegExp(worktreeId)}"[^>]*>`)
+      new RegExp(`<div[^>]*id="worktree-list-option-[^"]*%7C${escapeRegex(worktreeId)}"[^>]*>`)
     )?.[0] ?? ''
   )
 }
@@ -24,7 +26,7 @@ export function getFolderWorkspaceSurfaceOpeningTag(
   return (
     markup.match(
       new RegExp(
-        `<div[^>]*id="worktree-list-option-[^"]*%3A${escapeRegExp(folderWorkspaceId)}"[^>]*>` +
+        `<div[^>]*id="worktree-list-option-[^"]*%3A${escapeRegex(folderWorkspaceId)}"[^>]*>` +
           `[\\s\\S]*?<div class="relative"[^>]*>`
       )
     )?.[0] ?? ''
@@ -52,8 +54,4 @@ export function getFlushCardContentStart(args: {
     flushCardMargin +
     Math.max(flushCardMinimumInset, args.cardContentIndent - flushCardPullback)
   )
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }

--- a/src/shared/command-code-output-status.ts
+++ b/src/shared/command-code-output-status.ts
@@ -10,6 +10,7 @@ import {
   isCommandCodeIdlePromptCandidate
 } from './command-code-prompt-text'
 import { stripTerminalControl } from './terminal-control-stripping'
+import { escapeRegex } from './string-utils'
 
 export { stripTerminalControl } from './terminal-control-stripping'
 
@@ -100,11 +101,7 @@ const COMMAND_CODE_LLM_STATUS_WORDS = [
   'Razzmatazzing'
 ] as const
 
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-}
-
-const LLM_STATUS_WORDS_RE_SOURCE = COMMAND_CODE_LLM_STATUS_WORDS.map(escapeRegExp).join('|')
+const LLM_STATUS_WORDS_RE_SOURCE = COMMAND_CODE_LLM_STATUS_WORDS.map(escapeRegex).join('|')
 const ACTIVE_LLM_STATUS_RE = new RegExp(
   `(?:^|[\\r\\n])\\s*(?:${COMMAND_CODE_STATUS_GLYPH_RE_SOURCE}\\s*)?(?:${LLM_STATUS_WORDS_RE_SOURCE})\\b(?:…|\\.\\.\\.)`
 )

--- a/src/shared/feature-interactions.test.ts
+++ b/src/shared/feature-interactions.test.ts
@@ -12,6 +12,7 @@ import {
   normalizeFeatureInteractions,
   type FeatureInteractionId
 } from './feature-interactions'
+import { escapeRegex } from './string-utils'
 
 type DefinedFeatureInteractionId = (typeof FEATURE_INTERACTIONS)[number]['id']
 type MissingFeatureInteractionId = Exclude<FeatureInteractionId, DefinedFeatureInteractionId>
@@ -201,7 +202,7 @@ describe('feature interactions', () => {
   it('keeps every catalog id wired to a production writer', () => {
     const productionText = collectProductionSourceText()
     const missingWriters = FEATURE_INTERACTIONS.map((feature) => feature.id).filter((id) => {
-      const escaped = escapeRegExp(id)
+      const escaped = escapeRegex(id)
       const directRecord = new RegExp(
         `recordFeatureInteraction(?:\\?\\.)?\\(\\s*['"]${escaped}['"]`
       )
@@ -249,8 +250,4 @@ function collectSourceFiles(directory: string): string[] {
     files.push(path)
   }
   return files
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }

--- a/src/shared/workspace-name.ts
+++ b/src/shared/workspace-name.ts
@@ -2,6 +2,7 @@ import {
   collectCompactWorkspaceWords,
   foldWorkspaceNameWhitespaceToHyphen
 } from './workspace-name-text-scanner'
+import { escapeRegex } from './string-utils'
 
 function normalizeApostrophes(input: string): string {
   return input.replace(/[‘’]/g, "'")
@@ -135,10 +136,6 @@ function compactWords(input: string, maxWords = 4): string {
   return words.map(titleCaseWord).join(' ')
 }
 
-function escapeRegExp(input: string): string {
-  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-}
-
 function compactWorkItemTitle(title: string, item: WorkspaceIntentWorkItem): string {
   const identifier = item.linearIdentifier ?? item.jiraIdentifier
   let withoutPrefix = title
@@ -152,7 +149,7 @@ function compactWorkItemTitle(title: string, item: WorkspaceIntentWorkItem): str
   }
   if (identifier) {
     withoutPrefix = withoutPrefix
-      .replace(new RegExp(`^${escapeRegExp(identifier)}\\s*[:-]?\\s*`, 'i'), '')
+      .replace(new RegExp(`^${escapeRegex(identifier)}\\s*[:-]?\\s*`, 'i'), '')
       .trim()
   }
   return compactWords(withoutPrefix || title, 3)
@@ -181,7 +178,7 @@ export function getLinkedWorkItemWorkspaceName(
   let subject = getLinkedWorkItemTitleSubject(item) || item.title.trim()
   if (identifier) {
     subject = subject
-      .replace(new RegExp(`^${escapeRegExp(identifier)}\\s*[:-]?\\s*`, 'i'), '')
+      .replace(new RegExp(`^${escapeRegex(identifier)}\\s*[:-]?\\s*`, 'i'), '')
       .trim()
   }
   const displayName = [identifier, subject].filter(Boolean).join(' ') || workItemIdentity(item)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​28 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 |

<!-- /orca-pr-loc -->

## ELI5

Use the existing literal-regex escaping function instead of maintaining six identical copies.

## What Changed

- Migrated five production modules and one shared test to `src/shared/string-utils.ts::escapeRegex`.
- Removed six byte-identical local helpers.
- Deliberately left differently spelled/implemented watcher, Codex, config-script, and E2E helpers untouched.

## Why

Every migrated function performed the same one-call global replacement with the same regex and replacement string. Reuse keeps output, call count, replacement pass, and string allocation identical while removing duplicate function code/objects.

## Linked Issue

N/A — opportunistic zero-behavior-change cleanup requested directly.

## Visual Proof

N/A — outputs and UI behavior are unchanged.

## Testing

- [x] Focused behavior: 7 files, 173 assertions covered
- [x] Six files passed in the combined run; the source-scanning feature-interactions case exceeded its explicit 15s timeout only under concurrent load, then passed 7/7 in isolation (12.52s)
- [x] `pnpm run typecheck:node`
- [x] `pnpm run typecheck:web`
- [x] File-scoped oxlint with zero warnings
- [x] oxfmt check and commit hooks

## Review

The canonical helper is an import-free, side-effect-free leaf. Independent review confirmed identical regex/output/allocation behavior, safe import directions, and no changes to excluded variants. No wire, SSH, Git, platform, rendering, or runtime-work changes.

## Agent skill upstream boundary

- [x] Not applicable.

## Checklist

- [x] Small and focused
- [x] Behavior and performance independently reviewed
- [x] Cross-platform and remote impact considered: none
- [ ] Full repository suite deferred to CI; focused checks passed as described