### PR TITLE
build(orcad): gate orcad's own graph, and prove it loads under plain Node

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -475,6 +475,44 @@ jobs:
             --exclude=tests/e2e/cross-version-wire/** \
             --shard=${{ matrix.shard }}/${{ matrix.shard_total }}
 
+  # Why a separate job: the test needs a real Chrome, and the 32-way `test` matrix
+  # would pay for it 32 times to run one file in whichever shard it landed in.
+  orcad_browser:
+    name: orcad browser provider
+    needs: [code_paths]
+    if: needs.code_paths.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      # Why no native-runtime: the provider drives the prebuilt agent-browser binary
+      # shipped in node_modules and never touches node-pty.
+      - uses: ./.github/actions/install-node-dependencies
+
+      # Why the runner's Google Chrome and not its chromium: Ubuntu 24.04 only ships an
+      # AppArmor userns profile for the Chrome .deb, so chromium dies with "No usable
+      # sandbox" and the provider passes no --no-sandbox. Why fail instead of skip: an
+      # unset ORCA_BROWSER_EXECUTABLE is exactly how this test went uncovered for so long.
+      - name: Resolve Chrome for the browser provider
+        run: |
+          set -euo pipefail
+          chrome="$(command -v google-chrome || command -v google-chrome-stable || true)"
+          if [ -z "$chrome" ]; then
+            echo "::error::No Google Chrome on the runner; the browser provider test would silently skip."
+            exit 1
+          fi
+          "$chrome" --version
+          echo "ORCA_BROWSER_EXECUTABLE=$chrome" >> "$GITHUB_ENV"
+
+      - name: Test external Chromium browser provider
+        run: |
+          pnpm exec vitest run --config config/vitest.config.ts \
+            src/main/orcad/external-chromium-browser-process.integration.test.ts
+
   cross-version-wire:
     name: cross-version wire compatibility
     needs: [code_paths]
@@ -747,6 +785,7 @@ jobs:
       - xterm_patch_sync
       - shell_contracts
       - test
+      - orcad_browser
       - managed_hook_node18
       - package
       - package_windows
@@ -772,6 +811,7 @@ jobs:
           XTERM_PATCH_SYNC: ${{ needs.xterm_patch_sync.result }}
           SHELL_CONTRACTS: ${{ needs.shell_contracts.result }}
           TEST: ${{ needs.test.result }}
+          ORCAD_BROWSER: ${{ needs.orcad_browser.result }}
           MANAGED_HOOK_NODE18: ${{ needs.managed_hook_node18.result }}
           PACKAGE: ${{ needs.package.result }}
           PACKAGE_WINDOWS: ${{ needs.package_windows.result }}
@@ -791,6 +831,7 @@ jobs:
               "$XTERM_PATCH_SYNC" \
               "$SHELL_CONTRACTS" \
               "$TEST" \
+              "$ORCAD_BROWSER" \
               "$MANAGED_HOOK_NODE18" \
               "$PACKAGE" \
               "$PACKAGE_WINDOWS"; do
@@ -810,6 +851,7 @@ jobs:
             "$XTERM_PATCH_SYNC" \
             "$SHELL_CONTRACTS" \
             "$TEST" \
+            "$ORCAD_BROWSER" \
             "$MANAGED_HOOK_NODE18" \
             "$PACKAGE" \
             "$PACKAGE_WINDOWS"; do

--- a/config/scripts/build-orcad.mjs
+++ b/config/scripts/build-orcad.mjs
@@ -7,6 +7,7 @@
  * the only ones that statically import `node:sqlite`, so dropping them is what keeps
  * the host Node floor at 18 instead of 22.5+.
  */
+import { spawnSync } from 'node:child_process'
 import { build } from 'esbuild'
 import { chmodSync, copyFileSync, mkdirSync, rmSync } from 'node:fs'
 import { arch, platform } from 'node:os'
@@ -17,6 +18,7 @@ const ROOT = join(import.meta.dirname, '..', '..')
 const OUT_DIR = join(ROOT, 'out', 'orcad')
 const ENTRY = join(ROOT, 'src/main/orcad/main.ts')
 const AGENT_BROWSER_NAME = `agent-browser-${platform()}-${arch()}${process.platform === 'win32' ? '.exe' : ''}`
+const OUT_FILE = join(OUT_DIR, 'orcad.js')
 const AGENT_BROWSER_SOURCE = join(ROOT, 'node_modules', 'agent-browser', 'bin', AGENT_BROWSER_NAME)
 const AGENT_BROWSER_OUTPUT = join(OUT_DIR, AGENT_BROWSER_NAME)
 
