### PR TITLE
fix(remote): stop an empty host inventory settling the mirror

### DIFF
--- a/src/renderer/src/runtime/host-live-terminal-probe.ts
+++ b/src/renderer/src/runtime/host-live-terminal-probe.ts
@@ -1,0 +1,82 @@
+import type { RuntimeTerminalListResult } from '../../../shared/runtime-types'
+import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
+
+/**
+ * Asks the host whether ANY terminal is live in an environment, for the one
+ * question the session-tab mirror cannot answer: a live host that has not
+ * published yet returns the same empty inventory as a host with no terminals
+ * at all. `terminal.list` reads the PTY controller — `ptysById` plus the
+ * cross-generation daemon inventory — not the mirror, so it sees exactly that
+ * gap.
+ *
+ * `unverifiable` is a verdict, never a synonym for `none`: loss of contact
+ * with the execution host is no evidence a host-owned PTY exited.
+ */
+export type HostLiveTerminalProbeVerdict = 'live' | 'none' | 'unverifiable'
+
+type RuntimeCall = (args: {
+  selector: string
+  method: string
+  params: unknown
+  timeoutMs: number
+}) => Promise<RuntimeRpcResponse<unknown>>
+
+const inFlightProbeByEnvironment = new Map<string, Promise<HostLiveTerminalProbeVerdict>>()
+
+function isTerminalListResult(value: unknown): value is RuntimeTerminalListResult {
+  return (
+    Boolean(value) &&
+    typeof value === 'object' &&
+    Array.isArray((value as { terminals?: unknown }).terminals)
+  )
+}
+
+async function probeHost(
+  environmentId: string,
+  call: RuntimeCall
+): Promise<HostLiveTerminalProbeVerdict> {
+  const response = await call({
+    selector: environmentId,
+    method: 'terminal.list',
+    params: {
+      // Why: one row settles "any", and `totalCount` is the pre-limit census.
+      limit: 1,
+      // Why: without it an unavailable daemon inventory answers from stale PTY
+      // records — a false empty. It raises `terminal_liveness_unavailable`
+      // instead, which lands here as `unverifiable`.
+      requireFreshPtyLiveness: true,
+      includeVisualLayouts: false
+    },
+    timeoutMs: 15_000
+  })
+  if (response.ok === false || !isTerminalListResult(response.result)) {
+    return 'unverifiable'
+  }
+  const { terminals, totalCount } = response.result
+  return terminals.length > 0 || (typeof totalCount === 'number' && totalCount > 0)
+    ? 'live'
+    : 'none'
+}
+
+export function probeHostLiveTerminals(
+  environmentId: string,
+  call: RuntimeCall = (args) => window.api.runtimeEnvironments.call(args)
+): Promise<HostLiveTerminalProbeVerdict> {
+  const existing = inFlightProbeByEnvironment.get(environmentId)
+  if (existing) {
+    return existing
+  }
+  const probe = probeHost(environmentId, call)
+    .catch((): HostLiveTerminalProbeVerdict => 'unverifiable')
+    .finally(() => {
+      if (inFlightProbeByEnvironment.get(environmentId) === probe) {
+        inFlightProbeByEnvironment.delete(environmentId)
+      }
+    })
+  inFlightProbeByEnvironment.set(environmentId, probe)
+  return probe
+}
+
+export function clearHostLiveTerminalProbesForTests(): void {
+  inFlightProbeByEnvironment.clear()
+}

