### PR TITLE
fix(terminal): give OMP Pi's Windows Shift+Enter encoding

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.test.ts
@@ -41,6 +41,16 @@ describe('resolveWindowsShiftEnterEncoding', () => {
     ).toBe('csi-u')
   })
 
+  // Why: OMP wraps Pi, so an OMP-labelled title still reaches a Pi reader. Owner-pinning made the
+  // stored pane title read "OMP" for every OMP pane (#16373), so an omp profile without the Pi
+  // encoding sends Esc+CR — which submits instead of inserting a newline (#9703).
+  it('recovers CSI-u from an OMP title, which wraps the same Pi reader', () => {
+    const state = { paneForegroundAgentByPaneKey: {}, agentLaunchConfigByPaneKey: {} }
+    for (const title of ['⠸ OMP', 'OMP ready', 'OMP', 'OMP - action required']) {
+      expect(resolveWindowsShiftEnterEncodingForPane(state, 'tab:pane', title)).toBe('csi-u')
+    }
+  })
+
   it('keeps trusted process and shell evidence authoritative over titles', () => {
     const state = {
       paneForegroundAgentByPaneKey: {

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -148,7 +148,9 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     launchCmd: 'omp',
     expectedProcess: 'omp',
     promptInjectionMode: 'argv',
-    draftPromptEnvVar: 'ORCA_OMP_PREFILL'
+    draftPromptEnvVar: 'ORCA_OMP_PREFILL',
+    // Why: OMP wraps Pi's TUI, so the bytes land in a Pi reader that decodes CSI-u (see pi above).
+    windowsShiftEnterEncoding: 'csi-u'
   },
   'prime-agent': {
     detectCmd: 'prime-agent',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

On Windows, pressing Shift+Enter in an OMP session would **submit** your message instead of adding a new line. OMP is Pi under the hood, and Pi needs a specific keyboard byte encoding — but Orca's config table never listed that for OMP, only for Pi. This adds the missing line.

## What Changed

One config entry: `windowsShiftEnterEncoding: 'csi-u'` on the `omp` profile in `src/shared/tui-agent-config.ts`, plus a regression test.

## Why

`src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.ts:57-60` falls back to the pane's stored terminal title when process/shell evidence is unavailable (the documented "process-scan gaps" case). It resolves an agent from that title and reads `windowsShiftEnterEncoding`:

- `pi` → `'csi-u'` (`tui-agent-config.ts:143`, *"Pi decodes CSI-u; Esc+CR submits after tool subprocesses reset live KKP state (#9703)"*)
- `omp` → **absent** → defaults to `'alt-enter'`

Measured through the real resolver before this change:

```
"⠋ Pi"      -> agent=pi   shiftEnter=csi-u
"Pi"        -> agent=pi   shiftEnter=csi-u
"⠋ OMP"     -> agent=omp  shiftEnter=alt-enter
"OMP ready" -> agent=omp  shiftEnter=alt-enter
```

Since OMP wraps Pi, the process receiving those bytes **is** Pi's TUI — the one that needs CSI-u. `prime-agent` already carries this exact entry at `tui-agent-config.ts:162-163` (*"Prime Agent embeds Pi's TUI and decodes CSI-u the same way"*). OMP has the identical relationship and was simply missing it.

### Why it matters now

This was latent: an OMP pane's stored title could read `"Pi"` or `"OMP"` depending on which interleaved frame happened to commit first under the decorative-frame suppressor, so the encoding was effectively a coin flip.

**#16373 (merged) made it deterministic.** Pinning `runtimePaneTitlesByTabId` to the tab's launch owner means an OMP pane's title now always reads `"OMP"`, so the Windows fallback always resolves `omp` and always picks `alt-enter`. A latent config gap became a consistent, reproducible bug on every Windows OMP pane.

`runtimePaneTitlesByTabId` is not display-only — `keyboard-handlers.ts:385-388` feeds it straight into `resolveWindowsShiftEnterEncodingForPane` for local Windows ConPTY panes.

`hasCtrlEnterCsiUAuthorityForPane` reads the same title, but neither profile sets `ctrlEnterEncoding`, so Ctrl+Enter is unaffected.

## Proof

RED (config entry reverted, test at its committed state):

```
× recovers CSI-u from an OMP title, which wraps the same Pi reader
  expected "alt-enter" to be "csi-u"

Tests  1 failed | 13 passed (14)
```

GREEN (fix applied):

```
Test Files  1 passed (1)
     Tests  14 passed (14)
```

## Visual Proof

N/A — no Windows machine was available in this environment, and the change is a keyboard byte-encoding table entry with no UI surface. Behavior is pinned by a unit test against the real resolver.

**This has not been manually verified on Windows.** The causal chain is verified by reading the four call sites and by running the resolver, but no live Shift+Enter keypress in a Windows OMP pane was tested.

## Testing

- [ ] I manually tested these changes locally (no Windows host available)
- [x] Automated tests added/updated

- `terminal-windows-shift-enter.test.ts` — new case covering `⠸ OMP`, `OMP ready`, `OMP`, `OMP - action required`. RED/GREEN above.
- `src/shared/` + `src/renderer/src/components/terminal-pane/`: **9,397 passed / 66 skipped**.
- `npm run typecheck` — exit 0. `pnpm lint` — passes via pre-commit.

## Review

- **Security**: none — a static config literal.
- **Cross-platform**: the field is read only on `isLocalWindowsConptyPane()`; macOS and Linux are unaffected. Not manually validated on Windows.
- **SSH/remote**: no wire, RPC, or payload change.
- **Agent compatibility**: touches only the `omp` profile; every other agent is byte-identical.
- **Backwards compatibility**: no persisted state or schema change.
- **Performance**: none.

## Credit

Found by review of #16373. Co-authored with @psh4607 (Seongho.Bak), whose #16234 investigation established the OMP↔Pi wrapping relationship this fix depends on.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint`, `pnpm typecheck` pass; `pnpm build` not run (CI will cover)
