### PR TITLE
draft(crash-reporting): stop Orca.exe faulting-module attribution implying native Orca faults

### DIFF
--- a/src/main/crash-reporting/minidump-crash-signature.test.ts
+++ b/src/main/crash-reporting/minidump-crash-signature.test.ts
@@ -89,6 +89,8 @@ function buildDump(options: {
   simpleAnnotations?: Record<string, string>
   exception?: { code: number; address: bigint }
   modules?: { base: bigint; size: number; name: string }[]
+  /** Module Crashpad registered Chromium's annotations against. */
+  annotatedModuleIndex?: number
 }): BuiltDump {
   const streamCount =
     1 + (options.exception ? 1 : 0) + (options.modules && options.modules.length > 0 ? 1 : 0)
@@ -141,7 +143,7 @@ function buildDump(options: {
 
   const moduleLinkBuf = Buffer.alloc(4 + 12)
   moduleLinkBuf.writeUInt32LE(1, 0)
-  moduleLinkBuf.writeUInt32LE(0, 4) // minidump module index
+  moduleLinkBuf.writeUInt32LE(options.annotatedModuleIndex ?? 0, 4) // minidump module index
   moduleLinkBuf.writeUInt32LE(moduleInfoBuf.length, 8)
   moduleLinkBuf.writeUInt32LE(moduleInfoRva, 12)
   const moduleLinkRva = builder.append(moduleLinkBuf)
@@ -340,6 +342,186 @@ describe('parseMinidumpCrashSignature', () => {
     expect(signature?.faultingModuleOffset).toBe('0x1234')
   })
 
+  it('marks a fault inside the main executable image as non-localizing', () => {
+    const { dump } = buildDump({
+      // 1.4.188: exception address in the Orca.exe band, image base 0x7ff775510000.
+      exception: { code: 0x80000003, address: 0x7ff7_7bfd_606an },
+      modules: [
+        {
+          base: 0x7ff7_7551_0000n,
+          size: 0x0c00_0000,
+          name: 'C:\\Program Files\\Orca\\Orca.exe'
+        },
+        {
+          base: 0x7ff8_0000_0000n,
+          size: 0x10_0000,
+          name: 'C:\\Windows\\System32\\KERNELBASE.dll'
+        }
+      ]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe('Orca.exe')
+    expect(signature?.faultingModuleOffset).toBe('0x6ac606a')
+    expect(signature?.faultingModuleKind).toBe('product-image')
+  })
+
+  it('keeps a separately loaded module as a localizing fault', () => {
+    const { dump } = buildDump({
+      exception: { code: 0xe06d_7363, address: 0x7ff8_0005_813cn },
+      modules: [
+        {
+          base: 0x7ff7_7551_0000n,
+          size: 0x0c00_0000,
+          name: 'C:\\Program Files\\Orca\\Orca.exe'
+        },
+        {
+          base: 0x7ff8_0000_0000n,
+          size: 0x10_0000,
+          name: 'C:\\Windows\\System32\\KERNELBASE.dll'
+        }
+      ]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe('KERNELBASE.dll')
+    expect(signature?.faultingModuleKind).toBe('loaded-module')
+  })
+
+  it('marks the macOS Electron Framework, not helper module 0, as non-localizing', () => {
+    // On macOS module 0 is the ~10 KiB helper stub; Chromium is in the framework.
+    const macModules = [
+      {
+        base: 0x1_0000_0000n,
+        size: 0x4000,
+        name: '/Applications/Orca.app/Contents/Frameworks/Orca Helper (Renderer).app/Contents/MacOS/Orca Helper (Renderer)'
+      },
+      {
+        base: 0x1_1000_0000n,
+        size: 0x0d00_0000,
+        name: '/Applications/Orca.app/Contents/Frameworks/Electron Framework.framework/Versions/A/Electron Framework'
+      }
+    ]
+
+    const framework = parseMinidumpCrashSignature(
+      buildDump({
+        exception: { code: 5, address: 0x1_13a1_b2c3n },
+        modules: macModules,
+        annotatedModuleIndex: 1
+      }).dump
+    )
+    const stub = parseMinidumpCrashSignature(
+      buildDump({
+        exception: { code: 5, address: 0x1_0000_0100n },
+        modules: macModules,
+        annotatedModuleIndex: 1
+      }).dump
+    )
+
+    expect(framework?.faultingModule).toBe('Electron Framework')
+    expect(framework?.faultingModuleKind).toBe('product-image')
+    expect(stub?.faultingModule).toBe('Orca Helper (Renderer)')
+    expect(stub?.faultingModuleKind).toBe('loaded-module')
+  })
+
+  it('marks the Linux main executable as non-localizing', () => {
+    const { dump } = buildDump({
+      exception: { code: 11, address: 0x5555_5666_7777n },
+      modules: [
+        { base: 0x5555_5555_5000n, size: 0x0c00_0000, name: '/opt/Orca/orca' },
+        { base: 0x7f00_0000_0000n, size: 0x20_0000, name: '/usr/lib/x86_64-linux-gnu/libc.so.6' }
+      ]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe('orca')
+    expect(signature?.faultingModuleKind).toBe('product-image')
+  })
+
+  it('keeps a large GPU driver localizing instead of calling it the product image', () => {
+    // Mesa's radeonsi_dri.so clears the Chromium-image size floor on its own.
+    const { dump } = buildDump({
+      exception: { code: 11, address: 0x7f2a_0123_4567n },
+      modules: [
+        { base: 0x5555_5555_5000n, size: 0x0c00_0000, name: '/opt/Orca/orca' },
+        {
+          base: 0x7f2a_0000_0000n,
+          size: 0x05a0_0000,
+          name: '/usr/lib/x86_64-linux-gnu/dri/radeonsi_dri.so'
+        }
+      ]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe('radeonsi_dri.so')
+    expect(signature?.faultingModuleKind).toBe('loaded-module')
+  })
+
+  it('keeps a large Windows display driver localizing', () => {
+    const { dump } = buildDump({
+      exception: { code: 0xc000_0005, address: 0x7ff8_0234_5678n },
+      modules: [
+        {
+          base: 0x7ff7_7551_0000n,
+          size: 0x0c00_0000,
+          name: 'C:\\Program Files\\Orca\\Orca.exe'
+        },
+        {
+          base: 0x7ff8_0000_0000n,
+          size: 0x0480_0000,
+          name: 'C:\\Windows\\System32\\DriverStore\\nvoglv64.dll'
+        }
+      ]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe('nvoglv64.dll')
+    expect(signature?.faultingModuleKind).toBe('loaded-module')
+  })
+
+  it('leaves the kind unknown when no Crashpad link names a module we read', () => {
+    // Non-Chromium/corrupt dumps: unqualified beats a size guess.
+    const { dump } = buildDump({
+      exception: { code: 11, address: 0x5555_5666_7777n },
+      modules: [{ base: 0x5555_5555_5000n, size: 0x0c00_0000, name: '/opt/Orca/orca' }],
+      annotatedModuleIndex: 7
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe('orca')
+    expect(signature?.faultingModuleKind).toBeUndefined()
+  })
+
+  it('leaves the kind unknown when the Crashpad info stream is missing', () => {
+    // Crashpad may still be writing the dump we polled; no link is not "loaded-module".
+    const { dump } = buildDump({
+      exception: { code: 0x80000003, address: 0x7ff7_7bfd_606an },
+      modules: [
+        {
+          base: 0x7ff7_7551_0000n,
+          size: 0x0c00_0000,
+          name: 'C:\\Program Files\\Orca\\Orca.exe'
+        }
+      ]
+    })
+    // Directory entry 0 is the Crashpad info stream; retype it so nothing finds it.
+    const withoutCrashpadInfo = Buffer.from(dump)
+    withoutCrashpadInfo.writeUInt32LE(0xffff, 32)
+
+    const signature = parseMinidumpCrashSignature(withoutCrashpadInfo)
+
+    expect(signature?.faultingModule).toBe('Orca.exe')
+    expect(signature?.faultingModuleOffset).toBe('0x6ac606a')
+    expect(signature?.faultingModuleKind).toBeUndefined()
+    expect(minidumpSignatureDetails(signature!).minidumpFaultingModuleKind).toBeUndefined()
+  })
+
   it('omits the faulting module when no image range covers the address', () => {
     const { dump } = buildDump({
       exception: { code: 11, address: 0x10n },
@@ -397,6 +579,7 @@ describe('minidumpSignatureDetails', () => {
       minidumpProcessType: 'renderer',
       minidumpExceptionCode: '0x80000003',
       minidumpFaultingModule: 'chrome_elf.dll',
+      minidumpFaultingModuleKind: 'loaded-module',
       minidumpAnnotation_channel: 'stable'
     })
   })

--- a/src/main/crash-reporting/minidump-crash-signature.ts
+++ b/src/main/crash-reporting/minidump-crash-signature.ts
@@ -12,7 +12,7 @@
 // reporting.
 
 import { findStream, isMinidump, MAX_MODULES, MinidumpView } from './minidump-stream-reader'
-import { readCrashpadAnnotations } from './minidump-crashpad-annotations'
+import { readCrashpadInfo } from './minidump-crashpad-annotations'
 
 const STREAM_TYPE_MODULE_LIST = 4
 const STREAM_TYPE_EXCEPTION = 6
@@ -54,6 +54,15 @@ export type MinidumpCrashSignature = {
   /** Module whose image range contains `exceptionAddress`. */
   readonly faultingModule?: string
   readonly faultingModuleOffset?: string
+  /**
+   * Whether `faultingModule` localizes the fault. Electron statically links
+   * Chromium, V8 and Blink into one image — the executable on Windows/Linux,
+   * `Electron Framework` on macOS — so a Chromium-side fault lands there and
+   * the name says nothing beyond "in-process"; a separately loaded module (a
+   * GPU driver, KERNELBASE.dll) does localize it. Absent when the dump carries
+   * no usable Crashpad module link, which is unknown rather than either kind.
+   */
+  readonly faultingModuleKind?: 'product-image' | 'loaded-module'
   /** Allowlisted Crashpad annotations, verbatim. */
   readonly annotations: Readonly<Record<string, string>>
 }
@@ -171,17 +180,63 @@ function parseCheckLocation(checkMessage: string): {
   return { file: match[1], line: Number.isFinite(line) ? line : undefined }
 }
 
+// Chromium + V8 + Blink linked into one image runs >150 MiB on every platform.
+const CHROMIUM_IMAGE_MIN_BYTES = 64 * 1024 * 1024
+
+/**
+ * Whether the image is the one Chromium is statically linked into.
+ *
+ * Crashpad already answers this per platform: it registers Chromium's
+ * annotations against the linked-in image (the executable on Windows/Linux,
+ * `Electron Framework` on macOS, never the ~10 KiB macOS helper stub), so the
+ * recorded module index is the answer and neither size nor index 0 is a guess.
+ * The size floor only rejects a small satellite module that also registers
+ * annotations; on its own it would swallow big GPU driver images, which are
+ * exactly the modules whose name does localize a fault.
+ */
+function isProductImage(
+  module: ModuleRecord,
+  index: number,
+  annotatedModuleIndices: ReadonlySet<number>
+): boolean {
+  return annotatedModuleIndices.has(index) && module.size >= CHROMIUM_IMAGE_MIN_BYTES
+}
+
+/**
+ * Whether Crashpad's module link can classify anything at all: a dump read
+ * before the Crashpad info stream landed, or one whose link names an index the
+ * module list does not contain, gives no reference point for the product
+ * image. Without it every module is unknown, not "separately loaded".
+ */
+function hasUsableModuleLink(
+  modules: ModuleRecord[],
+  annotatedModuleIndices: ReadonlySet<number>
+): boolean {
+  for (const index of annotatedModuleIndices) {
+    if (index < modules.length) {
+      return true
+    }
+  }
+  return false
+}
+
 function findFaultingModule(
   modules: ModuleRecord[],
-  address: bigint
-): { name: string; offset: string } | undefined {
-  for (const module of modules) {
-    if (address >= module.base && address < module.base + BigInt(module.size)) {
-      return {
-        name: moduleBasename(module.name),
-        offset: toHex(address - module.base)
-      }
+  address: bigint,
+  annotatedModuleIndices: ReadonlySet<number>
+): { name: string; offset: string; kind?: 'product-image' | 'loaded-module' } | undefined {
+  const classifiable = hasUsableModuleLink(modules, annotatedModuleIndices)
+  for (const [index, module] of modules.entries()) {
+    if (address < module.base || address >= module.base + BigInt(module.size)) {
+      continue
     }
+    let kind: 'product-image' | 'loaded-module' | undefined
+    if (classifiable) {
+      kind = isProductImage(module, index, annotatedModuleIndices)
+        ? 'product-image'
+        : 'loaded-module'
+    }
+    return { name: moduleBasename(module.name), offset: toHex(address - module.base), kind }
   }
   return undefined
 }
@@ -208,7 +263,7 @@ export function parseMinidumpCrashSignature(
     return null
   }
   const view = new MinidumpView(dump)
-  const annotations = readCrashpadAnnotations(view)
+  const { annotations, annotatedModuleIndices } = readCrashpadInfo(view)
 
   const signature: {
     -readonly [K in keyof MinidumpCrashSignature]: MinidumpCrashSignature[K]
@@ -246,10 +301,13 @@ export function parseMinidumpCrashSignature(
     }
     if (address !== null) {
       signature.exceptionAddress = toHex(address)
-      const faulting = findFaultingModule(readModules(view), address)
+      const faulting = findFaultingModule(readModules(view), address, annotatedModuleIndices)
       if (faulting) {
         signature.faultingModule = faulting.name
         signature.faultingModuleOffset = faulting.offset
+        if (faulting.kind) {
+          signature.faultingModuleKind = faulting.kind
+        }
       }
     }
   }
@@ -285,6 +343,9 @@ export function minidumpSignatureDetails(
   }
   if (signature.faultingModuleOffset) {
     details.minidumpFaultingModuleOffset = signature.faultingModuleOffset
+  }
+  if (signature.faultingModuleKind) {
+    details.minidumpFaultingModuleKind = signature.faultingModuleKind
   }
   for (const [key, value] of Object.entries(signature.annotations)) {
     if (key === 'LOG_FATAL' || key === 'abort-message' || key === 'ptype') {

--- a/src/main/crash-reporting/minidump-crashpad-annotations.ts
+++ b/src/main/crash-reporting/minidump-crashpad-annotations.ts
@@ -1,4 +1,5 @@
-// Reads Chromium's crash keys out of a Crashpad minidump's annotation streams.
+// Reads the MinidumpCrashpadInfo stream: Chromium's crash keys, plus which
+// minidump module Crashpad hung them on.
 //
 // Some Chromium builds expose the fatal log line as `LOG_FATAL`; the signature
 // parser also handles builds that carry it only in captured process memory.
@@ -134,11 +135,22 @@ function readAnnotationObjects(
   }
 }
 
-export function readCrashpadAnnotations(view: MinidumpView): Record<string, string> {
+export type CrashpadInfo = {
+  readonly annotations: Readonly<Record<string, string>>
+  /**
+   * MINIDUMP_MODULE_LIST indices Crashpad registered annotations against. In a
+   * Chromium process that is the image Chromium is linked into — the
+   * executable on Windows/Linux, `Electron Framework` on macOS.
+   */
+  readonly annotatedModuleIndices: ReadonlySet<number>
+}
+
+export function readCrashpadInfo(view: MinidumpView): CrashpadInfo {
   const annotations: Record<string, string> = {}
+  const annotatedModuleIndices = new Set<number>()
   const info = findStream(view, STREAM_TYPE_CRASHPAD_INFO)
   if (!info || info.size < CRASHPAD_INFO_MIN_SIZE) {
-    return annotations
+    return { annotations, annotatedModuleIndices }
   }
 
   readSimpleAnnotations(
@@ -149,17 +161,21 @@ export function readCrashpadAnnotations(view: MinidumpView): Record<string, stri
 
   const moduleList = view.location(info.rva + CRASHPAD_INFO_MODULE_LIST_OFFSET)
   if (!moduleList) {
-    return annotations
+    return { annotations, annotatedModuleIndices }
   }
   const moduleCount = view.u32(moduleList.rva)
   if (moduleCount === null || moduleCount > MAX_MODULES) {
-    return annotations
+    return { annotations, annotatedModuleIndices }
   }
   for (let index = 0; index < moduleCount; index += 1) {
     const link = moduleList.rva + 4 + index * MODULE_CRASHPAD_INFO_LINK_SIZE
+    const minidumpModuleIndex = view.u32(link)
     const moduleInfo = view.location(link + 4)
     if (!moduleInfo || moduleInfo.size < MODULE_CRASHPAD_INFO_MIN_SIZE) {
       continue
+    }
+    if (minidumpModuleIndex !== null && minidumpModuleIndex < MAX_MODULES) {
+      annotatedModuleIndices.add(minidumpModuleIndex)
     }
     // Why: Chromium's crash keys land in annotation_objects on current
     // Crashpad, but older modules still populate the two legacy shapes.
@@ -174,5 +190,5 @@ export function readCrashpadAnnotations(view: MinidumpView): Record<string, stri
       annotations
     )
   }
-  return annotations
+  return { annotations, annotatedModuleIndices }
 }

--- a/src/shared/crash-report-signature-lines.ts
+++ b/src/shared/crash-report-signature-lines.ts
@@ -1,5 +1,57 @@
 // Type-only, so this erases at compile time and creates no import cycle.
 import type { CrashReportDetailValue } from './crash-reporting'
+import { posixSignalName } from './posix-wait-status'
+
+/** Only the NTSTATUS codes that change how the rest of the report should be read. */
+const WINDOWS_EXCEPTION_CODE_NAMES: Record<string, string> = {
+  '0x80000003': 'STATUS_BREAKPOINT',
+  '0xc0000005': 'STATUS_ACCESS_VIOLATION',
+  '0xc0000006': 'STATUS_IN_PAGE_ERROR',
+  '0xc000001d': 'STATUS_ILLEGAL_INSTRUCTION',
+  '0xc0000094': 'STATUS_INTEGER_DIVIDE_BY_ZERO',
+  '0xc0000409': 'STATUS_STACK_BUFFER_OVERRUN',
+  '0xc00000fd': 'STATUS_STACK_OVERFLOW',
+  '0xe06d7363': 'C++ exception'
+}
+
+// <mach/exception_types.h>. Crashpad usually records EXC_CRASH for a fatal
+// signal, so the type names the delivery mechanism, not the faulting operation.
+const MACH_EXCEPTION_TYPE_NAMES: Record<number, string> = {
+  1: 'EXC_BAD_ACCESS',
+  2: 'EXC_BAD_INSTRUCTION',
+  3: 'EXC_ARITHMETIC',
+  4: 'EXC_EMULATION',
+  5: 'EXC_SOFTWARE',
+  6: 'EXC_BREAKPOINT',
+  7: 'EXC_SYSCALL',
+  8: 'EXC_MACH_SYSCALL',
+  9: 'EXC_RPC_ALERT',
+  10: 'EXC_CRASH',
+  11: 'EXC_RESOURCE',
+  12: 'EXC_GUARD',
+  13: 'EXC_CORPSE_NOTIFY'
+}
+
+/**
+ * Crashpad reuses one minidump field per platform: an NTSTATUS on Windows, the
+ * Mach exception type on macOS, the POSIX signal everywhere else. Naming it off
+ * the wrong table would be worse than the bare hex.
+ */
+function nameExceptionCode(code: string, platform: NodeJS.Platform): string | null {
+  if (platform === 'win32') {
+    return WINDOWS_EXCEPTION_CODE_NAMES[code.toLowerCase()] ?? null
+  }
+  const value = Number.parseInt(code, 16)
+  if (!Number.isInteger(value)) {
+    return null
+  }
+  return platform === 'darwin' ? (MACH_EXCEPTION_TYPE_NAMES[value] ?? null) : posixSignalName(value)
+}
+
+// Wording stays platform-neutral: the image is `Orca.exe` on Windows, `orca` on
+// Linux and `Electron Framework` on macOS.
+const PRODUCT_IMAGE_CAVEAT =
+  'Electron image with Chromium statically linked in, so the module name does not localize the fault; read the offset and exception code instead'
 
 /**
  * Promotes the Crashpad-derived fields out of the details blob.
@@ -10,14 +62,23 @@ import type { CrashReportDetailValue } from './crash-reporting'
  */
 export function appendMinidumpSignatureLines(
   lines: string[],
-  details: Record<string, CrashReportDetailValue>
+  details: Record<string, CrashReportDetailValue>,
+  platform: NodeJS.Platform
 ): void {
   if (typeof details.minidumpCheckMessage === 'string') {
     lines.push(`Check failure: ${details.minidumpCheckMessage}`)
   }
+  const exceptionCode = details.minidumpExceptionCode
+  if (typeof exceptionCode === 'string') {
+    const name = nameExceptionCode(exceptionCode, platform)
+    lines.push(`Exception: ${exceptionCode}${name ? ` (${name})` : ''}`)
+  }
   if (typeof details.minidumpFaultingModule === 'string') {
     const offset = details.minidumpFaultingModuleOffset
     const suffix = typeof offset === 'string' ? `+${offset}` : ''
-    lines.push(`Faulting module: ${details.minidumpFaultingModule}${suffix}`)
+    // Older hosts send no kind; leaving those lines unqualified beats guessing.
+    const caveat =
+      details.minidumpFaultingModuleKind === 'product-image' ? ` (${PRODUCT_IMAGE_CAVEAT})` : ''
+    lines.push(`Faulting module: ${details.minidumpFaultingModule}${suffix}${caveat}`)
   }
 }

--- a/src/shared/crash-reporting.test.ts
+++ b/src/shared/crash-reporting.test.ts
@@ -179,6 +179,117 @@ describe('crash-reporting shared helpers', () => {
     expect(text.indexOf('Check failure:')).toBeLessThan(text.indexOf('Details:'))
   })
 
+  it('does not present a fault inside the product executable as an Orca-code fault', () => {
+    // Verbatim shape of the 1.4.188 Windows report: STATUS_BREAKPOINT at an
+    // address inside Orca.exe, which statically links Chromium on Windows.
+    const report: CrashReportRecord = {
+      id: 'crash-exe-band',
+      createdAt: '2026-08-18T01:00:00.000Z',
+      status: 'pending',
+      source: 'renderer',
+      processType: 'renderer',
+      reason: 'crashed',
+      exitCode: -2147483645,
+      appVersion: '1.4.188',
+      platform: 'win32',
+      osRelease: '10.0.19045',
+      arch: 'x64',
+      electronVersion: '43.1.0',
+      chromeVersion: '150.0.7871.47',
+      details: {
+        minidumpExceptionCode: '0x80000003',
+        minidumpExceptionAddress: '0x7ff77bfd606a',
+        minidumpFaultingModule: 'Orca.exe',
+        minidumpFaultingModuleOffset: '0x6ac606a',
+        minidumpFaultingModuleKind: 'product-image'
+      },
+      breadcrumbs: []
+    }
+
+    const text = formatCrashReportText(report)
+
+    expect(text).toContain(
+      'Faulting module: Orca.exe+0x6ac606a (Electron image with Chromium statically linked in'
+    )
+    expect(text).toContain('does not localize the fault')
+    expect(text).toContain('Exception: 0x80000003 (STATUS_BREAKPOINT)')
+    expect(text.indexOf('Exception: 0x80000003')).toBeLessThan(text.indexOf('Details:'))
+  })
+
+  it('keeps a fault in a separately loaded module as a located fault', () => {
+    const report: CrashReportRecord = {
+      id: 'crash-kernelbase',
+      createdAt: '2026-08-18T01:00:00.000Z',
+      status: 'pending',
+      source: 'renderer',
+      processType: 'renderer',
+      reason: 'crashed',
+      exitCode: -529697949,
+      appVersion: '1.4.188',
+      platform: 'win32',
+      osRelease: '10.0.19045',
+      arch: 'x64',
+      electronVersion: '43.1.0',
+      chromeVersion: '150.0.7871.47',
+      details: {
+        minidumpExceptionCode: '0xe06d7363',
+        minidumpFaultingModule: 'KERNELBASE.dll',
+        minidumpFaultingModuleOffset: '0x5813c',
+        minidumpFaultingModuleKind: 'loaded-module'
+      },
+      breadcrumbs: []
+    }
+
+    const text = formatCrashReportText(report)
+
+    // KERNELBASE means a C++ exception / RaiseException passed through Win32:
+    // real localization, so it must not pick up the product-image caveat.
+    expect(text).toContain('Faulting module: KERNELBASE.dll+0x5813c\n')
+    expect(text).toContain('Exception: 0xe06d7363 (C++ exception)')
+  })
+
+  it('names the exception code off the platform table Crashpad wrote it from', () => {
+    const posixReport = (
+      platform: NodeJS.Platform,
+      exceptionCode: string,
+      faultingModule: string
+    ): CrashReportRecord => ({
+      id: 'crash-posix-exception',
+      createdAt: '2026-08-18T01:00:00.000Z',
+      status: 'pending',
+      source: 'renderer',
+      processType: 'renderer',
+      reason: 'crashed',
+      exitCode: 139,
+      appVersion: '1.4.188',
+      platform,
+      osRelease: '6.8.0',
+      arch: 'x64',
+      electronVersion: '43.1.0',
+      chromeVersion: '150.0.7871.47',
+      details: {
+        minidumpExceptionCode: exceptionCode,
+        minidumpFaultingModule: faultingModule,
+        minidumpFaultingModuleOffset: '0x11122777',
+        minidumpFaultingModuleKind: 'product-image'
+      },
+      breadcrumbs: []
+    })
+
+    // The caveat sends the triager to the exception code, so it must be named
+    // there too: a signal on linux, a Mach exception type on darwin.
+    expect(formatCrashReportText(posixReport('linux', '0xb', 'orca'))).toContain(
+      'Exception: 0xb (SIGSEGV)'
+    )
+    expect(formatCrashReportText(posixReport('darwin', '0xa', 'Electron Framework'))).toContain(
+      'Exception: 0xa (EXC_CRASH)'
+    )
+    // An NTSTATUS-shaped name must never be borrowed for a POSIX code.
+    expect(formatCrashReportText(posixReport('linux', '0x80000003', 'orca'))).toContain(
+      'Exception: 0x80000003\n'
+    )
+  })
+
   it('decodes POSIX wait statuses in the exit code line and leaves Windows codes raw', () => {
     const report = (overrides: Partial<CrashReportRecord>): CrashReportRecord => ({
       id: 'crash-wait-status',

--- a/src/shared/crash-reporting.ts
+++ b/src/shared/crash-reporting.ts
@@ -253,7 +253,7 @@ export function formatCrashReportText(
     `Chrome: ${report.chromeVersion}`
   ]
 
-  appendMinidumpSignatureLines(lines, report.details)
+  appendMinidumpSignatureLines(lines, report.details, report.platform)
   appendDiagnosticBundleLines(lines, diagnosticBundle, sanitizeCrashReportString)
 
   const details = Object.entries(report.details)

--- a/src/shared/posix-wait-status.ts
+++ b/src/shared/posix-wait-status.ts
@@ -23,6 +23,11 @@ const POSIX_INVARIANT_SIGNAL_NAMES: Record<number, string> = {
   15: 'SIGTERM'
 }
 
+/** Name for a signal number that means the same thing on Linux and macOS; null otherwise. */
+export function posixSignalName(signal: number): string | null {
+  return POSIX_INVARIANT_SIGNAL_NAMES[signal] ?? null
+}
+
 const WAIT_STATUS_SIGNAL_MASK = 0x7f
 const WAIT_STATUS_CORE_DUMP_FLAG = 0x80
 const WAIT_STATUS_STOPPED_MARKER = 0x7f
@@ -42,7 +47,7 @@ export function decodePosixWaitStatus(status: number): PosixWaitStatusDecode | n
   return {
     kind: 'signaled',
     signal,
-    signalName: POSIX_INVARIANT_SIGNAL_NAMES[signal] ?? null,
+    signalName: posixSignalName(signal),
     coreDumped: (status & WAIT_STATUS_CORE_DUMP_FLAG) !== 0
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​295 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​294 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​164 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​143 |

<!-- /orca-pr-loc -->

> **Draft — do not merge.** 4 adversarial review loops, did not converge. The underlying observation is solid and confirmed; the *classifier* built on top of it kept being wrong in a new way each loop. Opening so the finding isn't lost.

## The confirmed observation

Minidump capture (#14823) records a faulting module on Windows crash reports. One report in the 1.4.188 batch shows:

```
minidumpExceptionCode:        0x80000003   (STATUS_BREAKPOINT)
minidumpFaultingModule:       Orca.exe
minidumpFaultingModuleOffset: 0x6ac606a
minidumpExceptionAddress:     0x7ff77bfd606a   (implied image base 0x7ff775510000 — the exe band)
```

**"Orca.exe" reads like our native code crashed. It cannot mean that.** `findFaultingModule` (`minidump-crash-signature.ts:173-185`) returns whichever loaded module range contains the exception address, and on Windows **Electron statically links Chromium, V8 and Blink into the product executable**. So *any* Chromium-side fault is structurally guaranteed to be attributed to `Orca.exe` and carries zero Orca-specific signal.

A triager reading "faulting module: Orca.exe" reasonably concludes our native code faulted. The data does not support that.

`KERNELBASE.dll`, which also appears in this batch, is the opposite case — it usually indicates a C++ exception or `RaiseException` passing through Win32, which **is** informative and must not be flattened away.

## Why it is a draft

Every loop agreed the observation is right and the classifier is wrong. The classifier was rewritten three times and broke differently each time:

- **Loop 1:** the `product-image` heuristic keyed on `index === 0` plus "no shared-object extension" — misclassifies on any layout where the product image isn't first.
- **Loop 2:** rewritten to classify on **image size alone (≥ 64 MiB)** — so any large third-party module is misread as the product image. No test covered a non-product module above the floor.
- **Loop 3–4:** still unresolved, plus a new one: when Crashpad reports nothing at all, the code stamps `loaded-module` — **an affirmative claim derived from absence of data**. That is the same class of error as the `Orca.exe` problem this PR exists to fix, reintroduced one level up.

Also unresolved across loops: the new `Exception:` line applies **Win32 NTSTATUS naming to `minidumpExceptionCode` unconditionally**, which is wrong on non-Windows dumps; and `EXCEPTION_CODE_NAMES` plus that output line are a second diagnostic feature bundled into a presentation fix (scope creep).

## What is here

```
 src/main/crash-reporting/minidump-crash-signature.ts    |  83 ++++++--
 src/main/crash-reporting/minidump-crash-signature.test.ts | 185 +++++++++++++++-
 src/main/crash-reporting/minidump-crashpad-annotations.ts |  28 ++-
 src/shared/crash-report-signature-lines.ts              |  65 ++++++-
 src/shared/crash-reporting.test.ts                      | 111 +++++++++++
```

Tests green as written: **21 files / 230 tests**. `/perf`: no meaningful impact — added cost is off the hot and startup paths, bounded, non-retaining. The ordering constraint on `crash-breadcrumb-store.test.ts:26-49` (the 32-push ring-pressure fixture) was respected and still passes.

## Suggested path

Split it. The presentation fix is genuinely small and worth having on its own: when the exception address falls inside the product image's own range, say so explicitly — *"Electron statically links Chromium into the product binary, so this module name does not localize the fault"* — and surface the module-relative **offset** and **exception code**, which do carry signal.

Three things to get right that this attempt didn't:
1. Identify the product image by **actual identity** (module path / name match against the running executable), not by index or size.
2. Make the answer **three-state** — product image / separately loaded module / **unknown** — and never infer `loaded-module` from missing Crashpad data.
3. Drop the `Exception:` naming table from this change, or gate it on Windows dumps only.