--- a/src/renderer/src/runtime/host-live-terminal-probe.ts
+++ b/src/renderer/src/runtime/host-live-terminal-probe.ts
@@ -1,7 +1,4 @@
-import type {
-  RuntimeTerminalListHostScope,
-  RuntimeTerminalListResult
-} from '../../../shared/runtime-types'
+import type { RuntimeTerminalListResult } from '../../../shared/runtime-types'
 import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
 
 /**
@@ -24,23 +21,32 @@ type RuntimeCall = (args: {
   timeoutMs: number
 }) => Promise<RuntimeRpcResponse<unknown>>
 
-type CompleteTerminalListResult = RuntimeTerminalListResult & {
+type ValidTerminalListResult = RuntimeTerminalListResult & {
   totalCount: number
-  hostScope: RuntimeTerminalListHostScope
 }
 
 const inFlightProbeByEnvironment = new Map<string, Promise<HostLiveTerminalProbeVerdict>>()
 
-function isTerminalListResult(value: unknown): value is CompleteTerminalListResult {
+function isTerminalListResult(value: unknown): value is ValidTerminalListResult {
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    !Array.isArray((value as { terminals?: unknown }).terminals) ||
+    !Number.isInteger((value as { totalCount?: unknown }).totalCount) ||
+    (value as { totalCount: number }).totalCount < 0
+  ) {
+    return false
+  }
+  const hostScope = (value as { hostScope?: unknown }).hostScope
+  if (hostScope === undefined) {
+    // Older hosts do not publish scope; preserve their best-effort list result.
+    return true
+  }
   return (
-    Boolean(value) &&
-    typeof value === 'object' &&
-    Array.isArray((value as { terminals?: unknown }).terminals) &&
-    Number.isInteger((value as { totalCount?: unknown }).totalCount) &&
-    (value as { totalCount: number }).totalCount >= 0 &&
-    Boolean((value as { hostScope?: unknown }).hostScope) &&
-    Array.isArray((value as { hostScope?: { hostIds?: unknown } }).hostScope?.hostIds) &&
-    Array.isArray((value as { hostScope?: { omittedHostIds?: unknown } }).hostScope?.omittedHostIds)
+    Boolean(hostScope) &&
+    typeof hostScope === 'object' &&
+    Array.isArray((hostScope as { hostIds?: unknown }).hostIds) &&
+    Array.isArray((hostScope as { omittedHostIds?: unknown }).omittedHostIds)
   )
 }
 
@@ -67,7 +73,8 @@ async function probeHost(
   }
   // An omitted execution host is an incomplete census. In particular, a relay
   // can list its local PTYs while an SSH child host is still starting up.
-  if (response.result.hostScope.omittedHostIds.length > 0) {
+  const hostScope = response.result.hostScope
+  if (hostScope && hostScope.omittedHostIds.length > 0) {
     return 'unverifiable'
   }
   const { terminals, totalCount } = response.result

--- a/src/renderer/src/runtime/host-live-terminal-probe.ts
+++ b/src/renderer/src/runtime/host-live-terminal-probe.ts
@@ -1,4 +1,7 @@
-import type { RuntimeTerminalListResult } from '../../../shared/runtime-types'
+import type {
+  RuntimeTerminalListHostScope,
+  RuntimeTerminalListResult
+} from '../../../shared/runtime-types'
 import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
 
 /**
@@ -21,13 +24,23 @@ type RuntimeCall = (args: {
   timeoutMs: number
 }) => Promise<RuntimeRpcResponse<unknown>>
 
+type CompleteTerminalListResult = RuntimeTerminalListResult & {
+  totalCount: number
+  hostScope: RuntimeTerminalListHostScope
+}
+
 const inFlightProbeByEnvironment = new Map<string, Promise<HostLiveTerminalProbeVerdict>>()
 
-function isTerminalListResult(value: unknown): value is RuntimeTerminalListResult {
+function isTerminalListResult(value: unknown): value is CompleteTerminalListResult {
   return (
     Boolean(value) &&
     typeof value === 'object' &&
-    Array.isArray((value as { terminals?: unknown }).terminals)
+    Array.isArray((value as { terminals?: unknown }).terminals) &&
+    Number.isInteger((value as { totalCount?: unknown }).totalCount) &&
+    (value as { totalCount: number }).totalCount >= 0 &&
+    Boolean((value as { hostScope?: unknown }).hostScope) &&
+    Array.isArray((value as { hostScope?: { hostIds?: unknown } }).hostScope?.hostIds) &&
+    Array.isArray((value as { hostScope?: { omittedHostIds?: unknown } }).hostScope?.omittedHostIds)
   )
 }
 
@@ -52,6 +65,11 @@ async function probeHost(
   if (response.ok === false || !isTerminalListResult(response.result)) {
     return 'unverifiable'
   }
+  // An omitted execution host is an incomplete census. In particular, a relay
+  // can list its local PTYs while an SSH child host is still starting up.
+  if (response.result.hostScope.omittedHostIds.length > 0) {
+    return 'unverifiable'
+  }
   const { terminals, totalCount } = response.result
   return terminals.length > 0 || (typeof totalCount === 'number' && totalCount > 0)
     ? 'live'
@@ -60,20 +78,22 @@ async function probeHost(
 
 export function probeHostLiveTerminals(
   environmentId: string,
-  call: RuntimeCall = (args) => window.api.runtimeEnvironments.call(args)
+  call: RuntimeCall = (args) => window.api.runtimeEnvironments.call(args),
+  connectionGeneration = 0
 ): Promise<HostLiveTerminalProbeVerdict> {
-  const existing = inFlightProbeByEnvironment.get(environmentId)
+  const key = `${environmentId}\0${connectionGeneration}`
+  const existing = inFlightProbeByEnvironment.get(key)
   if (existing) {
     return existing
   }
   const probe = probeHost(environmentId, call)
     .catch((): HostLiveTerminalProbeVerdict => 'unverifiable')
     .finally(() => {
-      if (inFlightProbeByEnvironment.get(environmentId) === probe) {
-        inFlightProbeByEnvironment.delete(environmentId)
+      if (inFlightProbeByEnvironment.get(key) === probe) {
+        inFlightProbeByEnvironment.delete(key)
       }
     })
-  inFlightProbeByEnvironment.set(environmentId, probe)
+  inFlightProbeByEnvironment.set(key, probe)
   return probe
 }
 

--- a/src/renderer/src/runtime/host-session-mirror-empty-inventory-settle.test.ts
+++ b/src/renderer/src/runtime/host-session-mirror-empty-inventory-settle.test.ts
@@ -157,6 +157,57 @@ describe('empty host inventory settling the session mirror', () => {
     expect(hasHostSessionMirrorHydrated(environmentId, WORKTREE)).toBe(false)
   })
 
+  it('accepts a legacy zero-terminal result without host scope', async () => {
+    const result = await probeHostLiveTerminals(
+      'env-legacy-zero',
+      vi.fn(async () => ({
+        id: 'legacy-zero',
+        ok: true as const,
+        result: { terminals: [], totalCount: 0, truncated: false },
+        _meta: { runtimeId: 'runtime' }
+      }))
+    )
+
+    expect(result).toBe('none')
+  })
+
+  it('accepts a legacy live result without host scope', async () => {
+    const result = await probeHostLiveTerminals(
+      'env-legacy-live',
+      vi.fn(async () => ({
+        id: 'legacy-live',
+        ok: true as const,
+        result: {
+          terminals: [{ handle: 'terminal-1' }],
+          totalCount: 1,
+          truncated: false
+        },
+        _meta: { runtimeId: 'runtime' }
+      }))
+    )
+
+    expect(result).toBe('live')
+  })
+
+  it('rejects a present malformed host scope as unverifiable', async () => {
+    const result = await probeHostLiveTerminals(
+      'env-malformed-scope',
+      vi.fn(async () => ({
+        id: 'malformed-scope',
+        ok: true as const,
+        result: {
+          terminals: [],
+          totalCount: 0,
+          truncated: false,
+          hostScope: { omittedHostIds: [] }
+        },
+        _meta: { runtimeId: 'runtime' }
+      }))
+    )
+
+    expect(result).toBe('unverifiable')
+  })
+
   it('still settles the environment when the inventory published snapshots', async () => {
     const environmentId = 'env-published'
     const calls = stubPairedHost(['terminal-1'])

--- a/src/renderer/src/runtime/host-session-mirror-empty-inventory-settle.test.ts
+++ b/src/renderer/src/runtime/host-session-mirror-empty-inventory-settle.test.ts
@@ -13,6 +13,7 @@
  * session-tab mirror — so an empty mirror plus a live PTY is a THIRD state.
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
 
 // Why: web-session-tabs-sync imports the app-level store singleton, and this
 // suite drives only the settle receipt — no store patch is exercised.
@@ -30,6 +31,10 @@ import {
   parkUntilHostSessionMirrorHydrates,
   resetHostSessionMirrorHydrationForTests
 } from './host-session-mirror-hydration'
+import {
+  clearHostLiveTerminalProbesForTests,
+  probeHostLiveTerminals
+} from './host-live-terminal-probe'
 import { applyWebSessionTabsStorePatch } from './web-session-tabs-sync'
 
 const WORKTREE = 'repo1::/path/wt1'
@@ -37,7 +42,10 @@ const WORKTREE = 'repo1::/path/wt1'
 type HostCall = { method: string; params: Record<string, unknown> }
 
 /** `null` models a failed probe: `unverifiable`, never `the host has none`. */
