### PR TITLE
draft(crash-reporting): stop deriving a faulting module from a POSIX data address

### DIFF
--- a/src/main/crash-reporting/minidump-crash-signature.test.ts
+++ b/src/main/crash-reporting/minidump-crash-signature.test.ts
@@ -1,9 +1,38 @@
 import { describe, expect, it } from 'vitest'
 import { minidumpSignatureDetails, parseMinidumpCrashSignature } from './minidump-crash-signature'
+import { appendMinidumpSignatureLines } from '../../shared/crash-report-signature-lines'
 
 const STREAM_TYPE_MODULE_LIST = 4
 const STREAM_TYPE_EXCEPTION = 6
 const STREAM_TYPE_CRASHPAD_INFO = 0x43500001
+const STREAM_TYPE_SYSTEM_INFO = 7
+
+const PLATFORM_ID_WIN32_NT = 2
+const PLATFORM_ID_MAC_OS_X = 0x8101
+const PLATFORM_ID_LINUX = 0x8201
+const CPU_ARCHITECTURE_AMD64 = 9
+const CPU_ARCHITECTURE_ARM64 = 12
+const CPU_ARCHITECTURE_ARM32 = 5
+
+const WINDOWS_X64 = { platformId: PLATFORM_ID_WIN32_NT, architecture: CPU_ARCHITECTURE_AMD64 }
+const LINUX_X64 = { platformId: PLATFORM_ID_LINUX, architecture: CPU_ARCHITECTURE_AMD64 }
+const MAC_ARM64 = { platformId: PLATFORM_ID_MAC_OS_X, architecture: CPU_ARCHITECTURE_ARM64 }
+
+/** CONTEXT_AMD64 with Rip at its documented offset. */
+function amd64Context(rip: bigint): Buffer {
+  const buf = Buffer.alloc(1232)
+  buf.writeUInt32LE(0x0010_000f, 48)
+  buf.writeBigUInt64LE(rip, 248)
+  return buf
+}
+
+/** Crashpad MinidumpContextARM64 with pc at its documented offset. */
+function arm64Context(pc: bigint): Buffer {
+  const buf = Buffer.alloc(912)
+  buf.writeUInt32LE(0x0040_0003, 0)
+  buf.writeBigUInt64LE(pc, 264)
+  return buf
+}
 
 /**
  * Builds real Crashpad-layout minidumps so the parser is tested against the
@@ -87,11 +116,17 @@ type BuiltDump = { dump: Buffer }
 function buildDump(options: {
   annotations?: Record<string, string>
   simpleAnnotations?: Record<string, string>
-  exception?: { code: number; address: bigint }
+  exception?: { code: number; address: bigint; threadContext?: Buffer }
   modules?: { base: bigint; size: number; name: string }[]
+  /** Count written into the module list header, as a corrupt dump would carry. */
+  declaredModuleCount?: number
+  systemInfo?: { platformId: number; architecture: number }
 }): BuiltDump {
   const streamCount =
-    1 + (options.exception ? 1 : 0) + (options.modules && options.modules.length > 0 ? 1 : 0)
+    1 +
+    (options.exception ? 1 : 0) +
+    (options.modules && options.modules.length > 0 ? 1 : 0) +
+    (options.systemInfo ? 1 : 0)
   const builder = new MinidumpBuilder(32 + streamCount * 12)
   const streams: { type: number; size: number; rva: number }[] = []
 
@@ -165,7 +200,7 @@ function buildDump(options: {
   if (options.modules && options.modules.length > 0) {
     const nameRvas = options.modules.map((module) => builder.utf16String(module.name))
     const listBuf = Buffer.alloc(4 + options.modules.length * 108)
-    listBuf.writeUInt32LE(options.modules.length, 0)
+    listBuf.writeUInt32LE(options.declaredModuleCount ?? options.modules.length, 0)
     options.modules.forEach((module, index) => {
       const at = 4 + index * 108
       listBuf.writeBigUInt64LE(module.base, at)
@@ -179,11 +214,28 @@ function buildDump(options: {
     })
   }
 
+  if (options.systemInfo) {
+    const systemInfoBuf = Buffer.alloc(56)
+    systemInfoBuf.writeUInt16LE(options.systemInfo.architecture, 0)
+    systemInfoBuf.writeUInt32LE(options.systemInfo.platformId, 20)
+    streams.push({
+      type: STREAM_TYPE_SYSTEM_INFO,
+      size: systemInfoBuf.length,
+      rva: builder.append(systemInfoBuf)
+    })
+  }
+
   if (options.exception) {
+    const contextRva = options.exception.threadContext
+      ? builder.append(options.exception.threadContext)
+      : 0
     const exceptionBuf = Buffer.alloc(168)
     exceptionBuf.writeUInt32LE(1234, 0) // ThreadId
     exceptionBuf.writeUInt32LE(options.exception.code, 8)
     exceptionBuf.writeBigUInt64LE(options.exception.address, 24)
+    // MINIDUMP_EXCEPTION_STREAM.ThreadContext, after the 152-byte MINIDUMP_EXCEPTION.
+    exceptionBuf.writeUInt32LE(options.exception.threadContext?.length ?? 0, 160)
+    exceptionBuf.writeUInt32LE(contextRva, 164)
     streams.push({
       type: STREAM_TYPE_EXCEPTION,
       size: exceptionBuf.length,
@@ -315,8 +367,9 @@ describe('parseMinidumpCrashSignature', () => {
     expect(Object.keys(signature?.annotations ?? {})).toEqual(['LOG_FATAL'])
   })
 
-  it('resolves the faulting module from the exception address', () => {
+  it('resolves the faulting module from a Windows exception address', () => {
     const { dump } = buildDump({
+      systemInfo: WINDOWS_X64,
       exception: { code: 0x80000003, address: 0x7ff8_0000_1234n },
       modules: [
         {
@@ -338,18 +391,313 @@ describe('parseMinidumpCrashSignature', () => {
     expect(signature?.exceptionAddress).toBe('0x7ff800001234')
     expect(signature?.faultingModule).toBe('chrome_elf.dll')
     expect(signature?.faultingModuleOffset).toBe('0x1234')
+    expect(signature?.faultingModuleUnavailable).toBeUndefined()
   })
 
-  it('omits the faulting module when no image range covers the address', () => {
+  it('reports why no image range covers a Windows exception address', () => {
     const { dump } = buildDump({
-      exception: { code: 11, address: 0x10n },
-      modules: [{ base: 0x7ff7_0000_0000n, size: 0x1000, name: '/opt/orca/orca' }]
+      systemInfo: WINDOWS_X64,
+      exception: { code: 0xc000_0005, address: 0x10n },
+      modules: [{ base: 0x7ff7_0000_0000n, size: 0x1000, name: 'C:\\Orca\\Orca.exe' }]
     })
 
     const signature = parseMinidumpCrashSignature(dump)
 
     expect(signature?.exceptionAddress).toBe('0x10')
     expect(signature?.faultingModule).toBeUndefined()
+    expect(signature?.faultingModuleUnavailable).toContain('0x10')
+  })
+
+  // Crash 1.4.188 / linux x64 SIGSEGV: exception address 0x27d787ec0000 is
+  // siginfo.si_addr, so a module covering it names the owner of the bad pointer.
+  it('never names a module from a POSIX signal exception address', () => {
+    const { dump } = buildDump({
+      systemInfo: LINUX_X64,
+      exception: { code: 11, address: 0x27d7_87ec_0000n },
+      modules: [
+        { base: 0x27d7_87ec_0000n, size: 0x10_0000, name: '/opt/orca/libffmpeg.so' },
+        { base: 0x5566_0000_0000n, size: 0x10_0000, name: '/opt/orca/orca' }
+      ]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.exceptionAddress).toBe('0x27d787ec0000')
+    expect(signature?.faultingModule).toBeUndefined()
+    expect(signature?.faultingModuleOffset).toBeUndefined()
+    expect(signature?.faultingModuleUnavailable).toMatch(/instruction pointer/i)
+  })
+
+  // Same crash shape, but with the thread context Crashpad normally writes.
+  it('names the module from the thread-context instruction pointer on Linux', () => {
+    const { dump } = buildDump({
+      systemInfo: LINUX_X64,
+      exception: {
+        code: 11,
+        address: 0x3f76_057d_ffbcn,
+        threadContext: amd64Context(0x5566_0000_2345n)
+      },
+      modules: [
+        { base: 0x3f76_0000_0000n, size: 0x1000_0000, name: '/opt/orca/libffmpeg.so' },
+        { base: 0x5566_0000_0000n, size: 0x10_0000, name: '/opt/orca/libGLESv2.so' }
+      ]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.exceptionAddress).toBe('0x3f76057dffbc')
+    expect(signature?.faultingModule).toBe('libGLESv2.so')
+    expect(signature?.faultingModuleOffset).toBe('0x2345')
+    expect(signature?.faultingModuleUnavailable).toBeUndefined()
+  })
+
+  it('reads the instruction pointer from an arm64 macOS thread context', () => {
+    const { dump } = buildDump({
+      systemInfo: MAC_ARM64,
+      exception: {
+        code: 10,
+        address: 0x1n,
+        threadContext: arm64Context(0x1_0400_0100n)
+      },
+      modules: [
+        { base: 0x1_0000_0000n, size: 0x1000, name: '/Applications/Orca.app/Contents/MacOS/Orca' },
+        {
+          base: 0x1_0400_0000n,
+          size: 0x10_0000,
+          name: '/Applications/Orca.app/Contents/Frameworks/Electron Framework'
+        }
+      ]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe('Electron Framework')
+    expect(signature?.faultingModuleOffset).toBe('0x100')
+  })
+
+  it('says the module is unavailable when a POSIX dump carries no thread context', () => {
+    const { dump } = buildDump({
+      systemInfo: LINUX_X64,
+      exception: { code: 11, address: 0x27d7_87ec_0000n },
+      modules: [{ base: 0x5566_0000_0000n, size: 0x10_0000, name: '/opt/orca/orca' }]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBeUndefined()
+    expect(signature?.faultingModuleUnavailable).toMatch(/thread context/i)
+  })
+
+  // Distrusting the exception address is a POSIX rule; a dump that never says
+  // which OS it came from must not lose an attribution over it.
+  it('still resolves a Windows exception address when the dump carries no system info', () => {
+    const { dump } = buildDump({
+      exception: { code: 0x80000003, address: 0x7ff8_0000_1234n },
+      modules: [{ base: 0x7ff8_0000_0000n, size: 0x10_0000, name: 'chrome_elf.dll' }]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe('chrome_elf.dll')
+    expect(signature?.faultingModuleOffset).toBe('0x1234')
+    expect(signature?.faultingModuleUnavailable).toBeUndefined()
+  })
+
+  // The unavailable reason is read as a debugging assertion: the fallback path
+  // has explicitly declined to establish that the value is an instruction pointer.
+  it('names the exception address, not an instruction pointer, in the out-of-range reason', () => {
+    const { dump } = buildDump({
+      systemInfo: WINDOWS_X64,
+      exception: { code: 0xc000_0005, address: 0x10n },
+      modules: [{ base: 0x7ff7_0000_0000n, size: 0x1000, name: 'C:\\Orca\\Orca.exe' }]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModuleUnavailable).toBe(
+      'exception address 0x10 is outside every loaded module'
+    )
+    expect(signature?.faultingModuleUnavailable).not.toMatch(/instruction pointer/i)
+  })
+
+  // The loop-1 crash again, minus the SYSTEM_INFO stream: the parser cannot tell
+  // this from a Windows dump, so it must publish the module with the caveat
+  // rather than as a confident instruction-pointer attribution.
+  it('caveats a module named from the exception address of an unidentified platform', () => {
+    const { dump } = buildDump({
+      exception: { code: 11, address: 0x27d7_87ec_0000n },
+      modules: [
+        { base: 0x27d7_87ec_0000n, size: 0x10_0000, name: '/opt/orca/libffmpeg.so' },
+        { base: 0x5566_0000_0000n, size: 0x10_0000, name: '/opt/orca/orca' }
+      ]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe('libffmpeg.so')
+    expect(signature?.faultingModuleOffset).toBe('0x0')
+    expect(signature?.faultingModuleCaveat).toBe(
+      'named from the exception address; this dump does not say which OS it came from, so that may be the faulting data address rather than the instruction pointer'
+    )
+    expect(minidumpSignatureDetails(signature!).minidumpFaultingModuleCaveat).toBe(
+      signature?.faultingModuleCaveat
+    )
+  })
+
+  it('caveats a module named from the exception address of an unrecognised platform id', () => {
+    const { dump } = buildDump({
+      systemInfo: { platformId: 0x7fff, architecture: CPU_ARCHITECTURE_AMD64 },
+      exception: { code: 0x80000003, address: 0x7ff8_0000_1234n },
+      modules: [{ base: 0x7ff8_0000_0000n, size: 0x10_0000, name: 'chrome_elf.dll' }]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe('chrome_elf.dll')
+    expect(signature?.faultingModuleCaveat).toMatch(/exception address/i)
+  })
+
+  // A dump that names a Windows platform id is not guessing: ExceptionAddress is
+  // the instruction pointer there, so the caveat would be noise.
+  it('does not caveat a module named from a Windows exception address', () => {
+    const { dump } = buildDump({
+      systemInfo: WINDOWS_X64,
+      exception: { code: 0x80000003, address: 0x7ff8_0000_1234n },
+      modules: [{ base: 0x7ff8_0000_0000n, size: 0x10_0000, name: 'chrome_elf.dll' }]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe('chrome_elf.dll')
+    expect(signature?.faultingModuleCaveat).toBeUndefined()
+    expect(minidumpSignatureDetails(signature!).minidumpFaultingModuleCaveat).toBeUndefined()
+  })
+
+  // An instruction pointer read from the thread context is never a guess.
+  it('does not caveat a module named from the thread-context instruction pointer', () => {
+    const { dump } = buildDump({
+      systemInfo: LINUX_X64,
+      exception: {
+        code: 11,
+        address: 0x3f76_057d_ffbcn,
+        threadContext: amd64Context(0x5566_0000_2345n)
+      },
+      modules: [{ base: 0x5566_0000_0000n, size: 0x10_0000, name: '/opt/orca/libGLESv2.so' }]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe('libGLESv2.so')
+    expect(signature?.faultingModuleCaveat).toBeUndefined()
+  })
+
+  it('still resolves an exception address when the platform id is unrecognised', () => {
+    const { dump } = buildDump({
+      systemInfo: { platformId: 0x7fff, architecture: CPU_ARCHITECTURE_AMD64 },
+      exception: { code: 0x80000003, address: 0x7ff8_0000_1234n },
+      modules: [{ base: 0x7ff8_0000_0000n, size: 0x10_0000, name: 'chrome_elf.dll' }]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe('chrome_elf.dll')
+    expect(signature?.faultingModuleOffset).toBe('0x1234')
+  })
+
+  it('does not claim a missing thread context when the architecture is unmapped', () => {
+    const { dump } = buildDump({
+      systemInfo: { platformId: PLATFORM_ID_LINUX, architecture: CPU_ARCHITECTURE_ARM32 },
+      exception: { code: 11, address: 0x27d7_87ec_0000n, threadContext: arm64Context(0x1n) },
+      modules: [{ base: 0x5566_0000_0000n, size: 0x10_0000, name: '/opt/orca/orca' }]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBeUndefined()
+    expect(signature?.faultingModuleUnavailable).not.toMatch(/no thread context/i)
+    expect(signature?.faultingModuleUnavailable).toMatch(/architecture/i)
+  })
+
+  it('distinguishes a truncated thread context from an absent one', () => {
+    const { dump } = buildDump({
+      systemInfo: LINUX_X64,
+      exception: { code: 11, address: 0x27d7_87ec_0000n, threadContext: Buffer.alloc(64) },
+      modules: [{ base: 0x5566_0000_0000n, size: 0x10_0000, name: '/opt/orca/orca' }]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBeUndefined()
+    expect(signature?.faultingModuleUnavailable).not.toMatch(/no thread context/i)
+    expect(signature?.faultingModuleUnavailable).toMatch(/truncat/i)
+  })
+
+  // SYSTEM_INFO describes the machine and can disagree with the CONTEXT actually
+  // stored; reading an ARM64 pc out of a CONTEXT_AMD64 yields a plausible zero.
+  it('falls back to the exception address when the context is not the named architecture', () => {
+    const { dump } = buildDump({
+      systemInfo: { platformId: PLATFORM_ID_WIN32_NT, architecture: CPU_ARCHITECTURE_ARM64 },
+      exception: {
+        code: 0xc000_0005,
+        address: 0x7ff8_0000_1234n,
+        threadContext: amd64Context(0x7ff8_0000_1234n)
+      },
+      modules: [{ base: 0x7ff8_0000_0000n, size: 0x10_0000, name: 'chrome_elf.dll' }]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe('chrome_elf.dll')
+    expect(signature?.faultingModuleOffset).toBe('0x1234')
+    expect(signature?.faultingModuleUnavailable).toBeUndefined()
+  })
+
+  // Breakpad records the main executable with an empty l_name; an empty basename
+  // would drop the whole line and leave an orphan offset detail behind.
+  it('still names a module whose recorded name has no basename', () => {
+    const { dump } = buildDump({
+      systemInfo: LINUX_X64,
+      exception: { code: 11, address: 0x1n, threadContext: amd64Context(0x5566_0000_0500n) },
+      modules: [{ base: 0x5566_0000_0000n, size: 0x10_0000, name: '' }]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+    const details = minidumpSignatureDetails(signature!)
+    const lines: string[] = []
+    appendMinidumpSignatureLines(lines, details)
+
+    expect(signature?.faultingModule).not.toBe('')
+    expect(details.minidumpFaultingModule).toBeDefined()
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toContain('+0x500')
+  })
+
+  it('says the module list could not be read rather than that the dump carries none', () => {
+    const { dump } = buildDump({
+      systemInfo: WINDOWS_X64,
+      exception: { code: 0xc000_0005, address: 0x7ff8_0000_1234n },
+      modules: [{ base: 0x7ff8_0000_0000n, size: 0x10_0000, name: 'chrome_elf.dll' }],
+      declaredModuleCount: 5_000
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModuleUnavailable).not.toMatch(/carries no module list/)
+    expect(signature?.faultingModuleUnavailable).toMatch(/could not be read/)
+  })
+
+  it('does not claim exhaustive coverage from a module list it could only read part of', () => {
+    const { dump } = buildDump({
+      systemInfo: WINDOWS_X64,
+      exception: { code: 0xc000_0005, address: 0xdead_beef_0000_0010n },
+      modules: [{ base: 0x7ff8_0000_0000n, size: 0x10_0000, name: 'chrome_elf.dll' }],
+      declaredModuleCount: 900
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBeUndefined()
+    expect(signature?.faultingModuleUnavailable).toMatch(/truncat/i)
   })
 
   it('returns null for a buffer that is not a minidump', () => {
@@ -384,6 +732,7 @@ describe('minidumpSignatureDetails', () => {
         ptype: 'renderer',
         channel: 'stable'
       },
+      systemInfo: WINDOWS_X64,
       exception: { code: 0x80000003, address: 0x7ff8_0000_1234n },
       modules: [{ base: 0x7ff8_0000_0000n, size: 0x10_0000, name: 'chrome_elf.dll' }]
     })
@@ -399,6 +748,20 @@ describe('minidumpSignatureDetails', () => {
       minidumpFaultingModule: 'chrome_elf.dll',
       minidumpAnnotation_channel: 'stable'
     })
+  })
+
+  it('flattens the unavailable reason so the report never silently omits it', () => {
+    const { dump } = buildDump({
+      systemInfo: LINUX_X64,
+      annotations: { ptype: 'renderer' },
+      exception: { code: 11, address: 0x27d7_87ec_0000n },
+      modules: [{ base: 0x27d7_87ec_0000n, size: 0x10_0000, name: '/opt/orca/libffmpeg.so' }]
+    })
+
+    const details = minidumpSignatureDetails(parseMinidumpCrashSignature(dump)!)
+
+    expect(details.minidumpFaultingModule).toBeUndefined()
+    expect(typeof details.minidumpFaultingModuleUnavailable).toBe('string')
   })
 
   it('does not duplicate the fatal line into an annotation key', () => {

--- a/src/main/crash-reporting/minidump-crash-signature.ts
+++ b/src/main/crash-reporting/minidump-crash-signature.ts
@@ -11,16 +11,11 @@
 // rather than throwing: a truncated dump must degrade, not break crash
 // reporting.
 
-import { findStream, isMinidump, MAX_MODULES, MinidumpView } from './minidump-stream-reader'
+import { findStream, isMinidump, MinidumpView } from './minidump-stream-reader'
 import { readCrashpadAnnotations } from './minidump-crashpad-annotations'
+import { dumpPathBasename, resolveFaultingModule } from './minidump-faulting-module'
 
-const STREAM_TYPE_MODULE_LIST = 4
 const STREAM_TYPE_EXCEPTION = 6
-
-const MODULE_RECORD_SIZE = 108
-const MODULE_BASE_OFFSET = 0
-const MODULE_SIZE_OFFSET = 8
-const MODULE_NAME_RVA_OFFSET = 20
 
 // MINIDUMP_EXCEPTION_STREAM: ThreadId u32, __alignment u32, then MINIDUMP_EXCEPTION.
 const EXCEPTION_RECORD_OFFSET = 8
@@ -50,47 +45,17 @@ export type MinidumpCrashSignature = {
   readonly processType?: string
   /** Win32 exception code / POSIX signal, e.g. 0x80000003 STATUS_BREAKPOINT. */
   readonly exceptionCode?: number
+  /** Win32 exception address, or POSIX `siginfo.si_addr` — a data address. */
   readonly exceptionAddress?: string
-  /** Module whose image range contains `exceptionAddress`. */
+  /** Module whose image range contains the crashing instruction pointer. */
   readonly faultingModule?: string
   readonly faultingModuleOffset?: string
+  /** Why no module could be named; set exactly when `faultingModule` is not. */
+  readonly faultingModuleUnavailable?: string
+  /** Why `faultingModule` is less than certain; never set for a verified IP. */
+  readonly faultingModuleCaveat?: string
   /** Allowlisted Crashpad annotations, verbatim. */
   readonly annotations: Readonly<Record<string, string>>
-}
-
-type ModuleRecord = {
-  readonly base: bigint
-  readonly size: number
-  readonly name: string
-}
-
-function readModules(view: MinidumpView): ModuleRecord[] {
-  const stream = findStream(view, STREAM_TYPE_MODULE_LIST)
-  if (!stream) {
-    return []
-  }
-  const count = view.u32(stream.rva)
-  if (count === null || count > MAX_MODULES) {
-    return []
-  }
-  const modules: ModuleRecord[] = []
-  for (let index = 0; index < count; index += 1) {
-    const record = stream.rva + 4 + index * MODULE_RECORD_SIZE
-    const base = view.u64(record + MODULE_BASE_OFFSET)
-    const size = view.u32(record + MODULE_SIZE_OFFSET)
-    const nameRva = view.u32(record + MODULE_NAME_RVA_OFFSET)
-    if (base === null || size === null || nameRva === null) {
-      break
-    }
-    const name = view.utf16String(nameRva, 2_048)
-    modules.push({ base, size, name: name ?? 'unknown' })
-  }
-  return modules
-}
-
-function moduleBasename(modulePath: string): string {
-  const separator = Math.max(modulePath.lastIndexOf('/'), modulePath.lastIndexOf('\\'))
-  return separator >= 0 ? modulePath.slice(separator + 1) : modulePath
 }
 
 function toHex(value: bigint): string {
@@ -150,7 +115,7 @@ function findEmbeddedCheckMessage(dump: Buffer): LocatedCheckMessage | undefined
       const line = Number.parseInt(match[3] ?? match[4], 10)
       return {
         message: candidate,
-        file: moduleBasename(match[2]),
+        file: dumpPathBasename(match[2]),
         line: Number.isFinite(line) ? line : undefined
       }
     }
@@ -169,21 +134,6 @@ function parseCheckLocation(checkMessage: string): {
   }
   const line = Number.parseInt(match[2], 10)
   return { file: match[1], line: Number.isFinite(line) ? line : undefined }
-}
-
-function findFaultingModule(
-  modules: ModuleRecord[],
-  address: bigint
-): { name: string; offset: string } | undefined {
-  for (const module of modules) {
-    if (address >= module.base && address < module.base + BigInt(module.size)) {
-      return {
-        name: moduleBasename(module.name),
-        offset: toHex(address - module.base)
-      }
-    }
-  }
-  return undefined
 }
 
 export type MinidumpParseOptions = {
@@ -246,11 +196,16 @@ export function parseMinidumpCrashSignature(
     }
     if (address !== null) {
       signature.exceptionAddress = toHex(address)
-      const faulting = findFaultingModule(readModules(view), address)
-      if (faulting) {
-        signature.faultingModule = faulting.name
-        signature.faultingModuleOffset = faulting.offset
+    }
+    const faulting = resolveFaultingModule(view, exception, address)
+    if (faulting.unavailable === undefined) {
+      signature.faultingModule = faulting.name
+      signature.faultingModuleOffset = faulting.offset
+      if (faulting.caveat) {
+        signature.faultingModuleCaveat = faulting.caveat
       }
+    } else {
+      signature.faultingModuleUnavailable = faulting.unavailable
     }
   }
 
@@ -282,9 +237,16 @@ export function minidumpSignatureDetails(
   }
   if (signature.faultingModule) {
     details.minidumpFaultingModule = signature.faultingModule
+    // An offset names nothing on its own; it is only published beside its module.
+    if (signature.faultingModuleOffset) {
+      details.minidumpFaultingModuleOffset = signature.faultingModuleOffset
+    }
   }
-  if (signature.faultingModuleOffset) {
-    details.minidumpFaultingModuleOffset = signature.faultingModuleOffset
+  if (signature.faultingModuleUnavailable) {
+    details.minidumpFaultingModuleUnavailable = signature.faultingModuleUnavailable
+  }
+  if (signature.faultingModuleCaveat) {
+    details.minidumpFaultingModuleCaveat = signature.faultingModuleCaveat
   }
   for (const [key, value] of Object.entries(signature.annotations)) {
     if (key === 'LOG_FATAL' || key === 'abort-message' || key === 'ptype') {

--- a/src/main/crash-reporting/minidump-faulting-module.ts
+++ b/src/main/crash-reporting/minidump-faulting-module.ts
@@ -1,0 +1,306 @@
+// Names the loaded module that owns the crashing instruction.
+//
+// Why this is not simply "the module containing ExceptionAddress": that record
+// field is the instruction pointer only on Windows. Crashpad fills it from
+// siginfo.si_addr on POSIX, so for SIGSEGV/SIGBUS it is the faulting *data*
+// address — resolving a module from it names whatever owns the bad pointer
+// rather than the code that dereferenced it. The instruction pointer lives in
+// the exception stream's thread context, so that is where it is read from, and
+// when it is missing we say exactly which piece was missing instead of
+// guessing — including when the stored context contradicts the architecture
+// SYSTEM_INFO names, since reading a pointer out of the wrong CONTEXT layout
+// yields a confident wrong answer. Only a dump that identifies itself as POSIX
+// is distrusted this way; otherwise the exception address stays a fallback —
+// marked with a caveat unless the dump names a Windows platform, where it
+// really is the pointer.
+
+import {
+  findStream,
+  type LocationDescriptor,
+  MAX_MODULES,
+  type MinidumpView
+} from './minidump-stream-reader'
+
+const STREAM_TYPE_MODULE_LIST = 4
+const STREAM_TYPE_SYSTEM_INFO = 7
+
+const MODULE_RECORD_SIZE = 108
+const MODULE_BASE_OFFSET = 0
+const MODULE_SIZE_OFFSET = 8
+const MODULE_NAME_RVA_OFFSET = 20
+
+// MINIDUMP_SYSTEM_INFO.
+const SYSTEM_INFO_ARCHITECTURE_OFFSET = 0
+const SYSTEM_INFO_PLATFORM_ID_OFFSET = 20
+
+// MINIDUMP_EXCEPTION_STREAM: ThreadId u32, __alignment u32, the 152-byte
+// MINIDUMP_EXCEPTION, then the thread's context location descriptor.
+const THREAD_CONTEXT_OFFSET = 160
+
+// Breakpad/Crashpad number every POSIX OS from 0x8000 up (MD_OS_UNIX and its
+// per-OS successors); Windows keeps the low VER_PLATFORM_* ids.
+const PLATFORM_ID_POSIX_MIN = 0x8000
+// VER_PLATFORM_WIN32s/WIN32_WINDOWS/WIN32_NT/WIN32_CE.
+const PLATFORM_ID_WINDOWS_MAX = 3
+
+const CPU_ARCHITECTURE_X86 = 0
+const CPU_ARCHITECTURE_AMD64 = 9
+const CPU_ARCHITECTURE_ARM64 = 12
+// Breakpad numbered arm64 differently; dumps carrying that id are still read.
+const CPU_ARCHITECTURE_ARM64_BREAKPAD = 0x8003
+
+// CONTEXT.ContextFlags carries the CPU in its high bits; the low byte is the
+// per-register-group selection.
+const CONTEXT_CPU_MASK = 0xffffff00
+const CONTEXT_CPU_X86 = 0x0001_0000
+const CONTEXT_CPU_AMD64 = 0x0010_0000
+const CONTEXT_CPU_ARM64 = 0x0040_0000
+// Breakpad's older arm64 flag; both spellings reach us.
+const CONTEXT_CPU_ARM64_OLD = 0x8000_0000
+const KNOWN_CONTEXT_CPUS = new Set([
+  CONTEXT_CPU_X86,
+  CONTEXT_CPU_AMD64,
+  CONTEXT_CPU_ARM64,
+  CONTEXT_CPU_ARM64_OLD
+])
+// CONTEXT_AMD64 alone puts ContextFlags after the six home-parameter slots.
+const AMD64_CONTEXT_FLAGS_OFFSET = 48
+const AMD64_CONTEXT_SIZE = 1232
+
+const ARM64_CONTEXT_CPUS = [CONTEXT_CPU_ARM64, CONTEXT_CPU_ARM64_OLD]
+
+/** Where the instruction pointer sits in each CONTEXT layout, by architecture. */
+const INSTRUCTION_POINTER_LAYOUTS = new Map<
+  number,
+  { offset: number; bytes: 4 | 8; cpus: readonly number[] }
+>([
+  // CONTEXT_X86.Eip
+  [CPU_ARCHITECTURE_X86, { offset: 184, bytes: 4, cpus: [CONTEXT_CPU_X86] }],
+  // CONTEXT_AMD64.Rip
+  [CPU_ARCHITECTURE_AMD64, { offset: 248, bytes: 8, cpus: [CONTEXT_CPU_AMD64] }],
+  // MinidumpContextARM64.pc
+  [CPU_ARCHITECTURE_ARM64, { offset: 264, bytes: 8, cpus: ARM64_CONTEXT_CPUS }],
+  // iregs[32] lands there too
+  [CPU_ARCHITECTURE_ARM64_BREAKPAD, { offset: 264, bytes: 8, cpus: ARM64_CONTEXT_CPUS }]
+])
+
+// One string per distinct cause: the report is read by someone debugging the
+// crash, so "context missing" must not be printed when the context is present.
+const NO_SYSTEM_INFO =
+  'the dump carries no readable system info, so the thread context layout is unknown'
+const NO_THREAD_CONTEXT = 'no thread context in this dump'
+const TRUNCATED_THREAD_CONTEXT = 'the thread context in this dump is truncated'
+const POSIX_ADDRESS_CAVEAT =
+  'the exception address is the faulting data address on POSIX, not the instruction pointer'
+const NO_MODULE_LIST = 'the dump carries no module list'
+const UNREADABLE_MODULE_LIST = "the dump's module list could not be read"
+const NO_MODULES_LISTED = "the dump's module list is empty"
+const CONTEXT_ARCHITECTURE_MISMATCH =
+  'the thread context in this dump is not the layout for the CPU architecture it names'
+const UNIDENTIFIED_PLATFORM_CAVEAT =
+  'named from the exception address; this dump does not say which OS it came from, so that may be the faulting data address rather than the instruction pointer'
+
+export type FaultingModule =
+  | {
+      readonly name: string
+      readonly offset: string
+      /** Set when the address used was not a verified instruction pointer. */
+      readonly caveat?: string
+      readonly unavailable?: undefined
+    }
+  | {
+      readonly name?: undefined
+      readonly offset?: undefined
+      readonly caveat?: undefined
+      readonly unavailable: string
+    }
+
+type ModuleRecord = {
+  readonly base: bigint
+  readonly size: number
+  readonly name: string
+}
+
+/** Basename of a path recorded in a dump, which may use either separator. */
+export function dumpPathBasename(recordedPath: string): string {
+  const separator = Math.max(recordedPath.lastIndexOf('/'), recordedPath.lastIndexOf('\\'))
+  return separator >= 0 ? recordedPath.slice(separator + 1) : recordedPath
+}
+
+/** `complete` false means the list is there but was not read end to end, so it
+ * cannot be cited as proof that an address belongs to no module. */
+type ModuleList = { readonly modules: ModuleRecord[]; readonly complete: boolean }
+
+function readModules(view: MinidumpView): ModuleList | null {
+  const stream = findStream(view, STREAM_TYPE_MODULE_LIST)
+  if (!stream) {
+    return null
+  }
+  const count = view.u32(stream.rva)
+  if (count === null || count > MAX_MODULES) {
+    return { modules: [], complete: false }
+  }
+  const modules: ModuleRecord[] = []
+  for (let index = 0; index < count; index += 1) {
+    const record = stream.rva + 4 + index * MODULE_RECORD_SIZE
+    const base = view.u64(record + MODULE_BASE_OFFSET)
+    const size = view.u32(record + MODULE_SIZE_OFFSET)
+    const nameRva = view.u32(record + MODULE_NAME_RVA_OFFSET)
+    if (base === null || size === null || nameRva === null) {
+      return { modules, complete: false }
+    }
+    const name = view.utf16String(nameRva, 2_048)
+    modules.push({ base, size, name: name ?? 'unknown' })
+  }
+  return { modules, complete: true }
+}
+
+/** Which CPU the stored context says it is, or null when it names none we know. */
+function contextCpu(view: MinidumpView, context: LocationDescriptor): number | null {
+  const named = (flags: number | null): number | null => {
+    const cpu = flags === null ? null : flags & CONTEXT_CPU_MASK
+    return cpu !== null && KNOWN_CONTEXT_CPUS.has(cpu) ? cpu : null
+  }
+  const amd64 =
+    context.size >= AMD64_CONTEXT_SIZE
+      ? named(view.u32(context.rva + AMD64_CONTEXT_FLAGS_OFFSET))
+      : null
+  return amd64 === CONTEXT_CPU_AMD64 ? amd64 : named(view.u32(context.rva))
+}
+
+function readSystemInfo(view: MinidumpView): { architecture: number; platformId: number } | null {
+  const stream = findStream(view, STREAM_TYPE_SYSTEM_INFO)
+  if (!stream) {
+    return null
+  }
+  const architecture = view.u16(stream.rva + SYSTEM_INFO_ARCHITECTURE_OFFSET)
+  const platformId = view.u32(stream.rva + SYSTEM_INFO_PLATFORM_ID_OFFSET)
+  if (architecture === null || platformId === null) {
+    return null
+  }
+  return { architecture, platformId }
+}
+
+type InstructionPointerRead =
+  | { readonly value: bigint; readonly unreadable?: undefined }
+  | { readonly value: null; readonly unreadable: string }
+
+function readInstructionPointer(
+  view: MinidumpView,
+  exception: LocationDescriptor,
+  architecture: number | undefined
+): InstructionPointerRead {
+  const layout =
+    architecture === undefined ? undefined : INSTRUCTION_POINTER_LAYOUTS.get(architecture)
+  if (!layout) {
+    return {
+      value: null,
+      unreadable:
+        architecture === undefined
+          ? NO_SYSTEM_INFO
+          : `this dump's CPU architecture (${architecture}) has no known thread context layout`
+    }
+  }
+  const context = view.location(exception.rva + THREAD_CONTEXT_OFFSET)
+  if (!context) {
+    return { value: null, unreadable: NO_THREAD_CONTEXT }
+  }
+  if (context.size < layout.offset + layout.bytes) {
+    return { value: null, unreadable: TRUNCATED_THREAD_CONTEXT }
+  }
+  // SYSTEM_INFO describes the machine; the context says what it actually is. On a
+  // disagreement the pointer would be read out of the wrong struct and believed.
+  const cpu = contextCpu(view, context)
+  if (cpu !== null && !layout.cpus.includes(cpu)) {
+    return { value: null, unreadable: CONTEXT_ARCHITECTURE_MISMATCH }
+  }
+  const at = context.rva + layout.offset
+  const raw = layout.bytes === 4 ? view.u32(at) : view.u64(at)
+  return raw === null
+    ? { value: null, unreadable: TRUNCATED_THREAD_CONTEXT }
+    : { value: BigInt(raw) }
+}
+
+/** `label` names what `address` actually is, since the fallback path has declined
+ * to call it an instruction pointer. */
+function locateModule(
+  view: MinidumpView,
+  address: bigint,
+  label: 'instruction pointer' | 'exception address'
+): FaultingModule {
+  const list = readModules(view)
+  if (!list) {
+    return { unavailable: NO_MODULE_LIST }
+  }
+  if (list.modules.length === 0) {
+    return { unavailable: list.complete ? NO_MODULES_LISTED : UNREADABLE_MODULE_LIST }
+  }
+  for (const module of list.modules) {
+    if (address >= module.base && address < module.base + BigInt(module.size)) {
+      return {
+        name: moduleLabel(module),
+        offset: `0x${(address - module.base).toString(16)}`
+      }
+    }
+  }
+  const at = `${label} 0x${address.toString(16)}`
+  return {
+    unavailable: list.complete
+      ? `${at} is outside every loaded module`
+      : `${at} is outside every module that could be read, and the dump's module list is truncated`
+  }
+}
+
+/** Breakpad records the main executable with an empty name, and a name may end in
+ * a separator; an empty label drops the whole line, reading as "no module". */
+function moduleLabel(module: ModuleRecord): string {
+  return (
+    dumpPathBasename(module.name) ||
+    module.name ||
+    `unnamed module at 0x${module.base.toString(16)}`
+  )
+}
+
+type DumpPlatform = 'posix' | 'windows' | 'unidentified'
+
+function classifyPlatform(platformId: number | undefined): DumpPlatform {
+  if (platformId === undefined) {
+    return 'unidentified'
+  }
+  if (platformId >= PLATFORM_ID_POSIX_MIN) {
+    return 'posix'
+  }
+  return platformId <= PLATFORM_ID_WINDOWS_MAX ? 'windows' : 'unidentified'
+}
+
+/**
+ * Resolves the module covering the crashing instruction, or states why it
+ * cannot be named. A module resolved from the exception address of a dump that
+ * does not identify its OS carries `caveat`, because it may still be a POSIX
+ * data address; callers must publish that alongside the name.
+ */
+export function resolveFaultingModule(
+  view: MinidumpView,
+  exception: LocationDescriptor,
+  exceptionAddress: bigint | null
+): FaultingModule {
+  const systemInfo = readSystemInfo(view)
+  const platform = classifyPlatform(systemInfo?.platformId)
+  const read = readInstructionPointer(view, exception, systemInfo?.architecture)
+  if (read.value !== null) {
+    return locateModule(view, read.value, 'instruction pointer')
+  }
+  // Only a POSIX dump's exception address is certainly a data address; an
+  // unknown platform keeps the attribution the parser used to make, caveated.
+  if (platform === 'posix' || exceptionAddress === null) {
+    return {
+      unavailable:
+        platform === 'posix' ? `${read.unreadable}; ${POSIX_ADDRESS_CAVEAT}` : read.unreadable
+    }
+  }
+  const located = locateModule(view, exceptionAddress, 'exception address')
+  if (located.unavailable !== undefined || platform === 'windows') {
+    return located
+  }
+  return { ...located, caveat: UNIDENTIFIED_PLATFORM_CAVEAT }
+}

--- a/src/shared/crash-report-signature-lines.ts
+++ b/src/shared/crash-report-signature-lines.ts
@@ -18,6 +18,12 @@ export function appendMinidumpSignatureLines(
   if (typeof details.minidumpFaultingModule === 'string') {
     const offset = details.minidumpFaultingModuleOffset
     const suffix = typeof offset === 'string' ? `+${offset}` : ''
-    lines.push(`Faulting module: ${details.minidumpFaultingModule}${suffix}`)
+    const caveat = details.minidumpFaultingModuleCaveat
+    // Published, not dropped: an uncertain attribution read as certain is the bug.
+    const note = typeof caveat === 'string' ? ` (${caveat})` : ''
+    lines.push(`Faulting module: ${details.minidumpFaultingModule}${suffix}${note}`)
+  } else if (typeof details.minidumpFaultingModuleUnavailable === 'string') {
+    // Stated, not omitted: silence reads as "no module was involved".
+    lines.push(`Faulting module: unavailable (${details.minidumpFaultingModuleUnavailable})`)
   }
 }

--- a/src/shared/crash-reporting.test.ts
+++ b/src/shared/crash-reporting.test.ts
@@ -223,6 +223,62 @@ describe('crash-reporting shared helpers', () => {
     expect(text.indexOf('Check failure:')).toBeLessThan(text.indexOf('Details:'))
   })
 
+  it('carries the exception-address caveat onto the faulting module line', () => {
+    const report: CrashReportRecord = {
+      id: 'crash-unidentified-platform',
+      createdAt: '2026-08-24T05:42:53.692Z',
+      status: 'pending',
+      source: 'renderer',
+      processType: 'renderer',
+      reason: 'crashed',
+      exitCode: 139,
+      appVersion: '1.4.188',
+      platform: 'linux',
+      osRelease: '7.0.0-30-generic',
+      arch: 'x64',
+      electronVersion: '43.1.0',
+      chromeVersion: '150.0.7871.47',
+      details: {
+        minidumpFaultingModule: 'libffmpeg.so',
+        minidumpFaultingModuleOffset: '0x0',
+        minidumpFaultingModuleCaveat: 'named from the exception address'
+      },
+      breadcrumbs: []
+    }
+
+    const text = formatCrashReportText(report)
+
+    expect(text).toContain('Faulting module: libffmpeg.so+0x0 (named from the exception address)')
+  })
+
+  it('states the faulting module is unavailable instead of dropping the line', () => {
+    const report: CrashReportRecord = {
+      id: 'crash-posix-sigsegv',
+      createdAt: '2026-08-24T05:42:53.692Z',
+      status: 'pending',
+      source: 'renderer',
+      processType: 'renderer',
+      reason: 'crashed',
+      exitCode: 139,
+      appVersion: '1.4.188',
+      platform: 'linux',
+      osRelease: '7.0.0-30-generic',
+      arch: 'x64',
+      electronVersion: '43.1.0',
+      chromeVersion: '150.0.7871.47',
+      details: {
+        minidumpExceptionCode: '0xb',
+        minidumpExceptionAddress: '0x27d787ec0000',
+        minidumpFaultingModuleUnavailable: 'no thread context in the dump'
+      },
+      breadcrumbs: []
+    }
+
+    const text = formatCrashReportText(report)
+
+    expect(text).toContain('Faulting module: unavailable (no thread context in the dump)')
+  })
+
   it('decodes POSIX wait statuses in the exit code line and leaves Windows codes raw', () => {
     const report = (overrides: Partial<CrashReportRecord>): CrashReportRecord => ({
       id: 'crash-wait-status',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​426 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​419 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​340 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​66 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​274 |

<!-- /orca-pr-loc -->

> **Draft — do not merge.** Ran the full 4 adversarial loops without converging; 3 majors still open, two of them unresolved across multiple loops. The underlying defect is real and confirmed — the fix is not settled.

## The defect (confirmed)

`minidumpFaultingModule` is only meaningful on Windows. On POSIX it is silently absent or **actively misleading**.

`minidump-crash-signature.ts:240-255` reads `MINIDUMP_EXCEPTION_STREAM`, takes `ExceptionAddress`, and hands it to `findFaultingModule()`, which walks the module list for a module whose image range contains that address.

That's correct on Windows, where `ExceptionAddress` is the instruction pointer. On POSIX it is **wrong**: Breakpad/Crashpad set the minidump exception address from `siginfo.si_addr` for SIGSEGV/SIGBUS — the faulting **data** address, not the instruction pointer. So on Linux/macOS the code either finds no module (3 POSIX minidumps in the 1.4.188 batch carry none) or resolves whichever module happens to contain the bad *data* address, which is worse than nothing.

Separate and already tracked: on Windows, `Orca.exe` as faulting module carries zero Orca signal because Electron statically links Chromium/V8/Blink into the product exe — that's draft #16154, not duplicated here.

Tests green as written: 22 files / 232 tests. `/perf`: no meaningful impact, one measurable improvement.

## Outstanding — why it's a draft

1. **Major:** a successful instruction-pointer read is trusted **unconditionally**, with no corroboration, and never falls back to an `ExceptionAddress` the code itself has already judged authoritative. Two corrupt reads produce a confident wrong answer.
2. **Major (unresolved since loop 3):** a module whose recorded name has an empty basename yields `faultingModule = ""` with `unavailable` undefined — the truthiness filter drops the name and keeps an orphan offset.
3. **Major (unresolved since loop 3):** `locateModule` asserts "the dump carries no module list" as fact, but `readModules` also returns `[]` for a module list that *is* present and merely unreadable or over-large. That's an affirmative claim derived from absent data — the same error class this PR exists to fix, one level up.

Finding 3 is the same failure mode that stalled draft #16154. Worth solving once, properly, for both.

## Suggested path

Make the answer explicitly three-state — **instruction-pointer-resolved / not-available-on-this-platform / unknown** — and never let "we couldn't read it" collapse into an affirmative verdict. Declining to name a module is a perfectly good answer and much better than a wrong one; the report should say so rather than omitting the field.
