### PR TITLE
fix(mobile): detect agents for folder workspaces in the new-tab drawer

### DIFF
--- a/mobile/src/session/mobile-new-tab-agent-loader.test.ts
+++ b/mobile/src/session/mobile-new-tab-agent-loader.test.ts
@@ -69,4 +69,125 @@ describe('mobile new-tab agent loading', () => {
       'preflight.detectRemoteAgents'
     ])
   })
+
+  it('detects agents locally for a folder workspace instead of resolving a repo', async () => {
+    const client = createClient(async (method) => {
+      if (method === 'settings.get') {
+        return { ok: true, result: { settings: {} } }
+      }
+      if (method === 'folderWorkspace.list') {
+        return {
+          ok: true,
+          result: { folderWorkspaces: [{ id: 'fw-1', projectGroupId: 'pg-1' }] }
+        }
+      }
+      if (method === 'projectGroup.list') {
+        return { ok: true, result: { groups: [{ id: 'pg-1' }] } }
+      }
+      if (method === 'preflight.detectAgents') {
+        return { ok: true, result: ['claude'] }
+      }
+      throw new Error(`unexpected request: ${method}`)
+    })
+
+    await expect(
+      loadMobileNewTabAgentOptions({ client, worktreeId: 'folder:fw-1' })
+    ).resolves.toEqual([{ agent: 'claude', label: 'Claude' }])
+    expect(client.sendRequest.mock.calls.map(([method]) => method)).not.toContain('repo.list')
+  })
+
+  it('detects agents through the project group connection for a remote folder workspace', async () => {
+    const client = createClient(async (method, params) => {
+      if (method === 'settings.get') {
+        return { ok: true, result: { settings: {} } }
+      }
+      if (method === 'folderWorkspace.list') {
+        return {
+          ok: true,
+          result: { folderWorkspaces: [{ id: 'fw-1', projectGroupId: 'pg-1' }] }
+        }
+      }
+      if (method === 'projectGroup.list') {
+        return { ok: true, result: { groups: [{ id: 'pg-1', connectionId: 'ssh-1' }] } }
+      }
+      if (method === 'preflight.detectRemoteAgents') {
+        expect(params).toEqual({ connectionId: 'ssh-1' })
+        return { ok: true, result: ['claude'] }
+      }
+      throw new Error(`unexpected request: ${method}`)
+    })
+
+    await expect(
+      loadMobileNewTabAgentOptions({ client, worktreeId: 'folder:fw-1' })
+    ).resolves.toEqual([{ agent: 'claude', label: 'Claude' }])
+  })
+
+  it('prefers the folder workspace connection over its project group', async () => {
+    const client = createClient(async (method, params) => {
+      if (method === 'settings.get') {
+        return { ok: true, result: { settings: {} } }
+      }
+      if (method === 'folderWorkspace.list') {
+        return {
+          ok: true,
+          result: {
+            folderWorkspaces: [{ id: 'fw-1', projectGroupId: 'pg-1', connectionId: 'ssh-own' }]
+          }
+        }
+      }
+      if (method === 'projectGroup.list') {
+        return { ok: true, result: { groups: [{ id: 'pg-1', connectionId: 'ssh-group' }] } }
+      }
+      if (method === 'preflight.detectRemoteAgents') {
+        expect(params).toEqual({ connectionId: 'ssh-own' })
+        return { ok: true, result: ['claude'] }
+      }
+      throw new Error(`unexpected request: ${method}`)
+    })
+
+    await expect(
+      loadMobileNewTabAgentOptions({ client, worktreeId: 'folder:fw-1' })
+    ).resolves.toEqual([{ agent: 'claude', label: 'Claude' }])
+  })
+
+  it('falls back to local detection when the host cannot list folder workspaces', async () => {
+    const client = createClient(async (method) => {
+      if (method === 'settings.get') {
+        return { ok: true, result: { settings: {} } }
+      }
+      if (method === 'folderWorkspace.list' || method === 'projectGroup.list') {
+        return { ok: false, error: { code: 'method_not_found', message: 'Unknown method' } }
+      }
+      if (method === 'preflight.detectAgents') {
+        return { ok: true, result: ['claude'] }
+      }
+      throw new Error(`unexpected request: ${method}`)
+    })
+
+    await expect(
+      loadMobileNewTabAgentOptions({ client, worktreeId: 'folder:fw-1' })
+    ).resolves.toEqual([{ agent: 'claude', label: 'Claude' }])
+  })
+
+  it('detects agents locally when the folder workspace is absent from the catalog', async () => {
+    const client = createClient(async (method) => {
+      if (method === 'settings.get') {
+        return { ok: true, result: { settings: {} } }
+      }
+      if (method === 'folderWorkspace.list') {
+        return { ok: true, result: { folderWorkspaces: [] } }
+      }
+      if (method === 'projectGroup.list') {
+        return { ok: true, result: { groups: [] } }
+      }
+      if (method === 'preflight.detectAgents') {
+        return { ok: true, result: ['claude'] }
+      }
+      throw new Error(`unexpected request: ${method}`)
+    })
+
+    await expect(
+      loadMobileNewTabAgentOptions({ client, worktreeId: 'folder:fw-1' })
+    ).resolves.toEqual([{ agent: 'claude', label: 'Claude' }])
+  })
 })

