### PR TITLE
fix(menu): let DevTools own Cmd+V instead of the focused terminal pane

### DIFF
--- a/src/main/menu/app-menu-selection-item.ts
+++ b/src/main/menu/app-menu-selection-item.ts
@@ -1,4 +1,5 @@
-import { BrowserWindow, Menu, webContents } from 'electron'
+import { BrowserWindow, Menu } from 'electron'
+import { resolveEditMenuTarget } from './edit-menu-focus-target'
 
 export type AppMenuSelectionAction = 'copy' | 'select-all'
 
@@ -17,12 +18,12 @@ export function createAppMenuSelectionItem({
     click: () => {
       const focusedWindow = BrowserWindow.getFocusedWindow()
       if (focusedWindow) {
-        const focusedContents = webContents.getFocusedWebContents()
-        if (focusedContents && focusedContents !== focusedWindow.webContents) {
+        const editTarget = resolveEditMenuTarget(focusedWindow)
+        if (editTarget) {
           if (action === 'copy') {
-            focusedContents.copy()
+            editTarget.copy()
           } else {
-            focusedContents.selectAll()
+            editTarget.selectAll()
           }
           return
         }

--- a/src/main/menu/edit-menu-focus-target.test.ts
+++ b/src/main/menu/edit-menu-focus-target.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getFocusedWebContentsMock } = vi.hoisted(() => ({
+  getFocusedWebContentsMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  webContents: { getFocusedWebContents: getFocusedWebContentsMock }
+}))
+
+import { resolveEditMenuTarget } from './edit-menu-focus-target'
+
+describe('resolveEditMenuTarget', () => {
+  const hostContents = {} as Electron.WebContents
+  const focusedWindow = { webContents: hostContents } as Electron.BrowserWindow
+
+  beforeEach(() => {
+    getFocusedWebContentsMock.mockReset()
+  })
+
+  it('returns the inner contents when DevTools or a guest view holds focus', () => {
+    const devToolsContents = {} as Electron.WebContents
+    getFocusedWebContentsMock.mockReturnValue(devToolsContents)
+
+    expect(resolveEditMenuTarget(focusedWindow)).toBe(devToolsContents)
+  })
+
+  it('returns null when the window renderer itself holds focus', () => {
+    getFocusedWebContentsMock.mockReturnValue(hostContents)
+
+    expect(resolveEditMenuTarget(focusedWindow)).toBeNull()
+  })
+
+  it('returns null when nothing holds focus', () => {
+    getFocusedWebContentsMock.mockReturnValue(null)
+
+    expect(resolveEditMenuTarget(focusedWindow)).toBeNull()
+  })
+})

--- a/src/main/menu/edit-menu-focus-target.ts
+++ b/src/main/menu/edit-menu-focus-target.ts
@@ -1,12 +1,8 @@
 import { webContents } from 'electron'
 
 /**
- * The WebContents that owns an Edit-menu action when it is not the window's own
- * renderer — docked/undocked DevTools, or an embedded browser guest view.
- *
- * Why: menu accelerators fire application-wide, and getFocusedWindow() still
- * returns the Orca window while its DevTools holds keyboard focus. Edit items
- * that override a native role must delegate here or they steal the keystroke.
+ * The focused WebContents when it is not the window's own renderer — DevTools or a
+ * guest view owns the Edit action even though the accelerator fired app-wide.
  */
 export function resolveEditMenuTarget(
   focusedWindow: Electron.BrowserWindow

--- a/src/main/menu/edit-menu-focus-target.ts
+++ b/src/main/menu/edit-menu-focus-target.ts
@@ -1,0 +1,19 @@
+import { webContents } from 'electron'
+
+/**
+ * The WebContents that owns an Edit-menu action when it is not the window's own
+ * renderer — docked/undocked DevTools, or an embedded browser guest view.
+ *
+ * Why: menu accelerators fire application-wide, and getFocusedWindow() still
+ * returns the Orca window while its DevTools holds keyboard focus. Edit items
+ * that override a native role must delegate here or they steal the keystroke.
+ */
+export function resolveEditMenuTarget(
+  focusedWindow: Electron.BrowserWindow
+): Electron.WebContents | null {
+  const focusedContents = webContents.getFocusedWebContents()
+  if (focusedContents && focusedContents !== focusedWindow.webContents) {
+    return focusedContents
+  }
+  return null
+}

--- a/src/main/menu/register-app-menu.test.ts
+++ b/src/main/menu/register-app-menu.test.ts
@@ -279,9 +279,6 @@ describe('registerAppMenu', () => {
     }
   )
 
-  // Why: menu accelerators fire app-wide and getFocusedWindow() still returns the
-  // Orca window while its DevTools console owns the caret — without delegating,
-  // Cmd+V lands in the focused terminal pane instead of the console.
   it('pastes into DevTools instead of an Orca pane when DevTools holds focus', () => {
     const send = vi.fn()
     const hostContents = { send }

--- a/src/main/menu/register-app-menu.test.ts
+++ b/src/main/menu/register-app-menu.test.ts
@@ -279,6 +279,27 @@ describe('registerAppMenu', () => {
     }
   )
 
+  // Why: menu accelerators fire app-wide and getFocusedWindow() still returns the
+  // Orca window while its DevTools console owns the caret — without delegating,
+  // Cmd+V lands in the focused terminal pane instead of the console.
+  it('pastes into DevTools instead of an Orca pane when DevTools holds focus', () => {
+    const send = vi.fn()
+    const hostContents = { send }
+    const devToolsContents = { paste: vi.fn() }
+    getFocusedWindowMock.mockReturnValue({ webContents: hostContents })
+    getFocusedWebContentsMock.mockReturnValue(devToolsContents)
+    registerAppMenu(buildMenuOptions())
+
+    const editSubmenu = getSubmenu(getTemplate(), 'Edit')
+    editSubmenu
+      .find((item) => item.label === 'Paste')
+      ?.click?.({} as never, {} as never, {} as never)
+
+    expect(devToolsContents.paste).toHaveBeenCalledOnce()
+    expect(send).not.toHaveBeenCalled()
+    expect(sendActionToFirstResponderMock).not.toHaveBeenCalled()
+  })
+
   it('keeps selection actions native in a focused guest webview', () => {
     const send = vi.fn()
     const guestContents = { copy: vi.fn(), selectAll: vi.fn() }

--- a/src/main/menu/register-app-menu.ts
+++ b/src/main/menu/register-app-menu.ts
@@ -8,6 +8,7 @@ import {
 import type { UpdateCheckOptions } from '../../shared/update-status-types'
 import { translateMain } from '../i18n/main-i18n'
 import { createAppMenuSelectionItem } from './app-menu-selection-item'
+import { resolveEditMenuTarget } from './edit-menu-focus-target'
 
 export type AppearanceMenuState = {
   showTasksButton: boolean
@@ -191,6 +192,14 @@ function buildAndApplyMenu(options: RegisterAppMenuOptions): void {
           // control, so raw Electron paste cannot know which Orca surface owns it.
           const focusedWindow = BrowserWindow.getFocusedWindow()
           if (focusedWindow) {
+            // Why: this accelerator fires app-wide, and getFocusedWindow() still
+            // returns the Orca window while its DevTools console (or a browser
+            // guest view) owns the caret — paste it there, not into a pane.
+            const editTarget = resolveEditMenuTarget(focusedWindow)
+            if (editTarget) {
+              editTarget.paste()
+              return
+            }
             focusedWindow.webContents.send('ui:appMenuPaste')
             return
           }

--- a/src/main/menu/register-app-menu.ts
+++ b/src/main/menu/register-app-menu.ts
@@ -192,9 +192,7 @@ function buildAndApplyMenu(options: RegisterAppMenuOptions): void {
           // control, so raw Electron paste cannot know which Orca surface owns it.
           const focusedWindow = BrowserWindow.getFocusedWindow()
           if (focusedWindow) {
-            // Why: this accelerator fires app-wide, and getFocusedWindow() still
-            // returns the Orca window while its DevTools console (or a browser
-            // guest view) owns the caret — paste it there, not into a pane.
+            // Why: DevTools or a guest view can own the caret while this window is "focused".
             const editTarget = resolveEditMenuTarget(focusedWindow)
             if (editTarget) {
               editTarget.paste()

--- a/src/main/window/createMainWindow-devtools-paste.test.ts
+++ b/src/main/window/createMainWindow-devtools-paste.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', async () =>
+  (await import('./createMainWindow-test-harness')).electronModuleMock()
+)
+vi.mock('@electron-toolkit/utils', async () =>
+  (await import('./createMainWindow-test-harness')).electronToolkitUtilsMock()
+)
+vi.mock('./macos-tahoe-release', async () =>
+  (await import('./createMainWindow-test-harness')).macosTahoeReleaseMock()
+)
+vi.mock('../app-icon', async () => (await import('./createMainWindow-test-harness')).appIconMock())
+vi.mock('../browser/browser-manager', async () =>
+  (await import('./createMainWindow-test-harness')).browserManagerMock()
+)
+
+import { createMainWindow } from './createMainWindow'
+import { resetExpectedTeardownStateForTest } from '../crash-reporting/expected-teardown-state'
+import {
+  browserWindowMock,
+  getFocusedWebContentsMock,
+  resetMainWindowMocks
+} from './createMainWindow-test-harness'
+
+const CMD_V = {
+  type: 'keyDown',
+  code: 'KeyV',
+  key: 'v',
+  meta: true,
+  control: false,
+  alt: false,
+  shift: false
+}
+
+function mountMainWindow() {
+  const windowHandlers: Record<string, (...args: any[]) => void> = {}
+  const webContents = {
+    on: vi.fn((event, handler) => {
+      windowHandlers[event] = handler
+    }),
+    setZoomLevel: vi.fn(),
+    setBackgroundThrottling: vi.fn(),
+    invalidate: vi.fn(),
+    setWindowOpenHandler: vi.fn(),
+    send: vi.fn(),
+    isDevToolsOpened: vi.fn(),
+    openDevTools: vi.fn(),
+    closeDevTools: vi.fn()
+  }
+  const browserWindowInstance = {
+    webContents,
+    on: vi.fn(),
+    isDestroyed: vi.fn(() => false),
+    isMaximized: vi.fn(() => true),
+    isFullScreen: vi.fn(() => false),
+    getSize: vi.fn(() => [1200, 800]),
+    setSize: vi.fn(),
+    setWindowButtonPosition: vi.fn(),
+    maximize: vi.fn(),
+    show: vi.fn(),
+    loadFile: vi.fn(),
+    loadURL: vi.fn()
+  }
+  browserWindowMock.mockImplementation(function () {
+    return browserWindowInstance
+  })
+
+  createMainWindow(null)
+
+  return { windowHandlers, webContents }
+}
+
+describe('createMainWindow macOS Cmd+V ownership', () => {
+  beforeEach(() => {
+    resetMainWindowMocks()
+    resetExpectedTeardownStateForTest()
+    // Why: pin darwin — the paste interception is macOS-only, so on a Linux CI
+    // runner an unpinned test would pass without ever entering the branch.
+    vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('claims Cmd+V for Orca paste ownership when this renderer holds focus', () => {
+    const { windowHandlers, webContents } = mountMainWindow()
+    getFocusedWebContentsMock.mockReturnValue(webContents)
+
+    const preventDefault = vi.fn()
+    windowHandlers['before-input-event']({ preventDefault } as never, CMD_V as never)
+
+    expect(preventDefault).toHaveBeenCalledOnce()
+    expect(webContents.send).toHaveBeenCalledWith('ui:appMenuPaste')
+  })
+
+  it('leaves Cmd+V to DevTools when the DevTools console holds focus', () => {
+    const { windowHandlers, webContents } = mountMainWindow()
+    getFocusedWebContentsMock.mockReturnValue({ paste: vi.fn() })
+
+    const preventDefault = vi.fn()
+    windowHandlers['before-input-event']({ preventDefault } as never, CMD_V as never)
+
+    expect(preventDefault).not.toHaveBeenCalled()
+    expect(webContents.send).not.toHaveBeenCalledWith('ui:appMenuPaste')
+  })
+})

--- a/src/main/window/createMainWindow-devtools-paste.test.ts
+++ b/src/main/window/createMainWindow-devtools-paste.test.ts
@@ -74,8 +74,7 @@ describe('createMainWindow macOS Cmd+V ownership', () => {
   beforeEach(() => {
     resetMainWindowMocks()
     resetExpectedTeardownStateForTest()
-    // Why: pin darwin — the paste interception is macOS-only, so on a Linux CI
-    // runner an unpinned test would pass without ever entering the branch.
+    // Why: pin darwin — on a Linux CI runner the macOS-only branch is never entered.
     vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
   })
 

--- a/src/main/window/createMainWindow-test-harness.ts
+++ b/src/main/window/createMainWindow-test-harness.ts
@@ -20,7 +20,7 @@ export const notificationMock: Mock<(...args: unknown[]) => { show: MainWindowSp
     return { show: notificationShowMock }
   }
 )
-/** Stands in for the real focus lookup: returns the window's own renderer unless a suite overrides it. */
+/** Mock for Electron's focused-WebContents lookup. Defaults to null. */
 export const getFocusedWebContentsMock: MainWindowSpy = vi.fn(() => null)
 export const powerMonitorOnMock: MainWindowSpy = vi.fn()
 export const powerMonitorRemoveListenerMock: MainWindowSpy = vi.fn()

--- a/src/main/window/createMainWindow-test-harness.ts
+++ b/src/main/window/createMainWindow-test-harness.ts
@@ -20,6 +20,8 @@ export const notificationMock: Mock<(...args: unknown[]) => { show: MainWindowSp
     return { show: notificationShowMock }
   }
 )
+/** Stands in for the real focus lookup: returns the window's own renderer unless a suite overrides it. */
+export const getFocusedWebContentsMock: MainWindowSpy = vi.fn(() => null)
 export const powerMonitorOnMock: MainWindowSpy = vi.fn()
 export const powerMonitorRemoveListenerMock: MainWindowSpy = vi.fn()
 export const isMock = { dev: false }
@@ -52,6 +54,7 @@ export type ElectronModuleMock = {
     getDisplayMatching: () => { scaleFactor: number }
   }
   shell: { openExternal: MainWindowSpy }
+  webContents: { getFocusedWebContents: MainWindowSpy }
 }
 
 export type BrowserManagerModuleMock = {
@@ -76,7 +79,8 @@ export function electronModuleMock(): ElectronModuleMock {
       getPrimaryDisplay: () => ({ workAreaSize: { width: 1440, height: 900 } }),
       getDisplayMatching: () => ({ scaleFactor: 2 })
     },
-    shell: { openExternal: openExternalMock }
+    shell: { openExternal: openExternalMock },
+    webContents: { getFocusedWebContents: getFocusedWebContentsMock }
   }
 }
 
@@ -110,6 +114,8 @@ export function browserManagerMock(): BrowserManagerModuleMock {
 export function resetMainWindowMocks(): void {
   browserWindowMock.mockReset()
   openExternalMock.mockReset()
+  getFocusedWebContentsMock.mockReset()
+  getFocusedWebContentsMock.mockReturnValue(null)
   attachGuestPoliciesMock.mockReset()
   buildFromTemplateMock.mockClear()
   menuPopupMock.mockClear()

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -844,8 +844,7 @@ export function createMainWindow(
     }
 
     if (isMacAppPasteInput(input)) {
-      // Why: DevTools and browser guest views are real editable surfaces that own
-      // their own paste; only claim Cmd+V when this renderer actually holds focus.
+      // Why: DevTools and guest views own their own paste; only claim Cmd+V when focused here.
       if (resolveEditMenuTarget(mainWindow)) {
         return
       }

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -11,6 +11,7 @@ import {
 } from 'electron'
 import { join } from 'node:path'
 import { is } from '@electron-toolkit/utils'
+import { resolveEditMenuTarget } from '../menu/edit-menu-focus-target'
 import type { Store } from '../persistence'
 import { getAppIconPath } from '../app-icon'
 import { browserManager } from '../browser/browser-manager'
@@ -843,6 +844,11 @@ export function createMainWindow(
     }
 
     if (isMacAppPasteInput(input)) {
+      // Why: DevTools and browser guest views are real editable surfaces that own
+      // their own paste; only claim Cmd+V when this renderer actually holds focus.
+      if (resolveEditMenuTarget(mainWindow)) {
+        return
+      }
       // Why: chat/terminal panes hold focus without native editable controls, so route Cmd+V through Orca's paste ownership.
       event.preventDefault()
       mainWindow.webContents.send('ui:appMenuPaste')


### PR DESCRIPTION
## Problem

On macOS, <kbd>Cmd</kbd>+<kbd>V</kbd> while the Chrome DevTools console has keyboard focus pastes into the focused **terminal pane** instead of the console input. <kbd>Cmd</kbd>+<kbd>C</kbd>, <kbd>Cmd</kbd>+<kbd>A</kbd>, and right-click → Paste all work correctly in DevTools — only the paste accelerator is broken.

Fixes #16285

## Root cause

`register-app-menu.ts` intentionally replaces Electron's `role: 'paste'` with a custom item hardcoding `accelerator: 'CmdOrCtrl+V'`, because a focused terminal or chat pane is not a native editable control and the built-in role cannot tell which Orca surface owns the paste. **That override is correct and is preserved here.**

The defect is that menu accelerators fire application-wide regardless of which `WebContents` holds keyboard focus, and `BrowserWindow.getFocusedWindow()` still returns the main Orca window while its docked DevTools holds focus. The click handler therefore unconditionally ran `focusedWindow.webContents.send('ui:appMenuPaste')`, handing the keystroke to the main renderer, which routed it to the focused pane.

The asymmetry with Copy/Select All pins it exactly: `app-menu-selection-item.ts` (added in #13388) already guards this case by delegating to `webContents.getFocusedWebContents()` when it differs from the window's own renderer. Paste never got the same guard — which is precisely why Cmd+C worked in DevTools and Cmd+V did not.

## Change

- Extract that focus lookup into `src/main/menu/edit-menu-focus-target.ts` as `resolveEditMenuTarget(focusedWindow)`, returning the focused `WebContents` when it is *not* the window's own renderer, else `null`.
- **Paste** (`register-app-menu.ts`): when `resolveEditMenuTarget` returns a target, call `.paste()` on it and return, instead of sending `ui:appMenuPaste`.
- **Copy / Select All** (`app-menu-selection-item.ts`): refactored onto the shared helper — no behavior change.
- **`before-input-event`** (`createMainWindow.ts`): the `isMacAppPasteInput` branch now declines to `preventDefault()` when another `WebContents` owns focus, so the keystroke reaches its native handler rather than being claimed by Orca.

Because the guard keys on "focused WebContents is not this window's renderer" rather than on DevTools specifically, undocked DevTools windows and embedded browser guest views (which are likewise separate `WebContents`) are covered by the same code path.

## Testing

- New `edit-menu-focus-target.test.ts` — covers inner-contents focus, host-renderer focus, and no focus.
- New case in `register-app-menu.test.ts` — Cmd+V with DevTools focused calls `devToolsContents.paste()` and does **not** send `ui:appMenuPaste`. Fails before this change.
- New `createMainWindow-devtools-paste.test.ts` — pins `process.platform = 'darwin'` (CI runs this suite on Linux, so an unpinned test never enters the macOS-only branch) and asserts both directions of the `before-input-event` guard.
- The pre-existing paste test, which asserts the terminal/chat-pane routing still works, passes unchanged — the intentional override is intact.
- `pnpm lint`, `pnpm typecheck`, `pnpm test`, `pnpm build` all pass locally.

`createMainWindow-test-harness.ts` gained a `webContents.getFocusedWebContents` mock so the electron module mock matches the real surface.

## AI-agent review summary

- **Cross-platform.** The Edit-menu accelerator is `CmdOrCtrl+V`, so the paste guard is active on all three platforms — correctly, since the app-wide-accelerator problem is not macOS-specific; it is only *reported* on macOS. The `before-input-event` guard sits inside the existing `isMacAppPasteInput` check and stays macOS-only. No new platform branches, no hardcoded `metaKey`, no path assumptions.
- **SSH / remote.** Purely a main-process keyboard-routing change in the local Electron window. It does not touch execution hosts, process liveness, or anything reported about remote work.
- **Remote wire compatibility.** No RPC params, stream frames, or published content changed. The `ui:appMenuPaste` IPC contract is unchanged — this only narrows *when* main emits it.
- **Agent / integration compat.** No change to terminal, chat, or agent paste behavior when an Orca pane holds focus; that path is byte-for-byte the same and is still covered by the pre-existing test. Browser guest views now keep their own native paste, matching how they already handle copy.
- **Performance.** One `webContents.getFocusedWebContents()` call per paste keystroke — the same call Copy and Select All already make on every Cmd+C/Cmd+A. Not on any hot path.
- **UI quality.** No visual change. Restores the expected native behavior in DevTools and removes the surprising side effect of clipboard text landing in a background terminal.
- **Security.** Reduces misrouting of clipboard contents: previously a paste aimed at the DevTools console was injected into a terminal pane, where it could be executed. The new path writes only to the surface the user actually focused. No new IPC surface, no new privileges, no clipboard content read in the main process.

## Notes

- Folder workspaces and git worktrees are unaffected — no workspace-shaped assumptions.
- Not reproducible on the contributor's Linux machine (the report is macOS-specific), so verification is by source analysis plus the unit tests above rather than a live repro.
