### PR TITLE
feat(editor): make the Copy context selection hint clickable

### DIFF
--- a/src/renderer/src/components/editor/contextual-copy-hint-widget.ts
+++ b/src/renderer/src/components/editor/contextual-copy-hint-widget.ts
@@ -1,0 +1,44 @@
+import { formatShortcutLabel } from '@/hooks/useShortcutLabel'
+import { translate } from '@/i18n/i18n'
+import { useAppStore } from '@/store'
+
+export function createContextualCopyHintNode(): HTMLButtonElement {
+  const copyHintNode = document.createElement('button')
+  copyHintNode.type = 'button'
+  copyHintNode.tabIndex = -1
+  copyHintNode.className =
+    'cursor-pointer rounded-md border border-border/90 bg-background px-2.5 py-1 text-xs font-medium text-foreground shadow-[0_6px_18px_rgba(15,23,42,0.18)] backdrop-blur whitespace-nowrap hover:bg-accent hover:text-accent-foreground'
+  copyHintNode.style.display = 'none'
+  refreshContextualCopyHintLabel(copyHintNode)
+  return copyHintNode
+}
+
+export function refreshContextualCopyHintLabel(copyHintNode: HTMLButtonElement): void {
+  const copyContextLabel = translate(
+    'auto.components.editor.setupContextualCopy.copyContext',
+    'Copy context'
+  )
+  copyHintNode.textContent = `${copyContextLabel} ${formatShortcutLabel(
+    'editor.copyContext',
+    useAppStore.getState().keybindings
+  )}`
+  copyHintNode.setAttribute('aria-label', copyContextLabel)
+}
+
+export function attachContextualCopyHintPointerDown(
+  copyHintNode: HTMLButtonElement,
+  onCopy: () => void
+): () => void {
+  // Why: pointerdown runs before Monaco steals focus / hides this widget on
+  // blur. preventDefault keeps the editor selection intact while we copy.
+  const handlePointerDown = (event: PointerEvent): void => {
+    if (event.button !== 0) {
+      return
+    }
+    event.preventDefault()
+    event.stopPropagation()
+    onCopy()
+  }
+  copyHintNode.addEventListener('pointerdown', handlePointerDown)
+  return () => copyHintNode.removeEventListener('pointerdown', handlePointerDown)
+}

