### PR TITLE
fix(terminal): stop OMP tab title flapping between OMP and Pi

### DIFF
--- a/src/renderer/src/store/slices/repro-omp-pi-alternating-title-frame-churn.test.ts
+++ b/src/renderer/src/store/slices/repro-omp-pi-alternating-title-frame-churn.test.ts
@@ -1,0 +1,176 @@
+/**
+ * OMP tab-title churn repro: an OMP-owned terminal tab's title text oscillates
+ * between "OMP" and "Pi" at spinner cadence, committing a fresh store patch on
+ * every frame.
+ *
+ * OMP wraps Pi, so TWO independent writers publish OSC title frames into the
+ * same pane, and both are "correct" from their own vantage point:
+ *
+ *  A) main's synthetic title spinner. `driveSyntheticTitleFromHook` starts a
+ *     shared 80ms interval (src/main/index.ts:1947 SPINNER_FRAMES, :1948
+ *     SPINNER_INTERVAL_MS) that injects `\x1b]0;<frame> <profile.workingLabel>\x07`
+ *     (:2170, :2205). For an OMP-owned pane the profile is `omp`, so every tick
+ *     asserts "<spinner> OMP".
+ *  B) the OMP process itself, which is Pi underneath and emits Pi's own frames.
+ *     "⠋ Pi" passes through untouched, and legacy "π …" frames are collapsed to
+ *     a HARDCODED "Pi" by `normalizeTerminalTitle`
+ *     (src/shared/agent-title-status.ts:135-144) — that collapse is
+ *     identity-blind, so an OMP-owned pane still yields the literal "Pi".
+ *
+ * `pi` and `omp` share `titleIdentityGroup: 'pi-compatible'`
+ * (src/shared/synthetic-agent-title.ts:45-56), so these are the SAME identity as
+ * far as ownership is concerned — but neither writer is normalized to the tab's
+ * launch owner before it reaches the store.
+ *
+ * The churn suppressor that normally absorbs spinner noise is defeated here.
+ * `isDecorativeAgentTitleFrameChange` keys on `status:textWithoutSpinner`
+ * (src/shared/agent-decorative-title-signature.ts:17): "⠋ OMP" -> `working:OMP`,
+ * "⠙ Pi" -> `working:Pi`. The signatures differ, so every alternating frame is
+ * classified as a MEANINGFUL change and commits — through
+ * `applyTerminalTabTitleUpdates`
+ * (src/renderer/src/store/slices/terminal-tab-title-batch.ts:183) for `tab.title`
+ * (the string `resolveTerminalTabTitle` renders in the tab bar) and through
+ * `setRuntimePaneTitle`
+ * (src/renderer/src/store/terminals/terminal-tab-presentation.ts:145-172) for the
+ * pane slot. At 80ms that is ~12 committed patches per second, per working OMP
+ * tab, with a visibly flickering label.
+ *
+ * The oracle is commit COUNT, not exact text: the status never leaves 'working'
+ * across the sequence, so a correctly owner-pinned title settles after the first
+ * frame and every later frame is decoration. Both tests drive the REAL store
+ * actions over the REAL frame text main emits.
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }))
+vi.mock('@/runtime/sync-runtime-graph', () => ({
+  scheduleRuntimeGraphSync: vi.fn()
+}))
+vi.mock('@/components/terminal-pane/pty-transport', () => ({
+  registerEagerPtyBuffer: vi.fn(),
+  ensurePtyDispatcher: vi.fn(),
+  unregisterPtyDataHandlers: vi.fn()
+}))
+vi.mock('@/components/terminal-pane/shutdown-buffer-captures', () => ({
+  shutdownBufferCaptures: vi.fn()
+}))
+
+// @ts-expect-error -- minimal preload API stub for the slice's IPC writes
+globalThis.window = { api: {} }
+
+import { getPiCompatibleSyntheticAgentLabel } from '../../../../shared/pi-compatible-synthetic-title'
+import { resolveTerminalTabTitle } from '../../../../shared/tab-title-resolution'
+import {
+  createTestStore,
+  makeTab,
+  makeUnifiedTab,
+  makeWorktree,
+  seedStore
+} from './store-test-helpers'
+
+const WT = 'wt-omp'
+const TAB_ID = 'tab-omp-1'
+const GROUP_ID = 'group-1'
+const PANE_ID = 1
+
+// Verbatim from src/main/index.ts:1947.
+const SPINNER_FRAMES = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
+
+/**
+ * 20 frames of one OMP turn: main's synthetic "OMP" tick interleaved with the
+ * wrapped Pi harness's own frame. Every frame classifies as 'working', so the
+ * ONLY thing changing is which of the two pi-compatible identities is showing.
+ */
+const OMP_TURN_TITLE_FRAMES = Array.from({ length: 20 }, (_, index) => {
+  const spinner = SPINNER_FRAMES[index % SPINNER_FRAMES.length]
+  return index % 2 === 0 ? `${spinner} OMP` : `${spinner} Pi`
+})
+
+function seedOmpTab(store: ReturnType<typeof createTestStore>): void {
+  seedStore(store, {
+    worktreesByRepo: {
+      repo1: [makeWorktree({ id: WT, repoId: 'repo1', path: '/path/wt-omp' })]
+    },
+    tabsByWorktree: {
+      // The user launched OMP into this tab — the identity the title must follow.
+      [WT]: [makeTab({ id: TAB_ID, worktreeId: WT, title: 'Terminal 1', launchAgent: 'omp' })]
+    },
+    unifiedTabsByWorktree: {
+      [WT]: [makeUnifiedTab({ id: TAB_ID, worktreeId: WT, groupId: GROUP_ID })]
+    },
+    activeWorktreeId: WT
+  })
+}
+
+/** The identity a tab-bar frame reads as: 'OMP', 'Pi', or null when neither. */
+function displayedAgentIdentity(tabTitle: string): string | null {
+  return getPiCompatibleSyntheticAgentLabel(
+    resolveTerminalTabTitle({ title: tabTitle }, false, 'Terminal 1')
+  )
+}
+
+describe('OMP-owned tab title across interleaved OMP/Pi spinner frames', () => {
+  it('commits at most one tab-title patch for the whole working turn', () => {
+    const store = createTestStore()
+    seedOmpTab(store)
+
+    // Zustand only notifies when the action returns a fresh patch, so one
+    // listener call === one committed store patch.
+    let commits = 0
+    const seenTitles: string[] = []
+    const unsubscribe = store.subscribe((state) => {
+      commits += 1
+      const title = state.tabsByWorktree[WT]?.[0]?.title
+      if (title && title !== seenTitles.at(-1)) {
+        seenTitles.push(title)
+      }
+    })
+
+    for (const frame of OMP_TURN_TITLE_FRAMES) {
+      store.getState().updateTabTitle(TAB_ID, frame)
+    }
+    unsubscribe()
+
+    // One commit takes the tab off its "Terminal 1" default; the remaining 19
+    // frames are pure decoration under the OMP owner.
+    expect(commits).toBeLessThanOrEqual(1)
+    expect(Array.from(new Set(seenTitles.map(displayedAgentIdentity)))).toEqual(['OMP'])
+  })
+
+  it('commits at most one runtime pane-title patch for the whole working turn', () => {
+    const store = createTestStore()
+    seedOmpTab(store)
+
+    let commits = 0
+    const unsubscribe = store.subscribe(() => {
+      commits += 1
+    })
+
+    for (const frame of OMP_TURN_TITLE_FRAMES) {
+      store.getState().setRuntimePaneTitle(TAB_ID, PANE_ID, frame)
+    }
+    unsubscribe()
+
+    expect(commits).toBeLessThanOrEqual(1)
+    expect(
+      getPiCompatibleSyntheticAgentLabel(
+        store.getState().runtimePaneTitlesByTabId[TAB_ID]?.[PANE_ID] ?? ''
+      )
+    ).toBe('OMP')
+  })
+
+  // Why: owner-pinning must stay scoped to bare identity frames. A semantic session title carries
+  // text no agent profile can reproduce, so relabeling it to "OMP ready" would lose real
+  // information — the complaint in #16093, which this fix must not reintroduce.
+  it('leaves a semantic session title untouched', () => {
+    const store = createTestStore()
+    seedOmpTab(store)
+
+    const semanticTitle = 'π - fixing the sidebar - orca'
+    store.getState().updateTabTitle(TAB_ID, semanticTitle)
+    store.getState().setRuntimePaneTitle(TAB_ID, PANE_ID, semanticTitle)
+
+    expect(store.getState().tabsByWorktree[WT]?.[0]?.title).toBe(semanticTitle)
+    expect(store.getState().runtimePaneTitlesByTabId[TAB_ID]?.[PANE_ID]).toBe(semanticTitle)
+  })
+})

