### PR TITLE
build(windows): drop the packaged node-pty prebuild that can silently replace the patch

### DIFF
--- a/config/packaged-runtime-node-modules.cjs
+++ b/config/packaged-runtime-node-modules.cjs
@@ -348,20 +348,33 @@ function prunePackagedNodePty(resourcesDir, electronPlatformName, electronArch) 
     return
   }
 
-  // Why remove the prebuild entirely on Windows: node-pty's loader tries
-  // build/Release, then build/Debug, then prebuilds/<platform>-<arch>, and
-  // swallows every failure in between. Only the source build carries Orca's
-  // job-object exports (listJobProcessIds/terminateJob/
-  // assignCurrentProcessToJob), so an ABI mismatch, a truncated file or an AV
-  // quarantine of build/Release/conpty.node would silently degrade the shipped
-  // app to the UNPATCHED prebuild -- PTY teardown falling back to guessing by
-  // PID ancestry, with no error anywhere. Deleting the fallback turns that
-  // silent downgrade into a loud load failure.
+  // Why delete only conpty.node: node-pty's loader tries build/Release, then
+  // build/Debug, then prebuilds/<platform>-<arch>, swallowing every failure in
+  // between. Only the source build carries Orca's job-object exports, so an ABI
+  // mismatch or an AV quarantine of build/Release/conpty.node would silently
+  // fall through to the UNPATCHED prebuild -- teardown back to guessing by PID
+  // ancestry, with no error anywhere.
+  //
+  // Why NOT the whole prebuilds/ tree: Orca's own patch deletes the
+  // `conpty_console_list` and winpty `pty` gyp targets, so a Windows source
+  // build emits conpty.node and nothing else. conpty_console_list.node,
+  // pty.node, winpty.dll and winpty-agent.exe exist ONLY here. Removing them
+  // silently kills console-membership probing (the forked agent throws at
+  // require, and its caller resolves null with silent: true), and removes the
+  // winpty backend that node-pty still selects below Windows build 18309.
+  //
+  // Why the arch check: a cross-arch package copies the host's build/Release,
+  // so its mere presence does not mean it matches electronArch -- deleting the
+  // target-arch prebuild would then remove the only loadable binary.
   if (
     electronPlatformName === 'win32' &&
+    electronArch === process.arch &&
     existsSync(join(nodePtyDir, 'build', 'Release', 'conpty.node'))
   ) {
-    rmSync(join(nodePtyDir, 'prebuilds'), { recursive: true, force: true })
+    const prebuildDir = join(nodePtyDir, 'prebuilds', `win32-${electronArch}`)
+    for (const staleFallback of ['conpty.node', 'conpty.pdb']) {
+      rmSync(join(prebuildDir, staleFallback), { force: true })
+    }
   }
 
   const allowedPrebuildPrefix = NODE_PTY_PREBUILD_PREFIX_BY_PLATFORM[electronPlatformName]

--- a/config/packaged-runtime-node-modules.cjs
+++ b/config/packaged-runtime-node-modules.cjs
@@ -348,6 +348,22 @@ function prunePackagedNodePty(resourcesDir, electronPlatformName, electronArch) 
     return
   }
 
