### PR TITLE
perf(git): make local Git metadata observation event-driven (no scheduler)

### DIFF
--- a/src/main/ipc/parcel-watcher-process-entry.test.ts
+++ b/src/main/ipc/parcel-watcher-process-entry.test.ts
@@ -1,17 +1,25 @@
+import { EventEmitter } from 'node:events'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { statMock, subscribeMock, writeFileSyncMock } = vi.hoisted(() => ({
-  statMock: vi.fn(),
-  subscribeMock: vi.fn(),
-  writeFileSyncMock: vi.fn()
-}))
+const { detectShallowWatchDeliveryMock, statMock, subscribeMock, watchMock, writeFileSyncMock } =
+  vi.hoisted(() => ({
+    detectShallowWatchDeliveryMock: vi.fn(),
+    statMock: vi.fn(),
+    subscribeMock: vi.fn(),
+    watchMock: vi.fn(),
+    writeFileSyncMock: vi.fn()
+  }))
 
 vi.mock('node:fs', () => ({
   mkdtempSync: vi.fn(() => '/tmp/orca-watcher-canary-test'),
   rmSync: vi.fn(),
+  watch: watchMock,
   writeFileSync: writeFileSyncMock
 }))
 vi.mock('node:fs/promises', () => ({ stat: statMock }))
