### PR TITLE
fix(remote): deliver paired agent completion and permission alerts

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -375,7 +375,12 @@ import {
   shouldDriveSyntheticAgentTitleFromHook,
   type SyntheticAgentTitleProfile
 } from '../shared/synthetic-agent-title'
-import type { AgentStatusState } from '../shared/agent-status-types'
+import {
+  pickParsedAgentStatusPayload,
+  type AgentStatusEntry,
+  type AgentStatusState
+} from '../shared/agent-status-types'
+import type { AgentStatusFactInput } from '../shared/agent-status-fact-types'
 import { resolveTuiAgentPermissionMode } from '../shared/tui-agent-permissions'
 import { isAskUserQuestionTool } from '../shared/agent-question-answered-intent'
 import type { TerminalSideEffectBatch } from '../shared/terminal-side-effect-facts'
@@ -2489,6 +2494,37 @@ void app.whenReady().then(async () => {
     if (hookStatusChangedSessionTabs(enriched)) {
       runtime?.touchMobileSessionTabsForPane(enriched.paneKey, enriched.worktreeId ?? null)
     }
+    if (
+      enriched.restoredUnconfirmed ||
+      enriched.providerSessionOnly ||
+      enriched.isReplay ||
+      !runtime
+    ) {
+      return
+    }
+    const worktreeId =
+      enriched.worktreeId ?? runtime.getTerminalWorktreeIdForPaneKey(enriched.paneKey) ?? null
+    if (!worktreeId) {
+      return
+    }
+    const { turnCompletedAt, ...statusPayload } = pickParsedAgentStatusPayload(enriched.payload)
+    const status: AgentStatusEntry = {
+      ...statusPayload,
+      updatedAt: enriched.receivedAt,
+      stateStartedAt: enriched.stateStartedAt,
+      paneKey: enriched.paneKey,
+      stateHistory: [],
+      ...(enriched.providerSession ? { providerSession: enriched.providerSession } : {}),
+      ...(enriched.tabId ? { tabId: enriched.tabId } : {}),
+      worktreeId
+    }
+    const fact: AgentStatusFactInput = {
+      paneKey: enriched.paneKey,
+      worktreeId,
+      status,
+      ...(turnCompletedAt !== undefined ? { turnCompletedAt } : {})
+    }
+    runtime.publishAgentStatusFact(fact)
   })
   // Teardown: agent exit, pane close, and the SSH transient-disconnect batch all land
   // here. Without it the live state published above becomes a zombie question card.
@@ -2500,6 +2536,12 @@ void app.whenReady().then(async () => {
     for (const paneKey of clearedPaneKeys) {
       hookStatusChangedSessionTabs.forgetPane(paneKey)
       runtime?.touchMobileSessionTabsForPane(paneKey)
+      const worktreeId =
+        runtime?.getAgentStatusWorktreeIdForPaneKey(paneKey) ??
+        runtime?.getTerminalWorktreeIdForPaneKey(paneKey)
+      if (runtime && worktreeId) {
+        runtime.publishAgentStatusFact({ paneKey, worktreeId, status: null })
+      }
     }
   })
   unsubscribeAgentAwakeStatusChanges = () => {

--- a/src/main/ipc/runtime-environment-transport-routing.ts
+++ b/src/main/ipc/runtime-environment-transport-routing.ts
@@ -312,6 +312,7 @@ function shouldUseSharedControlSubscription(method: string): boolean {
     method === 'session.tabs.subscribeAll' ||
     method === 'accounts.subscribe' ||
     method === 'notifications.subscribe' ||
+    method === 'agent.status.subscribe' ||
     method === 'files.watch'
   )
 }

--- a/src/main/ipc/runtime-environments-subscription-routing.test.ts
+++ b/src/main/ipc/runtime-environments-subscription-routing.test.ts
@@ -233,6 +233,63 @@ describe('registerRuntimeEnvironmentHandlers', () => {
     expect(subscribeRemoteRuntimeRequestMock).not.toHaveBeenCalled()
   })
 
+  it('routes agent status facts through reconnecting shared control when supported', async () => {
+    registerRuntimeEnvironmentHandlers(store as never)
+    sendRemoteRuntimeRequestMock.mockResolvedValue({
+      id: 'status',
+      ok: true,
+      result: {
+        runtimeId: 'runtime-remote',
+        capabilities: [REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY]
+      },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    subscribeRemoteRuntimeSharedControlRequestMock.mockResolvedValue({
+      requestId: 'agent-facts-shared',
+      close: vi.fn(),
+      sendBinary: vi.fn()
+    })
+
+    const add = handler<
+      { name: string; pairingCode: string },
+      { environment: { id: string; name: string } }
+    >('runtimeEnvironments:addFromPairingCode')
+    await add(null, { name: 'desk', pairingCode: pairingCode() })
+
+    const subscribe = handler<
+      { selector: string; method: string; params?: unknown; subscriptionId?: string },
+      { subscriptionId: string; requestId: string }
+    >('runtimeEnvironments:subscribe')
+    await expect(
+      subscribe(
+        {
+          sender: {
+            id: 1,
+            isDestroyed: () => false,
+            send: vi.fn(),
+            once: vi.fn(),
+            removeListener: vi.fn()
+          }
+        },
+        {
+          selector: 'desk',
+          method: 'agent.status.subscribe',
+          params: { epoch: 'epoch-1', lastSeenSeq: 7 }
+        }
+      )
+    ).resolves.toMatchObject({ requestId: 'agent-facts-shared' })
+
+    expect(subscribeRemoteRuntimeSharedControlRequestMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Object),
+      'agent.status.subscribe',
+      { epoch: 'epoch-1', lastSeenSeq: 7 },
+      15_000,
+      expect.any(Object)
+    )
+    expect(subscribeRemoteRuntimeRequestMock).not.toHaveBeenCalled()
+  })
+
   it('keeps shared-control subscriptions retained across transient errors until final close', async () => {
     registerRuntimeEnvironmentHandlers(store as never)
     const close = vi.fn()

--- a/src/main/runtime/agent-status-fact-journal.test.ts
+++ b/src/main/runtime/agent-status-fact-journal.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import type { AgentStatusFactInput } from '../../shared/agent-status-fact-types'
+import { AgentStatusFactJournal } from './agent-status-fact-journal'
+
+const fact = (paneKey: string): AgentStatusFactInput => ({
+  paneKey,
+  worktreeId: 'repo::/worktree',
+  status: null
+})
+
+describe('AgentStatusFactJournal', () => {
+  it('assigns ordered facts and replays after a cursor', () => {
+    const journal = new AgentStatusFactJournal(8)
+    const first = journal.record(fact('pane-1'))
+    const second = journal.record(fact('pane-2'))
+
+    expect(journal.readSince(first.seq, first.epoch).facts).toEqual([second])
+    expect(journal.readSince(second.seq, second.epoch).facts).toEqual([])
+  })
+
+  it('seeds a cold subscriber silently', () => {
+    const journal = new AgentStatusFactJournal(8)
+    journal.record(fact('pane-1'))
+    const read = journal.readSince()
+
+    expect(read.gap).toBe(false)
+    expect(read.facts).toEqual([])
+    expect(read.headSeq).toBe(1)
+  })
+
+  it('reports an epoch or retention gap without returning history', () => {
+    const journal = new AgentStatusFactJournal(2)
+    const first = journal.record(fact('pane-1'))
+    journal.record(fact('pane-2'))
+    journal.record(fact('pane-3'))
+
+    expect(journal.readSince(0, first.epoch).gap).toBe(true)
+    expect(journal.readSince(0, 'old-epoch')).toMatchObject({ gap: true, facts: [] })
+  })
+
+  it('fans out live facts exactly once per subscription', () => {
+    const journal = new AgentStatusFactJournal()
+    const received: number[] = []
+    const unsubscribe = journal.subscribe((entry) => received.push(entry.seq))
+
+    journal.record(fact('pane-1'))
+    unsubscribe()
+    journal.record(fact('pane-2'))
+
+    expect(received).toEqual([1])
+  })
+})

--- a/src/main/runtime/agent-status-fact-journal.test.ts
+++ b/src/main/runtime/agent-status-fact-journal.test.ts
@@ -49,4 +49,17 @@ describe('AgentStatusFactJournal', () => {
 
     expect(received).toEqual([1])
   })
+
+  it('isolates a throwing listener from later live subscribers', () => {
+    const journal = new AgentStatusFactJournal()
+    const received: string[] = []
+    journal.subscribe(() => {
+      throw new Error('stale stream')
+    })
+    journal.subscribe((entry) => received.push(entry.paneKey))
+
+    journal.record(fact('pane-1'))
+
+    expect(received).toEqual(['pane-1'])
+  })
 })

--- a/src/main/runtime/agent-status-fact-journal.ts
+++ b/src/main/runtime/agent-status-fact-journal.ts
@@ -1,0 +1,87 @@
+import { randomUUID } from 'node:crypto'
+import type { AgentStatusFact, AgentStatusFactInput } from '../../shared/agent-status-fact-types'
+
+export type AgentStatusFactJournalRead = {
+  epoch: string
+  headSeq: number
+  gap: boolean
+  facts: AgentStatusFact[]
+}
+
+const DEFAULT_CAPACITY = 512
+
+/** Host-owned ordered facts used by paired clients while their tab inventory is parked. */
+export class AgentStatusFactJournal {
+  private readonly capacity: number
+  private readonly epochId = randomUUID()
+  private nextSeq = 0
+  private readonly facts: AgentStatusFact[] = []
+  private readonly listeners = new Set<(fact: AgentStatusFact) => void>()
+
+  constructor(capacity = DEFAULT_CAPACITY) {
+    this.capacity = Math.max(1, Math.floor(capacity))
+  }
+
+  get epoch(): string {
+    return this.epochId
+  }
+
+  get headSeq(): number {
+    return this.nextSeq
+  }
+
+  record(input: AgentStatusFactInput): AgentStatusFact {
+    const fact: AgentStatusFact = {
+      ...input,
+      seq: ++this.nextSeq,
+      epoch: this.epochId
+    }
+    this.facts.push(fact)
+    if (this.facts.length > this.capacity) {
+      this.facts.splice(0, this.facts.length - this.capacity)
+    }
+    for (const listener of this.listeners) {
+      listener(fact)
+    }
+    return fact
+  }
+
+  readSince(lastSeenSeq?: number, epoch?: string): AgentStatusFactJournalRead {
+    if (lastSeenSeq === undefined || epoch === undefined) {
+      return { epoch: this.epochId, headSeq: this.nextSeq, gap: false, facts: [] }
+    }
+    if (epoch !== this.epochId) {
+      return { epoch: this.epochId, headSeq: this.nextSeq, gap: true, facts: [] }
+    }
+    const oldestSeq = this.facts[0]?.seq ?? this.nextSeq + 1
+    if (lastSeenSeq < oldestSeq - 1) {
+      return { epoch: this.epochId, headSeq: this.nextSeq, gap: true, facts: [] }
+    }
+    return {
+      epoch: this.epochId,
+      headSeq: this.nextSeq,
+      gap: false,
+      facts: this.facts.filter((fact) => fact.seq > lastSeenSeq)
+    }
+  }
+
+  subscribe(listener: (fact: AgentStatusFact) => void): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  subscribeWithReplay(
+    listener: (fact: AgentStatusFact) => void,
+    lastSeenSeq?: number,
+    epoch?: string
+  ): AgentStatusFactJournalRead & { unsubscribe: () => void } {
+    // Registration and the synchronous read share one turn of the event loop,
+    // so a fact cannot land between the replay boundary and live fan-out.
+    this.listeners.add(listener)
+    const replay = this.readSince(lastSeenSeq, epoch)
+    return {
+      ...replay,
+      unsubscribe: () => this.listeners.delete(listener)
+    }
+  }
+}

--- a/src/main/runtime/agent-status-fact-journal.ts
+++ b/src/main/runtime/agent-status-fact-journal.ts
@@ -41,7 +41,12 @@ export class AgentStatusFactJournal {
       this.facts.splice(0, this.facts.length - this.capacity)
     }
     for (const listener of this.listeners) {
-      listener(fact)
+      try {
+        listener(fact)
+      } catch (error) {
+        // A stale stream must not abort hook ingestion or starve other clients.
+        console.warn('[agent-status-facts] listener failed:', error)
+      }
     }
     return fact
   }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -57,6 +57,7 @@ import {
   type AgentStatusEntry
 } from '../../shared/agent-status-types'
 import { terminalStatusPayloadMatchesHook } from '../../shared/agent-terminal-status-equivalence'
