### PR TITLE
fix(codex): separate session backfill baseline from launch updates

### DIFF
--- a/src/main/codex-accounts/runtime-home-real-home-lane-routing.test.ts
+++ b/src/main/codex-accounts/runtime-home-real-home-lane-routing.test.ts
@@ -117,6 +117,50 @@ describe('CodexRuntimeHomeService', () => {
     expect(existsSync(getRuntimeCodexHomePath())).toBe(true)
   })
 
+  it('persists the pre-spawn launch date when setup crosses UTC midnight', async () => {
+    vi.setSystemTime(new Date('2026-08-06T00:00:01Z'))
+    const store = createStore(createSettings())
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+
+    service.prepareForCodexLaunch()
+    service.beginHostSystemDefaultSessionMigrationLaunch(getRuntimeCodexHomePath(), {
+      startedAt: new Date('2026-08-05T23:59:59Z')
+    })
+
+    const marker = JSON.parse(
+      readFileSync(
+        join(testState.userDataDir, 'codex-session-backfill', 'backfill-complete.json'),
+        'utf-8'
+      )
+    ) as { pendingSince?: string }
+    expect(marker.pendingSince).toBe('2026-08-05')
+  })
+
+  it('preserves the pending date when an active launch changes session targets', async () => {
+    vi.setSystemTime(new Date('2026-08-05T10:00:00Z'))
+    const store = createStore(createSettings())
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+
+    service.prepareForCodexLaunch()
+    service.beginHostSystemDefaultSessionMigrationLaunch(getRuntimeCodexHomePath())
+    const movedHome = join(testState.fakeHomeDir, 'moved-history')
+    store.updateSettings({ codexSessionSourceHome: { host: movedHome, wsl: {} } })
+
+    expect(service.prepareHostSystemDefaultSessionMigrationPass()).toBe(true)
+    const marker = JSON.parse(
+      readFileSync(
+        join(testState.userDataDir, 'codex-session-backfill', 'backfill-complete.json'),
+        'utf-8'
+      )
+    ) as { systemSessionsRoot?: string; pendingSince?: string }
+    expect(marker).toMatchObject({
+      systemSessionsRoot: join(movedHome, 'sessions'),
+      pendingSince: '2026-08-05'
+    })
+  })
+
   it('routes host system default to the real home', async () => {
     const store = createStore(createSettings({ shellStartupEnvProbeSupported: true }))
     const { CodexRuntimeHomeService } = await import('./runtime-home-service')

--- a/src/main/codex-accounts/runtime-home-real-home-lane-routing.test.ts
+++ b/src/main/codex-accounts/runtime-home-real-home-lane-routing.test.ts
@@ -54,7 +54,7 @@ describe('CodexRuntimeHomeService', () => {
     const { CodexRuntimeHomeService } = await import('./runtime-home-service')
     const service = new CodexRuntimeHomeService(store as never)
     expect(service.prepareForCodexLaunch()).toBe(getRuntimeCodexHomePath())
-    expect(existsSync(markerPath)).toBe(false)
+    expect(existsSync(markerPath)).toBe(true)
     service.finishHostSystemDefaultSessionMigrationPass()
     expect(service.beginHostSystemDefaultSessionMigrationLaunch(getRuntimeCodexHomePath())).toBe(
       true
@@ -82,7 +82,7 @@ describe('CodexRuntimeHomeService', () => {
     expect(service.beginHostSystemDefaultSessionMigrationLaunch(getRuntimeCodexHomePath())).toBe(
       false
     )
-    expect(existsSync(markerPath)).toBe(false)
+    expect(existsSync(markerPath)).toBe(true)
     service.prepareForCodexLaunch()
     expect(service.beginHostSystemDefaultSessionMigrationLaunch(getRuntimeCodexHomePath())).toBe(
       false
@@ -101,7 +101,7 @@ describe('CodexRuntimeHomeService', () => {
     expect(service.beginHostSystemDefaultSessionMigrationLaunch(null, { reattached: true })).toBe(
       false
     )
-    expect(existsSync(markerPath)).toBe(false)
+    expect(existsSync(markerPath)).toBe(true)
     store.updateSettings({
       codexSessionSourceHome: { host: join(testState.fakeHomeDir, 'moved-history'), wsl: {} }
     })
@@ -140,7 +140,7 @@ describe('CodexRuntimeHomeService', () => {
     mkdirSync(join(testState.userDataDir, 'codex-session-backfill'), { recursive: true })
     writeFileSync(markerPath, '{}\n', 'utf-8')
     expect(service.prepareForCodexLaunch()).toBe(getRuntimeCodexHomePath())
-    expect(existsSync(markerPath)).toBe(false)
+    expect(existsSync(markerPath)).toBe(true)
     expect(service.beginHostSystemDefaultSessionMigrationLaunch(getRuntimeCodexHomePath())).toBe(
       true
     )

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -71,8 +71,12 @@ import { getDefaultWslDistro, getWslHome } from '../wsl'
 import { hasCustomCodexHomeOverrideForLaunch } from '../codex/codex-real-home-path'
 import {
   hasCompletedCodexSessionBackfillMarker,
-  invalidateCodexSessionBackfillMarker
+  invalidateCodexSessionBackfillMarker,
+  markCodexSessionBackfillPending,
+  readCodexSessionBackfillMarkerStatus
 } from '../codex/codex-session-backfill-marker'
+import { getCodexSessionBackfillDate } from '../codex/codex-session-backfill-date'
+import type { CodexSessionBackfillDate } from '../codex/codex-session-backfill-types'
 import { resolveCodexSessionBackfillPaths } from '../codex/codex-session-backfill'
 import {
   ManagedCodexHomeTemporarilyUnavailableError,
@@ -309,14 +313,17 @@ export class CodexRuntimeHomeService {
     const paths = resolveCodexSessionBackfillPaths(
       resolveHostCodexSessionSourceHome(this.store.getSettings())
     )
+    const previousTarget = this.pendingHostSystemDefaultSessionMigrationTarget
     if (
       this.hostSystemDefaultSessionMigrationPending &&
-      this.pendingHostSystemDefaultSessionMigrationTarget !== paths.systemSessionsRoot
+      previousTarget !== paths.systemSessionsRoot
     ) {
       this.pendingHostSystemDefaultSessionMigrationNeedsFullScan = true
       this.pendingHostSystemDefaultSessionMigrationTarget = paths.systemSessionsRoot
     }
-    invalidateCodexSessionBackfillMarker(paths.markerPath)
+    if (previousTarget && previousTarget !== paths.systemSessionsRoot) {
+      invalidateCodexSessionBackfillMarker(paths.markerPath)
+    }
     return this.pendingHostSystemDefaultSessionMigrationNeedsFullScan
   }
 
@@ -324,6 +331,19 @@ export class CodexRuntimeHomeService {
     this.hostSystemDefaultSessionMigrationPending = false
     this.pendingHostSystemDefaultSessionMigrationNeedsFullScan = false
     this.pendingHostSystemDefaultSessionMigrationTarget = null
+  }
+
+  getHostSystemDefaultPendingSessionMigrationDates(): readonly CodexSessionBackfillDate[] {
+    const paths = resolveCodexSessionBackfillPaths(
+      resolveHostCodexSessionSourceHome(this.store.getSettings())
+    )
+    const markerStatus = readCodexSessionBackfillMarkerStatus(
+      paths.markerPath,
+      paths.systemSessionsRoot
+    )
+    return markerStatus.hasBaseline && markerStatus.pendingSince
+      ? getCodexSessionBackfillDatesBetween(markerStatus.pendingSince, new Date())
+      : []
   }
 
   // Why: a managed HOST account runs against its own self-contained CODEX_HOME
@@ -529,7 +549,16 @@ export class CodexRuntimeHomeService {
       this.pendingHostSystemDefaultSessionMigrationTarget = paths.systemSessionsRoot
       this.hostSystemDefaultSessionMigrationPending = true
     }
-    return this.prepareHostSystemDefaultSessionMigrationPass()
+    const paths = resolveCodexSessionBackfillPaths(
+      resolveHostCodexSessionSourceHome(this.store.getSettings())
+    )
+    const needsFullScan = markCodexSessionBackfillPending(
+      paths.markerPath,
+      paths.systemSessionsRoot,
+      getCodexSessionBackfillDate()
+    )
+    this.pendingHostSystemDefaultSessionMigrationNeedsFullScan ||= needsFullScan
+    return this.pendingHostSystemDefaultSessionMigrationNeedsFullScan
   }
 
   private startWslSessionBridgeForLaunch(
@@ -2372,6 +2401,24 @@ export class CodexRuntimeHomeService {
   clearSystemDefaultSnapshot(): void {
     rmSync(this.getSystemDefaultSnapshotPath(), { force: true })
   }
+}
+
+function getCodexSessionBackfillDatesBetween(
+  startedAt: CodexSessionBackfillDate,
+  finishedAt: Date
+): CodexSessionBackfillDate[] {
+  const cursor = new Date(
+    Date.UTC(Number(startedAt[0]), Number(startedAt[1]) - 1, Number(startedAt[2]))
+  )
+  const last = new Date(
+    Date.UTC(finishedAt.getUTCFullYear(), finishedAt.getUTCMonth(), finishedAt.getUTCDate())
+  )
+  const dates: CodexSessionBackfillDate[] = []
+  while (cursor <= last) {
+    dates.push(getCodexSessionBackfillDate(cursor))
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+  }
+  return dates
 }
 
 // Why: Codex reads this config inside WSL, so relative path settings must anchor to the Linux-side home (verbatim copy breaks load, os error 2).

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -285,7 +285,7 @@ export class CodexRuntimeHomeService {
 
   beginHostSystemDefaultSessionMigrationLaunch(
     codexHomePath: string | null,
-    options: { reattached?: boolean; launchEnv?: NodeJS.ProcessEnv } = {}
+    options: { reattached?: boolean; launchEnv?: NodeJS.ProcessEnv; startedAt?: Date } = {}
   ): boolean | null {
     if (
       !this.isHostSystemDefaultSessionMigrationEligible() ||
@@ -298,7 +298,8 @@ export class CodexRuntimeHomeService {
     }
     // Why: an older pass can clear launch preparation while PTY spawn awaits recovery.
     return this.invalidateBackfillAfterManagedSystemDefaultLaunch(
-      options.reattached && !codexHomePath ? undefined : options.launchEnv
+      options.reattached && !codexHomePath ? undefined : options.launchEnv,
+      options.startedAt
     )
   }
 
@@ -322,12 +323,23 @@ export class CodexRuntimeHomeService {
       this.pendingHostSystemDefaultSessionMigrationTarget = paths.systemSessionsRoot
     }
     if (previousTarget && previousTarget !== paths.systemSessionsRoot) {
+      const pendingSince = readCodexSessionBackfillMarkerStatus(
+        paths.markerPath,
+        previousTarget
+      ).pendingSince
       invalidateCodexSessionBackfillMarker(paths.markerPath)
+      if (pendingSince) {
+        markCodexSessionBackfillPending(paths.markerPath, paths.systemSessionsRoot, pendingSince)
+      }
     }
     return this.pendingHostSystemDefaultSessionMigrationNeedsFullScan
   }
 
-  finishHostSystemDefaultSessionMigrationPass(): void {
+  finishHostSystemDefaultSessionMigrationPass(keepLaunchTracking = false): void {
+    if (keepLaunchTracking) {
+      this.pendingHostSystemDefaultSessionMigrationNeedsFullScan = false
+      return
+    }
     this.hostSystemDefaultSessionMigrationPending = false
     this.pendingHostSystemDefaultSessionMigrationNeedsFullScan = false
     this.pendingHostSystemDefaultSessionMigrationTarget = null
@@ -531,7 +543,8 @@ export class CodexRuntimeHomeService {
   }
 
   private invalidateBackfillAfterManagedSystemDefaultLaunch(
-    launchEnv?: NodeJS.ProcessEnv
+    launchEnv?: NodeJS.ProcessEnv,
+    startedAt = new Date()
   ): boolean | null {
     const settings = this.store.getSettings()
     if (
@@ -555,7 +568,7 @@ export class CodexRuntimeHomeService {
     const needsFullScan = markCodexSessionBackfillPending(
       paths.markerPath,
       paths.systemSessionsRoot,
-      getCodexSessionBackfillDate()
+      getCodexSessionBackfillDate(startedAt)
     )
     this.pendingHostSystemDefaultSessionMigrationNeedsFullScan ||= needsFullScan
     return this.pendingHostSystemDefaultSessionMigrationNeedsFullScan

--- a/src/main/codex/codex-session-backfill-audit-pass.ts
+++ b/src/main/codex/codex-session-backfill-audit-pass.ts
@@ -5,6 +5,7 @@ import {
   createCodexSessionBackfillAuditWriter,
   createCodexSessionBackfillDiagnosticEventId,
   createCodexSessionBackfillFileEventId,
+  createCodexSessionBackfillFileInstanceId,
   readCodexSessionBackfillAuditCoverage,
   recordExistingCodexSessionForHeal,
   type CodexSessionBackfillAuditWriter
@@ -58,12 +59,22 @@ export async function createCodexSessionBackfillAuditPass(
       const fileEventId = targetStat
         ? createCodexSessionBackfillFileEventId(target, targetStat)
         : undefined
+      const fileInstanceId = targetStat
+        ? createCodexSessionBackfillFileInstanceId(target, targetStat)
+        : undefined
       if (fileEventId && coverage.fileEventIds.has(fileEventId)) {
         summary.skippedExistingFiles += 1
         return
       }
       if (
-        await recordExistingCodexSessionForHeal(appendRecord, summary, source, target, fileEventId)
+        await recordExistingCodexSessionForHeal(
+          appendRecord,
+          summary,
+          source,
+          target,
+          fileEventId,
+          fileInstanceId
+        )
       ) {
         if (fileEventId) {
           coverage.fileEventIds.add(fileEventId)
@@ -75,12 +86,16 @@ export async function createCodexSessionBackfillAuditPass(
       const fileEventId = targetStat
         ? createCodexSessionBackfillFileEventId(target, targetStat)
         : undefined
+      const fileInstanceId = targetStat
+        ? createCodexSessionBackfillFileInstanceId(target, targetStat)
+        : undefined
       if (
         await appendCodexSessionHealAuditRecord(appendRecord, summary, {
           action,
           source,
           target,
-          ...(fileEventId ? { fileEventId } : {})
+          ...(fileEventId ? { fileEventId } : {}),
+          ...(fileInstanceId ? { fileInstanceId } : {})
         })
       ) {
         if (fileEventId) {

--- a/src/main/codex/codex-session-backfill-audit.ts
+++ b/src/main/codex/codex-session-backfill-audit.ts
@@ -121,6 +121,14 @@ export function createCodexSessionBackfillFileEventId(targetPath: string, stat: 
     .digest('hex')
 }
 
+export function createCodexSessionBackfillFileInstanceId(targetPath: string, stat: Stats): string {
+  return createHash('sha256')
+    .update(normalizeRuntimePathForComparison(targetPath))
+    .update('\0')
+    .update([stat.dev, stat.ino, stat.birthtimeMs].join('\0'))
+    .digest('hex')
+}
+
 export function createCodexSessionBackfillDiagnosticEventId(args: {
   action: 'copy-unsupported' | 'failed'
   source: string
@@ -180,7 +188,8 @@ export async function recordExistingCodexSessionForHeal(
   summary: CodexSessionBackfillSummary,
   source: string,
   target: string,
-  fileEventId?: string
+  fileEventId?: string,
+  fileInstanceId?: string
 ): Promise<boolean> {
   summary.skippedExistingFiles += 1
   // Why: this also recovers a rollout installed before a crash or audit
@@ -189,7 +198,8 @@ export async function recordExistingCodexSessionForHeal(
     action: 'existing',
     source,
     target,
-    ...(fileEventId ? { fileEventId } : {})
+    ...(fileEventId ? { fileEventId } : {}),
+    ...(fileInstanceId ? { fileInstanceId } : {})
   })
 }
 

--- a/src/main/codex/codex-session-backfill-marker.test.ts
+++ b/src/main/codex/codex-session-backfill-marker.test.ts
@@ -14,7 +14,10 @@ vi.mock('node:os', async () => {
 })
 
 import { startCodexSessionBackfillInBackground } from './codex-session-backfill'
-import { markCodexSessionBackfillPending } from './codex-session-backfill-marker'
+import {
+  markCodexSessionBackfillPending,
+  readCodexSessionBackfillMarkerStatus
+} from './codex-session-backfill-marker'
 
 let fakeHomeDir: string
 let userDataDir: string
@@ -107,6 +110,104 @@ describe('Codex session backfill marker', () => {
       baseline: { summary: { scannedFiles: 1 } },
       pendingSince: '2026-08-05'
     })
+  })
+
+  it('keeps a zero-file v3 marker incomplete during migration', () => {
+    mkdirSync(dirname(getMarkerPath()), { recursive: true })
+    writeFileSync(
+      getMarkerPath(),
+      `${JSON.stringify({
+        version: 3,
+        systemSessionsRoot: getSystemSessionsRoot(),
+        completedAt: 1,
+        summary: { scannedFiles: 0 }
+      })}\n`,
+      'utf-8'
+    )
+
+    expect(
+      markCodexSessionBackfillPending(getMarkerPath(), getSystemSessionsRoot(), [
+        '2026',
+        '08',
+        '05'
+      ])
+    ).toBe(true)
+    expect(JSON.parse(readFileSync(getMarkerPath(), 'utf-8'))).toMatchObject({
+      version: 4,
+      pendingSince: '2026-08-05'
+    })
+    expect(JSON.parse(readFileSync(getMarkerPath(), 'utf-8'))).not.toHaveProperty('baseline')
+  })
+
+  it.each(['0000-00-00', '2026-02-29', '9999-12-31'])(
+    'rejects an unsafe pending date and requires a full scan: %s',
+    (pendingSince) => {
+      mkdirSync(dirname(getMarkerPath()), { recursive: true })
+      writeFileSync(
+        getMarkerPath(),
+        `${JSON.stringify({
+          version: 4,
+          systemSessionsRoot: getSystemSessionsRoot(),
+          baseline: { completedAt: 1, summary: { scannedFiles: 1 } },
+          pendingSince
+        })}\n`,
+        'utf-8'
+      )
+
+      expect(
+        readCodexSessionBackfillMarkerStatus(getMarkerPath(), getSystemSessionsRoot())
+      ).toEqual({ hasBaseline: false, pendingSince: undefined })
+    }
+  )
+
+  it('rejects a pending date outside the bounded recovery window', () => {
+    mkdirSync(dirname(getMarkerPath()), { recursive: true })
+    writeFileSync(
+      getMarkerPath(),
+      `${JSON.stringify({
+        version: 4,
+        systemSessionsRoot: getSystemSessionsRoot(),
+        baseline: { completedAt: 1, summary: { scannedFiles: 1 } },
+        pendingSince: '2020-01-01'
+      })}\n`,
+      'utf-8'
+    )
+
+    expect(readCodexSessionBackfillMarkerStatus(getMarkerPath(), getSystemSessionsRoot())).toEqual({
+      hasBaseline: false,
+      pendingSince: undefined
+    })
+  })
+
+  it('uses a zero-file baseline and discovers later rollouts through a launch date scan', async () => {
+    const empty = await startCodexSessionBackfillInBackground()
+    expect(empty).toMatchObject({ scannedFiles: 0, linkedFiles: 0 })
+    expect(JSON.parse(readFileSync(getMarkerPath(), 'utf-8'))).toMatchObject({
+      baseline: { summary: { scannedFiles: 0 } }
+    })
+    expect(await startCodexSessionBackfillInBackground()).toBeNull()
+
+    writeManagedSession(join('2026', '07', '28', 'rollout-later.jsonl'))
+    expect(
+      markCodexSessionBackfillPending(getMarkerPath(), getSystemSessionsRoot(), [
+        '2026',
+        '07',
+        '28'
+      ])
+    ).toBe(false)
+    const healed = await startCodexSessionBackfillInBackground({
+      ignoreCompletionMarker: true,
+      scanDates: [['2026', '07', '28']],
+      writeBoundedCompletionMarker: true
+    })
+
+    expect(healed).toMatchObject({ scannedFiles: 1, linkedFiles: 1 })
+    expect(
+      readFileSync(
+        join(getSystemSessionsRoot(), '2026', '07', '28', 'rollout-later.jsonl'),
+        'utf-8'
+      )
+    ).toBe('{"id":"a"}\n')
   })
 
   it('clears pendingSince after a successful bounded confirmation', async () => {

--- a/src/main/codex/codex-session-backfill-marker.test.ts
+++ b/src/main/codex/codex-session-backfill-marker.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import type * as NodeOs from 'node:os'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+const { homedirMock } = vi.hoisted(() => ({
+  homedirMock: vi.fn<() => string>()
+}))
+
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof NodeOs>('node:os')
+  return { ...actual, homedir: homedirMock }
+})
+
+import { startCodexSessionBackfillInBackground } from './codex-session-backfill'
+import { markCodexSessionBackfillPending } from './codex-session-backfill-marker'
+
+let fakeHomeDir: string
+let userDataDir: string
+let previousUserDataPath: string | undefined
+
+function getSystemSessionsRoot(): string {
+  return join(fakeHomeDir, '.codex', 'sessions')
+}
+
+function getManagedSessionsRoot(): string {
+  return join(userDataDir, 'codex-runtime-home', 'home', 'sessions')
+}
+
+function getMarkerPath(): string {
+  return join(userDataDir, 'codex-session-backfill', 'backfill-complete.json')
+}
+
+function writeManagedSession(relativePath: string): void {
+  const filePath = join(getManagedSessionsRoot(), relativePath)
+  mkdirSync(dirname(filePath), { recursive: true })
+  writeFileSync(filePath, '{"id":"a"}\n', 'utf-8')
+}
+
+beforeEach(() => {
+  fakeHomeDir = mkdtempSync(join(tmpdir(), 'orca-codex-marker-home-'))
+  userDataDir = mkdtempSync(join(tmpdir(), 'orca-codex-marker-user-data-'))
+  previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+  process.env.ORCA_USER_DATA_PATH = userDataDir
+  homedirMock.mockReturnValue(fakeHomeDir)
+})
+
+afterEach(() => {
+  rmSync(fakeHomeDir, { recursive: true, force: true })
+  rmSync(userDataDir, { recursive: true, force: true })
+  if (previousUserDataPath === undefined) {
+    delete process.env.ORCA_USER_DATA_PATH
+  } else {
+    process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+  }
+  vi.clearAllMocks()
+})
+
+describe('Codex session backfill marker', () => {
+  it('keeps a new launch generation from letting an older scan confirm completion', async () => {
+    writeManagedSession(join('2026', '08', '05', 'rollout-a.jsonl'))
+    let launchRecorded = false
+
+    const raced = await startCodexSessionBackfillInBackground({
+      shouldStop: () => {
+        if (!launchRecorded) {
+          launchRecorded = true
+          markCodexSessionBackfillPending(getMarkerPath(), getSystemSessionsRoot(), [
+            '2026',
+            '08',
+            '05'
+          ])
+        }
+        return false
+      }
+    })
+
+    expect(raced).toMatchObject({ linkedFiles: 1 })
+    const marker = JSON.parse(readFileSync(getMarkerPath(), 'utf-8')) as Record<string, unknown>
+    expect(marker).toMatchObject({ version: 4, pendingSince: '2026-08-05' })
+    expect(marker).not.toHaveProperty('baseline')
+  })
+
+  it('migrates a v3 baseline and records a launch without deleting it', () => {
+    mkdirSync(dirname(getMarkerPath()), { recursive: true })
+    writeFileSync(
+      getMarkerPath(),
+      `${JSON.stringify({
+        version: 3,
+        systemSessionsRoot: getSystemSessionsRoot(),
+        completedAt: 1,
+        summary: { scannedFiles: 1 }
+      })}\n`,
+      'utf-8'
+    )
+
+    expect(
+      markCodexSessionBackfillPending(getMarkerPath(), getSystemSessionsRoot(), [
+        '2026',
+        '08',
+        '05'
+      ])
+    ).toBe(false)
+    expect(JSON.parse(readFileSync(getMarkerPath(), 'utf-8'))).toMatchObject({
+      version: 4,
+      baseline: { summary: { scannedFiles: 1 } },
+      pendingSince: '2026-08-05'
+    })
+  })
+
+  it('clears pendingSince after a successful bounded confirmation', async () => {
+    writeManagedSession(join('2026', '08', '05', 'rollout-a.jsonl'))
+    await startCodexSessionBackfillInBackground()
+    markCodexSessionBackfillPending(getMarkerPath(), getSystemSessionsRoot(), ['2026', '08', '05'])
+
+    await startCodexSessionBackfillInBackground({
+      ignoreCompletionMarker: true,
+      scanDates: [['2026', '08', '05']],
+      writeBoundedCompletionMarker: true
+    })
+
+    const marker = JSON.parse(readFileSync(getMarkerPath(), 'utf-8')) as Record<string, unknown>
+    expect(marker).toMatchObject({ version: 4, baseline: { summary: { scannedFiles: 1 } } })
+    expect(marker).not.toHaveProperty('pendingSince')
+  })
+})

--- a/src/main/codex/codex-session-backfill-marker.ts
+++ b/src/main/codex/codex-session-backfill-marker.ts
@@ -7,6 +7,8 @@ import type {
 } from './codex-session-backfill-types'
 
 const CODEX_SESSION_BACKFILL_MARKER_VERSION = 4
+const MAX_PENDING_RECOVERY_DAYS = 366
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1_000
 let markerInvalidationGeneration = 0
 
 type CodexSessionBackfillMarker = {
@@ -34,7 +36,7 @@ export function readCodexSessionBackfillMarkerStatus(
 ): CodexSessionBackfillMarkerStatus {
   const marker = readCompatibleMarker(markerPath, systemSessionsRoot)
   return {
-    hasBaseline: marker?.baseline !== undefined && marker.baseline.summary.scannedFiles !== 0,
+    hasBaseline: marker?.baseline !== undefined,
     pendingSince: parseBackfillDate(marker?.pendingSince)
   }
 }
@@ -60,7 +62,7 @@ export function markCodexSessionBackfillPending(
   marker.pendingSince =
     marker.pendingSince && marker.pendingSince < pendingSince ? marker.pendingSince : pendingSince
   writeMarker(markerPath, marker)
-  return marker.baseline === undefined || marker.baseline.summary.scannedFiles === 0
+  return marker.baseline === undefined
 }
 
 export function writeCodexSessionBackfillMarker(
@@ -150,7 +152,7 @@ function readCompatibleMarker(
 function parseVersionFourMarker(
   marker: Record<string, unknown>,
   systemSessionsRoot: string
-): CodexSessionBackfillMarker {
+): CodexSessionBackfillMarker | null {
   const parsed: CodexSessionBackfillMarker = {
     version: CODEX_SESSION_BACKFILL_MARKER_VERSION,
     systemSessionsRoot
@@ -163,8 +165,12 @@ function parseVersionFourMarker(
       parsed.baseline = { completedAt, summary }
     }
   }
-  if (parseBackfillDate(marker.pendingSince)) {
-    parsed.pendingSince = marker.pendingSince as string
+  if (marker.pendingSince !== undefined) {
+    const pendingSince = parseBackfillDate(marker.pendingSince)
+    if (!pendingSince) {
+      return null
+    }
+    parsed.pendingSince = formatBackfillDate(pendingSince)
   }
   return parsed
 }
@@ -182,7 +188,29 @@ function parseBackfillDate(value: unknown): CodexSessionBackfillDate | undefined
     return undefined
   }
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
-  return match ? [match[1], match[2], match[3]] : undefined
+  if (!match) {
+    return undefined
+  }
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  const candidate = new Date(0)
+  candidate.setUTCFullYear(year, month - 1, day)
+  candidate.setUTCHours(0, 0, 0, 0)
+  if (
+    candidate.getUTCFullYear() !== year ||
+    candidate.getUTCMonth() !== month - 1 ||
+    candidate.getUTCDate() !== day
+  ) {
+    return undefined
+  }
+  const now = new Date()
+  const today = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  const age = today - candidate.getTime()
+  if (age < 0 || age > MAX_PENDING_RECOVERY_DAYS * MILLISECONDS_PER_DAY) {
+    return undefined
+  }
+  return [match[1], match[2], match[3]]
 }
 
 function formatBackfillDate(date: CodexSessionBackfillDate): string {

--- a/src/main/codex/codex-session-backfill-marker.ts
+++ b/src/main/codex/codex-session-backfill-marker.ts
@@ -1,78 +1,101 @@
 import { mkdirSync, readFileSync, rmSync } from 'node:fs'
 import { dirname } from 'node:path'
 import { writeFileAtomically } from '../codex-accounts/fs-utils'
-import type { CodexSessionBackfillSummary } from './codex-session-backfill-types'
+import type {
+  CodexSessionBackfillDate,
+  CodexSessionBackfillSummary
+} from './codex-session-backfill-types'
 
-// Why: bump to re-run the backfill for every host after a layout or semantics
-// change; the run itself stays skip-existing so re-runs never overwrite.
-const CODEX_SESSION_BACKFILL_MARKER_VERSION = 3
+const CODEX_SESSION_BACKFILL_MARKER_VERSION = 4
 let markerInvalidationGeneration = 0
+
+type CodexSessionBackfillMarker = {
+  version: 4
+  systemSessionsRoot: string
+  baseline?: {
+    completedAt: number
+    summary: CodexSessionBackfillSummary
+  }
+  pendingSince?: string
+}
+
+export type CodexSessionBackfillMarkerStatus = {
+  hasBaseline: boolean
+  pendingSince?: CodexSessionBackfillDate
+}
 
 export function captureCodexSessionBackfillMarkerGeneration(): number {
   return markerInvalidationGeneration
+}
+
+export function readCodexSessionBackfillMarkerStatus(
+  markerPath: string,
+  systemSessionsRoot: string
+): CodexSessionBackfillMarkerStatus {
+  const marker = readCompatibleMarker(markerPath, systemSessionsRoot)
+  return {
+    hasBaseline: marker?.baseline !== undefined && marker.baseline.summary.scannedFiles !== 0,
+    pendingSince: parseBackfillDate(marker?.pendingSince)
+  }
 }
 
 export function hasCompletedCodexSessionBackfillMarker(
   markerPath: string,
   systemSessionsRoot: string
 ): boolean {
-  try {
-    const parsed: unknown = JSON.parse(readFileSync(markerPath, 'utf-8'))
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      return false
-    }
-    const marker = parsed as {
-      version?: unknown
-      systemSessionsRoot?: unknown
-      summary?: { scannedFiles?: unknown }
-    }
-    // Why: changing the configured real Codex home must backfill the new
-    // target instead of honoring a marker written for a different history.
-    const markerMatchesTarget =
-      marker.version === CODEX_SESSION_BACKFILL_MARKER_VERSION &&
-      marker.systemSessionsRoot === systemSessionsRoot
-    if (!markerMatchesTarget) {
-      return false
-    }
-    // Why: an empty source can become populated after an early migration run;
-    // let the incremental async walk verify it without blocking the main thread.
-    return marker.summary?.scannedFiles !== 0
-  } catch {
-    return false
+  return readCodexSessionBackfillMarkerStatus(markerPath, systemSessionsRoot).hasBaseline
+}
+
+export function markCodexSessionBackfillPending(
+  markerPath: string,
+  systemSessionsRoot: string,
+  pendingDate: CodexSessionBackfillDate
+): boolean {
+  markerInvalidationGeneration += 1
+  const marker = readCompatibleMarker(markerPath, systemSessionsRoot) ?? {
+    version: CODEX_SESSION_BACKFILL_MARKER_VERSION,
+    systemSessionsRoot
   }
+  const pendingSince = formatBackfillDate(pendingDate)
+  marker.pendingSince =
+    marker.pendingSince && marker.pendingSince < pendingSince ? marker.pendingSince : pendingSince
+  writeMarker(markerPath, marker)
+  return marker.baseline === undefined || marker.baseline.summary.scannedFiles === 0
 }
 
 export function writeCodexSessionBackfillMarker(
   markerPath: string,
   systemSessionsRoot: string,
   summary: CodexSessionBackfillSummary,
-  expectedGeneration: number
+  expectedGeneration: number,
+  options: { bounded: boolean; preservePending: boolean }
 ): void {
-  // Why: a launch can invalidate this pass before its delayed replacement begins.
   if (expectedGeneration !== markerInvalidationGeneration) {
     return
   }
-  mkdirSync(dirname(markerPath), { recursive: true })
-  writeFileAtomically(
-    markerPath,
-    `${JSON.stringify(
-      {
-        version: CODEX_SESSION_BACKFILL_MARKER_VERSION,
-        systemSessionsRoot,
-        completedAt: Date.now(),
-        summary
-      },
-      null,
-      2
-    )}\n`
-  )
+  const current = readCompatibleMarker(markerPath, systemSessionsRoot)
+  if (options.bounded && !current?.baseline) {
+    return
+  }
+  const marker: CodexSessionBackfillMarker = {
+    version: CODEX_SESSION_BACKFILL_MARKER_VERSION,
+    systemSessionsRoot,
+    baseline: options.bounded
+      ? current!.baseline
+      : {
+          completedAt: Date.now(),
+          summary
+        }
+  }
+  if (options.preservePending && current?.pendingSince) {
+    marker.pendingSince = current.pendingSince
+  }
+  writeMarker(markerPath, marker)
 }
 
 export function invalidateCodexSessionBackfillMarker(markerPath: string): void {
   markerInvalidationGeneration += 1
   try {
-    // Why: a managed-lane system-default launch can create new source
-    // rollouts, so a prior one-time marker must not suppress the next opt-in.
     rmSync(markerPath, { force: true })
   } catch (error) {
     console.warn('[codex-session-backfill] Failed to invalidate completion marker:', error)
@@ -88,4 +111,89 @@ export function invalidateCodexSessionBackfillMarker(markerPath: string): void {
       )
     }
   }
+}
+
+function readCompatibleMarker(
+  markerPath: string,
+  systemSessionsRoot: string
+): CodexSessionBackfillMarker | null {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(markerPath, 'utf-8'))
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null
+    }
+    const marker = parsed as Record<string, unknown>
+    if (marker.systemSessionsRoot !== systemSessionsRoot) {
+      return null
+    }
+    if (marker.version === CODEX_SESSION_BACKFILL_MARKER_VERSION) {
+      return parseVersionFourMarker(marker, systemSessionsRoot)
+    }
+    if (marker.version === 3) {
+      const summary = parseSummary(marker.summary)
+      const migrated: CodexSessionBackfillMarker = {
+        version: CODEX_SESSION_BACKFILL_MARKER_VERSION,
+        systemSessionsRoot,
+        ...(summary && summary.scannedFiles !== 0
+          ? { baseline: { completedAt: readNumber(marker.completedAt) ?? Date.now(), summary } }
+          : {})
+      }
+      writeMarker(markerPath, migrated)
+      return migrated
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+function parseVersionFourMarker(
+  marker: Record<string, unknown>,
+  systemSessionsRoot: string
+): CodexSessionBackfillMarker {
+  const parsed: CodexSessionBackfillMarker = {
+    version: CODEX_SESSION_BACKFILL_MARKER_VERSION,
+    systemSessionsRoot
+  }
+  if (marker.baseline && typeof marker.baseline === 'object' && !Array.isArray(marker.baseline)) {
+    const baseline = marker.baseline as Record<string, unknown>
+    const summary = parseSummary(baseline.summary)
+    const completedAt = readNumber(baseline.completedAt)
+    if (summary && completedAt !== null) {
+      parsed.baseline = { completedAt, summary }
+    }
+  }
+  if (parseBackfillDate(marker.pendingSince)) {
+    parsed.pendingSince = marker.pendingSince as string
+  }
+  return parsed
+}
+
+function parseSummary(value: unknown): CodexSessionBackfillSummary | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+  const summary = value as Partial<CodexSessionBackfillSummary>
+  return typeof summary.scannedFiles === 'number' ? (summary as CodexSessionBackfillSummary) : null
+}
+
+function parseBackfillDate(value: unknown): CodexSessionBackfillDate | undefined {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+  return match ? [match[1], match[2], match[3]] : undefined
+}
+
+function formatBackfillDate(date: CodexSessionBackfillDate): string {
+  return date.join('-')
+}
+
+function readNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function writeMarker(markerPath: string, marker: CodexSessionBackfillMarker): void {
+  mkdirSync(dirname(markerPath), { recursive: true })
+  writeFileAtomically(markerPath, `${JSON.stringify(marker, null, 2)}\n`)
 }

--- a/src/main/codex/codex-session-backfill-types.ts
+++ b/src/main/codex/codex-session-backfill-types.ts
@@ -34,6 +34,8 @@ export type CodexSessionBackfillOptions = CodexSessionBridgeIncrementalOptions &
   writeBoundedCompletionMarker?: boolean
   /** Rechecks launch scheduling state immediately before marker publication. */
   canWriteCompletionMarker?: () => boolean
+  /** A full scan can establish a baseline while an active launch remains pending. */
+  preservePendingMarker?: boolean
 }
 
 export type CodexSessionBackfillDate = readonly [year: string, month: string, day: string]

--- a/src/main/codex/codex-session-backfill.test.ts
+++ b/src/main/codex/codex-session-backfill.test.ts
@@ -780,22 +780,6 @@ describe('startCodexSessionBackfillInBackground', () => {
     )
   })
 
-  it('self-heals a zero-file marker when managed rollouts appear later', async () => {
-    const empty = await startCodexSessionBackfillInBackground()
-    expect(empty).toMatchObject({ scannedFiles: 0, linkedFiles: 0 })
-    expect(JSON.parse(readFileSync(getMarkerPath(), 'utf-8'))).toMatchObject({
-      baseline: { summary: { scannedFiles: 0 } }
-    })
-
-    writeManagedSession(join('2026', '07', '28', 'rollout-later.jsonl'), '{"id":"later"}\n')
-    const healed = await startCodexSessionBackfillInBackground()
-
-    expect(healed).toMatchObject({ scannedFiles: 1, linkedFiles: 1 })
-    expect(
-      existsSync(join(getSystemSessionsRoot(), '2026', '07', '28', 'rollout-later.jsonl'))
-    ).toBe(true)
-  })
-
   it('recovers an installed rollout after the completion marker write fails', async () => {
     writeManagedSession(join('2026', '05', '26', 'rollout-a.jsonl'), '{"id":"a"}\n')
     mkdirSync(getMarkerPath(), { recursive: true })

--- a/src/main/codex/codex-session-backfill.test.ts
+++ b/src/main/codex/codex-session-backfill.test.ts
@@ -617,7 +617,7 @@ describe('startCodexSessionBackfillInBackground', () => {
     expect(JSON.parse(readFileSync(getMarkerPath(), 'utf-8'))).toMatchObject({ version: 0 })
     const recovered = await startCodexSessionBackfillInBackground()
     expect(recovered).toMatchObject({ skippedExistingFiles: 1 })
-    expect(JSON.parse(readFileSync(getMarkerPath(), 'utf-8'))).toMatchObject({ version: 3 })
+    expect(JSON.parse(readFileSync(getMarkerPath(), 'utf-8'))).toMatchObject({ version: 4 })
   })
 
   it('fails launch preparation when a stale marker cannot be invalidated', async () => {
@@ -629,7 +629,7 @@ describe('startCodexSessionBackfillInBackground', () => {
     expect(() => invalidateCodexSessionBackfillMarker(getMarkerPath())).toThrow(
       'Failed to invalidate Codex session backfill marker'
     )
-    expect(JSON.parse(readFileSync(getMarkerPath(), 'utf-8'))).toMatchObject({ version: 3 })
+    expect(JSON.parse(readFileSync(getMarkerPath(), 'utf-8'))).toMatchObject({ version: 4 })
   })
 
   it('writes a completion marker and skips the walk on later runs', async () => {
@@ -638,7 +638,7 @@ describe('startCodexSessionBackfillInBackground', () => {
     const first = await startCodexSessionBackfillInBackground()
     expect(first).toMatchObject({ linkedFiles: 1, failedFiles: 0 })
     expect(existsSync(getMarkerPath())).toBe(true)
-    expect(JSON.parse(readFileSync(getMarkerPath(), 'utf-8'))).toMatchObject({ version: 3 })
+    expect(JSON.parse(readFileSync(getMarkerPath(), 'utf-8'))).toMatchObject({ version: 4 })
 
     // An ordinary call remains a no-op; only a launch-scheduled pass bypasses the marker.
     writeManagedSession(join('2026', '07', '01', 'rollout-later.jsonl'), '{"id":"later"}\n')
@@ -677,7 +677,7 @@ describe('startCodexSessionBackfillInBackground', () => {
     expect(existsSync(getMarkerPath())).toBe(true)
   })
 
-  it('lets an explicit bounded final pass restore a certified baseline', async () => {
+  it('keeps a bounded final pass from recreating an invalidated baseline', async () => {
     writeManagedSession(join('2026', '05', '26', 'rollout-baseline.jsonl'), 'baseline\n')
     await startCodexSessionBackfillInBackground()
 
@@ -691,7 +691,7 @@ describe('startCodexSessionBackfillInBackground', () => {
     })
 
     expect(bounded).toMatchObject({ scannedFiles: 1, linkedFiles: 1 })
-    expect(existsSync(getMarkerPath())).toBe(true)
+    expect(existsSync(getMarkerPath())).toBe(false)
   })
 
   it('records a new heal event when a linked rollout grows in place', async () => {
@@ -784,7 +784,7 @@ describe('startCodexSessionBackfillInBackground', () => {
     const empty = await startCodexSessionBackfillInBackground()
     expect(empty).toMatchObject({ scannedFiles: 0, linkedFiles: 0 })
     expect(JSON.parse(readFileSync(getMarkerPath(), 'utf-8'))).toMatchObject({
-      summary: { scannedFiles: 0 }
+      baseline: { summary: { scannedFiles: 0 } }
     })
 
     writeManagedSession(join('2026', '07', '28', 'rollout-later.jsonl'), '{"id":"later"}\n')
@@ -810,7 +810,7 @@ describe('startCodexSessionBackfillInBackground', () => {
     rmSync(getMarkerPath(), { recursive: true })
     const resumed = await startCodexSessionBackfillInBackground()
     expect(resumed).toMatchObject({ skippedExistingFiles: 1, failedHealAuditRecords: 0 })
-    expect(JSON.parse(readFileSync(getMarkerPath(), 'utf-8'))).toMatchObject({ version: 3 })
+    expect(JSON.parse(readFileSync(getMarkerPath(), 'utf-8'))).toMatchObject({ version: 4 })
     expect(warnSpy).toHaveBeenCalled()
     warnSpy.mockRestore()
   })

--- a/src/main/codex/codex-session-backfill.ts
+++ b/src/main/codex/codex-session-backfill.ts
@@ -107,7 +107,10 @@ async function runCodexSessionBackfillOncePerHost(
     summary.failedDirectories === 0 &&
     summary.failedHealAuditRecords === 0
   ) {
-    writeBackfillMarker(paths.markerPath, paths.systemSessionsRoot, summary, markerGeneration)
+    writeBackfillMarker(paths.markerPath, paths.systemSessionsRoot, summary, markerGeneration, {
+      bounded: options.scanDates !== undefined,
+      preservePending: options.preservePendingMarker === true
+    })
   }
   return summary
 }

--- a/src/main/codex/codex-session-index-heal-processed-state.ts
+++ b/src/main/codex/codex-session-index-heal-processed-state.ts
@@ -1,0 +1,112 @@
+import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
+
+export const CODEX_SESSION_INDEX_HEAL_VERSION = 4
+
+export type ProcessedHealThreads = {
+  healedAuditRecords: Set<string>
+  legacyHealedThreadIds: Set<string>
+  missingAuditRecords: Set<string>
+  legacyMissingThreadIds: Set<string>
+  healedIdentities: Set<string>
+  missingIdentities: Set<string>
+  healedFileInstanceIds: Set<string>
+  missingFileInstanceIds: Set<string>
+  missingFileEventIds: Set<string>
+}
+
+export function collectProcessedHealThreads(args: {
+  ledgerLines: readonly Record<string, unknown>[]
+  auditEventByRecordId: ReadonlyMap<
+    string,
+    { targetPath: string; fileInstanceId?: string; fileEventId?: string }
+  >
+  systemSessionsRoot: string
+}): ProcessedHealThreads {
+  const processed: ProcessedHealThreads = {
+    healedAuditRecords: new Set<string>(),
+    legacyHealedThreadIds: new Set<string>(),
+    missingAuditRecords: new Set<string>(),
+    legacyMissingThreadIds: new Set<string>(),
+    healedIdentities: new Set<string>(),
+    missingIdentities: new Set<string>(),
+    healedFileInstanceIds: new Set<string>(),
+    missingFileInstanceIds: new Set<string>(),
+    missingFileEventIds: new Set<string>()
+  }
+  const expectedRoot = normalizeRuntimePathForComparison(args.systemSessionsRoot)
+  for (const line of args.ledgerLines) {
+    if (!isProcessedLedgerLine(line, expectedRoot)) {
+      continue
+    }
+    const threadId = line.threadId.toLowerCase()
+    const legacyEvent =
+      typeof line.auditRecordId === 'string'
+        ? args.auditEventByRecordId.get(line.auditRecordId)
+        : undefined
+    const targetPath =
+      typeof line.targetPath === 'string'
+        ? normalizeRuntimePathForComparison(line.targetPath)
+        : legacyEvent
+          ? normalizeRuntimePathForComparison(legacyEvent.targetPath)
+          : null
+    const identity = targetPath ? `${expectedRoot}\0${threadId}\0${targetPath}` : null
+    const fileInstanceId =
+      typeof line.fileInstanceId === 'string'
+        ? line.fileInstanceId
+        : (legacyEvent?.fileInstanceId ?? null)
+    const fileEventId =
+      typeof line.fileEventId === 'string' ? line.fileEventId : (legacyEvent?.fileEventId ?? null)
+    collectProcessedOutcome(processed, line, threadId, identity, fileInstanceId, fileEventId)
+  }
+  return processed
+}
+
+function isProcessedLedgerLine(
+  line: Record<string, unknown>,
+  expectedRoot: string
+): line is Record<string, unknown> & {
+  threadId: string
+  systemSessionsRoot: string
+  outcome: 'healed' | 'missing'
+} {
+  return (
+    (line.v === CODEX_SESSION_INDEX_HEAL_VERSION || line.v === 3) &&
+    typeof line.threadId === 'string' &&
+    typeof line.systemSessionsRoot === 'string' &&
+    (line.outcome === 'healed' || line.outcome === 'missing') &&
+    normalizeRuntimePathForComparison(line.systemSessionsRoot) === expectedRoot
+  )
+}
+
+function collectProcessedOutcome(
+  processed: ProcessedHealThreads,
+  line: Record<string, unknown> & { outcome: 'healed' | 'missing' },
+  threadId: string,
+  identity: string | null,
+  fileInstanceId: string | null,
+  fileEventId: string | null
+): void {
+  const identities =
+    line.outcome === 'healed' ? processed.healedIdentities : processed.missingIdentities
+  const fileInstances =
+    line.outcome === 'healed' ? processed.healedFileInstanceIds : processed.missingFileInstanceIds
+  const auditRecords =
+    line.outcome === 'healed' ? processed.healedAuditRecords : processed.missingAuditRecords
+  const legacyThreads =
+    line.outcome === 'healed' ? processed.legacyHealedThreadIds : processed.legacyMissingThreadIds
+
+  if (identity) {
+    identities.add(identity)
+  }
+  if (fileInstanceId) {
+    fileInstances.add(fileInstanceId)
+  }
+  if (line.outcome === 'missing' && fileEventId) {
+    processed.missingFileEventIds.add(fileEventId)
+  }
+  if (typeof line.auditRecordId === 'string') {
+    auditRecords.add(`${threadId}\0${line.auditRecordId}`)
+  } else if (!identity) {
+    legacyThreads.add(threadId)
+  }
+}

--- a/src/main/codex/codex-session-index-heal-republication.test.ts
+++ b/src/main/codex/codex-session-index-heal-republication.test.ts
@@ -1,0 +1,76 @@
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { collectPendingHealThreads } from './codex-session-index-heal-state'
+
+const threadId = '11111111-1111-1111-1111-111111111111'
+
+function target(root: string): string {
+  return join(root, '2026', '07', '01', `rollout-2026-07-01T10-00-00-${threadId}.jsonl`)
+}
+
+function paths() {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-heal-republication-'))
+  return {
+    auditLogPath: join(dir, 'audit.jsonl'),
+    healLedgerPath: join(dir, 'heal.jsonl'),
+    healMarkerPath: join(dir, 'marker.json'),
+    systemSessionsRoot: join(dir, 'system', 'sessions')
+  }
+}
+
+describe('Codex session index heal republication identity', () => {
+  it.each(['healed', 'missing'] as const)(
+    'keeps a same-path %s outcome when the file instance is unchanged',
+    (outcome) => {
+      const rig = paths()
+      const file = target(rig.systemSessionsRoot)
+      writeFileSync(
+        rig.auditLogPath,
+        `${JSON.stringify({ action: 'existing', target: file, fileInstanceId: 'same-instance', fileEventId: 'same-event' })}\n`
+      )
+      writeFileSync(
+        rig.healLedgerPath,
+        `${JSON.stringify({ v: 4, systemSessionsRoot: rig.systemSessionsRoot, threadId, outcome, targetPath: file, fileInstanceId: 'same-instance', fileEventId: 'same-event' })}\n`
+      )
+
+      expect(collectPendingHealThreads(rig)).toEqual([])
+    }
+  )
+
+  it('retries a missing same-path rollout after its contents grow', () => {
+    const rig = paths()
+    const file = target(rig.systemSessionsRoot)
+    writeFileSync(
+      rig.auditLogPath,
+      `${JSON.stringify({ action: 'existing', target: file, fileInstanceId: 'same-instance', fileEventId: 'new-event' })}\n`
+    )
+    writeFileSync(
+      rig.healLedgerPath,
+      `${JSON.stringify({ v: 4, systemSessionsRoot: rig.systemSessionsRoot, threadId, outcome: 'missing', targetPath: file, fileInstanceId: 'same-instance', fileEventId: 'old-event' })}\n`
+    )
+
+    expect(collectPendingHealThreads(rig)).toMatchObject([{ threadId, fileEventId: 'new-event' }])
+  })
+
+  it.each(['healed', 'missing'] as const)(
+    'requeues a same-path publication after a %s file instance changes',
+    (outcome) => {
+      const rig = paths()
+      const file = target(rig.systemSessionsRoot)
+      writeFileSync(
+        rig.auditLogPath,
+        `${JSON.stringify({ action: 'existing', target: file, recordId: 'new-record', fileInstanceId: 'new-instance', fileEventId: 'new-event' })}\n`
+      )
+      writeFileSync(
+        rig.healLedgerPath,
+        `${JSON.stringify({ v: 4, systemSessionsRoot: rig.systemSessionsRoot, threadId, outcome, targetPath: file, fileInstanceId: 'old-instance', fileEventId: 'old-event' })}\n`
+      )
+
+      expect(collectPendingHealThreads(rig)).toMatchObject([
+        { threadId, targetPath: file, fileInstanceId: 'new-instance' }
+      ])
+    }
+  )
+})

--- a/src/main/codex/codex-session-index-heal-state.ts
+++ b/src/main/codex/codex-session-index-heal-state.ts
@@ -5,6 +5,10 @@ import {
   normalizeRuntimePathForComparison
 } from '../../shared/cross-platform-path'
 import { writeFileAtomically } from '../codex-accounts/fs-utils'
+import {
+  CODEX_SESSION_INDEX_HEAL_VERSION,
+  collectProcessedHealThreads
+} from './codex-session-index-heal-processed-state'
 
 // State files for the session index heal: which backfilled rollouts exist
 // (the backfill audit ledger), which thread ids this pass already processed
@@ -13,7 +17,7 @@ import { writeFileAtomically } from '../codex-accounts/fs-utils'
 
 // Bump to re-drive the heal for every host after a semantics change; already
 // processed thread ids are re-read because ledger lines are version-scoped.
-export const CODEX_SESSION_INDEX_HEAL_VERSION = 4
+export { CODEX_SESSION_INDEX_HEAL_VERSION }
 
 // Why: an unsupported CLI stays unsupported until upgraded; re-probing once a
 // day is enough to notice an upgrade without a per-startup spawn.
@@ -35,6 +39,8 @@ export type HealLedgerOutcome = 'healed' | 'missing' | 'failed'
 export type PendingHealThread = {
   threadId: string
   targetPath: string
+  fileInstanceId: string | null
+  fileEventId: string | null
   /** Timestamp segment of the rollout file name; lexicographic recency order. */
   rolloutStamp: string
   /** Publication event identity; null only for audit records written before event ids. */
@@ -53,13 +59,24 @@ export type HealMarkerSummary = {
  */
 export function collectPendingHealThreads(paths: CodexSessionIndexHealPaths): PendingHealThread[] {
   const auditLines = readJsonlLines(paths.auditLogPath, true)
-  const auditTargetByRecordId = new Map<string, string>()
+  const auditEventByRecordId = new Map<
+    string,
+    { targetPath: string; fileInstanceId?: string; fileEventId?: string }
+  >()
   for (const line of auditLines) {
     if (typeof line.recordId === 'string' && typeof line.target === 'string') {
-      auditTargetByRecordId.set(line.recordId, line.target)
+      auditEventByRecordId.set(line.recordId, {
+        targetPath: line.target,
+        ...(typeof line.fileInstanceId === 'string' ? { fileInstanceId: line.fileInstanceId } : {}),
+        ...(typeof line.fileEventId === 'string' ? { fileEventId: line.fileEventId } : {})
+      })
     }
   }
-  const processed = readProcessedHealThreads(paths, auditTargetByRecordId)
+  const processed = collectProcessedHealThreads({
+    ledgerLines: readJsonlLines(paths.healLedgerPath),
+    auditEventByRecordId,
+    systemSessionsRoot: paths.systemSessionsRoot
+  })
   const pendingByThreadId = new Map<string, PendingHealThread>()
   const expectedRoot = normalizeRuntimePathForComparison(paths.systemSessionsRoot)
   for (const line of auditLines) {
@@ -80,23 +97,35 @@ export function collectPendingHealThreads(paths: CodexSessionIndexHealPaths): Pe
     }
     const threadId = match[2].toLowerCase()
     const auditRecordId = typeof line.recordId === 'string' ? line.recordId : null
+    const fileInstanceId = typeof line.fileInstanceId === 'string' ? line.fileInstanceId : null
+    const fileEventId = typeof line.fileEventId === 'string' ? line.fileEventId : null
     const targetPath = normalizeRuntimePathForComparison(line.target)
     const identity = `${expectedRoot}\0${threadId}\0${targetPath}`
-    if (
-      processed.healedIdentities.has(identity) ||
-      processed.missingIdentities.has(identity) ||
-      (auditRecordId
-        ? processed.healedAuditRecords.has(`${threadId}\0${auditRecordId}`) ||
-          processed.missingAuditRecords.has(`${threadId}\0${auditRecordId}`)
-        : processed.legacyHealedThreadIds.has(threadId) ||
-          processed.legacyMissingThreadIds.has(threadId))
-    ) {
+    const publicationRecordKey =
+      line.action !== 'existing' && auditRecordId ? `${threadId}\0${auditRecordId}` : null
+    const healedAlreadyProcessed = publicationRecordKey
+      ? processed.healedAuditRecords.has(publicationRecordKey)
+      : fileInstanceId
+        ? // Why: thread/read registers this rollout path in SQLite; appended JSONL
+          // content remains authoritative and must not trigger repeated DB heals.
+          processed.healedFileInstanceIds.has(fileInstanceId)
+        : processed.healedIdentities.has(identity) || processed.legacyHealedThreadIds.has(threadId)
+    const missingAlreadyProcessed = publicationRecordKey
+      ? processed.missingAuditRecords.has(publicationRecordKey)
+      : fileEventId
+        ? processed.missingFileEventIds.has(fileEventId)
+        : processed.missingIdentities.has(identity) ||
+          processed.legacyMissingThreadIds.has(threadId)
+    const alreadyProcessed = healedAlreadyProcessed || missingAlreadyProcessed
+    if (alreadyProcessed) {
       pendingByThreadId.delete(threadId)
       continue
     }
     pendingByThreadId.set(threadId, {
       threadId,
       targetPath: line.target,
+      fileInstanceId,
+      fileEventId,
       rolloutStamp: match[1],
       auditRecordId
     })
@@ -110,79 +139,14 @@ function lastPathSegment(filePath: string): string {
   return filePath.split(/[\\/]/).at(-1) ?? ''
 }
 
-function readProcessedHealThreads(
-  paths: CodexSessionIndexHealPaths,
-  auditTargetByRecordId: ReadonlyMap<string, string>
-): {
-  healedAuditRecords: Set<string>
-  legacyHealedThreadIds: Set<string>
-  missingAuditRecords: Set<string>
-  legacyMissingThreadIds: Set<string>
-  healedIdentities: Set<string>
-  missingIdentities: Set<string>
-} {
-  const healedAuditRecords = new Set<string>()
-  const legacyHealedThreadIds = new Set<string>()
-  const missingAuditRecords = new Set<string>()
-  const legacyMissingThreadIds = new Set<string>()
-  const healedIdentities = new Set<string>()
-  const missingIdentities = new Set<string>()
-  const expectedRoot = normalizeRuntimePathForComparison(paths.systemSessionsRoot)
-  for (const line of readJsonlLines(paths.healLedgerPath)) {
-    if (
-      (line.v === CODEX_SESSION_INDEX_HEAL_VERSION || line.v === 3) &&
-      typeof line.threadId === 'string' &&
-      typeof line.systemSessionsRoot === 'string' &&
-      (line.outcome === 'healed' || line.outcome === 'missing') &&
-      normalizeRuntimePathForComparison(line.systemSessionsRoot) === expectedRoot
-    ) {
-      const threadId = line.threadId.toLowerCase()
-      const legacyTarget =
-        typeof line.auditRecordId === 'string'
-          ? auditTargetByRecordId.get(line.auditRecordId)
-          : undefined
-      const targetPath =
-        typeof line.targetPath === 'string'
-          ? normalizeRuntimePathForComparison(line.targetPath)
-          : legacyTarget
-            ? normalizeRuntimePathForComparison(legacyTarget)
-            : null
-      const identity = targetPath ? `${expectedRoot}\0${threadId}\0${targetPath}` : null
-      if (line.outcome === 'healed') {
-        if (identity) {
-          healedIdentities.add(identity)
-        }
-        if (typeof line.auditRecordId === 'string') {
-          healedAuditRecords.add(`${threadId}\0${line.auditRecordId}`)
-        } else {
-          legacyHealedThreadIds.add(threadId)
-        }
-      } else if (typeof line.auditRecordId === 'string') {
-        if (identity) {
-          missingIdentities.add(identity)
-        }
-        missingAuditRecords.add(`${threadId}\0${line.auditRecordId}`)
-      } else {
-        legacyMissingThreadIds.add(threadId)
-      }
-    }
-  }
-  return {
-    healedAuditRecords,
-    legacyHealedThreadIds,
-    missingAuditRecords,
-    legacyMissingThreadIds,
-    healedIdentities,
-    missingIdentities
-  }
-}
-
 export function appendHealLedgerRecord(
   paths: CodexSessionIndexHealPaths,
   threadId: string,
   outcome: HealLedgerOutcome,
   targetPath?: string,
-  auditRecordId?: string | null
+  auditRecordId?: string | null,
+  fileInstanceId?: string | null,
+  fileEventId?: string | null
 ): boolean {
   try {
     mkdirSync(dirname(paths.healLedgerPath), { recursive: true })
@@ -197,6 +161,8 @@ export function appendHealLedgerRecord(
         outcome,
         ...(targetPath ? { targetPath } : {}),
         ...(auditRecordId ? { auditRecordId } : {}),
+        ...(fileInstanceId ? { fileInstanceId } : {}),
+        ...(fileEventId ? { fileEventId } : {}),
         at: new Date().toISOString()
       })}\n`
     )

--- a/src/main/codex/codex-session-index-heal-state.ts
+++ b/src/main/codex/codex-session-index-heal-state.ts
@@ -13,7 +13,7 @@ import { writeFileAtomically } from '../codex-accounts/fs-utils'
 
 // Bump to re-drive the heal for every host after a semantics change; already
 // processed thread ids are re-read because ledger lines are version-scoped.
-export const CODEX_SESSION_INDEX_HEAL_VERSION = 3
+export const CODEX_SESSION_INDEX_HEAL_VERSION = 4
 
 // Why: an unsupported CLI stays unsupported until upgraded; re-probing once a
 // day is enough to notice an upgrade without a per-startup spawn.
@@ -34,6 +34,7 @@ export type HealLedgerOutcome = 'healed' | 'missing' | 'failed'
 
 export type PendingHealThread = {
   threadId: string
+  targetPath: string
   /** Timestamp segment of the rollout file name; lexicographic recency order. */
   rolloutStamp: string
   /** Publication event identity; null only for audit records written before event ids. */
@@ -51,9 +52,17 @@ export type HealMarkerSummary = {
  * copied rollout whose thread id has not been processed yet, most recent first.
  */
 export function collectPendingHealThreads(paths: CodexSessionIndexHealPaths): PendingHealThread[] {
-  const processed = readProcessedHealThreads(paths)
+  const auditLines = readJsonlLines(paths.auditLogPath, true)
+  const auditTargetByRecordId = new Map<string, string>()
+  for (const line of auditLines) {
+    if (typeof line.recordId === 'string' && typeof line.target === 'string') {
+      auditTargetByRecordId.set(line.recordId, line.target)
+    }
+  }
+  const processed = readProcessedHealThreads(paths, auditTargetByRecordId)
   const pendingByThreadId = new Map<string, PendingHealThread>()
-  for (const line of readJsonlLines(paths.auditLogPath, true)) {
+  const expectedRoot = normalizeRuntimePathForComparison(paths.systemSessionsRoot)
+  for (const line of auditLines) {
     if (line.action !== 'hardlink' && line.action !== 'copy' && line.action !== 'existing') {
       continue
     }
@@ -71,19 +80,26 @@ export function collectPendingHealThreads(paths: CodexSessionIndexHealPaths): Pe
     }
     const threadId = match[2].toLowerCase()
     const auditRecordId = typeof line.recordId === 'string' ? line.recordId : null
+    const targetPath = normalizeRuntimePathForComparison(line.target)
+    const identity = `${expectedRoot}\0${threadId}\0${targetPath}`
     if (
-      auditRecordId
+      processed.healedIdentities.has(identity) ||
+      processed.missingIdentities.has(identity) ||
+      (auditRecordId
         ? processed.healedAuditRecords.has(`${threadId}\0${auditRecordId}`) ||
           processed.missingAuditRecords.has(`${threadId}\0${auditRecordId}`)
         : processed.legacyHealedThreadIds.has(threadId) ||
-          processed.legacyMissingThreadIds.has(threadId)
+          processed.legacyMissingThreadIds.has(threadId))
     ) {
-      // Why: only the newest publication event for a thread matters. A later
-      // processed event must displace an older pending event from this scan.
       pendingByThreadId.delete(threadId)
       continue
     }
-    pendingByThreadId.set(threadId, { threadId, rolloutStamp: match[1], auditRecordId })
+    pendingByThreadId.set(threadId, {
+      threadId,
+      targetPath: line.target,
+      rolloutStamp: match[1],
+      auditRecordId
+    })
   }
   return [...pendingByThreadId.values()].sort((left, right) =>
     left.rolloutStamp < right.rolloutStamp ? 1 : left.rolloutStamp > right.rolloutStamp ? -1 : 0
@@ -94,33 +110,57 @@ function lastPathSegment(filePath: string): string {
   return filePath.split(/[\\/]/).at(-1) ?? ''
 }
 
-function readProcessedHealThreads(paths: CodexSessionIndexHealPaths): {
+function readProcessedHealThreads(
+  paths: CodexSessionIndexHealPaths,
+  auditTargetByRecordId: ReadonlyMap<string, string>
+): {
   healedAuditRecords: Set<string>
   legacyHealedThreadIds: Set<string>
   missingAuditRecords: Set<string>
   legacyMissingThreadIds: Set<string>
+  healedIdentities: Set<string>
+  missingIdentities: Set<string>
 } {
   const healedAuditRecords = new Set<string>()
   const legacyHealedThreadIds = new Set<string>()
   const missingAuditRecords = new Set<string>()
   const legacyMissingThreadIds = new Set<string>()
+  const healedIdentities = new Set<string>()
+  const missingIdentities = new Set<string>()
   const expectedRoot = normalizeRuntimePathForComparison(paths.systemSessionsRoot)
   for (const line of readJsonlLines(paths.healLedgerPath)) {
     if (
-      line.v === CODEX_SESSION_INDEX_HEAL_VERSION &&
+      (line.v === CODEX_SESSION_INDEX_HEAL_VERSION || line.v === 3) &&
       typeof line.threadId === 'string' &&
       typeof line.systemSessionsRoot === 'string' &&
       (line.outcome === 'healed' || line.outcome === 'missing') &&
       normalizeRuntimePathForComparison(line.systemSessionsRoot) === expectedRoot
     ) {
       const threadId = line.threadId.toLowerCase()
+      const legacyTarget =
+        typeof line.auditRecordId === 'string'
+          ? auditTargetByRecordId.get(line.auditRecordId)
+          : undefined
+      const targetPath =
+        typeof line.targetPath === 'string'
+          ? normalizeRuntimePathForComparison(line.targetPath)
+          : legacyTarget
+            ? normalizeRuntimePathForComparison(legacyTarget)
+            : null
+      const identity = targetPath ? `${expectedRoot}\0${threadId}\0${targetPath}` : null
       if (line.outcome === 'healed') {
+        if (identity) {
+          healedIdentities.add(identity)
+        }
         if (typeof line.auditRecordId === 'string') {
           healedAuditRecords.add(`${threadId}\0${line.auditRecordId}`)
         } else {
           legacyHealedThreadIds.add(threadId)
         }
       } else if (typeof line.auditRecordId === 'string') {
+        if (identity) {
+          missingIdentities.add(identity)
+        }
         missingAuditRecords.add(`${threadId}\0${line.auditRecordId}`)
       } else {
         legacyMissingThreadIds.add(threadId)
@@ -131,7 +171,9 @@ function readProcessedHealThreads(paths: CodexSessionIndexHealPaths): {
     healedAuditRecords,
     legacyHealedThreadIds,
     missingAuditRecords,
-    legacyMissingThreadIds
+    legacyMissingThreadIds,
+    healedIdentities,
+    missingIdentities
   }
 }
 
@@ -139,6 +181,7 @@ export function appendHealLedgerRecord(
   paths: CodexSessionIndexHealPaths,
   threadId: string,
   outcome: HealLedgerOutcome,
+  targetPath?: string,
   auditRecordId?: string | null
 ): boolean {
   try {
@@ -152,6 +195,7 @@ export function appendHealLedgerRecord(
         systemSessionsRoot: paths.systemSessionsRoot,
         threadId,
         outcome,
+        ...(targetPath ? { targetPath } : {}),
         ...(auditRecordId ? { auditRecordId } : {}),
         at: new Date().toISOString()
       })}\n`

--- a/src/main/codex/codex-session-index-heal.test.ts
+++ b/src/main/codex/codex-session-index-heal.test.ts
@@ -104,7 +104,13 @@ function rolloutTarget(sessionsRoot: string, stamp: string, id: string): string 
 
 function createHealRig(options: {
   scenario?: string
-  auditedThreads?: { stamp: string; id: string; action?: string }[]
+  auditedThreads?: {
+    stamp: string
+    id: string
+    action?: string
+    recordId?: string | null
+    fileInstanceId?: string
+  }[]
   missingThreadIds?: string[]
   failingThreadIds?: string[]
   busyThreadIds?: string[]
@@ -134,7 +140,10 @@ function createHealRig(options: {
         action: audited.action ?? 'hardlink',
         source: '/managed/sessions/x.jsonl',
         target: rolloutTarget(systemSessionsRoot, audited.stamp, audited.id),
-        recordId: `audit-record-${index}`
+        ...(audited.recordId === null
+          ? {}
+          : { recordId: audited.recordId ?? `audit-record-${index}` }),
+        ...(audited.fileInstanceId ? { fileInstanceId: audited.fileInstanceId } : {})
       })}\n`
     )
   }
@@ -255,28 +264,6 @@ describe('runCodexSessionIndexHeal', () => {
     expect(rig.readLog().serverStarts).toBe(1)
   })
 
-  it('does not re-read a healed thread when the same target gets another audit event', async () => {
-    const id = threadId('1')
-    const stamp = '2026-07-01T10-00-00'
-    const rig = createHealRig({ auditedThreads: [{ stamp, id }] })
-    await runCodexSessionIndexHeal(rig.paths, {
-      buildInvocation: rig.buildInvocation,
-      interBatchDelayMs: 0
-    })
-
-    await createCodexSessionBackfillAuditWriter(rig.paths.auditLogPath)({
-      action: 'existing',
-      target: rolloutTarget(rig.paths.systemSessionsRoot, stamp, id)
-    })
-    const repeated = await runCodexSessionIndexHeal(rig.paths, {
-      buildInvocation: rig.buildInvocation,
-      interBatchDelayMs: 0
-    })
-
-    expect(repeated).toMatchObject({ pendingThreads: 0, healedThreads: 0 })
-    expect(rig.readLog().threadIds).toEqual([id])
-  })
-
   it('re-reads a healed thread when its target path changes', async () => {
     const id = threadId('1')
     const rig = createHealRig({
@@ -291,6 +278,34 @@ describe('runCodexSessionIndexHeal', () => {
       action: 'existing',
       target: rolloutTarget(rig.paths.systemSessionsRoot, '2026-07-02T10-00-00', id)
     })
+    const moved = await runCodexSessionIndexHeal(rig.paths, {
+      buildInvocation: rig.buildInvocation,
+      interBatchDelayMs: 0
+    })
+
+    expect(moved).toMatchObject({ pendingThreads: 1, healedThreads: 1 })
+    expect(rig.readLog().threadIds).toEqual([id, id])
+  })
+
+  it('re-reads a healed thread without record ids when its target path changes', async () => {
+    const id = threadId('1')
+    const rig = createHealRig({
+      auditedThreads: [{ stamp: '2026-07-01T10-00-00', id, recordId: null }]
+    })
+    await runCodexSessionIndexHeal(rig.paths, {
+      buildInvocation: rig.buildInvocation,
+      interBatchDelayMs: 0
+    })
+
+    appendFileSync(
+      rig.paths.auditLogPath,
+      `${JSON.stringify({
+        at: '2026-07-02T00:00:00.000Z',
+        action: 'existing',
+        source: '/managed/sessions/y.jsonl',
+        target: rolloutTarget(rig.paths.systemSessionsRoot, '2026-07-02T10-00-00', id)
+      })}\n`
+    )
     const moved = await runCodexSessionIndexHeal(rig.paths, {
       buildInvocation: rig.buildInvocation,
       interBatchDelayMs: 0
@@ -389,7 +404,14 @@ describe('runCodexSessionIndexHeal', () => {
   it('does not retry a missing thread when the same target gets another audit event', async () => {
     const id = threadId('1')
     const rig = createHealRig({
-      auditedThreads: [{ stamp: '2026-07-01T10-00-00', id }],
+      auditedThreads: [
+        {
+          stamp: '2026-07-01T10-00-00',
+          id,
+          action: 'existing',
+          fileInstanceId: 'instance-a'
+        }
+      ],
       missingThreadIds: [id]
     })
 
@@ -401,7 +423,8 @@ describe('runCodexSessionIndexHeal', () => {
 
     await createCodexSessionBackfillAuditWriter(rig.paths.auditLogPath)({
       action: 'existing',
-      target: rolloutTarget(rig.paths.systemSessionsRoot, '2026-07-01T10-00-00', id)
+      target: rolloutTarget(rig.paths.systemSessionsRoot, '2026-07-01T10-00-00', id),
+      fileInstanceId: 'instance-a'
     })
     const healed = await runCodexSessionIndexHeal(rig.paths, {
       buildInvocation: (home, timeoutMs) => {
@@ -423,6 +446,48 @@ describe('runCodexSessionIndexHeal', () => {
 
     expect(healed).toMatchObject({ outcome: 'completed', pendingThreads: 0, healedThreads: 0 })
     expect(rig.readLog().threadIds).toEqual([id])
+  })
+
+  it('retries a missing thread without record ids when its target path changes', async () => {
+    const id = threadId('1')
+    const rig = createHealRig({
+      auditedThreads: [{ stamp: '2026-07-01T10-00-00', id, recordId: null }],
+      missingThreadIds: [id]
+    })
+    await runCodexSessionIndexHeal(rig.paths, {
+      buildInvocation: rig.buildInvocation,
+      interBatchDelayMs: 0
+    })
+
+    appendFileSync(
+      rig.paths.auditLogPath,
+      `${JSON.stringify({
+        at: '2026-07-02T00:00:00.000Z',
+        action: 'existing',
+        source: '/managed/sessions/y.jsonl',
+        target: rolloutTarget(rig.paths.systemSessionsRoot, '2026-07-02T10-00-00', id)
+      })}\n`
+    )
+    const moved = await runCodexSessionIndexHeal(rig.paths, {
+      buildInvocation: (home, timeoutMs) => {
+        const invocation = rig.buildInvocation(home, timeoutMs)
+        return {
+          ...invocation,
+          env: {
+            STUB_CONFIG: JSON.stringify({
+              scenario: 'ok',
+              readLogFile: rig.readLogFile,
+              missingThreadIds: [],
+              failingThreadIds: []
+            })
+          }
+        }
+      },
+      interBatchDelayMs: 0
+    })
+
+    expect(moved).toMatchObject({ outcome: 'completed', pendingThreads: 1, healedThreads: 1 })
+    expect(rig.readLog().threadIds).toEqual([id, id])
   })
 
   it('keeps a processed outcome readable after a torn heal-ledger tail', async () => {

--- a/src/main/codex/codex-session-index-heal.test.ts
+++ b/src/main/codex/codex-session-index-heal.test.ts
@@ -255,7 +255,7 @@ describe('runCodexSessionIndexHeal', () => {
     expect(rig.readLog().serverStarts).toBe(1)
   })
 
-  it('re-reads a healed thread after a later publication event', async () => {
+  it('does not re-read a healed thread when the same target gets another audit event', async () => {
     const id = threadId('1')
     const stamp = '2026-07-01T10-00-00'
     const rig = createHealRig({ auditedThreads: [{ stamp, id }] })
@@ -273,7 +273,30 @@ describe('runCodexSessionIndexHeal', () => {
       interBatchDelayMs: 0
     })
 
-    expect(repeated).toMatchObject({ pendingThreads: 1, healedThreads: 1 })
+    expect(repeated).toMatchObject({ pendingThreads: 0, healedThreads: 0 })
+    expect(rig.readLog().threadIds).toEqual([id])
+  })
+
+  it('re-reads a healed thread when its target path changes', async () => {
+    const id = threadId('1')
+    const rig = createHealRig({
+      auditedThreads: [{ stamp: '2026-07-01T10-00-00', id }]
+    })
+    await runCodexSessionIndexHeal(rig.paths, {
+      buildInvocation: rig.buildInvocation,
+      interBatchDelayMs: 0
+    })
+
+    await createCodexSessionBackfillAuditWriter(rig.paths.auditLogPath)({
+      action: 'existing',
+      target: rolloutTarget(rig.paths.systemSessionsRoot, '2026-07-02T10-00-00', id)
+    })
+    const moved = await runCodexSessionIndexHeal(rig.paths, {
+      buildInvocation: rig.buildInvocation,
+      interBatchDelayMs: 0
+    })
+
+    expect(moved).toMatchObject({ pendingThreads: 1, healedThreads: 1 })
     expect(rig.readLog().threadIds).toEqual([id, id])
   })
 
@@ -363,7 +386,7 @@ describe('runCodexSessionIndexHeal', () => {
     expect(readLedgerOutcomes(rig.paths)[threadId('1')]).toBe('healed')
   })
 
-  it('retries a missing thread when a later backfill republishes its rollout', async () => {
+  it('does not retry a missing thread when the same target gets another audit event', async () => {
     const id = threadId('1')
     const rig = createHealRig({
       auditedThreads: [{ stamp: '2026-07-01T10-00-00', id }],
@@ -398,8 +421,8 @@ describe('runCodexSessionIndexHeal', () => {
       interBatchDelayMs: 0
     })
 
-    expect(healed).toMatchObject({ outcome: 'completed', pendingThreads: 1, healedThreads: 1 })
-    expect(rig.readLog().threadIds).toEqual([id, id])
+    expect(healed).toMatchObject({ outcome: 'completed', pendingThreads: 0, healedThreads: 0 })
+    expect(rig.readLog().threadIds).toEqual([id])
   })
 
   it('keeps a processed outcome readable after a torn heal-ledger tail', async () => {
@@ -770,7 +793,7 @@ describe('runCodexSessionIndexHeal', () => {
     expect(resumed).toMatchObject({ outcome: 'completed', pendingThreads: 0 })
     expect(rig.readLog().threadIds).toEqual([id])
     expect(JSON.parse(readFileSync(rig.paths.healMarkerPath, 'utf-8'))).toMatchObject({
-      version: 3
+      version: 4
     })
     expect(warnSpy).toHaveBeenCalled()
     warnSpy.mockRestore()

--- a/src/main/codex/codex-session-index-heal.ts
+++ b/src/main/codex/codex-session-index-heal.ts
@@ -252,7 +252,9 @@ function recordHealOutcome(
       thread.threadId,
       outcome,
       thread.targetPath,
-      thread.auditRecordId
+      thread.auditRecordId,
+      thread.fileInstanceId,
+      thread.fileEventId
     )
   ) {
     throw new Error(`Failed to persist Codex session index-heal outcome for ${thread.threadId}`)

--- a/src/main/codex/codex-session-index-heal.ts
+++ b/src/main/codex/codex-session-index-heal.ts
@@ -246,7 +246,15 @@ function recordHealOutcome(
   thread: PendingHealThread,
   outcome: HealLedgerOutcome
 ): void {
-  if (!appendHealLedgerRecord(paths, thread.threadId, outcome, thread.auditRecordId)) {
+  if (
+    !appendHealLedgerRecord(
+      paths,
+      thread.threadId,
+      outcome,
+      thread.targetPath,
+      thread.auditRecordId
+    )
+  ) {
     throw new Error(`Failed to persist Codex session index-heal outcome for ${thread.threadId}`)
   }
 }

--- a/src/main/codex/codex-session-migration-scheduler.test.ts
+++ b/src/main/codex/codex-session-migration-scheduler.test.ts
@@ -435,6 +435,65 @@ describe('createCodexSessionMigrationScheduler', () => {
     await vi.waitFor(() => expect(finishScheduledRun).toHaveBeenCalledOnce())
   })
 
+  it('establishes a full baseline while a Codex launch remains active', async () => {
+    const finishScheduledRun = vi.fn()
+    const startBackfill = vi.fn().mockResolvedValue({ stopped: false })
+    const scheduler = createCodexSessionMigrationScheduler({
+      isEligible: () => true,
+      isQuitting: () => false,
+      resolveSystemCodexHomePathOverride: () => undefined,
+      prepareScheduledRun: () => false,
+      finishScheduledRun,
+      startBackfill,
+      startIndexHeal: vi.fn().mockResolvedValue(null),
+      initialDelayMs: 1_000
+    })
+
+    scheduler.beginLaunch('pty-1', true)
+    await vi.advanceTimersByTimeAsync(1_000)
+    await vi.waitFor(() => expect(startBackfill).toHaveBeenCalledOnce())
+
+    expect(startBackfill).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scanDates: undefined,
+        writeCompletionMarker: true,
+        preservePendingMarker: true
+      }),
+      undefined
+    )
+    await vi.waitFor(() => expect(finishScheduledRun).toHaveBeenCalledOnce())
+  })
+
+  it('recovers persisted pending dates after an abnormal Orca exit', async () => {
+    const startBackfill = vi.fn().mockResolvedValue({ stopped: false })
+    const scheduler = createCodexSessionMigrationScheduler({
+      isEligible: () => true,
+      isQuitting: () => false,
+      resolveSystemCodexHomePathOverride: () => undefined,
+      resolvePendingScanDates: () => [
+        ['2026', '08', '05'],
+        ['2026', '08', '06']
+      ],
+      startBackfill,
+      startIndexHeal: vi.fn().mockResolvedValue(null),
+      initialDelayMs: 1_000
+    })
+
+    scheduler.scheduleInitialRun()
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(startBackfill).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ignoreCompletionMarker: true,
+        scanDates: [
+          ['2026', '08', '05'],
+          ['2026', '08', '06']
+        ]
+      }),
+      undefined
+    )
+  })
+
   it('blocks marker publication when a newer launch pass is pending', async () => {
     let releaseBackfill: ((result: { stopped: boolean }) => void) | undefined
     const startBackfill = vi.fn(

--- a/src/main/codex/codex-session-migration-scheduler.test.ts
+++ b/src/main/codex/codex-session-migration-scheduler.test.ts
@@ -354,6 +354,7 @@ describe('createCodexSessionMigrationScheduler', () => {
       '/new-history'
     )
     await vi.waitFor(() => expect(finishScheduledRun).toHaveBeenCalledOnce())
+    expect(finishScheduledRun).toHaveBeenCalledWith(false)
   })
 
   it('finishes a launch generation only after its PTY exits and every date is rescanned', async () => {
@@ -398,6 +399,7 @@ describe('createCodexSessionMigrationScheduler', () => {
       undefined
     )
     await vi.waitFor(() => expect(finishScheduledRun).toHaveBeenCalledOnce())
+    expect(finishScheduledRun).toHaveBeenCalledWith(false)
   })
 
   it('keeps a failed full scan required for the final launch pass', async () => {
@@ -433,6 +435,7 @@ describe('createCodexSessionMigrationScheduler', () => {
       undefined
     )
     await vi.waitFor(() => expect(finishScheduledRun).toHaveBeenCalledOnce())
+    expect(finishScheduledRun).toHaveBeenCalledWith(false)
   })
 
   it('establishes a full baseline while a Codex launch remains active', async () => {
@@ -462,6 +465,7 @@ describe('createCodexSessionMigrationScheduler', () => {
       undefined
     )
     await vi.waitFor(() => expect(finishScheduledRun).toHaveBeenCalledOnce())
+    expect(finishScheduledRun).toHaveBeenCalledWith(true)
   })
 
   it('recovers persisted pending dates after an abnormal Orca exit', async () => {
@@ -488,6 +492,40 @@ describe('createCodexSessionMigrationScheduler', () => {
         scanDates: [
           ['2026', '08', '05'],
           ['2026', '08', '06']
+        ]
+      }),
+      undefined
+    )
+  })
+
+  it('keeps recovered dates when a launch replaces the initial recovery timer', async () => {
+    vi.setSystemTime(new Date('2026-08-07T10:00:00Z'))
+    const startBackfill = vi.fn().mockResolvedValue({ stopped: false })
+    const scheduler = createCodexSessionMigrationScheduler({
+      isEligible: () => true,
+      isQuitting: () => false,
+      resolveSystemCodexHomePathOverride: () => undefined,
+      resolvePendingScanDates: () => [
+        ['2026', '08', '05'],
+        ['2026', '08', '06']
+      ],
+      startBackfill,
+      startIndexHeal: vi.fn().mockResolvedValue(null),
+      initialDelayMs: 1_000
+    })
+
+    scheduler.scheduleInitialRun()
+    await vi.advanceTimersByTimeAsync(500)
+    scheduler.beginLaunch('pty-1')
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(startBackfill).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ignoreCompletionMarker: true,
+        scanDates: [
+          ['2026', '08', '05'],
+          ['2026', '08', '06'],
+          ['2026', '08', '07']
         ]
       }),
       undefined

--- a/src/main/codex/codex-session-migration-scheduler.ts
+++ b/src/main/codex/codex-session-migration-scheduler.ts
@@ -29,6 +29,7 @@ export function createCodexSessionMigrationScheduler(args: {
   isEligible: () => boolean
   isQuitting: () => boolean
   resolveSystemCodexHomePathOverride: () => string | undefined
+  resolvePendingScanDates?: () => readonly CodexSessionBackfillDate[]
   prepareScheduledRun?: () => boolean | void
   finishScheduledRun?: () => void
   startBackfill: MigrationRun
@@ -106,11 +107,12 @@ export function createCodexSessionMigrationScheduler(args: {
           shouldStop,
           scanDates,
           ignoreCompletionMarker: isScheduledRun,
-          writeCompletionMarker: activeLaunches.size === 0,
+          writeCompletionMarker: fullScanRequired || activeLaunches.size === 0,
           writeBoundedCompletionMarker:
             isScheduledRun && activeLaunches.size === 0 && !fullScanRequired,
+          preservePendingMarker: activeLaunches.size > 0,
           canWriteCompletionMarker: () =>
-            activeLaunches.size === 0 &&
+            (fullScanRequired || activeLaunches.size === 0) &&
             scheduledTimer === null &&
             pendingScheduledRunGeneration === null &&
             (!isScheduledRun || activeScheduledRunGeneration === scheduledRunGeneration)
@@ -150,7 +152,7 @@ export function createCodexSessionMigrationScheduler(args: {
         if (
           isScheduledRun &&
           !incompleteBackfill &&
-          activeLaunches.size === 0 &&
+          (fullScanRequired || activeLaunches.size === 0) &&
           scheduledTimer === null &&
           pendingScheduledRunGeneration === null
         ) {
@@ -166,16 +168,25 @@ export function createCodexSessionMigrationScheduler(args: {
   const armScheduledRun = (generation?: number): void => {
     scheduledTimer = setTimeout(() => {
       scheduledTimer = null
+      let requestedGeneration = generation
       if (generation !== undefined) {
         const currentDate = getCodexSessionBackfillDate()
         scheduledScanDates.set(currentDate.join('-'), currentDate)
+      } else {
+        const recoveredScanDates = args.resolvePendingScanDates?.() ?? []
+        for (const scanDate of recoveredScanDates) {
+          scheduledScanDates.set(scanDate.join('-'), scanDate)
+        }
+        if (recoveredScanDates.length > 0) {
+          requestedGeneration = ++scheduledRunGeneration
+        }
       }
       const scanDates = [...scheduledScanDates.values()].sort(compareBackfillDates)
       scheduledScanDates.clear()
       const fullScanRequired = scheduledFullScan
       scheduledFullScan = false
       // Why: a launch can invalidate the marker while a long index-heal pass is active.
-      requestRun(true, generation, scanDates, fullScanRequired)
+      requestRun(true, requestedGeneration, scanDates, fullScanRequired)
     }, args.initialDelayMs ?? 15_000)
   }
 

--- a/src/main/codex/codex-session-migration-scheduler.ts
+++ b/src/main/codex/codex-session-migration-scheduler.ts
@@ -31,7 +31,7 @@ export function createCodexSessionMigrationScheduler(args: {
   resolveSystemCodexHomePathOverride: () => string | undefined
   resolvePendingScanDates?: () => readonly CodexSessionBackfillDate[]
   prepareScheduledRun?: () => boolean | void
-  finishScheduledRun?: () => void
+  finishScheduledRun?: (keepLaunchTracking: boolean) => void
   startBackfill: MigrationRun
   startIndexHeal: MigrationRun
   initialDelayMs?: number
@@ -156,7 +156,7 @@ export function createCodexSessionMigrationScheduler(args: {
           scheduledTimer === null &&
           pendingScheduledRunGeneration === null
         ) {
-          args.finishScheduledRun?.()
+          args.finishScheduledRun?.(activeLaunches.size > 0)
         }
         if (shouldRerun) {
           requestRun()
@@ -169,17 +169,15 @@ export function createCodexSessionMigrationScheduler(args: {
     scheduledTimer = setTimeout(() => {
       scheduledTimer = null
       let requestedGeneration = generation
+      const recoveredScanDates = args.resolvePendingScanDates?.() ?? []
+      for (const scanDate of recoveredScanDates) {
+        scheduledScanDates.set(scanDate.join('-'), scanDate)
+      }
       if (generation !== undefined) {
         const currentDate = getCodexSessionBackfillDate()
         scheduledScanDates.set(currentDate.join('-'), currentDate)
-      } else {
-        const recoveredScanDates = args.resolvePendingScanDates?.() ?? []
-        for (const scanDate of recoveredScanDates) {
-          scheduledScanDates.set(scanDate.join('-'), scanDate)
-        }
-        if (recoveredScanDates.length > 0) {
-          requestedGeneration = ++scheduledRunGeneration
-        }
+      } else if (recoveredScanDates.length > 0) {
+        requestedGeneration = ++scheduledRunGeneration
       }
       const scanDates = [...scheduledScanDates.values()].sort(compareBackfillDates)
       scheduledScanDates.clear()

--- a/src/main/codex/codex-session-migration-wiring.test.ts
+++ b/src/main/codex/codex-session-migration-wiring.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+describe('Codex session migration wiring', () => {
+  const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+
+  it('forwards active launch tracking when a scheduled run finishes', () => {
+    const schedulerStart = source.indexOf('codexSessionMigration = createCodexSessionMigrationScheduler({')
+    const schedulerEnd = source.indexOf('\n  })', schedulerStart)
+
+    expect(schedulerStart).toBeGreaterThanOrEqual(0)
+    expect(schedulerEnd).toBeGreaterThan(schedulerStart)
+
+    const schedulerWiring = source.slice(schedulerStart, schedulerEnd)
+    expect(schedulerWiring).toContain('finishScheduledRun: (keepLaunchTracking) =>')
+    expect(schedulerWiring).toContain(
+      'finishHostSystemDefaultSessionMigrationPass(keepLaunchTracking)'
+    )
+    expect(schedulerWiring).not.toContain('finishScheduledRun: () =>')
+  })
+})

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2561,6 +2561,8 @@ void app.whenReady().then(async () => {
     isQuitting: () => isQuitting,
     resolveSystemCodexHomePathOverride: () =>
       resolveHostCodexSessionSourceHome(store!.getSettings()),
+    resolvePendingScanDates: () =>
+      codexRuntimeHome?.getHostSystemDefaultPendingSessionMigrationDates() ?? [],
     prepareScheduledRun: () => codexRuntimeHome?.prepareHostSystemDefaultSessionMigrationPass(),
     finishScheduledRun: () => codexRuntimeHome?.finishHostSystemDefaultSessionMigrationPass(),
     startBackfill: startCodexSessionBackfillInBackground,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -473,7 +473,8 @@ function handleCodexHomePtySpawned(args: {
   const fullScanRequired =
     codexRuntimeHome?.beginHostSystemDefaultSessionMigrationLaunch(args.codexHomePath, {
       reattached: args.reattached,
-      launchEnv: args.launchEnv
+      launchEnv: args.launchEnv,
+      startedAt: args.startedAt
     }) ?? null
   if (fullScanRequired !== null) {
     codexSessionMigration?.beginLaunch(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2565,7 +2565,8 @@ void app.whenReady().then(async () => {
     resolvePendingScanDates: () =>
       codexRuntimeHome?.getHostSystemDefaultPendingSessionMigrationDates() ?? [],
     prepareScheduledRun: () => codexRuntimeHome?.prepareHostSystemDefaultSessionMigrationPass(),
-    finishScheduledRun: () => codexRuntimeHome?.finishHostSystemDefaultSessionMigrationPass(),
+    finishScheduledRun: (keepLaunchTracking) =>
+      codexRuntimeHome?.finishHostSystemDefaultSessionMigrationPass(keepLaunchTracking),
     startBackfill: startCodexSessionBackfillInBackground,
     startIndexHeal: startCodexSessionIndexHealInBackground
   })


### PR DESCRIPTION
## ELI5

Orca copies Codex session history into its managed Home. Previously, a new Codex launch could make that historical copy look unfinished again, so Orca might revisit the entire history while the user was trying to open a pane. This change remembers the completed historical baseline separately from new activity, so later launches process only the small date range that can have changed.

## What Changed

- Upgrade the backfill marker to a backward-compatible v4 format with a durable historical baseline and `pendingSince` date.
- Keep the baseline when a normal Codex launch occurs; only record the earliest pending activity date.
- Allow the first full scan to publish its baseline while a Codex launch remains active, with generation protection for concurrent updates.
- Scan only the current date after a baseline exists, and recover bounded date ranges after cross-midnight runs or abnormal Orca exits.
- Invalidate the baseline only when the system sessions root or managed Home routing changes, or when a full scan cannot be trusted.
- Make index-heal idempotency use `systemSessionsRoot + threadId + normalized target path`, while retaining compatibility with older ledger records.
- Add focused regression tests for marker migration, generation races, active-launch baseline publication, bounded recovery, and target-path changes.

## Why

A managed Home with a large Codex history could make the first panes slow and, during repeated or interrupted work, make Orca appear unresponsive. The old completion-marker lifecycle conflated historical completion with active launch updates. Splitting those states preserves synchronization without repeatedly scanning all historical files.

## Linked Issue

Fixes #16251

## Visual Proof

N/A - this is a background session migration and index-heal change with no UI layout or interaction changes.

## Testing

- Focused Vitest coverage: 5 backfill-related files, 99/99 tests passed.
- Node typecheck passed.
- Full lint passed.
- `build:desktop` passed.
- `build:web-from-renderer` passed.
- `verify:built-skills-cli` passed.
- Unpacked Windows build passed with native rebuild disabled because the local `@vscode/windows-process-tree` node-gyp step fails under the pnpm path on this machine.
- Packaged daemon/plugin verification passed.
- Full `pnpm test` was not runnable locally because the Node 24 native-runtime gate requires `windows_process_tree.node`; the same 13 pre-existing Codex resume/real-home failures occurred in the modified and unmodified baselines.
- Windows 11 field validation with `1.4.188-backfillfix.1`: stable 357-file historical baseline, later scan limited to 38 files in the current date directory, zero backfill failures, no duplicate heal for the same path, and no Orca unresponsive state.

Platforms exercised: Windows 11 native Orca/Codex environment. SSH, macOS, and Linux runtime behavior were not directly exercised by this change.

## Author

X (Twitter): N/A

## AI Disclosure

This PR was prepared with OpenAI Codex (GPT-5) assistance. The author reviewed the resulting diff, tests, and Windows validation evidence.

## Review

- Cross-platform: the change uses existing path/date abstractions and does not add Windows-only path parsing; non-Windows runtime paths remain on the existing code path.
- SSH/remote: no remote wire or SSH protocol fields changed; the scheduler remains local to the Codex session migration service.
- Agent/integration compatibility: the change is scoped to Codex session backfill and heal state; other agents and git providers are unaffected.
- Performance: normal launches avoid re-scanning the historical baseline and bounded recovery prevents a fallback to full-history work after abnormal exit.
- Security: no authentication, Codex credentials, or user session contents are changed; only existing marker and heal-ledger metadata are extended compatibly.

## Agent skill upstream boundary

- [x] Not applicable. This change does not copy or mechanically translate upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The change does not alter the managed Home contract, delete `.codex` history, disable backfill, or modify authentication/configuration. The local full suite remains limited by the environment's missing native Node 24 module noted above; CI should provide the complete cross-platform matrix.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos are not applicable; this is a background-only change
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, agent/integration, and path impact considered
- [x] Focused tests, typecheck, lint, desktop build, and Windows validation completed