### PR TITLE
feat(orcad): add headless browser providers

### DIFF
--- a/config/scripts/build-orcad.mjs
+++ b/config/scripts/build-orcad.mjs
@@ -8,13 +8,17 @@
  * the host Node floor at 18 instead of 22.5+.
  */
 import { build } from 'esbuild'
-import { mkdirSync, rmSync } from 'node:fs'
+import { chmodSync, copyFileSync, mkdirSync, rmSync } from 'node:fs'
+import { arch, platform } from 'node:os'
 import { join } from 'node:path'
 import process from 'node:process'
 
 const ROOT = join(import.meta.dirname, '..', '..')
 const OUT_DIR = join(ROOT, 'out', 'orcad')
 const ENTRY = join(ROOT, 'src/main/orcad/main.ts')
+const AGENT_BROWSER_NAME = `agent-browser-${platform()}-${arch()}${process.platform === 'win32' ? '.exe' : ''}`
+const AGENT_BROWSER_SOURCE = join(ROOT, 'node_modules', 'agent-browser', 'bin', AGENT_BROWSER_NAME)
+const AGENT_BROWSER_OUTPUT = join(OUT_DIR, AGENT_BROWSER_NAME)
 
 // Native addons must exist on the host; they cannot be bundled.
 // `electron` is external so a residual import fails loudly at require() time rather
@@ -48,6 +52,10 @@ const externalNativeAddons = {
 
 rmSync(OUT_DIR, { recursive: true, force: true })
 mkdirSync(OUT_DIR, { recursive: true })
+copyFileSync(AGENT_BROWSER_SOURCE, AGENT_BROWSER_OUTPUT)
+if (process.platform !== 'win32') {
+  chmodSync(AGENT_BROWSER_OUTPUT, 0o755)
+}
 
 const result = await build({
   entryPoints: [ENTRY],
@@ -78,12 +86,34 @@ for (const [file, info] of Object.entries(result.metafile.inputs)) {
     }
   }
 }
+const sqliteImporters = new Set()
+for (const [file, info] of Object.entries(result.metafile.inputs)) {
+  for (const imported of info.imports ?? []) {
+    const specifier = imported.original ?? imported.path
+    if (specifier === 'node:sqlite') {
+      sqliteImporters.add(file)
+    }
+  }
+}
 
+const graphErrors = []
 if (electronImporters.size > 0) {
-  console.error(
-    `[build-orcad] ${electronImporters.size} module(s) in the bundle import electron:
-${[...electronImporters].map((f) => `  - ${f}`).join('\n')}`
+  graphErrors.push(
+    `${electronImporters.size} module(s) in the bundle import electron:\n${[...electronImporters]
+      .map((file) => `  - ${file}`)
+      .join('\n')}`
   )
+}
+if (sqliteImporters.size > 0) {
+  graphErrors.push(
+    `${sqliteImporters.size} module(s) in the bundle import node:sqlite:\n${[...sqliteImporters]
+      .map((file) => `  - ${file}`)
+      .join('\n')}`
+  )
+}
+
+if (graphErrors.length > 0) {
+  console.error(`[build-orcad] ${graphErrors.join('\n')}`)
   // Why this can exceed the ratchet baseline: the ratchet measures the graph reachable
   // from orca-runtime + runtime-rpc, but this entry also imports ipc/pty directly to
   // install the PTY controller. Once orcad ships, it should become a ratchet entry
@@ -91,6 +121,6 @@ ${[...electronImporters].map((f) => `  - ${f}`).join('\n')}`
   process.exitCode = 1
 } else {
   console.log(
-    `[build-orcad] ok — ${(output.bytes / 1024 / 1024).toFixed(2)} MB, ${Object.keys(output.inputs).length} modules, zero electron imports.`
+    `[build-orcad] ok — ${(output.bytes / 1024 / 1024).toFixed(2)} MB, ${Object.keys(output.inputs).length} modules, zero electron and node:sqlite imports.`
   )
 }

--- a/config/scripts/runtime-serve-terminal-smoke.mjs
+++ b/config/scripts/runtime-serve-terminal-smoke.mjs
@@ -18,11 +18,14 @@
  *   - a paired client can list worktrees and create a terminal,
  *   - a command run in that terminal produces its output,
  *   - the server exits when asked.
+ * Optional `--browser` assertions:
+ *   - create, navigate, evaluate, and screenshot through the selected host provider.
  */
 import { spawn, spawnSync } from 'node:child_process'
 import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { randomBytes } from 'node:crypto'
 import process from 'node:process'
 
@@ -274,6 +277,50 @@ async function main() {
       throw new Error('worktree.create succeeded but worktree.show cannot resolve it')
     }
     log(`server resolves ${shown.id}`)
+    if (process.argv.includes('--browser')) {
+      const status = orca(pairingCode, ['status'])
+      if (!status?.runtime?.capabilities?.includes('browser.headless.v1')) {
+        throw new Error(
+          `status omitted browser.headless.v1: ${JSON.stringify(status?.runtime?.capabilities)}`
+        )
+      }
+      const fixturePath = join(userDataDir, 'browser-smoke.html')
+      writeFileSync(
+        fixturePath,
+        '<!doctype html><title>Orcad Browser Smoke</title><main>browser-ready</main>'
+      )
+      const browserPageId = orca(pairingCode, [
+        'tab',
+        'create',
+        '--worktree',
+        created.id,
+        '--url',
+        'about:blank'
+      ])?.browserPageId
+      if (!browserPageId) {
+        throw new Error('browser.tabCreate returned no browser page id')
+      }
+      const targetFlags = ['--worktree', created.id, '--page', browserPageId]
+      const targetUrl = pathToFileURL(fixturePath).href
+      const navigation = orca(pairingCode, ['goto', ...targetFlags, '--url', targetUrl])
+      if (navigation?.url !== targetUrl || navigation?.title !== 'Orcad Browser Smoke') {
+        throw new Error(`browser.goto returned the wrong page: ${JSON.stringify(navigation)}`)
+      }
+      const evaluated = orca(pairingCode, [
+        'eval',
+        ...targetFlags,
+        '--expression',
+        'document.querySelector("main")?.textContent'
+      ])
+      if (evaluated?.result !== 'browser-ready') {
+        throw new Error(`browser.eval returned ${JSON.stringify(evaluated)}`)
+      }
+      const screenshot = orca(pairingCode, ['screenshot', ...targetFlags])
+      if (screenshot?.format !== 'png' || typeof screenshot.data !== 'string' || !screenshot.data) {
+        throw new Error('browser.screenshot returned no PNG data')
+      }
+      log('browser navigate/evaluate/screenshot round trip OK')
+    }
 
     const terminal = orca(pairingCode, ['terminal', 'create', '--worktree', created.id])?.terminal
     if (!terminal?.handle) {

--- a/src/cli/runtime/client.ts
+++ b/src/cli/runtime/client.ts
@@ -172,7 +172,8 @@ export class RuntimeClient {
             ...(response.result.remoteUpdateSupport
               ? { remoteUpdateSupport: response.result.remoteUpdateSupport }
               : {}),
-            ...(response.result.capabilities ? { capabilities: response.result.capabilities } : {})
+            ...(response.result.capabilities ? { capabilities: response.result.capabilities } : {}),
+            ...(response.result.degradations ? { degradations: response.result.degradations } : {})
           },
           graph: {
             state: graphState

--- a/src/cli/runtime/status.test.ts
+++ b/src/cli/runtime/status.test.ts
@@ -47,7 +47,14 @@ describe.skipIf(process.platform === 'win32')('CLI runtime status', () => {
               rendererGraphEpoch: 1,
               graphStatus: 'ready',
               authoritativeWindowId: null,
-              liveTabCount: 0
+              liveTabCount: 0,
+              degradations: [
+                {
+                  code: 'browser_unavailable',
+                  capability: 'browser.headless.v1',
+                  message: 'Browser automation is unavailable.'
+                }
+              ]
             },
             _meta: { runtimeId: 'runtime-legacy' }
           })}\n`
@@ -72,7 +79,8 @@ describe.skipIf(process.platform === 'win32')('CLI runtime status', () => {
     expect(status.result.runtime).toMatchObject({
       reachable: true,
       runtimeId: 'runtime-legacy',
-      state: 'ready'
+      state: 'ready',
+      degradations: [expect.objectContaining({ code: 'browser_unavailable' })]
     })
   })
 })

--- a/src/cli/runtime/status.ts
+++ b/src/cli/runtime/status.ts
@@ -56,7 +56,8 @@ export async function getCliStatus(
         ...(response.result.remoteUpdateSupport
           ? { remoteUpdateSupport: response.result.remoteUpdateSupport }
           : {}),
-        ...(response.result.capabilities ? { capabilities: response.result.capabilities } : {})
+        ...(response.result.capabilities ? { capabilities: response.result.capabilities } : {}),
+        ...(response.result.degradations ? { degradations: response.result.degradations } : {})
       },
       graph: {
         state: graphState

--- a/src/cli/runtime/websocket-transport.test.ts
+++ b/src/cli/runtime/websocket-transport.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { WebSocketServer } from 'ws'
 import { encodePairingOffer, type PairingOffer } from '../../shared/pairing'
+import type { RuntimeStatus } from '../../shared/runtime-types'
 import {
   decrypt,
   deriveSharedKey,
@@ -90,7 +91,14 @@ describe('CLI remote WebSocket transport', () => {
         automatic: false,
         reason: 'manual-service-update-required'
       },
-      capabilities: ['updater.remote-control.v1']
+      capabilities: ['updater.remote-control.v1'],
+      degradations: [
+        {
+          code: 'browser_unavailable',
+          capability: 'browser.headless.v1',
+          message: 'Browser automation is unavailable.'
+        }
+      ]
     })
     servers.push(runtime)
     const offer: PairingOffer = {
@@ -113,7 +121,8 @@ describe('CLI remote WebSocket transport', () => {
     expect(status.result.runtime).toMatchObject({
       appVersion: '1.5.0',
       remoteUpdateSupport: { automatic: false, reason: 'manual-service-update-required' },
-      capabilities: ['updater.remote-control.v1']
+      capabilities: ['updater.remote-control.v1'],
+      degradations: [expect.objectContaining({ code: 'browser_unavailable' })]
     })
   })
 
@@ -243,6 +252,7 @@ async function startTestRuntime(
       reason: 'manual-service-update-required'
     }
     capabilities?: string[]
+    degradations?: RuntimeStatus['degradations']
   } = {}
 ): Promise<TestRuntime> {
   const serverKeyPair = generateKeyPair()
@@ -314,7 +324,8 @@ async function startTestRuntime(
                   MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION,
                 appVersion: statusOverrides.appVersion,
                 remoteUpdateSupport: statusOverrides.remoteUpdateSupport,
-                capabilities: statusOverrides.capabilities
+                capabilities: statusOverrides.capabilities,
+                degradations: statusOverrides.degradations
               },
               _meta: { runtimeId }
             }

--- a/src/main/orcad/electron-serve-browser-process.ts
+++ b/src/main/orcad/electron-serve-browser-process.ts
@@ -1,0 +1,299 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { createServer, type AddressInfo } from 'node:net'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
+import { z } from 'zod'
+import { BrowserError } from '../browser/browser-error'
+import type {
+  RuntimeBrowserCommandHost,
+  RuntimeBrowserCommands
+} from '../runtime/orca-runtime-browser'
+import type { RuntimeMetadata } from '../../shared/runtime-bootstrap'
+import { BROWSER_UNAVAILABLE_ERROR_CODE } from '../../shared/runtime-types'
+import { readRuntimeMetadata } from '../runtime/runtime-metadata'
+import { spawnProcess, type SpawnedProcess } from '../../shared/child-process/run-process'
+import { sendOrcadSidecarRequest } from './orcad-sidecar-runtime-client'
+import {
+  ElectronSidecarTabRegistry,
+  ElectronSidecarTabSchema,
+  type ElectronSidecarPage
+} from './electron-sidecar-tab-registry'
+import {
+  electronSidecarRuntimeMethodName,
+  TARGETLESS_BROWSER_METHODS
+} from './electron-sidecar-method-routing'
+
+const START_TIMEOUT_MS = 120_000
+const STOP_TIMEOUT_MS = 5_000
+const BrowserPageResult = z.object({ browserPageId: z.string() }).passthrough()
+const BrowserCloseResult = z.object({ closed: z.boolean() }).passthrough()
+const BrowserTabListResult = z.object({ tabs: z.array(ElectronSidecarTabSchema) }).passthrough()
+const RuntimeStatusResult = z.object({ capabilities: z.array(z.string()).optional() }).passthrough()
+
+async function reserveLoopbackPort(): Promise<number> {
+  const server = createServer()
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      server.removeListener('error', reject)
+      resolve()
+    })
+  })
+  const address = server.address() as AddressInfo
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error)
+      } else {
+        resolve()
+      }
+    })
+  })
+  return address.port
+}
+function electronServeEnvironment(): NodeJS.ProcessEnv {
+  const environment = { ...process.env }
+  for (const key of [
+    'AGENT_BROWSER_ARGS',
+    'AGENT_BROWSER_AUTO_CONNECT',
+    'AGENT_BROWSER_CDP',
+    'AGENT_BROWSER_ENGINE',
+    'AGENT_BROWSER_EXECUTABLE_PATH',
+    'AGENT_BROWSER_HEADED',
+    'AGENT_BROWSER_PROFILE',
+    'AGENT_BROWSER_PROVIDER',
+    'AGENT_BROWSER_SESSION',
+    'AGENT_BROWSER_SESSION_NAME',
+    'AGENT_BROWSER_STATE'
+  ]) {
+    delete environment[key]
+  }
+  return environment
+}
+
+function signalProcess(pid: number, signal: NodeJS.Signals): void {
+  try {
+    process.kill(pid, signal)
+  } catch {
+    // The sidecar already exited.
+  }
+}
+
+function processIsLive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export class ElectronServeBrowserProcess {
+  private child: SpawnedProcess | null = null
+  private metadata: RuntimeMetadata | null = null
+  private readonly tabs = new ElectronSidecarTabRegistry()
+  private sidecarDataPath: string | null = null
+
+  constructor(private readonly executablePath: string) {}
+
+  async start(): Promise<void> {
+    const temporaryRoot = process.platform === 'win32' ? tmpdir() : '/tmp'
+    const userDataPath = await mkdtemp(join(temporaryRoot, 'orcad-browser-'))
+    this.sidecarDataPath = userDataPath
+    const port = await reserveLoopbackPort()
+    const child = spawnProcess({
+      program: this.executablePath,
+      args: [
+        '--serve',
+        '--serve-port',
+        String(port),
+        '--serve-json',
+        '--serve-no-pairing',
+        `--user-data-dir=${userDataPath}`
+      ],
+      env: electronServeEnvironment()
+    })
+    this.child = child
+    for (const stream of [child.stdout, child.stderr]) {
+      stream?.on('error', () => undefined)
+      stream?.resume()
+    }
+    const deadline = Date.now() + START_TIMEOUT_MS
+    let lastError: unknown = null
+    while (Date.now() < deadline) {
+      const metadata = readRuntimeMetadata(userDataPath)
+      if (metadata) {
+        try {
+          const status = RuntimeStatusResult.parse(
+            await sendOrcadSidecarRequest(metadata, 'status.get', undefined, 5_000)
+          )
+          if (status.capabilities?.includes('browser.headless.v1')) {
+            this.metadata = metadata
+            return
+          }
+          lastError = new Error('Installed Electron app omitted browser.headless.v1.')
+        } catch (error) {
+          lastError = error
+        }
+      }
+      if (child.exitCode !== null || child.signalCode !== null) {
+        break
+      }
+      await delay(100)
+    }
+    throw new Error(
+      `Installed Electron browser provider did not become ready: ${
+        lastError instanceof Error ? lastError.message : 'no runtime metadata'
+      }`
+    )
+  }
+
+  createCommands(host: RuntimeBrowserCommandHost): RuntimeBrowserCommands {
+    return new Proxy({} as RuntimeBrowserCommands, {
+      get: (_target, property) => {
+        if (property === 'then') {
+          return undefined
+        }
+        if (typeof property !== 'string') {
+          return undefined
+        }
+        return (...args: unknown[]) => this.invoke(host, property, args)
+      }
+    })
+  }
+  isAvailable(): boolean {
+    return this.metadata !== null && processIsLive(this.metadata.pid)
+  }
+
+  async stop(): Promise<void> {
+    const child = this.child
+    const sidecarPid = this.metadata?.pid ?? child?.pid ?? null
+    const sidecarDataPath = this.sidecarDataPath
+    this.child = null
+    this.metadata = null
+    this.sidecarDataPath = null
+    this.tabs.clear()
+    if (sidecarPid) {
+      signalProcess(sidecarPid, 'SIGTERM')
+      const deadline = Date.now() + STOP_TIMEOUT_MS
+      while (processIsLive(sidecarPid) && Date.now() < deadline) {
+        await delay(50)
+      }
+      if (processIsLive(sidecarPid)) {
+        signalProcess(sidecarPid, 'SIGKILL')
+      }
+    }
+    if (sidecarDataPath) {
+      await rm(sidecarDataPath, { recursive: true, force: true })
+    }
+  }
+
+  private async invoke(
+    host: RuntimeBrowserCommandHost,
+    method: string,
+    args: unknown[]
+  ): Promise<unknown> {
+    if (method === 'browserScreencast') {
+      throw new BrowserError(
+        'browser_screencast_unavailable',
+        'The orcad Electron provider does not proxy screencast.'
+      )
+    }
+    const metadata = this.metadata
+    if (!metadata) {
+      throw new BrowserError(
+        BROWSER_UNAVAILABLE_ERROR_CODE,
+        'The Electron browser provider is not running.'
+      )
+    }
+    const original = (args[0] ?? {}) as Record<string, unknown>
+    const worktreeId =
+      typeof original.worktree === 'string'
+        ? (await host.resolveWorktreeSelector(original.worktree)).id
+        : undefined
+    const params: Record<string, unknown> = { ...original, worktree: undefined }
+    const requestedPageId = typeof original.page === 'string' ? original.page : undefined
+    const requestedIndex = typeof original.index === 'number' ? original.index : undefined
+    let targetPage: ElectronSidecarPage | undefined
+    let rpcMethod = electronSidecarRuntimeMethodName(method)
+    if (method === 'browserTabCreate' && requestedPageId) {
+      const existing = this.tabs.find(requestedPageId)
+      if (existing) {
+        this.tabs.require(requestedPageId, worktreeId)
+        return { browserPageId: requestedPageId }
+      }
+    }
+
+    if (method === 'browserTabCurrent' && worktreeId) {
+      targetPage = this.tabs.active(worktreeId)
+      rpcMethod = 'browser.tabShow'
+      params.page = targetPage.sidecarPageId
+    } else if (method === 'browserTabSwitch' || method === 'browserTabClose') {
+      targetPage = requestedPageId
+        ? this.tabs.require(requestedPageId, worktreeId)
+        : requestedIndex !== undefined
+          ? this.tabs.pageAt(worktreeId, requestedIndex)
+          : worktreeId
+            ? this.tabs.active(worktreeId)
+            : undefined
+      if (targetPage) {
+        params.page = targetPage.sidecarPageId
+        delete params.index
+      }
+    } else if (requestedPageId) {
+      targetPage = this.tabs.require(requestedPageId, worktreeId)
+      params.page = targetPage.sidecarPageId
+    } else if (worktreeId && !TARGETLESS_BROWSER_METHODS[method]) {
+      targetPage = this.tabs.active(worktreeId)
+      params.page = targetPage.sidecarPageId
+    }
+
+    let result: unknown
+    try {
+      result = await sendOrcadSidecarRequest(metadata, rpcMethod, params)
+    } catch (error) {
+      if (
+        targetPage &&
+        error instanceof BrowserError &&
+        (error.code === 'browser_tab_not_found' || error.code === 'browser_tab_closed')
+      ) {
+        this.tabs.delete(targetPage)
+      }
+      throw error
+    }
+    if (method === 'browserTabCreate') {
+      const created = BrowserPageResult.parse(result)
+      const page = this.tabs.register(created.browserPageId, requestedPageId, worktreeId)
+      return { ...created, browserPageId: page.publicPageId }
+    }
+    if (method === 'browserTabList') {
+      const listed = BrowserTabListResult.parse(result)
+      return { ...listed, tabs: this.tabs.reconcileTabs(listed.tabs, worktreeId) }
+    }
+    if (method === 'browserTabSwitch') {
+      const switched = BrowserPageResult.parse(result)
+      const page = this.tabs.pageForSidecar(switched.browserPageId)
+      if (page) {
+        this.tabs.setActive(page)
+      }
+      return {
+        ...switched,
+        ...(requestedIndex !== undefined ? { switched: requestedIndex } : {}),
+        browserPageId: this.tabs.publicPageId(switched.browserPageId)
+      }
+    }
+    if (method === 'browserTabClose' && targetPage) {
+      const closed = BrowserCloseResult.parse(result)
+      if (closed.closed) {
+        this.tabs.delete(targetPage)
+      }
+      return closed
+    }
+    if (method === 'browserTabProfileClone') {
+      const cloned = BrowserPageResult.parse(result)
+      this.tabs.register(cloned.browserPageId, undefined, targetPage?.worktreeId)
+    }
+    return this.tabs.rewriteResult(result)
+  }
+}

