### PR TITLE
fix(worktrees): fail visibly when runtime removal misses a live workspace (#16243)

### DIFF
--- a/src/renderer/src/store/slices/worktrees-removal-selector-miss-fail-closed.test.ts
+++ b/src/renderer/src/store/slices/worktrees-removal-selector-miss-fail-closed.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppState } from '../types'
+import { makeWorktree } from './worktrees-slice-test-fixtures'
+import {
+  createTestStore,
+  mockApi,
+  resetRemoteRuntimeMocks,
+  resetWorktreeSliceModuleMemory,
+  runtimeEnvironmentCall
+} from './worktrees-slice-test-harness'
+
+vi.mock('sonner', () => ({
+  toast: {
+    warning: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    dismiss: vi.fn()
+  }
+}))
+
+const requestWorktreeBaseFallbackNotice = vi.hoisted(() => vi.fn())
+vi.mock('@/components/worktree-base-fallback-notice', () => ({
+  requestWorktreeBaseFallbackNotice
+}))
+
+beforeEach(resetWorktreeSliceModuleMemory)
+
+// Why (#16243): a selector_not_found from the runtime used to fall through to a
+// local-only forgetLocal whenever the catalog still listed the workspace, which
+// read as success while nothing was deleted remotely — the row returned on the
+// next refresh. A live route on the confirmed host must fail visibly instead.
+describe('removeWorktree runtime selector miss', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetRemoteRuntimeMocks()
+  })
+
+  it('fails closed instead of forgetting locally when the catalog still resolves the route', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({ id: 'repo1::/path/wt1', repoId: 'repo1', path: '/path/wt1' })
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-rm',
+      ok: false,
+      error: { code: 'selector_not_found', message: 'selector_not_found' },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      worktreesByRepo: { repo1: [wt] }
+    } as Partial<AppState>)
+
+    const result = await store.getState().removeWorktree({ id: wt.id, executionHostId: null }, false)
+
+    expect(result).toMatchObject({ ok: false })
+    expect(String((result as { error?: string }).error)).toContain('selector_not_found')
+    expect(mockApi.worktrees.forgetLocal).not.toHaveBeenCalled()
+    // The live row must not be dropped from the shared renderer state either.
+    expect(store.getState().worktreesByRepo.repo1).toHaveLength(1)
+    expect(runtimeEnvironmentCall).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/store/slices/worktrees/teardown/remove-worktree.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/remove-worktree.ts
@@ -151,7 +151,13 @@ export function createRemoveWorktree(
             throw error
           }
           if (currentResolution.kind === 'resolved') {
+            // Why (#16243): a not-found verdict from the runtime while this same
+            // runtime's catalog still resolves the confirmed-host route is a host-
+            // qualification/resolution gap, not a stale mirror. Forgetting only the
+            // local mirror here silently abandoned a live remote workspace — the row
+            // returned on the next refresh with nothing deleted and no failure shown.
             removalGenerationGuard?.assertCurrent()
+            throw error
           }
           try {
             removalResult = await window.api.worktrees.forgetLocal({


### PR DESCRIPTION
Closes #16243

For paired-runtime workspaces, a worktree.rm selector_not_found rejection was misread by the renderer's stale-mirror fallback as "mirror is stale" - forgetting only the local mirror and reporting ok:true while the remote workspace stayed alive (the row resurrected on next refresh).

When the RPC says not-found but the catalog still resolves the confirmed host route, removal now fails visibly instead of local-only forgetting. Genuine stale mirrors (route unresolved) keep the existing recovery path. Regression test included.
