### PR TITLE
fix(git): parse partial-clone remote filters

### DIFF
--- a/src/shared/git-remote-identity.test.ts
+++ b/src/shared/git-remote-identity.test.ts
@@ -4,6 +4,7 @@ import {
   deriveGitRemoteIdentity,
   matchGitRemoteKeyParts,
   normalizeGitRemoteUrl,
+  parseGitRemoteVerboseOutput,
   splitGitRemoteKey
 } from './git-remote-identity'
 
@@ -51,6 +52,22 @@ describe('normalizeGitRemoteUrl', () => {
 })
 
 describe('deriveGitRemoteIdentity', () => {
+  it('recognizes fetch remotes with partial clone filters', () => {
+    const stdout = [
+      'origin\thttps://github.com/stablyai/orca.git (fetch) [blob:none]',
+      'origin\thttps://github.com/stablyai/orca.git (push)'
+    ].join('\n')
+
+    expect(parseGitRemoteVerboseOutput(stdout)).toEqual([
+      { name: 'origin', url: 'https://github.com/stablyai/orca.git' }
+    ])
+    expect(deriveGitRemoteIdentity(stdout)).toEqual({
+      canonicalKey: 'github.com/stablyai/orca',
+      remoteName: 'origin',
+      remoteUrl: 'https://github.com/stablyai/orca.git'
+    })
+  })
+
   it('prefers upstream, then origin, then the first named remote', () => {
     expect(
       deriveGitRemoteIdentity(

--- a/src/shared/git-remote-identity.ts
+++ b/src/shared/git-remote-identity.ts
@@ -95,10 +95,7 @@ export function parseGitRemoteVerboseOutput(stdout: string): GitRemoteEntry[] {
   const entries: GitRemoteEntry[] = []
   for (const rawLine of stdout.split(/\r?\n/)) {
     const line = rawLine.trim()
-    if (!line.endsWith('(fetch)')) {
-      continue
-    }
-    const match = /^(\S+)\s+(.+?)\s+\(fetch\)$/.exec(line)
+    const match = /^(\S+)\s+(.+?)\s+\(fetch\)(?:\s+\[[^\]]+\])?$/.exec(line)
     if (!match) {
       continue
     }


### PR DESCRIPTION
## ELI5

Partial clones add a filter annotation such as `[blob:none]` after the `(fetch)` marker in `git remote -v`. Orca expected `(fetch)` to be the end of the line, so it discarded the remote and generic remote identity detection returned `null`.

This does not mean every partial clone displays a long project name: provider-specific metadata can mask the missing generic identity. The visible grouping and setup failures occur when no provider identity fallback is available.

## What Changed

- Accept an optional bracketed filter annotation after `(fetch)` in `git remote -v` output.
- Add a regression test covering both `parseGitRemoteVerboseOutput` and `deriveGitRemoteIdentity`.
- Preserve ordinary fetch parsing, push filtering, multi-remote precedence, and URL normalization.

## Why

Generic Git remote identity should work consistently for partial clones across local, WSL, SSH, GitHub, GitLab, and self-hosted providers.

Provider metadata may reconstruct a GitHub identity and hide the parsing failure, while repositories without that fallback can be split across hosts or rejected by existing-folder identity checks.

This is complementary to #10809: remote re-probing still depends on this parser and otherwise receives no identity for partial clones.

## Linked Issue

Fixes the partial-clone failure mode related to #10620.

## Visual Proof

N/A — parser-only change with no direct UI or interaction changes.

## Testing

- [x] Reproduced `git remote -v` output ending in `(fetch) [blob:none]`
- [x] Added automated parser and derived-identity regression coverage
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/shared/git-remote-identity.test.ts`
- [x] Targeted `oxfmt` and `oxlint`
- [x] Changed-code quality gate
- [x] Node and Web TypeScript checks

Tested locally on macOS with Node 24.16.0. The parser is platform- and provider-neutral and is shared by local and remote Git probing.

## AI Disclosure

OpenAI Codex (GPT-5) assisted with implementation, tests, and review.

## Review

Clean self-review with no findings.

- Cross-platform: no platform-specific behavior
- Local/WSL/SSH: shared parser behavior remains consistent
- Git providers: provider-neutral
- Performance: one bounded optional suffix match per output line
- Security: no new I/O, execution, persistence, or trust boundary
- UI: no visual change

## Agent skill upstream boundary

- [x] Not applicable

## Notes

No changes to Git commands, remote wire formats, application installation, or provider-specific identity fallback behavior.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] `N/A` supplied for visual proof
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform and SSH/remote impact considered
- [ ] Full `pnpm lint`, `pnpm test`, and `pnpm build` run locally; targeted checks passed and CI can cover the full suite

## Author

X: @liugang_kv7
