### PR TITLE
feat(source-control): switch and create branches from the sidepanel

### DIFF
--- a/src/main/git/checkout.test.ts
+++ b/src/main/git/checkout.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { gitExecFileAsyncMock } = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn()
+}))
+
+vi.mock('./runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock,
+  gitExecFileAsyncBuffer: vi.fn()
+}))
+
+import { checkoutBranch, createAndCheckoutBranch, listLocalBranches } from './checkout'
+
+describe('checkoutBranch', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockReset()
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
+  })
+
+  it('ends the argv with -- so the branch can never be read as a pathspec', async () => {
+    await checkoutBranch('/repo', 'feature/login')
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['checkout', 'feature/login', '--'], {
+      cwd: '/repo'
+    })
+  })
+
+  it('refuses a flag-shaped branch name before spawning git', async () => {
+    await expect(checkoutBranch('/repo', '--upload-pack=evil')).rejects.toThrow(
+      'invalid_branch_name'
+    )
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('propagates git refusing to clobber uncommitted work', async () => {
+    gitExecFileAsyncMock.mockRejectedValue(
+      new Error('error: Your local changes would be overwritten by checkout')
+    )
+
+    await expect(checkoutBranch('/repo', 'main')).rejects.toThrow('would be overwritten')
+  })
+})
+
+describe('createAndCheckoutBranch', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockReset()
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
+  })
+
+  it('creates the branch at HEAD and switches to it', async () => {
+    await createAndCheckoutBranch('/repo', 'feature/new')
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['checkout', '-b', 'feature/new', '--'], {
+      cwd: '/repo'
+    })
+  })
+
+  it('applies the full ref-format rules to a user-typed name', async () => {
+    await expect(createAndCheckoutBranch('/repo', 'bad..name')).rejects.toThrow(
+      'invalid_branch_name'
+    )
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('lets git report a name that already exists rather than switching to it', async () => {
+    gitExecFileAsyncMock.mockRejectedValue(
+      new Error("fatal: a branch named 'main' already exists")
+    )
+
+    await expect(createAndCheckoutBranch('/repo', 'main')).rejects.toThrow('already exists')
+  })
+})
+
+describe('listLocalBranches', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockReset()
+  })
+
+  it('returns the parsed listing including which worktree holds each branch', async () => {
+    gitExecFileAsyncMock.mockResolvedValue({
+      stdout: '*\tmain\t/repos/app\n\tfeature\t/repos/app-feature\n\tidle\t\n',
+      stderr: ''
+    })
+
+    const listing = await listLocalBranches('/repo')
+
+    expect(listing.current).toBe('main')
+    expect(listing.entries).toEqual([
+      { name: 'main', worktreePath: '/repos/app' },
+      { name: 'feature', worktreePath: '/repos/app-feature' },
+      { name: 'idle' }
+    ])
+  })
+})

--- a/src/main/git/checkout.ts
+++ b/src/main/git/checkout.ts
@@ -1,25 +1,20 @@
+import {
+  LOCAL_BRANCH_LISTING_ARGV,
+  parseLocalBranchListing,
+  type GitLocalBranchListing
+} from '../../shared/git-local-branches'
+import { assertValidGitBranchName } from '../../shared/git-branch-name'
 import type { GitRuntimeOptions } from './git-runtime-options'
 import { gitOptionsForWorktree } from './git-runtime-options'
 import { gitExecFileAsync } from './runner'
 import { runWithGitReadCacheInvalidation } from './status'
 
 /**
- * Reject branch names git would parse as an option (`-`/`--…`) or that aren't a
- * valid ref. Defense-in-depth: callers also validate at the RPC schema, but the
- * relay entrypoint is reachable independently, so the helper guards too.
- */
-export function assertValidBranchName(branch: string): void {
-  if (branch.length === 0 || branch.startsWith('-')) {
-    throw new Error('invalid_branch_name')
-  }
-}
-
-/**
  * Switch the worktree to an existing local branch. Git itself refuses (and
  * surfaces a "would be overwritten by checkout" error) when uncommitted changes
  * would conflict, so we let that message propagate to the caller rather than
- * forcing — mobile shows it as a toast. Flag-injection is prevented by
- * `assertValidBranchName` (rejects `-…`); the trailing `--` marks that no
+ * forcing — clients show it verbatim. Flag-injection is prevented by
+ * `assertValidGitBranchName` (rejects `-…`); the trailing `--` marks that no
  * pathspecs follow, so the token is unambiguously treated as a branch ref.
  */
 export async function checkoutBranch(
@@ -27,50 +22,41 @@ export async function checkoutBranch(
   branch: string,
   options: GitRuntimeOptions = {}
 ): Promise<void> {
-  assertValidBranchName(branch)
+  assertValidGitBranchName(branch)
   await runWithGitReadCacheInvalidation(() =>
     gitExecFileAsync(['checkout', branch, '--'], gitOptionsForWorktree(worktreePath, options))
   )
 }
 
 /**
- * List local branch short-names for the branch picker, current branch first.
- * Uses `for-each-ref` (stable, scriptable output) instead of `branch` to avoid
- * locale-dependent decoration.
+ * Create a branch at the current HEAD and switch to it. `checkout -b` (not
+ * `switch -c`) because `switch` is Git 2.23 and still experimental at the 2.25
+ * baseline. Git rejects a name that already exists, which is the behavior we
+ * want: the picker offers "Create" only for names it did not list, and a race
+ * against an outside creation should fail loudly rather than silently switch.
  */
+export async function createAndCheckoutBranch(
+  worktreePath: string,
+  branch: string,
+  options: GitRuntimeOptions = {}
+): Promise<void> {
+  assertValidGitBranchName(branch)
+  await runWithGitReadCacheInvalidation(() =>
+    gitExecFileAsync(
+      ['checkout', '-b', branch, '--'],
+      gitOptionsForWorktree(worktreePath, options)
+    )
+  )
+}
+
+/** List local branches for the branch picker, current branch first. */
 export async function listLocalBranches(
   worktreePath: string,
   options: GitRuntimeOptions = {}
-): Promise<{ current: string | null; branches: string[] }> {
+): Promise<GitLocalBranchListing> {
   const { stdout } = await gitExecFileAsync(
-    ['for-each-ref', '--format=%(HEAD)%09%(refname:short)', 'refs/heads/'],
+    [...LOCAL_BRANCH_LISTING_ARGV],
     gitOptionsForWorktree(worktreePath, options)
   )
-  let current: string | null = null
-  const branches: string[] = []
-  for (const line of stdout.split('\n')) {
-    if (line.length === 0) {
-      continue
-    }
-    const [marker, name] = line.split('\t')
-    if (!name) {
-      continue
-    }
-    if (marker === '*') {
-      current = name
-    }
-    branches.push(name)
-  }
-  // Why: surface the checked-out branch first so the picker reads "you are here"
-  // at the top, then the rest in git's ref order.
-  branches.sort((a, b) => {
-    if (a === current) {
-      return -1
-    }
-    if (b === current) {
-      return 1
-    }
-    return 0
-  })
-  return { current, branches }
+  return parseLocalBranchListing(stdout)
 }

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -60,6 +60,8 @@ import {
   getCommitDiff
 } from '../git/status'
 import { getHistory } from '../git/history'
+import { checkoutBranch, createAndCheckoutBranch, listLocalBranches } from '../git/checkout'
+import type { GitLocalBranchListing } from '../../shared/git-local-branches'
 import {
   cancelGenerateCommitMessageLocal,
   cancelGeneratePullRequestFieldsLocal,
@@ -1391,6 +1393,75 @@ export function registerFilesystemHandlers(
         worktreePath
       )
       await abortRebase(worktreePath, gitOptions)
+    }
+  )
+
+  ipcMain.handle(
+    'git:localBranches',
+    async (
+      _event,
+      args: { worktreePath: string; connectionId?: string }
+    ): Promise<GitLocalBranchListing> => {
+      if (args.connectionId) {
+        const provider = getSshGitProvider(args.connectionId)
+        if (!provider) {
+          throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+        }
+        return provider.listLocalBranches(args.worktreePath)
+      }
+      const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
+      const gitOptions = getLocalGitOptionsForRegisteredWorktree(
+        store,
+        args.worktreePath,
+        worktreePath
+      )
+      return listLocalBranches(worktreePath, gitOptions)
+    }
+  )
+
+  ipcMain.handle(
+    'git:checkout',
+    async (
+      _event,
+      args: { worktreePath: string; branch: string; connectionId?: string }
+    ): Promise<void> => {
+      if (args.connectionId) {
+        const provider = getSshGitProvider(args.connectionId)
+        if (!provider) {
+          throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+        }
+        return provider.checkoutBranch(args.worktreePath, args.branch)
+      }
+      const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
+      const gitOptions = getLocalGitOptionsForRegisteredWorktree(
+        store,
+        args.worktreePath,
+        worktreePath
+      )
+      await checkoutBranch(worktreePath, args.branch, gitOptions)
+    }
+  )
+
+  ipcMain.handle(
+    'git:createBranch',
+    async (
+      _event,
+      args: { worktreePath: string; branch: string; connectionId?: string }
+    ): Promise<void> => {
+      if (args.connectionId) {
+        const provider = getSshGitProvider(args.connectionId)
+        if (!provider) {
+          throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+        }
+        return provider.createBranch(args.worktreePath, args.branch)
+      }
+      const worktreePath = await resolveRegisteredWorktreePath(args.worktreePath, store)
+      const gitOptions = getLocalGitOptionsForRegisteredWorktree(
+        store,
+        args.worktreePath,
+        worktreePath
+      )
+      await createAndCheckoutBranch(worktreePath, args.branch, gitOptions)
     }
   )
 

