### PR TITLE
fix(runtime): cancel pending driver timers on desktop reclaim

### DIFF
--- a/src/main/runtime/mobile-subscribe-integration.test.ts
+++ b/src/main/runtime/mobile-subscribe-integration.test.ts
@@ -851,18 +851,16 @@ describe('mobile subscribe integration', () => {
       expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
     })
 
-    it('reclaim cancels the soft-leave timer before it can clear the desktop driver', async () => {
+    it('reclaim cancels the soft-leave timer in the remote-layout branch', async () => {
       const { runtime } = createRuntime()
+      await runtime.updateRemoteDesktopViewer('pty-1', 'sub-a', 'viewer-a', 120, 32)
       await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
       runtime.handleMobileUnsubscribe('pty-1', 'client-a')
 
-      // The last unsubscribe arms the 250ms soft-leave timer while the fit is held.
-      expect(runtime.getDriver('pty-1')).toEqual({ kind: 'mobile', clientId: 'client-a' })
       expect(await runtime.reclaimTerminalForDesktop('pty-1')).toBe(true)
-      expect(runtime.getDriver('pty-1')).toEqual({ kind: 'desktop' })
-
-      await vi.advanceTimersByTimeAsync(250)
-      expect(runtime.getDriver('pty-1')).toEqual({ kind: 'desktop' })
+      expect(
+        (Reflect.get(runtime, 'pendingSoftLeavers') as Map<string, unknown>).has('pty-1')
+      ).toBe(false)
     })
 
     it('reclaim cancels a stale soft-leave timer in the active-subscriber branch', async () => {
@@ -872,13 +870,35 @@ describe('mobile subscribe integration', () => {
       // A different client can subscribe while the first client's grace timer is armed.
       await runtime.handleMobileSubscribe('pty-1', 'client-b', { cols: 40, rows: 18 })
 
-      expect(
-        (Reflect.get(runtime, 'pendingSoftLeavers') as Map<string, unknown>).has('pty-1')
-      ).toBe(true)
+      const pending = Reflect.get(runtime, 'pendingSoftLeavers') as Map<string, unknown>
+      expect(pending.has('pty-1')).toBe(true)
       await runtime.reclaimTerminalForDesktop('pty-1')
-      expect(
-        (Reflect.get(runtime, 'pendingSoftLeavers') as Map<string, unknown>).has('pty-1')
-      ).toBe(false)
+      expect(pending.has('pty-1')).toBe(false)
+    })
+
+    it('reclaim cancels pending restore timers on active, orphan, and no-lock branches', async () => {
+      for (const branch of ['active', 'orphan', 'none'] as const) {
+        const { runtime } = createRuntime()
+        await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+        if (branch !== 'active') {
+          runtime.handleMobileUnsubscribe('pty-1', 'client-a')
+        }
+        if (branch !== 'active') {
+          ;(Reflect.get(runtime, 'terminalFitOverrides') as Map<string, unknown>).delete('pty-1')
+        }
+        if (branch === 'none') {
+          ;(Reflect.get(runtime, 'currentDriver') as Map<string, { kind: string }>).set('pty-1', {
+            kind: 'idle'
+          })
+        }
+        const pending = Reflect.get(runtime, 'pendingRestoreTimers') as Map<string, unknown>
+        pending.set('pty-1', { timer: setTimeout(() => {}, 60_000), clientId: 'client-a' })
+        await runtime.reclaimTerminalForDesktop('pty-1')
+        expect(pending.has('pty-1')).toBe(false)
+        expect(
+          (Reflect.get(runtime, 'pendingSoftLeavers') as Map<string, unknown>).has('pty-1')
+        ).toBe(false)
+      }
     })
 
     it('reclaim cancels a stale soft-leave timer in the orphan-driver branch', async () => {
@@ -890,21 +910,6 @@ describe('mobile subscribe integration', () => {
       fitOverrides.delete('pty-1')
 
       expect(await runtime.reclaimTerminalForDesktop('pty-1')).toBe(true)
-      expect(
-        (Reflect.get(runtime, 'pendingSoftLeavers') as Map<string, unknown>).has('pty-1')
-      ).toBe(false)
-    })
-
-    it('reclaim cancels pending timers even when no driver lock remains', async () => {
-      const { runtime } = createRuntime()
-      await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
-      runtime.handleMobileUnsubscribe('pty-1', 'client-a')
-      const currentDriver = Reflect.get(runtime, 'currentDriver') as Map<string, { kind: string }>
-      currentDriver.set('pty-1', { kind: 'idle' })
-      const fitOverrides = Reflect.get(runtime, 'terminalFitOverrides') as Map<string, unknown>
-      fitOverrides.delete('pty-1')
-
-      expect(await runtime.reclaimTerminalForDesktop('pty-1')).toBe(false)
       expect(
         (Reflect.get(runtime, 'pendingSoftLeavers') as Map<string, unknown>).has('pty-1')
       ).toBe(false)

--- a/src/main/runtime/mobile-subscribe-integration.test.ts
+++ b/src/main/runtime/mobile-subscribe-integration.test.ts
@@ -840,15 +840,11 @@ describe('mobile subscribe integration', () => {
       await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
       runtime.handleMobileUnsubscribe('pty-1', 'client-a')
 
-      // No subscribers, indefinite hold — PTY stays at phone dims.
-      await vi.advanceTimersByTimeAsync(60_000)
-      expect(ptySizes.get('pty-1')).toEqual({ cols: 45, rows: 20 })
-      expect(runtime.isMobileSubscriberActive('pty-1')).toBe(false)
-
-      // Manual reclaim: PTY restored to desktop dims via the held branch.
-      const ok = await runtime.reclaimTerminalForDesktop('pty-1')
-      expect(ok).toBe(true)
+      await runtime.reclaimTerminalForDesktop('pty-1')
       expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
+
+      await vi.advanceTimersByTimeAsync(250)
+      expect(runtime.getDriver('pty-1')).toEqual({ kind: 'desktop' })
     })
 
     it('reclaim cancels the soft-leave timer in the remote-layout branch', async () => {
@@ -858,61 +854,66 @@ describe('mobile subscribe integration', () => {
       runtime.handleMobileUnsubscribe('pty-1', 'client-a')
 
       expect(await runtime.reclaimTerminalForDesktop('pty-1')).toBe(true)
-      expect(
-        (Reflect.get(runtime, 'pendingSoftLeavers') as Map<string, unknown>).has('pty-1')
-      ).toBe(false)
+      await vi.advanceTimersByTimeAsync(250)
+      expect(runtime.getDriver('pty-1')).toEqual({ kind: 'desktop' })
     })
 
-    it('reclaim cancels a stale soft-leave timer in the active-subscriber branch', async () => {
+    it('reclaim cancels pending restore timers on the active-subscriber branch', async () => {
       const { runtime } = createRuntime()
       await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
       runtime.handleMobileUnsubscribe('pty-1', 'client-a')
-      // A different client can subscribe while the first client's grace timer is armed.
       await runtime.handleMobileSubscribe('pty-1', 'client-b', { cols: 40, rows: 18 })
 
-      const pending = Reflect.get(runtime, 'pendingSoftLeavers') as Map<string, unknown>
-      expect(pending.has('pty-1')).toBe(true)
+      const pendingRestore = Reflect.get(runtime, 'pendingRestoreTimers') as Map<string, unknown>
+      pendingRestore.set('pty-1', { timer: setTimeout(() => {}, 60_000), clientId: 'client-b' })
+      const pendingSoft = Reflect.get(runtime, 'pendingSoftLeavers') as Map<string, unknown>
+      expect(pendingSoft.has('pty-1')).toBe(true)
       await runtime.reclaimTerminalForDesktop('pty-1')
-      expect(pending.has('pty-1')).toBe(false)
+      expect(pendingRestore.has('pty-1')).toBe(false)
+      expect(pendingSoft.has('pty-1')).toBe(false)
     })
 
-    it('reclaim cancels pending restore timers on active, orphan, and no-lock branches', async () => {
-      for (const branch of ['active', 'orphan', 'none'] as const) {
-        const { runtime } = createRuntime()
-        await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
-        if (branch !== 'active') {
-          runtime.handleMobileUnsubscribe('pty-1', 'client-a')
-        }
-        if (branch !== 'active') {
-          ;(Reflect.get(runtime, 'terminalFitOverrides') as Map<string, unknown>).delete('pty-1')
-        }
-        if (branch === 'none') {
-          ;(Reflect.get(runtime, 'currentDriver') as Map<string, { kind: string }>).set('pty-1', {
-            kind: 'idle'
-          })
-        }
-        const pending = Reflect.get(runtime, 'pendingRestoreTimers') as Map<string, unknown>
-        pending.set('pty-1', { timer: setTimeout(() => {}, 60_000), clientId: 'client-a' })
-        await runtime.reclaimTerminalForDesktop('pty-1')
-        expect(pending.has('pty-1')).toBe(false)
-        expect(
-          (Reflect.get(runtime, 'pendingSoftLeavers') as Map<string, unknown>).has('pty-1')
-        ).toBe(false)
-      }
-    })
-
-    it('reclaim cancels a stale soft-leave timer in the orphan-driver branch', async () => {
+    it('reclaim cancels pending restore timers on the orphan-driver branch', async () => {
       const { runtime } = createRuntime()
       await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
       runtime.handleMobileUnsubscribe('pty-1', 'client-a')
-      // Simulate a stale mobile lock whose fit override was already cleared.
-      const fitOverrides = Reflect.get(runtime, 'terminalFitOverrides') as Map<string, unknown>
-      fitOverrides.delete('pty-1')
+      ;(Reflect.get(runtime, 'terminalFitOverrides') as Map<string, unknown>).delete('pty-1')
 
-      expect(await runtime.reclaimTerminalForDesktop('pty-1')).toBe(true)
-      expect(
-        (Reflect.get(runtime, 'pendingSoftLeavers') as Map<string, unknown>).has('pty-1')
-      ).toBe(false)
+      const pendingRestore = Reflect.get(runtime, 'pendingRestoreTimers') as Map<string, unknown>
+      const pendingSoft = Reflect.get(runtime, 'pendingSoftLeavers') as Map<string, unknown>
+      await runtime.reclaimTerminalForDesktop('pty-1')
+      expect(pendingRestore.has('pty-1')).toBe(false)
+      expect(pendingSoft.has('pty-1')).toBe(false)
+    })
+
+    it('reclaim cancels pending restore timers when no driver lock remains', async () => {
+      const { runtime } = createRuntime()
+      await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+      runtime.handleMobileUnsubscribe('pty-1', 'client-a')
+      ;(Reflect.get(runtime, 'terminalFitOverrides') as Map<string, unknown>).delete('pty-1')
+      ;(Reflect.get(runtime, 'currentDriver') as Map<string, { kind: string }>).set('pty-1', {
+        kind: 'idle'
+      })
+
+      const pendingRestore = Reflect.get(runtime, 'pendingRestoreTimers') as Map<string, unknown>
+      const pendingSoft = Reflect.get(runtime, 'pendingSoftLeavers') as Map<string, unknown>
+      expect(await runtime.reclaimTerminalForDesktop('pty-1')).toBe(false)
+      expect(pendingRestore.has('pty-1')).toBe(false)
+      expect(pendingSoft.has('pty-1')).toBe(false)
+    })
+
+    it('reclaim revokes soft-leave grace admission for mobile input', async () => {
+      const { runtime } = createRuntime()
+      await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+      runtime.handleMobileUnsubscribe('pty-1', 'client-a')
+
+      const claim = runtime.beginMobileInputFloor('pty-1', 'client-a')
+      expect(claim).not.toBeNull()
+      claim?.rollback()
+
+      await runtime.reclaimTerminalForDesktop('pty-1')
+      expect(runtime.getDriver('pty-1')).toEqual({ kind: 'desktop' })
+      expect(runtime.beginMobileInputFloor('pty-1', 'client-a')).toBeNull()
     })
 
     it('reclaimTerminalForDesktop prefers fresh desktop geometry for a held PTY', async () => {

--- a/src/main/runtime/mobile-subscribe-integration.test.ts
+++ b/src/main/runtime/mobile-subscribe-integration.test.ts
@@ -851,6 +851,65 @@ describe('mobile subscribe integration', () => {
       expect(ptySizes.get('pty-1')).toEqual({ cols: 150, rows: 40 })
     })
 
+    it('reclaim cancels the soft-leave timer before it can clear the desktop driver', async () => {
+      const { runtime } = createRuntime()
+      await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+      runtime.handleMobileUnsubscribe('pty-1', 'client-a')
+
+      // The last unsubscribe arms the 250ms soft-leave timer while the fit is held.
+      expect(runtime.getDriver('pty-1')).toEqual({ kind: 'mobile', clientId: 'client-a' })
+      expect(await runtime.reclaimTerminalForDesktop('pty-1')).toBe(true)
+      expect(runtime.getDriver('pty-1')).toEqual({ kind: 'desktop' })
+
+      await vi.advanceTimersByTimeAsync(250)
+      expect(runtime.getDriver('pty-1')).toEqual({ kind: 'desktop' })
+    })
+
+    it('reclaim cancels a stale soft-leave timer in the active-subscriber branch', async () => {
+      const { runtime } = createRuntime()
+      await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+      runtime.handleMobileUnsubscribe('pty-1', 'client-a')
+      // A different client can subscribe while the first client's grace timer is armed.
+      await runtime.handleMobileSubscribe('pty-1', 'client-b', { cols: 40, rows: 18 })
+
+      expect(
+        (Reflect.get(runtime, 'pendingSoftLeavers') as Map<string, unknown>).has('pty-1')
+      ).toBe(true)
+      await runtime.reclaimTerminalForDesktop('pty-1')
+      expect(
+        (Reflect.get(runtime, 'pendingSoftLeavers') as Map<string, unknown>).has('pty-1')
+      ).toBe(false)
+    })
+
+    it('reclaim cancels a stale soft-leave timer in the orphan-driver branch', async () => {
+      const { runtime } = createRuntime()
+      await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+      runtime.handleMobileUnsubscribe('pty-1', 'client-a')
+      // Simulate a stale mobile lock whose fit override was already cleared.
+      const fitOverrides = Reflect.get(runtime, 'terminalFitOverrides') as Map<string, unknown>
+      fitOverrides.delete('pty-1')
+
+      expect(await runtime.reclaimTerminalForDesktop('pty-1')).toBe(true)
+      expect(
+        (Reflect.get(runtime, 'pendingSoftLeavers') as Map<string, unknown>).has('pty-1')
+      ).toBe(false)
+    })
+
+    it('reclaim cancels pending timers even when no driver lock remains', async () => {
+      const { runtime } = createRuntime()
+      await runtime.handleMobileSubscribe('pty-1', 'client-a', { cols: 45, rows: 20 })
+      runtime.handleMobileUnsubscribe('pty-1', 'client-a')
+      const currentDriver = Reflect.get(runtime, 'currentDriver') as Map<string, { kind: string }>
+      currentDriver.set('pty-1', { kind: 'idle' })
+      const fitOverrides = Reflect.get(runtime, 'terminalFitOverrides') as Map<string, unknown>
+      fitOverrides.delete('pty-1')
+
+      expect(await runtime.reclaimTerminalForDesktop('pty-1')).toBe(false)
+      expect(
+        (Reflect.get(runtime, 'pendingSoftLeavers') as Map<string, unknown>).has('pty-1')
+      ).toBe(false)
+    })
+
     it('reclaimTerminalForDesktop prefers fresh desktop geometry for a held PTY', async () => {
       // Why: manual restore must honor fresh desktop geometry measured while the PTY was phone-held, not the stale baseline.
       settingsState.mobileAutoRestoreFitMs = null

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -15387,16 +15387,7 @@ export class OrcaRuntimeService {
     this.layouts.delete(ptyId)
     this.layoutQueues.delete(ptyId)
     this.freshSubscribeGuard.delete(ptyId)
-    const pendingRestore = this.pendingRestoreTimers.get(ptyId)
-    if (pendingRestore) {
-      clearTimeout(pendingRestore.timer)
-      this.pendingRestoreTimers.delete(ptyId)
-    }
-    const pendingSoft = this.pendingSoftLeavers.get(ptyId)
-    if (pendingSoft) {
-      clearTimeout(pendingSoft.timer)
-      this.pendingSoftLeavers.delete(ptyId)
-    }
+    this.cancelPendingDriverMutations(ptyId)
     // Why: a cold restore can respawn under the same session id within the
     // delayed-Enter window; the armed Enter would inject \r into the
     // replacement and stamp rows it never received.
@@ -16109,7 +16100,7 @@ export class OrcaRuntimeService {
     return false
   }
 
-  // Why: an explicit desktop take-back supersedes every delayed driver mutation.
+  // Why: explicit take-back supersedes delayed mutations, revoking soft-leave grace admission for mobile input floors.
   private cancelPendingDriverMutations(ptyId: string): void {
     const pendingRestore = this.pendingRestoreTimers.get(ptyId)
     if (pendingRestore) {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -16100,7 +16100,8 @@ export class OrcaRuntimeService {
     return false
   }
 
-  // Why: explicit take-back supersedes delayed mutations, revoking soft-leave grace admission for mobile input floors.
+  // Why: teardown and desktop reclaim supersede delayed mobile mutations,
+  // revoking soft-leave grace admission for input floors.
   private cancelPendingDriverMutations(ptyId: string): void {
     const pendingRestore = this.pendingRestoreTimers.get(ptyId)
     if (pendingRestore) {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -16053,6 +16053,7 @@ export class OrcaRuntimeService {
   // frame. Returns `true` whenever there was a lock to reclaim, `false` only
   // when there was nothing to reclaim.
   async reclaimTerminalForDesktop(ptyId: string): Promise<boolean> {
+    this.cancelPendingDriverMutations(ptyId)
     if (this.isMobileSubscriberActive(ptyId)) {
       this.setMobileDisplayMode(ptyId, 'desktop')
       await this.applyMobileDisplayMode(ptyId)
@@ -16072,16 +16073,6 @@ export class OrcaRuntimeService {
     }
     const heldOverride = this.terminalFitOverrides.get(ptyId)
     if (heldOverride && this.hasRemoteDesktopLayoutState(ptyId)) {
-      const pending = this.pendingRestoreTimers.get(ptyId)
-      if (pending) {
-        clearTimeout(pending.timer)
-        this.pendingRestoreTimers.delete(ptyId)
-      }
-      const softLeaver = this.pendingSoftLeavers.get(ptyId)
-      if (softLeaver) {
-        clearTimeout(softLeaver.timer)
-        this.pendingSoftLeavers.delete(ptyId)
-      }
       // Why: applyRemoteDesktopLayout no-ops while the driver still reads mobile.
       this.setDriver(ptyId, { kind: 'idle' })
       // Why: best-effort, like the local held branch below. A host whose resize
@@ -16094,11 +16085,6 @@ export class OrcaRuntimeService {
       return true
     }
     if (heldOverride) {
-      const pending = this.pendingRestoreTimers.get(ptyId)
-      if (pending) {
-        clearTimeout(pending.timer)
-        this.pendingRestoreTimers.delete(ptyId)
-      }
       // Why: with no subscribers, resolveDesktopRestoreTarget can fall through
       // to current PTY size — which is at phone dims (wrong). Prefer a fresh
       // desktop renderer measurement when one exists; otherwise use the
@@ -16121,6 +16107,20 @@ export class OrcaRuntimeService {
       return true
     }
     return false
+  }
+
+  // Why: an explicit desktop take-back supersedes every delayed driver mutation.
+  private cancelPendingDriverMutations(ptyId: string): void {
+    const pendingRestore = this.pendingRestoreTimers.get(ptyId)
+    if (pendingRestore) {
+      clearTimeout(pendingRestore.timer)
+      this.pendingRestoreTimers.delete(ptyId)
+    }
+    const pendingSoft = this.pendingSoftLeavers.get(ptyId)
+    if (pendingSoft) {
+      clearTimeout(pendingSoft.timer)
+      this.pendingSoftLeavers.delete(ptyId)
+    }
   }
 
   // Why: the shared "banner must be gone now" step for an explicit desktop


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​73 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​65 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​17 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​25 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 |

<!-- /orca-pr-loc -->

## ELI5 — what this means for users

**Short version: nothing changes visibly, and that is the point.**

Your Mac and your phone can both "drive" a terminal, but only one owns it at a time. When you take a terminal back to the desktop, Orca has to cancel the delayed cleanup jobs the phone left behind. It was cancelling them on some code paths and not others.

A leftover job could fire about a quarter-second after your take-back and quietly drop the "the desktop owns this" flag. Another part of Orca leans on that flag to stop your phone from grabbing the terminal straight back.

**Why this says both "Fixes #16331" and "NOT REPRODUCED" — they answer different questions.**

- *Does this close the issue?* Yes. #16331 is not a user bug report; we filed it ourselves during a review of #15539. It reported that the cleanup was inconsistent between branches and asked for it to be made uniform. This PR does exactly that, so it closes the issue.
- *Could a user have hit it?* No, and we looked hard. The leftover job only runs when no phone is connected, and the flag only matters when one is — so the two conditions never overlap on any path we could measure.

In other words: the defect being fixed is real and is in the code. Its user impact today is nil. We are closing an unintended asymmetry before someone adds a sixth branch and turns it into a real bug — not repairing something users are currently hitting.

**One deliberate change you might notice:** right after a take-back there used to be a ~250 ms window where a keystroke from the phone would still be accepted. It is now rejected. That is intentional — an explicit take-back should beat a fading grace period.

---

Fixes #16331

## Reproduction

With fake timers, subscribe a phone to a PTY, unsubscribe it, and immediately invoke desktop take-back. The unsubscribe arms the 250 ms soft-leave timer; on the pre-fix local held-fit path, advancing 250 ms changed the driver from `{ kind: 'desktop' }` to `{ kind: 'idle' }`. This reproduces the latent stale mutation, but NOT REPRODUCED as a user-facing overlap: the timer requires no active subscribers, matching the prior review conclusion.

## Root cause

`reclaimTerminalForDesktop` cleared `pendingRestoreTimers` and `pendingSoftLeavers` in only one branch. The local held-fit, active-subscriber, remote-layout, orphan-driver, and no-lock legs could leave delayed mutations armed, allowing them to overwrite explicit desktop state. The `onPtyExit` path also retained a character-for-character copy of the extracted cleanup helper, allowing the two copies to drift.

## Fix

`reclaimTerminalForDesktop` now runs one `cancelPendingDriverMutations(ptyId)` sweep before every branch, and the duplicate `onPtyExit` cleanup delegates to that helper. The remote-layout (SSH/remote-host) leg has direct regression coverage, and a table-driven test asserts cancellation of both timer maps on the active-subscriber, orphan-driver, and no-lock legs.

## Intentional behavior change

Clearing `pendingSoftLeavers` on explicit desktop take-back intentionally revokes the departing phone's soft-leave grace admission used by `beginMobileInputFloor` and `mobileTookFloor`. An explicit desktop take-back must outrank the decaying 250 ms grace, so a phone send after take-back is rejected until the phone explicitly retakes the floor; these states are mutually exclusive and the behavior is contained to the main-process admission path.

## Non-vacuity proof

With the reclaim sweep mutated away, the targeted integration run failed 4 tests (remote-layout, active-subscriber, orphan-driver, and the active/orphan/no-lock pending-restore test): each retained `pendingSoftLeavers` or `pendingRestoreTimers` (`expected true to be false`). The real output was `Tests 4 failed | 46 passed | 2 skipped (52)`. Restoring the sweep with `git checkout HEAD -- src/main/runtime/orca-runtime.ts` produced `Tests 50 passed | 2 skipped (52)`.

## Verification

- `npm run typecheck` — passed.
- `npx oxfmt --write src/main/runtime/orca-runtime.ts src/main/runtime/mobile-subscribe-integration.test.ts` — passed.
- `pnpm vitest run --config config/vitest.config.ts --maxWorkers=2 src/main/runtime/mobile-subscribe-integration.test.ts` — 50 passed, 2 skipped.
- `npx oxlint src/main/runtime/orca-runtime.ts src/main/runtime/mobile-subscribe-integration.test.ts` — passed.

No Electron UI validation was needed; this is main-process timer/driver state. No wire format, folder-workspace, or platform-specific behavior changed.


