### PR TITLE
fix(sidebar): stop painting every project on launch, then walking the list back

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -762,6 +762,7 @@ function WorktreeJumpPaletteContent({
   const hideWorkspacesFromOtherDevices = useAppStore((s) => s.hideWorkspacesFromOtherDevices)
   const showSleepingWorkspaces = useAppStore((s) => s.showSleepingWorkspaces)
   const alwaysShowDefaultBranchWorkspace = useAppStore((s) => s.alwaysShowDefaultBranchWorkspace)
+  const pendingReconnectWorktreeIdList = useAppStore((s) => s.pendingReconnectWorktreeIds)
   const lastVisitedAtByWorktreeId = useAppStore((s) => s.lastVisitedAtByWorktreeId)
   const workspacePortScan = useAppStore((s) => s.workspacePortScan?.result ?? null)
   const openNewBrowserTabInActiveWorkspace = useAppStore(
@@ -932,6 +933,12 @@ function WorktreeJumpPaletteContent({
         : EMPTY_PAIRED_DEVICE_IDS_BY_ENVIRONMENT,
     [hideWorkspacesFromOtherDevices, runtimeEnvironments, runtimeStatusByEnvironmentId]
   )
+  // Why: same startup-reconnect exemption the sidebar sweep applies, so Cmd+J opened
+  // during restore lists the same workspaces the sidebar shows. #16247
+  const pendingReconnectWorktreeIds = useMemo(
+    () => new Set(pendingReconnectWorktreeIdList),
+    [pendingReconnectWorktreeIdList]
+  )
 
   // Why: empty-query mirrors sidebar filters so Search opens on the same quiet list; typed search widens to global non-archived scope.
   const emptyQueryVisibleWorktrees = useMemo(
@@ -973,7 +980,8 @@ function WorktreeJumpPaletteContent({
             tabsByWorktree,
             ptyIdsByTabId,
             browserTabsByWorktree,
-            worktreeIdsWithLiveAgent
+            worktreeIdsWithLiveAgent,
+            pendingReconnectWorktreeIds
           )
         ) {
           return false
@@ -994,7 +1002,8 @@ function WorktreeJumpPaletteContent({
       ptyIdsByTabId,
       showSleepingWorkspaces,
       tabsByWorktree,
-      worktreeIdsWithLiveAgent
+      worktreeIdsWithLiveAgent,
+      pendingReconnectWorktreeIds
     ]
   )
 

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -933,8 +933,7 @@ function WorktreeJumpPaletteContent({
         : EMPTY_PAIRED_DEVICE_IDS_BY_ENVIRONMENT,
     [hideWorkspacesFromOtherDevices, runtimeEnvironments, runtimeStatusByEnvironmentId]
   )
-  // Why: same startup-reconnect exemption the sidebar sweep applies, so Cmd+J opened
-  // during restore lists the same workspaces the sidebar shows. #16247
+  // Same startup-reconnect exemption as the sidebar sweep. #16247
   const pendingReconnectWorktreeIds = useMemo(
     () => new Set(pendingReconnectWorktreeIdList),
     [pendingReconnectWorktreeIdList]

--- a/src/renderer/src/components/sidebar/default-branch-visible-under-hide-sleeping.test.ts
+++ b/src/renderer/src/components/sidebar/default-branch-visible-under-hide-sleeping.test.ts
@@ -52,6 +52,7 @@ function visibleOptions(overrides: Partial<VisibleOptions> = {}): VisibleOptions
     ptyIdsByTabId: {},
     browserTabsByWorktree: {},
     worktreeIdsWithLiveAgent: new Set(),
+    pendingReconnectWorktreeIds: new Set(),
     hideDefaultBranchWorkspace: false,
     hideAutomationGeneratedWorkspaces: false,
     hideCliCreatedWorkspaces: false,

--- a/src/renderer/src/components/sidebar/empty-project-placeholder-repos.test.ts
+++ b/src/renderer/src/components/sidebar/empty-project-placeholder-repos.test.ts
@@ -48,8 +48,7 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
   })
 
   it('treats a missing worktreesByRepo key as empty once startup has settled', () => {
-    // Why: a repo whose scan failed (disconnected SSH, throwing provider) never gets
-    // a key, and must still keep a reachable header rather than vanish. #16247
+    // A failed scan never writes a key; the header must still come back. #16247
     expect(
       Array.from(
         getEmptyProjectPlaceholderRepoIds({
@@ -65,8 +64,7 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
   })
 
   it('does not placeholder an unscanned repo while startup is still refreshing', () => {
-    // Why: during startup every repo lands before its scan, so reading `undefined`
-    // as empty paints the whole project list and then walks it back. #16247
+    // Repos land before their scans; reading `undefined` as empty paints all of them. #16247
     expect(
       getEmptyProjectPlaceholderRepoIds({
         groupBy: 'repo',
@@ -80,8 +78,7 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
   })
 
   it('placeholders a scanned-empty repo during startup', () => {
-    // Why: `[]` is a settled answer even mid-startup, so a genuinely empty project
-    // appears as soon as its scan lands instead of waiting for the whole refresh.
+    // `[]` is settled even mid-startup, so an empty project appears as soon as it scans.
     expect(
       Array.from(
         getEmptyProjectPlaceholderRepoIds({
@@ -119,7 +116,7 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
     })
 
     expect(Array.from(duringStartup)).toEqual([scanned.id])
-    // Why: the list only ever grows — no header is painted and then withdrawn.
+    // The list only grows: no header is painted and then withdrawn.
     for (const id of duringStartup) {
       expect(afterSecondScan.has(id)).toBe(true)
     }

--- a/src/renderer/src/components/sidebar/empty-project-placeholder-repos.test.ts
+++ b/src/renderer/src/components/sidebar/empty-project-placeholder-repos.test.ts
@@ -40,13 +40,16 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
           repos: [repo],
           worktreesByRepo: { [repo.id]: [] },
           visibleWorktrees: [],
-          filterRepoIds: []
+          filterRepoIds: [],
+          startupWorktreeRefreshCompleted: true
         })
       )
     ).toEqual([repo.id])
   })
 
-  it('treats missing worktreesByRepo keys as empty for the current render', () => {
+  it('treats a missing worktreesByRepo key as empty once startup has settled', () => {
+    // Why: a repo whose scan failed (disconnected SSH, throwing provider) never gets
+    // a key, and must still keep a reachable header rather than vanish. #16247
     expect(
       Array.from(
         getEmptyProjectPlaceholderRepoIds({
@@ -54,10 +57,73 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
           repos: [repo],
           worktreesByRepo: {},
           visibleWorktrees: [],
-          filterRepoIds: []
+          filterRepoIds: [],
+          startupWorktreeRefreshCompleted: true
         })
       )
     ).toEqual([repo.id])
+  })
+
+  it('does not placeholder an unscanned repo while startup is still refreshing', () => {
+    // Why: during startup every repo lands before its scan, so reading `undefined`
+    // as empty paints the whole project list and then walks it back. #16247
+    expect(
+      getEmptyProjectPlaceholderRepoIds({
+        groupBy: 'repo',
+        repos: [repo],
+        worktreesByRepo: {},
+        visibleWorktrees: [],
+        filterRepoIds: [],
+        startupWorktreeRefreshCompleted: false
+      }).size
+    ).toBe(0)
+  })
+
+  it('placeholders a scanned-empty repo during startup', () => {
+    // Why: `[]` is a settled answer even mid-startup, so a genuinely empty project
+    // appears as soon as its scan lands instead of waiting for the whole refresh.
+    expect(
+      Array.from(
+        getEmptyProjectPlaceholderRepoIds({
+          groupBy: 'repo',
+          repos: [repo],
+          worktreesByRepo: { [repo.id]: [] },
+          visibleWorktrees: [],
+          filterRepoIds: [],
+          startupWorktreeRefreshCompleted: false
+        })
+      )
+    ).toEqual([repo.id])
+  })
+
+  it('converges monotonically as scans land during startup', () => {
+    const scanned: Repo = { ...repo, id: 'repo-scanned' }
+    const unscanned: Repo = { ...repo, id: 'repo-unscanned' }
+    const repos = [scanned, unscanned]
+
+    const duringStartup = getEmptyProjectPlaceholderRepoIds({
+      groupBy: 'repo',
+      repos,
+      worktreesByRepo: { [scanned.id]: [] },
+      visibleWorktrees: [],
+      filterRepoIds: [],
+      startupWorktreeRefreshCompleted: false
+    })
+    const afterSecondScan = getEmptyProjectPlaceholderRepoIds({
+      groupBy: 'repo',
+      repos,
+      worktreesByRepo: { [scanned.id]: [], [unscanned.id]: [] },
+      visibleWorktrees: [],
+      filterRepoIds: [],
+      startupWorktreeRefreshCompleted: false
+    })
+
+    expect(Array.from(duringStartup)).toEqual([scanned.id])
+    // Why: the list only ever grows — no header is painted and then withdrawn.
+    for (const id of duringStartup) {
+      expect(afterSecondScan.has(id)).toBe(true)
+    }
+    expect(Array.from(afterSecondScan)).toEqual([scanned.id, unscanned.id])
   })
 
   it('applies repo filters to empty placeholder candidates', () => {
@@ -71,7 +137,8 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
           repos: [selectedRepo, hiddenRepo],
           worktreesByRepo: { [selectedRepo.id]: [], [hiddenRepo.id]: [] },
           visibleWorktrees: [],
-          filterRepoIds: [selectedRepo.id]
+          filterRepoIds: [selectedRepo.id],
+          startupWorktreeRefreshCompleted: true
         })
       )
     ).toEqual([selectedRepo.id])
@@ -84,7 +151,8 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
         repos: [repo],
         worktreesByRepo: { [repo.id]: [] },
         visibleWorktrees: [],
-        filterRepoIds: []
+        filterRepoIds: [],
+        startupWorktreeRefreshCompleted: true
       }).size
     ).toBe(0)
   })
@@ -96,7 +164,8 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
         repos: [repo],
         worktreesByRepo: { [repo.id]: [worktree] },
         visibleWorktrees: [],
-        filterRepoIds: []
+        filterRepoIds: [],
+        startupWorktreeRefreshCompleted: true
       }).size
     ).toBe(0)
   })
@@ -112,7 +181,8 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
           repos: [groupedRepo],
           worktreesByRepo: { [groupedRepo.id]: [groupedWorktree] },
           visibleWorktrees: [],
-          filterRepoIds: []
+          filterRepoIds: [],
+          startupWorktreeRefreshCompleted: true
         })
       )
     ).toEqual([groupedRepo.id])
