### PR TITLE
fix(mobile): honor host worktree create retention

### DIFF
--- a/mobile/src/components/use-new-workspace-create-submit.ts
+++ b/mobile/src/components/use-new-workspace-create-submit.ts
@@ -16,6 +16,7 @@ import { normalizeWorkspaceAgent } from '../tasks/workspace-agent-selection'
 import type { WorkspaceCreateSetupDecision } from '../tasks/workspace-create-params'
 import type { WorkspaceSshGate } from '../tasks/workspace-ssh-gate'
 import type { useMobileComposerSource } from '../tasks/use-mobile-composer-source'
+import type { WorktreeCreateIdempotencySupport } from '../tasks/worktree-create-idempotency-policy'
 import {
   pickPreferredNewWorktreeAgent,
   type NewWorktreeAgentOption,
@@ -54,7 +55,7 @@ export function useNewWorkspaceCreateSubmit(args: {
   runSetup: boolean
   trustedOrcaHooks: PersistedTrustedOrcaHooks
   setTrustedOrcaHooks: (trust: PersistedTrustedOrcaHooks) => void
-  getWorktreeCreateCutoverSupport: () => Promise<boolean>
+  getWorktreeCreateCutoverSupport: () => Promise<WorktreeCreateIdempotencySupport | false>
   transitionDrawer: (view: Exclude<NewWorktreeDrawerView, 'transition'>) => void
   setError: Dispatch<SetStateAction<string>>
   onCreated: (worktreeId: string, name: string) => void
@@ -163,7 +164,7 @@ export function useNewWorkspaceCreateSubmit(args: {
             workspaceName: trimmedName || undefined,
             note: trimmedNote,
             nameIsAutoManaged: args.composer.isNameAutoManaged,
-            supportsIdempotentCutoverRetry: args.getWorktreeCreateCutoverSupport()
+            worktreeCreateIdempotency: args.getWorktreeCreateCutoverSupport()
           })
         : await createBlankWorkspace({
             client,
@@ -173,7 +174,7 @@ export function useNewWorkspaceCreateSubmit(args: {
             createdWithAgentId,
             comment: trimmedNote,
             setupDecision,
-            supportsIdempotentCutoverRetry: args.getWorktreeCreateCutoverSupport()
+            worktreeCreateIdempotency: args.getWorktreeCreateCutoverSupport()
           })
       if ('error' in result) {
         args.setError(result.error)

--- a/mobile/src/tasks/blank-workspace-create.test.ts
+++ b/mobile/src/tasks/blank-workspace-create.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import type { RpcClient } from '../transport/rpc-client'
 import { createBlankWorkspace } from './blank-workspace-create'
-import { WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS } from './worktree-create-idempotency-policy'
+import { WORKTREE_CREATE_DEDUPE_TTL_LEGACY_HOST_MS } from './worktree-create-idempotency-policy'
 
 type Call = { method: string; params: unknown }
 
 const IDEMPOTENT_CREATE_SUPPORT = {
-  dedupeTtlMs: WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS
+  dedupeTtlMs: WORKTREE_CREATE_DEDUPE_TTL_LEGACY_HOST_MS
 }
 
 function fakeClient(script: (method: string, call: number) => unknown, calls: Call[]): RpcClient {
@@ -40,7 +40,7 @@ describe('createBlankWorkspace', () => {
       comment: undefined,
       setupDecision: 'inherit',
       nameWasGenerated: false,
-      supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT
+      worktreeCreateIdempotency: IDEMPOTENT_CREATE_SUPPORT
     })
 
     expect(result).toEqual({ worktreeId: 'wt-1', name: 'octopus' })
@@ -75,7 +75,7 @@ describe('createBlankWorkspace', () => {
       comment: undefined,
       setupDecision: 'inherit',
       nameWasGenerated: true,
-      supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT
+      worktreeCreateIdempotency: IDEMPOTENT_CREATE_SUPPORT
     })
 
     expect(calls[0]?.params).toMatchObject({ nameWasGenerated: true })
@@ -95,7 +95,7 @@ describe('createBlankWorkspace', () => {
       comment: 'spike',
       setupDecision: 'run',
       nameWasGenerated: false,
-      supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT
+      worktreeCreateIdempotency: IDEMPOTENT_CREATE_SUPPORT
     })
 
     const params = calls[0]?.params as Record<string, unknown>
@@ -127,7 +127,7 @@ describe('createBlankWorkspace', () => {
       comment: undefined,
       setupDecision: 'inherit',
       nameWasGenerated: false,
-      supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT
+      worktreeCreateIdempotency: IDEMPOTENT_CREATE_SUPPORT
     })
 
     expect(result).toEqual({ worktreeId: 'wt-3', name: 'octopus-2' })
@@ -153,7 +153,7 @@ describe('createBlankWorkspace', () => {
       comment: undefined,
       setupDecision: 'inherit',
       nameWasGenerated: false,
-      supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT
+      worktreeCreateIdempotency: IDEMPOTENT_CREATE_SUPPORT
     })
 
     expect(result).toEqual({ worktreeId: 'wt-4', name: 'octopus-2' })
@@ -172,7 +172,7 @@ describe('createBlankWorkspace', () => {
       comment: undefined,
       setupDecision: 'skip',
       nameWasGenerated: false,
-      supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT
+      worktreeCreateIdempotency: IDEMPOTENT_CREATE_SUPPORT
     })
 
     expect(result).toEqual({ error: 'SSH connection is not available' })

--- a/mobile/src/tasks/blank-workspace-create.test.ts
+++ b/mobile/src/tasks/blank-workspace-create.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from 'vitest'
 import type { RpcClient } from '../transport/rpc-client'
 import { createBlankWorkspace } from './blank-workspace-create'
+import { WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS } from './worktree-create-idempotency-policy'
 
 type Call = { method: string; params: unknown }
+
+const IDEMPOTENT_CREATE_SUPPORT = {
+  dedupeTtlMs: WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS
+}
 
 function fakeClient(script: (method: string, call: number) => unknown, calls: Call[]): RpcClient {
   return {
@@ -35,7 +40,7 @@ describe('createBlankWorkspace', () => {
       comment: undefined,
       setupDecision: 'inherit',
       nameWasGenerated: false,
-      supportsIdempotentCutoverRetry: true
+      supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT
     })
 
     expect(result).toEqual({ worktreeId: 'wt-1', name: 'octopus' })
@@ -70,7 +75,7 @@ describe('createBlankWorkspace', () => {
       comment: undefined,
       setupDecision: 'inherit',
       nameWasGenerated: true,
-      supportsIdempotentCutoverRetry: true
+      supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT
     })
 
     expect(calls[0]?.params).toMatchObject({ nameWasGenerated: true })
@@ -90,7 +95,7 @@ describe('createBlankWorkspace', () => {
       comment: 'spike',
       setupDecision: 'run',
       nameWasGenerated: false,
-      supportsIdempotentCutoverRetry: true
+      supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT
     })
 
     const params = calls[0]?.params as Record<string, unknown>
@@ -122,7 +127,7 @@ describe('createBlankWorkspace', () => {
       comment: undefined,
       setupDecision: 'inherit',
       nameWasGenerated: false,
-      supportsIdempotentCutoverRetry: true
+      supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT
     })
 
     expect(result).toEqual({ worktreeId: 'wt-3', name: 'octopus-2' })
@@ -148,7 +153,7 @@ describe('createBlankWorkspace', () => {
       comment: undefined,
       setupDecision: 'inherit',
       nameWasGenerated: false,
-      supportsIdempotentCutoverRetry: true
+      supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT
     })
 
     expect(result).toEqual({ worktreeId: 'wt-4', name: 'octopus-2' })
@@ -167,7 +172,7 @@ describe('createBlankWorkspace', () => {
       comment: undefined,
       setupDecision: 'skip',
       nameWasGenerated: false,
-      supportsIdempotentCutoverRetry: true
+      supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT
     })
 
     expect(result).toEqual({ error: 'SSH connection is not available' })

--- a/mobile/src/tasks/blank-workspace-create.ts
+++ b/mobile/src/tasks/blank-workspace-create.ts
@@ -20,13 +20,13 @@ export async function createBlankWorkspace(args: {
   /** True when `baseName` is a generated creature name rather than one the user typed; only then
    *  may the host retire it. */
   nameWasGenerated: boolean
-  supportsIdempotentCutoverRetry: WorktreeCreateIdempotencyProbe
+  worktreeCreateIdempotency: WorktreeCreateIdempotencyProbe
 }): Promise<WorktreeCreateResult> {
   return createWorktreeWithNameRetry({
     client: args.client,
     baseName: args.baseName,
     nameWasGenerated: args.nameWasGenerated,
-    supportsIdempotentCutoverRetry: args.supportsIdempotentCutoverRetry,
+    worktreeCreateIdempotency: args.worktreeCreateIdempotency,
     buildParams: (name) => {
       const params: Record<string, unknown> = {
         repo: `id:${args.repoId}`,

--- a/mobile/src/tasks/blank-workspace-create.ts
+++ b/mobile/src/tasks/blank-workspace-create.ts
@@ -1,6 +1,7 @@
 import type { TuiAgent } from '../../../src/shared/tui-agent'
 import type { RpcClient } from '../transport/rpc-client'
 import { createWorktreeWithNameRetry, type WorktreeCreateResult } from './worktree-create-retry'
+import type { WorktreeCreateIdempotencyProbe } from './worktree-create-idempotency-policy'
 import {
   agentLaunchCreateFields,
   type WorkspaceCreateSetupDecision
@@ -19,7 +20,7 @@ export async function createBlankWorkspace(args: {
   /** True when `baseName` is a generated creature name rather than one the user typed; only then
    *  may the host retire it. */
   nameWasGenerated: boolean
-  supportsIdempotentCutoverRetry: boolean | Promise<boolean>
+  supportsIdempotentCutoverRetry: WorktreeCreateIdempotencyProbe
 }): Promise<WorktreeCreateResult> {
   return createWorktreeWithNameRetry({
     client: args.client,

--- a/mobile/src/tasks/source-workspace-create.test.ts
+++ b/mobile/src/tasks/source-workspace-create.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { RpcClient } from '../transport/rpc-client'
 import { createWorkspaceFromComposerSource } from './source-workspace-create'
 import type { MobileComposerCreateSelection } from './mobile-composer-source-types'
+import { WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS } from './worktree-create-idempotency-policy'
 
 type Call = { method: string; params: Record<string, unknown> }
 
@@ -24,6 +25,9 @@ function fakeClient(handle: (method: string, call: number) => unknown, calls: Ca
 }
 
 const agent = { choice: 'blank' as const }
+const IDEMPOTENT_CREATE_SUPPORT = {
+  dedupeTtlMs: WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS
+}
 
 const baseArgs = {
   targetRepoId: 'repo-1',
@@ -31,7 +35,7 @@ const baseArgs = {
   agent,
   workspaceName: undefined,
   note: undefined,
-  supportsIdempotentCutoverRetry: true
+  supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT
 }
 
 describe('createWorkspaceFromComposerSource', () => {

--- a/mobile/src/tasks/source-workspace-create.test.ts
+++ b/mobile/src/tasks/source-workspace-create.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { RpcClient } from '../transport/rpc-client'
 import { createWorkspaceFromComposerSource } from './source-workspace-create'
 import type { MobileComposerCreateSelection } from './mobile-composer-source-types'
-import { WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS } from './worktree-create-idempotency-policy'
+import { WORKTREE_CREATE_DEDUPE_TTL_LEGACY_HOST_MS } from './worktree-create-idempotency-policy'
 
 type Call = { method: string; params: Record<string, unknown> }
 
@@ -26,7 +26,7 @@ function fakeClient(handle: (method: string, call: number) => unknown, calls: Ca
 
 const agent = { choice: 'blank' as const }
 const IDEMPOTENT_CREATE_SUPPORT = {
-  dedupeTtlMs: WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS
+  dedupeTtlMs: WORKTREE_CREATE_DEDUPE_TTL_LEGACY_HOST_MS
 }
 
 const baseArgs = {
@@ -35,7 +35,7 @@ const baseArgs = {
   agent,
   workspaceName: undefined,
   note: undefined,
-  supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT
+  worktreeCreateIdempotency: IDEMPOTENT_CREATE_SUPPORT
 }
 
 describe('createWorkspaceFromComposerSource', () => {

--- a/mobile/src/tasks/source-workspace-create.ts
+++ b/mobile/src/tasks/source-workspace-create.ts
@@ -30,7 +30,7 @@ export type CreateWorkspaceFromComposerArgs = {
   workspaceName: string | undefined
   note: string | undefined
   nameIsAutoManaged?: boolean
-  supportsIdempotentCutoverRetry: WorktreeCreateIdempotencyProbe
+  worktreeCreateIdempotency: WorktreeCreateIdempotencyProbe
 }
 
 export async function createWorkspaceFromComposerSource(
@@ -93,7 +93,7 @@ async function createWorkItemWorkspace(args: {
   workspaceName: string | undefined
   note: string | undefined
   nameIsAutoManaged?: boolean
-  supportsIdempotentCutoverRetry: WorktreeCreateIdempotencyProbe
+  worktreeCreateIdempotency: WorktreeCreateIdempotencyProbe
 }): Promise<WorktreeCreateResult> {
   const { client, selection, targetRepoId, setupDecision, agent, workspaceName, note } = args
   const item = selection.item
@@ -138,7 +138,7 @@ async function createWorkItemWorkspace(args: {
   return createWorktreeWithNameRetry({
     client,
     baseName,
-    supportsIdempotentCutoverRetry: args.supportsIdempotentCutoverRetry,
+    worktreeCreateIdempotency: args.worktreeCreateIdempotency,
     buildParams: (name) => ({ ...params, name })
   })
 }
@@ -151,7 +151,7 @@ async function createBranchWorkspace(args: {
   agent: WorkspaceCreateAgentBundle
   workspaceName: string | undefined
   note: string | undefined
-  supportsIdempotentCutoverRetry: WorktreeCreateIdempotencyProbe
+  worktreeCreateIdempotency: WorktreeCreateIdempotencyProbe
 }): Promise<WorktreeCreateResult> {
   const { client, selection, targetRepoId, setupDecision, agent, workspaceName, note } = args
   const createdWithAgentId = agent.choice === 'blank' ? undefined : agent.choice
@@ -175,7 +175,7 @@ async function createBranchWorkspace(args: {
     return createWorktreeWithNameRetry({
       client,
       baseName,
-      supportsIdempotentCutoverRetry: args.supportsIdempotentCutoverRetry,
+      worktreeCreateIdempotency: args.worktreeCreateIdempotency,
       maxAttempts: 1,
       buildParams: (name) =>
         applyCommon({
@@ -197,7 +197,7 @@ async function createBranchWorkspace(args: {
   return createWorktreeWithNameRetry({
     client,
     baseName,
-    supportsIdempotentCutoverRetry: args.supportsIdempotentCutoverRetry,
+    worktreeCreateIdempotency: args.worktreeCreateIdempotency,
     buildParams: (candidate) => {
       const params: Record<string, unknown> = {
         repo: `id:${targetRepoId}`,
@@ -221,7 +221,7 @@ async function createNewBranchWorkspace(args: {
   agent: WorkspaceCreateAgentBundle
   workspaceName: string | undefined
   note: string | undefined
-  supportsIdempotentCutoverRetry: WorktreeCreateIdempotencyProbe
+  worktreeCreateIdempotency: WorktreeCreateIdempotencyProbe
 }): Promise<WorktreeCreateResult> {
   const { client, selection, targetRepoId, setupDecision, agent, note } = args
   const createdWithAgentId = agent.choice === 'blank' ? undefined : agent.choice
@@ -233,7 +233,7 @@ async function createNewBranchWorkspace(args: {
   return createWorktreeWithNameRetry({
     client,
     baseName: selection.branchName,
-    supportsIdempotentCutoverRetry: args.supportsIdempotentCutoverRetry,
+    worktreeCreateIdempotency: args.worktreeCreateIdempotency,
     buildParams: (candidate) => {
       const params: Record<string, unknown> = {
         repo: `id:${targetRepoId}`,

--- a/mobile/src/tasks/source-workspace-create.ts
+++ b/mobile/src/tasks/source-workspace-create.ts
@@ -13,6 +13,7 @@ import {
   type WorkspaceCreateTaskItem
 } from './workspace-create-params'
 import { createWorktreeWithNameRetry, type WorktreeCreateResult } from './worktree-create-retry'
+import type { WorktreeCreateIdempotencyProbe } from './worktree-create-idempotency-policy'
 
 // The agent bundle the modal resolved: `choice` drives launch resolution — the
 // host applies the agent's launch args (permission flags) and shell quoting.
@@ -29,7 +30,7 @@ export type CreateWorkspaceFromComposerArgs = {
   workspaceName: string | undefined
   note: string | undefined
   nameIsAutoManaged?: boolean
-  supportsIdempotentCutoverRetry: boolean | Promise<boolean>
+  supportsIdempotentCutoverRetry: WorktreeCreateIdempotencyProbe
 }
 
 export async function createWorkspaceFromComposerSource(
@@ -92,7 +93,7 @@ async function createWorkItemWorkspace(args: {
   workspaceName: string | undefined
   note: string | undefined
   nameIsAutoManaged?: boolean
-  supportsIdempotentCutoverRetry: boolean | Promise<boolean>
+  supportsIdempotentCutoverRetry: WorktreeCreateIdempotencyProbe
 }): Promise<WorktreeCreateResult> {
   const { client, selection, targetRepoId, setupDecision, agent, workspaceName, note } = args
   const item = selection.item
@@ -150,7 +151,7 @@ async function createBranchWorkspace(args: {
   agent: WorkspaceCreateAgentBundle
   workspaceName: string | undefined
   note: string | undefined
-  supportsIdempotentCutoverRetry: boolean | Promise<boolean>
+  supportsIdempotentCutoverRetry: WorktreeCreateIdempotencyProbe
 }): Promise<WorktreeCreateResult> {
   const { client, selection, targetRepoId, setupDecision, agent, workspaceName, note } = args
   const createdWithAgentId = agent.choice === 'blank' ? undefined : agent.choice
@@ -220,7 +221,7 @@ async function createNewBranchWorkspace(args: {
   agent: WorkspaceCreateAgentBundle
   workspaceName: string | undefined
   note: string | undefined
-  supportsIdempotentCutoverRetry: boolean | Promise<boolean>
+  supportsIdempotentCutoverRetry: WorktreeCreateIdempotencyProbe
 }): Promise<WorktreeCreateResult> {
   const { client, selection, targetRepoId, setupDecision, agent, note } = args
   const createdWithAgentId = agent.choice === 'blank' ? undefined : agent.choice

--- a/mobile/src/tasks/worktree-create-capability.test.ts
+++ b/mobile/src/tasks/worktree-create-capability.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest'
 import type { RpcClient } from '../transport/rpc-client'
 import { LogicalClientCutoverError } from '../transport/stable-logical-rpc-client'
 import { readNewWorktreeRuntimeCapabilities } from './worktree-create-capability'
-import { WORKTREE_CREATE_DEDUPE_TTL_LEGACY_HOST_MS } from './worktree-create-idempotency-policy'
+import {
+  WORKTREE_CREATE_DEDUPE_TTL_CLIENT_CEILING_MS,
+  WORKTREE_CREATE_DEDUPE_TTL_LEGACY_HOST_MS
+} from './worktree-create-idempotency-policy'
 
 type StatusOutcome =
   | 'cutover'
@@ -10,7 +13,7 @@ type StatusOutcome =
   | string[]
   | {
       capabilities?: string[]
-      worktreeCreateIdempotency?: { dedupeTtlMs: unknown }
+      worktreeCreateIdempotency?: unknown
     }
 
 function statusClient(outcomes: StatusOutcome[]): RpcClient {
@@ -61,10 +64,35 @@ describe('readNewWorktreeRuntimeCapabilities', () => {
       readNewWorktreeRuntimeCapabilities(statusClient([['worktree.create-idempotency.v1']]))
     ).resolves.toEqual({
       tasksSupported: false,
-      worktreeCreateIdempotency: { dedupeTtlMs: WORKTREE_CREATE_DEDUPE_TTL_LEGACY_HOST_MS },
+      worktreeCreateIdempotency: { dedupeTtlMs: WORKTREE_CREATE_DEDUPE_TTL_CLIENT_CEILING_MS },
       hostPlatform: 'darwin'
     })
   })
+
+  it.each([
+    { label: 'null', value: null },
+    { label: 'string', value: 'nonsense' },
+    { label: 'number', value: 20_000 },
+    { label: 'empty array', value: [] }
+  ])(
+    'fails closed for a malformed idempotency container ($label)',
+    async ({ value: worktreeCreateIdempotency }) => {
+      await expect(
+        readNewWorktreeRuntimeCapabilities(
+          statusClient([
+            {
+              capabilities: ['worktree.create-idempotency.v1'],
+              worktreeCreateIdempotency
+            }
+          ])
+        )
+      ).resolves.toEqual({
+        tasksSupported: false,
+        worktreeCreateIdempotency: { dedupeTtlMs: 0 },
+        hostPlatform: 'darwin'
+      })
+    }
+  )
 
   it('clamps an over-large host advertisement to the client fallback ceiling', async () => {
     await expect(

--- a/mobile/src/tasks/worktree-create-capability.test.ts
+++ b/mobile/src/tasks/worktree-create-capability.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { RpcClient } from '../transport/rpc-client'
 import { LogicalClientCutoverError } from '../transport/stable-logical-rpc-client'
 import { readNewWorktreeRuntimeCapabilities } from './worktree-create-capability'
-import { WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS } from './worktree-create-idempotency-policy'
+import { WORKTREE_CREATE_DEDUPE_TTL_LEGACY_HOST_MS } from './worktree-create-idempotency-policy'
 
 type StatusOutcome =
   | 'cutover'
@@ -61,7 +61,7 @@ describe('readNewWorktreeRuntimeCapabilities', () => {
       readNewWorktreeRuntimeCapabilities(statusClient([['worktree.create-idempotency.v1']]))
     ).resolves.toEqual({
       tasksSupported: false,
-      worktreeCreateIdempotency: { dedupeTtlMs: WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS },
+      worktreeCreateIdempotency: { dedupeTtlMs: WORKTREE_CREATE_DEDUPE_TTL_LEGACY_HOST_MS },
       hostPlatform: 'darwin'
     })
   })
@@ -78,10 +78,30 @@ describe('readNewWorktreeRuntimeCapabilities', () => {
       )
     ).resolves.toEqual({
       tasksSupported: false,
-      worktreeCreateIdempotency: { dedupeTtlMs: WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS },
+      worktreeCreateIdempotency: { dedupeTtlMs: WORKTREE_CREATE_DEDUPE_TTL_LEGACY_HOST_MS },
       hostPlatform: 'darwin'
     })
   })
+
+  it.each(['60000', -1, Number.NaN, 60_000.5, {}])(
+    'fails closed for malformed host advertisement %j',
+    async (advertisedDedupeTtlMs) => {
+      await expect(
+        readNewWorktreeRuntimeCapabilities(
+          statusClient([
+            {
+              capabilities: ['worktree.create-idempotency.v1'],
+              worktreeCreateIdempotency: { dedupeTtlMs: advertisedDedupeTtlMs }
+            }
+          ])
+        )
+      ).resolves.toEqual({
+        tasksSupported: false,
+        worktreeCreateIdempotency: { dedupeTtlMs: 0 },
+        hostPlatform: 'darwin'
+      })
+    }
+  )
 
   it('retries the safe status probe after a connection cutover', async () => {
     await expect(

--- a/mobile/src/tasks/worktree-create-capability.test.ts
+++ b/mobile/src/tasks/worktree-create-capability.test.ts
@@ -2,8 +2,18 @@ import { describe, expect, it } from 'vitest'
 import type { RpcClient } from '../transport/rpc-client'
 import { LogicalClientCutoverError } from '../transport/stable-logical-rpc-client'
 import { readNewWorktreeRuntimeCapabilities } from './worktree-create-capability'
+import { WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS } from './worktree-create-idempotency-policy'
 
-function statusClient(outcomes: Array<'cutover' | 'error' | string[]>): RpcClient {
+type StatusOutcome =
+  | 'cutover'
+  | 'error'
+  | string[]
+  | {
+      capabilities?: string[]
+      worktreeCreateIdempotency?: { dedupeTtlMs: unknown }
+    }
+
+function statusClient(outcomes: StatusOutcome[]): RpcClient {
   let call = 0
   return {
     sendRequest: async () => {
@@ -15,10 +25,13 @@ function statusClient(outcomes: Array<'cutover' | 'error' | string[]>): RpcClien
       if (outcome === 'error') {
         throw new Error('offline')
       }
+      const result = Array.isArray(outcome)
+        ? { capabilities: outcome, hostPlatform: 'darwin' }
+        : { ...outcome, hostPlatform: 'darwin' }
       return {
         id: '1',
         ok: true,
-        result: { capabilities: outcome, hostPlatform: 'darwin' },
+        result,
         _meta: { runtimeId: 'r' }
       }
     }
@@ -29,11 +42,43 @@ describe('readNewWorktreeRuntimeCapabilities', () => {
   it('reads task and idempotent-create support from status.get', async () => {
     await expect(
       readNewWorktreeRuntimeCapabilities(
-        statusClient([['mobile.tasks.v1', 'worktree.create-idempotency.v1']])
+        statusClient([
+          {
+            capabilities: ['mobile.tasks.v1', 'worktree.create-idempotency.v1'],
+            worktreeCreateIdempotency: { dedupeTtlMs: 20_000 }
+          }
+        ])
       )
     ).resolves.toEqual({
       tasksSupported: true,
-      idempotentWorktreeCreateSupported: true,
+      worktreeCreateIdempotency: { dedupeTtlMs: 20_000 },
+      hostPlatform: 'darwin'
+    })
+  })
+
+  it('uses the bounded fallback for an old idempotent host without an advertisement', async () => {
+    await expect(
+      readNewWorktreeRuntimeCapabilities(statusClient([['worktree.create-idempotency.v1']]))
+    ).resolves.toEqual({
+      tasksSupported: false,
+      worktreeCreateIdempotency: { dedupeTtlMs: WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS },
+      hostPlatform: 'darwin'
+    })
+  })
+
+  it('clamps an over-large host advertisement to the client fallback ceiling', async () => {
+    await expect(
+      readNewWorktreeRuntimeCapabilities(
+        statusClient([
+          {
+            capabilities: ['worktree.create-idempotency.v1'],
+            worktreeCreateIdempotency: { dedupeTtlMs: 600_000 }
+          }
+        ])
+      )
+    ).resolves.toEqual({
+      tasksSupported: false,
+      worktreeCreateIdempotency: { dedupeTtlMs: WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS },
       hostPlatform: 'darwin'
     })
   })
@@ -41,11 +86,17 @@ describe('readNewWorktreeRuntimeCapabilities', () => {
   it('retries the safe status probe after a connection cutover', async () => {
     await expect(
       readNewWorktreeRuntimeCapabilities(
-        statusClient(['cutover', ['worktree.create-idempotency.v1']])
+        statusClient([
+          'cutover',
+          {
+            capabilities: ['worktree.create-idempotency.v1'],
+            worktreeCreateIdempotency: { dedupeTtlMs: 30_000 }
+          }
+        ])
       )
     ).resolves.toEqual({
       tasksSupported: false,
-      idempotentWorktreeCreateSupported: true,
+      worktreeCreateIdempotency: { dedupeTtlMs: 30_000 },
       hostPlatform: 'darwin'
     })
   })
@@ -53,7 +104,7 @@ describe('readNewWorktreeRuntimeCapabilities', () => {
   it('fails closed when capability detection is unavailable', async () => {
     await expect(readNewWorktreeRuntimeCapabilities(statusClient(['error']))).resolves.toEqual({
       tasksSupported: false,
-      idempotentWorktreeCreateSupported: false,
+      worktreeCreateIdempotency: false,
       hostPlatform: null
     })
   })

--- a/mobile/src/tasks/worktree-create-capability.test.ts
+++ b/mobile/src/tasks/worktree-create-capability.test.ts
@@ -69,6 +69,23 @@ describe('readNewWorktreeRuntimeCapabilities', () => {
     })
   })
 
+  it('fails closed when a valid idempotency container omits dedupeTtlMs', async () => {
+    await expect(
+      readNewWorktreeRuntimeCapabilities(
+        statusClient([
+          {
+            capabilities: ['worktree.create-idempotency.v1'],
+            worktreeCreateIdempotency: {}
+          }
+        ])
+      )
+    ).resolves.toEqual({
+      tasksSupported: false,
+      worktreeCreateIdempotency: { dedupeTtlMs: 0 },
+      hostPlatform: 'darwin'
+    })
+  })
+
   it.each([
     { label: 'null', value: null },
     { label: 'string', value: 'nonsense' },

--- a/mobile/src/tasks/worktree-create-capability.ts
+++ b/mobile/src/tasks/worktree-create-capability.ts
@@ -4,6 +4,10 @@ import { isLogicalClientCutoverError } from '../transport/stable-logical-rpc-cli
 import type { RpcSuccess } from '../transport/types'
 import { readMobileRuntimeHostPlatform } from '../transport/mobile-runtime-host-platform'
 import { MOBILE_TASKS_CAPABILITY } from './mobile-tasks-capability'
+import {
+  resolveWorktreeCreateIdempotencySupport,
+  type WorktreeCreateIdempotencySupport
+} from './worktree-create-idempotency-policy'
 
 // Why: older hosts strip worktree.create's clientMutationId, so mobile must not
 // replay an ambiguous create unless the host advertises idempotency support.
@@ -14,13 +18,13 @@ const STATUS_CUTOVER_MAX_RETRIES = 5
 
 export type NewWorktreeRuntimeCapabilities = {
   tasksSupported: boolean
-  idempotentWorktreeCreateSupported: boolean
+  worktreeCreateIdempotency: WorktreeCreateIdempotencySupport | false
   hostPlatform: NodeJS.Platform | null
 }
 
 const UNSUPPORTED_CAPABILITIES: NewWorktreeRuntimeCapabilities = {
   tasksSupported: false,
-  idempotentWorktreeCreateSupported: false,
+  worktreeCreateIdempotency: false,
   hostPlatform: null
 }
 
@@ -35,13 +39,19 @@ export async function readNewWorktreeRuntimeCapabilities(
       if (!response.ok) {
         return UNSUPPORTED_CAPABILITIES
       }
-      const result = (response as RpcSuccess).result as { capabilities?: string[] }
+      const result = (response as RpcSuccess).result as {
+        capabilities?: string[]
+        worktreeCreateIdempotency?: { dedupeTtlMs?: unknown }
+      }
       const capabilities = result.capabilities ?? []
+      const supportsIdempotency = capabilities.includes(
+        MOBILE_WORKTREE_CREATE_IDEMPOTENCY_CAPABILITY
+      )
       return {
         tasksSupported: capabilities.includes(MOBILE_TASKS_CAPABILITY),
-        idempotentWorktreeCreateSupported: capabilities.includes(
-          MOBILE_WORKTREE_CREATE_IDEMPOTENCY_CAPABILITY
-        ),
+        worktreeCreateIdempotency: supportsIdempotency
+          ? resolveWorktreeCreateIdempotencySupport(result.worktreeCreateIdempotency?.dedupeTtlMs)
+          : false,
         hostPlatform: readMobileRuntimeHostPlatform(result)
       }
     } catch (error) {
@@ -58,7 +68,7 @@ export function useNewWorktreeRuntimeCapabilities(
 ): {
   tasksSupported: boolean
   hostPlatform: NodeJS.Platform | null
-  getWorktreeCreateCutoverSupport: () => Promise<boolean>
+  getWorktreeCreateCutoverSupport: () => Promise<WorktreeCreateIdempotencySupport | false>
 } {
   const [tasksSupported, setTasksSupported] = useState(false)
   const [hostPlatform, setHostPlatform] = useState<NodeJS.Platform | null>(null)
@@ -97,7 +107,7 @@ export function useNewWorktreeRuntimeCapabilities(
   }, [client, enabled, getCapabilities, setTasksSupported])
 
   const getWorktreeCreateCutoverSupport = useCallback(
-    () => getCapabilities().then((capabilities) => capabilities.idempotentWorktreeCreateSupported),
+    () => getCapabilities().then((capabilities) => capabilities.worktreeCreateIdempotency),
     [getCapabilities]
   )
   return { tasksSupported, hostPlatform, getWorktreeCreateCutoverSupport }

--- a/mobile/src/tasks/worktree-create-capability.ts
+++ b/mobile/src/tasks/worktree-create-capability.ts
@@ -5,6 +5,7 @@ import type { RpcSuccess } from '../transport/types'
 import { readMobileRuntimeHostPlatform } from '../transport/mobile-runtime-host-platform'
 import { MOBILE_TASKS_CAPABILITY } from './mobile-tasks-capability'
 import {
+  WORKTREE_CREATE_DEDUPE_TTL_LEGACY_HOST_MS,
   resolveWorktreeCreateIdempotencySupport,
   type WorktreeCreateIdempotencySupport
 } from './worktree-create-idempotency-policy'
@@ -52,7 +53,7 @@ export async function readNewWorktreeRuntimeCapabilities(
         tasksSupported: capabilities.includes(MOBILE_TASKS_CAPABILITY),
         worktreeCreateIdempotency: supportsIdempotency
           ? advertisedIdempotency === undefined
-            ? resolveWorktreeCreateIdempotencySupport(undefined)
+            ? { dedupeTtlMs: WORKTREE_CREATE_DEDUPE_TTL_LEGACY_HOST_MS }
             : advertisedIdempotency !== null &&
                 typeof advertisedIdempotency === 'object' &&
                 !Array.isArray(advertisedIdempotency)

--- a/mobile/src/tasks/worktree-create-capability.ts
+++ b/mobile/src/tasks/worktree-create-capability.ts
@@ -41,16 +41,25 @@ export async function readNewWorktreeRuntimeCapabilities(
       }
       const result = (response as RpcSuccess).result as {
         capabilities?: string[]
-        worktreeCreateIdempotency?: { dedupeTtlMs?: unknown }
+        worktreeCreateIdempotency?: unknown
       }
       const capabilities = result.capabilities ?? []
       const supportsIdempotency = capabilities.includes(
         MOBILE_WORKTREE_CREATE_IDEMPOTENCY_CAPABILITY
       )
+      const advertisedIdempotency = result.worktreeCreateIdempotency
       return {
         tasksSupported: capabilities.includes(MOBILE_TASKS_CAPABILITY),
         worktreeCreateIdempotency: supportsIdempotency
-          ? resolveWorktreeCreateIdempotencySupport(result.worktreeCreateIdempotency?.dedupeTtlMs)
+          ? advertisedIdempotency === undefined
+            ? resolveWorktreeCreateIdempotencySupport(undefined)
+            : advertisedIdempotency !== null &&
+                typeof advertisedIdempotency === 'object' &&
+                !Array.isArray(advertisedIdempotency)
+              ? resolveWorktreeCreateIdempotencySupport(
+                  (advertisedIdempotency as { dedupeTtlMs?: unknown }).dedupeTtlMs
+                )
+              : { dedupeTtlMs: 0 }
           : false,
         hostPlatform: readMobileRuntimeHostPlatform(result)
       }

--- a/mobile/src/tasks/worktree-create-idempotency-policy.ts
+++ b/mobile/src/tasks/worktree-create-idempotency-policy.ts
@@ -1,0 +1,44 @@
+// Why: old idempotent hosts omit policy; this fallback also caps advertisements
+// so a new host cannot widen a deployed client's replay behavior.
+export const WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS = 60_000
+
+// Why: the replay still has to reach the host before its dedupe record expires.
+const WORKTREE_CREATE_REPLAY_FLIGHT_MARGIN_MS = 10_000
+
+export type WorktreeCreateIdempotencySupport = {
+  dedupeTtlMs: number
+}
+
+export type WorktreeCreateIdempotencyProbe =
+  | WorktreeCreateIdempotencySupport
+  | false
+  | Promise<WorktreeCreateIdempotencySupport | false>
+
+export function resolveWorktreeCreateIdempotencySupport(
+  advertisedDedupeTtlMs: unknown
+): WorktreeCreateIdempotencySupport {
+  if (advertisedDedupeTtlMs === undefined) {
+    return { dedupeTtlMs: WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS }
+  }
+  if (
+    typeof advertisedDedupeTtlMs !== 'number' ||
+    !Number.isSafeInteger(advertisedDedupeTtlMs) ||
+    advertisedDedupeTtlMs < 0
+  ) {
+    return { dedupeTtlMs: 0 }
+  }
+  return {
+    dedupeTtlMs: Math.min(advertisedDedupeTtlMs, WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS)
+  }
+}
+
+export function getWorktreeCreateReplayWindowMs(support: WorktreeCreateIdempotencySupport): number {
+  if (!Number.isSafeInteger(support.dedupeTtlMs) || support.dedupeTtlMs <= 0) {
+    return 0
+  }
+  return Math.max(
+    0,
+    Math.min(support.dedupeTtlMs, WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS) -
+      WORKTREE_CREATE_REPLAY_FLIGHT_MARGIN_MS
+  )
+}

--- a/mobile/src/tasks/worktree-create-idempotency-policy.ts
+++ b/mobile/src/tasks/worktree-create-idempotency-policy.ts
@@ -1,6 +1,8 @@
-// Why: old idempotent hosts omit policy; this fallback also caps advertisements
-// so a new host cannot widen a deployed client's replay behavior.
-export const WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS = 60_000
+// Why: old idempotent hosts omit policy, so preserve today's effective replay window.
+export const WORKTREE_CREATE_DEDUPE_TTL_LEGACY_HOST_MS = 60_000
+
+// Why: a client must not trust a host advertisement beyond its tested ceiling.
+export const WORKTREE_CREATE_DEDUPE_TTL_CLIENT_CEILING_MS = 60_000
 
 // Why: the replay still has to reach the host before its dedupe record expires.
 const WORKTREE_CREATE_REPLAY_FLIGHT_MARGIN_MS = 10_000
@@ -18,27 +20,21 @@ export function resolveWorktreeCreateIdempotencySupport(
   advertisedDedupeTtlMs: unknown
 ): WorktreeCreateIdempotencySupport {
   if (advertisedDedupeTtlMs === undefined) {
-    return { dedupeTtlMs: WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS }
+    return { dedupeTtlMs: WORKTREE_CREATE_DEDUPE_TTL_LEGACY_HOST_MS }
   }
   if (
     typeof advertisedDedupeTtlMs !== 'number' ||
     !Number.isSafeInteger(advertisedDedupeTtlMs) ||
     advertisedDedupeTtlMs < 0
   ) {
+    // Truthy support preserves immediate cutover retries while disabling ambiguous replay.
     return { dedupeTtlMs: 0 }
   }
   return {
-    dedupeTtlMs: Math.min(advertisedDedupeTtlMs, WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS)
+    dedupeTtlMs: Math.min(advertisedDedupeTtlMs, WORKTREE_CREATE_DEDUPE_TTL_CLIENT_CEILING_MS)
   }
 }
 
 export function getWorktreeCreateReplayWindowMs(support: WorktreeCreateIdempotencySupport): number {
-  if (!Number.isSafeInteger(support.dedupeTtlMs) || support.dedupeTtlMs <= 0) {
-    return 0
-  }
-  return Math.max(
-    0,
-    Math.min(support.dedupeTtlMs, WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS) -
-      WORKTREE_CREATE_REPLAY_FLIGHT_MARGIN_MS
-  )
+  return Math.max(0, support.dedupeTtlMs - WORKTREE_CREATE_REPLAY_FLIGHT_MARGIN_MS)
 }

--- a/mobile/src/tasks/worktree-create-idempotency-policy.ts
+++ b/mobile/src/tasks/worktree-create-idempotency-policy.ts
@@ -20,7 +20,7 @@ export function resolveWorktreeCreateIdempotencySupport(
   advertisedDedupeTtlMs: unknown
 ): WorktreeCreateIdempotencySupport {
   if (advertisedDedupeTtlMs === undefined) {
-    return { dedupeTtlMs: WORKTREE_CREATE_DEDUPE_TTL_LEGACY_HOST_MS }
+    return { dedupeTtlMs: 0 }
   }
   if (
     typeof advertisedDedupeTtlMs !== 'number' ||

--- a/mobile/src/tasks/worktree-create-retry.test.ts
+++ b/mobile/src/tasks/worktree-create-retry.test.ts
@@ -4,21 +4,22 @@ import { markRpcDeliveryUnknown } from '../transport/rpc-delivery-ambiguity'
 import { LogicalClientCutoverError } from '../transport/stable-logical-rpc-client'
 import type { ConnectionState } from '../transport/types'
 import {
-  WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS,
+  getWorktreeCreateReplayWindowMs,
+  WORKTREE_CREATE_DEDUPE_TTL_LEGACY_HOST_MS,
   type WorktreeCreateIdempotencySupport
 } from './worktree-create-idempotency-policy'
 import {
   createWorktreeWithNameRetry,
-  WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS,
-  WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS
+  WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS
 } from './worktree-create-retry'
 import { WORKTREE_CREATE_TIMEOUT_MS } from './workspace-create-timeout'
 
 type Attempt = { method: string; params: Record<string, unknown> }
 
 const IDEMPOTENT_CREATE_SUPPORT = {
-  dedupeTtlMs: WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS
+  dedupeTtlMs: WORKTREE_CREATE_DEDUPE_TTL_LEGACY_HOST_MS
 }
+const LEGACY_HOST_REPLAY_WINDOW_MS = getWorktreeCreateReplayWindowMs(IDEMPOTENT_CREATE_SUPPORT)
 
 // Drives the transport state a replay has to wait on. Production couples the two:
 // a socket close rejects the pending frame AND drops the client off 'connected'.
@@ -121,7 +122,7 @@ describe('createWorktreeWithNameRetry', () => {
       client,
       baseName: 'puffin',
       buildParams: (name) => ({ repo: 'id:r', name }),
-      supportsIdempotentCutoverRetry: support,
+      worktreeCreateIdempotency: support,
       mintMutationId: () => 'key-ready'
     })
 
@@ -141,7 +142,7 @@ describe('createWorktreeWithNameRetry', () => {
       client,
       baseName: 'otter',
       buildParams: (name) => ({ repo: 'id:r', name }),
-      supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
+      worktreeCreateIdempotency: IDEMPOTENT_CREATE_SUPPORT,
       mintMutationId: () => 'key-1'
     })
     expect(result).toEqual({ worktreeId: 'wt-1', name: 'otter' })
@@ -159,7 +160,7 @@ describe('createWorktreeWithNameRetry', () => {
       client,
       baseName: 'seal',
       buildParams: (name) => ({ repo: 'id:r', name }),
-      supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
+      worktreeCreateIdempotency: IDEMPOTENT_CREATE_SUPPORT,
       mintMutationId: () => 'key-mig'
     })
     expect(result).toEqual({ worktreeId: 'wt-2', name: 'seal' })
@@ -179,7 +180,7 @@ describe('createWorktreeWithNameRetry', () => {
         client,
         baseName: 'crab',
         buildParams: (name) => ({ repo: 'id:r', name }),
-        supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
+        worktreeCreateIdempotency: IDEMPOTENT_CREATE_SUPPORT,
         mintMutationId: () => 'key-x'
       })
     ).rejects.toBeInstanceOf(LogicalClientCutoverError)
@@ -197,7 +198,7 @@ describe('createWorktreeWithNameRetry', () => {
         client,
         baseName: 'eel',
         buildParams: (name) => ({ repo: 'id:r', name }),
-        supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
+        worktreeCreateIdempotency: IDEMPOTENT_CREATE_SUPPORT,
         mintMutationId: () => 'key-t'
       })
     ).rejects.toThrow('Request timed out')
@@ -215,7 +216,7 @@ describe('createWorktreeWithNameRetry', () => {
       client,
       baseName: 'topic',
       buildParams: (name) => ({ repo: 'id:r', name }),
-      supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
+      worktreeCreateIdempotency: IDEMPOTENT_CREATE_SUPPORT,
       mintMutationId: () => `key-${(n += 1)}`
     })
     expect(result).toEqual({ worktreeId: 'wt-3', name: 'topic-2' })
@@ -238,7 +239,7 @@ describe('createWorktreeWithNameRetry', () => {
       baseName: 'nautilus-2',
       nameWasGenerated: true,
       buildParams: (name) => ({ repo: 'id:r', name, nameWasGenerated: true }),
-      supportsIdempotentCutoverRetry: false
+      worktreeCreateIdempotency: false
     })
 
     expect(result).toEqual({ worktreeId: 'wt-generated', name: 'nautilus-3' })
@@ -253,7 +254,7 @@ describe('createWorktreeWithNameRetry', () => {
         client,
         baseName: 'ray',
         buildParams: (name) => ({ repo: 'id:r', name }),
-        supportsIdempotentCutoverRetry: false,
+        worktreeCreateIdempotency: false,
         mintMutationId: () => 'must-not-be-used'
       })
     ).rejects.toBeInstanceOf(LogicalClientCutoverError)
@@ -280,7 +281,7 @@ describe('createWorktreeWithNameRetry', () => {
       client,
       baseName: 'urchin',
       buildParams: (name) => ({ repo: 'id:r', name }),
-      supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
+      worktreeCreateIdempotency: IDEMPOTENT_CREATE_SUPPORT,
       mintMutationId: () => 'key-drop'
     })
 
@@ -308,12 +309,38 @@ describe('createWorktreeWithNameRetry', () => {
         client,
         baseName: 'limpet',
         buildParams: (name) => ({ repo: 'id:r', name }),
-        supportsIdempotentCutoverRetry: false,
+        worktreeCreateIdempotency: false,
         mintMutationId: () => 'must-not-be-used'
       })
     ).rejects.toThrow('Connection interrupted')
     expect(attempts).toHaveLength(1)
     expect(attempts[0]!.params.clientMutationId).toBeUndefined()
+  })
+
+  it('disables ambiguous replay for a malformed advertisement', async () => {
+    const attempts: Attempt[] = []
+    const connection = connectionController()
+    const client = scriptedClient(
+      [
+        {
+          throws: markRpcDeliveryUnknown(new Error('Connection interrupted')),
+          dropsConnection: true
+        }
+      ],
+      attempts,
+      connection
+    )
+    await expect(
+      createWorktreeWithNameRetry({
+        client,
+        baseName: 'limpet',
+        buildParams: (name) => ({ repo: 'id:r', name }),
+        worktreeCreateIdempotency: { dedupeTtlMs: 0 },
+        mintMutationId: () => 'key-malformed'
+      })
+    ).rejects.toThrow('Connection interrupted')
+    expect(attempts).toHaveLength(1)
+    expect(attempts[0]!.params.clientMutationId).toBe('key-malformed')
   })
 
   it('gives up after the delivery-ambiguity replay budget, still inside the dedupe TTL', async () => {
@@ -338,21 +365,21 @@ describe('createWorktreeWithNameRetry', () => {
         client,
         baseName: 'barnacle',
         buildParams: (name) => ({ repo: 'id:r', name }),
-        supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
+        worktreeCreateIdempotency: IDEMPOTENT_CREATE_SUPPORT,
         mintMutationId: () => 'key-budget'
       }).catch((error: unknown) => {
         settledAt = Date.now()
         throw error
       })
       const settled = expect(pending).rejects.toThrow('Connection interrupted')
-      await vi.advanceTimersByTimeAsync(WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS)
+      await vi.advanceTimersByTimeAsync(WORKTREE_CREATE_DEDUPE_TTL_LEGACY_HOST_MS)
       await settled
       // Initial attempt + 2 replays.
       expect(attempts).toHaveLength(3)
       // The budget is a count, but what keeps a replay reconciling instead of building
       // a second worktree is wall clock: every attempt has to land while the host still
       // holds the record, with the watchdog's detection latency already deducted.
-      expect(settledAt - startedAt).toBeLessThanOrEqual(WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS)
+      expect(settledAt - startedAt).toBeLessThanOrEqual(LEGACY_HOST_REPLAY_WINDOW_MS)
     } finally {
       vi.useRealTimers()
     }
@@ -380,7 +407,7 @@ describe('createWorktreeWithNameRetry', () => {
         client,
         baseName: 'anemone',
         buildParams: (name) => ({ repo: 'id:r', name }),
-        supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
+        worktreeCreateIdempotency: IDEMPOTENT_CREATE_SUPPORT,
         mintMutationId: () => 'key-stuck'
       })
       const settled = expect(pending).rejects.toThrow('Connection interrupted')
@@ -418,7 +445,7 @@ describe('createWorktreeWithNameRetry', () => {
         client,
         baseName: 'mussel',
         buildParams: (name) => ({ repo: 'id:r', name }),
-        supportsIdempotentCutoverRetry: { dedupeTtlMs: 20_000 },
+        worktreeCreateIdempotency: { dedupeTtlMs: 20_000 },
         mintMutationId: () => 'key-short-ttl'
       })
       const settled = expect(pending).rejects.toThrow('Connection interrupted')
@@ -457,7 +484,7 @@ describe('createWorktreeWithNameRetry', () => {
         client,
         baseName: 'cuttlefish',
         buildParams: (name) => ({ repo: 'id:r', name }),
-        supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
+        worktreeCreateIdempotency: IDEMPOTENT_CREATE_SUPPORT,
         mintMutationId: () => 'key-expired'
       })
       const settled = expect(pending).rejects.toThrow('Request timed out')
@@ -506,19 +533,19 @@ describe('createWorktreeWithNameRetry', () => {
         client,
         baseName: 'nautilus',
         buildParams: (name) => ({ repo: 'id:r', name }),
-        supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
+        worktreeCreateIdempotency: IDEMPOTENT_CREATE_SUPPORT,
         mintMutationId: () => 'key-clamped'
       }).catch((error: unknown) => {
         settledAt = Date.now()
         throw error
       })
       const settled = expect(pending).rejects.toThrow('Connection interrupted')
-      await vi.advanceTimersByTimeAsync(WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS)
+      await vi.advanceTimersByTimeAsync(LEGACY_HOST_REPLAY_WINDOW_MS)
       await settled
       expect(attempts).toHaveLength(2)
       // The window is anchored at the FIRST ambiguity, so the second wait gets only the
       // remainder — it must not restart a full wait and carry the replay past the record.
-      expect(settledAt - startedAt).toBe(WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS)
+      expect(settledAt - startedAt).toBe(LEGACY_HOST_REPLAY_WINDOW_MS)
     } finally {
       vi.useRealTimers()
     }
@@ -551,7 +578,7 @@ describe('createWorktreeWithNameRetry', () => {
         client,
         baseName: 'limpet',
         buildParams: (name) => ({ repo: 'id:r', name }),
-        supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
+        worktreeCreateIdempotency: IDEMPOTENT_CREATE_SUPPORT,
         mintMutationId: () => 'key-stale'
       })
       const settled = expect(pending).rejects.toThrow('Connection interrupted')
@@ -593,7 +620,7 @@ describe('createWorktreeWithNameRetry', () => {
         client,
         baseName: 'kelp',
         buildParams: (name) => ({ repo: 'id:r', name }),
-        supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
+        worktreeCreateIdempotency: IDEMPOTENT_CREATE_SUPPORT,
         mintMutationId: () => 'key-long'
       })
       await vi.advanceTimersByTimeAsync(250_000)
@@ -648,7 +675,7 @@ describe('createWorktreeWithNameRetry', () => {
         client,
         baseName: 'urchin',
         buildParams: (name) => ({ repo: 'id:r', name }),
-        supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
+        worktreeCreateIdempotency: IDEMPOTENT_CREATE_SUPPORT,
         mintMutationId: () => 'key-anchored'
       })
       const settled = expect(pending).rejects.toThrow('Connection lost')
@@ -680,7 +707,7 @@ describe('createWorktreeWithNameRetry', () => {
         client,
         baseName: 'urchin',
         buildParams: (name) => ({ repo: 'id:r', name }),
-        supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
+        worktreeCreateIdempotency: IDEMPOTENT_CREATE_SUPPORT,
         mintMutationId: () => 'key-unmarked'
       })
     ).rejects.toThrow('Socket closed before send')
@@ -691,13 +718,12 @@ describe('createWorktreeWithNameRetry', () => {
     // The window is measured from a lower bound on when the host could have resolved, so
     // it has to leave the record room for the replay to still be in flight. Widening it
     // to the whole TTL would let the last replay land on a record that just expired.
-    expect(WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS).toBeGreaterThan(0)
-    expect(WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS).toBeLessThan(
-      WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS
-    )
-    // A single wait must not be able to consume the window on its own.
-    expect(WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS).toBeLessThan(
-      WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS
+    expect(LEGACY_HOST_REPLAY_WINDOW_MS).toBeGreaterThan(0)
+    expect(LEGACY_HOST_REPLAY_WINDOW_MS).toBeLessThan(WORKTREE_CREATE_DEDUPE_TTL_LEGACY_HOST_MS)
+    // A reconnect wait is clamped when a short advertisement leaves less time.
+    const shortReplayWindowMs = getWorktreeCreateReplayWindowMs({ dedupeTtlMs: 20_000 })
+    expect(Math.min(WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS, shortReplayWindowMs)).toBe(
+      shortReplayWindowMs
     )
   })
 })

--- a/mobile/src/tasks/worktree-create-retry.test.ts
+++ b/mobile/src/tasks/worktree-create-retry.test.ts
@@ -3,7 +3,10 @@ import type { RpcClient } from '../transport/rpc-client'
 import { markRpcDeliveryUnknown } from '../transport/rpc-delivery-ambiguity'
 import { LogicalClientCutoverError } from '../transport/stable-logical-rpc-client'
 import type { ConnectionState } from '../transport/types'
-import { WORKTREE_CREATE_DEDUPE_TTL_MS } from '../../../src/shared/new-workspace/worktree-create-retry-policy'
+import {
+  WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS,
+  type WorktreeCreateIdempotencySupport
+} from './worktree-create-idempotency-policy'
 import {
   createWorktreeWithNameRetry,
   WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS,
@@ -12,6 +15,10 @@ import {
 import { WORKTREE_CREATE_TIMEOUT_MS } from './workspace-create-timeout'
 
 type Attempt = { method: string; params: Record<string, unknown> }
+
+const IDEMPOTENT_CREATE_SUPPORT = {
+  dedupeTtlMs: WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS
+}
 
 // Drives the transport state a replay has to wait on. Production couples the two:
 // a socket close rejects the pending frame AND drops the client off 'connected'.
@@ -106,8 +113,8 @@ describe('createWorktreeWithNameRetry', () => {
   it('waits for capability detection before sending a create', async () => {
     const attempts: Attempt[] = []
     const client = scriptedClient([{ id: 'wt-ready' }], attempts)
-    let resolveSupport!: (supported: boolean) => void
-    const support = new Promise<boolean>((resolve) => {
+    let resolveSupport!: (supported: WorktreeCreateIdempotencySupport) => void
+    const support = new Promise<WorktreeCreateIdempotencySupport>((resolve) => {
       resolveSupport = resolve
     })
     const pending = createWorktreeWithNameRetry({
@@ -120,7 +127,7 @@ describe('createWorktreeWithNameRetry', () => {
 
     await Promise.resolve()
     expect(attempts).toHaveLength(0)
-    resolveSupport(true)
+    resolveSupport(IDEMPOTENT_CREATE_SUPPORT)
 
     await expect(pending).resolves.toEqual({ worktreeId: 'wt-ready', name: 'puffin' })
     expect(attempts).toHaveLength(1)
@@ -134,7 +141,7 @@ describe('createWorktreeWithNameRetry', () => {
       client,
       baseName: 'otter',
       buildParams: (name) => ({ repo: 'id:r', name }),
-      supportsIdempotentCutoverRetry: true,
+      supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
       mintMutationId: () => 'key-1'
     })
     expect(result).toEqual({ worktreeId: 'wt-1', name: 'otter' })
@@ -152,7 +159,7 @@ describe('createWorktreeWithNameRetry', () => {
       client,
       baseName: 'seal',
       buildParams: (name) => ({ repo: 'id:r', name }),
-      supportsIdempotentCutoverRetry: true,
+      supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
       mintMutationId: () => 'key-mig'
     })
     expect(result).toEqual({ worktreeId: 'wt-2', name: 'seal' })
@@ -172,7 +179,7 @@ describe('createWorktreeWithNameRetry', () => {
         client,
         baseName: 'crab',
         buildParams: (name) => ({ repo: 'id:r', name }),
-        supportsIdempotentCutoverRetry: true,
+        supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
         mintMutationId: () => 'key-x'
       })
     ).rejects.toBeInstanceOf(LogicalClientCutoverError)
@@ -190,7 +197,7 @@ describe('createWorktreeWithNameRetry', () => {
         client,
         baseName: 'eel',
         buildParams: (name) => ({ repo: 'id:r', name }),
-        supportsIdempotentCutoverRetry: true,
+        supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
         mintMutationId: () => 'key-t'
       })
     ).rejects.toThrow('Request timed out')
@@ -208,7 +215,7 @@ describe('createWorktreeWithNameRetry', () => {
       client,
       baseName: 'topic',
       buildParams: (name) => ({ repo: 'id:r', name }),
-      supportsIdempotentCutoverRetry: true,
+      supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
       mintMutationId: () => `key-${(n += 1)}`
     })
     expect(result).toEqual({ worktreeId: 'wt-3', name: 'topic-2' })
@@ -273,7 +280,7 @@ describe('createWorktreeWithNameRetry', () => {
       client,
       baseName: 'urchin',
       buildParams: (name) => ({ repo: 'id:r', name }),
-      supportsIdempotentCutoverRetry: true,
+      supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
       mintMutationId: () => 'key-drop'
     })
 
@@ -331,14 +338,14 @@ describe('createWorktreeWithNameRetry', () => {
         client,
         baseName: 'barnacle',
         buildParams: (name) => ({ repo: 'id:r', name }),
-        supportsIdempotentCutoverRetry: true,
+        supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
         mintMutationId: () => 'key-budget'
       }).catch((error: unknown) => {
         settledAt = Date.now()
         throw error
       })
       const settled = expect(pending).rejects.toThrow('Connection interrupted')
-      await vi.advanceTimersByTimeAsync(WORKTREE_CREATE_DEDUPE_TTL_MS)
+      await vi.advanceTimersByTimeAsync(WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS)
       await settled
       // Initial attempt + 2 replays.
       expect(attempts).toHaveLength(3)
@@ -373,7 +380,7 @@ describe('createWorktreeWithNameRetry', () => {
         client,
         baseName: 'anemone',
         buildParams: (name) => ({ repo: 'id:r', name }),
-        supportsIdempotentCutoverRetry: true,
+        supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
         mintMutationId: () => 'key-stuck'
       })
       const settled = expect(pending).rejects.toThrow('Connection interrupted')
@@ -387,6 +394,41 @@ describe('createWorktreeWithNameRetry', () => {
     // Generous: advanceTimersByTimeAsync yields through REAL macrotasks between ticks,
     // so vitest's default 5s real-time budget is reachable on a loaded runner.
   }, 30_000)
+
+  it('stops replaying when the host-advertised dedupe record has expired', async () => {
+    vi.useFakeTimers()
+    try {
+      const attempts: Attempt[] = []
+      const connection = connectionController()
+      const client = scriptedClient(
+        [
+          {
+            throws: markRpcDeliveryUnknown(new Error('Connection interrupted')),
+            dropsConnection: true,
+            takesMs: 12_000,
+            reconnectsAfterMs: 1_000
+          },
+          { id: 'wt-duplicate' }
+        ],
+        attempts,
+        connection
+      )
+
+      const pending = createWorktreeWithNameRetry({
+        client,
+        baseName: 'mussel',
+        buildParams: (name) => ({ repo: 'id:r', name }),
+        supportsIdempotentCutoverRetry: { dedupeTtlMs: 20_000 },
+        mintMutationId: () => 'key-short-ttl'
+      })
+      const settled = expect(pending).rejects.toThrow('Connection interrupted')
+      await vi.advanceTimersByTimeAsync(30_000)
+      await settled
+      expect(attempts).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
 
   it('does not replay an ambiguity that surfaced while the transport stayed connected', async () => {
     vi.useFakeTimers()
@@ -415,7 +457,7 @@ describe('createWorktreeWithNameRetry', () => {
         client,
         baseName: 'cuttlefish',
         buildParams: (name) => ({ repo: 'id:r', name }),
-        supportsIdempotentCutoverRetry: true,
+        supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
         mintMutationId: () => 'key-expired'
       })
       const settled = expect(pending).rejects.toThrow('Request timed out')
@@ -464,7 +506,7 @@ describe('createWorktreeWithNameRetry', () => {
         client,
         baseName: 'nautilus',
         buildParams: (name) => ({ repo: 'id:r', name }),
-        supportsIdempotentCutoverRetry: true,
+        supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
         mintMutationId: () => 'key-clamped'
       }).catch((error: unknown) => {
         settledAt = Date.now()
@@ -509,7 +551,7 @@ describe('createWorktreeWithNameRetry', () => {
         client,
         baseName: 'limpet',
         buildParams: (name) => ({ repo: 'id:r', name }),
-        supportsIdempotentCutoverRetry: true,
+        supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
         mintMutationId: () => 'key-stale'
       })
       const settled = expect(pending).rejects.toThrow('Connection interrupted')
@@ -551,7 +593,7 @@ describe('createWorktreeWithNameRetry', () => {
         client,
         baseName: 'kelp',
         buildParams: (name) => ({ repo: 'id:r', name }),
-        supportsIdempotentCutoverRetry: true,
+        supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
         mintMutationId: () => 'key-long'
       })
       await vi.advanceTimersByTimeAsync(250_000)
@@ -606,7 +648,7 @@ describe('createWorktreeWithNameRetry', () => {
         client,
         baseName: 'urchin',
         buildParams: (name) => ({ repo: 'id:r', name }),
-        supportsIdempotentCutoverRetry: true,
+        supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
         mintMutationId: () => 'key-anchored'
       })
       const settled = expect(pending).rejects.toThrow('Connection lost')
@@ -638,7 +680,7 @@ describe('createWorktreeWithNameRetry', () => {
         client,
         baseName: 'urchin',
         buildParams: (name) => ({ repo: 'id:r', name }),
-        supportsIdempotentCutoverRetry: true,
+        supportsIdempotentCutoverRetry: IDEMPOTENT_CREATE_SUPPORT,
         mintMutationId: () => 'key-unmarked'
       })
     ).rejects.toThrow('Socket closed before send')
@@ -650,7 +692,9 @@ describe('createWorktreeWithNameRetry', () => {
     // it has to leave the record room for the replay to still be in flight. Widening it
     // to the whole TTL would let the last replay land on a record that just expired.
     expect(WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS).toBeGreaterThan(0)
-    expect(WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS).toBeLessThan(WORKTREE_CREATE_DEDUPE_TTL_MS)
+    expect(WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS).toBeLessThan(
+      WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS
+    )
     // A single wait must not be able to consume the window on its own.
     expect(WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS).toBeLessThan(
       WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS

--- a/mobile/src/tasks/worktree-create-retry.test.ts
+++ b/mobile/src/tasks/worktree-create-retry.test.ts
@@ -722,8 +722,6 @@ describe('createWorktreeWithNameRetry', () => {
     expect(LEGACY_HOST_REPLAY_WINDOW_MS).toBeLessThan(WORKTREE_CREATE_DEDUPE_TTL_LEGACY_HOST_MS)
     // A reconnect wait is clamped when a short advertisement leaves less time.
     const shortReplayWindowMs = getWorktreeCreateReplayWindowMs({ dedupeTtlMs: 20_000 })
-    expect(Math.min(WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS, shortReplayWindowMs)).toBe(
-      shortReplayWindowMs
-    )
+    expect(Math.min(WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS, shortReplayWindowMs)).toBe(10_000)
   })
 })

--- a/mobile/src/tasks/worktree-create-retry.ts
+++ b/mobile/src/tasks/worktree-create-retry.ts
@@ -12,8 +12,6 @@ import {
 import { WORKTREE_CREATE_TIMEOUT_MS } from './workspace-create-timeout'
 import {
   getWorktreeCreateReplayWindowMs,
-  resolveWorktreeCreateIdempotencySupport,
-  WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS,
   type WorktreeCreateIdempotencyProbe,
   type WorktreeCreateIdempotencySupport
 } from './worktree-create-idempotency-policy'
@@ -50,9 +48,6 @@ const WORKTREE_CREATE_AMBIGUOUS_MAX_RETRIES = 2
 // the app is backgrounded, so any ceiling derived from timer intervals — a watchdog probe
 // budget, a request timeout — can be arbitrarily wrong across a background cycle, which is
 // exactly when a create sits ambiguous for minutes.
-export const WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS = getWorktreeCreateReplayWindowMs(
-  resolveWorktreeCreateIdempotencySupport(WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS)
-)
 // Bounded so the Create spinner doesn't sit for the whole window; the deadline still caps it.
 export const WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS = 20_000
 
@@ -61,7 +56,7 @@ export type CreateWorktreeWithNameRetryArgs = {
   baseName: string
   nameWasGenerated?: boolean
   buildParams: (name: string) => Record<string, unknown>
-  supportsIdempotentCutoverRetry: WorktreeCreateIdempotencyProbe
+  worktreeCreateIdempotency: WorktreeCreateIdempotencyProbe
   maxAttempts?: number
   // Injected in tests; production mints a fresh idempotency key per candidate.
   mintMutationId?: () => string
@@ -78,7 +73,7 @@ export async function createWorktreeWithNameRetry(
   const { client, baseName, buildParams } = args
   // Why: creating before status.get settles would silently disable safe replay
   // during the exact slow-network window this path is meant to recover from.
-  const idempotentCutoverRetrySupport = await args.supportsIdempotentCutoverRetry
+  const worktreeCreateIdempotency = await args.worktreeCreateIdempotency
   const maxAttempts = args.maxAttempts ?? CLIENT_WORKTREE_CREATE_MAX_ATTEMPTS
   const mintMutationId = args.mintMutationId ?? defaultWorktreeCreateMutationId
   let lastError: string | null = null
@@ -90,14 +85,10 @@ export async function createWorktreeWithNameRetry(
     // Why: older hosts strip unknown fields, so only stamp and replay when the
     // host advertises idempotency. One key per candidate makes cutover retries
     // safe while a name-collision bump remains a genuinely new create.
-    const params = idempotentCutoverRetrySupport
+    const params = worktreeCreateIdempotency
       ? { ...candidateParams, clientMutationId: mintMutationId() }
       : candidateParams
-    const response = await sendWorktreeCreateResilient(
-      client,
-      params,
-      idempotentCutoverRetrySupport
-    )
+    const response = await sendWorktreeCreateResilient(client, params, worktreeCreateIdempotency)
     if (response.ok) {
       const result = (response as RpcSuccess).result as { worktree: { id: string } }
       return { worktreeId: result.worktree.id, name: candidateName }
@@ -118,7 +109,7 @@ export async function createWorktreeWithNameRetry(
 async function sendWorktreeCreateResilient(
   client: RpcClient,
   params: Record<string, unknown>,
-  idempotentCutoverRetrySupport: WorktreeCreateIdempotencySupport | false
+  worktreeCreateIdempotency: WorktreeCreateIdempotencySupport | false
 ): Promise<RpcResponse> {
   let migrationRetry = 0
   let ambiguousRetry = 0
@@ -130,7 +121,7 @@ async function sendWorktreeCreateResilient(
         timeoutMs: WORKTREE_CREATE_TIMEOUT_MS
       })
     } catch (error) {
-      if (!idempotentCutoverRetrySupport) {
+      if (!worktreeCreateIdempotency) {
         throw error
       }
       if (isLogicalClientCutoverError(error)) {
@@ -158,7 +149,7 @@ async function sendWorktreeCreateResilient(
       }
       // Computed once: a later ambiguity reads a fresher lastInboundAt from the
       // replacement session, which would push the deadline past the record it respects.
-      replayDeadlineAt ??= resolveReplayDeadline(client, firstSentAt, idempotentCutoverRetrySupport)
+      replayDeadlineAt ??= resolveReplayDeadline(client, firstSentAt, worktreeCreateIdempotency)
       const remainingWindowMs = replayDeadlineAt - Date.now()
       if (remainingWindowMs <= 0) {
         throw error

--- a/mobile/src/tasks/worktree-create-retry.ts
+++ b/mobile/src/tasks/worktree-create-retry.ts
@@ -7,10 +7,16 @@ import {
   CLIENT_WORKTREE_CREATE_MAX_ATTEMPTS,
   getClientWorktreeCreateCandidate,
   getGeneratedWorktreeCreateRetryCandidate,
-  isRetryableWorktreeCreateConflict,
-  WORKTREE_CREATE_DEDUPE_TTL_MS
+  isRetryableWorktreeCreateConflict
 } from '../../../src/shared/new-workspace/worktree-create-retry-policy'
 import { WORKTREE_CREATE_TIMEOUT_MS } from './workspace-create-timeout'
+import {
+  getWorktreeCreateReplayWindowMs,
+  resolveWorktreeCreateIdempotencySupport,
+  WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS,
+  type WorktreeCreateIdempotencyProbe,
+  type WorktreeCreateIdempotencySupport
+} from './worktree-create-idempotency-policy'
 
 // Why: server-side collision checks (branch already exists locally / on a remote
 // / already has PR #N) can fire even after a pre-flight basename dedupe —
@@ -36,17 +42,17 @@ const WORKTREE_CREATE_CUTOVER_MAX_RETRIES = 5
 // finished the worktree. Replay on the same clientMutationId instead.
 const WORKTREE_CREATE_AMBIGUOUS_MAX_RETRIES = 2
 
-// Why: the host keeps a settled create's dedupe record for WORKTREE_CREATE_DEDUPE_TTL_MS
-// after it resolves; a replay that lands later misses it and the host's suffix loop
+// Why: the host keeps a settled create's advertised dedupe record after it resolves;
+// a replay that lands later misses it and the host's suffix loop
 // builds a SECOND worktree — and for folder workspaces a second one with the SAME name
 // and no collision check at all. So a replay is bounded by how stale our knowledge of the
 // host is, and that has to be measured in WALL CLOCK: iOS/Android suspend JS timers while
 // the app is backgrounded, so any ceiling derived from timer intervals — a watchdog probe
 // budget, a request timeout — can be arbitrarily wrong across a background cycle, which is
 // exactly when a create sits ambiguous for minutes.
-const WORKTREE_CREATE_REPLAY_FLIGHT_MARGIN_MS = 10_000
-export const WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS =
-  WORKTREE_CREATE_DEDUPE_TTL_MS - WORKTREE_CREATE_REPLAY_FLIGHT_MARGIN_MS
+export const WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS = getWorktreeCreateReplayWindowMs(
+  resolveWorktreeCreateIdempotencySupport(WORKTREE_CREATE_DEDUPE_TTL_FALLBACK_MS)
+)
 // Bounded so the Create spinner doesn't sit for the whole window; the deadline still caps it.
 export const WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS = 20_000
 
@@ -55,7 +61,7 @@ export type CreateWorktreeWithNameRetryArgs = {
   baseName: string
   nameWasGenerated?: boolean
   buildParams: (name: string) => Record<string, unknown>
-  supportsIdempotentCutoverRetry: boolean | Promise<boolean>
+  supportsIdempotentCutoverRetry: WorktreeCreateIdempotencyProbe
   maxAttempts?: number
   // Injected in tests; production mints a fresh idempotency key per candidate.
   mintMutationId?: () => string
@@ -72,7 +78,7 @@ export async function createWorktreeWithNameRetry(
   const { client, baseName, buildParams } = args
   // Why: creating before status.get settles would silently disable safe replay
   // during the exact slow-network window this path is meant to recover from.
-  const supportsIdempotentCutoverRetry = await args.supportsIdempotentCutoverRetry
+  const idempotentCutoverRetrySupport = await args.supportsIdempotentCutoverRetry
   const maxAttempts = args.maxAttempts ?? CLIENT_WORKTREE_CREATE_MAX_ATTEMPTS
   const mintMutationId = args.mintMutationId ?? defaultWorktreeCreateMutationId
   let lastError: string | null = null
@@ -84,13 +90,13 @@ export async function createWorktreeWithNameRetry(
     // Why: older hosts strip unknown fields, so only stamp and replay when the
     // host advertises idempotency. One key per candidate makes cutover retries
     // safe while a name-collision bump remains a genuinely new create.
-    const params = supportsIdempotentCutoverRetry
+    const params = idempotentCutoverRetrySupport
       ? { ...candidateParams, clientMutationId: mintMutationId() }
       : candidateParams
     const response = await sendWorktreeCreateResilient(
       client,
       params,
-      supportsIdempotentCutoverRetry
+      idempotentCutoverRetrySupport
     )
     if (response.ok) {
       const result = (response as RpcSuccess).result as { worktree: { id: string } }
@@ -112,7 +118,7 @@ export async function createWorktreeWithNameRetry(
 async function sendWorktreeCreateResilient(
   client: RpcClient,
   params: Record<string, unknown>,
-  supportsIdempotentCutoverRetry: boolean
+  idempotentCutoverRetrySupport: WorktreeCreateIdempotencySupport | false
 ): Promise<RpcResponse> {
   let migrationRetry = 0
   let ambiguousRetry = 0
@@ -124,7 +130,7 @@ async function sendWorktreeCreateResilient(
         timeoutMs: WORKTREE_CREATE_TIMEOUT_MS
       })
     } catch (error) {
-      if (!supportsIdempotentCutoverRetry) {
+      if (!idempotentCutoverRetrySupport) {
         throw error
       }
       if (isLogicalClientCutoverError(error)) {
@@ -152,7 +158,7 @@ async function sendWorktreeCreateResilient(
       }
       // Computed once: a later ambiguity reads a fresher lastInboundAt from the
       // replacement session, which would push the deadline past the record it respects.
-      replayDeadlineAt ??= resolveReplayDeadline(client, firstSentAt)
+      replayDeadlineAt ??= resolveReplayDeadline(client, firstSentAt, idempotentCutoverRetrySupport)
       const remainingWindowMs = replayDeadlineAt - Date.now()
       if (remainingWindowMs <= 0) {
         throw error
@@ -179,10 +185,14 @@ async function sendWorktreeCreateResilient(
 // so it stays honest across a suspension in a way a timer budget cannot; the send is the
 // fallback, and a sound floor either way, because the host cannot resolve a create it has
 // not yet received.
-function resolveReplayDeadline(client: RpcClient, firstSentAt: number): number {
+function resolveReplayDeadline(
+  client: RpcClient,
+  firstSentAt: number,
+  support: WorktreeCreateIdempotencySupport
+): number {
   const lastInboundAt = client.getLastInboundAt?.() ?? null
   const anchor = lastInboundAt !== null && lastInboundAt > firstSentAt ? lastInboundAt : firstSentAt
-  return anchor + WORKTREE_CREATE_AMBIGUOUS_REPLAY_WINDOW_MS
+  return anchor + getWorktreeCreateReplayWindowMs(support)
 }
 
 function defaultWorktreeCreateMutationId(): string {

--- a/mobile/src/tasks/worktree-create-retry.ts
+++ b/mobile/src/tasks/worktree-create-retry.ts
@@ -40,14 +40,6 @@ const WORKTREE_CREATE_CUTOVER_MAX_RETRIES = 5
 // finished the worktree. Replay on the same clientMutationId instead.
 const WORKTREE_CREATE_AMBIGUOUS_MAX_RETRIES = 2
 
-// Why: the host keeps a settled create's advertised dedupe record after it resolves;
-// a replay that lands later misses it and the host's suffix loop
-// builds a SECOND worktree — and for folder workspaces a second one with the SAME name
-// and no collision check at all. So a replay is bounded by how stale our knowledge of the
-// host is, and that has to be measured in WALL CLOCK: iOS/Android suspend JS timers while
-// the app is backgrounded, so any ceiling derived from timer intervals — a watchdog probe
-// budget, a request timeout — can be arbitrarily wrong across a background cycle, which is
-// exactly when a create sits ambiguous for minutes.
 // Bounded so the Create spinner doesn't sit for the whole window; the deadline still caps it.
 export const WORKTREE_CREATE_AMBIGUOUS_RECONNECT_WAIT_MS = 20_000
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -2098,6 +2098,7 @@ describe('OrcaRuntimeService', () => {
     expect(status.capabilities).toContain('mobile.tasks.v1')
     expect(status.capabilities).toContain('terminal.quick-commands.v1')
     expect(status.capabilities).toContain('worktree.create-idempotency.v1')
+    expect(status.worktreeCreateIdempotency).toEqual({ dedupeTtlMs: 60_000 })
     expect(status.capabilities).toContain('files.mutation-ownership.v1')
     expect(status.capabilities).toContain('project-host-setup.v1')
     expect(status.capabilities).toContain('linear.issue-attribute-filter.v1')

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1143,7 +1143,6 @@ import {
   isGeneratedWorktreeCreateName,
   WORKTREE_CREATE_MAX_SUFFIX_ATTEMPTS
 } from '../worktree-create-candidates'
-import { WORKTREE_CREATE_DEDUPE_TTL_MS } from '../../shared/new-workspace/worktree-create-retry-policy'
 import {
   failedWorktreeCreationNeedsRetirement,
   getRetiredNameRegistryForRepo,
@@ -2121,11 +2120,9 @@ function getAgentLaunchPlatformForRepo(
 // Why: long enough for a phone to reconnect and retry a create whose response
 // was lost, short enough that an intentional later re-resume forks fresh.
 const MOBILE_TERMINAL_CREATE_RESULT_TTL_MS = 60_000
-// Why: same idempotency window for worktree.create — a phone whose create was
-// interrupted by a connection migration retries with the same clientMutationId
-// and reuses the just-created worktree instead of spawning a duplicate. Shared with
-// the mobile client so its replay budget is sized against the real window.
-const WORKTREE_CREATE_RESULT_TTL_MS = WORKTREE_CREATE_DEDUPE_TTL_MS
+// Why: a phone whose create was interrupted retries with the same clientMutationId
+// and reuses the just-created worktree instead of spawning a duplicate.
+const WORKTREE_CREATE_RESULT_TTL_MS = 60_000
 const FOREGROUND_AGENT_WRAPPER_RETRY_INTERVAL_MS = 150
 const FOREGROUND_AGENT_WRAPPER_RETRY_TIMEOUT_MS = 6_500
 const BRACKETED_PASTE_BEGIN = '\x1b[200~'
@@ -6504,6 +6501,7 @@ export class OrcaRuntimeService {
       // must not treat browser panes as supported just because runtime RPC is up.
       capabilities,
       ...(degradations.length > 0 ? { degradations } : {}),
+      worktreeCreateIdempotency: { dedupeTtlMs: WORKTREE_CREATE_RESULT_TTL_MS },
       hostPlatform: process.platform,
       terminalWindowsShell: this.store?.getSettings?.().terminalWindowsShell ?? null,
       floatingWorkspaceEnabled: this.store?.getSettings?.().floatingTerminalEnabled !== false,

--- a/src/shared/new-workspace/worktree-create-retry-policy.ts
+++ b/src/shared/new-workspace/worktree-create-retry-policy.ts
@@ -65,10 +65,3 @@ export function getGeneratedWorktreeCreateRetryCandidate(
 export function isRetryableWorktreeCreateConflict(message: string): boolean {
   return RETRYABLE_WORKTREE_CREATE_CONFLICT_PATTERNS.some((pattern) => pattern.test(message))
 }
-
-// Why: the host drops a *settled* worktree.create dedupe record this long after it
-// resolves, so a client replaying an idempotent create must land inside the window
-// or the replay misses the record and the host's suffix loop builds a second
-// worktree. Shared so the client's replay budget can be asserted against it instead
-// of assuming a value that lives in another process.
-export const WORKTREE_CREATE_DEDUPE_TTL_MS = 60_000

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -97,7 +97,8 @@ export const TERMINAL_PAIRED_PARKING_RUNTIME_CAPABILITY = 'terminal.paired-parki
 // terminal creation, so mobile must hide Quick Commands unless both are present.
 export const TERMINAL_QUICK_COMMANDS_RUNTIME_CAPABILITY = 'terminal.quick-commands.v1' as const
 // Why: older hosts strip worktree.create's clientMutationId, so mobile must only
-// replay ambiguous cutovers when the host advertises idempotent create support.
+// replay ambiguous cutovers when the host advertises idempotent create support;
+// status.worktreeCreateIdempotency carries the optional host retention policy.
 export const WORKTREE_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY =
   'worktree.create-idempotency.v1' as const
 export const CODEX_RESET_CREDIT_RUNTIME_CAPABILITY = 'accounts.codex-reset-credit.v1' as const

--- a/src/shared/runtime-session-contracts.ts
+++ b/src/shared/runtime-session-contracts.ts
@@ -70,6 +70,10 @@ export type RuntimeStatus = {
   runtimeProtocolVersion?: number
   minCompatibleRuntimeClientVersion?: number
   capabilities?: RuntimeCapability[]
+  /** Optional policy for clients that negotiated worktree.create-idempotency.v1. */
+  worktreeCreateIdempotency?: {
+    dedupeTtlMs: number
+  }
   /**
    * Optional for mixed-version peers. Absence means the host predates structured
    * degradation reporting, not that the host proved every optional feature available.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​242 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​48 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​194 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​113 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​61 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​52 |

<!-- /orca-pr-loc -->

## ELI5 — what this means for users

**Short version: nothing changes today. This removes a way you could have ended up with two worktrees instead of one.**

Creating a worktree from your phone can take a while. If the connection drops mid-request, the phone cannot tell whether the Mac already finished the job. Rather than show you a failure for work that may have succeeded, the phone quietly asks again — and the Mac recognises the repeat and does not build a second one.

That only works while the Mac still remembers the original request. It remembers for one minute. The phone had that one-minute figure **compiled into the app**.

Phones and Macs update separately, so they can disagree. If we ever shortened that minute on the Mac, every phone already installed would still believe the old number, ask again too late, and the Mac — having forgotten — would cheerfully build **a second worktree**.

**Now:** the Mac tells the phone how long it actually remembers, and the phone uses that number. If the Mac sends nothing, sends something malformed, or sends an implausibly large value, the phone refuses to widen its window and falls back to something no longer than today's.

**Was this ever hit?** No. The two numbers match right now and there is roughly a 10-second safety margin absorbing normal delay. This defuses a landmine before someone tunes a constant and trips it.

---

## Summary

- Advertise the runtime's actual `worktree.create` dedupe TTL as the optional `status.get` field `worktreeCreateIdempotency.dedupeTtlMs` under the existing `worktree.create-idempotency.v1` capability.
- Size mobile's delivery-ambiguous replay window from the advertised duration, clamped to the client's 60s ceiling and reduced by the existing 10s flight margin.
- Preserve the client-local wall-clock anchor `max(firstSentAt, lastInboundAt)` and the bounded fallback for older hosts.

## Status and reproduction

This is not currently a live production bug: the host TTL has not changed, and today's 10s flight margin keeps the deployed client inside the current record lifetime. It is a latent mixed-version correctness hazard that would create a second worktree after a future host TTL reduction.

I reproduced that hazard deterministically, not as a live production duplicate: a host-advertised 20s TTL gives a safe 10s replay window after the flight margin, while the ambiguity surfaced at 12s. Before the fix, mobile ignored the advertisement, used its compiled 50s window, replayed, and returned the scripted second worktree:

```text
FAIL  src/tasks/worktree-create-retry.test.ts > createWorktreeWithNameRetry > stops replaying when the host-advertised dedupe record has expired
AssertionError: promise resolved "{ worktreeId: 'wt-duplicate', …(1) }" instead of rejecting

+ {
+   "name": "mussel",
+   "worktreeId": "wt-duplicate",
+ }
```

## Root cause

The mobile replay deadline was compiled from a shared TTL constant, but the dedupe record and its expiration timer are owned by the runtime handling `worktree.create`. Independently updated clients therefore had no way to learn a shorter host retention window.

## Compatibility and safety

- This is a new optional JSON field on the existing `status.get` result, not a new stream opcode. Old clients ignore the field.
- Old client/new host remains safe because the host's actual TTL remains 60s, preserving the old client's existing 50s effective window.
- New client/old host detects the existing idempotency capability with no policy field and falls back to today's 60s TTL, so its effective window is still 50s and never longer than today's.
- New client/new host uses `min(advertised TTL, 60s client ceiling) - 10s flight margin`. An over-large or buggy advertisement cannot widen replay behavior; malformed containers, absent `dedupeTtlMs` fields, or leaf values fail closed to a zero-length delivery-ambiguous replay window.
- The host advertises a duration, not a host timestamp. The deadline is computed entirely from the phone's wall clock using `max(firstSentAt, lastInboundAt)`, so phone/host clock offsets do not enter the calculation; the existing 10s margin remains available for flight time and ordinary clock-rate skew.
- Direct, relay, and SSH-backed workspaces all read `status.get` from the runtime that owns the RPC dedupe record. The optional field crosses those transports unchanged; remote repository side effects do not move ownership of that record.

## Verification

```text
cd mobile && npx tsc --noEmit
PASS (exit 0)

npm run typecheck
PASS (exit 0)

cd mobile && npx vitest run --config vitest.config.ts src/tasks/worktree-create-retry.test.ts
Test Files  1 passed (1)
Tests       20 passed (20)

cd mobile && npx vitest run --config vitest.config.ts src/tasks/worktree-create-capability.test.ts
Test Files  1 passed (1)
Tests       15 passed (15)

cd mobile && npx vitest run --config vitest.config.ts src/tasks/blank-workspace-create.test.ts
Test Files  1 passed (1)
Tests       6 passed (6)

cd mobile && npx vitest run --config vitest.config.ts src/tasks/source-workspace-create.test.ts
Test Files  1 passed (1)
Tests       9 passed (9)

pnpm vitest run --config config/vitest.config.ts --maxWorkers=2 src/main/runtime/orca-runtime.test.ts -t "reports runtime protocol, capabilities, and mobile aliases on status"
Test Files  1 passed (1)
Tests       1 passed | 1191 skipped (1192)
```

Non-vacuity was checked by restoring each source layer from `HEAD~1` while retaining the new tests:

```text
replay source reverted:     1 failed | 19 passed; returned wt-duplicate
capability source reverted: 5 failed; advertised/fallback/clamped policy was absent
host source reverted:       expected { dedupeTtlMs: 60000 }, received undefined
```

I did not verify a physical phone background cycle or create a real duplicate worktree; the wall-clock/background behavior is covered with fake wall-clock time and the issue is intentionally latent rather than live.

Fixes #16329


## Review fixes

- Added coverage for malformed container shapes (null, string, number, empty array), malformed leaf values, and a valid policy container with an absent `dedupeTtlMs` key; each fails closed to a zero-length ambiguous replay window while retaining immediate cutover idempotency.
- Removed the dead replay-window export, separated the legacy-host fallback from the client ceiling, removed replay-window re-validation, and renamed the policy plumbing to worktreeCreateIdempotency.
- Mutation proof: changing the malformed container leg to fail open produced 4 failed | 10 passed; suppressing the malformed key stamp produced expected undefined to be key-malformed. Restored after each mutation. Inverting the absent-field leg to fail open made the new test fail with:

```text
FAIL src/tasks/worktree-create-capability.test.ts > readNewWorktreeRuntimeCapabilities > fails closed when a valid idempotency container omits dedupeTtlMs
-     "dedupeTtlMs": 0,
+     "dedupeTtlMs": 60000,
```
- Follow-up: #16347 tracks a separate, unrelated status.get failure path that can also lose this protection by caching no idempotency.


