### PR TITLE
fix(antigravity): make the POSIX hook command spawnable as argv[0]

### DIFF
--- a/src/main/agent-hooks/installer-utils.ts
+++ b/src/main/agent-hooks/installer-utils.ts
@@ -105,7 +105,7 @@ export function getSharedManagedScriptPath(scriptFileName: string): string {
   return join(homedir(), '.orca', 'agent-hooks', scriptFileName)
 }
 
-export { wrapPosixHookCommand } from './posix-hook-command'
+export { wrapPosixHookCommand, wrapPosixHookCommandForExec } from './posix-hook-command'
 
 export function quotePowerShellString(value: string): string {
   return `'${value.replaceAll("'", "''")}'`

--- a/src/main/agent-hooks/posix-hook-command.ts
+++ b/src/main/agent-hooks/posix-hook-command.ts
@@ -23,3 +23,16 @@ export function wrapPosixHookCommand(
       : `printf '%s\\n' ${quotePosixShellString(options.fallbackStdout)}; ${POSIX_HOOK_STDIN_DRAIN_COMMAND}`
   return `if [ -f ${quoted} ] && [ -r ${quoted} ] && [ -x ${quoted} ]; then ${invocation}; else ${fallback}; fi`
 }
+
+// Why: Antigravity ACP hosts (Zed) `shlex.split` the hook command and exec argv[0] directly instead
+// of running it through a shell, so the guard above — which starts with the builtin `if` — fails to
+// spawn and the host reads a hook that never started as a deny on every tool call (#16087). This is
+// the POSIX twin of the Windows argv[0] contract in #8430: hand the same snippet to an explicit
+// interpreter so argv[0] is a real executable, without giving up the missing-script fallback (#2426).
+export function wrapPosixHookCommandForExec(
+  scriptPath: string,
+  env: Record<string, string> = {},
+  options: { fallbackStdout?: string } = {}
+): string {
+  return `/bin/sh -c ${quotePosixShellString(wrapPosixHookCommand(scriptPath, env, options))}`
+}

--- a/src/main/agent-hooks/posix-hook-exec-command.test-fixture.ts
+++ b/src/main/agent-hooks/posix-hook-exec-command.test-fixture.ts
@@ -1,7 +1,5 @@
-// Why: Zed's Antigravity ACP host runs hook commands with `shlex.split` + `create_subprocess_exec`,
-// so the installed string is tokenized and then exec'd directly — no shell. This mirrors that
-// tokenizer (POSIX mode: no expansion inside single quotes, backslash escapes outside them) so tests
-// can exercise the exec path instead of the `/bin/sh -c` path they would otherwise take.
+// Mirrors the ACP host's POSIX `shlex.split` so tests can exercise the exec path (#16087).
+// Throws on malformed input like shlex does, so a broken quoting change fails loudly here.
 export function shlexSplit(command: string): string[] {
   const tokens: string[] = []
   let current = ''
@@ -11,12 +9,13 @@ export function shlexSplit(command: string): string[] {
     const char = command[index]
     if (char === '\\' && quote !== "'") {
       const next = command[index + 1]
-      if (next !== undefined) {
-        current += next
-        started = true
-        index += 1
-        continue
+      if (next === undefined) {
+        throw new Error(`shlexSplit: trailing backslash with nothing to escape: ${command}`)
       }
+      current += next
+      started = true
+      index += 1
+      continue
     }
     if (quote === null && (char === '"' || char === "'")) {
       quote = char
@@ -38,14 +37,16 @@ export function shlexSplit(command: string): string[] {
     current += char
     started = true
   }
+  if (quote !== null) {
+    throw new Error(`shlexSplit: unbalanced ${quote} quote: ${command}`)
+  }
   if (started) {
     tokens.push(current)
   }
   return tokens
 }
 
-// Why: POSIX Antigravity commands are handed to `/bin/sh -c` so they stay exec-spawnable (#16087);
-// assertions about the shell snippet itself read the payload back out instead of matching its escaping.
+// Unwrap the `/bin/sh -c` payload so assertions match the snippet, not its escaping.
 export function posixHookInnerCommand(command: string): string {
   const argv = shlexSplit(command)
   return argv[0] === '/bin/sh' && argv[1] === '-c' && argv[2] !== undefined ? argv[2] : command

--- a/src/main/agent-hooks/posix-hook-exec-command.test-fixture.ts
+++ b/src/main/agent-hooks/posix-hook-exec-command.test-fixture.ts
@@ -1,0 +1,52 @@
+// Why: Zed's Antigravity ACP host runs hook commands with `shlex.split` + `create_subprocess_exec`,
+// so the installed string is tokenized and then exec'd directly — no shell. This mirrors that
+// tokenizer (POSIX mode: no expansion inside single quotes, backslash escapes outside them) so tests
+// can exercise the exec path instead of the `/bin/sh -c` path they would otherwise take.
+export function shlexSplit(command: string): string[] {
+  const tokens: string[] = []
+  let current = ''
+  let started = false
+  let quote: '"' | "'" | null = null
+  for (let index = 0; index < command.length; index += 1) {
+    const char = command[index]
+    if (char === '\\' && quote !== "'") {
+      const next = command[index + 1]
+      if (next !== undefined) {
+        current += next
+        started = true
+        index += 1
+        continue
+      }
+    }
+    if (quote === null && (char === '"' || char === "'")) {
+      quote = char
+      started = true
+      continue
+    }
+    if (quote === char) {
+      quote = null
+      continue
+    }
+    if (quote === null && /\s/.test(char)) {
+      if (started) {
+        tokens.push(current)
+        current = ''
+        started = false
+      }
+      continue
+    }
+    current += char
+    started = true
+  }
+  if (started) {
+    tokens.push(current)
+  }
+  return tokens
+}
+
+// Why: POSIX Antigravity commands are handed to `/bin/sh -c` so they stay exec-spawnable (#16087);
+// assertions about the shell snippet itself read the payload back out instead of matching its escaping.
+export function posixHookInnerCommand(command: string): string {
+  const argv = shlexSplit(command)
+  return argv[0] === '/bin/sh' && argv[1] === '-c' && argv[2] !== undefined ? argv[2] : command
+}

--- a/src/main/agent-hooks/remote-hook-service-installers.test.ts
+++ b/src/main/agent-hooks/remote-hook-service-installers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { parse as parseJsonc } from 'jsonc-parser'
 import type { SFTPWrapper } from 'ssh2'
+import { posixHookInnerCommand } from './posix-hook-exec-command.test-fixture'
 
 vi.mock('electron', () => ({
   app: {
@@ -339,24 +340,32 @@ describe('remote hook service installers', () => {
       >
     }
     for (const eventName of ['PreInvocation', 'PostInvocation', 'Stop']) {
-      const command = antigravityConfig['orca-status'][eventName]?.[0]?.command
+      // Why: the remote install path shares getPosixManagedCommand, so it is wrapped for exec too (#16087).
+      const command = posixHookInnerCommand(
+        antigravityConfig['orca-status'][eventName]?.[0]?.command ?? ''
+      )
       expect(command).toContain('/home/dev/.orca/agent-hooks/antigravity-hook.sh')
       expect(command).toContain(`ORCA_ANTIGRAVITY_EVENT='${eventName}'`)
     }
     for (const eventName of ['PreToolUse', 'PostToolUse']) {
       const definition = antigravityConfig['orca-status'][eventName]?.[0]
-      const command = definition?.hooks?.[0]?.command
+      const command = posixHookInnerCommand(definition?.hooks?.[0]?.command ?? '')
       expect(definition?.matcher).toBe('*')
       expect(command).toContain('/home/dev/.orca/agent-hooks/antigravity-hook.sh')
       expect(command).toContain(`ORCA_ANTIGRAVITY_EVENT='${eventName}'`)
     }
     // Why: #2426 was an SSH report — a remote host missing the script must still answer the gate, not deny every tool.
-    expect(antigravityConfig['orca-status'].PreToolUse[0].hooks?.[0]?.command).toContain(
-      `printf '%s\\n' '{"decision":"ask"}'`
-    )
-    expect(antigravityConfig['orca-status'].PostToolUse[0].hooks?.[0]?.command).not.toContain(
-      '{"decision"'
-    )
+    expect(
+      posixHookInnerCommand(
+        antigravityConfig['orca-status'].PreToolUse[0].hooks?.[0]?.command ?? ''
+      )
+    ).toContain(`printf '%s\\n' '{"decision":"ask"}'`)
+    // Why: unwrap here too — asserting against the escaped form would pass even if the decision leaked in.
+    expect(
+      posixHookInnerCommand(
+        antigravityConfig['orca-status'].PostToolUse[0].hooks?.[0]?.command ?? ''
+      )
+    ).not.toContain('{"decision"')
 
     const ampPlugin = amp.fs.files.get('/home/dev/.config/amp/plugins/orca-agent-status.ts')
     expect(ampPlugin).toContain('/hook/amp')

--- a/src/main/antigravity/hook-service.test.ts
+++ b/src/main/antigravity/hook-service.test.ts
@@ -19,6 +19,10 @@ vi.mock('os', async () => {
 import { AntigravityHookService } from './hook-service'
 import { POSIX_HOOK_STDIN_READER } from '../agent-hooks/hook-stdin-contract'
 import { createManagedCommandMatcher } from '../agent-hooks/installer-utils'
+import {
+  posixHookInnerCommand,
+  shlexSplit
+} from '../agent-hooks/posix-hook-exec-command.test-fixture'
 
 const ANTIGRAVITY_SCRIPT_FILE_NAME =
   process.platform === 'win32' ? 'antigravity-hook.cmd' : 'antigravity-hook.sh'
@@ -86,10 +90,12 @@ describe('AntigravityHookService', () => {
     if (process.platform === 'win32') {
       expect(config['orca-status'].PreInvocation[0].command).not.toContain('ORCA_ANTIGRAVITY_EVENT')
     } else {
-      expect(config['orca-status'].PreInvocation[0].command).toContain(
+      expect(posixHookInnerCommand(config['orca-status'].PreInvocation[0].command ?? '')).toContain(
         "ORCA_ANTIGRAVITY_EVENT='PreInvocation'"
       )
-      expect(config['orca-status'].Stop[0].command).toContain("ORCA_ANTIGRAVITY_EVENT='Stop'")
+      expect(posixHookInnerCommand(config['orca-status'].Stop[0].command ?? '')).toContain(
+        "ORCA_ANTIGRAVITY_EVENT='Stop'"
+      )
     }
 
     const script = readFileSync(
@@ -367,4 +373,71 @@ describe('AntigravityHookService', () => {
       join(homeDir, '.orca', 'agent-hooks', ANTIGRAVITY_POST_TOOL_USE_COMMAND)
     )
   })
+
+  // Why: the tokenizer above is load-bearing for the argv[0] tests, so pin its behaviour on the
+  // exact escape the wrapper emits ('\\'' inside a single-quoted string) before relying on it.
+  it('tokenizes single-quote escapes the way a POSIX shlex does', () => {
+    expect(shlexSplit(`/bin/sh -c 'printf '\\''%s'\\'' done'`)).toEqual([
+      '/bin/sh',
+      '-c',
+      "printf '%s' done"
+    ])
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'installs a PreToolUse command that is spawnable as argv[0] without a shell',
+    () => {
+      new AntigravityHookService().install()
+
+      const config = JSON.parse(
+        readFileSync(join(homeDir, '.gemini', 'config', 'hooks.json'), 'utf8')
+      ) as { 'orca-status': Record<string, { hooks?: { command: string }[] }[]> }
+      const command = config['orca-status'].PreToolUse[0].hooks?.[0]?.command
+      const argv = shlexSplit(command!)
+
+      // Why: a shell builtin as argv[0] makes exec fail with ENOENT, and Antigravity ACP reads a
+      // hook that never started as a deny — every tool call is blocked (#16087).
+      expect(argv[0]).not.toBe('if')
+
+      const result = spawnSync(argv[0]!, argv.slice(1), {
+        input: '{"toolCall":{"name":"run_command","args":{"CommandLine":"ls"}}}',
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          ORCA_AGENT_HOOK_ENDPOINT: '',
+          ORCA_AGENT_HOOK_PORT: '',
+          ORCA_AGENT_HOOK_TOKEN: '',
+          ORCA_PANE_KEY: ''
+        }
+      })
+
+      expect(result.error).toBeUndefined()
+      expect(result.status).toBe(0)
+      expect(result.stdout).toBe(`${PRE_TOOL_USE_DECISION}\n`)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'keeps answering the PreToolUse gate over exec when the managed script is missing',
+    () => {
+      new AntigravityHookService().install()
+      rmSync(join(homeDir, '.orca', 'agent-hooks'), { recursive: true, force: true })
+
+      const config = JSON.parse(
+        readFileSync(join(homeDir, '.gemini', 'config', 'hooks.json'), 'utf8')
+      ) as { 'orca-status': Record<string, { hooks?: { command: string }[] }[]> }
+      const argv = shlexSplit(config['orca-status'].PreToolUse[0].hooks?.[0]?.command ?? '')
+
+      const result = spawnSync(argv[0]!, argv.slice(1), {
+        input: '{"toolCall":{"name":"run_command"}}',
+        encoding: 'utf8'
+      })
+
+      // Why: making the command exec-spawnable must not cost the missing-script guard — dropping it
+      // would trade #16087 for #2426, where silence is itself a deny.
+      expect(result.error).toBeUndefined()
+      expect(result.status).toBe(0)
+      expect(result.stdout).toBe(`${PRE_TOOL_USE_DECISION}\n`)
+    }
+  )
 })

--- a/src/main/antigravity/hook-service.test.ts
+++ b/src/main/antigravity/hook-service.test.ts
@@ -376,6 +376,13 @@ describe('AntigravityHookService', () => {
 
   // Why: the tokenizer above is load-bearing for the argv[0] tests, so pin its behaviour on the
   // exact escape the wrapper emits ('\\'' inside a single-quoted string) before relying on it.
+  // Why: a fixture that silently accepts malformed input would let a broken quoting change pass —
+  // real shlex raises on both of these, so this one must too (coderabbitai on #16222).
+  it('rejects incomplete shell syntax instead of guessing', () => {
+    expect(() => shlexSplit(`/bin/sh -c 'printf ok`)).toThrow(/unbalanced/)
+    expect(() => shlexSplit('/bin/sh -c foo\\')).toThrow(/trailing backslash/)
+  })
+
   it('tokenizes single-quote escapes the way a POSIX shlex does', () => {
     expect(shlexSplit(`/bin/sh -c 'printf '\\''%s'\\'' done'`)).toEqual([
       '/bin/sh',

--- a/src/main/antigravity/hook-service.ts
+++ b/src/main/antigravity/hook-service.ts
@@ -5,7 +5,7 @@ import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared
 import {
   getSharedManagedScriptPath,
   readHooksJson,
-  wrapPosixHookCommand,
+  wrapPosixHookCommandForExec,
   wrapWindowsCmdHookCommand,
   writeHooksJson,
   writeManagedScript,
@@ -51,7 +51,9 @@ function getWindowsWrapperScriptPath(event: AntigravityEvent): string {
 }
 
 function getPosixManagedCommand(scriptPath: string, event: AntigravityEvent): string {
-  return wrapPosixHookCommand(
+  // Why: Antigravity's ACP host execs this string as argv[0] rather than running it through a shell,
+  // so it must stay one spawnable token (#16087) — see wrapPosixHookCommandForExec.
+  return wrapPosixHookCommandForExec(
     scriptPath,
     { ORCA_ANTIGRAVITY_EVENT: event.eventName },
     // Why: a missing managed script must not brick tools; the guard answers PreToolUse itself instead of staying silent.


### PR DESCRIPTION
## ELI5

Orca writes its Antigravity status hook into `~/.gemini/config/hooks.json` as a little shell snippet that starts with `if`. Zed's Antigravity ACP host doesn't run hooks through a shell — it splits the string and execs the first word. `if` is a shell builtin, not a program, so the spawn fails, and ACP treats a hook that failed to start as a **deny on every tool call**. This hands the same snippet to `/bin/sh -c` so the first word is a real executable.

## What Changed

- New `wrapPosixHookCommandForExec()` in `src/main/agent-hooks/posix-hook-command.ts` — wraps the existing `wrapPosixHookCommand()` output in `/bin/sh -c '…'`.
- `src/main/antigravity/hook-service.ts` uses it for `getPosixManagedCommand` (covers both the local and the SSH-remote install paths).
- **`wrapPosixHookCommand()` itself is unchanged.** The other callers (codex, cursor, droid, gemini, grok, copilot, devin) keep their current output byte-for-byte.

## Why

`create_subprocess_exec` + `shlex.split` means argv[0] must be a real executable. Windows already has this contract — `wrapWindowsCmdHookCommand` carries the comment *"Codex/Antigravity/Devin spawn the hook as argv[0], not via cmd.exe, so it must be one spawnable token (#8430)"*. POSIX never got the twin.

The issue suggests emitting `/usr/bin/env ORCA_ANTIGRAVITY_EVENT=… /bin/sh <script>` instead. That is spawnable, but it drops the `if [ -f/-r/-x ]` guard — and with it the `printf '{"decision":"ask"}'` fallback that #2426 added. With the guard gone, a swept `~/.orca` gives exit 127 and empty stdout, which Antigravity reads as a deny: the same bug in a new shape. Wrapping instead of rewriting keeps both properties.

Scope is deliberately narrow: only the Antigravity installer changes. Whether the other POSIX hosts want the same argv[0] contract is a separate question I raised on the issue and left for maintainers.

## Linked Issue

Fixes #16087

## Visual Proof

`N/A` — no UI or interaction surface; the change is the command string written into `hooks.json`.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Three tests in `src/main/antigravity/hook-service.test.ts`. Note that **every pre-existing POSIX test here runs the command via `spawnSync('/bin/sh', ['-c', cmd])`** — the path that already worked — so none of them could catch this. The new ones tokenize the command and exec argv[0], mirroring the ACP host:

1. `installs a PreToolUse command that is spawnable as argv[0] without a shell` — asserts argv[0] is not `if`, then execs and expects `{"decision":"ask"}`. Reverting the fix fails it with `expected 'if' not to be 'if'`.
2. `keeps answering the PreToolUse gate over exec when the managed script is missing` — deletes `~/.orca/agent-hooks` first, pinning that fixing #16087 does not regress #2426.
3. `tokenizes single-quote escapes the way a POSIX shlex does` — pins the test tokenizer itself on the `'\''` sequence the wrapper emits.

Cross-checked the escaping with Python's `shlex` (the tokenizer the issue names): the current string splits to argv[0] `'if'`; the new one splits to exactly `['/bin/sh', '-c', <snippet>]` with the snippet byte-identical after unquoting, and exec returns rc 0 with `{"decision":"ask"}`.

Also updated two pre-existing assertions that matched the raw command string: they now unwrap the `/bin/sh -c` payload before asserting, so they keep testing the snippet rather than the escaping. That includes the `not.toContain('{"decision"')` check on PostToolUse — left as-is it would have passed even if a decision leaked in.

`remote-hook-service-installers.test.ts` covers the SSH-remote install path, which shares `getPosixManagedCommand` and therefore gets the same wrapping.

Platforms: macOS (node 24). `pnpm typecheck`, `pnpm build`, and the `agent-hooks` / `antigravity` / codex hook suites (127 passed, 6 skipped) pass locally. **`pnpm lint` in full did not complete on my machine — the linter process was killed (`terminated abnormally, possibly out of memory`), which looks like a local resource limit rather than anything in this diff.** What did run clean: `oxlint` and `oxfmt --check` over `src/main/agent-hooks/` and `src/main/antigravity/` (125 files), plus the pre-commit hook's `oxlint` + react-doctor + `oxfmt` over the six changed files. Please let CI cover the remaining `pnpm lint` steps.

Windows paths are untouched (`getManagedCommand` still returns `wrapWindowsCmdHookCommand` on `win32`, and the Windows assertions in the same test file are unchanged).

I do not have a Zed + Antigravity ACP setup, so I have not verified the end-to-end tool-call recovery myself. @jrignacio, who reported the issue, offered to validate it end to end on macOS including the missing-script case.

## AI Disclosure

Written with Claude Opus 5 (Claude Code). Root cause, the rejected `env` alternative, and the escaping were verified by hand against the source and by executing the generated commands; the tests were run locally.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security**: no new interpolation. The script path is still single-quote escaped by the existing `quotePosixShellString`, and the outer layer escapes the whole snippet the same way.
- **Cross-platform**: Windows unchanged; Linux/macOS both go through `/bin/sh`, which is required by POSIX to exist.
- **Remote SSH**: `getPosixManagedCommand` is also the remote install path (`hook-service.ts`), so remote `hooks.json` gets the same spawnable form — the ACP host reads it identically.
- **Backwards compatibility**: hosts that already ran the command through a shell (Gemini CLI, `agy`) now run `sh -c 'sh -c …'` — one extra process per hook event, same semantics. Stale entries from older versions are replaced by the existing PreToolUse replacement logic, which the pre-existing test still covers.
- **Performance**: one extra `sh` per hook invocation on the Antigravity path only.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm typecheck`, `pnpm test`, and `pnpm build` pass locally; `pnpm lint` ran clean over the touched directories but the full chain OOM'd locally — see Testing
