### PR TITLE
feat(usage): show provider subscription plan labels

### DIFF
--- a/src/main/rate-limits/claude-fetcher-fable-usage.test.ts
+++ b/src/main/rate-limits/claude-fetcher-fable-usage.test.ts
@@ -83,7 +83,8 @@ describe('fetchClaudeRateLimits', () => {
         JSON.stringify({
           five_hour: { used_percentage: 23.5, resets_at: 1770000000 },
           seven_day: { used_percentage: 41.2, resets_at: 1770604800 },
-          fable_weekly: { used_percentage: 12.3, resets_at: 1770691200 }
+          fable_weekly: { used_percentage: 12.3, resets_at: 1770691200 },
+          plan_type: 'max_20x'
         }),
         { status: 200 }
       )
@@ -94,7 +95,8 @@ describe('fetchClaudeRateLimits', () => {
       status: 'ok',
       session: { usedPercent: 23.5, resetsAt: 1770000000000 },
       weekly: { usedPercent: 41.2, resetsAt: 1770604800000 },
-      fableWeekly: { usedPercent: 12.3, resetsAt: 1770691200000 }
+      fableWeekly: { usedPercent: 12.3, resetsAt: 1770691200000 },
+      planType: 'max_20x'
     })
   })
 

--- a/src/main/rate-limits/claude-fetcher.ts
+++ b/src/main/rate-limits/claude-fetcher.ts
@@ -296,6 +296,13 @@ type OAuthUsageResponse = {
   fable_seven_day?: OAuthUsageWindow
   seven_day_fable?: OAuthUsageWindow
   limits?: OAuthUsageLimit[] | null
+  // These fields are not present in every response, but newer Claude usage
+  // payloads may include the active subscription label. Keep them optional so
+  // the UI can show it when the server exposes it without guessing a tier.
+  plan_type?: string
+  planType?: string
+  subscription_tier?: string
+  subscriptionTier?: string
 }
 
 type ClaudeUsageAttemptState = {
@@ -334,6 +341,13 @@ function mapFableWeeklyWindow(data: OAuthUsageResponse): RateLimitWindow | null 
     mapClaudeUsageWindow(data.fable_seven_day, 10080) ??
     mapClaudeUsageWindow(data.seven_day_fable, 10080)
   )
+}
+
+function mapClaudePlanType(data: OAuthUsageResponse): string | null {
+  const candidate =
+    data.plan_type ?? data.planType ?? data.subscription_tier ?? data.subscriptionTier
+  const trimmed = candidate?.trim()
+  return trimmed || null
 }
 
 async function fetchViaOAuth(token: string, signal?: AbortSignal): Promise<ProviderRateLimits> {
@@ -376,6 +390,7 @@ async function fetchViaOAuth(token: string, signal?: AbortSignal): Promise<Provi
       session: mapClaudeUsageWindow(data.five_hour, 300),
       weekly: mapClaudeUsageWindow(data.seven_day, 10080),
       fableWeekly: mapFableWeeklyWindow(data),
+      planType: mapClaudePlanType(data),
       updatedAt: Date.now(),
       error: null,
       status: 'ok'
@@ -517,7 +532,8 @@ function mergeClaudeUsageWindows(
     ...primary,
     session: primary.session ?? supplement.session,
     weekly: primary.weekly ?? supplement.weekly,
-    fableWeekly: primary.fableWeekly ?? supplement.fableWeekly ?? null
+    fableWeekly: primary.fableWeekly ?? supplement.fableWeekly ?? null,
+    planType: primary.planType ?? supplement.planType ?? null
   }
 }
 

--- a/src/main/rate-limits/claude-pty.test.ts
+++ b/src/main/rate-limits/claude-pty.test.ts
@@ -324,6 +324,31 @@ describe('fetchViaPty', () => {
     })
   })
 