--- a/src/renderer/src/components/editor/setup-contextual-copy.test.ts
+++ b/src/renderer/src/components/editor/setup-contextual-copy.test.ts
@@ -3,7 +3,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { setupContextualCopy } from './setup-contextual-copy'
 
 vi.mock('@/hooks/useShortcutLabel', () => ({
-  formatShortcutLabel: () => 'Copy Context'
+  formatShortcutLabel: () => '⌘⌥C'
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
 }))
 
 vi.mock('@/lib/monaco-setup', () => ({
@@ -29,6 +33,50 @@ vi.mock('@/lib/primary-selection', () => ({
   setPrimarySelectionText: () => {}
 }))
 
+function createCopyHintNodeMock(): {
+  className: string
+  offsetHeight: number
+  style: { display: string }
+  textContent: string
+  type: string
+  tabIndex: number
+  setAttribute: ReturnType<typeof vi.fn>
+  addEventListener: ReturnType<typeof vi.fn>
+  removeEventListener: ReturnType<typeof vi.fn>
+  dispatchEvent: (event: Event) => boolean
+} {
+  const listeners = new Map<string, Set<(event: Event) => void>>()
+  return {
+    className: '',
+    offsetHeight: 28,
+    style: { display: '' },
+    textContent: '',
+    type: '',
+    tabIndex: 0,
+    setAttribute: vi.fn(),
+    addEventListener: vi.fn((type: string, listener: (event: Event) => void) => {
+      const set = listeners.get(type) ?? new Set()
+      set.add(listener)
+      listeners.set(type, set)
+    }),
+    removeEventListener: vi.fn((type: string, listener: (event: Event) => void) => {
+      listeners.get(type)?.delete(listener)
+    }),
+    dispatchEvent(event: Event) {
+      for (const listener of listeners.get(event.type) ?? []) {
+        listener(event)
+      }
+      return true
+    }
+  }
+}
+
+function createPointerDownEvent(button = 0): PointerEvent {
+  const event = new Event('pointerdown', { cancelable: true }) as PointerEvent
+  Object.defineProperty(event, 'button', { value: button })
+  return event
+}
+
 describe('setupContextualCopy', () => {
   afterEach(() => {
     vi.unstubAllGlobals()
@@ -43,12 +91,7 @@ describe('setupContextualCopy', () => {
       setTimeout: vi.fn(() => 2)
     })
     vi.stubGlobal('document', {
-      createElement: () => ({
-        className: '',
-        offsetHeight: 28,
-        style: { display: '' },
-        textContent: ''
-      })
+      createElement: () => createCopyHintNodeMock()
     })
 
     const editorInstance = {
@@ -94,12 +137,7 @@ describe('setupContextualCopy', () => {
       setTimeout: vi.fn(() => 2)
     })
     vi.stubGlobal('document', {
-      createElement: () => ({
-        className: '',
-        offsetHeight: 28,
-        style: { display: '' },
-        textContent: ''
-      })
+      createElement: () => createCopyHintNodeMock()
     })
 
     const selection = {
@@ -159,13 +197,9 @@ describe('setupContextualCopy', () => {
       setInterval: vi.fn(() => 1),
       setTimeout: vi.fn(() => 2)
     })
+    const copyHintNode = createCopyHintNodeMock()
     vi.stubGlobal('document', {
-      createElement: () => ({
-        className: '',
-        offsetHeight: 28,
-        style: { display: '' },
-        textContent: ''
-      })
+      createElement: () => copyHintNode
     })
 
     const editorDomNode = {
@@ -220,5 +254,81 @@ describe('setupContextualCopy', () => {
     expect(copyToastTimeoutRef.current).toBeNull()
     expect(setCopyToast).toHaveBeenCalledWith(null)
     expect(editorDomNode.removeEventListener).toHaveBeenCalledTimes(3)
+    expect(copyHintNode.removeEventListener).toHaveBeenCalledWith(
+      'pointerdown',
+      expect.any(Function)
+    )
+  })
+
+  it('copies the contextual selection when the hint button is pressed', async () => {
+    const writeClipboardText = vi.fn().mockResolvedValue(undefined)
+    vi.stubGlobal('window', {
+      api: { ui: { writeClipboardText } },
+      clearInterval: vi.fn(),
+      clearTimeout: vi.fn(),
+      setInterval: vi.fn(() => 1),
+      setTimeout: vi.fn(() => 2)
+    })
+    const copyHintNode = createCopyHintNodeMock()
+    vi.stubGlobal('document', {
+      createElement: () => copyHintNode
+    })
+
+    const selection = {
+      startLineNumber: 1,
+      startColumn: 1,
+      endLineNumber: 2,
+      endColumn: 4,
+      isEmpty: () => false,
+      getStartPosition: () => ({ lineNumber: 1, column: 1 }),
+      getEndPosition: () => ({ lineNumber: 2, column: 4 })
+    }
+    const setCopyToast = vi.fn()
+    const editorInstance = {
+      addContentWidget: vi.fn(),
+      getContainerDomNode: () => ({
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        getBoundingClientRect: () => ({ left: 10, top: 20, width: 800 })
+      }),
+      getLayoutInfo: () => ({ height: 500 }),
+      getModel: () => ({
+        getLineMaxColumn: () => 4,
+        getValueInRange: () => 'one\ntwo'
+      }),
+      getScrolledVisiblePosition: () => ({ top: 20, left: 8, height: 16 }),
+      getSelection: () => selection,
+      hasTextFocus: () => true,
+      layoutContentWidget: vi.fn(),
+      onDidBlurEditorText: () => ({ dispose: vi.fn() }),
+      onDidChangeCursorSelection: () => ({ dispose: vi.fn() }),
+      onDidDispose: () => ({ dispose: vi.fn() }),
+      onDidFocusEditorText: () => ({ dispose: vi.fn() }),
+      onDidScrollChange: () => ({ dispose: vi.fn() }),
+      removeContentWidget: vi.fn()
+    } as unknown as editor.IStandaloneCodeEditor
+
+    setupContextualCopy({
+      editorInstance,
+      filePath: 'src/example.ts',
+      setCopyToast,
+      propsRef: {
+        current: {
+          language: 'typescript',
+          relativePath: 'src/example.ts'
+        }
+      },
+      copyToastTimeoutRef: { current: null }
+    })
+
+    copyHintNode.dispatchEvent(createPointerDownEvent())
+
+    await vi.waitFor(() => {
+      expect(writeClipboardText).toHaveBeenCalledWith(
+        ['File: src/example.ts', 'Lines: 1-2', '', '```ts', 'one\ntwo', '```'].join('\n')
+      )
+    })
+    expect(setCopyToast).toHaveBeenCalledWith({ left: 18, top: 64 })
+    expect(copyHintNode.style.display).toBe('none')
   })
 })

--- a/src/renderer/src/components/editor/setup-contextual-copy.ts
+++ b/src/renderer/src/components/editor/setup-contextual-copy.ts
@@ -1,7 +1,10 @@
 import type { editor } from 'monaco-editor'
-import { formatShortcutLabel } from '@/hooks/useShortcutLabel'
 import { monaco } from '@/lib/monaco-setup'
-import { useAppStore } from '@/store'
+import {
+  attachContextualCopyHintPointerDown,
+  createContextualCopyHintNode,
+  refreshContextualCopyHintLabel
+} from './contextual-copy-hint-widget'
 import { editorShortcutMatches } from './editor-shortcuts'
 import { formatCopiedSelectionWithContext, getContextualCopyLineRange } from './selection-copy'
 import {
@@ -31,17 +34,7 @@ export function setupContextualCopy({
   let primarySelectionTimer: number | null = null
   let copyHintWidgetPosition: editor.IContentWidgetPosition | null = null
   let lastCopiedSelectionKey: string | null = null
-  const copyHintNode = document.createElement('div')
-  copyHintNode.className =
-    'pointer-events-none rounded-md border border-border/90 bg-background px-2.5 py-1 text-xs font-medium text-foreground shadow-[0_6px_18px_rgba(15,23,42,0.18)] backdrop-blur whitespace-nowrap'
-  const updateCopyHintLabel = (): void => {
-    copyHintNode.textContent = `Copy context ${formatShortcutLabel(
-      'editor.copyContext',
-      useAppStore.getState().keybindings
-    )}`
-  }
-  updateCopyHintLabel()
-  copyHintNode.style.display = 'none'
+  const copyHintNode = createContextualCopyHintNode()
   const copyHintWidget: editor.IContentWidget = {
     allowEditorOverflow: true,
     suppressMouseDown: true,
@@ -86,7 +79,7 @@ export function setupContextualCopy({
   }
 
   const updateCopyHint = (): void => {
-    updateCopyHintLabel()
+    refreshContextualCopyHintLabel(copyHintNode)
     const contextualCopyText = getContextualCopyText()
     if (!contextualCopyText) {
       copyHintNode.style.display = 'none'
@@ -270,6 +263,10 @@ export function setupContextualCopy({
     return true
   }
 
+  const detachCopyHintPointerDown = attachContextualCopyHintPointerDown(copyHintNode, () => {
+    void copySelectionWithContext()
+  })
+
   const selectionListener = editorInstance.onDidChangeCursorSelection((event) => {
     if (event.source !== 'restoreState') {
       schedulePrimarySelectionBufferUpdate()
@@ -329,6 +326,7 @@ export function setupContextualCopy({
     editorDomNode.removeEventListener('keydown', handleKeyDown, true)
     editorDomNode.removeEventListener('mouseup', refreshCopyHintAndPolling, true)
     editorDomNode.removeEventListener('keyup', refreshCopyHintAndPolling, true)
+    detachCopyHintPointerDown()
     stopCopyHintPolling()
     editorInstance.removeContentWidget(copyHintWidget)
   })

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14440,6 +14440,9 @@
             }
           }
         },
+        "setupContextualCopy": {
+          "copyContext": "Copy context"
+        },
         "useContextualCopySetup": {
           "059bfb0d94": "Context copied"
         },


### PR DESCRIPTION
## ELI5

Selecting code in the editor already showed a "Copy context" shortcut chip. That chip is now a button: click it and it copies the same file/line payload as the keyboard shortcut.

## What Changed

- The selection hint is a `button` instead of a non-interactive overlay.
- Primary click runs the existing contextual-copy path (`writeClipboardText` + "Context copied" toast).
- Hint widget construction lives in `contextual-copy-hint-widget.ts` so `setup-contextual-copy.ts` stays under the max-lines lint.

## Why

The shortcut was easy to miss. A clickable hint makes the same action discoverable without changing Cmd/Ctrl+C.

## Linked Issue

No existing issue.

## Visual Proof

N/A in this PR — the chip keeps the same copy and shortcut label; it gains a pointer cursor and hover background. Interaction change:

- **Before:** select multi-line text → see shortcut, only the keybinding copies
- **After:** select multi-line text → click the chip or use the shortcut; both copy contextual payload

## Testing

- [x] Automated tests added/updated, or explained why not below
- [ ] I manually tested these changes locally

Covered in unit tests:

- focused editor does not poll when the hint is hidden
- focused editor polls while the hint is visible
- dispose removes editor listeners and the hint `pointerdown` listener
- pressing the hint copies `File:` / `Lines:` fenced payload and hides the chip

```bash
pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/editor/setup-contextual-copy.test.ts
```

4 tests passed.

## AI Disclosure

Cursor Grok authored the implementation, tests, and this PR description.

## Review

- **Cross-platform:** shortcut label still comes from `formatShortcutLabel`; click path does not hardcode modifiers.
- **SSH / remote / folder:** copy payload still uses the editor relative path; no execution-host change.
- **UI:** hover uses `accent` tokens; existing floating shadow on the chip is unchanged.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Summary

- The editor Copy context hint is now a button that copies the same contextual payload as the shortcut.
- Hint widget DOM is extracted so the setup module stays within max-lines.

## Test plan

- [ ] Select multi-line text in a file editor → hint appears with Copy context + shortcut
- [ ] Click the hint → clipboard has `File:` / `Lines:` / fenced code; toast shows Context copied
- [ ] Press the shortcut on the same selection → same payload
- [ ] Clicking the hint does not collapse the selection
- [ ] Single-line selection still does not show the hint

Made with [Cursor](https://cursor.com)