### PR TITLE
orchestration: launch argv-capable worker agents with the dispatch preamble embedded, instead of paste + 5s submission verification

### DIFF
--- a/src/main/pty/posix-pty-process-groups.test.ts
+++ b/src/main/pty/posix-pty-process-groups.test.ts
@@ -99,6 +99,96 @@ describe('POSIX PTY process-group termination', () => {
     expect(fallback).toHaveBeenCalledOnce()
     expect(readProcessTable).not.toHaveBeenCalled()
   })
+
+  // Measured 2026-09-02 on a loaded Mac (17 agent sessions, a test gate running): the TTY-scoped
+  // `ps` timed out, so the only kill that reached the pane was the leader-only fallback. The
+  // `login` leader died, its `zsh -l` and the agent underneath survived with no controlling TTY,
+  // and each survivor kept an orchestration long-poll open until the runtime's 16-slot cap was
+  // full. The descendant tree needs no TTY to prove ownership: everything under the leader is the
+  // pane's, so it is the strategy that runs when the TTY read cannot.
+  describe('descendant-tree strategy', () => {
+    const TREE = `
+      100    1  100
+      101  100  101
+      102  101  102
+      103  102  103
+      104  101  101
+      200    1  200
+      999    1  999
+    `
+
+    it('kills every group under the leader when the TTY read fails, leader group last', () => {
+      const fallback = vi.fn()
+      const signalProcessGroup = vi.fn()
+
+      forceKillPosixPtyProcessGroups(100, fallback, {
+        platform: 'darwin',
+        currentPid: 999,
+        readProcessTable: () => {
+          throw new Error('ps timed out')
+        },
+        readDescendantTable: () => TREE,
+        signalProcessGroup
+      })
+
+      expect(signalProcessGroup.mock.calls.map(([pgid]) => pgid)).toEqual([101, 102, 103, 100])
+      expect(fallback).not.toHaveBeenCalled()
+    })
+
+    it('never group-signals a tree that contains Orca itself', () => {
+      const fallback = vi.fn()
+      const signalProcessGroup = vi.fn()
+
+      forceKillPosixPtyProcessGroups(100, fallback, {
+        platform: 'darwin',
+        currentPid: 103,
+        readProcessTable: () => {
+          throw new Error('ps timed out')
+        },
+        readDescendantTable: () => TREE,
+        signalProcessGroup
+      })
+
+      expect(signalProcessGroup).not.toHaveBeenCalled()
+      expect(fallback).toHaveBeenCalledOnce()
+    })
+
+    it('falls back only when neither table proves what the leader owns', () => {
+      const fallback = vi.fn()
+      const signalProcessGroup = vi.fn()
+
+      forceKillPosixPtyProcessGroups(100, fallback, {
+        platform: 'darwin',
+        currentPid: 999,
+        readProcessTable: () => {
+          throw new Error('ps timed out')
+        },
+        readDescendantTable: () => `
+          200    1  200
+        `,
+        signalProcessGroup
+      })
+
+      expect(signalProcessGroup).not.toHaveBeenCalled()
+      expect(fallback).toHaveBeenCalledOnce()
+    })
+
+    it('prefers the TTY table when it answers, so the proven path is unchanged', () => {
+      const readDescendantTable = vi.fn(() => TREE)
+      const signalProcessGroup = vi.fn()
+
+      forceKillPosixPtyProcessGroups(100, vi.fn(), {
+        platform: 'darwin',
+        currentPid: 999,
+        readProcessTable: () => TABLE,
+        readDescendantTable,
+        signalProcessGroup
+      })
+
+      expect(readDescendantTable).not.toHaveBeenCalled()
+      expect(signalProcessGroup.mock.calls.map(([pgid]) => pgid)).toEqual([101, 103, 100])
+    })
+  })
 })
 
 describe('POSIX PTY group-sweep breadcrumbs', () => {

--- a/src/main/pty/posix-pty-process-groups.ts
+++ b/src/main/pty/posix-pty-process-groups.ts
@@ -2,6 +2,9 @@ import { execFileSync } from 'node:child_process'
 import { recordSelfInitiatedTreeKill } from '../crash-reporting/self-initiated-tree-kill-log'
 
 const PROCESS_TABLE_TIMEOUT_MS = 1_000
+// Why: the whole-host read runs only after the TTY-scoped one failed, and it is the last thing
+// standing between a closed pane and a surviving agent process, so it gets the longer budget.
+const DESCENDANT_TABLE_TIMEOUT_MS = 3_000
 const PROCESS_TABLE_MAX_BYTES = 1024 * 1024
 
 type ProcessRow = {
@@ -10,17 +13,24 @@ type ProcessRow = {
   tty: string
 }
 
+type DescendantRow = {
+  pid: number
+  ppid: number
+  pgid: number
+}
+
 export type PosixPtyProcessGroupTerminationDeps = {
   platform?: NodeJS.Platform
   currentPid?: number
   readProcessTable?: () => string
+  readDescendantTable?: () => string
   signalProcessGroup?: (pgid: number) => void
 }
 
-function runPs(args: string[]): string {
+function runPs(args: string[], timeout = PROCESS_TABLE_TIMEOUT_MS): string {
   return execFileSync('ps', args, {
     encoding: 'utf8',
-    timeout: PROCESS_TABLE_TIMEOUT_MS,
+    timeout,
     maxBuffer: PROCESS_TABLE_MAX_BYTES
   })
 }
@@ -82,6 +92,52 @@ export function getPosixPtyProcessGroups(
   })
 }
 
+/**
+ * Every process group under one PTY leader, proven by parentage instead of TTY: the leader's
+ * own group last, so its children are dead before it is. Null when the leader is absent from the
+ * table or when Orca itself sits in the tree — never group-signal a group Orca belongs to.
+ */
+export function getPosixDescendantProcessGroups(
+  output: string,
+  rootPid: number,
+  currentPid = process.pid
+): number[] | null {
+  const rows: DescendantRow[] = []
+  for (const line of output.split(/\r?\n/)) {
+    const match = /^\s*(\d+)\s+(\d+)\s+(\d+)/.exec(line)
+    if (match) {
+      rows.push({ pid: Number(match[1]), ppid: Number(match[2]), pgid: Number(match[3]) })
+    }
+  }
+  const root = rows.find((row) => row.pid === rootPid)
+  if (!root || root.pgid <= 1) {
+    return null
+  }
+  const childrenByParent = new Map<number, DescendantRow[]>()
+  for (const row of rows) {
+    const siblings = childrenByParent.get(row.ppid)
+    if (siblings) {
+      siblings.push(row)
+    } else {
+      childrenByParent.set(row.ppid, [row])
+    }
+  }
+  const tree = [root]
+  for (let index = 0; index < tree.length; index++) {
+    for (const child of childrenByParent.get(tree[index].pid) ?? []) {
+      if (!tree.includes(child)) {
+        tree.push(child)
+      }
+    }
+  }
+  if (tree.some((row) => row.pid === currentPid)) {
+    return null
+  }
+  const groups = new Set(tree.filter((row) => row.pgid > 1).map((row) => row.pgid))
+  groups.delete(root.pgid)
+  return [...groups].sort((left, right) => left - right).concat(root.pgid)
+}
+
 function isProcessAlreadyGone(error: unknown): boolean {
   return (error as NodeJS.ErrnoException | undefined)?.code === 'ESRCH'
 }
@@ -96,6 +152,12 @@ export function forceKillPosixPtyProcessGroups(
     fallback()
     return
   }
+  // Why: the TTY-scoped table is the proven path — one `ps -t`, proportional to one terminal.
+  // When it cannot answer (a `ps` that timed out under load, a leader already off its TTY), the
+  // leader's descendant tree still proves ownership by parentage. Measured 2026-09-02 on a Mac
+  // running 17 agent sessions: the TTY read failed, the leader-only fallback killed `login` and
+  // left its `zsh -l` and the agent underneath alive with no controlling TTY, and each survivor
+  // held an orchestration long-poll until the runtime's cap was full.
   let groups: number[] | null
   try {
     groups = getPosixPtyProcessGroups(
@@ -105,6 +167,20 @@ export function forceKillPosixPtyProcessGroups(
     )
   } catch {
     groups = null
+  }
+  if (!groups || groups.length === 0) {
+    try {
+      groups = getPosixDescendantProcessGroups(
+        (
+          deps.readDescendantTable ??
+          (() => runPs(['-axo', 'pid=,ppid=,pgid='], DESCENDANT_TABLE_TIMEOUT_MS))
+        )(),
+        rootPid,
+        deps.currentPid ?? process.pid
+      )
+    } catch {
+      groups = null
+    }
   }
   if (!groups || groups.length === 0) {
     fallback()

--- a/src/main/runtime/orca-runtime-core.ts
+++ b/src/main/runtime/orca-runtime-core.ts
@@ -78,6 +78,11 @@ export const MOBILE_TERMINAL_SURFACE_TIMEOUT_MS = 10_000
 export const REJECTED_SPLIT_PTY_STOP_TIMEOUT_MS = 2_000
 
 export const EXPLICIT_TERMINAL_CLOSE_STOP_TIMEOUT_MS = 2_000
+// Why: a stop that misses the first deadline is usually late, not stuck — `ps` under load, a
+// shell still tearing down its jobs — and a second bounded attempt turns it into a confirmed
+// kill instead of an unverifiable one. Measured 2026-09-02: the fire-and-forget follow-up left
+// agent processes alive for hours behind a `ptyKilled: false` receipt.
+export const EXPLICIT_TERMINAL_CLOSE_RETRY_TIMEOUT_MS = 3_000
 
 export const CLAUDE_AGENT_PROMPT_RENDER_TIMEOUT_MS = 8000
 

--- a/src/main/runtime/orca-runtime-get-orchestration-dispatch-authority.ts
+++ b/src/main/runtime/orca-runtime-get-orchestration-dispatch-authority.ts
@@ -208,4 +208,18 @@ export class OrcaRuntimeWithGetOrchestrationDispatchAuthority extends OrcaRuntim
         : undefined
     })
   }
+
+  // Why: argv-injected prompts are built BEFORE a terminal exists, so the CLI
+  // name must come from the target workspace rather than a pane handle. This
+  // preserves `orca-ide` for WSL worktrees and bare `orca` for SSH/native.
+  async getWorktreeOrchestrationCliCommand(worktreeId: string): Promise<'orca' | 'orca-ide'> {
+    const workspace = await this.resolveTerminalWorkspaceLaunchScope(`id:${worktreeId}`)
+    return resolveTerminalOrchestrationCliCommand({
+      connectionId: workspace.connectionId,
+      isWsl: null,
+      worktreeId: workspace.id,
+      worktreePath: workspace.path,
+      projectRuntime: this.resolveProjectRuntimeForWorktree(workspace.id)
+    })
+  }
 }

