### PR TITLE
fix(sidebar): stop reporting an interrupted agent as done (STA-5357)

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.recent-tabs.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.recent-tabs.test.tsx
@@ -665,7 +665,7 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
     expect(getTabRowIds()).toContain('tab-alpha')
   })
 
-  it('excludes the current tab when its agent is merely done', async () => {
+  it.each([undefined, true])('excludes current terminal outcomes', async (interrupted) => {
     await renderPalette(
       makeRecentTabState({
         activeWorktreeId: 'wt-alpha',
@@ -674,7 +674,9 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
         activeTabIdByWorktree: { 'wt-alpha': 'term-alpha' },
         activeTabTypeByWorktree: { 'wt-alpha': 'terminal' },
         agentStatusByPaneKey: {
-          [makePaneKey('term-alpha', LEAF_ID)]: makeAgentEntry('term-alpha', 'done', Date.now())
+          [makePaneKey('term-alpha', LEAF_ID)]: makeAgentEntry('term-alpha', 'done', Date.now(), {
+            interrupted
+          })
         }
       })
     )

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -449,7 +449,7 @@ function shouldIncludeOpenTabInRecentSection({
       unreadAgentCompletionPanes
     })
   })
-  return badge != null && badge !== 'done'
+  return badge != null && badge !== 'done' && badge !== 'interrupted'
 }
 
 function PaletteRowShortcutBadge({

--- a/src/renderer/src/components/sidebar/StatusIndicator.test.ts
+++ b/src/renderer/src/components/sidebar/StatusIndicator.test.ts
@@ -60,4 +60,11 @@ describe('StatusIndicator', () => {
 
     expect(classNames).toContain('bg-emerald-500')
   })
+
+  it('renders interrupted distinctly from done', () => {
+    const classNames = renderDotClassNames('interrupted')
+
+    expect(classNames).toContain('bg-red-500')
+    expect(classNames).not.toContain('bg-emerald-500')
+  })
 })

--- a/src/renderer/src/components/sidebar/StatusIndicator.tsx
+++ b/src/renderer/src/components/sidebar/StatusIndicator.tsx
@@ -53,6 +53,21 @@ const StatusIndicator = React.memo(function StatusIndicator({
     )
   }
 
+  if (status === 'interrupted') {
+    return (
+      <span
+        className={cn('inline-flex h-3 w-3 shrink-0 items-center justify-center', className)}
+        title={resolvedTitle}
+        {...rest}
+      >
+        {/* Why red, and why not the emerald done dot: the turn was cancelled or died, so it needs a
+            human to restart or look — presenting it as a completion is the bug (STA-5357). Matches the
+            agent row's own interrupted treatment (AgentStateDot uses bg-red-500). */}
+        <span className="block size-1.5 rounded-full bg-red-500" />
+      </span>
+    )
+  }
+
   if (status === 'permission') {
     return (
       <span

--- a/src/renderer/src/components/sidebar/StatusIndicator.tsx
+++ b/src/renderer/src/components/sidebar/StatusIndicator.tsx
@@ -60,9 +60,6 @@ const StatusIndicator = React.memo(function StatusIndicator({
         title={resolvedTitle}
         {...rest}
       >
-        {/* Why red, and why not the emerald done dot: the turn was cancelled or died, so it needs a
-            human to restart or look — presenting it as a completion is the bug (STA-5357). Matches the
-            agent row's own interrupted treatment (AgentStateDot uses bg-red-500). */}
         <span className="block size-1.5 rounded-full bg-red-500" />
       </span>
     )

--- a/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-status.ts
@@ -26,6 +26,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
     hasPermission,
     hasLiveWorking,
     hasLiveMonitoring,
+    hasInterrupted,
     hasLiveDone,
     hasRetainedDone,
     agentStatusPaneIdsByTabId
@@ -46,6 +47,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
         hasPermission,
         hasLiveWorking,
         hasLiveMonitoring,
+        hasInterrupted,
         hasLiveDone,
         hasRetainedDone
       }),
@@ -59,6 +61,7 @@ export function useWorktreeActivityStatus(worktreeId: string): WorktreeStatus {
       hasPermission,
       hasLiveWorking,
       hasLiveMonitoring,
+      hasInterrupted,
       hasLiveDone,
       hasRetainedDone
     ]

--- a/src/renderer/src/components/sidebar/use-worktree-activity-statuses.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-activity-statuses.ts
@@ -34,6 +34,7 @@ export function selectWorktreeActivityStatuses(
       hasPermission,
       hasLiveWorking,
       hasLiveMonitoring,
+      hasInterrupted,
       hasLiveDone,
       hasRetainedDone,
       agentStatusPaneIdsByTabId
@@ -50,6 +51,7 @@ export function selectWorktreeActivityStatuses(
         hasPermission,
         hasLiveWorking,
         hasLiveMonitoring,
+        hasInterrupted,
         hasLiveDone,
         hasRetainedDone
       })

--- a/src/renderer/src/components/sidebar/worktree-agent-activity-summary.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-activity-summary.test.ts
@@ -17,6 +17,7 @@ function makeAgentStatusEntry(args: {
   parentPaneKey?: string
   restoredUnconfirmed?: true
   workingMode?: AgentStatusEntry['workingMode']
+  interrupted?: true
 }): AgentStatusEntry {
   return {
     paneKey: args.paneKey,
@@ -28,6 +29,7 @@ function makeAgentStatusEntry(args: {
     worktreeId: args.worktreeId,
     restoredUnconfirmed: args.restoredUnconfirmed,
     workingMode: args.workingMode,
+    interrupted: args.interrupted,
     orchestration: args.parentPaneKey
       ? {
           taskId: 'task-1',
@@ -191,6 +193,30 @@ describe('selectWorktreeAgentActivitySummary', () => {
     )
 
     expect(summary).toMatchObject({ hasLiveWorking: false, hasLiveMonitoring: true })
+  })
+
+  it('separates interrupted outcomes from clean completion', () => {
+    vi.spyOn(Date, 'now').mockReturnValue(2_000)
+    const paneKey = makePaneKey('tab-1', LEAF_ID)
+    const summary = selectWorktreeAgentActivitySummary(
+      {
+        tabsByWorktree: { 'repo::/wt-1': [makeTab('tab-1', 'repo::/wt-1')] },
+        agentStatusEpoch: 2,
+        agentStatusByPaneKey: {
+          [paneKey]: makeAgentStatusEntry({
+            paneKey,
+            state: 'done',
+            interrupted: true
+          })
+        },
+        migrationUnsupportedByPtyId: {},
+        runtimeAgentOrchestrationByPaneKey: {},
+        retainedAgentsByPaneKey: {}
+      },
+      'repo::/wt-1'
+    )
+
+    expect(summary).toMatchObject({ hasInterrupted: true, hasLiveDone: false })
   })
 
   it('lets an unconfirmed restored row suppress only its pane title', () => {

--- a/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
@@ -16,8 +16,7 @@ export type WorktreeAgentActivitySummary = {
   hasPermission: boolean
   hasLiveWorking: boolean
   hasLiveMonitoring: boolean
-  /** A fresh hook entry carrying `interrupted`. Separate from `hasLiveDone` because the flag only ever
-   *  rides on `done` — folding it in reports a cancelled turn as a clean finish (STA-5357). */
+  /** Fresh interrupted completion, kept separate from clean done outcomes. */
   hasInterrupted: boolean
   hasLiveDone: boolean
   hasRetainedDone: boolean
@@ -227,8 +226,7 @@ function applyLiveAgentState(
   if (entry.state === 'blocked' || entry.state === 'waiting') {
     summary.hasPermission = true
   } else if (entry.interrupted === true) {
-    // Why before the `done` branch: `interrupted` is clamped to `done` at parse time, so a cancelled
-    // turn would otherwise set `hasLiveDone` and render as a completed one.
+    // Interrupted is encoded as done, so it must be checked first.
     summary.hasInterrupted = true
   } else if (entry.state === 'working') {
     if (entry.workingMode === 'monitoring') {

--- a/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
+++ b/src/renderer/src/components/sidebar/worktree-agent-activity-summary.ts
@@ -16,6 +16,9 @@ export type WorktreeAgentActivitySummary = {
   hasPermission: boolean
   hasLiveWorking: boolean
   hasLiveMonitoring: boolean
+  /** A fresh hook entry carrying `interrupted`. Separate from `hasLiveDone` because the flag only ever
+   *  rides on `done` — folding it in reports a cancelled turn as a clean finish (STA-5357). */
+  hasInterrupted: boolean
   hasLiveDone: boolean
   hasRetainedDone: boolean
   agentStatusPaneIdsByTabId: Record<string, ReadonlySet<string>>
@@ -27,6 +30,7 @@ const EMPTY_SUMMARY: WorktreeAgentActivitySummary = {
   hasPermission: false,
   hasLiveWorking: false,
   hasLiveMonitoring: false,
+  hasInterrupted: false,
   hasLiveDone: false,
   hasRetainedDone: false,
   agentStatusPaneIdsByTabId: EMPTY_AGENT_STATUS_PANE_IDS_BY_TAB_ID
@@ -180,6 +184,7 @@ function summariesEqual(
     previous.hasPermission === next.hasPermission &&
     previous.hasLiveWorking === next.hasLiveWorking &&
     previous.hasLiveMonitoring === next.hasLiveMonitoring &&
+    previous.hasInterrupted === next.hasInterrupted &&
     previous.hasLiveDone === next.hasLiveDone &&
     previous.hasRetainedDone === next.hasRetainedDone &&
     agentStatusPaneIdsByTabIdEqual(
@@ -217,10 +222,14 @@ function agentStatusPaneIdsByTabIdEqual(
 
 function applyLiveAgentState(
   summary: WorktreeAgentActivitySummary,
-  entry: Pick<AgentStatusEntry, 'state' | 'workingMode'>
+  entry: Pick<AgentStatusEntry, 'state' | 'workingMode' | 'interrupted'>
 ): void {
   if (entry.state === 'blocked' || entry.state === 'waiting') {
     summary.hasPermission = true
+  } else if (entry.interrupted === true) {
+    // Why before the `done` branch: `interrupted` is clamped to `done` at parse time, so a cancelled
+    // turn would otherwise set `hasLiveDone` and render as a completed one.
+    summary.hasInterrupted = true
   } else if (entry.state === 'working') {
     if (entry.workingMode === 'monitoring') {
       summary.hasLiveMonitoring = true

--- a/src/renderer/src/components/sidebar/worktree-card-agent-summary.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-agent-summary.test.ts
@@ -55,4 +55,18 @@ describe('worktree card agent summary', () => {
       /Monitoring background tasks<\/span><span[^>]*> - Run background checks<\/span>/
     )
   })
+
+  it('lists interrupted outcomes before clean completions', () => {
+    const done = monitoringAgent()
+    done.state = 'done'
+    done.entry.state = 'done'
+    done.entry.workingMode = undefined
+    const interrupted = {
+      ...done,
+      paneKey: 'tab-1:leaf-2',
+      entry: { ...done.entry, paneKey: 'tab-1:leaf-2', interrupted: true }
+    }
+
+    expect(summarizeAgents([done, interrupted], 'Agents')).toBe('Agents: 1 interrupted, 1 done')
+  })
 })

--- a/src/renderer/src/components/sidebar/worktree-card-agent-summary.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-agent-summary.ts
@@ -8,15 +8,13 @@ export type SummaryAgentGroup = {
   agents: DashboardAgentRowData[]
 }
 
-// Why interrupted sits below done (STA-5357): Esc / Ctrl+C is a deliberate act, so the user already
-// knows — it demands the least attention of any live-ish state, matching smart-attention's Class 4.
 const SUMMARY_STATE_ORDER: AgentDotState[] = [
   'waiting',
   'blocked',
   'working',
   'monitoring',
-  'done',
   'interrupted',
+  'done',
   'idle'
 ]
 

--- a/src/renderer/src/components/sidebar/worktree-card-agent-summary.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-agent-summary.ts
@@ -8,13 +8,15 @@ export type SummaryAgentGroup = {
   agents: DashboardAgentRowData[]
 }
 
+// Why interrupted sits below done (STA-5357): Esc / Ctrl+C is a deliberate act, so the user already
+// knows — it demands the least attention of any live-ish state, matching smart-attention's Class 4.
 const SUMMARY_STATE_ORDER: AgentDotState[] = [
   'waiting',
   'blocked',
-  'interrupted',
   'working',
   'monitoring',
   'done',
+  'interrupted',
   'idle'
 ]
 

--- a/src/renderer/src/components/tab-bar/terminal-tab-activity-status.test.ts
+++ b/src/renderer/src/components/tab-bar/terminal-tab-activity-status.test.ts
@@ -110,7 +110,11 @@ describe('resolveTerminalTabActivityStatus', () => {
     ).toBe('done')
   })
 
-  it('treats an interrupted done as done, matching the worktree card', () => {
+  // Why this flipped (STA-5357): it used to assert `done`, deliberately mirroring the worktree card,
+  // which had no interrupted state. That made a cancelled turn indistinguishable from a clean finish
+  // on every glanceable surface. The card now distinguishes it, so the tab follows rather than
+  // preserving a consistency that was consistently wrong.
+  it('reports an interrupted done as interrupted, matching the worktree card', () => {
     const interrupted = entry(FIRST_LEAF_ID, 'done', { interrupted: true })
     expect(
       resolveTerminalTabActivityStatus({
@@ -118,7 +122,22 @@ describe('resolveTerminalTabActivityStatus', () => {
         agentStatusByPaneKey: { [interrupted.paneKey]: interrupted },
         ptyIdsByTabId: LIVE_PTY
       })
-    ).toBe('done')
+    ).toBe('interrupted')
+  })
+
+  it('does not let a finished sibling mask an interrupted pane', () => {
+    const interrupted = entry(FIRST_LEAF_ID, 'done', { interrupted: true })
+    const finished = entry(SECOND_LEAF_ID, 'done')
+    expect(
+      resolveTerminalTabActivityStatus({
+        tab: TAB,
+        agentStatusByPaneKey: {
+          [interrupted.paneKey]: interrupted,
+          [finished.paneKey]: finished
+        },
+        ptyIdsByTabId: LIVE_PTY
+      })
+    ).toBe('interrupted')
   })
 
   it('falls back to a live working title when hook status is stale', () => {

--- a/src/renderer/src/components/tab-bar/terminal-tab-activity-status.test.ts
+++ b/src/renderer/src/components/tab-bar/terminal-tab-activity-status.test.ts
@@ -125,7 +125,9 @@ describe('resolveTerminalTabActivityStatus', () => {
     ).toBe('interrupted')
   })
 
-  it('does not let a finished sibling mask an interrupted pane', () => {
+  it('lets a finished sibling win — interrupted is the quietest state', () => {
+    // Why: Esc / Ctrl+C is deliberate, so the user already knows. Interrupted must be
+    // DISTINGUISHABLE from done (that is the bug) without being LOUDER than anything live.
     const interrupted = entry(FIRST_LEAF_ID, 'done', { interrupted: true })
     const finished = entry(SECOND_LEAF_ID, 'done')
     expect(
@@ -137,7 +139,7 @@ describe('resolveTerminalTabActivityStatus', () => {
         },
         ptyIdsByTabId: LIVE_PTY
       })
-    ).toBe('interrupted')
+    ).toBe('done')
   })
 
   it('falls back to a live working title when hook status is stale', () => {

--- a/src/renderer/src/components/tab-bar/terminal-tab-activity-status.test.ts
+++ b/src/renderer/src/components/tab-bar/terminal-tab-activity-status.test.ts
@@ -110,10 +110,6 @@ describe('resolveTerminalTabActivityStatus', () => {
     ).toBe('done')
   })
 
-  // Why this flipped (STA-5357): it used to assert `done`, deliberately mirroring the worktree card,
-  // which had no interrupted state. That made a cancelled turn indistinguishable from a clean finish
-  // on every glanceable surface. The card now distinguishes it, so the tab follows rather than
-  // preserving a consistency that was consistently wrong.
   it('reports an interrupted done as interrupted, matching the worktree card', () => {
     const interrupted = entry(FIRST_LEAF_ID, 'done', { interrupted: true })
     expect(
@@ -125,9 +121,7 @@ describe('resolveTerminalTabActivityStatus', () => {
     ).toBe('interrupted')
   })
 
-  it('lets a finished sibling win — interrupted is the quietest state', () => {
-    // Why: Esc / Ctrl+C is deliberate, so the user already knows. Interrupted must be
-    // DISTINGUISHABLE from done (that is the bug) without being LOUDER than anything live.
+  it('does not let a finished sibling mask an interrupted outcome', () => {
     const interrupted = entry(FIRST_LEAF_ID, 'done', { interrupted: true })
     const finished = entry(SECOND_LEAF_ID, 'done')
     expect(
@@ -139,7 +133,7 @@ describe('resolveTerminalTabActivityStatus', () => {
         },
         ptyIdsByTabId: LIVE_PTY
       })
-    ).toBe('done')
+    ).toBe('interrupted')
   })
 
   it('falls back to a live working title when hook status is stale', () => {
@@ -294,6 +288,9 @@ describe('resolveTerminalTabAttentionBadge', () => {
     )
     expect(resolveTerminalTabAttentionBadge({ status: 'done', hasUnread: true })).toBe('unread')
     expect(resolveTerminalTabAttentionBadge({ status: 'done', hasUnread: false })).toBe('done')
+    expect(resolveTerminalTabAttentionBadge({ status: 'interrupted', hasUnread: false })).toBe(
+      'interrupted'
+    )
     expect(resolveTerminalTabAttentionBadge({ status: 'active', hasUnread: false })).toBeNull()
   })
 })
@@ -323,6 +320,7 @@ describe('terminalTabActivityToAgentDotState', () => {
     expect(terminalTabActivityToAgentDotState('monitoring')).toBe('monitoring')
     expect(terminalTabActivityToAgentDotState('permission')).toBe('permission')
     expect(terminalTabActivityToAgentDotState('done')).toBe('done')
+    expect(terminalTabActivityToAgentDotState('interrupted')).toBe('interrupted')
     expect(terminalTabActivityToAgentDotState('active')).toBeNull()
     expect(terminalTabActivityToAgentDotState('inactive')).toBeNull()
   })

--- a/src/renderer/src/components/tab-bar/terminal-tab-activity-status.ts
+++ b/src/renderer/src/components/tab-bar/terminal-tab-activity-status.ts
@@ -20,6 +20,7 @@ type TerminalTabActivityFlags = {
   hasPermission: boolean
   hasLiveWorking: boolean
   hasLiveMonitoring: boolean
+  hasInterrupted: boolean
   hasLiveDone: boolean
   paneIds: Set<string>
 }
@@ -81,10 +82,12 @@ function getTerminalTabActivityFlags(
       } else {
         flags.hasLiveWorking = true
       }
+    } else if (entry.interrupted === true) {
+      // Why before `done` (STA-5357): the flag is clamped to `done`, so folding it in reported a
+      // cancelled turn as a completed one. This used to mirror the WorktreeCard dot deliberately —
+      // that dot now distinguishes interrupted, so the tab follows rather than diverging.
+      flags.hasInterrupted = true
     } else if (entry.state === 'done') {
-      // Why: an interrupted `done` still reads as completed here, matching the
-      // WorktreeCard dot (resolveWorktreeStatus has no interrupted state); only
-      // the smart-sort ordering treats interrupts as idle.
       flags.hasLiveDone = true
     }
   }
@@ -103,6 +106,7 @@ function getOrCreateTerminalTabActivityFlags(
       hasPermission: false,
       hasLiveWorking: false,
       hasLiveMonitoring: false,
+      hasInterrupted: false,
       hasLiveDone: false,
       paneIds: new Set()
     }
@@ -164,6 +168,7 @@ export function resolveTerminalTabActivityStatus({
     hasPermission: flags?.hasPermission ?? false,
     hasLiveWorking: flags?.hasLiveWorking ?? false,
     hasLiveMonitoring: flags?.hasLiveMonitoring ?? false,
+    hasInterrupted: flags?.hasInterrupted ?? false,
     hasLiveDone: flags?.hasLiveDone ?? false,
     // Why: retained/orchestration promotions are worktree-aggregate concerns;
     // a tab reflects its own live panes and title only.
@@ -180,7 +185,13 @@ export function isTerminalTabActivityLive(status: TerminalTabActivityStatus): bo
  * Glyph-bearing attention states for a terminal tab (tab bar + Cmd+J recent chats).
  * Quiet active/inactive map to null so identity icons stay clean.
  */
-export type TerminalTabAttentionBadge = 'working' | 'monitoring' | 'permission' | 'unread' | 'done'
+export type TerminalTabAttentionBadge =
+  | 'working'
+  | 'monitoring'
+  | 'permission'
+  | 'interrupted'
+  | 'unread'
+  | 'done'
 
 /**
  * Single priority ladder shared by the tab strip and Cmd+J recent rows:
@@ -202,6 +213,10 @@ export function resolveTerminalTabAttentionBadge({
   if (status === 'monitoring') {
     return 'monitoring'
   }
+  // Why above unread and done: a cancelled turn needs a human, and an unread bell would bury it.
+  if (status === 'interrupted') {
+    return 'interrupted'
+  }
   if (hasUnread) {
     return 'unread'
   }
@@ -214,11 +229,12 @@ export function resolveTerminalTabAttentionBadge({
 /** Map a container activity status onto AgentStateDot's vocabulary (no unread — that's a bell). */
 export function terminalTabActivityToAgentDotState(
   status: TerminalTabActivityStatus
-): 'working' | 'monitoring' | 'permission' | 'done' | null {
+): 'working' | 'monitoring' | 'permission' | 'interrupted' | 'done' | null {
   switch (status) {
     case 'working':
     case 'monitoring':
     case 'permission':
+    case 'interrupted':
     case 'done':
       return status
     case 'active':

--- a/src/renderer/src/components/tab-bar/terminal-tab-activity-status.ts
+++ b/src/renderer/src/components/tab-bar/terminal-tab-activity-status.ts
@@ -83,9 +83,7 @@ function getTerminalTabActivityFlags(
         flags.hasLiveWorking = true
       }
     } else if (entry.interrupted === true) {
-      // Why before `done` (STA-5357): the flag is clamped to `done`, so folding it in reported a
-      // cancelled turn as a completed one. This used to mirror the WorktreeCard dot deliberately —
-      // that dot now distinguishes interrupted, so the tab follows rather than diverging.
+      // Interrupted is encoded as done, so it must be checked first.
       flags.hasInterrupted = true
     } else if (entry.state === 'done') {
       flags.hasLiveDone = true
@@ -219,8 +217,6 @@ export function resolveTerminalTabAttentionBadge({
   if (status === 'done') {
     return 'done'
   }
-  // Why last (STA-5357): the user pressed Esc / Ctrl+C, so this is the least attention-demanding
-  // signal — it must be distinguishable from `done`, but it must not outrank anything live.
   if (status === 'interrupted') {
     return 'interrupted'
   }

--- a/src/renderer/src/components/tab-bar/terminal-tab-activity-status.ts
+++ b/src/renderer/src/components/tab-bar/terminal-tab-activity-status.ts
@@ -213,15 +213,16 @@ export function resolveTerminalTabAttentionBadge({
   if (status === 'monitoring') {
     return 'monitoring'
   }
-  // Why above unread and done: a cancelled turn needs a human, and an unread bell would bury it.
-  if (status === 'interrupted') {
-    return 'interrupted'
-  }
   if (hasUnread) {
     return 'unread'
   }
   if (status === 'done') {
     return 'done'
+  }
+  // Why last (STA-5357): the user pressed Esc / Ctrl+C, so this is the least attention-demanding
+  // signal — it must be distinguishable from `done`, but it must not outrank anything live.
+  if (status === 'interrupted') {
+    return 'interrupted'
   }
   return null
 }

--- a/src/renderer/src/components/worktree-jump-palette-test-fixtures.ts
+++ b/src/renderer/src/components/worktree-jump-palette-test-fixtures.ts
@@ -93,7 +93,8 @@ export const LEAF_ID = '11111111-2222-4333-8444-555555555555'
 export function makeAgentEntry(
   tabId: string,
   state: AgentStatusState,
-  stateStartedAt: number
+  stateStartedAt: number,
+  overrides: Partial<AgentStatusEntry> = {}
 ): AgentStatusEntry {
   return {
     state,
@@ -101,7 +102,8 @@ export function makeAgentEntry(
     updatedAt: stateStartedAt,
     stateStartedAt,
     paneKey: makePaneKey(tabId, LEAF_ID),
-    stateHistory: []
+    stateHistory: [],
+    ...overrides
   }
 }
 

--- a/src/renderer/src/lib/recent-workspace-tab-rows.test.ts
+++ b/src/renderer/src/lib/recent-workspace-tab-rows.test.ts
@@ -312,6 +312,27 @@ describe('orderRecentWorkspaceTabs', () => {
 })
 
 describe('resolveRecentWorkspaceTabStatus', () => {
+  it('surfaces an interrupted outcome without promoting its sort class', () => {
+    const interrupted = entry('interrupted', 'done', NOW - 1_000, { interrupted: true })
+
+    expect(resolveRecentWorkspaceTabStatus(row('interrupted'), sources([interrupted]), NOW)).toBe(
+      'interrupted'
+    )
+  })
+
+  it('does not let a cleanly finished sibling mask an interruption', () => {
+    const interrupted = entry('mixed', 'done', NOW - 1_000, {
+      paneKey: `mixed:${LEAF_ID}`,
+      interrupted: true
+    })
+    const finished = entry('mixed', 'done', NOW - 2_000, {
+      paneKey: 'mixed:22222222-2222-4222-8222-222222222222'
+    })
+
+    expect(
+      resolveRecentWorkspaceTabStatus(row('mixed'), sources([interrupted, finished]), NOW)
+    ).toBe('interrupted')
+  })
   it('maps attention classes onto the sidebar dot vocabulary', () => {
     const blocked = row('blocked')
     const done = row('done')

--- a/src/renderer/src/lib/recent-workspace-tab-rows.ts
+++ b/src/renderer/src/lib/recent-workspace-tab-rows.ts
@@ -7,10 +7,12 @@ import {
   type WorktreeAttention
 } from '@/components/sidebar/smart-attention'
 import { tabHasLivePty } from './tab-has-live-pty'
+import { isExplicitAgentStatusFresh } from './pane-agent-evidence'
 import type { WorktreeStatus } from './worktree-status'
 import type { TabGroup } from '../../../shared/tab-types'
 import type { TerminalTab } from '../../../shared/terminal-tab-types'
 import type { ExecutionHostId } from '../../../shared/execution-host'
+import { AGENT_STATUS_STALE_AFTER_MS } from '../../../shared/agent-status-types'
 import { getWorktreeVisitTimestamp } from './worktree-visit-recency'
 import { composeWorktreeHostIdentity } from '../../../shared/worktree/host-qualified-identity'
 
@@ -105,7 +107,19 @@ export function resolveRecentWorkspaceTabStatus(
     )
     return hasForegroundWork ? 'working' : 'monitoring'
   }
-  if (explicit) {
+  if (explicit === 'permission') {
+    return explicit
+  }
+  const hasInterrupted = panes.some(
+    (pane) =>
+      pane.kind === 'hook' &&
+      pane.entry.interrupted === true &&
+      isExplicitAgentStatusFresh(pane.entry, now, AGENT_STATUS_STALE_AFTER_MS)
+  )
+  if (hasInterrupted) {
+    return 'interrupted'
+  }
+  if (explicit === 'done') {
     return explicit
   }
   return tabHasLivePty(paneSources.ptyIdsByTabId, row.terminalTab.id) ? 'active' : 'inactive'

--- a/src/renderer/src/lib/worktree-status.interrupted.test.ts
+++ b/src/renderer/src/lib/worktree-status.interrupted.test.ts
@@ -16,23 +16,21 @@ const base = {
 
 describe('resolveWorktreeStatus — interrupted (STA-5357)', () => {
   it('reports interrupted rather than done for an interrupted agent', () => {
-    // Why `hasLiveDone` is also set: `interrupted` only ever coexists with `done`
-    // (agent-status-types.ts clamps it), so the done flag is always present too.
-    // Before the fix that made the card indistinguishable from a clean finish.
-    expect(resolveWorktreeStatus({ ...base, hasInterrupted: true, hasLiveDone: true })).toBe(
-      'interrupted'
-    )
+    // The bug: `interrupted` is clamped onto `done` at parse time, so the summary swallowed it into
+    // hasLiveDone and the card rendered a cancelled turn as a clean finish.
+    expect(resolveWorktreeStatus({ ...base, hasInterrupted: true })).toBe('interrupted')
   })
 
-  it('keeps interrupted visible when a sibling agent merely finished', () => {
-    expect(resolveWorktreeStatus({ ...base, hasInterrupted: true, hasLiveDone: true })).not.toBe(
-      'done'
-    )
+  it('is never the emerald done state on its own', () => {
+    expect(resolveWorktreeStatus({ ...base, hasInterrupted: true })).not.toBe('done')
   })
 
-  it('outranks working, so a cancelled turn is not hidden by a busy sibling', () => {
+  // Why interrupted YIELDS to everything else: Esc / Ctrl+C is a deliberate act, so the user already
+  // knows. It is the least attention-demanding state — smart-attention already classes it 4 (idle),
+  // below both done and working. Distinguishable from done, never louder than a live agent.
+  it('yields to a working sibling — the live agent is the louder signal', () => {
     expect(resolveWorktreeStatus({ ...base, hasInterrupted: true, hasLiveWorking: true })).toBe(
-      'interrupted'
+      'working'
     )
   })
 
@@ -42,10 +40,14 @@ describe('resolveWorktreeStatus — interrupted (STA-5357)', () => {
     )
   })
 
-  it('outranks monitoring', () => {
+  it('yields to monitoring — background work is still live', () => {
     expect(resolveWorktreeStatus({ ...base, hasInterrupted: true, hasLiveMonitoring: true })).toBe(
-      'interrupted'
+      'monitoring'
     )
+  })
+
+  it('yields to a sibling that genuinely finished', () => {
+    expect(resolveWorktreeStatus({ ...base, hasInterrupted: true, hasLiveDone: true })).toBe('done')
   })
 
   it('leaves every other combination alone', () => {

--- a/src/renderer/src/lib/worktree-status.interrupted.test.ts
+++ b/src/renderer/src/lib/worktree-status.interrupted.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { resolveWorktreeStatus } from './worktree-status'
 
-// Why these live apart from the main suite: they pin the ONE rule STA-5357 adds —
-// an interrupted agent is not a completed one, and it must not be masked by a
-// sibling that merely finished.
 const base = {
   tabs: [] as never[],
   browserTabs: [] as never[],
@@ -16,8 +13,6 @@ const base = {
 
 describe('resolveWorktreeStatus — interrupted (STA-5357)', () => {
   it('reports interrupted rather than done for an interrupted agent', () => {
-    // The bug: `interrupted` is clamped onto `done` at parse time, so the summary swallowed it into
-    // hasLiveDone and the card rendered a cancelled turn as a clean finish.
     expect(resolveWorktreeStatus({ ...base, hasInterrupted: true })).toBe('interrupted')
   })
 
@@ -25,9 +20,6 @@ describe('resolveWorktreeStatus — interrupted (STA-5357)', () => {
     expect(resolveWorktreeStatus({ ...base, hasInterrupted: true })).not.toBe('done')
   })
 
-  // Why interrupted YIELDS to everything else: Esc / Ctrl+C is a deliberate act, so the user already
-  // knows. It is the least attention-demanding state — smart-attention already classes it 4 (idle),
-  // below both done and working. Distinguishable from done, never louder than a live agent.
   it('yields to a working sibling — the live agent is the louder signal', () => {
     expect(resolveWorktreeStatus({ ...base, hasInterrupted: true, hasLiveWorking: true })).toBe(
       'working'
@@ -46,8 +38,10 @@ describe('resolveWorktreeStatus — interrupted (STA-5357)', () => {
     )
   })
 
-  it('yields to a sibling that genuinely finished', () => {
-    expect(resolveWorktreeStatus({ ...base, hasInterrupted: true, hasLiveDone: true })).toBe('done')
+  it('outranks a cleanly finished sibling', () => {
+    expect(resolveWorktreeStatus({ ...base, hasInterrupted: true, hasLiveDone: true })).toBe(
+      'interrupted'
+    )
   })
 
   it('leaves every other combination alone', () => {

--- a/src/renderer/src/lib/worktree-status.interrupted.test.ts
+++ b/src/renderer/src/lib/worktree-status.interrupted.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { resolveWorktreeStatus } from './worktree-status'
+
+// Why these live apart from the main suite: they pin the ONE rule STA-5357 adds —
+// an interrupted agent is not a completed one, and it must not be masked by a
+// sibling that merely finished.
+const base = {
+  tabs: [] as never[],
+  browserTabs: [] as never[],
+  ptyIdsByTabId: {},
+  hasPermission: false,
+  hasLiveWorking: false,
+  hasLiveDone: false,
+  hasRetainedDone: false
+}
+
+describe('resolveWorktreeStatus — interrupted (STA-5357)', () => {
+  it('reports interrupted rather than done for an interrupted agent', () => {
+    // Why `hasLiveDone` is also set: `interrupted` only ever coexists with `done`
+    // (agent-status-types.ts clamps it), so the done flag is always present too.
+    // Before the fix that made the card indistinguishable from a clean finish.
+    expect(resolveWorktreeStatus({ ...base, hasInterrupted: true, hasLiveDone: true })).toBe(
+      'interrupted'
+    )
+  })
+
+  it('keeps interrupted visible when a sibling agent merely finished', () => {
+    expect(resolveWorktreeStatus({ ...base, hasInterrupted: true, hasLiveDone: true })).not.toBe(
+      'done'
+    )
+  })
+
+  it('outranks working, so a cancelled turn is not hidden by a busy sibling', () => {
+    expect(resolveWorktreeStatus({ ...base, hasInterrupted: true, hasLiveWorking: true })).toBe(
+      'interrupted'
+    )
+  })
+
+  it('yields to permission — a prompt waiting on the user is more urgent', () => {
+    expect(resolveWorktreeStatus({ ...base, hasInterrupted: true, hasPermission: true })).toBe(
+      'permission'
+    )
+  })
+
+  it('outranks monitoring', () => {
+    expect(resolveWorktreeStatus({ ...base, hasInterrupted: true, hasLiveMonitoring: true })).toBe(
+      'interrupted'
+    )
+  })
+
+  it('leaves every other combination alone', () => {
+    expect(resolveWorktreeStatus({ ...base, hasLiveDone: true })).toBe('done')
+    expect(resolveWorktreeStatus({ ...base, hasLiveWorking: true })).toBe('working')
+    expect(resolveWorktreeStatus({ ...base, hasLiveMonitoring: true })).toBe('monitoring')
+    expect(resolveWorktreeStatus({ ...base, hasPermission: true })).toBe('permission')
+  })
+})

--- a/src/renderer/src/lib/worktree-status.ts
+++ b/src/renderer/src/lib/worktree-status.ts
@@ -126,8 +126,7 @@ export function getWorktreeStatusLabel(status: WorktreeStatus): string {
 }
 
 /**
- * Apply the WorktreeCard priority overlay (permission > working > done >
- * heuristic) on top of the title-heuristic base. Explicit agent rows may
+ * Apply the WorktreeCard priority overlay on top of the title-heuristic base. Explicit agent rows may
  * promote the dot; sleep cleanup owns removing stale retained rows.
  *
  * Map args are narrowed to this worktree. `hasPermission`/`hasLiveWorking`/
@@ -174,16 +173,12 @@ export function resolveWorktreeStatus(args: {
   if (args.hasLiveMonitoring || heuristic === 'monitoring') {
     return 'monitoring'
   }
-  if (args.hasLiveDone || args.hasRetainedDone) {
-    return 'done'
-  }
-  // Why LAST (STA-5357): `interrupted` means the user pressed Esc or Ctrl+C, so they already know —
-  // it is the least attention-demanding state, exactly as smart-attention classes it (Class 4, idle,
-  // below both done and working). It still needs its own branch rather than folding into `done`,
-  // because the flag rides on `done` and rendering it as a completion is the bug this fixes: a
-  // cancelled turn is not a finished one.
+  // Terminal outcomes follow live states, but an interrupted outcome must not collapse into success.
   if (args.hasInterrupted) {
     return 'interrupted'
+  }
+  if (args.hasLiveDone || args.hasRetainedDone) {
+    return 'done'
   }
   return heuristic
 }

--- a/src/renderer/src/lib/worktree-status.ts
+++ b/src/renderer/src/lib/worktree-status.ts
@@ -167,13 +167,6 @@ export function resolveWorktreeStatus(args: {
   if (heuristic === 'permission') {
     return 'permission'
   }
-  // Why above working (STA-5357): `interrupted` only ever rides on `done`, so before this it set
-  // `hasLiveDone` and the card rendered a cancelled turn as a clean finish — and a busy sibling could
-  // hide it entirely. It sits below permission because a prompt waiting on the user is the more urgent
-  // ask, and matches SUMMARY_STATE_ORDER so the card and the expanded agent list agree.
-  if (args.hasInterrupted) {
-    return 'interrupted'
-  }
   // Why: restored cards get the hook snapshot before panes mount; trust the explicit working row so they stay yellow on restart.
   if (args.hasLiveWorking || heuristic === 'working') {
     return 'working'
@@ -183,6 +176,14 @@ export function resolveWorktreeStatus(args: {
   }
   if (args.hasLiveDone || args.hasRetainedDone) {
     return 'done'
+  }
+  // Why LAST (STA-5357): `interrupted` means the user pressed Esc or Ctrl+C, so they already know —
+  // it is the least attention-demanding state, exactly as smart-attention classes it (Class 4, idle,
+  // below both done and working). It still needs its own branch rather than folding into `done`,
+  // because the flag rides on `done` and rendering it as a completion is the bug this fixes: a
+  // cancelled turn is not a finished one.
+  if (args.hasInterrupted) {
+    return 'interrupted'
   }
   return heuristic
 }

--- a/src/renderer/src/lib/worktree-status.ts
+++ b/src/renderer/src/lib/worktree-status.ts
@@ -16,6 +16,7 @@ export type WorktreeStatus =
   | 'working'
   | 'monitoring'
   | 'permission'
+  | 'interrupted'
   | 'done'
   | 'inactive'
 
@@ -31,6 +32,7 @@ const STATUS_LABELS: Record<WorktreeStatus, string> = {
   working: 'Working',
   monitoring: 'Monitoring background tasks',
   permission: 'Needs permission',
+  interrupted: 'Interrupted',
   done: 'Done',
   inactive: 'Inactive'
 }
@@ -143,6 +145,7 @@ export function resolveWorktreeStatus(args: {
   hasPermission: boolean
   hasLiveWorking: boolean
   hasLiveMonitoring?: boolean
+  hasInterrupted?: boolean
   hasLiveDone: boolean
   hasRetainedDone: boolean
 }): WorktreeStatus {
@@ -163,6 +166,13 @@ export function resolveWorktreeStatus(args: {
   // Why: heuristic 'permission' outranks heuristic 'working' — the user-actionable signal wins when panes in one tab disagree.
   if (heuristic === 'permission') {
     return 'permission'
+  }
+  // Why above working (STA-5357): `interrupted` only ever rides on `done`, so before this it set
+  // `hasLiveDone` and the card rendered a cancelled turn as a clean finish — and a busy sibling could
+  // hide it entirely. It sits below permission because a prompt waiting on the user is the more urgent
+  // ask, and matches SUMMARY_STATE_ORDER so the card and the expanded agent list agree.
+  if (args.hasInterrupted) {
+    return 'interrupted'
   }
   // Why: restored cards get the hook snapshot before panes mount; trust the explicit working row so they stay yellow on restart.
   if (args.hasLiveWorking || heuristic === 'working') {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​146 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​142 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​72 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​59 |

<!-- /orca-pr-loc -->

## ELI5

When you interrupt an agent, or one dies mid-turn, the worktree card and the tab glyph showed the same thing as a clean finish: **done**. This makes an interrupted turn look interrupted.

## The bug

`interrupted` is a **flag clamped onto `done`**, never its own state (`agent-status-types.ts`):

```ts
interrupted: obj.interrupted === true && state === 'done' ? true : undefined,
```

The worktree activity summary never received it — its parameter was `Pick<AgentStatusEntry, 'state' | 'workingMode'>` — so an interrupted agent fell into the `done` branch, set `hasLiveDone`, and `resolveWorktreeStatus` returned `'done'`. `WorktreeStatus` had no `interrupted` member, so the card could not have expressed it anyway.

Two consequences:

- An interrupted agent was **indistinguishable from a completed one** on every glanceable surface.
- With several agents it contributed **no signal at all**, so a sibling that merely finished could mask it entirely.

The expanded agent list got it right the whole time (`getAgentDotState` checks the flag first), and `SUMMARY_STATE_ORDER` already ranked `interrupted` above `working` for the text summary. Only the card and tab never got the same treatment.

## What changed

The flag is threaded end to end — activity summary, both activity hooks, the resolver, the card glyph, and the tab badge — and slotted below live/actionable states while remaining distinct from clean completion:

```
permission → working → monitoring → interrupted → done
```

A clean completion sibling no longer masks an interrupted outcome, while live work and permission prompts remain more urgent. Smart-sort keeps interrupted rows quiet for ordering (its existing idle/Class 4 behavior), which is separate from the card/tab display precedence.

The card renders a red dot, matching the agent row's own interrupted treatment (`AgentStateDot` uses `bg-red-500`) rather than the emerald done check.

Also updated `hasInterrupted` in the summary's equality check — a new flag missed there would leave the card stale instead of re-rendering.

## A test that asserted the bug

`terminal-tab-activity-status.test.ts` contained:

```ts
it('treats an interrupted done as done, matching the worktree card', ...)
```

and the production code carried a matching comment saying an interrupted `done` "still reads as completed here, matching the WorktreeCard dot". The behaviour was known and deliberately mirrored for consistency. That premise is gone now the card distinguishes it, so the test is **flipped rather than deleted**, with the reason recorded inline. A second case pins that a finished sibling cannot mask an interrupted pane.

## Testing

- [x] Automated tests added/updated

Added focused coverage for the worktree summary/resolver, tab badge, compact/card glyph, and Cmd+J recent-tab resolver, including mixed-pane precedence and normal `done` behavior. **Red before the fix** (`expected 'done' to be 'interrupted'`), green after.

**Mutation-tested:** disabling the precedence branch turns 4 of those red, so the guard is load-bearing rather than incidental.

No regressions: **138 focused tests** across the affected renderer status, sidebar, tab-bar, and recent-tab suites; web typecheck, default/native/type-aware oxlint, formatting, max-lines, and diff checks are clean.

## Scope

Renderer only. `RuntimeWorktreeStatus` (`shared/runtime-types.ts`) is a **separate** vocabulary — `'active' | 'working' | 'permission' | 'done' | 'inactive'` — and carries neither `monitoring` nor `interrupted`, so nothing here crosses a version boundary and no capability negotiation is needed.

That does mean the same mislabelling still exists on the runtime surface that mobile and `orca worktree ps` read. Deliberately not fixed here: it is a wire-visible enum change and belongs in its own change with its own back-compat analysis.

## Linked Issue

Fixes STA-5357

