### PR TITLE
fix(file-links): trim CJK particles after ASCII file extensions

### DIFF
--- a/mobile/src/components/MobileMarkdown.tsx
+++ b/mobile/src/components/MobileMarkdown.tsx
@@ -7,6 +7,7 @@ import {
   isFilePathCodeSpan,
   normalizeFilePath
 } from './markdown-file-path-detection'
+import { trimFileLinkTrailingNonAsciiLetters } from '../../../src/shared/file-link-trailing-prose'
 import { routeMarkdownHref } from './markdown-href-routing'
 import {
   isIntrawordUnderscoreToken,
@@ -132,7 +133,9 @@ function renderInline(text: string, onOpenFile?: (pathText: string) => void): Re
           <Text
             key={key}
             style={[styles.inlineCode, styles.inlineCodeLink]}
-            onPress={() => onOpenFile(normalizeFilePath(code.trim()))}
+            onPress={() =>
+              onOpenFile(normalizeFilePath(trimFileLinkTrailingNonAsciiLetters(code.trim())))
+            }
           >
             {code}
           </Text>

--- a/mobile/src/components/markdown-file-path-detection.test.ts
+++ b/mobile/src/components/markdown-file-path-detection.test.ts
@@ -210,6 +210,26 @@ describe('detectFilePathSegments', () => {
       { type: 'file', value: 'src/app/Main.tsx', path: 'src/app/Main.tsx' }
     ])
   })
