### PR TITLE
Add workspace search and improve installation target UI

### DIFF
--- a/src/renderer/src/components/skills/SkillBundleInstallReview.tsx
+++ b/src/renderer/src/components/skills/SkillBundleInstallReview.tsx
@@ -57,16 +57,16 @@ export function SkillBundleInstallReview(props: {
 
   return (
     <div className="space-y-4">
-      <section className="space-y-2">
+      <div className="space-y-3 rounded-xl border border-border/70 bg-card/40 p-3.5">
         {manifest.skills.length > 1 ? (
-          <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center justify-between gap-3 pb-1">
             <p className="text-xs text-muted-foreground">
               {translate(
                 'auto.components.skills.install.chooseSkills',
                 'Choose what to install from this link.'
               )}
             </p>
-            <label className="flex items-center gap-2 text-xs">
+            <label className="flex cursor-pointer items-center gap-2 text-xs font-medium">
               <Checkbox
                 checked={allSelected ? true : props.selectedSkillIds.size ? 'indeterminate' : false}
                 disabled={props.busy}
@@ -87,24 +87,36 @@ export function SkillBundleInstallReview(props: {
           onSelectedChange={props.onToggleSkill}
         />
         {props.version.releaseNotes.trim() ? (
-          <p className="break-words whitespace-pre-wrap text-xs leading-5 text-muted-foreground">
-            {translate(
-              'auto.components.skills.SkillBundleInstallReview.01c5a11e09',
-              'Release notes:'
-            )}{' '}
+          <p className="break-words whitespace-pre-wrap rounded-lg border border-border/40 bg-muted/40 p-3 text-xs leading-5 text-muted-foreground">
+            <span className="font-semibold text-foreground">
+              {translate(
+                'auto.components.skills.SkillBundleInstallReview.01c5a11e09',
+                'Release notes:'
+              )}
+            </span>{' '}
             {props.version.releaseNotes}
           </p>
         ) : null}
-      </section>
+        <SkillInstallRiskNotice summary={props.riskSummary} />
+      </div>
 
-      <SkillInstallRiskNotice summary={props.riskSummary} />
-
-      {props.children}
+      <div className="space-y-3 rounded-xl border border-border/70 bg-card/40 p-3.5">
+        <div className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+          {translate(
+            'auto.components.skills.SkillInstallReviewContent.targetHeader',
+            'Installation Target'
+          )}
+        </div>
+        {props.children}
+      </div>
 
       {conflicts.length ? (
-        <section className="space-y-3 rounded-md border border-border p-3" role="alert">
-          <div className="flex items-center gap-2 text-sm font-medium">
-            <AlertTriangle className="size-4" />{' '}
+        <section
+          className="space-y-3 rounded-xl border border-destructive/30 bg-destructive/5 p-3.5"
+          role="alert"
+        >
+          <div className="flex items-center gap-2 text-sm font-medium text-destructive">
+            <AlertTriangle className="size-4 shrink-0" />{' '}
             {translate(
               'auto.components.skills.SkillBundleInstallReview.01c5a11e11',
               'Local copies need a decision'

--- a/src/renderer/src/components/skills/SkillInstallAgentPicker.test.tsx
+++ b/src/renderer/src/components/skills/SkillInstallAgentPicker.test.tsx
@@ -1,0 +1,114 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { SkillInstallAgentPicker } from './SkillInstallAgentPicker'
+
+describe('SkillInstallAgentPicker', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('renders summary in trigger button and title tooltip for hover', () => {
+    const selected = new Set(['claude', 'cursor'] as const)
+    render(
+      <SkillInstallAgentPicker
+        id="test-agents"
+        scope="workspace"
+        selected={selected}
+        detectedAgents={['claude', 'cursor', 'codex']}
+        busy={false}
+        onChange={() => undefined}
+      />
+    )
+
+    const trigger = screen.getByRole('button', { name: /Installing for:/ })
+    expect(trigger).toBeTruthy()
+    expect(trigger.getAttribute('title')).toContain('Installing for:')
+    expect(trigger.textContent).toContain('Claude Code')
+    expect(trigger.textContent).toContain('Cursor')
+  })
+
+  it('allows toggling selectable agents in popover', () => {
+    const onChange = vi.fn()
+    const selected = new Set(['claude'] as const)
+    render(
+      <SkillInstallAgentPicker
+        scope="global"
+        selected={selected}
+        detectedAgents={['claude', 'cursor']}
+        busy={false}
+        onChange={onChange}
+      />
+    )
+
+    const trigger = screen.getByRole('button', { name: /Installing for:/ })
+    fireEvent.click(trigger)
+
+    expect(screen.getByText('Additional Agent Directories')).toBeTruthy()
+    const cursorCheckbox = screen.getByRole('checkbox', { name: 'Cursor' })
+    expect(cursorCheckbox).toBeTruthy()
+    fireEvent.click(cursorCheckbox)
+
+    expect(onChange).toHaveBeenCalled()
+    const [next] = onChange.mock.calls[0] as [Set<string>]
+    expect(next.has('cursor')).toBe(true)
+  })
+
+  it('selects all selectable agents with header action', () => {
+    const onChange = vi.fn()
+    const selected = new Set(['claude'] as const)
+    render(
+      <SkillInstallAgentPicker
+        scope="global"
+        selected={selected}
+        detectedAgents={['claude', 'cursor', 'gemini']}
+        busy={false}
+        onChange={onChange}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /Installing for:/ }))
+
+    const selectAllBtn = screen.getByRole('button', { name: 'Select all' })
+    fireEvent.click(selectAllBtn)
+
+    expect(onChange).toHaveBeenCalled()
+    const [next] = onChange.mock.calls[0] as [Set<string>]
+    expect(next.has('cursor')).toBe(true)
+    expect(next.has('gemini')).toBe(true)
+  })
+
+  it('shows canonical agents in standard agents section with explanation', () => {
+    render(
+      <SkillInstallAgentPicker
+        scope="workspace"
+        selected={new Set()}
+        detectedAgents={['codex']}
+        busy={false}
+        onChange={() => undefined}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /Installing for:/ }))
+    expect(screen.getByText('Standard Agents (Always Included)')).toBeTruthy()
+    expect(screen.getByText('Codex')).toBeTruthy()
+    expect(screen.getByText('Cursor')).toBeTruthy()
+    expect(screen.getByText('Gemini CLI')).toBeTruthy()
+  })
+
+  it('shows not installed note for detected agents not found', () => {
+    render(
+      <SkillInstallAgentPicker
+        scope="workspace"
+        selected={new Set()}
+        detectedAgents={[]}
+        busy={false}
+        onChange={() => undefined}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: /Installing for:/ }))
+    expect(screen.getAllByText('Not installed').length).toBeGreaterThan(0)
+  })
+})

--- a/src/renderer/src/components/skills/SkillInstallAgentPicker.tsx
+++ b/src/renderer/src/components/skills/SkillInstallAgentPicker.tsx
@@ -1,7 +1,10 @@
-import { ChevronRight } from 'lucide-react'
+import { useState } from 'react'
+import { Bot, Check, ChevronsUpDown, Sparkles } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible'
 import { Label } from '@/components/ui/label'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
 import type { SkillInstallProviderId } from '../../../../shared/skill-install-providers'
 import {
@@ -26,7 +29,12 @@ function AgentRow({
 }): React.JSX.Element {
   return (
     <li>
-      <label className="flex cursor-pointer items-center gap-3 px-3 py-2 text-xs">
+      <label
+        className={cn(
+          'flex items-center gap-3 rounded-md px-2.5 py-2 text-xs transition-colors select-none',
+          disabled ? 'cursor-not-allowed opacity-75' : 'cursor-pointer hover:bg-accent/60'
+        )}
+      >
         <Checkbox
           checked={checked}
           disabled={disabled}
@@ -35,34 +43,40 @@ function AgentRow({
         />
         {/* Why: a fixed name column lines the paths up, so the eye reads one
             list of destinations instead of a ragged edge. */}
-        <span className="w-28 shrink-0 truncate">{name}</span>
+        <span className="w-28 shrink-0 truncate font-medium text-foreground">{name}</span>
         <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-muted-foreground">
           {directory}
         </span>
-        {note ? <span className="shrink-0 text-[11px] text-muted-foreground">{note}</span> : null}
+        {note ? (
+          <span className="shrink-0 rounded bg-muted/70 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+            {note}
+          </span>
+        ) : null}
       </label>
     </li>
   )
 }
 
 /**
- * Mirrors the `skills` CLI: one list, where agents that read the canonical
- * `.agents/skills` root at this scope are shown already on and locked, because
- * the canonical copy is written whatever the user picks.
+ * Explains canonical .agents/skills consumers in a dedicated header card, while
+ * offering clean selectable checkboxes for agents with custom directory placements.
  */
 export function SkillInstallAgentPicker({
+  id,
   scope,
   selected,
   detectedAgents,
   busy,
   onChange
 }: {
+  id?: string
   scope: 'global' | 'workspace'
   selected: ReadonlySet<SkillInstallProviderId>
   detectedAgents: readonly string[] | null
   busy: boolean
   onChange: (next: Set<SkillInstallProviderId>) => void
 }): React.JSX.Element {
+  const [open, setOpen] = useState(false)
   const { canonical, selectable } = groupSkillInstallProviders(scope, detectedAgents)
   const installed = detectedAgents ? new Set(detectedAgents) : null
   const canonicalRoot = scope === 'global' ? '~/.agents/skills' : '.agents/skills'
@@ -72,68 +86,166 @@ export function SkillInstallAgentPicker({
       .filter((choice) => selected.has(choice.provider.id))
       .map((choice) => choice.provider.displayName)
   ]
+
+  const selectableChosenCount = selectable.filter((choice) =>
+    selected.has(choice.provider.id)
+  ).length
+  const allSelectableChosen = selectable.length > 0 && selectableChosenCount === selectable.length
+
+  const selectAll = (): void => {
+    const next = new Set(selected)
+    for (const choice of selectable) {
+      next.add(choice.provider.id)
+    }
+    onChange(next)
+  }
+
+  const clearSelectable = (): void => {
+    const next = new Set(selected)
+    for (const choice of selectable) {
+      next.delete(choice.provider.id)
+    }
+    onChange(next)
+  }
+
+  const summaryText =
+    chosen.length === 0
+      ? translate('auto.components.skills.install.agentsNone', 'No agents selected')
+      : translate('auto.components.skills.install.agentsSelected', 'Installing for: {{value0}}', {
+          value0: chosen.join(', ')
+        })
+
   return (
-    <Collapsible className="space-y-2">
-      <div className="space-y-1">
-        <Label>{translate('auto.components.skills.install.agentsLabel', 'Agents')}</Label>
-        {/* Why: a full-width row with the chevron trailing, so this disclosure
-            and the skill rows above it open the same way. */}
-        <CollapsibleTrigger className="group flex w-full items-center gap-3 rounded-md text-left text-xs text-muted-foreground outline-none hover:text-foreground focus-visible:ring-1 focus-visible:ring-ring">
-          <span className="min-w-0 flex-1 truncate">
-            {chosen.length === 0
-              ? translate('auto.components.skills.install.agentsNone', 'No agents selected')
-              : translate(
-                  'auto.components.skills.install.agentsSelected',
-                  'Installing for: {{value0}}',
-                  { value0: chosen.join(', ') }
-                )}
-          </span>
-          <ChevronRight className="size-3.5 shrink-0 transition-transform group-data-[state=open]:rotate-90" />
-        </CollapsibleTrigger>
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <Label htmlFor={id}>
+          {translate('auto.components.skills.install.agentsLabel', 'Agents')}
+        </Label>
+        <span className="text-[11px] text-muted-foreground">
+          {translate('auto.components.skills.install.agentsCountBadge', '{{count}} selected', {
+            count: chosen.length
+          })}
+        </span>
       </div>
-      <CollapsibleContent className="collapsible-height-content space-y-2">
-        <ul className="divide-y divide-border rounded-md border border-border">
-          {canonical.map((provider) => (
-            <AgentRow
-              key={provider.id}
-              name={provider.displayName}
-              directory={canonicalRoot}
-              checked
-              disabled
-              note={translate('auto.components.skills.install.agentAlways', 'Always')}
-            />
-          ))}
-          {selectable.map(({ provider, directory }) => (
-            <AgentRow
-              key={provider.id}
-              name={provider.displayName}
-              directory={directory}
-              checked={selected.has(provider.id)}
-              disabled={busy}
-              note={
-                installed !== null && !installed.has(provider.id)
-                  ? translate('auto.components.skills.install.agentNotInstalled', 'Not installed')
-                  : null
-              }
-              onCheckedChange={(checked) =>
-                onChange(toggledSkillProviderSelection(selected, provider.id, checked))
-              }
-            />
-          ))}
-        </ul>
-        {canonical.length > 0 ? (
-          <p className="text-xs text-muted-foreground">
-            {translate(
-              'auto.components.skills.install.agentsCanonicalNote',
-              '{{value0}} read {{value1}}, which every install writes.',
-              {
-                value0: canonical.map((provider) => provider.displayName).join(', '),
-                value1: canonicalRoot
-              }
-            )}
-          </p>
-        ) : null}
-      </CollapsibleContent>
-    </Collapsible>
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            id={id}
+            type="button"
+            variant="outline"
+            role="button"
+            aria-expanded={open}
+            aria-label={summaryText}
+            disabled={busy}
+            title={summaryText}
+            className="h-9 w-full min-w-0 justify-between px-3 text-sm font-normal"
+          >
+            <span className="flex min-w-0 flex-1 items-center gap-2 truncate text-left">
+              <Bot className="size-4 shrink-0 text-muted-foreground" />
+              <span className="min-w-0 flex-1 truncate">
+                {chosen.length === 0 ? (
+                  <span className="text-muted-foreground">
+                    {translate('auto.components.skills.install.agentsNone', 'No agents selected')}
+                  </span>
+                ) : (
+                  <>
+                    <span className="font-medium text-foreground">
+                      {translate(
+                        'auto.components.skills.install.agentsCountLabel',
+                        '{{count}} {{label}}',
+                        {
+                          count: chosen.length,
+                          label: chosen.length === 1 ? 'agent' : 'agents'
+                        }
+                      )}
+                    </span>
+                    <span className="text-muted-foreground"> · {chosen.join(', ')}</span>
+                  </>
+                )}
+              </span>
+            </span>
+            <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent
+          align="start"
+          className="popover-wheel-scroll w-[var(--radix-popover-trigger-width)] min-w-[22rem] p-0 shadow-lg"
+        >
+          {canonical.length > 0 ? (
+            <div className="border-b border-border/50 bg-muted/20 px-3 py-2.5">
+              <div className="flex items-center gap-1.5 text-[11px] font-semibold tracking-wider text-muted-foreground uppercase">
+                <Sparkles className="size-3 text-primary shrink-0" />
+                <span>
+                  {translate(
+                    'auto.components.skills.install.canonicalHeader',
+                    'Standard Agents (Always Included)'
+                  )}
+                </span>
+              </div>
+              <p className="mt-1 text-[11px] leading-normal text-muted-foreground">
+                {translate(
+                  'auto.components.skills.install.canonicalExplanation',
+                  'These agents natively read {{root}}, which Orca installs to by default:',
+                  { root: canonicalRoot }
+                )}
+              </p>
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {canonical.map((provider) => (
+                  <span
+                    key={provider.id}
+                    className="inline-flex items-center gap-1 rounded-md border border-border/70 bg-background/90 px-2 py-0.5 text-xs font-medium text-foreground shadow-xs"
+                  >
+                    <Check className="size-3 shrink-0 text-emerald-500" />
+                    {provider.displayName}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          <div className="flex items-center justify-between border-b border-border/60 px-3 py-2">
+            <span className="text-xs font-semibold text-foreground">
+              {selectable.length > 0
+                ? translate(
+                    'auto.components.skills.install.additionalAgentsHeader',
+                    'Additional Agent Directories'
+                  )
+                : translate('auto.components.skills.install.targetAgentsHeader', 'Target Agents')}
+            </span>
+            {selectable.length > 0 ? (
+              <button
+                type="button"
+                disabled={busy}
+                onClick={allSelectableChosen ? clearSelectable : selectAll}
+                className="cursor-pointer text-[11px] text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none"
+              >
+                {allSelectableChosen
+                  ? translate('auto.components.skills.install.deselectAll', 'Deselect all')
+                  : translate('auto.components.skills.install.selectAll', 'Select all')}
+              </button>
+            ) : null}
+          </div>
+          <ul className="scrollbar-sleek max-h-52 overflow-y-auto divide-y divide-border/40 p-1">
+            {selectable.map(({ provider, directory }) => (
+              <AgentRow
+                key={provider.id}
+                name={provider.displayName}
+                directory={directory}
+                checked={selected.has(provider.id)}
+                disabled={busy}
+                note={
+                  installed !== null && !installed.has(provider.id)
+                    ? translate('auto.components.skills.install.agentNotInstalled', 'Not installed')
+                    : null
+                }
+                onCheckedChange={(checked) =>
+                  onChange(toggledSkillProviderSelection(selected, provider.id, checked))
+                }
+              />
+            ))}
+          </ul>
+        </PopoverContent>
+      </Popover>
+    </div>
   )
 }

--- a/src/renderer/src/components/skills/SkillInstallReviewContent.tsx
+++ b/src/renderer/src/components/skills/SkillInstallReviewContent.tsx
@@ -137,32 +137,44 @@ export function SkillInstallReview({
         destinationPreview.currentState
       ))
   return (
-    <div className="space-y-5">
-      <section className="space-y-2">
+    <div className="space-y-4">
+      <div className="space-y-3 rounded-xl border border-border/70 bg-card/40 p-3.5">
         <SkillPackageChecklist
           items={checklistItemsFromVersion(version)}
           selectedIds={null}
           busy={busy}
         />
         {version.releaseNotes.trim() ? (
-          <p className="break-words whitespace-pre-wrap text-xs leading-5 text-muted-foreground">
-            {translate(
-              'auto.components.skills.SkillInstallReviewContent.releaseNotes',
-              'Release notes:'
-            )}{' '}
+          <p className="break-words whitespace-pre-wrap rounded-lg border border-border/40 bg-muted/40 p-3 text-xs leading-5 text-muted-foreground">
+            <span className="font-semibold text-foreground">
+              {translate(
+                'auto.components.skills.SkillInstallReviewContent.releaseNotes',
+                'Release notes:'
+              )}
+            </span>{' '}
             {version.releaseNotes}
           </p>
         ) : null}
-      </section>
+        <SkillInstallRiskNotice summary={riskSummary} />
+      </div>
 
-      <SkillInstallRiskNotice summary={riskSummary} />
-
-      {children}
+      <div className="space-y-3 rounded-xl border border-border/70 bg-card/40 p-3.5">
+        <div className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+          {translate(
+            'auto.components.skills.SkillInstallReviewContent.targetHeader',
+            'Installation Target'
+          )}
+        </div>
+        {children}
+      </div>
 
       {hasConflict ? (
-        <section className="space-y-2 rounded-md border border-border p-3" role="alert">
-          <div className="flex items-center gap-2 text-sm font-medium">
-            <AlertTriangle className="size-4" />{' '}
+        <section
+          className="space-y-2 rounded-xl border border-destructive/30 bg-destructive/5 p-3.5"
+          role="alert"
+        >
+          <div className="flex items-center gap-2 text-sm font-medium text-destructive">
+            <AlertTriangle className="size-4 shrink-0" />{' '}
             {translate(
               'auto.components.skills.SkillInstallReviewContent.651b7d8a57',
               'Local copy needs a decision'

--- a/src/renderer/src/components/skills/SkillInstallRiskNotice.tsx
+++ b/src/renderer/src/components/skills/SkillInstallRiskNotice.tsx
@@ -1,5 +1,6 @@
-import { Info } from 'lucide-react'
+import { Info, ShieldAlert } from 'lucide-react'
 import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
 import type { SkillInstallRiskSummary } from './skill-package-install-risk'
 import { fileCountLabel } from './skill-display-labels'
 
@@ -43,9 +44,26 @@ export function SkillInstallRiskNotice({
       : translate('auto.components.skills.install.reviewInstructions', 'About this skill')
 
   return (
-    <section className="space-y-2 rounded-md border border-border p-3" role="note">
-      <div className="flex items-center gap-2 text-sm font-medium">
-        <Info className="size-4" />
+    <section
+      className={cn(
+        'space-y-1.5 rounded-lg border p-3',
+        summary.requiresAcknowledgement
+          ? 'border-amber-500/30 bg-amber-500/5 text-foreground'
+          : 'border-border/50 bg-muted/20 text-muted-foreground'
+      )}
+      role="note"
+    >
+      <div
+        className={cn(
+          'flex items-center gap-2 text-xs font-medium',
+          summary.requiresAcknowledgement ? 'text-amber-600 dark:text-amber-400' : 'text-foreground'
+        )}
+      >
+        {summary.requiresAcknowledgement ? (
+          <ShieldAlert className="size-4 shrink-0 text-amber-500" />
+        ) : (
+          <Info className="size-4 shrink-0 text-muted-foreground" />
+        )}
         {title}
       </div>
       {summary.requiresAcknowledgement ? (

--- a/src/renderer/src/components/skills/SkillInstallTargetFields.test.tsx
+++ b/src/renderer/src/components/skills/SkillInstallTargetFields.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment happy-dom
 
 import '@testing-library/jest-dom/vitest'
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { SkillInstallTargetFields } from './SkillInstallTargetFields'
 import { defaultSelectedSkillProviders } from './skill-install-provider-groups'
 
@@ -13,6 +13,13 @@ const callbacks = {
   onExecutionTargetChange: vi.fn()
 }
 
+beforeEach(() => {
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: { skills: { listWslDistros: vi.fn().mockResolvedValue(['Ubuntu-24.04']) } }
+  })
+})
+
 afterEach(() => {
   cleanup()
   vi.restoreAllMocks()
@@ -21,10 +28,6 @@ afterEach(() => {
 
 describe('SkillInstallTargetFields', () => {
   it('names every conditional selector and contains long destination labels', async () => {
-    Object.defineProperty(window, 'api', {
-      configurable: true,
-      value: { skills: { listWslDistros: vi.fn().mockResolvedValue(['Ubuntu-24.04']) } }
-    })
     const longWorkspace = `workspace-${'深'.repeat(240)}`
     const props = {
       ...callbacks,
@@ -55,5 +58,46 @@ describe('SkillInstallTargetFields', () => {
     const workspace = screen.getByRole('combobox', { name: 'Workspace' })
     expect(workspace).toHaveClass('w-full', 'min-w-0')
     expect(workspace.textContent).toContain(longWorkspace)
+  })
+
+  it('filters workspaces via search and calls onWorkspaceChange upon selection', () => {
+    const onWorkspaceChange = vi.fn()
+    const props = {
+      ...callbacks,
+      environmentId: 'local',
+      scope: 'workspace' as const,
+      workspace: '',
+      executionTarget: null,
+      runtimeEnvironments: [],
+      runtimeStatus: new Map(),
+      sshConnections: [],
+      workspaceChoices: [
+        { id: 'wt-1', label: 'orca-main', kind: 'worktree' as const },
+        { id: 'wt-2', label: 'feature-skills', kind: 'worktree' as const },
+        { id: 'folder_1', label: 'dotfiles', kind: 'folder' as const }
+      ],
+      providers: defaultSelectedSkillProviders(null),
+      detectedAgents: null,
+      onProvidersChange: vi.fn(),
+      onWorkspaceChange
+    }
+
+    render(<SkillInstallTargetFields {...props} />)
+
+    const workspaceTrigger = screen.getByRole('combobox', { name: 'Workspace' })
+    fireEvent.click(workspaceTrigger)
+
+    const searchInput = screen.getByPlaceholderText('Search workspaces...')
+    expect(searchInput).toBeInTheDocument()
+
+    // Type query to filter
+    fireEvent.change(searchInput, { target: { value: 'feature' } })
+
+    expect(screen.getByText('feature-skills ·')).toBeInTheDocument()
+    expect(screen.queryByText('orca-main ·')).toBeNull()
+
+    // Click matching item
+    fireEvent.click(screen.getByText('feature-skills ·'))
+    expect(onWorkspaceChange).toHaveBeenCalledWith('wt-2')
   })
 })

--- a/src/renderer/src/components/skills/SkillInstallTargetFields.tsx
+++ b/src/renderer/src/components/skills/SkillInstallTargetFields.tsx
@@ -10,6 +10,7 @@ import {
 import { SKILL_INSTALL_CAPABILITY } from '../../../../shared/skill-install-capability'
 import type { SkillInstallProviderId } from '../../../../shared/skill-install-providers'
 import { SkillInstallAgentPicker } from './SkillInstallAgentPicker'
+import { SkillInstallWorkspaceCombobox } from './SkillInstallWorkspaceCombobox'
 import type { SkillInstallWorkspaceChoice } from './skill-install-workspace-choices'
 import { translate } from '@/i18n/i18n'
 
@@ -197,32 +198,13 @@ export function SkillInstallTargetFields(props: {
           <Label htmlFor={`${fieldId}-workspace`}>
             {translate('auto.components.skills.SkillInstallTargetFields.0e5b43a9e3', 'Workspace')}
           </Label>
-          <Select value={props.workspace} onValueChange={props.onWorkspaceChange}>
-            <SelectTrigger id={`${fieldId}-workspace`} className="w-full min-w-0">
-              <SelectValue
-                placeholder={translate(
-                  'auto.components.skills.SkillInstallTargetFields.5845cfe543',
-                  'Choose a worktree or folder'
-                )}
-              />
-            </SelectTrigger>
-            <SelectContent>
-              {props.workspaceChoices.map((choice) => (
-                <SelectItem key={`${choice.kind}:${choice.id}`} value={choice.id}>
-                  {choice.label} ·{' '}
-                  {choice.kind === 'worktree'
-                    ? translate(
-                        'auto.components.skills.SkillInstallTargetFields.d628c416a2',
-                        'Git worktree'
-                      )
-                    : translate(
-                        'auto.components.skills.SkillInstallTargetFields.7a366323e7',
-                        'Folder'
-                      )}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+          <SkillInstallWorkspaceCombobox
+            id={`${fieldId}-workspace`}
+            value={props.workspace}
+            onValueChange={props.onWorkspaceChange}
+            choices={props.workspaceChoices}
+            disabled={props.busy}
+          />
           {props.workspaceChoices.length === 0 ? (
             <p className="text-xs text-muted-foreground">
               {translate(
@@ -235,6 +217,7 @@ export function SkillInstallTargetFields(props: {
       ) : null}
 
       <SkillInstallAgentPicker
+        id={`${fieldId}-agents`}
         scope={props.scope}
         selected={props.providers}
         detectedAgents={props.detectedAgents}

--- a/src/renderer/src/components/skills/SkillInstallWorkspaceCombobox.test.tsx
+++ b/src/renderer/src/components/skills/SkillInstallWorkspaceCombobox.test.tsx
@@ -1,0 +1,170 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { SkillInstallWorkspaceCombobox } from './SkillInstallWorkspaceCombobox'
+import type { SkillInstallWorkspaceChoice } from './skill-install-workspace-choices'
+
+const sampleChoices: SkillInstallWorkspaceChoice[] = [
+  { id: 'wt-1', label: 'orca-main', kind: 'worktree' },
+  { id: 'wt-2', label: 'feature-skills', kind: 'worktree' },
+  { id: 'f-1', label: 'dotfiles', kind: 'folder' },
+  { id: 'f-2', label: 'scripts-repo', kind: 'folder' }
+]
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+describe('SkillInstallWorkspaceCombobox', () => {
+  it('renders placeholder when no workspace is selected', () => {
+    render(
+      <SkillInstallWorkspaceCombobox value="" onValueChange={vi.fn()} choices={sampleChoices} />
+    )
+
+    const trigger = screen.getByRole('combobox')
+    expect(trigger).toHaveTextContent('Choose a worktree or folder')
+    expect(trigger).not.toBeDisabled()
+  })
+
+  it('renders selected workspace label and kind badge', () => {
+    render(
+      <SkillInstallWorkspaceCombobox value="wt-1" onValueChange={vi.fn()} choices={sampleChoices} />
+    )
+
+    const trigger = screen.getByRole('combobox')
+    expect(trigger).toHaveTextContent('orca-main · Git worktree')
+  })
+
+  it('is disabled when choices are empty', () => {
+    render(<SkillInstallWorkspaceCombobox value="" onValueChange={vi.fn()} choices={[]} />)
+
+    const trigger = screen.getByRole('combobox')
+    expect(trigger).toBeDisabled()
+  })
+
+  it('opens and displays all choices on click', () => {
+    render(
+      <SkillInstallWorkspaceCombobox value="" onValueChange={vi.fn()} choices={sampleChoices} />
+    )
+
+    const trigger = screen.getByRole('combobox')
+    fireEvent.click(trigger)
+
+    expect(screen.getByPlaceholderText('Search workspaces...')).toBeInTheDocument()
+    expect(screen.getByText('orca-main ·')).toBeInTheDocument()
+    expect(screen.getByText('feature-skills ·')).toBeInTheDocument()
+    expect(screen.getByText('dotfiles ·')).toBeInTheDocument()
+    expect(screen.getByText('scripts-repo ·')).toBeInTheDocument()
+  })
+
+  it('filters choices by workspace label', () => {
+    render(
+      <SkillInstallWorkspaceCombobox value="" onValueChange={vi.fn()} choices={sampleChoices} />
+    )
+
+    fireEvent.click(screen.getByRole('combobox'))
+    const searchInput = screen.getByPlaceholderText('Search workspaces...')
+
+    fireEvent.change(searchInput, { target: { value: 'feature' } })
+
+    expect(screen.getByText('feature-skills ·')).toBeInTheDocument()
+    expect(screen.queryByText('orca-main ·')).toBeNull()
+    expect(screen.queryByText('dotfiles ·')).toBeNull()
+    expect(screen.queryByText('scripts-repo ·')).toBeNull()
+  })
+
+  it('filters choices by workspace kind (folder vs worktree)', () => {
+    render(
+      <SkillInstallWorkspaceCombobox value="" onValueChange={vi.fn()} choices={sampleChoices} />
+    )
+
+    fireEvent.click(screen.getByRole('combobox'))
+    const searchInput = screen.getByPlaceholderText('Search workspaces...')
+
+    fireEvent.change(searchInput, { target: { value: 'folder' } })
+
+    expect(screen.getByText('dotfiles ·')).toBeInTheDocument()
+    expect(screen.getByText('scripts-repo ·')).toBeInTheDocument()
+    expect(screen.queryByText('orca-main ·')).toBeNull()
+    expect(screen.queryByText('feature-skills ·')).toBeNull()
+  })
+
+  it('shows empty state when no choices match search query', () => {
+    render(
+      <SkillInstallWorkspaceCombobox value="" onValueChange={vi.fn()} choices={sampleChoices} />
+    )
+
+    fireEvent.click(screen.getByRole('combobox'))
+    const searchInput = screen.getByPlaceholderText('Search workspaces...')
+
+    fireEvent.change(searchInput, { target: { value: 'nonexistent-workspace' } })
+
+    expect(screen.getByText('No workspaces found.')).toBeInTheDocument()
+  })
+
+  it('calls onValueChange and closes popover when an item is selected', () => {
+    const onValueChange = vi.fn()
+    render(
+      <SkillInstallWorkspaceCombobox
+        value=""
+        onValueChange={onValueChange}
+        choices={sampleChoices}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('combobox'))
+    fireEvent.click(screen.getByText('feature-skills ·'))
+
+    expect(onValueChange).toHaveBeenCalledWith('wt-2')
+  })
+
+  it('opens popover on ArrowDown key down on trigger', () => {
+    render(
+      <SkillInstallWorkspaceCombobox value="" onValueChange={vi.fn()} choices={sampleChoices} />
+    )
+
+    const trigger = screen.getByRole('combobox')
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' })
+
+    expect(screen.getByPlaceholderText('Search workspaces...')).toBeInTheDocument()
+  })
+
+  it('opens popover and seeds query on typing alphanumeric character on trigger', () => {
+    render(
+      <SkillInstallWorkspaceCombobox value="" onValueChange={vi.fn()} choices={sampleChoices} />
+    )
+
+    const trigger = screen.getByRole('combobox')
+    fireEvent.keyDown(trigger, { key: 'd' })
+
+    expect(screen.getByPlaceholderText('Search workspaces...')).toBeInTheDocument()
+    const searchInput = screen.getByPlaceholderText('Search workspaces...') as HTMLInputElement
+    expect(searchInput.value).toBe('d')
+    expect(screen.getByText('dotfiles ·')).toBeInTheDocument()
+    expect(screen.queryByText('orca-main ·')).toBeNull()
+  })
+
+  it('includes full name in title attribute for trigger when selected', () => {
+    render(
+      <SkillInstallWorkspaceCombobox value="wt-1" onValueChange={vi.fn()} choices={sampleChoices} />
+    )
+
+    const trigger = screen.getByRole('combobox')
+    expect(trigger).toHaveAttribute('title', 'orca-main · Git worktree')
+  })
+
+  it('includes full name in title attribute for dropdown items', () => {
+    render(
+      <SkillInstallWorkspaceCombobox value="" onValueChange={vi.fn()} choices={sampleChoices} />
+    )
+
+    fireEvent.click(screen.getByRole('combobox'))
+
+    const item = screen.getByTitle('feature-skills · Git worktree')
+    expect(item).toBeInTheDocument()
+    expect(item).toHaveTextContent('feature-skills · Git worktree')
+  })
+})

--- a/src/renderer/src/components/skills/SkillInstallWorkspaceCombobox.tsx
+++ b/src/renderer/src/components/skills/SkillInstallWorkspaceCombobox.tsx
@@ -1,0 +1,259 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react'
+import { Check, ChevronsUpDown } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList
+} from '@/components/ui/command'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { FilePathCursorTooltip } from '@/components/file-path-cursor-tooltip'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import type { SkillInstallWorkspaceChoice } from './skill-install-workspace-choices'
+
+export type SkillInstallWorkspaceComboboxProps = {
+  id?: string
+  value: string
+  onValueChange: (value: string) => void
+  choices: readonly SkillInstallWorkspaceChoice[]
+  disabled?: boolean
+  placeholder?: string
+  triggerClassName?: string
+}
+
+function searchChoices(
+  choices: readonly SkillInstallWorkspaceChoice[],
+  query: string
+): readonly SkillInstallWorkspaceChoice[] {
+  const trimmed = query.trim().toLowerCase()
+  if (!trimmed) {
+    return choices
+  }
+  const terms = trimmed.split(/\s+/)
+  return choices.filter((choice) => {
+    const kindLabel = choice.kind === 'worktree' ? 'git worktree' : 'folder'
+    const searchTarget = `${choice.label} ${kindLabel}`.toLowerCase()
+    return terms.every((term) => searchTarget.includes(term))
+  })
+}
+
+export function SkillInstallWorkspaceCombobox({
+  id,
+  value,
+  onValueChange,
+  choices,
+  disabled = false,
+  placeholder,
+  triggerClassName
+}: SkillInstallWorkspaceComboboxProps): React.JSX.Element {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [commandValue, setCommandValue] = useState(value)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const focusFrameRef = useRef<number | null>(null)
+
+  const selectedChoice = useMemo(
+    () => choices.find((choice) => choice.id === value) ?? null,
+    [choices, value]
+  )
+
+  const filteredChoices = useMemo(() => searchChoices(choices, query), [choices, query])
+
+  const cancelFocusFrame = useCallback((): void => {
+    if (focusFrameRef.current !== null) {
+      cancelAnimationFrame(focusFrameRef.current)
+      focusFrameRef.current = null
+    }
+  }, [])
+
+  const setInputNode = useCallback(
+    (node: HTMLInputElement | null): void => {
+      if (node === null) {
+        cancelFocusFrame()
+      }
+      inputRef.current = node
+    },
+    [cancelFocusFrame]
+  )
+
+  const focusSearchInput = useCallback(() => {
+    cancelFocusFrame()
+    focusFrameRef.current = requestAnimationFrame(() => {
+      focusFrameRef.current = null
+      const input = inputRef.current
+      if (!input) {
+        return
+      }
+      input.focus()
+      const end = input.value.length
+      input.setSelectionRange(end, end)
+    })
+  }, [cancelFocusFrame])
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      setOpen(nextOpen)
+      if (nextOpen) {
+        setCommandValue(value)
+        return
+      }
+      cancelFocusFrame()
+      setQuery('')
+    },
+    [cancelFocusFrame, value]
+  )
+
+  const handleSelect = useCallback(
+    (choiceId: string) => {
+      onValueChange(choiceId)
+      setOpen(false)
+      setQuery('')
+    },
+    [onValueChange]
+  )
+
+  const handleTriggerKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (open) {
+        return
+      }
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        event.preventDefault()
+        setCommandValue(value)
+        setOpen(true)
+        return
+      }
+      if (event.metaKey || event.ctrlKey || event.altKey) {
+        return
+      }
+      if (event.key.length === 1 && /\S/.test(event.key)) {
+        event.preventDefault()
+        setCommandValue(value)
+        setQuery(event.key)
+        setOpen(true)
+      }
+    },
+    [open, value]
+  )
+
+  const defaultPlaceholder = translate(
+    'auto.components.skills.SkillInstallTargetFields.5845cfe543',
+    'Choose a worktree or folder'
+  )
+
+  const selectedKindLabel =
+    selectedChoice?.kind === 'worktree'
+      ? translate('auto.components.skills.SkillInstallTargetFields.d628c416a2', 'Git worktree')
+      : translate('auto.components.skills.SkillInstallTargetFields.7a366323e7', 'Folder')
+  const selectedFullLabel = selectedChoice
+    ? `${selectedChoice.label} · ${selectedKindLabel}`
+    : undefined
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          id={id}
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled || choices.length === 0}
+          onKeyDown={handleTriggerKeyDown}
+          title={selectedFullLabel}
+          className={cn(
+            'h-9 w-full min-w-0 justify-between px-3 text-sm font-normal',
+            triggerClassName
+          )}
+        >
+          {selectedChoice ? (
+            <span className="truncate">
+              {selectedChoice.label} ·{' '}
+              <span className="text-muted-foreground">{selectedKindLabel}</span>
+            </span>
+          ) : (
+            <span className="truncate text-muted-foreground">
+              {placeholder ?? defaultPlaceholder}
+            </span>
+          )}
+          <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="popover-wheel-scroll w-[var(--radix-popover-trigger-width)] min-w-[20rem] p-0"
+        onOpenAutoFocus={(event) => {
+          event.preventDefault()
+          focusSearchInput()
+        }}
+      >
+        <Command shouldFilter={false} value={commandValue} onValueChange={setCommandValue}>
+          <CommandInput
+            ref={setInputNode}
+            placeholder={translate(
+              'auto.components.skills.SkillInstallWorkspaceCombobox.search',
+              'Search workspaces...'
+            )}
+            value={query}
+            onValueChange={setQuery}
+          />
+          <TooltipProvider delayDuration={200}>
+            <CommandList className="max-h-72">
+              <CommandEmpty>
+                {translate(
+                  'auto.components.skills.SkillInstallWorkspaceCombobox.empty',
+                  'No workspaces found.'
+                )}
+              </CommandEmpty>
+              {filteredChoices.map((choice) => {
+                const isSelected = choice.id === value
+                const kindLabel =
+                  choice.kind === 'worktree'
+                    ? translate(
+                        'auto.components.skills.SkillInstallTargetFields.d628c416a2',
+                        'Git worktree'
+                      )
+                    : translate(
+                        'auto.components.skills.SkillInstallTargetFields.7a366323e7',
+                        'Folder'
+                      )
+                const fullLabel = `${choice.label} · ${kindLabel}`
+
+                return (
+                  <CommandItem
+                    key={`${choice.kind}:${choice.id}`}
+                    value={choice.id}
+                    onSelect={() => handleSelect(choice.id)}
+                    className="min-w-0 !p-0 cursor-pointer"
+                  >
+                    <FilePathCursorTooltip path={fullLabel}>
+                      <div
+                        title={fullLabel}
+                        className="flex w-full min-w-0 items-center gap-2 px-3 py-2"
+                      >
+                        <Check
+                          className={cn(
+                            'size-4 shrink-0 text-foreground',
+                            isSelected ? 'opacity-100' : 'opacity-0'
+                          )}
+                        />
+                        <span className="truncate flex-1">
+                          {choice.label} ·{' '}
+                          <span className="text-muted-foreground">{kindLabel}</span>
+                        </span>
+                      </div>
+                    </FilePathCursorTooltip>
+                  </CommandItem>
+                )
+              })}
+            </CommandList>
+          </TooltipProvider>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4357,7 +4357,8 @@
           "27672470d9": "Opening the link does not install anything. Review the immutable version first.",
           "66cff7a804": "https://app.orca.dev/skills/share/…",
           "93eb0fe8c7": "Orca skill link",
-          "releaseNotes": "Release notes:"
+          "releaseNotes": "Release notes:",
+          "targetHeader": "Installation Target"
         },
         "SkillInstallTargetFields": {
           "8e6a972229": "No workspaces are known on this machine.",
@@ -4376,6 +4377,10 @@
           "0785d0a503": "— update required",
           "8562dd1e6e": "This computer",
           "b8a0b706ad": "Machine"
+        },
+        "SkillInstallWorkspaceCombobox": {
+          "search": "Search workspaces...",
+          "empty": "No workspaces found."
         },
         "SkillShareReviewContent": {
           "e3caf6baeb": "Revoking this link blocks future access. It does not remove copies already installed on recipients’ machines.",
@@ -4577,7 +4582,15 @@
           "supportingFileWarning": "The selected skills include {{fileCount}} beyond SKILL.md.",
           "agentAccessWarning": "Skills contain instructions your agent may follow. Continue only if you trust the source of this share link.",
           "fileBinary": "binary",
-          "fileRunnable": "runnable"
+          "fileRunnable": "runnable",
+          "agentsCountBadge": "{{count}} selected",
+          "agentsCountLabel": "{{count}} {{label}}",
+          "targetAgentsHeader": "Target Agents",
+          "deselectAll": "Deselect optional",
+          "selectAll": "Select all",
+          "canonicalHeader": "Standard Agents (Always Included)",
+          "canonicalExplanation": "These agents natively read {{root}}, which Orca installs to by default:",
+          "additionalAgentsHeader": "Additional Agent Directories"
         },
         "filter": {
           "allAgents": "All agents",


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​334 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​328 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​539 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​130 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​409 |

<!-- /orca-pr-loc -->

## Problem

When installing skills, users with many workspaces can't filter the workspace list, making selection tedious. The agent picker UI is also unclear about which agents are always included vs. optional.

## Solution

Introduce a searchable workspace combobox component and refactor the agent picker from a collapsible to a popover. The new UI clearly separates canonical agents (always included, shown in a dedicated header) from additional agent directories (selectable). Workspaces can now be filtered by name or kind (worktree/folder) during selection.

## What Changed

- **New SkillInstallWorkspaceCombobox component**: Searchable combobox for workspace/folder selection with live filtering by label or kind
- **Refactored SkillInstallAgentPicker**: Changed from collapsible to popover-based UI with clearer visual hierarchy; canonical agents now displayed in an info card with explanation
- **Improved visual styling**: Installation target sections now use consistent card styling with rounded borders and better spacing; risk notices have enhanced color coding (amber for caution, info for notes)
- **Comprehensive tests**: Added unit tests for both new components covering search, filtering, selection, and keyboard interactions
- **i18n strings**: Added localized strings for workspace search, agent selection labels, and canonical agent explanations

## Testing

Both new components include comprehensive test suites covering:
- Workspace filtering by label and kind
- Agent selection and deselection
- Keyboard navigation (ArrowDown, typing to filter)
- Empty states and edge cases
- Selection state and callbacks

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Self-reviewed for correctness, security, and performance
- [x] Automated tests added/updated
- [x] Cross-platform and path impact considered (uses combobox with path utilities)