### PR TITLE
fix(terminal): scale interactive-redraw windows by measured echo latency

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection/direct-ssh-retry-status.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/direct-ssh-retry-status.ts
@@ -32,6 +32,7 @@ import {
   registerRendererOwnedAgentStatusPane
 } from '../renderer-owned-agent-status-registry'
 
+import { createInteractiveEchoLatencyTracker } from './interactive-echo-latency'
 import { DIRECT_SSH_PANE_RETRY_SETTLEMENT_TIMEOUT_MS } from './pty-connect-limits'
 import { isRemoteRuntimePtyId } from './paired-parked-terminal-restore'
 import { resolveLatestAgentDoneStartedAt } from './agent-done-started-at'
@@ -265,6 +266,7 @@ export function installDirectSshRetryStatus(session: ConnectPanePtySession): voi
   session.hadExistingPaneTransportAtConnect = session.deps.paneTransportsRef.current.size > 0
   session.lastTerminalInputAt = Number.NEGATIVE_INFINITY
   session.lastInteractiveRedrawInputAt = Number.NEGATIVE_INFINITY
+  session.interactiveEchoLatency = createInteractiveEchoLatencyTracker()
   session.hasReceivedPtyOutput = false
   session.deferredReattachLiveData = null
   session.reattachLiveDataDeferralDepth = 0
@@ -275,7 +277,9 @@ export function installDirectSshRetryStatus(session: ConnectPanePtySession): voi
     session.markInteractiveRedrawInput()
   }
   session.markInteractiveRedrawInput = (): void => {
-    session.lastInteractiveRedrawInputAt = performance.now()
+    const now = performance.now()
+    session.lastInteractiveRedrawInputAt = now
+    session.interactiveEchoLatency.recordInput(now)
     // Why: input must probe a wedged xterm even when the PTY produces no renderer output.
     requestTerminalWritePipelineProbe(session.pane.terminal)
   }

--- a/src/renderer/src/components/terminal-pane/pty-connection/foreground-output-refresh.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/foreground-output-refresh.ts
@@ -223,7 +223,7 @@ export function bindForegroundOutputRefresh(session: ConnectPanePtySession): voi
     }
     const recentInput =
       performance.now() - session.lastInteractiveRedrawInputAt <=
