### PR TITLE
feat(terminal): add Copy Session ID to the terminal context menu

### DIFF
--- a/src/renderer/src/components/native-chat/use-native-chat-context-menu.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-context-menu.tsx
@@ -58,6 +58,8 @@ export type NativeChatContextMenuActions = {
   onForkAgentSession: () => void
   onSetTitle: () => void
   onCopyTerminalId: () => void
+  canCopyAgentSessionId: boolean
+  onCopyAgentSessionId: () => void
   onCopyPaneId: () => void
   canClosePane: boolean
   onClosePane: () => void
@@ -77,6 +79,8 @@ export const emptyNativeChatContextMenuActions: Omit<NativeChatContextMenuAction
   onForkAgentSession: () => {},
   onSetTitle: () => {},
   onCopyTerminalId: () => {},
+  canCopyAgentSessionId: false,
+  onCopyAgentSessionId: () => {},
   onCopyPaneId: () => {},
   canClosePane: false,
   onClosePane: () => {}
@@ -237,6 +241,15 @@ export function useNativeChatContextMenu({
               'Set Title…'
             )}
           </DropdownMenuItem>
+          {actions.canCopyAgentSessionId ? (
+            <DropdownMenuItem onSelect={actions.onCopyAgentSessionId}>
+              <Copy />
+              {translate(
+                'auto.components.terminal.pane.TerminalContextMenu.copySessionId',
+                'Copy Session ID'
+              )}
+            </DropdownMenuItem>
+          ) : null}
           <DropdownMenuItem onSelect={actions.onCopyTerminalId}>
             <Copy />
             {translate(

--- a/src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalContextMenu.test.tsx
@@ -94,6 +94,8 @@ function renderMenu(overrides: Record<string, unknown> = {}): string {
     onClearPaneTitle: vi.fn(),
     canClearPaneTitle: false,
     onCopyTerminalId: vi.fn(),
+    canCopyAgentSessionId: false,
+    onCopyAgentSessionId: vi.fn(),
     onCopyPaneId: vi.fn(),
     ...overrides
   }
@@ -125,6 +127,24 @@ describe('TerminalContextMenu', () => {
     expect(onCopyAgentSessionContext).toHaveBeenCalledTimes(1)
     // Why: copying context must not go through the fork dialog path.
     expect(onForkAgentSession).not.toHaveBeenCalled()
+  })
+
+  it('shows Copy Session ID only for panes whose agent reported one (issue #16261)', () => {
+    renderMenu()
+    expect(
+      items.list.find((item) => childrenText(item.children) === 'Copy Session ID')
+    ).toBeUndefined()
+
+    items.list = []
+    const onCopyAgentSessionId = vi.fn()
+    renderMenu({ canCopyAgentSessionId: true, onCopyAgentSessionId })
+    const sessionIdItem = items.list.find(
+      (item) => childrenText(item.children) === 'Copy Session ID'
+    )
+    expect(sessionIdItem).toBeDefined()
+
+    sessionIdItem?.onSelect?.()
+    expect(onCopyAgentSessionId).toHaveBeenCalledTimes(1)
   })
 
   it('shows new-session continuation only for eligible agent panes', () => {

--- a/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalContextMenu.tsx
@@ -71,6 +71,8 @@ type TerminalContextMenuProps = {
   onClearPaneTitle: () => void
   canClearPaneTitle: boolean
   onCopyTerminalId: () => void
+  canCopyAgentSessionId: boolean
+  onCopyAgentSessionId: () => void
   onCopyPaneId: () => void
 }
 
@@ -110,6 +112,8 @@ export default function TerminalContextMenu({
   onClearPaneTitle,
   canClearPaneTitle,
   onCopyTerminalId,
+  canCopyAgentSessionId,
+  onCopyAgentSessionId,
   onCopyPaneId
 }: TerminalContextMenuProps): React.JSX.Element {
   // Why: one primary binding prevents Windows/Linux shortcut labels from forcing row wraps.
@@ -299,6 +303,15 @@ export default function TerminalContextMenu({
             {showClearPaneTitleShortcut ? (
               <DropdownMenuShortcut>{shortcuts.clearPaneTitle}</DropdownMenuShortcut>
             ) : null}
+          </DropdownMenuItem>
+        ) : null}
+        {canCopyAgentSessionId ? (
+          <DropdownMenuItem onSelect={onCopyAgentSessionId}>
+            <Copy />
+            {translate(
+              'auto.components.terminal.pane.TerminalContextMenu.copySessionId',
+              'Copy Session ID'
+            )}
           </DropdownMenuItem>
         ) : null}
         <DropdownMenuItem onSelect={onCopyTerminalId}>

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -200,6 +200,7 @@ import { TerminalRemoteRuntimeReconnectBanner } from './TerminalRemoteRuntimeRec
 import { selectTerminalTabAgentTypesByLeaf } from './terminal-tab-agent-type-index'
 import { resolveProtectedMultilinePasteOptionsForPane } from './terminal-agent-paste-bracketing'
 import { resolveTerminalInputHostPlatform } from './terminal-input-host-platform'
+import { readPaneAgentSessionId } from './terminal-agent-session-id-copy'
 import { canContinueAgentSessionInNewSession } from './terminal-agent-session-continuation'
 import {
   updateTerminalRemoteRuntimeRecoveryUiState,
@@ -2973,6 +2974,18 @@ function TerminalPane(
     ? (paneTransportsRef.current.get(chatPane.id)?.getPtyId() ?? null)
     : null
   const chatPaneResolvedAgent = chatPane ? resolveTitleAgentForLeaf(chatPane.leafId) : null
+  // Why: only an agent that reported a provider session has an id to copy; a plain
+  // shell pane would otherwise show an item that can only fail (issue #16261).
+  const contextMenuHasAgentSessionId = useAppStore((store) =>
+    contextMenu.open && contextMenuLeafId
+      ? Boolean(readPaneAgentSessionId(store.agentStatusByPaneKey, tabId, contextMenuLeafId))
+      : false
+  )
+  const chatPaneHasAgentSessionId = useAppStore((store) =>
+    chatPane
+      ? Boolean(readPaneAgentSessionId(store.agentStatusByPaneKey, tabId, chatPane.leafId))
+      : false
+  )
   const chatPaneLaunchAgent = nativeChatLaunchAgentForLeaf({
     launchAgent: terminalTab?.launchAgent,
     launchAgentLeafId: getTabWideAgentHintLeafId(),
@@ -3170,6 +3183,9 @@ function TerminalPane(
                   onSetTitle: () => contextMenu.runForPane(chatPane.id, contextMenu.onSetTitle),
                   onCopyTerminalId: () =>
                     void contextMenu.runForPane(chatPane.id, contextMenu.onCopyTerminalId),
+                  canCopyAgentSessionId: chatPaneHasAgentSessionId,
+                  onCopyAgentSessionId: () =>
+                    void contextMenu.runForPane(chatPane.id, contextMenu.onCopyAgentSessionId),
                   onCopyPaneId: () =>
                     void contextMenu.runForPane(chatPane.id, contextMenu.onCopyPaneId),
                   canClosePane: managedPanes.length > 1,
@@ -3223,6 +3239,8 @@ function TerminalPane(
         onClearPaneTitle={contextMenu.onClearPaneTitle}
         canClearPaneTitle={menuPaneHasCustomTitle}
         onCopyTerminalId={() => void contextMenu.onCopyTerminalId()}
+        canCopyAgentSessionId={contextMenuHasAgentSessionId}
+        onCopyAgentSessionId={() => void contextMenu.onCopyAgentSessionId()}
         onCopyPaneId={contextMenu.onCopyPaneId}
       />
       <TerminalLinkActionPopover

--- a/src/renderer/src/components/terminal-pane/terminal-agent-session-id-copy.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-agent-session-id-copy.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import { copyPaneAgentSessionId, readPaneAgentSessionId } from './terminal-agent-session-id-copy'
+
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+
+function statusMap(entry: Partial<AgentStatusEntry>): Record<string, AgentStatusEntry> {
+  return { [`tab-1:${LEAF_ID}`]: entry as AgentStatusEntry }
+}
+
+describe('readPaneAgentSessionId', () => {
+  it('reads the provider session id reported for the pane', () => {
+    const map = statusMap({ providerSession: { key: 'session_id', id: 'session-abc' } })
+    expect(readPaneAgentSessionId(map, 'tab-1', LEAF_ID)).toBe('session-abc')
+  })
+
+  it('reads conversation-keyed ids the same way', () => {
+    const map = statusMap({ providerSession: { key: 'conversation_id', id: 'conv-9' } })
+    expect(readPaneAgentSessionId(map, 'tab-1', LEAF_ID)).toBe('conv-9')
+  })
+
+  it('returns null for panes with no agent, no session, or a blank id', () => {
+    expect(readPaneAgentSessionId({}, 'tab-1', LEAF_ID)).toBeNull()
+    expect(readPaneAgentSessionId(statusMap({}), 'tab-1', LEAF_ID)).toBeNull()
+    expect(
+      readPaneAgentSessionId(
+        statusMap({ providerSession: { key: 'session_id', id: '  ' } }),
+        'tab-1',
+        LEAF_ID
+      )
+    ).toBeNull()
+  })
+
+  it('does not leak another tab’s session id for the same leaf', () => {
+    const map = statusMap({ providerSession: { key: 'session_id', id: 'session-abc' } })
+    expect(readPaneAgentSessionId(map, 'tab-2', LEAF_ID)).toBeNull()
+  })
+})
+
+describe('copyPaneAgentSessionId', () => {
+  it('copies the session id', async () => {
+    const writeClipboardText = vi.fn().mockResolvedValue(undefined)
+
+    await expect(
+      copyPaneAgentSessionId({
+        agentStatusByPaneKey: statusMap({
+          providerSession: { key: 'session_id', id: 'session-abc' }
+        }),
+        tabId: 'tab-1',
+        leafId: LEAF_ID,
+        writeClipboardText
+      })
+    ).resolves.toBe('copied')
+    expect(writeClipboardText).toHaveBeenCalledWith('session-abc')
+  })
+
+  it('reports an absent session without touching the clipboard', async () => {
+    const writeClipboardText = vi.fn()
+
+    await expect(
+      copyPaneAgentSessionId({
+        agentStatusByPaneKey: {},
+        tabId: 'tab-1',
+        leafId: LEAF_ID,
+        writeClipboardText
+      })
+    ).resolves.toBe('unavailable')
+    expect(writeClipboardText).not.toHaveBeenCalled()
+  })
+
+  // Why: writeClipboardText rejects on insecure web origins; success must not be claimed.
+  it('reports a rejected clipboard write separately', async () => {
+    await expect(
+      copyPaneAgentSessionId({
+        agentStatusByPaneKey: statusMap({
+          providerSession: { key: 'session_id', id: 'session-abc' }
+        }),
+        tabId: 'tab-1',
+        leafId: LEAF_ID,
+        writeClipboardText: vi.fn().mockRejectedValue(new Error('denied'))
+      })
+    ).resolves.toBe('copy-failed')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-agent-session-id-copy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-agent-session-id-copy.ts
@@ -1,0 +1,34 @@
+import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+
+/** Provider-owned session id (Claude/Codex `session_id`, Antigravity `conversation_id`)
+ *  the pane's agent reported, or null when no agent has claimed the pane yet. */
+export function readPaneAgentSessionId(
+  agentStatusByPaneKey: Record<string, AgentStatusEntry>,
+  tabId: string,
+  leafId: string
+): string | null {
+  return agentStatusByPaneKey[makePaneKey(tabId, leafId)]?.providerSession?.id?.trim() || null
+}
+
+export type CopyAgentSessionIdOutcome = 'copied' | 'unavailable' | 'copy-failed'
+
+/** Why: separates "the agent never reported a session" from a rejected clipboard
+ *  write, so the caller can toast the accurate reason instead of one vague error. */
+export async function copyPaneAgentSessionId(args: {
+  agentStatusByPaneKey: Record<string, AgentStatusEntry>
+  tabId: string
+  leafId: string
+  writeClipboardText: (text: string) => Promise<void>
+}): Promise<CopyAgentSessionIdOutcome> {
+  const sessionId = readPaneAgentSessionId(args.agentStatusByPaneKey, args.tabId, args.leafId)
+  if (!sessionId) {
+    return 'unavailable'
+  }
+  try {
+    await args.writeClipboardText(sessionId)
+    return 'copied'
+  } catch {
+    return 'copy-failed'
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-pane-menu-copy-actions.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-menu-copy-actions.ts
@@ -3,7 +3,9 @@ import type { ManagedPane } from '@/lib/pane-manager/pane-manager'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 import { translate } from '@/i18n/i18n'
 import { copyTerminalHandleForPane } from './terminal-handle-copy'
+import { copyPaneAgentSessionId } from './terminal-agent-session-id-copy'
 import { runCopyPaneId, runTerminalCopy } from './terminal-copy-rejection-guards'
+import { useAppStore } from '@/store'
 
 export const copyTerminalPaneMenuSelection = async (pane: ManagedPane | null): Promise<void> => {
   if (!pane) {
@@ -82,4 +84,44 @@ export const copyTerminalPaneMenuTerminalId = async (
   } finally {
     pane.terminal.focus()
   }
+}
+
+// Why: the provider session id is what resumes the exact conversation in the
+// agent's own CLI; Orca terminal/pane ids cannot address it (issue #16261).
+export const copyTerminalPaneMenuAgentSessionId = async (
+  pane: ManagedPane | null,
+  tabId: string
+): Promise<void> => {
+  if (!pane) {
+    return
+  }
+  const outcome = await copyPaneAgentSessionId({
+    agentStatusByPaneKey: useAppStore.getState().agentStatusByPaneKey,
+    tabId,
+    leafId: pane.leafId,
+    writeClipboardText: window.api.ui.writeTerminalClipboardText
+  })
+  if (outcome === 'copied') {
+    toast.success(
+      translate(
+        'auto.components.terminal.pane.use.terminal.pane.context.menu.session.id.copied',
+        'Session ID copied'
+      )
+    )
+  } else if (outcome === 'unavailable') {
+    toast.error(
+      translate(
+        'auto.components.terminal.pane.use.terminal.pane.context.menu.session.id.unavailable',
+        'No agent session ID reported for this terminal yet'
+      )
+    )
+  } else {
+    toast.error(
+      translate(
+        'auto.components.terminal.pane.use.terminal.pane.context.menu.session.id.copy.failed',
+        'Unable to copy session ID'
+      )
+    )
+  }
+  pane.terminal.focus()
 }

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -11,6 +11,7 @@ import type { PreparedAgentSessionFork } from './terminal-agent-session-fork'
 import type { AgentSessionContinuationRequest } from '@/lib/agent-session-continuation'
 import { pasteTerminalPaneMenuClipboard } from './terminal-pane-menu-paste'
 import {
+  copyTerminalPaneMenuAgentSessionId,
   copyTerminalPaneMenuPaneId,
   copyTerminalPaneMenuSelection,
   copyTerminalPaneMenuTerminalId
@@ -56,6 +57,7 @@ type TerminalMenuState = {
   onCopy: () => Promise<void>
   onSelectAll: () => void
   onCopyTerminalId: () => Promise<void>
+  onCopyAgentSessionId: () => Promise<void>
   onCopyPaneId: () => Promise<void>
   onPaste: () => Promise<void>
   onSplitRight: () => void
@@ -169,6 +171,9 @@ export function useTerminalPaneContextMenu({
   const onCopyTerminalId = async (): Promise<void> =>
     copyTerminalPaneMenuTerminalId(resolveMenuPane(), tabId)
 
+  const onCopyAgentSessionId = async (): Promise<void> =>
+    copyTerminalPaneMenuAgentSessionId(resolveMenuPane(), tabId)
+
   const onPaste = async (): Promise<void> => pasteResolvedPane('context-menu')
 
   const onEqualizePaneSizes = (): void => {
@@ -273,6 +278,7 @@ export function useTerminalPaneContextMenu({
     onCopy,
     onSelectAll,
     onCopyTerminalId,
+    onCopyAgentSessionId,
     onCopyPaneId,
     onPaste,
     onSplitRight,

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2923,7 +2923,8 @@
             "925f49f210": "Expand Pane",
             "df766809e0": "Collapse Pane",
             "cff67afad1": "Copy Context",
-            "15dd899676": "Add to {{value0}}…"
+            "15dd899676": "Add to {{value0}}…",
+            "copySessionId": "Copy Session ID"
           },
           "TerminalErrorToast": {
             "e4aa243f8c": "Restart daemon",
@@ -3056,6 +3057,15 @@
                         "copied": "Terminal ID copied",
                         "copy": {
                           "failed": "Unable to copy terminal ID"
+                        }
+                      }
+                    },
+                    "session": {
+                      "id": {
+                        "copied": "Session ID copied",
+                        "unavailable": "No agent session ID reported for this terminal yet",
+                        "copy": {
+                          "failed": "Unable to copy session ID"
                         }
                       }
                     }


### PR DESCRIPTION
Closes #16261

## Problem

The terminal context menu offers **Copy Terminal ID** and **Copy Pane ID**, but neither addresses the agent's own conversation. When you want to resume an exact session in the agent CLI, or reference it somewhere else, there is no way to get the session id out of the pane.

## Change

Adds **Copy Session ID** to the terminal pane context menu, directly above Copy Terminal ID. It copies the provider-owned session id already tracked per pane in `agentStatusByPaneKey[paneKey].providerSession.id` (Claude/Codex `session_id`, Antigravity `conversation_id`) - the id the agent's own CLI resumes by.

The same item is added to the chat-view context menu, which carries the same copy actions.

## Notes on behavior

- **Hidden when there is nothing to copy.** A plain shell pane has no reported session, so the item only appears for panes whose agent reported one - the same gating "Continue in New Session…" uses. This avoids a menu entry that can only fail.
- **Honest failure reporting.** `copyPaneAgentSessionId` returns `copied` / `unavailable` / `copy-failed`, so a session that disappeared between render and click is reported differently from a rejected clipboard write. `writeTerminalClipboardText` really can reject (insecure web origin with no live user gesture), and claiming success there would be a silent lie - the same reasoning behind the existing copy rejection guards.
- **Focus is always returned to xterm**, matching every other copy action in this menu.

## Cross-cutting checks

- Reads only renderer store state that is already populated identically for local, SSH, and remote-runtime panes, so no wire change and no host assumptions.
- No new git commands, no provider-specific behavior, no platform-dependent code.
- Works the same for folder workspaces and worktrees.

## Test plan

- New `terminal-agent-session-id-copy.test.ts`: id read for both `session_id` and `conversation_id` keys, blank/absent session, cross-tab leakage (same leaf id under a different tab must not resolve), and all three copy outcomes including a rejected clipboard write.
- New case in `TerminalContextMenu.test.tsx`: the item is absent when the pane reports no session, present and wired when it does.
- `pnpm typecheck`, `oxlint`, changed-code quality gate, max-lines ratchet, and all localization verifications pass.
- The 15 failing IME/Korean-composition tests in this package fail identically on a pristine `main` checkout and are unrelated to this change.
