### PR TITLE
perf(github): stop re-spawning the repo-identity probe every 30 seconds

### DIFF
--- a/src/main/github/github-repository-identity.signed-cache.test.ts
+++ b/src/main/github/github-repository-identity.signed-cache.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as GitRunner from '../git/runner'
+
+// A resolved repo identity used to expire on a flat 30s clock, so a client
+// polling PR state re-ran `git remote get-url` for every repo every half
+// minute. On Windows that spawn costs 250-800ms in the field. The identity is
+// a read of `.git/config`, and the config signature already exists to say when
+// that file changed — so a signed answer is now held for the same five minutes
+// a signed negative already was, and revalidated against the signature.
+
+const { gitExecFileAsyncMock, readLocalGitConfigSignatureMock } = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn(),
+  readLocalGitConfigSignatureMock: vi.fn<() => Promise<string | undefined>>(async () => 'sig-1')
+}))
+
+vi.mock('../git/runner', async (importOriginal) => ({
+  ...(await importOriginal<typeof GitRunner>()),
+  gitExecFileAsync: gitExecFileAsyncMock
+}))
+
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: () => null,
+  getSshGitProviderGeneration: () => 0,
+  SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE: 'ssh git provider unavailable'
+}))
+
+vi.mock('./local-git-config-signature', () => ({
+  readLocalGitConfigSignature: readLocalGitConfigSignatureMock
+}))
+
+import { getOwnerRepoForRemote, _resetOwnerRepoCache } from './github-repository-identity'
+
+const REPO = '/tmp/signed-cache-repo'
+const THIRTY_SECONDS = 30_000
+const FOUR_MINUTES = 4 * 60_000
+
+let remoteUrl = 'https://github.com/stablyai/orca.git'
+
+const remoteGetUrlCalls = (): number =>
+  gitExecFileAsyncMock.mock.calls.filter(([args]) => (args as string[])[1] === 'get-url').length
+
+beforeEach(() => {
+  _resetOwnerRepoCache()
+  vi.useRealTimers()
+  gitExecFileAsyncMock.mockReset()
+  remoteUrl = 'https://github.com/stablyai/orca.git'
+  readLocalGitConfigSignatureMock.mockReset()
+  readLocalGitConfigSignatureMock.mockImplementation(async () => 'sig-1')
+  gitExecFileAsyncMock.mockImplementation(async () => ({ stdout: remoteUrl }))
+})
+
+describe('owner/repo identity cache', () => {
+  it('holds a signed identity past the unsigned TTL instead of re-spawning git', async () => {
+    vi.useFakeTimers()
+    await expect(getOwnerRepoForRemote(REPO, 'origin')).resolves.toEqual({
+      owner: 'stablyai',
+      repo: 'orca'
+    })
+    expect(remoteGetUrlCalls()).toBe(1)
+
+    // Why 4 minutes: past the 30s unsigned TTL that forced the re-probe, and
+    // still inside the signed window this change introduces.
+    vi.setSystemTime(Date.now() + FOUR_MINUTES)
+    await expect(getOwnerRepoForRemote(REPO, 'origin')).resolves.toEqual({
+      owner: 'stablyai',
+      repo: 'orca'
+    })
+    expect(remoteGetUrlCalls()).toBe(1)
+    vi.useRealTimers()
+  })
+
+  it('re-probes as soon as the git config signature changes', async () => {
+    vi.useFakeTimers()
+    await getOwnerRepoForRemote(REPO, 'origin')
+    expect(remoteGetUrlCalls()).toBe(1)
+
+    remoteUrl = 'https://github.com/other-org/orca.git'
+    readLocalGitConfigSignatureMock.mockImplementation(async () => 'sig-2')
+    vi.setSystemTime(Date.now() + THIRTY_SECONDS)
+
+    // Why not "after the TTL": a `git remote set-url` must be visible on the
+    // very next lookup, which is what the longer hold is allowed to rely on.
+    await expect(getOwnerRepoForRemote(REPO, 'origin')).resolves.toEqual({
+      owner: 'other-org',
+      repo: 'orca'
+    })
+    expect(remoteGetUrlCalls()).toBe(2)
+    vi.useRealTimers()
+  })
+
+  it('keeps the short TTL when no signature can be read', async () => {
+    vi.useFakeTimers()
+    readLocalGitConfigSignatureMock.mockImplementation(async () => undefined)
+    await getOwnerRepoForRemote(REPO, 'origin')
+    expect(remoteGetUrlCalls()).toBe(1)
+
+    // Why: with no signature nothing invalidates on change, so the entry must
+    // still expire on the clock rather than silently pinning a stale identity.
+    vi.setSystemTime(Date.now() + THIRTY_SECONDS + 1)
+    await getOwnerRepoForRemote(REPO, 'origin')
+    expect(remoteGetUrlCalls()).toBe(2)
+    vi.useRealTimers()
+  })
+
+  it('still coalesces concurrent lookups onto one probe', async () => {
+    const [first, second] = await Promise.all([
+      getOwnerRepoForRemote(REPO, 'origin'),
+      getOwnerRepoForRemote(REPO, 'origin')
+    ])
+    expect(first).toEqual({ owner: 'stablyai', repo: 'orca' })
+    expect(second).toEqual(first)
+    expect(remoteGetUrlCalls()).toBe(1)
+  })
+})

