### PR TITLE
Fix sidebar grouping for paired remote projects

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.delete-shortcut.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.delete-shortcut.test.tsx
@@ -112,8 +112,10 @@ vi.mock('@/store', () => ({
 
 vi.mock('@/store/selectors', () => ({
   useAllWorktrees: () => [],
-  useRepoById: (repoId?: string) =>
-    repoId ? { id: repoId, name: repoId, displayName: repoId } : undefined,
+  useRepoForWorktree: (worktree?: { repoId?: string }) =>
+    worktree?.repoId
+      ? { id: worktree.repoId, name: worktree.repoId, displayName: worktree.repoId }
+      : undefined,
   useRepoMap: () => new Map(),
   useWorktreeMap: () => new Map()
 }))

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
 import WorktreeContextMenuView from './WorktreeContextMenuView'
-import {
-  useWorktreeContextMenuModel,
-  type WorktreeContextMenuProps
-} from './use-worktree-context-menu-model'
+import { useWorktreeContextMenuModel } from './use-worktree-context-menu-model'
+import type { WorktreeContextMenuProps } from './worktree-context-menu-props'
 
 const WorktreeContextMenu = React.memo(function WorktreeContextMenu(
   props: WorktreeContextMenuProps

--- a/src/renderer/src/components/sidebar/WorktreeContextMenuView.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenuView.tsx
@@ -36,6 +36,7 @@ import { useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
 import type { WorktreeContextMenuModel } from './use-worktree-context-menu-model'
 import { WorktreeStatusMenuItems } from './WorktreeStatusMenuItems'
 import { WorktreeContextMenuOverlays } from './WorktreeContextMenuOverlays'
+import { getMoveToGroupMenuLabel } from './project-group-menu-label'
 import {
   CLOSE_ALL_CONTEXT_MENUS_EVENT,
   WORKTREE_CONTEXT_MENU_SCOPE_ATTR,
@@ -84,6 +85,7 @@ export default function WorktreeContextMenuView({ model }: { model: WorktreeCont
     menuOpen,
     menuPoint,
     onContextMenuSelect,
+    projectGroupHostLabel,
     projectGroups,
     removesProject,
     repo,
@@ -215,10 +217,7 @@ export default function WorktreeContextMenuView({ model }: { model: WorktreeCont
                     <DropdownMenuSub>
                       <DropdownMenuSubTrigger disabled={isDeleting}>
                         <FolderInput className="size-3.5" />
-                        {translate(
-                          'auto.components.sidebar.WorktreeContextMenu.76865d827f',
-                          'Move to group'
-                        )}
+                        {getMoveToGroupMenuLabel(projectGroupHostLabel)}
                       </DropdownMenuSubTrigger>
                       <DropdownMenuSubContent>
                         {projectGroups.map((group) => (

--- a/src/renderer/src/components/sidebar/WorktreeDeveloperMenuReveal.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeDeveloperMenuReveal.test.tsx
@@ -38,7 +38,7 @@ vi.mock('@/store', () => {
 
 vi.mock('@/store/selectors', () => ({
   useAllWorktrees: () => [],
-  useRepoById: () => null,
+  useRepoForWorktree: () => null,
   useRepoMap: () => new Map(),
   useWorktreeMap: () => new Map()
 }))

--- a/src/renderer/src/components/sidebar/WorktreeList.group-headers.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeList.group-headers.test.ts
@@ -142,7 +142,7 @@ describe('WorktreeList lineage child card renderer', () => {
     const markup = await renderWorktreeListMarkup()
 
     expect(markup).toContain('Move to group')
-    expect(markup).not.toContain('Move to group: Local')
+    expect(markup).not.toContain('Move to group:')
   })
 
   it('renders a collapse chevron on project group headers with children', async () => {

--- a/src/renderer/src/components/sidebar/WorktreeList.group-headers.test.ts
+++ b/src/renderer/src/components/sidebar/WorktreeList.group-headers.test.ts
@@ -128,6 +128,23 @@ describe('WorktreeList lineage child card renderer', () => {
     expect(markup).not.toContain('No workspaces found')
   })
 
+  it('keeps project group actions generic when the host filter shows one catalog', async () => {
+    setLineageFixtureState('repo', { projectGrouped: true })
+    mockStore.state = {
+      ...mockStore.state,
+      repos: [
+        ...(mockStore.state.repos as Repo[]),
+        { ...makeRepo(), id: 'remote-repo', executionHostId: 'runtime:work' }
+      ],
+      visibleWorkspaceHostIds: ['local']
+    }
+
+    const markup = await renderWorktreeListMarkup()
+
+    expect(markup).toContain('Move to group')
+    expect(markup).not.toContain('Move to group: Local')
+  })
+
   it('renders a collapse chevron on project group headers with children', async () => {
     setProjectGroupWithoutWorktreeRowsState()
     const markup = await renderWorktreeListMarkup()

--- a/src/renderer/src/components/sidebar/project-group-menu-actions.ts
+++ b/src/renderer/src/components/sidebar/project-group-menu-actions.ts
@@ -1,0 +1,94 @@
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
+import type { Repo } from '../../../../shared/repo-types'
+import { getRepoExecutionHostId } from '../../../../shared/execution-host'
+import type { RepoSlice } from '@/store/repos/repo-state'
+
+type ProjectGroupMenuMutations = Pick<RepoSlice, 'createProjectGroup' | 'moveProjectToGroup'>
+
+const unconfirmedMoveDescription = (): string =>
+  translate(
+    'auto.components.sidebar.project-group-menu-actions.moveUnconfirmedDescription',
+    "Orca could not confirm the move with the project's host. Recheck the project after reconnecting."
+  )
+
+export function reportProjectGroupMoveFailure(): void {
+  toast.error(
+    translate(
+      'auto.components.sidebar.project-group-menu-actions.moveFailed',
+      'Failed to move project'
+    ),
+    { description: unconfirmedMoveDescription() }
+  )
+}
+
+export async function createProjectGroupFromRepo(
+  repo: Repo,
+  name: string,
+  mutations: ProjectGroupMenuMutations
+): Promise<void> {
+  const hostId = getRepoExecutionHostId(repo)
+  const group = await mutations.createProjectGroup(name, { hostId })
+  if (!group) {
+    toast.error(
+      translate(
+        'auto.components.sidebar.project-group-menu-actions.createFailed',
+        'Failed to create group'
+      ),
+      {
+        description: translate(
+          'auto.components.sidebar.project-group-menu-actions.createFailedDescription',
+          "Orca could not confirm the new group with the project's host. Check the connection and try again."
+        )
+      }
+    )
+    return
+  }
+
+  const moved = await mutations.moveProjectToGroup(repo.id, group.id, undefined, { hostId })
+  if (!moved) {
+    toast.error(
+      translate(
+        'auto.components.sidebar.project-group-menu-actions.initialMoveUnconfirmed',
+        'Group created, but move was not confirmed'
+      ),
+      { description: unconfirmedMoveDescription() }
+    )
+  }
+}
+
+export async function moveProjectToGroupFromMenu(
+  repo: Repo,
+  groupId: string,
+  moveProjectToGroup: RepoSlice['moveProjectToGroup']
+): Promise<void> {
+  const moved = await moveProjectToGroup(repo.id, groupId, undefined, {
+    hostId: getRepoExecutionHostId(repo)
+  })
+  if (!moved) {
+    reportProjectGroupMoveFailure()
+  }
+}
+
+export async function removeProjectFromGroupFromMenu(
+  repo: Repo,
+  moveProjectToGroup: RepoSlice['moveProjectToGroup']
+): Promise<void> {
+  const removed = await moveProjectToGroup(repo.id, null, undefined, {
+    hostId: getRepoExecutionHostId(repo)
+  })
+  if (!removed) {
+    toast.error(
+      translate(
+        'auto.components.sidebar.project-group-menu-actions.removeFailed',
+        'Failed to remove project from group'
+      ),
+      {
+        description: translate(
+          'auto.components.sidebar.project-group-menu-actions.removeFailedDescription',
+          "Orca could not confirm the change with the project's host. Recheck the project after reconnecting."
+        )
+      }
+    )
+  }
+}

--- a/src/renderer/src/components/sidebar/project-group-menu-label.test.ts
+++ b/src/renderer/src/components/sidebar/project-group-menu-label.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const translate = vi.hoisted(() =>
+  vi.fn((_key: string, fallback: string, values?: Record<string, unknown>) =>
+    fallback.replace('{{hostLabel}}', String(values?.hostLabel ?? ''))
+  )
+)
+
+vi.mock('@/i18n/i18n', () => ({ translate }))
+
+import { getMoveToGroupMenuLabel } from './project-group-menu-label'
+
+describe('project group menu localization', () => {
+  afterEach(() => {
+    translate.mockClear()
+  })
+
+  it('uses an intent-named id for the generic action', () => {
+    expect(getMoveToGroupMenuLabel()).toBe('Move to group')
+    expect(translate).toHaveBeenCalledWith(
+      'auto.components.sidebar.project-group-menu-label.moveToGroup',
+      'Move to group'
+    )
+  })
+
+  it('names the host with a semantic interpolation placeholder', () => {
+    expect(getMoveToGroupMenuLabel('Work')).toBe('Move to group: Work')
+    expect(translate).toHaveBeenCalledWith(
+      'auto.components.sidebar.project-group-menu-label.moveToGroupForHost',
+      'Move to group: {{hostLabel}}',
+      { hostLabel: 'Work' }
+    )
+  })
+})

--- a/src/renderer/src/components/sidebar/project-group-menu-label.ts
+++ b/src/renderer/src/components/sidebar/project-group-menu-label.ts
@@ -1,0 +1,30 @@
+import { translate } from '@/i18n/i18n'
+import type { Repo } from '../../../../shared/repo-types'
+import { getExecutionHostLabel } from '../../../../shared/execution-host'
+import { getProjectGroupCatalogHostIdForRepo } from '@/store/slices/project-group-owner-routing'
+
+export function getProjectGroupMenuHostLabel(
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'>,
+  hasMultipleCatalogHosts: boolean,
+  preferredLabel?: string | null
+): string | undefined {
+  if (!hasMultipleCatalogHosts) {
+    return undefined
+  }
+  const hostId = getProjectGroupCatalogHostIdForRepo(repo)
+  if (hostId === 'local') {
+    return translate('auto.components.sidebar.project-group-menu-label.local', 'Local')
+  }
+  return preferredLabel?.trim() || getExecutionHostLabel(hostId)
+}
+
+export function getMoveToGroupMenuLabel(hostLabel?: string | null): string {
+  if (!hostLabel) {
+    return translate('auto.components.sidebar.project-group-menu-label.4a08fb55f2', 'Move to group')
+  }
+  return translate(
+    'auto.components.sidebar.project-group-menu-label.16bc925de6',
+    'Move to group: {{value0}}',
+    { value0: hostLabel }
+  )
+}

--- a/src/renderer/src/components/sidebar/project-group-menu-label.ts
+++ b/src/renderer/src/components/sidebar/project-group-menu-label.ts
@@ -20,11 +20,14 @@ export function getProjectGroupMenuHostLabel(
 
 export function getMoveToGroupMenuLabel(hostLabel?: string | null): string {
   if (!hostLabel) {
-    return translate('auto.components.sidebar.project-group-menu-label.4a08fb55f2', 'Move to group')
+    return translate(
+      'auto.components.sidebar.project-group-menu-label.moveToGroup',
+      'Move to group'
+    )
   }
   return translate(
-    'auto.components.sidebar.project-group-menu-label.16bc925de6',
-    'Move to group: {{value0}}',
-    { value0: hostLabel }
+    'auto.components.sidebar.project-group-menu-label.moveToGroupForHost',
+    'Move to group: {{hostLabel}}',
+    { hostLabel }
   )
 }

--- a/src/renderer/src/components/sidebar/project-group-menu-label.ts
+++ b/src/renderer/src/components/sidebar/project-group-menu-label.ts
@@ -1,21 +1,59 @@
 import { translate } from '@/i18n/i18n'
 import type { Repo } from '../../../../shared/repo-types'
-import { getExecutionHostLabel } from '../../../../shared/execution-host'
-import { getProjectGroupCatalogHostIdForRepo } from '@/store/slices/project-group-owner-routing'
+import type { Worktree } from '../../../../shared/worktree/types'
+import {
+  getExecutionHostLabel,
+  getWorktreeExecutionHostId,
+  LOCAL_EXECUTION_HOST_ID,
+  toRuntimeExecutionHostId,
+  type ExecutionHostId
+} from '../../../../shared/execution-host'
+import {
+  getProjectGroupCatalogHostId,
+  getProjectGroupCatalogHostIdForRepo
+} from '@/store/slices/project-group-owner-routing'
 
-export function getProjectGroupMenuHostLabel(
-  repo: Pick<Repo, 'connectionId' | 'executionHostId'>,
+function getProjectGroupMenuHostLabelForCatalog(
+  hostId: ExecutionHostId,
   hasMultipleCatalogHosts: boolean,
   preferredLabel?: string | null
 ): string | undefined {
   if (!hasMultipleCatalogHosts) {
     return undefined
   }
-  const hostId = getProjectGroupCatalogHostIdForRepo(repo)
-  if (hostId === 'local') {
+  if (hostId === LOCAL_EXECUTION_HOST_ID) {
     return translate('auto.components.sidebar.project-group-menu-label.local', 'Local')
   }
   return preferredLabel?.trim() || getExecutionHostLabel(hostId)
+}
+
+export function getProjectGroupMenuHostLabel(
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'>,
+  hasMultipleCatalogHosts: boolean,
+  preferredLabel?: string | null
+): string | undefined {
+  return getProjectGroupMenuHostLabelForCatalog(
+    getProjectGroupCatalogHostIdForRepo(repo),
+    hasMultipleCatalogHosts,
+    preferredLabel
+  )
+}
+
+export function getProjectGroupMenuHostLabelForWorktree(
+  worktree: Pick<Worktree, 'hostId' | 'runtimeOwnerEnvironmentId'>,
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'> | undefined,
+  hasMultipleCatalogHosts: boolean,
+  preferredLabel?: string | null
+): string | undefined {
+  const runtimeOwnerEnvironmentId = worktree.runtimeOwnerEnvironmentId?.trim()
+  const ownerHostId = runtimeOwnerEnvironmentId
+    ? toRuntimeExecutionHostId(runtimeOwnerEnvironmentId)
+    : getWorktreeExecutionHostId(worktree, repo, LOCAL_EXECUTION_HOST_ID)
+  return getProjectGroupMenuHostLabelForCatalog(
+    getProjectGroupCatalogHostId(ownerHostId),
+    hasMultipleCatalogHosts,
+    preferredLabel
+  )
 }
 
 export function getMoveToGroupMenuLabel(hostLabel?: string | null): string {

--- a/src/renderer/src/components/sidebar/project-header-drag-commit.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-commit.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { commitProjectHeaderDragDrop } from './project-header-drag-commit'
 import type { ProjectHeaderDragSession } from './project-header-drag-contract'
 import type { Repo } from '../../../../shared/repo-types'
+import { getRepoExecutionHostId } from '../../../../shared/execution-host'
 
 function makeRepo(id: string, overrides: Partial<Repo> = {}): Repo {
   return {
@@ -17,11 +18,13 @@ function makeRepo(id: string, overrides: Partial<Repo> = {}): Repo {
 }
 
 function makeSession(
-  repoId: string,
+  repo: Repo,
   sidebarRepoHeaderIds: readonly string[]
 ): ProjectHeaderDragSession {
   return {
-    repoId,
+    repoId: repo.id,
+    repoHostId: getRepoExecutionHostId(repo),
+    projectGroupId: repo.projectGroupId ?? null,
     bucketKey: 'ungrouped',
     sidebarRepoHeaderIds,
     pointerId: 1,
@@ -41,7 +44,7 @@ describe('commitProjectHeaderDragDrop', () => {
     const repoById = new Map(repos.map((repo) => [repo.id, repo]))
 
     commitProjectHeaderDragDrop({
-      session: makeSession('c', ['a', 'b', 'c']),
+      session: makeSession(repos[2]!, ['a', 'b', 'c']),
       sidebarDropIndex: 0,
       orderedRepoIds: ['a', 'b', 'c'],
       repoById,
@@ -59,7 +62,7 @@ describe('commitProjectHeaderDragDrop', () => {
     const repoById = new Map(repos.map((repo) => [repo.id, repo]))
 
     commitProjectHeaderDragDrop({
-      session: makeSession('same', ['b', 'same', 'c']),
+      session: makeSession(repos[1]!, ['b', 'same', 'c']),
       sidebarDropIndex: 0,
       orderedRepoIds: ['b', 'same', 'c', 'same'],
       repoById,
@@ -77,7 +80,7 @@ describe('commitProjectHeaderDragDrop', () => {
     const repoById = new Map(repos.map((repo) => [repo.id, repo]))
 
     commitProjectHeaderDragDrop({
-      session: makeSession('same', ['b', 'same', 'c']),
+      session: makeSession(repos[1]!, ['b', 'same', 'c']),
       sidebarDropIndex: 2,
       orderedRepoIds: ['b', 'same', 'c', 'same'],
       repoById,
@@ -99,7 +102,7 @@ describe('commitProjectHeaderDragDrop', () => {
     const repoById = new Map(repos.map((repo) => [repo.id, repo]))
 
     commitProjectHeaderDragDrop({
-      session: makeSession('c', ['a', 'b', 'c']),
+      session: makeSession(repos[2]!, ['a', 'b', 'c']),
       sidebarDropIndex: 0,
       orderedRepoIds: ['a', 'b', 'c'],
       repoById,
@@ -108,6 +111,45 @@ describe('commitProjectHeaderDragDrop', () => {
       onCommitProjectGroupOrder
     })
 
-    expect(onCommitProjectGroupOrder).toHaveBeenCalledWith('c', 'group-1', -1)
+    expect(onCommitProjectGroupOrder).toHaveBeenCalledWith('c', 'group-1', -1, 'local')
+  })
+
+  it('preserves the dragged host when another host has the same repo id', () => {
+    const onCommitProjectGroupOrder = vi.fn()
+    const localRepo = makeRepo('same', {
+      executionHostId: 'local',
+      projectGroupId: 'local-group'
+    })
+    const runtimeRepo = makeRepo('same', {
+      executionHostId: 'runtime:env-1',
+      projectGroupId: 'runtime-group'
+    })
+    const runtimeSibling = makeRepo('other', {
+      executionHostId: 'runtime:env-1',
+      projectGroupId: 'runtime-group',
+      projectGroupOrder: 1
+    })
+    const repoById = new Map([
+      [localRepo.id, localRepo],
+      [runtimeSibling.id, runtimeSibling]
+    ])
+    const session = makeSession(runtimeRepo, ['same', 'other'])
+
+    commitProjectHeaderDragDrop({
+      session,
+      sidebarDropIndex: 2,
+      orderedRepoIds: ['same', 'other', 'same'],
+      repoById,
+      usesProjectGroupOrdering: true,
+      onCommitRepoOrder: vi.fn(),
+      onCommitProjectGroupOrder
+    })
+
+    expect(onCommitProjectGroupOrder).toHaveBeenCalledWith(
+      'same',
+      'runtime-group',
+      expect.any(Number),
+      'runtime:env-1'
+    )
   })
 })

--- a/src/renderer/src/components/sidebar/project-header-drag-commit.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-commit.ts
@@ -7,6 +7,7 @@ import {
 } from './project-header-drop'
 import type { ProjectHeaderDragSession } from './project-header-drag-contract'
 import type { Repo } from '../../../../shared/repo-types'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
 
 export function commitProjectHeaderDragDrop(args: {
   session: ProjectHeaderDragSession
@@ -15,10 +16,14 @@ export function commitProjectHeaderDragDrop(args: {
   repoById: ReadonlyMap<string, Repo>
   usesProjectGroupOrdering: boolean
   onCommitRepoOrder: (orderedIds: string[]) => void
-  onCommitProjectGroupOrder: (repoId: string, projectGroupId: string | null, order: number) => void
+  onCommitProjectGroupOrder: (
+    repoId: string,
+    projectGroupId: string | null,
+    order: number,
+    repoHostId: ExecutionHostId
+  ) => void
 }): void {
-  const draggedRepo = args.repoById.get(args.session.repoId)
-  if (!draggedRepo) {
+  if (!args.repoById.has(args.session.repoId)) {
     return
   }
 
@@ -59,7 +64,12 @@ export function commitProjectHeaderDragDrop(args: {
       dropIndex: siblingDropIndex,
       repoOrderRankById
     })
-    args.onCommitProjectGroupOrder(args.session.repoId, draggedRepo.projectGroupId ?? null, order)
+    args.onCommitProjectGroupOrder(
+      args.session.repoId,
+      args.session.projectGroupId,
+      order,
+      args.session.repoHostId
+    )
     return
   }
 

--- a/src/renderer/src/components/sidebar/project-header-drag-contract.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-contract.ts
@@ -2,6 +2,7 @@ import type { PointerEvent } from 'react'
 
 import type { ProjectHeaderDragBucketKey, ProjectHeaderDragRect } from './project-header-drop'
 import type { Repo } from '../../../../shared/repo-types'
+import type { ExecutionHostId } from '../../../../shared/execution-host'
 
 export type RepoDragState = {
   draggingRepoId: string | null
@@ -21,17 +22,24 @@ export type UseRepoHeaderDragArgs = {
   repoById: ReadonlyMap<string, Repo>
   usesProjectGroupOrdering: boolean
   onCommitRepoOrder: (orderedIds: string[]) => void
-  onCommitProjectGroupOrder: (repoId: string, projectGroupId: string | null, order: number) => void
+  onCommitProjectGroupOrder: (
+    repoId: string,
+    projectGroupId: string | null,
+    order: number,
+    repoHostId: ExecutionHostId
+  ) => void
   getScrollContainer: () => HTMLElement | null
 }
 
 export type RepoHeaderDragController = {
   state: RepoDragState
-  onHandlePointerDown: (event: PointerEvent<HTMLElement>, repoId: string) => void
+  onHandlePointerDown: (event: PointerEvent<HTMLElement>, repo: Repo) => void
 }
 
 export type ProjectHeaderDragSession = {
   repoId: string
+  repoHostId: ExecutionHostId
+  projectGroupId: string | null
   bucketKey: ProjectHeaderDragBucketKey
   sidebarRepoHeaderIds: readonly string[]
   pointerId: number

--- a/src/renderer/src/components/sidebar/project-header-drag-start.test.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-start.test.ts
@@ -24,7 +24,7 @@ describe('createProjectHeaderDragSession', () => {
     const scrollContainer = document.createElement('div')
     document.body.append(scrollContainer, handleEl)
 
-    const repoById = new Map<string, Repo>([['repo-a', createRepo('repo-a')]])
+    const repo = createRepo('repo-a')
     const sidebarRepoHeaderIdsByBucket = new Map([['ungrouped', ['repo-a', 'repo-b']]])
 
     const session = createProjectHeaderDragSession({
@@ -36,8 +36,7 @@ describe('createProjectHeaderDragSession', () => {
         target: handleEl,
         currentTarget: handleEl
       } as unknown as React.PointerEvent<HTMLElement>,
-      repoId: 'repo-a',
-      repoById,
+      repo,
       sidebarRepoHeaderIdsByBucket,
       getScrollContainer: () => scrollContainer
     })
@@ -54,7 +53,7 @@ describe('createProjectHeaderDragSession', () => {
     const scrollContainer = document.createElement('div')
     document.body.append(scrollContainer, header)
 
-    const repoById = new Map<string, Repo>([['repo-a', createRepo('repo-a')]])
+    const repo = createRepo('repo-a')
     const sidebarRepoHeaderIdsByBucket = new Map([['ungrouped', ['repo-a', 'repo-b']]])
 
     const session = createProjectHeaderDragSession({
@@ -66,13 +65,44 @@ describe('createProjectHeaderDragSession', () => {
         target: label,
         currentTarget: header
       } as unknown as React.PointerEvent<HTMLElement>,
-      repoId: 'repo-a',
-      repoById,
+      repo,
       sidebarRepoHeaderIdsByBucket,
       getScrollContainer: () => scrollContainer
     })
 
     expect(session?.repoId).toBe('repo-a')
+  })
+
+  it('captures the group and host from the dragged repo row', () => {
+    const header = document.createElement('div')
+    header.setAttribute('data-repo-header-drag-handle', '')
+    const scrollContainer = document.createElement('div')
+    document.body.append(scrollContainer, header)
+    const repo = {
+      ...createRepo('same', 'runtime-group'),
+      executionHostId: 'runtime:env-1' as const
+    }
+    const sidebarRepoHeaderIdsByBucket = new Map([['group:runtime-group', ['same', 'other']]])
+
+    const session = createProjectHeaderDragSession({
+      event: {
+        button: 0,
+        pointerId: 1,
+        clientX: 10,
+        clientY: 20,
+        target: header,
+        currentTarget: header
+      } as unknown as React.PointerEvent<HTMLElement>,
+      repo,
+      sidebarRepoHeaderIdsByBucket,
+      getScrollContainer: () => scrollContainer
+    })
+
+    expect(session).toMatchObject({
+      repoId: 'same',
+      repoHostId: 'runtime:env-1',
+      projectGroupId: 'runtime-group'
+    })
   })
 
   it('arms a drag session when pressing the project icon svg (SVGElement target)', () => {
@@ -85,7 +115,7 @@ describe('createProjectHeaderDragSession', () => {
     const scrollContainer = document.createElement('div')
     document.body.append(scrollContainer, header)
 
-    const repoById = new Map<string, Repo>([['repo-a', createRepo('repo-a')]])
+    const repo = createRepo('repo-a')
     const sidebarRepoHeaderIdsByBucket = new Map([['ungrouped', ['repo-a', 'repo-b']]])
 
     const session = createProjectHeaderDragSession({
@@ -97,8 +127,7 @@ describe('createProjectHeaderDragSession', () => {
         target: iconSvg,
         currentTarget: header
       } as unknown as React.PointerEvent<HTMLElement>,
-      repoId: 'repo-a',
-      repoById,
+      repo,
       sidebarRepoHeaderIdsByBucket,
       getScrollContainer: () => scrollContainer
     })
@@ -119,7 +148,7 @@ describe('createProjectHeaderDragSession', () => {
     const scrollContainer = document.createElement('div')
     document.body.append(scrollContainer, header)
 
-    const repoById = new Map<string, Repo>([['repo-a', createRepo('repo-a')]])
+    const repo = createRepo('repo-a')
     const sidebarRepoHeaderIdsByBucket = new Map([['ungrouped', ['repo-a', 'repo-b']]])
 
     const session = createProjectHeaderDragSession({
@@ -131,8 +160,7 @@ describe('createProjectHeaderDragSession', () => {
         target: actionIcon,
         currentTarget: header
       } as unknown as React.PointerEvent<HTMLElement>,
-      repoId: 'repo-a',
-      repoById,
+      repo,
       sidebarRepoHeaderIdsByBucket,
       getScrollContainer: () => scrollContainer
     })
@@ -154,7 +182,7 @@ describe('createProjectHeaderDragSession', () => {
     const scrollContainer = document.createElement('div')
     document.body.append(scrollContainer, header)
 
-    const repoById = new Map<string, Repo>([['repo-a', createRepo('repo-a')]])
+    const repo = createRepo('repo-a')
     const sidebarRepoHeaderIdsByBucket = new Map([['ungrouped', ['repo-a', 'repo-b']]])
 
     const sessionFromActions = createProjectHeaderDragSession({
@@ -166,8 +194,7 @@ describe('createProjectHeaderDragSession', () => {
         target: actions,
         currentTarget: header
       } as unknown as React.PointerEvent<HTMLElement>,
-      repoId: 'repo-a',
-      repoById,
+      repo,
       sidebarRepoHeaderIdsByBucket,
       getScrollContainer: () => scrollContainer
     })
@@ -180,8 +207,7 @@ describe('createProjectHeaderDragSession', () => {
         target: label,
         currentTarget: header
       } as unknown as React.PointerEvent<HTMLElement>,
-      repoId: 'repo-a',
-      repoById,
+      repo,
       sidebarRepoHeaderIdsByBucket,
       getScrollContainer: () => scrollContainer
     })
@@ -194,8 +220,7 @@ describe('createProjectHeaderDragSession', () => {
         target: header,
         currentTarget: header
       } as unknown as React.PointerEvent<HTMLElement>,
-      repoId: 'repo-a',
-      repoById,
+      repo,
       sidebarRepoHeaderIdsByBucket,
       getScrollContainer: () => scrollContainer
     })

--- a/src/renderer/src/components/sidebar/project-header-drag-start.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag-start.ts
@@ -11,11 +11,11 @@ import {
   type ProjectHeaderDragSession
 } from './project-header-drag-contract'
 import type { Repo } from '../../../../shared/repo-types'
+import { getRepoExecutionHostId } from '../../../../shared/execution-host'
 
 export function createProjectHeaderDragSession(args: {
   event: PointerEvent<HTMLElement>
-  repoId: string
-  repoById: ReadonlyMap<string, Repo>
+  repo: Repo
   sidebarRepoHeaderIdsByBucket: ReadonlyMap<ProjectHeaderDragBucketKey, readonly string[]>
   getScrollContainer: () => HTMLElement | null
 }): ProjectHeaderDragSession | null {
@@ -28,11 +28,7 @@ export function createProjectHeaderDragSession(args: {
   if (isRepoHeaderActionTarget(args.event.target, args.event.currentTarget)) {
     return null
   }
-  const repo = args.repoById.get(args.repoId)
-  if (!repo) {
-    return null
-  }
-  const bucketKey = getProjectHeaderDragBucketKey(repo)
+  const bucketKey = getProjectHeaderDragBucketKey(args.repo)
   const sidebarRepoHeaderIds = args.sidebarRepoHeaderIdsByBucket.get(bucketKey) ?? []
   // Why: a single project in its bucket has nowhere to land, so skip arming
   // drag and let the header click toggle collapse instead.
@@ -47,7 +43,9 @@ export function createProjectHeaderDragSession(args: {
   // Why: defer setPointerCapture until the drag threshold is crossed so a
   // header click still reaches the inner collapse handler on pointerup.
   return {
-    repoId: args.repoId,
+    repoId: args.repo.id,
+    repoHostId: getRepoExecutionHostId(args.repo),
+    projectGroupId: args.repo.projectGroupId ?? null,
     bucketKey,
     sidebarRepoHeaderIds,
     pointerId: args.event.pointerId,

--- a/src/renderer/src/components/sidebar/project-header-drag.ts
+++ b/src/renderer/src/components/sidebar/project-header-drag.ts
@@ -5,6 +5,7 @@ import {
   measureProjectHeaderDragRects
 } from './project-header-drop'
 import { commitProjectHeaderDragDrop } from './project-header-drag-commit'
+import type { Repo } from '../../../../shared/repo-types'
 import {
   INITIAL_REPO_DRAG_STATE,
   PROJECT_HEADER_DRAG_THRESHOLD_PX,
@@ -296,23 +297,19 @@ export function useRepoHeaderDrag({
     }
   }, [state.draggingRepoId])
 
-  const onHandlePointerDown = useCallback(
-    (event: React.PointerEvent<HTMLElement>, repoId: string) => {
-      const session = createProjectHeaderDragSession({
-        event,
-        repoId,
-        repoById: repoByIdRef.current,
-        sidebarRepoHeaderIdsByBucket: sidebarRepoHeaderIdsByBucketRef.current,
-        getScrollContainer: getContainerRef.current
-      })
-      if (!session) {
-        return
-      }
-      dragSessionRef.current = session
-      setSessionArmed(true)
-    },
-    []
-  )
+  const onHandlePointerDown = useCallback((event: React.PointerEvent<HTMLElement>, repo: Repo) => {
+    const session = createProjectHeaderDragSession({
+      event,
+      repo,
+      sidebarRepoHeaderIdsByBucket: sidebarRepoHeaderIdsByBucketRef.current,
+      getScrollContainer: getContainerRef.current
+    })
+    if (!session) {
+      return
+    }
+    dragSessionRef.current = session
+    setSessionArmed(true)
+  }, [])
 
   return { state, onHandlePointerDown }
 }

--- a/src/renderer/src/components/sidebar/use-worktree-card-foundation-project-group-label.test.tsx
+++ b/src/renderer/src/components/sidebar/use-worktree-card-foundation-project-group-label.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { cleanup, renderHook } from '@testing-library/react'
+import { useAppStore } from '@/store'
+import type { Repo } from '../../../../shared/repo-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import { useWorktreeCardFoundation } from './use-worktree-card-foundation'
+
+const initialState = useAppStore.getInitialState()
+
+const localRepo = {
+  id: 'local-repo',
+  path: '/tmp/local-repo',
+  displayName: 'local-repo',
+  badgeColor: '#111',
+  addedAt: 1,
+  executionHostId: 'local'
+} as Repo
+
+const remoteRepo = {
+  ...localRepo,
+  id: 'remote-repo',
+  path: '/tmp/remote-repo',
+  executionHostId: 'runtime:work'
+} as Repo
+
+const localWorktree = {
+  id: 'local-repo::/tmp/local-repo',
+  repoId: localRepo.id,
+  path: localRepo.path,
+  displayName: localRepo.displayName,
+  branch: 'refs/heads/main',
+  head: 'abc123',
+  isBare: false,
+  isMainWorktree: true,
+  comment: '',
+  linkedIssue: null,
+  linkedPR: null,
+  linkedLinearIssue: null,
+  isArchived: false,
+  isUnread: false,
+  isPinned: false,
+  sortOrder: 0,
+  lastActivityAt: 1,
+  hostId: 'local'
+} as Worktree
+
+describe('worktree card project group host label', () => {
+  beforeEach(() => {
+    useAppStore.setState(initialState, true)
+  })
+
+  afterEach(() => {
+    cleanup()
+    useAppStore.setState(initialState, true)
+  })
+
+  it('stays generic when the host filter hides the other catalog', () => {
+    useAppStore.setState({
+      repos: [localRepo, remoteRepo],
+      visibleWorkspaceHostIds: ['local'],
+      workspaceHostScope: 'all'
+    })
+
+    const { result } = renderHook(() =>
+      useWorktreeCardFoundation({ worktree: localWorktree, repo: localRepo })
+    )
+
+    expect(result.current.projectGroupHostLabel).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/sidebar/use-worktree-card-foundation-project-group-label.test.tsx
+++ b/src/renderer/src/components/sidebar/use-worktree-card-foundation-project-group-label.test.tsx
@@ -69,4 +69,41 @@ describe('worktree card project group host label', () => {
 
     expect(result.current.projectGroupHostLabel).toBeUndefined()
   })
+
+  it('uses the worktree owner when duplicate repo ids point at another host', () => {
+    const duplicateLocalRepo = { ...localRepo, id: 'shared-repo' }
+    const duplicateRemoteRepo = { ...remoteRepo, id: 'shared-repo' }
+    const remoteWorktree = {
+      ...localWorktree,
+      id: 'shared-repo::/tmp/remote-repo',
+      repoId: 'shared-repo',
+      hostId: 'ssh:air',
+      runtimeOwnerEnvironmentId: 'work'
+    } as Worktree
+    const localDuplicateWorktree = {
+      ...localWorktree,
+      id: 'shared-repo::/tmp/local-repo',
+      repoId: 'shared-repo'
+    } as Worktree
+    useAppStore.setState({
+      repos: [duplicateRemoteRepo, duplicateLocalRepo],
+      runtimeEnvironments: [{ id: 'work', name: 'Work' }] as never,
+      visibleWorkspaceHostIds: null,
+      workspaceHostScope: 'all'
+    })
+
+    const remote = renderHook(() =>
+      useWorktreeCardFoundation({ worktree: remoteWorktree, repo: duplicateLocalRepo })
+    )
+    expect(remote.result.current.projectGroupHostLabel).toBe('Work')
+    remote.unmount()
+
+    const local = renderHook(() =>
+      useWorktreeCardFoundation({
+        worktree: localDuplicateWorktree,
+        repo: duplicateRemoteRepo
+      })
+    )
+    expect(local.result.current.projectGroupHostLabel).toBe('Local')
+  })
 })

--- a/src/renderer/src/components/sidebar/use-worktree-card-foundation.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-card-foundation.ts
@@ -18,6 +18,8 @@ import {
 } from '@/store/slices/runtime-environment-ssh'
 import { EMPTY_WORKSPACE_PORTS, type WorktreeCardProps } from './worktree-card-model'
 import { getDeleteStateForWorktreeHost } from './worktree-delete-state-host-match'
+import { hasMultipleProjectGroupCatalogHosts } from '@/store/slices/project-group-owner-routing'
+import { getProjectGroupMenuHostLabel } from './project-group-menu-label'
 
 export function useWorktreeCardFoundation({
   worktree,
@@ -177,6 +179,12 @@ export function useWorktreeCardFoundation({
   const runtimeHostLabel = runtimeHostId
     ? (getHostDisplayLabelOverrides(settings).get(runtimeHostId) ?? runtimeEnvironmentName)
     : null
+  const showProjectGroupHostLabels = useAppStore((s) =>
+    hasMultipleProjectGroupCatalogHosts(s.repos ?? [])
+  )
+  const projectGroupHostLabel = repo
+    ? getProjectGroupMenuHostLabel(repo, showProjectGroupHostLabels, runtimeHostLabel)
+    : undefined
   // Why: runtime ("Orca server") hosts get the same disconnected dimming as SSH when their environment has no live status.
   const isRuntimeDisconnected = useAppStore((s) => {
     if (!runtimeOwnerEnvironmentId) {
@@ -224,6 +232,7 @@ export function useWorktreeCardFoundation({
     sshTargetRemoved,
     parsedRepoHost,
     runtimeHostLabel,
+    projectGroupHostLabel,
     isRuntimeDisconnected,
     titleRenaming,
     setTitleRenaming,

--- a/src/renderer/src/components/sidebar/use-worktree-card-foundation.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-card-foundation.ts
@@ -20,7 +20,7 @@ import {
 import { EMPTY_WORKSPACE_PORTS, type WorktreeCardProps } from './worktree-card-model'
 import { getDeleteStateForWorktreeHost } from './worktree-delete-state-host-match'
 import { hasMultipleProjectGroupCatalogHosts } from '@/store/slices/project-group-owner-routing'
-import { getProjectGroupMenuHostLabel } from './project-group-menu-label'
+import { getProjectGroupMenuHostLabelForWorktree } from './project-group-menu-label'
 import {
   filterReposForVisibleHosts,
   getVisibleSidebarHostIdSet
@@ -196,9 +196,12 @@ export function useWorktreeCardFoundation({
     )
     return hasMultipleProjectGroupCatalogHosts(visibleRepos)
   })
-  const projectGroupHostLabel = repo
-    ? getProjectGroupMenuHostLabel(repo, showProjectGroupHostLabels, runtimeHostLabel)
-    : undefined
+  const projectGroupHostLabel = getProjectGroupMenuHostLabelForWorktree(
+    worktree,
+    repo,
+    showProjectGroupHostLabels,
+    runtimeHostLabel
+  )
   // Why: runtime ("Orca server") hosts get the same disconnected dimming as SSH when their environment has no live status.
   const isRuntimeDisconnected = useAppStore((s) => {
     if (!runtimeOwnerEnvironmentId) {

--- a/src/renderer/src/components/sidebar/use-worktree-card-foundation.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-card-foundation.ts
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react'
 
 import { DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE } from '../../../../shared/constants'
 import {
+  getSettingsFocusedExecutionHostId,
   isRuntimeOwnedSshTargetId,
   parseExecutionHostId,
   toRuntimeExecutionHostId
@@ -20,6 +21,10 @@ import { EMPTY_WORKSPACE_PORTS, type WorktreeCardProps } from './worktree-card-m
 import { getDeleteStateForWorktreeHost } from './worktree-delete-state-host-match'
 import { hasMultipleProjectGroupCatalogHosts } from '@/store/slices/project-group-owner-routing'
 import { getProjectGroupMenuHostLabel } from './project-group-menu-label'
+import {
+  filterReposForVisibleHosts,
+  getVisibleSidebarHostIdSet
+} from './worktree-list/listing/host-filtering'
 
 export function useWorktreeCardFoundation({
   worktree,
@@ -179,9 +184,18 @@ export function useWorktreeCardFoundation({
   const runtimeHostLabel = runtimeHostId
     ? (getHostDisplayLabelOverrides(settings).get(runtimeHostId) ?? runtimeEnvironmentName)
     : null
-  const showProjectGroupHostLabels = useAppStore((s) =>
-    hasMultipleProjectGroupCatalogHosts(s.repos ?? [])
-  )
+  const showProjectGroupHostLabels = useAppStore((s) => {
+    const visibleHostIds = getVisibleSidebarHostIdSet(
+      s.visibleWorkspaceHostIds,
+      s.workspaceHostScope
+    )
+    const visibleRepos = filterReposForVisibleHosts(
+      s.repos ?? [],
+      visibleHostIds,
+      getSettingsFocusedExecutionHostId(s.settings)
+    )
+    return hasMultipleProjectGroupCatalogHosts(visibleRepos)
+  })
   const projectGroupHostLabel = repo
     ? getProjectGroupMenuHostLabel(repo, showProjectGroupHostLabels, runtimeHostLabel)
     : undefined

--- a/src/renderer/src/components/sidebar/use-worktree-card-foundation.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-card-foundation.ts
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useState } from 'react'
 
 import { DEFAULT_AGENT_ACTIVITY_DISPLAY_MODE } from '../../../../shared/constants'
 import {
-  getSettingsFocusedExecutionHostId,
   isRuntimeOwnedSshTargetId,
   parseExecutionHostId,
   toRuntimeExecutionHostId
@@ -19,12 +18,8 @@ import {
 } from '@/store/slices/runtime-environment-ssh'
 import { EMPTY_WORKSPACE_PORTS, type WorktreeCardProps } from './worktree-card-model'
 import { getDeleteStateForWorktreeHost } from './worktree-delete-state-host-match'
-import { hasMultipleProjectGroupCatalogHosts } from '@/store/slices/project-group-owner-routing'
 import { getProjectGroupMenuHostLabelForWorktree } from './project-group-menu-label'
-import {
-  filterReposForVisibleHosts,
-  getVisibleSidebarHostIdSet
-} from './worktree-list/listing/host-filtering'
+import { selectHasMultipleVisibleProjectGroupCatalogHosts } from './worktree-list/listing/project-group-catalog-visibility'
 
 export function useWorktreeCardFoundation({
   worktree,
@@ -184,18 +179,7 @@ export function useWorktreeCardFoundation({
   const runtimeHostLabel = runtimeHostId
     ? (getHostDisplayLabelOverrides(settings).get(runtimeHostId) ?? runtimeEnvironmentName)
     : null
-  const showProjectGroupHostLabels = useAppStore((s) => {
-    const visibleHostIds = getVisibleSidebarHostIdSet(
-      s.visibleWorkspaceHostIds,
-      s.workspaceHostScope
-    )
-    const visibleRepos = filterReposForVisibleHosts(
-      s.repos ?? [],
-      visibleHostIds,
-      getSettingsFocusedExecutionHostId(s.settings)
-    )
-    return hasMultipleProjectGroupCatalogHosts(visibleRepos)
-  })
+  const showProjectGroupHostLabels = useAppStore(selectHasMultipleVisibleProjectGroupCatalogHosts)
   const projectGroupHostLabel = getProjectGroupMenuHostLabelForWorktree(
     worktree,
     repo,

--- a/src/renderer/src/components/sidebar/use-worktree-context-menu-commands.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-context-menu-commands.ts
@@ -2,7 +2,6 @@ import { useCallback } from 'react'
 import type { useAppStore } from '@/store'
 import type { Repo } from '../../../../shared/repo-types'
 import type { WorkspaceStatusDefinition, Worktree } from '../../../../shared/worktree/types'
-import { getRepoExecutionHostId } from '../../../../shared/execution-host'
 import {
   createWorktreeContextMenuDeleteIntent,
   deferWorktreeContextMenuDeleteIntent
@@ -14,6 +13,11 @@ import {
   planWorkspaceStatusAssignment,
   preserveDeleteSiblingPosition
 } from './worktree-context-menu-policy'
+import {
+  createProjectGroupFromRepo,
+  moveProjectToGroupFromMenu,
+  removeProjectFromGroupFromMenu
+} from './project-group-menu-actions'
 
 export function useWorktreeContextMenuCommands(args: {
   activeContextWorktrees: readonly Worktree[]
@@ -71,11 +75,7 @@ export function useWorktreeContextMenuCommands(args: {
       if (!args.repo) {
         return
       }
-      const hostId = getRepoExecutionHostId(args.repo)
-      const group = await args.createProjectGroup(name, { hostId })
-      if (group) {
-        await args.moveProjectToGroup(args.repo.id, group.id, undefined, { hostId })
-      }
+      await createProjectGroupFromRepo(args.repo, name, args)
     },
     [args]
   )
@@ -84,17 +84,13 @@ export function useWorktreeContextMenuCommands(args: {
       if (!args.repo || args.repo.projectGroupId === groupId) {
         return
       }
-      void args.moveProjectToGroup(args.repo.id, groupId, undefined, {
-        hostId: getRepoExecutionHostId(args.repo)
-      })
+      void moveProjectToGroupFromMenu(args.repo, groupId, args.moveProjectToGroup)
     },
     [args]
   )
   const handleRemoveProjectFromGroup = useCallback(() => {
     if (args.repo) {
-      void args.moveProjectToGroup(args.repo.id, null, undefined, {
-        hostId: getRepoExecutionHostId(args.repo)
-      })
+      void removeProjectFromGroupFromMenu(args.repo, args.moveProjectToGroup)
     }
   }, [args])
   const handleAssignWorkspaceStatus = useCallback(

--- a/src/renderer/src/components/sidebar/use-worktree-context-menu-commands.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-context-menu-commands.ts
@@ -2,6 +2,7 @@ import { useCallback } from 'react'
 import type { useAppStore } from '@/store'
 import type { Repo } from '../../../../shared/repo-types'
 import type { WorkspaceStatusDefinition, Worktree } from '../../../../shared/worktree/types'
+import { getRepoExecutionHostId } from '../../../../shared/execution-host'
 import {
   createWorktreeContextMenuDeleteIntent,
   deferWorktreeContextMenuDeleteIntent
@@ -70,9 +71,10 @@ export function useWorktreeContextMenuCommands(args: {
       if (!args.repo) {
         return
       }
-      const group = await args.createProjectGroup(name)
+      const hostId = getRepoExecutionHostId(args.repo)
+      const group = await args.createProjectGroup(name, { hostId })
       if (group) {
-        await args.moveProjectToGroup(args.repo.id, group.id)
+        await args.moveProjectToGroup(args.repo.id, group.id, undefined, { hostId })
       }
     },
     [args]
@@ -82,13 +84,17 @@ export function useWorktreeContextMenuCommands(args: {
       if (!args.repo || args.repo.projectGroupId === groupId) {
         return
       }
-      void args.moveProjectToGroup(args.repo.id, groupId)
+      void args.moveProjectToGroup(args.repo.id, groupId, undefined, {
+        hostId: getRepoExecutionHostId(args.repo)
+      })
     },
     [args]
   )
   const handleRemoveProjectFromGroup = useCallback(() => {
     if (args.repo) {
-      void args.moveProjectToGroup(args.repo.id, null)
+      void args.moveProjectToGroup(args.repo.id, null, undefined, {
+        hostId: getRepoExecutionHostId(args.repo)
+      })
     }
   }, [args])
   const handleAssignWorkspaceStatus = useCallback(

--- a/src/renderer/src/components/sidebar/use-worktree-context-menu-model.tsx
+++ b/src/renderer/src/components/sidebar/use-worktree-context-menu-model.tsx
@@ -31,6 +31,7 @@ import {
 import { useWorktreeContextMenuCommands } from './use-worktree-context-menu-commands'
 import { useWorktreeParentPickerTransition } from './use-worktree-parent-picker-transition'
 import { useWorktreeContextMenuSecondaryActions } from './use-worktree-context-menu-secondary-actions'
+import { filterProjectGroupsForRepo } from '@/store/slices/project-group-owner-routing'
 
 export type WorktreeContextMenuProps = {
   worktree: Worktree
@@ -403,7 +404,7 @@ export function useWorktreeContextMenuModel({
     onContextMenuSelect,
     parentPicker,
     parentPickerOpen,
-    projectGroups,
+    projectGroups: repo ? filterProjectGroupsForRepo(projectGroups, repo) : [],
     ptyIdsByTabId,
     removesProject,
     repo,

--- a/src/renderer/src/components/sidebar/use-worktree-context-menu-model.tsx
+++ b/src/renderer/src/components/sidebar/use-worktree-context-menu-model.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useAppStore } from '@/store'
-import { useAllWorktrees, useRepoById, useRepoMap, useWorktreeMap } from '@/store/selectors'
+import { useAllWorktrees, useRepoForWorktree, useRepoMap, useWorktreeMap } from '@/store/selectors'
 import type { Worktree } from '../../../../shared/worktree/types'
 import {
   getCyclicProjectedWorktreeLineageIds,
@@ -63,7 +63,7 @@ export function useWorktreeContextMenuModel({
   const projectGroups = useAppStore((s) => s.projectGroups)
   const createProjectGroup = useAppStore((s) => s.createProjectGroup)
   const moveProjectToGroup = useAppStore((s) => s.moveProjectToGroup)
-  const repo = useRepoById(worktree.repoId)
+  const repo = useRepoForWorktree(worktree)
   const deleteState = useAppStore((s) =>
     getDeleteStateForWorktreeHost(worktree, s.deleteStateByWorktreeId)
   )

--- a/src/renderer/src/components/sidebar/use-worktree-context-menu-model.tsx
+++ b/src/renderer/src/components/sidebar/use-worktree-context-menu-model.tsx
@@ -32,22 +32,13 @@ import { useWorktreeContextMenuCommands } from './use-worktree-context-menu-comm
 import { useWorktreeParentPickerTransition } from './use-worktree-parent-picker-transition'
 import { useWorktreeContextMenuSecondaryActions } from './use-worktree-context-menu-secondary-actions'
 import { filterProjectGroupsForRepo } from '@/store/slices/project-group-owner-routing'
-
-export type WorktreeContextMenuProps = {
-  worktree: Worktree
-  children: React.ReactNode
-  contentClassName?: string
-  selectedWorktrees?: readonly Worktree[]
-  onContextMenuSelect?: (event: React.MouseEvent<HTMLElement>) => readonly Worktree[]
-  onAssignWorkspaceStatus?: (worktreeIds: readonly string[], status: string) => void
-  onOpenChange?: (open: boolean) => void
-  onLifecycleComplete?: () => void
-}
+import type { WorktreeContextMenuProps } from './worktree-context-menu-props'
 
 export function useWorktreeContextMenuModel({
   worktree,
   children,
   contentClassName,
+  projectGroupHostLabel,
   selectedWorktrees,
   onContextMenuSelect,
   onAssignWorkspaceStatus,
@@ -404,6 +395,7 @@ export function useWorktreeContextMenuModel({
     onContextMenuSelect,
     parentPicker,
     parentPickerOpen,
+    projectGroupHostLabel,
     projectGroups: repo ? filterProjectGroupsForRepo(projectGroups, repo) : [],
     ptyIdsByTabId,
     removesProject,

--- a/src/renderer/src/components/sidebar/worktree-card-surface.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-surface.tsx
@@ -29,6 +29,7 @@ export function WorktreeCardSurface({ card }: { card: WorktreeCardController }):
     titleRenaming,
     isDeleting,
     isRuntimeDisconnected,
+    projectGroupHostLabel,
     isQueuedForDeletion,
     deleteLabel,
     handleClick,
@@ -112,6 +113,7 @@ export function WorktreeCardSurface({ card }: { card: WorktreeCardController }):
       ) : (
         <WorktreeContextMenu
           worktree={worktree}
+          projectGroupHostLabel={projectGroupHostLabel}
           selectedWorktrees={selectedWorktrees}
           onContextMenuSelect={handleContextMenuSelect}
           onAssignWorkspaceStatus={onAssignWorkspaceStatus}

--- a/src/renderer/src/components/sidebar/worktree-context-menu-props.ts
+++ b/src/renderer/src/components/sidebar/worktree-context-menu-props.ts
@@ -1,0 +1,14 @@
+import type React from 'react'
+import type { Worktree } from '../../../../shared/worktree/types'
+
+export type WorktreeContextMenuProps = {
+  worktree: Worktree
+  children: React.ReactNode
+  contentClassName?: string
+  projectGroupHostLabel?: string | null
+  selectedWorktrees?: readonly Worktree[]
+  onContextMenuSelect?: (event: React.MouseEvent<HTMLElement>) => readonly Worktree[]
+  onAssignWorkspaceStatus?: (worktreeIds: readonly string[], status: string) => void
+  onOpenChange?: (open: boolean) => void
+  onLifecycleComplete?: () => void
+}

--- a/src/renderer/src/components/sidebar/worktree-list/drag/use-header-drag.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/drag/use-header-drag.ts
@@ -5,10 +5,7 @@ import { getProjectGroupHostId } from '@/store/slices/project-group-owner-routin
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import type { ProjectOrderBy } from '../../../../../../shared/ui-chrome-types'
 import type { Repo } from '../../../../../../shared/repo-types'
-import {
-  getRepoExecutionHostId,
-  type ExecutionHostId
-} from '../../../../../../shared/execution-host'
+import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 import type { HostHeaderRow, HostSectionRow } from '../../host-section-rows'
 import type { Row, WorktreeGroupBy } from '../grouping/row-types'
 import type { RenderRow } from '../listing/render-row'
@@ -160,16 +157,10 @@ export function useWorktreeSidebarHeaderDrag(args: {
     [sidebarProjectGroupHeaderIdsByBucket]
   )
   const commitProjectGroupOrder = useCallback(
-    (repoId: string, projectGroupId: string | null, order: number) => {
-      const repo = repoMap.get(repoId)
-      void moveProjectToGroup(
-        repoId,
-        projectGroupId,
-        order,
-        repo ? { hostId: getRepoExecutionHostId(repo) } : undefined
-      )
+    (repoId: string, projectGroupId: string | null, order: number, repoHostId: ExecutionHostId) => {
+      void moveProjectToGroup(repoId, projectGroupId, order, { hostId: repoHostId })
     },
-    [moveProjectToGroup, repoMap]
+    [moveProjectToGroup]
   )
   const commitProjectGroupHeaderOrder = useCallback(
     (groupId: string, tabOrder: number) => {

--- a/src/renderer/src/components/sidebar/worktree-list/drag/use-header-drag.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/drag/use-header-drag.ts
@@ -19,6 +19,7 @@ import { getSidebarOrderedRepoHeaderIdsByBucket } from '../../project-header-dro
 import { useProjectGroupHeaderDrag } from '../../project-group-header-drag'
 import { getSidebarOrderedProjectGroupHeaderIdsByBucket } from '../../project-group-header-drop'
 import { USER_SCROLL_MEASUREMENT_ADJUSTMENT_SUPPRESS_MS } from '../viewport/use-scroll-suppression'
+import { reportProjectGroupMoveFailure } from '../../project-group-menu-actions'
 
 export type WorktreeSidebarHeaderDrag = ReturnType<typeof useWorktreeSidebarHeaderDrag>
 
@@ -158,7 +159,13 @@ export function useWorktreeSidebarHeaderDrag(args: {
   )
   const commitProjectGroupOrder = useCallback(
     (repoId: string, projectGroupId: string | null, order: number, repoHostId: ExecutionHostId) => {
-      void moveProjectToGroup(repoId, projectGroupId, order, { hostId: repoHostId })
+      void moveProjectToGroup(repoId, projectGroupId, order, { hostId: repoHostId }).then(
+        (moved) => {
+          if (!moved) {
+            reportProjectGroupMoveFailure()
+          }
+        }
+      )
     },
     [moveProjectToGroup]
   )

--- a/src/renderer/src/components/sidebar/worktree-list/drag/use-header-drag.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/drag/use-header-drag.ts
@@ -5,7 +5,10 @@ import { getProjectGroupHostId } from '@/store/slices/project-group-owner-routin
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import type { ProjectOrderBy } from '../../../../../../shared/ui-chrome-types'
 import type { Repo } from '../../../../../../shared/repo-types'
-import type { ExecutionHostId } from '../../../../../../shared/execution-host'
+import {
+  getRepoExecutionHostId,
+  type ExecutionHostId
+} from '../../../../../../shared/execution-host'
 import type { HostHeaderRow, HostSectionRow } from '../../host-section-rows'
 import type { Row, WorktreeGroupBy } from '../grouping/row-types'
 import type { RenderRow } from '../listing/render-row'
@@ -158,9 +161,15 @@ export function useWorktreeSidebarHeaderDrag(args: {
   )
   const commitProjectGroupOrder = useCallback(
     (repoId: string, projectGroupId: string | null, order: number) => {
-      void moveProjectToGroup(repoId, projectGroupId, order)
+      const repo = repoMap.get(repoId)
+      void moveProjectToGroup(
+        repoId,
+        projectGroupId,
+        order,
+        repo ? { hostId: getRepoExecutionHostId(repo) } : undefined
+      )
     },
-    [moveProjectToGroup]
+    [moveProjectToGroup, repoMap]
   )
   const commitProjectGroupHeaderOrder = useCallback(
     (groupId: string, tabOrder: number) => {

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts
@@ -8,6 +8,7 @@ import { cloneDefaultWorkspaceStatuses } from '../../../../../../shared/workspac
 import type { AppState } from '../../../../store/types'
 import { LOCAL_EXECUTION_HOST_ID } from '../../../../../../shared/execution-host'
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
+import { hasMultipleProjectGroupCatalogHosts as detectMultipleProjectGroupCatalogHosts } from '@/store/slices/project-group-owner-routing'
 import { getWorktreeHostIdentity } from '../../../../../../shared/worktree/host-qualified-identity'
 import { getCyclicProjectedWorktreeLineageIds } from '../../worktree-lineage-projection'
 import { ALL_GROUP_KEY, ALL_GROUP_META } from './group-keys'
@@ -70,7 +71,10 @@ export function buildRows(
   folderWorkspaces: readonly FolderWorkspace[] = [],
   hostLabelById?: ReadonlyMap<string, string>,
   defaultHostId: ExecutionHostId = LOCAL_EXECUTION_HOST_ID,
-  pinnedDisplayPolicy: PinnedWorktreeDisplayPolicy = getPinnedWorktreeDisplayPolicy(settings)
+  pinnedDisplayPolicy: PinnedWorktreeDisplayPolicy = getPinnedWorktreeDisplayPolicy(settings),
+  hasMultipleProjectGroupCatalogHosts = detectMultipleProjectGroupCatalogHosts([
+    ...repoMap.values()
+  ])
 ): Row[] {
   const result: Row[] = []
   const projectIndex = buildProjectGroupingIndex(projectGrouping)
@@ -220,6 +224,7 @@ export function buildRows(
     repoMap,
     defaultHostId,
     hostLabelById,
+    hasMultipleProjectGroupCatalogHosts,
     projectIndex,
     importedWorktreesByRepo,
     newExternalWorktreesInboxByRepo,

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/group-sections.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/group-sections.ts
@@ -1,7 +1,11 @@
 import type { Repo } from '../../../../../../shared/repo-types'
 import type { WorktreeLineage } from '../../../../../../shared/worktree/lineage-types'
 import type { WorkspaceStatusDefinition, Worktree } from '../../../../../../shared/worktree/types'
-import type { ExecutionHostId } from '../../../../../../shared/execution-host'
+import {
+  getRepoExecutionHostId,
+  type ExecutionHostId
+} from '../../../../../../shared/execution-host'
+import { getProjectGroupMenuHostLabel } from '../../project-group-menu-label'
 import {
   getWorkspaceStatusFromGroupKey,
   getWorkspaceStatusVisualMeta
@@ -40,6 +44,7 @@ export type SectionAppendContext = {
   repoMap: Map<string, Repo>
   defaultHostId: ExecutionHostId
   hostLabelById: ReadonlyMap<string, string> | undefined
+  hasMultipleProjectGroupCatalogHosts: boolean
   projectIndex: ProjectGroupingIndex | null
   importedWorktreesByRepo: ReadonlyMap<string, ImportedWorktreesCardCandidate>
   newExternalWorktreesInboxByRepo: ReadonlyMap<string, NewExternalWorktreesInboxCandidate>
@@ -65,6 +70,7 @@ export function appendOrderedGroups(
     repoMap,
     defaultHostId,
     hostLabelById,
+    hasMultipleProjectGroupCatalogHosts,
     projectIndex,
     importedWorktreesByRepo,
     newExternalWorktreesInboxByRepo,
@@ -89,6 +95,13 @@ export function appendOrderedGroups(
             tone: PROJECT_GROUP_META.tone,
             icon: PROJECT_GROUP_META.icon,
             repo,
+            projectGroupHostLabel: repo
+              ? getProjectGroupMenuHostLabel(
+                  repo,
+                  hasMultipleProjectGroupCatalogHosts,
+                  hostLabelById?.get(getRepoExecutionHostId(repo))
+                )
+              : undefined,
             projectGroupDepth
           }
         : groupBy === 'workspace-status'

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/row-types.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/row-types.ts
@@ -22,6 +22,7 @@ export type GroupHeaderRow = {
   tone: string
   icon?: React.ComponentType<{ className?: string }>
   repo?: Repo
+  projectGroupHostLabel?: string
   projectGroup?: ProjectGroup | { id: null; name: 'Ungrouped'; tabOrder: number }
   projectGroupDepth?: number
   hostId?: ExecutionHostId

--- a/src/renderer/src/components/sidebar/worktree-list/listing/host-filtering.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/host-filtering.ts
@@ -1,5 +1,6 @@
 import {
   ALL_EXECUTION_HOSTS_SCOPE,
+  getRepoExecutionHostId,
   normalizeExecutionHostId,
   parseExecutionHostId,
   toSshExecutionHostId,
@@ -9,6 +10,7 @@ import {
 import type { FolderWorkspacePathStatusRequest } from '../../../../../../shared/folder-workspace-path-status'
 import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
+import type { Repo } from '../../../../../../shared/repo-types'
 
 /** null means "no host filter" — every host is visible. */
 export function getVisibleSidebarHostIdSet(
@@ -19,6 +21,21 @@ export function getVisibleSidebarHostIdSet(
     visibleWorkspaceHostIds ??
     (workspaceHostScope === ALL_EXECUTION_HOSTS_SCOPE ? null : [workspaceHostScope])
   return visibleHostIds ? new Set<ExecutionHostId>(visibleHostIds) : null
+}
+
+export function filterReposForVisibleHosts(
+  repos: readonly Repo[],
+  visibleHostIdSet: ReadonlySet<ExecutionHostId> | null,
+  defaultHostId: ExecutionHostId
+): readonly Repo[] {
+  if (!visibleHostIdSet) {
+    return repos
+  }
+  return repos.filter((repo) => {
+    const hostId =
+      repo.connectionId || repo.executionHostId ? getRepoExecutionHostId(repo) : defaultHostId
+    return visibleHostIdSet.has(hostId)
+  })
 }
 
 // Why shared: the sidebar render path and the Cmd+1–9 order must apply the same

--- a/src/renderer/src/components/sidebar/worktree-list/listing/project-group-catalog-visibility.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/project-group-catalog-visibility.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../../../shared/repo-types'
+import type { AppState } from '../../../../store/types'
+import {
+  resetProjectGroupCatalogVisibilityCacheForTest,
+  selectHasMultipleVisibleProjectGroupCatalogHosts
+} from './project-group-catalog-visibility'
+
+const localRepo = {
+  id: 'local',
+  path: '/tmp/local',
+  displayName: 'Local',
+  badgeColor: '#111',
+  addedAt: 1,
+  executionHostId: 'local'
+} as Repo
+const remoteRepo = {
+  ...localRepo,
+  id: 'remote',
+  path: '/tmp/remote',
+  displayName: 'Remote',
+  executionHostId: 'runtime:work'
+} as Repo
+
+function visibilityState(
+  repos: Repo[],
+  visibleWorkspaceHostIds: AppState['visibleWorkspaceHostIds']
+): Parameters<typeof selectHasMultipleVisibleProjectGroupCatalogHosts>[0] {
+  return {
+    repos,
+    settings: null,
+    visibleWorkspaceHostIds,
+    workspaceHostScope: 'all'
+  }
+}
+
+describe('visible project group catalog selector', () => {
+  beforeEach(() => {
+    resetProjectGroupCatalogVisibilityCacheForTest()
+  })
+
+  it('uses only catalogs in the visible host scope', () => {
+    const repos = [localRepo, remoteRepo]
+
+    expect(selectHasMultipleVisibleProjectGroupCatalogHosts(visibilityState(repos, null))).toBe(
+      true
+    )
+    expect(
+      selectHasMultipleVisibleProjectGroupCatalogHosts(visibilityState(repos, ['local']))
+    ).toBe(false)
+  })
+
+  it('scans the catalog once while relevant state is unchanged', () => {
+    const repos = [localRepo, remoteRepo]
+    const filter = vi.spyOn(repos, 'filter')
+    const visibleWorkspaceHostIds: AppState['visibleWorkspaceHostIds'] = ['local']
+    const state = visibilityState(repos, visibleWorkspaceHostIds)
+
+    expect(selectHasMultipleVisibleProjectGroupCatalogHosts(state)).toBe(false)
+    expect(selectHasMultipleVisibleProjectGroupCatalogHosts({ ...state })).toBe(false)
+
+    expect(filter).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps partial component stores on the single-catalog default', () => {
+    expect(selectHasMultipleVisibleProjectGroupCatalogHosts({ settings: null })).toBe(false)
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list/listing/project-group-catalog-visibility.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/project-group-catalog-visibility.ts
@@ -1,0 +1,57 @@
+import {
+  ALL_EXECUTION_HOSTS_SCOPE,
+  getSettingsFocusedExecutionHostId,
+  type ExecutionHostId
+} from '../../../../../../shared/execution-host'
+import type { AppState } from '../../../../store/types'
+import { hasMultipleProjectGroupCatalogHosts } from '../../../../store/slices/project-group-owner-routing'
+import { filterReposForVisibleHosts, getVisibleSidebarHostIdSet } from './host-filtering'
+
+type ProjectGroupCatalogVisibilityState = Partial<
+  Pick<AppState, 'repos' | 'settings' | 'visibleWorkspaceHostIds' | 'workspaceHostScope'>
+>
+
+type ProjectGroupCatalogVisibilityCache = {
+  repos: AppState['repos']
+  visibleWorkspaceHostIds: AppState['visibleWorkspaceHostIds']
+  workspaceHostScope: AppState['workspaceHostScope']
+  focusedHostId: ExecutionHostId
+  result: boolean
+}
+
+const EMPTY_REPOS: AppState['repos'] = []
+let cache: ProjectGroupCatalogVisibilityCache | null = null
+
+export function selectHasMultipleVisibleProjectGroupCatalogHosts(
+  state: ProjectGroupCatalogVisibilityState
+): boolean {
+  const repos = state.repos ?? EMPTY_REPOS
+  const visibleWorkspaceHostIds = state.visibleWorkspaceHostIds ?? null
+  const workspaceHostScope = state.workspaceHostScope ?? ALL_EXECUTION_HOSTS_SCOPE
+  const focusedHostId = getSettingsFocusedExecutionHostId(state.settings)
+  if (
+    cache &&
+    cache.repos === repos &&
+    cache.visibleWorkspaceHostIds === visibleWorkspaceHostIds &&
+    cache.workspaceHostScope === workspaceHostScope &&
+    cache.focusedHostId === focusedHostId
+  ) {
+    return cache.result
+  }
+
+  const visibleHostIds = getVisibleSidebarHostIdSet(visibleWorkspaceHostIds, workspaceHostScope)
+  const visibleRepos = filterReposForVisibleHosts(repos, visibleHostIds, focusedHostId)
+  const result = hasMultipleProjectGroupCatalogHosts(visibleRepos)
+  cache = {
+    repos,
+    visibleWorkspaceHostIds,
+    workspaceHostScope,
+    focusedHostId,
+    result
+  }
+  return result
+}
+
+export function resetProjectGroupCatalogVisibilityCacheForTest(): void {
+  cache = null
+}

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-host-visible-scope.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-host-visible-scope.ts
@@ -2,15 +2,13 @@ import { useMemo } from 'react'
 import type { FolderWorkspace } from '../../../../../../shared/folder-workspace-types'
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import type { Repo } from '../../../../../../shared/repo-types'
-import {
-  getRepoExecutionHostId,
-  type ExecutionHostId
-} from '../../../../../../shared/execution-host'
+import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 import type { SidebarWorktreeFilters } from './use-filters'
 import { filterFolderWorkspacesFromOtherDevices } from '../../workspace-creator-visibility'
 import {
   filterFolderWorkspacesForVisibleHosts,
   filterProjectGroupsForVisibleHosts,
+  filterReposForVisibleHosts,
   getVisibleSidebarHostIdSet
 } from './host-filtering'
 
@@ -31,16 +29,10 @@ export function useSidebarHostVisibleScope(args: {
     () => getVisibleSidebarHostIdSet(visibleWorkspaceHostIds, workspaceHostScope),
     [visibleWorkspaceHostIds, workspaceHostScope]
   )
-  const visibleReposForRows = useMemo(() => {
-    if (!visibleHostIdSet) {
-      return repos
-    }
-    return repos.filter((repo) => {
-      const hostId =
-        repo.connectionId || repo.executionHostId ? getRepoExecutionHostId(repo) : defaultHostId
-      return visibleHostIdSet.has(hostId)
-    })
-  }, [defaultHostId, repos, visibleHostIdSet])
+  const visibleReposForRows = useMemo(
+    () => filterReposForVisibleHosts(repos, visibleHostIdSet, defaultHostId),
+    [defaultHostId, repos, visibleHostIdSet]
+  )
   const visibleProjectGroupsForRows = useMemo(
     () => filterProjectGroupsForVisibleHosts(projectGroups, visibleHostIdSet, defaultHostId),
     [defaultHostId, projectGroups, visibleHostIdSet]

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-section-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-section-rows.ts
@@ -20,7 +20,7 @@ import { addHostSectionRows } from '../../host-section-rows'
 import { orderHostSectionOptions } from '../../host-section-order'
 import { buildSidebarHostOptions } from '../../sidebar-host-options'
 import { selectPendingWorktreeCreationKeys } from './pending-worktree-creation-keys'
-import { hasMultipleProjectGroupCatalogHosts } from '@/store/slices/project-group-owner-routing'
+import { selectHasMultipleVisibleProjectGroupCatalogHosts } from './project-group-catalog-visibility'
 
 type SectionRowsArgs = {
   groupBy: WorktreeGroupBy
@@ -141,10 +141,7 @@ export function useSidebarSectionRows(args: SectionRowsArgs) {
     () => new Map(hostOptions.map((host) => [host.id, host.label])),
     [hostOptions]
   )
-  const showProjectGroupHostLabels = useMemo(
-    () => hasMultipleProjectGroupCatalogHosts(args.visibleReposForRows),
-    [args.visibleReposForRows]
-  )
+  const showProjectGroupHostLabels = useAppStore(selectHasMultipleVisibleProjectGroupCatalogHosts)
 
   const rows: Row[] = useMemo(
     () =>

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-section-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-section-rows.ts
@@ -20,6 +20,7 @@ import { addHostSectionRows } from '../../host-section-rows'
 import { orderHostSectionOptions } from '../../host-section-order'
 import { buildSidebarHostOptions } from '../../sidebar-host-options'
 import { selectPendingWorktreeCreationKeys } from './pending-worktree-creation-keys'
+import { hasMultipleProjectGroupCatalogHosts } from '@/store/slices/project-group-owner-routing'
 
 type SectionRowsArgs = {
   groupBy: WorktreeGroupBy
@@ -140,6 +141,10 @@ export function useSidebarSectionRows(args: SectionRowsArgs) {
     () => new Map(hostOptions.map((host) => [host.id, host.label])),
     [hostOptions]
   )
+  const showProjectGroupHostLabels = useMemo(
+    () => hasMultipleProjectGroupCatalogHosts(repos),
+    [repos]
+  )
 
   const rows: Row[] = useMemo(
     () =>
@@ -165,7 +170,8 @@ export function useSidebarSectionRows(args: SectionRowsArgs) {
         args.visibleFolderWorkspacesForRows,
         hostLabelById,
         defaultHostId,
-        args.pinnedDisplayPolicy
+        args.pinnedDisplayPolicy,
+        showProjectGroupHostLabels
       ),
     [
       args.groupBy,
@@ -188,6 +194,7 @@ export function useSidebarSectionRows(args: SectionRowsArgs) {
       args.newExternalWorktreesInboxByRepo,
       pendingCreations,
       hostLabelById,
+      showProjectGroupHostLabels,
       args.pinnedDisplayPolicy
     ]
   )

--- a/src/renderer/src/components/sidebar/worktree-list/listing/use-section-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/listing/use-section-rows.ts
@@ -142,8 +142,8 @@ export function useSidebarSectionRows(args: SectionRowsArgs) {
     [hostOptions]
   )
   const showProjectGroupHostLabels = useMemo(
-    () => hasMultipleProjectGroupCatalogHosts(repos),
-    [repos]
+    () => hasMultipleProjectGroupCatalogHosts(args.visibleReposForRows),
+    [args.visibleReposForRows]
   )
 
   const rows: Row[] = useMemo(

--- a/src/renderer/src/components/sidebar/worktree-list/rows/SectionHeader.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/SectionHeader.tsx
@@ -384,6 +384,7 @@ export function renderWorktreeSectionHeaderRow(args: {
             <RepoHeaderProjectActionsMenu
               repo={row.repo}
               label={row.label}
+              projectGroupHostLabel={row.projectGroupHostLabel}
               projectGroups={ctx.projectGroups}
               actions={ctx.projectActions}
             />

--- a/src/renderer/src/components/sidebar/worktree-list/rows/SectionHeader.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/SectionHeader.tsx
@@ -88,9 +88,10 @@ export function renderWorktreeSectionHeaderRow(args: {
 }): React.JSX.Element {
   const { ctx, row, vItem, isActiveStickyHeader } = args
   const { headerDrag } = ctx
-  const isRepoHeader = ctx.groupBy === 'repo' && row.repo !== undefined
+  const repoForHeader = ctx.groupBy === 'repo' ? row.repo : undefined
+  const isRepoHeader = repoForHeader !== undefined
   const isProjectGroupHeader = ctx.groupBy === 'repo' && row.projectGroup !== undefined
-  const projectIdForHeader = isRepoHeader ? row.repo!.id : undefined
+  const projectIdForHeader = repoForHeader?.id
   const projectGroupIdForHeader =
     isProjectGroupHeader && !row.repo && typeof row.projectGroup?.id === 'string'
       ? row.projectGroup.id
@@ -273,8 +274,8 @@ export function renderWorktreeSectionHeaderRow(args: {
             : undefined
         }
         onPointerDown={
-          isDraggableRepoHeader && projectIdForHeader
-            ? (event) => headerDrag.repoDrag.onHandlePointerDown(event, projectIdForHeader)
+          isDraggableRepoHeader && repoForHeader
+            ? (event) => headerDrag.repoDrag.onHandlePointerDown(event, repoForHeader)
             : isDraggableProjectGroupHeader && projectGroupIdForHeader
               ? (event) =>
                   headerDrag.projectGroupDrag.onHandlePointerDown(event, projectGroupIdForHeader)

--- a/src/renderer/src/components/sidebar/worktree-list/rows/repo-header-project-actions.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/repo-header-project-actions.test.tsx
@@ -35,7 +35,9 @@ vi.mock('lucide-react', async () =>
 
 vi.mock('@/i18n/i18n', () => ({
   translate: (_key: string, fallback: string, values?: Record<string, unknown>) =>
-    fallback.replace('{{value0}}', String(values?.value0 ?? ''))
+    fallback
+      .replace('{{hostLabel}}', String(values?.hostLabel ?? ''))
+      .replace('{{value0}}', String(values?.value0 ?? ''))
 }))
 
 const { RepoHeaderProjectActionsMenu } = await import('./repo-header-project-actions')

--- a/src/renderer/src/components/sidebar/worktree-list/rows/repo-header-project-actions.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/repo-header-project-actions.test.tsx
@@ -1,0 +1,156 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import type { ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import type { ProjectGroup } from '../../../../../../shared/project-group-types'
+import type { Repo } from '../../../../../../shared/repo-types'
+import type { ExecutionHostId } from '../../../../../../shared/execution-host'
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children }: { children?: ReactNode }) => <button>{children}</button>
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children?: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/components/ui/dropdown-menu', () => {
+  const Passthrough = ({ children }: { children?: ReactNode }) => <>{children}</>
+  return {
+    DropdownMenu: Passthrough,
+    DropdownMenuContent: Passthrough,
+    DropdownMenuItem: Passthrough,
+    DropdownMenuSeparator: () => null,
+    DropdownMenuSub: Passthrough,
+    DropdownMenuSubContent: Passthrough,
+    DropdownMenuSubTrigger: Passthrough,
+    DropdownMenuTrigger: Passthrough
+  }
+})
+
+vi.mock('lucide-react', async () =>
+  (await import('../../../tab-bar/lucide-icon-stub-fixture')).stubEveryIcon()
+)
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string, values?: Record<string, unknown>) =>
+    fallback.replace('{{value0}}', String(values?.value0 ?? ''))
+}))
+
+const { RepoHeaderProjectActionsMenu } = await import('./repo-header-project-actions')
+const { getProjectGroupMenuHostLabel } = await import('../../project-group-menu-label')
+
+const repo: Repo = {
+  id: 'tooling',
+  path: '/work/tooling',
+  displayName: 'tooling',
+  badgeColor: '#111',
+  addedAt: 1,
+  executionHostId: 'runtime:work'
+}
+
+function group(id: string, name: string, executionHostId: ExecutionHostId): ProjectGroup {
+  return {
+    id,
+    name,
+    parentPath: null,
+    parentGroupId: null,
+    createdFrom: 'manual',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1,
+    executionHostId
+  }
+}
+
+function actions() {
+  return {
+    getWorktreeVisibilityDefaults: vi.fn(),
+    onOpenRepoSettings: vi.fn(),
+    onOpenWorktreeVisibility: vi.fn(),
+    onCreateGroupFromRepo: vi.fn(),
+    onMoveProjectToGroup: vi.fn(),
+    onRemoveProjectFromGroup: vi.fn(),
+    onRemoveProject: vi.fn(),
+    onCreateForRepo: vi.fn()
+  }
+}
+
+describe('repository project-group menu host context', () => {
+  it('names the owning Orca remote and excludes groups from another remote', () => {
+    const projectGroups = [
+      group('work-group', 'Work Group', 'runtime:work'),
+      group('home-group', 'Home Group', 'runtime:home')
+    ]
+    const markup = renderToStaticMarkup(
+      <RepoHeaderProjectActionsMenu
+        repo={repo}
+        label="tooling"
+        projectGroupHostLabel={getProjectGroupMenuHostLabel(repo, true, 'Work')}
+        projectGroups={projectGroups}
+        actions={actions()}
+      />
+    )
+
+    expect(markup).toContain('Move to group: Work')
+    expect(markup).toContain('Work Group')
+    expect(markup).not.toContain('Home Group')
+  })
+
+  it('keeps the generic label for local projects', () => {
+    const localRepo = { ...repo, executionHostId: 'local' as const }
+    const projectGroups = [group('local-group', 'Local Group', 'local')]
+    const markup = renderToStaticMarkup(
+      <RepoHeaderProjectActionsMenu
+        repo={localRepo}
+        label="tooling"
+        projectGroupHostLabel={getProjectGroupMenuHostLabel(localRepo, false)}
+        projectGroups={projectGroups}
+        actions={actions()}
+      />
+    )
+
+    expect(markup).toContain('Move to group')
+    expect(markup).not.toContain('Move to group:')
+  })
+
+  it('names the local catalog when local and remote groups coexist', () => {
+    const localRepo = { ...repo, executionHostId: 'local' as const }
+    const projectGroups = [
+      group('local-group', 'Local Group', 'local'),
+      group('work-group', 'Work Group', 'runtime:work')
+    ]
+    const markup = renderToStaticMarkup(
+      <RepoHeaderProjectActionsMenu
+        repo={localRepo}
+        label="tooling"
+        projectGroupHostLabel={getProjectGroupMenuHostLabel(localRepo, true)}
+        projectGroups={projectGroups}
+        actions={actions()}
+      />
+    )
+
+    expect(markup).toContain('Move to group: Local')
+    expect(markup).toContain('Local Group')
+    expect(markup).not.toContain('Work Group')
+  })
+
+  it('keeps the generic label when only one remote catalog exists', () => {
+    const projectGroups = [group('work-group', 'Work Group', 'runtime:work')]
+    const markup = renderToStaticMarkup(
+      <RepoHeaderProjectActionsMenu
+        repo={repo}
+        label="tooling"
+        projectGroupHostLabel={getProjectGroupMenuHostLabel(repo, false, 'Work')}
+        projectGroups={projectGroups}
+        actions={actions()}
+      />
+    )
+
+    expect(markup).toContain('Move to group')
+    expect(markup).not.toContain('Move to group:')
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-list/rows/repo-header-project-actions.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/repo-header-project-actions.tsx
@@ -44,6 +44,7 @@ import {
   stopRepoHeaderMenuEvent
 } from './header-event-guards'
 import { filterProjectGroupsForRepo } from '@/store/slices/project-group-owner-routing'
+import { getMoveToGroupMenuLabel } from '../../project-group-menu-label'
 
 function getWorktreeVisibilityMenuLabel(
   repo: Repo,
@@ -71,11 +72,13 @@ export type RepoHeaderProjectActions = {
 export function RepoHeaderProjectActionsMenu({
   repo,
   label,
+  projectGroupHostLabel,
   projectGroups,
   actions
 }: {
   repo: Repo
   label: string
+  projectGroupHostLabel?: string
   projectGroups: readonly ProjectGroup[]
   actions: RepoHeaderProjectActions
 }): React.JSX.Element {
@@ -144,7 +147,7 @@ export function RepoHeaderProjectActionsMenu({
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>
               <FolderInput className="size-3.5" />
-              {translate('auto.components.sidebar.WorktreeList.4a08fb55f2', 'Move to group')}
+              {getMoveToGroupMenuLabel(projectGroupHostLabel)}
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent>
               {compatibleProjectGroups.map((group) => (

--- a/src/renderer/src/components/sidebar/worktree-list/rows/repo-header-project-actions.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/repo-header-project-actions.tsx
@@ -43,6 +43,7 @@ import {
   stopRepoHeaderKeyboardToggle,
   stopRepoHeaderMenuEvent
 } from './header-event-guards'
+import { filterProjectGroupsForRepo } from '@/store/slices/project-group-owner-routing'
 
 function getWorktreeVisibilityMenuLabel(
   repo: Repo,
@@ -78,6 +79,7 @@ export function RepoHeaderProjectActionsMenu({
   projectGroups: readonly ProjectGroup[]
   actions: RepoHeaderProjectActions
 }): React.JSX.Element {
+  const compatibleProjectGroups = filterProjectGroupsForRepo(projectGroups, repo)
   return (
     <DropdownMenu modal={false}>
       <Tooltip>
@@ -138,14 +140,14 @@ export function RepoHeaderProjectActionsMenu({
           <FolderPlus className="size-3.5" />
           {translate('auto.components.sidebar.WorktreeList.cbfd565f83', 'New group from project')}
         </DropdownMenuItem>
-        {projectGroups.length > 0 ? (
+        {compatibleProjectGroups.length > 0 ? (
           <DropdownMenuSub>
             <DropdownMenuSubTrigger>
               <FolderInput className="size-3.5" />
               {translate('auto.components.sidebar.WorktreeList.4a08fb55f2', 'Move to group')}
             </DropdownMenuSubTrigger>
             <DropdownMenuSubContent>
-              {projectGroups.map((group) => (
+              {compatibleProjectGroups.map((group) => (
                 <DropdownMenuItem
                   key={group.id}
                   disabled={repo.projectGroupId === group.id}

--- a/src/renderer/src/components/sidebar/worktree-list/rows/use-project-group-dialogs-owner-host.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/use-project-group-dialogs-owner-host.test.tsx
@@ -77,6 +77,7 @@ async function renderHookProbe(): Promise<void> {
 beforeEach(() => {
   vi.clearAllMocks()
   mocks.createProjectGroup.mockResolvedValue(remoteGroup)
+  mocks.moveProjectToGroup.mockResolvedValue(true)
   mocks.updateProjectGroup.mockResolvedValue(true)
   mocks.deleteProjectGroupWithContainedProjects.mockResolvedValue({
     status: 'deleted-group',
@@ -117,6 +118,67 @@ describe('project group dialogs carry the owner host', () => {
         hostId: 'runtime:env-1'
       }
     )
+  })
+
+  it('reports when the owner host does not confirm group creation', async () => {
+    mocks.createProjectGroup.mockResolvedValue(null)
+    await renderHookProbe()
+    await act(async () => {
+      latest!.handleCreateGroupFromRepo(remoteRepo)
+    })
+    await act(async () => {
+      await latest!.handleSubmitProjectGroupName('Flute')
+    })
+
+    expect(mocks.moveProjectToGroup).not.toHaveBeenCalled()
+    expect(mocks.toastError).toHaveBeenCalledWith('Failed to create group', {
+      description:
+        "Orca could not confirm the new group with the project's host. Check the connection and try again."
+    })
+  })
+
+  it('reports when the group is created but the initial move is not confirmed', async () => {
+    mocks.moveProjectToGroup.mockResolvedValue(false)
+    await renderHookProbe()
+    await act(async () => {
+      latest!.handleCreateGroupFromRepo(remoteRepo)
+    })
+    await act(async () => {
+      await latest!.handleSubmitProjectGroupName('Flute')
+    })
+
+    expect(mocks.toastError).toHaveBeenCalledWith('Group created, but move was not confirmed', {
+      description:
+        "Orca could not confirm the move with the project's host. Recheck the project after reconnecting."
+    })
+  })
+
+  it('reports when a move is not confirmed by the owner host', async () => {
+    mocks.moveProjectToGroup.mockResolvedValue(false)
+    await renderHookProbe()
+    await act(async () => {
+      latest!.handleMoveProjectToGroup(remoteRepo, remoteGroup.id)
+      await Promise.resolve()
+    })
+
+    expect(mocks.toastError).toHaveBeenCalledWith('Failed to move project', {
+      description:
+        "Orca could not confirm the move with the project's host. Recheck the project after reconnecting."
+    })
+  })
+
+  it('reports when removing a project from its group is not confirmed', async () => {
+    mocks.moveProjectToGroup.mockResolvedValue(false)
+    await renderHookProbe()
+    await act(async () => {
+      latest!.handleRemoveProjectFromGroup(remoteRepo)
+      await Promise.resolve()
+    })
+
+    expect(mocks.toastError).toHaveBeenCalledWith('Failed to remove project from group', {
+      description:
+        "Orca could not confirm the change with the project's host. Recheck the project after reconnecting."
+    })
   })
 
   it('renames through the host that owns the group row', async () => {

--- a/src/renderer/src/components/sidebar/worktree-list/rows/use-project-group-dialogs-owner-host.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/use-project-group-dialogs-owner-host.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useProjectGroupDialogs, type ProjectGroupDialogs } from './use-project-group-dialogs'
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
+import type { Repo } from '../../../../../../shared/repo-types'
 
 const mocks = vi.hoisted(() => ({
   moveProjectToGroup: vi.fn(),
@@ -42,6 +43,15 @@ const remoteGroup: ProjectGroup = {
   updatedAt: 1
 }
 
+const remoteRepo: Repo = {
+  id: 'repo-1',
+  path: '/srv/repo',
+  displayName: 'Repo',
+  badgeColor: '#111',
+  addedAt: 1,
+  executionHostId: 'runtime:env-1'
+}
+
 let latest: ProjectGroupDialogs | null = null
 const roots: Root[] = []
 
@@ -66,6 +76,7 @@ async function renderHookProbe(): Promise<void> {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mocks.createProjectGroup.mockResolvedValue(remoteGroup)
   mocks.updateProjectGroup.mockResolvedValue(true)
   mocks.deleteProjectGroupWithContainedProjects.mockResolvedValue({
     status: 'deleted-group',
@@ -86,6 +97,28 @@ afterEach(async () => {
 })
 
 describe('project group dialogs carry the owner host', () => {
+  it('creates a group through the paired repo owner', async () => {
+    await renderHookProbe()
+    await act(async () => {
+      latest!.handleCreateGroupFromRepo(remoteRepo)
+    })
+    await act(async () => {
+      await latest!.handleSubmitProjectGroupName('Flute')
+    })
+
+    expect(mocks.createProjectGroup).toHaveBeenCalledWith('Flute', {
+      hostId: 'runtime:env-1'
+    })
+    expect(mocks.moveProjectToGroup).toHaveBeenCalledWith(
+      remoteRepo.id,
+      remoteGroup.id,
+      undefined,
+      {
+        hostId: 'runtime:env-1'
+      }
+    )
+  })
+
   it('renames through the host that owns the group row', async () => {
     await renderHookProbe()
     await act(async () => {

--- a/src/renderer/src/components/sidebar/worktree-list/rows/use-project-group-dialogs.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/use-project-group-dialogs.ts
@@ -5,7 +5,10 @@ import { translate } from '@/i18n/i18n'
 import { selectProjectGroupRemovalTargets } from '@/store/slices/project-group-removal-targets'
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import type { Repo } from '../../../../../../shared/repo-types'
-import type { ExecutionHostId } from '../../../../../../shared/execution-host'
+import {
+  getRepoExecutionHostId,
+  type ExecutionHostId
+} from '../../../../../../shared/execution-host'
 
 export type ProjectGroupNameDialogState =
   | { type: 'create-from-repo'; repo: Repo }
@@ -86,14 +89,18 @@ export function useProjectGroupDialogs(args: {
       if (repo.projectGroupId === groupId) {
         return
       }
-      void moveProjectToGroup(repo.id, groupId)
+      void moveProjectToGroup(repo.id, groupId, undefined, {
+        hostId: getRepoExecutionHostId(repo)
+      })
     },
     [moveProjectToGroup]
   )
 
   const handleRemoveProjectFromGroup = useCallback(
     (repo: Repo) => {
-      void moveProjectToGroup(repo.id, null)
+      void moveProjectToGroup(repo.id, null, undefined, {
+        hostId: getRepoExecutionHostId(repo)
+      })
     },
     [moveProjectToGroup]
   )
@@ -111,9 +118,13 @@ export function useProjectGroupDialogs(args: {
         return
       }
       if (nameDialog.type === 'create-from-repo') {
-        const group = await createProjectGroup(name)
+        const group = await createProjectGroup(name, {
+          hostId: getRepoExecutionHostId(nameDialog.repo)
+        })
         if (group) {
-          await moveProjectToGroup(nameDialog.repo.id, group.id)
+          await moveProjectToGroup(nameDialog.repo.id, group.id, undefined, {
+            hostId: getRepoExecutionHostId(nameDialog.repo)
+          })
         }
         return
       }

--- a/src/renderer/src/components/sidebar/worktree-list/rows/use-project-group-dialogs.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/rows/use-project-group-dialogs.ts
@@ -5,10 +5,12 @@ import { translate } from '@/i18n/i18n'
 import { selectProjectGroupRemovalTargets } from '@/store/slices/project-group-removal-targets'
 import type { ProjectGroup } from '../../../../../../shared/project-group-types'
 import type { Repo } from '../../../../../../shared/repo-types'
+import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 import {
-  getRepoExecutionHostId,
-  type ExecutionHostId
-} from '../../../../../../shared/execution-host'
+  createProjectGroupFromRepo,
+  moveProjectToGroupFromMenu,
+  removeProjectFromGroupFromMenu
+} from '../../project-group-menu-actions'
 
 export type ProjectGroupNameDialogState =
   | { type: 'create-from-repo'; repo: Repo }
@@ -89,18 +91,14 @@ export function useProjectGroupDialogs(args: {
       if (repo.projectGroupId === groupId) {
         return
       }
-      void moveProjectToGroup(repo.id, groupId, undefined, {
-        hostId: getRepoExecutionHostId(repo)
-      })
+      void moveProjectToGroupFromMenu(repo, groupId, moveProjectToGroup)
     },
     [moveProjectToGroup]
   )
 
   const handleRemoveProjectFromGroup = useCallback(
     (repo: Repo) => {
-      void moveProjectToGroup(repo.id, null, undefined, {
-        hostId: getRepoExecutionHostId(repo)
-      })
+      void removeProjectFromGroupFromMenu(repo, moveProjectToGroup)
     },
     [moveProjectToGroup]
   )
@@ -118,14 +116,10 @@ export function useProjectGroupDialogs(args: {
         return
       }
       if (nameDialog.type === 'create-from-repo') {
-        const group = await createProjectGroup(name, {
-          hostId: getRepoExecutionHostId(nameDialog.repo)
+        await createProjectGroupFromRepo(nameDialog.repo, name, {
+          createProjectGroup,
+          moveProjectToGroup
         })
-        if (group) {
-          await moveProjectToGroup(nameDialog.repo.id, group.id, undefined, {
-            hostId: getRepoExecutionHostId(nameDialog.repo)
-          })
-        }
         return
       }
       const renamed = await updateProjectGroup(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6279,9 +6279,9 @@
           "retained": "Existing worktrees are kept until a scan succeeds. Click to retry."
         },
         "project-group-menu-label": {
-          "4a08fb55f2": "Move to group",
-          "16bc925de6": "Move to group: {{value0}}",
-          "local": "Local"
+          "local": "Local",
+          "moveToGroup": "Move to group",
+          "moveToGroupForHost": "Move to group: {{hostLabel}}"
         },
         "project-group-menu-actions": {
           "createFailed": "Failed to create group",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6282,6 +6282,15 @@
           "4a08fb55f2": "Move to group",
           "16bc925de6": "Move to group: {{value0}}",
           "local": "Local"
+        },
+        "project-group-menu-actions": {
+          "createFailed": "Failed to create group",
+          "createFailedDescription": "Orca could not confirm the new group with the project's host. Check the connection and try again.",
+          "initialMoveUnconfirmed": "Group created, but move was not confirmed",
+          "moveFailed": "Failed to move project",
+          "moveUnconfirmedDescription": "Orca could not confirm the move with the project's host. Recheck the project after reconnecting.",
+          "removeFailed": "Failed to remove project from group",
+          "removeFailedDescription": "Orca could not confirm the change with the project's host. Recheck the project after reconnecting."
         }
       },
       "shared": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6277,6 +6277,11 @@
           "title": "Worktree scan failed for {{value0}}",
           "retry": "Retry scan",
           "retained": "Existing worktrees are kept until a scan succeeds. Click to retry."
+        },
+        "project-group-menu-label": {
+          "4a08fb55f2": "Move to group",
+          "16bc925de6": "Move to group: {{value0}}",
+          "local": "Local"
         }
       },
       "shared": {

--- a/src/renderer/src/store/project-groups/project-group-mutations.ts
+++ b/src/renderer/src/store/project-groups/project-group-mutations.ts
@@ -6,6 +6,7 @@ import { selectProjectGroupRemovalTargets } from '../slices/project-group-remova
 import {
   catalogOwnsHost,
   filterProjectGroupsForRepo,
+  getProjectGroupCatalogHostId,
   getProjectGroupHostId,
   projectGroupMatchesOwnerHost,
   resolveProjectGroupOwnerHostId,
@@ -20,6 +21,30 @@ import { applyProjectGroupDeleteCascade } from './project-group-removal-state'
 import { repoWithFetchedOwner, settingsForRepoOwner } from '../repos/owner-routing'
 import { projectGroupWithFetchedOwner } from './project-group-owner-stamping'
 import { getProjectSetupRuntimeTarget } from '../projects/project-host-routing'
+import { claimHostCatalogFence } from '../host-catalog-fencing'
+
+function upsertProjectGroupForOwner(
+  projectGroups: readonly ProjectGroup[],
+  ownedGroup: ProjectGroup
+): ProjectGroup[] {
+  const ownerHostId = getProjectGroupCatalogHostId(getProjectGroupHostId(ownedGroup))
+  let inserted = false
+  const next: ProjectGroup[] = []
+  for (const group of projectGroups) {
+    if (projectGroupMatchesOwnerHost(group, ownedGroup.id, ownerHostId)) {
+      if (!inserted) {
+        next.push(ownedGroup)
+        inserted = true
+      }
+    } else {
+      next.push(group)
+    }
+  }
+  if (!inserted) {
+    next.push(ownedGroup)
+  }
+  return next
+}
 
 export function createProjectGroupMutationActions(
   set: Parameters<StateCreator<AppState>>[0],
@@ -52,6 +77,7 @@ export function createProjectGroupMutationActions(
                   { timeoutMs: 15_000 }
                 )
               ).group
+        claimHostCatalogFence(get, 'project-groups', target)
         const ownedGroup = projectGroupWithFetchedOwner(group, target)
         const ownerHostId = getProjectGroupHostId(ownedGroup)
         set((s) => {
@@ -79,7 +105,6 @@ export function createProjectGroupMutationActions(
     updateProjectGroup: async (groupId, updates, options) => {
       try {
         // Why: the sidebar lists groups from every host, so the mutation follows the group's owner, not the focused host.
-        const ownerHostId = resolveProjectGroupOwnerHostId(get(), groupId, options?.hostId)
         const target = getActiveRuntimeTarget(
           settingsForProjectGroupOwner(get(), groupId, options?.hostId)
         )
@@ -97,11 +122,10 @@ export function createProjectGroupMutationActions(
         if (!updated) {
           return false
         }
+        claimHostCatalogFence(get, 'project-groups', target)
         const ownedGroup = projectGroupWithFetchedOwner(updated, target)
         set((s) => ({
-          projectGroups: s.projectGroups.map((group) =>
-            projectGroupMatchesOwnerHost(group, groupId, ownerHostId) ? ownedGroup : group
-          ),
+          projectGroups: upsertProjectGroupForOwner(s.projectGroups, ownedGroup),
           folderWorkspacePathStatuses: {}
         }))
         return true
@@ -132,6 +156,7 @@ export function createProjectGroupMutationActions(
         if (!deleted) {
           return false
         }
+        claimHostCatalogFence(get, 'project-groups', target)
         set((s) => applyProjectGroupDeleteCascade(s, groupId, ownerHostId))
         return true
       } catch (err) {

--- a/src/renderer/src/store/project-groups/project-group-mutations.ts
+++ b/src/renderer/src/store/project-groups/project-group-mutations.ts
@@ -5,6 +5,7 @@ import type { Repo } from '../../../../shared/repo-types'
 import { selectProjectGroupRemovalTargets } from '../slices/project-group-removal-targets'
 import {
   catalogOwnsHost,
+  filterProjectGroupsForRepo,
   getProjectGroupHostId,
   projectGroupMatchesOwnerHost,
   resolveProjectGroupOwnerHostId,
@@ -18,6 +19,7 @@ import { mergeProjectCompatibilityForHostRepoChange } from '../repos/repo-catalo
 import { applyProjectGroupDeleteCascade } from './project-group-removal-state'
 import { repoWithFetchedOwner, settingsForRepoOwner } from '../repos/owner-routing'
 import { projectGroupWithFetchedOwner } from './project-group-owner-stamping'
+import { getProjectSetupRuntimeTarget } from '../projects/project-host-routing'
 
 export function createProjectGroupMutationActions(
   set: Parameters<StateCreator<AppState>>[0],
@@ -31,9 +33,11 @@ export function createProjectGroupMutationActions(
   | 'moveProjectToGroup'
 > {
   return {
-    createProjectGroup: async (name) => {
+    createProjectGroup: async (name, options) => {
       try {
-        const target = getActiveRuntimeTarget(get().settings)
+        const target = options?.hostId
+          ? getProjectSetupRuntimeTarget(options.hostId)
+          : getActiveRuntimeTarget(get().settings)
         const group =
           target.kind === 'local'
             ? await window.api.projectGroups.create({
@@ -219,12 +223,27 @@ export function createProjectGroupMutationActions(
       }
     },
 
-    moveProjectToGroup: async (projectId, groupId, order) => {
+    moveProjectToGroup: async (projectId, groupId, order, options) => {
       try {
-        if (!findRepoForHost(get().repos, projectId, { settings: get().settings })) {
+        const state = get()
+        const ownerRepo = findRepoForHost(state.repos, projectId, {
+          settings: state.settings,
+          hostId: options?.hostId
+        })
+        if (!ownerRepo) {
           return false
         }
-        const target = getActiveRuntimeTarget(settingsForRepoOwner(get(), projectId))
+        if (
+          groupId &&
+          !filterProjectGroupsForRepo(state.projectGroups, ownerRepo).some(
+            (group) => group.id === groupId
+          )
+        ) {
+          return false
+        }
+        const target = getActiveRuntimeTarget(
+          settingsForRepoOwner(state, projectId, getRepoExecutionHostId(ownerRepo))
+        )
         const moved =
           target.kind === 'local'
             ? await window.api.projectGroups.moveProject({

--- a/src/renderer/src/store/repos/repo-state.ts
+++ b/src/renderer/src/store/repos/repo-state.ts
@@ -193,7 +193,10 @@ export type RepoSlice = {
     runtimeEnvironmentId?: string | null
     mode: 'group' | 'separate'
   }) => Promise<ProjectGroupImportResult | null>
-  createProjectGroup: (name: string) => Promise<ProjectGroup | null>
+  createProjectGroup: (
+    name: string,
+    options?: { hostId?: ExecutionHostId }
+  ) => Promise<ProjectGroup | null>
   createFolderWorkspace: (
     args: {
       projectGroupId: string
@@ -242,7 +245,8 @@ export type RepoSlice = {
   moveProjectToGroup: (
     projectId: string,
     groupId: string | null,
-    order?: number
+    order?: number,
+    options?: { hostId?: ExecutionHostId }
   ) => Promise<boolean>
   // options.hostId disambiguates which host's row to remove when the id exists on multiple hosts; else the focused host is assumed.
   // options.errorFeedback defaults to 'silent' so bulk/background callers keep their own aggregate reporting.

--- a/src/renderer/src/store/selectors.test.ts
+++ b/src/renderer/src/store/selectors.test.ts
@@ -13,6 +13,7 @@ import {
   resetFloatingVisibleTabCountSelectorCacheForTest,
   resetFloatingWorkspaceUnreadSelectorCacheForTest,
   selectRepoByIdForActiveWorkspace,
+  selectRepoForWorktree,
   selectFloatingVisibleTabCount,
   selectFloatingWorkspaceHasUnread
 } from './selectors'
@@ -320,6 +321,34 @@ describe('store selectors', () => {
       'hub-repo'
     )
     expect(activeRepo ? isGitRepoKind(activeRepo) : false).toBe(true)
+  })
+
+  it('resolves a context worktree repo through its catalog owner host', () => {
+    const local = makeRepo({
+      id: 'same-repo',
+      path: '/local/repo',
+      displayName: 'local',
+      executionHostId: 'local'
+    })
+    const runtime = makeRepo({
+      id: 'same-repo',
+      path: '/runtime/repo',
+      displayName: 'runtime',
+      executionHostId: toRuntimeExecutionHostId('hub-a')
+    })
+    const state = {
+      repos: [runtime, local],
+      settings: { activeRuntimeEnvironmentId: null } as AppState['settings']
+    }
+
+    expect(
+      selectRepoForWorktree(state, {
+        repoId: 'same-repo',
+        hostId: toSshExecutionHostId('hub-private-target'),
+        runtimeOwnerEnvironmentId: 'hub-a'
+      })
+    ).toBe(runtime)
+    expect(selectRepoForWorktree(state, { repoId: 'same-repo', hostId: 'local' })).toBe(local)
   })
 
   it('fails a paired-hub repo fallback closed when rival HUB rows share the repo ID', () => {

--- a/src/renderer/src/store/selectors.ts
+++ b/src/renderer/src/store/selectors.ts
@@ -8,9 +8,11 @@ import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import {
   getRepoExecutionHostId,
   parseExecutionHostId,
+  toRuntimeExecutionHostId,
   type ExecutionHostId
 } from '../../../shared/execution-host'
 import { getProjectHostSetupProjectionFromState } from './project-host-setup-selector'
+import { findRepoForHost } from './slices/repo-host-identity'
 import {
   getIndexedAllWorktrees as getCachedAllWorktrees,
   getIndexedRepoMap as getCachedRepoMap,
@@ -289,8 +291,23 @@ export function selectRepoByIdForActiveWorkspace(
   return resolved
 }
 
+type RepoOwningWorktree = Pick<Worktree, 'hostId' | 'repoId' | 'runtimeOwnerEnvironmentId'>
+
+export function selectRepoForWorktree(
+  state: Pick<AppState, 'repos' | 'settings'>,
+  worktree: RepoOwningWorktree
+): Repo | null {
+  const runtimeOwnerEnvironmentId = worktree.runtimeOwnerEnvironmentId?.trim()
+  const hostId = runtimeOwnerEnvironmentId
+    ? toRuntimeExecutionHostId(runtimeOwnerEnvironmentId)
+    : worktree.hostId
+  return findRepoForHost(state.repos, worktree.repoId, { settings: state.settings, hostId })
+}
+
 export const useRepoById = (repoId: string | null) =>
   useAppStore((s) => selectRepoByIdForActiveWorkspace(s, repoId))
+export const useRepoForWorktree = (worktree: RepoOwningWorktree) =>
+  useAppStore((s) => selectRepoForWorktree(s, worktree))
 export const useProjectHostSetupProjection = () =>
   useAppStore((s) => getProjectHostSetupProjectionFromState(s))
 

--- a/src/renderer/src/store/slices/project-group-owner-routing.test.ts
+++ b/src/renderer/src/store/slices/project-group-owner-routing.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { ProjectGroup } from '../../../../shared/project-group-types'
 import type { Repo } from '../../../../shared/repo-types'
-import { filterProjectGroupsForRepo } from './project-group-owner-routing'
+import {
+  filterProjectGroupsForRepo,
+  hasMultipleProjectGroupCatalogHosts
+} from './project-group-owner-routing'
 
 const baseGroup: ProjectGroup = {
   id: 'group',
@@ -49,5 +52,17 @@ describe('project groups available to a repo', () => {
     const localGroup = { ...baseGroup, executionHostId: 'local' as const }
 
     expect(filterProjectGroupsForRepo([localGroup], repo)).toEqual([localGroup])
+  })
+
+  it('requires host labels only when projects span group catalogs', () => {
+    const localRepo = { ...baseRepo, executionHostId: 'local' as const }
+    const directSshRepo = { ...baseRepo, id: 'ssh', connectionId: 'workstation' }
+    const workRepo = { ...baseRepo, id: 'work', executionHostId: 'runtime:work' as const }
+    const homeRepo = { ...baseRepo, id: 'home', executionHostId: 'runtime:home' as const }
+
+    expect(hasMultipleProjectGroupCatalogHosts([localRepo, directSshRepo])).toBe(false)
+    expect(hasMultipleProjectGroupCatalogHosts([workRepo])).toBe(false)
+    expect(hasMultipleProjectGroupCatalogHosts([workRepo, homeRepo])).toBe(true)
+    expect(hasMultipleProjectGroupCatalogHosts([localRepo, workRepo])).toBe(true)
   })
 })

--- a/src/renderer/src/store/slices/project-group-owner-routing.test.ts
+++ b/src/renderer/src/store/slices/project-group-owner-routing.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+import type { ProjectGroup } from '../../../../shared/project-group-types'
+import type { Repo } from '../../../../shared/repo-types'
+import { filterProjectGroupsForRepo } from './project-group-owner-routing'
+
+const baseGroup: ProjectGroup = {
+  id: 'group',
+  name: 'Group',
+  parentPath: null,
+  parentGroupId: null,
+  createdFrom: 'manual',
+  tabOrder: 0,
+  isCollapsed: false,
+  color: null,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+const baseRepo: Repo = {
+  id: 'repo',
+  path: '/repo',
+  displayName: 'Repo',
+  badgeColor: '#111',
+  addedAt: 1
+}
+
+describe('project groups available to a repo', () => {
+  it('offers a paired repo only groups from the same runtime host', () => {
+    const repo = { ...baseRepo, executionHostId: 'runtime:env-1' as const }
+    const localGroup = { ...baseGroup, id: 'local', executionHostId: 'local' as const }
+    const owningRuntimeGroup = {
+      ...baseGroup,
+      id: 'runtime-1',
+      executionHostId: 'runtime:env-1' as const
+    }
+    const otherRuntimeGroup = {
+      ...baseGroup,
+      id: 'runtime-2',
+      executionHostId: 'runtime:env-2' as const
+    }
+
+    expect(
+      filterProjectGroupsForRepo([localGroup, owningRuntimeGroup, otherRuntimeGroup], repo)
+    ).toEqual([owningRuntimeGroup])
+  })
+
+  it('keeps direct-SSH repos compatible with the client-owned catalog', () => {
+    const repo = { ...baseRepo, connectionId: 'ssh-1' }
+    const localGroup = { ...baseGroup, executionHostId: 'local' as const }
+
+    expect(filterProjectGroupsForRepo([localGroup], repo)).toEqual([localGroup])
+  })
+})

--- a/src/renderer/src/store/slices/project-group-owner-routing.test.ts
+++ b/src/renderer/src/store/slices/project-group-owner-routing.test.ts
@@ -54,6 +54,13 @@ describe('project groups available to a repo', () => {
     expect(filterProjectGroupsForRepo([localGroup], repo)).toEqual([localGroup])
   })
 
+  it('keeps direct-SSH-stamped groups in the client-owned catalog', () => {
+    const repo = { ...baseRepo, connectionId: 'ssh-1' }
+    const otherSshGroup = { ...baseGroup, connectionId: 'ssh-2' }
+
+    expect(filterProjectGroupsForRepo([otherSshGroup], repo)).toEqual([otherSshGroup])
+  })
+
   it('requires host labels only when projects span group catalogs', () => {
     const localRepo = { ...baseRepo, executionHostId: 'local' as const }
     const directSshRepo = { ...baseRepo, id: 'ssh', connectionId: 'workstation' }

--- a/src/renderer/src/store/slices/project-group-owner-routing.ts
+++ b/src/renderer/src/store/slices/project-group-owner-routing.ts
@@ -81,18 +81,31 @@ export function resolveProjectGroupOwnerHostId(
   groupId: string,
   hostId?: ExecutionHostId
 ): ExecutionHostId | null {
-  const owner = findIndexedProjectGroupOwner(state.projectGroups, groupId, hostId)
+  const catalogHostId = hostId ? getProjectGroupCatalogHostId(hostId) : null
+  const catalogMatches = catalogHostId
+    ? state.projectGroups.filter(
+        (group) =>
+          group.id === groupId && catalogOwnsHost(catalogHostId, getProjectGroupHostId(group))
+      )
+    : null
+  // Why: callers can pass the logical local catalog after resolving an SSH row;
+  // exact physical-host lookup would lose that owner on the next mutation step.
+  const owner = catalogMatches
+    ? catalogMatches.length === 1
+      ? catalogMatches[0]
+      : null
+    : findIndexedProjectGroupOwner(state.projectGroups, groupId)
   if (!owner) {
     return null
   }
-  if (hostId) {
-    return hostId
+  if (catalogHostId) {
+    return catalogHostId
   }
   // Why: an unstamped row carries no owner, so keep the focused-host behavior instead of assuming local.
   if (!owner.executionHostId && !owner.connectionId) {
     return null
   }
-  return getProjectGroupHostId(owner)
+  return getProjectGroupCatalogHostId(getProjectGroupHostId(owner))
 }
 
 // Why: the sidebar lists groups from every host, so mutations must route to the row's owner

--- a/src/renderer/src/store/slices/project-group-owner-routing.ts
+++ b/src/renderer/src/store/slices/project-group-owner-routing.ts
@@ -59,8 +59,10 @@ export function filterProjectGroupsForRepo(
   projectGroups: readonly ProjectGroup[],
   repo: Pick<Repo, 'connectionId' | 'executionHostId'>
 ): ProjectGroup[] {
-  const repoHostId = getRepoExecutionHostId(repo)
-  return projectGroups.filter((group) => catalogOwnsHost(getProjectGroupHostId(group), repoHostId))
+  const catalogHostId = getProjectGroupCatalogHostIdForRepo(repo)
+  return projectGroups.filter((group) =>
+    catalogOwnsHost(catalogHostId, getProjectGroupHostId(group))
+  )
 }
 
 export function projectGroupMatchesOwnerHost(

--- a/src/renderer/src/store/slices/project-group-owner-routing.ts
+++ b/src/renderer/src/store/slices/project-group-owner-routing.ts
@@ -41,7 +41,10 @@ export function catalogOwnsHost(catalogHostId: string, rowHostId: string): boole
 export function getProjectGroupCatalogHostIdForRepo(
   repo: Pick<Repo, 'connectionId' | 'executionHostId'>
 ): ExecutionHostId {
-  const hostId = getRepoExecutionHostId(repo)
+  return getProjectGroupCatalogHostId(getRepoExecutionHostId(repo))
+}
+
+export function getProjectGroupCatalogHostId(hostId: ExecutionHostId): ExecutionHostId {
   return parseExecutionHostId(hostId)?.kind === 'runtime' ? hostId : LOCAL_EXECUTION_HOST_ID
 }
 

--- a/src/renderer/src/store/slices/project-group-owner-routing.ts
+++ b/src/renderer/src/store/slices/project-group-owner-routing.ts
@@ -38,6 +38,20 @@ export function catalogOwnsHost(catalogHostId: string, rowHostId: string): boole
   return parseExecutionHostId(rowHostId)?.kind !== 'runtime'
 }
 
+export function getProjectGroupCatalogHostIdForRepo(
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'>
+): ExecutionHostId {
+  const hostId = getRepoExecutionHostId(repo)
+  return parseExecutionHostId(hostId)?.kind === 'runtime' ? hostId : LOCAL_EXECUTION_HOST_ID
+}
+
+export function hasMultipleProjectGroupCatalogHosts(
+  repos: readonly Pick<Repo, 'connectionId' | 'executionHostId'>[]
+): boolean {
+  const firstHostId = repos[0] ? getProjectGroupCatalogHostIdForRepo(repos[0]) : null
+  return repos.some((repo) => getProjectGroupCatalogHostIdForRepo(repo) !== firstHostId)
+}
+
 export function filterProjectGroupsForRepo(
   projectGroups: readonly ProjectGroup[],
   repo: Pick<Repo, 'connectionId' | 'executionHostId'>

--- a/src/renderer/src/store/slices/project-group-owner-routing.ts
+++ b/src/renderer/src/store/slices/project-group-owner-routing.ts
@@ -1,6 +1,8 @@
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import type { ProjectGroup } from '../../../../shared/project-group-types'
+import type { Repo } from '../../../../shared/repo-types'
 import {
+  getRepoExecutionHostId,
   LOCAL_EXECUTION_HOST_ID,
   normalizeExecutionHostId,
   parseExecutionHostId,
@@ -34,6 +36,14 @@ export function catalogOwnsHost(catalogHostId: string, rowHostId: string): boole
     return catalogHostId === rowHostId
   }
   return parseExecutionHostId(rowHostId)?.kind !== 'runtime'
+}
+
+export function filterProjectGroupsForRepo(
+  projectGroups: readonly ProjectGroup[],
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'>
+): ProjectGroup[] {
+  const repoHostId = getRepoExecutionHostId(repo)
+  return projectGroups.filter((group) => catalogOwnsHost(getProjectGroupHostId(group), repoHostId))
 }
 
 export function projectGroupMatchesOwnerHost(

--- a/src/renderer/src/store/slices/repos-project-groups-owner-routing.test.ts
+++ b/src/renderer/src/store/slices/repos-project-groups-owner-routing.test.ts
@@ -130,6 +130,25 @@ describe('project group mutations route to the owning host', () => {
     expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
   })
 
+  it('keeps the direct-SSH catalog owner through the contained-project delete flow', async () => {
+    projectGroupsDelete.mockResolvedValue(true)
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      projectGroups: [{ ...folderScanGroup, connectionId: 'conn-1' }]
+    })
+
+    await expect(
+      store.getState().deleteProjectGroupWithContainedProjects(folderScanGroup.id, {
+        removeContainedProjects: false,
+        hostId: 'ssh:conn-1'
+      })
+    ).resolves.toMatchObject({ status: 'deleted-group' })
+
+    expect(projectGroupsDelete).toHaveBeenCalledWith({ groupId: folderScanGroup.id })
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
+  })
+
   it('prefers an explicit hostId over both the focused host and a colliding row', async () => {
     runtimeEnvironmentCall.mockResolvedValue(runtimeRpcResponse({ deleted: true }))
     const store = createTestStore()
@@ -244,6 +263,48 @@ describe('project group state cascades stay scoped to the owner host', () => {
     expect(store.getState().repos).toMatchObject([
       { id: 'local-repo', projectGroupId: null },
       { id: 'remote-repo', projectGroupId: folderScanGroup.id }
+    ])
+  })
+
+  it('clears every client-catalog project when deleting a direct-SSH-stamped group', async () => {
+    projectGroupsDelete.mockResolvedValue(true)
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      projectGroups: [
+        { ...folderScanGroup, connectionId: 'conn-1' },
+        { ...folderScanGroup, name: 'Runtime projects', executionHostId: 'runtime:env-1' }
+      ],
+      repos: [
+        { ...baseRepo, id: 'local-repo', projectGroupId: folderScanGroup.id },
+        {
+          ...baseRepo,
+          id: 'ssh-repo',
+          connectionId: 'conn-2',
+          projectGroupId: folderScanGroup.id
+        },
+        {
+          ...baseRepo,
+          id: 'runtime-repo',
+          executionHostId: 'runtime:env-1',
+          projectGroupId: folderScanGroup.id
+        }
+      ]
+    })
+
+    await expect(
+      store.getState().deleteProjectGroup(folderScanGroup.id, { hostId: 'ssh:conn-1' })
+    ).resolves.toBe(true)
+
+    expect(projectGroupsDelete).toHaveBeenCalledWith({ groupId: folderScanGroup.id })
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
+    expect(store.getState().projectGroups).toMatchObject([
+      { id: folderScanGroup.id, executionHostId: 'runtime:env-1' }
+    ])
+    expect(store.getState().repos).toMatchObject([
+      { id: 'local-repo', projectGroupId: null },
+      { id: 'ssh-repo', projectGroupId: null },
+      { id: 'runtime-repo', projectGroupId: folderScanGroup.id }
     ])
   })
 

--- a/src/renderer/src/store/slices/repos-remote-project-groups.test.ts
+++ b/src/renderer/src/store/slices/repos-remote-project-groups.test.ts
@@ -97,6 +97,170 @@ describe('paired runtime project group routing', () => {
     )
   })
 
+  it('keeps a confirmed runtime group when an older catalog fetch finishes later', async () => {
+    let resolveStaleList!: (value: unknown) => void
+    runtimeEnvironmentCall.mockImplementation(({ method }) => {
+      if (method === 'projectGroup.list') {
+        return new Promise((resolve) => {
+          resolveStaleList = resolve
+        })
+      }
+      if (method === 'projectGroup.create') {
+        return Promise.resolve({
+          id: 'rpc-create',
+          ok: true,
+          result: { group: projectGroup },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      throw new Error(`Unexpected method: ${method}`)
+    })
+    const store = createTestStore()
+
+    const staleFetch = store.getState().fetchProjectGroups({ runtimeEnvironmentId: 'env-1' })
+    await vi.waitFor(() => expect(resolveStaleList).toBeTypeOf('function'))
+
+    await expect(
+      store.getState().createProjectGroup('Flute', { hostId: 'runtime:env-1' })
+    ).resolves.toEqual({ ...projectGroup, executionHostId: 'runtime:env-1' })
+
+    resolveStaleList({
+      id: 'rpc-stale-list',
+      ok: true,
+      result: { groups: [] },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    await staleFetch
+
+    expect(store.getState().projectGroups).toEqual([
+      { ...projectGroup, executionHostId: 'runtime:env-1' }
+    ])
+  })
+
+  it('does not duplicate a created group already published by a catalog refresh', async () => {
+    let resolveCreate!: (value: unknown) => void
+    runtimeEnvironmentCall.mockImplementation(({ method }) => {
+      if (method === 'projectGroup.create') {
+        return new Promise((resolve) => {
+          resolveCreate = resolve
+        })
+      }
+      if (method === 'projectGroup.list') {
+        return Promise.resolve({
+          id: 'rpc-list',
+          ok: true,
+          result: { groups: [projectGroup] },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      throw new Error(`Unexpected method: ${method}`)
+    })
+    const store = createTestStore()
+
+    const pendingCreate = store.getState().createProjectGroup('Flute', { hostId: 'runtime:env-1' })
+    await vi.waitFor(() => expect(resolveCreate).toBeTypeOf('function'))
+
+    await store.getState().fetchProjectGroups({ runtimeEnvironmentId: 'env-1' })
+    resolveCreate({
+      id: 'rpc-create',
+      ok: true,
+      result: { group: projectGroup },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    await pendingCreate
+
+    expect(store.getState().projectGroups).toEqual([
+      { ...projectGroup, executionHostId: 'runtime:env-1' }
+    ])
+  })
+
+  it('restores a confirmed rename after an older catalog fetch removed the row', async () => {
+    let resolveStaleList!: (value: unknown) => void
+    let resolveUpdate!: (value: unknown) => void
+    runtimeEnvironmentCall.mockImplementation(({ method }) => {
+      if (method === 'projectGroup.list') {
+        return new Promise((resolve) => {
+          resolveStaleList = resolve
+        })
+      }
+      if (method === 'projectGroup.update') {
+        return new Promise((resolve) => {
+          resolveUpdate = resolve
+        })
+      }
+      throw new Error(`Unexpected method: ${method}`)
+    })
+    const runtimeGroup = { ...projectGroup, executionHostId: 'runtime:env-1' as const }
+    const store = createTestStore()
+    store.setState({ projectGroups: [runtimeGroup] })
+
+    const staleFetch = store.getState().fetchProjectGroups({ runtimeEnvironmentId: 'env-1' })
+    await vi.waitFor(() => expect(resolveStaleList).toBeTypeOf('function'))
+    const pendingUpdate = store
+      .getState()
+      .updateProjectGroup(projectGroup.id, { name: 'Brass' }, { hostId: 'runtime:env-1' })
+    await vi.waitFor(() => expect(resolveUpdate).toBeTypeOf('function'))
+
+    resolveStaleList({
+      id: 'rpc-stale-list',
+      ok: true,
+      result: { groups: [] },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    await staleFetch
+    resolveUpdate({
+      id: 'rpc-update',
+      ok: true,
+      result: { group: { ...projectGroup, name: 'Brass' } },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    await pendingUpdate
+
+    expect(store.getState().projectGroups).toEqual([
+      { ...projectGroup, name: 'Brass', executionHostId: 'runtime:env-1' }
+    ])
+  })
+
+  it('does not resurrect a deleted runtime group from an older catalog fetch', async () => {
+    let resolveStaleList!: (value: unknown) => void
+    runtimeEnvironmentCall.mockImplementation(({ method }) => {
+      if (method === 'projectGroup.list') {
+        return new Promise((resolve) => {
+          resolveStaleList = resolve
+        })
+      }
+      if (method === 'projectGroup.delete') {
+        return Promise.resolve({
+          id: 'rpc-delete',
+          ok: true,
+          result: { deleted: true },
+          _meta: { runtimeId: 'runtime-remote' }
+        })
+      }
+      throw new Error(`Unexpected method: ${method}`)
+    })
+    const runtimeGroup = { ...projectGroup, executionHostId: 'runtime:env-1' as const }
+    const store = createTestStore()
+    store.setState({ projectGroups: [runtimeGroup] })
+
+    const staleFetch = store.getState().fetchProjectGroups({ runtimeEnvironmentId: 'env-1' })
+    await vi.waitFor(() => expect(resolveStaleList).toBeTypeOf('function'))
+
+    await expect(
+      store.getState().deleteProjectGroup(projectGroup.id, { hostId: 'runtime:env-1' })
+    ).resolves.toBe(true)
+
+    resolveStaleList({
+      id: 'rpc-stale-list',
+      ok: true,
+      result: { groups: [projectGroup] },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    await staleFetch
+
+    expect(store.getState().projectGroups).toEqual([])
+  })
+
   it('rejects a client-owned group for a paired runtime repo', async () => {
     runtimeEnvironmentCall.mockResolvedValue({
       id: 'rpc-invalid-move',

--- a/src/renderer/src/store/slices/repos-remote-project-groups.test.ts
+++ b/src/renderer/src/store/slices/repos-remote-project-groups.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ProjectGroup } from '../../../../shared/project-group-types'
+import type { Repo } from '../../../../shared/repo-types'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from '../../runtime/runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+import { createTestStore } from './store-test-helpers'
+
+const remoteRepo: Repo = {
+  id: 'remote-repo',
+  path: '/remote',
+  displayName: 'Remote',
+  badgeColor: '#111',
+  addedAt: 2
+}
+
+const projectGroup: ProjectGroup = {
+  id: 'group-1',
+  name: 'Flute',
+  parentPath: null,
+  parentGroupId: null,
+  createdFrom: 'manual',
+  tabOrder: 0,
+  isCollapsed: false,
+  color: null,
+  createdAt: 1,
+  updatedAt: 1
+}
+
+const projectGroupsCreate = vi.fn()
+const projectGroupsMoveProject = vi.fn()
+const runtimeEnvironmentCall = vi.fn()
+const runtimeEnvironmentTransportCall = vi.fn()
+
+beforeEach(() => {
+  clearRuntimeCompatibilityCacheForTests()
+  vi.clearAllMocks()
+  runtimeEnvironmentTransportCall.mockImplementation((args: RuntimeEnvironmentCallRequest) => {
+    return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
+  })
+  vi.stubGlobal('window', {
+    api: {
+      projectGroups: {
+        create: projectGroupsCreate,
+        moveProject: projectGroupsMoveProject
+      },
+      runtimeEnvironments: { call: runtimeEnvironmentTransportCall }
+    }
+  })
+})
+
+describe('paired runtime project group routing', () => {
+  it('creates and groups a paired runtime repo through its owning host', async () => {
+    runtimeEnvironmentCall.mockImplementation(async ({ method }) => ({
+      id: `rpc-${method}`,
+      ok: true,
+      result:
+        method === 'projectGroup.create'
+          ? { group: projectGroup }
+          : { repo: { ...remoteRepo, projectGroupId: projectGroup.id } },
+      _meta: { runtimeId: 'runtime-remote' }
+    }))
+    projectGroupsCreate.mockRejectedValue(
+      new Error('The client catalog does not own paired project groups')
+    )
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: null } as never,
+      repos: [{ ...remoteRepo, executionHostId: 'runtime:env-1' }]
+    })
+
+    const group = await store.getState().createProjectGroup('Flute', { hostId: 'runtime:env-1' })
+
+    expect(group).toEqual({ ...projectGroup, executionHostId: 'runtime:env-1' })
+    await expect(
+      store.getState().moveProjectToGroup(remoteRepo.id, group!.id, undefined, {
+        hostId: 'runtime:env-1'
+      })
+    ).resolves.toBe(true)
+    expect(store.getState().repos).toEqual([
+      {
+        ...remoteRepo,
+        projectGroupId: projectGroup.id,
+        executionHostId: 'runtime:env-1'
+      }
+    ])
+  })
+
+  it('rejects a client-owned group for a paired runtime repo', async () => {
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-invalid-move',
+      ok: true,
+      result: { repo: { ...remoteRepo, projectGroupId: projectGroup.id } },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    const ownedRemoteRepo = { ...remoteRepo, executionHostId: 'runtime:env-1' as const }
+    const store = createTestStore()
+    store.setState({
+      repos: [ownedRemoteRepo],
+      projectGroups: [{ ...projectGroup, executionHostId: 'local' }]
+    })
+
+    await expect(store.getState().moveProjectToGroup(remoteRepo.id, projectGroup.id)).resolves.toBe(
+      false
+    )
+    expect(store.getState().repos).toEqual([ownedRemoteRepo])
+  })
+
+  it('moves the requested paired repo when its id also exists locally', async () => {
+    const runtimeGroup = { ...projectGroup, executionHostId: 'runtime:env-1' as const }
+    const localRepo = { ...remoteRepo, path: '/local', executionHostId: 'local' as const }
+    const runtimeRepo = {
+      ...remoteRepo,
+      path: '/runtime',
+      executionHostId: 'runtime:env-1' as const
+    }
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-host-qualified-move',
+      ok: true,
+      result: { repo: { ...runtimeRepo, projectGroupId: runtimeGroup.id } },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: null } as never,
+      repos: [localRepo, runtimeRepo],
+      projectGroups: [runtimeGroup]
+    })
+
+    await expect(
+      store.getState().moveProjectToGroup(remoteRepo.id, runtimeGroup.id, undefined, {
+        hostId: 'runtime:env-1'
+      })
+    ).resolves.toBe(true)
+    expect(store.getState().repos).toEqual([
+      localRepo,
+      { ...runtimeRepo, projectGroupId: runtimeGroup.id }
+    ])
+  })
+})

--- a/src/renderer/src/store/slices/repos-remote-project-groups.test.ts
+++ b/src/renderer/src/store/slices/repos-remote-project-groups.test.ts
@@ -52,7 +52,7 @@ beforeEach(() => {
 })
 
 describe('paired runtime project group routing', () => {
-  it('creates and groups a paired runtime repo through its owning host', async () => {
+  it('creates and groups a paired runtime repo through its owner instead of the active host', async () => {
     runtimeEnvironmentCall.mockImplementation(async ({ method }) => ({
       id: `rpc-${method}`,
       ok: true,
@@ -67,7 +67,7 @@ describe('paired runtime project group routing', () => {
     )
     const store = createTestStore()
     store.setState({
-      settings: { activeRuntimeEnvironmentId: null } as never,
+      settings: { activeRuntimeEnvironmentId: 'env-2' } as never,
       repos: [{ ...remoteRepo, executionHostId: 'runtime:env-1' }]
     })
 
@@ -86,6 +86,15 @@ describe('paired runtime project group routing', () => {
         executionHostId: 'runtime:env-1'
       }
     ])
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith(
+      expect.objectContaining({ selector: 'env-1', method: 'projectGroup.create' })
+    )
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith(
+      expect.objectContaining({ selector: 'env-1', method: 'projectGroup.moveProject' })
+    )
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalledWith(
+      expect.objectContaining({ selector: 'env-2' })
+    )
   })
 
   it('rejects a client-owned group for a paired runtime repo', async () => {

--- a/src/renderer/src/store/slices/repos.test.ts
+++ b/src/renderer/src/store/slices/repos.test.ts
@@ -8,7 +8,6 @@ import {
   installReposRuntimeRoutingHarness,
   localRepo,
   orcaProfileFindProjectProfiles,
-  projectGroupsMoveProject,
   projectsSetupExistingFolder,
   ptyKill,
   remoteRepo,
@@ -603,33 +602,6 @@ describe('repo slice runtime routing', () => {
       displayName: 'Project',
       setupMethod: 'cloned'
     })
-  })
-
-  it('keeps runtime ownership when a runtime repo is moved between groups', async () => {
-    runtimeEnvironmentCall.mockResolvedValue({
-      id: 'rpc-move',
-      ok: true,
-      result: { repo: { ...remoteRepo, projectGroupId: 'group-1' } },
-      _meta: { runtimeId: 'runtime-remote' }
-    })
-    const store = createTestStore()
-    store.setState({
-      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
-      repos: [{ ...remoteRepo, executionHostId: 'runtime:env-1' }]
-    })
-
-    await expect(store.getState().moveProjectToGroup(remoteRepo.id, 'group-1')).resolves.toBe(true)
-
-    expect(store.getState().repos).toEqual([
-      { ...remoteRepo, projectGroupId: 'group-1', executionHostId: 'runtime:env-1' }
-    ])
-    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
-      selector: 'env-1',
-      method: 'projectGroup.moveProject',
-      params: { repo: remoteRepo.id, groupId: 'group-1', order: undefined },
-      timeoutMs: 15_000
-    })
-    expect(projectGroupsMoveProject).not.toHaveBeenCalled()
   })
 
   it('does not open the client folder picker when a remote runtime environment is active', async () => {


### PR DESCRIPTION
## ELI5

Grouping a project owned by a paired Orca server used to depend on the global Active Server setting. If Active Server was set to Local, creating or moving that remote project into a group could appear to work while leaving it ungrouped.

Group actions now follow the selected project's owner. The menu offers only compatible groups, names the catalog when more than one is visible, and reports an error when the owner cannot confirm the action.

## What Changed

- Route group creation, moves, removals, and drag commits through the selected project's execution host, including cases where different hosts reuse the same project ID.
- Limit each project menu to groups from its catalog and label ambiguous menus with `Local` or the paired server's display name. Single-catalog menus keep the shorter `Move to group` label.
- Keep local and direct SSH projects in the client-owned catalog while isolating paired runtime catalogs. Delete cascades clear every client-catalog member without touching a colliding runtime group.
- Fence confirmed creates, renames, and deletes against older catalog responses. Creation keeps a refreshed row for the same physical host, while updates replace stale or duplicate rows within their owner catalog.
- Show actionable feedback when the owning host does not confirm a create, move, removal, or drag-and-drop mutation.

## Why

The sidebar can show projects and groups from several Orca runtimes at once. Before this change, contextual group creation followed Active Server while moves followed the project's owner. A group ID created in the client catalog could then be sent to a paired server that had no such group.

The selected project already identifies the runtime that owns the mutation, so contextual actions now use that owner. Active Server remains the fallback for operations without project context.

Direct SSH projects execute on another machine but store their groups in the client catalog. Treating the physical SSH host as the catalog owner broke compatible moves and delete cleanup. The implementation now follows storage ownership for routing while preserving physical-host identity when deduplicating concurrent create responses.

## Linked Issue

Related to https://github.com/stablyai/orca/issues/10755

## Visual Proof

Before: `scripts` and `tooling` stayed ungrouped after being moved into `REMOTE GROUP`. The remote `monorepo` menu also offered the client-owned `LuisUrrutia` group and the remote-owned `REMOTE GROUP` without identifying their catalogs.

<img width="912" height="856" alt="Before: a remote project menu offers local and remote groups without identifying their catalogs" src="https://github.com/user-attachments/assets/a765232f-d169-4796-8033-dc7e19287df2" />

After (`Local` catalog): the local `skills` project shows `Move to group: Local` and only offers the local `LuisUrrutia` group.

<img width="938" height="1138" alt="After: a local project menu says Move to group: Local and offers only the local group" src="https://github.com/user-attachments/assets/b61335a9-f7c1-4943-81f3-681dc7b24944" />

After (`Work` catalog): the paired `tooling` project shows `Move to group: Work` and only offers `TEST`, a group owned by that server.

<img width="938" height="868" alt="After: a paired remote project menu says Move to group: Work and offers only that remote's group" src="https://github.com/user-attachments/assets/41d09edd-a32f-4d54-8a9a-93354eff95b2" />

When the sidebar contains projects from one catalog, the label remains `Move to group`.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- `git range-diff 1d1b73c40850a0e362186e0f0ec593cf613caa84..6c10780bda9fecc557efd798094512d79e6c4f40 upstream/main..HEAD`: 9 commits remained patch-equivalent. Commits 1 and 11 retained `main`'s create/refresh deduplication while adding the PR's owner routing and catalog fences.
- `pnpm test` with the PR's focused files plus `main`'s project-group creation race suite: 18 files and 148 tests passed.
- `pnpm tc`: passed all TypeScript projects.
- `pnpm run check:code-quality:changed`: 0 new standard, type-aware, or React Doctor findings across 42 analyzed files.
- `pnpm run build:desktop`: passed typecheck, Linux/macOS/Windows relay builds for x64 and arm64, WSL relays, CLI, Electron, skill verification, and the web projection. The optional `/usr/local/bin/orca-dev` symlink reported a non-fatal permission warning.
- `git diff --check upstream/main...HEAD`: passed.
- macOS Electron CDP before this rebase verified the `Local` and `Work` labels, catalog-filtered destinations, and unconfirmed-move toast. The rebase changed only the create/refresh race integration, which the focused tests cover. Native Linux and Windows runtime validation is left to PR CI.

## AI Disclosure

OpenAI Codex (GPT-5.6 Sol) diagnosed, implemented, reviewed, rebased, and tested the change.

## Review

- Cross-platform: the branch changes renderer and store TypeScript without adding platform-specific paths, shortcuts, shells, native modules, or child processes. `build:desktop` compiled every Linux, macOS, and Windows relay target.
- Remote and SSH: paired runtime actions follow the project owner. Local and direct SSH projects share the client-owned catalog, while paired runtime catalogs remain isolated. No RPC parameter, stream opcode, published payload, or other remote wire contract changed.
- Failure and concurrency: unconfirmed mutations return feedback, and host-scoped fences prevent older catalog reads from overwriting confirmed create, rename, or delete results. Creation retains `main`'s rule that same-ID Local and direct-SSH rows remain distinct.
- Performance: catalog filtering, fences, and upserts operate on existing in-memory arrays. Visible catalog detection is memoized, and the branch adds no polling or network calls.
- Security and UI: the branch adds no credential, privilege, input, or executable boundary. It reuses the existing menu, toast, localization, and design-system primitives.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Project groups remain catalog-owned. The branch does not introduce groups that span the client catalog and paired runtime hosts, and the catalog suffix appears only when multiple catalogs are visible.

## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
