### PR TITLE
fix(git): support strict bare repositories

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -879,9 +879,9 @@ jobs:
           src/main/git/runner-strict-bare-repository.test.ts
           src/main/git/runner-wsl-login-shell-capture.test.ts
           src/main/git/git-blob-read-strict-bare-repository.test.ts
+          src/main/git/git-compare-strict-bare-repository.test.ts
           src/main/git/worktree-separate-git-dir.test.ts
           src/relay/git-handler-strict-bare-repository.test.ts
-          src/relay/git-handler-worktree-inspection.test.ts
           src/shared/secure-file-fsync-flags.test.ts
           src/shared/secure-path-windows-acl.win32.test.ts
           src/main/runtime/unreadable-secret-store-preservation.win32.test.ts

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -874,6 +874,14 @@ jobs:
           src/main/startup/windows-install-dir-acl-repair.win32.test.ts
           src/main/runtime/repo-worktree-admin-fingerprint.test.ts
           src/main/runtime/worktree-scan-admin-fingerprint-gate.test.ts
+          src/shared/git-bare-repository-command.test.ts
+          src/shared/git-fetch-head-lock.test.ts
+          src/main/git/runner-strict-bare-repository.test.ts
+          src/main/git/runner-wsl-login-shell-capture.test.ts
+          src/main/git/git-blob-read-strict-bare-repository.test.ts
+          src/main/git/worktree-separate-git-dir.test.ts
+          src/relay/git-handler-strict-bare-repository.test.ts
+          src/relay/git-handler-worktree-inspection.test.ts
           src/shared/secure-file-fsync-flags.test.ts
           src/shared/secure-path-windows-acl.win32.test.ts
           src/main/runtime/unreadable-secret-store-preservation.win32.test.ts

--- a/src/main/git/command-runner/git-exec-file.ts
+++ b/src/main/git/command-runner/git-exec-file.ts
@@ -5,7 +5,10 @@ import {
   resolveGitFetchHeadCommand,
   runWithGitFetchHeadLock
 } from '../../../shared/git-fetch-head-lock'
-import { runWithExplicitBareRepositoryRetry } from '../../../shared/git-bare-repository-command'
+import {
+  explicitBareRepositoryRetryArgs,
+  runWithExplicitBareRepositoryRetry
+} from '../../../shared/git-bare-repository-command'
 import {
   isWslLinkedWorktreeGitRoutingCandidate,
   prepareWslLinkedWorktreeGitRouting
@@ -121,6 +124,12 @@ async function gitExecFileAsyncUnlocked(
             !isQuietGitControlFlowExit(error) &&
             !options.signal?.aborted
           ) {
+            if (
+              options.allowExplicitBareRepositoryRetry &&
+              explicitBareRepositoryRetryArgs(args, error)
+            ) {
+              throw error
+            }
             await terminationState.current
             const wasMissing = invalidateMissingDirectWslGit(error, resolved)
             const fallback = resolveGitCommand(
@@ -175,7 +184,7 @@ export function gitExecFileAsync(
       : run()
   }
   return options.allowExplicitBareRepositoryRetry
-    ? runWithExplicitBareRepositoryRetry(args, execute)
+    ? runWithExplicitBareRepositoryRetry(args, execute, options.explicitBareRepositoryReadState)
     : execute(args)
 }
 
@@ -196,6 +205,7 @@ export async function gitExecFileAsyncBuffer(
     | 'preferWslDirectGit'
     | 'admissionTier'
     | 'allowExplicitBareRepositoryRetry'
+    | 'explicitBareRepositoryReadState'
   >
 ): Promise<{ stdout: Buffer }> {
   const execute = async (commandArgs: string[]): Promise<{ stdout: Buffer }> => {
@@ -223,11 +233,7 @@ export async function gitExecFileAsyncBuffer(
         tier: options.admissionTier
       })
       span?.setAttribute('git.queue_wait_ms', grant.queueWaitMs)
-      const timeoutMs = gitCommandTimeoutMs(
-        commandArgs,
-        options.timeout,
-        options.timeoutMsForTest
-      )
+      const timeoutMs = gitCommandTimeoutMs(commandArgs, options.timeout, options.timeoutMsForTest)
       let termination: Promise<void> | null = null
       try {
         let reportTerminated: () => void = () => {}
@@ -257,7 +263,7 @@ export async function gitExecFileAsyncBuffer(
     })
   }
   return options.allowExplicitBareRepositoryRetry
-    ? runWithExplicitBareRepositoryRetry(args, execute)
+    ? runWithExplicitBareRepositoryRetry(args, execute, options.explicitBareRepositoryReadState)
     : execute(args)
 }
 

--- a/src/main/git/command-runner/git-exec-file.ts
+++ b/src/main/git/command-runner/git-exec-file.ts
@@ -5,6 +5,7 @@ import {
   resolveGitFetchHeadCommand,
   runWithGitFetchHeadLock
 } from '../../../shared/git-fetch-head-lock'
+import { explicitBareRepositoryRetryArgs } from '../../../shared/git-bare-repository-command'
 import {
   isWslLinkedWorktreeGitRoutingCandidate,
   prepareWslLinkedWorktreeGitRouting
@@ -166,15 +167,20 @@ export function gitExecFileAsync(
   args: string[],
   options: GitExecOptions
 ): Promise<{ stdout: string; stderr: string }> {
-  const command = resolveGitFetchHeadCommand(args, options.cwd)
-  return command.needsLock
-    ? runWithGitFetchHeadLock(
-        command.cwd,
-        options.signal,
-        () => gitExecFileAsyncUnlocked(args, options),
-        command.gitDir
-      )
-    : gitExecFileAsyncUnlocked(args, options)
+  const execute = (commandArgs: string[]) => {
+    const run = () => gitExecFileAsyncUnlocked(commandArgs, options)
+    const command = resolveGitFetchHeadCommand(commandArgs, options.cwd)
+    return command.needsLock
+      ? runWithGitFetchHeadLock(command.cwd, options.signal, run, command.gitDir)
+      : run()
+  }
+  return execute(args).catch((error: unknown) => {
+    const retryArgs = explicitBareRepositoryRetryArgs(args, error)
+    if (!retryArgs) {
+      throw error
+    }
+    return execute(retryArgs)
+  })
 }
 
 /**

--- a/src/main/git/command-runner/git-exec-file.ts
+++ b/src/main/git/command-runner/git-exec-file.ts
@@ -5,14 +5,14 @@ import {
   resolveGitFetchHeadCommand,
   runWithGitFetchHeadLock
 } from '../../../shared/git-fetch-head-lock'
-import { explicitBareRepositoryRetryArgs } from '../../../shared/git-bare-repository-command'
+import { runWithExplicitBareRepositoryRetry } from '../../../shared/git-bare-repository-command'
 import {
   isWslLinkedWorktreeGitRoutingCandidate,
   prepareWslLinkedWorktreeGitRouting
 } from '../wsl-linked-worktree-git-routing'
 import { resolveCommand, type ResolvedCommand } from './wsl-command-resolution'
 import { annotateWslHostFailure } from './wsl-host-failure'
-import type { GitAdmissionTier, GitExecOptions } from './git-exec-options'
+import type { GitExecOptions } from './git-exec-options'
 import { execFileCapture, execFileCaptureToTermination } from './exec-file-capture'
 import {
   pendingWslDirectGitReadEnvironment,
@@ -174,13 +174,9 @@ export function gitExecFileAsync(
       ? runWithGitFetchHeadLock(command.cwd, options.signal, run, command.gitDir)
       : run()
   }
-  return execute(args).catch((error: unknown) => {
-    const retryArgs = explicitBareRepositoryRetryArgs(args, error)
-    if (!retryArgs) {
-      throw error
-    }
-    return execute(retryArgs)
-  })
+  return options.allowExplicitBareRepositoryRetry
+    ? runWithExplicitBareRepositoryRetry(args, execute)
+    : execute(args)
 }
 
 /**
@@ -189,69 +185,80 @@ export function gitExecFileAsync(
  */
 export async function gitExecFileAsyncBuffer(
   args: string[],
-  options: {
-    cwd: string
-    maxBuffer?: number
-    timeout?: number
-    timeoutMsForTest?: number
-    env?: NodeJS.ProcessEnv
-    wslDistro?: string
-    preferWslDirectGit?: boolean
-    admissionTier?: GitAdmissionTier
-  }
+  options: Pick<
+    GitExecOptions,
+    | 'cwd'
+    | 'maxBuffer'
+    | 'timeout'
+    | 'timeoutMsForTest'
+    | 'env'
+    | 'wslDistro'
+    | 'preferWslDirectGit'
+    | 'admissionTier'
+    | 'allowExplicitBareRepositoryRetry'
+  >
 ): Promise<{ stdout: Buffer }> {
-  return withGitSpan({ args, cwd: options.cwd }, async (span) => {
-    if (isWslLinkedWorktreeGitRoutingCandidate(options.cwd, options.wslDistro)) {
-      await prepareWslLinkedWorktreeGitRouting(options.cwd, options.wslDistro)
-    }
-    const readEnvironmentReady = pendingWslDirectGitReadEnvironment(args, options)
-    if (readEnvironmentReady) {
-      await readEnvironmentReady
-    }
-    // `git show` is a read, so this normally runs with no shell at all. The fence
-    // still matters for the login-shell fallback: these are raw blob bytes going
-    // straight to the diff/blob viewer, where a banner becomes file content.
-    let resolved = resolveGitCommand(args, options, false, true)
-    const environmentReady = prepareWindowsHostGitEnvironment(resolved, undefined)
-    if (environmentReady) {
-      await environmentReady
-    }
-    resolved = resolveGitCommand(args, options, false, true)
-    const grant = await acquireGitAdmission({
-      args,
-      cwd: options.cwd,
-      wslDistro: options.wslDistro,
-      tier: options.admissionTier
-    })
-    span?.setAttribute('git.queue_wait_ms', grant.queueWaitMs)
-    const timeoutMs = gitCommandTimeoutMs(args, options.timeout, options.timeoutMsForTest)
-    let termination: Promise<void> | null = null
-    try {
-      let reportTerminated: () => void = () => {}
-      termination = new Promise<void>((resolve) => {
-        reportTerminated = resolve
-      })
-      const { stdout } = (await execFileCapture(resolved.binary, resolved.args, {
-        cwd: resolved.cwd,
-        encoding: 'buffer',
-        maxBuffer: options.maxBuffer,
-        timeout: timeoutMs,
-        env: untranslatedGitOutputEnv(options.env),
-        admissionTier: options.admissionTier,
-        onChildTerminated: reportTerminated,
-        ...(timeoutMs === undefined
-          ? {}
-          : { createTimeoutError: () => new GitCommandTimeoutError(timeoutMs) })
-      })) as { stdout: Buffer }
-      return { stdout: readCapturedGitBuffer(stdout, resolved) }
-    } finally {
-      if (termination) {
-        void termination.then(grant.release)
-      } else {
-        grant.release()
+  const execute = async (commandArgs: string[]): Promise<{ stdout: Buffer }> => {
+    return withGitSpan({ args: commandArgs, cwd: options.cwd }, async (span) => {
+      if (isWslLinkedWorktreeGitRoutingCandidate(options.cwd, options.wslDistro)) {
+        await prepareWslLinkedWorktreeGitRouting(options.cwd, options.wslDistro)
       }
-    }
-  })
+      const readEnvironmentReady = pendingWslDirectGitReadEnvironment(commandArgs, options)
+      if (readEnvironmentReady) {
+        await readEnvironmentReady
+      }
+      // `git show` is a read, so this normally runs with no shell at all. The fence
+      // still matters for the login-shell fallback: these are raw blob bytes going
+      // straight to the diff/blob viewer, where a banner becomes file content.
+      let resolved = resolveGitCommand(commandArgs, options, false, true)
+      const environmentReady = prepareWindowsHostGitEnvironment(resolved, undefined)
+      if (environmentReady) {
+        await environmentReady
+      }
+      resolved = resolveGitCommand(commandArgs, options, false, true)
+      const grant = await acquireGitAdmission({
+        args: commandArgs,
+        cwd: options.cwd,
+        wslDistro: options.wslDistro,
+        tier: options.admissionTier
+      })
+      span?.setAttribute('git.queue_wait_ms', grant.queueWaitMs)
+      const timeoutMs = gitCommandTimeoutMs(
+        commandArgs,
+        options.timeout,
+        options.timeoutMsForTest
+      )
+      let termination: Promise<void> | null = null
+      try {
+        let reportTerminated: () => void = () => {}
+        termination = new Promise<void>((resolve) => {
+          reportTerminated = resolve
+        })
+        const { stdout } = (await execFileCapture(resolved.binary, resolved.args, {
+          cwd: resolved.cwd,
+          encoding: 'buffer',
+          maxBuffer: options.maxBuffer,
+          timeout: timeoutMs,
+          env: untranslatedGitOutputEnv(options.env),
+          admissionTier: options.admissionTier,
+          onChildTerminated: reportTerminated,
+          ...(timeoutMs === undefined
+            ? {}
+            : { createTimeoutError: () => new GitCommandTimeoutError(timeoutMs) })
+        })) as { stdout: Buffer }
+        return { stdout: readCapturedGitBuffer(stdout, resolved) }
+      } finally {
+        if (termination) {
+          void termination.then(grant.release)
+        } else {
+          grant.release()
+        }
+      }
+    })
+  }
+  return options.allowExplicitBareRepositoryRetry
+    ? runWithExplicitBareRepositoryRetry(args, execute)
+    : execute(args)
 }
 
 /**

--- a/src/main/git/command-runner/git-exec-options.ts
+++ b/src/main/git/command-runner/git-exec-options.ts
@@ -20,4 +20,5 @@ export type GitExecOptions = {
   captureWslLoginShellOutput?: boolean
   /** Scheduler priority for this child; status is the safe default. */
   admissionTier?: GitAdmissionTier
+  allowExplicitBareRepositoryRetry?: boolean
 }

--- a/src/main/git/command-runner/git-exec-options.ts
+++ b/src/main/git/command-runner/git-exec-options.ts
@@ -1,3 +1,5 @@
+import type { ExplicitBareRepositoryReadState } from '../../../shared/git-bare-repository-command'
+
 // Why: cap execFile output to prevent an uncatchable V8 string overflow; match relay MAX_GIT_BUFFER.
 export const DEFAULT_GIT_MAX_BUFFER = 10 * 1024 * 1024
 
@@ -21,4 +23,5 @@ export type GitExecOptions = {
   /** Scheduler priority for this child; status is the safe default. */
   admissionTier?: GitAdmissionTier
   allowExplicitBareRepositoryRetry?: boolean
+  explicitBareRepositoryReadState?: ExplicitBareRepositoryReadState
 }

--- a/src/main/git/git-blob-read-strict-bare-repository.test.ts
+++ b/src/main/git/git-blob-read-strict-bare-repository.test.ts
@@ -1,0 +1,53 @@
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import * as path from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { runGitFixture } from '../../shared/git-process-test-fixture'
+import { readGitBlobAtOidPath } from './source-control/git-blob-read'
+
+const tempRoots: string[] = []
+
+async function createCommittedBareRepo(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), 'orca-bare-blob-read-'))
+  const sourcePath = path.join(root, 'source')
+  const barePath = path.join(root, 'repo.git')
+  tempRoots.push(root)
+  await mkdir(sourcePath)
+  await runGitFixture(sourcePath, ['init', '--quiet'])
+  await writeFile(path.join(sourcePath, 'file.txt'), 'committed content\n')
+  await runGitFixture(sourcePath, ['add', 'file.txt'])
+  await runGitFixture(sourcePath, [
+    '-c',
+    'user.email=test@example.com',
+    '-c',
+    'user.name=Test User',
+    'commit',
+    '--quiet',
+    '-m',
+    'initial'
+  ])
+  await runGitFixture(root, ['clone', '--bare', '--quiet', sourcePath, barePath])
+  return realpath(barePath)
+}
+
+afterEach(async () => {
+  vi.unstubAllEnvs()
+  await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('Git blob reads from strict bare repositories', () => {
+  it('reads committed content through an explicit gitdir retry', async () => {
+    const barePath = await createCommittedBareRepo()
+    vi.stubEnv('GIT_CONFIG_COUNT', '1')
+    vi.stubEnv('GIT_CONFIG_KEY_0', 'safe.bareRepository')
+    vi.stubEnv('GIT_CONFIG_VALUE_0', 'explicit')
+
+    const result = await readGitBlobAtOidPath(barePath, 'HEAD', 'file.txt')
+
+    expect(result).toEqual({
+      content: 'committed content\n',
+      isBinary: false,
+      exists: true
+    })
+  })
+})

--- a/src/main/git/git-compare-strict-bare-repository.test.ts
+++ b/src/main/git/git-compare-strict-bare-repository.test.ts
@@ -1,0 +1,86 @@
+import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import * as path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { runGitFixture } from '../../shared/git-process-test-fixture'
+import { getBranchCompare, getCommitCompare } from './status'
+
+const tempRoots: string[] = []
+
+describe('Git compares from strict bare repositories', () => {
+  let barePath: string
+  let baseOid: string
+  let headOid: string
+
+  beforeEach(async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'orca-bare-compare-'))
+    const sourcePath = path.join(root, 'source')
+    barePath = path.join(root, 'repo.git')
+    tempRoots.push(root)
+    await mkdir(sourcePath)
+    await runGitFixture(sourcePath, ['init', '--quiet'])
+    await writeFile(path.join(sourcePath, 'file.txt'), 'base\n')
+    await runGitFixture(sourcePath, ['add', 'file.txt'])
+    await runGitFixture(sourcePath, [
+      '-c',
+      'user.email=test@example.com',
+      '-c',
+      'user.name=Test User',
+      'commit',
+      '--quiet',
+      '-m',
+      'base'
+    ])
+    baseOid = (await runGitFixture(sourcePath, ['rev-parse', 'HEAD'])).trim()
+    await runGitFixture(sourcePath, ['branch', 'base', baseOid])
+    await writeFile(path.join(sourcePath, 'file.txt'), 'head\n')
+    await runGitFixture(sourcePath, [
+      '-c',
+      'user.email=test@example.com',
+      '-c',
+      'user.name=Test User',
+      'commit',
+      '--quiet',
+      '-am',
+      'head'
+    ])
+    headOid = (await runGitFixture(sourcePath, ['rev-parse', 'HEAD'])).trim()
+    await runGitFixture(root, ['clone', '--bare', '--quiet', sourcePath, barePath])
+    barePath = await realpath(barePath)
+    vi.stubEnv('GIT_CONFIG_COUNT', '1')
+    vi.stubEnv('GIT_CONFIG_KEY_0', 'safe.bareRepository')
+    vi.stubEnv('GIT_CONFIG_VALUE_0', 'explicit')
+  })
+
+  afterEach(async () => {
+    vi.unstubAllEnvs()
+    await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+  })
+
+  it('loads commit metadata before reading the selected diff', async () => {
+    const result = await getCommitCompare(barePath, headOid)
+
+    expect(result.summary).toMatchObject({
+      commitOid: headOid,
+      parentOid: baseOid,
+      status: 'ready',
+      changedFiles: 1
+    })
+    expect(result.entries).toEqual([{ path: 'file.txt', status: 'modified', added: 1, removed: 1 }])
+  })
+
+  it('loads branch metadata before reading the selected diff', async () => {
+    const result = await getBranchCompare(barePath, 'refs/heads/base')
+
+    expect(result.summary).toMatchObject({
+      baseOid,
+      headOid,
+      mergeBase: baseOid,
+      status: 'ready',
+      changedFiles: 1,
+      commitsAhead: 1,
+      commitsBehind: 0
+    })
+    expect(result.entries).toEqual([{ path: 'file.txt', status: 'modified', added: 1, removed: 1 }])
+  })
+})

