### PR TITLE
fix(daemon): let PTY inventory recover from a dead terminal host

### DIFF
--- a/src/main/daemon/daemon-pty-adapter-inventory-respawn.test.ts
+++ b/src/main/daemon/daemon-pty-adapter-inventory-respawn.test.ts
@@ -1,0 +1,76 @@
+/* Inventory after the terminal host dies: worktree removal must not hard-fail. */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DaemonPtyAdapter } from './daemon-pty-adapter'
+import { DaemonServer } from './daemon-server'
+import { createMockSubprocess, startDaemonAdapterHarness } from './daemon-pty-adapter-test-harness'
+
+describe('inventory after the terminal host dies (#10087)', () => {
+  let harness: Awaited<ReturnType<typeof startDaemonAdapterHarness>>
+  let respawnServer: DaemonServer | undefined
+
+  beforeEach(async () => {
+    harness = await startDaemonAdapterHarness(() => createMockSubprocess())
+  })
+  afterEach(async () => {
+    harness.adapter.dispose()
+    await respawnServer?.shutdown()
+    await harness.server.shutdown().catch(() => {})
+    respawnServer = undefined
+  })
+
+  /** An adapter that can bring the host back, as production does. */
+  const healingAdapter = (): { adapter: DaemonPtyAdapter; respawn: ReturnType<typeof vi.fn> } => {
+    const respawn = vi.fn(async () => {
+      respawnServer = new DaemonServer({
+        socketPath: harness.socketPath,
+        tokenPath: harness.tokenPath,
+        spawnSubprocess: () => createMockSubprocess()
+      })
+      await respawnServer.start()
+    })
+    return {
+      adapter: new DaemonPtyAdapter({
+        socketPath: harness.socketPath,
+        tokenPath: harness.tokenPath,
+        respawn
+      }),
+      respawn
+    }
+  }
+
+  it('lists processes after the host dies instead of failing the removal', async () => {
+    // The reported failure: worktree remove inventories PTYs through
+    // listProcesses, and a dead named pipe surfaced as
+    // `connect ENOENT \\?\pipe\orca-terminal-host-...`, blocking removal until
+    // the whole app was restarted. spawn already recovers from this; inventory
+    // did not, so the destructive path was the one that could not heal.
+    const { adapter, respawn } = healingAdapter()
+    try {
+      await adapter.spawn({ cols: 80, rows: 24 })
+      await harness.server.shutdown()
+
+      const processes = await adapter.listProcesses()
+
+      expect(Array.isArray(processes)).toBe(true)
+      expect(respawn).toHaveBeenCalled()
+    } finally {
+      adapter.dispose()
+    }
+  })
+
+  it('still recovers on spawn, the path that already worked', async () => {
+    // Control: proves the harness really kills the host, so the test above is
+    // not passing because nothing broke.
+    const { adapter, respawn } = healingAdapter()
+    try {
+      await adapter.spawn({ cols: 80, rows: 24 })
+      await harness.server.shutdown()
+
+      await adapter.spawn({ cols: 80, rows: 24 })
+
+      expect(respawn).toHaveBeenCalled()
+    } finally {
+      adapter.dispose()
+    }
+  })
+})

--- a/src/main/daemon/daemon-pty-session-inventory.ts
+++ b/src/main/daemon/daemon-pty-session-inventory.ts
@@ -21,14 +21,27 @@ export abstract class DaemonPtySessionInventory extends DaemonPtyProcessInspecti
     // be reconciled away below.
     const preRequestActiveIds = new Set(this.activeSessionIds)
     try {
+      // Why retry: this inventory is what destructive teardown consults, and a
+      // dead host pipe surfaced as `connect ENOENT \\?\\pipe\\orca-terminal-host-...`
+      // that failed worktree removal until the app was restarted (#10087). Spawn
+      // already recovered from exactly this; inventory did not, so the one path
+      // that must not get stuck was the only one that could not heal.
+      //
+      // Why the request is inside too: a host that dies between connect and
+      // listSessions throws the same daemon-gone error, so retrying only the
+      // connect would still fail. The reconciliation below stays outside --
+      // retrying that would double-apply it.
+      //
       // Why: connect + listSessions share the caller's one absolute deadline so a
       // wedged handshake cannot burn the whole teardown budget before the list issues.
-      await this.ensureConnected(opts?.deadlineMs)
-      const result = await this.client.request<ListSessionsResult>(
-        'listSessions',
-        undefined,
-        remainingDaemonRequestTimeoutMs(opts?.deadlineMs)
-      )
+      const result = await this.withDaemonRetry(async () => {
+        await this.ensureConnected(opts?.deadlineMs)
+        return this.client.request<ListSessionsResult>(
+          'listSessions',
+          undefined,
+          remainingDaemonRequestTimeoutMs(opts?.deadlineMs)
+        )
+      })
       const admission = new PtyProcessListAdmission()
       const processes: PtyProcessInfo[] = []
       const aliveSessionIds = new Set<string>()


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​76 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​76 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 |

<!-- /orca-pr-loc -->

Fixes #10087. Independently reproduced and fixed; @innocarpe reached the same diagnosis first in #10350 and is credited as co-author.

## ELI5

Removing a worktree asks the terminal host "what PTYs are still running?" so it can shut them down before deleting files.

If that host process has died — which it does, after normal terminal and agent use — the question fails with:

```
connect ENOENT \\?\pipe\orca-terminal-host-v24-b51f469ab4fe
```

and the removal stops there. The worktree cannot be deleted at all. The only workaround reported was: quit Orca, force-kill every Orca process, relaunch, and delete *before* opening a terminal.

The adapter already knew how to handle this — `spawn` wraps its work in `withDaemonRetry`, which respawns a dead host and retries. **Inventory did not.** So the one operation that must not get stuck was the only one that could not heal itself.

## Reproduced before fixing

A real daemon, killed mid-test:

| | before |
|---|---|
| `listProcesses()` after host death | **throws `DaemonConnectionLostError`** |
| `spawn()` after the identical kill | recovers |

Both are now regression tests. The second is a control: it proves the harness genuinely kills the host, so the first test is not passing because nothing broke.

## The fix

`listProcesses` wraps connect + `listSessions` in `withDaemonRetry`.

Both go inside, deliberately: a host that dies *between* them throws the same daemon-gone error, so retrying only the connect would still fail. The reconciliation after the request stays outside — retrying that would double-apply it.

## Proof of no regression

- Full `src/main/daemon` suite: **1,579 passed**, 3 skipped.
- Lint and typecheck exit 0.
- The retry helper is unchanged; this only puts an existing, proven mechanism on a path that was missing it.

## User-facing trade-offs

**None.** The failing case previously threw and blocked removal; it now respawns once and returns an inventory. A healthy host takes the same path it always did — `withDaemonRetry` only does anything on a daemon-gone error.

## Relationship to #10350

@innocarpe identified the same root cause and the same asymmetry. I reproduced it independently before writing anything, which turned up two details worth keeping:

- The request must be inside the retry alongside the connect, not just the connect.
- The reconciliation must stay outside it.

Deliberately **not** included, matching that PR's own scope note: the Resource Manager kill button (separate surface) and OS-level orphaned children after host death (#10004 / #9045).
