### PR TITLE
fix(cli): seed nvm's default version, not the newest install

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -701,9 +701,10 @@ if (app.isPackaged && process.platform !== 'win32') {
       mergePathSegments(result.segments)
       return
     }
-    // Why: on failure the seeded fallbacks stay in front, which for an nvm user means
-    // the newest install rather than their `default`. Name the reason so that shows up
-    // in a log bundle instead of as an unexplained missing CLI.
+    // Why: on failure the seeded fallbacks stay in front. For an nvm user that is
+    // now their `default` version rather than the newest install, so it is usually
+    // survivable — but it is still not what their shell would have resolved. Name
+    // the reason so it shows up in a log bundle instead of as a missing CLI.
     console.warn(
       `[shell-path] login-shell probe failed (${result.failureReason}); using seeded PATH`
     )

--- a/src/main/startup/hydrate-shell-path.test.ts
+++ b/src/main/startup/hydrate-shell-path.test.ts
@@ -168,7 +168,7 @@ describe('hydrateShellPath', () => {
         failureReason: 'timeout'
       })
 
-      await vi.advanceTimersByTimeAsync(5000)
+      await vi.advanceTimersByTimeAsync(10_000)
 
       await assertion
       expect(proc.kill).toHaveBeenCalledWith('SIGKILL')

--- a/src/main/startup/hydrate-shell-path.ts
+++ b/src/main/startup/hydrate-shell-path.ts
@@ -48,7 +48,8 @@ let probeQueue = Promise.resolve()
 // the seeded version rather than reporting what the user's shell really
 // resolves. The seed now prefers the `default` alias, but still falls back to
 // newest-first when default resolution yields nothing (no alias, `system`,
-// uninstalled target, cycle), so the probe must stay insulated from it. Snapshot PATH here instead: module init runs while the import graph is
+// uninstalled target, cycle), so the probe must stay insulated from it.
+// Snapshot PATH here instead: module init runs while the import graph is
 // evaluated, strictly before any statement in main's body, so it cannot observe the
 // seeds — and unlike an explicit hand-off from the seeding site, there is no call
 // ordering left for a later refactor to break. Windows keys it `Path`, and a Git Bash

--- a/src/main/startup/hydrate-shell-path.ts
+++ b/src/main/startup/hydrate-shell-path.ts
@@ -15,10 +15,13 @@ const DELIMITER = '__ORCA_SHELL_PATH__'
 // Why 10s: 5s was chosen without measurement and a real profile overruns it —
 // a bash -ilc loading nvm, rvm, conda and gcloud measures ~1s idle but 6-7s on a
 // loaded machine, so a cold start under load silently fell back to the seeded
-// PATH. Startup does not block on this (index.ts fires it and forgets), and the
-// one awaited consumer is agent detection, which gets a worse answer from a
-// probe that gives up at 5s than from one that finishes at 6s. Mirrors the
-// budget mature GUI editors settled on for the same probe.
+// PATH. Mirrors the budget mature GUI editors settled on for the same probe.
+//
+// The tail this lengthens is not uniform. On posix the probe is fire-and-forget
+// (index.ts) and only agent detection awaits it. On packaged Windows it also
+// gates terminal runtime services and every non-WSL git command, so the extra
+// 5s binds there — but only for a profile that already blew the old budget, and
+// those users were otherwise stuck with a wrong PATH for the whole session.
 const SPAWN_TIMEOUT_MS = 10_000
 
 // ANSI escape sequences can leak into the captured output when the user's rc
@@ -39,11 +42,13 @@ export type HydrationResult =
 
 let cached: Promise<HydrationResult> | null = null
 let probeQueue = Promise.resolve()
-// Why: patchPackagedProcessPath seeds a version manager's newest install dir
-// ahead of PATH. nvm's startup `use` honors whatever node is already on PATH over
-// the user's `default` alias, so a probe inheriting that seed comes back pinned to
-// the newest install and every terminal loses the global CLIs installed under
-// `default`. Snapshot PATH here instead: module init runs while the import graph is
+// Why: patchPackagedProcessPath seeds a version-manager install dir ahead of
+// PATH. nvm's startup `use` honors whatever node is already on PATH over the
+// user's `default` alias, so a probe inheriting that seed comes back pinned to
+// the seeded version rather than reporting what the user's shell really
+// resolves. The seed now prefers the `default` alias, but still falls back to
+// newest-first when default resolution yields nothing (no alias, `system`,
+// uninstalled target, cycle), so the probe must stay insulated from it. Snapshot PATH here instead: module init runs while the import graph is
 // evaluated, strictly before any statement in main's body, so it cannot observe the
 // seeds — and unlike an explicit hand-off from the seeding site, there is no call
 // ordering left for a later refactor to break. Windows keys it `Path`, and a Git Bash

