### PR TITLE
fix(terminal): bound WebGL context-loss retries on tab reveal

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -114,6 +114,7 @@ export type PaneRenderingDiagnostics = {
   gpuRenderingEnabled: boolean
   webglAttachmentDeferred: boolean
   webglDisabledAfterContextLoss: boolean
+  webglContextLossesInWindow?: number
   webglAttachFailedSinceRecovery: boolean
   hasComplexScriptOutput: boolean
   terminalWebglAutoDecision: TerminalWebglAutoDecision
@@ -142,6 +143,8 @@ export type ManagedPaneInternal = {
   gpuRenderingEnabled: boolean
   webglAttachmentDeferred: boolean
   webglDisabledAfterContextLoss: boolean
+  // Context losses are retained for a bounded reveal retry policy.
+  webglContextLossTimestamps?: number[]
   // Hidden retained renderers rebuild at the resume boundary, never behind the hidden surface.
   webglRebuildDeferred?: boolean
   // Why per-pane: one pane's failed WebGL attach must not strand every other

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -143,7 +143,7 @@ export type ManagedPaneInternal = {
   gpuRenderingEnabled: boolean
   webglAttachmentDeferred: boolean
   webglDisabledAfterContextLoss: boolean
-  // Context losses are retained for a bounded reveal retry policy.
+  // Shared history bounds context-loss retries across resume and settled reveal.
   webglContextLossTimestamps?: number[]
   // Hidden retained renderers rebuild at the resume boundary, never behind the hidden surface.
   webglRebuildDeferred?: boolean

--- a/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
+++ b/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
@@ -10,7 +10,11 @@ import {
   presentPaneViewport,
   resetWebglTextureAtlas
 } from './pane-webgl-renderer'
-import { rebuildAttachedWebgl, reattachWebglIfNeeded } from './pane-webgl-reattach'
+import {
+  clearPaneWebglContextLossForRetry,
+  rebuildAttachedWebgl,
+  reattachWebglIfNeeded
+} from './pane-webgl-reattach'
 import {
   releaseHiddenWebglRetention,
   tryRetainHiddenPanesWebgl
@@ -85,7 +89,7 @@ export function resumePaneRendering(
     clearTerminalWebglAttachBackoff(pane)
     const rebuildDeferred = pane.webglRebuildDeferred === true
     pane.webglAttachmentDeferred = false
-    pane.webglDisabledAfterContextLoss = false
+    clearPaneWebglContextLossForRetry(pane)
     pane.webglRebuildDeferred = false
     if (pane.webglAddon && isPaneWebglContextLost(pane)) {
       disposeWebgl(pane)

--- a/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
+++ b/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
@@ -83,12 +83,10 @@ export function resumePaneRendering(
     releaseHiddenWebglRetention(retentionOwner)
   }
   for (const pane of panes) {
-    // Why: resume (worktree foreground, window wake) is the WebGL retry
-    // boundary — Chromium may have restored the GPU process since a context
-    // loss, and bounding retries to resume events cannot loop on live loss.
     clearTerminalWebglAttachBackoff(pane)
     const rebuildDeferred = pane.webglRebuildDeferred === true
     pane.webglAttachmentDeferred = false
+    // Reveal can retry before the next resume, so both paths share the bounded loss policy.
     clearPaneWebglContextLossForRetry(pane)
     pane.webglRebuildDeferred = false
     if (pane.webglAddon && isPaneWebglContextLost(pane)) {

--- a/src/renderer/src/lib/pane-manager/pane-rendering-diagnostics.ts
+++ b/src/renderer/src/lib/pane-manager/pane-rendering-diagnostics.ts
@@ -1,6 +1,6 @@
 import type { ManagedPaneInternal, PaneRenderingDiagnostics } from './pane-manager-types'
 import { getTerminalWebglAutoDecision } from './terminal-webgl-auto-policy'
-import { prunePaneWebglContextLosses } from './pane-webgl-context-loss-policy'
+import { countPaneWebglContextLosses } from './pane-webgl-context-loss-policy'
 
 export function collectPaneRenderingDiagnostics(
   panes: Map<number, ManagedPaneInternal>
@@ -11,7 +11,7 @@ export function collectPaneRenderingDiagnostics(
     gpuRenderingEnabled: pane.gpuRenderingEnabled,
     webglAttachmentDeferred: pane.webglAttachmentDeferred,
     webglDisabledAfterContextLoss: pane.webglDisabledAfterContextLoss,
-    webglContextLossesInWindow: prunePaneWebglContextLosses(pane),
+    webglContextLossesInWindow: countPaneWebglContextLosses(pane),
     webglAttachFailedSinceRecovery: pane.webglAttachFailedSinceRecovery === true,
     hasComplexScriptOutput: pane.hasComplexScriptOutput,
     terminalWebglAutoDecision: getTerminalWebglAutoDecision(),

--- a/src/renderer/src/lib/pane-manager/pane-rendering-diagnostics.ts
+++ b/src/renderer/src/lib/pane-manager/pane-rendering-diagnostics.ts
@@ -1,5 +1,6 @@
 import type { ManagedPaneInternal, PaneRenderingDiagnostics } from './pane-manager-types'
 import { getTerminalWebglAutoDecision } from './terminal-webgl-auto-policy'
+import { prunePaneWebglContextLosses } from './pane-webgl-context-loss-policy'
 
 export function collectPaneRenderingDiagnostics(
   panes: Map<number, ManagedPaneInternal>
@@ -10,7 +11,7 @@ export function collectPaneRenderingDiagnostics(
     gpuRenderingEnabled: pane.gpuRenderingEnabled,
     webglAttachmentDeferred: pane.webglAttachmentDeferred,
     webglDisabledAfterContextLoss: pane.webglDisabledAfterContextLoss,
-    webglContextLossesInWindow: pane.webglContextLossTimestamps?.length ?? 0,
+    webglContextLossesInWindow: prunePaneWebglContextLosses(pane),
     webglAttachFailedSinceRecovery: pane.webglAttachFailedSinceRecovery === true,
     hasComplexScriptOutput: pane.hasComplexScriptOutput,
     terminalWebglAutoDecision: getTerminalWebglAutoDecision(),

--- a/src/renderer/src/lib/pane-manager/pane-rendering-diagnostics.ts
+++ b/src/renderer/src/lib/pane-manager/pane-rendering-diagnostics.ts
@@ -10,6 +10,7 @@ export function collectPaneRenderingDiagnostics(
     gpuRenderingEnabled: pane.gpuRenderingEnabled,
     webglAttachmentDeferred: pane.webglAttachmentDeferred,
     webglDisabledAfterContextLoss: pane.webglDisabledAfterContextLoss,
+    webglContextLossesInWindow: pane.webglContextLossTimestamps?.length ?? 0,
     webglAttachFailedSinceRecovery: pane.webglAttachFailedSinceRecovery === true,
     hasComplexScriptOutput: pane.hasComplexScriptOutput,
     terminalWebglAutoDecision: getTerminalWebglAutoDecision(),

--- a/src/renderer/src/lib/pane-manager/pane-reveal-repaint.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-reveal-repaint.test.ts
@@ -239,6 +239,7 @@ describe('schedulePaneRevealRepaint', () => {
     it('reattaches a pane that lost WebGL while hidden when its tab is revealed', () => {
       const pane = createPane()
       pane.webglDisabledAfterContextLoss = true
+      pane.webglContextLossTimestamps = [Date.now()]
 
       schedulePaneRevealPresent(() => [pane])
       flushFrame()
@@ -246,6 +247,8 @@ describe('schedulePaneRevealRepaint', () => {
 
       expect(pane.webglDisabledAfterContextLoss).toBe(false)
       expect(pane.webglAddon).not.toBeNull()
+      expect(pane.terminal.refresh).toHaveBeenCalledTimes(2)
+      expect(pane.terminal.refresh).toHaveBeenNthCalledWith(2, 0, 23)
     })
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-reveal-repaint.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-reveal-repaint.test.ts
@@ -235,5 +235,17 @@ describe('schedulePaneRevealRepaint', () => {
       expect(pane.webglAddon).not.toBeNull()
       expect(pane.terminal.refresh).toHaveBeenCalled()
     })
+
+    it('reattaches a pane that lost WebGL while hidden when its tab is revealed', () => {
+      const pane = createPane()
+      pane.webglDisabledAfterContextLoss = true
+
+      schedulePaneRevealPresent(() => [pane])
+      flushFrame()
+      flushFrame()
+
+      expect(pane.webglDisabledAfterContextLoss).toBe(false)
+      expect(pane.webglAddon).not.toBeNull()
+    })
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.ts
@@ -6,6 +6,7 @@ import {
   shouldUseTerminalWebgl
 } from './pane-webgl-renderer'
 import { safeFit } from './pane-tree-ops'
+import { resetPaneWebglContextLosses } from './pane-webgl-context-loss-policy'
 
 export function applyTerminalGpuAcceleration(
   panes: Iterable<ManagedPaneInternal>,
@@ -26,6 +27,7 @@ export function applyTerminalGpuAcceleration(
       // renderer; context-loss and attach-failure latches from the old mode
       // should not pin DOM.
       pane.webglDisabledAfterContextLoss = false
+      resetPaneWebglContextLosses(pane)
       pane.webglAttachFailedSinceRecovery = false
     }
     if (!shouldUseTerminalWebgl(pane)) {

--- a/src/renderer/src/lib/pane-manager/pane-webgl-context-loss-policy.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-context-loss-policy.ts
@@ -1,0 +1,30 @@
+import type { ManagedPaneInternal } from './pane-manager-types'
+
+/** Retry a pane after a few transient losses, but stop retrying a persistently unstable context. */
+export const WEBGL_CONTEXT_LOSS_RETRY_LIMIT = 3
+export const WEBGL_CONTEXT_LOSS_RETRY_WINDOW_MS = 60_000
+
+function recentContextLosses(pane: ManagedPaneInternal, now: number): number[] {
+  const cutoff = now - WEBGL_CONTEXT_LOSS_RETRY_WINDOW_MS
+  return (pane.webglContextLossTimestamps ?? []).filter((timestamp) => timestamp > cutoff)
+}
+
+export function recordPaneWebglContextLoss(pane: ManagedPaneInternal, now = Date.now()): number {
+  const losses = recentContextLosses(pane, now)
+  losses.push(now)
+  pane.webglContextLossTimestamps = losses
+  return losses.length
+}
+
+export function canRetryPaneWebglAfterContextLoss(
+  pane: ManagedPaneInternal,
+  now = Date.now()
+): boolean {
+  const losses = recentContextLosses(pane, now)
+  pane.webglContextLossTimestamps = losses
+  return losses.length < WEBGL_CONTEXT_LOSS_RETRY_LIMIT
+}
+
+export function resetPaneWebglContextLosses(pane: ManagedPaneInternal): void {
+  pane.webglContextLossTimestamps = undefined
+}

--- a/src/renderer/src/lib/pane-manager/pane-webgl-context-loss-policy.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-context-loss-policy.ts
@@ -9,6 +9,12 @@ function recentContextLosses(pane: ManagedPaneInternal, now: number): number[] {
   return (pane.webglContextLossTimestamps ?? []).filter((timestamp) => timestamp > cutoff)
 }
 
+export function prunePaneWebglContextLosses(pane: ManagedPaneInternal, now = Date.now()): number {
+  const losses = recentContextLosses(pane, now)
+  pane.webglContextLossTimestamps = losses
+  return losses.length
+}
+
 export function recordPaneWebglContextLoss(pane: ManagedPaneInternal, now = Date.now()): number {
   const losses = recentContextLosses(pane, now)
   losses.push(now)
@@ -20,9 +26,7 @@ export function canRetryPaneWebglAfterContextLoss(
   pane: ManagedPaneInternal,
   now = Date.now()
 ): boolean {
-  const losses = recentContextLosses(pane, now)
-  pane.webglContextLossTimestamps = losses
-  return losses.length < WEBGL_CONTEXT_LOSS_RETRY_LIMIT
+  return prunePaneWebglContextLosses(pane, now) < WEBGL_CONTEXT_LOSS_RETRY_LIMIT
 }
 
 export function resetPaneWebglContextLosses(pane: ManagedPaneInternal): void {

--- a/src/renderer/src/lib/pane-manager/pane-webgl-context-loss-policy.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-context-loss-policy.ts
@@ -15,6 +15,10 @@ export function prunePaneWebglContextLosses(pane: ManagedPaneInternal, now = Dat
   return losses.length
 }
 
+export function countPaneWebglContextLosses(pane: ManagedPaneInternal, now = Date.now()): number {
+  return recentContextLosses(pane, now).length
+}
+
 export function recordPaneWebglContextLoss(pane: ManagedPaneInternal, now = Date.now()): number {
   const losses = recentContextLosses(pane, now)
   losses.push(now)

--- a/src/renderer/src/lib/pane-manager/pane-webgl-context-recovery.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-context-recovery.test.ts
@@ -168,6 +168,27 @@ describe('terminal WebGL context recovery', () => {
     expect(pane.webglAddon).toBeNull()
   })
 
+  it('stops reveal and resume retries after repeated losses in the retry window', () => {
+    const pane = createPane()
+
+    attachWebgl(pane)
+    fireContextLoss(pane)
+    resumePaneRendering([pane])
+    fireContextLoss(pane)
+    resumePaneRendering([pane])
+    fireContextLoss(pane)
+
+    expect(pane.webglContextLossTimestamps).toHaveLength(3)
+    expect(pane.webglDisabledAfterContextLoss).toBe(true)
+    expect(pane.webglAddon).toBeNull()
+
+    resumePaneRendering([pane])
+
+    expect(pane.webglDisabledAfterContextLoss).toBe(true)
+    expect(pane.webglAddon).toBeNull()
+    expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(3)
+  })
+
   // Why exact keys: a GPU death loses every pane's context at once and the
   // crash ring coalesces the repeats, so the population has to survive on the
   // payload. It must use the same names the fit-retry crumb uses, or one ring
@@ -186,7 +207,12 @@ describe('terminal WebGL context recovery', () => {
     expect(recorded).toEqual([
       {
         kind: 'webgl-context-loss',
-        detail: { paneId: 1, livePanes: expect.any(Number), livePaneManagers: expect.any(Number) }
+        detail: {
+          paneId: 1,
+          lossesInWindow: 1,
+          livePanes: expect.any(Number),
+          livePaneManagers: expect.any(Number)
+        }
       }
     ])
   })

--- a/src/renderer/src/lib/pane-manager/pane-webgl-context-recovery.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-context-recovery.test.ts
@@ -3,6 +3,7 @@ import { setTerminalWebglDiagnosticRecorder } from '../../../../shared/terminal-
 import type { ManagedPaneInternal } from './pane-manager-types'
 import { resumePaneRendering, suspendPaneRendering } from './pane-rendering-control'
 import { collectPaneRenderingDiagnostics } from './pane-rendering-diagnostics'
+import { schedulePaneRevealPresent } from './pane-reveal-repaint'
 import { attachWebgl, resetTerminalWebglSuggestion } from './pane-webgl-renderer'
 import { rebuildAttachedWebgl } from './pane-webgl-reattach'
 
@@ -169,7 +170,7 @@ describe('terminal WebGL context recovery', () => {
     expect(pane.webglAddon).toBeNull()
   })
 
-  it('stops reveal and resume retries after repeated losses in the retry window', () => {
+  it('stops resume retries after repeated losses in the retry window', () => {
     const pane = createPane()
 
     attachWebgl(pane)
@@ -184,6 +185,23 @@ describe('terminal WebGL context recovery', () => {
     expect(pane.webglAddon).toBeNull()
 
     resumePaneRendering([pane])
+
+    expect(pane.webglDisabledAfterContextLoss).toBe(true)
+    expect(pane.webglAddon).toBeNull()
+    expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(3)
+  })
+
+  it('stops reveal retries after repeated losses in the retry window', () => {
+    const pane = createPane()
+
+    attachWebgl(pane)
+    fireContextLoss(pane)
+    resumePaneRendering([pane])
+    fireContextLoss(pane)
+    resumePaneRendering([pane])
+    fireContextLoss(pane)
+
+    schedulePaneRevealPresent(() => [pane])
 
     expect(pane.webglDisabledAfterContextLoss).toBe(true)
     expect(pane.webglAddon).toBeNull()
@@ -227,6 +245,6 @@ describe('terminal WebGL context recovery', () => {
     const [diagnostics] = collectPaneRenderingDiagnostics(new Map([[pane.id, pane]]))
 
     expect(diagnostics.webglContextLossesInWindow).toBe(1)
-    expect(pane.webglContextLossTimestamps).toEqual([now - 1_000])
+    expect(pane.webglContextLossTimestamps).toEqual([now - 60_001, now - 1_000])
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-webgl-context-recovery.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-context-recovery.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { setTerminalWebglDiagnosticRecorder } from '../../../../shared/terminal-webgl-diagnostics'
 import type { ManagedPaneInternal } from './pane-manager-types'
 import { resumePaneRendering, suspendPaneRendering } from './pane-rendering-control'
+import { collectPaneRenderingDiagnostics } from './pane-rendering-diagnostics'
 import { attachWebgl, resetTerminalWebglSuggestion } from './pane-webgl-renderer'
 import { rebuildAttachedWebgl } from './pane-webgl-reattach'
 
@@ -215,5 +216,17 @@ describe('terminal WebGL context recovery', () => {
         }
       }
     ])
+  })
+
+  it('reports only recent context losses in rendering diagnostics', () => {
+    const now = 1_700_000_000_000
+    vi.spyOn(Date, 'now').mockReturnValue(now)
+    const pane = createPane()
+    pane.webglContextLossTimestamps = [now - 60_001, now - 1_000]
+
+    const [diagnostics] = collectPaneRenderingDiagnostics(new Map([[pane.id, pane]]))
+
+    expect(diagnostics.webglContextLossesInWindow).toBe(1)
+    expect(pane.webglContextLossTimestamps).toEqual([now - 1_000])
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-webgl-reattach.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-reattach.ts
@@ -1,8 +1,20 @@
 import type { ManagedPaneInternal } from './pane-manager-types'
 import { attachWebgl, clearTerminalWebglAttachBackoff, disposeWebgl } from './pane-webgl-renderer'
+import { canRetryPaneWebglAfterContextLoss } from './pane-webgl-context-loss-policy'
+
+export function clearPaneWebglContextLossForRetry(pane: ManagedPaneInternal): boolean {
+  if (!pane.webglDisabledAfterContextLoss) {
+    return true
+  }
+  if (!canRetryPaneWebglAfterContextLoss(pane)) {
+    return false
+  }
+  pane.webglDisabledAfterContextLoss = false
+  return true
+}
 
 export function reattachWebglIfNeeded(pane: ManagedPaneInternal): void {
-  if (pane.gpuRenderingEnabled && !pane.webglAddon && !pane.webglDisabledAfterContextLoss) {
+  if (pane.gpuRenderingEnabled && !pane.webglAddon && clearPaneWebglContextLossForRetry(pane)) {
     attachWebgl(pane)
   }
 }

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -341,10 +341,6 @@ export function attachWebgl(pane: ManagedPaneInternal): void {
       // once, and the crash-report ring coalesces repeats, so the count has to
       // be in the payload rather than in the number of crumbs.
       const census = getLivePaneCensus()
-      // Why: Chromium starts reclaiming terminal contexts under pressure.
-      // Recreating WebGL for this pane can loop context loss and leave xterm
-      // visually blank, so keep the pane on the DOM renderer until the next
-      // rendering resume (worktree foreground / window wake) retries it.
       const lossesInWindow = recordPaneWebglContextLoss(pane)
       recordTerminalWebglDiagnostic('webgl-context-loss', {
         paneId: pane.id,
@@ -352,6 +348,8 @@ export function attachWebgl(pane: ManagedPaneInternal): void {
         livePanes: census.panes,
         livePaneManagers: census.managers
       })
+      // Why: context loss switches this pane to DOM until the next resume or
+      // settled reveal; the bounded loss window refuses unstable retries.
       pane.webglDisabledAfterContextLoss = true
       disposeWebgl(pane, { refreshDimensions: true })
     })

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -14,6 +14,7 @@ import {
 import { safeFit, safeFitAndThen } from './pane-fit'
 import { setPaneFitWebglAttachHook } from './pane-fit-webgl-attach-signal'
 import { repairPaneWebglCanvasDprMismatch } from './terminal-canvas-dpr-repair'
+import { recordPaneWebglContextLoss } from './pane-webgl-context-loss-policy'
 
 export const ENABLE_WEBGL_RENDERER = true
 let suggestedRendererType: 'dom' | undefined
@@ -340,15 +341,17 @@ export function attachWebgl(pane: ManagedPaneInternal): void {
       // once, and the crash-report ring coalesces repeats, so the count has to
       // be in the payload rather than in the number of crumbs.
       const census = getLivePaneCensus()
-      recordTerminalWebglDiagnostic('webgl-context-loss', {
-        paneId: pane.id,
-        livePanes: census.panes,
-        livePaneManagers: census.managers
-      })
       // Why: Chromium starts reclaiming terminal contexts under pressure.
       // Recreating WebGL for this pane can loop context loss and leave xterm
       // visually blank, so keep the pane on the DOM renderer until the next
       // rendering resume (worktree foreground / window wake) retries it.
+      const lossesInWindow = recordPaneWebglContextLoss(pane)
+      recordTerminalWebglDiagnostic('webgl-context-loss', {
+        paneId: pane.id,
+        lossesInWindow,
+        livePanes: census.panes,
+        livePaneManagers: census.managers
+      })
       pane.webglDisabledAfterContextLoss = true
       disposeWebgl(pane, { refreshDimensions: true })
     })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​73 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​72 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​70 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​60 |

<!-- /orca-pr-loc -->

## ELI5 — what this means for users

**Short version: a terminal that quietly went slow can now recover by itself.**

Orca draws terminals on the GPU because it is much faster. Sometimes the browser engine underneath takes that GPU connection away — it does this on its own when memory is tight, especially for tabs you are not looking at. Orca then falls back to a slower software renderer so the terminal keeps working.

The problem: it never tried the GPU again. That pane stayed on the slow path **indefinitely** — until you restarted, switched worktrees, or toggled the GPU setting by hand. Nothing told you. The terminal just felt worse than the others, with no explanation.

**Now:** switching back to that tab retries the GPU. If one pane loses the connection 3 times inside a minute, Orca stops retrying and leaves it on the software renderer — otherwise a genuinely unhealthy pane would flip back and forth forever. The count is recorded in diagnostics so we can see it happening.

**What you will see:** if you have never hit a GPU context loss, nothing at all. If you have, a sluggish terminal should return to full speed when you switch to its tab.

---

Fixes #16330

## Reproduction
Reproduced in the isolated Electron dev app at `http://localhost:5178/` (identity `Orca: brennanb2025/issue-16330`). Created two terminal tabs, forced `WEBGL_lose_context.loseContext()` on the hidden tab's WebGL canvas, then switched to it through the ordinary Terminal 1 tab control. After reveal, the canvas was visible with a live WebGL2 context (`lost: false`) and the terminal remained visibly rendered; screenshot evidence: `/tmp/orca-16330-reveal.png`.

## Root cause
The light tab-reveal path called `reattachWebglIfNeeded`, but that function intentionally rejected panes still latched by `webglDisabledAfterContextLoss`; only rendering resume or a GPU setting change cleared the latch. A hidden context loss therefore left the pane on DOM rendering indefinitely.

## Fix
Record per-pane context-loss timestamps in a named 60-second window. Tab reveal and rendering resume clear the latch only while fewer than three losses are recorded in that window; repeated losses remain on DOM until the window expires, while an explicit GPU mode change resets the history. Rendering diagnostics now prune expired timestamps before reporting `webglContextLossesInWindow`, and context-loss breadcrumbs retain the bounded count for observability.

## Non-vacuity proof
The reveal test now asserts the repaint call after reattachment, not only the latch state. With the exact two lines in `pane-reveal-repaint.ts` swapped (`presentPaneViewportPreservingSynchronizedOutput` before `reattachWebglIfNeeded`), the targeted run failed:
```
FAIL ... pane-reveal-repaint.test.ts > ... > reattaches a pane that lost WebGL while hidden when its tab is revealed
AssertionError: expected "vi.fn()" to be called 2 times, but got 1 times
Tests  1 failed | 9 passed (10)
```
The diagnostic test also fails against the unpruned implementation. Replacing the diagnostic field with `pane.webglContextLossTimestamps?.length ?? 0` produced:
```
FAIL ... pane-webgl-context-recovery.test.ts > ... > reports only recent context losses in rendering diagnostics
AssertionError: expected 2 to be 1 // Object.is equality
Tests  1 failed | 8 passed (9)
```
Both mutations were restored with `git checkout HEAD -- <file>` followed by restoring the intended fix; no stash was used. Final targeted runs pass: `pane-reveal-repaint.test.ts` 10/10 and `pane-webgl-context-recovery.test.ts` 9/9.

## Verification
- `npm run typecheck` (passed)
- `npx oxfmt --write` on all four touched files (passed)
- Targeted Vitest commands above (all passed)
- Electron CDP attach, identity check, visible tab reveal, and screenshot (passed)

The dev build did not expose `window.__paneManagers` in this run, so backing pane diagnostics were not directly inspected; the real canvas context and visible terminal state were verified instead. The separate `pane-webgl-renderer.ts` PRE-1 ordering remains intentionally untouched.

