### PR TITLE
perf(persistence): partition workspace sessions

### DIFF
--- a/src/main/orca-profiles/profile-persistence-deadline.ts
+++ b/src/main/orca-profiles/profile-persistence-deadline.ts
@@ -12,7 +12,13 @@ export async function flushActiveProfileBeforeFileMutation(store: Store): Promis
     }, PROFILE_PERSISTENCE_TIMEOUT_MS)
   })
   try {
-    await Promise.race([store.flushPendingOrThrowAsync({ signal: controller.signal }), deadline])
+    await Promise.race([
+      store.flushPendingOrThrowAsync({
+        signal: controller.signal,
+        syncCompatibilityProjection: true
+      }),
+      deadline
+    ])
   } finally {
     if (timeout) {
       clearTimeout(timeout)

--- a/src/main/orca-profiles/profile-project-state-file.ts
+++ b/src/main/orca-profiles/profile-project-state-file.ts
@@ -1,9 +1,8 @@
-import { randomUUID } from 'node:crypto'
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { dirname } from 'node:path'
 import { getDefaultPersistedState, getDefaultWorkspaceSession } from '../../shared/constants'
-import type { ExecutionHostId } from '../../shared/execution-host'
+import { normalizeExecutionHostId, type ExecutionHostId } from '../../shared/execution-host'
 import { projectHostSetupProjectionFromRepos } from '../../shared/project-host-setup-projection'
 import { carryProjectStateThroughIdentityChange } from '../../shared/project-identity-succession'
 import type { PersistedState } from '../../shared/persisted-state-types'
@@ -13,6 +12,11 @@ import type { WorkspaceSessionState } from '../../shared/workspace-session-state
 import type { SparsePreset } from '../../shared/worktree/create-types'
 import type { RetiredNameRegistry } from '../../shared/worktree/retired-name-registry'
 import { getOrcaProfileDataFile } from './profile-index-store'
+import {
+  readWorkspaceSessionSidecarsForProfile,
+  replaceWorkspaceSessionSidecarsSync
+} from '../persistence/loading-store/workspace-session-sidecar'
+import { durableWriteTempPath, writeFileDurableSync } from '../durable-file-write'
 
 export type TransferProfileState = PersistedState
 
@@ -35,7 +39,7 @@ export function readProfileState(profileId: string, userDataPath: string): Trans
     return structuredClone(defaults)
   }
   const parsed = JSON.parse(readFileSync(dataFile, 'utf-8')) as Partial<PersistedState>
-  return rebuildRepoBackedProjectState({
+  const state = rebuildRepoBackedProjectState({
     ...defaults,
     ...parsed,
     repos: arrayOrEmpty<Repo>(parsed.repos),
@@ -84,18 +88,69 @@ export function readProfileState(profileId: string, userDataPath: string): Trans
       ? parsed.featureInteractionTelemetryBuckets
       : defaults.featureInteractionTelemetryBuckets
   })
+  const embeddedHostIds = new Set<ExecutionHostId>()
+  if (isRecord(parsed.workspaceSessionsByHostId)) {
+    for (const rawHostId of Object.keys(parsed.workspaceSessionsByHostId)) {
+      const hostId = normalizeExecutionHostId(rawHostId)
+      if (hostId && hostId !== 'local') {
+        embeddedHostIds.add(hostId)
+      }
+    }
+  }
+  return {
+    ...state,
+    ...readWorkspaceSessionSidecarsForProfile({
+      dataFile,
+      workspaceSession: state.workspaceSession,
+      workspaceSessionsByHostId: state.workspaceSessionsByHostId,
+      embeddedLocalPresent: parsed.workspaceSession !== undefined,
+      embeddedHostIds,
+      embeddedPayloadPresent:
+        parsed.workspaceSession !== undefined || parsed.workspaceSessionsByHostId !== undefined,
+      embeddedGenerationByHostId: state.workspaceSessionSidecarGenerationByHostId,
+      replacementPending: state.workspaceSessionSidecarReplacementPending
+    })
+  }
+}
+export type ProfileStateWriteOptions = {
+  afterJournalWrite?: () => void
+  afterSidecarReplacement?: () => void
 }
 
 export function writeProfileState(
   profileId: string,
   userDataPath: string,
-  state: TransferProfileState
+  state: TransferProfileState,
+  options: ProfileStateWriteOptions = {}
 ): void {
   const dataFile = getOrcaProfileDataFile(profileId, userDataPath)
   mkdirSync(dirname(dataFile), { recursive: true })
-  const tmpPath = `${dataFile}.${process.pid}.${randomUUID()}.tmp`
-  writeFileSync(tmpPath, JSON.stringify(state, null, 2), 'utf-8')
-  renameSync(tmpPath, dataFile)
+  const writeCore = (coreState: TransferProfileState): void => {
+    writeFileDurableSync(
+      durableWriteTempPath(dataFile),
+      dataFile,
+      JSON.stringify(coreState, null, 2)
+    )
+  }
+  // Journal first: if sidecar publication or pruning stops halfway, the complete embedded
+  // projection remains authoritative and the next load repairs every partition.
+  writeCore({
+    ...state,
+    workspaceSessionSidecarGenerationByHostId: {},
+    workspaceSessionSidecarReplacementPending: true
+  })
+  options.afterJournalWrite?.()
+  const generations = replaceWorkspaceSessionSidecarsSync({
+    dataFile,
+    workspaceSession: state.workspaceSession,
+    workspaceSessionsByHostId: state.workspaceSessionsByHostId
+  })
+  options.afterSidecarReplacement?.()
+  writeCore({
+    ...state,
+    workspaceSessionSidecarGenerationByHostId: generations,
+    workspaceSessionSidecarReplacementPending: false
+  })
 }
 
 function isRepoBackedProjectHostSetup(

--- a/src/main/orca-profiles/profile-project-transfer.test.ts
+++ b/src/main/orca-profiles/profile-project-transfer.test.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
@@ -11,6 +11,10 @@ import type { PersistedState } from '../../shared/persisted-state-types'
 import type { Repo } from '../../shared/repo-types'
 import type { WorktreeMeta } from '../../shared/worktree/meta-types'
 import type { SshTarget } from '../../shared/ssh-types'
+import {
+  readProfileState as readHydratedProfileState,
+  writeProfileState as writeHydratedProfileState
+} from './profile-project-state-file'
 
 const testState = { dir: '' }
 
@@ -57,7 +61,7 @@ function writeProfileState(profileId: string, state: PersistedState): void {
 }
 
 function readProfileState(profileId: string): PersistedState {
-  return JSON.parse(readFileSync(profileDataPath(profileId), 'utf-8')) as PersistedState
+  return readHydratedProfileState(profileId, testState.dir)
 }
 
 function makeRepo(overrides: Partial<Repo> = {}): Repo {
@@ -323,5 +327,34 @@ describe('profile project transfer', () => {
       duplicateRepoId: 'repo-existing'
     })
     expect(readProfileState('work').repos.map((repo) => repo.id)).toEqual(['repo-existing'])
+  })
+  it('recovers the complete embedded transfer projection when sidecar publication is interrupted', () => {
+    const desired = makeState({
+      workspaceSession: {
+        ...getDefaultPersistedState('/Users/tester').workspaceSession,
+        activeRepoId: 'journal-local'
+      },
+      workspaceSessionsByHostId: {
+        'runtime:journal-host': {
+          ...getDefaultPersistedState('/Users/tester').workspaceSession,
+          activeRepoId: 'journal-remote'
+        }
+      }
+    })
+
+    expect(() =>
+      writeHydratedProfileState('work', testState.dir, desired, {
+        afterJournalWrite: () => {
+          throw new Error('injected transfer interruption')
+        }
+      })
+    ).toThrow('injected transfer interruption')
+
+    const recovered = readHydratedProfileState('work', testState.dir)
+    expect(recovered.workspaceSession.activeRepoId).toBe('journal-local')
+    expect(recovered.workspaceSessionsByHostId?.['runtime:journal-host']?.activeRepoId).toBe(
+      'journal-remote'
+    )
+    expect(recovered.workspaceSessionSidecarReplacementPending).toBe(true)
   })
 })

