### PR TITLE
docs(cli): document worktree rm branch cleanup

### DIFF
--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -548,7 +548,7 @@ export function formatFlagHelp(flag: string): string {
     title: '--title <text>         Custom title for the terminal tab (omit to reset)',
     enter: '--enter                Append Enter after sending text',
     force:
-      '--force                Force worktree removal when supported; see notes on branch deletion',
+      '--force                Force worktree removal when supported; does not force branch deletion',
     focus: '--focus                Reveal the created terminal session in Orca',
     for: '--for exit|tui-idle    Wait condition to satisfy',
     'from-element-index': '--from-element-index <n> Source element index from get-app-state',

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -547,7 +547,8 @@ export function formatFlagHelp(flag: string): string {
     'element-index': '--element-index <n>   Element index from get-app-state',
     title: '--title <text>         Custom title for the terminal tab (omit to reset)',
     enter: '--enter                Append Enter after sending text',
-    force: '--force                Force worktree removal when supported',
+    force:
+      '--force                Force worktree removal when supported; see notes on branch deletion',
     focus: '--focus                Reveal the created terminal session in Orca',
     for: '--for exit|tui-idle    Wait condition to satisfy',
     'from-element-index': '--from-element-index <n> Source element index from get-app-state',

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -170,7 +170,10 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     summary: 'Remove a worktree from Orca and git',
     usage: 'orca worktree rm --worktree <selector> [--force] [--run-hooks] [--json]',
     allowedFlags: [...GLOBAL_FLAGS, 'worktree', 'force', 'run-hooks'],
-    notes: ['Repo-defined orca.yaml archive hooks are skipped unless --run-hooks is passed.']
+    notes: [
+      'Repo-defined orca.yaml archive hooks are skipped unless --run-hooks is passed.',
+      'Removal also deletes the branch Orca created for this worktree once it is fully merged, with or without --force. A branch with unmerged commits, or one you checked out rather than had Orca create, is left alone.'
+    ]
   },
   {
     path: ['worktree', 'ps'],

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -172,7 +172,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     allowedFlags: [...GLOBAL_FLAGS, 'worktree', 'force', 'run-hooks'],
     notes: [
       'Repo-defined orca.yaml archive hooks are skipped unless --run-hooks is passed.',
-      'Removal also deletes the branch Orca created for this worktree once it is fully merged, with or without --force. A branch with unmerged commits, or one you checked out rather than had Orca create, is left alone.'
+      'For Git worktrees, removal also attempts to delete the checked-out local branch, with or without --force. Orca retains branches it knows predated the worktree and any branch whose changes it cannot prove are already merged.'
     ]
   },
   {


### PR DESCRIPTION
## ELI5

`orca worktree rm` removes a Git worktree and may also remove its checked-out local branch. `--force` only changes whether worktree removal may proceed; it does not make branch deletion more aggressive. This PR documents that existing behavior.

## What Changed

- Clarified that `--force` does not force branch deletion.
- Added `worktree rm` notes covering branch cleanup for Git worktrees.
- Clarified when Orca preserves a branch.

## Verified Behavior

- Local and SSH removal attempt branch cleanup independently of `--force`.
- Folder workspaces do not run Git branch cleanup.
- Branches Orca knows predated the worktree are retained.
- Otherwise, Orca first requests Git safe deletion. If Git refuses, Orca can still delete through an expected-head-guarded ref update after proving the branch changes are already present on a cleanup target, including squash-merge cases.
- If Orca cannot prove the changes are merged, it retains the branch and reports it as preserved.

## Linked Issue

Fixes #16088

## Testing

- CLI suite: 900/900 pass after rerunning two load-sensitive timeout cases in isolation.
- Branch cleanup and removal routing: 26/26 focused tests pass.
- CLI typecheck passes.
- Formatting and staged-file lint checks pass.

## Visual Proof

N/A — CLI help text only.

## AI Disclosure

AI assisted with tracing local, SSH/relay, imported-worktree, and folder-workspace behavior and drafting the documentation. The final wording and behavior were reviewed before merge.

## Agent skill upstream boundary

- [x] Not applicable — this is a CLI help-text change.