### PR TITLE
fix(sidebar): defensive worktree selection hardening (#16241)

### DIFF
--- a/src/renderer/src/components/sidebar/use-workspace-kanban-selection.ts
+++ b/src/renderer/src/components/sidebar/use-workspace-kanban-selection.ts
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useLayoutEffect, useMemo, useState } from 'react'
 import type { Worktree } from '../../../../shared/worktree/types'
 import { getWorktreeHostIdentity } from '../../../../shared/worktree/host-qualified-identity'
 import {
@@ -21,6 +21,24 @@ function resolveRenderedAnchorId(
   return renderedWorktreeIds.find((id) => selectedWorktreeIds.has(id)) ?? null
 }
 
+export type WorkspaceKanbanSelection = {
+  selectedWorktreeIds: ReadonlySet<string>
+  selectedWorktrees: readonly Worktree[]
+  selectionAnchorId: string | null
+  updateSelectionForGesture: (event: React.MouseEvent<HTMLElement>, worktreeId: string) => boolean
+  updateSelectionForArea: (
+    areaIds: readonly string[],
+    additive: boolean,
+    baseSelectedIds?: ReadonlySet<string>,
+    baseAnchorId?: string | null
+  ) => void
+  clearSelection: () => void
+  selectForContextMenu: (
+    event: React.MouseEvent<HTMLElement>,
+    worktree: Worktree
+  ) => readonly Worktree[]
+}
+
 // Why: board search hides cards without dropping them from the board, so range
 // and area gestures index the rendered subset while pruning still spans the
 // whole board — a card hidden by a query keeps its selection until a gesture
@@ -29,7 +47,7 @@ export function useWorkspaceKanbanSelection(
   open: boolean,
   boardWorktrees: readonly Worktree[],
   renderedWorktrees: readonly Worktree[] = boardWorktrees
-) {
+): WorkspaceKanbanSelection {
   const boardWorktreeIds = useMemo(
     () => boardWorktrees.map(getWorktreeHostIdentity),
     [boardWorktrees]
@@ -40,32 +58,42 @@ export function useWorkspaceKanbanSelection(
   )
   const [selectedWorktreeIds, setSelectedWorktreeIds] = useState<Set<string>>(new Set())
   const [selectionAnchorId, setSelectionAnchorId] = useState<string | null>(null)
+
+  // Why memo: derive pruned selection during render so children never receive or commit stale unrendered IDs, without executing setState in the render body.
+  const prunedSelection = useMemo(
+    () =>
+      open
+        ? pruneWorktreeSelection(selectedWorktreeIds, selectionAnchorId, boardWorktreeIds)
+        : { selectedIds: new Set<string>(), anchorId: null },
+    [boardWorktreeIds, open, selectedWorktreeIds, selectionAnchorId]
+  )
+  const effectiveSelectedWorktreeIds = prunedSelection.selectedIds
+  const effectiveSelectionAnchorId = prunedSelection.anchorId
+
   const selectedWorktrees = useMemo(
     () =>
       boardWorktrees.filter((worktree) =>
-        selectedWorktreeIds.has(getWorktreeHostIdentity(worktree))
+        effectiveSelectedWorktreeIds.has(getWorktreeHostIdentity(worktree))
       ),
-    [boardWorktrees, selectedWorktreeIds]
+    [boardWorktrees, effectiveSelectedWorktreeIds]
   )
 
-  if (!open) {
-    if (selectedWorktreeIds.size > 0) {
-      setSelectedWorktreeIds(new Set())
+  // Why layout effect: synchronize pruned state back to local state after commit if filtering dropped selected cards, using equality guards.
+  useLayoutEffect(() => {
+    if (!areWorktreeSelectionsEqual(selectedWorktreeIds, effectiveSelectedWorktreeIds)) {
+      setSelectedWorktreeIds(effectiveSelectedWorktreeIds)
     }
-    if (selectionAnchorId !== null) {
-      setSelectionAnchorId(null)
+    if (selectionAnchorId !== effectiveSelectionAnchorId) {
+      setSelectionAnchorId(effectiveSelectionAnchorId)
     }
-  } else {
-    const pruned = pruneWorktreeSelection(selectedWorktreeIds, selectionAnchorId, boardWorktreeIds)
-    // Why: the drawer can keep rendering while rows are filtered/reordered.
-    // Prune stale local selection before children see ids that no longer exist.
-    if (!areWorktreeSelectionsEqual(selectedWorktreeIds, pruned.selectedIds)) {
-      setSelectedWorktreeIds(pruned.selectedIds)
-    }
-    if (selectionAnchorId !== pruned.anchorId) {
-      setSelectionAnchorId(pruned.anchorId)
-    }
-  }
+  }, [
+    boardWorktreeIds,
+    effectiveSelectedWorktreeIds,
+    effectiveSelectionAnchorId,
+    open,
+    selectedWorktreeIds,
+    selectionAnchorId
+  ])
 
   const updateSelectionForGesture = useCallback(
     (event: React.MouseEvent<HTMLElement>, worktreeId: string): boolean => {
@@ -75,13 +103,16 @@ export function useWorkspaceKanbanSelection(
       // from visibleIds as "no anchor" and collapses the range to the click,
       // so re-anchor onto the first still-rendered selected card instead.
       const anchorId =
-        intent === 'range' && selectionAnchorId !== null
-          ? (resolveRenderedAnchorId(renderedWorktreeIds, selectedWorktreeIds, selectionAnchorId) ??
-            selectionAnchorId)
-          : selectionAnchorId
+        intent === 'range' && effectiveSelectionAnchorId !== null
+          ? (resolveRenderedAnchorId(
+              renderedWorktreeIds,
+              effectiveSelectedWorktreeIds,
+              effectiveSelectionAnchorId
+            ) ?? effectiveSelectionAnchorId)
+          : effectiveSelectionAnchorId
       const result = updateWorktreeSelection({
         visibleIds: renderedWorktreeIds,
-        previousSelectedIds: selectedWorktreeIds,
+        previousSelectedIds: effectiveSelectedWorktreeIds,
         previousAnchorId: anchorId,
         targetId: worktreeId,
         intent
@@ -93,28 +124,31 @@ export function useWorkspaceKanbanSelection(
       setSelectionAnchorId(result.anchorId)
       return intent !== 'replace'
     },
-    [renderedWorktreeIds, selectedWorktreeIds, selectionAnchorId]
+    [effectiveSelectedWorktreeIds, effectiveSelectionAnchorId, renderedWorktreeIds]
   )
 
   const selectForContextMenu = useCallback(
     (_event: React.MouseEvent<HTMLElement>, worktree: Worktree): readonly Worktree[] => {
       const worktreeIdentity = getWorktreeHostIdentity(worktree)
-      if (selectedWorktreeIds.has(worktreeIdentity) && selectedWorktreeIds.size > 1) {
+      if (
+        effectiveSelectedWorktreeIds.has(worktreeIdentity) &&
+        effectiveSelectedWorktreeIds.size > 1
+      ) {
         return selectedWorktrees
       }
       setSelectedWorktreeIds(new Set([worktreeIdentity]))
       setSelectionAnchorId(worktreeIdentity)
       return [worktree]
     },
-    [selectedWorktreeIds, selectedWorktrees]
+    [effectiveSelectedWorktreeIds, selectedWorktrees]
   )
 
   const updateSelectionForArea = useCallback(
     (
       areaIds: readonly string[],
       additive: boolean,
-      baseSelectedIds: ReadonlySet<string> = selectedWorktreeIds,
-      baseAnchorId: string | null = selectionAnchorId
+      baseSelectedIds: ReadonlySet<string> = effectiveSelectedWorktreeIds,
+      baseAnchorId: string | null = effectiveSelectionAnchorId
     ): void => {
       const result = updateWorktreeAreaSelection({
         visibleIds: renderedWorktreeIds,
@@ -130,7 +164,7 @@ export function useWorkspaceKanbanSelection(
         previous === result.anchorId ? previous : result.anchorId
       )
     },
-    [renderedWorktreeIds, selectedWorktreeIds, selectionAnchorId]
+    [effectiveSelectedWorktreeIds, effectiveSelectionAnchorId, renderedWorktreeIds]
   )
 
   const clearSelection = useCallback(() => {
@@ -139,9 +173,9 @@ export function useWorkspaceKanbanSelection(
   }, [])
 
   return {
-    selectedWorktreeIds,
+    selectedWorktreeIds: effectiveSelectedWorktreeIds,
     selectedWorktrees,
-    selectionAnchorId,
+    selectionAnchorId: effectiveSelectionAnchorId,
     updateSelectionForGesture,
     updateSelectionForArea,
     clearSelection,

--- a/src/renderer/src/components/sidebar/use-workspace-kanban-selection.ts
+++ b/src/renderer/src/components/sidebar/use-workspace-kanban-selection.ts
@@ -59,7 +59,7 @@ export function useWorkspaceKanbanSelection(
   const [selectedWorktreeIds, setSelectedWorktreeIds] = useState<Set<string>>(new Set())
   const [selectionAnchorId, setSelectionAnchorId] = useState<string | null>(null)
 
-  // Why memo: derive pruned selection during render so children never receive or commit stale unrendered IDs, without executing setState in the render body.
+  // Why memo: derive pruned selection during render so children never receive or commit IDs no longer present on the board (retaining query-hidden cards), without executing setState in the render body.
   const prunedSelection = useMemo(
     () =>
       open

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/use-selection.react185.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/use-selection.react185.test.tsx
@@ -7,6 +7,7 @@ import type { HostSectionRow } from '../../host-section-rows'
 import type { Worktree } from '../../../../../../shared/worktree/types'
 import { getWorktreeHostIdentity } from '../../../../../../shared/worktree/host-qualified-identity'
 import { useSidebarWorktreeSelection, type SidebarWorktreeSelection } from './use-selection'
+
 declare global {
   var IS_REACT_ACT_ENVIRONMENT: boolean | undefined
 }
@@ -104,12 +105,14 @@ describe('useSidebarWorktreeSelection cannot trigger React #185 loop', () => {
     expect(latestSelection!.selectedWorktreeIds.size).toBe(1)
     expect(latestSelection!.selectedWorktreeIds.has(getWorktreeHostIdentity(wt1))).toBe(true)
 
-    // 3. Select wt-2 via context menu
+    // 3. Select wt-2 via context menu (replaces single selection)
     act(() => {
       const mouseEvent = {} as React.MouseEvent<HTMLElement>
       latestSelection!.selectForContextMenu(mouseEvent, wt2)
     })
     expect(latestSelection!.selectedWorktreeIds.has(getWorktreeHostIdentity(wt2))).toBe(true)
+    expect(latestSelection!.selectedWorktreeIds.size).toBe(1)
+    expect(latestSelection!.selectedWorktreeIds.has(getWorktreeHostIdentity(wt1))).toBe(false)
 
     // 4. Trigger outside pointerdown -> should clear selection
     act(() => {
@@ -137,7 +140,7 @@ describe('useSidebarWorktreeSelection cannot trigger React #185 loop', () => {
     }
     expect(latestSelection!.selectedWorktreeIds.size).toBe(0)
 
-    // 7. Stress test: rapid outside clicks and filtering cycles
+    // 7. Stress test: rapid outside clicks and filtering cycles while actively selecting
     for (let i = 0; i < 50; i += 1) {
       act(() => {
         document.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
@@ -145,13 +148,22 @@ describe('useSidebarWorktreeSelection cannot trigger React #185 loop', () => {
     }
 
     for (let i = 0; i < 20; i += 1) {
+      const selectedWorktree = i % 2 === 0 ? wt2 : wt1
       act(() => {
-        root.render(
-          <SelectionHarness
-            sectionRows={makeSectionRows(i % 2 === 0 ? [wt1, wt2] : [wt2, wt3, wt4])}
-          />
-        )
+        latestSelection!.selectForContextMenu({} as React.MouseEvent<HTMLElement>, selectedWorktree)
       })
+      expect(
+        latestSelection!.selectedWorktreeIds.has(getWorktreeHostIdentity(selectedWorktree))
+      ).toBe(true)
+
+      const nextRows = i % 2 === 0 ? [wt1, wt3] : [wt2, wt4]
+      act(() => {
+        root.render(<SelectionHarness sectionRows={makeSectionRows(nextRows)} />)
+      })
+      expect(
+        latestSelection!.selectedWorktreeIds.has(getWorktreeHostIdentity(selectedWorktree))
+      ).toBe(false)
+      expect(latestSelection!.selectedWorktreeIds.size).toBe(0)
     }
 
     expect(renderCount).toBeLessThan(MAX_PASSES)

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/use-selection.react185.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/use-selection.react185.test.tsx
@@ -86,14 +86,12 @@ describe('useSidebarWorktreeSelection cannot trigger React #185 loop', () => {
     const wt3 = makeWorktree('wt-3')
     const wt4 = makeWorktree('wt-4')
 
-    // 1. Initial mount with 3 worktrees
     act(() => {
       root.render(<SelectionHarness sectionRows={makeSectionRows([wt1, wt2, wt3])} />)
     })
     expect(latestSelection).not.toBeNull()
     expect(latestSelection!.selectedWorktreeIds.size).toBe(0)
 
-    // 2. Drive selection through gesture API (select wt-1)
     act(() => {
       const mouseEvent = {
         metaKey: false,
@@ -105,7 +103,6 @@ describe('useSidebarWorktreeSelection cannot trigger React #185 loop', () => {
     expect(latestSelection!.selectedWorktreeIds.size).toBe(1)
     expect(latestSelection!.selectedWorktreeIds.has(getWorktreeHostIdentity(wt1))).toBe(true)
 
-    // 3. Select wt-2 via context menu (replaces single selection)
     act(() => {
       const mouseEvent = {} as React.MouseEvent<HTMLElement>
       latestSelection!.selectForContextMenu(mouseEvent, wt2)
@@ -114,20 +111,17 @@ describe('useSidebarWorktreeSelection cannot trigger React #185 loop', () => {
     expect(latestSelection!.selectedWorktreeIds.size).toBe(1)
     expect(latestSelection!.selectedWorktreeIds.has(getWorktreeHostIdentity(wt1))).toBe(false)
 
-    // 4. Trigger outside pointerdown -> should clear selection
     act(() => {
       document.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
     })
     expect(latestSelection!.selectedWorktreeIds.size).toBe(0)
 
-    // 5. Select wt-1 again
     act(() => {
       const mouseEvent = {} as React.MouseEvent<HTMLElement>
       latestSelection!.selectForContextMenu(mouseEvent, wt1)
     })
     expect(latestSelection!.selectedWorktreeIds.has(getWorktreeHostIdentity(wt1))).toBe(true)
 
-    // 6. Filter rows so wt-1 is no longer rendered (prune test)
     renderedSnapshots.length = 0
     act(() => {
       root.render(<SelectionHarness sectionRows={makeSectionRows([wt2, wt3])} />)
@@ -156,7 +150,6 @@ describe('useSidebarWorktreeSelection cannot trigger React #185 loop', () => {
     // Why <= 2: functional guards bail out of redundant renders on already-empty state.
     expect(renderCount - rendersBeforeBurst).toBeLessThanOrEqual(2)
 
-    // 8. Active selection pruning during rapid filtering cycles
     for (let i = 0; i < 20; i += 1) {
       const selectedWorktree = i % 2 === 0 ? wt2 : wt1
       act(() => {

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/use-selection.react185.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/use-selection.react185.test.tsx
@@ -1,4 +1,5 @@
 /** @vitest-environment happy-dom */
+import { join } from 'node:path'
 import { act } from 'react'
 import { createRoot } from 'react-dom/client'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -6,7 +7,6 @@ import type { HostSectionRow } from '../../host-section-rows'
 import type { Worktree } from '../../../../../../shared/worktree/types'
 import { getWorktreeHostIdentity } from '../../../../../../shared/worktree/host-qualified-identity'
 import { useSidebarWorktreeSelection, type SidebarWorktreeSelection } from './use-selection'
-
 declare global {
   var IS_REACT_ACT_ENVIRONMENT: boolean | undefined
 }
@@ -17,7 +17,7 @@ const MAX_PASSES = 400
 function makeWorktree(id: string): Worktree {
   return {
     id,
-    path: `/repo/${id}`,
+    path: join(process.cwd(), 'repo', id),
     repoId: 'repo-1',
     hostId: 'local',
     createdAt: 0,

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/use-selection.react185.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/use-selection.react185.test.tsx
@@ -1,0 +1,159 @@
+/** @vitest-environment happy-dom */
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { HostSectionRow } from '../../host-section-rows'
+import type { Worktree } from '../../../../../../shared/worktree/types'
+import { getWorktreeHostIdentity } from '../../../../../../shared/worktree/host-qualified-identity'
+import { useSidebarWorktreeSelection, type SidebarWorktreeSelection } from './use-selection'
+
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean | undefined
+}
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const MAX_PASSES = 400
+
+function makeWorktree(id: string): Worktree {
+  return {
+    id,
+    path: `/repo/${id}`,
+    repoId: 'repo-1',
+    hostId: 'local',
+    createdAt: 0,
+    sortOrder: 0
+  } as unknown as Worktree
+}
+
+function makeSectionRows(worktrees: Worktree[]): HostSectionRow[] {
+  return worktrees.map((worktree) => ({
+    type: 'item',
+    rowKey: `row:${worktree.hostId ?? 'local'}:${worktree.id}`,
+    sectionKey: 'all',
+    worktree,
+    repo: undefined,
+    depth: 0,
+    groupDepth: 0,
+    lineageTrail: [],
+    isLastLineageChild: false,
+    lineageChildCount: 0
+  }))
+}
+
+let cleanup: (() => void) | null = null
+
+afterEach(() => {
+  cleanup?.()
+  cleanup = null
+})
+
+describe('useSidebarWorktreeSelection cannot trigger React #185 loop', () => {
+  it('drives selection via gestures, verifies outside pointerdown clears selection, and prunes stale items without render loops', () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    cleanup = () => {
+      act(() => root.unmount())
+      container.remove()
+    }
+
+    let renderCount = 0
+    let latestSelection: SidebarWorktreeSelection | null = null
+    const renderedSnapshots: string[][] = []
+
+    function SelectionHarness({ sectionRows }: { sectionRows: HostSectionRow[] }) {
+      renderCount += 1
+      if (renderCount > MAX_PASSES) {
+        throw new Error('Maximum update depth exceeded')
+      }
+      const selection = useSidebarWorktreeSelection({
+        sectionRows,
+        pinnedDisplayPolicy: 'single-location'
+      })
+      latestSelection = selection
+      renderedSnapshots.push(Array.from(selection.selectedWorktreeIds))
+
+      return (
+        <div data-worktree-sidebar-container="true">
+          <div data-testid="count">{selection.selectedWorktreeIds.size}</div>
+        </div>
+      )
+    }
+
+    const wt1 = makeWorktree('wt-1')
+    const wt2 = makeWorktree('wt-2')
+    const wt3 = makeWorktree('wt-3')
+    const wt4 = makeWorktree('wt-4')
+
+    // 1. Initial mount with 3 worktrees
+    act(() => {
+      root.render(<SelectionHarness sectionRows={makeSectionRows([wt1, wt2, wt3])} />)
+    })
+    expect(latestSelection).not.toBeNull()
+    expect(latestSelection!.selectedWorktreeIds.size).toBe(0)
+
+    // 2. Drive selection through gesture API (select wt-1)
+    act(() => {
+      const mouseEvent = {
+        metaKey: false,
+        ctrlKey: false,
+        shiftKey: false
+      } as unknown as React.MouseEvent<HTMLElement>
+      latestSelection!.updateSelectionForGesture(mouseEvent, wt1)
+    })
+    expect(latestSelection!.selectedWorktreeIds.size).toBe(1)
+    expect(latestSelection!.selectedWorktreeIds.has(getWorktreeHostIdentity(wt1))).toBe(true)
+
+    // 3. Select wt-2 via context menu
+    act(() => {
+      const mouseEvent = {} as React.MouseEvent<HTMLElement>
+      latestSelection!.selectForContextMenu(mouseEvent, wt2)
+    })
+    expect(latestSelection!.selectedWorktreeIds.has(getWorktreeHostIdentity(wt2))).toBe(true)
+
+    // 4. Trigger outside pointerdown -> should clear selection
+    act(() => {
+      document.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+    })
+    expect(latestSelection!.selectedWorktreeIds.size).toBe(0)
+
+    // 5. Select wt-1 again
+    act(() => {
+      const mouseEvent = {} as React.MouseEvent<HTMLElement>
+      latestSelection!.selectForContextMenu(mouseEvent, wt1)
+    })
+    expect(latestSelection!.selectedWorktreeIds.has(getWorktreeHostIdentity(wt1))).toBe(true)
+
+    // 6. Filter rows so wt-1 is no longer rendered (prune test)
+    renderedSnapshots.length = 0
+    act(() => {
+      root.render(<SelectionHarness sectionRows={makeSectionRows([wt2, wt3])} />)
+    })
+
+    // Invariant: in EVERY render pass during and after filtering, children NEVER receive stale selected IDs
+    expect(renderedSnapshots.length).toBeGreaterThan(0)
+    for (const snapshot of renderedSnapshots) {
+      expect(snapshot).not.toContain(getWorktreeHostIdentity(wt1))
+    }
+    expect(latestSelection!.selectedWorktreeIds.size).toBe(0)
+
+    // 7. Stress test: rapid outside clicks and filtering cycles
+    for (let i = 0; i < 50; i += 1) {
+      act(() => {
+        document.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+      })
+    }
+
+    for (let i = 0; i < 20; i += 1) {
+      act(() => {
+        root.render(
+          <SelectionHarness
+            sectionRows={makeSectionRows(i % 2 === 0 ? [wt1, wt2] : [wt2, wt3, wt4])}
+          />
+        )
+      })
+    }
+
+    expect(renderCount).toBeLessThan(MAX_PASSES)
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/use-selection.react185.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/use-selection.react185.test.tsx
@@ -140,13 +140,25 @@ describe('useSidebarWorktreeSelection cannot trigger React #185 loop', () => {
     }
     expect(latestSelection!.selectedWorktreeIds.size).toBe(0)
 
-    // 7. Stress test: rapid outside clicks and filtering cycles while actively selecting
-    for (let i = 0; i < 50; i += 1) {
-      act(() => {
-        document.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
-      })
-    }
+    // 7. Functional guard test: select a worktree, then dispatch rapid pointerdown burst in a single act
+    // before React cleans up the listener, ensuring functional guards (prev => prev.size === 0 ? prev : new Set())
+    // bail out of redundant state updates and prevent render cascades.
+    act(() => {
+      latestSelection!.selectForContextMenu({} as React.MouseEvent<HTMLElement>, wt2)
+    })
+    expect(latestSelection!.selectedWorktreeIds.size).toBe(1)
 
+    const rendersBeforeBurst = renderCount
+    act(() => {
+      for (let i = 0; i < 50; i += 1) {
+        document.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }))
+      }
+    })
+    expect(latestSelection!.selectedWorktreeIds.size).toBe(0)
+    // Functional guard prevents 50 separate re-renders; settles in at most 2 commits
+    expect(renderCount - rendersBeforeBurst).toBeLessThanOrEqual(2)
+
+    // 8. Active selection pruning during rapid filtering cycles
     for (let i = 0; i < 20; i += 1) {
       const selectedWorktree = i % 2 === 0 ? wt2 : wt1
       act(() => {

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/use-selection.react185.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/use-selection.react185.test.tsx
@@ -140,9 +140,7 @@ describe('useSidebarWorktreeSelection cannot trigger React #185 loop', () => {
     }
     expect(latestSelection!.selectedWorktreeIds.size).toBe(0)
 
-    // 7. Functional guard test: select a worktree, then dispatch rapid pointerdown burst in a single act
-    // before React cleans up the listener, ensuring functional guards (prev => prev.size === 0 ? prev : new Set())
-    // bail out of redundant state updates and prevent render cascades.
+    // Why single act: burst events before effect cleanup to verify redundant clears bail out.
     act(() => {
       latestSelection!.selectForContextMenu({} as React.MouseEvent<HTMLElement>, wt2)
     })
@@ -155,7 +153,7 @@ describe('useSidebarWorktreeSelection cannot trigger React #185 loop', () => {
       }
     })
     expect(latestSelection!.selectedWorktreeIds.size).toBe(0)
-    // Functional guard prevents 50 separate re-renders; settles in at most 2 commits
+    // Why <= 2: functional guards bail out of redundant renders on already-empty state.
     expect(renderCount - rendersBeforeBurst).toBeLessThanOrEqual(2)
 
     // 8. Active selection pruning during rapid filtering cycles

--- a/src/renderer/src/components/sidebar/worktree-list/navigation/use-selection.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/navigation/use-selection.ts
@@ -14,12 +14,24 @@ import {
 } from '../../worktree-multi-selection'
 import { useReusedArrayIdentity } from '../listing/use-reused-array-identity'
 
+export type SidebarWorktreeSelection = {
+  renderedWorktreeIds: readonly string[]
+  renderedWorktreeIdentities: readonly string[]
+  selectedWorktreeIds: ReadonlySet<string>
+  selectedWorktrees: readonly Worktree[]
+  updateSelectionForGesture: (event: React.MouseEvent<HTMLElement>, worktree: Worktree) => boolean
+  selectForContextMenu: (
+    event: React.MouseEvent<HTMLElement>,
+    worktree: Worktree
+  ) => readonly Worktree[]
+}
+
 // Multi-select over the rows the sidebar actually rendered, so gestures, context menus, and
 // the Cmd+1–9 shortcut cache all agree on one order.
 export function useSidebarWorktreeSelection(args: {
   sectionRows: HostSectionRow[]
   pinnedDisplayPolicy: PinnedWorktreeDisplayPolicy
-}) {
+}): SidebarWorktreeSelection {
   const { sectionRows, pinnedDisplayPolicy } = args
   // Why: derive order from the built rows, not the flat worktrees array, so Cmd+1–9 match visual positions when grouping reorders cards.
   const renderedWorktrees = useMemo(
@@ -43,41 +55,50 @@ export function useSidebarWorktreeSelection(args: {
   )
   const [selectedWorktreeIds, setSelectedWorktreeIds] = useState<Set<string>>(new Set())
   const [selectionAnchorId, setSelectionAnchorId] = useState<string | null>(null)
-
-  const prunedSelection = pruneWorktreeSelection(
-    selectedWorktreeIds,
-    selectionAnchorId,
-    renderedWorktreeIdentities
+  // Why memo: derive pruned selection during render so children never receive or commit stale unrendered IDs, without executing setState in the render body.
+  const prunedSelection = useMemo(
+    () =>
+      pruneWorktreeSelection(selectedWorktreeIds, selectionAnchorId, renderedWorktreeIdentities),
+    [renderedWorktreeIdentities, selectedWorktreeIds, selectionAnchorId]
   )
-  // Why: filters/grouping can hide selected cards; prune during render so nothing sees stale ids for unrendered worktrees.
-  if (!areWorktreeSelectionsEqual(selectedWorktreeIds, prunedSelection.selectedIds)) {
-    setSelectedWorktreeIds(prunedSelection.selectedIds)
-  }
-  if (selectionAnchorId !== prunedSelection.anchorId) {
-    setSelectionAnchorId(prunedSelection.anchorId)
-  }
+  const effectiveSelectedWorktreeIds = prunedSelection.selectedIds
+  const effectiveSelectionAnchorId = prunedSelection.anchorId
 
+  // Why layout effect: synchronize pruned state back to local state after commit if filtering dropped selected rows, using equality guards.
+  useLayoutEffect(() => {
+    if (!areWorktreeSelectionsEqual(selectedWorktreeIds, effectiveSelectedWorktreeIds)) {
+      setSelectedWorktreeIds(effectiveSelectedWorktreeIds)
+    }
+    if (selectionAnchorId !== effectiveSelectionAnchorId) {
+      setSelectionAnchorId(effectiveSelectionAnchorId)
+    }
+  }, [
+    effectiveSelectedWorktreeIds,
+    effectiveSelectionAnchorId,
+    selectedWorktreeIds,
+    selectionAnchorId
+  ])
   // Why identity reuse: the empty/unchanged-selection case must keep one array
   // identity — selectForContextMenu and both drag-start handlers depend on
   // this array, and card memo bail-out depends on those staying stable.
   const selectedWorktrees = useReusedArrayIdentity(
     useMemo(() => {
-      if (selectedWorktreeIds.size === 0) {
+      if (effectiveSelectedWorktreeIds.size === 0) {
         return []
       }
       const selected = new Map<string, Worktree>()
       for (const worktree of renderedWorktrees) {
         const identity = getWorktreeHostIdentity(worktree)
-        if (selectedWorktreeIds.has(identity) && !selected.has(identity)) {
+        if (effectiveSelectedWorktreeIds.has(identity) && !selected.has(identity)) {
           selected.set(identity, worktree)
         }
       }
       return Array.from(selected.values())
-    }, [renderedWorktrees, selectedWorktreeIds])
+    }, [effectiveSelectedWorktreeIds, renderedWorktrees])
   )
 
   useEffect(() => {
-    if (selectedWorktreeIds.size === 0) {
+    if (effectiveSelectedWorktreeIds.size === 0) {
       return
     }
 
@@ -87,15 +108,15 @@ export function useSidebarWorktreeSelection(args: {
       if (target instanceof Node && sidebarContainer?.contains(target)) {
         return
       }
-      setSelectedWorktreeIds(new Set())
-      setSelectionAnchorId(null)
+      setSelectedWorktreeIds((previous) => (previous.size === 0 ? previous : new Set()))
+      setSelectionAnchorId((previous) => (previous === null ? previous : null))
     }
 
     document.addEventListener('pointerdown', clearSelectionOutsideSidebar, { capture: true })
     return () => {
       document.removeEventListener('pointerdown', clearSelectionOutsideSidebar, { capture: true })
     }
-  }, [selectedWorktreeIds.size])
+  }, [effectiveSelectedWorktreeIds.size])
 
   const updateSelectionForGesture = useCallback(
     (event: React.MouseEvent<HTMLElement>, worktree: Worktree): boolean => {
@@ -103,8 +124,8 @@ export function useSidebarWorktreeSelection(args: {
       const intent = getWorktreeSelectionIntent(event, navigator.userAgent.includes('Mac'))
       const result = updateWorktreeSelection({
         visibleIds: renderedWorktreeIdentities,
-        previousSelectedIds: selectedWorktreeIds,
-        previousAnchorId: selectionAnchorId,
+        previousSelectedIds: effectiveSelectedWorktreeIds,
+        previousAnchorId: effectiveSelectionAnchorId,
         targetId: worktreeIdentity,
         intent
       })
@@ -113,22 +134,24 @@ export function useSidebarWorktreeSelection(args: {
       // Plain click navigates; modifier gestures are selection-only so a batch can build without switching away.
       return intent !== 'replace'
     },
-    [renderedWorktreeIdentities, selectedWorktreeIds, selectionAnchorId]
+    [effectiveSelectedWorktreeIds, effectiveSelectionAnchorId, renderedWorktreeIdentities]
   )
 
   const selectForContextMenu = useCallback(
     (_event: React.MouseEvent<HTMLElement>, worktree: Worktree): readonly Worktree[] => {
       const worktreeIdentity = getWorktreeHostIdentity(worktree)
-      if (selectedWorktreeIds.has(worktreeIdentity) && selectedWorktreeIds.size > 1) {
+      if (
+        effectiveSelectedWorktreeIds.has(worktreeIdentity) &&
+        effectiveSelectedWorktreeIds.size > 1
+      ) {
         return selectedWorktrees
       }
       setSelectedWorktreeIds(new Set([worktreeIdentity]))
       setSelectionAnchorId(worktreeIdentity)
       return [worktree]
     },
-    [selectedWorktreeIds, selectedWorktrees]
+    [effectiveSelectedWorktreeIds, selectedWorktrees]
   )
-
   // Why layout effect: the Cmd/Ctrl+1–9 handler can fire right after commit; publishing after paint would leave the shortcut cache stale.
   useLayoutEffect(() => {
     setVisibleWorktreeIds(renderedWorktreeIds)
@@ -148,7 +171,7 @@ export function useSidebarWorktreeSelection(args: {
   return {
     renderedWorktreeIds,
     renderedWorktreeIdentities,
-    selectedWorktreeIds,
+    selectedWorktreeIds: effectiveSelectedWorktreeIds,
     selectedWorktrees,
     updateSelectionForGesture,
     selectForContextMenu


### PR DESCRIPTION
## ELI5

When selecting worktrees in the sidebar, the application previously updated state during the drawing (render) phase to remove hidden items. This change computes the cleaned-up selection directly without updating state during render and ignores clicks outside the sidebar when nothing is selected.

## What Changed

1. **Derived Render Selection (`useMemo`):**
   - Refactored `useSidebarWorktreeSelection` (`use-selection.ts`) to compute `prunedSelection` via `useMemo` in the render phase against currently rendered IDs.
   - Refactored `useWorkspaceKanbanSelection` (`use-workspace-kanban-selection.ts`) to derive pruned selection during render against IDs still present on the board (intentionally retaining query-hidden cards).
   - In both hooks, children immediately receive valid selection state without executing synchronous `setState` inside the render body.
2. **Post-Commit State Synchronization (`useLayoutEffect`):**
   - Synchronized local selection state post-commit using `useLayoutEffect` protected by `areWorktreeSelectionsEqual` equality guards.
3. **Functional Guards on Outside Pointer Listener:**
   - In `clearSelectionOutsideSidebar` and `clearSelection`, guarded `setSelectedWorktreeIds(prev => prev.size === 0 ? prev : new Set())` and `setSelectionAnchorId(prev => prev === null ? prev : null)` to bail out of no-op re-renders when selection is already empty.
4. **Regression Test Suite:**
   - Added `use-selection.react185.test.tsx` verifying gesture-driven selection, context-menu selection replacement, outside pointerdown clearing, and row pruning freshness with active selection during rapid filtering cycles. Built fixtures with `path.join(process.cwd(), ...)` for cross-platform portability.

## Why

During multi-worktree investigation on Windows (Issue #16241), trace logs recorded a `Minified React Error #185` (*Maximum update depth exceeded*) originating from `HTMLDocument.clearSelectionOutsideSidebar`.

Under React's concurrent model, executing synchronous `setState` in render bodies and dispatching unguarded `new Set()` instances on document pointer events can induce or amplify nested commit loops. Moving pruning to derived render-time calculation and guarding outside clicks removes these update-loop risk factors.

*Note on Evidence Boundary:* In accordance with `react-185-bystander-attribution.test.tsx`, this PR is codified as defensive selection hardening. It does not claim to resolve the captured #185 event without full originating-fiber reproduction. Issue #16241 remains open for ongoing long-session freeze diagnostics.

## Linked Issue

Relates to #16241

## Visual Proof

`N/A` - Pure state/effect lifecycle hardening for multi-selection with no user-visible layout or appearance change.

## Testing

Tested on Windows 11 Home (x64):
- Targeted Selection Tests: `npx vitest run src/renderer/src/components/sidebar/worktree-list/navigation/use-selection.react185.test.tsx ...` (4 files, 21 tests pass).
- Full Sidebar Suite: `npx vitest run src/renderer/src/components/sidebar/` (269 files, 2,310 tests pass).
- Typecheck: `npm run tc:web` (0 errors).
- Linter: `npx oxlint` on touched files (0 warnings).

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

AI-assisted development.

## Review

Self-reviewed for React concurrent render safety, memory leak prevention, and cross-platform path safety.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Cross-platform support:** Verified `path.join` for all test fixtures.
- **Performance:** Bails out of React re-renders when selection is empty via referential `prev` equality.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