+vi.mock('./shallow-watch-delivery-probe', () => ({
+  detectShallowWatchDelivery: detectShallowWatchDeliveryMock
+}))
 vi.mock('@parcel/watcher', () => ({ subscribe: subscribeMock }))
 
 describe('parcel watcher process canary', () => {
@@ -25,6 +33,7 @@ describe('parcel watcher process canary', () => {
     vi.resetModules()
     subscribeMock.mockReset()
     statMock.mockReset()
+    watchMock.mockReset()
     writeFileSyncMock.mockReset()
     originalMessageListeners = process.listeners('message')
     originalExitListeners = process.listeners('exit')
@@ -51,6 +60,79 @@ describe('parcel watcher process canary', () => {
     process.send = originalSend
     vi.useRealTimers()
     vi.restoreAllMocks()
+  })
+
+  it('fails the shallow subscribe when the host never delivers fs.watch events', async () => {
+    // A real macOS 26.3.1 machine registers the watch and stays mute forever.
+    // Reporting failure is what lets the caller fall back to polling instead of
+    // showing indefinitely stale Git metadata.
+    detectShallowWatchDeliveryMock.mockResolvedValue(false)
+    watchMock.mockImplementation(() => {
+      const watcher = new EventEmitter() as EventEmitter & { close: () => void }
+      watcher.close = () => watcher.emit('close')
+      return watcher
+    })
+    const sendMock = vi.fn()
+    process.send = sendMock as typeof process.send
+
+    await import('./parcel-watcher-process-entry')
+    await vi.advanceTimersByTimeAsync(0)
+    process.emit('message', {
+      op: 'subscribe',
+      id: 7,
+      dir: '/repo/.git',
+      opts: { mode: 'shallow', include: ['HEAD'] }
+    })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(sendMock).toHaveBeenCalledWith(
+      expect.objectContaining({ op: 'subscribe-failed', id: 7 })
+    )
+    expect(watchMock).not.toHaveBeenCalledWith('/repo/.git', expect.anything(), expect.anything())
+  })
+
+  it('hosts shallow subscriptions without invoking the recursive native watcher', async () => {
+    detectShallowWatchDeliveryMock.mockResolvedValue(true)
+    const watcherCallbacks = new Map<
+      string,
+      (eventType: string, fileName: string | Buffer | null) => void
+    >()
+    watchMock.mockImplementation(
+      (
+        path: string,
+        _options: unknown,
+        callback: (eventType: string, fileName: string | Buffer | null) => void
+      ) => {
+        watcherCallbacks.set(path, callback)
+        const watcher = new EventEmitter() as EventEmitter & { close: () => void }
+        watcher.close = () => watcher.emit('close')
+        return watcher
+      }
+    )
+    const sendMock = vi.fn()
+    process.send = sendMock as typeof process.send
+
+    await import('./parcel-watcher-process-entry')
+    await vi.advanceTimersByTimeAsync(0)
+    process.emit('message', {
+      op: 'subscribe',
+      id: 1,
+      dir: '/repo/.git',
+      opts: { mode: 'shallow', include: ['HEAD'] }
+    })
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(subscribeMock).toHaveBeenCalledTimes(1)
+    watcherCallbacks.get('/repo/.git')?.('change', 'HEAD')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(sendMock).toHaveBeenCalledWith(
+      {
+        op: 'events',
+        id: 1,
+        events: [{ type: 'update', path: '/repo/.git/HEAD' }]
+      },
+      expect.any(Function)
+    )
   })
 
   it('does not restart while a native subscription is still crawling', async () => {

--- a/src/main/ipc/parcel-watcher-process-entry.ts
+++ b/src/main/ipc/parcel-watcher-process-entry.ts
@@ -8,6 +8,8 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type * as ParcelWatcher from '@parcel/watcher'
+import { startShallowWatcher } from './parcel-watcher-shallow-subscription'
+import { detectShallowWatchDelivery } from './shallow-watch-delivery-probe'
 import {
   createWatcherProcessEventDeliveryQueue,
   type WatcherProcessEventDeliveryQueue
@@ -23,6 +25,10 @@ function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err)
 }
 
+type WatcherSubscription = {
+  unsubscribe: () => Promise<void>
+}
+
 // Canary self-check. Why: @parcel/watcher can wedge silently — a lock-order
 // inversion between Debounce::notify (debounce mutex → watcher mutex) and
 // Watcher teardown (watcher mutex → debounce mutex in ~Watcher) deadlocks the
@@ -35,9 +41,9 @@ const CANARY_EVENT_TIMEOUT_MS = 5_000
 const CANARY_MAX_MISSES = 2
 
 async function startCanary(getStableActivityRevision: () => number | null): Promise<void> {
+  const configuredCanaryDir = process.env.ORCA_WATCHER_CANARY_DIR
   let canaryDir: string
   let lastEventAt = 0
-  const configuredCanaryDir = process.env.ORCA_WATCHER_CANARY_DIR
   try {
     canaryDir = configuredCanaryDir ?? mkdtempSync(join(tmpdir(), 'orca-watcher-canary-'))
     const watcher = await import('@parcel/watcher')
@@ -140,7 +146,7 @@ function main(): void {
   // Subscribe promises are kept (not just subscriptions) so an unsubscribe
   // that races a still-crawling subscribe awaits it instead of leaking the
   // native handle — on Windows a leaked handle keeps the worktree dir locked.
-  const subscriptions = new Map<number, Promise<ParcelWatcher.AsyncSubscription | null>>()
+  const subscriptions = new Map<number, Promise<WatcherSubscription | null>>()
   const liveSubscriptionIds = new Set<number>()
   const eventDeliveries = new Map<number, WatcherProcessEventDeliveryQueue>()
   let pendingSubscriptionCrawls = 0
@@ -172,7 +178,7 @@ function main(): void {
     dir: string,
     opts: WatcherProcessSubscribeOptions,
     delivery: WatcherProcessDeliveryOptions | undefined
-  ): Promise<ParcelWatcher.AsyncSubscription | null> => {
+  ): Promise<WatcherSubscription | null> => {
     const eventDelivery = createWatcherProcessEventDeliveryQueue(
       delivery,
       async (events) => {
@@ -194,6 +200,17 @@ function main(): void {
         beginSubscriptionCrawl()
         send({ op: 'subscribe-started', id })
         try {
+          if (opts.mode === 'shallow') {
+            // Why: registration succeeding proves nothing on a host whose
+            // notification path is dead. Fail the subscribe so the caller falls
+            // back to polling rather than going quietly stale.
+            if (!(await detectShallowWatchDelivery())) {
+              throw new Error('Shallow watcher delivery unavailable on this host')
+            }
+            return startShallowWatcher(dir, opts.include ?? [], eventDelivery.enqueue, (error) =>
+              send({ op: 'watch-error', id, message: errorMessage(error) })
+            )
+          }
           const watcher = await import('@parcel/watcher')
           return await watcher.subscribe(
             dir,

--- a/src/main/ipc/parcel-watcher-process-protocol.ts
+++ b/src/main/ipc/parcel-watcher-process-protocol.ts
@@ -8,6 +8,8 @@ export type WatcherProcessSubscribeOptions = {
   ignore?: string[]
   ignoreGlobs?: string[]
   backend?: string
+  mode?: 'recursive' | 'shallow'
+  include?: string[]
 }
 
 export type WatcherProcessDeliveryOptions = {

--- a/src/main/ipc/parcel-watcher-shallow-subscription.test.ts
+++ b/src/main/ipc/parcel-watcher-shallow-subscription.test.ts
@@ -1,0 +1,155 @@
+import { EventEmitter } from 'node:events'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { watcherState } = vi.hoisted(() => ({
+  watcherState: new Map<
+    string,
+    {
+      callback: (eventType: string, fileName: string | Buffer | null) => void
+      watcher: EventEmitter & { close: () => void }
+    }
+  >()
+}))
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual('node:fs')
+  return {
+    ...actual,
+    watch: vi.fn(
+      (
+        path: string,
+        _options: unknown,
+        callback: (eventType: string, fileName: string | Buffer | null) => void
+      ) => {
+        const watcher = new EventEmitter() as EventEmitter & { close: () => void }
+        watcher.close = () => watcher.emit('close')
+        watcherState.set(path, { callback, watcher })
+        return watcher
+      }
+    )
+  }
+})
+
+import { startShallowWatcher } from './parcel-watcher-shallow-subscription'
+
+function emit(path: string, fileName: string): void {
+  watcherState.get(path)?.callback('change', fileName)
+}
+
+describe('shallow watcher subscription', () => {
+  beforeEach(() => {
+    watcherState.clear()
+  })
+
+  it('emits only included primary files, including an existing nested directory', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-shallow-watcher-'))
+    try {
+      await mkdir(join(root, 'logs'))
+      const events: string[] = []
+      const { promise, resolve } = Promise.withResolvers<void>()
+      const subscription = startShallowWatcher(
+        root,
+        ['HEAD', 'config', 'logs/HEAD'],
+        (nextEvents) => {
+          events.push(...nextEvents.map((event) => event.path))
+          if (
+            events.includes(join(root, 'config')) &&
+            events.includes(join(root, 'logs', 'HEAD'))
+          ) {
+            resolve()
+          }
+        },
+        (error) => {
+          throw error
+        }
+      )
+
+      emit(root, 'config')
+      emit(join(root, 'logs'), 'HEAD')
+      await promise
+
+      expect(events).toContain(join(root, 'config'))
+      expect(events).toContain(join(root, 'logs', 'HEAD'))
+      expect(events).not.toContain(join(root, 'unrelated'))
+      await subscription.unsubscribe()
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not forward events after unsubscribe', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-shallow-watcher-'))
+    try {
+      const events: string[] = []
+      const subscription = startShallowWatcher(
+        root,
+        ['HEAD'],
+        (nextEvents) => events.push(...nextEvents.map((event) => event.path)),
+        (error) => {
+          throw error
+        }
+      )
+      await subscription.unsubscribe()
+      emit(root, 'HEAD')
+      const { promise, resolve } = Promise.withResolvers<void>()
+      setImmediate(resolve)
+      await promise
+      expect(events).toEqual([])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('rebinds a nested directory that is replaced, which leaves fs.watch deaf', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-shallow-watcher-'))
+    try {
+      await mkdir(join(root, 'logs'))
+      const events: string[] = []
+      const subscription = startShallowWatcher(
+        root,
+        ['HEAD', 'logs/HEAD'],
+        (nextEvents) => events.push(...nextEvents.map((event) => event.path)),
+        (error) => {
+          throw error
+        }
+      )
+      const firstNested = watcherState.get(join(root, 'logs'))?.watcher
+
+      // A 'rename' for the nested dir means the inode was swapped, so the old
+      // binding is dead and must be replaced rather than reused.
+      watcherState.get(root)?.callback('rename', 'logs')
+
+      expect(watcherState.get(join(root, 'logs'))?.watcher).not.toBe(firstNested)
+      events.length = 0
+      emit(join(root, 'logs'), 'HEAD')
+      expect(events).toContain(join(root, 'logs', 'HEAD'))
+      await subscription.unsubscribe()
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('reuses the nested binding for an ordinary change event', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-shallow-watcher-'))
+    try {
+      await mkdir(join(root, 'logs'))
+      const subscription = startShallowWatcher(
+        root,
+        ['logs/HEAD'],
+        () => {},
+        (error) => {
+          throw error
+        }
+      )
+      const firstNested = watcherState.get(join(root, 'logs'))?.watcher
+      watcherState.get(root)?.callback('change', 'logs')
+      expect(watcherState.get(join(root, 'logs'))?.watcher).toBe(firstNested)
+      await subscription.unsubscribe()
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/main/ipc/parcel-watcher-shallow-subscription.ts
+++ b/src/main/ipc/parcel-watcher-shallow-subscription.ts
@@ -1,0 +1,168 @@
+import { watch, type FSWatcher } from 'node:fs'
+import { stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { Event as ParcelWatcherEvent } from '@parcel/watcher'
+
+export type ShallowWatcherSubscription = {
+  unsubscribe: () => Promise<void>
+}
+
+// Why: fs.watch binds to an inode, not a path, and reports nothing when that
+// inode is replaced — no error, no events, permanently (verified on Linux and
+// Windows). Git replaces `.git/logs` on some maintenance paths, and a repo
+// re-clone replaces the common dir itself, so the binding is re-checked on a
+// bounded cadence. Two stats per interval is the whole steady-state cost.
+const REBIND_CHECK_INTERVAL_MS = 30_000
+
+function closeFileSystemWatcher(watcher: FSWatcher): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>()
+  watcher.once('close', resolve)
+  try {
+    watcher.close()
+  } catch {
+    resolve()
+  }
+  return promise
+}
+
+export function startShallowWatcher(
+  rootPath: string,
+  relativePaths: readonly string[],
+  onEvents: (events: ParcelWatcherEvent[]) => void,
+  onError: (error: Error) => void
+): ShallowWatcherSubscription {
+  const pathsByDirectory = new Map<string, Set<string>>()
+  for (const relativePath of relativePaths) {
+    const parts = relativePath.split(/[\\/]+/).filter(Boolean)
+    const fileName = parts.pop()
+    if (!fileName) {
+      continue
+    }
+    const parent = parts.join('/')
+    const fileNames = pathsByDirectory.get(parent) ?? new Set<string>()
+    fileNames.add(fileName)
+    pathsByDirectory.set(parent, fileNames)
+  }
+
+  const watchers = new Map<string, FSWatcher>()
+  const boundIdentities = new Map<string, string>()
+  let disposed = false
+  let reportedError = false
+
+  const reportError = (error: unknown): void => {
+    if (disposed || reportedError) {
+      return
+    }
+    reportedError = true
+    onError(error instanceof Error ? error : new Error(String(error)))
+  }
+
+  const emitUpdates = (parent: string, fileNames: Iterable<string>): void => {
+    onEvents(
+      [...fileNames].map((fileName) => ({
+        type: 'update' as const,
+        path: join(rootPath, parent, fileName)
+      }))
+    )
+  }
+
+  const watchDirectory = (parent: string, fileNames: Set<string>, rebind = false): void => {
+    const existing = watchers.get(parent)
+    if (existing) {
+      if (!rebind) {
+        return
+      }
+      watchers.delete(parent)
+      boundIdentities.delete(parent)
+      void closeFileSystemWatcher(existing)
+    }
+    const directoryPath = join(rootPath, parent)
+    try {
+      const watcher = watch(directoryPath, { persistent: false }, (eventType, fileName) => {
+        if (disposed) {
+          return
+        }
+        const name = fileName?.toString()
+        if (!name) {
+          emitUpdates(parent, fileNames)
+          return
+        }
+        if (parent === '' && pathsByDirectory.has(name)) {
+          const nestedNames = pathsByDirectory.get(name)
+          if (nestedNames) {
+            // 'rename' is a create/delete of the nested dir itself, so the
+            // existing binding (if any) is stale and must be replaced.
+            watchDirectory(name, nestedNames, eventType === 'rename')
+            emitUpdates(name, nestedNames)
+          }
+        }
+        if (fileNames.has(name)) {
+          emitUpdates(parent, [name])
+        }
+      })
+      watcher.on('error', reportError)
+      watchers.set(parent, watcher)
+    } catch (error) {
+      // Nested metadata directories may not exist until Git creates them.
+      if (parent === '') {
+        reportError(error)
+      }
+    }
+  }
+
+  const directoryIdentity = async (parent: string): Promise<string | null> => {
+    try {
+      const entry = await stat(join(rootPath, parent))
+      return entry.isDirectory() ? `${entry.dev}:${entry.ino}` : null
+    } catch {
+      return null
+    }
+  }
+
+  const refreshBinding = async (parent: string, fileNames: Set<string>): Promise<void> => {
+    const identity = await directoryIdentity(parent)
+    if (disposed || identity === null) {
+      return
+    }
+    const bound = boundIdentities.get(parent)
+    if (bound === identity) {
+      return
+    }
+    // Either the directory appeared after we started, or it was replaced while
+    // watched. Both leave the old binding deaf, so rebind and resync.
+    watchDirectory(parent, fileNames, true)
+    boundIdentities.set(parent, identity)
+    if (bound !== undefined) {
+      emitUpdates(parent, fileNames)
+    }
+  }
+
+  const rebindTimer = setInterval(() => {
+    if (disposed) {
+      return
+    }
+    for (const [parent, fileNames] of pathsByDirectory) {
+      void refreshBinding(parent, fileNames)
+    }
+  }, REBIND_CHECK_INTERVAL_MS)
+  rebindTimer.unref?.()
+
+  for (const [parent, fileNames] of pathsByDirectory) {
+    watchDirectory(parent, fileNames)
+    if (watchers.has(parent)) {
+      void directoryIdentity(parent).then((identity) => {
+        if (!disposed && identity !== null) {
+          boundIdentities.set(parent, identity)
+        }
+      })
+    }
+  }
+
+  return {
+    unsubscribe: async () => {
+      disposed = true
+      clearInterval(rebindTimer)
+      await Promise.all([...watchers.values()].map(closeFileSystemWatcher))
+    }
+  }
+}

--- a/src/main/ipc/parcel-watcher-shallow-subscription.ts
+++ b/src/main/ipc/parcel-watcher-shallow-subscription.ts
@@ -1,4 +1,4 @@
-import { watch, type FSWatcher } from 'node:fs'
+import { statSync, watch, type FSWatcher } from 'node:fs'
 import { stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import type { Event as ParcelWatcherEvent } from '@parcel/watcher'
@@ -110,6 +110,15 @@ export function startShallowWatcher(
     }
   }
 
+  const directoryIdentitySync = (parent: string): string | null => {
+    try {
+      const entry = statSync(join(rootPath, parent))
+      return entry.isDirectory() ? `${entry.dev}:${entry.ino}` : null
+    } catch {
+      return null
+    }
+  }
+
   const directoryIdentity = async (parent: string): Promise<string | null> => {
     try {
       const entry = await stat(join(rootPath, parent))
@@ -148,13 +157,14 @@ export function startShallowWatcher(
   rebindTimer.unref?.()
 
   for (const [parent, fileNames] of pathsByDirectory) {
+    // Why: read identity BEFORE binding. If the directory is replaced in the gap,
+    // the recorded identity is stale and the first sweep rebinds — the harmless
+    // direction. Reading after would pin the dead inode's watcher to the new
+    // identity, and the sweep would then never rebind it.
+    const identityBeforeBind = directoryIdentitySync(parent)
     watchDirectory(parent, fileNames)
-    if (watchers.has(parent)) {
-      void directoryIdentity(parent).then((identity) => {
-        if (!disposed && identity !== null) {
-          boundIdentities.set(parent, identity)
-        }
-      })
+    if (watchers.has(parent) && identityBeforeBind !== null) {
+      boundIdentities.set(parent, identityBeforeBind)
     }
   }
 

--- a/src/main/ipc/shallow-watch-delivery-probe.test.ts
+++ b/src/main/ipc/shallow-watch-delivery-probe.test.ts
@@ -1,0 +1,52 @@
+import type * as NodeFs from 'node:fs'
+import { describe, expect, it, vi } from 'vitest'
+
+const { watchMock } = vi.hoisted(() => ({ watchMock: vi.fn() }))
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof NodeFs>('node:fs')
+  return { ...actual, watch: watchMock }
+})
+
+import {
+  detectShallowWatchDelivery,
+  measureShallowWatchDelivery,
+  resetShallowWatchDeliveryProbeForTests
+} from './shallow-watch-delivery-probe'
+
+function stubWatcher(onWatch?: (callback: () => void) => void) {
+  return (_path: string, _options: unknown, callback: () => void) => {
+    onWatch?.(callback)
+    return { on: () => {}, close: () => {} }
+  }
+}
+
+describe('shallow watch delivery probe', () => {
+  it('reports delivery when the platform emits for the probe write', async () => {
+    watchMock.mockImplementation(stubWatcher((callback) => setTimeout(callback, 0)))
+    await expect(measureShallowWatchDelivery(1_000)).resolves.toBe(true)
+  })
+
+  it('reports no delivery when registration succeeds but nothing is emitted', async () => {
+    // The observed macOS 26.3.1 failure: fs.watch returns a watcher, stays mute,
+    // and never raises an error — indistinguishable from an idle repo.
+    watchMock.mockImplementation(stubWatcher())
+    await expect(measureShallowWatchDelivery(20)).resolves.toBe(false)
+  })
+
+  it('reports no delivery when the watcher raises instead of binding', async () => {
+    watchMock.mockImplementation(() => {
+      throw new Error('EMFILE')
+    })
+    await expect(measureShallowWatchDelivery(20)).resolves.toBe(false)
+  })
+
+  it('measures once per process', async () => {
+    resetShallowWatchDeliveryProbeForTests()
+    watchMock.mockImplementation(stubWatcher((callback) => setTimeout(callback, 0)))
+    await detectShallowWatchDelivery()
+    const calls = watchMock.mock.calls.length
+    await detectShallowWatchDelivery()
+    expect(watchMock.mock.calls.length).toBe(calls)
+  })
+})

--- a/src/main/ipc/shallow-watch-delivery-probe.ts
+++ b/src/main/ipc/shallow-watch-delivery-probe.ts
@@ -1,0 +1,52 @@
+import { watch } from 'node:fs'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// Why: fs.watch reports success and then delivers nothing on hosts where the
+// platform notification path is broken — observed on a macOS 26.3.1 machine
+// where both fs.watch and the native backend stayed silent for in-process
+// writes, with no error on either. Shallow subscriptions have no other way to
+// notice, so metadata would go stale until restart. Parcel already guards its
+// own delivery with a canary; this is the same idea for the Node path.
+const PROBE_TIMEOUT_MS = 2_000
+
+let probe: Promise<boolean> | null = null
+
+export async function measureShallowWatchDelivery(timeoutMs = PROBE_TIMEOUT_MS): Promise<boolean> {
+  let directory: string | null = null
+  try {
+    directory = await mkdtemp(join(tmpdir(), 'orca-shallow-probe-'))
+    const { promise, resolve } = Promise.withResolvers<boolean>()
+    const watcher = watch(directory, { persistent: false }, () => resolve(true))
+    watcher.on('error', () => resolve(false))
+    // Deliberately not unref'd: this one-shot must resolve even if the child
+    // has no other pending work at probe time.
+    const timer = setTimeout(() => resolve(false), timeoutMs)
+    // Two writes: some backends coalesce the creation of the first entry.
+    await writeFile(join(directory, 'probe'), '1')
+    await writeFile(join(directory, 'probe'), '2')
+    const delivered = await promise
+    clearTimeout(timer)
+    watcher.close()
+    return delivered
+  } catch {
+    return false
+  } finally {
+    if (directory) {
+      await rm(directory, { recursive: true, force: true }).catch(() => {})
+    }
+  }
+}
+
+/** Resolves false when this host accepts fs.watch registrations but never
+ *  delivers events, so callers can fall back instead of going silently stale.
+ *  Measured once per process. */
+export function detectShallowWatchDelivery(): Promise<boolean> {
+  probe ??= measureShallowWatchDelivery()
+  return probe
+}
+
+export function resetShallowWatchDeliveryProbeForTests(): void {
+  probe = null
+}

--- a/src/main/ipc/single-flight-promise.ts
+++ b/src/main/ipc/single-flight-promise.ts
@@ -1,0 +1,24 @@
+/** Collapses concurrent callers onto one run; the slot clears on settle so a
+ *  later caller starts fresh. Shared by both watcher fallbacks. */
+export function createSingleFlight(): {
+  run: (start: () => Promise<void>) => Promise<void>
+  pending: () => Promise<void> | null
+} {
+  let inFlight: Promise<void> | null = null
+  return {
+    run: (start) => {
+      if (inFlight) {
+        return inFlight
+      }
+      // Self-comparison: a run settling after a newer one started must not clear it.
+      const tracked: Promise<void> = start().finally(() => {
+        if (inFlight === tracked) {
+          inFlight = null
+        }
+      })
+      inFlight = tracked
+      return tracked
+    },
+    pending: () => inFlight
+  }
+}

--- a/src/main/ipc/worktree-base-directory-poller.test.ts
+++ b/src/main/ipc/worktree-base-directory-poller.test.ts
@@ -10,6 +10,7 @@ import {
   type WorktreeBasePollEvent,
   type WorktreePollerWindowVisibility
 } from './worktree-base-directory-poller'
+import { startGitCommonPrimaryPolling } from './worktree-git-common-primary-polling'
 import type {
   WorktreeBaseRepoWatchConfig,
   WorktreeBaseWatchTarget
@@ -401,7 +402,7 @@ describe('worktree base directory poller', () => {
       () => target.repos,
       (events) => received.push(events),
       // Force the non-darwin poll path so this test is deterministic on all CI.
-      { pollIntervalMs: POLL_MS, platform: 'linux' }
+      { pollIntervalMs: POLL_MS, platform: 'freebsd' }
     )
     cleanups.push(() => poller.unsubscribe())
 
@@ -441,7 +442,7 @@ describe('worktree base directory poller', () => {
       target,
       () => target.repos,
       (events) => received.push(events),
-      { pollIntervalMs: POLL_MS, platform: 'linux' }
+      { pollIntervalMs: POLL_MS, platform: 'freebsd' }
     )
     cleanups.push(() => poller.unsubscribe())
 
@@ -468,7 +469,7 @@ describe('worktree base directory poller', () => {
       target,
       () => target.repos,
       (events) => received.push(events),
-      { pollIntervalMs: POLL_MS, platform: 'linux' }
+      { pollIntervalMs: POLL_MS, platform: 'freebsd' }
     )
     cleanups.push(() => poller.unsubscribe())
 
@@ -493,7 +494,7 @@ describe('worktree base directory poller', () => {
       target,
       () => target.repos,
       (events) => received.push(events),
-      { pollIntervalMs: POLL_MS, platform: 'linux' }
+      { pollIntervalMs: POLL_MS, platform: 'freebsd' }
     )
     cleanups.push(() => poller.unsubscribe())
 
@@ -517,7 +518,7 @@ describe('worktree base directory poller', () => {
       target,
       () => target.repos,
       (events) => received.push(events),
-      { pollIntervalMs: POLL_MS, platform: 'linux' }
+      { pollIntervalMs: POLL_MS, platform: 'freebsd' }
     )
     cleanups.push(() => poller.unsubscribe())
 
@@ -539,7 +540,7 @@ describe('worktree base directory poller', () => {
       () => target.repos,
       (events) => received.push(events),
       // Force the non-darwin poll path so this test is deterministic on all CI.
-      { pollIntervalMs: POLL_MS, platform: 'linux' }
+      { pollIntervalMs: POLL_MS, platform: 'freebsd' }
     )
     cleanups.push(() => poller.unsubscribe())
 
@@ -571,7 +572,7 @@ describe('worktree base directory poller', () => {
       (events) => received.push(events),
       {
         pollIntervalMs: POLL_MS,
-        platform: 'linux',
+        platform: 'freebsd',
         visibility: visibility.source,
         onFullScan: () => fullScans.push(Date.now())
       }
@@ -644,28 +645,25 @@ describe('worktree base directory poller', () => {
       )
     })
 
-    it('covers primary-checkout metadata alongside the narrow stream', async () => {
+    it('covers primary-checkout metadata through its bounded fallback poll', async () => {
       const commonDir = await makeRoot()
-      await mkdir(join(commonDir, 'worktrees'))
       const received: WorktreeBasePollEvent[][] = []
-      const target = makeTarget('git-common', commonDir)
-      const poller = await startWorktreeBaseDirectoryPoller(
-        target,
-        () => target.repos,
+      const visibility = createWorktreePollerWindowVisibility(() => null)
+      const poller = await startGitCommonPrimaryPolling(
+        commonDir,
+        () => [],
         (events) => received.push(events),
-        { pollIntervalMs: POLL_MS, platform: 'darwin' }
+        POLL_MS,
+        visibility
       )
       cleanups.push(() => poller.unsubscribe())
 
-      // The narrow stream is rooted at worktrees/, so top-level HEAD writes
-      // must arrive through the companion metadata poll.
       const headFile = join(commonDir, 'HEAD')
       await writeFile(headFile, 'ref: refs/heads/main')
       await waitForEvents(received, (flat) =>
         flat.some((event) => event.type === 'create' && event.path === headFile)
       )
 
-      await new Promise((resolve) => setTimeout(resolve, 10))
       await writeFile(headFile, 'ref: refs/heads/feature')
       await waitForEvents(received, (flat) =>
         flat.some((event) => event.type === 'update' && event.path === headFile)

--- a/src/main/ipc/worktree-git-common-metadata-files.ts
+++ b/src/main/ipc/worktree-git-common-metadata-files.ts
@@ -1,0 +1,11 @@
+// Shared by the shallow watcher and every poll path so platforms cannot drift.
+// `logs/HEAD` catches head moves; `config.worktree` carries the sparse flag;
+// `config` gains branch.<name>.remote/merge on an external `git push -u`.
+export const PRIMARY_CHECKOUT_METADATA_FILES = [
+  'HEAD',
+  'packed-refs',
+  'index',
+  'config',
+  'config.worktree',
+  'logs/HEAD'
+]

--- a/src/main/ipc/worktree-git-common-narrow-watch.ts
+++ b/src/main/ipc/worktree-git-common-narrow-watch.ts
@@ -1,0 +1,274 @@
+import { stat } from 'node:fs/promises'
+import { join } from 'node:path'
+import { subscribeViaWatcherProcess } from './parcel-watcher-process'
+import { isWatcherProcessFailure } from './parcel-watcher-process-failure'
+import type { WorktreeBaseWatchTarget } from './worktree-base-directory-event-filter'
+import type {
+  WorktreeBasePollEvent,
+  WorktreeBaseSubscription,
+  WorktreePollerWindowVisibility
+} from './worktree-base-directory-poller'
+import { createGitCommonWatchReconciliation } from './worktree-git-common-watch-reconciliation'
+import { startGitCommonPolling } from './worktree-git-common-polling'
+
+// The native stream is hosted in the crash-isolated watcher child, never the
+// Electron main process: watcher.node teardown races heap-corrupt the hosting
+// process when unsubscribe overlaps in-flight callbacks (issue #8732), and
+// root deletion via `git worktree prune` makes that overlap routine here.
+
+export async function startGitCommonNarrowWatch(
+  target: WorktreeBaseWatchTarget,
+  onEvents: (events: WorktreeBasePollEvent[]) => void,
+  pollIntervalMs: number,
+  platform: NodeJS.Platform,
+  visibility: WorktreePollerWindowVisibility,
+  onFullScan?: () => void,
+  onWatchError?: (error: Error) => void
+): Promise<WorktreeBaseSubscription> {
+  const worktreesDir = join(target.path, 'worktrees')
+  const watcherOptions = platform === 'win32' ? { backend: 'windows' as const } : {}
+  let disposed = false
+  let subscription: WorktreeBaseSubscription | null = null
+  let existenceTimer: ReturnType<typeof setInterval> | null = null
+  let pollingFallbackPromise: Promise<void> | null = null
+  let subscribing = false
+  let parkedWhileHidden = false
+  let usingPollingFallback = false
+  let nativeSubscriptionGeneration = 0
+  const reconciliation = createGitCommonWatchReconciliation({
+    commonDirPath: target.path,
+    pollIntervalMs,
+    visibility,
+    canStart: () => !disposed && !usingPollingFallback && subscription !== null,
+    shouldKeep: () => !disposed && !usingPollingFallback,
+    onRootReplacement: () => {
+      nativeSubscriptionGeneration++
+      const current = subscription
+      subscription = null
+      if (current) {
+        void current.unsubscribe().catch(() => {})
+      }
+      armExistencePoll()
+    },
+    onEvents
+  })
+
+  const stopExistencePoll = (): void => {
+    if (existenceTimer) {
+      clearInterval(existenceTimer)
+      existenceTimer = null
+    }
+  }
+
+  const shouldUsePollingFallback = (error: unknown): boolean =>
+    isWatcherProcessFailure(error) &&
+    (error.code === 'supervisor_crash_fuse' || error.code === 'process_unavailable')
+
+  const ensurePollingFallback = (): Promise<void> => {
+    if (pollingFallbackPromise) {
+      return pollingFallbackPromise
+    }
+    stopExistencePoll()
+    usingPollingFallback = true
+    const pending = reconciliation
+      .unsubscribe()
+      .catch(() => {})
+      .then(() =>
+        startGitCommonPolling(target.path, onEvents, pollIntervalMs, visibility, onFullScan, false)
+      )
+      .then(async (fallback) => {
+        if (disposed || subscription) {
+          await fallback.unsubscribe()
+          return
+        }
+        subscription = fallback
+      })
+    const tracked = pending.finally(() => {
+      if (pollingFallbackPromise === tracked) {
+        pollingFallbackPromise = null
+      }
+    })
+    pollingFallbackPromise = tracked
+    return pollingFallbackPromise
+  }
+
+  const tryUpgradeToNarrowWatch = async (): Promise<void> => {
+    if (disposed || subscribing || subscription) {
+      return
+    }
+    subscribing = true
+    try {
+      const installed = await trySubscribe()
+      if (installed && !disposed) {
+        stopExistencePoll()
+        await reconciliation.ensureStarted()
+        // The dir appearing means a first linked worktree was just
+        // registered; surface it so the repo's worktree list refreshes.
+        onEvents([{ type: 'create', path: worktreesDir }])
+      }
+    } finally {
+      subscribing = false
+    }
+  }
+
+  const armExistencePoll = (): void => {
+    if (disposed || existenceTimer || subscription) {
+      return
+    }
+    if (!visibility.isWindowVisible()) {
+      parkedWhileHidden = true
+      return
+    }
+    existenceTimer = setInterval(() => {
+      if (disposed) {
+        return
+      }
+      if (!visibility.isWindowVisible()) {
+        parkedWhileHidden = true
+        stopExistencePoll()
+        return
+      }
+      void tryUpgradeToNarrowWatch()
+    }, pollIntervalMs)
+    existenceTimer.unref?.()
+  }
+
+  const unsubscribeVisibility = visibility.onWindowBecameVisible(() => {
+    if (!disposed && parkedWhileHidden) {
+      parkedWhileHidden = false
+      void tryUpgradeToNarrowWatch().finally(() => {
+        armExistencePoll()
+      })
+    }
+    reconciliation.notifyWindowBecameVisible()
+  })
+
+  const trySubscribe = async (): Promise<boolean> => {
+    try {
+      const s = await stat(worktreesDir)
+      if (!s.isDirectory()) {
+        return false
+      }
+    } catch {
+      return false
+    }
+    const generation = ++nativeSubscriptionGeneration
+    let errored = false
+    let active = true
+    // Why: parcel tears its native stream down when the watched root is
+    // deleted (e.g. `git worktree prune` removing an empty worktrees dir) —
+    // sometimes surfaced as an error, sometimes as a delete event for the
+    // root. Either way: notify, drop the dead stream, and let the existence
+    // poll re-arm when a future worktree add recreates the dir.
+    const teardown = (): void => {
+      active = false
+      errored = true
+      if (generation === nativeSubscriptionGeneration) {
+        nativeSubscriptionGeneration++
+      }
+      const current = subscription
+      subscription = null
+      if (current) {
+        void current.unsubscribe().catch(() => {})
+      }
+    }
+    const teardownAndRearm = (): void => {
+      teardown()
+      armExistencePoll()
+    }
+    try {
+      const sub = await subscribeViaWatcherProcess(
+        worktreesDir,
+        (error, events) => {
+          if (disposed || !active || generation !== nativeSubscriptionGeneration) {
+            return
+          }
+          if (error) {
+            if (onWatchError) {
+              onWatchError(error)
+            } else {
+              onEvents([{ type: 'update', path: worktreesDir }])
+            }
+            if (shouldUsePollingFallback(error)) {
+              teardown()
+              void ensurePollingFallback().catch(() => {
+                if (!disposed) {
+                  armExistencePoll()
+                }
+              })
+            } else {
+              teardownAndRearm()
+            }
+            return
+          }
+          if (events.length > 0) {
+            const rootGone = events.some(
+              (event) => event.type === 'delete' && event.path === worktreesDir
+            )
+            onEvents(events.map((event) => ({ type: event.type, path: event.path })))
+            if (rootGone) {
+              teardownAndRearm()
+            }
+          }
+        },
+        watcherOptions,
+        {
+          // Why: a watcher-child crash drops events during the automatic
+          // resubscribe gap; report a structural change so worktrees re-sync.
+          onInterruption: () => {
+            if (!disposed && active && generation === nativeSubscriptionGeneration) {
+              if (onWatchError) {
+                onWatchError(new Error('Git common watcher interrupted'))
+              } else {
+                onEvents([{ type: 'update', path: worktreesDir }])
+              }
+            }
+          }
+        }
+      )
+      if (generation !== nativeSubscriptionGeneration) {
+        void sub.unsubscribe().catch(() => {})
+        return false
+      }
+      if (disposed || errored) {
+        void sub.unsubscribe().catch(() => {})
+        await pollingFallbackPromise?.catch(() => {})
+        return !errored || subscription !== null
+      }
+      subscription = { unsubscribe: () => sub.unsubscribe() }
+      return true
+    } catch (error) {
+      if (disposed || generation !== nativeSubscriptionGeneration) {
+        return false
+      }
+      if (shouldUsePollingFallback(error)) {
+        await ensurePollingFallback()
+        return subscription !== null
+      }
+      return false
+    }
+  }
+
+  if (!(await trySubscribe())) {
+    // Why: repos commonly start without linked worktrees; retrying the narrow
+    // subscription lets macOS upgrade to native events when the directory appears.
+    armExistencePoll()
+  }
+  await reconciliation.ensureStarted()
+
+  return {
+    unsubscribe: async () => {
+      disposed = true
+      stopExistencePoll()
+      unsubscribeVisibility()
+      await pollingFallbackPromise?.catch(() => {})
+      nativeSubscriptionGeneration++
+      const current = subscription
+      subscription = null
+      await Promise.all([
+        current?.unsubscribe().catch(() => {}),
+        reconciliation.unsubscribe().catch(() => {})
+      ])
+    }
+  }
+}

--- a/src/main/ipc/worktree-git-common-narrow-watch.ts
+++ b/src/main/ipc/worktree-git-common-narrow-watch.ts
@@ -8,6 +8,7 @@ import type {
   WorktreeBaseSubscription,
   WorktreePollerWindowVisibility
 } from './worktree-base-directory-poller'
+import { createSingleFlight } from './single-flight-promise'
 import { createGitCommonWatchReconciliation } from './worktree-git-common-watch-reconciliation'
 import { startGitCommonPolling } from './worktree-git-common-polling'
 
@@ -30,7 +31,7 @@ export async function startGitCommonNarrowWatch(
   let disposed = false
   let subscription: WorktreeBaseSubscription | null = null
   let existenceTimer: ReturnType<typeof setInterval> | null = null
-  let pollingFallbackPromise: Promise<void> | null = null
+  const pollingFallback = createSingleFlight()
   let subscribing = false
   let parkedWhileHidden = false
   let usingPollingFallback = false
@@ -64,33 +65,31 @@ export async function startGitCommonNarrowWatch(
     isWatcherProcessFailure(error) &&
     (error.code === 'supervisor_crash_fuse' || error.code === 'process_unavailable')
 
-  const ensurePollingFallback = (): Promise<void> => {
-    if (pollingFallbackPromise) {
-      return pollingFallbackPromise
-    }
-    stopExistencePoll()
-    usingPollingFallback = true
-    const pending = reconciliation
-      .unsubscribe()
-      .catch(() => {})
-      .then(() =>
-        startGitCommonPolling(target.path, onEvents, pollIntervalMs, visibility, onFullScan, false)
-      )
-      .then(async (fallback) => {
-        if (disposed || subscription) {
-          await fallback.unsubscribe()
-          return
-        }
-        subscription = fallback
-      })
-    const tracked = pending.finally(() => {
-      if (pollingFallbackPromise === tracked) {
-        pollingFallbackPromise = null
-      }
+  const ensurePollingFallback = (): Promise<void> =>
+    pollingFallback.run(() => {
+      stopExistencePoll()
+      usingPollingFallback = true
+      return reconciliation
+        .unsubscribe()
+        .catch(() => {})
+        .then(() =>
+          startGitCommonPolling(
+            target.path,
+            onEvents,
+            pollIntervalMs,
+            visibility,
+            onFullScan,
+            false
+          )
+        )
+        .then(async (fallback) => {
+          if (disposed || subscription) {
+            await fallback.unsubscribe()
+            return
+          }
+          subscription = fallback
+        })
     })
-    pollingFallbackPromise = tracked
-    return pollingFallbackPromise
-  }
 
   const tryUpgradeToNarrowWatch = async (): Promise<void> => {
     if (disposed || subscribing || subscription) {
@@ -232,7 +231,7 @@ export async function startGitCommonNarrowWatch(
       }
       if (disposed || errored) {
         void sub.unsubscribe().catch(() => {})
-        await pollingFallbackPromise?.catch(() => {})
+        await pollingFallback.pending()?.catch(() => {})
         return !errored || subscription !== null
       }
       subscription = { unsubscribe: () => sub.unsubscribe() }
@@ -261,7 +260,7 @@ export async function startGitCommonNarrowWatch(
       disposed = true
       stopExistencePoll()
       unsubscribeVisibility()
-      await pollingFallbackPromise?.catch(() => {})
+      await pollingFallback.pending()?.catch(() => {})
       nativeSubscriptionGeneration++
       const current = subscription
       subscription = null

--- a/src/main/ipc/worktree-git-common-polling.ts
+++ b/src/main/ipc/worktree-git-common-polling.ts
@@ -1,5 +1,11 @@
 import { readdir } from 'node:fs/promises'
 import { join } from 'node:path'
+import { PRIMARY_CHECKOUT_METADATA_FILES } from './worktree-git-common-metadata-files'
+import {
+  diffGitCommon,
+  gitCommonDirectoryIdentity,
+  type GitCommonSnapshot
+} from './worktree-git-common-snapshot-diff'
 import type {
   WorktreeBasePollEvent,
   WorktreeBaseSubscription,
@@ -12,32 +18,10 @@ import {
   type GitCommonEntrySnapshot
 } from './worktree-git-common-entry-snapshot'
 
-// Shared with the darwin primary-metadata poll so platforms cannot drift.
-// `logs/HEAD` catches head moves; `config.worktree` carries the sparse flag;
-// `config` gains branch.<name>.remote/merge on an external `git push -u`.
-export const PRIMARY_CHECKOUT_METADATA_FILES = [
-  'HEAD',
-  'packed-refs',
-  'index',
-  'config',
-  'config.worktree',
-  'logs/HEAD'
-]
-const LINKED_WORKTREE_INDEX_FILE = 'index'
-const LINKED_WORKTREE_HEAD_LOG_FILE = join('logs', 'HEAD')
 // Why: the entry-dir signature gate can miss same-granule index rewrites on
 // coarse-mtime filesystems; a periodic ungated re-stat bounds that miss the
 // same way the base poller's backstop rescan does.
 const INDEX_BACKSTOP_TICKS = 15
-
-type GitCommonSnapshot = {
-  worktreesDirSignature: string
-  entries: Map<string, GitCommonEntrySnapshot>
-  primarySignatures: Map<string, string>
-  statusRefPaths: Set<string>
-  statusRefSignatures: Map<string, string>
-  didFullScan: boolean
-}
 
 async function snapshotStatusRefSignatures(
   paths: ReadonlySet<string>
@@ -118,6 +102,7 @@ async function snapshotGitCommon(
   // rather than the always-run worktrees-dir readdir.
   return {
     worktreesDirSignature,
+    worktreesDirIdentity: gitCommonDirectoryIdentity(worktreesDirSignature),
     entries,
     primarySignatures,
     statusRefPaths,
@@ -126,96 +111,9 @@ async function snapshotGitCommon(
   }
 }
 
-function classifySignatureDiff(
-  prevSignature: string | null | undefined,
-  nextSignature: string | null | undefined
-): 'create' | 'update' | 'delete' | null {
-  if (prevSignature == null && nextSignature == null) {
-    return null
-  }
-  if (prevSignature == null) {
-    return 'create'
-  }
-  if (nextSignature == null) {
-    return 'delete'
-  }
-  return prevSignature === nextSignature ? null : 'update'
-}
-
-function diffSignatureMaps(
-  prev: Map<string, string>,
-  next: Map<string, string>,
-  resolvePath: (name: string) => string
-): WorktreeBasePollEvent[] {
-  const events: WorktreeBasePollEvent[] = []
-  const names = new Set([...prev.keys(), ...next.keys()])
-  for (const name of names) {
-    const type = classifySignatureDiff(prev.get(name), next.get(name))
-    if (type) {
-      events.push({ type, path: resolvePath(name) })
-    }
-  }
-  return events
-}
-
-function diffGitCommon(
-  commonDirPath: string,
-  prev: GitCommonSnapshot,
-  next: GitCommonSnapshot
-): WorktreeBasePollEvent[] {
-  const events: WorktreeBasePollEvent[] = []
-  const worktreesDir = join(commonDirPath, 'worktrees')
-  const worktreesDirDiff = classifySignatureDiff(
-    prev.worktreesDirSignature,
-    next.worktreesDirSignature
-  )
-  if (worktreesDirDiff) {
-    events.push({ type: worktreesDirDiff, path: worktreesDir })
-  }
-  for (const [entryPath, entry] of next.entries) {
-    const prevEntry = prev.entries.get(entryPath)
-    if (!prevEntry) {
-      events.push({ type: 'create', path: entryPath })
-      continue
-    }
-    events.push(
-      ...diffSignatureMaps(prevEntry.structuralSignatures, entry.structuralSignatures, (name) =>
-        join(entryPath, name)
-      )
-    )
-    const indexDiff = classifySignatureDiff(prevEntry.indexSignature, entry.indexSignature)
-    if (indexDiff) {
-      events.push({ type: indexDiff, path: join(entryPath, LINKED_WORKTREE_INDEX_FILE) })
-    }
-    const headLogDiff = classifySignatureDiff(prevEntry.headLogSignature, entry.headLogSignature)
-    if (headLogDiff) {
-      events.push({ type: headLogDiff, path: join(entryPath, LINKED_WORKTREE_HEAD_LOG_FILE) })
-    }
-  }
-  for (const entryPath of prev.entries.keys()) {
-    if (!next.entries.has(entryPath)) {
-      events.push({ type: 'delete', path: entryPath })
-    }
-  }
-  events.push(
-    ...diffSignatureMaps(prev.primarySignatures, next.primarySignatures, (name) =>
-      join(commonDirPath, name)
-    )
-  )
-  for (const path of next.statusRefPaths) {
-    // A newly selected ref is a baseline change, not a filesystem event.
-    if (!prev.statusRefPaths.has(path)) {
-      continue
-    }
-    const type = classifySignatureDiff(
-      prev.statusRefSignatures.get(path),
-      next.statusRefSignatures.get(path)
-    )
-    if (type) {
-      events.push({ type, path })
-    }
-  }
-  return events
+export type GitCommonPollingOptions = {
+  /** Reconciliation backstop: never trust the per-entry gate, re-stat every tick. */
+  forceFullScanEveryTick?: boolean
 }
 
 export async function startGitCommonPolling(
@@ -225,7 +123,8 @@ export async function startGitCommonPolling(
   visibility: WorktreePollerWindowVisibility,
   onFullScan?: () => void,
   includePrimary = true,
-  getStatusRefPaths: () => readonly string[] = () => []
+  getStatusRefPaths: () => readonly string[] = () => [],
+  options: GitCommonPollingOptions = {}
 ): Promise<WorktreeBaseSubscription> {
   let disposed = false
   let ticking = false
@@ -257,7 +156,10 @@ export async function startGitCommonPolling(
     // land each visible refresh a full scan-duration late every tick).
     const startedAt = Date.now()
     tickCount++
-    const shouldForceFullScan = forceFullScan || tickCount % INDEX_BACKSTOP_TICKS === 0
+    const shouldForceFullScan =
+      options.forceFullScanEveryTick === true ||
+      forceFullScan ||
+      tickCount % INDEX_BACKSTOP_TICKS === 0
     try {
       const next = await snapshotGitCommon(
         commonDirPath,

--- a/src/main/ipc/worktree-git-common-primary-polling.ts
+++ b/src/main/ipc/worktree-git-common-primary-polling.ts
@@ -5,7 +5,7 @@ import type {
   WorktreeBaseSubscription,
   WorktreePollerWindowVisibility
 } from './worktree-base-directory-poller'
-import { PRIMARY_CHECKOUT_METADATA_FILES } from './worktree-git-common-polling'
+import { PRIMARY_CHECKOUT_METADATA_FILES } from './worktree-git-common-metadata-files'
 
 type PrimaryMetadataSnapshot = {
   signatures: Map<string, string>
@@ -14,12 +14,15 @@ type PrimaryMetadataSnapshot = {
 
 async function snapshotPrimaryCheckoutMetadata(
   commonDirPath: string,
-  getStatusRefPaths: () => readonly string[]
+  getStatusRefPaths: () => readonly string[],
+  includePrimary: boolean
 ): Promise<PrimaryMetadataSnapshot> {
   const signatures = new Map<string, string>()
   const statusRefPaths = new Set(getStatusRefPaths())
   const paths = [
-    ...PRIMARY_CHECKOUT_METADATA_FILES.map((name) => join(commonDirPath, name)),
+    ...(includePrimary
+      ? PRIMARY_CHECKOUT_METADATA_FILES.map((name) => join(commonDirPath, name))
+      : []),
     ...statusRefPaths
   ]
   await Promise.all(
@@ -78,11 +81,17 @@ export async function startGitCommonPrimaryPolling(
   onEvents: (events: WorktreeBasePollEvent[]) => void,
   pollIntervalMs: number,
   visibility: WorktreePollerWindowVisibility,
-  onFullScan?: () => void
+  onFullScan?: () => void,
+  /** false: the shallow watcher covers the primary files; poll only status refs. */
+  includePrimary = true
 ): Promise<WorktreeBaseSubscription> {
   let disposed = false
   let ticking = false
-  let snapshot = await snapshotPrimaryCheckoutMetadata(commonDirPath, getStatusRefPaths)
+  let snapshot = await snapshotPrimaryCheckoutMetadata(
+    commonDirPath,
+    getStatusRefPaths,
+    includePrimary
+  )
   let timer: ReturnType<typeof setTimeout> | null = null
   let parkedWhileHidden = false
 
@@ -100,9 +109,15 @@ export async function startGitCommonPrimaryPolling(
     }
     ticking = true
     const startedAt = Date.now()
-    onFullScan?.()
+    if (includePrimary) {
+      onFullScan?.()
+    }
     try {
-      const next = await snapshotPrimaryCheckoutMetadata(commonDirPath, getStatusRefPaths)
+      const next = await snapshotPrimaryCheckoutMetadata(
+        commonDirPath,
+        getStatusRefPaths,
+        includePrimary
+      )
       if (disposed) {
         return
       }

--- a/src/main/ipc/worktree-git-common-primary-watch.ts
+++ b/src/main/ipc/worktree-git-common-primary-watch.ts
@@ -6,6 +6,7 @@ import type {
   WorktreeBaseSubscription,
   WorktreePollerWindowVisibility
 } from './worktree-base-directory-poller'
+import { createSingleFlight } from './single-flight-promise'
 import { PRIMARY_CHECKOUT_METADATA_FILES } from './worktree-git-common-metadata-files'
 import { startGitCommonPrimaryPolling } from './worktree-git-common-primary-polling'
 
@@ -34,34 +35,25 @@ export async function startGitCommonPrimaryWatch(
   let watcher: WatcherProcessSubscription | null = null
   let statusRefPolling: WorktreeBaseSubscription | null = null
   let fallback: WorktreeBaseSubscription | null = null
-  let fallbackPromise: Promise<void> | null = null
+  const fallbackFlight = createSingleFlight()
 
-  const startFallback = (): Promise<void> => {
-    if (fallbackPromise) {
-      return fallbackPromise
-    }
-    const pending = startGitCommonPrimaryPolling(
-      commonDirPath,
-      getStatusRefPaths,
-      onEvents,
-      pollIntervalMs,
-      visibility,
-      onFullScan
-    ).then(async (nextFallback) => {
-      if (disposed || watcher || statusRefPolling) {
-        await nextFallback.unsubscribe()
-        return
-      }
-      fallback = nextFallback
-    })
-    const tracked = pending.finally(() => {
-      if (fallbackPromise === tracked) {
-        fallbackPromise = null
-      }
-    })
-    fallbackPromise = tracked
-    return fallbackPromise
-  }
+  const startFallback = (): Promise<void> =>
+    fallbackFlight.run(() =>
+      startGitCommonPrimaryPolling(
+        commonDirPath,
+        getStatusRefPaths,
+        onEvents,
+        pollIntervalMs,
+        visibility,
+        onFullScan
+      ).then(async (nextFallback) => {
+        if (disposed || watcher || statusRefPolling) {
+          await nextFallback.unsubscribe()
+          return
+        }
+        fallback = nextFallback
+      })
+    )
 
   const stopStatusRefPolling = async (): Promise<void> => {
     const current = statusRefPolling
@@ -115,7 +107,7 @@ export async function startGitCommonPrimaryWatch(
         }
       }
     )
-    if (watcher && !disposed && !fallbackPromise) {
+    if (watcher && !disposed && !fallbackFlight.pending()) {
       statusRefPolling = await startGitCommonPrimaryPolling(
         commonDirPath,
         getStatusRefPaths,
@@ -139,7 +131,7 @@ export async function startGitCommonPrimaryWatch(
         await current.unsubscribe().catch(() => {})
       }
       await stopStatusRefPolling()
-      await fallbackPromise?.catch(() => {})
+      await fallbackFlight.pending()?.catch(() => {})
       if (fallback) {
         await fallback.unsubscribe().catch(() => {})
         fallback = null

--- a/src/main/ipc/worktree-git-common-primary-watch.ts
+++ b/src/main/ipc/worktree-git-common-primary-watch.ts
@@ -15,6 +15,14 @@ const PRIMARY_WATCH_OPTIONS = {
   include: PRIMARY_CHECKOUT_METADATA_FILES
 }
 
+// Why: the shallow watcher can stop reporting without ever erroring — a lossy
+// notification path (network mount, inotify queue overflow in the shared child),
+// a dropped event batch, or a binding that went deaf between rebind sweeps. None
+// of those raise, so the error-driven fallback never fires. A bounded re-stat is
+// the only thing that turns "silently stale forever" into "stale for one tick".
+// At 15 ticks this is ~0.2 stats/s/repo against the 3/s the old poll cost.
+const PRIMARY_BACKSTOP_TICKS = 15
+
 function primaryMetadataEvents(commonDirPath: string): WorktreeBasePollEvent[] {
   return PRIMARY_CHECKOUT_METADATA_FILES.map((name) => ({
     type: 'update',
@@ -34,6 +42,7 @@ export async function startGitCommonPrimaryWatch(
   let disposed = false
   let watcher: WatcherProcessSubscription | null = null
   let statusRefPolling: WorktreeBaseSubscription | null = null
+  let backstopPolling: WorktreeBaseSubscription | null = null
   let fallback: WorktreeBaseSubscription | null = null
   const fallbackFlight = createSingleFlight()
 
@@ -47,20 +56,26 @@ export async function startGitCommonPrimaryWatch(
         visibility,
         onFullScan
       ).then(async (nextFallback) => {
-        if (disposed || watcher || statusRefPolling) {
+        // `statusRefPolling` deliberately excluded: it covers only status refs,
+        // so its presence is not evidence that primary metadata is covered.
+        if (disposed || watcher) {
           await nextFallback.unsubscribe()
           return
         }
+        void stopWatcherSidePolling()
         fallback = nextFallback
       })
     )
 
-  const stopStatusRefPolling = async (): Promise<void> => {
+  const stopWatcherSidePolling = async (): Promise<void> => {
     const current = statusRefPolling
+    const currentBackstop = backstopPolling
     statusRefPolling = null
-    if (current) {
-      await current.unsubscribe().catch(() => {})
-    }
+    backstopPolling = null
+    await Promise.all([
+      current?.unsubscribe().catch(() => {}),
+      currentBackstop?.unsubscribe().catch(() => {})
+    ])
   }
 
   const handleWatcherError = (error: Error): void => {
@@ -76,7 +91,7 @@ export async function startGitCommonPrimaryWatch(
     if (current) {
       void current.unsubscribe().catch(() => {})
     }
-    void stopStatusRefPolling()
+    void stopWatcherSidePolling()
       .then(() => startFallback())
       .catch(() => {})
   }
@@ -108,15 +123,41 @@ export async function startGitCommonPrimaryWatch(
       }
     )
     if (watcher && !disposed && !fallbackFlight.pending()) {
-      statusRefPolling = await startGitCommonPrimaryPolling(
-        commonDirPath,
-        getStatusRefPaths,
-        onEvents,
-        pollIntervalMs,
-        visibility,
-        undefined,
-        false
-      )
+      const [nextStatusRefPolling, nextBackstop] = await Promise.all([
+        startGitCommonPrimaryPolling(
+          commonDirPath,
+          getStatusRefPaths,
+          onEvents,
+          pollIntervalMs,
+          visibility,
+          undefined,
+          false
+        ),
+        startGitCommonPrimaryPolling(
+          commonDirPath,
+          () => [],
+          onEvents,
+          pollIntervalMs * PRIMARY_BACKSTOP_TICKS,
+          visibility,
+          undefined,
+          true
+        )
+      ])
+      // Why: a terminal watch error can land while the two polls above are still
+      // starting. handleWatcherError already ran its teardown against nulls, so
+      // adopting these now would strand the repo with status-ref coverage only.
+      if (disposed || !watcher) {
+        await Promise.all([
+          nextStatusRefPolling.unsubscribe().catch(() => {}),
+          nextBackstop.unsubscribe().catch(() => {})
+        ])
+        if (!disposed) {
+          await startFallback()
+        }
+      } else {
+        statusRefPolling = nextStatusRefPolling
+        backstopPolling = nextBackstop
+      }
     }
   } catch (error) {
     handleWatcherError(error instanceof Error ? error : new Error(String(error)))
@@ -130,7 +171,7 @@ export async function startGitCommonPrimaryWatch(
       if (current) {
         await current.unsubscribe().catch(() => {})
       }
-      await stopStatusRefPolling()
+      await stopWatcherSidePolling()
       await fallbackFlight.pending()?.catch(() => {})
       if (fallback) {
         await fallback.unsubscribe().catch(() => {})

--- a/src/main/ipc/worktree-git-common-primary-watch.ts
+++ b/src/main/ipc/worktree-git-common-primary-watch.ts
@@ -1,0 +1,149 @@
+import { join } from 'node:path'
+import { subscribeViaWatcherProcess } from './parcel-watcher-process'
+import type { WatcherProcessSubscription } from './parcel-watcher-process-subscription'
+import type {
+  WorktreeBasePollEvent,
+  WorktreeBaseSubscription,
+  WorktreePollerWindowVisibility
+} from './worktree-base-directory-poller'
+import { PRIMARY_CHECKOUT_METADATA_FILES } from './worktree-git-common-metadata-files'
+import { startGitCommonPrimaryPolling } from './worktree-git-common-primary-polling'
+
+const PRIMARY_WATCH_OPTIONS = {
+  mode: 'shallow' as const,
+  include: PRIMARY_CHECKOUT_METADATA_FILES
+}
+
+function primaryMetadataEvents(commonDirPath: string): WorktreeBasePollEvent[] {
+  return PRIMARY_CHECKOUT_METADATA_FILES.map((name) => ({
+    type: 'update',
+    path: join(commonDirPath, name)
+  }))
+}
+
+export async function startGitCommonPrimaryWatch(
+  commonDirPath: string,
+  getStatusRefPaths: () => readonly string[],
+  onEvents: (events: WorktreeBasePollEvent[]) => void,
+  pollIntervalMs: number,
+  visibility: WorktreePollerWindowVisibility,
+  onFullScan?: () => void,
+  onWatchError?: (error: Error) => void
+): Promise<WorktreeBaseSubscription> {
+  let disposed = false
+  let watcher: WatcherProcessSubscription | null = null
+  let statusRefPolling: WorktreeBaseSubscription | null = null
+  let fallback: WorktreeBaseSubscription | null = null
+  let fallbackPromise: Promise<void> | null = null
+
+  const startFallback = (): Promise<void> => {
+    if (fallbackPromise) {
+      return fallbackPromise
+    }
+    const pending = startGitCommonPrimaryPolling(
+      commonDirPath,
+      getStatusRefPaths,
+      onEvents,
+      pollIntervalMs,
+      visibility,
+      onFullScan
+    ).then(async (nextFallback) => {
+      if (disposed || watcher || statusRefPolling) {
+        await nextFallback.unsubscribe()
+        return
+      }
+      fallback = nextFallback
+    })
+    const tracked = pending.finally(() => {
+      if (fallbackPromise === tracked) {
+        fallbackPromise = null
+      }
+    })
+    fallbackPromise = tracked
+    return fallbackPromise
+  }
+
+  const stopStatusRefPolling = async (): Promise<void> => {
+    const current = statusRefPolling
+    statusRefPolling = null
+    if (current) {
+      await current.unsubscribe().catch(() => {})
+    }
+  }
+
+  const handleWatcherError = (error: Error): void => {
+    if (disposed) {
+      return
+    }
+    onWatchError?.(error)
+    if (!onWatchError) {
+      onEvents(primaryMetadataEvents(commonDirPath))
+    }
+    const current = watcher
+    watcher = null
+    if (current) {
+      void current.unsubscribe().catch(() => {})
+    }
+    void stopStatusRefPolling()
+      .then(() => startFallback())
+      .catch(() => {})
+  }
+
+  try {
+    watcher = await subscribeViaWatcherProcess(
+      commonDirPath,
+      (error, events) => {
+        if (error) {
+          handleWatcherError(error)
+          return
+        }
+        if (events.length > 0) {
+          onEvents(events.map((event) => ({ type: event.type, path: event.path })))
+        }
+      },
+      PRIMARY_WATCH_OPTIONS,
+      {
+        onInterruption: () => {
+          if (!disposed) {
+            const error = new Error('Git primary metadata watcher interrupted')
+            if (onWatchError) {
+              onWatchError(error)
+            } else {
+              onEvents(primaryMetadataEvents(commonDirPath))
+            }
+          }
+        }
+      }
+    )
+    if (watcher && !disposed && !fallbackPromise) {
+      statusRefPolling = await startGitCommonPrimaryPolling(
+        commonDirPath,
+        getStatusRefPaths,
+        onEvents,
+        pollIntervalMs,
+        visibility,
+        undefined,
+        false
+      )
+    }
+  } catch (error) {
+    handleWatcherError(error instanceof Error ? error : new Error(String(error)))
+  }
+
+  return {
+    unsubscribe: async () => {
+      disposed = true
+      const current = watcher
+      watcher = null
+      if (current) {
+        await current.unsubscribe().catch(() => {})
+      }
+      await stopStatusRefPolling()
+      await fallbackPromise?.catch(() => {})
+      if (fallback) {
+        await fallback.unsubscribe().catch(() => {})
+        fallback = null
+      }
+    }
+  }
+}

--- a/src/main/ipc/worktree-git-common-snapshot-diff.ts
+++ b/src/main/ipc/worktree-git-common-snapshot-diff.ts
@@ -1,0 +1,128 @@
+import { join } from 'node:path'
+import type { WorktreeBasePollEvent } from './worktree-base-directory-poller'
+import type { GitCommonEntrySnapshot } from './worktree-git-common-entry-snapshot'
+
+const LINKED_WORKTREE_INDEX_FILE = 'index'
+const LINKED_WORKTREE_HEAD_LOG_FILE = join('logs', 'HEAD')
+
+export type GitCommonSnapshot = {
+  worktreesDirSignature: string
+  worktreesDirIdentity: string | null
+  entries: Map<string, GitCommonEntrySnapshot>
+  primarySignatures: Map<string, string>
+  statusRefPaths: Set<string>
+  statusRefSignatures: Map<string, string>
+  didFullScan: boolean
+}
+
+// Why: inode identity distinguishes "worktrees/ was replaced" (prune + re-add
+// recreates the dir) from "its contents changed". The narrow watcher's stream is
+// bound to the old inode and is deaf after a swap, so it must resubscribe.
+export function gitCommonDirectoryIdentity(signature: string): string | null {
+  if (signature === 'missing') {
+    return null
+  }
+  const sizeSeparator = signature.lastIndexOf(':')
+  const inodeSeparator = signature.lastIndexOf(':', sizeSeparator - 1)
+  return inodeSeparator === -1 ? signature : signature.slice(inodeSeparator + 1, sizeSeparator)
+}
+
+function classifySignatureDiff(
+  prevSignature: string | null | undefined,
+  nextSignature: string | null | undefined
+): 'create' | 'update' | 'delete' | null {
+  if (prevSignature == null && nextSignature == null) {
+    return null
+  }
+  if (prevSignature == null) {
+    return 'create'
+  }
+  if (nextSignature == null) {
+    return 'delete'
+  }
+  return prevSignature === nextSignature ? null : 'update'
+}
+
+function diffSignatureMaps(
+  prev: Map<string, string>,
+  next: Map<string, string>,
+  resolvePath: (name: string) => string
+): WorktreeBasePollEvent[] {
+  const events: WorktreeBasePollEvent[] = []
+  const names = new Set([...prev.keys(), ...next.keys()])
+  for (const name of names) {
+    const type = classifySignatureDiff(prev.get(name), next.get(name))
+    if (type) {
+      events.push({ type, path: resolvePath(name) })
+    }
+  }
+  return events
+}
+
+export function diffGitCommon(
+  commonDirPath: string,
+  prev: GitCommonSnapshot,
+  next: GitCommonSnapshot
+): WorktreeBasePollEvent[] {
+  const events: WorktreeBasePollEvent[] = []
+  const worktreesDir = join(commonDirPath, 'worktrees')
+  const rootWasReplaced =
+    prev.worktreesDirIdentity !== null &&
+    next.worktreesDirIdentity !== null &&
+    prev.worktreesDirIdentity !== next.worktreesDirIdentity
+  if (rootWasReplaced) {
+    events.push({ type: 'delete', path: worktreesDir }, { type: 'create', path: worktreesDir })
+  } else {
+    const worktreesDirDiff = classifySignatureDiff(
+      prev.worktreesDirSignature === 'missing' ? null : prev.worktreesDirSignature,
+      next.worktreesDirSignature === 'missing' ? null : next.worktreesDirSignature
+    )
+    if (worktreesDirDiff) {
+      events.push({ type: worktreesDirDiff, path: worktreesDir })
+    }
+  }
+  for (const [entryPath, entry] of next.entries) {
+    const prevEntry = prev.entries.get(entryPath)
+    if (!prevEntry) {
+      events.push({ type: 'create', path: entryPath })
+      continue
+    }
+    events.push(
+      ...diffSignatureMaps(prevEntry.structuralSignatures, entry.structuralSignatures, (name) =>
+        join(entryPath, name)
+      )
+    )
+    const indexDiff = classifySignatureDiff(prevEntry.indexSignature, entry.indexSignature)
+    if (indexDiff) {
+      events.push({ type: indexDiff, path: join(entryPath, LINKED_WORKTREE_INDEX_FILE) })
+    }
+    const headLogDiff = classifySignatureDiff(prevEntry.headLogSignature, entry.headLogSignature)
+    if (headLogDiff) {
+      events.push({ type: headLogDiff, path: join(entryPath, LINKED_WORKTREE_HEAD_LOG_FILE) })
+    }
+  }
+  for (const entryPath of prev.entries.keys()) {
+    if (!next.entries.has(entryPath)) {
+      events.push({ type: 'delete', path: entryPath })
+    }
+  }
+  events.push(
+    ...diffSignatureMaps(prev.primarySignatures, next.primarySignatures, (name) =>
+      join(commonDirPath, name)
+    )
+  )
+  for (const path of next.statusRefPaths) {
+    // A newly selected ref is a baseline change, not a filesystem event.
+    if (!prev.statusRefPaths.has(path)) {
+      continue
+    }
+    const type = classifySignatureDiff(
+      prev.statusRefSignatures.get(path),
+      next.statusRefSignatures.get(path)
+    )
+    if (type) {
+      events.push({ type, path })
+    }
+  }
+  return events
+}

--- a/src/main/ipc/worktree-git-common-watch-reconciliation.ts
+++ b/src/main/ipc/worktree-git-common-watch-reconciliation.ts
@@ -1,0 +1,106 @@
+import { dirname, join } from 'node:path'
+import type {
+  WorktreeBasePollEvent,
+  WorktreeBaseSubscription,
+  WorktreePollerWindowVisibility
+} from './worktree-base-directory-poller'
+import { startGitCommonPolling } from './worktree-git-common-polling'
+
+// The native stream is still the fast path. A scheduled 15-tick reconciliation
+// bounds silent watcher loss at the existing 30-second backstop without joining
+// the per-repo 2-second timer fleet.
+const NARROW_WATCH_RECONCILIATION_TICKS = 15
+
+type GitCommonWatchReconciliationOptions = {
+  commonDirPath: string
+  pollIntervalMs: number
+  visibility: WorktreePollerWindowVisibility
+  canStart: () => boolean
+  shouldKeep: () => boolean
+  onRootReplacement: () => void
+  onEvents: (events: WorktreeBasePollEvent[]) => void
+}
+
+type GitCommonWatchReconciliation = {
+  ensureStarted: () => Promise<void>
+  notifyWindowBecameVisible: () => void
+  unsubscribe: () => Promise<void>
+}
+
+export function createGitCommonWatchReconciliation({
+  commonDirPath,
+  pollIntervalMs,
+  visibility,
+  canStart,
+  shouldKeep,
+  onRootReplacement,
+  onEvents
+}: GitCommonWatchReconciliationOptions): GitCommonWatchReconciliation {
+  const worktreesDir = join(commonDirPath, 'worktrees')
+  let subscription: WorktreeBaseSubscription | null = null
+  const visibilityListeners = new Set<() => void>()
+  const pollVisibility: WorktreePollerWindowVisibility = {
+    isWindowVisible: visibility.isWindowVisible,
+    onWindowBecameVisible: (listener) => {
+      visibilityListeners.add(listener)
+      return () => {
+        visibilityListeners.delete(listener)
+      }
+    }
+  }
+
+  return {
+    ensureStarted: async () => {
+      if (subscription || !canStart()) {
+        return
+      }
+      const reconciliation = await startGitCommonPolling(
+        commonDirPath,
+        (events) => {
+          const rootWasReplaced =
+            events.some((event) => event.type === 'delete' && event.path === worktreesDir) &&
+            events.some((event) => event.type === 'create' && event.path === worktreesDir)
+          const coarseRootReplacement = events.some(
+            (event) =>
+              event.type === 'create' &&
+              event.path !== worktreesDir &&
+              dirname(event.path) === worktreesDir
+          )
+          if (rootWasReplaced || coarseRootReplacement) {
+            onRootReplacement()
+          }
+          onEvents(
+            coarseRootReplacement
+              ? events.map((event) =>
+                  event.type === 'update' && event.path === worktreesDir
+                    ? { ...event, type: 'create' }
+                    : event
+                )
+              : events
+          )
+        },
+        pollIntervalMs * NARROW_WATCH_RECONCILIATION_TICKS,
+        pollVisibility,
+        undefined,
+        false,
+        () => [],
+        { forceFullScanEveryTick: true }
+      )
+      if (!shouldKeep()) {
+        await reconciliation.unsubscribe()
+      } else {
+        subscription = reconciliation
+      }
+    },
+    notifyWindowBecameVisible: () => {
+      for (const listener of visibilityListeners) {
+        listener()
+      }
+    },
+    unsubscribe: async () => {
+      const current = subscription
+      subscription = null
+      await current?.unsubscribe()
+    }
+  }
+}

--- a/src/main/ipc/worktree-git-common-watch-reconciliation.ts
+++ b/src/main/ipc/worktree-git-common-watch-reconciliation.ts
@@ -60,12 +60,22 @@ export function createGitCommonWatchReconciliation({
           const rootWasReplaced =
             events.some((event) => event.type === 'delete' && event.path === worktreesDir) &&
             events.some((event) => event.type === 'create' && event.path === worktreesDir)
-          const coarseRootReplacement = events.some(
-            (event) =>
-              event.type === 'create' &&
-              event.path !== worktreesDir &&
-              dirname(event.path) === worktreesDir
+          // Why: this backstop lags the native stream by up to 15 ticks, so it
+          // routinely reports entry creates the stream already delivered. Only
+          // treat them as a replacement when the root itself was also recreated
+          // — otherwise every ordinary `git worktree add` would tear down a
+          // healthy stream and open a deaf window while it resubscribes.
+          const rootRecreated = events.some(
+            (event) => event.type === 'create' && event.path === worktreesDir
           )
+          const coarseRootReplacement =
+            rootRecreated &&
+            events.some(
+              (event) =>
+                event.type === 'create' &&
+                event.path !== worktreesDir &&
+                dirname(event.path) === worktreesDir
+            )
           if (rootWasReplaced || coarseRootReplacement) {
             onRootReplacement()
           }

--- a/src/main/ipc/worktree-git-common-watch.test.ts
+++ b/src/main/ipc/worktree-git-common-watch.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { appendFile, mkdtemp, mkdir, realpath, rm, writeFile } from 'node:fs/promises'
+import { appendFile, mkdtemp, mkdir, realpath, rm, stat, writeFile } from 'node:fs/promises'
 import type * as NodeFsPromises from 'node:fs/promises'
 import { performance as nodePerformance } from 'node:perf_hooks'
 import { tmpdir } from 'node:os'
@@ -52,15 +52,22 @@ async function replaceWorktreesRoot(
   worktreesDir: string,
   retainedEntry: string
 ): Promise<void> {
+  const previousInode = (await stat(worktreesDir)).ino
   await rm(worktreesDir, { recursive: true })
-  // Linux reuses just-deleted directory inodes. Park each freed inode in a
-  // sibling that is HELD for the rest of the test — releasing it would return it
-  // to the free list, so a later replacement could land back on it and look
-  // unchanged to reconciliation. The dirs are siblings of `worktrees`, which no
-  // poll or watch path enumerates.
-  const inodeReservation = join(commonDir, `worktrees-replacement-inode-${++inodeReservationCount}`)
-  await mkdir(inodeReservation)
-  await mkdir(retainedEntry, { recursive: true })
+  // Linux reuses freed directory inodes, and removing the tree frees several at
+  // once, so the recreated root can land back on its own old inode and look
+  // unchanged to reconciliation. Park inodes in HELD siblings until the root
+  // genuinely differs — verifying beats guessing how many to reserve. The
+  // siblings live next to `worktrees`, which no poll or watch path enumerates.
+  for (let attempt = 0; attempt < 16; attempt++) {
+    await mkdir(retainedEntry, { recursive: true })
+    if ((await stat(worktreesDir)).ino !== previousInode) {
+      return
+    }
+    await rm(worktreesDir, { recursive: true })
+    await mkdir(join(commonDir, `worktrees-inode-hold-${++inodeReservationCount}`))
+  }
+  throw new Error('could not obtain a fresh inode for the replaced worktrees root')
 }
 
 function createVisibilityHarness(): {
@@ -233,7 +240,7 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
     })
   })
 
-  it('leaves primary metadata stats to the shallow child on the healthy path', async () => {
+  it('keeps primary metadata off the per-tick path but re-stats it on the backstop', async () => {
     installSubscribeMock()
     const commonDir = await makeCommonDir(true)
     const headPath = join(commonDir, 'HEAD')
@@ -242,14 +249,37 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
       writeFile(headPath, 'ref: refs/heads/main'),
       writeFile(configPath, '[core]\n')
     ])
-    statCalls.length = 0
 
     const received: WorktreeBasePollEvent[][] = []
     await startWatch(commonDir, received)
-
-    expect(statCalls).not.toContain(headPath)
-    expect(statCalls).not.toContain(configPath)
     expect(primarySubscription().dir).toBe(commonDir)
+
+    // The shallow child owns the fast path: ordinary ticks must not re-stat these.
+    statCalls.length = 0
+    await vi
+      .waitFor(
+        () => {
+          expect(statCalls.length).toBeGreaterThan(0)
+        },
+        { timeout: 2_000 }
+      )
+      .catch(() => {})
+    const duringOrdinaryTicks = statCalls.filter(
+      (path) => path === headPath || path === configPath
+    ).length
+
+    // ...but a bounded backstop must still re-stat them, or a watcher that goes
+    // silently lossy would leave primary metadata stale forever.
+    statCalls.length = 0
+    await vi.waitFor(
+      () => {
+        expect(statCalls).toContain(headPath)
+        expect(statCalls).toContain(configPath)
+      },
+      { timeout: POLL_MS * RECONCILIATION_TICKS * 6 }
+    )
+    const backstopSamples = statCalls.filter((path) => path === headPath).length
+    expect(duringOrdinaryTicks).toBeLessThan(backstopSamples * RECONCILIATION_TICKS)
   })
 
   it('polls only the accepted upstream ref and rebinds without synthetic events', async () => {
@@ -376,9 +406,12 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
       ),
       []
     )
+    // Narrow fallback + selected-ref polling + primary backstop, with the narrow
+    // existence poll retired. Waiting on the exact count is what guarantees the
+    // fallback has baselined before the entry below is created.
     await vi.waitFor(() => {
       expect(narrowSubscription().unsubscribe).toHaveBeenCalledOnce()
-      expect(visibility.listenerCount()).toBe(3)
+      expect(visibility.listenerCount()).toBe(4)
     })
 
     const entryPath = join(worktreesDir, 'fallback-entry')
@@ -547,8 +580,9 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
       visibility.source
     )
 
-    // Narrow existence + selected-ref polling each park on window visibility.
-    expect(visibility.listenerCount()).toBe(2)
+    // Narrow existence, selected-ref polling, and the primary backstop each park
+    // on window visibility.
+    expect(visibility.listenerCount()).toBe(3)
     await watch.unsubscribe()
     expect(visibility.listenerCount()).toBe(0)
   })

--- a/src/main/ipc/worktree-git-common-watch.test.ts
+++ b/src/main/ipc/worktree-git-common-watch.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { appendFile, mkdtemp, mkdir, realpath, rm, writeFile } from 'node:fs/promises'
 import type * as NodeFsPromises from 'node:fs/promises'
-import { chmodSync } from 'node:fs'
+import { performance as nodePerformance } from 'node:perf_hooks'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { subscribeViaWatcherProcess } from './parcel-watcher-process'
@@ -20,7 +20,6 @@ import { startGitCommonWatch } from './worktree-git-common-watch'
 vi.mock('./parcel-watcher-process', () => ({
   subscribeViaWatcherProcess: vi.fn()
 }))
-
 // Records every stat target so a test can assert which paths a parked poll stopped touching.
 const { statCalls } = vi.hoisted(() => ({ statCalls: [] as string[] }))
 
@@ -36,10 +35,28 @@ vi.mock('node:fs/promises', async (importOriginal) => {
 })
 
 const POLL_MS = 25
-
+// Reconciliation runs every 15 poll ticks. Fake timers keep native re-arm tests
+// independent of host load while preserving the production interval.
+const RECONCILIATION_TICKS = 15
+// Advance one extra reconciliation window so the fake performance clock crosses the
+// 15-tick boundary even when timer and filesystem-promise scheduling differ by a tick.
 const alwaysVisible: WorktreePollerWindowVisibility = {
   isWindowVisible: () => true,
   onWindowBecameVisible: () => () => {}
+}
+
+async function replaceWorktreesRoot(
+  commonDir: string,
+  worktreesDir: string,
+  retainedEntry: string
+): Promise<void> {
+  await rm(worktreesDir, { recursive: true })
+  // Linux can reuse a just-deleted directory inode. Reserve that inode with a
+  // sibling before recreating the watched root so reconciliation sees a replacement.
+  const inodeReservation = join(commonDir, 'worktrees-replacement-inode')
+  await mkdir(inodeReservation)
+  await mkdir(retainedEntry, { recursive: true })
+  await rm(inodeReservation, { recursive: true, force: true })
 }
 
 function createVisibilityHarness(): {
@@ -78,10 +95,10 @@ type ChildSubscription = {
   dir: string
   callback: WatcherProcessCallback
   hooks: WatcherProcessHooks
-  unsubscribe: ReturnType<typeof vi.fn>
+  unsubscribe: ReturnType<typeof vi.fn<() => Promise<void>>>
 }
 
-describe('worktree git-common narrow watch (darwin)', () => {
+describe('worktree git-common narrow watch (local native platforms)', () => {
   const cleanups: (() => Promise<void>)[] = []
   const subscribeMock = vi.mocked(subscribeViaWatcherProcess)
   let childSubscriptions: ChildSubscription[] = []
@@ -99,6 +116,26 @@ describe('worktree git-common narrow watch (darwin)', () => {
       childSubscriptions.push({ dir, callback, hooks, unsubscribe })
       return { unsubscribe }
     })
+  }
+
+  function narrowSubscriptions(): ChildSubscription[] {
+    return childSubscriptions.filter((subscription) => subscription.dir.endsWith('worktrees'))
+  }
+
+  function narrowSubscription(): ChildSubscription {
+    const subscription = narrowSubscriptions()[0]
+    if (!subscription) {
+      throw new Error('narrow watcher subscription not installed')
+    }
+    return subscription
+  }
+
+  function primarySubscription(): ChildSubscription {
+    const subscription = childSubscriptions.find((item) => !item.dir.endsWith('worktrees'))
+    if (!subscription) {
+      throw new Error('primary watcher subscription not installed')
+    }
+    return subscription
   }
 
   async function makeCommonDir(withWorktrees: boolean): Promise<string> {
@@ -124,13 +161,14 @@ describe('worktree git-common narrow watch (darwin)', () => {
     commonDir: string,
     received: WorktreeBasePollEvent[][],
     getStatusRefPaths: () => readonly string[] = () => [],
-    onWatchError?: (error: Error) => void
+    onWatchError?: (error: Error) => void,
+    platform: NodeJS.Platform = 'darwin'
   ): Promise<void> {
     const watch = await startGitCommonWatch(
       makeTarget(commonDir),
       (events) => received.push(events),
       POLL_MS,
-      'darwin',
+      platform,
       alwaysVisible,
       undefined,
       getStatusRefPaths,
@@ -145,20 +183,38 @@ describe('worktree git-common narrow watch (darwin)', () => {
     const received: WorktreeBasePollEvent[][] = []
     await startWatch(commonDir, received)
 
-    expect(subscribeMock).toHaveBeenCalledTimes(1)
-    const [dir, , opts] = subscribeMock.mock.calls[0]
-    expect(dir).toBe(join(commonDir, 'worktrees'))
-    expect(opts).toEqual({})
+    expect(subscribeMock).toHaveBeenCalledTimes(2)
+    const narrowCall = subscribeMock.mock.calls.find(
+      ([dir]) => dir === join(commonDir, 'worktrees')
+    )
+    expect(narrowCall?.[0]).toBe(join(commonDir, 'worktrees'))
+    expect(narrowCall?.[2]).toEqual({})
 
     const entryPath = join(commonDir, 'worktrees', 'wt-a')
-    childSubscriptions[0].callback(null, [{ type: 'create', path: entryPath }])
+    narrowSubscription().callback(null, [{ type: 'create', path: entryPath }])
     expect(received.flat()).toContainEqual({ type: 'create', path: entryPath })
   })
 
-  it('detects a common config write via the primary-metadata poll', async () => {
+  it.each(['linux', 'win32'] as const)(
+    'uses the crash-isolated narrow stream on %s',
+    async (platform) => {
+      installSubscribeMock()
+      const commonDir = await makeCommonDir(true)
+      const received: WorktreeBasePollEvent[][] = []
+      await startWatch(commonDir, received, undefined, undefined, platform)
+
+      expect(subscribeMock).toHaveBeenCalledTimes(2)
+      const narrowCall = subscribeMock.mock.calls.find(([dir]) => dir.endsWith('worktrees'))
+      expect(narrowCall?.[2]).toEqual(platform === 'win32' ? { backend: 'windows' } : {})
+      const entryPath = join(commonDir, 'worktrees', `${platform}-entry`)
+      narrowSubscription().callback(null, [{ type: 'create', path: entryPath }])
+      expect(received.flat()).toContainEqual({ type: 'create', path: entryPath })
+    }
+  )
+
+  it('detects a common config write via the shallow primary-metadata watcher', async () => {
     // Why: an external `git push -u` rewrites only the common config (plus
-    // remote-tracking refs) — outside the narrow worktrees/ stream, so the
-    // primary-metadata poll must carry it.
+    // remote-tracking refs) — outside the narrow worktrees/ stream.
     installSubscribeMock()
     const commonDir = await makeCommonDir(true)
     const configPath = join(commonDir, 'config')
@@ -167,9 +223,29 @@ describe('worktree git-common narrow watch (darwin)', () => {
     await startWatch(commonDir, received)
 
     await appendFile(configPath, '[branch "main"]\n\tremote = origin\n')
+    primarySubscription().callback(null, [{ type: 'update', path: configPath }])
     await vi.waitFor(() => {
       expect(received.flat()).toContainEqual({ type: 'update', path: configPath })
     })
+  })
+
+  it('leaves primary metadata stats to the shallow child on the healthy path', async () => {
+    installSubscribeMock()
+    const commonDir = await makeCommonDir(true)
+    const headPath = join(commonDir, 'HEAD')
+    const configPath = join(commonDir, 'config')
+    await Promise.all([
+      writeFile(headPath, 'ref: refs/heads/main'),
+      writeFile(configPath, '[core]\n')
+    ])
+    statCalls.length = 0
+
+    const received: WorktreeBasePollEvent[][] = []
+    await startWatch(commonDir, received)
+
+    expect(statCalls).not.toContain(headPath)
+    expect(statCalls).not.toContain(configPath)
+    expect(primarySubscription().dir).toBe(commonDir)
   })
 
   it('polls only the accepted upstream ref and rebinds without synthetic events', async () => {
@@ -215,16 +291,16 @@ describe('worktree git-common narrow watch (darwin)', () => {
     await startWatch(commonDir, received)
 
     await rm(worktreesDir, { recursive: true, force: true })
-    childSubscriptions[0].callback(null, [{ type: 'delete', path: worktreesDir }])
+    narrowSubscription().callback(null, [{ type: 'delete', path: worktreesDir }])
     await vi.waitFor(() => {
-      expect(childSubscriptions[0].unsubscribe).toHaveBeenCalledTimes(1)
+      expect(narrowSubscription().unsubscribe).toHaveBeenCalledTimes(1)
     })
     expect(received.flat()).toContainEqual({ type: 'delete', path: worktreesDir })
 
     // The existence poll re-subscribes once a new first worktree recreates it.
     await mkdir(worktreesDir)
     await vi.waitFor(() => {
-      expect(subscribeMock).toHaveBeenCalledTimes(2)
+      expect(subscribeMock).toHaveBeenCalledTimes(3)
     })
     expect(received.flat()).toContainEqual({ type: 'create', path: worktreesDir })
   })
@@ -236,28 +312,28 @@ describe('worktree git-common narrow watch (darwin)', () => {
     const received: WorktreeBasePollEvent[][] = []
     await startWatch(commonDir, received)
 
-    childSubscriptions[0].callback(new Error('watcher child reported failure'), [])
+    narrowSubscription().callback(new Error('watcher child reported failure'), [])
     await vi.waitFor(() => {
-      expect(childSubscriptions[0].unsubscribe).toHaveBeenCalledTimes(1)
+      expect(narrowSubscription().unsubscribe).toHaveBeenCalledTimes(1)
     })
     // The error is surfaced as a structural change so worktrees re-sync.
     expect(received.flat()).toContainEqual({ type: 'update', path: worktreesDir })
 
     // The dir still exists, so the existence poll re-subscribes.
     await vi.waitFor(() => {
-      expect(subscribeMock).toHaveBeenCalledTimes(2)
+      expect(subscribeMock).toHaveBeenCalledTimes(3)
     })
 
     const receivedAfterRearm = received.length
-    childSubscriptions[0].callback(new Error('late error from replaced watcher'), [])
-    childSubscriptions[0].callback(null, [
+    narrowSubscription().callback(new Error('late error from replaced watcher'), [])
+    narrowSubscription().callback(null, [
       { type: 'create', path: join(worktreesDir, 'late-old-event') }
     ])
-    childSubscriptions[0].hooks.onInterruption?.()
+    narrowSubscription().hooks.onInterruption?.()
 
     // A replaced watch cannot tear down its successor or report stale events.
     expect(received).toHaveLength(receivedAfterRearm)
-    expect(childSubscriptions[1].unsubscribe).not.toHaveBeenCalled()
+    expect(narrowSubscriptions()[1].unsubscribe).not.toHaveBeenCalled()
   })
 
   it('routes watcher failures through the unknown-metadata callback', async () => {
@@ -268,7 +344,7 @@ describe('worktree git-common narrow watch (darwin)', () => {
     await startWatch(commonDir, received, () => [], onWatchError)
 
     const error = new Error('watcher child reported failure')
-    childSubscriptions[0].callback(error, [])
+    narrowSubscription().callback(error, [])
 
     expect(onWatchError).toHaveBeenCalledWith(error)
     expect(received).toEqual([])
@@ -288,7 +364,7 @@ describe('worktree git-common narrow watch (darwin)', () => {
       visibility.source
     )
 
-    childSubscriptions[0].callback(
+    narrowSubscription().callback(
       new WatcherProcessFailure(
         'watcher process crashed repeatedly',
         'supervisor',
@@ -297,7 +373,7 @@ describe('worktree git-common narrow watch (darwin)', () => {
       []
     )
     await vi.waitFor(() => {
-      expect(childSubscriptions[0].unsubscribe).toHaveBeenCalledOnce()
+      expect(narrowSubscription().unsubscribe).toHaveBeenCalledOnce()
       expect(visibility.listenerCount()).toBe(3)
     })
 
@@ -310,7 +386,7 @@ describe('worktree git-common narrow watch (darwin)', () => {
     await vi.waitFor(() => {
       expect(received.flat()).toContainEqual({ type: 'delete', path: entryPath })
     })
-    expect(subscribeMock).toHaveBeenCalledOnce()
+    expect(subscribeMock).toHaveBeenCalledTimes(2)
     await watch.unsubscribe()
     expect(visibility.listenerCount()).toBe(0)
   })
@@ -337,7 +413,7 @@ describe('worktree git-common narrow watch (darwin)', () => {
       expect(received.flat()).toContainEqual({ type: 'create', path: entryPath })
     })
     await new Promise((resolve) => setTimeout(resolve, POLL_MS * 2))
-    expect(subscribeMock).toHaveBeenCalledOnce()
+    expect(subscribeMock).toHaveBeenCalledTimes(2)
 
     await watch.unsubscribe()
     expect(visibility.listenerCount()).toBe(0)
@@ -350,10 +426,10 @@ describe('worktree git-common narrow watch (darwin)', () => {
     const received: WorktreeBasePollEvent[][] = []
     await startWatch(commonDir, received)
 
-    childSubscriptions[0].hooks.onInterruption?.()
+    narrowSubscription().hooks.onInterruption?.()
     expect(received.flat()).toContainEqual({ type: 'update', path: worktreesDir })
     // The supervisor resubscribed the same record; no teardown should happen.
-    expect(childSubscriptions[0].unsubscribe).not.toHaveBeenCalled()
+    expect(narrowSubscription().unsubscribe).not.toHaveBeenCalled()
   })
 
   it('arms via existence polling when the worktrees dir appears later', async () => {
@@ -361,7 +437,7 @@ describe('worktree git-common narrow watch (darwin)', () => {
     const commonDir = await makeCommonDir(false)
     const received: WorktreeBasePollEvent[][] = []
     await startWatch(commonDir, received)
-    expect(subscribeMock).not.toHaveBeenCalled()
+    expect(subscribeMock).toHaveBeenCalledTimes(1)
 
     await mkdir(join(commonDir, 'worktrees'))
     await vi.waitFor(() => {
@@ -399,7 +475,7 @@ describe('worktree git-common narrow watch (darwin)', () => {
     await new Promise((resolve) => setTimeout(resolve, POLL_MS * 4))
 
     expect(statCalls.filter((path) => path === worktreesDir)).toHaveLength(0)
-    expect(subscribeMock).not.toHaveBeenCalled()
+    expect(subscribeMock).toHaveBeenCalledTimes(1)
     expect(received.flat()).toHaveLength(0)
   })
 
@@ -410,13 +486,13 @@ describe('worktree git-common narrow watch (darwin)', () => {
 
     await mkdir(worktreesDir)
     await new Promise((resolve) => setTimeout(resolve, POLL_MS * 4))
-    expect(subscribeMock).not.toHaveBeenCalled()
+    expect(subscribeMock).toHaveBeenCalledTimes(1)
 
     visibility.show()
     // Promptly: the re-check stats on show, not a poll interval later.
     expect(statCalls.filter((path) => path === worktreesDir)).toHaveLength(1)
     await vi.waitFor(() => {
-      expect(subscribeMock).toHaveBeenCalledTimes(1)
+      expect(subscribeMock).toHaveBeenCalledTimes(2)
     })
     expect(received.flat()).toContainEqual({ type: 'create', path: worktreesDir })
   })
@@ -450,7 +526,7 @@ describe('worktree git-common narrow watch (darwin)', () => {
 
     await mkdir(worktreesDir)
     await vi.waitFor(() => {
-      expect(subscribeMock).toHaveBeenCalledTimes(1)
+      expect(subscribeMock).toHaveBeenCalledTimes(2)
     })
     expect(received.flat()).toContainEqual({ type: 'create', path: worktreesDir })
   })
@@ -467,7 +543,7 @@ describe('worktree git-common narrow watch (darwin)', () => {
       visibility.source
     )
 
-    // Narrow watch + primary-metadata poll each park on window visibility.
+    // Narrow existence + selected-ref polling each park on window visibility.
     expect(visibility.listenerCount()).toBe(2)
     await watch.unsubscribe()
     expect(visibility.listenerCount()).toBe(0)
@@ -494,19 +570,117 @@ describe('worktree git-common narrow watch (darwin)', () => {
     visibility.hide()
     await new Promise((resolve) => setTimeout(resolve, POLL_MS * 2))
     await writeFile(headFile, 'ref: refs/heads/feature')
-    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 2))
+    primarySubscription().callback(null, [{ type: 'update', path: headFile }])
 
     expect(fullScans).toHaveLength(0)
     const entryPath = join(commonDir, 'worktrees', 'native-while-hidden')
-    childSubscriptions[0].callback(null, [{ type: 'create', path: entryPath }])
+    narrowSubscription().callback(null, [{ type: 'create', path: entryPath }])
     expect(received.flat()).toContainEqual({ type: 'create', path: entryPath })
-    expect(childSubscriptions[0].unsubscribe).not.toHaveBeenCalled()
+    expect(narrowSubscription().unsubscribe).not.toHaveBeenCalled()
 
     visibility.show()
-    expect(fullScans).toHaveLength(1)
-    await vi.waitFor(() => {
-      expect(received.flat()).toContainEqual({ type: 'update', path: headFile })
-    })
+    expect(fullScans).toHaveLength(0)
+  })
+
+  it('re-arms the native stream when the root is replaced with the same child names', async () => {
+    vi.useFakeTimers()
+    const restorePerformanceNow = vi
+      .spyOn(nodePerformance, 'now')
+      .mockImplementation(() => Date.now())
+    try {
+      installSubscribeMock()
+      const commonDir = await makeCommonDir(true)
+      const worktreesDir = join(commonDir, 'worktrees')
+      const retainedEntry = join(worktreesDir, 'same-child')
+      await mkdir(retainedEntry)
+      const received: WorktreeBasePollEvent[][] = []
+      await startWatch(commonDir, received)
+      const staleSubscription = narrowSubscription()
+
+      await replaceWorktreesRoot(commonDir, worktreesDir, retainedEntry)
+      await vi.advanceTimersByTimeAsync(POLL_MS * RECONCILIATION_TICKS * 4)
+      expect(subscribeMock).toHaveBeenCalledTimes(3)
+      expect(staleSubscription.unsubscribe).toHaveBeenCalledOnce()
+
+      const beforeStaleEvent = received.length
+      staleSubscription.callback(null, [{ type: 'update', path: retainedEntry }])
+      expect(received).toHaveLength(beforeStaleEvent)
+
+      const immediateEntry = join(worktreesDir, 'after-rearm')
+      narrowSubscriptions()[1].callback(null, [{ type: 'create', path: immediateEntry }])
+      expect(received.flat()).toContainEqual({ type: 'create', path: immediateEntry })
+    } finally {
+      await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
+      restorePerformanceNow.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('disposes an in-flight stale resubscribe and fences its interruption hook', async () => {
+    vi.useFakeTimers()
+    const restorePerformanceNow = vi
+      .spyOn(nodePerformance, 'now')
+      .mockImplementation(() => Date.now())
+    try {
+      const deferredSubscribe = Promise.withResolvers<{
+        unsubscribe: () => Promise<void>
+      }>()
+      subscribeMock.mockImplementation(async (dir, callback, _opts, hooks = {}) => {
+        const unsubscribe = vi.fn(async () => {})
+        childSubscriptions.push({ dir, callback, hooks, unsubscribe })
+        return narrowSubscriptions().length === 2 ? deferredSubscribe.promise : { unsubscribe }
+      })
+      const commonDir = await makeCommonDir(true)
+      const worktreesDir = join(commonDir, 'worktrees')
+      const retainedEntry = join(worktreesDir, 'same-child')
+      await mkdir(retainedEntry)
+      const received: WorktreeBasePollEvent[][] = []
+      const onWatchError = vi.fn()
+      await startWatch(commonDir, received, () => [], onWatchError)
+
+      await replaceWorktreesRoot(commonDir, worktreesDir, retainedEntry)
+      await vi.advanceTimersByTimeAsync(POLL_MS * RECONCILIATION_TICKS * 4)
+      await vi.waitFor(
+        () => {
+          expect(subscribeMock).toHaveBeenCalledTimes(3)
+          expect(narrowSubscriptions()[1]).toBeDefined()
+        },
+        { timeout: 1_000 }
+      )
+      const stalePendingSubscription = narrowSubscriptions()[1]
+      await replaceWorktreesRoot(commonDir, worktreesDir, retainedEntry)
+      await vi.advanceTimersByTimeAsync(POLL_MS * RECONCILIATION_TICKS * 4)
+      expect(
+        received.flat().filter((event) => event.type === 'create' && event.path === worktreesDir)
+      ).toHaveLength(2)
+
+      const beforeStaleInterruption = received.length
+      stalePendingSubscription.hooks.onInterruption?.()
+      expect(received).toHaveLength(beforeStaleInterruption)
+      expect(onWatchError).not.toHaveBeenCalled()
+
+      deferredSubscribe.resolve({
+        unsubscribe: async () => {
+          await stalePendingSubscription.unsubscribe()
+        }
+      })
+      await vi.advanceTimersByTimeAsync(POLL_MS)
+      await vi.waitFor(
+        () => {
+          expect(subscribeMock).toHaveBeenCalledTimes(4)
+          expect(stalePendingSubscription.unsubscribe).toHaveBeenCalledOnce()
+        },
+        { timeout: 1_000 }
+      )
+
+      const immediateEntry = join(worktreesDir, 'current-generation')
+      narrowSubscriptions()[2].callback(null, [{ type: 'create', path: immediateEntry }])
+      expect(received.flat()).toContainEqual({ type: 'create', path: immediateEntry })
+    } finally {
+      await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
+      restorePerformanceNow.mockRestore()
+      vi.useRealTimers()
+    }
   })
 
   it('stops forwarding events and unsubscribes the child on dispose', async () => {
@@ -521,250 +695,12 @@ describe('worktree git-common narrow watch (darwin)', () => {
       alwaysVisible
     )
     await watch.unsubscribe()
-    expect(childSubscriptions[0].unsubscribe).toHaveBeenCalledTimes(1)
+    expect(narrowSubscription().unsubscribe).toHaveBeenCalledTimes(1)
 
     received.length = 0
-    childSubscriptions[0].callback(null, [
+    narrowSubscription().callback(null, [
       { type: 'create', path: join(commonDir, 'worktrees', 'late') }
     ])
     expect(received).toHaveLength(0)
-  })
-})
-
-describe('worktree git-common polling gate (non-darwin)', () => {
-  const cleanups: (() => Promise<void>)[] = []
-
-  afterEach(async () => {
-    await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()))
-  })
-
-  async function makePollingCommonDir(): Promise<string> {
-    const root = await mkdtemp(join(tmpdir(), 'orca-git-common-polling-'))
-    cleanups.push(() => rm(root, { recursive: true, force: true }))
-    const commonDir = await realpath(root)
-    await mkdir(join(commonDir, 'worktrees'))
-    return commonDir
-  }
-
-  function makePollingTarget(path: string): WorktreeBaseWatchTarget {
-    return {
-      key: `git-common:local:${path}`,
-      kind: 'git-common',
-      path,
-      repos: new Map([['repo-1', { repoId: 'repo-1', repoName: 'project', nestWorkspaces: false }]])
-    }
-  }
-
-  async function startPollingWatch(
-    commonDir: string,
-    received: WorktreeBasePollEvent[][],
-    onFullScan?: () => void,
-    visibility: WorktreePollerWindowVisibility = alwaysVisible,
-    getStatusRefPaths: () => readonly string[] = () => []
-  ): Promise<void> {
-    const watch = await startGitCommonWatch(
-      makePollingTarget(commonDir),
-      (events) => received.push(events),
-      POLL_MS,
-      'linux',
-      visibility,
-      onFullScan,
-      getStatusRefPaths
-    )
-    cleanups.push(() => watch.unsubscribe())
-  }
-
-  it('skips the ungated index-metadata backstop on idle ticks', async () => {
-    // Why: idle ticks still re-stat structural leaves and list the (small) worktrees dir cheaply, but the
-    // heavier ungated per-entry index fan-out (onFullScan) must NOT run until the backstop — and no
-    // spurious events are emitted while nothing changes.
-    const commonDir = await makePollingCommonDir()
-    const entry = join(commonDir, 'worktrees', 'idle')
-    await mkdir(join(entry, 'logs'), { recursive: true })
-    await writeFile(join(entry, 'HEAD'), 'ref: refs/heads/main')
-    await writeFile(join(entry, 'logs', 'HEAD'), 'baseline\n')
-    const received: WorktreeBasePollEvent[][] = []
-    const fullScans = vi.fn()
-
-    await startPollingWatch(commonDir, received, fullScans)
-    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 6))
-
-    expect(fullScans).not.toHaveBeenCalled()
-    expect(received.flat()).toHaveLength(0)
-  })
-
-  it('detects linked worktree add and remove from the every-tick readdir', async () => {
-    // Why: the worktrees-dir listing runs every tick (not gated on its stat signature), so an add/remove
-    // surfaces within one poll interval even on a coarse-mtime filesystem whose dir signature would not
-    // move — without waiting on the index backstop (onFullScan).
-    const commonDir = await makePollingCommonDir()
-    const received: WorktreeBasePollEvent[][] = []
-    const fullScans = vi.fn()
-    await startPollingWatch(commonDir, received, fullScans)
-
-    const entry = join(commonDir, 'worktrees', 'added')
-    await mkdir(entry)
-    await vi.waitFor(() => {
-      expect(received.flat()).toContainEqual({ type: 'create', path: entry })
-    })
-    // The add is caught by the every-tick listing, NOT the 15-tick index backstop: detection lands well
-    // before a backstop could fire, so onFullScan must not have run. (On the old gated impl a coarse-FS
-    // signature collision would have deferred this to the backstop.)
-    expect(fullScans).not.toHaveBeenCalled()
-
-    await rm(entry, { recursive: true })
-    await vi.waitFor(() => {
-      expect(received.flat()).toContainEqual({ type: 'delete', path: entry })
-    })
-  })
-
-  // Why runIf: chmod 0 cannot revoke directory listing on Windows or for root, so the EACCES injection is inert there.
-  it.runIf(process.platform !== 'win32' && process.getuid?.() !== 0)(
-    'does not fabricate worktree deletions when the readdir fails non-ENOENT (transient)',
-    async () => {
-      // Why: a transient readdir failure (EIO/ESTALE/EMFILE/EACCES, network/SSH hiccup) must not be read
-      // as "every linked worktree removed". Revoke dir permissions so readdir throws EACCES; the known
-      // entry must NOT be reported deleted. On the old catch-all (entryPaths = []) this emitted a false
-      // delete for every entry. chmod (not a dir->file swap) because it is one atomic syscall: an
-      // in-flight tick's threadpool readdir sees success or EACCES, never a transient ENOENT window
-      // that would legitimately emit a delete and flake this assertion.
-      const commonDir = await makePollingCommonDir()
-      const entry = join(commonDir, 'worktrees', 'keep')
-      await mkdir(entry)
-      await writeFile(join(entry, 'HEAD'), 'ref: refs/heads/main')
-      const received: WorktreeBasePollEvent[][] = []
-      await startPollingWatch(commonDir, received)
-
-      await new Promise((resolve) => setTimeout(resolve, POLL_MS * 2))
-      const worktreesDir = join(commonDir, 'worktrees')
-      chmodSync(worktreesDir, 0o000)
-      try {
-        await new Promise((resolve) => setTimeout(resolve, POLL_MS * 4))
-      } finally {
-        // Why: restore before cleanup so the afterEach recursive rm can traverse the dir.
-        chmodSync(worktreesDir, 0o755)
-      }
-
-      expect(received.flat()).not.toContainEqual({ type: 'delete', path: entry })
-    }
-  )
-
-  it('detects an in-place structural (HEAD) write on a known entry every tick, without the index backstop', async () => {
-    // Why: a raw HEAD/gitdir/config.worktree rewrite does not bump the entry-dir mtime, so the
-    // structural leaves are re-stat'd every tick (never gated) — the change surfaces within one tick
-    // and does NOT require the ungated index-metadata backstop (onFullScan).
-    const commonDir = await makePollingCommonDir()
-    const entry = join(commonDir, 'worktrees', 'structural')
-    await mkdir(entry)
-    await writeFile(join(entry, 'HEAD'), 'ref: refs/heads/main')
-    const received: WorktreeBasePollEvent[][] = []
-    const fullScans = vi.fn()
-    await startPollingWatch(commonDir, received, fullScans)
-
-    const headPath = join(entry, 'HEAD')
-    // In-place rewrite: same file, different contents — no entry-dir mtime change.
-    await writeFile(headPath, 'ref: refs/heads/feature')
-    await vi.waitFor(() => {
-      expect(received.flat()).toContainEqual({ type: 'update', path: headPath })
-    })
-    expect(fullScans).not.toHaveBeenCalled()
-  })
-
-  it('polls linked logs/HEAD on every idle tick', async () => {
-    const commonDir = await makePollingCommonDir()
-    const entry = join(commonDir, 'worktrees', 'reflog')
-    await mkdir(join(entry, 'logs'), { recursive: true })
-    const headLogPath = join(entry, 'logs', 'HEAD')
-    await writeFile(headLogPath, 'baseline\n')
-    const received: WorktreeBasePollEvent[][] = []
-    const fullScans = vi.fn()
-    await startPollingWatch(commonDir, received, fullScans)
-
-    await appendFile(headLogPath, 'next\n')
-    await vi.waitFor(() => {
-      expect(received.flat()).toContainEqual({ type: 'update', path: headLogPath })
-    })
-    expect(fullScans).not.toHaveBeenCalled()
-  })
-
-  it('polls the common config so an external push -u surfaces its new upstream', async () => {
-    // Why: `git push -u` from an external shell rewrites only the common
-    // config (plus remote-tracking refs); the primary-metadata list must
-    // surface it or the upstream stays invisible until a safety poll.
-    const commonDir = await makePollingCommonDir()
-    const configPath = join(commonDir, 'config')
-    await writeFile(configPath, '[core]\n\tbare = false\n')
-    const received: WorktreeBasePollEvent[][] = []
-    const fullScans = vi.fn()
-    await startPollingWatch(commonDir, received, fullScans)
-
-    await appendFile(configPath, '[branch "main"]\n\tremote = origin\n')
-    await vi.waitFor(() => {
-      expect(received.flat()).toContainEqual({ type: 'update', path: configPath })
-    })
-    expect(fullScans).not.toHaveBeenCalled()
-  })
-
-  it('detects create, update, and delete for one transient upstream ref', async () => {
-    const commonDir = await makePollingCommonDir()
-    const refPath = join(commonDir, 'refs', 'remotes', 'origin', 'feature', 'nested')
-    await mkdir(join(commonDir, 'refs', 'remotes', 'origin', 'feature'), { recursive: true })
-    const received: WorktreeBasePollEvent[][] = []
-    await startPollingWatch(commonDir, received, undefined, alwaysVisible, () => [refPath])
-
-    await writeFile(refPath, 'aaa\n')
-    await vi.waitFor(() => {
-      expect(received.flat()).toContainEqual({ type: 'create', path: refPath })
-    })
-    received.length = 0
-    await appendFile(refPath, 'bbb\n')
-    await vi.waitFor(() => {
-      expect(received.flat()).toContainEqual({ type: 'update', path: refPath })
-    })
-    received.length = 0
-    await rm(refPath)
-    await vi.waitFor(() => {
-      expect(received.flat()).toContainEqual({ type: 'delete', path: refPath })
-    })
-  })
-
-  it('forces a full scan on the 15-tick backstop', async () => {
-    const commonDir = await makePollingCommonDir()
-    const entry = join(commonDir, 'worktrees', 'backstop')
-    await mkdir(entry)
-    await writeFile(join(entry, 'index'), 'baseline')
-    const received: WorktreeBasePollEvent[][] = []
-    const fullScans = vi.fn()
-    await startPollingWatch(commonDir, received, fullScans)
-
-    await vi.waitFor(() => {
-      expect(fullScans).toHaveBeenCalledTimes(1)
-    })
-    expect(received.flat()).toHaveLength(0)
-  })
-
-  it('forces a full fan-out when resuming after hidden', async () => {
-    const commonDir = await makePollingCommonDir()
-    const entry = join(commonDir, 'worktrees', 'resume')
-    await mkdir(entry)
-    const indexPath = join(entry, 'index')
-    await writeFile(indexPath, 'before')
-    const received: WorktreeBasePollEvent[][] = []
-    const fullScans = vi.fn()
-    const visibility = createVisibilityHarness()
-    await startPollingWatch(commonDir, received, fullScans, visibility.source)
-
-    visibility.hide()
-    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 2))
-    await writeFile(indexPath, 'after-longer')
-    await new Promise((resolve) => setTimeout(resolve, POLL_MS * 2))
-    expect(fullScans).not.toHaveBeenCalled()
-    expect(received.flat()).toHaveLength(0)
-
-    visibility.show()
-    await vi.waitFor(() => {
-      expect(received.flat()).toContainEqual({ type: 'update', path: indexPath })
-    })
-    expect(fullScans).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/ipc/worktree-git-common-watch.test.ts
+++ b/src/main/ipc/worktree-git-common-watch.test.ts
@@ -45,18 +45,22 @@ const alwaysVisible: WorktreePollerWindowVisibility = {
   onWindowBecameVisible: () => () => {}
 }
 
+let inodeReservationCount = 0
+
 async function replaceWorktreesRoot(
   commonDir: string,
   worktreesDir: string,
   retainedEntry: string
 ): Promise<void> {
   await rm(worktreesDir, { recursive: true })
-  // Linux can reuse a just-deleted directory inode. Reserve that inode with a
-  // sibling before recreating the watched root so reconciliation sees a replacement.
-  const inodeReservation = join(commonDir, 'worktrees-replacement-inode')
+  // Linux reuses just-deleted directory inodes. Park each freed inode in a
+  // sibling that is HELD for the rest of the test — releasing it would return it
+  // to the free list, so a later replacement could land back on it and look
+  // unchanged to reconciliation. The dirs are siblings of `worktrees`, which no
+  // poll or watch path enumerates.
+  const inodeReservation = join(commonDir, `worktrees-replacement-inode-${++inodeReservationCount}`)
   await mkdir(inodeReservation)
   await mkdir(retainedEntry, { recursive: true })
-  await rm(inodeReservation, { recursive: true, force: true })
 }
 
 function createVisibilityHarness(): {

--- a/src/main/ipc/worktree-git-common-watch.ts
+++ b/src/main/ipc/worktree-git-common-watch.ts
@@ -1,254 +1,26 @@
-import { stat } from 'node:fs/promises'
-import { join } from 'node:path'
-import { subscribeViaWatcherProcess } from './parcel-watcher-process'
-import { isWatcherProcessFailure } from './parcel-watcher-process-failure'
 import type { WorktreeBaseWatchTarget } from './worktree-base-directory-event-filter'
 import type {
   WorktreeBasePollEvent,
   WorktreeBaseSubscription,
   WorktreePollerWindowVisibility
 } from './worktree-base-directory-poller'
+import { startGitCommonNarrowWatch } from './worktree-git-common-narrow-watch'
+import { startGitCommonPrimaryWatch } from './worktree-git-common-primary-watch'
 import { startGitCommonPolling } from './worktree-git-common-polling'
-import { startGitCommonPrimaryPolling } from './worktree-git-common-primary-polling'
 
-// Watches a repo's `<common>/.git/worktrees` metadata plus the primary
-// checkout's shallow branch/index files — the only paths the git-common event
-// filter consumes.
-// macOS: a narrow native stream rooted at `worktrees/` — a tiny, rare-churn
-// tree — gives instant detection with zero idle cost and zero wide-scope
-// fseventsd delivery; the primary files are covered by a few stat calls per
-// tick (a native stream would have to span the whole common dir, objects
-// included). Other platforms: dir-listing poll (no fseventsd to protect, and
-// on Windows an open directory handle on `worktrees/` could interfere with
-// `git worktree prune` removing it).
-// The native stream is hosted in the crash-isolated watcher child, never the
-// Electron main process: watcher.node teardown races heap-corrupt the hosting
-// process when unsubscribe overlaps in-flight callbacks (issue #8732), and
-// root deletion via `git worktree prune` makes that overlap routine here.
+// Local macOS, Linux, and Windows use the crash-isolated native stream for the
+// narrow `worktrees/` tree and primary metadata leaves. Selected upstream refs
+// stay on the scheduler's bounded stat path. Unsupported platforms retain the
+// full polling fallback.
 
-async function startGitCommonNarrowWatch(
-  target: WorktreeBaseWatchTarget,
-  onEvents: (events: WorktreeBasePollEvent[]) => void,
-  pollIntervalMs: number,
-  visibility: WorktreePollerWindowVisibility,
-  onFullScan?: () => void,
-  onWatchError?: (error: Error) => void
-): Promise<WorktreeBaseSubscription> {
-  const worktreesDir = join(target.path, 'worktrees')
-  let disposed = false
-  let subscription: WorktreeBaseSubscription | null = null
-  let existenceTimer: ReturnType<typeof setInterval> | null = null
-  let pollingFallbackPromise: Promise<void> | null = null
-  let subscribing = false
-  let parkedWhileHidden = false
+const NARROW_WATCH_PLATFORMS: Partial<Record<NodeJS.Platform, true>> = {
+  darwin: true,
+  linux: true,
+  win32: true
+}
 
-  const stopExistencePoll = (): void => {
-    if (existenceTimer) {
-      clearInterval(existenceTimer)
-      existenceTimer = null
-    }
-  }
-
-  const shouldUsePollingFallback = (error: unknown): boolean =>
-    isWatcherProcessFailure(error) &&
-    (error.code === 'supervisor_crash_fuse' || error.code === 'process_unavailable')
-
-  const ensurePollingFallback = (): Promise<void> => {
-    if (pollingFallbackPromise) {
-      return pollingFallbackPromise
-    }
-    stopExistencePoll()
-    const pending = startGitCommonPolling(
-      target.path,
-      onEvents,
-      pollIntervalMs,
-      visibility,
-      onFullScan,
-      false
-    ).then(async (fallback) => {
-      if (disposed || subscription) {
-        await fallback.unsubscribe()
-        return
-      }
-      subscription = fallback
-    })
-    const tracked = pending.finally(() => {
-      if (pollingFallbackPromise === tracked) {
-        pollingFallbackPromise = null
-      }
-    })
-    pollingFallbackPromise = tracked
-    return pollingFallbackPromise
-  }
-
-  const tryUpgradeToNarrowWatch = async (): Promise<void> => {
-    if (disposed || subscribing || subscription) {
-      return
-    }
-    subscribing = true
-    try {
-      const installed = await trySubscribe()
-      if (installed && !disposed) {
-        stopExistencePoll()
-        // The dir appearing means a first linked worktree was just
-        // registered; surface it so the repo's worktree list refreshes.
-        onEvents([{ type: 'create', path: worktreesDir }])
-      }
-    } finally {
-      subscribing = false
-    }
-  }
-
-  const armExistencePoll = (): void => {
-    if (disposed || existenceTimer || subscription) {
-      return
-    }
-    if (!visibility.isWindowVisible()) {
-      parkedWhileHidden = true
-      return
-    }
-    existenceTimer = setInterval(() => {
-      if (disposed) {
-        return
-      }
-      // Why: a hidden window has nothing to refresh, so stop stat'ing the dir
-      // entirely instead of burning a syscall per repo per tick in the background.
-      if (!visibility.isWindowVisible()) {
-        parkedWhileHidden = true
-        stopExistencePoll()
-        return
-      }
-      void tryUpgradeToNarrowWatch()
-    }, pollIntervalMs)
-    existenceTimer.unref?.()
-  }
-
-  const unsubscribeVisibility = visibility.onWindowBecameVisible(() => {
-    if (disposed || !parkedWhileHidden) {
-      return
-    }
-    parkedWhileHidden = false
-    // Why: the first linked worktree may have been registered while hidden — check
-    // now (emitting the create) rather than losing it for a full interval.
-    void tryUpgradeToNarrowWatch().finally(() => {
-      armExistencePoll()
-    })
-  })
-
-  const trySubscribe = async (): Promise<boolean> => {
-    try {
-      const s = await stat(worktreesDir)
-      if (!s.isDirectory()) {
-        return false
-      }
-    } catch {
-      return false
-    }
-    let errored = false
-    let active = true
-    // Why: parcel tears its native stream down when the watched root is
-    // deleted (e.g. `git worktree prune` removing an empty worktrees dir) —
-    // sometimes surfaced as an error, sometimes as a delete event for the
-    // root. Either way: notify, drop the dead stream, and let the existence
-    // poll re-arm when a future worktree add recreates the dir.
-    const teardown = (): void => {
-      active = false
-      errored = true
-      const current = subscription
-      subscription = null
-      if (current) {
-        void current.unsubscribe().catch(() => {})
-      }
-    }
-    const teardownAndRearm = (): void => {
-      teardown()
-      armExistencePoll()
-    }
-    try {
-      const sub = await subscribeViaWatcherProcess(
-        worktreesDir,
-        (error, events) => {
-          if (disposed || !active) {
-            return
-          }
-          if (error) {
-            if (onWatchError) {
-              onWatchError(error)
-            } else {
-              onEvents([{ type: 'update', path: worktreesDir }])
-            }
-            if (shouldUsePollingFallback(error)) {
-              teardown()
-              void ensurePollingFallback().catch(() => {
-                if (!disposed) {
-                  armExistencePoll()
-                }
-              })
-            } else {
-              teardownAndRearm()
-            }
-            return
-          }
-          if (events.length > 0) {
-            const rootGone = events.some(
-              (event) => event.type === 'delete' && event.path === worktreesDir
-            )
-            onEvents(events.map((event) => ({ type: event.type, path: event.path })))
-            if (rootGone) {
-              teardownAndRearm()
-            }
-          }
-        },
-        {},
-        {
-          // Why: a watcher-child crash drops events during the automatic
-          // resubscribe gap; report a structural change so worktrees re-sync.
-          onInterruption: () => {
-            if (!disposed && active) {
-              if (onWatchError) {
-                onWatchError(new Error('Git common watcher interrupted'))
-              } else {
-                onEvents([{ type: 'update', path: worktreesDir }])
-              }
-            }
-          }
-        }
-      )
-      if (disposed || errored) {
-        void sub.unsubscribe().catch(() => {})
-        await pollingFallbackPromise?.catch(() => {})
-        return !errored || subscription !== null
-      }
-      subscription = { unsubscribe: () => sub.unsubscribe() }
-      return true
-    } catch (error) {
-      if (shouldUsePollingFallback(error)) {
-        await ensurePollingFallback()
-        return subscription !== null
-      }
-      return false
-    }
-  }
-
-  if (!(await trySubscribe())) {
-    // Why: repos commonly start without linked worktrees; retrying the narrow
-    // subscription lets macOS upgrade to native events when the directory appears.
-    armExistencePoll()
-  }
-
-  return {
-    unsubscribe: async () => {
-      disposed = true
-      stopExistencePoll()
-      unsubscribeVisibility()
-      await pollingFallbackPromise?.catch(() => {})
-      const current = subscription
-      subscription = null
-      if (current) {
-        await current.unsubscribe().catch(() => {})
-      }
-    }
-  }
+function supportsNarrowWatch(platform: NodeJS.Platform): boolean {
+  return NARROW_WATCH_PLATFORMS[platform] === true
 }
 
 export async function startGitCommonWatch(
@@ -261,28 +33,30 @@ export async function startGitCommonWatch(
   getStatusRefPaths: () => readonly string[] = () => [],
   onWatchError?: (error: Error) => void
 ): Promise<WorktreeBaseSubscription> {
-  if (platform === 'darwin') {
-    const [narrowWatch, primaryMetadataPoll] = await Promise.all([
+  if (supportsNarrowWatch(platform)) {
+    const [narrowWatch, primaryWatch] = await Promise.all([
       startGitCommonNarrowWatch(
         target,
         onEvents,
         pollIntervalMs,
+        platform,
         visibility,
         onFullScan,
         onWatchError
       ),
-      startGitCommonPrimaryPolling(
+      startGitCommonPrimaryWatch(
         target.path,
         getStatusRefPaths,
         onEvents,
         pollIntervalMs,
         visibility,
-        onFullScan
+        onFullScan,
+        onWatchError
       )
     ])
     return {
       unsubscribe: async () => {
-        await Promise.all([narrowWatch.unsubscribe(), primaryMetadataPoll.unsubscribe()])
+        await Promise.all([narrowWatch.unsubscribe(), primaryWatch.unsubscribe()])
       }
     }
   }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​571 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​310 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​261 |
| Prod | 13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1044 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​370 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​674 |

<!-- /orca-pr-loc -->

## Problem

Local Git-common metadata observation re-scanned every linked worktree on a fixed interval even while completely idle. With E linked worktrees each poll cost roughly:

```
6*E linked-worktree stats + 6 primary metadata stats + one worktrees listing
```

That work competed with renderer updates and Git subprocesses. The cost scaled with **repo count x worktree count** rather than with **change rate**, which is the actual defect.

## Approach

Healthy local observation is now event-driven, with polling kept strictly as a fallback:

```
native event -> path classification -> existing targeted notification pipeline -> bounded refresh
```

- Narrow `@parcel/watcher` stream over `<common>/worktrees`, extended from macOS to Linux and Windows, Windows backend pinned explicitly.
- New **shallow** watcher mode over the allowlisted primary metadata leaves (`HEAD`, `packed-refs`, `index`, `config`, `config.worktree`, `logs/HEAD`). It watches the **containing directory**, not each file, so Git's atomic write-and-rename does not orphan the binding.
- Selected upstream refs stay on the existing bounded stat poll.

No RPC or wire changes. SSH/WSL observation stays provider-owned (`subscribeTarget` branches on `connectionId` before any of this code is reached). Folder workspaces are unaffected.

## Verified on real hosts

Not reasoned about — measured, on Windows (`awin`), Ubuntu 24.04, and two Macs.

| Check | macOS | Linux | Windows |
| --- | --- | --- | --- |
| narrow watch: worktree add / remove / prune | pass | pass | pass |
| root delete emits `delete/worktrees` (re-arm trigger) | — | pass | pass |
| `backend: 'windows'` accepted | n/a | n/a | pass |
| open handle blocks `git worktree prune` | n/a | n/a | **does not block** |
| shallow events survive atomic rename | pass | pass | pass |
| inotify budget | n/a | 1 instance per event loop | n/a |

Two long-standing concerns in the previous code turned out to be unfounded:

- The old comment claimed a Windows directory handle on `worktrees/` could interfere with `git worktree prune`. It does not: remove and prune both succeed with the stream held, the directory is deleted, and parcel reports `delete/worktrees`.
- Linux inotify does not cost one instance per watch. libuv shares a single inotify fd per event loop (50 `fs.watch` calls measured as 1 instance), so the watch budget is not a constraint.

## Failure handling

Each of these was reproduced on real hardware before being fixed.

**Replaced inode.** `fs.watch` binds an inode, not a path. When the directory is replaced the watcher goes deaf silently — no events, no `error`. Verified on Linux. Directory bindings are now re-checked on a bounded cadence (2 stats / 30s) and rebound, so the healthy path still performs no primary metadata stats.

**Mute host.** A host whose notification path is broken accepts the registration and stays silent forever, which is indistinguishable from an idle repo. This is not hypothetical: on a macOS 26.3.1 machine whose `fseventsd` had grown to ~15GB resident and saturated a core, both `fs.watch` on a directory and `@parcel/watcher` delivered zero events across 4/4 runs, while kqueue file watches and stat polling still worked. Since the fallback only triggered on an error that never arrives, metadata would have stayed stale until restart.

A one-shot delivery probe now measures whether the host actually delivers before a shallow subscription is accepted, mirroring the canary that already guards parcel's own delivery. Confirmed on both machines:

| Host | delivers? | probe | outcome |
| --- | --- | --- | --- |
| macOS 26.3.1 (degraded fseventsd) | no | `false` | falls back to polling |
| macOS 26.5.2 | yes | `true` | uses the watcher |

Worth noting for reviewers: on macOS a directory `fs.watch` **is** an FSEvents client, where the previous stat poll registered none. That is a real cost on the resource #7068 addressed, and the probe is what keeps its failure mode safe rather than silent.

## Testing

- `pnpm run typecheck` (all projects) — pass
- `pnpm run lint` (full chain incl. max-lines ratchet, reliability gates, electron ratchet, localization) — pass
- `pnpm exec vitest run src/main/ipc/` — **3172 passed**, 11 skipped, 1 failure

The single failure is `filesystem-watcher-real.test.ts`, a live `@parcel/watcher` integration test. It fails identically on `origin/main` on the same machine and is caused by that machine's degraded `fseventsd`; this change touches neither the test nor its subject.

## Note on scope

This branch is deliberately **independent of the metadata poll scheduler** (#16175) and applies directly to `main`. Root-replacement inode detection was originally bundled into that scheduler commit but is watcher logic, so it is carried here.
