### PR TITLE
fix(relay): reject requests for detached clients

### DIFF
--- a/src/relay/dispatcher-detached-client-requests.test.ts
+++ b/src/relay/dispatcher-detached-client-requests.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RelayDispatcher } from './dispatcher'
+import { encodeJsonRpcFrame, type JsonRpcRequest } from './protocol'
+
+const LONG_REQUEST_TIMEOUT_MS = 10 * 60_000
+
+function decodeRequest(frame: Buffer): JsonRpcRequest {
+  const length = frame.readUInt32BE(9)
+  return JSON.parse(frame.subarray(13, 13 + length).toString('utf-8')) as JsonRpcRequest
+}
+
+async function immediateOutcome(promise: Promise<unknown>): Promise<string> {
+  let outcome = 'pending'
+  void promise.then(
+    () => {
+      outcome = 'resolved'
+    },
+    (error: unknown) => {
+      outcome = `rejected:${error instanceof Error ? error.message : String(error)}`
+    }
+  )
+  await Promise.resolve()
+  await Promise.resolve()
+  return outcome
+}
+
+describe('RelayDispatcher detached client requests', () => {
+  let dispatcher: RelayDispatcher
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    dispatcher = new RelayDispatcher(() => {})
+  })
+
+  afterEach(() => {
+    dispatcher.dispose()
+    vi.useRealTimers()
+  })
+
+  it('rejects a pending request immediately when its target client detaches', async () => {
+    const ownerWritten: Buffer[] = []
+    const ownerId = dispatcher.attachClient((data) => {
+      ownerWritten.push(Buffer.from(data))
+    })
+    const pending = dispatcher.requestAnyClient('orca.cli', undefined, {
+      timeoutMs: LONG_REQUEST_TIMEOUT_MS
+    })
+
+    expect(ownerWritten).toHaveLength(1)
+    expect(vi.getTimerCount()).toBe(2)
+
+    dispatcher.detachClient(ownerId)
+
+    await expect(immediateOutcome(pending)).resolves.toBe(
+      `rejected:Client ${ownerId} detached while request was pending`
+    )
+    expect(vi.getTimerCount()).toBe(1)
+  })
+
+  it("preserves another client's pending request when one client detaches", async () => {
+    dispatcher.invalidateClient()
+    const firstWritten: Buffer[] = []
+    const secondWritten: Buffer[] = []
+    const firstId = dispatcher.attachClient((data) => {
+      firstWritten.push(Buffer.from(data))
+    })
+    const secondId = dispatcher.attachClient((data) => {
+      secondWritten.push(Buffer.from(data))
+    })
+    const firstPending = dispatcher.requestAnyClient('first.request', undefined, {
+      timeoutMs: LONG_REQUEST_TIMEOUT_MS
+    })
+    const secondPending = dispatcher.requestAnyClient('second.request', undefined, {
+      timeoutMs: LONG_REQUEST_TIMEOUT_MS,
+      excludeClientId: firstId
+    })
+
+    expect(firstWritten).toHaveLength(1)
+    expect(secondWritten).toHaveLength(1)
+
+    dispatcher.detachClient(firstId)
+
+    await expect(immediateOutcome(firstPending)).resolves.toBe(
+      `rejected:Client ${firstId} detached while request was pending`
+    )
+    await expect(immediateOutcome(secondPending)).resolves.toBe('pending')
+
+    const secondRequest = decodeRequest(secondWritten[0])
+    dispatcher.feedClient(
+      secondId,
+      encodeJsonRpcFrame({ jsonrpc: '2.0', id: secondRequest.id, result: 'second-result' }, 1, 0)
+    )
+    await expect(secondPending).resolves.toBe('second-result')
+  })
+
+  it('does not revive an invalidated primary request or accept its late response', async () => {
+    const primaryWritten: Buffer[] = []
+    dispatcher.dispose()
+    dispatcher = new RelayDispatcher((data) => {
+      primaryWritten.push(Buffer.from(data))
+    })
+    const oldPending = dispatcher.requestPrimary('old.request', undefined, {
+      timeoutMs: LONG_REQUEST_TIMEOUT_MS
+    })
+    const oldRequest = decodeRequest(primaryWritten[0])
+
+    dispatcher.invalidateClient()
+    dispatcher.invalidateClient()
+
+    await expect(immediateOutcome(oldPending)).resolves.toBe(
+      'rejected:Client 1 detached while request was pending'
+    )
+
+    const revivedWritten: Buffer[] = []
+    dispatcher.setWrite((data) => {
+      revivedWritten.push(Buffer.from(data))
+    })
+    const revivedPending = dispatcher.requestPrimary('revived.request', undefined, {
+      timeoutMs: LONG_REQUEST_TIMEOUT_MS
+    })
+    const revivedRequest = decodeRequest(revivedWritten[0])
+
+    dispatcher.feed(encodeJsonRpcFrame({ jsonrpc: '2.0', id: oldRequest.id, result: 'late' }, 1, 0))
+    await expect(immediateOutcome(revivedPending)).resolves.toBe('pending')
+
+    dispatcher.feed(
+      encodeJsonRpcFrame({ jsonrpc: '2.0', id: revivedRequest.id, result: 'revived' }, 2, 0)
+    )
+    await expect(revivedPending).resolves.toBe('revived')
+    expect(vi.getTimerCount()).toBe(1)
+  })
+})