--- a/src/main/startup/hydrate-shell-path.ts
+++ b/src/main/startup/hydrate-shell-path.ts
@@ -12,7 +12,14 @@ import { WindowsShellPathOwnership, windowsPathSegmentKey } from './windows-shel
 // Probe the profile-loading shell once instead of hard-coding every tool's install path.
 
 const DELIMITER = '__ORCA_SHELL_PATH__'
-const SPAWN_TIMEOUT_MS = 5000
+// Why 10s: 5s was chosen without measurement and a real profile overruns it —
+// a bash -ilc loading nvm, rvm, conda and gcloud measures ~1s idle but 6-7s on a
+// loaded machine, so a cold start under load silently fell back to the seeded
+// PATH. Startup does not block on this (index.ts fires it and forgets), and the
+// one awaited consumer is agent detection, which gets a worse answer from a
+// probe that gives up at 5s than from one that finishes at 6s. Mirrors the
+// budget mature GUI editors settled on for the same probe.
+const SPAWN_TIMEOUT_MS = 10_000
 
 // ANSI escape sequences can leak into the captured output when the user's rc
 // files print banners or set colored prompts. Strip them before parsing.

--- a/src/shared/node-cli-command-resolution.ts
+++ b/src/shared/node-cli-command-resolution.ts
@@ -124,7 +124,9 @@ function getBaseVersionManagerDirectories(platform: NodeJS.Platform, homePath: s
 // Why bounded and cycle-guarded: an nvm alias may point at another alias
 // (`default` -> `lts/*` -> `lts/krypton` -> a version), and a hand-edited pair
 // can point at each other. nvm's own resolver tracks seen aliases; mirror that
-// rather than trusting the files to be acyclic.
+// rather than trusting the files to be acyclic. Termination comes from the hop
+// bound; the seen-set is what turns a cycle into "no preference" instead of
+// silently resolving whichever alias the walk happened to stop on.
 const NVM_ALIAS_CHAIN_LIMIT = 10
 
 /** Resolves `alias/default` to an installed version directory name, or null. */
@@ -143,7 +145,7 @@ function resolveNvmDefaultVersion(nvmVersionsDir: string, installed: string[]): 
     }
     token = next
   }
