### PR TITLE
fix(notes): match mirrored targets to runtime terminals

### DIFF
--- a/src/renderer/src/lib/active-agent-note-send-explicit-target.test.ts
+++ b/src/renderer/src/lib/active-agent-note-send-explicit-target.test.ts
@@ -11,6 +11,7 @@ import {
   PASTE_END,
   type NoteSendAppState
 } from './active-agent-note-send-test-harness'
+import { toWebTerminalSurfaceTabId } from '../../../shared/terminal-surface-id'
 
 const testState = vi.hoisted(() => ({
   appState: null as unknown as NoteSendAppState,
@@ -52,9 +53,11 @@ describe('active agent note send', () => {
     testState.getActiveRuntimeTarget.mockReturnValue({ kind: 'local' })
   })
 
-  it('sends notes immediately to an explicit note target using bracketed paste and Enter', async () => {
+  it('sends notes to a mirrored explicit target using the raw runtime tab identity', async () => {
     testState.appState.activeTabType = 'editor'
     testState.appState.activeTabIdByWorktree = {}
+    const hostTabId = 'host-tab-9'
+    const mirroredTabId = toWebTerminalSurfaceTabId(hostTabId)
     const methods: string[] = []
     testState.callRuntimeRpc.mockImplementation(async (_target, method, params) => {
       methods.push(method)
@@ -66,7 +69,7 @@ describe('active agent note send', () => {
               worktreeId: 'wt-1',
               worktreePath: '/repo',
               branch: 'main',
-              tabId: 'tab-9',
+              tabId: hostTabId,
               leafId: OTHER_LEAF_ID,
               title: 'Codex',
               connected: true,
@@ -98,7 +101,7 @@ describe('active agent note send', () => {
       sendNotesToActiveAgentSession({
         worktreeId: 'wt-1',
         prompt: 'notes',
-        noteTarget: { tabId: 'tab-9', leafId: OTHER_LEAF_ID }
+        noteTarget: { tabId: mirroredTabId, leafId: OTHER_LEAF_ID }
       })
     ).resolves.toEqual({ status: 'sent' })
 

--- a/src/renderer/src/lib/active-agent-note-target.ts
+++ b/src/renderer/src/lib/active-agent-note-target.ts
@@ -1,4 +1,5 @@
 import type { RuntimeTerminalListResult } from '../../../shared/runtime-types'
+import { toHostSessionTabId } from '../../../shared/terminal-surface-id'
 import {
   AGENT_STATUS_STALE_AFTER_MS,
   type AgentStatusEntry
@@ -174,9 +175,11 @@ export async function findActiveRuntimeTerminal(
     },
     { timeoutMs }
   )
+  // Why: paired renderer tabs wrap the host id with `web-terminal-*`.
+  const runtimeTabId = toHostSessionTabId(noteTarget.tabId)
   return (
     terminals.find(
-      (terminal) => terminal.tabId === noteTarget.tabId && terminal.leafId === noteTarget.leafId
+      (terminal) => terminal.tabId === runtimeTabId && terminal.leafId === noteTarget.leafId
     ) ?? null
   )
 }


### PR DESCRIPTION
## ELI5

In a paired Orca session, the renderer gives a mirrored terminal tab a local `web-terminal-*` ID, while the runtime still lists that same terminal by its raw host ID. Review-note sending compared those two spellings directly, so it incorrectly reported that the selected terminal was unavailable. This change translates the renderer ID back to the runtime ID at the lookup boundary.

## What Changed

- Normalize the selected renderer tab ID with the existing `toHostSessionTabId()` codec before matching `terminal.list` results.
- Keep exact worktree routing, leaf matching, live runtime handle lookup, and guarded paste/Enter authorization unchanged.
- Update the explicit-target regression test to model a mirrored renderer ID against a raw runtime terminal ID.

## Why

Paired-runtime Markdown review notes currently fail with "The selected terminal is no longer available" even when the agent terminal is connected and writable. The renderer stores mirrored tabs as `web-terminal-*`, but `terminal.list` publishes the raw host tab ID.

Normalizing only at the renderer-to-runtime inventory boundary fixes the identity mismatch without rewriting renderer store keys or changing the wire protocol.

## Linked Issue

Fixes #16225

## Visual Proof

N/A — no visual layout, styling, or copy changed. This is an identity lookup fix at the renderer/runtime boundary; the paired identity behavior is covered by the explicit-send regression test.

## Testing

- [ ] I manually tested these changes in a live paired desktop session — not run locally; the exact paired-ID case is covered by the regression test below.
- [x] Automated tests added/updated, or explained why not below
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/active-agent-note-send-explicit-target.test.ts src/renderer/src/lib/active-agent-note-send-target-detection.test.ts src/renderer/src/lib/active-agent-note-send-focused-session.test.ts` — 34/34 passed
- `pnpm lint` — passed
- `pnpm typecheck` — passed
- `pnpm build` — passed
- Full Vitest run completed 57,662 tests with one unrelated load-sensitive timeout in `src/relay/subprocess.test.ts`; that file passed immediately standalone (31/31). Remote CI will provide the clean-suite signal.

Platforms and environments reviewed:

- macOS: local automated validation and full build completed.
- Linux/Windows: no platform-specific code changed; cross-platform relay/build outputs passed.
- Local/SSH/folder workspaces: non-mirrored IDs are identity-preserving through the codec.
- Paired runtime/mixed versions: client-only normalization; no RPC schema, opcode, or host publication change.
- Mobile: N/A; no mobile surface or protocol changed.

## AI Disclosure

Implemented and reviewed with OpenAI Codex (GPT-5.6).

## Review

- Security: exact worktree target, tab/leaf match, live handle lookup, and guarded-send checks remain intact.
- Cross-platform: pure string identity conversion; no OS-specific paths, APIs, or shortcuts.
- Remote/SSH/local: `toHostSessionTabId()` leaves non-mirrored IDs unchanged.
- Agents/integrations: provider-neutral; all agents continue through the existing guarded-send path.
- Performance: one bounded prefix/decode operation per probe/send.
- UI quality: no layout, styling, or copy changes.
- Backwards compatibility: no wire or content contract change; new clients remain compatible with existing hosts.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- X handle: Not provided.
- StablyAI contributor status: Not provided.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, and `pnpm build` pass; the local full-test exception is documented above and remote CI will verify the suite