--- a/src/main/git/git-runtime-options.ts
+++ b/src/main/git/git-runtime-options.ts
@@ -10,25 +10,40 @@ export type GitRuntimeOptions = {
   admissionTier?: GitAdmissionTier
 }
 
-export type GitExplicitBareRepositoryReadOptions = GitRuntimeOptions & {
-  explicitBareRepositoryReadState: ExplicitBareRepositoryReadState
+const compareReadStateKey = Symbol('compareReadState')
+
+export type GitCompareOptions = GitRuntimeOptions & {
+  [compareReadStateKey]: ExplicitBareRepositoryReadState
 }
 
-export function createGitExplicitBareRepositoryReadOptions(
-  options: GitRuntimeOptions
-): GitExplicitBareRepositoryReadOptions {
-  return { ...options, explicitBareRepositoryReadState: createExplicitBareRepositoryReadState() }
+export function createGitCompareOptions(options: GitRuntimeOptions): GitCompareOptions {
+  return { ...options, [compareReadStateKey]: createExplicitBareRepositoryReadState() }
 }
 
 export function gitOptionsForWorktree(
   cwd: string,
   options: GitRuntimeOptions = {}
-): { cwd: string; wslDistro?: string; signal?: AbortSignal; admissionTier?: GitAdmissionTier } {
+): {
+  cwd: string
+  wslDistro?: string
+  signal?: AbortSignal
+  admissionTier?: GitAdmissionTier
+  allowExplicitBareRepositoryRetry?: true
+  explicitBareRepositoryReadState?: ExplicitBareRepositoryReadState
+} {
+  const readState =
+    compareReadStateKey in options ? (options as GitCompareOptions)[compareReadStateKey] : undefined
   return {
     cwd,
     ...(options.wslDistro ? { wslDistro: options.wslDistro } : {}),
     ...(options.signal ? { signal: options.signal } : {}),
-    ...(options.admissionTier ? { admissionTier: options.admissionTier } : {})
+    ...(options.admissionTier ? { admissionTier: options.admissionTier } : {}),
+    ...(readState
+      ? {
+          allowExplicitBareRepositoryRetry: true as const,
+          explicitBareRepositoryReadState: readState
+        }
+      : {})
   }
 }
 
@@ -49,18 +64,4 @@ export function gitReadOptionsForWorktree(
   preferWslDirectGit: true
 } {
   return { ...gitOptionsForWorktree(cwd, options), preferWslDirectGit: true }
-}
-
-export function gitExplicitBareRepositoryReadOptionsForWorktree(
-  cwd: string,
-  options: GitExplicitBareRepositoryReadOptions
-): ReturnType<typeof gitReadOptionsForWorktree> & {
-  allowExplicitBareRepositoryRetry: true
-  explicitBareRepositoryReadState: ExplicitBareRepositoryReadState
-} {
-  return {
-    ...gitReadOptionsForWorktree(cwd, options),
-    allowExplicitBareRepositoryRetry: true,
-    explicitBareRepositoryReadState: options.explicitBareRepositoryReadState
-  }
 }

--- a/src/main/git/git-runtime-options.ts
+++ b/src/main/git/git-runtime-options.ts
@@ -1,9 +1,23 @@
 import type { GitAdmissionTier } from './command-runner/git-exec-options'
+import {
+  createExplicitBareRepositoryReadState,
+  type ExplicitBareRepositoryReadState
+} from '../../shared/git-bare-repository-command'
 
 export type GitRuntimeOptions = {
   wslDistro?: string
   signal?: AbortSignal
   admissionTier?: GitAdmissionTier
+}
+
+export type GitExplicitBareRepositoryReadOptions = GitRuntimeOptions & {
+  explicitBareRepositoryReadState: ExplicitBareRepositoryReadState
+}
+
+export function createGitExplicitBareRepositoryReadOptions(
+  options: GitRuntimeOptions
+): GitExplicitBareRepositoryReadOptions {
+  return { ...options, explicitBareRepositoryReadState: createExplicitBareRepositoryReadState() }
 }
 
 export function gitOptionsForWorktree(
@@ -35,4 +49,18 @@ export function gitReadOptionsForWorktree(
   preferWslDirectGit: true
 } {
   return { ...gitOptionsForWorktree(cwd, options), preferWslDirectGit: true }
+}
+
+export function gitExplicitBareRepositoryReadOptionsForWorktree(
+  cwd: string,
+  options: GitExplicitBareRepositoryReadOptions
+): ReturnType<typeof gitReadOptionsForWorktree> & {
+  allowExplicitBareRepositoryRetry: true
+  explicitBareRepositoryReadState: ExplicitBareRepositoryReadState
+} {
+  return {
+    ...gitReadOptionsForWorktree(cwd, options),
+    allowExplicitBareRepositoryRetry: true,
+    explicitBareRepositoryReadState: options.explicitBareRepositoryReadState
+  }
 }

--- a/src/main/git/runner-strict-bare-repository.test.ts
+++ b/src/main/git/runner-strict-bare-repository.test.ts
@@ -1,0 +1,90 @@
+import { EventEmitter } from 'node:events'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }))
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+  execFileSync: vi.fn(),
+  spawn: vi.fn()
+}))
+
+import { gitExecFileAsync, gitExecFileAsyncBuffer } from './runner'
+
+function strictBareRepositoryError(): Error & { stderr: string } {
+  return Object.assign(new Error('git failed'), {
+    stderr: "fatal: cannot use bare repository '/repo.git' (safe.bareRepository is 'explicit')"
+  })
+}
+
+function childProcess(): EventEmitter {
+  return Object.assign(new EventEmitter(), { kill: vi.fn() })
+}
+
+describe('git strict bare repository retry', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+  })
+
+  it('does not retry commands unless the caller trusts the repository read', async () => {
+    execFileMock.mockImplementation((_command, _args, _options, callback) => {
+      const error = strictBareRepositoryError()
+      callback(error, '', error.stderr)
+      return childProcess()
+    })
+
+    await expect(gitExecFileAsync(['status'], { cwd: '/repo.git' })).rejects.toThrow('git failed')
+
+    expect(execFileMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries an opted-in repository read with an explicit gitdir', async () => {
+    execFileMock
+      .mockImplementationOnce((_command, _args, _options, callback) => {
+        const error = strictBareRepositoryError()
+        callback(error, '', error.stderr)
+        return childProcess()
+      })
+      .mockImplementationOnce((_command, _args, _options, callback) => {
+        callback(null, 'ok', '')
+        return childProcess()
+      })
+
+    await expect(
+      gitExecFileAsync(['worktree', 'list', '--porcelain'], {
+        cwd: '/repo.git',
+        allowExplicitBareRepositoryRetry: true
+      })
+    ).resolves.toEqual({ stdout: 'ok', stderr: '' })
+
+    expect(execFileMock.mock.calls.map(([, args]) => args)).toEqual([
+      ['worktree', 'list', '--porcelain'],
+      ['--git-dir=.', 'worktree', 'list', '--porcelain']
+    ])
+  })
+
+  it('retries opted-in binary reads when Git reports the failure as a buffer', async () => {
+    const errorText = strictBareRepositoryError().stderr
+    execFileMock
+      .mockImplementationOnce((_command, _args, _options, callback) => {
+        callback(new Error('git failed'), Buffer.alloc(0), Buffer.from(errorText))
+        return childProcess()
+      })
+      .mockImplementationOnce((_command, _args, _options, callback) => {
+        callback(null, Buffer.from('blob'), Buffer.alloc(0))
+        return childProcess()
+      })
+
+    await expect(
+      gitExecFileAsyncBuffer(['show', 'HEAD:file.txt'], {
+        cwd: '/repo.git',
+        allowExplicitBareRepositoryRetry: true
+      })
+    ).resolves.toEqual({ stdout: Buffer.from('blob') })
+
+    expect(execFileMock.mock.calls.map(([, args]) => args)).toEqual([
+      ['show', 'HEAD:file.txt'],
+      ['--git-dir=.', 'show', 'HEAD:file.txt']
+    ])
+  })
+})

--- a/src/main/git/runner-strict-bare-repository.test.ts
+++ b/src/main/git/runner-strict-bare-repository.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'node:events'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createExplicitBareRepositoryReadState } from '../../shared/git-bare-repository-command'
 
 const { execFileMock } = vi.hoisted(() => ({ execFileMock: vi.fn() }))
 
@@ -18,7 +19,9 @@ function strictBareRepositoryError(): Error & { stderr: string } {
 }
 
 function childProcess(): EventEmitter {
-  return Object.assign(new EventEmitter(), { kill: vi.fn() })
+  const child = Object.assign(new EventEmitter(), { kill: vi.fn() })
+  queueMicrotask(() => child.emit('close', 0, null))
+  return child
 }
 
 describe('git strict bare repository retry', () => {
@@ -63,8 +66,9 @@ describe('git strict bare repository retry', () => {
     ])
   })
 