+
+  it('detects CJK directory segments and trims trailing particles', () => {
+    expect(detectFilePathSegments('열기 /Users/me/docs/한글폴더/파일.md로 완료')).toEqual([
+      { type: 'text', value: '열기 ' },
+      {
+        type: 'file',
+        value: '/Users/me/docs/한글폴더/파일.md',
+        path: '/Users/me/docs/한글폴더/파일.md'
+      },
+      { type: 'text', value: '로 완료' }
+    ])
+  })
+
+  it('detects ASCII separator paths with glued CJK particles in prose', () => {
+    expect(detectFilePathSegments('저장 경로는 plans/foo.md로 확정')).toEqual([
+      { type: 'text', value: '저장 경로는 ' },
+      { type: 'file', value: 'plans/foo.md', path: 'plans/foo.md' },
+      { type: 'text', value: '로 확정' }
+    ])
+  })
 })
 
 describe('isFilePathCodeSpan', () => {
@@ -255,6 +275,12 @@ describe('isFilePathCodeSpan', () => {
   it('rejects emails and git URLs with a mid-token @', () => {
     expect(isFilePathCodeSpan('git@github.com:user/repo.git')).toBe(false)
     expect(isFilePathCodeSpan('user@host.com/path/file.txt')).toBe(false)
+  })
+
+  it('accepts code spans with CJK particles glued after the extension', () => {
+    expect(isFilePathCodeSpan('src/foo.ts로')).toBe(true)
+    expect(isFilePathCodeSpan('plans/foo.md에')).toBe(true)
+    expect(isFilePathCodeSpan('package.jsonです')).toBe(true)
   })
 })
 

--- a/mobile/src/components/markdown-file-path-detection.ts
+++ b/mobile/src/components/markdown-file-path-detection.ts
@@ -4,6 +4,7 @@
 // annoyance, but a false positive on prose or a version number is a broken tap.
 
 import { parseFileLinkLocation } from '../../../src/shared/file-link-location'
+import { trimFileLinkTrailingNonAsciiLetters } from '../../../src/shared/file-link-trailing-prose'
 
 export type FilePathSegment =
   | { type: 'text'; value: string }
@@ -88,8 +89,11 @@ const EXTENSION_SET = new Set<string>(FILE_EXTENSIONS)
 // connected runtime, which may be Windows even when the phone is not. Leading
 // alternatives cover Windows drives, UNC, and POSIX absolute roots; the optional
 // tail captures only bounded agent-style :line(:col) citations.
+// Why \p{L}\p{M}\p{N}: ASCII-only segments truncated CJK directory names. Keep
+// the extension ASCII so particles after `.md` stay outside the match; still
+// run trimFileLinkTrailingNonAsciiLetters for code-span / line:col edges.
 const CANDIDATE_PATTERN =
-  /(?:(?:[A-Za-z]:[\\/]|\\\\|[\\/]|\.{1,2}[\\/])(?:[\w.@~+-]+[\\/])*|(?:[\w.@~+-]+[\\/])+)[\w.@+-]+\.[A-Za-z0-9]+(?::[1-9]\d*(?::[1-9]\d*)?(?![\w@%]))?/g
+  /(?:(?:[A-Za-z]:[\\/]|\\\\|[\\/]|\.{1,2}[\\/])(?:[\p{L}\p{M}\p{N}_.@~+-]+[\\/])*|(?:[\p{L}\p{M}\p{N}_.@~+-]+[\\/])+)[\p{L}\p{M}\p{N}_.@+-]+\.[A-Za-z0-9]+(?::[1-9]\d*(?::[1-9]\d*)?(?![A-Za-z0-9_@%]))?/gu
 
 // A path candidate in chat prose is short; a much longer run can't hold one worth
 // linkifying but can push CANDIDATE_PATTERN into super-linear backtracking, so we
@@ -124,8 +128,9 @@ export function splitFilePathLineSuffix(pathText: string): {
 }
 
 function isOpenablePath(pathText: string): boolean {
-  // A :line(:col) tail is part of the citation, not the file name.
-  const { path: candidate } = splitFilePathLineSuffix(pathText)
+  // A :line(:col) tail is part of the citation, not the file name. Strip CJK
+  // particles glued after an ASCII extension before extension lookup.
+  const { path: candidate } = splitFilePathLineSuffix(trimFileLinkTrailingNonAsciiLetters(pathText))
   // Reject anything URL-ish or scheme-bearing — those are handled as web links.
   if (candidate.includes('://') || hasMidTokenAt(candidate)) {
     return false
@@ -178,12 +183,12 @@ export function detectFilePathSegments(text: string): FilePathSegment[] {
   CANDIDATE_PATTERN.lastIndex = 0
 
   while ((match = CANDIDATE_PATTERN.exec(text))) {
-    const candidate = match[0]
+    const candidate = trimFileLinkTrailingNonAsciiLetters(match[0])
     // Skip candidates that are part of a URL: a scheme colon, a domain tail, or
     // a preceding slash (the leading slash of an absolute path is part of the
     // match itself, so prev '/' means a '://' or '//' remainder, not a path).
     const prev = match.index > 0 ? text[match.index - 1]! : ''
-    if (prev === ':' || prev === '/' || prev === '\\' || /[\w.@]/.test(prev)) {
+    if (prev === ':' || prev === '/' || prev === '\\' || /[A-Za-z0-9_.@]/.test(prev)) {
       continue
     }
     if (!isOpenablePath(candidate)) {
@@ -212,7 +217,7 @@ export function detectFilePathSegments(text: string): FilePathSegment[] {
  * bare `file.ts` here even without a slash.
  */
 export function isFilePathCodeSpan(code: string): boolean {
-  const trimmed = code.trim()
+  const trimmed = trimFileLinkTrailingNonAsciiLetters(code.trim())
   if (!trimmed || /\s/.test(trimmed)) {
     return false
   }
@@ -234,7 +239,7 @@ export function isFilePathCodeSpan(code: string): boolean {
   }
   const name = path.slice(0, dot)
   const ext = path.slice(dot + 1).toLowerCase()
-  if (/[^\w.@+-]/.test(name)) {
+  if (/[^\p{L}\p{M}\p{N}_.@+-]/u.test(name)) {
     return false
   }
   return EXTENSION_SET.has(ext)

--- a/mobile/src/terminal/terminal-path-tap-injected.ts
+++ b/mobile/src/terminal/terminal-path-tap-injected.ts
@@ -14,10 +14,11 @@
 // often print a bare filename (the markdown link target is consumed, leaving
 // only the label text), so requiring a slash would miss the common case.
 export const TERMINAL_PATH_TAP_JS = String.raw`
-	  var FILE_PATH_RE = /(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/]|[A-Za-z0-9._-]+[\\/]|(?=[A-Za-z0-9._-]*\.[A-Za-z0-9]))[A-Za-z0-9._~\-\/%+@\\()[\]]*(?::\d+)?(?::\d+)?/g;
-	  var SPACED_PATH_RE = /(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/]|[A-Za-z0-9._-]+[\\/])[^()[\]{}'",;<>|\`\r\n]+(?::\d+)?(?::\d+)?/g;
+	  var FILE_PATH_RE = /(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/]|[\p{L}\p{M}\p{N}._-]+[\\/]|(?=[\p{L}\p{M}\p{N}._-]*\.[A-Za-z0-9]))[\p{L}\p{M}\p{N}._~\-\/%+@\\()[\]]*(?::\d+)?(?::\d+)?/gu;
+	  var SPACED_PATH_RE = /(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/]|[\p{L}\p{M}\p{N}._-]+[\\/])[^()[\]{}'",;<>|\x60\r\n]+(?::\d+)?(?::\d+)?/gu;
 	  var PATH_LEADING_TRIM = { '(': 1, '[': 1, '{': 1, '"': 1, "'": 1 };
 	  var PATH_TRAILING_TRIM = { ')': 1, ']': 1, '}': 1, '"': 1, "'": 1, ',': 1, ';': 1, '.': 1 };
+	  var ASCII_EXT_THEN_NON_ASCII_LETTERS = /^(.*\.[A-Za-z0-9_+-]+(?::\d+)?(?::\d+)?)((?:(?![A-Za-z])\p{L})+)$/u;
 
 	  function parsePathLineCol(value) {
     var m = /^(.*?)(?::(\d+))?(?::(\d+))?$/.exec(value);
@@ -39,6 +40,12 @@ export const TERMINAL_PATH_TAP_JS = String.raw`
 	    return { text: raw.slice(start, end), startIndex: rawStart + start, endIndex: rawStart + end };
 	  }
 
+	  function trimTrailingNonAsciiLetters(range) {
+	    var match = ASCII_EXT_THEN_NON_ASCII_LETTERS.exec(range.text);
+	    if (!match) return range;
+	    return { text: match[1], startIndex: range.startIndex, endIndex: range.startIndex + match[1].length };
+	  }
+
 	  function hasSeparatorAfterWhitespace(text) {
 	    var sawWhitespace = false;
 	    for (var i = 0; i < text.length; i++) {
@@ -53,7 +60,8 @@ export const TERMINAL_PATH_TAP_JS = String.raw`
 	    // A line-end extension token only extends the span when the added segment
 	    // is path-like (contains a separator) — prose must not be swallowed.
 	    var selected = null;
-	    var extensionPrefixPattern = /\.[A-Za-z0-9_+-]+(?::\d+)?(?::\d+)?(?=\s+|$)/g;
+	    // Also stop before non-ASCII letters (CJK particles glued to the ext).
+	    var extensionPrefixPattern = /\.[A-Za-z0-9_+-]+(?::\d+)?(?::\d+)?(?=\s+|$|(?:(?![A-Za-z])\p{L}))/gu;
 	    var match;
 	    while ((match = extensionPrefixPattern.exec(range.text)) !== null) {
 	      var end = match.index + match[0].length;
@@ -91,8 +99,9 @@ export const TERMINAL_PATH_TAP_JS = String.raw`
 	    while ((match = SPACED_PATH_RE.exec(lineText)) !== null) {
 	      var trimmed = trimPathBoundaryPunctuation(match[0], match.index);
 	      if (!trimmed || (!hasSeparatorAfterWhitespace(trimmed.text) && !hasSpacedPathExtension(trimmed.text))) continue;
-	      var candidate = trimSpacedPathTrailingProse(trimmed, col);
-	      if (!candidate) continue;
+	      var proseTrimmed = trimSpacedPathTrailingProse(trimmed, col);
+	      if (!proseTrimmed) continue;
+	      var candidate = trimTrailingNonAsciiLetters(proseTrimmed);
 	      if (col < candidate.startIndex || col >= candidate.endIndex) continue;
 	      var parsed = parsePathLineCol(candidate.text);
 	      if (parsed) return parsed;
@@ -110,8 +119,9 @@ export const TERMINAL_PATH_TAP_JS = String.raw`
       if (raw.length === 0) { FILE_PATH_RE.lastIndex += 1; continue; }
 	      var trimmed = trimPathBoundaryPunctuation(raw, match.index);
 	      if (!trimmed) continue;
-	      if (col < trimmed.startIndex || col >= trimmed.endIndex) continue;
-	      var parsed = parsePathLineCol(trimmed.text);
+	      var candidate = trimTrailingNonAsciiLetters(trimmed);
+	      if (col < candidate.startIndex || col >= candidate.endIndex) continue;
+	      var parsed = parsePathLineCol(candidate.text);
 	      if (parsed) return parsed;
     }
     return null;

--- a/mobile/src/terminal/terminal-path-tap.test.ts
+++ b/mobile/src/terminal/terminal-path-tap.test.ts
@@ -164,6 +164,27 @@ describe('matchFilePathAtColumn', () => {
     const line = '• Here you go: README.md'
     expect(matchFilePathAtColumn(line, colOf(line, 'Here'))).toBeNull()
   })
+
+  it('trims CJK particles from bare filenames under the tap', () => {
+    const line = 'See README.md로 for details'
+    expect(matchFilePathAtColumn(line, colOf(line, 'README'))).toEqual({
+      pathText: 'README.md',
+      line: null,
+      column: null
+    })
+    expect(matchFilePathAtColumn(line, colOf(line, '로'))).toBeNull()
+  })
+
+  it('matches non-Latin separator paths and trims trailing particles', () => {
+    const path = '/Users/me/docs/한글폴더/파일.md'
+    const line = `${path}로 열었습니다`
+    expect(matchFilePathAtColumn(line, colOf(line, '파일'))).toEqual({
+      pathText: path,
+      line: null,
+      column: null
+    })
+    expect(matchFilePathAtColumn(line, colOf(line, '로'))).toBeNull()
+  })
 })
 
 describe('injected matchFilePathAtColumn', () => {

--- a/mobile/src/terminal/terminal-path-tap.ts
+++ b/mobile/src/terminal/terminal-path-tap.ts
@@ -7,6 +7,7 @@ import {
   parseFileLinkLocation,
   type ParsedFileLinkLocation
 } from '../../../src/shared/file-link-location'
+import { trimFileLinkRangeTrailingNonAsciiLetters } from '../../../src/shared/file-link-trailing-prose'
 
 export type TappedFilePath = ParsedFileLinkLocation
 
@@ -15,10 +16,13 @@ export type TappedFilePath = ParsedFileLinkLocation
 // with :line or :line:col. Like desktop, we propose candidates and let the host
 // existence-check reject non-files — agents often print a bare filename, so
 // requiring a slash would miss the common case.
+// Why \p{L}\p{M}\p{N}: ASCII-only classes truncated CJK path segments (#13396).
+// Pair with trimFileLinkRangeTrailingNonAsciiLetters so glued particles after
+// an extension are not part of the tap target.
 const LOCAL_PATH_REGEX =
-  /(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/]|[A-Za-z0-9._-]+[\\/]|(?=[A-Za-z0-9._-]*\.[A-Za-z0-9]))[A-Za-z0-9._~\-/%+@\\()[\]]*(?::\d+)?(?::\d+)?/g
+  /(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/]|[\p{L}\p{M}\p{N}._-]+[\\/]|(?=[\p{L}\p{M}\p{N}._-]*\.[A-Za-z0-9]))[\p{L}\p{M}\p{N}._~\-/%+@\\()[\]]*(?::\d+)?(?::\d+)?/gu
 const SPACED_PATH_REGEX =
-  /(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/]|[A-Za-z0-9._-]+[\\/])[^()[\]{}'",;<>|`\r\n]+(?::\d+)?(?::\d+)?/g
+  /(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/]|[\p{L}\p{M}\p{N}._-]+[\\/])[^()[\]{}'",;<>|`\r\n]+(?::\d+)?(?::\d+)?/gu
 
 const LEADING_TRIM_CHARS = new Set(['(', '[', '{', '"', "'"])
 const TRAILING_TRIM_CHARS = new Set([')', ']', '}', '"', "'", ',', ';', '.'])
@@ -82,7 +86,10 @@ function trimSpacedPathTrailingProse(
   // segment is path-like (contains a separator) — "v1.2 reports/result.json"
   // extends, prose like "failed to start app.py" must not be swallowed.
   let selected: string | null = null
-  const extensionPrefixPattern = /\.[A-Za-z0-9_+-]+(?::\d+)?(?::\d+)?(?=\s+|$)/g
+  // Why: also stop before non-ASCII letters so `…/파일.md로 열었습니다` keeps
+  // only the path after `\p{L}` widening (space-only trim leaves the particle).
+  const extensionPrefixPattern =
+    /\.[A-Za-z0-9_+-]+(?::\d+)?(?::\d+)?(?=\s+|$|(?:(?![A-Za-z])\p{L}))/gu
   let match: RegExpExecArray | null
   while ((match = extensionPrefixPattern.exec(range.text)) !== null) {
     const end = match.index + match[0].length
@@ -148,10 +155,11 @@ function matchSpacedFilePathAtColumn(lineText: string, col: number): TappedFileP
     ) {
       continue
     }
-    const candidate = trimSpacedPathTrailingProse(trimmed, col)
-    if (!candidate) {
+    const proseTrimmed = trimSpacedPathTrailingProse(trimmed, col)
+    if (!proseTrimmed) {
       continue
     }
+    const candidate = trimFileLinkRangeTrailingNonAsciiLetters(proseTrimmed)
     if (col < candidate.startIndex || col >= candidate.endIndex) {
       continue
     }
@@ -181,10 +189,11 @@ export function matchFilePathAtColumn(lineText: string, col: number): TappedFile
     if (!trimmed) {
       continue
     }
-    if (col < trimmed.startIndex || col >= trimmed.endIndex) {
+    const candidate = trimFileLinkRangeTrailingNonAsciiLetters(trimmed)
+    if (col < candidate.startIndex || col >= candidate.endIndex) {
       continue
     }
-    const parsed = parsePathWithOptionalLineColumn(trimmed.text)
+    const parsed = parsePathWithOptionalLineColumn(candidate.text)
     if (parsed) {
       return parsed
     }

--- a/src/renderer/src/lib/terminal-bare-file-link-detection.ts
+++ b/src/renderer/src/lib/terminal-bare-file-link-detection.ts
@@ -1,3 +1,4 @@
+import { trimFileLinkRangeTrailingNonAsciiLetters } from '../../../shared/file-link-trailing-prose'
 import {
   detectTerminalFileLinkRanges,
   terminalFileLinkRangesOverlap,
@@ -58,7 +59,10 @@ export function detectBareFilenameLinks(
     if (range.text.length > MAX_BARE_FILENAME_TOKEN_LENGTH) {
       continue
     }
-    const link = toParsedTerminalFileLink(range)
+    // Why: space-less languages glue particles onto bare filenames
+    // (`README.md로`); trim before the ASCII filename check or the token
+    // fails looksLikeFilename and never becomes a link.
+    const link = toParsedTerminalFileLink(trimFileLinkRangeTrailingNonAsciiLetters(range))
     if (!link || !looksLikeFilename(link.pathText)) {
       continue
     }

--- a/src/renderer/src/lib/terminal-links-redos.test.ts
+++ b/src/renderer/src/lib/terminal-links-redos.test.ts
@@ -9,7 +9,10 @@ import { extractTerminalFileLinks, extractTerminalFileLinkCandidates } from './t
 describe('terminal-links ReDoS guard (#5970)', () => {
   const cases: [string, string][] = [
     ['separator + space padding', `a/${' '.repeat(30_000)}`],
-    ['advertised url + space padding', `Web Interface http://127.0.0.1:4040${' '.repeat(30_000)}`]
+    ['advertised url + space padding', `Web Interface http://127.0.0.1:4040${' '.repeat(30_000)}`],
+    // The local-path class accepts Unicode letters/marks; keep that scan linear too.
+    ['non-latin separator + space padding', `한/${' '.repeat(30_000)}`],
+    ['non-latin run + space padding', `${'한글'.repeat(15_000)}/${' '.repeat(30_000)}`]
   ]
 
   for (const [name, line] of cases) {

--- a/src/renderer/src/lib/terminal-links.test.ts
+++ b/src/renderer/src/lib/terminal-links.test.ts
@@ -112,6 +112,17 @@ describe('terminal path helpers', () => {
       expect(performance.now() - startedAt).toBeLessThan(100)
       expect(links.map((link) => link.displayText)).toEqual(['package.json'])
     })
+
+    it.each([
+      ['README.md로', 'README.md'],
+      ['AGENTS.md에', 'AGENTS.md'],
+      ['file.tsです', 'file.ts']
+    ])('trims CJK/JP particles from bare filenames: %s', (token, pathText) => {
+      const links = extractTerminalFileLinks(token)
+      expect(links).toHaveLength(1)
+      expect(links[0]).toMatchObject({ pathText, displayText: pathText })
+      expect(token.slice(links[0].startIndex, links[0].endIndex)).toBe(pathText)
+    })
   })
 
   describe('extractTerminalFileLinks local path tokens', () => {
@@ -215,6 +226,67 @@ describe('terminal path helpers', () => {
       expect(links).toHaveLength(20_000)
       expect(links[0].pathText).toBe('/tmp/Foo Bar/file')
     }, 5_000)
+
+    // An ASCII-only character class truncated these at the first non-Latin
+    // character, so only the ASCII prefix was linkified and the filename sat
+    // outside every link range (#13396).
+    it.each([
+      ['Korean', '/Users/me/docs/한글폴더/파일.md'],
+      ['Japanese', '/Users/me/docs/日本語/ファイル.md'],
+      ['Chinese', '/Users/me/docs/中文目录/文件.md'],
+      ['Cyrillic', '/Users/me/docs/Документы/файл.md'],
+      ['Greek', '/Users/me/docs/έγγραφα/αρχείο.md']
+    ])('detects unspaced %s paths end to end', (_script, path) => {
+      const links = extractTerminalFileLinks(path)
+      expect(links).toHaveLength(1)
+      expect(links[0]).toMatchObject({ pathText: path, displayText: path })
+    })
+
+    it('detects relative paths that start with a non-Latin segment', () => {
+      const links = extractTerminalFileLinks('한글폴더/파일.md')
+      expect(links).toHaveLength(1)
+      expect(links[0]).toMatchObject({ pathText: '한글폴더/파일.md' })
+    })
+
+    it('keeps line and column suffixes on non-Latin paths', () => {
+      const links = extractTerminalFileLinks('/Users/me/docs/한글폴더/파일.ts:42:7')
+      expect(links).toHaveLength(1)
+      expect(links[0]).toMatchObject({
+        pathText: '/Users/me/docs/한글폴더/파일.ts',
+        line: 42,
+        column: 7
+      })
+    })
+
+    // macOS stores many names decomposed, while terminal output is composed.
+    it('detects NFD-decomposed non-Latin paths', () => {
+      const path = `/Users/me/docs/${'한글폴더'.normalize('NFD')}/${'파일.md'.normalize('NFD')}`
+      const links = extractTerminalFileLinks(path)
+      expect(links).toHaveLength(1)
+      expect(links[0]).toMatchObject({ pathText: path })
+    })
+
+    it('trims particles glued after a separator path extension', () => {
+      const line = '저장 경로는 plans/foo.md로 확정했습니다.'
+      const links = extractTerminalFileLinks(line)
+      expect(links.map((link) => link.pathText)).toContain('plans/foo.md')
+      const link = links.find((entry) => entry.pathText === 'plans/foo.md')
+      expect(link).toBeDefined()
+      expect(line.slice(link!.startIndex, link!.endIndex)).toBe('plans/foo.md')
+    })
+
+    it('trims particles after a non-Latin path while keeping the CJK segments', () => {
+      const path = '/Users/me/docs/한글폴더/파일.md'
+      const line = `${path}로 열었습니다`
+      const links = extractTerminalFileLinks(line)
+      expect(links).toHaveLength(1)
+      expect(links[0]).toMatchObject({ pathText: path, displayText: path })
+    })
+
+    it('does not trim Latin tails after an extension', () => {
+      const links = extractTerminalFileLinks('file.mdbackup')
+      expect(links.map((link) => link.pathText)).toEqual(['file.mdbackup'])
+    })
   })
 
   it('supports Windows cwd resolution for terminal file links', () => {

--- a/src/renderer/src/lib/terminal-links.ts
+++ b/src/renderer/src/lib/terminal-links.ts
@@ -1,3 +1,4 @@
+import { trimFileLinkRangeTrailingNonAsciiLetters } from '../../../shared/file-link-trailing-prose'
 import { normalizeAbsolutePath } from './terminal-path-normalization'
 import { resolveExplicitFileLinkTarget } from './explicit-file-link-target'
 import { detectBareFilenameLinks } from './terminal-bare-file-link-detection'
@@ -10,6 +11,7 @@ import {
   type DetectedTerminalFileLinkRange
 } from './terminal-file-link-detection-ranges'
 import { detectTerminalFileUriLinks } from './terminal-file-uri-link'
+import { trimSpacedPathTrailingProse } from './terminal-spaced-path-trailing-prose'
 
 export type ParsedTerminalFileLink = {
   pathText: string
@@ -33,8 +35,11 @@ export type ResolvedTerminalFileLink = Pick<ParsedTerminalFileLink, 'line' | 'co
 // `:line` and `:col` suffixes (e.g. `src/foo.ts:12:3`, `./bin`, `/abs/path`).
 // Why: framework route files commonly use punctuation segments like
 // `app/(shop)/products/[id]/page.tsx`; keep those links whole.
+// Why \p{L}\p{M}\p{N}: an ASCII-only class truncated at the first non-Latin
+// character (#13396). Pair with trimFileLinkRangeTrailingNonAsciiLetters so
+// particles glued after an extension (`…/파일.md로`) are not swallowed.
 const LOCAL_PATH_REGEX =
-  /(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/]|[A-Za-z0-9._-]+[\\/])[A-Za-z0-9._~\-/%+@\\()[\]]*(?::\d+)?(?::\d+)?/g
+  /(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/]|[\p{L}\p{M}\p{N}._-]+[\\/])[\p{L}\p{M}\p{N}._~\-/%+@\\()[\]]*(?::\d+)?(?::\d+)?/gu
 
 // Matches separator paths whose file or folder names include spaces. This runs
 // before LOCAL_PATH_REGEX so `/Users/A/Foo Bar/file.ts` is claimed as one link
@@ -115,50 +120,6 @@ function isInsideUriScheme(lineText: string, range: DetectedTerminalFileLinkRang
   )
 }
 
-function trimSpacedPathTrailingProse(
-  range: DetectedTerminalFileLinkRange
-): DetectedTerminalFileLinkRange {
-  // Why: keep one extension-terminated path, but drop trailing prose or a
-  // second unrelated path that the broad spaced-path scan also captured. A
-  // line-end extension token only extends the span when the added segment is
-  // path-like (contains a separator) — "v1.2 reports/result.json" extends,
-  // prose like "failed to start app.py" must not be swallowed.
-  let selected: string | null = null
-  const extensionPrefixPattern = /\.[A-Za-z0-9_+-]+(?::\d+)?(?::\d+)?(?=\s+|$)/g
-  let match: RegExpExecArray | null
-  while ((match = extensionPrefixPattern.exec(range.text)) !== null) {
-    const end = match.index + match[0].length
-    const text = range.text.slice(0, end)
-    if (countPathStarts(text) > 1) {
-      continue
-    }
-    if (
-      end < range.text.length ||
-      selected === null ||
-      /[\\/]/.test(range.text.slice(selected.length, end))
-    ) {
-      selected = text
-    }
-  }
-  if (!selected) {
-    return range
-  }
-  return {
-    text: selected,
-    startIndex: range.startIndex,
-    endIndex: range.startIndex + selected.length
-  }
-}
-
-function countPathStarts(text: string): number {
-  let count = 0
-  for (const match of text.matchAll(/(?:^|\s)(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/])/g)) {
-    void match
-    count += 1
-  }
-  return count
-}
-
 function trimTrailingWhitespace(
   range: DetectedTerminalFileLinkRange
 ): DetectedTerminalFileLinkRange {
@@ -217,7 +178,7 @@ function detectLocalPathLinks(
     if (!/[\\/]/.test(range.text)) {
       continue
     }
-    const link = toParsedTerminalFileLink(range)
+    const link = toParsedTerminalFileLink(trimFileLinkRangeTrailingNonAsciiLetters(range))
     if (link) {
       links.push(link)
     }
@@ -259,7 +220,9 @@ function detectSpacedLocalPathLinks(
       const candidateLinks = candidateRanges
         .map((candidateRange) =>
           toParsedTerminalFileLink(
-            trimSpacedPathTrailingProse(trimTrailingWhitespace(candidateRange))
+            trimFileLinkRangeTrailingNonAsciiLetters(
+              trimSpacedPathTrailingProse(trimTrailingWhitespace(candidateRange))
+            )
           )
         )
         .filter((link): link is ParsedTerminalFileLink => link !== null)

--- a/src/renderer/src/lib/terminal-spaced-path-trailing-prose.ts
+++ b/src/renderer/src/lib/terminal-spaced-path-trailing-prose.ts
@@ -1,0 +1,50 @@
+import type { DetectedTerminalFileLinkRange } from './terminal-file-link-detection-ranges'
+
+// Why: keep one extension-terminated path, but drop trailing prose or a second
+// unrelated path that the broad spaced-path scan also captured. A line-end
+// extension token only extends the span when the added segment is path-like
+// (contains a separator) — "v1.2 reports/result.json" extends, prose like
+// "failed to start app.py" must not be swallowed.
+// Also stop before non-ASCII letters so `…/파일.md로 열었습니다` keeps only
+// the path after `\p{L}` widening (space-only trim leaves the particle).
+const EXTENSION_PREFIX_PATTERN =
+  /\.[A-Za-z0-9_+-]+(?::\d+)?(?::\d+)?(?=\s+|$|(?:(?![A-Za-z])\p{L}))/gu
+
+function countPathStarts(text: string): number {
+  let count = 0
+  for (const match of text.matchAll(/(?:^|\s)(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/])/g)) {
+    void match
+    count += 1
+  }
+  return count
+}
+
+export function trimSpacedPathTrailingProse(
+  range: DetectedTerminalFileLinkRange
+): DetectedTerminalFileLinkRange {
+  let selected: string | null = null
+  EXTENSION_PREFIX_PATTERN.lastIndex = 0
+  let match: RegExpExecArray | null
+  while ((match = EXTENSION_PREFIX_PATTERN.exec(range.text)) !== null) {
+    const end = match.index + match[0].length
+    const text = range.text.slice(0, end)
+    if (countPathStarts(text) > 1) {
+      continue
+    }
+    if (
+      end < range.text.length ||
+      selected === null ||
+      /[\\/]/.test(range.text.slice(selected.length, end))
+    ) {
+      selected = text
+    }
+  }
+  if (!selected) {
+    return range
+  }
+  return {
+    text: selected,
+    startIndex: range.startIndex,
+    endIndex: range.startIndex + selected.length
+  }
+}

--- a/src/shared/file-link-trailing-prose.test.ts
+++ b/src/shared/file-link-trailing-prose.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import {
+  trimFileLinkRangeTrailingNonAsciiLetters,
+  trimFileLinkTrailingNonAsciiLetters
+} from './file-link-trailing-prose'
+
+describe('trimFileLinkTrailingNonAsciiLetters', () => {
+  it.each([
+    ['README.md로', 'README.md'],
+    ['AGENTS.md에', 'AGENTS.md'],
+    ['file.tsです', 'file.ts'],
+    ['plans/foo.md로', 'plans/foo.md'],
+    ['src/foo.ts:12로', 'src/foo.ts:12'],
+    ['src/foo.ts:12:3에', 'src/foo.ts:12:3'],
+    ['/Users/me/docs/한글폴더/파일.md로', '/Users/me/docs/한글폴더/파일.md'],
+    ['파일.md了', '파일.md']
+  ])('trims non-ASCII letters after an ASCII extension: %s', (input, expected) => {
+    expect(trimFileLinkTrailingNonAsciiLetters(input)).toBe(expected)
+  })
+
+  it.each([
+    'README.md',
+    'README.md for',
+    'file.mdbackup',
+    'file.mdBackup',
+    'plans/foo.md',
+    '/Users/me/docs/한글폴더/파일.md',
+    'Makefile',
+    'src/foo.ts:12:3'
+  ])('leaves non-particle text unchanged: %s', (input) => {
+    expect(trimFileLinkTrailingNonAsciiLetters(input)).toBe(input)
+  })
+
+  it('adjusts endIndex when trimming a range', () => {
+    const range = {
+      text: 'README.md로',
+      startIndex: 10,
+      endIndex: 10 + 'README.md로'.length
+    }
+    expect(trimFileLinkRangeTrailingNonAsciiLetters(range)).toEqual({
+      text: 'README.md',
+      startIndex: 10,
+      endIndex: 19
+    })
+  })
+})

--- a/src/shared/file-link-trailing-prose.ts
+++ b/src/shared/file-link-trailing-prose.ts
@@ -1,0 +1,37 @@
+/**
+ * Strip CJK (and other non-ASCII) letter runs that glue onto a file extension
+ * in space-less languages. Agents and comments often write:
+ *
+ *   plans/foo.md로 확정했습니다.
+ *   See `README.md에`
+ *
+ * English splits on spaces (`…md for`), but Korean/Japanese/Chinese particles
+ * stay in the same token. ASCII Latin tails like `file.mdbackup` are kept —
+ * only non-ASCII letters after an ASCII extension (and optional :line[:col])
+ * count as trailing prose.
+ *
+ * Pair this with any `\p{L}` widening of path regexes: without the trim,
+ * `…/파일.md로` would be swallowed whole (#13396 / #15240).
+ */
+
+const ASCII_EXT_THEN_NON_ASCII_LETTERS =
+  /^(?<path>.*\.[A-Za-z0-9_+-]+(?::\d+)?(?::\d+)?)(?<prose>(?:(?![A-Za-z])\p{L})+)$/u
+
+export function trimFileLinkTrailingNonAsciiLetters(text: string): string {
+  const match = ASCII_EXT_THEN_NON_ASCII_LETTERS.exec(text)
+  return match?.groups?.path ?? text
+}
+
+export function trimFileLinkRangeTrailingNonAsciiLetters<
+  T extends { text: string; startIndex: number; endIndex: number }
+>(range: T): T {
+  const trimmed = trimFileLinkTrailingNonAsciiLetters(range.text)
+  if (trimmed === range.text) {
+    return range
+  }
+  return {
+    ...range,
+    text: trimmed,
+    endIndex: range.startIndex + trimmed.length
+  }
+}


### PR DESCRIPTION
## ELI5

In Korean, Japanese, and Chinese, agents often write paths with a particle stuck on the end — `README.md로`, `plans/foo.md에`. English splits on spaces (`…md for`), but these languages do not, so the whole run was one token and the file link never opened (or opened with the particle still attached).

This change keeps the real path clickable and leaves the particle as ordinary text.

## What Changed

- Added shared `trimFileLinkTrailingNonAsciiLetters` / range helper: after an ASCII extension (and optional `:line[:col]`), strip a trailing run of non-ASCII letters; keep Latin tails like `file.mdbackup`.
- Desktop terminal: widen `LOCAL_PATH_REGEX` with `\p{L}\p{M}\p{N}` (+ `u`) for mid-path CJK (#13396), then trim particles; wire the same trim into bare-filename and spaced-path detection.
- Mobile markdown + terminal path tap (+ injected twin): same widen + trim; code-span open path also trims before `onOpenFile`.
- Tests for particles (`README.md로`, `plans/foo.md로`, NFD/CJK paths, ReDoS non-Latin padding) and mobile code spans.

## Why

#15240 taught that non-ASCII **punctuation** ends a URL while CJK **letters** in a path must stay. The mirror for file links: CJK letters **inside** a path stay, but letters **after** a known ASCII extension are prose particles. Widening alone (closed #13399) would newly swallow `…/파일.md로` — trim makes that safe.

## Linked Issue

Fixes #13396
Related: #15240

## Visual Proof

No visual change — only the hover/underline and tap range for affected paths shrinks to exclude trailing particles.

## Testing

- [x] Automated tests added/updated
- [ ] I manually tested these changes locally (logic covered by unit tests; no desktop UI smoke in this session)

Verified locally:

- `pnpm lint` ✅
- `pnpm typecheck` ✅
- Focused: `terminal-links` / `file-link-trailing-prose` / mobile markdown + path-tap suites ✅ (191 tests)
- `pnpm build`: Electron/vite client+main bundles succeeded; local `build:native` failed on a broken host `pnpm` shim (unrelated to this diff) — CI should cover native
- Full `pnpm test`: saw pre-existing flaky relay/git/socket failures unrelated to file-link parsing (same class noted on #13399)

## AI Disclosure

Implemented with Cursor (Composer) assistance.

## Review

**AI review notes**

- **Cross-platform:** Character-class widen + trim only; Windows drive / UNC prefixes unchanged. Underscore kept in mobile classes that replaced `\w`.
- **SSH / remote:** Detection stays text-only before existence/auth probes.
- **Mobile:** TS + injected WebView twin kept in sync; injected `u`-flag regex uses `\x60` instead of invalid `\``.
- **Performance / ReDoS:** Non-Latin padding cases added to #5970 guard; extension trim is linear.
- **False positives:** `file.mdbackup` is not trimmed to `file.md`.
- **Security:** Still only widens recognition; open path still goes through existing resolve/stat/auth gates.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