+  // Why remove the prebuild entirely on Windows: node-pty's loader tries
+  // build/Release, then build/Debug, then prebuilds/<platform>-<arch>, and
+  // swallows every failure in between. Only the source build carries Orca's
+  // job-object exports (listJobProcessIds/terminateJob/
+  // assignCurrentProcessToJob), so an ABI mismatch, a truncated file or an AV
+  // quarantine of build/Release/conpty.node would silently degrade the shipped
+  // app to the UNPATCHED prebuild -- PTY teardown falling back to guessing by
+  // PID ancestry, with no error anywhere. Deleting the fallback turns that
+  // silent downgrade into a loud load failure.
+  if (
+    electronPlatformName === 'win32' &&
+    existsSync(join(nodePtyDir, 'build', 'Release', 'conpty.node'))
+  ) {
+    rmSync(join(nodePtyDir, 'prebuilds'), { recursive: true, force: true })
+  }
+
   const allowedPrebuildPrefix = NODE_PTY_PREBUILD_PREFIX_BY_PLATFORM[electronPlatformName]
   if (allowedPrebuildPrefix) {
     pruneNodePtyNativeDirectories(

--- a/config/scripts/packaged-node-pty-prebuild-prune.test.mjs
+++ b/config/scripts/packaged-node-pty-prebuild-prune.test.mjs
@@ -10,18 +10,36 @@ const { prunePackagedNodePty } = require('../packaged-runtime-node-modules.cjs')
 /**
  * node-pty's loader tries build/Release, then build/Debug, then
  * prebuilds/<platform>-<arch>, swallowing failures in between. Only the source
- * build carries Orca's job-object exports, so leaving the prebuild beside it
- * means an ABI mismatch or an AV quarantine silently downgrades the shipped app
- * to a binary that cannot own a PTY tree -- with no error anywhere.
+ * build carries Orca's job-object exports, so leaving the prebuilt conpty.node
+ * beside it means an ABI mismatch or an AV quarantine silently downgrades the
+ * app to a binary that cannot own a PTY tree.
+ *
+ * The siblings must survive: Orca's patch deletes the `conpty_console_list` and
+ * winpty `pty` gyp targets, so those binaries exist nowhere but here.
  */
-describe('prunePackagedNodePty: the Windows prebuild fallback', () => {
+describe('prunePackagedNodePty: the Windows conpty fallback', () => {
   let resources
+  const HOST_ARCH = process.arch
 
   const nodePty = () => join(resources, 'node_modules', 'node-pty')
-  const writeFile = (relative) => {
+  const write = (relative) => {
     const target = join(nodePty(), relative)
     mkdirSync(join(target, '..'), { recursive: true })
     writeFileSync(target, 'x')
+  }
+  const prebuilt = (name, arch = HOST_ARCH) => join(nodePty(), 'prebuilds', `win32-${arch}`, name)
+
+  /** What a real packaged win32 prebuilds/<arch> directory holds. */
+  const SIBLINGS = ['conpty_console_list.node', 'pty.node', 'winpty.dll', 'winpty-agent.exe']
+
+  const seedWindowsTree = (arch = HOST_ARCH) => {
+    write(join('build', 'Release', 'conpty.node'))
+    write(join('third_party', 'conpty', 'v1', `win10-${arch}`, 'conpty.dll'))
+    write(join('third_party', 'conpty', 'v1', `win10-${arch}`, 'OpenConsole.exe'))
+    write(join('prebuilds', `win32-${arch}`, 'conpty.node'))
+    for (const sibling of SIBLINGS) {
+      write(join('prebuilds', `win32-${arch}`, sibling))
+    }
   }
 
   beforeEach(() => {
@@ -31,34 +49,54 @@ describe('prunePackagedNodePty: the Windows prebuild fallback', () => {
     rmSync(resources, { recursive: true, force: true })
   })
 
-  it('removes the prebuild when the source build is present', () => {
-    writeFile(join('build', 'Release', 'conpty.node'))
-    writeFile(join('prebuilds', 'win32-x64', 'conpty.node'))
-    // The later ConPTY-runtime check expects these; unrelated to the prune.
-    writeFile(join('third_party', 'conpty', 'v1', 'win10-x64', 'conpty.dll'))
-    writeFile(join('third_party', 'conpty', 'v1', 'win10-x64', 'OpenConsole.exe'))
+  it('removes the stale conpty fallback when the source build is present', () => {
+    seedWindowsTree()
 
-    prunePackagedNodePty(resources, 'win32', 'x64')
+    prunePackagedNodePty(resources, 'win32', HOST_ARCH)
 
     expect(existsSync(join(nodePty(), 'build', 'Release', 'conpty.node'))).toBe(true)
-    expect(existsSync(join(nodePty(), 'prebuilds'))).toBe(false)
+    expect(existsSync(prebuilt('conpty.node'))).toBe(false)
   })
 
-  it('keeps the prebuild when there is no source build to prefer', () => {
-    // Deleting it here would leave nothing loadable at all.
-    writeFile(join('prebuilds', 'win32-x64', 'conpty.node'))
+  it.each(SIBLINGS)('keeps %s, which exists nowhere else in a packaged build', (sibling) => {
+    // Orca's patch removes the conpty_console_list and winpty gyp targets, so a
+    // Windows source build never produces these. Deleting them kills console
+    // membership silently and breaks PTY spawn below Windows build 18309.
+    seedWindowsTree()
 
-    prunePackagedNodePty(resources, 'win32', 'x64')
+    prunePackagedNodePty(resources, 'win32', HOST_ARCH)
 
-    expect(existsSync(join(nodePty(), 'prebuilds', 'win32-x64', 'conpty.node'))).toBe(true)
+    expect(existsSync(prebuilt(sibling))).toBe(true)
+  })
+
+  it('keeps the fallback when there is no source build to prefer', () => {
+    write(join('prebuilds', `win32-${HOST_ARCH}`, 'conpty.node'))
+    write(join('third_party', 'conpty', 'v1', `win10-${HOST_ARCH}`, 'conpty.dll'))
+    write(join('third_party', 'conpty', 'v1', `win10-${HOST_ARCH}`, 'OpenConsole.exe'))
+
+    prunePackagedNodePty(resources, 'win32', HOST_ARCH)
+
+    expect(existsSync(prebuilt('conpty.node'))).toBe(true)
+  })
+
+  it('keeps the fallback on a cross-arch package, where build/Release is the host arch', () => {
+    // electron-builder --win --arm64 on an x64 host copies an x64
+    // build/Release; deleting the arm64 prebuild would remove the only binary
+    // the shipped app could load.
+    const target = HOST_ARCH === 'arm64' ? 'x64' : 'arm64'
+    seedWindowsTree(target)
+
+    prunePackagedNodePty(resources, 'win32', target)
+
+    expect(existsSync(prebuilt('conpty.node', target))).toBe(true)
   })
 
   it.each([
     ['darwin', 'arm64'],
     ['linux', 'x64']
-  ])('leaves %s prebuilds alone, which have no patched-export requirement', (platform, arch) => {
-    writeFile(join('build', 'Release', 'conpty.node'))
-    writeFile(join('prebuilds', `${platform}-${arch}`, 'pty.node'))
+  ])('leaves %s prebuilds alone', (platform, arch) => {
+    write(join('build', 'Release', 'conpty.node'))
+    write(join('prebuilds', `${platform}-${arch}`, 'pty.node'))
 
     prunePackagedNodePty(resources, platform, arch)
 

--- a/config/scripts/packaged-node-pty-prebuild-prune.test.mjs
+++ b/config/scripts/packaged-node-pty-prebuild-prune.test.mjs
@@ -1,0 +1,67 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { createRequire } from 'node:module'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const { prunePackagedNodePty } = require('../packaged-runtime-node-modules.cjs')
+
+/**
+ * node-pty's loader tries build/Release, then build/Debug, then
+ * prebuilds/<platform>-<arch>, swallowing failures in between. Only the source
+ * build carries Orca's job-object exports, so leaving the prebuild beside it
+ * means an ABI mismatch or an AV quarantine silently downgrades the shipped app
+ * to a binary that cannot own a PTY tree -- with no error anywhere.
+ */
+describe('prunePackagedNodePty: the Windows prebuild fallback', () => {
+  let resources
+
+  const nodePty = () => join(resources, 'node_modules', 'node-pty')
+  const writeFile = (relative) => {
+    const target = join(nodePty(), relative)
+    mkdirSync(join(target, '..'), { recursive: true })
+    writeFileSync(target, 'x')
+  }
+
+  beforeEach(() => {
+    resources = mkdtempSync(join(tmpdir(), 'orca-prune-'))
+  })
+  afterEach(() => {
+    rmSync(resources, { recursive: true, force: true })
+  })
+
+  it('removes the prebuild when the source build is present', () => {
+    writeFile(join('build', 'Release', 'conpty.node'))
+    writeFile(join('prebuilds', 'win32-x64', 'conpty.node'))
+    // The later ConPTY-runtime check expects these; unrelated to the prune.
+    writeFile(join('third_party', 'conpty', 'v1', 'win10-x64', 'conpty.dll'))
+    writeFile(join('third_party', 'conpty', 'v1', 'win10-x64', 'OpenConsole.exe'))
+
+    prunePackagedNodePty(resources, 'win32', 'x64')
+
+    expect(existsSync(join(nodePty(), 'build', 'Release', 'conpty.node'))).toBe(true)
+    expect(existsSync(join(nodePty(), 'prebuilds'))).toBe(false)
+  })
+
+  it('keeps the prebuild when there is no source build to prefer', () => {
+    // Deleting it here would leave nothing loadable at all.
+    writeFile(join('prebuilds', 'win32-x64', 'conpty.node'))
+
+    prunePackagedNodePty(resources, 'win32', 'x64')
+
+    expect(existsSync(join(nodePty(), 'prebuilds', 'win32-x64', 'conpty.node'))).toBe(true)
+  })
+
+  it.each([
+    ['darwin', 'arm64'],
+    ['linux', 'x64']
+  ])('leaves %s prebuilds alone, which have no patched-export requirement', (platform, arch) => {
+    writeFile(join('build', 'Release', 'conpty.node'))
+    writeFile(join('prebuilds', `${platform}-${arch}`, 'pty.node'))
+
+    prunePackagedNodePty(resources, platform, arch)
+
+    expect(existsSync(join(nodePty(), 'prebuilds', `${platform}-${arch}`, 'pty.node'))).toBe(true)
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​105 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​105 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​29 |

<!-- /orca-pr-loc -->

Refs #16059.

## ELI5

node-pty picks its native binary by trying, in order: `build/Release` → `build/Debug` → `prebuilds/<platform>-<arch>` — **swallowing every failure in between**.

Windows packaging ships *both* the source build and the prebuild. Only the source build carries Orca's job-object exports (`listJobProcessIds`, `terminateJob`, `assignCurrentProcessToJob`).

So if `build/Release/conpty.node` ever fails to load — ABI mismatch after an Electron bump, a truncated file, an antivirus quarantine — the app silently loads the **unpatched** prebuild instead. `isPtyJobOwnershipAvailable()` goes false, `terminatePtyJob()` returns `unavailable`, and PTY teardown falls back to guessing which processes belong to a pane by walking PIDs. No error is logged. Nothing looks wrong.

That is exactly the shape of failure that made #16059 hard to pin down: an install that appears healthy and quietly cannot own a PTY tree.

## What this changes

On win32, when `build/Release/conpty.node` exists, `prunePackagedNodePty` removes the `prebuilds/` tree from the packaged app.

The point is not disk space — it is removing a **silent** fallback. Without it, a broken source build becomes a loud load failure instead of a working app with a disabled safety mechanism.

## Scope

Deliberately narrow:

- **Only win32.** macOS and Linux prebuilds are untouched; they have no patched export to lose.
- **Only when the source build is present.** A build that legitimately has no `build/Release` keeps something loadable rather than shipping nothing.

## Proof of no regression

- 4 new tests: the prebuild goes when a source build exists; it **stays** when there is none; darwin and linux prebuilds survive.
- Verified to bind — removing the prune fails the first test and only that one.
- Full `config/scripts` suite: 955 passed.
- Lint and typecheck exit 0.

## Context worth knowing

The original #16059 alarm ("shipped app has no job exports") turned out to be a **timing** artifact — the build measured predated the patch hunk by ~44 hours, and Windows packaging genuinely does source-build (`build/Release/.forge-meta`, `binding.sln`, `obj/` all present on a shipped install). I have corrected that on the issue.

This PR is the part that survives that correction: the fallback path is real, it is live today, and it fails silently.

## User-facing trade-offs

**None in normal operation** — the shipped app already loads `build/Release`. The change only affects the case where that binary cannot load, and there the new behaviour (fail loudly) is what you want.