--- a/src/main/orcad/electron-sidecar-method-routing.ts
+++ b/src/main/orcad/electron-sidecar-method-routing.ts
@@ -1,0 +1,37 @@
+export const TARGETLESS_BROWSER_METHODS: Record<string, true> = {
+  browserProfileClearDefaultCookies: true,
+  browserProfileCreate: true,
+  browserProfileDelete: true,
+  browserProfileDetectBrowsers: true,
+  browserProfileImportFromBrowser: true,
+  browserProfileList: true,
+  browserTabCreate: true,
+  browserTabList: true
+}
+
+export function electronSidecarRuntimeMethodName(browserMethod: string): string {
+  const suffix = browserMethod.slice('browser'.length)
+  if (suffix === 'ProceedCertificate') {
+    return 'browser.certificate.proceed'
+  }
+  if (suffix === 'SetViewport') {
+    return 'browser.viewport'
+  }
+  if (suffix === 'SetGeolocation') {
+    return 'browser.geolocation'
+  }
+  for (const group of ['Cookie', 'Intercept', 'Capture'] as const) {
+    if (suffix.startsWith(group)) {
+      const action = suffix.slice(group.length)
+      return `browser.${group.toLowerCase()}.${action[0].toLowerCase()}${action.slice(1)}`
+    }
+  }
+  for (const storage of ['StorageLocal', 'StorageSession'] as const) {
+    if (suffix.startsWith(storage)) {
+      const action = suffix.slice(storage.length)
+      const area = storage === 'StorageLocal' ? 'local' : 'session'
+      return `browser.storage.${area}.${action[0].toLowerCase()}${action.slice(1)}`
+    }
+  }
+  return `browser.${suffix[0].toLowerCase()}${suffix.slice(1)}`
+}

--- a/src/main/orcad/electron-sidecar-tab-registry.test.ts
+++ b/src/main/orcad/electron-sidecar-tab-registry.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { ElectronSidecarTabRegistry } from './electron-sidecar-tab-registry'
+
+describe('ElectronSidecarTabRegistry', () => {
+  it('preserves requested ids and fences explicit worktree scope', () => {
+    const registry = new ElectronSidecarTabRegistry()
+    registry.register('sidecar-a', 'public-a', 'worktree-a')
+    registry.register('sidecar-b', 'public-b', 'worktree-b')
+
+    expect(registry.require('public-a', 'worktree-a').sidecarPageId).toBe('sidecar-a')
+    expect(() => registry.require('public-a', 'worktree-b')).toThrow(
+      expect.objectContaining({ code: 'browser_tab_not_found' })
+    )
+    expect(registry.active('worktree-b').publicPageId).toBe('public-b')
+  })
+
+  it('rewrites sidecar ids, worktree-relative indices, and stale pages', () => {
+    const registry = new ElectronSidecarTabRegistry()
+    registry.register('sidecar-a', 'public-a', 'worktree-a')
+    registry.register('sidecar-b', 'public-b', 'worktree-b')
+    registry.register('sidecar-c', 'public-c', 'worktree-a')
+
+    const tabs = registry.reconcileTabs(
+      [
+        { browserPageId: 'sidecar-a', active: false },
+        { browserPageId: 'sidecar-b', active: true },
+        { browserPageId: 'sidecar-c', active: true }
+      ],
+      'worktree-a'
+    )
+    expect(tabs).toEqual([
+      expect.objectContaining({ browserPageId: 'public-a', index: 0 }),
+      expect.objectContaining({ browserPageId: 'public-c', index: 1 })
+    ])
+    expect(registry.active('worktree-a').publicPageId).toBe('public-c')
+
+    registry.reconcileTabs([{ browserPageId: 'sidecar-c' }])
+    expect(() => registry.require('public-a')).toThrow(
+      expect.objectContaining({ code: 'browser_tab_not_found' })
+    )
+  })
+
+  it('rewrites page ids in tab and command results', () => {
+    const registry = new ElectronSidecarTabRegistry()
+    registry.register('sidecar-a', 'public-a', 'worktree-a')
+
+    expect(
+      registry.rewriteResult({
+        browserPageId: 'sidecar-a',
+        tab: {
+          browserPageId: 'sidecar-a',
+          certificateFailure: { browserPageId: 'sidecar-a', challengeId: 'challenge-a' }
+        }
+      })
+    ).toEqual({
+      browserPageId: 'public-a',
+      tab: {
+        browserPageId: 'public-a',
+        certificateFailure: { browserPageId: 'public-a', challengeId: 'challenge-a' }
+      }
+    })
+  })
+})

