### PR TITLE
fix(ports): stop joining an undefined resourcesPath on a non-Electron host

### DIFF
--- a/src/main/ports/port-scan-command-client.test.ts
+++ b/src/main/ports/port-scan-command-client.test.ts
@@ -298,3 +298,29 @@ describe('PortScanCommandClient on a real worker thread', () => {
     }
   }, 30_000)
 })
+
+describe('resolveWorkerEntryPath on a non-Electron host', () => {
+  // Why: orcad reports isPackaged true (it is a production build), but
+  // process.resourcesPath is Electron-only and undefined there. Joining undefined threw
+  // a TypeError instead of failing as a missing worker — a crash where a clean
+  // "worker unavailable" was the honest outcome.
+  it('does not join an undefined resourcesPath', () => {
+    expect(() =>
+      resolveWorkerEntryPath({
+        isPackaged: true,
+        resourcesPath: undefined,
+        moduleDir: '/opt/orcad'
+      })
+    ).not.toThrow()
+  })
+
+  it('falls back to the module directory when there is no resources tree', () => {
+    expect(
+      resolveWorkerEntryPath({
+        isPackaged: true,
+        resourcesPath: undefined,
+        moduleDir: '/opt/orcad'
+      })
+    ).toBe(join('/opt/orcad', 'port-scan-command-worker-entry.js'))
+  })
+})

--- a/src/main/ports/port-scan-command-client.ts
+++ b/src/main/ports/port-scan-command-client.ts
@@ -303,7 +303,8 @@ const WORKER_ENTRY_FILENAME = 'port-scan-command-worker-entry.js'
 /** Where the built worker entry can live: packaged resources or the build dir. */
 export type WorkerEntryLayout = {
   isPackaged: boolean
-  resourcesPath: string
+  /** Undefined on a non-Electron host: `process.resourcesPath` is Electron-only. */
+  resourcesPath: string | undefined
   moduleDir: string
 }
 
@@ -318,7 +319,12 @@ export function resolveWorkerEntryPath(layout: WorkerEntryLayout): string {
   // the bundler's __dirname, matching the shipped stt/warp/opencode workers.
   // Split out from the electron read so the packaged branch is testable without
   // a packaged build.
-  if (layout.isPackaged) {
+  // Why the resourcesPath guard: `isPackaged` is true on orcad too, but
+  // `process.resourcesPath` is Electron-only and undefined under plain Node — joining
+  // it threw a TypeError rather than failing as a missing worker. A host without an
+  // Electron resources tree has no asar to look in, so fall back to the module dir and
+  // let the caller report a missing worker honestly.
+  if (layout.isPackaged && layout.resourcesPath) {
     return join(layout.resourcesPath, 'app.asar', 'out', 'main', WORKER_ENTRY_FILENAME)
   }
   return join(layout.moduleDir, WORKER_ENTRY_FILENAME)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​26 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 |

<!-- /orca-pr-loc -->

Plan item 2's remainder, stacked on #16369. A live crash path in the shipped `orcad` bundle.

## The bug

`resolveWorkerEntryPath` branched on `isPackaged` alone and joined `process.resourcesPath`:

```ts
if (layout.isPackaged) {
  return join(layout.resourcesPath, 'app.asar', 'out', 'main', WORKER_ENTRY_FILENAME)
}
```

`orcad` reports `isPackaged` **true** — correctly; it is a production build, and ~15 consumers read it that way to gate HTTPS-only skill downloads and the real CLI name. But `process.resourcesPath` is **Electron-only and `undefined` under plain Node**, and the worker entry name is in the orcad bundle.

So the packaged branch threw:

```
TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined
```

where a clean *"worker unavailable"* was the honest outcome. A crash, not a degradation.

## Why it hid

The type said `resourcesPath: string`. It is now `string | undefined`, so the compiler carries the fact rather than a comment asserting it.

A host with no Electron resources tree has no asar to look in, so it falls back to the module directory and lets the caller report a missing worker.

## Provenance

Found by the item 1 agent while auditing the same `isPackaged` defect class that broke the watcher — it flagged this one as *worse*, because it throws rather than degrades. Correct call.

It also flagged two siblings I am **not** fixing here: `ai-vault/session-scanner-service-entry-path.ts` and `computer/sidecar-client.ts` carry the same `!isPackaged` gate and are in the bundle, but neither child is shipped in any orcad layout, so correcting their paths only relocates the failure. Those are declare-the-gap material, not path fixes.

## Proof

Verified in both directions — reverting the guard reproduces the exact TypeError:

```
FAIL  resolveWorkerEntryPath on a non-Electron host > does not join an undefined resourcesPath
AssertionError: expected [Function] to not throw an error but
'TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received undefined' was thrown
```

Ratchet 0, `build-orcad` green (incl. the plain-Node smoke-load), `smoke:orcad-terminal` passes, typecheck and lint clean.

## Trade-offs

Zero user-facing. The desktop path is unchanged: with a real Electron resources tree, `layout.resourcesPath` is truthy and the asar branch is taken exactly as before.