@@ -63,7 +65,7 @@ const result = await build({
   platform: 'node',
   target: 'node18',
   format: 'cjs',
-  outfile: join(OUT_DIR, 'orcad.js'),
+  outfile: OUT_FILE,
   external: EXTERNAL,
   plugins: [jsoncParserEsm, externalNativeAddons],
   metafile: true,
@@ -120,6 +122,31 @@ if (graphErrors.length > 0) {
   // point so the two numbers cannot drift.
   process.exitCode = 1
 } else {
+  // Why smoke-load and not just read the metafile: the import scan proves no module
+  // *names* electron, but a graph can still fail to resolve under plain Node — a
+  // dynamic require, a missing native, a top-level throw. The plain-node-entry-guard
+  // smoke-loads its entries for exactly this reason, and orcad cannot join that guard
+  // because it is an esbuild artifact rather than a rollup input.
+  const smoke = spawnSync(process.execPath, [OUT_FILE, '--orcad-smoke-load-check'], {
+    encoding: 'utf8',
+    timeout: 60_000
+  })
+  const smokeOutput = `${smoke.stdout ?? ''}${smoke.stderr ?? ''}`
+  if (
+    smoke.error ||
+    smoke.signal ||
+    !/Unknown argument: --orcad-smoke-load-check/.test(smokeOutput)
+  ) {
+    console.error(
+      `[build-orcad] the bundle did not load under plain Node.\n` +
+        `Expected argv rejection, got signal=${smoke.signal ?? 'none'} ` +
+        `error=${smoke.error?.message ?? 'none'}\n${smokeOutput.slice(0, 2000)}`
+    )
+    process.exitCode = 1
+  }
+}
+
+if (process.exitCode !== 1) {
   console.log(
     `[build-orcad] ok — ${(output.bytes / 1024 / 1024).toFixed(2)} MB, ${Object.keys(output.inputs).length} modules, zero electron and node:sqlite imports.`
   )

--- a/config/scripts/check-runtime-electron-ratchet.mjs
+++ b/config/scripts/check-runtime-electron-ratchet.mjs
@@ -34,7 +34,11 @@ const BASELINE_PATH = path.join(ROOT, 'config', 'runtime-electron-baseline.txt')
 // itself and the RPC server that fronts it.
 const ENTRY_POINTS = [
   path.join(ROOT, 'src', 'main', 'runtime', 'orca-runtime.ts'),
-  path.join(ROOT, 'src', 'main', 'runtime', 'runtime-rpc.ts')
+  path.join(ROOT, 'src', 'main', 'runtime', 'runtime-rpc.ts'),
+  // Why orcad too: it imports ipc/pty directly to install the PTY controller, so its
+  // graph is strictly larger than the two runtime entries. Measuring only those let the
+  // two numbers drift — the gate would read zero while the shipped artifact regressed.
+  path.join(ROOT, 'src', 'main', 'orcad', 'main.ts')
 ]
 
 // Native addons and electron cannot be bundled; externalising them is what the

--- a/config/scripts/pr-workflow-parallelism.test.mjs
+++ b/config/scripts/pr-workflow-parallelism.test.mjs
@@ -345,6 +345,7 @@ describe('PR workflow parallelism', () => {
       'xterm_patch_sync',
       'shell_contracts',
       'test',
+      'orcad_browser',
       'managed_hook_node18',
       'package',
       'package_windows'
@@ -354,5 +355,9 @@ describe('PR workflow parallelism', () => {
     )
     expect(verifyStep.env.MANAGED_HOOK_NODE18).toBe('${{ needs.managed_hook_node18.result }}')
     expect(verifyStep.run).toContain('"$MANAGED_HOOK_NODE18"')
+    // Why assert this one too: the browser provider test skips itself without
+    // ORCA_BROWSER_EXECUTABLE, so it only guards anything if verify actually reads it.
+    expect(verifyStep.env.ORCAD_BROWSER).toBe('${{ needs.orcad_browser.result }}')
+    expect(verifyStep.run).toContain('"$ORCAD_BROWSER"')
   })
 })

--- a/src/main/orcad/__fixtures__/fake-orcad-electron-sidecar.cjs
+++ b/src/main/orcad/__fixtures__/fake-orcad-electron-sidecar.cjs
@@ -1,0 +1,166 @@
+/**
+ * Stands in for an installed Orca app running `--serve`, so the orcad Electron
+ * provider can be driven over a real socket by a real child process.
+ *
+ * Contract with the provider under test: read `--user-data-dir=` from argv,
+ * listen on a local transport, then publish `orca-runtime.json` there.
+ *
+ * Test-only channels (injected by the spawn wrapper, never by production code):
+ *   ORCA_FAKE_SIDECAR_LOG      JSONL of every request received.
+ *   ORCA_FAKE_SIDECAR_CONTROL  JSON re-read per request: { capabilities, errors }.
+ *   ORCA_FAKE_SIDECAR_MODE     'exit-before-ready' to die without publishing.
+ */
+'use strict'
+
+const { createServer } = require('node:net')
+const { appendFileSync, readFileSync, renameSync, writeFileSync } = require('node:fs')
+const { join } = require('node:path')
+
+const USER_DATA_FLAG = '--user-data-dir='
+const userDataDir = (
+  process.argv.slice(2).find((arg) => arg.startsWith(USER_DATA_FLAG)) ?? ''
+).slice(USER_DATA_FLAG.length)
+const logPath = process.env.ORCA_FAKE_SIDECAR_LOG
+const controlPath = process.env.ORCA_FAKE_SIDECAR_CONTROL
+
+if (!userDataDir) {
+  process.stderr.write('fake sidecar: missing --user-data-dir\n')
+  process.exit(2)
+}
+if (process.env.ORCA_FAKE_SIDECAR_MODE === 'exit-before-ready') {
+  process.exit(3)
+}
+
+function control() {
+  try {
+    return JSON.parse(readFileSync(controlPath, 'utf8'))
+  } catch {
+    return {}
+  }
+}
+
+const tabs = new Map()
+let nextSidecarPageId = 0
+let statusCalls = 0
+
+function createTab() {
+  const browserPageId = `sidecar-${++nextSidecarPageId}`
+  for (const tab of tabs.values()) {
+    tab.active = false
+  }
+  tabs.set(browserPageId, { browserPageId, active: true, url: 'about:blank' })
+  return browserPageId
+}
+
+function activate(browserPageId) {
+  for (const tab of tabs.values()) {
+    tab.active = tab.browserPageId === browserPageId
+  }
+}
+
+function handle(method, params) {
+  const injected = (control().errors ?? {})[method]
+  if (injected) {
+    const error = new Error(injected.message)
+    error.code = injected.code
+    throw error
+  }
+  if (method === 'status.get') {
+    statusCalls += 1
+    const schedule = control().capabilities ?? [['browser.headless.v1']]
+    return { capabilities: schedule[Math.min(statusCalls - 1, schedule.length - 1)] }
+  }
+  if (method === 'browser.tabCreate') {
+    return { browserPageId: createTab() }
+  }
+  if (method === 'browser.tabProfileClone') {
+    return { browserPageId: createTab(), sourceBrowserPageId: params.page }
+  }
+  if (method === 'browser.tabList') {
+    return { tabs: [...tabs.values()] }
+  }
+  if (method === 'browser.tabShow' || method === 'browser.tabSwitch') {
+    activate(params.page)
+    return { browserPageId: params.page }
+  }
+  if (method === 'browser.tabClose') {
+    tabs.delete(params.page)
+    return { closed: true }
+  }
+  if (method === 'browser.goto') {
+    const tab = tabs.get(params.page)
+    if (tab) {
+      tab.url = params.url
+    }
+    return { browserPageId: params.page, url: params.url, title: 'Fake page' }
+  }
+  return { browserPageId: params.page ?? undefined, method }
+}
+
+const endpoint =
+  process.platform === 'win32'
+    ? `\\\\.\\pipe\\orcad-fake-sidecar-${process.pid}`
+    : join(userDataDir, 'rpc.sock')
+
+const server = createServer((socket) => {
+  socket.setEncoding('utf8')
+  socket.on('error', () => undefined)
+  let buffer = ''
+  socket.on('data', (chunk) => {
+    // Why String(): setEncoding('utf8') above makes this a string at runtime, but the
+    // declared type stays string | Buffer and the type-aware lint rejects the concat.
+    buffer += String(chunk)
+    let newline = buffer.indexOf('\n')
+    while (newline !== -1) {
+      const line = buffer.slice(0, newline)
+      buffer = buffer.slice(newline + 1)
+      newline = buffer.indexOf('\n')
+      if (!line.trim()) {
+        continue
+      }
+      const request = JSON.parse(line)
+      if (logPath) {
+        appendFileSync(
+          logPath,
+          `${JSON.stringify({
+            method: request.method,
+            params: request.params ?? null,
+            authToken: request.authToken ?? null
+          })}\n`
+        )
+      }
+      let response
+      try {
+        response = {
+          id: request.id,
+          ok: true,
+          result: handle(request.method, request.params ?? {})
+        }
+      } catch (error) {
+        response = {
+          id: request.id,
+          ok: false,
+          error: { code: error.code ?? 'browser_error', message: error.message }
+        }
+      }
+      socket.write(`${JSON.stringify(response)}\n`)
+    }
+  })
+})
+
+server.listen(endpoint, () => {
+  const metadataPath = join(userDataDir, 'orca-runtime.json')
+  // Publish atomically: the provider polls with existsSync + readFileSync and would
+  // otherwise parse a half-written file.
+  writeFileSync(
+    `${metadataPath}.staging`,
+    JSON.stringify({
+      runtimeId: `fake-sidecar-${process.pid}`,
+      pid: process.pid,
+      transports: [{ kind: process.platform === 'win32' ? 'named-pipe' : 'unix', endpoint }],
+      authToken: 'fake-sidecar-auth-token',
+      startedAt: Date.now()
+    })
+  )
+  renameSync(`${metadataPath}.staging`, metadataPath)
+})

--- a/src/main/orcad/electron-serve-browser-process.test.ts
+++ b/src/main/orcad/electron-serve-browser-process.test.ts
@@ -1,0 +1,325 @@
+import { existsSync } from 'node:fs'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as RunProcessModule from '../../shared/child-process/run-process'
+import type { RuntimeBrowserCommandHost } from '../runtime/orca-runtime-browser'
+
+const { spawnProcessMock } = vi.hoisted(() => ({ spawnProcessMock: vi.fn() }))
+
+// Why wrap rather than fake: the provider must still go through the real spawn
+// path (argv/env handling, a real pid to signal); only the program is swapped
+// for a stub that speaks the sidecar's serve protocol.
+vi.mock('../../shared/child-process/run-process', async (importOriginal) => ({
+  ...(await importOriginal<typeof RunProcessModule>()),
+  spawnProcess: spawnProcessMock
+}))
+
+import { ElectronServeBrowserProcess } from './electron-serve-browser-process'
+
+const FAKE_SIDECAR = join(import.meta.dirname, '__fixtures__', 'fake-orcad-electron-sidecar.cjs')
+const INSTALLED_EXECUTABLE = join('/Applications', 'Orca.app', 'Contents', 'MacOS', 'Orca')
+
+/** Every key the provider must strip so the sidecar cannot inherit orcad's own browser config. */
+const AGENT_BROWSER_ENVIRONMENT_KEYS = [
+  'AGENT_BROWSER_ARGS',
+  'AGENT_BROWSER_AUTO_CONNECT',
+  'AGENT_BROWSER_CDP',
+  'AGENT_BROWSER_ENGINE',
+  'AGENT_BROWSER_EXECUTABLE_PATH',
+  'AGENT_BROWSER_HEADED',
+  'AGENT_BROWSER_PROFILE',
+  'AGENT_BROWSER_PROVIDER',
+  'AGENT_BROWSER_SESSION',
+  'AGENT_BROWSER_SESSION_NAME',
+  'AGENT_BROWSER_STATE'
+]
+
+type SidecarRequest = { method: string; params: Record<string, unknown>; authToken: string | null }
+
+const host: RuntimeBrowserCommandHost = {
+  getAgentBrowserBridge: () => null,
+  // Why an id distinct from the selector: it proves the registry fences on the
+  // resolved worktree id, not on whatever string the caller passed.
+  resolveWorktreeSelector: async (selector) => ({ id: `id-${selector}` }),
+  getAuthoritativeWindow: () => {
+    throw new Error('No renderer')
+  },
+  getAvailableAuthoritativeWindow: () => null,
+  getOffscreenBrowserBackend: () => null
+}
+
+let harnessRoot: string
+let logPath: string
+let controlPath: string
+let sidecarMode: string | undefined
+let started: ElectronServeBrowserProcess[]
+
+async function setControl(control: Record<string, unknown>): Promise<void> {
+  await writeFile(controlPath, JSON.stringify(control))
+}
+
+async function sidecarRequests(): Promise<SidecarRequest[]> {
+  const raw = await readFile(logPath, 'utf8')
+  return raw
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => JSON.parse(line) as SidecarRequest)
+}
+
+async function browserRequests(): Promise<SidecarRequest[]> {
+  return (await sidecarRequests()).filter((request) => request.method !== 'status.get')
+}
+
+async function startProvider(): Promise<ElectronServeBrowserProcess> {
+  const processHandle = new ElectronServeBrowserProcess(INSTALLED_EXECUTABLE)
+  started.push(processHandle)
+  await processHandle.start()
+  return processHandle
+}
+
+function spawnSpec(): RunProcessModule.ProcessSpec {
+  return spawnProcessMock.mock.calls[0][0] as RunProcessModule.ProcessSpec
+}
+
+beforeEach(async () => {
+  harnessRoot = await mkdtemp(join(tmpdir(), 'orcad-electron-harness-'))
+  logPath = join(harnessRoot, 'requests.jsonl')
+  controlPath = join(harnessRoot, 'control.json')
+  sidecarMode = undefined
+  started = []
+  await writeFile(logPath, '')
+  await setControl({})
+  const actual = await vi.importActual<typeof RunProcessModule>(
+    '../../shared/child-process/run-process'
+  )
+  spawnProcessMock.mockReset()
+  spawnProcessMock.mockImplementation((spec: RunProcessModule.ProcessSpec) =>
+    actual.spawnProcess({
+      ...spec,
+      program: process.execPath,
+      args: [FAKE_SIDECAR, ...(spec.args ?? [])],
+      env: {
+        ...spec.env,
+        ORCA_FAKE_SIDECAR_LOG: logPath,
+        ORCA_FAKE_SIDECAR_CONTROL: controlPath,
+        ...(sidecarMode ? { ORCA_FAKE_SIDECAR_MODE: sidecarMode } : {})
+      }
+    })
+  )
+})
+
+afterEach(async () => {
+  for (const processHandle of started) {
+    await processHandle.stop()
+  }
+  vi.unstubAllEnvs()
+  await rm(harnessRoot, { recursive: true, force: true })
+})
+
+describe('ElectronServeBrowserProcess start-up', () => {
+  it('launches the installed app in headless serve mode without orcad browser env', async () => {
+    for (const key of AGENT_BROWSER_ENVIRONMENT_KEYS) {
+      vi.stubEnv(key, `leaked-${key}`)
+    }
+    vi.stubEnv('ORCA_HARNESS_UNRELATED', 'preserved')
+
+    const processHandle = await startProvider()
+
+    const spec = spawnSpec()
+    expect(spec.program).toBe(INSTALLED_EXECUTABLE)
+    const args = [...(spec.args ?? [])]
+    expect(args).toEqual(
+      expect.arrayContaining(['--serve', '--serve-port', '--serve-json', '--serve-no-pairing'])
+    )
+    const port = Number(args[args.indexOf('--serve-port') + 1])
+    expect(Number.isInteger(port) && port > 0 && port < 65_536).toBe(true)
+    const userDataArg = args.find((arg) => arg.startsWith('--user-data-dir='))
+    expect(userDataArg).toBeDefined()
+    for (const key of AGENT_BROWSER_ENVIRONMENT_KEYS) {
+      expect(spec.env).not.toHaveProperty(key)
+    }
+    expect(spec.env?.ORCA_HARNESS_UNRELATED).toBe('preserved')
+    expect(processHandle.isAvailable()).toBe(true)
+  })
+
+  it('keeps polling until the sidecar advertises browser.headless.v1', async () => {
+    await setControl({
+      capabilities: [['runtime.v1'], ['runtime.v1'], ['runtime.v1', 'browser.headless.v1']]
+    })
+
+    const processHandle = await startProvider()
+
+    const statusCalls = (await sidecarRequests()).filter(
+      (request) => request.method === 'status.get'
+    )
+    expect(statusCalls).toHaveLength(3)
+    expect(processHandle.isAvailable()).toBe(true)
+  })
+
+  it('fails fast when the installed app exits before publishing runtime metadata', async () => {
+    sidecarMode = 'exit-before-ready'
+    const processHandle = new ElectronServeBrowserProcess(INSTALLED_EXECUTABLE)
+    started.push(processHandle)
+
+    await expect(processHandle.start()).rejects.toThrow(/did not become ready/)
+    expect(processHandle.isAvailable()).toBe(false)
+  })
+
+  it('stops the sidecar process and removes its user data directory', async () => {
+    const processHandle = await startProvider()
+    const userDataPath = (spawnSpec().args ?? [])
+      .find((arg) => arg.startsWith('--user-data-dir='))!
+      .slice('--user-data-dir='.length)
+    const metadata = JSON.parse(
+      await readFile(join(userDataPath, 'orca-runtime.json'), 'utf8')
+    ) as { pid: number }
+
+    await processHandle.stop()
+
+    expect(processHandle.isAvailable()).toBe(false)
+    expect(existsSync(userDataPath)).toBe(false)
+    expect(() => process.kill(metadata.pid, 0)).toThrow()
+  })
+})
+
+describe('ElectronServeBrowserProcess command routing', () => {
+  it('rejects commands before start and after stop', async () => {
+    const processHandle = new ElectronServeBrowserProcess(INSTALLED_EXECUTABLE)
+    await expect(
+      processHandle.createCommands(host).browserGoto({ url: 'https://example.test/' })
+    ).rejects.toMatchObject({ code: 'browser_unavailable' })
+
+    const runningHandle = await startProvider()
+    const commands = runningHandle.createCommands(host)
+    await runningHandle.stop()
+    await expect(commands.browserGoto({ url: 'https://example.test/' })).rejects.toMatchObject({
+      code: 'browser_unavailable'
+    })
+  })
+
+  it('refuses screencast without reaching the sidecar', async () => {
+    const processHandle = await startProvider()
+
+    await expect(
+      processHandle
+        .createCommands(host)
+        .browserScreencast({ worktree: 'wt-a', format: 'jpeg' }, { sendBinary: () => true })
+    ).rejects.toMatchObject({ code: 'browser_screencast_unavailable' })
+    expect(await browserRequests()).toEqual([])
+  })
+
+  it('forwards the sidecar auth token and strips the worktree selector from params', async () => {
+    const commands = (await startProvider()).createCommands(host)
+
+    const created = (await commands.browserTabCreate({ worktree: 'wt-a' })) as {
+      browserPageId: string
+    }
+    await commands.browserGoto({ worktree: 'wt-a', url: 'https://example.test/' })
+
+    const requests = await browserRequests()
+    expect(requests.map((request) => request.method)).toEqual(['browser.tabCreate', 'browser.goto'])
+    for (const request of requests) {
+      expect(request.authToken).toBe('fake-sidecar-auth-token')
+      expect(request.params).not.toHaveProperty('worktree')
+    }
+    // The active page is targeted implicitly once the worktree resolves.
+    expect(requests[1].params.page).toBe(created.browserPageId)
+  })
+
+  it('leaves targetless methods untargeted and renumbers listed tabs per worktree', async () => {
+    const commands = (await startProvider()).createCommands(host)
+    const first = (await commands.browserTabCreate({ worktree: 'wt-a' })) as {
+      browserPageId: string
+    }
+    const second = (await commands.browserTabCreate({ worktree: 'wt-a' })) as {
+      browserPageId: string
+    }
+    await commands.browserTabCreate({ worktree: 'wt-b' })
+
+    const listed = (await commands.browserTabList({ worktree: 'wt-a' })) as {
+      tabs: { browserPageId: string; index: number }[]
+    }
+
+    expect(listed.tabs).toEqual([
+      expect.objectContaining({ browserPageId: first.browserPageId, index: 0 }),
+      expect.objectContaining({ browserPageId: second.browserPageId, index: 1 })
+    ])
+    const listRequest = (await browserRequests()).find(
+      (request) => request.method === 'browser.tabList'
+    )
+    expect(listRequest?.params).not.toHaveProperty('page')
+  })
+
+  it('fences pages to the worktree that created them without calling the sidecar', async () => {
+    const commands = (await startProvider()).createCommands(host)
+    const created = (await commands.browserTabCreate({ worktree: 'wt-a' })) as {
+      browserPageId: string
+    }
+    const before = (await browserRequests()).length
+
+    await expect(
+      commands.browserGoto({
+        worktree: 'wt-b',
+        page: created.browserPageId,
+        url: 'https://example.test/'
+      })
+    ).rejects.toMatchObject({ code: 'browser_tab_not_found' })
+    expect(await browserRequests()).toHaveLength(before)
+  })
+
+  it('routes browserTabCurrent to browser.tabShow for the active page', async () => {
+    const commands = (await startProvider()).createCommands(host)
+    const created = (await commands.browserTabCreate({ worktree: 'wt-a' })) as {
+      browserPageId: string
+    }
+
+    await commands.browserTabCurrent({ worktree: 'wt-a' })
+
+    const request = (await browserRequests()).at(-1)
+    expect(request?.method).toBe('browser.tabShow')
+    expect(request?.params.page).toBe(created.browserPageId)
+  })
+
+  it('re-creating a known page id is idempotent and issues no sidecar request', async () => {
+    const commands = (await startProvider()).createCommands(host)
+    const created = (await commands.browserTabCreate({ worktree: 'wt-a' })) as {
+      browserPageId: string
+    }
+    const before = (await browserRequests()).length
+
+    await expect(
+      commands.browserTabCreate({ worktree: 'wt-a', page: created.browserPageId })
+    ).resolves.toEqual({ browserPageId: created.browserPageId })
+    expect(await browserRequests()).toHaveLength(before)
+  })
+
+  it('forgets a page the sidecar reports as closed', async () => {
+    const commands = (await startProvider()).createCommands(host)
+    await commands.browserTabCreate({ worktree: 'wt-a' })
+    await setControl({
+      errors: { 'browser.goto': { code: 'browser_tab_closed', message: 'Tab was closed.' } }
+    })
+
+    await expect(
+      commands.browserGoto({ worktree: 'wt-a', url: 'https://example.test/' })
+    ).rejects.toMatchObject({ code: 'browser_tab_closed' })
+
+    await setControl({})
+    await expect(commands.browserTabCurrent({ worktree: 'wt-a' })).rejects.toMatchObject({
+      code: 'browser_no_tab'
+    })
+  })
+
+  // Why this matters: the runtime advertises browser.tabCreate.known-id.v1
+  // unconditionally, so a web client will send a provisional id for a page that does
+  // not exist yet. Requiring it first made every such create throw.
+  it('creates a tab under a caller-chosen page id', async () => {
+    const commands = (await startProvider()).createCommands(host)
+
+    await expect(
+      commands.browserTabCreate({ worktree: 'wt-a', page: 'provisional-page-1' })
+    ).resolves.toEqual({ browserPageId: 'provisional-page-1' })
+  })
+})

--- a/src/main/orcad/electron-serve-browser-process.ts
+++ b/src/main/orcad/electron-serve-browser-process.ts
@@ -223,6 +223,11 @@ export class ElectronServeBrowserProcess {
         this.tabs.require(requestedPageId, worktreeId)
         return { browserPageId: requestedPageId }
       }
+      // Why drop `page`: the runtime advertises browser.tabCreate.known-id.v1, so web
+      // clients send a provisional id for a page that does not exist yet. The sidecar
+      // mints its own id and the caller's is adopted as the public one below; passing
+      // the unknown id through would make the generic branch require() a missing page.
+      delete params.page
     }
 
     if (method === 'browserTabCurrent' && worktreeId) {
@@ -241,7 +246,7 @@ export class ElectronServeBrowserProcess {
         params.page = targetPage.sidecarPageId
         delete params.index
       }
-    } else if (requestedPageId) {
+    } else if (requestedPageId && method !== 'browserTabCreate') {
       targetPage = this.tabs.require(requestedPageId, worktreeId)
       params.page = targetPage.sidecarPageId
     } else if (worktreeId && !TARGETLESS_BROWSER_METHODS[method]) {

--- a/src/main/orcad/electron-serve-provider-selection.test.ts
+++ b/src/main/orcad/electron-serve-provider-selection.test.ts
@@ -1,0 +1,148 @@
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as RunProcessModule from '../../shared/child-process/run-process'
+
+const { runProcessMock, spawnProcessMock } = vi.hoisted(() => ({
+  runProcessMock: vi.fn(),
+  spawnProcessMock: vi.fn()
+}))
+
+vi.mock('../../shared/child-process/run-process', async (importOriginal) => ({
+  ...(await importOriginal<typeof RunProcessModule>()),
+  runProcess: runProcessMock,
+  spawnProcess: spawnProcessMock
+}))
+
+import { resolveOrcadBrowserProvider, type OrcadBrowserProvider } from './orcad-browser-provider'
+
+const FAKE_SIDECAR = join(import.meta.dirname, '__fixtures__', 'fake-orcad-electron-sidecar.cjs')
+const INSTALLED_EXECUTABLE = join('/Applications', 'Orca.app', 'Contents', 'MacOS', 'Orca')
+
+let harnessRoot: string
+let controlPath: string
+let chromiumExecutable: string
+let sidecarMode: string | undefined
+let provider: OrcadBrowserProvider | null
+
+/** Strips the session/profile/args prefix the agent-browser invocation carries. */
+function commandFromArgs(args: readonly string[]): string[] {
+  let index = 0
+  while (['--session', '--profile', '--args'].includes(args[index] ?? '')) {
+    index += 2
+  }
+  return args.slice(index, -1)
+}
+
+function agentBrowserSuccess(data: unknown) {
+  return Promise.resolve({
+    code: 0,
+    signal: null,
+    stdout: JSON.stringify({ success: true, data, error: null }),
+    stderr: '',
+    timedOut: false
+  })
+}
+
+beforeEach(async () => {
+  harnessRoot = await mkdtemp(join(tmpdir(), 'orcad-provider-selection-'))
+  controlPath = join(harnessRoot, 'control.json')
+  chromiumExecutable = join(harnessRoot, process.platform === 'win32' ? 'chromium.exe' : 'chromium')
+  sidecarMode = undefined
+  provider = null
+  await writeFile(controlPath, '{}')
+  await writeFile(chromiumExecutable, '')
+  if (process.platform !== 'win32') {
+    await chmod(chromiumExecutable, 0o755)
+  }
+
+  const actual = await vi.importActual<typeof RunProcessModule>(
+    '../../shared/child-process/run-process'
+  )
+  spawnProcessMock.mockReset()
+  spawnProcessMock.mockImplementation((spec: RunProcessModule.ProcessSpec) =>
+    actual.spawnProcess({
+      ...spec,
+      program: process.execPath,
+      args: [FAKE_SIDECAR, ...(spec.args ?? [])],
+      env: {
+        ...spec.env,
+        ORCA_FAKE_SIDECAR_CONTROL: controlPath,
+        ...(sidecarMode ? { ORCA_FAKE_SIDECAR_MODE: sidecarMode } : {})
+      }
+    })
+  )
+  runProcessMock.mockReset()
+  runProcessMock.mockImplementation(async (spec: RunProcessModule.ProcessSpec) => {
+    const command = commandFromArgs(spec.args ?? [])
+    if (command[0] === 'open') {
+      return agentBrowserSuccess({ url: 'about:blank', title: '' })
+    }
+    if (command[0] === 'tab') {
+      return agentBrowserSuccess({
+        tabs: [{ active: true, tabId: 't1', title: '', url: 'about:blank' }]
+      })
+    }
+    if (command[0] === 'close') {
+      return agentBrowserSuccess({ closed: true })
+    }
+    throw new Error(`Unexpected agent-browser command: ${command.join(' ')}`)
+  })
+})
+
+afterEach(async () => {
+  await provider?.stop()
+  vi.restoreAllMocks()
+  await rm(harnessRoot, { recursive: true, force: true })
+})
+
+describe('resolveOrcadBrowserProvider Electron preference', () => {
+  it('uses the installed Electron app even when a Chromium executable is configured', async () => {
+    provider = await resolveOrcadBrowserProvider({
+      userDataPath: join(harnessRoot, 'state'),
+      environment: { ORCA_BROWSER_EXECUTABLE: chromiumExecutable },
+      resolveInstalledElectronExecutable: async () => INSTALLED_EXECUTABLE,
+      resolveAgentBrowserBinary: () => '/agent-browser'
+    })
+
+    expect(provider?.kind).toBe('electron')
+    expect(provider?.isAvailable()).toBe(true)
+    expect(spawnProcessMock.mock.calls[0][0].program).toBe(INSTALLED_EXECUTABLE)
+    expect(runProcessMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the operator Chromium when the installed Electron app cannot start', async () => {
+    sidecarMode = 'exit-before-ready'
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    provider = await resolveOrcadBrowserProvider({
+      userDataPath: join(harnessRoot, 'state'),
+      environment: { ORCA_BROWSER_EXECUTABLE: chromiumExecutable },
+      resolveInstalledElectronExecutable: async () => INSTALLED_EXECUTABLE,
+      resolveAgentBrowserBinary: () => '/agent-browser'
+    })
+
+    expect(spawnProcessMock).toHaveBeenCalled()
+    expect(provider?.kind).toBe('chromium')
+    expect(warn).toHaveBeenCalledWith(
+      '[orcad] Installed Electron browser provider unavailable:',
+      expect.anything()
+    )
+  })
+
+  it('returns no provider when Electron fails and no Chromium is configured', async () => {
+    sidecarMode = 'exit-before-ready'
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+
+    provider = await resolveOrcadBrowserProvider({
+      userDataPath: join(harnessRoot, 'state'),
+      environment: {},
+      resolveInstalledElectronExecutable: async () => INSTALLED_EXECUTABLE,
+      resolveAgentBrowserBinary: () => '/agent-browser'
+    })
+
+    expect(provider).toBeNull()
+    expect(runProcessMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/orcad/electron-sidecar-method-routing.test.ts
+++ b/src/main/orcad/electron-sidecar-method-routing.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import { BROWSER_CORE_METHODS } from '../runtime/rpc/methods/browser-core'
+import { BROWSER_EXTRA_METHODS } from '../runtime/rpc/methods/browser-extras'
+import { BROWSER_SCREENCAST_METHODS } from '../runtime/rpc/methods/browser-screencast'
+import { electronSidecarRuntimeMethodName } from './electron-sidecar-method-routing'
+
+/**
+ * Why drive the real registry: the Electron provider reaches the sidecar by
+ * reversing a string transform, so a browser RPC method whose name is not a
+ * mechanical camel-case of its runtime command is silently unreachable — the
+ * sidecar answers "unknown method", not "wrong route".
+ */
+const BROWSER_RPC_METHODS = [
+  ...BROWSER_CORE_METHODS,
+  ...BROWSER_SCREENCAST_METHODS,
+  ...BROWSER_EXTRA_METHODS
+]
+
+/**
+ * Known-broken today (PR #16193 shipped these mis-routed): the RPC names drop
+ * the `Log` suffix that the runtime command carries. Fix the transform and
+ * delete the entry — do not add to this list to silence a new mismatch.
+ */
+const UNROUTABLE_RUNTIME_COMMANDS = new Set(['browserConsoleLog', 'browserNetworkLog'])
+
+/** `browser.screencast.unsubscribe` cleans up a subscription without a browser command. */
+const RPC_METHODS_WITHOUT_BROWSER_COMMAND = new Set(['browser.screencast.unsubscribe'])
+
+/** Records the `runtime.browserX` the handler dispatches to, without a live runtime. */
+async function runtimeCommandFor(
+  method: (typeof BROWSER_RPC_METHODS)[number]
+): Promise<string | null> {
+  let recorded: string | null = null
+  const runtime = new Proxy({} as Record<string, unknown>, {
+    get: (_target, property) => {
+      if (typeof property === 'string' && recorded === null && property.startsWith('browser')) {
+        recorded = property
+      }
+      return () => ({})
+    }
+  })
+  try {
+    await (method.handler as (...args: unknown[]) => Promise<unknown>)(
+      { value: '', input: '', text: '', subscriptionId: 'subscription' },
+      { runtime },
+      () => undefined
+    )
+  } catch {
+    // Handlers that guard on host state still record the property access above.
+  }
+  return recorded
+}
+
+describe('electronSidecarRuntimeMethodName', () => {
+  it('round-trips every registered browser RPC method', async () => {
+    const mismatches: string[] = []
+    const unmapped: string[] = []
+    for (const method of BROWSER_RPC_METHODS) {
+      const command = await runtimeCommandFor(method)
+      if (!command) {
+        unmapped.push(method.name)
+        continue
+      }
+      if (UNROUTABLE_RUNTIME_COMMANDS.has(command)) {
+        expect(electronSidecarRuntimeMethodName(command)).not.toBe(method.name)
+        continue
+      }
+      const routed = electronSidecarRuntimeMethodName(command)
+      if (routed !== method.name) {
+        mismatches.push(`${command} routes to ${routed}, sidecar registers ${method.name}`)
+      }
+    }
+    expect(mismatches).toEqual([])
+    expect(unmapped).toEqual([...RPC_METHODS_WITHOUT_BROWSER_COMMAND])
+  })
+
+  it('covers every registered browser method, so the round-trip cannot pass vacuously', async () => {
+    expect(BROWSER_RPC_METHODS.length).toBeGreaterThan(70)
+    expect(BROWSER_RPC_METHODS.map((method) => method.name)).toEqual(
+      expect.arrayContaining([
+        'browser.certificate.proceed',
+        'browser.viewport',
+        'browser.geolocation',
+        'browser.cookie.get',
+        'browser.intercept.enable',
+        'browser.capture.start',
+        'browser.storage.local.set',
+        'browser.storage.session.clear'
+      ])
+    )
+  })
+})

--- a/src/main/orcad/external-chromium-browser-process.integration.test.ts
+++ b/src/main/orcad/external-chromium-browser-process.integration.test.ts
@@ -7,6 +7,13 @@ import { resolveOrcadBrowserProvider } from './orcad-browser-provider'
 
 const executablePath = process.env.ORCA_BROWSER_EXECUTABLE
 
+// Why 120s rather than the 30s global default: one macOS run took 30s and timed out,
+// while a Linux run with an empty ~/.agent-browser was 2.8s — so the cost looks like a
+// one-time Gatekeeper/codesign verification of the Rust binary, not a Linux cold start.
+// Sized for the slow observation anyway: headroom on a passing test is free, and a
+// timeout here would land as a flaky required check.
+const COLD_BROWSER_START_TIMEOUT_MS = 120_000
+
 describe('ExternalChromiumBrowserProcess integration', () => {
   it.runIf(Boolean(executablePath))(
     'navigates, evaluates, and screenshots with the operator executable',
@@ -58,6 +65,7 @@ describe('ExternalChromiumBrowserProcess integration', () => {
         await provider?.stop()
         await rm(root, { recursive: true, force: true })
       }
-    }
+    },
+    COLD_BROWSER_START_TIMEOUT_MS
   )
 })

--- a/src/main/orcad/orcad-browser-provider.test.ts
+++ b/src/main/orcad/orcad-browser-provider.test.ts
@@ -2,12 +2,19 @@ import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { runProcess } from '../../shared/child-process/run-process'
+import { runProcess, spawnProcess } from '../../shared/child-process/run-process'
 import { ExternalChromiumBrowserProcess } from './external-chromium-browser-process'
 import { installedElectronCandidates, resolveOrcadBrowserProvider } from './orcad-browser-provider'
 import { orcadAgentBrowserNativeName } from './orcad-agent-browser-binary'
+import {
+  runtimeBrowserUnavailableCause,
+  setRuntimeBrowserUnavailableCause
+} from '../runtime/runtime-browser-commands-factory'
 
-vi.mock('../../shared/child-process/run-process', () => ({ runProcess: vi.fn() }))
+vi.mock('../../shared/child-process/run-process', () => ({
+  runProcess: vi.fn(),
+  spawnProcess: vi.fn()
+}))
 
 type BrowserState = {
   activeTabId: string
@@ -15,6 +22,7 @@ type BrowserState = {
 }
 
 const runProcessMock = vi.mocked(runProcess)
+const spawnProcessMock = vi.mocked(spawnProcess)
 let root: string
 let screenshotPath: string
 let browserState: BrowserState
@@ -80,7 +88,9 @@ beforeEach(async () => {
     tabs: [{ active: true, tabId: 't1', title: '', url: 'about:blank' }]
   }
   runProcessMock.mockReset()
+  spawnProcessMock.mockReset()
   installAgentBrowserMock()
+  setRuntimeBrowserUnavailableCause(null)
 })
 
 afterEach(async () => {
@@ -203,5 +213,140 @@ describe('resolveOrcadBrowserProvider', () => {
       })
     ).resolves.toBeNull()
     expect(runProcessMock).not.toHaveBeenCalled()
+    expect(runtimeBrowserUnavailableCause()).toEqual({ reason: 'unconfigured' })
+  })
+
+  it('reports a missing driver rather than falling through as unconfigured', async () => {
+    const executable = join(root, 'chromium')
+    await writeFile(executable, '')
+    if (process.platform !== 'win32') {
+      await chmod(executable, 0o755)
+    }
+
+    await expect(
+      resolveOrcadBrowserProvider({
+        userDataPath: root,
+        environment: { ORCA_BROWSER_EXECUTABLE: executable },
+        resolveInstalledElectronExecutable: async () => null,
+        resolveAgentBrowserBinary: () => null
+      })
+    ).resolves.toBeNull()
+    expect(runtimeBrowserUnavailableCause()).toEqual({ reason: 'driver_missing' })
+  })
+
+  it('reports an ORCA_BROWSER_EXECUTABLE path that does not exist', async () => {
+    const missing = join(root, 'absent-chromium')
+
+    await expect(
+      resolveOrcadBrowserProvider({
+        userDataPath: root,
+        environment: { ORCA_BROWSER_EXECUTABLE: missing },
+        resolveInstalledElectronExecutable: async () => null,
+        resolveAgentBrowserBinary: () => '/agent-browser'
+      })
+    ).resolves.toBeNull()
+    expect(runtimeBrowserUnavailableCause()).toEqual({
+      reason: 'executable_not_found',
+      detail: missing
+    })
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'separates a non-executable ORCA_BROWSER_EXECUTABLE from a missing one',
+    async () => {
+      const executable = join(root, 'unchmodded-chromium')
+      await writeFile(executable, '')
+      await chmod(executable, 0o644)
+
+      await expect(
+        resolveOrcadBrowserProvider({
+          userDataPath: root,
+          environment: { ORCA_BROWSER_EXECUTABLE: executable },
+          resolveInstalledElectronExecutable: async () => null,
+          resolveAgentBrowserBinary: () => '/agent-browser'
+        })
+      ).resolves.toBeNull()
+      expect(runtimeBrowserUnavailableCause()).toEqual({
+        reason: 'executable_not_executable',
+        detail: executable
+      })
+    }
+  )
+
+  it('reports a failed Electron start instead of staying invisible to the client', async () => {
+    spawnProcessMock.mockImplementation(() => {
+      throw new Error('spawn ENOENT')
+    })
+
+    await expect(
+      resolveOrcadBrowserProvider({
+        userDataPath: root,
+        environment: {},
+        resolveInstalledElectronExecutable: async () => '/opt/Orca/orca-ide',
+        resolveAgentBrowserBinary: () => '/agent-browser'
+      })
+    ).resolves.toBeNull()
+    expect(runtimeBrowserUnavailableCause()).toEqual({
+      reason: 'electron_start_failed',
+      detail: 'spawn ENOENT'
+    })
+  })
+
+  it('prefers the configured Chromium fault over an earlier Electron failure', async () => {
+    spawnProcessMock.mockImplementation(() => {
+      throw new Error('spawn ENOENT')
+    })
+
+    await expect(
+      resolveOrcadBrowserProvider({
+        userDataPath: root,
+        environment: { ORCA_BROWSER_EXECUTABLE: join(root, 'absent-chromium') },
+        resolveInstalledElectronExecutable: async () => '/opt/Orca/orca-ide',
+        resolveAgentBrowserBinary: () => null
+      })
+    ).resolves.toBeNull()
+    expect(runtimeBrowserUnavailableCause()).toEqual({ reason: 'driver_missing' })
+  })
+
+  it('reports a failed Chromium launch with the underlying error', async () => {
+    const executable = join(root, 'chromium')
+    await writeFile(executable, '')
+    if (process.platform !== 'win32') {
+      await chmod(executable, 0o755)
+    }
+    runProcessMock.mockRejectedValue(new Error('spawn EACCES'))
+
+    await expect(
+      resolveOrcadBrowserProvider({
+        userDataPath: root,
+        environment: { ORCA_BROWSER_EXECUTABLE: executable },
+        resolveInstalledElectronExecutable: async () => null,
+        resolveAgentBrowserBinary: () => '/agent-browser'
+      })
+    ).resolves.toBeNull()
+    expect(runtimeBrowserUnavailableCause()).toEqual({
+      reason: 'chromium_start_failed',
+      detail: 'spawn EACCES'
+    })
+  })
+
+  it('clears any recorded cause once a provider resolves', async () => {
+    const executable = join(root, 'chromium')
+    await writeFile(executable, '')
+    if (process.platform !== 'win32') {
+      await chmod(executable, 0o755)
+    }
+    setRuntimeBrowserUnavailableCause({ reason: 'driver_missing' })
+
+    const provider = await resolveOrcadBrowserProvider({
+      userDataPath: root,
+      environment: { ORCA_BROWSER_EXECUTABLE: executable },
+      resolveInstalledElectronExecutable: async () => null,
+      resolveAgentBrowserBinary: () => '/agent-browser'
+    })
+
+    expect(provider?.kind).toBe('chromium')
+    expect(runtimeBrowserUnavailableCause()).toEqual({ reason: 'unknown' })
+    await provider?.stop()
   })
 })

--- a/src/main/orcad/orcad-browser-provider.ts
+++ b/src/main/orcad/orcad-browser-provider.ts
@@ -2,7 +2,11 @@ import { access, mkdir } from 'node:fs/promises'
 import { constants } from 'node:fs'
 import { homedir } from 'node:os'
 import { posix, win32 } from 'node:path'
-import type { RuntimeBrowserCommandsFactory } from '../runtime/runtime-browser-commands-factory'
+import {
+  setRuntimeBrowserUnavailableCause,
+  type RuntimeBrowserCommandsFactory,
+  type RuntimeBrowserUnavailableCause
+} from '../runtime/runtime-browser-commands-factory'
 import {
   ExternalChromiumBrowserProcess,
   type ExternalChromiumLaunch
@@ -24,13 +28,33 @@ export type OrcadBrowserProviderOptions = {
   resolveAgentBrowserBinary?: () => string | null
 }
 
-async function executableExists(path: string): Promise<boolean> {
+type ExecutableProbe = 'ok' | 'missing' | 'not_executable'
+
+/** Splits the two failures apart: a wrong path and a forgotten chmod +x need different fixes. */
+async function probeExecutable(path: string): Promise<ExecutableProbe> {
+  const mode = process.platform === 'win32' ? constants.F_OK : constants.X_OK
   try {
-    await access(path, process.platform === 'win32' ? constants.F_OK : constants.X_OK)
-    return true
+    await access(path, mode)
+    return 'ok'
   } catch {
-    return false
+    if (mode === constants.F_OK) {
+      return 'missing'
+    }
   }
+  try {
+    await access(path, constants.F_OK)
+    return 'not_executable'
+  } catch {
+    return 'missing'
+  }
+}
+
+async function executableExists(path: string): Promise<boolean> {
+  return (await probeExecutable(path)) === 'ok'
+}
+
+function errorDetail(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
 }
 
 export function installedElectronCandidates(
@@ -115,27 +139,50 @@ export async function resolveOrcadBrowserProvider(
   const environment = options.environment ?? process.env
   await mkdir(options.userDataPath, { recursive: true, mode: 0o700 })
 
+  const declined = (cause: RuntimeBrowserUnavailableCause): null => {
+    setRuntimeBrowserUnavailableCause(cause)
+    return null
+  }
+
   const installedElectronExecutable = await (
     options.resolveInstalledElectronExecutable ?? resolveInstalledElectronExecutable
   )()
+  // Why held rather than reported now: Chromium may still resolve, and if it does not, its
+  // own concrete fault is the more actionable one for an operator who set the env var.
+  let electronFailure: RuntimeBrowserUnavailableCause | null = null
   if (installedElectronExecutable) {
     try {
+      setRuntimeBrowserUnavailableCause(null)
       return await startElectronServeProvider(installedElectronExecutable)
     } catch (error) {
       console.warn('[orcad] Installed Electron browser provider unavailable:', error)
+      electronFailure = { reason: 'electron_start_failed', detail: errorDetail(error) }
     }
   }
-  const agentBrowserPath = (options.resolveAgentBrowserBinary ?? resolveOrcadAgentBrowserBinary)()
 
-  if (!agentBrowserPath) {
-    return null
-  }
-
+  // Why the env var is read before the driver: with it set, a missing driver is a driver
+  // problem, not an unconfigured host. Telling someone to set ORCA_BROWSER_EXECUTABLE when
+  // they already did is the misdirection this ordering exists to prevent.
   const chromiumExecutable = environment.ORCA_BROWSER_EXECUTABLE?.trim()
-  if (!chromiumExecutable || !(await executableExists(chromiumExecutable))) {
-    return null
+  if (!chromiumExecutable) {
+    return declined(electronFailure ?? { reason: 'unconfigured' })
   }
+
+  const agentBrowserPath = (options.resolveAgentBrowserBinary ?? resolveOrcadAgentBrowserBinary)()
+  if (!agentBrowserPath) {
+    return declined({ reason: 'driver_missing' })
+  }
+
+  const probe = await probeExecutable(chromiumExecutable)
+  if (probe !== 'ok') {
+    return declined({
+      reason: probe === 'missing' ? 'executable_not_found' : 'executable_not_executable',
+      detail: chromiumExecutable
+    })
+  }
+
   try {
+    setRuntimeBrowserUnavailableCause(null)
     return await startProvider(
       agentBrowserPath,
       { executablePath: chromiumExecutable, provider: 'chromium' },
@@ -143,6 +190,6 @@ export async function resolveOrcadBrowserProvider(
     )
   } catch (error) {
     console.warn('[orcad] External Chromium browser provider unavailable:', error)
-    return null
+    return declined({ reason: 'chromium_start_failed', detail: errorDetail(error) })
   }
 }

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1,7 +1,10 @@
 /* eslint-disable max-lines -- Why: runtime behavior is stateful and cross-cutting, so these tests stay in one file to preserve the end-to-end invariants around handles, waits, and graph sync. */
 import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from 'vitest'
 import { RuntimeBrowserCommands } from './orca-runtime-browser'
-import { setRuntimeBrowserCommandsFactory } from './runtime-browser-commands-factory'
+import {
+  setRuntimeBrowserCommandsFactory,
+  setRuntimeBrowserUnavailableCause
+} from './runtime-browser-commands-factory'
 import { setRuntimeDesktopSurface } from './runtime-desktop-surface'
 import { installFakeAppEnvironment } from '../../../config/scripts/vitest-host-ports-setup'
 import type * as GitUsernameModule from '../git/git-username'
@@ -687,6 +690,7 @@ function resetRuntimeTestMocks(): void {
   // production installs this at the Electron entry. A Node host installs none and the
   // browser RPCs reject rather than silently succeeding.
   setRuntimeBrowserCommandsFactory((host) => new RuntimeBrowserCommands(host))
+  setRuntimeBrowserUnavailableCause(null)
   // Why: the runtime's notification, window lookup and tab-create-reply channel are
   // injected now, so the electron mock alone is inert. Back the surface with the same
   // mocks so every existing expectation still holds.
@@ -2355,8 +2359,14 @@ describe('OrcaRuntimeService', () => {
     available = false
     const degraded = createRuntime().getStatus()
     expect(degraded.capabilities).not.toContain('browser.headless.v1')
+    // A provider that resolved and then died is a health failure, never a config mistake.
     expect(degraded.degradations).toEqual([
-      expect.objectContaining({ code: 'browser_unavailable' })
+      {
+        code: 'browser_unavailable',
+        capability: 'browser.headless.v1',
+        reason: 'provider_unhealthy',
+        message: 'The browser provider started but is no longer answering health checks.'
+      }
     ])
   })
   it('surfaces live offscreen load failures in headless browser snapshots', () => {
@@ -2498,7 +2508,9 @@ describe('OrcaRuntimeService', () => {
       {
         code: 'browser_unavailable',
         capability: 'browser.headless.v1',
-        message: 'Browser automation requires the Electron provider or ORCA_BROWSER_EXECUTABLE.'
+        reason: 'unknown',
+        message:
+          'Browser automation is unavailable on this host, and the cause could not be determined.'
       }
     ])
     const browserCalls = Object.entries(runtime).filter(
@@ -2518,6 +2530,66 @@ describe('OrcaRuntimeService', () => {
         code: 'browser_unavailable'
       })
     }
+  })
+
+  it('reports the driver as missing instead of telling a configured operator to configure it', () => {
+    setRuntimeBrowserCommandsFactory(null)
+    setRuntimeBrowserUnavailableCause({ reason: 'driver_missing' })
+
+    const [degradation] = createRuntime().getStatus().degradations ?? []
+
+    expect(degradation).toEqual({
+      code: 'browser_unavailable',
+      capability: 'browser.headless.v1',
+      reason: 'driver_missing',
+      message:
+        'ORCA_BROWSER_EXECUTABLE is set, but the bundled agent-browser driver is missing or not executable on this host, so Chromium cannot be driven.'
+    })
+    // The whole point: never send someone to set a variable they already set.
+    expect(degradation?.message).not.toMatch(/set ORCA_BROWSER_EXECUTABLE/)
+  })
+
+  it('carries the underlying error to the client when a provider failed to start', () => {
+    setRuntimeBrowserCommandsFactory(null)
+    setRuntimeBrowserUnavailableCause({
+      reason: 'electron_start_failed',
+      detail: 'sidecar exited with code 1'
+    })
+
+    const [degradation] = createRuntime().getStatus().degradations ?? []
+
+    expect(degradation).toEqual({
+      code: 'browser_unavailable',
+      capability: 'browser.headless.v1',
+      reason: 'electron_start_failed',
+      detail: 'sidecar exited with code 1',
+      message:
+        'The installed Electron browser provider failed to start. (sidecar exited with code 1)'
+    })
+  })
+
+  it('blames the missing desktop window when a renderer-backed factory is installed', () => {
+    const [degradation] = createRuntime().getStatus().degradations ?? []
+
+    expect(degradation).toMatchObject({
+      reason: 'desktop_window_unavailable',
+      message: 'Browser automation on this host needs a desktop window, and none is available.'
+    })
+  })
+
+  it('keeps the degradation wire-safe for peers that predate structured causes', () => {
+    setRuntimeBrowserCommandsFactory(null)
+    setRuntimeBrowserUnavailableCause({ reason: 'executable_not_found', detail: '/nope/chromium' })
+
+    const [degradation] = createRuntime().getStatus().degradations ?? []
+
+    // Old clients read only these three: the closed code must not move and the human
+    // sentence must stand alone without the optional fields.
+    expect(degradation?.code).toBe('browser_unavailable')
+    expect(degradation?.capability).toBe('browser.headless.v1')
+    expect(degradation?.message).toBe(
+      'ORCA_BROWSER_EXECUTABLE points at a path that does not exist. (/nope/chromium)'
+    )
   })
 
   it('closes a worktree’s offscreen browser pages when its metadata is removed (leak fix)', () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -426,7 +426,9 @@ import type {
 } from '../../shared/linear/agent-access'
 import {
   BROWSER_UNAVAILABLE_ERROR_CODE,
+  browserUnavailableMessage,
   HEADLESS_RUNTIME_WINDOW_ID,
+  type RuntimeDegradation,
   type RuntimeDesktopWindowStatus,
   type RuntimeGraphStatus,
   type RuntimeRepoSearchRefs,
@@ -661,7 +663,8 @@ import type { AutomationService } from '../automations/service'
 import type { RuntimeBrowserCommands } from './orca-runtime-browser'
 import {
   createRuntimeBrowserCommands,
-  runtimeBrowserCommandsFactoryIsHeadless
+  runtimeBrowserCommandsFactoryIsHeadless,
+  runtimeBrowserUnavailableCause
 } from './runtime-browser-commands-factory'
 import { RemoteRuntimeTerminalCreateIdempotency } from './remote-runtime-terminal-create-idempotency'
 import { deriveRemoteRuntimeTerminalCreateHandle } from './remote-runtime-terminal-create-identity'
@@ -6156,17 +6159,21 @@ export class OrcaRuntimeService {
     if (canBrowse) {
       capabilities.push(BROWSER_CERTIFICATE_TRUST_RUNTIME_CAPABILITY)
     }
-    const degradations =
-      canBrowse || hasHeadlessCommands
-        ? []
-        : [
-            {
-              code: BROWSER_UNAVAILABLE_ERROR_CODE,
-              capability: BROWSER_HEADLESS_RUNTIME_CAPABILITY,
-              message:
-                'Browser automation requires the Electron provider or ORCA_BROWSER_EXECUTABLE.'
-            }
-          ]
+    // Why the cause and not one fixed sentence: the operator can only act on the reason
+    // that actually applies, and a host that says "set ORCA_BROWSER_EXECUTABLE" to someone
+    // who already set it sends them to fix a thing that is not broken.
+    const cause = canBrowse || hasHeadlessCommands ? null : runtimeBrowserUnavailableCause()
+    const degradations: RuntimeDegradation[] = cause
+      ? [
+          {
+            code: BROWSER_UNAVAILABLE_ERROR_CODE,
+            capability: BROWSER_HEADLESS_RUNTIME_CAPABILITY,
+            message: browserUnavailableMessage(cause.reason, cause.detail),
+            reason: cause.reason,
+            ...(cause.detail ? { detail: cause.detail } : {})
+          }
+        ]
+      : []
     return {
       runtimeId: this.runtimeId,
       rendererGraphEpoch: this.rendererGraphEpoch,

--- a/src/main/runtime/runtime-browser-commands-factory.ts
+++ b/src/main/runtime/runtime-browser-commands-factory.ts
@@ -1,5 +1,8 @@
 import { BrowserError } from '../browser/browser-error'
-import { BROWSER_UNAVAILABLE_ERROR_CODE } from '../../shared/runtime-types'
+import {
+  BROWSER_UNAVAILABLE_ERROR_CODE,
+  type RuntimeBrowserUnavailableReason
+} from '../../shared/runtime-types'
 import type { RuntimeBrowserCommandHost, RuntimeBrowserCommands } from './orca-runtime-browser'
 
 /**
@@ -52,6 +55,37 @@ export function runtimeBrowserCommandsFactoryIsAvailable(): boolean {
 
 export function runtimeBrowserCommandsFactoryIsHeadless(): boolean {
   return runtimeBrowserCommandsFactoryIsAvailable() && currentOptions.headless === true
+}
+
+export type RuntimeBrowserUnavailableCause = {
+  reason: RuntimeBrowserUnavailableReason
+  detail?: string
+}
+
+let unavailableCause: RuntimeBrowserUnavailableCause | null = null
+
+/**
+ * Recorded by whoever tried to resolve a provider, because only that code can tell a
+ * missing driver from an unset env var from a launch that threw. Null once one resolves.
+ */
+export function setRuntimeBrowserUnavailableCause(
+  cause: RuntimeBrowserUnavailableCause | null
+): void {
+  unavailableCause = cause
+}
+
+/**
+ * The cause this process can prove. An installed factory outranks any recorded note: it
+ * means resolution succeeded, so the failure is later and elsewhere — a dead provider, or
+ * a renderer-backed factory with no window. Unknown beats guessing.
+ */
+export function runtimeBrowserUnavailableCause(): RuntimeBrowserUnavailableCause {
+  if (currentFactory) {
+    return runtimeBrowserCommandsFactoryIsAvailable()
+      ? { reason: 'desktop_window_unavailable' }
+      : { reason: 'provider_unhealthy' }
+  }
+  return unavailableCause ?? { reason: 'unknown' }
 }
 
 /**

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -67,10 +67,60 @@ export type RuntimeBrowserDriverState = RuntimeTerminalDriverState
 
 export const BROWSER_UNAVAILABLE_ERROR_CODE = 'browser_unavailable' as const
 
+/**
+ * Why a host declined browser automation. Members are opaque to clients: new ones
+ * ship without a protocol bump, so render `message` and never switch exhaustively
+ * (same contract as RuntimeTerminalWaitBlockedReason).
+ */
+export type RuntimeBrowserUnavailableReason =
+  | 'unconfigured'
+  | 'driver_missing'
+  | 'executable_not_found'
+  | 'executable_not_executable'
+  | 'electron_start_failed'
+  | 'chromium_start_failed'
+  | 'provider_unhealthy'
+  | 'desktop_window_unavailable'
+  | 'unknown'
+
+// Why: one sentence per cause, each naming the thing the operator can change. The host
+// renders these so an older client still shows an accurate reason it cannot decode.
+const BROWSER_UNAVAILABLE_MESSAGES: Record<RuntimeBrowserUnavailableReason, string> = {
+  unconfigured:
+    'Browser automation has no backend on this host. Install the Orca desktop app, or set ORCA_BROWSER_EXECUTABLE to a Chromium executable.',
+  driver_missing:
+    'ORCA_BROWSER_EXECUTABLE is set, but the bundled agent-browser driver is missing or not executable on this host, so Chromium cannot be driven.',
+  executable_not_found: 'ORCA_BROWSER_EXECUTABLE points at a path that does not exist.',
+  executable_not_executable:
+    'ORCA_BROWSER_EXECUTABLE points at a file that is not executable by this host.',
+  electron_start_failed: 'The installed Electron browser provider failed to start.',
+  chromium_start_failed:
+    'The Chromium browser provider named by ORCA_BROWSER_EXECUTABLE failed to start.',
+  provider_unhealthy: 'The browser provider started but is no longer answering health checks.',
+  desktop_window_unavailable:
+    'Browser automation on this host needs a desktop window, and none is available.',
+  unknown: 'Browser automation is unavailable on this host, and the cause could not be determined.'
+}
+
+export function browserUnavailableMessage(
+  reason: RuntimeBrowserUnavailableReason,
+  detail?: string
+): string {
+  const base = BROWSER_UNAVAILABLE_MESSAGES[reason]
+  return detail ? `${base} (${detail})` : base
+}
+
 export type RuntimeDegradation = {
   code: typeof BROWSER_UNAVAILABLE_ERROR_CODE
   capability: 'browser.headless.v1'
   message: string
+  /**
+   * Machine-readable cause. Optional for mixed-version peers: absence means the host
+   * predates structured causes, NOT that the cause is 'unconfigured'.
+   */
+  reason?: RuntimeBrowserUnavailableReason
+  /** Underlying error text when the host has one. Diagnostic only; never load-bearing. */
+  detail?: string
 }
 
 export type RuntimeStatus = {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​967 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​961 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​243 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​27 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​216 |

<!-- /orca-pr-loc -->

Plan item 0 from `docs/design/shipping-orcad.html`. It goes first because every later item edits runtime code, and that is the window a re-coupling lands in — the guard exists because a dead terminal daemon once shipped from exactly that regression.

Two gaps the artifact's own comment asked for.

## The ratchet was measuring the wrong graph

It covered `orca-runtime` + `runtime-rpc`, but `orcad` imports `ipc/pty` directly to install the PTY controller, so its graph is strictly larger. **The gate could read zero while the shipped artifact regressed.** `orcad`'s entry is now a ratchet entry point; the baseline stays empty with it included.

## A static scan cannot prove the bundle loads

`orcad` cannot join `plain-node-entry-guard` — that is a rollup plugin keyed on electron-vite input names, and `orcad` is an esbuild artifact. But the half that matters here is the guard's **smoke-load**.

Reading the metafile proves no module *names* electron. It does not prove the graph *resolves* under plain Node: a dynamic require, a missing native, or a top-level throw all pass the scan and die at runtime. `build-orcad` now runs the built bundle with a bogus flag and requires the argv rejection that only a fully loaded graph can produce.

**Verified it bites** — a bundle that builds but throws on load:

```
[build-orcad] the bundle did not load under plain Node.
Expected argv rejection, got signal=none error=none
out/orcad/orcad.js:1
throw new Error('simulated load failure')
EXIT=1
```

## Proof

Ratchet 0 with the larger graph included; `build-orcad` green; `smoke:orcad-terminal` passes; typecheck and lint clean.

## Trade-offs

Zero user-facing — this is build-time gating only.