--- a/src/main/orcad/electron-sidecar-tab-registry.ts
+++ b/src/main/orcad/electron-sidecar-tab-registry.ts
@@ -1,0 +1,169 @@
+import { z } from 'zod'
+import { BrowserError } from '../browser/browser-error'
+
+const CertificateFailure = z
+  .object({ browserPageId: z.string() })
+  .passthrough()
+  .nullable()
+  .optional()
+export const ElectronSidecarTabSchema = z
+  .object({
+    browserPageId: z.string(),
+    index: z.number().optional(),
+    active: z.boolean().optional(),
+    certificateFailure: CertificateFailure
+  })
+  .passthrough()
+const ElectronSidecarResult = z
+  .object({
+    browserPageId: z.string().optional(),
+    sourceBrowserPageId: z.string().optional(),
+    tab: ElectronSidecarTabSchema.optional()
+  })
+  .passthrough()
+
+export type ElectronSidecarTab = z.infer<typeof ElectronSidecarTabSchema>
+
+export type ElectronSidecarPage = {
+  publicPageId: string
+  sidecarPageId: string
+  worktreeId?: string
+}
+
+export class ElectronSidecarTabRegistry {
+  private readonly pagesByPublicId = new Map<string, ElectronSidecarPage>()
+  private readonly pagesBySidecarId = new Map<string, ElectronSidecarPage>()
+  private readonly activePageIdByWorktree = new Map<string, string>()
+
+  clear(): void {
+    this.pagesByPublicId.clear()
+    this.pagesBySidecarId.clear()
+    this.activePageIdByWorktree.clear()
+  }
+
+  register(sidecarPageId: string, requestedPageId: string | undefined, worktreeId?: string) {
+    const publicPageId = requestedPageId || sidecarPageId
+    const page = { publicPageId, sidecarPageId, worktreeId }
+    this.pagesByPublicId.set(publicPageId, page)
+    this.pagesBySidecarId.set(sidecarPageId, page)
+    this.setActive(page)
+    return page
+  }
+  find(publicPageId: string): ElectronSidecarPage | undefined {
+    return this.pagesByPublicId.get(publicPageId)
+  }
+
+  require(publicPageId: string, worktreeId?: string): ElectronSidecarPage {
+    const page = this.pagesByPublicId.get(publicPageId)
+    if (!page || (worktreeId && page.worktreeId !== worktreeId)) {
+      throw new BrowserError(
+        'browser_tab_not_found',
+        `Browser page ${publicPageId} was not found in this worktree.`
+      )
+    }
+    return page
+  }
+
+  active(worktreeId?: string): ElectronSidecarPage {
+    const publicPageId = this.activePageIdByWorktree.get(worktreeId ?? '')
+    const page = publicPageId ? this.pagesByPublicId.get(publicPageId) : undefined
+    if (!page) {
+      throw new BrowserError('browser_no_tab', 'No browser tab is active in this worktree.')
+    }
+    return page
+  }
+
+  pageAt(worktreeId: string | undefined, index: number): ElectronSidecarPage {
+    const page = [...this.pagesByPublicId.values()].filter(
+      (candidate) => !worktreeId || candidate.worktreeId === worktreeId
+    )[index]
+    if (!page) {
+      throw new BrowserError('browser_tab_not_found', `Browser tab index ${index} was not found.`)
+    }
+    return page
+  }
+
+  pageForSidecar(sidecarPageId: string): ElectronSidecarPage | undefined {
+    return this.pagesBySidecarId.get(sidecarPageId)
+  }
+
+  setActive(page: ElectronSidecarPage): void {
+    this.activePageIdByWorktree.set(page.worktreeId ?? '', page.publicPageId)
+  }
+
+  delete(page: ElectronSidecarPage): void {
+    this.pagesByPublicId.delete(page.publicPageId)
+    this.pagesBySidecarId.delete(page.sidecarPageId)
+    const key = page.worktreeId ?? ''
+    if (this.activePageIdByWorktree.get(key) === page.publicPageId) {
+      const replacement = [...this.pagesByPublicId.values()].find(
+        (candidate) => candidate.worktreeId === page.worktreeId
+      )
+      if (replacement) {
+        this.activePageIdByWorktree.set(key, replacement.publicPageId)
+      } else {
+        this.activePageIdByWorktree.delete(key)
+      }
+    }
+  }
+
+  publicPageId(sidecarPageId: string): string {
+    return this.pagesBySidecarId.get(sidecarPageId)?.publicPageId ?? sidecarPageId
+  }
+
+  reconcileTabs(tabs: ElectronSidecarTab[], worktreeId?: string): ElectronSidecarTab[] {
+    const liveSidecarPageIds = new Set(tabs.map((tab) => tab.browserPageId))
+    for (const page of this.pagesByPublicId.values()) {
+      if (!liveSidecarPageIds.has(page.sidecarPageId)) {
+        this.delete(page)
+      }
+    }
+    return tabs
+      .flatMap((tab) => {
+        const page =
+          this.pagesBySidecarId.get(tab.browserPageId) ??
+          (worktreeId ? undefined : this.register(tab.browserPageId, undefined, undefined))
+        if (!page || (worktreeId && page.worktreeId !== worktreeId)) {
+          return []
+        }
+        if (tab.active === true) {
+          this.setActive(page)
+        }
+        return [this.rewriteTab(tab)]
+      })
+      .map((tab, index) => ({ ...tab, index }))
+  }
+
+  rewriteResult(result: unknown): unknown {
+    const parsed = ElectronSidecarResult.safeParse(result)
+    if (!parsed.success) {
+      return result
+    }
+    const rewritten = { ...parsed.data }
+    if (rewritten.browserPageId) {
+      rewritten.browserPageId = this.publicPageId(rewritten.browserPageId)
+    }
+    if (rewritten.sourceBrowserPageId) {
+      rewritten.sourceBrowserPageId = this.publicPageId(rewritten.sourceBrowserPageId)
+    }
+    if (rewritten.tab) {
+      rewritten.tab = this.rewriteTab(rewritten.tab)
+    }
+    return rewritten
+  }
+
+  private rewriteTab(tab: ElectronSidecarTab): ElectronSidecarTab {
+    return {
+      ...tab,
+      browserPageId: this.publicPageId(tab.browserPageId),
+      ...(tab.certificateFailure
+        ? {
+            certificateFailure: {
+              ...tab.certificateFailure,
+              browserPageId: this.publicPageId(tab.certificateFailure.browserPageId)
+            }
+          }
+        : {})
+    }
+  }
+}

--- a/src/main/orcad/external-chromium-browser-process.integration.test.ts
+++ b/src/main/orcad/external-chromium-browser-process.integration.test.ts
@@ -1,0 +1,63 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { resolveOrcadBrowserProvider } from './orcad-browser-provider'
+
+const executablePath = process.env.ORCA_BROWSER_EXECUTABLE
+
+describe('ExternalChromiumBrowserProcess integration', () => {
+  it.runIf(Boolean(executablePath))(
+    'navigates, evaluates, and screenshots with the operator executable',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'orcad-external-browser-'))
+      const fixturePath = join(root, 'fixture.html')
+      await writeFile(
+        fixturePath,
+        '<!doctype html><title>External Chromium</title><main>external-ready</main>'
+      )
+      const provider = await resolveOrcadBrowserProvider({
+        userDataPath: root,
+        environment: { ORCA_BROWSER_EXECUTABLE: executablePath },
+        resolveInstalledElectronExecutable: async () => null
+      })
+      try {
+        expect(provider?.kind).toBe('chromium')
+        if (!provider) {
+          throw new Error('External Chromium provider did not resolve.')
+        }
+        const commands = provider.factory({
+          getAgentBrowserBridge: () => null,
+          resolveWorktreeSelector: async (selector) => ({ id: selector }),
+          getAuthoritativeWindow: () => {
+            throw new Error('No renderer')
+          },
+          getAvailableAuthoritativeWindow: () => null,
+          getOffscreenBrowserBackend: () => null
+        })
+        await expect(
+          commands.browserTabCreate({ page: 'external-page', url: 'about:blank' })
+        ).resolves.toEqual({ browserPageId: 'external-page' })
+        await expect(
+          commands.browserGoto({
+            page: 'external-page',
+            url: pathToFileURL(fixturePath).href
+          })
+        ).resolves.toMatchObject({ title: 'External Chromium' })
+        await expect(
+          commands.browserEval({
+            page: 'external-page',
+            expression: 'document.querySelector("main")?.textContent'
+          })
+        ).resolves.toMatchObject({ result: 'external-ready' })
+        await expect(
+          commands.browserScreenshot({ page: 'external-page', format: 'png' })
+        ).resolves.toMatchObject({ data: expect.stringMatching(/\S+/), format: 'png' })
+      } finally {
+        await provider?.stop()
+        await rm(root, { recursive: true, force: true })
+      }
+    }
+  )
+})

--- a/src/main/orcad/external-chromium-browser-process.ts
+++ b/src/main/orcad/external-chromium-browser-process.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod'
-import type { RuntimeBrowserCommands } from '../runtime/orca-runtime-browser'
-import type { RuntimeBrowserCommandHost } from '../runtime/orca-runtime-browser'
+import type {
+  RuntimeBrowserCommandHost,
+  RuntimeBrowserCommands
+} from '../runtime/orca-runtime-browser'
 import { BrowserError } from '../browser/browser-error'
 import {
   ExternalChromiumBrowserSession,

--- a/src/main/orcad/external-chromium-browser-process.ts
+++ b/src/main/orcad/external-chromium-browser-process.ts
@@ -1,0 +1,186 @@
+import { z } from 'zod'
+import type { RuntimeBrowserCommands } from '../runtime/orca-runtime-browser'
+import type { RuntimeBrowserCommandHost } from '../runtime/orca-runtime-browser'
+import { BrowserError } from '../browser/browser-error'
+import {
+  ExternalChromiumBrowserSession,
+  type ExternalChromiumLaunch
+} from './external-chromium-browser-session'
+export type { ExternalChromiumLaunch } from './external-chromium-browser-session'
+import { normalizeBrowserNavigationUrl } from '../../shared/browser-url'
+import {
+  externalChromiumCommandArguments,
+  normalizeExternalChromiumCommandResult
+} from './external-chromium-command-arguments'
+import {
+  externalChromiumSnapshotResult,
+  type ExternalChromiumPageRecord as PageRecord
+} from './external-chromium-tab-projection'
+import { ExternalChromiumTabRegistry } from './external-chromium-tab-registry'
+const AgentBrowserSnapshot = z.object({
+  refs: z
+    .record(z.string(), z.object({ name: z.string().optional(), role: z.string().optional() }))
+    .optional(),
+  snapshot: z.string().optional()
+})
+
+export class ExternalChromiumBrowserProcess {
+  private readonly session: ExternalChromiumBrowserSession
+  private readonly tabs: ExternalChromiumTabRegistry
+  private queue: Promise<void> = Promise.resolve()
+  private available = false
+
+  constructor(agentBrowserPath: string, launch: ExternalChromiumLaunch, statePath: string) {
+    this.session = new ExternalChromiumBrowserSession(agentBrowserPath, launch, statePath)
+    this.tabs = new ExternalChromiumTabRegistry(this.session)
+  }
+
+  async start(): Promise<void> {
+    this.tabs.initialize(await this.session.start())
+    this.available = true
+  }
+
+  createCommands(host: RuntimeBrowserCommandHost): RuntimeBrowserCommands {
+    return new Proxy({} as RuntimeBrowserCommands, {
+      get: (_target, property) => {
+        if (property === 'then') {
+          return undefined
+        }
+        if (typeof property !== 'string') {
+          return undefined
+        }
+        return (...args: unknown[]) => this.enqueue(() => this.invoke(host, property, args))
+      }
+    })
+  }
+  isAvailable(): boolean {
+    return this.available
+  }
+
+  async stop(): Promise<void> {
+    this.available = false
+    await this.enqueue(async () => {
+      await this.session.stop()
+      this.tabs.clear()
+    })
+  }
+
+  private enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.queue.then(operation, operation)
+    this.queue = result.then(
+      () => undefined,
+      () => undefined
+    )
+    return result
+  }
+
+  private async invoke(
+    host: RuntimeBrowserCommandHost,
+    method: string,
+    args: unknown[]
+  ): Promise<unknown> {
+    const params = (args[0] ?? {}) as Record<string, unknown>
+    if (method === 'browserTabCreate') {
+      return this.tabs.createTab(host, params)
+    }
+    if (method === 'browserTabList') {
+      return this.tabs.listTabs(host, params)
+    }
+    if (method === 'browserTabShow') {
+      return { tab: await this.tabs.describeTab(host, params) }
+    }
+    if (method === 'browserTabCurrent') {
+      return { tab: await this.tabs.currentTab(host, params) }
+    }
+    if (method === 'browserTabSwitch') {
+      return this.tabs.switchTab(host, params)
+    }
+    if (method === 'browserTabClose') {
+      return this.tabs.closeTab(host, params)
+    }
+    if (
+      method.startsWith('browserProfile') ||
+      method === 'browserTabSetProfile' ||
+      method === 'browserTabProfileClone'
+    ) {
+      throw new BrowserError(
+        'browser_profile_unavailable',
+        'Browser profile import and switching require the desktop Electron provider.'
+      )
+    }
+    if (method === 'browserTabProfileShow') {
+      const tab = await this.tabs.describeTab(host, params)
+      return {
+        browserPageId: tab.browserPageId,
+        worktreeId: tab.worktreeId,
+        profileId: 'default',
+        profileLabel: 'Default'
+      }
+    }
+    if (method === 'browserScreencast') {
+      throw new BrowserError(
+        'browser_screencast_unavailable',
+        'This browser provider does not offer screencast.'
+      )
+    }
+    if (method === 'browserProceedCertificate') {
+      throw new BrowserError(
+        'browser_certificate_trust_unavailable',
+        'This browser provider cannot override certificate failures.'
+      )
+    }
+
+    const page = await this.tabs.resolveTargetPage(host, params)
+    await this.session.selectPage(page.agentPageId)
+    if (method === 'browserSnapshot') {
+      return this.snapshot(page)
+    }
+    if (method === 'browserScreenshot') {
+      return this.session.screenshot(params, false)
+    }
+    if (method === 'browserFullScreenshot') {
+      return this.session.screenshot(params, true)
+    }
+    if (method === 'browserPdf') {
+      return this.session.pdf()
+    }
+    if (method === 'browserGoto') {
+      const url = normalizeBrowserNavigationUrl(String(params.url ?? ''))
+      if (!url) {
+        throw new BrowserError(
+          'invalid_argument',
+          `Unsupported browser URL: ${String(params.url ?? '')}`
+        )
+      }
+      return this.session.run(['open', url])
+    }
+    if (method === 'browserEval') {
+      return this.session.run(['eval', String(params.expression ?? '')])
+    }
+    if (method === 'browserSelectAll') {
+      await this.session.run(['focus', String(params.element ?? '')])
+      await this.session.run(['press', 'Control+a'])
+      return { selected: String(params.element ?? '') }
+    }
+    if (method === 'browserBack' || method === 'browserForward' || method === 'browserReload') {
+      await this.session.run([method.slice('browser'.length).toLowerCase()])
+      const tab = await this.tabs.describePage(page)
+      return { url: tab.url, title: tab.title }
+    }
+
+    const command = externalChromiumCommandArguments(method, params)
+    if (!command) {
+      throw new BrowserError(
+        'browser_command_unavailable',
+        `${method} is not supported by this browser provider.`
+      )
+    }
+    const result = await this.session.run(command)
+    return normalizeExternalChromiumCommandResult(method, params, result)
+  }
+
+  private async snapshot(page: PageRecord): Promise<unknown> {
+    const data = AgentBrowserSnapshot.parse(await this.session.run(['snapshot']))
+    return externalChromiumSnapshotResult(page, data, await this.tabs.describePage(page))
+  }
+}

