### PR TITLE
fix(orchestration): fail worker startup on early agent exit

### DIFF
--- a/NOTAS.md
+++ b/NOTAS.md
@@ -1,0 +1,20 @@
+# Correctivo del criterio 8
+
+## Cambios
+
+- La salida confirmada del agente durante `worker-start` registra la autoridad exacta de la terminal creada antes de fallar el Dispatch.
+- Tras registrar el fallo, reutiliza la liberación normal (`requestWorkerTerminalRelease` y `completeWorkerTerminalRelease`) y elimina la terminal liquidada de `residualResources`.
+- La prueba directa cubre Codex y OpenCode con salida cero, y OpenCode con salida distinta de cero; exige `residualResources: []` y el cierre de `term_worker`.
+
+## Decisiones
+
+- La liberación automática se limita a terminales creadas por el arranque; una terminal explícita reutilizada conserva su propiedad externa.
+- Si la liberación no puede confirmarse, se conserva el recibo original con su recurso residual para no declarar una liquidación falsa.
+- No se modificó la detección de salida, el diagnóstico ni el formato del recibo fuera del recurso ya liberado.
+
+## Dudas y validación
+
+- Sin dudas funcionales pendientes.
+- La batería del paquete pasó: 1.222 pruebas y 1 omitida.
+- La suite global directa obtuvo 57.476 pasadas, 254 omitidas y tres fallos ambientales: dos de `node-pty-fd-leak.test.ts` por faltar el binario parcheado y uno del arnés cross-version por no disponer de tags estables.
+- `pnpm test` no llegó a Vitest porque `ensure-native-runtime` no pudo cargar el `node-pty` parcheado para Node 24.3.0.

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -36622,7 +36622,8 @@ describe('OrcaRuntimeService', () => {
       const [terminal] = (await runtime.listTerminals()).terminals
       const waitPromise = runtime.waitForTerminal(terminal.handle, {
         condition: 'tui-idle',
-        timeoutMs: 1_000
+        timeoutMs: 1_000,
+        superviseCommandExit: true
       })
       const timeoutAssertion = expect(waitPromise).rejects.toThrow('timeout')
 
@@ -36632,6 +36633,210 @@ describe('OrcaRuntimeService', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('fails tui-idle immediately when the launched command exits zero', async () => {
+    const runtime = new OrcaRuntimeService(store)
+
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-1',
+          worktreeId: 'repo-1::/tmp/worktree-a',
+          title: 'OpenCode',
+          activeLeafId: 'pane:1',
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-1',
+          worktreeId: 'repo-1::/tmp/worktree-a',
+          leafId: 'pane:1',
+          paneRuntimeId: 1,
+          ptyId: 'pty-1'
+        }
+      ]
+    })
+    const [terminal] = (await runtime.listTerminals()).terminals
+    const wait = runtime.waitForTerminal(terminal.handle, {
+      condition: 'tui-idle',
+      timeoutMs: 60_000,
+      superviseCommandExit: true
+    })
+
+    runtime.onPtyData(
+      'pty-1',
+      '\x1b]133;C\x07OpenCode startup failed\n\x1b]133;D;0\x07',
+      Date.now()
+    )
+    runtime.onPtyData('pty-1', '\x1b]0;✳ Late readiness\x07', Date.now())
+
+    await expect(wait).resolves.toMatchObject({
+      satisfied: false,
+      status: 'exited',
+      exitCode: 0
+    })
+    await expect(runtime.readTerminal(terminal.handle)).resolves.toMatchObject({
+      tail: expect.arrayContaining([expect.stringContaining('OpenCode startup failed')])
+    })
+  })
+
+  it('replays a pre-wait command exit and preserves its nonzero code', async () => {
+    const runtime = new OrcaRuntimeService(store)
+
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-1',
+          worktreeId: 'repo-1::/tmp/worktree-a',
+          title: 'Agent',
+          activeLeafId: 'pane:1',
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-1',
+          worktreeId: 'repo-1::/tmp/worktree-a',
+          leafId: 'pane:1',
+          paneRuntimeId: 1,
+          ptyId: 'pty-1'
+        }
+      ]
+    })
+    runtime.onPtyData('pty-1', '\x1b]133;C\x07failed\x1b]133;D;23\x07', Date.now())
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    await expect(
+      runtime.waitForTerminal(terminal.handle, {
+        condition: 'tui-idle',
+        timeoutMs: 60_000,
+        superviseCommandExit: true
+      })
+    ).resolves.toMatchObject({ satisfied: false, status: 'exited', exitCode: 23 })
+  })
+
+  it('does not supervise command completion for an ordinary tui-idle wait', async () => {
+    const runtime = new OrcaRuntimeService(store)
+
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-1',
+          worktreeId: 'repo-1::/tmp/worktree-a',
+          title: 'Agent',
+          activeLeafId: 'pane:1',
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-1',
+          worktreeId: 'repo-1::/tmp/worktree-a',
+          leafId: 'pane:1',
+          paneRuntimeId: 1,
+          ptyId: 'pty-1'
+        }
+      ]
+    })
+    const [terminal] = (await runtime.listTerminals()).terminals
+    const wait = runtime.waitForTerminal(terminal.handle, {
+      condition: 'tui-idle',
+      timeoutMs: 60_000
+    })
+
+    runtime.onPtyData('pty-1', '\x1b]133;C\x07failed\x1b]133;D;1\x07', Date.now())
+    runtime.onPtyData('pty-1', '\x1b]0;✳ Ready\x07', Date.now())
+
+    await expect(wait).resolves.toMatchObject({
+      satisfied: true,
+      status: 'running',
+      exitCode: null
+    })
+  })
+
+  it('lets readiness win once when command completion follows it', async () => {
+    const runtime = new OrcaRuntimeService(store)
+
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-1',
+          worktreeId: 'repo-1::/tmp/worktree-a',
+          title: 'Agent',
+          activeLeafId: 'pane:1',
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-1',
+          worktreeId: 'repo-1::/tmp/worktree-a',
+          leafId: 'pane:1',
+          paneRuntimeId: 1,
+          ptyId: 'pty-1'
+        }
+      ]
+    })
+    const [terminal] = (await runtime.listTerminals()).terminals
+    const wait = runtime.waitForTerminal(terminal.handle, {
+      condition: 'tui-idle',
+      timeoutMs: 60_000,
+      superviseCommandExit: true
+    })
+
+    runtime.onPtyData('pty-1', '\x1b]133;C\x07\x1b]0;✳ Ready\x07', Date.now())
+    runtime.onPtyData('pty-1', '\x1b]133;D;7\x07', Date.now())
+
+    await expect(wait).resolves.toMatchObject({
+      satisfied: true,
+      status: 'running',
+      exitCode: null
+    })
+  })
+
+  it('returns a zero PTY exit as failed readiness instead of waiting for timeout', async () => {
+    const runtime = new OrcaRuntimeService(store)
+
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-1',
+          worktreeId: 'repo-1::/tmp/worktree-a',
+          title: 'Agent',
+          activeLeafId: 'pane:1',
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-1',
+          worktreeId: 'repo-1::/tmp/worktree-a',
+          leafId: 'pane:1',
+          paneRuntimeId: 1,
+          ptyId: 'pty-1'
+        }
+      ]
+    })
+    const [terminal] = (await runtime.listTerminals()).terminals
+    const wait = runtime.waitForTerminal(terminal.handle, {
+      condition: 'tui-idle',
+      timeoutMs: 60_000
+    })
+
+    runtime.onPtyExit('pty-1', 0)
+
+    await expect(wait).resolves.toMatchObject({
+      satisfied: false,
+      status: 'exited',
+      exitCode: 0
+    })
   })
 
   it('tui-idle resolves on agent working→idle OSC title transition', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -37,6 +37,7 @@ import {
   type TerminalTitleFactMeta,
   type TerminalTitleTracker
 } from '../../shared/terminal-output-side-effects'
+import { createOsc133CommandFinishedScanner } from '../../shared/terminal-osc133-command-finished'
 import { getDecorativeAgentTitleSignature } from '../../shared/agent-decorative-title-signature'
 import { createCommandCodeOutputStatusDetector } from '../../shared/command-code-output-status'
 import type {
@@ -2326,6 +2327,7 @@ type TerminalWaiter = {
   reject: (error: Error) => void
   timeout: NodeJS.Timeout | null
   pollInterval: NodeJS.Timeout | null
+  dataCleanup: (() => void) | null
   abortCleanup: (() => void) | null
 }
 
@@ -15327,8 +15329,8 @@ export class OrcaRuntimeService {
       pty.runtimeSessionOwned = false
       this.setPairedRendererSessionOwnership(pty.ptyId, false)
       pty.disconnectedAt = Date.now()
-      pty.lastExitCode = exitCode
-      pty.lastExitCause = exitCause
+      pty.lastExitCode = preservesAbnormalSshSurface ? null : exitCode
+      pty.lastExitCause = preservesAbnormalSshSurface ? null : exitCause
       if (exitCode >= 0 || options?.hostExitConfirmed === true) {
         // A real wait status from the owning host is the death certificate; the
         // synthetic -1 we emit on a failed/unroutable stop is not.
@@ -15356,8 +15358,8 @@ export class OrcaRuntimeService {
       this.detachedPreAllocatedLeaves.delete(ptyId)
       leaf.connected = false
       leaf.writable = false
-      leaf.lastExitCode = exitCode
-      leaf.lastExitCause = exitCause
+      leaf.lastExitCode = preservesAbnormalSshSurface ? null : exitCode
+      leaf.lastExitCause = preservesAbnormalSshSurface ? null : exitCause
       leaf.lastAgentStatusObservedLive = false
       this.resolveExitWaiters(leaf)
       const leafHandle = this.handleByLeafKey.get(this.getLeafKey(leaf.tabId, leaf.leafId))
@@ -19616,13 +19618,24 @@ export class OrcaRuntimeService {
       condition?: RuntimeTerminalWaitCondition
       timeoutMs?: number
       signal?: AbortSignal
+      superviseCommandExit?: boolean
     }
   ): Promise<RuntimeTerminalWait> {
     const condition = options?.condition ?? 'exit'
     const pty = this.getLivePtyForHandle(handle)
     if (pty) {
-      if (condition === 'exit' && !pty.pty.connected) {
-        return buildPtyTerminalWaitResult(handle, condition, pty.pty)
+      if (!pty.pty.connected) {
+        if (this.getPtyLivenessVerdict(pty.pty.ptyId)?.status === 'unverifiable') {
+          return buildUnverifiableTerminalWaitResult(handle, condition)
+        }
+        return condition === 'exit'
+          ? buildPtyTerminalWaitResult(handle, condition, pty.pty)
+          : buildPrematureTerminalExitWaitResult(
+              handle,
+              condition,
+              pty.pty.lastExitCode,
+              pty.pty.lastExitCause
+            )
       }
       const ptyWaitText = buildTerminalWaitText(
         pty.pty.tailBuffer,
@@ -19657,6 +19670,7 @@ export class OrcaRuntimeService {
           reject,
           timeout: null,
           pollInterval: null,
+          dataCleanup: null,
           abortCleanup: null
         }
         if (!this.bindTerminalWaiterAbort(waiter, options?.signal)) {
@@ -19675,12 +19689,30 @@ export class OrcaRuntimeService {
           this.waitersByHandle.set(handle, waiters)
         }
         waiters.add(waiter)
+        if (condition === 'tui-idle' && options?.superviseCommandExit === true) {
+          this.startTuiIdleCommandExitWatch(waiter, pty.pty.ptyId)
+          if (!waiters.has(waiter)) {
+            return
+          }
+        }
         const live = this.getLivePtyForHandle(handle)
         if (!live) {
           this.removeWaiter(waiter)
           reject(new Error('terminal_handle_stale'))
-        } else if (condition === 'exit' && !live.pty.connected) {
-          this.resolveWaiter(waiter, buildPtyTerminalWaitResult(handle, condition, live.pty))
+        } else if (!live.pty.connected) {
+          this.resolveWaiter(
+            waiter,
+            this.getPtyLivenessVerdict(live.pty.ptyId)?.status === 'unverifiable'
+              ? buildUnverifiableTerminalWaitResult(handle, condition)
+              : condition === 'exit'
+                ? buildPtyTerminalWaitResult(handle, condition, live.pty)
+                : buildPrematureTerminalExitWaitResult(
+                    handle,
+                    condition,
+                    live.pty.lastExitCode,
+                    live.pty.lastExitCause
+                  )
+          )
         } else if (condition === 'tui-idle') {
           const livePtyWaitText = buildTerminalWaitText(
             live.pty.tailBuffer,
@@ -19708,8 +19740,23 @@ export class OrcaRuntimeService {
     }
     const { leaf } = this.getLiveLeafForHandle(handle)
 
-    if (condition === 'exit' && getTerminalState(leaf) === 'exited') {
-      return buildTerminalWaitResult(handle, condition, leaf)
+    if (
+      !leaf.connected &&
+      leaf.ptyId &&
+      this.getPtyLivenessVerdict(leaf.ptyId)?.status === 'unverifiable'
+    ) {
+      return buildUnverifiableTerminalWaitResult(handle, condition)
+    }
+
+    if (getTerminalState(leaf) === 'exited') {
+      return condition === 'exit'
+        ? buildTerminalWaitResult(handle, condition, leaf)
+        : buildPrematureTerminalExitWaitResult(
+            handle,
+            condition,
+            leaf.lastExitCode,
+            leaf.lastExitCause
+          )
     }
 
     const leafWaitText = buildTerminalWaitText(leaf.tailBuffer, leaf.tailPartialLine, leaf.preview)
@@ -19754,6 +19801,7 @@ export class OrcaRuntimeService {
         reject,
         timeout: null,
         pollInterval: null,
+        dataCleanup: null,
         abortCleanup: null
       }
 
@@ -19775,14 +19823,36 @@ export class OrcaRuntimeService {
         this.waitersByHandle.set(handle, waiters)
       }
       waiters.add(waiter)
+      if (condition === 'tui-idle' && leaf.ptyId && options?.superviseCommandExit === true) {
+        this.startTuiIdleCommandExitWatch(waiter, leaf.ptyId)
+        if (!waiters.has(waiter)) {
+          return
+        }
+      }
 
       // Why: the handle may go stale or exit in the small gap between the first
       // validation and waiter registration. Re-checking here keeps wait --for
       // exit honest instead of hanging on a terminal that already changed.
       try {
         const live = this.getLiveLeafForHandle(handle)
-        if (getTerminalState(live.leaf) === 'exited') {
-          this.resolveWaiter(waiter, buildTerminalWaitResult(handle, condition, live.leaf))
+        if (
+          !live.leaf.connected &&
+          live.leaf.ptyId &&
+          this.getPtyLivenessVerdict(live.leaf.ptyId)?.status === 'unverifiable'
+        ) {
+          this.resolveWaiter(waiter, buildUnverifiableTerminalWaitResult(handle, condition))
+        } else if (getTerminalState(live.leaf) === 'exited') {
+          this.resolveWaiter(
+            waiter,
+            condition === 'exit'
+              ? buildTerminalWaitResult(handle, condition, live.leaf)
+              : buildPrematureTerminalExitWaitResult(
+                  handle,
+                  condition,
+                  live.leaf.lastExitCode,
+                  live.leaf.lastExitCause
+                )
+          )
         } else if (condition === 'tui-idle') {
           const liveLeafWaitText = buildTerminalWaitText(
             live.leaf.tailBuffer,
@@ -35297,13 +35367,25 @@ export class OrcaRuntimeService {
     if (!waiters || waiters.size === 0) {
       return
     }
+    const livenessUnverifiable =
+      leaf.ptyId != null && this.getPtyLivenessVerdict(leaf.ptyId)?.status === 'unverifiable'
     for (const waiter of [...waiters]) {
+      if (livenessUnverifiable) {
+        this.resolveWaiter(waiter, buildUnverifiableTerminalWaitResult(handle, waiter.condition))
+        continue
+      }
       if (waiter.condition === 'exit') {
         this.resolveWaiter(waiter, buildTerminalWaitResult(handle, 'exit', leaf))
       } else {
-        // Why: after exit, conditions like tui-idle can never be satisfied — reject now instead of spinning the poll until timeout on a dead process.
-        this.removeWaiter(waiter)
-        waiter.reject(new Error('terminal_exited'))
+        this.resolveWaiter(
+          waiter,
+          buildPrematureTerminalExitWaitResult(
+            handle,
+            waiter.condition,
+            leaf.lastExitCode,
+            leaf.lastExitCause
+          )
+        )
       }
     }
   }
@@ -35340,14 +35422,51 @@ export class OrcaRuntimeService {
     if (!waiters || waiters.size === 0) {
       return
     }
+    const livenessUnverifiable = this.getPtyLivenessVerdict(ptyId)?.status === 'unverifiable'
     for (const waiter of [...waiters]) {
+      if (livenessUnverifiable) {
+        this.resolveWaiter(waiter, buildUnverifiableTerminalWaitResult(handle, waiter.condition))
+        continue
+      }
       if (waiter.condition === 'exit') {
         this.resolveWaiter(waiter, buildPtyTerminalWaitResult(handle, 'exit', pty))
       } else {
-        this.removeWaiter(waiter)
-        waiter.reject(new Error('terminal_exited'))
+        this.resolveWaiter(
+          waiter,
+          buildPrematureTerminalExitWaitResult(
+            handle,
+            waiter.condition,
+            pty.lastExitCode,
+            pty.lastExitCause
+          )
+        )
       }
     }
+  }
+
+  private startTuiIdleCommandExitWatch(waiter: TerminalWaiter, ptyId: string): void {
+    let commandStarted = false
+    const scanner = createOsc133CommandFinishedScanner(
+      (exitCode) => {
+        if (!commandStarted || !this.waitersByHandle.get(waiter.handle)?.has(waiter)) {
+          return
+        }
+        this.resolveWaiter(
+          waiter,
+          buildPrematureTerminalExitWaitResult(waiter.handle, waiter.condition, exitCode)
+        )
+      },
+      () => {
+        commandStarted = true
+      }
+    )
+    waiter.dataCleanup = this.subscribeToTerminalData(ptyId, scanner.scan)
+    const replay = this.recentPtyOutputById.get(ptyId)?.read()
+    if (replay) {
+      scanner.scan(replay)
+    }
+    // A startup command can predate waiter registration; its next completion is still terminal.
+    commandStarted = true
   }
 
   private isPtyKnownExited(ptyId: string): boolean {
@@ -35678,6 +35797,8 @@ export class OrcaRuntimeService {
     if (waiter.pollInterval) {
       clearInterval(waiter.pollInterval)
     }
+    waiter.dataCleanup?.()
+    waiter.dataCleanup = null
     if (waiter.abortCleanup) {
       waiter.abortCleanup()
       waiter.abortCleanup = null
@@ -40326,6 +40447,35 @@ function buildTerminalWait(
     exitCode,
     ...(exitCause ? { exitCause } : {}),
     ...(blockedReason ? { blockedReason } : {})
+  }
+}
+
+function buildPrematureTerminalExitWaitResult(
+  handle: string,
+  condition: RuntimeTerminalWaitCondition,
+  exitCode: number | null,
+  exitCause?: TerminalExitCause | null
+): RuntimeTerminalWait {
+  return {
+    handle,
+    condition,
+    satisfied: false,
+    status: 'exited',
+    exitCode,
+    ...(exitCause ? { exitCause } : {})
+  }
+}
+
+function buildUnverifiableTerminalWaitResult(
+  handle: string,
+  condition: RuntimeTerminalWaitCondition
+): RuntimeTerminalWait {
+  return {
+    handle,
+    condition,
+    satisfied: false,
+    status: 'unknown',
+    exitCode: null
   }
 }
 

--- a/src/main/runtime/pty-inventory-liveness-verdict.test.ts
+++ b/src/main/runtime/pty-inventory-liveness-verdict.test.ts
@@ -71,6 +71,55 @@ describe('inventory sweep liveness verdicts', () => {
     })
   })
 
+  it('resolves SSH disconnect waiters as unverifiable instead of exited', async () => {
+    const runtime = makeRuntimeMissingFromInventory(() => null)
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab-remote',
+          worktreeId: WORKTREE_ID,
+          title: 'Remote agent',
+          activeLeafId: 'pane:1',
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab-remote',
+          worktreeId: WORKTREE_ID,
+          leafId: 'pane:1',
+          paneRuntimeId: 1,
+          ptyId: REMOTE_PTY_ID
+        }
+      ]
+    })
+    const [terminal] = (await runtime.listTerminals()).terminals
+    const exitWait = runtime.waitForTerminal(terminal.handle, {
+      condition: 'exit',
+      timeoutMs: 60_000
+    })
+    const readinessWait = runtime.waitForTerminal(terminal.handle, {
+      condition: 'tui-idle',
+      timeoutMs: 60_000
+    })
+
+    runtime.onPtyExit(REMOTE_PTY_ID, -1)
+
+    await expect(exitWait).resolves.toMatchObject({
+      satisfied: false,
+      status: 'unknown',
+      exitCode: null
+    })
+    await expect(readinessWait).resolves.toMatchObject({
+      satisfied: false,
+      status: 'unknown',
+      exitCode: null
+    })
+    await expect(
+      runtime.waitForTerminal(terminal.handle, { condition: 'exit', timeoutMs: 60_000 })
+    ).resolves.toMatchObject({ satisfied: false, status: 'unknown', exitCode: null })
+  })
+
   it('preserves a more specific lost-contact reason across an abnormal SSH exit', () => {
     const runtime = makeRuntimeMissingFromInventory(() => null)
     runtime.markPtyLivenessUnverifiable(REMOTE_PTY_ID, 'inventory transport failed')

--- a/src/main/runtime/rpc/methods/orchestration-agent-readiness.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-agent-readiness.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { getAgentReadinessFailure } from './orchestration-agent-readiness'
+
+describe('orchestration agent readiness', () => {
+  it('accepts only live readiness', () => {
+    expect(
+      getAgentReadinessFailure({
+        handle: 'term-worker',
+        condition: 'tui-idle',
+        satisfied: true,
+        status: 'running',
+        exitCode: null
+      })
+    ).toBeNull()
+  })
+
+  it('preserves known exit codes and does not invent an unknown one', () => {
+    const failure = (exitCode: number | null) =>
+      getAgentReadinessFailure({
+        handle: 'term-worker',
+        condition: 'tui-idle',
+        satisfied: false,
+        status: 'exited',
+        exitCode
+      })
+
+    expect(failure(17)).toBe('Agent process exited before becoming ready with code 17.')
+    expect(failure(null)).toBe('Agent process exited before becoming ready.')
+  })
+
+  it('includes only bounded redacted diagnostic output', () => {
+    const dispatchCapability = `dcap_${'a'.repeat(32)}`
+    const lines = [
+      'old output that must be omitted',
+      ...Array.from({ length: 20 }, (_, index) => `startup detail ${index}`),
+      `Authorization: Bearer bearer-secret ${dispatchCapability} ${'x'.repeat(5_000)}`
+    ]
+    const failure = getAgentReadinessFailure(
+      {
+        handle: 'term-worker',
+        condition: 'tui-idle',
+        satisfied: false,
+        status: 'exited',
+        exitCode: 1
+      },
+      lines
+    )!
+    const diagnostic = failure.split('Diagnostic output:\n')[1]!
+
+    expect(diagnostic.length).toBeLessThanOrEqual(4_000)
+    expect(diagnostic).toContain('diagnostic output truncated')
+    expect(diagnostic).not.toContain('old output that must be omitted')
+    expect(diagnostic).not.toContain('bearer-secret')
+    expect(diagnostic).not.toContain(dispatchCapability)
+  })
+
+  it('redacts multiline PEM blocks from diagnostic output', () => {
+    const failure = getAgentReadinessFailure(
+      {
+        handle: 'term-worker',
+        condition: 'tui-idle',
+        satisfied: false,
+        status: 'exited',
+        exitCode: 1
+      },
+      [
+        'startup failed while loading key',
+        '-----BEGIN PRIVATE KEY-----',
+        'multiline-secret-material',
+        '-----END PRIVATE KEY-----'
+      ]
+    )!
+
+    expect(failure).toContain('[redacted:pem]')
+    expect(failure).not.toContain('multiline-secret-material')
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration-agent-readiness.ts
+++ b/src/main/runtime/rpc/methods/orchestration-agent-readiness.ts
@@ -1,0 +1,43 @@
+import type { RuntimeTerminalWait } from '../../../../shared/runtime-types'
+import { redactString } from '../../../observability/redactor'
+import { redactWorkerTerminalLines } from '../../orchestration/worker-transcript-payload'
+
+const READINESS_DIAGNOSTIC_MAX_LINES = 20
+const READINESS_DIAGNOSTIC_MAX_CHARS = 4_000
+const READINESS_DIAGNOSTIC_TRUNCATED = '… (diagnostic output truncated)'
+
+export function getAgentReadinessFailure(
+  wait: RuntimeTerminalWait,
+  terminalLines: readonly string[] = []
+): string | null {
+  if (wait.satisfied && wait.status === 'running') {
+    return null
+  }
+  let summary: string
+  if (wait.blockedReason) {
+    summary = `Agent startup blocked: ${wait.blockedReason}`
+  } else if (wait.status === 'exited') {
+    const code = wait.exitCode === null ? '' : ` with code ${wait.exitCode}`
+    summary = `Agent process exited before becoming ready${code}.`
+  } else {
+    summary = `Agent did not become ready (${wait.status}).`
+  }
+  const diagnostic = buildReadinessDiagnostic(terminalLines)
+  return diagnostic ? `${summary}\nDiagnostic output:\n${diagnostic}` : summary
+}
+
+function buildReadinessDiagnostic(lines: readonly string[]): string {
+  const selected = lines.slice(-READINESS_DIAGNOSTIC_MAX_LINES)
+  const dispatchRedacted = redactWorkerTerminalLines(selected).lines.join('\n')
+  const output = redactString(dispatchRedacted).trim()
+  if (!output) {
+    return ''
+  }
+  const wasTruncated =
+    selected.length < lines.length || output.length > READINESS_DIAGNOSTIC_MAX_CHARS
+  if (!wasTruncated) {
+    return output
+  }
+  const contentBudget = READINESS_DIAGNOSTIC_MAX_CHARS - READINESS_DIAGNOSTIC_TRUNCATED.length - 1
+  return `${READINESS_DIAGNOSTIC_TRUNCATED}\n${output.slice(-contentBudget)}`
+}

--- a/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
@@ -66,6 +66,34 @@ describe('orchestration RPC methods', () => {
       })
     }
 
+    function mockExitedWorkerRelease(): void {
+      vi.mocked(runtime.showTerminal).mockResolvedValue({
+        handle: 'term_worker',
+        worktreeId: 'repo::worktree',
+        status: 'exited',
+        connected: false
+      } as never)
+      vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockReturnValue({
+        terminalHandle: 'term_worker',
+        paneKey: 'tab_worker:leaf_worker',
+        processIncarnation: 'runtime_test:term_worker:1',
+        hostScope: { kind: 'local', hostId: 'local' }
+      } as never)
+      vi.spyOn(runtime, 'getExactWorkerProviderSession').mockReturnValue(null)
+      vi.spyOn(runtime, 'readTerminal').mockResolvedValue({
+        handle: 'term_worker',
+        status: 'exited',
+        tail: [],
+        truncated: false,
+        nextCursor: null
+      })
+      vi.spyOn(runtime, 'closeTerminal').mockResolvedValue({
+        handle: 'term_worker',
+        tabId: 'tab_worker',
+        ptyKilled: true
+      } as never)
+    }
+
     it('starts a fresh agent in the coordinator current worktree', async () => {
       setup()
       mockCurrentWorkerStart()
@@ -380,19 +408,27 @@ describe('orchestration RPC methods', () => {
           status: 'exited',
           exitCode: 0
         })
+        mockExitedWorkerRelease()
         const task = db.createTask({ spec: 'worker exits during startup' })
 
         const result = (await call('orchestration.workerStart', {
           task: task.id,
           from: 'term_coord',
           agent
-        })) as { state: string; failedStage: string; lastError: string }
+        })) as {
+          state: string
+          failedStage: string
+          lastError: string
+          residualResources: unknown[]
+        }
 
         expect(result).toMatchObject({
           state: 'failed',
           failedStage: 'agent_readiness',
-          lastError: 'Agent process exited before becoming ready with code 0.'
+          lastError: 'Agent process exited before becoming ready with code 0.',
+          residualResources: []
         })
+        expect(runtime.closeTerminal).toHaveBeenCalledWith('term_worker')
         expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
       }
     )
@@ -407,6 +443,7 @@ describe('orchestration RPC methods', () => {
         status: 'exited',
         exitCode: 1
       })
+      mockExitedWorkerRelease()
       vi.spyOn(runtime, 'readTerminal').mockResolvedValue({
         handle: 'term_worker',
         status: 'exited',
@@ -420,10 +457,12 @@ describe('orchestration RPC methods', () => {
         task: task.id,
         from: 'term_coord',
         agent: 'opencode'
-      })) as { lastError: string }
+      })) as { lastError: string; residualResources: unknown[] }
 
       expect(result.lastError).toContain('Diagnostic output:\nOpenCode startup failed:')
       expect(result.lastError).not.toContain('provider-secret')
+      expect(result.residualResources).toEqual([])
+      expect(runtime.closeTerminal).toHaveBeenCalledWith('term_worker')
       expect(runtime.readTerminal).toHaveBeenCalledWith('term_worker', { limit: 20 })
     })
 

--- a/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
@@ -368,6 +368,90 @@ describe('orchestration RPC methods', () => {
       expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
     })
 
+    it.each(['codex', 'opencode'] as const)(
+      'fails %s startup when its process exits zero before readiness',
+      async (agent) => {
+        setup()
+        mockCurrentWorkerStart()
+        vi.mocked(runtime.waitForTerminal).mockResolvedValueOnce({
+          handle: 'term_worker',
+          condition: 'tui-idle',
+          satisfied: false,
+          status: 'exited',
+          exitCode: 0
+        })
+        const task = db.createTask({ spec: 'worker exits during startup' })
+
+        const result = (await call('orchestration.workerStart', {
+          task: task.id,
+          from: 'term_coord',
+          agent
+        })) as { state: string; failedStage: string; lastError: string }
+
+        expect(result).toMatchObject({
+          state: 'failed',
+          failedStage: 'agent_readiness',
+          lastError: 'Agent process exited before becoming ready with code 0.'
+        })
+        expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
+      }
+    )
+
+    it('returns redacted terminal diagnostics when agent startup exits early', async () => {
+      setup()
+      mockCurrentWorkerStart()
+      vi.mocked(runtime.waitForTerminal).mockResolvedValueOnce({
+        handle: 'term_worker',
+        condition: 'tui-idle',
+        satisfied: false,
+        status: 'exited',
+        exitCode: 1
+      })
+      vi.spyOn(runtime, 'readTerminal').mockResolvedValue({
+        handle: 'term_worker',
+        status: 'exited',
+        tail: ['OpenCode startup failed: api_key=provider-secret'],
+        truncated: false,
+        nextCursor: null
+      })
+      const task = db.createTask({ spec: 'capture startup diagnostic' })
+
+      const result = (await call('orchestration.workerStart', {
+        task: task.id,
+        from: 'term_coord',
+        agent: 'opencode'
+      })) as { lastError: string }
+
+      expect(result.lastError).toContain('Diagnostic output:\nOpenCode startup failed:')
+      expect(result.lastError).not.toContain('provider-secret')
+      expect(runtime.readTerminal).toHaveBeenCalledWith('term_worker', { limit: 20 })
+    })
+
+    it('keeps an unverifiable readiness loss as outcome unknown', async () => {
+      setup()
+      mockCurrentWorkerStart()
+      vi.mocked(runtime.waitForTerminal).mockResolvedValueOnce({
+        handle: 'term_worker',
+        condition: 'tui-idle',
+        satisfied: false,
+        status: 'unknown',
+        exitCode: null
+      })
+      const task = db.createTask({ spec: 'worker contact is lost during startup' })
+
+      const result = (await call('orchestration.workerStart', {
+        task: task.id,
+        from: 'term_coord',
+        agent: 'codex'
+      })) as { state: string; lastError: string }
+
+      expect(result).toMatchObject({
+        state: 'outcome_unknown',
+        lastError: 'Agent did not become ready (unknown).'
+      })
+      expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
+    })
+
     it('returns a no-effect failure when terminal creation fails', async () => {
       setup()
       mockCurrentWorkerStart()

--- a/src/main/runtime/rpc/methods/orchestration-federation.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation.ts
@@ -18,6 +18,7 @@ import {
 import { FederationAttachStartParams } from './orchestration-federation-start-schema'
 import { failFederatedAttachmentWithReceipt } from './orchestration-federation-start-receipt'
 import { prepareFederationAttachmentWorkerStart } from './orchestration-worker-start-validation'
+import { getAgentReadinessFailure } from './orchestration-agent-readiness'
 
 export const ORCHESTRATION_FEDERATION_ATTACH_METHODS: RpcMethod[] = [
   defineMethod({
@@ -197,18 +198,23 @@ export const ORCHESTRATION_FEDERATION_ATTACH_METHODS: RpcMethod[] = [
         failedStage = 'agent_readiness'
         const wait = await runtime.waitForTerminal(terminalHandle, {
           condition: 'tui-idle',
-          timeoutMs: params.timeoutMs ?? 60_000
+          timeoutMs: params.timeoutMs ?? 60_000,
+          superviseCommandExit: true
         })
         persistFederatedSetupWaitOutcome({ ...setupStage, wait })
-        if (!wait.satisfied) {
+        let readinessFailure = getAgentReadinessFailure(wait)
+        if (readinessFailure) {
+          const diagnostic = await runtime
+            .readTerminal(terminalHandle, { limit: 20 })
+            .catch(() => null)
+          readinessFailure = getAgentReadinessFailure(wait, diagnostic?.tail) ?? readinessFailure
           if (setup.state === 'failed') {
             failedStage = 'setup_wait'
           }
-          throw new Error(
-            wait.blockedReason
-              ? `Agent startup blocked: ${wait.blockedReason}`
-              : `Agent did not become ready (${wait.status}).`
-          )
+          if (wait.status === 'unknown') {
+            throw new OrchestrationError('operation_unknown', readinessFailure)
+          }
+          throw new Error(readinessFailure)
         }
         const paneKey = runtime.getTerminalPaneKey(terminalHandle)
         const processIncarnation = runtime.getTerminalProcessIncarnation(terminalHandle)

--- a/src/main/runtime/rpc/methods/orchestration-worker-start-terminal-release.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-start-terminal-release.ts
@@ -33,26 +33,30 @@ export async function releaseFailedWorkerStartTerminal(args: {
   failedStage: string
   failure: Record<string, unknown>
 }): Promise<Record<string, unknown>> {
-  const requested = args.db.requestWorkerTerminalRelease(args.dispatchId)
-  if (requested.disposition !== 'requested') {
+  try {
+    const requested = args.db.requestWorkerTerminalRelease(args.dispatchId)
+    if (requested.disposition !== 'requested') {
+      return args.failure
+    }
+    const release = await completeWorkerTerminalRelease({
+      runtime: args.runtime,
+      db: args.db,
+      dispatchId: args.dispatchId,
+      resource: requested.resource
+    })
+    if (release.state !== 'released') {
+      return args.failure
+    }
+    const residualResources = (args.failure.residualResources as WorkerEffect[]).filter(
+      (effect) => effect.kind !== 'terminal' || effect.id !== requested.resource.terminal_handle
+    )
+    args.db.recordWorkerStage({
+      dispatchId: args.dispatchId,
+      stage: args.failedStage,
+      residualResources
+    })
+    return { ...args.failure, residualResources }
+  } catch {
     return args.failure
   }
-  const release = await completeWorkerTerminalRelease({
-    runtime: args.runtime,
-    db: args.db,
-    dispatchId: args.dispatchId,
-    resource: requested.resource
-  })
-  if (release.state !== 'released') {
-    return args.failure
-  }
-  const residualResources = (args.failure.residualResources as WorkerEffect[]).filter(
-    (effect) => effect.kind !== 'terminal' || effect.id !== requested.resource.terminal_handle
-  )
-  args.db.recordWorkerStage({
-    dispatchId: args.dispatchId,
-    stage: args.failedStage,
-    residualResources
-  })
-  return { ...args.failure, residualResources }
 }

--- a/src/main/runtime/rpc/methods/orchestration-worker-start-terminal-release.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-start-terminal-release.ts
@@ -1,0 +1,58 @@
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import type { OrchestrationDb } from '../../orchestration/db'
+import { requireWorkerAuthority, type WorkerEffect } from './orchestration-worker-topology'
+import { completeWorkerTerminalRelease } from './orchestration-worker-release-completion'
+
+export function attachExitedWorkerTerminalAuthority(
+  runtime: OrcaRuntimeService,
+  args: {
+    db: OrchestrationDb
+    dispatchId: string
+    terminalHandle: string
+    worktreeId: string
+    effects: WorkerEffect[]
+    setup: { state: string }
+  }
+): void {
+  const authority = requireWorkerAuthority(runtime, args.terminalHandle)
+  args.db.prepareStartingWorkerAuthority({
+    dispatchId: args.dispatchId,
+    handle: args.terminalHandle,
+    ...authority,
+    worktreeId: args.worktreeId,
+    effects: args.effects,
+    setupState: args.setup.state,
+    terminalOwnership: 'created'
+  })
+}
+
+export async function releaseFailedWorkerStartTerminal(args: {
+  runtime: OrcaRuntimeService
+  db: OrchestrationDb
+  dispatchId: string
+  failedStage: string
+  failure: Record<string, unknown>
+}): Promise<Record<string, unknown>> {
+  const requested = args.db.requestWorkerTerminalRelease(args.dispatchId)
+  if (requested.disposition !== 'requested') {
+    return args.failure
+  }
+  const release = await completeWorkerTerminalRelease({
+    runtime: args.runtime,
+    db: args.db,
+    dispatchId: args.dispatchId,
+    resource: requested.resource
+  })
+  if (release.state !== 'released') {
+    return args.failure
+  }
+  const residualResources = (args.failure.residualResources as WorkerEffect[]).filter(
+    (effect) => effect.kind !== 'terminal' || effect.id !== requested.resource.terminal_handle
+  )
+  args.db.recordWorkerStage({
+    dispatchId: args.dispatchId,
+    stage: args.failedStage,
+    residualResources
+  })
+  return { ...args.failure, residualResources }
+}

--- a/src/main/runtime/rpc/methods/orchestration-workers.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers.ts
@@ -21,6 +21,10 @@ import {
 import { failWorkerStartWithReceipt } from './orchestration-worker-start-receipt'
 import { prepareLocalWorkerStart } from './orchestration-worker-start-validation'
 import { getAgentReadinessFailure } from './orchestration-agent-readiness'
+import {
+  attachExitedWorkerTerminalAuthority,
+  releaseFailedWorkerStartTerminal
+} from './orchestration-worker-start-terminal-release'
 
 export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
   defineMethod({
@@ -127,6 +131,7 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
       let terminalHandle = params.terminal
       let terminalRevealWarning: string | undefined
       let failedStage = 'terminal_create'
+      let releaseExitedTerminal = false
       let setupReceipt: WorkerSetupReceipt = {
         requested: 'not_applicable',
         effective: 'not_applicable',
@@ -213,6 +218,10 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
           if (wait.status === 'unknown') {
             throw new OrchestrationError('operation_unknown', readinessFailure)
           }
+          releaseExitedTerminal = wait.status === 'exited' && !params.terminal
+          if (releaseExitedTerminal) {
+            attachExitedWorkerTerminalAuthority(runtime, setupStage)
+          }
           throw new Error(readinessFailure)
         }
         const terminalAuthority = requireWorkerAuthority(runtime, terminalHandle)
@@ -267,7 +276,7 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
           ...(terminalRevealWarning ? { warning: terminalRevealWarning } : {})
         }
       } catch (error) {
-        return failWorkerStartWithReceipt({
+        const failure = failWorkerStartWithReceipt({
           db,
           runId: run.id,
           taskId: task.id,
@@ -276,7 +285,16 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
           error,
           setup: setupReceipt,
           launch: launch.receipt
-        })
+        }) as Record<string, unknown>
+        return releaseExitedTerminal
+          ? releaseFailedWorkerStartTerminal({
+              runtime,
+              db,
+              dispatchId: started.dispatch.id,
+              failedStage,
+              failure
+            })
+          : failure
       }
     }
   })

--- a/src/main/runtime/rpc/methods/orchestration-workers.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers.ts
@@ -20,6 +20,7 @@ import {
 } from './orchestration-worker-setup-gate'
 import { failWorkerStartWithReceipt } from './orchestration-worker-start-receipt'
 import { prepareLocalWorkerStart } from './orchestration-worker-start-validation'
+import { getAgentReadinessFailure } from './orchestration-agent-readiness'
 
 export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
   defineMethod({
@@ -196,18 +197,23 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
         failedStage = 'agent_readiness'
         const wait = await runtime.waitForTerminal(terminalHandle, {
           condition: 'tui-idle',
-          timeoutMs: params.timeoutMs ?? 60_000
+          timeoutMs: params.timeoutMs ?? 60_000,
+          superviseCommandExit: true
         })
         persistWorkerSetupWaitOutcome({ ...setupStage, wait })
-        if (!wait.satisfied) {
+        let readinessFailure = getAgentReadinessFailure(wait)
+        if (readinessFailure) {
+          const diagnostic = await runtime
+            .readTerminal(terminalHandle, { limit: 20 })
+            .catch(() => null)
+          readinessFailure = getAgentReadinessFailure(wait, diagnostic?.tail) ?? readinessFailure
           if (setupReceipt.state === 'failed') {
             failedStage = 'setup_wait'
           }
-          throw new Error(
-            wait.blockedReason
-              ? `Agent startup blocked: ${wait.blockedReason}`
-              : `Agent did not become ready (${wait.status}).`
-          )
+          if (wait.status === 'unknown') {
+            throw new OrchestrationError('operation_unknown', readinessFailure)
+          }
+          throw new Error(readinessFailure)
         }
         const terminalAuthority = requireWorkerAuthority(runtime, terminalHandle)
         const capability = db.prepareStartingWorkerAuthority({


### PR DESCRIPTION
Paquete B del diagnóstico de fábrica (PLANS/ORCA_DIAGNOSTICO_OPENCODE_TERMINAL_READYING_2026_08_23.md). Si el agente muere durante el arranque, el worker ahora falla el startup en vez de quedar colgado; incluye prueba de redacción PEM en orchestration-agent-readiness.test.ts. Referencia única: c0c38d2d.