### PR TITLE
fix(renderer): support status authority without randomUUID

### DIFF
--- a/src/renderer/src/lib/non-secure-context-crypto.repro.test.ts
+++ b/src/renderer/src/lib/non-secure-context-crypto.repro.test.ts
@@ -3,11 +3,12 @@
  * hides crypto.randomUUID and crypto.subtle (secure-context-only). This test
  * recreates that exact global shape and drives the real call sites.
  */
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const realCrypto = globalThis.crypto
 
 beforeEach(() => {
+  vi.resetModules()
   // Match a non-secure browser context: getRandomValues stays, the
   // secure-context-only members are undefined.
   Object.defineProperty(globalThis, 'crypto', {
@@ -54,6 +55,14 @@ describe('non-secure context (plain HTTP LAN web client)', () => {
     const { createBrowserUuid } = await import('./browser-uuid')
     expect(createBrowserUuid()).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    )
+  })
+
+  it('initializes the renderer status authority when randomUUID is missing', async () => {
+    const { rendererAgentStatusObservations } = await import('./renderer-agent-status-observations')
+
+    expect(rendererAgentStatusObservations.getAuthorityId()).toMatch(
+      /^renderer:[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
     )
   })
 })

--- a/src/renderer/src/lib/renderer-agent-status-observations.ts
+++ b/src/renderer/src/lib/renderer-agent-status-observations.ts
@@ -2,6 +2,7 @@ import {
   AgentStatusObservationSequencer,
   createAgentStatusAuthorityId
 } from '../../../shared/agent-status-observation'
+import { createBrowserUuid } from './browser-uuid'
 
 /**
  * The renderer's sequencer for status rows it writes itself: remote-runtime OSC bytes it
@@ -13,5 +14,5 @@ import {
  * ids from different authorities are incomparable, not merely older.
  */
 export const rendererAgentStatusObservations = new AgentStatusObservationSequencer(
-  createAgentStatusAuthorityId('renderer')
+  createAgentStatusAuthorityId('renderer', createBrowserUuid)
 )

--- a/src/shared/agent-status-observation.ts
+++ b/src/shared/agent-status-observation.ts
@@ -167,6 +167,9 @@ export class AgentStatusObservationSequencer {
 /** Per-instance authority id. Regenerated every process start on purpose: a restarted
  *  authority's revision counter starts over, so its observations must not be comparable
  *  with the ones it emitted before (including any rehydrated from disk). */
-export function createAgentStatusAuthorityId(role: string): string {
-  return `${role}:${globalThis.crypto.randomUUID()}`
+export function createAgentStatusAuthorityId(
+  role: string,
+  createUuid: () => string = () => globalThis.crypto.randomUUID()
+): string {
+  return `${role}:${createUuid()}`
 }


### PR DESCRIPTION
## ELI5

Plain-HTTP browsers can expose `crypto.getRandomValues` without exposing `crypto.randomUUID`. Orca created the renderer's agent-status authority ID while its module loaded, so that missing method could blank the web client before the UI started. The renderer now uses Orca's existing browser-safe UUID creator for that one ID.

## What Changed

- Let `createAgentStatusAuthorityId` accept an optional UUID creator while preserving its native `crypto.randomUUID` default.
- Supply `createBrowserUuid` when the renderer creates its import-time authority singleton.
- Extend the existing non-secure-context crypto repro suite to import the real renderer module and require a renderer-prefixed UUIDv4 authority ID.

## Why

This fixes the startup crash at its runtime boundary without copying another UUID fallback into shared code. Main-process agent hooks keep their existing default behavior, and authority IDs remain distinct per process instance.

## Linked Issue

Fixes #16232

## Visual Proof

N/A — this changes no appearance or interaction design; it prevents an import-time web-client crash.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- RED: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/non-secure-context-crypto.repro.test.ts` failed only the new case with `TypeError: globalThis.crypto.randomUUID is not a function` at `createAgentStatusAuthorityId`.
- GREEN: the same focused suite passed 5/5 on Node 24.18.0.
- Adjacent renderer/shared matrix: 7 files, 55 tests passed.
- `pnpm lint` passed, including 89 reliability gates and the max-lines ratchet.
- `pnpm typecheck` passed; targeted Node and web typechecks also passed.
- `env -u HISTFILE ZDOTDIR=/var/empty pnpm test` passed 6,134 files and 57,704 tests, with 39 files and 239 tests skipped by the repository.
- `pnpm build` passed for desktop, web, relay, CLI, and native macOS targets.
- Automated validation ran on macOS. Linux, Windows, SSH/paired runtime, and plain-HTTP browser pairing were not manually exercised.

## AI Disclosure

OpenAI Codex (GPT-5) was used to investigate, implement, test, and self-review this change.

## Review

- **Correctness:** The new test executes the real import-time singleton path with the reported missing-`randomUUID` global. Shared uniqueness coverage and renderer observation tests remain green.
- **Security:** No authentication, credential, secret, or trust boundary changes. The authority ID is ordering provenance, not a security token, and the renderer reuses the existing browser UUID policy.
- **Cross-platform:** No platform-specific paths, processes, shortcuts, native modules, or shell behavior changed. Node/main keeps the native default; web uses the existing browser-safe provider.
- **Remote/local/mixed versions:** No wire schema, RPC, stream opcode, persistence, or published payload changed. Local, SSH, paired, folder-workspace, and mixed client/host behavior therefore keep the same protocol surface.
- **Agents/integrations/providers:** Provider-neutral status sequencing only; no agent, integration, or Git-provider behavior changed.
- **Performance:** One injected function call runs once when the renderer module initializes. No polling, I/O, subscriptions, or hot-path work was added.
- **UI/mobile:** No layout, styling, interaction, or mobile code changed. Visual proof is not applicable.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- No manual HTTP pairing, UI validation, screenshot, or video was performed.
- X / Twitter: Not provided.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