--- a/src/main/orcad/external-chromium-browser-session.ts
+++ b/src/main/orcad/external-chromium-browser-session.ts
@@ -1,0 +1,154 @@
+import { createHash, randomUUID } from 'node:crypto'
+import { mkdir, readFile, rm } from 'node:fs/promises'
+import { join } from 'node:path'
+import { z } from 'zod'
+import { BrowserError } from '../browser/browser-error'
+import { BROWSER_UNAVAILABLE_ERROR_CODE } from '../../shared/runtime-types'
+import { runProcess } from '../../shared/child-process/run-process'
+
+const COMMAND_TIMEOUT_MS = 90_000
+const MAX_OUTPUT_BYTES = 50 * 1024 * 1024
+const CLOSE_TIMEOUT_MS = 5_000
+
+export type ExternalChromiumLaunch = {
+  executablePath: string
+  browserArgs?: readonly string[]
+  provider: 'electron' | 'chromium'
+}
+
+const AgentBrowserTab = z.object({
+  active: z.boolean(),
+  tabId: z.string(),
+  title: z.string(),
+  url: z.string()
+})
+const AgentBrowserTabsResult = z.object({ tabs: z.array(AgentBrowserTab).optional() })
+const AgentBrowserScreenshotResult = z.object({ path: z.string().min(1) })
+const AgentBrowserEnvelope = z.object({
+  success: z.boolean(),
+  data: z.unknown().optional(),
+  error: z.string().nullable().optional()
+})
+
+export type AgentBrowserTab = z.infer<typeof AgentBrowserTab>
+
+function classifyAgentBrowserError(message: string): string {
+  if (/unknown ref|ref not found|element not found: @e/i.test(message)) {
+    return 'browser_stale_ref'
+  }
+  if (/evaluation error/i.test(message)) {
+    return 'browser_eval_error'
+  }
+  if (/navigation|net::err/i.test(message)) {
+    return 'browser_navigation_failed'
+  }
+  if (/timed out|timeout/i.test(message)) {
+    return 'browser_timeout'
+  }
+  if (/tab.*not found|unknown tab/i.test(message)) {
+    return 'browser_tab_not_found'
+  }
+  return 'browser_error'
+}
+
+export class ExternalChromiumBrowserSession {
+  private readonly profilePath: string
+  private readonly sessionName: string
+
+  constructor(
+    private readonly agentBrowserPath: string,
+    private readonly launch: ExternalChromiumLaunch,
+    statePath: string
+  ) {
+    const identity = createHash('sha256')
+      .update(`${statePath}:${launch.provider}`)
+      .digest('hex')
+      .slice(0, 16)
+    this.sessionName = `orca-orcad-${identity}`
+    this.profilePath = join(statePath, `browser-${launch.provider}`)
+  }
+
+  async start(): Promise<string> {
+    await mkdir(this.profilePath, { recursive: true })
+    await this.run(['open', 'about:blank'])
+    const tabs = await this.readTabs()
+    const active = tabs.find((tab) => tab.active) ?? tabs[0]
+    if (!active) {
+      throw new BrowserError(
+        BROWSER_UNAVAILABLE_ERROR_CODE,
+        'The browser launched without an automation target.'
+      )
+    }
+    return active.tabId
+  }
+
+  async stop(): Promise<void> {
+    try {
+      await this.run(['close'], CLOSE_TIMEOUT_MS)
+    } catch {
+      // Closing an already-dead browser is complete cleanup.
+    }
+  }
+
+  async selectPage(agentPageId: string): Promise<void> {
+    await this.run(['tab', agentPageId])
+  }
+
+  async readTabs(): Promise<AgentBrowserTab[]> {
+    return AgentBrowserTabsResult.parse(await this.run(['tab'])).tabs ?? []
+  }
+
+  async screenshot(params: Record<string, unknown>, full: boolean): Promise<unknown> {
+    const format = params.format === 'jpeg' ? 'jpeg' : 'png'
+    const command = ['screenshot', ...(full ? ['--full'] : []), '--screenshot-format', format]
+    const result = AgentBrowserScreenshotResult.parse(await this.run(command))
+    const data = (await readFile(result.path)).toString('base64')
+    await rm(result.path, { force: true }).catch(() => undefined)
+    return { data, format }
+  }
+
+  async pdf(): Promise<unknown> {
+    const outputPath = join(this.profilePath, `capture-${randomUUID()}.pdf`)
+    await this.run(['pdf', outputPath])
+    const data = (await readFile(outputPath)).toString('base64')
+    await rm(outputPath, { force: true }).catch(() => undefined)
+    return { data }
+  }
+
+  async run(command: readonly string[], timeoutMs = COMMAND_TIMEOUT_MS): Promise<unknown> {
+    const args = ['--session', this.sessionName, '--profile', this.profilePath]
+    if (this.launch.browserArgs?.length) {
+      args.push('--args', this.launch.browserArgs.join('\n'))
+    }
+    args.push(...command, '--json')
+    const env = {
+      ...process.env,
+      AGENT_BROWSER_EXECUTABLE_PATH: this.launch.executablePath,
+      AGENT_BROWSER_PROFILE: this.profilePath,
+      AGENT_BROWSER_SESSION: this.sessionName,
+      AGENT_BROWSER_ARGS: this.launch.browserArgs?.join('\n') ?? ''
+    }
+    const result = await runProcess({
+      program: this.agentBrowserPath,
+      args,
+      env,
+      timeoutMs,
+      maxOutputBytes: MAX_OUTPUT_BYTES
+    })
+    if (result.timedOut) {
+      throw new BrowserError('browser_timeout', 'Browser command timed out.')
+    }
+    let envelope: z.infer<typeof AgentBrowserEnvelope>
+    try {
+      envelope = AgentBrowserEnvelope.parse(JSON.parse(result.stdout))
+    } catch {
+      const detail = result.stderr.trim() || `exit ${String(result.code)}`
+      throw new BrowserError('browser_error', `Browser command failed: ${detail.slice(0, 1000)}`)
+    }
+    if (!envelope.success) {
+      const message = envelope.error ?? (result.stderr.trim() || 'Unknown browser error.')
+      throw new BrowserError(classifyAgentBrowserError(message), message)
+    }
+    return envelope.data
+  }
+}

--- a/src/main/orcad/external-chromium-command-arguments.ts
+++ b/src/main/orcad/external-chromium-command-arguments.ts
@@ -1,0 +1,293 @@
+import { BrowserError } from '../browser/browser-error'
+const TARGET_OVERRIDE_FLAGS: Record<string, true> = {
+  '--args': true,
+  '--cdp': true,
+  '--executable-path': true,
+  '--profile': true,
+  '--session': true
+}
+const TARGET_OVERRIDE_FLAG_PREFIXES = Object.keys(TARGET_OVERRIDE_FLAGS).map((flag) => `${flag}=`)
+
+function parseExecArguments(input: string): string[] {
+  const args: string[] = []
+  let value = ''
+  let quote: '"' | "'" | null = null
+  let escaped = false
+  for (const char of input.trim()) {
+    if (escaped) {
+      value += char
+      escaped = false
+    } else if (char === '\\' && quote !== "'") {
+      escaped = true
+    } else if (quote) {
+      if (char === quote) {
+        quote = null
+      } else {
+        value += char
+      }
+    } else if (char === '"' || char === "'") {
+      quote = char
+    } else if (/\s/.test(char)) {
+      if (value) {
+        args.push(value)
+        value = ''
+      }
+    } else {
+      value += char
+    }
+  }
+  if (escaped) {
+    value += '\\'
+  }
+  if (quote) {
+    throw new BrowserError('invalid_argument', 'Browser command has an unclosed quote.')
+  }
+  if (value) {
+    args.push(value)
+  }
+  return args
+}
+function stripTargetOverrideArguments(args: string[]): string[] {
+  const stripped: string[] = []
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+    if (TARGET_OVERRIDE_FLAGS[arg]) {
+      index++
+      continue
+    }
+    if (TARGET_OVERRIDE_FLAG_PREFIXES.some((prefix) => arg.startsWith(prefix))) {
+      continue
+    }
+    stripped.push(arg)
+  }
+  return stripped
+}
+
+function waitArguments(params: Record<string, unknown>): string[] {
+  const args = ['wait']
+  if (params.selector) {
+    args.push(String(params.selector))
+  } else if (params.timeout != null && !params.text && !params.url && !params.load && !params.fn) {
+    args.push(String(params.timeout))
+  }
+  for (const [key, flag] of [
+    ['text', '--text'],
+    ['url', '--url'],
+    ['load', '--load'],
+    ['fn', '--fn'],
+    ['state', '--state']
+  ] as const) {
+    if (params[key]) {
+      args.push(flag, String(params[key]))
+    }
+  }
+  return args
+}
+
+function cookieSetArguments(params: Record<string, unknown>): string[] {
+  const args = ['cookies', 'set', String(params.name ?? ''), String(params.value ?? '')]
+  for (const [key, flag] of [
+    ['domain', '--domain'],
+    ['path', '--path'],
+    ['sameSite', '--sameSite'],
+    ['expires', '--expires']
+  ] as const) {
+    if (params[key] != null) {
+      args.push(flag, String(params[key]))
+    }
+  }
+  if (params.secure) {
+    args.push('--secure')
+  }
+  if (params.httpOnly) {
+    args.push('--httpOnly')
+  }
+  return args
+}
+function cookieDeleteArguments(params: Record<string, unknown>): string[] {
+  const args = ['cookies', 'clear']
+  if (params.name) {
+    args.push('--name', String(params.name))
+  }
+  if (params.domain) {
+    args.push('--domain', String(params.domain))
+  }
+  return args
+}
+
+export function externalChromiumCommandArguments(
+  method: string,
+  params: Record<string, unknown>
+): string[] | null {
+  const text = (key: string): string => String(params[key] ?? '')
+  const optional = (key: string): string[] => (params[key] == null ? [] : [String(params[key])])
+  switch (method) {
+    case 'browserClick':
+      return ['click', text('element')]
+    case 'browserDblclick':
+      return ['dblclick', text('element')]
+    case 'browserFill':
+      return ['fill', text('element'), text('value')]
+    case 'browserType':
+      return ['keyboard', 'type', text('input')]
+    case 'browserSelect':
+      return ['select', text('element'), text('value')]
+    case 'browserScroll':
+      return ['scroll', text('direction'), ...optional('amount')]
+    case 'browserHover':
+      return ['hover', text('element')]
+    case 'browserDrag':
+      return ['drag', text('from'), text('to')]
+    case 'browserUpload':
+      return ['upload', text('element'), ...((params.files as string[] | undefined) ?? [])]
+    case 'browserCheck':
+      return [params.checked === false ? 'uncheck' : 'check', text('element')]
+    case 'browserFocus':
+      return ['focus', text('element')]
+    case 'browserClear':
+      return ['fill', text('element'), '']
+    case 'browserKeypress':
+      return ['press', text('key')]
+    case 'browserScrollIntoView':
+      return ['scrollintoview', text('element')]
+    case 'browserGet':
+      return ['get', text('what'), ...optional('selector')]
+    case 'browserIs':
+      return ['is', text('what'), text('selector')]
+    case 'browserKeyboardInsertText':
+      return ['keyboard', 'inserttext', text('text')]
+    case 'browserMouseMove':
+      return ['mouse', 'move', text('x'), text('y')]
+    case 'browserMouseDown':
+      return ['mouse', 'down', ...optional('button')]
+    case 'browserMouseClick':
+      if (
+        params.radius != null ||
+        (Array.isArray(params.modifiers) && params.modifiers.length > 0)
+      ) {
+        return null
+      }
+      return ['mouse', 'click', text('x'), text('y'), ...optional('button')]
+    case 'browserMouseUp':
+      return ['mouse', 'up', ...optional('button')]
+    case 'browserMouseWheel':
+      return ['mouse', 'wheel', text('dy'), ...optional('dx')]
+    case 'browserFind':
+      return ['find', text('locator'), text('value'), text('action'), ...optional('text')]
+    case 'browserSetDevice':
+      return ['set', 'device', text('name')]
+    case 'browserSetOffline':
+      return ['set', 'offline', ...optional('state')]
+    case 'browserSetHeaders':
+      return ['set', 'headers', text('headers')]
+    case 'browserSetCredentials':
+      return ['set', 'credentials', text('user'), text('pass')]
+    case 'browserSetMedia':
+      return ['set', 'media', ...optional('colorScheme'), ...optional('reducedMotion')]
+    case 'browserClipboardRead':
+      return ['clipboard', 'read']
+    case 'browserClipboardWrite':
+      return ['clipboard', 'write', text('text')]
+    case 'browserDialogAccept':
+      return ['dialog', 'accept', ...optional('text')]
+    case 'browserDialogDismiss':
+      return ['dialog', 'dismiss']
+    case 'browserStorageLocalGet':
+      return ['storage', 'local', 'get', text('key')]
+    case 'browserStorageLocalSet':
+      return ['storage', 'local', 'set', text('key'), text('value')]
+    case 'browserStorageLocalClear':
+      return ['storage', 'local', 'clear']
+    case 'browserStorageSessionGet':
+      return ['storage', 'session', 'get', text('key')]
+    case 'browserStorageSessionSet':
+      return ['storage', 'session', 'set', text('key'), text('value')]
+    case 'browserStorageSessionClear':
+      return ['storage', 'session', 'clear']
+    case 'browserDownload':
+      return ['download', text('selector'), text('path')]
+    case 'browserHighlight':
+      return ['highlight', text('selector')]
+    case 'browserCookieGet':
+      return ['cookies', 'get']
+    case 'browserCookieDelete':
+      return cookieDeleteArguments(params)
+    case 'browserSetGeolocation':
+      return ['set', 'geo', text('latitude'), text('longitude')]
+    case 'browserInterceptDisable':
+      return ['network', 'unroute']
+    case 'browserInterceptList':
+    case 'browserNetworkLog':
+      return ['network', 'requests']
+    case 'browserConsoleLog':
+      return ['console']
+    case 'browserCaptureStart':
+      return ['network', 'har', 'start']
+    case 'browserCaptureStop':
+      return ['network', 'har', 'stop']
+    case 'browserExec':
+      return stripTargetOverrideArguments(parseExecArguments(text('command')))
+    case 'browserSetViewport':
+      if (
+        params.mobile === true ||
+        (params.deviceScaleFactor != null && params.deviceScaleFactor !== 1)
+      ) {
+        return null
+      }
+      return ['set', 'viewport', text('width'), text('height')]
+    case 'browserWait':
+      return waitArguments(params)
+    case 'browserCookieSet':
+      return cookieSetArguments(params)
+    case 'browserInterceptEnable':
+      return ['network', 'route', (params.patterns as string[] | undefined)?.[0] ?? '**/*']
+    default:
+      return null
+  }
+}
+
+export function normalizeExternalChromiumCommandResult(
+  method: string,
+  params: Record<string, unknown>,
+  result: unknown
+): unknown {
+  switch (method) {
+    case 'browserClick':
+      return { clicked: String(params.element) }
+    case 'browserFill':
+      return { filled: String(params.element) }
+    case 'browserType':
+      return { typed: true }
+    case 'browserSelect':
+      return { selected: String(params.value) }
+    case 'browserScroll':
+      return { scrolled: params.direction }
+    case 'browserHover':
+      return { hovered: String(params.element) }
+    case 'browserDrag':
+      return { dragged: { from: params.from, to: params.to } }
+    case 'browserUpload':
+      return { uploaded: Array.isArray(params.files) ? params.files.length : 0 }
+    case 'browserCheck':
+      return { checked: params.checked !== false }
+    case 'browserFocus':
+      return { focused: String(params.element) }
+    case 'browserClear':
+      return { cleared: String(params.element) }
+    case 'browserSelectAll':
+      return { selected: String(params.element) }
+    case 'browserKeypress':
+      return { pressed: String(params.key) }
+    case 'browserWait':
+      return { waited: true }
+    case 'browserSetViewport':
+      return {
+        width: params.width,
+        height: params.height,
+        deviceScaleFactor: 1,
+        mobile: false
+      }
+    default:
+      return result
+  }
+}

