### PR TITLE
fix(codex): emit neutral JSON from the managed Codex hook

### DIFF
--- a/src/main/agent-hooks/hook-script-outside-orca.test.ts
+++ b/src/main/agent-hooks/hook-script-outside-orca.test.ts
@@ -31,7 +31,9 @@ describe('managed hook outside an Orca terminal', () => {
     const dir = mkdtempSync(join(tmpdir(), 'orca-outside-'))
     const res = runHook(dir)
     expect(res.status).toBe(0)
-    expect(res.stdout).toBe('')
+    // Why: Codex fails closed on non-JSON hook stdout (#16356), so the neutral '{}' is required even
+    // outside an Orca terminal; inertness is still asserted by exit 0, empty stderr and no files written.
+    expect(res.stdout).toBe('{}\n')
     expect(res.stderr).toBe('')
     expect(readdirSync(dir)).toEqual(['codex-hook.sh'])
   })
@@ -40,7 +42,9 @@ describe('managed hook outside an Orca terminal', () => {
     const dir = mkdtempSync(join(tmpdir(), 'orca-outside-partial-'))
     const res = runHook(dir, { ORCA_PANE_KEY: 'tab:0', ORCA_TAB_ID: 'tab' })
     expect(res.status).toBe(0)
-    expect(res.stdout).toBe('')
+    // Why: Codex fails closed on non-JSON hook stdout (#16356), so the neutral '{}' is required even
+    // outside an Orca terminal; inertness is still asserted by exit 0, empty stderr and no files written.
+    expect(res.stdout).toBe('{}\n')
     expect(res.stderr).toBe('')
     expect(readdirSync(dir)).toEqual(['codex-hook.sh'])
   })
@@ -52,7 +56,9 @@ describe('managed hook outside an Orca terminal', () => {
       ORCA_PANE_KEY: 'tab:0'
     })
     expect(res.status).toBe(0)
-    expect(res.stdout).toBe('')
+    // Why: Codex fails closed on non-JSON hook stdout (#16356), so the neutral '{}' is required even
+    // outside an Orca terminal; inertness is still asserted by exit 0, empty stderr and no files written.
+    expect(res.stdout).toBe('{}\n')
     expect(res.stderr).toBe('')
     // a stale env var must not create a spool tree for an Orca that is not installed here
     expect(readdirSync(dir)).toEqual(['codex-hook.sh'])
@@ -64,7 +70,9 @@ describe('managed hook outside an Orca terminal', () => {
     writeFileSync(endpoint, 'ORCA_AGENT_HOOK_PORT=9\nORCA_AGENT_HOOK_TOKEN=stale\n')
     const res = runHook(dir, { ORCA_AGENT_HOOK_ENDPOINT: endpoint })
     expect(res.status).toBe(0)
-    expect(res.stdout).toBe('')
+    // Why: Codex fails closed on non-JSON hook stdout (#16356), so the neutral '{}' is required even
+    // outside an Orca terminal; inertness is still asserted by exit 0, empty stderr and no files written.
+    expect(res.stdout).toBe('{}\n')
     expect(res.stderr).toBe('')
     expect(readdirSync(dir).sort()).toEqual(['codex-hook.sh', 'endpoint.env'])
   })

