### PR TITLE
fix(linear): make new-issue dialog popovers scrollable

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -12746,7 +12746,10 @@ export default function TaskPage(): React.JSX.Element {
                       <ChevronDown className="size-3 text-muted-foreground" />
                     </Button>
                   </PopoverTrigger>
-                  <PopoverContent align="start" className="w-64 p-1">
+                  <PopoverContent
+                    align="start"
+                    className="popover-scroll-content scrollbar-sleek w-64 p-1"
+                  >
                     <div className="text-[10px] font-semibold text-muted-foreground px-2 py-1.5 uppercase tracking-wider">
                       {translate('auto.components.TaskPage.4f3cb99f41', 'Switch Team')}
                     </div>
@@ -12840,7 +12843,10 @@ export default function TaskPage(): React.JSX.Element {
                     <ChevronDown className="size-3 text-muted-foreground/70" />
                   </button>
                 </PopoverTrigger>
-                <PopoverContent align="start" className="w-56 p-1">
+                <PopoverContent
+                  align="start"
+                  className="popover-scroll-content scrollbar-sleek w-56 p-1"
+                >
                   <div className="text-[10px] font-semibold text-muted-foreground px-2 py-1 uppercase tracking-wider">
                     {translate('auto.components.TaskPage.154b0fa623', 'Status')}
                   </div>
@@ -12849,7 +12855,7 @@ export default function TaskPage(): React.JSX.Element {
                       <LoaderCircle className="size-4 animate-spin text-muted-foreground" />
                     </div>
                   ) : (
-                    <div className="max-h-60 overflow-y-auto scrollbar-sleek">
+                    <div>
                       {newLinearStates.data.map((s) => (
                         <button
                           key={s.id}
@@ -12920,7 +12926,10 @@ export default function TaskPage(): React.JSX.Element {
                     <ChevronDown className="size-3 text-muted-foreground/70" />
                   </button>
                 </PopoverTrigger>
-                <PopoverContent align="start" className="w-64 p-1">
+                <PopoverContent
+                  align="start"
+                  className="popover-scroll-content scrollbar-sleek w-64 p-1"
+                >
                   <div className="text-[10px] font-semibold text-muted-foreground px-2 py-1 uppercase tracking-wider">
                     {translate('auto.components.TaskPage.d2a876ca53', 'Assignee')}
                   </div>
@@ -12929,7 +12938,7 @@ export default function TaskPage(): React.JSX.Element {
                       <LoaderCircle className="size-4 animate-spin text-muted-foreground" />
                     </div>
                   ) : (
-                    <div className="max-h-60 overflow-y-auto scrollbar-sleek">
+                    <div>
                       <button
                         type="button"
                         onClick={() => setNewLinearIssueAssigneeId(null)}
@@ -13005,7 +13014,10 @@ export default function TaskPage(): React.JSX.Element {
                     <ChevronDown className="size-3 text-muted-foreground/70" />
                   </button>
                 </PopoverTrigger>
-                <PopoverContent align="start" className="w-48 p-1">
+                <PopoverContent
+                  align="start"
+                  className="popover-scroll-content scrollbar-sleek w-48 p-1"
+                >
                   <div className="text-[10px] font-semibold text-muted-foreground px-2 py-1 uppercase tracking-wider">
                     {translate('auto.components.TaskPage.c8d5bec5f7', 'Priority')}
                   </div>
@@ -13061,7 +13073,10 @@ export default function TaskPage(): React.JSX.Element {
                     <ChevronDown className="size-3 text-muted-foreground/70" />
                   </button>
                 </PopoverTrigger>
-                <PopoverContent align="start" className="w-64 p-1">
+                <PopoverContent
+                  align="start"
+                  className="popover-scroll-content scrollbar-sleek w-64 p-1"
+                >
                   <div className="text-[10px] font-semibold text-muted-foreground px-2 py-1 uppercase tracking-wider">
                     {translate('auto.components.TaskPage.00022ec0ba', 'Project')}
                   </div>
@@ -13070,7 +13085,7 @@ export default function TaskPage(): React.JSX.Element {
                       <LoaderCircle className="size-4 animate-spin text-muted-foreground" />
                     </div>
                   ) : (
-                    <div className="max-h-60 overflow-y-auto scrollbar-sleek">
+                    <div>
                       <button
                         type="button"
                         onClick={() => setNewLinearIssueProjectId(null)}
@@ -13139,7 +13154,10 @@ export default function TaskPage(): React.JSX.Element {
                     <ChevronDown className="size-3 text-muted-foreground/70" />
                   </button>
                 </PopoverTrigger>
-                <PopoverContent align="start" className="w-64 p-1">
+                <PopoverContent
+                  align="start"
+                  className="popover-scroll-content scrollbar-sleek w-64 p-1"
+                >
                   <div className="text-[10px] font-semibold text-muted-foreground px-2 py-1 uppercase tracking-wider">
                     {translate('auto.components.TaskPage.d0ca4aa1d0', 'Labels')}
                   </div>
@@ -13148,7 +13166,7 @@ export default function TaskPage(): React.JSX.Element {
                       <LoaderCircle className="size-4 animate-spin text-muted-foreground" />
                     </div>
                   ) : (
-                    <div className="max-h-60 overflow-y-auto scrollbar-sleek">
+                    <div>
                       {newLinearLabels.data.map((l) => {
                         const isSelected = newLinearIssueLabelIds.includes(l.id)
                         return (

--- a/src/renderer/src/components/task-page-linear-issue-dialog-popover-scroll.test.ts
+++ b/src/renderer/src/components/task-page-linear-issue-dialog-popover-scroll.test.ts
@@ -28,6 +28,17 @@ describe('Linear new-issue dialog popovers', () => {
   })
 
   it('leaves no fixed-height inner scroller that the outer cap would clip', () => {
-    expect(newLinearIssueDialog()).not.toContain('max-h-60 overflow-y-auto scrollbar-sleek"')
+    // Only wrapper divs: the description textarea caps its own growth with the
+    // same classes and is not a popover child.
+    const wrapperClassNames = [
+      ...newLinearIssueDialog().matchAll(/<div\b[^>]*?className="([^"]*)"/gs)
+    ].map((m) => m[1])
+
+    for (const className of wrapperClassNames) {
+      const tokens = new Set(className.split(/\s+/))
+      const isFixedScroller =
+        tokens.has('max-h-60') && tokens.has('overflow-y-auto') && tokens.has('scrollbar-sleek')
+      expect(isFixedScroller, `fixed-height inner scroller: ${className}`).toBe(false)
+    }
   })
 })

--- a/src/renderer/src/components/task-page-linear-issue-dialog-popover-scroll.test.ts
+++ b/src/renderer/src/components/task-page-linear-issue-dialog-popover-scroll.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const taskPageSource = readFileSync(new URL('./TaskPage.tsx', import.meta.url), 'utf8')
+
+/** The Linear "New Issue" dialog, up to the Jira dialog that follows it. */
+function newLinearIssueDialog(): string {
+  const start = taskPageSource.indexOf('open={newLinearIssueOpen}')
+  const end = taskPageSource.indexOf('open={newJiraIssueOpen}', start)
+  expect(start).toBeGreaterThan(-1)
+  expect(end).toBeGreaterThan(start)
+  return taskPageSource.slice(start, end)
+}
+
+function popoverContentClassNames(section: string): string[] {
+  return [...section.matchAll(/<PopoverContent\b[^>]*?className="([^"]*)"/gs)].map((m) => m[1])
+}
+
+describe('Linear new-issue dialog popovers', () => {
+  it('caps every attribute popover to the available height and opts into the wheel shim', () => {
+    const classNames = popoverContentClassNames(newLinearIssueDialog())
+
+    expect(classNames.length).toBeGreaterThanOrEqual(6)
+    for (const className of classNames) {
+      expect(className).toContain('popover-scroll-content')
+      expect(className).toContain('scrollbar-sleek')
+    }
+  })
+
+  it('leaves no fixed-height inner scroller that the outer cap would clip', () => {
+    expect(newLinearIssueDialog()).not.toContain('max-h-60 overflow-y-auto scrollbar-sleek"')
+  })
+})


### PR DESCRIPTION
## ELI5

The team picker in Linear's "New Issue" dialog stopped at the bottom edge of the window and just cut the rest of the list off — no scrollbar, and the wheel did nothing. If your workspace has a lot of teams, the ones near the end of the alphabet were simply unreachable. This makes that dropdown (and the five others in the same dialog) scroll like every other dropdown in Orca already does.

## What Changed

All six `PopoverContent`s in the Linear new-issue dialog now use the `popover-scroll-content scrollbar-sleek` pattern that `LinearItemDrawer`, `JiraIssueWorkspace`, and `github-item-dialog` already use:

- **Team switcher, Status, Assignee, Priority, Project, Labels** — added `popover-scroll-content scrollbar-sleek` to `PopoverContent`.
- **Status, Assignee, Project, Labels** — dropped the inner `max-h-60 overflow-y-auto scrollbar-sleek` wrapper, which is now redundant.

One new test file, `task-page-linear-issue-dialog-popover-scroll.test.ts`, holds the invariant so the dialog can't drift back out of the pattern.

## Why

Two defects stacked on each other:

1. **The cap clips instead of scrolling.** `main.css` already caps every popover with `[data-slot='popover-content'] { max-height: var(--radix-popover-content-available-height) }`, but `PopoverContent`'s base class is `overflow-hidden` and the team switcher passed only `className="w-64 p-1"`. So the list was bounded to the available height and everything past it was cut off with no scroller — this is what the before screenshot shows.

2. **The wheel was swallowed.** Radix's dialog scroll-lock eats native wheel events in portaled popovers. `popover.tsx` already ships `handlePopoverWheel` for exactly this, but it only runs for content marked `popover-scroll-content` or `popover-wheel-scroll`. None of the six carried a marker, so Status / Assignee / Project / Labels — which *did* have an inner `max-h-60` box — couldn't be wheel-scrolled either.

`popover-scroll-content` fixes both at once: it re-declares the cap as `min(15rem, var(--radix-popover-content-available-height))` — still viewport-aware, so it holds on a short window too — and adds the `overflow-y: auto` the old rule was missing, while the class name is what opts the content into the wheel shim.

The inner `max-h-60` boxes had to go rather than stay: stacking a 15rem inner box plus a header inside a 15rem outer cap creates nested scrollers whose combined height exceeds the outer one, leaving the bottom of each list unreachable — the same class of bug in a new place.

## Linked Issue

Fixes #16378

## Visual Proof

**Real app, my own workspace** (~25 Linear teams; team names redacted). Same workspace on both sides — before is the shipped build, after is this branch:

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/GagaKor/orca/pr-assets/1-real-before.png" alt="before — list runs off the window, no scrollbar"> | <img src="https://raw.githubusercontent.com/GagaKor/orca/pr-assets/2-real-after.png" alt="after — bounded popover with a scrollbar"> |

Before, the list runs past the bottom of the window and stops there — no scrollbar, and the wheel does nothing. After, the popover is a bounded box with a working scrollbar (visible on its right edge) and every team is reachable.

**Controlled pair** — same 25-team fixture, same window, driven through the E2E harness on this commit and its parent:

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/GagaKor/orca/pr-assets/3-fixture-before.png" alt="fixture before"> | <img src="https://raw.githubusercontent.com/GagaKor/orca/pr-assets/4-fixture-after.png" alt="fixture after"> |

Measured on the popover element in a 949px-tall window:

| | max-height | overflow-y | client / scroll height | scrollTop reachable |
|---|---|---|---|---|
| **before** | 611px | `hidden` | 609 / 735 | — (no user-facing scroll) |
| **after** | 240px | `auto` | 238 / 735 | 0 → 497 |

Before, 126px of the list sits past the cut with no scrollbar and no wheel response. After, the popover is a bounded scroller and every team is reachable.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

`task-page-linear-issue-dialog-popover-scroll.test.ts` follows the existing `TaskPage` source-scan pattern (`task-page-github-issue-creation.test.ts` et al.), because `TaskPage.tsx` is ~13.5k lines and cannot be practically mounted. It asserts two things about the new-issue dialog slice:

1. Every `PopoverContent` carries `popover-scroll-content scrollbar-sleek` — this is what enables both the viewport-aware cap and the wheel shim.
2. No fixed-height inner scroller is left that the outer cap would clip.

Verified **red before the change** (both assertions fail on the parent commit) and **green after**. `src/renderer/src/components/ui/popover-wheel-scroll.test.tsx` continues to pass, covering the shim itself.

Beyond the unit test, I drove the real dialog through the E2E harness (`_electron.launch` + stubbed Linear IPC, 25 fixture teams) on both this commit and its parent, and read the popover's own layout metrics — that is where the before/after table above comes from.

Full local run: `pnpm typecheck` and `pnpm lint` pass. `pnpm test` is 58,442 passed / 6 failed; all 6 fail identically on the parent commit with no change applied (4 `@parcel/watcher` + worktree-poller FSEvents tests, plus a timing-sensitive orchestration perf test that passes on rerun), so none are from this change.

Platforms tested: **macOS**. The change is CSS-class only with no platform-conditional code, so Linux and Windows behavior follows from the same shared stylesheet and the same `popover.tsx` shim — neither the classes nor the CSS are platform-gated.

## AI Disclosure

Claude Opus 5 (via Claude Code) did the root-cause investigation, the change, and the test. Reviewed by me before opening.

## Review

- **Cross-platform (macOS / Linux / Windows):** No platform-conditional code, no path handling, no keyboard accelerators. `.popover-scroll-content` lives in `main.css` and applies uniformly; the wheel shim in `popover.tsx` is platform-neutral. No `metaKey` / `ctrlKey` involved.
- **SSH / remote / local:** Renderer-only presentation change. Touches no execution host, no process lifecycle, no RPC params, no stream frames, and nothing either side of the client/host wire publishes. Nothing here can change a `live` / `unverifiable` / `exited` verdict.
- **Agent / integration / git-provider compatibility:** Scoped to the Linear new-issue dialog's own popovers. No provider-specific branching added or removed; nothing GitHub-, GitLab-, or Jira-specific is touched.
- **Performance:** Strictly negative cost — four wrapper `<div>`s lose their class attributes, and no new elements, listeners, state, or renders are introduced. The wheel shim's listener was already attached to every `PopoverContent` regardless of marker; the marker only decides whether it acts.
- **UI quality:** Adopts the app's existing dropdown pattern rather than inventing one, so these six popovers now match `LinearItemDrawer` / `JiraIssueWorkspace` / `github-item-dialog`. Uses documented tokens only — no new color, size, or shadow values. `.popover-scroll-content` carries `color-scheme: dark` for its scrollbar, which is the same in every other popover already using it, so it introduces no light/dark inconsistency relative to the rest of the app.
- **Security:** No new input handling, no IPC, no network, no filesystem, no credential or user-content path. Nothing rendered as HTML.
- **Backwards compatibility:** No persisted state, schema, setting, or wire format is involved.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

I hit this in my own workspace, which has ~25 Linear teams. The cutoff point depends on window height, so smaller workspaces would not run into it.

Scope was deliberately kept to the new-issue dialog. The same missing-marker pattern also exists in the **new Linear project** dialog (5 popovers) and the **new Jira issue** dialog (1). Those are the same defect but a different surface — happy to follow up in a separate PR, or fold them in here if you'd rather have one sweep.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