--- a/src/main/persistence-host-partitioned-sessions.test.ts
+++ b/src/main/persistence-host-partitioned-sessions.test.ts
@@ -134,10 +134,10 @@ describe('Store host-partitioned workspace sessions', () => {
     // The legacy blob is the 'local' partition; an explicit/default hostId reads it.
     expect(store.getWorkspaceSession().activeRepoId).toBe('legacy-repo')
     expect(store.getWorkspaceSession('local').activeRepoId).toBe('legacy-repo')
-    // No data was moved, so a downgrade still finds the legacy field intact.
     store.flush()
-    const persisted = readDataFile() as { workspaceSession?: { activeRepoId?: string } }
-    expect(persisted.workspaceSession?.activeRepoId).toBe('legacy-repo')
+    expect(readDataFile()).toHaveProperty('workspaceSession')
+    const reloaded = await createStore()
+    expect(reloaded.getWorkspaceSession('local').activeRepoId).toBe('legacy-repo')
   })
 
   it('is idempotent: re-loading already-partitioned state preserves all hosts', async () => {
@@ -419,7 +419,12 @@ describe('Store host-partitioned workspace sessions', () => {
     const store = await createStore()
     store.setWorkspaceSession(makeBoundHostSession(null), 'local')
     store.setWorkspaceSession(makeBoundHostSession(null), 'ssh:ssh-1')
-    const flush = vi.spyOn(store, 'flushOrThrow').mockImplementationOnce(() => {
+    const sidecars = (
+      store as unknown as {
+        workspaceSessionSidecars: { flushSync: (trigger?: string) => void }
+      }
+    ).workspaceSessionSidecars
+    const flush = vi.spyOn(sidecars, 'flushSync').mockImplementationOnce(() => {
       throw new Error('disk unavailable')
     })
 
@@ -441,6 +446,11 @@ describe('Store host-partitioned workspace sessions', () => {
     ).toBeNull()
     expect(
       store.getWorkspaceSession('local').tabsByWorktree['repo-1::/worktree'][0]?.ptyId
+    ).toBeNull()
+    store.freezeWrites()
+    const reloaded = await createStore()
+    expect(
+      reloaded.getWorkspaceSession('ssh:ssh-1').tabsByWorktree['repo-1::/worktree'][0]?.ptyId
     ).toBeNull()
   })
 
@@ -806,7 +816,17 @@ describe('Store host-partitioned workspace sessions', () => {
     // dirtied every load would otherwise leave those tests silently vacuous.
     await loadAndAwaitScheduledSave()
     expect(readFileSync(dataFile(), 'utf-8')).toBe(canonical)
-    return JSON.parse(canonical) as PersistedSessionsFile
+    const store = await createStore()
+    const workspaceSessionsByHostId: Record<string, WorkspaceSessionState> = {}
+    for (const hostId of store.getWorkspaceSessionHostIds()) {
+      if (hostId !== 'local') {
+        workspaceSessionsByHostId[hostId] = structuredClone(store.getWorkspaceSession(hostId))
+      }
+    }
+    return {
+      workspaceSession: structuredClone(store.getWorkspaceSession('local')),
+      workspaceSessionsByHostId
+    }
   }
 
   it('schedules a save for a salvaged local session instead of re-salvaging every launch', async () => {
@@ -835,10 +855,10 @@ describe('Store host-partitioned workspace sessions', () => {
       warn.mockRestore()
     }
 
-    const persisted = readDataFile() as PersistedSessionsFile
-    expect(persisted.workspaceSession?.tabsByWorktree?.[worktreeId]?.map((tab) => tab.id)).toEqual([
-      'tab-keep'
-    ])
+    const persisted = await createStore()
+    expect(
+      persisted.getWorkspaceSession('local').tabsByWorktree?.[worktreeId]?.map((tab) => tab.id)
+    ).toEqual(['tab-keep'])
   })
 
   it('schedules a save for salvaged host partitions', async () => {
@@ -868,14 +888,18 @@ describe('Store host-partitioned workspace sessions', () => {
     writeDataFile(profile)
     await loadAndAwaitScheduledSave()
 
-    const persisted = (readDataFile() as PersistedSessionsFile).workspaceSessionsByHostId
+    const persisted = await createStore()
     expect(
-      persisted?.['runtime:env-a']?.tabsByWorktree?.[worktreeId]?.map((tab) => tab.id)
+      persisted
+        .getWorkspaceSession('runtime:env-a')
+        .tabsByWorktree?.[worktreeId]?.map((tab) => tab.id)
     ).toEqual(['runtime-keep'])
-    expect(persisted?.['ssh:target-b']?.tabsByWorktree?.[worktreeId]?.map((tab) => tab.id)).toEqual(
-      ['ssh-keep']
-    )
-    expect(persisted).not.toHaveProperty('runtime:broken')
+    expect(
+      persisted
+        .getWorkspaceSession('ssh:target-b')
+        .tabsByWorktree?.[worktreeId]?.map((tab) => tab.id)
+    ).toEqual(['ssh-keep'])
+    expect(persisted.getWorkspaceSessionHostIds()).not.toContain('runtime:broken')
   })
 
   it('writes back sleeping-agent records dropped during salvage', async () => {
@@ -893,7 +917,7 @@ describe('Store host-partitioned workspace sessions', () => {
 
     await loadAndAwaitScheduledSave()
 
-    const persisted = readDataFile() as PersistedSessionsFile
-    expect(persisted.workspaceSession?.sleepingAgentSessionsByPaneKey).toBeUndefined()
+    const persisted = await createStore()
+    expect(persisted.getWorkspaceSession('local').sleepingAgentSessionsByPaneKey).toBeUndefined()
   })
 })

--- a/src/main/persistence-split-pane-incarnation.test.ts
+++ b/src/main/persistence-split-pane-incarnation.test.ts
@@ -348,7 +348,11 @@ describe('Store', () => {
       },
       terminalPtyIncarnationsByPaneKey: { [paneKey]: 'inc-stale' }
     })
-    vi.spyOn(store, 'flushOrThrow').mockImplementationOnce(() => {
+    const storeInternals = store as unknown as {
+      workspaceSessionSidecars: { flushSync: (trigger?: string) => void }
+    }
+    const sidecarStore = storeInternals.workspaceSessionSidecars
+    vi.spyOn(sidecarStore, 'flushSync').mockImplementationOnce(() => {
       throw new Error('disk full')
     })
 

--- a/src/main/persistence-test-harness.ts
+++ b/src/main/persistence-test-harness.ts
@@ -7,12 +7,13 @@ import type { Repo } from '../shared/repo-types'
 import type { TerminalTab } from '../shared/terminal-tab-types'
 import type { WorkspaceLineage, WorktreeLineage } from '../shared/worktree/lineage-types'
 import { folderWorkspaceKey, worktreeWorkspaceKey } from '../shared/workspace-scope'
+import type { StoreOptions } from './persistence/loading-store/store'
 
 // Shared mutable state so the electron mock can reference a per-test directory
 export const testState = { dir: '' }
 
 /** Reset modules and dynamically import Store so the data-file path picks up the current testState.dir */
-export async function createStore() {
+export async function createStore(options: StoreOptions = {}) {
   vi.resetModules()
   // Why here and not a per-file vi.mock('electron'): the data-file path resolves through
   // AppEnvironment now, and it must point at this test's dir rather than the global
@@ -20,7 +21,7 @@ export async function createStore() {
   installFakeAppEnvironment({ getPath: () => testState.dir })
   const { Store, initDataPath } = await import('./persistence')
   initDataPath()
-  return new Store()
+  return new Store(options)
 }
 
 export async function withPlatform<T>(platform: NodeJS.Platform, fn: () => Promise<T>): Promise<T> {

--- a/src/main/persistence-workspace-session-sidecars.test.ts
+++ b/src/main/persistence-workspace-session-sidecars.test.ts
@@ -1,0 +1,716 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from 'node:fs'
+import type * as NodeFs from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { getDefaultWorkspaceSession } from '../shared/constants'
+import type { WorkspaceSessionState } from '../shared/workspace-session-state-types'
+import { normalizeExecutionHostId, type ExecutionHostId } from '../shared/execution-host'
+import type * as NodeFsPromises from 'node:fs/promises'
+import { folderWorkspaceKey } from '../shared/workspace-scope'
+import {
+  WorkspaceSessionSidecarStore,
+  getWorkspaceSessionPartitionFile,
+  replaceWorkspaceSessionSidecarsSync,
+  type WorkspaceSessionPartitionTrace
+} from './persistence/loading-store/workspace-session-sidecar'
+import {
+  createStore,
+  dataFile,
+  makeTerminalTab,
+  readDataFile,
+  testState,
+  writeDataFile
+} from './persistence-test-harness'
+import { TEST_LEAF_1, makeSessionWithBrowserHistory } from './persistence-session-fixtures'
+import { flushActiveProfileBeforeFileMutation } from './orca-profiles/profile-persistence-deadline'
+
+const coreRenameGate = vi.hoisted(() => ({
+  release: null as Promise<void> | null,
+  started: null as (() => void) | null
+}))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFsPromises>()
+  return {
+    ...actual,
+    rename: async (source: NodeFs.PathLike, destination: NodeFs.PathLike) => {
+      if (
+        coreRenameGate.release &&
+        typeof destination === 'string' &&
+        destination.endsWith('/orca-data.json')
+      ) {
+        const release = coreRenameGate.release
+        coreRenameGate.release = null
+        coreRenameGate.started?.()
+        await release
+      }
+      return actual.rename(source, destination)
+    }
+  }
+})
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => testState.dir
+  },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (plaintext: string) => Buffer.from(`encrypted:${plaintext}`, 'utf-8'),
+    decryptString: (ciphertext: Buffer) => ciphertext.toString('utf-8').replace(/^encrypted:/, '')
+  }
+}))
+
+function session(activeRepoId: string): WorkspaceSessionState {
+  return { ...getDefaultWorkspaceSession(), activeRepoId }
+}
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void
+  const promise = new Promise<void>((next) => {
+    resolve = next
+  })
+  return { promise, resolve }
+}
+
+function delayNextCoreRename(): { release: () => void; started: Promise<void> } {
+  const release = deferred()
+  const started = deferred()
+  coreRenameGate.release = release.promise
+  coreRenameGate.started = started.resolve
+  return { release: release.resolve, started: started.promise }
+}
+function boundSession(repoId: string, worktreeId: string, tabId: string, ptyId: string) {
+  return {
+    ...session(repoId),
+    tabsByWorktree: {
+      [worktreeId]: [makeTerminalTab({ id: tabId, worktreeId, ptyId })]
+    },
+    terminalLayoutsByTabId: {
+      [tabId]: {
+        root: { type: 'leaf' as const, leafId: TEST_LEAF_1 },
+        activeLeafId: TEST_LEAF_1,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [TEST_LEAF_1]: ptyId }
+      }
+    }
+  }
+}
+
+function readPartition(hostId: ExecutionHostId): {
+  hostId: ExecutionHostId
+  writeGeneration: number
+  session: WorkspaceSessionState
+} {
+  return JSON.parse(
+    readFileSync(getWorkspaceSessionPartitionFile(dataFile(), hostId), 'utf-8')
+  ) as {
+    hostId: ExecutionHostId
+    writeGeneration: number
+    session: WorkspaceSessionState
+  }
+}
+
+describe('workspace session sidecars', () => {
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-session-sidecar-'))
+    coreRenameGate.release = null
+    coreRenameGate.started = null
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    rmSync(testState.dir, { recursive: true, force: true })
+  })
+
+  it('keeps an ordinary host patch off the core projection and serializes only that host', async () => {
+    const seed = await createStore()
+    seed.flush()
+
+    const serializedHosts: ExecutionHostId[] = []
+    const store = await createStore({
+      workspaceSessionSidecars: {
+        serialize: (value) => {
+          if (
+            !value ||
+            typeof value !== 'object' ||
+            !('hostId' in value) ||
+            typeof value.hostId !== 'string'
+          ) {
+            throw new Error('missing partition host id')
+          }
+          const hostId = normalizeExecutionHostId(value.hostId)
+          if (!hostId) {
+            throw new Error('invalid partition host id')
+          }
+          serializedHosts.push(hostId)
+          return JSON.stringify(value)
+        }
+      }
+    })
+    store.setWorkspaceSession(session('repo-a'), 'runtime:host-a')
+    store.setWorkspaceSession(session('repo-b'), 'ssh:host-b')
+    await store.flushPendingOrThrowAsync()
+    serializedHosts.length = 0
+
+    const buildStateToSave = vi.spyOn(
+      store as unknown as { buildStateToSave: () => unknown },
+      'buildStateToSave'
+    )
+    store.patchWorkspaceSession({ activeTabId: 'tab-a' }, 'runtime:host-a')
+    await store.waitForPendingWrite()
+
+    expect(buildStateToSave).not.toHaveBeenCalled()
+    expect(serializedHosts).toEqual(['runtime:host-a'])
+    expect(readPartition('runtime:host-a').session).toMatchObject({
+      activeRepoId: 'repo-a',
+      activeTabId: 'tab-a'
+    })
+    expect(readPartition('ssh:host-b').session.activeRepoId).toBe('repo-b')
+    buildStateToSave.mockRestore()
+    store.flush()
+    const core = readDataFile()
+    expect(core).toHaveProperty('workspaceSession')
+    expect(core).toHaveProperty('workspaceSessionsByHostId')
+  })
+
+  it('uses write generations so a patch racing a flush cannot install torn or stale state', async () => {
+    let injectConcurrentPatch = false
+    const traces: WorkspaceSessionPartitionTrace[] = []
+    let sidecars!: WorkspaceSessionSidecarStore
+    sidecars = new WorkspaceSessionSidecarStore(dataFile(), {
+      serialize: (value) => {
+        if (injectConcurrentPatch) {
+          injectConcurrentPatch = false
+          sidecars.markDirty('runtime:host-a', session('newest'), 'patch')
+        }
+        return JSON.stringify(value)
+      },
+      onTrace: (trace) => {
+        traces.push(trace)
+      }
+    })
+    sidecars.resolveForLoad({
+      workspaceSession: session('local'),
+      workspaceSessionsByHostId: {},
+      embeddedLocalPresent: false,
+      embeddedHostIds: new Set(),
+      embeddedPayloadPresent: false
+    })
+    sidecars.initialize(session('local'), {})
+    sidecars.markDirty('runtime:host-a', session('stale'), 'patch')
+    injectConcurrentPatch = true
+    await sidecars.flushPending({ drainToStableGeneration: true })
+
+    const installed = readPartition('runtime:host-a')
+    expect(installed.session.activeRepoId).toBe('newest')
+    expect(installed.writeGeneration).toBe(2)
+    expect(() =>
+      JSON.parse(
+        readFileSync(getWorkspaceSessionPartitionFile(dataFile(), 'runtime:host-a'), 'utf-8')
+      )
+    ).not.toThrow()
+    expect(traces.at(-1)).toMatchObject({
+      hostId: 'runtime:host-a',
+      partitionBytes: expect.any(Number),
+      durationMs: expect.any(Number),
+      trigger: 'patch',
+      writeGeneration: 2,
+      committed: true
+    })
+  })
+
+  it('bounds an ordinary flush to its captured generation under continuous churn', async () => {
+    let serializations = 0
+    let sidecars!: WorkspaceSessionSidecarStore
+    sidecars = new WorkspaceSessionSidecarStore(dataFile(), {
+      serialize: (value) => {
+        serializations++
+        sidecars.markDirty('runtime:churn', session(`newer-${serializations}`), 'patch')
+        return JSON.stringify(value)
+      }
+    })
+    sidecars.resolveForLoad({
+      workspaceSession: session('local'),
+      workspaceSessionsByHostId: {},
+      embeddedLocalPresent: false,
+      embeddedHostIds: new Set(),
+      embeddedPayloadPresent: false
+    })
+    sidecars.initialize(session('local'), {})
+    sidecars.markDirty('runtime:churn', session('captured'), 'patch')
+
+    await sidecars.flushPending({ drainToStableGeneration: false })
+
+    expect(serializations).toBe(1)
+    expect(readPartition('runtime:churn').session.activeRepoId).toBe('captured')
+    sidecars.freeze()
+  })
+
+  it('retries transient sidecar failures but bounds permanent failures', async () => {
+    let attempts = 0
+    const sidecars = new WorkspaceSessionSidecarStore(dataFile(), {
+      serialize: (value) => {
+        attempts++
+        if (attempts <= 2) {
+          throw new Error('transient disk failure')
+        }
+        return JSON.stringify(value)
+      }
+    })
+    sidecars.resolveForLoad({
+      workspaceSession: session('local'),
+      workspaceSessionsByHostId: {},
+      embeddedLocalPresent: false,
+      embeddedHostIds: new Set(),
+      embeddedPayloadPresent: false
+    })
+    sidecars.initialize(session('local'), {})
+    sidecars.markDirty('runtime:retry', session('retry-ok'), 'patch')
+    await sidecars.flushPending({ drainToStableGeneration: true })
+    expect(attempts).toBe(3)
+    expect(readPartition('runtime:retry').session.activeRepoId).toBe('retry-ok')
+    let permanentAttempts = 0
+
+    const permanent = new WorkspaceSessionSidecarStore(dataFile(), {
+      serialize: () => {
+        permanentAttempts++
+        throw new Error('permanent disk failure')
+      }
+    })
+    permanent.resolveForLoad({
+      workspaceSession: session('local'),
+      workspaceSessionsByHostId: {},
+      embeddedLocalPresent: false,
+      embeddedHostIds: new Set(),
+      embeddedPayloadPresent: false
+    })
+    permanent.initialize(session('local'), {})
+    permanent.markDirty('runtime:permanent', session('never-written'), 'patch')
+    await expect(permanent.flushPending({ drainToStableGeneration: true })).rejects.toThrow(
+      'permanent disk failure'
+    )
+    expect(permanentAttempts).toBe(6)
+    permanent.freeze()
+  })
+
+  it('round-trips a supported rollback through the embedded compatibility projection', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      workspaceSession: session('local-legacy'),
+      workspaceSessionsByHostId: {
+        'runtime:host-a': session('remote-legacy')
+      }
+    })
+
+    const store = await createStore()
+    await store.flushPendingOrThrowAsync()
+
+    expect(readPartition('local').session.activeRepoId).toBe('local-legacy')
+    expect(readPartition('runtime:host-a').session.activeRepoId).toBe('remote-legacy')
+    const rollbackCore = readDataFile() as {
+      workspaceSession: WorkspaceSessionState
+      workspaceSessionsByHostId: Record<ExecutionHostId, WorkspaceSessionState>
+      workspaceSessionSidecarGenerationByHostId?: unknown
+    }
+    rollbackCore.workspaceSession.activeRepoId = 'rollback-local'
+    rollbackCore.workspaceSessionsByHostId['runtime:host-a'].activeRepoId = 'rollback-remote'
+    delete rollbackCore.workspaceSessionSidecarGenerationByHostId
+    writeDataFile(rollbackCore)
+
+    const returned = await createStore()
+    expect(returned.getWorkspaceSession('local').activeRepoId).toBe('rollback-local')
+    expect(returned.getWorkspaceSession('runtime:host-a').activeRepoId).toBe('rollback-remote')
+    await returned.flushPendingOrThrowAsync()
+    expect(readPartition('local').session.activeRepoId).toBe('rollback-local')
+    expect(readPartition('runtime:host-a').session.activeRepoId).toBe('rollback-remote')
+  })
+
+  it('keeps a newer sidecar when an old build rewrites an unchanged embedded projection', async () => {
+    writeDataFile({
+      schemaVersion: 1,
+      workspaceSession: session('local-v1'),
+      workspaceSessionsByHostId: {
+        'runtime:host-a': session('remote-v1')
+      }
+    })
+
+    const store = await createStore()
+    await store.flushPendingOrThrowAsync({ syncCompatibilityProjection: true })
+    const oldBuildCore = readDataFile() as {
+      workspaceSessionSidecarGenerationByHostId?: unknown
+    }
+
+    store.patchWorkspaceSession({ activeRepoId: 'remote-v2' }, 'runtime:host-a')
+    await store.flushPendingOrThrowAsync()
+    expect(readPartition('runtime:host-a').session.activeRepoId).toBe('remote-v2')
+
+    // A rollback build can preserve the embedded payload byte-for-byte while dropping
+    // sidecar metadata it does not understand. That must not look like an intentional edit.
+    delete oldBuildCore.workspaceSessionSidecarGenerationByHostId
+    writeDataFile(oldBuildCore)
+
+    const returned = await createStore()
+    expect(returned.getWorkspaceSession('runtime:host-a').activeRepoId).toBe('remote-v2')
+  })
+
+  it('leaves embedded data intact when its migration cannot become durable', async () => {
+    writeDataFile({ schemaVersion: 1, workspaceSession: session('must-survive') })
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const store = await createStore({
+      workspaceSessionSidecars: {
+        serialize: () => {
+          throw new Error('disk unavailable')
+        }
+      }
+    })
+    await expect(store.flushPendingOrThrowAsync()).rejects.toThrow('disk unavailable')
+    const persisted = readDataFile()
+    expect(
+      persisted && typeof persisted === 'object' && 'workspaceSession' in persisted
+        ? persisted.workspaceSession
+        : undefined
+    ).toMatchObject({ activeRepoId: 'must-survive' })
+    expect(error).toHaveBeenCalled()
+  })
+
+  it('recovers corrupt and missing primaries from per-host backups without crossing hosts', async () => {
+    const sidecars = new WorkspaceSessionSidecarStore(dataFile())
+    sidecars.resolveForLoad({
+      workspaceSession: session('local'),
+      workspaceSessionsByHostId: {},
+      embeddedLocalPresent: false,
+      embeddedHostIds: new Set(),
+      embeddedPayloadPresent: false
+    })
+    sidecars.initialize(session('local'), {})
+    sidecars.markDirty('runtime:corrupt', session('corrupt-backup'), 'replace')
+    sidecars.markDirty('ssh:missing', session('missing-backup'), 'replace')
+    await sidecars.flushPending()
+    sidecars.markDirty('runtime:corrupt', session('corrupt-newer'), 'replace')
+    sidecars.markDirty('ssh:missing', session('missing-newer'), 'replace')
+    await sidecars.flushPending()
+
+    writeFileSync(getWorkspaceSessionPartitionFile(dataFile(), 'runtime:corrupt'), '{', 'utf-8')
+    unlinkSync(getWorkspaceSessionPartitionFile(dataFile(), 'ssh:missing'))
+    const recovered = new WorkspaceSessionSidecarStore(dataFile()).resolveForLoad({
+      workspaceSession: session('local'),
+      workspaceSessionsByHostId: {},
+      embeddedLocalPresent: false,
+      embeddedHostIds: new Set(),
+      embeddedPayloadPresent: false
+    })
+
+    expect(recovered.workspaceSessionsByHostId['runtime:corrupt']?.activeRepoId).toBe(
+      'corrupt-backup'
+    )
+    expect(recovered.workspaceSessionsByHostId['ssh:missing']?.activeRepoId).toBe('missing-backup')
+    expect(recovered.workspaceSession.activeRepoId).toBe('local')
+  })
+
+  it('prunes removed host files only after replacement sidecars are durable', () => {
+    replaceWorkspaceSessionSidecarsSync({
+      dataFile: dataFile(),
+      workspaceSession: session('local'),
+      workspaceSessionsByHostId: {
+        'runtime:keep': session('keep'),
+        'ssh:remove': session('remove')
+      }
+    })
+    replaceWorkspaceSessionSidecarsSync({
+      dataFile: dataFile(),
+      workspaceSession: session('local-next'),
+      workspaceSessionsByHostId: { 'runtime:keep': session('keep-next') }
+    })
+
+    expect(readPartition('runtime:keep').session.activeRepoId).toBe('keep-next')
+    expect(() => readPartition('ssh:remove')).toThrow()
+  })
+
+  it('prefers valid newer sidecars when the core profile is restored from a stale backup', async () => {
+    writeDataFile({ schemaVersion: 1, workspaceSession: session('stale-core') })
+    const store = await createStore()
+    await store.flushPendingOrThrowAsync()
+    const staleCore = readFileSync(dataFile(), 'utf-8')
+
+    store.patchWorkspaceSession({ activeRepoId: 'newer-sidecar' }, 'local')
+    await store.waitForPendingWrite()
+    store.freezeWrites()
+    writeFileSync(`${dataFile()}.bak.0`, staleCore, 'utf-8')
+    writeFileSync(dataFile(), '{', 'utf-8')
+
+    const restored = await createStore()
+    expect(restored.getWorkspaceSession('local').activeRepoId).toBe('newer-sidecar')
+  })
+
+  it('propagates identity, folder removal, and group cascade mutations to sidecars', async () => {
+    const store = await createStore()
+    const group = store.createProjectGroup({
+      name: 'Folder group',
+      parentPath: '/workspace/folders',
+      createdFrom: 'folder-scan'
+    })
+    const workspace = store.createFolderWorkspace({
+      projectGroupId: group.id,
+      name: 'Folder workspace'
+    })
+    const folderKey = folderWorkspaceKey(workspace.id)
+    store.setWorkspaceSession({
+      ...session('local'),
+      tabsByWorktree: {
+        [folderKey]: [makeTerminalTab({ id: 'folder-tab', worktreeId: folderKey })]
+      }
+    })
+    await store.flushPendingOrThrowAsync()
+    store.removeFolderWorkspace(workspace.id)
+    await store.waitForPendingWrite()
+    expect(readPartition('local').session.tabsByWorktree[folderKey]).toBeUndefined()
+
+    const cascadeGroup = store.createProjectGroup({
+      name: 'Cascade group',
+      parentPath: '/workspace/cascade',
+      createdFrom: 'folder-scan'
+    })
+    const cascade = store.createFolderWorkspace({
+      projectGroupId: cascadeGroup.id,
+      name: 'Cascade workspace'
+    })
+    const cascadeKey = folderWorkspaceKey(cascade.id)
+    store.patchWorkspaceSession({
+      tabsByWorktree: {
+        [cascadeKey]: [makeTerminalTab({ id: 'cascade-tab', worktreeId: cascadeKey })]
+      }
+    })
+    await store.flushPendingOrThrowAsync()
+    store.deleteProjectGroup(cascadeGroup.id)
+    await store.waitForPendingWrite()
+    expect(readPartition('local').session.tabsByWorktree[cascadeKey]).toBeUndefined()
+
+    const oldWorktreeId = 'repo::/workspace/old'
+    const newWorktreeId = 'repo::/workspace/new'
+    const oldSession = {
+      ...session('repo'),
+
+      tabsByWorktree: {
+        [oldWorktreeId]: [makeTerminalTab({ id: 'rename-tab', worktreeId: oldWorktreeId })]
+      }
+    }
+    store.setWorkspaceSession(structuredClone(oldSession), 'local')
+    store.setWorkspaceSession(structuredClone(oldSession), 'runtime:rename-host')
+    await store.flushPendingOrThrowAsync()
+    store.migrateWorktreeIdentity(oldWorktreeId, newWorktreeId)
+    await store.waitForPendingWrite()
+
+    expect(readPartition('local').session.tabsByWorktree[newWorktreeId]).toHaveLength(1)
+    expect(readPartition('runtime:rename-host').session.tabsByWorktree[newWorktreeId]).toHaveLength(
+      1
+    )
+    store.flush()
+  })
+
+  it('rewrites sidecars when load-time pane normalization changes their session state', async () => {
+    const worktreeId = 'repo::/workspace/legacy-pane'
+    const legacySession: WorkspaceSessionState = {
+      ...session('repo'),
+      tabsByWorktree: {
+        [worktreeId]: [makeTerminalTab({ id: 'legacy-tab', worktreeId, ptyId: 'legacy-pty' })]
+      },
+      terminalLayoutsByTabId: {
+        'legacy-tab': {
+          root: { type: 'leaf', leafId: 'pane:1' },
+          activeLeafId: 'pane:1',
+          expandedLeafId: null,
+          ptyIdsByLeafId: { 'pane:1': 'legacy-pty' }
+        }
+      }
+    }
+    writeDataFile({ schemaVersion: 1 })
+    replaceWorkspaceSessionSidecarsSync({
+      dataFile: dataFile(),
+      workspaceSession: legacySession
+    })
+
+    await createStore()
+
+    const root = readPartition('local').session.terminalLayoutsByTabId['legacy-tab']?.root
+    expect(root?.type === 'leaf' ? root.leafId : null).not.toBe('pane:1')
+  })
+
+  it('republishes load-time host-session pruning to its sidecar', async () => {
+    writeDataFile({ schemaVersion: 1 })
+    replaceWorkspaceSessionSidecarsSync({
+      dataFile: dataFile(),
+      workspaceSession: session('local'),
+      workspaceSessionsByHostId: {
+        'runtime:history': makeSessionWithBrowserHistory(500)
+      }
+    })
+
+    const store = await createStore()
+    await store.waitForPendingWrite()
+    expect(store.getWorkspaceSession('runtime:history').browserUrlHistory).toHaveLength(200)
+
+    expect(readPartition('runtime:history').session.browserUrlHistory).toHaveLength(200)
+  })
+  it('does not rewrite normalized histories on many-host startup and republishes only one change', async () => {
+    const seed = await createStore()
+    const hostIds = Array.from({ length: 8 }, (_, index) => `runtime:history-${index}` as const)
+    for (const hostId of hostIds) {
+      seed.setWorkspaceSession(makeSessionWithBrowserHistory(3), hostId)
+    }
+    await seed.flushPendingOrThrowAsync({ syncCompatibilityProjection: true })
+    const canonicalizer = await createStore()
+    await canonicalizer.waitForPendingWrite()
+    const canonicalCore = readFileSync(dataFile(), 'utf-8')
+    const generations = Object.fromEntries(
+      hostIds.map((hostId) => [hostId, readPartition(hostId).writeGeneration])
+    )
+
+    const cleanReload = await createStore()
+    await cleanReload.waitForPendingWrite()
+    expect(readFileSync(dataFile(), 'utf-8')).toBe(canonicalCore)
+    for (const hostId of hostIds) {
+      expect(readPartition(hostId).writeGeneration).toBe(generations[hostId])
+    }
+
+    const external = new WorkspaceSessionSidecarStore(dataFile())
+    external.resolveForLoad({
+      workspaceSession: session('local'),
+      workspaceSessionsByHostId: {},
+      embeddedLocalPresent: false,
+      embeddedHostIds: new Set(),
+      embeddedPayloadPresent: false
+    })
+    external.markDirty(hostIds[3], makeSessionWithBrowserHistory(500), 'patch')
+    external.flushSync()
+    const changedGeneration = readPartition(hostIds[3]).writeGeneration
+
+    const migrated = await createStore()
+    await migrated.waitForPendingWrite()
+    expect(readPartition(hostIds[3]).writeGeneration).toBe(changedGeneration + 1)
+    for (const hostId of hostIds.filter((hostId) => hostId !== hostIds[3])) {
+      expect(readPartition(hostId).writeGeneration).toBe(generations[hostId])
+    }
+  })
+  it('persists lease and target binding cleanup to only the affected host sidecars', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(boundSession('local', 'local-wt', 'local-tab', 'local-pty'), 'local')
+    store.setWorkspaceSession(
+      boundSession('ssh-a', 'ssh-a-wt', 'ssh-a-tab', 'ssh-a-pty'),
+      'ssh:ssh-a'
+    )
+    store.setWorkspaceSession(
+      boundSession('ssh-b', 'ssh-b-wt', 'ssh-b-tab', 'ssh-b-pty'),
+      'ssh:ssh-b'
+    )
+    for (const [targetId, worktreeId, tabId, ptyId] of [
+      ['ssh-a', 'ssh-a-wt', 'ssh-a-tab', 'ssh-a-pty'],
+      ['ssh-b', 'ssh-b-wt', 'ssh-b-tab', 'ssh-b-pty']
+    ] as const) {
+      store.upsertSshRemotePtyLease({
+        targetId,
+        ptyId,
+        worktreeId,
+        tabId,
+        leafId: TEST_LEAF_1,
+        state: 'detached'
+      })
+    }
+    await store.flushPendingOrThrowAsync()
+
+    store.removeSshRemotePtyLease('ssh-a', 'ssh-a-pty')
+    store.removeSshRemotePtyLeases('ssh-b')
+    await store.flushPendingOrThrowAsync()
+
+    const reloaded = await createStore()
+    expect(
+      reloaded.getWorkspaceSession('ssh:ssh-a').terminalLayoutsByTabId['ssh-a-tab'].ptyIdsByLeafId
+    ).toEqual({})
+    expect(
+      reloaded.getWorkspaceSession('ssh:ssh-b').terminalLayoutsByTabId['ssh-b-tab'].ptyIdsByLeafId
+    ).toEqual({})
+    expect(
+      reloaded.getWorkspaceSession('local').terminalLayoutsByTabId['local-tab'].ptyIdsByLeafId
+    ).toEqual({ [TEST_LEAF_1]: 'local-pty' })
+  })
+
+  it('reassigns and prunes an SSH host sidecar without disturbing other hosts', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(session('local-stable'), 'local')
+    store.setWorkspaceSession(session('old-host'), 'ssh:ssh-old')
+    store.setWorkspaceSession(session('other-host'), 'ssh:ssh-other')
+    await store.flushPendingOrThrowAsync()
+
+    store.patchWorkspaceSession({ activeTabId: 'latest-old' }, 'ssh:ssh-old')
+    store.reassignSshTargetId('ssh-old', 'ssh-new')
+    await flushActiveProfileBeforeFileMutation(store)
+    store.freezeWrites()
+
+    expect(() => readPartition('ssh:ssh-old')).toThrow()
+    expect(readPartition('ssh:ssh-new').session).toMatchObject({
+      activeRepoId: 'old-host',
+      activeTabId: 'latest-old'
+    })
+    const reloaded = await createStore()
+    expect(reloaded.getWorkspaceSession('ssh:ssh-new').activeTabId).toBe('latest-old')
+    expect(reloaded.getWorkspaceSession('ssh:ssh-other').activeRepoId).toBe('other-host')
+    expect(reloaded.getWorkspaceSession('local').activeRepoId).toBe('local-stable')
+  })
+
+  it('profile-transfer barrier retries when a session changes during its core rename', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(session('profile-v0'), 'runtime:host-a')
+    await store.flushPendingOrThrowAsync({ syncCompatibilityProjection: true })
+
+    const rename = delayNextCoreRename()
+    store.patchWorkspaceSession({ activeRepoId: 'profile-v1' }, 'runtime:host-a')
+    const barrier = flushActiveProfileBeforeFileMutation(store)
+    await rename.started
+
+    store.patchWorkspaceSession({ activeRepoId: 'profile-v2' }, 'runtime:host-a')
+    rename.release()
+    await barrier
+    store.freezeWrites()
+
+    const core = readDataFile() as {
+      workspaceSessionsByHostId: Record<ExecutionHostId, WorkspaceSessionState>
+    }
+    expect(core.workspaceSessionsByHostId['runtime:host-a'].activeRepoId).toBe('profile-v2')
+    expect(readPartition('runtime:host-a').session.activeRepoId).toBe('profile-v2')
+  })
+
+  it('quit retries after a pre-quit session patch races an in-flight core rename', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(session('quit-v0'), 'runtime:host-a')
+    await store.flushPendingOrThrowAsync({ syncCompatibilityProjection: true })
+
+    const rename = delayNextCoreRename()
+    store.updateSettings({ branchPrefix: 'none' })
+    const staleCoreWrite = store.flushPendingOrThrowAsync()
+    await rename.started
+
+    store.patchWorkspaceSession({ activeRepoId: 'quit-v1' }, 'runtime:host-a')
+    const quit = store.flushAsync()
+    rename.release()
+    await staleCoreWrite
+    await quit
+
+    const core = readDataFile() as {
+      workspaceSessionsByHostId: Record<ExecutionHostId, WorkspaceSessionState>
+    }
+    expect(core.workspaceSessionsByHostId['runtime:host-a'].activeRepoId).toBe('quit-v1')
+    expect(readPartition('runtime:host-a').session.activeRepoId).toBe('quit-v1')
+  })
+  it('quit and profile-switch barriers resolve only after the latest sidecar is readable', async () => {
+    const seed = await createStore()
+    seed.flush()
+    const store = await createStore()
+    store.patchWorkspaceSession({ activeRepoId: 'profile-switch' }, 'runtime:host-a')
+
+    await store.flushPendingOrThrowAsync()
+    expect(readPartition('runtime:host-a').session.activeRepoId).toBe('profile-switch')
+
+    store.patchWorkspaceSession({ activeRepoId: 'quit' }, 'runtime:host-a')
+    await store.flushAsync()
+    expect(readPartition('runtime:host-a').session.activeRepoId).toBe('quit')
+  })
+})