-function stubPairedHost(liveTerminalHandles: readonly string[] | null): HostCall[] {
+function stubPairedHost(
+  liveTerminalHandles: readonly string[] | null,
+  omittedHostIds: readonly string[] = []
+): HostCall[] {
   const calls: HostCall[] = []
   const call = vi.fn(async (args: { method: string; params: Record<string, unknown> }) => {
     calls.push({ method: args.method, params: args.params })
@@ -53,7 +61,8 @@ function stubPairedHost(liveTerminalHandles: readonly string[] | null): HostCall
           connected: true
         })),
         totalCount: liveTerminalHandles.length,
-        truncated: false
+        truncated: false,
+        hostScope: { hostIds: ['runtime:env'], omittedHostIds }
       }
     }
   })
@@ -77,6 +86,7 @@ describe('empty host inventory settling the session mirror', () => {
   beforeEach(() => {
     resetHostSessionMirrorHydrationForTests()
     clearRuntimeEnvironmentConnectionGenerationsForTests()
+    clearHostLiveTerminalProbesForTests()
   })
 
   afterEach(() => {
@@ -132,6 +142,21 @@ describe('empty host inventory settling the session mirror', () => {
     expect(hasHostSessionMirrorHydrated(environmentId, WORKTREE)).toBe(false)
   })
 
+  it('leaves waiters parked when terminal.list omits an execution host', async () => {
+    const environmentId = 'env-omitted-host'
+    stubPairedHost([], ['ssh:box-1'])
+    let resumeSweeps = 0
+    parkUntilHostSessionMirrorHydrates(environmentId, WORKTREE, () => {
+      resumeSweeps += 1
+    })
+
+    settleEmptyInventory(environmentId)
+    await flushProbe()
+
+    expect(resumeSweeps).toBe(0)
+    expect(hasHostSessionMirrorHydrated(environmentId, WORKTREE)).toBe(false)
+  })
+
   it('still settles the environment when the inventory published snapshots', async () => {
     const environmentId = 'env-published'
     const calls = stubPairedHost(['terminal-1'])
@@ -157,5 +182,44 @@ describe('empty host inventory settling the session mirror', () => {
     expect(hasHostSessionMirrorHydrated(environmentId, WORKTREE)).toBe(true)
     await flushProbe()
     expect(calls).toEqual([])
+  })
+
+  it('does not reuse an in-flight probe across connection generations', async () => {
+    const responses: ((response: RuntimeRpcResponse<unknown>) => void)[] = []
+    const call = vi.fn(
+      (): Promise<RuntimeRpcResponse<unknown>> =>
+        new Promise((resolve) => {
+          responses.push(resolve)
+        })
+    )
+    const firstProbe = probeHostLiveTerminals('env-generation', call, 1)
+    const secondProbe = probeHostLiveTerminals('env-generation', call, 2)
+
+    expect(call).toHaveBeenCalledTimes(2)
+    responses[0]!({
+      id: 'probe-1',
+      ok: true,
+      result: {
+        terminals: [{}],
+        totalCount: 1,
+        truncated: false,
+        hostScope: { hostIds: ['runtime:env'], omittedHostIds: [] }
+      },
+      _meta: { runtimeId: 'runtime' }
+    })
+    responses[1]!({
+      id: 'probe-2',
+      ok: true,
+      result: {
+        terminals: [],
+        totalCount: 0,
+        truncated: false,
+        hostScope: { hostIds: ['runtime:env'], omittedHostIds: [] }
+      },
+      _meta: { runtimeId: 'runtime' }
+    })
+
+    await expect(firstProbe).resolves.toBe('live')
+    await expect(secondProbe).resolves.toBe('none')
   })
 })

--- a/src/renderer/src/runtime/host-session-mirror-empty-inventory-settle.test.ts
+++ b/src/renderer/src/runtime/host-session-mirror-empty-inventory-settle.test.ts
@@ -1,0 +1,161 @@
+/**
+ * STA-5377. An inventory that published zero snapshots satisfied
+ * `settles.length === fullInventory.publishedSnapshotCount` as `0 === 0` and
+ * fired the environment-wide "the host has spoken" verdict with no host
+ * evidence behind it. A live relay/SSH-paired host answers exactly that until
+ * its renderer's first mirror publish, so the drained resume sweep forked
+ * `codex resume` / `claude --resume` onto a PTY the host was still running.
+ *
+ * All three states are pinned here because the naive floor
+ * (`settles.length > 0`) trades the duplicate session for the opposite defect:
+ * a genuinely zero-terminal host whose panes park forever. The distinguisher
+ * is host readiness — `terminal.list` reads the PTY controller, not the
+ * session-tab mirror — so an empty mirror plus a live PTY is a THIRD state.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Why: web-session-tabs-sync imports the app-level store singleton, and this
+// suite drives only the settle receipt — no store patch is exercised.
+vi.mock('../store', () => ({
+  useAppStore: {
+    setState: vi.fn(),
+    getState: vi.fn(() => ({})),
+    subscribe: vi.fn(() => () => {})
+  }
+}))
+
+import { clearRuntimeEnvironmentConnectionGenerationsForTests } from '@/store/slices/runtime-status'
+import {
+  hasHostSessionMirrorHydrated,
+  parkUntilHostSessionMirrorHydrates,
+  resetHostSessionMirrorHydrationForTests
+} from './host-session-mirror-hydration'
+import { applyWebSessionTabsStorePatch } from './web-session-tabs-sync'
+
+const WORKTREE = 'repo1::/path/wt1'
+
+type HostCall = { method: string; params: Record<string, unknown> }
+
+/** `null` models a failed probe: `unverifiable`, never `the host has none`. */
+function stubPairedHost(liveTerminalHandles: readonly string[] | null): HostCall[] {
+  const calls: HostCall[] = []
+  const call = vi.fn(async (args: { method: string; params: Record<string, unknown> }) => {
+    calls.push({ method: args.method, params: args.params })
+    if (liveTerminalHandles === null) {
+      return { ok: false, error: { code: -32000, message: 'terminal_liveness_unavailable' } }
+    }
+    return {
+      ok: true,
+      result: {
+        terminals: liveTerminalHandles.map((handle) => ({
+          handle,
+          worktreeId: WORKTREE,
+          connected: true
+        })),
+        totalCount: liveTerminalHandles.length,
+        truncated: false
+      }
+    }
+  })
+  vi.stubGlobal('window', { api: { runtimeEnvironments: { call } } })
+  return calls
+}
+
+/** The exact verdict both `listAll` sites build when the host publishes nothing. */
+function settleEmptyInventory(environmentId: string): void {
+  applyWebSessionTabsStorePatch(() => ({}), {
+    frames: [],
+    fullInventory: { environmentId, publishedSnapshotCount: 0 }
+  })()
+}
+
+async function flushProbe(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+describe('empty host inventory settling the session mirror', () => {
+  beforeEach(() => {
+    resetHostSessionMirrorHydrationForTests()
+    clearRuntimeEnvironmentConnectionGenerationsForTests()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('leaves waiters parked when the host is live but has not published', async () => {
+    const environmentId = 'env-live-unpublished'
+    const calls = stubPairedHost(['terminal-1'])
+    let resumeSweeps = 0
+    parkUntilHostSessionMirrorHydrates(environmentId, WORKTREE, () => {
+      resumeSweeps += 1
+    })
+
+    settleEmptyInventory(environmentId)
+    await flushProbe()
+
+    expect(resumeSweeps).toBe(0)
+    expect(hasHostSessionMirrorHydrated(environmentId, WORKTREE)).toBe(false)
+    expect(calls.map((entry) => entry.method)).toEqual(['terminal.list'])
+    // A stale PTY record would answer an empty list for a live daemon.
+    expect(calls[0]?.params.requireFreshPtyLiveness).toBe(true)
+  })
+
+  it('settles a host that genuinely owns no terminals', async () => {
+    const environmentId = 'env-no-terminals'
+    stubPairedHost([])
+    let resumeSweeps = 0
+    parkUntilHostSessionMirrorHydrates(environmentId, WORKTREE, () => {
+      resumeSweeps += 1
+    })
+
+    settleEmptyInventory(environmentId)
+    await flushProbe()
+
+    expect(resumeSweeps).toBe(1)
+    expect(hasHostSessionMirrorHydrated(environmentId, WORKTREE)).toBe(true)
+  })
+
+  it('leaves waiters parked when the readiness probe fails', async () => {
+    const environmentId = 'env-probe-failed'
+    stubPairedHost(null)
+    let resumeSweeps = 0
+    parkUntilHostSessionMirrorHydrates(environmentId, WORKTREE, () => {
+      resumeSweeps += 1
+    })
+
+    settleEmptyInventory(environmentId)
+    await flushProbe()
+
+    expect(resumeSweeps).toBe(0)
+    expect(hasHostSessionMirrorHydrated(environmentId, WORKTREE)).toBe(false)
+  })
+
+  it('still settles the environment when the inventory published snapshots', async () => {
+    const environmentId = 'env-published'
+    const calls = stubPairedHost(['terminal-1'])
+    let resumeSweeps = 0
+    parkUntilHostSessionMirrorHydrates(environmentId, WORKTREE, () => {
+      resumeSweeps += 1
+    })
+
+    applyWebSessionTabsStorePatch(() => ({}), {
+      frames: [
+        {
+          environmentId,
+          worktreeId: WORKTREE,
+          decision: { apply: true, settlesHostMirror: true } as never
+        }
+      ],
+      fullInventory: { environmentId, publishedSnapshotCount: 1 }
+    })()
+
+    // Why: a published inventory is host evidence on its own — it must settle
+    // in the same tick as before, with no probe round trip.
+    expect(resumeSweeps).toBe(1)
+    expect(hasHostSessionMirrorHydrated(environmentId, WORKTREE)).toBe(true)
+    await flushProbe()
+    expect(calls).toEqual([])
+  })
+})

--- a/src/renderer/src/runtime/host-session-mirror-settle-census.test.ts
+++ b/src/renderer/src/runtime/host-session-mirror-settle-census.test.ts
@@ -103,8 +103,12 @@ describe('host-session-mirror settle census', () => {
       // The definitions themselves.
       'runtime/host-session-mirror-hydration.ts': { hydrated: 1, worktreeHydrated: 1 },
       // Exactly the receipt constructors: the patch receipt (environment-wide
-      // and per-worktree) and the stale-frame receipt.
-      'runtime/web-session-tabs-sync.ts': { hydrated: 1, worktreeHydrated: 2 }
+      // and per-worktree) and the stale-frame receipt. The environment-wide
+      // mark has two audited arms, both inside the receipt: an inventory that
+      // published snapshots settles on the spot, and one that published none
+      // settles only after `terminal.list` says the host has no live PTY —
+      // `0 === 0` is not host evidence (STA-5377).
+      'runtime/web-session-tabs-sync.ts': { hydrated: 2, worktreeHydrated: 2 }
     })
   })
 

--- a/src/renderer/src/runtime/web-session-tabs-sync-window-visibility.test.tsx
+++ b/src/renderer/src/runtime/web-session-tabs-sync-window-visibility.test.tsx
@@ -40,6 +40,7 @@ import { useAppStore } from '@/store'
 import type { PublicKnownRuntimeEnvironment } from '../../../shared/runtime-environments'
 import type { AppState } from '@/store/types'
 import { replaceRuntimeEnvironmentRevisions } from './runtime-environment-revision'
+import { clearHostLiveTerminalProbesForTests } from './host-live-terminal-probe'
 import {
   acceptReplayedWebSessionTabsSnapshot,
   _getWebSessionTabsRecoveryTrackingCountsForTest,
@@ -74,12 +75,27 @@ type Deferred<T> = {
 }
 
 const subscriptions: RuntimeSubscription[] = []
-const runtimeCall = vi.fn(async () => ({
+const runtimeCall = vi.fn(async (_args: { method: string }) => ({
   id: 'list-all',
   ok: true as const,
   result: { snapshots: [] },
   _meta: { runtimeId: 'runtime-test' }
 }))
+
+/** Why: an inventory that publishes nothing now buys one `terminal.list`
+ *  readiness probe before it may settle the mirror, so a bare call count no
+ *  longer says which questions the client asked (STA-5377). */
+function runtimeCallMethods(): string[] {
+  return runtimeCall.mock.calls.map(([args]) => args.method).sort()
+}
+
+/** Both seeded environments answer an empty inventory, so each owes a probe. */
+const EMPTY_INVENTORY_CALLS = [
+  'session.tabs.listAll',
+  'session.tabs.listAll',
+  'terminal.list',
+  'terminal.list'
+]
 const runtimeSubscribe = vi.fn<RuntimeSubscribe>(async (request, callbacks) => {
   const unsubscribe = vi.fn()
   subscriptions.push({ request, callbacks, unsubscribe })
@@ -213,6 +229,7 @@ describe('useWebSessionTabsSync window visibility', () => {
     })
     setDocumentVisibility('visible')
     resetWebSessionTabsSnapshotFreshnessForTests()
+    clearHostLiveTerminalProbesForTests()
     seedRemoteMirrorState()
   })
 
@@ -230,7 +247,7 @@ describe('useWebSessionTabsSync window visibility', () => {
     const hook = renderHook(() => useWebSessionTabsSync())
     await act(settle)
 
-    expect(runtimeCall).toHaveBeenCalledTimes(2)
+    expect(runtimeCallMethods()).toEqual(EMPTY_INVENTORY_CALLS)
     expect(runtimeSubscribe).toHaveBeenCalledTimes(3)
     expect(subscriptions.map(({ request }) => request.method).sort()).toEqual([
       'session.tabs.subscribe',
@@ -251,7 +268,7 @@ describe('useWebSessionTabsSync window visibility', () => {
     act(() => vi.advanceTimersByTime(WEB_SESSION_TABS_VISIBILITY_RESUME_STAGGER_MS))
     await act(settle)
     expect(runtimeSubscribe).toHaveBeenCalledTimes(6)
-    expect(runtimeCall).toHaveBeenCalledTimes(2)
+    expect(runtimeCallMethods()).toEqual(EMPTY_INVENTORY_CALLS)
 
     act(() => {
       setDocumentVisibility('hidden')
@@ -342,7 +359,7 @@ describe('useWebSessionTabsSync window visibility', () => {
     act(() => setDocumentVisibility('visible'))
     act(() => vi.advanceTimersByTime(WEB_SESSION_TABS_VISIBILITY_RESUME_STAGGER_MS))
     await act(settle)
-    expect(runtimeCall).toHaveBeenCalledTimes(2)
+    expect(runtimeCallMethods()).toEqual(EMPTY_INVENTORY_CALLS)
     expect(runtimeSubscribe).toHaveBeenCalledTimes(3)
     hook.unmount()
   })

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -3720,7 +3720,7 @@ export type HostSessionMirrorPatchVerdict = {
  */
 function settleEmptyHostInventoryOnlyIfHostHasNoTerminals(environmentId: string): void {
   const probedGeneration = getRuntimeEnvironmentConnectionGeneration(environmentId)
-  void probeHostLiveTerminals(environmentId).then((verdict) => {
+  void probeHostLiveTerminals(environmentId, undefined, probedGeneration).then((verdict) => {
     // Why: the probe is a round trip, and a reconnect in between would make its
     // answer speak for a connection whose PTYs nobody listed.
     if (

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -46,6 +46,8 @@ import {
   markHostSessionMirrorHydrated,
   markHostSessionMirrorWorktreeHydrated
 } from './host-session-mirror-hydration'
+import { probeHostLiveTerminals } from './host-live-terminal-probe'
+import { getRuntimeEnvironmentConnectionGeneration } from '@/store/slices/runtime-status'
 import {
   createWebRuntimeSessionTerminal,
   HOST_TERMINAL_SURFACE_SEPARATOR,
@@ -3704,6 +3706,32 @@ export type HostSessionMirrorPatchVerdict = {
   fullInventory?: { environmentId: string; publishedSnapshotCount: number }
 }
 
+/**
+ * An inventory that published nothing is the one shape carrying no host
+ * evidence at all: `settles.length === publishedSnapshotCount` is `0 === 0`, so
+ * a live host answering `[]` before its renderer's first publish used to be
+ * upgraded into an environment-wide "the host has spoken" — draining parked
+ * resumes into forking a second agent onto a PTY the host still runs.
+ *
+ * The distinguisher has to be host readiness, not list emptiness: a host with
+ * genuinely zero terminals must still settle or its panes park forever. Only
+ * `none` settles; `live` and `unverifiable` leave waiters for the next
+ * inventory or per-worktree frame.
+ */
+function settleEmptyHostInventoryOnlyIfHostHasNoTerminals(environmentId: string): void {
+  const probedGeneration = getRuntimeEnvironmentConnectionGeneration(environmentId)
+  void probeHostLiveTerminals(environmentId).then((verdict) => {
+    // Why: the probe is a round trip, and a reconnect in between would make its
+    // answer speak for a connection whose PTYs nobody listed.
+    if (
+      verdict === 'none' &&
+      getRuntimeEnvironmentConnectionGeneration(environmentId) === probedGeneration
+    ) {
+      markHostSessionMirrorHydrated(environmentId)
+    }
+  })
+}
+
 function createHostSessionMirrorSettle(
   verdict: HostSessionMirrorPatchVerdict
 ): HostSessionMirrorSettle {
@@ -3711,6 +3739,10 @@ function createHostSessionMirrorSettle(
     const { frames, fullInventory } = verdict
     const settles = frames.filter(({ decision }) => decision.settlesHostMirror)
     if (fullInventory && settles.length === fullInventory.publishedSnapshotCount) {
+      if (fullInventory.publishedSnapshotCount === 0) {
+        settleEmptyHostInventoryOnlyIfHostHasNoTerminals(fullInventory.environmentId)
+        return
+      }
       markHostSessionMirrorHydrated(fullInventory.environmentId)
       return
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​303 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​297 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​141 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​141 |

<!-- /orca-pr-loc -->

## ELI5 — what a user actually sees

**Who this affects:** anyone running an agent on a *remote* machine — an SSH host or a paired runtime. Purely local and WSL sessions are unaffected.

**The setup.** You have Codex or Claude running in a terminal on a remote host. You close the lid, lose wifi for a moment, or the app reconnects for any reason.

**Before this fix.** On reconnect, Orca asks the host "which terminal sessions do you have?" The host is alive and your agent is still running — but it hasn't finished publishing its session list yet, so it truthfully answers *"none so far."*

Orca reads that empty answer as **"the agent is gone"** and helpfully starts a fresh one. Now there are **two agents running against the same workspace**: the original, still alive on the host and still writing files, plus a brand-new duplicate. What you see:

- an agent session that appears to restart itself after a reconnect
- two agents editing the same repo, interleaving each other's work
- Codex refusing the new session with an "already has an active writer" style error
- in the worst case, the duplicate resuming from an older checkpoint and undoing work the original just did

**After this fix.** Before concluding the agent is gone, Orca asks a second, different question: *"do you actually have any live terminals right now?"* That question reads the host's live PTY table rather than its session list, so it sees the truth even before publishing finishes.

- host says **"yes, I have live terminals"** → Orca waits instead of forking. Your agent reconnects to the session it already had.
- host says **"genuinely none"** → Orca proceeds exactly as before. Nothing hangs.
- the question **fails or is unanswerable** → Orca waits rather than guessing. A missing answer is not proof of death.

**Why the "genuinely none" case matters.** The naive fix — "never settle on an empty list" — would swap this bug for a worse one: a host that legitimately has zero terminals would leave your panes waiting **forever**. The tests pin both directions, so neither failure can come back.

**Net effect for users:** reconnecting to a remote agent no longer risks spawning a duplicate of it, and a remote host with no terminals still opens instantly.

## What breaks

`web-session-tabs-sync.ts` upgrades a fully-applied host inventory into an
environment-wide "the host has spoken" verdict:

```js
const settles = frames.filter(({ decision }) => decision.settlesHostMirror)
if (fullInventory && settles.length === fullInventory.publishedSnapshotCount) {
  markHostSessionMirrorHydrated(fullInventory.environmentId)
```

With **zero** published snapshots both sides are `0`, so `0 === 0` fires that
verdict with no host evidence behind it. There is no floor requiring that even
one frame carried any.

A live host legitimately answers `[]`: `session.tabs.listAll` returns
`[...this.mobileSessionTabsByWorktree.values()]` from a map constructed empty,
and the full hydrate early-returns without writing when an authoritative window
already exists. So an unpublished-but-live host is indistinguishable from a host
that owns nothing — as far as the session-tab mirror is concerned.

## Consequence

`markHostSessionMirrorHydrated` stamps the generation and drains parked waiters
→ `host-mirrored-pane-liveness.ts` returns null because the mirror now reads as
hydrated even though `ptyIdsByTabId[tabId]` is still empty →
`resume-sleeping-agent-session.ts` stops parking → it forks `codex resume` /
`claude --resume` against a PTY the host is **still running**. Duplicate agent
sessions (`codex -32600 already has an active writer`). Relay / SSH-paired only.

`host-session-mirror-hydration.ts` exists precisely to prevent this — its header
says it tells *"the host reported no PTY"* apart from *"the host has not
answered yet"*. An empty inventory from an unpublished host is a **third** case
the code did not distinguish. Per the SSH execution boundary it is
`unverifiable`, not `exited`.

## The tension this fix has to respect

A healthy host with **genuinely zero terminals** must still settle, or its panes
park **forever** — the opposite failure, frozen instead of duplicated. Naively
requiring `settles.length > 0` trades one bug for the other. The distinguisher
has to be host **readiness**, not list emptiness.

## Why `terminal.list` is the right signal

`terminal.list` reads the host's PTY controller — `ptysById` plus the
cross-generation daemon inventory via
`refreshPtyWorktreeRecordsWithControllerInventory` → `allLivePtyIds` — **not**
the session-tab mirror. So it sees live PTYs even when
`mobileSessionTabsByWorktree` is empty. That is exactly the third state the
mirror cannot see, and it needs no wire change: the client already calls
`terminal.list` on this same path, on the same paired connection, from
`web-session-terminal-orphan-recovery.ts` — routing, auth and error guards all
exist.

When `publishedSnapshotCount === 0`, the environment-wide settle is now gated
behind one probe for that environment:

- **empty answer** → settle (genuinely zero-terminal host, no hang)
- **non-empty, or error** → leave waiters parked; later `updated` frames and
  tombstones settle per-worktree as before

`requireFreshPtyLiveness: true` means an unavailable daemon inventory raises
`terminal_liveness_unavailable` rather than answering a false empty, and that
lands as `unverifiable` → parked. Park-on-error matches the module's own rule
that a failed inventory is never proof a host-owned PTY exited.

Per-worktree settles (`markHostSessionMirrorWorktreeHydrated`) are untouched,
and an inventory that **did** publish snapshots still settles synchronously in
the same tick, with no probe round trip (pinned by a test). The deferred arm
re-checks the connection generation before stamping, because a reconnect during
the round trip would make the answer speak for a connection whose PTYs nobody
listed.

## Old hosts need no fallback

The client pulls, so every deployed host already answers `terminal.list`. On
hosts predating `requireFreshPtyLiveness` (#5473) zod strips the unknown param
and the host returns a best-effort list: a non-empty answer still parks (safe),
and a false empty reproduces today's behaviour exactly. Strictly monotone
improvement, no regression, no capability negotiation needed.

## Test coverage

`publishedSnapshotCount` previously appeared **only** in the production file —
zero tests. That is why this shipped. The new suite pins all three states,
because two of them are opposite failure modes:

1. live-but-unpublished host (`snapshots: []` + a live PTY) ⇒ **must not**
   settle, waiters stay parked — this is the regression
2. genuinely zero-terminal host (both empty) ⇒ settle **does** fire — guards the
   hang
3. probe error ⇒ stays parked
4. plus: a published inventory still settles in-tick with no probe

`host-session-mirror-settle-census.test.ts` is updated deliberately (the
env-wide mark now has two audited arms inside the same receipt), as that census
instructs.

## Red / green

`src/renderer/src/runtime/web-session-tabs-sync.ts` reverted to `origin/main`
(`5ebc4bb2bc`), everything else unchanged:

```
### RED — src/renderer/src/runtime/web-session-tabs-sync.ts reverted to origin/main (5ebc4bb2bc)

 FAIL  host-session-mirror-empty-inventory-settle.test.ts > empty host inventory settling the session mirror > leaves waiters parked when the host is live but has not published
AssertionError: expected 1 to be +0 // Object.is equality

- Expected
+ Received

- 0
+ 1

 ❯ src/renderer/src/runtime/host-session-mirror-empty-inventory-settle.test.ts:98:26
     96|     await flushProbe()
     97|
     98|     expect(resumeSweeps).toBe(0)
       |                          ^

 FAIL  host-session-mirror-empty-inventory-settle.test.ts > empty host inventory settling the session mirror > leaves waiters parked when the readiness probe fails
AssertionError: expected 1 to be +0 // Object.is equality

- Expected
+ Received

- 0
+ 1

 ❯ src/renderer/src/runtime/host-session-mirror-empty-inventory-settle.test.ts:131:26

 Test Files  1 failed (1)
      Tests  2 failed | 2 passed (4)
```

Note which two pass on unfixed main: the zero-terminal settle and the
published-inventory settle. The regression is the parking pair.

Fix restored:

```
### GREEN — fix restored

 RUN  v4.1.5

 Test Files  1 passed (1)
      Tests  4 passed (4)
```

Full renderer runtime suite on the rebased base:

```
 Test Files  119 passed (119)
      Tests  881 passed (881)
```

`src/renderer/src/lib/` (the resume/liveness consumers): `453 passed`,
`4322 passed | 1 skipped`. `typecheck:web`, `oxfmt`, `oxlint` (base +
code-quality native + type-aware), `check:max-lines-ratchet` and
`check:reliability-gates` all clean.

Fixes STA-5377

