### PR TITLE
perf(renderer): incrementally index terminal tab owners

### DIFF
--- a/src/renderer/src/store/slices/terminal-tab-owner-index.test.ts
+++ b/src/renderer/src/store/slices/terminal-tab-owner-index.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest'
+import { createTerminalTabOwnerIndex } from './terminal-tab-owner-index'
+
+function trackedTab(id: string, onRead: () => void): { id: string } {
+  return Object.defineProperty({}, 'id', {
+    configurable: true,
+    enumerable: true,
+    get() {
+      onRead()
+      return id
+    }
+  }) as { id: string }
+}
+
+describe('terminal tab owner index', () => {
+  it('updates added, removed, and moved buckets without inspecting an unchanged bucket', () => {
+    const reads = { stable: 0, moving: 0, added: 0, removed: 0 }
+    const stableBucket = [
+      trackedTab('stable-tab', () => {
+        reads.stable += 1
+      })
+    ]
+    const sourceBucket = [
+      trackedTab('moving-tab', () => {
+        reads.moving += 1
+      })
+    ]
+    const removedBucket = [
+      trackedTab('removed-tab', () => {
+        reads.removed += 1
+      })
+    ]
+    const index = createTerminalTabOwnerIndex()
+
+    index.getOwners({ stable: stableBucket, source: sourceBucket, removed: removedBucket })
+    reads.stable = 0
+    reads.moving = 0
+    reads.added = 0
+    reads.removed = 0
+
+    const owners = index.getOwners({
+      stable: stableBucket,
+      source: [],
+      destination: [
+        trackedTab('moving-tab', () => {
+          reads.moving += 1
+        })
+      ],
+      added: [
+        trackedTab('added-tab', () => {
+          reads.added += 1
+        })
+      ]
+    })
+
+    expect(owners.get('stable-tab')).toBe('stable')
+    expect(owners.get('moving-tab')).toBe('destination')
+    expect(owners.get('added-tab')).toBe('added')
+    expect(owners.has('removed-tab')).toBe(false)
+    expect(reads).toEqual({ stable: 0, moving: 1, added: 1, removed: 0 })
+  })
+
+  it('adopts a warm metadata-only replacement without fleet visits or owner-map allocation', () => {
+    let outerKeyVisits = 0
+    let bucketVisits = 0
+    const observeOuterMap = <T extends Record<string, readonly { id: string }[]>>(value: T): T =>
+      new Proxy(value, {
+        ownKeys(target) {
+          outerKeyVisits += 1
+          return Reflect.ownKeys(target)
+        },
+        get(target, property, receiver) {
+          if (typeof property === 'string' && property.startsWith('wt-')) {
+            bucketVisits += 1
+          }
+          return Reflect.get(target, property, receiver)
+        }
+      })
+    const initial = observeOuterMap(
+      Object.fromEntries(
+        Array.from({ length: 300 }, (_, index) => [
+          `wt-${index}`,
+          [{ id: `tab-${index}`, title: 'Initial title' }]
+        ])
+      )
+    )
+    const index = createTerminalTabOwnerIndex()
+    const owners = index.getOwners(initial)
+    const next = observeOuterMap({
+      ...initial,
+      'wt-299': [{ id: 'tab-299', title: 'Changed title' }]
+    })
+    index.adoptMetadataOnlyBucketReplacements(initial, next, ['wt-299'])
+    outerKeyVisits = 0
+    bucketVisits = 0
+
+    const warmOwners = index.getOwners(next)
+
+    expect(warmOwners).toBe(owners)
+    expect(warmOwners.get('tab-299')).toBe('wt-299')
+    expect(outerKeyVisits).toBe(0)
+    expect(bucketVisits).toBe(0)
+  })
+
+  it('replaces the topology on hydration across every workspace key kind', () => {
+    const index = createTerminalTabOwnerIndex()
+    index.getOwners({ stale: [{ id: 'stale-tab' }] })
+
+    const hydrated = {
+      'repo-local::/Users/me/project': [{ id: 'local-tab' }],
+      'folder:folder-workspace-id': [{ id: 'folder-tab' }],
+      'repo-ssh::/srv/project': [{ id: 'ssh-tab' }],
+      'repo-wsl::\\\\wsl.localhost\\Ubuntu\\home\\me\\project': [{ id: 'wsl-tab' }],
+      'worktree:repo-runtime::/workspace::workspace:paired-runtime-id': [
+        { id: 'paired-runtime-tab' }
+      ]
+    }
+    const owners = index.getOwners(hydrated)
+
+    expect(Object.fromEntries(owners)).toEqual({
+      'local-tab': 'repo-local::/Users/me/project',
+      'folder-tab': 'folder:folder-workspace-id',
+      'ssh-tab': 'repo-ssh::/srv/project',
+      'wsl-tab': 'repo-wsl::\\\\wsl.localhost\\Ubuntu\\home\\me\\project',
+      'paired-runtime-tab': 'worktree:repo-runtime::/workspace::workspace:paired-runtime-id'
+    })
+    expect(owners.has('stale-tab')).toBe(false)
+  })
+
+  it('preserves last-wins object order for duplicate ids when only outer keys reorder', () => {
+    let idReads = 0
+    const firstBucket = [
+      trackedTab('duplicate-tab', () => {
+        idReads += 1
+      }),
+      trackedTab('duplicate-tab', () => {
+        idReads += 1
+      })
+    ]
+    const secondBucket = [
+      trackedTab('duplicate-tab', () => {
+        idReads += 1
+      })
+    ]
+    const index = createTerminalTabOwnerIndex()
+
+    expect(index.getOwner({ first: firstBucket, second: secondBucket }, 'duplicate-tab')).toBe(
+      'second'
+    )
+    idReads = 0
+
+    expect(index.getOwner({ second: secondBucket, first: firstBucket }, 'duplicate-tab')).toBe(
+      'first'
+    )
+    expect(idReads).toBe(0)
+  })
+})

