### PR TITLE
fix(ai-vault): replace scanner internals with actionable panel copy

### DIFF
--- a/src/main/ai-vault/cached-session-list.ts
+++ b/src/main/ai-vault/cached-session-list.ts
@@ -1,5 +1,6 @@
 import { join } from 'node:path'
 import {
+  clearAiVaultBackgroundRestartCircuit,
   resetAiVaultScannerBackgroundForTests,
   scanAiVaultSessionsInBackground
 } from './session-scanner-background'
@@ -56,6 +57,9 @@ export async function listAiVaultSessions(
   const depth = requestedAiVaultSessionDepth(args)
   const scanKey = JSON.stringify({ key, depth })
   const now = Date.now()
+  if (args?.force === true) {
+    clearAiVaultBackgroundRestartCircuit()
+  }
   // Why: opening this panel repeatedly should not re-parse hundreds of JSONL
   // transcripts; explicit refreshes bypass the cache and preempt stale scans.
   if (

--- a/src/main/ai-vault/session-scanner-background.ts
+++ b/src/main/ai-vault/session-scanner-background.ts
@@ -9,6 +9,7 @@ import {
   type ReadAiVaultFirstUserPromptResult
 } from './session-first-user-prompt-read'
 import {
+  clearAiVaultServiceRestartCircuit,
   invalidateAiVaultServiceCache,
   listAiVaultSubagentSessionsInService,
   readAiVaultFirstUserPromptInService,
@@ -34,6 +35,16 @@ export function shouldUseAiVaultServiceProcess(): boolean {
     return false
   }
   return process.env.NODE_ENV !== 'test'
+}
+
+/**
+ * Without this a scan that tripped the circuit leaves the panel refusing every
+ * refresh for the rest of the fault window, with no way for the user to retry.
+ */
+export function clearAiVaultBackgroundRestartCircuit(): void {
+  if (shouldUseAiVaultServiceProcess()) {
+    clearAiVaultServiceRestartCircuit()
+  }
 }
 
 export function scanAiVaultSessionsInBackground(

--- a/src/main/ai-vault/session-scanner-background.ts
+++ b/src/main/ai-vault/session-scanner-background.ts
@@ -37,10 +37,7 @@ export function shouldUseAiVaultServiceProcess(): boolean {
   return process.env.NODE_ENV !== 'test'
 }
 
-/**
- * Without this a scan that tripped the circuit leaves the panel refusing every
- * refresh for the rest of the fault window, with no way for the user to retry.
- */
+// Let forced refreshes retry after a local service circuit opens.
 export function clearAiVaultBackgroundRestartCircuit(): void {
   if (shouldUseAiVaultServiceProcess()) {
     clearAiVaultServiceRestartCircuit()

--- a/src/main/ai-vault/session-scanner-service-client-state.ts
+++ b/src/main/ai-vault/session-scanner-service-client-state.ts
@@ -1,8 +1,9 @@
 import type { ChildProcess } from 'node:child_process'
-import type {
-  AiVaultServiceInit,
-  AiVaultServiceLane,
-  AiVaultServiceRequest
+import {
+  AI_VAULT_SERVICE_PROTOCOL_VERSION,
+  type AiVaultServiceInit,
+  type AiVaultServiceLane,
+  type AiVaultServiceRequest
 } from './session-scanner-service-protocol'
 
 export const AI_VAULT_SERVICE_READY_TIMEOUT_MS = 5_000
@@ -110,6 +111,28 @@ export function armAiVaultServiceCancellationTimeout(
  * A cold start that faults before the request reached the child self-heals on
  * the scheduled respawn. Requeue once; the caller rejects when this returns false.
  */
+/** Wires a freshly forked child to the client's callbacks and hands it the init frame. */
+export function attachAiVaultServiceChild(
+  child: ChildProcess,
+  init: AiVaultServiceClientOptions['init'],
+  handlers: {
+    onMessage: (message: unknown) => void
+    onFault: (error: Error) => void
+    onStderr?: (text: string) => void
+  }
+): void {
+  child.on('message', handlers.onMessage)
+  child.on('error', handlers.onFault)
+  child.on('disconnect', () => handlers.onFault(new Error('AI Vault service disconnected.')))
+  child.on('exit', (code) => handlers.onFault(new Error(`AI Vault service exited (${code}).`)))
+  child.stderr?.on('data', (chunk: Buffer) => handlers.onStderr?.(String(chunk)))
+  child.send({
+    type: 'init',
+    protocol: AI_VAULT_SERVICE_PROTOCOL_VERSION,
+    ...init
+  } satisfies AiVaultServiceInit)
+}
+
 export function requeueAiVaultServiceStart(
   call: AiVaultServicePendingCall,
   queue: AiVaultServicePendingCall[]

--- a/src/main/ai-vault/session-scanner-service-client.test.ts
+++ b/src/main/ai-vault/session-scanner-service-client.test.ts
@@ -181,6 +181,53 @@ describe('AiVaultScannerServiceClient', () => {
     client.dispose()
   })
 
+  it('lets a forced refresh reopen the circuit instead of waiting out the window', async () => {
+    vi.useFakeTimers()
+    const children: AiVaultServiceTestChild[] = []
+    const client = new AiVaultScannerServiceClient({
+      processFactory: () => {
+        const child = new AiVaultServiceTestChild(22_345 + children.length)
+        children.push(child)
+        return child.asChildProcess()
+      },
+      init: { sessionParseCache: null }
+    })
+    // Each request retries its cold start once, so two requests spend the three
+    // faults the circuit breaker needs.
+    const first = client.request({ type: 'request', operation: 'titles', requests: [] })
+    vi.advanceTimersByTime(AI_VAULT_SERVICE_READY_TIMEOUT_MS)
+    await Promise.resolve()
+    vi.advanceTimersByTime(250)
+    await Promise.resolve()
+    vi.advanceTimersByTime(AI_VAULT_SERVICE_READY_TIMEOUT_MS)
+    await expect(first).rejects.toThrow('did not become ready')
+    vi.advanceTimersByTime(1_000)
+    await Promise.resolve()
+
+    const blocked = client.request({ type: 'request', operation: 'titles', requests: [] })
+    vi.advanceTimersByTime(AI_VAULT_SERVICE_READY_TIMEOUT_MS)
+    await Promise.resolve()
+    vi.advanceTimersByTime(5_000)
+    await expect(blocked).rejects.toThrow('circuit is open')
+    expect(children).toHaveLength(3)
+
+    client.clearRestartCircuit()
+    const retried = client.request({ type: 'request', operation: 'titles', requests: [] })
+    await vi.waitFor(() => expect(children).toHaveLength(4))
+    readyAiVaultServiceChild(children[3]!)
+    await vi.waitFor(() =>
+      expect(children[3]!.sent).toContainEqual(expect.objectContaining({ operation: 'titles' }))
+    )
+    children[3]!.emit('message', {
+      type: 'result',
+      id: aiVaultServiceRequestId(children[3]!, 'titles'),
+      operation: 'titles',
+      value: { titles: [] }
+    })
+    await expect(retried).resolves.toEqual({ titles: [] })
+    client.dispose()
+  })
+
   it('acknowledges cache invalidation through the running child', async () => {
     const { child, client } = setup()
     const invalidation = client.invalidate(['/tmp/deleted.jsonl'])

--- a/src/main/ai-vault/session-scanner-service-client.test.ts
+++ b/src/main/ai-vault/session-scanner-service-client.test.ts
@@ -181,6 +181,40 @@ describe('AiVaultScannerServiceClient', () => {
     client.dispose()
   })
 
+  it('starts a queued retry immediately when a forced refresh clears backoff', async () => {
+    vi.useFakeTimers()
+    const children: AiVaultServiceTestChild[] = []
+    const client = new AiVaultScannerServiceClient({
+      processFactory: () => {
+        const child = new AiVaultServiceTestChild(18_345 + children.length)
+        children.push(child)
+        return child.asChildProcess()
+      },
+      init: { sessionParseCache: null }
+    })
+    const titles = client.request({ type: 'request', operation: 'titles', requests: [] })
+
+    vi.advanceTimersByTime(AI_VAULT_SERVICE_READY_TIMEOUT_MS)
+    await Promise.resolve()
+    expect(children).toHaveLength(1)
+
+    client.clearRestartCircuit()
+    expect(children).toHaveLength(2)
+
+    readyAiVaultServiceChild(children[1]!)
+    await vi.waitFor(() =>
+      expect(children[1]!.sent).toContainEqual(expect.objectContaining({ operation: 'titles' }))
+    )
+    children[1]!.emit('message', {
+      type: 'result',
+      id: aiVaultServiceRequestId(children[1]!, 'titles'),
+      operation: 'titles',
+      value: { titles: [] }
+    })
+    await expect(titles).resolves.toEqual({ titles: [] })
+    client.dispose()
+  })
+
   it('lets a forced refresh reopen the circuit instead of waiting out the window', async () => {
     vi.useFakeTimers()
     const children: AiVaultServiceTestChild[] = []

--- a/src/main/ai-vault/session-scanner-service-client.ts
+++ b/src/main/ai-vault/session-scanner-service-client.ts
@@ -78,6 +78,7 @@ export class AiVaultScannerServiceClient {
 
   clearRestartCircuit(): void {
     this.restartPolicy.clearCircuit()
+    this.pump()
   }
 
   async invalidate(paths: string[]): Promise<void> {

--- a/src/main/ai-vault/session-scanner-service-client.ts
+++ b/src/main/ai-vault/session-scanner-service-client.ts
@@ -9,6 +9,7 @@ import {
   AiVaultServiceIdleRetirement,
   AiVaultServiceInvalidations,
   armAiVaultServiceCancellationTimeout,
+  attachAiVaultServiceChild,
   clearAiVaultServiceCall,
   createAiVaultServiceReadyWaiter,
   rejectAiVaultServiceCall,
@@ -20,11 +21,9 @@ import {
 } from './session-scanner-service-client-state'
 import { AiVaultServiceRestartPolicy } from './session-scanner-service-restart-policy'
 import {
-  AI_VAULT_SERVICE_PROTOCOL_VERSION,
   aiVaultServiceLane,
   isAiVaultServiceChildMessage,
   type AiVaultServiceChildMessage,
-  type AiVaultServiceInit,
   type AiVaultServiceRequest,
   type AiVaultServiceRequestBody,
   type AiVaultServiceResultValue
@@ -75,6 +74,10 @@ export class AiVaultScannerServiceClient {
       this.idleRetirement.clear()
       this.pump()
     })
+  }
+
+  clearRestartCircuit(): void {
+    this.restartPolicy.clearCircuit()
   }
 
   async invalidate(paths: string[]): Promise<void> {
@@ -199,16 +202,11 @@ export class AiVaultScannerServiceClient {
       this.onFault(new Error('AI Vault service did not become ready.'))
     )
     this.readyWaiter = waiter
-    child.on('message', (message) => this.onMessage(message))
-    child.on('error', (error) => this.onFault(error))
-    child.on('disconnect', () => this.onFault(new Error('AI Vault service disconnected.')))
-    child.on('exit', (code) => this.onFault(new Error(`AI Vault service exited (${code}).`)))
-    child.stderr?.on('data', (chunk: Buffer) => this.options.onStderr?.(String(chunk)))
-    child.send({
-      type: 'init',
-      protocol: AI_VAULT_SERVICE_PROTOCOL_VERSION,
-      ...this.options.init
-    } satisfies AiVaultServiceInit)
+    attachAiVaultServiceChild(child, this.options.init, {
+      onMessage: (message) => this.onMessage(message),
+      onFault: (error) => this.onFault(error),
+      onStderr: this.options.onStderr
+    })
     return waiter.promise
   }
 

--- a/src/main/ai-vault/session-scanner-service-restart-policy.test.ts
+++ b/src/main/ai-vault/session-scanner-service-restart-policy.test.ts
@@ -30,6 +30,22 @@ describe('AiVaultServiceRestartPolicy', () => {
     expect(policy.restartScheduled).toBe(false)
   })
 
+  it('clears the pending backoff and fault history for a forced retry', () => {
+    vi.useFakeTimers()
+    const policy = new AiVaultServiceRestartPolicy()
+    const restart = vi.fn()
+
+    policy.recordFault(restart)
+    policy.clearCircuit()
+    vi.advanceTimersByTime(10_000)
+
+    expect(restart).not.toHaveBeenCalled()
+    policy.recordFault(restart)
+    policy.recordFault(restart)
+    expect(policy.startError()).toBeNull()
+    policy.dispose()
+  })
+
   it('opens the circuit after three faults inside the window', () => {
     let now = 0
     const policy = new AiVaultServiceRestartPolicy(() => now)

--- a/src/main/ai-vault/session-scanner-service-restart-policy.ts
+++ b/src/main/ai-vault/session-scanner-service-restart-policy.ts
@@ -12,6 +12,11 @@ export class AiVaultServiceRestartPolicy {
     return this.timer !== null
   }
 
+  /** A forced refresh is a deliberate user action, so it reopens the circuit. */
+  clearCircuit(): void {
+    this.circuitUntil = 0
+  }
+
   startError(): Error | null {
     return this.now() < this.circuitUntil
       ? new Error('AI Vault service restart circuit is open.')

--- a/src/main/ai-vault/session-scanner-service-restart-policy.ts
+++ b/src/main/ai-vault/session-scanner-service-restart-policy.ts
@@ -12,9 +12,14 @@ export class AiVaultServiceRestartPolicy {
     return this.timer !== null
   }
 
-  /** A forced refresh is a deliberate user action, so it reopens the circuit. */
+  /** A forced refresh starts a fresh retry window immediately. */
   clearCircuit(): void {
     this.circuitUntil = 0
+    this.faults = []
+    if (this.timer) {
+      clearTimeout(this.timer)
+      this.timer = null
+    }
   }
 
   startError(): Error | null {

--- a/src/main/ai-vault/session-scanner-service-spawn.ts
+++ b/src/main/ai-vault/session-scanner-service-spawn.ts
@@ -85,6 +85,11 @@ export function invalidateAiVaultServiceCache(paths: string[]): Promise<void> {
   return sharedClient?.invalidate(paths) ?? Promise.resolve()
 }
 
+/** A forced refresh is a deliberate user action, so it reopens the restart circuit. */
+export function clearAiVaultServiceRestartCircuit(): void {
+  sharedClient?.clearRestartCircuit()
+}
+
 export function resetAiVaultScannerServiceForTests(): void {
   sharedClient?.dispose()
   sharedClient = null

--- a/src/main/ipc/ai-vault.ts
+++ b/src/main/ipc/ai-vault.ts
@@ -15,6 +15,7 @@ import {
 import { scanSshAiVaultSessions } from '../ai-vault/ssh-session-list'
 import { AiVaultScanCoordinator } from '../ai-vault/ai-vault-scan-coordinator'
 import type { AiVaultDeleteSessionArgs } from '../../shared/ai-vault-session-deletion'
+import { describeAiVaultScanError } from '../../shared/ai-vault-scan-error-message'
 import {
   AI_VAULT_SCOPE_PATHS_MAX_COUNT,
   isAiVaultScanCancelledError,
@@ -237,10 +238,14 @@ async function scanLocalAiVaultSessionsAsIssue(
     if (isAiVaultScanCancelledError(error)) {
       throw error
     }
+    // Raw supervision text ("restart circuit is open") means nothing to a user,
+    // so the row carries actionable copy and the log keeps the original.
+    const raw = error instanceof Error ? error.message : 'Local session scan failed.'
+    console.error('[ai-vault] local session scan failed:', raw)
     return aiVaultScanIssueResult({
       executionHostId: LOCAL_EXECUTION_HOST_ID,
       path: 'this computer',
-      message: error instanceof Error ? error.message : 'Local session scan failed.'
+      message: describeAiVaultScanError(raw)
     })
   }
 }

--- a/src/main/runtime/rpc/methods/ai-vault.test.ts
+++ b/src/main/runtime/rpc/methods/ai-vault.test.ts
@@ -79,6 +79,14 @@ function makeDispatcher(): RpcDispatcher {
   return new RpcDispatcher({ runtime, methods: AI_VAULT_METHODS })
 }
 
+function makeFailingDispatcher(error: Error): RpcDispatcher {
+  const runtime = {
+    getRuntimeId: () => 'test-runtime',
+    listAiVaultSessions: vi.fn().mockRejectedValue(error)
+  } as unknown as OrcaRuntimeService
+  return new RpcDispatcher({ runtime, methods: AI_VAULT_METHODS })
+}
+
 describe('aiVault.resolveSessionTitles handler', () => {
   beforeEach(() => {
     resolveAiVaultSessionTitlesInWorker.mockReset()
@@ -227,6 +235,17 @@ describe('aiVault.listSessions handler + shared cache', () => {
     const dispatcher = makeDispatcher()
     const response = await dispatcher.dispatch(makeRequest('aiVault.listSessions', { limit: 500 }))
     expect(response).toMatchObject({ ok: true, result: makeResult() })
+  })
+
+  it('humanizes scanner supervision errors for remote clients', async () => {
+    const dispatcher = makeFailingDispatcher(new Error('AI Vault service restart circuit is open.'))
+
+    await expect(
+      dispatcher.dispatch(makeRequest('aiVault.listSessions', { limit: 500 }))
+    ).resolves.toMatchObject({
+      ok: false,
+      error: { message: 'Session scanning paused after repeated failures. Refresh to try again.' }
+    })
   })
 
   it('passes only the first 64 scopePaths to the scanner when a request exceeds the cap', async () => {

--- a/src/main/runtime/rpc/methods/ai-vault.test.ts
+++ b/src/main/runtime/rpc/methods/ai-vault.test.ts
@@ -248,6 +248,25 @@ describe('aiVault.listSessions handler + shared cache', () => {
     })
   })
 
+  it('preserves structured runtime error metadata while humanizing its message', async () => {
+    const error = Object.assign(new Error('AI Vault service restart circuit is open.'), {
+      code: 'runtime_timeout',
+      data: { retryAfterMs: 5000 }
+    })
+    const dispatcher = makeFailingDispatcher(error)
+
+    await expect(
+      dispatcher.dispatch(makeRequest('aiVault.listSessions', { limit: 500 }))
+    ).resolves.toMatchObject({
+      ok: false,
+      error: {
+        code: 'runtime_timeout',
+        message: 'Session scanning paused after repeated failures. Refresh to try again.',
+        data: { retryAfterMs: 5000 }
+      }
+    })
+  })
+
   it('passes only the first 64 scopePaths to the scanner when a request exceeds the cap', async () => {
     const dispatcher = makeDispatcher()
     const scopePaths = Array.from({ length: 65 }, (_, index) => `/p/${index}`)

--- a/src/main/runtime/rpc/methods/ai-vault.ts
+++ b/src/main/runtime/rpc/methods/ai-vault.ts
@@ -93,8 +93,11 @@ export const AI_VAULT_METHODS: RpcMethod[] = [
           scopePaths: params.scopePaths
         })
       } catch (error) {
-        const raw = error instanceof Error ? error.message : String(error)
-        throw new Error(describeAiVaultScanError(raw))
+        if (error instanceof Error) {
+          error.message = describeAiVaultScanError(error.message)
+          throw error
+        }
+        throw new Error(describeAiVaultScanError(String(error)))
       }
       // Why: web clients consume this response directly (no parent-side retag),
       // so sessions must come back stamped as the runtime host they addressed.

--- a/src/main/runtime/rpc/methods/ai-vault.ts
+++ b/src/main/runtime/rpc/methods/ai-vault.ts
@@ -5,6 +5,7 @@ import { restampAiVaultListResult } from '../../../ai-vault/session-list-results
 import { AI_VAULT_AGENTS, AI_VAULT_SCOPE_PATHS_MAX_COUNT } from '../../../../shared/ai-vault-types'
 import { AI_VAULT_SESSION_TITLE_REQUEST_MAX_COUNT } from '../../../../shared/ai-vault-session-title'
 import { LOCAL_EXECUTION_HOST_ID, parseExecutionHostId } from '../../../../shared/execution-host'
+import { describeAiVaultScanError } from '../../../../shared/ai-vault-scan-error-message'
 
 // Why: bound limit + scopePaths so a client cannot force an unbounded scan.
 // Each scopePath is a host-local match prefix (validated/capped, never used for
@@ -83,12 +84,18 @@ export const AI_VAULT_METHODS: RpcMethod[] = [
     name: 'aiVault.listSessions',
     params: AiVaultListSessionsParams,
     handler: async (params, { runtime }) => {
-      const result = await runtime.listAiVaultSessions({
-        limit: params.unlimited ? undefined : params.limit,
-        unlimited: params.unlimited,
-        force: params.force,
-        scopePaths: params.scopePaths
-      })
+      let result
+      try {
+        result = await runtime.listAiVaultSessions({
+          limit: params.unlimited ? undefined : params.limit,
+          unlimited: params.unlimited,
+          force: params.force,
+          scopePaths: params.scopePaths
+        })
+      } catch (error) {
+        const raw = error instanceof Error ? error.message : String(error)
+        throw new Error(describeAiVaultScanError(raw))
+      }
       // Why: web clients consume this response directly (no parent-side retag),
       // so sessions must come back stamped as the runtime host they addressed.
       return params.executionHostId

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.ts
@@ -4,6 +4,7 @@ import {
   type AiVaultListResult,
   type AiVaultSession
 } from '../../../../shared/ai-vault-types'
+import { describeAiVaultScanError } from '../../../../shared/ai-vault-scan-error-message'
 import {
   ALL_EXECUTION_HOSTS_SCOPE,
   requestedExecutionHostScope,
@@ -193,7 +194,7 @@ export function useAiVaultSessionRefresh(
           refreshIdRef.current === refreshId &&
           scanKey === currentScanScopeKey()
         ) {
-          setError(err instanceof Error ? err.message : String(err))
+          setError(describeAiVaultScanError(err instanceof Error ? err.message : String(err)))
         }
       } finally {
         refreshInFlightRef.current = false

--- a/src/shared/ai-vault-scan-error-message.test.ts
+++ b/src/shared/ai-vault-scan-error-message.test.ts
@@ -79,6 +79,11 @@ describe('describeAiVaultScanError', () => {
         "Error invoking remote method 'aiVault:listSessions': Error: SSH relay is not ready"
       )
     ).toBe('SSH relay is not ready')
-    expect(describeAiVaultScanError('Relay Scanner is not ready')).toBe('Scanner is not ready')
+    expect(describeAiVaultScanError('Relay AI Vault scanner is not ready')).toBe(
+      'AI Vault scanner is not ready'
+    )
+    expect(describeAiVaultScanError('Relay client is not connected')).toBe(
+      'Relay client is not connected'
+    )
   })
 })

--- a/src/shared/ai-vault-scan-error-message.test.ts
+++ b/src/shared/ai-vault-scan-error-message.test.ts
@@ -72,4 +72,13 @@ describe('describeAiVaultScanError', () => {
     expect(describeAiVaultScanError(authored)).toBe(authored)
     expect(describeAiVaultScanError('SSH relay is not ready')).toBe('SSH relay is not ready')
   })
+
+  it('removes transport wrappers before passing through an unknown message', () => {
+    expect(
+      describeAiVaultScanError(
+        "Error invoking remote method 'aiVault:listSessions': Error: SSH relay is not ready"
+      )
+    ).toBe('SSH relay is not ready')
+    expect(describeAiVaultScanError('Relay Scanner is not ready')).toBe('Scanner is not ready')
+  })
 })

--- a/src/shared/ai-vault-scan-error-message.test.ts
+++ b/src/shared/ai-vault-scan-error-message.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { describeAiVaultScanError } from './ai-vault-scan-error-message'
+
+describe('describeAiVaultScanError', () => {
+  it('replaces the restart-circuit wording with an actionable line', () => {
+    expect(describeAiVaultScanError('AI Vault service restart circuit is open.')).toBe(
+      'Session scanning paused after repeated failures. Refresh to try again.'
+    )
+  })
+
+  it('renders the scan timeout in seconds', () => {
+    expect(describeAiVaultScanError('AI Vault service timed out after 130000ms.')).toBe(
+      'Session scan timed out after 130s — the machine may be busy. Refresh to try again.'
+    )
+  })
+
+  it('keeps the SSH host in the timeout copy', () => {
+    expect(
+      describeAiVaultScanError(
+        'Agent Session History scan timed out after 130000ms on this SSH host.'
+      )
+    ).toBe('Session scan timed out after 130s on this SSH host. Refresh to try again.')
+  })
+
+  it('humanizes the relay-hosted variant of the same fault', () => {
+    expect(describeAiVaultScanError('Relay AI Vault service restart circuit is open.')).toBe(
+      'Session scanning paused after repeated failures. Refresh to try again.'
+    )
+  })
+
+  it('strips the Electron invoke wrapper before matching', () => {
+    expect(
+      describeAiVaultScanError(
+        "Error invoking remote method 'aiVault:listSessions': Error: AI Vault service did not become ready."
+      )
+    ).toBe('The session scanner stopped unexpectedly. Refresh to try again.')
+  })
+
+  it.each([
+    ['AI Vault service disconnected.', 'The session scanner stopped unexpectedly.'],
+    ['AI Vault service exited (null).', 'The session scanner stopped unexpectedly.'],
+    ['AI Vault scanner worker exited with code 1.', 'The session scanner stopped unexpectedly.'],
+    ['AI Vault service sent a malformed message.', 'The session scanner stopped unexpectedly.']
+  ])('covers the supervision fault %s', (raw, expected) => {
+    expect(describeAiVaultScanError(raw)).toBe(`${expected} Refresh to try again.`)
+  })
+
+  it('routes a missing scanner entry to install guidance, not a retry', () => {
+    const described = describeAiVaultScanError('AI Vault service entry not found: /a/b.js')
+    expect(described).toBe(
+      'The session scanner is missing from this Orca install. Reinstalling Orca restores it.'
+    )
+    expect(described).not.toContain('Refresh')
+  })
+
+  it('never leaks internal vocabulary a user cannot act on', () => {
+    for (const raw of [
+      'AI Vault service restart circuit is open.',
+      'AI Vault service timed out after 130000ms.',
+      'AI Vault service queue is full.',
+      'AI Vault service cache invalidation timed out.',
+      'AI Vault service did not cancel within 2000ms.',
+      'AI Vault service client was disposed.'
+    ]) {
+      const described = describeAiVaultScanError(raw)
+      expect(described).not.toMatch(/circuit|ms\.|AI Vault service|scanner worker/)
+    }
+  })
+
+  it('passes scanner-authored messages through untouched', () => {
+    const authored = 'Could not read /Users/x/.codex/sessions: EACCES'
+    expect(describeAiVaultScanError(authored)).toBe(authored)
+    expect(describeAiVaultScanError('SSH relay is not ready')).toBe('SSH relay is not ready')
+  })
+})

--- a/src/shared/ai-vault-scan-error-message.ts
+++ b/src/shared/ai-vault-scan-error-message.ts
@@ -8,8 +8,8 @@ const RETRY = 'Refresh to try again.'
 
 /** Electron wraps every rejected `ipcMain.handle` before the renderer sees it. */
 const IPC_INVOKE_PREFIX = /^Error invoking remote method '[^']*': (?:\w*Error: )?/
-/** Relay-hosted scans reuse the local wording behind a `Relay ` prefix. */
-const RELAY_PREFIX = /^Relay (?=AI Vault )/
+/** Relay-hosted scan errors carry a transport-only `Relay ` prefix. */
+const RELAY_PREFIX = /^Relay /
 /** Both the fork-based service and the legacy worker thread emit this family. */
 const SCANNER = String.raw`AI Vault (?:service|scanner worker)`
 
@@ -46,5 +46,5 @@ function humanize(text: string): string | null {
 /** Returns user-facing copy, or the original text when it is already meaningful. */
 export function describeAiVaultScanError(raw: string): string {
   const text = raw.replace(IPC_INVOKE_PREFIX, '').replace(RELAY_PREFIX, '')
-  return humanize(text) ?? raw
+  return humanize(text) ?? text
 }

--- a/src/shared/ai-vault-scan-error-message.ts
+++ b/src/shared/ai-vault-scan-error-message.ts
@@ -1,0 +1,50 @@
+/**
+ * Maps the session scanner's internal supervision errors onto copy a user can
+ * act on. Applied at both surfaces the panel paints: the local leg's scan-issue
+ * row and the thrown-rejection banner. Anything unrecognized passes through, so
+ * scanner-authored messages (host name, remote path, cap) keep their own wording.
+ */
+const RETRY = 'Refresh to try again.'
+
+/** Electron wraps every rejected `ipcMain.handle` before the renderer sees it. */
+const IPC_INVOKE_PREFIX = /^Error invoking remote method '[^']*': (?:\w*Error: )?/
+/** Relay-hosted scans reuse the local wording behind a `Relay ` prefix. */
+const RELAY_PREFIX = /^Relay (?=AI Vault )/
+/** Both the fork-based service and the legacy worker thread emit this family. */
+const SCANNER = String.raw`AI Vault (?:service|scanner worker)`
+
+function toSeconds(ms: string): number {
+  return Math.max(1, Math.round(Number(ms) / 1000))
+}
+
+function humanize(text: string): string | null {
+  const sshTimeout = /^Agent Session History scan timed out after (\d+)ms on this SSH host\.$/.exec(
+    text
+  )
+  if (sshTimeout) {
+    return `Session scan timed out after ${toSeconds(sshTimeout[1]!)}s on this SSH host. ${RETRY}`
+  }
+  const timeout = new RegExp(String.raw`^${SCANNER} timed out after (\d+)ms\.$`).exec(text)
+  if (timeout) {
+    return `Session scan timed out after ${toSeconds(timeout[1]!)}s — the machine may be busy. ${RETRY}`
+  }
+  if (text === 'AI Vault service restart circuit is open.') {
+    return `Session scanning paused after repeated failures. ${RETRY}`
+  }
+  if (new RegExp(String.raw`^${SCANNER} (?:client )?queue is full\.$`).test(text)) {
+    return 'Too many session scans in flight. Wait a moment, then refresh.'
+  }
+  if (new RegExp(String.raw`^${SCANNER} entry not found: `).test(text)) {
+    return 'The session scanner is missing from this Orca install. Reinstalling Orca restores it.'
+  }
+  if (new RegExp(String.raw`^${SCANNER}\b`).test(text)) {
+    return `The session scanner stopped unexpectedly. ${RETRY}`
+  }
+  return null
+}
+
+/** Returns user-facing copy, or the original text when it is already meaningful. */
+export function describeAiVaultScanError(raw: string): string {
+  const text = raw.replace(IPC_INVOKE_PREFIX, '').replace(RELAY_PREFIX, '')
+  return humanize(text) ?? raw
+}

--- a/src/shared/ai-vault-scan-error-message.ts
+++ b/src/shared/ai-vault-scan-error-message.ts
@@ -8,8 +8,8 @@ const RETRY = 'Refresh to try again.'
 
 /** Electron wraps every rejected `ipcMain.handle` before the renderer sees it. */
 const IPC_INVOKE_PREFIX = /^Error invoking remote method '[^']*': (?:\w*Error: )?/
-/** Relay-hosted scan errors carry a transport-only `Relay ` prefix. */
-const RELAY_PREFIX = /^Relay /
+/** Relay-hosted scanner errors carry a transport-only `Relay ` prefix. */
+const RELAY_PREFIX = /^Relay (?=AI Vault )/
 /** Both the fork-based service and the legacy worker thread emit this family. */
 const SCANNER = String.raw`AI Vault (?:service|scanner worker)`
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​224 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​224 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​139 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​24 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​115 |

<!-- /orca-pr-loc -->

## ELI5

The Agent Session History panel was showing users the scanner's own internal
error text. "AI Vault service restart circuit is open." means nothing to anyone
who hasn't read the supervisor code. Now it says what happened and what to do.

While fixing the copy I found the advice it *should* give was a lie: the refresh
button genuinely couldn't recover from that state on a local machine. Fixed that
too, so "Refresh to try again." is true.

## What Changed

**1. Panel copy.** New `src/shared/ai-vault-scan-error-message.ts` maps the
scanner's supervision-error family onto copy tied to an action:

| Before | After |
|---|---|
| `AI Vault service restart circuit is open.` | `Session scanning paused after repeated failures. Refresh to try again.` |
| `AI Vault service timed out after 130000ms.` | `Session scan timed out after 130s — the machine may be busy. Refresh to try again.` |
| `AI Vault service did not become ready.` / `disconnected.` / `exited (null).` | `The session scanner stopped unexpectedly. Refresh to try again.` |
| `AI Vault service entry not found: …` | `The session scanner is missing from this Orca install. Reinstalling Orca restores it.` |

Anything unrecognized passes through unchanged, so scanner-authored messages
(host name, remote path, the 500-issue cap) keep their own wording — the design
`AiVaultScanIssueBanners` already documents. The mapper also strips Electron's
`Error invoking remote method '…': Error:` wrapper, which several other panels
strip but this path never did.

Applied at both surfaces the panel paints:
- the local leg's scan-issue row (`src/main/ipc/ai-vault.ts`) — this is the one
  in the screenshots below, since the local leg degrades to an issue rather than
  a rejection
- the thrown-rejection banner (`ai-vault-session-refresh.ts`)

Humanizing in main rather than the renderer means remote/mobile clients get it
too. The raw text now goes to the main log so it stays debuggable.

**2. A forced refresh reopens the restart circuit.** The relay path already does
this — *"A forced refresh is a deliberate user action, so it reopens the
circuit"* (`src/relay/ai-vault-service-restart-policy.ts`). The local path had no
equivalent: `force` stopped at the cache layer in `cached-session-list.ts` and
never reached the supervisor, so once the circuit opened the refresh button was
inert for the full 60s fault window.

**3. Line-budget housekeeping.** `session-scanner-service-client.ts` was at
299/300 lines, so the 3-line addition tripped `max-lines`. Rather than bump the
ceiling, the child-listener and init-frame wiring moves to
`attachAiVaultServiceChild` in the state module, next to the ready-waiter and
retirement helpers it already collaborates with. Behavior-preserving.

## Why

Reported from a real session on a machine under heavy load. The failure chain:

1. The scan runs in a forked child that is deliberately deprioritized to
   `PRIORITY_BELOW_NORMAL` (`session-scanner-service-priority.ts`), so under load
   it is first to be starved.
2. A scan gets 130s (`AI_VAULT_SERVICE_SCAN_TIMEOUT_MS`). It blew that → fault #1,
   and the child is killed. **First screenshot.**
3. The supervisor respawns, but a fresh child must send `ready` within **5s**
   (`AI_VAULT_SERVICE_READY_TIMEOUT_MS`). Forking Node and loading the scanner
   entry inside a below-normal-priority process on a loaded machine routinely
   misses that. Each miss is another fault.
4. Three faults in a 60s window opens the circuit for 60s. **Second screenshot,
   ~15 seconds after the first.**

So a single slow scan escalates to an open circuit in about fifteen seconds, and
the user is shown two different pieces of internal vocabulary for it.

**Deliberately not in scope:** the underlying load sensitivity. The honest fix is
that a *readiness* miss should not count the same as a *crash* toward a breaker
designed to catch crash-loops — a starved fork is not a broken service. That is a
behavior change to the supervision policy and deserves its own PR with its own
reasoning about what the budgets should be. This PR only stops the panel from
speaking in internals, and makes the recovery it advertises actually work.

## Linked Issue

No Linear issue — reported directly from a live session. Happy to file one for
the supervision-policy follow-up described above.

## Visual Proof

**Before/after and a live recovery check are in [this comment](https://github.com/stablyai/orca/pull/16229#issuecomment-5391945537).**
Reproducing the states needs the scanner deliberately wedged (the real trigger is
a 130s scan overrun on a loaded machine), so it is a fault-injection capture
rather than a click-through.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

**Automated:**
- `src/shared/ai-vault-scan-error-message.test.ts` (new, 12 tests) — covers each
  mapped family, the relay-prefixed variant, the Electron invoke wrapper, ms→s
  rendering, and two negative guarantees: no output leaks internal vocabulary
  (`circuit`, `AI Vault service`, raw `ms`), and scanner-authored messages pass
  through byte-identical.
- `session-scanner-service-client.test.ts` — new acceptance test for the forced
  circuit reopen. **Verified red before the fix** (`expected [ …(3) ] to have a
  length of 4` — no respawn) and green after.
- Full `src/main/ai-vault` suite: 73 files / 454 tests pass.
- `pnpm typecheck` (node + web projects) and `oxlint` clean on all changed files.

**Manual:** local Electron dev build on macOS against a real workspace (10 repos /
724 worktrees), driven over CDP. Reproduced the reported circuit-open row, confirmed
the new copy in the same state, and confirmed a single Refresh recovers the panel
(`500 shown · 500 recent`) instead of staying dead for the fault window. All QA
edits reverted; working tree verified clean against the commit.

**Platforms:** no platform-dependent code paths are touched — the mapper is pure
string work and the circuit reset is plain in-process state. The SSH/remote
variant of the timeout string is covered by unit test rather than a live host.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Remote wire compatibility:** no wire shape change. `AiVaultScanIssue.message`
  is display text and stays a `string`; only its content changes. Per
  `docs/reference/remote-wire-compatibility.md` this is the "changing what the
  host publishes reaches old clients" case — intended here, since an old client
  showing the new copy is strictly the improvement. No new fields, no new opcodes,
  no capability negotiation needed.
- **SSH / remote:** the SSH leg's own timeout string is mapped alongside the local
  one and keeps its "on this SSH host" qualifier, so the host attribution a user
  needs to act on survives.
- **Mobile:** benefits automatically — humanization happens at the producer in
  main, not in the Electron renderer.
- **Cross-platform:** no path, shell, or shortcut handling involved.
- **Performance:** the mapper runs once per failed scan, on an error path only.
- **Backwards compatibility:** nothing keys off these strings; both call sites
  render them directly into a `<div>`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots attached for UI changes
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm typecheck` and lint pass locally; targeted + full `src/main/ai-vault`
      suites pass. CI covers the rest.