--- a/src/renderer/src/store/slices/repro-omp-pi-alternating-title-frame-churn.test.ts
+++ b/src/renderer/src/store/slices/repro-omp-pi-alternating-title-frame-churn.test.ts
@@ -105,7 +105,7 @@ function seedOmpTab(store: ReturnType<typeof createTestStore>): void {
 /** The identity a tab-bar frame reads as: 'OMP', 'Pi', or null when neither. */
 function displayedAgentIdentity(tabTitle: string): string | null {
   return getPiCompatibleSyntheticAgentLabel(
-    resolveTerminalTabTitle({ title: tabTitle }, false, 'Terminal 1')
+    resolveTerminalTabTitle({ title: tabTitle, customTitle: null }, false, 'Terminal 1')
   )
 }
 
@@ -157,6 +157,31 @@ describe('OMP-owned tab title across interleaved OMP/Pi spinner frames', () => {
         store.getState().runtimePaneTitlesByTabId[TAB_ID]?.[PANE_ID] ?? ''
       )
     ).toBe('OMP')
+  })
+
+  // Why: relabeling is for frames naming a DIFFERENT group member. A frame that already names the
+  // owner carries its own status wording, so restating bare "OMP" as "OMP ready" would change a
+  // tab that never flapped — and the same guard keeps a plain Pi-owned tab byte-identical.
+  it.each([
+    ['omp', 'OMP'],
+    ['pi', 'Pi']
+  ] as const)('leaves a %s-owned tab’s own identity frames untouched', (launchAgent, label) => {
+    const store = createTestStore()
+    seedStore(store, {
+      worktreesByRepo: { repo1: [makeWorktree({ id: WT, repoId: 'repo1', path: '/path/wt-omp' })] },
+      tabsByWorktree: {
+        [WT]: [makeTab({ id: TAB_ID, worktreeId: WT, title: 'Terminal 1', launchAgent })]
+      },
+      unifiedTabsByWorktree: {
+        [WT]: [makeUnifiedTab({ id: TAB_ID, worktreeId: WT, groupId: GROUP_ID })]
+      },
+      activeWorktreeId: WT
+    })
+
+    for (const frame of [label, `${label} ready`, `⠋ ${label}`]) {
+      store.getState().setRuntimePaneTitle(TAB_ID, PANE_ID, frame)
+      expect(store.getState().runtimePaneTitlesByTabId[TAB_ID]?.[PANE_ID]).toBe(frame)
+    }
   })
 
   // Why: owner-pinning must stay scoped to bare identity frames. A semantic session title carries

