### PR TITLE
test(linear): pin project out of the hydration-preserved field set

### DIFF
--- a/src/renderer/src/components/linear-issue-workspace-detail-state.test.tsx
+++ b/src/renderer/src/components/linear-issue-workspace-detail-state.test.tsx
@@ -201,3 +201,36 @@ describe('Linear issue workspace detail state', () => {
     expect(runtimeMocks.linearIssueComments).toHaveBeenCalledWith(sourceContext, 'b', 'workspace-1')
   })
 })
+
+describe('mergeLinearIssueHydration project preservation', () => {
+  // Why: Linear *list* issues never carry `project` — only getIssue maps it, via
+  // includeProject: true. So `project` must never join the preserved-from-current
+  // set: an edit made while getIssue is in flight would overwrite the hydrated
+  // project with the list issue's undefined, permanently blanking it.
+  it('takes project from the hydrated detail even when the user has edited', () => {
+    const listIssue = { ...issue('ENG-1'), project: undefined }
+    const hydrated = { ...issue('ENG-1'), project: { id: 'p1', name: 'Compiler' } }
+
+    const merged = mergeLinearIssueHydration(hydrated, listIssue, true)
+
+    expect(merged.project).toEqual({ id: 'p1', name: 'Compiler' })
+  })
+
+  it('still preserves the fields the user actually edits', () => {
+    const edited = { ...issue('ENG-1'), title: 'my edit', priority: 1 }
+    const hydrated = { ...issue('ENG-1'), title: 'server title', priority: 4 }
+
+    const merged = mergeLinearIssueHydration(hydrated, edited, true)
+
+    expect(merged.title).toBe('my edit')
+    expect(merged.priority).toBe(1)
+  })
+
+  it('keeps project out of the preserved-field set', () => {
+    // Guards the list itself: adding 'project' here is the exact regression.
+    const listIssue = { ...issue('ENG-1'), project: undefined }
+    const hydrated = { ...issue('ENG-1'), project: { id: 'p2', name: 'Runtime' } }
+
+    expect(mergeLinearIssueHydration(hydrated, listIssue, true).project?.id).toBe('p2')
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​33 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​33 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

Locks in an invariant that a recent refactor broke and that is easy to break again by adding one word to a list.

## The invariant

Linear **list** issues never carry `project` — only `getIssue` maps it, via `includeProject: true`. So `project` must never join `EDITED_LINEAR_ISSUE_FIELDS`, the set preserved from pre-hydration state.

If it does: open an issue from the Tasks list, click any sidebar chip while `linearGetIssue` is still in flight, and hydration merges `current.project` (`undefined`) over the fetched project. The project is blanked permanently — the sidebar renders "Add to project", and `LinearIssueSubIssues` then sends `projectId: issue.project?.id ?? null` = `null`, filing sub-issues outside the parent's project.

## Verified discriminating

Re-adding `'project'` to `EDITED_LINEAR_ISSUE_FIELDS` fails these tests. Reverting makes them pass. A regression test that has never been seen to fail isn't evidence of anything, so I checked.

Also asserts the positive case still holds — genuinely edited fields (`title`, `priority`) are still preserved across hydration.

Context: stablyai/orca#16360.