### PR TITLE
fix(mobile): parse Grok question option payloads

### DIFF
--- a/mobile/src/session/mobile-native-chat-ask.test.ts
+++ b/mobile/src/session/mobile-native-chat-ask.test.ts
@@ -104,23 +104,82 @@ describe('parseAskFromStatus', () => {
     expect(parseAskFromStatus('{"foo":1}')).toBeNull()
   })
 
-  it('parses Grok question notifications whose payload is the questions array', () => {
-    const grokQuestions = [
-      {
-        question: 'Ship to which region?',
-        options: [
-          { label: 'us-east', description: 'US East' },
-          { label: 'eu-west', description: 'EU West' }
-        ],
-        multi_select: false
-      }
-    ]
-    const ask = parseAskFromStatus(JSON.stringify(grokQuestions), 'ask_user_question')
-    expect(ask?.questions[0]).toMatchObject({
-      question: 'Ship to which region?',
-      options: [{ label: 'us-east' }, { label: 'eu-west' }],
-      multiSelect: false
-    })
+  it('parses the captured Grok ask_user_question envelope and options', () => {
+    // Captured from ~/.grok/sessions/.../chat_history.jsonl. Keep the
+    // {questions:[...]} envelope: Grok does not send a bare array here.
+    const grokInput = {
+      questions: [
+        {
+          question: 'How should we proceed with the 0.0.41 mobile release?',
+          options: [
+            {
+              label: 'Both platforms (Recommended)',
+              description:
+                'iOS: App Store Connect with existing TestFlight 0.0.41; Android: trigger release workflow'
+            },
+            {
+              label: 'iOS only',
+              description: 'Prepare App Store Connect copy; no Android CI.'
+            },
+            {
+              label: 'Android only',
+              description: 'Tag/dispatch Mobile Android Release with release_version 0.0.41'
+            },
+            {
+              label: 'Status only for now',
+              description: 'Stop here; I’ll handle ASC/Android myself with the drafts above'
+            }
+          ],
+          multi_select: false
+        },
+        {
+          question: 'How should we trigger the Android release (if shipping Android)?',
+          options: [
+            {
+              label: 'Tag push mobile-android-v0.0.41 (Recommended)',
+              description: 'git tag on origin/main and push'
+            },
+            {
+              label: 'workflow_dispatch',
+              description: 'Dispatch Mobile Android Release with release_version 0.0.41'
+            },
+            { label: 'N/A — not shipping Android', description: 'Skip Android trigger' }
+          ],
+          multi_select: false
+        }
+      ]
+    }
+    const ask = parseAskFromStatus(JSON.stringify(grokInput), 'ask_user_question')
+    expect(ask?.questions).toHaveLength(2)
+    expect(
+      ask?.questions.flatMap((question) => question.options.map((option) => option.label))
+    ).toEqual([
+      'Both platforms (Recommended)',
+      'iOS only',
+      'Android only',
+      'Status only for now',
+      'Tag push mobile-android-v0.0.41 (Recommended)',
+      'workflow_dispatch',
+      'N/A — not shipping Android'
+    ])
+    expect(ask?.questions.every((question) => question.multiSelect)).toBe(false)
+  })
+
+  it('maps Grok multi_select to the selector flag', () => {
+    const capturedShapeWithMultiSelect = {
+      questions: [
+        {
+          question: 'Pick release targets',
+          options: [{ label: 'iOS' }, { label: 'Android' }],
+          multi_select: true
+        }
+      ]
+    }
+    const ask = parseAskFromStatus(
+      JSON.stringify(capturedShapeWithMultiSelect),
+      'ask_user_question'
+    )
+    expect(ask?.questions[0]?.multiSelect).toBe(true)
   })
 })
 

--- a/mobile/src/session/mobile-native-chat-ask.test.ts
+++ b/mobile/src/session/mobile-native-chat-ask.test.ts
@@ -103,6 +103,25 @@ describe('parseAskFromStatus', () => {
     expect(parseAskFromStatus('{not json')).toBeNull()
     expect(parseAskFromStatus('{"foo":1}')).toBeNull()
   })
+
+  it('parses Grok question notifications whose payload is the questions array', () => {
+    const grokQuestions = [
+      {
+        question: 'Ship to which region?',
+        options: [
+          { label: 'us-east', description: 'US East' },
+          { label: 'eu-west', description: 'EU West' }
+        ],
+        multi_select: false
+      }
+    ]
+    const ask = parseAskFromStatus(JSON.stringify(grokQuestions), 'ask_user_question')
+    expect(ask?.questions[0]).toMatchObject({
+      question: 'Ship to which region?',
+      options: [{ label: 'us-east' }, { label: 'eu-west' }],
+      multiSelect: false
+    })
+  })
 })
 
 describe('formatAskAnswer', () => {

--- a/mobile/src/session/mobile-native-chat-ask.test.ts
+++ b/mobile/src/session/mobile-native-chat-ask.test.ts
@@ -5,6 +5,7 @@ import {
   formatAskAnswer,
   parseAskFromStatus
 } from '../../../src/shared/native-chat-ask'
+import { buildGrokAskAnswerKeys } from '../../../src/shared/native-chat-grok-ask-answer'
 import type { NativeChatMessage } from '../../../src/shared/native-chat-types'
 
 function msg(blocks: NativeChatMessage['blocks'], id = 'm'): NativeChatMessage {
@@ -232,6 +233,63 @@ describe('buildAskAnswerKeys', () => {
       { raw: '1' },
       { raw: '3' },
       { raw: '\x1b[C' },
+      { raw: '\r' }
+    ])
+  })
+})
+
+describe('buildGrokAskAnswerKeys', () => {
+  it('selects and submits a single-question single-select answer', () => {
+    const prompt = {
+      questions: [
+        { question: 'q', multiSelect: false, options: [{ label: 'Tabs' }, { label: 'Spaces' }] }
+      ]
+    }
+    expect(buildGrokAskAnswerKeys(prompt, [{ indices: [1] }])).toEqual([
+      { raw: '2' },
+      { raw: '\r' }
+    ])
+  })
+
+  it('moves between questions with Grok navigation before submitting', () => {
+    const prompt = {
+      questions: [
+        { question: 'q1', multiSelect: false, options: [{ label: 'A' }, { label: 'B' }] },
+        { question: 'q2', multiSelect: false, options: [{ label: 'C' }, { label: 'D' }] }
+      ]
+    }
+    expect(buildGrokAskAnswerKeys(prompt, [{ indices: [1] }, { indices: [0] }])).toEqual([
+      { raw: '2' },
+      { raw: 'l' },
+      { raw: '1' },
+      { raw: '\r' }
+    ])
+  })
+
+  it('picks every Grok multi-select option before submitting', () => {
+    const prompt = {
+      questions: [
+        {
+          question: 'q',
+          multiSelect: true,
+          options: [{ label: 'A' }, { label: 'B' }, { label: 'C' }]
+        }
+      ]
+    }
+    expect(buildGrokAskAnswerKeys(prompt, [{ indices: [0, 2] }])).toEqual([
+      { raw: '1' },
+      { raw: '3' },
+      { raw: '\r' }
+    ])
+  })
+
+  it('opens Grok free text with z before typing and submitting', () => {
+    const prompt = {
+      questions: [{ question: 'q', multiSelect: false, options: [{ label: 'A' }] }]
+    }
+    expect(buildGrokAskAnswerKeys(prompt, [{ indices: [], other: 'custom' }])).toEqual([
+      { raw: 'z' },
+      { text: 'custom' },
       { raw: '\r' }
     ])
   })

--- a/mobile/src/session/mobile-native-chat-ask.test.ts
+++ b/mobile/src/session/mobile-native-chat-ask.test.ts
@@ -245,13 +245,10 @@ describe('buildGrokAskAnswerKeys', () => {
         { question: 'q', multiSelect: false, options: [{ label: 'Tabs' }, { label: 'Spaces' }] }
       ]
     }
-    expect(buildGrokAskAnswerKeys(prompt, [{ indices: [1] }])).toEqual([
-      { raw: '2' },
-      { raw: '\r' }
-    ])
+    expect(buildGrokAskAnswerKeys(prompt, [{ indices: [1] }])).toEqual([{ raw: '2' }])
   })
 
