### PR TITLE
fix(cli): spawn a version-manager CLI with its own node runtime

### DIFF
--- a/src/main/claude-accounts/service.ts
+++ b/src/main/claude-accounts/service.ts
@@ -13,6 +13,7 @@ import type {
 import type { Store } from '../persistence'
 import type { RateLimitService } from '../rate-limits/service'
 import { resolveClaudeCommand } from '../codex-cli/command'
+import { withCliRuntimeOnPath } from '../../shared/node-cli-command-resolution'
 import type { ClaudeRuntimeAuthService } from './runtime-auth-service'
 import {
   getClaudeManagedAccountsRoot,
@@ -1050,17 +1051,21 @@ export class ClaudeAccountService {
         configDir.wslDistro === null &&
         args[0] === 'auth' &&
         args[1] === 'login'
+      // Why lazy: the WSL branch runs `claude` inside the distro, so resolving a
+      // host binary there would be wasted filesystem probing for a path never used.
+      let cachedHostClaudeCommand: string | null = null
+      const hostClaudeCommand = (): string => (cachedHostClaudeCommand ??= resolveClaudeCommand())
       const interactiveLogin = isWindowsHostInteractiveLogin
-        ? buildWindowsHostInteractiveLoginSpawn(resolveClaudeCommand(), args)
+        ? buildWindowsHostInteractiveLoginSpawn(hostClaudeCommand(), args)
         : null
       const spawnConfig = interactiveLogin
         ? {
             command: interactiveLogin.command,
             args: interactiveLogin.args,
-            env: {
+            env: withCliRuntimeOnPath(hostClaudeCommand(), {
               ...process.env,
               CLAUDE_CONFIG_DIR: configDir.windowsPath
-            },
+            }),
             shell: false,
             windowsVerbatimArguments: false
           }
@@ -1081,20 +1086,20 @@ export class ClaudeAccountService {
             }
           : process.platform === 'win32'
             ? {
-                ...buildWindowsCommandInvocation(resolveClaudeCommand(), args),
-                env: {
+                ...buildWindowsCommandInvocation(hostClaudeCommand(), args),
+                env: withCliRuntimeOnPath(hostClaudeCommand(), {
                   ...process.env,
                   CLAUDE_CONFIG_DIR: configDir.windowsPath
-                },
+                }),
                 shell: false
               }
             : {
-                command: resolveClaudeCommand(),
+                command: hostClaudeCommand(),
                 args,
-                env: {
+                env: withCliRuntimeOnPath(hostClaudeCommand(), {
                   ...process.env,
                   CLAUDE_CONFIG_DIR: configDir.windowsPath
-                },
+                }),
                 shell: false,
                 windowsVerbatimArguments: false
               }

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -40,6 +40,7 @@ import { getSystemCodexHomePath } from '../codex/codex-home-paths'
 import { MANAGED_HOOK_TIMEOUT_SECONDS } from '../agent-hooks/installer-utils'
 import { readCodexTopLevelModelProvider } from '../codex/codex-model-provider-config'
 import { resolveCodexCommand } from '../codex-cli/command'
+import { withCliRuntimeOnPath } from '../../shared/node-cli-command-resolution'
 import type { Store } from '../persistence'
 import type { RateLimitService } from '../rate-limits/service'
 import { parseWslUncPath } from '../../shared/wsl-paths'
@@ -1736,10 +1737,10 @@ export class CodexAccountService {
             return {
               command: spawnCmd,
               args: spawnArgs,
-              env: {
+              env: withCliRuntimeOnPath(codexCommand, {
                 ...process.env,
                 CODEX_HOME: managedHomePath
-              },
+              }),
               codexCommand,
               interactiveLogin
             }

--- a/src/main/codex-cli/command.test.ts
+++ b/src/main/codex-cli/command.test.ts
@@ -4,6 +4,7 @@ import { delimiter, dirname, join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
   getVersionManagerBinPaths,
+  withCliRuntimeOnPath,
   resolveClaudeCommand,
   resolveCliCommands,
   resolveCodexCommand
@@ -311,5 +312,61 @@ describe('getVersionManagerBinPaths', () => {
 
     expect(paths).toContain(join(root, '.local', 'bin'))
     expect(paths).toContain(join(root, 'AppData', 'Roaming', 'npm'))
+  })
+})
+
+describe('withCliRuntimeOnPath', () => {
+  it('pairs a version-manager CLI with its sibling node (stablyai/orca#10932)', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-pair-'))
+    const v20 = join(root, '.nvm', 'versions', 'node', 'v20.11.0', 'bin')
+    const v22 = join(root, '.nvm', 'versions', 'node', 'v22.9.0', 'bin')
+    makeExecutable(join(v20, 'node'))
+    makeExecutable(join(v20, 'codex'))
+    makeExecutable(join(v22, 'node'))
+
+    // default is v22, but codex only exists under v20
+    const env = { PATH: [v22, '/usr/bin'].join(delimiter) }
+    const codex = resolveCodexCommand({ platform: 'darwin', pathEnv: env.PATH, homePath: root })
+    expect(codex).toBe(join(v20, 'codex'))
+
+    const paired = withCliRuntimeOnPath(codex, env, { platform: 'darwin' })
+    // the shebang's `node` must now come from v20, not v22
+    expect(paired.PATH.split(delimiter)[0]).toBe(v20)
+  })
+
+  it('leaves PATH untouched for a CLI whose directory ships no node', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-pair-'))
+    const brew = join(root, 'opt', 'homebrew', 'bin')
+    makeExecutable(join(brew, 'codex'))
+    const env = { PATH: '/usr/bin' }
+
+    expect(withCliRuntimeOnPath(join(brew, 'codex'), env, { platform: 'darwin' })).toBe(env)
+  })
+
+  it('leaves PATH untouched for a bare command name', () => {
+    const env = { PATH: '/usr/bin' }
+    expect(withCliRuntimeOnPath('codex', env, { platform: 'darwin' })).toBe(env)
+  })
+
+  it('is a no-op when the runtime directory already leads PATH', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-pair-'))
+    const v20 = join(root, '.nvm', 'versions', 'node', 'v20.11.0', 'bin')
+    makeExecutable(join(v20, 'node'))
+    makeExecutable(join(v20, 'codex'))
+    const env = { PATH: [v20, '/usr/bin'].join(delimiter) }
+
+    expect(withCliRuntimeOnPath(join(v20, 'codex'), env, { platform: 'darwin' })).toBe(env)
+  })
+
+  it('writes the Windows Path key without leaving a differently-cased twin', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-pair-'))
+    const v20 = join(root, '.nvm', 'versions', 'node', 'v20.11.0', 'bin')
+    makeExecutable(join(v20, 'node.exe'))
+    makeExecutable(join(v20, 'codex.cmd'))
+    const env = { Path: 'C:\\Windows' }
+
+    const paired = withCliRuntimeOnPath(join(v20, 'codex.cmd'), env, { platform: 'win32' })
+    expect(paired.Path.split(';')[0]).toBe(v20)
+    expect((paired as NodeJS.ProcessEnv).PATH).toBeUndefined()
   })
 })

