### PR TITLE
fix(crash-reporting): scope renderer crash evidence

### DIFF
--- a/src/main/crash-reporting/crash-breadcrumb-renderer-attribution.test.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-renderer-attribution.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  clearCrashBreadcrumbsForTest,
+  getCrashBreadcrumbSnapshot,
+  recordCoalescedCrashBreadcrumb,
+  recordCrashBreadcrumb
+} from './crash-breadcrumb-store'
+
+describe('renderer crash breadcrumb attribution', () => {
+  beforeEach(() => {
+    clearCrashBreadcrumbsForTest()
+  })
+
+  it('filters a renderer report to its own breadcrumbs while retaining global evidence', () => {
+    recordCrashBreadcrumb('app_started', { packaged: true })
+    recordCrashBreadcrumb('renderer_a_event', undefined, 'renderer:11')
+    recordCrashBreadcrumb('renderer_b_event', undefined, 'renderer:22')
+
+    expect(getCrashBreadcrumbSnapshot('renderer:11').map((entry) => entry.name)).toEqual([
+      'app_started',
+      'renderer_a_event'
+    ])
+    expect(getCrashBreadcrumbSnapshot('renderer:22').map((entry) => entry.name)).toEqual([
+      'app_started',
+      'renderer_b_event'
+    ])
+    expect(getCrashBreadcrumbSnapshot().map((entry) => entry.name)).toEqual([
+      'app_started',
+      'renderer_a_event',
+      'renderer_b_event'
+    ])
+  })
+
+  it('does not merge identical coalesced storms from sibling renderers', () => {
+    recordCoalescedCrashBreadcrumb({
+      name: 'renderer_error',
+      data: { message: 'boom' },
+      coalesceKey: 'renderer:11\u0000renderer_error:boom',
+      minIntervalMs: 30_000,
+      origin: 'renderer:11'
+    })
+    recordCoalescedCrashBreadcrumb({
+      name: 'renderer_error',
+      data: { message: 'boom' },
+      coalesceKey: 'renderer:22\u0000renderer_error:boom',
+      minIntervalMs: 30_000,
+      origin: 'renderer:22'
+    })
+
+    expect(getCrashBreadcrumbSnapshot('renderer:11')).toHaveLength(1)
+    expect(getCrashBreadcrumbSnapshot('renderer:22')).toHaveLength(1)
+    expect(getCrashBreadcrumbSnapshot('renderer:11')[0]?.origin).toBe('renderer:11')
+    expect(getCrashBreadcrumbSnapshot('renderer:22')[0]?.origin).toBe('renderer:22')
+  })
+
+  it('retains identical high-water profiles independently per renderer', () => {
+    const profile = { rendererSurface: 'main', thresholdPct: 80, usedHeapMB: 512 }
+    recordCrashBreadcrumb('renderer_memory_highwater', profile, 'renderer:11')
+    recordCrashBreadcrumb('renderer_memory_highwater', profile, 'renderer:22')
+
+    expect(getCrashBreadcrumbSnapshot('renderer:11')[0]?.origin).toBe('renderer:11')
+    expect(getCrashBreadcrumbSnapshot('renderer:22')[0]?.origin).toBe('renderer:22')
+  })
+
+  it('preserves the reporter trail when sibling renderer traffic fills the ring', () => {
+    for (let index = 0; index < 4; index += 1) {
+      recordCrashBreadcrumb('renderer_memory_highwater', {
+        rendererSurface: `surface-${index}`,
+        thresholdPct: 80
+      })
+    }
+    recordCrashBreadcrumb('renderer_a_event', undefined, 'renderer:11')
+    for (let index = 0; index < 26; index += 1) {
+      recordCrashBreadcrumb(`renderer_b_event_${index}`, undefined, 'renderer:22')
+    }
+
+    expect(getCrashBreadcrumbSnapshot('renderer:11').map((entry) => entry.name)).toContain(
+      'renderer_a_event'
+    )
+  })
+})

--- a/src/main/crash-reporting/crash-breadcrumb-renderer-attribution.test.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-renderer-attribution.test.ts
@@ -79,4 +79,56 @@ describe('renderer crash breadcrumb attribution', () => {
       'renderer_a_event'
     )
   })
+
+  it('folds pending repeats using the reporter-specific evidence window', () => {
+    recordCoalescedCrashBreadcrumb({
+      name: 'renderer_error',
+      data: { message: 'boom' },
+      coalesceKey: 'renderer:11\u0000renderer_error:boom',
+      minIntervalMs: 30_000,
+      origin: 'renderer:11'
+    })
+    recordCoalescedCrashBreadcrumb({
+      name: 'renderer_error',
+      data: { message: 'boom' },
+      coalesceKey: 'renderer:22\u0000renderer_error:boom',
+      minIntervalMs: 30_000,
+      origin: 'renderer:22'
+    })
+    recordCoalescedCrashBreadcrumb({
+      name: 'renderer_error',
+      data: { message: 'boom' },
+      coalesceKey: 'renderer:22\u0000renderer_error:boom',
+      minIntervalMs: 30_000,
+      origin: 'renderer:22'
+    })
+    recordCoalescedCrashBreadcrumb({
+      name: 'renderer_error',
+      data: { message: 'boom' },
+      coalesceKey: 'renderer:11\u0000renderer_error:boom',
+      minIntervalMs: 30_000,
+      origin: 'renderer:11'
+    })
+    for (let index = 0; index < 4; index += 1) {
+      recordCrashBreadcrumb(
+        'renderer_memory_highwater',
+        { rendererSurface: `surface-${index}`, thresholdPct: 80 },
+        'renderer:22'
+      )
+    }
+    for (let index = 0; index < 25; index += 1) {
+      recordCrashBreadcrumb(`renderer_b_event_${index}`, undefined, 'renderer:22')
+    }
+
+    const snapshot = getCrashBreadcrumbSnapshot('renderer:11')
+
+    expect(snapshot).toHaveLength(1)
+    expect(snapshot[0]?.data).toEqual({ message: 'boom', suppressedSinceLast: 1 })
+
+    const siblingSnapshot = getCrashBreadcrumbSnapshot('renderer:22')
+    expect(siblingSnapshot.find((entry) => entry.name === 'renderer_error')?.data).toEqual({
+      message: 'boom',
+      suppressedSinceLast: 1
+    })
+  })
 })