--- a/src/main/providers/git-provider-contract.ts
+++ b/src/main/providers/git-provider-contract.ts
@@ -13,6 +13,7 @@ import type {
 import type { RemoveWorktreeResult } from '../../shared/worktree/create-types'
 import type { GitPushTarget, GitWorktreeInfo } from '../../shared/worktree/types'
 import type { GitHistoryOptions, GitHistoryResult } from '../../shared/git-history'
+import type { GitLocalBranchListing } from '../../shared/git-local-branches'
 import type { CommitMessageDraftContext } from '../../shared/commit-message-generation'
 import type { GitProviderStatusOptions } from './git-provider-status-options'
 
@@ -45,7 +46,8 @@ export type IGitProvider = {
   abortMerge(worktreePath: string): Promise<void>
   abortRebase(worktreePath: string): Promise<void>
   checkoutBranch(worktreePath: string, branch: string): Promise<void>
-  listLocalBranches(worktreePath: string): Promise<{ current: string | null; branches: string[] }>
+  createBranch(worktreePath: string, branch: string): Promise<void>
+  listLocalBranches(worktreePath: string): Promise<GitLocalBranchListing>
   getBranchCompare(worktreePath: string, baseRef: string): Promise<GitBranchCompareResult>
   getCommitCompare(worktreePath: string, commitId: string): Promise<GitCommitCompareResult>
   getUpstreamStatus(worktreePath: string, pushTarget?: GitPushTarget): Promise<GitUpstreamStatus>

--- a/src/main/providers/ssh-git-working-tree-provider.ts
+++ b/src/main/providers/ssh-git-working-tree-provider.ts
@@ -3,6 +3,7 @@ import type {
   GitCommitCompareResult
 } from '../../shared/git-diff-compare-types'
 import type { GitHistoryOptions, GitHistoryResult } from '../../shared/git-history'
+import type { GitLocalBranchListing } from '../../shared/git-local-branches'
 import type { GitConflictOperation } from '../../shared/git-status-types'
 import { SshGitNoninteractiveProvider } from './ssh-git-noninteractive-provider'
 
@@ -97,13 +98,16 @@ export class SshGitWorkingTreeProvider extends SshGitNoninteractiveProvider {
     })
   }
 