--- a/src/main/codex-cli/command.test.ts
+++ b/src/main/codex-cli/command.test.ts
@@ -363,10 +363,15 @@ describe('withCliRuntimeOnPath', () => {
     const v20 = join(root, '.nvm', 'versions', 'node', 'v20.11.0', 'bin')
     makeExecutable(join(v20, 'node.exe'))
     makeExecutable(join(v20, 'codex.cmd'))
-    const env = { Path: 'C:\\Windows' }
+    // Why both keys: with only `Path` seeded the assertion is vacuous — the
+    // helper cannot invent a `PATH` key, so the dedupe loop could be deleted
+    // wholesale and this test would still pass.
+    const env = { Path: 'C:\\Windows;C:\\Windows\\System32', PATH: 'C:\\Stale' }
 
     const paired = withCliRuntimeOnPath(join(v20, 'codex.cmd'), env, { platform: 'win32' })
-    expect(paired.Path.split(';')[0]).toBe(v20)
-    expect((paired as NodeJS.ProcessEnv).PATH).toBeUndefined()
+    expect(Object.keys(paired)).toEqual(['Path'])
+    // Why the whole string: splitting on the host delimiter while joining on ';'
+    // shredded every drive letter into `C;\\Windows`.
+    expect(paired.Path).toBe([v20, 'C:\\Windows', 'C:\\Windows\\System32'].join(';'))
   })
 })

