### PR TITLE
fix(linear): make new-project dialog popovers scrollable

### DIFF
--- a/src/renderer/src/components/task-page/dialogs/new-linear-project-dialog.tsx
+++ b/src/renderer/src/components/task-page/dialogs/new-linear-project-dialog.tsx
@@ -102,11 +102,14 @@ export function NewLinearProjectDialog({
                     <ChevronDown className="size-3 flex-none text-muted-foreground" />
                   </Button>
                 </PopoverTrigger>
-                <PopoverContent align="start" className="w-72 p-1">
+                <PopoverContent
+                  align="start"
+                  className="w-72 p-1 popover-scroll-content scrollbar-sleek"
+                >
                   <div className="px-2 py-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
                     {translate('auto.components.TaskPage.a98cbe7664', 'Team')}
                   </div>
-                  <div className="max-h-64 overflow-y-auto scrollbar-sleek">
+                  <div>
                     {availableTeams.map((team) => (
                       <button
                         key={team.id}

--- a/src/renderer/src/components/task-page/dialogs/new-linear-project-fields.tsx
+++ b/src/renderer/src/components/task-page/dialogs/new-linear-project-fields.tsx
@@ -58,7 +58,7 @@ export function NewLinearProjectFields({
             <ChevronDown className="size-3 text-muted-foreground/70" />
           </button>
         </PopoverTrigger>
-        <PopoverContent align="start" className="w-48 p-1">
+        <PopoverContent align="start" className="w-48 p-1 popover-scroll-content scrollbar-sleek">
           <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
             {translate('auto.components.TaskPage.c8d5bec5f7', 'Priority')}
           </div>
@@ -101,7 +101,7 @@ export function NewLinearProjectFields({
             <ChevronDown className="size-3 text-muted-foreground/70" />
           </button>
         </PopoverTrigger>
-        <PopoverContent align="start" className="w-64 p-1">
+        <PopoverContent align="start" className="w-64 p-1 popover-scroll-content scrollbar-sleek">
           <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
             {translate('auto.components.TaskPage.34da8ac06c', 'Lead')}
           </div>
@@ -110,7 +110,7 @@ export function NewLinearProjectFields({
               <LoaderCircle className="size-4 animate-spin text-muted-foreground" />
             </div>
           ) : (
-            <div className="max-h-64 overflow-y-auto scrollbar-sleek">
+            <div>
               <button
                 type="button"
                 onClick={() => setNewLinearProjectLeadId(null)}
@@ -180,7 +180,7 @@ export function NewLinearProjectFields({
             <ChevronDown className="size-3 text-muted-foreground/70" />
           </button>
         </PopoverTrigger>
-        <PopoverContent align="start" className="w-64 p-1">
+        <PopoverContent align="start" className="w-64 p-1 popover-scroll-content scrollbar-sleek">
           <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
             {translate('auto.components.TaskPage.d6cda23ef1', 'Members')}
           </div>
@@ -189,7 +189,7 @@ export function NewLinearProjectFields({
               <LoaderCircle className="size-4 animate-spin text-muted-foreground" />
             </div>
           ) : (
-            <div className="max-h-64 overflow-y-auto scrollbar-sleek">
+            <div>
               {newLinearProjectMembers.data.map((member) => {
                 const selected = newLinearProjectMemberIds.includes(member.id)
                 return (
@@ -248,7 +248,7 @@ export function NewLinearProjectFields({
             <ChevronDown className="size-3 text-muted-foreground/70" />
           </button>
         </PopoverTrigger>
-        <PopoverContent align="start" className="w-64 p-1">
+        <PopoverContent align="start" className="w-64 p-1 popover-scroll-content scrollbar-sleek">
           <div className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
             {translate('auto.components.TaskPage.d0ca4aa1d0', 'Labels')}
           </div>
@@ -257,7 +257,7 @@ export function NewLinearProjectFields({
               <LoaderCircle className="size-4 animate-spin text-muted-foreground" />
             </div>
           ) : (
-            <div className="max-h-64 overflow-y-auto scrollbar-sleek">
+            <div>
               {newLinearProjectLabels.data.length === 0 ? (
                 <div className="px-2 py-2 text-xs text-muted-foreground">
                   {translate('auto.components.TaskPage.af9e877f30', 'No labels')}

--- a/src/renderer/src/components/task-page/dialogs/new-linear-project-popover-scroll.test.tsx
+++ b/src/renderer/src/components/task-page/dialogs/new-linear-project-popover-scroll.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment happy-dom
+import { readFileSync } from 'node:fs'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+})
+
+function listState<T>(data: T[]): { data: T[]; loading: boolean; error: string | null } {
+  return { data, loading: false, error: null }
+}
+
+const MEMBERS = Array.from({ length: 30 }, (_, i) => ({
+  id: `member-${i}`,
+  name: `Member ${i}`,
+  displayName: `Member ${i}`,
+  email: `member${i}@example.test`
+}))
+
+const LABELS = Array.from({ length: 30 }, (_, i) => ({
+  id: `label-${i}`,
+  name: `Label ${i}`,
+  color: '#888888'
+}))
+
+async function renderFields(): Promise<void> {
+  const { NewLinearProjectFields } = await import('./new-linear-project-fields')
+  await act(async () =>
+    root.render(
+      <NewLinearProjectFields
+        newLinearProjectSubmitting={false}
+        newLinearProjectPriority={0}
+        setNewLinearProjectPriority={() => {}}
+        newLinearProjectMembers={listState(MEMBERS) as never}
+        newLinearProjectLeadId={null}
+        setNewLinearProjectLeadId={() => {}}
+        newLinearProjectMemberIds={[]}
+        setNewLinearProjectMemberIds={() => {}}
+        newLinearProjectLabelIds={[]}
+        setNewLinearProjectLabelIds={() => {}}
+        newLinearProjectLabels={listState(LABELS) as never}
+        newLinearProjectStartDate=""
+        setNewLinearProjectStartDate={() => {}}
+        newLinearProjectTargetDate=""
+        setNewLinearProjectTargetDate={() => {}}
+      />
+    )
+  )
+}
+
+function triggers(): HTMLElement[] {
+  return [...document.querySelectorAll<HTMLElement>('[data-slot="popover-trigger"]')]
+}
+
+async function toggle(trigger: HTMLElement): Promise<void> {
+  // Radix opens on pointerdown, not a synthetic click.
+  await act(async () => {
+    trigger.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerType: 'mouse' }))
+    trigger.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerType: 'mouse' }))
+    trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+function openContent(): HTMLElement {
+  const el = document.querySelector<HTMLElement>('[data-slot="popover-content"]')
+  if (!el) {
+    throw new Error('Popover content did not render')
+  }
+  return el
+}
+
+describe('Linear new-project dialog popovers', () => {
+  it('renders every attribute popover as a capped scroller that the wheel shim can drive', async () => {
+    await renderFields()
+    const all = triggers()
+    expect(all.length).toBe(4)
+
+    for (const [index, trigger] of all.entries()) {
+      await toggle(trigger)
+      const content = openContent()
+
+      // The marker is what supplies overflow-y and opts into popover.tsx's
+      // wheel shim, which Radix's dialog scroll-lock otherwise defeats.
+      expect(content.className, `popover ${index} is not a capped scroller`).toContain(
+        'popover-scroll-content'
+      )
+      expect(content.className).toContain('scrollbar-sleek')
+
+      // A nested fixed-height scroller inside the cap strands its own overflow.
+      const nested = [...content.querySelectorAll<HTMLElement>('div')].filter((el) => {
+        const tokens = new Set(el.className.split(/\s+/))
+        return (
+          [...tokens].some((t) => /^max-h-(\d+|\[.+\])$/.test(t)) && tokens.has('overflow-y-auto')
+        )
+      })
+      expect(
+        nested.map((el) => el.className),
+        `popover ${index} nests a scroller`
+      ).toEqual([])
+
+      await toggle(trigger)
+    }
+  })
+
+  it('keeps the team switcher in the same pattern', () => {
+    // The team switcher lives in the dialog shell, which needs the whole task
+    // page to mount; assert on its source instead.
+    const source = readFileSync(
+      'src/renderer/src/components/task-page/dialogs/new-linear-project-dialog.tsx',
+      'utf8'
+    )
+    const tags = [...source.matchAll(/<PopoverContent\b[^>]*?>/gs)].map((m) => m[0])
+
+    expect(tags.length).toBeGreaterThanOrEqual(1)
+    for (const tag of tags) {
+      const className = tag.match(/\bclassName="([^"]*)"/)?.[1] ?? null
+      expect(className, `className must be a plain literal: ${tag}`).not.toBeNull()
+      expect(className).toContain('popover-scroll-content')
+      expect(className).toContain('scrollbar-sleek')
+    }
+  })
+})


### PR DESCRIPTION
## ELI5

The Linear **new project** dialog has the same broken dropdowns that #16382 just fixed in the **new issue** dialog next door. These ones are sneakier: a scrollbar actually shows up, so they look fine — but the mouse wheel and trackpad do nothing over them, so you can only move the list by dragging that thin scrollbar. This makes them scroll normally.

> **Rebased onto current main.** #15163 landed in the meantime and split `TaskPage.tsx` into `task-page/` modules, which moved this code out from under the original patch. The branch was rebased and the fix reapplied at its new home — the diff is smaller and the test is stronger as a result. Force-pushed, so the earlier review history predates the current commit.

## What Changed

All five `PopoverContent`s in the Linear new-project dialog now use the `popover-scroll-content scrollbar-sleek` pattern, matching what #16382 did for the new-issue dialog:

- `task-page/dialogs/new-linear-project-dialog.tsx` — the **Team** switcher.
- `task-page/dialogs/new-linear-project-fields.tsx` — **Priority, Lead, Members, Labels**.

The four inner `max-h-64 overflow-y-auto scrollbar-sleek` wrappers are dropped, now redundant.

New test: `task-page/dialogs/new-linear-project-popover-scroll.test.tsx`.

## Why

Two shapes of the same defect:

- **Team / Lead / Members / Labels** each wrap their list in an inner `max-h-64 overflow-y-auto` box. The box overflows and CSS renders a scrollbar, so it *looks* functional — but the `PopoverContent` carries no `popover-scroll-content` / `popover-wheel-scroll` marker, so `handlePopoverWheel` in `popover.tsx` never runs and Radix's dialog scroll-lock cancels the native wheel. Dragging the scrollbar works; the wheel does not.
- **Priority** has no inner scroller at all, so it falls back to the global `[data-slot='popover-content']` cap with the base `overflow-hidden` and clips, exactly like the team switcher in #16378.

`popover-scroll-content` handles both: it re-declares the cap as `min(15rem, var(--radix-popover-content-available-height))`, supplies the `overflow-y: auto`, and its class name is what opts the content into the wheel shim.

## Linked Issue

Fixes #16412

## Visual Proof

**Real app, my own workspace** (~50 Linear teams; team names blurred). Two builds of the same tree differing only by this fix, same isolated profile, same window. Team picker in the new-project dialog:

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/GagaKor/orca/pr-assets/7-project-wheel-before.gif" alt="before — wheel does nothing, only dragging the scrollbar moves the list"> | <img src="https://raw.githubusercontent.com/GagaKor/orca/pr-assets/8-project-wheel-after.gif" alt="after — wheel scrolls the list"> |

In the **before** clip the scrollbar is dragged first, which works and proves there is more list below the fold. Then the pointer moves over the list and the wheel and trackpad are used — the list does not budge for the rest of the clip. In the **after** clip the same wheel input scrolls it immediately.

Measured on the popover element, driving **actual wheel input** through the browser (`page.mouse.wheel` and a raw CDP `Input.dispatchMouseEvent`) rather than setting `scrollTop`, which succeeds either way and would hide the bug entirely:

| | real scroller | client / scroll height | overflow-y | wheel → scrollTop |
|---|---|---|---|---|
| **before** | inner `div.max-h-64` | 256 / 1288 | `auto` | **0 → 0** (dead, both injection paths) |
| **after** | `PopoverContent` | 238 / 735 | `auto` | **0 → 400** |

On this workspace that leaves **1032px of the list — about 80% of it — unreachable by wheel** before the change.

Static screenshots are the weakest evidence for this one, since a scrollbar renders either way and the difference is behavioral. Kept for completeness (captured pre-rebase, same behavior):

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/GagaKor/orca/pr-assets/5-project-before.png" alt="fixture before"> | <img src="https://raw.githubusercontent.com/GagaKor/orca/pr-assets/6-project-after.png" alt="fixture after"> |

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Because #15163 split the task page into focused modules, `NewLinearProjectFields` is now a ~230-line presentational component with plain props — so the test **mounts it and asserts on the rendered DOM**, rather than scanning source text the way the pre-rebase version and #16382's test had to. Failures now quote the actual rendered `className`.

Three assertions, each verified to actually fail:

1. **Every rendered popover is a capped scroller** — opens each of the four pickers and asserts `popover-scroll-content scrollbar-sleek` on the live `[data-slot="popover-content"]`. Red against the parent commit's sources.
2. **No nested fixed-height scroller inside the cap** — order-independent (token set, not substring), so reintroducing the wrapper as `scrollbar-sleek overflow-y-auto max-h-64` still fails. Verified red by planting exactly that.
3. **The team switcher stays in the pattern** — it lives in the dialog shell, which needs the whole task page to mount, so this one asserts on its source. It also requires the `className` to be a plain literal, closing the gap raised in the #16382 review: a popover written with `cn(...)` or a template literal would otherwise skip the marker check silently rather than fail it. Verified red by rewriting one as `className={cn("w-72 p-1")}`.

Full sweep re-run against the rebased tree, not carried over from the pre-rebase commit:

- `pnpm lint` — exit 0
- `pnpm typecheck` — exit 0
- `pnpm build` — exit 0
- `pnpm test` — 61,168 passed / 6 failed across 5 files

All 6 failures are pre-existing on `upstream/main`. I checked rather than assumed: running those 5 files in isolation on this commit and on its parent gives the identical result (2 failed / 39 passed / 1 skipped, same two test names) — `local-pty-provider-shell-readiness` (a PATH assertion) and `filesystem-watcher-real` (a `@parcel/watcher` FSEvents timeout). The other 4 only fail under full-suite load and pass in isolation: three `native-chat/transcript-watch` timeouts and one `ai-vault-session-worktree-map` perf assertion (`164ms` against a `150ms` budget). None of the 5 files import or reference the three files this PR touches.

Also passing: `oxfmt --check` and `pnpm run check:code-quality:changed` on the changed files, and 16 tests across this file (2), #16382's sibling test (2), and `ui/popover-wheel-scroll.test.tsx` (12).

Platforms tested: **macOS**. CSS-class only, no platform-conditional code — the stylesheet and the `popover.tsx` shim are not platform-gated.

## AI Disclosure

Claude Opus 5 (via Claude Code) did the investigation, the change, and the tests. Reviewed by me before opening.

## Review

- **Cross-platform (macOS / Linux / Windows):** No platform-conditional code, no paths, no accelerators. `.popover-scroll-content` and the wheel shim are platform-neutral.
- **SSH / remote / local:** Renderer-only presentation change. No execution host, process lifecycle, RPC param, stream frame, or published content is touched.
- **Agent / integration / git-provider compatibility:** Confined to this one Linear dialog's popovers. The Jira new-issue dialog was checked and is **not** affected — its popover wraps a cmdk `Command`, whose `CommandList` brings both a capped scroller and its own non-passive wheel listener. (Thanks for confirming that independently in the #16382 review.)
- **Performance:** Net negative cost — four wrapper `<div>`s lose their class attributes; no new elements, listeners, state, or renders. The shim's listener was already attached to every `PopoverContent`; the marker only decides whether it acts.
- **UI quality:** Adopts the existing app-wide dropdown pattern, so this dialog now matches the new-issue dialog and `LinearItemDrawer`. Documented tokens only. As in #16382, the uppercase section header now scrolls with the list instead of staying pinned — same cosmetic trade-off, same rationale (the trigger chip already shows the current value).
- **Security:** No input handling, IPC, network, filesystem, or credential path. Nothing rendered as HTML.
- **Backwards compatibility:** No persisted state, schema, setting, or wire format involved.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

I hit this in my own workspace, which has ~50 Linear teams. The cutoff point depends on window height, so smaller workspaces would not run into it.

With this merged I found no remaining popover in either Linear create dialog missing the marker.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — lint/typecheck/build clean; `pnpm test`'s 6 failures are pre-existing on main, verified against the parent commit (details in Testing)