@@ -128,7 +198,8 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
         repos: [groupedRepo],
         worktreesByRepo: { [groupedRepo.id]: [groupedWorktree] },
         visibleWorktrees: [groupedWorktree],
-        filterRepoIds: []
+        filterRepoIds: [],
+        startupWorktreeRefreshCompleted: true
       }).size
     ).toBe(0)
   })
@@ -151,7 +222,8 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
           // Why: simulate Hide sleeping removing every card while the project
           // filter still intentionally excludes `filteredOut`.
           visibleWorktrees: [],
-          filterRepoIds: [selected.id]
+          filterRepoIds: [selected.id],
+          startupWorktreeRefreshCompleted: true
         })
       )
     ).toEqual([selected.id])
@@ -173,7 +245,8 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
             [awake.id]: [awakeWt]
           },
           visibleWorktrees: [awakeWt],
-          filterRepoIds: []
+          filterRepoIds: [],
+          startupWorktreeRefreshCompleted: true
         })
       )
     ).toEqual([sleeping.id])
@@ -195,7 +268,8 @@ describe('getEmptyProjectPlaceholderRepoIds', () => {
             [ungrouped.id]: [ungroupedWt]
           },
           visibleWorktrees: [],
-          filterRepoIds: []
+          filterRepoIds: [],
+          startupWorktreeRefreshCompleted: true
         })
       )
     ).toEqual([grouped.id])