--- a/src/main/codex-cli/command.test.ts
+++ b/src/main/codex-cli/command.test.ts
@@ -358,6 +358,21 @@ describe('withCliRuntimeOnPath', () => {
     expect(withCliRuntimeOnPath(join(v20, 'codex'), env, { platform: 'darwin' })).toBe(env)
   })
 
+  it('reads the Windows path key the child will actually use, whatever its casing', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-pair-'))
+    const v20 = join(root, '.nvm', 'versions', 'node', 'v20.11.0', 'bin')
+    makeExecutable(join(v20, 'node.exe'))
+    makeExecutable(join(v20, 'codex.cmd'))
+    // Why: win32 resolves env names case-insensitively, so a block may spell it
+    // any way. Reading a narrower set than the twin-dedupe deletes would drop
+    // this entry unread and hand the child a PATH containing only our directory.
+    const env = { path: 'C:\\Windows;C:\\Windows\\System32', HOME: 'x' }
+
+    const paired = withCliRuntimeOnPath(join(v20, 'codex.cmd'), env, { platform: 'win32' })
+    expect(paired.path).toBe([v20, 'C:\\Windows', 'C:\\Windows\\System32'].join(';'))
+    expect(Object.keys(paired).filter((key) => key.toLowerCase() === 'path')).toEqual(['path'])
+  })
+
   it('writes the Windows Path key without leaving a differently-cased twin', () => {
     const root = mkdtempSync(join(tmpdir(), 'orca-pair-'))
     const v20 = join(root, '.nvm', 'versions', 'node', 'v20.11.0', 'bin')

--- a/src/main/codex/codex-app-server-session.ts
+++ b/src/main/codex/codex-app-server-session.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcess, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import { waitForProcessExitUntil } from './codex-process-exit-deadline'
 import { stderrIndicatesMissingAppServer } from './codex-app-server-capability-signal'
+import { withCliRuntimeOnPath } from '../../shared/node-cli-command-resolution'
 
 // Why: `codex app-server` is Orca's sanctioned RPC surface into Codex-owned
 // state (hook trust hashes, the sqlite thread index). This module owns the
@@ -10,6 +11,13 @@ import { stderrIndicatesMissingAppServer } from './codex-app-server-capability-s
 export type CodexAppServerInvocation = {
   command: string
   args: string[]
+  /**
+   * The resolved CLI path, when `command` is a wrapper such as cmd.exe. Used to
+   * pair the CLI with the `node` it was installed against; without it a CLI
+   * resolved out of a version-manager directory runs under whatever node leads
+   * PATH and dies on a NODE_MODULE_VERSION mismatch (stablyai/orca#10932).
+   */
+  cliPath?: string
   /** Overlay applied on top of the inherited environment (e.g. CODEX_HOME). */
   env?: Record<string, string>
   /** Env keys stripped from the inherited environment before spawn (e.g. an
@@ -111,8 +119,9 @@ export async function runCodexAppServerSession<T>(
   for (const key of invocation.envToDelete ?? []) {
     delete childEnv[key]
   }
+  const pairedEnv = withCliRuntimeOnPath(invocation.cliPath ?? invocation.command, childEnv)
   const child = spawnImpl(invocation.command, invocation.args, {
-    env: childEnv,
+    env: pairedEnv,
     stdio: ['pipe', 'pipe', 'pipe'],
     windowsHide: true
   }) as ChildProcessWithoutNullStreams

--- a/src/main/codex/codex-session-index-heal.ts
+++ b/src/main/codex/codex-session-index-heal.ts
@@ -267,6 +267,7 @@ function buildNativeHealInvocation(
   return {
     command: spawnCmd,
     args: spawnArgs,
+    cliPath: command,
     // Why: pin the real home explicitly — nested Orca launches can inherit a
     // managed CODEX_HOME from the daemon environment, which would index the
     // wrong sqlite DB.

--- a/src/main/codex/codex-trust-grant-host.ts
+++ b/src/main/codex/codex-trust-grant-host.ts
@@ -65,6 +65,7 @@ export function resolveCodexTrustGrantHost(host: CodexTrustGrantHost): ResolvedC
         invocation: {
           command: spawnCmd,
           args: spawnArgs,
+          cliPath: command,
           ...(useDefaultCodexHome
             ? { envToDelete: ['CODEX_HOME'] }
             : { env: { CODEX_HOME: input.runtimeHomePath } }),

--- a/src/main/rate-limits/claude-pty.ts
+++ b/src/main/rate-limits/claude-pty.ts
@@ -4,6 +4,9 @@ make the lifecycle harder to audit. */
 import type { ProviderRateLimits, RateLimitWindow } from '../../shared/rate-limit-types'
 import { buildConfiguredProxyEnv, type NetworkProxySettings } from '../../shared/network-proxy'
 import { resolveClaudeCommand } from '../codex-cli/command'
+// Why: import from the shared module, not the codex-cli re-export, so a test that
+// mocks '../codex-cli/command' does not have to restate this pure helper.
+import { withCliRuntimeOnPath } from '../../shared/node-cli-command-resolution'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
 import { applyClaudeEnvPatch } from '../claude-accounts/environment'
 import { withMacTailscaleDnsHint } from '../network/macos-tailscale-dns-diagnostic'
@@ -292,7 +295,7 @@ export async function fetchViaPty(options?: {
       // Why: hidden usage PTYs must not inherit the process cwd (e.g. / or a
       // drive root), which can trigger unbounded file discovery.
       cwd: resolveHiddenRateLimitPtyCwd(),
-      env: spawnEnv
+      env: withCliRuntimeOnPath(claudeCommand, spawnEnv)
     })
     const termDisposables: { dispose: () => void }[] = [registerHiddenRateLimitPty(term)]
     let enterInterval: ReturnType<typeof setInterval> | null = null

--- a/src/main/rate-limits/codex-fetcher-runtime-pairing.test.ts
+++ b/src/main/rate-limits/codex-fetcher-runtime-pairing.test.ts
@@ -1,0 +1,133 @@
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { EventEmitter } from 'node:events'
+import { tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { childSpawnMock, readFileMock, resolveCodexCommandMock, ptySpawnMock } = vi.hoisted(() => ({
+  childSpawnMock: vi.fn(),
+  readFileMock: vi.fn(),
+  resolveCodexCommandMock: vi.fn(),
+  ptySpawnMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({ spawn: childSpawnMock }))
+vi.mock('node:fs/promises', () => ({ readFile: readFileMock }))
+vi.mock('../codex-cli/command', () => ({ resolveCodexCommand: resolveCodexCommandMock }))
+vi.mock('node-pty', () => ({ spawn: ptySpawnMock }))
+vi.mock('../codex/codex-state-db', () => ({ isCodexStateDbBackfillPending: vi.fn(() => false) }))
+vi.mock('../codex/codex-state-db-backfill-recovery', () => ({
+  startCodexStateDbBackfillRecoveryInBackground: vi.fn(() => Promise.resolve(null))
+}))
+vi.mock('./codex-auth-presence', () => ({ probeCodexAuthPresence: vi.fn(() => 'present') }))
+
+import { fetchCodexRateLimits } from './codex-fetcher'
+
+function makeRpcChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+    stdin: EventEmitter & { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> }
+    kill: ReturnType<typeof vi.fn>
+    exitCode: number | null
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  const exitNow = (): void => {
+    child.exitCode = 0
+    child.emit('exit', 0, null)
+    child.emit('close', 0, null)
+  }
+  child.stdin = Object.assign(new EventEmitter(), { write: vi.fn(), end: vi.fn(exitNow) })
+  child.exitCode = null
+  child.kill = vi.fn(() => {
+    exitNow()
+    return true
+  })
+  return child
+}
+
+/** A CLI installed under one version manager entry, with its sibling node. */
+function makeVersionManagerCli(cliName = 'codex'): { bin: string; cli: string } {
+  const root = mkdtempSync(join(tmpdir(), 'orca-fetch-pair-'))
+  const bin = join(root, '.nvm', 'versions', 'node', 'v20.11.0', 'bin')
+  mkdirSync(bin, { recursive: true })
+  for (const name of ['node', 'node.exe', cliName]) {
+    writeFileSync(join(bin, name), '')
+    chmodSync(join(bin, name), 0o755)
+  }
+  return { bin, cli: join(bin, cliName) }
+}
+
+describe('codex rate-limit spawn runtime pairing', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    readFileMock.mockRejectedValue(new Error('no auth fixture'))
+    vi.stubGlobal('fetch', vi.fn())
+  })
+
+  it("spawns the RPC reader with the resolved CLI's own node ahead of PATH", async () => {
+    // Why a real fixture: the helper short-circuits on a non-absolute command,
+    // so a bare 'codex' mock would make this pass vacuously.
+    const { bin, cli } = makeVersionManagerCli()
+    resolveCodexCommandMock.mockReturnValue(cli)
+    const rpcChild = makeRpcChild()
+    childSpawnMock.mockReturnValue(rpcChild)
+
+    const resultPromise = fetchCodexRateLimits({ allowPtyFallback: false })
+    await vi.advanceTimersByTimeAsync(0)
+
+    const spawnEnv = childSpawnMock.mock.calls[0]?.[2]?.env as NodeJS.ProcessEnv
+    // Guards the argument choice: pairing spawnCmd (cmd.exe on win32) rather than
+    // the resolved CLI silently reverts the ABI fix (stablyai/orca#10932).
+    expect(spawnEnv.PATH?.split(delimiter)[0]).toBe(bin)
+
+    rpcChild.emit('close')
+    await resultPromise
+  })
+
+  it('pairs the resolved CLI on win32, where the spawn command is cmd.exe', async () => {
+    // Why win32 specifically: on posix getSpawnArgsForWindows returns the CLI
+    // itself, so pairing the spawn command instead of the resolved CLI is
+    // indistinguishable. Only here does the wrong argument become cmd.exe.
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    try {
+      const { bin, cli } = makeVersionManagerCli('codex.cmd')
+      resolveCodexCommandMock.mockReturnValue(cli)
+      const rpcChild = makeRpcChild()
+      childSpawnMock.mockReturnValue(rpcChild)
+
+      const resultPromise = fetchCodexRateLimits({ allowPtyFallback: false })
+      await vi.advanceTimersByTimeAsync(0)
+
+      const spawnCommand = childSpawnMock.mock.calls[0]?.[0] as string
+      expect(spawnCommand.toLowerCase()).toContain('cmd.exe')
+      const spawnEnv = childSpawnMock.mock.calls[0]?.[2]?.env as NodeJS.ProcessEnv
+      expect((spawnEnv.Path ?? spawnEnv.PATH)?.split(';')[0]).toBe(bin)
+
+      rpcChild.emit('close')
+      await resultPromise
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
+  })
+
+  it('leaves PATH alone when the CLI resolves to a bare command name', async () => {
+    resolveCodexCommandMock.mockReturnValue('codex')
+    const rpcChild = makeRpcChild()
+    childSpawnMock.mockReturnValue(rpcChild)
+
+    const resultPromise = fetchCodexRateLimits({ allowPtyFallback: false })
+    await vi.advanceTimersByTimeAsync(0)
+
+    const spawnEnv = childSpawnMock.mock.calls[0]?.[2]?.env as NodeJS.ProcessEnv
+    expect(spawnEnv.PATH).toBe(process.env.PATH)
+
+    rpcChild.emit('close')
+    await resultPromise
+  })
+})

--- a/src/main/rate-limits/codex-fetcher.ts
+++ b/src/main/rate-limits/codex-fetcher.ts
@@ -19,6 +19,9 @@ import {
   type CodexRateWindowSnapshot
 } from './codex-rate-limit-window-classification'
 import { resolveCodexCommand } from '../codex-cli/command'
+// Why: import from the shared module, not the codex-cli re-export, so a test that
+// mocks '../codex-cli/command' does not have to restate this pure helper.
+import { withCliRuntimeOnPath } from '../../shared/node-cli-command-resolution'
 import { CODEX_READ_ONLY_APP_SERVER_ARGS } from '../codex-cli/codex-read-only-app-server-args'
 import { withMacTailscaleDnsHint } from '../network/macos-tailscale-dns-diagnostic'
 import { getCmdExePath, getSpawnArgsForWindows } from '../win32-utils'
@@ -648,10 +651,10 @@ async function fetchViaRpc(options?: FetchCodexRateLimitsOptions): Promise<Provi
       // Why: scope the selected account to this subprocess only; never mutate process.env globally.
       // Why windowsHide: without it, background cmd.exe /c polls flash a console window on Windows.
       windowsHide: true,
-      env: {
+      env: withCliRuntimeOnPath(codexCommand, {
         ...(wslCodex ? cloneProcessEnvWithoutCodexHome() : process.env),
         ...(options?.codexHomePath && !wslCodex ? { CODEX_HOME: options.codexHomePath } : {})
-      }
+      })
     })
 
     let timeout: ReturnType<typeof setTimeout> | null = null
@@ -1005,11 +1008,11 @@ async function fetchViaPty(options?: FetchCodexRateLimitsOptions): Promise<Provi
       cols: 120,
       rows: 40,
       cwd: resolveHiddenRateLimitPtyCwd(),
-      env: {
+      env: withCliRuntimeOnPath(codexCommand, {
         ...(wslCodex ? cloneProcessEnvWithoutCodexHome() : process.env),
         TERM: 'xterm-256color',
         ...(options?.codexHomePath && !wslCodex ? { CODEX_HOME: options.codexHomePath } : {})
-      }
+      })
     })
     const termDisposables: { dispose: () => void }[] = [registerHiddenRateLimitPty(term)]
 

