### PR TITLE
perf(renderer): gate runtime store projections

### DIFF
--- a/src/renderer/src/components/terminal-pane/paired-runtime-parking-capabilities.ts
+++ b/src/renderer/src/components/terminal-pane/paired-runtime-parking-capabilities.ts
@@ -1,0 +1,57 @@
+import { TERMINAL_PAIRED_PARKING_RUNTIME_CAPABILITY } from '../../../../shared/protocol-version'
+
+type PairedRuntimeParkingCapabilityStatuses = ReadonlyMap<
+  string,
+  { status: { capabilities?: readonly string[] } | null | undefined }
+>
+
+type PairedRuntimeParkingEnvironmentIdsCache = {
+  statuses: PairedRuntimeParkingCapabilityStatuses
+  environmentIds: ReadonlySet<string>
+}
+
+let pairedRuntimeParkingEnvironmentIdsCache: PairedRuntimeParkingEnvironmentIdsCache | null = null
+
+function haveSameEnvironmentIds(left: ReadonlySet<string>, right: ReadonlySet<string>): boolean {
+  if (left.size !== right.size) {
+    return false
+  }
+  for (const environmentId of left) {
+    if (!right.has(environmentId)) {
+      return false
+    }
+  }
+  return true
+}
+
+export function selectPairedRuntimeParkingEnvironmentIds(
+  statuses: PairedRuntimeParkingCapabilityStatuses
+): ReadonlySet<string> {
+  const cached = pairedRuntimeParkingEnvironmentIdsCache
+  if (cached?.statuses === statuses) {
+    return cached.environmentIds
+  }
+
+  const capable = new Set<string>()
+  for (const [environmentId, entry] of statuses) {
+    if (entry.status?.capabilities?.includes(TERMINAL_PAIRED_PARKING_RUNTIME_CAPABILITY)) {
+      capable.add(environmentId)
+    }
+  }
+  const environmentIds =
+    cached && haveSameEnvironmentIds(cached.environmentIds, capable)
+      ? cached.environmentIds
+      : capable
+  pairedRuntimeParkingEnvironmentIdsCache = { statuses, environmentIds }
+  return environmentIds
+}
+
+export function selectPairedRuntimeParkingEnvironmentIdsFromState(state: {
+  runtimeStatusByEnvironmentId: PairedRuntimeParkingCapabilityStatuses
+}): ReadonlySet<string> {
+  return selectPairedRuntimeParkingEnvironmentIds(state.runtimeStatusByEnvironmentId)
+}
+
+export function resetPairedRuntimeParkingEnvironmentIdsCacheForTest(): void {
+  pairedRuntimeParkingEnvironmentIdsCache = null
+}