--- a/src/main/persistence/leasing-ssh-ptys/ssh-pty-binding-cleanup.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-pty-binding-cleanup.ts
@@ -7,6 +7,7 @@ export type SshPtyBindingCleanupOperations = {
   state: StoreOwnedPersistedState
   toComparablePtyId: (targetId: string, ptyId: string) => string
   scheduleSave: () => void
+  workspaceSessionPartitionsChanged: (hostIds: ReadonlySet<string>) => void
 }
 
 function sshRemotePtyLeaseMayReferenceBinding(
@@ -51,13 +52,18 @@ export function clearSshRemotePtyBindingsForLeases(
     return false
   }
   let changed = false
-  const sessions = new Set(
-    [
-      operations.state.workspaceSession,
-      operations.state.workspaceSessionsByHostId?.[toSshExecutionHostId(targetId)]
-    ].filter((session): session is WorkspaceSessionState => Boolean(session))
+  const changedHostIds = new Set<string>()
+  const sessions = [
+    { hostId: 'local', session: operations.state.workspaceSession },
+    {
+      hostId: toSshExecutionHostId(targetId),
+      session: operations.state.workspaceSessionsByHostId?.[toSshExecutionHostId(targetId)]
+    }
+  ].filter((entry): entry is { hostId: string; session: WorkspaceSessionState } =>
+    Boolean(entry.session)
   )
-  for (const session of sessions) {
+  for (const { hostId, session } of sessions) {
+    let sessionChanged = false
     for (const [worktreeId, tabs] of Object.entries(session.tabsByWorktree ?? {})) {
       for (const tab of tabs) {
         if (
@@ -73,6 +79,7 @@ export function clearSshRemotePtyBindingsForLeases(
         ) {
           tab.ptyId = null
           changed = true
+          sessionChanged = true
         }
       }
     }
@@ -107,10 +114,15 @@ export function clearSshRemotePtyBindingsForLeases(
       if (Object.keys(nextBindings).length !== Object.keys(bindings).length) {
         layout.ptyIdsByLeafId = nextBindings
         changed = true
+        sessionChanged = true
       }
+    }
+    if (sessionChanged) {
+      changedHostIds.add(hostId)
     }
   }
   if (changed) {
+    operations.workspaceSessionPartitionsChanged(changedHostIds)
     operations.scheduleSave()
   }
   return changed

--- a/src/main/persistence/leasing-ssh-ptys/ssh-pty-consumer-recovery.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-pty-consumer-recovery.ts
@@ -7,6 +7,7 @@ import { normalizeSshPtyConsumerRecovery } from './ssh-normalization'
 export type SshPtyConsumerRecoveryOperations = {
   state: StoreOwnedPersistedState
   protectedSecrets: Pick<ProtectedSecretPersistence, 'isSealed' | 'removeRetainedBlob'>
+  scheduleSave: () => void
   flushDurableStateOrThrowAsync: () => Promise<void>
 }
 
@@ -51,6 +52,7 @@ export async function upsertSshPtyConsumerRecovery(
     ...recoveries.filter((candidate) => candidate.targetId !== normalized.targetId),
     normalized
   ]
+  operations.scheduleSave()
   await flushSshPtyConsumerRecovery(operations)
 }
 
@@ -65,5 +67,6 @@ export async function removeSshPtyConsumerRecovery(
   }
   operations.state.sshPtyConsumerRecoveries = next
   operations.protectedSecrets.removeRetainedBlob(sshPtyOwnerLeaseSecretSlot(targetId))
+  operations.scheduleSave()
   await flushSshPtyConsumerRecovery(operations)
 }

--- a/src/main/persistence/leasing-ssh-ptys/ssh-pty-lease-operations.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-pty-lease-operations.ts
@@ -8,6 +8,7 @@ export type SshPtyLeaseOperations = {
   toStoredPtyId: (targetId: string, ptyId: string) => string
   clearBindingsForTarget: (targetId: string) => void
   clearBindingsForLeases: (targetId: string, leases: SshRemotePtyLease[]) => boolean
+  scheduleSave: () => void
   flush: () => void
   flushDurableStateOrThrowAsync: () => Promise<void>
 }
@@ -54,6 +55,7 @@ export function upsertSshRemotePtyLease(
   } else {
     operations.state.sshRemotePtyLeases.push(next)
   }
+  operations.scheduleSave()
   operations.flush()
 }
 
@@ -104,6 +106,7 @@ export function markSshRemotePtyLeases(
   state: SshRemotePtyLease['state']
 ): void {
   if (updateSshRemotePtyLeaseStates(operations, targetId, state)) {
+    operations.scheduleSave()
     operations.flush()
   }
 }
@@ -125,6 +128,7 @@ export async function markSshRemotePtyLeasesAsync(
   state: SshRemotePtyLease['state']
 ): Promise<void> {
   if (updateSshRemotePtyLeaseStates(operations, targetId, state)) {
+    operations.scheduleSave()
     await operations.flushDurableStateOrThrowAsync()
   }
 }
@@ -136,6 +140,7 @@ export async function markSshRemotePtyLeasesAttachedAsync(
 ): Promise<void> {
   const relayPtyIds = new Set(ptyIds.map((ptyId) => operations.toStoredPtyId(targetId, ptyId)))
   if (updateSshRemotePtyLeaseStates(operations, targetId, 'attached', relayPtyIds)) {
+    operations.scheduleSave()
     await operations.flushDurableStateOrThrowAsync()
   }
 }
@@ -156,6 +161,7 @@ export function markSshRemotePtyLease(
   const shouldClearBindings = state === 'terminated' || state === 'expired'
   if (lease.state === state) {
     if (shouldClearBindings && operations.clearBindingsForLeases(targetId, [lease])) {
+      operations.scheduleSave()
       operations.flush()
     }
     return
@@ -171,6 +177,7 @@ export function markSshRemotePtyLease(
   if (shouldClearBindings) {
     operations.clearBindingsForLeases(targetId, [lease])
   }
+  operations.scheduleSave()
   operations.flush()
 }
 
@@ -189,6 +196,7 @@ export function removeSshRemotePtyLease(
     (lease) => lease.targetId !== targetId || lease.ptyId !== relayPtyId
   )
   if (operations.state.sshRemotePtyLeases.length !== before) {
+    operations.scheduleSave()
     operations.flush()
   }
 }
@@ -204,6 +212,7 @@ export function removeSshRemotePtyLeases(
     (lease) => lease.targetId !== targetId
   )
   if (operations.state.sshRemotePtyLeases.length !== before) {
+    operations.scheduleSave()
     operations.flush()
   }
 }

--- a/src/main/persistence/leasing-ssh-ptys/ssh-target-reassignment.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-target-reassignment.ts
@@ -17,6 +17,11 @@ export type SshTargetReassignmentOperations = {
   protectedSecrets: Pick<ProtectedSecretPersistence, 'removeRetainedBlob'>
   syncProjectHostSetupCompatibilityState: () => void
   scheduleSave: () => void
+  workspaceSessionPartitionsReassigned: (
+    oldHostId: string,
+    newHostId: string,
+    changedHostIds: ReadonlySet<string>
+  ) => void
 }
 
 /** Retirement namespaces key on the endpoint a target reaches, so a rotation moves them only when
@@ -83,14 +88,21 @@ export function reassignSshTargetId(
     }
   }
   // Why: any carrier still holding the old id later throws `SSH target not found` (STA-1468); migrate them all.
+  const changedSessionHostIds = new Set<string>()
   let carrierChanged = migrateWorkspaceSessionSshTargetId(
     operations.state.workspaceSession,
     oldTargetId,
     newTargetId
   )
-  for (const session of Object.values(operations.state.workspaceSessionsByHostId ?? {})) {
+  if (carrierChanged) {
+    changedSessionHostIds.add('local')
+  }
+  for (const [hostId, session] of Object.entries(
+    operations.state.workspaceSessionsByHostId ?? {}
+  )) {
     if (session && migrateWorkspaceSessionSshTargetId(session, oldTargetId, newTargetId)) {
       carrierChanged = true
+      changedSessionHostIds.add(hostId)
     }
   }
   // Why: partitions are read by host id; re-key from the removed id to the new one (keep new if it already exists).
@@ -100,6 +112,8 @@ export function reassignSshTargetId(
     delete partitions[oldHostId]
     partitions[newHostId] ??= oldPartition
     carrierChanged = true
+    changedSessionHostIds.delete(oldHostId)
+    changedSessionHostIds.add(newHostId)
   }
   if (migrateUiHostScopeSshTargetId(operations.state.ui, oldTargetId, newTargetId)) {
     carrierChanged = true
@@ -148,6 +162,7 @@ export function reassignSshTargetId(
   if (repoIds.size > 0 || setupsChanged) {
     operations.syncProjectHostSetupCompatibilityState()
   }
+  operations.workspaceSessionPartitionsReassigned(oldHostId, newHostId, changedSessionHostIds)
   if (repoIds.size > 0 || metaChanged || carrierChanged || setupsChanged) {
     operations.scheduleSave()
   }

--- a/src/main/persistence/leasing-ssh-ptys/ssh-target-state.ts
+++ b/src/main/persistence/leasing-ssh-ptys/ssh-target-state.ts
@@ -107,6 +107,7 @@ export function addClaudeLivePtySessionId(
   operations.state.claudeLivePtySessionIds = [...ids, sessionId].slice(
     -MAX_CLAUDE_LIVE_PTY_SESSION_IDS
   )
+  operations.scheduleSave()
   // Why: flush sync so a force-quit right after a Claude spawn still seeds the live-PTY gate next launch.
   operations.flush()
 }

--- a/src/main/persistence/loading-store/store.ts
+++ b/src/main/persistence/loading-store/store.ts
@@ -2617,6 +2617,7 @@ export class Store {
     return {
       state: this.state,
       flush: () => this.flush(),
+      scheduleSave: () => this.scheduleSave(),
       recordCreated: () => this.recordFeatureInteraction('automation-created')
     }
   }
@@ -2625,6 +2626,7 @@ export class Store {
     return {
       state: this.state,
       flush: () => this.flush(),
+      scheduleSave: () => this.scheduleSave(),
       recordManualRun: () => this.recordFeatureInteraction('automation-run'),
       getWorkspaceDisplayName: (workspaceId) =>
         this.getAutomationRunWorkspaceDisplayName(workspaceId)

--- a/src/main/persistence/loading-store/store.ts
+++ b/src/main/persistence/loading-store/store.ts
@@ -3856,6 +3856,7 @@ export class Store {
     return {
       state: this.state,
       protectedSecrets: this.protectedSecrets,
+      scheduleSave: () => this.scheduleSave(),
       flushDurableStateOrThrowAsync: () => this.flushDurableStateOrThrowAsync()
     }
   }
@@ -3909,6 +3910,7 @@ export class Store {
           targetId,
           leases
         ),
+      scheduleSave: () => this.scheduleSave(),
       flush: () => this.flush(),
       flushDurableStateOrThrowAsync: () => this.flushDurableStateOrThrowAsync()
     }

--- a/src/main/persistence/loading-store/store.ts
+++ b/src/main/persistence/loading-store/store.ts
@@ -3601,6 +3601,9 @@ export class Store {
       this.markWorkspaceSessionPartitionDirty(resolvedHostId, 'pty-binding')
       try {
         this.workspaceSessionSidecars.flushSync('pty-binding')
+        if (!existsSync(this.dataFile)) {
+          this.flushOrThrow()
+        }
       } catch (err) {
         restoreSession()
         try {
@@ -3655,6 +3658,9 @@ export class Store {
     this.markWorkspaceSessionPartitionDirty(resolvedHostId, 'pty-binding')
     try {
       this.workspaceSessionSidecars.flushSync('pty-binding')
+      if (!existsSync(this.dataFile)) {
+        this.flushOrThrow()
+      }
     } catch (err) {
       restoreSession()
       try {

--- a/src/main/persistence/loading-store/store.ts
+++ b/src/main/persistence/loading-store/store.ts
@@ -201,6 +201,12 @@ import {
 } from '../leasing-ssh-ptys/secret-validation'
 import { getDataFile, getGithubCacheFile, readGithubCacheSnapshot } from './user-data-path'
 import {
+  WorkspaceSessionSidecarStore,
+  workspaceSessionHash,
+  type WorkspaceSessionSidecarOptions,
+  type WorkspaceSessionPartitionWriteTrigger
+} from './workspace-session-sidecar'
+import {
   STALE_DURABLE_WRITE_TEMP_AGE_MS,
   gcStaleWorktreeMeta,
   normalizeWorktreeLinkedItemMetadata
@@ -362,6 +368,10 @@ import { ProjectHostSetupPersistenceOperations } from '../tracking-repos/project
 // Why (issue #1158): keep 5 rolling backups at >=1h spacing so a corrupt/empty write leaves an earlier copy recoverable.
 const BACKUP_COUNT = 5
 const BACKUP_MIN_INTERVAL_MS = 60 * 60 * 1000
+const loadMigratedSessionHostIdsByState = new WeakMap<
+  PersistedState,
+  ReadonlySet<ExecutionHostId>
+>()
 const WORKSPACE_SESSION_PATCH_FULL_NORMALIZATION_KEYS = new Set<keyof WorkspaceSessionState>([
   'tabsByWorktree',
   'terminalLayoutsByTabId'
@@ -393,8 +403,8 @@ function workspaceSessionSalvageLogDetails(result: {
   }
 }
 
-/** Normalize non-'local' host partitions; 'local' (the legacy workspaceSession blob) is dropped so the two surfaces never diverge.
- *  Each partition is zod-validated independently, so one corrupt host drops to defaults without taking out the others. Idempotent. */
+/** Normalize legacy embedded non-local partitions; 'local' is read from the separate legacy field.
+ *  Each partition is zod-validated independently, so one corrupt host drops to defaults without taking out the others. */
 function parseWorkspaceSessionsByHostId(
   raw: unknown,
   defaults: WorkspaceSessionState
@@ -498,6 +508,7 @@ function deleteRemovedTerminalScrollbackSnapshots(
 
 export type StoreOptions = {
   dataFile?: string
+  workspaceSessionSidecars?: WorkspaceSessionSidecarOptions
 }
 
 export type PtyBindingSourceExpectation = {
@@ -513,6 +524,7 @@ export class Store {
   private readonly state: PersistedState
   private readonly dataFile: string
   private readonly activeViewPreference: ActiveViewPreference
+  private readonly workspaceSessionSidecars: WorkspaceSessionSidecarStore
   private readonly terminalScrollbackSnapshotStorage: TerminalScrollbackSnapshotStorage
   private writeTimer: ReturnType<typeof setTimeout> | null = null
   private pendingWrite: Promise<void> | null = null
@@ -529,7 +541,9 @@ export class Store {
   private quitFlushPromise: Promise<void> | null = null
   // Content hash at last write, to skip no-op writes; derived from the payload with encrypted blobs normalized back to plaintext (see buildStateToSave), since encrypt() uses a random IV per call.
   private lastWrittenStateHash: string | null = null
-  private lastDurableWriteGeneration = -1
+  private lastDurableWriteGeneration = 0
+  private sessionCompatibilityGeneration = 0
+  private lastCoreSessionCompatibilityGeneration = 0
   private firstPendingSaveAt: number | null = null
   private githubCacheDirty = false
   private githubCacheGeneration = 0
@@ -538,6 +552,7 @@ export class Store {
   private readonly gitUsernameCache = new Map<string, string>()
   private readonly protectedSecrets = new ProtectedSecretPersistence()
   private loadNeedsSave = false
+  private coreRestoredFromBackup = false
   private settingsChangeListeners = new Set<
     (
       updates: Partial<GlobalSettings>,
@@ -550,6 +565,16 @@ export class Store {
   constructor(options: StoreOptions = {}) {
     // Why: profile switching yields multiple state paths; capture per Store so late async writes can't follow a global path.
     this.dataFile = options.dataFile ?? getDataFile()
+    if (!existsSync(this.dataFile)) {
+      this.lastDurableWriteGeneration = -1
+    }
+    this.workspaceSessionSidecars = new WorkspaceSessionSidecarStore(this.dataFile, {
+      ...options.workspaceSessionSidecars,
+      onTrace: (trace) => {
+        options.workspaceSessionSidecars?.onTrace?.(trace)
+        logPersistenceStartupMilestone('persistence-session-partition-write', trace)
+      }
+    })
     this.staleTempCleanup = removeStaleDurableWriteTempFiles(this.dataFile, {
       minimumAgeMs: STALE_DURABLE_WRITE_TEMP_AGE_MS
     })
@@ -565,12 +590,44 @@ export class Store {
     }
     const loaded = this.load()
     const normalized = normalizePersistedPaneIdentityState(loaded)
+    const normalizedSessionHostIds = new Set<ExecutionHostId>(
+      loadMigratedSessionHostIdsByState.get(loaded)
+    )
+    if (loaded.workspaceSession !== normalized.state.workspaceSession) {
+      normalizedSessionHostIds.add(LOCAL_EXECUTION_HOST_ID)
+    }
+    for (const [rawHostId, session] of Object.entries(
+      normalized.state.workspaceSessionsByHostId ?? {}
+    )) {
+      const hostId = normalizeExecutionHostId(rawHostId)
+      if (hostId && session !== loaded.workspaceSessionsByHostId?.[hostId]) {
+        normalizedSessionHostIds.add(hostId)
+      }
+    }
     this.state = normalized.state
     // Why: activeView is a frequent, tiny preference; keeping it beside the
     // profile avoids serializing the multi-MB recovery store on navigation.
     this.activeViewPreference = new ActiveViewPreference(this.dataFile, this.state.ui?.activeView)
     const adaptedProjectGroups = this.adaptFlatFolderScanProjectGroups()
     this.hydrateFolderWorkspaceDiffComments()
+    this.workspaceSessionSidecars.initialize(
+      this.state.workspaceSession,
+      this.state.workspaceSessionsByHostId,
+      normalizedSessionHostIds
+    )
+    const durableSessionGenerations = this.workspaceSessionSidecars.getDurableGenerationByHostId()
+    const persistedSessionGenerations = this.state.workspaceSessionSidecarGenerationByHostId ?? {}
+    if (
+      this.state.workspaceSessionSidecarReplacementPending === true ||
+      Object.keys(durableSessionGenerations).length !==
+        Object.keys(persistedSessionGenerations).length ||
+      Object.entries(durableSessionGenerations).some(([rawHostId, generation]) => {
+        const hostId = normalizeExecutionHostId(rawHostId)
+        return !hostId || persistedSessionGenerations[hostId] !== generation
+      })
+    ) {
+      this.loadNeedsSave = true
+    }
     for (const entry of normalized.migrationUnsupportedEntries) {
       setMigrationUnsupportedPty(entry)
     }
@@ -794,6 +851,7 @@ export class Store {
         const raw = readFileSync(path, 'utf-8')
         JSON.parse(raw)
         mkdirSync(dirname(dataFile), { recursive: true })
+        this.coreRestoredFromBackup = true
         writeFileSync(dataFile, raw, 'utf-8')
         console.warn(`[persistence] Recovered state from backup slot ${i}: ${path}`)
         return true
@@ -813,6 +871,9 @@ export class Store {
     })
 
     let result: PersistedState | null = null
+    let embeddedSessionPayloadPresent = false
+    let embeddedLocalSessionPresent = false
+    const embeddedSessionHostIds = new Set<ExecutionHostId>()
     try {
       if (fileExistedOnLoad) {
         const readStartedAt = performance.now()
@@ -823,6 +884,21 @@ export class Store {
         })
         logPersistenceStartupMilestone('persistence-json-parse-start')
         const parsed = JSON.parse(raw) as PersistedState
+        embeddedLocalSessionPresent = parsed.workspaceSession !== undefined
+        embeddedSessionPayloadPresent =
+          embeddedLocalSessionPresent || parsed.workspaceSessionsByHostId !== undefined
+        if (
+          parsed.workspaceSessionsByHostId &&
+          typeof parsed.workspaceSessionsByHostId === 'object' &&
+          !Array.isArray(parsed.workspaceSessionsByHostId)
+        ) {
+          for (const rawHostId of Object.keys(parsed.workspaceSessionsByHostId)) {
+            const hostId = normalizeExecutionHostId(rawHostId)
+            if (hostId && hostId !== LOCAL_EXECUTION_HOST_ID) {
+              embeddedSessionHostIds.add(hostId)
+            }
+          }
+        }
         logPersistenceStartupMilestone('persistence-json-parse-done')
 
         // Why: secrets are stored encrypted via safeStorage; decrypt at the load boundary so the app sees plaintext.
@@ -1499,7 +1575,8 @@ export class Store {
             }
             return { ...defaults.workspaceSession, ...result.value }
           })(),
-          // Why: per-host session partitions, validated independently; 'local' stays in workspaceSession for downgrade compat.
+          // Why: validate legacy embedded host partitions independently before sidecars resolve
+          // the newest mixed-version copy.
           workspaceSessionsByHostId: (() => {
             const { partitions, repaired } = parseWorkspaceSessionsByHostId(
               parsed.workspaceSessionsByHostId,
@@ -1511,6 +1588,10 @@ export class Store {
             }
             return partitions
           })(),
+          workspaceSessionSidecarGenerationByHostId:
+            parsed.workspaceSessionSidecarGenerationByHostId ?? {},
+          workspaceSessionSidecarReplacementPending:
+            parsed.workspaceSessionSidecarReplacementPending === true,
           sshTargets: (parsed.sshTargets ?? []).map(normalizeSshTarget),
           deletedSshConfigAliases: Array.isArray(parsed.deletedSshConfigAliases)
             ? parsed.deletedSshConfigAliases.filter(
@@ -1571,11 +1652,50 @@ export class Store {
     }
 
     if (result === null) {
+      if (fileExistedOnLoad) {
+        this.loadNeedsSave = true
+      }
       result = getDefaultPersistedState(homedir())
     }
-
+    const loadedSessionPartitions = this.workspaceSessionSidecars.resolveForLoad({
+      workspaceSession: result.workspaceSession,
+      workspaceSessionsByHostId: result.workspaceSessionsByHostId,
+      embeddedLocalPresent: embeddedLocalSessionPresent,
+      embeddedHostIds: embeddedSessionHostIds,
+      embeddedPayloadPresent: embeddedSessionPayloadPresent,
+      embeddedGenerationByHostId: result.workspaceSessionSidecarGenerationByHostId,
+      coreRestoredFromBackup: this.coreRestoredFromBackup,
+      replacementPending: result.workspaceSessionSidecarReplacementPending
+    })
+    result = {
+      ...result,
+      ...loadedSessionPartitions
+    }
+    const resolvedWorkspaceSessionHash = workspaceSessionHash(
+      loadedSessionPartitions.workspaceSession
+    )
+    const resolvedWorkspaceSessionHashesByHostId = Object.fromEntries(
+      Object.entries(loadedSessionPartitions.workspaceSessionsByHostId).map(([hostId, session]) => [
+        hostId,
+        session ? workspaceSessionHash(session) : null
+      ])
+    )
+    const loadMigratedSessionHostIds = new Set<ExecutionHostId>()
     const workspaceSession = pruneWorkspaceSessionBrowserHistory(
       pruneLocalTerminalScrollbackBuffers(result.workspaceSession, result.repos)
+    )
+    if (workspaceSession !== result.workspaceSession) {
+      loadMigratedSessionHostIds.add(LOCAL_EXECUTION_HOST_ID)
+    }
+    result.workspaceSessionsByHostId = Object.fromEntries(
+      Object.entries(result.workspaceSessionsByHostId ?? {}).map(([rawHostId, session]) => {
+        const pruned = session ? pruneWorkspaceSessionBrowserHistory(session) : session
+        const hostId = normalizeExecutionHostId(rawHostId)
+        if (hostId && pruned !== session) {
+          loadMigratedSessionHostIds.add(hostId)
+        }
+        return [rawHostId, pruned]
+      })
     )
     const migratedScrollback = migrateWorkspaceSessionTerminalScrollbackSnapshots(
       workspaceSession,
@@ -1641,6 +1761,21 @@ export class Store {
     } else {
       migrated.githubCache = readGithubCacheSnapshot(this.dataFile) ?? migrated.githubCache
     }
+
+    if (workspaceSessionHash(migrated.workspaceSession) !== resolvedWorkspaceSessionHash) {
+      loadMigratedSessionHostIds.add(LOCAL_EXECUTION_HOST_ID)
+    }
+    for (const [rawHostId, session] of Object.entries(migrated.workspaceSessionsByHostId ?? {})) {
+      const hostId = normalizeExecutionHostId(rawHostId)
+      if (
+        hostId &&
+        session &&
+        workspaceSessionHash(session) !== resolvedWorkspaceSessionHashesByHostId[hostId]
+      ) {
+        loadMigratedSessionHostIds.add(hostId)
+      }
+    }
+    loadMigratedSessionHostIdsByState.set(migrated, loadMigratedSessionHostIds)
 
     logPersistenceStartupMilestone('persistence-load-done', {
       repos: migrated.repos.length,
@@ -1757,13 +1892,22 @@ export class Store {
 
   /** Wait for any in-flight async disk write to complete. Used in tests. */
   async waitForPendingWrite(): Promise<void> {
-    await Promise.all([this.pendingWrite, this.activeViewPreference.waitForPendingWrite()])
+    await Promise.all([
+      this.pendingWrite,
+      this.workspaceSessionSidecars.waitForPendingWrite(),
+      this.activeViewPreference.waitForPendingWrite()
+    ])
   }
 
-  // Why githubCache is omitted: memory-only this session (see getGithubCacheFile), so refreshes never touch the durable file.
+  // The rollback-compatible core projection is synchronized on the ordinary core debounce; sidecars remain the hot-path authority.
   private getDurableState(): Omit<PersistedState, 'githubCache'> {
     const { githubCache: _memoryOnly, ...durable } = this.state
-    return durable
+    return {
+      ...durable,
+      workspaceSessionSidecarGenerationByHostId:
+        this.workspaceSessionSidecars.getDurableGenerationByHostId(),
+      workspaceSessionSidecarReplacementPending: false
+    }
   }
 
   // Why: build payload synchronously so hash and bytes reflect one state tick. A degraded prefix makes the first healthy retry durable even when plaintext state is unchanged.
@@ -1868,10 +2012,27 @@ export class Store {
     if (this.writesFrozen) {
       return
     }
+    await this.workspaceSessionSidecars.flushPending({
+      drainToStableGeneration: true,
+      trigger: 'flush'
+    })
+    if (!this.workspaceSessionSidecars.isCoreCleanupReady()) {
+      throw new Error('Workspace session migration is not durable')
+    }
     const gen = this.writeGeneration
+    const compatibilityGeneration = this.sessionCompatibilityGeneration
+    const coreProjectionHashes = this.workspaceSessionSidecars.captureCoreProjectionHashes(
+      this.state.workspaceSession,
+      this.state.workspaceSessionsByHostId
+    )
     const { payload, stateHash, protectedSecretUpdates } = this.buildStateToSave()
     // Why: don't rewrite a byte-identical multi-MB file when state nets out to already-persisted.
     if (stateHash === this.lastWrittenStateHash) {
+      this.lastCoreSessionCompatibilityGeneration = Math.max(
+        this.lastCoreSessionCompatibilityGeneration,
+        compatibilityGeneration
+      )
+      this.workspaceSessionSidecars.commitCoreProjectionHashes(coreProjectionHashes)
       this.lastDurableWriteGeneration = Math.max(this.lastDurableWriteGeneration, gen)
       return
     }
@@ -1917,6 +2078,16 @@ export class Store {
       }
       if (renamed) {
         this.lastDurableWriteGeneration = Math.max(this.lastDurableWriteGeneration, gen)
+        this.lastCoreSessionCompatibilityGeneration = Math.max(
+          this.lastCoreSessionCompatibilityGeneration,
+          compatibilityGeneration
+        )
+        this.workspaceSessionSidecars.commitCoreProjectionHashes(coreProjectionHashes)
+        if (this.sessionCompatibilityGeneration > compatibilityGeneration) {
+          this.workspaceSessionSidecars.refreshPartitionsNewerThanCoreProjection(
+            coreProjectionHashes
+          )
+        }
       }
     } finally {
       if (!renamed) {
@@ -1938,9 +2109,23 @@ export class Store {
     if (this.writesFrozen) {
       return
     }
+    this.workspaceSessionSidecars.flushSync('flush')
+    if (!this.workspaceSessionSidecars.isCoreCleanupReady()) {
+      throw new Error('Workspace session migration is not durable')
+    }
+    const compatibilityGeneration = this.sessionCompatibilityGeneration
+    const coreProjectionHashes = this.workspaceSessionSidecars.captureCoreProjectionHashes(
+      this.state.workspaceSession,
+      this.state.workspaceSessionsByHostId
+    )
     const { payload, stateHash, protectedSecretUpdates } = this.buildStateToSave()
     // Why: matching hash means the file already holds this state; force overrides when an async rename may be racing past the gen check.
     if (!opts.force && stateHash === this.lastWrittenStateHash) {
+      this.lastCoreSessionCompatibilityGeneration = Math.max(
+        this.lastCoreSessionCompatibilityGeneration,
+        compatibilityGeneration
+      )
+      this.workspaceSessionSidecars.commitCoreProjectionHashes(coreProjectionHashes)
       return
     }
     const dataFile = this.dataFile
@@ -1963,6 +2148,11 @@ export class Store {
         this.lastDurableWriteGeneration,
         this.writeGeneration
       )
+      this.lastCoreSessionCompatibilityGeneration = Math.max(
+        this.lastCoreSessionCompatibilityGeneration,
+        compatibilityGeneration
+      )
+      this.workspaceSessionSidecars.commitCoreProjectionHashes(coreProjectionHashes)
     } finally {
       if (!renamed) {
         try {
@@ -1982,14 +2172,30 @@ export class Store {
     if (this.quitFlushStarted) {
       throw new Error('Cannot synchronously flush after final persistence has started')
     }
+    this.workspaceSessionSidecars.flushSync('flush')
+    if (
+      this.lastCoreSessionCompatibilityGeneration < this.sessionCompatibilityGeneration &&
+      this.lastDurableWriteGeneration >= this.writeGeneration
+    ) {
+      this.writeGeneration++
+    }
+    const coreWritePending =
+      this.writeTimer !== null ||
+      this.pendingWrite !== null ||
+      this.lastDurableWriteGeneration < this.writeGeneration
     if (this.writeTimer) {
       clearTimeout(this.writeTimer)
       this.writeTimer = null
     }
     this.firstPendingSaveAt = null
+    if (!coreWritePending) {
+      return
+    }
     const asyncWriteWasInFlight = this.pendingWrite !== null
     // Why: bump writeGeneration so an in-flight async write skips its rename and can't overwrite this sync write.
-    this.writeGeneration++
+    if (asyncWriteWasInFlight) {
+      this.writeGeneration++
+    }
     if (this.inFlightAsyncTmpFile) {
       try {
         unlinkSync(this.inFlightAsyncTmpFile)
@@ -2107,6 +2313,8 @@ export class Store {
     this.projectGroupOperations ??= new ProjectGroupPersistenceOperations({
       state: this.state,
       scheduleSave: () => this.scheduleSave(),
+      workspaceSessionChanged: () =>
+        this.markWorkspaceSessionPartitionDirty(LOCAL_EXECUTION_HOST_ID, 'prune'),
       removeWorkspaceLineageForFolderParent: (folderWorkspaceId) =>
         this.removeWorkspaceLineageForFolderParent(folderWorkspaceId),
       pruneMobileClientTabSelections: (matchesWorktreeId) =>
@@ -2142,6 +2350,8 @@ export class Store {
     this.folderWorkspaceOperations ??= new FolderWorkspacePersistenceOperations({
       state: this.state,
       scheduleSave: () => this.scheduleSave(),
+      workspaceSessionChanged: () =>
+        this.markWorkspaceSessionPartitionDirty(LOCAL_EXECUTION_HOST_ID, 'prune'),
       removeWorkspaceLineageForFolderParent: (folderWorkspaceId) =>
         this.removeWorkspaceLineageForFolderParent(folderWorkspaceId),
       pruneMobileClientTabSelections: (matchesWorktreeId) =>
@@ -2215,6 +2425,7 @@ export class Store {
       this.state.workspaceSessionsByHostId,
       id
     )
+    this.markAllWorkspaceSessionPartitionsDirty('prune')
     this.scheduleSave()
   }
 
@@ -2238,6 +2449,7 @@ export class Store {
         this.state.workspaceSessionsByHostId,
         id
       )
+      this.markAllWorkspaceSessionPartitionsDirty('prune')
     } else if (parseExecutionHostId(hostId)?.kind === 'runtime') {
       const session = this.state.workspaceSessionsByHostId?.[hostId]
       if (session) {
@@ -2245,6 +2457,7 @@ export class Store {
           ...this.state.workspaceSessionsByHostId,
           [hostId]: removeRepoFromWorkspaceSession(session, id)
         }
+        this.markWorkspaceSessionPartitionDirty(hostId, 'prune')
       }
     }
     this.scheduleSave()
@@ -2591,6 +2804,7 @@ export class Store {
    */
   migrateWorktreeIdentity(oldWorktreeId: string, newWorktreeId: string): void {
     if (migrateWorktreeIdentityOperation(this.state, oldWorktreeId, newWorktreeId)) {
+      this.markAllWorkspaceSessionPartitionsDirty('replace')
       this.scheduleSave()
     }
   }
@@ -2771,6 +2985,24 @@ export class Store {
   private resolveHostId(hostId?: string | null): ExecutionHostId {
     return normalizeExecutionHostId(hostId) ?? LOCAL_EXECUTION_HOST_ID
   }
+  private markWorkspaceSessionPartitionDirty(
+    hostId: ExecutionHostId,
+    trigger: WorkspaceSessionPartitionWriteTrigger
+  ): void {
+    if (this.quitFlushStarted) {
+      return
+    }
+    this.workspaceSessionSidecars.markDirty(hostId, this.getWorkspaceSession(hostId), trigger)
+    this.sessionCompatibilityGeneration++
+  }
+
+  private markAllWorkspaceSessionPartitionsDirty(
+    trigger: WorkspaceSessionPartitionWriteTrigger
+  ): void {
+    for (const hostId of this.getWorkspaceSessionHostIds()) {
+      this.markWorkspaceSessionPartitionDirty(hostId, trigger)
+    }
+  }
 
   getWorkspaceSession(hostId?: string | null): PersistedState['workspaceSession'] {
     const resolved = this.resolveHostId(hostId)
@@ -2851,7 +3083,7 @@ export class Store {
         [resolved]: session
       }
     }
-    this.scheduleSave()
+    this.markWorkspaceSessionPartitionDirty(resolved, 'prune')
   }
 
   /** Whether a partition still holds terminal membership for `worktreeId`. */
@@ -2895,7 +3127,7 @@ export class Store {
       ...this.state.workspaceSessionsByHostId,
       [hostId]: pruned
     }
-    this.scheduleSave()
+    this.markWorkspaceSessionPartitionDirty(hostId, 'replace')
   }
 
   private setLocalWorkspaceSession(
@@ -2903,6 +3135,7 @@ export class Store {
     deferSnapshotFiles = false
   ): void {
     const prior = this.state.workspaceSession
+    let coreStateChanged = false
     session = sanitizeWorkspaceSessionTerminalRetirements(session, prior)
     session = pruneWorkspaceSessionBrowserHistory(
       pruneLocalTerminalScrollbackBuffers(session, this.state.repos)
@@ -2925,6 +3158,7 @@ export class Store {
         ...this.state.ui,
         acknowledgedAgentsByPaneKey: remappedAcknowledgements.acknowledgements
       }
+      coreStateChanged = true
     }
     for (const entry of normalized.legacyPaneKeyAliasEntries) {
       registerPersistedPaneKeyAlias(entry)
@@ -2940,6 +3174,7 @@ export class Store {
     )
     if (remappedLeases.changed) {
       this.state.sshRemotePtyLeases = remappedLeases.leases
+      coreStateChanged = true
     }
     if (session && prior) {
       const priorTabs = prior.tabsByWorktree ?? {}
@@ -3049,7 +3284,10 @@ export class Store {
     if (deferSnapshotFiles) {
       this.enqueueTerminalScrollbackSnapshotWork(prior, session)
     }
-    this.scheduleSave()
+    this.markWorkspaceSessionPartitionDirty(LOCAL_EXECUTION_HOST_ID, 'replace')
+    if (coreStateChanged) {
+      this.scheduleSave()
+    }
   }
 
   private enqueueTerminalScrollbackSnapshotWork(
@@ -3077,6 +3315,7 @@ export class Store {
           this.state.workspaceSession === staged ? migrated : this.state.workspaceSession
         if (this.state.workspaceSession === staged) {
           this.state.workspaceSession = migrated
+          this.markWorkspaceSessionPartitionDirty(LOCAL_EXECUTION_HOST_ID, 'snapshot')
         } else if (current) {
           await deleteRemovedTerminalScrollbackSnapshotsAsync(
             migrated,
@@ -3125,7 +3364,7 @@ export class Store {
         [resolved]: next
       }
     }
-    this.scheduleSave()
+    this.markWorkspaceSessionPartitionDirty(resolved, 'patch')
   }
 
   private getTerminalLayoutLeafIds(root: TerminalPaneLayoutNode | null): Set<string> {
@@ -3313,6 +3552,7 @@ export class Store {
           [resolvedHostId]: sessionBeforeBinding
         }
       }
+      this.markWorkspaceSessionPartitionDirty(resolvedHostId, 'pty-binding')
     }
     if (args.incarnationId) {
       session.terminalPtyIncarnationsByPaneKey = {
@@ -3356,10 +3596,16 @@ export class Store {
     if (!isTerminalLeafId(args.leafId)) {
       // Why: keep legacy renderer-local pane ids out of durable leaf-keyed layout state after the UUID migration.
       advanceTopologyFence()
+      this.markWorkspaceSessionPartitionDirty(resolvedHostId, 'pty-binding')
       try {
-        this.flushOrThrow()
+        this.workspaceSessionSidecars.flushSync('pty-binding')
       } catch (err) {
         restoreSession()
+        try {
+          this.workspaceSessionSidecars.flushSync('pty-binding')
+        } catch {
+          // Preserve the original persistence error; restored state remains dirty for retry.
+        }
         throw err
       }
       return true
@@ -3404,10 +3650,16 @@ export class Store {
       }
     }
     advanceTopologyFence()
+    this.markWorkspaceSessionPartitionDirty(resolvedHostId, 'pty-binding')
     try {
-      this.flushOrThrow()
+      this.workspaceSessionSidecars.flushSync('pty-binding')
     } catch (err) {
       restoreSession()
+      try {
+        this.workspaceSessionSidecars.flushSync('pty-binding')
+      } catch {
+        // Preserve the original persistence error; restored state remains dirty for retry.
+      }
       throw err
     }
     return true
@@ -3570,9 +3822,32 @@ export class Store {
       state: this.state,
       protectedSecrets: this.protectedSecrets,
       syncProjectHostSetupCompatibilityState: () => this.syncProjectHostSetupCompatibilityState(),
-      scheduleSave: () => this.scheduleSave()
+      scheduleSave: () => this.scheduleSave(),
+      workspaceSessionPartitionsReassigned: (oldHostId, newHostId, changedHostIds) => {
+        this.state.workspaceSessionSidecarReplacementPending = true
+        this.scheduleSave()
+        this.flushOrThrow()
+        const normalizedOldHostId = normalizeExecutionHostId(oldHostId)
+        const normalizedNewHostId = normalizeExecutionHostId(newHostId)
+        if (normalizedOldHostId && normalizedNewHostId) {
+          this.workspaceSessionSidecars.reassignHostPartition(
+            normalizedOldHostId,
+            normalizedNewHostId,
+            this.state.workspaceSessionsByHostId?.[normalizedNewHostId]
+          )
+        }
+        for (const rawHostId of changedHostIds) {
+          const hostId = normalizeExecutionHostId(rawHostId)
+          if (hostId && hostId !== normalizedOldHostId && hostId !== normalizedNewHostId) {
+            this.markWorkspaceSessionPartitionDirty(hostId, 'replace')
+          }
+        }
+        this.state.workspaceSessionSidecarReplacementPending = false
+      }
     }
-    return reassignSshTargetIdOperation(operations, oldTargetId, newTargetId)
+    const reassigned = reassignSshTargetIdOperation(operations, oldTargetId, newTargetId)
+    this.flushOrThrow()
+    return reassigned
   }
 
   // ── SSH PTY Consumer Recovery ──────────────────────────────────────
@@ -3607,7 +3882,15 @@ export class Store {
       state: this.state,
       toComparablePtyId: (targetId, ptyId) =>
         this.getRelayPtyIdForSshLeaseComparison(targetId, ptyId),
-      scheduleSave: () => this.scheduleSave()
+      scheduleSave: () => this.scheduleSave(),
+      workspaceSessionPartitionsChanged: (hostIds) => {
+        for (const rawHostId of hostIds) {
+          const hostId = normalizeExecutionHostId(rawHostId)
+          if (hostId) {
+            this.markWorkspaceSessionPartitionDirty(hostId, 'pty-binding')
+          }
+        }
+      }
     }
   }
 
@@ -3717,7 +4000,19 @@ export class Store {
       return this.quitFlushPromise
     }
     this.quitFlushStarted = true
-    this.quitFlushPromise = this.flushCurrentStateAsync(true).catch(() => {})
+    const pendingSnapshotFileWork = this.pendingSnapshotFileWork
+    this.quitFlushPromise = (async () => {
+      await pendingSnapshotFileWork
+      if (pendingSnapshotFileWork) {
+        this.workspaceSessionSidecars.markDirty(
+          LOCAL_EXECUTION_HOST_ID,
+          this.state.workspaceSession,
+          'snapshot'
+        )
+      }
+      this.workspaceSessionSidecars.beginFinalFlush()
+      await this.flushCurrentStateAsync(true)
+    })().catch(() => {})
     return this.quitFlushPromise
   }
 
@@ -3727,12 +4022,22 @@ export class Store {
   }
 
   flushPendingOrThrowAsync(
-    options: { signal?: AbortSignal; drainToStableGeneration?: boolean } = {}
+    options: {
+      signal?: AbortSignal
+      drainToStableGeneration?: boolean
+      syncCompatibilityProjection?: boolean
+    } = {}
   ): Promise<void> {
     if (this.writesFrozen || this.quitFlushStarted) {
       return Promise.reject(new Error('Cannot flush while persistence is finalized'))
     }
-    return this.flushCurrentStateAsync(false, options.signal, options.drainToStableGeneration, true)
+    return this.flushCurrentStateAsync(
+      false,
+      options.signal,
+      options.drainToStableGeneration,
+      true,
+      options.syncCompatibilityProjection
+    )
   }
 
   // Async twin of flushOrThrow: durable state only. Active-view and GitHub sidecars are
@@ -3747,8 +4052,11 @@ export class Store {
         this.writeTimer = null
       }
       this.firstPendingSaveAt = null
+      await this.workspaceSessionSidecars.flushPending({ drainToStableGeneration: true })
       const generation = this.writeGeneration
-      await this.enqueueWrite()
+      if (this.lastDurableWriteGeneration < generation || this.pendingWrite !== null) {
+        await this.enqueueWrite()
+      }
       if (generation === this.writeGeneration) {
         break
       }
@@ -3759,7 +4067,8 @@ export class Store {
     final: boolean,
     signal?: AbortSignal,
     drainToStableGeneration = true,
-    requireInitialGenerationDurable = false
+    requireInitialGenerationDurable = false,
+    syncCompatibilityProjection = false
   ): Promise<void> {
     const requiredDurableGeneration = requireInitialGenerationDurable ? this.writeGeneration : null
     for (;;) {
@@ -3771,9 +4080,24 @@ export class Store {
         this.writeTimer = null
       }
       this.firstPendingSaveAt = null
-      const generation = this.writeGeneration
+      let generation = this.writeGeneration
       try {
-        await this.enqueueWrite()
+        await this.workspaceSessionSidecars.flushPending({
+          signal,
+          drainToStableGeneration,
+          trigger: final ? 'quit' : 'flush'
+        })
+        if (
+          (final || syncCompatibilityProjection) &&
+          this.lastCoreSessionCompatibilityGeneration < this.sessionCompatibilityGeneration &&
+          this.lastDurableWriteGeneration >= this.writeGeneration
+        ) {
+          this.writeGeneration++
+        }
+        generation = this.writeGeneration
+        if (this.lastDurableWriteGeneration < generation || this.pendingWrite !== null) {
+          await this.enqueueWrite()
+        }
       } catch (error) {
         await (final
           ? this.activeViewPreference.flushAsync()
@@ -3797,7 +4121,10 @@ export class Store {
         }
         continue
       }
-      if (generation === this.writeGeneration) {
+      const compatibilityProjectionCurrent =
+        !(final || syncCompatibilityProjection) ||
+        this.lastCoreSessionCompatibilityGeneration >= this.sessionCompatibilityGeneration
+      if (generation === this.writeGeneration && compatibilityProjectionCurrent) {
         break
       }
     }
@@ -3859,6 +4186,7 @@ export class Store {
   // Why: a project move rewrote the data file directly; in-memory state is now stale and any write would undo the transfer.
   freezeWrites(): void {
     this.writesFrozen = true
+    this.workspaceSessionSidecars.freeze()
     if (this.writeTimer) {
       clearTimeout(this.writeTimer)
       this.writeTimer = null

--- a/src/main/persistence/loading-store/workspace-session-sidecar-files.ts
+++ b/src/main/persistence/loading-store/workspace-session-sidecar-files.ts
@@ -1,0 +1,282 @@
+// Atomic workspace-session partition file format, recovery, and backup helpers.
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import { readFile } from 'node:fs/promises'
+import { basename, dirname, extname, join } from 'node:path'
+import { createHash } from 'node:crypto'
+import { isDeepStrictEqual } from 'node:util'
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+import { normalizeExecutionHostId, type ExecutionHostId } from '../../../shared/execution-host'
+import { parseWorkspaceSessionSalvaging } from '../../../shared/workspace-session-salvage'
+import { getDefaultWorkspaceSession } from '../../../shared/constants'
+import {
+  durableWriteTempPath,
+  writeFileDurable,
+  writeFileDurableSync
+} from '../../durable-file-write'
+
+export const PARTITION_SCHEMA_VERSION = 1
+const BACKUP_COUNT = 2
+export const SAVE_DEBOUNCE_MS = 1_000
+export const SAVE_MAX_WAIT_MS = 5_000
+
+export type WorkspaceSessionPartitionEnvelope = {
+  schemaVersion: typeof PARTITION_SCHEMA_VERSION
+  hostId: ExecutionHostId
+  writeGeneration: number
+  writtenAt: number
+  lastSynchronizedCoreHash?: string
+  session: WorkspaceSessionState
+}
+
+export type WorkspaceSessionPartitionWriteTrigger =
+  | 'patch'
+  | 'replace'
+  | 'prune'
+  | 'pty-binding'
+  | 'snapshot'
+  | 'migration'
+  | 'flush'
+  | 'quit'
+  | 'profile-transfer'
+
+export type WorkspaceSessionPartitionTrace = {
+  hostId: ExecutionHostId
+  partitionBytes: number
+  durationMs: number
+  trigger: WorkspaceSessionPartitionWriteTrigger
+  writeGeneration: number
+  committed: boolean
+}
+
+export type WorkspaceSessionSidecarOptions = {
+  onTrace?: (trace: WorkspaceSessionPartitionTrace) => void
+  serialize?: (value: unknown) => string
+  now?: () => number
+}
+
+export type LoadedPartition = {
+  envelope: WorkspaceSessionPartitionEnvelope
+  recovered: boolean
+  repaired: boolean
+}
+
+export type LoadResolution = {
+  workspaceSession: WorkspaceSessionState
+  workspaceSessionsByHostId: Partial<Record<ExecutionHostId, WorkspaceSessionState>>
+}
+
+export type DirtyPartition = {
+  trigger: WorkspaceSessionPartitionWriteTrigger
+  migration: boolean
+}
+
+function partitionDirectory(dataFile: string): string {
+  const extension = extname(dataFile)
+  const stem = basename(dataFile, extension)
+  return join(dirname(dataFile), `${stem}-workspace-sessions`)
+}
+
+export function getWorkspaceSessionPartitionFile(
+  dataFile: string,
+  hostId: ExecutionHostId
+): string {
+  return join(partitionDirectory(dataFile), `${encodeURIComponent(hostId)}.json`)
+}
+
+function backupPath(partitionFile: string, index: number): string {
+  return `${partitionFile}.bak.${index}`
+}
+function hostIdFromPartitionFilename(filename: string): ExecutionHostId | null {
+  const jsonSuffixIndex = filename.indexOf('.json')
+  if (jsonSuffixIndex === -1) {
+    return null
+  }
+  const suffix = filename.slice(jsonSuffixIndex)
+  if (suffix !== '.json' && !/^\.json\.bak\.[0-9]+$/.test(suffix)) {
+    return null
+  }
+  try {
+    return normalizeExecutionHostId(decodeURIComponent(filename.slice(0, jsonSuffixIndex)))
+  } catch {
+    return null
+  }
+}
+export function workspaceSessionHash(session: WorkspaceSessionState): string {
+  return createHash('sha256').update(JSON.stringify(session)).digest('hex')
+}
+
+function parseEnvelope(raw: string, expectedHostId?: ExecutionHostId): LoadedPartition | null {
+  const parsed = JSON.parse(raw) as Partial<WorkspaceSessionPartitionEnvelope>
+  const hostId = normalizeExecutionHostId(parsed.hostId)
+  if (
+    parsed.schemaVersion !== PARTITION_SCHEMA_VERSION ||
+    !hostId ||
+    (expectedHostId !== undefined && hostId !== expectedHostId) ||
+    !Number.isSafeInteger(parsed.writeGeneration) ||
+    (parsed.writeGeneration ?? -1) < 0 ||
+    typeof parsed.writtenAt !== 'number' ||
+    !Number.isFinite(parsed.writtenAt)
+  ) {
+    return null
+  }
+  const session = parseWorkspaceSessionSalvaging(parsed.session)
+  if (!session.ok) {
+    return null
+  }
+  const normalizedSession = { ...getDefaultWorkspaceSession(), ...session.value }
+  return {
+    envelope: {
+      schemaVersion: PARTITION_SCHEMA_VERSION,
+      hostId,
+      writeGeneration: parsed.writeGeneration!,
+      writtenAt: parsed.writtenAt,
+      lastSynchronizedCoreHash:
+        typeof parsed.lastSynchronizedCoreHash === 'string'
+          ? parsed.lastSynchronizedCoreHash
+          : undefined,
+      session: normalizedSession
+    },
+    recovered: false,
+    repaired: session.droppedCount > 0 || !isDeepStrictEqual(parsed.session, normalizedSession)
+  }
+}
+
+function readCandidate(path: string, expectedHostId: ExecutionHostId): LoadedPartition | null {
+  try {
+    return parseEnvelope(readFileSync(path, 'utf-8'), expectedHostId)
+  } catch {
+    return null
+  }
+}
+
+export function readPartitionWithRecovery(
+  dataFile: string,
+  hostId: ExecutionHostId
+): LoadedPartition | null {
+  const partitionFile = getWorkspaceSessionPartitionFile(dataFile, hostId)
+  const primary = readCandidate(partitionFile, hostId)
+  if (primary) {
+    return primary
+  }
+  for (let index = 0; index < BACKUP_COUNT; index += 1) {
+    const recovered = readCandidate(backupPath(partitionFile, index), hostId)
+    if (!recovered) {
+      continue
+    }
+    try {
+      mkdirSync(dirname(partitionFile), { recursive: true })
+      writeFileDurableSync(
+        durableWriteTempPath(partitionFile),
+        partitionFile,
+        JSON.stringify(recovered.envelope)
+      )
+      console.warn(
+        `[persistence] Recovered workspace session partition ${hostId} from backup ${index}`
+      )
+    } catch (error) {
+      console.error(`[persistence] Failed to restore workspace session partition ${hostId}:`, error)
+    }
+    return { ...recovered, recovered: true }
+  }
+  return null
+}
+
+export function listPartitionHostIds(dataFile: string): ExecutionHostId[] {
+  try {
+    return readdirSync(partitionDirectory(dataFile), { withFileTypes: true })
+      .filter((entry) => entry.isFile())
+      .map((entry) => hostIdFromPartitionFilename(entry.name))
+      .filter((hostId): hostId is ExecutionHostId => hostId !== null)
+  } catch {
+    return []
+  }
+}
+export function isDefaultWorkspaceSession(session: WorkspaceSessionState): boolean {
+  return JSON.stringify(session) === JSON.stringify(getDefaultWorkspaceSession())
+}
+
+function isValidEnvelopePayload(raw: string, hostId: ExecutionHostId): boolean {
+  try {
+    return parseEnvelope(raw, hostId) !== null
+  } catch {
+    return false
+  }
+}
+
+function rotateBackupsSync(partitionFile: string, hostId: ExecutionHostId): void {
+  if (!existsSync(partitionFile)) {
+    return
+  }
+  let primary: string
+  try {
+    primary = readFileSync(partitionFile, 'utf-8')
+  } catch {
+    return
+  }
+  if (!isValidEnvelopePayload(primary, hostId)) {
+    return
+  }
+  const newestBackup = backupPath(partitionFile, 0)
+  if (existsSync(newestBackup)) {
+    try {
+      const previous = readFileSync(newestBackup, 'utf-8')
+      if (isValidEnvelopePayload(previous, hostId)) {
+        writeFileDurableSync(
+          durableWriteTempPath(backupPath(partitionFile, 1)),
+          backupPath(partitionFile, 1),
+          previous
+        )
+      }
+    } catch {
+      // Preserve the current primary even when an older backup cannot rotate.
+    }
+  }
+  writeFileDurableSync(durableWriteTempPath(newestBackup), newestBackup, primary)
+}
+
+export async function rotateBackups(partitionFile: string, hostId: ExecutionHostId): Promise<void> {
+  let primary: string
+  try {
+    primary = await readFile(partitionFile, 'utf-8')
+  } catch {
+    return
+  }
+  if (!isValidEnvelopePayload(primary, hostId)) {
+    return
+  }
+  const newestBackup = backupPath(partitionFile, 0)
+  try {
+    const previous = await readFile(newestBackup, 'utf-8')
+    if (isValidEnvelopePayload(previous, hostId)) {
+      await writeFileDurable(
+        durableWriteTempPath(backupPath(partitionFile, 1)),
+        backupPath(partitionFile, 1),
+        previous
+      )
+    }
+  } catch {
+    // A missing/unreadable older backup does not block protecting the current primary.
+  }
+  await writeFileDurable(durableWriteTempPath(newestBackup), newestBackup, primary)
+}
+
+export function writePartitionSync(
+  dataFile: string,
+  envelope: WorkspaceSessionPartitionEnvelope,
+  serialize: (value: unknown) => string
+): number {
+  const partitionFile = getWorkspaceSessionPartitionFile(dataFile, envelope.hostId)
+  mkdirSync(dirname(partitionFile), { recursive: true })
+  rotateBackupsSync(partitionFile, envelope.hostId)
+  const payload = serialize(envelope)
+  writeFileDurableSync(durableWriteTempPath(partitionFile), partitionFile, payload)
+  return Buffer.byteLength(payload)
+}
+
+export function removePartitionFilesSync(dataFile: string, hostId: ExecutionHostId): void {
+  const file = getWorkspaceSessionPartitionFile(dataFile, hostId)
+  rmSync(file, { force: true })
+  for (let index = 0; index < BACKUP_COUNT; index += 1) {
+    rmSync(backupPath(file, index), { force: true })
+  }
+}

--- a/src/main/persistence/loading-store/workspace-session-sidecar-load-resolution.ts
+++ b/src/main/persistence/loading-store/workspace-session-sidecar-load-resolution.ts
@@ -1,0 +1,131 @@
+// Resolves embedded and partitioned workspace sessions into the in-memory load state.
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+import { LOCAL_EXECUTION_HOST_ID, type ExecutionHostId } from '../../../shared/execution-host'
+import {
+  isDefaultWorkspaceSession,
+  listPartitionHostIds,
+  readPartitionWithRecovery,
+  workspaceSessionHash,
+  type DirtyPartition,
+  type LoadResolution
+} from './workspace-session-sidecar-files'
+
+export type WorkspaceSessionSidecarLoadArguments = {
+  workspaceSession: WorkspaceSessionState
+  workspaceSessionsByHostId?: Partial<Record<ExecutionHostId, WorkspaceSessionState>>
+  embeddedLocalPresent: boolean
+  embeddedHostIds: ReadonlySet<ExecutionHostId>
+  embeddedPayloadPresent: boolean
+  embeddedGenerationByHostId?: Partial<Record<ExecutionHostId, number>>
+  coreRestoredFromBackup?: boolean
+  replacementPending?: boolean
+}
+
+type WorkspaceSessionSidecarLoadState = {
+  dataFile: string
+  sessions: Map<ExecutionHostId, WorkspaceSessionState>
+  generations: Map<ExecutionHostId, number>
+  durableGenerations: Map<ExecutionHostId, number>
+  dirty: Map<ExecutionHostId, DirtyPartition>
+  synchronizedCoreHashes: Map<ExecutionHostId, string>
+  pendingPruneHostIds: Set<ExecutionHostId>
+}
+
+export function resolveWorkspaceSessionSidecarLoad(
+  state: WorkspaceSessionSidecarLoadState,
+  args: WorkspaceSessionSidecarLoadArguments
+): LoadResolution {
+  state.sessions.clear()
+  state.generations.clear()
+  state.durableGenerations.clear()
+  state.dirty.clear()
+  state.synchronizedCoreHashes.clear()
+  state.pendingPruneHostIds.clear()
+
+  const replacementPending =
+    args.replacementPending === true && args.coreRestoredFromBackup !== true
+  const existingSidecarHostIds = new Set(listPartitionHostIds(state.dataFile))
+  const sidecarHostIds = replacementPending
+    ? new Set<ExecutionHostId>()
+    : new Set(existingSidecarHostIds)
+  if (args.embeddedLocalPresent) {
+    sidecarHostIds.add(LOCAL_EXECUTION_HOST_ID)
+  }
+  for (const hostId of args.embeddedHostIds) {
+    sidecarHostIds.add(hostId)
+  }
+  if (replacementPending) {
+    for (const hostId of existingSidecarHostIds) {
+      if (!sidecarHostIds.has(hostId)) {
+        state.pendingPruneHostIds.add(hostId)
+      }
+    }
+  }
+
+  for (const hostId of sidecarHostIds) {
+    const loaded = readPartitionWithRecovery(state.dataFile, hostId)
+    const embedded =
+      hostId === LOCAL_EXECUTION_HOST_ID
+        ? args.workspaceSession
+        : args.workspaceSessionsByHostId?.[hostId]
+    const embeddedPresent =
+      hostId === LOCAL_EXECUTION_HOST_ID
+        ? args.embeddedLocalPresent
+        : args.embeddedHostIds.has(hostId)
+    const embeddedIsUnmaterializedLocalDefault =
+      hostId === LOCAL_EXECUTION_HOST_ID &&
+      !loaded &&
+      embeddedPresent &&
+      embedded !== undefined &&
+      isDefaultWorkspaceSession(embedded)
+    const embeddedGeneration = args.embeddedGenerationByHostId?.[hostId]
+    const embeddedHash = embedded ? workspaceSessionHash(embedded) : undefined
+    if (embeddedHash) {
+      state.synchronizedCoreHashes.set(hostId, embeddedHash)
+    } else if (loaded?.envelope.lastSynchronizedCoreHash) {
+      state.synchronizedCoreHashes.set(hostId, loaded.envelope.lastSynchronizedCoreHash)
+    }
+    const rollbackPayloadChanged =
+      embeddedGeneration === undefined &&
+      loaded?.envelope.lastSynchronizedCoreHash !== undefined &&
+      embeddedHash !== loaded.envelope.lastSynchronizedCoreHash
+    const embeddedIsNewer =
+      !embeddedIsUnmaterializedLocalDefault &&
+      embeddedPresent &&
+      embedded !== undefined &&
+      (!loaded ||
+        (!args.coreRestoredFromBackup &&
+          (replacementPending ||
+            (embeddedGeneration === undefined
+              ? loaded.envelope.lastSynchronizedCoreHash === undefined || rollbackPayloadChanged
+              : embeddedGeneration > loaded.envelope.writeGeneration))))
+    const session = embeddedIsNewer ? embedded : loaded?.envelope.session
+    if (!session) {
+      continue
+    }
+    state.sessions.set(hostId, session)
+    const generation = loaded?.envelope.writeGeneration ?? 0
+    state.generations.set(hostId, generation)
+    state.durableGenerations.set(hostId, loaded ? generation : -1)
+    if (embeddedIsNewer || loaded?.repaired || loaded?.recovered) {
+      state.dirty.set(hostId, { trigger: 'migration', migration: embeddedIsNewer })
+    }
+  }
+
+  if (!state.sessions.has(LOCAL_EXECUTION_HOST_ID)) {
+    state.sessions.set(LOCAL_EXECUTION_HOST_ID, args.workspaceSession)
+    state.generations.set(LOCAL_EXECUTION_HOST_ID, 0)
+    state.durableGenerations.set(LOCAL_EXECUTION_HOST_ID, -1)
+  }
+
+  const workspaceSessionsByHostId: Partial<Record<ExecutionHostId, WorkspaceSessionState>> = {}
+  for (const [hostId, session] of state.sessions) {
+    if (hostId !== LOCAL_EXECUTION_HOST_ID) {
+      workspaceSessionsByHostId[hostId] = session
+    }
+  }
+  return {
+    workspaceSession: state.sessions.get(LOCAL_EXECUTION_HOST_ID)!,
+    workspaceSessionsByHostId
+  }
+}

--- a/src/main/persistence/loading-store/workspace-session-sidecar-profile.ts
+++ b/src/main/persistence/loading-store/workspace-session-sidecar-profile.ts
@@ -1,0 +1,55 @@
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+import {
+  LOCAL_EXECUTION_HOST_ID,
+  normalizeExecutionHostId,
+  type ExecutionHostId
+} from '../../../shared/execution-host'
+import {
+  listPartitionHostIds,
+  PARTITION_SCHEMA_VERSION,
+  readPartitionWithRecovery,
+  removePartitionFilesSync,
+  workspaceSessionHash,
+  writePartitionSync
+} from './workspace-session-sidecar-files'
+
+export function replaceWorkspaceSessionSidecarsSync(args: {
+  dataFile: string
+  workspaceSession: WorkspaceSessionState
+  workspaceSessionsByHostId?: Partial<Record<ExecutionHostId, WorkspaceSessionState>>
+}): Partial<Record<ExecutionHostId, number>> {
+  const desired = new Map<ExecutionHostId, WorkspaceSessionState>([
+    [LOCAL_EXECUTION_HOST_ID, args.workspaceSession]
+  ])
+  for (const [rawHostId, session] of Object.entries(args.workspaceSessionsByHostId ?? {})) {
+    const hostId = normalizeExecutionHostId(rawHostId)
+    if (hostId && hostId !== LOCAL_EXECUTION_HOST_ID && session) {
+      desired.set(hostId, session)
+    }
+  }
+  const writtenAt = Date.now()
+  const generations: Partial<Record<ExecutionHostId, number>> = {}
+  for (const [hostId, session] of desired) {
+    const loaded = readPartitionWithRecovery(args.dataFile, hostId)
+    const generation = (loaded?.envelope.writeGeneration ?? 0) + 1
+    writePartitionSync(
+      args.dataFile,
+      {
+        schemaVersion: PARTITION_SCHEMA_VERSION,
+        hostId,
+        writeGeneration: generation,
+        writtenAt,
+        lastSynchronizedCoreHash: workspaceSessionHash(session),
+        session
+      },
+      JSON.stringify
+    )
+    generations[hostId] = generation
+  }
+  for (const hostId of listPartitionHostIds(args.dataFile)) {
+    if (!desired.has(hostId)) {
+      removePartitionFilesSync(args.dataFile, hostId)
+    }
+  }
+  return generations
+}

--- a/src/main/persistence/loading-store/workspace-session-sidecar-state.ts
+++ b/src/main/persistence/loading-store/workspace-session-sidecar-state.ts
@@ -1,0 +1,324 @@
+// In-memory workspace-session partition state, migration resolution, and write scheduling.
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+import {
+  LOCAL_EXECUTION_HOST_ID,
+  normalizeExecutionHostId,
+  type ExecutionHostId
+} from '../../../shared/execution-host'
+import {
+  isDefaultWorkspaceSession,
+  listPartitionHostIds,
+  readPartitionWithRecovery,
+  removePartitionFilesSync,
+  SAVE_DEBOUNCE_MS,
+  SAVE_MAX_WAIT_MS,
+  workspaceSessionHash,
+  type DirtyPartition,
+  type LoadResolution,
+  type WorkspaceSessionPartitionTrace,
+  type WorkspaceSessionPartitionWriteTrigger,
+  type WorkspaceSessionSidecarOptions
+} from './workspace-session-sidecar-files'
+
+export abstract class WorkspaceSessionSidecarState {
+  protected readonly dataFile: string
+  protected readonly onTrace?: (trace: WorkspaceSessionPartitionTrace) => void
+  protected readonly serialize: (value: unknown) => string
+  protected readonly now: () => number
+  protected readonly sessions = new Map<ExecutionHostId, WorkspaceSessionState>()
+  protected readonly generations = new Map<ExecutionHostId, number>()
+  protected readonly durableGenerations = new Map<ExecutionHostId, number>()
+  protected readonly dirty = new Map<ExecutionHostId, DirtyPartition>()
+  protected readonly pendingWrites = new Map<ExecutionHostId, Promise<void>>()
+  protected readonly synchronizedCoreHashes = new Map<ExecutionHostId, string>()
+  private embeddedPayloadPresent = false
+  protected frozen = false
+  private finalFlushStarted = false
+  protected writeTimer: ReturnType<typeof setTimeout> | null = null
+  private firstPendingSaveAt: number | null = null
+  private readonly pendingPruneHostIds = new Set<ExecutionHostId>()
+  private readonly retryAttempts = new Map<ExecutionHostId, number>()
+
+  constructor(dataFile: string, options: WorkspaceSessionSidecarOptions = {}) {
+    this.dataFile = dataFile
+    this.onTrace = options.onTrace
+    this.serialize = options.serialize ?? JSON.stringify
+    this.now = options.now ?? Date.now
+  }
+  abstract flushSync(trigger?: WorkspaceSessionPartitionWriteTrigger): void
+
+  abstract flushPending(options?: {
+    signal?: AbortSignal
+    drainToStableGeneration?: boolean
+    trigger?: WorkspaceSessionPartitionWriteTrigger
+  }): Promise<void>
+
+  resolveForLoad(args: {
+    workspaceSession: WorkspaceSessionState
+    workspaceSessionsByHostId?: Partial<Record<ExecutionHostId, WorkspaceSessionState>>
+    embeddedLocalPresent: boolean
+    embeddedHostIds: ReadonlySet<ExecutionHostId>
+    embeddedPayloadPresent: boolean
+    embeddedGenerationByHostId?: Partial<Record<ExecutionHostId, number>>
+    coreRestoredFromBackup?: boolean
+    replacementPending?: boolean
+  }): LoadResolution {
+    this.sessions.clear()
+    this.generations.clear()
+    this.durableGenerations.clear()
+    this.dirty.clear()
+    this.synchronizedCoreHashes.clear()
+    this.pendingPruneHostIds.clear()
+    this.embeddedPayloadPresent = args.embeddedPayloadPresent
+
+    const replacementPending =
+      args.replacementPending === true && args.coreRestoredFromBackup !== true
+    const existingSidecarHostIds = new Set(listPartitionHostIds(this.dataFile))
+    const sidecarHostIds = replacementPending
+      ? new Set<ExecutionHostId>()
+      : new Set(existingSidecarHostIds)
+    if (args.embeddedLocalPresent) {
+      sidecarHostIds.add(LOCAL_EXECUTION_HOST_ID)
+    }
+    for (const hostId of args.embeddedHostIds) {
+      sidecarHostIds.add(hostId)
+    }
+    if (replacementPending) {
+      for (const hostId of existingSidecarHostIds) {
+        if (!sidecarHostIds.has(hostId)) {
+          this.pendingPruneHostIds.add(hostId)
+        }
+      }
+    }
+
+    for (const hostId of sidecarHostIds) {
+      const loaded = readPartitionWithRecovery(this.dataFile, hostId)
+      const embedded =
+        hostId === LOCAL_EXECUTION_HOST_ID
+          ? args.workspaceSession
+          : args.workspaceSessionsByHostId?.[hostId]
+      const embeddedPresent =
+        hostId === LOCAL_EXECUTION_HOST_ID
+          ? args.embeddedLocalPresent
+          : args.embeddedHostIds.has(hostId)
+      const embeddedIsUnmaterializedLocalDefault =
+        hostId === LOCAL_EXECUTION_HOST_ID &&
+        !loaded &&
+        embeddedPresent &&
+        embedded !== undefined &&
+        isDefaultWorkspaceSession(embedded)
+      const embeddedGeneration = args.embeddedGenerationByHostId?.[hostId]
+      const embeddedHash = embedded ? workspaceSessionHash(embedded) : undefined
+      if (embeddedHash) {
+        this.synchronizedCoreHashes.set(hostId, embeddedHash)
+      } else if (loaded?.envelope.lastSynchronizedCoreHash) {
+        this.synchronizedCoreHashes.set(hostId, loaded.envelope.lastSynchronizedCoreHash)
+      }
+      const rollbackPayloadChanged =
+        embeddedGeneration === undefined &&
+        loaded?.envelope.lastSynchronizedCoreHash !== undefined &&
+        embeddedHash !== loaded.envelope.lastSynchronizedCoreHash
+      const embeddedIsNewer =
+        !embeddedIsUnmaterializedLocalDefault &&
+        embeddedPresent &&
+        embedded !== undefined &&
+        (!loaded ||
+          (!args.coreRestoredFromBackup &&
+            (replacementPending ||
+              (embeddedGeneration === undefined
+                ? loaded.envelope.lastSynchronizedCoreHash === undefined || rollbackPayloadChanged
+                : embeddedGeneration > loaded.envelope.writeGeneration))))
+      const session = embeddedIsNewer ? embedded : loaded?.envelope.session
+      if (!session) {
+        continue
+      }
+      this.sessions.set(hostId, session)
+      const generation = loaded?.envelope.writeGeneration ?? 0
+      this.generations.set(hostId, generation)
+      this.durableGenerations.set(hostId, loaded ? generation : -1)
+      if (embeddedIsNewer || loaded?.repaired || loaded?.recovered) {
+        this.dirty.set(hostId, { trigger: 'migration', migration: embeddedIsNewer })
+      }
+    }
+
+    if (!this.sessions.has(LOCAL_EXECUTION_HOST_ID)) {
+      this.sessions.set(LOCAL_EXECUTION_HOST_ID, args.workspaceSession)
+      this.generations.set(LOCAL_EXECUTION_HOST_ID, 0)
+      this.durableGenerations.set(LOCAL_EXECUTION_HOST_ID, -1)
+    }
+
+    const workspaceSessionsByHostId: Partial<Record<ExecutionHostId, WorkspaceSessionState>> = {}
+    for (const [hostId, session] of this.sessions) {
+      if (hostId !== LOCAL_EXECUTION_HOST_ID) {
+        workspaceSessionsByHostId[hostId] = session
+      }
+    }
+    return {
+      workspaceSession: this.sessions.get(LOCAL_EXECUTION_HOST_ID)!,
+      workspaceSessionsByHostId
+    }
+  }
+
+  initialize(
+    workspaceSession: WorkspaceSessionState,
+    workspaceSessionsByHostId?: Partial<Record<ExecutionHostId, WorkspaceSessionState>>,
+    normalizedHostIds: ReadonlySet<ExecutionHostId> = new Set()
+  ): { coreCleanupReady: boolean; embeddedPayloadPresent: boolean } {
+    this.sessions.set(LOCAL_EXECUTION_HOST_ID, workspaceSession)
+    for (const [rawHostId, session] of Object.entries(workspaceSessionsByHostId ?? {})) {
+      const hostId = normalizeExecutionHostId(rawHostId)
+      if (hostId && hostId !== LOCAL_EXECUTION_HOST_ID && session) {
+        this.sessions.set(hostId, session)
+      }
+    }
+    for (const hostId of normalizedHostIds) {
+      if (this.sessions.has(hostId)) {
+        this.dirty.set(hostId, { trigger: 'migration', migration: false })
+      }
+    }
+    for (const hostId of this.dirty.keys()) {
+      this.bumpGeneration(hostId)
+    }
+    try {
+      this.flushSync('migration')
+    } catch (error) {
+      console.error(
+        '[persistence] Failed to migrate embedded workspace sessions to sidecars:',
+        error
+      )
+    }
+    if (!this.hasPendingMigration()) {
+      for (const hostId of this.pendingPruneHostIds) {
+        removePartitionFilesSync(this.dataFile, hostId)
+      }
+      this.pendingPruneHostIds.clear()
+    }
+    return {
+      coreCleanupReady: !this.hasPendingMigration(),
+      embeddedPayloadPresent: this.embeddedPayloadPresent
+    }
+  }
+
+  markDirty(
+    hostId: ExecutionHostId,
+    session: WorkspaceSessionState,
+    trigger: WorkspaceSessionPartitionWriteTrigger
+  ): void {
+    if (this.frozen || this.finalFlushStarted) {
+      return
+    }
+    this.sessions.set(hostId, session)
+    this.bumpGeneration(hostId)
+    this.dirty.set(hostId, { trigger, migration: this.dirty.get(hostId)?.migration ?? false })
+    this.scheduleWrite()
+  }
+
+  private bumpGeneration(hostId: ExecutionHostId): number {
+    const generation = (this.generations.get(hostId) ?? 0) + 1
+    this.generations.set(hostId, generation)
+    return generation
+  }
+
+  protected scheduleWrite(delayMs = SAVE_DEBOUNCE_MS): void {
+    if (this.frozen) {
+      return
+    }
+    const now = this.now()
+    this.firstPendingSaveAt ??= now
+    if (this.writeTimer) {
+      clearTimeout(this.writeTimer)
+    }
+    const untilMaxWait = Math.max(0, this.firstPendingSaveAt + SAVE_MAX_WAIT_MS - now)
+    this.writeTimer = setTimeout(
+      () => {
+        this.writeTimer = null
+        this.firstPendingSaveAt = null
+        void this.flushPending({ drainToStableGeneration: false }).catch((error) => {
+          console.error('[persistence] Failed to write workspace session partition:', error)
+        })
+      },
+      Math.min(delayMs, untilMaxWait)
+    )
+  }
+  protected noteWriteSucceeded(hostId: ExecutionHostId): void {
+    this.retryAttempts.delete(hostId)
+  }
+
+  protected noteWriteFailed(hostId: ExecutionHostId): void {
+    const attempt = (this.retryAttempts.get(hostId) ?? 0) + 1
+    this.retryAttempts.set(hostId, attempt)
+    if (attempt > 5 || this.frozen) {
+      return
+    }
+    const hostJitter = [...hostId].reduce((sum, character) => sum + character.charCodeAt(0), 0) % 97
+    this.scheduleWrite(Math.min(5_000, 100 * 2 ** (attempt - 1) + hostJitter))
+  }
+
+  protected clearWriteTimer(): void {
+    if (this.writeTimer) {
+      clearTimeout(this.writeTimer)
+      this.writeTimer = null
+    }
+    this.firstPendingSaveAt = null
+  }
+
+  private hasPendingMigration(): boolean {
+    for (const dirty of this.dirty.values()) {
+      if (dirty.migration) {
+        return true
+      }
+    }
+    return false
+  }
+
+  isCoreCleanupReady(): boolean {
+    return !this.hasPendingMigration()
+  }
+
+  hasEmbeddedPayload(): boolean {
+    return this.embeddedPayloadPresent
+  }
+
+  captureCoreProjectionHashes(
+    workspaceSession: WorkspaceSessionState,
+    workspaceSessionsByHostId?: Partial<Record<ExecutionHostId, WorkspaceSessionState>>
+  ): Partial<Record<ExecutionHostId, string>> {
+    const hashes: Partial<Record<ExecutionHostId, string>> = {
+      [LOCAL_EXECUTION_HOST_ID]: workspaceSessionHash(workspaceSession)
+    }
+    for (const [rawHostId, session] of Object.entries(workspaceSessionsByHostId ?? {})) {
+      const hostId = normalizeExecutionHostId(rawHostId)
+      if (hostId && session) {
+        hashes[hostId] = workspaceSessionHash(session)
+      }
+    }
+    return hashes
+  }
+
+  commitCoreProjectionHashes(hashes: Partial<Record<ExecutionHostId, string>>): void {
+    this.synchronizedCoreHashes.clear()
+    for (const [rawHostId, hash] of Object.entries(hashes)) {
+      const hostId = normalizeExecutionHostId(rawHostId)
+      if (hostId && hash) {
+        this.synchronizedCoreHashes.set(hostId, hash)
+      }
+    }
+  }
+  refreshPartitionsNewerThanCoreProjection(hashes: Partial<Record<ExecutionHostId, string>>): void {
+    for (const [hostId, session] of this.sessions) {
+      if (workspaceSessionHash(session) !== hashes[hostId]) {
+        this.markDirty(hostId, session, 'patch')
+      }
+    }
+  }
+
+  beginFinalFlush(): void {
+    this.finalFlushStarted = true
+    this.clearWriteTimer()
+  }
+
+  freeze(): void {
+    this.frozen = true
+    this.clearWriteTimer()
+  }
+}

--- a/src/main/persistence/loading-store/workspace-session-sidecar-state.ts
+++ b/src/main/persistence/loading-store/workspace-session-sidecar-state.ts
@@ -6,9 +6,6 @@ import {
   type ExecutionHostId
 } from '../../../shared/execution-host'
 import {
-  isDefaultWorkspaceSession,
-  listPartitionHostIds,
-  readPartitionWithRecovery,
   removePartitionFilesSync,
   SAVE_DEBOUNCE_MS,
   SAVE_MAX_WAIT_MS,
@@ -19,6 +16,10 @@ import {
   type WorkspaceSessionPartitionWriteTrigger,
   type WorkspaceSessionSidecarOptions
 } from './workspace-session-sidecar-files'
+import {
+  resolveWorkspaceSessionSidecarLoad,
+  type WorkspaceSessionSidecarLoadArguments
+} from './workspace-session-sidecar-load-resolution'
 
 export abstract class WorkspaceSessionSidecarState {
   protected readonly dataFile: string
@@ -53,110 +54,20 @@ export abstract class WorkspaceSessionSidecarState {
     trigger?: WorkspaceSessionPartitionWriteTrigger
   }): Promise<void>
 
-  resolveForLoad(args: {
-    workspaceSession: WorkspaceSessionState
-    workspaceSessionsByHostId?: Partial<Record<ExecutionHostId, WorkspaceSessionState>>
-    embeddedLocalPresent: boolean
-    embeddedHostIds: ReadonlySet<ExecutionHostId>
-    embeddedPayloadPresent: boolean
-    embeddedGenerationByHostId?: Partial<Record<ExecutionHostId, number>>
-    coreRestoredFromBackup?: boolean
-    replacementPending?: boolean
-  }): LoadResolution {
-    this.sessions.clear()
-    this.generations.clear()
-    this.durableGenerations.clear()
-    this.dirty.clear()
-    this.synchronizedCoreHashes.clear()
-    this.pendingPruneHostIds.clear()
+  resolveForLoad(args: WorkspaceSessionSidecarLoadArguments): LoadResolution {
     this.embeddedPayloadPresent = args.embeddedPayloadPresent
-
-    const replacementPending =
-      args.replacementPending === true && args.coreRestoredFromBackup !== true
-    const existingSidecarHostIds = new Set(listPartitionHostIds(this.dataFile))
-    const sidecarHostIds = replacementPending
-      ? new Set<ExecutionHostId>()
-      : new Set(existingSidecarHostIds)
-    if (args.embeddedLocalPresent) {
-      sidecarHostIds.add(LOCAL_EXECUTION_HOST_ID)
-    }
-    for (const hostId of args.embeddedHostIds) {
-      sidecarHostIds.add(hostId)
-    }
-    if (replacementPending) {
-      for (const hostId of existingSidecarHostIds) {
-        if (!sidecarHostIds.has(hostId)) {
-          this.pendingPruneHostIds.add(hostId)
-        }
-      }
-    }
-
-    for (const hostId of sidecarHostIds) {
-      const loaded = readPartitionWithRecovery(this.dataFile, hostId)
-      const embedded =
-        hostId === LOCAL_EXECUTION_HOST_ID
-          ? args.workspaceSession
-          : args.workspaceSessionsByHostId?.[hostId]
-      const embeddedPresent =
-        hostId === LOCAL_EXECUTION_HOST_ID
-          ? args.embeddedLocalPresent
-          : args.embeddedHostIds.has(hostId)
-      const embeddedIsUnmaterializedLocalDefault =
-        hostId === LOCAL_EXECUTION_HOST_ID &&
-        !loaded &&
-        embeddedPresent &&
-        embedded !== undefined &&
-        isDefaultWorkspaceSession(embedded)
-      const embeddedGeneration = args.embeddedGenerationByHostId?.[hostId]
-      const embeddedHash = embedded ? workspaceSessionHash(embedded) : undefined
-      if (embeddedHash) {
-        this.synchronizedCoreHashes.set(hostId, embeddedHash)
-      } else if (loaded?.envelope.lastSynchronizedCoreHash) {
-        this.synchronizedCoreHashes.set(hostId, loaded.envelope.lastSynchronizedCoreHash)
-      }
-      const rollbackPayloadChanged =
-        embeddedGeneration === undefined &&
-        loaded?.envelope.lastSynchronizedCoreHash !== undefined &&
-        embeddedHash !== loaded.envelope.lastSynchronizedCoreHash
-      const embeddedIsNewer =
-        !embeddedIsUnmaterializedLocalDefault &&
-        embeddedPresent &&
-        embedded !== undefined &&
-        (!loaded ||
-          (!args.coreRestoredFromBackup &&
-            (replacementPending ||
-              (embeddedGeneration === undefined
-                ? loaded.envelope.lastSynchronizedCoreHash === undefined || rollbackPayloadChanged
-                : embeddedGeneration > loaded.envelope.writeGeneration))))
-      const session = embeddedIsNewer ? embedded : loaded?.envelope.session
-      if (!session) {
-        continue
-      }
-      this.sessions.set(hostId, session)
-      const generation = loaded?.envelope.writeGeneration ?? 0
-      this.generations.set(hostId, generation)
-      this.durableGenerations.set(hostId, loaded ? generation : -1)
-      if (embeddedIsNewer || loaded?.repaired || loaded?.recovered) {
-        this.dirty.set(hostId, { trigger: 'migration', migration: embeddedIsNewer })
-      }
-    }
-
-    if (!this.sessions.has(LOCAL_EXECUTION_HOST_ID)) {
-      this.sessions.set(LOCAL_EXECUTION_HOST_ID, args.workspaceSession)
-      this.generations.set(LOCAL_EXECUTION_HOST_ID, 0)
-      this.durableGenerations.set(LOCAL_EXECUTION_HOST_ID, -1)
-    }
-
-    const workspaceSessionsByHostId: Partial<Record<ExecutionHostId, WorkspaceSessionState>> = {}
-    for (const [hostId, session] of this.sessions) {
-      if (hostId !== LOCAL_EXECUTION_HOST_ID) {
-        workspaceSessionsByHostId[hostId] = session
-      }
-    }
-    return {
-      workspaceSession: this.sessions.get(LOCAL_EXECUTION_HOST_ID)!,
-      workspaceSessionsByHostId
-    }
+    return resolveWorkspaceSessionSidecarLoad(
+      {
+        dataFile: this.dataFile,
+        sessions: this.sessions,
+        generations: this.generations,
+        durableGenerations: this.durableGenerations,
+        dirty: this.dirty,
+        synchronizedCoreHashes: this.synchronizedCoreHashes,
+        pendingPruneHostIds: this.pendingPruneHostIds
+      },
+      args
+    )
   }
 
   initialize(

--- a/src/main/persistence/loading-store/workspace-session-sidecar.ts
+++ b/src/main/persistence/loading-store/workspace-session-sidecar.ts
@@ -1,0 +1,308 @@
+import { mkdir } from 'node:fs/promises'
+import { dirname } from 'node:path'
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
+import type { ExecutionHostId } from '../../../shared/execution-host'
+import {
+  durableWriteTempPath,
+  removeStaleDurableWriteTempFiles,
+  writeFileDurableIfCurrent
+} from '../../durable-file-write'
+import {
+  getWorkspaceSessionPartitionFile,
+  PARTITION_SCHEMA_VERSION,
+  removePartitionFilesSync,
+  rotateBackups,
+  type WorkspaceSessionPartitionEnvelope,
+  writePartitionSync,
+  type LoadResolution,
+  type WorkspaceSessionPartitionWriteTrigger
+} from './workspace-session-sidecar-files'
+import { WorkspaceSessionSidecarState } from './workspace-session-sidecar-state'
+
+export {
+  getWorkspaceSessionPartitionFile,
+  workspaceSessionHash
+} from './workspace-session-sidecar-files'
+export type {
+  WorkspaceSessionPartitionTrace,
+  WorkspaceSessionPartitionWriteTrigger,
+  WorkspaceSessionSidecarOptions
+} from './workspace-session-sidecar-files'
+
+export class WorkspaceSessionSidecarStore extends WorkspaceSessionSidecarState {
+  flushSync(trigger: WorkspaceSessionPartitionWriteTrigger = 'flush'): void {
+    if (this.frozen) {
+      throw new Error('Cannot flush workspace sessions while persistence is finalized')
+    }
+    this.clearWriteTimer()
+    for (const hostId of this.dirty.keys()) {
+      const session = this.sessions.get(hostId)
+      if (!session) {
+        continue
+      }
+      const generation = this.generations.get(hostId) ?? 0
+      const dirty = this.dirty.get(hostId)!
+      const effectiveTrigger = dirty.trigger === 'migration' ? 'migration' : trigger
+      const startedAt = performance.now()
+      let partitionBytes: number
+      try {
+        partitionBytes = writePartitionSync(
+          this.dataFile,
+          {
+            schemaVersion: PARTITION_SCHEMA_VERSION,
+            hostId,
+            writeGeneration: generation,
+            writtenAt: this.now(),
+            lastSynchronizedCoreHash: this.synchronizedCoreHashes.get(hostId),
+            session
+          },
+          this.serialize
+        )
+        this.noteWriteSucceeded(hostId)
+      } catch (error) {
+        this.noteWriteFailed(hostId)
+        throw error
+      }
+      this.durableGenerations.set(hostId, generation)
+      if (this.generations.get(hostId) === generation) {
+        this.dirty.delete(hostId)
+      }
+      this.onTrace?.({
+        hostId,
+        partitionBytes,
+        durationMs: performance.now() - startedAt,
+        trigger: effectiveTrigger,
+        writeGeneration: generation,
+        committed: true
+      })
+    }
+  }
+
+  async flushPending(
+    options: {
+      signal?: AbortSignal
+      drainToStableGeneration?: boolean
+      trigger?: WorkspaceSessionPartitionWriteTrigger
+    } = {}
+  ): Promise<void> {
+    if (this.frozen) {
+      throw new Error('Cannot flush workspace sessions while persistence is finalized')
+    }
+    this.clearWriteTimer()
+    const drain = options.drainToStableGeneration ?? true
+    const required = new Map(
+      [...this.dirty.keys()].map((hostId) => [hostId, this.generations.get(hostId) ?? 0])
+    )
+    let transientFailures = 0
+    for (;;) {
+      if (options.signal?.aborted) {
+        throw new Error('Workspace session flush aborted')
+      }
+      const hosts = [...this.dirty.keys()].filter((hostId) => {
+        if (drain) {
+          return true
+        }
+        return (this.durableGenerations.get(hostId) ?? -1) < (required.get(hostId) ?? -1)
+      })
+      if (hosts.length === 0) {
+        const pending = [...this.pendingWrites.values()]
+        if (pending.length === 0) {
+          return
+        }
+        await Promise.all(pending)
+        continue
+      }
+      try {
+        await Promise.all(
+          hosts.map((hostId) => this.enqueueHostWrite(hostId, options.trigger, !drain))
+        )
+      } catch (error) {
+        transientFailures++
+        if (!drain || transientFailures > 5) {
+          throw error
+        }
+        const { promise, resolve } = Promise.withResolvers<void>()
+        setTimeout(resolve, Math.min(2_000, 100 * 2 ** (transientFailures - 1)))
+        await promise
+        continue
+      }
+      if (!drain) {
+        let requirementsMet = true
+        for (const [hostId, generation] of required) {
+          if ((this.durableGenerations.get(hostId) ?? -1) < generation) {
+            requirementsMet = false
+            break
+          }
+        }
+        if (requirementsMet) {
+          return
+        }
+      }
+    }
+  }
+  private enqueueHostWrite(
+    hostId: ExecutionHostId,
+    triggerOverride?: WorkspaceSessionPartitionWriteTrigger,
+    allowSupersededCommit = false
+  ): Promise<void> {
+    const previous = this.pendingWrites.get(hostId) ?? Promise.resolve()
+    const write = previous
+      .then(async () => {
+        if (this.frozen || !this.dirty.has(hostId)) {
+          return
+        }
+        const session = this.sessions.get(hostId)
+        if (!session) {
+          return
+        }
+        const generation = this.generations.get(hostId) ?? 0
+        const dirty = this.dirty.get(hostId)!
+        const trigger =
+          dirty.trigger === 'migration' ? 'migration' : (triggerOverride ?? dirty.trigger)
+        const envelope: WorkspaceSessionPartitionEnvelope = {
+          schemaVersion: PARTITION_SCHEMA_VERSION,
+          hostId,
+          writeGeneration: generation,
+          writtenAt: this.now(),
+          lastSynchronizedCoreHash: this.synchronizedCoreHashes.get(hostId),
+          session
+        }
+        const startedAt = performance.now()
+        const payload = this.serialize(envelope)
+        const partitionBytes = Buffer.byteLength(payload)
+        const partitionFile = getWorkspaceSessionPartitionFile(this.dataFile, hostId)
+        await mkdir(dirname(partitionFile), { recursive: true })
+        await removeStaleDurableWriteTempFiles(partitionFile)
+        await rotateBackups(partitionFile, hostId)
+        const committed = await writeFileDurableIfCurrent(
+          durableWriteTempPath(partitionFile),
+          partitionFile,
+          payload,
+          () =>
+            !this.frozen &&
+            (this.generations.get(hostId) === generation ||
+              (allowSupersededCommit && (this.durableGenerations.get(hostId) ?? -1) < generation))
+        )
+        if (committed) {
+          this.noteWriteSucceeded(hostId)
+          this.durableGenerations.set(hostId, generation)
+          if (this.generations.get(hostId) === generation) {
+            this.dirty.delete(hostId)
+          }
+        }
+        this.onTrace?.({
+          hostId,
+          partitionBytes,
+          durationMs: performance.now() - startedAt,
+          trigger,
+          writeGeneration: generation,
+          committed
+        })
+      })
+      .catch((error: unknown) => {
+        this.noteWriteFailed(hostId)
+        throw error
+      })
+    const tracked = write.finally(() => {
+      if (this.pendingWrites.get(hostId) === tracked) {
+        this.pendingWrites.delete(hostId)
+      }
+    })
+    this.pendingWrites.set(hostId, tracked)
+    return tracked
+  }
+
+  reassignHostPartition(
+    oldHostId: ExecutionHostId,
+    newHostId: ExecutionHostId,
+    session: WorkspaceSessionState | undefined
+  ): void {
+    if (this.frozen || oldHostId === newHostId) {
+      return
+    }
+    const previousOldWrite = this.pendingWrites.get(oldHostId) ?? Promise.resolve()
+    this.generations.set(oldHostId, (this.generations.get(oldHostId) ?? 0) + 1)
+    this.sessions.delete(oldHostId)
+    this.dirty.delete(oldHostId)
+    this.synchronizedCoreHashes.delete(oldHostId)
+    if (session) {
+      this.markDirty(newHostId, session, 'replace')
+      const generation = this.generations.get(newHostId) ?? 0
+      const startedAt = performance.now()
+      let partitionBytes: number
+      try {
+        partitionBytes = writePartitionSync(
+          this.dataFile,
+          {
+            schemaVersion: PARTITION_SCHEMA_VERSION,
+            hostId: newHostId,
+            writeGeneration: generation,
+            writtenAt: this.now(),
+            lastSynchronizedCoreHash: this.synchronizedCoreHashes.get(newHostId),
+            session
+          },
+          this.serialize
+        )
+        this.noteWriteSucceeded(newHostId)
+      } catch (error) {
+        this.noteWriteFailed(newHostId)
+        throw error
+      }
+      this.durableGenerations.set(newHostId, generation)
+      this.dirty.delete(newHostId)
+      this.onTrace?.({
+        hostId: newHostId,
+        partitionBytes,
+        durationMs: performance.now() - startedAt,
+        trigger: 'replace',
+        writeGeneration: generation,
+        committed: true
+      })
+    }
+    removePartitionFilesSync(this.dataFile, oldHostId)
+    this.durableGenerations.delete(oldHostId)
+    const cleanup = previousOldWrite.then(() => {
+      removePartitionFilesSync(this.dataFile, oldHostId)
+    })
+    const tracked = cleanup.finally(() => {
+      if (this.pendingWrites.get(oldHostId) === tracked) {
+        this.pendingWrites.delete(oldHostId)
+      }
+    })
+    this.pendingWrites.set(oldHostId, tracked)
+  }
+
+  async waitForPendingWrite(): Promise<void> {
+    if (this.writeTimer) {
+      await this.flushPending({ drainToStableGeneration: true })
+    }
+    await Promise.all(this.pendingWrites.values())
+  }
+
+  getDurableGenerationByHostId(): Partial<Record<ExecutionHostId, number>> {
+    const generations: Partial<Record<ExecutionHostId, number>> = {}
+    for (const hostId of this.sessions.keys()) {
+      const generation = this.durableGenerations.get(hostId)
+      if (generation !== undefined && generation >= 0) {
+        generations[hostId] = generation
+      }
+    }
+    return generations
+  }
+}
+
+export function readWorkspaceSessionSidecarsForProfile(args: {
+  dataFile: string
+  workspaceSession: WorkspaceSessionState
+  workspaceSessionsByHostId?: Partial<Record<ExecutionHostId, WorkspaceSessionState>>
+  embeddedLocalPresent: boolean
+  embeddedHostIds: ReadonlySet<ExecutionHostId>
+  embeddedPayloadPresent: boolean
+  embeddedGenerationByHostId?: Partial<Record<ExecutionHostId, number>>
+  coreRestoredFromBackup?: boolean
+  replacementPending?: boolean
+}): LoadResolution {
+  return new WorkspaceSessionSidecarStore(args.dataFile).resolveForLoad(args)
+}
+
+export { replaceWorkspaceSessionSidecarsSync } from './workspace-session-sidecar-profile'

--- a/src/main/persistence/restoring-sessions/folder-workspace-operations.ts
+++ b/src/main/persistence/restoring-sessions/folder-workspace-operations.ts
@@ -14,6 +14,7 @@ import { removeWorkspaceSessionOwner } from './session-owner-removal'
 export type FolderWorkspaceMutationOperations = {
   state: StoreOwnedPersistedState
   scheduleSave: () => void
+  workspaceSessionChanged: () => void
   removeWorkspaceLineageForFolderParent: (folderWorkspaceId: string) => void
   pruneMobileClientTabSelections: (matchesWorktreeId: (worktreeId: string) => boolean) => void
   hydrateRepo: (repo: Repo) => Repo
@@ -220,6 +221,7 @@ export class FolderWorkspacePersistenceOperations {
       this.state.workspaceSession,
       folderWorkspaceKey(id)
     )!
+    this.operations.workspaceSessionChanged()
     this.removeWorkspaceLineageForFolderParent(id)
     this.pruneMobileClientTabSelections((worktreeId) => worktreeId === folderWorkspaceKey(id))
     this.scheduleSave()

--- a/src/main/persistence/scheduling-automations/automation-definition-operations.ts
+++ b/src/main/persistence/scheduling-automations/automation-definition-operations.ts
@@ -18,6 +18,7 @@ import {
 export type AutomationDefinitionOperations = {
   state: StoreOwnedPersistedState
   flush: () => void
+  scheduleSave: () => void
   recordCreated: () => void
 }
 
@@ -67,6 +68,7 @@ export function createAutomation(
     updatedAt: now
   }
   operations.state.automations = [...(operations.state.automations ?? []), automation]
+  operations.scheduleSave()
   operations.recordCreated()
   operations.flush()
   return automation
@@ -151,6 +153,7 @@ export function updateAutomation(
     updatedAt: Date.now()
   }
   operations.state.automations[index] = updated
+  operations.scheduleSave()
   operations.flush()
   return updated
 }
@@ -162,5 +165,6 @@ export function deleteAutomation(operations: AutomationDefinitionOperations, id:
   operations.state.automationRuns = (operations.state.automationRuns ?? []).filter(
     (entry) => entry.automationId !== id
   )
+  operations.scheduleSave()
   operations.flush()
 }

--- a/src/main/persistence/scheduling-automations/automation-run-operations.ts
+++ b/src/main/persistence/scheduling-automations/automation-run-operations.ts
@@ -22,6 +22,7 @@ import {
 export type AutomationRunOperations = {
   state: StoreOwnedPersistedState
   flush: () => void
+  scheduleSave: () => void
   recordManualRun: () => void
   getWorkspaceDisplayName: (workspaceId: string | null | undefined) => string | null
 }
@@ -85,6 +86,7 @@ export function createAutomationRun(
   if (trigger === 'manual') {
     operations.recordManualRun()
   }
+  operations.scheduleSave()
   operations.flush()
   return run
 }
@@ -139,6 +141,7 @@ export function updateAutomationRun(
     automation.lastRunAt = now
     automation.updatedAt = now
   }
+  operations.scheduleSave()
   operations.flush()
   return updated
 }
@@ -161,6 +164,7 @@ export function snapshotAutomationRunWorkspaceDisplayName(
     return { ...run, workspaceDisplayName: normalizedDisplayName }
   })
   if (updatedCount > 0) {
+    operations.scheduleSave()
     operations.flush()
   }
   return updatedCount

--- a/src/main/persistence/tracking-repos/project-group-operations.ts
+++ b/src/main/persistence/tracking-repos/project-group-operations.ts
@@ -12,6 +12,7 @@ import { removeWorkspaceSessionOwner } from '../restoring-sessions/session-owner
 export type ProjectGroupMutationOperations = {
   state: StoreOwnedPersistedState
   scheduleSave: () => void
+  workspaceSessionChanged: () => void
   removeWorkspaceLineageForFolderParent: (folderWorkspaceId: string) => void
   pruneMobileClientTabSelections: (matchesWorktreeId: (worktreeId: string) => boolean) => void
 }
@@ -112,6 +113,9 @@ export class ProjectGroupPersistenceOperations {
         )!
         this.removeWorkspaceLineageForFolderParent(workspace.id)
       }
+    }
+    if (removedFolderWorkspaceKeys.size > 0) {
+      this.operations.workspaceSessionChanged()
     }
     this.state.folderWorkspaces = (this.state.folderWorkspaces ?? []).filter(
       (workspace) => !deletedGroupIds.has(workspace.projectGroupId)

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -35686,6 +35686,9 @@ describe('OrcaRuntimeService', () => {
 
   it('leaves later delivery to the idle edge instead of polling a working mailbox', async () => {
     vi.useFakeTimers()
+    // Why: CI reuses Vitest workers across files. Reset their fake-clock queue so
+    // this leak assertion measures only timers allocated by the mailbox path below.
+    vi.clearAllTimers()
     try {
       const runtime = new OrcaRuntimeService(store)
       const db = new InMemoryOrchestrationMessages()

--- a/src/shared/persisted-state-types.ts
+++ b/src/shared/persisted-state-types.ts
@@ -85,10 +85,17 @@ export type PersistedState = {
     pr: Record<string, { data: PRInfo | null; fetchedAt: number }>
     issue: Record<string, { data: IssueInfo | null; fetchedAt: number }>
   }
-  /** Legacy single-blob session, kept as the canonical 'local' host partition so an app downgrade still reads its workspace. */
+  /** In-memory local-host API and rollback-compatible core projection. The sidecar is the hot-path
+   *  authority; core synchronization is debounced separately. */
   workspaceSession: WorkspaceSessionState
-  /** Per-execution-host session partitions for non-'local' hosts (ssh:/runtime:); 'local' stays in workspaceSession so pre-partition builds keep working. */
+  /** In-memory non-local partitions and rollback-compatible core projection. Each host also has an
+   *  independently atomic sidecar. */
   workspaceSessionsByHostId?: Partial<Record<ExecutionHostId, WorkspaceSessionState>>
+  /** Logical generations mirrored into the rollback-compatible core projection. */
+  workspaceSessionSidecarGenerationByHostId?: Partial<Record<ExecutionHostId, number>>
+  /** Profile transfer journal: while true, embedded sessions/host ids are authoritative over a
+   *  possibly partial sidecar replacement. */
+  workspaceSessionSidecarReplacementPending?: boolean
   sshTargets: SshTarget[]
   /** SSH config aliases the user deleted; suppresses re-import from ~/.ssh/config so a deleted host doesn't reappear. */
   deletedSshConfigAliases: string[]

--- a/src/shared/workspace-session-browser-history.ts
+++ b/src/shared/workspace-session-browser-history.ts
@@ -42,7 +42,11 @@ export function normalizeBrowserHistoryEntries(
       continue
     }
     seen.add(key)
-    normalizedEntries.push({ ...entry, url: safeUrl, normalizedUrl: key })
+    normalizedEntries.push(
+      entry.url === safeUrl && entry.normalizedUrl === key
+        ? entry
+        : { ...entry, url: safeUrl, normalizedUrl: key }
+    )
     if (normalizedEntries.length >= MAX_BROWSER_HISTORY_ENTRIES) {
       break
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​800 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​780 |
| Prod | 20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1523 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​47 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1476 |

<!-- /orca-pr-loc -->

## Problem
Ordinary workspace-session churn (terminal tabs, layouts, PTY bindings, browser history, and host recovery state) flowed through the monolithic profile writer. A one-host session patch could project, stringify, sentinel-substitute, encrypt/hash, and atomically rewrite the full profile—about 5.2 MB in the measured fleet case—on the main-process persistence path.

## Solution
- Store local and remote workspace sessions in independently atomic per-host sidecars.
- Serialize only changed host partitions during ordinary session churn; keep core profile projection out of that debounce path.
- Use durable temp/fsync/rename writes, two bounded backups per materialized host, write generations, host isolation, bounded exponential retry with deterministic jitter, and trace bytes/duration/trigger fields.
- Preserve rollback compatibility with synchronized core hashes and a replacement journal. Core compatibility synchronization occurs at quit, profile switch/transfer, and non-session core writes.
- Migrate legacy embedded sessions only after durable sidecars, recover corrupt/missing primaries from backups, prune removed/reassigned hosts, and propagate exact load migrations and SSH lease/target mutations to their affected partitions.
- Make profile/quit barriers await stable core and session generations, while ordinary debounce flushes remain bounded to one captured generation under continuous churn.

## ELI5
Instead of rewriting one giant notebook every time one computer's terminal tab changes, Orca now gives each computer/runtime a small notebook. A change rewrites only that notebook. The big notebook is updated at compatibility boundaries so older Orca builds still have a safe copy.

## Proof
- `pnpm exec vitest run --config config/vitest.config.ts src/main/persistence-workspace-session-sidecars.test.ts src/main/persistence-host-partitioned-sessions.test.ts src/main/persistence-settings-update.test.ts src/main/orca-profiles/profile-project-transfer.test.ts src/main/persistence-ssh-remote-pty-leases.test.ts src/main/persistence-repo-lifecycle.test.ts` — 6 files, 126 tests passed.
- `pnpm typecheck` — passed (`typecheck:node` coverage included).
- Worker full `pnpm lint` — passed, including native/type-aware oxlint, reliability, max-lines, Electron, skill, and localization gates.
- Scale/steady-state: 8 already-normalized hosts restart with byte-identical core and zero sidecar generation bumps; one changed host rewrites only that partition.
- Deterministic coverage includes concurrent write generations, crash reload, rollback builds that drop unknown metadata, corrupt/missing primary recovery, migration failure retention, bounded transient/permanent retry, continuous churn I/O bounds, PTY rollback, SSH cleanup/reassignment, quit, and profile-switch barriers.
- Long review-until-clean pass fixed every discovered functional/readiness/security issue. Final functional, readiness, and security reviews report P0/P1/P2 = 0 across all seven reviews.

## Readiness verdict
CLEAN — P0: 0, P1: 0, P2: 0.

## User-visible tradeoffs
- Each materialized host may retain one primary sidecar plus two backups, adding bounded disk usage and write amplification for that changed partition.
- The rollback-compatible core projection still synchronizes on quit, profile changes/transfers, and non-session core writes.
- Transient disk failures retry with bounded exponential backoff; permanent errors stop after the bounded barrier attempt budget and remain surfaced rather than spinning forever.

## Surface and residual risk
- No mobile-facing API or renderer surface changes.
- Residual risk is filesystem-specific behavior outside covered fault injection; durable helpers retain macOS/Linux/Windows semantics, including SSH/runtime/folder profiles, and tests inject rename/write/corruption/crash races rather than exercising every real filesystem implementation.