### PR TITLE
fix(crash-reporting): stamp React #185 boundary attribution as unreliable

### DIFF
--- a/src/main/ipc/crash-reporting-renderer-error-report-attribution.test.ts
+++ b/src/main/ipc/crash-reporting-renderer-error-report-attribution.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CrashReportStore } from '../crash-reporting/crash-report-store'
+import {
+  formatCrashReportText,
+  sanitizeCrashReportDetails,
+  type CrashReportRecord
+} from '../../shared/crash-reporting'
+import {
+  recentRendererErrorReportKeys,
+  recordRendererErrorReport
+} from './crash-reporting-renderer-error-report'
+
+vi.mock('electron', () => ({ app: { getVersion: () => '1.4.188' } }))
+vi.mock('../crash-reporting/crash-breadcrumb-store', () => ({
+  getCrashBreadcrumbSnapshot: () => []
+}))
+
+const REACT_185_DIGEST =
+  'Minified React error #185; visit https://react.dev/errors/185 for the full message.'
+
+function makeStore(): { store: CrashReportStore; record: ReturnType<typeof vi.fn> } {
+  const record = vi.fn(async (input: { details: Record<string, unknown> }) => ({
+    id: 'crash-1',
+    createdAt: '2026-08-20T00:00:00.000Z',
+    status: 'pending',
+    source: 'renderer',
+    processType: 'react-render',
+    reason: 'react-error-boundary',
+    exitCode: null,
+    appVersion: '1.4.188',
+    platform: 'darwin',
+    osRelease: '25.0.0',
+    arch: 'arm64',
+    electronVersion: '41.0.0',
+    chromeVersion: '141.0.0',
+    details: sanitizeCrashReportDetails(input.details)
+  }))
+  return { store: { record } as unknown as CrashReportStore, record }
+}
+
+function baseArgs(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    boundaryId: 'page.automations',
+    surface: 'page',
+    errorName: 'Error',
+    errorMessage: REACT_185_DIGEST,
+    componentStack: 'at AutomationsPage\nat App',
+    ...overrides
+  }
+}
+
+describe('renderer error report attribution', () => {
+  beforeEach(() => {
+    recentRendererErrorReportKeys.clear()
+  })
+
+  it('stamps unreliable attribution plus a human-readable note on the stored report', async () => {
+    const { store, record } = makeStore()
+
+    const result = await recordRendererErrorReport(store, baseArgs({ attribution: 'unreliable' }))
+
+    expect(result).toMatchObject({ ok: true, deduped: false })
+    const details = record.mock.calls[0]?.[0]?.details as Record<string, unknown>
+    expect(details.attribution).toBe('unreliable')
+    expect(String(details.attribution_note)).toContain('boundary_id')
+    // Boundary id stays intact for continuity with existing triage.
+    expect(details.boundary_id).toBe('page.automations')
+  })
+
+  it('omits attribution when the renderer does not send one', async () => {
+    const { store, record } = makeStore()
+
+    await recordRendererErrorReport(store, baseArgs())
+
+    const details = record.mock.calls[0]?.[0]?.details as Record<string, unknown>
+    expect(details).not.toHaveProperty('attribution')
+    expect(details).not.toHaveProperty('attribution_note')
+  })
+
+  it('ignores unknown attribution values from a newer or hostile renderer', async () => {
+    const { store, record } = makeStore()
+
+    await recordRendererErrorReport(store, baseArgs({ attribution: 'definitely-this-component' }))
+
+    const details = record.mock.calls[0]?.[0]?.details as Record<string, unknown>
+    expect(details).not.toHaveProperty('attribution')
+  })
+
+  it('surfaces the caveat in the formatted report text a human reads', async () => {
+    const { store } = makeStore()
+
+    const result = await recordRendererErrorReport(store, baseArgs({ attribution: 'unreliable' }))
+    const report = (result as { report: CrashReportRecord }).report
+    const text = formatCrashReportText(report)
+
+    expect(text).toContain('Attribution: unreliable')
+    expect(text).toContain('boundary_id')
+    expect(text.indexOf('Attribution: unreliable')).toBeLessThan(text.indexOf('Details:'))
+  })
+})

