### PR TITLE
fix(github): list default issues via REST so account mismatches surface errors (#16244)

### DIFF
--- a/src/main/github/client/list/list-recent-work-items-rest-issues.test.ts
+++ b/src/main/github/client/list/list-recent-work-items-rest-issues.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { ghExecFileAsyncMock, acquireMock, releaseMock } = vi.hoisted(() => ({
+  ghExecFileAsyncMock: vi.fn(),
+  acquireMock: vi.fn(),
+  releaseMock: vi.fn()
+}))
+
+vi.mock('../../gh-utils', () => ({
+  ghExecFileAsync: ghExecFileAsyncMock,
+  classifyGhError: (stderr: string) => ({ type: 'unknown', message: stderr }),
+  classifyListIssuesError: (stderr: string) => ({ type: 'unknown', message: stderr }),
+  classifyListPrsError: (stderr: string) => ({ type: 'unknown', message: stderr }),
+  ghRepoExecOptions: (context: {
+    repoPath: string
+    connectionId?: string | null
+    wslDistro?: string
+  }) =>
+    context.connectionId
+      ? {}
+      : { cwd: context.repoPath, ...(context.wslDistro ? { wslDistro: context.wslDistro } : {}) },
+  githubRepoContext: (
+    repoPath: string,
+    connectionId?: string | null,
+    localGitOptions: { wslDistro?: string } = {}
+  ) => ({
+    repoPath,
+    connectionId: connectionId ?? null,
+    ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {})
+  }),
+  acquire: acquireMock,
+  release: releaseMock
+}))
+
+vi.mock('../../github-api-repository', () => ({
+  githubHostExecOptions: () => ({})
+}))
+
+vi.mock('../detect/hydrate-work-item-merge-metadata', () => ({
+  hydrateWorkItemRepositoryMergeMetadata: async (prs: unknown[]) => prs
+}))
+
+vi.mock('../github-exec-scope', () => ({
+  githubPRStackExecutionScope: () => undefined
+}))
+
+import { buildRecentIssueListRequest } from './work-item-list-request'
+import { listRecentWorkItems } from './work-item-pages'
+
+describe('buildRecentIssueListRequest', () => {
+  it('targets the REST repo-issues listing instead of the Search API', () => {
+    const request = buildRecentIssueListRequest({ ownerRepo: { owner: 'acme', repo: 'widgets' }, limit: 24, page: 1 })
+    expect(request.offset).toBe(0)
+    expect(request.args[0]).toBe('api')
+    expect(request.args[3]).toBe(
+      'repos/acme/widgets/issues?per_page=24&page=1&state=open&sort=created&direction=desc'
+    )
+    expect(request.args.join(' ')).not.toContain('search/issues')
+  })
+
+  it('keeps the --cache flags at indices 1..2 so the noCache splice keeps working', () => {
+    const request = buildRecentIssueListRequest({ ownerRepo: { owner: 'a', repo: 'b' }, limit: 5, page: 2 })
+    expect(request.args.slice(1, 3)).toEqual(['--cache', '120s'])
+  })
+})
+
+describe('listRecentWorkItems issue-side source', () => {
+  beforeEach(() => {
+    ghExecFileAsyncMock.mockReset()
+    acquireMock.mockReset().mockResolvedValue(undefined)
+    releaseMock.mockReset()
+  })
+
+  it('queries the REST issues endpoint for the default listing', async () => {
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          { number: 7, title: 'Broken thing', state: 'open', html_url: 'https://x/7' }
+        ])
+      })
+      .mockResolvedValueOnce({ stdout: '[]' })
+
+    const result = await listRecentWorkItems(
+      '/repo-root',
+      { owner: 'acme', repo: 'widgets' },
+      { owner: 'acme', repo: 'widgets' },
+      24,
+      1
+    )
+
+    expect(ghExecFileAsyncMock.mock.calls[0][0][0]).toContain('repos/acme/widgets/issues?')
+    expect(result.items.map((item) => item.id)).toEqual(['issue:7'])
+  })
+
+  it('surfaces a classified error when the account cannot see the repo instead of reading as empty', async () => {
+    const failure = Object.assign(new Error('gh: HTTP 404'), { stderr: 'gh: HTTP 404' })
+    ghExecFileAsyncMock.mockRejectedValueOnce(failure).mockResolvedValueOnce({ stdout: '[]' })
+
+    const result = await listRecentWorkItems(
+      '/repo-root',
+      { owner: 'acme', repo: 'private-widgets' },
+      { owner: 'acme', repo: 'private-widgets' },
+      24,
+      1
+    )
+
+    expect(result.issuesError).toEqual({ type: 'unknown', message: 'gh: HTTP 404' })
+  })
+})