--- a/src/main/codex/codex-hook-script.ts
+++ b/src/main/codex/codex-hook-script.ts
@@ -12,6 +12,8 @@ export function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     return [
       '@echo off',
       'setlocal',
+      // Why: Codex fails closed on a hook whose stdout is not valid JSON (#16356); neutral JSON first, like claude/hook-service.ts (#14818).
+      'echo {}',
       // Why: the endpoint file holds this install's live port/token; sourcing it lets a surviving PTY reach the current server (see claude/hook-service.ts).
       'if defined ORCA_AGENT_HOOK_ENDPOINT if exist "%ORCA_AGENT_HOOK_ENDPOINT%" call "%ORCA_AGENT_HOOK_ENDPOINT%" 2>nul',
       ...buildWindowsHookEnvironmentGuardLines(),
@@ -24,6 +26,8 @@ export function getManagedScript(target: 'local' | 'posix' = 'local'): string {
 
   return [
     '#!/bin/sh',
+    // Why: Codex fails closed on a hook whose stdout is not valid JSON (#16356); neutral JSON first, like claude/hook-service.ts (#14818).
+    'printf "{}\\n"',
     ...buildPosixHookPayloadCapture(),
     ...buildPosixHookSpoolLines('codex'),
     // Why: sourcing refreshes PORT/TOKEN/ENV/VERSION from the current Orca so a surviving PTY keeps reporting after a restart (see claude/hook-service.ts).

--- a/src/main/codex/hook-service-neutral-json.test.ts
+++ b/src/main/codex/hook-service-neutral-json.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', async () => {
+  const { tmpdir } = await import('node:os')
+  const { join } = await import('node:path')
+  return {
+    app: {
+      getPath: () => join(tmpdir(), 'orca-user-data')
+    }
+  }
+})
+
+import { getCodexManagedHookInstallMaterial } from './hook-service'
+
+const realPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+
+function scriptForPlatform(platform: 'darwin' | 'win32'): string {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true })
+  return getCodexManagedHookInstallMaterial().script
+}
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', realPlatform)
+})
+
+// Why: Codex fails every SessionStart/Stop hook whose stdout is not valid JSON (#16356), the same
+// fail-closed contract Claude's hook already answers with neutral JSON (#14818).
+describe('managed Codex hook script neutral JSON', () => {
+  it('emits neutral JSON before anything can exit early, on POSIX', () => {
+    const script = scriptForPlatform('darwin')
+
+    expect(script.indexOf('printf "{}\\n"')).toBe(
+      script.indexOf('#!/bin/sh') + '#!/bin/sh\n'.length
+    )
+    // Why: the guards below return 0 without posting, so a later printf would never run.
+    expect(script.indexOf('printf "{}\\n"')).toBeLessThan(script.indexOf('exit 0'))
+  })
+
+  it('emits neutral JSON before anything can exit early, on Windows', () => {
+    const lines = scriptForPlatform('win32').split('\r\n')
+
+    // Why: same precision as the POSIX case above - an exact offset, so moving the endpoint load
+    // (or anything else) ahead of the neutral JSON fails the test instead of silently passing.
+    expect(lines.indexOf('echo {}')).toBe(lines.indexOf('setlocal') + 1)
+    expect(lines.indexOf('echo {}')).toBeLessThan(
+      lines.findIndex((line) => line.startsWith('exit /b'))
+    )
+  })
+})


### PR DESCRIPTION
## ELI5

Codex refuses any hook whose output isn't JSON. Orca's Codex hook printed nothing, so Codex marked every session start and stop as failed — even though the hook's real work succeeded. This prints `{}` first, which is what Orca's Claude, Gemini, Copilot and Antigravity hooks already do.

## What Changed

`src/main/codex/codex-hook-script.ts`, in `getManagedScript`:

- POSIX branch: `printf "{}\n"` immediately after `#!/bin/sh`, before the payload capture.
- Windows `.cmd` branch: `echo {}` immediately after `setlocal`.

Placement matters: both branches exit 0 without posting when the payload or the `ORCA_*` environment is missing, so neutral JSON emitted later would never run.

New `src/main/codex/hook-service-neutral-json.test.ts` pins the ordering on both branches, using the same `indexOf` idiom as `src/main/claude/hook-service.test.ts`.

