### PR TITLE
feat: add generic Custom AI Provider usage tracking

### DIFF
--- a/src/main/codex-accounts/runtime-home-settings-test-fixtures.ts
+++ b/src/main/codex-accounts/runtime-home-settings-test-fixtures.ts
@@ -113,6 +113,7 @@ export function createSettings(overrides: TestSettingsOverrides = {}): GlobalSet
     opencodeWorkspaceId: '',
     minimaxGroupId: '',
     minimaxUsageModels: 'general',
+    customProviderAccounts: [],
     geminiCliOAuthEnabled: false,
     agentCmdOverrides: {},
     keepComputerAwakeWhileAgentsRun: false,

--- a/src/main/codex-accounts/service-reset-credit-test-fixtures.ts
+++ b/src/main/codex-accounts/service-reset-credit-test-fixtures.ts
@@ -35,6 +35,7 @@ export function createResetRateLimitState(
     antigravity: null,
     minimax: null,
     grok: null,
+    customProviderUsage: {},
     minimaxCookieConfigured: false,
     grokAuthConfigured: false,
     claudeTarget: { runtime: 'host', wslDistro: null },

--- a/src/main/codex-accounts/service-test-harness.ts
+++ b/src/main/codex-accounts/service-test-harness.ts
@@ -134,6 +134,7 @@ export function createSettings(overrides: Partial<GlobalSettings> = {}): GlobalS
     opencodeWorkspaceId: '',
     minimaxGroupId: '',
     minimaxUsageModels: 'general',
+    customProviderAccounts: [],
     geminiCliOAuthEnabled: false,
     agentCmdOverrides: {},
     keepComputerAwakeWhileAgentsRun: false,

--- a/src/main/custom-providers/custom-provider-account-schema.test.ts
+++ b/src/main/custom-providers/custom-provider-account-schema.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { CustomProviderAccount, CustomProviderAccountList } from './custom-provider-account-schema'
+
+function makeRawAccount(overrides: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return {
+    id: 'acc-1',
+    displayName: 'Acme',
+    enabled: true,
+    usageUrl: 'https://example.com/usage',
+    mappingMode: 'percent',
+    percentPath: 'percent',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides
+  }
+}
+
+describe('CustomProviderAccount displayName validation (#1)', () => {
+  it('rejects a whitespace-only display name', () => {
+    const result = CustomProviderAccount.safeParse(makeRawAccount({ displayName: '   ' }))
+    expect(result.success).toBe(false)
+  })
+
+  it('trims a display name with surrounding whitespace instead of persisting it verbatim', () => {
+    const result = CustomProviderAccount.safeParse(makeRawAccount({ displayName: '  Acme  ' }))
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.displayName).toBe('Acme')
+    }
+  })
+
+  it('accepts a non-empty trimmed display name', () => {
+    const result = CustomProviderAccount.safeParse(makeRawAccount({ displayName: 'Acme' }))
+    expect(result.success).toBe(true)
+  })
+})
+
+describe('CustomProviderAccountList duplicate detection', () => {
+  it('still detects duplicate names once whitespace-only names are rejected upstream', () => {
+    const result = CustomProviderAccountList.safeParse([
+      makeRawAccount({ id: 'a', displayName: 'Acme' }),
+      makeRawAccount({ id: 'b', displayName: ' acme ' })
+    ])
+    expect(result.success).toBe(false)
+  })
+})

--- a/src/main/custom-providers/custom-provider-account-schema.ts
+++ b/src/main/custom-providers/custom-provider-account-schema.ts
@@ -3,7 +3,10 @@ import { z } from 'zod'
 export const CustomProviderAccount = z
   .object({
     id: z.string().min(1),
-    displayName: z.string().min(1),
+    // Why: trim before the min-length check so whitespace-only names ("   ")
+    // are rejected instead of persisted — the duplicate-name check below
+    // already treats the trimmed value as the identity.
+    displayName: z.string().trim().min(1),
     enabled: z.boolean(),
     icon: z.string().optional(),
     usageUrl: z.string().startsWith('https://', 'usageUrl must start with https://'),

--- a/src/main/custom-providers/custom-provider-account-schema.ts
+++ b/src/main/custom-providers/custom-provider-account-schema.ts
@@ -1,0 +1,69 @@
+import { z } from 'zod'
+
+export const CustomProviderAccount = z
+  .object({
+    id: z.string().min(1),
+    displayName: z.string().min(1),
+    enabled: z.boolean(),
+    icon: z.string().optional(),
+    usageUrl: z.string().startsWith('https://', 'usageUrl must start with https://'),
+    tokenEnvVar: z.string().optional(),
+    mappingMode: z.enum(['percent', 'used-limit']),
+    percentPath: z.string().optional(),
+    usedPaths: z.array(z.string().min(1)).min(1).max(4).optional(),
+    limitPath: z.string().optional(),
+    createdAt: z.number(),
+    updatedAt: z.number()
+  })
+  .strict()
+  .superRefine((account, ctx) => {
+    if (account.mappingMode === 'percent' && !account.percentPath?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'percentPath is required when mappingMode is "percent"',
+        path: ['percentPath']
+      })
+    }
+    if (account.mappingMode === 'used-limit') {
+      if (!account.usedPaths || account.usedPaths.length === 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'usedPaths is required when mappingMode is "used-limit"',
+          path: ['usedPaths']
+        })
+      }
+      if (!account.limitPath?.trim()) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'limitPath is required when mappingMode is "used-limit"',
+          path: ['limitPath']
+        })
+      }
+    }
+  })
+
+export const CustomProviderAccountList = z
+  .array(CustomProviderAccount)
+  .superRefine((accounts, ctx) => {
+    const seenIds = new Set<string>()
+    const seenNames = new Set<string>()
+    accounts.forEach((account, index) => {
+      if (seenIds.has(account.id)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Duplicate account id: ${account.id}`,
+          path: [index, 'id']
+        })
+      }
+      seenIds.add(account.id)
+      const nameKey = account.displayName.trim().toLowerCase()
+      if (seenNames.has(nameKey)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Duplicate account name: ${account.displayName}`,
+          path: [index, 'displayName']
+        })
+      }
+      seenNames.add(nameKey)
+    })
+  })

