### PR TITLE
perf(git): only schedule the upstream-ref poll for the repo that has one

### DIFF
--- a/src/main/ipc/worktree-git-common-primary-watch.ts
+++ b/src/main/ipc/worktree-git-common-primary-watch.ts
@@ -7,6 +7,7 @@ import type {
   WorktreePollerWindowVisibility
 } from './worktree-base-directory-poller'
 import { createSingleFlight } from './single-flight-promise'
+import { onActiveGitStatusRefBindingChanged } from './worktree-git-status-ref-watch'
 import { PRIMARY_CHECKOUT_METADATA_FILES } from './worktree-git-common-metadata-files'
 import { startGitCommonPrimaryPolling } from './worktree-git-common-primary-polling'
 
@@ -67,6 +68,50 @@ export async function startGitCommonPrimaryWatch(
       })
     )
 
+  const startStatusRefPollingIfSelected = async (): Promise<WorktreeBaseSubscription | null> =>
+    getStatusRefPaths().length === 0
+      ? null
+      : startGitCommonPrimaryPolling(
+          commonDirPath,
+          getStatusRefPaths,
+          onEvents,
+          pollIntervalMs,
+          visibility,
+          undefined,
+          false
+        )
+
+  // Why: rebinding is synchronous and in-process, so reacting to it costs the
+  // same detection latency as polling would have, without the idle wake-ups.
+  const syncStatusRefPolling = async (): Promise<void> => {
+    if (disposed || !watcher) {
+      return
+    }
+    const selected = getStatusRefPaths().length > 0
+    if (selected === (statusRefPolling !== null)) {
+      return
+    }
+    if (!selected) {
+      const current = statusRefPolling
+      statusRefPolling = null
+      await current?.unsubscribe().catch(() => {})
+      return
+    }
+    const next = await startStatusRefPollingIfSelected()
+    if (!next) {
+      return
+    }
+    if (disposed || !watcher || statusRefPolling) {
+      await next.unsubscribe().catch(() => {})
+      return
+    }
+    statusRefPolling = next
+  }
+
+  const unsubscribeBindingChanges = onActiveGitStatusRefBindingChanged(() => {
+    void syncStatusRefPolling().catch(() => {})
+  })
+
   const stopWatcherSidePolling = async (): Promise<void> => {
     const current = statusRefPolling
     const currentBackstop = backstopPolling
@@ -124,15 +169,7 @@ export async function startGitCommonPrimaryWatch(
     )
     if (watcher && !disposed && !fallbackFlight.pending()) {
       const [nextStatusRefPolling, nextBackstop] = await Promise.all([
-        startGitCommonPrimaryPolling(
-          commonDirPath,
-          getStatusRefPaths,
-          onEvents,
-          pollIntervalMs,
-          visibility,
-          undefined,
-          false
-        ),
+        startStatusRefPollingIfSelected(),
         startGitCommonPrimaryPolling(
           commonDirPath,
           () => [],
@@ -148,7 +185,7 @@ export async function startGitCommonPrimaryWatch(
       // adopting these now would strand the repo with status-ref coverage only.
       if (disposed || !watcher) {
         await Promise.all([
-          nextStatusRefPolling.unsubscribe().catch(() => {}),
+          nextStatusRefPolling?.unsubscribe().catch(() => {}),
           nextBackstop.unsubscribe().catch(() => {})
         ])
         if (!disposed) {
@@ -166,6 +203,7 @@ export async function startGitCommonPrimaryWatch(
   return {
     unsubscribe: async () => {
       disposed = true
+      unsubscribeBindingChanges()
       const current = watcher
       watcher = null
       if (current) {

--- a/src/main/ipc/worktree-git-common-primary-watch.ts
+++ b/src/main/ipc/worktree-git-common-primary-watch.ts
@@ -101,7 +101,11 @@ export async function startGitCommonPrimaryWatch(
     if (!next) {
       return
     }
-    if (disposed || !watcher || statusRefPolling) {
+    // Why: rebinding can flip back while the poller was being built. A concurrent
+    // unbind sees `statusRefPolling` still null and correctly does nothing, so
+    // selection has to be re-read here or this adopts a poller for a repo that
+    // no longer holds a ref — reinstating the idle wake-ups this removes.
+    if (disposed || !watcher || statusRefPolling || getStatusRefPaths().length === 0) {
       await next.unsubscribe().catch(() => {})
       return
     }

--- a/src/main/ipc/worktree-git-common-primary-watch.ts
+++ b/src/main/ipc/worktree-git-common-primary-watch.ts
@@ -43,6 +43,11 @@ export async function startGitCommonPrimaryWatch(
   let disposed = false
   let watcher: WatcherProcessSubscription | null = null
   let statusRefPolling: WorktreeBaseSubscription | null = null
+  // Why: startup and every rebind can each be mid-build at the same time. The
+  // generation names which attempt still owns the slot, so a loser unsubscribes
+  // its own poller instead of being silently overwritten — an overwrite would
+  // strand that poller's timer and visibility listener for the process lifetime.
+  let statusRefGeneration = 0
   let backstopPolling: WorktreeBaseSubscription | null = null
   let fallback: WorktreeBaseSubscription | null = null
   const fallbackFlight = createSingleFlight()
@@ -83,10 +88,33 @@ export async function startGitCommonPrimaryWatch(
 
   // Why: rebinding is synchronous and in-process, so reacting to it costs the
   // same detection latency as polling would have, without the idle wake-ups.
+  // Adopts a freshly built poller only if this attempt still owns the slot and a
+  // ref is still selected; anything else unsubscribes what it built.
+  const adoptStatusRefPolling = async (
+    generation: number,
+    next: WorktreeBaseSubscription | null
+  ): Promise<void> => {
+    if (!next) {
+      return
+    }
+    if (
+      generation !== statusRefGeneration ||
+      disposed ||
+      !watcher ||
+      statusRefPolling ||
+      getStatusRefPaths().length === 0
+    ) {
+      await next.unsubscribe().catch(() => {})
+      return
+    }
+    statusRefPolling = next
+  }
+
   const syncStatusRefPolling = async (): Promise<void> => {
     if (disposed || !watcher) {
       return
     }
+    const generation = ++statusRefGeneration
     const selected = getStatusRefPaths().length > 0
     if (selected === (statusRefPolling !== null)) {
       return
@@ -97,19 +125,7 @@ export async function startGitCommonPrimaryWatch(
       await current?.unsubscribe().catch(() => {})
       return
     }
-    const next = await startStatusRefPollingIfSelected()
-    if (!next) {
-      return
-    }
-    // Why: rebinding can flip back while the poller was being built. A concurrent
-    // unbind sees `statusRefPolling` still null and correctly does nothing, so
-    // selection has to be re-read here or this adopts a poller for a repo that
-    // no longer holds a ref — reinstating the idle wake-ups this removes.
-    if (disposed || !watcher || statusRefPolling || getStatusRefPaths().length === 0) {
-      await next.unsubscribe().catch(() => {})
-      return
-    }
-    statusRefPolling = next
+    await adoptStatusRefPolling(generation, await startStatusRefPollingIfSelected())
   }
 
   const unsubscribeBindingChanges = onActiveGitStatusRefBindingChanged(() => {
@@ -117,6 +133,7 @@ export async function startGitCommonPrimaryWatch(
   })
 
   const stopWatcherSidePolling = async (): Promise<void> => {
+    statusRefGeneration++
     const current = statusRefPolling
     const currentBackstop = backstopPolling
     statusRefPolling = null
@@ -172,6 +189,7 @@ export async function startGitCommonPrimaryWatch(
       }
     )
     if (watcher && !disposed && !fallbackFlight.pending()) {
+      const generation = ++statusRefGeneration
       const [nextStatusRefPolling, nextBackstop] = await Promise.all([
         startStatusRefPollingIfSelected(),
         startGitCommonPrimaryPolling(
@@ -196,7 +214,7 @@ export async function startGitCommonPrimaryWatch(
           await startFallback()
         }
       } else {
-        statusRefPolling = nextStatusRefPolling
+        await adoptStatusRefPolling(generation, nextStatusRefPolling)
         backstopPolling = nextBackstop
       }
     }

--- a/src/main/ipc/worktree-git-common-watch.test.ts
+++ b/src/main/ipc/worktree-git-common-watch.test.ts
@@ -406,12 +406,13 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
       ),
       []
     )
-    // Narrow fallback + selected-ref polling + primary backstop, with the narrow
-    // existence poll retired. Waiting on the exact count is what guarantees the
-    // fallback has baselined before the entry below is created.
+    // Narrow fallback + primary backstop, with the narrow existence poll retired.
+    // No upstream ref is selected here, so no selected-ref poll is scheduled at
+    // all. Waiting on the exact count is what guarantees the fallback has
+    // baselined before the entry below is created.
     await vi.waitFor(() => {
       expect(narrowSubscription().unsubscribe).toHaveBeenCalledOnce()
-      expect(visibility.listenerCount()).toBe(4)
+      expect(visibility.listenerCount()).toBe(3)
     })
 
     const entryPath = join(worktreesDir, 'fallback-entry')
@@ -580,9 +581,9 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
       visibility.source
     )
 
-    // Narrow existence, selected-ref polling, and the primary backstop each park
-    // on window visibility.
-    expect(visibility.listenerCount()).toBe(3)
+    // Narrow existence and the primary backstop park on window visibility. No
+    // upstream ref is selected, so no selected-ref poll exists to park.
+    expect(visibility.listenerCount()).toBe(2)
     await watch.unsubscribe()
     expect(visibility.listenerCount()).toBe(0)
   })
@@ -637,10 +638,15 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
 
       await replaceWorktreesRoot(commonDir, worktreesDir, retainedEntry)
       await vi.advanceTimersByTimeAsync(POLL_MS * RECONCILIATION_TICKS * 4)
-      await vi.waitFor(() => {
-        expect(subscribeMock).toHaveBeenCalledTimes(3)
-      })
-      expect(staleSubscription.unsubscribe).toHaveBeenCalledOnce()
+      // Reconciliation's snapshot is real filesystem work, so advancing the fake
+      // clock schedules it but does not guarantee it has settled.
+      await vi.waitFor(
+        () => {
+          expect(subscribeMock).toHaveBeenCalledTimes(3)
+          expect(staleSubscription.unsubscribe).toHaveBeenCalledOnce()
+        },
+        { timeout: 2_000 }
+      )
 
       const beforeStaleEvent = received.length
       staleSubscription.callback(null, [{ type: 'update', path: retainedEntry }])

--- a/src/main/ipc/worktree-git-common-watch.test.ts
+++ b/src/main/ipc/worktree-git-common-watch.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { appendFile, mkdtemp, mkdir, realpath, rm, stat, writeFile } from 'node:fs/promises'
 import type * as NodeFsPromises from 'node:fs/promises'
 import { performance as nodePerformance } from 'node:perf_hooks'
+import { updateActiveGitStatusRefBinding } from './worktree-git-status-ref-watch'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { subscribeViaWatcherProcess } from './parcel-watcher-process'
@@ -280,6 +281,61 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
     )
     const backstopSamples = statCalls.filter((path) => path === headPath).length
     expect(duringOrdinaryTicks).toBeLessThan(backstopSamples * RECONCILIATION_TICKS)
+  })
+
+  it('drops the ref poller when the binding moves away, leaving no orphan', async () => {
+    installSubscribeMock()
+    const commonDir = await makeCommonDir(true)
+    await mkdir(join(commonDir, 'refs', 'remotes', 'origin'), { recursive: true })
+    await writeFile(join(commonDir, 'refs', 'remotes', 'origin', 'main'), 'aaa\n')
+    const visibility = createVisibilityHarness()
+    const target = makeTarget(commonDir)
+    const watchTarget = {
+      kind: target.kind,
+      path: target.path,
+      repos: target.repos,
+      gitStatusRefPaths: new Set<string>()
+    }
+    const watch = await startGitCommonWatch(
+      target,
+      () => {},
+      POLL_MS,
+      'darwin',
+      visibility.source,
+      undefined,
+      () => [...watchTarget.gitStatusRefPaths]
+    )
+    cleanups.push(() => watch.unsubscribe())
+    const baseline = visibility.listenerCount()
+
+    const bind = (branch?: string): Promise<void> =>
+      updateActiveGitStatusRefBinding(
+        {
+          worktreeId: `${[...target.repos.keys()][0]}::${commonDir}`,
+          worktreePath: commonDir,
+          executionHostId: 'local',
+          branch,
+          upstreamName: branch ? 'origin/main' : undefined
+        },
+        () => [watchTarget],
+        async () => 'refs/remotes/origin/main'
+      )
+
+    // Bind then unbind repeatedly: each cycle must hand back whatever it took.
+    for (let round = 0; round < 4; round++) {
+      await bind('main')
+      await vi.waitFor(() => {
+        expect(visibility.listenerCount()).toBeGreaterThan(baseline)
+      })
+      await bind(undefined)
+      await vi.waitFor(() => {
+        expect(visibility.listenerCount()).toBe(baseline)
+      })
+    }
+
+    await watch.unsubscribe()
+    cleanups.pop()
+    expect(visibility.listenerCount()).toBe(0)
   })
 
   it('polls only the accepted upstream ref and rebinds without synthetic events', async () => {

--- a/src/main/ipc/worktree-git-status-ref-watch.ts
+++ b/src/main/ipc/worktree-git-status-ref-watch.ts
@@ -74,9 +74,27 @@ export function applyActiveGitStatusRefBinding(watch: GitStatusRefWatchTarget): 
   }
 }
 
+// Why: at most one worktree holds a selected upstream ref at a time, so every
+// other repo's ref poll would wake only to stat nothing. Publishing the
+// transition lets those pollers stay unscheduled until they actually have a ref,
+// with no detection delay — rebinding is an in-process event, not a timer.
+const bindingChangeListeners = new Set<() => void>()
+
+export function onActiveGitStatusRefBindingChanged(listener: () => void): () => void {
+  bindingChangeListeners.add(listener)
+  return () => {
+    bindingChangeListeners.delete(listener)
+  }
+}
+
 function applyBindingToWatches(watches: Iterable<GitStatusRefWatchTarget>): void {
   for (const watch of watches) {
     applyActiveGitStatusRefBinding(watch)
+  }
+  // Snapshot first: a listener may unsubscribe while being notified.
+  const listeners = Array.from(bindingChangeListeners)
+  for (const listener of listeners) {
+    listener()
   }
 }
 


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​73 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​62 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​89 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​78 |

<!-- /orca-pr-loc -->

## Background: what "holding a ref" means

To show *ahead/behind* for a branch, Orca has to notice when the branch's **upstream ref file** changes — e.g. `.git/refs/remotes/origin/main` moving when someone else pushes. So it watches that one file.

It only does this for **one worktree at a time**: the one whose ahead/behind is actually on screen. That's `activeGitStatusRefBinding` — a single module-level value in `worktree-git-status-ref-watch.ts`, set as you move around the UI:

```ts
let activeBinding: ActiveGitStatusRefBinding | null = null
```

`applyActiveGitStatusRefBinding()` then gives that one worktree a one-element set of paths to watch, and clears it for everyone else:

```ts
watch.gitStatusRefPaths.clear()
if (activeBinding && watchMatchesBinding(watch, activeBinding)) {
  watch.gitStatusRefPaths.add(resolveRuntimePath(watch.path, activeBinding.upstreamRef))
}
```

So "repo N holds a ref" just means: *N is the one worktree currently being shown, so it has one upstream ref file worth watching.* Every other repo's set is empty.

## The bug

Every repo scheduled its own 2-second poll over that set — including the repos whose set is empty. Those pollers woke twice a second, allocated a `Set`, `await`ed `Promise.all([])`, diffed two empty maps, and went back to sleep. With 100 repos open, 99 of them were doing this forever and could never find anything, because a repo only gets a path when it becomes the active one.

## The fix

Only schedule the poll for the repo that actually has a path, and start/stop it from the rebinding event rather than from a timer.

**This costs nothing in detection latency.** Rebinding is synchronous and in-process — `applyBindingToWatches()` runs when the active worktree changes — so a newly selected ref starts its poll on the same tick it would previously have been noticed. The wake-ups weren't a safety margin; they were pure waste. The repo that *does* hold a ref polls exactly as before.

## Measured

100 repos, none holding a ref, 20s idle window:

```
before (always scheduled)  0.811 CPU-ms/s
after  (demand driven)     0.320 CPU-ms/s
```

The 0.320 is the measurement harness itself, so the poll's own cost effectively goes to zero.

## Test changes, and why

- Two listener-count assertions drop by one in cases where no ref is selected. That decrease *is* the saving — one fewer poller parking on window visibility.
- One re-arm assertion now waits for reconciliation to settle instead of assuming a fixed fake-clock advance. Removing a poller removed incidental async activity that the old bare assertion had been relying on to let real filesystem promises settle. The sibling test in the same file already used `vi.waitFor` for exactly this reason; this makes the two consistent.

Follows #16404. Independent of the metadata poll scheduler.