### PR TITLE
Retain Pi and OMP working-title fallback on relays

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1733,7 +1733,9 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
       const profile = getSyntheticAgentTitleProfile(payload.agentType)
       if (
         profile &&
-        shouldDriveSyntheticAgentTitleFromHook(payload.agentType, payload.state) &&
+        shouldDriveSyntheticAgentTitleFromHook(payload.agentType, payload.state, {
+          isRelay: connectionId !== null
+        }) &&
         !suppressSyntheticCodexAutoApprovalTitle
       ) {
         driveSyntheticTitleFromHook(paneKey, payload.state, profile)

--- a/src/shared/synthetic-agent-title.test.ts
+++ b/src/shared/synthetic-agent-title.test.ts
@@ -41,4 +41,12 @@ describe('synthetic agent titles', () => {
     expect(getSyntheticAgentTerminalTitle('pi', 'waiting')).toBe('Pi - action required')
     expect(shouldDriveSyntheticAgentTitleFromHook('pi', 'working')).toBe(false)
   })
+
+  it('synthesizes Pi-compatible working titles when a relay has no native title source', () => {
+    expect(shouldDriveSyntheticAgentTitleFromHook('omp', 'working', { isRelay: true })).toBe(true)
+    expect(shouldDriveSyntheticAgentTitleFromHook('pi', 'working', { isRelay: true })).toBe(true)
+    expect(shouldDriveSyntheticAgentTitleFromHook('codex', 'working', { isRelay: true })).toBe(
+      false
+    )
+  })
 })