--- a/src/main/github/github-repository-identity.ts
+++ b/src/main/github/github-repository-identity.ts
@@ -61,6 +61,14 @@ export function ghRepoExecOptions(context: GitHubRepoContext): {
 
 const OWNER_REPO_POSITIVE_CACHE_TTL_MS = 30_000
 const OWNER_REPO_NEGATIVE_CACHE_TTL_MS = 5 * 60_000
+/**
+ * A signature-backed answer is held as long as a negative one. `git remote
+ * get-url` reads `.git/config`, and the signature covers that file plus every
+ * path it includes — so while the signature holds, a re-probe can only return
+ * what is already cached. The short TTL above is the no-signature fallback
+ * (remote runtimes, an unreadable gitdir), where nothing invalidates on change.
+ */
+const OWNER_REPO_SIGNED_CACHE_TTL_MS = 5 * 60_000
 const OWNER_REPO_CACHE_MAX_ENTRIES = 512
 
 type OwnerRepoCacheEntry = {
@@ -106,10 +114,10 @@ export async function getRemoteUrlForRepo(
 }
 
 function getOwnerRepoCacheTtl(value: OwnerRepo | null, configSignature?: string): number {
-  if (value) {
-    return OWNER_REPO_POSITIVE_CACHE_TTL_MS
+  if (configSignature) {
+    return value ? OWNER_REPO_SIGNED_CACHE_TTL_MS : OWNER_REPO_NEGATIVE_CACHE_TTL_MS
   }
-  return configSignature ? OWNER_REPO_NEGATIVE_CACHE_TTL_MS : OWNER_REPO_POSITIVE_CACHE_TTL_MS
+  return OWNER_REPO_POSITIVE_CACHE_TTL_MS
 }
 
 export async function getOwnerRepoForRemote(
@@ -135,7 +143,11 @@ export async function getOwnerRepoForRemote(
   pruneOwnerRepoCache(now)
   const cached = ownerRepoCache.get(cacheKey)
   if (cached && cached.expiresAt > now) {
-    if (cached.value === null && cached.configSignature !== undefined) {
+    // Why every signed entry, not only the negatives: a positive identity is
+    // held for the same five minutes now, so the same revalidation is what
+    // keeps a `git remote set-url` visible within one lookup rather than five
+    // minutes. The signature read is fs stat/readFile, not a Git subprocess.
+    if (cached.configSignature !== undefined) {
       const currentSignature = await readLocalGitConfigSignature(context)
       if (currentSignature !== cached.configSignature) {
         ownerRepoCache.delete(cacheKey)
@@ -203,9 +215,14 @@ async function resolveOwnerRepoForRemote(
     // Why: PR mutations need the effective host behind an SSH alias.
     const classification = await classifyGitHubOwnerRepoFromRemoteUrl(remoteUrl, context)
     if (classification.kind === 'github') {
+      // Why store the signature: without it this entry can only expire on the
+      // clock, which put a `git remote get-url` (plus its ssh-alias probe) on
+      // every PR refresh cycle — the second most frequent Git subprocess in a
+      // Windows field trace, on a host spawning Git at ~250-800ms a call.
       ownerRepoCache.set(cacheKey, {
         value: classification.ownerRepo,
-        expiresAt: now + getOwnerRepoCacheTtl(classification.ownerRepo, configSignature)
+        expiresAt: now + getOwnerRepoCacheTtl(classification.ownerRepo, configSignature),
+        ...(configSignature ? { configSignature } : {})
       })
       pruneOwnerRepoCache(now)
       return classification.ownerRepo


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​114 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​114 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​22 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​17 |

<!-- /orca-pr-loc -->

## ELI5

Before Orca can list or act on GitHub issues and pull requests, it must turn a workspace's Git remotes into a GitHub `owner/repo`. This “repository-identity scan” is not a file or commit scan: Orca normally runs `git remote get-url` for `upstream` and/or `origin`, parses the URL, and may run `ssh -G` when the URL uses an SSH host alias.

The result tells Orca which GitHub repository to query. Work-item polling repeatedly asks for that identity, but a successful result was cached for only 30 seconds. That made an unchanged repository spawn Git again on later polling cycles. This PR reuses a local result for up to five minutes while rechecking the Git config signature on every lookup.

## What Changed

- Store the local Git-config signature with successful GitHub identities, not only stable misses.
- Hold signature-backed identities for five minutes instead of 30 seconds.
- Revalidate every signed cache hit against `.git/config`, `config.worktree`, and their included config files. A changed signature evicts the entry before it is returned, so a normal `git remote set-url` is visible on the next lookup.
- Keep the 30-second TTL when Orca cannot produce a host-filesystem signature, including SSH and WSL runtimes and unreadable gitdirs.
- Preserve probe coalescing and the 512-entry cache bound.

An untouched signed repository still re-probes when the five-minute entry expires; this reduces the steady-state Git spawn rate by about 10× rather than eliminating it.

## Why

In the Windows field trace behind the current slowdown reports (crash `36048e26`, Orca 1.4.188, about 25 hours of spans), `git remote get-url` was the second most frequent Git subprocess: 1,192 of 6,274 Git calls.

| subcommand | calls | p50 |
| --- | ---: | ---: |
| `worktree list` | 1,466 | 307 ms |
| **`remote get-url`** | **1,192** | **243 ms** |
| `rev-parse` | 844 | 446 ms |
| `status` | 414 | 586 ms |

On that Windows host, even no-I/O Git commands paid roughly 250–800 ms in process startup. A filesystem signature check is sufficient for ordinary local remotes and avoids most of those repeated process launches.

## User-Facing Trade-offs

- Normal local repositories should only get faster; there is no UI or workflow change.
- Cache hits are not free: each lookup stats/reads the local Git config and included files. This is normally much cheaper than spawning Git, but a pathological network mount can move some latency into filesystem metadata reads; those reads have a two-second caller deadline.
- The signature uses config path, modification time, and size. An unusual edit that preserves both mtime and size can leave the old identity cached until the five-minute TTL expires.
- A successful identity that depended on `~/.ssh/config` alias expansion can remain cached for up to five minutes after only the SSH alias mapping changes, because the signature covers Git config, not SSH config. Changing the Git remote URL itself invalidates on the next lookup.
- SSH and WSL workspaces keep the existing 30-second behavior. They avoid new staleness risk but do not receive this performance improvement.

These are bounded cache-freshness trade-offs, not persisted state; restarting Orca or reaching the five-minute expiry forces a fresh probe.

## Linked Issue

No linked issue. This is a measured follow-up from the Windows slowdown investigation; related diagnostics work is in #16449.

## Visual Proof

N/A — main-process cache policy only; no visual or interaction change.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

Focused verification:

- `github-repository-identity.signed-cache.test.ts`: signed reuse past 30 seconds, immediate signature invalidation, unsigned 30-second expiry, and concurrent coalescing.
- `pnpm exec vitest run --config config/vitest.config.ts src/main/github/github-repository-identity.signed-cache.test.ts src/main/github/gh-utils.test.ts` — 40 tests passed.
- Full typecheck, oxlint, oxfmt, and the complete `src/main/github` suite (690 tests) passed during branch validation.

Platform coverage: performance evidence is from Windows; focused review verification ran on macOS. SSH/WSL behavior is unchanged by construction because those contexts do not receive a local signature.

## AI Disclosure

<!-- Internal contributor; intentionally not filled. -->

## Review

Low merge risk. The changed contract is limited to positive cache lifetime and signature revalidation. Failure behavior remains conservative: transient probe errors are not cached, unsigned contexts retain the short TTL, remote runtime keys remain isolated, and concurrent probes remain coalesced.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or translates no upstream skill-installer material.

## Notes

- No RPC, stream, persisted-data, provider, or UI contract changes.
- No new Git command or option; Git 2.25 compatibility is unchanged.
- Folder workspaces and linked worktrees use the existing gitdir/config-path resolver.
- SSH/WSL execution remains on the owning runtime and keeps existing cache behavior.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Typecheck, lint/format, and the affected suite pass; CI covers the full build