--- a/src/main/runtime/orca-runtime-resolve-worktree-removal-target.ts
+++ b/src/main/runtime/orca-runtime-resolve-worktree-removal-target.ts
@@ -200,7 +200,7 @@ export class OrcaRuntimeWithResolveWorktreeRemovalTarget extends OrcaRuntimeWith
     const sessionOptions = this.toAgentSessionOptions(opts.launchPreferences)
     const startupPlan = buildAgentStartupPlan({
       agent,
-      prompt: '',
+      prompt: opts.agentPrompt ?? '',
       cmdOverrides: settings.agentCmdOverrides ?? {},
       agentArgs: resolveTuiAgentLaunchArgs(agent, settings.agentDefaultArgs),
       agentEnv: resolveTuiAgentLaunchEnv(agent, settings.agentDefaultEnv),
@@ -218,6 +218,13 @@ export class OrcaRuntimeWithResolveWorktreeRemovalTarget extends OrcaRuntimeWith
         throw new Error(`Could not build launch command for ${opts.startupAgent}.`)
       }
       return opts
+    }
+    // Why: a deferred followupPrompt means the plan could NOT embed the prompt
+    // in the launch and expects a post-start paste — exactly the submission
+    // race agentPrompt exists to avoid. Refuse loudly instead of silently
+    // degrading to the paste path.
+    if (opts.agentPrompt && startupPlan.followupPrompt) {
+      throw new Error(`Agent ${agent} cannot embed a startup prompt in its launch command.`)
     }
 
     await this.markWorkspaceTrustedForAgent(agent, workspace.connectionId, workspace.path)

--- a/src/main/runtime/orca-runtime-stop-explicitly-closed-tab-ptys.ts
+++ b/src/main/runtime/orca-runtime-stop-explicitly-closed-tab-ptys.ts
@@ -1,6 +1,9 @@
 // @ts-nocheck -- mechanically split from OrcaRuntimeService; behavior is covered by AST equivalence and characterization tests.
 import { OrcaRuntimeWithFocusTerminal } from './orca-runtime-focus-terminal'
-import { EXPLICIT_TERMINAL_CLOSE_STOP_TIMEOUT_MS } from './orca-runtime-core'
+import {
+  EXPLICIT_TERMINAL_CLOSE_RETRY_TIMEOUT_MS,
+  EXPLICIT_TERMINAL_CLOSE_STOP_TIMEOUT_MS
+} from './orca-runtime-core'
 import { SSH_PROVIDER_UNREGISTERED_REASON } from '../../shared/pty-liveness-verdict'
 import type { RuntimeTerminalClose } from '../../shared/runtime-types'
 import { countTerminalLayoutLeaves } from './headless-terminal-split-layout'