--- a/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it } from 'vitest'
 import {
   clearTerminalProviderSnapshotCapabilities,
   synchronizeTerminalProviderSnapshotCapabilities
@@ -11,12 +11,17 @@ import {
   canParkTerminalWorktreeRenderers,
   isParkRestorableTerminalPty,
   isSnapshotBackedTerminalPty,
+  resetPairedRuntimeParkingEnvironmentIdsCacheForTest,
   selectPairedRuntimeParkingEnvironmentIds,
   selectColdParkedTerminalTabs,
   selectColdParkedTerminalWorktrees
 } from './terminal-hidden-view-parking'
 
 describe('selectPairedRuntimeParkingEnvironmentIds', () => {
+  beforeEach(() => {
+    resetPairedRuntimeParkingEnvironmentIdsCacheForTest()
+  })
+
   it('selects only reachable hosts advertising the paired parking contract', () => {
     const statuses = new Map([
       [
@@ -28,6 +33,39 @@ describe('selectPairedRuntimeParkingEnvironmentIds', () => {
     ])
 
     expect(selectPairedRuntimeParkingEnvironmentIds(statuses)).toEqual(new Set(['capable']))
+  })
+
+  it('shares the capability Set across status-only changes and replaces it on membership changes', () => {
+    const first = selectPairedRuntimeParkingEnvironmentIds(
+      new Map([
+        ['runtime-a', { status: { capabilities: ['terminal.paired-parking.v1'] } }],
+        ['runtime-b', { status: { capabilities: ['terminal.multiplex.v1'] } }]
+      ])
+    )
+    const statusOnlyUpdate = selectPairedRuntimeParkingEnvironmentIds(
+      new Map([
+        [
+          'runtime-a',
+          {
+            status: {
+              capabilities: ['terminal.paired-parking.v1'],
+              runtimeId: 'peer-a-reconnected'
+            }
+          }
+        ],
+        ['runtime-b', { status: { capabilities: ['terminal.multiplex.v1'], appVersion: '1.5.0' } }]
+      ])
+    )
+    expect(statusOnlyUpdate).toBe(first)
+
+    const capabilityUpdate = selectPairedRuntimeParkingEnvironmentIds(
+      new Map([
+        ['runtime-a', { status: { capabilities: ['terminal.paired-parking.v1'] } }],
+        ['runtime-b', { status: { capabilities: ['terminal.paired-parking.v1'] } }]
+      ])
+    )
+    expect(capabilityUpdate).not.toBe(first)
+    expect(capabilityUpdate).toEqual(new Set(['runtime-a', 'runtime-b']))
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.ts
@@ -1,7 +1,6 @@
 import { isRemoteRuntimePtyId } from '@/runtime/runtime-terminal-inspection'
 import { getRemoteRuntimePtyEnvironmentId } from '@/runtime/runtime-terminal-stream'
 import { PTY_SESSION_ID_SEPARATOR } from '../../../../shared/pty-session-id-format'
-import { TERMINAL_PAIRED_PARKING_RUNTIME_CAPABILITY } from '../../../../shared/protocol-version'
 import { parseAppSshPtyId } from '../../../../shared/ssh-pty-id'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 
@@ -92,17 +91,11 @@ export type TerminalParkRestorePolicy = {
   pairedRuntimeParkingEnvironmentIds?: ReadonlySet<string>
 }
 
-export function selectPairedRuntimeParkingEnvironmentIds(
-  statuses: ReadonlyMap<string, { status: { capabilities?: readonly string[] } | null | undefined }>
-): Set<string> {
-  const capable = new Set<string>()
-  for (const [environmentId, entry] of statuses) {
-    if (entry.status?.capabilities?.includes(TERMINAL_PAIRED_PARKING_RUNTIME_CAPABILITY)) {
-      capable.add(environmentId)
-    }
-  }
-  return capable
-}
+export {
+  resetPairedRuntimeParkingEnvironmentIdsCacheForTest,
+  selectPairedRuntimeParkingEnvironmentIds,
+  selectPairedRuntimeParkingEnvironmentIdsFromState
+} from './paired-runtime-parking-capabilities'
 
 // Why: SSH uses local main's model; paired PTYs are eligible only when their
 // exact host advertises authoritative bounded restore.

--- a/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.test.ts
@@ -2,6 +2,7 @@
 import { act, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+import type { selectColdParkedTerminalTabs } from './terminal-hidden-view-parking'
 
 const mocks = vi.hoisted(() => ({
   storeState: {
@@ -18,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   },
   exemptTabIds: new Set<string>(),
   exemptSelectCalls: 0,
+  coldParkSelectCalls: 0,
   /** Toggled to churn the park verdict the way the crash cluster does. */
   watcherCoverage: true
 }))
@@ -25,6 +27,21 @@ const mocks = vi.hoisted(() => ({
 vi.mock('../../store', () => ({
   useAppStore: (selector: (state: unknown) => unknown) => selector(mocks.storeState)
 }))
+
+vi.mock('./terminal-hidden-view-parking', async (importOriginal) => {
+  const actual = await importOriginal<{
+    selectColdParkedTerminalTabs: typeof selectColdParkedTerminalTabs
+  }>()
+  return {
+    ...actual,
+    selectColdParkedTerminalTabs: (
+      args: Parameters<typeof actual.selectColdParkedTerminalTabs>[0]
+    ) => {
+      mocks.coldParkSelectCalls += 1
+      return actual.selectColdParkedTerminalTabs(args)
+    }
+  }
+})
 
 vi.mock('./terminal-eviction-exempt-tabs', () => ({
   selectEvictionExemptTerminalTabIds: (_worktreeId: string, tabs: readonly { id: string }[]) => {
@@ -86,6 +103,7 @@ describe('useTerminalTabColdParking measure-clock contract', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000_000)
+    mocks.coldParkSelectCalls = 0
   })
 
   afterEach(() => {
@@ -203,6 +221,51 @@ describe('useTerminalTabColdParking measure-clock contract', () => {
       expect(result.current).toEqual(expected)
       unmount()
     }
+  })
+
+  it('skips parking scans for capability-equivalent status writes and scans membership changes', () => {
+    const args = hookArgs(false)
+    mocks.storeState.runtimeStatusByEnvironmentId = new Map([
+      ['runtime-a', { status: { capabilities: ['terminal.multiplex.v1'], runtimeId: 'peer-a' } }]
+    ])
+    const { rerender } = renderHook(
+      (props: ReturnType<typeof hookArgs>) => useTerminalTabColdParking(props),
+      { initialProps: args }
+    )
+    const initialSelectCalls = mocks.coldParkSelectCalls
+
+    mocks.storeState.runtimeStatusByEnvironmentId = new Map([
+      [
+        'runtime-a',
+        {
+          status: {
+            capabilities: ['terminal.multiplex.v1'],
+            runtimeId: 'peer-a-reconnected',
+            appVersion: '1.5.0'
+          }
+        }
+      ]
+    ])
+    act(() => {
+      rerender(args)
+    })
+    expect(mocks.coldParkSelectCalls).toBe(initialSelectCalls)
+
+    mocks.storeState.runtimeStatusByEnvironmentId = new Map([
+      [
+        'runtime-a',
+        {
+          status: {
+            capabilities: ['terminal.multiplex.v1', 'terminal.paired-parking.v1'],
+            runtimeId: 'peer-a-reconnected'
+          }
+        }
+      ]
+    ])
+    act(() => {
+      rerender(args)
+    })
+    expect(mocks.coldParkSelectCalls).toBe(initialSelectCalls + 1)
   })
 
   // Why: the flip-damping pin removes the tab from the parked set, and every

--- a/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
@@ -16,7 +16,7 @@ import {
 import { getTerminalTabColdParkRecheckDelayMs } from './terminal-cold-park-recheck-deadlines'
 import {
   TERMINAL_TAB_COLD_PARK_DELAY_MS,
-  selectPairedRuntimeParkingEnvironmentIds,
+  selectPairedRuntimeParkingEnvironmentIdsFromState,
   selectColdParkedTerminalTabs
 } from './terminal-hidden-view-parking'
 import {
@@ -105,10 +105,8 @@ export function useTerminalTabColdParking(args: {
   const terminalSshParkingEnabled = useAppStore(
     (state) => state.settings?.terminalSshViewParking !== false
   )
-  const runtimeStatusByEnvironmentId = useAppStore((state) => state.runtimeStatusByEnvironmentId)
-  const pairedRuntimeParkingEnvironmentIds = useMemo(
-    () => selectPairedRuntimeParkingEnvironmentIds(runtimeStatusByEnvironmentId),
-    [runtimeStatusByEnvironmentId]
+  const pairedRuntimeParkingEnvironmentIds = useAppStore(
+    selectPairedRuntimeParkingEnvironmentIdsFromState
   )
   const sleepingAgentSessionsByPaneKey = useAppStore(
     (state) => state.sleepingAgentSessionsByPaneKey
@@ -254,7 +252,7 @@ export function useTerminalTabColdParking(args: {
     activeTerminalTabId,
     isWorktreeActive,
     pendingStartupByTabId,
-    runtimeStatusByEnvironmentId,
+    pairedRuntimeParkingEnvironmentIds,
     shouldMeasureHiddenWorktree,
     terminalParkingEnabled,
     terminalSshParkingEnabled,

--- a/src/renderer/src/hooks/useIpcEvents-runtime-environment-selectors.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents-runtime-environment-selectors.test.ts
@@ -1,9 +1,17 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   buildRuntimeClientEventEnvironmentKey,
+  createRuntimeEnvironmentStoreSyncSubscriber,
   getNewlyConnectedRuntimeEnvironmentIds,
   getNewlyDisconnectedRuntimeEnvironmentIds,
-  getRuntimeProjectRefreshEnvironmentIds
+  getReachableRuntimeEnvironmentIds,
+  getRuntimeClientEventEnvironmentIds,
+  getRuntimeProjectRefreshEnvironmentIds,
+  invalidateRuntimeClientEventReplay
+} from './useIpcEvents'
+import type {
+  RuntimeEnvironmentStoreSyncState,
+  RuntimeEnvironmentStoreSyncSubscriber
 } from './useIpcEvents'
 
 describe('buildRuntimeClientEventEnvironmentKey', () => {
@@ -61,5 +69,276 @@ describe('getRuntimeProjectRefreshEnvironmentIds', () => {
         nextReachable: ['env-a']
       })
     ).toEqual(['env-a'])
+  })
+})
+
+type RuntimeEnvironmentStoreSubscriber = RuntimeEnvironmentStoreSyncSubscriber
+type RuntimeEnvironmentStoreState = RuntimeEnvironmentStoreSyncState
+
+function makeRuntimeEnvironmentStoreState(args: {
+  environments: readonly { id: string; createdAt: number; pairingRevision?: number }[]
+  statuses: ReadonlyMap<string, { status: { runtimeId: string } | null; checkedAt: number }>
+  sshStateByEnvironment?: ReadonlyMap<string, unknown>
+  activeEnvironmentId?: string | null
+  settingsRevision?: number
+}): RuntimeEnvironmentStoreState {
+  return {
+    runtimeEnvironments: args.environments,
+    runtimeStatusByEnvironmentId: args.statuses,
+    sshStateByEnvironment: args.sshStateByEnvironment ?? new Map(),
+    settings: {
+      activeRuntimeEnvironmentId: args.activeEnvironmentId ?? null,
+      terminalFontSize: args.settingsRevision ?? 0
+    }
+  } as unknown as RuntimeEnvironmentStoreState
+}
+
+describe('createRuntimeEnvironmentStoreSyncSubscriber', () => {
+  it('does no host enumeration or key building for 1,000 unrelated local, SSH, and folder writes', () => {
+    const environments = Array.from({ length: 100 }, (_, index) => ({
+      id: `runtime-${index}`,
+      createdAt: index + 1
+    }))
+    const statuses = new Map(
+      environments.map((environment) => [
+        environment.id,
+        { status: { runtimeId: `peer-${environment.id}` }, checkedAt: 1 }
+      ])
+    )
+    let currentState = makeRuntimeEnvironmentStoreState({ environments, statuses })
+    let hostEnumerations = 0
+    let keyBuilds = 0
+    let syncs = 0
+    const subscriber = createRuntimeEnvironmentStoreSyncSubscriber({
+      initialDesiredEnvironmentIds: getRuntimeClientEventEnvironmentIds(currentState),
+      initialReachableEnvironmentIds: getReachableRuntimeEnvironmentIds(currentState),
+      getDesiredEnvironmentIds: (state) => {
+        hostEnumerations += 1
+        return getRuntimeClientEventEnvironmentIds(state)
+      },
+      getReachableEnvironmentIds: (state) => {
+        hostEnumerations += 1
+        return getReachableRuntimeEnvironmentIds(state)
+      },
+      buildEnvironmentKey: (environmentIds) => {
+        keyBuilds += 1
+        return [...environmentIds].sort().join('\0')
+      },
+      requestProjectRefresh: vi.fn(),
+      markEnvironmentSshStateStale: vi.fn(),
+      sync: () => {
+        syncs += 1
+      }
+    })
+    keyBuilds = 0
+
+    for (let write = 0; write < 1_000; write += 1) {
+      const previousState = currentState
+      currentState = {
+        ...currentState,
+        // These represent the high-frequency boundaries that must stay outside
+        // runtime-host discovery: local terminal state, direct SSH state, and
+        // folder-workspace catalog churn.
+        settings: {
+          activeRuntimeEnvironmentId: currentState.settings?.activeRuntimeEnvironmentId ?? null,
+          terminalFontSize: write
+        },
+        pendingStartupByTabId: { [`local-tab-${write}`]: true },
+        sshConnectionStates: new Map([[`direct-ssh-${write}`, { status: 'connected' }]]),
+        folderWorkspaces: [{ id: `folder-${write}` }]
+      } as unknown as RuntimeEnvironmentStoreState
+      subscriber(currentState, previousState)
+    }
+
+    expect(hostEnumerations).toBe(0)
+    expect(keyBuilds).toBe(0)
+    expect(syncs).toBe(0)
+  })
+
+  it('syncs each connect, disconnect, re-pair, runtime generation, and nested SSH generation once', () => {
+    let environments = [
+      { id: 'runtime-a', createdAt: 1, pairingRevision: 1 },
+      { id: 'runtime-b', createdAt: 2, pairingRevision: 1 }
+    ]
+    let statuses = new Map([
+      ['runtime-a', { status: { runtimeId: 'peer-a' }, checkedAt: 1 }],
+      ['runtime-b', { status: null, checkedAt: 1 }]
+    ])
+    let sshStateByEnvironment: ReadonlyMap<string, unknown> = new Map([
+      ['runtime-a', { targetsHydrated: true }]
+    ])
+    let currentState = makeRuntimeEnvironmentStoreState({
+      environments,
+      statuses,
+      sshStateByEnvironment,
+      activeEnvironmentId: 'runtime-a'
+    })
+    const runtimeGenerations = new Map([
+      ['runtime-a', 1],
+      ['runtime-b', 0]
+    ])
+    const sshGenerations = new Map([
+      ['runtime-a', 0],
+      ['runtime-b', 0]
+    ])
+    const pairingRevisions = new Map([
+      ['runtime-a', 1],
+      ['runtime-b', 1]
+    ])
+    const refreshes: string[] = []
+    let syncs = 0
+    let subscriber: RuntimeEnvironmentStoreSubscriber
+    const publish = (nextState: RuntimeEnvironmentStoreState): void => {
+      const previousState = currentState
+      currentState = nextState
+      subscriber(nextState, previousState)
+    }
+    const buildEnvironmentKey = (environmentIds: string[]): string =>
+      [...new Set(environmentIds)]
+        .sort()
+        .map(
+          (environmentId) =>
+            `${environmentId}:${runtimeGenerations.get(environmentId) ?? 0}:${sshGenerations.get(environmentId) ?? 0}:${pairingRevisions.get(environmentId) ?? 0}`
+        )
+        .join('\0')
+
+    subscriber = createRuntimeEnvironmentStoreSyncSubscriber({
+      initialDesiredEnvironmentIds: getRuntimeClientEventEnvironmentIds(currentState),
+      initialReachableEnvironmentIds: getReachableRuntimeEnvironmentIds(currentState),
+      getDesiredEnvironmentIds: getRuntimeClientEventEnvironmentIds,
+      getReachableEnvironmentIds: getReachableRuntimeEnvironmentIds,
+      buildEnvironmentKey,
+      requestProjectRefresh: (environmentId) => refreshes.push(environmentId),
+      markEnvironmentSshStateStale: (environmentId) => {
+        sshGenerations.set(environmentId, (sshGenerations.get(environmentId) ?? 0) + 1)
+        const previousState = currentState
+        sshStateByEnvironment = new Map(sshStateByEnvironment).set(environmentId, {
+          targetsHydrated: false
+        })
+        currentState = makeRuntimeEnvironmentStoreState({
+          environments,
+          statuses,
+          sshStateByEnvironment,
+          activeEnvironmentId: 'runtime-a'
+        })
+        // Zustand publishes this nested write synchronously. The outer pass must
+        // absorb its generation instead of enumerating/syncing it a second time.
+        subscriber(currentState, previousState)
+      },
+      sync: () => {
+        syncs += 1
+      }
+    })
+
+    runtimeGenerations.set('runtime-b', 1)
+    statuses = new Map(statuses).set('runtime-b', {
+      status: { runtimeId: 'peer-b' },
+      checkedAt: 2
+    })
+    publish(
+      makeRuntimeEnvironmentStoreState({
+        environments,
+        statuses,
+        sshStateByEnvironment,
+        activeEnvironmentId: 'runtime-a'
+      })
+    )
+    expect(syncs).toBe(1)
+    expect(refreshes).toEqual(['runtime-b'])
+
+    statuses = new Map(statuses).set('runtime-a', { status: null, checkedAt: 3 })
+    publish(
+      makeRuntimeEnvironmentStoreState({
+        environments,
+        statuses,
+        sshStateByEnvironment,
+        activeEnvironmentId: 'runtime-a'
+      })
+    )
+    expect(syncs).toBe(2)
+
+    environments = [environments[0], { ...environments[1], pairingRevision: 2 }]
+    pairingRevisions.set('runtime-b', 2)
+    publish(
+      makeRuntimeEnvironmentStoreState({
+        environments,
+        statuses,
+        sshStateByEnvironment,
+        activeEnvironmentId: 'runtime-a'
+      })
+    )
+    expect(syncs).toBe(3)
+
+    runtimeGenerations.set('runtime-b', 2)
+    statuses = new Map(statuses).set('runtime-b', {
+      status: { runtimeId: 'peer-b-reconnected' },
+      checkedAt: 4
+    })
+    publish(
+      makeRuntimeEnvironmentStoreState({
+        environments,
+        statuses,
+        sshStateByEnvironment,
+        activeEnvironmentId: 'runtime-a'
+      })
+    )
+    expect(syncs).toBe(4)
+
+    sshGenerations.set('runtime-b', 1)
+    sshStateByEnvironment = new Map(sshStateByEnvironment).set('runtime-b', {
+      targetsHydrated: true
+    })
+    publish(
+      makeRuntimeEnvironmentStoreState({
+        environments,
+        statuses,
+        sshStateByEnvironment,
+        activeEnvironmentId: 'runtime-a'
+      })
+    )
+    expect(syncs).toBe(5)
+  })
+})
+
+describe('invalidateRuntimeClientEventReplay', () => {
+  it('explicitly syncs an advanced SSH generation when stale publication is a no-op and hydration fails', async () => {
+    const sshStateReference = new Map()
+    const requestProjectRefresh = vi.fn()
+    const markEnvironmentSshStateStale = vi.fn()
+    const sync = vi.fn()
+    const hydrateEnvironmentSshState = vi
+      .fn<() => Promise<unknown>>()
+      .mockRejectedValue(new Error('runtime stayed unreachable'))
+
+    invalidateRuntimeClientEventReplay({
+      getSshStateReference: () => sshStateReference,
+      requestProjectRefresh,
+      markEnvironmentSshStateStale,
+      hydrateEnvironmentSshState,
+      sync
+    })
+    await Promise.resolve()
+
+    expect(requestProjectRefresh).toHaveBeenCalledOnce()
+    expect(markEnvironmentSshStateStale).toHaveBeenCalledOnce()
+    expect(sync).toHaveBeenCalledOnce()
+    expect(hydrateEnvironmentSshState).toHaveBeenCalledOnce()
+  })
+
+  it('leaves tracked bucket publications to the synchronous store subscriber', () => {
+    let sshStateReference = new Map()
+    const sync = vi.fn()
+
+    invalidateRuntimeClientEventReplay({
+      getSshStateReference: () => sshStateReference,
+      requestProjectRefresh: vi.fn(),
+      markEnvironmentSshStateStale: () => {
+        sshStateReference = new Map()
+      },
+      hydrateEnvironmentSshState: () => Promise.resolve(),
+      sync
+    })
+
+    expect(sync).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -575,14 +575,20 @@ function remountTerminalTabsAwaitingHostHydration(): void {
   }
 }
 
-function getActiveRuntimeEnvironmentId(): string | null {
-  return useAppStore.getState().settings?.activeRuntimeEnvironmentId?.trim() || null
+export type RuntimeEnvironmentStoreSyncState = Pick<
+  AppState,
+  'runtimeEnvironments' | 'runtimeStatusByEnvironmentId' | 'settings' | 'sshStateByEnvironment'
+>
+
+function getActiveRuntimeEnvironmentId(state: RuntimeEnvironmentStoreSyncState): string | null {
+  return state.settings?.activeRuntimeEnvironmentId?.trim() || null
 }
 
-function getRuntimeClientEventEnvironmentIds(): string[] {
-  const state = useAppStore.getState()
+export function getRuntimeClientEventEnvironmentIds(
+  state: RuntimeEnvironmentStoreSyncState
+): string[] {
   const ids = new Set<string>()
-  const activeEnvironmentId = getActiveRuntimeEnvironmentId()
+  const activeEnvironmentId = getActiveRuntimeEnvironmentId(state)
   if (activeEnvironmentId) {
     ids.add(activeEnvironmentId)
   }
@@ -595,8 +601,9 @@ function getRuntimeClientEventEnvironmentIds(): string[] {
   return [...ids]
 }
 
-function getReachableRuntimeEnvironmentIds(): string[] {
-  const state = useAppStore.getState()
+export function getReachableRuntimeEnvironmentIds(
+  state: RuntimeEnvironmentStoreSyncState
+): string[] {
   const ids: string[] = []
   for (const [environmentId, status] of state.runtimeStatusByEnvironmentId ?? []) {
     if (status?.status) {
@@ -604,6 +611,18 @@ function getReachableRuntimeEnvironmentIds(): string[] {
     }
   }
   return ids
+}
+
+export function canSkipRuntimeEnvironmentStoreSync(
+  state: RuntimeEnvironmentStoreSyncState,
+  previousState: RuntimeEnvironmentStoreSyncState
+): boolean {
+  return (
+    state.runtimeEnvironments === previousState.runtimeEnvironments &&
+    state.runtimeStatusByEnvironmentId === previousState.runtimeStatusByEnvironmentId &&
+    state.sshStateByEnvironment === previousState.sshStateByEnvironment &&
+    getActiveRuntimeEnvironmentId(state) === getActiveRuntimeEnvironmentId(previousState)
+  )
 }
 
 export function buildRuntimeClientEventEnvironmentKey(environmentIds: string[]): string {
@@ -645,6 +664,115 @@ export function getRuntimeProjectRefreshEnvironmentIds(args: {
       ...getNewlyConnectedRuntimeEnvironmentIds(args.previousReachable, args.nextReachable)
     ])
   ]
+}
+
+type RuntimeEnvironmentStoreSyncSubscriberDeps = {
+  initialDesiredEnvironmentIds: string[]
+  initialReachableEnvironmentIds: string[]
+  buildEnvironmentKey: (environmentIds: string[]) => string
+  getDesiredEnvironmentIds: (state: RuntimeEnvironmentStoreSyncState) => string[]
+  getReachableEnvironmentIds: (state: RuntimeEnvironmentStoreSyncState) => string[]
+  requestProjectRefresh: (environmentId: string) => void
+  markEnvironmentSshStateStale: (environmentId: string) => void
+  sync: () => void
+}
+
+export type RuntimeEnvironmentStoreSyncSubscriber = (
+  state: RuntimeEnvironmentStoreSyncState,
+  previousState: RuntimeEnvironmentStoreSyncState
+) => void
+
+/**
+ * Builds the one renderer-wide runtime subscriber. The reference gate runs
+ * before either host collection is enumerated; key generation remains the
+ * second gate for relevant-reference writes whose effective subscription set
+ * did not change.
+ */
+export function createRuntimeEnvironmentStoreSyncSubscriber(
+  deps: RuntimeEnvironmentStoreSyncSubscriberDeps
+): RuntimeEnvironmentStoreSyncSubscriber {
+  let desiredEnvironmentIds = deps.initialDesiredEnvironmentIds
+  let desiredEnvironmentKey = deps.buildEnvironmentKey(desiredEnvironmentIds)
+  let reachableEnvironmentIds = deps.initialReachableEnvironmentIds
+  let reachableEnvironmentKey = deps.buildEnvironmentKey(reachableEnvironmentIds)
+  let handlingStoreWrite = false
+
+  return (state, previousState) => {
+    // markEnvironmentSshStateStale can synchronously publish its nested SSH
+    // bucket. The outer pass incorporates that generation before syncing, so a
+    // re-entrant pass would only enumerate and sync the same transition twice.
+    if (handlingStoreWrite || canSkipRuntimeEnvironmentStoreSync(state, previousState)) {
+      return
+    }
+
+    handlingStoreWrite = true
+    try {
+      const nextDesiredEnvironmentIds = deps.getDesiredEnvironmentIds(state)
+      const nextReachableEnvironmentIds = deps.getReachableEnvironmentIds(state)
+      const refreshEnvironmentIds = getRuntimeProjectRefreshEnvironmentIds({
+        previousDesired: desiredEnvironmentIds,
+        nextDesired: nextDesiredEnvironmentIds,
+        previousReachable: reachableEnvironmentIds,
+        nextReachable: nextReachableEnvironmentIds
+      })
+      const disconnectedEnvironmentIds = getNewlyDisconnectedRuntimeEnvironmentIds(
+        reachableEnvironmentIds,
+        nextReachableEnvironmentIds
+      )
+
+      desiredEnvironmentIds = nextDesiredEnvironmentIds
+      reachableEnvironmentIds = nextReachableEnvironmentIds
+      for (const environmentId of refreshEnvironmentIds) {
+        deps.requestProjectRefresh(environmentId)
+      }
+      for (const environmentId of disconnectedEnvironmentIds) {
+        deps.markEnvironmentSshStateStale(environmentId)
+      }
+
+      // Build after disconnect invalidation: marking a mirrored SSH bucket stale
+      // advances its generation, and the replacement subscription must capture
+      // that final generation in this same (single) sync.
+      const nextDesiredEnvironmentKey = deps.buildEnvironmentKey(desiredEnvironmentIds)
+      const nextReachableEnvironmentKey = deps.buildEnvironmentKey(reachableEnvironmentIds)
+      if (
+        nextDesiredEnvironmentKey === desiredEnvironmentKey &&
+        nextReachableEnvironmentKey === reachableEnvironmentKey
+      ) {
+        return
+      }
+      desiredEnvironmentKey = nextDesiredEnvironmentKey
+      reachableEnvironmentKey = nextReachableEnvironmentKey
+      deps.sync()
+    } finally {
+      handlingStoreWrite = false
+    }
+  }
+}
+
+type RuntimeClientEventReplayInvalidationDeps = {
+  getSshStateReference: () => RuntimeEnvironmentStoreSyncState['sshStateByEnvironment']
+  requestProjectRefresh: () => void
+  markEnvironmentSshStateStale: () => void
+  hydrateEnvironmentSshState: () => Promise<unknown>
+  sync: () => void
+}
+
+/**
+ * Invalidates a replay after the runtime event stream reports a transport gap.
+ * A tracked SSH bucket publishes synchronously and lets the store subscriber
+ * sync it; an empty/already-stale bucket has no reference publication, so this
+ * path must explicitly sync the advanced module-level SSH generation.
+ */
+export function invalidateRuntimeClientEventReplay(
+  deps: RuntimeClientEventReplayInvalidationDeps
+): void {
+  deps.requestProjectRefresh()
+  const previousSshStateReference = deps.getSshStateReference()
+  deps.markEnvironmentSshStateStale()
+  if (deps.getSshStateReference() === previousSshStateReference) {
+    deps.sync()
+  }
+  void deps.hydrateEnvironmentSshState().catch(() => {})
 }
 
 function getWorktreeRuntimeEnvironmentId(worktreeId: string | null | undefined): string | null {
@@ -1061,7 +1189,7 @@ export function useIpcEvents(): void {
     }
 
     const runtimeClientEventsSync = createRuntimeClientEventsSync({
-      getDesiredEnvironmentIds: getRuntimeClientEventEnvironmentIds,
+      getDesiredEnvironmentIds: () => getRuntimeClientEventEnvironmentIds(useAppStore.getState()),
       getSubscriptionKey: (environmentId) => buildRuntimeClientEventEnvironmentKey([environmentId]),
       subscribe: (environmentId, onEvent, onError) => {
         const sshGeneration = getEnvironmentSshStateGeneration(environmentId)
@@ -1080,62 +1208,53 @@ export function useIpcEvents(): void {
           },
           onError,
           () => {
-            // Why: events during a transport gap are lost; a quick reconnect won't flip unreachable, so refetch (#7970).
-            runtimeProjectRefreshScheduler.request(environmentId)
-            // Why: sshStateChanged events during the transport gap are lost, so downgrade the possibly-stale bucket, then refetch.
-            useAppStore.getState().markEnvironmentSshStateStale(environmentId)
-            void hydrateRuntimeEnvironmentSshState(environmentId, { force: true }).catch(() => {})
+            invalidateRuntimeClientEventReplay({
+              getSshStateReference: () => useAppStore.getState().sshStateByEnvironment,
+              requestProjectRefresh: () => runtimeProjectRefreshScheduler.request(environmentId),
+              markEnvironmentSshStateStale: () =>
+                useAppStore.getState().markEnvironmentSshStateStale(environmentId),
+              hydrateEnvironmentSshState: () =>
+                hydrateRuntimeEnvironmentSshState(environmentId, { force: true }),
+              sync: runtimeClientEventsSync.sync
+            })
           }
         )
       },
       onEvent: handleRuntimeClientEvent
     })
 
-    runtimeClientEventsSync.sync()
     // Why: no on-connect repo fetch (PR #2); seed discovery for connected runtimes or remote projects hide until Add-Project.
-    let runtimeClientEventEnvironmentIds = getRuntimeClientEventEnvironmentIds()
+    const initialRuntimeEnvironmentState = useAppStore.getState()
+    const runtimeClientEventEnvironmentIds = getRuntimeClientEventEnvironmentIds(
+      initialRuntimeEnvironmentState
+    )
     for (const environmentId of runtimeClientEventEnvironmentIds) {
       runtimeProjectRefreshScheduler.request(environmentId)
     }
-    let runtimeClientEventEnvironmentKey = buildRuntimeClientEventEnvironmentKey(
-      runtimeClientEventEnvironmentIds
+    const reachableRuntimeEnvironmentIds = getReachableRuntimeEnvironmentIds(
+      initialRuntimeEnvironmentState
     )
-    let reachableRuntimeEnvironmentIds = getReachableRuntimeEnvironmentIds()
-    let reachableRuntimeEnvironmentKey = buildRuntimeClientEventEnvironmentKey(
-      reachableRuntimeEnvironmentIds
-    )
-    const unsubscribeRuntimeEnvironmentStore = useAppStore.subscribe(() => {
-      const nextEnvironmentIds = getRuntimeClientEventEnvironmentIds()
-      const nextKey = buildRuntimeClientEventEnvironmentKey(nextEnvironmentIds)
-      const nextReachableEnvironmentIds = getReachableRuntimeEnvironmentIds()
-      const nextReachableKey = buildRuntimeClientEventEnvironmentKey(nextReachableEnvironmentIds)
-      if (
-        nextKey === runtimeClientEventEnvironmentKey &&
-        nextReachableKey === reachableRuntimeEnvironmentKey
-      ) {
-        return
-      }
-      for (const environmentId of getRuntimeProjectRefreshEnvironmentIds({
-        previousDesired: runtimeClientEventEnvironmentIds,
-        nextDesired: nextEnvironmentIds,
-        previousReachable: reachableRuntimeEnvironmentIds,
-        nextReachable: nextReachableEnvironmentIds
-      })) {
-        runtimeProjectRefreshScheduler.request(environmentId)
-      }
-      for (const environmentId of getNewlyDisconnectedRuntimeEnvironmentIds(
-        reachableRuntimeEnvironmentIds,
-        nextReachableEnvironmentIds
-      )) {
+    const handleRuntimeEnvironmentStoreWrite = createRuntimeEnvironmentStoreSyncSubscriber({
+      initialDesiredEnvironmentIds: runtimeClientEventEnvironmentIds,
+      initialReachableEnvironmentIds: reachableRuntimeEnvironmentIds,
+      buildEnvironmentKey: buildRuntimeClientEventEnvironmentKey,
+      getDesiredEnvironmentIds: getRuntimeClientEventEnvironmentIds,
+      getReachableEnvironmentIds: getReachableRuntimeEnvironmentIds,
+      requestProjectRefresh: (environmentId) =>
+        runtimeProjectRefreshScheduler.request(environmentId),
+      markEnvironmentSshStateStale: (environmentId) => {
         // No-op when the environment has no SSH bucket (e.g. web client).
         useAppStore.getState().markEnvironmentSshStateStale(environmentId)
-      }
-      runtimeClientEventEnvironmentIds = nextEnvironmentIds
-      runtimeClientEventEnvironmentKey = nextKey
-      reachableRuntimeEnvironmentIds = nextReachableEnvironmentIds
-      reachableRuntimeEnvironmentKey = nextReachableKey
-      runtimeClientEventsSync.sync()
+      },
+      sync: runtimeClientEventsSync.sync
     })
+    const unsubscribeRuntimeEnvironmentStore = useAppStore.subscribe(
+      handleRuntimeEnvironmentStoreWrite
+    )
+    // Subscribe before the first runtime stream starts: replay invalidation may
+    // synchronously publish a tracked SSH bucket and relies on this listener to
+    // replace that subscription exactly once.
+    runtimeClientEventsSync.sync()
     unsubs.push(runtimeClientEventsSync.stop)
     unsubs.push(runtimeProjectRefreshScheduler.stop)
 

--- a/src/renderer/src/store/selectors.test.ts
+++ b/src/renderer/src/store/selectors.test.ts
@@ -11,6 +11,7 @@ import {
   getProjectHostSetupProjectionFromState,
   getWorktreeMapFromState,
   resetFloatingVisibleTabCountSelectorCacheForTest,
+  resetFloatingWorkspaceUnreadSelectorCacheForTest,
   selectRepoByIdForActiveWorkspace,
   selectFloatingVisibleTabCount,
   selectFloatingWorkspaceHasUnread
@@ -608,6 +609,10 @@ describe('selectFloatingWorkspaceHasUnread', () => {
 
   type UnreadState = Parameters<typeof selectFloatingWorkspaceHasUnread>[0]
 
+  beforeEach(() => {
+    resetFloatingWorkspaceUnreadSelectorCacheForTest()
+  })
+
   function makeState(overrides: Partial<UnreadState>): UnreadState {
     return {
       tabsByWorktree: {},
@@ -667,5 +672,73 @@ describe('selectFloatingWorkspaceHasUnread', () => {
       unreadAgentCompletionPanes: { 'ft-closed:leaf-a': true }
     })
     expect(selectFloatingWorkspaceHasUnread(state)).toBe(false)
+  })
+
+  it('shares one scan across consumers and skips 1,000 unrelated writes', () => {
+    let tabIdReads = 0
+    let terminalUnreadReads = 0
+    let completionKeyScans = 0
+    const tabs = [
+      {
+        get id() {
+          tabIdReads += 1
+          return 'ft1'
+        },
+        title: 'floating',
+        ptyId: null
+      } as unknown as TerminalTab
+    ]
+    const unreadTerminalTabs = new Proxy<Record<string, true>>(
+      {},
+      {
+        get(target, property, receiver) {
+          if (typeof property === 'string') {
+            terminalUnreadReads += 1
+          }
+          return Reflect.get(target, property, receiver)
+        }
+      }
+    )
+    const unreadAgentCompletionPanes = new Proxy<Record<string, true>>(
+      { 'main-tab:leaf-a': true },
+      {
+        ownKeys(target) {
+          completionKeyScans += 1
+          return Reflect.ownKeys(target)
+        }
+      }
+    )
+    const state = makeState({
+      tabsByWorktree: { [FLOATING]: tabs },
+      unreadTerminalTabs,
+      unreadAgentCompletionPanes
+    })
+
+    expect(selectFloatingWorkspaceHasUnread(state)).toBe(false)
+    const countsAfterFirstConsumer = {
+      tabIdReads,
+      terminalUnreadReads,
+      completionKeyScans
+    }
+    expect(selectFloatingWorkspaceHasUnread(state)).toBe(false)
+    for (let write = 0; write < 1_000; write += 1) {
+      expect(
+        selectFloatingWorkspaceHasUnread({
+          ...state,
+          unrelatedStoreRevision: write
+        } as unknown as UnreadState)
+      ).toBe(false)
+    }
+    expect({ tabIdReads, terminalUnreadReads, completionKeyScans }).toEqual(
+      countsAfterFirstConsumer
+    )
+
+    expect(
+      selectFloatingWorkspaceHasUnread({
+        ...state,
+        unreadTerminalTabs: { ft1: true }
+      })
+    ).toBe(true)
+    expect(tabIdReads).toBeGreaterThan(countsAfterFirstConsumer.tabIdReads)
   })
 })

--- a/src/renderer/src/store/selectors.ts
+++ b/src/renderer/src/store/selectors.ts
@@ -118,6 +118,14 @@ type FloatingWorkspaceUnreadState = Pick<
   AppState,
   'tabsByWorktree' | 'unreadTerminalTabs' | 'unreadAgentCompletionPanes'
 >
+type FloatingWorkspaceUnreadCache = {
+  tabs: NonNullable<AppState['tabsByWorktree'][string]>
+  unreadTerminalTabs: AppState['unreadTerminalTabs']
+  unreadAgentCompletionPanes: AppState['unreadAgentCompletionPanes']
+  hasUnread: boolean
+}
+
+let floatingWorkspaceUnreadCache: FloatingWorkspaceUnreadCache | null = null
 
 /**
  * True when any terminal tab in the floating workspace has an unacknowledged
@@ -129,32 +137,57 @@ type FloatingWorkspaceUnreadState = Pick<
  * removed tabs cannot light it). Bells mark `unreadTerminalTabs[tabId]`;
  * completions mark `unreadAgentCompletionPanes[paneKey]` — both ungated.
  *
- * Returns a primitive boolean, so subscribers re-render only when it flips, and
- * the empty-workspace early return keeps the common case O(1) despite Zustand
- * rerunning selectors on every write.
+ * The launcher and floating overlay both stay mounted. Cache their shared
+ * reference projection so the second consumer and unrelated Zustand writes
+ * return in O(1) without repeating either unread-map scan.
  */
 export function selectFloatingWorkspaceHasUnread(state: FloatingWorkspaceUnreadState): boolean {
-  const tabs = state.tabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID]
-  if (!tabs || tabs.length === 0) {
-    return false
+  const tabs = state.tabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? EMPTY_TABS
+  const cached = floatingWorkspaceUnreadCache
+  if (
+    cached &&
+    cached.tabs === tabs &&
+    cached.unreadTerminalTabs === state.unreadTerminalTabs &&
+    cached.unreadAgentCompletionPanes === state.unreadAgentCompletionPanes
+  ) {
+    return cached.hasUnread
   }
-  const floatingTabIds = new Set<string>()
-  for (const tab of tabs) {
-    if (state.unreadTerminalTabs[tab.id]) {
-      return true
+
+  let hasUnread = false
+  if (tabs.length > 0) {
+    const floatingTabIds = new Set<string>()
+    for (const tab of tabs) {
+      if (state.unreadTerminalTabs[tab.id]) {
+        hasUnread = true
+        break
+      }
+      floatingTabIds.add(tab.id)
     }
-    floatingTabIds.add(tab.id)
-  }
-  // paneKey is `${tabId}:${leafId}` and tabIds never contain ":", so the prefix
-  // up to the first ":" is the owning tab id.
-  for (const paneKey of Object.keys(state.unreadAgentCompletionPanes)) {
-    const separatorIndex = paneKey.indexOf(':')
-    const tabId = separatorIndex === -1 ? paneKey : paneKey.slice(0, separatorIndex)
-    if (floatingTabIds.has(tabId)) {
-      return true
+    if (!hasUnread) {
+      // paneKey is `${tabId}:${leafId}` and tabIds never contain ":", so the
+      // prefix up to the first ":" is the owning tab id.
+      for (const paneKey of Object.keys(state.unreadAgentCompletionPanes)) {
+        const separatorIndex = paneKey.indexOf(':')
+        const tabId = separatorIndex === -1 ? paneKey : paneKey.slice(0, separatorIndex)
+        if (floatingTabIds.has(tabId)) {
+          hasUnread = true
+          break
+        }
+      }
     }
   }
-  return false
+
+  floatingWorkspaceUnreadCache = {
+    tabs,
+    unreadTerminalTabs: state.unreadTerminalTabs,
+    unreadAgentCompletionPanes: state.unreadAgentCompletionPanes,
+    hasUnread
+  }
+  return hasUnread
+}
+
+export function resetFloatingWorkspaceUnreadSelectorCacheForTest(): void {
+  floatingWorkspaceUnreadCache = null
 }
 
 export function getAllWorktreesFromState(state: Pick<AppState, 'worktreesByRepo'>): Worktree[] {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​456 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​453 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​288 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​88 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​200 |

<!-- /orca-pr-loc -->

## Problem

Global Zustand writes rebuilt runtime-event host collections and subscription keys even when no runtime input changed. Paired-runtime parking also depended on the full runtime status map, and two always-mounted floating-workspace consumers repeated the same unread scans.

## Why

These subscribers and selectors sit on hot, app-wide store paths. Their work scaled with saved runtimes, terminal tabs, and unread maps, so unrelated local terminal, direct SSH, folder-workspace, and settings updates paid remote-host and UI projection costs.

## Solution

- Add an O(1) semantic reference gate for the runtime catalog, status map, nested runtime SSH state, and trimmed active runtime id before any host enumeration or key construction.
- Preserve the per-host connection generation, nested SSH generation, and pairing/runtime revision key so connect, disconnect, same-id re-pair, reconnect, and SSH invalidation still replace subscriptions.
- Coalesce disconnect-triggered nested SSH publication into one final-generation sync.
- Install the store listener before runtime streams start and explicitly resync replay invalidation when the module-level SSH generation advances without publishing a tracked store reference. Forced hydration failure cannot strand the replay generation.
- Structurally share paired-parking capability Sets and make per-worktree parking depend on capability membership rather than the full status map.
- Share one reference-keyed floating-workspace unread cache across its two always-mounted consumers.

## ELI5

Before, changing almost anything in the app made Orca recount every paired computer and recheck several UI lists. Now it first checks a few labels: if none changed, it stops immediately. If a runtime stream loses messages, Orca still replaces that one subscription even when there was no visible SSH bucket update to wake the store.

## Proof

- 4 focused test files, 87 tests passing.
- `pnpm run typecheck:web` passing.
- Deterministic coverage includes 1,000 unrelated writes across 100 runtime hosts with zero host enumerations/key builds.
- Connect, disconnect, re-pair, runtime generation, nested SSH generation, replay invalidation, no-publication stale buckets, and failed forced hydration are covered.
- Parking capability-stable status writes perform zero parking scans; membership changes rescan.
- Two floating unread consumers plus 1,000 unrelated writes share the cached scan.

## No regression

- Local daemon, direct SSH, paired runtime, folder-workspace, foreign/fail-open PTY, and mixed-version capability boundaries remain fail-closed and covered.
- Missing `terminal.paired-parking.v1` continues to keep paired PTYs mounted.
- Runtime subscription keys retain all existing generation and revision invalidation inputs.
- No mobile-facing surface changed.

## User tradeoffs

- One module-level cache entry is retained for each shared projection.
- A replay gap forces one SSH hydrate/resubscribe attempt so missed events cannot remain stale.
- Outside replay gaps and semantic input changes, the added path does zero broad work.

## Readiness and security

- CLEAN across all seven readiness reviews.
- Security review: P0/P1/P2 = 0.
- No new external input handling, permissions, persistence, or mobile-facing API.

## Readiness verdict

CLEAN — P0: 0, P1: 0, P2: 0.

## Residual risk

Residual risk is limited to network timing around runtime replay-gap recovery; generation guards reject stale callbacks, and the focused disconnect/replay/failed-hydration cases pass.