--- a/src/renderer/src/store/slices/terminal-tab-title-batch.ts
+++ b/src/renderer/src/store/slices/terminal-tab-title-batch.ts
@@ -1,5 +1,6 @@
 import { deriveGeneratedTabTitle } from '../../../../shared/agent-tab-title'
 import { isDecorativeAgentTitleFrameChange } from '../../../../shared/agent-decorative-title-signature'
+import { relabelCompatibleAgentIdentityFrameForOwner } from '../../../../shared/agent-title-owner'
 import { parseLegacyNumericPaneKey, parsePaneKey } from '../../../../shared/stable-pane-id'
 import type { Tab } from '../../../../shared/tab-types'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
@@ -179,7 +180,10 @@ export function applyTerminalTabTitleUpdates(
     if (!currentTab || !tabIndexes) {
       continue
     }
-    const nextTitle = title.trim() || getFallbackTabTitle(currentTab)
+    // Why: a wrapped harness emits the inner agent's identity (OMP wraps Pi), so pin those frames
+    // to the launch owner — otherwise the alternating label defeats the decorative check below.
+    const ownedTitle = relabelCompatibleAgentIdentityFrameForOwner(title, currentTab.launchAgent)
+    const nextTitle = ownedTitle.trim() || getFallbackTabTitle(currentTab)
     if (isDecorativeAgentTitleFrameChange(currentTab.title, nextTitle)) {
       updateStageUnifiedLabel(stage, tabId, 'label', currentTab.title)
       continue

--- a/src/renderer/src/store/terminals/terminal-tab-presentation.ts
+++ b/src/renderer/src/store/terminals/terminal-tab-presentation.ts
@@ -1,4 +1,6 @@
 import { isDecorativeAgentTitleFrameChange } from '../../../../shared/agent-decorative-title-signature'
+import { relabelCompatibleAgentIdentityFrameForOwner } from '../../../../shared/agent-title-owner'
+import { getPiCompatibleSyntheticAgentLabel } from '../../../../shared/pi-compatible-synthetic-title'
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { classifyTitleActivity } from '@/lib/pane-agent-evidence'
 import {
@@ -10,7 +12,20 @@ import {
   getTerminalTabOwnerWorktreeId
 } from '../slices/terminal-tab-owner-index'
 import { getTabIdFromPaneKey } from './terminal-pty-identities'
+import type { TuiAgent } from '../../../../shared/tui-agent'
+import type { AppState } from '../types'
 import type { TerminalSlice, TerminalStoreGet, TerminalStoreSet } from './terminal-state'
+
+function getTabLaunchAgent(
+  state: Pick<AppState, 'tabsByWorktree'>,
+  tabId: string
+): TuiAgent | undefined {
+  const ownerWorktreeId = getTerminalTabOwnerWorktreeId(state.tabsByWorktree, tabId)
+  if (!ownerWorktreeId) {
+    return undefined
+  }
+  return state.tabsByWorktree[ownerWorktreeId]?.find((tab) => tab.id === tabId)?.launchAgent
+}
 
 export function createTerminalTabPresentationActions(
   set: TerminalStoreSet,
@@ -142,8 +157,13 @@ export function createTerminalTabPresentationActions(
         return { tabsByWorktree: { ...s.tabsByWorktree, [ownerWorktreeId]: nextTabs } }
       })
     },
-    setRuntimePaneTitle: (tabId, paneId, title) => {
+    setRuntimePaneTitle: (tabId, paneId, rawTitle) => {
       set((s) => {
+        // Why: same-group frames (OMP wraps Pi) must read as the launch owner or the alternating
+        // label defeats the decorative check below; the owner lookup stays off the common path.
+        const title = getPiCompatibleSyntheticAgentLabel(rawTitle)
+          ? relabelCompatibleAgentIdentityFrameForOwner(rawTitle, getTabLaunchAgent(s, tabId))
+          : rawTitle
         const currentByPane = s.runtimePaneTitlesByTabId[tabId] ?? {}
         const prevTitle = currentByPane[paneId]
         if (prevTitle === title) {

--- a/src/shared/agent-title-owner.ts
+++ b/src/shared/agent-title-owner.ts
@@ -181,7 +181,14 @@ export function relabelCompatibleAgentIdentityFrameForOwner(
   title: string,
   ownerAgentType: AgentType | null | undefined
 ): string {
-  if (!getPiCompatibleSyntheticAgentLabel(title)) {
+  const frameLabel = getPiCompatibleSyntheticAgentLabel(title)
+  if (!frameLabel) {
+    return title
+  }
+  // Why: the frame already names the owner, so its own status wording is authoritative — rewriting
+  // it would restate bare "Pi" as "Pi ready" and change a Pi-owned tab that never flapped.
+  const ownerProfile = getSyntheticAgentTitleProfile(ownerAgentType)
+  if (ownerProfile?.workingLabel.toLowerCase() === frameLabel.toLowerCase()) {
     return title
   }
   return normalizeCompatibleAgentTitleForOwner(title, ownerAgentType)

--- a/src/shared/agent-title-owner.ts
+++ b/src/shared/agent-title-owner.ts
@@ -5,7 +5,10 @@ import {
   SYNTHETIC_AGENT_TITLE_PROFILES,
   type SyntheticAgentTitleProfile
 } from './synthetic-agent-title'
-import { isLegacyPiCompatibleTitle } from './pi-compatible-synthetic-title'
+import {
+  getPiCompatibleSyntheticAgentLabel,
+  isLegacyPiCompatibleTitle
+} from './pi-compatible-synthetic-title'
 import { getWrapperTitleSegments } from './terminal-title-wrapper-segments'
 
 type TitleProfileMatch = {
@@ -164,6 +167,24 @@ export function normalizeCompatibleAgentTitleForOwner(
     return ownerProfile.idleLabel
   }
   return ownerProfile.workingLabel
+}
+
+/**
+ * Relabels only a bare identity frame ("⠋ Pi", "Pi ready") to the owner's label.
+ *
+ * Why: a wrapped harness publishes the inner agent's identity (OMP wraps Pi), so those frames
+ * alternate against the owner's own and defeat decorative-frame suppression at the store. A
+ * semantic session title ("π - <session> - <cwd>") is left alone — it carries text no owner
+ * profile can reproduce, so rewriting it to a generic label would lose real information.
+ */
+export function relabelCompatibleAgentIdentityFrameForOwner(
+  title: string,
+  ownerAgentType: AgentType | null | undefined
+): string {
+  if (!getPiCompatibleSyntheticAgentLabel(title)) {
+    return title
+  }
+  return normalizeCompatibleAgentTitleForOwner(title, ownerAgentType)
 }
 
 /**


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​201 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​201 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​55 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​52 |

<!-- /orca-pr-loc -->

## ELI5

Launch OMP in a terminal tab and the tab label ping-pongs between "OMP" and "Pi" many times a second. OMP is Pi underneath, so two different parts of Orca kept renaming the same tab — one insisted "OMP", the other "Pi". Orca already has a filter that ignores spinner noise, but because the *name* kept changing (not just the spinner), the filter let every single frame through. Each one rebuilt store state and re-rendered the tab. This pins the label to whichever agent the user actually launched, so the filter works again.

## What Changed

- Pin `pi-compatible` identity title frames to the tab's `launchAgent` at the two store choke points: `applyTerminalTabTitleUpdates` (tab title) and `setRuntimePaneTitle` (pane title slot).
- Added `relabelCompatibleAgentIdentityFrameForOwner` to `src/shared/agent-title-owner.ts`, which wraps the existing `normalizeCompatibleAgentTitleForOwner` and scopes the relabel to bare identity frames only.
- Added a store-level regression suite that asserts commit **counts**, not just label text.

## Why

`pi` and `omp` share `titleIdentityGroup: 'pi-compatible'` (`src/shared/synthetic-agent-title.ts:45-56`). An OMP pane has two title writers that disagree on the label:

- **Writer A** — main's synthetic spinner injects `"<frame> OMP"` every 80 ms (`src/main/index.ts:1948` `SPINNER_INTERVAL_MS`, `:2170`, `:2205`).
- **Writer B** — the wrapped Pi harness emits its own frames. `"⠋ Pi"` passes through untouched, and legacy `"π …"` frames are collapsed to a **hardcoded** `"Pi"` by `normalizeTerminalTitle` (`src/shared/agent-title-status.ts:135-144`) — that collapse is identity-blind.

The churn suppressor `isDecorativeAgentTitleFrameChange` keys on `status:textWithoutSpinner` (`src/shared/agent-decorative-title-signature.ts:17`). It correctly absorbs `⠋/⠙/⠹ OMP` (all → `working:OMP`), but `"⠋ OMP"` → `working:OMP` vs `"⠋ Pi"` → `working:Pi` are **different signatures**, so the alternation defeated suppression entirely. Every 80 ms frame became a committed store patch on both title paths, each dragging a `scheduleRuntimeGraphSync()` with it.

A plain Pi pane never flaps — both writers agree on "Pi". That is why this reproduces only with OMP.

The tab **icon** was already hardened for exactly this case (`resolveTabAgentFromSignals` pins `omp` over Pi-compatible wrapper titles, per #6689/#7633/#9077). The **title string** never got the same treatment. This closes that asymmetry by reusing the same owner-normalization helper already applied on the sidebar (`worktree-title-derived-agent-rows.ts:144`), remote-sync (`web-session-tabs-sync.ts:1103`), and mounted-pane (`terminal-title-evidence.ts:17`) paths — but not, until now, at the store.

## Scope note: semantic session titles

`normalizeCompatibleAgentTitleForOwner` applied naively also rewrites *semantic* titles: `"π - fixing sidebar - orca"` → `"OMP ready"`. That is precisely what open issue #16093 wants preserved. The relabel is therefore gated on `getPiCompatibleSyntheticAgentLabel`, which matches only bare identity frames (`"⠋ Pi"`, `"Pi ready"`, `"OMP - action required"`) and never a title carrying session text.

This is not a live regression today — `normalizeTerminalTitle` already destroys that text upstream — but it would have become one the moment #16093 is fixed. A regression test pins it.

## Relationship to #16234

Open PR #16234 ("Preserve OMP and Pi semantic session titles", fixes #16093) disables synthetic working-title synthesis for **local** pi/omp, removing Writer A locally. These are complementary, not competing:

- #16234 deliberately **retains** the synthetic writer for relay/SSH-hosted pi/omp sessions, where this flap would remain.
- #16234 does not touch the identity-blind `normalizeTerminalTitle` collapse, so an OMP pane can still be labeled "Pi".
- This PR fixes the label at the store regardless of which writers are active.

No conflict: #16234 touches `src/shared/synthetic-agent-title.ts` and `src/main/index.ts`; this touches the renderer store and `agent-title-owner.ts`.

Prior art in the same family: #6619/#6689, #6943/#6954, #7633, #8032, #8986, commits `dd0f4c39c8f` and `bf26ccb3100`. Still open and related: #12870.

## Proof

RED — fix reverted, regression suite at its committed state:

```
× commits at most one tab-title patch for the whole working turn
  AssertionError: expected 20 to be less than or equal to 1
× commits at most one runtime pane-title patch for the whole working turn
  AssertionError: expected 20 to be less than or equal to 1

Tests  2 failed | 1 passed (3)
```

20 alternating frames → **20 committed store patches**, on both paths.

GREEN — fix applied:

```
Test Files  1 passed (1)
     Tests  3 passed (3)
```

20 frames → **≤1 commit**, and the displayed identity is `OMP` for every frame.

## Visual Proof

N/A — no live OMP install was available in this environment to film. The change is OSC title-writer arbitration with no layout, color, or component change; the user-visible effect (label stops alternating) is pinned by deterministic commit-count assertions rather than a screenshot.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

- `src/renderer/src/store/slices/repro-omp-pi-alternating-title-frame-churn.test.ts` — 3 tests: tab-title commit count, pane-title commit count, semantic-title preservation. RED/GREEN transcript above.
- Broad regression sweep (store, terminal-pane, sidebar, runtime, shared, lib): **16,928 passed / 67 skipped**, then **15,457 passed** after the gating refactor.
- `pnpm lint` — passed (exit 0), before and after the refactor.
- `npx tsc --noEmit` — passed (exit 0), before and after the refactor.
- `pnpm build` — not run.

## Review

- **Security**: no input, credential, process, filesystem, or shell surface changes.
- **Cross-platform**: platform-neutral store logic; no path, shortcut, or process handling. Not manually run on Windows or Linux.
- **SSH/remote**: the fix sits in the renderer store, so it applies to mirrored remote panes as well as local ones. No RPC, stream, opcode, schema, or published-payload change — no wire-compatibility impact.
- **Folder workspaces**: owner lookup goes through `getTerminalTabOwnerWorktreeId`, which is workspace-kind agnostic.
- **Agent compatibility**: scoped to the `pi-compatible` identity group. `normalizeCompatibleAgentTitleForOwner` early-returns for any owner without a `titleIdentityGroup`, so Claude, Codex, OpenCode, Droid, and others are untouched — confirmed by the unchanged suites.
- **Performance**: strictly reduces work. The `setRuntimePaneTitle` owner lookup is gated behind a cheap regex so non-pi-compatible titles skip it entirely.
- **Backwards compatibility**: no persisted format or setting changes.

## Notes

Reported symptom was a perf problem, and the store-commit count is the mechanism — this is a perf fix as much as a cosmetic one.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint`, `pnpm typecheck` pass; `pnpm build` not run (CI will cover)
