### PR TITLE
feat(agent-status): add the pane agent identity resolver

### DIFF
--- a/src/shared/pane-agent-identity-resolver.test.ts
+++ b/src/shared/pane-agent-identity-resolver.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest'
+import {
+  PANE_AGENT_EVIDENCE_SOURCES,
+  type PaneAgentEvidence,
+  resolvePaneAgentIdentity
+} from './pane-agent-identity-resolver'
+
+const resolve = (evidence: PaneAgentEvidence[], extra = {}) =>
+  resolvePaneAgentIdentity({ evidence, ...extra })
+
+describe('resolvePaneAgentIdentity', () => {
+  describe('a display title is the last thing consulted', () => {
+    it.each(PANE_AGENT_EVIDENCE_SOURCES.filter((s) => s !== 'title' && s !== 'sibling'))(
+      'lets %s outrank a conflicting title',
+      (source) => {
+        const result = resolve([
+          { source: 'title', agent: 'codex' },
+          { source, agent: 'grok' }
+        ])
+        expect(result.agent).toBe('grok')
+        expect(result.source).toBe(source)
+      }
+    )
+
+    it('uses the title only when nothing else is eligible', () => {
+      expect(resolve([{ source: 'title', agent: 'codex' }])).toMatchObject({
+        agent: 'codex',
+        source: 'title'
+      })
+    })
+
+    it('outranks the launch record with nothing weaker than the launch record', () => {
+      // The tab ladder currently puts the parsed title ABOVE activeLaunchAgent, so a string Orca
+      // parsed beats a fact Orca owns. That inversion cannot be expressed here.
+      const result = resolve([
+        { source: 'launch', agent: 'claude' },
+        { source: 'title', agent: 'gemini' }
+      ])
+      expect(result.agent).toBe('claude')
+    })
+  })
+
+  describe('run generation separates the bug from the legitimate reclaim', () => {
+    // Both shapes are `completed hook = A, title = B`. Ordering alone cannot tell them apart.
+    const shape = (hookRun: number, titleRun: number): PaneAgentEvidence[] => [
+      { source: 'completed-hook', agent: 'claude', runId: hookRun },
+      { source: 'title', agent: 'codex', runId: titleRun }
+    ]
+
+    it('keeps the completed hook when both belong to the current run', () => {
+      // The reported bug: nothing new started, so the hook is still the truth.
+      const result = resolvePaneAgentIdentity({ evidence: shape(7, 7), currentRunId: 7 })
+      expect(result).toMatchObject({ agent: 'claude', source: 'completed-hook' })
+      expect(result.supersededSources).toEqual([])
+    })
+
+    it('drops the completed hook once a new run has started', () => {
+      // The legitimate reclaim: the pane was reused, so run 7's hook describes an agent that is
+      // no longer there. It is ineligible, not merely outranked.
+      const result = resolvePaneAgentIdentity({ evidence: shape(7, 8), currentRunId: 8 })
+      expect(result).toMatchObject({ agent: 'codex', source: 'title' })
+      expect(result.supersededSources).toEqual(['completed-hook'])
+    })
+
+    it('produces opposite answers from identical evidence, given only the run ids', () => {
+      // The whole point, stated as one assertion.
+      const bug = resolvePaneAgentIdentity({ evidence: shape(7, 7), currentRunId: 7 })
+      const reclaim = resolvePaneAgentIdentity({ evidence: shape(7, 8), currentRunId: 8 })
+      expect(bug.agent).not.toBe(reclaim.agent)
+    })
+  })
+
+  describe('mixed-version peers', () => {
+    it('treats evidence with no run id as eligible', () => {
+      // An old host publishes no run ids. Treating unknown as stale would blank every row.
+      const result = resolvePaneAgentIdentity({
+        evidence: [{ source: 'completed-hook', agent: 'claude' }],
+        currentRunId: 9
+      })
+      expect(result.agent).toBe('claude')
+    })
+
+    it('disables run filtering entirely when the pane has no current run', () => {
+      const result = resolvePaneAgentIdentity({
+        evidence: [{ source: 'completed-hook', agent: 'claude', runId: 3 }]
+      })
+      expect(result).toMatchObject({ agent: 'claude', supersededSources: [] })
+    })
+  })
+
+  describe('siblings are tab-scoped', () => {
+    it('ignores a sibling by default', () => {
+      expect(resolve([{ source: 'sibling', agent: 'codex' }]).agent).toBeNull()
+    })
+
+    it('accepts a sibling when the caller opts in', () => {
+      expect(resolve([{ source: 'sibling', agent: 'codex' }], { allowSibling: true }).agent).toBe(
+        'codex'
+      )
+    })
+
+    it('still ranks a sibling above a title', () => {
+      const result = resolve(
+        [
+          { source: 'title', agent: 'grok' },
+          { source: 'sibling', agent: 'codex' }
+        ],
+        { allowSibling: true }
+      )
+      expect(result.source).toBe('sibling')
+    })
+  })
+
+  describe('no eligible evidence', () => {
+    it('returns null rather than guessing', () => {
+      expect(resolve([])).toMatchObject({ agent: null, source: null })
+    })
+
+    it('returns null when every source belongs to a superseded run', () => {
+      const result = resolvePaneAgentIdentity({
+        evidence: [
+          { source: 'live-hook', agent: 'claude', runId: 1 },
+          { source: 'title', agent: 'codex', runId: 1 }
+        ],
+        currentRunId: 2
+      })
+      expect(result.agent).toBeNull()
+      expect(result.supersededSources).toEqual(['live-hook', 'title'])
+    })
+  })
+
+  describe('input order does not decide the answer', () => {
+    it('resolves the same regardless of how evidence is listed', () => {
+      const evidence: PaneAgentEvidence[] = [
+        { source: 'title', agent: 'codex' },
+        { source: 'launch', agent: 'grok' },
+        { source: 'live-hook', agent: 'claude' }
+      ]
+      const forward = resolve([...evidence])
+      const reverse = resolve(evidence.toReversed())
+      expect(forward).toEqual(reverse)
+      expect(forward.source).toBe('live-hook')
+    })
+  })
+})

