### PR TITLE
feat(markdown): add inline text color formatting

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -117,6 +117,15 @@
   --color-git-graph-lane-4: var(--git-graph-lane-4);
   --color-git-graph-lane-5: var(--git-graph-lane-5);
   --color-annotation-highlight: var(--annotation-highlight);
+  --color-markdown-text-gray: var(--markdown-text-gray);
+  --color-markdown-text-red: var(--markdown-text-red);
+  --color-markdown-text-orange: var(--markdown-text-orange);
+  --color-markdown-text-yellow: var(--markdown-text-yellow);
+  --color-markdown-text-green: var(--markdown-text-green);
+  --color-markdown-text-teal: var(--markdown-text-teal);
+  --color-markdown-text-blue: var(--markdown-text-blue);
+  --color-markdown-text-purple: var(--markdown-text-purple);
+  --color-markdown-text-pink: var(--markdown-text-pink);
   --shadow-floating: 0 10px 24px rgb(0 0 0 / 0.18);
   --radius-sm: calc(var(--radius) * 0.6);
   --radius-md: calc(var(--radius) * 0.8);
@@ -238,6 +247,15 @@
   --git-graph-lane-4: #40b0a6;
   --git-graph-lane-5: #b66dff;
   --annotation-highlight: #f59e0b;
+  --markdown-text-gray: var(--color-zinc-700);
+  --markdown-text-red: var(--color-red-700);
+  --markdown-text-orange: var(--color-orange-700);
+  --markdown-text-yellow: var(--color-yellow-700);
+  --markdown-text-green: var(--color-green-700);
+  --markdown-text-teal: var(--color-teal-700);
+  --markdown-text-blue: var(--color-blue-700);
+  --markdown-text-purple: var(--color-violet-700);
+  --markdown-text-pink: var(--color-pink-700);
   --markdown-search-match: #facc15;
   --markdown-search-match-active: #fb923c;
   /* Why: tab-group splits use a dedicated divider — `--border` is too faint on
@@ -350,6 +368,15 @@
   --git-graph-lane-4: #40b0a6;
   --git-graph-lane-5: #b66dff;
   --annotation-highlight: #fbbf24;
+  --markdown-text-gray: var(--color-zinc-300);
+  --markdown-text-red: var(--color-red-300);
+  --markdown-text-orange: var(--color-orange-300);
+  --markdown-text-yellow: var(--color-yellow-300);
+  --markdown-text-green: var(--color-green-300);
+  --markdown-text-teal: var(--color-teal-300);
+  --markdown-text-blue: var(--color-blue-300);
+  --markdown-text-purple: var(--color-violet-300);
+  --markdown-text-pink: var(--color-pink-300);
   --markdown-search-match: #facc15;
   --markdown-search-match-active: #fb923c;
   /* Brighter than terminal defaults so the always-visible line clears 3:1 on `--card`. */

--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -68,6 +68,174 @@
   color: var(--foreground);
 }
 
