### PR TITLE
fix(git): discard restores the working tree from the index, not HEAD

### DIFF
--- a/src/main/git/source-control/discard-changes.ts
+++ b/src/main/git/source-control/discard-changes.ts
@@ -40,7 +40,10 @@ export async function discardChanges(
 
     if (tracked) {
       await gitExecFileAsync(
-        ['restore', '--worktree', '--source=HEAD', '--', literalPathspec(filePath, options)],
+        // Why: no `--source`, so the working tree is rebuilt from the index.
+        // `--source=HEAD` would also erase the staged half of a partially staged
+        // file, and delete a newly added file (`AM`) from disk outright.
+        ['restore', '--worktree', '--', literalPathspec(filePath, options)],
         {
           ...gitOptionsForWorktree(worktreePath, options)
         }
@@ -129,7 +132,8 @@ export async function bulkDiscardChanges(
       (targetPaths) => cleanUntrackedPaths(worktreePath, targetPaths, options),
       async () => {
         const commands = bulkPathspecCommands(
-          ['restore', '--worktree', '--source=HEAD', '--'],
+          // Why: index-sourced restore, matching discardChanges above.
+          ['restore', '--worktree', '--'],
           trackedPaths,
           worktreePath,
           options

--- a/src/main/git/status-discard-and-bulk-staging.test.ts
+++ b/src/main/git/status-discard-and-bulk-staging.test.ts
@@ -72,7 +72,7 @@ describe('discardChanges', () => {
     realpathMock.mockImplementation(async (targetPath: string) => path.resolve(targetPath))
   })
 
-  it('restores tracked files from HEAD', async () => {
+  it('restores tracked files from the index', async () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'src/file.ts\n' })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' })
 
@@ -87,12 +87,26 @@ describe('discardChanges', () => {
     )
     expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(
       2,
-      ['restore', '--worktree', '--source=HEAD', '--', ':(literal)src/file.ts'],
+      ['restore', '--worktree', '--', ':(literal)src/file.ts'],
       {
         cwd: '/repo'
       }
     )
     expect(rmMock).not.toHaveBeenCalled()
+  })
+
+  // Why: `--source=HEAD` rewrites the working tree from HEAD, so discarding the
+  // unstaged half of a partially-staged (`MM`) file also erases the staged half
+  // from disk. Restoring from the index is what "discard unstaged changes" means.
+  it('does not rebuild a partially staged file from HEAD', async () => {
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'src/file.ts\n' })
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' })
+
+    await discardChanges('/repo', 'src/file.ts')
+
+    const restoreArgs = gitExecFileAsyncMock.mock.calls[1]?.[0] as string[]
+    expect(restoreArgs).not.toContain('--source=HEAD')
+    expect(restoreArgs.some((arg) => arg.startsWith('--source'))).toBe(false)
   })
 
   it('removes untracked files from disk', async () => {
@@ -207,7 +221,7 @@ describe('bulk git helpers', () => {
     // tracked descendant, which keeps directory pathspecs on the restore path.
     expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(
       2,
-      ['restore', '--worktree', '--source=HEAD', '--', ':(literal)src/file.ts', ':(literal)docs'],
+      ['restore', '--worktree', '--', ':(literal)src/file.ts', ':(literal)docs'],
       {
         cwd: '/repo'
       }
@@ -234,12 +248,26 @@ describe('bulk git helpers', () => {
 
     expect(gitExecFileAsyncMock).toHaveBeenNthCalledWith(
       2,
-      ['restore', '--worktree', '--source=HEAD', '--', ':(literal)docs'],
+      ['restore', '--worktree', '--', ':(literal)docs'],
       {
         cwd: '/repo'
       }
     )
     expect(rmMock).not.toHaveBeenCalled()
+  })
+
+  // Why: the bulk path carries the same HEAD-vs-index defect as discardChanges,
+  // and it is the path the "Discard all" affordance uses.
+  it('does not rebuild bulk-discarded files from HEAD', async () => {
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'src/file.ts\0' })
+      .mockResolvedValueOnce({ stdout: '' })
+
+    await bulkDiscardChanges('/repo', ['src/file.ts'])
+
+    const restoreArgs = gitExecFileAsyncMock.mock.calls[1]?.[0] as string[]
+    expect(restoreArgs).not.toContain('--source=HEAD')
+    expect(restoreArgs.some((arg) => arg.startsWith('--source'))).toBe(false)
   })
 
   it('rejects bulk discard paths that traverse outside the worktree', async () => {

--- a/src/relay/git-handler-discard-operations.ts
+++ b/src/relay/git-handler-discard-operations.ts
@@ -57,7 +57,10 @@ export class GitHandlerDiscardOperations extends GitHandlerOperationContext {
 
       if (tracked) {
         await this.git(
-          ['restore', '--worktree', '--source=HEAD', '--', this.literalPathspec(filePath)],
+          // Why: no `--source`, so the working tree is rebuilt from the index.
+          // Mirrors the local path in src/main/git/source-control/discard-changes.ts;
+          // `--source=HEAD` would also erase a partially staged file's staged half.
+          ['restore', '--worktree', '--', this.literalPathspec(filePath)],
           worktreePath
         )
         return
@@ -112,13 +115,8 @@ export class GitHandlerDiscardOperations extends GitHandlerOperationContext {
           for (let i = 0; i < trackedPaths.length; i += BULK_CHUNK_SIZE) {
             const chunk = trackedPaths.slice(i, i + BULK_CHUNK_SIZE)
             await this.git(
-              [
-                'restore',
-                '--worktree',
-                '--source=HEAD',
-                '--',
-                ...chunk.map((p) => this.literalPathspec(p))
-              ],
+              // Why: index-sourced restore, matching discardOne above.
+              ['restore', '--worktree', '--', ...chunk.map((p) => this.literalPathspec(p))],
               worktreePath
             )
           }

--- a/src/relay/git-handler-working-tree-changes.test.ts
+++ b/src/relay/git-handler-working-tree-changes.test.ts
@@ -284,6 +284,39 @@ describe('GitHandler', () => {
       )
     })
 
+    // Why: this is issue #16424. `--source=HEAD` rebuilt the working tree from
+    // HEAD, so discarding the unstaged half of a partially staged (`MM`) file
+    // also erased the staged half from disk, and a newly added (`AM`) file was
+    // removed outright. Restoring from the index is what "discard unstaged
+    // changes" means, and the remote path must match the local one.
+    it('keeps the staged half of a partially staged file when discarding', async () => {
+      gitInit(tmpDir)
+      writeFileSync(path.join(tmpDir, 'f.txt'), 'base\n')
+      gitCommit(tmpDir, 'initial')
+      writeFileSync(path.join(tmpDir, 'f.txt'), 'base\nfeature1\n')
+      execFileSync('git', ['add', 'f.txt'], { cwd: tmpDir, stdio: 'pipe' })
+      writeFileSync(path.join(tmpDir, 'f.txt'), 'base\nfeature1\nfeature2\n')
+
+      await dispatcher.callRequest('git.discard', { worktreePath: tmpDir, filePath: 'f.txt' })
+
+      await expect(fs.readFile(path.join(tmpDir, 'f.txt'), 'utf-8')).resolves.toBe(
+        'base\nfeature1\n'
+      )
+    })
+
+    it('keeps a newly added file on disk when discarding its unstaged edit', async () => {
+      gitInit(tmpDir)
+      writeFileSync(path.join(tmpDir, 'seed.txt'), 'seed\n')
+      gitCommit(tmpDir, 'initial')
+      writeFileSync(path.join(tmpDir, 'new.txt'), 'brand new\n')
+      execFileSync('git', ['add', 'new.txt'], { cwd: tmpDir, stdio: 'pipe' })
+      writeFileSync(path.join(tmpDir, 'new.txt'), 'brand new\nplus an edit\n')
+
+      await dispatcher.callRequest('git.discard', { worktreePath: tmpDir, filePath: 'new.txt' })
+
+      await expect(fs.readFile(path.join(tmpDir, 'new.txt'), 'utf-8')).resolves.toBe('brand new\n')
+    })
+
     it('bulk discards tracked and untracked files', async () => {
       gitInit(tmpDir)
       writeFileSync(path.join(tmpDir, 'a.txt'), 'a')
@@ -324,7 +357,7 @@ describe('GitHandler', () => {
 
       expect(gitMock).toHaveBeenNthCalledWith(
         2,
-        ['restore', '--worktree', '--source=HEAD', '--', ':(literal)docs'],
+        ['restore', '--worktree', '--', ':(literal)docs'],
         tmpDir
       )
     })

--- a/src/renderer/src/components/right-sidebar/discard-all-sequence.test.ts
+++ b/src/renderer/src/components/right-sidebar/discard-all-sequence.test.ts
@@ -40,9 +40,9 @@ describe('getDiscardAllPaths', () => {
         conflictStatus: 'unresolved'
       })
     ]
-    // Why: `git restore --worktree --source=HEAD` on an unresolved conflict
-    // clears the `u` record silently before the user has reviewed it, which
-    // is why the per-row Stage/Discard buttons also suppress this case.
+    // Why: discarding an unresolved conflict touches the `u` record before the
+    // user has reviewed it, which is why the per-row Stage/Discard buttons also
+    // suppress this case.
     expect(getDiscardAllPaths(entries, 'unstaged')).toEqual(['clean.ts'])
   })
 

--- a/src/renderer/src/components/right-sidebar/source-control/commit/discard-all-sequence.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/commit/discard-all-sequence.ts
@@ -98,12 +98,12 @@ export type DiscardAllResult = {
  * Run the "Discard all" sequence for a given area.
  *
  * For 'staged', this first bulk-unstages the paths — without that step,
- * `discardOne` (which maps to `git restore --worktree --source=HEAD`) would
- * reset the working tree to HEAD but leave the index carrying the staged
- * delta, producing phantom inverse "Changes" rows the user thought they just
- * discarded. If the unstage fails we MUST skip the discard loop entirely for
- * the same reason: a stale index with a clean worktree is a worse state than
- * the one the user started in.
+ * `discardOne` (which maps to `git restore --worktree`, i.e. restore from the
+ * index) would rewrite the working tree from the still-staged index and leave
+ * the staged delta in place, so the rows the user asked to discard would come
+ * back. If the unstage fails we MUST skip the discard loop entirely for the
+ * same reason: a stale index driving the worktree is a worse state than the
+ * one the user started in.
  *
  * Per-file `discardOne` failures are best-effort: we continue past a failed
  * file so a single stuck path does not block the rest of the bulk action.


### PR DESCRIPTION
## ELI5

You stage some work, keep editing the same file, then decide the *newest* edits were a mistake and hit Discard. Orca threw away the staged work too. If the file was brand new, Orca deleted it off your disk. This makes Discard throw away only what you asked it to.

## What Changed

Both discard paths dropped `--source=HEAD` from their `git restore` invocation:

- `src/main/git/source-control/discard-changes.ts` — `discardChanges` and `bulkDiscardChanges` (local worktrees)
- `src/relay/git-handler.ts` — `discardOne` and `bulkDiscard` (SSH/remote worktrees)

No other behaviour changed: path-safety checks, tracked/untracked classification, `:(literal)` pathspecs, chunking, and the untracked `git clean -ffdx` branch are all untouched.

Two doc comments that quoted the old command string were updated so they no longer describe a flag that is gone. The `discard-all-sequence` bulk-unstage pre-step is kept — its conclusion still holds, only its mechanism description changed.

## Why

`git restore --worktree --source=HEAD` rebuilds the working tree **from HEAD**. `git restore --worktree` (no `--source`) rebuilds it **from the index**. Discarding *unstaged* changes means "go back to what's staged", i.e. the index.

Verified in a scratch repo on this machine:

| Case | Start | `--source=HEAD` (before) | no `--source` (after) |
|---|---|---|---|
| `MM` — `feature1` staged, `feature2` unstaged | `base/feature1/feature2` | file is **`base` only** — the staged `feature1` is erased from disk, and the file stays `MM` as a phantom inverse | `base/feature1`, status `M ` ✅ |
| `AM` — new file added, then edited | file on disk | status `AD`, **file removed from disk** | status `A `, file intact ✅ |

The first row is exactly the reproduction in #16424.

Corroborating evidence already in the tree: the `runDiscardAllForArea` doc comment describes the bulk-unstage pre-step as necessary *because* `discardOne` "would reset the working tree to HEAD but leave the index carrying the staged delta, producing phantom inverse Changes rows". That is this defect, worked around at one call site rather than fixed at the source.

The relay handler carried a verbatim copy of the same two invocations, so remote worktrees had the identical data loss. Fixing only the local path would have left local and SSH behaviour divergent.

## Linked Issue

Fixes #16424

### Relationship to #5880

#5880 identified the same root cause back in June and deserves the credit for spotting it. It is currently `CONFLICTING`, 74 files / +6003 −263, last pushed 2026-08-10, with no human review, and has grown into staged-discard capability negotiation, a receipt ledger, and a `protocol-version.ts` bump.

**This PR is deliberately only the index-semantics correction** — it does not touch the capability negotiation, the receipt ledger, or the protocol version, and takes no position on whether those are wanted. If you would rather land #5880, please close this one; the intent is to unblock the data loss in the meantime, not to compete with that design.

### Deliberately out of scope

#16424 also reports that the diff preview shows the staged content mixed into the unstaged view. That is the `compareAgainstHead` selection in the Source Control diff, not the discard command, and #11173 (`feat(source-control): unstaged-only Changes diffs and toolbar refresh`) is already addressing it. Not touched here.

## Visual Proof

N/A — this changes argv for a main-process/relay `git` invocation. There is no UI or interaction change; the observable difference is file content on disk, asserted directly by the new relay tests.

## Testing

Red first, then green. The two argv regressions failed against unmodified `main`:

```
× does not rebuild a partially staged file from HEAD
× does not rebuild bulk-discarded files from HEAD
AssertionError: expected [ 'restore', '--worktree', …(3) ] to not include '--source=HEAD'
Tests  2 failed | 9 passed (11)
```

Added:
- `src/main/git/status-discard-and-bulk-staging.test.ts` — 2 argv regressions (single + bulk); the existing `restores tracked files from HEAD` case is renamed to `…from the index` and its three argv assertions updated.
- `src/relay/git-handler-working-tree-changes.test.ts` — 2 **behavioural** regressions against a real temp git repo, asserting file *content* on disk after discard: the `MM` case keeps `base\nfeature1\n`, and the `AM` case keeps the file with `brand new\n`. These fail against `main` for the real reason, not just an argv shape.

Local runs on macOS arm64, node 24.14.0 / pnpm 10.24.0:

- `pnpm typecheck` — pass
- `pnpm lint` — pass, including `max-lines ratchet OK — 117 grandfathered suppression(s), no new bypasses`
- `pnpm exec vitest --run src/main/git src/relay` — 312 files, **3420 passed, 1 failed**
- `pnpm build` — the electron-vite/TS stages emit `out/main/*` successfully; the run then exits 1 at `codesign` of the Swift `Orca Computer Use.app` helper with `errSecInternalComponent`

Both non-passing results were controlled for by stashing this diff and re-running on clean `main`, where **each reproduces identically**:

- `git-handler-fork-remote-exec.test.ts > adds and removes the fork remote` expects `https://github.com/...` and receives `git@github.com:...`. My global git config has `url.git@github.com:.insteadOf https://github.com/`, which rewrites the URL the test asserts. Unrelated to this change.
- The `codesign` failure is a local signing-identity problem. This diff touches no file under `native/`.

The branch is rebased onto `main` at `822087c8e`; `pnpm typecheck`, `pnpm lint` and the five affected test files were re-run after the rebase and are green.

Per CONTRIBUTING, fork PRs do not get the CI matrix without a maintainer approving the workflow, so the above is the full local verification.

## AI Disclosure

Claude Opus 5 (via Claude Code) was used throughout: locating the call sites, writing the tests and the patch, and running the verification. Every claim in this PR was produced by actually executing the command, not by inference — the red/green output, the scratch-repo `MM`/`AM` comparison, the 3420-test run, and both stash-controlled baselines were all run on this machine. The root cause was checked against `origin/main` rather than a local checkout, which matters here because `status.ts` was split into `src/main/git/source-control/` by #16393 while this was being prepared.

## Review

AI code review summary, per CONTRIBUTING:

- **Cross-platform** — the change removes an argument; it adds no platform branch. `--source` has been optional on `git restore` since it was introduced in Git 2.23, and index-sourced restore is the documented default, so there is no version floor beyond what the repo already requires. The WSL pathspec conversion in `literalPathspec` is untouched, and `status-wsl-pathspecs.test.ts` still passes.
- **SSH / remote / local** — explicitly in scope. The relay handler carried a duplicate of both invocations and is fixed in the same commit, so local and remote discard stay identical. This is the main reason the diff is larger than the two-line core fix.
- **Supported agents and integrations** — none call discard; the mobile client reaches it through the existing `git.discard` / `git.bulkDiscard` RPC, whose signatures, parameters, and return shape are unchanged. No protocol or capability change, so mixed-version desktop/mobile/relay pairs are unaffected.
- **Performance** — one fewer argv element. No extra subprocess, no extra I/O.
- **UI quality** — no UI change. The one user-visible improvement is the disappearance of the phantom-inverse `MM` row that the old behaviour produced.
- **Security** — the pathspec-injection guard (`:(literal)`), the `isWithinWorktree` traversal check, and the symlink-safe untracked cleanup are all untouched; their tests still pass. Restoring from the index reads strictly less than restoring from HEAD.
- **Backward compatibility** — no persisted state, no schema, no protocol version. The only behaviour change is the one the issue asks for. The `runDiscardAllForArea` bulk-unstage pre-step still yields the same end state: unstage moves the index to HEAD, then the index-sourced restore reaches the same content the HEAD-sourced one did.