--- a/src/shared/synthetic-agent-title.ts
+++ b/src/shared/synthetic-agent-title.ts
@@ -8,6 +8,11 @@ export type SyntheticAgentTitleProfile = {
   titleIdentityGroup?: string
   synthesizeTerminalTitle?: boolean
   synthesizeWorkingTitle?: boolean
+  synthesizeWorkingTitleOnRelay?: boolean
+}
+
+type SyntheticAgentTitleHookContext = {
+  isRelay?: boolean
 }
 
 export const SYNTHETIC_AGENT_TITLE_AGENTS = [
@@ -50,7 +55,8 @@ export const SYNTHETIC_AGENT_TITLE_PROFILES: Record<string, SyntheticAgentTitleP
     // Why: Pi owns its working OSC title (`π ⠋ <session>`) and animates it itself. Synthesizing
     // over it replaced the session label and fought its frames at 80ms. Terminal states still
     // synthesize: they carry the pane's agent identity downstream, and Pi is quiet at rest.
-    synthesizeWorkingTitle: false
+    synthesizeWorkingTitle: false,
+    synthesizeWorkingTitleOnRelay: true
   },
   omp: {
     workingLabel: 'OMP',
@@ -59,7 +65,8 @@ export const SYNTHETIC_AGENT_TITLE_PROFILES: Record<string, SyntheticAgentTitleP
     titleIdentityGroup: 'pi-compatible',
     // Why: on an Orca-hosted pane it is Orca's own injected titlebar extension writing the
     // working title (src/main/pi/titlebar-extension-source.ts). See pi above.
-    synthesizeWorkingTitle: false
+    synthesizeWorkingTitle: false,
+    synthesizeWorkingTitleOnRelay: true
   },
   droid: {
     workingLabel: 'Droid',
@@ -100,11 +107,16 @@ export function getSyntheticAgentTerminalTitle(
 
 export function shouldDriveSyntheticAgentTitleFromHook(
   agentType: AgentType | null | undefined,
-  state: AgentStatusState
+  state: AgentStatusState,
+  context: SyntheticAgentTitleHookContext = {}
 ): boolean {
   const profile = getSyntheticAgentTitleProfile(agentType)
   if (!profile || profile.synthesizeTerminalTitle === false) {
     return false
   }
-  return state !== 'working' || profile.synthesizeWorkingTitle !== false
+  // Why: relays install status hooks but not Pi-compatible native title sources.
+  const synthesizeWorkingTitle = context.isRelay
+    ? (profile.synthesizeWorkingTitleOnRelay ?? profile.synthesizeWorkingTitle)
+    : profile.synthesizeWorkingTitle
+  return state !== 'working' || synthesizeWorkingTitle !== false
 }


### PR DESCRIPTION
## ELI5

Main now preserves Pi and OMP semantic working titles locally through #16381. Relay-hosted sessions are different: Orca installs their status hook but not the native titlebar source. Without a relay fallback, a working SSH/WSL pane can keep its old shell or idle title and look done. This keeps the native title locally and restores Orca's generic working title only on relays.

## What Changed

- Pass the existing hook `connectionId` boundary into the synthetic-title policy.
- Let Pi and OMP synthesize working titles only for relay-hosted hook events.
- Keep local native working titles and synthetic done/waiting titles unchanged.
- Cover relay Pi/OMP behavior while confirming Codex remains unchanged.

## Why

#16381 fixed the local root cause for #16093 by disabling Pi/OMP working-title synthesis and preserving the semantic title text. During review of this PR, the SSH path exposed a separate boundary: `SshRelaySession.installPluginsOnRelay` sends only `getPiAgentStatusExtensionSource(...)`, and `PluginOverlay.materializePi` installs only `orca-agent-status.ts`. It does not install the Pi-compatible titlebar extension.

Hook events already carry `connectionId: null` locally and a non-null relay id for SSH/WSL. Using that existing boundary restores the pre-existing remote fallback without adding an RPC field, stream opcode, or remote payload change.

## Linked Issue

- Follow-up to #16381, which completed #16093.
- Preserves the relay behavior identified during review of #16234.

## Visual Proof

N/A — this is title-writer arbitration with no layout change. No live SSH or Pi/OMP session was available; deterministic policy and adjacent relay/title tests cover the behavior.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

TDD evidence:

- RED: the focused suite failed 1/7 because relay OMP working-title synthesis returned `false`.
- GREEN: the focused suite passed 7/7 after the relay-only override; Pi returned `true` on relay and Codex remained `false`.

Post-rebase verification on current main:

- Focused semantic/synthetic title tests: 2 files, 52/52 passed.
- Adjacent SSH/plugin-overlay/titlebar/renderer/cross-version wire tests: 12 files, 136/136 passed.
- `pnpm lint` — passed.
- `pnpm typecheck` — passed.
- `pnpm build` — passed on macOS. The optional `/usr/local/bin/orca-dev` symlink reported a permission warning; the build exited 0 and completed all build targets.

The full `pnpm test` suite was not rerun after this rebase. No Windows, Linux, live SSH, or live Pi/OMP manual run was performed.

## AI Disclosure

OpenAI Codex was used for conflict investigation, rebase resolution, implementation verification, self-review, and PR metadata updates under user direction.

## Review

- Security: no input, credential, process, filesystem, or shell surface changes.
- Cross-platform: uses the existing platform-neutral hook `connectionId`; Windows was not manually tested.
- SSH/WSL/wire: retains synthetic working titles for relay events without changing RPC, stream, schema, opcode, or published relay content.
- Agent compatibility: the relay override is limited to Pi and OMP. Codex, OpenCode, and other profiles are unchanged.
- Backwards compatibility: local behavior is the #16381 contract; relay behavior retains Orca's previous generic working fallback.
- Performance: local Pi/OMP panes avoid the competing timer; relay panes retain it because no native title source is installed there.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- The original local title-preservation commit was dropped during rebase because #16381 now supplies that behavior on main.
- The rebased PR contains one relay-specific commit and three changed files.
- No social handle was provided, so none is listed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm test` was not rerun after rebase; focused/adjacent tests, `pnpm lint`, `pnpm typecheck`, and `pnpm build` pass
