### PR TITLE
fix(pty): restore the webContents liveness guard dropped by #15927 (STA-5373)

### DIFF
--- a/src/main/ipc/pty-renderer-surface.test.ts
+++ b/src/main/ipc/pty-renderer-surface.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest'
+import { isRendererGone, rendererWebContents, sendToRenderer } from './pty-renderer-surface'
+
+/**
+ * Regression cover for STA-5373: #15927 replaced a two-condition renderer-liveness
+ * guard with a one-condition one, dropping the `webContents.isDestroyed()` half.
+ *
+ * That is fatal rather than cosmetic. `webContents.send()` throws on a destroyed
+ * webContents, the daemon-death fan-out calling it is not inside a try/catch, and an
+ * uncaught throw in the Electron main process exits the app — killing every terminal.
+ * A live window with dead webContents is the exact state a renderer crash or an
+ * in-flight reload produces.
+ */
+function fakeWindow(options: {
+  windowDestroyed?: boolean
+  contentsDestroyed?: boolean
+  omitIsDestroyed?: boolean
+  send?: () => void
+}): never {
+  const contents = {
+    send: options.send ?? (() => {}),
+    ...(options.omitIsDestroyed ? {} : { isDestroyed: () => options.contentsDestroyed === true })
+  }
+  return {
+    isDestroyed: () => options.windowDestroyed === true,
+    webContents: contents
+  } as never
+}
+
+describe('pty renderer surface', () => {
+  it('treats a live window with destroyed webContents as gone', () => {
+    expect(isRendererGone(fakeWindow({ contentsDestroyed: true }))).toBe(true)
+  })
+
+  it('does not send to a live window whose webContents is destroyed', () => {
+    const send = vi.fn()
+    sendToRenderer(fakeWindow({ contentsDestroyed: true, send }), 'pty:data', { id: 'x' })
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  it('still sends when both the window and its webContents are alive', () => {
+    const send = vi.fn()
+    sendToRenderer(fakeWindow({ send }), 'pty:data', { id: 'x' })
+    expect(send).toHaveBeenCalledExactlyOnceWith('pty:data', { id: 'x' })
+  })
+
+  it('treats a destroyed window as gone without consulting webContents', () => {
+    expect(isRendererGone(fakeWindow({ windowDestroyed: true }))).toBe(true)
+  })
+
+  it('treats a missing renderer as gone', () => {
+    expect(isRendererGone(null)).toBe(true)
+    expect(rendererWebContents(null)).toBeNull()
+  })
+
+  it('survives a webContents that does not expose isDestroyed', () => {
+    // Why: the original fix carried a typeof guard, so a partially torn down or stubbed
+    // webContents cannot make the liveness check itself throw.
+    expect(() => isRendererGone(fakeWindow({ omitIsDestroyed: true }))).not.toThrow()
+  })
+
+  it('withholds webContents from callers once it is destroyed', () => {
+    expect(rendererWebContents(fakeWindow({ contentsDestroyed: true }))).toBeNull()
+  })
+})

--- a/src/main/ipc/pty-renderer-surface.ts
+++ b/src/main/ipc/pty-renderer-surface.ts
@@ -14,9 +14,25 @@ import type { BrowserWindow, WebContents } from 'electron'
  * already guards on `isDestroyed()` and skips — so model it as `null` and say so.
  */
 
-/** True when there is no renderer, or it is gone. Callers already treat these the same. */
+/**
+ * True when there is no renderer, or it is gone. Callers already treat these the same.
+ *
+ * Why webContents is checked separately (STA-2373, re-broken by #15927 as STA-5373): a
+ * window can be alive while its webContents is already destroyed — teardown, a renderer
+ * crash, a reload in flight. `webContents.send()` then THROWS, and the daemon-death
+ * fan-out that calls it is not inside a try/catch, so an uncaught throw in the main
+ * process kills the whole app and every terminal with it.
+ *
+ * Why the typeof guard: preserved from the original fix — a stubbed or partially torn
+ * down webContents may not expose the method, and this must never be the thing that
+ * throws.
+ */
 export function isRendererGone(window: BrowserWindow | null): boolean {
-  return window === null || window.isDestroyed()
+  if (window === null || window.isDestroyed()) {
+    return true
+  }
+  const contents = window.webContents as WebContents | undefined
+  return !contents || (typeof contents.isDestroyed === 'function' && contents.isDestroyed())
 }
 
 /** Send to the renderer if one is listening. Absent renderer drops the message, as a destroyed one does. */


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​65 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​65 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 |

<!-- /orca-pr-loc -->

**Release blocker. This is my regression, from #15927.**

## What broke

#15927 replaced a two-condition renderer-liveness guard with a one-condition one, silently dropping the `webContents.isDestroyed()` half.

```
v1.4.188  src/main/ipc/pty.ts   webContents.isDestroyed  ×4
main      src/main/ipc/pty.ts   webContents.isDestroyed  ×0
```

Before (`v1.4.188`):
```js
mainWindow.isDestroyed() ||
(typeof mainWindow.webContents.isDestroyed === 'function' &&
  mainWindow.webContents.isDestroyed())
```

After (`pty-renderer-surface.ts`, shipped):
```ts
return window === null || window.isDestroyed()   // webContents half gone
```

## Why it kills the app

A window can be alive while its webContents is already destroyed — teardown, a renderer crash, a reload in flight. `webContents.send()` **throws** in that state, and neither affected call site is inside a try/catch:

- `src/main/ipc/pty.ts:4067` — the daemon-death fan-out, `onWriteUnavailable`
- `src/main/ipc/pty.ts:7236` — `reportUnavailablePtyWrite`

`main-process-error-guards.ts` exempts only `EIO`/`EPIPE` and re-throws everything else on the next tick. So the entire main process exits — **taking every terminal with it** — with a clean exit code and no crash report.

## The fix

Both halves restored, including the `typeof` check the original carried so a stubbed or partially torn down webContents cannot make the liveness check itself throw.

## Proof

Seven new tests in `pty-renderer-surface.test.ts`. **Verified in both directions** — reverting to the shipped one-condition version fails three of them:

```
FAIL  treats a live window with destroyed webContents as gone
FAIL  does not send to a live window whose webContents is destroyed
FAIL  withholds webContents from callers once it is destroyed
```

`pnpm run typecheck` clean, `pnpm run lint` clean, 593 pty tests pass.

## Why it slipped

#15927 was behaviour-preserving everywhere else, and I treated "renderer gone" as one concept. This guard was the one place where collapsing two conditions into one was not equivalent — a live window with dead webContents is a real state, and it is exactly the state the daemon-death path hits.

The refactor had no test asserting the webContents half, so nothing failed. That gap is now closed.