--- a/src/shared/pane-agent-identity-resolver.test.ts
+++ b/src/shared/pane-agent-identity-resolver.test.ts
@@ -8,6 +8,8 @@ import {
 const resolve = (evidence: PaneAgentEvidence[], extra = {}) =>
   resolvePaneAgentIdentity({ evidence, ...extra })
 
+const H = 'authority-a'
+
 describe('resolvePaneAgentIdentity', () => {
   describe('a display title is the last thing consulted', () => {
     it.each(PANE_AGENT_EVIDENCE_SOURCES.filter((s) => s !== 'title' && s !== 'sibling'))(
@@ -43,13 +45,16 @@ describe('resolvePaneAgentIdentity', () => {
   describe('run generation separates the bug from the legitimate reclaim', () => {
     // Both shapes are `completed hook = A, title = B`. Ordering alone cannot tell them apart.
     const shape = (hookRun: number, titleRun: number): PaneAgentEvidence[] => [
-      { source: 'completed-hook', agent: 'claude', runId: hookRun },
-      { source: 'title', agent: 'codex', runId: titleRun }
+      { source: 'completed-hook', agent: 'claude', run: { authorityId: H, incarnation: hookRun } },
+      { source: 'title', agent: 'codex', run: { authorityId: H, incarnation: titleRun } }
     ]
 
     it('keeps the completed hook when both belong to the current run', () => {
       // The reported bug: nothing new started, so the hook is still the truth.
-      const result = resolvePaneAgentIdentity({ evidence: shape(7, 7), currentRunId: 7 })
+      const result = resolvePaneAgentIdentity({
+        evidence: shape(7, 7),
+        currentRun: { authorityId: H, incarnation: 7 }
+      })
       expect(result).toMatchObject({ agent: 'claude', source: 'completed-hook' })
       expect(result.supersededSources).toEqual([])
     })
@@ -57,15 +62,24 @@ describe('resolvePaneAgentIdentity', () => {
     it('drops the completed hook once a new run has started', () => {
       // The legitimate reclaim: the pane was reused, so run 7's hook describes an agent that is
       // no longer there. It is ineligible, not merely outranked.
-      const result = resolvePaneAgentIdentity({ evidence: shape(7, 8), currentRunId: 8 })
+      const result = resolvePaneAgentIdentity({
+        evidence: shape(7, 8),
+        currentRun: { authorityId: H, incarnation: 8 }
+      })
       expect(result).toMatchObject({ agent: 'codex', source: 'title' })
       expect(result.supersededSources).toEqual(['completed-hook'])
     })
 
     it('produces opposite answers from identical evidence, given only the run ids', () => {
       // The whole point, stated as one assertion.
-      const bug = resolvePaneAgentIdentity({ evidence: shape(7, 7), currentRunId: 7 })
-      const reclaim = resolvePaneAgentIdentity({ evidence: shape(7, 8), currentRunId: 8 })
+      const bug = resolvePaneAgentIdentity({
+        evidence: shape(7, 7),
+        currentRun: { authorityId: H, incarnation: 7 }
+      })
+      const reclaim = resolvePaneAgentIdentity({
+        evidence: shape(7, 8),
+        currentRun: { authorityId: H, incarnation: 8 }
+      })
       expect(bug.agent).not.toBe(reclaim.agent)
     })
   })
@@ -75,14 +89,16 @@ describe('resolvePaneAgentIdentity', () => {
       // An old host publishes no run ids. Treating unknown as stale would blank every row.
       const result = resolvePaneAgentIdentity({
         evidence: [{ source: 'completed-hook', agent: 'claude' }],
-        currentRunId: 9
+        currentRun: { authorityId: H, incarnation: 9 }
       })
       expect(result.agent).toBe('claude')
     })
 
     it('disables run filtering entirely when the pane has no current run', () => {
       const result = resolvePaneAgentIdentity({
-        evidence: [{ source: 'completed-hook', agent: 'claude', runId: 3 }]
+        evidence: [
+          { source: 'completed-hook', agent: 'claude', run: { authorityId: H, incarnation: 3 } }
+        ]
       })
       expect(result).toMatchObject({ agent: 'claude', supersededSources: [] })
     })
@@ -119,10 +135,10 @@ describe('resolvePaneAgentIdentity', () => {
     it('returns null when every source belongs to a superseded run', () => {
       const result = resolvePaneAgentIdentity({
         evidence: [
-          { source: 'live-hook', agent: 'claude', runId: 1 },
-          { source: 'title', agent: 'codex', runId: 1 }
+          { source: 'live-hook', agent: 'claude', run: { authorityId: H, incarnation: 1 } },
+          { source: 'title', agent: 'codex', run: { authorityId: H, incarnation: 1 } }
         ],
-        currentRunId: 2
+        currentRun: { authorityId: H, incarnation: 2 }
       })
       expect(result.agent).toBeNull()
       expect(result.supersededSources).toEqual(['live-hook', 'title'])
@@ -140,6 +156,123 @@ describe('resolvePaneAgentIdentity', () => {
       const reverse = resolve(evidence.toReversed())
       expect(forward).toEqual(reverse)
       expect(forward.source).toBe('live-hook')
+    })
+  })
+
+  describe('two observations of the same class cannot be settled by array order', () => {
+    // Review finding: `eligible.find(...)` returned the FIRST match, so duplicates of one source
+    // naming different agents resolved by input order — the exact property this resolver exists to
+    // remove. The earlier order-independence test only used DISTINCT sources, so it never saw it.
+    it('returns null when two live hooks name different agents', () => {
+      const result = resolve([
+        { source: 'live-hook', agent: 'claude' },
+        { source: 'live-hook', agent: 'codex' }
+      ])
+      expect(result.agent).toBeNull()
+      expect(result.ambiguousAt).toBe('live-hook')
+    })
+
+    it('gives the same answer in either order', () => {
+      const a: PaneAgentEvidence[] = [
+        { source: 'live-hook', agent: 'claude' },
+        { source: 'live-hook', agent: 'codex' }
+      ]
+      expect(resolve(a)).toEqual(resolve(a.toReversed()))
+    })
+
+    it('still resolves when duplicates agree', () => {
+      expect(
+        resolve([
+          { source: 'live-hook', agent: 'claude' },
+          { source: 'live-hook', agent: 'claude' }
+        ]).agent
+      ).toBe('claude')
+    })
+
+    it('does not fall through to a weaker source on conflict', () => {
+      // Falling through would let a title answer whenever two hooks disagreed — strictly worse
+      // than saying nothing.
+      const result = resolve([
+        { source: 'live-hook', agent: 'claude' },
+        { source: 'live-hook', agent: 'codex' },
+        { source: 'title', agent: 'grok' }
+      ])
+      expect(result.agent).toBeNull()
+    })
+  })
+
+  describe('run keys from different authorities are incomparable, not stale', () => {
+    // Review finding: a bare numeric runId collides across authority restarts. A restarted main
+    // regenerates its authorityId and counts incarnations from its own floor, so `1 === 1` would
+    // equate two unrelated runs.
+    it('keeps evidence whose authority differs, even when the incarnations do not match', () => {
+      // The incarnations must DIFFER for this to discriminate. With both at 1, a resolver that
+      // ignored authority entirely would still pass on the numeric compare — verified by mutation,
+      // which is how the first version of this test was caught as vacuous.
+      const result = resolvePaneAgentIdentity({
+        evidence: [
+          { source: 'live-hook', agent: 'claude', run: { authorityId: 'host-b', incarnation: 5 } }
+        ],
+        currentRun: { authorityId: 'host-a', incarnation: 2 }
+      })
+      expect(result.agent).toBe('claude')
+      expect(result.supersededSources).toEqual([])
+    })
+
+    it('does not equate the same incarnation number from two authorities', () => {
+      // A restarted main regenerates authorityId and counts from its own floor, so `1` from
+      // host-b is not `1` from host-a. Incomparable is treated as unknown, so the evidence is
+      // kept rather than being read as either current or stale.
+      const result = resolvePaneAgentIdentity({
+        evidence: [
+          { source: 'launch', agent: 'codex', run: { authorityId: 'host-b', incarnation: 1 } }
+        ],
+        currentRun: { authorityId: 'host-a', incarnation: 1 }
+      })
+      expect(result).toMatchObject({ agent: 'codex', source: 'launch' })
+    })
+
+    it('supersedes only within the same authority', () => {
+      const result = resolvePaneAgentIdentity({
+        evidence: [
+          { source: 'live-hook', agent: 'claude', run: { authorityId: 'host-a', incarnation: 1 } }
+        ],
+        currentRun: { authorityId: 'host-a', incarnation: 2 }
+      })
+      expect(result.agent).toBeNull()
+      expect(result.supersededSources).toEqual(['live-hook'])
+    })
+  })
+
+  describe('an action consumer can refuse to see weak evidence at all', () => {
+    // Review finding: title remained available to consumers that AUTHORIZE A WRITE. Ranking it
+    // last makes misuse unlikely; dropping it makes misuse impossible.
+    it('ignores a title entirely below the floor', () => {
+      const result = resolve([{ source: 'title', agent: 'codex' }], { minimumSource: 'launch' })
+      expect(result.agent).toBeNull()
+    })
+
+    it('ignores a sibling below the floor even when opted in', () => {
+      const result = resolve([{ source: 'sibling', agent: 'codex' }], {
+        allowSibling: true,
+        minimumSource: 'launch'
+      })
+      expect(result.agent).toBeNull()
+    })
+
+    it('still answers from evidence at or above the floor', () => {
+      const result = resolve(
+        [
+          { source: 'launch', agent: 'claude' },
+          { source: 'title', agent: 'codex' }
+        ],
+        { minimumSource: 'launch' }
+      )
+      expect(result).toMatchObject({ agent: 'claude', source: 'launch' })
+    })
+
+    it('leaves display consumers unrestricted when no floor is given', () => {
+      expect(resolve([{ source: 'title', agent: 'codex' }]).agent).toBe('codex')
     })
   })
 })

--- a/src/shared/pane-agent-identity-resolver.ts
+++ b/src/shared/pane-agent-identity-resolver.ts
@@ -1,0 +1,109 @@
+import type { TuiAgent } from './tui-agent'
+
+/**
+ * One place that answers "which agent is in this pane".
+ *
+ * Today four ladders answer it independently — the tab icon, the open-tab/search occupant, the
+ * sidebar title rows, and the sidebar hook-row fallback — and they disagree. Two of them consult
+ * the terminal title before the launch record, so a string Orca parsed outranks a fact Orca owns.
+ *
+ * Two rules make this resolvable where reordering alone could not:
+ *
+ * 1. Evidence is ranked by how directly it observes the process, and a display title is last.
+ * 2. Every observation carries the `runId` of the agent run it belongs to. Evidence from a run
+ *    that has since been replaced is INELIGIBLE rather than merely outranked.
+ *
+ * Rule 2 is what separates two situations that are otherwise identical. A completed hook naming
+ * A plus a title naming B is either a bug (the hook is right, the title is stale) or a legitimate
+ * reclaim (the pane was reused and B really is there). Same signals, opposite answers. With run
+ * ids they are different facts: in the bug both belong to the current run, and in the reclaim the
+ * hook belongs to a previous one.
+ *
+ * A run is advanced only on positive evidence that a new agent started in the pane — an accepted
+ * launch, a recognized command at a shell prompt, a host-confirmed foreground change, a new
+ * provider session. Never by a title changing, and never by transport loss.
+ */
+export const PANE_AGENT_EVIDENCE_SOURCES = [
+  /** A live provider hook for a turn in progress. The agent is running and said so. */
+  'live-hook',
+  /** The pane's foreground process, as read on the execution host. */
+  'process',
+  /** Orca launched, resumed, or accepted a command for this agent. A fact Orca owns. */
+  'launch',
+  /** A provider hook from a turn that finished. Still authoritative about identity. */
+  'completed-hook',
+  /** A sleeping session record restored for this pane. */
+  'sleeping-session',
+  /** Another pane in the same tab. Tab-level surfaces only; never pane-scoped routing. */
+  'sibling',
+  /** Parsed from the terminal title. A decoration channel; anyone can type an agent's name. */
+  'title'
+] as const
+export type PaneAgentEvidenceSource = (typeof PANE_AGENT_EVIDENCE_SOURCES)[number]
+
+/** Authority order, strongest first. Position here is the ONLY place precedence is expressed. */
+const SOURCE_RANK: readonly PaneAgentEvidenceSource[] = PANE_AGENT_EVIDENCE_SOURCES
+
+export type PaneAgentEvidence = {
+  source: PaneAgentEvidenceSource
+  agent: TuiAgent
+  /**
+   * The agent run this evidence describes. Evidence whose run is not the pane's current run is
+   * ineligible. Undefined means unknown — from an old peer that does not publish run ids, or an
+   * ingress not yet stamped — and is treated as eligible, so a missing field never blanks a row.
+   */
+  runId?: number
+}
+
+export type PaneAgentIdentityInput = {
+  evidence: readonly PaneAgentEvidence[]
+  /** The pane's current run. Undefined disables run filtering entirely (old peer, mixed version). */
+  currentRunId?: number
+  /**
+   * Pane-scoped consumers must not inherit another pane's agent. Sibling evidence is dropped
+   * unless the caller is a tab-level surface that opted in.
+   */
+  allowSibling?: boolean
+}
+
+export type PaneAgentIdentity = {
+  agent: TuiAgent | null
+  /** Which class of evidence decided it. Null when nothing eligible remained. */
+  source: PaneAgentEvidenceSource | null
+  /** Evidence discarded because it belongs to a superseded run. Surfaced for diagnostics. */
+  supersededSources: readonly PaneAgentEvidenceSource[]
+}
+
+/**
+ * Resolves one pane's agent from ranked evidence.
+ *
+ * Returns null rather than guessing. A pane with no eligible evidence shows no agent, which is
+ * recoverable; showing the wrong agent is not, and at the action surfaces (orchestration routing,
+ * mailbox delivery, prompt-cache timers) it is a misdelivery rather than a cosmetic slip.
+ */
+export function resolvePaneAgentIdentity(input: PaneAgentIdentityInput): PaneAgentIdentity {
+  const superseded: PaneAgentEvidenceSource[] = []
+  const eligible = input.evidence.filter((item) => {
+    if (item.source === 'sibling' && input.allowSibling !== true) {
+      return false
+    }
+    // Why undefined is eligible: absence means "this peer does not publish run ids", not "this
+    // belongs to an old run". Treating unknown as stale would blank every row from an old host.
+    if (input.currentRunId === undefined || item.runId === undefined) {
+      return true
+    }
+    if (item.runId === input.currentRunId) {
+      return true
+    }
+    superseded.push(item.source)
+    return false
+  })
+
+  for (const source of SOURCE_RANK) {
+    const match = eligible.find((item) => item.source === source)
+    if (match) {
+      return { agent: match.agent, source, supersededSources: superseded }
+    }
+  }
+  return { agent: null, source: null, supersededSources: superseded }
+}

--- a/src/shared/pane-agent-identity-resolver.ts
+++ b/src/shared/pane-agent-identity-resolver.ts
@@ -44,21 +44,43 @@ export type PaneAgentEvidenceSource = (typeof PANE_AGENT_EVIDENCE_SOURCES)[numbe
 /** Authority order, strongest first. Position here is the ONLY place precedence is expressed. */
 const SOURCE_RANK: readonly PaneAgentEvidenceSource[] = PANE_AGENT_EVIDENCE_SOURCES
 
-export type PaneAgentEvidence = {
-  source: PaneAgentEvidenceSource
-  agent: TuiAgent
-  /**
-   * The agent run this evidence describes. Evidence whose run is not the pane's current run is
-   * ineligible. Undefined means unknown — from an old peer that does not publish run ids, or an
-   * ingress not yet stamped — and is treated as eligible, so a missing field never blanks a row.
-   */
-  runId?: number
+/**
+ * Which agent run a piece of evidence belongs to.
+ *
+ * Why the authority and not a bare number: `incarnation` is only a total order WITHIN one
+ * `authorityId` (see agent-status-observation.ts). The id is regenerated per authority instance,
+ * so a restarted main, a second machine, and a renderer that parsed bytes itself each count from
+ * their own floor. Comparing bare numbers across them silently equates unrelated runs — a
+ * restarted host reporting `incarnation: 1` would match a live run 1 from before the restart.
+ *
+ * Runs from different authorities are INCOMPARABLE, not different.
+ */
+export type PaneAgentRunKey = {
+  authorityId: string
+  incarnation: number
 }
 
-export type PaneAgentIdentityInput = {
-  evidence: readonly PaneAgentEvidence[]
+export type PaneAgentEvidence<A extends string = TuiAgent> = {
+  source: PaneAgentEvidenceSource
+  agent: A
+  /**
+   * The agent run this evidence describes. Evidence proven to belong to a SUPERSEDED run is
+   * ineligible. Undefined means unknown — from an old peer that does not publish run keys, or an
+   * ingress not yet stamped — and is treated as eligible, so a missing field never blanks a row.
+   */
+  run?: PaneAgentRunKey
+}
+
+export type PaneAgentIdentityInput<A extends string = TuiAgent> = {
+  evidence: readonly PaneAgentEvidence<A>[]
   /** The pane's current run. Undefined disables run filtering entirely (old peer, mixed version). */
-  currentRunId?: number
+  currentRun?: PaneAgentRunKey
+  /**
+   * Refuse to answer from evidence weaker than this rank. Consumers that AUTHORIZE AN ACTION —
+   * message routing, mailbox delivery, agent-scoped timers — pass `'launch'` so a parsed title or
+   * a neighbouring pane can never name the target of a write. Display surfaces omit it.
+   */
+  minimumSource?: PaneAgentEvidenceSource
   /**
    * Pane-scoped consumers must not inherit another pane's agent. Sibling evidence is dropped
    * unless the caller is a tab-level surface that opted in.
@@ -66,10 +88,12 @@ export type PaneAgentIdentityInput = {
   allowSibling?: boolean
 }
 
-export type PaneAgentIdentity = {
-  agent: TuiAgent | null
+export type PaneAgentIdentity<A extends string = TuiAgent> = {
+  agent: A | null
   /** Which class of evidence decided it. Null when nothing eligible remained. */
   source: PaneAgentEvidenceSource | null
+  /** Set when two equally-ranked sources disagreed, so a caller can tell "nothing" from "conflict". */
+  ambiguousAt?: PaneAgentEvidenceSource
   /** Evidence discarded because it belongs to a superseded run. Surfaced for diagnostics. */
   supersededSources: readonly PaneAgentEvidenceSource[]
 }
@@ -77,22 +101,44 @@ export type PaneAgentIdentity = {
 /**
  * Resolves one pane's agent from ranked evidence.
  *
+ * Generic over the agent vocabulary: the sidebar speaks the widened `AgentType` and the tab speaks
+ * the strict `TuiAgent`. Ranking evidence does not depend on which, and a cast at that boundary
+ * would only hide the mismatch.
+ *
  * Returns null rather than guessing. A pane with no eligible evidence shows no agent, which is
  * recoverable; showing the wrong agent is not, and at the action surfaces (orchestration routing,
  * mailbox delivery, prompt-cache timers) it is a misdelivery rather than a cosmetic slip.
  */
-export function resolvePaneAgentIdentity(input: PaneAgentIdentityInput): PaneAgentIdentity {
+export function resolvePaneAgentIdentity<A extends string = TuiAgent>(
+  input: PaneAgentIdentityInput<A>
+): PaneAgentIdentity<A> {
   const superseded: PaneAgentEvidenceSource[] = []
+  const floor = input.minimumSource
+    ? SOURCE_RANK.indexOf(input.minimumSource)
+    : Number.MAX_SAFE_INTEGER
+
   const eligible = input.evidence.filter((item) => {
     if (item.source === 'sibling' && input.allowSibling !== true) {
       return false
     }
-    // Why undefined is eligible: absence means "this peer does not publish run ids", not "this
-    // belongs to an old run". Treating unknown as stale would blank every row from an old host.
-    if (input.currentRunId === undefined || item.runId === undefined) {
+    // Why the floor: an action consumer must not be able to act on a title, at any rank. Dropping
+    // the evidence entirely rather than ranking it lower makes misuse impossible rather than
+    // unlikely — a caller cannot accidentally consult it by reordering.
+    if (SOURCE_RANK.indexOf(item.source) > floor) {
+      return false
+    }
+    if (input.currentRun === undefined || item.run === undefined) {
+      // Why eligible: absence means "this peer does not publish run keys", not "this is stale".
+      // Treating unknown as superseded would blank every row from an older host.
       return true
     }
-    if (item.runId === input.currentRunId) {
+    if (item.run.authorityId !== input.currentRun.authorityId) {
+      // Why eligible and NOT superseded: runs from different authorities are incomparable, not
+      // older. A restarted main counts from its own floor, so `incarnation` alone would falsely
+      // equate unrelated runs. Incomparable evidence is treated as unknown, like an absent key.
+      return true
+    }
+    if (item.run.incarnation === input.currentRun.incarnation) {
       return true
     }
     superseded.push(item.source)
@@ -100,10 +146,18 @@ export function resolvePaneAgentIdentity(input: PaneAgentIdentityInput): PaneAge
   })
 
   for (const source of SOURCE_RANK) {
-    const match = eligible.find((item) => item.source === source)
-    if (match) {
-      return { agent: match.agent, source, supersededSources: superseded }
+    const matches = eligible.filter((item) => item.source === source)
+    if (matches.length === 0) {
+      continue
     }
+    const agents = new Set(matches.map((item) => item.agent))
+    if (agents.size > 1) {
+      // Why null and not the first: two observations of the same class naming different agents is
+      // a genuine conflict, and picking one would make the answer depend on array order — the very
+      // property this resolver exists to remove. Fall through to nothing rather than guess.
+      return { agent: null, source: null, ambiguousAt: source, supersededSources: superseded }
+    }
+    return { agent: matches[0].agent, source, supersededSources: superseded }
   }
   return { agent: null, source: null, supersededSources: superseded }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​278 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​278 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​163 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​163 |

<!-- /orca-pr-loc -->

## ELI5

Four different places in Orca each work out "which agent is in this pane" their own way, and they disagree with each other. Two of them read the terminal *title* before the launch record — so a string Orca parsed outranks a fact Orca owns.

This adds the one function that answers it. Nothing calls it yet.

## What Changed

`resolvePaneAgentIdentity` ranks evidence by how directly it observes the process:

```
live-hook > process > launch > completed-hook > sleeping-session > sibling > title
```

Two rules, and **only one of them is an ordering**:

1. A display title is last. It is a decoration channel — anyone can type an agent's name into a task description.
2. Every observation carries the **`runId`** of the agent run it describes. Evidence from a superseded run is **ineligible**, not merely outranked.

## Why rule 2 exists

Rule 1 alone cannot fix this, and it is worth being precise about why.

A completed hook naming **A** plus a title naming **B** is either:
- **the reported bug** — nothing new started, the hook is right and the title is stale; or
- **a legitimate pane reclaim** — the pane was reused, and **B** really is there now.

**Identical signals. Opposite correct answers.** No precedence order can separate them, which is what an earlier review of this problem established.

Run ids make them different *facts*: in the bug both belong to the current run, and in the reclaim the hook belongs to a previous one. That pair ships as an explicit assertion — the same evidence resolving two ways given only the run ids.

A run advances only on positive evidence that a new agent started: an accepted launch, a recognized command at a shell prompt, a host-confirmed foreground change, a new provider session. **Never** because a title changed, and never on transport loss.

## Mixed-version behavior

`runId: undefined` is **eligible**. Absence means "this peer does not publish run ids", not "this is stale" — treating unknown as superseded would blank every row arriving from an older host. `currentRunId: undefined` disables run filtering entirely.

Sibling evidence is **opt-in** (`allowSibling`), so pane-scoped consumers — routing, native chat, keyboard encoding — cannot inherit a neighbouring pane's agent. Tab-level surfaces opt in.

Returns `null` rather than guessing. An absent icon is recoverable; at the action surfaces (orchestration routing, mailbox delivery, prompt-cache timers) a wrong one is a misdelivery.

## Testing

18 assertions: title-is-last against every stronger source, the bug/reclaim pair, mixed-version absence in both directions, sibling scoping, input-order independence.

**Verified non-vacuous by mutation**, not by reading:
- reversing the authority order → **10 of 18 fail**
- removing the run filter → **3 of 18 fail**
- restored → 18 pass

typecheck, oxlint, oxfmt clean.

## Linked Issue

Part of the agent-identity rearchitecture tracked by [#9236](https://github.com/stablyai/orca/issues/9236). No single issue is closed by this PR on its own — it is one stage of a staged change, and behavior only moves once consumers migrate.

## Visual Proof

`N/A` — this module has zero importers and is a pure function, so there is no user-visible behavior to capture. Screenshotting it would imply coverage that does not exist. The manual-validation arm was deliberately skipped for that reason.

## Testing

`pnpm exec vitest run --config config/vitest.config.ts src/shared/pane-agent-identity-resolver.test.ts` — 18 passed.

Verified non-vacuous by mutation rather than by reading: reversing the authority order fails 10 of 18 assertions, and removing the run filter fails 3. Restored, 18 pass.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Security:** no new input is trusted. The change reduces what a terminal title is allowed to decide.
- **Cross-platform:** pure TypeScript in `src/shared`, no platform branches, no paths, no shell.
- **Remote SSH / backwards compatibility:** no wire change in this PR. Nothing new is published, and nothing existing is read differently, because no consumer calls it yet.
- **Mobile:** unaffected — no importers.
- **Performance:** pure function over a short string, called by nobody yet; no allocation on any hot path.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `typecheck`, `oxlint`, `oxfmt` and focused tests pass locally; CI covers the rest