-  if (!token || seen.size > NVM_ALIAS_CHAIN_LIMIT) {
+  if (!token) {
     return null
   }
   // Why: `system` selects the OS node, so nvm owns nothing to prefer here.
@@ -176,13 +178,17 @@ function readNvmAlias(aliasPath: string): string | null {
 
 /** `24` matches the highest installed `v24.x.y`; `v24.18.0` matches exactly. */
 function matchNvmVersion(token: string, installed: string[]): string | null {
-  // Why a shape check and not a length check: parseVersionSegment coerces every
-  // unparseable segment to 0, so an unresolvable token like `garbage` or
-  // `lts/nonexistent` became [0] and prefix-matched `v0.12.x` — or any stray
-  // non-version directory — instead of matching nothing. (A length check cannot
-  // catch it: ''.split('.') is [''], never empty.) Real nvm answers N/A here,
-  // and so must we, which leaves the newest-first ordering untouched.
-  if (!/^v?\d/.test(token)) {
+  // Why a full shape check: parseVersionSegment coerces every unparseable
+  // segment to 0 (parseInt stops at the first non-digit), so an unresolvable
+  // token prefix-matched `v0.12.x` — or any stray non-version directory —
+  // instead of matching nothing. Anchoring only the first character was not
+  // enough: `0x18`, `00` and `0abc` all still parsed to [0]. nvm writes such a
+  // token to the alias file even while warning it does not exist, then answers
+  // N/A for it, and so must we — which leaves newest-first ordering untouched.
+  // Leading zeros are rejected for the same reason: nvm calls `00` and `024`
+  // N/A, while parseInt happily reads them as 0 and 24.
+  // (A length check cannot catch any of this: ''.split('.') is [''].)
+  if (!/^v?(0|[1-9]\d*)(\.(0|[1-9]\d*))*$/.test(token)) {
     return null
   }
   const wanted = parseVersionSegment(token)

--- a/src/shared/node-cli-command-resolution.ts
+++ b/src/shared/node-cli-command-resolution.ts
@@ -1,4 +1,4 @@
-import { accessSync, constants, existsSync, readdirSync, statSync } from 'node:fs'
+import { accessSync, constants, existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { delimiter, dirname, isAbsolute, join } from 'node:path'
 
@@ -121,17 +121,96 @@ function getBaseVersionManagerDirectories(platform: NodeJS.Platform, homePath: s
   return directories
 }
 
+// Why bounded and cycle-guarded: an nvm alias may point at another alias
+// (`default` -> `lts/*` -> `lts/krypton` -> a version), and a hand-edited pair
+// can point at each other. nvm's own resolver tracks seen aliases; mirror that
+// rather than trusting the files to be acyclic.
+const NVM_ALIAS_CHAIN_LIMIT = 10
+
+/** Resolves `alias/default` to an installed version directory name, or null. */
+function resolveNvmDefaultVersion(nvmVersionsDir: string, installed: string[]): string | null {
+  const aliasDir = join(nvmVersionsDir, '..', '..', 'alias')
+  let token = readNvmAlias(join(aliasDir, 'default'))
+  const seen = new Set<string>()
+  for (let hop = 0; token && hop < NVM_ALIAS_CHAIN_LIMIT; hop += 1) {
+    if (seen.has(token)) {
+      return null
+    }
+    seen.add(token)
+    const next = readNvmAlias(join(aliasDir, token))
+    if (!next) {
+      break
+    }
+    token = next
+  }
+  if (!token || seen.size > NVM_ALIAS_CHAIN_LIMIT) {
+    return null
+  }
+  // Why: `system` selects the OS node, so nvm owns nothing to prefer here.
+  // `node`/`stable` mean newest, which is the ordering we already produce.
+  if (token === 'system' || token === 'node' || token === 'stable') {
+    return null
+  }
+  return matchNvmVersion(token, installed)
+}
+
+function readNvmAlias(aliasPath: string): string | null {
+  // Why the traversal guard: the token is interpolated into a path below, and a
+  // hand-edited alias must not be able to walk out of the alias directory.
+  if (aliasPath.includes('..')) {
+    return null
+  }
+  try {
+    if (!statSync(aliasPath).isFile()) {
+      return null
+    }
+    const value = readFileSync(aliasPath, 'utf8').trim()
+    return value.length > 0 ? value : null
+  } catch {
+    return null
+  }
+}
+
+/** `24` matches the highest installed `v24.x.y`; `v24.18.0` matches exactly. */
+function matchNvmVersion(token: string, installed: string[]): string | null {
+  const wanted = parseVersionSegment(token)
+  if (wanted.length === 0) {
+    return null
+  }
+  const matches = installed.filter((entry) => {
+    const parts = parseVersionSegment(entry)
+    return wanted.every((segment, index) => parts[index] === segment)
+  })
+  return matches.sort(compareVersionDesc)[0] ?? null
+}
+
 function getNvmVersionDirectories(homePath: string): string[] {
   const nvmVersionsDir = join(homePath, '.nvm', 'versions', 'node')
   if (!existsSync(nvmVersionsDir)) {
     return []
   }
 
-  return readdirSync(nvmVersionsDir, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => entry.name)
-    .sort(compareVersionDesc)
-    .map((entry) => join(nvmVersionsDir, entry, 'bin'))
+  let installed: string[]
+  try {
+    installed = readdirSync(nvmVersionsDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort(compareVersionDesc)
+  } catch {
+    return []
+  }
+
+  // Why default-first rather than newest-first: this ordering decides which node
+  // a CLI runs under whenever the login-shell probe does not land. Newest is
+  // usually the version the user just installed and has put nothing into, so it
+  // hid every globally installed CLI and mismatched native module ABIs
+  // (stablyai/orca#10932). The rest stay behind it as fallbacks, so a CLI
+  // installed outside the default version is still reachable.
+  const preferred = resolveNvmDefaultVersion(nvmVersionsDir, installed)
+  const ordered = preferred
+    ? [preferred, ...installed.filter((entry) => entry !== preferred)]
+    : installed
+  return ordered.map((entry) => join(nvmVersionsDir, entry, 'bin'))
 }
 
 function getVersionManagerDirectories(

--- a/src/shared/node-cli-command-resolution.ts
+++ b/src/shared/node-cli-command-resolution.ts
@@ -155,8 +155,11 @@ function resolveNvmDefaultVersion(nvmVersionsDir: string, installed: string[]): 
 }
 
 function readNvmAlias(aliasPath: string): string | null {
-  // Why the traversal guard: the token is interpolated into a path below, and a
-  // hand-edited alias must not be able to walk out of the alias directory.
+  // Why this is a cheap check and not the actual containment: join() normalizes
+  // `..` away before we ever see it, so this only rejects the literal spelling.
+  // The real guarantee is downstream — matchNvmVersion can only ever return an
+  // entry of readdirSync(versions/node), so no token can put a foreign path on
+  // PATH regardless of what the alias file says.
   if (aliasPath.includes('..')) {
     return null
   }
@@ -173,10 +176,16 @@ function readNvmAlias(aliasPath: string): string | null {
 
 /** `24` matches the highest installed `v24.x.y`; `v24.18.0` matches exactly. */
 function matchNvmVersion(token: string, installed: string[]): string | null {
-  const wanted = parseVersionSegment(token)
-  if (wanted.length === 0) {
+  // Why a shape check and not a length check: parseVersionSegment coerces every
+  // unparseable segment to 0, so an unresolvable token like `garbage` or
+  // `lts/nonexistent` became [0] and prefix-matched `v0.12.x` — or any stray
+  // non-version directory — instead of matching nothing. (A length check cannot
+  // catch it: ''.split('.') is [''], never empty.) Real nvm answers N/A here,
+  // and so must we, which leaves the newest-first ordering untouched.
+  if (!/^v?\d/.test(token)) {
     return null
   }
+  const wanted = parseVersionSegment(token)
   const matches = installed.filter((entry) => {
     const parts = parseVersionSegment(entry)
     return wanted.every((segment, index) => parts[index] === segment)

--- a/src/shared/nvm-default-alias.test.ts
+++ b/src/shared/nvm-default-alias.test.ts
@@ -102,19 +102,32 @@ describe('nvm default alias decides the seeded runtime', () => {
     expect(seededNvmDir(home)).toBe(join(home, '.nvm', 'versions', 'node', 'v26.7.0', 'bin'))
   })
 
-  it.each(['garbage', 'iojs', 'lts/nonexistent', 'my-custom-alias'])(
-    'treats the unresolvable default %s as no preference, like nvm N/A',
-    (token) => {
-      // Why v0.12.7 is in the fixture: parseVersionSegment coerces unparseable
-      // segments to 0, so before the shape guard these tokens became [0] and
-      // prefix-matched the 0.x install — seeding a decade-old node.
-      const home = makeNvmHome({
-        versions: ['v0.12.7', 'v24.18.0', 'v26.7.0'],
-        defaultAlias: token
-      })
-      expect(seededNvmDir(home)).toBe(join(home, '.nvm', 'versions', 'node', 'v26.7.0', 'bin'))
-    }
-  )
+  // Why the digit-leading entries: parseInt stops at the first non-digit, so
+  // anchoring only the first character still let `0x18` and `00` parse to 0 and
+  // prefix-match a decade-old v0.x. nvm writes such a token to the alias file
+  // even while warning it does not exist, then answers N/A for it.
+  it.each([
+    'garbage',
+    'iojs',
+    'lts/nonexistent',
+    'my-custom-alias',
+    '0x18',
+    '00',
+    '0abc',
+    '024',
+    '24abc',
+    'v24.18.0-nightly',
+    'V24'
+  ])('treats the unresolvable default %s as no preference, like nvm N/A', (token) => {
+    // Why v0.12.7 is in the fixture: parseVersionSegment coerces unparseable
+    // segments to 0, so before the shape guard these tokens became [0] and
+    // prefix-matched the 0.x install — seeding a decade-old node.
+    const home = makeNvmHome({
+      versions: ['v0.12.7', 'v24.18.0', 'v26.7.0'],
+      defaultAlias: token
+    })
+    expect(seededNvmDir(home)).toBe(join(home, '.nvm', 'versions', 'node', 'v26.7.0', 'bin'))
+  })
 
   it('still treats a numeric default as a version prefix, matching nvm', () => {
     // The guard must reject non-versions without rejecting legitimate prefixes:

--- a/src/shared/nvm-default-alias.test.ts
+++ b/src/shared/nvm-default-alias.test.ts
@@ -68,15 +68,22 @@ describe('nvm default alias decides the seeded runtime', () => {
     expect(seededNvmDir(home)).toBe(join(home, '.nvm', 'versions', 'node', 'v24.18.0', 'bin'))
   })
 
-  it('follows an alias chain (default -> lts/* -> lts/krypton -> version)', () => {
-    const home = makeNvmHome({
-      versions: ['v22.9.0', 'v26.7.0'],
-      defaultAlias: 'lts/*',
-      aliases: { 'lts/*': 'lts/krypton', 'lts/krypton': 'v22.9.0' },
-      cliIn: 'v22.9.0'
-    })
-    expect(seededNvmDir(home)).toBe(join(home, '.nvm', 'versions', 'node', 'v22.9.0', 'bin'))
-  })
+  // Why skipIf rather than renaming the fixture: `lts/*` is the real alias nvm
+  // ships, and `*` is a reserved Win32 filename character, so the fixture cannot
+  // be materialized there. Keeping the real name is worth more than the case
+  // running on a platform where seededNvmDir already pins platform: 'darwin'.
+  it.skipIf(process.platform === 'win32')(
+    'follows an alias chain (default -> lts/* -> lts/krypton -> version)',
+    () => {
+      const home = makeNvmHome({
+        versions: ['v22.9.0', 'v26.7.0'],
+        defaultAlias: 'lts/*',
+        aliases: { 'lts/*': 'lts/krypton', 'lts/krypton': 'v22.9.0' },
+        cliIn: 'v22.9.0'
+      })
+      expect(seededNvmDir(home)).toBe(join(home, '.nvm', 'versions', 'node', 'v22.9.0', 'bin'))
+    }
+  )
 
   it('falls back to newest when there is no default alias', () => {
     const home = makeNvmHome({ versions: ['v24.18.0', 'v26.7.0'] })

--- a/src/shared/nvm-default-alias.test.ts
+++ b/src/shared/nvm-default-alias.test.ts
@@ -102,6 +102,27 @@ describe('nvm default alias decides the seeded runtime', () => {
     expect(seededNvmDir(home)).toBe(join(home, '.nvm', 'versions', 'node', 'v26.7.0', 'bin'))
   })
 
+  it.each(['garbage', 'iojs', 'lts/nonexistent', 'my-custom-alias'])(
+    'treats the unresolvable default %s as no preference, like nvm N/A',
+    (token) => {
+      // Why v0.12.7 is in the fixture: parseVersionSegment coerces unparseable
+      // segments to 0, so before the shape guard these tokens became [0] and
+      // prefix-matched the 0.x install — seeding a decade-old node.
+      const home = makeNvmHome({
+        versions: ['v0.12.7', 'v24.18.0', 'v26.7.0'],
+        defaultAlias: token
+      })
+      expect(seededNvmDir(home)).toBe(join(home, '.nvm', 'versions', 'node', 'v26.7.0', 'bin'))
+    }
+  )
+
+  it('still treats a numeric default as a version prefix, matching nvm', () => {
+    // The guard must reject non-versions without rejecting legitimate prefixes:
+    // real nvm resolves `0` to an installed v0.x.
+    const home = makeNvmHome({ versions: ['v0.12.7', 'v24.18.0'], defaultAlias: '0' })
+    expect(seededNvmDir(home)).toBe(join(home, '.nvm', 'versions', 'node', 'v0.12.7', 'bin'))
+  })
+
   it('still finds a CLI that lives outside the default version', () => {
     // Ordering must be a preference, not a restriction: the other versions stay
     // as fallbacks so a CLI installed elsewhere is still reachable.

--- a/src/shared/nvm-default-alias.test.ts
+++ b/src/shared/nvm-default-alias.test.ts
@@ -1,0 +1,117 @@
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { getVersionManagerBinPaths, resolveCliCommand } from './node-cli-command-resolution'
+
+/**
+ * The seed decides which node a CLI runs under whenever the login-shell probe
+ * does not land (timeout, or a shell whose rc never initializes nvm). Picking
+ * the newest install there is what broke #10932: the newest version is usually
+ * the one the user just added and has installed nothing into.
+ */
+function makeNvmHome(options: {
+  versions: string[]
+  defaultAlias?: string
+  aliases?: Record<string, string>
+  cliIn?: string
+}): string {
+  const home = mkdtempSync(join(tmpdir(), 'orca-nvm-'))
+  for (const version of options.versions) {
+    const bin = join(home, '.nvm', 'versions', 'node', version, 'bin')
+    mkdirSync(bin, { recursive: true })
+    for (const name of ['node', 'node.exe']) {
+      writeFileSync(join(bin, name), '')
+      chmodSync(join(bin, name), 0o755)
+    }
+    if (options.cliIn === version) {
+      writeFileSync(join(bin, 'codex'), '')
+      chmodSync(join(bin, 'codex'), 0o755)
+    }
+  }
+  if (options.defaultAlias !== undefined) {
+    mkdirSync(join(home, '.nvm', 'alias'), { recursive: true })
+    writeFileSync(join(home, '.nvm', 'alias', 'default'), `${options.defaultAlias}\n`)
+  }
+  for (const [name, value] of Object.entries(options.aliases ?? {})) {
+    const file = join(home, '.nvm', 'alias', name)
+    mkdirSync(join(file, '..'), { recursive: true })
+    writeFileSync(file, `${value}\n`)
+  }
+  return home
+}
+
+function seededNvmDir(homePath: string): string | undefined {
+  return getVersionManagerBinPaths({ platform: 'darwin', pathEnv: '', homePath }).find((entry) =>
+    entry.includes('.nvm')
+  )
+}
+
+describe('nvm default alias decides the seeded runtime', () => {
+  it('seeds the default version, not the newest install (#10932)', () => {
+    // The exact shape that broke: `nvm install 26` adds a bare newest version
+    // while every CLI lives under the default.
+    const home = makeNvmHome({
+      versions: ['v24.18.0', 'v26.7.0'],
+      defaultAlias: '24',
+      cliIn: 'v24.18.0'
+    })
+    expect(seededNvmDir(home)).toBe(join(home, '.nvm', 'versions', 'node', 'v24.18.0', 'bin'))
+  })
+
+  it('resolves a partial default to the highest matching install', () => {
+    const home = makeNvmHome({
+      versions: ['v24.9.0', 'v24.18.0', 'v26.7.0'],
+      defaultAlias: '24',
+      cliIn: 'v24.18.0'
+    })
+    expect(seededNvmDir(home)).toBe(join(home, '.nvm', 'versions', 'node', 'v24.18.0', 'bin'))
+  })
+
+  it('follows an alias chain (default -> lts/* -> lts/krypton -> version)', () => {
+    const home = makeNvmHome({
+      versions: ['v22.9.0', 'v26.7.0'],
+      defaultAlias: 'lts/*',
+      aliases: { 'lts/*': 'lts/krypton', 'lts/krypton': 'v22.9.0' },
+      cliIn: 'v22.9.0'
+    })
+    expect(seededNvmDir(home)).toBe(join(home, '.nvm', 'versions', 'node', 'v22.9.0', 'bin'))
+  })
+
+  it('falls back to newest when there is no default alias', () => {
+    const home = makeNvmHome({ versions: ['v24.18.0', 'v26.7.0'] })
+    expect(seededNvmDir(home)).toBe(join(home, '.nvm', 'versions', 'node', 'v26.7.0', 'bin'))
+  })
+
+  it('falls back to newest when the default names an uninstalled version', () => {
+    const home = makeNvmHome({ versions: ['v24.18.0', 'v26.7.0'], defaultAlias: '18' })
+    expect(seededNvmDir(home)).toBe(join(home, '.nvm', 'versions', 'node', 'v26.7.0', 'bin'))
+  })
+
+  it('survives a cyclic alias chain instead of hanging', () => {
+    const home = makeNvmHome({
+      versions: ['v24.18.0', 'v26.7.0'],
+      defaultAlias: 'a',
+      aliases: { a: 'b', b: 'a' }
+    })
+    expect(seededNvmDir(home)).toBe(join(home, '.nvm', 'versions', 'node', 'v26.7.0', 'bin'))
+  })
+
+  it('ignores a `system` default, which means no nvm node at all', () => {
+    const home = makeNvmHome({ versions: ['v24.18.0', 'v26.7.0'], defaultAlias: 'system' })
+    expect(seededNvmDir(home)).toBe(join(home, '.nvm', 'versions', 'node', 'v26.7.0', 'bin'))
+  })
+
+  it('still finds a CLI that lives outside the default version', () => {
+    // Ordering must be a preference, not a restriction: the other versions stay
+    // as fallbacks so a CLI installed elsewhere is still reachable.
+    const home = makeNvmHome({
+      versions: ['v24.18.0', 'v26.7.0'],
+      defaultAlias: '24',
+      cliIn: 'v26.7.0'
+    })
+    expect(resolveCliCommand('codex', { platform: 'darwin', pathEnv: '', homePath: home })).toBe(
+      join(home, '.nvm', 'versions', 'node', 'v26.7.0', 'bin', 'codex')
+    )
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​159 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​158 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​123 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​15 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​108 |

<!-- /orca-pr-loc -->

Fixes #10932 (reopened — the earlier PR closed it without addressing the policy defect).

## ELI5

nvm lets you mark one Node version as your `default`. Your CLIs are installed under it.

When Orca can't work out your real PATH in time, it guesses — and it was guessing the **newest** version you have installed. That's the worst possible guess: the newest version is usually the one you just added and haven't installed anything into. So Orca would run with an empty Node version and every CLI would vanish.

Now it guesses your `default`, which is where your CLIs actually are.

## Why this still mattered after #16314 and #16365

#16314 stopped the login-shell probe from *inheriting* the seed. But the seed itself still picked newest, and the seed decides everything whenever the probe doesn't land.

I assumed that was a rare fallback. An end-to-end reproduction showed it isn't:

```
[shell-path] login-shell probe failed (timeout); using seeded PATH
```

A `bash -ilc` loading nvm, rvm, conda and gcloud measures **~1s idle but 6-7s on a loaded machine**, against a 5s budget. A cold start under load lands on the seed — and with `nvm install 26` leaving a bare v26.7.0 while `default` is 24, the seeded dir has no CLIs at all. That is #10932's original symptom, reproduced on current `main`.

## The fix

Resolve `alias/default` the way nvm does:

- **Alias chains** — `default` → `lts/*` → `lts/krypton` → a version. Real: `alias/lts/*` literally contains `lts/krypton`.
- **Partial versions** — `default` commonly holds `24`, not `v24.18.0`. Resolves to the highest matching install.
- **`system` / `node` / `stable`** — no preference; newest-first ordering stands.
- **Bounded and cycle-guarded** — nvm's own resolver tracks seen aliases, and hand-edited files can point at each other.
- **A traversal guard** on the alias token, which is interpolated into a path.

Ordering is a **preference, not a restriction**: remaining versions stay behind the default, so a CLI installed outside it is still reachable (pinned by a test).

Other version managers need no equivalent — volta, asdf, fnm and mise all seed stable, non-version-pinned directories. Only nvm encodes a version in the path.

## Probe budget: 5s → 10s

The old value was never measured against a real profile. With the seed now correct a timeout is survivable rather than breaking, but 5s is simply too tight — measured overruns above. Startup doesn't block on the probe (`index.ts` fires and forgets); the one awaited consumer is agent detection, better served by a probe that finishes late than one that gives up early. The existing timeout test was updated and still pins the budget — raising it to 30s makes that test fail.

## Verification

**Tests written first, and verified to fail before the fix existed.** Against `main`, the harness fails exactly the three bug cases (default-vs-newest, partial version, alias chain) and passes the five safety cases (no default, uninstalled default, cyclic alias, `system`, CLI-outside-default). All 8 pass after.

Measured on a real machine with `default=24` and a bare `v26.7.0` installed:

| resolver | seeds |
|---|---|
| current `main` | `v26.7.0/bin` — no CLIs |
| this PR | `v24.18.0/bin` — every CLI |

`pnpm typecheck` clean, `oxlint` clean, 7310 tests pass across `shared`, `startup`, `codex-cli`, `rate-limits`, `cli`. `remote-runtime-client` and `setup-agent-sequencing` flake under parallel load on `main` too — confirmed by repeat runs on both sides.