+.rich-markdown-toolbar-button[data-rich-markdown-text-color] {
+  color: var(--rich-markdown-current-text-color);
+}
+
+.rich-markdown-selection-toolbar {
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--popover);
+  color: var(--popover-foreground);
+  box-shadow: var(--shadow-floating);
+}
+
+.rich-markdown-selection-toolbar .rich-markdown-toolbar-button {
+  color: var(--popover-foreground);
+}
+
+.rich-markdown-text-color-popover {
+  width: auto;
+  padding: 6px;
+}
+
+.rich-markdown-text-color-options {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+
+.rich-markdown-text-color-option {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--muted-foreground);
+}
+
+.rich-markdown-text-color-option[data-rich-markdown-text-color] {
+  color: var(--rich-markdown-current-text-color);
+}
+
+.rich-markdown-text-color-swatch {
+  width: 14px;
+  height: 14px;
+  border-radius: 999px;
+  background: currentColor;
+}
+
+.rich-markdown-text-color-option:hover,
+.rich-markdown-text-color-option.is-active {
+  border-color: color-mix(in srgb, var(--border) 82%, transparent);
+  background: var(--accent);
+}
+
+.rich-markdown-text-color-divider {
+  width: 1px;
+  height: 18px;
+  margin: 0 3px;
+  background: color-mix(in srgb, var(--border) 72%, transparent);
+}
+
+:is(
+  .rich-markdown-toolbar-button,
+  .rich-markdown-text-color-option
+)[data-rich-markdown-text-color='gray'] {
+  --rich-markdown-current-text-color: var(--markdown-text-gray);
+}
+
+:is(
+  .rich-markdown-toolbar-button,
+  .rich-markdown-text-color-option
+)[data-rich-markdown-text-color='red'] {
+  --rich-markdown-current-text-color: var(--markdown-text-red);
+}
+
+:is(
+  .rich-markdown-toolbar-button,
+  .rich-markdown-text-color-option
+)[data-rich-markdown-text-color='orange'] {
+  --rich-markdown-current-text-color: var(--markdown-text-orange);
+}
+
+:is(
+  .rich-markdown-toolbar-button,
+  .rich-markdown-text-color-option
+)[data-rich-markdown-text-color='yellow'] {
+  --rich-markdown-current-text-color: var(--markdown-text-yellow);
+}
+
+:is(
+  .rich-markdown-toolbar-button,
+  .rich-markdown-text-color-option
+)[data-rich-markdown-text-color='green'] {
+  --rich-markdown-current-text-color: var(--markdown-text-green);
+}
+
+:is(
+  .rich-markdown-toolbar-button,
+  .rich-markdown-text-color-option
+)[data-rich-markdown-text-color='teal'] {
+  --rich-markdown-current-text-color: var(--markdown-text-teal);
+}
+
+:is(
+  .rich-markdown-toolbar-button,
+  .rich-markdown-text-color-option
+)[data-rich-markdown-text-color='blue'] {
+  --rich-markdown-current-text-color: var(--markdown-text-blue);
+}
+
+:is(
+  .rich-markdown-toolbar-button,
+  .rich-markdown-text-color-option
+)[data-rich-markdown-text-color='purple'] {
+  --rich-markdown-current-text-color: var(--markdown-text-purple);
+}
+
+:is(
+  .rich-markdown-toolbar-button,
+  .rich-markdown-text-color-option
+)[data-rich-markdown-text-color='pink'] {
+  --rich-markdown-current-text-color: var(--markdown-text-pink);
+}
+
+:is(.rich-markdown-editor, .markdown-preview) [data-orca-text-color='gray'] {
+  color: var(--markdown-text-gray);
+}
+
+:is(.rich-markdown-editor, .markdown-preview) [data-orca-text-color='red'] {
+  color: var(--markdown-text-red);
+}
+
+:is(.rich-markdown-editor, .markdown-preview) [data-orca-text-color='orange'] {
+  color: var(--markdown-text-orange);
+}
+
+:is(.rich-markdown-editor, .markdown-preview) [data-orca-text-color='yellow'] {
+  color: var(--markdown-text-yellow);
+}
+
+:is(.rich-markdown-editor, .markdown-preview) [data-orca-text-color='green'] {
+  color: var(--markdown-text-green);
+}
+
+:is(.rich-markdown-editor, .markdown-preview) [data-orca-text-color='teal'] {
+  color: var(--markdown-text-teal);
+}
+
+:is(.rich-markdown-editor, .markdown-preview) [data-orca-text-color='blue'] {
+  color: var(--markdown-text-blue);
+}
+
+:is(.rich-markdown-editor, .markdown-preview) [data-orca-text-color='purple'] {
+  color: var(--markdown-text-purple);
+}
+
+:is(.rich-markdown-editor, .markdown-preview) [data-orca-text-color='pink'] {
+  color: var(--markdown-text-pink);
+}
+
 .github-markdown-composer .rich-markdown-editor-toolbar {
   padding: 6px 8px;
   background: color-mix(in srgb, var(--background) 92%, transparent);

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -18,7 +18,7 @@ import remarkMath from 'remark-math'
 import rehypeHighlight from 'rehype-highlight'
 import rehypeKatex from 'rehype-katex'
 import rehypeRaw from 'rehype-raw'
-import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
+import rehypeSanitize from 'rehype-sanitize'
 import rehypeSlug from 'rehype-slug'
 import { extractFrontMatter } from './markdown-frontmatter'
 import {
@@ -100,6 +100,7 @@ import { findWorktreeById } from '@/store/slices/worktree-helpers'
 import { dirname } from '@/lib/path'
 import { relativePathInsideRoot } from '../../../../shared/cross-platform-path'
 import { translate } from '@/i18n/i18n'
+import { markdownPreviewSanitizeSchema } from './markdown-preview-sanitize-schema'
 
 const EMPTY_MARKDOWN_DOCUMENTS: MarkdownDocument[] = []
 
@@ -291,45 +292,6 @@ function getMarkdownPreviewAnnotationQuote(node: React.ReactNode): string | unde
 function hasMarkdownPreviewNestedBlock(node: MarkdownPreviewPositionNode | undefined): boolean {
   const blockTags = new Set(['p', 'pre', 'table', 'blockquote', 'ul', 'ol'])
   return Boolean(node?.children?.some((child) => child.tagName && blockTags.has(child.tagName)))
-}
-
-const markdownPreviewSanitizeSchema = {
-  ...defaultSchema,
-  tagNames: [...(defaultSchema.tagNames ?? []), 'details', 'summary', 'kbd', 'sub', 'sup', 'ins'],
-  protocols: {
-    ...defaultSchema.protocols,
-    // Why: keep file:// through sanitize so the click handler can authorize and open the target (the security decision lives there).
-    href: [...(defaultSchema.protocols?.href ?? []), 'file'],
-    src: [...(defaultSchema.protocols?.src ?? []), 'file']
-  },
-  attributes: {
-    ...defaultSchema.attributes,
-    '*': [...(defaultSchema.attributes?.['*'] ?? []), 'id'],
-    a: [...(defaultSchema.attributes?.a ?? []), 'href', 'title'],
-    code: [
-      ...(defaultSchema.attributes?.code ?? []),
-      ['className', /^language-[\w-]+$/, 'math-inline', 'math-display']
-    ],
-    div: [...(defaultSchema.attributes?.div ?? []), ['className', /^language-[\w-]+$/], 'align'],
-    details: [
-      ...(defaultSchema.attributes?.details ?? []),
-      'open',
-      ['className', 'orca-details'],
-      ['dataOrcaToggle', 'heading-1', 'heading-2', 'heading-3', 'heading-4', 'heading-5']
-    ],
-    h1: [...(defaultSchema.attributes?.h1 ?? []), 'id'],
-    h2: [...(defaultSchema.attributes?.h2 ?? []), 'id'],
-    h3: [...(defaultSchema.attributes?.h3 ?? []), 'id'],
-    h4: [...(defaultSchema.attributes?.h4 ?? []), 'id'],
-    h5: [...(defaultSchema.attributes?.h5 ?? []), 'id'],
-    h6: [...(defaultSchema.attributes?.h6 ?? []), 'id'],
-    img: [...(defaultSchema.attributes?.img ?? []), 'src', 'alt', 'title', 'width', 'height'],
-    input: [...(defaultSchema.attributes?.input ?? []), 'type', 'checked', 'disabled'],
-    pre: [...(defaultSchema.attributes?.pre ?? []), ['className', /^language-[\w-]+$/]],
-    span: [...(defaultSchema.attributes?.span ?? []), ['className', /^hljs(?:-[\w-]+)?$/]],
-    td: [...(defaultSchema.attributes?.td ?? []), 'align'],
-    th: [...(defaultSchema.attributes?.th ?? []), 'align']
-  }
 }
 
 // Why: react-markdown's <Markdown> has no internal memoization — it rebuilds the whole

--- a/src/renderer/src/components/editor/RichMarkdownEditorSurface.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownEditorSurface.tsx
@@ -12,6 +12,7 @@ import { RichMarkdownAnnotationOverlay } from './RichMarkdownAnnotationOverlay'
 import { RichMarkdownReviewNoteLayer } from './RichMarkdownReviewNoteLayer'
 import { RichMarkdownReviewRailActions } from './RichMarkdownReviewRailActions'
 import { RichMarkdownTableControls } from './RichMarkdownTableControls'
+import { RichMarkdownSelectionToolbar } from './RichMarkdownSelectionToolbar'
 import type { DocLinkMenuRow, DocLinkMenuState } from './rich-markdown-commands'
 import type { SlashCommand, SlashMenuState } from './rich-markdown-slash-commands'
 import type { MarkdownTocItem } from './markdown-table-of-contents'
@@ -218,6 +219,12 @@ export function RichMarkdownEditorSurface({
             }}
           >
             <EditorContent editor={editor} />
+            <RichMarkdownSelectionToolbar
+              editor={editor}
+              blocked={Boolean(linkBubble || annotationPopover)}
+              scrollContainer={scrollContainerRef.current}
+              onToggleLink={onToggleLink}
+            />
             <RichMarkdownTableControls editor={editor} scrollContainerRef={scrollContainerRef} />
             {reviewRailVisible && notePositions.length > 0 ? (
               <RichMarkdownReviewNoteLayer

--- a/src/renderer/src/components/editor/RichMarkdownSelectionToolbar.test.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownSelectionToolbar.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment happy-dom
+import type { ReactNode } from 'react'
+import { Editor } from '@tiptap/core'
+import type { EditorView } from '@tiptap/pm/view'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createRichMarkdownExtensions } from './rich-markdown-extensions'
+import { createRichMarkdownEditorCodec } from './rich-markdown-source-transport'
+import {
+  RichMarkdownSelectionToolbar,
+  shouldShowRichMarkdownSelectionToolbar
+} from './RichMarkdownSelectionToolbar'
+
+const menuState = vi.hoisted(() => ({
+  onHide: null as (() => void) | null,
+  popoverOpen: undefined as boolean | undefined,
+  onPopoverOpenChange: null as ((open: boolean) => void) | null
+}))
+
+vi.mock('@tiptap/react/menus', () => ({
+  BubbleMenu: ({
+    children,
+    options
+  }: {
+    children: ReactNode
+    options?: { onHide?: () => void }
+  }) => {
+    menuState.onHide = options?.onHide ?? null
+    return <div>{children}</div>
+  }
+}))
+
+vi.mock('@/components/ui/popover', () => ({
+  Popover: ({
+    children,
+    open,
+    onOpenChange
+  }: {
+    children: ReactNode
+    open?: boolean
+    onOpenChange?: (open: boolean) => void
+  }) => {
+    menuState.popoverOpen = open
+    menuState.onPopoverOpenChange = onOpenChange ?? null
+    return <>{children}</>
+  },
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: ReactNode }) => <div>{children}</div>
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  TooltipProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+afterEach(cleanup)
+
+function createEditor(content = 'selected text'): Editor {
+  return new Editor({
+    element: document.createElement('div'),
+    extensions: createRichMarkdownExtensions({ codec: createRichMarkdownEditorCodec() }),
+    content,
+    contentType: 'markdown'
+  })
+}
+
+describe('RichMarkdownSelectionToolbar', () => {
+  it('shows only for a focused, non-empty text selection', () => {
+    const editor = createEditor()
+    editor.commands.setTextSelection({ from: 1, to: 9 })
+    const element = document.createElement('div')
+    const view = { hasFocus: () => true } as EditorView
+
+    try {
+      expect(
+        shouldShowRichMarkdownSelectionToolbar({
+          blocked: false,
+          editor,
+          element,
+          view,
+          state: editor.state,
+          from: 1,
+          to: 9
+        })
+      ).toBe(true)
+
+      expect(
+        shouldShowRichMarkdownSelectionToolbar({
+          blocked: true,
+          editor,
+          element,
+          view,
+          state: editor.state,
+          from: 1,
+          to: 9
+        })
+      ).toBe(false)
+
+      editor.commands.setTextSelection(1)
+      expect(
+        shouldShowRichMarkdownSelectionToolbar({
+          blocked: false,
+          editor,
+          element,
+          view,
+          state: editor.state,
+          from: 1,
+          to: 1
+        })
+      ).toBe(false)
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('exposes inline formatting and text color actions', async () => {
+    const editor = createEditor()
+    editor.commands.setTextSelection({ from: 1, to: 9 })
+
+    try {
+      render(
+        <RichMarkdownSelectionToolbar
+          editor={editor}
+          blocked={false}
+          scrollContainer={null}
+          onToggleLink={vi.fn()}
+        />
+      )
+
+      expect(screen.getByRole('button', { name: 'Text color' })).toBeTruthy()
+      fireEvent.click(screen.getByRole('button', { name: 'Bold' }))
+
+      await waitFor(() => expect(editor.getMarkdown().trimEnd()).toBe('**selected** text'))
+      expect(screen.getByRole('button', { name: 'Bold' }).classList.contains('is-active')).toBe(
+        true
+      )
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('closes the text color popover when the selection collapses', async () => {
+    const editor = createEditor()
+    editor.commands.setTextSelection({ from: 1, to: 9 })
+
+    try {
+      render(
+        <RichMarkdownSelectionToolbar
+          editor={editor}
+          blocked={false}
+          scrollContainer={null}
+          onToggleLink={vi.fn()}
+        />
+      )
+
+      act(() => menuState.onPopoverOpenChange?.(true))
+      expect(menuState.popoverOpen).toBe(true)
+
+      act(() => editor.commands.setTextSelection(1))
+      await waitFor(() => expect(menuState.popoverOpen).toBe(false))
+    } finally {
+      editor.destroy()
+    }
+  })
+})

--- a/src/renderer/src/components/editor/RichMarkdownSelectionToolbar.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownSelectionToolbar.tsx
@@ -1,0 +1,125 @@
+import React from 'react'
+import type { Editor } from '@tiptap/react'
+import { useEditorState } from '@tiptap/react'
+import { BubbleMenu } from '@tiptap/react/menus'
+import { TextSelection, type EditorState } from '@tiptap/pm/state'
+import type { EditorView } from '@tiptap/pm/view'
+import { Link as LinkIcon } from 'lucide-react'
+import { translate } from '@/i18n/i18n'
+import { RichMarkdownTextColorControl } from './RichMarkdownTextColorControl'
+import { RichMarkdownToolbarButton } from './RichMarkdownToolbarButton'
+
+type RichMarkdownSelectionToolbarProps = {
+  editor: Editor | null
+  blocked: boolean
+  scrollContainer: HTMLElement | null
+  onToggleLink: () => void
+}
+
+type SelectionToolbarVisibilityArgs = {
+  blocked: boolean
+  editor: Editor
+  element: HTMLElement
+  view: EditorView
+  state: EditorState
+  from: number
+  to: number
+}
+
+export function shouldShowRichMarkdownSelectionToolbar({
+  blocked,
+  editor,
+  element,
+  view,
+  state,
+  from,
+  to
+}: SelectionToolbarVisibilityArgs): boolean {
+  const selection = state.selection
+  const menuFocused = element.contains(document.activeElement)
+
+  return (
+    !blocked &&
+    editor.isEditable &&
+    selection instanceof TextSelection &&
+    !selection.empty &&
+    state.doc.textBetween(from, to).trim().length > 0 &&
+    (view.hasFocus() || menuFocused)
+  )
+}
+
+export function RichMarkdownSelectionToolbar({
+  editor,
+  blocked,
+  scrollContainer,
+  onToggleLink
+}: RichMarkdownSelectionToolbarProps): React.JSX.Element | null {
+  const [textColorPopoverOpen, setTextColorPopoverOpen] = React.useState(false)
+  const activeMarks = useEditorState({
+    editor,
+    selector: ({ editor: activeEditor }) =>
+      activeEditor
+        ? `${Number(activeEditor.isActive('bold'))}${Number(activeEditor.isActive('italic'))}${Number(activeEditor.isActive('strike'))}${Number(activeEditor.isActive('link'))}`
+        : '0000'
+  })
+  const markState = activeMarks ?? '0000'
+
+  if (!editor) {
+    return null
+  }
+
+  return (
+    <BubbleMenu
+      editor={editor}
+      pluginKey="richMarkdownSelectionToolbar"
+      className="rich-markdown-selection-toolbar"
+      appendTo={() => document.body}
+      shouldShow={(args) => shouldShowRichMarkdownSelectionToolbar({ ...args, editor, blocked })}
+      options={{
+        placement: 'top',
+        offset: 8,
+        flip: { padding: 8 },
+        shift: { padding: 8 },
+        inline: true,
+        scrollTarget: scrollContainer ?? window,
+        onHide: () => setTextColorPopoverOpen(false)
+      }}
+    >
+      <RichMarkdownToolbarButton
+        active={markState[0] === '1'}
+        label={translate('auto.components.editor.RichMarkdownToolbar.4f9e789fe0', 'Bold')}
+        onClick={() => editor.chain().focus().toggleBold().run()}
+      >
+        B
+      </RichMarkdownToolbarButton>
+      <RichMarkdownToolbarButton
+        active={markState[1] === '1'}
+        label={translate('auto.components.editor.RichMarkdownToolbar.6b4ccf9493', 'Italic')}
+        onClick={() => editor.chain().focus().toggleItalic().run()}
+      >
+        I
+      </RichMarkdownToolbarButton>
+      <RichMarkdownToolbarButton
+        active={markState[2] === '1'}
+        label={translate('auto.components.editor.RichMarkdownToolbar.0bea19a988', 'Strike')}
+        onClick={() => editor.chain().focus().toggleStrike().run()}
+      >
+        S
+      </RichMarkdownToolbarButton>
+      <div className="rich-markdown-toolbar-separator" />
+      <RichMarkdownToolbarButton
+        active={markState[3] === '1'}
+        label={translate('auto.components.editor.RichMarkdownToolbar.6d52624712', 'Link')}
+        onClick={onToggleLink}
+      >
+        <LinkIcon className="size-3.5" />
+      </RichMarkdownToolbarButton>
+      <RichMarkdownTextColorControl
+        editor={editor}
+        open={textColorPopoverOpen}
+        onOpenChange={setTextColorPopoverOpen}
+        closeOnSelectionCollapse
+      />
+    </BubbleMenu>
+  )
+}

--- a/src/renderer/src/components/editor/RichMarkdownTextColorControl.test.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownTextColorControl.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+import type { ReactNode } from 'react'
+import { Editor } from '@tiptap/core'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createRichMarkdownExtensions } from './rich-markdown-extensions'
+import { createRichMarkdownEditorCodec } from './rich-markdown-source-transport'
+import { RichMarkdownTextColorControl } from './RichMarkdownTextColorControl'
+
+vi.mock('@/components/ui/popover', () => ({
+  Popover: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: ReactNode }) => <div>{children}</div>
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  TooltipProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  Tooltip: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+afterEach(cleanup)
+
+describe('RichMarkdownTextColorControl', () => {
+  it('applies and clears a selected text color', async () => {
+    const codec = createRichMarkdownEditorCodec()
+    const editor = new Editor({
+      element: document.createElement('div'),
+      extensions: createRichMarkdownExtensions({ codec }),
+      content: 'colored text',
+      contentType: 'markdown'
+    })
+    editor.commands.setTextSelection({ from: 1, to: 8 })
+
+    try {
+      render(<RichMarkdownTextColorControl editor={editor} />)
+      fireEvent.click(screen.getByRole('button', { name: 'Red' }))
+
+      await waitFor(() => {
+        expect(editor.getMarkdown().trimEnd()).toBe(
+          '<span data-orca-text-color="red">colored</span> text'
+        )
+      })
+      expect(screen.getByRole('button', { name: 'Red' }).getAttribute('aria-pressed')).toBe('true')
+
+      fireEvent.click(screen.getByRole('button', { name: 'Clear text color' }))
+      await waitFor(() => expect(editor.getMarkdown().trimEnd()).toBe('colored text'))
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('clears a mixed-color selection without showing a false active color', async () => {
+    const codec = createRichMarkdownEditorCodec()
+    const editor = new Editor({
+      element: document.createElement('div'),
+      extensions: createRichMarkdownExtensions({ codec }),
+      content:
+        '<span data-orca-text-color="red">red</span> <span data-orca-text-color="blue">blue</span>',
+      contentType: 'markdown'
+    })
+    editor.commands.setTextSelection({ from: 1, to: 9 })
+
+    try {
+      render(<RichMarkdownTextColorControl editor={editor} />)
+      expect(
+        screen
+          .getByRole('button', { name: 'Text color' })
+          .getAttribute('data-rich-markdown-text-color')
+      ).toBeNull()
+
+      fireEvent.click(screen.getByRole('button', { name: 'Clear text color' }))
+      await waitFor(() => expect(editor.getMarkdown().trimEnd()).toBe('red blue'))
+    } finally {
+      editor.destroy()
+    }
+  })
+})

--- a/src/renderer/src/components/editor/RichMarkdownTextColorControl.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownTextColorControl.tsx
@@ -1,0 +1,174 @@
+import React from 'react'
+import type { Editor } from '@tiptap/core'
+import { useEditorState } from '@tiptap/react'
+import { Baseline, Eraser } from 'lucide-react'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import { RICH_MARKDOWN_TEXT_COLORS, type RichMarkdownTextColor } from './rich-markdown-text-color'
+
+type RichMarkdownTextColorControlProps = {
+  editor: Editor | null
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+  closeOnSelectionCollapse?: boolean
+}
+
+function getColorLabel(color: RichMarkdownTextColor): string {
+  const labels: Record<RichMarkdownTextColor, string> = {
+    gray: translate('auto.components.editor.RichMarkdownTextColorControl.gray', 'Gray'),
+    red: translate('auto.components.editor.RichMarkdownTextColorControl.red', 'Red'),
+    orange: translate('auto.components.editor.RichMarkdownTextColorControl.orange', 'Orange'),
+    yellow: translate('auto.components.editor.RichMarkdownTextColorControl.yellow', 'Yellow'),
+    green: translate('auto.components.editor.RichMarkdownTextColorControl.green', 'Green'),
+    teal: translate('auto.components.editor.RichMarkdownTextColorControl.teal', 'Teal'),
+    blue: translate('auto.components.editor.RichMarkdownTextColorControl.blue', 'Blue'),
+    purple: translate('auto.components.editor.RichMarkdownTextColorControl.purple', 'Purple'),
+    pink: translate('auto.components.editor.RichMarkdownTextColorControl.pink', 'Pink')
+  }
+  return labels[color]
+}
+
+export function RichMarkdownTextColorControl({
+  editor,
+  open: controlledOpen,
+  onOpenChange,
+  closeOnSelectionCollapse = false
+}: RichMarkdownTextColorControlProps): React.JSX.Element {
+  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(false)
+  const open = controlledOpen ?? uncontrolledOpen
+  const currentColor = useEditorState({
+    editor,
+    selector: ({ editor: activeEditor }) => {
+      if (!activeEditor) {
+        return null
+      }
+      return (
+        RICH_MARKDOWN_TEXT_COLORS.find((color) =>
+          activeEditor.isActive('richMarkdownTextColor', { color })
+        ) ?? null
+      )
+    }
+  })
+  const label = translate(
+    'auto.components.editor.RichMarkdownTextColorControl.textColor',
+    'Text color'
+  )
+  const clearLabel = translate(
+    'auto.components.editor.RichMarkdownTextColorControl.clear',
+    'Clear text color'
+  )
+
+  const setOpen = React.useCallback(
+    (nextOpen: boolean): void => {
+      if (controlledOpen === undefined) {
+        setUncontrolledOpen(nextOpen)
+      }
+      onOpenChange?.(nextOpen)
+    },
+    [controlledOpen, onOpenChange]
+  )
+
+  React.useEffect(() => {
+    if (!editor || !closeOnSelectionCollapse) {
+      return
+    }
+
+    const closeForCollapsedSelection = (): void => {
+      if (editor.state.selection.empty) {
+        setOpen(false)
+      }
+    }
+
+    editor.on('selectionUpdate', closeForCollapsedSelection)
+    return () => {
+      editor.off('selectionUpdate', closeForCollapsedSelection)
+    }
+  }, [closeOnSelectionCollapse, editor, setOpen])
+
+  const setColor = (color: RichMarkdownTextColor): void => {
+    editor?.chain().focus().setMark('richMarkdownTextColor', { color }).run()
+    setOpen(false)
+  }
+
+  const clearColor = (): void => {
+    editor?.chain().focus().unsetMark('richMarkdownTextColor').run()
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className={cn('rich-markdown-toolbar-button', currentColor && 'is-active')}
+              data-rich-markdown-text-color={currentColor ?? undefined}
+              aria-label={label}
+              onMouseDown={(event) => event.preventDefault()}
+            >
+              <Baseline className="size-3.5" />
+            </button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" sideOffset={4}>
+          {label}
+        </TooltipContent>
+      </Tooltip>
+      <PopoverContent
+        align="start"
+        side="bottom"
+        className="rich-markdown-text-color-popover"
+        onOpenAutoFocus={(event) => event.preventDefault()}
+      >
+        <div className="rich-markdown-text-color-options">
+          {RICH_MARKDOWN_TEXT_COLORS.map((color) => {
+            const colorLabel = getColorLabel(color)
+            return (
+              <Tooltip key={color}>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className={cn(
+                      'rich-markdown-text-color-option',
+                      currentColor === color && 'is-active'
+                    )}
+                    data-rich-markdown-text-color={color}
+                    aria-label={colorLabel}
+                    aria-pressed={currentColor === color}
+                    onMouseDown={(event) => event.preventDefault()}
+                    onClick={() => setColor(color)}
+                  >
+                    <span className="rich-markdown-text-color-swatch" aria-hidden="true" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={4}>
+                  {colorLabel}
+                </TooltipContent>
+              </Tooltip>
+            )
+          })}
+          <div className="rich-markdown-text-color-divider" />
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                className="rich-markdown-text-color-option"
+                aria-label={clearLabel}
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={clearColor}
+              >
+                <Eraser className="size-4" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom" sideOffset={4}>
+              {clearLabel}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/renderer/src/components/editor/RichMarkdownToolbar.tsx
+++ b/src/renderer/src/components/editor/RichMarkdownToolbar.tsx
@@ -28,6 +28,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/comp
 import { RichMarkdownToolbarButton } from './RichMarkdownToolbarButton'
 import { translate } from '@/i18n/i18n'
 import { insertToggle } from './rich-markdown-slash-command-primitives'
+import { RichMarkdownTextColorControl } from './RichMarkdownTextColorControl'
 
 type RichMarkdownToolbarProps = {
   editor: Editor | null
@@ -149,6 +150,7 @@ export function RichMarkdownToolbar({
       >
         S
       </RichMarkdownToolbarButton>
+      <RichMarkdownTextColorControl editor={editor} />
       <Separator />
       <RichMarkdownToolbarButton
         active={false}

--- a/src/renderer/src/components/editor/markdown-preview-sanitize-schema.test.tsx
+++ b/src/renderer/src/components/editor/markdown-preview-sanitize-schema.test.tsx
@@ -1,0 +1,34 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import Markdown from 'react-markdown'
+import rehypeRaw from 'rehype-raw'
+import rehypeSanitize from 'rehype-sanitize'
+import { describe, expect, it } from 'vitest'
+import { markdownPreviewSanitizeSchema } from './markdown-preview-sanitize-schema'
+import { RICH_MARKDOWN_TEXT_COLORS } from './rich-markdown-text-color-palette'
+
+function renderSanitizedMarkdown(content: string): string {
+  return renderToStaticMarkup(
+    <Markdown rehypePlugins={[rehypeRaw, [rehypeSanitize, markdownPreviewSanitizeSchema]]}>
+      {content}
+    </Markdown>
+  )
+}
+
+describe('markdown preview text color sanitization', () => {
+  it.each(RICH_MARKDOWN_TEXT_COLORS)(
+    'keeps the controlled %s text color and removes style attributes',
+    (color) => {
+      const html = renderSanitizedMarkdown(
+        `<span data-orca-text-color="${color}" style="font-size: 100px">safe</span>`
+      )
+      expect(html).toContain(`<span data-orca-text-color="${color}">safe</span>`)
+      expect(html).not.toContain('style=')
+    }
+  )
+
+  it('removes unsupported text colors', () => {
+    const html = renderSanitizedMarkdown('<span data-orca-text-color="cyan">plain</span>')
+    expect(html).toContain('<span>plain</span>')
+    expect(html).not.toContain('data-orca-text-color')
+  })
+})

--- a/src/renderer/src/components/editor/markdown-preview-sanitize-schema.ts
+++ b/src/renderer/src/components/editor/markdown-preview-sanitize-schema.ts
@@ -1,0 +1,45 @@
+import { defaultSchema, type Options } from 'rehype-sanitize'
+import { RICH_MARKDOWN_TEXT_COLORS } from './rich-markdown-text-color-palette'
+
+export const markdownPreviewSanitizeSchema: Options = {
+  ...defaultSchema,
+  tagNames: [...(defaultSchema.tagNames ?? []), 'details', 'summary', 'kbd', 'sub', 'sup', 'ins'],
+  protocols: {
+    ...defaultSchema.protocols,
+    // Why: the click handler owns authorization for local file targets.
+    href: [...(defaultSchema.protocols?.href ?? []), 'file'],
+    src: [...(defaultSchema.protocols?.src ?? []), 'file']
+  },
+  attributes: {
+    ...defaultSchema.attributes,
+    '*': [...(defaultSchema.attributes?.['*'] ?? []), 'id'],
+    a: [...(defaultSchema.attributes?.a ?? []), 'href', 'title'],
+    code: [
+      ...(defaultSchema.attributes?.code ?? []),
+      ['className', /^language-[\w-]+$/, 'math-inline', 'math-display']
+    ],
+    div: [...(defaultSchema.attributes?.div ?? []), ['className', /^language-[\w-]+$/], 'align'],
+    details: [
+      ...(defaultSchema.attributes?.details ?? []),
+      'open',
+      ['className', 'orca-details'],
+      ['dataOrcaToggle', 'heading-1', 'heading-2', 'heading-3', 'heading-4', 'heading-5']
+    ],
+    h1: [...(defaultSchema.attributes?.h1 ?? []), 'id'],
+    h2: [...(defaultSchema.attributes?.h2 ?? []), 'id'],
+    h3: [...(defaultSchema.attributes?.h3 ?? []), 'id'],
+    h4: [...(defaultSchema.attributes?.h4 ?? []), 'id'],
+    h5: [...(defaultSchema.attributes?.h5 ?? []), 'id'],
+    h6: [...(defaultSchema.attributes?.h6 ?? []), 'id'],
+    img: [...(defaultSchema.attributes?.img ?? []), 'src', 'alt', 'title', 'width', 'height'],
+    input: [...(defaultSchema.attributes?.input ?? []), 'type', 'checked', 'disabled'],
+    pre: [...(defaultSchema.attributes?.pre ?? []), ['className', /^language-[\w-]+$/]],
+    span: [
+      ...(defaultSchema.attributes?.span ?? []),
+      ['className', /^hljs(?:-[\w-]+)?$/],
+      ['dataOrcaTextColor', ...RICH_MARKDOWN_TEXT_COLORS]
+    ],
+    td: [...(defaultSchema.attributes?.td ?? []), 'align'],
+    th: [...(defaultSchema.attributes?.th ?? []), 'align']
+  }
+}

--- a/src/renderer/src/components/editor/markdown-round-trip.test.ts
+++ b/src/renderer/src/components/editor/markdown-round-trip.test.ts
@@ -5,6 +5,7 @@ import { createRichMarkdownExtensions } from './rich-markdown-extensions'
 import { createRichMarkdownEditorCodec } from './rich-markdown-source-transport'
 import type { SlashCommandId } from './rich-markdown-slash-commands'
 import { slashCommands } from './rich-markdown-slash-commands'
+import { RICH_MARKDOWN_TEXT_COLORS } from './rich-markdown-text-color-palette'
 
 function roundTripMarkdown(content: string): string {
   const codec = createRichMarkdownEditorCodec()
@@ -46,6 +47,55 @@ function markdownAfterTextReplace(content: string, search: string, replacement: 
       throw new Error(`Missing text: ${search}`)
     }
     editor.view.dispatch(editor.state.tr.insertText(replacement, from, from + search.length))
+    return editor.getMarkdown().trimEnd()
+  } finally {
+    editor.destroy()
+  }
+}
+
+function markdownAfterColorCommand(
+  content: string,
+  from: number,
+  to: number,
+  color: string | null
+): string {
+  const codec = createRichMarkdownEditorCodec()
+  const editor = new Editor({
+    element: null,
+    extensions: createRichMarkdownExtensions({ codec }),
+    content: encodeRawMarkdownHtmlForRichEditor(content, codec),
+    contentType: 'markdown'
+  })
+
+  try {
+    const chain = editor.chain().setTextSelection({ from, to })
+    if (color) {
+      chain.setMark('richMarkdownTextColor', { color }).run()
+    } else {
+      chain.unsetMark('richMarkdownTextColor').run()
+    }
+    return editor.getMarkdown().trimEnd()
+  } finally {
+    editor.destroy()
+  }
+}
+
+function markdownAfterColoredTyping(content: string, position: number, text: string): string {
+  const codec = createRichMarkdownEditorCodec()
+  const editor = new Editor({
+    element: null,
+    extensions: createRichMarkdownExtensions({ codec }),
+    content,
+    contentType: 'markdown'
+  })
+
+  try {
+    editor
+      .chain()
+      .setTextSelection(position)
+      .setMark('richMarkdownTextColor', { color: 'purple' })
+      .run()
+    editor.view.dispatch(editor.state.tr.insertText(text))
     return editor.getMarkdown().trimEnd()
   } finally {
     editor.destroy()
@@ -97,6 +147,51 @@ function slashCommandSelectionParent(commandId: SlashCommandId): string {
 }
 
 describe('rich markdown round trip', () => {
+  it.each(RICH_MARKDOWN_TEXT_COLORS)('preserves the %s text color mark', (color) => {
+    const source = `<span data-orca-text-color="${color}">colored text</span>`
+    expect(roundTripMarkdown(source)).toBe(source)
+  })
+
+  it('preserves markdown formatting inside a text color mark', () => {
+    const source = '<span data-orca-text-color="blue">**bold** and *italic*</span>'
+    expect(roundTripMarkdown(source)).toBe(source)
+  })
+
+  it('applies a text color mark to the selected text', () => {
+    expect(markdownAfterColorCommand('marked text', 1, 7, 'red')).toBe(
+      '<span data-orca-text-color="red">marked</span> text'
+    )
+  })
+
+  it('clears a text color mark from the selected text', () => {
+    expect(
+      markdownAfterColorCommand('<span data-orca-text-color="green">plain</span>', 1, 6, null)
+    ).toBe('plain')
+  })
+
+  it('continues a selected text color while typing', () => {
+    expect(markdownAfterColoredTyping('plain ', 7, 'purple')).toBe(
+      'plain <span data-orca-text-color="purple">purple</span>'
+    )
+  })
+
+  it('preserves unsupported colors through raw HTML passthrough', () => {
+    const source = '<span data-orca-text-color="cyan">unchanged</span>'
+    expect(roundTripMarkdown(source)).toBe(source)
+  })
+
+  it('preserves ordinary spans through raw HTML passthrough', () => {
+    const source = '<span class="label">unchanged</span>'
+    expect(roundTripMarkdown(source)).toBe(source)
+  })
+
+  it('keeps text color syntax literal inside code', () => {
+    const inline = '`<span data-orca-text-color="red">inline</span>`'
+    const fenced = '```html\n<span data-orca-text-color="red">block</span>\n```'
+    expect(roundTripMarkdown(inline)).toBe(inline)
+    expect(roundTripMarkdown(fenced)).toBe(fenced)
+  })
+
   it('preserves inline html inside paragraphs', () => {
     expect(roundTripMarkdown('Before <span>hi</span> after\n')).toBe('Before <span>hi</span> after')
   })

--- a/src/renderer/src/components/editor/raw-markdown-html.ts
+++ b/src/renderer/src/components/editor/raw-markdown-html.ts
@@ -9,6 +9,7 @@ import type {
 } from './rich-markdown-source-transport'
 import { isReservedRichMarkdownTransportBody } from './rich-markdown-source-transport'
 import { matchHtmlSuperscriptLinkSource } from './rich-markdown-html-superscript-link-source'
+import { matchRichMarkdownTextColorSource } from './rich-markdown-text-color'
 
 const INLINE_HTML_PATTERN = /^<!--[\s\S]*?-->|^<\/?[A-Za-z][\w.:-]*(?:\s[^<>]*?)?\/?>/
 
@@ -167,6 +168,12 @@ export function encodeRawMarkdownHtmlForRichEditor(
     }
 
     if (normalizedContent[index] === '<' && !isEscaped(normalizedContent, index)) {
+      const textColor = matchRichMarkdownTextColorSource(normalizedContent, index)
+      if (textColor) {
+        result += textColor.raw
+        index = textColor.end
+        continue
+      }
       if (htmlSuperscriptLinks) {
         const superscriptLink = matchHtmlSuperscriptLinkSource(normalizedContent, index)
         if (superscriptLink) {

--- a/src/renderer/src/components/editor/rich-markdown-extensions.ts
+++ b/src/renderer/src/components/editor/rich-markdown-extensions.ts
@@ -33,6 +33,7 @@ import type { RichMarkdownEditorCodec } from './rich-markdown-source-transport'
 import { createRichMarkdownHtmlSuperscriptLink } from './rich-markdown-html-superscript-link'
 import type { RichMarkdownHtmlSuperscriptLinkContext } from './rich-markdown-html-superscript-link-context'
 import { RichMarkdownTaskList } from './rich-markdown-task-list'
+import { RichMarkdownTextColorExtension } from './rich-markdown-text-color'
 
 const lowlight = createLowlight(common)
 
@@ -213,6 +214,7 @@ export function createRichMarkdownExtensions({
       }
     }),
     createRichMarkdownLiteral(codec.transport),
+    RichMarkdownTextColorExtension,
     ...(htmlSuperscriptLinks
       ? [createRichMarkdownHtmlSuperscriptLink(codec.transport, htmlSuperscriptLinkContext!)]
       : []),

--- a/src/renderer/src/components/editor/rich-markdown-text-color-palette.ts
+++ b/src/renderer/src/components/editor/rich-markdown-text-color-palette.ts
@@ -1,0 +1,13 @@
+export const RICH_MARKDOWN_TEXT_COLORS = [
+  'gray',
+  'red',
+  'orange',
+  'yellow',
+  'green',
+  'teal',
+  'blue',
+  'purple',
+  'pink'
+] as const
+
+export type RichMarkdownTextColor = (typeof RICH_MARKDOWN_TEXT_COLORS)[number]

--- a/src/renderer/src/components/editor/rich-markdown-text-color.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-text-color.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment happy-dom
+import { Editor } from '@tiptap/core'
+import { describe, expect, it } from 'vitest'
+import { createRichMarkdownExtensions } from './rich-markdown-extensions'
+import { createRichMarkdownEditorCodec } from './rich-markdown-source-transport'
+import {
+  matchRichMarkdownTextColorSource,
+  RICH_MARKDOWN_TEXT_COLORS
+} from './rich-markdown-text-color'
+
+function markdownAfterHtmlImport(content: string): string {
+  const codec = createRichMarkdownEditorCodec()
+  const editor = new Editor({
+    element: document.createElement('div'),
+    extensions: createRichMarkdownExtensions({ codec }),
+    content
+  })
+
+  try {
+    return editor.getMarkdown().trimEnd()
+  } finally {
+    editor.destroy()
+  }
+}
+
+describe('rich markdown text color source', () => {
+  it.each(RICH_MARKDOWN_TEXT_COLORS)('matches the controlled %s color', (color) => {
+    const source = `before <span data-orca-text-color="${color}">text</span> after`
+    expect(matchRichMarkdownTextColorSource(source, 7)).toEqual({
+      raw: `<span data-orca-text-color="${color}">text</span>`,
+      content: 'text',
+      color,
+      end: source.length - 6
+    })
+  })
+
+  it('accepts harmless source whitespace and single quotes', () => {
+    expect(
+      matchRichMarkdownTextColorSource("<span data-orca-text-color = 'blue' >text</span>")
+    ).toMatchObject({ content: 'text', color: 'blue' })
+  })
+
+  it.each([
+    '<span data-orca-text-color="cyan">text</span>',
+    '<span style="color: red">text</span>',
+    '<span data-orca-text-color="red" class="extra">text</span>',
+    '<span data-orca-text-color="red">text',
+    '<span data-orca-text-color="red"><strong>text</strong></span>'
+  ])('rejects unsupported source: %s', (source) => {
+    expect(matchRichMarkdownTextColorSource(source)).toBeNull()
+  })
+
+  it('imports controlled text colors from rich clipboard HTML', () => {
+    expect(
+      markdownAfterHtmlImport('<p><span data-orca-text-color="orange">pasted</span></p>')
+    ).toBe('<span data-orca-text-color="orange">pasted</span>')
+  })
+
+  it('drops unsupported color attributes from rich clipboard HTML', () => {
+    expect(markdownAfterHtmlImport('<p><span data-orca-text-color="cyan">plain</span></p>')).toBe(
+      'plain'
+    )
+  })
+
+  it('supports undo and redo after applying a text color', () => {
+    const codec = createRichMarkdownEditorCodec()
+    const editor = new Editor({
+      element: document.createElement('div'),
+      extensions: createRichMarkdownExtensions({ codec }),
+      content: 'history',
+      contentType: 'markdown'
+    })
+
+    try {
+      editor
+        .chain()
+        .setTextSelection({ from: 1, to: 8 })
+        .setMark('richMarkdownTextColor', { color: 'blue' })
+        .run()
+      expect(editor.getMarkdown().trimEnd()).toBe(
+        '<span data-orca-text-color="blue">history</span>'
+      )
+
+      editor.commands.undo()
+      expect(editor.getMarkdown().trimEnd()).toBe('history')
+
+      editor.commands.redo()
+      expect(editor.getMarkdown().trimEnd()).toBe(
+        '<span data-orca-text-color="blue">history</span>'
+      )
+    } finally {
+      editor.destroy()
+    }
+  })
+})

--- a/src/renderer/src/components/editor/rich-markdown-text-color.ts
+++ b/src/renderer/src/components/editor/rich-markdown-text-color.ts
@@ -1,0 +1,123 @@
+import { Mark } from '@tiptap/core'
+import {
+  RICH_MARKDOWN_TEXT_COLORS,
+  type RichMarkdownTextColor
+} from './rich-markdown-text-color-palette'
+
+export { RICH_MARKDOWN_TEXT_COLORS, type RichMarkdownTextColor }
+
+type RichMarkdownTextColorSource = {
+  raw: string
+  content: string
+  color: RichMarkdownTextColor
+  end: number
+}
+
+const COLOR_SOURCE_PATTERN = RICH_MARKDOWN_TEXT_COLORS.join('|')
+const OPENING_TAG_PATTERN = new RegExp(
+  `^<span\\s+data-orca-text-color\\s*=\\s*(["'])(${COLOR_SOURCE_PATTERN})\\1\\s*>`
+)
+const CLOSING_TAG_PATTERN = /<\/span\s*>/
+
+export function isRichMarkdownTextColor(value: unknown): value is RichMarkdownTextColor {
+  return (
+    typeof value === 'string' && RICH_MARKDOWN_TEXT_COLORS.includes(value as RichMarkdownTextColor)
+  )
+}
+
+export function matchRichMarkdownTextColorSource(
+  source: string,
+  start = 0
+): RichMarkdownTextColorSource | null {
+  const remaining = source.slice(start)
+  const opening = remaining.match(OPENING_TAG_PATTERN)
+  if (!opening || !isRichMarkdownTextColor(opening[2])) {
+    return null
+  }
+
+  const closing = CLOSING_TAG_PATTERN.exec(remaining.slice(opening[0].length))
+  if (!closing) {
+    return null
+  }
+
+  const closingIndex = opening[0].length + closing.index
+  const content = remaining.slice(opening[0].length, closingIndex)
+  // Raw HTML inside a color mark cannot be represented without changing its source.
+  if (content.includes('<')) {
+    return null
+  }
+
+  const length = closingIndex + closing[0].length
+  return {
+    raw: remaining.slice(0, length),
+    content,
+    color: opening[2],
+    end: start + length
+  }
+}
+
+export const RichMarkdownTextColorExtension = Mark.create({
+  name: 'richMarkdownTextColor',
+
+  addAttributes() {
+    return {
+      color: {
+        default: null,
+        rendered: false
+      }
+    }
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'span[data-orca-text-color]',
+        getAttrs: (element: HTMLElement) => {
+          const color = element.getAttribute('data-orca-text-color')
+          return isRichMarkdownTextColor(color) ? { color } : false
+        }
+      }
+    ]
+  },
+
+  renderHTML({ mark }) {
+    const color = mark.attrs.color
+    return isRichMarkdownTextColor(color)
+      ? ['span', { 'data-orca-text-color': color }, 0]
+      : ['span', {}, 0]
+  },
+
+  markdownTokenName: 'richMarkdownTextColor',
+  markdownTokenizer: {
+    name: 'richMarkdownTextColor',
+    level: 'inline',
+    start: '<span',
+    tokenize(source, _tokens, lexer) {
+      const matched = matchRichMarkdownTextColorSource(source)
+      if (!matched) {
+        return undefined
+      }
+      return {
+        type: 'richMarkdownTextColor',
+        raw: matched.raw,
+        color: matched.color,
+        tokens: lexer.inlineTokens(matched.content)
+      }
+    }
+  },
+  parseMarkdown: (token, helpers) => {
+    if (!isRichMarkdownTextColor(token.color)) {
+      return []
+    }
+    return helpers.applyMark('richMarkdownTextColor', helpers.parseInline(token.tokens ?? []), {
+      color: token.color
+    })
+  },
+  renderMarkdown: (node, helpers) => {
+    const color = node.attrs?.color
+    const content = helpers.renderChildren(node)
+    return isRichMarkdownTextColor(color)
+      ? `<span data-orca-text-color="${color}">${content}</span>`
+      : content
+  }
+})

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14584,6 +14584,19 @@
           "insertColumnRight": "Insert column right",
           "deleteRow": "Delete row",
           "deleteColumn": "Delete column"
+        },
+        "RichMarkdownTextColorControl": {
+          "gray": "Gray",
+          "red": "Red",
+          "orange": "Orange",
+          "yellow": "Yellow",
+          "green": "Green",
+          "teal": "Teal",
+          "blue": "Blue",
+          "purple": "Purple",
+          "pink": "Pink",
+          "textColor": "Text color",
+          "clear": "Clear text color"
         }
       },
       "diff": {


### PR DESCRIPTION
## ELI5

  Users can select text in the Markdown editor and apply a color from a small formatting palette, similar to document editors such as
  Feishu.

  ## What Changed

  - Added inline text color formatting to the rich Markdown editor.
  - Added a selection toolbar with bold, italic, strike, link, and text color actions.
  - Added nine theme-aware colors: gray, red, orange, yellow, green, teal, blue, purple, and pink.
  - Added a clear-color action.
  - Added safe Markdown preview sanitization for supported color values.
  - Preserved colored text through Markdown parse, edit, save, and preview round trips.
  - Added focused tests for parsing, serialization, sanitization, toolbar behavior, and selection collapse.

  Colored text is serialized as controlled inline HTML:

  ```html
  <span data-orca-text-color="blue">colored text</span>

  ## Why

  The rich Markdown editor supports common emphasis formatting but has no way to visually categorize or highlight text using
  foreground colors.

  A fixed allowlist keeps the feature predictable and safe:

  - arbitrary CSS and style attributes are not accepted;
  - light and dark themes use design-system tokens;
  - existing Markdown formatting can remain inside colored spans;
  - unsupported values degrade without throwing or deleting their text;
  - existing color names remain stable for backwards compatibility.

  ## Linked Issue

  Fixes #<ISSUE_NUMBER>

  ## Visual Proof

   Before                                              After
  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
   No text color action in the Markdown toolbar        Nine-color palette in the toolbar
  ──────────────────────────────────────────────────  ──────────────────────────────────────────────────
   No contextual formatting UI after selecting text    Selection toolbar with an anchored color palette
  <!-- Upload the before and after screenshots here using drag-and-drop. -->

  ## Testing

  Tested locally on macOS:

  - Selected text and opened the contextual formatting toolbar.
  - Applied and cleared text colors.
  - Verified all nine swatches in light and dark themes.
  - Verified the toolbar and palette close when the selection collapses.
  - Verified Markdown editor and preview rendering.
  - Verified controlled color attributes are preserved while arbitrary styles are removed.

  Automated verification:

  - 88 focused Vitest tests passed across five editor test files.
  - pnpm run typecheck:web
  - Oxlint, type-aware Oxlint, and React Doctor rules
  - Localization catalog, extraction, and coverage checks
  - Max-lines ratchet
  - electron-vite build --mode e2e

  Linux, Windows, SSH, and mobile were not manually exercised. The change is renderer-only and introduces no path, shortcut, process,
  RPC, or remote-wire behavior.

  - [x] I manually tested these changes locally
  - [x] Automated tests added/updated, or explained why not below

  ## AI Disclosure

  OpenAI Codex (GPT-5) was used to assist with implementation, test development, and validation.

  ## Review

  - Security: preview sanitization allows only fixed color values and strips arbitrary style attributes.
  - Cross-platform: no platform-specific APIs, paths, or keyboard shortcuts were introduced.
  - SSH/remote: no execution, RPC, stream, or remote-wire behavior changed.
  - Mobile: no mobile behavior changed.
  - Backwards compatibility: existing Markdown remains unchanged; unsupported color markup preserves its content.
  - Performance: the palette is fixed-size and adds no polling or document-wide runtime processing.

  ## Agent skill upstream boundary

  - [x] Not applicable, or this change follows docs/reference/agent-skill-sharing-upstream-boundary.md and copies or mechanically
    translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

  ## Notes

  No known issues were found in security, cross-platform behavior, remote SSH behavior, mobile behavior, backwards compatibility, or
  performance.

  ## Checklist

  - [x] This PR is small and focused
  - [x] I explained what changed and why (including ELI5)
  - [ ] Before/after screenshots or videos attached for UI changes, or N/A with reason
  - [x] Self-reviewed for correctness, security, and performance
  - [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
  - [ ] pnpm lint, pnpm typecheck, pnpm test, and pnpm build pass (or CI will cover; local preferred)