### PR TITLE
perf(renderer): narrow appearance store subscriptions

### DIFF
--- a/src/renderer/src/app-shell/use-document-appearance.test.tsx
+++ b/src/renderer/src/app-shell/use-document-appearance.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment happy-dom
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultSettings } from '../../../shared/constants'
+import { useAppStore } from '../store'
+
+const mocks = vi.hoisted(() => ({
+  applyDocumentTheme: vi.fn(),
+  buildAppFontFamily: vi.fn((fontFamily: string | null | undefined) => fontFamily ?? '')
+}))
+
+vi.mock('../lib/document-theme', () => ({
+  applyDocumentTheme: mocks.applyDocumentTheme
+}))
+
+vi.mock('@/lib/app-font-family', () => ({
+  buildAppFontFamily: mocks.buildAppFontFamily
+}))
+
+vi.mock('../runtime/sync-runtime-graph', () => ({
+  scheduleRuntimeGraphSync: vi.fn()
+}))
+
+import { useDocumentAppearance } from './use-document-appearance'
+
+const initialState = useAppStore.getState()
+
+describe('useDocumentAppearance', () => {
+  beforeEach(() => {
+    mocks.applyDocumentTheme.mockReset()
+    mocks.buildAppFontFamily.mockClear()
+    useAppStore.setState({
+      settings: {
+        ...getDefaultSettings('/tmp'),
+        theme: 'dark'
+      }
+    })
+  })
+
+  afterEach(() => {
+    useAppStore.setState(initialState, true)
+  })
+
+  it('ignores unrelated settings object replacements', () => {
+    const { unmount } = renderHook(() => useDocumentAppearance())
+
+    expect(mocks.applyDocumentTheme).toHaveBeenCalledTimes(1)
+    expect(mocks.buildAppFontFamily).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      const settings = useAppStore.getState().settings!
+      useAppStore.setState({
+        settings: { ...settings, editorAutoSave: !settings.editorAutoSave }
+      })
+    })
+
+    expect(mocks.applyDocumentTheme).toHaveBeenCalledTimes(1)
+    expect(mocks.buildAppFontFamily).toHaveBeenCalledTimes(1)
+    unmount()
+  })
+
+  it('still applies changed theme and font values', () => {
+    const { unmount } = renderHook(() => useDocumentAppearance())
+
+    act(() => {
+      const settings = useAppStore.getState().settings!
+      useAppStore.setState({
+        settings: { ...settings, theme: 'light', appFontFamily: 'Monaco' }
+      })
+    })
+
+    expect(mocks.applyDocumentTheme).toHaveBeenLastCalledWith('light')
+    expect(mocks.applyDocumentTheme).toHaveBeenCalledTimes(2)
+    expect(mocks.buildAppFontFamily).toHaveBeenLastCalledWith('Monaco')
+    expect(mocks.buildAppFontFamily).toHaveBeenCalledTimes(2)
+    unmount()
+  })
+})

--- a/src/renderer/src/app-shell/use-document-appearance.ts
+++ b/src/renderer/src/app-shell/use-document-appearance.ts
@@ -6,17 +6,18 @@ import { useAppStore } from '../store'
 
 /** Applies the settings-driven theme and app font to the document root. */
 export function useDocumentAppearance(): void {
-  const settings = useAppStore((s) => s.settings)
+  const theme = useAppStore((s) => s.settings?.theme)
+  const appFontFamily = useAppStore((s) => s.settings?.appFontFamily)
 
   useEffect(() => {
-    if (!settings) {
+    if (!theme) {
       return
     }
 
-    if (settings.theme === 'dark') {
+    if (theme === 'dark') {
       applyDocumentTheme('dark')
       return undefined
-    } else if (settings.theme === 'light') {
+    } else if (theme === 'light') {
       applyDocumentTheme('light')
       return undefined
     }
@@ -30,12 +31,12 @@ export function useDocumentAppearance(): void {
     }
     mq.addEventListener('change', handler)
     return () => mq.removeEventListener('change', handler)
-  }, [settings])
+  }, [theme])
 
   useEffect(() => {
     document.documentElement.style.setProperty(
       '--app-font-family',
-      buildAppFontFamily(settings?.appFontFamily)
+      buildAppFontFamily(appFontFamily)
     )
-  }, [settings?.appFontFamily])
+  }, [appFontFamily])
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​78 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​78 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1 |

<!-- /orca-pr-loc -->

## Problem
The always-mounted document appearance hook subscribed to the entire `settings` object, although it only consumes `theme` and `appFontFamily`. Every settings object replacement therefore reran theme application, media-query setup/cleanup, and font CSS projection.

## Change
Subscribe to the two primitive fields directly. Unrelated settings replacements no longer rerender this hook or rerun appearance effects. Theme and font changes retain their existing behavior.

## Evidence
- Focused regression: `use-document-appearance.test.tsx` — 2 tests passed. It proves an unrelated settings replacement causes zero additional theme/font effect work and that changed theme/font values still apply.
- `pnpm run typecheck:web` passed.
- Targeted React Doctor/Oxlint passed.

## Risk
Low. No IPC, persistence, wire, terminal, or settings-search behavior changes. This is a selector/effect dependency narrowing with unchanged output for every consumed value.