--- a/src/main/ipc/crash-reporting-renderer-error-report.ts
+++ b/src/main/ipc/crash-reporting-renderer-error-report.ts
@@ -4,6 +4,12 @@ import type {
   ReactErrorBoundaryReportArgs,
   ReactErrorBoundaryReportResult
 } from '../../shared/crash-reporting'
+import {
+  CRASH_REPORT_ATTRIBUTION_DETAIL_KEY,
+  CRASH_REPORT_ATTRIBUTION_NOTE_DETAIL_KEY,
+  UNRELIABLE_BOUNDARY_ATTRIBUTION,
+  UNRELIABLE_BOUNDARY_ATTRIBUTION_NOTE
+} from '../../shared/react-update-depth-attribution'
 import type { CrashReportStore } from '../crash-reporting/crash-report-store'
 import { getCrashBreadcrumbSnapshot } from '../crash-reporting/crash-breadcrumb-store'
 
@@ -45,11 +51,17 @@ function nullableStringField(value: unknown, maxLength: number): string | null |
   return stringField(value, maxLength)
 }
 
+function attributionField(value: unknown): ReactErrorBoundaryReportArgs['attribution'] {
+  // Only the one known verdict; anything else from a newer renderer degrades to no attribution.
+  return value === UNRELIABLE_BOUNDARY_ATTRIBUTION ? UNRELIABLE_BOUNDARY_ATTRIBUTION : undefined
+}
+
 function normalizeRendererErrorReportArgs(args: unknown): ReactErrorBoundaryReportArgs | null {
   if (!args || typeof args !== 'object') {
     return null
   }
   const record = args as Record<string, unknown>
+  const attribution = attributionField(record.attribution)
   const boundaryId = stringField(record.boundaryId, 120)
   const surface = stringField(record.surface, 80)
   const errorName = stringField(record.errorName, 120) ?? 'Error'
@@ -87,7 +99,8 @@ function normalizeRendererErrorReportArgs(args: unknown): ReactErrorBoundaryRepo
       : {}),
     ...(typeof record.hasActiveWorktree === 'boolean'
       ? { hasActiveWorktree: record.hasActiveWorktree }
-      : {})
+      : {}),
+    ...(attribution ? { attribution } : {})
   }
 }
 