--- a/src/main/orcad/external-chromium-tab-projection.ts
+++ b/src/main/orcad/external-chromium-tab-projection.ts
@@ -1,0 +1,45 @@
+import type { AgentBrowserTab } from './external-chromium-browser-session'
+
+export type ExternalChromiumPageRecord = {
+  agentPageId: string
+  publicPageId: string
+  worktreeId?: string
+}
+
+export function externalChromiumTabInfo(
+  page: ExternalChromiumPageRecord,
+  tab: AgentBrowserTab,
+  index: number
+): Record<string, unknown> {
+  return {
+    browserPageId: page.publicPageId,
+    index,
+    url: tab.url,
+    title: tab.title,
+    active: tab.active,
+    worktreeId: page.worktreeId ?? null,
+    profileId: 'default',
+    profileLabel: 'Default'
+  }
+}
+
+export function externalChromiumSnapshotResult(
+  page: ExternalChromiumPageRecord,
+  data: {
+    refs?: Record<string, { name?: string; role?: string }>
+    snapshot?: string
+  },
+  tab: Record<string, unknown>
+): Record<string, unknown> {
+  return {
+    browserPageId: page.publicPageId,
+    snapshot: data.snapshot ?? '',
+    refs: Object.entries(data.refs ?? {}).map(([ref, value]) => ({
+      ref,
+      role: value.role ?? '',
+      name: value.name ?? ''
+    })),
+    url: tab.url,
+    title: tab.title
+  }
+}

--- a/src/main/orcad/external-chromium-tab-registry.ts
+++ b/src/main/orcad/external-chromium-tab-registry.ts
@@ -1,0 +1,248 @@
+import { randomUUID } from 'node:crypto'
+import { z } from 'zod'
+import type { RuntimeBrowserCommandHost } from '../runtime/orca-runtime-browser'
+import { BrowserError } from '../browser/browser-error'
+import { normalizeBrowserNavigationUrl } from '../../shared/browser-url'
+import type { ExternalChromiumBrowserSession } from './external-chromium-browser-session'
+import {
+  externalChromiumTabInfo,
+  type ExternalChromiumPageRecord
+} from './external-chromium-tab-projection'
+const AgentBrowserCreatedTab = z.object({ tabId: z.string().min(1) })
+
+export class ExternalChromiumTabRegistry {
+  private readonly pagesByPublicId = new Map<string, ExternalChromiumPageRecord>()
+  private readonly pagesByAgentId = new Map<string, ExternalChromiumPageRecord>()
+  private readonly activePageIdByWorktree = new Map<string, string>()
+  private initialAgentPageId: string | null = null
+
+  constructor(private readonly session: ExternalChromiumBrowserSession) {}
+
+  initialize(agentPageId: string): void {
+    this.initialAgentPageId = agentPageId
+  }
+
+  clear(): void {
+    this.pagesByPublicId.clear()
+    this.pagesByAgentId.clear()
+    this.activePageIdByWorktree.clear()
+    this.initialAgentPageId = null
+  }
+
+  async createTab(
+    host: RuntimeBrowserCommandHost,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    if (typeof params.profileId === 'string' && params.profileId !== 'default') {
+      throw new BrowserError(
+        'browser_profile_unavailable',
+        'Only the default browser profile is available.'
+      )
+    }
+    const worktreeId = await this.resolveWorktreeId(host, params.worktree)
+    const requestedPageId =
+      typeof params.page === 'string' && params.page.length > 0 ? params.page : undefined
+    const existing = requestedPageId ? this.pagesByPublicId.get(requestedPageId) : undefined
+    if (existing) {
+      if (worktreeId && existing.worktreeId !== worktreeId) {
+        throw new BrowserError(
+          'browser_tab_not_found',
+          `Browser page ${requestedPageId} was not found in this worktree.`
+        )
+      }
+      this.setActivePage(existing)
+      return { browserPageId: existing.publicPageId }
+    }
+    const url = normalizeBrowserNavigationUrl(String(params.url ?? 'about:blank'))
+    if (!url) {
+      throw new BrowserError(
+        'invalid_argument',
+        `Unsupported browser URL: ${String(params.url ?? '')}`
+      )
+    }
+    let agentPageId: string
+    if (this.initialAgentPageId) {
+      agentPageId = this.initialAgentPageId
+      this.initialAgentPageId = null
+      await this.session.selectPage(agentPageId)
+      await this.session.run(['open', url])
+    } else {
+      agentPageId = AgentBrowserCreatedTab.parse(await this.session.run(['tab', 'new', url])).tabId
+    }
+    const publicPageId = requestedPageId ?? randomUUID()
+    const page = { agentPageId, publicPageId, worktreeId }
+    this.pagesByPublicId.set(publicPageId, page)
+    this.pagesByAgentId.set(agentPageId, page)
+    this.setActivePage(page)
+    host.markHeadlessBrowserSessionTabActive?.(
+      worktreeId,
+      publicPageId,
+      typeof params.targetGroupId === 'string' ? params.targetGroupId : undefined
+    )
+    if (worktreeId) {
+      host.notifyHeadlessBrowserSessionTabsChanged?.(worktreeId)
+    }
+    return { browserPageId: publicPageId }
+  }
+
+  async listTabs(
+    host: RuntimeBrowserCommandHost,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const requestedWorktreeId = await this.resolveWorktreeId(host, params.worktree)
+    const tabs = await this.session.readTabs()
+    const liveAgentPageIds = new Set(tabs.map((tab) => tab.tabId))
+    for (const page of this.pagesByPublicId.values()) {
+      if (!liveAgentPageIds.has(page.agentPageId)) {
+        this.deletePage(page)
+      }
+    }
+    const visibleTabs = tabs.flatMap((tab) => {
+      const page = this.pagesByAgentId.get(tab.tabId)
+      if (!page || (requestedWorktreeId && page.worktreeId !== requestedWorktreeId)) {
+        return []
+      }
+      if (tab.active) {
+        this.setActivePage(page)
+      }
+      return [{ page, tab }]
+    })
+    return {
+      tabs: visibleTabs.map(({ page, tab }, index) => externalChromiumTabInfo(page, tab, index))
+    }
+  }
+
+  async describeTab(
+    host: RuntimeBrowserCommandHost,
+    params: Record<string, unknown>
+  ): Promise<Record<string, unknown>> {
+    return this.describePage(await this.resolveTargetPage(host, params))
+  }
+
+  async currentTab(
+    host: RuntimeBrowserCommandHost,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const worktreeId = await this.resolveWorktreeId(host, params.worktree)
+    const page = this.findActivePage(worktreeId)
+    if (!page) {
+      throw new BrowserError('browser_no_tab', 'No browser tab is active in this worktree.')
+    }
+    return this.describePage(page)
+  }
+
+  async switchTab(
+    host: RuntimeBrowserCommandHost,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const worktreeId = await this.resolveWorktreeId(host, params.worktree)
+    const pages = [...this.pagesByPublicId.values()].filter(
+      (page) => !worktreeId || page.worktreeId === worktreeId
+    )
+    const page =
+      typeof params.page === 'string'
+        ? this.pagesByPublicId.get(params.page)
+        : typeof params.index === 'number'
+          ? pages[params.index]
+          : undefined
+    if (!page || (worktreeId && page.worktreeId !== worktreeId)) {
+      throw new BrowserError('browser_tab_not_found', 'Browser tab was not found in this worktree.')
+    }
+    await this.session.selectPage(page.agentPageId)
+    this.setActivePage(page)
+    return { switched: pages.indexOf(page), browserPageId: page.publicPageId }
+  }
+
+  async closeTab(
+    host: RuntimeBrowserCommandHost,
+    params: Record<string, unknown>
+  ): Promise<unknown> {
+    const worktreeId = await this.resolveWorktreeId(host, params.worktree)
+    const pages = [...this.pagesByPublicId.values()].filter(
+      (page) => !worktreeId || page.worktreeId === worktreeId
+    )
+    const page =
+      typeof params.page === 'string'
+        ? this.pagesByPublicId.get(params.page)
+        : typeof params.index === 'number'
+          ? pages[params.index]
+          : this.findActivePage(worktreeId)
+    if (!page || (worktreeId && page.worktreeId !== worktreeId)) {
+      if (typeof params.page === 'string') {
+        throw new BrowserError(
+          'browser_tab_not_found',
+          'Browser tab was not found in this worktree.'
+        )
+      }
+      return { closed: false }
+    }
+    await this.session.run(['tab', 'close', page.agentPageId])
+    this.deletePage(page)
+    if (page.worktreeId) {
+      host.notifyHeadlessBrowserSessionTabsChanged?.(page.worktreeId)
+    }
+    return { closed: true }
+  }
+
+  async resolveTargetPage(
+    host: RuntimeBrowserCommandHost,
+    params: Record<string, unknown>
+  ): Promise<ExternalChromiumPageRecord> {
+    const worktreeId = await this.resolveWorktreeId(host, params.worktree)
+    const page =
+      typeof params.page === 'string'
+        ? this.pagesByPublicId.get(params.page)
+        : this.findActivePage(worktreeId)
+    if (!page || (worktreeId && page.worktreeId !== worktreeId)) {
+      throw new BrowserError('browser_no_tab', 'No browser tab is active in this worktree.')
+    }
+    return page
+  }
+
+  async describePage(page: ExternalChromiumPageRecord): Promise<Record<string, unknown>> {
+    const tabs = await this.session.readTabs()
+    const scopedTabs = tabs.filter(
+      (tab) => this.pagesByAgentId.get(tab.tabId)?.worktreeId === page.worktreeId
+    )
+    const index = scopedTabs.findIndex((tab) => tab.tabId === page.agentPageId)
+    if (index === -1) {
+      this.deletePage(page)
+      throw new BrowserError('browser_tab_closed', 'Browser tab is no longer available.')
+    }
+    return externalChromiumTabInfo(page, scopedTabs[index], index)
+  }
+
+  private findActivePage(worktreeId?: string): ExternalChromiumPageRecord | undefined {
+    const key = worktreeId ?? ''
+    const activePageId = this.activePageIdByWorktree.get(key)
+    const active = activePageId ? this.pagesByPublicId.get(activePageId) : undefined
+    if (active) {
+      return active
+    }
+    return [...this.pagesByPublicId.values()].find(
+      (page) => !worktreeId || page.worktreeId === worktreeId
+    )
+  }
+
+  private setActivePage(page: ExternalChromiumPageRecord): void {
+    this.activePageIdByWorktree.set(page.worktreeId ?? '', page.publicPageId)
+  }
+
+  private deletePage(page: ExternalChromiumPageRecord): void {
+    this.pagesByPublicId.delete(page.publicPageId)
+    this.pagesByAgentId.delete(page.agentPageId)
+    const key = page.worktreeId ?? ''
+    if (this.activePageIdByWorktree.get(key) === page.publicPageId) {
+      this.activePageIdByWorktree.delete(key)
+    }
+  }
+
+  private async resolveWorktreeId(
+    host: RuntimeBrowserCommandHost,
+    worktree: unknown
+  ): Promise<string | undefined> {
+    return typeof worktree === 'string' && worktree
+      ? (await host.resolveWorktreeSelector(worktree)).id
+      : undefined
+  }
+}

--- a/src/main/orcad/orcad-agent-browser-binary.ts
+++ b/src/main/orcad/orcad-agent-browser-binary.ts
@@ -1,0 +1,31 @@
+import { accessSync, constants, existsSync } from 'node:fs'
+import { arch, platform } from 'node:os'
+import { dirname, join } from 'node:path'
+
+export function orcadAgentBrowserNativeName(
+  platformName: NodeJS.Platform,
+  architecture: string
+): string {
+  const ext = platformName === 'win32' ? '.exe' : ''
+  return `agent-browser-${platformName}-${architecture}${ext}`
+}
+
+export function resolveOrcadAgentBrowserBinary(): string | null {
+  const name = orcadAgentBrowserNativeName(platform(), arch())
+  const candidates = [
+    join(dirname(process.argv[1] ?? __filename), name),
+    join(process.cwd(), 'node_modules', 'agent-browser', 'bin', name)
+  ]
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) {
+      continue
+    }
+    try {
+      accessSync(candidate, process.platform === 'win32' ? constants.F_OK : constants.X_OK)
+      return candidate
+    } catch {
+      // Keep searching; a copied but non-executable binary is not a provider.
+    }
+  }
+  return null
+}

