### PR TITLE
fix(tabs): include open files in all-types cycling

### DIFF
--- a/src/renderer/src/components/tab-bar/group-tab-order.test.ts
+++ b/src/renderer/src/components/tab-bar/group-tab-order.test.ts
@@ -91,6 +91,32 @@ describe('getGroupVisibleTabOrder', () => {
     ])
   })
 
+  it('appends live group tabs missing from tabOrder and excludes stale ids (regression: #16389)', () => {
+    const group: TabGroup = {
+      id: 'g1',
+      worktreeId: 'wt',
+      activeTabId: 'tab-t1',
+      tabOrder: ['tab-t1', 'tab-phantom']
+    }
+    const tabs: Tab[] = [
+      terminalTab('tab-t1', 'g1', 'term-1', 0),
+      editorTab('tab-e1', 'g1', '/repo/file.md', 1)
+    ]
+
+    expect(
+      getGroupVisibleTabOrder(
+        group,
+        tabs,
+        new Set(['term-1']),
+        new Set(['/repo/file.md']),
+        new Set()
+      )
+    ).toEqual([
+      { type: 'terminal', id: 'term-1', tabId: 'tab-t1' },
+      { type: 'editor', id: '/repo/file.md', tabId: 'tab-e1' }
+    ])
+  })
+
   it('walks tabs in the reordered group.tabOrder sequence (regression: drag-reordered tabs)', () => {
     // Original visual order was [term-1, term-2, term-3]; user dragged
     // term-1 to the end so tabOrder is now [tab-t2, tab-t3, tab-t1]. The

--- a/src/renderer/src/components/tab-bar/group-tab-order.ts
+++ b/src/renderer/src/components/tab-bar/group-tab-order.ts
@@ -32,13 +32,9 @@ export type ActiveTabNavOrderIds = {
  * unified tab id for exact split-group selection. That keeps both code paths
  * on the same order without collapsing the identifier domains.
  *
- * Note: TabBar's reconciler appends entities present in state but missing
- * from `group.tabOrder` (an invariant-repair fallback). This helper
- * intentionally does not mirror that append — appending silently would
- * reintroduce the class of order-drift this change fixes. In practice
- * `group.tabOrder` is kept in sync on tab create/close, so the divergence
- * only matters during hydration races and is preferable to cycling tabs
- * in a phantom order.
+ * Note: mirror TabBar's reconciler so stale order entries are dropped and
+ * live group tabs missing from `group.tabOrder` are appended in the same
+ * per-type natural order as the rendered strip.
  *
  * Scope is intentionally per-group: with split layouts each group has its
  * own tab strip, and users expect the shortcut to cycle within the strip
@@ -55,7 +51,42 @@ export function getGroupVisibleTabOrder(
   browserEntityIds: ReadonlySet<string>,
   simulatorTabIds: ReadonlySet<string> = new Set()
 ): VisibleTabRef[] {
-  const tabsById = new Map(groupTabs.map((t) => [t.id, t]))
+  const tabsById = new Map<string, Tab>()
+  const terminalTabIds: string[] = []
+  const editorTabIds: string[] = []
+  const browserTabIds: string[] = []
+  const liveSimulatorTabIds: string[] = []
+  for (const tab of groupTabs) {
+    if (tab.contentType === 'terminal') {
+      if (!terminalEntityIds.has(tab.entityId)) {
+        continue
+      }
+      terminalTabIds.push(tab.id)
+    } else if (tab.contentType === 'browser') {
+      if (!browserEntityIds.has(tab.entityId)) {
+        continue
+      }
+      browserTabIds.push(tab.id)
+    } else if (tab.contentType === 'simulator') {
+      if (!simulatorTabIds.has(tab.id)) {
+        continue
+      }
+      liveSimulatorTabIds.push(tab.id)
+    } else {
+      if (!editorEntityIds.has(tab.entityId)) {
+        continue
+      }
+      editorTabIds.push(tab.id)
+    }
+    tabsById.set(tab.id, tab)
+  }
+  const orderedTabIds = reconcileTabOrder(
+    group.tabOrder,
+    terminalTabIds,
+    editorTabIds,
+    browserTabIds,
+    liveSimulatorTabIds
+  )
   const result: VisibleTabRef[] = []
   // Dedupe per category: terminal/browser key by entityId (multiple tabs
   // can theoretically point at the same runtime entity), editor keys by
@@ -65,7 +96,7 @@ export function getGroupVisibleTabOrder(
   const seenBrowsers = new Set<string>()
   const seenEditors = new Set<string>()
   const seenSimulators = new Set<string>()
-  for (const unifiedId of group.tabOrder) {
+  for (const unifiedId of orderedTabIds) {
     const tab = tabsById.get(unifiedId)
     if (!tab) {
       continue

--- a/src/renderer/src/components/tab-bar/recent-tab-switching.test.ts
+++ b/src/renderer/src/components/tab-bar/recent-tab-switching.test.ts
@@ -28,7 +28,8 @@ function tab(id: string, entityId: string, label: string): Tab {
 function stateWithTabs(
   tabOrder: string[],
   recentTabIds: string[],
-  activeTabId: string
+  activeTabId: string,
+  liveTabIds: string[] = ['tab-a', 'tab-b', 'tab-c']
 ): Pick<
   AppState,
   | 'activeBrowserTabId'
@@ -47,7 +48,7 @@ function stateWithTabs(
     tab('tab-a', 'file-a', 'A'),
     tab('tab-b', 'file-b', 'B'),
     tab('tab-c', 'file-c', 'C')
-  ]
+  ].filter((entry) => liveTabIds.includes(entry.id))
   return {
     activeBrowserTabId: null,
     activeFileId: tabs.find((entry) => entry.id === activeTabId)?.entityId ?? null,
@@ -103,7 +104,7 @@ describe('buildRecentTabSwitcherModel', () => {
 
   it('returns null when there is no other tab to switch to', () => {
     const model = buildRecentTabSwitcherModel(
-      stateWithTabs(['tab-a'], ['tab-a'], 'tab-a'),
+      stateWithTabs(['tab-a'], ['tab-a'], 'tab-a', ['tab-a']),
       WT,
       'mru'
     )

--- a/src/renderer/src/hooks/ipc-tab-switch.test.ts
+++ b/src/renderer/src/hooks/ipc-tab-switch.test.ts
@@ -370,3 +370,77 @@ describe('handleSwitchRecentTab', () => {
     expect(store.setActiveTabType).not.toHaveBeenCalled()
   })
 })
+
+describe('reconciled group navigation composition', () => {
+  it('cycles an omitted live editor across all types but not within terminal type (#16389)', async () => {
+    vi.resetModules()
+    vi.doUnmock('@/components/tab-bar/group-tab-order')
+    const tabSwitch = await import('./ipc-tab-switch')
+    const { getActiveTabNavOrder } = await import('@/components/tab-bar/group-tab-order')
+    const group = {
+      id: 'group-1',
+      worktreeId: 'wt-1',
+      activeTabId: 'tab-term-2',
+      tabOrder: ['tab-term-1', 'tab-term-2']
+    }
+    const store = {
+      ...makeStore('terminal', {
+        activeTabId: 'term-2',
+        activeFileId: '/repo/omitted.md',
+        groupsByWorktree: { 'wt-1': [group] }
+      }),
+      unifiedTabsByWorktree: {
+        'wt-1': [
+          {
+            id: 'tab-term-1',
+            entityId: 'term-1',
+            groupId: 'group-1',
+            contentType: 'terminal'
+          },
+          {
+            id: 'tab-editor',
+            entityId: '/repo/omitted.md',
+            groupId: 'group-1',
+            contentType: 'editor'
+          },
+          {
+            id: 'tab-term-2',
+            entityId: 'term-2',
+            groupId: 'group-1',
+            contentType: 'terminal'
+          }
+        ]
+      },
+      tabBarOrderByWorktree: { 'wt-1': [] },
+      tabsByWorktree: { 'wt-1': [{ id: 'term-1' }, { id: 'term-2' }] },
+      openFiles: [{ id: '/repo/omitted.md', worktreeId: 'wt-1' }],
+      browserTabsByWorktree: {}
+    }
+    getStateMock.mockReturnValue(store)
+
+    expect(vi.isMockFunction(getActiveTabNavOrder)).toBe(false)
+    expect(getActiveTabNavOrder(store as never, 'wt-1')).toEqual([
+      { type: 'terminal', id: 'term-1', tabId: 'tab-term-1' },
+      { type: 'terminal', id: 'term-2', tabId: 'tab-term-2' },
+      { type: 'editor', id: '/repo/omitted.md', tabId: 'tab-editor' }
+    ])
+    expect(tabSwitch.handleSwitchTabAcrossAllTypes(1)).toBe(true)
+    expect(store.setActiveFile).toHaveBeenCalledWith('/repo/omitted.md')
+    expect(store.activateTab).toHaveBeenCalledWith('tab-editor')
+
+    vi.clearAllMocks()
+    store.activeTabId = 'term-1'
+    group.activeTabId = 'tab-term-1'
+    getStateMock.mockReturnValue(store)
+    expect(tabSwitch.handleSwitchTabAcrossAllTypes(-1)).toBe(true)
+    expect(store.setActiveFile).toHaveBeenCalledWith('/repo/omitted.md')
+    expect(store.activateTab).toHaveBeenCalledWith('tab-editor')
+
+    vi.clearAllMocks()
+    getStateMock.mockReturnValue(store)
+    expect(tabSwitch.handleSwitchTab(1)).toBe(true)
+    expect(store.setActiveTab).toHaveBeenCalledWith('term-2')
+    expect(store.setActiveFile).not.toHaveBeenCalled()
+    expect(store.activateTab).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## ELI5

The tab bar could visibly recover an open file when its saved tab order was stale, but keyboard navigation used the stale list directly. The file stayed clickable while the all-types shortcuts could not reach it. Keyboard cycling now uses the same live visible-tab reconciliation as the tab bar.

## What Changed

- Reconcile active-group keyboard navigation order with all live, backed tabs visible in the tab bar.
- Preserve canonical drag order, split-tab identity, stale-entry filtering, and per-type activation semantics.
- Add regression coverage for missing editor tabs, forward and reverse all-types cycling, same-type isolation, and recent-tab single-item behavior.

## Why

`tab.nextAllTypes` and `tab.previousAllTypes` already routed correctly. The defect was downstream: `getGroupVisibleTabOrder` intentionally omitted live tabs missing from `group.tabOrder`, while the rendered `TabBar` appended those tabs. Sharing the reconciliation contract fixes the source mismatch without changing keybindings or adding special cases.

## Linked Issue

Fixes #16389

## Visual Proof

N/A — no visual or layout pixels change. This is keyboard-only tab activation behavior; the before/after contract is covered by real-module composition tests for both navigation directions.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Verified locally:

- `pnpm lint` — passed
- `pnpm typecheck` — passed
- Focused Vitest suite — 45/45 passed
- `pnpm build:desktop` — passed
- General Vitest suite excluding the repository's isolated `#13767` real-shell lane — 6,255 files passed; one resource-sensitive relay test timed out under full parallel load and passed 31/31 when rerun alone

Environment notes:

- The repository requires Node 24; this workstation exposed Node 26.7.0.
- The two `#13767` real-shell cases also timed out when isolated locally and are already excluded from general CI shards in favor of their Node 24 real-shell lane.
- Full `pnpm build` completed the desktop build, then the unrelated macOS native universal step failed because Swift emitted neither expected `lipo` input path. `pnpm build:desktop` passed.

Platforms actually exercised: macOS. No platform-specific shortcut matching, execution-host, SSH, path, or wire code changed.

## AI Disclosure

OpenAI Codex (GPT-5.6-sol) was used for repository analysis, implementation, regression tests, adversarial review, and PR preparation.

## Review

- Correctness: traced DOM, browser-guest IPC, floating-workspace, selector, cycle, and activation paths. The routing was correct; the visible inventory source was inconsistent.
- Adversarial review: two independent reviews challenged render/cycle equivalence, direction coverage, split identity, stale entries, duplicate identities, transient tabs, floating routing, and simulator behavior. Issue-specific coverage was strengthened; pre-existing unrelated identity and floating-path concerns were excluded to keep this PR focused.
- Cross-platform: platform-neutral state reconciliation only; keybindings and modifier handling are unchanged.
- SSH/remote/local: renderer-local tab inventory only; no RPC, execution-host, filesystem, or remote-wire contract changed.
- Agent/integration/provider compatibility: unaffected.
- Performance: linear reconciliation over the active group's small tab list on shortcut invocation; no render-loop work added.
- Security: no new input, I/O, process, credential, or network surface.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Author: GitHub `@hanbong5938`. X handle not provided.

Security, cross-platform support, remote SSH, mobile, backward compatibility, and performance were reviewed. The change is renderer-only and does not affect mobile or remote execution contracts.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