@@ -155,6 +168,12 @@ export async function recordRendererErrorReport(
       error_message: normalized.errorMessage,
       ...(normalized.errorStack ? { error_stack: normalized.errorStack } : {}),
       ...(normalized.componentStack ? { component_stack: normalized.componentStack } : {}),
+      ...(normalized.attribution
+        ? {
+            [CRASH_REPORT_ATTRIBUTION_DETAIL_KEY]: normalized.attribution,
+            [CRASH_REPORT_ATTRIBUTION_NOTE_DETAIL_KEY]: UNRELIABLE_BOUNDARY_ATTRIBUTION_NOTE
+          }
+        : {}),
       ...(normalized.activeView ? { active_view: normalized.activeView } : {}),
       ...(normalized.activeModal !== undefined ? { active_modal: normalized.activeModal } : {}),
       ...(normalized.activeTabType ? { active_tab_type: normalized.activeTabType } : {}),

--- a/src/renderer/src/components/error-boundaries/react-185-bystander-attribution.test.tsx
+++ b/src/renderer/src/components/error-boundaries/react-185-bystander-attribution.test.tsx
@@ -1,0 +1,116 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactElement } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { RecoverableRenderErrorBoundary } from './RecoverableRenderErrorBoundary'
+import { RichMarkdownErrorBoundary } from '@/components/editor/RichMarkdownErrorBoundary'
+import { clearReactErrorBoundaryReportingForTest } from '@/lib/react-error-boundary-reporting'
+
+const mocks = vi.hoisted(() => ({ recordRendererError: vi.fn() }))
+
+vi.mock('@/store', () => ({
+  useAppStore: { getState: () => ({}) }
+}))
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const REACT_185_PRODUCTION =
+  'Minified React error #185; visit https://react.dev/errors/185 for the full message.'
+const UNRELATED_RENDER_ERROR =
+  'Minified React error #310; visit https://react.dev/errors/310 for the full message.'
+
+// Every reporting boundary must stamp #185, not just the one nearest the runaway fiber.
+const BOUNDARIES: { name: string; boundaryId: string; render: () => ReactElement }[] = [
+  {
+    name: 'RecoverableRenderErrorBoundary',
+    boundaryId: 'page.automations',
+    render: () => (
+      <RecoverableRenderErrorBoundary boundaryId="page.automations" surface="page">
+        <Broken />
+      </RecoverableRenderErrorBoundary>
+    )
+  },
+  {
+    name: 'RichMarkdownErrorBoundary',
+    boundaryId: 'editor.rich-markdown',
+    render: () => (
+      <RichMarkdownErrorBoundary fileId="notes.md">
+        <Broken />
+      </RichMarkdownErrorBoundary>
+    )
+  }
+]
+
+let thrownError = new Error('unset')
+
+function Broken(): ReactElement {
+  throw thrownError
+}
+
+describe('React #185 bystander attribution', () => {
+  let root: Root | null = null
+  let container: HTMLDivElement | null = null
+  let consoleError: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    clearReactErrorBoundaryReportingForTest()
+    mocks.recordRendererError.mockReset()
+    mocks.recordRendererError.mockResolvedValue({ ok: true, deduped: false })
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true)
+    window.api = {
+      crashReports: { recordRendererError: mocks.recordRendererError }
+    } as unknown as typeof window.api
+  })
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount())
+    }
+    container?.remove()
+    root = null
+    container = null
+    consoleError.mockRestore()
+    vi.unstubAllGlobals()
+  })
+
+  async function renderThrowing(element: ReactElement, message: string): Promise<void> {
+    thrownError = new Error(message)
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    await act(async () => {
+      root?.render(element)
+    })
+  }
+
+  for (const boundary of BOUNDARIES) {
+    it(`stamps unreliable attribution from ${boundary.name}`, async () => {
+      await renderThrowing(boundary.render(), REACT_185_PRODUCTION)
+
+      expect(mocks.recordRendererError).toHaveBeenCalledWith(
+        expect.objectContaining({ boundaryId: boundary.boundaryId, attribution: 'unreliable' })
+      )
+    })
+
+    it(`leaves unrelated render errors unattributed from ${boundary.name}`, async () => {
+      await renderThrowing(boundary.render(), UNRELATED_RENDER_ERROR)
+
+      expect(mocks.recordRendererError).toHaveBeenCalledTimes(1)
+      expect(mocks.recordRendererError.mock.calls[0]?.[0]).not.toHaveProperty('attribution')
+    })
+  }
+
+  it('stamps the development "Maximum update depth exceeded" message', async () => {
+    await renderThrowing(
+      BOUNDARIES[0]!.render(),
+      'Maximum update depth exceeded. This can happen when a component repeatedly calls setState.'
+    )
+
+    expect(mocks.recordRendererError).toHaveBeenCalledWith(
+      expect.objectContaining({ attribution: 'unreliable' })
+    )
+  })
+})

--- a/src/renderer/src/lib/react-error-boundary-reporting.test.ts
+++ b/src/renderer/src/lib/react-error-boundary-reporting.test.ts
@@ -96,6 +96,28 @@ describe('react error boundary reporting', () => {
     })
   })
 
