### PR TITLE
fix(orcad): answer host paths honestly and ship the watcher child

### DIFF
--- a/config/scripts/build-orcad.mjs
+++ b/config/scripts/build-orcad.mjs
@@ -7,16 +7,21 @@
  * the only ones that statically import `node:sqlite`, so dropping them is what keeps
  * the host Node floor at 18 instead of 22.5+.
  */
-import { spawnSync } from 'node:child_process'
+import { fork, spawnSync } from 'node:child_process'
 import { build } from 'esbuild'
-import { chmodSync, copyFileSync, mkdirSync, rmSync } from 'node:fs'
-import { arch, platform } from 'node:os'
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { arch, platform, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import process from 'node:process'
 
 const ROOT = join(import.meta.dirname, '..', '..')
 const OUT_DIR = join(ROOT, 'out', 'orcad')
 const ENTRY = join(ROOT, 'src/main/orcad/main.ts')
+// Why beside orcad.js: the watcher runs in a forked child so a native @parcel/watcher
+// fault crashes that child instead of the server, and `resolveWatcherProcessEntryPath`
+// looks for it in the app root. A deployment has no desktop out/main to fall back to.
+const WATCHER_ENTRY = join(ROOT, 'src/main/ipc/parcel-watcher-process-entry.ts')
+const WATCHER_OUT_FILE = join(OUT_DIR, 'parcel-watcher-process-entry.js')
 const AGENT_BROWSER_NAME = `agent-browser-${platform()}-${arch()}${process.platform === 'win32' ? '.exe' : ''}`
 const OUT_FILE = join(OUT_DIR, 'orcad.js')
 const AGENT_BROWSER_SOURCE = join(ROOT, 'node_modules', 'agent-browser', 'bin', AGENT_BROWSER_NAME)
@@ -58,6 +63,21 @@ copyFileSync(AGENT_BROWSER_SOURCE, AGENT_BROWSER_OUTPUT)
 if (process.platform !== 'win32') {
   chmodSync(AGENT_BROWSER_OUTPUT, 0o755)
 }
+
+await build({
+  entryPoints: [WATCHER_ENTRY],
+  bundle: true,
+  platform: 'node',
+  target: 'node18',
+  format: 'cjs',
+  outfile: WATCHER_OUT_FILE,
+  external: EXTERNAL,
+  plugins: [externalNativeAddons],
+  minify: true,
+  sourcemap: false,
+  define: { 'process.env.NODE_ENV': '"production"' },
+  logLevel: 'error'
+})
 
 const result = await build({
   entryPoints: [ENTRY],
@@ -144,10 +164,61 @@ if (graphErrors.length > 0) {
     )
     process.exitCode = 1
   }
+  const watcherFailure = await smokeLoadWatcherChild()
+  if (watcherFailure) {
+    console.error(
+      `[build-orcad] the watcher child did not run under plain Node.\n${watcherFailure}`
+    )
+    process.exitCode = 1
+  }
 }
 
 if (process.exitCode !== 1) {
   console.log(
     `[build-orcad] ok — ${(output.bytes / 1024 / 1024).toFixed(2)} MB, ${Object.keys(output.inputs).length} modules, zero electron and node:sqlite imports.`
   )
+}
+
+/**
+ * Fork the shipped watcher child and drive one message through it.
+ *
+ * Why a real fork and not existsSync: the file being present says nothing about whether
+ * its graph resolves under plain Node, and this child is only ever reached through
+ * `fork()` at runtime — a broken one degrades silently to in-process watching.
+ * `subscribe-started` is acked before the native module is touched, so this passes on a
+ * build machine with no compiled @parcel/watcher.
+ */
+async function smokeLoadWatcherChild() {
+  const probeDir = mkdtempSync(join(tmpdir(), 'orcad-watcher-smoke-'))
+  const child = fork(WATCHER_OUT_FILE, [], { stdio: ['ignore', 'ignore', 'pipe', 'ipc'] })
+  let stderr = ''
+  child.stderr?.on('data', (chunk) => {
+    stderr += String(chunk)
+  })
+  try {
+    return await new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        child.kill('SIGKILL')
+        resolve(`No 'subscribe-started' ack within 30s.\n${stderr.slice(0, 2000)}`)
+      }, 30_000)
+      const settle = (failure) => {
+        clearTimeout(timer)
+        resolve(failure)
+      }
+      child.on('message', (message) => {
+        if (message?.op === 'subscribe-started') {
+          child.disconnect()
+        }
+      })
+      child.on('error', (error) => settle(`fork failed: ${error.message}`))
+      // Why exit and not disconnect: the child exits 0 on disconnect, so a non-zero code
+      // or a signal here is a load failure rather than a clean teardown.
+      child.on('exit', (code, signal) =>
+        settle(code === 0 ? null : `exit code=${code} signal=${signal}\n${stderr.slice(0, 2000)}`)
+      )
+      child.send({ op: 'subscribe', id: 1, dir: probeDir, opts: {} })
+    })
+  } finally {
+    rmSync(probeDir, { recursive: true, force: true })
+  }
 }