-  it('retries opted-in binary reads when Git reports the failure as a buffer', async () => {
+  it('reuses explicit mode for later opted-in binary reads', async () => {
     const errorText = strictBareRepositoryError().stderr
+    const readState = createExplicitBareRepositoryReadState()
     execFileMock
       .mockImplementationOnce((_command, _args, _options, callback) => {
         callback(new Error('git failed'), Buffer.alloc(0), Buffer.from(errorText))
@@ -74,17 +78,30 @@ describe('git strict bare repository retry', () => {
         callback(null, Buffer.from('blob'), Buffer.alloc(0))
         return childProcess()
       })
+      .mockImplementationOnce((_command, _args, _options, callback) => {
+        callback(null, Buffer.from('next blob'), Buffer.alloc(0))
+        return childProcess()
+      })
 
     await expect(
       gitExecFileAsyncBuffer(['show', 'HEAD:file.txt'], {
         cwd: '/repo.git',
-        allowExplicitBareRepositoryRetry: true
+        allowExplicitBareRepositoryRetry: true,
+        explicitBareRepositoryReadState: readState
       })
     ).resolves.toEqual({ stdout: Buffer.from('blob') })
+    await expect(
+      gitExecFileAsyncBuffer(['show', 'HEAD:next.txt'], {
+        cwd: '/repo.git',
+        allowExplicitBareRepositoryRetry: true,
+        explicitBareRepositoryReadState: readState
+      })
+    ).resolves.toEqual({ stdout: Buffer.from('next blob') })
 
     expect(execFileMock.mock.calls.map(([, args]) => args)).toEqual([
       ['show', 'HEAD:file.txt'],
-      ['--git-dir=.', 'show', 'HEAD:file.txt']
+      ['--git-dir=.', 'show', 'HEAD:file.txt'],
+      ['--git-dir=.', 'show', 'HEAD:next.txt']
     ])
   })
 })

--- a/src/main/git/runner-wsl-login-shell-capture.test.ts
+++ b/src/main/git/runner-wsl-login-shell-capture.test.ts
@@ -91,6 +91,43 @@ describe('WSL login-shell reads are fenced', () => {
     expect(Buffer.compare(stdout, binary)).toBe(0)
   })
 
+  it('retries strict bare blob reads inside the selected WSL distro', async () => {
+    const errorText =
+      "fatal: cannot use bare repository '/repo.git' (safe.bareRepository is 'explicit')"
+    execFileMock.mockImplementation((_command, args, _options, callback) => {
+      const script = String(args.at(-1))
+      if (!script.includes("'show'")) {
+        queueMicrotask(() => callback?.(null, Buffer.alloc(0), Buffer.alloc(0)))
+        return createMockChild()
+      }
+      if (!script.includes('--git-dir=.')) {
+        queueMicrotask(() =>
+          callback?.(new Error('git failed'), Buffer.alloc(0), Buffer.from(errorText))
+        )
+        return createMockChild()
+      }
+      const nonce = /__ORCA_WSL_CAPTURE_BEGIN_([^_]+)__/.exec(script)?.[1] ?? ''
+      const stdout = Buffer.from(
+        `${BANNER}__ORCA_WSL_CAPTURE_BEGIN_${nonce}__blob__ORCA_WSL_CAPTURE_END_${nonce}__`
+      )
+      queueMicrotask(() => callback?.(null, stdout, Buffer.alloc(0)))
+      return createMockChild()
+    })
+
+    const { stdout } = await gitExecFileAsyncBuffer(['show', 'HEAD:file.txt'], {
+      cwd: WSL_CWD,
+      wslDistro: DISTRO,
+      allowExplicitBareRepositoryRetry: true
+    })
+
+    expect(stdout.toString('utf8')).toBe('blob')
+    const gitReadScripts = execFileMock.mock.calls
+      .map((call) => String(call[1]?.at(-1)))
+      .filter((script) => script.includes("'show'"))
+    expect(gitReadScripts).toHaveLength(2)
+    expect(gitReadScripts[1]).toContain('--git-dir=.')
+  })
+
   /** Answer the core.sshCommand probe with `configured`, and any other command with ok. */
   function respondToSshPolicyProbe(configured: string): void {
     execFileMock.mockImplementation((_command, args, _options, callback) => {

--- a/src/main/git/runner-wsl-login-shell-capture.test.ts
+++ b/src/main/git/runner-wsl-login-shell-capture.test.ts
@@ -19,13 +19,21 @@ vi.mock('../diagnostics/main-thread-churn-probe', () => ({ recordSubprocessSpawn
 
 import { gitExecFileAsync, gitExecFileAsyncBuffer } from './runner'
 import { _resetGitAdmissionForTests } from './command-runner/git-subprocess-admission'
+import {
+  resetWslGitReadEnvironmentForTests,
+  seedWslGitReadEnvironmentForTests
+} from './wsl-git-read-environment'
 
 afterEach(() => _resetGitAdmissionForTests())
-import { resetWslGitReadEnvironmentForTests } from './wsl-git-read-environment'
 
 const DISTRO = 'Ubuntu'
 const WSL_CWD = String.raw`\\wsl.localhost\Ubuntu\home\alice\repo`
 const BANNER = 'To run a command as administrator (user "root"), use "sudo <command>".\n\n'
+const LOGIN_ENVIRONMENT = {
+  gitPath: '/home/alice/bin/git',
+  home: '/home/alice',
+  path: '/home/alice/bin:/usr/bin:/bin'
+}
 
 function createMockChild(): EventEmitter & { stdout: EventEmitter; stderr: EventEmitter } {
   const child = new EventEmitter() as EventEmitter & {
@@ -126,6 +134,37 @@ describe('WSL login-shell reads are fenced', () => {
       .filter((script) => script.includes("'show'"))
     expect(gitReadScripts).toHaveLength(2)
     expect(gitReadScripts[1]).toContain('--git-dir=.')
+  })
+
+  it('retries a strict bare text read directly without a redundant login shell', async () => {
+    seedWslGitReadEnvironmentForTests(DISTRO, LOGIN_ENVIRONMENT)
+    const errorText =
+      "fatal: cannot use bare repository '/repo.git' (safe.bareRepository is 'explicit')"
+    execFileMock.mockImplementation((_command, args, _options, callback) => {
+      const commandArgs = args as string[]
+      if (!commandArgs.includes('--git-dir=.')) {
+        queueMicrotask(() =>
+          callback?.(Object.assign(new Error('git failed'), { code: 128 }), '', errorText)
+        )
+        return createMockChild()
+      }
+      queueMicrotask(() => callback?.(null, 'worktree output', ''))
+      return createMockChild()
+    })
+
+    await expect(
+      gitExecFileAsync(['worktree', 'list', '--porcelain'], {
+        cwd: WSL_CWD,
+        wslDistro: DISTRO,
+        allowExplicitBareRepositoryRetry: true
+      })
+    ).resolves.toEqual({ stdout: 'worktree output', stderr: '' })
+
+    expect(execFileMock).toHaveBeenCalledTimes(2)
+    expect(execFileMock.mock.calls.map((call) => call[1])).toEqual([
+      expect.arrayContaining(['--exec', LOGIN_ENVIRONMENT.gitPath, 'worktree']),
+      expect.arrayContaining(['--exec', LOGIN_ENVIRONMENT.gitPath, '--git-dir=.', 'worktree'])
+    ])
   })
 
   /** Answer the core.sshCommand probe with `configured`, and any other command with ok. */

--- a/src/main/git/source-control/branch-change-entries.ts
+++ b/src/main/git/source-control/branch-change-entries.ts
@@ -2,8 +2,8 @@ import type { GitBranchChangeEntry } from '../../../shared/git-diff-compare-type
 import type { GitBranchChangeStatus } from '../../../shared/git-status-types'
 import { parseNumstat } from '../../../shared/git-uncommitted-line-stats'
 import { decodeGitCQuotedPath } from '../../../shared/git-cquoted-path'
-import type { GitExplicitBareRepositoryReadOptions } from '../git-runtime-options'
-import { gitExplicitBareRepositoryReadOptionsForWorktree } from '../git-runtime-options'
+import type { GitCompareOptions } from '../git-runtime-options'
+import { gitOptionsForWorktree } from '../git-runtime-options'
 import { gitExecFileAsync } from '../runner'
 import { MAX_GIT_SHOW_BYTES } from './git-show-max-bytes'
 
@@ -28,11 +28,11 @@ export async function loadBranchChanges(
   worktreePath: string,
   mergeBase: string,
   headOid: string,
-  options: GitExplicitBareRepositoryReadOptions
+  options: GitCompareOptions
 ): Promise<GitBranchChangeEntry[]> {
   // Why: core.quotePath=false keeps real UTF-8 paths — see getStatus rationale.
   const gitOptions = {
-    ...gitExplicitBareRepositoryReadOptionsForWorktree(worktreePath, options),
+    ...gitOptionsForWorktree(worktreePath, options),
     maxBuffer: MAX_GIT_SHOW_BYTES
   }
   // Why: both diffs are independent, so run them concurrently instead of serializing.
@@ -66,7 +66,7 @@ export async function loadCommitChanges(
   worktreePath: string,
   parentOid: string | null,
   commitOid: string,
-  options: GitExplicitBareRepositoryReadOptions
+  options: GitCompareOptions
 ): Promise<GitBranchChangeEntry[]> {
   // Why: root commits have no parent tree; diff-tree --root uses git's empty tree, avoiding a hardcoded hash-format-specific oid.
   const args = parentOid
@@ -99,7 +99,7 @@ export async function loadCommitChanges(
         commitOid
       ]
   const gitOptions = {
-    ...gitExplicitBareRepositoryReadOptionsForWorktree(worktreePath, options),
+    ...gitOptionsForWorktree(worktreePath, options),
     maxBuffer: MAX_GIT_SHOW_BYTES
   }
   // Why: the two git queries are independent, so run them in parallel.

--- a/src/main/git/source-control/branch-change-entries.ts
+++ b/src/main/git/source-control/branch-change-entries.ts
@@ -2,8 +2,8 @@ import type { GitBranchChangeEntry } from '../../../shared/git-diff-compare-type
 import type { GitBranchChangeStatus } from '../../../shared/git-status-types'
 import { parseNumstat } from '../../../shared/git-uncommitted-line-stats'
 import { decodeGitCQuotedPath } from '../../../shared/git-cquoted-path'
-import type { GitRuntimeOptions } from '../git-runtime-options'
-import { gitOptionsForWorktree } from '../git-runtime-options'
+import type { GitExplicitBareRepositoryReadOptions } from '../git-runtime-options'
+import { gitExplicitBareRepositoryReadOptionsForWorktree } from '../git-runtime-options'
 import { gitExecFileAsync } from '../runner'
 import { MAX_GIT_SHOW_BYTES } from './git-show-max-bytes'
 
@@ -28,11 +28,11 @@ export async function loadBranchChanges(
   worktreePath: string,
   mergeBase: string,
   headOid: string,
-  options: GitRuntimeOptions = {}
+  options: GitExplicitBareRepositoryReadOptions
 ): Promise<GitBranchChangeEntry[]> {
   // Why: core.quotePath=false keeps real UTF-8 paths — see getStatus rationale.
   const gitOptions = {
-    ...gitOptionsForWorktree(worktreePath, options),
+    ...gitExplicitBareRepositoryReadOptionsForWorktree(worktreePath, options),
     maxBuffer: MAX_GIT_SHOW_BYTES
   }
   // Why: both diffs are independent, so run them concurrently instead of serializing.
@@ -66,7 +66,7 @@ export async function loadCommitChanges(
   worktreePath: string,
   parentOid: string | null,
   commitOid: string,
-  options: GitRuntimeOptions = {}
+  options: GitExplicitBareRepositoryReadOptions
 ): Promise<GitBranchChangeEntry[]> {
   // Why: root commits have no parent tree; diff-tree --root uses git's empty tree, avoiding a hardcoded hash-format-specific oid.
   const args = parentOid
@@ -99,7 +99,7 @@ export async function loadCommitChanges(
         commitOid
       ]
   const gitOptions = {
-    ...gitOptionsForWorktree(worktreePath, options),
+    ...gitExplicitBareRepositoryReadOptionsForWorktree(worktreePath, options),
     maxBuffer: MAX_GIT_SHOW_BYTES
   }
   // Why: the two git queries are independent, so run them in parallel.

--- a/src/main/git/source-control/branch-compare.ts
+++ b/src/main/git/source-control/branch-compare.ts
@@ -5,6 +5,10 @@ import type {
 import { readBranchCompareHead } from '../../../shared/git-branch-compare-head'
 import { resolveWorktreeAddBaseRef } from '../../../shared/worktree/base-ref'
 import type { GitRuntimeOptions } from '../git-runtime-options'
+import {
+  createGitExplicitBareRepositoryReadOptions,
+  gitExplicitBareRepositoryReadOptionsForWorktree
+} from '../git-runtime-options'
 import { resolveWorktreeBaseCommitOid } from '../worktree-base-ref-probe'
 import { loadBranchChanges } from './branch-change-entries'
 import {
@@ -19,6 +23,7 @@ export async function getBranchCompare(
   baseRef: string,
   options: GitRuntimeOptions = {}
 ): Promise<GitBranchCompareResult> {
+  const readOptions = createGitExplicitBareRepositoryReadOptions(options)
   const summary: GitBranchCompareSummary = {
     baseRef,
     baseOid: null,
@@ -33,21 +38,25 @@ export async function getBranchCompare(
   // commits; remote-tracking refs may store annotated tags whose raw oid must be preserved.
   const reusableProbedOidByRef = new Map<string, string>()
   const { compareRef, headOidResult, baseOidResult } = await readBranchCompareHead({
-    readCompareRef: () => resolveCompareRef(worktreePath, options),
+    readCompareRef: () => resolveCompareRef(worktreePath, readOptions),
     resolveBaseRef: () =>
       // Why: short refs like "origin/main" can collide with a local branch; use the proven remote-tracking ref.
       resolveWorktreeAddBaseRef(baseRef, async (qualifiedRef) => {
-        const oid = await resolveWorktreeBaseCommitOid(worktreePath, qualifiedRef, options)
+        const oid = await resolveWorktreeBaseCommitOid(
+          worktreePath,
+          qualifiedRef,
+          gitExplicitBareRepositoryReadOptionsForWorktree(worktreePath, readOptions)
+        )
         if (oid !== null && qualifiedRef.startsWith('refs/heads/')) {
           reusableProbedOidByRef.set(qualifiedRef, oid)
         }
         return oid !== null
       }),
-    readHeadOid: () => resolveRefOid(worktreePath, 'HEAD', options),
+    readHeadOid: () => resolveRefOid(worktreePath, 'HEAD', readOptions),
     readBaseOid: (ref) => {
       const reusableOid = reusableProbedOidByRef.get(ref)
       return reusableOid === undefined
-        ? resolveRefOid(worktreePath, ref, options)
+        ? resolveRefOid(worktreePath, ref, readOptions)
         : Promise.resolve(reusableOid)
     }
   })
@@ -86,7 +95,7 @@ export async function getBranchCompare(
 
   let mergeBase = ''
   try {
-    mergeBase = await resolveMergeBase(worktreePath, baseOid, headOid, options)
+    mergeBase = await resolveMergeBase(worktreePath, baseOid, headOid, readOptions)
     summary.mergeBase = mergeBase
   } catch {
     summary.status = 'no-merge-base'
@@ -96,8 +105,8 @@ export async function getBranchCompare(
 
   try {
     const [entries, divergence] = await Promise.all([
-      loadBranchChanges(worktreePath, mergeBase, headOid, options),
-      countCompareDivergence(worktreePath, baseOid, headOid, options)
+      loadBranchChanges(worktreePath, mergeBase, headOid, readOptions),
+      countCompareDivergence(worktreePath, baseOid, headOid, readOptions)
     ])
     summary.changedFiles = entries.length
     summary.commitsAhead = divergence.ahead

--- a/src/main/git/source-control/branch-compare.ts
+++ b/src/main/git/source-control/branch-compare.ts
@@ -5,10 +5,7 @@ import type {
 import { readBranchCompareHead } from '../../../shared/git-branch-compare-head'
 import { resolveWorktreeAddBaseRef } from '../../../shared/worktree/base-ref'
 import type { GitRuntimeOptions } from '../git-runtime-options'
-import {
-  createGitExplicitBareRepositoryReadOptions,
-  gitExplicitBareRepositoryReadOptionsForWorktree
-} from '../git-runtime-options'
+import { createGitCompareOptions, gitOptionsForWorktree } from '../git-runtime-options'
 import { resolveWorktreeBaseCommitOid } from '../worktree-base-ref-probe'
 import { loadBranchChanges } from './branch-change-entries'
 import {
@@ -23,7 +20,7 @@ export async function getBranchCompare(
   baseRef: string,
   options: GitRuntimeOptions = {}
 ): Promise<GitBranchCompareResult> {
-  const readOptions = createGitExplicitBareRepositoryReadOptions(options)
+  const compareOptions = createGitCompareOptions(options)
   const summary: GitBranchCompareSummary = {
     baseRef,
     baseOid: null,
@@ -38,25 +35,25 @@ export async function getBranchCompare(
   // commits; remote-tracking refs may store annotated tags whose raw oid must be preserved.
   const reusableProbedOidByRef = new Map<string, string>()
   const { compareRef, headOidResult, baseOidResult } = await readBranchCompareHead({
-    readCompareRef: () => resolveCompareRef(worktreePath, readOptions),
+    readCompareRef: () => resolveCompareRef(worktreePath, compareOptions),
     resolveBaseRef: () =>
       // Why: short refs like "origin/main" can collide with a local branch; use the proven remote-tracking ref.
       resolveWorktreeAddBaseRef(baseRef, async (qualifiedRef) => {
         const oid = await resolveWorktreeBaseCommitOid(
           worktreePath,
           qualifiedRef,
-          gitExplicitBareRepositoryReadOptionsForWorktree(worktreePath, readOptions)
+          gitOptionsForWorktree(worktreePath, compareOptions)
         )
         if (oid !== null && qualifiedRef.startsWith('refs/heads/')) {
           reusableProbedOidByRef.set(qualifiedRef, oid)
         }
         return oid !== null
       }),
-    readHeadOid: () => resolveRefOid(worktreePath, 'HEAD', readOptions),
+    readHeadOid: () => resolveRefOid(worktreePath, 'HEAD', compareOptions),
     readBaseOid: (ref) => {
       const reusableOid = reusableProbedOidByRef.get(ref)
       return reusableOid === undefined
-        ? resolveRefOid(worktreePath, ref, readOptions)
+        ? resolveRefOid(worktreePath, ref, compareOptions)
         : Promise.resolve(reusableOid)
     }
   })
@@ -95,7 +92,7 @@ export async function getBranchCompare(
 
   let mergeBase = ''
   try {
-    mergeBase = await resolveMergeBase(worktreePath, baseOid, headOid, readOptions)
+    mergeBase = await resolveMergeBase(worktreePath, baseOid, headOid, compareOptions)
     summary.mergeBase = mergeBase
   } catch {
     summary.status = 'no-merge-base'
@@ -105,8 +102,8 @@ export async function getBranchCompare(
 
   try {
     const [entries, divergence] = await Promise.all([
-      loadBranchChanges(worktreePath, mergeBase, headOid, readOptions),
-      countCompareDivergence(worktreePath, baseOid, headOid, readOptions)
+      loadBranchChanges(worktreePath, mergeBase, headOid, compareOptions),
+      countCompareDivergence(worktreePath, baseOid, headOid, compareOptions)
     ])
     summary.changedFiles = entries.length
     summary.commitsAhead = divergence.ahead

--- a/src/main/git/source-control/branch-diff.ts
+++ b/src/main/git/source-control/branch-diff.ts
@@ -1,6 +1,6 @@
 import type { GitDiffResult } from '../../../shared/git-diff-compare-types'
 import { stableInFlightKey } from '../../../shared/in-flight-promise-dedupe'
-import type { GitRuntimeOptions } from '../git-runtime-options'
+import { createGitCompareOptions, type GitRuntimeOptions } from '../git-runtime-options'
 import { gitRuntimeOptionsKey } from './git-runtime-options-cache-key'
 import { gitDiffReadDedupe } from './git-read-cache-invalidation'
 import { buildDiffResult } from './diff-result'
@@ -40,13 +40,14 @@ async function loadBranchDiff(
   },
   options: GitRuntimeOptions
 ): Promise<GitDiffResult> {
+  const compareOptions = createGitCompareOptions(options)
   try {
     const leftPath = args.oldPath ?? args.filePath
     // Why concurrent: the two sides are independent `git show` spawns, so awaiting
     // them in series doubles the latency of every diff the review panel opens.
     const [leftBlob, rightBlob] = await Promise.all([
-      readGitBlobAtOidPath(worktreePath, args.mergeBase, leftPath, options),
-      readGitBlobAtOidPath(worktreePath, args.headOid, args.filePath, options)
+      readGitBlobAtOidPath(worktreePath, args.mergeBase, leftPath, compareOptions),
+      readGitBlobAtOidPath(worktreePath, args.headOid, args.filePath, compareOptions)
     ])
 
     return buildDiffResult(

--- a/src/main/git/source-control/commit-compare.ts
+++ b/src/main/git/source-control/commit-compare.ts
@@ -1,10 +1,7 @@
 import type { GitCommitCompareResult } from '../../../shared/git-diff-compare-types'
 import { parseGitRevListFirstParentOid } from '../../../shared/git-rev-list-output'
 import type { GitRuntimeOptions } from '../git-runtime-options'
-import {
-  createGitExplicitBareRepositoryReadOptions,
-  gitExplicitBareRepositoryReadOptionsForWorktree
-} from '../git-runtime-options'
+import { createGitCompareOptions, gitOptionsForWorktree } from '../git-runtime-options'
 import { gitExecFileAsync } from '../runner'
 import { loadCommitChanges } from './branch-change-entries'
 import { resolveRefOid } from './compare-ref-oids'
@@ -14,10 +11,10 @@ export async function getCommitCompare(
   commitId: string,
   options: GitRuntimeOptions = {}
 ): Promise<GitCommitCompareResult> {
-  const readOptions = createGitExplicitBareRepositoryReadOptions(options)
+  const compareOptions = createGitCompareOptions(options)
   let commitOid = ''
   try {
-    commitOid = await resolveRefOid(worktreePath, `${commitId}^{commit}`, readOptions)
+    commitOid = await resolveRefOid(worktreePath, `${commitId}^{commit}`, compareOptions)
   } catch {
     return {
       summary: {
@@ -45,13 +42,18 @@ export async function getCommitCompare(
   try {
     const { stdout } = await gitExecFileAsync(
       ['rev-list', '--parents', '-n', '1', commitOid],
-      gitExplicitBareRepositoryReadOptionsForWorktree(worktreePath, readOptions)
+      gitOptionsForWorktree(worktreePath, compareOptions)
     )
     const firstParent = parseGitRevListFirstParentOid(stdout)
     summary.parentOid = firstParent
     summary.baseRef = firstParent ? firstParent.slice(0, 7) : 'empty tree'
 
-    const entries = await loadCommitChanges(worktreePath, summary.parentOid, commitOid, readOptions)
+    const entries = await loadCommitChanges(
+      worktreePath,
+      summary.parentOid,
+      commitOid,
+      compareOptions
+    )
     summary.changedFiles = entries.length
     return { summary, entries }
   } catch (error) {

--- a/src/main/git/source-control/commit-compare.ts
+++ b/src/main/git/source-control/commit-compare.ts
@@ -1,7 +1,10 @@
 import type { GitCommitCompareResult } from '../../../shared/git-diff-compare-types'
 import { parseGitRevListFirstParentOid } from '../../../shared/git-rev-list-output'
 import type { GitRuntimeOptions } from '../git-runtime-options'
-import { gitOptionsForWorktree } from '../git-runtime-options'
+import {
+  createGitExplicitBareRepositoryReadOptions,
+  gitExplicitBareRepositoryReadOptionsForWorktree
+} from '../git-runtime-options'
 import { gitExecFileAsync } from '../runner'
 import { loadCommitChanges } from './branch-change-entries'
 import { resolveRefOid } from './compare-ref-oids'
@@ -11,9 +14,10 @@ export async function getCommitCompare(
   commitId: string,
   options: GitRuntimeOptions = {}
 ): Promise<GitCommitCompareResult> {
+  const readOptions = createGitExplicitBareRepositoryReadOptions(options)
   let commitOid = ''
   try {
-    commitOid = await resolveRefOid(worktreePath, `${commitId}^{commit}`, options)
+    commitOid = await resolveRefOid(worktreePath, `${commitId}^{commit}`, readOptions)
   } catch {
     return {
       summary: {
@@ -41,13 +45,13 @@ export async function getCommitCompare(
   try {
     const { stdout } = await gitExecFileAsync(
       ['rev-list', '--parents', '-n', '1', commitOid],
-      gitOptionsForWorktree(worktreePath, options)
+      gitExplicitBareRepositoryReadOptionsForWorktree(worktreePath, readOptions)
     )
     const firstParent = parseGitRevListFirstParentOid(stdout)
     summary.parentOid = firstParent
     summary.baseRef = firstParent ? firstParent.slice(0, 7) : 'empty tree'
 
-    const entries = await loadCommitChanges(worktreePath, summary.parentOid, commitOid, options)
+    const entries = await loadCommitChanges(worktreePath, summary.parentOid, commitOid, readOptions)
     summary.changedFiles = entries.length
     return { summary, entries }
   } catch (error) {

--- a/src/main/git/source-control/commit-diff.ts
+++ b/src/main/git/source-control/commit-diff.ts
@@ -1,6 +1,6 @@
 import type { GitDiffResult } from '../../../shared/git-diff-compare-types'
 import { stableInFlightKey } from '../../../shared/in-flight-promise-dedupe'
-import type { GitRuntimeOptions } from '../git-runtime-options'
+import { createGitCompareOptions, type GitRuntimeOptions } from '../git-runtime-options'
 import { gitRuntimeOptionsKey } from './git-runtime-options-cache-key'
 import { gitDiffReadDedupe } from './git-read-cache-invalidation'
 import { buildDiffResult } from './diff-result'
@@ -40,15 +40,16 @@ async function loadCommitDiff(
   },
   options: GitRuntimeOptions
 ): Promise<GitDiffResult> {
+  const compareOptions = createGitCompareOptions(options)
   try {
     const leftPath = args.oldPath ?? args.filePath
     // Why concurrent: the two sides are independent `git show` spawns. A root
     // commit has no parent to read, so that side resolves without a spawn.
     const [leftBlob, rightBlob] = await Promise.all([
       args.parentOid
-        ? readGitBlobAtOidPath(worktreePath, args.parentOid, leftPath, options)
+        ? readGitBlobAtOidPath(worktreePath, args.parentOid, leftPath, compareOptions)
         : Promise.resolve({ content: '', isBinary: false }),
-      readGitBlobAtOidPath(worktreePath, args.commitOid, args.filePath, options)
+      readGitBlobAtOidPath(worktreePath, args.commitOid, args.filePath, compareOptions)
     ])
 
     return buildDiffResult(

--- a/src/main/git/source-control/compare-ref-oids.ts
+++ b/src/main/git/source-control/compare-ref-oids.ts
@@ -1,14 +1,14 @@
-import type { GitRuntimeOptions } from '../git-runtime-options'
-import { gitOptionsForWorktree } from '../git-runtime-options'
+import type { GitExplicitBareRepositoryReadOptions } from '../git-runtime-options'
+import { gitExplicitBareRepositoryReadOptionsForWorktree } from '../git-runtime-options'
 import { gitExecFileAsync } from '../runner'
 
 export async function resolveCompareRef(
   worktreePath: string,
-  options: GitRuntimeOptions = {}
+  options: GitExplicitBareRepositoryReadOptions
 ): Promise<string> {
   try {
     const { stdout } = await gitExecFileAsync(['branch', '--show-current'], {
-      ...gitOptionsForWorktree(worktreePath, options)
+      ...gitExplicitBareRepositoryReadOptionsForWorktree(worktreePath, options)
     })
     const branch = stdout.trim()
     return branch || 'HEAD'
@@ -20,10 +20,10 @@ export async function resolveCompareRef(
 export async function resolveRefOid(
   worktreePath: string,
   ref: string,
-  options: GitRuntimeOptions = {}
+  options: GitExplicitBareRepositoryReadOptions
 ): Promise<string> {
   const { stdout } = await gitExecFileAsync(['rev-parse', '--verify', '--end-of-options', ref], {
-    ...gitOptionsForWorktree(worktreePath, options)
+    ...gitExplicitBareRepositoryReadOptionsForWorktree(worktreePath, options)
   })
   return stdout.trim()
 }
@@ -32,10 +32,10 @@ export async function resolveMergeBase(
   worktreePath: string,
   baseOid: string,
   headOid: string,
-  options: GitRuntimeOptions = {}
+  options: GitExplicitBareRepositoryReadOptions
 ): Promise<string> {
   const { stdout } = await gitExecFileAsync(['merge-base', baseOid, headOid], {
-    ...gitOptionsForWorktree(worktreePath, options)
+    ...gitExplicitBareRepositoryReadOptionsForWorktree(worktreePath, options)
   })
   return stdout.trim()
 }
@@ -46,11 +46,11 @@ export async function countCompareDivergence(
   worktreePath: string,
   baseOid: string,
   headOid: string,
-  options: GitRuntimeOptions = {}
+  options: GitExplicitBareRepositoryReadOptions
 ): Promise<{ ahead: number; behind: number }> {
   const { stdout } = await gitExecFileAsync(
     ['rev-list', '--left-right', '--count', `${baseOid}...${headOid}`],
-    { ...gitOptionsForWorktree(worktreePath, options) }
+    { ...gitExplicitBareRepositoryReadOptionsForWorktree(worktreePath, options) }
   )
   const [behind = '', ahead = ''] = stdout.trim().split(/\s+/)
   return {

--- a/src/main/git/source-control/compare-ref-oids.ts
+++ b/src/main/git/source-control/compare-ref-oids.ts
@@ -1,14 +1,14 @@
-import type { GitExplicitBareRepositoryReadOptions } from '../git-runtime-options'
-import { gitExplicitBareRepositoryReadOptionsForWorktree } from '../git-runtime-options'
+import type { GitCompareOptions } from '../git-runtime-options'
+import { gitOptionsForWorktree } from '../git-runtime-options'
 import { gitExecFileAsync } from '../runner'
 
 export async function resolveCompareRef(
   worktreePath: string,
-  options: GitExplicitBareRepositoryReadOptions
+  options: GitCompareOptions
 ): Promise<string> {
   try {
     const { stdout } = await gitExecFileAsync(['branch', '--show-current'], {
-      ...gitExplicitBareRepositoryReadOptionsForWorktree(worktreePath, options)
+      ...gitOptionsForWorktree(worktreePath, options)
     })
     const branch = stdout.trim()
     return branch || 'HEAD'
@@ -20,10 +20,10 @@ export async function resolveCompareRef(
 export async function resolveRefOid(
   worktreePath: string,
   ref: string,
-  options: GitExplicitBareRepositoryReadOptions
+  options: GitCompareOptions
 ): Promise<string> {
   const { stdout } = await gitExecFileAsync(['rev-parse', '--verify', '--end-of-options', ref], {
-    ...gitExplicitBareRepositoryReadOptionsForWorktree(worktreePath, options)
+    ...gitOptionsForWorktree(worktreePath, options)
   })
   return stdout.trim()
 }
@@ -32,10 +32,10 @@ export async function resolveMergeBase(
   worktreePath: string,
   baseOid: string,
   headOid: string,
-  options: GitExplicitBareRepositoryReadOptions
+  options: GitCompareOptions
 ): Promise<string> {
   const { stdout } = await gitExecFileAsync(['merge-base', baseOid, headOid], {
-    ...gitExplicitBareRepositoryReadOptionsForWorktree(worktreePath, options)
+    ...gitOptionsForWorktree(worktreePath, options)
   })
   return stdout.trim()
 }
@@ -46,11 +46,11 @@ export async function countCompareDivergence(
   worktreePath: string,
   baseOid: string,
   headOid: string,
-  options: GitExplicitBareRepositoryReadOptions
+  options: GitCompareOptions
 ): Promise<{ ahead: number; behind: number }> {
   const { stdout } = await gitExecFileAsync(
     ['rev-list', '--left-right', '--count', `${baseOid}...${headOid}`],
-    { ...gitExplicitBareRepositoryReadOptionsForWorktree(worktreePath, options) }
+    { ...gitOptionsForWorktree(worktreePath, options) }
   )
   const [behind = '', ahead = ''] = stdout.trim().split(/\s+/)
   return {

--- a/src/main/git/source-control/file-diff.ts
+++ b/src/main/git/source-control/file-diff.ts
@@ -2,7 +2,7 @@ import * as path from 'node:path'
 import type { GitDiffResult } from '../../../shared/git-diff-compare-types'
 import { resolveWorktreeHostPath } from '../../../shared/git-metadata-path'
 import { stableInFlightKey } from '../../../shared/in-flight-promise-dedupe'
-import type { GitRuntimeOptions } from '../git-runtime-options'
+import { createGitCompareOptions, type GitRuntimeOptions } from '../git-runtime-options'
 import { gitRuntimeOptionsKey } from './git-runtime-options-cache-key'
 import { gitDiffReadDedupe, settledDiffCache } from './git-read-cache-invalidation'
 import { readWorktreeDiffStamp } from './worktree-diff-stamp'
@@ -104,8 +104,9 @@ async function loadDiff(
   compareAgainstHead: boolean,
   options: GitRuntimeOptions
 ): Promise<LoadedDiff> {
+  const compareOptions = createGitCompareOptions(options)
   // Why: gitlink paths can't be read as blobs, so route submodule diffs explicitly (root → pointer, inner → recurse).
-  const submodulePaths = await listSubmodulePaths(worktreePath, options)
+  const submodulePaths = await listSubmodulePaths(worktreePath, compareOptions)
   if (submodulePaths.length > 0) {
     const matchedSubmodule = findContainingSubmodule(submodulePaths, filePath)
     if (matchedSubmodule) {
@@ -119,19 +120,19 @@ async function loadDiff(
             matchedSubmodule,
             staged,
             compareAgainstHead,
-            options,
+            compareOptions,
             submoduleWorktreePath
           )
         )
       }
       const innerPath = normalizedFilePath.slice(matchedSubmodule.length + 1)
       const fromOid = staged
-        ? await readGitlinkOidFromTree(worktreePath, 'HEAD', matchedSubmodule, options)
-        : (await readGitlinkOidFromIndex(worktreePath, matchedSubmodule, options)) ||
-          (await readGitlinkOidFromTree(worktreePath, 'HEAD', matchedSubmodule, options))
+        ? await readGitlinkOidFromTree(worktreePath, 'HEAD', matchedSubmodule, compareOptions)
+        : (await readGitlinkOidFromIndex(worktreePath, matchedSubmodule, compareOptions)) ||
+          (await readGitlinkOidFromTree(worktreePath, 'HEAD', matchedSubmodule, compareOptions))
       const toOid = staged
-        ? await readGitlinkOidFromIndex(worktreePath, matchedSubmodule, options)
-        : await readWorkingSubmoduleHead(submoduleWorktreePath, options)
+        ? await readGitlinkOidFromIndex(worktreePath, matchedSubmodule, compareOptions)
+        : await readWorkingSubmoduleHead(submoduleWorktreePath, compareOptions)
       // Why: a moved gitlink with a clean submodule worktree means the change is committed — diff the two commits.
       if (fromOid && toOid && fromOid !== toOid) {
         return notReusable(
@@ -140,7 +141,7 @@ async function loadDiff(
             innerPath,
             fromOid,
             toOid,
-            options
+            compareOptions
           )
         )
       }
@@ -163,8 +164,8 @@ async function loadDiff(
       // Why concurrent: HEAD and the index are independent `git show` spawns.
       // Only this branch qualifies — the unstaged left read chains index→HEAD.
       const [leftBlob, rightBlob] = await Promise.all([
-        readGitBlobAtOidPath(worktreePath, 'HEAD', filePath, options),
-        readGitBlobAtIndexPath(worktreePath, filePath, options)
+        readGitBlobAtOidPath(worktreePath, 'HEAD', filePath, compareOptions),
+        readGitBlobAtIndexPath(worktreePath, filePath, compareOptions)
       ])
       originalContent = leftBlob.content
       originalIsBinary = leftBlob.isBinary
@@ -179,8 +180,8 @@ async function loadDiff(
       const hostWorktreePath = resolveWorktreeHostPath(worktreePath, options)
       const [leftBlob, workingTreeBlob] = await Promise.all([
         compareAgainstHead
-          ? readGitBlobAtOidPath(worktreePath, 'HEAD', filePath, options)
-          : readUnstagedLeftBlob(worktreePath, filePath, options),
+          ? readGitBlobAtOidPath(worktreePath, 'HEAD', filePath, compareOptions)
+          : readUnstagedLeftBlob(worktreePath, filePath, compareOptions),
         hostWorktreePath
           ? readWorkingTreeFile(path.join(hostWorktreePath, filePath))
           : Promise.resolve(UNSPELLABLE_WORKING_TREE_READ)

--- a/src/main/git/source-control/git-blob-read.ts
+++ b/src/main/git/source-control/git-blob-read.ts
@@ -54,7 +54,8 @@ export async function readGitBlobAtIndexPath(
   try {
     const { stdout } = await gitExecFileAsyncBuffer(['show', `:${gitPath}`], {
       ...gitReadOptionsForWorktree(worktreePath, options),
-      maxBuffer: MAX_GIT_SHOW_BYTES
+      maxBuffer: MAX_GIT_SHOW_BYTES,
+      allowExplicitBareRepositoryRetry: true
     })
 
     return { ...bufferToBlob(stdout, filePath), exists: true }
@@ -79,7 +80,8 @@ export async function readGitBlobAtOidPath(
       ['show', '--end-of-options', `${oid}:${gitPath}`],
       {
         ...gitReadOptionsForWorktree(worktreePath, options),
-        maxBuffer: MAX_GIT_SHOW_BYTES
+        maxBuffer: MAX_GIT_SHOW_BYTES,
+        allowExplicitBareRepositoryRetry: true
       }
     )
 

--- a/src/main/git/status-branch-compare.test.ts
+++ b/src/main/git/status-branch-compare.test.ts
@@ -382,11 +382,11 @@ describe('getBranchCompare', () => {
     })
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'],
-      { cwd: '/repo' }
+      expect.objectContaining({ cwd: '/repo', allowExplicitBareRepositoryRetry: true })
     )
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       ['rev-parse', '--verify', '--end-of-options', 'refs/remotes/origin/main'],
-      { cwd: '/repo' }
+      expect.objectContaining({ cwd: '/repo', allowExplicitBareRepositoryRetry: true })
     )
   })
 

--- a/src/main/git/status-diff.test.ts
+++ b/src/main/git/status-diff.test.ts
@@ -103,7 +103,8 @@ describe('getDiff', () => {
     expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(['show', ':src/file.ts'], {
       cwd: '/repo',
       maxBuffer: 10 * 1024 * 1024,
-      preferWslDirectGit: true
+      preferWslDirectGit: true,
+      allowExplicitBareRepositoryRetry: true
     })
     expect(readFileMock).toHaveBeenCalledWith(path.join('/repo', 'src/file.ts'))
     expect(result).toEqual({
@@ -124,7 +125,8 @@ describe('getDiff', () => {
     expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(['show', ':src/file.ts'], {
       cwd: '/repo',
       maxBuffer: 10 * 1024 * 1024,
-      preferWslDirectGit: true
+      preferWslDirectGit: true,
+      allowExplicitBareRepositoryRetry: true
     })
   })
 
@@ -142,7 +144,8 @@ describe('getDiff', () => {
       {
         cwd: '/repo',
         maxBuffer: 10 * 1024 * 1024,
-        preferWslDirectGit: true
+        preferWslDirectGit: true,
+        allowExplicitBareRepositoryRetry: true
       }
     )
     expect(result.originalContent).toBe('head-content\n')

--- a/src/main/git/status-diff.test.ts
+++ b/src/main/git/status-diff.test.ts
@@ -100,12 +100,15 @@ describe('getDiff', () => {
 
     const result = await getDiff('/repo', 'src/file.ts', false)
 
-    expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(['show', ':src/file.ts'], {
-      cwd: '/repo',
-      maxBuffer: 10 * 1024 * 1024,
-      preferWslDirectGit: true,
-      allowExplicitBareRepositoryRetry: true
-    })
+    expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(
+      ['show', ':src/file.ts'],
+      expect.objectContaining({
+        cwd: '/repo',
+        maxBuffer: 10 * 1024 * 1024,
+        preferWslDirectGit: true,
+        allowExplicitBareRepositoryRetry: true
+      })
+    )
     expect(readFileMock).toHaveBeenCalledWith(path.join('/repo', 'src/file.ts'))
     expect(result).toEqual({
       kind: 'text',
@@ -122,12 +125,15 @@ describe('getDiff', () => {
 
     await getDiff('/repo', 'src\\file.ts', false)
 
-    expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(['show', ':src/file.ts'], {
-      cwd: '/repo',
-      maxBuffer: 10 * 1024 * 1024,
-      preferWslDirectGit: true,
-      allowExplicitBareRepositoryRetry: true
-    })
+    expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(
+      ['show', ':src/file.ts'],
+      expect.objectContaining({
+        cwd: '/repo',
+        maxBuffer: 10 * 1024 * 1024,
+        preferWslDirectGit: true,
+        allowExplicitBareRepositoryRetry: true
+      })
+    )
   })
 
   it('falls back to HEAD for unstaged diffs when the file is not in the index', async () => {
@@ -141,12 +147,17 @@ describe('getDiff', () => {
     expect(gitExecFileAsyncBufferMock).toHaveBeenNthCalledWith(
       2,
       ['show', '--end-of-options', 'HEAD:src/file.ts'],
-      {
+      expect.objectContaining({
         cwd: '/repo',
         maxBuffer: 10 * 1024 * 1024,
         preferWslDirectGit: true,
         allowExplicitBareRepositoryRetry: true
-      }
+      })
+    )
+    const firstReadOptions = gitExecFileAsyncBufferMock.mock.calls[0]?.[1]
+    const secondReadOptions = gitExecFileAsyncBufferMock.mock.calls[1]?.[1]
+    expect(firstReadOptions.explicitBareRepositoryReadState).toBe(
+      secondReadOptions.explicitBareRepositoryReadState
     )
     expect(result.originalContent).toBe('head-content\n')
     expect(result.modifiedContent).toBe('working-tree-content')

--- a/src/main/git/status-discard-symlink.test.ts
+++ b/src/main/git/status-discard-symlink.test.ts
@@ -3,6 +3,7 @@ import { execFileSync } from 'node:child_process'
 import { mkdtemp, mkdir, rm, symlink, writeFile, access, readFile } from 'node:fs/promises'
 import * as path from 'node:path'
 import { tmpdir } from 'node:os'
+import { runGitFixture } from '../../shared/git-process-test-fixture'
 import { bulkDiscardChanges, discardChanges } from './status'
 
 const tempRoots: string[] = []
@@ -118,9 +119,13 @@ describe('discardChanges symlink safety', () => {
     const { repo } = await createRepoWithOutsideDirectory()
     await writeFile(path.join(repo, globNamedFile), 'selected')
     await writeFile(path.join(repo, globMatchedFile), 'keep')
-    execFileSync('git', ['add', '-f', '--', gitLiteralPathspec(globNamedFile), globMatchedFile], {
-      cwd: repo
-    })
+    await runGitFixture(repo, [
+      'add',
+      '-f',
+      '--',
+      gitLiteralPathspec(globNamedFile),
+      globMatchedFile
+    ])
     execFileSync('git', ['commit', '-q', '-m', 'track log fixtures'], { cwd: repo })
     await writeFile(path.join(repo, globNamedFile), 'selected modified')
     await writeFile(path.join(repo, globMatchedFile), 'keep modified')

--- a/src/main/git/status-discard-symlink.test.ts
+++ b/src/main/git/status-discard-symlink.test.ts
@@ -118,7 +118,9 @@ describe('discardChanges symlink safety', () => {
     const { repo } = await createRepoWithOutsideDirectory()
     await writeFile(path.join(repo, globNamedFile), 'selected')
     await writeFile(path.join(repo, globMatchedFile), 'keep')
-    execFileSync('git', ['add', gitLiteralPathspec(globNamedFile), globMatchedFile], { cwd: repo })
+    execFileSync('git', ['add', '-f', '--', gitLiteralPathspec(globNamedFile), globMatchedFile], {
+      cwd: repo
+    })
     execFileSync('git', ['commit', '-q', '-m', 'track log fixtures'], { cwd: repo })
     await writeFile(path.join(repo, globNamedFile), 'selected modified')
     await writeFile(path.join(repo, globMatchedFile), 'keep modified')

--- a/src/main/git/status-pathspec-literals.test.ts
+++ b/src/main/git/status-pathspec-literals.test.ts
@@ -21,7 +21,9 @@ async function createRepoWithGlobNamedFiles(): Promise<string> {
   execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: repo })
   await writeFile(path.join(repo, globNamedFile), 'selected')
   await writeFile(path.join(repo, globMatchedFile), 'keep')
-  execFileSync('git', ['add', gitLiteralPathspec(globNamedFile), globMatchedFile], { cwd: repo })
+  execFileSync('git', ['add', '-f', '--', gitLiteralPathspec(globNamedFile), globMatchedFile], {
+    cwd: repo
+  })
   execFileSync('git', ['commit', '-q', '-m', 'initial'], { cwd: repo })
   await writeFile(path.join(repo, globNamedFile), 'selected modified')
   await writeFile(path.join(repo, globMatchedFile), 'keep modified')

--- a/src/main/git/status-pathspec-literals.test.ts
+++ b/src/main/git/status-pathspec-literals.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import * as path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
+import { runGitFixture } from '../../shared/git-process-test-fixture'
 import { bulkStageFiles, bulkUnstageFiles, stageFile, unstageFile } from './status'
 
 const tempRoots: string[] = []
@@ -21,9 +22,7 @@ async function createRepoWithGlobNamedFiles(): Promise<string> {
   execFileSync('git', ['config', 'user.name', 'Test User'], { cwd: repo })
   await writeFile(path.join(repo, globNamedFile), 'selected')
   await writeFile(path.join(repo, globMatchedFile), 'keep')
-  execFileSync('git', ['add', '-f', '--', gitLiteralPathspec(globNamedFile), globMatchedFile], {
-    cwd: repo
-  })
+  await runGitFixture(repo, ['add', '-f', '--', gitLiteralPathspec(globNamedFile), globMatchedFile])
   execFileSync('git', ['commit', '-q', '-m', 'initial'], { cwd: repo })
   await writeFile(path.join(repo, globNamedFile), 'selected modified')
   await writeFile(path.join(repo, globMatchedFile), 'keep modified')

--- a/src/main/git/status-submodule.test.ts
+++ b/src/main/git/status-submodule.test.ts
@@ -123,11 +123,21 @@ describe('submodule diff routing', () => {
 
     expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(
       ['show', '--end-of-options', `${OLD_OID}:lib/main.dart`],
-      { cwd: SUBMODULE, maxBuffer: 10 * 1024 * 1024, preferWslDirectGit: true }
+      {
+        cwd: SUBMODULE,
+        maxBuffer: 10 * 1024 * 1024,
+        preferWslDirectGit: true,
+        allowExplicitBareRepositoryRetry: true
+      }
     )
     expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(
       ['show', '--end-of-options', `${NEW_OID}:lib/main.dart`],
-      { cwd: SUBMODULE, maxBuffer: 10 * 1024 * 1024, preferWslDirectGit: true }
+      {
+        cwd: SUBMODULE,
+        maxBuffer: 10 * 1024 * 1024,
+        preferWslDirectGit: true,
+        allowExplicitBareRepositoryRetry: true
+      }
     )
     expect(result.kind).toBe('text')
     expect(result.originalContent).toBe('v1\n')
@@ -167,11 +177,21 @@ describe('submodule diff routing', () => {
 
     expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(
       ['show', '--end-of-options', `${OLD_OID}:lib/main.dart`],
-      { cwd: SUBMODULE, maxBuffer: 10 * 1024 * 1024, preferWslDirectGit: true }
+      {
+        cwd: SUBMODULE,
+        maxBuffer: 10 * 1024 * 1024,
+        preferWslDirectGit: true,
+        allowExplicitBareRepositoryRetry: true
+      }
     )
     expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(
       ['show', '--end-of-options', `${NEW_OID}:lib/main.dart`],
-      { cwd: SUBMODULE, maxBuffer: 10 * 1024 * 1024, preferWslDirectGit: true }
+      {
+        cwd: SUBMODULE,
+        maxBuffer: 10 * 1024 * 1024,
+        preferWslDirectGit: true,
+        allowExplicitBareRepositoryRetry: true
+      }
     )
     expect(result.kind).toBe('text')
     expect(result.originalContent).toBe('v1\n')
@@ -203,7 +223,8 @@ describe('submodule diff routing', () => {
     expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(['show', ':lib/main.dart'], {
       cwd: SUBMODULE,
       maxBuffer: 10 * 1024 * 1024,
-      preferWslDirectGit: true
+      preferWslDirectGit: true,
+      allowExplicitBareRepositoryRetry: true
     })
     expect(readFileMock).toHaveBeenCalledWith(path.join(SUBMODULE, 'lib/main.dart'))
     expect(result.kind).toBe('text')

--- a/src/main/git/status-submodule.test.ts
+++ b/src/main/git/status-submodule.test.ts
@@ -123,21 +123,24 @@ describe('submodule diff routing', () => {
 
     expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(
       ['show', '--end-of-options', `${OLD_OID}:lib/main.dart`],
-      {
+      expect.objectContaining({
         cwd: SUBMODULE,
         maxBuffer: 10 * 1024 * 1024,
         preferWslDirectGit: true,
         allowExplicitBareRepositoryRetry: true
-      }
+      })
     )
     expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(
       ['show', '--end-of-options', `${NEW_OID}:lib/main.dart`],
-      {
+      expect.objectContaining({
         cwd: SUBMODULE,
         maxBuffer: 10 * 1024 * 1024,
         preferWslDirectGit: true,
         allowExplicitBareRepositoryRetry: true
-      }
+      })
+    )
+    expect(gitExecFileAsyncBufferMock.mock.calls[0]?.[1].explicitBareRepositoryReadState).toBe(
+      gitExecFileAsyncBufferMock.mock.calls[1]?.[1].explicitBareRepositoryReadState
     )
     expect(result.kind).toBe('text')
     expect(result.originalContent).toBe('v1\n')
@@ -177,21 +180,21 @@ describe('submodule diff routing', () => {
 
     expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(
       ['show', '--end-of-options', `${OLD_OID}:lib/main.dart`],
-      {
+      expect.objectContaining({
         cwd: SUBMODULE,
         maxBuffer: 10 * 1024 * 1024,
         preferWslDirectGit: true,
         allowExplicitBareRepositoryRetry: true
-      }
+      })
     )
     expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(
       ['show', '--end-of-options', `${NEW_OID}:lib/main.dart`],
-      {
+      expect.objectContaining({
         cwd: SUBMODULE,
         maxBuffer: 10 * 1024 * 1024,
         preferWslDirectGit: true,
         allowExplicitBareRepositoryRetry: true
-      }
+      })
     )
     expect(result.kind).toBe('text')
     expect(result.originalContent).toBe('v1\n')
@@ -220,12 +223,15 @@ describe('submodule diff routing', () => {
 
     const result = await getDiff(PARENT, 'flutter_mine/lib/main.dart', false)
 
-    expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(['show', ':lib/main.dart'], {
-      cwd: SUBMODULE,
-      maxBuffer: 10 * 1024 * 1024,
-      preferWslDirectGit: true,
-      allowExplicitBareRepositoryRetry: true
-    })
+    expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(
+      ['show', ':lib/main.dart'],
+      expect.objectContaining({
+        cwd: SUBMODULE,
+        maxBuffer: 10 * 1024 * 1024,
+        preferWslDirectGit: true,
+        allowExplicitBareRepositoryRetry: true
+      })
+    )
     expect(readFileMock).toHaveBeenCalledWith(path.join(SUBMODULE, 'lib/main.dart'))
     expect(result.kind).toBe('text')
     expect(result.originalContent).toBe('old\n')

--- a/src/main/git/worktree-base-ref-probe.ts
+++ b/src/main/git/worktree-base-ref-probe.ts
@@ -3,9 +3,12 @@ import { isShowRefNoMatchError } from './exact-ref-probe'
 import { hasCommitObjectViaGitExec } from './commit-object-ref'
 import { isSafeGitRefName } from '../../shared/git-status-upstream-ref'
 import { resolveWorktreeAddBaseRef } from '../../shared/worktree/base-ref'
+import type { ExplicitBareRepositoryReadState } from '../../shared/git-bare-repository-command'
+import type { GitRuntimeOptions } from './git-runtime-options'
 
-type GitExecOptions = {
-  wslDistro?: string
+type GitExecOptions = GitRuntimeOptions & {
+  allowExplicitBareRepositoryRetry?: boolean
+  explicitBareRepositoryReadState?: ExplicitBareRepositoryReadState
 }
 
 /**

--- a/src/main/git/worktree-list-reader.ts
+++ b/src/main/git/worktree-list-reader.ts
@@ -198,7 +198,8 @@ export async function readWorktreeList(
   const execOptions = {
     cwd: repoPath,
     ...options,
-    timeout: options.timeout ?? WORKTREE_LIST_TIMEOUT_MS
+    timeout: options.timeout ?? WORKTREE_LIST_TIMEOUT_MS,
+    allowExplicitBareRepositoryRetry: true
   }
   return withLocalGitCapabilityCacheForExecution(
     { cwd: repoPath, wslDistro: options.wslDistro, signal: options.signal },

--- a/src/main/git/worktree-separate-git-dir.test.ts
+++ b/src/main/git/worktree-separate-git-dir.test.ts
@@ -87,6 +87,7 @@ async function createBareRepo(): Promise<string> {
 
 afterEach(async () => {
   revParseTopLevelCalls.count = 0
+  vi.unstubAllEnvs()
   await Promise.all(tempRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
 })
 
@@ -179,6 +180,9 @@ describe('git worktree separate git dir paths', () => {
 
   it.skipIf(process.platform === 'win32')('does not throw for a bare repo', async () => {
     const repoPath = await createBareRepo()
+    vi.stubEnv('GIT_CONFIG_COUNT', '1')
+    vi.stubEnv('GIT_CONFIG_KEY_0', 'safe.bareRepository')
+    vi.stubEnv('GIT_CONFIG_VALUE_0', 'explicit')
 
     const worktrees = await listWorktrees(repoPath)
     const mainWorktree = worktrees.find((worktree) => worktree.isMainWorktree)

--- a/src/main/git/worktree-separate-git-dir.test.ts
+++ b/src/main/git/worktree-separate-git-dir.test.ts
@@ -3,6 +3,7 @@ import { mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promis
 import { tmpdir } from 'node:os'
 import * as path from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { runGitFixture } from '../../shared/git-process-test-fixture'
 import type * as GitRunner from './runner'
 
 // Why: spy on the git runner so we can count rev-parse invocations while still
@@ -81,7 +82,7 @@ async function createBareRepo(): Promise<string> {
   const root = await mkdtemp(path.join(tmpdir(), 'orca-bare-worktree-'))
   tempRoots.push(root)
   const repoPath = path.join(root, 'repo.git')
-  execFileSync('git', ['init', '--bare', '--quiet', repoPath])
+  await runGitFixture(root, ['init', '--bare', '--quiet', repoPath])
   return realpath(repoPath)
 }
 

--- a/src/main/git/worktree-separate-git-dir.test.ts
+++ b/src/main/git/worktree-separate-git-dir.test.ts
@@ -178,7 +178,7 @@ describe('git worktree separate git dir paths', () => {
     }
   )
 
-  it.skipIf(process.platform === 'win32')('does not throw for a bare repo', async () => {
+  it('does not throw for a bare repo', async () => {
     const repoPath = await createBareRepo()
     vi.stubEnv('GIT_CONFIG_COUNT', '1')
     vi.stubEnv('GIT_CONFIG_KEY_0', 'safe.bareRepository')

--- a/src/main/runtime/repo-worktree-admin-fingerprint.test.ts
+++ b/src/main/runtime/repo-worktree-admin-fingerprint.test.ts
@@ -3,24 +3,20 @@
 // Also listed in pr.yml's Windows boundary step: reading Git's admin layout directly depends on
 // Windows path resolution, CRLF in `HEAD`/`gitdir`/`commondir`, and whether `worktree move`/`lock`
 // and deleting a live checkout behave as they do on POSIX. The Linux shards cannot reach any of it.
-import { execFile } from 'node:child_process'
 import { mkdir, mkdtemp, realpath, writeFile } from 'node:fs/promises'
 import { removeTree } from '../../shared/windows-transient-lock-removal'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { promisify } from 'node:util'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { runGitFixture } from '../../shared/git-process-test-fixture'
 import { readRepoWorktreeAdminFingerprint } from './repo-worktree-admin-fingerprint'
-
-const execFileAsync = promisify(execFile)
 
 let scratchDir = ''
 let repoPath = ''
 let worktreePath = ''
 
 async function git(args: string[], cwd: string): Promise<string> {
-  const { stdout } = await execFileAsync('git', args, { cwd })
-  return stdout
+  return await runGitFixture(cwd, args)
 }
 
 async function fingerprint(path = repoPath): Promise<string | null> {

--- a/src/main/runtime/repo-worktree-admin-fingerprint.test.ts
+++ b/src/main/runtime/repo-worktree-admin-fingerprint.test.ts
@@ -9,7 +9,7 @@ import { removeTree } from '../../shared/windows-transient-lock-removal'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { promisify } from 'node:util'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { readRepoWorktreeAdminFingerprint } from './repo-worktree-admin-fingerprint'
 
 const execFileAsync = promisify(execFile)
@@ -44,6 +44,7 @@ beforeEach(async () => {
 })
 
 afterEach(async () => {
+  vi.unstubAllEnvs()
   await removeTree(scratchDir)
 })
 
@@ -135,10 +136,21 @@ describe('readRepoWorktreeAdminFingerprint', () => {
   it('reads a bare repo through its own gitdir', async () => {
     const barePath = join(scratchDir, 'bare.git')
     await git(['clone', '-q', '--bare', repoPath, barePath], scratchDir)
+    vi.stubEnv('GIT_CONFIG_COUNT', '1')
+    vi.stubEnv('GIT_CONFIG_KEY_0', 'safe.bareRepository')
+    vi.stubEnv('GIT_CONFIG_VALUE_0', 'explicit')
     const before = await fingerprint(barePath)
     expect(before).not.toBeNull()
     await git(
-      ['worktree', 'add', '-q', join(scratchDir, 'trees', 'from-bare'), '-b', 'bare-tree'],
+      [
+        '--git-dir=.',
+        'worktree',
+        'add',
+        '-q',
+        join(scratchDir, 'trees', 'from-bare'),
+        '-b',
+        'bare-tree'
+      ],
       barePath
     )
     expect(await fingerprint(barePath)).not.toBe(before)

--- a/src/relay/git-handler-comparison-operations.ts
+++ b/src/relay/git-handler-comparison-operations.ts
@@ -13,6 +13,16 @@ import { createExplicitBareRepositoryReadState } from '../shared/git-bare-reposi
 import type { GitExec } from './git-handler-ops'
 
 export class GitHandlerComparisonOperations extends GitHandlerOperationContext {
+  private createCompareGit(): GitExec {
+    const readState = createExplicitBareRepositoryReadState()
+    return (args, cwd, options) =>
+      this.git(args, cwd, {
+        ...options,
+        allowExplicitBareRepositoryRetry: true,
+        explicitBareRepositoryReadState: readState
+      })
+  }
+
   async branchCompare(params: Record<string, unknown>) {
     const worktreePath = params.worktreePath as string
     const baseRef = params.baseRef as string
@@ -20,21 +30,15 @@ export class GitHandlerComparisonOperations extends GitHandlerOperationContext {
     if (baseRef.startsWith('-')) {
       throw new Error('Base ref must not start with "-"')
     }
-    const explicitBareRepositoryReadState = createExplicitBareRepositoryReadState()
-    const gitBound: GitExec = (args, cwd, options) =>
-      this.git(args, cwd, {
-        ...options,
-        allowExplicitBareRepositoryRetry: true,
-        explicitBareRepositoryReadState
-      })
-    return branchCompareOp(gitBound, worktreePath, baseRef, async (mergeBase, headOid) => {
+    const git = this.createCompareGit()
+    return branchCompareOp(git, worktreePath, baseRef, async (mergeBase, headOid) => {
       // Why: preserve non-ASCII filenames as UTF-8 for parseBranchDiff.
       const [{ stdout }, { stdout: numstat }] = await Promise.all([
-        gitBound(
+        git(
           ['-c', 'core.quotePath=false', 'diff', '--name-status', '-M', '-C', mergeBase, headOid],
           worktreePath
         ),
-        gitBound(
+        git(
           ['-c', 'core.quotePath=false', 'diff', '--numstat', '-M', '-C', mergeBase, headOid],
           worktreePath
         )
@@ -46,14 +50,7 @@ export class GitHandlerComparisonOperations extends GitHandlerOperationContext {
   async commitCompare(params: Record<string, unknown>) {
     const worktreePath = params.worktreePath as string
     const commitId = params.commitId as string
-    const explicitBareRepositoryReadState = createExplicitBareRepositoryReadState()
-    const gitBound: GitExec = (args, cwd, options) =>
-      this.git(args, cwd, {
-        ...options,
-        allowExplicitBareRepositoryRetry: true,
-        explicitBareRepositoryReadState
-      })
-    return commitCompareOp(gitBound, worktreePath, commitId)
+    return commitCompareOp(this.createCompareGit(), worktreePath, commitId)
   }
 
   async upstreamStatus(params: Record<string, unknown>) {

--- a/src/relay/git-handler-comparison-operations.ts
+++ b/src/relay/git-handler-comparison-operations.ts
@@ -9,6 +9,8 @@ import { assertGitPushTargetShape } from '../shared/git-push-target-validation'
 import { getPublishTargetStatus, type GitCommandRunner } from '../shared/git-publish-target-status'
 import type { GitPushTarget } from '../shared/worktree/types'
 import { getEffectiveGitUpstreamStatus } from '../shared/git-effective-upstream'
+import { createExplicitBareRepositoryReadState } from '../shared/git-bare-repository-command'
+import type { GitExec } from './git-handler-ops'
 
 export class GitHandlerComparisonOperations extends GitHandlerOperationContext {
   async branchCompare(params: Record<string, unknown>) {
@@ -18,7 +20,13 @@ export class GitHandlerComparisonOperations extends GitHandlerOperationContext {
     if (baseRef.startsWith('-')) {
       throw new Error('Base ref must not start with "-"')
     }
-    const gitBound = this.git.bind(this)
+    const explicitBareRepositoryReadState = createExplicitBareRepositoryReadState()
+    const gitBound: GitExec = (args, cwd, options) =>
+      this.git(args, cwd, {
+        ...options,
+        allowExplicitBareRepositoryRetry: true,
+        explicitBareRepositoryReadState
+      })
     return branchCompareOp(gitBound, worktreePath, baseRef, async (mergeBase, headOid) => {
       // Why: preserve non-ASCII filenames as UTF-8 for parseBranchDiff.
       const [{ stdout }, { stdout: numstat }] = await Promise.all([
@@ -38,7 +46,14 @@ export class GitHandlerComparisonOperations extends GitHandlerOperationContext {
   async commitCompare(params: Record<string, unknown>) {
     const worktreePath = params.worktreePath as string
     const commitId = params.commitId as string
-    return commitCompareOp(this.git.bind(this), worktreePath, commitId)
+    const explicitBareRepositoryReadState = createExplicitBareRepositoryReadState()
+    const gitBound: GitExec = (args, cwd, options) =>
+      this.git(args, cwd, {
+        ...options,
+        allowExplicitBareRepositoryRetry: true,
+        explicitBareRepositoryReadState
+      })
+    return commitCompareOp(gitBound, worktreePath, commitId)
   }
 
   async upstreamStatus(params: Record<string, unknown>) {

--- a/src/relay/git-handler-object-diff-operations.ts
+++ b/src/relay/git-handler-object-diff-operations.ts
@@ -33,6 +33,7 @@ export class GitHandlerObjectDiffOperations extends GitHandlerOperationContext {
         options.oldPath ?? null
       ]),
       () => {
+        const gitBuffer = this.createCompareGitBuffer()
         if (
           headOid &&
           isFullGitObjectId(baseRef) &&
@@ -41,7 +42,7 @@ export class GitHandlerObjectDiffOperations extends GitHandlerOperationContext {
           options.filePath.length > 0
         ) {
           return branchDiffEntryAtPinnedOids(
-            this.gitBuffer.bind(this),
+            gitBuffer,
             worktreePath,
             baseRef,
             headOid,
@@ -49,13 +50,7 @@ export class GitHandlerObjectDiffOperations extends GitHandlerOperationContext {
             options.oldPath
           )
         }
-        return branchDiffEntries(
-          this.git.bind(this),
-          this.gitBuffer.bind(this),
-          worktreePath,
-          baseRef,
-          options
-        )
+        return branchDiffEntries(this.git.bind(this), gitBuffer, worktreePath, baseRef, options)
       }
     )
     return this.maybeStreamResponse(result, params, context)
@@ -78,7 +73,7 @@ export class GitHandlerObjectDiffOperations extends GitHandlerOperationContext {
         args.filePath,
         args.oldPath ?? null
       ]),
-      () => commitDiffEntry(this.gitBuffer.bind(this), worktreePath, args)
+      () => commitDiffEntry(this.createCompareGitBuffer(), worktreePath, args)
     )
     return this.maybeStreamResponse(result, params, context)
   }

--- a/src/relay/git-handler-operation-context.ts
+++ b/src/relay/git-handler-operation-context.ts
@@ -3,7 +3,11 @@ import type { InFlightPromiseDedupe } from '../shared/in-flight-promise-dedupe'
 import type { GitCapabilityCache } from '../shared/git-capability-cache'
 import type { SubmodulePathsCache } from './git-handler-submodule-ops'
 import type { RelayFilesystemWatchRegistry } from './relay-filesystem-watch-registry'
-import type { ExplicitBareRepositoryReadState } from '../shared/git-bare-repository-command'
+import {
+  createExplicitBareRepositoryReadState,
+  type ExplicitBareRepositoryReadState
+} from '../shared/git-bare-repository-command'
+import type { GitBufferExec } from './git-handler-ops'
 
 export const GIT_BULK_CHUNK_SIZE = 100
 
@@ -32,7 +36,11 @@ export type GitHandlerOperationHost = {
     cwd: string,
     opts?: GitHandlerCommandOptions
   ): Promise<GitHandlerCommandResult>
-  gitBuffer(args: string[], cwd: string): Promise<Buffer>
+  gitBuffer(
+    args: string[],
+    cwd: string,
+    readState?: ExplicitBareRepositoryReadState
+  ): Promise<Buffer>
   spawnClone(
     args: string[],
     cwd: string,
@@ -75,8 +83,17 @@ export abstract class GitHandlerOperationContext {
     return this.host.git(args, cwd, opts)
   }
 
-  protected gitBuffer(args: string[], cwd: string): Promise<Buffer> {
-    return this.host.gitBuffer(args, cwd)
+  protected gitBuffer(
+    args: string[],
+    cwd: string,
+    readState?: ExplicitBareRepositoryReadState
+  ): Promise<Buffer> {
+    return this.host.gitBuffer(args, cwd, readState)
+  }
+
+  protected createCompareGitBuffer(): GitBufferExec {
+    const readState = createExplicitBareRepositoryReadState()
+    return (args, cwd) => this.gitBuffer(args, cwd, readState)
   }
 
   protected spawnClone(

--- a/src/relay/git-handler-operation-context.ts
+++ b/src/relay/git-handler-operation-context.ts
@@ -14,6 +14,7 @@ export type GitHandlerCommandOptions = {
   stdin?: string
   timeout?: number
   terminationBarrier?: boolean
+  allowExplicitBareRepositoryRetry?: boolean
 }
 
 export type GitHandlerCommandResult = { stdout: string; stderr: string }

--- a/src/relay/git-handler-operation-context.ts
+++ b/src/relay/git-handler-operation-context.ts
@@ -3,6 +3,7 @@ import type { InFlightPromiseDedupe } from '../shared/in-flight-promise-dedupe'
 import type { GitCapabilityCache } from '../shared/git-capability-cache'
 import type { SubmodulePathsCache } from './git-handler-submodule-ops'
 import type { RelayFilesystemWatchRegistry } from './relay-filesystem-watch-registry'
+import type { ExplicitBareRepositoryReadState } from '../shared/git-bare-repository-command'
 
 export const GIT_BULK_CHUNK_SIZE = 100
 
@@ -15,6 +16,7 @@ export type GitHandlerCommandOptions = {
   timeout?: number
   terminationBarrier?: boolean
   allowExplicitBareRepositoryRetry?: boolean
+  explicitBareRepositoryReadState?: ExplicitBareRepositoryReadState
 }
 
 export type GitHandlerCommandResult = { stdout: string; stderr: string }

--- a/src/relay/git-handler-ops.ts
+++ b/src/relay/git-handler-ops.ts
@@ -6,6 +6,7 @@
  * remain decoupled from the GitHandler class.
  */
 import * as path from 'node:path'
+import type { ExplicitBareRepositoryReadState } from '../shared/git-bare-repository-command'
 import { bufferToBlob, parseBranchDiff } from './git-handler-utils'
 import { buildDiffResult } from './git-diff-result'
 import { isGitBufferOverflowError } from './git-buffer-overflow'
@@ -22,6 +23,8 @@ export type GitExec = (
     signal?: AbortSignal
     stdin?: string
     timeout?: number
+    allowExplicitBareRepositoryRetry?: boolean
+    explicitBareRepositoryReadState?: ExplicitBareRepositoryReadState
   }
 ) => Promise<{ stdout: string; stderr: string }>
 

--- a/src/relay/git-handler-read-operations.ts
+++ b/src/relay/git-handler-read-operations.ts
@@ -113,6 +113,7 @@ export class GitHandlerReadOperations extends GitHandlerOperationContext {
     const result = await this.gitDiffReadDedupe.run(
       stableInFlightKey(['diff', worktreePath, filePath, staged, compareAgainstHead]),
       async () => {
+        const gitBuffer = this.createCompareGitBuffer()
         // Why: route gitlink roots to pointer diffs and inner files to their submodule worktree.
         const submodulePaths = await listSubmodulePathsCached(
           this.git.bind(this),
@@ -146,7 +147,7 @@ export class GitHandlerReadOperations extends GitHandlerOperationContext {
             // Why: a moved gitlink (clean worktree) keeps inner changes in committed history, so diff the two commits; otherwise read the working-tree blob.
             if (fromOid && toOid && fromOid !== toOid) {
               return buildSubmoduleInnerCommitRangeDiff(
-                this.gitBuffer.bind(this),
+                gitBuffer,
                 submoduleWorktreePath,
                 innerPath,
                 fromOid,
@@ -154,7 +155,7 @@ export class GitHandlerReadOperations extends GitHandlerOperationContext {
               )
             }
             return computeDiff(
-              this.gitBuffer.bind(this),
+              gitBuffer,
               submoduleWorktreePath,
               innerPath,
               staged,
@@ -162,13 +163,7 @@ export class GitHandlerReadOperations extends GitHandlerOperationContext {
             )
           }
         }
-        return computeDiff(
-          this.gitBuffer.bind(this),
-          worktreePath,
-          filePath,
-          staged,
-          compareAgainstHead
-        )
+        return computeDiff(gitBuffer, worktreePath, filePath, staged, compareAgainstHead)
       }
     )
     return this.maybeStreamResponse(result, params, context)

--- a/src/relay/git-handler-staging.test.ts
+++ b/src/relay/git-handler-staging.test.ts
@@ -9,6 +9,7 @@ import * as fs from 'node:fs/promises'
 import { mkdtempSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { execFileSync } from 'node:child_process'
+import { runGitFixture } from '../shared/git-process-test-fixture'
 import { GitHandler } from './git-handler'
 import { RelayContext } from './context'
 import {
@@ -36,14 +37,11 @@ const PATHSPEC_MUTATION_CASES = [
   }
 ] as const
 
-function createPathspecCollisionChanges(dir: string): void {
+async function createPathspecCollisionChanges(dir: string): Promise<void> {
   gitInit(dir)
   writeFileSync(path.join(dir, PATHSPEC_SELECTED_FILE), 'selected')
   writeFileSync(path.join(dir, PATHSPEC_MATCHING_FILE), 'matching')
-  execFileSync('git', ['add', '-f', '--', PATHSPEC_SELECTED_FILE, PATHSPEC_MATCHING_FILE], {
-    cwd: dir,
-    stdio: 'pipe'
-  })
+  await runGitFixture(dir, ['add', '-f', '--', PATHSPEC_SELECTED_FILE, PATHSPEC_MATCHING_FILE])
   gitCommit(dir, 'initial')
   writeFileSync(path.join(dir, PATHSPEC_SELECTED_FILE), 'selected modified')
   writeFileSync(path.join(dir, PATHSPEC_MATCHING_FILE), 'matching modified')
@@ -111,7 +109,7 @@ describe('GitHandler — commit & staging', () => {
     it.each(PATHSPEC_MUTATION_CASES)(
       'treats $mode stage paths with Git glob characters as literals',
       async ({ stageMethod, selection }) => {
-        createPathspecCollisionChanges(tmpDir)
+        await createPathspecCollisionChanges(tmpDir)
 
         await dispatcher.callRequest(stageMethod, { worktreePath: tmpDir, ...selection })
 
@@ -126,7 +124,7 @@ describe('GitHandler — commit & staging', () => {
     it.each(PATHSPEC_MUTATION_CASES)(
       'treats $mode unstage paths with Git glob characters as literals',
       async ({ unstageMethod, selection }) => {
-        createPathspecCollisionChanges(tmpDir)
+        await createPathspecCollisionChanges(tmpDir)
         execFileSync('git', ['add', '.'], { cwd: tmpDir, stdio: 'pipe' })
 
         await dispatcher.callRequest(unstageMethod, { worktreePath: tmpDir, ...selection })

--- a/src/relay/git-handler-staging.test.ts
+++ b/src/relay/git-handler-staging.test.ts
@@ -40,6 +40,10 @@ function createPathspecCollisionChanges(dir: string): void {
   gitInit(dir)
   writeFileSync(path.join(dir, PATHSPEC_SELECTED_FILE), 'selected')
   writeFileSync(path.join(dir, PATHSPEC_MATCHING_FILE), 'matching')
+  execFileSync('git', ['add', '-f', '--', PATHSPEC_SELECTED_FILE, PATHSPEC_MATCHING_FILE], {
+    cwd: dir,
+    stdio: 'pipe'
+  })
   gitCommit(dir, 'initial')
   writeFileSync(path.join(dir, PATHSPEC_SELECTED_FILE), 'selected modified')
   writeFileSync(path.join(dir, PATHSPEC_MATCHING_FILE), 'matching modified')

--- a/src/relay/git-handler-strict-bare-repository.test.ts
+++ b/src/relay/git-handler-strict-bare-repository.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from 'node:fs/promises'
+import { mkdir, realpath, writeFile } from 'node:fs/promises'
 import * as path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { runGitFixture } from '../shared/git-process-test-fixture'
@@ -37,6 +37,7 @@ describe('GitHandler strict bare repositories', () => {
       'base'
     ])
     baseOid = (await runGitFixture(sourcePath, ['rev-parse', 'HEAD'])).trim()
+    await runGitFixture(sourcePath, ['branch', 'base', baseOid])
     await writeFile(path.join(sourcePath, 'file.txt'), 'head\n')
     await runGitFixture(sourcePath, [
       '-c',
@@ -50,6 +51,7 @@ describe('GitHandler strict bare repositories', () => {
     ])
     headOid = (await runGitFixture(sourcePath, ['rev-parse', 'HEAD'])).trim()
     await runGitFixture(rootPath, ['clone', '--bare', '--quiet', sourcePath, barePath])
+    barePath = await realpath(barePath)
     ;({ dispatcher, handler } = createGitHandlerRelay())
     vi.stubEnv('GIT_CONFIG_COUNT', '1')
     vi.stubEnv('GIT_CONFIG_KEY_0', 'safe.bareRepository')
@@ -71,6 +73,16 @@ describe('GitHandler strict bare repositories', () => {
     ).rejects.toThrow(/cannot use bare repository/)
   })
 
+  it('lists the registered bare repository through the relay entry point', async () => {
+    const result = (await dispatcher.callRequest('git.listWorktrees', {
+      repoPath: barePath
+    })) as Record<string, unknown>[]
+
+    expect(result).toEqual([
+      expect.objectContaining({ path: barePath, isBare: true, isMainWorktree: true })
+    ])
+  })
+
   it('reads commit diff blobs through an explicit gitdir retry', async () => {
     const result = await dispatcher.callRequest('git.commitDiff', {
       worktreePath: barePath,
@@ -86,5 +98,38 @@ describe('GitHandler strict bare repositories', () => {
       originalIsBinary: false,
       modifiedIsBinary: false
     })
+  })
+
+  it('loads commit compare metadata through the relay entry point', async () => {
+    const result = (await dispatcher.callRequest('git.commitCompare', {
+      worktreePath: barePath,
+      commitId: headOid
+    })) as { summary: Record<string, unknown>; entries: unknown[] }
+
+    expect(result.summary).toMatchObject({
+      commitOid: headOid,
+      parentOid: baseOid,
+      status: 'ready',
+      changedFiles: 1
+    })
+    expect(result.entries).toHaveLength(1)
+  })
+
+  it('loads branch compare metadata through the relay entry point', async () => {
+    const result = (await dispatcher.callRequest('git.branchCompare', {
+      worktreePath: barePath,
+      baseRef: 'refs/heads/base'
+    })) as { summary: Record<string, unknown>; entries: unknown[] }
+
+    expect(result.summary).toMatchObject({
+      baseOid,
+      headOid,
+      mergeBase: baseOid,
+      status: 'ready',
+      changedFiles: 1,
+      commitsAhead: 1,
+      commitsBehind: 0
+    })
+    expect(result.entries).toHaveLength(1)
   })
 })

--- a/src/relay/git-handler-strict-bare-repository.test.ts
+++ b/src/relay/git-handler-strict-bare-repository.test.ts
@@ -10,6 +10,14 @@ import {
   removeGitTempDir
 } from './git-handler-test-harness'
 
+type GitBufferTarget = {
+  gitBuffer(
+    args: string[],
+    cwd: string,
+    readState?: { useExplicitGitDir: boolean }
+  ): Promise<Buffer>
+}
+
 describe('GitHandler strict bare repositories', () => {
   let dispatcher: MockDispatcher
   let handler: GitHandler
@@ -84,6 +92,8 @@ describe('GitHandler strict bare repositories', () => {
   })
 
   it('reads commit diff blobs through an explicit gitdir retry', async () => {
+    const gitBufferSpy = vi.spyOn(handler as unknown as GitBufferTarget, 'gitBuffer')
+
     const result = await dispatcher.callRequest('git.commitDiff', {
       worktreePath: barePath,
       commitOid: headOid,
@@ -98,6 +108,10 @@ describe('GitHandler strict bare repositories', () => {
       originalIsBinary: false,
       modifiedIsBinary: false
     })
+    const firstReadState = gitBufferSpy.mock.calls[0]?.[2]
+    const secondReadState = gitBufferSpy.mock.calls[1]?.[2]
+    expect(firstReadState).toBe(secondReadState)
+    expect(firstReadState).toEqual({ useExplicitGitDir: true })
   })
 
   it('loads commit compare metadata through the relay entry point', async () => {

--- a/src/relay/git-handler-strict-bare-repository.test.ts
+++ b/src/relay/git-handler-strict-bare-repository.test.ts
@@ -1,0 +1,90 @@
+import { mkdir, writeFile } from 'node:fs/promises'
+import * as path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { runGitFixture } from '../shared/git-process-test-fixture'
+import type { GitHandler } from './git-handler'
+import type { MockDispatcher } from './git-handler-test-setup'
+import {
+  createGitHandlerRelay,
+  createGitTempDir,
+  removeGitTempDir
+} from './git-handler-test-harness'
+
+describe('GitHandler strict bare repositories', () => {
+  let dispatcher: MockDispatcher
+  let handler: GitHandler
+  let rootPath: string
+  let barePath: string
+  let baseOid: string
+  let headOid: string
+
+  beforeEach(async () => {
+    rootPath = createGitTempDir()
+    const sourcePath = path.join(rootPath, 'source')
+    barePath = path.join(rootPath, 'repo.git')
+    await mkdir(sourcePath)
+    await runGitFixture(sourcePath, ['init', '--quiet'])
+    await writeFile(path.join(sourcePath, 'file.txt'), 'base\n')
+    await runGitFixture(sourcePath, ['add', 'file.txt'])
+    await runGitFixture(sourcePath, [
+      '-c',
+      'user.email=test@example.com',
+      '-c',
+      'user.name=Test User',
+      'commit',
+      '--quiet',
+      '-m',
+      'base'
+    ])
+    baseOid = (await runGitFixture(sourcePath, ['rev-parse', 'HEAD'])).trim()
+    await writeFile(path.join(sourcePath, 'file.txt'), 'head\n')
+    await runGitFixture(sourcePath, [
+      '-c',
+      'user.email=test@example.com',
+      '-c',
+      'user.name=Test User',
+      'commit',
+      '--quiet',
+      '-am',
+      'head'
+    ])
+    headOid = (await runGitFixture(sourcePath, ['rev-parse', 'HEAD'])).trim()
+    await runGitFixture(rootPath, ['clone', '--bare', '--quiet', sourcePath, barePath])
+    ;({ dispatcher, handler } = createGitHandlerRelay())
+    vi.stubEnv('GIT_CONFIG_COUNT', '1')
+    vi.stubEnv('GIT_CONFIG_KEY_0', 'safe.bareRepository')
+    vi.stubEnv('GIT_CONFIG_VALUE_0', 'explicit')
+  })
+
+  afterEach(async () => {
+    handler.dispose()
+    vi.unstubAllEnvs()
+    await removeGitTempDir(rootPath)
+  })
+
+  it('does not bypass the policy for generic relay commands', async () => {
+    await expect(
+      dispatcher.callRequest('git.exec', {
+        args: ['rev-parse', '--is-bare-repository'],
+        cwd: barePath
+      })
+    ).rejects.toThrow(/cannot use bare repository/)
+  })
+
+  it('reads commit diff blobs through an explicit gitdir retry', async () => {
+    const result = await dispatcher.callRequest('git.commitDiff', {
+      worktreePath: barePath,
+      commitOid: headOid,
+      parentOid: baseOid,
+      filePath: 'file.txt'
+    })
+
+    expect(result).toEqual({
+      kind: 'text',
+      originalContent: 'base\n',
+      modifiedContent: 'head\n',
+      originalIsBinary: false,
+      modifiedIsBinary: false
+    })
+  })
+})

--- a/src/relay/git-handler-working-tree-changes.test.ts
+++ b/src/relay/git-handler-working-tree-changes.test.ts
@@ -272,6 +272,10 @@ describe('GitHandler', () => {
       gitInit(tmpDir)
       writeFileSync(path.join(tmpDir, '[k]eep.log'), 'selected')
       writeFileSync(path.join(tmpDir, 'keep.log'), 'keep')
+      execFileSync('git', ['add', '-f', '--', '[k]eep.log', 'keep.log'], {
+        cwd: tmpDir,
+        stdio: 'pipe'
+      })
       gitCommit(tmpDir, 'track log fixtures')
       writeFileSync(path.join(tmpDir, '[k]eep.log'), 'selected modified')
       writeFileSync(path.join(tmpDir, 'keep.log'), 'keep modified')

--- a/src/relay/git-handler-working-tree-changes.test.ts
+++ b/src/relay/git-handler-working-tree-changes.test.ts
@@ -8,6 +8,7 @@ import * as path from 'node:path'
 import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { execFileSync } from 'node:child_process'
+import { runGitFixture } from '../shared/git-process-test-fixture'
 import type { GitHandler } from './git-handler'
 import { gitInit, gitCommit, type MockDispatcher } from './git-handler-test-setup'
 import {
@@ -272,10 +273,7 @@ describe('GitHandler', () => {
       gitInit(tmpDir)
       writeFileSync(path.join(tmpDir, '[k]eep.log'), 'selected')
       writeFileSync(path.join(tmpDir, 'keep.log'), 'keep')
-      execFileSync('git', ['add', '-f', '--', '[k]eep.log', 'keep.log'], {
-        cwd: tmpDir,
-        stdio: 'pipe'
-      })
+      await runGitFixture(tmpDir, ['add', '-f', '--', '[k]eep.log', 'keep.log'])
       gitCommit(tmpDir, 'track log fixtures')
       writeFileSync(path.join(tmpDir, '[k]eep.log'), 'selected modified')
       writeFileSync(path.join(tmpDir, 'keep.log'), 'keep modified')

--- a/src/relay/git-handler-worktree-inspection.test.ts
+++ b/src/relay/git-handler-worktree-inspection.test.ts
@@ -75,7 +75,8 @@ describe('GitHandler', () => {
         )
       ).rejects.toThrow('aborted')
       expect(gitSpy).toHaveBeenCalledWith(['worktree', 'list', '--porcelain', '-z'], tmpDir, {
-        signal: controller.signal
+        signal: controller.signal,
+        allowExplicitBareRepositoryRetry: true
       })
     })
 

--- a/src/relay/git-handler-worktree-inspection.test.ts
+++ b/src/relay/git-handler-worktree-inspection.test.ts
@@ -7,6 +7,7 @@ import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import { mkdirSync, symlinkSync, writeFileSync } from 'node:fs'
 import { execFileSync } from 'node:child_process'
+import { runGitFixture } from '../shared/git-process-test-fixture'
 import type { GitHandler } from './git-handler'
 import { gitInit, gitCommit, type MockDispatcher } from './git-handler-test-setup'
 import {
@@ -45,7 +46,7 @@ describe('GitHandler', () => {
     })
 
     it('lists a bare repo when safe.bareRepository requires an explicit gitdir', async () => {
-      execFileSync('git', ['init', '--bare', '--quiet'], { cwd: tmpDir, stdio: 'pipe' })
+      await runGitFixture(tmpDir, ['init', '--bare', '--quiet'])
       const barePath = await fs.realpath(tmpDir)
       vi.stubEnv('GIT_CONFIG_COUNT', '1')
       vi.stubEnv('GIT_CONFIG_KEY_0', 'safe.bareRepository')

--- a/src/relay/git-handler-worktree-inspection.test.ts
+++ b/src/relay/git-handler-worktree-inspection.test.ts
@@ -7,7 +7,6 @@ import * as fs from 'node:fs/promises'
 import * as path from 'node:path'
 import { mkdirSync, symlinkSync, writeFileSync } from 'node:fs'
 import { execFileSync } from 'node:child_process'
-import { runGitFixture } from '../shared/git-process-test-fixture'
 import type { GitHandler } from './git-handler'
 import { gitInit, gitCommit, type MockDispatcher } from './git-handler-test-setup'
 import {
@@ -43,22 +42,6 @@ describe('GitHandler', () => {
       })) as Record<string, unknown>[]
       expect(result.length).toBeGreaterThanOrEqual(1)
       expect(result[0].isMainWorktree).toBe(true)
-    })
-
-    it('lists a bare repo when safe.bareRepository requires an explicit gitdir', async () => {
-      await runGitFixture(tmpDir, ['init', '--bare', '--quiet'])
-      const barePath = await fs.realpath(tmpDir)
-      vi.stubEnv('GIT_CONFIG_COUNT', '1')
-      vi.stubEnv('GIT_CONFIG_KEY_0', 'safe.bareRepository')
-      vi.stubEnv('GIT_CONFIG_VALUE_0', 'explicit')
-
-      const result = (await dispatcher.callRequest('git.listWorktrees', {
-        repoPath: barePath
-      })) as Record<string, unknown>[]
-
-      expect(result).toEqual([
-        expect.objectContaining({ path: barePath, isBare: true, isMainWorktree: true })
-      ])
     })
 
     it('passes request cancellation to the git worktree list subprocess', async () => {

--- a/src/relay/git-handler-worktree-inspection.test.ts
+++ b/src/relay/git-handler-worktree-inspection.test.ts
@@ -27,6 +27,7 @@ describe('GitHandler', () => {
   })
 
   afterEach(async () => {
+    vi.unstubAllEnvs()
     await removeGitTempDir(tmpDir)
   })
 
@@ -41,6 +42,22 @@ describe('GitHandler', () => {
       })) as Record<string, unknown>[]
       expect(result.length).toBeGreaterThanOrEqual(1)
       expect(result[0].isMainWorktree).toBe(true)
+    })
+
+    it('lists a bare repo when safe.bareRepository requires an explicit gitdir', async () => {
+      execFileSync('git', ['init', '--bare', '--quiet'], { cwd: tmpDir, stdio: 'pipe' })
+      const barePath = await fs.realpath(tmpDir)
+      vi.stubEnv('GIT_CONFIG_COUNT', '1')
+      vi.stubEnv('GIT_CONFIG_KEY_0', 'safe.bareRepository')
+      vi.stubEnv('GIT_CONFIG_VALUE_0', 'explicit')
+
+      const result = (await dispatcher.callRequest('git.listWorktrees', {
+        repoPath: barePath
+      })) as Record<string, unknown>[]
+
+      expect(result).toEqual([
+        expect.objectContaining({ path: barePath, isBare: true, isMainWorktree: true })
+      ])
     })
 
     it('passes request cancellation to the git worktree list subprocess', async () => {

--- a/src/relay/git-handler-worktree-operations.ts
+++ b/src/relay/git-handler-worktree-operations.ts
@@ -125,7 +125,8 @@ export class GitHandlerWorktreeOperations extends GitHandlerOperationContext {
       'worktree-list-z',
       async () => {
         const { stdout } = await this.git(['worktree', 'list', '--porcelain', '-z'], repoPath, {
-          signal: context?.signal
+          signal: context?.signal,
+          allowExplicitBareRepositoryRetry: true
         })
         return this.normalizeMainWorktreePath(
           repoPath,
@@ -137,7 +138,8 @@ export class GitHandlerWorktreeOperations extends GitHandlerOperationContext {
         // Why no catch (#14004): swallowing to `[]` would report an unreadable catalog as an authoritative
         // empty one, and callers use that to authorize missing-worktree teardown. Let the failure propagate.
         const { stdout } = await this.git(['worktree', 'list', '--porcelain'], repoPath, {
-          signal: context?.signal
+          signal: context?.signal,
+          allowExplicitBareRepositoryRetry: true
         })
         const normalized = await this.normalizeMainWorktreePath(repoPath, parseWorktreeList(stdout))
         // Why: Git <2.31 emits no `prunable` annotation, so probe each linked worktree's existence instead of trusting stale registrations (issue #8389).

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -25,7 +25,7 @@ import { registerGitHandlers } from './git-handler-registration'
 import { resolveGitFetchHeadCommand, runWithGitFetchHeadLock } from '../shared/git-fetch-head-lock'
 import { endSubprocessStdin } from '../shared/subprocess-stdin-write'
 import { MAX_GIT_BUFFER, runGitToTermination } from './git-handler-command-termination'
-import { explicitBareRepositoryRetryArgs } from '../shared/git-bare-repository-command'
+import { runWithExplicitBareRepositoryRetry } from '../shared/git-bare-repository-command'
 
 const execFileAsync = promisify(execFile)
 
@@ -188,25 +188,21 @@ export class GitHandler {
         ? runWithGitFetchHeadLock(command.cwd, opts?.signal, () => run(commandArgs), command.gitDir)
         : run(commandArgs)
     }
-    try {
-      return await execute(args)
-    } catch (error) {
-      const retryArgs = explicitBareRepositoryRetryArgs(args, error)
-      if (!retryArgs) {
-        throw error
-      }
-      return execute(retryArgs)
-    }
+    return opts?.allowExplicitBareRepositoryRetry
+      ? runWithExplicitBareRepositoryRetry(args, execute)
+      : execute(args)
   }
 
   private async gitBuffer(args: string[], cwd: string): Promise<Buffer> {
-    const { stdout } = (await execFileAsync('git', args, {
-      cwd,
-      env: buildRelayGitEnv(),
-      encoding: 'buffer',
-      maxBuffer: MAX_GIT_BUFFER
-    })) as { stdout: Buffer }
-    return stdout
+    return runWithExplicitBareRepositoryRetry(args, async (commandArgs) => {
+      const { stdout } = (await execFileAsync('git', commandArgs, {
+        cwd,
+        env: buildRelayGitEnv(),
+        encoding: 'buffer',
+        maxBuffer: MAX_GIT_BUFFER
+      })) as { stdout: Buffer }
+      return stdout
+    })
   }
 
   private async spawnClone(

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -25,6 +25,7 @@ import { registerGitHandlers } from './git-handler-registration'
 import { resolveGitFetchHeadCommand, runWithGitFetchHeadLock } from '../shared/git-fetch-head-lock'
 import { endSubprocessStdin } from '../shared/subprocess-stdin-write'
 import { MAX_GIT_BUFFER, runGitToTermination } from './git-handler-command-termination'
+import { explicitBareRepositoryRetryArgs } from '../shared/git-bare-repository-command'
 
 const execFileAsync = promisify(execFile)
 
@@ -159,7 +160,7 @@ export class GitHandler {
     opts?: GitHandlerCommandOptions
   ): Promise<GitHandlerCommandResult> {
     const expandedCwd = expandTilde(cwd)
-    const run = async (): Promise<{ stdout: string; stderr: string }> => {
+    const run = async (commandArgs: string[]): Promise<{ stdout: string; stderr: string }> => {
       const env = opts?.nonInteractive ? buildRelayUnattendedGitEnv() : buildRelayGitEnv()
       if (opts?.disableOptionalLocks) {
         env.GIT_OPTIONAL_LOCKS = '0'
@@ -173,18 +174,29 @@ export class GitHandler {
         signal: opts?.signal
       } satisfies ExecFileOptions
       if (opts?.terminationBarrier) {
-        return runGitToTermination(args, execOptions, opts.stdin)
+        return runGitToTermination(commandArgs, execOptions, opts.stdin)
       }
       if (opts?.stdin !== undefined) {
-        return execFileWithStdin('git', args, execOptions, opts.stdin)
+        return execFileWithStdin('git', commandArgs, execOptions, opts.stdin)
       }
-      const { stdout, stderr } = await execFileAsync('git', args, execOptions)
+      const { stdout, stderr } = await execFileAsync('git', commandArgs, execOptions)
       return { stdout: String(stdout), stderr: String(stderr) }
     }
-    const command = resolveGitFetchHeadCommand(args, expandedCwd)
-    return command.needsLock
-      ? runWithGitFetchHeadLock(command.cwd, opts?.signal, run, command.gitDir)
-      : run()
+    const execute = (commandArgs: string[]) => {
+      const command = resolveGitFetchHeadCommand(commandArgs, expandedCwd)
+      return command.needsLock
+        ? runWithGitFetchHeadLock(command.cwd, opts?.signal, () => run(commandArgs), command.gitDir)
+        : run(commandArgs)
+    }
+    try {
+      return await execute(args)
+    } catch (error) {
+      const retryArgs = explicitBareRepositoryRetryArgs(args, error)
+      if (!retryArgs) {
+        throw error
+      }
+      return execute(retryArgs)
+    }
   }
 
   private async gitBuffer(args: string[], cwd: string): Promise<Buffer> {

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -189,7 +189,7 @@ export class GitHandler {
         : run(commandArgs)
     }
     return opts?.allowExplicitBareRepositoryRetry
-      ? runWithExplicitBareRepositoryRetry(args, execute)
+      ? runWithExplicitBareRepositoryRetry(args, execute, opts.explicitBareRepositoryReadState)
       : execute(args)
   }
 

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -25,7 +25,10 @@ import { registerGitHandlers } from './git-handler-registration'
 import { resolveGitFetchHeadCommand, runWithGitFetchHeadLock } from '../shared/git-fetch-head-lock'
 import { endSubprocessStdin } from '../shared/subprocess-stdin-write'
 import { MAX_GIT_BUFFER, runGitToTermination } from './git-handler-command-termination'
-import { runWithExplicitBareRepositoryRetry } from '../shared/git-bare-repository-command'
+import {
+  runWithExplicitBareRepositoryRetry,
+  type ExplicitBareRepositoryReadState
+} from '../shared/git-bare-repository-command'
 
 const execFileAsync = promisify(execFile)
 
@@ -90,7 +93,7 @@ export class GitHandler {
       watcherRegistry: this.watcherRegistry,
       git: (args, cwd, opts) =>
         opts === undefined ? this.git(args, cwd) : this.git(args, cwd, opts),
-      gitBuffer: (args, cwd) => this.gitBuffer(args, cwd),
+      gitBuffer: (args, cwd, readState) => this.gitBuffer(args, cwd, readState),
       spawnClone: (args, cwd, progressId, context) =>
         this.spawnClone(args, cwd, progressId, context),
       clearGitMutationReadCaches: () => this.clearGitMutationReadCaches(),
@@ -193,16 +196,24 @@ export class GitHandler {
       : execute(args)
   }
 
-  private async gitBuffer(args: string[], cwd: string): Promise<Buffer> {
-    return runWithExplicitBareRepositoryRetry(args, async (commandArgs) => {
-      const { stdout } = (await execFileAsync('git', commandArgs, {
-        cwd,
-        env: buildRelayGitEnv(),
-        encoding: 'buffer',
-        maxBuffer: MAX_GIT_BUFFER
-      })) as { stdout: Buffer }
-      return stdout
-    })
+  private async gitBuffer(
+    args: string[],
+    cwd: string,
+    readState?: ExplicitBareRepositoryReadState
+  ): Promise<Buffer> {
+    return runWithExplicitBareRepositoryRetry(
+      args,
+      async (commandArgs) => {
+        const { stdout } = (await execFileAsync('git', commandArgs, {
+          cwd,
+          env: buildRelayGitEnv(),
+          encoding: 'buffer',
+          maxBuffer: MAX_GIT_BUFFER
+        })) as { stdout: Buffer }
+        return stdout
+      },
+      readState
+    )
   }
 
   private async spawnClone(

--- a/src/shared/git-bare-repository-command.test.ts
+++ b/src/shared/git-bare-repository-command.test.ts
@@ -31,4 +31,30 @@ describe('explicitBareRepositoryRetryArgs', () => {
 
     expect(args).toBeNull()
   })
+
+  it('finds an explicit gitdir after global options with values', () => {
+    const error = Object.assign(new Error('git failed'), {
+      stderr: "fatal: cannot use bare repository '/repo.git' (safe.bareRepository is 'explicit')"
+    })
+
+    const args = explicitBareRepositoryRetryArgs(
+      ['-C', 'repo', '-c', 'core.fsmonitor=false', '--git-dir', '.', 'status'],
+      error
+    )
+
+    expect(args).toBeNull()
+  })
+
+  it.each([
+    ['rev-parse', '--git-dir', '--git-common-dir'],
+    ['ls-files', '--', '--git-dir=fixture']
+  ])('retries when --git-dir appears after the subcommand', (...args) => {
+    const error = Object.assign(new Error('git failed'), {
+      stderr: "fatal: cannot use bare repository '/repo.git' (safe.bareRepository is 'explicit')"
+    })
+
+    const retryArgs = explicitBareRepositoryRetryArgs(args, error)
+
+    expect(retryArgs).toEqual(['--git-dir=.', ...args])
+  })
 })

--- a/src/shared/git-bare-repository-command.test.ts
+++ b/src/shared/git-bare-repository-command.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { explicitBareRepositoryRetryArgs } from './git-bare-repository-command'
+
+describe('explicitBareRepositoryRetryArgs', () => {
+  it('retries strict implicit bare-repository failures through the current gitdir', () => {
+    const error = Object.assign(new Error('git failed'), {
+      stderr: "fatal: cannot use bare repository '/repo.git' (safe.bareRepository is 'explicit')"
+    })
+
+    const args = explicitBareRepositoryRetryArgs(['worktree', 'list', '--porcelain'], error)
+
+    expect(args).toEqual(['--git-dir=.', 'worktree', 'list', '--porcelain'])
+  })
+
+  it('does not retry unrelated repository failures', () => {
+    const error = Object.assign(new Error('git failed'), {
+      stderr: 'fatal: not a git repository'
+    })
+
+    const args = explicitBareRepositoryRetryArgs(['worktree', 'list'], error)
+
+    expect(args).toBeNull()
+  })
+
+  it('does not retry a command that already selected its gitdir', () => {
+    const error = Object.assign(new Error('git failed'), {
+      stderr: "fatal: cannot use bare repository '/repo.git' (safe.bareRepository is 'explicit')"
+    })
+
+    const args = explicitBareRepositoryRetryArgs(['--git-dir=.', 'status'], error)
+
+    expect(args).toBeNull()
+  })
+})

--- a/src/shared/git-bare-repository-command.test.ts
+++ b/src/shared/git-bare-repository-command.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { explicitBareRepositoryRetryArgs } from './git-bare-repository-command'
+import {
+  createExplicitBareRepositoryReadState,
+  explicitBareRepositoryRetryArgs,
+  runWithExplicitBareRepositoryRetry
+} from './git-bare-repository-command'
 
 describe('explicitBareRepositoryRetryArgs', () => {
   it('retries strict implicit bare-repository failures through the current gitdir', () => {
@@ -56,5 +60,33 @@ describe('explicitBareRepositoryRetryArgs', () => {
     const retryArgs = explicitBareRepositoryRetryArgs(args, error)
 
     expect(retryArgs).toEqual(['--git-dir=.', ...args])
+  })
+
+  it('keeps later pathspec reads explicit after a confirmed retry', async () => {
+    const state = createExplicitBareRepositoryReadState()
+    const calls: string[][] = []
+    const run = async (args: string[]): Promise<string> => {
+      calls.push(args)
+      if (calls.length === 1) {
+        throw Object.assign(new Error('git failed'), {
+          stderr:
+            "fatal: cannot use bare repository '/repo.git' (safe.bareRepository is 'explicit')"
+        })
+      }
+      return 'ok'
+    }
+
+    await expect(
+      runWithExplicitBareRepositoryRetry(['rev-parse', 'HEAD'], run, state)
+    ).resolves.toBe('ok')
+    await expect(
+      runWithExplicitBareRepositoryRetry(['diff', 'base', 'head'], run, state)
+    ).resolves.toBe('ok')
+
+    expect(calls).toEqual([
+      ['rev-parse', 'HEAD'],
+      ['--git-dir=.', 'rev-parse', 'HEAD'],
+      ['--git-dir=.', 'diff', 'base', 'head']
+    ])
   })
 })

--- a/src/shared/git-bare-repository-command.ts
+++ b/src/shared/git-bare-repository-command.ts
@@ -8,8 +8,32 @@ function gitErrorText(error: unknown): string {
     .join('\n')
 }
 
+const GIT_GLOBAL_OPTIONS_WITH_VALUE = new Set([
+  '-c',
+  '-C',
+  '--work-tree',
+  '--namespace',
+  '--super-prefix',
+  '--config-env',
+  '--exec-path'
+])
+
 function hasExplicitGitDir(args: readonly string[]): boolean {
-  return args.some((arg) => arg === '--git-dir' || arg.startsWith('--git-dir='))
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (arg === '--git-dir' || arg.startsWith('--git-dir=')) {
+      return true
+    }
+    if (GIT_GLOBAL_OPTIONS_WITH_VALUE.has(arg)) {
+      index += 1
+      continue
+    }
+    if (arg.startsWith('-')) {
+      continue
+    }
+    return false
+  }
+  return false
 }
 
 export function explicitBareRepositoryRetryArgs(

--- a/src/shared/git-bare-repository-command.ts
+++ b/src/shared/git-bare-repository-command.ts
@@ -4,7 +4,10 @@ function gitErrorText(error: unknown): string {
   }
   return ['message', 'stderr']
     .map((field) => (error as Record<string, unknown>)[field])
-    .filter((value): value is string => typeof value === 'string')
+    .map((value) =>
+      typeof value === 'string' ? value : Buffer.isBuffer(value) ? value.toString('utf8') : ''
+    )
+    .filter(Boolean)
     .join('\n')
 }
 
@@ -49,4 +52,19 @@ export function explicitBareRepositoryRetryArgs(
     return null
   }
   return ['--git-dir=.', ...args]
+}
+
+export async function runWithExplicitBareRepositoryRetry<T>(
+  args: readonly string[],
+  run: (commandArgs: string[]) => Promise<T>
+): Promise<T> {
+  try {
+    return await run([...args])
+  } catch (error) {
+    const retryArgs = explicitBareRepositoryRetryArgs(args, error)
+    if (!retryArgs) {
+      throw error
+    }
+    return run(retryArgs)
+  }
 }

--- a/src/shared/git-bare-repository-command.ts
+++ b/src/shared/git-bare-repository-command.ts
@@ -1,0 +1,28 @@
+function gitErrorText(error: unknown): string {
+  if (typeof error !== 'object' || error === null) {
+    return String(error)
+  }
+  return ['message', 'stderr']
+    .map((field) => (error as Record<string, unknown>)[field])
+    .filter((value): value is string => typeof value === 'string')
+    .join('\n')
+}
+
+function hasExplicitGitDir(args: readonly string[]): boolean {
+  return args.some((arg) => arg === '--git-dir' || arg.startsWith('--git-dir='))
+}
+
+export function explicitBareRepositoryRetryArgs(
+  args: readonly string[],
+  error: unknown
+): string[] | null {
+  if (
+    hasExplicitGitDir(args) ||
+    !/cannot use bare repository[\s\S]*safe\.bareRepository is ['"]explicit['"]/i.test(
+      gitErrorText(error)
+    )
+  ) {
+    return null
+  }
+  return ['--git-dir=.', ...args]
+}

--- a/src/shared/git-bare-repository-command.ts
+++ b/src/shared/git-bare-repository-command.ts
@@ -39,6 +39,16 @@ function hasExplicitGitDir(args: readonly string[]): boolean {
   return false
 }
 
+export type ExplicitBareRepositoryReadState = { useExplicitGitDir: boolean }
+
+export function createExplicitBareRepositoryReadState(): ExplicitBareRepositoryReadState {
+  return { useExplicitGitDir: false }
+}
+
+function explicitBareRepositoryArgs(args: readonly string[]): string[] {
+  return hasExplicitGitDir(args) ? [...args] : ['--git-dir=.', ...args]
+}
+
 export function explicitBareRepositoryRetryArgs(
   args: readonly string[],
   error: unknown
@@ -51,13 +61,17 @@ export function explicitBareRepositoryRetryArgs(
   ) {
     return null
   }
-  return ['--git-dir=.', ...args]
+  return explicitBareRepositoryArgs(args)
 }
 
 export async function runWithExplicitBareRepositoryRetry<T>(
   args: readonly string[],
-  run: (commandArgs: string[]) => Promise<T>
+  run: (commandArgs: string[]) => Promise<T>,
+  state?: ExplicitBareRepositoryReadState
 ): Promise<T> {
+  if (state?.useExplicitGitDir) {
+    return run(explicitBareRepositoryArgs(args))
+  }
   try {
     return await run([...args])
   } catch (error) {
@@ -65,6 +79,10 @@ export async function runWithExplicitBareRepositoryRetry<T>(
     if (!retryArgs) {
       throw error
     }
-    return run(retryArgs)
+    const result = await run(retryArgs)
+    if (state) {
+      state.useExplicitGitDir = true
+    }
+    return result
   }
 }

--- a/src/shared/git-fetch-head-lock.test.ts
+++ b/src/shared/git-fetch-head-lock.test.ts
@@ -37,6 +37,13 @@ describe('runWithGitFetchHeadLock', () => {
       gitDir: path.resolve('/tmp', '/repo/.git'),
       needsLock: true
     })
+    expect(
+      resolveGitFetchHeadCommand(['--git-dir=.', '-C', 'repo', 'fetch'], '/tmp')
+    ).toMatchObject({
+      cwd: '/tmp/repo',
+      gitDir: '/tmp/repo',
+      needsLock: true
+    })
   })
 
   it('serializes FETCH_HEAD users in one worktree without blocking another', async () => {

--- a/src/shared/git-fetch-head-lock.test.ts
+++ b/src/shared/git-fetch-head-lock.test.ts
@@ -29,19 +29,21 @@ describe('runWithGitFetchHeadLock', () => {
   // Why resolve() rather than a literal: the subject resolves these through path.resolve, so a
   // POSIX literal asserts the separator of the machine running the suite instead of the behaviour.
   it('resolves -C and --git-dir before deriving the lock identity', () => {
+    const initialCwd = path.resolve('/tmp')
+    const repoCwd = path.resolve(initialCwd, 'repo')
     expect(resolveGitFetchHeadCommand(['-C', 'repo', 'fetch'], '/tmp')).toMatchObject({
-      cwd: path.resolve('/tmp', 'repo'),
+      cwd: repoCwd,
       needsLock: true
     })
     expect(resolveGitFetchHeadCommand(['--git-dir=/repo/.git', 'fetch'], '/tmp')).toMatchObject({
-      gitDir: path.resolve('/tmp', '/repo/.git'),
+      gitDir: path.resolve('/repo/.git'),
       needsLock: true
     })
     expect(
       resolveGitFetchHeadCommand(['--git-dir=.', '-C', 'repo', 'fetch'], '/tmp')
     ).toMatchObject({
-      cwd: '/tmp/repo',
-      gitDir: '/tmp/repo',
+      cwd: repoCwd,
+      gitDir: repoCwd,
       needsLock: true
     })
   })

--- a/src/shared/git-fetch-head-lock.ts
+++ b/src/shared/git-fetch-head-lock.ts
@@ -32,7 +32,7 @@ export function resolveGitFetchHeadCommand(
   initialCwd: string
 ): GitFetchHeadCommand {
   let cwd = initialCwd
-  let gitDir: string | undefined
+  let gitDirArg: string | undefined
   let subcommandIndex = -1
   for (let index = 0; index < args.length; index += 1) {
     const arg = args[index]
@@ -46,12 +46,12 @@ export function resolveGitFetchHeadCommand(
       continue
     }
     if (arg === '--git-dir' && args[index + 1]) {
-      gitDir = path.resolve(cwd, args[index + 1])
+      gitDirArg = args[index + 1]
       index += 1
       continue
     }
     if (arg.startsWith('--git-dir=')) {
-      gitDir = path.resolve(cwd, arg.slice('--git-dir='.length))
+      gitDirArg = arg.slice('--git-dir='.length)
       continue
     }
     if (GLOBAL_OPTIONS_WITH_VALUE.has(arg)) {
@@ -64,6 +64,7 @@ export function resolveGitFetchHeadCommand(
     subcommandIndex = index
     break
   }
+  const gitDir = gitDirArg === undefined ? undefined : path.resolve(cwd, gitDirArg)
   const subcommand = args[subcommandIndex]
   if (subcommand === 'pull') {
     return { needsLock: true, cwd, gitDir }

--- a/src/shared/git-process-test-fixture.test.ts
+++ b/src/shared/git-process-test-fixture.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { runGitFixture } from './git-process-test-fixture'
+
+describe('runGitFixture', () => {
+  it('returns stdout when Git succeeds', async () => {
+    const stdout = await runGitFixture(process.cwd(), ['--version'])
+
+    expect(stdout).toMatch(/^git version /)
+  })
+
+  it('throws when Git exits unsuccessfully', async () => {
+    const failure = runGitFixture(process.cwd(), ['--definitely-invalid-option'])
+
+    await expect(failure).rejects.toThrow(/git --definitely-invalid-option/)
+  })
+})

--- a/src/shared/git-process-test-fixture.ts
+++ b/src/shared/git-process-test-fixture.ts
@@ -1,0 +1,16 @@
+import { runProcess, type ProcessResult } from './child-process/run-process'
+
+function gitFailure(args: readonly string[], result: ProcessResult): Error {
+  const detail = result.timedOut
+    ? 'timed out'
+    : result.stderr.trim() || `exited with ${result.code ?? 'no exit code'}`
+  return new Error(`git ${args.join(' ')} ${detail}`)
+}
+
+export async function runGitFixture(cwd: string, args: readonly string[]): Promise<string> {
+  const result = await runProcess({ program: 'git', args, cwd })
+  if (result.code !== 0 || result.timedOut) {
+    throw gitFailure(args, result)
+  }
+  return result.stdout
+}


### PR DESCRIPTION
## ELI5

Most Orca users will never enter this path. It applies only when Git is configured with `safe.bareRepository=explicit` and Orca opens an already registered bare repository. Git then rejects normal repository discovery, so Orca retries that exact failure by selecting the current repository explicitly. Normal repositories and unrelated Git commands keep their existing behavior.

## What Changed

- Recognize Git's exact strict-bare rejection and retry trusted repository reads with the fixed argument `--git-dir=.`.
- Apply the fallback to local, WSL, and relay reads used by worktree discovery, blobs, and commit or branch comparisons.
- Keep the exceptional policy inside Git execution plumbing. Normal comparison code still uses domain names such as `compareOptions` and `gitOptionsForWorktree`.
- Preserve explicit mode for the rest of one comparison after the first strict-bare rejection. This is needed because a later `git diff` can otherwise interpret commit IDs as pathspecs without repeating the original error.
- Keep the fallback request-scoped. Orca does not cache the policy across operations because the repository path or Git configuration can change outside Orca.
- Make strict-bare and literal-pathspec fixtures deterministic across macOS, Linux, and Windows, including environments with a global `*.log` ignore rule.
- Add eight focused Git boundary suites to the existing Windows-specific PR test step.

## Why

Orca already knows which bare repository it intends to read and runs Git from that registered directory. With `safe.bareRepository=explicit`, Git refuses implicit discovery even in that directory. Retrying with `--git-dir=.` states the same repository explicitly; it does not weaken the user's Git policy or accept a new path.

The fallback is intentionally narrow because this configuration is uncommon:

- Ordinary repositories stay on the existing command path with no extra probe or retry.
- Only trusted read operations can opt in. Generic commands and mutations cannot.
- The retry requires Git's exact strict-bare error.
- Commands that already select a Git directory are not rewritten.
- The only added repository selector is the constant `--git-dir=.`.

The compare state matters after that retry. Some metadata commands reproduce the strict-bare error, but later pathspec-aware `git diff` commands can fail differently and treat object IDs as paths. Remembering explicit mode only for the active comparison prevents that second failure without making the rare configuration part of the common comparison API.

The fixture changes solve a separate source of nondeterminism exposed during cross-platform verification. Literal pathspec tests intentionally use filenames that look like patterns. Force-adding those files ensures a developer's global ignore file cannot silently change what the test covers.

## Linked Issue

Fixes https://github.com/stablyai/orca/issues/16445

## Visual Proof

N/A. The diff changes Git execution and test coverage, not UI or interaction behavior.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Passed on macOS at `6fb546b1b4`:

```text
pnpm exec vitest run src/shared/git-bare-repository-command.test.ts src/shared/git-fetch-head-lock.test.ts src/shared/git-process-test-fixture.test.ts src/main/git/runner-strict-bare-repository.test.ts src/main/git/runner-wsl-login-shell-capture.test.ts src/main/git/runner-wsl-direct-read.test.ts src/main/git/git-blob-read-strict-bare-repository.test.ts src/main/git/git-compare-strict-bare-repository.test.ts src/main/git/worktree-separate-git-dir.test.ts src/main/git/status-branch-compare.test.ts src/main/git/status-diff.test.ts src/main/git/status-submodule.test.ts src/main/runtime/repo-worktree-admin-fingerprint.test.ts src/relay/git-handler-strict-bare-repository.test.ts src/relay/git-handler-worktree-inspection.test.ts src/main/git/command-runner/git-subprocess-admission.test.ts src/main/git/command-runner/git-command-timeout.test.ts src/main/git/command-runner/wsl-host-failure.test.ts --pool=forks --maxWorkers=2
```

Result: 18 files and 176 tests passed.

```text
pnpm exec vitest run src/main/runtime/runtime-git-api-contract.test.ts src/main/runtime/rpc/methods/git.test.ts src/main/ipc/filesystem-branch-compare-diff.test.ts src/relay/git-handler-branch-diff.test.ts --pool=forks --maxWorkers=2
```

Result: 4 smoke-test files and 61 tests passed.

```text
pnpm tc
pnpm run check:code-quality:changed
pnpm run check:max-lines-ratchet
actionlint .github/workflows/pr.yml
pnpm exec vitest run config/scripts/pr-workflow-lint-parity.test.mjs config/scripts/pr-workflow-parallelism.test.mjs --pool=forks --maxWorkers=2
git diff --name-only -z upstream/main...HEAD | xargs -0 pnpm exec oxfmt --check
```

Result: all passed. The workflow suites passed 19 tests, and changed-code quality reported no new findings across 41 changed code files.

```text
pnpm run build:desktop
```

Result: passed, including typecheck and relay bundles for Linux x64/arm64, macOS x64/arm64, Windows x64/arm64, and WSL. The local CLI install emitted a non-fatal permission warning for `/usr/local/bin/orca-dev`; the build exited successfully.

No physical Windows or Linux machine and no live SSH host were used locally. The focused Windows boundary suites below are therefore part of the required CI evidence.

## AI Disclosure

OpenAI Codex implemented and verified the branch. The author challenged the CI scope and the naming of the rare fallback; both were reviewed and the comparison API was simplified before this update.

## Review

- **Why `.github/workflows/pr.yml` changes:** The implementation touches behavior with real platform-specific failure modes: Windows path semantics, WSL command construction and stdout fencing, and Windows child-process argument handling. A macOS-only run cannot prove those boundaries. The workflow change adds the eight relevant suites to the existing `Test Windows-specific boundaries` step, which already uses an explicit file list for this purpose.
  - It does not create a job, add a runner, widen a matrix, change permissions or triggers, or add an install step.
  - It does not run the whole Git test suite on Windows. It adds only the shared strict-bare matcher, fetch-lock regression, local runner retry, WSL login-shell capture, blob read, compare read, separate-git-dir, and relay retry suites.
  - Those suites cover either production paths changed by this PR or Windows-specific regressions found while making their real-Git fixtures portable.
  - Keeping them only as local macOS tests would leave the cross-platform claim unverified and allow future Windows-only argument or path regressions to merge.
- **Common path:** The rare configuration does not leak into normal call-site names or generic Git execution. Only a trusted read that returns the exact error retries; later reads in the same comparison reuse that decision.
- **Security:** The retry accepts no external path, adds only `--git-dir=.`, and preserves commands that already carry Git-directory selection. The user's strict Git policy remains enabled.
- **SSH and remote behavior:** Local and relay execution share the same matcher, while the execution host still owns Git work. No RPC parameter, stream frame, capability, or published payload changed.
- **Compatibility:** Command construction remains argv-based, preserves global Git options before the subcommand, and stays within the Git 2.25 baseline. The tests use the repository's cross-platform process wrapper.
- **Performance:** The common path is unchanged. The uncommon strict-bare path pays the rejected command and retry needed to identify the policy. State is not persisted across requests, avoiding stale behavior after external repository or Git-config changes.
- **Providers and UI:** No provider-specific, mobile, agent, UI, or persisted-data behavior changed.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Author X handle: `@luisurrutia_dev`.

The branch is limited to strict-bare reads, comparison continuity, deterministic Git fixtures, and the CI coverage needed to verify those boundaries.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