--- a/src/main/custom-providers/custom-provider-token-store.ts
+++ b/src/main/custom-providers/custom-provider-token-store.ts
@@ -1,0 +1,130 @@
+import { safeStorage } from 'electron'
+import { existsSync, readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { hardenExistingSecureFile, writeSecureFile } from '../../shared/secure-file'
+import type { CustomProviderAccount } from '../../shared/custom-provider-types'
+
+// Why: one encrypted file holding a map of {accountId: token}, mirroring
+// minimax-cookie-store.ts's envelope scheme but keyed for an arbitrary-length
+// list of custom provider accounts instead of a single slot.
+const TOKENS_FILE = 'custom-provider-tokens.enc'
+const TOKENS_ENVELOPE_PREFIX = 'orca-custom-provider-tokens:v1:'
+let cachedTokens: Map<string, string> | null = null
+
+function getTokensPath(): string {
+  return join(homedir(), '.orca', TOKENS_FILE)
+}
+
+function encodeEnvelope(kind: 'encrypted' | 'plaintext', payload: Buffer): string {
+  return `${TOKENS_ENVELOPE_PREFIX}${kind}:${payload.toString('base64')}`
+}
+
+function decodeEnvelope(raw: Buffer): { kind: 'encrypted' | 'plaintext'; payload: Buffer } {
+  const text = raw.toString('utf8')
+  if (!text.startsWith(TOKENS_ENVELOPE_PREFIX)) {
+    throw new Error('Custom provider token store could not be decrypted')
+  }
+  const rest = text.slice(TOKENS_ENVELOPE_PREFIX.length)
+  const separator = rest.indexOf(':')
+  const kind = separator === -1 ? '' : rest.slice(0, separator)
+  if (kind !== 'encrypted' && kind !== 'plaintext') {
+    throw new Error('Custom provider token store could not be decrypted')
+  }
+  return { kind, payload: Buffer.from(rest.slice(separator + 1), 'base64') }
+}
+
+function decodePayload(envelope: { kind: 'encrypted' | 'plaintext'; payload: Buffer }): string {
+  if (envelope.kind === 'plaintext') {
+    return envelope.payload.toString('utf8')
+  }
+  if (!safeStorage.isEncryptionAvailable()) {
+    throw new Error('Custom provider token store could not be decrypted')
+  }
+  return safeStorage.decryptString(envelope.payload)
+}
+
+function loadTokens(): Map<string, string> {
+  if (cachedTokens) {
+    return cachedTokens
+  }
+  const path = getTokensPath()
+  if (!existsSync(path)) {
+    cachedTokens = new Map()
+    return cachedTokens
+  }
+  try {
+    hardenExistingSecureFile(path)
+  } catch (error) {
+    console.warn('[custom-providers] Failed to harden token store while reading', error)
+  }
+  try {
+    const raw = readFileSync(path)
+    const json = decodePayload(decodeEnvelope(raw))
+    const parsed: unknown = JSON.parse(json)
+    cachedTokens = new Map(
+      typeof parsed === 'object' && parsed !== null ? Object.entries(parsed as object) : []
+    )
+    return cachedTokens
+  } catch (error) {
+    console.error('[custom-providers] failed to decode/decrypt token store', error)
+    throw new Error('Custom provider token store could not be decrypted')
+  }
+}
+
+function persistTokens(tokens: Map<string, string>): void {
+  const json = JSON.stringify(Object.fromEntries(tokens))
+  if (safeStorage.isEncryptionAvailable()) {
+    writeSecureFile(getTokensPath(), encodeEnvelope('encrypted', safeStorage.encryptString(json)))
+    return
+  }
+  console.warn(
+    '[custom-providers] safeStorage encryption unavailable — storing tokens in plaintext'
+  )
+  writeSecureFile(getTokensPath(), encodeEnvelope('plaintext', Buffer.from(json, 'utf8')))
+}
+
+export function hasCustomProviderToken(accountId: string): boolean {
+  return loadTokens().has(accountId)
+}
+
+export function readCustomProviderToken(accountId: string): string | null {
+  return loadTokens().get(accountId) ?? null
+}
+
+export function saveCustomProviderToken(accountId: string, token: string): void {
+  const trimmed = token.trim()
+  if (!trimmed) {
+    throw new Error('Custom provider token is required')
+  }
+  const tokens = new Map(loadTokens())
+  tokens.set(accountId, trimmed)
+  persistTokens(tokens)
+  cachedTokens = tokens
+}
+
+export function clearCustomProviderToken(accountId: string): void {
+  const tokens = new Map(loadTokens())
+  if (!tokens.delete(accountId)) {
+    return
+  }
+  persistTokens(tokens)
+  cachedTokens = tokens
+}
+
+/** Resolves the token to actually use for a fetch: `tokenEnvVar` (re-read from
+ *  process.env every call, so rotating it never needs a restart) takes
+ *  priority when it has a non-empty value; otherwise falls back to
+ *  `fallbackToken` (e.g. the keychain-stored token, or a draft's typed value). */
+export function resolveCustomProviderToken(
+  account: Pick<CustomProviderAccount, 'tokenEnvVar'>,
+  fallbackToken: string | null
+): string | null {
+  if (account.tokenEnvVar) {
+    const envValue = process.env[account.tokenEnvVar]
+    if (envValue) {
+      return envValue
+    }
+  }
+  return fallbackToken
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -225,6 +225,7 @@ import {
 } from './startup/serve-desktop-activation'
 import { RateLimitService } from './rate-limits/service'
 import { readMiniMaxSessionCookie } from './minimax/minimax-cookie-store'
+import { readCustomProviderToken } from './custom-providers/custom-provider-token-store'
 import { getInitialClaudeRateLimitTarget } from './rate-limits/claude-rate-limit-target'
 import { getInitialCodexRateLimitTarget } from './rate-limits/codex-rate-limit-target'
 import { getKimiRuntimeTarget, resolveKimiHome } from './kimi/kimi-runtime-home'
@@ -2624,6 +2625,8 @@ void app.whenReady().then(async () => {
     }
   })
   rateLimits.setGeminiCliOAuthEnabledResolver(() => store!.getSettings().geminiCliOAuthEnabled)
+  rateLimits.setCustomProviderConfigResolver(() => store!.getSettings().customProviderAccounts)
+  rateLimits.setCustomProviderTokenResolver((accountId) => readCustomProviderToken(accountId))
   rateLimits.setNetworkProxySettingsResolver(() => store!.getSettings())
   keybindings = new KeybindingService({
     homePath: app.getPath('home'),

--- a/src/main/ipc/custom-provider-accounts.ts
+++ b/src/main/ipc/custom-provider-accounts.ts
@@ -1,0 +1,83 @@
+import { ipcMain } from 'electron'
+import {
+  clearCustomProviderToken,
+  hasCustomProviderToken,
+  resolveCustomProviderToken,
+  saveCustomProviderToken
+} from '../custom-providers/custom-provider-token-store'
+import { CustomProviderAccount as CustomProviderAccountSchema } from '../custom-providers/custom-provider-account-schema'
+import { fetchCustomProviderUsage } from '../rate-limits/custom-provider-fetcher'
+import type {
+  CustomProviderAccount,
+  CustomProviderUsageResult
+} from '../../shared/custom-provider-types'
+import type { RateLimitService } from '../rate-limits/service'
+
+export type CustomProviderTokenStatus = {
+  configured: boolean
+}
+
+// Why: fire-and-forget — the save/clear call returns immediately; the refresh
+// runs in the background, same pattern as minimax-credentials.ts.
+function refreshAfterTokenChange(
+  rateLimits: RateLimitService | null,
+  action: 'save' | 'clear'
+): void {
+  void rateLimits?.refresh().catch((error: unknown) => {
+    console.error(`[custom-providers] failed to trigger rate-limit refresh after ${action}:`, error)
+  })
+}
+
+function assertString(value: unknown, message: string): asserts value is string {
+  if (typeof value !== 'string') {
+    throw new Error(message)
+  }
+}
+
+export function registerCustomProviderAccountHandlers(rateLimits: RateLimitService | null): void {
+  ipcMain.handle('customProviderAccounts:getTokenStatus', (_event, accountId: string) => {
+    assertString(accountId, 'accountId must be a string')
+    return { configured: hasCustomProviderToken(accountId) } satisfies CustomProviderTokenStatus
+  })
+
+  ipcMain.handle(
+    'customProviderAccounts:saveToken',
+    (_event, args: { accountId: string; token: string }) => {
+      assertString(args?.accountId, 'accountId must be a string')
+      assertString(args?.token, 'token must be a string')
+      saveCustomProviderToken(args.accountId, args.token)
+      refreshAfterTokenChange(rateLimits, 'save')
+      return {
+        configured: hasCustomProviderToken(args.accountId)
+      } satisfies CustomProviderTokenStatus
+    }
+  )
+
+  ipcMain.handle('customProviderAccounts:clearToken', (_event, accountId: string) => {
+    assertString(accountId, 'accountId must be a string')
+    clearCustomProviderToken(accountId)
+    refreshAfterTokenChange(rateLimits, 'clear')
+    return { configured: hasCustomProviderToken(accountId) } satisfies CustomProviderTokenStatus
+  })
+
+  // Why: the "Test & Preview" step (mandatory before Save per usability review)
+  // must run against the UNSAVED draft — no persistence, no rate-limit
+  // invalidation, just one live fetch so the user can verify before committing.
+  // Why: this is a renderer-facing IPC boundary — validate the FULL account
+  // shape (including the https:// requirement) with the same schema used for
+  // persisted accounts, rather than trusting an untyped `account` object. A
+  // compromised or buggy renderer could otherwise pass an http:// URL or a
+  // malformed shape and still trigger a real fetch with a resolved secret.
+  ipcMain.handle(
+    'customProviderAccounts:testDraft',
+    (
+      _event,
+      args: { account: CustomProviderAccount; token: string }
+    ): Promise<CustomProviderUsageResult> => {
+      const account = CustomProviderAccountSchema.parse(args?.account)
+      assertString(args.token, 'token must be a string')
+      const token = resolveCustomProviderToken(account, args.token.trim() || null)
+      return fetchCustomProviderUsage(account, token)
+    }
+  )
+}

--- a/src/main/ipc/register-core-handlers/register-core-handlers.test.ts
+++ b/src/main/ipc/register-core-handlers/register-core-handlers.test.ts
@@ -65,7 +65,8 @@ const {
   registerLocalhostWorktreeLabelHandlersMock,
   registerNativeChatHandlersMock,
   registerEmulatorFrameStreamHandlersMock,
-  registerEmulatorVideoStreamHandlersMock
+  registerEmulatorVideoStreamHandlersMock,
+  registerCustomProviderAccountHandlersMock
 } = vi.hoisted(() => ({
   getPathMock: vi.fn(() => '/test/user-data'),
   listEnvironmentsMock: vi.fn(() => []),
@@ -131,7 +132,8 @@ const {
   registerLocalhostWorktreeLabelHandlersMock: vi.fn(),
   registerNativeChatHandlersMock: vi.fn(),
   registerEmulatorFrameStreamHandlersMock: vi.fn(),
-  registerEmulatorVideoStreamHandlersMock: vi.fn()
+  registerEmulatorVideoStreamHandlersMock: vi.fn(),
+  registerCustomProviderAccountHandlersMock: vi.fn()
 }))
 
 vi.mock('electron', () => ({
@@ -182,6 +184,10 @@ vi.mock('../preflight', () => ({
 
 vi.mock('../usage-provider-handlers', () => ({
   registerUsageProviderHandlers: registerUsageProviderHandlersMock
+}))
+
+vi.mock('../custom-provider-accounts', () => ({
+  registerCustomProviderAccountHandlers: registerCustomProviderAccountHandlersMock
 }))
 
 vi.mock('../github', () => ({
@@ -454,6 +460,7 @@ describe('registerCoreHandlers', () => {
     registerNativeChatHandlersMock.mockReset()
     registerEmulatorFrameStreamHandlersMock.mockReset()
     registerEmulatorVideoStreamHandlersMock.mockReset()
+    registerCustomProviderAccountHandlersMock.mockReset()
   })
 
   it('passes the store through to handler registrars that need it', async () => {
@@ -502,6 +509,7 @@ describe('registerCoreHandlers', () => {
       codexUsage,
       openCodeUsage
     })
+    expect(registerCustomProviderAccountHandlersMock).toHaveBeenCalledWith(rateLimits)
     expect(registerAppHandlersMock).toHaveBeenCalledWith(store, { onBeforeRelaunch })
     expect(registerCodexAccountHandlersMock).toHaveBeenCalledWith(
       codexAccounts,

--- a/src/main/ipc/register-core-handlers/register-core-handlers.ts
+++ b/src/main/ipc/register-core-handlers/register-core-handlers.ts
@@ -63,6 +63,7 @@ import { registerAgentTrustHandlers } from '../agent-trust'
 import { registerClaudeAccountHandlers } from '../claude-accounts'
 import { registerMiniMaxCredentialsHandlers } from '../minimax-credentials'
 import { registerGrokAccountHandlers } from '../grok-accounts'
+import { registerCustomProviderAccountHandlers } from '../custom-provider-accounts'
 import { registerUpdaterHandlers } from '../../window/attach-main-window-services'
 import {
   registerClipboardHandlers,
@@ -147,6 +148,7 @@ export function registerCoreHandlers(
   registerAgentTrustHandlers()
   registerClaudeAccountHandlers(claudeAccounts)
   registerMiniMaxCredentialsHandlers(rateLimits)
+  registerCustomProviderAccountHandlers(rateLimits)
   registerGrokAccountHandlers()
   registerRateLimitHandlers(rateLimits, codexAccounts)
   registerGitHubHandlers(store, stats)

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -34,6 +34,7 @@ import {
   computerAwakeSettingsForMode,
   normalizeComputerAwakeMode
 } from '../../shared/computer-awake-mode'
+import { CustomProviderAccountList } from '../custom-providers/custom-provider-account-schema'
 
 // Why: the whitelist is the source-of-truth for which keys we emit on. Casting
 // to a Set once at module load lets the IPC handler's per-key membership
@@ -151,6 +152,19 @@ export function registerSettingsHandlers(
     if ('httpProxyUrl' in args) {
       const proxyUrl = normalizeProxyUrl(args.httpProxyUrl)
       sanitizedArgs.httpProxyUrl = proxyUrl.ok ? proxyUrl.value : ''
+    }
+    if ('customProviderAccounts' in args) {
+      // Why: this is the real trust boundary for a field the poll loop resolves
+      // secrets against — the renderer's own draft validation is a UX nicety,
+      // not enforcement. Reject the whole update on any invalid entry (bad
+      // https:// scheme, duplicate id/name, missing mapping-mode fields) rather
+      // than persisting a partially-trusted array.
+      const parsed = CustomProviderAccountList.safeParse(args.customProviderAccounts)
+      if (parsed.success) {
+        sanitizedArgs.customProviderAccounts = parsed.data
+      } else {
+        delete sanitizedArgs.customProviderAccounts
+      }
     }
     if ('httpProxyBypassRules' in args) {
       sanitizedArgs.httpProxyBypassRules = normalizeProxyBypassRules(args.httpProxyBypassRules)

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -156,13 +156,18 @@ export function registerSettingsHandlers(
     if ('customProviderAccounts' in args) {
       // Why: this is the real trust boundary for a field the poll loop resolves
       // secrets against — the renderer's own draft validation is a UX nicety,
-      // not enforcement. Reject the whole update on any invalid entry (bad
-      // https:// scheme, duplicate id/name, missing mapping-mode fields) rather
-      // than persisting a partially-trusted array.
+      // not enforcement. Drop the field on any invalid entry (bad https://
+      // scheme, duplicate id/name, missing mapping-mode fields) rather than
+      // persisting a partially-trusted array; the rest of this settings:set
+      // update still applies.
       const parsed = CustomProviderAccountList.safeParse(args.customProviderAccounts)
       if (parsed.success) {
         sanitizedArgs.customProviderAccounts = parsed.data
       } else {
+        console.warn(
+          '[settings] rejected invalid customProviderAccounts update:',
+          parsed.error.issues
+        )
         delete sanitizedArgs.customProviderAccounts
       }
     }

--- a/src/main/rate-limits/custom-provider-fetcher.test.ts
+++ b/src/main/rate-limits/custom-provider-fetcher.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { net } from 'electron'
+import type { CustomProviderAccount } from '../../shared/custom-provider-types'
+import { fetchCustomProviderUsage, resolveJsonPath } from './custom-provider-fetcher'
+
+vi.mock('electron', () => ({
+  net: { fetch: vi.fn() }
+}))
+
+function makeAccount(overrides: Partial<CustomProviderAccount> = {}): CustomProviderAccount {
+  return {
+    id: 'acc-1',
+    displayName: 'Acme',
+    enabled: true,
+    usageUrl: 'https://example.com/usage',
+    mappingMode: 'percent',
+    percentPath: 'percent',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides
+  }
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body)
+  } as unknown as Response
+}
+
+beforeEach(() => {
+  vi.mocked(net.fetch).mockReset()
+})
+
+describe('resolveJsonPath', () => {
+  it('does not resolve inherited/prototype properties (#2)', () => {
+    // Why: `segment in current` would previously resolve this truthily even
+    // though the parsed JSON response never contains a "constructor" field.
+    expect(resolveJsonPath({}, 'constructor').found).toBe(false)
+    expect(resolveJsonPath({}, 'toString').found).toBe(false)
+    expect(resolveJsonPath({}, 'hasOwnProperty').found).toBe(false)
+  })
+
+  it('still resolves genuine own properties, including a literal falsy value', () => {
+    expect(resolveJsonPath({ a: { b: 0 } }, 'a.b')).toEqual({ found: true, value: 0 })
+  })
+})
+
+describe('fetchCustomProviderUsage', () => {
+  it('rejects a negative summed used value instead of returning a negative percent (#3)', async () => {
+    vi.mocked(net.fetch).mockResolvedValue(jsonResponse({ usage: { used: -5 }, limit: 100 }))
+    const account = makeAccount({
+      mappingMode: 'used-limit',
+      usedPaths: ['usage.used'],
+      limitPath: 'limit'
+    })
+
+    const result = await fetchCustomProviderUsage(account, 'token')
+
+    expect(result.status).toBe('error')
+    expect(result.usedPercent).toBeNull()
+    expect(result.failureKind).toBe('out-of-range')
+  })
+
+  it('sums multiple usedPaths and rejects only when the total is negative', async () => {
+    vi.mocked(net.fetch).mockResolvedValue(jsonResponse({ input: 10, output: -30 }, 200))
+    const account = makeAccount({
+      mappingMode: 'used-limit',
+      usedPaths: ['input', 'output'],
+      limitPath: 'limit'
+    })
+
+    const result = await fetchCustomProviderUsage(account, 'token')
+
+    expect(result.status).toBe('error')
+    expect(result.failureKind).toBe('out-of-range')
+  })
+
+  it('computes a valid percent for a healthy used/limit response', async () => {
+    vi.mocked(net.fetch).mockResolvedValue(jsonResponse({ used: 25, limit: 100 }))
+    const account = makeAccount({
+      mappingMode: 'used-limit',
+      usedPaths: ['used'],
+      limitPath: 'limit'
+    })
+
+    const result = await fetchCustomProviderUsage(account, 'token')
+
+    expect(result.status).toBe('ok')
+    expect(result.usedPercent).toBe(25)
+  })
+
+  it('returns unavailable with no network call when no token is configured', async () => {
+    const account = makeAccount()
+
+    const result = await fetchCustomProviderUsage(account, null)
+
+    expect(result.status).toBe('unavailable')
+    expect(result.failureKind).toBe('missing-token')
+    expect(net.fetch).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/rate-limits/custom-provider-fetcher.ts
+++ b/src/main/rate-limits/custom-provider-fetcher.ts
@@ -1,0 +1,218 @@
+import { net } from 'electron'
+import type {
+  CustomProviderAccount,
+  CustomProviderUsageFailureKind,
+  CustomProviderUsageResult
+} from '../../shared/custom-provider-types'
+
+const API_TIMEOUT_MS = 10_000
+
+function pad2(value: number): string {
+  return String(value).padStart(2, '0')
+}
+
+/** Substitutes {yyyy}/{mm}/{dd} with today's UTC date — documented as UTC in the Settings UI
+ *  so a daily-reset API's boundary matches what the user sees, regardless of local timezone. */
+export function substituteDatePlaceholders(url: string, now: Date): string {
+  return url
+    .replace(/\{yyyy\}/g, String(now.getUTCFullYear()))
+    .replace(/\{mm\}/g, pad2(now.getUTCMonth() + 1))
+    .replace(/\{dd\}/g, pad2(now.getUTCDate()))
+}
+
+function nextUtcMidnight(now: Date): Date {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1))
+}
+
+type PathSegment = string | number
+
+const PATH_SEGMENT_PATTERN = /^(?:[^[\].]+|\[\d+\])+$/
+const PATH_TOKEN_PATTERN = /[^[\].]+|\[(\d+)\]/g
+
+// Why: a deliberately small grammar (dot keys + numeric array indices) instead of full
+// JSONPath/JMESPath — per usability review, more power here would hurt supportability for a
+// semi-technical audience without adding real capability for this feature's stated use case.
+// Rejects malformed syntax explicitly (e.g. "a[bad]", trailing dots) instead of silently
+// dropping the unparsed remainder, so a typo surfaces as a config error, not a wrong value.
+export function parsePathSegments(path: string): PathSegment[] | null {
+  if (path.trim().length === 0) {
+    return null
+  }
+  const parts = path.split('.')
+  if (parts.some((part) => part.length === 0 || !PATH_SEGMENT_PATTERN.test(part))) {
+    return null
+  }
+  return parts.flatMap((part) =>
+    [...part.matchAll(PATH_TOKEN_PATTERN)].map((match) =>
+      match[1] !== undefined ? Number(match[1]) : match[0]
+    )
+  )
+}
+
+type PathResolution = { found: true; value: unknown } | { found: false; invalidSyntax?: true }
+
+export function resolveJsonPath(data: unknown, path: string): PathResolution {
+  const segments = parsePathSegments(path)
+  if (segments === null) {
+    return { found: false, invalidSyntax: true }
+  }
+  let current: unknown = data
+  for (const segment of segments) {
+    if (current === null || typeof current !== 'object') {
+      return { found: false }
+    }
+    if (typeof segment === 'number') {
+      if (!Array.isArray(current) || segment >= current.length) {
+        return { found: false }
+      }
+      current = current[segment]
+    } else {
+      if (!(segment in current)) {
+        return { found: false }
+      }
+      current = (current as Record<string, unknown>)[segment]
+    }
+  }
+  return current === undefined ? { found: false } : { found: true, value: current }
+}
+
+type NumericPathResult =
+  | { kind: 'ok'; value: number }
+  | { kind: 'not-found' }
+  | { kind: 'non-numeric' }
+  | { kind: 'invalid-syntax' }
+
+function resolveNumericPath(data: unknown, path: string): NumericPathResult {
+  const resolved = resolveJsonPath(data, path)
+  if (!resolved.found) {
+    return resolved.invalidSyntax ? { kind: 'invalid-syntax' } : { kind: 'not-found' }
+  }
+  return typeof resolved.value === 'number' && Number.isFinite(resolved.value)
+    ? { kind: 'ok', value: resolved.value }
+    : { kind: 'non-numeric' }
+}
+
+function result(
+  accountId: string,
+  status: CustomProviderUsageResult['status'],
+  error: string | null,
+  failureKind?: CustomProviderUsageFailureKind,
+  usedPercent: number | null = null,
+  resetsAt: number | null = null
+): CustomProviderUsageResult {
+  return {
+    accountId,
+    usedPercent,
+    resetsAt,
+    updatedAt: Date.now(),
+    error,
+    status,
+    ...(failureKind ? { failureKind } : {})
+  }
+}
+
+type MappingFailure = { failureKind: CustomProviderUsageFailureKind; error: string }
+
+function numericPathFailure(
+  result: Extract<NumericPathResult, { kind: 'not-found' | 'non-numeric' | 'invalid-syntax' }>,
+  label: string,
+  path: string
+): MappingFailure {
+  if (result.kind === 'invalid-syntax') {
+    return { failureKind: 'invalid-path-syntax', error: `${label} path "${path}" is malformed` }
+  }
+  if (result.kind === 'not-found') {
+    return { failureKind: 'path-not-found', error: `${label} path "${path}" did not resolve` }
+  }
+  return { failureKind: 'non-numeric', error: `${label} path "${path}" is not a number` }
+}
+
+function computeUsedPercent(
+  account: CustomProviderAccount,
+  data: unknown
+): { percent: number } | MappingFailure {
+  if (account.mappingMode === 'percent') {
+    const path = account.percentPath ?? ''
+    const resolved = resolveNumericPath(data, path)
+    if (resolved.kind !== 'ok') {
+      return numericPathFailure(resolved, 'Percent', path)
+    }
+    if (resolved.value < 0 || resolved.value > 100) {
+      return {
+        failureKind: 'out-of-range',
+        error: `Percent path "${path}" resolved to ${resolved.value}, outside 0-100`
+      }
+    }
+    return { percent: resolved.value }
+  }
+
+  let used = 0
+  for (const path of account.usedPaths ?? []) {
+    const resolved = resolveNumericPath(data, path)
+    if (resolved.kind !== 'ok') {
+      return numericPathFailure(resolved, 'Used', path)
+    }
+    used += resolved.value
+  }
+  const limitPath = account.limitPath ?? ''
+  const limitResolved = resolveNumericPath(data, limitPath)
+  if (limitResolved.kind !== 'ok') {
+    return numericPathFailure(limitResolved, 'Limit', limitPath)
+  }
+  if (limitResolved.value <= 0) {
+    return { failureKind: 'invalid-limit', error: `Limit path "${limitPath}" resolved to <= 0` }
+  }
+  return { percent: Math.min(100, (used / limitResolved.value) * 100) }
+}
+
+/** Read-only usage check for a user-defined custom provider account. Bring-your-own-endpoint:
+ *  Orca calls `account.usageUrl` (with {yyyy}/{mm}/{dd} substituted) and maps the JSON response
+ *  through the account's configured path grammar — see custom-provider-types.ts. */
+export async function fetchCustomProviderUsage(
+  account: CustomProviderAccount,
+  token: string | null,
+  now: Date = new Date()
+): Promise<CustomProviderUsageResult> {
+  if (!token) {
+    return result(account.id, 'unavailable', 'No token configured', 'missing-token')
+  }
+
+  const url = substituteDatePlaceholders(account.usageUrl, now)
+  const resetsAt = account.usageUrl.includes('{') ? nextUtcMidnight(now).getTime() : null
+
+  let res: Response
+  try {
+    res = await net.fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(API_TIMEOUT_MS)
+    })
+  } catch (err) {
+    const isTimeout = err instanceof Error && err.name === 'TimeoutError'
+    return result(
+      account.id,
+      'error',
+      err instanceof Error ? err.message : 'Custom provider usage request failed',
+      isTimeout ? 'timeout' : 'network'
+    )
+  }
+
+  if (res.status === 401 || res.status === 403) {
+    return result(account.id, 'error', `Unauthorized (HTTP ${res.status})`, 'unauthorized')
+  }
+  if (!res.ok) {
+    return result(account.id, 'error', `Request failed (HTTP ${res.status})`, 'unknown')
+  }
+
+  let data: unknown
+  try {
+    data = await res.json()
+  } catch {
+    return result(account.id, 'error', 'Response was not valid JSON', 'non-json')
+  }
+
+  const computed = computeUsedPercent(account, data)
+  if ('failureKind' in computed) {
+    return result(account.id, 'error', computed.error, computed.failureKind)
+  }
+  return result(account.id, 'ok', null, undefined, computed.percent, resetsAt)
+}

--- a/src/main/rate-limits/custom-provider-fetcher.ts
+++ b/src/main/rate-limits/custom-provider-fetcher.ts
@@ -67,7 +67,9 @@ export function resolveJsonPath(data: unknown, path: string): PathResolution {
       }
       current = current[segment]
     } else {
-      if (!(segment in current)) {
+      // Why: `in` also matches inherited/prototype properties (e.g. "constructor"),
+      // which would resolve truthily against a response that has no such field.
+      if (!Object.hasOwn(current, segment)) {
         return { found: false }
       }
       current = (current as Record<string, unknown>)[segment]
@@ -153,6 +155,12 @@ function computeUsedPercent(
       return numericPathFailure(resolved, 'Used', path)
     }
     used += resolved.value
+  }
+  if (!Number.isFinite(used) || used < 0) {
+    return {
+      failureKind: 'out-of-range',
+      error: `Summed used value (${used}) must be a finite, non-negative number`
+    }
   }
   const limitPath = account.limitPath ?? ''
   const limitResolved = resolveNumericPath(data, limitPath)

--- a/src/main/rate-limits/service-custom-provider-usage.test.ts
+++ b/src/main/rate-limits/service-custom-provider-usage.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CustomProviderAccount } from '../../shared/custom-provider-types'
+import { RateLimitService } from './service'
+import { fetchCustomProviderUsage } from './custom-provider-fetcher'
+import { resetRateLimitProviderMocks } from './rate-limit-service-test-harness'
+
+vi.mock('./claude-fetcher', () => ({
+  fetchClaudeRateLimits: vi.fn(),
+  fetchManagedAccountUsage: vi.fn()
+}))
+
+vi.mock('./codex-fetcher', () => ({
+  consumeCodexRateLimitResetCredit: vi.fn(),
+  fetchCodexRateLimits: vi.fn()
+}))
+
+vi.mock('./gemini-usage-fetcher', () => ({
+  fetchGeminiRateLimits: vi.fn()
+}))
+
+vi.mock('./kimi-fetcher', () => ({
+  fetchKimiRateLimits: vi.fn()
+}))
+
+vi.mock('./opencode-go-usage-fetcher', () => ({
+  fetchOpenCodeGoRateLimits: vi.fn()
+}))
+
+vi.mock('./minimax-fetcher', () => ({
+  fetchMiniMaxRateLimits: vi.fn()
+}))
+
+vi.mock('./grok-fetcher', () => ({
+  fetchGrokRateLimits: vi.fn()
+}))
+
+vi.mock('./grok-auth', () => ({
+  readGrokAuthSession: vi.fn(() => ({ status: 'missing' }))
+}))
+
+vi.mock('../minimax/minimax-cookie-store', () => ({
+  hasMiniMaxSessionCookie: vi.fn(() => false)
+}))
+
+vi.mock('./custom-provider-fetcher', () => ({
+  fetchCustomProviderUsage: vi.fn()
+}))
+
+function makeAccount(overrides: Partial<CustomProviderAccount> = {}): CustomProviderAccount {
+  return {
+    id: 'acc-1',
+    displayName: 'Acme',
+    enabled: true,
+    usageUrl: 'https://example.com/usage',
+    mappingMode: 'percent',
+    percentPath: 'percent',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    ...overrides
+  }
+}
+
+// Why: fetchCustomProviders() is fire-and-forget from fetchAll()/refresh() —
+// awaiting a manual refresh() call (which explicitly awaits it) is the only
+// externally-observable way to know the cycle has settled.
+function serviceInternals(service: RateLimitService): {
+  fetchCustomProviders: () => Promise<void>
+} {
+  return service as unknown as { fetchCustomProviders: () => Promise<void> }
+}
+
+describe('RateLimitService custom-provider usage', () => {
+  beforeEach(() => {
+    resetRateLimitProviderMocks()
+    vi.mocked(fetchCustomProviderUsage).mockReset()
+  })
+
+  it('isolates a per-account token-resolution failure instead of rejecting the whole batch (#4)', async () => {
+    const healthy = makeAccount({ id: 'acc-healthy' })
+    const corrupt = makeAccount({ id: 'acc-corrupt' })
+    const service = new RateLimitService()
+    service.setCustomProviderConfigResolver(() => [healthy, corrupt])
+    service.setCustomProviderTokenResolver((accountId) => {
+      if (accountId === 'acc-corrupt') {
+        throw new Error('keychain decrypt failed')
+      }
+      return 'token-value'
+    })
+    vi.mocked(fetchCustomProviderUsage).mockImplementation(async (account) => ({
+      accountId: account.id,
+      usedPercent: 42,
+      resetsAt: null,
+      updatedAt: Date.now(),
+      error: null,
+      status: 'ok'
+    }))
+
+    // Why: fetchCustomProviders() must not reject — a throwing resolver for
+    // one account must not take down Promise.all for every account.
+    await expect(serviceInternals(service).fetchCustomProviders()).resolves.toBeUndefined()
+
+    const usage = service.getState().customProviderUsage
+    expect(usage['acc-healthy']?.status).toBe('ok')
+    expect(usage['acc-healthy']?.usedPercent).toBe(42)
+    expect(usage['acc-corrupt']?.status).toBe('error')
+    expect(usage['acc-corrupt']?.error).toContain('keychain decrypt failed')
+  })
+
+  it('fetches each enabled custom provider exactly once per manual refresh (#5)', async () => {
+    const account = makeAccount()
+    const service = new RateLimitService()
+    service.setCustomProviderConfigResolver(() => [account])
+    service.setCustomProviderTokenResolver(() => 'token-value')
+    vi.mocked(fetchCustomProviderUsage).mockResolvedValue({
+      accountId: account.id,
+      usedPercent: 10,
+      resetsAt: null,
+      updatedAt: Date.now(),
+      error: null,
+      status: 'ok'
+    })
+    // Why: assert on the custom-provider cycle count directly, and on exactly
+    // what refresh() passes to fetchAll, rather than driving the unrelated
+    // fixed-provider fetchAll cycle (claude/codex/etc.) through to real
+    // completion — that cycle needs its own unrelated mocking to not throw
+    // and isn't what this regression is about. The regression: fetchAll's own
+    // body also starts a fetchCustomProviders() cycle unless told not to, so
+    // refresh() must pass skipCustomProviders: true or every manual refresh
+    // double-fires an authenticated request per enabled custom provider.
+    const fetchCustomProvidersSpy = vi.spyOn(
+      service as unknown as { fetchCustomProviders: () => Promise<void> },
+      'fetchCustomProviders'
+    )
+    const fetchAllSpy = vi
+      .spyOn(service as unknown as { fetchAll: (options?: unknown) => Promise<void> }, 'fetchAll')
+      .mockResolvedValue(undefined)
+
+    await service.refresh()
+
+    expect(fetchCustomProvidersSpy).toHaveBeenCalledTimes(1)
+    expect(fetchCustomProviderUsage).toHaveBeenCalledTimes(1)
+    expect(fetchAllSpy).toHaveBeenCalledWith(expect.objectContaining({ skipCustomProviders: true }))
+  })
+
+  it('does not preserve stale usage once the account becomes unavailable, e.g. after clearToken() (#11)', async () => {
+    const account = makeAccount()
+    const service = new RateLimitService()
+    service.setCustomProviderConfigResolver(() => [account])
+    service.setCustomProviderTokenResolver(() => 'token-value')
+
+    vi.mocked(fetchCustomProviderUsage).mockResolvedValueOnce({
+      accountId: account.id,
+      usedPercent: 77,
+      resetsAt: null,
+      updatedAt: Date.now(),
+      error: null,
+      status: 'ok'
+    })
+    await serviceInternals(service).fetchCustomProviders()
+    expect(service.getState().customProviderUsage[account.id]?.usedPercent).toBe(77)
+
+    // Why: clearToken() is an intentional user action, not a transient
+    // failure — 'unavailable' must replace the stale percent immediately.
+    vi.mocked(fetchCustomProviderUsage).mockResolvedValueOnce({
+      accountId: account.id,
+      usedPercent: null,
+      resetsAt: null,
+      updatedAt: Date.now(),
+      error: 'No token configured',
+      status: 'unavailable',
+      failureKind: 'missing-token'
+    })
+    await serviceInternals(service).fetchCustomProviders()
+
+    const usage = service.getState().customProviderUsage[account.id]
+    expect(usage?.status).toBe('unavailable')
+    expect(usage?.usedPercent).toBeNull()
+  })
+
+  it('still preserves the last successful percent on a genuine fetch error', async () => {
+    const account = makeAccount()
+    const service = new RateLimitService()
+    service.setCustomProviderConfigResolver(() => [account])
+    service.setCustomProviderTokenResolver(() => 'token-value')
+
+    vi.mocked(fetchCustomProviderUsage).mockResolvedValueOnce({
+      accountId: account.id,
+      usedPercent: 55,
+      resetsAt: null,
+      updatedAt: Date.now(),
+      error: null,
+      status: 'ok'
+    })
+    await serviceInternals(service).fetchCustomProviders()
+
+    vi.mocked(fetchCustomProviderUsage).mockResolvedValueOnce({
+      accountId: account.id,
+      usedPercent: null,
+      resetsAt: null,
+      updatedAt: Date.now(),
+      error: 'Request failed (HTTP 500)',
+      status: 'error',
+      failureKind: 'unknown'
+    })
+    await serviceInternals(service).fetchCustomProviders()
+
+    const usage = service.getState().customProviderUsage[account.id]
+    expect(usage?.status).toBe('error')
+    expect(usage?.usedPercent).toBe(55)
+  })
+})

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -336,9 +336,9 @@ export class RateLimitService {
     )
     const results = await Promise.all(
       enabled.map(async (account) => {
-        const keychainToken = this.customProviderTokenResolver?.(account.id) ?? null
-        const token = resolveCustomProviderToken(account, keychainToken)
         try {
+          const keychainToken = this.customProviderTokenResolver?.(account.id) ?? null
+          const token = resolveCustomProviderToken(account, keychainToken)
           return await fetchCustomProviderUsage(account, token)
         } catch (error) {
           return {
@@ -370,10 +370,13 @@ export class RateLimitService {
     for (const id of currentIds) {
       const fresh = results.find((r) => r.accountId === id)
       const previous = this.customProviderUsage[id]
-      // Why: preserve the last successful percent on failure (a stale/error
+      // Why: preserve the last successful percent on a fetch error (a stale/error
       // indicator) rather than snapping the status-bar row to a misleading 0%.
+      // A non-'error' non-'ok' status (e.g. 'unavailable' right after the user
+      // clears their token) is an intentional state change, not a transient
+      // failure, and must be reflected immediately rather than papered over.
       const merged =
-        fresh && fresh.status !== 'ok' && previous?.usedPercent != null
+        fresh && fresh.status === 'error' && previous?.usedPercent != null
           ? { ...fresh, usedPercent: previous.usedPercent }
           : (fresh ?? previous)
       if (merged) {
@@ -492,10 +495,17 @@ export class RateLimitService {
     // endpoint — see RemoteAccountsRateLimitState. Otherwise, also await the
     // custom-provider cycle explicitly (fetchAll's internal call is
     // fire-and-forget) so the returned state reflects it, not just the fixed
-    // providers — a plain await fetchAll() alone would race this call.
+    // providers — a plain await fetchAll() alone would race this call. Both
+    // branches pass skipCustomProviders: true to fetchAll itself so it never
+    // starts its own fire-and-forget cycle on top of the one already awaited
+    // here (or intentionally skipped above), which would otherwise double-fire
+    // an authenticated request per enabled custom provider on every refresh.
     await (options?.skipCustomProviders
       ? this.fetchAll({ force: true, skipCustomProviders: true })
-      : Promise.all([this.fetchAll({ force: true }), this.fetchCustomProviders()]))
+      : Promise.all([
+          this.fetchAll({ force: true, skipCustomProviders: true }),
+          this.fetchCustomProviders()
+        ]))
     return this.getState()
   }
 

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -27,6 +27,12 @@ import { fetchGrokRateLimits } from './grok-fetcher'
 import { readGrokAuthSession } from './grok-auth'
 import { hasMiniMaxSessionCookie } from '../minimax/minimax-cookie-store'
 import { fetchMiniMaxRateLimits } from './minimax-fetcher'
+import { fetchCustomProviderUsage } from './custom-provider-fetcher'
+import { resolveCustomProviderToken } from '../custom-providers/custom-provider-token-store'
+import type {
+  CustomProviderAccount,
+  CustomProviderUsageResult
+} from '../../shared/custom-provider-types'
 import { fetchOpenCodeGoRateLimits } from './opencode-go-usage-fetcher'
 import {
   normalizeCodexAccountSelectionTarget,
@@ -249,6 +255,15 @@ export class RateLimitService {
   private lastInactiveCodexFetchAt = 0
   private inactiveCodexAccountsGeneration = 0
   private stateListeners = new Set<(state: RateLimitState) => void>()
+  // Why: an arbitrary-length, user-defined list — kept parallel to the fixed
+  // InternalRateLimitState fields above rather than folded into them, since
+  // those are exhaustively switched on throughout the status bar/settings code.
+  private customProviderConfigResolver: (() => CustomProviderAccount[]) | null = null
+  private customProviderTokenResolver: ((accountId: string) => string | null) | null = null
+  private customProviderUsage: Record<string, CustomProviderUsageResult> = {}
+  // Why: guards against a slower, superseded fetch cycle clobbering a fresher one — same
+  // pattern as claudeFetchGeneration/codexFetchGeneration/minimaxFetchGeneration below.
+  private customProviderFetchGeneration = 0
 
   constructor() {}
 
@@ -301,6 +316,72 @@ export class RateLimitService {
 
   setClaudeFetchTarget(target?: ClaudeAccountSelectionTarget): void {
     this.claudeFetchTarget = normalizeClaudeAccountSelectionTarget(target)
+  }
+
+  setCustomProviderConfigResolver(resolver: () => CustomProviderAccount[]): void {
+    this.customProviderConfigResolver = resolver
+  }
+
+  setCustomProviderTokenResolver(resolver: (accountId: string) => string | null): void {
+    this.customProviderTokenResolver = resolver
+  }
+
+  // Why: fire-and-forget from fetchAll() rather than joining its Promise.allSettled batch —
+  // an arbitrary-length list shouldn't gate on or be gated by the fixed providers' generation
+  // counters/config-change diffing, which are sized for a known, bounded set.
+  private async fetchCustomProviders(): Promise<void> {
+    const generation = ++this.customProviderFetchGeneration
+    const enabled = (this.customProviderConfigResolver?.() ?? []).filter(
+      (account) => account.enabled
+    )
+    const results = await Promise.all(
+      enabled.map(async (account) => {
+        const keychainToken = this.customProviderTokenResolver?.(account.id) ?? null
+        const token = resolveCustomProviderToken(account, keychainToken)
+        try {
+          return await fetchCustomProviderUsage(account, token)
+        } catch (error) {
+          return {
+            accountId: account.id,
+            usedPercent: null,
+            resetsAt: null,
+            updatedAt: Date.now(),
+            error: error instanceof Error ? error.message : 'Custom provider usage request failed',
+            status: 'error' as const,
+            failureKind: 'unknown' as const
+          }
+        }
+      })
+    )
+    // Why: a slower, superseded cycle must never apply over a fresher one that
+    // already started (mirrors claudeFetchGeneration/codexFetchGeneration below).
+    if (generation !== this.customProviderFetchGeneration) {
+      return
+    }
+    // Why: re-read the config fresh rather than trust the `enabled` snapshot
+    // captured before the fetch — an account deleted/disabled/renamed mid-fetch
+    // must be pruned here, not revived with this cycle's now-stale result.
+    const currentIds = new Set(
+      (this.customProviderConfigResolver?.() ?? [])
+        .filter((account) => account.enabled)
+        .map((account) => account.id)
+    )
+    const next: Record<string, CustomProviderUsageResult> = {}
+    for (const id of currentIds) {
+      const fresh = results.find((r) => r.accountId === id)
+      const previous = this.customProviderUsage[id]
+      // Why: preserve the last successful percent on failure (a stale/error
+      // indicator) rather than snapping the status-bar row to a misleading 0%.
+      const merged =
+        fresh && fresh.status !== 'ok' && previous?.usedPercent != null
+          ? { ...fresh, usedPercent: previous.usedPercent }
+          : (fresh ?? previous)
+      if (merged) {
+        next[id] = merged
+      }
+    }
+    this.customProviderUsage = next
+    this.pushToRenderer()
   }
 
   setOpenCodeGoConfigResolver(resolver: () => OpenCodeGoRateLimitConfig): void {
@@ -398,20 +479,30 @@ export class RateLimitService {
       inactiveCodexAccounts: this.buildInactiveArray(
         this.inactiveCodexCache,
         this.inactiveCodexFetching
-      )
+      ),
+      customProviderUsage: this.customProviderUsage
     }
   }
 
-  async refresh(): Promise<RateLimitState> {
+  async refresh(options?: { skipCustomProviders?: boolean }): Promise<RateLimitState> {
     // Why: this user-directed refresh must bypass the poll throttle, else the click can no-op after wake/focus and feel broken.
-    await this.fetchAll({ force: true })
+    // Why: skipCustomProviders lets a paired/remote/mobile-triggered refresh
+    // reach the fixed providers without also being the proximate cause of the
+    // host resolving a tokenEnvVar secret and hitting a user-configured
+    // endpoint — see RemoteAccountsRateLimitState. Otherwise, also await the
+    // custom-provider cycle explicitly (fetchAll's internal call is
+    // fire-and-forget) so the returned state reflects it, not just the fixed
+    // providers — a plain await fetchAll() alone would race this call.
+    await (options?.skipCustomProviders
+      ? this.fetchAll({ force: true, skipCustomProviders: true })
+      : Promise.all([this.fetchAll({ force: true }), this.fetchCustomProviders()]))
     return this.getState()
   }
 
-  async refreshIfStale(): Promise<RateLimitState> {
+  async refreshIfStale(options?: { skipCustomProviders?: boolean }): Promise<RateLimitState> {
     // Why: reconnecting mobile subscribers need fresh backgrounded-desktop data, but replaying a subscription must not queue another forced fetch.
     const plan = this.getActiveWindowRefreshPlan(Date.now())
-    await this.runActiveWindowRefreshPlan(plan)
+    await this.runActiveWindowRefreshPlan(plan, options)
     return this.getState()
   }
 
@@ -918,7 +1009,10 @@ export class RateLimitService {
     return { kind: 'providers', providers: retryableFailures }
   }
 
-  private async runActiveWindowRefreshPlan(plan: ActiveWindowRefreshPlan): Promise<void> {
+  private async runActiveWindowRefreshPlan(
+    plan: ActiveWindowRefreshPlan,
+    options?: { skipCustomProviders?: boolean }
+  ): Promise<void> {
     if (plan.kind === 'none') {
       return
     }
@@ -933,7 +1027,7 @@ export class RateLimitService {
           }
         }
       }
-      await this.fetchAll()
+      await this.fetchAll({ skipCustomProviders: options?.skipCustomProviders })
       return
     }
 
@@ -951,7 +1045,7 @@ export class RateLimitService {
       INDIVIDUALLY_REFRESHABLE_PROVIDERS.has(provider)
     )
     if (!canRefreshIndividually) {
-      await this.fetchAll()
+      await this.fetchAll({ skipCustomProviders: options?.skipCustomProviders })
       return
     }
 
@@ -975,7 +1069,19 @@ export class RateLimitService {
     await this.runActiveWindowRefreshPlan(plan)
   }
 
-  private async fetchAll(options?: { force?: boolean }): Promise<void> {
+  private async fetchAll(options?: {
+    force?: boolean
+    skipCustomProviders?: boolean
+  }): Promise<void> {
+    // Why: decoupled from the fixed-provider reentrancy/queueing below (own
+    // generation guard handles overlap) but still triggered by the same
+    // coordinator on every poll tick / forced refresh, per review (#codex).
+    // skipCustomProviders lets a paired/remote/mobile-triggered refresh reach
+    // the fixed providers without also causing the host to resolve a
+    // tokenEnvVar secret and hit a user-configured endpoint on its behalf.
+    if (!options?.skipCustomProviders) {
+      void this.fetchCustomProviders()
+    }
     if (this.isFetching) {
       if (options?.force) {
         this.fullFetchQueued = true

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1257,10 +1257,24 @@ export type RemoteTrackingBase = {
   base: string
 }
 
+// Why: user-defined custom-provider usage is desktop-only by design — a
+// paired/remote/mobile client must not be able to read it.
+export type RemoteAccountsRateLimitState = Omit<RateLimitState, 'customProviderUsage'>
+
+// Why: every RateLimitState-shaped value that crosses the accounts.* RPC
+// boundary (the initial accounts.list/subscribe snapshot, the ongoing
+// subscribe push on every state change, and consumeCodexResetCredit's
+// snapshot) must go through this same strip — see RemoteAccountsRateLimitState.
+function stripCustomProviderUsageForRemote(state: RateLimitState): RemoteAccountsRateLimitState {
+  const { customProviderUsage: _customProviderUsage, ...remoteState } = state
+  void _customProviderUsage
+  return remoteState
+}
+
 export type AccountsSnapshot = {
   claude: ClaudeRateLimitAccountsState
   codex: CodexRateLimitAccountsState
-  rateLimits: RateLimitState
+  rateLimits: RemoteAccountsRateLimitState
 }
 
 export type CodexRateLimitResetRpcResult = {
@@ -1358,6 +1372,7 @@ type RuntimeStore = {
     compactWorktreeCards?: GlobalSettings['compactWorktreeCards']
     minimaxGroupId?: GlobalSettings['minimaxGroupId']
     minimaxUsageModels?: GlobalSettings['minimaxUsageModels']
+    customProviderAccounts?: GlobalSettings['customProviderAccounts']
     prBotAuthorOverrides?: GlobalSettings['prBotAuthorOverrides']
     artifactSharingEnabled?: GlobalSettings['artifactSharingEnabled']
     agentSkillSharingEnabled?: GlobalSettings['agentSkillSharingEnabled']
@@ -14803,7 +14818,7 @@ export class OrcaRuntimeService {
     return {
       claude: claudeAccounts.listAccounts(),
       codex: codexAccounts.listAccounts(),
-      rateLimits: rateLimits.getState()
+      rateLimits: stripCustomProviderUsageForRemote(rateLimits.getState())
     }
   }
 
@@ -14815,7 +14830,11 @@ export class OrcaRuntimeService {
   async refreshAccountsForMobile(): Promise<void> {
     const { rateLimits } = this.requireAccountServices()
     await Promise.allSettled([
-      rateLimits.refresh(),
+      // Why: a paired/remote/mobile-triggered refresh must never be the
+      // proximate cause of the host resolving a custom provider's tokenEnvVar
+      // secret and hitting its configured endpoint — see
+      // RemoteAccountsRateLimitState.
+      rateLimits.refresh({ skipCustomProviders: true }),
       rateLimits.fetchInactiveClaudeAccountsOnOpen(),
       rateLimits.fetchInactiveCodexAccountsOnOpen()
     ])
@@ -14826,7 +14845,7 @@ export class OrcaRuntimeService {
   async refreshAccountsForMobileSubscriber(): Promise<void> {
     const { rateLimits } = this.requireAccountServices()
     await Promise.allSettled([
-      rateLimits.refreshIfStale(),
+      rateLimits.refreshIfStale({ skipCustomProviders: true }),
       rateLimits.fetchInactiveClaudeAccountsOnOpen(),
       rateLimits.fetchInactiveCodexAccountsOnOpen()
     ])
@@ -14858,7 +14877,7 @@ export class OrcaRuntimeService {
     const snapshot = {
       claude: claudeAccounts.listAccounts(),
       codex: result.codex,
-      rateLimits: result.rateLimits
+      rateLimits: stripCustomProviderUsageForRemote(result.rateLimits)
     }
     if ('status' in result) {
       return {
@@ -14919,7 +14938,7 @@ export class OrcaRuntimeService {
       listener({
         claude: services.claudeAccounts.listAccounts(),
         codex: services.codexAccounts.listAccounts(),
-        rateLimits
+        rateLimits: stripCustomProviderUsageForRemote(rateLimits)
       })
     })
   }

--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -79,6 +79,7 @@ const WorkspaceStatusDefinition = z.object({
   color: z.string().optional(),
   icon: z.string().optional()
 })
+
 const FeatureInteractionRecord = z
   .object({
     firstInteractedAt: z.number().finite().nonnegative(),

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -4,7 +4,8 @@ import type {
   CodexAccountsApi,
   CodexConfigSyncApi,
   GrokAccountsApi,
-  MinimaxCredentialsApi
+  MinimaxCredentialsApi,
+  CustomProviderAccountsApi
 } from './api/agent-account-api'
 import type { AgentHooksApi, HooksApi } from './api/agent-hook-api'
 import type { SkillsApi } from './api/agent-skill-api'
@@ -139,6 +140,7 @@ export type PreloadApi = {
   runtimeEnvironments: RuntimeApi['runtimeEnvironments']
   rateLimits: RateLimitsApi
   minimaxCredentials: MinimaxCredentialsApi
+  customProviderAccounts: CustomProviderAccountsApi
   grokAccounts: GrokAccountsApi
   ssh: SshApi
   automations: AutomationsApi

--- a/src/preload/api/agent-account-api.ts
+++ b/src/preload/api/agent-account-api.ts
@@ -4,6 +4,10 @@ import type {
 } from '../../shared/managed-account-types'
 import type { CodexConfigSyncStatus } from '../../shared/codex-config-sync-types'
 import type { GrokAccountStatus } from '../../shared/rate-limit-types'
+import type {
+  CustomProviderAccount,
+  CustomProviderUsageResult
+} from '../../shared/custom-provider-types'
 
 export type CodexAccountsApi = {
   list: () => Promise<CodexRateLimitAccountsState>
@@ -66,4 +70,11 @@ export type MinimaxCredentialsApi = {
 
 export type CodexConfigSyncApi = {
   status: () => Promise<CodexConfigSyncStatus>
+}
+
+export type CustomProviderAccountsApi = {
+  getTokenStatus: (accountId: string) => Promise<{ configured: boolean }>
+  saveToken: (accountId: string, token: string) => Promise<{ configured: boolean }>
+  clearToken: (accountId: string) => Promise<{ configured: boolean }>
+  testDraft: (account: CustomProviderAccount, token: string) => Promise<CustomProviderUsageResult>
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -195,6 +195,10 @@ import type {
   RateLimitRuntimeTarget,
   RateLimitState
 } from '../shared/rate-limit-types'
+import type {
+  CustomProviderAccount,
+  CustomProviderUsageResult
+} from '../shared/custom-provider-types'
 import type { WorkspaceSpaceScanProgress } from '../shared/workspace-space-types'
 import type { WorkspaceCleanupScanProgress } from '../shared/workspace-cleanup'
 import type { WorkspacePortAdvertisedUrlChangedEvent } from '../shared/workspace-ports'
@@ -4681,6 +4685,20 @@ const api = {
       ipcRenderer.invoke('minimaxCredentials:saveCookie', cookie),
     clearCookie: (): Promise<{ configured: boolean }> =>
       ipcRenderer.invoke('minimaxCredentials:clearCookie')
+  },
+
+  customProviderAccounts: {
+    getTokenStatus: (accountId: string): Promise<{ configured: boolean }> =>
+      ipcRenderer.invoke('customProviderAccounts:getTokenStatus', accountId),
+    saveToken: (accountId: string, token: string): Promise<{ configured: boolean }> =>
+      ipcRenderer.invoke('customProviderAccounts:saveToken', { accountId, token }),
+    clearToken: (accountId: string): Promise<{ configured: boolean }> =>
+      ipcRenderer.invoke('customProviderAccounts:clearToken', accountId),
+    testDraft: (
+      account: CustomProviderAccount,
+      token: string
+    ): Promise<CustomProviderUsageResult> =>
+      ipcRenderer.invoke('customProviderAccounts:testDraft', { account, token })
   },
 
   grokAccounts: {

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -45,6 +45,7 @@ import { toast } from 'sonner'
 import {
   getAccountsClaudeSearchEntries,
   getAccountsCodexSearchEntries,
+  getAccountsCustomProviderSearchEntries,
   getAccountsGeminiSearchEntries,
   getAccountsLocationSearchEntries,
   getAccountsGrokSearchEntries,
@@ -1987,7 +1988,9 @@ export function AccountsPane({
     matchesSettingsSearch(searchQuery, getAccountsGrokSearchEntries()) ? (
       <GrokAccountsSection key="grok" />
     ) : null,
-    <CustomProviderAccountsSection key="custom-providers" />
+    matchesSettingsSearch(searchQuery, getAccountsCustomProviderSearchEntries()) ? (
+      <CustomProviderAccountsSection key="custom-providers" />
+    ) : null
   ].filter(Boolean)
 
   return (

--- a/src/renderer/src/components/settings/AccountsPane.tsx
+++ b/src/renderer/src/components/settings/AccountsPane.tsx
@@ -53,6 +53,7 @@ import {
   getAccountsPaneSearchEntries
 } from './accounts-search'
 import { GrokAccountsSection } from './GrokAccountsSection'
+import { CustomProviderAccountsSection } from './CustomProviderAccountsSection'
 import { getRemoteAccountsPaneScope } from './provider-account-scope'
 import { ProviderHostScopeControl } from './ProviderHostScopeControl'
 import { SearchableSetting } from './SearchableSetting'
@@ -1985,7 +1986,8 @@ export function AccountsPane({
     ) : null,
     matchesSettingsSearch(searchQuery, getAccountsGrokSearchEntries()) ? (
       <GrokAccountsSection key="grok" />
-    ) : null
+    ) : null,
+    <CustomProviderAccountsSection key="custom-providers" />
   ].filter(Boolean)
 
   return (

--- a/src/renderer/src/components/settings/CustomProviderAccountCard.tsx
+++ b/src/renderer/src/components/settings/CustomProviderAccountCard.tsx
@@ -1,0 +1,138 @@
+import { Loader2, Pencil, Trash2 } from 'lucide-react'
+import type {
+  CustomProviderAccount,
+  CustomProviderUsageResult
+} from '../../../../shared/custom-provider-types'
+import { Button } from '../ui/button'
+import { Switch } from '../ui/switch'
+import { getCustomProviderIconOption } from './custom-provider-icon-options'
+import { translate } from '@/i18n/i18n'
+
+type CustomProviderAccountCardProps = {
+  account: CustomProviderAccount
+  usage: CustomProviderUsageResult | undefined
+  busy: boolean
+  onToggleEnabled: (account: CustomProviderAccount, enabled: boolean) => void
+  onEdit: (account: CustomProviderAccount) => void
+  onRemove: (account: CustomProviderAccount) => void
+}
+
+function usageSummary(
+  account: CustomProviderAccount,
+  usage: CustomProviderUsageResult | undefined
+): { text: string; tone: 'ok' | 'error' | 'muted' } {
+  if (!account.enabled) {
+    return {
+      text: translate('auto.components.settings.CustomProviderAccountCard.disabled', 'Disabled'),
+      tone: 'muted'
+    }
+  }
+  if (!usage) {
+    return {
+      text: translate(
+        'auto.components.settings.CustomProviderAccountCard.pending',
+        'Not fetched yet'
+      ),
+      tone: 'muted'
+    }
+  }
+  if (usage.status === 'fetching') {
+    return {
+      text: translate('auto.components.settings.CustomProviderAccountCard.fetching', 'Fetching…'),
+      tone: 'muted'
+    }
+  }
+  if (usage.usedPercent != null) {
+    const stale = usage.status !== 'ok'
+    const percent = `${Math.round(usage.usedPercent)}%`
+    return {
+      text: stale
+        ? translate(
+            'auto.components.settings.CustomProviderAccountCard.staleSuffix',
+            '{{value0}} (stale)',
+            {
+              value0: percent
+            }
+          )
+        : percent,
+      tone: stale ? 'error' : 'ok'
+    }
+  }
+  return {
+    text:
+      usage.error ?? translate('auto.components.settings.CustomProviderAccountCard.error', 'Error'),
+    tone: 'error'
+  }
+}
+
+export function CustomProviderAccountCard({
+  account,
+  usage,
+  busy,
+  onToggleEnabled,
+  onEdit,
+  onRemove
+}: CustomProviderAccountCardProps): React.JSX.Element {
+  const { Icon } = getCustomProviderIconOption(account.icon)
+  const summary = usageSummary(account, usage)
+
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-border/50 bg-card/40 px-4 py-3">
+      <Icon className="size-4 shrink-0 text-muted-foreground" />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-sm font-medium">{account.displayName}</span>
+          <span
+            className={
+              summary.tone === 'ok'
+                ? 'text-[11px] text-emerald-500'
+                : summary.tone === 'error'
+                  ? 'text-[11px] text-red-400'
+                  : 'text-[11px] text-muted-foreground'
+            }
+          >
+            {summary.text}
+          </span>
+        </div>
+        <p className="truncate text-xs text-muted-foreground">{account.usageUrl}</p>
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        <Switch
+          checked={account.enabled}
+          disabled={busy}
+          onCheckedChange={(checked) => onToggleEnabled(account, checked)}
+          aria-label={translate(
+            'auto.components.settings.CustomProviderAccountCard.toggleAria',
+            'Enable {{value0}}',
+            { value0: account.displayName }
+          )}
+        />
+        <Button
+          variant="ghost"
+          size="xs"
+          onClick={() => onEdit(account)}
+          disabled={busy}
+          aria-label={translate(
+            'auto.components.settings.CustomProviderAccountCard.editAria',
+            'Edit'
+          )}
+        >
+          {busy ? <Loader2 className="size-3 animate-spin" /> : <Pencil className="size-3" />}
+        </Button>
+        <Button
+          variant="ghost"
+          size="xs"
+          onClick={() => onRemove(account)}
+          disabled={busy}
+          className="text-muted-foreground hover:text-destructive"
+          aria-label={translate(
+            'auto.components.settings.CustomProviderAccountCard.removeAria',
+            'Remove'
+          )}
+        >
+          <Trash2 className="size-3" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/CustomProviderAccountCard.tsx
+++ b/src/renderer/src/components/settings/CustomProviderAccountCard.tsx
@@ -85,9 +85,9 @@ export function CustomProviderAccountCard({
           <span
             className={
               summary.tone === 'ok'
-                ? 'text-[11px] text-emerald-500'
+                ? 'text-[11px] text-status-success'
                 : summary.tone === 'error'
-                  ? 'text-[11px] text-red-400'
+                  ? 'text-[11px] text-destructive'
                   : 'text-[11px] text-muted-foreground'
             }
           >
@@ -101,11 +101,19 @@ export function CustomProviderAccountCard({
           checked={account.enabled}
           disabled={busy}
           onCheckedChange={(checked) => onToggleEnabled(account, checked)}
-          aria-label={translate(
-            'auto.components.settings.CustomProviderAccountCard.toggleAria',
-            'Enable {{value0}}',
-            { value0: account.displayName }
-          )}
+          aria-label={
+            account.enabled
+              ? translate(
+                  'auto.components.settings.CustomProviderAccountCard.disableAria',
+                  'Disable {{value0}}',
+                  { value0: account.displayName }
+                )
+              : translate(
+                  'auto.components.settings.CustomProviderAccountCard.toggleAria',
+                  'Enable {{value0}}',
+                  { value0: account.displayName }
+                )
+          }
         />
         <Button
           variant="ghost"

--- a/src/renderer/src/components/settings/CustomProviderAccountForm.tsx
+++ b/src/renderer/src/components/settings/CustomProviderAccountForm.tsx
@@ -1,0 +1,419 @@
+import { Loader2, Plus, X } from 'lucide-react'
+import { Button } from '../ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '../ui/dialog'
+import { Input } from '../ui/input'
+import { Label } from '../ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import { getCustomProviderIconOptions } from './custom-provider-icon-options'
+import { CustomProviderJsonPanel } from './CustomProviderJsonPanel'
+import type { CustomProviderDraft } from './custom-provider-draft'
+import type { CustomProviderUsageResult } from '../../../../shared/custom-provider-types'
+import { translate } from '@/i18n/i18n'
+
+type CustomProviderAccountFormProps = {
+  open: boolean
+  isEditing: boolean
+  form: CustomProviderDraft
+  saving: boolean
+  testing: boolean
+  testResult: CustomProviderUsageResult | null
+  onFormChange: (updater: (prev: CustomProviderDraft) => CustomProviderDraft) => void
+  onTest: () => void
+  onSave: () => void
+  onOpenChange: (open: boolean) => void
+}
+
+export function CustomProviderAccountForm({
+  open,
+  isEditing,
+  form,
+  saving,
+  testing,
+  testResult,
+  onFormChange,
+  onTest,
+  onSave,
+  onOpenChange
+}: CustomProviderAccountFormProps): React.JSX.Element {
+  // Why: progressive disclosure (usability review) — the mapping-mode fields,
+  // which most users will never need to think hard about, stay hidden until
+  // the basics are filled in. Deliberately independent of the token field —
+  // a preset (or a user typing the URL first) should surface the filled-in
+  // mapping right away, without also requiring a token just to see it.
+  const basicsComplete = Boolean(form.displayName.trim() && form.usageUrl.trim() && form.icon)
+  const canTest = Boolean(
+    form.displayName.trim() &&
+    form.usageUrl.trim().startsWith('https://') &&
+    (form.token.trim() || form.tokenEnvVar.trim()) &&
+    (form.mappingMode === 'percent'
+      ? form.percentPath.trim()
+      : form.usedPaths.some((p) => p.trim()) && form.limitPath.trim())
+  )
+  // Why: mandatory test-before-save (usability review, top priority) — Save
+  // stays disabled until the current draft has a fresh successful test.
+  const canSave = testResult?.status === 'ok'
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="flex max-h-[calc(100vh-3rem)] flex-col gap-0 overflow-hidden p-0 sm:max-w-lg">
+        <form
+          className="flex min-h-0 flex-1 flex-col"
+          onSubmit={(e) => {
+            e.preventDefault()
+            if (!saving && canSave) {
+              onSave()
+            }
+          }}
+        >
+          <DialogHeader className="shrink-0 gap-1.5 border-b border-border/60 px-6 pt-6 pr-12 pb-4 text-left">
+            <DialogTitle>
+              {isEditing
+                ? translate(
+                    'auto.components.settings.CustomProviderAccountForm.editTitle',
+                    'Edit custom provider'
+                  )
+                : translate(
+                    'auto.components.settings.CustomProviderAccountForm.addTitle',
+                    'Add custom provider'
+                  )}
+            </DialogTitle>
+            <DialogDescription>
+              {translate(
+                'auto.components.settings.CustomProviderAccountForm.description',
+                'Point Orca at an internal usage-tracking endpoint. No credentials leave this device except to the URL you enter.'
+              )}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-6 py-4 scrollbar-sleek">
+            <div className="space-y-1.5">
+              <Label htmlFor="cp-name">
+                {translate('auto.components.settings.CustomProviderAccountForm.name', 'Name')}
+              </Label>
+              <Input
+                id="cp-name"
+                autoFocus
+                value={form.displayName}
+                onChange={(e) => onFormChange((f) => ({ ...f, displayName: e.target.value }))}
+                placeholder={translate(
+                  'auto.components.settings.CustomProviderAccountForm.namePlaceholder',
+                  'Internal Gateway'
+                )}
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label>
+                {translate('auto.components.settings.CustomProviderAccountForm.icon', 'Icon')}
+              </Label>
+              <div className="flex flex-wrap gap-1.5">
+                {getCustomProviderIconOptions().map(({ id, label, Icon }) => (
+                  <button
+                    key={id}
+                    type="button"
+                    title={label}
+                    onClick={() => onFormChange((f) => ({ ...f, icon: id }))}
+                    className={`flex size-8 items-center justify-center rounded-md border ${
+                      form.icon === id
+                        ? 'border-primary bg-primary/10'
+                        : 'border-border/50 hover:bg-accent/50'
+                    }`}
+                  >
+                    <Icon className="size-4" />
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="cp-url">
+                {translate('auto.components.settings.CustomProviderAccountForm.url', 'Usage URL')}
+              </Label>
+              <Input
+                id="cp-url"
+                value={form.usageUrl}
+                onChange={(e) => onFormChange((f) => ({ ...f, usageUrl: e.target.value }))}
+                placeholder={translate(
+                  'auto.components.settings.CustomProviderAccountForm.urlPlaceholder',
+                  'https://internal.example.com/usage?year={yyyy}&month={mm}&day={dd}'
+                )}
+                spellCheck={false}
+              />
+              <p className="text-[11px] text-muted-foreground">
+                {translate(
+                  'auto.components.settings.CustomProviderAccountForm.urlHelp',
+                  // Why: {yyyy}/{mm}/{dd} placeholders substitute today's UTC date before
+                  // every call — kept a small, documented grammar, not a full templating engine.
+                  'Supports {yyyy}/{mm}/{dd} placeholders, replaced with today’s UTC date on every call.'
+                )}
+              </p>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="cp-token">
+                {translate(
+                  'auto.components.settings.CustomProviderAccountForm.token',
+                  'Bearer token'
+                )}
+              </Label>
+              <Input
+                id="cp-token"
+                type="password"
+                value={form.token}
+                onChange={(e) => onFormChange((f) => ({ ...f, token: e.target.value }))}
+                placeholder={
+                  isEditing
+                    ? translate(
+                        'auto.components.settings.CustomProviderAccountForm.tokenEditPlaceholder',
+                        'Leave blank to keep the existing token'
+                      )
+                    : translate(
+                        'auto.components.settings.CustomProviderAccountForm.tokenPlaceholder',
+                        'Bearer …'
+                      )
+                }
+                spellCheck={false}
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="cp-token-env-var">
+                {translate(
+                  'auto.components.settings.CustomProviderAccountForm.tokenEnvVar',
+                  'Token env var (optional)'
+                )}
+              </Label>
+              <Input
+                id="cp-token-env-var"
+                value={form.tokenEnvVar}
+                onChange={(e) => onFormChange((f) => ({ ...f, tokenEnvVar: e.target.value }))}
+                placeholder={translate(
+                  'auto.components.settings.CustomProviderAccountForm.tokenEnvVarPlaceholder',
+                  'MY_INTERNAL_API_KEY'
+                )}
+                spellCheck={false}
+              />
+              <p className="text-[11px] text-muted-foreground">
+                {translate(
+                  'auto.components.settings.CustomProviderAccountForm.tokenEnvVarHelp',
+                  'If this environment variable has a value on this machine, it is used instead of the Bearer token above — re-checked on every refresh.'
+                )}
+              </p>
+            </div>
+
+            {basicsComplete ? (
+              <>
+                <div className="space-y-1.5">
+                  <Label>
+                    {translate(
+                      'auto.components.settings.CustomProviderAccountForm.mappingMode',
+                      'Response mapping'
+                    )}
+                  </Label>
+                  <Select
+                    value={form.mappingMode}
+                    onValueChange={(value) =>
+                      onFormChange((f) => ({
+                        ...f,
+                        mappingMode: value as CustomProviderDraft['mappingMode']
+                      }))
+                    }
+                  >
+                    <SelectTrigger size="sm" className="w-full">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="percent">
+                        {translate(
+                          'auto.components.settings.CustomProviderAccountForm.percentMode',
+                          'Percent field (0-100)'
+                        )}
+                      </SelectItem>
+                      <SelectItem value="used-limit">
+                        {translate(
+                          'auto.components.settings.CustomProviderAccountForm.usedLimitMode',
+                          'Used / limit fields'
+                        )}
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                {form.mappingMode === 'percent' ? (
+                  <div className="space-y-1.5">
+                    <Label htmlFor="cp-percent-path">
+                      {translate(
+                        'auto.components.settings.CustomProviderAccountForm.percentPath',
+                        'Percent path'
+                      )}
+                    </Label>
+                    <Input
+                      id="cp-percent-path"
+                      value={form.percentPath}
+                      onChange={(e) => onFormChange((f) => ({ ...f, percentPath: e.target.value }))}
+                      placeholder={translate(
+                        'auto.components.settings.CustomProviderAccountForm.percentPathPlaceholder',
+                        'usage.percent'
+                      )}
+                      spellCheck={false}
+                    />
+                  </div>
+                ) : (
+                  <>
+                    <div className="space-y-1.5">
+                      <Label>
+                        {translate(
+                          'auto.components.settings.CustomProviderAccountForm.usedPaths',
+                          'Used-value paths (summed)'
+                        )}
+                      </Label>
+                      {form.usedPaths.map((path, index) => (
+                        <div key={index} className="flex gap-1.5">
+                          <Input
+                            value={path}
+                            onChange={(e) =>
+                              onFormChange((f) => ({
+                                ...f,
+                                usedPaths: f.usedPaths.map((p, i) =>
+                                  i === index ? e.target.value : p
+                                )
+                              }))
+                            }
+                            placeholder={translate(
+                              'auto.components.settings.CustomProviderAccountForm.usedPathPlaceholder',
+                              'summary.totalInputTokens'
+                            )}
+                            spellCheck={false}
+                          />
+                          {form.usedPaths.length > 1 ? (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="xs"
+                              onClick={() =>
+                                onFormChange((f) => ({
+                                  ...f,
+                                  usedPaths: f.usedPaths.filter((_, i) => i !== index)
+                                }))
+                              }
+                            >
+                              <X className="size-3" />
+                            </Button>
+                          ) : null}
+                        </div>
+                      ))}
+                      {form.usedPaths.length < 4 ? (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="xs"
+                          className="gap-1.5"
+                          onClick={() =>
+                            onFormChange((f) => ({ ...f, usedPaths: [...f.usedPaths, ''] }))
+                          }
+                        >
+                          <Plus className="size-3" />
+                          {translate(
+                            'auto.components.settings.CustomProviderAccountForm.addPath',
+                            'Add another'
+                          )}
+                        </Button>
+                      ) : null}
+                    </div>
+                    <div className="space-y-1.5">
+                      <Label htmlFor="cp-limit-path">
+                        {translate(
+                          'auto.components.settings.CustomProviderAccountForm.limitPath',
+                          'Limit path'
+                        )}
+                      </Label>
+                      <Input
+                        id="cp-limit-path"
+                        value={form.limitPath}
+                        onChange={(e) => onFormChange((f) => ({ ...f, limitPath: e.target.value }))}
+                        placeholder={translate(
+                          'auto.components.settings.CustomProviderAccountForm.limitPathPlaceholder',
+                          'totalDailyLimit'
+                        )}
+                        spellCheck={false}
+                      />
+                    </div>
+                  </>
+                )}
+
+                <div className="space-y-2 rounded-lg border border-border/60 bg-muted/20 p-3">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="xs"
+                    className="gap-1.5"
+                    disabled={!canTest || testing}
+                    onClick={onTest}
+                  >
+                    {testing ? <Loader2 className="size-3 animate-spin" /> : null}
+                    {translate(
+                      'auto.components.settings.CustomProviderAccountForm.test',
+                      'Test & Preview'
+                    )}
+                  </Button>
+                  {testResult ? (
+                    testResult.status === 'ok' ? (
+                      <p className="text-xs text-emerald-500">
+                        {translate(
+                          'auto.components.settings.CustomProviderAccountForm.testOk',
+                          'Success — {{value0}}%',
+                          { value0: Math.round(testResult.usedPercent ?? 0) }
+                        )}
+                      </p>
+                    ) : (
+                      <p className="text-xs text-red-400 [overflow-wrap:anywhere]">
+                        {testResult.error ??
+                          translate(
+                            'auto.components.settings.CustomProviderAccountForm.testFailed',
+                            'Test failed'
+                          )}
+                      </p>
+                    )
+                  ) : (
+                    <p className="text-[11px] text-muted-foreground">
+                      {translate(
+                        'auto.components.settings.CustomProviderAccountForm.testRequired',
+                        'A successful test is required before saving.'
+                      )}
+                    </p>
+                  )}
+                </div>
+              </>
+            ) : null}
+
+            <CustomProviderJsonPanel form={form} onFormChange={onFormChange} />
+          </div>
+
+          <DialogFooter className="shrink-0 gap-2 border-t border-border/60 bg-muted/10 px-6 py-4 sm:justify-end">
+            <Button type="button" variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+              {translate('auto.components.settings.CustomProviderAccountForm.cancel', 'Cancel')}
+            </Button>
+            <Button type="submit" size="sm" disabled={saving || !canSave}>
+              {isEditing
+                ? translate(
+                    'auto.components.settings.CustomProviderAccountForm.saveChanges',
+                    'Save Changes'
+                  )
+                : translate(
+                    'auto.components.settings.CustomProviderAccountForm.addAccount',
+                    'Add Account'
+                  )}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/settings/CustomProviderAccountsSection.tsx
+++ b/src/renderer/src/components/settings/CustomProviderAccountsSection.tsx
@@ -1,0 +1,305 @@
+import { useRef, useState } from 'react'
+import { toast } from 'sonner'
+import { Plus } from 'lucide-react'
+import { useAppStore } from '@/store'
+import { useMountedRef } from '@/hooks/useMountedRef'
+import { Button } from '../ui/button'
+import { CustomProviderAccountCard } from './CustomProviderAccountCard'
+import { CustomProviderAccountForm } from './CustomProviderAccountForm'
+import {
+  buildCustomProviderAccount,
+  EMPTY_CUSTOM_PROVIDER_DRAFT,
+  getEditingDraftForAccount,
+  validateCustomProviderDraft,
+  type CustomProviderDraft
+} from './custom-provider-draft'
+import type {
+  CustomProviderAccount,
+  CustomProviderUsageResult
+} from '../../../../shared/custom-provider-types'
+import { translate } from '@/i18n/i18n'
+
+function makeAccountId(): string {
+  return `custom-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+// Why: a stable module-level reference so the selector below never returns a
+// fresh array on every store write when settings hasn't hydrated yet.
+const EMPTY_CUSTOM_PROVIDER_ACCOUNTS: CustomProviderAccount[] = []
+
+export function CustomProviderAccountsSection(): React.JSX.Element {
+  const accounts = useAppStore(
+    (s) => s.settings?.customProviderAccounts ?? EMPTY_CUSTOM_PROVIDER_ACCOUNTS
+  )
+  const updateSettings = useAppStore((s) => s.updateSettings)
+  const refreshRateLimits = useAppStore((s) => s.refreshRateLimits)
+  const usageByAccountId = useAppStore((s) => s.rateLimits.customProviderUsage)
+  const recordFeatureInteraction = useAppStore((s) => s.recordFeatureInteraction)
+  const mountedRef = useMountedRef()
+
+  const [showForm, setShowForm] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [form, setForm] = useState<CustomProviderDraft>(EMPTY_CUSTOM_PROVIDER_DRAFT)
+  const [saving, setSaving] = useState(false)
+  const [testing, setTesting] = useState(false)
+  const [testResult, setTestResult] = useState<CustomProviderUsageResult | null>(null)
+  const [busyId, setBusyId] = useState<string | null>(null)
+  // Why: bumped on every form edit so a testDraft response that resolves
+  // AFTER a later edit (the response races the edit, not just the request)
+  // is discarded instead of re-enabling Save for a draft it never tested.
+  const testGenerationRef = useRef(0)
+
+  const openAddForm = (): void => {
+    setEditingId(null)
+    setForm(EMPTY_CUSTOM_PROVIDER_DRAFT)
+    setTestResult(null)
+    testGenerationRef.current += 1
+    setShowForm(true)
+  }
+
+  const handleEdit = (account: CustomProviderAccount): void => {
+    setEditingId(account.id)
+    setForm(getEditingDraftForAccount(account))
+    // Why: an existing entry was validated when first saved — re-testing is
+    // only required if the user actually changes something below.
+    setTestResult({
+      accountId: account.id,
+      usedPercent: 0,
+      resetsAt: null,
+      updatedAt: 0,
+      error: null,
+      status: 'ok'
+    })
+    testGenerationRef.current += 1
+    setShowForm(true)
+  }
+
+  const handleFormChange = (updater: (prev: CustomProviderDraft) => CustomProviderDraft): void => {
+    setForm((prev) => updater(prev))
+    // Why: any edit invalidates a prior successful test — Save must not trust
+    // a test that ran against different field values.
+    setTestResult(null)
+    testGenerationRef.current += 1
+  }
+
+  const handleTest = async (): Promise<void> => {
+    const generation = testGenerationRef.current
+    const editing = editingId ? accounts.find((a) => a.id === editingId) : null
+    const draftAccount = {
+      id: editing?.id ?? 'draft',
+      createdAt: editing?.createdAt ?? Date.now(),
+      ...buildCustomProviderAccount(form, editing ?? null)
+    }
+    setTesting(true)
+    try {
+      const result = await window.api.customProviderAccounts.testDraft(
+        draftAccount,
+        form.token.trim()
+      )
+      if (mountedRef.current && generation === testGenerationRef.current) {
+        setTestResult(result)
+      }
+    } catch (err) {
+      if (mountedRef.current && generation === testGenerationRef.current) {
+        setTestResult({
+          accountId: draftAccount.id,
+          usedPercent: null,
+          resetsAt: null,
+          updatedAt: Date.now(),
+          error: err instanceof Error ? err.message : 'Test failed',
+          status: 'error'
+        })
+      }
+    } finally {
+      if (mountedRef.current) {
+        setTesting(false)
+      }
+    }
+  }
+
+  const handleSave = async (): Promise<void> => {
+    const validation = validateCustomProviderDraft(form, accounts, editingId)
+    if (!validation.ok) {
+      toast.error(validation.error)
+      return
+    }
+    if (saving) {
+      return
+    }
+    setSaving(true)
+    try {
+      const editing = editingId ? accounts.find((a) => a.id === editingId) : null
+      const id = editing?.id ?? makeAccountId()
+      const account: CustomProviderAccount = {
+        id,
+        createdAt: editing?.createdAt ?? Date.now(),
+        ...buildCustomProviderAccount(form, editing ?? null)
+      }
+      const nextAccounts = editing
+        ? accounts.map((a) => (a.id === id ? account : a))
+        : [...accounts, account]
+      await updateSettings({ customProviderAccounts: nextAccounts })
+      if (form.token.trim()) {
+        await window.api.customProviderAccounts.saveToken(id, form.token.trim())
+      } else {
+        // Why: saveToken's IPC handler is what wakes the main-process poll
+        // loop today — an env-var-only account (no Bearer token typed) would
+        // otherwise sit at "Not fetched yet" until the next scheduled poll.
+        void refreshRateLimits()
+      }
+      recordFeatureInteraction('usage-tracking')
+      if (!mountedRef.current) {
+        return
+      }
+      toast.success(
+        editing
+          ? translate(
+              'auto.components.settings.CustomProviderAccountsSection.updated',
+              'Provider updated'
+            )
+          : translate(
+              'auto.components.settings.CustomProviderAccountsSection.added',
+              'Provider added'
+            )
+      )
+      setShowForm(false)
+      setEditingId(null)
+      setForm(EMPTY_CUSTOM_PROVIDER_DRAFT)
+    } catch (err) {
+      if (mountedRef.current) {
+        toast.error(
+          err instanceof Error
+            ? err.message
+            : translate(
+                'auto.components.settings.CustomProviderAccountsSection.saveFailed',
+                'Failed to save provider'
+              )
+        )
+      }
+    } finally {
+      if (mountedRef.current) {
+        setSaving(false)
+      }
+    }
+  }
+
+  const handleToggleEnabled = async (
+    account: CustomProviderAccount,
+    enabled: boolean
+  ): Promise<void> => {
+    setBusyId(account.id)
+    try {
+      await updateSettings({
+        customProviderAccounts: accounts.map((a) => (a.id === account.id ? { ...a, enabled } : a))
+      })
+      // Why: re-enabling would otherwise show stale/no usage until the next poll.
+      void refreshRateLimits()
+    } finally {
+      if (mountedRef.current) {
+        setBusyId(null)
+      }
+    }
+  }
+
+  const handleRemove = async (account: CustomProviderAccount): Promise<void> => {
+    setBusyId(account.id)
+    try {
+      await updateSettings({ customProviderAccounts: accounts.filter((a) => a.id !== account.id) })
+      await window.api.customProviderAccounts.clearToken(account.id)
+      if (mountedRef.current) {
+        toast.success(
+          translate(
+            'auto.components.settings.CustomProviderAccountsSection.removed',
+            'Provider removed'
+          )
+        )
+      }
+    } catch (err) {
+      if (mountedRef.current) {
+        toast.error(
+          err instanceof Error
+            ? err.message
+            : translate(
+                'auto.components.settings.CustomProviderAccountsSection.removeFailed',
+                'Failed to remove provider'
+              )
+        )
+      }
+    } finally {
+      if (mountedRef.current) {
+        setBusyId(null)
+      }
+    }
+  }
+
+  return (
+    <section
+      key="custom-providers"
+      id="accounts-custom-providers"
+      className="space-y-4 scroll-mt-6"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="space-y-0.5">
+          <h3 className="text-sm font-semibold">
+            {translate(
+              'auto.components.settings.CustomProviderAccountsSection.title',
+              'Custom Providers'
+            )}
+          </h3>
+          <p className="text-xs text-muted-foreground">
+            {translate(
+              'auto.components.settings.CustomProviderAccountsSection.description',
+              'Add an internal usage-tracking endpoint to show its usage in the status bar.'
+            )}
+          </p>
+        </div>
+        <Button variant="outline" size="xs" className="gap-1.5" onClick={openAddForm}>
+          <Plus className="size-3" />
+          {translate('auto.components.settings.CustomProviderAccountsSection.add', 'Add Provider')}
+        </Button>
+      </div>
+
+      {accounts.length === 0 ? (
+        <div className="flex items-center justify-center rounded-lg border border-dashed border-border/60 bg-card/30 px-4 py-5 text-sm text-muted-foreground">
+          {translate(
+            'auto.components.settings.CustomProviderAccountsSection.empty',
+            'No custom providers configured.'
+          )}
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {accounts.map((account) => (
+            <CustomProviderAccountCard
+              key={account.id}
+              account={account}
+              usage={usageByAccountId[account.id]}
+              busy={busyId === account.id}
+              onToggleEnabled={(a, enabled) => void handleToggleEnabled(a, enabled)}
+              onEdit={handleEdit}
+              onRemove={(a) => void handleRemove(a)}
+            />
+          ))}
+        </div>
+      )}
+
+      <CustomProviderAccountForm
+        open={showForm}
+        isEditing={editingId != null}
+        form={form}
+        saving={saving}
+        testing={testing}
+        testResult={testResult}
+        onFormChange={handleFormChange}
+        onTest={() => void handleTest()}
+        onSave={() => void handleSave()}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen) {
+            setShowForm(false)
+            setEditingId(null)
+            setForm(EMPTY_CUSTOM_PROVIDER_DRAFT)
+          }
+        }}
+      />
+    </section>
+  )
+}

--- a/src/renderer/src/components/settings/CustomProviderAccountsSection.tsx
+++ b/src/renderer/src/components/settings/CustomProviderAccountsSection.tsx
@@ -194,6 +194,17 @@ export function CustomProviderAccountsSection(): React.JSX.Element {
       })
       // Why: re-enabling would otherwise show stale/no usage until the next poll.
       void refreshRateLimits()
+    } catch (err) {
+      if (mountedRef.current) {
+        toast.error(
+          err instanceof Error
+            ? err.message
+            : translate(
+                'auto.components.settings.CustomProviderAccountsSection.toggleFailed',
+                'Failed to update provider'
+              )
+        )
+      }
     } finally {
       if (mountedRef.current) {
         setBusyId(null)

--- a/src/renderer/src/components/settings/CustomProviderJsonPanel.tsx
+++ b/src/renderer/src/components/settings/CustomProviderJsonPanel.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useRef, useState } from 'react'
+import { Label } from '../ui/label'
+import { Textarea } from '../ui/textarea'
+import type { CustomProviderDraft } from './custom-provider-draft'
+import {
+  mergeJsonIntoDraft,
+  serializeDraftToJson,
+  validateCustomProviderJsonShape
+} from './custom-provider-json-view'
+import { translate } from '@/i18n/i18n'
+
+type CustomProviderJsonPanelProps = {
+  form: CustomProviderDraft
+  onFormChange: (updater: (prev: CustomProviderDraft) => CustomProviderDraft) => void
+}
+
+// Why: two-way bound raw-JSON <-> structured-form editor. Field edits (or a
+// preset click) re-serialize into this box live; typing valid JSON here
+// flows back into the fields (and the icon picker above) live. The ref
+// suppresses the form->JSON resync for exactly the tick our own edit caused,
+// so we never fight the user's cursor/formatting mid-keystroke.
+export function CustomProviderJsonPanel({
+  form,
+  onFormChange
+}: CustomProviderJsonPanelProps): React.JSX.Element {
+  const [jsonText, setJsonText] = useState(() => serializeDraftToJson(form))
+  const [jsonError, setJsonError] = useState<string | null>(null)
+  const syncingFromJson = useRef(false)
+
+  useEffect(() => {
+    if (syncingFromJson.current) {
+      syncingFromJson.current = false
+      return
+    }
+    setJsonText(serializeDraftToJson(form))
+    setJsonError(null)
+  }, [form])
+
+  const handleChange = (text: string): void => {
+    setJsonText(text)
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(text)
+    } catch (err) {
+      setJsonError(err instanceof Error ? err.message : 'Invalid JSON')
+      return
+    }
+    const result = validateCustomProviderJsonShape(parsed)
+    if (!result.ok) {
+      setJsonError(result.error)
+      return
+    }
+    setJsonError(null)
+    syncingFromJson.current = true
+    onFormChange((prev) => mergeJsonIntoDraft(prev, result.value))
+  }
+
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor="cp-json">
+        {translate('auto.components.settings.CustomProviderJsonPanel.title', 'Config JSON')}
+      </Label>
+      <Textarea
+        id="cp-json"
+        value={jsonText}
+        onChange={(e) => handleChange(e.target.value)}
+        spellCheck={false}
+        rows={9}
+        className="font-mono text-xs"
+      />
+      {jsonError ? (
+        <p className="text-xs text-red-400 [overflow-wrap:anywhere]">{jsonError}</p>
+      ) : (
+        <p className="text-[11px] text-muted-foreground">
+          {translate(
+            'auto.components.settings.CustomProviderJsonPanel.help',
+            'Stays in sync with the fields above in both directions. The token is never shown here.'
+          )}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/accounts-search.ts
+++ b/src/renderer/src/components/settings/accounts-search.ts
@@ -212,6 +212,30 @@ export const getAccountsGrokSearchEntries = createLocalizedCatalog(() => [
   }
 ])
 
+export const getAccountsCustomProviderSearchEntries = createLocalizedCatalog(() => [
+  {
+    title: translate(
+      'auto.components.settings.accounts.search.a1c3e5f7b9',
+      'Custom AI Provider Accounts'
+    ),
+    description: translate(
+      'auto.components.settings.accounts.search.b2d4f6a8c0',
+      'Point Orca at an internal or corporate usage-tracking endpoint to show its usage in the status bar.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.accounts.search.c3e5a7b9d1', 'custom'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.9f70aa706c', 'provider'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.d4f6b8c0e2', 'endpoint'),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.e5a7c9d1f3', 'usage'),
+      ...translateSearchKeyword(
+        'auto.components.settings.accounts.search.e949b08ffb',
+        'rate limit'
+      ),
+      ...translateSearchKeyword('auto.components.settings.accounts.search.86edc96bc9', 'status bar')
+    ]
+  }
+])
+
 export const getAccountsPaneSearchEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
   ...getAccountsLocationSearchEntries(),
   ...getAccountsClaudeSearchEntries(),
@@ -219,5 +243,6 @@ export const getAccountsPaneSearchEntries = createLocalizedCatalog((): SettingsS
   ...getAccountsGeminiSearchEntries(),
   ...getAccountsOpencodeSearchEntries(),
   ...getAccountsMiniMaxSearchEntries(),
-  ...getAccountsGrokSearchEntries()
+  ...getAccountsGrokSearchEntries(),
+  ...getAccountsCustomProviderSearchEntries()
 ])

--- a/src/renderer/src/components/settings/custom-provider-draft.ts
+++ b/src/renderer/src/components/settings/custom-provider-draft.ts
@@ -1,0 +1,146 @@
+import type { CustomProviderAccount } from '../../../../shared/custom-provider-types'
+import { DEFAULT_CUSTOM_PROVIDER_ICON_ID } from './custom-provider-icon-options'
+import { translate } from '@/i18n/i18n'
+
+export type CustomProviderDraft = {
+  displayName: string
+  icon: string
+  usageUrl: string
+  token: string
+  /** If set and resolvable in the main process's env, takes priority over `token`. */
+  tokenEnvVar: string
+  mappingMode: 'percent' | 'used-limit'
+  percentPath: string
+  usedPaths: string[]
+  limitPath: string
+}
+
+export const EMPTY_CUSTOM_PROVIDER_DRAFT: CustomProviderDraft = {
+  displayName: '',
+  icon: DEFAULT_CUSTOM_PROVIDER_ICON_ID,
+  usageUrl: '',
+  token: '',
+  tokenEnvVar: '',
+  mappingMode: 'percent',
+  percentPath: '',
+  usedPaths: [''],
+  limitPath: ''
+}
+
+export function getEditingDraftForAccount(account: CustomProviderAccount): CustomProviderDraft {
+  return {
+    displayName: account.displayName,
+    icon: account.icon ?? DEFAULT_CUSTOM_PROVIDER_ICON_ID,
+    usageUrl: account.usageUrl,
+    // Why: never round-trip the saved token back into the form — same
+    // convention as MiniMax's cookie draft. Blank means "keep the existing one".
+    token: '',
+    tokenEnvVar: account.tokenEnvVar ?? '',
+    mappingMode: account.mappingMode,
+    percentPath: account.percentPath ?? '',
+    usedPaths: account.usedPaths && account.usedPaths.length > 0 ? account.usedPaths : [''],
+    limitPath: account.limitPath ?? ''
+  }
+}
+
+export type CustomProviderDraftValidation = { ok: true } | { ok: false; error: string }
+
+// Why: the wire schema (client-ui-schemas.ts) enforces this too, but only for the
+// paired-client RPC surface — the everyday local Settings save goes through the
+// unvalidated settings:set path, so the real guardrail has to live here.
+export function validateCustomProviderDraft(
+  draft: CustomProviderDraft,
+  existingAccounts: CustomProviderAccount[],
+  editingId: string | null
+): CustomProviderDraftValidation {
+  const displayName = draft.displayName.trim()
+  if (!displayName) {
+    return {
+      ok: false,
+      error: translate(
+        'auto.components.settings.customProviderDraft.nameRequired',
+        'Name is required.'
+      )
+    }
+  }
+  const nameKey = displayName.toLowerCase()
+  if (
+    existingAccounts.some(
+      (account) => account.id !== editingId && account.displayName.trim().toLowerCase() === nameKey
+    )
+  ) {
+    return {
+      ok: false,
+      error: translate(
+        'auto.components.settings.customProviderDraft.duplicateName',
+        'An account named "{{value0}}" already exists.',
+        { value0: displayName }
+      )
+    }
+  }
+  if (!draft.usageUrl.trim().startsWith('https://')) {
+    return {
+      ok: false,
+      error: translate(
+        'auto.components.settings.customProviderDraft.urlMustBeHttps',
+        'Usage URL must start with https://.'
+      )
+    }
+  }
+  if (draft.mappingMode === 'percent') {
+    if (!draft.percentPath.trim()) {
+      return {
+        ok: false,
+        error: translate(
+          'auto.components.settings.customProviderDraft.percentPathRequired',
+          'Percent path is required.'
+        )
+      }
+    }
+  } else {
+    const usedPaths = draft.usedPaths.map((path) => path.trim()).filter(Boolean)
+    if (usedPaths.length === 0) {
+      return {
+        ok: false,
+        error: translate(
+          'auto.components.settings.customProviderDraft.usedPathRequired',
+          'At least one used-value path is required.'
+        )
+      }
+    }
+    if (!draft.limitPath.trim()) {
+      return {
+        ok: false,
+        error: translate(
+          'auto.components.settings.customProviderDraft.limitPathRequired',
+          'Limit path is required.'
+        )
+      }
+    }
+  }
+  return { ok: true }
+}
+
+export function buildCustomProviderAccount(
+  draft: CustomProviderDraft,
+  existing: CustomProviderAccount | null
+): Omit<CustomProviderAccount, 'id' | 'createdAt'> {
+  return {
+    displayName: draft.displayName.trim(),
+    enabled: existing?.enabled ?? true,
+    icon: draft.icon,
+    usageUrl: draft.usageUrl.trim(),
+    ...(draft.tokenEnvVar.trim() ? { tokenEnvVar: draft.tokenEnvVar.trim() } : {}),
+    mappingMode: draft.mappingMode,
+    ...(draft.mappingMode === 'percent'
+      ? { percentPath: draft.percentPath.trim() }
+      : {
+          usedPaths: draft.usedPaths.map((path) => path.trim()).filter(Boolean),
+          limitPath: draft.limitPath.trim()
+        }),
+    // Why: this call always represents a fresh save (test-draft calls don't
+    // persist), so the edit timestamp should always advance — not the
+    // previous save's stamp.
+    updatedAt: Date.now()
+  }
+}

--- a/src/renderer/src/components/settings/custom-provider-icon-options.ts
+++ b/src/renderer/src/components/settings/custom-provider-icon-options.ts
@@ -1,0 +1,59 @@
+import { Boxes, Cloud, Globe, Server, Shield, Sparkles, Zap } from 'lucide-react'
+import type { ComponentType } from 'react'
+import { createLocalizedCatalog } from '@/i18n/localized-catalog'
+import { translate } from '@/i18n/i18n'
+
+export type CustomProviderIconOption = {
+  id: string
+  label: string
+  Icon: ComponentType<{ className?: string }>
+}
+
+// Why: a small bundled preset catalog, never raw user SVG — avoids the
+// sanitization/XSS surface entirely for a rarely-cosmetic feature.
+export const getCustomProviderIconOptions = createLocalizedCatalog<CustomProviderIconOption[]>(
+  () => [
+    {
+      id: 'server',
+      label: translate('auto.components.settings.customProviderIconOptions.server', 'Server'),
+      Icon: Server
+    },
+    {
+      id: 'cloud',
+      label: translate('auto.components.settings.customProviderIconOptions.cloud', 'Cloud'),
+      Icon: Cloud
+    },
+    {
+      id: 'globe',
+      label: translate('auto.components.settings.customProviderIconOptions.globe', 'Globe'),
+      Icon: Globe
+    },
+    {
+      id: 'shield',
+      label: translate('auto.components.settings.customProviderIconOptions.shield', 'Shield'),
+      Icon: Shield
+    },
+    {
+      id: 'zap',
+      label: translate('auto.components.settings.customProviderIconOptions.zap', 'Zap'),
+      Icon: Zap
+    },
+    {
+      id: 'sparkles',
+      label: translate('auto.components.settings.customProviderIconOptions.sparkles', 'Sparkles'),
+      Icon: Sparkles
+    },
+    {
+      id: 'boxes',
+      label: translate('auto.components.settings.customProviderIconOptions.boxes', 'Boxes'),
+      Icon: Boxes
+    }
+  ]
+)
+
+export const DEFAULT_CUSTOM_PROVIDER_ICON_ID = 'server'
+
+export function getCustomProviderIconOption(id: string | undefined): CustomProviderIconOption {
+  const options = getCustomProviderIconOptions()
+  return options.find((option) => option.id === id) ?? options[0]
+}

--- a/src/renderer/src/components/settings/custom-provider-json-view.test.ts
+++ b/src/renderer/src/components/settings/custom-provider-json-view.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { EMPTY_CUSTOM_PROVIDER_DRAFT } from './custom-provider-draft'
+import { mergeJsonIntoDraft } from './custom-provider-json-view'
+
+describe('mergeJsonIntoDraft key-deletion semantics (#7)', () => {
+  const prev = {
+    ...EMPTY_CUSTOM_PROVIDER_DRAFT,
+    tokenEnvVar: 'MY_TOKEN',
+    percentPath: 'a.b',
+    usedPaths: ['x', 'y'],
+    limitPath: 'limit'
+  }
+
+  it('clears tokenEnvVar when the key is deleted from the JSON (absent, not just falsy)', () => {
+    const merged = mergeJsonIntoDraft(prev, {})
+    expect(merged.tokenEnvVar).toBe('')
+  })
+
+  it('keeps the previous tokenEnvVar when the key is present but simply not included in this partial shape update', () => {
+    const merged = mergeJsonIntoDraft(prev, { tokenEnvVar: 'OTHER_TOKEN' })
+    expect(merged.tokenEnvVar).toBe('OTHER_TOKEN')
+  })
+
+  it('clears percentPath/usedPaths/limitPath when their keys are absent', () => {
+    const merged = mergeJsonIntoDraft(prev, {})
+    expect(merged.percentPath).toBe('')
+    expect(merged.usedPaths).toEqual([])
+    expect(merged.limitPath).toBe('')
+  })
+
+  it('does not resurrect a deleted key on the next re-serialize/merge round trip', () => {
+    const afterDeletion = mergeJsonIntoDraft(prev, {})
+    const afterSecondMerge = mergeJsonIntoDraft(afterDeletion, {})
+    expect(afterSecondMerge.tokenEnvVar).toBe('')
+  })
+})

--- a/src/renderer/src/components/settings/custom-provider-json-view.ts
+++ b/src/renderer/src/components/settings/custom-provider-json-view.ts
@@ -108,10 +108,16 @@ export function mergeJsonIntoDraft(
     displayName: json.displayName ?? prev.displayName,
     icon: json.icon ?? prev.icon,
     usageUrl: json.usageUrl ?? prev.usageUrl,
-    tokenEnvVar: json.tokenEnvVar ?? prev.tokenEnvVar,
+    // Why: `json` is always a full re-parse of the entire JSON textarea (see
+    // CustomProviderJsonPanel), never a partial patch — so for these optional
+    // fields, an ABSENT key unambiguously means "the user deleted this line to
+    // clear it," not "leave the old value alone." Falling back to `prev` here
+    // (as `??` does) would resurrect a deleted line the moment the panel
+    // re-serializes the draft.
+    tokenEnvVar: json.tokenEnvVar ?? '',
     mappingMode: (json.mappingMode as CustomProviderDraft['mappingMode']) ?? prev.mappingMode,
-    percentPath: json.percentPath ?? prev.percentPath,
-    usedPaths: json.usedPaths ?? prev.usedPaths,
-    limitPath: json.limitPath ?? prev.limitPath
+    percentPath: json.percentPath ?? '',
+    usedPaths: json.usedPaths ?? [],
+    limitPath: json.limitPath ?? ''
   }
 }

--- a/src/renderer/src/components/settings/custom-provider-json-view.ts
+++ b/src/renderer/src/components/settings/custom-provider-json-view.ts
@@ -1,0 +1,117 @@
+import type { CustomProviderDraft } from './custom-provider-draft'
+import { translate } from '@/i18n/i18n'
+
+/** The subset of the draft shown/edited as JSON — token is intentionally
+ *  excluded so a secret never sits in a plain-text, copy-pasteable box. */
+export type CustomProviderJsonShape = {
+  displayName?: string
+  icon?: string
+  usageUrl?: string
+  /** The env var *name*, not its value — safe to show/edit as plain JSON. */
+  tokenEnvVar?: string
+  mappingMode?: string
+  percentPath?: string
+  usedPaths?: string[]
+  limitPath?: string
+}
+
+export function serializeDraftToJson(draft: CustomProviderDraft): string {
+  const shape: CustomProviderJsonShape = {
+    displayName: draft.displayName,
+    icon: draft.icon,
+    usageUrl: draft.usageUrl,
+    ...(draft.tokenEnvVar.trim() ? { tokenEnvVar: draft.tokenEnvVar } : {}),
+    mappingMode: draft.mappingMode,
+    ...(draft.mappingMode === 'percent'
+      ? { percentPath: draft.percentPath }
+      : { usedPaths: draft.usedPaths, limitPath: draft.limitPath })
+  }
+  return JSON.stringify(shape, null, 2)
+}
+
+const STRING_FIELDS = [
+  'displayName',
+  'icon',
+  'usageUrl',
+  'tokenEnvVar',
+  'percentPath',
+  'limitPath'
+] as const
+
+export type CustomProviderJsonValidation =
+  | { ok: true; value: CustomProviderJsonShape }
+  | { ok: false; error: string }
+
+// Why: a lighter check than validateCustomProviderDraft — this only asserts
+// the JSON is *shaped* correctly (right types, valid enum), not that it's
+// complete/ready to save. Required-ness is still enforced by Test/Save.
+export function validateCustomProviderJsonShape(parsed: unknown): CustomProviderJsonValidation {
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      error: translate(
+        'auto.components.settings.customProviderJsonView.mustBeObject',
+        'Must be a JSON object.'
+      )
+    }
+  }
+  const obj = parsed as Record<string, unknown>
+  const value: CustomProviderJsonShape = {}
+  for (const key of STRING_FIELDS) {
+    if (key in obj) {
+      if (typeof obj[key] !== 'string') {
+        return {
+          ok: false,
+          error: translate(
+            'auto.components.settings.customProviderJsonView.mustBeString',
+            '"{{value0}}" must be a string.',
+            { value0: key }
+          )
+        }
+      }
+      value[key] = obj[key] as string
+    }
+  }
+  if ('mappingMode' in obj) {
+    if (obj.mappingMode !== 'percent' && obj.mappingMode !== 'used-limit') {
+      return {
+        ok: false,
+        error: translate(
+          'auto.components.settings.customProviderJsonView.invalidMappingMode',
+          '"mappingMode" must be "percent" or "used-limit".'
+        )
+      }
+    }
+    value.mappingMode = obj.mappingMode
+  }
+  if ('usedPaths' in obj) {
+    if (!Array.isArray(obj.usedPaths) || obj.usedPaths.some((path) => typeof path !== 'string')) {
+      return {
+        ok: false,
+        error: translate(
+          'auto.components.settings.customProviderJsonView.invalidUsedPaths',
+          '"usedPaths" must be an array of strings.'
+        )
+      }
+    }
+    value.usedPaths = obj.usedPaths as string[]
+  }
+  return { ok: true, value }
+}
+
+export function mergeJsonIntoDraft(
+  prev: CustomProviderDraft,
+  json: CustomProviderJsonShape
+): CustomProviderDraft {
+  return {
+    ...prev,
+    displayName: json.displayName ?? prev.displayName,
+    icon: json.icon ?? prev.icon,
+    usageUrl: json.usageUrl ?? prev.usageUrl,
+    tokenEnvVar: json.tokenEnvVar ?? prev.tokenEnvVar,
+    mappingMode: (json.mappingMode as CustomProviderDraft['mappingMode']) ?? prev.mappingMode,
+    percentPath: json.percentPath ?? prev.percentPath,
+    usedPaths: json.usedPaths ?? prev.usedPaths,
+    limitPath: json.limitPath ?? prev.limitPath
+  }
+}

--- a/src/renderer/src/components/stats/GrokUsagePane.test.tsx
+++ b/src/renderer/src/components/stats/GrokUsagePane.test.tsx
@@ -37,6 +37,7 @@ const mockStoreState = {
       error: null,
       status: 'ok'
     },
+    customProviderUsage: {},
     minimaxCookieConfigured: false,
     grokAuthConfigured: true,
     claudeTarget: { runtime: 'host', wslDistro: null },

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -63,6 +63,7 @@ import { ClaudeIcon, GeminiIcon, MiniMaxIcon, OpenAIIcon, OpenCodeGoIcon } from 
 import { AgentIcon } from '@/lib/agent-catalog'
 import { UsageRosterPanel, getTightestUsageSection } from './UsageRosterPanel'
 import { getUsageProviderAccountsSectionId } from './usage-provider-settings-target'
+import { getCustomProviderIconOption } from '../settings/custom-provider-icon-options'
 import { formatRateLimitWindowChipLabel } from '@/lib/window-label-formatter'
 import { useResetCountdownClock } from '@/hooks/useResetCountdownClock'
 import {
@@ -2106,7 +2107,22 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     return null
   }
 
-  const { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok } = rateLimits
+  const {
+    claude,
+    codex,
+    gemini,
+    opencodeGo,
+    kimi,
+    antigravity,
+    minimax,
+    grok,
+    customProviderUsage
+  } = rateLimits
+  // Why: an arbitrary-length, user-defined list rendered alongside the fixed
+  // providers above but kept out of their closed-union-typed roster/segment
+  // components (ProviderSegment/UsageRosterPanel) — see custom-provider-types.ts.
+  const enabledCustomProviders = (settings?.customProviderAccounts ?? []).filter((a) => a.enabled)
+  const hasCustomProviders = enabledCustomProviders.length > 0
 
   // Why: a bar is earned by a live snapshot or durable Settings setup; detection-gating hides per-CLI bars when the agent isn't on PATH.
   // Why: Antigravity has no persisted credential, so a checked status item + detected CLI is the durable "show its slot" signal.
@@ -2171,13 +2187,15 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     showKimi ||
     showAntigravity ||
     showMiniMax ||
-    showGrok
+    showGrok ||
+    hasCustomProviders
   const anyVisible = hasVisibleUsageMeters || showResourceUsage
   // Why: include Settings so durable managed accounts count — a configured user isn't shown the empty state while snapshots hydrate.
-  const isEmptyUsageState = isUsageEmptyState(
-    { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok },
-    usageSettings
-  )
+  const isEmptyUsageState =
+    isUsageEmptyState(
+      { claude, codex, gemini, opencodeGo, kimi, antigravity, minimax, grok },
+      usageSettings
+    ) && !hasCustomProviders
   // Why: one-time nudge — once dismissed, stays hidden even if providers reconnect later.
   const showEmptyUsageCta = isEmptyUsageState && !usageEmptyStateDismissed
   const anyFetching =
@@ -2188,7 +2206,8 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
     kimi?.status === 'fetching' ||
     antigravity?.status === 'fetching' ||
     minimax?.status === 'fetching' ||
-    grok?.status === 'fetching'
+    grok?.status === 'fetching' ||
+    enabledCustomProviders.some((a) => customProviderUsage[a.id]?.status === 'fetching')
 
   const compact = containerWidth < 900
   const iconOnly = containerWidth < 500
@@ -2291,6 +2310,25 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
                       />
                     )
                   )}
+                  {enabledCustomProviders.map((account) => {
+                    const usage = customProviderUsage[account.id]
+                    const { Icon } = getCustomProviderIconOption(account.icon)
+                    const percent =
+                      usage?.usedPercent != null ? `${Math.round(usage.usedPercent)}%` : '--'
+                    return (
+                      <span
+                        key={account.id}
+                        title={account.displayName}
+                        className={`inline-flex items-center gap-1 text-xs ${
+                          usage && usage.status !== 'ok' ? 'text-red-400' : ''
+                        }`}
+                      >
+                        <Icon className="size-3" />
+                        {!iconOnly ? <span className="truncate">{account.displayName}</span> : null}
+                        <span>{percent}</span>
+                      </span>
+                    )
+                  })}
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent
@@ -2358,6 +2396,30 @@ function StatusBarInner({ floatingTerminalOpen }: StatusBarProps): React.JSX.Ele
                     )
                   }}
                 />
+                {enabledCustomProviders.length > 0 ? (
+                  <div className="border-t border-border/60 p-1">
+                    {enabledCustomProviders.map((account) => {
+                      const usage = customProviderUsage[account.id]
+                      const { Icon } = getCustomProviderIconOption(account.icon)
+                      return (
+                        <button
+                          key={account.id}
+                          type="button"
+                          onClick={handleManageAccounts}
+                          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs hover:bg-accent/50"
+                        >
+                          <Icon className="size-3.5 shrink-0 text-muted-foreground" />
+                          <span className="min-w-0 flex-1 truncate">{account.displayName}</span>
+                          <span className={usage && usage.status !== 'ok' ? 'text-red-400' : ''}>
+                            {usage?.usedPercent != null
+                              ? `${Math.round(usage.usedPercent)}%`
+                              : '--'}
+                          </span>
+                        </button>
+                      )
+                    })}
+                  </div>
+                ) : null}
               </DropdownMenuContent>
             </DropdownMenu>
           </UsagePercentageDisplayChangeNotice>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -8509,6 +8509,11 @@
         },
         "accounts": {
           "search": {
+            "a1c3e5f7b9": "Custom AI Provider Accounts",
+            "b2d4f6a8c0": "Point Orca at an internal or corporate usage-tracking endpoint to show its usage in the status bar.",
+            "c3e5a7b9d1": "custom",
+            "d4f6b8c0e2": "endpoint",
+            "e5a7c9d1f3": "usage",
             "86edc96bc9": "status bar",
             "e949b08ffb": "rate limit",
             "7e67d7d1b6": "wrk",
@@ -11345,6 +11350,7 @@
           "missionControlConflict": "Blocked by Mission Control. Remap here or change it in System Settings."
         },
         "CustomProviderAccountCard": {
+          "disableAria": "Disable {{value0}}",
           "disabled": "Disabled",
           "editAria": "Edit",
           "error": "Error",
@@ -11397,6 +11403,7 @@
           "removed": "Provider removed",
           "saveFailed": "Failed to save provider",
           "title": "Custom Providers",
+          "toggleFailed": "Failed to update provider",
           "updated": "Provider updated"
         },
         "CustomProviderJsonPanel": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11343,6 +11343,88 @@
         },
         "shortcutDefinitionCatalog": {
           "missionControlConflict": "Blocked by Mission Control. Remap here or change it in System Settings."
+        },
+        "CustomProviderAccountCard": {
+          "disabled": "Disabled",
+          "editAria": "Edit",
+          "error": "Error",
+          "fetching": "Fetching…",
+          "pending": "Not fetched yet",
+          "removeAria": "Remove",
+          "staleSuffix": "{{value0}} (stale)",
+          "toggleAria": "Enable {{value0}}"
+        },
+        "CustomProviderAccountForm": {
+          "addAccount": "Add Account",
+          "addPath": "Add another",
+          "addTitle": "Add custom provider",
+          "cancel": "Cancel",
+          "description": "Point Orca at an internal usage-tracking endpoint. No credentials leave this device except to the URL you enter.",
+          "editTitle": "Edit custom provider",
+          "icon": "Icon",
+          "limitPath": "Limit path",
+          "limitPathPlaceholder": "totalDailyLimit",
+          "mappingMode": "Response mapping",
+          "name": "Name",
+          "namePlaceholder": "Internal Gateway",
+          "percentMode": "Percent field (0-100)",
+          "percentPath": "Percent path",
+          "percentPathPlaceholder": "usage.percent",
+          "saveChanges": "Save Changes",
+          "test": "Test & Preview",
+          "testFailed": "Test failed",
+          "testOk": "Success — {{value0}}%",
+          "testRequired": "A successful test is required before saving.",
+          "token": "Bearer token",
+          "tokenEditPlaceholder": "Leave blank to keep the existing token",
+          "tokenEnvVar": "Token env var (optional)",
+          "tokenEnvVarHelp": "If this environment variable has a value on this machine, it is used instead of the Bearer token above — re-checked on every refresh.",
+          "tokenEnvVarPlaceholder": "MY_INTERNAL_API_KEY",
+          "tokenPlaceholder": "Bearer …",
+          "url": "Usage URL",
+          "urlHelp": "Supports {yyyy}/{mm}/{dd} placeholders, replaced with today’s UTC date on every call.",
+          "urlPlaceholder": "https://internal.example.com/usage?year={yyyy}&month={mm}&day={dd}",
+          "usedLimitMode": "Used / limit fields",
+          "usedPathPlaceholder": "summary.totalInputTokens",
+          "usedPaths": "Used-value paths (summed)"
+        },
+        "CustomProviderAccountsSection": {
+          "add": "Add Provider",
+          "added": "Provider added",
+          "description": "Add an internal usage-tracking endpoint to show its usage in the status bar.",
+          "empty": "No custom providers configured.",
+          "removeFailed": "Failed to remove provider",
+          "removed": "Provider removed",
+          "saveFailed": "Failed to save provider",
+          "title": "Custom Providers",
+          "updated": "Provider updated"
+        },
+        "CustomProviderJsonPanel": {
+          "help": "Stays in sync with the fields above in both directions. The token is never shown here.",
+          "title": "Config JSON"
+        },
+        "customProviderDraft": {
+          "duplicateName": "An account named \"{{value0}}\" already exists.",
+          "limitPathRequired": "Limit path is required.",
+          "nameRequired": "Name is required.",
+          "percentPathRequired": "Percent path is required.",
+          "urlMustBeHttps": "Usage URL must start with https://.",
+          "usedPathRequired": "At least one used-value path is required."
+        },
+        "customProviderIconOptions": {
+          "boxes": "Boxes",
+          "cloud": "Cloud",
+          "globe": "Globe",
+          "server": "Server",
+          "shield": "Shield",
+          "sparkles": "Sparkles",
+          "zap": "Zap"
+        },
+        "customProviderJsonView": {
+          "invalidMappingMode": "\"mappingMode\" must be \"percent\" or \"used-limit\".",
+          "invalidUsedPaths": "\"usedPaths\" must be an array of strings.",
+          "mustBeObject": "Must be a JSON object.",
+          "mustBeString": "\"{{value0}}\" must be a string."
         }
       },
       "right": {

--- a/src/renderer/src/store/slices/rate-limits.ts
+++ b/src/renderer/src/store/slices/rate-limits.ts
@@ -25,6 +25,7 @@ export const createRateLimitSlice: StateCreator<AppState, [], [], RateLimitSlice
     antigravity: null,
     minimax: null,
     grok: null,
+    customProviderUsage: {},
     minimaxCookieConfigured: false,
     grokAuthConfigured: false,
     claudeTarget: { runtime: 'host', wslDistro: null },

--- a/src/renderer/src/web/preload-api/web-agent-accounts-api.ts
+++ b/src/renderer/src/web/preload-api/web-agent-accounts-api.ts
@@ -12,6 +12,21 @@ export function createMiniMaxCredentialsApi(): NonNullable<
   }
 }
 
+export function createCustomProviderAccountsApi(): NonNullable<
+  Partial<PreloadApi>['customProviderAccounts']
+> {
+  const notConfigured = { configured: false }
+  const unsupportedError = new Error(
+    'Custom provider token storage is only available in the desktop app.'
+  )
+  return {
+    getTokenStatus: () => Promise.resolve(notConfigured),
+    saveToken: () => Promise.reject(unsupportedError),
+    clearToken: () => Promise.resolve(notConfigured),
+    testDraft: () => Promise.reject(unsupportedError)
+  }
+}
+
 export function createGrokAccountsApi(): NonNullable<Partial<PreloadApi>['grokAccounts']> {
   const unsigned = {
     signedIn: false,

--- a/src/renderer/src/web/preload-api/web-rate-limits-api.ts
+++ b/src/renderer/src/web/preload-api/web-rate-limits-api.ts
@@ -12,6 +12,7 @@ export function createRateLimitsApi(): NonNullable<Partial<PreloadApi>['rateLimi
     antigravity: null,
     minimax: null,
     grok: null,
+    customProviderUsage: {},
     minimaxCookieConfigured: false,
     grokAuthConfigured: false,
     claudeTarget: { runtime: 'host', wslDistro: null },

--- a/src/renderer/src/web/web-preload-api-composition.test.ts
+++ b/src/renderer/src/web/web-preload-api-composition.test.ts
@@ -53,6 +53,7 @@ describe('web preload API composition', () => {
       'preflight',
       'notifications',
       'rateLimits',
+      'customProviderAccounts',
       'minimaxCredentials',
       'grokAccounts',
       'codexAccounts',

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -3,6 +3,7 @@ import type { StatsSummary } from '../../../shared/process-stats-types'
 import { createWebE2EApi } from './preload-api/web-e2e-api'
 import {
   createAccountsApi,
+  createCustomProviderAccountsApi,
   createGrokAccountsApi,
   createMiniMaxCredentialsApi
 } from './preload-api/web-agent-accounts-api'
@@ -106,6 +107,7 @@ function createWebPreloadApi(): Partial<PreloadApi> {
     preflight: createPreflightApi(),
     notifications: createNotificationsApi(),
     rateLimits: createRateLimitsApi(),
+    customProviderAccounts: createCustomProviderAccountsApi(),
     minimaxCredentials: createMiniMaxCredentialsApi(),
     grokAccounts: createGrokAccountsApi(),
     codexAccounts: createAccountsApi(),

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -336,6 +336,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     opencodeWorkspaceId: '',
     minimaxGroupId: '',
     minimaxUsageModels: 'general',
+    customProviderAccounts: [],
     geminiCliOAuthEnabled: false,
     agentCmdOverrides: {},
     agentDefaultArgs: { ...DEFAULT_TUI_AGENT_ARGS },

--- a/src/shared/custom-provider-types.ts
+++ b/src/shared/custom-provider-types.ts
@@ -1,0 +1,50 @@
+/** A user-defined AI provider account whose usage % Orca polls and shows in the status bar.
+ *  No universal usage-API shape exists across vendors, so the response mapping is a small,
+ *  deliberately constrained grammar (dot keys + numeric array indices) rather than full
+ *  JSONPath/JMESPath — see custom-provider-fetcher.ts. */
+export type CustomProviderUsageMappingMode = 'percent' | 'used-limit'
+
+export type CustomProviderAccount = {
+  id: string
+  displayName: string
+  enabled: boolean
+  /** Preset icon-catalog id (see custom-provider-icon-options.ts) — never raw SVG. */
+  icon?: string
+  /** May contain {yyyy}/{mm}/{dd}, substituted with today's UTC date before each call. */
+  usageUrl: string
+  /** Optional env var name — if it resolves to a non-empty value at fetch time (main
+   *  process env), it's used as the Bearer token instead of the keychain-stored one. */
+  tokenEnvVar?: string
+  mappingMode: CustomProviderUsageMappingMode
+  /** 'percent' mode: path to a 0-100 number. */
+  percentPath?: string
+  /** 'used-limit' mode: 1-4 paths summed as the used amount. */
+  usedPaths?: string[]
+  /** 'used-limit' mode: path to the limit; percent = min(100, sum(usedPaths) / limit * 100). */
+  limitPath?: string
+  createdAt: number
+  updatedAt: number
+}
+
+export type CustomProviderUsageFailureKind =
+  | 'missing-token'
+  | 'unauthorized'
+  | 'network'
+  | 'timeout'
+  | 'non-json'
+  | 'path-not-found'
+  | 'invalid-path-syntax'
+  | 'non-numeric'
+  | 'invalid-limit'
+  | 'out-of-range'
+  | 'unknown'
+
+export type CustomProviderUsageResult = {
+  accountId: string
+  usedPercent: number | null
+  resetsAt: number | null
+  updatedAt: number
+  error: string | null
+  status: 'ok' | 'error' | 'unavailable' | 'fetching'
+  failureKind?: CustomProviderUsageFailureKind
+}

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -1,4 +1,5 @@
 import type { ExecutionHostId } from './execution-host'
+import type { CustomProviderAccount } from './custom-provider-types'
 import type { GitHubProjectSettings } from './github/project-types'
 import type { VoiceSettings } from './speech-types'
 import type { GitLabProjectSettings } from './gitlab-types'
@@ -345,6 +346,9 @@ export type GlobalSettings = {
   minimaxGroupId: string
   /** Comma-separated MiniMax model names to show in the status bar usage window. */
   minimaxUsageModels: string
+  /** User-defined AI provider accounts polled for a generic usage %. Auth tokens live in the
+   *  keychain-backed custom-provider-token-store, not here. */
+  customProviderAccounts: CustomProviderAccount[]
   /** Extract OAuth credentials from the local Gemini CLI for rate-limit fetching. Off by default (explicit opt-in). */
   geminiCliOAuthEnabled: boolean
   /** Per-agent CLI command overrides. A missing key means use the catalog default binary name. */

--- a/src/shared/rate-limit-types.test.ts
+++ b/src/shared/rate-limit-types.test.ts
@@ -16,6 +16,7 @@ describe('RateLimitState', () => {
       antigravity: null,
       minimax: null,
       grok: null,
+      customProviderUsage: {},
       minimaxCookieConfigured: false,
       grokAuthConfigured: false,
       claudeTarget: { runtime: 'host', wslDistro: null },

--- a/src/shared/rate-limit-types.ts
+++ b/src/shared/rate-limit-types.ts
@@ -1,3 +1,5 @@
+import type { CustomProviderUsageResult } from './custom-provider-types'
+
 export type RateLimitWindow = {
   /** Percentage of the window consumed (0–100). */
   usedPercent: number
@@ -124,6 +126,10 @@ export type RateLimitState = {
   antigravity: ProviderRateLimits | null
   minimax: ProviderRateLimits | null
   grok: ProviderRateLimits | null
+  /** User-defined custom provider usage, keyed by CustomProviderAccount.id. A separate,
+   *  arbitrary-length structure — not folded into the fixed `provider` union above, since that
+   *  union is exhaustively switched on throughout the status bar/settings code. */
+  customProviderUsage: Record<string, CustomProviderUsageResult>
   /**
    * True when a MiniMax session cookie is persisted on disk. The cookie lives
    * outside GlobalSettings, so this flag is the durable signal that the

--- a/tests/e2e/custom-provider-json-panel.spec.ts
+++ b/tests/e2e/custom-provider-json-panel.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * Verifies the Config JSON panel: form->JSON live sync, JSON->form live sync
+ * (including the icon picker), and syntax-error display for invalid JSON, by
+ * driving the real Add Provider dialog. No external network calls.
+ */
+
+import { test, expect } from './helpers/orca-app'
+import { waitForSessionReady } from './helpers/store'
+
+test('the JSON panel stays in sync with the form in both directions', async ({ orcaPage }) => {
+  test.setTimeout(60_000)
+  await waitForSessionReady(orcaPage)
+
+  await orcaPage.evaluate(async () => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+    // Why: the spec asserts on English strings; the host machine may run a
+    // non-English system locale, which 'system' would follow.
+    await store.getState().updateSettings({ uiLanguage: 'en' })
+    store.getState().openSettingsTarget({ pane: 'accounts', repoId: null })
+    store.getState().openSettingsPage()
+  })
+  await orcaPage.getByText('Custom Providers').first().waitFor({ timeout: 10_000 })
+  await orcaPage.getByRole('button', { name: 'Add Provider' }).click()
+
+  const jsonBox = orcaPage.locator('#cp-json')
+  await jsonBox.waitFor({ timeout: 10_000 })
+
+  // 1. Form -> JSON: typing a name updates the JSON live.
+  await orcaPage.locator('#cp-name').fill('Sync Test')
+  await expect(jsonBox).toHaveValue(/"displayName": "Sync Test"/, { timeout: 5_000 })
+
+  // 2. JSON -> Form: editing the JSON's usageUrl updates the URL input, and
+  //    switching mappingMode in JSON reveals the used-limit fields (icon-
+  //    picker-adjacent "form resource" following the JSON, not just text).
+  const edited = JSON.stringify(
+    {
+      displayName: 'Sync Test',
+      icon: 'cloud',
+      usageUrl: 'https://example.com/usage?year={yyyy}&month={mm}&day={dd}',
+      mappingMode: 'used-limit',
+      usedPaths: ['a.b'],
+      limitPath: 'c.d'
+    },
+    null,
+    2
+  )
+  await jsonBox.fill(edited)
+  await expect(orcaPage.locator('#cp-url')).toHaveValue(
+    'https://example.com/usage?year={yyyy}&month={mm}&day={dd}'
+  )
+  await expect(orcaPage.locator('#cp-limit-path')).toHaveValue('c.d', { timeout: 5_000 })
+
+  // 3. Invalid JSON syntax shows an error and does not corrupt the form.
+  await jsonBox.fill('{ not valid json')
+  await orcaPage
+    .getByText(/Unexpected|Expected|JSON/i)
+    .first()
+    .waitFor({ timeout: 5_000 })
+  await expect(orcaPage.locator('#cp-name')).toHaveValue('Sync Test')
+})

--- a/tests/e2e/custom-provider-json-panel.spec.ts
+++ b/tests/e2e/custom-provider-json-panel.spec.ts
@@ -54,10 +54,13 @@ test('the JSON panel stays in sync with the form in both directions', async ({ o
   await expect(orcaPage.locator('#cp-limit-path')).toHaveValue('c.d', { timeout: 5_000 })
 
   // 3. Invalid JSON syntax shows an error and does not corrupt the form.
+  // Why: scoped to the red error paragraph, not just /JSON/i — the "Config
+  // JSON" field label itself matches that pattern and is present from the
+  // moment the dialog opens, so a looser locator would pass without ever
+  // proving the error actually rendered.
   await jsonBox.fill('{ not valid json')
-  await orcaPage
-    .getByText(/Unexpected|Expected|JSON/i)
-    .first()
-    .waitFor({ timeout: 5_000 })
+  await expect(
+    orcaPage.locator('p.text-red-400').filter({ hasText: /Unexpected|Expected/i })
+  ).toBeVisible({ timeout: 5_000 })
   await expect(orcaPage.locator('#cp-name')).toHaveValue('Sync Test')
 })


### PR DESCRIPTION
## ELI5

Orca already shows Claude/Codex/Gemini/etc. usage % in the status bar. This adds a "Custom Providers" section so anyone can point Orca at their own internal or corporate usage-tracking API and get the same status-bar usage %, without Orca needing to know anything vendor-specific about that endpoint.

## What Changed

- New "Custom Providers" section in Settings → AI Provider Accounts. Each entry has a display name, icon, a usage URL (supports `{yyyy}`/`{mm}`/`{dd}` UTC-date placeholders), an auth token (kept in the OS keychain) or an env-var name to read it from instead, and a small response-mapping grammar (a direct 0-100 percent field, or a used/limit pair with up to 4 summed "used" paths) to turn an arbitrary JSON response into a percentage.
- A mandatory "Test & Preview" step must succeed against the current draft before Save is enabled.
- A two-way JSON/form editor lets the whole draft be edited as raw JSON (secrets excluded) with live sync in both directions and a syntax checker.
- Modeled as a parallel structure (its own settings array, keychain store, and `RateLimitState` field) rather than widening the existing fixed-provider union, since that union is exhaustively switched on throughout the status-bar/settings code for a known, bounded set of vendors.
- The feature is desktop-only end-to-end: `customProviderAccounts` and `customProviderUsage` are excluded from the paired/remote-client RPC surface (settings sync, `accounts.list`/`accounts.subscribe` snapshots, `consumeCodexResetCredit`), and a paired/remote/mobile-triggered refresh never causes the host to fetch a custom provider's endpoint.

## Why

Requested in #9239 — no built-in provider covers an internal/corporate LLM gateway, and there's no universal "usage API" shape across vendors for Orca to special-case. This lets anyone wire up their own endpoint instead of waiting for a vendor-specific integration.

## Linked Issue

Fixes #9239

## Visual Proof

Adding a custom provider (fields, live JSON sync, mandatory Test & Preview):

![Add custom provider](https://github.com/user-attachments/assets/1800c46e-0e15-45dc-a7a3-3409868a29fb)

The new section in Settings → AI Provider Accounts, alongside the existing providers:

![Custom Providers section](https://github.com/user-attachments/assets/53ee194c-e1ae-4e64-b3bd-c18a94f649b7)

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

Ran against a real internal usage-tracking endpoint (an internal HMC gateway) during development to verify the generic mechanism end-to-end, including the token-env-var resolution path — those specs read a personal token from a local file and hit a real non-public API, so they're not included in this PR; `tests/e2e/custom-provider-json-panel.spec.ts` (JSON↔form two-way sync, no network) is the one added to the tracked suite. Also added/updated unit tests across `src/main/rate-limits/*`, `src/main/ipc/register-core-handlers.test.ts`, and the status-bar visibility tests for the new state shape.

Tested on macOS. Not yet verified on Linux/Windows or over SSH/remote-runtime — the feature only touches the local main process (Electron `net.fetch`, `safeStorage` keychain), so I don't expect platform-specific behavior, but flagging since I couldn't test those platforms myself.

## AI Disclosure

This PR was developed with heavy AI assistance (Claude Code), including the design iterations, implementation, and the security-focused review pass described in Notes below.

## Review

- Ran a usability-focused review pass early on the field/flow design (mandatory Test & Preview before Save, progressive disclosure of mapping fields, a small constrained JSON-path grammar rather than full JSONPath/JMESPath).
- Ran a second, architecture/security-focused review pass on the implementation, across three rounds, which found and led to fixing:
  - a critical wiring bug (the custom-provider fetch cycle was defined but never actually invoked),
  - a race condition where a slower fetch cycle could overwrite a fresher one or revive a deleted account (fixed with a generation counter),
  - the local `settings:set` IPC path not validating `customProviderAccounts` (only the Test & Preview draft path was validated) — now both go through the same strict schema,
  - `customProviderUsage` leaking to paired/remote/mobile clients through multiple RPC surfaces (initial snapshot, the ongoing subscription push, and `consumeCodexResetCredit`'s snapshot) — now stripped at all of them,
  - a paired/remote/mobile client being able to trigger a real fetch of a locally-configured custom provider's endpoint even though it could no longer read the result — now an explicit opt-out threaded through the fetch/refresh methods for the two mobile-triggered call sites only,
  - a UI race where an in-flight Test & Preview response arriving after a later form edit could re-enable Save for a draft that was never actually tested,
  - `updatedAt` not advancing on an edited account's save.
- Cross-platform: the feature only touches Electron's `net.fetch` and `safeStorage` (both already used elsewhere in this codebase), no OS-specific paths.
- Remote/SSH: intentionally excluded from the remote-client RPC surface — see "desktop-only" above.
- Agent/integration compatibility: no interaction with CLI agents or git providers.
- Security: the main new consideration is that a user-configured `tokenEnvVar` resolves whatever value the *host's own* main process has for that env-var name and sends it to the URL that same user configured, from the local, first-party Settings UI (Test & Preview shows exactly what would be sent before Save is even enabled). I treated this as the feature's inherent, disclosed design — the same trust model as any other "point this app at a webhook/endpoint you configure" feature — rather than something to further restrict, since restricting it would defeat the purpose. Happy to discuss if maintainers see it differently.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

This was built and reviewed iteratively (see Review above) specifically to make sure it wasn't just "usability-shaped" but also safe as a remote-facing surface, since Orca supports paired/mobile clients. Would appreciate a careful look at the "desktop-only" boundary in particular, since that's the part most likely to have a gap I didn't think of.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm run build:desktop` pass locally (or CI will cover; local preferred)
