### PR TITLE
fix(daemon): keep attach guard behind client timeout

### DIFF
--- a/src/main/daemon/daemon-client-rpc-request.test.ts
+++ b/src/main/daemon/daemon-client-rpc-request.test.ts
@@ -21,7 +21,67 @@ function addSiblingRequest(pendingRequests: DaemonPendingRequests, reject: () =>
 
 describe('requestDaemonRpc', () => {
   afterEach(() => {
+    vi.restoreAllMocks()
     vi.useRealTimers()
+  })
+
+  it('puts the create guard after the client timeout and cancellation grace', async () => {
+    const pendingRequests = new DaemonPendingRequests()
+    const abort = new AbortController()
+    const write = vi.fn()
+    const request = requestDaemonRpc({
+      socket: { write } as unknown as Socket,
+      pendingRequests,
+      id: 'req-1',
+      type: 'createOrAttach',
+      payload: { sessionId: 'guarded-spawn' },
+      timeoutMs: 30_000,
+      signal: abort.signal,
+      unmatchedCancelGraceMs: 5_000,
+      onCreateCancellationFailure: vi.fn(),
+      settleCreateCancellation: vi.fn(async () => ({ canceled: true }))
+    })
+    const rejected = expect(request).rejects.toThrow('client_disconnected')
+
+    expect(JSON.parse(String(write.mock.calls[0]?.[0]))).toMatchObject({
+      payload: { sessionId: 'guarded-spawn', cancelAfterMs: 35_000 }
+    })
+    abort.abort()
+
+    await rejected
+  })
+
+  it('translates the create guard cancellation when the client timeout callback is stalled', async () => {
+    vi.useFakeTimers()
+    const monotonicNow = vi.spyOn(performance, 'now').mockReturnValue(0)
+    const pendingRequests = new DaemonPendingRequests()
+    const settleCreateCancellation = vi.fn(() => new Promise<{ canceled: boolean }>(() => {}))
+    const request = requestDaemonRpc({
+      socket: { write: vi.fn() } as unknown as Socket,
+      pendingRequests,
+      id: 'req-1',
+      type: 'createOrAttach',
+      payload: { sessionId: 'deadline-spawn' },
+      timeoutMs: 10,
+      unmatchedCancelGraceMs: 5,
+      onCreateCancellationFailure: vi.fn(),
+      settleCreateCancellation
+    })
+    const rejected = expect(request).rejects.toMatchObject({
+      name: 'DaemonRequestTimeoutError',
+      message: 'Request createOrAttach timed out after 10ms'
+    })
+
+    monotonicNow.mockReturnValue(16)
+    expect(settleCreateCancellation).not.toHaveBeenCalled()
+    pendingRequests.settle({
+      id: 'req-1',
+      ok: false,
+      error: 'Attach canceled for session deadline-spawn'
+    })
+
+    await rejected
+    expect(settleCreateCancellation).not.toHaveBeenCalled()
   })
 
   it('keeps a completed spawn result when cancellation arrives too late', async () => {

--- a/src/main/daemon/daemon-client-rpc-request.ts
+++ b/src/main/daemon/daemon-client-rpc-request.ts
@@ -54,14 +54,21 @@ function wedgedDaemonError(requestError: Error, cancelError: unknown): Error | n
 }
 
 export function requestDaemonRpc<T>(opts: DaemonRpcRequestOptions): Promise<T> {
+  // Why: a stalled event loop can deliver a daemon cancellation before the overdue timer runs.
+  const clientDeadlineMs = performance.now() + opts.timeoutMs
   const { payload, type } = opts
+  const createTimeoutError = (): DaemonRequestTimeoutError =>
+    new DaemonRequestTimeoutError(`Request ${type} timed out after ${opts.timeoutMs}ms`)
   const createSessionId =
     type === 'createOrAttach' && payload !== null && typeof payload === 'object'
       ? Reflect.get(payload, 'sessionId')
       : null
   const requestPayload =
     type === 'createOrAttach' && payload !== null && typeof payload === 'object'
-      ? { ...payload, cancelAfterMs: Math.max(1, opts.timeoutMs - 100) }
+      ? {
+          ...payload,
+          cancelAfterMs: Math.max(1, opts.timeoutMs + opts.unmatchedCancelGraceMs)
+        }
       : payload
   const encoded = encodeNdjson({
     id: opts.id,
@@ -146,9 +153,7 @@ export function requestDaemonRpc<T>(opts: DaemonRpcRequestOptions): Promise<T> {
         })
     }
     const timer = setTimeout(() => {
-      const error = new DaemonRequestTimeoutError(
-        `Request ${type} timed out after ${opts.timeoutMs}ms`
-      )
+      const error = createTimeoutError()
       if (typeof createSessionId === 'string') {
         cancelCreate(error)
       } else {
@@ -172,8 +177,11 @@ export function requestDaemonRpc<T>(opts: DaemonRpcRequestOptions): Promise<T> {
         removeAbortListener()
         clearTimers()
         reject(
-          cancellationError !== null && isTerminalAttachCanceledMessage(error.message)
-            ? cancellationError
+          isTerminalAttachCanceledMessage(error.message)
+            ? (cancellationError ??
+                (type === 'createOrAttach' && performance.now() >= clientDeadlineMs
+                  ? createTimeoutError()
+                  : error))
             : error
         )
       },


### PR DESCRIPTION
## ELI5

The daemon used to cancel a terminal slightly before the app's own timeout handler ran. That ordering could expose an internal `Attach canceled` protocol error and leave the terminal pane on the wrong failure path. The daemon guard now runs after the client timeout/cancellation window, and an overdue guard response is classified with the client timeout even if the client event loop was temporarily stalled.

## What Changed

- Schedule `createOrAttach`'s daemon cleanup guard after the client timeout plus cancellation-settlement grace.
- Record the monotonic client deadline so a daemon cancellation processed before an overdue timer callback still becomes the expected `DaemonRequestTimeoutError`.
- Add regressions for the encoded deadline ordering and the stalled-event-loop settlement race.

## Why

`cancelAfterMs` was `timeoutMs - 100`, making the daemon intentionally win the race. Its `Attach canceled for session …` response could therefore arrive while `cancellationError` was still unset and escape as `DaemonProtocolError`. Moving the guard behind the client cancellation window fixes the source ordering; the monotonic deadline check closes the remaining event-loop-stall interleaving without reclassifying early, unrelated cancellations.

## Linked Issue

Fixes #16386

## Visual Proof

N/A — no UI or interaction layout changed; this is daemon request cancellation ordering.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Verified on macOS:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/daemon/daemon-client-rpc-request.test.ts src/main/daemon/client.test.ts` — 43 tests passed.
- `pnpm run typecheck` — passed.
- `pnpm run check:code-quality:changed` — passed (all three scans, zero findings).

The reporter's exact local workspace/session state was unavailable, so no claim of reproducing that specific terminal interactively. CI covers the broader repository gates.

## AI Disclosure

OpenAI GPT-5.6-Sol coordinated independent root-cause analyses, two competing minimal implementations, and two adversarial reviews. The timer-ordering implementation was selected; the review-discovered event-loop-stall gap was corrected before delivery.

## Review

Two adversarial reviews examined timer ordering, mixed-version behavior, same-session cancellation, attach-only handling, and test quality. The actionable event-loop-stall race was fixed. Server-side late-success and old-client findings were rejected after tracing existing synchronous abort/poll checks and scoping this patch to the reported current local client/daemon path.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No wire field or opcode change. No platform branch. SSH/remote ownership, folder workspaces, mobile, and provider selection are unchanged. The server cleanup guard remains bounded and client disappearance still triggers existing cancellation cleanup.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (focused tests, full typecheck, and changed-code quality passed locally; CI will cover full lint/test/build)
