### PR TITLE
fix(cli): pair every resolved CLI with its runtime, and ratchet it

### DIFF
--- a/src/cli/handlers/account.test.ts
+++ b/src/cli/handlers/account.test.ts
@@ -1,3 +1,4 @@
+import type * as NodeCliCommandResolutionModule from '../../shared/node-cli-command-resolution'
 import { EventEmitter } from 'node:events'
 import { createHash } from 'node:crypto'
 import { existsSync } from 'node:fs'
@@ -43,7 +44,10 @@ vi.mock('../../main/claude-accounts/keychain', () => ({
   readActiveClaudeKeychainCredentialsStrict: readKeychainMock,
   writeActiveClaudeKeychainCredentials: writeKeychainMock
 }))
-vi.mock('../../shared/node-cli-command-resolution', () => ({
+// Why importOriginal: withCliRuntimeOnPath is a pure filesystem-probing helper,
+// and the PATH assertions below are only meaningful against the real one.
+vi.mock('../../shared/node-cli-command-resolution', async (importOriginal) => ({
+  ...(await importOriginal<typeof NodeCliCommandResolutionModule>()),
   getVersionManagerBinPaths: getVersionManagerBinPathsMock,
   resolveCliCommand: resolveCliCommandMock
 }))

--- a/src/cli/handlers/account.ts
+++ b/src/cli/handlers/account.ts
@@ -14,7 +14,8 @@ import {
 } from '../../main/claude-accounts/keychain'
 import {
   getVersionManagerBinPaths,
-  resolveCliCommand
+  resolveCliCommand,
+  withCliRuntimeOnPath
 } from '../../shared/node-cli-command-resolution'
 import {
   getSpawnArgsForWindows,
@@ -113,7 +114,13 @@ async function runAgentLoginInTerminal(
       )
       return
     }
-    const env = addAgentNodePaths({ ...stripElectronRunAsNode(process.env), ...extraEnv })
+    // Why paired after the seed: addAgentNodePaths prepends the *newest* version
+    // manager bin, which is not necessarily where this CLI lives. Pairing last puts
+    // the CLI's own node in front of that seed (stablyai/orca#10932).
+    const env = withCliRuntimeOnPath(
+      resolvedCommand,
+      addAgentNodePaths({ ...stripElectronRunAsNode(process.env), ...extraEnv })
+    )
     const consoleStdio = stdioForWindowsInteractiveChild(json)
     let child: ReturnType<typeof spawn>
     try {

--- a/src/cli/handlers/skills.ts
+++ b/src/cli/handlers/skills.ts
@@ -1,9 +1,8 @@
 import { spawn } from 'node:child_process'
 import type { CommandHandler } from '../dispatch'
 import { RuntimeClientError } from '../runtime-client'
-import { delimiter, dirname } from 'node:path'
 import { getRepeatedStringFlag } from '../flags'
-import { resolveCliCommand } from '../../shared/node-cli-command-resolution'
+import { resolveCliCommand, withCliRuntimeOnPath } from '../../shared/node-cli-command-resolution'
 import { detectCommandsInInstallDirs } from '../../shared/local-agent-install-dir-detection'
 import {
   getTuiAgentDetectionProbeCommands,
@@ -103,16 +102,6 @@ function resolveSelectedSkillNames(
 }
 
 /** PATH with the resolved npx's own directory first, so its `env node` shebang resolves. */
-function buildNpxPath(resolvedNpx: string): string {
-  // Why: resolveCliCommand falls back to the bare name when it finds nothing, and
-  // dirname('npx') is '.', so prepending it blindly would run ./npx out of the
-  // caller's checkout instead of reporting that npx is missing.
-  const own = dirname(resolvedNpx)
-  const existing = process.env.PATH ?? process.env.Path ?? ''
-  // Why: every version manager ships node beside npx in the same bin directory,
-  // so the resolved sibling is all the child needs to run npx's shebang.
-  return [own === '.' ? '' : own, existing].filter(Boolean).join(delimiter)
-}
 
 function runNpxSkills(args: string[]): Promise<number> {
   return new Promise((resolve, reject) => {
@@ -145,7 +134,10 @@ function runNpxSkills(args: string[]): Promise<number> {
     // 'error' event and the message below never fires.
     const child = spawn(spawnCmd, spawnArgs, {
       stdio: 'inherit',
-      env: { ...process.env, PATH: buildNpxPath(resolved) }
+      // Why the shared helper: it verifies the sibling node actually exists,
+      // skips a bare-name fallback whose dirname is '.', and writes the key
+      // Windows will really read — all of which a local join got wrong.
+      env: withCliRuntimeOnPath(resolved, { ...process.env })
     })
     // Why: a missing npx/Node on a headless host surfaces as a raw spawn ENOENT;
     // wrap it so the CLI reports an actionable message like every other failure here.

--- a/src/cli/skills.test.ts
+++ b/src/cli/skills.test.ts
@@ -1,6 +1,8 @@
+import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { EventEmitter } from 'node:events'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { delimiter } from 'node:path'
+import { delimiter, join } from 'node:path'
 import type * as CodexCliCommandModule from '../shared/node-cli-command-resolution'
 import { WINDOWS_BATCH_UNSAFE_CHARACTERS_LABEL } from '../shared/windows-batch-spawn'
 
@@ -656,9 +658,16 @@ describe('orca skills CLI', () => {
   })
 
   it('puts the resolved npx directory on the child PATH', async () => {
+    // Why a real directory with a real sibling node: pairing only fires when the
+    // node it would add actually exists, so a fictional path proves nothing.
+    const npxBin = mkdtempSync(join(tmpdir(), 'orca-npx-'))
+    for (const name of ['node', 'npx']) {
+      writeFileSync(join(npxBin, name), '')
+      chmodSync(join(npxBin, name), 0o755)
+    }
     const child = createFakeChild()
     spawnMock.mockReturnValue(child)
-    resolveCliCommandMock.mockReturnValue('/home/alice/.nvm/versions/node/v22/bin/npx')
+    resolveCliCommandMock.mockReturnValue(join(npxBin, 'npx'))
     vi.stubEnv('PATH', `/usr/bin${delimiter}/bin`)
     vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
 
@@ -672,10 +681,28 @@ describe('orca skills CLI', () => {
     const env = spawnMock.mock.calls[0]?.[2]?.env
     // Why: the child still needs the inherited PATH and the rest of the parent
     // environment; replacing it outright breaks git, node, HOME and npm config.
-    expect(env?.PATH).toBe(
-      `/home/alice/.nvm/versions/node/v22/bin${delimiter}/usr/bin${delimiter}/bin`
-    )
+    expect(env?.PATH).toBe(`${npxBin}${delimiter}/usr/bin${delimiter}/bin`)
     expect(env?.HOME ?? env?.USERPROFILE).toBe(process.env.HOME ?? process.env.USERPROFILE)
+  })
+
+  it('leaves PATH untouched when no node ships beside the resolved npx', async () => {
+    // Why: prepending a directory that has no node buys nothing and would shadow
+    // the caller's own ordering for every other binary the child resolves.
+    const npxBin = mkdtempSync(join(tmpdir(), 'orca-npx-bare-'))
+    writeFileSync(join(npxBin, 'npx'), '')
+    chmodSync(join(npxBin, 'npx'), 0o755)
+    const child = createFakeChild()
+    spawnMock.mockReturnValue(child)
+    resolveCliCommandMock.mockReturnValue(join(npxBin, 'npx'))
+    vi.stubEnv('PATH', `/usr/bin${delimiter}/bin`)
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    const resultPromise = main(['skills', 'install', '--skill', 'alpha'], '/tmp/repo')
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled())
+    child.emit('exit', 0, null)
+    await resultPromise
+
+    expect(spawnMock.mock.calls[0]?.[2]?.env?.PATH).toBe(`/usr/bin${delimiter}/bin`)
   })
 
   it('reports a Windows npx path cmd.exe would reinterpret', async () => {

--- a/src/main/codex/codex-app-server-client.test.ts
+++ b/src/main/codex/codex-app-server-client.test.ts
@@ -132,6 +132,7 @@ function createStubRequest(options: {
     request: {
       invocation: {
         command: process.execPath,
+        cliPath: null,
         args: [stubPath],
         env: {
           STUB_CONFIG: JSON.stringify({
@@ -227,7 +228,7 @@ describe('runCodexHookTrustGrantSession', () => {
     const spawnImpl = vi.fn(() => child) as unknown as typeof spawn
 
     const session = runCodexAppServerSession(
-      { command: 'codex', args: ['app-server'], timeoutMs: 2_000 },
+      { command: 'codex', cliPath: null, args: ['app-server'], timeoutMs: 2_000 },
       async () => undefined,
       spawnImpl
     )
@@ -456,6 +457,7 @@ describe('runCodexHookTrustGrantSession', () => {
     const request: CodexHookTrustGrantRequest = {
       invocation: {
         command: join(tmpdir(), 'orca-codex-missing-binary-does-not-exist'),
+        cliPath: null,
         args: [],
         timeoutMs: 2_000
       },
@@ -479,7 +481,7 @@ describe('runCodexHookTrustGrantSessionSync', () => {
   }
 
   const baseRequest: CodexHookTrustGrantRequest = {
-    invocation: { command: 'codex', args: ['app-server'], timeoutMs: 1_000 },
+    invocation: { command: 'codex', cliPath: null, args: ['app-server'], timeoutMs: 1_000 },
     hooksListCwd: '/tmp',
     expectedTrustKeys: ['k'],
     managedCommand: MANAGED_COMMAND

--- a/src/main/codex/codex-app-server-session.test.ts
+++ b/src/main/codex/codex-app-server-session.test.ts
@@ -29,6 +29,7 @@ describe('runCodexAppServerSession environment', () => {
     const result = await runCodexAppServerSession(
       {
         command: process.execPath,
+        cliPath: null,
         args: ['-e', server],
         envToDelete: ['CODEX_HOME'],
         timeoutMs: 5_000

--- a/src/main/codex/codex-app-server-session.ts
+++ b/src/main/codex/codex-app-server-session.ts
@@ -12,12 +12,16 @@ export type CodexAppServerInvocation = {
   command: string
   args: string[]
   /**
-   * The resolved CLI path, when `command` is a wrapper such as cmd.exe. Used to
-   * pair the CLI with the `node` it was installed against; without it a CLI
-   * resolved out of a version-manager directory runs under whatever node leads
-   * PATH and dies on a NODE_MODULE_VERSION mismatch (stablyai/orca#10932).
+   * The resolved CLI path, used to pair the CLI with the `node` it was installed
+   * against — without it a CLI resolved out of a version-manager directory runs
+   * under whatever node leads PATH and dies on a NODE_MODULE_VERSION mismatch
+   * (stablyai/orca#10932).
+   *
+   * Required, and `null` only for a guest-side launcher (wsl.exe) where the host
+   * path means nothing. Optional would let a native builder omit it and silently
+   * fall back to pairing against a cmd.exe wrapper with no type error.
    */
-  cliPath?: string
+  cliPath: string | null
   /** Overlay applied on top of the inherited environment (e.g. CODEX_HOME). */
   env?: Record<string, string>
   /** Env keys stripped from the inherited environment before spawn (e.g. an
@@ -119,7 +123,9 @@ export async function runCodexAppServerSession<T>(
   for (const key of invocation.envToDelete ?? []) {
     delete childEnv[key]
   }
-  const pairedEnv = withCliRuntimeOnPath(invocation.cliPath ?? invocation.command, childEnv)
+  const pairedEnv = invocation.cliPath
+    ? withCliRuntimeOnPath(invocation.cliPath, childEnv)
+    : childEnv
   const child = spawnImpl(invocation.command, invocation.args, {
     env: pairedEnv,
     stdio: ['pipe', 'pipe', 'pipe'],

--- a/src/main/codex/codex-session-index-heal.test.ts
+++ b/src/main/codex/codex-session-index-heal.test.ts
@@ -147,6 +147,7 @@ function createHealRig(options: {
     readLogFile,
     buildInvocation: (_systemCodexHomePath, timeoutMs) => ({
       command: process.execPath,
+      cliPath: null,
       args: [stubPath],
       env: {
         STUB_CONFIG: JSON.stringify({

--- a/src/main/codex/codex-state-db-backfill-recovery.ts
+++ b/src/main/codex/codex-state-db-backfill-recovery.ts
@@ -8,6 +8,7 @@ import { withManagedHookInstallLock } from '../agent-hooks/managed-hook-install-
 import { readManagedHookHostIdentity } from '../agent-hooks/managed-hook-owner-identity'
 import { buildWslCodexAppServerArgs } from '../codex-accounts/wsl-codex-command'
 import { resolveCodexCommand } from '../codex-cli/command'
+import { withCliRuntimeOnPath } from '../../shared/node-cli-command-resolution'
 import { CODEX_READ_ONLY_APP_SERVER_ARGS } from '../codex-cli/codex-read-only-app-server-args'
 import { terminateCodexProbeChild } from '../rate-limits/codex-probe-termination'
 import { getSpawnArgsForWindows } from '../win32-utils'
@@ -110,7 +111,7 @@ function spawnRecoveryProcess(
     cwd: codexHomePath,
     stdio: ['pipe', 'ignore', 'ignore'],
     windowsHide: true,
-    env: { ...process.env, CODEX_HOME: codexHomePath }
+    env: withCliRuntimeOnPath(command, { ...process.env, CODEX_HOME: codexHomePath })
   })
 }
 

--- a/src/main/codex/codex-trust-grant-host.ts
+++ b/src/main/codex/codex-trust-grant-host.ts
@@ -43,6 +43,8 @@ export function resolveCodexTrustGrantHost(host: CodexTrustGrantHost): ResolvedC
       buildRequest: (input) => ({
         invocation: {
           command: 'wsl.exe',
+          // Why null: the guest resolves `codex` inside the distro, so a host path pairs nothing.
+          cliPath: null,
           args: buildWslCodexAppServerArgs(host.distro, host.linuxRuntimeHome),
           timeoutMs: WSL_GRANT_TIMEOUT_MS
         },

--- a/src/main/codex/codex-user-hook-trust-rebase-client.test.ts
+++ b/src/main/codex/codex-user-hook-trust-rebase-client.test.ts
@@ -15,7 +15,7 @@ vi.mock('./codex-app-server-session', async (importOriginal) => {
 
 import { runCodexUserHookTrustRebaseSession } from './codex-user-hook-trust-rebase-client'
 
-const invocation = { command: 'codex', args: ['app-server'], timeoutMs: 1000 }
+const invocation = { command: 'codex', cliPath: null, args: ['app-server'], timeoutMs: 1000 }
 const oldTrusted = '/home/a/.codex/hooks.json:stop:1:0'
 const oldUntrusted = '/home/a/.codex/hooks.json:stop:2:0'
 const newTrusted = '/home/a/.codex/hooks.json:stop:0:0'

--- a/src/main/skills/skill-update-run.ts
+++ b/src/main/skills/skill-update-run.ts
@@ -5,6 +5,7 @@ import {
   type SkillUpdateStartResult
 } from '../../shared/skill-freshness'
 import { resolveCliCommand } from '../codex-cli/command'
+import { withCliRuntimeOnPath } from '../../shared/node-cli-command-resolution'
 import { killWithDescendantSweep } from '../pty-descendant-termination'
 import { getSpawnArgsForWindows, WINDOWS_BATCH_UNSAFE_CHARACTERS_LABEL } from '../win32-utils'
 
@@ -128,7 +129,9 @@ export class SkillUpdateRunner {
       // is the second half of the CLI's non-interactive gate.
       stdio: ['ignore', 'pipe', 'pipe'],
       windowsHide: true,
-      env: process.env
+      // Why: npx is an `#!/usr/bin/env node` script — without its own node ahead of
+      // PATH it loads under whatever version leads, and a native dep dies on ABI.
+      env: withCliRuntimeOnPath(npxCommand, { ...process.env })
     })
     this.child = child
 

--- a/src/main/text-generation/commit-message-text-generation.ts
+++ b/src/main/text-generation/commit-message-text-generation.ts
@@ -54,6 +54,7 @@ import type { SourceControlAiOperation } from '../../shared/source-control-ai-ty
 import { formatLinkedIssueTemplateValue } from '../../shared/source-control-ai-action-variables'
 import { renderSourceControlActionCommandTemplate } from '../../shared/source-control-ai-actions'
 import { resolveCliCommand } from '../codex-cli/command'
+import { withCliRuntimeOnPath } from '../../shared/node-cli-command-resolution'
 import {
   resolveCodexHomeProcessLockKeyForSpawnEnv,
   withCodexHomeProcessLock
@@ -344,7 +345,7 @@ export async function discoverCommitMessageModelsLocal(
               : planned.plan.binary
           const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(resolvedBinary, planned.plan.args)
           child = spawn(spawnCmd, spawnArgs, {
-            env: spawnEnv,
+            env: withCliRuntimeOnPath(resolvedBinary, spawnEnv),
             stdio: [stdinMode, 'pipe', 'pipe'],
             windowsHide: true
           })

--- a/src/shared/__fixtures__/cli-runtime-pairing-allowlist.txt
+++ b/src/shared/__fixtures__/cli-runtime-pairing-allowlist.txt
@@ -1,0 +1,12 @@
+# Files that resolve a CLI through resolveCliCommand/resolveCodexCommand/
+# resolveClaudeCommand and spawn it, but deliberately do NOT pair the CLI with
+# its sibling `node` runtime.
+#
+# This list only shrinks. Adding an entry means arguing why a resolved CLI may
+# run under an unrelated node — which for a Node CLI with a native dependency is
+# a NODE_MODULE_VERSION crash (stablyai/orca#10932).
+
+# Launches the user's GUI editor, not a Node CLI. The resolved binary is a
+# desktop app whose own launcher picks its runtime; prepending a node directory
+# would only perturb the editor's inherited PATH.
+src/main/external-editor-launch.ts

--- a/src/shared/cli-runtime-pairing-boundary.test.ts
+++ b/src/shared/cli-runtime-pairing-boundary.test.ts
@@ -1,0 +1,99 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Guard the CLI/runtime pairing at the tree level rather than per call site.
+ *
+ * `resolveCliCommand` falls back to scanning every version-manager install, so
+ * it can return a CLI from one Node version while PATH leads with another. The
+ * CLI's `#!/usr/bin/env node` shebang then picks the wrong runtime and a native
+ * module dies on NODE_MODULE_VERSION (stablyai/orca#10932). Six call sites got
+ * this wrong at once because each made the decision separately.
+ *
+ * Pairing is one call — `withCliRuntimeOnPath` — and this test is what stops the
+ * next spawn site from forgetting it.
+ */
+const ALLOWLIST: readonly string[] = readFileSync(
+  join(__dirname, '__fixtures__', 'cli-runtime-pairing-allowlist.txt'),
+  'utf8'
+)
+  .split('\n')
+  .map((line) => line.trim())
+  .filter((line) => line.length > 0 && !line.startsWith('#'))
+
+// Why no call-paren: several sites pass the resolver as a value into a
+// dependency bag (`resolveCommand: resolveCodexCommand`) and call it later, so
+// requiring `(` here let exactly that shape through the ratchet unnoticed.
+const RESOLVES_CLI = /\b(?:resolveCliCommand|resolveCodexCommand|resolveClaudeCommand)\b/
+const SPAWNS = /\b(?:spawn|spawnProcess|spawnSync|runProcess)\s*\(/
+const PAIRS = /\bwithCliRuntimeOnPath\b/
+
+const SCANNED_ROOTS = ['src/main', 'src/shared', 'src/cli']
+const IGNORED_DIRECTORIES = new Set([
+  'node_modules',
+  'dist',
+  'out',
+  'build',
+  '.git',
+  '__fixtures__'
+])
+
+function isTestFile(path: string): boolean {
+  return /\.(?:test|spec)\.tsx?$/.test(path) || path.includes('/__tests__/')
+}
+
+function collectSourceFiles(root: string): string[] {
+  let found: string[] = []
+  let entries: string[]
+  try {
+    entries = readdirSync(root)
+  } catch {
+    return found
+  }
+  for (const entry of entries) {
+    if (IGNORED_DIRECTORIES.has(entry)) {
+      continue
+    }
+    const path = join(root, entry)
+    if (statSync(path).isDirectory()) {
+      found = found.concat(collectSourceFiles(path))
+    } else if (/\.tsx?$/.test(path) && !isTestFile(path)) {
+      found.push(path)
+    }
+  }
+  return found
+}
+
+describe('CLI runtime pairing boundary', () => {
+  const repoRoot = resolve(__dirname, '..', '..')
+
+  function offenders(): string[] {
+    return SCANNED_ROOTS.flatMap((scanRoot) => collectSourceFiles(join(repoRoot, scanRoot)))
+      .filter((path) => {
+        const source = readFileSync(path, 'utf8')
+        return RESOLVES_CLI.test(source) && SPAWNS.test(source) && !PAIRS.test(source)
+      })
+      .map((path) => relative(repoRoot, path).split('\\').join('/'))
+      .sort()
+  }
+
+  it('pairs every resolved CLI with its own node runtime', () => {
+    expect(offenders()).toEqual([...ALLOWLIST].sort())
+  })
+
+  it('keeps the allowlist honest — every entry still resolves and spawns a CLI', () => {
+    const stale = ALLOWLIST.filter((entry) => {
+      let source: string
+      try {
+        source = readFileSync(join(repoRoot, entry), 'utf8')
+      } catch {
+        return true
+      }
+      return !(RESOLVES_CLI.test(source) && SPAWNS.test(source)) || PAIRS.test(source)
+    })
+    // Why: an entry that no longer needs the exemption must be deleted, not left
+    // to quietly re-authorize a future edit to the same file.
+    expect(stale).toEqual([])
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​155 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​146 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​24 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​12 |

<!-- /orca-pr-loc -->

Follow-up to #16365. That PR paired 8 spawn sites by hand — and hand-pairing is exactly how the class got introduced, so this closes it structurally.

## ELI5

A CLI installed through a version manager only works with the Node version it was installed under. Orca finds the CLI correctly but then runs it with whatever Node happens to be first on PATH, which can be a different one — and it dies with an error that never mentions Node versions.

#16365 fixed the eight places that did this. This one adds a test that fails if a ninth place ever appears, and fixes the four that were already there.

## Make the type do the work

`cliPath` was optional on `CodexAppServerInvocation`, so a future native builder could omit it and silently fall back to pairing against a cmd.exe wrapper — no type error, no test failure, fix quietly reverted.

It is now `string | null`, required, with `null` reserved for the guest-side `wsl.exe` launcher where a host path pairs nothing. Every production construction site already passed it; only test fixtures needed updating, which is the type doing its job.

## Four more sites

- `codex-state-db-backfill-recovery.ts:113` — spawns the same `codex app-server` subcommand #16365 fixed elsewhere.
- `cli/handlers/account.ts` — the worst case. `addAgentNodePaths` prepends the **newest** version-manager bin, which is not necessarily where the CLI being launched lives, so it *actively created* the mismatch. Pairing now runs last, so the CLI's own node wins over that seed.
- `text-generation/commit-message-text-generation.ts`
- `skills/skill-update-run.ts`

`cli/handlers/skills.ts` had grown its own `buildNpxPath` — a weaker local copy that prepended unconditionally, ignored the Windows `Path` key, and special-cased a `.` dirname. Replaced with the shared helper, which additionally verifies the sibling `node` exists. That behavior change is real and one test had pinned the old form; it now uses a real fixture, plus a new test pinning the no-op when no node ships beside the binary.

## The ratchet is the point

`src/shared/cli-runtime-pairing-boundary.test.ts`: any file that resolves a CLI and spawns it must reference `withCliRuntimeOnPath`, with a shrink-only allowlist.

It earned its keep immediately — it caught `skill-update-run.ts`, which I had missed.

It also caught a hole in itself. The first draft required a call paren, so files passing the resolver as a value into a dependency bag (`resolveCommand: resolveCodexCommand`) sailed through. I found that by deleting a pairing and watching the ratchet stay green, then widened the pattern until it failed. Both assertions are mutation-verified:

- remove a pairing → `pairs every resolved CLI with its own node runtime` fails, naming the file
- add a stale allowlist entry → `keeps the allowlist honest` fails, so an exemption cannot outlive its reason

`external-editor-launch.ts` stays allowlisted with its reason recorded: it launches a GUI editor, not a Node CLI whose ABI matters.

## Verification

- `pnpm typecheck` clean, `oxlint src/` clean, max-lines ratchet exits 0 with no new bypasses.
- 8885 tests pass across `cli`, `codex`, `text-generation`, `skills`, `rate-limits`, `codex-cli`, `shared`, `codex-accounts`, `claude-accounts`.
- One unrelated failure, `skill-freshness-inventory.test.ts` (#10918), is pre-existing: I baselined it on clean `main` and it fails identically there.