### PR TITLE
fix(sidebar): follow agent-side session renames in agent rows

### DIFF
--- a/src/renderer/src/components/dashboard/dashboard-card-labels.ts
+++ b/src/renderer/src/components/dashboard/dashboard-card-labels.ts
@@ -49,7 +49,12 @@ export function rowConversationName(
     parsePaneKey(row.paneKey)?.leafId
   )
   return (
-    getAgentRowConversationName(row.tab, row.agentType, generatedTitlesEnabled, paneLiveTitle) ??
-    undefined
+    getAgentRowConversationName(
+      row.tab,
+      row.agentType,
+      generatedTitlesEnabled,
+      paneLiveTitle,
+      row.entry.providerSession?.id ?? null
+    ) ?? undefined
   )
 }

--- a/src/renderer/src/components/dashboard/use-agent-row-conversation-name.test.ts
+++ b/src/renderer/src/components/dashboard/use-agent-row-conversation-name.test.ts
@@ -264,4 +264,83 @@ describe('useAgentRowConversationName', () => {
     }
     expect(useAgentRowConversationName(agent)).toBe('Fix intake flow')
   })
+
+  describe('AI Vault session titles', () => {
+    function codexAgent(providerSessionId?: string): DashboardAgentRow {
+      return makeAgent({
+        agentType: 'codex',
+        entry: {
+          prompt: 'fix the sidebar',
+          ...(providerSessionId ? { providerSession: { id: providerSessionId } } : {})
+        },
+        tab: { id: 'tab-1', worktreeId: 'wt-1', customTitle: null, title: 'Codex ready' }
+      } as Partial<DashboardAgentRow>)
+    }
+
+    it('follows an agent-side session rename without a manual tab rename', () => {
+      // Why: Codex `/rename` updates session_index.jsonl; ai-vault title sync
+      // writes it onto the live tab, and the row must read that live value.
+      storeState.current = {
+        settings: {},
+        tabsByWorktree: {
+          'wt-1': [
+            {
+              id: 'tab-1',
+              worktreeId: 'wt-1',
+              customTitle: null,
+              title: 'Codex ready',
+              aiVaultTitle: { agent: 'codex', sessionId: 'sess-1', title: 'orca sidebar rename' }
+            }
+          ]
+        }
+      }
+      expect(useAgentRowConversationName(codexAgent('sess-1'))).toBe('orca sidebar rename')
+    })
+
+    it('updates when the synced title changes on the live tab', () => {
+      const writeStore = (title: string): void => {
+        storeState.current = {
+          settings: {},
+          tabsByWorktree: {
+            'wt-1': [
+              {
+                id: 'tab-1',
+                worktreeId: 'wt-1',
+                customTitle: null,
+                title: 'Codex ready',
+                aiVaultTitle: { agent: 'codex', sessionId: 'sess-1', title }
+              }
+            ]
+          }
+        }
+      }
+      writeStore('first name')
+      expect(useAgentRowConversationName(codexAgent('sess-1'))).toBe('first name')
+      writeStore('renamed by /rename')
+      expect(useAgentRowConversationName(codexAgent('sess-1'))).toBe('renamed by /rename')
+    })
+
+    it('keeps a different session from lending its name to this row', () => {
+      storeState.current = {
+        settings: {},
+        tabsByWorktree: {
+          'wt-1': [
+            {
+              id: 'tab-1',
+              worktreeId: 'wt-1',
+              customTitle: null,
+              title: 'Codex ready',
+              aiVaultTitle: { agent: 'codex', sessionId: 'sess-other', title: 'Sibling name' }
+            }
+          ]
+        },
+        // Why: a split tab makes pane-live-title resolution return null for an
+        // unattributed pane, proving ownership matters even without a live title.
+        terminalLayoutsByTabId: {
+          'tab-1': { root: { type: 'split' } }
+        }
+      }
+      expect(useAgentRowConversationName(codexAgent('sess-1'))).toBeNull()
+    })
+  })
 })