--- a/src/main/github/client/list/work-item-list-request.ts
+++ b/src/main/github/client/list/work-item-list-request.ts
@@ -100,6 +100,29 @@ export function buildWorkItemListRequest(args: {
   return { args: out, offset: (page - 1) * limit }
 }
 
+// Why REST instead of Search for the default (no-query) listing: the Search
+// API answers HTTP 200 with zero items when the authenticated gh account
+// cannot see the repo, so an account switch or re-login silently empties the
+// Tasks list with nothing to act on (#16244). The REST listing fails with a
+// classifiable 403/404 instead, letting the existing error envelope explain
+// the empty state.
+export function buildRecentIssueListRequest(args: {
+  ownerRepo: OwnerRepo
+  limit: number
+  page: number
+}): WorkItemListRequest {
+  const { ownerRepo, limit, page } = args
+  return {
+    args: [
+      'api',
+      '--cache',
+      '120s',
+      `repos/${ownerRepo.owner}/${ownerRepo.repo}/issues?per_page=${limit}&page=${page}&state=open&sort=created&direction=desc`
+    ],
+    offset: 0
+  }
+}
+
 // Why: shared shape so listWorkItems can lift per-side errors (#1076 silent wrongness) into the IPC envelope — a swallowed side reads as end-of-data to pagination (#11485).
 export type PartialWorkItemsResult = {
   items: MainWorkItem[]

--- a/src/main/github/client/list/work-item-pages.ts
+++ b/src/main/github/client/list/work-item-pages.ts
@@ -1,6 +1,6 @@
 import type { ClassifiedError } from '../../../../shared/classified-error'
 import { classifyGitHubUnavailable } from '../../../../shared/github/api-availability'
-import { parseTaskQuery, type ParsedTaskQuery } from '../../../../shared/task-query'
+import type { ParsedTaskQuery } from '../../../../shared/task-query'
 import { sortWorkItemsByNumber } from '../../../../shared/work-items'
 import {
   ghExecFileAsync,
@@ -18,6 +18,7 @@ import type { MainWorkItem } from './../map/work-item-field-coercion'
 import { mapIssueWorkItem, mapPullRequestWorkItem } from './../map/work-item'
 import {
   buildWorkItemListRequest,
+  buildRecentIssueListRequest,
   assertSshRepoHasResolvedGitHubSource,
   type PartialWorkItemsResult
 } from './work-item-list-request'
@@ -33,15 +34,8 @@ export async function listRecentWorkItems(
 ): Promise<PartialWorkItemsResult> {
   const ghOptions = ghRepoExecOptions(githubRepoContext(repoPath, connectionId, localGitOptions))
   assertSshRepoHasResolvedGitHubSource({ connectionId, issueOwnerRepo, prOwnerRepo })
-  const recentQuery = parseTaskQuery('is:open')
   const issueRequest = issueOwnerRepo
-    ? buildWorkItemListRequest({
-        kind: 'issue',
-        ownerRepo: issueOwnerRepo,
-        limit,
-        query: recentQuery,
-        page
-      })
+    ? buildRecentIssueListRequest({ ownerRepo: issueOwnerRepo, limit, page })
     : null
   const prRequest = prOwnerRepo
     ? buildWorkItemListRequest({


### PR DESCRIPTION
Closes #16244

After switching/re-logging-in gh accounts, the Tasks issues panel went silently empty: the Search API answers HTTP 200 with zero items when the active account cannot see the repo, which read as "no issues".

Default (unfiltered) issue listing now uses the REST repo-issues endpoint instead, whose 403/404 flow through the existing classified-error envelope so failures become visible errors rather than an empty panel. Queried search and PR listing untouched.