--- a/src/relay/dispatcher.ts
+++ b/src/relay/dispatcher.ts
@@ -107,6 +107,7 @@ type DroppedProducerNotificationLog = {
 }
 
 type PendingRelayRequest = {
+  clientId: number
   resolve: (result: unknown) => void
   reject: (error: Error) => void
   timer: ReturnType<typeof setTimeout>
@@ -847,7 +848,7 @@ export class RelayDispatcher {
         this.pendingRelayRequests.delete(id)
         reject(new Error(`Request "${method}" timed out after ${timeoutMs}ms`))
       }, timeoutMs)
-      this.pendingRelayRequests.set(id, { resolve, reject, timer })
+      this.pendingRelayRequests.set(id, { clientId, resolve, reject, timer })
       if (!this.enqueueFrame(client, msg, 'control', () => {}, 'reject')) {
         clearTimeout(timer)
         this.pendingRelayRequests.delete(id)
@@ -1447,6 +1448,14 @@ export class RelayDispatcher {
       return
     }
     client.closed = true
+    for (const [id, pending] of this.pendingRelayRequests) {
+      if (pending.clientId !== client.id) {
+        continue
+      }
+      clearTimeout(pending.timer)
+      this.pendingRelayRequests.delete(id)
+      pending.reject(new Error(`Client ${client.id} detached while request was pending`))
+    }
     this.requestAborts.abortClient(client.id)
     client.writer.close(error)
     client.generation++


### PR DESCRIPTION
## ELI5

When the relay asks a desktop Orca client to do something, it waits for that specific client to answer. If that client disconnects, Orca now stops waiting immediately and reports that the client detached instead of staying silent until a timeout that can last several minutes.

## What Changed

- Record the target client ID with each pending relay-to-client request.
- When a client closes, clear the timer, remove the entry, and reject only requests targeting that client with an explicit detach error.
- Add focused coverage for immediate rejection without advancing a 10-minute timeout, isolation between clients, timer cleanup, repeated primary invalidation, primary revival, and late responses from the retired request.

## Why

`closeClient()` already aborted inbound handlers owned by the closing client, but outbound `pendingRelayRequests` did not remember their target and survived until timeout. Associating each entry with its client lets the existing close boundary clean up exactly the affected requests. Cleanup removes the map entry and timer before rejection, so a late response, timeout, repeated close, or later dispatcher dispose cannot settle it again.

## Linked Issue

Fixes #16302

## Visual Proof

N/A — this changes relay lifecycle bookkeeping only and has no rendered UI surface.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

RED, with the production fix removed:

```text
volta run --node 24.19.0 --pnpm 10.24.0 pnpm exec vitest run --config config/vitest.config.ts src/relay/dispatcher-detached-client-requests.test.ts -t "rejects a pending request immediately"
```

Result: 1 failed, 2 skipped in 9 ms. Expected the detach error but received `pending` without advancing the 10-minute request timer.

GREEN and regression checks:

```text
volta run --node 24.19.0 --pnpm 10.24.0 pnpm exec vitest run --config config/vitest.config.ts src/relay/dispatcher-detached-client-requests.test.ts
# 3 passed

volta run --node 24.19.0 --pnpm 10.24.0 pnpm exec vitest run --config config/vitest.config.ts src/relay/dispatcher-detached-client-requests.test.ts src/relay/dispatcher.test.ts src/relay/dispatcher-timeout.test.ts src/relay/dispatcher-client-close-cause.test.ts src/relay/dispatcher-structured-error.test.ts src/relay/dispatcher-capacity-degradation.test.ts src/relay/integration.test.ts
# 7 files passed, 90 tests passed

volta run --node 24.19.0 --pnpm 10.24.0 pnpm lint
# passed

volta run --node 24.19.0 --pnpm 10.24.0 pnpm typecheck
# passed

volta run --node 24.19.0 --pnpm 10.24.0 pnpm build:relay
# passed for linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64, win32-arm64, and WSL
```

A broader `src/relay` Vitest run completed with 1,469 passed and 2 skipped, plus 3 failures in unchanged Windows-to-WSL `HISTFILE` fixtures (`pty-handler-revive.test.ts` and `pty-handler-spawn-environment.test.ts`). Those failures reproduced when the two files were run in isolation. Full desktop/mobile `pnpm test`, full `pnpm build`, live SSH disconnect testing, and live Windows/Linux runtime testing were not performed.

## AI Disclosure

OpenAI Codex (GPT-5) was used for issue preflight, diagnosis, RED/GREEN test design, implementation, verification, self-review, and PR drafting.

## Review

- **Correctness and concurrency:** each pending request captures its target once. Client close clears its timer and deletes it before rejection; response, timeout, close, and dispose therefore have a single winner. Requests for other clients remain pending and can still resolve normally.
- **Lifecycle:** repeated close is guarded by `client.closed`; invalidated primary requests stay rejected after `setWrite()` revival; late responses for retired request IDs are ignored. Existing writer-capacity and timeout cleanup paths remain unchanged and were included in the adjacent dispatcher tests.
- **Remote/SSH compatibility:** this is relay-internal state only. It changes no RPC parameter, stream frame, opcode, or published payload, and it makes no claim that a detached transport means a remote process exited.
- **Cross-platform and integrations:** no OS, path, shell, keyboard, Git provider, agent, mobile, or integration-specific behavior changed. The relay bundle compiled for all configured desktop relay targets and WSL.
- **Performance and security:** client close adds a bounded scan over currently pending outbound requests only; no hot-path polling or new input/auth surface was added.
- **UI:** no renderer code or visual behavior changed.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- The change is intentionally limited to `RelayDispatcher` bookkeeping and focused regression coverage.
- X/Twitter handle: not provided.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