`src/main/agent-hooks/hook-script-outside-orca.test.ts` (added in #16685, after this PR was opened) asserted the managed Codex hook stays byte-silent outside an Orca terminal. Its four `stdout` assertions now expect `{}\n` — see **Outside an Orca terminal** below, where I lay out why and what a maintainer may want to overrule.

## Why

Codex fails closed on a hook whose stdout is not valid JSON, so **every** Codex session launched from an Orca terminal reported:

```
• SessionStart hook (failed)  error: hook returned invalid session start JSON output
• Stop hook (failed)          error: hook returned invalid stop hook JSON output
```

The hook's actual job was fine — the POST to `http://127.0.0.1:<port>/hook/codex` went through and `worker-read` still returned `source: transcript`. What broke was only the stdout contract, and the cost is that users are trained to ignore red hook errors, including real ones.

**Codex was the only managed hook without neutral JSON:**

| agent | POSIX | Windows |
|---|---|---|
| claude | `src/main/claude/hook-service.ts:99` `printf "{}\n"` | `src/main/claude/hook-service.ts:71` `echo {}` |
| gemini | `src/main/gemini/hook-service.ts:74` | `src/main/gemini/hook-service.ts:60` |
| copilot | `src/main/copilot/copilot-managed-script.ts:57` `printf '{}\n'` | — |
| antigravity | `src/main/antigravity/hook-script.ts:53` | `src/main/antigravity/hook-script.ts:30`, `:103` |
| **codex** | **absent → now `src/main/codex/codex-hook-script.ts:30`** | **absent → now `src/main/codex/codex-hook-script.ts:16`** |

The Claude one carries the same rationale, from #14818. This closes the gap rather than introducing a new convention. `{}` is the correct neutral response — every field in Codex's hook output schema is optional.

## Outside an Orca terminal — needs a maintainer's call

`src/main/agent-hooks/hook-script-outside-orca.test.ts`, added in #16685 on 2026-08-26 (after this PR was opened), asserts the managed Codex hook produces `stdout === ''` when run outside an Orca terminal.

That silence is precisely the failure #16356 reports. The managed hook is installed into the user's Codex config, so it also runs for sessions launched from a plain terminal — exactly where empty stdout yields `invalid session start/stop hook JSON output`. As written, the test pins the bug rather than the contract, and it passes today only because Codex is the one agent still missing the line: every sibling prints neutral JSON unconditionally on current `main` (see the table above).

I changed those four `stdout` assertions to expect `{}\n`. The inertness they actually guard is unchanged and still asserted in all four cases — exit 0, empty stderr, and no spool tree or other file written into the temp dir.

If the intent of #16685 was that Codex specifically must stay byte-silent outside Orca, say so and I will gate the neutral JSON on the Orca environment instead — but that leaves #16356 unfixed for out-of-terminal sessions.

## Linked Issue

Fixes #16356

## Visual Proof

N/A — no UI surface; this changes a generated shell script.

## Testing

Running the real generated script (`getCodexManagedHookInstallMaterial().script`) on macOS 15 arm64:

```console
# before
$ printf '{"e":1}' | sh codex-hook.sh
$ echo "stdout empty, exit=$?"
stdout empty, exit=0

# after
$ printf '{"e":1}' | sh codex-hook.sh
{}
$ echo "exit=$?"
exit=0
```

Early exits verified intact — empty payload and missing `ORCA_*` environment both still return 0 after emitting `{}`; identical output under `sh`, `bash` and `dash`.

New tests fail on `main` and pass with the change (`expected -1 to be 2` without the fix).

Re-verified on the rebased head `54f6a1373` (base `d607a6367`): `pnpm typecheck` and `pnpm lint` clean, including `check:max-lines-ratchet` (no new bypasses). `vitest src/main/codex src/main/agent-hooks src/main/claude`: 2472 passed, 0 failed. Running the generated script by hand across `sh`/`bash`/`dash` x payload-present/payload-empty, all six combinations give `stdout=[{}] exit=0 stderr=[]`, and `json.load` accepts the output.

⚠️ **The Windows branch is not verified on Windows.** I have no Windows host. `echo {}` is a byte-for-byte mirror of the line Claude's `.cmd` hook has carried since #14818, placed at the same position relative to `setlocal`, and its ordering is covered by a platform-stubbed unit test. Worth a reviewer's eye on a real Windows box.

## AI Disclosure

Written with Claude Code (Claude Opus 5). I verified every claim against `origin/main` myself, ran the generated script by hand, and wrote the failing test before the fix. Re-verified after the rebase onto #17260's module split.

## Review

AI code review summary, per CONTRIBUTING:

- **Cross-platform** — both branches changed symmetrically. The POSIX line is `printf`, not `echo -n`/`echo -e`, so it behaves identically under `sh`/`dash`/`bash` (verified). Windows uses `echo {}`, matching Claude's `.cmd`; `{` and `}` are not `cmd.exe` metacharacters and need no escaping. **Windows not tested on Windows** (see Testing).
- **SSH/remote/local** — `getManagedScript('posix')` is the same builder used by `installRemote` and the WSL runtime install path, so remote and WSL installs pick the line up automatically with no separate change. Trust hashes are computed over the script, so remote and local stay byte-matched — `getCodexManagedHookInstallMaterial` returns this same string, which is what keeps the real-home lane in sync.
- **Agent/integration compatibility** — Codex only; no shared helper touched, so no other agent's script changes. `{}` is a valid, fully-optional Codex hook response, so it cannot alter a permission decision or turn outcome.
- **Performance** — one `printf` per hook invocation, before any I/O. Immeasurable next to the curl POST that follows.
- **UI quality** — N/A.
- **Security** — no new input handling, no new process spawn, no change to token or endpoint handling; the emitted string is a constant.
- **Regression risk** — additive only (+4 lines, 0 removed). The early-exit guards, payload capture and the WSL curl.exe fallback are untouched, and their behaviour was re-verified by hand.

