### PR TITLE
fix(ssh): restore the reconnect model-paint gate dropped by #15166

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection-direct-ssh-reattach-retry.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-direct-ssh-reattach-retry.test.ts
@@ -366,6 +366,13 @@ describe('connectPanePty', () => {
     expect(transport.resize).not.toHaveBeenCalledWith(119, 40)
   })
 
+  it('paints a reconnect from the alt-screen model when the relay has no replay', async () => {
+    const { writes } = await reconnectWithAltScreenModel('')
+
+    expect(window.api.pty.getMainBufferSnapshot).toHaveBeenCalledTimes(1)
+    expect(writes.join('')).toContain('MODEL-ALT-FRAME')
+  })
+
   it('uses the SSH relay replay for a reconnect once the replay shows the app left alt screen', async () => {
     const { writes } = await reconnectWithAltScreenModel('\x1b[?1049l\r\n$ real-shell-output')
 

--- a/src/renderer/src/components/terminal-pane/pty-connection-direct-ssh-reattach-retry.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-direct-ssh-reattach-retry.test.ts
@@ -282,14 +282,19 @@ describe('connectPanePty', () => {
     )
   })
 
-  it('uses the SSH relay replay for a reconnect even when main has an alt-screen model', async () => {
+  // Why both directions: #15166 dropped #14844's reconnect model-paint gate and pinned the
+  // degraded relay-only paint here. The gate's contract is that the relay wins only when the
+  // replay SHOWS the app left the alternate screen, so pin the veto and its absence together.
+  async function reconnectWithAltScreenModel(
+    replay: string
+  ): Promise<{ writes: string[]; transport: MockTransport }> {
     const { connectPanePty } = await import('./pty-connection')
     const restoredPtyId = toAppSshPtyId('target-a', 'pty-restored-relay')
     const transport = createMockTransport(restoredPtyId)
     transport.connect.mockResolvedValue({
       id: restoredPtyId,
       isReattach: true,
-      replay: '9l\r\n$ real-shell-output'
+      replay
     })
     transportFactoryQueue.push(transport)
     const pendingRetry = {
@@ -347,11 +352,29 @@ describe('connectPanePty', () => {
       }) as never
     )
     await flushAsyncTicks(20)
+    return { writes, transport }
+  }
 
+  it('paints a reconnect from the alt-screen model when the replay shows no alt-screen exit', async () => {
+    // The tail begins mid-escape — the ESC of its `?1049l` was evicted with the bytes before
+    // it — so it carries no readable transition and cannot rebuild the frame it no longer
+    // holds. Known limit of lastAlternateScreenTransition, and the model is the better paint.
+    const { writes, transport } = await reconnectWithAltScreenModel('9l\r\n$ real-shell-output')
+
+    expect(window.api.pty.getMainBufferSnapshot).toHaveBeenCalled()
+    expect(writes.join('')).toContain('MODEL-ALT-FRAME')
+    expect(transport.resize).not.toHaveBeenCalledWith(119, 40)
+  })
+
+  it('uses the SSH relay replay for a reconnect once the replay shows the app left alt screen', async () => {
+    const { writes } = await reconnectWithAltScreenModel('\x1b[?1049l\r\n$ real-shell-output')
+
+    // Vetoed before the probe is even issued: the model still reports alternateScreen because
+    // it never consumed those bytes, so painting it would freeze a dead frame AND discard the
+    // shell output only the replay holds.
     expect(window.api.pty.getMainBufferSnapshot).not.toHaveBeenCalled()
     expect(writes.join('')).toContain('real-shell-output')
     expect(writes.join('')).not.toContain('MODEL-ALT-FRAME')
-    expect(transport.resize).not.toHaveBeenCalledWith(119, 40)
   })
 
   it('rejects expired reattach state after its direct SSH retry lease is revoked', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection/agent-idle-working-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/agent-idle-working-handlers.ts
@@ -151,6 +151,17 @@ export function installAgentIdleWorkingHandlers(session: ConnectPanePtySession):
           : undefined
     return attempt
   })()
+  // Only the PENDING retry marks a mount that a reconnect created. directSshRetryAttempt also
+  // accepts the live binding, which is written at the same tab generation once the reconnect
+  // succeeds and then outlives it — so it stays truthy for every later remount of that generation,
+  // not just this one.
+  session.followsDirectSshReconnect = (() => {
+    const pending = session.state.directSshPaneRetryByTabId?.[session.deps.tabId]
+    return (
+      pending?.authority.targetId === session.connectionId &&
+      pending.tabGeneration === (session.tab?.generation ?? 0)
+    )
+  })()
   // Generation is part of ownership: a recovery remount must not join a spawn
   // started by the pane instance it replaced, while StrictMode remounts keep
   // the same generation and may still share their in-flight spawn.

--- a/src/renderer/src/components/terminal-pane/pty-connection/apply-reattach-payload.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/apply-reattach-payload.ts
@@ -14,6 +14,10 @@ import {
 } from '../terminal-snapshot-replay-paint'
 
 import { isRemoteRuntimePtyId } from './paired-parked-terminal-restore'
+import {
+  lastAlternateScreenTransition,
+  sshReconnectPaintsFromModel
+} from '../ssh-reattach-model-restore'
 import { restoredSnapshotPaintsPrintableContent } from '../restored-snapshot-coverage'
 
 import type { ReattachPayloadContext } from './reattach-payload-context'
@@ -110,10 +114,35 @@ export function createReattachPayloadHandlers(
       // model still holds, but an in-place reattach (network reconnect, wake,
       // reload) already has that replay in hand, so probing would only delay its
       // paint by the timeout. Memoized, so this is never a second probe.
-      const modelSnapshot = ctx.revealFollowsTerminalPark
+      // An SSH reconnect may use the model only under sshReconnectPaintsFromModel: the reconnect
+      // replay reaches the renderer without passing through main's model (forwardReattachReplay
+      // and the inline attach replay both bypass onPtyData), so the model is stale by exactly
+      // the outage and the replay is the only witness to it. A park has no such hole, so it
+      // keeps using the model either way.
+      const revealSnapshot = ctx.revealFollowsTerminalPark
         ? (ctx.prefetchedParkModelSnapshot ??
           (isRemoteRuntimePtyId(ctx.ptyId) ? null : await ctx.fetchSshMainModelReattachSnapshot()))
         : null
+      // Asked before the probe, not after: if the replay shows the app left the alternate
+      // screen, no snapshot can be used no matter what it says, so fetching one only spends the
+      // 750ms timeout to throw the answer away — and spends it inside the coordinator, with live
+      // PTY bytes deferred and the payload still able to be superseded.
+      const replayTransition = lastAlternateScreenTransition(ctx.connectResult?.replay)
+      const replayVetoesModel = replayTransition === 'exited'
+      const reconnectSnapshot =
+        !revealSnapshot && ctx.reconnectMayUseModel && !replayVetoesModel
+          ? await ctx.fetchSshMainModelReattachSnapshot()
+          : null
+      const paintsReconnectFromModel = sshReconnectPaintsFromModel({
+        snapshot: reconnectSnapshot,
+        hasReplay: Boolean(ctx.connectResult?.replay),
+        replayTransition,
+        altFrameWouldBeSkipped: shouldSkipAltFrameForWidthMismatch(
+          reconnectSnapshot?.cols,
+          readProposedTerminalCols(session.pane)
+        )
+      })
+      const modelSnapshot = revealSnapshot ?? (paintsReconnectFromModel ? reconnectSnapshot : null)
       if (!ctx.isCurrentReattachPayload()) {
         return
       }
@@ -142,6 +171,13 @@ export function createReattachPayloadHandlers(
           kittyKeyboardFlags: modelSnapshot.kittyKeyboardFlags,
           snapshotSeq: modelSnapshot.seq
         })
+        if (paintsReconnectFromModel && ctx.connectResult?.replay) {
+          // Why after the snapshot: painting the model discards the replay, but the app's kitty
+          // pushes during the outage exist ONLY there. Snapshot first for the pre-outage
+          // baseline, then the replay layers the outage on top — otherwise Option/Alt chords
+          // encode against a stale flag stack.
+          session.kittyKeyboardModes.scanReplay(ctx.connectResult.replay)
+        }
         // Why shared: park+reveal of an alt-screen TUI needs the same
         // ?1049l/?1049h rebuild as applyMainBufferSnapshot (main strips
         // the ?1049h marker when splitting scrollbackAnsi) — inlined here

--- a/src/renderer/src/components/terminal-pane/pty-connection/apply-reattach-payload.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/apply-reattach-payload.ts
@@ -14,11 +14,8 @@ import {
 } from '../terminal-snapshot-replay-paint'
 
 import { isRemoteRuntimePtyId } from './paired-parked-terminal-restore'
-import {
-  lastAlternateScreenTransition,
-  sshReconnectPaintsFromModel
-} from '../ssh-reattach-model-restore'
 import { restoredSnapshotPaintsPrintableContent } from '../restored-snapshot-coverage'
+import { resolveSshReconnectModelPaint } from './resolve-ssh-reconnect-model-paint'
 
 import type { ReattachPayloadContext } from './reattach-payload-context'
 import type { ReattachPayloadSession } from './reattach-payload-session'
@@ -109,7 +106,11 @@ export function createReattachPayloadHandlers(
           window.api.pty.ackColdRestore(ctx.ptyId)
         }
       }
-    } else if (ctx.connectResult?.replay || ctx.prefetchedParkModelSnapshot) {
+    } else if (
+      ctx.connectResult?.replay ||
+      ctx.prefetchedParkModelSnapshot ||
+      ctx.reconnectMayUseModel
+    ) {
       // Why scoped to a park-reveal: the 100KiB relay tail loses scrollback the
       // model still holds, but an in-place reattach (network reconnect, wake,
       // reload) already has that replay in hand, so probing would only delay its
@@ -123,26 +124,15 @@ export function createReattachPayloadHandlers(
         ? (ctx.prefetchedParkModelSnapshot ??
           (isRemoteRuntimePtyId(ctx.ptyId) ? null : await ctx.fetchSshMainModelReattachSnapshot()))
         : null
-      // Asked before the probe, not after: if the replay shows the app left the alternate
-      // screen, no snapshot can be used no matter what it says, so fetching one only spends the
-      // 750ms timeout to throw the answer away — and spends it inside the coordinator, with live
-      // PTY bytes deferred and the payload still able to be superseded.
-      const replayTransition = lastAlternateScreenTransition(ctx.connectResult?.replay)
-      const replayVetoesModel = replayTransition === 'exited'
-      const reconnectSnapshot =
-        !revealSnapshot && ctx.reconnectMayUseModel && !replayVetoesModel
-          ? await ctx.fetchSshMainModelReattachSnapshot()
-          : null
-      const paintsReconnectFromModel = sshReconnectPaintsFromModel({
-        snapshot: reconnectSnapshot,
-        hasReplay: Boolean(ctx.connectResult?.replay),
-        replayTransition,
-        altFrameWouldBeSkipped: shouldSkipAltFrameForWidthMismatch(
-          reconnectSnapshot?.cols,
-          readProposedTerminalCols(session.pane)
-        )
+      const reconnectPaint = await resolveSshReconnectModelPaint({
+        reconnectMayUseModel: !revealSnapshot && ctx.reconnectMayUseModel,
+        replay: ctx.connectResult?.replay,
+        fetchSnapshot: ctx.fetchSshMainModelReattachSnapshot,
+        readTargetCols: () => readProposedTerminalCols(session.pane)
       })
-      const modelSnapshot = revealSnapshot ?? (paintsReconnectFromModel ? reconnectSnapshot : null)
+      const paintsReconnectFromModel = reconnectPaint.paintsFromModel
+      const modelSnapshot =
+        revealSnapshot ?? (paintsReconnectFromModel ? reconnectPaint.snapshot : null)
       if (!ctx.isCurrentReattachPayload()) {
         return
       }
@@ -183,10 +173,9 @@ export function createReattachPayloadHandlers(
         // the ?1049h marker when splitting scrollbackAnsi) — inlined here
         // because nesting structuralReplayCoordinator would deadlock.
         for (const replayChunk of buildMainModelSnapshotReplayWrites(modelSnapshot, {
-          skipAltFrame: shouldSkipAltFrameForWidthMismatch(
-            modelCols,
-            readProposedTerminalCols(session.pane)
-          ),
+          skipAltFrame: paintsReconnectFromModel
+            ? reconnectPaint.altFrameWouldBeSkipped
+            : shouldSkipAltFrameForWidthMismatch(modelCols, readProposedTerminalCols(session.pane)),
           paneOnAlternateScreen: session.isPaneOnAlternateScreen()
         })) {
           session.writeReplayData(replayChunk)
@@ -310,7 +299,7 @@ export function createReattachPayloadHandlers(
         session.schedulePendingStartupCommandDelivery()
       }
     }
-    if (ctx.hasStructuralReplay || ctx.prefetchedParkModelSnapshot) {
+    if (ctx.shouldApplyStructuralPayload) {
       await waitForTerminalReplayWritesParsed(session.pane.terminal)
       if (!ctx.isCurrentReattachPayload()) {
         return

--- a/src/renderer/src/components/terminal-pane/pty-connection/reattach-payload-context.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/reattach-payload-context.test.ts
@@ -34,6 +34,7 @@ function createContext(replay: string, attemptGeneration: number): ReattachPaylo
     attemptGeneration,
     prefetchedParkModelSnapshot: null,
     revealFollowsTerminalPark: false,
+    reconnectMayUseModel: false,
     fetchSshMainModelReattachSnapshot: async () => null,
     hasStructuralReplay: true,
     coldRestoreStartup: undefined,

--- a/src/renderer/src/components/terminal-pane/pty-connection/reattach-payload-context.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/reattach-payload-context.test.ts
@@ -36,7 +36,7 @@ function createContext(replay: string, attemptGeneration: number): ReattachPaylo
     revealFollowsTerminalPark: false,
     reconnectMayUseModel: false,
     fetchSshMainModelReattachSnapshot: async () => null,
-    hasStructuralReplay: true,
+    shouldApplyStructuralPayload: true,
     coldRestoreStartup: undefined,
     reattachPayloadApplied: false
   }

--- a/src/renderer/src/components/terminal-pane/pty-connection/reattach-payload-context.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/reattach-payload-context.ts
@@ -9,6 +9,8 @@ export type ReattachPayloadContext = {
   attemptGeneration: number
   prefetchedParkModelSnapshot: PtyBufferSnapshot | null
   revealFollowsTerminalPark: boolean
+  /** SSH reconnect remount that may paint from main's model under sshReconnectPaintsFromModel. */
+  reconnectMayUseModel: boolean
   fetchSshMainModelReattachSnapshot: () => Promise<PtyBufferSnapshot | null>
   hasStructuralReplay: boolean
   coldRestoreStartup: ColdRestoreAgentResumeStartup | null | undefined

--- a/src/renderer/src/components/terminal-pane/pty-connection/reattach-payload-context.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/reattach-payload-context.ts
@@ -12,7 +12,7 @@ export type ReattachPayloadContext = {
   /** SSH reconnect remount that may paint from main's model under sshReconnectPaintsFromModel. */
   reconnectMayUseModel: boolean
   fetchSshMainModelReattachSnapshot: () => Promise<PtyBufferSnapshot | null>
-  hasStructuralReplay: boolean
+  shouldApplyStructuralPayload: boolean
   coldRestoreStartup: ColdRestoreAgentResumeStartup | null | undefined
   reattachPayloadApplied: boolean
 }

--- a/src/renderer/src/components/terminal-pane/pty-connection/reattach-payload-ssh-reconnect-model-paint.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/reattach-payload-ssh-reconnect-model-paint.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createPane } from '../pty-connection-test-pane-fixtures'
+import {
+  installTerminalTestGlobals,
+  restoreTerminalTestGlobals
+} from '../pty-connection-test-environment'
+import { createReattachPayloadHandlers } from './apply-reattach-payload'
+import type { PtyBufferSnapshot } from '../pty-transport'
+import type { ReattachPayloadContext } from './reattach-payload-context'
+import type { ReattachPayloadSession } from './reattach-payload-session'
+
+const ALT_ON = '\x1b[?1049h'
+const ALT_OFF = '\x1b[?1049l'
+const MODEL_MARKER = 'MODEL-FULL-SCREEN-FRAME'
+const PARK_MARKER = 'PARK-PREFETCHED-FRAME'
+// Shaped like the real fragment: a ~100KiB relay tail begins mid-escape, so its
+// head prints as literal text instead of rebuilding the frame it no longer holds.
+const RELAY_TAIL = '30;1Hupd-0003312'
+
+/** One log for every ordering-relevant call, so fire order is asserted on real sequence. */
+type FireLog = string[]
+
+function createModelSnapshot(overrides: Partial<PtyBufferSnapshot> = {}): PtyBufferSnapshot {
+  return {
+    source: 'headless',
+    alternateScreen: true,
+    data: MODEL_MARKER,
+    cols: 120,
+    rows: 40,
+    seq: 42,
+    ...overrides
+  }
+}
+
+function createSession(
+  fireLog: FireLog,
+  overrides: Record<string, unknown> = {}
+): ReattachPayloadSession {
+  return {
+    pane: createPane(1),
+    rememberReattachPayloadAgentSignal: vi.fn(),
+    writeReplayData: vi.fn((data: string) => fireLog.push(`write:${data}`)),
+    reattachReplayResetSequence: vi.fn(() => '<reset>'),
+    sendFocusedReattachFocusInAfterReplay: vi.fn(),
+    applySnapshotKittyKeyboardModes: vi.fn(() => fireLog.push('kitty:snapshot-baseline')),
+    setRestoredSnapshotBaseline: vi.fn(),
+    recordRendererOrderedSeq: vi.fn(),
+    isPaneOnAlternateScreen: vi.fn(() => false),
+    shouldPreserveAgentReattachModes: vi.fn(() => false),
+    kittyKeyboardModes: {
+      hasProvenBaseline: true,
+      isAlternateScreen: false,
+      reset: vi.fn(),
+      resetForSnapshot: vi.fn(() => fireLog.push('kitty:reset-for-snapshot')),
+      scanReplay: vi.fn(() => fireLog.push('kitty:scan-replay'))
+    },
+    ...overrides
+  } as unknown as ReattachPayloadSession
+}
+
+function createContext(overrides: Partial<ReattachPayloadContext>): ReattachPayloadContext {
+  return {
+    isCurrentReattachPayload: () => true,
+    connectResult: { id: 'pty-1', replay: RELAY_TAIL },
+    ptyId: 'ssh:conn-1:pty-1',
+    attemptGeneration: 1,
+    prefetchedParkModelSnapshot: null,
+    revealFollowsTerminalPark: false,
+    reconnectMayUseModel: false,
+    fetchSshMainModelReattachSnapshot: async () => null,
+    hasStructuralReplay: true,
+    coldRestoreStartup: undefined,
+    reattachPayloadApplied: false,
+    ...overrides
+  }
+}
+
+function paintedBytes(fireLog: FireLog): string {
+  return fireLog
+    .filter((entry) => entry.startsWith('write:'))
+    .map((entry) => entry.slice('write:'.length))
+    .join('')
+}
+
+// Regression guard for STA-5395: #15166 unhooked this gate while the pure-function
+// test over sshReconnectPaintsFromModel stayed green, so the coverage has to run
+// through createReattachPayloadHandlers rather than the gate itself.
+describe('reattach payload SSH reconnect model paint', () => {
+  beforeEach(() => installTerminalTestGlobals())
+
+  afterEach(async () => restoreTerminalTestGlobals())
+
+  it('paints a non-park SSH reconnect from main model and layers the replay over the kitty baseline', async () => {
+    const fireLog: FireLog = []
+    const session = createSession(fireLog)
+    const probe = vi.fn(async () => createModelSnapshot())
+    const ctx = createContext({
+      reconnectMayUseModel: true,
+      fetchSshMainModelReattachSnapshot: probe
+    })
+
+    await createReattachPayloadHandlers(session, ctx).applyReattachPayload()
+
+    // Soft so an unhooked gate reports every invariant it broke, not just the probe.
+    expect.soft(probe).toHaveBeenCalledTimes(1)
+    const painted = paintedBytes(fireLog)
+    expect.soft(painted).toContain(MODEL_MARKER)
+    // The tail is exactly what the model replaces; painting both would duplicate output.
+    expect.soft(painted).not.toContain(RELAY_TAIL)
+    // Kitty pushes made during the outage exist only in the replay, so the replay
+    // scan layers ON TOP of the snapshot baseline — inverted, the baseline wins.
+    expect.soft(session.kittyKeyboardModes.scanReplay).toHaveBeenCalledWith(RELAY_TAIL)
+    expect.soft(fireLog).toContain('kitty:snapshot-baseline')
+    expect
+      .soft(fireLog.indexOf('kitty:scan-replay'))
+      .toBeGreaterThan(fireLog.indexOf('kitty:snapshot-baseline'))
+  })
+
+  it('never spends the probe timeout when the replay shows the app left the alternate screen', async () => {
+    const fireLog: FireLog = []
+    const session = createSession(fireLog)
+    const probe = vi.fn(async () => createModelSnapshot())
+    const exitedReplay = `${ALT_ON}stale frame${ALT_OFF}$ echo done\r\ndone\r\n$ `
+    const ctx = createContext({
+      connectResult: { id: 'pty-1', replay: exitedReplay },
+      reconnectMayUseModel: true,
+      fetchSshMainModelReattachSnapshot: probe
+    })
+
+    await createReattachPayloadHandlers(session, ctx).applyReattachPayload()
+
+    // The veto is decided before the fetch: probing first would burn
+    // SSH_REATTACH_MODEL_SNAPSHOT_TIMEOUT_MS inside the coordinator only to discard it.
+    expect(probe).not.toHaveBeenCalled()
+    const painted = paintedBytes(fireLog)
+    expect(painted).toContain(exitedReplay)
+    expect(painted).not.toContain(MODEL_MARKER)
+  })
+
+  it('keeps park precedence over the reconnect snapshot', async () => {
+    const fireLog: FireLog = []
+    const session = createSession(fireLog)
+    const probe = vi.fn(async () => createModelSnapshot())
+    // Both flags set deliberately: the handler must resolve the precedence itself
+    // rather than relying on the caller keeping park and reconnect disjoint.
+    const ctx = createContext({
+      revealFollowsTerminalPark: true,
+      reconnectMayUseModel: true,
+      prefetchedParkModelSnapshot: createModelSnapshot({ data: PARK_MARKER }),
+      fetchSshMainModelReattachSnapshot: probe
+    })
+
+    await createReattachPayloadHandlers(session, ctx).applyReattachPayload()
+
+    expect(probe).not.toHaveBeenCalled()
+    const painted = paintedBytes(fireLog)
+    expect(painted).toContain(PARK_MARKER)
+    expect(painted).not.toContain(MODEL_MARKER)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-connection/reattach-payload-ssh-reconnect-model-paint.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/reattach-payload-ssh-reconnect-model-paint.test.ts
@@ -68,7 +68,7 @@ function createContext(overrides: Partial<ReattachPayloadContext>): ReattachPayl
     revealFollowsTerminalPark: false,
     reconnectMayUseModel: false,
     fetchSshMainModelReattachSnapshot: async () => null,
-    hasStructuralReplay: true,
+    shouldApplyStructuralPayload: true,
     coldRestoreStartup: undefined,
     reattachPayloadApplied: false,
     ...overrides
@@ -110,10 +110,29 @@ describe('reattach payload SSH reconnect model paint', () => {
     // Kitty pushes made during the outage exist only in the replay, so the replay
     // scan layers ON TOP of the snapshot baseline — inverted, the baseline wins.
     expect.soft(session.kittyKeyboardModes.scanReplay).toHaveBeenCalledWith(RELAY_TAIL)
+    expect.soft(session.pane.fitAddon.proposeDimensions).toHaveBeenCalledTimes(2)
     expect.soft(fireLog).toContain('kitty:snapshot-baseline')
     expect
       .soft(fireLog.indexOf('kitty:scan-replay'))
       .toBeGreaterThan(fireLog.indexOf('kitty:snapshot-baseline'))
+  })
+
+  it('paints the model when a reconnect has no relay tail', async () => {
+    const fireLog: FireLog = []
+    const session = createSession(fireLog)
+    const probe = vi.fn(async () => createModelSnapshot())
+    const ctx = createContext({
+      connectResult: { id: 'pty-1', isReattach: true, replay: '' },
+      reconnectMayUseModel: true,
+      fetchSshMainModelReattachSnapshot: probe
+    })
+
+    await createReattachPayloadHandlers(session, ctx).applyReattachPayload()
+
+    expect(probe).toHaveBeenCalledTimes(1)
+    expect(paintedBytes(fireLog)).toContain(MODEL_MARKER)
+    expect(session.pane.fitAddon.proposeDimensions).toHaveBeenCalledTimes(2)
+    expect(ctx.reattachPayloadApplied).toBe(true)
   })
 
   it('never spends the probe timeout when the replay shows the app left the alternate screen', async () => {
@@ -132,6 +151,7 @@ describe('reattach payload SSH reconnect model paint', () => {
     // The veto is decided before the fetch: probing first would burn
     // SSH_REATTACH_MODEL_SNAPSHOT_TIMEOUT_MS inside the coordinator only to discard it.
     expect(probe).not.toHaveBeenCalled()
+    expect(session.pane.fitAddon.proposeDimensions).not.toHaveBeenCalled()
     const painted = paintedBytes(fireLog)
     expect(painted).toContain(exitedReplay)
     expect(painted).not.toContain(MODEL_MARKER)
@@ -153,6 +173,8 @@ describe('reattach payload SSH reconnect model paint', () => {
     await createReattachPayloadHandlers(session, ctx).applyReattachPayload()
 
     expect(probe).not.toHaveBeenCalled()
+    // Park painting measures for its own width checks, but must not pay a third reconnect check.
+    expect(session.pane.fitAddon.proposeDimensions).toHaveBeenCalledTimes(2)
     const painted = paintedBytes(fireLog)
     expect(painted).toContain(PARK_MARKER)
     expect(painted).not.toContain(MODEL_MARKER)

--- a/src/renderer/src/components/terminal-pane/pty-connection/reattach-result-handler.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/reattach-result-handler.ts
@@ -32,6 +32,7 @@ type ReattachResultSession = ReattachPayloadSession &
     | 'disposed'
     | 'getSshMainModelSnapshotProbe'
     | 'handleReattachResult'
+    | 'followsDirectSshReconnect'
     | 'mountFollowsTerminalPark'
     | 'registerEffectiveLaunchConfig'
     | 'registerPaneSerializerFor'
@@ -206,6 +207,17 @@ export function bindHandleReattachResult(sessionBag: ConnectPanePtySession): voi
       session.mountFollowsTerminalPark &&
       (connectResult?.isReattach === true || isRemoteRuntimePtyId(ptyId))
     session.mountFollowsTerminalPark = false
+    // An SSH reconnect remounts the pane (tab.generation is its React key), so it also paints into
+    // a fresh xterm — but unlike a park it may only use the model for a FULL-SCREEN app. See
+    // sshReconnectPaintsFromModel for why.
+    //
+    // NOT consume-once, unlike mountFollowsTerminalPark: followsDirectSshReconnect is captured per
+    // connectPanePty and never cleared, so this re-arms if one connect reaches handleReattachResult
+    // twice. Bounded by connectStarted and by the emptiness/alt-screen gates rather than by the
+    // read itself. It still reads the PENDING retry rather than directSshRetryAttempt, which also
+    // accepts the live binding and so stays truthy for every later remount of the generation.
+    const reconnectMayUseModel =
+      Boolean(session.followsDirectSshReconnect) && !revealFollowsTerminalPark
     // Why: ordinary parking destroys xterm. Rebuild from the authoritative
     // host snapshot before releasing queued live bytes; null falls back to
     // the subscribe screen without keeping the old xterm mounted.
@@ -236,6 +248,7 @@ export function bindHandleReattachResult(sessionBag: ConnectPanePtySession): voi
       attemptGeneration,
       prefetchedParkModelSnapshot,
       revealFollowsTerminalPark,
+      reconnectMayUseModel,
       fetchSshMainModelReattachSnapshot,
       hasStructuralReplay,
       coldRestoreStartup,

--- a/src/renderer/src/components/terminal-pane/pty-connection/reattach-result-handler.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/reattach-result-handler.ts
@@ -241,6 +241,10 @@ export function bindHandleReattachResult(sessionBag: ConnectPanePtySession): voi
         return false
       }
     }
+    // A reconnect with no relay tail can still restore main's model. Keep that probe and paint in
+    // the structural transaction so live output cannot overtake the snapshot.
+    const shouldApplyStructuralPayload =
+      hasStructuralReplay || prefetchedParkModelSnapshot !== null || reconnectMayUseModel
     const reattachPayload: ReattachPayloadContext = {
       isCurrentReattachPayload,
       connectResult,
@@ -250,15 +254,15 @@ export function bindHandleReattachResult(sessionBag: ConnectPanePtySession): voi
       revealFollowsTerminalPark,
       reconnectMayUseModel,
       fetchSshMainModelReattachSnapshot,
-      hasStructuralReplay,
+      shouldApplyStructuralPayload,
       coldRestoreStartup,
-      reattachPayloadApplied: !hasStructuralReplay && prefetchedParkModelSnapshot === null
+      reattachPayloadApplied: !shouldApplyStructuralPayload
     }
     const { applyReattachPayload, fitAfterReattachRestore } = createReattachPayloadHandlers(
       session,
       reattachPayload
     )
-    if (hasStructuralReplay || prefetchedParkModelSnapshot) {
+    if (shouldApplyStructuralPayload) {
       await session.structuralReplayCoordinator.run(applyReattachPayload, {
         shouldRestore: isCurrentReattachPayload,
         afterRestore: fitAfterReattachRestore

--- a/src/renderer/src/components/terminal-pane/pty-connection/resolve-ssh-reconnect-model-paint.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/resolve-ssh-reconnect-model-paint.ts
@@ -1,0 +1,43 @@
+import {
+  lastAlternateScreenTransition,
+  sshReconnectPaintsFromModel
+} from '../ssh-reattach-model-restore'
+import { shouldSkipAltFrameForWidthMismatch } from '../terminal-snapshot-replay-paint'
+
+import type { PtyBufferSnapshot } from '../pty-transport'
+
+type SshReconnectModelPaint = {
+  altFrameWouldBeSkipped: boolean
+  paintsFromModel: boolean
+  snapshot: PtyBufferSnapshot | null
+}
+
+export async function resolveSshReconnectModelPaint(args: {
+  reconnectMayUseModel: boolean
+  replay: string | undefined
+  fetchSnapshot: () => Promise<PtyBufferSnapshot | null>
+  readTargetCols: () => number | undefined
+}): Promise<SshReconnectModelPaint> {
+  if (!args.reconnectMayUseModel) {
+    return { altFrameWouldBeSkipped: false, paintsFromModel: false, snapshot: null }
+  }
+  // Decide before the probe: an exit makes the snapshot unusable, so waiting only delays replay.
+  const replayTransition = lastAlternateScreenTransition(args.replay)
+  if (replayTransition === 'exited') {
+    return { altFrameWouldBeSkipped: false, paintsFromModel: false, snapshot: null }
+  }
+  const snapshot = await args.fetchSnapshot()
+  const altFrameWouldBeSkipped = snapshot
+    ? shouldSkipAltFrameForWidthMismatch(snapshot.cols, args.readTargetCols())
+    : false
+  return {
+    altFrameWouldBeSkipped,
+    paintsFromModel: sshReconnectPaintsFromModel({
+      snapshot,
+      hasReplay: Boolean(args.replay),
+      replayTransition,
+      altFrameWouldBeSkipped
+    }),
+    snapshot
+  }
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​217 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​213 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​109 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​98 |

<!-- /orca-pr-loc -->

## What broke

[#15166](https://github.com/stablyai/orca/pull/15166) split `pty-connection.ts` into modules and dropped the **"paint from main's model on SSH reconnect"** half of the reattach gate. Only the park-reveal half survived:

```js
// pty-connection/apply-reattach-payload.ts:113 on main
const modelSnapshot = ctx.revealFollowsTerminalPark ? (ctx.prefetchedParkModelSnapshot ?? …) : null
```

So on a plain SSH reconnect — network drop, wake, reload — that is **not** a park-reveal, `modelSnapshot` is unconditionally `null` and the pane repaints from the relay replay tail alone. That tail is capped at `REPLAY_BUFFER_MAX = 100*1024` (`src/relay/pty-handler.ts`) and cannot rebuild a full-screen frame whose start it no longer holds.

This regressed **v1.4.188**'s [#14844](https://github.com/stablyai/orca/pull/14844) (`feat(ssh): verify host keys, and restore panes correctly across a reconnect`) — the exact fragmentation that PR fixed. Gate-identifier occurrences: `v1.4.188` **26** → `origin/main` **21**. `sshReconnectPaintsFromModel` and `lastAlternateScreenTransition` survived in `ssh-reattach-model-restore.ts` with **zero production callers**.

`git log -S` on both identifiers returns exactly two commits — `24e662adc1` (#14844, added) and `7a72f341f7` (#15166, removed the callers). Nothing since; there was no fix anywhere to cherry-pick.

## Live A/B evidence

Docker `node:20-bullseye` + sshd, real repo, relay built and deployed by Orca, SSH target connected from inside the app. In the SSH pane: enter alt screen, paint a full-screen frame once, then emit ~171 KB of cursor-addressed updates with no repaint — sized against the 100 KiB relay cap so the frame start is evicted. Then a real network drop (`docker network disconnect`), wait `reconnecting` → `connected`, read the xterm buffer.

| Arm | Result after reconnect |
|---|---|
| **`main` (gate-less)** | `bufType:"normal"` — not even alt screen. Row 0 is literal garbage `30;1Hupd-0003312` (tail begins mid-escape and prints as text). Frame marker **gone**, both static rows **gone** |
| **Same commit + this restore** | `bufType:"alternate"`, frame marker intact, `STATIC-ROW-3`, `STATIC-ROW-45`, full frame **restored** |

Decisive detail: a pre-drop probe of `window.api.pty.getMainBufferSnapshot` returned `{source:'headless', alternateScreen:true, holdsMarker:true}` — **main's model held the good payload at reconnect time and the code discarded it.**

## What this restores

1. `followsDirectSshReconnect` — a **PENDING-only** read of `directSshPaneRetryByTabId[tabId]`. Deliberately not `directSshRetryAttempt`, which also accepts the live binding and so stays truthy for every later remount of the generation.
2. `reconnectMayUseModel = followsDirectSshReconnect && !revealFollowsTerminalPark` — keeps park and reconnect mutually exclusive.
3. The `replayTransition === 'exited'` veto, computed **before** the probe. Ordering is load-bearing: probing first spends the 750 ms `SSH_REATTACH_MODEL_SNAPSHOT_TIMEOUT_MS` inside the structural-replay coordinator, with live PTY bytes deferred, only to discard the answer.
4. Fetch through `ctx.fetchSshMainModelReattachSnapshot` — the same memoized single-flight probe the park path uses, so no second timeout.
5. `sshReconnectPaintsFromModel({snapshot, hasReplay, replayTransition, altFrameWouldBeSkipped})`.
6. `modelSnapshot = revealSnapshot ?? (paintsReconnectFromModel ? reconnectSnapshot : null)` — park precedence preserved.
7. `kittyKeyboardModes.scanReplay(replay)` placed **after** `applySnapshotKittyKeyboardModes`. Note this is not a bug on main today — the degraded relay path does its own `resetForSnapshot()` + `scanReplay()`. But any fix that restores model painting **must** re-add the layered scan, or the fix itself introduces a stale-flag-stack bug: the snapshot sets the pre-outage baseline and the replay layers the outage's kitty pushes on top. Omitted, Option/Alt chords encode against stale flags; inverted, the baseline clobbers the outage pushes.

The original `Why:` comments from `617f7c8de3` are transplanted verbatim — including the second paragraph of the model-snapshot comment that #15166 deleted, which is the only signal a future reader has that the reconnect case exists at all.

`apply-reattach-payload.ts` lands at 356 lines, under the split's 400 budget. No `max-lines` suppression added.

## The test — and why the old one could not catch this

The only prior coverage was `ssh-reconnect-model-paint-gate.test.ts`, which calls the pure function **directly**. It stayed green through the entire removal, validating a gate nothing consulted. The full suite was green on a tree carrying this bug.

This PR adds `pty-connection/reattach-payload-ssh-reconnect-model-paint.test.ts`, a **call-site** test over `createReattachPayloadHandlers`:

- **(a)** non-park SSH reconnect ctx, replay with no 1049 transition ⇒ probe called, model bytes painted, relay tail **not** painted, and `scanReplay` fires **after** the snapshot kitty baseline.
- **(b)** replay containing `\x1b[?1049l` ⇒ probe **never issued** (proves the veto precedes the fetch), relay bytes painted.
- **(c)** park + reconnect both armed ⇒ prefetched park snapshot wins, probe never issued.

### RED — case (a) on unfixed `main`

4 production files reverted to `origin/main` @ `2960fe9193`, test files kept. Assertions are `expect.soft` so an unhooked gate reports every invariant it broke:

```
 ❯ .../reattach-payload-ssh-reconnect-model-paint.test.ts (3 tests | 1 failed)
   × paints a non-park SSH reconnect from main model and layers the replay over the kitty baseline

AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times

AssertionError: expected '…' to contain 'MODEL-FULL-SCREEN-FRAME'
  Expected: "MODEL-FULL-SCREEN-FRAME"
  Received: "[0m[2J[3J[H30;1Hupd-0003312<reset>"

AssertionError: expected '…' not to contain '30;1Hupd-0003312'
  Expected: "30;1Hupd-0003312"
  Received: "[0m[2J[3J[H30;1Hupd-0003312<reset>"

AssertionError: expected [ …(4) ] to include 'kitty:snapshot-baseline'

 Test Files  1 failed (1)
      Tests  1 failed | 2 passed (3)
```

The `Received` value is the bug verbatim: the pane paints `30;1Hupd-0003312`, the same garbled mid-escape tail the live A/B captured in row 0.

### GREEN — with the fix

```
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

## One existing test changed — please read this bit

`pty-connection-direct-ssh-reattach-retry.test.ts` had a case named *"uses the SSH relay replay for a reconnect even when main has an alt-screen model"*. `git log -S` shows it was **added by #15166 itself** (`7a72f341f7`), in the same PR that removed the gate — its commit log reads *"Simplify reconnect model restoration by removing the conditional model snapshot probe and using relay replay directly."* No pre-split counterpart existed. It pins the regressed behavior, so it blocks the restore.

Its fixture is a reconnect whose replay is `'9l\r\n$ real-shell-output'` — a tail whose `\x1b[?1049l` lost its ESC to byte eviction. `lastAlternateScreenTransition` cannot read a transition there (documented in its own comment: *"A tail can begin mid-escape, so the first chunk is ordinary text and simply fails to match"*), so under #14844's shipped contract the model wins.

I rewrote it into **two** cases against a shared fixture rather than deleting it:

- `paints a reconnect from the alt-screen model when the replay shows no alt-screen exit` — the original fixture, expectation flipped to v1.4.188's contract. **This one is also RED on main** (`expected "vi.fn()" to be called at least once`).
- `uses the SSH relay replay for a reconnect once the replay shows the app left alt screen` — same fixture with a readable `\x1b[?1049l`. Pins that the relay still wins and the probe is never issued.

Net that file goes 7 → 8 tests, all passing.

**Known limitation, pre-existing in v1.4.188, not addressed here:** in that first fixture the shell really did leave alt screen, and painting the model discards `real-shell-output`. The gate cannot see it because the ESC was evicted. Closing that hole means new heuristics #14844 never had, which is outside a restore — flagging it rather than smuggling it in.

## Verification

- `oxfmt` clean; `oxlint` clean.
- `check:code-quality:changed`: 0 new findings (code quality, type-aware, React Doctor) across 7 changed files.
- `check:max-lines-ratchet`: OK, no new bypasses.
- Full `src/renderer/src/components/terminal-pane/` suite: **392 files / 3780 tests passed**.

Fixes STA-5395