+  it('derives #185 attribution from the error itself, without boundary opt-in', async () => {
+    await reportReactErrorBoundaryCrash({
+      boundaryId: 'page.settings',
+      surface: 'page',
+      error: new Error('Minified React error #185; visit https://react.dev/errors/185')
+    })
+
+    expect(mocks.recordRendererError).toHaveBeenCalledWith(
+      expect.objectContaining({ attribution: 'unreliable' })
+    )
+  })
+
+  it('omits attribution for ordinary render errors', () => {
+    const args = buildReactErrorBoundaryReportArgs({
+      boundaryId: 'page.settings',
+      surface: 'page',
+      error: new Error('render failed')
+    })
+
+    expect(args).not.toHaveProperty('attribution')
+  })
+
   it('reports a caught render error once per boundary signature', async () => {
     const error = new Error('render failed')
     await reportReactErrorBoundaryCrash({

--- a/src/renderer/src/lib/react-error-boundary-reporting.ts
+++ b/src/renderer/src/lib/react-error-boundary-reporting.ts
@@ -3,6 +3,7 @@ import type {
   CrashReportRecord,
   ReactErrorBoundaryReportArgs
 } from '../../../shared/crash-reporting'
+import { getReactErrorBoundaryAttribution } from '../../../shared/react-update-depth-attribution'
 
 type RendererErrorContext = Pick<
   ReactErrorBoundaryReportArgs,
@@ -65,6 +66,8 @@ export function buildReactErrorBoundaryReportArgs({
 }: BuildReportArgsInput): ReactErrorBoundaryReportArgs {
   const fields = stringFromThrown(error)
   const componentStack = errorInfo?.componentStack?.trim()
+  // Derived here, not per boundary: React #185 lands on a bystander, so every boundary needs the caveat.
+  const attribution = getReactErrorBoundaryAttribution(error)
   return {
     boundaryId,
     surface,
@@ -72,6 +75,7 @@ export function buildReactErrorBoundaryReportArgs({
     errorMessage: fields.message,
     ...(fields.stack ? { errorStack: fields.stack } : {}),
     ...(componentStack ? { componentStack } : {}),
+    ...(attribution ? { attribution } : {}),
     ...(context?.activeView ? { activeView: context.activeView } : {}),
     ...(context?.activeModal !== undefined ? { activeModal: context.activeModal } : {}),
     ...(context?.activeTabType ? { activeTabType: context.activeTabType } : {}),

--- a/src/shared/crash-report-attribution-lines.ts
+++ b/src/shared/crash-report-attribution-lines.ts
@@ -1,0 +1,22 @@
+// Type-only, so this erases at compile time and creates no import cycle.
+import type { CrashReportDetailValue } from './crash-reporting'
+import {
+  CRASH_REPORT_ATTRIBUTION_DETAIL_KEY,
+  CRASH_REPORT_ATTRIBUTION_NOTE_DETAIL_KEY,
+  UNRELIABLE_BOUNDARY_ATTRIBUTION
+} from './react-update-depth-attribution'
+
+/** Promotes the attribution caveat above the details blob so a triager cannot scroll past it. */
+export function appendBoundaryAttributionLines(
+  lines: string[],
+  details: Record<string, CrashReportDetailValue>
+): void {
+  if (details[CRASH_REPORT_ATTRIBUTION_DETAIL_KEY] !== UNRELIABLE_BOUNDARY_ATTRIBUTION) {
+    return
+  }
+  const note = details[CRASH_REPORT_ATTRIBUTION_NOTE_DETAIL_KEY]
+  lines.push('', `Attribution: ${UNRELIABLE_BOUNDARY_ATTRIBUTION}`)
+  if (typeof note === 'string' && note) {
+    lines.push(note)
+  }
+}

--- a/src/shared/crash-reporting.ts
+++ b/src/shared/crash-reporting.ts
@@ -4,6 +4,8 @@ import {
 } from './crash-reporting-diagnostic-bundle'
 import { appendMinidumpSignatureLines } from './crash-report-signature-lines'
 import { formatCrashReportExitCode } from './crash-report-exit-code'
+import { appendBoundaryAttributionLines } from './crash-report-attribution-lines'
+import type { CrashReportAttribution } from './react-update-depth-attribution'
 
 export type { CrashReportDiagnosticBundle } from './crash-reporting-diagnostic-bundle'
 
@@ -86,6 +88,8 @@ export type ReactErrorBoundaryReportArgs = {
   activeTabType?: string | null
   activeRightSidebarTab?: string | null
   hasActiveWorktree?: boolean
+  // Absent means "attribution is as trustworthy as it ever was"; older hosts ignore it.
+  attribution?: CrashReportAttribution
 }
 
 export type ReactErrorBoundaryReportResult =
@@ -254,6 +258,7 @@ export function formatCrashReportText(
   ]
 
   appendMinidumpSignatureLines(lines, report.details)
+  appendBoundaryAttributionLines(lines, report.details)
   appendDiagnosticBundleLines(lines, diagnosticBundle, sanitizeCrashReportString)
 
   const details = Object.entries(report.details)

--- a/src/shared/react-update-depth-attribution.test.ts
+++ b/src/shared/react-update-depth-attribution.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import {
+  UNRELIABLE_BOUNDARY_ATTRIBUTION,
+  getReactErrorBoundaryAttribution
+} from './react-update-depth-attribution'
+
+describe('react update depth attribution', () => {
+  it('matches the minified production digest for error #185', () => {
+    expect(
+      getReactErrorBoundaryAttribution(
+        new Error(
+          'Minified React error #185; visit https://react.dev/errors/185 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.'
+        )
+      )
+    ).toBe(UNRELIABLE_BOUNDARY_ATTRIBUTION)
+  })
+
+  it('matches the legacy error-decoder invariant form', () => {
+    expect(
+      getReactErrorBoundaryAttribution(
+        new Error(
+          'Minified React error #185; visit https://reactjs.org/docs/error-decoder.html?invariant=185 for the full message.'
+        )
+      )
+    ).toBe(UNRELIABLE_BOUNDARY_ATTRIBUTION)
+  })
+
+  it('matches the development message', () => {
+    expect(
+      getReactErrorBoundaryAttribution(new Error('Maximum update depth exceeded. This can happen…'))
+    ).toBe(UNRELIABLE_BOUNDARY_ATTRIBUTION)
+  })
+
+  it('matches a non-Error thrown value carrying the digest', () => {
+    expect(getReactErrorBoundaryAttribution('Minified React error #185; visit https://x')).toBe(
+      UNRELIABLE_BOUNDARY_ATTRIBUTION
+    )
+  })
+
+  it('does not match other React error numbers, including #185 prefixes', () => {
+    expect(
+      getReactErrorBoundaryAttribution(new Error('Minified React error #310; visit https://x'))
+    ).toBeUndefined()
+    expect(
+      getReactErrorBoundaryAttribution(new Error('Minified React error #1852; visit https://x'))
+    ).toBeUndefined()
+    expect(
+      getReactErrorBoundaryAttribution(new Error('Minified React error #18; visit https://x'))
+    ).toBeUndefined()
+  })
+
+  it('does not match unrelated errors', () => {
+    expect(getReactErrorBoundaryAttribution(new TypeError('x is not a function'))).toBeUndefined()
+    expect(getReactErrorBoundaryAttribution(null)).toBeUndefined()
+  })
+})

--- a/src/shared/react-update-depth-attribution.ts
+++ b/src/shared/react-update-depth-attribution.ts
@@ -1,0 +1,40 @@
+/**
+ * React's nested-update counter is module-global and keyed on the root, not per fiber, so
+ * "Maximum update depth exceeded" (minified #185) throws on whichever fiber calls setState
+ * next after the counter trips. The catching boundary is a bystander picked by commit order.
+ */
+
+export const UNRELIABLE_BOUNDARY_ATTRIBUTION = 'unreliable'
+export type CrashReportAttribution = typeof UNRELIABLE_BOUNDARY_ATTRIBUTION
+
+export const CRASH_REPORT_ATTRIBUTION_DETAIL_KEY = 'attribution'
+export const CRASH_REPORT_ATTRIBUTION_NOTE_DETAIL_KEY = 'attribution_note'
+
+// Keep under the 240-char detail cap so the note is never truncated mid-sentence.
+export const UNRELIABLE_BOUNDARY_ATTRIBUTION_NOTE =
+  'React #185: the throw lands on whichever component called setState next after a root-global counter tripped, so boundary_id and component_stack name a bystander. Do not cluster these reports by boundary_id.'
+
+// #185 only: require a non-digit after 185 so #1850+ and #18 never match.
+const REACT_UPDATE_DEPTH_ERROR =
+  /Minified React error #185(?!\d)|errors\/185(?!\d)|invariant=185(?!\d)|Maximum update depth exceeded/
+
+function messageOf(error: unknown): string {
+  if (typeof error === 'string') {
+    return error
+  }
+  if (error instanceof Error) {
+    return error.message
+  }
+  if (error && typeof error === 'object' && typeof (error as Error).message === 'string') {
+    return (error as Error).message
+  }
+  return ''
+}
+
+export function getReactErrorBoundaryAttribution(
+  error: unknown
+): CrashReportAttribution | undefined {
+  return REACT_UPDATE_DEPTH_ERROR.test(messageOf(error))
+    ? UNRELIABLE_BOUNDARY_ATTRIBUTION
+    : undefined
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​294 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​294 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​91 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​90 |

<!-- /orca-pr-loc -->

## Description

**`boundary_id` and `component_stack` on a React #185 crash report name a bystander, not the component that is looping.** This PR stamps those reports so triage stops clustering on a field that cannot carry that meaning.

React 19.2.7's infinite-update detector is a **module-global counter**, not per-fiber state:

- `commitRootImpl` (`react-dom-client.development.js:18325-18332`) increments `nestedUpdateCount` when a commit leaves sync-ish lanes (`remainingLanes & 42`) pending on the **root** — and Orca has one root. Otherwise it resets to 0.
- `getRootForUpdatedFiber` (`:4619-4633`) throws *"Maximum update depth exceeded"* once the counter passes `NESTED_UPDATE_LIMIT` (50, `:27373`). That function runs on **every** `enqueueConcurrentHookUpdate` — i.e. on the next `setState` from *any* fiber anywhere in the tree.

So once one runaway commit-phase loop pushes the counter past 50, the throw is delivered to whichever fiber calls `setState` next, and is caught by *that* fiber's nearest boundary. All eight #185 reports in the 1.4.188 batch begin `getRootForUpdatedFiber → enqueueConcurrentHookUpdate → dispatchSetStateInternal → dispatchSetState`. **None of them shows the loop.**

This was demonstrated, not argued: a test that flips two sibling subtrees changes the reported `boundary_id` with nothing else about the bug changed.

### Why this matters

Triage has been clustering #185 by `boundary_id` for months. That produced the apparent "2 → 5 boundaries in 1.4.188" spread, which read as a regression — it isn't. Under a bystander model, going from ~2 samples to 8 predicts more distinct boundaries on its own, and no supporting code change was found (the boundary-id inventory, the victim components, and the `useLayoutEffect`/`flushSync` call-site count are all unchanged across the range).

It also means prior narrowing — "SortableTab's own fiber", "the TerminalPane fiber" — named bystanders.

## Fix evidence

Tests written first, implementation absent:

```
FAIL src/main/ipc/...-attribution.test.ts > stamps unreliable attribution plus a human-readable note
  AssertionError: expected undefined to be 'unreliable'
FAIL ... > surfaces the caveat in the formatted report text a human reads
  expected '[Crash Report]...' to contain 'Attribution: unreliable'
FAIL ... > stamps the minified production #185 digest as unreliable attribution
FAIL ... > stamps the development "Maximum update depth exceeded" message as unreliable
Test Files  4 failed (4)      Tests  5 failed | 6 passed (11)
```

**After** — 31 files / 282 tests passed across the error boundaries, `react-error-boundary-reporting`, `crash-reporting` (main + shared), and the crash-report UI. `tsc` clean on **both** `tsconfig.node.json` and `tsconfig.web.json`; `oxlint` zero warnings; `oxfmt --check` clean.

A #185 report now formats with the caveat **above** the Details block, so a Slack reader hits it first:

```
[Crash Report]
...
Attribution: unreliable
React #185: the throw lands on whichever component called setState next after a
root-global counter tripped, so boundary_id and component_stack name a bystander.
Do not cluster these reports by boundary_id.

Details:
- boundary_id: page.automations        <-- left intact for continuity
- attribution: unreliable
- attribution_note: React #185: the throw lands on ...
```

## ELI5

A factory has one alarm that counts how many times work bounced back in a row. When the count hits 50 the alarm fires — but it fires at *whoever touches a machine next*, not at the machine causing the bounces.

We've been reading the alarm log as "this machine is broken" and sending engineers to five different machines. Those five were just whoever happened to reach for a lever at the wrong moment.

This change doesn't find the broken machine. It stamps the log with "this name is whoever was standing nearby — don't dispatch on it," so nobody spends another month investigating bystanders.

## Trade-offs

- **This does not fix the loop.** The driver is still unidentified. This is a diagnosability change; the underlying #185 crashes continue until the driver is found.
- **`boundary_id` is deliberately left populated** rather than nulled, for continuity with historical reports and existing dashboards. A reader who ignores the new caveat can still be misled — mitigated by putting the caveat above the Details block.
- **Detection is by error identity, narrowly.** One regex matches `Minified React error #185`, `errors/185`, `invariant=185` (legacy decoder URL) and the dev text, with each numeric form guarded by `(?!\d)` so `#1850`/`#1852`/`#18` don't match and other React numbers (`#310`) never do. It reads the message off `Error` instances, bare strings, and any object with a string `message`, so a non-Error throwable still classifies.
- **Wire compatibility** (`docs/reference/remote-wire-compatibility.md`): new **optional** field only. `attribution?: 'unreliable'` on the renderer→main IPC args plus two optional detail keys. Nothing removed or repurposed; absent degrades exactly to today's behavior. The main normalizer emits `attribution` only when the value is literally `'unreliable'`, so a future renderer sending a different verdict degrades to *no* attribution rather than being trusted. The note text is **main-generated from a shared constant**, not trusted from the renderer, and goes through `sanitizeCrashReportDetails` under the 240-char cap so it can't be truncated mid-sentence.
- **No `max-lines` disable.** Adding the formatter inline pushed `crash-reporting.ts` to 314 counted lines (cap 300), so the caveat formatter was extracted to `crash-report-attribution-lines.ts`, mirroring the existing `crash-report-signature-lines.ts`.

## Adversarial review

**Clean after 2 loops.**

- **Loop 1 — 1 major, 2 minor.** *Major:* the stamp was applied in only one boundary class, so reports from the second reporting boundary were unstamped. **Fixed.**
- **Loop 2 — clean.** Three residual minors, deliberately left: `getRendererErrorReportKey` still keys dedupe on `boundaryId` (correct — dedupe should stay per-boundary even when attribution is unreliable); `formatSummary` still asserts a React-render summary; and main accepts the renderer's `attribution` without independent validation (bounded to the single literal `'unreliable'`, and the note is main-generated).

## Perf

`/perf`: **no meaningful impact, no changes applied.** One regex on an already-fatal error path.

## Follow-up

The corrected search space for the actual driver: it must leave sync-ish lanes pending on **every** commit — layout effects, ref callbacks, render-phase `setState`, **and** passive effects that write a `useSyncExternalStore`/zustand store (`forceStoreRerender` schedules at SyncLane, and `commitRootImpl` flushes passive effects synchronously *before* sampling `remainingLanes`). That last case matters here: zustand v5 is used in **95 renderer files**. Event/IPC-driven churn is excluded — each event's commit is its own settled turn.

Related: #15736 (draft) would name the store slice writing on every commit.
