### PR TITLE
Restore previously-active tab when closing a browser tab

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -1774,9 +1774,12 @@ function Terminal(): React.JSX.Element | null {
       }
       const currentTabs = state.browserTabsByWorktree[owningWorktreeId] ?? []
       if (currentTabs.length <= 1) {
+        const hasUnifiedEntry = Object.values(state.unifiedTabsByWorktree).some((tabs) =>
+          tabs.some((tab) => tab.contentType === 'browser' && tab.entityId === tabId)
+        )
         destroyWorkspaceWebviews(state.browserPagesByWorkspace, tabId)
         closeBrowserTab(tabId)
-        if (state.activeWorktreeId === owningWorktreeId) {
+        if (!hasUnifiedEntry && state.activeWorktreeId === owningWorktreeId) {
           const worktreeFile = state.openFiles.find((file) => file.worktreeId === owningWorktreeId)
           if (worktreeFile) {
             setActiveFile(worktreeFile.id)
@@ -1793,24 +1796,10 @@ function Terminal(): React.JSX.Element | null {
         }
         return
       }
-      if (state.activeWorktreeId === owningWorktreeId && tabId === state.activeBrowserTabId) {
-        const idx = currentTabs.findIndex((tab) => tab.id === tabId)
-        const nextTab = currentTabs[idx + 1] ?? currentTabs[idx - 1]
-        if (nextTab) {
-          setActiveBrowserTab(nextTab.id)
-        }
-      }
       destroyWorkspaceWebviews(state.browserPagesByWorkspace, tabId)
       closeBrowserTab(tabId)
     },
-    [
-      closeBrowserTab,
-      setActiveBrowserTab,
-      setActiveFile,
-      setActiveTab,
-      setActiveTabType,
-      setActiveWorktree
-    ]
+    [closeBrowserTab, setActiveFile, setActiveTab, setActiveTabType, setActiveWorktree]
   )
 
   const handlePtyExit = useCallback(

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -1777,8 +1777,9 @@ function Terminal(): React.JSX.Element | null {
         const hasUnifiedEntry = Object.values(state.unifiedTabsByWorktree).some((tabs) =>
           tabs.some((tab) => tab.contentType === 'browser' && tab.entityId === tabId)
         )
-        destroyWorkspaceWebviews(state.browserPagesByWorkspace, tabId)
         closeBrowserTab(tabId)
+        // closeBrowserTab announces the MRU target before guest teardown can trigger bridge fallback.
+        destroyWorkspaceWebviews(state.browserPagesByWorkspace, tabId)
         if (!hasUnifiedEntry && state.activeWorktreeId === owningWorktreeId) {
           const worktreeFile = state.openFiles.find((file) => file.worktreeId === owningWorktreeId)
           if (worktreeFile) {
@@ -1796,8 +1797,9 @@ function Terminal(): React.JSX.Element | null {
         }
         return
       }
-      destroyWorkspaceWebviews(state.browserPagesByWorkspace, tabId)
       closeBrowserTab(tabId)
+      // closeBrowserTab announces the MRU target before guest teardown can trigger bridge fallback.
+      destroyWorkspaceWebviews(state.browserPagesByWorkspace, tabId)
     },
     [closeBrowserTab, setActiveFile, setActiveTab, setActiveTabType, setActiveWorktree]
   )
@@ -1868,8 +1870,8 @@ function Terminal(): React.JSX.Element | null {
         } else if (
           (state.browserTabsByWorktree[activeWorktreeId] ?? []).some((tab) => tab.id === id)
         ) {
-          destroyWorkspaceWebviews(state.browserPagesByWorkspace, id)
           closeBrowserTab(id)
+          destroyWorkspaceWebviews(state.browserPagesByWorkspace, id)
         } else if (unifiedTab?.contentType === 'simulator') {
           // Why: simulator tabs live only in the unified-tab store, so the
           // entity-store checks above never match them.

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -896,8 +896,8 @@ export function FloatingTerminalPanel({
         if (item.contentType === 'terminal') {
           closeTab(item.entityId, { reason: 'cleanup' })
         } else if (item.contentType === 'browser') {
-          destroyWorkspaceWebviews(state.browserPagesByWorkspace, item.entityId)
           closeBrowserTab(item.entityId)
+          destroyWorkspaceWebviews(state.browserPagesByWorkspace, item.entityId)
         } else if (item.contentType === 'simulator') {
           closeUnifiedTab(item.id)
         } else {
@@ -952,8 +952,8 @@ export function FloatingTerminalPanel({
         onClose: () => {
           const latest = useAppStore.getState()
           if (item.contentType === 'browser') {
-            destroyWorkspaceWebviews(latest.browserPagesByWorkspace, item.entityId)
             closeBrowserTab(item.entityId)
+            destroyWorkspaceWebviews(latest.browserPagesByWorkspace, item.entityId)
           } else if (item.contentType === 'simulator') {
             closeUnifiedTab(item.id)
           } else {

--- a/src/renderer/src/components/tab-group/useTabGroupTabCloseCommands.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupTabCloseCommands.ts
@@ -99,8 +99,8 @@ export function useTabGroupTabCloseCommands({
             reason: 'user'
           })
         }
-        destroyWorkspaceWebviews(browserState.browserPagesByWorkspace, item.entityId)
         closeBrowserTab(item.entityId)
+        destroyWorkspaceWebviews(browserState.browserPagesByWorkspace, item.entityId)
         closeUnifiedTab(item.id)
       } else if (item.contentType === 'simulator') {
         closeUnifiedTab(item.id)
@@ -159,8 +159,8 @@ export function useTabGroupTabCloseCommands({
               reason: 'user'
             })
           }
-          destroyWorkspaceWebviews(browserState.browserPagesByWorkspace, item.entityId)
           closeBrowserTab(item.entityId)
+          destroyWorkspaceWebviews(browserState.browserPagesByWorkspace, item.entityId)
           closeUnifiedTab(item.id)
         } else if (item.contentType === 'terminal') {
           closeTab(item.entityId)

--- a/src/renderer/src/store/slices/browser.test.ts
+++ b/src/renderer/src/store/slices/browser.test.ts
@@ -105,6 +105,21 @@ function makeAnnotation(pageId: string, id = 'annotation-1'): BrowserPageAnnotat
 }
 
 describe('createBrowserSlice annotations', () => {
+  it('announces the store-selected browser page before its guest is destroyed', () => {
+    const store = createTestStore()
+    const previous = store.getState().createBrowserTab('wt-1', 'https://previous.example.com')
+    const closing = store.getState().createBrowserTab('wt-1', 'https://closing.example.com')
+    store.getState().setActiveBrowserTab(previous.id)
+    store.getState().setActiveBrowserTab(closing.id)
+    mockApi.browser.notifyActiveTabChanged.mockClear()
+
+    store.getState().closeBrowserTab(closing.id)
+
+    expect(mockApi.browser.notifyActiveTabChanged).toHaveBeenCalledWith({
+      browserPageId: previous.activePageId
+    })
+  })
+
   it('keeps a requested canonical page identity distinct from its workspace', () => {
     const store = createTestStore()
     const tab = store.getState().createBrowserTab('wt-1', 'about:blank', {

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -23,13 +23,13 @@ import {
   normalizeBrowserHistoryEntries,
   normalizeBrowserHistoryUrl
 } from '../../../../shared/workspace-session-browser-history'
-import { pickNeighbor } from './tab-group-state'
 import { destroyWorkspaceWebviews } from './browser-webview-cleanup'
 import {
   getRecentlyClosedTabPosition,
   restoreRecentlyClosedTabPosition,
   pushRecentlyClosedTabKind
 } from './recently-closed-tabs'
+import { pickNeighbor } from './tab-group-state'
 import type { RecentlyClosedTabPosition } from './recently-closed-tabs'
 import { callRuntimeRpc, type RuntimeClientTarget } from '@/runtime/runtime-rpc-client'
 import { toRuntimeWorktreeSelector } from '@/runtime/runtime-worktree-selector'
@@ -846,13 +846,14 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
         delete nextRemoteBrowserPageHandlesByPageId[page.id]
       }
 
-      const nextActiveBrowserTabIdByWorktree = { ...s.activeBrowserTabIdByWorktree }
       const remainingBrowserTabs = nextBrowserTabsByWorktree[owningWorktreeId] ?? []
-      const tabBarOrder = s.tabBarOrderByWorktree[owningWorktreeId] ?? []
-      const neighborTabId = pickNeighbor(tabBarOrder, tabId)
+      const nextActiveBrowserTabIdByWorktree = { ...s.activeBrowserTabIdByWorktree }
       if (nextActiveBrowserTabIdByWorktree[owningWorktreeId] === tabId) {
+        const neighborId = pickNeighbor(s.tabBarOrderByWorktree[owningWorktreeId] ?? [], tabId)
         nextActiveBrowserTabIdByWorktree[owningWorktreeId] =
-          neighborTabId ?? remainingBrowserTabs[0]?.id ?? null
+          (neighborId && remainingBrowserTabs.some((tab) => tab.id === neighborId)
+            ? neighborId
+            : remainingBrowserTabs[0]?.id) ?? null
       }
 
       const nextTabBarOrder = {
@@ -916,7 +917,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
         browserPagesByWorkspace: nextBrowserPagesByWorkspace,
         activeBrowserTabId:
           s.activeBrowserTabId === tabId
-            ? (neighborTabId ?? remainingBrowserTabs[0]?.id ?? null)
+            ? (nextActiveBrowserTabIdByWorktree[owningWorktreeId] ?? null)
             : s.activeBrowserTabId,
         activeBrowserTabIdByWorktree: nextActiveBrowserTabIdByWorktree,
         tabBarOrderByWorktree: nextTabBarOrder,

--- a/src/renderer/src/store/slices/browser.ts
+++ b/src/renderer/src/store/slices/browser.ts
@@ -805,6 +805,7 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
   },
   closeBrowserTab: (tabId) => {
     let remotePagesToClose: { worktreeId: string; handle: RemoteBrowserPageHandle }[] = []
+    let activeBrowserWorktreeIdToNotify: string | null = null
     set((s) => {
       let owningWorktreeId: string | null = null
       let closedWorkspace: BrowserWorkspace | null = null
@@ -865,6 +866,9 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
 
       const isActiveTabInOwningWorktree =
         s.activeWorktreeId === owningWorktreeId && s.activeBrowserTabId === tabId
+      if (isActiveTabInOwningWorktree) {
+        activeBrowserWorktreeIdToNotify = owningWorktreeId
+      }
       const nextActiveTabTypeByWorktree = { ...s.activeTabTypeByWorktree }
       let nextActiveTabType = s.activeTabType
       if (remainingBrowserTabs.length === 0) {
@@ -946,6 +950,34 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
         get().closeUnifiedTab(workspaceItem.id)
       }
     }
+
+    // Why: announce the MRU page before guest teardown so bridge fallback cannot choose registration order.
+    if (activeBrowserWorktreeIdToNotify) {
+      const state = get()
+      const activeWorkspaceId = state.activeBrowserTabIdByWorktree[activeBrowserWorktreeIdToNotify]
+      const activeWorkspace = activeWorkspaceId
+        ? findWorkspace(state.browserTabsByWorktree, activeWorkspaceId)
+        : null
+      const activePage = activeWorkspace?.activePageId
+        ? (state.browserPagesByWorkspace[activeWorkspace.id] ?? []).find(
+            (page) => page.id === activeWorkspace.activePageId
+          )
+        : undefined
+      if (
+        activeWorkspace?.activePageId &&
+        isLocalBrowserPageOwner(
+          state,
+          activeBrowserWorktreeIdToNotify,
+          activePage?.browserRuntimeEnvironmentId
+        ) &&
+        typeof window !== 'undefined' &&
+        window.api?.browser
+      ) {
+        window.api.browser
+          .notifyActiveTabChanged({ browserPageId: activeWorkspace.activePageId })
+          .catch(() => {})
+      }
+    }
   },
 
   shutdownWorktreeBrowsers: async (worktreeId) => {
@@ -953,8 +985,9 @@ export const createBrowserSlice: StateCreator<AppState, [], [], BrowserSlice> = 
     // Why: snapshot before the loop — closeBrowserTab empties the array, so set() below couldn't recompute hadBrowserTabs.
     const hadBrowserTabs = workspaces.length > 0
     for (const workspace of workspaces) {
-      destroyWorkspaceWebviews(get().browserPagesByWorkspace, workspace.id)
+      const browserPagesByWorkspace = get().browserPagesByWorkspace
       get().closeBrowserTab(workspace.id)
+      destroyWorkspaceWebviews(browserPagesByWorkspace, workspace.id)
     }
     set((s) => {
       const nextBrowserTabsByWorktree = { ...s.browserTabsByWorktree }

--- a/src/renderer/src/store/slices/store-active-worktree-tab-close.test.ts
+++ b/src/renderer/src/store/slices/store-active-worktree-tab-close.test.ts
@@ -424,6 +424,108 @@ describe('setActiveWorktree', () => {
     expect(s.activeBrowserTabIdByWorktree[backgroundWt]).toBe(browserTab.id)
   })
 
+  it('uses unified MRU selection when closing an active browser tab', () => {
+    const store = createTestStore()
+    const wt = 'repo1::/path/wt1'
+
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
+      },
+      activeWorktreeId: wt
+    })
+
+    const previous = store.getState().createBrowserTab(wt, 'https://previous.example.com')
+    store.getState().createBrowserTab(wt, 'https://neighbor.example.com')
+    const closing = store.getState().createBrowserTab(wt, 'https://closing.example.com')
+    store.getState().setActiveBrowserTab(previous.id)
+    store.getState().setActiveBrowserTab(closing.id)
+
+    store.getState().closeBrowserTab(closing.id)
+
+    expect(store.getState().activeBrowserTabId).toBe(previous.id)
+    expect(store.getState().activeBrowserTabIdByWorktree[wt]).toBe(previous.id)
+  })
+
+  it('keeps the unified MRU target when closing the last browser tab', () => {
+    const store = createTestStore()
+    const wt = 'repo1::/path/wt1'
+
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
+      },
+      activeWorktreeId: wt
+    })
+
+    store.getState().createTab(wt)
+    const previous = store.getState().createTab(wt)
+    const closing = store.getState().createBrowserTab(wt, 'https://closing.example.com')
+
+    store.getState().closeBrowserTab(closing.id)
+
+    expect(store.getState().activeTabId).toBe(previous.id)
+    expect(store.getState().activeTabType).toBe('terminal')
+  })
+
+  it('keeps a valid browser target for an inactive worktree after close', () => {
+    const store = createTestStore()
+    const activeWt = 'repo1::/path/active'
+    const backgroundWt = 'repo1::/path/background'
+
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [
+          makeWorktree({ id: activeWt, repoId: 'repo1', path: '/path/active' }),
+          makeWorktree({ id: backgroundWt, repoId: 'repo1', path: '/path/background' })
+        ]
+      },
+      activeWorktreeId: activeWt
+    })
+
+    const previous = store
+      .getState()
+      .createBrowserTab(backgroundWt, 'https://previous.example.com', {
+        activate: false
+      })
+    const closing = store.getState().createBrowserTab(backgroundWt, 'https://closing.example.com', {
+      activate: false
+    })
+    store.setState({ activeBrowserTabIdByWorktree: { [backgroundWt]: closing.id } })
+
+    store.getState().closeBrowserTab(closing.id)
+
+    expect(store.getState().activeBrowserTabIdByWorktree[backgroundWt]).toBe(previous.id)
+  })
+
+  it('keeps the global browser target when closing a legacy tab without a unified wrapper', () => {
+    const store = createTestStore()
+    const wt = 'repo1::/path/wt1'
+
+    seedStore(store, {
+      worktreesByRepo: {
+        repo1: [makeWorktree({ id: wt, repoId: 'repo1', path: '/path/wt1' })]
+      },
+      activeWorktreeId: wt
+    })
+
+    const previous = store.getState().createBrowserTab(wt, 'https://previous.example.com', {
+      activate: false
+    })
+    const closing = store.getState().createBrowserTab(wt, 'https://closing.example.com', {
+      activate: false
+    })
+    store.setState({
+      unifiedTabsByWorktree: {},
+      activeBrowserTabId: closing.id,
+      activeBrowserTabIdByWorktree: { [wt]: closing.id }
+    })
+
+    store.getState().closeBrowserTab(closing.id)
+
+    expect(store.getState().activeBrowserTabId).toBe(previous.id)
+  })
+
   it('queues and consumes a one-shot address-bar focus request for a fresh blank browser tab', () => {
     const store = createTestStore()
     const wt = 'repo1::/path/wt1'

--- a/src/renderer/src/store/slices/tabs-open-close-lifecycle.test.ts
+++ b/src/renderer/src/store/slices/tabs-open-close-lifecycle.test.ts
@@ -347,12 +347,12 @@ describe('TabsSlice', () => {
       expect(buildMobileSessionTabSnapshots(store.getState())[0]?.tabs ?? []).toEqual([])
     })
 
-    it('activates the previously-active tab (MRU) instead of the visual neighbor', () => {
+    it('activates the previously-active tab across content types', () => {
       const t1 = store.getState().createUnifiedTab(WT, 'terminal')
-      const t2 = store.getState().createUnifiedTab(WT, 'terminal')
-      const t3 = store.getState().createUnifiedTab(WT, 'terminal')
+      const t2 = store.getState().createUnifiedTab(WT, 'browser')
+      const t3 = store.getState().createUnifiedTab(WT, 'editor')
 
-      // Visit order ...→t3→t1→t3; closing t3 should jump to t1 (MRU previous), not the visual neighbor t2.
+      // Visit order ...→t3→t1→t3; closing t3 should jump to t1, not browser neighbor t2.
       store.getState().activateTab(t1.id)
       store.getState().activateTab(t3.id)
       store.getState().closeUnifiedTab(t3.id)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​121 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​117 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​55 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​30 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​25 |

<!-- /orca-pr-loc -->

## Problem

When closing a browser tab, Orca switches to the next tab in visual order (right neighbor, or left if none). This ignores user context — they want to return to what they were working on before, not just the adjacent tab.

## Solution

Changed tab-close behavior to restore the previously-active (MRU) tab instead of picking a visual neighbor. This respects the actual usage pattern and works across content types (browser, terminal, editor tabs tracked together in the unified system).

## What Changed

**browser.ts**: Improved next-tab selection when closing a browser tab. Uses `pickNeighbor()` to find a candidate, but validates it still exists; falls back to the first remaining tab. Fixed global `activeBrowserTabId` to use the pre-computed worktree-specific selection instead of recalculating.

**Terminal.tsx**: Removed the inline tab-switching logic that was picking neighbors. Moved responsibility to the store via MRU tracking. When closing the last browser tab in a worktree, checks if it's wrapped in the unified tab system before falling back to a file tab.

**Tests**: Added 4 new tests for MRU restoration:
- MRU selection when closing active browser tab in active worktree
- Keeping unified MRU target when closing the last browser tab (switches to previous terminal/editor tab)
- Proper selection for inactive worktrees
- Legacy tab handling without unified wrapper

Updated existing test to verify MRU works across content types (terminal → browser → editor), not just visual neighbors.

## Visual Proof

N/A — interaction change verified by unit tests. Manual verification: open 3+ browser tabs, activate tab A, activate tab B, close tab B → should return to tab A (not the visual neighbor).

## Testing

- [x] Automated tests added/updated
  - New MRU selection tests for various scenarios
  - Updated existing tab-close test to verify cross-content-type MRU
  - Covers active/inactive worktree cases and legacy (non-unified) tab handling

## Cross-platform Impact

No platform-specific behavior added. Logic is generic tab management, applicable to macOS, Linux, Windows, and SSH.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [ ] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)