-  async listLocalBranches(
-    worktreePath: string
-  ): Promise<{ current: string | null; branches: string[] }> {
-    return (await this.mux.request('git.localBranches', { worktreePath })) as {
-      current: string | null
-      branches: string[]
-    }
+  async createBranch(worktreePath: string, branch: string): Promise<void> {
+    await this.runWithGitReadInvalidation(async () => {
+      await this.mux.request('git.createBranch', { worktreePath, branch })
+    })
+  }
+
+  async listLocalBranches(worktreePath: string): Promise<GitLocalBranchListing> {
+    return (await this.mux.request('git.localBranches', {
+      worktreePath
+    })) as GitLocalBranchListing
   }
 
   async getBranchCompare(worktreePath: string, baseRef: string): Promise<GitBranchCompareResult> {

--- a/src/main/runtime/orca-runtime-git.ts
+++ b/src/main/runtime/orca-runtime-git.ts
@@ -47,7 +47,7 @@ import {
   stageFile,
   unstageFile
 } from '../git/status'
-import { checkoutBranch, listLocalBranches } from '../git/checkout'
+import { checkoutBranch, createAndCheckoutBranch, listLocalBranches } from '../git/checkout'
 import type { RuntimeGitCheckoutResult, RuntimeGitLocalBranches } from '../../shared/runtime-types'
 import { getHistory as getGitHistory } from '../git/history'
 import { getUpstreamStatus } from '../git/upstream'
@@ -327,6 +327,23 @@ export class RuntimeGitCommands {
       return { ok: true, branch }
     }
     await checkoutBranch(target.worktree.path, branch, localGitOptionsForTarget(target))
+    return { ok: true, branch }
+  }
+
+  async createRuntimeGitBranch(
+    worktreeSelector: string,
+    branch: string
+  ): Promise<RuntimeGitCheckoutResult> {
+    const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
+    const provider = target.connectionId ? getSshGitProvider(target.connectionId) : null
+    if (target.connectionId) {
+      if (!provider) {
+        throw new Error(SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE)
+      }
+      await provider.createBranch(target.worktree.path, branch)
+      return { ok: true, branch }
+    }
+    await createAndCheckoutBranch(target.worktree.path, branch, localGitOptionsForTarget(target))
     return { ok: true, branch }
   }
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -10451,6 +10451,8 @@ export class OrcaRuntimeService {
     this.gitCommands.checkoutRuntimeGitBranch.bind(this.gitCommands)
   listRuntimeGitLocalBranches: RuntimeGitCommands['listRuntimeGitLocalBranches'] =
     this.gitCommands.listRuntimeGitLocalBranches.bind(this.gitCommands)
+  createRuntimeGitBranch: RuntimeGitCommands['createRuntimeGitBranch'] =
+    this.gitCommands.createRuntimeGitBranch.bind(this.gitCommands)
   getRuntimeGitDiff: RuntimeGitCommands['getRuntimeGitDiff'] =
     this.gitCommands.getRuntimeGitDiff.bind(this.gitCommands)
   getRuntimeGitBranchCompare: RuntimeGitCommands['getRuntimeGitBranchCompare'] =

--- a/src/main/runtime/rpc/methods/git-params.ts
+++ b/src/main/runtime/rpc/methods/git-params.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { isValidGitBranchName } from '../../../../shared/git-branch-name'
 
 export const WorktreeSelector = z.object({
   worktree: z
@@ -249,6 +250,17 @@ export const GitCheckout = WorktreeSelector.extend({
         // Why: never let a branch arg be parsed as a git flag (arg injection).
         .refine((value) => !value.startsWith('-'), 'Branch must not start with -')
     )
+})
+
+/**
+ * Create takes a user-typed name, so it gets the full `check-ref-format` rule set
+ * rather than checkout's narrower flag-injection guard.
+ */
+export const GitCreateBranch = WorktreeSelector.extend({
+  branch: z
+    .unknown()
+    .transform((v) => (typeof v === 'string' ? v : ''))
+    .pipe(z.string().refine(isValidGitBranchName, 'Invalid branch name'))
 })
 
 export const GitRemoteFileUrl = WorktreeSelector.extend({

--- a/src/main/runtime/rpc/methods/git.ts
+++ b/src/main/runtime/rpc/methods/git.ts
@@ -8,6 +8,7 @@ import {
   GitCheckout,
   GitCommit,
   GitCommitCompare,
+  GitCreateBranch,
   GitFilePath,
   GitForkSync,
   GitHistory,
@@ -92,6 +93,12 @@ export const GIT_METHODS: RpcMethod[] = [
     params: GitCheckout,
     handler: async (params, { runtime }) =>
       runtime.checkoutRuntimeGitBranch(params.worktree, params.branch)
+  }),
+  defineMethod({
+    name: 'git.createBranch',
+    params: GitCreateBranch,
+    handler: async (params, { runtime }) =>
+      runtime.createRuntimeGitBranch(params.worktree, params.branch)
   }),
   defineMethod({
     name: 'git.localBranches',

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -237,6 +237,7 @@ const MOBILE_RPC_METHOD_ALLOWLIST = new Set([
   'git.commit',
   'git.commitCompare',
   'git.commitDiff',
+  'git.createBranch',
   'git.discard',
   'git.discoverCommitMessageModels',
   'git.diff',

--- a/src/preload/api/git-inspection-api.ts
+++ b/src/preload/api/git-inspection-api.ts
@@ -11,6 +11,7 @@ import type {
 } from '../../shared/git-status-types'
 import type { GitPushTarget } from '../../shared/worktree/types'
 import type { GitHistoryOptions, GitHistoryResult } from '../../shared/git-history'
+import type { GitLocalBranchListing } from '../../shared/git-local-branches'
 import type {
   CommitMessageAgentCapability,
   CommitMessageModelCapability
@@ -55,6 +56,10 @@ export type GitInspectionApi = {
     worktreePath: string
     connectionId?: string
   }) => Promise<GitConflictOperation>
+  localBranches: (args: {
+    worktreePath: string
+    connectionId?: string
+  }) => Promise<GitLocalBranchListing>
   diff: (args: {
     worktreePath: string
     filePath: string

--- a/src/preload/api/git-operation-api.ts
+++ b/src/preload/api/git-operation-api.ts
@@ -9,6 +9,16 @@ export type GitOperationApi = {
   appendGitignore: (args: { worktreePath: string; folderName: string }) => Promise<boolean>
   abortMerge: (args: { worktreePath: string; connectionId?: string }) => Promise<void>
   abortRebase: (args: { worktreePath: string; connectionId?: string }) => Promise<void>
+  checkout: (args: {
+    worktreePath: string
+    branch: string
+    connectionId?: string
+  }) => Promise<void>
+  createBranch: (args: {
+    worktreePath: string
+    branch: string
+    connectionId?: string
+  }) => Promise<void>
   fetch: (args: {
     worktreePath: string
     connectionId?: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3525,6 +3525,18 @@ const api = {
       ipcRenderer.invoke('git:abortMerge', args),
     abortRebase: (args: { worktreePath: string; connectionId?: string }): Promise<void> =>
       ipcRenderer.invoke('git:abortRebase', args),
+    localBranches: (args: { worktreePath: string; connectionId?: string }): Promise<unknown> =>
+      ipcRenderer.invoke('git:localBranches', args),
+    checkout: (args: {
+      worktreePath: string
+      branch: string
+      connectionId?: string
+    }): Promise<void> => ipcRenderer.invoke('git:checkout', args),
+    createBranch: (args: {
+      worktreePath: string
+      branch: string
+      connectionId?: string
+    }): Promise<void> => ipcRenderer.invoke('git:createBranch', args),
     diff: (args: {
       worktreePath: string
       filePath: string

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -13,6 +13,11 @@ import {
 } from './git-handler-utils'
 import { parseNumstat } from '../shared/git-uncommitted-line-stats'
 import {
+  LOCAL_BRANCH_LISTING_ARGV,
+  parseLocalBranchListing
+} from '../shared/git-local-branches'
+import { assertValidGitBranchName } from '../shared/git-branch-name'
+import {
   computeDiff,
   branchCompare as branchCompareOp,
   branchDiffEntries,
@@ -273,6 +278,7 @@ export class GitHandler {
     this.dispatcher.onRequest('git.abortRebase', (p) => this.abortRebase(p))
     this.dispatcher.onRequest('git.checkout', (p) => this.checkout(p))
     this.dispatcher.onRequest('git.localBranches', (p) => this.localBranches(p))
+    this.dispatcher.onRequest('git.createBranch', (p) => this.createBranch(p))
     this.dispatcher.onRequest('git.discard', (p) => this.discard(p))
     this.dispatcher.onRequest('git.bulkDiscard', (p) => this.bulkDiscard(p))
     this.dispatcher.onRequest('git.conflictOperation', (p) => this.conflictOperation(p))
@@ -661,10 +667,11 @@ export class GitHandler {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
     const branch = params.branch as string
-    // Defense-in-depth: reject `-`-prefixed branch tokens to block flag injection (this relay entrypoint is reachable independently of the RPC schema).
-    if (typeof branch !== 'string' || branch.length === 0 || branch.startsWith('-')) {
+    // Defense-in-depth: this relay entrypoint is reachable independently of the RPC schema.
+    if (typeof branch !== 'string') {
       throw new Error('invalid_branch_name')
     }
+    assertValidGitBranchName(branch)
     try {
       await this.git(['checkout', branch, '--'], worktreePath)
       return { ok: true as const, branch }
@@ -673,29 +680,26 @@ export class GitHandler {
     }
   }
 
+  private async createBranch(params: Record<string, unknown>) {
+    this.clearGitMutationReadCaches()
+    const worktreePath = params.worktreePath as string
+    const branch = params.branch as string
+    if (typeof branch !== 'string') {
+      throw new Error('invalid_branch_name')
+    }
+    assertValidGitBranchName(branch)
+    try {
+      await this.git(['checkout', '-b', branch, '--'], worktreePath)
+      return { ok: true as const, branch }
+    } finally {
+      this.clearGitMutationReadCaches()
+    }
+  }
+
   private async localBranches(params: Record<string, unknown>) {
     const worktreePath = params.worktreePath as string
-    const { stdout } = await this.git(
-      ['for-each-ref', '--format=%(HEAD)%09%(refname:short)', 'refs/heads/'],
-      worktreePath
-    )
-    let current: string | null = null
-    const branches: string[] = []
-    for (const line of stdout.split('\n')) {
-      if (line.length === 0) {
-        continue
-      }
-      const [marker, name] = line.split('\t')
-      if (!name) {
-        continue
-      }
-      if (marker === '*') {
-        current = name
-      }
-      branches.push(name)
-    }
-    branches.sort((a, b) => (a === current ? -1 : b === current ? 1 : 0))
-    return { current, branches }
+    const { stdout } = await this.git([...LOCAL_BRANCH_LISTING_ARGV], worktreePath)
+    return parseLocalBranchListing(stdout)
   }
 
   private normalizeGitPathForCompare(filePath: string): string {

--- a/src/renderer/src/components/right-sidebar/source-control/panel/branch-context-row.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/branch-context-row.tsx
@@ -8,8 +8,8 @@ import type {
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { DetachedHeadBadge } from '@/components/DetachedHeadBadge'
 import type { WorktreeGitIdentityDisplay } from '@/lib/worktree-git-identity-display'
+import { HeadIdentity, resolveHeadFlowLabel } from './head-identity'
 import { SourceControlHeaderIconButton } from './header-icon-button'
 import { SourceControlBranchLineTotalChip } from './branch-line-total-chip'
 import {
@@ -95,60 +95,6 @@ function ManualReviewLinkButton({
   )
 }
 
-function resolveHeadFlowLabel(
-  display: WorktreeGitIdentityDisplay | null | undefined
-): string | null {
-  if (display?.kind === 'branch') {
-    return display.branchName
-  }
-  if (display?.kind === 'detached') {
-    return display.sourceControlLabel
-  }
-  return null
-}
-
-function HeadIdentity({ display }: { display: WorktreeGitIdentityDisplay }): React.JSX.Element {
-  if (display.kind === 'detached') {
-    return (
-      <DetachedHeadBadge
-        display={display}
-        side="bottom"
-        // Why: tooltip carries the full detached explanation; keep it keyboard-reachable.
-        tabIndex={0}
-        className="min-w-0 max-w-full shrink"
-      />
-    )
-  }
-
-  const branchAriaLabel = translate(
-    'auto.components.right.sidebar.SourceControl.a4e93c21d7',
-    'Current branch: {{value0}}',
-    { value0: display.branchName }
-  )
-
-  // Why: focusable + tooltip so truncated long branch names stay discoverable.
-  // Native title omitted — Radix Tooltip already surfaces the full name on hover.
-  // `block` is load-bearing: `truncate` clips nothing on an inline box, so an
-  // inline span here let long names run under the line-total chip.
-  return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <span
-          className="block min-w-0 max-w-full truncate rounded-sm font-mono text-[10.5px] font-medium text-foreground/90 outline-none focus-visible:ring-1 focus-visible:ring-ring"
-          tabIndex={0}
-          aria-label={branchAriaLabel}
-          data-testid="source-control-head-identity"
-        >
-          {display.branchName}
-        </span>
-      </TooltipTrigger>
-      <TooltipContent side="bottom" sideOffset={6} className="max-w-72 break-all font-mono">
-        {display.branchName}
-      </TooltipContent>
-    </Tooltip>
-  )
-}
-
 function CompareFlowGroup({
   flowLabel,
   busy,
@@ -224,7 +170,8 @@ function StackedCompareFlow({
   changeBaseTitle,
   leading,
   trailing,
-  headTrailing
+  headTrailing,
+  headSlot
 }: {
   headDisplay: WorktreeGitIdentityDisplay | null
   baseRef: string
@@ -234,6 +181,7 @@ function StackedCompareFlow({
   leading?: React.ReactNode
   trailing?: React.ReactNode
   headTrailing?: React.ReactNode
+  headSlot?: React.ReactNode
 }): React.JSX.Element {
   if (!headDisplay) {
     return (
@@ -264,7 +212,7 @@ function StackedCompareFlow({
           counts reads as part of the branch name. */}
       <div className="flex min-w-0 items-center gap-2">
         <span className="flex min-w-0 flex-1 items-center">
-          <HeadIdentity display={headDisplay} />
+          <HeadIdentity display={headDisplay} headSlot={headSlot} />
         </span>
         {headTrailing}
       </div>
@@ -289,6 +237,7 @@ export function SourceControlBranchContextRow({
   upstreamStatus,
   manualReviewUrl,
   branchLineTotal,
+  headSlot,
   onChangeBaseRef,
   onRetry
 }: {
@@ -298,6 +247,8 @@ export function SourceControlBranchContextRow({
   upstreamStatus?: GitUpstreamStatus
   manualReviewUrl?: string | null
   branchLineTotal?: GitBranchLineTotal | null
+  /** Replaces the static HEAD label, letting the caller make it a branch picker. */
+  headSlot?: React.ReactNode
   onChangeBaseRef: () => void
   onRetry: () => void
 }): React.JSX.Element | null {
@@ -311,7 +262,7 @@ export function SourceControlBranchContextRow({
     }
     return (
       <div className="min-w-0 text-[11px] text-muted-foreground">
-        <HeadIdentity display={headDisplay} />
+        <HeadIdentity display={headDisplay} headSlot={headSlot} />
       </div>
     )
   }
@@ -344,6 +295,7 @@ export function SourceControlBranchContextRow({
           baseLabel={baseLabel}
           onChangeBaseRef={onChangeBaseRef}
           changeBaseTitle={changeBaseTitle}
+          headSlot={headSlot}
           leading={<Loader2 className="size-3 shrink-0 animate-spin" aria-hidden="true" />}
           trailing={<ManualReviewLinkButton url={manualReviewUrl} />}
         />
@@ -366,6 +318,7 @@ export function SourceControlBranchContextRow({
           baseLabel={baseLabel}
           onChangeBaseRef={onChangeBaseRef}
           changeBaseTitle={changeBaseTitle}
+          headSlot={headSlot}
           trailing={
             <>
               <ManualReviewLinkButton url={manualReviewUrl} />
@@ -419,6 +372,7 @@ export function SourceControlBranchContextRow({
         baseLabel={baseLabel}
         onChangeBaseRef={onChangeBaseRef}
         changeBaseTitle={changeBaseTitle}
+        headSlot={headSlot}
         trailing={trailing}
         headTrailing={<SourceControlBranchLineTotalChip branchLineTotal={branchLineTotal} />}
       />

--- a/src/renderer/src/components/right-sidebar/source-control/panel/branch-picker-rows.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/branch-picker-rows.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest'
+import { buildBranchPickerRows } from './branch-picker-rows'
+import type { GitLocalBranchListing } from '../../../../../../shared/git-local-branches'
+
+const listing: GitLocalBranchListing = {
+  current: 'main',
+  branches: ['main', 'feature/login', 'release'],
+  entries: [
+    { name: 'main', worktreePath: '/repos/app' },
+    { name: 'feature/login', worktreePath: '/repos/app-login' },
+    { name: 'release' }
+  ]
+}
+
+const SELF = '/repos/app'
+
+describe('buildBranchPickerRows', () => {
+  it('marks the checked-out branch as current rather than occupied', () => {
+    const rows = buildBranchPickerRows({ listing, query: '', worktreePath: SELF })
+
+    expect(rows[0]).toEqual({ kind: 'branch', name: 'main', isCurrent: true, occupiedBy: null })
+  })
+
+  it('names the workspace holding a branch checked out in another worktree', () => {
+    const rows = buildBranchPickerRows({
+      listing,
+      query: '',
+      worktreePath: SELF,
+      worktreeLabelByPath: new Map([['/repos/app-login', 'Login work']])
+    })
+
+    expect(rows.find((row) => row.kind === 'branch' && row.name === 'feature/login')).toEqual({
+      kind: 'branch',
+      name: 'feature/login',
+      isCurrent: false,
+      occupiedBy: 'Login work'
+    })
+  })
+
+  it('falls back to the raw path when no workspace matches the occupying worktree', () => {
+    const rows = buildBranchPickerRows({ listing, query: '', worktreePath: SELF })
+
+    expect(rows.find((row) => row.kind === 'branch' && row.name === 'feature/login')).toMatchObject({
+      occupiedBy: '/repos/app-login'
+    })
+  })
+
+  it('leaves a branch no worktree holds selectable', () => {
+    const rows = buildBranchPickerRows({ listing, query: '', worktreePath: SELF })
+
+    expect(rows.find((row) => row.kind === 'branch' && row.name === 'release')).toMatchObject({
+      occupiedBy: null
+    })
+  })
+
+  it('filters branches case-insensitively on the typed query', () => {
+    const rows = buildBranchPickerRows({ listing, query: 'LOGIN', worktreePath: SELF })
+
+    expect(rows.filter((row) => row.kind === 'branch').map((row) => row.name)).toEqual([
+      'feature/login'
+    ])
+  })
+
+  it('offers to create a branch for a name no local branch matches', () => {
+    const rows = buildBranchPickerRows({ listing, query: 'new-thing', worktreePath: SELF })
+
+    expect(rows.at(-1)).toEqual({ kind: 'create', name: 'new-thing', rejection: null })
+  })
+
+  it('does not offer to create a branch that already exists', () => {
+    const rows = buildBranchPickerRows({ listing, query: 'release', worktreePath: SELF })
+
+    expect(rows.some((row) => row.kind === 'create')).toBe(false)
+  })
+
+  it('offers no create row for an empty query', () => {
+    const rows = buildBranchPickerRows({ listing, query: '   ', worktreePath: SELF })
+
+    expect(rows.some((row) => row.kind === 'create')).toBe(false)
+  })
+
+  it('surfaces why a typed name cannot be created instead of hiding the row', () => {
+    const rows = buildBranchPickerRows({ listing, query: 'bad..name', worktreePath: SELF })
+
+    expect(rows.at(-1)).toEqual({
+      kind: 'create',
+      name: 'bad..name',
+      rejection: 'invalid-characters'
+    })
+  })
+
+  it('treats every branch as free when an older host reports no occupancy', () => {
+    const legacy: GitLocalBranchListing = { current: 'main', branches: ['main', 'feature/login'] }
+
+    const rows = buildBranchPickerRows({ listing: legacy, query: '', worktreePath: SELF })
+
+    expect(rows).toEqual([
+      { kind: 'branch', name: 'main', isCurrent: true, occupiedBy: null },
+      { kind: 'branch', name: 'feature/login', isCurrent: false, occupiedBy: null }
+    ])
+  })
+
+  it('compares worktree paths case- and separator-insensitively', () => {
+    const windowsListing: GitLocalBranchListing = {
+      current: 'main',
+      branches: ['main'],
+      entries: [{ name: 'main', worktreePath: 'C:/Repos/App' }]
+    }
+
+    const rows = buildBranchPickerRows({
+      listing: windowsListing,
+      query: '',
+      worktreePath: 'C:\\Repos\\App'
+    })
+
+    expect(rows[0]).toMatchObject({ isCurrent: true, occupiedBy: null })
+  })
+
+  it('renders an empty list, not a crash, before the listing arrives', () => {
+    expect(buildBranchPickerRows({ listing: null, query: '', worktreePath: SELF })).toEqual([])
+  })
+
+  it('still offers creation while the listing is loading', () => {
+    const rows = buildBranchPickerRows({ listing: null, query: 'fresh', worktreePath: SELF })
+
+    expect(rows).toEqual([{ kind: 'create', name: 'fresh', rejection: null }])
+  })
+})

--- a/src/renderer/src/components/right-sidebar/source-control/panel/branch-picker-rows.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/branch-picker-rows.ts
@@ -1,0 +1,82 @@
+import {
+  checkGitBranchName,
+  type GitBranchNameRejection
+} from '../../../../../../shared/git-branch-name'
+import type {
+  GitLocalBranchEntry,
+  GitLocalBranchListing
+} from '../../../../../../shared/git-local-branches'
+import { normalizeRuntimePathForComparison } from '../../../../../../shared/cross-platform-path'
+
+export type BranchPickerRow =
+  | {
+      kind: 'branch'
+      name: string
+      isCurrent: boolean
+      /**
+       * Label of the workspace already holding this branch, or the raw path when
+       * no workspace matches. Null when the branch is free — or when the host is
+       * too old to report occupancy, in which case the checkout is attempted and
+       * git's own refusal is what the user sees.
+       */
+      occupiedBy: string | null
+    }
+  | { kind: 'create'; name: string; rejection: GitBranchNameRejection | null }
+
+function matchesQuery(name: string, query: string): boolean {
+  return name.toLowerCase().includes(query.toLowerCase())
+}
+
+/**
+ * Rows for the Source Control branch picker: matching local branches, then a
+ * create row when the typed name is not one of them.
+ */
+export function buildBranchPickerRows(args: {
+  listing: GitLocalBranchListing | null
+  query: string
+  /** Worktree the picker is acting on; its own occupancy is "current", not a conflict. */
+  worktreePath: string | null
+  /** Display name per worktree path, so occupancy reads as a workspace, not a path. */
+  worktreeLabelByPath?: ReadonlyMap<string, string>
+}): BranchPickerRow[] {
+  const { listing, query, worktreePath, worktreeLabelByPath } = args
+  const trimmedQuery = query.trim()
+  const rows: BranchPickerRow[] = []
+  const selfPath = worktreePath ? normalizeRuntimePathForComparison(worktreePath) : null
+
+  // Why: a host older than `entries` still sends `branches`; widen it to the same
+  // shape with occupancy unknown rather than hiding those branches from the picker.
+  const entries: readonly GitLocalBranchEntry[] =
+    listing?.entries ?? listing?.branches.map((name): GitLocalBranchEntry => ({ name })) ?? []
+  for (const entry of entries) {
+    if (trimmedQuery.length > 0 && !matchesQuery(entry.name, trimmedQuery)) {
+      continue
+    }
+    const entryPath = entry.worktreePath
+      ? normalizeRuntimePathForComparison(entry.worktreePath)
+      : null
+    const occupiedElsewhere = entryPath !== null && entryPath !== selfPath
+    rows.push({
+      kind: 'branch',
+      name: entry.name,
+      isCurrent: entry.name === listing?.current,
+      occupiedBy: occupiedElsewhere
+        ? (worktreeLabelByPath?.get(entryPath) ?? entry.worktreePath ?? null)
+        : null
+    })
+  }
+
+  // Why: only offer creation for a name the listing does not already hold —
+  // `checkout -b` on an existing branch fails, and offering it would read as a switch.
+  const alreadyExists = entries.some((entry) => entry.name === trimmedQuery)
+  if (trimmedQuery.length > 0 && !alreadyExists) {
+    const check = checkGitBranchName(trimmedQuery)
+    rows.push({
+      kind: 'create',
+      name: trimmedQuery,
+      rejection: check.ok ? null : check.reason
+    })
+  }
+
+  return rows
+}

--- a/src/renderer/src/components/right-sidebar/source-control/panel/branch-switcher.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/branch-switcher.tsx
@@ -1,0 +1,178 @@
+import React from 'react'
+import { Check, GitBranch, Loader2, Plus } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList
+} from '@/components/ui/command'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import type { SourceControlBranchSwitch } from '../sync/use-branch-switch'
+import type { BranchPickerRow } from './branch-picker-rows'
+
+function CreateRow({
+  row,
+  disabled,
+  onSelect
+}: {
+  row: Extract<BranchPickerRow, { kind: 'create' }>
+  disabled: boolean
+  onSelect: () => void
+}): React.JSX.Element {
+  return (
+    <CommandItem
+      value={`create:${row.name}`}
+      disabled={disabled || row.rejection !== null}
+      onSelect={onSelect}
+    >
+      <Plus className="size-3.5" aria-hidden="true" />
+      <span className="min-w-0 flex-1 truncate font-mono text-[11px]">
+        {translate(
+          'auto.components.right.sidebar.SourceControl.4ec1304f7b',
+          'Create branch {{value0}}',
+          { value0: row.name }
+        )}
+      </span>
+      {row.rejection !== null ? (
+        <span className="shrink-0 text-[10px] text-muted-foreground">
+          {translate('auto.components.right.sidebar.SourceControl.96fb1f9512', 'Invalid branch name')}
+        </span>
+      ) : null}
+    </CommandItem>
+  )
+}
+
+function BranchRow({
+  row,
+  disabled,
+  onSelect
+}: {
+  row: Extract<BranchPickerRow, { kind: 'branch' }>
+  disabled: boolean
+  onSelect: () => void
+}): React.JSX.Element {
+  // Why: git refuses to check a branch out in two worktrees, so an occupied row
+  // is inert rather than a checkout that is guaranteed to fail.
+  const blocked = row.occupiedBy !== null
+  return (
+    <CommandItem
+      value={`branch:${row.name}`}
+      disabled={disabled || blocked || row.isCurrent}
+      onSelect={onSelect}
+    >
+      {row.isCurrent ? (
+        <Check className="size-3.5" aria-hidden="true" />
+      ) : (
+        <GitBranch className="size-3.5 opacity-60" aria-hidden="true" />
+      )}
+      <span className="min-w-0 flex-1 truncate font-mono text-[11px]">{row.name}</span>
+      {row.isCurrent ? (
+        <span className="shrink-0 text-[10px] text-muted-foreground">
+          {translate('auto.components.right.sidebar.SourceControl.97b0560280', 'current')}
+        </span>
+      ) : null}
+      {blocked ? (
+        <span className="min-w-0 max-w-28 shrink-0 truncate text-[10px] text-muted-foreground">
+          {translate(
+            'auto.components.right.sidebar.SourceControl.419ab6fb4e',
+            'Checked out in {{value0}}',
+            { value0: row.occupiedBy ?? '' }
+          )}
+        </span>
+      ) : null}
+    </CommandItem>
+  )
+}
+
+/**
+ * The HEAD branch name as a picker trigger. Renders the same text the static
+ * identity did, so the header reads identically until it is activated.
+ */
+export function SourceControlBranchSwitcher({
+  branchName,
+  branchSwitch
+}: {
+  branchName: string
+  branchSwitch: SourceControlBranchSwitch
+}): React.JSX.Element {
+  const { isBusy, isLoading, isOpen, onOpenChange, query, rows, setQuery } = branchSwitch
+
+  return (
+    <Popover open={isOpen} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            'block min-w-0 max-w-full truncate rounded-sm border-0 bg-transparent p-0 text-left font-mono text-[10.5px] font-medium text-foreground/90',
+            'underline decoration-transparent underline-offset-2 outline-none',
+            'hover:decoration-border focus-visible:ring-1 focus-visible:ring-ring'
+          )}
+          aria-label={translate(
+            'auto.components.right.sidebar.SourceControl.e000af1035',
+            'Current branch: {{value0}}. Activate to switch branch.',
+            { value0: branchName }
+          )}
+          data-testid="source-control-head-identity"
+        >
+          {branchName}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" side="bottom" sideOffset={6} className="w-72 p-0">
+        {/* Why: rows are already filtered against the typed query, and cmdk's own
+            fuzzy pass would additionally hide the create row for a novel name. */}
+        <Command shouldFilter={false}>
+          <CommandInput
+            value={query}
+            onValueChange={setQuery}
+            placeholder={translate(
+              'auto.components.right.sidebar.SourceControl.22f3ebc156',
+              'Search or create branch…'
+            )}
+            trailing={
+              isBusy || isLoading ? (
+                <Loader2 className="size-3.5 animate-spin opacity-60" aria-hidden="true" />
+              ) : null
+            }
+          />
+          <CommandList>
+            {isLoading ? (
+              <div className="px-3 py-4 text-center text-[11px] text-muted-foreground">
+                {translate(
+                  'auto.components.right.sidebar.SourceControl.55704e8f60',
+                  'Loading branches…'
+                )}
+              </div>
+            ) : (
+              <CommandEmpty>
+                {translate(
+                  'auto.components.right.sidebar.SourceControl.68f9e0ee45',
+                  'No matching branches'
+                )}
+              </CommandEmpty>
+            )}
+            {rows.map((row) =>
+              row.kind === 'create' ? (
+                <CreateRow
+                  key={`create:${row.name}`}
+                  row={row}
+                  disabled={isBusy}
+                  onSelect={() => branchSwitch.createBranch(row.name)}
+                />
+              ) : (
+                <BranchRow
+                  key={`branch:${row.name}`}
+                  row={row}
+                  disabled={isBusy}
+                  onSelect={() => branchSwitch.switchToBranch(row.name)}
+                />
+              )
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/source-control/panel/head-identity.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/head-identity.tsx
@@ -1,0 +1,71 @@
+import React from 'react'
+import { translate } from '@/i18n/i18n'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { DetachedHeadBadge } from '@/components/DetachedHeadBadge'
+import type { WorktreeGitIdentityDisplay } from '@/lib/worktree-git-identity-display'
+
+export function resolveHeadFlowLabel(
+  display: WorktreeGitIdentityDisplay | null | undefined
+): string | null {
+  if (display?.kind === 'branch') {
+    return display.branchName
+  }
+  if (display?.kind === 'detached') {
+    return display.sourceControlLabel
+  }
+  return null
+}
+
+export function HeadIdentity({
+  display,
+  headSlot
+}: {
+  display: WorktreeGitIdentityDisplay
+  headSlot?: React.ReactNode
+}): React.JSX.Element {
+  if (display.kind === 'detached') {
+    return (
+      <DetachedHeadBadge
+        display={display}
+        side="bottom"
+        // Why: tooltip carries the full detached explanation; keep it keyboard-reachable.
+        tabIndex={0}
+        className="min-w-0 max-w-full shrink"
+      />
+    )
+  }
+
+  // Why: the switcher owns its own trigger label and popover; only fall back to
+  // the static span when no switcher is available (folder workspace, no worktree).
+  if (headSlot) {
+    return <>{headSlot}</>
+  }
+
+  const branchAriaLabel = translate(
+    'auto.components.right.sidebar.SourceControl.a4e93c21d7',
+    'Current branch: {{value0}}',
+    { value0: display.branchName }
+  )
+
+  // Why: focusable + tooltip so truncated long branch names stay discoverable.
+  // Native title omitted — Radix Tooltip already surfaces the full name on hover.
+  // `block` is load-bearing: `truncate` clips nothing on an inline box, so an
+  // inline span here let long names run under the line-total chip.
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span
+          className="block min-w-0 max-w-full truncate rounded-sm font-mono text-[10.5px] font-medium text-foreground/90 outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          tabIndex={0}
+          aria-label={branchAriaLabel}
+          data-testid="source-control-head-identity"
+        >
+          {display.branchName}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="bottom" sideOffset={6} className="max-w-72 break-all font-mono">
+        {display.branchName}
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/source-control/panel/header-toolbar.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/header-toolbar.tsx
@@ -43,6 +43,8 @@ type SourceControlHeaderToolbarProps = {
   upstreamStatus?: GitUpstreamStatus
   manualReviewUrl?: string | null
   branchLineTotal?: GitBranchLineTotal | null
+  /** Branch picker rendered in place of the static HEAD label. */
+  branchSwitcher?: React.ReactNode
 }
 
 function HostedReviewToolbarLink({
@@ -149,7 +151,8 @@ export function SourceControlHeaderToolbar({
   headDisplay = null,
   upstreamStatus,
   manualReviewUrl,
-  branchLineTotal
+  branchLineTotal,
+  branchSwitcher
 }: SourceControlHeaderToolbarProps): React.JSX.Element {
   const filterInputRef = useRef<HTMLInputElement>(null)
   const normalizedFilter = filterQuery.trim()
@@ -297,6 +300,7 @@ export function SourceControlHeaderToolbar({
             upstreamStatus={upstreamStatus}
             manualReviewUrl={manualReviewUrl}
             branchLineTotal={branchLineTotal}
+            headSlot={branchSwitcher}
             onChangeBaseRef={onChangeBaseRef}
             onRetry={onRefreshBranchCompare}
           />

--- a/src/renderer/src/components/right-sidebar/source-control/panel/panel-ready.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/panel-ready.tsx
@@ -1,4 +1,5 @@
 import { BulkActionBar } from '../commit/bulk-action-bar'
+import { SourceControlBranchSwitcher } from './branch-switcher'
 import { SourceControlHeaderToolbar } from './header-toolbar'
 import { SourceControlNotesShelf } from '../notes/notes-shelf'
 import { SourceControlPanelContent } from './panel-content'
@@ -12,6 +13,7 @@ export function SourceControlPanelReady(props: SourceControlPanelReadyProps) {
     activeGroupId,
     activeWorktreeId,
     branchLineTotal,
+    branchSwitch,
     branchSummary,
     bulkStagePaths,
     bulkUnstagePaths,
@@ -82,6 +84,14 @@ export function SourceControlPanelReady(props: SourceControlPanelReadyProps) {
           onExpandNotes={() => setDiffCommentsExpanded(true)}
           branchSummary={branchSummary}
           branchLineTotal={branchLineTotal}
+          branchSwitcher={
+            gitIdentityDisplay?.kind === 'branch' && branchSwitch.canSwitch ? (
+              <SourceControlBranchSwitcher
+                branchName={gitIdentityDisplay.branchName}
+                branchSwitch={branchSwitch}
+              />
+            ) : null
+          }
           compareBaseRef={compareBaseRef}
           headDisplay={gitIdentityDisplay}
           upstreamStatus={remoteStatus}

--- a/src/renderer/src/components/right-sidebar/source-control/panel/use-panel-model.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/panel/use-panel-model.ts
@@ -7,6 +7,7 @@ import { useSourceControlActionDispatch } from '../review/use-action-dispatch'
 import { useSourceControlActionModel } from '../review/use-action-model'
 import { useSourceControlCreatePrIntentFlows } from '../review/use-create-pr-intent-flows'
 import { useSourceControlReviewFlows } from '../review/use-review-flows'
+import { useSourceControlBranchSwitch } from '../sync/use-branch-switch'
 import { useSourceControlUpstreamStatusFetch } from '../sync/use-upstream-status-fetch'
 import { useSourceControlPanelFoundation } from './use-panel-foundation'
 
@@ -162,7 +163,17 @@ export function useSourceControlPanelModel() {
     refreshActiveGitStatusAfterMutation
   })
 
+  const branchSwitch = useSourceControlBranchSwitch({
+    activeRepoSettings,
+    activeWorktreeId,
+    refreshActiveGitStatusAfterMutation,
+    refreshBranchCompareRef: foundation.refreshBranchCompareRef,
+    refreshGitHistoryRef: foundation.refreshGitHistoryRef,
+    worktreePath
+  })
+
   return {
+    branchSwitch,
     ...foundation,
     ...commitFlows,
     ...reviewFlows,

--- a/src/renderer/src/components/right-sidebar/source-control/sync/use-branch-switch.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/sync/use-branch-switch.ts
@@ -1,0 +1,193 @@
+import { useCallback, useMemo, useState } from 'react'
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
+import { getConnectionId } from '@/lib/connection-context'
+import { useAppStore } from '@/store'
+import {
+  checkoutRuntimeGitBranch,
+  createRuntimeGitBranch,
+  listRuntimeGitLocalBranches
+} from '@/runtime/runtime-git-client'
+import { getRepoIdFromWorktreeId } from '../../../../../../shared/worktree/id'
+import { normalizeRuntimePathForComparison } from '../../../../../../shared/cross-platform-path'
+import type { GitLocalBranchListing } from '../../../../../../shared/git-local-branches'
+import type { SourceControlWorktreeContext } from '../listing/use-worktree-context'
+import type { SourceControlStatusRefresh } from './use-status-refresh'
+import { buildBranchPickerRows, type BranchPickerRow } from '../panel/branch-picker-rows'
+import { refreshSourceControlAfterRemoteAction } from './remote-refresh'
+
+/** An older host answers `git.createBranch` with method_not_found rather than creating. */
+function isUnsupportedMethodError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error)
+  return message.includes('method_not_found') || message.includes('Unknown method')
+}
+
+/**
+ * Drives the Source Control branch picker: loads local branches on open, then
+ * switches to or creates one. Git refuses a checkout that would clobber
+ * uncommitted work, and that refusal is surfaced verbatim rather than forced —
+ * the user decides whether to commit first.
+ */
+export function useSourceControlBranchSwitch({
+  activeRepoSettings,
+  activeWorktreeId,
+  refreshActiveGitStatusAfterMutation,
+  refreshBranchCompareRef,
+  refreshGitHistoryRef,
+  worktreePath
+}: {
+  activeRepoSettings: SourceControlWorktreeContext['activeRepoSettings']
+  activeWorktreeId: string | null
+  refreshActiveGitStatusAfterMutation: SourceControlStatusRefresh['refreshActiveGitStatusAfterMutation']
+  refreshBranchCompareRef: React.RefObject<() => Promise<void>>
+  refreshGitHistoryRef: React.RefObject<() => Promise<void>>
+  worktreePath: string | null
+}) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [listing, setListing] = useState<GitLocalBranchListing | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [worktreeLabelByPath, setWorktreeLabelByPath] = useState<ReadonlyMap<string, string>>(
+    new Map()
+  )
+  const [isBusy, setIsBusy] = useState(false)
+
+  const canSwitch = activeWorktreeId !== null && worktreePath !== null
+
+  const runtimeContext = useCallback(() => {
+    if (!activeWorktreeId || !worktreePath) {
+      return null
+    }
+    return {
+      // Why: route by the repo OWNER host, matching every other source-control git call.
+      settings: activeRepoSettings,
+      worktreeId: activeWorktreeId,
+      worktreePath,
+      connectionId: getConnectionId(activeWorktreeId) ?? undefined
+    }
+  }, [activeRepoSettings, activeWorktreeId, worktreePath])
+
+  const loadBranches = useCallback(async (): Promise<void> => {
+    const context = runtimeContext()
+    if (!context) {
+      return
+    }
+    setIsLoading(true)
+    // Why: snapshot sibling worktrees alongside the listing so occupancy reads as
+    // a workspace name; reading the store during render would refresh on nothing.
+    const repoId = getRepoIdFromWorktreeId(context.worktreeId)
+    const labels = new Map<string, string>()
+    for (const worktree of useAppStore.getState().worktreesByRepo[repoId] ?? []) {
+      labels.set(normalizeRuntimePathForComparison(worktree.path), worktree.displayName)
+    }
+    setWorktreeLabelByPath(labels)
+    try {
+      setListing(await listRuntimeGitLocalBranches(context))
+    } catch {
+      // Why: an empty listing still lets the user type a name and create it.
+      setListing({ current: null, branches: [] })
+    } finally {
+      setIsLoading(false)
+    }
+  }, [runtimeContext])
+
+  const openPicker = useCallback(
+    (open: boolean): void => {
+      setIsOpen(open)
+      if (!open) {
+        return
+      }
+      setQuery('')
+      setListing(null)
+      void loadBranches()
+    },
+    [loadBranches]
+  )
+
+  const rows: BranchPickerRow[] = useMemo(
+    () => buildBranchPickerRows({ listing, query, worktreePath, worktreeLabelByPath }),
+    [listing, query, worktreePath, worktreeLabelByPath]
+  )
+
+  const run = useCallback(
+    async (branch: string, mode: 'switch' | 'create'): Promise<void> => {
+      const context = runtimeContext()
+      if (!context || isBusy) {
+        return
+      }
+      setIsBusy(true)
+      try {
+        if (mode === 'create') {
+          await createRuntimeGitBranch(context, branch)
+          toast.success(
+            translate('auto.components.right.sidebar.SourceControl.4bc4d3b0dc', 'Created {{value0}}', {
+              value0: branch
+            })
+          )
+        } else {
+          await checkoutRuntimeGitBranch(context, branch)
+          toast.success(
+            translate(
+              'auto.components.right.sidebar.SourceControl.c1e2e60a6b',
+              'Switched to {{value0}}',
+              { value0: branch }
+            )
+          )
+        }
+        setIsOpen(false)
+      } catch (error) {
+        const description =
+          mode === 'create' && isUnsupportedMethodError(error)
+            ? translate(
+                'auto.components.right.sidebar.SourceControl.ac1edbe604',
+                'This host does not support creating branches. Update Orca on the remote host.'
+              )
+            : error instanceof Error
+              ? error.message
+              : String(error)
+        toast.error(
+          mode === 'create'
+            ? translate(
+                'auto.components.right.sidebar.SourceControl.7da2448a29',
+                'Create branch failed'
+              )
+            : translate(
+                'auto.components.right.sidebar.SourceControl.f4b9a48c43',
+                'Switch branch failed'
+              ),
+          { description }
+        )
+      } finally {
+        setIsBusy(false)
+        refreshSourceControlAfterRemoteAction({
+          refreshGitStatus: refreshActiveGitStatusAfterMutation,
+          refreshBranchCompare: refreshBranchCompareRef.current,
+          refreshGitHistory: refreshGitHistoryRef.current
+        })
+      }
+    },
+    [
+      isBusy,
+      refreshActiveGitStatusAfterMutation,
+      refreshBranchCompareRef,
+      refreshGitHistoryRef,
+      runtimeContext
+    ]
+  )
+
+  return {
+    canSwitch,
+    isBusy,
+    isLoading,
+    isOpen,
+    listing,
+    onOpenChange: openPicker,
+    query,
+    rows,
+    setQuery,
+    switchToBranch: useCallback((branch: string) => void run(branch, 'switch'), [run]),
+    createBranch: useCallback((branch: string) => void run(branch, 'create'), [run])
+  }
+}
+
+export type SourceControlBranchSwitch = ReturnType<typeof useSourceControlBranchSwitch>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11811,7 +11811,20 @@
             "c7d4e2f801": "Change base ref: {{value0}}",
             "f3a1b8c204": "upstream",
             "createPrIntentEmptyGeneratedBody": "Generated review details did not include a description. Retry Create PR.",
-            "createPrIntentGenerateDetailsFailed": "Could not generate review details. Retry Create PR."
+            "createPrIntentGenerateDetailsFailed": "Could not generate review details. Retry Create PR.",
+            "4ec1304f7b": "Create branch {{value0}}",
+            "96fb1f9512": "Invalid branch name",
+            "97b0560280": "current",
+            "419ab6fb4e": "Checked out in {{value0}}",
+            "e000af1035": "Current branch: {{value0}}. Activate to switch branch.",
+            "22f3ebc156": "Search or create branch…",
+            "55704e8f60": "Loading branches…",
+            "68f9e0ee45": "No matching branches",
+            "4bc4d3b0dc": "Created {{value0}}",
+            "c1e2e60a6b": "Switched to {{value0}}",
+            "ac1edbe604": "This host does not support creating branches. Update Orca on the remote host.",
+            "7da2448a29": "Create branch failed",
+            "f4b9a48c43": "Switch branch failed"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "Could not start the selected agent.",

--- a/src/renderer/src/runtime/runtime-git-client.ts
+++ b/src/renderer/src/runtime/runtime-git-client.ts
@@ -23,6 +23,7 @@ import type { HostedReviewProvider } from '../../../shared/hosted-review'
 import type { ResolvedSourceControlAiGenerationParams } from '../../../shared/source-control-ai'
 import { getCommitMessageModelDiscoveryHostKeyForScope } from '../../../shared/commit-message-host-key'
 import type { GitHistoryOptions, GitHistoryResult } from '../../../shared/git-history'
+import type { GitLocalBranchListing } from '../../../shared/git-local-branches'
 import { REBASE_FROM_BASE_RPC_TIMEOUT_MS } from '../../../shared/git-rebase-source'
 import { getRepoIdFromWorktreeId, splitWorktreeIdForFilesystem } from '../../../shared/worktree/id'
 import { callRuntimeRpc, getActiveRuntimeTarget } from './runtime-rpc-client'
@@ -349,6 +350,66 @@ export async function abortRuntimeGitRebase(context: RuntimeGitContext): Promise
     'git.abortRebase',
     { worktree: toRuntimeWorktreeSelector(context.worktreeId) },
     { timeoutMs: 30_000 }
+  )
+}
+
+export async function listRuntimeGitLocalBranches(
+  context: RuntimeGitContext
+): Promise<GitLocalBranchListing> {
+  const target = getActiveRuntimeTarget(context.settings)
+  if (target.kind === 'local' || !context.worktreeId) {
+    return window.api.git.localBranches({
+      worktreePath: resolveLocalWorktreePath(context),
+      connectionId: context.connectionId
+    })
+  }
+  return callRuntimeRpc<GitLocalBranchListing>(
+    target,
+    'git.localBranches',
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId) },
+    { timeoutMs: 15_000 }
+  )
+}
+
+export async function checkoutRuntimeGitBranch(
+  context: RuntimeGitContext,
+  branch: string
+): Promise<void> {
+  const target = getActiveRuntimeTarget(context.settings)
+  if (target.kind === 'local' || !context.worktreeId) {
+    await window.api.git.checkout({
+      worktreePath: resolveLocalWorktreePath(context),
+      branch,
+      connectionId: context.connectionId
+    })
+    return
+  }
+  await callRuntimeRpc(
+    target,
+    'git.checkout',
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId), branch },
+    { timeoutMs: 60_000 }
+  )
+}
+
+export async function createRuntimeGitBranch(
+  context: RuntimeGitContext,
+  branch: string
+): Promise<void> {
+  const target = getActiveRuntimeTarget(context.settings)
+  if (target.kind === 'local' || !context.worktreeId) {
+    await window.api.git.createBranch({
+      worktreePath: resolveLocalWorktreePath(context),
+      branch,
+      connectionId: context.connectionId
+    })
+    return
+  }
+  await callRuntimeRpc(
+    target,
+    'git.createBranch',
+    { worktree: toRuntimeWorktreeSelector(context.worktreeId), branch },
+    { timeoutMs: 60_000 }
   )
 }
 

--- a/src/renderer/src/web/preload-api/web-git-api.ts
+++ b/src/renderer/src/web/preload-api/web-git-api.ts
@@ -2,6 +2,7 @@ import type { PreloadApi } from '../../../../preload/api-types'
 import { callAbortableRuntimeEnvironment } from '../../runtime/abortable-runtime-environment-call'
 import { toRuntimeWorktreeSelector } from '../../runtime/runtime-worktree-selector'
 import { translate } from '@/i18n/i18n'
+import { createGitBranchApi } from './web-git-branch-api'
 import { callRuntimeResult } from './web-runtime-calls'
 import { requireActiveEnvironment, updateEnvironmentFromResponse } from './web-runtime-session'
 import {
@@ -111,6 +112,7 @@ export function createGitApi(): NonNullable<Partial<PreloadApi>['git']> {
         worktree: toRuntimeWorktreeSelector(worktree.id)
       })
     },
+    ...createGitBranchApi(),
     diff: async ({ worktreePath, filePath, staged, compareAgainstHead }) => {
       const file = await resolveRuntimeFilePath(filePath, worktreePath)
       return callRuntimeResult('git.diff', {

--- a/src/renderer/src/web/preload-api/web-git-branch-api.ts
+++ b/src/renderer/src/web/preload-api/web-git-branch-api.ts
@@ -1,0 +1,32 @@
+import type { PreloadApi } from '../../../../preload/api-types'
+import { toRuntimeWorktreeSelector } from '../../runtime/runtime-worktree-selector'
+import { callRuntimeResult } from './web-runtime-calls'
+import { resolveRuntimeWorktreeByPath } from './web-runtime-worktree-catalog'
+
+type GitApi = NonNullable<Partial<PreloadApi>['git']>
+
+/** Branch listing and switching, split out to keep `web-git-api` within its line budget. */
+export function createGitBranchApi(): Pick<GitApi, 'localBranches' | 'checkout' | 'createBranch'> {
+  return {
+    localBranches: async ({ worktreePath }) => {
+      const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
+      return callRuntimeResult('git.localBranches', {
+        worktree: toRuntimeWorktreeSelector(worktree.id)
+      })
+    },
+    checkout: async ({ worktreePath, branch }) => {
+      const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
+      await callRuntimeResult('git.checkout', {
+        worktree: toRuntimeWorktreeSelector(worktree.id),
+        branch
+      })
+    },
+    createBranch: async ({ worktreePath, branch }) => {
+      const worktree = await resolveRuntimeWorktreeByPath(worktreePath)
+      await callRuntimeResult('git.createBranch', {
+        worktree: toRuntimeWorktreeSelector(worktree.id),
+        branch
+      })
+    }
+  }
+}

--- a/src/shared/git-branch-name.test.ts
+++ b/src/shared/git-branch-name.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertValidGitBranchName,
+  checkGitBranchName,
+  isValidGitBranchName
+} from './git-branch-name'
+
+describe('checkGitBranchName', () => {
+  it.each([
+    'main',
+    'feature/add-thing',
+    'release-1.2.3',
+    'user/JIRA-42_fix',
+    'a',
+    'deep/nested/branch/name'
+  ])('accepts %s', (branch) => {
+    expect(checkGitBranchName(branch)).toEqual({ ok: true })
+  })
+
+  it.each([
+    ['', 'empty'],
+    ['-rf', 'leading-dash'],
+    ['--upload-pack=evil', 'leading-dash'],
+    ['@', 'reserved'],
+    ['has space', 'invalid-characters'],
+    ['tilde~1', 'invalid-characters'],
+    ['caret^2', 'invalid-characters'],
+    ['colon:name', 'invalid-characters'],
+    ['question?', 'invalid-characters'],
+    ['star*', 'invalid-characters'],
+    ['bracket[0]', 'invalid-characters'],
+    ['back\\slash', 'invalid-characters'],
+    ['double..dot', 'invalid-characters'],
+    ['at@{brace', 'invalid-characters'],
+    ['/leading', 'invalid-path-component'],
+    ['trailing/', 'invalid-path-component'],
+    ['double//slash', 'invalid-path-component'],
+    ['trailing.', 'invalid-path-component'],
+    ['.hidden', 'invalid-path-component'],
+    ['nested/.hidden', 'invalid-path-component'],
+    ['name.lock', 'invalid-path-component'],
+    ['nested/name.lock', 'invalid-path-component']
+  ])('rejects %s as %s', (branch, reason) => {
+    expect(checkGitBranchName(branch)).toEqual({ ok: false, reason })
+  })
+
+  it('rejects control characters that would otherwise reach the git argv', () => {
+    const newline = String.fromCharCode(10)
+    const del = String.fromCharCode(127)
+    const nul = String.fromCharCode(0)
+
+    expect(isValidGitBranchName(`bad${newline}name`)).toBe(false)
+    expect(isValidGitBranchName(`bad${del}name`)).toBe(false)
+    expect(isValidGitBranchName(`bad${nul}name`)).toBe(false)
+  })
+})
+
+describe('assertValidGitBranchName', () => {
+  it('throws a stable error code for a name git would reject', () => {
+    expect(() => assertValidGitBranchName('-rf')).toThrow('invalid_branch_name')
+  })
+
+  it('passes a valid name through', () => {
+    expect(() => assertValidGitBranchName('feature/ok')).not.toThrow()
+  })
+})

--- a/src/shared/git-branch-name.ts
+++ b/src/shared/git-branch-name.ts
@@ -1,0 +1,77 @@
+/**
+ * Branch-name rules mirroring `git check-ref-format --branch`, shared by the
+ * renderer (so the picker can disable "Create" and say why before spending a
+ * round trip) and by every host entrypoint (defense in depth — the relay is
+ * reachable independently of the RPC schema).
+ */
+
+export type GitBranchNameRejection =
+  | 'empty'
+  | 'leading-dash'
+  | 'invalid-characters'
+  | 'invalid-path-component'
+  | 'reserved'
+
+export type GitBranchNameCheck = { ok: true } | { ok: false; reason: GitBranchNameRejection }
+
+/** Tokens git reserves for revision syntax. */
+const FORBIDDEN_PUNCTUATION = '~^:?*[\\'
+
+/**
+ * Why a scan and not a regex: the forbidden set is mostly control characters,
+ * and a regex literal spelling them out trips `no-control-regex`.
+ */
+function hasForbiddenCharacter(branch: string): boolean {
+  for (const character of branch) {
+    const code = character.codePointAt(0) ?? 0
+    if (code <= 0x20 || code === 0x7f || FORBIDDEN_PUNCTUATION.includes(character)) {
+      return true
+    }
+  }
+  return false
+}
+
+export function checkGitBranchName(branch: string): GitBranchNameCheck {
+  if (branch.length === 0) {
+    return { ok: false, reason: 'empty' }
+  }
+  // Why: a leading dash is the flag-injection vector, not merely an invalid ref.
+  if (branch.startsWith('-')) {
+    return { ok: false, reason: 'leading-dash' }
+  }
+  if (branch === '@') {
+    return { ok: false, reason: 'reserved' }
+  }
+  if (hasForbiddenCharacter(branch) || branch.includes('..') || branch.includes('@{')) {
+    return { ok: false, reason: 'invalid-characters' }
+  }
+  if (
+    branch.startsWith('/') ||
+    branch.endsWith('/') ||
+    branch.includes('//') ||
+    branch.endsWith('.')
+  ) {
+    return { ok: false, reason: 'invalid-path-component' }
+  }
+  for (const component of branch.split('/')) {
+    if (component.startsWith('.') || component.endsWith('.lock')) {
+      return { ok: false, reason: 'invalid-path-component' }
+    }
+  }
+  return { ok: true }
+}
+
+export function isValidGitBranchName(branch: string): boolean {
+  return checkGitBranchName(branch).ok
+}
+
+/**
+ * Throw on any name git would reject. Callers that accept a name git itself
+ * produced (an existing branch being checked out) still pay this so a corrupted
+ * or hostile ref list cannot smuggle a flag through.
+ */
+export function assertValidGitBranchName(branch: string): void {
+  if (!isValidGitBranchName(branch)) {
+    throw new Error('invalid_branch_name')
+  }
+}

--- a/src/shared/git-local-branches.test.ts
+++ b/src/shared/git-local-branches.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { LOCAL_BRANCH_LISTING_ARGV, parseLocalBranchListing } from './git-local-branches'
+
+describe('parseLocalBranchListing', () => {
+  it('reads the current branch from the HEAD marker and lists it first', () => {
+    const listing = parseLocalBranchListing(['\tmain\t', '*\tfeature\t', '\trelease\t'].join('\n'))
+
+    expect(listing.current).toBe('feature')
+    expect(listing.branches).toEqual(['feature', 'main', 'release'])
+  })
+
+  it('records the worktree holding each branch and leaves free branches unmarked', () => {
+    const listing = parseLocalBranchListing(
+      ['*\tmain\t/repos/app', '\tfeature\t/repos/app-feature', '\tidle\t'].join('\n')
+    )
+
+    expect(listing.entries).toEqual([
+      { name: 'main', worktreePath: '/repos/app' },
+      { name: 'feature', worktreePath: '/repos/app-feature' },
+      { name: 'idle' }
+    ])
+  })
+
+  it('reports no current branch when HEAD is detached', () => {
+    const listing = parseLocalBranchListing(['\tmain\t', '\tfeature\t'].join('\n'))
+
+    expect(listing.current).toBeNull()
+    expect(listing.branches).toEqual(['main', 'feature'])
+  })
+
+  it('skips blank and nameless lines rather than emitting empty branches', () => {
+    const listing = parseLocalBranchListing(['', '\t\t', '*\tmain\t', ''].join('\n'))
+
+    expect(listing.branches).toEqual(['main'])
+  })
+
+  it('handles an empty repository with no branches', () => {
+    expect(parseLocalBranchListing('')).toEqual({ current: null, branches: [], entries: [] })
+  })
+
+  it('keeps branch names containing slashes intact', () => {
+    const listing = parseLocalBranchListing('*\tfeat/nested/thing\t/repos/app')
+
+    expect(listing.branches).toEqual(['feat/nested/thing'])
+  })
+
+  it('asks git for the worktree path, which the picker needs for occupancy', () => {
+    expect(LOCAL_BRANCH_LISTING_ARGV).toContain(
+      '--format=%(HEAD)%09%(refname:short)%09%(worktreepath)'
+    )
+  })
+})

--- a/src/shared/git-local-branches.ts
+++ b/src/shared/git-local-branches.ts
@@ -1,0 +1,69 @@
+/**
+ * Local-branch listing shared by every host that can answer it: the desktop
+ * main process, the relay, and the SSH provider. Kept in one place so the argv
+ * and the parser cannot drift between them — a mismatch would show different
+ * branch sets depending on where the worktree lives.
+ */
+
+export type GitLocalBranchEntry = {
+  name: string
+  /**
+   * Worktree holding this branch, when git reports one. Git refuses to check a
+   * branch out twice, so the picker needs this to explain why a row is inert
+   * instead of letting the checkout fail.
+   */
+  worktreePath?: string
+}
+
+export type GitLocalBranchListing = {
+  current: string | null
+  /** Short names, current branch first. */
+  branches: string[]
+  /**
+   * Per-branch detail. Optional because a host older than this field still
+   * answers `git.localBranches` with `current`/`branches` alone; callers must
+   * degrade to "occupancy unknown" rather than assume the branch is free.
+   */
+  entries?: GitLocalBranchEntry[]
+}
+
+/**
+ * `for-each-ref` rather than `branch`: scriptable output with no locale-dependent
+ * decoration. `%(worktreepath)` is Git 2.23, under the 2.25 baseline, and is
+ * empty for branches no worktree has checked out.
+ */
+export const LOCAL_BRANCH_LISTING_ARGV: readonly string[] = [
+  'for-each-ref',
+  '--format=%(HEAD)%09%(refname:short)%09%(worktreepath)',
+  'refs/heads/'
+]
+
+export function parseLocalBranchListing(stdout: string): GitLocalBranchListing {
+  let current: string | null = null
+  const entries: GitLocalBranchEntry[] = []
+  for (const line of stdout.split('\n')) {
+    if (line.length === 0) {
+      continue
+    }
+    const [marker, name, worktreePath] = line.split('\t')
+    if (!name) {
+      continue
+    }
+    if (marker === '*') {
+      current = name
+    }
+    entries.push(worktreePath ? { name, worktreePath } : { name })
+  }
+  // Why: surface the checked-out branch first so the picker reads "you are here"
+  // at the top, then the rest in git's ref order.
+  entries.sort((a, b) => {
+    if (a.name === current) {
+      return -1
+    }
+    if (b.name === current) {
+      return 1
+    }
+    return 0
+  })
+  return { current, branches: entries.map((entry) => entry.name), entries }
+}

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-lines -- Why: shared type definitions for all runtime RPC methods live in one file for discoverability and import simplicity. */
+import type { GitLocalBranchListing } from './git-local-branches'
 import type {
   AgentStatusEntry,
   AgentStatusOrchestrationContext,
@@ -880,10 +881,7 @@ export type RuntimeWorktreePsSummary = {
   agents: RuntimeWorktreeAgentRow[]
 }
 
-export type RuntimeGitLocalBranches = {
-  current: string | null
-  branches: string[]
-}
+export type RuntimeGitLocalBranches = GitLocalBranchListing
 
 /** One speech model as presented to the mobile dictation-setup sheet: catalog
  *  metadata joined with live download/ready state. */


### PR DESCRIPTION
## ELI5

The Source Control panel shows which branch you are on, but the name is just text. This makes it a button: click it, search your local branches, switch to one, or type a new name and create it.

## What Changed

The switching engine already exists and ships on mobile — `git.checkout` and `git.localBranches` already reach local, SSH and relay hosts. Desktop had no path to it: the HEAD label was a static span and no IPC channel exposed either call. Branch creation existed nowhere.

**Shared, so hosts cannot drift**

- `src/shared/git-local-branches.ts` — the `for-each-ref` argv and its parser, replacing the copies `src/main/git/checkout.ts` and `src/relay/git-handler.ts` each carried. The format now also asks for `%(worktreepath)`.
- `src/shared/git-branch-name.ts` — `check-ref-format` rules, used by the renderer to explain a bad name before spending a round trip, and by every host entrypoint as defense in depth. The previous guard rejected only a leading dash, which is too weak for a user-typed name.

**Hosts** — `createAndCheckoutBranch`; `createBranch` on the provider contract, the SSH provider and the relay; a `git.createBranch` RPC method; `git:localBranches` / `git:checkout` / `git:createBranch` IPC channels; preload and web-shim entries.

**UI** — `HeadIdentity` moves to its own module and accepts a `headSlot`, which `panel-ready` fills with the picker only for a real branch. `branch-picker-rows.ts` holds the logic and is pure; `use-branch-switch.ts` drives loading and the two mutations; `branch-switcher.tsx` is a cmdk popover.

Three behaviors worth reviewing:

- **A branch checked out in another worktree is inert** and names the workspace holding it. Git refuses to check a branch out twice, and in a worktree-heavy app that refusal is the common case, not an edge one.
- **A dirty tree is never forced.** Git's "would be overwritten by checkout" propagates verbatim so the user decides whether to commit first.
- **`git.createBranch` is a new RPC method**, so a host predating it answers `method_not_found`; the picker reports that the remote host needs updating rather than surfacing a raw error.

Detached HEAD and folder workspaces keep the static label.

**Stash is deliberately excluded.** The issue also asks for it; it is a much larger separate feature with its own open PR (#11571), and bundling it would make this unreviewable.

## Why

Issue #16362 asks to switch and create branches from the Source Control blade. #12984 asks for the same capability from the project view. Today the only in-app way to reach another branch is to create a whole workspace, or to drop to a terminal.

The desktop already reconciles a branch switch made outside the UI — `worktree-git-identity-update.ts` re-derives auto-generated display names and clears branch-scoped review links, and `worktree-listing-branch-switch.ts` exists to win the race between the two refresh paths that observe one. An in-app checkout inherits all of that by calling the same refresh trio, so this needs no new reconciliation machinery.

Extracting the shared parser rather than adding a third copy follows the note in `git-handler.ts` about paths that must be kept in sync by hand.

## Linked Issue

Fixes #16362

Also addresses #12984 (same capability, requested from the project view) — worth closing or cross-linking.

## Visual Proof

**Missing — flagging rather than claiming N/A, because this is a UI change and the template requires it.**

I could not launch the app: the Electron postinstall never ran in my environment, so no `$electron` / Playwright CDP pass was possible. Screenshots of the picker (closed trigger, open list, occupied-branch row, create row) are needed before this merges, and I would rather say so than attach nothing and tick the box.

## Testing

Everything below ran on Linux (Node 24, container) against this branch.

- `pnpm typecheck` — clean, all projects.
- `pnpm lint` — every gate passes: oxlint, both code-quality audits, reliability gates, max-lines ratchet, runtime-electron ratchet, skill guides/manifest, and all three localization checks. No `max-lines` suppression added; two files that crossed their budget were split (`web-git-branch-api.ts`, `head-identity.tsx`).
- 59 new tests across 4 files, all passing:
  - `src/shared/git-local-branches.test.ts` — parser: occupancy, current-first, detached HEAD, malformed lines, empty repo.
  - `src/shared/git-branch-name.test.ts` — accept/reject table across the `check-ref-format` rules, plus control characters and flag injection.
  - `src/main/git/checkout.test.ts` — exact argv for switch and create, the `--` terminator, rejection before spawn, and git's dirty-tree refusal propagating.
  - `branch-picker-rows.test.ts` — filtering, create-row gating, occupancy labelling, Windows path comparison, and the older-host fallback.
- Full suite: 94 failed files with this branch vs **81 on a clean-tree baseline** of the same commit. I chased all 13 of the difference; **every one passes in isolation** — they are timing assertions and timeouts (`-performance`, `-complexity`, `-leak`, `parallelism`) that trip under container load. The 81 baseline failures are environmental in my setup: `node-pty`'s native module (I installed with `--ignore-scripts`), Electron tests, live-shell tests, Windows tests.

Not run:
- `pnpm build`.
- `tests/e2e/cross-version-wire/…` — needs `vX.Y.Z` release tags, which my fork has none of. It covers the terminal wire, untouched here, but it is the enforcement gate for the compatibility rules below.
- Mobile typecheck (separate workspace/lockfile). Mobile reads only `.current` / `.branches` off this type, both unchanged.
- macOS and Windows.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

<!-- Author: please complete. Left blank deliberately rather than filled in on your behalf. -->

## Review

## Agent skill upstream boundary

- [x] Not applicable — this change touches no skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- **Security** — branch names are validated at the RPC schema, the IPC handler, the relay entrypoint and the git helper. `checkout`/`checkout -b` argv ends with `--` so a name can never be read as a pathspec, and a leading dash is rejected before spawn. No new secrets, no new network surface.
- **Cross-platform** — no hardcoded separators; worktree paths are compared through `normalizeRuntimePathForComparison`, covered by a Windows-path test. `%(worktreepath)` is Git 2.23, under the documented 2.25 baseline, so no capability gate is needed; `checkout -b` is used rather than `switch -c`, which is 2.23 and still experimental at that baseline.
- **Remote SSH** — routed through the repo owner host like every other source-control call, via the existing SSH provider and relay handlers.
- **Backwards compatibility** — the `entries` field on the listing is optional per `remote-wire-compatibility.md` rule 1; an older host omitting it degrades to "occupancy unknown" and lets git's own refusal surface, rather than hiding the branch. The new RPC method fails loudly with `method_not_found` against an older host, and that is translated into a clear message.
- **Mobile** — reads only `current` / `branches`, both unchanged. The mobile picker keeps working exactly as before.
- **Performance** — the listing is fetched only when the picker opens; row building is pure and synchronous over local branches.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes, or `N/A` with reason — **see Visual Proof; genuinely missing**
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass — lint/typecheck/test pass; **build not run**