+  it('captures a provider-reported Claude package label from the usage header', async () => {
+    const term = makeMockTerm()
+    spawnMock.mockReturnValue(term)
+
+    const resultPromise = fetchViaPty()
+
+    await vi.advanceTimersByTimeAsync(2_000)
+    term.emitData(`
+      Claude Max 20x
+
+      Plan usage limits
+      Current session
+      18% used
+      Current week (all models)
+      42% used
+    `)
+    await vi.advanceTimersByTimeAsync(2_000)
+
+    await expect(resultPromise).resolves.toMatchObject({
+      provider: 'claude',
+      status: 'ok',
+      planType: 'Max 20x'
+    })
+  })
+
   it('parses generic weekly and Fable weekly limits as separate windows', async () => {
     const term = makeMockTerm()
     spawnMock.mockReturnValue(term)

--- a/src/main/rate-limits/claude-pty.ts
+++ b/src/main/rate-limits/claude-pty.ts
@@ -39,7 +39,7 @@ const PERCENT_RE = /(\d{1,3})(?:\.\d+)?\s*%\s*(used|consumed|left|remaining|avai
 // example "Max 20x" or "Pro 5x". Keep this deliberately narrow so a random
 // occurrence of "pro" in the TUI cannot become a package label.
 const PLAN_LABEL_RE =
-  /^(?:(?:current|active)\s+)?(?:(?:subscription|plan)(?:\s+(?:tier|type))?\s*[:\-]\s*)?(?:claude\s+)?(max|pro|team|enterprise|go)(?:\s+(\d+(?:\.\d+)?)\s*x?)?$/i
+  /^(?:(?:current|active)\s+)?(?:(?:subscription|plan)(?:\s+(?:tier|type))?\s*[:-]\s*)?(?:claude\s+)?(max|pro|team|enterprise|go)(?:\s+(\d+(?:\.\d+)?)\s*x?)?$/i
 const ESC = String.fromCharCode(27)
 const BEL = String.fromCharCode(7)
 const OSC_SEQUENCE_RE = new RegExp(`${ESC}\\][^${BEL}]*(?:${BEL}|${ESC}\\\\)`, 'g')
@@ -100,7 +100,7 @@ function extractPlanType(lines: string[]): string | null {
   // Only inspect the header before the first usage section. This avoids
   // treating model names or prose in the usage details as a subscription.
   const firstUsageLine = lines.findIndex(isSectionLabel)
-  const headerLines = firstUsageLine >= 0 ? lines.slice(0, firstUsageLine) : lines
+  const headerLines = firstUsageLine !== -1 ? lines.slice(0, firstUsageLine) : lines
   for (const line of headerLines) {
     const match = PLAN_LABEL_RE.exec(line.trim().replace(/\s+/g, ' '))
     if (!match) {

--- a/src/main/rate-limits/claude-pty.ts
+++ b/src/main/rate-limits/claude-pty.ts
@@ -35,6 +35,11 @@ const FABLE_WEEKLY_LABEL_RE = new RegExp(
   'i'
 )
 const PERCENT_RE = /(\d{1,3})(?:\.\d+)?\s*%\s*(used|consumed|left|remaining|available)/i
+// Claude's plan-usage panel may put the subscription on its own line, for
+// example "Max 20x" or "Pro 5x". Keep this deliberately narrow so a random
+// occurrence of "pro" in the TUI cannot become a package label.
+const PLAN_LABEL_RE =
+  /^(?:(?:current|active)\s+)?(?:(?:subscription|plan)(?:\s+(?:tier|type))?\s*[:\-]\s*)?(?:claude\s+)?(max|pro|team|enterprise|go)(?:\s+(\d+(?:\.\d+)?)\s*x?)?$/i
 const ESC = String.fromCharCode(27)
 const BEL = String.fromCharCode(7)
 const OSC_SEQUENCE_RE = new RegExp(`${ESC}\\][^${BEL}]*(?:${BEL}|${ESC}\\\\)`, 'g')
@@ -91,13 +96,32 @@ function extractPercentAfterLabel(
   return null
 }
 
+function extractPlanType(lines: string[]): string | null {
+  // Only inspect the header before the first usage section. This avoids
+  // treating model names or prose in the usage details as a subscription.
+  const firstUsageLine = lines.findIndex(isSectionLabel)
+  const headerLines = firstUsageLine >= 0 ? lines.slice(0, firstUsageLine) : lines
+  for (const line of headerLines) {
+    const match = PLAN_LABEL_RE.exec(line.trim().replace(/\s+/g, ' '))
+    if (!match) {
+      continue
+    }
+    const tier = match[1]
+    const multiplier = match[2]
+    return `${tier.charAt(0).toUpperCase()}${tier.slice(1).toLowerCase()}${multiplier ? ` ${multiplier}x` : ''}`
+  }
+  return null
+}
+
 function parsePtyUsage(output: string): {
   session: RateLimitWindow | null
   weekly: RateLimitWindow | null
   fableWeekly: RateLimitWindow | null
+  planType: string | null
 } {
   const lines = output.split(/\r\n|\n|\r/)
 
+  const planType = extractPlanType(lines)
   const sessionPct = extractPercentAfterLabel(lines, (line) => SESSION_RE.test(line))
   const weeklyPct = extractPercentAfterLabel(lines, matchesWeeklyLabel)
   const fableWeeklyPct = extractPercentAfterLabel(lines, matchesFableUsageLabel)
@@ -143,7 +167,7 @@ function parsePtyUsage(output: string): {
         }
       : null
 
-  return { session, weekly, fableWeekly }
+  return { session, weekly, fableWeekly, planType }
 }
 
 // Why: these substrings indicate the /usage TUI panel has finished
@@ -349,13 +373,14 @@ export async function fetchViaPty(options?: {
         cleanupHiddenRateLimitPty(term, termDisposables, { kill: true })
         // Even on timeout, try to parse whatever we collected
         const clean = stripTerminalControlSequences(output)
-        const { session, weekly, fableWeekly } = parsePtyUsage(clean)
+        const { session, weekly, fableWeekly, planType } = parsePtyUsage(clean)
         if (session || weekly || fableWeekly) {
           resolve({
             provider: 'claude',
             session,
             weekly,
             fableWeekly,
+            planType,
             updatedAt: Date.now(),
             error: null,
             status: 'ok'
@@ -404,7 +429,7 @@ export async function fetchViaPty(options?: {
       cleanupHiddenRateLimitPty(term, termDisposables, { kill: true })
 
       const clean = stripTerminalControlSequences(output)
-      const { session, weekly, fableWeekly } = parsePtyUsage(clean)
+      const { session, weekly, fableWeekly, planType } = parsePtyUsage(clean)
 
       if (!session && !weekly && !fableWeekly) {
         resolve({
@@ -421,6 +446,7 @@ export async function fetchViaPty(options?: {
           session,
           weekly,
           fableWeekly,
+          planType,
           updatedAt: Date.now(),
           error: null,
           status: 'ok'
@@ -505,12 +531,13 @@ export async function fetchViaPty(options?: {
           timeout = null
         }
         const clean = stripTerminalControlSequences(output)
-        const { session, weekly, fableWeekly } = parsePtyUsage(clean)
+        const { session, weekly, fableWeekly, planType } = parsePtyUsage(clean)
         resolve({
           provider: 'claude',
           session,
           weekly,
           fableWeekly,
+          planType,
           updatedAt: Date.now(),
           error:
             session || weekly || fableWeekly

--- a/src/main/rate-limits/grok-fetcher.test.ts
+++ b/src/main/rate-limits/grok-fetcher.test.ts
@@ -83,6 +83,7 @@ describe('fetchGrokRateLimits', () => {
 
     const result = await fetchGrokRateLimits()
     expect(result.status).toBe('ok')
+    expect(result.planType).toBe('SuperGrok')
     expect(result.weekly?.usedPercent).toBe(42)
     expect(result.weekly?.windowMinutes).toBe(10_080)
     expect(result.usageMetadata?.source).toBe('oauth')

--- a/src/main/rate-limits/grok-fetcher.ts
+++ b/src/main/rate-limits/grok-fetcher.ts
@@ -173,6 +173,7 @@ function billingUsageResult(
     session: null,
     weekly: windows.weekly ?? null,
     ...(windows.monthly ? { monthly: windows.monthly } : {}),
+    ...(tier ? { planType: tier } : {}),
     updatedAt: Date.now(),
     error: null,
     status: 'ok',

--- a/src/renderer/src/components/status-bar/UsageRosterPanel.test.tsx
+++ b/src/renderer/src/components/status-bar/UsageRosterPanel.test.tsx
@@ -87,6 +87,21 @@ describe('UsageRow', () => {
     expect(markup).not.toContain('width:25%')
   })
 
+  it('renders the package label beside the provider name', () => {
+    const markup = renderToStaticMarkup(
+      <UsageRow
+        p={{ ...signedOutCodex, planType: 'pro_5x' }}
+        display="used"
+        state={{ kind: 'sign-in', statusLabel: 'not signed in' }}
+        showSignInAction={false}
+        now={mocks.now}
+      />
+    )
+
+    expect(markup).toContain('Codex')
+    expect(markup).toContain('Pro 5x')
+  })
+
   it('uses one shared clock for live reset labels across the roster', () => {
     const sessionReset = mocks.now + 2 * 60_000
     const weeklyReset = mocks.now + 7 * 24 * 60 * 60_000

--- a/src/renderer/src/components/status-bar/tooltip.test.ts
+++ b/src/renderer/src/components/status-bar/tooltip.test.ts
@@ -448,6 +448,25 @@ describe('getWindowSections', () => {
 })
 
 describe('ProviderPanel reset rendering', () => {
+  it('renders a provider-reported subscription package in the detail header', () => {
+    const p = provider({
+      provider: 'claude',
+      status: 'ok',
+      planType: 'max_20x',
+      session: {
+        usedPercent: 20,
+        windowMinutes: 300,
+        resetsAt: null,
+        resetDescription: null
+      }
+    })
+
+    const markup = renderToStaticMarkup(ProviderPanel({ p }))
+
+    expect(markup).toContain('Claude')
+    expect(markup).toContain('Max 20x')
+  })
+
   it('renders the Fable reset countdown when Claude reports a reset timestamp', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date(2026, 6, 3, 20, 0))

--- a/src/renderer/src/components/status-bar/tooltip.tsx
+++ b/src/renderer/src/components/status-bar/tooltip.tsx
@@ -17,6 +17,7 @@ import {
   type UsagePercentageDisplay
 } from '../../../../shared/usage-percentage-display'
 import { formatUsagePercentageLabel } from './usage-percentage-label'
+import { formatPlanLabel } from './usage-roster-formatting'
 
 // Re-exported from its shared home so status-bar callers keep a single import.
 export { clampUsedPercent }
@@ -265,6 +266,7 @@ export function ProviderPanel({
   }
 
   const name = getProviderDisplayName(p.provider)
+  const plan = formatPlanLabel(p.planType)
 
   if (p.status === 'unavailable') {
     return (
@@ -272,6 +274,7 @@ export function ProviderPanel({
         <div className={`flex items-center gap-1.5 font-medium ${textClass}`}>
           <ProviderIcon provider={p.provider} />
           {name}
+          {plan ? <span className={`font-normal ${mutedClass}`}> · {plan}</span> : null}
         </div>
         <div className={mutedClass}>
           {p.error ?? translate('auto.components.status.bar.tooltip.1292d4f2ee', 'Unavailable')}
@@ -286,6 +289,7 @@ export function ProviderPanel({
         <div className={`flex items-center gap-1.5 font-medium ${textClass}`}>
           <ProviderIcon provider={p.provider} />
           {name}
+          {plan ? <span className={`font-normal ${mutedClass}`}> · {plan}</span> : null}
         </div>
         <div className="mt-2">
           <ErrorMessage
@@ -314,6 +318,7 @@ export function ProviderPanel({
         <div className={`flex items-center gap-1.5 text-[13px] font-medium ${textClass}`}>
           <ProviderIcon provider={p.provider} />
           {name}
+          {plan ? <span className={`font-normal ${mutedClass}`}> · {plan}</span> : null}
         </div>
         <div className={faintClass}>{updatedAgo}</div>
         {resetCreditCount !== null && resetCreditCount !== undefined ? (

--- a/src/renderer/src/components/status-bar/usage-roster-formatting.test.ts
+++ b/src/renderer/src/components/status-bar/usage-roster-formatting.test.ts
@@ -13,6 +13,8 @@ describe('formatPlanLabel', () => {
     expect(formatPlanLabel('CHATGPT_PLUS')).toBe('ChatGPT Plus')
     expect(formatPlanLabel('team-plus')).toBe('Team Plus')
     expect(formatPlanLabel('pro trial')).toBe('Pro Trial')
+    expect(formatPlanLabel('max_20x')).toBe('Max 20x')
+    expect(formatPlanLabel('pro_5x')).toBe('Pro 5x')
   })
 
   it('returns null when there is no usable plan', () => {

--- a/src/renderer/src/components/status-bar/usage-roster-formatting.ts
+++ b/src/renderer/src/components/status-bar/usage-roster-formatting.ts
@@ -1,8 +1,8 @@
 // Pure formatting for the consolidated Usage roster, split out so it can be unit
 // tested without pulling in React / UI dependencies.
 
-// "plus" -> "Plus", "chatgpt_business" -> "ChatGPT Business". Codex is the only
-// provider that reports a plan today; others render just the name.
+// "plus" -> "Plus", "chatgpt_business" -> "ChatGPT Business". Provider
+// adapters own the raw value; this only turns it into a compact display label.
 export function formatPlanLabel(planType: string | null | undefined): string | null {
   const trimmed = planType?.trim()
   if (!trimmed) {

--- a/src/shared/rate-limit-types.ts
+++ b/src/shared/rate-limit-types.ts
@@ -78,7 +78,7 @@ export type ProviderRateLimits = {
       grantedAt: number | null
     }[]
   } | null
-  /** Subscription plan tier for the active account (Codex `plan_type`, e.g. "plus"). */
+  /** Provider-reported subscription tier/package label (for example "plus" or "Max 20x"). */
   planType?: string | null
   /** Unix ms timestamp of the last successful data update. */
   updatedAt: number

--- a/src/shared/tui-agent-usage-support.test.ts
+++ b/src/shared/tui-agent-usage-support.test.ts
@@ -12,27 +12,27 @@ describe('TuiAgent usage support catalog', () => {
   it('maps only adapters with a matching usage provider', () => {
     expect(getTuiAgentUsageSupport('claude')).toEqual({
       usageProvider: 'claude',
-      usageAuth: 'oauth-or-cli',
+      usageCredentialSource: 'oauth-or-cli',
       planLabelSource: 'provider-account'
     })
     expect(getTuiAgentUsageSupport('claude-agent-teams')).toEqual({
       usageProvider: 'claude',
-      usageAuth: 'oauth-or-cli',
+      usageCredentialSource: 'oauth-or-cli',
       planLabelSource: 'provider-account'
     })
     expect(getTuiAgentUsageSupport('codex')).toEqual({
       usageProvider: 'codex',
-      usageAuth: 'oauth',
+      usageCredentialSource: 'oauth',
       planLabelSource: 'provider-account'
     })
     expect(getTuiAgentUsageSupport('grok')).toEqual({
       usageProvider: 'grok',
-      usageAuth: 'oauth',
+      usageCredentialSource: 'oauth',
       planLabelSource: 'provider-account'
     })
     expect(getTuiAgentUsageSupport('opencode')).toEqual({
       usageProvider: null,
-      usageAuth: 'none',
+      usageCredentialSource: 'not-owned',
       planLabelSource: 'not-exposed'
     })
   })

--- a/src/shared/tui-agent-usage-support.test.ts
+++ b/src/shared/tui-agent-usage-support.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { TUI_AGENT_CONFIG } from './tui-agent-config'
+import { getTuiAgentUsageSupport, TUI_AGENT_USAGE_SUPPORT } from './tui-agent-usage-support'
+
+describe('TuiAgent usage support catalog', () => {
+  it('covers every Orca launchable agent without PATH detection', () => {
+    expect(Object.keys(TUI_AGENT_USAGE_SUPPORT).sort()).toEqual(
+      Object.keys(TUI_AGENT_CONFIG).sort()
+    )
+  })
+
+  it('maps only adapters with a matching usage provider', () => {
+    expect(getTuiAgentUsageSupport('claude')).toEqual({
+      usageProvider: 'claude',
+      usageAuth: 'oauth-or-cli',
+      planLabelSource: 'provider-account'
+    })
+    expect(getTuiAgentUsageSupport('claude-agent-teams')).toEqual({
+      usageProvider: 'claude',
+      usageAuth: 'oauth-or-cli',
+      planLabelSource: 'provider-account'
+    })
+    expect(getTuiAgentUsageSupport('codex')).toEqual({
+      usageProvider: 'codex',
+      usageAuth: 'oauth',
+      planLabelSource: 'provider-account'
+    })
+    expect(getTuiAgentUsageSupport('grok')).toEqual({
+      usageProvider: 'grok',
+      usageAuth: 'oauth',
+      planLabelSource: 'provider-account'
+    })
+    expect(getTuiAgentUsageSupport('opencode')).toEqual({
+      usageProvider: null,
+      usageAuth: 'none',
+      planLabelSource: 'not-exposed'
+    })
+  })
+})

--- a/src/shared/tui-agent-usage-support.ts
+++ b/src/shared/tui-agent-usage-support.ts
@@ -5,15 +5,15 @@ import type { TuiAgent } from './tui-agent'
 export type TuiAgentUsageSupport = {
   /** Orca adapter that can supply quota data for this agent, when one exists. */
   usageProvider: ProviderRateLimits['provider'] | null
-  /** Credential path used by Orca's usage adapter, not the agent's launch auth. */
-  usageAuth: 'oauth' | 'oauth-or-cli' | 'shared-gemini-oauth' | 'none'
+  /** Credential source owned by Orca's usage adapter, not the agent's launch auth. */
+  usageCredentialSource: 'oauth' | 'oauth-or-cli' | 'shared-gemini-oauth' | 'not-owned'
   /** Whether the adapter currently has a provider-owned plan label to report. */
   planLabelSource: 'provider-account' | 'not-exposed'
 }
 
 const noUsageAdapter: TuiAgentUsageSupport = {
   usageProvider: null,
-  usageAuth: 'none',
+  usageCredentialSource: 'not-owned',
   planLabelSource: 'not-exposed'
 }
 
@@ -21,16 +21,20 @@ const noUsageAdapter: TuiAgentUsageSupport = {
 export const TUI_AGENT_USAGE_SUPPORT = {
   claude: {
     usageProvider: 'claude',
-    usageAuth: 'oauth-or-cli',
+    usageCredentialSource: 'oauth-or-cli',
     planLabelSource: 'provider-account'
   },
   'claude-agent-teams': {
     usageProvider: 'claude',
-    usageAuth: 'oauth-or-cli',
+    usageCredentialSource: 'oauth-or-cli',
     planLabelSource: 'provider-account'
   },
   openclaude: noUsageAdapter,
-  codex: { usageProvider: 'codex', usageAuth: 'oauth', planLabelSource: 'provider-account' },
+  codex: {
+    usageProvider: 'codex',
+    usageCredentialSource: 'oauth',
+    planLabelSource: 'provider-account'
+  },
   autohand: noUsageAdapter,
   // OpenCode can use many upstream accounts; OpenCode Go is a separate
   // cookie-backed adapter and must not be inferred for the generic CLI.
@@ -38,10 +42,14 @@ export const TUI_AGENT_USAGE_SUPPORT = {
   'mimo-code': noUsageAdapter,
   pi: noUsageAdapter,
   omp: noUsageAdapter,
-  gemini: { usageProvider: 'gemini', usageAuth: 'oauth', planLabelSource: 'not-exposed' },
+  gemini: {
+    usageProvider: 'gemini',
+    usageCredentialSource: 'oauth',
+    planLabelSource: 'not-exposed'
+  },
   antigravity: {
     usageProvider: 'antigravity',
-    usageAuth: 'shared-gemini-oauth',
+    usageCredentialSource: 'shared-gemini-oauth',
     planLabelSource: 'not-exposed'
   },
   aider: noUsageAdapter,
@@ -57,14 +65,22 @@ export const TUI_AGENT_USAGE_SUPPORT = {
   continue: noUsageAdapter,
   cursor: noUsageAdapter,
   droid: noUsageAdapter,
-  kimi: { usageProvider: 'kimi', usageAuth: 'oauth', planLabelSource: 'not-exposed' },
+  kimi: {
+    usageProvider: 'kimi',
+    usageCredentialSource: 'oauth',
+    planLabelSource: 'not-exposed'
+  },
   'mistral-vibe': noUsageAdapter,
   'qwen-code': noUsageAdapter,
   rovo: noUsageAdapter,
   hermes: noUsageAdapter,
   openclaw: noUsageAdapter,
   copilot: noUsageAdapter,
-  grok: { usageProvider: 'grok', usageAuth: 'oauth', planLabelSource: 'provider-account' },
+  grok: {
+    usageProvider: 'grok',
+    usageCredentialSource: 'oauth',
+    planLabelSource: 'provider-account'
+  },
   devin: noUsageAdapter,
   ante: noUsageAdapter,
   trae: noUsageAdapter,

--- a/src/shared/tui-agent-usage-support.ts
+++ b/src/shared/tui-agent-usage-support.ts
@@ -1,0 +1,76 @@
+import type { ProviderRateLimits } from './rate-limit-types'
+import type { TuiAgent } from './tui-agent'
+
+/** Install-independent usage and plan coverage for a launchable TUI agent. */
+export type TuiAgentUsageSupport = {
+  /** Orca adapter that can supply quota data for this agent, when one exists. */
+  usageProvider: ProviderRateLimits['provider'] | null
+  /** Credential path used by Orca's usage adapter, not the agent's launch auth. */
+  usageAuth: 'oauth' | 'oauth-or-cli' | 'shared-gemini-oauth' | 'none'
+  /** Whether the adapter currently has a provider-owned plan label to report. */
+  planLabelSource: 'provider-account' | 'not-exposed'
+}
+
+const noUsageAdapter: TuiAgentUsageSupport = {
+  usageProvider: null,
+  usageAuth: 'none',
+  planLabelSource: 'not-exposed'
+}
+
+/** Static coverage for every Orca TuiAgent; runtime detection is separate. */
+export const TUI_AGENT_USAGE_SUPPORT = {
+  claude: {
+    usageProvider: 'claude',
+    usageAuth: 'oauth-or-cli',
+    planLabelSource: 'provider-account'
+  },
+  'claude-agent-teams': {
+    usageProvider: 'claude',
+    usageAuth: 'oauth-or-cli',
+    planLabelSource: 'provider-account'
+  },
+  openclaude: noUsageAdapter,
+  codex: { usageProvider: 'codex', usageAuth: 'oauth', planLabelSource: 'provider-account' },
+  autohand: noUsageAdapter,
+  // OpenCode can use many upstream accounts; OpenCode Go is a separate
+  // cookie-backed adapter and must not be inferred for the generic CLI.
+  opencode: noUsageAdapter,
+  'mimo-code': noUsageAdapter,
+  pi: noUsageAdapter,
+  omp: noUsageAdapter,
+  gemini: { usageProvider: 'gemini', usageAuth: 'oauth', planLabelSource: 'not-exposed' },
+  antigravity: {
+    usageProvider: 'antigravity',
+    usageAuth: 'shared-gemini-oauth',
+    planLabelSource: 'not-exposed'
+  },
+  aider: noUsageAdapter,
+  goose: noUsageAdapter,
+  amp: noUsageAdapter,
+  kilo: noUsageAdapter,
+  kiro: noUsageAdapter,
+  crush: noUsageAdapter,
+  aug: noUsageAdapter,
+  cline: noUsageAdapter,
+  codebuff: noUsageAdapter,
+  'command-code': noUsageAdapter,
+  continue: noUsageAdapter,
+  cursor: noUsageAdapter,
+  droid: noUsageAdapter,
+  kimi: { usageProvider: 'kimi', usageAuth: 'oauth', planLabelSource: 'not-exposed' },
+  'mistral-vibe': noUsageAdapter,
+  'qwen-code': noUsageAdapter,
+  rovo: noUsageAdapter,
+  hermes: noUsageAdapter,
+  openclaw: noUsageAdapter,
+  copilot: noUsageAdapter,
+  grok: { usageProvider: 'grok', usageAuth: 'oauth', planLabelSource: 'provider-account' },
+  devin: noUsageAdapter,
+  ante: noUsageAdapter,
+  trae: noUsageAdapter,
+  'prime-agent': noUsageAdapter
+} satisfies Record<TuiAgent, TuiAgentUsageSupport>
+
+export function getTuiAgentUsageSupport(agent: TuiAgent): TuiAgentUsageSupport {
+  return TUI_AGENT_USAGE_SUPPORT[agent]
+}


### PR DESCRIPTION
## ELI5
Usage rows now show an account-provided package label when available, such as `Claude · Max 20x` or `Codex · Pro`.

## What Changed
- Preserve optional provider `planType` data and format it only at the UI boundary.
- Parse Claude package headers narrowly while keeping OAuth/CLI fallback behavior.
- Add install-independent metadata and tests covering all 36 Orca `TuiAgent` entries.
- Leave the label blank when the provider does not expose a plan.

## Why
Plan names must come from authenticated provider/account data, not model names or PATH detection.

## Linked Issue
Fixes #16296

## Visual Proof
The existing Usage roster and provider detail header gain only an optional ` · <plan>` suffix. Renderer tests cover the changed states; no Electron runtime was started in this handoff.

## Testing
- Targeted Vitest: 7 files / 96 tests passed.
- `pnpm run typecheck` passed.
- `pnpm run lint` passed, including native/type-aware and localization audits.
- `git diff --check` passed.
- Full `pnpm run test` was not run locally because Node 26.5 cannot load Orca's patched `node-pty`; the repository engine is Node 24.

## AI Disclosure
Implemented and reviewed with OpenAI Codex.

## Review
- No credential writes, persistence, or logging; plan data remains optional and provider-owned.
- All agent catalog entries are covered without PATH detection or local CLI installation.
- Existing cross-platform, WSL/SSH, auth, polling, and wire-schema paths are unchanged.
- No release/version changes.

## Agent skill upstream boundary
- [x] Not applicable.

## Checklist
- [x] Small, focused change
- [x] Linked issue, tests, and review notes included
- [x] Security, performance, cross-platform, and remote paths reviewed
- [ ] Electron screenshot not captured; render tests cover this text-only suffix

## Author
- X / Twitter: @RobithYusuf