--- a/src/renderer/src/components/sidebar/empty-project-placeholder-repos.ts
+++ b/src/renderer/src/components/sidebar/empty-project-placeholder-repos.ts
@@ -8,6 +8,8 @@ export function getEmptyProjectPlaceholderRepoIds(args: {
   worktreesByRepo: Readonly<Record<string, readonly Worktree[] | undefined>>
   visibleWorktrees: readonly Worktree[]
   filterRepoIds: readonly string[]
+  /** Startup's all-host worktree scan has settled (or bailed out). */
+  startupWorktreeRefreshCompleted: boolean
 }): Set<string> {
   if (args.groupBy !== 'repo') {
     return new Set()
@@ -20,7 +22,16 @@ export function getEmptyProjectPlaceholderRepoIds(args: {
     if (filterSet && !filterSet.has(repo.id)) {
       continue
     }
-    const hasNoWorktrees = (args.worktreesByRepo[repo.id]?.length ?? 0) === 0
+    const worktrees = args.worktreesByRepo[repo.id]
+    // Why: `undefined` is "not scanned yet", `[]` is "scanned, genuinely empty".
+    // Reading the first as empty paints every repo as a project header at launch,
+    // then walks the whole list back as scans land, twice (#16247). Once startup
+    // settles, fall back to the optimistic read so a repo whose scan failed —
+    // disconnected SSH, a throwing provider — still keeps a reachable header.
+    if (worktrees === undefined && !args.startupWorktreeRefreshCompleted) {
+      continue
+    }
+    const hasNoWorktrees = (worktrees?.length ?? 0) === 0
     // Why: workspace filters hide cards, but must not rewrite the visible
     // membership of a persisted Project Group. #8865
     const isFilteredProjectGroupMember = repo.projectGroupId != null && !visibleRepoIds.has(repo.id)

--- a/src/renderer/src/components/sidebar/empty-project-placeholder-repos.ts
+++ b/src/renderer/src/components/sidebar/empty-project-placeholder-repos.ts
@@ -23,11 +23,8 @@ export function getEmptyProjectPlaceholderRepoIds(args: {
       continue
     }
     const worktrees = args.worktreesByRepo[repo.id]
-    // Why: `undefined` is "not scanned yet", `[]` is "scanned, genuinely empty".
-    // Reading the first as empty paints every repo as a project header at launch,
-    // then walks the whole list back as scans land, twice (#16247). Once startup
-    // settles, fall back to the optimistic read so a repo whose scan failed —
-    // disconnected SSH, a throwing provider — still keeps a reachable header.
+    // `undefined` is "not scanned yet", `[]` is "scanned, empty" (#16247). After
+    // startup, fall back so a repo whose scan failed still keeps a header.
     if (worktrees === undefined && !args.startupWorktreeRefreshCompleted) {
       continue
     }

--- a/src/renderer/src/components/sidebar/restoring-workspace-visible-under-hide-sleeping.test.ts
+++ b/src/renderer/src/components/sidebar/restoring-workspace-visible-under-hide-sleeping.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest'
+import { computeVisibleWorktreeIds } from './visible-worktrees'
+import type { Repo } from '../../../../shared/repo-types'
+import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import { LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
+
+/**
+ * Repro for #16247 — the sidebar walks its project list back for seconds after launch.
+ *
+ * Startup hydrates `tabsByWorktree` from the persisted session but does not publish
+ * any `ptyId` until `reconnectPersistedTerminals` finishes. For that window every
+ * restored workspace reads as sleeping, so under "Hide sleeping" its row — and its
+ * whole project header, if it was the only row — vanishes and then returns.
+ *
+ * `pendingReconnectWorktreeIds` is the session's own list of workspaces that were
+ * awake at shutdown, and reconnect drains it, so it is exactly the set that must
+ * survive the sweep while their PTYs are in flight.
+ */
+
+function makeRepo(id: string): Repo {
+  return { id, path: `/${id}`, displayName: id, badgeColor: '#000', addedAt: 0 }
+}
+
+function makeTab(id: string, worktreeId: string, ptyId: string | null): TerminalTab {
+  return {
+    id,
+    ptyId,
+    worktreeId,
+    title: id,
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 0
+  }
+}
+
+function makeWorktree(id: string): Worktree {
+  return {
+    id,
+    repoId: 'repo1',
+    path: `/tmp/${id}`,
+    head: 'abc123',
+    branch: `refs/heads/${id}`,
+    isBare: false,
+    isMainWorktree: false,
+    displayName: id,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0
+  }
+}
+
+const repoMap = new Map<string, Repo>([['repo1', makeRepo('repo1')]])
+const restoring = makeWorktree('restoring')
+const slept = makeWorktree('slept')
+const worktreesByRepo = { repo1: [restoring, slept] }
+const sortedIds = ['restoring', 'slept']
+
+type VisibleOptions = Parameters<typeof computeVisibleWorktreeIds>[2]
+
+/**
+ * The exact shape startup produces mid-reconnect: session tabs hydrated, no ptyId
+ * republished yet, so both rows look identical to the sweep.
+ */
+function midReconnectOptions(overrides: Partial<VisibleOptions> = {}): VisibleOptions {
+  return {
+    filterRepoIds: [],
+    showSleepingWorkspaces: false,
+    tabsByWorktree: {
+      restoring: [makeTab('tab-restoring', 'restoring', null)],
+      slept: [makeTab('tab-slept', 'slept', null)]
+    },
+    ptyIdsByTabId: { 'tab-restoring': [], 'tab-slept': [] },
+    browserTabsByWorktree: {},
+    worktreeIdsWithLiveAgent: new Set(),
+    pendingReconnectWorktreeIds: new Set(),
+    hideDefaultBranchWorkspace: false,
+    hideAutomationGeneratedWorkspaces: false,
+    hideCliCreatedWorkspaces: false,
+    hideDetachedHeadWorkspaces: false,
+    hideWorkspacesFromOtherDevices: false,
+    pairedDeviceIdsByEnvironment: new Map(),
+    repoMap,
+    workspaceHostScope: 'all',
+    defaultHostId: LOCAL_EXECUTION_HOST_ID,
+    worktreeLineageById: {},
+    ...overrides
+  }
+}
+
+describe('startup reconnect exemption under Hide sleeping', () => {
+  it('keeps a workspace awaiting reconnect while dropping a genuinely slept one', () => {
+    expect(
+      computeVisibleWorktreeIds(
+        worktreesByRepo,
+        sortedIds,
+        midReconnectOptions({ pendingReconnectWorktreeIds: new Set(['restoring']) })
+      )
+    ).toEqual(['restoring'])
+  })
+
+  it('drops both rows once reconnect drains the pending set without a live pty', () => {
+    expect(computeVisibleWorktreeIds(worktreesByRepo, sortedIds, midReconnectOptions())).toEqual([])
+  })
+
+  it('does not change membership when the reconnected pty lands', () => {
+    const duringReconnect = computeVisibleWorktreeIds(
+      worktreesByRepo,
+      sortedIds,
+      midReconnectOptions({ pendingReconnectWorktreeIds: new Set(['restoring']) })
+    )
+    const afterReconnect = computeVisibleWorktreeIds(
+      worktreesByRepo,
+      sortedIds,
+      midReconnectOptions({
+        ptyIdsByTabId: { 'tab-restoring': ['pty-1'], 'tab-slept': [] }
+      })
+    )
+
+    expect(duringReconnect).toEqual(['restoring'])
+    // Why this is the whole point: the row must not blink out between the exemption
+    // expiring and the real pty arriving.
+    expect(afterReconnect).toEqual(duringReconnect)
+  })
+
+  it('leaves membership alone when Hide sleeping is off', () => {
+    expect(
+      computeVisibleWorktreeIds(
+        worktreesByRepo,
+        sortedIds,
+        midReconnectOptions({
+          showSleepingWorkspaces: true,
+          pendingReconnectWorktreeIds: new Set(['restoring'])
+        })
+      )
+    ).toEqual(sortedIds)
+  })
+})

--- a/src/renderer/src/components/sidebar/restoring-workspace-visible-under-hide-sleeping.test.ts
+++ b/src/renderer/src/components/sidebar/restoring-workspace-visible-under-hide-sleeping.test.ts
@@ -6,16 +6,9 @@ import type { Worktree } from '../../../../shared/worktree/types'
 import { LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
 
 /**
- * Repro for #16247 — the sidebar walks its project list back for seconds after launch.
- *
- * Startup hydrates `tabsByWorktree` from the persisted session but does not publish
- * any `ptyId` until `reconnectPersistedTerminals` finishes. For that window every
- * restored workspace reads as sleeping, so under "Hide sleeping" its row — and its
- * whole project header, if it was the only row — vanishes and then returns.
- *
- * `pendingReconnectWorktreeIds` is the session's own list of workspaces that were
- * awake at shutdown, and reconnect drains it, so it is exactly the set that must
- * survive the sweep while their PTYs are in flight.
+ * Repro for #16247. Startup hydrates tabs before reconnect publishes any ptyId, so
+ * under "Hide sleeping" every restored workspace briefly reads as asleep and its row
+ * — and its project header — vanishes and returns.
  */
 
 function makeRepo(id: string): Repo {
@@ -65,10 +58,7 @@ const sortedIds = ['restoring', 'slept']
 
 type VisibleOptions = Parameters<typeof computeVisibleWorktreeIds>[2]
 
-/**
- * The exact shape startup produces mid-reconnect: session tabs hydrated, no ptyId
- * republished yet, so both rows look identical to the sweep.
- */
+/** Mid-reconnect: tabs hydrated, no ptyId yet, so both rows look alike to the sweep. */
 function midReconnectOptions(overrides: Partial<VisibleOptions> = {}): VisibleOptions {
   return {
     filterRepoIds: [],
@@ -125,8 +115,7 @@ describe('startup reconnect exemption under Hide sleeping', () => {
     )
 
     expect(duringReconnect).toEqual(['restoring'])
-    // Why this is the whole point: the row must not blink out between the exemption
-    // expiring and the real pty arriving.
+    // The row must not blink out between the exemption expiring and the pty landing.
     expect(afterReconnect).toEqual(duringReconnect)
   })
 

--- a/src/renderer/src/components/sidebar/use-visible-workspace-kanban-worktree-ids.ts
+++ b/src/renderer/src/components/sidebar/use-visible-workspace-kanban-worktree-ids.ts
@@ -63,8 +63,7 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
         )
       : EMPTY_WORKTREE_ID_SET
   }, [agentStatusEpoch, showSleepingWorkspaces, tabsByWorktree])
-  // Why: mirrors the sidebar's startup-reconnect exemption so the board does not
-  // disagree about which workspaces are asleep during restore. #16247
+  // Same startup-reconnect exemption as the sidebar, so the two agree. #16247
   const pendingReconnectWorktreeIdList = useAppStore((s) =>
     showSleepingWorkspaces ? null : s.pendingReconnectWorktreeIds
   )

--- a/src/renderer/src/components/sidebar/use-visible-workspace-kanban-worktree-ids.ts
+++ b/src/renderer/src/components/sidebar/use-visible-workspace-kanban-worktree-ids.ts
@@ -63,6 +63,18 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
         )
       : EMPTY_WORKTREE_ID_SET
   }, [agentStatusEpoch, showSleepingWorkspaces, tabsByWorktree])
+  // Why: mirrors the sidebar's startup-reconnect exemption so the board does not
+  // disagree about which workspaces are asleep during restore. #16247
+  const pendingReconnectWorktreeIdList = useAppStore((s) =>
+    showSleepingWorkspaces ? null : s.pendingReconnectWorktreeIds
+  )
+  const pendingReconnectWorktreeIds = useMemo(
+    () =>
+      pendingReconnectWorktreeIdList?.length
+        ? new Set(pendingReconnectWorktreeIdList)
+        : EMPTY_WORKTREE_ID_SET,
+    [pendingReconnectWorktreeIdList]
+  )
 
   return useMemo(() => {
     // Why: the board has its own status ordering, but visibility must match
@@ -76,6 +88,7 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
         ptyIdsByTabId,
         browserTabsByWorktree,
         worktreeIdsWithLiveAgent,
+        pendingReconnectWorktreeIds,
         hideDefaultBranchWorkspace,
         hideAutomationGeneratedWorkspaces,
         hideCliCreatedWorkspaces,
@@ -115,6 +128,7 @@ export function useVisibleWorkspaceKanbanWorktreeIds({
     showSleepingWorkspaces,
     tabsByWorktree,
     worktreeIdsWithLiveAgent,
+    pendingReconnectWorktreeIds,
     worktreesByRepo
   ])
 }

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -79,6 +79,7 @@ function visibleOptions(overrides: Partial<VisibleOptions> = {}): VisibleOptions
     ptyIdsByTabId: {},
     browserTabsByWorktree: {},
     worktreeIdsWithLiveAgent: new Set(),
+    pendingReconnectWorktreeIds: new Set(),
     hideDefaultBranchWorkspace: false,
     hideAutomationGeneratedWorkspaces: false,
     hideCliCreatedWorkspaces: false,

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -68,11 +68,7 @@ type VisibleWorktreeOptions = {
   ptyIdsByTabId: Record<string, string[]> | null
   browserTabsByWorktree?: Record<string, { id: string }[]> | null
   worktreeIdsWithLiveAgent: ReadonlySet<string>
-  /**
-   * Workspaces whose persisted terminals are still being reattached by startup
-   * reconnect. They were awake at shutdown, so the sleeping sweep must not drop
-   * them while `ptyIdsByTabId` is still filling in. #16247
-   */
+  /** Awake at shutdown, pty not reattached yet; the sleeping sweep must keep them. #16247 */
   pendingReconnectWorktreeIds: ReadonlySet<string>
   hideDefaultBranchWorkspace: boolean
   hideAutomationGeneratedWorkspaces: boolean

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -68,6 +68,12 @@ type VisibleWorktreeOptions = {
   ptyIdsByTabId: Record<string, string[]> | null
   browserTabsByWorktree?: Record<string, { id: string }[]> | null
   worktreeIdsWithLiveAgent: ReadonlySet<string>
+  /**
+   * Workspaces whose persisted terminals are still being reattached by startup
+   * reconnect. They were awake at shutdown, so the sleeping sweep must not drop
+   * them while `ptyIdsByTabId` is still filling in. #16247
+   */
+  pendingReconnectWorktreeIds: ReadonlySet<string>
   hideDefaultBranchWorkspace: boolean
   hideAutomationGeneratedWorkspaces: boolean
   hideCliCreatedWorkspaces: boolean
@@ -152,7 +158,8 @@ export function computeVisibleWorktrees(
           opts.tabsByWorktree,
           opts.ptyIdsByTabId,
           opts.browserTabsByWorktree,
-          opts.worktreeIdsWithLiveAgent
+          opts.worktreeIdsWithLiveAgent,
+          opts.pendingReconnectWorktreeIds
         )
     )
   }
@@ -310,6 +317,7 @@ export function getVisibleWorktreeIds(): string[] {
       state.tabsByWorktree,
       Date.now()
     ),
+    pendingReconnectWorktreeIds: new Set(state.pendingReconnectWorktreeIds),
     hideDefaultBranchWorkspace: state.hideDefaultBranchWorkspace,
     hideAutomationGeneratedWorkspaces: state.hideAutomationGeneratedWorkspaces,
     hideCliCreatedWorkspaces: state.hideCliCreatedWorkspaces,

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-section-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-section-rows.ts
@@ -70,6 +70,7 @@ function collectRenderedSidebarRowKeys(sectionRows: ReturnType<typeof addHostSec
 export function useSidebarSectionRows(args: SectionRowsArgs) {
   const { repos, worktrees, repoMap, effectiveCollapsedGroups, defaultHostId } = args
   const worktreesByRepo = useAppStore((s) => s.worktreesByRepo)
+  const startupWorktreeRefreshCompleted = useAppStore((s) => s.startupWorktreeRefreshCompleted)
   const sshTargetLabels = useAppStore((s) => s.sshTargetLabels)
   const sshConnectionStates = useAppStore((s) => s.sshConnectionStates)
   const runtimeEnvironments = useAppStore((s) => s.runtimeEnvironments)
@@ -90,9 +91,17 @@ export function useSidebarSectionRows(args: SectionRowsArgs) {
         repos: args.visibleReposForRows,
         worktreesByRepo,
         visibleWorktrees: worktrees,
-        filterRepoIds: args.filterRepoIds
+        filterRepoIds: args.filterRepoIds,
+        startupWorktreeRefreshCompleted
       }),
-    [args.filterRepoIds, args.groupBy, args.visibleReposForRows, worktrees, worktreesByRepo]
+    [
+      args.filterRepoIds,
+      args.groupBy,
+      args.visibleReposForRows,
+      startupWorktreeRefreshCompleted,
+      worktrees,
+      worktreesByRepo
+    ]
   )
 
   // Why: subscribe on a flat key array (useShallow) so progress ticks don't rebuild the whole row model.

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-visible-worktrees.ts
@@ -65,8 +65,7 @@ export function useVisibleSidebarWorktrees(args: {
   const browserTabsByWorktree = useAppStore((s) =>
     !showSleepingWorkspaces ? getVisibleWorktreeBrowserActivityTabs(s.browserTabsByWorktree) : null
   )
-  // Why: startup reconnect drains this list, so it is empty for the whole steady state
-  // and only exempts the workspaces that were provably awake at shutdown. #16247
+  // Drained by startup reconnect, so empty in the steady state. #16247
   const pendingReconnectWorktreeIdList = useAppStore((s) =>
     showSleepingWorkspaces ? null : s.pendingReconnectWorktreeIds
   )

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-visible-worktrees.ts
@@ -65,6 +65,18 @@ export function useVisibleSidebarWorktrees(args: {
   const browserTabsByWorktree = useAppStore((s) =>
     !showSleepingWorkspaces ? getVisibleWorktreeBrowserActivityTabs(s.browserTabsByWorktree) : null
   )
+  // Why: startup reconnect drains this list, so it is empty for the whole steady state
+  // and only exempts the workspaces that were provably awake at shutdown. #16247
+  const pendingReconnectWorktreeIdList = useAppStore((s) =>
+    showSleepingWorkspaces ? null : s.pendingReconnectWorktreeIds
+  )
+  const pendingReconnectWorktreeIds = useMemo(
+    () =>
+      pendingReconnectWorktreeIdList?.length
+        ? new Set(pendingReconnectWorktreeIdList)
+        : EMPTY_WORKTREE_ID_SET,
+    [pendingReconnectWorktreeIdList]
+  )
 
   const recomputedVisibleWorktrees = useMemo(() => {
     void agentStatusEpoch
@@ -82,6 +94,7 @@ export function useVisibleSidebarWorktrees(args: {
             tabsByWorktree,
             Date.now()
           ),
+      pendingReconnectWorktreeIds,
       hideDefaultBranchWorkspace,
       hideAutomationGeneratedWorkspaces,
       hideCliCreatedWorkspaces,
@@ -116,6 +129,7 @@ export function useVisibleSidebarWorktrees(args: {
     tabsByWorktree,
     ptyIdsByTabId,
     browserTabsByWorktree,
+    pendingReconnectWorktreeIds,
     sortedIds,
     worktreeLineageById,
     worktreesByRepo,

--- a/src/renderer/src/lib/worktree-activity-state.test.ts
+++ b/src/renderer/src/lib/worktree-activity-state.test.ts
@@ -123,6 +123,48 @@ describe('worktree activity state', () => {
       isInactiveWorkspace('wt-1', { 'wt-1': [makeTab('tab-1')] }, { 'tab-1': [] }, {}, new Set())
     ).toBe(true)
   })
+
+  it('keeps a workspace awake while startup reconnect still owes it a PTY', () => {
+    // Why: startup hydrates tabs before reconnect restores ptyIds, so this exact
+    // shape — tabs present, no live pty — is every restored workspace for a
+    // second. Without the exemption each one flickers out of the sidebar. #16247
+    expect(
+      isInactiveWorkspace(
+        'wt-1',
+        { 'wt-1': [makeTab('tab-1')] },
+        { 'tab-1': [] },
+        {},
+        new Set(),
+        new Set(['wt-1'])
+      )
+    ).toBe(false)
+  })
+
+  it('does not exempt a workspace outside the pending reconnect set', () => {
+    expect(
+      isInactiveWorkspace(
+        'wt-2',
+        { 'wt-2': [makeTab('tab-2')] },
+        { 'tab-2': [] },
+        {},
+        new Set(),
+        new Set(['wt-1'])
+      )
+    ).toBe(true)
+  })
+
+  it('sleeps again once reconnect drains the pending set', () => {
+    expect(
+      isInactiveWorkspace(
+        'wt-1',
+        { 'wt-1': [makeTab('tab-1')] },
+        { 'tab-1': [] },
+        {},
+        new Set(),
+        new Set()
+      )
+    ).toBe(true)
+  })
 })
 
 describe('getWorktreeIdsWithLiveAgent', () => {

--- a/src/renderer/src/lib/worktree-activity-state.test.ts
+++ b/src/renderer/src/lib/worktree-activity-state.test.ts
@@ -125,9 +125,7 @@ describe('worktree activity state', () => {
   })
 
   it('keeps a workspace awake while startup reconnect still owes it a PTY', () => {
-    // Why: startup hydrates tabs before reconnect restores ptyIds, so this exact
-    // shape — tabs present, no live pty — is every restored workspace for a
-    // second. Without the exemption each one flickers out of the sidebar. #16247
+    // Tabs present, no live pty: every restored workspace for a second. #16247
     expect(
       isInactiveWorkspace(
         'wt-1',

--- a/src/renderer/src/lib/worktree-activity-state.ts
+++ b/src/renderer/src/lib/worktree-activity-state.ts
@@ -76,9 +76,8 @@ export function hasActiveWorkspaceActivity(
   // Why: a running agent keeps the workspace visible through brief PTY gaps
   // such as an SSH reconnect or an unmounted remote pane. #7197
   const hasLiveAgent = worktreeIdsWithLiveAgent.has(worktreeId)
-  // Why: startup hydrates tabs before reconnect restores their PTYs, so a workspace
-  // that was awake at shutdown reads as asleep for that window and flickers out of
-  // the sidebar and back. reconnectPersistedTerminals drains this set. #16247
+  // Startup hydrates tabs before reconnect restores their ptyIds; without this a
+  // workspace awake at shutdown reads as asleep until then. #16247
   const isReattaching = pendingReconnectWorktreeIds.has(worktreeId)
   return hasLiveTerminal || hasBrowser || hasLiveAgent || isReattaching
 }

--- a/src/renderer/src/lib/worktree-activity-state.ts
+++ b/src/renderer/src/lib/worktree-activity-state.ts
@@ -9,6 +9,8 @@ import { resolveAgentStatusWorktreeId } from './agent-status-worktree-attributio
 type TerminalLikeTab = Pick<TerminalTab, 'id'>
 type BrowserLikeTab = { id: string }
 
+const EMPTY_WORKTREE_ID_SET: ReadonlySet<string> = new Set()
+
 type TabsByWorktree = Record<string, readonly TerminalLikeTab[]>
 type PtyIdsByTabId = Record<string, string[]>
 type BrowserTabsByWorktree = Record<string, readonly BrowserLikeTab[]>
@@ -64,7 +66,8 @@ export function hasActiveWorkspaceActivity(
   tabsByWorktree: TabsByWorktree | null | undefined,
   ptyIdsByTabId: PtyIdsByTabId | null | undefined,
   browserTabsByWorktree: BrowserTabsByWorktree | null | undefined,
-  worktreeIdsWithLiveAgent: ReadonlySet<string>
+  worktreeIdsWithLiveAgent: ReadonlySet<string>,
+  pendingReconnectWorktreeIds: ReadonlySet<string> = EMPTY_WORKTREE_ID_SET
 ): boolean {
   const tabs = tabsByWorktree?.[worktreeId] ?? []
   const hasLiveTerminal =
@@ -73,7 +76,11 @@ export function hasActiveWorkspaceActivity(
   // Why: a running agent keeps the workspace visible through brief PTY gaps
   // such as an SSH reconnect or an unmounted remote pane. #7197
   const hasLiveAgent = worktreeIdsWithLiveAgent.has(worktreeId)
-  return hasLiveTerminal || hasBrowser || hasLiveAgent
+  // Why: startup hydrates tabs before reconnect restores their PTYs, so a workspace
+  // that was awake at shutdown reads as asleep for that window and flickers out of
+  // the sidebar and back. reconnectPersistedTerminals drains this set. #16247
+  const isReattaching = pendingReconnectWorktreeIds.has(worktreeId)
+  return hasLiveTerminal || hasBrowser || hasLiveAgent || isReattaching
 }
 
 export function isInactiveWorkspace(
@@ -81,13 +88,15 @@ export function isInactiveWorkspace(
   tabsByWorktree: TabsByWorktree | null | undefined,
   ptyIdsByTabId: PtyIdsByTabId | null | undefined,
   browserTabsByWorktree: BrowserTabsByWorktree | null | undefined,
-  worktreeIdsWithLiveAgent: ReadonlySet<string>
+  worktreeIdsWithLiveAgent: ReadonlySet<string>,
+  pendingReconnectWorktreeIds: ReadonlySet<string> = EMPTY_WORKTREE_ID_SET
 ): boolean {
   return !hasActiveWorkspaceActivity(
     worktreeId,
     tabsByWorktree,
     ptyIdsByTabId,
     browserTabsByWorktree,
-    worktreeIdsWithLiveAgent
+    worktreeIdsWithLiveAgent,
+    pendingReconnectWorktreeIds
   )
 }

--- a/src/renderer/src/store/slices/store-session-terminal-reconnect.test.ts
+++ b/src/renderer/src/store/slices/store-session-terminal-reconnect.test.ts
@@ -96,6 +96,9 @@ describe('reconnectPersistedTerminals', () => {
         ptyIdsByTabId: s.ptyIdsByTabId,
         browserTabsByWorktree: s.browserTabsByWorktree,
         worktreeIdsWithLiveAgent: new Set(),
+        // Why: reconnect has drained this above; a regression that leaves it
+        // populated would wrongly exempt wt2 from the sleeping sweep.
+        pendingReconnectWorktreeIds: new Set(s.pendingReconnectWorktreeIds),
         hideDefaultBranchWorkspace: false,
         hideAutomationGeneratedWorkspaces: false,
         hideCliCreatedWorkspaces: false,
@@ -445,6 +448,9 @@ describe('reconnectPersistedTerminals', () => {
         ptyIdsByTabId: s.ptyIdsByTabId,
         browserTabsByWorktree: s.browserTabsByWorktree,
         worktreeIdsWithLiveAgent: new Set(),
+        // Why: reconnect has drained this above; a regression that leaves it
+        // populated would wrongly exempt wt2 from the sleeping sweep.
+        pendingReconnectWorktreeIds: new Set(s.pendingReconnectWorktreeIds),
         hideDefaultBranchWorkspace: false,
         hideAutomationGeneratedWorkspaces: false,
         hideCliCreatedWorkspaces: false,

--- a/src/renderer/src/store/slices/store-session-terminal-reconnect.test.ts
+++ b/src/renderer/src/store/slices/store-session-terminal-reconnect.test.ts
@@ -96,8 +96,7 @@ describe('reconnectPersistedTerminals', () => {
         ptyIdsByTabId: s.ptyIdsByTabId,
         browserTabsByWorktree: s.browserTabsByWorktree,
         worktreeIdsWithLiveAgent: new Set(),
-        // Why: reconnect has drained this above; a regression that leaves it
-        // populated would wrongly exempt wt2 from the sleeping sweep.
+        // Drained above; if a regression leaves it populated, wt2 wrongly survives.
         pendingReconnectWorktreeIds: new Set(s.pendingReconnectWorktreeIds),
         hideDefaultBranchWorkspace: false,
         hideAutomationGeneratedWorkspaces: false,
@@ -448,8 +447,7 @@ describe('reconnectPersistedTerminals', () => {
         ptyIdsByTabId: s.ptyIdsByTabId,
         browserTabsByWorktree: s.browserTabsByWorktree,
         worktreeIdsWithLiveAgent: new Set(),
-        // Why: reconnect has drained this above; a regression that leaves it
-        // populated would wrongly exempt wt2 from the sleeping sweep.
+        // Drained above; if a regression leaves it populated, wt2 wrongly survives.
         pendingReconnectWorktreeIds: new Set(s.pendingReconnectWorktreeIds),
         hideDefaultBranchWorkspace: false,
         hideAutomationGeneratedWorkspaces: false,


### PR DESCRIPTION
## What this fixes

On cold launch the sidebar painted **every imported project** as a header row — including projects with nothing but sleeping workspaces — and then spent several seconds withdrawing them as data arrived. With 28 projects and **Hide sleeping** on, the list went `28 → 9 → 8 → 10 → 11 → 10 → 3` before settling on 3.

The first paint was not a partial render that filled in. It was a wrong render that had to be walked back, twice — once for local repos and again when the deferred remote/runtime catalog landed.

Fixes #16247

Out of scope here: row **content** convergence — cards painted from provisional (non-authoritative) metadata can still visibly repaint once their scan lands, tracked in #20119.

## Root cause

Two places rendered *unknown* state as a confident answer.

**1. "Not scanned yet" was read as "genuinely empty".**

`worktreesByRepo[repoId]` is `undefined` until that repo's git scan lands and `[]` once it has. The empty-project placeholder pass collapsed the two:

```ts
const hasNoWorktrees = (args.worktreesByRepo[repo.id]?.length ?? 0) === 0
```

Every not-yet-scanned repo therefore became an "empty project" and got a header. `worktree-grouping.ts` already knew this was happening — *"repos can arrive before worktree scans"*.

Placeholders now require a settled scan. After startup finishes the optimistic read returns, so a repo whose scan **failed** — disconnected SSH, a throwing provider — still keeps a reachable header instead of vanishing.

**2. "PTY hasn't reattached yet" was read as "workspace is asleep".**

`isInactiveWorkspace` defines sleeping as *no live pty*, but startup hydrates `tabsByWorktree` from the persisted session well before `reconnect-terminals` republishes any `ptyId`. For that window every restored workspace read as asleep, so its row — and its project header, if it was the only row — dropped out and came back.

The sweep now exempts `pendingReconnectWorktreeIds`: the session's own list of workspaces that were awake at shutdown, populated at hydration and drained by `reconnectPersistedTerminals`. It is empty for the entire steady state, so this narrows nothing after boot.

The jump palette and the workspace board apply the same exemption — those three surfaces re-implement one filter pass, and a second copy is how they drift.

## Measurement

Same machine, same build, same real 28-project profile (192 workspaces, 50 with terminal tabs, 2 awake at shutdown, `Hide sleeping` on). Only the fix toggled. Sidebar sampled through CDP.

| | peak headers | shrink events | settled |
|---|---|---|---|
| before | 28 | 4 | 3 |
| after | **3** | **0** | 3 |

Before, at 5 Hz:

```
t=4.58s   28 headers   <- every project painted at once
t=4.94s    9
t=5.28s    8
t=5.58s   10  (2 cards)
t=5.85s   11
t=7.03s   10
t=7.58s    3  <- settles
```

After, re-sampled at 40 Hz to look for a sub-frame flash:

```
t=0.27s → 3.85s   sidebar not mounted   0 headers
t=4.06s → 15.0s   sidebar mounted       3 headers, 3 cards
```

One transition, straight to the correct list. Same final membership, reached without painting anything that then has to be removed.

"Shrink events" counts samples where the header count dropped — each one is a row the user watched appear and then disappear.

## Screenshots

Cold launch, recorded on a synthetic profile with the same shape as the reporting user's real one — 28 projects, one workspace each, 2 awake at shutdown, **Hide sleeping** on. Both clips start the instant the window appears.

**Before** — every project painted at once, then withdrawn over the next ~3s:

<img width="1400" height="823" alt="sidebar-startup-before" src="https://github.com/user-attachments/assets/9a240d38-46e6-416c-a9d0-8b8c1db68a0e" />

**After** — the list appears once, already correct, and never shrinks:

<img width="1400" height="823" alt="sidebar-startup-after" src="https://github.com/user-attachments/assets/741066b4-89d7-4c79-bff8-dc7368aa1fc9" />

Final membership is identical in both; only the path to it differs.

## Tests

- `restoring-workspace-visible-under-hide-sleeping.test.ts` (new) — the mid-reconnect shape end-to-end: a workspace awaiting reconnect survives while a genuinely slept sibling is dropped; membership is **unchanged** when the real pty lands (the row must not blink between the exemption expiring and the pty arriving); the sweep is inert when Hide sleeping is off.
- `empty-project-placeholder-repos.test.ts` — unscanned repos produce no placeholder mid-startup; a scanned-empty repo still does; a repo with no key at all recovers its header once startup settles; plus a monotonic-convergence case asserting the set only grows.
- `worktree-activity-state.test.ts` — the pending set exempts only its own members, and stops exempting once drained.
- `store-session-terminal-reconnect.test.ts` — now asserts against the real drained `pendingReconnectWorktreeIds` rather than a hardcoded empty set, so a regression that leaves it populated fails here.

`pnpm lint` · `pnpm typecheck` · `pnpm test` (57,019 passed, 0 failed) · `pnpm build` all pass.

## AI agent review

- **Cross-platform** — pure renderer selector logic. No paths, no shell, no platform branches.
- **SSH / remote** — the post-startup fallback exists for this case: a disconnected-SSH repo never gets a `worktreesByRepo` key, and would have been hidden permanently by a naive `undefined` check. It keeps its header once `startupWorktreeRefreshCompleted` flips, which is set in a `finally` and by degraded-startup recovery, so it cannot be stranded.
- **Remote wire** — none. No RPC params, stream frames, or published content changed.
- **Folder workspaces** — the placeholder pass is keyed on repos and already returns early outside `groupBy: 'repo'`; folder workspaces flow through their own row path, untouched.
- **Agents / integrations** — the live-agent exemption (#7197) is untouched; the reconnect exemption is a separate additional term.
- **Performance** — strictly less work during startup (fewer placeholder rows to build and render). The new set is read from existing store state behind the `showSleepingWorkspaces` guard, so it costs nothing when Hide sleeping is off, and is empty in the steady state.
- **UI quality** — the point of the change. No new styling.
- **Security** — none; no new data crosses a boundary.

## Risk

The behavior change is confined to startup. After `startupWorktreeRefreshCompleted`, placeholder selection is byte-identical to before, and `pendingReconnectWorktreeIds` is empty so the sweep is byte-identical too. A user who never restarts Orca sees no difference at all.