--- a/src/main/crash-reporting/crash-breadcrumb-store.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.ts
@@ -164,22 +164,29 @@ export function recordCoalescedCrashBreadcrumb({
 /** Whether any future snapshot can still include this crumb. The ring only
  *  appends and the retained map only grows toward its cap, so an entry pushed
  *  past the snapshot budget is invisible forever, not just for now. */
-function isCoalescedCrumbStillInEvidence(crumb: CrashReportBreadcrumb): boolean {
-  const visibleFrom = breadcrumbs.length - (MAX_BREADCRUMBS - retainedBreadcrumbs.size)
-  const index = breadcrumbs.indexOf(crumb)
-  if (index !== -1 && index >= visibleFrom) {
+function isCoalescedCrumbStillInEvidence(
+  crumb: CrashReportBreadcrumb,
+  reporterOrigin?: string
+): boolean {
+  const retained = [...retainedBreadcrumbs.values()].filter((breadcrumb) =>
+    isVisibleToReporter(breadcrumb, reporterOrigin)
+  )
+  if (retained.some((retainedBreadcrumb) => retainedBreadcrumb === crumb)) {
     return true
   }
-  for (const retained of retainedBreadcrumbs.values()) {
-    if (retained === crumb) {
-      return true
-    }
-  }
-  return false
+  const visibleRecent = breadcrumbs.filter((breadcrumb) =>
+    isVisibleToReporter(breadcrumb, reporterOrigin)
+  )
+  return visibleRecent
+    .slice(-(MAX_BREADCRUMBS - retained.length))
+    .some((recentBreadcrumb) => recentBreadcrumb === crumb)
 }
 
 /** Fold a key's newest suppressed payload into the ring entry it owns. */
-function resolvePendingCoalescedBreadcrumb(state: CoalescedBreadcrumbState): void {
+function resolvePendingCoalescedBreadcrumb(
+  state: CoalescedBreadcrumbState,
+  reporterOrigin?: string
+): void {
   // `data` is optional, so the count—not pending payload presence—marks unresolved work.
   if (!state.emitted || state.suppressed <= state.resolved) {
     return
@@ -189,7 +196,7 @@ function resolvePendingCoalescedBreadcrumb(state: CoalescedBreadcrumbState): voi
   // then claim nothing — the burst vanishes from the record entirely. Drop the
   // handle (keeping `resolved` for folds that landed while it was live) so a
   // later emit or bounded cleanup can materialize the unclaimed repeats.
-  if (!isCoalescedCrumbStillInEvidence(state.emitted)) {
+  if (!isCoalescedCrumbStillInEvidence(state.emitted, reporterOrigin)) {
     state.emitted = undefined
     return
   }
@@ -208,7 +215,7 @@ function resolvePendingCoalescedBreadcrumb(state: CoalescedBreadcrumbState): voi
 /** Resolve into the owned crumb, or emit the unclaimed repeats before bounded
  *  cleanup drops an orphan's last accounting state. */
 function preservePendingCoalescedBreadcrumb(state: CoalescedBreadcrumbState): void {
-  resolvePendingCoalescedBreadcrumb(state)
+  resolvePendingCoalescedBreadcrumb(state, state.origin)
   const unresolved = state.suppressed - state.resolved
   if (state.emitted || unresolved <= 0) {
     return
@@ -222,9 +229,12 @@ function preservePendingCoalescedBreadcrumb(state: CoalescedBreadcrumbState): vo
   state.pending = undefined
 }
 
-function resolveAllPendingCoalescedBreadcrumbs(): void {
+function resolveAllPendingCoalescedBreadcrumbs(reporterOrigin?: string): void {
   for (const state of coalescedBreadcrumbs.values()) {
-    resolvePendingCoalescedBreadcrumb(state)
+    if (reporterOrigin && state.origin && state.origin !== reporterOrigin) {
+      continue
+    }
+    resolvePendingCoalescedBreadcrumb(state, reporterOrigin)
   }
 }
 
@@ -236,7 +246,7 @@ function isVisibleToReporter(
 }
 
 export function getCrashBreadcrumbSnapshot(reporterOrigin?: string): CrashReportBreadcrumb[] {
-  resolveAllPendingCoalescedBreadcrumbs()
+  resolveAllPendingCoalescedBreadcrumbs(reporterOrigin)
   // Why: long sessions must retain threshold profiles without growing the 30-entry budget.
   const retained = [...retainedBreadcrumbs.values()].filter((breadcrumb) =>
     isVisibleToReporter(breadcrumb, reporterOrigin)

--- a/src/main/crash-reporting/crash-breadcrumb-store.ts
+++ b/src/main/crash-reporting/crash-breadcrumb-store.ts
@@ -30,6 +30,7 @@ type CoalescedBreadcrumbState = {
   emitted?: CrashReportBreadcrumb
   /** Newest suppressed payload, sanitized only if a snapshot actually asks for it. */
   pending?: CrashReportBreadcrumbData
+  origin?: string
 }
 
 let breadcrumbs: CrashReportBreadcrumb[] = []
@@ -42,19 +43,21 @@ function retainedBreadcrumbKey(breadcrumb: CrashReportBreadcrumb): string | null
   }
   const surface = breadcrumb.data?.rendererSurface
   const threshold = breadcrumb.data?.thresholdPct
-  return `${breadcrumb.name}:${String(surface)}:${String(threshold)}`
+  return `${breadcrumb.name}:${String(surface)}:${String(threshold)}:${breadcrumb.origin ?? 'global'}`
 }
 
 /** Returns the stored breadcrumb so coalescing can refresh the entry it owns. */
 export function recordCrashBreadcrumb(
   name: string,
-  data?: CrashReportBreadcrumbData
+  data?: CrashReportBreadcrumbData,
+  origin?: string
 ): CrashReportBreadcrumb | undefined {
   const sanitized = sanitizeCrashReportBreadcrumbs([
     {
       createdAt: new Date().toISOString(),
       name,
-      data
+      data,
+      ...(origin ? { origin } : {})
     }
   ])
   const breadcrumb = sanitized?.[0]
@@ -85,12 +88,14 @@ export function recordCoalescedCrashBreadcrumb({
   name,
   data,
   coalesceKey,
-  minIntervalMs
+  minIntervalMs,
+  origin
 }: {
   name: string
   data?: CrashReportBreadcrumbData
   coalesceKey: string
   minIntervalMs: number
+  origin?: string
 }): { suppressedSinceLast: number } | undefined {
   const now = monotonicNow()
   const previous = coalescedBreadcrumbs.get(coalesceKey)
@@ -136,7 +141,8 @@ export function recordCoalescedCrashBreadcrumb({
     windowStartedAtMs: now,
     suppressed: 0,
     carried: suppressedSinceLast,
-    resolved: 0
+    resolved: 0,
+    ...(origin ? { origin } : {})
   }
   coalescedBreadcrumbs.set(coalesceKey, state)
   while (coalescedBreadcrumbs.size > MAX_COALESCE_KEYS) {
@@ -149,7 +155,8 @@ export function recordCoalescedCrashBreadcrumb({
   }
   state.emitted = recordCrashBreadcrumb(
     name,
-    suppressedSinceLast > 0 ? { ...data, suppressedSinceLast } : data
+    suppressedSinceLast > 0 ? { ...data, suppressedSinceLast } : data,
+    origin
   )
   return { suppressedSinceLast }
 }
@@ -206,10 +213,11 @@ function preservePendingCoalescedBreadcrumb(state: CoalescedBreadcrumbState): vo
   if (state.emitted || unresolved <= 0) {
     return
   }
-  recordCrashBreadcrumb(state.name, {
-    ...state.pending,
-    suppressedSinceLast: unresolved
-  })
+  recordCrashBreadcrumb(
+    state.name,
+    { ...state.pending, suppressedSinceLast: unresolved },
+    state.origin
+  )
   state.resolved = state.suppressed
   state.pending = undefined
 }
@@ -220,11 +228,23 @@ function resolveAllPendingCoalescedBreadcrumbs(): void {
   }
 }
 
-export function getCrashBreadcrumbSnapshot(): CrashReportBreadcrumb[] {
+function isVisibleToReporter(
+  breadcrumb: CrashReportBreadcrumb,
+  reporterOrigin: string | undefined
+): boolean {
+  return !reporterOrigin || !breadcrumb.origin || breadcrumb.origin === reporterOrigin
+}
+
+export function getCrashBreadcrumbSnapshot(reporterOrigin?: string): CrashReportBreadcrumb[] {
   resolveAllPendingCoalescedBreadcrumbs()
   // Why: long sessions must retain threshold profiles without growing the 30-entry budget.
-  const retained = [...retainedBreadcrumbs.values()]
-  const recent = breadcrumbs.slice(-(MAX_BREADCRUMBS - retained.length))
+  const retained = [...retainedBreadcrumbs.values()].filter((breadcrumb) =>
+    isVisibleToReporter(breadcrumb, reporterOrigin)
+  )
+  const visibleRecent = breadcrumbs.filter((breadcrumb) =>
+    isVisibleToReporter(breadcrumb, reporterOrigin)
+  )
+  const recent = visibleRecent.slice(-(MAX_BREADCRUMBS - retained.length))
   return [...retained, ...recent]
     .sort((left, right) => left.createdAt.localeCompare(right.createdAt))
     .map((breadcrumb) => ({

--- a/src/main/crash-reporting/crash-report-store.test.ts
+++ b/src/main/crash-reporting/crash-report-store.test.ts
@@ -41,7 +41,8 @@ function input(reason = 'crashed'): CrashReportCreateInput {
       {
         createdAt: '2026-05-16T01:00:00.000Z',
         name: 'workspace_opened',
-        data: { path: '/Users/alice/project', ssh: false }
+        data: { path: '/Users/alice/project', ssh: false },
+        origin: 'renderer:42'
       }
     ]
   }

--- a/src/main/crash-reporting/crash-report-store.ts
+++ b/src/main/crash-reporting/crash-report-store.ts
@@ -96,7 +96,9 @@ export class CrashReportStore {
         createdAt: new Date().toISOString(),
         status: 'pending',
         details: sanitizeCrashReportDetails(input.details),
-        breadcrumbs: sanitizeCrashReportBreadcrumbs(input.breadcrumbs)
+        breadcrumbs: sanitizeCrashReportBreadcrumbs(input.breadcrumbs)?.map(
+          ({ origin: _origin, ...breadcrumb }) => breadcrumb
+        )
       }
       return {
         reports: [report, ...reports].slice(0, MAX_REPORTS),

--- a/src/main/crash-reporting/durable-crash-breadcrumb.ts
+++ b/src/main/crash-reporting/durable-crash-breadcrumb.ts
@@ -41,11 +41,12 @@ function traceDurableBreadcrumb(
 export function recordDurableCrashBreadcrumb(
   name: string,
   data?: CrashReportBreadcrumbData,
-  failureCause?: string
+  failureCause?: string,
+  origin?: string
 ): void {
   const sanitizedName = sanitizeCrashReportString(name)
   const lifecycleData = buildLifecycleData(data)
-  recordCrashBreadcrumb(sanitizedName, lifecycleData)
+  recordCrashBreadcrumb(sanitizedName, lifecycleData, origin)
   traceDurableBreadcrumb(sanitizedName, lifecycleData, failureCause)
 }
 
@@ -56,12 +57,14 @@ export function recordCoalescedDurableCrashBreadcrumb({
   name,
   data,
   coalesceKey,
-  minIntervalMs
+  minIntervalMs,
+  origin
 }: {
   name: string
   data?: CrashReportBreadcrumbData
   coalesceKey: string
   minIntervalMs: number
+  origin?: string
 }): void {
   const sanitizedName = sanitizeCrashReportString(name)
   const lifecycleData = buildLifecycleData(data)
@@ -69,7 +72,8 @@ export function recordCoalescedDurableCrashBreadcrumb({
     name: sanitizedName,
     data: lifecycleData,
     coalesceKey,
-    minIntervalMs
+    minIntervalMs,
+    ...(origin ? { origin } : {})
   })
   if (!coalesced) {
     return

--- a/src/main/crash-reporting/process-gone-dedupe.test.ts
+++ b/src/main/crash-reporting/process-gone-dedupe.test.ts
@@ -77,6 +77,23 @@ describe('ProcessGoneDedupe', () => {
     ).toBe(true)
   })
 
+  it('does not suppress simultaneous crashes from different renderers', () => {
+    const dedupe = new ProcessGoneDedupe({ windowMs: 2_000 })
+
+    expect(
+      dedupe.shouldRecord(getProcessGoneDedupeKey('renderer', 'renderer', 'crashed', 5, 11), 1_000)
+    ).toBe(true)
+    expect(
+      dedupe.shouldRecord(getProcessGoneDedupeKey('renderer', 'renderer', 'crashed', 5, 22), 1_001)
+    ).toBe(true)
+    expect(
+      dedupe.shouldRecord(
+        getProcessGoneDedupeKey('renderer', 'renderer', 'oom', -536870904, 11),
+        1_002
+      )
+    ).toBe(false)
+  })
+
   it('keeps child process crash tuples distinct inside renderer burst windows', () => {
     const dedupe = new ProcessGoneDedupe({ windowMs: 2_000 })
 

--- a/src/main/crash-reporting/process-gone-dedupe.ts
+++ b/src/main/crash-reporting/process-gone-dedupe.ts
@@ -80,12 +80,14 @@ export function getProcessGoneDedupeKey(
   source: 'renderer' | 'child',
   processType: string,
   reason: string,
-  exitCode: number | null
+  exitCode: number | null,
+  webContentsId?: number
 ): string {
   // Why: one renderer death can surface as crashed/oom/launch-failed in a
-  // burst. Coalesce that prompt noise while keeping child identities precise.
+  // burst. Coalesce that prompt noise per renderer while keeping child
+  // identities precise.
   if (source === 'renderer') {
-    return `${source}:${processType}`
+    return `${source}:${processType}:${webContentsId ?? 'global'}`
   }
   return `${source}:${processType}:${reason}:${exitCode ?? 'null'}`
 }

--- a/src/main/crash-reporting/process-gone-recorder.test.ts
+++ b/src/main/crash-reporting/process-gone-recorder.test.ts
@@ -114,6 +114,22 @@ describe('recordProcessGoneCrash', () => {
     expect(sink.flushMock).toHaveBeenCalledOnce()
   })
 
+  it('keeps suppressed renderer evidence scoped to its renderer', () => {
+    const dedupe = new ProcessGoneDedupe()
+    const suppressed = (webContentsId: number) =>
+      event({ reason: 'killed', exitCode: 1, expectedTeardown: 'renderer-reload', webContentsId })
+
+    recordProcessGoneCrash({ record: vi.fn() } as never, suppressed(11), dedupe)
+    recordProcessGoneCrash({ record: vi.fn() } as never, suppressed(22), dedupe)
+
+    expect(getCrashBreadcrumbSnapshot('renderer:11')).toEqual([
+      expect.objectContaining({ origin: 'renderer:11' })
+    ])
+    expect(getCrashBreadcrumbSnapshot('renderer:22')).toEqual([
+      expect.objectContaining({ origin: 'renderer:22' })
+    ])
+  })
+
   it('coalesces a recoverable-service crash loop instead of flushing every event', () => {
     const record = vi.fn()
     const dedupe = new ProcessGoneDedupe()
@@ -312,6 +328,26 @@ describe('recordProcessGoneCrash', () => {
       })
     ])
     expect(sink.flushMock).toHaveBeenCalledOnce()
+  })
+
+  it('keeps simultaneous renderer reports distinct by webContents identity', async () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+    const dedupe = new ProcessGoneDedupe()
+
+    recordProcessGoneCrash(
+      { record, attachDetails } as never,
+      event({ webContentsId: 11 }),
+      dedupe,
+      noMinidump
+    )
+    recordProcessGoneCrash(
+      { record, attachDetails } as never,
+      event({ webContentsId: 22 }),
+      dedupe,
+      noMinidump
+    )
+
+    await vi.waitFor(() => expect(record).toHaveBeenCalledTimes(2))
   })
 
   it('still persists the report when the forced trace flush fails', async () => {

--- a/src/main/crash-reporting/process-gone-recorder.ts
+++ b/src/main/crash-reporting/process-gone-recorder.ts
@@ -7,6 +7,7 @@ import {
   type CrashReportBreadcrumbData
 } from '../../shared/crash-reporting'
 import { decodePosixWaitStatus, describePosixWaitStatus } from '../../shared/posix-wait-status'
+import { rendererCrashBreadcrumbOrigin } from '../../shared/crash-breadcrumb-origin'
 import type { CrashReportStore } from './crash-report-store'
 import { getCrashBreadcrumbSnapshot } from './crash-breadcrumb-store'
 import {
@@ -41,6 +42,7 @@ export type ProcessGoneCrashEvent = {
   exitCode: number | null
   expectedTeardown: ExpectedTeardownScope
   details: Record<string, unknown>
+  webContentsId?: number
 }
 
 type CrashReportRecorderStore = Pick<CrashReportStore, 'record' | 'attachDetails'>
@@ -72,6 +74,12 @@ const SUPPRESSED_PROCESS_GONE_COALESCE_MS = 30_000
 
 function processGoneBreadcrumbData(event: ProcessGoneCrashEvent) {
   return buildSuppressedProcessGoneBreadcrumbData(event)
+}
+
+function processGoneRendererOrigin(event: ProcessGoneCrashEvent): string | undefined {
+  return event.webContentsId === undefined
+    ? undefined
+    : rendererCrashBreadcrumbOrigin(event.webContentsId)
 }
 
 // Why: key off the emitted breadcrumb, not the crash-report dedupe key, so two
@@ -179,11 +187,15 @@ export function recordProcessGoneCrash(
     // 1459/min) and each suppressed event costs a span plus a forced disk flush,
     // which both floods the 30-entry ring and evicts the real pre-crash trail.
     const suppressedData = processGoneBreadcrumbData(event)
+    const origin = processGoneRendererOrigin(event)
     recordCoalescedDurableCrashBreadcrumb({
       name: 'process_gone_suppressed',
       data: suppressedData,
-      coalesceKey: suppressedProcessGoneCoalesceKey(suppressedData),
-      minIntervalMs: SUPPRESSED_PROCESS_GONE_COALESCE_MS
+      coalesceKey: origin
+        ? `${origin}\u0000${suppressedProcessGoneCoalesceKey(suppressedData)}`
+        : suppressedProcessGoneCoalesceKey(suppressedData),
+      minIntervalMs: SUPPRESSED_PROCESS_GONE_COALESCE_MS,
+      ...(origin ? { origin } : {})
     })
     return
   }
@@ -191,12 +203,19 @@ export function recordProcessGoneCrash(
     recordDurableCrashBreadcrumb(
       'crash_report_store_unavailable',
       processGoneBreadcrumbData(event),
-      'Crash report store unavailable'
+      'Crash report store unavailable',
+      processGoneRendererOrigin(event)
     )
     return
   }
 
-  const key = getProcessGoneDedupeKey(event.source, event.processType, event.reason, event.exitCode)
+  const key = getProcessGoneDedupeKey(
+    event.source,
+    event.processType,
+    event.reason,
+    event.exitCode,
+    event.webContentsId
+  )
   const claim = dedupe.tryClaim(key)
   if (!claim) {
     return
@@ -209,7 +228,8 @@ export function recordProcessGoneCrash(
     },
     event.processType
   )
-  const breadcrumbs = getCrashBreadcrumbSnapshot()
+  const breadcrumbs = getCrashBreadcrumbSnapshot(processGoneRendererOrigin(event))
+  const reportBreadcrumbs = breadcrumbs?.map(({ origin: _origin, ...breadcrumb }) => breadcrumb)
   const span = startSpan('electron.process_gone', {
     attributes: {
       'crash.source': event.source,
@@ -227,7 +247,7 @@ export function recordProcessGoneCrash(
       'app.main_process.launch_id': mainProcessLifecycle.mainProcessLaunchId,
       'app.main_process.started_at': mainProcessLifecycle.mainProcessStartedAt,
       details: crashDetails,
-      breadcrumbs
+      breadcrumbs: reportBreadcrumbs
     }
   })
   // Why: a renderer crash can be followed by another process exit before the
@@ -252,7 +272,7 @@ export function recordProcessGoneCrash(
       electronVersion: process.versions.electron ?? 'unknown',
       chromeVersion: process.versions.chrome ?? 'unknown',
       details: crashDetails,
-      breadcrumbs
+      breadcrumbs: reportBreadcrumbs
     })
     .then((report) => {
       // Why: kept off the returned chain so a minidump failure can never reach
@@ -268,7 +288,8 @@ export function recordProcessGoneCrash(
         recordDurableCrashBreadcrumb(
           'minidump_signature_attach_failed',
           processGoneBreadcrumbData(event),
-          error instanceof Error ? error.message : String(error)
+          error instanceof Error ? error.message : String(error),
+          processGoneRendererOrigin(event)
         )
       })
     })
@@ -279,7 +300,8 @@ export function recordProcessGoneCrash(
       recordDurableCrashBreadcrumb(
         'crash_report_persist_failed',
         data,
-        `${String(data.errorName)}: ${String(data.errorMessage)}`
+        `${String(data.errorName)}: ${String(data.errorMessage)}`,
+        processGoneRendererOrigin(event)
       )
     })
 }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1905,7 +1905,8 @@ function recordProcessGoneCrash(
     reason,
     exitCode,
     expectedTeardown: getExpectedTeardownScope(webContentsId),
-    details
+    details,
+    ...(webContentsId !== undefined ? { webContentsId } : {})
   })
 }
 

--- a/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
+++ b/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
@@ -76,8 +76,11 @@ function registerHandlersWithStubStore(): void {
   } as never)
 }
 
-function emitRendererBreadcrumb(args: unknown): void {
-  listeners.get('crashReports:recordBreadcrumb')?.(null, args)
+function emitRendererBreadcrumb(args: unknown, senderId?: number): void {
+  listeners.get('crashReports:recordBreadcrumb')?.(
+    senderId === undefined ? null : { sender: { id: senderId } },
+    args
+  )
 }
 
 describe('renderer breadcrumb IPC routing', () => {
@@ -119,6 +122,17 @@ describe('renderer breadcrumb IPC routing', () => {
       }
     })
     expect(spanEndMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes the trusted sender identity into renderer breadcrumb attribution', () => {
+    emitRendererBreadcrumb({ name: 'renderer_error', data: { message: 'boom' } }, 42)
+
+    expect(recordCoalescedCrashBreadcrumbMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        origin: 'renderer:42',
+        coalesceKey: expect.stringContaining('renderer:42')
+      })
+    )
   })
 
   it('coalesces renderer rejection breadcrumbs by reason message', () => {

--- a/src/main/ipc/crash-reporting-renderer-breadcrumbs.ts
+++ b/src/main/ipc/crash-reporting-renderer-breadcrumbs.ts
@@ -125,10 +125,10 @@ function rendererBreadcrumbCoalesceKey(
   return JSON.stringify([name, message, ...sourceIdentity])
 }
 
-export function recordRendererBreadcrumbFromRenderer(args?: {
-  name?: unknown
-  data?: unknown
-}): void {
+export function recordRendererBreadcrumbFromRenderer(
+  args?: { name?: unknown; data?: unknown },
+  origin?: string
+): void {
   if (!args || typeof args.name !== 'string') {
     return
   }
@@ -136,15 +136,20 @@ export function recordRendererBreadcrumbFromRenderer(args?: {
   if (COALESCED_RENDERER_BREADCRUMB_NAMES.has(args.name)) {
     const coalesceKey = rendererBreadcrumbCoalesceKey(args.name, data)
     if (!coalesceKey) {
-      recordCrashBreadcrumb(args.name, data)
+      if (origin) {
+        recordCrashBreadcrumb(args.name, data, origin)
+      } else {
+        recordCrashBreadcrumb(args.name, data)
+      }
       recordRendererBreadcrumbTrace(args.name, data)
       return
     }
     const coalesceResult = recordCoalescedCrashBreadcrumb({
       name: args.name,
       data,
-      coalesceKey,
-      minIntervalMs: RENDERER_BREADCRUMB_COALESCE_MS
+      coalesceKey: origin ? `${origin}\u0000${coalesceKey}` : coalesceKey,
+      minIntervalMs: RENDERER_BREADCRUMB_COALESCE_MS,
+      ...(origin ? { origin } : {})
     })
     // Why: tracing every suppressed duplicate would preserve the same
     // serialization and disk churn that breadcrumb coalescing removes.
@@ -157,7 +162,11 @@ export function recordRendererBreadcrumbFromRenderer(args?: {
       )
     }
   } else {
-    recordCrashBreadcrumb(args.name, data)
+    if (origin) {
+      recordCrashBreadcrumb(args.name, data, origin)
+    } else {
+      recordCrashBreadcrumb(args.name, data)
+    }
     recordRendererBreadcrumbTrace(args.name, data)
   }
 }

--- a/src/main/ipc/crash-reporting-renderer-error-report-attribution.test.ts
+++ b/src/main/ipc/crash-reporting-renderer-error-report-attribution.test.ts
@@ -97,4 +97,15 @@ describe('renderer error report attribution', () => {
     expect(text).toContain('boundary_id')
     expect(text.indexOf('Attribution: unreliable')).toBeLessThan(text.indexOf('Details:'))
   })
+
+  it('does not dedupe identical errors from separate renderer windows', async () => {
+    const first = makeStore()
+    const second = makeStore()
+
+    const firstResult = await recordRendererErrorReport(first.store, baseArgs(), 11)
+    const secondResult = await recordRendererErrorReport(second.store, baseArgs(), 22)
+
+    expect(firstResult).toMatchObject({ ok: true, deduped: false })
+    expect(secondResult).toMatchObject({ ok: true, deduped: false })
+  })
 })

--- a/src/main/ipc/crash-reporting-renderer-error-report.ts
+++ b/src/main/ipc/crash-reporting-renderer-error-report.ts
@@ -11,6 +11,7 @@ import {
   UNRELIABLE_BOUNDARY_ATTRIBUTION_NOTE
 } from '../../shared/react-update-depth-attribution'
 import type { CrashReportStore } from '../crash-reporting/crash-report-store'
+import { rendererCrashBreadcrumbOrigin } from '../../shared/crash-breadcrumb-origin'
 import { getCrashBreadcrumbSnapshot } from '../crash-reporting/crash-breadcrumb-store'
 
 export const recentRendererErrorReportKeys = new Map<string, number>()
@@ -119,8 +120,12 @@ function pruneRendererErrorReportKeys(now: number): void {
   }
 }
 
-function getRendererErrorReportKey(args: ReactErrorBoundaryReportArgs): string {
+function getRendererErrorReportKey(
+  args: ReactErrorBoundaryReportArgs,
+  webContentsId?: number
+): string {
   return JSON.stringify({
+    webContentsId,
     boundaryId: args.boundaryId,
     surface: args.surface,
     errorName: args.errorName,
@@ -131,7 +136,8 @@ function getRendererErrorReportKey(args: ReactErrorBoundaryReportArgs): string {
 
 export async function recordRendererErrorReport(
   store: CrashReportStore,
-  args: unknown
+  args: unknown,
+  webContentsId?: number
 ): Promise<ReactErrorBoundaryReportResult> {
   const normalized = normalizeRendererErrorReportArgs(args)
   if (!normalized) {
@@ -140,7 +146,7 @@ export async function recordRendererErrorReport(
 
   const now = Date.now()
   pruneRendererErrorReportKeys(now)
-  const key = getRendererErrorReportKey(normalized)
+  const key = getRendererErrorReportKey(normalized, webContentsId)
   if (now - (recentRendererErrorReportKeys.get(key) ?? 0) < RENDERER_ERROR_DEDUPE_MS) {
     return { ok: true, report: null, deduped: true }
   }
@@ -186,7 +192,9 @@ export async function recordRendererErrorReport(
     },
     // Why: React render failures are recoverable only because a boundary
     // caught them; persist the same recent app breadcrumbs as native crashes.
-    breadcrumbs: getCrashBreadcrumbSnapshot()
+    breadcrumbs: getCrashBreadcrumbSnapshot(
+      webContentsId === undefined ? undefined : rendererCrashBreadcrumbOrigin(webContentsId)
+    )
   })
 
   return { ok: true, report, deduped: false }

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -5,6 +5,7 @@ import {
   formatCrashReportText
 } from '../../shared/crash-reporting'
 import type { CrashReportStore } from '../crash-reporting/crash-report-store'
+import { rendererCrashBreadcrumbOrigin } from '../../shared/crash-breadcrumb-origin'
 import {
   assertClipboardTextWriteWithinLimit,
   isClipboardTextWriteTooLargeError
@@ -64,8 +65,12 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
   ipcMain.removeAllListeners('crashReports:recordBreadcrumb')
   ipcMain.on(
     'crashReports:recordBreadcrumb',
-    (_event, args?: { name?: unknown; data?: unknown }) => {
-      recordRendererBreadcrumbFromRenderer(args)
+    (event, args?: { name?: unknown; data?: unknown }) => {
+      const senderId = event?.sender?.id
+      recordRendererBreadcrumbFromRenderer(
+        args,
+        typeof senderId === 'number' ? rendererCrashBreadcrumbOrigin(senderId) : undefined
+      )
     }
   )
 
@@ -94,9 +99,9 @@ export function registerCrashReportingHandlers(store: CrashReportStore): void {
   )
 
   ipcMain.removeHandler('crashReports:recordRendererError')
-  ipcMain.handle('crashReports:recordRendererError', async (_event, args: unknown) => {
+  ipcMain.handle('crashReports:recordRendererError', async (event, args: unknown) => {
     try {
-      return await recordRendererErrorReport(store, args)
+      return await recordRendererErrorReport(store, args, event?.sender?.id)
     } catch (error) {
       console.error('[crash-reporting] Failed to record renderer error report:', error)
       return { ok: false, error: 'Failed to record renderer error report.' }

--- a/src/shared/crash-breadcrumb-origin.ts
+++ b/src/shared/crash-breadcrumb-origin.ts
@@ -1,0 +1,4 @@
+/** Single origin label shared by renderer breadcrumb recording and snapshots. */
+export function rendererCrashBreadcrumbOrigin(webContentsId: number): string {
+  return `renderer:${webContentsId}`
+}

--- a/src/shared/crash-reporting.ts
+++ b/src/shared/crash-reporting.ts
@@ -19,11 +19,10 @@ export type CrashReportBreadcrumb = {
   createdAt: string
   name: string
   data?: CrashReportBreadcrumbData
+  origin?: string
 }
 
-export type CrashReportBreadcrumbInput = {
-  createdAt: string
-  name: string
+export type CrashReportBreadcrumbInput = Omit<CrashReportBreadcrumb, 'data'> & {
   data?: Record<string, unknown>
 }
 
@@ -44,7 +43,6 @@ export type CrashReportRecord = {
   details: Record<string, CrashReportDetailValue>
   breadcrumbs?: CrashReportBreadcrumb[]
 }
-
 export type UncapturedCrashReportContext = {
   createdAt: string
   appVersion: string
@@ -54,7 +52,6 @@ export type UncapturedCrashReportContext = {
   electronVersion: string
   chromeVersion: string
 }
-
 export type CrashReportCreateInput = Omit<
   CrashReportRecord,
   'id' | 'createdAt' | 'status' | 'details' | 'breadcrumbs'
@@ -62,7 +59,6 @@ export type CrashReportCreateInput = Omit<
   details: Record<string, unknown>
   breadcrumbs?: CrashReportBreadcrumbInput[]
 }
-
 export type ReactErrorBoundarySurface =
   | 'app-root'
   | 'web-root'
@@ -217,7 +213,6 @@ export function sanitizeCrashReportBreadcrumbs(
   if (!breadcrumbs || breadcrumbs.length === 0) {
     return undefined
   }
-
   const sanitized = breadcrumbs
     .slice(-MAX_BREADCRUMBS)
     .map((breadcrumb): CrashReportBreadcrumb | null => {
@@ -225,10 +220,14 @@ export function sanitizeCrashReportBreadcrumbs(
         return null
       }
       const data = breadcrumb.data ? sanitizeCrashReportDetails(breadcrumb.data) : {}
+      const origin = breadcrumb.origin
+        ? sanitizeCrashReportString(breadcrumb.origin).slice(0, 80)
+        : ''
       return {
         createdAt: sanitizeCrashReportString(breadcrumb.createdAt),
         name: sanitizeCrashReportString(breadcrumb.name).slice(0, MAX_BREADCRUMB_NAME_LENGTH),
-        ...(Object.keys(data).length > 0 ? { data } : {})
+        ...(Object.keys(data).length > 0 ? { data } : {}),
+        ...(origin ? { origin } : {})
       }
     })
     .filter((breadcrumb): breadcrumb is CrashReportBreadcrumb => breadcrumb !== null)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​216 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​213 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​157 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​71 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​86 |

<!-- /orca-pr-loc -->

## Summary

Scope renderer crash breadcrumbs and dedupe by the trusted Electron `webContentsId` so one renderer cannot make another renderer's crash look actionable.

This is a diagnostics-attribution fix. It does not claim to fix the underlying React #185, renderer OOM, native renderer, or Utility crash causes.

## Why

Slack crash triage across 267 reports from 2026-08-20 through 2026-08-24 showed recurring renderer reports whose breadcrumb evidence could be global or sibling-renderer activity. The diagnosis thread is [here](https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1787523960605589). This matches the direction of [PR #15709](https://github.com/stablyai/orca/pull/15709) and the React attribution caveat in [PR #16153](https://github.com/stablyai/orca/pull/16153).

## Changes

- Preserve trusted renderer origin through renderer breadcrumb IPC and process-gone events.
- Scope renderer error and process-gone dedupe per renderer while retaining child-process behavior.
- Filter renderer snapshots before applying the bounded recent breadcrumb budget.
- Keep suppressed and asynchronous failure breadcrumbs renderer-scoped.
- Include origin in in-memory coalescing/retained keys without persisting it to crash JSON or telemetry span breadcrumb attributes.
- Add deterministic regression coverage for sibling activity, dedupe, suppression, IPC sender routing, persistence scrubbing, and failure paths.

## Validation

- `pnpm test` — 6,202 files, 58,274 tests passed; 40 files and 249 tests skipped by suite configuration.
- `pnpm run lint` — passed, including code-quality audits, reliability gates, max-lines ratchet, runtime-electron ratchet, skill manifests, and localization checks.
- `pnpm run typecheck` — passed.
- Focused crash-reporting suite — 25 files, 268 tests passed.
- Electron CDP smoke — candidate launched from this worktree; visible Orca UI rendered; real renderer breadcrumb and React error IPC flow recorded and dismissed a report; returned persisted report contained no internal `renderer:<id>` origin.
- Three fresh read-only delegated reviews — no blockers.

## Risks and scope

- The retained high-water profile map remains globally capped at four entries; heavy multi-renderer activity can evict older historical profiles, but cannot cross-attribute them.
- Renderer reports intentionally omit sibling-renderer breadcrumbs, reducing some cross-renderer context.
- Per-renderer dedupe can retain more simultaneous reports, but all maps and persisted report storage remain bounded.
- No renderer UI, SSH/WSL, folder-workspace, mobile RPC, or remote-wire contract was changed.

## Crash triage conclusion

React #185, OOM, generic renderer killed/crashed, and Utility clusters remain historical or inconclusive without a deterministic Orca-owned root cause. This PR improves the evidence needed for the next crash investigation; it is not an underlying crash-rate fix.