--- a/src/main/ipc/parcel-watcher-entry-path.test.ts
+++ b/src/main/ipc/parcel-watcher-entry-path.test.ts
@@ -41,6 +41,25 @@ describe('resolveWatcherProcessEntryPath', () => {
     )
   })
 
+  it('uses the adjacent entry for a packaged host whose app root is not an asar', () => {
+    // orcad: a packaged Node bundle that ships this child beside orcad.js. Gating the
+    // adjacent probe on isPackaged sent it to a desktop out/main that never exists here.
+    const orcadRoot = path.join(path.sep, 'opt', 'orca')
+    const adjacentEntry = path.join(orcadRoot, 'parcel-watcher-process-entry.js')
+
+    expect(
+      resolveWatcherProcessEntryPath(orcadRoot, true, (candidate) => candidate === adjacentEntry)
+    ).toBe(adjacentEntry)
+  })
+
+  it('falls back to the nested entry when a non-asar packaged host ships no adjacent child', () => {
+    const orcadRoot = path.join(path.sep, 'opt', 'orca')
+
+    expect(resolveWatcherProcessEntryPath(orcadRoot, true, () => false)).toBe(
+      path.join(orcadRoot, 'out', 'main', 'parcel-watcher-process-entry.js')
+    )
+  })
+
   it('uses resourcesPath for packaged Electron-as-Node serve processes', () => {
     const resourcesPath = path.join('Applications', 'Orca.app', 'Contents', 'Resources')
     const packagedEntry = path.join(

--- a/src/main/ipc/parcel-watcher-entry-path.ts
+++ b/src/main/ipc/parcel-watcher-entry-path.ts
@@ -18,11 +18,15 @@ export function resolveWatcherProcessEntryPath(
 ): string {
   // Why: ELECTRON_RUN_AS_NODE bypasses Electron's asar integration, so the
   // packaged entry must be forked from app.asar.unpacked.
-  const basePath = isPackaged ? appPath.replace('app.asar', 'app.asar.unpacked') : appPath
+  const usesAsarArchive = isPackaged && appPath.includes('app.asar')
+  const basePath = usesAsarArchive ? appPath.replace('app.asar', 'app.asar.unpacked') : appPath
   const adjacentBuildEntry = join(basePath, 'parcel-watcher-process-entry.js')
   // Why: electron-vite's unpackaged appPath is already out/main. Appending
   // out/main again silently disables crash isolation in dev and E2E builds.
-  if (!isPackaged && pathExists(adjacentBuildEntry)) {
+  // Why asar and not isPackaged: orcad is a packaged non-Electron host whose app root
+  // holds orcad.js and this child side by side. Only the asar layout nests it under
+  // out/main, and only there is the adjacent probe guaranteed to miss.
+  if (!usesAsarArchive && pathExists(adjacentBuildEntry)) {
     return adjacentBuildEntry
   }
   return join(basePath, 'out', 'main', 'parcel-watcher-process-entry.js')

--- a/src/main/orcad/orcad-app-paths.test.ts
+++ b/src/main/orcad/orcad-app-paths.test.ts
@@ -1,0 +1,122 @@
+import { homedir, tmpdir } from 'node:os'
+import { join, sep } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { AppPathName } from '../../shared/app-environment'
+import { resolveOrcadInstallRoot, resolveOrcadPath, resolveUserDataPath } from './orcad-app-paths'
+
+const ALL_PATH_NAMES: AppPathName[] = [
+  'userData',
+  'home',
+  'appData',
+  'temp',
+  'downloads',
+  'logs',
+  'exe'
+]
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+
+function setPlatform(value: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { configurable: true, value })
+}
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', originalPlatform)
+  vi.unstubAllEnvs()
+})
+
+describe('resolveUserDataPath', () => {
+  it('prefers ORCA_USER_DATA, then XDG_DATA_HOME, then ~/.orca', () => {
+    vi.stubEnv('ORCA_USER_DATA', join(sep, 'srv', 'orca-state'))
+    vi.stubEnv('XDG_DATA_HOME', join(sep, 'xdg'))
+    expect(resolveUserDataPath()).toBe(join(sep, 'srv', 'orca-state'))
+
+    vi.stubEnv('ORCA_USER_DATA', '')
+    expect(resolveUserDataPath()).toBe(join(sep, 'xdg', 'Orca'))
+
+    vi.stubEnv('XDG_DATA_HOME', '')
+    expect(resolveUserDataPath()).toBe(join(homedir(), '.orca'))
+  })
+})
+
+describe('resolveOrcadPath', () => {
+  it('answers every path name without ever falling back to the data directory', () => {
+    vi.stubEnv('ORCA_USER_DATA', join(sep, 'srv', 'orca-state'))
+    const answers = new Map(ALL_PATH_NAMES.map((name) => [name, resolveOrcadPath(name)]))
+
+    for (const [name, answer] of answers) {
+      expect(answer, `${name} answered nothing`).toBeTruthy()
+      if (name !== 'userData') {
+        // The catch-all this replaced returned the data directory for four of seven
+        // names, 'exe' included — a data directory is not an executable.
+        expect(answer, `${name} answered the userData directory`).not.toBe(
+          join(sep, 'srv', 'orca-state')
+        )
+      }
+    }
+  })
+
+  it("answers 'exe' with the Node binary running this process", () => {
+    expect(resolveOrcadPath('exe')).toBe(process.execPath)
+  })
+
+  it("keeps 'logs' inside the data root so the whole deployment is one directory", () => {
+    vi.stubEnv('ORCA_USER_DATA', join(sep, 'srv', 'orca-state'))
+    expect(resolveOrcadPath('logs')).toBe(join(sep, 'srv', 'orca-state', 'logs'))
+  })
+
+  it("answers 'home' and 'temp' from the OS", () => {
+    expect(resolveOrcadPath('home')).toBe(homedir())
+    expect(resolveOrcadPath('temp')).toBe(tmpdir())
+  })
+
+  it("answers 'appData' with the per-user application-data root of each platform", () => {
+    setPlatform('darwin')
+    expect(resolveOrcadPath('appData')).toBe(join(homedir(), 'Library', 'Application Support'))
+
+    setPlatform('win32')
+    vi.stubEnv('APPDATA', join('C:', 'Users', 'orca', 'AppData', 'Roaming'))
+    expect(resolveOrcadPath('appData')).toBe(join('C:', 'Users', 'orca', 'AppData', 'Roaming'))
+    vi.stubEnv('APPDATA', '')
+    expect(resolveOrcadPath('appData')).toBe(join(homedir(), 'AppData', 'Roaming'))
+
+    setPlatform('linux')
+    vi.stubEnv('XDG_CONFIG_HOME', join(sep, 'xdg-config'))
+    expect(resolveOrcadPath('appData')).toBe(join(sep, 'xdg-config'))
+    vi.stubEnv('XDG_CONFIG_HOME', '')
+    expect(resolveOrcadPath('appData')).toBe(join(homedir(), '.config'))
+  })
+
+  it("answers 'downloads' from XDG_DOWNLOAD_DIR before the home default", () => {
+    vi.stubEnv('XDG_DOWNLOAD_DIR', join(sep, 'srv', 'incoming'))
+    expect(resolveOrcadPath('downloads')).toBe(join(sep, 'srv', 'incoming'))
+
+    vi.stubEnv('XDG_DOWNLOAD_DIR', '')
+    expect(resolveOrcadPath('downloads')).toBe(join(homedir(), 'Downloads'))
+  })
+})
+
+describe('resolveOrcadInstallRoot', () => {
+  it('is the directory holding the running bundle, not the working directory', () => {
+    expect(resolveOrcadInstallRoot(join(sep, 'opt', 'orca', 'orcad.js'))).toBe(
+      join(sep, 'opt', 'orca')
+    )
+  })
+
+  it('absolutizes a relative script path against the working directory', () => {
+    expect(resolveOrcadInstallRoot(join('out', 'orcad', 'orcad.js'))).toBe(
+      join(process.cwd(), 'out', 'orcad')
+    )
+  })
+
+  it('refuses instead of guessing when the process has no main script', () => {
+    const originalArgv = process.argv
+    // `node -e` leaves argv[1] unset; cwd would be a guess, not an answer.
+    process.argv = [process.execPath]
+    try {
+      expect(() => resolveOrcadInstallRoot()).toThrow(/orcad_install_root_unavailable/)
+    } finally {
+      process.argv = originalArgv
+    }
+  })
+})

--- a/src/main/orcad/orcad-app-paths.ts
+++ b/src/main/orcad/orcad-app-paths.ts
@@ -1,0 +1,82 @@
+/**
+ * The path half of orcad's `AppEnvironment`: every `AppPathName` gets a real answer for
+ * a Node host, or throws.
+ *
+ * Why not a catch-all: returning the data directory for names this host had not thought
+ * about — `'exe'` above all — hands the caller a plausible string it then forks, installs
+ * beside, or resolves resources against. The failure surfaces far from here, as a missing
+ * file rather than a missing implementation.
+ */
+import { homedir, tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import process from 'node:process'
+import type { AppPathName } from '../../shared/app-environment'
+
+/** Empty is unset: a supervisor that exports `APPDATA=` has configured nothing. */
+function env(name: string): string | null {
+  const value = process.env[name]
+  return value ? value : null
+}
+
+/** XDG-ish data root. `$ORCA_USER_DATA` wins so a smoke test can isolate state. */
+export function resolveUserDataPath(): string {
+  const explicit = env('ORCA_USER_DATA')
+  if (explicit) {
+    return explicit
+  }
+  const xdg = env('XDG_DATA_HOME')
+  return xdg ? join(xdg, 'Orca') : join(homedir(), '.orca')
+}
+
+/** Electron's `'appData'` definition, computed without Electron. */
+function resolveAppDataPath(): string {
+  if (process.platform === 'darwin') {
+    return join(homedir(), 'Library', 'Application Support')
+  }
+  if (process.platform === 'win32') {
+    return env('APPDATA') ?? join(homedir(), 'AppData', 'Roaming')
+  }
+  return env('XDG_CONFIG_HOME') ?? join(homedir(), '.config')
+}
+
+/**
+ * The directory orcad was launched from — the bundle root that `orcad.js` and the
+ * children shipped beside it (the watcher entry, the agent-browser binary) live in.
+ *
+ * Why argv[1] and not cwd: cwd is wherever the operator or supervisor happened to be,
+ * so resolving siblings against it finds them only by luck. Node resolves argv[1] to an
+ * absolute path before we see it; `resolve` covers a caller-supplied relative one.
+ */
+export function resolveOrcadInstallRoot(scriptPath = process.argv[1]): string {
+  if (!scriptPath) {
+    throw new Error(
+      'orcad_install_root_unavailable — process.argv[1] is unset, so this process has no ' +
+        'bundle root to resolve sibling entry points against'
+    )
+  }
+  return dirname(resolve(scriptPath))
+}
+
+export function resolveOrcadPath(name: AppPathName): string {
+  switch (name) {
+    case 'userData':
+      return resolveUserDataPath()
+    case 'home':
+      return homedir()
+    case 'temp':
+      return tmpdir()
+    case 'appData':
+      return resolveAppDataPath()
+    // Why inside userData rather than Electron's macOS ~/Library/Logs: a headless
+    // deployment's whole state is one removable directory, and a service account
+    // often has no Library tree to write into.
+    case 'logs':
+      return join(resolveUserDataPath(), 'logs')
+    // The Node binary running this bundle. There is no app executable to point at.
+    case 'exe':
+      return process.execPath
+    // The XDG user-dirs override, else the cross-platform default location.
+    case 'downloads':
+      return env('XDG_DOWNLOAD_DIR') ?? join(homedir(), 'Downloads')
+  }
+}

--- a/src/main/orcad/orcad-entry.ts
+++ b/src/main/orcad/orcad-entry.ts
@@ -11,28 +11,17 @@
  * the runtime factory, but only when an Electron serve sidecar or an operator-supplied
  * Chromium proves available at startup.
  */
-import { homedir, tmpdir } from 'node:os'
-import { join } from 'node:path'
 import process from 'node:process'
 import { setAppEnvironment, type AppEnvironment } from '../../shared/app-environment'
 import { setSecretStore, type SecretStore } from '../../shared/secret-store'
 import type { ServeReadiness } from '../server/serve-readiness'
 import { setRuntimeBrowserCommandsFactory } from '../runtime/runtime-browser-commands-factory'
 import { resolveOrcadBrowserProvider, type OrcadBrowserProvider } from './orcad-browser-provider'
+import { resolveOrcadInstallRoot, resolveOrcadPath, resolveUserDataPath } from './orcad-app-paths'
 
-/** XDG-ish data root. `$ORCA_USER_DATA` wins so a smoke test can isolate state. */
-function resolveUserDataPath(): string {
-  const explicit = process.env.ORCA_USER_DATA
-  if (explicit) {
-    return explicit
-  }
-  const xdg = process.env.XDG_DATA_HOME
-  return xdg ? join(xdg, 'Orca') : join(homedir(), '.orca')
-}
 let runOrcadQuitHandlers = (): void => {}
 
 function createNodeAppEnvironment(): AppEnvironment {
-  const userData = resolveUserDataPath()
   const quitHandlers: (() => void)[] = []
   // The main signal handler awaits runtime and browser teardown before process.exit.
   // Keep will-quit callbacks synchronous, but never let them pre-empt that async barrier.
@@ -46,9 +35,14 @@ function createNodeAppEnvironment(): AppEnvironment {
     }
   }
   return {
-    getPath: (name) => (name === 'home' ? homedir() : name === 'temp' ? tmpdir() : userData),
-    getAppPath: () => process.cwd(),
+    getPath: resolveOrcadPath,
+    getAppPath: () => resolveOrcadInstallRoot(),
     getVersion: () => process.env.ORCA_VERSION ?? '0.0.0-orcad',
+    // Why still true: consumers read this as "production build, not a dev checkout" —
+    // it gates HTTPS-only skill downloads, the real CLI command name, and shell-PATH
+    // hydration. Answering false to satisfy a path resolver would relax a security
+    // posture. Layout questions must ask whether the app root is an asar archive
+    // instead (see parcel-watcher-entry-path.ts).
     isPackaged: () => true,
     onWillQuit: (handler) => quitHandlers.push(handler),
     exit: (code = 0) => process.exit(code),

--- a/src/main/orcad/orcad-forked-child-paths.test.ts
+++ b/src/main/orcad/orcad-forked-child-paths.test.ts
@@ -1,0 +1,61 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { getAppEnvironment } from '../../shared/app-environment'
+import { getWatcherProcessEntryPath } from '../ipc/parcel-watcher-entry-path'
+import { installOrcadHostAdapters } from './orcad-entry'
+
+/**
+ * The composition, not the pieces: orcad's real host adapters against the real resolver
+ * and a real deployment layout on disk. Both halves of this passed their own unit tests
+ * while the running server forked a path that has never existed in an orcad deployment.
+ */
+describe('orcad forked-child paths', () => {
+  let deployRoot: string
+  let originalArgv: string[]
+
+  beforeEach(() => {
+    deployRoot = mkdtempSync(join(tmpdir(), 'orcad-deploy-'))
+    // The layout build-orcad.mjs emits: the bundle and its children side by side.
+    writeFileSync(join(deployRoot, 'orcad.js'), '')
+    writeFileSync(join(deployRoot, 'parcel-watcher-process-entry.js'), '')
+    originalArgv = process.argv
+    process.argv = [process.execPath, join(deployRoot, 'orcad.js')]
+    installOrcadHostAdapters()
+  })
+
+  afterEach(() => {
+    process.argv = originalArgv
+    rmSync(deployRoot, { recursive: true, force: true })
+  })
+
+  it('forks the watcher child shipped beside orcad.js', () => {
+    expect(getWatcherProcessEntryPath()).toBe(join(deployRoot, 'parcel-watcher-process-entry.js'))
+  })
+
+  it('ignores a decoy child under the working directory', () => {
+    // A cwd-derived app root finds the real child only when the operator happens to
+    // launch from the install directory, which a supervisor never does — and here it
+    // would find someone else's build instead.
+    const elsewhere = mkdtempSync(join(tmpdir(), 'orcad-cwd-'))
+    mkdirSync(join(elsewhere, 'out', 'main'), { recursive: true })
+    writeFileSync(join(elsewhere, 'out', 'main', 'parcel-watcher-process-entry.js'), '')
+    writeFileSync(join(elsewhere, 'parcel-watcher-process-entry.js'), '')
+    const originalCwd = process.cwd()
+    process.chdir(elsewhere)
+    try {
+      expect(getWatcherProcessEntryPath()).toBe(join(deployRoot, 'parcel-watcher-process-entry.js'))
+    } finally {
+      process.chdir(originalCwd)
+      rmSync(elsewhere, { recursive: true, force: true })
+    }
+  })
+
+  it('reports the install root and the Node binary, not the data directory', () => {
+    const environment = getAppEnvironment()
+    expect(environment.getAppPath()).toBe(deployRoot)
+    expect(environment.getPath('exe')).toBe(process.execPath)
+    expect(environment.getPath('exe')).not.toBe(environment.getPath('userData'))
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​202 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​202 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​170 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​19 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​151 |

<!-- /orca-pr-loc -->

Plan item 1, stacked on #16368. Two symptoms, one cause: the host port answered plausibly-wrong instead of refusing, and something downstream believed it.

## The port lied by omission

`AppPathName` has seven members. `orcad` implemented three and returned the **userData directory** for the other four — including `'exe'`. A data directory is not an executable path. That is the bundler-shim anti-pattern the design explicitly rejects.

Now every name answers for a Node host or throws:

| Name | Answer |
|---|---|
| `userData` / `home` / `temp` | unchanged |
| `appData` | real per-platform app-data root |
| `logs` | `userData/logs` — a headless deployment's whole state is one removable directory, and a service account often has no `~/Library` to write into |
| `exe` | `process.execPath` — the Node binary running the bundle; there is no app executable to point at |
| `downloads` | `XDG_DOWNLOAD_DIR`, else the cross-platform default |

## The watcher was unreachable, and `isPackaged` was the wrong lever

`resolveWatcherProcessEntryPath` consulted the adjacent child **only when `!isPackaged`**. With `orcad` claiming packaged it skipped that and resolved a desktop-build path that does not exist in an `orcad` deployment — and `build-orcad` emitted one entry, so the child was never built either.

**`isPackaged: () => true` is kept deliberately.** Consumers read it as *"production build, not a dev checkout"*: it gates HTTPS-only skill downloads, the real CLI command name, and shell-PATH hydration. Answering `false` to satisfy a path resolver would relax a security posture to fix a layout bug.

So the resolver now asks the question it actually means — *is the app root an asar archive* — rather than *is this packaged*. Only the asar layout nests the child under `out/main`; `orcad` is a packaged non-Electron host whose root holds `orcad.js` and the child side by side. `build-orcad` now ships the child, the same way it already ships the `agent-browser` binary.

## Proof

Reverting the resolver fix fails three tests:

```
FAIL  orcad forked-child paths > forks the watcher child shipped beside orcad.js
FAIL  orcad forked-child paths > ignores a decoy child under the working directory
FAIL  resolveWatcherProcessEntryPath > uses the adjacent entry for a packaged host whose app root is not an asar
```

`out/orcad/` now contains `orcad.js`, `agent-browser-*`, and `parcel-watcher-process-entry.js`. Ratchet 0, `build-orcad` green (including item 0's plain-Node smoke-load), `smoke:orcad-terminal` passes, typecheck and lint clean.

## Trade-offs

Zero user-facing. The desktop path is unchanged — `usesAsarArchive` is `isPackaged && appPath.includes('app.asar')`, which is exactly the old condition for a real packaged Electron app.