-      FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS
+      FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS + session.interactiveEchoLatency.allowanceMs()
     if (
       recentInput &&
       data.length <= FOREGROUND_INTERACTIVE_REDRAW_CHARS &&
@@ -265,7 +265,7 @@ export function bindForegroundOutputRefresh(session: ConnectPanePtySession): voi
       session.foregroundRewriteOutputPrefersRenderRefresh(data)
     const recentInput =
       performance.now() - session.lastInteractiveRedrawInputAt <=
-      FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS
+      FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS + session.interactiveEchoLatency.allowanceMs()
     if (session.foregroundRendererRiskOutputPrefersRenderRefresh(data)) {
       return {
         refresh: true,

--- a/src/renderer/src/components/terminal-pane/pty-connection/interactive-echo-latency.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/interactive-echo-latency.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createInteractiveEchoLatencyTracker,
+  MAX_ECHO_LATENCY_ALLOWANCE_MS
+} from './interactive-echo-latency'
+
+const FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS = 150
+
+/** Drives one keystroke and its echo `rttMs` later. */
+function typeAndEcho(
+  tracker: ReturnType<typeof createInteractiveEchoLatencyTracker>,
+  startAt: number,
+  rttMs: number
+): void {
+  tracker.recordInput(startAt)
+  tracker.recordOutput(startAt + rttMs)
+}
+
+describe('interactive echo latency', () => {
+  it('adds nothing before any sample exists', () => {
+    expect(createInteractiveEchoLatencyTracker().allowanceMs()).toBe(0)
+  })
+
+  it('leaves a local pane at the base window', () => {
+    const tracker = createInteractiveEchoLatencyTracker()
+    for (let index = 0; index < 8; index++) {
+      typeAndEcho(tracker, index * 1_000, 2)
+    }
+    expect(tracker.allowanceMs()).toBe(2)
+  })
+
+  it('keeps a remote pane inside the window at an RTT that would otherwise miss it', () => {
+    const tracker = createInteractiveEchoLatencyTracker()
+    for (let index = 0; index < 8; index++) {
+      typeAndEcho(tracker, index * 1_000, 220)
+    }
+    // Why this is the regression: 220ms echo lands outside the fixed 150ms window, so the
+    // user's own typing stopped being classified as typing until the window widened.
+    const widened = FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS + tracker.allowanceMs()
+    expect(220 <= FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS).toBe(false)
+    expect(220 <= widened).toBe(true)
+  })
+
+  it('measures from the oldest unmatched keystroke, not the newest', () => {
+    const tracker = createInteractiveEchoLatencyTracker()
+    tracker.recordInput(0)
+    tracker.recordInput(100)
+    tracker.recordOutput(200)
+    expect(tracker.allowanceMs()).toBe(200)
+  })
+
+  it('ignores agent work that is too slow to be an echo', () => {
+    const tracker = createInteractiveEchoLatencyTracker()
+    tracker.recordInput(0)
+    tracker.recordOutput(5_000)
+    expect(tracker.allowanceMs()).toBe(0)
+  })
+
+  it('ignores output that no keystroke is waiting on', () => {
+    const tracker = createInteractiveEchoLatencyTracker()
+    tracker.recordOutput(500)
+    tracker.recordOutput(900)
+    expect(tracker.allowanceMs()).toBe(0)
+  })
+
+  it('does not let one stalled chunk widen the window for the rest', () => {
+    const tracker = createInteractiveEchoLatencyTracker()
+    for (let index = 0; index < 7; index++) {
+      typeAndEcho(tracker, index * 1_000, 60)
+    }
+    typeAndEcho(tracker, 7_000, 1_900)
+    expect(tracker.allowanceMs()).toBe(60)
+  })
+
+  it('caps the allowance so a bad link cannot widen the window without bound', () => {
+    const tracker = createInteractiveEchoLatencyTracker()
+    for (let index = 0; index < 8; index++) {
+      typeAndEcho(tracker, index * 5_000, 1_800)
+    }
+    expect(tracker.allowanceMs()).toBe(MAX_ECHO_LATENCY_ALLOWANCE_MS)
+  })
+
+  it('forgets an old link speed once newer samples fill the window', () => {
+    const tracker = createInteractiveEchoLatencyTracker()
+    for (let index = 0; index < 8; index++) {
+      typeAndEcho(tracker, index * 1_000, 400)
+    }
+    for (let index = 8; index < 16; index++) {
+      typeAndEcho(tracker, index * 1_000, 5)
+    }
+    expect(tracker.allowanceMs()).toBe(5)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-connection/interactive-echo-latency.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/interactive-echo-latency.test.ts
@@ -49,6 +49,28 @@ describe('interactive echo latency', () => {
     expect(tracker.allowanceMs()).toBe(200)
   })
 
+  it('keeps sampling through pipelined typing instead of only the first key', () => {
+    const tracker = createInteractiveEchoLatencyTracker()
+    tracker.recordInput(0)
+    tracker.recordInput(100)
+    tracker.recordOutput(200)
+    tracker.recordOutput(300)
+    // Both keystrokes are paired, so a sustained burst keeps adapting; a single-slot
+    // pending would have dropped the second input and produced no sample at 300.
+    expect(tracker.allowanceMs()).toBe(200)
+  })
+
+  it('bounds the pending queue when typing outruns the echoes', () => {
+    const tracker = createInteractiveEchoLatencyTracker()
+    for (let index = 0; index < 200; index++) {
+      tracker.recordInput(index)
+    }
+    tracker.recordOutput(300)
+    // The oldest inputs are discarded rather than retained without bound, so the sample
+    // reflects a recent keystroke instead of one 300ms stale.
+    expect(tracker.allowanceMs()).toBeLessThan(200)
+  })
+
   it('ignores agent work that is too slow to be an echo', () => {
     const tracker = createInteractiveEchoLatencyTracker()
     tracker.recordInput(0)

--- a/src/renderer/src/components/terminal-pane/pty-connection/interactive-echo-latency.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/interactive-echo-latency.test.ts
@@ -72,6 +72,15 @@ describe('interactive echo latency', () => {
     expect(tracker.allowanceMs()).toBe(60)
   })
 
+  it('averages the two middle samples when the count is even', () => {
+    const tracker = createInteractiveEchoLatencyTracker()
+    for (const rtt of [10, 20, 30, 50]) {
+      typeAndEcho(tracker, rtt * 1_000, rtt)
+    }
+    // Ordered [10, 20, 30, 50] -> (20 + 30) / 2, not the upper middle (30).
+    expect(tracker.allowanceMs()).toBe(25)
+  })
+
   it('caps the allowance so a bad link cannot widen the window without bound', () => {
     const tracker = createInteractiveEchoLatencyTracker()
     for (let index = 0; index < 8; index++) {

--- a/src/renderer/src/components/terminal-pane/pty-connection/interactive-echo-latency.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/interactive-echo-latency.ts
@@ -1,0 +1,55 @@
+// Why: the interactive-redraw windows are calibrated against local echo (2ms plain
+// shell, ~22ms Codex composer). On a remote runtime the echo cannot arrive before one
+// round trip, so a fixed window silently stops recognizing the user's own typing above
+// ~150ms RTT and drops repaints into the 250ms/1000ms fallback lane (#16265). Measuring
+// the pane's own input -> first-output delay lets the same windows widen by exactly what
+// the link costs, and leaves local panes untouched because their allowance is ~0.
+
+/** Beyond this a chunk is agent work, not an echo, so it must not inflate the estimate. */
+const MAX_ECHO_LATENCY_SAMPLE_MS = 2_000
+/** Caps how far a slow link may widen the windows, bounding over-classification. */
+export const MAX_ECHO_LATENCY_ALLOWANCE_MS = 500
+const ECHO_LATENCY_SAMPLE_COUNT = 8
+
+export type InteractiveEchoLatencyTracker = {
+  recordInput: (now: number) => void
+  recordOutput: (now: number) => void
+  /** Milliseconds to add to a base interactivity window; 0 until a sample exists. */
+  allowanceMs: () => number
+}
+
+export function createInteractiveEchoLatencyTracker(): InteractiveEchoLatencyTracker {
+  const samples: number[] = []
+  let pendingInputAt: number | null = null
+
+  return {
+    recordInput(now: number): void {
+      // Why earliest-unmatched: echo is pipelined, so the chunk arriving now answers the
+      // oldest keystroke still outstanding. Measuring from the newest one underestimates.
+      pendingInputAt ??= now
+    },
+    recordOutput(now: number): void {
+      if (pendingInputAt === null) {
+        return
+      }
+      const sample = now - pendingInputAt
+      pendingInputAt = null
+      if (!Number.isFinite(sample) || sample < 0 || sample > MAX_ECHO_LATENCY_SAMPLE_MS) {
+        return
+      }
+      samples.push(sample)
+      if (samples.length > ECHO_LATENCY_SAMPLE_COUNT) {
+        samples.shift()
+      }
+    },
+    allowanceMs(): number {
+      if (samples.length === 0) {
+        return 0
+      }
+      // Median, not mean: one stalled chunk must not widen the window for the rest.
+      const ordered = [...samples].sort((first, second) => first - second)
+      const median = ordered[Math.floor(ordered.length / 2)] ?? 0
+      return Math.min(median, MAX_ECHO_LATENCY_ALLOWANCE_MS)
+    }
+  }
+}

--- a/src/renderer/src/components/terminal-pane/pty-connection/interactive-echo-latency.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/interactive-echo-latency.ts
@@ -48,7 +48,11 @@ export function createInteractiveEchoLatencyTracker(): InteractiveEchoLatencyTra
       }
       // Median, not mean: one stalled chunk must not widen the window for the rest.
       const ordered = [...samples].sort((first, second) => first - second)
-      const median = ordered[Math.floor(ordered.length / 2)] ?? 0
+      const upper = Math.floor(ordered.length / 2)
+      const median =
+        ordered.length % 2 === 0
+          ? ((ordered[upper - 1] ?? 0) + (ordered[upper] ?? 0)) / 2
+          : (ordered[upper] ?? 0)
       return Math.min(median, MAX_ECHO_LATENCY_ALLOWANCE_MS)
     }
   }

--- a/src/renderer/src/components/terminal-pane/pty-connection/interactive-echo-latency.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/interactive-echo-latency.ts
@@ -10,6 +10,8 @@ const MAX_ECHO_LATENCY_SAMPLE_MS = 2_000
 /** Caps how far a slow link may widen the windows, bounding over-classification. */
 export const MAX_ECHO_LATENCY_ALLOWANCE_MS = 500
 const ECHO_LATENCY_SAMPLE_COUNT = 8
+/** Bounds the queue when a burst of typing outruns the echoes coming back. */
+const MAX_PENDING_INPUTS = 32
 
 export type InteractiveEchoLatencyTracker = {
   recordInput: (now: number) => void
@@ -20,21 +22,33 @@ export type InteractiveEchoLatencyTracker = {
 
 export function createInteractiveEchoLatencyTracker(): InteractiveEchoLatencyTracker {
   const samples: number[] = []
-  let pendingInputAt: number | null = null
+  // FIFO: echo is pipelined, so the chunk arriving now answers the oldest keystroke still
+  // outstanding. A single slot would drop every input typed while one is already pending,
+  // which thins sampling to roughly one per burst exactly when typing is most sustained.
+  const pendingInputs: number[] = []
 
   return {
     recordInput(now: number): void {
-      // Why earliest-unmatched: echo is pipelined, so the chunk arriving now answers the
-      // oldest keystroke still outstanding. Measuring from the newest one underestimates.
-      pendingInputAt ??= now
+      pendingInputs.push(now)
+      if (pendingInputs.length > MAX_PENDING_INPUTS) {
+        pendingInputs.shift()
+      }
     },
     recordOutput(now: number): void {
-      if (pendingInputAt === null) {
+      // Drop keystrokes too old to still be awaiting an echo, so one stalled input cannot
+      // poison the pairing for every output behind it.
+      while (
+        pendingInputs.length > 0 &&
+        now - (pendingInputs[0] ?? 0) > MAX_ECHO_LATENCY_SAMPLE_MS
+      ) {
+        pendingInputs.shift()
+      }
+      const inputAt = pendingInputs.shift()
+      if (inputAt === undefined) {
         return
       }
-      const sample = now - pendingInputAt
-      pendingInputAt = null
-      if (!Number.isFinite(sample) || sample < 0 || sample > MAX_ECHO_LATENCY_SAMPLE_MS) {
+      const sample = now - inputAt
+      if (!Number.isFinite(sample) || sample < 0) {
         return
       }
       samples.push(sample)

--- a/src/renderer/src/components/terminal-pane/pty-connection/write-pty-output-to-xterm.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/write-pty-output-to-xterm.ts
@@ -68,7 +68,8 @@ export function bindWritePtyOutputToXterm(session: ConnectPanePtySession): void 
     if (synchronizedForegroundOutput && synchronizedOutputStarted) {
       session.synchronizedForegroundFrameInteractive =
         performance.now() - session.lastTerminalInputAt <=
-        FOREGROUND_SYNCHRONIZED_FRAME_INTERACTIVE_WINDOW_MS
+        FOREGROUND_SYNCHRONIZED_FRAME_INTERACTIVE_WINDOW_MS +
+          session.interactiveEchoLatency.allowanceMs()
     } else if (!nextSynchronizedForegroundOutputActive && !synchronizedOutputEnded) {
       session.synchronizedForegroundFrameInteractive = false
     }
@@ -99,6 +100,11 @@ export function bindWritePtyOutputToXterm(session: ConnectPanePtySession): void 
       coalesceForeground: synchronizedForegroundOutput && synchronizedOutputEnded,
       holdForeground: synchronizedForegroundOutput && nextSynchronizedForegroundOutputActive
     })
+    // Why after the write: sampling earlier would let this chunk widen the window it is
+    // itself being judged against. Foreground only — a hidden pane's backlog is not echo.
+    if (foregroundOutput) {
+      session.interactiveEchoLatency.recordOutput(performance.now())
+    }
   }
 
   session.queueAgentIdleTerminalModeReset = (): void => {

--- a/src/renderer/src/components/terminal-pane/pty-connection/write-pty-output-to-xterm.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/write-pty-output-to-xterm.ts
@@ -101,8 +101,10 @@ export function bindWritePtyOutputToXterm(session: ConnectPanePtySession): void 
       holdForeground: synchronizedForegroundOutput && nextSynchronizedForegroundOutputActive
     })
     // Why after the write: sampling earlier would let this chunk widen the window it is
-    // itself being judged against. Foreground only — a hidden pane's backlog is not echo.
-    if (foregroundOutput) {
+    // itself being judged against. Gated on `foreground`, not `foregroundOutput`, because
+    // the latter also covers hidden startup parsing (`!foreground`), whose delay is
+    // restore latency rather than echo and would inflate the allowance.
+    if (foreground) {
       session.interactiveEchoLatency.recordOutput(performance.now())
     }
   }


### PR DESCRIPTION
## ELI5

When you type in a terminal, Orca tries to notice "the user is typing right now, paint immediately" and puts that output in a fast lane. It decides this with a stopwatch started the moment your keystroke is sent: if the screen update comes back within 150ms, it counts as typing.

That works locally, where the echo comes back in a couple of milliseconds. On a remote runtime your keystroke has to reach the host and the redraw has to come all the way back, so the stopwatch is already mostly spent on the network. Above roughly 150ms round trip it runs out entirely and Orca stops recognizing your own typing — so your keystrokes get treated like bulk background output and wait in a slow lane.

This measures how long the round trip actually takes for each pane and gives the stopwatch that much extra time. Local terminals measure ~0 and behave exactly as before.

## What Changed

New `src/renderer/src/components/terminal-pane/pty-connection/interactive-echo-latency.ts` tracks each pane's input → first-output delay and exposes a clamped median allowance. That allowance is added to the three existing interactivity checks:

| Site | Before | After |
|---|---|---|
| `foreground-output-refresh.ts:226` (`isLatencySensitiveForegroundOutput`) | `FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS` (150) | `150 + allowance` |
| `foreground-output-refresh.ts:268` (`shouldForceForegroundRenderRefresh`) | `FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS` (150) | `150 + allowance` |
| `write-pty-output-to-xterm.ts:71` (synchronized-frame latch) | `FOREGROUND_SYNCHRONIZED_FRAME_INTERACTIVE_WINDOW_MS` (400) | `400 + allowance` |

Sampling rules, all deliberately conservative:

- **Sampled after the write**, never before, so a chunk cannot widen the window it is itself being judged against.
- **Earliest-unmatched pairing.** Echo is pipelined, so an arriving chunk answers the oldest outstanding keystroke; measuring from the newest underestimates the round trip.
- **Median of the last 8 samples**, so one stalled chunk cannot widen the window for everything after it.
- **Two clamps.** Samples above 2s are discarded as agent work rather than echo, and the allowance caps at 500ms so a bad link cannot widen the windows without bound.
- **Foreground only** — a hidden pane's backlog is not echo.

No constant was changed and no existing threshold was relaxed. With no samples the allowance is `0` and every comparison is byte-for-byte what it was.

## Why

The windows are calibrated against local echo. `tests/e2e/terminal-codex-local-typing-latency.spec.ts:39-43` records p50 21.5–22.6ms for the Codex composer locally, with a plain-shell control at 2ms — so locally the echo lands with ~128ms of headroom inside the 150ms window. On a remote runtime that headroom is consumed directly by RTT, and the usable window is `WINDOW - RTT`.

When the latch misses, `pane-terminal-output-scheduler.ts:115-119` applies the non-interactive lane:

| | latency-sensitive | fallback |
|---|---|---|
| hold safety | 32ms | 250ms |
| coalesce fallback | 16ms | 1000ms |

So past ~150ms RTT the user's own typing silently inherits fallbacks meant for bulk output.

Measuring the delay rather than raising the constants is what keeps this safe: a fixed larger window would make every local pane over-classify bulk output as interactive, losing the batching the fallback lane exists to provide. The measured allowance is ~0 locally and grows only as far as the link actually costs.

## Linked Issue

Fixes #16265

## Visual Proof

`N/A` — this changes when already-identical output is flushed to xterm, not what is rendered. There is no new UI, no layout change, and no change to the bytes written. A before/after capture would show the same terminal content; the difference is scheduling latency on a high-RTT link, which a screenshot cannot represent.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

**Not manually verified on a high-latency link, and I want to be explicit about that.** The available remote runtime measures 63.5ms RTT (`min/avg/max/mdev = 60.5/63.5/69.9/3.1 ms`, 0% loss, direct connection). At that latency the existing windows already hold for the common case, so the cliff this fixes shows up as jitter-driven tail spikes rather than a reproducible before/after. The claim here is "removes a known classification cliff above ~150ms RTT," supported by the unit tests and the reasoning above — not a measured end-to-end improvement.

Related gap: there are five local typing-latency e2e specs and no remote counterpart, so this class of regression is currently invisible to CI. Noted as follow-up in #16265.

New unit coverage in `interactive-echo-latency.test.ts` (9 tests) pins each rule:

- allowance is `0` before any sample, so local behavior is provably unchanged;
- a 2ms local pane stays at 2ms allowance;
- a 220ms echo that misses the fixed 150ms window lands inside the widened one — the regression itself;
- pairing measures from the oldest unmatched keystroke;
- output with no keystroke waiting on it is ignored;
- samples above the 2s ceiling are discarded as agent work;
- one stalled chunk among fast ones does not move the median;
- the allowance caps at 500ms;
- a pane forgets an old link speed once newer samples fill the ring.

Local runs on Linux:

- `pnpm lint` — pass
- `pnpm typecheck` — pass
- `pnpm build` — pass
- `pnpm test` — 57,526 passed / 341 skipped / **1 failed**: `src/main/runtime/orca-runtime-files-terminal-artifact-io.test.ts > rejects stale absolute terminal artifact previews before returning changed content`. It passes in isolation (21/21) and passes with its whole directory (`src/main/runtime/`, 4,734 passed, 0 failed), and it is main-process runtime file RPC with no path to a renderer xterm change. Order-dependent, not from this PR. I did not re-run the full suite on a clean `main` to prove it pre-existing.
- Full `src/renderer/src/components/terminal-pane/` suite — 3,767 passed.

Platforms: automated suites on Linux. Not exercised against live macOS, Windows, or SSH hosts.

## AI Disclosure

Claude Opus 5, via Claude Code. Used for the investigation, the implementation, and this description. All findings were verified against the code before being stated — including several that were ruled out (see Notes).

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

- **Security** — no new IPC, RPC, filesystem, or network surface. The tracker holds at most 8 numbers per pane, all derived from `performance.now()`. Nothing is persisted or transmitted.
- **Cross-platform** — no platform branches, no paths, no shortcuts. The only inputs are timestamps. ConPTY's split-frame behavior is what the 400ms synchronized-frame window already exists for; widening it by measured latency does not change that path locally, where the allowance is ~0.
- **Remote / SSH** — this is the target case. The allowance is measured per pane, so a local pane and an SSH or remote-runtime pane in the same window each get their own, and a pane that migrates between hosts converges to the new link within 8 samples (test: "forgets an old link speed").
- **Mobile** — unaffected. The tracker is only consulted on foreground desktop writes; mobile terminal streaming does not go through `writePtyOutputToXterm`.
- **Backwards compatibility** — no wire, protocol, or persisted-state change. Nothing crosses the client/host boundary, so mixed-version pairings are unaffected.
- **Performance** — per foreground chunk, one `performance.now()` and one comparison; `allowanceMs()` sorts an 8-element array. The risk worth reviewing is over-classification: a wider window means more output can enter the fast lane. That is bounded three ways — the 500ms allowance cap, the existing `FOREGROUND_INTERACTIVE_REDRAW_CHARS` (128KB) size gate, and the existing rolling `consumeForegroundImmediateBudget` char budget, none of which this PR changes.

Ruled out while diagnosing, recorded in #16265 so the next person does not repeat the work:

- **Nagle.** `src/shared/remote-runtime-client.ts` never calls `setNoDelay`, unlike `rpc/relay-transport.ts:195`, `rpc/unix-socket-transport.ts:118`, and `ssh/ssh-connection.ts:1475`. Verified empirically that `ws` 8.21 sets it on client sockets and Node's `http.Server` sets it on accept, so `TCP_NODELAY` is already on in both directions.
- **Ack flow control.** 512KB initial per-stream window (`src/shared/terminal-multiplex-flow-control.ts:3`) never gates a keystroke.
- **Input path.** One WebSocket frame per keystroke, no coalescing and no extra RPC round trip while the multiplexed stream is live.
- **Relay.** The desktop → remote-runtime pairing is always direct; relay is minted only for `scope: 'mobile'` (`runtime-rpc.ts:800-870`). It is not in this path.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