--- a/src/renderer/src/store/slices/terminal-tab-owner-index.ts
+++ b/src/renderer/src/store/slices/terminal-tab-owner-index.ts
@@ -1,0 +1,185 @@
+type TerminalTabOwnerBuckets = Readonly<Record<string, readonly { id: string }[]>>
+
+type IndexedBucket = {
+  source: readonly { id: string }[]
+  tabIds: ReadonlySet<string>
+}
+
+export type TerminalTabOwnerIndex = {
+  getOwners(tabsByWorktree: TerminalTabOwnerBuckets): ReadonlyMap<string, string>
+  getOwner(tabsByWorktree: TerminalTabOwnerBuckets, tabId: string): string | null
+  adoptMetadataOnlyBucketReplacements(
+    previousTabsByWorktree: TerminalTabOwnerBuckets,
+    nextTabsByWorktree: TerminalTabOwnerBuckets,
+    replacedWorktreeIds: Iterable<string>
+  ): void
+}
+
+export function createTerminalTabOwnerIndex(): TerminalTabOwnerIndex {
+  let source: TerminalTabOwnerBuckets | null = null
+  let orderedKeys: string[] = []
+  const bucketByWorktreeId = new Map<string, IndexedBucket>()
+  const worktreeIdsByTabId = new Map<string, Set<string>>()
+  const ownerByTabId = new Map<string, string>()
+
+  const removeBucketMembership = (worktreeId: string, tabIds: ReadonlySet<string>): void => {
+    for (const tabId of tabIds) {
+      const worktreeIds = worktreeIdsByTabId.get(tabId)
+      if (!worktreeIds) {
+        continue
+      }
+      worktreeIds.delete(worktreeId)
+      if (worktreeIds.size === 0) {
+        worktreeIdsByTabId.delete(tabId)
+      }
+    }
+  }
+
+  const addBucketMembership = (worktreeId: string, tabIds: ReadonlySet<string>): void => {
+    for (const tabId of tabIds) {
+      const worktreeIds = worktreeIdsByTabId.get(tabId)
+      if (worktreeIds) {
+        worktreeIds.add(worktreeId)
+      } else {
+        worktreeIdsByTabId.set(tabId, new Set([worktreeId]))
+      }
+    }
+  }
+
+  const update = (tabsByWorktree: TerminalTabOwnerBuckets): ReadonlyMap<string, string> => {
+    if (source === tabsByWorktree) {
+      return ownerByTabId
+    }
+
+    const nextOrderedKeys = Object.keys(tabsByWorktree)
+    const orderChanged =
+      orderedKeys.length !== nextOrderedKeys.length ||
+      orderedKeys.some((key, index) => key !== nextOrderedKeys[index])
+    const nextKeySet = new Set(nextOrderedKeys)
+    const affectedTabIds = new Set<string>()
+
+    for (const [worktreeId, indexed] of bucketByWorktreeId) {
+      if (nextKeySet.has(worktreeId)) {
+        continue
+      }
+      for (const tabId of indexed.tabIds) {
+        affectedTabIds.add(tabId)
+      }
+      removeBucketMembership(worktreeId, indexed.tabIds)
+      bucketByWorktreeId.delete(worktreeId)
+    }
+
+    for (const worktreeId of nextOrderedKeys) {
+      const tabs = tabsByWorktree[worktreeId] ?? []
+      const indexed = bucketByWorktreeId.get(worktreeId)
+      if (indexed?.source === tabs) {
+        continue
+      }
+
+      if (indexed) {
+        for (const tabId of indexed.tabIds) {
+          affectedTabIds.add(tabId)
+        }
+        removeBucketMembership(worktreeId, indexed.tabIds)
+      }
+
+      // Why: tab arrays are the immutable topology buckets. Reading ids only for a
+      // replaced bucket keeps a one-worktree title update independent of fleet size.
+      const tabIds = new Set(tabs.map((tab) => tab.id))
+      for (const tabId of tabIds) {
+        affectedTabIds.add(tabId)
+      }
+      bucketByWorktreeId.set(worktreeId, { source: tabs, tabIds })
+      addBucketMembership(worktreeId, tabIds)
+    }
+
+    const orderByWorktreeId = new Map(
+      nextOrderedKeys.map((worktreeId, index) => [worktreeId, index] as const)
+    )
+    const tabIdsToResolve = orderChanged ? worktreeIdsByTabId.keys() : affectedTabIds
+    for (const tabId of tabIdsToResolve) {
+      const worktreeIds = worktreeIdsByTabId.get(tabId)
+      let owner: string | null = null
+      let ownerOrder = -1
+      for (const worktreeId of worktreeIds ?? []) {
+        const order = orderByWorktreeId.get(worktreeId)
+        if (order !== undefined && order > ownerOrder) {
+          owner = worktreeId
+          ownerOrder = order
+        }
+      }
+      if (owner === null) {
+        ownerByTabId.delete(tabId)
+      } else {
+        ownerByTabId.set(tabId, owner)
+      }
+    }
+    for (const tabId of affectedTabIds) {
+      if (!worktreeIdsByTabId.has(tabId)) {
+        ownerByTabId.delete(tabId)
+      }
+    }
+
+    source = tabsByWorktree
+    orderedKeys = nextOrderedKeys
+    return ownerByTabId
+  }
+
+  const adoptMetadataOnlyBucketReplacements = (
+    previousTabsByWorktree: TerminalTabOwnerBuckets,
+    nextTabsByWorktree: TerminalTabOwnerBuckets,
+    replacedWorktreeIds: Iterable<string>
+  ): void => {
+    if (source !== previousTabsByWorktree) {
+      return
+    }
+    for (const worktreeId of replacedWorktreeIds) {
+      const indexed = bucketByWorktreeId.get(worktreeId)
+      const previousTabs = previousTabsByWorktree[worktreeId]
+      const nextTabs = nextTabsByWorktree[worktreeId]
+      if (!indexed || indexed.source !== previousTabs || !nextTabs) {
+        // Why: this fast path is valid only for title-only bucket replacements.
+        // Falling back to the normal diff keeps an unexpected caller mismatch correct.
+        source = null
+        return
+      }
+      indexed.source = nextTabs
+    }
+    // Why: title writes preserve ids and outer key order, so ownership is unchanged.
+    // Adopting the exact produced map keeps the next hot lookup O(1).
+    source = nextTabsByWorktree
+  }
+
+  return {
+    getOwners: update,
+    getOwner: (tabsByWorktree, tabId) => update(tabsByWorktree).get(tabId) ?? null,
+    adoptMetadataOnlyBucketReplacements
+  }
+}
+
+const sharedTerminalTabOwnerIndex = createTerminalTabOwnerIndex()
+
+export function getTerminalTabOwners(
+  tabsByWorktree: TerminalTabOwnerBuckets
+): ReadonlyMap<string, string> {
+  return sharedTerminalTabOwnerIndex.getOwners(tabsByWorktree)
+}
+
+export function getTerminalTabOwnerWorktreeId(
+  tabsByWorktree: TerminalTabOwnerBuckets,
+  tabId: string
+): string | null {
+  return sharedTerminalTabOwnerIndex.getOwner(tabsByWorktree, tabId)
+}
+
+export function adoptTerminalTabOwnerMetadataOnlyBuckets(
+  previousTabsByWorktree: TerminalTabOwnerBuckets,
+  nextTabsByWorktree: TerminalTabOwnerBuckets,
+  replacedWorktreeIds: Iterable<string>
+): void {
+  sharedTerminalTabOwnerIndex.adoptMetadataOnlyBucketReplacements(
+    previousTabsByWorktree,
+    nextTabsByWorktree,
+    replacedWorktreeIds
+  )
+}