@@ -31,8 +34,24 @@ export class OrcaRuntimeWithStopExplicitlyClosedTabPtys extends OrcaRuntimeWithF
             verdict?.status === 'unverifiable' &&
             verdict.reason === SSH_PROVIDER_UNREGISTERED_REASON
           if (!providerAlreadyRetiredPty) {
+            // Why: one more exact, verified attempt under its own deadline before the
+            // fire-and-forget follow-up. The first miss is rarely a process that will not die;
+            // it is a `ps` or a shell teardown that took longer than 2 s.
+            try {
+              stopped = await this.ptyController.stopAndWait(ptyId, {
+                deadlineMs: Date.now() + EXPLICIT_TERMINAL_CLOSE_RETRY_TIMEOUT_MS
+              })
+            } catch (error) {
+              this.markPtyLivenessUnverifiable(
+                ptyId,
+                error instanceof Error ? error.message : String(error)
+              )
+            }
+          }
+          if (!stopped && !providerAlreadyRetiredPty) {
+            const retried = this.getPtyLivenessVerdict(ptyId)
             this.ptyController.kill(ptyId)
-            if (!verdict || verdict.status === 'live') {
+            if (!retried || retried.status === 'live') {
               this.markPtyLivenessUnverifiable(
                 ptyId,
                 'a follow-up stop was issued but its outcome could not be verified'

--- a/src/main/runtime/orca-runtime-terminal-close-continuity.test.ts
+++ b/src/main/runtime/orca-runtime-terminal-close-continuity.test.ts
@@ -366,6 +366,35 @@ describe('terminal close and handle incarnation continuity', () => {
     expect(harness.kill).toHaveBeenCalledWith(PTY_ID)
   })
 
+  it('retries an unconfirmed stop once, bounded, before issuing the unverified follow-up', async () => {
+    // Measured 2026-09-02 on a loaded Mac: the first exact stop missed its 2 s deadline while
+    // `ps` was slow, the follow-up was fire-and-forget, and the receipt read `ptyKilled: false`
+    // for a pane whose agent then outlived the tab by hours. A second bounded attempt is
+    // cheap, and it turns a late stop into a confirmed one instead of an unverifiable one.
+    const harness = createHarness()
+    const [{ handle }] = (await harness.runtime.listTerminals(`id:${WORKTREE_ID}`)).terminals
+    let attempts = 0
+    harness.setVerifiedStopResult(false)
+    harness.setStopAndWaitAction(() => {
+      attempts += 1
+      if (attempts === 2) {
+        harness.setVerifiedStopResult(true)
+      }
+    })
+
+    const closing = harness.runtime.closeTerminal(handle)
+    await vi.waitFor(() => expect(harness.closeTerminalTab).toHaveBeenCalled())
+    harness.retirePersistedTab()
+    harness.acknowledged.resolve()
+
+    const close = await closing
+    expect(close.ptyKilled).toBe(true)
+    expect(close.ptyStopVerdict).toBeUndefined()
+    expect(harness.stopAndWait).toHaveBeenCalledTimes(2)
+    expect(harness.stopAndWait.mock.calls[1]).toEqual([PTY_ID, { deadlineMs: expect.any(Number) }])
+    expect(harness.kill).not.toHaveBeenCalled()
+  })
+
   it('leaves a confirmed kill receipt free of any stop verdict', async () => {
     const harness = createHarness()
     const [{ handle }] = (await harness.runtime.listTerminals(`id:${WORKTREE_ID}`)).terminals

--- a/src/main/runtime/orchestration/cli-command.test.ts
+++ b/src/main/runtime/orchestration/cli-command.test.ts
@@ -38,6 +38,14 @@ describe('resolveTerminalOrchestrationCliCommand', () => {
         worktreeId: 'repo::\\\\wsl.localhost\\Ubuntu\\home\\alice\\repo'
       })
     ).toBe('orca-ide')
+    expect(
+      resolveTerminalOrchestrationCliCommand({
+        connectionId: null,
+        isWsl: null,
+        worktreeId: 'folder:workspace-1',
+        worktreePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\repo'
+      })
+    ).toBe('orca-ide')
   })
 
   it('preserves native and SSH bare-orca commands', () => {

--- a/src/main/runtime/orchestration/cli-command.ts
+++ b/src/main/runtime/orchestration/cli-command.ts
@@ -8,6 +8,10 @@ export function resolveTerminalOrchestrationCliCommand(args: {
   connectionId: string | null
   isWsl: boolean | null | undefined
   worktreeId: string
+  // Why: pre-spawn callers know the resolved workspace path but may not have
+  // a repo-shaped worktree id (folder workspaces use opaque ids). Prefer this
+  // explicit fact over decoding the id.
+  worktreePath?: string
   projectRuntime?: ProjectExecutionRuntimeResolution
 }): OrchestrationCliCommand {
   if (args.connectionId) {
@@ -20,6 +24,7 @@ export function resolveTerminalOrchestrationCliCommand(args: {
     return 'orca-ide'
   }
 
-  const worktreePath = splitWorktreeIdForFilesystem(args.worktreeId)?.worktreePath
+  const worktreePath =
+    args.worktreePath ?? splitWorktreeIdForFilesystem(args.worktreeId)?.worktreePath
   return worktreePath && isWslUncPath(worktreePath) ? 'orca-ide' : 'orca'
 }

--- a/src/main/runtime/orchestration/db/attach-orchestration-db-methods.ts
+++ b/src/main/runtime/orchestration/db/attach-orchestration-db-methods.ts
@@ -48,6 +48,7 @@ import { attachTaskStore } from './tasks/task-store'
 import { attachTaskStatusTransition } from './tasks/task-status-transition'
 import { attachFederatedWorkerStartReconcile } from './worker-dispatch/federated-worker-start-reconcile'
 import { attachWorkerDispatchAbandon } from './worker-dispatch/worker-dispatch-abandon'
+import { attachWorkerDispatchArgvAuthority } from './worker-dispatch/worker-dispatch-argv-authority'
 import { attachWorkerDispatchAuthority } from './worker-dispatch/worker-dispatch-authority'
 import { attachWorkerDispatchOutcome } from './worker-dispatch/worker-dispatch-outcome'
 import { attachWorkerDispatchStage } from './worker-dispatch/worker-dispatch-stage'
@@ -94,6 +95,7 @@ export function attachOrchestrationDbMethods(ctor: { prototype: object }): void 
   attachWorkerDispatchStart(ctor)
   attachWorkerDispatchStage(ctor)
   attachWorkerDispatchAuthority(ctor)
+  attachWorkerDispatchArgvAuthority(ctor)
   attachWorkerDispatchOutcome(ctor)
   attachFederatedWorkerStartReconcile(ctor)
   attachWorkerTerminalRecovery(ctor)

--- a/src/main/runtime/orchestration/db/orchestration-db-methods.ts
+++ b/src/main/runtime/orchestration/db/orchestration-db-methods.ts
@@ -48,6 +48,7 @@ import type { TaskStoreMethods } from './tasks/task-store'
 import type { TaskStatusTransitionMethods } from './tasks/task-status-transition'
 import type { FederatedWorkerStartReconcileMethods } from './worker-dispatch/federated-worker-start-reconcile'
 import type { WorkerDispatchAbandonMethods } from './worker-dispatch/worker-dispatch-abandon'
+import type { WorkerDispatchArgvAuthorityMethods } from './worker-dispatch/worker-dispatch-argv-authority'
 import type { WorkerDispatchAuthorityMethods } from './worker-dispatch/worker-dispatch-authority'
 import type { WorkerDispatchOutcomeMethods } from './worker-dispatch/worker-dispatch-outcome'
 import type { WorkerDispatchStageMethods } from './worker-dispatch/worker-dispatch-stage'
@@ -93,6 +94,7 @@ export type OrchestrationDbMethods = CreateTablesMethods &
   WorkerDispatchStartMethods &
   WorkerDispatchStageMethods &
   WorkerDispatchAuthorityMethods &
+  WorkerDispatchArgvAuthorityMethods &
   WorkerDispatchOutcomeMethods &
   FederatedWorkerStartReconcileMethods &
   WorkerTerminalRecoveryMethods &

--- a/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-argv-authority.test.ts
+++ b/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-argv-authority.test.ts
@@ -1,0 +1,166 @@
+import { createHash } from 'node:crypto'
+import { afterEach, describe, expect, it } from 'vitest'
+import { OrchestrationDb } from '../orchestration-db'
+
+const PANE = 'tab_worker:11111111-1111-4111-8111-111111111111'
+const OTHER_PANE = 'tab_other:22222222-2222-4222-8222-222222222222'
+const INCARNATION = 'runtime:pty:1'
+const TOKEN_HASH = createHash('sha256').update('launch-token').digest('hex')
+
+describe('argv worker authority: mint before spawn, bind after', () => {
+  let db: OrchestrationDb | undefined
+
+  afterEach(() => {
+    db?.close()
+  })
+
+  function startDispatch() {
+    db = new OrchestrationDb(':memory:')
+    const task = db.createTask({ spec: 'argv worker' })
+    const started = db.createStartingWorkerDispatch({ taskId: task.id, startOptions: {} })
+    return { d: db, dispatchId: started.dispatch.id }
+  }
+
+  function bindParams(dispatchId: string, overrides?: { launchTokenHash?: string }) {
+    return {
+      dispatchId,
+      handle: 'term_worker',
+      paneKey: PANE,
+      processIncarnation: INCARNATION,
+      launchTokenHash: overrides?.launchTokenHash ?? TOKEN_HASH,
+      worktreeId: 'repo::worktree',
+      setupState: 'not_applicable',
+      effects: [{ kind: 'terminal', action: 'created', id: 'term_worker' }],
+      terminalOwnership: 'created' as const
+    }
+  }
+
+  it('mints an unbound capability that authorizes nothing until bind', () => {
+    const { d, dispatchId } = startDispatch()
+    const capability = d.mintStartingWorkerCapability({ dispatchId })
+    expect(capability).toMatch(/^dcap_/)
+    expect(d.getDispatchContextById(dispatchId)).toMatchObject({
+      status: 'pending',
+      assignee_handle: null,
+      assignee_pane_key: null,
+      process_incarnation: null
+    })
+    // Why: the whole pre-spawn mint is safe only because an unbound
+    // capability is inert — this is the invariant the argv path leans on.
+    expect(
+      d.verifyDispatchCapability({
+        dispatchId,
+        capability,
+        paneKey: PANE,
+        processIncarnation: INCARNATION
+      })
+    ).toMatchObject({ valid: false, reason: 'The caller is not the Dispatch pane.' })
+  })
+
+  it('refuses a second mint instead of silently rotating the argv-baked capability', () => {
+    const { d, dispatchId } = startDispatch()
+    d.mintStartingWorkerCapability({ dispatchId })
+    expect(() => d.mintStartingWorkerCapability({ dispatchId })).toThrow(
+      /already has a lifecycle capability/
+    )
+  })
+
+  it('refuses to mint for a dispatch that is not starting', () => {
+    const { d, dispatchId } = startDispatch()
+    d.failWorkerStart(dispatchId, 'terminal_create', 'spawn failed')
+    expect(() => d.mintStartingWorkerCapability({ dispatchId })).toThrow(/is not starting/)
+  })
+
+  it('refuses to bind when nothing was minted', () => {
+    const { d, dispatchId } = startDispatch()
+    d.commitDispatchLaunchTokenHash(dispatchId, TOKEN_HASH)
+    expect(() => d.bindStartingWorkerAuthority(bindParams(dispatchId))).toThrow(
+      /has no minted capability to bind/
+    )
+  })
+
+  it('refuses to bind a pane whose launch token does not match the commitment', () => {
+    const { d, dispatchId } = startDispatch()
+    d.commitDispatchLaunchTokenHash(dispatchId, TOKEN_HASH)
+    d.mintStartingWorkerCapability({ dispatchId })
+    const wrongHash = createHash('sha256').update('some-other-token').digest('hex')
+    expect(() =>
+      d.bindStartingWorkerAuthority(bindParams(dispatchId, { launchTokenHash: wrongHash }))
+    ).toThrow(/launch-token commitment does not match/)
+    expect(d.getDispatchContextById(dispatchId)).toMatchObject({ assignee_pane_key: null })
+  })
+
+  it('refuses to bind a pane that presents no launch token when one was committed', () => {
+    const { d, dispatchId } = startDispatch()
+    d.commitDispatchLaunchTokenHash(dispatchId, TOKEN_HASH)
+    d.mintStartingWorkerCapability({ dispatchId })
+    const params = bindParams(dispatchId)
+    const { launchTokenHash: _omitted, ...withoutToken } = params
+    expect(() => d.bindStartingWorkerAuthority(withoutToken)).toThrow(
+      /launch-token commitment does not match/
+    )
+  })
+
+  it('never resurrects a capability revoked between mint and bind', () => {
+    const { d, dispatchId } = startDispatch()
+    d.commitDispatchLaunchTokenHash(dispatchId, TOKEN_HASH)
+    d.mintStartingWorkerCapability({ dispatchId })
+    d.revokeDispatchCapability(dispatchId)
+    expect(() => d.bindStartingWorkerAuthority(bindParams(dispatchId))).toThrow(
+      /capability is revoked/
+    )
+    // Why: the atomic prepare path clears capability_revoked_at because
+    // nothing can revoke inside one transaction. Across two transactions
+    // that reset would resurrect a revocation, so bind must keep it.
+    expect(d.getDispatchContextById(dispatchId)?.capability_revoked_at).not.toBeNull()
+  })
+
+  it('binds the spawned pane and only then makes the capability valid for that exact pane', () => {
+    const { d, dispatchId } = startDispatch()
+    d.commitDispatchLaunchTokenHash(dispatchId, TOKEN_HASH)
+    const capability = d.mintStartingWorkerCapability({ dispatchId })
+    d.bindStartingWorkerAuthority(bindParams(dispatchId))
+    expect(d.getDispatchContextById(dispatchId)).toMatchObject({
+      assignee_handle: 'term_worker',
+      assignee_pane_key: PANE,
+      process_incarnation: INCARNATION,
+      launch_token_hash: TOKEN_HASH
+    })
+    expect(
+      d.verifyDispatchCapability({
+        dispatchId,
+        capability,
+        paneKey: PANE,
+        processIncarnation: INCARNATION
+      })
+    ).toEqual({ valid: true })
+    expect(
+      d.verifyDispatchCapability({
+        dispatchId,
+        capability,
+        paneKey: OTHER_PANE,
+        processIncarnation: INCARNATION
+      })
+    ).toMatchObject({ valid: false })
+    expect(d.getWorkerTerminalResourceByOwner(dispatchId)).toMatchObject({
+      terminal_handle: 'term_worker',
+      pane_key: PANE
+    })
+  })
+
+  it('refuses to bind a pane that already carries another active dispatch', () => {
+    const { d, dispatchId } = startDispatch()
+    d.commitDispatchLaunchTokenHash(dispatchId, TOKEN_HASH)
+    d.mintStartingWorkerCapability({ dispatchId })
+    d.bindStartingWorkerAuthority(bindParams(dispatchId))
+    d.markWorkerDispatchReady(dispatchId)
+
+    const rival = d.createTask({ spec: 'rival argv worker' })
+    const second = d.createStartingWorkerDispatch({ taskId: rival.id, startOptions: {} })
+    d.commitDispatchLaunchTokenHash(second.dispatch.id, TOKEN_HASH)
+    d.mintStartingWorkerCapability({ dispatchId: second.dispatch.id })
+    expect(() => d.bindStartingWorkerAuthority(bindParams(second.dispatch.id))).toThrow(
+      /already has an active dispatch/
+    )
+  })
+})

--- a/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-argv-authority.test.ts
+++ b/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-argv-authority.test.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto'
 import { afterEach, describe, expect, it } from 'vitest'
 import { OrchestrationDb } from '../orchestration-db'
+import { NESTED_WORKER_MAX_DEPTH_DEFAULT } from '../../../../../shared/nested-worker-depth'
 
 const PANE = 'tab_worker:11111111-1111-4111-8111-111111111111'
 const OTHER_PANE = 'tab_other:22222222-2222-4222-8222-222222222222'
@@ -17,7 +18,15 @@ describe('argv worker authority: mint before spawn, bind after', () => {
   function startDispatch() {
     db = new OrchestrationDb(':memory:')
     const task = db.createTask({ spec: 'argv worker' })
-    const started = db.createStartingWorkerDispatch({ taskId: task.id, startOptions: {} })
+    const started = db.createStartingWorkerDispatch({
+      taskId: task.id,
+      startOptions: {},
+      // Upstream #16668 requires every caller to decide its nesting. These cases mint a
+      // root dispatch and assert authority, not depth, so a root creator and the shipped
+      // default keep the subject unchanged.
+      creator: { kind: 'system' },
+      maxDepth: NESTED_WORKER_MAX_DEPTH_DEFAULT
+    })
     return { d: db, dispatchId: started.dispatch.id }
   }
 
@@ -77,6 +86,15 @@ describe('argv worker authority: mint before spawn, bind after', () => {
     expect(() => d.bindStartingWorkerAuthority(bindParams(dispatchId))).toThrow(
       /has no minted capability to bind/
     )
+  })
+
+  it('refuses to bind without a launch-token commitment', () => {
+    const { d, dispatchId } = startDispatch()
+    d.mintStartingWorkerCapability({ dispatchId })
+    expect(() => d.bindStartingWorkerAuthority(bindParams(dispatchId))).toThrow(
+      /launch-token commitment does not match/
+    )
+    expect(d.getDispatchContextById(dispatchId)).toMatchObject({ assignee_pane_key: null })
   })
 
   it('refuses to bind a pane whose launch token does not match the commitment', () => {
@@ -156,7 +174,15 @@ describe('argv worker authority: mint before spawn, bind after', () => {
     d.markWorkerDispatchReady(dispatchId)
 
     const rival = d.createTask({ spec: 'rival argv worker' })
-    const second = d.createStartingWorkerDispatch({ taskId: rival.id, startOptions: {} })
+    const second = d.createStartingWorkerDispatch({
+      taskId: rival.id,
+      startOptions: {},
+      // Upstream #16668 requires every caller to decide its nesting. These cases mint a
+      // root dispatch and assert authority, not depth, so a root creator and the shipped
+      // default keep the subject unchanged.
+      creator: { kind: 'system' },
+      maxDepth: NESTED_WORKER_MAX_DEPTH_DEFAULT
+    })
     d.commitDispatchLaunchTokenHash(second.dispatch.id, TOKEN_HASH)
     d.mintStartingWorkerCapability({ dispatchId: second.dispatch.id })
     expect(() => d.bindStartingWorkerAuthority(bindParams(second.dispatch.id))).toThrow(

--- a/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-argv-authority.ts
+++ b/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-argv-authority.ts
@@ -1,0 +1,222 @@
+import { randomBytes } from 'node:crypto'
+import { OrchestrationError } from '../../orchestration-error'
+import { hashDispatchCapability } from '../dispatch-capability-hash'
+import type { OrchestrationDb } from '../orchestration-db'
+
+// Why: argv-injected worker starts need the capability text BEFORE the worker
+// terminal exists — the dispatch preamble is baked into the agent's launch
+// argv, so it cannot wait for a pane. Minting is safe pre-bind because
+// verifyDispatchCapability refuses any use until assignee_pane_key and
+// process_incarnation are bound: an unbound capability authorizes nothing.
+export function mintStartingWorkerCapability(
+  this: OrchestrationDb,
+  params: { dispatchId: string }
+): string {
+  this.db.exec('BEGIN IMMEDIATE')
+  try {
+    const dispatch = this.getDispatchContextById(params.dispatchId)
+    const worker = this.getWorkerDispatch(params.dispatchId)
+    if (!dispatch || dispatch.status !== 'pending' || worker?.state !== 'starting') {
+      throw new OrchestrationError(
+        'dispatch_inactive',
+        `Dispatch ${params.dispatchId} is not starting.`
+      )
+    }
+    // Why: the plaintext is returned exactly once; a second mint could not
+    // reproduce it and would silently orphan the capability already baked
+    // into a launch argv. Refuse instead of rotating.
+    if (dispatch.capability_hash) {
+      throw new OrchestrationError(
+        'request_mismatch',
+        `Dispatch ${params.dispatchId} already has a lifecycle capability.`
+      )
+    }
+    if (dispatch.capability_revoked_at) {
+      throw new OrchestrationError(
+        'dispatch_inactive',
+        `Dispatch ${params.dispatchId} capability is revoked.`
+      )
+    }
+    const capability = `dcap_${randomBytes(32).toString('base64url')}`
+    const contextUpdate = this.db
+      .prepare(
+        `UPDATE dispatch_contexts
+         SET capability_hash = ?
+         WHERE id = ? AND status = 'pending' AND capability_hash IS NULL`
+      )
+      .run(hashDispatchCapability(capability), params.dispatchId)
+    if (contextUpdate.changes !== 1) {
+      throw new OrchestrationError(
+        'dispatch_inactive',
+        `Dispatch ${params.dispatchId} is not starting.`
+      )
+    }
+    this.db.exec('COMMIT')
+    return capability
+  } catch (error) {
+    this.db.exec('ROLLBACK')
+    throw error
+  }
+}
+
+// Why: the post-spawn half of an argv worker start. Everything
+// prepareStartingWorkerAuthority does EXCEPT capability generation, plus two
+// hardened guards: the launch-token commitment is REQUIRED to match (it is the
+// only proof the binding pane is the exact process that received
+// ORCA_AGENT_LAUNCH_TOKEN at spawn), and a revoked capability is never
+// resurrected — the atomic mint+bind clears capability_revoked_at because
+// nothing can revoke inside one transaction; across two transactions that
+// reset would resurrect a capability revoked between mint and bind.
+export function bindStartingWorkerAuthority(
+  this: OrchestrationDb,
+  params: {
+    dispatchId: string
+    handle: string
+    paneKey: string
+    processIncarnation: string
+    launchTokenHash?: string
+    worktreeId: string
+    effects: unknown[]
+    setupState: string
+    hostScope?: string | null
+    terminalOwnership?: 'created' | 'external'
+  }
+): void {
+  this.db.exec('BEGIN IMMEDIATE')
+  try {
+    const dispatch = this.getDispatchContextById(params.dispatchId)
+    const worker = this.getWorkerDispatch(params.dispatchId)
+    if (!dispatch || dispatch.status !== 'pending' || worker?.state !== 'starting') {
+      throw new OrchestrationError(
+        'dispatch_inactive',
+        `Dispatch ${params.dispatchId} is not starting.`
+      )
+    }
+    if (!dispatch.capability_hash) {
+      throw new OrchestrationError(
+        'request_mismatch',
+        `Dispatch ${params.dispatchId} has no minted capability to bind.`
+      )
+    }
+    if (dispatch.capability_revoked_at) {
+      throw new OrchestrationError(
+        'dispatch_inactive',
+        `Dispatch ${params.dispatchId} capability is revoked.`
+      )
+    }
+    if (
+      dispatch.launch_token_hash &&
+      dispatch.launch_token_hash !== (params.launchTokenHash ?? null)
+    ) {
+      throw new OrchestrationError(
+        'request_mismatch',
+        `Dispatch ${params.dispatchId} launch-token commitment does not match the binding pane.`
+      )
+    }
+    const existing = this.findActiveDispatchForAssignee(params.handle, params.paneKey)
+    if (existing && existing.id !== params.dispatchId) {
+      throw new Error(
+        `Terminal ${params.handle} already has an active dispatch (${existing.id} for task ${existing.task_id})`
+      )
+    }
+    const contextUpdate = this.db
+      .prepare(
+        `UPDATE dispatch_contexts
+         SET assignee_handle = ?, assignee_pane_key = ?, process_incarnation = ?
+         WHERE id = ? AND status = 'pending' AND capability_revoked_at IS NULL`
+      )
+      .run(params.handle, params.paneKey, params.processIncarnation, params.dispatchId)
+    if (contextUpdate.changes !== 1) {
+      throw new OrchestrationError(
+        'dispatch_inactive',
+        `Dispatch ${params.dispatchId} is not starting.`
+      )
+    }
+    const workerUpdate = this.db
+      .prepare(
+        `UPDATE worker_dispatches
+         SET stage = 'authority_attached', worktree_id = ?, agent_terminal_handle = ?,
+             setup_state = ?, effects = ?, residual_resources = ?, updated_at = datetime('now')
+         WHERE dispatch_id = ? AND state = 'starting'`
+      )
+      .run(
+        params.worktreeId,
+        params.handle,
+        params.setupState,
+        JSON.stringify(params.effects),
+        JSON.stringify(
+          params.effects.filter((effect) =>
+            Boolean(
+              effect &&
+              typeof effect === 'object' &&
+              ((effect as { action?: string }).action?.startsWith('created') ||
+                (effect as { action?: string }).action === 'reused_agent_terminal')
+            )
+          )
+        ),
+        params.dispatchId
+      )
+    if (workerUpdate.changes !== 1) {
+      throw new OrchestrationError(
+        'dispatch_inactive',
+        `Dispatch ${params.dispatchId} is not starting.`
+      )
+    }
+    if (params.terminalOwnership && !this.getWorkerTerminalResourceByOwner(params.dispatchId)) {
+      if (params.terminalOwnership === 'created') {
+        this.createWorkerTerminalResourceStatement({
+          dispatchId: params.dispatchId,
+          worktreeId: params.worktreeId,
+          terminalHandle: params.handle,
+          paneKey: params.paneKey,
+          processIncarnation: params.processIncarnation,
+          hostScope: params.hostScope,
+          ownership: 'owned'
+        })
+      } else {
+        const transferable = this.findTransferableWorkerTerminalResource({
+          terminalHandle: params.handle,
+          paneKey: params.paneKey,
+          processIncarnation: params.processIncarnation,
+          hostScope: params.hostScope ?? null
+        })
+        if (transferable) {
+          this.transferWorkerTerminalResourceStatement({
+            resourceId: transferable.id,
+            toDispatchId: params.dispatchId,
+            terminalHandle: params.handle,
+            paneKey: params.paneKey,
+            processIncarnation: params.processIncarnation,
+            hostScope: params.hostScope ?? null
+          })
+        } else {
+          this.createWorkerTerminalResourceStatement({
+            dispatchId: params.dispatchId,
+            worktreeId: params.worktreeId,
+            terminalHandle: params.handle,
+            paneKey: params.paneKey,
+            processIncarnation: params.processIncarnation,
+            hostScope: params.hostScope,
+            ownership: 'external'
+          })
+        }
+      }
+    }
+    this.db.exec('COMMIT')
+  } catch (error) {
+    this.db.exec('ROLLBACK')
+    throw error
+  }
+}
+
+export type WorkerDispatchArgvAuthorityMethods = {
+  mintStartingWorkerCapability: typeof mintStartingWorkerCapability
+  bindStartingWorkerAuthority: typeof bindStartingWorkerAuthority
+}
+
+export function attachWorkerDispatchArgvAuthority(ctor: { prototype: object }): void {
+  Object.assign(ctor.prototype, {
+    mintStartingWorkerCapability,
+    bindStartingWorkerAuthority
+  })
+}

--- a/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-argv-authority.ts
+++ b/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-argv-authority.ts
@@ -105,7 +105,7 @@ export function bindStartingWorkerAuthority(
       )
     }
     if (
-      dispatch.launch_token_hash &&
+      !dispatch.launch_token_hash ||
       dispatch.launch_token_hash !== (params.launchTokenHash ?? null)
     ) {
       throw new OrchestrationError(

--- a/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { RpcContext } from '../core'
 import { createOrchestrationRpcHarness } from './orchestration-rpc-test-harness'
@@ -25,11 +26,17 @@ describe('orchestration RPC methods', () => {
   }
 
   describe('composed workers', () => {
-    function mockCurrentWorkerStart(options?: { ready?: boolean }): void {
+    function mockCurrentWorkerStart(options?: { ready?: boolean; terminalWarning?: string }): void {
+      // Why: the argv worker-start path pre-allocates the handle and mints the
+      // launch token BEFORE createTerminal. Real createTerminal adopts both;
+      // a mock that ignored them would trip the handle-substitution guard and
+      // the launch-token bind guard, testing a runtime that cannot exist.
+      let workerHandle = 'term_worker'
+      let workerLaunchTokenHash: string | null = null
       vi.mocked(runtime.getTerminalPaneKey).mockImplementation((handle) =>
         handle === 'term_coord'
           ? coordinatorPaneKey
-          : handle === 'term_worker'
+          : handle === workerHandle
             ? 'tab_worker:leaf_worker'
             : null
       )
@@ -43,22 +50,49 @@ describe('orchestration RPC methods', () => {
       vi.spyOn(runtime, 'showManagedTerminalWorkspace').mockResolvedValue({
         id: 'repo::worktree'
       } as never)
-      vi.spyOn(runtime, 'createTerminal').mockResolvedValue({
-        handle: 'term_worker',
-        worktreeId: 'repo::worktree',
-        title: 'worker'
+      vi.spyOn(runtime, 'createTerminal').mockImplementation(async (_selector, opts) => {
+        workerHandle = opts?.preAllocatedHandle ?? 'term_worker'
+        workerLaunchTokenHash = opts?.launchToken
+          ? createHash('sha256').update(opts.launchToken).digest('hex')
+          : null
+        return {
+          handle: workerHandle,
+          worktreeId: 'repo::worktree',
+          title: 'worker',
+          ...(options?.terminalWarning
+            ? { surface: 'background' as const, warning: options.terminalWarning }
+            : {})
+        } as never
       })
-      vi.spyOn(runtime, 'waitForTerminal').mockResolvedValue({
-        handle: 'term_worker',
-        condition: 'tui-idle',
-        satisfied: options?.ready !== false,
-        status: 'running',
-        exitCode: null
-      })
+      vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockImplementation((handle) =>
+        handle === workerHandle && workerLaunchTokenHash
+          ? ({
+              runtimeId: runtime.getRuntimeId(),
+              terminalHandle: workerHandle,
+              ptyId: 'pty_worker',
+              worktreeId: 'repo::worktree',
+              paneKey: 'tab_worker:leaf_worker',
+              processIncarnation: 'runtime_test:term_worker:1',
+              launchTokenHash: workerLaunchTokenHash,
+              hostScope: null
+            } as never)
+          : null
+      )
+      vi.spyOn(runtime, 'waitForTerminal').mockImplementation(
+        async (handle) =>
+          ({
+            handle,
+            condition: 'tui-idle',
+            satisfied: options?.ready !== false,
+            status: 'running',
+            exitCode: null
+          }) as never
+      )
       vi.mocked(runtime.getTerminalProcessIncarnation).mockImplementation((handle) =>
-        handle === 'term_worker' ? 'runtime_test:term_worker:1' : null
+        handle === workerHandle ? 'runtime_test:term_worker:1' : null
       )
       vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
+      vi.spyOn(runtime, 'getWorktreeOrchestrationCliCommand').mockResolvedValue('orca')
       vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockResolvedValue({
         handle: 'term_worker',
         accepted: true,
@@ -154,17 +188,36 @@ describe('orchestration RPC methods', () => {
       // the tab without scrolling the sidebar to the worker's workspace.
       expect(runtime.createTerminal).toHaveBeenCalledWith('id:repo::worktree', {
         startupAgent: 'codex',
+        preAllocatedHandle: expect.stringMatching(/^term_/),
+        launchToken: expect.any(String),
+        // Why: the preamble travels in the launch argv — the capability the
+        // worker presents later must be the one baked in at spawn.
+        agentPrompt: expect.stringContaining('--dispatch-capability dcap_'),
         title: `worker-${task.id}`,
         surfaceOwner: false
       })
-      expect(runtime.sendTerminalAgentPrompt).toHaveBeenCalledWith(
-        'term_worker',
-        expect.stringContaining('--dispatch-capability dcap_')
-      )
+      expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
     })
 
+    it('embeds the WSL CLI name before the worker pane exists', async () => {
+      setup()
+      mockCurrentWorkerStart()
+      vi.mocked(runtime.getWorktreeOrchestrationCliCommand).mockResolvedValueOnce('orca-ide')
+      const task = db.createTask({ spec: 'report from WSL' })
+
+      await call('orchestration.workerStart', {
+        task: task.id,
+        from: 'term_coord',
+        agent: 'codex'
+      })
+
+      const createOptions = vi.mocked(runtime.createTerminal).mock.calls.at(-1)?.[1]
+      expect(createOptions?.agentPrompt).toContain('orca-ide orchestration send')
+      expect(runtime.getWorktreeOrchestrationCliCommand).toHaveBeenCalledWith('repo::worktree')
+    })
     it('applies and reports opaque per-invocation model preferences', async () => {
       setup()
+
       mockCurrentWorkerStart()
       const task = db.createTask({ spec: 'launch a custom model' })
 
@@ -244,16 +297,6 @@ describe('orchestration RPC methods', () => {
     it('commits the launched worker token with its durable authority', async () => {
       setup()
       mockCurrentWorkerStart()
-      vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockReturnValue({
-        runtimeId: runtime.getRuntimeId(),
-        terminalHandle: 'term_worker',
-        ptyId: 'pty_worker',
-        worktreeId: 'repo::worktree',
-        paneKey: 'tab_worker:leaf_worker',
-        processIncarnation: 'runtime_test:term_worker:1',
-        launchTokenHash: 'worker-launch-token-hash',
-        hostScope: { kind: 'local', hostId: 'local' }
-      })
       const task = db.createTask({ spec: 'persist worker identity' })
 
       const result = (await call('orchestration.workerStart', {
@@ -262,20 +305,20 @@ describe('orchestration RPC methods', () => {
         agent: 'codex'
       })) as { dispatchId: string }
 
+      // Why: the token handed to the spawn is the ONLY identity proof the
+      // binding pane can present; the context must carry exactly its hash.
+      const createOptions = vi.mocked(runtime.createTerminal).mock.calls.at(-1)?.[1]
+      const launchToken = createOptions?.launchToken
+      expect(launchToken).toBeTruthy()
       expect(db.getDispatchContextById(result.dispatchId)?.launch_token_hash).toBe(
-        'worker-launch-token-hash'
+        createHash('sha256').update(launchToken!).digest('hex')
       )
     })
 
     it('surfaces a worker terminal reveal failure without discarding the live worker', async () => {
       setup()
-      mockCurrentWorkerStart()
-      vi.mocked(runtime.createTerminal).mockResolvedValue({
-        handle: 'term_worker',
-        worktreeId: 'repo::worktree',
-        title: 'worker',
-        surface: 'background',
-        warning: 'Terminal term_worker is running but could not be revealed.'
+      mockCurrentWorkerStart({
+        terminalWarning: 'Terminal term_worker is running but could not be revealed.'
       })
       const task = db.createTask({ spec: 'keep working if reveal fails' })
 
@@ -300,7 +343,9 @@ describe('orchestration RPC methods', () => {
           warning: 'Terminal term_worker is running but could not be revealed.'
         })
       )
-      expect(runtime.sendTerminalAgentPrompt).toHaveBeenCalled()
+      expect(result.effects).toContainEqual(
+        expect.objectContaining({ kind: 'dispatch_input', state: 'accepted' })
+      )
     })
 
     it('starts in an exact existing worktree from a floating coordinator', async () => {
@@ -410,6 +455,8 @@ describe('orchestration RPC methods', () => {
       expect(createWorktree).not.toHaveBeenCalled()
     })
 
+    // Why: agents without launch-embedded prompts still take the paste path,
+    // where tui-idle readiness gates the brief; its timeout stays a failure.
     it('returns a failed receipt and preserves a created terminal as residual', async () => {
       setup()
       mockCurrentWorkerStart({ ready: false })
@@ -418,7 +465,7 @@ describe('orchestration RPC methods', () => {
       const result = (await call('orchestration.workerStart', {
         task: task.id,
         from: 'term_coord',
-        agent: 'codex'
+        agent: 'goose'
       })) as { state: string; failedStage: string; residualResources: { id: string }[] }
 
       expect(result).toMatchObject({ state: 'failed', failedStage: 'agent_readiness' })
@@ -447,6 +494,7 @@ describe('orchestration RPC methods', () => {
       expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
     })
 
+    // Why: prompt paste (and its rejection) only exists on the non-argv path.
     it('preserves the exact attached terminal when task input is rejected', async () => {
       setup()
       mockCurrentWorkerStart()
@@ -458,7 +506,7 @@ describe('orchestration RPC methods', () => {
       const result = (await call('orchestration.workerStart', {
         task: task.id,
         from: 'term_coord',
-        agent: 'codex'
+        agent: 'goose'
       })) as {
         state: string
         failedStage: string
@@ -472,7 +520,7 @@ describe('orchestration RPC methods', () => {
     })
 
     it.each(['codex-update-prompt', 'codex-trust-workspace'] as const)(
-      'returns a truthful readiness failure for %s',
+      'reports a blocked startup screen without failing the ready dispatch for %s',
       async (blockedReason) => {
         setup()
         mockCurrentWorkerStart()
@@ -484,19 +532,31 @@ describe('orchestration RPC methods', () => {
           exitCode: null,
           blockedReason
         })
+        const notify = vi.spyOn(runtime, 'notifyMessageArrived').mockImplementation(() => {})
+        const insertMessage = vi.spyOn(db, 'insertMessage')
         const task = db.createTask({ spec: 'blocked startup prompt' })
 
         const result = (await call('orchestration.workerStart', {
           task: task.id,
           from: 'term_coord',
           agent: 'codex'
-        })) as { state: string; failedStage: string; lastError: string }
+        })) as { state: string; dispatchId: string }
 
-        expect(result).toMatchObject({
-          state: 'failed',
-          failedStage: 'agent_readiness',
-          lastError: `Agent startup blocked: ${blockedReason}`
+        // Why: the brief is already delivered via argv and the capability is
+        // bound — failing the start would revoke a capability the worker
+        // presents after a human clears the screen. Ready stands; the blocked
+        // screen surfaces as durable high-priority evidence to the Run.
+        expect(result.state).toBe('ready')
+        await vi.waitFor(() => {
+          expect(insertMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+              priority: 'high',
+              subject: expect.stringContaining(`startup blocked: ${blockedReason}`)
+            })
+          )
         })
+        expect(notify).toHaveBeenCalled()
+        expect(db.getWorkerDispatch(result.dispatchId)?.state).toBe('ready')
         expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
       }
     )

--- a/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
@@ -494,6 +494,45 @@ describe('orchestration RPC methods', () => {
       expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
     })
 
+    // Why: createTerminal can substitute a canonical surface handle after spawn.
+    // The identity mismatch still fails, but the spawned pane must remain on
+    // the receipt so cleanup/abandon can see it.
+    it('reports a substituted spawn handle as residual on identity mismatch', async () => {
+      setup()
+      mockCurrentWorkerStart()
+      vi.mocked(runtime.createTerminal).mockImplementation(
+        async () =>
+          ({
+            handle: 'term_substituted',
+            worktreeId: 'repo::worktree',
+            title: 'worker'
+          }) as never
+      )
+      const task = db.createTask({ spec: 'substituted handle' })
+
+      const result = (await call('orchestration.workerStart', {
+        task: task.id,
+        from: 'term_coord',
+        agent: 'codex'
+      })) as {
+        state: string
+        failedStage: string
+        residualResources: { kind: string; action?: string; id: string }[]
+      }
+
+      expect(result).toMatchObject({
+        state: 'failed',
+        failedStage: 'authority_bind'
+      })
+      expect(result.residualResources).toEqual([
+        expect.objectContaining({
+          kind: 'terminal',
+          action: 'created',
+          id: 'term_substituted'
+        })
+      ])
+    })
+
     // Why: prompt paste (and its rejection) only exists on the non-argv path.
     it('preserves the exact attached terminal when task input is rejected', async () => {
       setup()

--- a/src/main/runtime/rpc/methods/orchestration-worker-argv-start.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-argv-start.ts
@@ -1,0 +1,225 @@
+import { createHash, randomUUID } from 'node:crypto'
+import { setTimeout as delay } from 'node:timers/promises'
+import type { TuiAgent } from '../../../../shared/tui-agent'
+import type { AgentLaunchPreferences } from '../../../../shared/agent-session-host-authority'
+import { buildDispatchPreamble } from '../../orchestration/preamble'
+import type { OrchestrationDb } from '../../orchestration/db'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import {
+  monitorWorkerSetup,
+  requireWorkerAuthority,
+  type WorkerEffect,
+  type WorkerSetupReceipt
+} from './orchestration-worker-topology'
+import {
+  persistGatedSetupSpawnFailure,
+  persistWorkerReadinessStage
+} from './orchestration-worker-setup-gate'
+import type { OrchestrationWorkerLaunchReceipt } from './orchestration-worker-launch-preferences'
+
+// Why: agents whose promptInjectionMode is 'argv' start the first turn WITH
+// the process — the dispatch preamble travels in the launch command, so
+// there is no paste, no Enter, no submission verification window, and no
+// agent_prompt_stalled revocation of a healthy worker. The capability and
+// preamble exist before the terminal; the pane proves it is the exact
+// spawned process by echoing the launch token it received in its
+// environment. Nothing timing-based ever sits between spawn, bind and
+// ready: a fast completion is settled, never refused.
+export async function startArgvWorkerDispatch(args: {
+  runtime: OrcaRuntimeService
+  db: OrchestrationDb
+  runId: string
+  task: { id: string; spec: string }
+  dispatchId: string
+  coordinatorHandle: string
+  devMode?: boolean
+  timeoutMs: number
+  agent: TuiAgent
+  launchPreferences?: AgentLaunchPreferences
+  launchReceipt: OrchestrationWorkerLaunchReceipt
+  worktreeId: string
+  effects: WorkerEffect[]
+  setupReceipt: WorkerSetupReceipt
+  // Why: the caller's catch settles the dispatch with the stage that was
+  // active when the failure happened; this callback keeps that ledger
+  // accurate without threading a mutable variable through the module.
+  onStage: (stage: string) => void
+}): Promise<Record<string, unknown>> {
+  const { runtime, db, effects } = args
+  const preAllocatedHandle = runtime.createPreAllocatedTerminalHandle()
+  const workerLaunchToken = randomUUID()
+  db.commitDispatchLaunchTokenHash(
+    args.dispatchId,
+    createHash('sha256').update(workerLaunchToken).digest('hex')
+  )
+  const capability = db.mintStartingWorkerCapability({ dispatchId: args.dispatchId })
+  const cliCommand = await runtime.getWorktreeOrchestrationCliCommand(args.worktreeId)
+  const preamble = buildDispatchPreamble({
+    taskId: args.task.id,
+    dispatchId: args.dispatchId,
+    taskSpec: args.task.spec,
+    coordinatorHandle: args.coordinatorHandle,
+    workerHandle: preAllocatedHandle,
+    dispatchCapability: capability,
+    devMode: args.devMode,
+    cliCommand
+  })
+  const terminal = await runtime.createTerminal(`id:${args.worktreeId}`, {
+    startupAgent: args.agent,
+    ...(args.launchPreferences ? { launchPreferences: args.launchPreferences } : {}),
+    preAllocatedHandle,
+    launchToken: workerLaunchToken,
+    agentPrompt: preamble,
+    title: `worker-${args.task.id}`,
+    // Why: dispatching a worker is background work; it must not pull the
+    // sidebar to the worker's workspace while the user reads somewhere else.
+    surfaceOwner: false
+  })
+  effects.push({
+    kind: 'terminal',
+    role: 'agent',
+    action: 'created',
+    id: terminal.handle,
+    surface: terminal.surface,
+    warning: terminal.warning
+  })
+  args.onStage('authority_bind')
+  // Why: adoption paths can substitute a canonical surface handle
+  // (agentSessionEnsure/stablePaneOwner). The preamble already names
+  // preAllocatedHandle as the worker's identity; a substituted handle would
+  // make the worker self-identify wrongly forever.
+  if (terminal.handle !== preAllocatedHandle) {
+    throw new Error(
+      `Worker terminal adopted handle ${terminal.handle} instead of the pre-allocated ${preAllocatedHandle}.`
+    )
+  }
+  const setupStage = {
+    db,
+    dispatchId: args.dispatchId,
+    worktreeId: args.worktreeId,
+    terminalHandle: terminal.handle,
+    setup: args.setupReceipt,
+    effects
+  }
+  if (persistGatedSetupSpawnFailure(setupStage)) {
+    args.onStage('setup_start')
+    throw new Error('Setup terminal failed to start before the gated agent launch.')
+  }
+  persistWorkerReadinessStage(setupStage)
+  const boundAuthority = await requireWorkerAuthorityAfterSpawn(runtime, terminal.handle)
+  db.bindStartingWorkerAuthority({
+    dispatchId: args.dispatchId,
+    handle: terminal.handle,
+    ...boundAuthority,
+    worktreeId: args.worktreeId,
+    effects,
+    setupState: args.setupReceipt.state,
+    terminalOwnership: 'created'
+  })
+  // Why: nothing may sit between bind and ready — the dispatch context stays
+  // 'pending' until markWorkerDispatchReady, and worker_done settlement
+  // refuses a pending dispatch, so any gate here would reject a fast
+  // completion. Blocked-screen detection is detached below.
+  effects.push({
+    kind: 'dispatch_input',
+    role: 'agent',
+    id: terminal.handle,
+    state: 'accepted'
+  })
+  const worker = db.markWorkerDispatchReady(args.dispatchId, effects)
+  monitorWorkerSetup({
+    runtime,
+    db,
+    runId: args.runId,
+    dispatchId: args.dispatchId,
+    setupReceipt: args.setupReceipt,
+    effects
+  })
+  monitorArgvStartupBlocked({
+    runtime,
+    db,
+    runId: args.runId,
+    dispatchId: args.dispatchId,
+    terminalHandle: terminal.handle,
+    timeoutMs: args.timeoutMs
+  })
+  return {
+    runId: args.runId,
+    taskId: args.task.id,
+    dispatchId: args.dispatchId,
+    state: worker.state,
+    stage: worker.stage,
+    setup: args.setupReceipt,
+    launch: args.launchReceipt,
+    timeoutMs: args.timeoutMs,
+    effects,
+    residualResources: [],
+    ...(terminal.warning ? { warning: terminal.warning } : {})
+  }
+}
+
+// Why: createTerminal resolution is the identity barrier for a freshly
+// spawned worker — handle registration, launch token and paneKey are stored
+// before it resolves. The bounded retry covers only create variants whose
+// registration timing differs; any other error is real and thrown as-is.
+async function requireWorkerAuthorityAfterSpawn(
+  runtime: OrcaRuntimeService,
+  terminalHandle: string
+) {
+  const deadline = Date.now() + 5_000
+  for (;;) {
+    try {
+      return requireWorkerAuthority(runtime, terminalHandle)
+    } catch (error) {
+      const paneStillRegistering =
+        error instanceof Error && error.message === 'stable_pane_required' && Date.now() < deadline
+      if (!paneStillRegistering) {
+        throw error
+      }
+      await delay(100)
+    }
+  }
+}
+
+// Why: an argv worker's brief is delivered at spawn, so a trust menu or
+// update prompt that renders instead of the first turn must NOT fail the
+// start — the dispatch identity is sound, and once the screen is cleared
+// the agent runs the brief with a still-valid capability. Failing here
+// would revoke that capability and orphan the recovered work; a timing
+// gate before ready would refuse a fast completion. The scan is therefore
+// detached evidence: ready returns immediately, and a detected blocked
+// screen becomes a high-priority message to the Run.
+function monitorArgvStartupBlocked(args: {
+  runtime: OrcaRuntimeService
+  db: OrchestrationDb
+  runId: string
+  dispatchId: string
+  terminalHandle: string
+  timeoutMs: number
+}): void {
+  void args.runtime
+    .waitForTerminal(args.terminalHandle, {
+      condition: 'tui-idle',
+      timeoutMs: args.timeoutMs
+    })
+    .then((wait) => {
+      if (!wait.blockedReason) {
+        return
+      }
+      const message = args.db.insertMessage({
+        runId: args.runId,
+        from: `dispatch:${args.dispatchId}`,
+        to: `run:${args.runId}`,
+        subject: `Worker ${args.dispatchId} startup blocked: ${wait.blockedReason}`,
+        type: 'status',
+        priority: 'high',
+        payload: JSON.stringify({
+          dispatchId: args.dispatchId,
+          blockedReason: wait.blockedReason,
+          terminalHandle: args.terminalHandle
+        })
+      })
+      args.runtime.notifyMessageArrived(message.to_handle, message.type)
+    })
+    .catch(() => undefined)
+}

--- a/src/main/runtime/rpc/methods/orchestration-worker-argv-start.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-argv-start.ts
@@ -84,15 +84,6 @@ export async function startArgvWorkerDispatch(args: {
     warning: terminal.warning
   })
   args.onStage('authority_bind')
-  // Why: adoption paths can substitute a canonical surface handle
-  // (agentSessionEnsure/stablePaneOwner). The preamble already names
-  // preAllocatedHandle as the worker's identity; a substituted handle would
-  // make the worker self-identify wrongly forever.
-  if (terminal.handle !== preAllocatedHandle) {
-    throw new Error(
-      `Worker terminal adopted handle ${terminal.handle} instead of the pre-allocated ${preAllocatedHandle}.`
-    )
-  }
   const setupStage = {
     db,
     dispatchId: args.dispatchId,
@@ -100,6 +91,15 @@ export async function startArgvWorkerDispatch(args: {
     terminalHandle: terminal.handle,
     setup: args.setupReceipt,
     effects
+  }
+  // Why: createTerminal has already spawned the pane. failWorkerStartWithReceipt
+  // rebuilds effects from DB, so the identity mismatch must persist the exact
+  // terminal residual before it throws or the receipt loses the spawned handle.
+  if (terminal.handle !== preAllocatedHandle) {
+    persistWorkerReadinessStage(setupStage)
+    throw new Error(
+      `Worker terminal adopted handle ${terminal.handle} instead of the pre-allocated ${preAllocatedHandle}.`
+    )
   }
   if (persistGatedSetupSpawnFailure(setupStage)) {
     args.onStage('setup_start')

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-recovery.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-recovery.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { OrchestrationDb } from '../../orchestration/db'
 import { reconcileRequestedWorkerTerminalReleases } from '../../orchestration/worker-terminal-release-reconciliation'
@@ -34,12 +35,19 @@ describe('orchestration worker release recovery', () => {
     vi.spyOn(runtime, 'getTerminalProcessIncarnation').mockImplementation((handle) =>
       handle === 'term_worker' ? 'runtime_test:term_worker:1' : null
     )
+    // Why: the argv worker-start path pre-allocates the handle and hands the
+    // spawn a launch token; the pane's authority must echo that token's hash
+    // or the bind guard (rightly) refuses the pane. Pinning the pre-allocated
+    // handle keeps every 'term_worker'-keyed fixture in this file valid.
+    let workerLaunchTokenHash: string | null = null
+    vi.spyOn(runtime, 'createPreAllocatedTerminalHandle').mockReturnValue('term_worker')
     vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockImplementation((handle) =>
       handle === 'term_worker'
         ? ({
             terminalHandle: handle,
             paneKey: workerPaneKey,
             processIncarnation: 'runtime_test:term_worker:1',
+            ...(workerLaunchTokenHash ? { launchTokenHash: workerLaunchTokenHash } : {}),
             hostScope: { kind: 'local', hostId: 'local' }
           } as never)
         : null
@@ -51,10 +59,15 @@ describe('orchestration worker release recovery', () => {
     vi.spyOn(runtime, 'showManagedTerminalWorkspace').mockResolvedValue({
       id: 'repo::worktree'
     } as never)
-    vi.spyOn(runtime, 'createTerminal').mockResolvedValue({
-      handle: 'term_worker',
-      worktreeId: 'repo::worktree',
-      title: 'worker'
+    vi.spyOn(runtime, 'createTerminal').mockImplementation(async (_selector, opts) => {
+      workerLaunchTokenHash = opts?.launchToken
+        ? createHash('sha256').update(opts.launchToken).digest('hex')
+        : null
+      return {
+        handle: opts?.preAllocatedHandle ?? 'term_worker',
+        worktreeId: 'repo::worktree',
+        title: 'worker'
+      } as never
     })
     vi.spyOn(runtime, 'waitForTerminal').mockResolvedValue({
       handle: 'term_worker',
@@ -64,6 +77,7 @@ describe('orchestration worker release recovery', () => {
       exitCode: null
     })
     vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
+    vi.spyOn(runtime, 'getWorktreeOrchestrationCliCommand').mockResolvedValue('orca')
     vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockResolvedValue({
       handle: 'term_worker',
       accepted: true,

--- a/src/main/runtime/rpc/methods/orchestration-worker-release.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -47,12 +48,19 @@ describe('orchestration worker release', () => {
     vi.spyOn(runtime, 'getTerminalProcessIncarnation').mockImplementation((handle) =>
       handle === 'term_worker' || handle === 'term_reminted' ? 'runtime_test:term_worker:1' : null
     )
+    // Why: the argv worker-start path pre-allocates the handle and hands the
+    // spawn a launch token; the pane's authority must echo that token's hash
+    // or the bind guard (rightly) refuses the pane. Pinning the pre-allocated
+    // handle keeps every 'term_worker'-keyed fixture in this file valid.
+    let workerLaunchTokenHash: string | null = null
+    vi.spyOn(runtime, 'createPreAllocatedTerminalHandle').mockReturnValue('term_worker')
     vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockImplementation((handle) =>
       handle === 'term_worker' || handle === 'term_reminted'
         ? ({
             terminalHandle: handle,
             paneKey: workerPaneKey,
             processIncarnation: 'runtime_test:term_worker:1',
+            ...(workerLaunchTokenHash ? { launchTokenHash: workerLaunchTokenHash } : {}),
             hostScope: { kind: 'local', hostId: 'local' }
           } as never)
         : null
@@ -64,10 +72,11 @@ describe('orchestration worker release', () => {
     vi.spyOn(runtime, 'showManagedTerminalWorkspace').mockResolvedValue({
       id: 'repo::worktree'
     } as never)
-    vi.spyOn(runtime, 'createTerminal').mockResolvedValue({
-      handle: 'term_worker',
-      worktreeId: 'repo::worktree',
-      title: 'worker'
+    vi.spyOn(runtime, 'createTerminal').mockImplementation(async (_selector, opts) => {
+      workerLaunchTokenHash = opts?.launchToken
+        ? createHash('sha256').update(opts.launchToken).digest('hex')
+        : null
+      return { handle: 'term_worker', worktreeId: 'repo::worktree', title: 'worker' } as never
     })
     vi.spyOn(runtime, 'waitForTerminal').mockResolvedValue({
       handle: 'term_worker',
@@ -77,6 +86,7 @@ describe('orchestration worker release', () => {
       exitCode: null
     })
     vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
+    vi.spyOn(runtime, 'getWorktreeOrchestrationCliCommand').mockResolvedValue('orca')
     vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockResolvedValue({
       handle: 'term_worker',
       accepted: true,

--- a/src/main/runtime/rpc/methods/orchestration-workers.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers.ts
@@ -1,9 +1,11 @@
+import { TUI_AGENT_CONFIG } from '../../../../shared/tui-agent-config'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import { buildDispatchPreamble } from '../../orchestration/preamble'
 import { OrchestrationError } from '../../orchestration/orchestration-error'
 import { defineMethod, type RpcMethod } from '../core'
 import { startFederatedWorker } from './orchestration-federated-worker-start'
 import { assertOrchestrationWorktreeCreationSupported } from './orchestration-folder-worktree-placement'
+import { startArgvWorkerDispatch } from './orchestration-worker-argv-start'
 import { WorkerStartParams } from './orchestration-worker-start-schema'
 import {
   createExistingWorktreeWorkerTerminal,
@@ -181,6 +183,31 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
             worktreeId: resolvedWorktree!.id,
             effects
           })
+          // Why: agents that embed the prompt in their launch argv start the
+          // first turn WITH the process — no paste, no Enter, no submission
+          // verification, no agent_prompt_stalled revocation of a healthy
+          // worker. The whole path lives in orchestration-worker-argv-start.
+          if (agent && TUI_AGENT_CONFIG[agent].promptInjectionMode === 'argv') {
+            return await startArgvWorkerDispatch({
+              runtime,
+              db,
+              runId: run.id,
+              task,
+              dispatchId: started.dispatch.id,
+              coordinatorHandle: params.from,
+              devMode: params.devMode,
+              timeoutMs: params.timeoutMs ?? 60_000,
+              agent,
+              launchPreferences: launch.preferences,
+              launchReceipt: launch.receipt,
+              worktreeId: resolvedWorktree!.id,
+              effects,
+              setupReceipt,
+              onStage: (stage) => {
+                failedStage = stage
+              }
+            })
+          }
           const terminal = await createExistingWorktreeWorkerTerminal({
             runtime,
             worktreeId: resolvedWorktree!.id,

--- a/src/main/runtime/rpc/orchestration-mutation-executor.ts
+++ b/src/main/runtime/rpc/orchestration-mutation-executor.ts
@@ -107,6 +107,17 @@ export class OrchestrationMutationExecutor {
     try {
       const result = await active
       const receipted = attachMutationReceipt(result, requestId, resumedPendingMutation)
+      if (request.method === 'orchestration.workerRelease' && isNonFinalWorkerRelease(result)) {
+        // Why: `release_pending` and `release_unknown` are the runtime saying the release did
+        // NOT happen yet, and the receipt's own recovery prescribes repeating worker-release
+        // with the same --retry-request. A completed receipt would serve every repeat from the
+        // ledger without re-entering the release — measured 2026-09-02: a resource stuck in
+        // `release_state = 'unknown'` for a day, with a live agent process behind it, and no
+        // request id the coordinator was allowed to mint. So the receipt is dropped and the
+        // same id re-enters; only a final state completes.
+        db.discardPendingMutationReceipt(callerFingerprint, requestId)
+        return receipted
+      }
       db.completeMutationReceipt({ ...identity, receipt: JSON.stringify(receipted) })
       return receipted
     } catch (error) {
@@ -187,6 +198,11 @@ function attachMutationReceipt(result: unknown, requestId: string, replayed: boo
     return { result, mutation: { requestId, replayed } }
   }
   return { ...(result as Record<string, unknown>), mutation: { requestId, replayed } }
+}
+
+function isNonFinalWorkerRelease(result: unknown): boolean {
+  const state = (result as { state?: unknown } | null)?.state
+  return state === 'release_pending' || state === 'release_unknown'
 }
 
 function getPendingWorkerStartRecovery(

--- a/src/main/runtime/rpc/orchestration-mutation-ledger.test.ts
+++ b/src/main/runtime/rpc/orchestration-mutation-ledger.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { z } from 'zod'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi, type Mock } from 'vitest'
 import { ORCHESTRATION_CONTRACT_VERSION } from '../../../shared/protocol-version'
 import { OrcaRuntimeService } from '../orca-runtime'
 import { OrchestrationDb } from '../orchestration/db'
@@ -247,22 +247,20 @@ describe('durable orchestration mutation ledger', () => {
     db.close()
   })
 
-  it('resumes a pending idempotent worker release after restart', async () => {
+  // A release that answers `release_pending` or `release_unknown` has NOT done the thing it was
+  // asked to do: Orca itself says so in the receipt, and its own `recovery` text prescribes
+  // repeating worker-release with the same --retry-request. Measured 2026-09-02 on a Mac: the
+  // receipt was completed anyway, so every repeat was served from the ledger (`replayed: true`)
+  // without re-entering the release, the resource sat in `release_state = 'unknown'` for the rest
+  // of the day (the reconciler's backlog excludes `unknown`), and the only way out was a fresh
+  // request id the coordinator is forbidden to mint. So a non-final release state leaves no
+  // completed receipt: the same request id re-enters the release, exactly as the recovery says.
+  type ReleaseEffect = Mock<(params: { dispatch: string }) => unknown>
+
+  function releaseHarness(effect: ReleaseEffect) {
     const db = new OrchestrationDb(':memory:')
     const runtime = new OrcaRuntimeService()
     runtime.setOrchestrationDb(db)
-    const params = { dispatch: 'ctx_release' }
-    const callerFingerprint = db.getOrCreateLocalMutationCallerFingerprint()
-    const payloadHash = createHash('sha256')
-      .update(JSON.stringify({ method: 'orchestration.workerRelease', params }))
-      .digest('hex')
-    db.beginMutationReceipt({
-      callerFingerprint,
-      requestId: 'mutation_release',
-      method: 'orchestration.workerRelease',
-      payloadHash
-    })
-    const effect = vi.fn().mockReturnValue({ state: 'release_pending' })
     const dispatcher = new RpcDispatcher({
       runtime,
       methods: [
@@ -273,15 +271,34 @@ describe('durable orchestration mutation ledger', () => {
         })
       ]
     })
+    const params = { dispatch: 'ctx_release' }
+    const dispatch = (rpcId: string) =>
+      dispatcher.dispatch({
+        id: rpcId,
+        authToken: 'caller-token',
+        method: 'orchestration.workerRelease',
+        params,
+        orchestrationContractVersion: ORCHESTRATION_CONTRACT_VERSION,
+        orchestrationRequestId: 'mutation_release'
+      })
+    const callerFingerprint = db.getOrCreateLocalMutationCallerFingerprint()
+    const payloadHash = createHash('sha256')
+      .update(JSON.stringify({ method: 'orchestration.workerRelease', params }))
+      .digest('hex')
+    return { db, dispatch, callerFingerprint, payloadHash }
+  }
 
-    const result = await dispatcher.dispatch({
-      id: 'rpc_release_retry',
-      authToken: 'caller-token',
+  it('resumes a pending idempotent worker release after restart, and keeps it re-enterable while non-final', async () => {
+    const effect: ReleaseEffect = vi.fn(() => ({ state: 'release_pending' }))
+    const { db, dispatch, callerFingerprint, payloadHash } = releaseHarness(effect)
+    db.beginMutationReceipt({
+      callerFingerprint,
+      requestId: 'mutation_release',
       method: 'orchestration.workerRelease',
-      params,
-      orchestrationContractVersion: ORCHESTRATION_CONTRACT_VERSION,
-      orchestrationRequestId: 'mutation_release'
+      payloadHash
     })
+
+    const result = await dispatch('rpc_release_retry')
 
     expect(result).toMatchObject({
       ok: true,
@@ -291,7 +308,42 @@ describe('durable orchestration mutation ledger', () => {
       }
     })
     expect(effect).toHaveBeenCalledTimes(1)
+    expect(db.getMutationReceipt(callerFingerprint, 'mutation_release')).toBeUndefined()
+
+    effect.mockReturnValue({ state: 'released' })
+    const again = await dispatch('rpc_release_again')
+    expect(again).toMatchObject({ ok: true, result: { state: 'released' } })
+    expect(effect).toHaveBeenCalledTimes(2)
     expect(db.getMutationReceipt(callerFingerprint, 'mutation_release')?.state).toBe('completed')
+    db.close()
+  })
+
+  it('re-enters a release that answered release_unknown instead of replaying it', async () => {
+    const effect: ReleaseEffect = vi.fn(() => ({
+      state: 'release_unknown',
+      processAction: 'closed_agent_terminal',
+      lastError: 'The agent terminal was closed but its process could not be confirmed stopped'
+    }))
+    const { db, dispatch, callerFingerprint } = releaseHarness(effect)
+
+    const first = await dispatch('rpc_release_1')
+    expect(first).toMatchObject({ ok: true, result: { state: 'release_unknown' } })
+    expect(db.getMutationReceipt(callerFingerprint, 'mutation_release')).toBeUndefined()
+
+    effect.mockReturnValue({ state: 'released', processAction: 'closed_agent_terminal' })
+    const second = await dispatch('rpc_release_2')
+    expect(second).toMatchObject({
+      ok: true,
+      result: { state: 'released', mutation: { requestId: 'mutation_release', replayed: false } }
+    })
+    expect(effect).toHaveBeenCalledTimes(2)
+
+    const third = await dispatch('rpc_release_3')
+    expect(third).toMatchObject({
+      ok: true,
+      result: { state: 'released', mutation: { requestId: 'mutation_release', replayed: true } }
+    })
+    expect(effect).toHaveBeenCalledTimes(2)
     db.close()
   })
 

--- a/src/main/runtime/runtime-terminal-contracts.ts
+++ b/src/main/runtime/runtime-terminal-contracts.ts
@@ -29,6 +29,11 @@ export type TerminalCreateOptions = {
   launchToken?: string
   launchAgent?: TuiAgent
   startupAgent?: TuiAgent
+  // Why: only meaningful with startupAgent. The prompt is embedded in the
+  // agent's launch (argv/flag per promptInjectionMode) so the first turn
+  // starts with the process — no paste, no submission verification. Agents
+  // whose plan would defer the prompt to a post-start paste are refused.
+  agentPrompt?: string
   launchPreferences?: AgentLaunchPreferences
   terminalColorQueryReplies?: TerminalOscColorQueryReplyColors
   viewMode?: 'terminal' | 'chat'

--- a/src/main/runtime/runtime-terminal-contracts.ts
+++ b/src/main/runtime/runtime-terminal-contracts.ts
@@ -29,10 +29,11 @@ export type TerminalCreateOptions = {
   launchToken?: string
   launchAgent?: TuiAgent
   startupAgent?: TuiAgent
-  // Why: only meaningful with startupAgent. The prompt is embedded in the
-  // agent's launch (argv/flag per promptInjectionMode) so the first turn
-  // starts with the process — no paste, no submission verification. Agents
-  // whose plan would defer the prompt to a post-start paste are refused.
+  // Why: embedded for startupAgent and for a bare command that resolves to a
+  // known TUI agent. The prompt is in the launch (argv/flag per
+  // promptInjectionMode) so the first turn starts with the process — no paste,
+  // no submission verification. Agents whose plan would defer the prompt to a
+  // post-start paste are refused.
   agentPrompt?: string
   launchPreferences?: AgentLaunchPreferences
   terminalColorQueryReplies?: TerminalOscColorQueryReplyColors

--- a/tests/e2e/completed-worker-retirement-resume.unit.test.ts
+++ b/tests/e2e/completed-worker-retirement-resume.unit.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { SleepingAgentSessionRecord } from '../../src/shared/agent-session-resume'
@@ -251,6 +252,8 @@ async function releaseCompletedWorker(terminalState: 'running' | 'exited'): Prom
     return method.handler(parsed, ctx)
   }
 
+  let workerLaunchTokenHash: string | null = null
+  vi.spyOn(runtime, 'createPreAllocatedTerminalHandle').mockReturnValue(TERMINAL_HANDLE)
   vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) =>
     handle === 'terminal-coordinator' ? coordinatorPaneKey : ORIGINAL_PANE_KEY
   )
@@ -258,21 +261,27 @@ async function releaseCompletedWorker(terminalState: 'running' | 'exited'): Prom
     handle === TERMINAL_HANDLE ? 'runtime:test:worker:1' : null
   )
   vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockImplementation((handle) =>
-    handle === TERMINAL_HANDLE
+    handle === TERMINAL_HANDLE && workerLaunchTokenHash
       ? ({
           terminalHandle: TERMINAL_HANDLE,
           paneKey: ORIGINAL_PANE_KEY,
           processIncarnation: 'runtime:test:worker:1',
+          launchTokenHash: workerLaunchTokenHash,
           hostScope: { kind: 'local', hostId: 'local' }
         } as never)
       : null
   )
   vi.spyOn(runtime, 'validateOrchestrationAgentLauncher').mockImplementation(() => {})
   vi.spyOn(runtime, 'showManagedTerminalWorkspace').mockResolvedValue({ id: WORKTREE_ID } as never)
-  vi.spyOn(runtime, 'createTerminal').mockResolvedValue({
-    handle: TERMINAL_HANDLE,
-    worktreeId: WORKTREE_ID,
-    title: 'PR 4626 unified correction r3'
+  vi.spyOn(runtime, 'createTerminal').mockImplementation(async (_selector, opts) => {
+    workerLaunchTokenHash = opts?.launchToken
+      ? createHash('sha256').update(opts.launchToken).digest('hex')
+      : null
+    return {
+      handle: TERMINAL_HANDLE,
+      worktreeId: WORKTREE_ID,
+      title: 'PR 4626 unified correction r3'
+    }
   })
   vi.spyOn(runtime, 'waitForTerminal').mockResolvedValue({
     handle: TERMINAL_HANDLE,
@@ -282,6 +291,7 @@ async function releaseCompletedWorker(terminalState: 'running' | 'exited'): Prom
     exitCode: null
   })
   vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
+  vi.spyOn(runtime, 'getWorktreeOrchestrationCliCommand').mockResolvedValue('orca')
   vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockResolvedValue({
     handle: TERMINAL_HANDLE,
     accepted: true,


### PR DESCRIPTION
### Problem

`orchestration.workerStart` currently delivers the dispatch preamble to a freshly created
agent terminal by waiting for `tui-idle`, pasting, pressing Enter, and then requiring a
`workingSequence` rise within `AGENT_PROMPT_EFFECT_TIMEOUT_MS` (5s, module constant —
`--timeout-ms` does not extend it).

For TUI agents with a long cold boot this verification fails in two distinct ways that
produce the same receipt:

1. Enter lands before the composer accepts input — the preamble sits unsubmitted in the
   editor. Measured on macOS/arm64 with `omp`: one fresh pane per trial, Enter at pane age
   5/6/7s never submits; at 8s and later it submits in ~1.5–2.2s.
2. The prompt IS submitted, but the agent runs pre-turn work (memory recall, compaction,
   classification) and reports `working` after the window closes.

Either way `failWorkerStart('dispatch_input', 'agent_prompt_stalled')` revokes the dispatch
capability. The damage is that the worker is frequently healthy: the brief runs (immediately
in case 2, or after any later Enter in case 1), the task completes, and the worker's
`worker_done` is then refused with "capability is revoked". Coordinator-side we measured
15/15 consecutive dispatches lost this way in one session.

Related: #16095, #15976, #15920, #15180 (tracker #15190).

### Approach

Agents whose `TUI_AGENT_CONFIG` entry has `promptInjectionMode: 'argv'` (claude, codex, omp,
trae, prime-agent, …) can start their first turn WITH the process — the same mechanism
`worktree create --prompt` already uses. For those agents, on the created-terminal path,
worker-start no longer pastes anything:

```
create dispatch
  → preAllocatedHandle = createPreAllocatedTerminalHandle()
  → launchToken = randomUUID(); commitDispatchLaunchTokenHash(dispatchId, sha256(token))
  → capability = mintStartingWorkerCapability(dispatchId)        # NEW: mint without binding
  → preamble = buildDispatchPreamble({ capability, workerHandle: preAllocatedHandle, … })
  → await createTerminal({ startupAgent, preAllocatedHandle, launchToken,
                           agentPrompt: preamble })               # prompt becomes argv
  → bindStartingWorkerAuthority(dispatchId, handle, paneKey, incarnation, launchTokenHash)
  → markWorkerDispatchReady                                       # immediately after bind
  → detached blocked-screen monitor (see below)
```

There is no submission to verify, so `agent_prompt_stalled` cannot fire on this path, and no
timing-based step exists anywhere between spawn, bind and ready — a fast completion can never
be refused as pending/pre-bind.

Everything used here already existed: `preAllocatedHandle` + `registerPreAllocatedHandleForPty`,
caller-supplied `launchToken` injected as `ORCA_AGENT_LAUNCH_TOKEN`, `launch_token_hash` on
`dispatch_contexts`, and the argv prompt plumbing in `buildAgentStartupPlan`. The change is a
reorder plus one DB method split.

### Security

- A capability minted before binding is inert: `verifyDispatchCapability` refuses any use
  until `assignee_pane_key` and `process_incarnation` are bound and match the caller.
- `bindStartingWorkerAuthority` requires the pane's launch-token hash to equal the
  pre-committed one — the binding pane must be the exact process that received
  `ORCA_AGENT_LAUNCH_TOKEN` at spawn. It also refuses to touch a revoked context (the atomic
  mint+bind could clear `capability_revoked_at`; split across transactions, clearing it would
  resurrect a capability revoked in between).
- Handle substitution by pane-adoption paths (`agentSessionEnsure`/`stablePaneOwner`) fails
  the start loudly: the preamble already names the pre-allocated handle as the worker's
  identity.
- The preamble is now visible in the process list. It contains the capability the same way
  the pasted pane text already did; same same-user trust boundary, called out for review.

### Blocked first screens

The old path failed the start when `tui-idle` detected a trust menu / update prompt. On the
argv path the brief is already delivered to the process, so failing (and revoking) would
orphan the work a human recovers by clearing the screen. Instead, `monitorArgvStartupBlocked`
runs detached AFTER ready and posts a high-priority `status` message to the Run when a
blocked reason is detected. Non-argv agents and the `--terminal` reuse path keep the existing
paste + verification behavior, including the hard readiness failure.

### Scope

Unchanged: `--terminal` reuse, non-argv agents, agent-first worktree creation
(`worker-start --worktree new-*`), federated/remote workers, `wait-for-setup` gated launches.

The worker CLI name (`orca` vs `orca-ide`) is resolved pre-spawn from the target workspace
(`getWorktreeOrchestrationCliCommand`) instead of the pane, preserving `orca-ide` for WSL
worktrees and bare `orca` for SSH/native.

### Files

- `rpc/methods/orchestration-worker-argv-start.ts` (new) — the argv dispatch path.
- `orchestration/db/worker-dispatch/worker-dispatch-argv-authority.ts` (new) —
  `mintStartingWorkerCapability` + `bindStartingWorkerAuthority`; `prepareStartingWorkerAuthority`
  stays as the atomic mint+bind for existing callers.
- `orchestration/cli-command.ts` — optional explicit `worktreePath` input.
- `orca-runtime.ts` — `TerminalCreateOptions.agentPrompt` threaded into the `startupAgent`
  launch plan (refused when the plan would defer to a post-start paste);
  `getWorktreeOrchestrationCliCommand`.
- `rpc/methods/orchestration-workers.ts` — routes argv-capable created-terminal starts to the
  new module.

### Tests

- `worker-dispatch-argv-authority.test.ts` (new): the mint/bind guards directly against an
  in-memory OrchestrationDb — an unbound capability is inert (`verifyDispatchCapability`
  refuses), a second mint is refused instead of rotating the argv-baked plaintext, bind
  refuses a missing mint, a mismatched or absent launch token against a commitment, and a
  revocation that landed between mint and bind (never resurrected); after bind the capability
  is valid only for the exact bound pane, and a pane carrying another active dispatch refuses
  a second bind.
- `cli-command.test.ts`: workspace CLI resolver coverage (WSL pane, WSL project runtime, UNC
  path, opaque folder id + explicit path, native, SSH).
- `orchestration-composed-workers.test.ts` updated to the argv contract: preamble delivered
  via `createTerminal.agentPrompt` with the capability baked in; launch-token commitment
  equals the token handed to the spawn; blocked screens yield a ready dispatch plus a
  high-priority Run message; `orca-ide` embedded pre-spawn for WSL workspaces. Paste-path
  contracts (readiness timeout, input rejection accounting) retained on a non-argv agent.
- Full `src/main/runtime/orchestration` + `src/main/runtime/rpc`: 2037 passed / 5 skipped.
  `orca-runtime.test.ts` + `tui-agent-startup.test.ts`: 1261 passed / 1 skipped. Node
  typecheck clean.
- Local end-to-end on a packaged unsigned macOS build, isolated profile: cold
  `worker-start --worktree current --agent omp` returned `state: ready` in 0.16s; the
  dispatch was `dispatched/ready` while the pane was still `Working…`; the worker's
  `worker_done` settled `succeeded` with the capability alive until normal settlement.
