### PR TITLE
draft(editor): explain oversized files instead of a dead editor

### DIFF
--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -435,8 +435,48 @@ describe('registerFilesystemHandlers', () => {
     expect(readFileMock).not.toHaveBeenCalled()
   })
 
+  // Regression: a 14MB JSON/CSV is well inside Monaco's large-file handling and must still open.
+  it('opens local text files between the remote budget and the local one', async () => {
+    statMock.mockResolvedValue({ size: 14 * 1024 * 1024, isDirectory: () => false, mtimeMs: 123 })
+    openMock.mockResolvedValue({
+      read: vi.fn(async (buffer: Buffer) => {
+        buffer.write('{"a":1}')
+        return { bytesRead: 7, buffer }
+      }),
+      close: vi.fn()
+    })
+    readFileMock.mockResolvedValue(Buffer.from('{"a":1}'))
+
+    registerFilesystemHandlers(store as never)
+
+    await expect(
+      handlers.get('fs:readFile')!(null, { filePath: path.resolve('/workspace/repo/huge.json') })
+    ).resolves.toEqual({ content: '{"a":1}', isBinary: false })
+  })
+
+  it('still opens local log snapshots at the local text budget', async () => {
+    const content = Buffer.alloc(12 * 1024 * 1024, 'a')
+    const close = vi.fn()
+    openMock.mockResolvedValue({
+      stat: vi.fn().mockResolvedValue({ size: content.byteLength, dev: 1, ino: 2, birthtimeMs: 3 }),
+      readFile: vi.fn().mockResolvedValue(content),
+      close
+    })
+
+    registerFilesystemHandlers(store as never)
+
+    await expect(
+      handlers.get('fs:readFile')!(null, {
+        filePath: path.resolve('/workspace/repo/session.jsonl'),
+        includeLocalLogMetadata: true
+      })
+    ).resolves.toMatchObject({ isBinary: false, fileIdentity: '1:2:3' })
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  // Regression: a 20MB zip must reach the binary probe and get the placeholder, not a size refusal.
   it('probes large unknown binaries without reading the full file', async () => {
-    statMock.mockResolvedValue({ size: 6 * 1024 * 1024, isDirectory: () => false, mtimeMs: 123 })
+    statMock.mockResolvedValue({ size: 20 * 1024 * 1024, isDirectory: () => false, mtimeMs: 123 })
     openMock.mockResolvedValue({
       read: vi.fn(async (buffer: Buffer) => {
         buffer[0] = 0x00

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -141,18 +141,19 @@ import { getWorktreeSharedLinkPaths } from '../git/worktree-shared-directories'
 import { createSenderScopedRequestCancellations } from './sender-scoped-request-cancellation'
 import { QuickOpenPathRanker } from '../../shared/quick-open-path-search'
 import {
+  MAX_LOCAL_TEXT_FILE_BYTES,
+  MAX_PREVIEWABLE_BINARY_BYTES,
+  fileTooLargeMessage
+} from '../../shared/editor-file-read-limits'
+import {
   applyGitStatusUpstreamRefWatchRequest,
   type GitStatusUpstreamRefWatchRequest
 } from './git-status-upstream-ref-watch-request'
 
-// Why: Monaco degrades features on large files like VS Code, so a 5MB block would needlessly lock out ordinary JSON/log files.
-const MAX_TEXT_FILE_SIZE = 50 * 1024 * 1024 // 50MB
 const BINARY_PROBE_BYTES = 8192
 const FULL_GIT_OBJECT_ID_PATTERN = /^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$/
 // 32 visible matches plus one truncation sentinel stays below the legacy frame ceiling.
 const QUICK_OPEN_SSH_LEGACY_RESULT_LIMIT = 33
-// Why: previewable binaries are base64 blobs (not parsed as text), and local IPC has no frame limit (unlike the relay's 10MB), so 50MB is safe.
-const MAX_PREVIEWABLE_BINARY_SIZE = 50 * 1024 * 1024 // 50MB
 const PREVIEWABLE_BINARY_MIME_TYPES: Record<string, string> = {
   '.png': 'image/png',
   '.jpg': 'image/jpeg',
@@ -172,16 +173,12 @@ async function readLocalLogSnapshot(filePath: string): Promise<{
   const handle = await open(filePath, 'r')
   try {
     const stats = await handle.stat()
-    if (stats.size > MAX_TEXT_FILE_SIZE) {
-      throw new Error(
-        `File too large: ${(stats.size / 1024 / 1024).toFixed(1)}MB exceeds ${MAX_TEXT_FILE_SIZE / 1024 / 1024}MB limit`
-      )
+    if (stats.size > MAX_LOCAL_TEXT_FILE_BYTES) {
+      throw new Error(fileTooLargeMessage(stats.size, MAX_LOCAL_TEXT_FILE_BYTES))
     }
     const buffer = await handle.readFile()
-    if (buffer.byteLength > MAX_TEXT_FILE_SIZE) {
-      throw new Error(
-        `File too large: ${(buffer.byteLength / 1024 / 1024).toFixed(1)}MB exceeds ${MAX_TEXT_FILE_SIZE / 1024 / 1024}MB limit`
-      )
+    if (buffer.byteLength > MAX_LOCAL_TEXT_FILE_BYTES) {
+      throw new Error(fileTooLargeMessage(buffer.byteLength, MAX_LOCAL_TEXT_FILE_BYTES))
     }
     if (isBinaryBuffer(buffer)) {
       return { content: '', isBinary: true }
@@ -599,11 +596,9 @@ export function registerFilesystemHandlers(
       }
       const stats = await stat(filePath)
       const mimeType = PREVIEWABLE_BINARY_MIME_TYPES[extname(filePath).toLowerCase()]
-      const sizeLimit = mimeType ? MAX_PREVIEWABLE_BINARY_SIZE : MAX_TEXT_FILE_SIZE
+      const sizeLimit = mimeType ? MAX_PREVIEWABLE_BINARY_BYTES : MAX_LOCAL_TEXT_FILE_BYTES
       if (stats.size > sizeLimit) {
-        throw new Error(
-          `File too large: ${(stats.size / 1024 / 1024).toFixed(1)}MB exceeds ${sizeLimit / 1024 / 1024}MB limit`
-        )
+        throw new Error(fileTooLargeMessage(stats.size, sizeLimit))
       }
 
       if (mimeType) {

--- a/src/main/ssh/ssh-file-stream-read-cap.test.ts
+++ b/src/main/ssh/ssh-file-stream-read-cap.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { sshFileStreamReadCap } from './ssh-file-stream-read-cap'
+import {
+  MAX_PREVIEWABLE_BINARY_BYTES,
+  MAX_REMOTE_TEXT_FILE_BYTES
+} from '../../shared/editor-file-read-limits'
+import {
+  MAX_PREVIEWABLE_BINARY_SIZE as RELAY_BINARY_CAP,
+  MAX_TEXT_FILE_SIZE as RELAY_TEXT_CAP
+} from '../../relay/fs-handler-utils'
+
+describe('sshFileStreamReadCap', () => {
+  // Regression: the SSH cap and the relay cap were separate literals that could drift apart.
+  it('shares one budget with the relay read path', () => {
+    expect(sshFileStreamReadCap(false)).toBe(MAX_REMOTE_TEXT_FILE_BYTES)
+    expect(sshFileStreamReadCap(true)).toBe(MAX_PREVIEWABLE_BINARY_BYTES)
+    expect(RELAY_TEXT_CAP).toBe(MAX_REMOTE_TEXT_FILE_BYTES)
+    expect(RELAY_BINARY_CAP).toBe(MAX_PREVIEWABLE_BINARY_BYTES)
+  })
+
+  it('clamps a client-requested cap to the shared budget', () => {
+    expect(sshFileStreamReadCap(false, { maxTextBytes: Number.MAX_SAFE_INTEGER })).toBe(
+      MAX_REMOTE_TEXT_FILE_BYTES
+    )
+    expect(sshFileStreamReadCap(false, { maxTextBytes: 1024 })).toBe(1024)
+  })
+})

--- a/src/main/ssh/ssh-file-stream-read-cap.ts
+++ b/src/main/ssh/ssh-file-stream-read-cap.ts
@@ -1,10 +1,11 @@
 import type { FileReadLimits } from '../providers/types'
-
-const MAX_PREVIEWABLE_BINARY_SIZE = 50 * 1024 * 1024
-const MAX_TEXT_FILE_SIZE = 10 * 1024 * 1024
+import {
+  MAX_PREVIEWABLE_BINARY_BYTES,
+  MAX_REMOTE_TEXT_FILE_BYTES
+} from '../../shared/editor-file-read-limits'
 
 export function sshFileStreamReadCap(isBinary: boolean, limits?: FileReadLimits): number {
-  const defaultCap = isBinary ? MAX_PREVIEWABLE_BINARY_SIZE : MAX_TEXT_FILE_SIZE
+  const defaultCap = isBinary ? MAX_PREVIEWABLE_BINARY_BYTES : MAX_REMOTE_TEXT_FILE_BYTES
   const requestedCap = isBinary ? limits?.maxBinaryBytes : limits?.maxTextBytes
   return requestedCap === undefined ? defaultCap : Math.min(defaultCap, requestedCap)
 }

--- a/src/relay/fs-handler-file-read.ts
+++ b/src/relay/fs-handler-file-read.ts
@@ -12,15 +12,14 @@ import {
   isBinaryBuffer,
   isBinaryFilePrefix
 } from './fs-handler-utils'
+import { fileTooLargeMessage } from '../shared/editor-file-read-limits'
 
 export async function readRelayFileContent(filePath: string) {
   const stats = await stat(filePath)
   const mimeType = IMAGE_MIME_TYPES[extname(filePath).toLowerCase()]
   const sizeLimit = mimeType ? MAX_PREVIEWABLE_BINARY_SIZE : MAX_TEXT_FILE_SIZE
   if (stats.size > sizeLimit) {
-    throw new Error(
-      `File too large: ${(stats.size / 1024 / 1024).toFixed(1)}MB exceeds ${sizeLimit / 1024 / 1024}MB limit`
-    )
+    throw new Error(fileTooLargeMessage(stats.size, sizeLimit))
   }
 
   if (mimeType) {
@@ -82,9 +81,7 @@ export async function readRelayFileStreamMetadata(
   const mimeType = IMAGE_MIME_TYPES[extname(filePath).toLowerCase()]
   const sizeLimit = mimeType ? MAX_PREVIEWABLE_BINARY_SIZE : MAX_TEXT_FILE_SIZE
   if (stats.size > sizeLimit) {
-    throw new Error(
-      `File too large: ${(stats.size / 1024 / 1024).toFixed(1)}MB exceeds ${sizeLimit / 1024 / 1024}MB limit`
-    )
+    throw new Error(fileTooLargeMessage(stats.size, sizeLimit))
   }
 
   if (stats.size === 0) {

--- a/src/relay/fs-handler-utils.ts
+++ b/src/relay/fs-handler-utils.ts
@@ -15,6 +15,10 @@ import {
   SEARCH_TIMEOUT_MS as SHARED_SEARCH_TIMEOUT_MS
 } from '../shared/text-search'
 import { IMAGE_FILE_MIME_TYPES } from '../shared/image-file-extensions'
+import {
+  MAX_PREVIEWABLE_BINARY_BYTES,
+  MAX_REMOTE_TEXT_FILE_BYTES
+} from '../shared/editor-file-read-limits'
 import type { SearchResult as SharedSearchResult } from '../shared/code-search-types'
 import {
   absorbPendingRipgrepSpawnError,
@@ -26,14 +30,10 @@ import {
 
 // ─── Constants ───────────────────────────────────────────────────────
 
-// Why: remote reads still travel through bounded JSON-RPC frames, but matching
-// the old 5MB search cap would block common JSON/log files before Monaco's
-// large-file optimizations can handle them.
-export const MAX_TEXT_FILE_SIZE = 10 * 1024 * 1024
-// Why: matches the local cap (src/main/ipc/filesystem.ts MAX_PREVIEWABLE_BINARY_SIZE).
-// Reads above the legacy 16MB single-frame budget go through fs.readFileStream,
-// which chunks at STREAM_CHUNK_SIZE; see docs/relay-file-stream-design.md.
-export const MAX_PREVIEWABLE_BINARY_SIZE = 50 * 1024 * 1024
+// Why: re-exported under the relay's existing names so the SSH and relay reads share one
+// source; see docs/relay-file-stream-design.md for the chunking above the single-frame budget.
+export const MAX_TEXT_FILE_SIZE = MAX_REMOTE_TEXT_FILE_BYTES
+export const MAX_PREVIEWABLE_BINARY_SIZE = MAX_PREVIEWABLE_BINARY_BYTES
 export const BINARY_PROBE_BYTES = 8192
 export const SEARCH_TIMEOUT_MS = SHARED_SEARCH_TIMEOUT_MS
 export const DEFAULT_MAX_RESULTS = 2000

--- a/src/renderer/src/components/editor/EditorFileLoadErrorView.test.tsx
+++ b/src/renderer/src/components/editor/EditorFileLoadErrorView.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { EditorFileLoadErrorView } from './EditorFileLoadErrorView'
+
+afterEach(cleanup)
+
+describe('EditorFileLoadErrorView', () => {
+  it('explains an oversized file instead of reporting a load failure', () => {
+    render(
+      <EditorFileLoadErrorView
+        message="Error invoking remote method 'fs:readFile': Error: File too large: 14.0MB exceeds 10MB limit"
+        onRetry={vi.fn()}
+      />
+    )
+
+    expect(screen.getByTestId('large-file-fallback')).toBeTruthy()
+    expect(screen.queryByText('Unable to load file')).toBe(null)
+    expect(screen.getByText(/14\.0 MB/)).toBeTruthy()
+    expect(screen.getByText(/10 MB/)).toBeTruthy()
+  })
+
+  // The local and remote budgets differ on purpose, so the card must not claim otherwise.
+  it('does not claim local and remote share one limit', () => {
+    render(
+      <EditorFileLoadErrorView
+        message="File too large: 14.0MB exceeds 10MB limit"
+        onRetry={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByText(/same limit/i)).toBe(null)
+  })
+
+  it('keeps the retry affordance so a shrunken file can be reopened', () => {
+    const onRetry = vi.fn()
+    render(
+      <EditorFileLoadErrorView
+        message="File too large: 14.0MB exceeds 10MB limit"
+        onRetry={onRetry}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button'))
+
+    expect(onRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it('still reports unrelated read failures as errors', () => {
+    render(
+      <EditorFileLoadErrorView
+        message="Access denied: path resolves outside allowed directories"
+        onRetry={vi.fn()}
+      />
+    )
+
+    expect(screen.queryByTestId('large-file-fallback')).toBe(null)
+    expect(screen.getByText('Unable to load file')).toBeTruthy()
+  })
+})

--- a/src/renderer/src/components/editor/EditorFileLoadErrorView.tsx
+++ b/src/renderer/src/components/editor/EditorFileLoadErrorView.tsx
@@ -1,6 +1,8 @@
 import { AlertCircle, RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { translate } from '@/i18n/i18n'
+import { parseFileTooLargeMessage } from '../../../../shared/editor-file-read-limits'
+import { LargeFileFallback } from './LargeFileFallback'
 
 export function EditorFileLoadErrorView({
   message,
@@ -9,6 +11,12 @@ export function EditorFileLoadErrorView({
   message: string
   onRetry: () => void
 }): React.JSX.Element {
+  // Why: an oversized file is a known limit, not a failure — say so instead of an error card with no next step.
+  const tooLarge = parseFileTooLargeMessage(message)
+  if (tooLarge) {
+    return <LargeFileFallback details={tooLarge} onRetry={onRetry} />
+  }
+
   return (
     <div className="flex h-full items-center justify-center bg-editor-surface p-6 text-sm text-muted-foreground">
       <div className="flex max-w-xl items-start gap-3 rounded-md border border-border bg-background p-4">

--- a/src/renderer/src/components/editor/LargeFileFallback.tsx
+++ b/src/renderer/src/components/editor/LargeFileFallback.tsx
@@ -1,0 +1,51 @@
+import { RefreshCw } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { translate } from '@/i18n/i18n'
+import {
+  megabytesLabel,
+  type FileTooLargeDetails
+} from '../../../../shared/editor-file-read-limits'
+
+export function LargeFileFallback({
+  details,
+  onRetry
+}: {
+  details: FileTooLargeDetails
+  onRetry: () => void
+}): React.JSX.Element {
+  return (
+    <div
+      data-testid="large-file-fallback"
+      className="flex h-full items-center justify-center bg-editor-surface p-6 text-muted-foreground"
+    >
+      <div className="max-w-xl space-y-3 text-center">
+        <div className="text-sm font-medium text-foreground">
+          {translate(
+            'auto.components.editor.LargeFileFallback.0aabd49594',
+            'This file is too large to open in the editor.'
+          )}
+        </div>
+        <div className="grid gap-1 text-xs sm:grid-cols-2 sm:text-left">
+          <div>
+            {translate('auto.components.editor.LargeFileFallback.64689ffd03', 'Size')}:{' '}
+            {megabytesLabel(details.observedMb, 1)}
+          </div>
+          <div>
+            {translate('auto.components.editor.LargeFileFallback.a66faf5b54', 'Editor limit')}:{' '}
+            {megabytesLabel(details.limitMb)}
+          </div>
+        </div>
+        <div className="text-xs">
+          {translate(
+            'auto.components.editor.LargeFileFallback.e13c1c94e0',
+            'Files this large are not loaded into the editor, so the window stays responsive. Open it in an external editor, or split it before editing.'
+          )}
+        </div>
+        <Button type="button" variant="outline" size="sm" onClick={onRetry}>
+          <RefreshCw className="size-3.5" />
+          {translate('auto.components.editor.LargeFileFallback.e51e6a81c9', 'Try again')}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14475,6 +14475,13 @@
           "23433fcdea": "combined characters",
           "7944ed9fb8": "Not counted"
         },
+        "LargeFileFallback": {
+          "0aabd49594": "This file is too large to open in the editor.",
+          "64689ffd03": "Size",
+          "a66faf5b54": "Editor limit",
+          "e13c1c94e0": "Files this large are not loaded into the editor, so the window stays responsive. Open it in an external editor, or split it before editing.",
+          "e51e6a81c9": "Try again"
+        },
         "DiffViewer": {
           "b5675b0694": "Save",
           "593f2193f6": "This draft crossed the safe display limit, but it can still be saved."

--- a/src/shared/editor-file-read-limits.test.ts
+++ b/src/shared/editor-file-read-limits.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_LOCAL_TEXT_FILE_BYTES,
+  MAX_PREVIEWABLE_BINARY_BYTES,
+  MAX_REMOTE_TEXT_FILE_BYTES,
+  fileTooLargeMessage,
+  megabytesLabel,
+  parseFileTooLargeMessage
+} from './editor-file-read-limits'
+
+describe('editor file read limits', () => {
+  // Regression: the local budget was cut to the remote one, locking out 14MB JSON/CSV files
+  // that Monaco already handles. The remote budget is transport-bound and stays where it is.
+  it('keeps the local budget above the frame-bound remote one', () => {
+    expect(MAX_LOCAL_TEXT_FILE_BYTES).toBe(50 * 1024 * 1024)
+    expect(MAX_REMOTE_TEXT_FILE_BYTES).toBe(10 * 1024 * 1024)
+    expect(MAX_PREVIEWABLE_BINARY_BYTES).toBe(50 * 1024 * 1024)
+  })
+
+  it('parses the message every read path emits', () => {
+    const message = fileTooLargeMessage(14 * 1024 * 1024, MAX_REMOTE_TEXT_FILE_BYTES)
+
+    expect(message).toBe('File too large: 14.0MB exceeds 10MB limit')
+    expect(parseFileTooLargeMessage(message)).toEqual({ observedMb: 14, limitMb: 10 })
+  })
+
+  it('parses the message after IPC prefixes the invoke channel', () => {
+    expect(
+      parseFileTooLargeMessage(
+        "Error invoking remote method 'fs:readFile': Error: File too large: 51.2MB exceeds 10MB limit"
+      )
+    ).toEqual({ observedMb: 51.2, limitMb: 10 })
+  })
+
+  it('labels megabytes for display', () => {
+    expect(megabytesLabel(14.03, 1)).toBe('14.0 MB')
+    expect(megabytesLabel(10)).toBe('10 MB')
+  })
+
+  it('ignores unrelated load failures', () => {
+    expect(
+      parseFileTooLargeMessage('Access denied: path resolves outside allowed directories')
+    ).toBe(null)
+  })
+})

--- a/src/shared/editor-file-read-limits.ts
+++ b/src/shared/editor-file-read-limits.ts
@@ -1,0 +1,37 @@
+/**
+ * File-read budgets and the "File too large" message shape, shared by every editor read
+ * path — local IPC, relay, and SSH — so producers and the renderer that parses them agree.
+ */
+
+// Why: Monaco degrades features on large files like VS Code, so a smaller block would
+// needlessly lock out ordinary JSON/CSV/log files that local reads can hold in memory.
+export const MAX_LOCAL_TEXT_FILE_BYTES = 50 * 1024 * 1024
+// Why: lower than local because the legacy single-shot fs.readFile reply carries the whole
+// file in one JSON-RPC frame, and MAX_MESSAGE_SIZE is 16MB before JSON escaping.
+export const MAX_REMOTE_TEXT_FILE_BYTES = 10 * 1024 * 1024
+// Why: previewable binaries are base64 blobs handed to a viewer, never parsed as text or
+// tokenized, and reads above the legacy 16MB single-frame budget go through fs.readFileStream.
+export const MAX_PREVIEWABLE_BINARY_BYTES = 50 * 1024 * 1024
+
+export function fileTooLargeMessage(observedBytes: number, maxBytes: number): string {
+  return `File too large: ${(observedBytes / 1024 / 1024).toFixed(1)}MB exceeds ${maxBytes / 1024 / 1024}MB limit`
+}
+
+// Why: unit symbol, not prose — kept out of JSX so the localization audit does not read it as copy.
+export function megabytesLabel(megabytes: number, fractionDigits = 0): string {
+  return `${megabytes.toFixed(fractionDigits)} MB`
+}
+
+// Why: IPC and RPC rejections reach the renderer as a plain string, so the shape is parsed back here
+// rather than re-derived — keeping the producer and the consumer in one file.
+const FILE_TOO_LARGE_PATTERN = /File too large: (\d+(?:\.\d+)?)MB exceeds (\d+(?:\.\d+)?)MB limit/
+
+export type FileTooLargeDetails = { observedMb: number; limitMb: number }
+
+export function parseFileTooLargeMessage(message: string): FileTooLargeDetails | null {
+  const match = FILE_TOO_LARGE_PATTERN.exec(message)
+  if (!match) {
+    return null
+  }
+  return { observedMb: Number(match[1]), limitMb: Number(match[2]) }
+}

--- a/src/shared/node-bounded-file-reader.ts
+++ b/src/shared/node-bounded-file-reader.ts
@@ -1,5 +1,6 @@
 import { closeSync, fstatSync, openSync, readSync, type Stats } from 'node:fs'
 import { open } from 'node:fs/promises'
+import { fileTooLargeMessage } from './editor-file-read-limits'
 
 const MIN_GROWTH_BYTES = 64 * 1024
 
@@ -8,9 +9,7 @@ export class NodeFileReadTooLargeError extends Error {
     readonly observedBytes: number,
     readonly maxBytes: number
   ) {
-    super(
-      `File too large: ${(observedBytes / 1024 / 1024).toFixed(1)}MB exceeds ${maxBytes / 1024 / 1024}MB limit`
-    )
+    super(fileTooLargeMessage(observedBytes, maxBytes))
     this.name = 'NodeFileReadTooLargeError'
   }
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​174 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​173 |
| Prod | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​132 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​37 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​95 |

<!-- /orca-pr-loc -->

> **Draft — do not merge, and the current approach is probably wrong.** Only 1 adversarial loop completed (the 2nd and the perf pass died on network errors), and that loop found a **blocker: this change silently reverts a merged PR**. Opening for the analysis, not the code.

## The observation (real)

@CORCJO (Windows, 1.4.188) wrote *"I tried to opening a 14 mb json file that was generated via a script created"* and their renderer died.

The local (non-SSH) editor read path is `src/main/ipc/filesystem.ts:596-604` with `MAX_TEXT_FILE_SIZE = 50 * 1024 * 1024`. A 14 MB JSON sails through with no downstream large-file handling. Every neighbouring surface is far tighter:

| Surface | Limit |
|---|---|
| Local editor text | **50 MB** |
| SSH / relay file read | 10 MB |
| Diff viewer | 6 MB combined chars / 120k lines per side, with `LargeDiffFallback` |

So the same file opens locally at 5× the SSH cap and 8× the diff cap, with no fallback view.

## Why the current diff is wrong

**Blocker:** it resolves the mismatch by cutting the local budget 5× (50 MB → 10 MB), which **silently reverts merged PR #1367 ("Allow large text files to open in editor")**. That PR exists because someone wanted this. Fixing an inconsistency by undoing a deliberate feature isn't a fix.

My own brief warned about exactly this — *"if lowering it would break a real use case, say so and propose the fallback-only route instead"* — and the agent lowered it anyway. That's on the approach, not on the reviewer who caught it.

Two more majors from the same loop:
- Non-previewable binaries between 10 MB and 50 MB now fail with "File too large" instead of the existing binary-file placeholder, because the size gate runs before the binary probe.
- The new copy asserts *"Local and remote files use the same limit"* while the change keeps two exceptions, and the fallback never renders for the Orca-runtime remote path it claims to unify.

## Suggested path

**Drop the cap change entirely; keep only the fallback.** Follow the `LargeDiffFallback` precedent so an oversized file degrades to an explanatory view instead of a dead editor — that addresses the user-visible symptom without reverting #1367 or touching the binary path.

## Honesty note

It is **not proven** that the 14 MB JSON caused this crash. That report is separately **mis-filed against a Chromium utility process** (the V8 Proxy Resolver — see draft #16434), and the same user's renderer had been **silent for 13.5 minutes** before it died (see draft #16436). This work is justified by the local/SSH inconsistency and the missing fallback, not by a proven causal chain.