--- a/src/shared/node-cli-command-resolution.ts
+++ b/src/shared/node-cli-command-resolution.ts
@@ -16,13 +16,16 @@ function getExecutableNames(platform: NodeJS.Platform, commandName: string): str
   return [commandName]
 }
 
-function splitPath(pathEnv: string | null | undefined): string[] {
+function splitPath(
+  pathEnv: string | null | undefined,
+  pathDelimiter: string = delimiter
+): string[] {
   if (!pathEnv) {
     return []
   }
 
   return pathEnv
-    .split(delimiter)
+    .split(pathDelimiter)
     .map((entry) => entry.trim())
     .filter(Boolean)
 }
@@ -221,7 +224,7 @@ export function resolveClaudeCommand(options: ResolveCommandOptions = {}): strin
  * installed against instead.
  *
  * Only prepends when the sibling `node` really exists, so a CLI resolved from a
- * plain directory (Homebrew, /usr/local/bin) leaves PATH untouched.
+ * directory that ships no node is left alone.
  */
 export function withCliRuntimeOnPath<T extends NodeJS.ProcessEnv>(
   commandPath: string,
@@ -238,7 +241,7 @@ export function withCliRuntimeOnPath<T extends NodeJS.ProcessEnv>(
   }
   const pathKey = platform === 'win32' && env.Path !== undefined ? 'Path' : 'PATH'
   const pathDelimiter = platform === 'win32' ? ';' : delimiter
-  const segments = splitPath(env[pathKey])
+  const segments = splitPath(env[pathKey], pathDelimiter)
   if (segments[0] === commandDirectory) {
     return env
   }

--- a/src/shared/node-cli-command-resolution.ts
+++ b/src/shared/node-cli-command-resolution.ts
@@ -1,6 +1,6 @@
 import { accessSync, constants, existsSync, readdirSync, statSync } from 'node:fs'
 import { homedir } from 'node:os'
-import { delimiter, dirname, join } from 'node:path'
+import { delimiter, dirname, isAbsolute, join } from 'node:path'
 
 type ResolveCommandOptions = {
   pathEnv?: string | null
@@ -207,6 +207,55 @@ export function resolveCodexCommand(options: ResolveCommandOptions = {}): string
 
 export function resolveClaudeCommand(options: ResolveCommandOptions = {}): string {
   return resolveCliCommand('claude', options)
+}
+
+/**
+ * Put a resolved CLI's own directory ahead of PATH when that directory ships a
+ * sibling `node`.
+ *
+ * Why: `resolveCliCommand` falls back to scanning every version-manager install
+ * when PATH misses, so it can hand back `~/.nvm/versions/node/v20.x/bin/codex`
+ * while PATH still leads with v22. The CLI's `#!/usr/bin/env node` shebang then
+ * loads a v20-built native module under a v22 ABI and the agent dies on first
+ * require (stablyai/orca#10932). Pair the binary with the runtime it was
+ * installed against instead.
+ *
+ * Only prepends when the sibling `node` really exists, so a CLI resolved from a
+ * plain directory (Homebrew, /usr/local/bin) leaves PATH untouched.
+ */
+export function withCliRuntimeOnPath<T extends NodeJS.ProcessEnv>(
+  commandPath: string,
+  env: T,
+  options: Pick<ResolveCommandOptions, 'platform'> = {}
+): T {
+  const platform = options.platform ?? process.platform
+  if (!isAbsolute(commandPath)) {
+    return env
+  }
+  const commandDirectory = dirname(commandPath)
+  if (!findFirstExecutable(platform, [commandDirectory], getExecutableNames(platform, 'node'))) {
+    return env
+  }
+  const pathKey = platform === 'win32' && env.Path !== undefined ? 'Path' : 'PATH'
+  const pathDelimiter = platform === 'win32' ? ';' : delimiter
+  const segments = splitPath(env[pathKey])
+  if (segments[0] === commandDirectory) {
+    return env
+  }
+  const next = [commandDirectory, ...segments.filter((entry) => entry !== commandDirectory)].join(
+    pathDelimiter
+  )
+  const paired = { ...env, [pathKey]: next }
+  if (platform === 'win32') {
+    // Why: the spread is case-sensitive while Windows env lookup is not, so a
+    // differently-cased twin would keep shadowing the value we just wrote.
+    for (const name of Object.keys(paired)) {
+      if (name !== pathKey && name.toLowerCase() === pathKey.toLowerCase()) {
+        delete (paired as NodeJS.ProcessEnv)[name]
+      }
+    }
+  }
+  return paired as T
 }
 
 // Why: Node-script CLIs need their version-manager sibling `node` on PATH.

--- a/src/shared/node-cli-command-resolution.ts
+++ b/src/shared/node-cli-command-resolution.ts
@@ -212,6 +212,21 @@ export function resolveClaudeCommand(options: ResolveCommandOptions = {}): strin
   return resolveCliCommand('claude', options)
 }
 
+// Why: Win32 resolves env names case-insensitively and object order preserves
+// the block order, so the entry the child will actually read is the FIRST
+// case-insensitive match — not necessarily `Path` or `PATH`. Reading a narrower
+// set than the dedupe below deletes would destroy a third spelling unread.
+// Mirrors resolvePathEnvKey in src/main/pty/windows-path-segment-merge.ts, which
+// src/shared must not import.
+function firstWindowsPathEnvKey(env: NodeJS.ProcessEnv): string {
+  for (const key of Object.keys(env)) {
+    if (key.toLowerCase() === 'path' && env[key] !== undefined) {
+      return key
+    }
+  }
+  return 'Path'
+}
+
 /**
  * Put a resolved CLI's own directory ahead of PATH when that directory ships a
  * sibling `node`.
@@ -239,7 +254,7 @@ export function withCliRuntimeOnPath<T extends NodeJS.ProcessEnv>(
   if (!findFirstExecutable(platform, [commandDirectory], getExecutableNames(platform, 'node'))) {
     return env
   }
-  const pathKey = platform === 'win32' && env.Path !== undefined ? 'Path' : 'PATH'
+  const pathKey = platform === 'win32' ? firstWindowsPathEnvKey(env) : 'PATH'
   const pathDelimiter = platform === 'win32' ? ';' : delimiter
   const segments = splitPath(env[pathKey], pathDelimiter)
   if (segments[0] === commandDirectory) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​210 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​210 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​110 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​90 |

<!-- /orca-pr-loc -->

Closes #10932.

## ELI5

nvm keeps several Node versions side by side. A globally installed CLI like `codex` lives inside whichever version was active when you installed it, and its native pieces are compiled for *that* version specifically.

When Orca can't find `codex` on PATH, it goes looking through every Node version you have until it finds one — and it does find it. But it then runs it using whatever Node happens to be first on PATH, which may be a completely different version. The CLI's first line says "run me with node", and nobody checked *which* node.

So Orca hands a v20-shaped program to a v22 engine, and it dies on startup with a message about `NODE_MODULE_VERSION` that says nothing about nvm.

This pairs them up: if we found the CLI inside a version's folder, we run it with that version's Node.

## The bug

`resolveCliCommand` (`node-cli-command-resolution.ts:156-176`) falls back to scanning every version-manager install when PATH misses. It correctly returns `~/.nvm/versions/node/v20.x/bin/codex` — but the spawn sites then pass `env: process.env`, whose PATH still leads with a different version. The `#!/usr/bin/env node` shebang resolves *that* node, and a native module built for v20 loads under a v22 ABI.

Note this is the second half of #10932. The first half — Orca's PATH probe being pinned to the newest nvm install — was fixed in #16314, which resolves the reporter's literal repro (`nvm install <newer>` leaves the `default` alias alone, so the login shell still resolves the version holding the CLI). What survives is the case where your **default node simply isn't where your CLIs are installed**: `nvm alias default <newer>`, a shell that never initializes nvm, or a probe timeout.

## Reproduced, not asserted

A CLI requiring a `cpu-features` build for `NODE_MODULE_VERSION 115`, spawned exactly as Orca does today:

```
### BEFORE — CLI resolved from v20, PATH leads v24
Error: The module '.../cpufeatures.node'
was compiled against a different Node.js version using
NODE_MODULE_VERSION 115. This version of Node.js requires
exit=1

### AFTER — same spawn, with the CLI's own bin directory prepended
mycli OK under node v20.13.1
```

## The fix

`withCliRuntimeOnPath(commandPath, env)` prepends the resolved command's directory when that directory ships a sibling `node`, and returns `env` untouched otherwise. Two properties fall out for free:

- A CLI resolved from Homebrew or `/usr/local/bin` has no sibling `node`, so PATH is left alone.
- The WSL paths pass a bare `codex` / `claude`, which is not absolute, so they no-op — the host PATH is meaningless inside the distro anyway.

Wired into the six spawn sites that inherit `process.env`: `codex-fetcher` (subprocess + PTY), `claude-pty`, `codex-accounts/service`, and the three non-WSL branches of `claude-accounts/service`.

Host CLI resolution in the Claude login path is now lazy, so the WSL branch stops resolving a host binary it never spawns — caught by an existing test asserting exactly that separation.

## Verification

- Real ABI crash reproduced and fixed (above), with a genuinely non-N-API addon; N-API modules can't exhibit this, which is why the first attempt with `bufferutil` was inconclusive.
- 5 unit tests: the #10932 scenario, no-op for a plain directory, no-op for a bare command name, no-op when already leading, and the Windows `Path` key.
- Run natively on a Windows machine: `withCliRuntimeOnPath` redirects real resolution — `where node` returns `C:\Program Files\nodejs\node.exe` before pairing and the paired version's node after — leaving exactly one path-ish env key, no `Path`/`PATH` twin.
- Windows suite parity: 12 pre-existing failures on this branch, the identical 12 on `main` (1201 passed vs main's 1196). None introduced here.
- `pnpm typecheck` clean; 1987 tests green locally across `codex-cli`, `rate-limits`, `codex-accounts`, `claude-accounts`, `codex`, `startup`.