### PR TITLE
perf(terminal): coalesce scroll-intent settles instead of one per wheel event

### DIFF
--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent-settle-coalescing.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent-settle-coalescing.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { TerminalScrollIntentTarget } from './terminal-scroll-intent'
+
+const syncFromViewport = vi.fn()
+
+vi.mock('./terminal-scroll-intent', () => ({
+  syncTerminalScrollIntentFromViewport: (...args: unknown[]) => syncFromViewport(...args)
+}))
+
+const { syncTerminalScrollIntentSoon } = await import('./terminal-scroll-intent-settle')
+
+let frameCallbacks: FrameRequestCallback[] = []
+
+function flushFrames(): void {
+  // Why: the double-frame phase queues its inner callback while draining, so run
+  // until the queue is empty rather than over a snapshot of it.
+  let guard = 0
+  while (frameCallbacks.length > 0 && guard < 20) {
+    const callbacks = frameCallbacks
+    frameCallbacks = []
+    for (const callback of callbacks) {
+      callback(16)
+    }
+    guard += 1
+  }
+}
+
+function createTerminal(): TerminalScrollIntentTarget {
+  return {} as TerminalScrollIntentTarget
+}
+
+describe('syncTerminalScrollIntentSoon coalescing', () => {
+  beforeEach(() => {
+    syncFromViewport.mockClear()
+    frameCallbacks = []
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      frameCallbacks.push(callback)
+      return frameCallbacks.length
+    })
+    // Why: clearTimeout must be faked alongside setTimeout, otherwise the real
+    // clearTimeout cannot cancel a fake timer and the debounce looks broken.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('collapses a burst of calls into one sync per phase instead of one per call', async () => {
+    // Why: a trackpad delivers many wheel events per frame; each used to schedule its
+    // own microtask, two frames and an 80ms settle.
+    const terminal = createTerminal()
+
+    for (let index = 0; index < 10; index += 1) {
+      syncTerminalScrollIntentSoon(terminal)
+    }
+
+    await Promise.resolve()
+    flushFrames()
+    vi.advanceTimersByTime(80)
+
+    // microtask + frame + double-frame + settle, once each, not ten times each.
+    expect(syncFromViewport).toHaveBeenCalledTimes(4)
+  })
+
+  it('settles once after the last call rather than once per call', async () => {
+    // Why: spacing the calls 30ms apart keeps every settle deadline in the future
+    // at the point the baseline is taken, so an undebounced timer chain shows up as
+    // three settles instead of one.
+    const terminal = createTerminal()
+
+    syncTerminalScrollIntentSoon(terminal)
+    vi.advanceTimersByTime(30)
+    syncTerminalScrollIntentSoon(terminal)
+    vi.advanceTimersByTime(30)
+    syncTerminalScrollIntentSoon(terminal)
+
+    await Promise.resolve()
+    flushFrames()
+    const beforeSettle = syncFromViewport.mock.calls.length
+
+    vi.advanceTimersByTime(200)
+
+    expect(syncFromViewport.mock.calls.length).toBe(beforeSettle + 1)
+  })
+
+  it('keeps terminals independent', async () => {
+    const first = createTerminal()
+    const second = createTerminal()
+
+    syncTerminalScrollIntentSoon(first)
+    syncTerminalScrollIntentSoon(second)
+
+    await Promise.resolve()
+
+    expect(syncFromViewport).toHaveBeenCalledTimes(2)
+    expect(syncFromViewport.mock.calls[0]?.[0]).toBe(first)
+    expect(syncFromViewport.mock.calls[1]?.[0]).toBe(second)
+  })
+
+  it('applies the newest options so a later wheel does not inherit earlier pinning', async () => {
+    const terminal = createTerminal()
+
+    syncTerminalScrollIntentSoon(terminal, { preservePinnedAtBottom: true })
+    syncTerminalScrollIntentSoon(terminal, { preservePinnedAtBottom: false })
+
+    await Promise.resolve()
+
+    expect(syncFromViewport).toHaveBeenCalledTimes(1)
+    expect(syncFromViewport.mock.calls[0]?.[1]).toEqual({ preservePinnedAtBottom: false })
+  })
+
+  it('honors a shouldSync veto for both the immediate and settle phases', async () => {
+    const terminal = createTerminal()
+
+    syncTerminalScrollIntentSoon(terminal, { shouldSync: () => false })
+
+    await Promise.resolve()
+    flushFrames()
+    vi.advanceTimersByTime(80)
+
+    expect(syncFromViewport).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent-settle.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent-settle.ts
@@ -3,31 +3,93 @@ import {
   type TerminalScrollIntentTarget
 } from './terminal-scroll-intent'
 
+const SETTLE_DELAY_MS = 80
+
+type SyncOptions = {
+  allowBufferShrink?: boolean
+  preservePinnedAtBottom?: boolean
+  shouldSync?: () => boolean
+}
+
+type PendingSync = {
+  options: SyncOptions
+  microtaskScheduled: boolean
+  frameScheduled: boolean
+  doubleFrameScheduled: boolean
+  settleTimer: ReturnType<typeof setTimeout> | null
+}
+
+// Why: a trackpad gesture delivers wheel events far faster than one per frame, and
+// every one of them used to schedule its own microtask, two frame callbacks and an
+// 80ms settle. Coalescing per terminal keeps one sync in flight per phase, so the
+// classification stays as fresh as the frame it lands in without replaying the same
+// viewport read several times inside it.
+const pendingByTerminal = new WeakMap<TerminalScrollIntentTarget, PendingSync>()
+
+function runSync(terminal: TerminalScrollIntentTarget, pending: PendingSync): void {
+  const options = pending.options
+  if (options.shouldSync?.() === false) {
+    return
+  }
+  syncTerminalScrollIntentFromViewport(terminal, options)
+}
+
 export function syncTerminalScrollIntentSoon(
   terminal: TerminalScrollIntentTarget,
-  options: {
-    allowBufferShrink?: boolean
-    preservePinnedAtBottom?: boolean
-    shouldSync?: () => boolean
-  } = {}
+  options: SyncOptions = {}
 ): void {
-  const sync = (): void => {
-    if (options.shouldSync?.() === false) {
-      return
-    }
-    syncTerminalScrollIntentFromViewport(terminal, options)
+  const existing = pendingByTerminal.get(terminal)
+  // Why: the newest call carries the newest intent, so later options win rather than
+  // merging. A downward wheel after an upward one must not inherit its pinning.
+  const pending: PendingSync = existing ?? {
+    options,
+    microtaskScheduled: false,
+    frameScheduled: false,
+    doubleFrameScheduled: false,
+    settleTimer: null
   }
-  queueMicrotask(sync)
-  requestAnimationFrame(sync)
-  requestAnimationFrame(() => requestAnimationFrame(sync))
+  pending.options = options
+  pendingByTerminal.set(terminal, pending)
+
+  if (!pending.microtaskScheduled) {
+    pending.microtaskScheduled = true
+    queueMicrotask(() => {
+      pending.microtaskScheduled = false
+      runSync(terminal, pending)
+    })
+  }
+
+  if (!pending.frameScheduled) {
+    pending.frameScheduled = true
+    requestAnimationFrame(() => {
+      pending.frameScheduled = false
+      runSync(terminal, pending)
+    })
+  }
+
+  if (!pending.doubleFrameScheduled) {
+    pending.doubleFrameScheduled = true
+    requestAnimationFrame(() =>
+      requestAnimationFrame(() => {
+        pending.doubleFrameScheduled = false
+        runSync(terminal, pending)
+      })
+    )
+  }
+
   // Why: preservePinnedAtBottom only bridges xterm's async scroll application.
   // The settle tick must reclassify from the real viewport, otherwise a wheel
-  // the viewport never followed latches a phantom pin at the bottom.
-  setTimeout(() => {
-    if (options.shouldSync?.() !== false) {
+  // the viewport never followed latches a phantom pin at the bottom. Debounced,
+  // not deduped: a gesture settles once after its last event, not once per event.
+  if (pending.settleTimer !== null) {
+    clearTimeout(pending.settleTimer)
+  }
+  pending.settleTimer = setTimeout(() => {
+    pending.settleTimer = null
+    if (pending.options.shouldSync?.() !== false) {
       syncTerminalScrollIntentFromViewport(terminal, {
-        allowBufferShrink: options.allowBufferShrink
+        allowBufferShrink: pending.options.allowBufferShrink
       })
     }
-  }, 80)
+  }, SETTLE_DELAY_MS)
 }


### PR DESCRIPTION
## ELI5

Every time you nudge the scroll wheel in a terminal, Orca schedules four little jobs to work out
"where is the user actually looking now". A trackpad sends those nudges much faster than the
screen redraws, and nothing was checking whether those jobs were already queued. So a one second
scroll queued hundreds of them, all asking the same question about the same screen, and the last
batch only came due after you had already stopped scrolling.

Now each terminal keeps one of each job in flight, and the final "settle" waits until you actually
stop instead of firing once per nudge.

## What Changed

`syncTerminalScrollIntentSoon` now keeps one pending record per terminal:

- microtask, frame, and double-frame phases allow a single sync in flight at a time
- the 80ms settle is **debounced** rather than deduplicated, so a gesture settles once after its
  last event
- the newest call's options win rather than merging

## Why

The function scheduled four callbacks unconditionally:

```ts
queueMicrotask(sync)
requestAnimationFrame(sync)
requestAnimationFrame(() => requestAnimationFrame(sync))
setTimeout(..., 80)
```

`onWheel` in `terminal-scroll-intent-dom-tracking.ts` calls it on every wheel event. A trackpad
delivers events far faster than one per frame, so a one second gesture queued roughly a hundred of
each phase. Every one re-read the same viewport and reclassified the same intent, and the 80ms
settles all came due in a trailing burst after the gesture had already stopped.

Three decisions worth naming:

- **The frame phases dedupe, they do not debounce.** Classification should stay as fresh as the
  frame it lands in. Deduping removes the repeats inside a frame without delaying the next frame's
  read.
- **The settle debounces.** Its comment explains it exists to reclassify from the real viewport so
  "a wheel the viewport never followed" cannot latch a phantom pin at the bottom. Only the final
  settle can do that job, so firing one per event was never useful.
- **Later options win rather than merging.** A downward wheel after an upward one must not inherit
  its `preservePinnedAtBottom`.

## Linked Issue

Refs #16137

Deliberately `Refs` and not `Fixes`. That issue also reports that TUI Scroll Speed has no effect on
trackpads, and as far as I can tell that part is intended rather than broken:
`resolveTrackpadPixelWheelReportCount` returns before the multiplier is applied, and its comment
says trackpad pixel streams are meant to map 1:1 to physical distance with no per-event cap. So
this addresses the scheduling half only. Happy to be told the multiplier half should change too,
but I did not want to quietly reverse a documented decision.

I also cannot claim this resolves the reporter's stutter, because I have not profiled their setup.
What I can show is that the redundant work is real and is now gone.

## Visual Proof

`N/A` — no UI change. Nothing renders differently; this changes how often an existing viewport
read is scheduled.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

New suite mocks `syncTerminalScrollIntentFromViewport` and counts calls per phase:

- ten calls inside one frame produce four syncs instead of thirteen
- three calls spaced 30ms apart settle once instead of three times
- terminals stay independent
- the newest options are the ones applied
- a `shouldSync` veto still suppresses both the immediate and settle phases

Reverting the implementation fails three of the five. The terminal-independence and
`shouldSync`-veto cases pass either way on purpose; they guard behavior I did not want to change.

Checks run locally on macOS:

- `src/renderer/src/lib/pane-manager` + `src/renderer/src/components/terminal-pane` — 456 files
  pass. One failure, `terminal-ime-xterm-consumed-key-commit.test.ts`, reproduces identically on a
  pristine `upstream/main` checkout without this commit, so it is pre-existing and unrelated.
- `pnpm lint` — exit 0
- `pnpm typecheck` — exit 0

One note for anyone extending these tests: `clearTimeout` has to be faked alongside `setTimeout`.
With only `setTimeout` faked, the real `clearTimeout` cannot cancel a fake timer and the debounce
looks broken when it is not. That cost me a while and is called out in the test.

## AI Disclosure

Claude Opus 5 (Claude Code) was used to confirm the scheduling behavior against `main`, build the
per-phase counting tests, and run the mutation check.

## Review

- **Cross-platform (macOS/Linux/Windows):** no platform-dependent code. `queueMicrotask`,
  `requestAnimationFrame`, `setTimeout` and `clearTimeout` are all standard renderer globals.
- **SSH / remote / local:** none. This is renderer-local scroll classification and does not depend
  on where the PTY executes.
- **Remote wire compatibility:** no RPC params, stream frames, or published content change.
- **Agent / integration compatibility:** not touched.
- **Performance:** this is the point of the change. Redundant viewport reads during a gesture drop
  from roughly one per wheel event per phase to one per phase per frame, and settles from one per
  event to one per gesture.
- **UI quality:** N/A, nothing renders differently.
- **Security:** no new input handling, execution, network, or filesystem access.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md`
      and copies or mechanically translates no upstream skill-installer source, tests, fixtures,
      registry entries, path tables, comments, or documentation.

## Notes

The pending record is held in a `WeakMap` keyed by terminal, so a disposed terminal's entry is
collected with it and there is nothing new to tear down.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: n/a
