### PR TITLE
fix(mobile): preserve relay close recovery codes

### DIFF
--- a/mobile/src/transport/mobile-relay-e2ee-link.test.ts
+++ b/mobile/src/transport/mobile-relay-e2ee-link.test.ts
@@ -59,4 +59,114 @@ describe('MobileRelayE2eeLink', () => {
     )
     expect(socket.close).toHaveBeenCalledOnce()
   })
+
+  it('keeps a typed close code when transport error precedes close', () => {
+    const socket = new ThrowingSocket()
+    const onError = vi.fn()
+    new MobileRelayE2eeLink({
+      endpoint: {
+        cellUrl: 'https://relay-c1.onorca.dev',
+        relayHostId: 'AbCdEf0123_-xyZ9'
+      },
+      credential: 'credential',
+      expectedCredentialKind: 'resume',
+      deviceToken: 'device-token',
+      desktopPublicKeyB64: 'desktop-key',
+      onAuthenticated: vi.fn(),
+      onText: vi.fn(),
+      onBinary: vi.fn(),
+      onError,
+      createSocket: () => socket as unknown as WebSocket
+    })
+
+    socket.onerror?.()
+    socket.onclose?.({ code: 4409 })
+
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'relay_outer_4409' }))
+  })
+
+  it('classifies an opaque close after transport error as 1006', () => {
+    const socket = new ThrowingSocket()
+    const onError = vi.fn()
+    new MobileRelayE2eeLink({
+      endpoint: {
+        cellUrl: 'https://relay-c1.onorca.dev',
+        relayHostId: 'AbCdEf0123_-xyZ9'
+      },
+      credential: 'credential',
+      expectedCredentialKind: 'resume',
+      deviceToken: 'device-token',
+      desktopPublicKeyB64: 'desktop-key',
+      onAuthenticated: vi.fn(),
+      onText: vi.fn(),
+      onBinary: vi.fn(),
+      onError,
+      createSocket: () => socket as unknown as WebSocket
+    })
+
+    socket.onerror?.()
+    socket.onclose?.({ code: 0 })
+
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'relay_outer_1006' }))
+  })
+
+  it('bounds an error when the platform never emits close', async () => {
+    vi.useFakeTimers()
+    try {
+      const socket = new ThrowingSocket()
+      const onError = vi.fn()
+      const link = new MobileRelayE2eeLink({
+        endpoint: {
+          cellUrl: 'https://relay-c1.onorca.dev',
+          relayHostId: 'AbCdEf0123_-xyZ9'
+        },
+        credential: 'credential',
+        expectedCredentialKind: 'resume',
+        deviceToken: 'device-token',
+        desktopPublicKeyB64: 'desktop-key',
+        onAuthenticated: vi.fn(),
+        onText: vi.fn(),
+        onBinary: vi.fn(),
+        onError,
+        createSocket: () => socket as unknown as WebSocket
+      })
+      socket.onerror?.()
+      await vi.advanceTimersByTimeAsync(250)
+
+      expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'relay_outer_1006' }))
+      link.close()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('cancels the missing-close timer when explicitly closed', async () => {
+    vi.useFakeTimers()
+    try {
+      const socket = new ThrowingSocket()
+      const onError = vi.fn()
+      const link = new MobileRelayE2eeLink({
+        endpoint: {
+          cellUrl: 'https://relay-c1.onorca.dev',
+          relayHostId: 'AbCdEf0123_-xyZ9'
+        },
+        credential: 'credential',
+        expectedCredentialKind: 'resume',
+        deviceToken: 'device-token',
+        desktopPublicKeyB64: 'desktop-key',
+        onAuthenticated: vi.fn(),
+        onText: vi.fn(),
+        onBinary: vi.fn(),
+        onError,
+        createSocket: () => socket as unknown as WebSocket
+      })
+      socket.onerror?.()
+      link.close()
+      await vi.advanceTimersByTimeAsync(250)
+
+      expect(onError).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 })

--- a/mobile/src/transport/mobile-relay-e2ee-link.ts
+++ b/mobile/src/transport/mobile-relay-e2ee-link.ts
@@ -6,6 +6,10 @@ import { MobileE2EEV2ClientSession } from './mobile-e2ee-v2-client-session'
 import { MobileE2EEV2PhysicalChannel } from './mobile-e2ee-v2-physical-channel'
 import { websocketPayloadToUint8 } from './websocket-payload-bytes'
 
+// Native WebSockets normally emit close immediately after error; bound the
+// missing-close case so a dead socket cannot leave recovery pending forever.
+const RELAY_ERROR_CLOSE_GRACE_MS = 250
+
 export class RelayOuterError extends Error {
   constructor(readonly code: number) {
     super(`relay_outer_${code}`)
@@ -32,6 +36,7 @@ export class MobileRelayE2eeLink {
   private readonly channel: MobileE2EEV2PhysicalChannel
   private outerReady = false
   private closed = false
+  private transportErrorTimer: ReturnType<typeof setTimeout> | null = null
   private inboundChain: Promise<void> = Promise.resolve()
 
   constructor(options: MobileRelayE2eeLinkOptions) {
@@ -70,6 +75,10 @@ export class MobileRelayE2eeLink {
       return
     }
     this.closed = true
+    if (this.transportErrorTimer) {
+      clearTimeout(this.transportErrorTimer)
+      this.transportErrorTimer = null
+    }
     this.channel.dispose()
     this.socket.close()
   }
@@ -103,8 +112,21 @@ export class MobileRelayE2eeLink {
         })
         .catch((error: unknown) => this.fail(asError(error)))
     }
-    this.socket.onerror = () => this.fail(new Error('relay transport error'))
-    this.socket.onclose = (event) => this.fail(new RelayOuterError(event.code || 1006))
+    // `error` is often delivered just before `close`; wait for close so a
+    // typed relay code is not replaced by a generic transport error.
+    this.socket.onerror = () => {
+      this.transportErrorTimer ??= setTimeout(() => {
+        this.transportErrorTimer = null
+        this.fail(new RelayOuterError(1006))
+      }, RELAY_ERROR_CLOSE_GRACE_MS)
+    }
+    this.socket.onclose = (event) => {
+      if (this.transportErrorTimer) {
+        clearTimeout(this.transportErrorTimer)
+        this.transportErrorTimer = null
+      }
+      this.fail(new RelayOuterError(event.code || 1006))
+    }
   }
 
   private acceptHello(raw: unknown): void {
@@ -137,6 +159,10 @@ export class MobileRelayE2eeLink {
       return
     }
     this.closed = true
+    if (this.transportErrorTimer) {
+      clearTimeout(this.transportErrorTimer)
+      this.transportErrorTimer = null
+    }
     this.channel.dispose()
     this.options.onError(error)
     this.socket.close()

--- a/mobile/src/transport/mobile-relay-invite-director.test.ts
+++ b/mobile/src/transport/mobile-relay-invite-director.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { resolvePairingInviteThroughDirector } from './mobile-relay-invite-director'
+import {
+  RelayDirectorMoveNotNewerError,
+  resolvePairingInviteThroughDirector
+} from './mobile-relay-invite-director'
 
 class FakeSocket {
   sent: string[] = []
@@ -59,7 +62,7 @@ describe('pairing invite director resolution', () => {
     })
   })
 
-  it('rejects same/older epochs and untrusted extra fields', async () => {
+  it('rejects malformed moves with untrusted extra fields', async () => {
     const socket = new FakeSocket()
     const resolving = resolvePairingInviteThroughDirector({
       relay,
@@ -75,6 +78,31 @@ describe('pairing invite director resolution', () => {
       })
     })
 
-    await expect(resolving).rejects.toThrow(/not strictly newer/)
+    await expect(resolving).rejects.toThrow(/invalid relay director move/)
+  })
+
+  it('describes a same-epoch move without accepting it', async () => {
+    const socket = new FakeSocket()
+    const resolving = resolvePairingInviteThroughDirector({
+      relay,
+      createSocket: () => socket as unknown as WebSocket
+    })
+    socket.onmessage?.({
+      data: JSON.stringify({
+        type: 'relay-moved',
+        v: 1,
+        cellUrl: relay.cellUrl,
+        assignmentEpoch: relay.assignmentEpoch
+      })
+    })
+
+    const error = await resolving.catch((value: unknown) => value)
+    expect(error).toBeInstanceOf(RelayDirectorMoveNotNewerError)
+    expect(error).toMatchObject({
+      cellUrl: relay.cellUrl,
+      assignmentEpoch: relay.assignmentEpoch,
+      currentCellUrl: relay.cellUrl,
+      currentAssignmentEpoch: relay.assignmentEpoch
+    })
   })
 })

--- a/mobile/src/transport/mobile-relay-invite-director.ts
+++ b/mobile/src/transport/mobile-relay-invite-director.ts
@@ -1,6 +1,27 @@
 import type { PairingRelay } from '../../../src/shared/mobile-relay-pairing-offer'
 import { RelayMovedSchema } from '../../../src/shared/mobile-relay-phone-protocol'
 
+export class RelayDirectorMoveNotNewerError extends Error {
+  readonly cellUrl: string
+  readonly assignmentEpoch: number
+  readonly currentCellUrl: string
+  readonly currentAssignmentEpoch: number
+
+  constructor(args: {
+    cellUrl: string
+    assignmentEpoch: number
+    currentCellUrl: string
+    currentAssignmentEpoch: number
+  }) {
+    super('relay director move was not strictly newer')
+    this.name = 'RelayDirectorMoveNotNewerError'
+    this.cellUrl = args.cellUrl
+    this.assignmentEpoch = args.assignmentEpoch
+    this.currentCellUrl = args.currentCellUrl
+    this.currentAssignmentEpoch = args.currentAssignmentEpoch
+  }
+}
+
 export function resolvePairingInviteThroughDirector(args: {
   relay: PairingRelay
   timeoutMs?: number
@@ -38,8 +59,19 @@ export function resolvePairingInviteThroughDirector(args: {
         return
       }
       const moved = RelayMovedSchema.safeParse(value)
-      if (!moved.success || moved.data.assignmentEpoch <= args.relay.assignmentEpoch) {
-        finish(new Error('relay director move was not strictly newer'))
+      if (!moved.success) {
+        finish(new Error('invalid relay director move'))
+        return
+      }
+      if (moved.data.assignmentEpoch <= args.relay.assignmentEpoch) {
+        finish(
+          new RelayDirectorMoveNotNewerError({
+            cellUrl: moved.data.cellUrl,
+            assignmentEpoch: moved.data.assignmentEpoch,
+            currentCellUrl: args.relay.cellUrl,
+            currentAssignmentEpoch: args.relay.assignmentEpoch
+          })
+        )
         return
       }
       settled = true

--- a/mobile/src/transport/mobile-relay-physical-client.test.ts
+++ b/mobile/src/transport/mobile-relay-physical-client.test.ts
@@ -134,6 +134,57 @@ describe('mobile relay physical pairing client', () => {
     expect(fakes.start).not.toHaveBeenCalled()
   })
 
+  it('keeps the typed close code when transport error precedes close', async () => {
+    const socket = new FakeSocket()
+    const client = connectMobileRelayForPairing({
+      relay,
+      deviceToken: 'device-token',
+      desktopPublicKeyB64: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+      createSocket: () => socket as unknown as WebSocket
+    })
+    const status = client.sendRequest('status.get')
+    socket.onerror?.()
+    socket.onclose?.({ code: 4409 })
+
+    await expect(status).rejects.toEqual(new RelayOuterError(4409))
+  })
+
+  it('classifies an opaque close after transport error as 1006', async () => {
+    const socket = new FakeSocket()
+    const client = connectMobileRelayForPairing({
+      relay,
+      deviceToken: 'device-token',
+      desktopPublicKeyB64: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+      createSocket: () => socket as unknown as WebSocket
+    })
+    const status = client.sendRequest('status.get')
+    socket.onerror?.()
+    socket.onclose?.({ code: 0 })
+
+    await expect(status).rejects.toEqual(new RelayOuterError(1006))
+  })
+
+  it('settles after an error when the platform never emits close', async () => {
+    vi.useFakeTimers()
+    try {
+      const socket = new FakeSocket()
+      const client = connectMobileRelayForPairing({
+        relay,
+        deviceToken: 'device-token',
+        desktopPublicKeyB64: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=',
+        createSocket: () => socket as unknown as WebSocket
+      })
+      const status = client.sendRequest('status.get')
+      const rejected = expect(status).rejects.toEqual(new RelayOuterError(1006))
+      socket.onerror?.()
+      await vi.advanceTimersByTimeAsync(250)
+
+      await rejected
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('narrates dial, outer auth, handshake and authentication without leaking the invite', async () => {
     const socket = new FakeSocket()
     const entries: ConnectionLogEntry[] = []

--- a/mobile/src/transport/mobile-relay-physical-client.ts
+++ b/mobile/src/transport/mobile-relay-physical-client.ts
@@ -10,6 +10,8 @@ import { websocketPayloadToUint8 } from './websocket-payload-bytes'
 export { RelayOuterError } from './mobile-relay-e2ee-link'
 import { RelayOuterError } from './mobile-relay-e2ee-link'
 
+const RELAY_ERROR_CLOSE_GRACE_MS = 250
+
 type PendingRequest = {
   resolve: (response: RpcResponse) => void
   reject: (error: Error) => void
@@ -46,6 +48,7 @@ export function connectMobileRelayForPairing(args: {
   let requestCounter = 0
   let closed = false
   let intentionallyClosed = false
+  let transportErrorTimer: ReturnType<typeof setTimeout> | null = null
   let outerReady = false
   let authenticated = false
   let resolveAuthenticated!: () => void
@@ -111,8 +114,21 @@ export function connectMobileRelayForPairing(args: {
       })
       .catch((error: unknown) => fail(asError(error)))
   }
-  socket.onerror = () => fail(new Error('relay transport error'))
-  socket.onclose = (event) => fail(new RelayOuterError(event.code || 1006))
+  // WebSocket implementations commonly emit `error` immediately before
+  // `close`; the bounded fallback represents an opaque 1006 close.
+  socket.onerror = () => {
+    transportErrorTimer ??= setTimeout(() => {
+      transportErrorTimer = null
+      fail(new RelayOuterError(1006))
+    }, RELAY_ERROR_CLOSE_GRACE_MS)
+  }
+  socket.onclose = (event) => {
+    if (transportErrorTimer) {
+      clearTimeout(transportErrorTimer)
+      transportErrorTimer = null
+    }
+    fail(new RelayOuterError(event.code || 1006))
+  }
 
   function acceptRelayHello(raw: unknown): void {
     if (typeof raw !== 'string') {
@@ -144,6 +160,10 @@ export function connectMobileRelayForPairing(args: {
       return
     }
     closed = true
+    if (transportErrorTimer) {
+      clearTimeout(transportErrorTimer)
+      transportErrorTimer = null
+    }
     if (intentionallyClosed) {
       log('info', 'Relay: pairing socket closed', cellHost)
     } else {

--- a/mobile/src/transport/pairing-relay-candidate.test.ts
+++ b/mobile/src/transport/pairing-relay-candidate.test.ts
@@ -121,6 +121,49 @@ describe('recovering pairing relay candidate', () => {
     expect(persistMove).not.toHaveBeenCalled()
   })
 
+  it('keeps recovery bounded when the authoritative-cell constructor throws', async () => {
+    const stale = client(Promise.reject(new RelayOuterError(1006)))
+    const target = client(Promise.resolve(success()))
+    const entries: ConnectionLogEntry[] = []
+    let connects = 0
+    const candidate = createRecoveringPairingRelayCandidate({
+      journal,
+      connect: () => {
+        connects++
+        if (connects === 1) {
+          return stale
+        }
+        if (connects === 2) {
+          throw new Error('relay constructor failed')
+        }
+        return target
+      },
+      resolveDirector: async (relay) => {
+        throw new RelayDirectorMoveNotNewerError({
+          cellUrl: relay.cellUrl,
+          assignmentEpoch: relay.assignmentEpoch,
+          currentCellUrl: relay.cellUrl,
+          currentAssignmentEpoch: relay.assignmentEpoch
+        })
+      },
+      persistMove: vi.fn(),
+      now: () => 1,
+      random: () => 0,
+      sleep: async () => {},
+      onLog: (entry) => entries.push(entry)
+    })
+
+    await expect(candidate.sendRequest('status.get')).resolves.toEqual(success())
+    expect(connects).toBe(3)
+    expect(entries).toContainEqual(
+      expect.objectContaining({
+        level: 'warn',
+        message: 'Relay: recovery attempt 1 failed',
+        detail: 'Error: relay constructor failed'
+      })
+    )
+  })
+
   it('does not retry a same-epoch move to a different cell', async () => {
     const stale = client(Promise.reject(new RelayOuterError(1006)))
     const resolveDirector = vi.fn(async (relay) => {

--- a/mobile/src/transport/pairing-relay-candidate.test.ts
+++ b/mobile/src/transport/pairing-relay-candidate.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { PairingCandidateClient } from './mobile-relay-physical-client'
 import { RelayOuterError } from './mobile-relay-physical-client'
 import { createRecoveringPairingRelayCandidate } from './pairing-relay-candidate'
+import { RelayDirectorMoveNotNewerError } from './mobile-relay-invite-director'
 import type { MobileRelayPairingJournal } from './mobile-relay-pairing-journal'
 import type { ConnectionLogEntry } from './types'
 
@@ -87,6 +88,66 @@ describe('recovering pairing relay candidate', () => {
     await expect(candidate.sendRequest('status.get')).resolves.toEqual(success())
     expect(events).toEqual(['connect:7', 'persist:8', 'connect:8'])
     expect(stale.close).toHaveBeenCalledOnce()
+  })
+
+  it('retries the authoritative cell when the director confirms the same assignment', async () => {
+    const stale = client(Promise.reject(new RelayOuterError(1006)))
+    const target = client(Promise.resolve(success()))
+    const persistMove = vi.fn()
+    let connects = 0
+    const candidate = createRecoveringPairingRelayCandidate({
+      journal,
+      connect: (relay) => {
+        expect(relay.cellUrl).toBe(journal.metadata.relay.cellUrl)
+        expect(relay.assignmentEpoch).toBe(journal.metadata.relay.assignmentEpoch)
+        return connects++ === 0 ? stale : target
+      },
+      resolveDirector: async (relay) => {
+        throw new RelayDirectorMoveNotNewerError({
+          cellUrl: relay.cellUrl,
+          assignmentEpoch: relay.assignmentEpoch,
+          currentCellUrl: relay.cellUrl,
+          currentAssignmentEpoch: relay.assignmentEpoch
+        })
+      },
+      persistMove,
+      now: () => 1,
+      random: () => 0,
+      sleep: async () => {}
+    })
+
+    await expect(candidate.sendRequest('status.get')).resolves.toEqual(success())
+    expect(connects).toBe(2)
+    expect(persistMove).not.toHaveBeenCalled()
+  })
+
+  it('does not retry a same-epoch move to a different cell', async () => {
+    const stale = client(Promise.reject(new RelayOuterError(1006)))
+    const resolveDirector = vi.fn(async (relay) => {
+      throw new RelayDirectorMoveNotNewerError({
+        cellUrl: 'https://relay-c2.onorca.dev',
+        assignmentEpoch: relay.assignmentEpoch,
+        currentCellUrl: relay.cellUrl,
+        currentAssignmentEpoch: relay.assignmentEpoch
+      })
+    })
+    let connects = 0
+    const candidate = createRecoveringPairingRelayCandidate({
+      journal,
+      connect: () => {
+        connects++
+        return stale
+      },
+      resolveDirector,
+      persistMove: vi.fn(),
+      now: () => 1,
+      random: () => 0,
+      sleep: async () => {}
+    })
+
+    await expect(candidate.sendRequest('status.get')).rejects.toThrow(/not strictly newer/)
+    expect(resolveDirector).toHaveBeenCalledTimes(3)
+    expect(connects).toBe(1)
   })
 
   it('does not ask the director to reinterpret endpoint-scoped host-offline', async () => {

--- a/mobile/src/transport/pairing-relay-candidate.ts
+++ b/mobile/src/transport/pairing-relay-candidate.ts
@@ -100,8 +100,8 @@ export function createRecoveringPairingRelayCandidate(args: {
           if (closed) {
             throw new Error('relay pairing client closed')
           }
-          client = args.connect(relay, args.onLog)
           try {
+            client = args.connect(relay, args.onLog)
             return await client.sendRequest(method, params)
           } catch (retryError) {
             lastError = retryError

--- a/mobile/src/transport/pairing-relay-candidate.ts
+++ b/mobile/src/transport/pairing-relay-candidate.ts
@@ -1,6 +1,7 @@
 import type { PairingRelay } from '../../../src/shared/mobile-relay-pairing-offer'
 import type { MobileRelayPairingJournal } from './mobile-relay-pairing-journal'
 import { RelayOuterError, type PairingCandidateClient } from './mobile-relay-physical-client'
+import { RelayDirectorMoveNotNewerError } from './mobile-relay-invite-director'
 import { createPairingRelayLogger, pairingRelayErrorDetail } from './pairing-relay-log'
 import { redactSocketEndpoint } from './socket-event-debug'
 import type { ConnectionLogSink } from './types'
@@ -88,6 +89,35 @@ export function createRecoveringPairingRelayCandidate(args: {
         return await client.sendRequest(method, params)
       } catch (error) {
         lastError = error
+        if (isCurrentAssignmentMove(error, relay)) {
+          log(
+            'info',
+            'Relay: director kept current assignment',
+            redactSocketEndpoint(relay.cellUrl)
+          )
+          client.close()
+          await backOff(attempt)
+          if (closed) {
+            throw new Error('relay pairing client closed')
+          }
+          client = args.connect(relay, args.onLog)
+          try {
+            return await client.sendRequest(method, params)
+          } catch (retryError) {
+            lastError = retryError
+            log(
+              'warn',
+              `Relay: recovery attempt ${attempt + 1} failed`,
+              pairingRelayErrorDetail(retryError)
+            )
+            if (!isDirectorRecoverable(retryError) || attempt + 1 >= maxAttempts) {
+              log('error', 'Relay: recovery gave up', `after ${attempt + 1} attempt(s)`)
+              throw retryError
+            }
+            await backOff(attempt)
+            continue
+          }
+        }
         log('warn', `Relay: recovery attempt ${attempt + 1} failed`, pairingRelayErrorDetail(error))
         if (!isDirectorRecoverable(error) || attempt + 1 >= maxAttempts) {
           log('error', 'Relay: recovery gave up', `after ${attempt + 1} attempt(s)`)
@@ -98,6 +128,16 @@ export function createRecoveringPairingRelayCandidate(args: {
     }
     throw lastError
   }
+}
+
+function isCurrentAssignmentMove(error: unknown, relay: PairingRelay): boolean {
+  return (
+    error instanceof RelayDirectorMoveNotNewerError &&
+    error.assignmentEpoch === relay.assignmentEpoch &&
+    error.cellUrl === relay.cellUrl &&
+    error.currentAssignmentEpoch === relay.assignmentEpoch &&
+    error.currentCellUrl === relay.cellUrl
+  )
 }
 
 function pairingRelayFromJournal(journal: MobileRelayPairingJournal): PairingRelay {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​296 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​293 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​124 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​118 |

<!-- /orca-pr-loc -->

## Summary

- Preserve typed relay close codes when WebSocket `error` precedes `close`.
- Normalize opaque or missing-close failures to `RelayOuterError(1006)` with a bounded 250 ms fallback.
- Cancel the fallback timer on close, failure, and explicit shutdown.
- Add deterministic pairing and runtime regression coverage.

## STA-5293 findings

The client previously latched generic `relay transport error` before the later typed close (for example, `4409`). This loses the evidence needed for safe recovery classification. The reported incident also shows director recovery returning an equal/stale assignment epoch; strict newer-epoch validation remains unchanged and must not be relaxed. This PR is client transport hardening, not a claim that the relay-service assignment-state issue is resolved.

## Validation

- Full mobile suite: 458 files, 3,680 passed, 3 skipped.
- Focused relay suites: 77 passed.
- Mobile typecheck and lint passed.
- Read-only relay contract/blackbox suites: 40 passed.

## Follow-up

Relay-service owners should inspect cell/host registration and durable assignment epoch state with a read-only deterministic harness. No production topology was used.