### PR TITLE
fix: keep same-host same-remote clones as separate projects

### DIFF
--- a/src/renderer/src/components/settings/settings-project-list.test.ts
+++ b/src/renderer/src/components/settings/settings-project-list.test.ts
@@ -49,11 +49,16 @@ const gitRemote = {
 describe('buildSettingsProjectList', () => {
   it('collapses a git same-remote pair on two hosts (different ids) into one project', () => {
     const repos: Repo[] = [
-      makeRepo({ id: 'local-1', gitRemoteIdentity: gitRemote }),
+      makeRepo({
+        id: 'local-1',
+        gitRemoteIdentity: gitRemote,
+        projectHostSetupMethod: 'imported-existing-folder'
+      }),
       makeRepo({
         id: 'remote-9',
         gitRemoteIdentity: gitRemote,
-        executionHostId: 'runtime:home-mac'
+        executionHostId: 'runtime:home-mac',
+        projectHostSetupMethod: 'imported-existing-folder'
       })
     ]
 
@@ -63,6 +68,31 @@ describe('buildSettingsProjectList', () => {
     expect(projects[0].setups).toHaveLength(2)
     // Representative is the local host's repo.
     expect(projects[0].representativeRepoId).toBe('local-1')
+  })
+
+  it('keeps independently imported same-host clones as separate projects', () => {
+    const repos: Repo[] = [
+      makeRepo({
+        id: 'local-first',
+        addedAt: 100,
+        gitRemoteIdentity: gitRemote,
+        projectHostSetupMethod: 'imported-existing-folder'
+      }),
+      makeRepo({
+        id: 'local-second',
+        addedAt: 200,
+        gitRemoteIdentity: gitRemote,
+        projectHostSetupMethod: 'imported-existing-folder'
+      })
+    ]
+
+    const projects = buildSettingsProjectList(repos)
+
+    expect(projects).toHaveLength(2)
+    expect(projects.map((project) => project.representativeRepoId)).toEqual([
+      'local-first',
+      'local-second'
+    ])
   })
 
   it('collapses a folder with the same id on local + runtime into one project', () => {

--- a/src/shared/project-host-setup-clone-identity.ts
+++ b/src/shared/project-host-setup-clone-identity.ts
@@ -1,0 +1,54 @@
+import { getRepoExecutionHostId } from './execution-host'
+import type { Repo } from './repo-types'
+
+type GetProjectId = (repo: Repo) => string
+
+function compareProjectRegistrations(left: Repo, right: Repo): number {
+  const leftAddedAt =
+    Number.isFinite(left.addedAt) && left.addedAt !== 0 ? left.addedAt : Number.MAX_SAFE_INTEGER
+  const rightAddedAt =
+    Number.isFinite(right.addedAt) && right.addedAt !== 0 ? right.addedAt : Number.MAX_SAFE_INTEGER
+  const timeDifference = leftAddedAt - rightAddedAt
+  if (timeDifference !== 0) {
+    return timeDifference
+  }
+  if (left.id === right.id) {
+    return 0
+  }
+  return left.id < right.id ? -1 : 1
+}
+
+export function getSecondarySameHostCloneIds(
+  repos: readonly Repo[],
+  getProjectId: GetProjectId
+): ReadonlySet<string> {
+  const explicitReposByProjectHost = new Map<string, Repo[]>()
+  for (const repo of repos) {
+    if (!repo.projectHostSetupMethod) {
+      continue
+    }
+    const key = `${getProjectId(repo)}\u0000${getRepoExecutionHostId(repo)}`
+    const siblings = explicitReposByProjectHost.get(key)
+    if (siblings) {
+      siblings.push(repo)
+    } else {
+      explicitReposByProjectHost.set(key, [repo])
+    }
+  }
+
+  const secondaryRepoIds = new Set<string>()
+  for (const siblings of explicitReposByProjectHost.values()) {
+    if (siblings.length < 2) {
+      continue
+    }
+    const primary = siblings.reduce((left, right) =>
+      compareProjectRegistrations(left, right) <= 0 ? left : right
+    )
+    for (const sibling of siblings) {
+      if (sibling.id !== primary.id) {
+        secondaryRepoIds.add(sibling.id)
+      }
+    }
+  }
+  return secondaryRepoIds
+}

--- a/src/shared/project-host-setup-projection.ts
+++ b/src/shared/project-host-setup-projection.ts
@@ -2,6 +2,7 @@ import { getRepoExecutionHostId } from './execution-host'
 import { normalizeGitHubRemoteHost } from './git-remote-host-alias'
 import { githubRepoIdentityKey, isDefaultGitHubHost } from './github/repository-identity-key'
 import type { Project, ProjectHostSetup, ProjectProviderIdentity } from './project-types'
+import { getSecondarySameHostCloneIds } from './project-host-setup-clone-identity'
 import type { Repo } from './repo-types'
 import type { WorktreeMeta } from './worktree/meta-types'
 
@@ -241,12 +242,12 @@ export function mergeCatalogUpdatedAt(left: number, right: number): number {
   return Math.max(known, other)
 }
 
-function createProjectFromRepo(repo: Repo): Project {
+function createProjectFromRepo(repo: Repo, projectId: string): Project {
   const identity = getProjectProviderIdentity(repo)
   const gitRemoteIdentity = getProjectGitRemoteIdentity(repo)
   const addedAt = catalogTimestampFromAddedAt(repo.addedAt)
   return {
-    id: getProjectId(repo),
+    id: projectId,
     displayName: repo.displayName,
     badgeColor: repo.badgeColor,
     ...(repo.repoIcon !== undefined ? { repoIcon: repo.repoIcon } : {}),
@@ -305,13 +306,16 @@ export function projectHostSetupProjectionFromRepos(
 ): ProjectHostSetupProjection {
   const projectById = new Map<string, ProjectAccumulator>()
   const setups: ProjectHostSetup[] = []
+  const secondarySameHostCloneIds = getSecondarySameHostCloneIds(repos, getProjectId)
 
   for (const repo of repos) {
-    const projectId = getProjectId(repo)
+    const projectId = secondarySameHostCloneIds.has(repo.id)
+      ? `${HOST_LOCAL_PROJECT_ID_PREFIX}${repo.id}`
+      : getProjectId(repo)
     const existing = projectById.get(projectId)
     const project = existing
       ? mergeProjectRepo(existing.project, repo)
-      : createProjectFromRepo(repo)
+      : createProjectFromRepo(repo, projectId)
     const setup = createSetupFromRepo(repo, projectId)
     projectById.set(projectId, {
       project


### PR DESCRIPTION
## ELI5

When the same Git repository is cloned into two different folders on one machine, Orca now keeps those explicit imports as two projects instead of merging them because their GitHub address matches. The same repository on different machines still stays grouped as one cross-host project.

## What Changed

- detect multiple explicit repo imports with the same derived project identity and execution host
- keep the earliest registered checkout on the provider-derived project ID and assign later same-host clones their repo-local project IDs
- preserve existing cross-host grouping and legacy repo projection behavior
- add a Settings project-list regression test for both same-host separation and cross-host grouping

## Why

A project supports one ready setup per execution host. Independent clones currently produce two ready local setups under one provider-derived project, making one clone inaccessible as an independent project. Linked Git worktrees are already deduplicated before registration; independent clones need separate project identities.

## Linked Issue

Fixes #16387

## Visual Proof

No screenshot attached. This patch changes catalog projection rather than component layout or styling; the before/after behavior is asserted by the new project-list regression test.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Windows 11:

- `corepack pnpm exec vitest run --config config/vitest.config.ts src/shared/project-host-setup-projection.test.ts src/renderer/src/components/settings/settings-project-list.test.ts` — 52 passed
- `corepack pnpm run typecheck` — passed
- `corepack pnpm exec oxlint --report-unused-disable-directives-severity warn src/renderer/src/components/settings/settings-project-list.test.ts src/shared/project-host-setup-projection.ts src/shared/project-host-setup-clone-identity.ts` — passed
- pre-commit `oxlint`, React Doctor lint, and `oxfmt` — passed

## AI Disclosure

OpenAI Codex GPT-5.6 was used to investigate, implement, test, and review this change.

## Review

- Cross-platform: uses existing normalized execution-host IDs and no path parsing; Windows, macOS, and Linux behavior is identical.
- Local/SSH/runtime: disambiguation is scoped by execution host. One explicit checkout per host keeps the shared provider identity; additional checkouts only on that same host split.
- Git providers: provider-neutral; it consumes the existing derived project ID and does not add GitHub-specific matching.
- Agents/integrations/mobile: no protocol or agent-session changes.
- Performance: two linear passes over the repo catalog with bounded per-project-host grouping; no I/O.
- UI quality: no component or styling changes.
- Security: no new input, process, filesystem, or network surface.
- Backwards compatibility: legacy repo records without an explicit setup method retain their existing projection behavior.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Full `pnpm lint`, full test suite, and build are left to CI. The focused tests, full TypeScript typecheck, changed-file lint, and pre-commit checks pass.

Author X handle: N/A

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)