--- a/src/renderer/src/store/slices/terminal-tab-title-batch.test.ts
+++ b/src/renderer/src/store/slices/terminal-tab-title-batch.test.ts
@@ -24,6 +24,7 @@ import {
   seedStore
 } from './store-test-helpers'
 import type { GeneratedTabTitleUpdate } from './terminal-tab-title-batch'
+import { adoptTerminalTabOwnerMetadataOnlyBuckets } from './terminal-tab-owner-index'
 
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'
 
@@ -98,6 +99,64 @@ describe('terminal tab title batches', () => {
         `Remote agent ${index}`
       )
     }
+  })
+
+  it('inspects only the changed bucket for a warm title change across 300 worktrees', () => {
+    const store = createTestStore()
+    const fixture = makeScaleState(300)
+    seedStore(store, {
+      worktreesByRepo: { repo1: fixture.worktrees },
+      tabsByWorktree: fixture.tabsByWorktree,
+      unifiedTabsByWorktree: fixture.unifiedTabsByWorktree
+    })
+    store.getState().updateTabTitle('tab-299', 'First warm title')
+
+    const idReadsByWorktree = Array.from({ length: 300 }, () => 0)
+    for (let index = 0; index < 300; index += 1) {
+      const tab = store.getState().tabsByWorktree[`wt-${index}`]?.[0]
+      if (!tab) {
+        throw new Error(`missing scale tab ${index}`)
+      }
+      const id = tab.id
+      Object.defineProperty(tab, 'id', {
+        configurable: true,
+        enumerable: true,
+        get() {
+          idReadsByWorktree[index] += 1
+          return id
+        }
+      })
+    }
+
+    let outerKeyVisits = 0
+    let bucketVisits = 0
+    const currentTabsByWorktree = store.getState().tabsByWorktree
+    const observedTabsByWorktree = new Proxy(currentTabsByWorktree, {
+      ownKeys(target) {
+        outerKeyVisits += 1
+        return Reflect.ownKeys(target)
+      },
+      get(target, property, receiver) {
+        if (typeof property === 'string' && property.startsWith('wt-')) {
+          bucketVisits += 1
+        }
+        return Reflect.get(target, property, receiver)
+      }
+    })
+    adoptTerminalTabOwnerMetadataOnlyBuckets(currentTabsByWorktree, observedTabsByWorktree, [])
+    store.setState({ tabsByWorktree: observedTabsByWorktree })
+    outerKeyVisits = 0
+    bucketVisits = 0
+
+    store.getState().updateTabTitle('tab-299', 'Second warm title')
+
+    expect(idReadsByWorktree[299]).toBeGreaterThan(0)
+    expect(idReadsByWorktree.slice(0, 299).reduce((sum, count) => sum + count, 0)).toBe(0)
+    expect(outerKeyVisits).toBe(1)
+    // The unavoidable outer-map copy reads 300 buckets; staging and cache adoption
+    // read the changed owner twice. A second fleet traversal would add 300 more.
+    expect(bucketVisits).toBe(302)
+    expect(store.getState().tabsByWorktree['wt-299']?.[0]?.title).toBe('Second warm title')
   })
 
   it('preserves ordered duplicate updates and last-owner duplicate-id routing', () => {

--- a/src/renderer/src/store/slices/terminal-tab-title-batch.ts
+++ b/src/renderer/src/store/slices/terminal-tab-title-batch.ts
@@ -4,6 +4,10 @@ import { parseLegacyNumericPaneKey, parsePaneKey } from '../../../../shared/stab
 import type { Tab } from '../../../../shared/tab-types'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 import type { AppState } from '../types'
+import {
+  adoptTerminalTabOwnerMetadataOnlyBuckets,
+  getTerminalTabOwners
+} from './terminal-tab-owner-index'
 
 export type TerminalTabTitleUpdate = { tabId: string; title: string }
 
@@ -46,16 +50,6 @@ function getFallbackTabTitle(tab: TerminalTab): string {
 
 function getTabIdFromPaneKey(paneKey: string): string | null {
   return parsePaneKey(paneKey)?.tabId ?? parseLegacyNumericPaneKey(paneKey)?.tabId ?? null
-}
-
-function buildOwnerIndex(tabsByWorktree: TitleState['tabsByWorktree']): Map<string, string> {
-  const ownerByTabId = new Map<string, string>()
-  for (const [worktreeId, tabs] of Object.entries(tabsByWorktree)) {
-    for (const tab of tabs) {
-      ownerByTabId.set(tab.id, worktreeId)
-    }
-  }
-  return ownerByTabId
 }
 
 function getOwnerStage(
@@ -157,14 +151,21 @@ function finishTitleStages(
   if (sortEpochIncrement > 0) {
     patch.sortEpoch = state.sortEpoch + sortEpochIncrement
   }
+  if (patch.tabsByWorktree) {
+    adoptTerminalTabOwnerMetadataOnlyBuckets(
+      state.tabsByWorktree,
+      patch.tabsByWorktree,
+      stages.keys()
+    )
+  }
   return { patch, runtimeGraphChanged: tabsChanged }
 }
 
 export function applyTerminalTabTitleUpdates(
   state: TitleState,
-  updates: readonly TerminalTabTitleUpdate[],
-  ownerByTabId = buildOwnerIndex(state.tabsByWorktree)
+  updates: readonly TerminalTabTitleUpdate[]
 ): TitleUpdateResult {
+  const ownerByTabId = getTerminalTabOwners(state.tabsByWorktree)
   const stages = new Map<string, OwnerStage>()
   let sortEpochIncrement = 0
   for (const { tabId, title } of updates) {
@@ -204,9 +205,9 @@ export function applyTerminalTabTitleUpdates(
 
 export function applyGeneratedTabTitleUpdates(
   state: TitleState,
-  updates: readonly GeneratedTabTitleUpdate[],
-  ownerByTabId = buildOwnerIndex(state.tabsByWorktree)
+  updates: readonly GeneratedTabTitleUpdate[]
 ): TitleUpdateResult {
+  const ownerByTabId = getTerminalTabOwners(state.tabsByWorktree)
   if (state.settings?.tabAutoGenerateTitle !== true) {
     return { patch: null, runtimeGraphChanged: false }
   }

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -73,6 +73,10 @@ import {
   type TerminalTabTitleUpdate
 } from './terminal-tab-title-batch'
 import {
+  adoptTerminalTabOwnerMetadataOnlyBuckets,
+  getTerminalTabOwnerWorktreeId
+} from './terminal-tab-owner-index'
+import {
   dedupeTabOrder,
   ensureGroup,
   findTabByEntityInGroup,
@@ -307,26 +311,6 @@ function buildRuntimeSessionPlaceholders({
     nextWorktreesByRepo[parsed.repoId] = [...current, placeholder]
   }
   return { repos: nextRepos, worktreesByRepo: nextWorktreesByRepo }
-}
-
-let terminalTabOwnerCacheSource: Record<string, TerminalTab[]> | null = null
-let terminalTabOwnerCache = new Map<string, string>()
-
-function getTerminalTabOwnerWorktreeId(
-  tabsByWorktree: Record<string, TerminalTab[]>,
-  tabId: string
-): string | null {
-  if (terminalTabOwnerCacheSource !== tabsByWorktree) {
-    const nextCache = new Map<string, string>()
-    for (const [worktreeId, tabs] of Object.entries(tabsByWorktree)) {
-      for (const tab of tabs) {
-        nextCache.set(tab.id, worktreeId)
-      }
-    }
-    terminalTabOwnerCacheSource = tabsByWorktree
-    terminalTabOwnerCache = nextCache
-  }
-  return terminalTabOwnerCache.get(tabId) ?? null
 }
 
 function getTabIdFromPaneKey(paneKey: string): string | null {
@@ -1954,11 +1938,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
 
   updateTabTitle: (tabId, title) => {
     set((state) => {
-      const ownerWorktreeId = getTerminalTabOwnerWorktreeId(state.tabsByWorktree, tabId)
-      const ownerByTabId = ownerWorktreeId
-        ? new Map([[tabId, ownerWorktreeId]])
-        : new Map<string, string>()
-      const result = applyTerminalTabTitleUpdates(state, [{ tabId, title }], ownerByTabId)
+      const result = applyTerminalTabTitleUpdates(state, [{ tabId, title }])
       if (result.runtimeGraphChanged) {
         scheduleRuntimeGraphSync()
       }
@@ -1995,13 +1975,17 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
         return s
       }
       const ownerTabs = tabs.map((tab) => (tab.id === tabId ? { ...tab, aiVaultTitle } : tab))
+      const nextTabsByWorktree = { ...s.tabsByWorktree, [ownerWorktreeId]: ownerTabs }
       const unifiedTabs = s.unifiedTabsByWorktree[ownerWorktreeId] ?? []
       const nextUnifiedTabs = unifiedTabs.map((tab) =>
         tab.contentType === 'terminal' && tab.entityId === tabId ? { ...tab, aiVaultTitle } : tab
       )
+      adoptTerminalTabOwnerMetadataOnlyBuckets(s.tabsByWorktree, nextTabsByWorktree, [
+        ownerWorktreeId
+      ])
       scheduleRuntimeGraphSync()
       return {
-        tabsByWorktree: { ...s.tabsByWorktree, [ownerWorktreeId]: ownerTabs },
+        tabsByWorktree: nextTabsByWorktree,
         unifiedTabsByWorktree: {
           ...s.unifiedTabsByWorktree,
           [ownerWorktreeId]: nextUnifiedTabs
@@ -2031,11 +2015,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
       return
     }
     set((latestState) => {
-      const result = applyGeneratedTabTitleUpdates(
-        latestState,
-        [{ paneKey, prompt, options }],
-        new Map([[tabId, ownerWorktreeId]])
-      )
+      const result = applyGeneratedTabTitleUpdates(latestState, [{ paneKey, prompt, options }])
       if (result.runtimeGraphChanged) {
         scheduleRuntimeGraphSync()
       }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​216 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​216 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​211 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​45 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​166 |

<!-- /orca-pr-loc -->

## Problem / Why

Terminal title writes replace the outer `tabsByWorktree` object. The prior owner cache treated every replacement as a topology change and rebuilt tab ownership by scanning every workspace bucket, so one title update scaled with the entire workspace fleet. The first follow-up implementation reused unchanged arrays but still enumerated every outer key and allocated fleet-sized diff structures on the warm path; review-until-clean caught that remaining O(W) work.

## What this fixes

- Adds a shared incremental terminal-tab owner topology index.
- Updates only changed, added, and removed tab-array buckets for real topology changes.
- Lets live, generated, batched, and AI Vault title writes explicitly adopt metadata-only bucket replacements, making the next owner lookup an O(1) identity check with no outer-key traversal or owner-map allocation.
- Preserves last-wins object-order behavior for duplicate tab IDs, including outer-key-only reorder.
- Treats local, folder, SSH, WSL, and paired-runtime workspace keys as opaque identities.
- Covers add, remove, move, hydrate, reorder, duplicate IDs, and mixed workspace key kinds.

## ELI5

The app keeps a phone book that says which workspace owns each terminal tab. Renaming one terminal used to make it reread every workspace page. Now it swaps that workspace's page and tells the phone book the page changed, so the next lookup returns immediately. Real tab moves still update the phone book, and duplicate IDs still belong to whichever workspace appears last.

## Proof / no regression

- Focused Vitest: **2 files, 10 tests passed**.
- `pnpm typecheck:web`: passed.
- Deterministic 300-worktree warm-title proof:
  - zero ID reads from 299 unchanged buckets;
  - one unavoidable outer-map enumeration and 302 bucket gets for the state copy/staging/adoption path;
  - the rejected extra fleet index pass would produce two enumerations and 602 gets;
  - direct warm owner lookup records zero outer-key visits, zero bucket visits, and returns the same owner `Map` identity (no owner-map allocation).
- Commit hooks passed `oxlint`, React Doctor oxlint, and `oxfmt`.
- Review-until-clean finding fixed: warm display-only replacements no longer execute `Object.keys`, allocate Set/order maps, or iterate cached workspaces in the owner index.

## User tradeoffs

- The renderer keeps a resident index bounded by current workspace buckets and tab IDs.
- Real topology changes remain O(W) to detect outer-key add/remove/reorder and preserve duplicate ordering.
- Display-only title changes avoid topology work. Otherwise there is zero behavior tradeoff: title routing, duplicate precedence, hydration, workspace identity, and sorting behavior remain unchanged.

## Readiness verdict

**CLEAN — P0: 0, P1: 0, P2: 0.**

- **Function / backward compatibility:** existing title and duplicate-owner semantics preserved; hydrate and mixed-version persisted shapes remain accepted.
- **Performance:** warm title lookup is O(1); deterministic fleet counters defend against regression.
- **SSH / cross-platform:** SSH, WSL, local, folder, and paired-runtime keys are never parsed or normalized by the index.
- **Crash / security:** renderer-only in-memory derived state; no IPC, persistence, filesystem, process, credential, or trust-boundary changes.
- **Mobile:** no mobile-facing surface or protocol change.

## Residual risk

The optimization relies on the store's existing immutable-update contract: a real topology change must replace the affected worktree's tab-array reference. In-place mutation was already invisible to the previous outer-map identity cache. Alternating independent store instances can cause a safe full reindex, but production has one renderer store; correctness is preserved.