--- a/mobile/src/session/mobile-new-tab-agent-loader.ts
+++ b/mobile/src/session/mobile-new-tab-agent-loader.ts
@@ -1,7 +1,10 @@
 import type { RpcClient } from '../transport/rpc-client'
 import type { RpcFailure, RpcSuccess } from '../transport/types'
 import { isFloatingWorkspaceWorktreeId } from './floating-workspace'
-import { getRepoIdFromMobileWorktreeId } from './mobile-session-route-helpers'
+import {
+  getFolderWorkspaceIdFromMobileWorktreeId,
+  getRepoIdFromMobileWorktreeId
+} from './mobile-session-route-helpers'
 import {
   buildMobileNewTabAgentOptions,
   type MobileNewTabAgentOption,
@@ -13,15 +16,23 @@ type RuntimeRepoSummary = {
   connectionId?: string | null
 }
 
+type RuntimeFolderWorkspaceSummary = {
+  id: string
+  projectGroupId?: string | null
+  connectionId?: string | null
+}
+
+type RuntimeProjectGroupSummary = {
+  id: string
+  connectionId?: string | null
+}
+
 export async function loadMobileNewTabAgentOptions(args: {
   client: RpcClient
   worktreeId: string
 }): Promise<MobileNewTabAgentOption[]> {
   const { client, worktreeId } = args
-  // Why: the floating workspace runs on the paired host, so it has no repo connection to resolve.
-  const detectedAgentsRequest = isFloatingWorkspaceWorktreeId(worktreeId)
-    ? client.sendRequest('preflight.detectAgents')
-    : loadWorkspaceDetectedAgents(client, worktreeId)
+  const detectedAgentsRequest = requestDetectedAgents(client, worktreeId)
   const [settingsResponse, detectedResponse] = await Promise.all([
     client.sendRequest('settings.get'),
     detectedAgentsRequest
@@ -43,6 +54,18 @@ export async function loadMobileNewTabAgentOptions(args: {
   )
 }
 
+function requestDetectedAgents(client: RpcClient, worktreeId: string) {
+  // Why: the floating workspace runs on the paired host, so it has no repo connection to resolve.
+  if (isFloatingWorkspaceWorktreeId(worktreeId)) {
+    return client.sendRequest('preflight.detectAgents')
+  }
+  const folderWorkspaceId = getFolderWorkspaceIdFromMobileWorktreeId(worktreeId)
+  if (folderWorkspaceId) {
+    return loadFolderWorkspaceDetectedAgents(client, folderWorkspaceId)
+  }
+  return loadWorkspaceDetectedAgents(client, worktreeId)
+}
+
 async function loadWorkspaceDetectedAgents(client: RpcClient, worktreeId: string) {
   const repoResponse = await client.sendRequest('repo.list')
   if (!repoResponse.ok) {
@@ -55,8 +78,39 @@ async function loadWorkspaceDetectedAgents(client: RpcClient, worktreeId: string
   if (!repo) {
     throw new Error('worktree_repo_not_found')
   }
-  const connectionId = repo.connectionId?.trim() || null
-  return connectionId
-    ? client.sendRequest('preflight.detectRemoteAgents', { connectionId })
+  return detectAgentsForConnection(client, repo.connectionId)
+}
+
+/** A folder workspace names no repo, so its execution host comes from the workspace's own
+ *  connection, falling back to its project group's. Anything unresolvable detects locally:
+ *  the workspace is never in the worktree catalog, so treating a miss as an error would
+ *  leave presets permanently unavailable — including against a host too old to list them. */
+async function loadFolderWorkspaceDetectedAgents(client: RpcClient, folderWorkspaceId: string) {
+  const [workspacesResponse, groupsResponse] = await Promise.all([
+    client.sendRequest('folderWorkspace.list'),
+    client.sendRequest('projectGroup.list')
+  ])
+  if (!workspacesResponse.ok || !groupsResponse.ok) {
+    return client.sendRequest('preflight.detectAgents')
+  }
+  const workspaces =
+    (
+      (workspacesResponse as RpcSuccess).result as {
+        folderWorkspaces?: RuntimeFolderWorkspaceSummary[]
+      }
+    ).folderWorkspaces ?? []
+  const workspace = workspaces.find((candidate) => candidate.id === folderWorkspaceId)
+  const groups =
+    ((groupsResponse as RpcSuccess).result as { groups?: RuntimeProjectGroupSummary[] }).groups ?? []
+  const group = workspace?.projectGroupId
+    ? groups.find((candidate) => candidate.id === workspace.projectGroupId)
+    : undefined
+  return detectAgentsForConnection(client, workspace?.connectionId ?? group?.connectionId)
+}
+
+function detectAgentsForConnection(client: RpcClient, connectionId: string | null | undefined) {
+  const normalized = connectionId?.trim() || null
+  return normalized
+    ? client.sendRequest('preflight.detectRemoteAgents', { connectionId: normalized })
     : client.sendRequest('preflight.detectAgents')
 }

--- a/mobile/src/session/mobile-session-route-helpers.ts
+++ b/mobile/src/session/mobile-session-route-helpers.ts
@@ -28,6 +28,18 @@ export function getRepoIdFromMobileWorktreeId(id: string): string {
   return separatorIdx === -1 ? id : id.slice(0, separatorIdx)
 }
 
+export const MOBILE_FOLDER_WORKSPACE_ROUTE_PREFIX = 'folder:'
+
+/** The folder workspace id behind a `folder:<id>` route, or null for any other route.
+ *  Folder workspace routes name no repo, so callers must branch on this before
+ *  resolving a worktree id through `repo.list`. */
+export function getFolderWorkspaceIdFromMobileWorktreeId(id: string): string | null {
+  if (!id.startsWith(MOBILE_FOLDER_WORKSPACE_ROUTE_PREFIX)) {
+    return null
+  }
+  return id.slice(MOBILE_FOLDER_WORKSPACE_ROUTE_PREFIX.length) || null
+}
+
 export function isGestureMouseTrackingMode(
   mode: TerminalModes['mouseTrackingMode'] | undefined
 ): boolean {

--- a/mobile/src/session/synthetic-workspace-route.ts
+++ b/mobile/src/session/synthetic-workspace-route.ts
@@ -1,8 +1,12 @@
 import { isFloatingWorkspaceWorktreeId } from './floating-workspace'
+import { MOBILE_FOLDER_WORKSPACE_ROUTE_PREFIX } from './mobile-session-route-helpers'
 
 /** Route ids that name no managed worktree, so the host can never list or resolve them.
  *  Every "is this workspace still there?" check must exempt them, or their permanent
  *  absence from the catalog reads as a deletion. */
 export function isSyntheticWorkspaceRoute(worktreeId: string): boolean {
-  return worktreeId.startsWith('folder:') || isFloatingWorkspaceWorktreeId(worktreeId)
+  return (
+    worktreeId.startsWith(MOBILE_FOLDER_WORKSPACE_ROUTE_PREFIX) ||
+    isFloatingWorkspaceWorktreeId(worktreeId)
+  )
 }


### PR DESCRIPTION
## ELI5

On mobile, opening **New Tab** inside a folder workspace always said "Agent Presets Unavailable — Check the host connection", even though the connection was fine. The code was looking up a git repo for a workspace that has no repo, and reported the miss as a connection problem. Now folder workspaces figure out their host the way the rest of the app already does.

## What Changed

- `mobile-new-tab-agent-loader.ts`: route selection moved into `requestDetectedAgents`, which now has a third branch for `folder:<id>` routes. It resolves the execution host from `folderWorkspace.connectionId ?? projectGroup.connectionId` and dispatches to `preflight.detectRemoteAgents` or `preflight.detectAgents` accordingly. The repo-connection path is unchanged; connection dispatch is shared via `detectAgentsForConnection`.
- `mobile-session-route-helpers.ts`: added `MOBILE_FOLDER_WORKSPACE_ROUTE_PREFIX` and `getFolderWorkspaceIdFromMobileWorktreeId`, next to the existing `getRepoIdFromMobileWorktreeId`.
- `synthetic-workspace-route.ts`: uses the shared prefix constant instead of a bare `'folder:'` literal. No behavior change.
- 5 loader tests: local folder workspace, remote via project group, workspace connection winning over its group's, host that cannot list folder workspaces, and workspace absent from the catalog.

`agent-history-resume-target.ts` is left alone — it already resolves folder workspaces correctly, and its extra `executionHostId` handling is for a different question (resume target status, not which host to probe).

## Why

The loader exempted only the floating workspace from repo resolution:

```ts
const detectedAgentsRequest = isFloatingWorkspaceWorktreeId(worktreeId)
  ? client.sendRequest('preflight.detectAgents')
  : loadWorkspaceDetectedAgents(client, worktreeId)
```

A `folder:<id>` route names no repo, so it fell into `loadWorkspaceDetectedAgents`, where `getRepoIdFromMobileWorktreeId` returns the id unchanged (no `::`), nothing matches in `repo.list`, and it throws `worktree_repo_not_found`. The caller's `.catch()` turns any throw into `createTabAgentLoadState = 'error'`, whose only rendering is "Agent Presets Unavailable / Check the host connection" — so a repo-resolution miss was surfaced as a connection fault.

This is the case `isSyntheticWorkspaceRoute`'s doc comment describes ("Every 'is this workspace still there?' check must exempt them"); the loader was one of the places that never got the exemption.

On the fallback choice: an unresolvable folder workspace detects locally instead of throwing. A folder workspace is never in the worktree catalog, so treating a miss as an error is what produced the permanent "Unavailable" state in the first place — and per the remote wire-compatibility guidance, a client can be paired with a host too old to answer `folderWorkspace.list` at all. Local detection is the safe answer for a route that has no repo scope; a wrong-host preset is recoverable, a permanently empty drawer is not.

## Linked Issue

Fixes #16215

## Visual Proof

**BEFORE:** in a folder workspace, the New Tab drawer's first row reads "Agent Presets Unavailable / Check the host connection" (disabled), while Terminal / Browser / Markdown Note below it are all functional and agent tabs already open in that workspace keep running normally.

**AFTER: not captured.** This is mobile-app code — verifying the rendered drawer needs a new mobile build installed on a device, which I could not do in this environment. The behavior change is covered by unit tests at the loader boundary (the exact call sequence and dispatch target for each case) rather than by a screenshot. Flagging this explicitly so a reviewer with a device can confirm the drawer now lists presets before merging.

## Testing

- `vitest run src/session/mobile-new-tab-agent-loader.test.ts src/session/use-missing-worktree-bounce.test.ts` — 11 passed (5 new)
- Full mobile suite: `457/458 files, 3677 passed, 3 skipped`. The one failure is `src/mock-server-key-pair.test.ts`, which fails identically with these changes stashed — pre-existing and unrelated (spawns a key-creator subprocess).
- `oxlint` clean.
- `tsc --noEmit` reports one error, `vitest.config.ts(6,21) import.meta.dirname` — pre-existing, in a file this PR does not touch. All three changed files typecheck clean.
- Not manually verified on a device, for the reason given under Visual Proof.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below