--- a/src/main/orcad/orcad-browser-provider.test.ts
+++ b/src/main/orcad/orcad-browser-provider.test.ts
@@ -1,0 +1,207 @@
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { runProcess } from '../../shared/child-process/run-process'
+import { ExternalChromiumBrowserProcess } from './external-chromium-browser-process'
+import { installedElectronCandidates, resolveOrcadBrowserProvider } from './orcad-browser-provider'
+import { orcadAgentBrowserNativeName } from './orcad-agent-browser-binary'
+
+vi.mock('../../shared/child-process/run-process', () => ({ runProcess: vi.fn() }))
+
+type BrowserState = {
+  activeTabId: string
+  tabs: { active: boolean; tabId: string; title: string; url: string }[]
+}
+
+const runProcessMock = vi.mocked(runProcess)
+let root: string
+let screenshotPath: string
+let browserState: BrowserState
+
+function commandFromArgs(args: readonly string[]): string[] {
+  let index = 0
+  while (['--session', '--profile', '--args'].includes(args[index] ?? '')) {
+    index += 2
+  }
+  return args.slice(index, -1)
+}
+
+function success(data: unknown) {
+  return Promise.resolve({
+    code: 0,
+    signal: null,
+    stdout: JSON.stringify({ success: true, data, error: null }),
+    stderr: '',
+    timedOut: false
+  })
+}
+
+function installAgentBrowserMock(): void {
+  runProcessMock.mockImplementation(async (spec) => {
+    const command = commandFromArgs(spec.args ?? [])
+    if (command[0] === 'open') {
+      const active = browserState.tabs.find((tab) => tab.tabId === browserState.activeTabId)!
+      active.url = command[1]
+      active.title = command[1] === 'about:blank' ? '' : 'Fixture page'
+      return success({ url: active.url, title: active.title })
+    }
+    if (command[0] === 'tab' && command.length === 1) {
+      return success({
+        tabs: browserState.tabs.map((tab) => ({
+          ...tab,
+          active: tab.tabId === browserState.activeTabId
+        }))
+      })
+    }
+    if (command[0] === 'tab' && command.length === 2) {
+      browserState.activeTabId = command[1]
+      return success({ tabId: command[1] })
+    }
+    if (command[0] === 'eval') {
+      return success({ result: 'Fixture page', origin: 'https://fixture.test/' })
+    }
+    if (command[0] === 'screenshot') {
+      return success({ path: screenshotPath })
+    }
+    if (command[0] === 'close') {
+      return success({ closed: true })
+    }
+    throw new Error(`Unexpected agent-browser command: ${command.join(' ')}`)
+  })
+}
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'orcad-browser-provider-'))
+  screenshotPath = join(root, 'fixture.png')
+  await writeFile(screenshotPath, Buffer.from('fixture-image'))
+  browserState = {
+    activeTabId: 't1',
+    tabs: [{ active: true, tabId: 't1', title: '', url: 'about:blank' }]
+  }
+  runProcessMock.mockReset()
+  installAgentBrowserMock()
+})
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true })
+})
+
+describe('ExternalChromiumBrowserProcess', () => {
+  it('navigates, evaluates, and screenshots through the operator browser', async () => {
+    const processHandle = new ExternalChromiumBrowserProcess(
+      '/agent-browser',
+      { executablePath: '/operator/chromium', provider: 'chromium' },
+      root
+    )
+    await processHandle.start()
+    const commands = processHandle.createCommands({
+      getAgentBrowserBridge: () => null,
+      resolveWorktreeSelector: async (selector) => ({ id: selector }),
+      getAuthoritativeWindow: () => {
+        throw new Error('No renderer')
+      },
+      getAvailableAuthoritativeWindow: () => null,
+      getOffscreenBrowserBackend: () => null
+    })
+
+    await expect(
+      commands.browserTabCreate({
+        url: 'https://fixture.test/',
+        worktree: 'worktree-1',
+        page: 'page-1'
+      })
+    ).resolves.toEqual({ browserPageId: 'page-1' })
+    await expect(
+      commands.browserGoto({
+        url: 'https://fixture.test/next',
+        worktree: 'worktree-1',
+        page: 'page-1'
+      })
+    ).resolves.toEqual({ url: 'https://fixture.test/next', title: 'Fixture page' })
+    await expect(
+      commands.browserEval({
+        expression: 'document.title',
+        worktree: 'worktree-1',
+        page: 'page-1'
+      })
+    ).resolves.toEqual({ result: 'Fixture page', origin: 'https://fixture.test/' })
+    await expect(
+      commands.browserScreenshot({ format: 'png', worktree: 'worktree-1', page: 'page-1' })
+    ).resolves.toEqual({ data: Buffer.from('fixture-image').toString('base64'), format: 'png' })
+    await expect(
+      commands.browserExec({
+        page: 'page-1',
+        worktree: 'worktree-1',
+        command:
+          '--session stolen --cdp 9222 --profile /tmp/stolen --executable-path /bad --args bad eval document.title'
+      })
+    ).resolves.toEqual({ result: 'Fixture page', origin: 'https://fixture.test/' })
+    const execArgs = runProcessMock.mock.calls.at(-1)?.[0].args ?? []
+    expect(execArgs).not.toContain('stolen')
+    expect(execArgs).not.toContain('9222')
+    expect(execArgs).not.toContain('/tmp/stolen')
+    expect(execArgs).not.toContain('/bad')
+
+    expect(runProcessMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: expect.objectContaining({ AGENT_BROWSER_EXECUTABLE_PATH: '/operator/chromium' })
+      })
+    )
+    await processHandle.stop()
+  })
+})
+
+describe('cross-platform browser provider paths', () => {
+  it('resolves installed Electron launchers on macOS, Linux, and Windows', () => {
+    expect(installedElectronCandidates('darwin', '/Users/test', {})).toContain(
+      '/Users/test/Applications/Orca.app/Contents/MacOS/Orca'
+    )
+    expect(installedElectronCandidates('linux', '/home/test', {})).toContain(
+      '/home/test/.local/bin/orca-ide'
+    )
+    expect(
+      installedElectronCandidates('win32', 'C:\\Users\\test', {
+        LOCALAPPDATA: 'C:\\Users\\test\\AppData\\Local'
+      })
+    ).toContain('C:\\Users\\test\\AppData\\Local\\Programs\\Orca\\Orca.exe')
+  })
+
+  it('uses platform-specific bundled agent-browser names', () => {
+    expect(orcadAgentBrowserNativeName('darwin', 'arm64')).toBe('agent-browser-darwin-arm64')
+    expect(orcadAgentBrowserNativeName('linux', 'x64')).toBe('agent-browser-linux-x64')
+    expect(orcadAgentBrowserNativeName('win32', 'x64')).toBe('agent-browser-win32-x64.exe')
+  })
+})
+
+describe('resolveOrcadBrowserProvider', () => {
+  it('uses ORCA_BROWSER_EXECUTABLE when Electron is absent', async () => {
+    const executable = join(root, process.platform === 'win32' ? 'chromium.exe' : 'chromium')
+    await writeFile(executable, '')
+    if (process.platform !== 'win32') {
+      await chmod(executable, 0o755)
+    }
+
+    const provider = await resolveOrcadBrowserProvider({
+      userDataPath: root,
+      environment: { ORCA_BROWSER_EXECUTABLE: executable },
+      resolveInstalledElectronExecutable: async () => null,
+      resolveAgentBrowserBinary: () => '/agent-browser'
+    })
+
+    expect(provider?.kind).toBe('chromium')
+    await provider?.stop()
+  })
+
+  it('returns no provider when neither executable resolves', async () => {
+    await expect(
+      resolveOrcadBrowserProvider({
+        userDataPath: root,
+        environment: {},
+        resolveInstalledElectronExecutable: async () => null,
+        resolveAgentBrowserBinary: () => '/agent-browser'
+      })
+    ).resolves.toBeNull()
+    expect(runProcessMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/orcad/orcad-browser-provider.ts
+++ b/src/main/orcad/orcad-browser-provider.ts
@@ -1,0 +1,148 @@
+import { access, mkdir } from 'node:fs/promises'
+import { constants } from 'node:fs'
+import { homedir } from 'node:os'
+import { posix, win32 } from 'node:path'
+import type { RuntimeBrowserCommandsFactory } from '../runtime/runtime-browser-commands-factory'
+import {
+  ExternalChromiumBrowserProcess,
+  type ExternalChromiumLaunch
+} from './external-chromium-browser-process'
+import { resolveOrcadAgentBrowserBinary } from './orcad-agent-browser-binary'
+import { ElectronServeBrowserProcess } from './electron-serve-browser-process'
+
+export type OrcadBrowserProvider = {
+  kind: 'electron' | 'chromium'
+  factory: RuntimeBrowserCommandsFactory
+  isAvailable(): boolean
+  stop(): Promise<void>
+}
+
+export type OrcadBrowserProviderOptions = {
+  userDataPath: string
+  environment?: NodeJS.ProcessEnv
+  resolveInstalledElectronExecutable?: () => Promise<string | null>
+  resolveAgentBrowserBinary?: () => string | null
+}
+
+async function executableExists(path: string): Promise<boolean> {
+  try {
+    await access(path, process.platform === 'win32' ? constants.F_OK : constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function installedElectronCandidates(
+  platform: NodeJS.Platform,
+  homePath: string,
+  environment: NodeJS.ProcessEnv
+): string[] {
+  const joinPath = platform === 'win32' ? win32.join : posix.join
+  if (platform === 'darwin') {
+    return [
+      '/Applications/Orca.app/Contents/MacOS/Orca',
+      joinPath(homePath, 'Applications', 'Orca.app', 'Contents', 'MacOS', 'Orca')
+    ]
+  }
+  if (platform === 'win32') {
+    return [
+      ...(environment.LOCALAPPDATA
+        ? [joinPath(environment.LOCALAPPDATA, 'Programs', 'Orca', 'Orca.exe')]
+        : []),
+      ...(environment.ProgramFiles ? [joinPath(environment.ProgramFiles, 'Orca', 'Orca.exe')] : [])
+    ]
+  }
+  return [
+    joinPath(homePath, '.local', 'bin', 'orca-ide'),
+    '/usr/local/bin/orca-ide',
+    '/usr/bin/orca-ide',
+    '/opt/Orca/orca-ide'
+  ]
+}
+
+/** Only paths with stable installer ownership qualify; never guess arbitrary AppImage locations. */
+export async function resolveInstalledElectronExecutable(): Promise<string | null> {
+  const candidates = installedElectronCandidates(process.platform, homedir(), process.env)
+  for (const candidate of candidates) {
+    if (await executableExists(candidate)) {
+      return candidate
+    }
+  }
+  return null
+}
+
+async function startProvider(
+  agentBrowserPath: string,
+  launch: ExternalChromiumLaunch,
+  userDataPath: string
+): Promise<OrcadBrowserProvider> {
+  const processHandle = new ExternalChromiumBrowserProcess(agentBrowserPath, launch, userDataPath)
+  try {
+    await processHandle.start()
+  } catch (error) {
+    await processHandle.stop()
+    throw error
+  }
+  return {
+    kind: launch.provider,
+    factory: (host) => processHandle.createCommands(host),
+    isAvailable: () => processHandle.isAvailable(),
+    stop: () => processHandle.stop()
+  }
+}
+
+async function startElectronServeProvider(executablePath: string): Promise<OrcadBrowserProvider> {
+  const processHandle = new ElectronServeBrowserProcess(executablePath)
+  try {
+    await processHandle.start()
+  } catch (error) {
+    await processHandle.stop()
+    throw error
+  }
+  return {
+    kind: 'electron',
+    factory: (host) => processHandle.createCommands(host),
+    isAvailable: () => processHandle.isAvailable(),
+    stop: () => processHandle.stop()
+  }
+}
+
+/** Resolve once at startup: Electron first, then the operator-supplied Chromium. */
+export async function resolveOrcadBrowserProvider(
+  options: OrcadBrowserProviderOptions
+): Promise<OrcadBrowserProvider | null> {
+  const environment = options.environment ?? process.env
+  await mkdir(options.userDataPath, { recursive: true, mode: 0o700 })
+
+  const installedElectronExecutable = await (
+    options.resolveInstalledElectronExecutable ?? resolveInstalledElectronExecutable
+  )()
+  if (installedElectronExecutable) {
+    try {
+      return await startElectronServeProvider(installedElectronExecutable)
+    } catch (error) {
+      console.warn('[orcad] Installed Electron browser provider unavailable:', error)
+    }
+  }
+  const agentBrowserPath = (options.resolveAgentBrowserBinary ?? resolveOrcadAgentBrowserBinary)()
+
+  if (!agentBrowserPath) {
+    return null
+  }
+
+  const chromiumExecutable = environment.ORCA_BROWSER_EXECUTABLE?.trim()
+  if (!chromiumExecutable || !(await executableExists(chromiumExecutable))) {
+    return null
+  }
+  try {
+    return await startProvider(
+      agentBrowserPath,
+      { executablePath: chromiumExecutable, provider: 'chromium' },
+      options.userDataPath
+    )
+  } catch (error) {
+    console.warn('[orcad] External Chromium browser provider unavailable:', error)
+    return null
+  }
+}

--- a/src/main/orcad/orcad-entry.ts
+++ b/src/main/orcad/orcad-entry.ts
@@ -5,11 +5,11 @@
  * desktop uses, installs a PTY controller via `registerHeadlessPtyRuntime`, and
  * serves runtime RPC. See docs/design/node-only-runtime-backend.html.
  *
- * The desktop-only surfaces are deliberately left uninstalled: no notifications, no
- * renderer window, no browser panes. Most are declared rather than faked — see
- * `runtime-desktop-surface.ts` and `pty-host-bindings.ts`. The renderer window is the
- * exception: `registerPtyHandlers` takes a non-null `BrowserWindow`, so the headless
- * path still fakes one that reports itself destroyed.
+ * Desktop UI surfaces stay uninstalled: no notifications, no renderer window. The
+ * renderer window is faked as a destroyed one because `registerPtyHandlers` takes a
+ * non-null `BrowserWindow`. Browser automation is different — it is installed through
+ * the runtime factory, but only when an Electron serve sidecar or an operator-supplied
+ * Chromium proves available at startup.
  */
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -17,6 +17,8 @@ import process from 'node:process'
 import { setAppEnvironment, type AppEnvironment } from '../../shared/app-environment'
 import { setSecretStore, type SecretStore } from '../../shared/secret-store'
 import type { ServeReadiness } from '../server/serve-readiness'
+import { setRuntimeBrowserCommandsFactory } from '../runtime/runtime-browser-commands-factory'
+import { resolveOrcadBrowserProvider, type OrcadBrowserProvider } from './orcad-browser-provider'
 
 /** XDG-ish data root. `$ORCA_USER_DATA` wins so a smoke test can isolate state. */
 function resolveUserDataPath(): string {
@@ -27,13 +29,14 @@ function resolveUserDataPath(): string {
   const xdg = process.env.XDG_DATA_HOME
   return xdg ? join(xdg, 'Orca') : join(homedir(), '.orca')
 }
+let runOrcadQuitHandlers = (): void => {}
 
 function createNodeAppEnvironment(): AppEnvironment {
   const userData = resolveUserDataPath()
   const quitHandlers: (() => void)[] = []
-  // Why SIGTERM/SIGINT: this is the Node equivalent of electron's will-quit, and the
-  // runtime's teardown (daemon disconnect, PTY kill, store flush) hangs off it.
-  const runQuitHandlers = (): void => {
+  // The main signal handler awaits runtime and browser teardown before process.exit.
+  // Keep will-quit callbacks synchronous, but never let them pre-empt that async barrier.
+  runOrcadQuitHandlers = (): void => {
     for (const handler of quitHandlers.splice(0)) {
       try {
         handler()
@@ -42,14 +45,6 @@ function createNodeAppEnvironment(): AppEnvironment {
       }
     }
   }
-  process.once('SIGTERM', () => {
-    runQuitHandlers()
-    process.exit(0)
-  })
-  process.once('SIGINT', () => {
-    runQuitHandlers()
-    process.exit(0)
-  })
   return {
     getPath: (name) => (name === 'home' ? homedir() : name === 'temp' ? tmpdir() : userData),
     getAppPath: () => process.cwd(),
@@ -105,7 +100,26 @@ export type OrcadHandle = {
  */
 export async function startOrcad(options: OrcadOptions = {}): Promise<OrcadHandle> {
   installOrcadHostAdapters()
+  const userDataPath = resolveUserDataPath()
+  const browserProvider = await resolveOrcadBrowserProvider({ userDataPath })
+  setRuntimeBrowserCommandsFactory(browserProvider?.factory ?? null, {
+    headless: browserProvider !== null,
+    ...(browserProvider ? { isAvailable: () => browserProvider.isAvailable() } : {})
+  })
+  try {
+    return await startOrcadRuntime(options, browserProvider)
+  } catch (error) {
+    await browserProvider?.stop()
+    setRuntimeBrowserCommandsFactory(null)
+    runOrcadQuitHandlers()
+    throw error
+  }
+}
 
+async function startOrcadRuntime(
+  options: OrcadOptions,
+  browserProvider: OrcadBrowserProvider | null
+): Promise<OrcadHandle> {
   const { OrcaRuntimeService } = await import('../runtime/orca-runtime')
   const { OrcaRuntimeRpcServer } = await import('../runtime/runtime-rpc')
   const { registerHeadlessPtyRuntime, getLocalPtyProvider, getSshPtyProvider } =
@@ -118,9 +132,9 @@ export async function startOrcad(options: OrcadOptions = {}): Promise<OrcadHandl
     await import('../orca-profiles/profile-index-store')
   const { initSshHostKeyStoreFile } = await import('../ssh/ssh-host-key-store')
 
-  const userDataPath = getAppEnvironment().getPath('userData')
+  const runtimeUserDataPath = getAppEnvironment().getPath('userData')
   initOrcaProfilePaths()
-  const profile = ensureActiveOrcaProfile(userDataPath)
+  const profile = ensureActiveOrcaProfile(runtimeUserDataPath)
   // Why a real Store: without one every persistence-backed RPC throws `runtime_unavailable`
   // and the read paths that use `this.store?.x ?? []` quietly answer "empty" instead —
   // a server that pairs and lists nothing looks healthy and is not.
@@ -162,7 +176,7 @@ export async function startOrcad(options: OrcadOptions = {}): Promise<OrcadHandl
 
   const rpc = new OrcaRuntimeRpcServer({
     runtime,
-    userDataPath,
+    userDataPath: runtimeUserDataPath,
     enableWebSocket: true,
     exposeNetworkByDefault: true,
     ...(options.port !== undefined ? { wsPort: options.port, preferPinnedWsPort: true } : {})
@@ -212,7 +226,13 @@ export async function startOrcad(options: OrcadOptions = {}): Promise<OrcadHandl
   return {
     readiness,
     stop: async () => {
-      await rpc.stop()
+      try {
+        await rpc.stop()
+      } finally {
+        await browserProvider?.stop()
+        setRuntimeBrowserCommandsFactory(null)
+        runOrcadQuitHandlers()
+      }
     }
   }
 }

--- a/src/main/orcad/orcad-sidecar-runtime-client.ts
+++ b/src/main/orcad/orcad-sidecar-runtime-client.ts
@@ -1,0 +1,132 @@
+import { randomUUID } from 'node:crypto'
+import { createConnection } from 'node:net'
+import { z } from 'zod'
+import { findTransport, type RuntimeMetadata } from '../../shared/runtime-bootstrap'
+import { BROWSER_UNAVAILABLE_ERROR_CODE } from '../../shared/runtime-types'
+import { BrowserError } from '../browser/browser-error'
+const SIDECAR_MAX_RESPONSE_BYTES = 64 * 1024 * 1024
+
+const RuntimeResponse = z.discriminatedUnion('ok', [
+  z.object({ id: z.string(), ok: z.literal(true), result: z.unknown() }).passthrough(),
+  z
+    .object({
+      id: z.string(),
+      ok: z.literal(false),
+      error: z.object({ code: z.string(), message: z.string() }).passthrough()
+    })
+    .passthrough()
+])
+
+export async function sendOrcadSidecarRequest(
+  metadata: RuntimeMetadata,
+  method: string,
+  params: unknown,
+  timeoutMs = 90_000
+): Promise<unknown> {
+  const transport = findTransport(metadata, 'unix', 'named-pipe')
+  if (!transport) {
+    throw new BrowserError(
+      BROWSER_UNAVAILABLE_ERROR_CODE,
+      'Electron browser sidecar has no local RPC transport.'
+    )
+  }
+  return await new Promise((resolve, reject) => {
+    const socket = createConnection(transport.endpoint)
+    const requestId = randomUUID()
+    let buffer = ''
+    let retainedBytes = 0
+    let settled = false
+    const finish = (error: Error | null, result?: unknown): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      socket.end()
+      if (error) {
+        reject(error)
+      } else {
+        resolve(result)
+      }
+    }
+    const timer = setTimeout(() => {
+      socket.destroy()
+      finish(new BrowserError('browser_timeout', 'Electron browser sidecar request timed out.'))
+    }, timeoutMs)
+    timer.unref?.()
+    socket.setEncoding('utf8')
+    socket.once('error', () => {
+      finish(
+        new BrowserError(
+          BROWSER_UNAVAILABLE_ERROR_CODE,
+          'Could not connect to Electron browser sidecar.'
+        )
+      )
+    })
+    socket.once('close', () => {
+      finish(
+        new BrowserError(
+          BROWSER_UNAVAILABLE_ERROR_CODE,
+          'Electron browser sidecar closed before responding.'
+        )
+      )
+    })
+    socket.on('data', (chunk: string) => {
+      buffer += chunk
+      retainedBytes += Buffer.byteLength(chunk, 'utf8')
+      if (retainedBytes > SIDECAR_MAX_RESPONSE_BYTES) {
+        socket.destroy()
+        finish(new BrowserError('browser_error', 'Electron browser sidecar response is too large.'))
+        return
+      }
+      let newline = buffer.indexOf('\n')
+      while (newline !== -1 && !settled) {
+        const line = buffer.slice(0, newline)
+        buffer = buffer.slice(newline + 1)
+        retainedBytes = Buffer.byteLength(buffer, 'utf8')
+        newline = buffer.indexOf('\n')
+        if (!line.trim()) {
+          continue
+        }
+        let raw: unknown
+        try {
+          raw = JSON.parse(line)
+        } catch {
+          finish(
+            new BrowserError('browser_error', 'Electron browser sidecar returned invalid JSON.')
+          )
+          return
+        }
+        if (raw && typeof raw === 'object' && '_keepalive' in raw) {
+          timer.refresh()
+          continue
+        }
+        const parsed = RuntimeResponse.safeParse(raw)
+        if (!parsed.success || parsed.data.id !== requestId) {
+          finish(
+            new BrowserError(
+              'browser_error',
+              'Electron browser sidecar returned an invalid response.'
+            )
+          )
+          return
+        }
+        if (!parsed.data.ok) {
+          finish(new BrowserError(parsed.data.error.code, parsed.data.error.message))
+          return
+        }
+        finish(null, parsed.data.result)
+      }
+    })
+    socket.on('connect', () => {
+      socket.write(
+        `${JSON.stringify({
+          id: requestId,
+          authToken: metadata.authToken,
+          method,
+          params
+        })}\n`
+      )
+    })
+  })
+}

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -2338,6 +2338,27 @@ describe('OrcaRuntimeService', () => {
     expect(capabilities).toContain('browser.headless.v1')
     expect(capabilities).toContain('browser.certificate-trust.v1')
   })
+
+  it('advertises only while headless browser commands remain live', () => {
+    let available = true
+    setRuntimeBrowserCommandsFactory((host) => new RuntimeBrowserCommands(host), {
+      headless: true,
+      isAvailable: () => available
+    })
+    const status = createRuntime().getStatus()
+
+    expect(status.capabilities).toContain('browser.headless.v1')
+    expect(status.capabilities).not.toContain('browser.screencast.v1')
+    expect(status.capabilities).not.toContain('browser.certificate-trust.v1')
+    expect(status.degradations).toBeUndefined()
+
+    available = false
+    const degraded = createRuntime().getStatus()
+    expect(degraded.capabilities).not.toContain('browser.headless.v1')
+    expect(degraded.degradations).toEqual([
+      expect.objectContaining({ code: 'browser_unavailable' })
+    ])
+  })
   it('surfaces live offscreen load failures in headless browser snapshots', () => {
     const runtime = createRuntime()
     runtime.setOffscreenBrowserBackend({ createTab: vi.fn(), closeTab: vi.fn() })
@@ -2465,11 +2486,38 @@ describe('OrcaRuntimeService', () => {
     expect(runtime.getStatus().capabilities).toContain('browser.certificate-trust.v1')
   })
 
-  it('does not advertise certificate trust when no browser backend is available', () => {
+  it('declares browser unavailability when no browser provider resolves', async () => {
+    setRuntimeBrowserCommandsFactory(null)
     const runtime = createRuntime()
+    const status = runtime.getStatus()
 
-    expect(runtime.getStatus().capabilities).not.toContain('browser.certificate-trust.v1')
-    expect(runtime.getStatus().capabilities).not.toContain('browser.screencast.v1')
+    expect(status.capabilities).not.toContain('browser.headless.v1')
+    expect(status.capabilities).not.toContain('browser.certificate-trust.v1')
+    expect(status.capabilities).not.toContain('browser.screencast.v1')
+    expect(status.degradations).toEqual([
+      {
+        code: 'browser_unavailable',
+        capability: 'browser.headless.v1',
+        message: 'Browser automation requires the Electron provider or ORCA_BROWSER_EXECUTABLE.'
+      }
+    ])
+    const browserCalls = Object.entries(runtime).filter(
+      ([name, value]) => /^browser[A-Z]/.test(name) && typeof value === 'function'
+    )
+    expect(browserCalls.length).toBeGreaterThan(50)
+    for (const [name, call] of browserCalls) {
+      const invoke =
+        name === 'browserScreencast'
+          ? () =>
+              (call as CallableFunction)(
+                { format: 'jpeg' },
+                { sendBinary: () => true, emit: () => undefined }
+              )
+          : () => (call as CallableFunction)({})
+      await expect(Promise.resolve().then(invoke)).rejects.toMatchObject({
+        code: 'browser_unavailable'
+      })
+    }
   })
 
   it('closes a worktree’s offscreen browser pages when its metadata is removed (leak fix)', () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -425,6 +425,7 @@ import type {
   LinearStatusSetResult
 } from '../../shared/linear/agent-access'
 import {
+  BROWSER_UNAVAILABLE_ERROR_CODE,
   HEADLESS_RUNTIME_WINDOW_ID,
   type RuntimeDesktopWindowStatus,
   type RuntimeGraphStatus,
@@ -658,7 +659,10 @@ import {
 import { advertisedUrlWatcher } from '../ports/advertised-url-watcher'
 import type { AutomationService } from '../automations/service'
 import type { RuntimeBrowserCommands } from './orca-runtime-browser'
-import { createRuntimeBrowserCommands } from './runtime-browser-commands-factory'
+import {
+  createRuntimeBrowserCommands,
+  runtimeBrowserCommandsFactoryIsHeadless
+} from './runtime-browser-commands-factory'
 import { RemoteRuntimeTerminalCreateIdempotency } from './remote-runtime-terminal-create-idempotency'
 import { deriveRemoteRuntimeTerminalCreateHandle } from './remote-runtime-terminal-create-identity'
 import {
@@ -6132,6 +6136,7 @@ export class OrcaRuntimeService {
     // so they must not fall back to a local desktop browser tab.
     const hasRenderer = Boolean(this.getAvailableAuthoritativeWindow())
     const hasOffscreen = !hasRenderer && Boolean(this.offscreenBrowserBackend)
+    const hasHeadlessCommands = runtimeBrowserCommandsFactoryIsHeadless()
     const canBrowse = hasRenderer || hasOffscreen
     const capabilities: RuntimeCapability[] = RUNTIME_CAPABILITIES.filter(
       (capability) =>
@@ -6142,7 +6147,7 @@ export class OrcaRuntimeService {
         (process.env.ORCA_E2E_DISABLE_PAIRED_TERMINAL_PARKING !== '1' ||
           capability !== TERMINAL_PAIRED_PARKING_RUNTIME_CAPABILITY)
     )
-    if (hasOffscreen) {
+    if (hasOffscreen || hasHeadlessCommands) {
       capabilities.push(BROWSER_HEADLESS_RUNTIME_CAPABILITY)
     }
     // Why: certificate proceed is owned by the browser-hosting process for both
@@ -6151,6 +6156,17 @@ export class OrcaRuntimeService {
     if (canBrowse) {
       capabilities.push(BROWSER_CERTIFICATE_TRUST_RUNTIME_CAPABILITY)
     }
+    const degradations =
+      canBrowse || hasHeadlessCommands
+        ? []
+        : [
+            {
+              code: BROWSER_UNAVAILABLE_ERROR_CODE,
+              capability: BROWSER_HEADLESS_RUNTIME_CAPABILITY,
+              message:
+                'Browser automation requires the Electron provider or ORCA_BROWSER_EXECUTABLE.'
+            }
+          ]
     return {
       runtimeId: this.runtimeId,
       rendererGraphEpoch: this.rendererGraphEpoch,
@@ -6164,6 +6180,7 @@ export class OrcaRuntimeService {
       // Why: headless orca serve cannot create/stream BrowserViews, so clients
       // must not treat browser panes as supported just because runtime RPC is up.
       capabilities,
+      ...(degradations.length > 0 ? { degradations } : {}),
       hostPlatform: process.platform,
       terminalWindowsShell: this.store?.getSettings?.().terminalWindowsShell ?? null,
       floatingWorkspaceEnabled: this.store?.getSettings?.().floatingTerminalEnabled !== false,

--- a/src/main/runtime/rpc/methods/browser-screencast.ts
+++ b/src/main/runtime/rpc/methods/browser-screencast.ts
@@ -1,6 +1,9 @@
 import { z } from 'zod'
 import { defineMethod, defineStreamingMethod, type RpcAnyMethod } from '../core'
 import { Screencast } from './browser-schemas'
+import { BrowserError } from '../../../browser/browser-error'
+import { BROWSER_UNAVAILABLE_ERROR_CODE } from '../../../../shared/runtime-types'
+import { runtimeBrowserCommandsFactoryIsAvailable } from '../../runtime-browser-commands-factory'
 
 const ScreencastUnsubscribe = z.object({
   subscriptionId: z.string().min(1, 'Missing required --subscription-id')
@@ -17,6 +20,12 @@ export const BROWSER_SCREENCAST_METHODS: RpcAnyMethod[] = [
     name: 'browser.screencast.unsubscribe',
     params: ScreencastUnsubscribe,
     handler: async (params, { runtime }) => {
+      if (!runtimeBrowserCommandsFactoryIsAvailable()) {
+        throw new BrowserError(
+          BROWSER_UNAVAILABLE_ERROR_CODE,
+          'Browser automation is unavailable on this host.'
+        )
+      }
       runtime.cleanupSubscription(params.subscriptionId)
       return { unsubscribed: true }
     }

--- a/src/main/runtime/rpc/methods/browser.test.ts
+++ b/src/main/runtime/rpc/methods/browser.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { RpcDispatcher } from '../dispatcher'
 import type { RpcRequest } from '../core'
 import type { OrcaRuntimeService } from '../../orca-runtime'
+import { setRuntimeBrowserCommandsFactory } from '../../runtime-browser-commands-factory'
 import {
   CLIPBOARD_TEXT_MEASURE_YIELD_CODE_UNITS,
   CLIPBOARD_TEXT_WRITE_MAX_BYTES,
@@ -155,6 +156,32 @@ describe('browser RPC methods', () => {
       cleanupSubscription: vi.fn()
     } as unknown as OrcaRuntimeService
     const dispatcher = new RpcDispatcher({ runtime, methods: BROWSER_SCREENCAST_METHODS })
+    setRuntimeBrowserCommandsFactory(() => ({}) as never)
+
+    try {
+      const response = await dispatcher.dispatch(
+        makeRequest('browser.screencast.unsubscribe', {
+          subscriptionId: 'browser-screencast:page-1:test'
+        })
+      )
+
+      expect(runtime.cleanupSubscription).toHaveBeenCalledWith('browser-screencast:page-1:test')
+      expect(response).toMatchObject({
+        ok: true,
+        result: { unsubscribed: true }
+      })
+    } finally {
+      setRuntimeBrowserCommandsFactory(null)
+    }
+  })
+
+  it('rejects browser screencast unsubscribe when no provider resolved', async () => {
+    setRuntimeBrowserCommandsFactory(null)
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      cleanupSubscription: vi.fn()
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: BROWSER_SCREENCAST_METHODS })
 
     const response = await dispatcher.dispatch(
       makeRequest('browser.screencast.unsubscribe', {
@@ -162,11 +189,11 @@ describe('browser RPC methods', () => {
       })
     )
 
-    expect(runtime.cleanupSubscription).toHaveBeenCalledWith('browser-screencast:page-1:test')
     expect(response).toMatchObject({
-      ok: true,
-      result: { unsubscribed: true }
+      ok: false,
+      error: { code: 'browser_unavailable' }
     })
+    expect(runtime.cleanupSubscription).not.toHaveBeenCalled()
   })
 
   it('routes browser session and environment controls to the runtime server', async () => {

--- a/src/main/runtime/runtime-browser-commands-factory.ts
+++ b/src/main/runtime/runtime-browser-commands-factory.ts
@@ -1,3 +1,5 @@
+import { BrowserError } from '../browser/browser-error'
+import { BROWSER_UNAVAILABLE_ERROR_CODE } from '../../shared/runtime-types'
 import type { RuntimeBrowserCommandHost, RuntimeBrowserCommands } from './orca-runtime-browser'
 
 /**
@@ -8,9 +10,9 @@ import type { RuntimeBrowserCommandHost, RuntimeBrowserCommands } from './orca-r
  * 15 modules that a Node host cannot load at all. Importing the class for its *type*
  * is free; constructing it is what drags the cluster in.
  *
- * The desktop installs the real factory. A Node host installs none and every browser
- * RPC rejects with `browser_unavailable`, which the runtime already advertises through
- * capability filtering — clients do not offer the affordance.
+ * The desktop installs the Electron factory. A Node host installs an external provider
+ * when one resolves; otherwise every browser RPC rejects with the closed
+ * `browser_unavailable` code and capability filtering hides the affordance.
  *
  * Deliberately NOT a stub object with silently-succeeding methods: that is the
  * "looks fine, returns a lie" shape this codebase rejects. Absent means rejected.
@@ -20,12 +22,36 @@ export type RuntimeBrowserCommandsFactory = (
   host: RuntimeBrowserCommandHost
 ) => RuntimeBrowserCommands
 
+export type RuntimeBrowserCommandsFactoryOptions = {
+  /** The provider owns browser pages without a renderer window. */
+  headless?: boolean
+  /** Live health probe; failure must remove advertised capability. */
+  isAvailable?: () => boolean
+}
+
 let currentFactory: RuntimeBrowserCommandsFactory | null = null
+let currentOptions: RuntimeBrowserCommandsFactoryOptions = {}
 
 export function setRuntimeBrowserCommandsFactory(
-  factory: RuntimeBrowserCommandsFactory | null
+  factory: RuntimeBrowserCommandsFactory | null,
+  options: RuntimeBrowserCommandsFactoryOptions = {}
 ): void {
   currentFactory = factory
+  currentOptions = factory ? options : {}
+}
+export function runtimeBrowserCommandsFactoryIsAvailable(): boolean {
+  if (!currentFactory) {
+    return false
+  }
+  try {
+    return currentOptions.isAvailable?.() !== false
+  } catch {
+    return false
+  }
+}
+
+export function runtimeBrowserCommandsFactoryIsHeadless(): boolean {
+  return runtimeBrowserCommandsFactoryIsAvailable() && currentOptions.headless === true
 }
 
 /**
@@ -46,7 +72,10 @@ export function createRuntimeBrowserCommands(
         return undefined
       }
       return () => {
-        throw new Error(`browser_unavailable: ${String(property)} needs a desktop host`)
+        throw new BrowserError(
+          BROWSER_UNAVAILABLE_ERROR_CODE,
+          'Browser automation is unavailable on this host.'
+        )
       }
     }
   })

--- a/src/shared/child-process/run-process.ts
+++ b/src/shared/child-process/run-process.ts
@@ -7,6 +7,8 @@ import {
 import { buildWindowsCmdShimCommandLine, isCmdInterpretedProgram } from './windows-command-line'
 import { forceTerminateProcessTree, signalProcessTree } from './process-tree-termination'
 
+export type SpawnedProcess = ChildProcess
+
 /**
  * The single place Orca starts a child process.
  *

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -65,6 +65,14 @@ export type RuntimeTerminalDriverState =
 
 export type RuntimeBrowserDriverState = RuntimeTerminalDriverState
 
+export const BROWSER_UNAVAILABLE_ERROR_CODE = 'browser_unavailable' as const
+
+export type RuntimeDegradation = {
+  code: typeof BROWSER_UNAVAILABLE_ERROR_CODE
+  capability: 'browser.headless.v1'
+  message: string
+}
+
 export type RuntimeStatus = {
   runtimeId: string
   /** Authenticated requester identity. Missing for in-process callers and older hosts. */
@@ -80,6 +88,11 @@ export type RuntimeStatus = {
   runtimeProtocolVersion?: number
   minCompatibleRuntimeClientVersion?: number
   capabilities?: RuntimeCapability[]
+  /**
+   * Optional for mixed-version peers. Absence means the host predates structured
+   * degradation reporting, not that the host proved every optional feature available.
+   */
+  degradations?: RuntimeDegradation[]
   // Why: optional fields let updated clients inventory both new and legacy paired servers.
   appVersion?: string
   remoteUpdateSupport?: RemoteServerUpdateSupport
@@ -123,6 +136,7 @@ export type CliStatusResult = {
     appVersion?: string
     remoteUpdateSupport?: RemoteServerUpdateSupport
     capabilities?: RuntimeCapability[]
+    degradations?: RuntimeDegradation[]
   }
   graph: {
     state: RuntimeGraphStatus | 'not_running' | 'starting'
@@ -1297,6 +1311,11 @@ export type BrowserTabCreateResult = {
 }
 
 export type BrowserErrorCode =
+  | typeof BROWSER_UNAVAILABLE_ERROR_CODE
+  | 'browser_command_unavailable'
+  | 'browser_profile_unavailable'
+  | 'browser_screencast_unavailable'
+  | 'browser_certificate_trust_unavailable'
   | 'browser_no_tab'
   | 'browser_tab_not_found'
   | 'browser_tab_closed'


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​438 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​427 |
| Prod | 21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1953 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​34 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1919 |

<!-- /orca-pr-loc -->

## ELI5

`orcad` can now own browser automation without pulling Electron-only browser code into its Node 18 bundle. At startup it uses an installed Orca app through the same headless `orca serve` backend when available; otherwise it launches the operator-provided `ORCA_BROWSER_EXECUTABLE` and drives it over real CDP. If neither provider is usable, the runtime stays up but reports a structured degradation and every browser RPC fails with the closed `browser_unavailable` code.

## What Changed

- Added startup browser-provider resolution through the existing `setRuntimeBrowserCommandsFactory` seam:
  1. installed Orca Electron launcher on macOS, Linux, or Windows;
  2. `ORCA_BROWSER_EXECUTABLE` plus the bundled platform `agent-browser` binary;
  3. no provider, with explicit refusal.
- Added an isolated Electron `orca serve` sidecar that:
  - uses the incumbent offscreen browser backend;
  - communicates over its private local Unix socket / named pipe with pairing disabled;
  - preserves caller-visible page IDs across mixed versions;
  - fences explicit worktree scope and keeps per-worktree tab indices/active pages;
  - removes stale tab mappings, bounds response buffering, and tears down its process/profile on failure or shutdown;
  - removes `browser.headless.v1` from status if the sidecar dies.
- Added the external Chromium provider using the native `agent-browser` CDP client:
  - real Chromium launch from `ORCA_BROWSER_EXECUTABLE`;
  - navigation, evaluation, screenshots, tab lifecycle, input, storage, cookies, capture, and environment commands;
  - target/session/profile/executable override flags stripped from raw `browser.exec` commands;
  - requested page IDs and worktree ownership preserved;
  - bounded subprocess output and close deadlines.
- Added the optional, mixed-version-safe `RuntimeStatus.degradations[]` field and projected it through local and remote CLI status JSON.
- Changed the no-provider factory from a message-only `Error` to `BrowserError('browser_unavailable', ...)`, including screencast unsubscribe.
- Kept screencast separate: neither new `orcad` provider advertises `browser.screencast.v1`.
- Hardened `build-orcad.mjs`:
  - copies the current platform's `agent-browser` binary beside `orcad.js`;
  - fails on any `electron` importer;
  - fails on any `node:sqlite` importer.
- Extended the shared Electron/`orcad` smoke harness with optional browser capability, navigate, evaluate, and screenshot assertions.
- Fixed `orcad` signal/startup cleanup so async runtime and browser-provider teardown completes before exit and startup failures cannot leak providers.

## Why

The two cookie-import modules are the only browser-cluster paths that statically import `node:sqlite`. Re-including that cluster would silently raise `orcad`'s Node floor from 18 to 22.5+, invalidating the deployment model. This keeps that graph boundary intact while preserving headless browser automation, removing the capability trade that previously blocked retiring Electron `orca serve`.

The provider order is deliberate: an installed Electron app reuses the existing, proven `orca serve` behavior; a standalone host can supply any compatible Chromium executable; a future downloaded-Chromium resolver can be inserted as a third startup step without changing the runtime-command seam.

## Linked Issue

N/A — this worktree has no linked Linear issue; this is the reviewed `orcad` viability follow-up requested directly.

## Visual Proof

N/A — no renderer/UI surface changed. Verification drives the public runtime/CLI browser surface against real Electron and Chromium processes.

## Testing

- [x] I manually tested these changes locally on macOS.
- [x] Automated tests added/updated.

Commands and observed results:

- `pnpm exec oxfmt --check <affected files>` — pass.
- `pnpm exec tsc -p config/tsconfig.node.json --noEmit` — pass.
- `pnpm exec oxlint <affected files>` — pass.
- Browser/runtime/RPC focused suites — 41 passed.
- CLI status + sidecar tab authority suites — 20 passed.
- `ORCA_BROWSER_EXECUTABLE="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" pnpm exec vitest run --config config/vitest.config.ts src/main/orcad/external-chromium-browser-process.integration.test.ts` — real Chromium navigate/evaluate/screenshot pass.
- `pnpm run build:orcad` — 4.48 MB, 2,048 modules, zero Electron imports, zero `node:sqlite` imports.
- `node config/scripts/runtime-serve-terminal-smoke.mjs --target orcad --browser` — installed Electron provider advertises `browser.headless.v1`; browser navigate/evaluate/screenshot and terminal round trip pass.
- `pnpm run smoke:orcad-terminal` — pass.
- `pnpm run check:runtime-electron-ratchet` — 0 entries, unchanged.
- `pnpm run check:max-lines-ratchet` — no new bypasses.
- Post-smoke process check — no provider processes left behind.

Platforms actually executed: macOS arm64, installed Orca Electron app, Google Chrome arm64. Windows/Linux launcher and native-binary naming contracts have deterministic unit coverage; real Windows/Linux process launch remains CI coverage.

## AI Disclosure


## Review

Readiness checklist verdict: **READY — no proven P0, P1, or P2 findings remain.**

Reviewed explicitly for:

- SSH/remote/network: providers run on the execution host; no client-side fallback; paired-network transport unchanged; sidecar transport is private/local and bounded.
- Crash/retry/growth: startup/command/close deadlines, failed-start cleanup, live health gating, stale-map pruning, bounded buffers/output, no unbounded retries or queues.
- Security/supply chain: no dependency/lockfile changes, downloads, shell execution, embedded credentials, or profile-database imports; explicit executable ownership; raw command target overrides fenced; sidecar pairing disabled and temp root private/randomized.
- Performance/resources: startup polling is bounded and temporary; command subprocess behavior matches the incumbent agent-browser bridge; maps and response buffers are bounded/pruned; provider cleanup verified after repeated smoke runs.
- Functional correctness: provider precedence, capability honesty, closed errors, page-ID compatibility, worktree authority, CLI degradation projection, and core browser flows exercised.
- Backward/mobile compatibility: only additive optional status fields; existing capability vocabulary reused; no persisted mobile state, routes, handshake, E2EE, or mobile source changed.
- Cross-platform/remoting: `path` APIs, `spawnProcess`, named-pipe support, POSIX executable checks, AppImage/deb/macOS/Windows launcher candidates, and platform native-binary names reviewed and unit-tested.

Residual risk: real Windows/Linux provider launch was not executed locally; sidecar failure degrades capability honestly but recovery requires restarting `orcad`; screencast remains deliberately out of scope.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation were copied or translated.

## Notes

No mobile-facing source was touched. The only mobile-visible surface is an additive optional field on `status.get`; older clients ignore it under the remote-wire compatibility contract.

## Checklist

- [ ] This PR is small and focused. The behavior is focused, but the two-provider implementation and proof span multiple modules.
- [x] I explained what changed and why (including ELI5).
- [x] Visual proof is N/A because no UI changed.
- [x] Self-reviewed for correctness, security, performance, crash behavior, and resource cleanup.
- [x] Cross-platform, SSH/remote, mobile, and backward-compatibility impact considered.
- [x] Focused formatting, typecheck, lint, tests, build, real-provider E2Es, ratchet, and smoke gates pass. Full repository-wide `pnpm lint`, `pnpm test`, and `pnpm build` remain CI coverage.
