### PR TITLE
feat(i18n): localize CLI-created workspace labels to Korean

### DIFF
--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4273,7 +4273,7 @@
           "489d1c8c9f": "프로젝트 검색...",
           "ee240a39eb": "필터 편집",
           "automationCreated": "자동화로 생성된 워크스페이스 숨기기",
-          "cliCreated": "Hide CLI-created",
+          "cliCreated": "CLI로 생성된 워크스페이스 숨기기",
           "detachedHead": "분리된 HEAD 숨기기",
           "keepDefaultBranch": "기본 브랜치는 제외",
           "keepDefaultBranchAria": "슬립 중인 워크스페이스를 숨겨도 기본 브랜치는 계속 표시"
@@ -4342,7 +4342,7 @@
           "ed1611b65b": "슬립 중인 항목 숨기기",
           "82594419ba": "필터",
           "automationCreated": "자동화로 생성된 워크스페이스 숨기기",
-          "cliCreated": "Hide CLI-created",
+          "cliCreated": "CLI로 생성된 워크스페이스 숨기기",
           "detachedHead": "분리된 HEAD 숨기기",
           "keepDefaultBranch": "기본 브랜치는 제외",
           "keepDefaultBranchAria": "슬립 중인 워크스페이스를 숨겨도 기본 브랜치는 계속 표시"
@@ -4515,10 +4515,10 @@
           "issueLinkLabel": "이슈 링크",
           "reviewLinkLabel": "{{value0}} 링크",
           "cliHeader": "Orca CLI",
-          "cliCreatedFromAgent": "Created by an agent via `orca worktree create`",
-          "cliCreatedFromShell": "Created via `orca worktree create`",
-          "cliStartupAgent": "Started with {{value0}}",
-          "cliCreated": "Created by Orca CLI",
+          "cliCreatedFromAgent": "Agent가 `orca worktree create`로 생성",
+          "cliCreatedFromShell": "`orca worktree create`로 생성",
+          "cliStartupAgent": "{{value0}}(으)로 시작됨",
+          "cliCreated": "Orca CLI로 생성됨",
           "jiraIssue": "Jira {{value0}}",
           "viewOnJira": "Jira에서 보기",
           "linkedJira": "연결된 Jira {{value0}}"


### PR DESCRIPTION


## ELI5

The sidebar filter toggles and workspace card details for CLI-created workspaces were displaying in English even when the app language was set to Korean. This PR adds the missing Korean translations so all CLI-created workspace labels and descriptions appear naturally in Korean.

## What Changed

Added/updated 6 Korean localization keys in `src/renderer/src/i18n/locales/ko.json`:

- **Sidebar Filter Toggle** (`auto.components.sidebar.SidebarFilter.cliCreated`): `"Hide CLI-created"` → `"CLI로 생성된 워크스페이스 숨기기"`
- **Sidebar Options Filter Section** (`auto.components.sidebar.SidebarWorkspaceFilterSection.cliCreated`): `"Hide CLI-created"` → `"CLI로 생성된 워크스페이스 숨기기"`
- **Workspace Card Detail (Agent)** (`auto.components.sidebar.WorktreeCardMeta.cliCreatedFromAgent`): `"Created by an agent via \`orca worktree create\`"` → `"Agent가 \`orca worktree create\`로 생성"`
- **Workspace Card Detail (Shell)** (`auto.components.sidebar.WorktreeCardMeta.cliCreatedFromShell`): `"Created via \`orca worktree create\`"` → `"\`orca worktree create\`로 생성"`
- **Workspace Card Startup Agent** (`auto.components.sidebar.WorktreeCardMeta.cliStartupAgent`): `"Started with {{value0}}"` → `"{{value0}}(으)로 시작됨"`
- **Workspace Card Meta Badge (a11y)** (`auto.components.sidebar.WorktreeCardMeta.cliCreated`): `"Created by Orca CLI"` → `"Orca CLI로 생성됨"`

Kept the change strictly scoped to `ko.json` (no source code, English source, or other locale files touched), consistent with the sparse-target-catalog architecture in `config/i18n-translation-source.md`.


## Why

In `SidebarFilter.tsx`, `SidebarWorkspaceFilterSection.tsx`, `WorktreeCardCliDetailSection.tsx`, and `WorktreeCardMetaBadges.tsx`, strings are translated via `auto.components.sidebar.SidebarFilter.cliCreated`, `auto.components.sidebar.SidebarWorkspaceFilterSection.cliCreated`, and `auto.components.sidebar.WorktreeCardMeta.cli*`.

`ko.json` contained untranslated English strings for these keys, causing i18next to fall back to English. Localizing these keys ensures consistent Korean UI across all workspace filtering and card detail views.

## Linked Issue

<!-- Link the issue this PR addresses, there should ALWAYS be one -->

Fixes #16208

## Visual Proof

| Area | Before|
|---|---|
|<img width="565" height="486" alt="image" src="https://github.com/user-attachments/assets/687ea364-c692-4595-8886-10053514c5b4" />|<img width="594" height="479" alt="image" src="https://github.com/user-attachments/assets/bc2d144b-80e5-4aed-aca5-f7aa21f682fd" />|
|<img width="641" height="340" alt="image" src="https://github.com/user-attachments/assets/9a380f8d-ae40-431d-ab58-71a2b9d57904" />|<img width="668" height="229" alt="image" src="https://github.com/user-attachments/assets/e1a13ab8-68e6-486a-ab14-241d413faef8" />|
|<img width="640" height="285" alt="image" src="https://github.com/user-attachments/assets/4fabab79-997c-4c21-990e-b9cbae728de4" />|<img width="672" height="190" alt="image" src="https://github.com/user-attachments/assets/024926d8-38f0-4336-9a6e-46de4cba02ad" />|




## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Developed and validated with Gemini 3.7 Flash via Antigravity pair-programming agent. All Korean translations were reviewed against existing `ko.json` catalog conventions and terminology policies.

## Review

- **Cross-platform**: UI-only text additions to `ko.json`. No platform-specific branching, shortcuts, shell scripts, or Electron APIs touched.
- **SSH / Remote / Local**: Pure renderer translation data with zero runtime execution impact.
- **Catalog Integrity**: All 6 keys match `en.json` exact structure. No interpolation placeholder discrepancies.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security**: No risk — pure static translation JSON data. No user input handling, command execution, auth, secrets, or IPC changes.
- **Cross-platform support**: Consumed identically across macOS, Linux, and Windows.
- **Terminology**: Follows established `ko.json` patterns (e.g. `automationCreated` -> "자동화로 생성된 워크스페이스 숨기기").


## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
