### PR TITLE
test(cli): ratchet the exec/fork family, not just spawn

### DIFF
--- a/src/shared/__fixtures__/cli-runtime-pairing-allowlist.txt
+++ b/src/shared/__fixtures__/cli-runtime-pairing-allowlist.txt
@@ -10,3 +10,10 @@
 # desktop app whose own launcher picks its runtime; prepending a node directory
 # would only perturb the editor's inherited PATH.
 src/main/external-editor-launch.ts
+
+# Resolves codex, but never launches it here: the only exec is a `wsl.exe`
+# identity probe for the binary stamp, and the actual codex launch is built as a
+# CodexAppServerInvocation whose cliPath is paired centrally in
+# codex-app-server-session.ts. Delete this entry if this file ever execs the
+# resolved CLI itself.
+src/main/codex/codex-trust-grant-host.ts

--- a/src/shared/cli-runtime-pairing-boundary.test.ts
+++ b/src/shared/cli-runtime-pairing-boundary.test.ts
@@ -26,7 +26,13 @@ const ALLOWLIST: readonly string[] = readFileSync(
 // dependency bag (`resolveCommand: resolveCodexCommand`) and call it later, so
 // requiring `(` here let exactly that shape through the ratchet unnoticed.
 const RESOLVES_CLI = /\b(?:resolveCliCommand|resolveCodexCommand|resolveClaudeCommand)\b/
-const SPAWNS = /\b(?:spawn|spawnProcess|spawnSync|runProcess)\s*\(/
+// Why the exec/fork family too: a resolved CLI handed to execFile is the same
+// unpaired launch as spawn. The first draft matched only the spawn names, and
+// codex-trust-grant-host.ts — which resolves a CLI and calls execFileSync — was
+// invisible to the ratchet purely through that omission.
+// The lookbehind keeps `RE.exec(` and other method calls out.
+const SPAWNS =
+  /(?<!\.)\b(?:spawn|spawnProcess|spawnSync|runProcess|execFile|execFileSync|execSync|exec|fork)\s*\(/
 const PAIRS = /\bwithCliRuntimeOnPath\b/
 
 const SCANNED_ROOTS = ['src/main', 'src/shared', 'src/cli']


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​14 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

Follow-up to #16383. Closes a hole in the pairing ratchet that PR added.

## The gap

The ratchet matched `spawn|spawnProcess|spawnSync|runProcess` only. A resolved CLI handed to `execFile` is the same unpaired launch — same #10932 crash — with none of the enforcement.

`src/main/codex/codex-trust-grant-host.ts` resolves codex **and** calls `execFileSync`, and was invisible to the ratchet purely through that omission. It is correct today, but the next `execFileSync(resolvedCli, ...)` anywhere would have sailed through silently.

## The fix

Widen to the exec/fork family. The negative lookbehind is what makes the bare `exec` name safe to include — without it every `RE.exec(` in the tree would trip the ratchet.

Both directions are mutation-verified:

- adding `execFileSync(resolvedCli, ...)` to an otherwise-paired file → the ratchet fails and names it
- adding `/x/.exec('x')` to that same file → stays green, so the lookbehind holds

`codex-trust-grant-host.ts` is allowlisted rather than changed. Its only exec is a `wsl.exe` identity probe for the binary stamp; its actual codex launch is built as a `CodexAppServerInvocation` whose `cliPath` is paired centrally in `codex-app-server-session.ts`. The allowlist entry records exactly what would invalidate it, so the exemption cannot quietly outlive its reason.

## Scope

Two files, both test-side: the ratchet regex and the allowlist fixture. No production code changes.

## Verification

`oxlint` clean; ratchet green in both assertions.

Pre-existing failures unrelated to this change, confirmed by baselining the same files on clean `main`: `setup-agent-sequencing.test.ts` fails 4 tests there identically, and `handler-group-manifest.test.ts` is load-flaky (10 failures under full parallel load collapse to 0-1 in isolation, on `main` as well).