+import type { AgentStatusFact, AgentStatusFactInput } from '../../shared/agent-status-fact-types'
 import { indexAgentStatusRowsByPaneKey } from '../agent-hooks/agent-status-pane-index'
 import type { AgentHookAuthorityAttestation } from '../agent-hooks/server'
 import type {
@@ -132,6 +133,7 @@ import { mkdir, readFile, readdir, rm, stat } from 'node:fs/promises'
 import { resolveWorktreeCreateBase } from '../worktree-create-base'
 import { resolveWorktreeAddBaseRef } from '../../shared/worktree/base-ref'
 import { OrchestrationDb } from './orchestration/db'
+import { AgentStatusFactJournal } from './agent-status-fact-journal'
 import type { DispatchStatus } from './orchestration/types'
 import { reconcileRequestedWorkerTerminalReleases } from './orchestration/worker-terminal-release-reconciliation'
 import {
@@ -3231,6 +3233,8 @@ export class OrcaRuntimeService {
     listener: (snapshot: RuntimeMobileSessionTabsResult) => void
     clientNavigationId?: string
   }>()
+  private readonly agentStatusFactJournal = new AgentStatusFactJournal()
+  private readonly agentStatusWorktreeByPaneKey = new Map<string, string>()
   // Why: one watermark per repo replaces per-closed-pane fences while preserving stale-write safety.
   private terminalTopologyRevisionByRepoId = new Map<string, number>()
   // Why: provider exit can beat surface registration; that exact dead incarnation must never publish.
@@ -11240,6 +11244,53 @@ export class OrcaRuntimeService {
         this.mobileSessionTabsAgentStatusHeartbeat.cancelPending()
       }
     }
+  }
+
+  publishAgentStatusFact(fact: AgentStatusFactInput): AgentStatusFact {
+    if (fact.status === null) {
+      this.agentStatusWorktreeByPaneKey.delete(fact.paneKey)
+    } else {
+      this.agentStatusWorktreeByPaneKey.set(fact.paneKey, fact.worktreeId)
+    }
+    return this.agentStatusFactJournal.record(fact)
+  }
+
+  getAgentStatusWorktreeIdForPaneKey(paneKey: string): string | null {
+    return this.agentStatusWorktreeByPaneKey.get(paneKey) ?? null
+  }
+
+  readAgentStatusFactsSince(
+    lastSeenSeq?: number,
+    epoch?: string
+  ): ReturnType<AgentStatusFactJournal['readSince']> {
+    return this.agentStatusFactJournal.readSince(lastSeenSeq, epoch)
+  }
+
+  onAgentStatusFact(
+    listener: (fact: AgentStatusFact) => void,
+    lastSeenSeq?: number,
+    epoch?: string
+  ): {
+    replay: ReturnType<AgentStatusFactJournal['readSince']>
+    unsubscribe: () => void
+  } {
+    const subscription = this.agentStatusFactJournal.subscribeWithReplay(
+      listener,
+      lastSeenSeq,
+      epoch
+    )
+    // The journal owns the live fan-out. Keep the service set as an explicit
+    // liveness index so tests and teardown can inspect active fact consumers.
+    return {
+      replay: subscription,
+      unsubscribe: () => {
+        subscription.unsubscribe()
+      }
+    }
+  }
+
+  getAgentStatusFactJournalEpoch(): string {
+    return this.agentStatusFactJournal.epoch
   }
 
   forgetClientNavigationState(clientNavigationId: string): void {

--- a/src/main/runtime/rpc/methods/agent-status-facts.test.ts
+++ b/src/main/runtime/rpc/methods/agent-status-facts.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { AgentStatusFact } from '../../../../shared/agent-status-fact-types'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import { isStreamingMethod, type RpcContext, type RpcStreamingMethod } from '../core'
+import { ALL_RPC_METHODS } from './index'
+
+const subscribeMethod = ALL_RPC_METHODS.find(
+  (method) => method.name === 'agent.status.subscribe' && isStreamingMethod(method)
+) as RpcStreamingMethod
+
+const unsubscribeMethod = ALL_RPC_METHODS.find(
+  (method) => method.name === 'agent.status.unsubscribe'
+)!
+
+const fact: AgentStatusFact = {
+  epoch: 'epoch-1',
+  seq: 4,
+  paneKey: 'tab:leaf',
+  worktreeId: 'wt-1',
+  status: null
+}
+
+describe('agent status fact RPC', () => {
+  it('emits ready, replay, live facts, and end on cleanup', async () => {
+    const emitted: unknown[] = []
+    let liveListener: ((next: AgentStatusFact) => void) | null = null
+    let cleanup: (() => void) | null = null
+    const unsubscribe = vi.fn()
+    const runtime = {
+      registerSubscriptionCleanup: vi.fn((_id: string, callback: () => void) => {
+        cleanup = callback
+      }),
+      onAgentStatusFact: vi.fn((listener: (next: AgentStatusFact) => void) => {
+        liveListener = listener
+        return {
+          replay: { epoch: 'epoch-1', headSeq: 4, gap: false, facts: [fact] },
+          unsubscribe
+        }
+      })
+    } as unknown as OrcaRuntimeService
+
+    const pending = subscribeMethod.handler(
+      { lastSeenSeq: 3, epoch: 'epoch-1' },
+      { runtime, connectionId: 'conn-1', requestId: 'req-1' } as RpcContext,
+      (message) => emitted.push(message)
+    )
+
+    await vi.waitFor(() => expect(emitted).toHaveLength(2))
+    expect(emitted).toEqual([
+      {
+        type: 'ready',
+        subscriptionId: 'agent-status:conn-1:req-1',
+        epoch: 'epoch-1',
+        headSeq: 4,
+        gap: false
+      },
+      { type: 'fact', fact }
+    ])
+    liveListener!(fact)
+    expect(emitted).toHaveLength(3)
+
+    cleanup!()
+    await pending
+    expect(unsubscribe).toHaveBeenCalledOnce()
+    expect(emitted.at(-1)).toEqual({ type: 'end' })
+  })
+
+  it('only allows the owning connection to unsubscribe', async () => {
+    const cleanup = vi.fn()
+    const runtime = {
+      cleanupSubscription: cleanup
+    } as unknown as OrcaRuntimeService
+    const context = { runtime, connectionId: 'conn-1' } as RpcContext
+
+    await unsubscribeMethod.handler(
+      { subscriptionId: 'agent-status:conn-2:req-1' },
+      context,
+      () => {}
+    )
+    expect(cleanup).not.toHaveBeenCalled()
+
+    await unsubscribeMethod.handler(
+      { subscriptionId: 'agent-status:conn-1:req-1' },
+      context,
+      () => {}
+    )
+    expect(cleanup).toHaveBeenCalledWith('agent-status:conn-1:req-1')
+  })
+})

--- a/src/main/runtime/rpc/methods/agent-status-facts.ts
+++ b/src/main/runtime/rpc/methods/agent-status-facts.ts
@@ -1,0 +1,83 @@
+import { z } from 'zod'
+import { defineMethod, defineStreamingMethod, type RpcAnyMethod } from '../core'
+import type { AgentStatusFactStreamMessage } from '../../../../shared/agent-status-fact-types'
+
+const AgentStatusFactsSubscribeParams = z
+  .object({
+    lastSeenSeq: z.number().int().min(0).optional(),
+    epoch: z.string().min(1).optional()
+  })
+  .nullish()
+
+const AgentStatusFactsUnsubscribeParams = z.object({
+  subscriptionId: z.string().min(1)
+})
+
+let agentStatusSubscriptionSeq = 0
+
+export const AGENT_STATUS_FACT_METHODS: readonly RpcAnyMethod[] = [
+  defineStreamingMethod({
+    name: 'agent.status.subscribe',
+    params: AgentStatusFactsSubscribeParams,
+    handler: async (params, { runtime, connectionId, requestId }, emit) => {
+      let closed = false
+      let finish: (() => void) | null = null
+      const subscriptionId = `agent-status:${connectionId ?? 'local'}:${requestId ?? ++agentStatusSubscriptionSeq}`
+      runtime.registerSubscriptionCleanup(
+        subscriptionId,
+        () => {
+          closed = true
+          finish?.()
+          emit({ type: 'end' } satisfies AgentStatusFactStreamMessage)
+        },
+        connectionId
+      )
+
+      const subscription = runtime.onAgentStatusFact(
+        (fact) => {
+          if (!closed) {
+            emit({ type: 'fact', fact } satisfies AgentStatusFactStreamMessage)
+          }
+        },
+        params?.lastSeenSeq,
+        params?.epoch
+      )
+      if (closed) {
+        subscription.unsubscribe()
+        return
+      }
+
+      emit({
+        type: 'ready',
+        subscriptionId,
+        epoch: subscription.replay.epoch,
+        headSeq: subscription.replay.headSeq,
+        gap: subscription.replay.gap
+      } satisfies AgentStatusFactStreamMessage)
+      for (const fact of subscription.replay.facts) {
+        if (!closed) {
+          emit({ type: 'fact', fact } satisfies AgentStatusFactStreamMessage)
+        }
+      }
+
+      await new Promise<void>((resolve) => {
+        finish = () => {
+          subscription.unsubscribe()
+          resolve()
+        }
+      })
+    }
+  }),
+  defineMethod({
+    name: 'agent.status.unsubscribe',
+    params: AgentStatusFactsUnsubscribeParams,
+    handler: async (params, { runtime, connectionId }) => {
+      const expectedPrefix = `agent-status:${connectionId ?? 'local'}:`
+      if (!params.subscriptionId.startsWith(expectedPrefix)) {
+        return { unsubscribed: false }
+      }
+      runtime.cleanupSubscription(params.subscriptionId)
+      return { unsubscribed: true }
+    }
+  })
+]

--- a/src/main/runtime/rpc/methods/index.ts
+++ b/src/main/runtime/rpc/methods/index.ts
@@ -42,6 +42,7 @@ import { EMULATOR_METHODS } from './emulator'
 import { PAIRING_METHODS } from './pairing'
 import { UPDATER_METHODS } from './updater'
 import { AGENT_SESSION_METHODS } from './agent-session'
+import { AGENT_STATUS_FACT_METHODS } from './agent-status-facts'
 import { ARTIFACT_METHODS } from './artifacts'
 
 // Why: a flat manifest keeps registration order explicit and provides one
@@ -55,6 +56,7 @@ export const ALL_RPC_METHODS: readonly RpcAnyMethod[] = [
   ...REPO_METHODS,
   ...WORKTREE_METHODS,
   ...AGENT_SESSION_METHODS,
+  ...AGENT_STATUS_FACT_METHODS,
   ...TERMINAL_METHODS,
   ...TERMINAL_ORPHAN_METHODS,
   ...BROWSER_CORE_METHODS,

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -422,6 +422,8 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'status.get',
   'agentTeams.prepareLaunch',
   'agentTeams.tmuxCompat',
+  'agent.status.subscribe',
+  'agent.status.unsubscribe',
   'terminal.clearBuffer',
   'terminal.close',
   'terminal.closeTab',

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-dispose-leak.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-dispose-leak.test.ts
@@ -102,6 +102,15 @@ describe('agent completion coordinator identity map stays bounded (leak regressi
     expect(getAgentCompletionCoordinatorIdentityCountForTest()).toBe(1)
   })
 
+  it('allows authoritative tombstones to clear replay state while still live', () => {
+    const live = { value: true }
+    const coordinator = driveCompletion('tab-1:leaf-remote-tombstone', live)
+    expect(getAgentCompletionCoordinatorIdentityCountForTest()).toBe(1)
+
+    coordinator.dispose({ clearReplayState: true })
+    expect(getAgentCompletionCoordinatorIdentityCountForTest()).toBe(0)
+  })
+
   it('clears per-coordinator working boundaries on reset and dispose', () => {
     const live = { value: true }
     const coordinator = createAgentCompletionCoordinator(

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-types.ts
@@ -57,5 +57,5 @@ export type AgentCompletionCoordinator = {
   startProcessTracking: () => void
   hasPendingHookDoneCompletion: () => boolean
   resetCompletionState: (options?: { requireFreshWorking?: boolean }) => void
-  dispose: () => void
+  dispose: (options?: { clearReplayState?: boolean }) => void
 }

--- a/src/renderer/src/components/terminal-pane/agent-completion-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-lifecycle.ts
@@ -61,7 +61,7 @@ export function createAgentCompletionLifecycle({
     clearWorkingBoundary()
   }
 
-  function dispose(): void {
+  function dispose(disposeOptions: { clearReplayState?: boolean } = {}): void {
     if (processState.disposed) {
       return
     }
@@ -71,7 +71,7 @@ export function createAgentCompletionLifecycle({
     clearPendingCodexAttention()
     dropPendingTitle()
     clearWorkingBoundary()
-    identityScope.dispose(isLive())
+    identityScope.dispose(disposeOptions.clearReplayState === true ? false : isLive())
   }
 
   return {

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -265,7 +265,6 @@ describe('dispatchTerminalNotification', () => {
       agentType: 'claude',
       terminalTitle: 'claude'
     })
-
     dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'claude',
@@ -453,7 +452,6 @@ describe('dispatchTerminalNotification', () => {
     mockState.tabsByWorktree = {
       'wt-secondary': [{ id: 'tab-1' }]
     }
-
     dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: 'codex',
@@ -552,7 +550,6 @@ describe('dispatchTerminalNotification', () => {
       terminalTitle: 'Codex',
       lastAssistantMessage: undefined
     })
-
     dispatchTerminalNotification('wt-primary', {
       source: 'agent-task-complete',
       terminalTitle: '✳ Claude Code',
@@ -765,7 +762,6 @@ describe('dispatchTerminalNotification', () => {
       terminalTitle: '/workspace/orca',
       paneKey
     })
-
     expect(window.api.notifications.dispatch).toHaveBeenCalled()
     expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
   })
@@ -798,6 +794,29 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markAgentCompletionPaneUnread).not.toHaveBeenCalled()
     expect(mockState.markTerminalTabUnread).not.toHaveBeenCalled()
     expect(mockState.markTerminalPaneUnread).not.toHaveBeenCalled()
+  })
+
+  it('trusts an authoritative remote completion despite a newer client-local timestamp', () => {
+    mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
+      state: 'working',
+      stateStartedAt: Date.now() + 60_000
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey,
+      authoritativeRemote: true,
+      agentStatusSnapshot: {
+        state: 'done',
+        prompt: 'remote completion',
+        agentType: 'codex',
+        stateStartedAt: Date.now()
+      }
+    })
+
+    expect(window.api.notifications.dispatch).toHaveBeenCalled()
+    expect(mockState.markWorktreeUnread).toHaveBeenCalledWith('wt-primary')
   })
 
   it('drops accepted hook snapshots for an intentionally suppressed pty', () => {

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -117,6 +117,7 @@ export function dispatchTerminalNotification(
       : undefined
   if (
     event.source === 'agent-task-complete' &&
+    !event.authoritativeRemote &&
     isSupersededAgentCompletionSnapshot(storedAgentStatus, eventAgentStatusSnapshot)
   ) {
     return

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -58,6 +58,7 @@ export type TerminalNotificationEvent = {
   paneKey?: string
   agentStatusSnapshot?: AgentCompletionStatusSnapshot
   agentCompletionSource?: AgentCompletionDispatchMeta['source']
+  authoritativeRemote?: boolean
   suppressOsNotification?: boolean
 }
 
@@ -150,7 +151,7 @@ export function dispatchTerminalNotification(
       const isCurrentPane = hasLivePty
         ? isCurrentLivePaneKey(state, worktreeId, event.paneKey)
         : isCurrentKnownPaneKey(state, worktreeId, event.paneKey)
-      if (!tabId || !isCurrentPane) {
+      if (!tabId || (!event.authoritativeRemote && !isCurrentPane)) {
         return
       }
     }

--- a/src/renderer/src/hooks/agent-hook-completion-coordinator-factory.test.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-coordinator-factory.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const createCoordinator = vi.hoisted(() => vi.fn(() => ({}) as never))
+
+vi.mock('@/store', () => ({ useAppStore: { getState: () => ({ settings: null }) } }))
+vi.mock('@/components/terminal-pane/agent-completion-coordinator', () => ({
+  createAgentCompletionCoordinator: createCoordinator
+}))
+vi.mock('@/components/terminal-pane/use-notification-dispatch', () => ({
+  dispatchTerminalNotification: vi.fn()
+}))
+vi.mock('@/components/terminal-pane/agent-hook-terminal-lifecycle', () => ({
+  dispatchAgentHookTerminalLifecycle: vi.fn()
+}))
+
+import { createAgentHookCompletionCoordinator } from './agent-hook-completion-coordinator-factory'
+
+describe('agent hook completion coordinator factory', () => {
+  beforeEach(() => createCoordinator.mockClear())
+
+  it('does not apply client-local Codex suppression to authoritative remote facts', () => {
+    createAgentHookCompletionCoordinator({
+      paneKey: 'remote-pane',
+      worktreeId: 'remote-worktree',
+      authoritativeRemote: true,
+      getPtyId: () => null,
+      isLive: () => true,
+      isTrackingEnabled: () => true,
+      requiresFreshWorking: () => false
+    })
+
+    expect(createCoordinator).toHaveBeenCalledWith(
+      expect.objectContaining({ shouldSuppressHookCompletion: undefined })
+    )
+  })
+})

--- a/src/renderer/src/hooks/agent-hook-completion-coordinator-factory.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-coordinator-factory.ts
@@ -1,0 +1,71 @@
+import { useAppStore } from '@/store'
+import { createAgentCompletionCoordinator } from '@/components/terminal-pane/agent-completion-coordinator'
+import type { AgentCompletionCoordinator } from '@/components/terminal-pane/agent-completion-coordinator-types'
+import { dispatchTerminalNotification } from '@/components/terminal-pane/use-notification-dispatch'
+import { createCodexAutoApprovalHookCompletionSuppressor } from '@/components/terminal-pane/codex-auto-approval-notification-suppression'
+import { dispatchAgentHookTerminalLifecycle } from '@/components/terminal-pane/agent-hook-terminal-lifecycle'
+import type { RuntimeTerminalProcessInspection } from '@/runtime/runtime-terminal-inspection'
+
+export function createAgentHookCompletionCoordinator(args: {
+  paneKey: string
+  worktreeId: string
+  authoritativeRemote: boolean
+  getPtyId: () => string | null
+  isLive: () => boolean
+  isTrackingEnabled: () => boolean
+  requiresFreshWorking: () => boolean
+}): AgentCompletionCoordinator {
+  const {
+    paneKey,
+    worktreeId,
+    authoritativeRemote,
+    getPtyId,
+    isLive,
+    isTrackingEnabled,
+    requiresFreshWorking
+  } = args
+  return createAgentCompletionCoordinator({
+    paneKey,
+    statusLane: 'hook',
+    getPtyId,
+    getSettings: () => useAppStore.getState().settings,
+    inspectProcess: async (): Promise<RuntimeTerminalProcessInspection> => ({
+      foregroundProcess: null,
+      hasChildProcesses: false
+    }),
+    dispatchHookLifecycle: (payload) => dispatchAgentHookTerminalLifecycle(paneKey, payload),
+    dispatchCompletion: (title, meta) => {
+      if (!isTrackingEnabled() || requiresFreshWorking()) {
+        return
+      }
+      dispatchTerminalNotification(worktreeId, {
+        source: 'agent-task-complete',
+        terminalTitle: title,
+        paneKey,
+        suppressOsNotification: !isAgentTaskCompleteNotificationEnabled(),
+        ...(authoritativeRemote && { authoritativeRemote: true }),
+        ...(meta?.agentStatus ? { agentStatusSnapshot: meta.agentStatus } : {})
+      })
+    },
+    dispatchAttention: (title, meta) => {
+      if (!isTrackingEnabled() || requiresFreshWorking()) {
+        return
+      }
+      dispatchTerminalNotification(worktreeId, {
+        source: 'agent-task-complete',
+        terminalTitle: title,
+        paneKey,
+        suppressOsNotification: !isAgentTaskCompleteNotificationEnabled(),
+        ...(authoritativeRemote && { authoritativeRemote: true }),
+        agentStatusSnapshot: meta.agentStatus
+      })
+    },
+    isLive,
+    shouldSuppressHookCompletion: createCodexAutoApprovalHookCompletionSuppressor(paneKey)
+  })
+}
+
+function isAgentTaskCompleteNotificationEnabled(): boolean {
+  const n = useAppStore.getState().settings?.notifications
+  return n?.enabled !== false && n?.agentTaskComplete !== false
+}

--- a/src/renderer/src/hooks/agent-hook-completion-coordinator-factory.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-coordinator-factory.ts
@@ -61,7 +61,11 @@ export function createAgentHookCompletionCoordinator(args: {
       })
     },
     isLive,
-    shouldSuppressHookCompletion: createCodexAutoApprovalHookCompletionSuppressor(paneKey)
+    // Remote status is authoritative on the host; client launch arguments may
+    // describe a different or stale pane and must not suppress its attention.
+    shouldSuppressHookCompletion: authoritativeRemote
+      ? undefined
+      : createCodexAutoApprovalHookCompletionSuppressor(paneKey)
   })
 }
 

--- a/src/renderer/src/hooks/agent-hook-completion-notifications.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-notifications.ts
@@ -18,14 +18,12 @@ import {
 
 type CoordinatorEntry = {
   worktreeId: string
+  authoritativeRemote: boolean
   coordinator: AgentCompletionCoordinator
 }
 
 type StoreSnapshot = ReturnType<typeof useAppStore.getState>
 type WorktreeTab = NonNullable<StoreSnapshot['tabsByWorktree']>[string][number]
-// Why: a paneKey resolves to a tab by id. Prebuilding this index once per prune
-// pass avoids re-flattening tabsByWorktree per coordinator (O(coordinators x
-// tabs)) when a liveness or notification-setting update requires a prune.
 type TabIndex = ReadonlyMap<string, WorktreeTab>
 type PaneCoordinatorLivenessSnapshot = Pick<
   StoreSnapshot,
@@ -44,6 +42,9 @@ function disposeCoordinatorForPaneKey(paneKey: string): void {
   paneKeysRequiringFreshWorking.delete(paneKey)
 }
 
+export function forgetAgentHookCompletionNotificationCoordinator(paneKey: string): void {
+  disposeCoordinatorForPaneKey(paneKey)
+}
 function buildTabIndex(tabsByWorktree: StoreSnapshot['tabsByWorktree']): TabIndex {
   const index = new Map<string, WorktreeTab>()
   for (const tabs of Object.values(tabsByWorktree ?? {})) {
@@ -57,10 +58,7 @@ function buildTabIndex(tabsByWorktree: StoreSnapshot['tabsByWorktree']): TabInde
   }
   return index
 }
-
 function pruneClosedPaneCoordinators(): void {
-  // Why: hook-completion coordinators are module-scoped and may outlive a pane
-  // unless liveness changes from close/sleep paths evict them here.
   if (coordinatorsByPaneKey.size === 0 && paneKeysRequiringFreshWorking.size === 0) {
     lastPrunedLivenessSnapshot = null
     return
@@ -81,8 +79,6 @@ function pruneClosedPaneCoordinators(): void {
     return
   }
   lastPrunedLivenessSnapshot = livenessSnapshot
-  // Why: build the paneKey->tab index once for the whole pass instead of
-  // re-flattening tabsByWorktree inside paneCanReceiveHookCompletion per entry.
   const tabIndex = buildTabIndex(livenessSnapshot.tabsByWorktree)
   for (const paneKey of coordinatorsByPaneKey.keys()) {
     if (!paneCanReceiveHookCompletion(paneKey, tabIndex)) {
@@ -98,20 +94,16 @@ function pruneClosedPaneCoordinators(): void {
     lastPrunedLivenessSnapshot = null
   }
 }
-
 function isAgentTaskCompleteNotificationEnabled(): boolean {
-  const notifications = useAppStore.getState().settings?.notifications
-  return notifications?.enabled !== false && notifications?.agentTaskComplete !== false
+  const n = useAppStore.getState().settings?.notifications
+  return n?.enabled !== false && n?.agentTaskComplete !== false
 }
-
 function isTerminalAttentionEnabled(): boolean {
   return useAppStore.getState().settings?.experimentalTerminalAttention === true
 }
-
 function isAgentTaskCompleteTrackingEnabled(): boolean {
   return isAgentTaskCompleteNotificationEnabled() || isTerminalAttentionEnabled()
 }
-
 function syncAgentTaskCompleteTrackingEnabled(enabled: boolean): void {
   if (wasAgentTaskCompleteTrackingEnabled === undefined) {
     wasAgentTaskCompleteTrackingEnabled = enabled
@@ -126,20 +118,16 @@ function syncAgentTaskCompleteTrackingEnabled(enabled: boolean): void {
   }
   wasAgentTaskCompleteTrackingEnabled = enabled
 }
-
 export function syncAgentHookCompletionNotificationSettings(): boolean {
   pruneClosedPaneCoordinators()
   const enabled = isAgentTaskCompleteTrackingEnabled()
   syncAgentTaskCompleteTrackingEnabled(enabled)
   return enabled
 }
-
 export function syncAgentHookCompletionNotificationsForStoreUpdate(
   current: AgentHookCompletionStoreSnapshot,
   previous: AgentHookCompletionStoreSnapshot
 ): boolean {
-  // Why: Zustand also publishes high-rate title/status writes that cannot make
-  // module-scoped completion coordinators stale.
   if (!shouldSyncAgentHookCompletionForStoreUpdate(current, previous)) {
     return false
   }
@@ -149,7 +137,6 @@ export function syncAgentHookCompletionNotificationsForStoreUpdate(
   syncAgentHookCompletionNotificationSettings()
   return true
 }
-
 function getPtyIdForPaneKey(paneKey: string): string | null {
   const parsed = parsePaneKey(paneKey)
   if (!parsed) {
@@ -187,11 +174,9 @@ function getPtyIdForPaneKey(paneKey: string): string | null {
   }
   return tabPtyIds[0] ?? null
 }
-
 function paneHasLivePty(paneKey: string): boolean {
   return getPtyIdForPaneKey(paneKey) !== null
 }
-
 function resolveTabById(
   state: StoreSnapshot,
   tabId: string,
@@ -208,7 +193,6 @@ function resolveTabById(
   }
   return undefined
 }
-
 function paneKeyHasUnsuppressedPtyHint(
   state: StoreSnapshot,
   paneKey: string,
@@ -233,15 +217,17 @@ function paneKeyHasUnsuppressedPtyHint(
   const ptyHints = [tab.ptyId, leafPtyId].filter((ptyId): ptyId is string => Boolean(ptyId))
   return ptyHints.length === 0 || ptyHints.some((ptyId) => !state.suppressedPtyExitIds?.[ptyId])
 }
-
 function paneCanReceiveHookCompletion(paneKey: string, tabIndex?: TabIndex): boolean {
   const state = useAppStore.getState()
   // Why: native hook IPC is itself a live status signal. Inactive worktrees can
   // have accepted hook updates before their renderer PTY map catches up.
   return paneKeyHasUnsuppressedPtyHint(state, paneKey, tabIndex) || paneHasLivePty(paneKey)
 }
-
-function createCoordinator(paneKey: string, worktreeId: string): AgentCompletionCoordinator {
+function createCoordinator(
+  paneKey: string,
+  worktreeId: string,
+  authoritativeRemote = false
+): AgentCompletionCoordinator {
   return createAgentCompletionCoordinator({
     paneKey,
     statusLane: 'hook',
@@ -261,6 +247,7 @@ function createCoordinator(paneKey: string, worktreeId: string): AgentCompletion
         terminalTitle: title,
         paneKey,
         suppressOsNotification: !isAgentTaskCompleteNotificationEnabled(),
+        ...(authoritativeRemote && { authoritativeRemote: true }),
         ...(meta?.agentStatus ? { agentStatusSnapshot: meta.agentStatus } : {})
       })
     },
@@ -275,29 +262,30 @@ function createCoordinator(paneKey: string, worktreeId: string): AgentCompletion
         terminalTitle: title,
         paneKey,
         suppressOsNotification: !isAgentTaskCompleteNotificationEnabled(),
+        ...(authoritativeRemote && { authoritativeRemote: true }),
         agentStatusSnapshot: meta.agentStatus
       })
     },
-    isLive: () => paneCanReceiveHookCompletion(paneKey),
+    isLive: () => authoritativeRemote || paneCanReceiveHookCompletion(paneKey),
     shouldSuppressHookCompletion: createCodexAutoApprovalHookCompletionSuppressor(paneKey)
   })
 }
-
 export function observeAgentHookCompletionForNotification({
   paneKey,
   worktreeId,
   payload,
-  seedOnly
+  seedOnly,
+  authoritativeRemote
 }: {
   paneKey: string
   worktreeId: string
   payload: AgentCompletionStatusSnapshot
   seedOnly?: boolean
+  authoritativeRemote?: boolean
 }): void {
-  // Why: replay seeds already passed indexed snapshot ownership; re-resolving every row makes startup batches quadratic.
   if (seedOnly !== true) {
     pruneClosedPaneCoordinators()
-    if (!paneCanReceiveHookCompletion(paneKey)) {
+    if (!authoritativeRemote && !paneCanReceiveHookCompletion(paneKey)) {
       return
     }
   }
@@ -310,19 +298,22 @@ export function observeAgentHookCompletionForNotification({
   }
 
   let entry = coordinatorsByPaneKey.get(paneKey)
-  if (!entry || entry.worktreeId !== worktreeId) {
+  if (
+    !entry ||
+    entry.worktreeId !== worktreeId ||
+    (authoritativeRemote === true && !entry.authoritativeRemote)
+  ) {
     entry?.coordinator.dispose()
     entry = {
       worktreeId,
-      coordinator: createCoordinator(paneKey, worktreeId)
+      authoritativeRemote: authoritativeRemote === true,
+      coordinator: createCoordinator(paneKey, worktreeId, authoritativeRemote)
     }
     coordinatorsByPaneKey.set(paneKey, entry)
     if (requireFreshWorkingForNewTrackingCoordinators) {
       paneKeysRequiringFreshWorking.add(paneKey)
     }
   }
-  // Why: notification preferences may suppress alerts, but accepted hooks must
-  // still release pane-owned cursor/cache effects after the quiet window.
   if (payload.state === 'working' && payload.turnCompletedAt === undefined && trackingEnabled) {
     paneKeysRequiringFreshWorking.delete(paneKey)
   }
@@ -332,7 +323,6 @@ export function observeAgentHookCompletionForNotification({
     entry.coordinator.observeHookStatus(payload)
   }
 }
-
 export function resetAgentHookCompletionNotificationCoordinators(): void {
   for (const entry of coordinatorsByPaneKey.values()) {
     entry.coordinator.dispose()
@@ -343,7 +333,6 @@ export function resetAgentHookCompletionNotificationCoordinators(): void {
   wasAgentTaskCompleteTrackingEnabled = isAgentTaskCompleteTrackingEnabled()
   requireFreshWorkingForNewTrackingCoordinators = !wasAgentTaskCompleteTrackingEnabled
 }
-
 export function _getAgentHookCompletionNotificationCoordinatorCountForTest(): number {
   return coordinatorsByPaneKey.size
 }

--- a/src/renderer/src/hooks/agent-hook-completion-notifications.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-notifications.ts
@@ -33,7 +33,7 @@ let requireFreshWorkingForNewTrackingCoordinators = false
 let lastPrunedLivenessSnapshot: PaneCoordinatorLivenessSnapshot | null = null
 
 function disposeCoordinatorForPaneKey(paneKey: string): void {
-  coordinatorsByPaneKey.get(paneKey)?.coordinator.dispose()
+  coordinatorsByPaneKey.get(paneKey)?.coordinator.dispose({ clearReplayState: true })
   coordinatorsByPaneKey.delete(paneKey)
   paneKeysRequiringFreshWorking.delete(paneKey)
 }

--- a/src/renderer/src/hooks/agent-hook-completion-notifications.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-notifications.ts
@@ -1,15 +1,11 @@
 import { useAppStore } from '@/store'
 import { parsePaneKey } from '../../../shared/stable-pane-id'
-import { createAgentCompletionCoordinator } from '@/components/terminal-pane/agent-completion-coordinator'
 import type {
   AgentCompletionCoordinator,
   AgentCompletionStatusSnapshot
 } from '@/components/terminal-pane/agent-completion-coordinator-types'
-import type { RuntimeTerminalProcessInspection } from '@/runtime/runtime-terminal-inspection'
-import { dispatchTerminalNotification } from '@/components/terminal-pane/use-notification-dispatch'
 import { collectLeafIdsInOrder } from '@/components/terminal-pane/layout-serialization'
-import { createCodexAutoApprovalHookCompletionSuppressor } from '@/components/terminal-pane/codex-auto-approval-notification-suppression'
-import { dispatchAgentHookTerminalLifecycle } from '@/components/terminal-pane/agent-hook-terminal-lifecycle'
+import { createAgentHookCompletionCoordinator } from './agent-hook-completion-coordinator-factory'
 import {
   isAgentHookCompletionTrackingEnabled,
   shouldSyncAgentHookCompletionForStoreUpdate,
@@ -223,53 +219,6 @@ function paneCanReceiveHookCompletion(paneKey: string, tabIndex?: TabIndex): boo
   // have accepted hook updates before their renderer PTY map catches up.
   return paneKeyHasUnsuppressedPtyHint(state, paneKey, tabIndex) || paneHasLivePty(paneKey)
 }
-function createCoordinator(
-  paneKey: string,
-  worktreeId: string,
-  authoritativeRemote = false
-): AgentCompletionCoordinator {
-  return createAgentCompletionCoordinator({
-    paneKey,
-    statusLane: 'hook',
-    getPtyId: () => getPtyIdForPaneKey(paneKey),
-    getSettings: () => useAppStore.getState().settings,
-    inspectProcess: async (): Promise<RuntimeTerminalProcessInspection> => ({
-      foregroundProcess: null,
-      hasChildProcesses: false
-    }),
-    dispatchHookLifecycle: (payload) => dispatchAgentHookTerminalLifecycle(paneKey, payload),
-    dispatchCompletion: (title, meta) => {
-      if (!isAgentTaskCompleteTrackingEnabled() || paneKeysRequiringFreshWorking.has(paneKey)) {
-        return
-      }
-      dispatchTerminalNotification(worktreeId, {
-        source: 'agent-task-complete',
-        terminalTitle: title,
-        paneKey,
-        suppressOsNotification: !isAgentTaskCompleteNotificationEnabled(),
-        ...(authoritativeRemote && { authoritativeRemote: true }),
-        ...(meta?.agentStatus ? { agentStatusSnapshot: meta.agentStatus } : {})
-      })
-    },
-    dispatchAttention: (title, meta) => {
-      if (!isAgentTaskCompleteTrackingEnabled() || paneKeysRequiringFreshWorking.has(paneKey)) {
-        return
-      }
-      // Why: native notification settings still label this channel as "agent
-      // task complete"; the snapshot state makes the banner read "needs input".
-      dispatchTerminalNotification(worktreeId, {
-        source: 'agent-task-complete',
-        terminalTitle: title,
-        paneKey,
-        suppressOsNotification: !isAgentTaskCompleteNotificationEnabled(),
-        ...(authoritativeRemote && { authoritativeRemote: true }),
-        agentStatusSnapshot: meta.agentStatus
-      })
-    },
-    isLive: () => authoritativeRemote || paneCanReceiveHookCompletion(paneKey),
-    shouldSuppressHookCompletion: createCodexAutoApprovalHookCompletionSuppressor(paneKey)
-  })
-}
 export function observeAgentHookCompletionForNotification({
   paneKey,
   worktreeId,
@@ -307,7 +256,15 @@ export function observeAgentHookCompletionForNotification({
     entry = {
       worktreeId,
       authoritativeRemote: authoritativeRemote === true,
-      coordinator: createCoordinator(paneKey, worktreeId, authoritativeRemote)
+      coordinator: createAgentHookCompletionCoordinator({
+        paneKey,
+        worktreeId,
+        authoritativeRemote: authoritativeRemote === true,
+        getPtyId: () => getPtyIdForPaneKey(paneKey),
+        isLive: () => authoritativeRemote === true || paneCanReceiveHookCompletion(paneKey),
+        isTrackingEnabled: isAgentTaskCompleteTrackingEnabled,
+        requiresFreshWorking: () => paneKeysRequiringFreshWorking.has(paneKey)
+      })
     }
     coordinatorsByPaneKey.set(paneKey, entry)
     if (requireFreshWorkingForNewTrackingCoordinators) {

--- a/src/renderer/src/lib/runtime-session-mirror-owners.ts
+++ b/src/renderer/src/lib/runtime-session-mirror-owners.ts
@@ -42,6 +42,9 @@ export function getRuntimeSessionMirrorEnvironmentIds(state: WorktreeRuntimeOwne
   for (const group of state.projectGroups ?? []) {
     addRuntimeExecutionHost(ids, group.executionHostId)
   }
+  for (const workspace of state.folderWorkspaces ?? []) {
+    addRuntimeExecutionHost(ids, workspace.executionHostId)
+  }
   for (const hostId of Object.values(state.restoredRuntimeHostIdByWorkspaceSessionKey ?? {})) {
     addRuntimeExecutionHost(ids, hostId)
   }

--- a/src/renderer/src/runtime/remote-agent-status-facts.test.ts
+++ b/src/renderer/src/runtime/remote-agent-status-facts.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentStatusFactStreamMessage } from '../../../shared/agent-status-fact-types'
+import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
+
+const mocks = vi.hoisted(() => ({
+  supportsCapability: vi.fn(),
+  getRevision: vi.fn(),
+  observe: vi.fn(),
+  forget: vi.fn()
+}))
+
+vi.mock('./runtime-rpc-client', () => ({
+  runtimeEnvironmentSupportsCapability: mocks.supportsCapability
+}))
+vi.mock('./runtime-environment-revision', () => ({
+  getRuntimeEnvironmentRevision: mocks.getRevision
+}))
+vi.mock('@/hooks/agent-hook-completion-notifications', () => ({
+  observeAgentHookCompletionForNotification: mocks.observe,
+  forgetAgentHookCompletionNotificationCoordinator: mocks.forget
+}))
+
+import {
+  resetRemoteAgentStatusFactCursorsForTests,
+  subscribeRemoteAgentStatusFacts
+} from './remote-agent-status-facts'
+
+type Callback = (response: RuntimeRpcResponse<unknown>) => void
+
+const subscribe = vi.fn()
+let onResponse: Callback
+
+function send(message: AgentStatusFactStreamMessage): void {
+  onResponse({ id: 'fact', ok: true, result: message, _meta: { runtimeId: 'runtime-a' } })
+}
+
+describe('remote agent status facts', () => {
+  beforeEach(() => {
+    resetRemoteAgentStatusFactCursorsForTests()
+    mocks.supportsCapability.mockReset().mockResolvedValue(true)
+    mocks.getRevision.mockReset().mockReturnValue(7)
+    mocks.observe.mockReset()
+    mocks.forget.mockReset()
+    subscribe.mockReset().mockImplementation(async (_request, callbacks) => {
+      onResponse = callbacks.onResponse
+      return { unsubscribe: vi.fn() }
+    })
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { runtimeEnvironments: { subscribe } }
+    })
+  })
+
+  it('seeds a cold cursor silently and dispatches each newer fact once', async () => {
+    await subscribeRemoteAgentStatusFacts('env-a', 7, vi.fn(), ['agent-status.fact-stream.v1'])
+    send({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-1', headSeq: 12, gap: false })
+    send({
+      type: 'fact',
+      fact: {
+        epoch: 'epoch-1',
+        seq: 13,
+        paneKey: 'tab::leaf',
+        worktreeId: 'wt-1',
+        status: {
+          state: 'done',
+          prompt: '',
+          updatedAt: 20,
+          stateStartedAt: 20,
+          stateHistory: [],
+          paneKey: 'tab::leaf'
+        }
+      }
+    })
+    send({
+      type: 'fact',
+      fact: {
+        epoch: 'epoch-1',
+        seq: 13,
+        paneKey: 'tab::leaf',
+        worktreeId: 'wt-1',
+        status: {
+          state: 'done',
+          prompt: '',
+          updatedAt: 20,
+          stateStartedAt: 20,
+          stateHistory: [],
+          paneKey: 'tab::leaf'
+        }
+      }
+    })
+
+    expect(mocks.observe).toHaveBeenCalledOnce()
+  })
+
+  it('seeds a gap and disposes a pane on its tombstone', async () => {
+    await subscribeRemoteAgentStatusFacts('env-a', 7, vi.fn(), ['agent-status.fact-stream.v1'])
+    send({ type: 'ready', subscriptionId: 'sub-1', epoch: 'epoch-2', headSeq: 40, gap: true })
+    send({
+      type: 'fact',
+      fact: { epoch: 'epoch-2', seq: 41, paneKey: 'tab::leaf', worktreeId: 'wt-1', status: null }
+    })
+
+    expect(mocks.observe).not.toHaveBeenCalled()
+    expect(mocks.forget).toHaveBeenCalledWith('tab::leaf')
+  })
+
+  it('does not subscribe when the host does not advertise the capability', async () => {
+    const result = await subscribeRemoteAgentStatusFacts('env-a', 7, vi.fn(), [])
+    expect(result).toBeNull()
+    expect(subscribe).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/runtime/remote-agent-status-facts.ts
+++ b/src/renderer/src/runtime/remote-agent-status-facts.ts
@@ -1,0 +1,142 @@
+import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
+import {
+  AGENT_STATUS_FACT_STREAM_RUNTIME_CAPABILITY,
+  type AgentStatusFactStreamMessage
+} from '../../../shared/agent-status-fact-types'
+import { runtimeEnvironmentSupportsCapability } from './runtime-rpc-client'
+import { getRuntimeEnvironmentRevision } from './runtime-environment-revision'
+import {
+  forgetAgentHookCompletionNotificationCoordinator,
+  observeAgentHookCompletionForNotification
+} from '@/hooks/agent-hook-completion-notifications'
+import { makePaneKey, parsePaneKey } from '../../../shared/stable-pane-id'
+import { toWebTerminalSurfaceTabId } from './web-runtime-session'
+
+type AgentStatusFactCursor = { epoch: string; seq: number }
+type AgentStatusFactSubscribeParams = { epoch?: string; lastSeenSeq?: number }
+
+function toMirroredPaneKey(paneKey: string): string {
+  const parsed = parsePaneKey(paneKey)
+  return parsed ? makePaneKey(toWebTerminalSurfaceTabId(parsed.tabId), parsed.leafId) : paneKey
+}
+
+const cursorsByEnvironment = new Map<string, AgentStatusFactCursor>()
+
+export function resetRemoteAgentStatusFactCursorsForTests(): void {
+  cursorsByEnvironment.clear()
+}
+
+export async function subscribeRemoteAgentStatusFacts(
+  environmentId: string,
+  expectedEnvironmentPairingRevision: number | undefined,
+  onError: (error: unknown) => void = console.warn,
+  knownCapabilities?: readonly string[]
+): Promise<{ unsubscribe: () => void } | null> {
+  if (knownCapabilities === undefined) {
+    try {
+      if (
+        !(await runtimeEnvironmentSupportsCapability(
+          environmentId,
+          AGENT_STATUS_FACT_STREAM_RUNTIME_CAPABILITY,
+          15_000
+        ))
+      ) {
+        return null
+      }
+    } catch (error) {
+      onError(error)
+      return null
+    }
+  } else if (!knownCapabilities.includes(AGENT_STATUS_FACT_STREAM_RUNTIME_CAPABILITY)) {
+    return null
+  }
+
+  const existingCursor = cursorsByEnvironment.get(environmentId)
+  const params: AgentStatusFactSubscribeParams = existingCursor
+    ? { ...existingCursor, lastSeenSeq: existingCursor.seq }
+    : {}
+  let stopped = false
+  let handle: { unsubscribe: () => void } | null = null
+  const isCurrent = (): boolean =>
+    !stopped && getRuntimeEnvironmentRevision(environmentId) === expectedEnvironmentPairingRevision
+
+  const onResponse = (response: RuntimeRpcResponse<unknown>): void => {
+    if (!isCurrent()) {
+      return
+    }
+    if (response.ok === false) {
+      onError(response.error)
+      return
+    }
+    const message = response.result as AgentStatusFactStreamMessage
+    if (message.type === 'ready') {
+      const cursor = cursorsByEnvironment.get(environmentId)
+      // A cold client or a journal gap intentionally seeds at the current head;
+      // only an uninterrupted epoch/cursor pair is allowed to replay attention.
+      if (!cursor || cursor.epoch !== message.epoch || message.gap) {
+        const next = { epoch: message.epoch, seq: message.headSeq }
+        cursorsByEnvironment.set(environmentId, next)
+        params.epoch = next.epoch
+        params.lastSeenSeq = next.seq
+      }
+      return
+    }
+    if (message.type !== 'fact') {
+      return
+    }
+    const cursor = cursorsByEnvironment.get(environmentId)
+    if (!cursor || cursor.epoch !== message.fact.epoch || message.fact.seq <= cursor.seq) {
+      return
+    }
+    const next = { epoch: cursor.epoch, seq: message.fact.seq }
+    cursorsByEnvironment.set(environmentId, next)
+    params.epoch = next.epoch
+    params.lastSeenSeq = next.seq
+    if (message.fact.status === null) {
+      forgetAgentHookCompletionNotificationCoordinator(toMirroredPaneKey(message.fact.paneKey))
+      return
+    }
+    observeAgentHookCompletionForNotification({
+      paneKey: toMirroredPaneKey(message.fact.paneKey),
+      worktreeId: message.fact.worktreeId,
+      authoritativeRemote: true,
+      payload: {
+        ...message.fact.status,
+        ...(message.fact.turnCompletedAt !== undefined
+          ? { turnCompletedAt: message.fact.turnCompletedAt }
+          : {})
+      }
+    })
+  }
+
+  try {
+    handle = await window.api.runtimeEnvironments.subscribe(
+      {
+        selector: environmentId,
+        method: 'agent.status.subscribe',
+        params,
+        timeoutMs: 15_000,
+        expectedEnvironmentPairingRevision
+      },
+      { onResponse, onError }
+    )
+  } catch (error) {
+    if (!stopped) {
+      onError(error)
+    }
+    return null
+  }
+  if (stopped) {
+    handle.unsubscribe()
+    return null
+  }
+  return {
+    unsubscribe: () => {
+      if (stopped) {
+        return
+      }
+      stopped = true
+      handle?.unsubscribe()
+    }
+  }
+}

--- a/src/renderer/src/runtime/use-runtime-session-mirror-environment-key.test.ts
+++ b/src/renderer/src/runtime/use-runtime-session-mirror-environment-key.test.ts
@@ -68,6 +68,7 @@ function seedMirrorState(): void {
       repos: [],
       worktreesByRepo: {},
       detectedWorktreesByRepo: {},
+      folderWorkspaces: [],
       projectGroups: [],
       restoredRuntimeHostIdByWorkspaceSessionKey: {},
       runtimeEnvironments: [
@@ -216,6 +217,19 @@ describe('useRuntimeSessionMirrorEnvironmentKey', () => {
       source: 'project group host',
       change: (): Partial<AppState> => ({
         projectGroups: [makeProjectGroup('runtime:env-b')]
+      })
+    },
+    {
+      source: 'folder workspace host',
+      change: (): Partial<AppState> => ({
+        folderWorkspaces: [
+          {
+            id: 'folder-b',
+            projectGroupId: null,
+            connectionId: null,
+            executionHostId: 'runtime:env-b'
+          } as unknown as AppState['folderWorkspaces'][number]
+        ]
       })
     },
     {

--- a/src/renderer/src/runtime/use-runtime-session-mirror-environment-key.ts
+++ b/src/renderer/src/runtime/use-runtime-session-mirror-environment-key.ts
@@ -9,6 +9,7 @@ export type RuntimeSessionMirrorTargetInputs = Pick<
   | 'repos'
   | 'worktreesByRepo'
   | 'detectedWorktreesByRepo'
+  | 'folderWorkspaces'
   | 'projectGroups'
   | 'restoredRuntimeHostIdByWorkspaceSessionKey'
   | 'runtimeEnvironments'
@@ -25,6 +26,7 @@ export function selectRuntimeSessionMirrorTargetInputs(
     repos: state.repos,
     worktreesByRepo: state.worktreesByRepo,
     detectedWorktreesByRepo: state.detectedWorktreesByRepo,
+    folderWorkspaces: state.folderWorkspaces,
     projectGroups: state.projectGroups,
     restoredRuntimeHostIdByWorkspaceSessionKey: state.restoredRuntimeHostIdByWorkspaceSessionKey,
     runtimeEnvironments: state.runtimeEnvironments,
@@ -40,6 +42,7 @@ export function buildRuntimeSessionMirrorEnvironmentKey(
     repos: inputs.repos,
     worktreesByRepo: inputs.worktreesByRepo,
     detectedWorktreesByRepo: inputs.detectedWorktreesByRepo,
+    folderWorkspaces: inputs.folderWorkspaces,
     projectGroups: inputs.projectGroups,
     restoredRuntimeHostIdByWorkspaceSessionKey: inputs.restoredRuntimeHostIdByWorkspaceSessionKey,
     runtimeEnvironments: inputs.runtimeEnvironments,
@@ -60,6 +63,7 @@ export function useRuntimeSessionMirrorEnvironmentKey(): string {
     repos,
     worktreesByRepo,
     detectedWorktreesByRepo,
+    folderWorkspaces,
     projectGroups,
     restoredRuntimeHostIdByWorkspaceSessionKey,
     runtimeEnvironments,
@@ -72,6 +76,7 @@ export function useRuntimeSessionMirrorEnvironmentKey(): string {
         repos,
         worktreesByRepo,
         detectedWorktreesByRepo,
+        folderWorkspaces,
         projectGroups,
         restoredRuntimeHostIdByWorkspaceSessionKey,
         runtimeEnvironments,
@@ -82,6 +87,7 @@ export function useRuntimeSessionMirrorEnvironmentKey(): string {
       repos,
       worktreesByRepo,
       detectedWorktreesByRepo,
+      folderWorkspaces,
       projectGroups,
       restoredRuntimeHostIdByWorkspaceSessionKey,
       runtimeEnvironments,

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -129,6 +129,7 @@ import {
   sameRuntimeBrowserPlacement,
   type RuntimeBrowserPlacement
 } from '../../../shared/runtime-browser-placement'
+import { subscribeRemoteAgentStatusFacts } from './remote-agent-status-facts'
 
 const WEB_SESSION_GROUP_PREFIX = 'web-session-tabs:'
 export const WEB_SESSION_TABS_VISIBILITY_RESUME_STAGGER_MS = 100
@@ -4483,6 +4484,18 @@ export function useWebSessionTabsSync(): void {
       ? (state.runtimeStatusByEnvironmentId.get(environmentId)?.connectionGeneration ?? 0)
       : 0
   })
+  const runtimeStatusByEnvironmentId = useAppStore((state) => state.runtimeStatusByEnvironmentId)
+  const runtimeStatusByEnvironmentIdRef = useRef(runtimeStatusByEnvironmentId)
+  runtimeStatusByEnvironmentIdRef.current = runtimeStatusByEnvironmentId
+  const runtimeStatusCapabilitiesKey = useAppStore((state) =>
+    Array.from(state.runtimeStatusByEnvironmentId.entries())
+      .map(
+        ([id, entry]) =>
+          `${id}\u0001${entry.connectionGeneration ?? 0}\u0001${entry.status?.capabilities?.join(',') ?? ''}`
+      )
+      .sort()
+      .join('\u0000')
+  )
   const activeWorktreeRuntimePairingRevision = useAppStore((state) => {
     const environmentId = getExplicitRuntimeEnvironmentIdForWorktree(state, state.activeWorktreeId)
     const environment = state.runtimeEnvironments.find(
@@ -5285,6 +5298,70 @@ export function useWebSessionTabsSync(): void {
       }
     }
   }, [runtimeSessionMirrorEnvironmentKey, workspaceSessionReady])
+
+  // Agent facts are deliberately outside the visibility parking layer. The
+  // session-tab inventory may sleep while the desktop is hidden; this stream
+  // remains the host-owned ordered source for new/new pairs.
+  useEffect(() => {
+    const environments = runtimeSessionMirrorEnvironmentKey
+      ? runtimeSessionMirrorEnvironmentKey
+          .split('\u0000')
+          .map((entry) => {
+            const [environmentId = '', , , rawRevision = ''] = entry.split('\u0001')
+            return {
+              environmentId,
+              expectedEnvironmentPairingRevision:
+                rawRevision === '' ? undefined : Number(rawRevision)
+            }
+          })
+          .filter(({ environmentId }) => environmentId.trim())
+      : []
+    if (!workspaceSessionReady || environments.length === 0) {
+      return
+    }
+    let disposed = false
+    const subscriptions: { unsubscribe: () => void }[] = []
+    let started = false
+    const start = (): void => {
+      if (started || disposed) {
+        return
+      }
+      started = true
+      for (const { environmentId, expectedEnvironmentPairingRevision } of environments) {
+        const knownStatus = runtimeStatusByEnvironmentIdRef.current.get(environmentId)
+        const knownCapabilities = knownStatus?.status?.capabilities
+        if (!knownCapabilities) {
+          continue
+        }
+        void subscribeRemoteAgentStatusFacts(
+          environmentId,
+          expectedEnvironmentPairingRevision,
+          (error) => {
+            if (!disposed) {
+              console.warn('[web-session-tabs-sync] agent fact stream error:', error)
+            }
+          },
+          knownCapabilities
+        ).then((subscription) => {
+          if (!subscription) {
+            return
+          }
+          if (disposed) {
+            subscription.unsubscribe()
+          } else {
+            subscriptions.push(subscription)
+          }
+        })
+      }
+    }
+    start()
+    return () => {
+      disposed = true
+      for (const subscription of subscriptions) {
+        subscription.unsubscribe()
+      }
+    }
+  }, [runtimeSessionMirrorEnvironmentKey, runtimeStatusCapabilitiesKey, workspaceSessionReady])
 
   useEffect(() => {
     const environmentId = activeWorktreeRuntimeEnvironmentId?.trim()

--- a/src/shared/agent-status-fact-types.ts
+++ b/src/shared/agent-status-fact-types.ts
@@ -1,0 +1,28 @@
+import type { AgentStatusEntry } from './agent-status-types'
+
+/** Capability advertised by hosts that retain ordered agent-status facts. */
+export const AGENT_STATUS_FACT_STREAM_RUNTIME_CAPABILITY = 'agent-status.fact-stream.v1' as const
+
+export type AgentStatusFact = {
+  seq: number
+  epoch: string
+  paneKey: string
+  worktreeId: string
+  /** Null is a pane teardown tombstone; it must never raise attention. */
+  status: AgentStatusEntry | null
+  /** Event-only turn identity used while Claude remains in `working`. */
+  turnCompletedAt?: number
+}
+
+export type AgentStatusFactStreamMessage =
+  | {
+      type: 'ready'
+      subscriptionId: string
+      epoch: string
+      headSeq: number
+      gap: boolean
+    }
+  | { type: 'fact'; fact: AgentStatusFact }
+  | { type: 'end' }
+
+export type AgentStatusFactInput = Omit<AgentStatusFact, 'seq' | 'epoch'>

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -10,6 +10,7 @@ import {
   SKILL_MANAGEMENT_CAPABILITY,
   SKILL_UPLOAD_CAPABILITY
 } from './skill-install-capability'
+import { AGENT_STATUS_FACT_STREAM_RUNTIME_CAPABILITY } from './agent-status-fact-types'
 export { SKILL_INSTALL_RESULT_V2_CAPABILITY } from './skill-install-capability'
 
 // Why: declares the Orca runtime RPC compatibility contract. Desktop,
@@ -119,6 +120,7 @@ export const AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY =
 // older host answers the unknown member with invalid_argument — a code the launch fallback does
 // not retry on — so clients must probe before taking the host-authority path.
 export const AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY = 'agent-session.kimi-resume.v1' as const
+export { AGENT_STATUS_FACT_STREAM_RUNTIME_CAPABILITY } from './agent-status-fact-types'
 // Why: older runtimes strip mutation owner fields, so clients must fence writes before RPC.
 export const FILE_MUTATION_OWNERSHIP_RUNTIME_CAPABILITY = 'files.mutation-ownership.v1' as const
 export const FILE_MUTATION_OWNERSHIP_UPDATE_REQUIRED_MESSAGE =
@@ -197,6 +199,7 @@ export const RUNTIME_CAPABILITIES = [
   AGENT_SESSION_HOST_AUTHORITY_RUNTIME_CAPABILITY,
   AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
   AGENT_SESSION_KIMI_RESUME_RUNTIME_CAPABILITY,
+  AGENT_STATUS_FACT_STREAM_RUNTIME_CAPABILITY,
   FILE_MUTATION_OWNERSHIP_RUNTIME_CAPABILITY,
   WORKTREE_VISIBILITY_DEFAULTS_RUNTIME_CAPABILITY,
   WORKTREE_VISIBILITY_SOURCE_DEFAULTS_RUNTIME_CAPABILITY,

--- a/src/shared/remote-runtime-shared-control-protocol.ts
+++ b/src/shared/remote-runtime-shared-control-protocol.ts
@@ -70,6 +70,12 @@ export function getCleanupRequest(
   if (subscription.method === 'notifications.subscribe' && subscription.remoteSubscriptionId) {
     return cleanupBySubscriptionId('notifications.unsubscribe', subscription.remoteSubscriptionId)
   }
+  if (subscription.method === 'agent.status.subscribe') {
+    return cleanupBySubscriptionId(
+      'agent.status.unsubscribe',
+      subscription.remoteSubscriptionId ?? subscription.requestId
+    )
+  }
   if (
     subscription.method === 'runtime.clientEvents.subscribe' &&
     subscription.remoteSubscriptionId

--- a/src/shared/remote-runtime-shared-control-protocol.ts
+++ b/src/shared/remote-runtime-shared-control-protocol.ts
@@ -71,10 +71,10 @@ export function getCleanupRequest(
     return cleanupBySubscriptionId('notifications.unsubscribe', subscription.remoteSubscriptionId)
   }
   if (subscription.method === 'agent.status.subscribe') {
-    return cleanupBySubscriptionId(
-      'agent.status.unsubscribe',
-      subscription.remoteSubscriptionId ?? subscription.requestId
-    )
+    if (!subscription.remoteSubscriptionId) {
+      return null
+    }
+    return cleanupBySubscriptionId('agent.status.unsubscribe', subscription.remoteSubscriptionId)
   }
   if (
     subscription.method === 'runtime.clientEvents.subscribe' &&

--- a/src/shared/remote-runtime-shared-control-subscriptions.test.ts
+++ b/src/shared/remote-runtime-shared-control-subscriptions.test.ts
@@ -24,6 +24,22 @@ function makeSubscriptions(): {
   return { subscriptions, subscription }
 }
 
+function makeAgentStatusSubscription(): {
+  subscriptions: Map<string, SharedControlLogicalSubscription<unknown>>
+  subscription: SharedControlLogicalSubscription<unknown>
+} {
+  const subscriptions = new Map<string, SharedControlLogicalSubscription<unknown>>()
+  const subscription = createSharedControlSubscription({
+    requestId: 'req-agent-1',
+    method: 'agent.status.subscribe',
+    params: null,
+    retainedParamsBytes: 0,
+    callbacks: { onResponse: vi.fn(), onError: vi.fn() }
+  })
+  subscriptions.set(subscription.requestId, subscription)
+  return { subscriptions, subscription }
+}
+
 function okResponse(subscriptionId: string): RuntimeRpcResponse<unknown> {
   return {
     ok: true,
@@ -33,6 +49,30 @@ function okResponse(subscriptionId: string): RuntimeRpcResponse<unknown> {
 }
 
 describe('closeSharedControlLogicalSubscription — replay-window leak', () => {
+  it('defers agent-status cleanup until the host returns its concrete id', () => {
+    const { subscriptions, subscription } = makeAgentStatusSubscription()
+    subscription.sent = true
+
+    const request = vi.fn()
+    closeSharedControlLogicalSubscription({ subscriptions, subscription, request })
+
+    expect(subscription.closeAfterReady).toBe(true)
+    expect(subscriptions.size).toBe(1)
+    expect(request).not.toHaveBeenCalled()
+
+    handleSharedControlLogicalResponse({
+      subscriptions,
+      subscription,
+      response: okResponse('agent-status:connection-1:rpc-1'),
+      request
+    })
+
+    expect(request).toHaveBeenCalledWith('agent.status.unsubscribe', {
+      subscriptionId: 'agent-status:connection-1:rpc-1'
+    })
+    expect(subscriptions.size).toBe(0)
+  })
+
   it('sends the unsubscribe when closed after an established subscribe replay completes', () => {
     const { subscriptions, subscription } = makeSubscriptions()
     // First establishment: server assigned a concrete subscription id.

--- a/src/shared/remote-runtime-shared-control-subscriptions.ts
+++ b/src/shared/remote-runtime-shared-control-subscriptions.ts
@@ -137,6 +137,7 @@ function cleanupNeedsRemoteSubscriptionId(method: string): boolean {
   return (
     method === 'accounts.subscribe' ||
     method === 'notifications.subscribe' ||
+    method === 'agent.status.subscribe' ||
     method === 'runtime.clientEvents.subscribe' ||
     method === 'files.watch'
   )

--- a/tests/e2e/helpers/agent-hook-endpoint.ts
+++ b/tests/e2e/helpers/agent-hook-endpoint.ts
@@ -54,7 +54,7 @@ export async function emitCodexHookStatus(
   status: {
     paneKey: string
     worktreeId: string
-    state: 'working' | 'done'
+    state: 'working' | 'waiting' | 'done'
     prompt?: string
     lastAssistantMessage?: string
   }
@@ -66,10 +66,16 @@ export async function emitCodexHookStatus(
           hook_event_name: 'UserPromptSubmit',
           prompt: status.prompt
         }
-      : {
-          hook_event_name: 'Stop',
-          last_assistant_message: status.lastAssistantMessage
-        }
+      : status.state === 'waiting'
+        ? {
+            hook_event_name: 'PreToolUse',
+            tool_name: 'request_user_input',
+            tool_input: { question: 'sta5244 permission' }
+          }
+        : {
+            hook_event_name: 'Stop',
+            last_assistant_message: status.lastAssistantMessage
+          }
   const response = await fetch(`http://127.0.0.1:${endpoint.port}/hook/codex`, {
     method: 'POST',
     headers: {

--- a/tests/e2e/sta5244-remote-agent-notifications.spec.ts
+++ b/tests/e2e/sta5244-remote-agent-notifications.spec.ts
@@ -6,7 +6,6 @@ import {
   type PairedElectronClient
 } from './helpers/paired-electron-client'
 import { emitCodexHookStatus, readHookEndpoint } from './helpers/agent-hook-endpoint'
-import type { AgentHookEndpoint } from '../../src/shared/agent-hook-endpoint-file'
 
 type Dispatch = { source?: string; paneKey?: string }
 
@@ -56,34 +55,6 @@ async function isUnread(page: Page, worktreeId: string): Promise<boolean> {
       .find((candidate) => candidate.id === id)
     return worktree?.isUnread === true
   }, worktreeId)
-}
-
-async function postClaudePermission(
-  endpoint: AgentHookEndpoint,
-  paneKey: string,
-  worktreeId: string
-): Promise<void> {
-  const [tabId] = paneKey.split(':')
-  const response = await fetch(`http://127.0.0.1:${endpoint.port}/hook/claude`, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Orca-Agent-Hook-Token': endpoint.token
-    },
-    body: JSON.stringify({
-      paneKey,
-      tabId,
-      worktreeId,
-      env: endpoint.env,
-      version: endpoint.version,
-      payload: {
-        hook_event_name: 'PermissionRequest',
-        tool_name: 'Bash',
-        tool_input: { command: 'echo permission' }
-      }
-    })
-  })
-  expect(response.status).toBe(204)
 }
 
 test('STA-5244 new/new paired headed client receives one hidden completion and permission alert', async ({
@@ -203,6 +174,42 @@ test('STA-5244 new/new paired headed client receives one hidden completion and p
     await client.app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0]?.show())
     await expect.poll(() => dispatches(client!.app), { timeout: 10_000 }).toHaveLength(1)
 
+    await client.page.evaluate(
+      (id) => window.__store?.getState().clearWorktreeUnread(id),
+      worktreeId
+    )
+    await installDispatchSpy(client.app)
+    await client.app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0]?.hide())
+
+    await emitCodexHookStatus(endpoint, {
+      paneKey,
+      worktreeId,
+      state: 'working',
+      prompt: 'sta5244 permission turn'
+    })
+    await emitCodexHookStatus(endpoint, {
+      paneKey,
+      worktreeId,
+      state: 'waiting'
+    })
+    await expect
+      .poll(
+        async () => {
+          const snapshot = await host.client.call<{
+            tabs: { id: string; agentStatus?: { paneKey?: string; state?: string } }[]
+          }>('session.tabs.list', { worktree: `id:${worktreeId}` })
+          return snapshot.result.tabs.some(
+            (tab) =>
+              tab.id === `${created.tab.parentTabId}::${created.tab.leafId}` &&
+              tab.agentStatus?.paneKey === paneKey &&
+              tab.agentStatus.state === 'waiting'
+          )
+        },
+        { timeout: 30_000 }
+      )
+      .toBe(true)
+    await expect.poll(() => dispatches(client!.app), { timeout: 30_000 }).toHaveLength(1)
+
     await client.page.evaluate(async (selector) => {
       await window.api.runtimeEnvironments.disconnect({ selector })
       const response = await window.api.runtimeEnvironments.connect({ selector })
@@ -221,27 +228,7 @@ test('STA-5244 new/new paired headed client receives one hidden completion and p
         { timeout: 30_000, message: 'paired runtime did not become graph-ready after reconnect' }
       )
       .toBe('ready')
-    await expect.poll(() => isUnread(client!.page, worktreeId), { timeout: 10_000 }).toBe(true)
-    await installDispatchSpy(client.app)
-
-    await postClaudePermission(endpoint, paneKey, worktreeId)
-    await expect
-      .poll(
-        async () => {
-          const snapshot = await host.client.call<{
-            tabs: { id: string; agentStatus?: { paneKey?: string; state?: string } }[]
-          }>('session.tabs.list', { worktree: `id:${worktreeId}` })
-          return snapshot.result.tabs.some(
-            (tab) =>
-              tab.id === `${created.tab.parentTabId}::${created.tab.leafId}` &&
-              tab.agentStatus?.paneKey === paneKey &&
-              tab.agentStatus.state === 'waiting'
-          )
-        },
-        { timeout: 30_000 }
-      )
-      .toBe(true)
-    await expect.poll(() => dispatches(client!.app), { timeout: 30_000 }).toHaveLength(1)
+    await expect.poll(() => dispatches(client!.app), { timeout: 10_000 }).toHaveLength(1)
   } finally {
     await client?.dispose()
     await host.dispose()

--- a/tests/e2e/sta5244-remote-agent-notifications.spec.ts
+++ b/tests/e2e/sta5244-remote-agent-notifications.spec.ts
@@ -1,0 +1,249 @@
+import { expect, test } from './helpers/orca-app'
+import type { ElectronApplication, Page } from '@stablyai/playwright-test'
+import { launchHeadlessPairedRuntimeHost } from './helpers/headless-paired-runtime-host'
+import {
+  launchPairedElectronClient,
+  type PairedElectronClient
+} from './helpers/paired-electron-client'
+import { emitCodexHookStatus, readHookEndpoint } from './helpers/agent-hook-endpoint'
+import type { AgentHookEndpoint } from '../../src/shared/agent-hook-endpoint-file'
+
+type Dispatch = { source?: string; paneKey?: string }
+
+async function callRuntime<TResult>(
+  page: Page,
+  environmentId: string,
+  method: string,
+  params: unknown
+): Promise<TResult> {
+  const response = await page.evaluate(
+    async ({ environmentId, method, params }) =>
+      window.api.runtimeEnvironments.call({ selector: environmentId, method, params }),
+    { environmentId, method, params }
+  )
+  if (!response.ok) {
+    throw new Error(`${response.error.code}: ${response.error.message}`)
+  }
+  return response.result as TResult
+}
+
+async function installDispatchSpy(app: ElectronApplication): Promise<void> {
+  await app.evaluate(({ ipcMain }) => {
+    const state = globalThis as typeof globalThis & {
+      __sta5244Dispatches?: Dispatch[]
+    }
+    state.__sta5244Dispatches = []
+    ipcMain.removeHandler('notifications:dispatch')
+    ipcMain.handle('notifications:dispatch', (_event, payload: Dispatch) => {
+      state.__sta5244Dispatches?.push(payload)
+      return { delivered: true }
+    })
+  })
+}
+
+async function dispatches(app: ElectronApplication): Promise<Dispatch[]> {
+  return app.evaluate(() => {
+    const state = globalThis as typeof globalThis & { __sta5244Dispatches?: Dispatch[] }
+    return state.__sta5244Dispatches ?? []
+  })
+}
+
+async function isUnread(page: Page, worktreeId: string): Promise<boolean> {
+  return page.evaluate((id) => {
+    const worktree = window.__store
+      ?.getState()
+      .allWorktrees()
+      .find((candidate) => candidate.id === id)
+    return worktree?.isUnread === true
+  }, worktreeId)
+}
+
+async function postClaudePermission(
+  endpoint: AgentHookEndpoint,
+  paneKey: string,
+  worktreeId: string
+): Promise<void> {
+  const [tabId] = paneKey.split(':')
+  const response = await fetch(`http://127.0.0.1:${endpoint.port}/hook/claude`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Orca-Agent-Hook-Token': endpoint.token
+    },
+    body: JSON.stringify({
+      paneKey,
+      tabId,
+      worktreeId,
+      env: endpoint.env,
+      version: endpoint.version,
+      payload: {
+        hook_event_name: 'PermissionRequest',
+        tool_name: 'Bash',
+        tool_input: { command: 'echo permission' }
+      }
+    })
+  })
+  expect(response.status).toBe(204)
+}
+
+test('STA-5244 new/new paired headed client receives one hidden completion and permission alert', async ({
+  testRepoPath
+}, testInfo) => {
+  test.setTimeout(240_000)
+  const host = await launchHeadlessPairedRuntimeHost()
+  let client: PairedElectronClient | null = null
+  try {
+    const added = await host.client.call<{ repo: { id: string } }>('repo.add', {
+      path: testRepoPath,
+      kind: 'git'
+    })
+    await host.client.call('repo.update', {
+      repo: `id:${added.result.repo.id}`,
+      updates: { externalWorktreeVisibility: 'show' }
+    })
+    const listed = await host.client.call<{ worktrees: { id: string }[] }>('worktree.list', {
+      repo: `id:${added.result.repo.id}`
+    })
+    const worktreeId = listed.result.worktrees[0]?.id
+    if (!worktreeId) {
+      throw new Error('headless host did not publish a worktree')
+    }
+
+    client = await launchPairedElectronClient(host.offer, testInfo, 'STA-5244 headless host')
+    await installDispatchSpy(client.app)
+    await expect
+      .poll(
+        () =>
+          client!.page.evaluate(
+            (id) =>
+              window.__store
+                ?.getState()
+                .allWorktrees()
+                .some((w) => w.id === id),
+            worktreeId
+          ),
+        { timeout: 60_000 }
+      )
+      .toBe(true)
+    await client.page.evaluate((id) => window.__store?.getState().setActiveWorktree(id), worktreeId)
+
+    const created = await callRuntime<{
+      tab: { parentTabId: string; leafId: string; terminal: string | null }
+    }>(client.page, client.environmentId, 'session.tabs.createTerminal', {
+      worktree: `id:${worktreeId}`,
+      command: 'sleep 120',
+      launchAgent: 'codex',
+      activate: true,
+      select: true,
+      navigation: 'caller'
+    })
+    if (!created.tab.terminal) {
+      throw new Error('headless host did not create the managed agent terminal')
+    }
+    const paneKey = `${created.tab.parentTabId}:${created.tab.leafId}`
+    await expect
+      .poll(
+        async () => {
+          const result = await callRuntime<{ terminals: { handle: string; connected: boolean }[] }>(
+            client!.page,
+            client!.environmentId,
+            'terminal.list',
+            { worktree: `id:${worktreeId}` }
+          )
+          return result.terminals.some(
+            (terminal) => terminal.handle === created.tab.terminal && terminal.connected
+          )
+        },
+        { timeout: 30_000, message: 'managed agent terminal never became connected' }
+      )
+      .toBe(true)
+    const endpoint = await readHookEndpoint(host.app)
+    await client.app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0]?.show())
+    await expect.poll(() => client!.page.evaluate(() => document.visibilityState)).toBe('visible')
+
+    await emitCodexHookStatus(endpoint, {
+      paneKey,
+      worktreeId,
+      state: 'working',
+      prompt: 'sta5244 deterministic turn'
+    })
+    await expect
+      .poll(
+        async () => {
+          const snapshot = await host.client.call<{
+            tabs: { id: string; agentStatus?: { paneKey?: string; state?: string } }[]
+          }>('session.tabs.list', { worktree: `id:${worktreeId}` })
+          return snapshot.result.tabs.some(
+            (tab) =>
+              tab.id === `${created.tab.parentTabId}::${created.tab.leafId}` &&
+              tab.agentStatus?.paneKey === paneKey
+          )
+        },
+        { timeout: 30_000, message: 'managed agent hook row never reached host inventory' }
+      )
+      .toBe(true)
+    await client.app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0]?.hide())
+    await emitCodexHookStatus(endpoint, {
+      paneKey,
+      worktreeId,
+      state: 'done',
+      prompt: 'sta5244 deterministic turn',
+      lastAssistantMessage: 'done while hidden'
+    })
+    await emitCodexHookStatus(endpoint, {
+      paneKey,
+      worktreeId,
+      state: 'done',
+      prompt: 'sta5244 deterministic turn',
+      lastAssistantMessage: 'done while hidden'
+    })
+
+    await expect.poll(() => isUnread(client!.page, worktreeId), { timeout: 10_000 }).toBe(true)
+    await expect.poll(() => dispatches(client!.app), { timeout: 30_000 }).toHaveLength(1)
+    await client.app.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows()[0]?.show())
+    await expect.poll(() => dispatches(client!.app), { timeout: 10_000 }).toHaveLength(1)
+
+    await client.page.evaluate(async (selector) => {
+      await window.api.runtimeEnvironments.disconnect({ selector })
+      const response = await window.api.runtimeEnvironments.connect({ selector })
+      if (!response.ok) {
+        throw new Error(`runtime reconnect failed: ${response.error.message}`)
+      }
+    }, client.environmentId)
+    await expect
+      .poll(
+        () =>
+          client!.page.evaluate(
+            (id) =>
+              window.__store?.getState().runtimeStatusByEnvironmentId.get(id)?.status?.graphStatus,
+            client!.environmentId
+          ),
+        { timeout: 30_000, message: 'paired runtime did not become graph-ready after reconnect' }
+      )
+      .toBe('ready')
+    await expect.poll(() => isUnread(client!.page, worktreeId), { timeout: 10_000 }).toBe(true)
+    await installDispatchSpy(client.app)
+
+    await postClaudePermission(endpoint, paneKey, worktreeId)
+    await expect
+      .poll(
+        async () => {
+          const snapshot = await host.client.call<{
+            tabs: { id: string; agentStatus?: { paneKey?: string; state?: string } }[]
+          }>('session.tabs.list', { worktree: `id:${worktreeId}` })
+          return snapshot.result.tabs.some(
+            (tab) =>
+              tab.id === `${created.tab.parentTabId}::${created.tab.leafId}` &&
+              tab.agentStatus?.paneKey === paneKey &&
+              tab.agentStatus.state === 'waiting'
+          )
+        },
+        { timeout: 30_000 }
+      )
+      .toBe(true)
+    await expect.poll(() => dispatches(client!.app), { timeout: 30_000 }).toHaveLength(1)
+  } finally {
+    await client?.dispose()
+    await host.dispose()
+  }
+})

--- a/tests/e2e/sta5244-remote-agent-notifications.spec.ts
+++ b/tests/e2e/sta5244-remote-agent-notifications.spec.ts
@@ -187,11 +187,6 @@ test('STA-5244 new/new paired headed client receives one hidden completion and p
       state: 'working',
       prompt: 'sta5244 permission turn'
     })
-    await emitCodexHookStatus(endpoint, {
-      paneKey,
-      worktreeId,
-      state: 'waiting'
-    })
     await expect
       .poll(
         async () => {
@@ -202,20 +197,34 @@ test('STA-5244 new/new paired headed client receives one hidden completion and p
             (tab) =>
               tab.id === `${created.tab.parentTabId}::${created.tab.leafId}` &&
               tab.agentStatus?.paneKey === paneKey &&
-              tab.agentStatus.state === 'waiting'
+              tab.agentStatus.state === 'working'
           )
         },
         { timeout: 30_000 }
       )
       .toBe(true)
-    await expect.poll(() => dispatches(client!.app), { timeout: 30_000 }).toHaveLength(1)
 
     await client.page.evaluate(async (selector) => {
       await window.api.runtimeEnvironments.disconnect({ selector })
+      window.__store?.getState().setRuntimeEnvironmentStatus(selector, {
+        status: null,
+        checkedAt: Date.now()
+      })
+    }, client.environmentId)
+    await emitCodexHookStatus(endpoint, {
+      paneKey,
+      worktreeId,
+      state: 'waiting'
+    })
+    await client.page.evaluate(async (selector) => {
       const response = await window.api.runtimeEnvironments.connect({ selector })
       if (!response.ok) {
         throw new Error(`runtime reconnect failed: ${response.error.message}`)
       }
+      window.__store?.getState().setRuntimeEnvironmentStatus(selector, {
+        status: response.result,
+        checkedAt: Date.now()
+      })
     }, client.environmentId)
     await expect
       .poll(
@@ -228,6 +237,14 @@ test('STA-5244 new/new paired headed client receives one hidden completion and p
         { timeout: 30_000, message: 'paired runtime did not become graph-ready after reconnect' }
       )
       .toBe('ready')
+    await expect.poll(() => isUnread(client!.page, worktreeId), { timeout: 30_000 }).toBe(true)
+    await expect.poll(() => dispatches(client!.app), { timeout: 10_000 }).toHaveLength(1)
+
+    await emitCodexHookStatus(endpoint, {
+      paneKey,
+      worktreeId,
+      state: 'waiting'
+    })
     await expect.poll(() => dispatches(client!.app), { timeout: 10_000 }).toHaveLength(1)
   } finally {
     await client?.dispose()

--- a/tests/e2e/sta5244-remote-agent-notifications.spec.ts
+++ b/tests/e2e/sta5244-remote-agent-notifications.spec.ts
@@ -240,6 +240,25 @@ test('STA-5244 new/new paired headed client receives one hidden completion and p
     await expect.poll(() => isUnread(client!.page, worktreeId), { timeout: 30_000 }).toBe(true)
     await expect.poll(() => dispatches(client!.app), { timeout: 10_000 }).toHaveLength(1)
 
+    await client.page.evaluate(
+      (id) => window.__store?.getState().clearWorktreeUnread(id),
+      worktreeId
+    )
+    await installDispatchSpy(client.app)
+    await emitCodexHookStatus(endpoint, {
+      paneKey,
+      worktreeId,
+      state: 'working',
+      prompt: 'sta5244 post-reconnect turn'
+    })
+    await emitCodexHookStatus(endpoint, {
+      paneKey,
+      worktreeId,
+      state: 'waiting'
+    })
+    await expect.poll(() => isUnread(client!.page, worktreeId), { timeout: 30_000 }).toBe(true)
+    await expect.poll(() => dispatches(client!.app), { timeout: 30_000 }).toHaveLength(1)
+
     await emitCodexHookStatus(endpoint, {
       paneKey,
       worktreeId,


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​730 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​721 |
| Prod | 20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​648 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​86 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​562 |

<!-- /orca-pr-loc -->

## Summary

STA-5244 affects a paired macOS client with a Linux headless `orca serve` host: the host's agent row reaches the client after the desktop was hidden or reconnected, but completion/permission attention did not make the workspace unread or dispatch the banner/Dock notification.

This branch replaces the old renderer/session-inventory reconciler hypothesis with a host-owned ordered agent-status fact stream. Accepted live hook transitions are journaled by the authoritative host with `epoch + seq`; paired clients subscribe when the host advertises `agent-status.fact-stream.v1`. Cold inventory, same-turn replay, duplicate frames, journal gaps, and epoch changes seed silently. New facts feed the existing completion coordinator and notification dispatcher exactly once.

## Why this boundary

The host owns hook acceptance, pane/worktree identity, and event order. Keeping that truth at the host avoids timestamp comparisons across machines, renderer-side receipt races, and duplicated call-site defenses. Existing coordinator/dispatcher code remains the semantic owner of unread, banner, Dock badge, notification settings, and completion/attention policy.

Remote facts bypass client-local PTY liveness, Codex auto-approval settings, and client timestamp supersession; a paired client's launch configuration, PTY, and wall clock are not authoritative for a remote host. Pane tombstones explicitly clear coordinator replay state. The fact journal isolates throwing stale listeners so one closed stream cannot abort hook ingestion or starve other clients. Old/new combinations remain on the existing capability-gated behavior and are no worse than current old/old behavior.

## Deterministic validation

```sh
pnpm exec playwright test tests/e2e/sta5244-remote-agent-notifications.spec.ts \
  --config tests/playwright.config.ts --project electron-headless --workers=1
```

The real paired Electron client/headless host E2E verifies managed Codex hook ownership, hidden completion unread + one dispatch, duplicate completion silence, a Codex `request_user_input` waiting state emitted while disconnected and replayed after reconnect, a fresh waiting transition delivered after the replacement subscription is live, and duplicate waiting silence.

Latest result: **1 passed**.

Focused Vitest suites: **44 passed** for journal listener isolation, RPC ready/replay/live/end and connection-owned cleanup, remote cursor dedupe, coordinator authority/tombstones, and notification dispatch clock-boundary behavior. `typecheck:node`, `typecheck:web`, changed-file oxlint, Electron/CLI builds, and `git diff --check` pass.

## Scope and remaining gaps

The journal is intentionally in-memory and bounded to 512 facts. Exact-once is scoped to a live host and a reconnect within the retained epoch/tail; host restart or journal overflow causes a silent seed rather than an historical notification storm. A durable/latest-attention retention protocol would be a separate product decision.

No physical Windows/WSL/SSH matrix or packaged mixed-version E2E was available in this run. Capability gating preserves current behavior for mixed versions. Multiple hidden paired clients alert independently, consistent with per-client unread/notification state.

This supersedes the old 5k-line renderer reconciler draft in PR #16103; do not merge that draft body or implementation.
