### PR TITLE
feat(tab-bar): add "Copy Terminal ID" and "Copy Session ID" to the tab context menu

### DIFF
--- a/src/renderer/src/components/tab-bar/SortableTab.rename-shortcut.test.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTab.rename-shortcut.test.tsx
@@ -86,6 +86,9 @@ vi.mock('lucide-react', () => ({
   Columns2: function Columns2(props: Record<string, unknown>) {
     return { type: 'Columns2', props }
   },
+  Copy: function Copy(props: Record<string, unknown>) {
+    return { type: 'Copy', props }
+  },
   Minimize2: function Minimize2(props: Record<string, unknown>) {
     return { type: 'Minimize2', props }
   },

--- a/src/renderer/src/components/tab-bar/SortableTabContextMenu.test.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTabContextMenu.test.tsx
@@ -6,6 +6,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { REQUEST_ACTIVE_TERMINAL_PANE_SPLIT_EVENT } from '@/constants/terminal'
 import { requestActiveTerminalPaneSplit } from './request-active-terminal-pane-split'
+import { toast } from 'sonner'
 import { SortableTabContextMenu } from './SortableTabContextMenu'
 
 const storeMock = vi.hoisted(() => ({
@@ -69,7 +70,8 @@ vi.mock('lucide-react', () => ({
 }))
 
 vi.mock('@/i18n/i18n', () => ({
-  translate: (_key: string, fallback: string) => fallback
+  translate: (_key: string, fallback: string, vars?: Record<string, string>) =>
+    vars ? fallback.replaceAll(/\{\{(\w+)\}\}/g, (_match, name) => vars[name] ?? '') : fallback
 }))
 
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
@@ -82,6 +84,11 @@ vi.mock('../../store', () => ({
     }
   )
 }))
+
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+
+const callRuntime = vi.fn()
+const writeClipboardText = vi.fn()
 
 const mounted: { container: HTMLDivElement; root: Root }[] = []
 
@@ -153,9 +160,23 @@ function getLastSplitEvent(spy: ReturnType<typeof vi.spyOn>): CustomEvent {
 
 beforeEach(() => {
   storeMock.dropUnifiedTab.mockReset()
+  callRuntime.mockReset().mockResolvedValue({
+    ok: true,
+    result: { terminal: { handle: 'term_worker' } }
+  })
+  writeClipboardText.mockReset().mockResolvedValue(undefined)
+  vi.mocked(toast.success).mockReset()
+  vi.mocked(toast.error).mockReset()
+  Object.assign(window, {
+    api: { runtime: { call: callRuntime }, ui: { writeClipboardText } }
+  })
   storeMock.state = {
     keybindings: {},
     dropUnifiedTab: storeMock.dropUnifiedTab,
+    terminalLayoutsByTabId: {},
+    agentStatusByPaneKey: {},
+    paneForegroundAgentByPaneKey: {},
+    sleepingAgentSessionsByPaneKey: {},
     groupsByWorktree: {
       'wt-1': [
         {
@@ -278,6 +299,63 @@ describe('SortableTabContextMenu', () => {
 
     expect(getButton(container, 'Close Tabs To The Left').disabled).toBe(true)
     expect(getButton(container, 'Close Tabs To The Right').disabled).toBe(true)
+  })
+
+  it('copies the focused pane terminal handle from the tab menu', async () => {
+    storeMock.state = {
+      ...storeMock.state,
+      terminalLayoutsByTabId: {
+        'term-1': { root: { type: 'leaf', leafId: LEAF_ID }, activeLeafId: LEAF_ID }
+      }
+    }
+    const { container } = renderMenu()
+
+    act(() => getButton(container, 'Copy Terminal ID').click())
+    await vi.waitFor(() => expect(writeClipboardText).toHaveBeenCalledWith('term_worker'))
+    expect(callRuntime).toHaveBeenCalledWith({
+      method: 'terminal.resolvePane',
+      params: { paneKey: `term-1:${LEAF_ID}` }
+    })
+  })
+
+  it('offers the agent session id only when the tab has one', async () => {
+    expect(renderMenu().container.textContent).not.toContain('Copy Session ID')
+
+    storeMock.state = {
+      ...storeMock.state,
+      terminalLayoutsByTabId: {
+        'term-1': { root: { type: 'leaf', leafId: LEAF_ID }, activeLeafId: LEAF_ID }
+      },
+      agentStatusByPaneKey: {
+        [`term-1:${LEAF_ID}`]: { providerSession: { key: 'session_id', id: 'session-9' } }
+      }
+    }
+    const { container } = renderMenu()
+
+    act(() => getButton(container, 'Copy Session ID').click())
+    await vi.waitFor(() => expect(writeClipboardText).toHaveBeenCalledWith('session-9'))
+  })
+
+  // Why: an insecure origin with no live user gesture rejects the write, and the menu discards the
+  // promise - without an explicit failure path the copy looks like it succeeded.
+  it('toasts a failure when the session id clipboard write rejects', async () => {
+    writeClipboardText.mockRejectedValue(new Error('clipboard_denied'))
+    storeMock.state = {
+      ...storeMock.state,
+      terminalLayoutsByTabId: {
+        'term-1': { root: { type: 'leaf', leafId: LEAF_ID }, activeLeafId: LEAF_ID }
+      },
+      agentStatusByPaneKey: {
+        [`term-1:${LEAF_ID}`]: { providerSession: { key: 'session_id', id: 'session-9' } }
+      }
+    }
+    const { container } = renderMenu()
+
+    act(() => getButton(container, 'Copy Session ID').click())
+    await vi.waitFor(() =>
+      expect(vi.mocked(toast.error)).toHaveBeenCalledWith('Unable to copy session ID')
+    )
+    expect(vi.mocked(toast.success)).not.toHaveBeenCalled()
   })
 
   it('hides move-tab split actions for a single-tab group', () => {

--- a/src/renderer/src/components/tab-bar/SortableTabContextMenu.tsx
+++ b/src/renderer/src/components/tab-bar/SortableTabContextMenu.tsx
@@ -1,4 +1,5 @@
 import {
+  Copy,
   MessageSquare,
   PanelLeftClose,
   PanelRightClose,
@@ -23,6 +24,8 @@ import { formatShortcutLabel, useOptionalShortcutLabel } from '@/hooks/useShortc
 import { translate } from '@/i18n/i18n'
 import { TerminalTabSplitMenuSection } from './TerminalTabSplitMenuSection'
 import { TAB_CONTEXT_MENU_CONTENT_CLASS } from './tab-context-menu-sizing'
+import { copyTabAgentSessionId, copyTabTerminalId } from './tab-identifier-clipboard'
+import { resolveTabAgentSessionId } from './tab-terminal-identifiers'
 
 const TAB_COLORS = [
   {
@@ -147,6 +150,16 @@ export function SortableTabContextMenu({
   const keybindings = useAppStore((state) => state.keybindings)
   const splitRightShortcut = formatShortcutLabel('terminal.splitRight', keybindings)
   const splitDownShortcut = formatShortcutLabel('terminal.splitDown', keybindings)
+  // Why: every tab keeps this menu mounted, so only the open one pays for the lookup.
+  const agentSessionId = useAppStore((state) =>
+    open
+      ? resolveTabAgentSessionId({
+          tabId: tab.id,
+          layout: state.terminalLayoutsByTabId[tab.id],
+          state
+        })
+      : null
+  )
 
   const closeShortcut = useOptionalShortcutLabel('tab.close')
   const renameShortcut = useOptionalShortcutLabel('tab.rename')
@@ -234,6 +247,22 @@ export function SortableTabContextMenu({
           {translate('auto.components.tab.bar.SortableTabContextMenu.2f697b3c31', 'Change Title')}
           {renameShortcut ? <DropdownMenuShortcut>{renameShortcut}</DropdownMenuShortcut> : null}
         </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => void copyTabTerminalId(tab.id)}>
+          <Copy className="size-3.5 shrink-0" />
+          {translate(
+            'auto.components.terminal.pane.TerminalContextMenu.copyTerminalId',
+            'Copy Terminal ID'
+          )}
+        </DropdownMenuItem>
+        {agentSessionId ? (
+          <DropdownMenuItem onSelect={() => void copyTabAgentSessionId(agentSessionId)}>
+            <Copy className="size-3.5 shrink-0" />
+            {translate(
+              'components.terminalPane.TerminalContextMenu.copySessionId',
+              'Copy Session ID'
+            )}
+          </DropdownMenuItem>
+        ) : null}
         <div className="px-2 pt-1.5 pb-1">
           <div className="text-xs font-medium text-muted-foreground mb-1.5">
             {translate('auto.components.tab.bar.SortableTabContextMenu.35e8892fd0', 'Tab Color')}

--- a/src/renderer/src/components/tab-bar/tab-identifier-clipboard.ts
+++ b/src/renderer/src/components/tab-bar/tab-identifier-clipboard.ts
@@ -5,7 +5,7 @@ import { copyTerminalHandleForPane } from '../terminal-pane/terminal-handle-copy
 import { runTerminalIdentityCopy } from '../terminal-pane/terminal-copy-rejection-guards'
 import { resolveTabIdentityLeafId } from './tab-terminal-identifiers'
 
-// Why: the menu opens from the tab strip, so no pane held focus to hand back.
+/** No-op focus handoff: the menu opens from the tab strip, so no pane held focus to give back. */
 const NO_PANE_TO_REFOCUS = (): void => {}
 
 /** Runtime terminal handle of the tab's focused pane — what agents and the CLI address. */
@@ -37,6 +37,11 @@ export async function copyTabTerminalId(tabId: string): Promise<void> {
   }
 }
 
+/**
+ * Provider-owned session id the tab can be resumed by, already resolved by the menu so the item
+ * is hidden when there is none to copy. Routed through the shared identity-copy guard rather than
+ * a local try/catch, so a rejected clipboard write toasts the failure instead of a false success.
+ */
 export async function copyTabAgentSessionId(sessionId: string): Promise<void> {
   await runTerminalIdentityCopy({
     text: sessionId,

--- a/src/renderer/src/components/tab-bar/tab-identifier-clipboard.ts
+++ b/src/renderer/src/components/tab-bar/tab-identifier-clipboard.ts
@@ -1,0 +1,60 @@
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
+import { useAppStore } from '../../store'
+import { copyTerminalHandleForPane } from '../terminal-pane/terminal-handle-copy'
+import { runTerminalIdentityCopy } from '../terminal-pane/terminal-copy-rejection-guards'
+import { resolveTabIdentityLeafId } from './tab-terminal-identifiers'
+
+// Why: the menu opens from the tab strip, so no pane held focus to hand back.
+const NO_PANE_TO_REFOCUS = (): void => {}
+
+/** Runtime terminal handle of the tab's focused pane — what agents and the CLI address. */
+export async function copyTabTerminalId(tabId: string): Promise<void> {
+  try {
+    const leafId = resolveTabIdentityLeafId(useAppStore.getState().terminalLayoutsByTabId[tabId])
+    if (!leafId) {
+      throw new Error('terminal_not_found')
+    }
+    await copyTerminalHandleForPane({
+      tabId,
+      leafId,
+      callRuntime: window.api.runtime.call,
+      writeClipboardText: window.api.ui.writeClipboardText
+    })
+    toast.success(
+      translate(
+        'auto.components.terminal.pane.use.terminal.pane.context.menu.terminal.id.copied',
+        'Terminal ID copied'
+      )
+    )
+  } catch {
+    toast.error(
+      translate(
+        'auto.components.terminal.pane.use.terminal.pane.context.menu.terminal.id.copy.failed',
+        'Unable to copy terminal ID'
+      )
+    )
+  }
+}
+
+export async function copyTabAgentSessionId(sessionId: string): Promise<void> {
+  await runTerminalIdentityCopy({
+    text: sessionId,
+    writeClipboardText: window.api.ui.writeClipboardText,
+    onSuccess: () =>
+      toast.success(
+        translate(
+          'components.terminalPane.TerminalContextMenu.copySessionIdSuccess',
+          'Session ID copied'
+        )
+      ),
+    onError: () =>
+      toast.error(
+        translate(
+          'components.terminalPane.TerminalContextMenu.copySessionIdError',
+          'Unable to copy session ID'
+        )
+      ),
+    focus: NO_PANE_TO_REFOCUS
+  })
+}

--- a/src/renderer/src/components/tab-bar/tab-terminal-identifiers.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-terminal-identifiers.test.ts
@@ -6,6 +6,8 @@ import { resolveTabAgentSessionId, resolveTabIdentityLeafId } from './tab-termin
 const FOCUSED_LEAF = '11111111-1111-4111-8111-111111111111'
 const SIBLING_LEAF = '22222222-2222-4222-8222-222222222222'
 
+/** Two-pane tab whose focus is the variable under test: `null` stands in for a tab never
+ *  activated, a sibling id for a live focus, an unknown id for a stale one. */
 function splitLayout(activeLeafId: string | null): TerminalLayoutSnapshot {
   return {
     root: {
@@ -19,6 +21,8 @@ function splitLayout(activeLeafId: string | null): TerminalLayoutSnapshot {
   }
 }
 
+/** Session-resolution input with every agent-state map empty by default, so each test names only
+ *  the source it exercises and an unset map cannot silently supply a session. */
 function sessionArgs(overrides: {
   layout?: TerminalLayoutSnapshot
   agentStatusByPaneKey?: Record<string, unknown>

--- a/src/renderer/src/components/tab-bar/tab-terminal-identifiers.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-terminal-identifiers.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it } from 'vitest'
+import type { TerminalLayoutSnapshot } from '../../../../shared/terminal-tab-types'
+import type { PaneAgentSessionIdState } from '../terminal-pane/pane-agent-session-id'
+import { resolveTabAgentSessionId, resolveTabIdentityLeafId } from './tab-terminal-identifiers'
+
+const FOCUSED_LEAF = '11111111-1111-4111-8111-111111111111'
+const SIBLING_LEAF = '22222222-2222-4222-8222-222222222222'
+
+function splitLayout(activeLeafId: string | null): TerminalLayoutSnapshot {
+  return {
+    root: {
+      type: 'split',
+      direction: 'vertical',
+      first: { type: 'leaf', leafId: FOCUSED_LEAF },
+      second: { type: 'leaf', leafId: SIBLING_LEAF }
+    },
+    activeLeafId,
+    expandedLeafId: null
+  }
+}
+
+function sessionArgs(overrides: {
+  layout?: TerminalLayoutSnapshot
+  agentStatusByPaneKey?: Record<string, unknown>
+  sleepingAgentSessionsByPaneKey?: Record<string, unknown>
+  paneForegroundAgentByPaneKey?: Record<string, unknown>
+}): Parameters<typeof resolveTabAgentSessionId>[0] {
+  return {
+    tabId: 'term-1',
+    layout: overrides.layout,
+    state: {
+      agentStatusByPaneKey: overrides.agentStatusByPaneKey ?? {},
+      sleepingAgentSessionsByPaneKey: overrides.sleepingAgentSessionsByPaneKey ?? {},
+      paneForegroundAgentByPaneKey: overrides.paneForegroundAgentByPaneKey ?? {}
+    } as PaneAgentSessionIdState
+  }
+}
+
+describe('resolveTabIdentityLeafId', () => {
+  it('prefers the focused pane of a split tab', () => {
+    expect(resolveTabIdentityLeafId(splitLayout(SIBLING_LEAF))).toBe(SIBLING_LEAF)
+  })
+
+  it('falls back to the first pane when focus is missing or stale', () => {
+    expect(resolveTabIdentityLeafId(splitLayout(null))).toBe(FOCUSED_LEAF)
+    expect(resolveTabIdentityLeafId(splitLayout('33333333-3333-4333-8333-333333333333'))).toBe(
+      FOCUSED_LEAF
+    )
+  })
+
+  it('keeps a persisted focus for a tab whose layout has no tree yet', () => {
+    expect(
+      resolveTabIdentityLeafId({ root: null, activeLeafId: FOCUSED_LEAF, expandedLeafId: null })
+    ).toBe(FOCUSED_LEAF)
+    expect(resolveTabIdentityLeafId(undefined)).toBeNull()
+  })
+
+  // Why: once a tree exists, a leaf missing from it has been removed. Honouring it would hand a
+  // dead pane key to copyTerminalHandleForPane and to the session lookup.
+  it('rejects a stale focus once the tree holds no terminal leaf', () => {
+    expect(
+      resolveTabIdentityLeafId({
+        root: { type: 'leaf', leafId: 'not-a-stable-pane-id' },
+        activeLeafId: FOCUSED_LEAF,
+        expandedLeafId: null
+      })
+    ).toBeNull()
+  })
+
+  it('binds a rootless tab to its single pty when no focus was persisted', () => {
+    expect(
+      resolveTabIdentityLeafId({
+        root: null,
+        activeLeafId: null,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [FOCUSED_LEAF]: 'pty-1' }
+      })
+    ).toBe(FOCUSED_LEAF)
+  })
+})
+
+describe('resolveTabAgentSessionId', () => {
+  // Why: #18070 moved the pane-level copy off the tab menu because resolving to the tab's active
+  // pane silently picks one of several agents. Offering nothing keeps the tab menu unambiguous;
+  // a split tab is copied from each pane's own menu.
+  it('offers nothing when two panes own different sessions', () => {
+    expect(
+      resolveTabAgentSessionId(
+        sessionArgs({
+          layout: splitLayout(SIBLING_LEAF),
+          agentStatusByPaneKey: {
+            [`term-1:${FOCUSED_LEAF}`]: { providerSession: { key: 'session_id', id: 'first' } },
+            [`term-1:${SIBLING_LEAF}`]: { providerSession: { key: 'session_id', id: 'second' } }
+          }
+        })
+      )
+    ).toBeNull()
+  })
+
+  it('still resolves when both panes report the same session', () => {
+    expect(
+      resolveTabAgentSessionId(
+        sessionArgs({
+          layout: splitLayout(SIBLING_LEAF),
+          agentStatusByPaneKey: {
+            [`term-1:${FOCUSED_LEAF}`]: { providerSession: { key: 'session_id', id: 'shared' } },
+            [`term-1:${SIBLING_LEAF}`]: { providerSession: { key: 'session_id', id: 'shared' } }
+          }
+        })
+      )
+    ).toBe('shared')
+  })
+
+  it('resolves a lone session owned by an unfocused pane', () => {
+    const sessionId = resolveTabAgentSessionId(
+      sessionArgs({
+        layout: splitLayout(FOCUSED_LEAF),
+        agentStatusByPaneKey: {
+          [`term-1:${SIBLING_LEAF}`]: { providerSession: { key: 'session_id', id: 'sibling' } }
+        }
+      })
+    )
+
+    expect(sessionId).toBe('sibling')
+  })
+
+  // Why: Copy Terminal ID resolves a rootless restored tab via the identity leaf, so Copy Session
+  // ID must see the same pane rather than reporting the tab has none.
+  it('resolves the session of a rootless restored tab', () => {
+    expect(
+      resolveTabAgentSessionId(
+        sessionArgs({
+          layout: { root: null, activeLeafId: FOCUSED_LEAF, expandedLeafId: null },
+          agentStatusByPaneKey: {
+            [`term-1:${FOCUSED_LEAF}`]: { providerSession: { key: 'session_id', id: 'restored' } }
+          }
+        })
+      )
+    ).toBe('restored')
+  })
+
+  it('keeps a slept agent copyable', () => {
+    expect(
+      resolveTabAgentSessionId(
+        sessionArgs({
+          layout: splitLayout(FOCUSED_LEAF),
+          sleepingAgentSessionsByPaneKey: {
+            [`term-1:${FOCUSED_LEAF}`]: { providerSession: { key: 'session_id', id: 'slept' } }
+          }
+        })
+      )
+    ).toBe('slept')
+  })
+
+  // Why: the pane menu hides its own Copy Session ID for these two states, so the tab menu that
+  // delegates to the same resolver must hide it too rather than copy an unresumable id.
+  it('reports no session once the pane is back at the shell', () => {
+    expect(
+      resolveTabAgentSessionId(
+        sessionArgs({
+          layout: splitLayout(FOCUSED_LEAF),
+          agentStatusByPaneKey: {
+            [`term-1:${FOCUSED_LEAF}`]: { providerSession: { key: 'session_id', id: 'exited' } }
+          },
+          paneForegroundAgentByPaneKey: {
+            [`term-1:${FOCUSED_LEAF}`]: { shellForeground: true }
+          }
+        })
+      )
+    ).toBeNull()
+  })
+
+  it('ignores an unconfirmed restored entry and prefers the durable record', () => {
+    expect(
+      resolveTabAgentSessionId(
+        sessionArgs({
+          layout: splitLayout(FOCUSED_LEAF),
+          agentStatusByPaneKey: {
+            [`term-1:${FOCUSED_LEAF}`]: {
+              restoredUnconfirmed: true,
+              providerSession: { key: 'session_id', id: 'unconfirmed' }
+            }
+          },
+          sleepingAgentSessionsByPaneKey: {
+            [`term-1:${FOCUSED_LEAF}`]: { providerSession: { key: 'session_id', id: 'durable' } }
+          }
+        })
+      )
+    ).toBe('durable')
+  })
+
+  it('reports no session for a plain shell tab', () => {
+    expect(resolveTabAgentSessionId(sessionArgs({ layout: splitLayout(FOCUSED_LEAF) }))).toBeNull()
+  })
+})

--- a/src/renderer/src/components/tab-bar/tab-terminal-identifiers.ts
+++ b/src/renderer/src/components/tab-bar/tab-terminal-identifiers.ts
@@ -1,0 +1,73 @@
+import type { TerminalLayoutSnapshot } from '../../../../shared/terminal-tab-types'
+import { isTerminalLeafId, makePaneKey } from '../../../../shared/stable-pane-id'
+import {
+  collectLeafIdsInOrder,
+  resolveRootlessTerminalLayoutLeafId
+} from '../terminal-pane/terminal-layout-leaf-ids'
+import {
+  resolvePaneAgentSessionId,
+  type PaneAgentSessionIdState
+} from '../terminal-pane/pane-agent-session-id'
+
+/**
+ * Pane a tab-level identifier copy acts on: the focused one, so a split tab
+ * copies what the user is looking at. Falls back to the first pane when the
+ * focus is stale (a close/hydration race can leave it pointing at a removed
+ * leaf) or absent (tab restored but never activated).
+ */
+export function resolveTabIdentityLeafId(
+  layout: TerminalLayoutSnapshot | undefined
+): string | null {
+  if (!layout) {
+    return null
+  }
+  // Why: a rootless snapshot is a tab restored but never hydrated, where the persisted focus is
+  // the only signal. Once there is a tree, a leaf absent from it is gone, so it must not pass.
+  // normalizeTerminalLayoutSnapshot draws the same line on `root`.
+  if (!layout.root) {
+    return resolveRootlessTerminalLayoutLeafId(layout)
+  }
+  const leafIds = collectLeafIdsInOrder(layout.root).filter(isTerminalLeafId)
+  const activeLeafId = layout.activeLeafId
+  if (activeLeafId && isTerminalLeafId(activeLeafId) && leafIds.includes(activeLeafId)) {
+    return activeLeafId
+  }
+  return leafIds[0] ?? null
+}
+
+/**
+ * Provider-owned session id this tab can be resumed by — the id CLI `--resume` takes; Orca
+ * terminal ids are not agent-session ids. Resolved only when the whole tab owns exactly one
+ * session, because a tab-level copy has no way to say which pane it picked. A split tab running
+ * two agents therefore offers nothing here and is copied from each pane's own menu instead.
+ */
+export function resolveTabAgentSessionId(args: {
+  tabId: string
+  layout: TerminalLayoutSnapshot | undefined
+  state: PaneAgentSessionIdState
+}): string | null {
+  const sessionIds = new Set<string>()
+  for (const leafId of tabTerminalLeafIds(args.layout)) {
+    // Why: per-pane resolution is delegated so this menu and the pane's own menu never disagree
+    // about whether a session is resumable (shell-foreground and unconfirmed-restore gates).
+    const sessionId = resolvePaneAgentSessionId(args.state, makePaneKey(args.tabId, leafId))
+    if (sessionId) {
+      sessionIds.add(sessionId)
+    }
+  }
+  const [only] = sessionIds
+  return sessionIds.size === 1 ? only : null
+}
+
+/**
+ * Terminal panes the tab currently has. A rootless snapshot has no tree to walk, so its one
+ * resolvable pane is the identity leaf - keeping both menu items in agreement about whether a
+ * restored-but-unhydrated tab has a pane at all.
+ */
+function tabTerminalLeafIds(layout: TerminalLayoutSnapshot | undefined): string[] {
+  if (layout?.root) {
+    return collectLeafIdsInOrder(layout.root).filter(isTerminalLeafId)
+  }
+  const identityLeafId = resolveTabIdentityLeafId(layout)
+  return identityLeafId ? [identityLeafId] : []
+}


### PR DESCRIPTION
## ELI5

Right-clicking a terminal tab now offers **Copy Terminal ID** and **Copy Session ID**. Before this, the only way to get a tab's terminal handle was to right-click *inside* the terminal, and the only way to get its agent session id was to hunt for the session in the AI Vault sidebar. Both identifiers are things you paste into a CLI command, so the tab you are looking at should just hand them to you.

## What Changed

Two items added to the terminal tab context menu, between **Change Title** and the **Tab Color** row:

- **Copy Terminal ID** — resolves the tab's focused pane and copies the runtime terminal handle through the existing `terminal.resolvePane` RPC, so it yields exactly the same handle the pane-level menu already copies (the one agents and `orca` CLI commands address).
- **Copy Session ID** — copies the provider-owned agent session id (what `claude --resume` / `codex resume` take).

New modules:

- `tab-terminal-identifiers.ts` — picks which pane a tab-level copy acts on (the focused one, so a split tab copies what you are looking at; falls back to the first pane when focus is stale or absent), and resolves the tab's session id from live status, then retained (finished) records, then sleeping records.
- `tab-identifier-clipboard.ts` — the two clipboard actions and their toasts.

**Copy Session ID renders only when the tab actually has a session.** A plain shell tab has none, and a permanently dead menu item would be noise; this matches how the same menu already gates *Switch to chat view*. **Copy Terminal ID is always shown**, and reports a failure toast the same way the pane-menu action does.

Both labels reuse the already-translated catalog keys from the pane menu and the AI Vault session row, so all five shipped locales are covered on day one rather than falling back to English.

## Why

Fixes the gap described in the issue: neither identifier was reachable from the tab strip. The tab is the natural place to ask for them — it is what you right-click when you want to talk about "this terminal" from somewhere else.

Two design notes worth reviewing:

- **Focused-pane semantics.** A tab can hold several panes. Copying "the tab's" id has to mean *some* pane, and the focused one is the only choice that matches what the user is pointing at. Stale-focus and rootless-layout cases fall back to the first pane rather than failing.
- **Perf.** Every tab keeps `SortableTabContextMenu` mounted, so an unconditional per-tab store subscription that scans panes is exactly the fan-out `tab-agent-status-index.ts` exists to avoid. The session lookup is therefore gated on the menu being open, and the terminal-id action reads the layout via `getState()` inside the click handler, taking no render-time subscription at all.

## Linked Issue

Fixes #16262

## Visual Proof

Terminal tab context menu, captured from the real app through the E2E Electron harness.

**Before**

<img width="516" alt="Tab context menu before the change" src="https://raw.githubusercontent.com/n0an/orca/pr-assets-16262/pr-assets/16262-before.png" />

**After** (tab running an agent, so both items are offered)

<img width="516" alt="Tab context menu after the change" src="https://raw.githubusercontent.com/n0an/orca/pr-assets-16262/pr-assets/16262-after-agent.png" />

On a plain shell tab the menu shows **Copy Terminal ID** only — **Copy Session ID** is omitted because there is no agent session to copy.

## Testing

Tested on **macOS**.

- `pnpm lint` (including `verify:localization-catalog`, `verify:localization-extraction`, `verify:localization-coverage`, `check:max-lines-ratchet`, `check:reliability-gates`, and both code-quality oxlint passes) — passes.
- `pnpm typecheck` (node / cli / web) — passes.
- Tab-bar suite: 50 files, 400 tests — passes.
- Rendered-UI check: drove the real Electron app through the E2E harness, opened the tab context menu, and confirmed both items appear and that **Copy Session ID** is absent on a session-less tab. The screenshots above are from those runs.

Steps for a reviewer:

1. Right-click a plain shell tab → **Copy Terminal ID** is present, **Copy Session ID** is not. Paste the value into `orca terminal read <id>` and confirm it addresses that terminal.
2. Launch an agent in a tab, right-click it → both items present. The copied session id is the one the agent's CLI accepts for `--resume`.
3. Split the tab, focus the second pane, right-click the tab → the copied ids belong to the focused pane.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

New tests: `tab-terminal-identifiers.test.ts` (7 cases — focused-pane preference, stale/absent focus fallback, sibling fallback, retained and sleeping records, and the no-session case) plus 2 cases in `SortableTabContextMenu.test.tsx` covering the copy actions and the gating of **Copy Session ID**.

Pre-existing, unrelated: 15 xterm IME preedit tests under `src/renderer/src/components/terminal-pane/` fail on `main` in my environment (Korean composition overlay visibility). Nothing in this change is in their import graph.

## AI Disclosure

Written with Claude Code (Opus).

## Review

Self-review against the areas called out in CONTRIBUTING:

- **Cross-platform** — no platform-conditional code paths, no path construction, no new keyboard shortcuts or shortcut labels. The two items carry no accelerators, so there is no `⌘` / `Ctrl+` divergence to get wrong.
- **Remote / SSH** — **Copy Terminal ID** goes through `terminal.resolvePane`, the same RPC the pane menu already uses, so it inherits that path's host behavior rather than introducing a new one; it does not assume a local process. **Copy Session ID** is a pure renderer-store read with no execution-host dependency. No new RPC methods, params, or stream opcodes, so there is no remote wire-compatibility surface.
- **Agent / provider neutrality** — the session id is read from `providerSession`, which every resumable agent populates; nothing branches on a specific agent or git provider.
- **Performance** — covered under *Why* above: no unconditional per-tab subscription, and the session lookup is bounded by the number of panes in one tab rather than the size of the global status map.
- **UI quality** — both items use the shared `size-3.5` icon convention and the menu's existing sizing tokens; the repo's `tab-context-menu-consistency` test enforces both and passes. Verified in the running app (screenshots above).
- **Security** — no new IPC surface, no credentials or paths written to the clipboard; the terminal handle and session id are the same values already copyable elsewhere in the app.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Scoped to the terminal tab menu only. Editor-file and browser tabs are untouched — neither has a terminal handle or an agent session, so the items would be meaningless there.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — ran `pnpm lint`, `pnpm typecheck`, and the affected test suites locally; leaving the full `pnpm test` and `pnpm build` to CI
