### PR TITLE
Add keyboard shortcut for workspace deletion

### DIFF
--- a/src/main/browser/browser-guest-shortcut-dispatch.ts
+++ b/src/main/browser/browser-guest-shortcut-dispatch.ts
@@ -46,7 +46,10 @@ export function forwardGuestShortcutInput(
     return true
   }
   if (input.isAutoRepeat) {
-    if (action?.type === 'dictationKeyDown' && shouldForwardDictationShortcut?.()) {
+    if (
+      (action?.type === 'dictationKeyDown' && shouldForwardDictationShortcut?.()) ||
+      action?.type === 'deleteCurrentWorkspace'
+    ) {
       event.preventDefault()
       return true
     }
@@ -176,6 +179,8 @@ export function forwardGuestShortcutInput(
     renderer.send('ui:toggleQuickCommandsMenu')
   } else if (action?.type === 'openNewWorkspace') {
     renderer.send('ui:openNewWorkspace')
+  } else if (action?.type === 'deleteCurrentWorkspace') {
+    renderer.send('ui:deleteCurrentWorkspace')
   } else if (action?.type === 'openWorkspaceBoard') {
     renderer.send('ui:openWorkspaceBoard')
   } else if (action?.type === 'openTasks') {

--- a/src/main/browser/browser-guest-shortcut-forwarding.test.ts
+++ b/src/main/browser/browser-guest-shortcut-forwarding.test.ts
@@ -623,6 +623,47 @@ describe('setupGuestShortcutForwarding', () => {
     expect(rendererSendMock).toHaveBeenCalledWith('ui:toggleQuickCommandsMenu')
   })
 
+  it('forwards workspace delete shortcuts from focused guest pages', () => {
+    setupGuestShortcutForwarding({
+      browserTabId,
+      guest: makeGuest(),
+      resolveRenderer: () => makeRenderer()
+    })
+
+    const isMac = process.platform === 'darwin'
+    const preventDefault = triggerBeforeInput({
+      code: 'Backspace',
+      key: 'Backspace',
+      meta: isMac,
+      control: !isMac,
+      shift: true
+    })
+
+    expect(preventDefault).toHaveBeenCalledOnce()
+    expect(rendererSendMock).toHaveBeenCalledWith('ui:deleteCurrentWorkspace')
+  })
+
+  it('consumes repeated workspace delete shortcuts from focused guest pages', () => {
+    setupGuestShortcutForwarding({
+      browserTabId,
+      guest: makeGuest(),
+      resolveRenderer: () => makeRenderer()
+    })
+
+    const isMac = process.platform === 'darwin'
+    const preventDefault = triggerBeforeInput({
+      code: 'Backspace',
+      key: 'Backspace',
+      meta: isMac,
+      control: !isMac,
+      shift: true,
+      isAutoRepeat: true
+    })
+
+    expect(preventDefault).toHaveBeenCalledOnce()
+    expect(rendererSendMock).not.toHaveBeenCalled()
+  })
+
   it('consumes guest zoom shortcuts even when the renderer is unavailable', () => {
     setupGuestShortcutForwarding({
       browserTabId,

--- a/src/main/window/createMainWindow-terminal-focus-shortcuts.test.ts
+++ b/src/main/window/createMainWindow-terminal-focus-shortcuts.test.ts
@@ -341,6 +341,64 @@ describe('createMainWindow', () => {
     expect(webContents.send).not.toHaveBeenCalled()
   })
 
+  it('suppresses auto-repeat workspace deletes from before-input-event', () => {
+    const windowHandlers: Record<string, (...args: any[]) => void> = {}
+    const webContents = {
+      on: vi.fn((event, handler) => {
+        windowHandlers[event] = handler
+      }),
+      setZoomLevel: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      invalidate: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn(),
+      isDevToolsOpened: vi.fn(),
+      openDevTools: vi.fn(),
+      closeDevTools: vi.fn()
+    }
+    const browserWindowInstance = {
+      webContents,
+      on: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isMaximized: vi.fn(() => true),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+
+    createMainWindow(null)
+
+    const isDarwin = process.platform === 'darwin'
+    const input = {
+      type: 'keyDown',
+      code: 'Backspace',
+      key: 'Backspace',
+      meta: isDarwin,
+      control: !isDarwin,
+      alt: false,
+      shift: true
+    }
+    windowHandlers['before-input-event']({ preventDefault: vi.fn() } as never, input)
+    expect(webContents.send).toHaveBeenCalledWith('ui:deleteCurrentWorkspace')
+
+    webContents.send.mockClear()
+    const repeatPreventDefault = vi.fn()
+    windowHandlers['before-input-event']({ preventDefault: repeatPreventDefault } as never, {
+      ...input,
+      isAutoRepeat: true
+    })
+
+    expect(repeatPreventDefault).toHaveBeenCalledOnce()
+    expect(webContents.send).not.toHaveBeenCalled()
+  })
+
   it('lets Terminal-first pass risky app shortcuts through when terminal input is focused', () => {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {
@@ -624,7 +682,7 @@ describe('createMainWindow', () => {
     expect(webContents.send).toHaveBeenNthCalledWith(2, 'ui:openQuickOpen')
   })
 
-  it('forwards the configured workspace delete shortcut while terminal input is focused', () => {
+  it('forwards the default workspace delete shortcut while terminal input is focused', () => {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {
       on: vi.fn((event, handler) => {
@@ -662,7 +720,7 @@ describe('createMainWindow', () => {
         getSettings: () => ({ terminalShortcutPolicy: 'terminal-first' })
       } as never,
       {
-        getKeybindings: () => ({ 'workspace.delete': ['Mod+Shift+Backspace'] })
+        getKeybindings: () => ({})
       }
     )
 

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -811,7 +811,10 @@ export function createMainWindow(
       return true
     }
 
-    if (action.type === 'toggleQuickCommandsMenu' && isAutoRepeat) {
+    if (
+      (action.type === 'toggleQuickCommandsMenu' || action.type === 'deleteCurrentWorkspace') &&
+      isAutoRepeat
+    ) {
       event.preventDefault()
       return true
     }

--- a/src/renderer/src/app-shell/app-command-handlers-workspace-delete.test.ts
+++ b/src/renderer/src/app-shell/app-command-handlers-workspace-delete.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppState } from '@/store/types'
+import type { HoveredWorkspaceDeleteTarget } from '../components/sidebar/hovered-workspace-delete'
+import type { AppShortcutState, ShortcutDispatchInput } from './app-command-handlers'
+
+const mocks = vi.hoisted(() => ({
+  deleteHoveredWorkspaceImmediately: vi.fn(),
+  hoveredTarget: { kind: 'worktree', worktree: {} } as HoveredWorkspaceDeleteTarget | null,
+  store: {} as AppState
+}))
+
+vi.mock('../store', () => ({
+  useAppStore: Object.assign(vi.fn(), { getState: () => mocks.store })
+}))
+
+vi.mock('../components/sidebar/hovered-workspace-delete', () => ({
+  deleteHoveredWorkspaceImmediately: mocks.deleteHoveredWorkspaceImmediately,
+  resolveHoveredWorkspaceDeleteTarget: () => mocks.hoveredTarget
+}))
+
+vi.mock('@/lib/floating-workspace-terminal-actions', () => ({
+  isFloatingWorkspacePanelFocused: () => false
+}))
+
+vi.mock('@/lib/terminal-shortcut-capture-notification', () => ({
+  showTerminalShortcutCaptureNotification: vi.fn()
+}))
+
+import { createAppCommandHandlers } from './app-command-handlers'
+
+function shortcutState(overrides: Partial<AppShortcutState> = {}): AppShortcutState {
+  return {
+    activeView: 'terminal',
+    activeWorktreeId: 'repo::/feature',
+    actions: {} as AppShortcutState['actions'],
+    creationLayoutActive: false,
+    floatingTerminalEnabled: false,
+    floatingTerminalOpen: false,
+    floatingVisibleTabCount: 0,
+    keybindings: {},
+    openFloatingWorkspaceMaximized: vi.fn(),
+    pluginCommands: [],
+    setFloatingTerminalOpen: vi.fn(),
+    terminalShortcutPolicy: 'orca-first',
+    workspaceChromeActive: true,
+    ...overrides
+  }
+}
+
+function shortcutInput(): ShortcutDispatchInput {
+  return {
+    target: null,
+    defaultPrevented: false,
+    preventDefault: vi.fn()
+  }
+}
+
+describe('workspace delete app command', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.store = { activeWorktreeId: 'repo::/feature' } as AppState
+    mocks.hoveredTarget = { kind: 'worktree', worktree: {} as never }
+  })
+
+  it('claims the chord and immediately deletes the active workspace', () => {
+    const input = shortcutInput()
+    const handler = createAppCommandHandlers(shortcutState(), input, 'terminal').get(
+      'workspace.delete'
+    )
+
+    expect(handler?.()).toBe(true)
+    expect(input.preventDefault).toHaveBeenCalledOnce()
+    expect(mocks.deleteHoveredWorkspaceImmediately).toHaveBeenCalledWith(
+      mocks.store,
+      mocks.hoveredTarget
+    )
+  })
+
+  it('does not claim the chord without a hovered workspace', () => {
+    const input = shortcutInput()
+    const handler = createAppCommandHandlers(shortcutState(), input).get('workspace.delete')
+
+    mocks.hoveredTarget = null
+    expect(handler?.()).toBe(false)
+    expect(input.preventDefault).not.toHaveBeenCalled()
+    expect(mocks.deleteHoveredWorkspaceImmediately).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/app-shell/app-command-handlers.ts
+++ b/src/renderer/src/app-shell/app-command-handlers.ts
@@ -5,6 +5,10 @@ import { requestScrollToCurrentWorkspaceRevealAndRename } from '@/lib/scroll-to-
 import { showTerminalShortcutCaptureNotification } from '@/lib/terminal-shortcut-capture-notification'
 import { shouldShowWorktreeHistoryControls } from '../lib/titlebar-worktree-history-controls'
 import { TOGGLE_WORKSPACE_BOARD_EVENT } from '../components/sidebar/useWorkspaceBoardPanel'
+import {
+  deleteHoveredWorkspaceImmediately,
+  resolveHoveredWorkspaceDeleteTarget
+} from '../components/sidebar/hovered-workspace-delete'
 import { useAppStore } from '../store'
 import type { usePluginCommands } from '@/store/plugin-panels'
 import { isGitRepoKind } from '../../../shared/repo-kind'
@@ -188,6 +192,22 @@ export function createAppCommandHandlers(
         return claim('workspace.rename', () => {
           useAppStore.getState().setSidebarOpen(true)
           requestScrollToCurrentWorkspaceRevealAndRename()
+        })
+      }
+    ],
+    [
+      'workspace.delete',
+      () => {
+        if (floatingWorkspaceFocused) {
+          return false
+        }
+        const store = useAppStore.getState()
+        const target = resolveHoveredWorkspaceDeleteTarget(store)
+        if (!target) {
+          return false
+        }
+        return claim('workspace.delete', () => {
+          deleteHoveredWorkspaceImmediately(store, target)
         })
       }
     ],

--- a/src/renderer/src/app-shell/use-global-keybindings.ts
+++ b/src/renderer/src/app-shell/use-global-keybindings.ts
@@ -236,6 +236,9 @@ export function useGlobalKeybindings(args: {
       }
 
       const handlers = createAppCommandHandlers(state, input, context)
+      if (matchShortcut('workspace.delete') && handlers.get('workspace.delete')?.()) {
+        return
+      }
       for (const actionId of PLUGIN_COMMAND_ALIAS_ACTION_IDS) {
         if (matchShortcut(actionId) && handlers.get(actionId)?.()) {
           return

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.delete-shortcut.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.delete-shortcut.test.tsx
@@ -1,0 +1,244 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Worktree } from '../../../../shared/worktree/types'
+import WorktreeContextMenu from './WorktreeContextMenu'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const shortcutLabelMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/hooks/useShortcutLabel', () => ({
+  useOptionalShortcutLabel: shortcutLabelMock,
+  formatShortcutLabel: () => '',
+  formatOptionalShortcutLabel: () => null
+}))
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: function DropdownMenu(props: { children?: React.ReactNode; open?: boolean }) {
+    return <div data-testid="dropdown-menu">{props.children}</div>
+  },
+  DropdownMenuContent: function DropdownMenuContent(props: { children?: React.ReactNode }) {
+    return <div data-testid="dropdown-menu-content">{props.children}</div>
+  },
+  DropdownMenuItem: function DropdownMenuItem(props: {
+    children?: React.ReactNode
+    disabled?: boolean
+    variant?: string
+  }) {
+    return (
+      <div
+        data-testid="dropdown-menu-item"
+        data-variant={props.variant}
+        data-disabled={props.disabled}
+      >
+        {props.children}
+      </div>
+    )
+  },
+  DropdownMenuSeparator: function DropdownMenuSeparator() {
+    return <hr />
+  },
+  DropdownMenuShortcut: function DropdownMenuShortcut(props: { children?: React.ReactNode }) {
+    return <span data-testid="dropdown-menu-shortcut">{props.children}</span>
+  },
+  DropdownMenuLabel: function DropdownMenuLabel(props: { children?: React.ReactNode }) {
+    return <div>{props.children}</div>
+  },
+  DropdownMenuSub: function DropdownMenuSub(props: { children?: React.ReactNode }) {
+    return <div>{props.children}</div>
+  },
+  DropdownMenuSubContent: function DropdownMenuSubContent(props: { children?: React.ReactNode }) {
+    return <div>{props.children}</div>
+  },
+  DropdownMenuSubTrigger: function DropdownMenuSubTrigger(props: { children?: React.ReactNode }) {
+    return <div>{props.children}</div>
+  },
+  DropdownMenuTrigger: function DropdownMenuTrigger(props: { children?: React.ReactNode }) {
+    return <div>{props.children}</div>
+  },
+  DropdownMenuRadioGroup: function DropdownMenuRadioGroup(props: { children?: React.ReactNode }) {
+    return <div>{props.children}</div>
+  },
+  DropdownMenuRadioItem: function DropdownMenuRadioItem(props: { children?: React.ReactNode }) {
+    return <div>{props.children}</div>
+  }
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('lucide-react', async () =>
+  (await import('../tab-bar/lucide-icon-stub-fixture')).stubEveryIcon()
+)
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+const defaultStoreState = {
+  updateWorktreeMeta: vi.fn(),
+  setWorktreesPinnedAndReveal: vi.fn(),
+  workspaceStatuses: [],
+  openModal: vi.fn(),
+  projectGroups: [],
+  createProjectGroup: vi.fn(),
+  moveProjectToGroup: vi.fn(),
+  deleteStateByWorktreeId: {},
+  worktreeLineageById: {},
+  workspaceLineageByChildKey: {},
+  updateWorktreeLineage: vi.fn(),
+  tabsByWorktree: {},
+  ptyIdsByTabId: {},
+  browserTabsByWorktree: {},
+  worktreesByRepo: {},
+  repos: []
+}
+
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign(
+    (selector: (state: typeof defaultStoreState) => unknown) => selector(defaultStoreState),
+    {
+      getState: () => defaultStoreState
+    }
+  )
+}))
+
+vi.mock('@/store/selectors', () => ({
+  useAllWorktrees: () => [],
+  useRepoById: (repoId?: string) =>
+    repoId ? { id: repoId, name: repoId, displayName: repoId } : undefined,
+  useRepoMap: () => new Map(),
+  useWorktreeMap: () => new Map()
+}))
+
+vi.mock('./ProjectGroupNameDialog', () => ({
+  ProjectGroupNameDialog: () => null
+}))
+
+vi.mock('./WorktreeParentPickerPopover', () => ({
+  WorktreeParentPickerPopover: () => null
+}))
+
+vi.mock('./WorktreeDeveloperMenu', () => ({
+  WorktreeDeveloperMenu: () => null
+}))
+
+vi.mock('./WorktreeOpenInMenu', () => ({
+  WorktreeOpenInSubMenu: () => null
+}))
+
+vi.mock('./WorkspaceSleepMenuItems', () => ({
+  WorkspaceSleepMenuItems: () => null
+}))
+
+const mounted: { container: HTMLDivElement; root: Root }[] = []
+
+function renderContextMenu(worktree: Worktree) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  act(() => {
+    root.render(
+      <WorktreeContextMenu worktree={worktree}>
+        <div data-testid="card-child">Card Content</div>
+      </WorktreeContextMenu>
+    )
+  })
+  mounted.push({ container, root })
+  return container
+}
+
+describe('WorktreeContextMenu delete shortcut display', () => {
+  beforeEach(() => {
+    shortcutLabelMock.mockImplementation((action: string) => {
+      if (action === 'workspace.delete') {
+        return '⌘⇧⌫'
+      }
+      return null
+    })
+  })
+
+  afterEach(() => {
+    for (const { root, container } of mounted) {
+      act(() => {
+        root.unmount()
+      })
+      container.remove()
+    }
+    mounted.length = 0
+  })
+
+  it('renders the delete shortcut badge for standard worktree delete', () => {
+    const worktree = {
+      id: 'repo::wt-1',
+      repoId: 'repo',
+      name: 'wt-1',
+      path: '/path/to/wt-1',
+      isMainWorktree: false
+    } as unknown as Worktree
+
+    const container = renderContextMenu(worktree)
+    const target = container.querySelector('[data-worktree-context-menu-scope]') as HTMLElement
+    expect(target).toBeTruthy()
+    act(() => {
+      target.dispatchEvent(
+        new MouseEvent('contextmenu', { bubbles: true, cancelable: true, clientX: 10, clientY: 10 })
+      )
+    })
+
+    const shortcuts = container.querySelectorAll('[data-testid="dropdown-menu-shortcut"]')
+    const deleteShortcuts = Array.from(shortcuts).filter((el) => el.textContent === '⌘⇧⌫')
+    expect(deleteShortcuts.length).toBe(1)
+  })
+
+  it('renders the delete shortcut on disabled Delete Worktree for primary checkout', () => {
+    const worktree = {
+      id: 'repo-1::main',
+      repoId: 'repo-1',
+      name: 'main',
+      path: '/path/to/main',
+      isMainWorktree: true
+    } as unknown as Worktree
+
+    const container = renderContextMenu(worktree)
+    const target = container.querySelector('[data-worktree-context-menu-scope]') as HTMLElement
+    act(() => {
+      target.dispatchEvent(
+        new MouseEvent('contextmenu', { bubbles: true, cancelable: true, clientX: 10, clientY: 10 })
+      )
+    })
+
+    const shortcuts = container.querySelectorAll('[data-testid="dropdown-menu-shortcut"]')
+    const deleteShortcuts = Array.from(shortcuts).filter((el) => el.textContent === '⌘⇧⌫')
+    expect(deleteShortcuts.length).toBe(1)
+  })
+
+  it('omits the shortcut badge when the action is unassigned', () => {
+    shortcutLabelMock.mockReturnValue(null)
+    const worktree = {
+      id: 'repo::wt-1',
+      repoId: 'repo',
+      name: 'wt-1',
+      path: '/path/to/wt-1',
+      isMainWorktree: false
+    } as unknown as Worktree
+
+    const container = renderContextMenu(worktree)
+    const target = container.querySelector('[data-worktree-context-menu-scope]') as HTMLElement
+    act(() => {
+      target.dispatchEvent(
+        new MouseEvent('contextmenu', { bubbles: true, cancelable: true, clientX: 10, clientY: 10 })
+      )
+    })
+
+    const shortcuts = container.querySelectorAll('[data-testid="dropdown-menu-shortcut"]')
+    expect(shortcuts.length).toBe(0)
+  })
+})

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.delete-shortcut.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.delete-shortcut.test.tsx
@@ -198,7 +198,7 @@ describe('WorktreeContextMenu delete shortcut display', () => {
     expect(deleteShortcuts.length).toBe(1)
   })
 
-  it('renders the delete shortcut on disabled Delete Worktree for primary checkout', () => {
+  it('omits the delete shortcut on disabled Delete Worktree for primary checkout', () => {
     const worktree = {
       id: 'repo-1::main',
       repoId: 'repo-1',
@@ -217,7 +217,7 @@ describe('WorktreeContextMenu delete shortcut display', () => {
 
     const shortcuts = container.querySelectorAll('[data-testid="dropdown-menu-shortcut"]')
     const deleteShortcuts = Array.from(shortcuts).filter((el) => el.textContent === '⌘⇧⌫')
-    expect(deleteShortcuts.length).toBe(1)
+    expect(deleteShortcuts.length).toBe(0)
   })
 
   it('omits the shortcut badge when the action is unassigned', () => {

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -1033,9 +1033,6 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
                       'auto.components.sidebar.WorktreeContextMenu.deleteWorktree',
                       'Delete Worktree'
                     )}
-                    {deleteShortcut ? (
-                      <DropdownMenuShortcut>{deleteShortcut}</DropdownMenuShortcut>
-                    ) : null}
                   </DropdownMenuItem>
                 </div>
               </TooltipTrigger>
@@ -1092,7 +1089,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
                           'auto.components.sidebar.WorktreeContextMenu.f4475537d8',
                           'Delete'
                         )}
-            {!removesProject && deleteShortcut ? (
+            {!isMultiContext && !removesProject && deleteShortcut ? (
               <DropdownMenuShortcut>{deleteShortcut}</DropdownMenuShortcut>
             ) : null}
           </DropdownMenuItem>

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
+  DropdownMenuShortcut,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
@@ -68,6 +69,7 @@ import { translate } from '@/i18n/i18n'
 import { unnestWorktrees } from './worktree-unnest'
 import { parseWorkspaceKey, worktreeWorkspaceKey } from '../../../../shared/workspace-scope'
 import { getDeleteStateForWorktreeHost } from './worktree-delete-state-host-match'
+import { useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
 
 type Props = {
   worktree: Worktree
@@ -337,6 +339,7 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
   const deleteState = useAppStore((s) =>
     getDeleteStateForWorktreeHost(worktree, s.deleteStateByWorktreeId)
   )
+  const deleteShortcut = useOptionalShortcutLabel('workspace.delete')
   const [menuOpen, setMenuOpen] = useState(false)
   // Why: the Developer submenu is a power-user affordance, so it is revealed by
   // holding Option/Alt at right-click — captured at open time (like the Help
@@ -1030,6 +1033,9 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
                       'auto.components.sidebar.WorktreeContextMenu.deleteWorktree',
                       'Delete Worktree'
                     )}
+                    {deleteShortcut ? (
+                      <DropdownMenuShortcut>{deleteShortcut}</DropdownMenuShortcut>
+                    ) : null}
                   </DropdownMenuItem>
                 </div>
               </TooltipTrigger>
@@ -1086,6 +1092,9 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
                           'auto.components.sidebar.WorktreeContextMenu.f4475537d8',
                           'Delete'
                         )}
+            {!removesProject && deleteShortcut ? (
+              <DropdownMenuShortcut>{deleteShortcut}</DropdownMenuShortcut>
+            ) : null}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/src/renderer/src/components/sidebar/WorktreeDeveloperMenuReveal.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeDeveloperMenuReveal.test.tsx
@@ -66,7 +66,8 @@ vi.mock('@/components/ui/dropdown-menu', () => {
     DropdownMenuSub: passthrough,
     DropdownMenuSubContent: passthrough,
     DropdownMenuSubTrigger: passthrough,
-    DropdownMenuTrigger: passthrough
+    DropdownMenuTrigger: passthrough,
+    DropdownMenuShortcut: passthrough
   }
 })
 

--- a/src/renderer/src/components/sidebar/hovered-workspace-delete.test.ts
+++ b/src/renderer/src/components/sidebar/hovered-workspace-delete.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AppState } from '@/store/types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import {
+  deleteHoveredWorkspaceImmediately,
+  getHoveredWorkspaceIdentity,
+  resolveHoveredWorkspaceDeleteTarget
+} from './hovered-workspace-delete'
+
+function worktree(overrides: Partial<Worktree> = {}): Worktree {
+  return {
+    id: 'repo::/feature',
+    repoId: 'repo',
+    path: '/feature',
+    branch: 'feature',
+    isMainWorktree: false,
+    ...overrides
+  } as Worktree
+}
+
+function hoveredDocument(...rows: { workspaceId: string; hostIdentity: string }[]) {
+  return {
+    activeElement: null,
+    querySelectorAll: () => ({
+      length: rows.length,
+      item: (index: number) => {
+        const row = rows[index]
+        return row
+          ? ({
+              dataset: {
+                worktreeId: row.workspaceId,
+                worktreeHostIdentity: row.hostIdentity
+              }
+            } as unknown as HTMLElement)
+          : null
+      }
+    })
+  } as unknown as Pick<Document, 'activeElement' | 'querySelectorAll'>
+}
+
+function state(worktrees: Worktree[] = []): AppState {
+  return {
+    activeModal: 'none',
+    activeWorkspaceExecutionHostId: worktrees[0]?.hostId ?? null,
+    activeWorktreeId: worktrees[0]?.id ?? null,
+    deleteFolderWorkspace: vi.fn(),
+    deleteStateByWorktreeId: {},
+    setActiveWorktree: vi.fn(),
+    worktreesByRepo: { repo: worktrees }
+  } as unknown as AppState
+}
+
+describe('hovered workspace delete', () => {
+  it('uses the deepest hovered worktree row', () => {
+    expect(
+      getHoveredWorkspaceIdentity(
+        hoveredDocument(
+          { workspaceId: 'parent', hostIdentity: 'local|parent' },
+          { workspaceId: 'child', hostIdentity: 'local|child' }
+        )
+      )
+    ).toEqual({ workspaceId: 'child', hostIdentity: 'local|child' })
+  })
+
+  it('resolves the exact hovered host instead of the active workspace', () => {
+    const active = worktree({ id: 'repo::/active', path: '/active', hostId: 'local' })
+    const hovered = worktree({ hostId: 'ssh:build', instanceId: 'instance-2' })
+
+    expect(
+      resolveHoveredWorkspaceDeleteTarget(
+        state([active, hovered]),
+        hoveredDocument({ workspaceId: hovered.id, hostIdentity: 'ssh:build|repo::/feature' })
+      )
+    ).toEqual({ kind: 'worktree', worktree: hovered })
+  })
+
+  it('retains the hovered host when resolving a folder workspace', () => {
+    expect(
+      resolveHoveredWorkspaceDeleteTarget(
+        state(),
+        hoveredDocument({
+          workspaceId: 'folder:folder-1',
+          hostIdentity: 'runtime:remote-1|folder:folder-1'
+        })
+      )
+    ).toEqual({
+      kind: 'folder',
+      executionHostId: 'runtime:remote-1',
+      folderWorkspaceId: 'folder-1',
+      workspaceKey: 'folder:folder-1'
+    })
+  })
+
+  it('rejects primary worktrees, stale rows, and missing hover', () => {
+    const primary = worktree({ hostId: 'local', isMainWorktree: true })
+    const current = state([primary])
+
+    expect(
+      resolveHoveredWorkspaceDeleteTarget(
+        current,
+        hoveredDocument({ workspaceId: primary.id, hostIdentity: 'local|repo::/feature' })
+      )
+    ).toBeNull()
+    expect(
+      resolveHoveredWorkspaceDeleteTarget(
+        current,
+        hoveredDocument({ workspaceId: 'stale', hostIdentity: 'local|stale' })
+      )
+    ).toBeNull()
+    expect(resolveHoveredWorkspaceDeleteTarget(current, hoveredDocument())).toBeNull()
+  })
+
+  it('rejects worktrees that are already deleting', () => {
+    const target = worktree({ hostId: 'ssh:build' })
+    const current = state([target])
+    current.deleteStateByWorktreeId = {
+      'ssh:build|repo::/feature': {
+        isDeleting: true,
+        error: null,
+        canForceDelete: false,
+        forceDeleteReason: null
+      }
+    }
+
+    expect(
+      resolveHoveredWorkspaceDeleteTarget(
+        current,
+        hoveredDocument({ workspaceId: target.id, hostIdentity: 'ssh:build|repo::/feature' })
+      )
+    ).toBeNull()
+  })
+
+  it('rejects hovered rows while an editable control has focus', () => {
+    class EditableElement {
+      classList = { contains: () => false }
+      isContentEditable = false
+      closest = () => this
+    }
+    vi.stubGlobal('HTMLElement', EditableElement)
+    const target = worktree({ hostId: 'local' })
+    const doc = hoveredDocument({
+      workspaceId: target.id,
+      hostIdentity: 'local|repo::/feature'
+    }) as Pick<Document, 'activeElement' | 'querySelectorAll'>
+    Object.defineProperty(doc, 'activeElement', { value: new EditableElement() })
+
+    try {
+      expect(resolveHoveredWorkspaceDeleteTarget(state([target]), doc)).toBeNull()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('routes the hovered worktree through the host-qualified safety flow', () => {
+    const target = worktree({ hostId: 'ssh:build', instanceId: 'instance-2' })
+    const deleteWorktree = vi.fn()
+    const current = state([target])
+
+    expect(
+      deleteHoveredWorkspaceImmediately(
+        current,
+        { kind: 'worktree', worktree: target },
+        {
+          deleteWorktree,
+          getCurrentState: () => current
+        }
+      )
+    ).toBe(true)
+    expect(deleteWorktree).toHaveBeenCalledWith(target.id, {
+      expectedHostId: 'ssh:build',
+      expectedInstanceId: 'instance-2'
+    })
+  })
+
+  it('removes a hovered folder workspace from Orca without deleting its directory', async () => {
+    const current = state()
+    current.activeWorktreeId = 'folder:folder-1'
+    current.activeWorkspaceExecutionHostId = 'runtime:remote-1'
+    current.deleteFolderWorkspace = vi.fn().mockResolvedValue(true)
+
+    expect(
+      deleteHoveredWorkspaceImmediately(
+        current,
+        {
+          kind: 'folder',
+          executionHostId: 'runtime:remote-1',
+          folderWorkspaceId: 'folder-1',
+          workspaceKey: 'folder:folder-1'
+        },
+        { deleteWorktree: vi.fn(), getCurrentState: () => current }
+      )
+    ).toBe(true)
+    await vi.waitFor(() => expect(current.setActiveWorktree).toHaveBeenCalledWith(null))
+    expect(current.deleteFolderWorkspace).toHaveBeenCalledWith('folder-1', {
+      executionHostId: 'runtime:remote-1'
+    })
+  })
+
+  it('rejects a duplicate folder delete while the first request is pending', async () => {
+    let finishDelete!: (deleted: boolean) => void
+    const current = state()
+    current.deleteFolderWorkspace = vi.fn(
+      () => new Promise<boolean>((resolve) => (finishDelete = resolve))
+    )
+    const target = {
+      kind: 'folder' as const,
+      executionHostId: 'runtime:remote-2' as const,
+      folderWorkspaceId: 'folder-2',
+      workspaceKey: 'folder:folder-2'
+    }
+    const dependencies = { deleteWorktree: vi.fn(), getCurrentState: () => current }
+
+    expect(deleteHoveredWorkspaceImmediately(current, target, dependencies)).toBe(true)
+    expect(deleteHoveredWorkspaceImmediately(current, target, dependencies)).toBe(false)
+    expect(current.deleteFolderWorkspace).toHaveBeenCalledOnce()
+
+    finishDelete(false)
+    await vi.waitFor(() =>
+      expect(deleteHoveredWorkspaceImmediately(current, target, dependencies)).toBe(true)
+    )
+    finishDelete(false)
+  })
+})

--- a/src/renderer/src/components/sidebar/hovered-workspace-delete.ts
+++ b/src/renderer/src/components/sidebar/hovered-workspace-delete.ts
@@ -4,11 +4,12 @@ import type { AppState } from '@/store/types'
 import { isEditableTarget } from '@/lib/editable-target'
 import {
   composeWorktreeHostIdentity,
+  getExecutionHostIdFromWorktreeHostIdentity,
   getWorktreeHostIdentity
 } from '../../../../shared/worktree/host-qualified-identity'
 import type { Worktree } from '../../../../shared/worktree/types'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
-import { parseExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
 import { runWorktreeDelete } from './delete-worktree-flow'
 import { getDeleteStateForWorktreeHost } from './worktree-delete-state-host-match'
 
@@ -67,9 +68,7 @@ export function resolveHoveredWorkspaceDeleteTarget(
   }
   const workspaceScope = parseWorkspaceKey(hovered.workspaceId)
   if (workspaceScope?.type === 'folder') {
-    const executionHostId = parseExecutionHostId(
-      hovered.hostIdentity.slice(0, hovered.hostIdentity.indexOf('|'))
-    )?.id
+    const executionHostId = getExecutionHostIdFromWorktreeHostIdentity(hovered.hostIdentity)
     if (!executionHostId) {
       return null
     }

--- a/src/renderer/src/components/sidebar/hovered-workspace-delete.ts
+++ b/src/renderer/src/components/sidebar/hovered-workspace-delete.ts
@@ -1,0 +1,134 @@
+import { useAppStore } from '@/store'
+import { getAllWorktreesFromState } from '@/store/selectors'
+import type { AppState } from '@/store/types'
+import { isEditableTarget } from '@/lib/editable-target'
+import {
+  composeWorktreeHostIdentity,
+  getWorktreeHostIdentity
+} from '../../../../shared/worktree/host-qualified-identity'
+import type { Worktree } from '../../../../shared/worktree/types'
+import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
+import { parseExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
+import { runWorktreeDelete } from './delete-worktree-flow'
+import { getDeleteStateForWorktreeHost } from './worktree-delete-state-host-match'
+
+const pendingFolderDeletes = new Set<string>()
+
+type DeleteWorktree = typeof runWorktreeDelete
+type HoveredWorkspaceDeleteState = Pick<
+  AppState,
+  | 'activeModal'
+  | 'activeWorktreeId'
+  | 'deleteFolderWorkspace'
+  | 'deleteStateByWorktreeId'
+  | 'worktreesByRepo'
+>
+type CurrentWorkspaceState = Pick<
+  AppState,
+  'activeWorkspaceExecutionHostId' | 'activeWorktreeId' | 'setActiveWorktree'
+>
+type HoveredWorkspaceDeleteDependencies = {
+  deleteWorktree: DeleteWorktree
+  getCurrentState: () => CurrentWorkspaceState
+}
+type HoveredWorkspaceDocument = Pick<Document, 'activeElement' | 'querySelectorAll'>
+
+export type HoveredWorkspaceDeleteTarget =
+  | {
+      kind: 'folder'
+      executionHostId: ExecutionHostId
+      folderWorkspaceId: string
+      workspaceKey: string
+    }
+  | { kind: 'worktree'; worktree: Worktree }
+
+export function getHoveredWorkspaceIdentity(
+  doc: HoveredWorkspaceDocument = document
+): { hostIdentity: string; workspaceId: string } | null {
+  const hoveredRows = doc.querySelectorAll<HTMLElement>(
+    '[data-worktree-sidebar] [role="option"][data-worktree-id]:hover'
+  )
+  const row = hoveredRows.item(hoveredRows.length - 1)
+  const workspaceId = row?.dataset.worktreeId
+  const hostIdentity = row?.dataset.worktreeHostIdentity
+  return workspaceId && hostIdentity ? { workspaceId, hostIdentity } : null
+}
+
+export function resolveHoveredWorkspaceDeleteTarget(
+  state: HoveredWorkspaceDeleteState,
+  doc: HoveredWorkspaceDocument = document
+): HoveredWorkspaceDeleteTarget | null {
+  if (state.activeModal !== 'none' || (doc.activeElement && isEditableTarget(doc.activeElement))) {
+    return null
+  }
+  const hovered = getHoveredWorkspaceIdentity(doc)
+  if (!hovered) {
+    return null
+  }
+  const workspaceScope = parseWorkspaceKey(hovered.workspaceId)
+  if (workspaceScope?.type === 'folder') {
+    const executionHostId = parseExecutionHostId(
+      hovered.hostIdentity.slice(0, hovered.hostIdentity.indexOf('|'))
+    )?.id
+    if (!executionHostId) {
+      return null
+    }
+    return {
+      kind: 'folder',
+      executionHostId,
+      folderWorkspaceId: workspaceScope.folderWorkspaceId,
+      workspaceKey: hovered.workspaceId
+    }
+  }
+  const worktree = getAllWorktreesFromState(state).find(
+    (candidate) =>
+      candidate.id === hovered.workspaceId &&
+      getWorktreeHostIdentity(candidate) === hovered.hostIdentity
+  )
+  return worktree &&
+    !worktree.isMainWorktree &&
+    !getDeleteStateForWorktreeHost(worktree, state.deleteStateByWorktreeId)?.isDeleting
+    ? { kind: 'worktree', worktree }
+    : null
+}
+
+export function deleteHoveredWorkspaceImmediately(
+  state: HoveredWorkspaceDeleteState,
+  target: HoveredWorkspaceDeleteTarget | null = resolveHoveredWorkspaceDeleteTarget(state),
+  dependencies: HoveredWorkspaceDeleteDependencies = {
+    deleteWorktree: runWorktreeDelete,
+    getCurrentState: useAppStore.getState
+  }
+): boolean {
+  if (!target) {
+    return false
+  }
+  if (target.kind === 'folder') {
+    const pendingIdentity = composeWorktreeHostIdentity(target.executionHostId, target.workspaceKey)
+    if (pendingFolderDeletes.has(pendingIdentity)) {
+      return false
+    }
+    pendingFolderDeletes.add(pendingIdentity)
+    void state
+      .deleteFolderWorkspace(target.folderWorkspaceId, {
+        executionHostId: target.executionHostId
+      })
+      .then((deleted) => {
+        const current = dependencies.getCurrentState()
+        if (
+          deleted &&
+          current.activeWorktreeId === target.workspaceKey &&
+          current.activeWorkspaceExecutionHostId === target.executionHostId
+        ) {
+          current.setActiveWorktree(null)
+        }
+      })
+      .finally(() => pendingFolderDeletes.delete(pendingIdentity))
+    return true
+  }
+  dependencies.deleteWorktree(target.worktree.id, {
+    expectedInstanceId: target.worktree.instanceId,
+    ...(target.worktree.hostId ? { expectedHostId: target.worktree.hostId } : {})
+  })
+  return true
+}

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -8,7 +8,7 @@ import { getWorktreeMapFromState, getRepoMapFromState } from '@/store/selectors'
 import { applyUIZoom } from '@/lib/ui-zoom'
 import { activateAndRevealWorktree, activateAndRevealWorkspace } from '@/lib/worktree-activation'
 import { buildLinearIssueLinkedWorkItem } from '@/lib/linear-linked-work-item'
-import { runWorktreeDelete } from '@/components/sidebar/delete-worktree-flow'
+import { deleteHoveredWorkspaceImmediately } from '@/components/sidebar/hovered-workspace-delete'
 import { runSleepWorktree } from '@/components/sidebar/sleep-worktree-flow'
 import { createBackgroundSleepingAgentWakeDispatcher } from '@/lib/wake-sleeping-agents-in-background'
 import { TOGGLE_WORKSPACE_BOARD_EVENT } from '@/components/sidebar/useWorkspaceBoardPanel'
@@ -1426,20 +1426,10 @@ export function useIpcEvents(): void {
     if (window.api.ui.onDeleteCurrentWorkspace) {
       unsubs.push(
         window.api.ui.onDeleteCurrentWorkspace(() => {
-          const store = useAppStore.getState()
-          if (
-            store.activeModal !== 'none' ||
-            store.activeView !== 'terminal' ||
-            !store.activeWorktreeId
-          ) {
+          if (isFloatingWorkspacePanelFocused()) {
             return
           }
-          runWorktreeDelete(
-            store.activeWorktreeId,
-            store.activeWorkspaceExecutionHostId
-              ? { expectedHostId: store.activeWorkspaceExecutionHostId }
-              : {}
-          )
+          deleteHoveredWorkspaceImmediately(useAppStore.getState())
         })
       )
     }

--- a/src/renderer/src/lib/worktree-runtime-owner-index.ts
+++ b/src/renderer/src/lib/worktree-runtime-owner-index.ts
@@ -54,7 +54,7 @@ type IndexedProjectGroupOwnerResolution =
   | { kind: 'missing' }
   | { kind: 'ambiguous' }
 
-function catalogOwnerHostId(owner: {
+export function getCatalogOwnerHostId(owner: {
   connectionId?: string | null
   executionHostId?: string | null
 }): ExecutionHostId {
@@ -74,11 +74,11 @@ function buildCatalogOwnerIndex<
   const next = new Map<string, { kind: 'resolved'; owner: T } | { kind: 'ambiguous' }>()
   for (const record of records) {
     const id = record.id
-    const hostId = catalogOwnerHostId(record)
+    const hostId = getCatalogOwnerHostId(record)
     const current = next.get(id)
     if (!current) {
       next.set(id, { kind: 'resolved', owner: record })
-    } else if (current.kind === 'resolved' && catalogOwnerHostId(current.owner) !== hostId) {
+    } else if (current.kind === 'resolved' && getCatalogOwnerHostId(current.owner) !== hostId) {
       next.set(id, { kind: 'ambiguous' })
     }
     next.set(`${id}\0${hostId}`, {

--- a/src/renderer/src/store/slices/folder-workspace-owner-routed-mutations.test.ts
+++ b/src/renderer/src/store/slices/folder-workspace-owner-routed-mutations.test.ts
@@ -427,6 +427,7 @@ describe('folder workspace owner-routed mutations', () => {
       timeoutMs: 15_000
     })
     expect(folderWorkspacesDelete).not.toHaveBeenCalled()
+    expect(store.getState().folderWorkspaces).toEqual([])
   })
 
   it('deletes only the host-qualified folder when ids collide', async () => {

--- a/src/renderer/src/store/slices/folder-workspace-owner-routed-mutations.test.ts
+++ b/src/renderer/src/store/slices/folder-workspace-owner-routed-mutations.test.ts
@@ -428,4 +428,37 @@ describe('folder workspace owner-routed mutations', () => {
     })
     expect(folderWorkspacesDelete).not.toHaveBeenCalled()
   })
+
+  it('deletes only the host-qualified folder when ids collide', async () => {
+    const localFolder = makeFolderWorkspace({ executionHostId: 'local' })
+    const runtimeFolder = makeFolderWorkspace({ executionHostId: 'runtime:env-owner' })
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-delete-folder',
+      ok: true,
+      result: { deleted: true },
+      _meta: { runtimeId: 'runtime-owner' }
+    })
+    const store = createTestStore()
+    store.setState({
+      activeWorktreeId: `folder:${runtimeFolder.id}`,
+      activeWorkspaceExecutionHostId: 'runtime:env-owner',
+      settings: { activeRuntimeEnvironmentId: 'env-owner' } as never,
+      projectGroups: [{ ...projectGroup, executionHostId: 'local' }],
+      folderWorkspaces: [localFolder, runtimeFolder]
+    })
+
+    await expect(
+      store
+        .getState()
+        .deleteFolderWorkspace(runtimeFolder.id, { executionHostId: 'runtime:env-owner' })
+    ).resolves.toBe(true)
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-owner',
+      method: 'folderWorkspace.delete',
+      params: { folderWorkspaceId: runtimeFolder.id },
+      timeoutMs: 15_000
+    })
+    expect(store.getState().folderWorkspaces).toEqual([localFolder])
+  })
 })

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -112,8 +112,10 @@ import { getEnvironmentSshStateGeneration } from './runtime-environment-ssh'
 import { getRuntimeEnvironmentConnectionGeneration } from './runtime-status'
 import {
   findFolderWorkspaceOwner,
+  getExecutionHostIdForFolderWorkspace,
   getRuntimeEnvironmentIdForFolderWorkspace
 } from '@/lib/folder-workspace-runtime-owner'
+import { getCatalogOwnerHostId } from '@/lib/worktree-runtime-owner-index'
 import {
   FolderWorkspaceUpdateCoordinator,
   type FolderWorkspaceUpdateTicket
@@ -1908,7 +1910,10 @@ export type RepoSlice = {
     updates: FolderWorkspaceUpdates,
     options?: { executionHostId?: ExecutionHostId }
   ) => Promise<boolean>
-  deleteFolderWorkspace: (folderWorkspaceId: string) => Promise<boolean>
+  deleteFolderWorkspace: (
+    folderWorkspaceId: string,
+    options?: { executionHostId?: ExecutionHostId }
+  ) => Promise<boolean>
   // options.hostId targets a specific host's row + RPC target when the id exists on multiple hosts; else the group's own host owns the call.
   updateProjectGroup: (
     groupId: string,
@@ -2980,12 +2985,22 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     }
   },
 
-  deleteFolderWorkspace: async (folderWorkspaceId) => {
+  deleteFolderWorkspace: async (folderWorkspaceId, options) => {
     const state = get()
-    if (!findFolderWorkspaceOwner(state, folderWorkspaceId)) {
+    const executionHostId = options?.executionHostId
+    if (!findFolderWorkspaceOwner(state, folderWorkspaceId, executionHostId)) {
       return false
     }
-    const runtimeEnvironmentId = getRuntimeEnvironmentIdForFolderWorkspace(state, folderWorkspaceId)
+    const ownerHostId = getExecutionHostIdForFolderWorkspace(
+      state,
+      folderWorkspaceId,
+      executionHostId
+    )
+    const runtimeEnvironmentId = getRuntimeEnvironmentIdForFolderWorkspace(
+      state,
+      folderWorkspaceId,
+      executionHostId
+    )
     try {
       // Why: deletion targets the folder's owner; focus may be on a different host.
       const target = getActiveRuntimeTarget({ activeRuntimeEnvironmentId: runtimeEnvironmentId })
@@ -3006,11 +3021,14 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       const workspaceKey = folderWorkspaceKey(folderWorkspaceId)
       set((s) => ({
         folderWorkspaces: s.folderWorkspaces.filter(
-          (workspace) => workspace.id !== folderWorkspaceId
+          (workspace) =>
+            workspace.id !== folderWorkspaceId || getCatalogOwnerHostId(workspace) !== ownerHostId
         ),
         folderWorkspacePathStatuses: {}
       }))
-      get().purgeWorktreeTerminalState([workspaceKey])
+      if (!get().folderWorkspaces.some((workspace) => workspace.id === folderWorkspaceId)) {
+        get().purgeWorktreeTerminalState([workspaceKey])
+      }
       return true
     } catch (err) {
       console.error('Failed to delete folder workspace:', err)

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -115,7 +115,6 @@ import {
   getExecutionHostIdForFolderWorkspace,
   getRuntimeEnvironmentIdForFolderWorkspace
 } from '@/lib/folder-workspace-runtime-owner'
-import { getCatalogOwnerHostId } from '@/lib/worktree-runtime-owner-index'
 import {
   FolderWorkspaceUpdateCoordinator,
   type FolderWorkspaceUpdateTicket
@@ -3022,7 +3021,8 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       set((s) => ({
         folderWorkspaces: s.folderWorkspaces.filter(
           (workspace) =>
-            workspace.id !== folderWorkspaceId || getCatalogOwnerHostId(workspace) !== ownerHostId
+            workspace.id !== folderWorkspaceId ||
+            getFolderWorkspaceHostId(workspace, s.projectGroups) !== ownerHostId
         ),
         folderWorkspacePathStatuses: {}
       }))

--- a/src/shared/keybindings-parsing.test.ts
+++ b/src/shared/keybindings-parsing.test.ts
@@ -144,6 +144,8 @@ describe('keybindings', () => {
   it('formats keybindings with platform labels', () => {
     expect(formatKeybindingList(['Mod+Shift+J'], 'darwin')).toBe('⌘⇧J')
     expect(formatKeybindingList(['Mod+Shift+J'], 'linux')).toBe('Ctrl+Shift+J')
+    expect(formatKeybindingList(['Mod+Shift+Backspace'], 'darwin')).toBe('⌘⇧⌫')
+    expect(formatKeybindingList(['Mod+Shift+Backspace'], 'linux')).toBe('Ctrl+Shift+Backspace')
     expect(formatKeybindingList([], 'win32')).toBe('Unassigned')
   })
 

--- a/src/shared/keybindings-unassigned-actions.test.ts
+++ b/src/shared/keybindings-unassigned-actions.test.ts
@@ -56,7 +56,7 @@ describe('keybindings', () => {
     ).toBe(true)
   })
 
-  it('keeps workspace delete unassigned until users customize it', () => {
+  it('binds immediate workspace delete without claiming terminal split right', () => {
     const binding = {
       key: 'Backspace',
       code: 'Backspace',
@@ -66,13 +66,28 @@ describe('keybindings', () => {
       shift: true
     }
 
-    expect(getEffectiveKeybindingsForAction('workspace.delete', 'linux')).toEqual([])
-    expect(keybindingMatchesAction('workspace.delete', binding, 'linux')).toBe(false)
+    expect(getEffectiveKeybindingsForAction('workspace.delete', 'darwin')).toEqual([
+      'Mod+Shift+Backspace'
+    ])
+    expect(getEffectiveKeybindingsForAction('workspace.delete', 'linux')).toEqual([
+      'Mod+Shift+Backspace'
+    ])
+    expect(getEffectiveKeybindingsForAction('workspace.delete', 'win32')).toEqual([
+      'Mod+Shift+Backspace'
+    ])
+    expect(keybindingMatchesAction('workspace.delete', binding, 'linux')).toBe(true)
     expect(
       keybindingMatchesAction('workspace.delete', binding, 'linux', {
-        'workspace.delete': ['Mod+Shift+Backspace']
+        'workspace.delete': []
       })
-    ).toBe(true)
+    ).toBe(false)
+    expect(
+      keybindingMatchesAction(
+        'workspace.delete',
+        { key: 'd', code: 'KeyD', control: false, meta: true, alt: true, shift: false },
+        'darwin'
+      )
+    ).toBe(false)
   })
 
   it('keeps workspace board unassigned until users customize it', () => {

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -293,8 +293,8 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
       'remove',
       'trash'
     ],
-    // Why: ship now without a default chord; user overrides still win when a future default is assigned.
-    defaultBindings: platformBindings([]),
+    // Why: Backspace avoids the terminal pane's D-based split shortcuts on every platform.
+    defaultBindings: platformBindings(['Mod+Shift+Backspace']),
     allowInTerminal: true
   },
   {
@@ -2281,7 +2281,7 @@ export function formatKeybinding(binding: string, platform: NodeJS.Platform): st
   if (parsed.shift) {
     parts.push(isMac ? '⇧' : 'Shift')
   }
-  parts.push(formatKeyToken(parsed.key))
+  parts.push(formatKeyToken(parsed.key, isMac))
   return parts
 }
 
@@ -2317,7 +2317,7 @@ export function findKeybindingActionsForBinding(
   ).map((definition) => definition.id)
 }
 
-function formatKeyToken(token: string): string {
+function formatKeyToken(token: string, isMac: boolean): string {
   const labels: Record<string, string> = {
     BracketLeft: '[',
     BracketRight: ']',
@@ -2341,7 +2341,7 @@ function formatKeyToken(token: string): string {
     Quote: "'",
     Backquote: '`',
     Enter: 'Enter',
-    Backspace: 'Backspace',
+    Backspace: isMac ? '⌫' : 'Backspace',
     Delete: 'Delete',
     Insert: 'Insert',
     Tab: 'Tab',

--- a/src/shared/window-shortcut-policy.test.ts
+++ b/src/shared/window-shortcut-policy.test.ts
@@ -377,7 +377,7 @@ describe('resolveWindowShortcutAction', () => {
     ).toEqual({ type: 'openTasks' })
   })
 
-  it('leaves workspace delete unbound by default but honors custom terminal-active bindings', () => {
+  it('resolves workspace delete by default and honors custom terminal-active bindings', () => {
     const input = {
       code: 'Backspace',
       key: 'Backspace',
@@ -387,17 +387,18 @@ describe('resolveWindowShortcutAction', () => {
       shift: true
     }
 
-    expect(resolveWindowShortcutAction(input, 'linux')).toBeNull()
+    expect(resolveWindowShortcutAction(input, 'linux')).toEqual({ type: 'deleteCurrentWorkspace' })
+    const customInput = { ...input, code: 'KeyX', key: 'x', alt: true, shift: false }
     expect(
-      resolveWindowShortcutAction(input, 'linux', {
-        'workspace.delete': ['Mod+Shift+Backspace']
+      resolveWindowShortcutAction(customInput, 'linux', {
+        'workspace.delete': ['Mod+Alt+X']
       })
     ).toEqual({ type: 'deleteCurrentWorkspace' })
     expect(
       resolveWindowShortcutAction(
-        input,
+        customInput,
         'linux',
-        { 'workspace.delete': ['Mod+Shift+Backspace'] },
+        { 'workspace.delete': ['Mod+Alt+X'] },
         { context: 'terminal', terminalShortcutPolicy: 'terminal-first' }
       )
     ).toEqual({ type: 'deleteCurrentWorkspace' })

--- a/src/shared/worktree/host-qualified-identity.test.ts
+++ b/src/shared/worktree/host-qualified-identity.test.ts
@@ -63,4 +63,25 @@ describe('worktree host identity', () => {
   it('rejects identities without a host separator', () => {
     expect(getExecutionHostIdFromWorktreeHostIdentity('ssh:build-box')).toBeUndefined()
   })
+
+  // An unqualified row must not be assumed local: a destructive action keyed off
+  // this would then run against the wrong host.
+  it('leaves an unqualified identity without a host', () => {
+    expect(
+      getExecutionHostIdFromWorktreeHostIdentity(
+        composeWorktreeHostIdentity(undefined, WORKTREE_ID)
+      )
+    ).toBeUndefined()
+  })
+
+  it('recovers the host from a qualified identity', () => {
+    expect(
+      getExecutionHostIdFromWorktreeHostIdentity(composeWorktreeHostIdentity('local', WORKTREE_ID))
+    ).toBe('local')
+    expect(
+      getExecutionHostIdFromWorktreeHostIdentity(
+        composeWorktreeHostIdentity(toSshExecutionHostId('build-box'), WORKTREE_ID)
+      )
+    ).toBe(toSshExecutionHostId('build-box'))
+  })
 })

--- a/src/shared/worktree/host-qualified-identity.test.ts
+++ b/src/shared/worktree/host-qualified-identity.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import { toRuntimeExecutionHostId, toSshExecutionHostId } from '../execution-host'
 import {
   composeWorktreeHostIdentity,
+  getExecutionHostIdFromWorktreeHostIdentity,
   getWorktreeHostIdentity,
   getWorktreeIdFromHostIdentity
 } from './host-qualified-identity'
@@ -57,5 +58,9 @@ describe('worktree host identity', () => {
     // encodeURIComponent escapes '|' as %7C, which is what makes the split exact.
     expect(toSshExecutionHostId('we|rd')).not.toContain('|')
     expect(toRuntimeExecutionHostId('we|rd')).not.toContain('|')
+  })
+
+  it('rejects identities without a host separator', () => {
+    expect(getExecutionHostIdFromWorktreeHostIdentity('ssh:build-box')).toBeUndefined()
   })
 })

--- a/src/shared/worktree/host-qualified-identity.ts
+++ b/src/shared/worktree/host-qualified-identity.ts
@@ -1,4 +1,5 @@
 import type { ExecutionHostId } from '../execution-host'
+import { parseExecutionHostId } from '../execution-host'
 import type { Worktree } from './types'
 
 /**
@@ -36,6 +37,16 @@ export function composeWorktreeHostIdentity(
   worktreeId: string
 ): string {
   return `${hostId ?? ''}${HOST_SEPARATOR}${worktreeId}`
+}
+
+export function getExecutionHostIdFromWorktreeHostIdentity(
+  identity: string
+): ExecutionHostId | undefined {
+  const separatorIndex = identity.indexOf(HOST_SEPARATOR)
+  if (separatorIndex <= 0) {
+    return undefined
+  }
+  return parseExecutionHostId(identity.slice(0, separatorIndex))?.id
 }
 
 /**

--- a/src/shared/worktree/host-qualified-identity.ts
+++ b/src/shared/worktree/host-qualified-identity.ts
@@ -39,6 +39,13 @@ export function composeWorktreeHostIdentity(
   return `${hostId ?? ''}${HOST_SEPARATOR}${worktreeId}`
 }
 
+/**
+ * The host back out of an identity, when the identity names one.
+ *
+ * An empty prefix (`|<worktreeId>`) stays undefined rather than defaulting to
+ * `local`: an unqualified row may be on any host, and callers use this to pick
+ * the host a destructive action runs against.
+ */
 export function getExecutionHostIdFromWorktreeHostIdentity(
   identity: string
 ): ExecutionHostId | undefined {

--- a/tests/e2e/worktree-delete-shortcut.spec.ts
+++ b/tests/e2e/worktree-delete-shortcut.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from './helpers/orca-app'
+import { getAllWorktreeIds, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { pressShortcut } from './helpers/shortcuts'
+import { worktreeRow } from './worktree-row-locators'
+
+async function createIsolatedWorktree(
+  page: Parameters<typeof waitForActiveWorktree>[0]
+): Promise<string> {
+  const name = `e2e-delete-shortcut-${Date.now()}`
+  return page.evaluate(async (worktreeName) => {
+    const state = window.__store?.getState()
+    if (!state?.activeWorktreeId) {
+      throw new Error('No active worktree to derive repo from')
+    }
+    const worktree = Object.values(state.worktreesByRepo)
+      .flat()
+      .find((candidate) => candidate.id === state.activeWorktreeId)
+    if (!worktree) {
+      throw new Error('Active worktree was not found')
+    }
+
+    const result = await state.createWorktree(worktree.repoId, worktreeName)
+    await state.fetchWorktrees(worktree.repoId)
+    return result.worktree.id
+  }, name)
+}
+
+test.describe('Worktree Delete Shortcut', () => {
+  let createdWorktreeId: string | null = null
+
+  test.beforeEach(async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+  })
+
+  test.afterEach(async ({ orcaPage }) => {
+    if (!createdWorktreeId) {
+      return
+    }
+    const worktreeId = createdWorktreeId
+    createdWorktreeId = null
+    await orcaPage
+      .evaluate(async (id) => {
+        const state = window.__store?.getState()
+        await state?.removeWorktree(
+          { id, executionHostId: state.getKnownWorktreeById(id)?.hostId ?? null },
+          true
+        )
+      }, worktreeId)
+      .catch(() => undefined)
+  })
+
+  test('deletes the hovered worktree after Mod+Shift+Backspace confirmation', async ({
+    orcaPage
+  }) => {
+    createdWorktreeId = await createIsolatedWorktree(orcaPage)
+    const worktreeId = createdWorktreeId
+    const row = worktreeRow(orcaPage, worktreeId)
+    await expect(row).toBeVisible()
+
+    await row.hover()
+    await pressShortcut(orcaPage, 'Backspace', { shift: true })
+
+    const dialog = orcaPage.getByRole('dialog')
+    await expect(dialog).toBeVisible()
+    await dialog.getByRole('button', { name: 'Delete Workspace', exact: true }).click()
+
+    await expect
+      .poll(async () => getAllWorktreeIds(orcaPage), {
+        timeout: 15_000,
+        message: 'hovered worktree was not removed by the delete shortcut'
+      })
+      .not.toContain(worktreeId)
+    createdWorktreeId = null
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​823 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​809 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​225 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​29 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​196 |

<!-- /orca-pr-loc -->

## Problem

Users had to right-click on a worktree and navigate through the context menu to delete it. No keyboard shortcut was available for this common operation.

## Solution

Added a default keyboard shortcut (`Mod+Shift+Backspace` / `⌘⇧⌫` on Mac, `Ctrl+Shift+Backspace` on Linux/Windows) that immediately initiates deletion of the hovered worktree or folder workspace. The existing confirmation dialog still appears for safety. The shortcut detects which workspace is under the mouse, so no focus change is needed.

## What Changed

- Main process forwards `deleteCurrentWorkspace` action to renderer
- Renderer command handler resolves hovered workspace and triggers delete flow  
- New `hovered-workspace-delete.ts` utilities identify hovered workspaces and route deletes safely
- Context menu displays the shortcut label when assigned
- Auto-repeat key events consumed in both browser guest and main window handlers

## Why

Backspace is mnemonic for deletion, and `Shift+Mod` avoids conflicts with terminal split shortcuts. Hovering to identify the delete target removes friction compared to switching focus before deleting.

## Linked Issue

None

## Visual Proof

Minimal UI change—adds shortcut label to context menu items only. Confirmation dialog unchanged.

## Testing

- Unit tests cover shortcut forwarding, hovered workspace detection, and delete routing
- Host-qualified folder workspace deletion verified when same ID exists on multiple execution hosts  
- Context menu shortcut display tested with and without keybindings assigned
- E2E test creates worktree, hovers it, triggers shortcut, and verifies deletion
- Platform-specific tests verify Backspace formatting (⌫ on Mac, text on Linux/Windows)

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

## AI Disclosure

Internal contributor (N/A)

## Review

## Agent skill upstream boundary

- [x] Not applicable

## Notes

Cross-platform verified. Terminal shortcut policies (terminal-first, Orca-first) both honored. SSH and folder workspace execution hosts qualified correctly. Auto-repeat suppressed to prevent spam.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Minimal UI change (shortcut label); N/A for before/after
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and shortcut impact considered
- [x] Tests added for shortcut forwarding, hover detection, and e2e flow