-  it('moves between questions with Grok navigation before submitting', () => {
+  it('lets each Grok single-select digit advance or submit', () => {
     const prompt = {
       questions: [
         { question: 'q1', multiSelect: false, options: [{ label: 'A' }, { label: 'B' }] },
@@ -260,13 +257,11 @@ describe('buildGrokAskAnswerKeys', () => {
     }
     expect(buildGrokAskAnswerKeys(prompt, [{ indices: [1] }, { indices: [0] }])).toEqual([
       { raw: '2' },
-      { raw: 'l' },
-      { raw: '1' },
-      { raw: '\r' }
+      { raw: '1' }
     ])
   })
 
-  it('picks every Grok multi-select option before submitting', () => {
+  it('toggles Grok multi-select rows with Space before submitting', () => {
     const prompt = {
       questions: [
         {
@@ -277,8 +272,10 @@ describe('buildGrokAskAnswerKeys', () => {
       ]
     }
     expect(buildGrokAskAnswerKeys(prompt, [{ indices: [0, 2] }])).toEqual([
-      { raw: '1' },
-      { raw: '3' },
+      { raw: ' ' },
+      { raw: '\x1b[B' },
+      { raw: '\x1b[B' },
+      { raw: ' ' },
       { raw: '\r' }
     ])
   })

--- a/mobile/src/session/use-mobile-native-chat-answer-send.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-answer-send.test.ts
@@ -256,13 +256,21 @@ describe('useMobileNativeChatAnswerSend', () => {
     ])
   })
 
-  it('answers Grok selector prompts with the option number', async () => {
+  it('answers Grok selector prompts with its pick and submit keys', async () => {
     const sendRequest = vi.fn().mockResolvedValue(acceptedResponse())
     await mount({ sendRequest } as unknown as RpcClient, vi.fn(), 'grok')
 
-    await expect(answerSend?.answerAsk(TABS_OR_SPACES, [{ indices: [1] }])).resolves.toBe(true)
-    expect(sendRequest).toHaveBeenCalledTimes(1)
-    expect(sendRequest.mock.calls[0]?.[1]).toMatchObject({ text: '2', enter: false })
+    let result: Promise<boolean> | undefined
+    await act(async () => {
+      result = answerSend?.answerAsk(TABS_OR_SPACES, [{ indices: [1] }])
+    })
+    await act(async () => vi.runAllTimersAsync())
+
+    await expect(result).resolves.toBe(true)
+    expect(sendRequest.mock.calls.map((call) => call[1])).toEqual([
+      expect.objectContaining({ text: '2', enter: false }),
+      expect.objectContaining({ text: '\r', enter: false })
+    ])
   })
 
   it('keeps the marker for a Grok selector answer', async () => {
@@ -270,9 +278,17 @@ describe('useMobileNativeChatAnswerSend', () => {
     await mount({ sendRequest } as unknown as RpcClient, vi.fn(), 'grok')
     markMobileNativeChatInputStale('terminal')
 
-    await expect(answerSend?.answerAsk(TABS_OR_SPACES, [{ indices: [1] }])).resolves.toBe(true)
-    expect(sendRequest).toHaveBeenCalledTimes(1)
-    expect(sendRequest.mock.calls[0]?.[1]).toMatchObject({ text: '2', enter: false })
+    let result: Promise<boolean> | undefined
+    await act(async () => {
+      result = answerSend?.answerAsk(TABS_OR_SPACES, [{ indices: [1] }])
+    })
+    await act(async () => vi.runAllTimersAsync())
+
+    await expect(result).resolves.toBe(true)
+    expect(sendRequest.mock.calls.map((call) => call[1])).toEqual([
+      expect.objectContaining({ text: '2', enter: false }),
+      expect.objectContaining({ text: '\r', enter: false })
+    ])
     expect(isMobileNativeChatInputStale('terminal')).toBe(true)
   })
 
@@ -731,7 +747,7 @@ describe('useMobileNativeChatAnswerSend', () => {
           settle.push(resolve)
         })
     )
-    await mount({ sendRequest } as unknown as RpcClient, onSendError, 'grok')
+    await mount({ sendRequest } as unknown as RpcClient, onSendError, 'omp')
 
     let first: Promise<boolean> | undefined
     let second: Promise<boolean> | undefined
@@ -739,6 +755,7 @@ describe('useMobileNativeChatAnswerSend', () => {
       first = acceptedAnswerAsk?.(TABS_OR_SPACES, [{ indices: [0] }])
       await Promise.resolve()
     })
+    expect(sendRequest.mock.calls[0]?.[1]).toMatchObject({ text: 'Tabs', enter: true })
     await act(async () => {
       second = acceptedAnswerAsk?.(TABS_OR_SPACES, [{ indices: [1] }])
       await Promise.resolve()
@@ -797,13 +814,14 @@ describe('useMobileNativeChatAnswerSend', () => {
           settle.push(resolve)
         })
     )
-    await mount({ sendRequest } as unknown as RpcClient, onSendError, 'grok')
+    await mount({ sendRequest } as unknown as RpcClient, onSendError, 'omp')
 
     let first: Promise<boolean> | undefined
     await act(async () => {
       first = acceptedAnswerAsk?.(TABS_OR_SPACES, [{ indices: [1] }])
       await Promise.resolve()
     })
+    expect(sendRequest.mock.calls[0]?.[1]).toMatchObject({ text: 'Spaces', enter: true })
     await act(async () => {
       answerSend?.cancelPending()
       settle[0]!(acceptedResponse())

--- a/mobile/src/session/use-mobile-native-chat-answer-send.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-answer-send.test.ts
@@ -256,29 +256,24 @@ describe('useMobileNativeChatAnswerSend', () => {
     ])
   })
 
-  it('submits a non-selector answer as pasted label text with a single Enter', async () => {
+  it('answers Grok selector prompts with the option number', async () => {
     const sendRequest = vi.fn().mockResolvedValue(acceptedResponse())
     await mount({ sendRequest } as unknown as RpcClient, vi.fn(), 'grok')
 
     await expect(answerSend?.answerAsk(TABS_OR_SPACES, [{ indices: [1] }])).resolves.toBe(true)
-    // Grok's question tool commits the pasted answer: label text + one Enter.
     expect(sendRequest).toHaveBeenCalledTimes(1)
-    expect(sendRequest.mock.calls[0]?.[1]).toMatchObject({ text: 'Spaces', enter: true })
+    expect(sendRequest.mock.calls[0]?.[1]).toMatchObject({ text: '2', enter: false })
   })
 
-  it('clears an orphaned image paste before an answer that commits with Enter (#10228)', async () => {
+  it('keeps the marker for a Grok selector answer', async () => {
     const sendRequest = vi.fn().mockResolvedValue(acceptedResponse())
     await mount({ sendRequest } as unknown as RpcClient, vi.fn(), 'grok')
-    // An earlier image send left its path on this terminal's composer line.
     markMobileNativeChatInputStale('terminal')
 
     await expect(answerSend?.answerAsk(TABS_OR_SPACES, [{ indices: [1] }])).resolves.toBe(true)
-    // Without the leading clear, the pasted label + Enter would submit
-    // "<image path>Spaces" as one prompt.
-    expect(sendRequest).toHaveBeenCalledTimes(2)
-    expect(sendRequest.mock.calls[0]?.[1]).toMatchObject({ text: '\x15', enter: false })
-    expect(sendRequest.mock.calls[1]?.[1]).toMatchObject({ text: 'Spaces', enter: true })
-    expect(isMobileNativeChatInputStale('terminal')).toBe(false)
+    expect(sendRequest).toHaveBeenCalledTimes(1)
+    expect(sendRequest.mock.calls[0]?.[1]).toMatchObject({ text: '2', enter: false })
+    expect(isMobileNativeChatInputStale('terminal')).toBe(true)
   })
 
   it('keeps the marker for a selector answer, which cannot submit the composer', async () => {
@@ -303,7 +298,7 @@ describe('useMobileNativeChatAnswerSend', () => {
       result: { send: { accepted: false } },
       _meta: { runtimeId: 'runtime' }
     })
-    await mount({ sendRequest } as unknown as RpcClient, onSendError, 'grok')
+    await mount({ sendRequest } as unknown as RpcClient, onSendError, 'omp')
     markMobileNativeChatInputStale('terminal')
 
     await expect(answerSend?.answerAsk(TABS_OR_SPACES, [{ indices: [1] }])).resolves.toBe(false)

--- a/mobile/src/session/use-mobile-native-chat-answer-send.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-answer-send.test.ts
@@ -256,7 +256,7 @@ describe('useMobileNativeChatAnswerSend', () => {
     ])
   })
 
-  it('answers Grok selector prompts with its pick and submit keys', async () => {
+  it('answers Grok single-select prompts with the auto-submitting pick key', async () => {
     const sendRequest = vi.fn().mockResolvedValue(acceptedResponse())
     await mount({ sendRequest } as unknown as RpcClient, vi.fn(), 'grok')
 
@@ -268,8 +268,7 @@ describe('useMobileNativeChatAnswerSend', () => {
 
     await expect(result).resolves.toBe(true)
     expect(sendRequest.mock.calls.map((call) => call[1])).toEqual([
-      expect.objectContaining({ text: '2', enter: false }),
-      expect.objectContaining({ text: '\r', enter: false })
+      expect.objectContaining({ text: '2', enter: false })
     ])
   })
 
@@ -286,8 +285,7 @@ describe('useMobileNativeChatAnswerSend', () => {
 
     await expect(result).resolves.toBe(true)
     expect(sendRequest.mock.calls.map((call) => call[1])).toEqual([
-      expect.objectContaining({ text: '2', enter: false }),
-      expect.objectContaining({ text: '\r', enter: false })
+      expect.objectContaining({ text: '2', enter: false })
     ])
     expect(isMobileNativeChatInputStale('terminal')).toBe(true)
   })

--- a/mobile/src/session/use-mobile-native-chat-answer-send.ts
+++ b/mobile/src/session/use-mobile-native-chat-answer-send.ts
@@ -223,8 +223,8 @@ export function useMobileNativeChatAnswerSend(args: {
           }
           return false
         }
-        // Grok commits pasted labels; Claude and Codex need their selector-specific
-        // keystrokes paced so each step renders before the next lands.
+        // Claude, Codex, and Grok need selector-specific keystrokes paced so each
+        // step renders before the next lands; other agents commit pasted labels.
         if (!shouldStepNativeChatAskAnswer(agentRef.current)) {
           // This shape pastes the label into the composer and commits it, so an
           // orphaned image paste would be submitted along with the answer (#10228).

--- a/mobile/src/session/use-mobile-native-chat-answer-send.ts
+++ b/mobile/src/session/use-mobile-native-chat-answer-send.ts
@@ -7,6 +7,7 @@ import {
   type AskAnswerSelection,
   type AskPrompt
 } from '../../../src/shared/native-chat-ask'
+import { buildGrokAskAnswerKeys } from '../../../src/shared/native-chat-grok-ask-answer'
 import type { RpcClient } from '../transport/rpc-client'
 import { MOBILE_NATIVE_CHAT_QUESTION_STEP_MS } from './mobile-native-chat-answer-stepping'
 import {
@@ -258,10 +259,13 @@ export function useMobileNativeChatAnswerSend(args: {
           const sent = (await sendTerminal(formatAskAnswer(prompt, selections), true)) || fail()
           return sent && writeTurnsRef.current.get(handle) === turn
         }
+        const transcriptAgent = resolveNativeChatTranscriptAgent(agentRef.current)
         const groups =
-          resolveNativeChatTranscriptAgent(agentRef.current) === 'codex'
+          transcriptAgent === 'codex'
             ? buildCodexAskAnswerKeys(prompt, selections)
-            : buildAskAnswerKeys(prompt, selections)
+            : transcriptAgent === 'grok'
+              ? buildGrokAskAnswerKeys(prompt, selections)
+              : buildAskAnswerKeys(prompt, selections)
         for (let index = 0; index < groups.length; index += 1) {
           if (generationRef.current !== generation) {
             return false

--- a/mobile/src/session/use-mobile-native-chat-answer-send.ts
+++ b/mobile/src/session/use-mobile-native-chat-answer-send.ts
@@ -1,13 +1,10 @@
 import { useCallback, useEffect, useRef, type MutableRefObject } from 'react'
 import {
-  buildAskAnswerKeys,
-  buildCodexAskAnswerKeys,
   formatAskAnswer,
   hasAskAnswer,
   type AskAnswerSelection,
   type AskPrompt
 } from '../../../src/shared/native-chat-ask'
-import { buildGrokAskAnswerKeys } from '../../../src/shared/native-chat-grok-ask-answer'
 import type { RpcClient } from '../transport/rpc-client'
 import { MOBILE_NATIVE_CHAT_QUESTION_STEP_MS } from './mobile-native-chat-answer-stepping'
 import {
@@ -19,12 +16,9 @@ import {
   acquireMobileNativeChatTerminalWrite,
   releaseMobileNativeChatTerminalWrite
 } from './mobile-native-chat-terminal-write-lock'
-import {
-  resolveNativeChatTranscriptAgent,
-  shouldStepNativeChatAskAnswer
-} from '../../../src/shared/native-chat-agent-support'
+import { resolveNativeChatAskAnswerBuilder } from '../../../src/shared/native-chat-agent-support'
 
-/** Sends an ask-user answer to the active chat pane. Claude and Codex selectors
+/** Sends an ask-user answer to the active chat pane. Stepped selectors
  *  use their agent-specific keystrokes; other agents get pasted label text.
  *  Extracted from the session route to keep that file under its line cap and to
  *  own the pending-timer lifecycle in one place. */
@@ -226,7 +220,8 @@ export function useMobileNativeChatAnswerSend(args: {
         }
         // Claude, Codex, and Grok need selector-specific keystrokes paced so each
         // step renders before the next lands; other agents commit pasted labels.
-        if (!shouldStepNativeChatAskAnswer(agentRef.current)) {
+        const answerBuilder = resolveNativeChatAskAnswerBuilder(agentRef.current)
+        if (!answerBuilder) {
           // This shape pastes the label into the composer and commits it, so an
           // orphaned image paste would be submitted along with the answer (#10228).
           // The selector shapes below deliberately skip the heal: their keys are
@@ -259,13 +254,7 @@ export function useMobileNativeChatAnswerSend(args: {
           const sent = (await sendTerminal(formatAskAnswer(prompt, selections), true)) || fail()
           return sent && writeTurnsRef.current.get(handle) === turn
         }
-        const transcriptAgent = resolveNativeChatTranscriptAgent(agentRef.current)
-        const groups =
-          transcriptAgent === 'codex'
-            ? buildCodexAskAnswerKeys(prompt, selections)
-            : transcriptAgent === 'grok'
-              ? buildGrokAskAnswerKeys(prompt, selections)
-              : buildAskAnswerKeys(prompt, selections)
+        const groups = answerBuilder(prompt, selections)
         for (let index = 0; index < groups.length; index += 1) {
           if (generationRef.current !== generation) {
             return false

--- a/src/renderer/src/components/native-chat/native-chat-interactive-prompt.ts
+++ b/src/renderer/src/components/native-chat/native-chat-interactive-prompt.ts
@@ -13,10 +13,12 @@ import {
   type AskQuestion,
   type InteractiveQuestionParser
 } from '../../../../shared/native-chat-ask'
+import { buildGrokAskAnswerKeys } from '../../../../shared/native-chat-grok-ask-answer'
 
 export {
   buildAskAnswerKeys,
   buildCodexAskAnswerKeys,
+  buildGrokAskAnswerKeys,
   formatAskAnswer,
   hasAskAnswer,
   parseAskFromStatus,

--- a/src/renderer/src/components/native-chat/use-native-chat-interactive-send.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-interactive-send.test.tsx
@@ -66,18 +66,34 @@ describe('useNativeChatInteractiveSend', () => {
 
   it('routes a non-selector answer through the pasted-text send path', () => {
     const { result } = renderHook(() =>
-      useNativeChatInteractiveSend('tab-1', PANE_KEY, 'pty-1', 'grok')
+      useNativeChatInteractiveSend('tab-1', PANE_KEY, 'pty-1', 'omp')
     )
 
     act(() => result.current.sendAnswer(PROMPT, [{ indices: [1] }]))
 
-    // Grok commits a pasted answer: label text 'B', not option-number keystrokes.
+    // OMP commits a pasted answer: label text 'B', not option-number keystrokes.
     expect(mocks.sendNativeChatMessage).toHaveBeenCalledWith(
       { terminalTabId: 'tab-1' },
       'pty-1',
       'B'
     )
     expect(mocks.sendNativeChatAskAnswer).not.toHaveBeenCalled()
+  })
+
+  it('routes a Grok answer through its question-card keystrokes', () => {
+    const { result } = renderHook(() =>
+      useNativeChatInteractiveSend('tab-1', PANE_KEY, 'pty-1', 'grok')
+    )
+
+    act(() => result.current.sendAnswer(PROMPT, [{ indices: [1] }]))
+
+    expect(mocks.sendNativeChatAskAnswer).toHaveBeenCalledWith(
+      { terminalTabId: 'tab-1' },
+      'pty-1',
+      [{ raw: '2' }, { raw: '\r' }],
+      expect.any(Function)
+    )
+    expect(mocks.sendNativeChatMessage).not.toHaveBeenCalled()
   })
 
   it('routes a Codex answer through the option-number keystroke path', () => {

--- a/src/renderer/src/components/native-chat/use-native-chat-interactive-send.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-interactive-send.test.tsx
@@ -90,7 +90,7 @@ describe('useNativeChatInteractiveSend', () => {
     expect(mocks.sendNativeChatAskAnswer).toHaveBeenCalledWith(
       { terminalTabId: 'tab-1' },
       'pty-1',
-      [{ raw: '2' }, { raw: '\r' }],
+      [{ raw: '2' }],
       expect.any(Function)
     )
     expect(mocks.sendNativeChatMessage).not.toHaveBeenCalled()

--- a/src/renderer/src/components/native-chat/use-native-chat-interactive-send.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-interactive-send.ts
@@ -10,6 +10,7 @@ import {
 import {
   buildAskAnswerKeys,
   buildCodexAskAnswerKeys,
+  buildGrokAskAnswerKeys,
   formatAskAnswer,
   hasAskAnswer,
   type AskAnswerSelection,
@@ -96,7 +97,7 @@ export function useNativeChatInteractiveSend(
       // Claude, Codex, and Grok ignore pasted labels but have different selector
       // state machines. OpenClaude follows Claude's path.
       const stepsAnswer = shouldStepNativeChatAskAnswer(agent)
-      const buildsCodexAnswer = resolveNativeChatTranscriptAgent(agent) === 'codex'
+      const transcriptAgent = resolveNativeChatTranscriptAgent(agent)
       // Why: pin the answered question's baseline BEFORE delivery. A late settle
       // callback (paced writes + remote acceptance can span seconds on SSH) must
       // not read the live status and mint a fresh baseline for a replacement
@@ -132,9 +133,11 @@ export function useNativeChatInteractiveSend(
         ? sendNativeChatAskAnswer(
             settings,
             targetPtyId,
-            buildsCodexAnswer
+            transcriptAgent === 'codex'
               ? buildCodexAskAnswerKeys(prompt, selections)
-              : buildAskAnswerKeys(prompt, selections),
+              : transcriptAgent === 'grok'
+                ? buildGrokAskAnswerKeys(prompt, selections)
+                : buildAskAnswerKeys(prompt, selections),
             onSettled
           )
         : sendNativeChatMessage(settings, targetPtyId, formatAskAnswer(prompt, selections))

--- a/src/renderer/src/components/native-chat/use-native-chat-interactive-send.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-interactive-send.ts
@@ -93,8 +93,8 @@ export function useNativeChatInteractiveSend(
       // Cancel any prior in-flight answer before starting a new one.
       cancelInFlight()
       const settings = getSettingsForAgentTabRuntimeOwner(terminalTabId)
-      // Claude and Codex ignore pasted labels but have different selector state
-      // machines; Grok commits pasted text. OpenClaude follows Claude's path.
+      // Claude, Codex, and Grok ignore pasted labels but have different selector
+      // state machines. OpenClaude follows Claude's path.
       const stepsAnswer = shouldStepNativeChatAskAnswer(agent)
       const buildsCodexAnswer = resolveNativeChatTranscriptAgent(agent) === 'codex'
       // Why: pin the answered question's baseline BEFORE delivery. A late settle

--- a/src/renderer/src/components/native-chat/use-native-chat-interactive-send.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-interactive-send.ts
@@ -3,14 +3,8 @@ import { useAppStore } from '../../store'
 import { sendRuntimePtyInput } from '@/runtime/runtime-terminal-inspection'
 import { getSettingsForAgentTabRuntimeOwner } from '@/lib/agent-paste-draft'
 import type { AgentType } from '../../../../shared/native-chat-types'
+import { resolveNativeChatAskAnswerBuilder } from '../../../../shared/native-chat-agent-support'
 import {
-  resolveNativeChatTranscriptAgent,
-  shouldStepNativeChatAskAnswer
-} from '../../../../shared/native-chat-agent-support'
-import {
-  buildAskAnswerKeys,
-  buildCodexAskAnswerKeys,
-  buildGrokAskAnswerKeys,
   formatAskAnswer,
   hasAskAnswer,
   type AskAnswerSelection,
@@ -96,8 +90,8 @@ export function useNativeChatInteractiveSend(
       const settings = getSettingsForAgentTabRuntimeOwner(terminalTabId)
       // Claude, Codex, and Grok ignore pasted labels but have different selector
       // state machines. OpenClaude follows Claude's path.
-      const stepsAnswer = shouldStepNativeChatAskAnswer(agent)
-      const transcriptAgent = resolveNativeChatTranscriptAgent(agent)
+      const answerBuilder = resolveNativeChatAskAnswerBuilder(agent)
+      const stepsAnswer = answerBuilder !== null
       // Why: pin the answered question's baseline BEFORE delivery. A late settle
       // callback (paced writes + remote acceptance can span seconds on SSH) must
       // not read the live status and mint a fresh baseline for a replacement
@@ -133,11 +127,7 @@ export function useNativeChatInteractiveSend(
         ? sendNativeChatAskAnswer(
             settings,
             targetPtyId,
-            transcriptAgent === 'codex'
-              ? buildCodexAskAnswerKeys(prompt, selections)
-              : transcriptAgent === 'grok'
-                ? buildGrokAskAnswerKeys(prompt, selections)
-                : buildAskAnswerKeys(prompt, selections),
+            answerBuilder!(prompt, selections),
             onSettled
           )
         : sendNativeChatMessage(settings, targetPtyId, formatAskAnswer(prompt, selections))

--- a/src/renderer/src/components/terminal-pane/agent-question-answered-inference.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-question-answered-inference.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
+import { isQuestionAnsweredSubmitInput } from '../../../../shared/agent-question-answered-intent'
 import { createAgentQuestionAnsweredInference } from './agent-question-answered-inference'
 
 const PANE_KEY = 'tab-1:11111111-1111-4111-8111-111111111111'
@@ -97,6 +98,19 @@ describe('agent question-answered inference', () => {
       inference.observeSentTerminalInput('\r')
       expect(inferQuestionAnswered).not.toHaveBeenCalled()
     }
+  })
+
+  it('keeps waiting when a Grok multi_select digit only picks a partial answer', () => {
+    const interactivePrompt = JSON.stringify({
+      questions: [
+        {
+          question: 'pick several',
+          multi_select: true,
+          options: [{ label: 'A' }, { label: 'B' }]
+        }
+      ]
+    })
+    expect(isQuestionAnsweredSubmitInput('1', interactivePrompt)).toBe(false)
   })
 
   it('keeps waiting when the synthetic free-text row is selected', () => {

--- a/src/shared/agent-question-answered-intent.ts
+++ b/src/shared/agent-question-answered-intent.ts
@@ -43,8 +43,17 @@ function readSingleSelectOptionCount(interactivePrompt: string | undefined): num
     if (!Array.isArray(parsed.questions) || parsed.questions.length !== 1) {
       return -1
     }
-    const [question] = parsed.questions as { multiSelect?: unknown; options?: unknown }[]
-    if (!question || question.multiSelect === true || !Array.isArray(question.options)) {
+    const [question] = parsed.questions as {
+      multiSelect?: unknown
+      multi_select?: unknown
+      options?: unknown
+    }[]
+    if (
+      !question ||
+      question.multiSelect === true ||
+      question.multi_select === true ||
+      !Array.isArray(question.options)
+    ) {
       return -1
     }
     return question.options.length

--- a/src/shared/agent-question-answered-intent.ts
+++ b/src/shared/agent-question-answered-intent.ts
@@ -1,4 +1,5 @@
 import type { AgentType } from './agent-status-types'
+import { isNativeChatMultiSelectQuestion } from './native-chat-question-shape'
 
 /** Baseline snapshot the renderer captured when it observed the submit
  *  keystroke. The main process re-validates every field against its own
@@ -43,15 +44,10 @@ function readSingleSelectOptionCount(interactivePrompt: string | undefined): num
     if (!Array.isArray(parsed.questions) || parsed.questions.length !== 1) {
       return -1
     }
-    const [question] = parsed.questions as {
-      multiSelect?: unknown
-      multi_select?: unknown
-      options?: unknown
-    }[]
+    const [question] = parsed.questions as { options?: unknown }[]
     if (
       !question ||
-      question.multiSelect === true ||
-      question.multi_select === true ||
+      isNativeChatMultiSelectQuestion(question) ||
       !Array.isArray(question.options)
     ) {
       return -1

--- a/src/shared/native-chat-agent-support.test.ts
+++ b/src/shared/native-chat-agent-support.test.ts
@@ -49,16 +49,17 @@ describe('nativeChatRequiresLocalTranscript', () => {
 })
 
 describe('shouldStepNativeChatAskAnswer', () => {
-  it('steps the digit-commit selector agents (Claude, OpenClaude, Codex)', () => {
+  it('steps the digit-commit selector agents (Claude, OpenClaude, Codex, Grok)', () => {
     expect(shouldStepNativeChatAskAnswer('claude')).toBe(true)
     expect(shouldStepNativeChatAskAnswer('openclaude')).toBe(true)
     // Codex 0.145's request_user_input card ignores typed labels and commits on
     // the highlighted row, so pasted answers misdeliver like STA-1860.
     expect(shouldStepNativeChatAskAnswer('codex')).toBe(true)
+    // Grok's ask_user_question card also commits option digits directly.
+    expect(shouldStepNativeChatAskAnswer('grok')).toBe(true)
   })
 
   it('does not step other or unknown agents', () => {
-    expect(shouldStepNativeChatAskAnswer('grok')).toBe(false)
     expect(shouldStepNativeChatAskAnswer('omp')).toBe(false)
     expect(shouldStepNativeChatAskAnswer('cursor')).toBe(false)
     expect(shouldStepNativeChatAskAnswer(null)).toBe(false)

--- a/src/shared/native-chat-agent-support.test.ts
+++ b/src/shared/native-chat-agent-support.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from 'vitest'
 import {
   isNativeChatSupportedAgent,
   nativeChatRequiresLocalTranscript,
+  resolveNativeChatAskAnswerBuilder,
   resolveNativeChatTranscriptAgent,
   shouldStepNativeChatAskAnswer
 } from './native-chat-agent-support'
+import { buildAskAnswerKeys, buildCodexAskAnswerKeys } from './native-chat-ask'
+import { buildGrokAskAnswerKeys } from './native-chat-grok-ask-answer'
 
 describe('resolveNativeChatTranscriptAgent', () => {
   it('maps OpenClaude onto the Claude transcript format', () => {
@@ -49,6 +52,14 @@ describe('nativeChatRequiresLocalTranscript', () => {
 })
 
 describe('shouldStepNativeChatAskAnswer', () => {
+  it('resolves selector builders from the shared agent policy', () => {
+    expect(resolveNativeChatAskAnswerBuilder('claude')).toBe(buildAskAnswerKeys)
+    expect(resolveNativeChatAskAnswerBuilder('openclaude')).toBe(buildAskAnswerKeys)
+    expect(resolveNativeChatAskAnswerBuilder('codex')).toBe(buildCodexAskAnswerKeys)
+    expect(resolveNativeChatAskAnswerBuilder('grok')).toBe(buildGrokAskAnswerKeys)
+    expect(resolveNativeChatAskAnswerBuilder('omp')).toBeNull()
+  })
+
   it('steps the digit-commit selector agents (Claude, OpenClaude, Codex, Grok)', () => {
     expect(shouldStepNativeChatAskAnswer('claude')).toBe(true)
     expect(shouldStepNativeChatAskAnswer('openclaude')).toBe(true)

--- a/src/shared/native-chat-agent-support.ts
+++ b/src/shared/native-chat-agent-support.ts
@@ -31,12 +31,13 @@ export function nativeChatRequiresLocalTranscript(agent: string | null | undefin
 
 /** True when the agent renders a digit-commit question selector that ignores
  *  typed label text (pasting "Blue" + Enter commits the highlighted FIRST
- *  option — STA-1860): Claude's AskUserQuestion and Codex 0.145's
- *  request_user_input card both behave this way, so answers must be delivered
- *  as per-option keystrokes. Other agents commit a pasted answer. */
+ *  option — STA-1860): Claude's AskUserQuestion, Codex 0.145's
+ *  request_user_input, and Grok's ask_user_question cards behave this way,
+ *  so answers must be delivered as per-option keystrokes. Other agents commit
+ *  a pasted answer. */
 export function shouldStepNativeChatAskAnswer(agent: string | null | undefined): boolean {
   const transcriptAgent = resolveNativeChatTranscriptAgent(agent)
-  return transcriptAgent === 'claude' || transcriptAgent === 'codex'
+  return transcriptAgent === 'claude' || transcriptAgent === 'codex' || transcriptAgent === 'grok'
 }
 
 export function resolveNativeChatTranscriptAgent(

--- a/src/shared/native-chat-agent-support.ts
+++ b/src/shared/native-chat-agent-support.ts
@@ -1,6 +1,27 @@
+import {
+  buildAskAnswerKeys,
+  buildCodexAskAnswerKeys,
+  type AskAnswerKeyGroup,
+  type AskAnswerSelection,
+  type AskPrompt
+} from './native-chat-ask'
+import { buildGrokAskAnswerKeys } from './native-chat-grok-ask-answer'
 import type { TuiAgent } from './tui-agent'
 
 export type NativeChatTranscriptAgent = 'claude' | 'codex' | 'grok' | 'omp'
+
+export type NativeChatAskAnswerBuilder = (
+  prompt: AskPrompt,
+  selections: AskAnswerSelection[]
+) => AskAnswerKeyGroup[]
+
+const NATIVE_CHAT_ASK_ANSWER_BUILDERS: Partial<
+  Record<NativeChatTranscriptAgent, NativeChatAskAnswerBuilder>
+> = {
+  claude: buildAskAnswerKeys,
+  codex: buildCodexAskAnswerKeys,
+  grok: buildGrokAskAnswerKeys
+}
 
 /** Agents whose transcripts the native chat view can parse and render, in the
  *  order the settings pane advertises them. */
@@ -36,8 +57,15 @@ export function nativeChatRequiresLocalTranscript(agent: string | null | undefin
  *  so answers must be delivered as per-option keystrokes. Other agents commit
  *  a pasted answer. */
 export function shouldStepNativeChatAskAnswer(agent: string | null | undefined): boolean {
+  return resolveNativeChatAskAnswerBuilder(agent) !== null
+}
+
+/** Returns the selector strategy registered for an agent's transcript format. */
+export function resolveNativeChatAskAnswerBuilder(
+  agent: string | null | undefined
+): NativeChatAskAnswerBuilder | null {
   const transcriptAgent = resolveNativeChatTranscriptAgent(agent)
-  return transcriptAgent === 'claude' || transcriptAgent === 'codex' || transcriptAgent === 'grok'
+  return transcriptAgent ? (NATIVE_CHAT_ASK_ANSWER_BUILDERS[transcriptAgent] ?? null) : null
 }
 
 export function resolveNativeChatTranscriptAgent(

--- a/src/shared/native-chat-ask.ts
+++ b/src/shared/native-chat-ask.ts
@@ -20,10 +20,11 @@ export function registerQuestionTool(toolName: string, parser: InteractiveQuesti
 }
 
 function parseQuestionsShape(input: unknown): AskPrompt | null {
-  if (!input || typeof input !== 'object') {
-    return null
-  }
-  const rawQuestions = (input as { questions?: unknown }).questions
+  const rawQuestions = Array.isArray(input)
+    ? input
+    : input && typeof input === 'object'
+      ? (input as { questions?: unknown }).questions
+      : undefined
   if (!Array.isArray(rawQuestions) || rawQuestions.length === 0) {
     return null
   }
@@ -39,7 +40,7 @@ function parseQuestionsShape(input: unknown): AskPrompt | null {
       questions.push({
         question: text,
         header: typeof question.header === 'string' ? question.header : undefined,
-        multiSelect: question.multiSelect === true,
+        multiSelect: question.multiSelect === true || question.multi_select === true,
         options
       })
     }

--- a/src/shared/native-chat-ask.ts
+++ b/src/shared/native-chat-ask.ts
@@ -20,11 +20,8 @@ export function registerQuestionTool(toolName: string, parser: InteractiveQuesti
 }
 
 function parseQuestionsShape(input: unknown): AskPrompt | null {
-  const rawQuestions = Array.isArray(input)
-    ? input
-    : input && typeof input === 'object'
-      ? (input as { questions?: unknown }).questions
-      : undefined
+  const rawQuestions =
+    input && typeof input === 'object' ? (input as { questions?: unknown }).questions : undefined
   if (!Array.isArray(rawQuestions) || rawQuestions.length === 0) {
     return null
   }

--- a/src/shared/native-chat-ask.ts
+++ b/src/shared/native-chat-ask.ts
@@ -5,6 +5,7 @@ import type {
   InteractiveQuestionParser
 } from './native-chat-ask-types'
 import { isInterruptedStatusMessage, type NativeChatMessage } from './native-chat-types'
+import { isNativeChatMultiSelectQuestion } from './native-chat-question-shape'
 
 export type { AskOption, AskPrompt, AskQuestion, InteractiveQuestionParser }
 
@@ -37,7 +38,7 @@ function parseQuestionsShape(input: unknown): AskPrompt | null {
       questions.push({
         question: text,
         header: typeof question.header === 'string' ? question.header : undefined,
-        multiSelect: question.multiSelect === true || question.multi_select === true,
+        multiSelect: isNativeChatMultiSelectQuestion(question),
         options
       })
     }

--- a/src/shared/native-chat-grok-ask-answer.test.ts
+++ b/src/shared/native-chat-grok-ask-answer.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { buildGrokAskAnswerKeys } from './native-chat-grok-ask-answer'
+
+const CAPTURED_GROK_1_0_5_INTERACTION = {
+  prompt: {
+    questions: [
+      {
+        question: 'Color',
+        multiSelect: false,
+        options: [{ label: 'Red' }, { label: 'Blue' }]
+      },
+      {
+        question: 'Features',
+        multiSelect: true,
+        options: [{ label: 'Auth' }, { label: 'Search' }, { label: 'Metrics' }]
+      },
+      {
+        question: 'Deploy',
+        multiSelect: false,
+        options: [{ label: 'Now' }, { label: 'Later' }]
+      }
+    ]
+  },
+  selections: [{ indices: [1] }, { indices: [0, 2] }, { indices: [0] }],
+  keys: [
+    { raw: '2' },
+    { raw: ' ' },
+    { raw: '\x1b[B' },
+    { raw: '\x1b[B' },
+    { raw: ' ' },
+    { raw: '\r' },
+    { raw: '1' }
+  ]
+}
+
+describe('buildGrokAskAnswerKeys', () => {
+  it('matches a captured three-question Grok interaction', () => {
+    expect(
+      buildGrokAskAnswerKeys(
+        CAPTURED_GROK_1_0_5_INTERACTION.prompt,
+        CAPTURED_GROK_1_0_5_INTERACTION.selections
+      )
+    ).toEqual(CAPTURED_GROK_1_0_5_INTERACTION.keys)
+  })
+})

--- a/src/shared/native-chat-grok-ask-answer.ts
+++ b/src/shared/native-chat-grok-ask-answer.ts
@@ -1,0 +1,53 @@
+import type { AskAnswerKeyGroup, AskAnswerSelection, AskPrompt } from './native-chat-ask'
+
+const GROK_ENTER = '\r'
+const GROK_NEXT_QUESTION = 'l'
+const GROK_FREE_TEXT = 'z'
+
+function optionKey(index: number): string | null {
+  if (index >= 0 && index < 9) {
+    return String(index + 1)
+  }
+  if (index >= 9 && index < 15) {
+    return String.fromCharCode('a'.charCodeAt(0) + index - 9)
+  }
+  return null
+}
+
+/** Grok picks options by shortcut, moves questions with `l`, and opens free text with `z`. */
+export function buildGrokAskAnswerKeys(
+  prompt: AskPrompt,
+  selections: AskAnswerSelection[]
+): AskAnswerKeyGroup[] {
+  const groups: AskAnswerKeyGroup[] = []
+
+  prompt.questions.forEach((question, questionIndex) => {
+    const selection = selections[questionIndex]
+    const other = (selection?.other ?? '').trim()
+    const selectedIndices = question.multiSelect
+      ? (selection?.indices ?? [])
+      : (selection?.indices.slice(0, 1) ?? [])
+
+    if (!other || question.multiSelect) {
+      for (const index of selectedIndices) {
+        const key = optionKey(index)
+        if (key) {
+          groups.push({ raw: key })
+        }
+      }
+    }
+
+    if (other) {
+      const freeText = question.multiSelect
+        ? other
+        : [question.options[selectedIndices[0] ?? -1]?.label, other].filter(Boolean).join(', ')
+      groups.push({ raw: GROK_FREE_TEXT }, { text: freeText }, { raw: GROK_ENTER })
+    } else if (questionIndex < prompt.questions.length - 1) {
+      groups.push({ raw: GROK_NEXT_QUESTION })
+    } else if (selectedIndices.length > 0) {
+      groups.push({ raw: GROK_ENTER })
+    }
+  })
+
+  return groups
+}

--- a/src/shared/native-chat-grok-ask-answer.ts
+++ b/src/shared/native-chat-grok-ask-answer.ts
@@ -3,6 +3,8 @@ import type { AskAnswerKeyGroup, AskAnswerSelection, AskPrompt } from './native-
 const GROK_ENTER = '\r'
 const GROK_NEXT_QUESTION = 'l'
 const GROK_FREE_TEXT = 'z'
+const GROK_NEXT_OPTION = '\x1b[B'
+const GROK_TOGGLE_OPTION = ' '
 
 function optionKey(index: number): string | null {
   if (index >= 0 && index < 9) {
@@ -14,7 +16,16 @@ function optionKey(index: number): string | null {
   return null
 }
 
-/** Grok picks options by shortcut, moves questions with `l`, and opens free text with `z`. */
+function selectedOptionIndices(
+  question: AskPrompt['questions'][number],
+  selection: AskAnswerSelection | undefined
+): number[] {
+  return [...new Set(selection?.indices ?? [])]
+    .filter((index) => index >= 0 && index < question.options.length)
+    .sort((left, right) => left - right)
+}
+
+/** Grok commits digit picks immediately; multi-selects toggle focused rows with Space. */
 export function buildGrokAskAnswerKeys(
   prompt: AskPrompt,
   selections: AskAnswerSelection[]
@@ -24,28 +35,40 @@ export function buildGrokAskAnswerKeys(
   prompt.questions.forEach((question, questionIndex) => {
     const selection = selections[questionIndex]
     const other = (selection?.other ?? '').trim()
-    const selectedIndices = question.multiSelect
-      ? (selection?.indices ?? [])
-      : (selection?.indices.slice(0, 1) ?? [])
+    const selectedIndices = selectedOptionIndices(question, selection)
 
-    if (!other || question.multiSelect) {
+    if (question.multiSelect) {
+      let cursor = 0
       for (const index of selectedIndices) {
-        const key = optionKey(index)
-        if (key) {
-          groups.push({ raw: key })
+        while (cursor < index) {
+          groups.push({ raw: GROK_NEXT_OPTION })
+          cursor += 1
         }
+        groups.push({ raw: GROK_TOGGLE_OPTION })
       }
+      if (other) {
+        groups.push({ raw: GROK_FREE_TEXT }, { text: other }, { raw: GROK_ENTER })
+      } else if (selectedIndices.length > 0) {
+        groups.push({ raw: GROK_ENTER })
+      } else if (questionIndex < prompt.questions.length - 1) {
+        groups.push({ raw: GROK_NEXT_QUESTION })
+      }
+      return
     }
 
     if (other) {
-      const freeText = question.multiSelect
-        ? other
-        : [question.options[selectedIndices[0] ?? -1]?.label, other].filter(Boolean).join(', ')
+      const freeText = [question.options[selectedIndices[0] ?? -1]?.label, other]
+        .filter(Boolean)
+        .join(', ')
       groups.push({ raw: GROK_FREE_TEXT }, { text: freeText }, { raw: GROK_ENTER })
+      return
+    }
+
+    const key = optionKey(selectedIndices[0] ?? -1)
+    if (key) {
+      groups.push({ raw: key })
     } else if (questionIndex < prompt.questions.length - 1) {
       groups.push({ raw: GROK_NEXT_QUESTION })
-    } else if (selectedIndices.length > 0) {
-      groups.push({ raw: GROK_ENTER })
     }
   })
 

--- a/src/shared/native-chat-question-shape.ts
+++ b/src/shared/native-chat-question-shape.ts
@@ -1,0 +1,8 @@
+/** True for either spelling accepted by supported question-tool payloads. */
+export function isNativeChatMultiSelectQuestion(question: unknown): boolean {
+  if (!question || typeof question !== 'object') {
+    return false
+  }
+  const value = question as { multiSelect?: unknown; multi_select?: unknown }
+  return value.multiSelect === true || value.multi_select === true
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​252 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​231 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​143 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​38 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​105 |

<!-- /orca-pr-loc -->

## ELI5 — what this means for users

**Short version: this makes answering a Grok question work properly from your phone. It is *not* confirmed to be the bug that was reported.**

Grok's question card commits a numbered single-choice answer immediately: the digit advances to the next question, or submits the final one. A multi-choice answer is different — Space toggles the focused rows, then Enter advances or submits. Orca previously treated digits as picks that stayed on the current question, so multi-choice and longer prompts sent later keys to the wrong place.

**Why this is still a draft:** the original report was *"when Grok asks a question there are no options like on desktop."* The captured question already parses correctly, so the reported missing-options cause remains unexplained. This fixes a genuine but separate answering defect, which is why the PR says `Refs #16327` rather than `Fixes`.

**Also known:** this does not help over SSH — Grok's chat view does not open there, for an unrelated reason.

---

## Summary

Refs #16327

Keep the proven `multi_select` parsing correction and align desktop/mobile answer delivery with the shipped Grok question card's observed key behavior.

## Reproduction and diagnosis

The reported missing-options symptom is still not reproduced. The answer-delivery defect is reproduced against a live Grok Build 1.0.5 three-question card:

- `2` selected Blue and immediately advanced from question 1 to question 2.
- Space, Down, Down, Space toggled Auth and Metrics; Enter advanced to question 3.
- Final `1` selected Now and submitted without a trailing Enter.

The previous model instead emitted `2`, `l`, `1`, `3`, `l`, `1`, Enter. Because every digit already advances or submits, those extra navigation/submit keys and digit-based multi-selects desynchronize the card.

## Changes

- Re-derive Grok single-select delivery as one auto-advancing digit with no trailing navigation or Enter.
- Deliver Grok multi-selects by navigating rows and toggling each choice with Space before Enter advances/submits.
- Register Claude, Codex, and Grok answer builders in one shared agent-to-builder map used by desktop, mobile, and step-policy checks.
- Share the `multiSelect` / `multi_select` synonym predicate without changing either parser's distinct missing/malformed sentinel behavior.
- Add a regression fixture anchored to the captured live three-question interaction.

## Verification

- `pnpm vitest run --config config/vitest.config.ts --maxWorkers=2 src/shared/native-chat-grok-ask-answer.test.ts` — 1 passed
- `pnpm vitest run --config config/vitest.config.ts --maxWorkers=2 src/shared/native-chat-agent-support.test.ts` — 7 passed
- `pnpm vitest run --config config/vitest.config.ts --maxWorkers=2 src/renderer/src/components/native-chat/native-chat-interactive-prompt.test.ts` — 26 passed
- `pnpm vitest run --config config/vitest.config.ts --maxWorkers=2 src/renderer/src/components/terminal-pane/agent-question-answered-inference.test.ts` — 11 passed
- `pnpm vitest run --config config/vitest.config.ts --maxWorkers=2 src/renderer/src/components/native-chat/use-native-chat-interactive-send.test.tsx` — 14 passed
- `cd mobile && npx vitest run --config vitest.config.ts src/session/mobile-native-chat-ask.test.ts` — 18 passed
- `cd mobile && npx vitest run --config vitest.config.ts src/session/use-mobile-native-chat-answer-send.test.ts` — 32 passed
- `npm run typecheck` — passed
- `cd mobile && npx tsc --noEmit` — passed
- `npm run check:max-lines-ratchet` — passed
- Targeted root and mobile `oxlint` checks — passed

## Mutation proof

Restoring the incorrect pick-without-advance model makes the captured interaction test fail with received `2`, `l`, `1`, `3`, `l`, `1`, Enter versus expected `2`, Space, Down, Down, Space, Enter, `1`. The corrected source was restored before the final green runs.

## Mobile QA

Blocked for the changed flow. The available paired host exposed an unrelated worktree with no live Grok question to exercise, so no changed-behavior screenshot is claimed.
