### PR TITLE
fix(lint): exempt verbatim-moved code from the changed-lines quality gate

### DIFF
--- a/config/scripts/check-changed-code-quality.mjs
+++ b/config/scripts/check-changed-code-quality.mjs
@@ -139,7 +139,79 @@ function diagnosticLineRange(root, filename, span) {
   return { start: startLine, end: startLine + (highlighted.match(/\n/g)?.length ?? 0) }
 }
 
-export function diagnosticTouchesAddedLines(diagnostic, rangesByFile, root = process.cwd()) {
+// Why: a file-splitting refactor makes every line of the new module an "added"
+// line, so pre-existing lint debt in code that merely MOVED starts failing the
+// changed-lines gate. The only way to satisfy it is to edit the moved code,
+// which is exactly what a behavior-preserving refactor must not do. So a
+// diagnostic is exempt when its highlighted lines already existed, verbatim and
+// contiguous, somewhere in the base revision of the files this change touches.
+function normalizeSourceLine(line) {
+  return line.replace(/\s+/g, ' ').trim()
+}
+
+export function collectBaseLineBlocks(root, comparisonBase, files = null) {
+  // Why: in a split, the moved code's base text lives in the ORIGINAL file, which is
+  // often deleted or renamed away. Deleted paths never reach the changed-file list
+  // (it filters to ACMRTUB), so read every path the diff touches, deletions included.
+  const paths =
+    files ??
+    splitNullDelimited(
+      runGit(root, ['diff', '--name-only', '-z', comparisonBase, '--'])
+    ).filter((file) => SOURCE_FILE_PATTERN.test(file))
+  const blocks = []
+  for (const file of paths) {
+    const result = spawnSync('git', ['show', `${comparisonBase}:${file}`], {
+      cwd: root,
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024
+    })
+    if (result.status !== 0 || typeof result.stdout !== 'string') {
+      continue
+    }
+    blocks.push(result.stdout.split(/\r?\n/).map(normalizeSourceLine).filter((line) => line !== ''))
+  }
+  return blocks
+}
+
+export function isMovedCode(highlightedLines, baseBlocks) {
+  const needle = highlightedLines.map(normalizeSourceLine).filter((line) => line !== '')
+  if (needle.length === 0) {
+    return false
+  }
+  return baseBlocks.some((rawHaystack) => {
+    const haystack = rawHaystack.map(normalizeSourceLine).filter((line) => line !== '')
+    for (let start = 0; start + needle.length <= haystack.length; start += 1) {
+      let matched = true
+      for (let offset = 0; offset < needle.length; offset += 1) {
+        if (haystack[start + offset] !== needle[offset]) {
+          matched = false
+          break
+        }
+      }
+      if (matched) {
+        return true
+      }
+    }
+    return false
+  })
+}
+
+function diagnosticHighlightedLines(root, filename, span) {
+  const absolutePath = path.isAbsolute(filename) ? filename : path.join(root, filename)
+  const source = readFileSync(absolutePath, 'utf8').split(/\r?\n/)
+  const range = diagnosticLineRange(root, filename, span)
+  if (range === null) {
+    return []
+  }
+  return source.slice(range.start - 1, range.end)
+}
+
+export function diagnosticTouchesAddedLines(
+  diagnostic,
+  rangesByFile,
+  root = process.cwd(),
+  baseBlocks = []
+) {
   const file = normalizedDiagnosticPath(root, diagnostic.filename)
   const ranges = rangesByFile.get(file)
   if (!ranges) {
@@ -147,7 +219,10 @@ export function diagnosticTouchesAddedLines(diagnostic, rangesByFile, root = pro
   }
   return (diagnostic.labels ?? []).some((label) => {
     const lineRange = diagnosticLineRange(root, diagnostic.filename, label.span)
-    return lineRange !== null && overlapsAddedLines(lineRange.start, lineRange.end, ranges)
+    if (lineRange === null || !overlapsAddedLines(lineRange.start, lineRange.end, ranges)) {
+      return false
+    }
+    return !isMovedCode(diagnosticHighlightedLines(root, diagnostic.filename, label.span), baseBlocks)
   })
 }
 
@@ -193,10 +268,12 @@ export function main(
     return 0
   }
 
+  const baseBlocks = collectBaseLineBlocks(root, comparisonBase)
+
   let failures = 0
   for (const scan of OXLINT_SCANS) {
     const diagnostics = runOxlintScan(root, scan, files).filter((diagnostic) =>
-      diagnosticTouchesAddedLines(diagnostic, rangesByFile, root)
+      diagnosticTouchesAddedLines(diagnostic, rangesByFile, root, baseBlocks)
     )
     for (const diagnostic of diagnostics) {
       printDiagnostic(diagnostic, root)

--- a/config/scripts/check-changed-code-quality.test.mjs
+++ b/config/scripts/check-changed-code-quality.test.mjs
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   OXLINT_SCANS,
   diagnosticTouchesAddedLines,
+  isMovedCode,
   overlapsAddedLines,
   parseAddedLineRanges
 } from './check-changed-code-quality.mjs'
@@ -50,5 +51,41 @@ describe('changed-code quality line matching', () => {
 
     expect(scan.args).not.toContain('--config')
     expect(scan.args).not.toContain('--disable-nested-config')
+  })
+})
+
+describe('moved-code exemption', () => {
+  it('treats a verbatim contiguous block from the base as moved', () => {
+    const base = [['const a = 1', 'items.map((item, index) => (', 'key={index}', '))']]
+    expect(isMovedCode(['items.map((item, index) => (', 'key={index}', '))'], base)).toBe(true)
+  })
+
+  it('ignores indentation and whitespace changes from the move', () => {
+    const base = [['    items.map((item, index) => (', '      key={index}']]
+    expect(isMovedCode(['items.map((item, index) => (', 'key={index}'], base)).toBe(true)
+  })
+
+  it('does not exempt a genuinely new violation', () => {
+    const base = [['const a = 1', 'const b = 2']]
+    expect(isMovedCode(['rows.map((row, i) => <td key={i} />)'], base)).toBe(false)
+  })
+
+  it('does not exempt a block that is only partly present in the base', () => {
+    const base = [['doThing()', 'unrelated()']]
+    expect(isMovedCode(['doThing()', 'newlyAddedSideEffect()'], base)).toBe(false)
+  })
+
+  it('does not exempt when the base lines are non-contiguous', () => {
+    const base = [['doThing()', 'filler()', 'other()']]
+    expect(isMovedCode(['doThing()', 'other()'], base)).toBe(false)
+  })
+
+  it('ignores blank lines when matching', () => {
+    const base = [['a()', 'b()']]
+    expect(isMovedCode(['a()', '', 'b()'], base)).toBe(true)
+  })
+
+  it('never exempts an empty highlight', () => {
+    expect(isMovedCode(['', '   '], [['a()']])).toBe(false)
   })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​80 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​77 |

<!-- /orca-pr-loc -->

## Problem

`check-changed-code-quality.mjs` keeps any diagnostic whose span overlaps an **added line**, with no rename or move detection. In a file-splitting refactor *every* line of the new module is an added line, so pre-existing lint debt in code that merely **moved** suddenly fails the gate.

There is no way to satisfy it without editing the moved code — and the edits it asks for are behavior changes:

- `no-array-index-as-key` → changing React keys changes reconciliation identity
- `no-adjust-state-on-prop-change` → deleting a state-clearing effect changes when state clears
- `no-side-effect-in-state-updater-function` → hoisting a ref write changes when a latch flips

The in-source `oxlint-disable react-doctor/*` idiom does not work here either: the root `.oxlintrc.json` does not load the react-doctor plugin, so the directive becomes an *"unused disable directive"* warning under the first scan and the finding count is unchanged. In a split refactor there is no line the changed-lines filter will not see.

### This is not hypothetical

While auditing a batch of 34 refactor PRs, several regressions traced directly to an author "fixing" these warnings on moved code:

- notebook output React keys changed from `key={index}` to a content hash that `JSON.stringify`s every output — including raw base64 images — on every keystroke
- a `useEffect` that reset `selectedProjectGroupId` to `null` replaced by a read-side mask, so the raw state was never cleared and a deselected group silently resurrected

Both were reverted to merge-base behavior — which made CI fail again, on the *correct* code. That is the gate inverting its own purpose.

## Change

Exempt a diagnostic when its highlighted lines already existed **verbatim and contiguous** in the base revision of the files this change touches.

- `collectBaseLineBlocks()` reads the base text of every path in the diff, **including deletions** (the split's original file is usually deleted, and deleted paths never reach the changed-file list because it filters to `ACMRTUB`)
- `isMovedCode()` requires the diagnostic's whole normalized, non-blank line sequence to appear as a contiguous run in some base file — not a per-line match, which would be far too loose
- whitespace and blank-line differences are normalized on both sides, so the reflow a move causes does not defeat the match

## Verification

- 11 unit tests, including negative cases: partial overlap, non-contiguous base lines, and a genuinely new violation are all still reported
- Against the two PRs this was blocking, the gate now passes: `#16143` 0 findings across 24 files, `#16182` 0 findings across 76 files
- **Negative control:** added a new component with a fresh `key={index}` violation on a brand-new line — the gate still fails it with `react-doctor(no-array-index-as-key)`. The exemption is scoped to moved code only.