--- a/src/renderer/src/components/dashboard/use-agent-row-conversation-name.test.ts
+++ b/src/renderer/src/components/dashboard/use-agent-row-conversation-name.test.ts
@@ -266,6 +266,7 @@ describe('useAgentRowConversationName', () => {
   })
 
   describe('AI Vault session titles', () => {
+    /** A Codex row whose entry optionally carries a provider session id. */
     function codexAgent(providerSessionId?: string): DashboardAgentRow {
       return makeAgent({
         agentType: 'codex',
@@ -298,6 +299,7 @@ describe('useAgentRowConversationName', () => {
     })
 
     it('updates when the synced title changes on the live tab', () => {
+      /** Points the live store tab's synced AI Vault title at a new name. */
       const writeStore = (title: string): void => {
         storeState.current = {
           settings: {},

--- a/src/renderer/src/components/dashboard/use-agent-row-conversation-name.ts
+++ b/src/renderer/src/components/dashboard/use-agent-row-conversation-name.ts
@@ -59,11 +59,15 @@ export function useAgentRowConversationName(agent: DashboardAgentRow): string | 
   if (cannotOwnTabName) {
     return null
   }
+  // Why: the AI Vault title is tab-scoped, so split panes must prove the
+  // session is theirs before borrowing its name.
+  const providerSessionId = agent.entry.providerSession?.id ?? null
   // Why: retained row snapshots need a fallback after their live tab disappears.
   return getAgentRowConversationName(
     liveTab ?? agent.tab,
     agent.agentType,
     generatedTitlesEnabled,
-    paneLiveTitle
+    paneLiveTitle,
+    providerSessionId
   )
 }

--- a/src/renderer/src/components/dashboard/use-agent-row-conversation-name.ts
+++ b/src/renderer/src/components/dashboard/use-agent-row-conversation-name.ts
@@ -9,6 +9,7 @@ type WorktreeTabs = NonNullable<AppState['tabsByWorktree'][string]>
 
 const tabIndexByTabs = new WeakMap<WorktreeTabs, ReadonlyMap<string, WorktreeTabs[number]>>()
 
+/** Looks a tab up in the per-array index, building the index on first use. */
 function getIndexedTab(
   tabs: WorktreeTabs | undefined,
   tabId: string

--- a/src/shared/agent-row-conversation-name.test.ts
+++ b/src/shared/agent-row-conversation-name.test.ts
@@ -4,6 +4,7 @@ import {
   type ConversationNameTab
 } from './agent-row-conversation-name'
 
+/** A conversation-name tab with every source empty unless a test overrides it. */
 function makeTab(overrides: Partial<ConversationNameTab> = {}): ConversationNameTab {
   return { customTitle: null, title: '', ...overrides }
 }

--- a/src/shared/agent-row-conversation-name.test.ts
+++ b/src/shared/agent-row-conversation-name.test.ts
@@ -31,6 +31,44 @@ describe('getAgentRowConversationName', () => {
     )
   })
 
+  it('uses the AI Vault session title like the tab bar does', () => {
+    // Why: Codex `/rename` names the session in session_index.jsonl; the tab
+    // bar already surfaces that name via aiVaultTitle, so the sidebar row must
+    // agree instead of falling back to the generated title.
+    const tab = makeTab({
+      aiVaultTitle: { agent: 'codex', sessionId: 'sess-1', title: 'orca sidebar rename' },
+      generatedTitle: 'Fix intake flow',
+      title: 'Codex ready'
+    })
+    expect(getAgentRowConversationName(tab, 'codex', true, undefined, 'sess-1')).toBe(
+      'orca sidebar rename'
+    )
+  })
+
+  it('keeps tab-owned renames above the AI Vault session title', () => {
+    const tab = makeTab({
+      customTitle: 'Patient sync spike',
+      aiVaultTitle: { agent: 'codex', sessionId: 'sess-1', title: 'orca sidebar rename' }
+    })
+    expect(getAgentRowConversationName(tab, 'codex', true, undefined, 'sess-1')).toBe(
+      'Patient sync spike'
+    )
+  })
+
+  it('lends an AI Vault title only to the row that owns the session', () => {
+    const tab = makeTab({
+      aiVaultTitle: { agent: 'codex', sessionId: 'sess-1', title: 'orca sidebar rename' },
+      generatedTitle: 'Fix intake flow'
+    })
+    // A split sibling with a different session keeps its own labels.
+    expect(getAgentRowConversationName(tab, 'codex', true, null, 'sess-2')).toBe('Fix intake flow')
+    // A row without a session may only borrow the title on a single-pane tab.
+    expect(getAgentRowConversationName(tab, 'codex', true, undefined)).toBe('orca sidebar rename')
+    expect(getAgentRowConversationName(tab, 'codex', true, null)).toBe('Fix intake flow')
+    // And only when the agent identity agrees.
+    expect(getAgentRowConversationName(tab, 'claude', true, undefined)).toBe('Fix intake flow')
+  })
+
   it('uses the generated title only when generated titles are enabled', () => {
     const tab = makeTab({ generatedTitle: 'Fix intake flow', title: '✳ Investigate replay bug' })
     expect(getAgentRowConversationName(tab, 'claude', true)).toBe('Fix intake flow')

--- a/src/shared/agent-row-conversation-name.ts
+++ b/src/shared/agent-row-conversation-name.ts
@@ -1,11 +1,13 @@
 // Resolves the stable "conversation name" an agent row can show instead of the
 // live last-message preview. Sources, in the same precedence the tab bar uses
 // (tab-title-resolution.ts): manual rename → quick-command label → OpenCode's
-// semantic session title → Orca's generated title → the agent-set live title.
+// semantic session title → the AI Vault session title (the agent-side
+// `/rename` name) → Orca's generated title → the agent-set live title.
 // Live titles are accepted only when they carry a real name — pure status,
 // identity-echo, and spinner/cwd titles yield null so callers keep the
 // last-message label.
 import type { AgentType } from './agent-status-types'
+import type { AiVaultSessionTitle } from './ai-vault-session-title'
 import { isClaudeManagementTitle } from './agent-title-core'
 import { stripLeadingAgentTitleDecorationOrEmpty } from './agent-title-decoration'
 import { formatAgentTypeLabel } from './agent-type-label'
@@ -15,7 +17,7 @@ import type { TerminalTab } from './terminal-tab-types'
 
 export type ConversationNameTab = Pick<
   TerminalTab,
-  'customTitle' | 'quickCommandLabel' | 'generatedTitle' | 'title' | 'defaultTitle'
+  'customTitle' | 'quickCommandLabel' | 'aiVaultTitle' | 'generatedTitle' | 'title' | 'defaultTitle'
 >
 
 // Why: synthetic status titles ("Codex ready", "Cursor - action required") are
@@ -78,6 +80,26 @@ function isCwdLikeTitle(title: string): boolean {
   return !/\s/.test(title) && /[\\/]/.test(title)
 }
 
+/**
+ * Whether the tab's AI Vault session title belongs to THIS row.
+ *
+ * The title is stored per tab while the row is per pane: on a split tab it may
+ * name a sibling pane's session. A row proves ownership with its provider
+ * session id; rows without one (title-derived fallbacks) may only borrow the
+ * title on a single-pane tab, and only when the agent identity agrees.
+ */
+function aiVaultTitleOwnsRow(
+  title: AiVaultSessionTitle,
+  agentType: AgentType | null | undefined,
+  providerSessionId: string | null | undefined,
+  paneLiveTitle: string | null | undefined
+): boolean {
+  if (providerSessionId) {
+    return title.sessionId === providerSessionId
+  }
+  return paneLiveTitle === undefined && agentType === title.agent
+}
+
 function conversationNameFromLiveTitle(
   liveTitle: string,
   agentType: AgentType | null | undefined,
@@ -119,7 +141,11 @@ export function getAgentRowConversationName(
   // this row's own pane title, or `null` when none resolves; `undefined` (a
   // single-pane tab) keeps the tab title. Tab-owned names above are unaffected:
   // the user gave those to the whole tab and they do not flip on focus.
-  paneLiveTitle?: string | null
+  paneLiveTitle?: string | null,
+  // Why: `aiVaultTitle` is tab-scoped, so a split tab's sibling session must
+  // not lend its name to this row. The row's provider session id proves which
+  // session the row belongs to.
+  providerSessionId?: string | null
 ): string | null {
   const customTitle = tab.customTitle?.trim()
   if (customTitle) {
@@ -133,6 +159,14 @@ export function getAgentRowConversationName(
     paneLiveTitle === undefined ? (tab.title?.trim() ?? '') : (paneLiveTitle?.trim() ?? '')
   if (isMeaningfulOpenCodeTerminalTitle(liveTitle)) {
     return liveTitle
+  }
+  const aiVaultTitle = tab.aiVaultTitle?.title.trim()
+  if (
+    aiVaultTitle &&
+    tab.aiVaultTitle &&
+    aiVaultTitleOwnsRow(tab.aiVaultTitle, agentType, providerSessionId, paneLiveTitle)
+  ) {
+    return aiVaultTitle
   }
   const generatedTitle = generatedTitlesEnabled ? tab.generatedTitle?.trim() : ''
   if (generatedTitle) {

--- a/src/shared/agent-row-conversation-name.ts
+++ b/src/shared/agent-row-conversation-name.ts
@@ -100,6 +100,10 @@ function aiVaultTitleOwnsRow(
   return paneLiveTitle === undefined && agentType === title.agent
 }
 
+/**
+ * The usable name inside an agent-set live title, or null when the title is
+ * pure status/identity/cwd noise and the caller should keep its own label.
+ */
 function conversationNameFromLiveTitle(
   liveTitle: string,
   agentType: AgentType | null | undefined,


### PR DESCRIPTION
## ELI5

When you rename a session inside the agent (e.g. Codex `/rename`), Orca's tab already picks up the new name, but the agent row in the left sidebar keeps the old/default label. This PR makes the sidebar row (and the dashboard card) use the same session name the tab bar already shows.

## What Changed

- `getAgentRowConversationName` (`src/shared/agent-row-conversation-name.ts`) now resolves the AI Vault session title (`tab.aiVaultTitle`) with the same precedence the tab bar uses in `resolveTerminalTabTitle`: manual rename → quick-command label → OpenCode semantic title → **AI Vault session title** → generated title → agent-set live title.
- Because `aiVaultTitle` is stored per tab while rows are per pane, the title is only lent to a row that owns it: a row proves ownership via its `providerSession.id`; rows without a provider session may borrow it only on a single-pane tab and only when the agent identity agrees, so split panes cannot swap each other's names.
- Both call sites — the sidebar row hook (`use-agent-row-conversation-name.ts`) and the dashboard card labels (`dashboard-card-labels.ts`) — pass the row's provider session id.
- Unit tests for precedence, live-title updates, split-pane ownership, and manual-rename precedence.

## Why

The name already flows into Orca — the missing piece was one resolver:

```
Codex /rename
  → ~/.codex/session_index.jsonl (thread_name)
  → AI Vault session scanner
  → ai-vault-tab-title-sync writes tab.aiVaultTitle
  → resolveTerminalTabTitle reads aiVaultTitle      → tab updates ✓
  → getAgentRowConversationName ignored aiVaultTitle → sidebar stuck ✗
```

Until now the only way to make both surfaces agree was a manual tab rename (⌘R), because that writes `customTitle`, which every resolver honors. Aligning the row resolver with the tab resolver keeps all session surfaces consistent without user action.

## Linked Issue

Fixes #9707
Refs #10250, #16094, #15497

## Visual Proof

Behavior change (labels, no layout change):

- **BEFORE:** after Codex `/rename orca自动改名`, the terminal tab shows `orca自动改名` while the left-sidebar agent row keeps the default/project label until the user renames the tab manually (⌘R).
    <img width="774" height="386" alt="Clipboard_Screenshot_1787651006" src="https://github.com/user-attachments/assets/4e78cba1-1e4c-4d0a-8840-c0433c19588c" />

- **AFTER:** the sidebar agent row updates to `orca自动改名` together with the tab title (verified on macOS; a new tab or pane switch triggers the reconcile immediately, otherwise the existing 5-minute live refresh applies — identical to today's tab behavior).
    <img width="729" height="350" alt="Clipboard_Screenshot_1787651042" src="https://github.com/user-attachments/assets/f3c3999f-4dfd-4e01-81ba-1c7810781cf2" />

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Manual (macOS, ARM, dev build on the PR branch): opened a Codex session, ran `/rename`, and confirmed the sidebar agent row now follows the session name together with the tab title. Manual ⌘R rename still takes precedence, as before.

Automated:

- `pnpm vitest run --config config/vitest.config.ts src/shared/agent-row-conversation-name.test.ts src/renderer/src/components/dashboard/use-agent-row-conversation-name.test.ts` — 31 passed (8 new cases: follow agent-side rename, re-resolve on synced-title change, split-pane ownership, manual-rename precedence).
- `pnpm vitest run --config config/vitest.config.ts src/renderer/src/components/dashboard/build-dashboard-snapshot.test.ts src/renderer/src/components/sidebar/WorktreeCardAgents.test.tsx src/renderer/src/components/dashboard/DashboardAgentRow.test.tsx` — 77 passed.
- `pnpm typecheck`, `oxlint`, and `oxfmt` pass on the touched files.

## AI Disclosure

Implementation, tests, and this description were drafted with AI assistance (Codex agent, GLM model via TKEHub); the fix was reviewed, built, and manually verified by the PR author on macOS.

## Review

Small, focused change: one shared resolver + two call sites + tests. The ownership rule (provider-session match, single-pane fallback with agent-identity check) is the only subtle part and is covered by tests.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Security: no new input surface; the title already arrives via the existing local AI Vault scan pipeline, and no paths are derived from it.
- Cross-platform (Linux/Windows/macOS): pure shared/renderer string logic, no platform branches.
- Remote SSH: remote sessions report `providerSession` through the existing hook path and are covered by the same ownership check; hook-less panes without an AI Vault title keep their previous fallback behavior.
- Mobile/web: surfaces built on the same shared resolver label sessions consistently.
- Backwards compatibility: the new resolver argument is optional; callers that do not pass it keep their previous behavior. Manual renames (⌘R) and quick-command labels still outrank the session title.
- Performance: no new subscriptions or scans — only a string comparison on rows that already re-render when their tab record changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — lint/typecheck/targeted tests run locally; full test suite and build covered by CI