### PR TITLE
fix(ssh): stop claiming a host was removed before its tombstone label arrives

### DIFF
--- a/src/renderer/src/hooks/ipc-events-agent-status-window-test-fixtures.ts
+++ b/src/renderer/src/hooks/ipc-events-agent-status-window-test-fixtures.ts
@@ -113,6 +113,7 @@ export function buildWindowApi(args: {
       },
       ssh: {
         listTargets: () => Promise.resolve([]),
+        listRemovedTargetLabels: () => Promise.resolve({}),
         listPortForwards: () => Promise.resolve([]),
         listDetectedPorts: () => Promise.resolve([]),
         getState: () => Promise.resolve(null),

--- a/src/renderer/src/hooks/ipc-events-test-harness.ts
+++ b/src/renderer/src/hooks/ipc-events-test-harness.ts
@@ -238,7 +238,7 @@ export async function loadIpcEventsHarness(
           listTargets: () => Promise.resolve([]),
           listPortForwards: () => Promise.resolve([]),
           listDetectedPorts: () => Promise.resolve([]),
-          listRemovedTargetLabels: () => Promise.resolve([]),
+          listRemovedTargetLabels: () => Promise.resolve({}),
           getState: () => Promise.resolve(null),
           onStateChanged: () => () => {},
           onCredentialRequest: () => () => {},

--- a/src/renderer/src/hooks/ipc-events/direct-ssh-hydration-fanout.test.ts
+++ b/src/renderer/src/hooks/ipc-events/direct-ssh-hydration-fanout.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import type { SshConnectionState } from '../../../../shared/ssh-types'
+import type { DirectSshBridgeRuntime } from './direct-ssh-bridge-runtime'
+import { registerDirectSshStateIpcBridge } from './direct-ssh-state-ipc-bridge'
+
+function connectingState(targetId: string): SshConnectionState {
+  return { targetId, status: 'connecting', error: null, reconnectAttempt: 0 }
+}
+
+function bridgeRuntime(): DirectSshBridgeRuntime {
+  return {
+    reconnectAuthorityByTarget: new Map(),
+    reconnectCoordinator: {
+      requestReconnect: vi.fn(async () => ({ status: 'complete' })),
+      replaceAuthority: vi.fn(),
+      correctUnboundTerminals: vi.fn(() => 0),
+      invalidate: vi.fn()
+    },
+    currentAuthority: () => null,
+    terminalActions: () => ({}),
+    prepareAndSync: vi.fn(async () => {}),
+    isStopped: () => false,
+    addDeadline: vi.fn(),
+    removeDeadline: vi.fn(),
+    stop: vi.fn()
+  } as unknown as DirectSshBridgeRuntime
+}
+
+async function settle(): Promise<void> {
+  for (let index = 0; index < 40; index += 1) {
+    await Promise.resolve()
+  }
+}
+
+describe('direct SSH hydration fanout', () => {
+  const unsubs: (() => void)[] = []
+
+  beforeEach(() => {
+    useAppStore.setState({
+      sshTargetLabels: new Map(),
+      removedSshTargetLabels: new Map(),
+      sshTargetsHydrated: false,
+      sshConnectionStates: new Map()
+    })
+  })
+
+  afterEach(() => {
+    for (const unsub of unsubs.splice(0)) {
+      unsub()
+    }
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('does not let one wedged target stall hydration of every target behind it', async () => {
+    // More targets than the fanout width: the pool must drain past the wedged one, not just
+    // dispatch the first wave.
+    const targets = ['ssh-wedged', 'ssh-b', 'ssh-c', 'ssh-d', 'ssh-e', 'ssh-f']
+    const dispatched: string[] = []
+    vi.stubGlobal('window', {
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      api: {
+        ui: {},
+        ssh: {
+          listTargets: () =>
+            Promise.resolve(targets.map((id) => ({ id, label: id }))),
+          listRemovedTargetLabels: () => Promise.resolve({}),
+          // A wedged relay answers nothing until the 30s RPC timeout fires.
+          getState: ({ targetId }: { targetId: string }) => {
+            dispatched.push(targetId)
+            return targetId === 'ssh-wedged'
+              ? new Promise<SshConnectionState | null>(() => {})
+              : Promise.resolve(connectingState(targetId))
+          },
+          listPortForwards: () => Promise.resolve([]),
+          listDetectedPorts: () => Promise.resolve([]),
+          onCredentialRequest: () => () => {},
+          onCredentialResolved: () => () => {},
+          onPortForwardsChanged: () => () => {},
+          onDetectedPortsChanged: () => () => {},
+          onStateChanged: () => () => {}
+        }
+      }
+    })
+
+    registerDirectSshStateIpcBridge(unsubs, bridgeRuntime())
+    await settle()
+
+    const states = useAppStore.getState().sshConnectionStates
+    expect({
+      dispatched: dispatched.length,
+      hydrated: targets.filter((id) => states.has(id))
+    }).toEqual({
+      dispatched: 6,
+      hydrated: ['ssh-b', 'ssh-c', 'ssh-d', 'ssh-e', 'ssh-f']
+    })
+  })
+})

--- a/src/renderer/src/hooks/ipc-events/direct-ssh-hydration-target-metadata.test.ts
+++ b/src/renderer/src/hooks/ipc-events/direct-ssh-hydration-target-metadata.test.ts
@@ -122,15 +122,16 @@ describe('direct SSH hydration target metadata', () => {
         return Promise.resolve([{ id: 'ssh-live', label: 'devbox' }])
       },
       listRemovedTargetLabels: () => new Promise(() => {}),
-      getState: () => Promise.resolve(null)
+      getState: () => Promise.resolve(connectingState('ssh-live'))
     })
 
     registerDirectSshStateIpcBridge(unsubs, bridgeRuntime())
     await settle()
 
-    expect(selectRuntimeAwareSshTargetLabel(useAppStore.getState(), null, 'ssh-live')).toBe(
-      'devbox'
-    )
+    expect({
+      label: selectRuntimeAwareSshTargetLabel(useAppStore.getState(), null, 'ssh-live'),
+      status: useAppStore.getState().sshConnectionStates.get('ssh-live')?.status
+    }).toEqual({ label: 'devbox', status: 'connecting' })
 
     // A push for a known target takes the fast path instead of re-querying the
     // link that is already failing to answer.

--- a/src/renderer/src/hooks/ipc-events/direct-ssh-hydration-target-metadata.test.ts
+++ b/src/renderer/src/hooks/ipc-events/direct-ssh-hydration-target-metadata.test.ts
@@ -1,0 +1,244 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import {
+  selectRuntimeAwareSshTargetLabel,
+  selectRuntimeAwareSshTargetRemoved
+} from '@/store/slices/runtime-environment-ssh'
+import type { SshConnectionState } from '../../../../shared/ssh-types'
+import { registerDirectSshStateIpcBridge } from './direct-ssh-state-ipc-bridge'
+import type { DirectSshBridgeRuntime } from './direct-ssh-bridge-runtime'
+
+type SshApiStub = {
+  listTargets: () => Promise<{ id: string; label: string }[]>
+  listRemovedTargetLabels: () => Promise<Record<string, string>>
+  getState: (args: { targetId: string }) => Promise<SshConnectionState | null>
+}
+
+function connectingState(targetId: string): SshConnectionState {
+  return { targetId, status: 'connecting', error: null, reconnectAttempt: 0 }
+}
+
+let onStateChangedHandler: ((data: { targetId: string; state: unknown }) => void) | null = null
+
+function stubWindow(ssh: SshApiStub): void {
+  vi.stubGlobal('window', {
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    api: {
+      ui: {},
+      ssh: {
+        ...ssh,
+        listPortForwards: () => Promise.resolve([]),
+        listDetectedPorts: () => Promise.resolve([]),
+        onCredentialRequest: () => () => {},
+        onCredentialResolved: () => () => {},
+        onPortForwardsChanged: () => () => {},
+        onDetectedPortsChanged: () => () => {},
+        onStateChanged: (handler: (data: { targetId: string; state: unknown }) => void) => {
+          onStateChangedHandler = handler
+          return () => {}
+        }
+      }
+    }
+  })
+}
+
+function bridgeRuntime(): DirectSshBridgeRuntime {
+  return {
+    reconnectAuthorityByTarget: new Map(),
+    reconnectCoordinator: {
+      requestReconnect: vi.fn(async () => ({ status: 'complete' })),
+      replaceAuthority: vi.fn(),
+      correctUnboundTerminals: vi.fn(() => 0),
+      invalidate: vi.fn()
+    },
+    currentAuthority: () => null,
+    terminalActions: () => ({}),
+    prepareAndSync: vi.fn(async () => {}),
+    isStopped: () => false,
+    addDeadline: vi.fn(),
+    removeDeadline: vi.fn(),
+    stop: vi.fn()
+  } as unknown as DirectSshBridgeRuntime
+}
+
+/** Lets pending IPC promises settle without leaning on a wall-clock delay. */
+async function settle(): Promise<void> {
+  for (let index = 0; index < 12; index += 1) {
+    await Promise.resolve()
+  }
+}
+
+describe('direct SSH hydration target metadata', () => {
+  const unsubs: (() => void)[] = []
+
+  beforeEach(() => {
+    onStateChangedHandler = null
+    useAppStore.setState({
+      sshTargetLabels: new Map(),
+      removedSshTargetLabels: new Map(),
+      sshTargetsHydrated: false,
+      sshConnectionStates: new Map()
+    })
+  })
+
+  afterEach(() => {
+    for (const unsub of unsubs.splice(0)) {
+      unsub()
+    }
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('names a ghost host once its tombstone label lands', async () => {
+    let resolveRemovedLabels!: (labels: Record<string, string>) => void
+    stubWindow({
+      listTargets: () => Promise.resolve([{ id: 'ssh-live', label: 'devbox' }]),
+      listRemovedTargetLabels: () =>
+        new Promise((resolve) => {
+          resolveRemovedLabels = resolve
+        }),
+      getState: () => Promise.resolve(null)
+    })
+
+    registerDirectSshStateIpcBridge(unsubs, bridgeRuntime())
+    await settle()
+
+    resolveRemovedLabels({ 'ssh-ghost': 'old devbox' })
+    await settle()
+
+    const settled = useAppStore.getState()
+    expect({
+      removed: selectRuntimeAwareSshTargetRemoved(settled, null, 'ssh-ghost'),
+      label: selectRuntimeAwareSshTargetLabel(settled, null, 'ssh-ghost')
+    }).toEqual({ removed: true, label: 'old devbox' })
+  })
+
+  it('lands live target labels while the removed-labels round trip is still in flight', async () => {
+    let listTargetsCalls = 0
+    stubWindow({
+      listTargets: () => {
+        listTargetsCalls += 1
+        return Promise.resolve([{ id: 'ssh-live', label: 'devbox' }])
+      },
+      listRemovedTargetLabels: () => new Promise(() => {}),
+      getState: () => Promise.resolve(null)
+    })
+
+    registerDirectSshStateIpcBridge(unsubs, bridgeRuntime())
+    await settle()
+
+    expect(selectRuntimeAwareSshTargetLabel(useAppStore.getState(), null, 'ssh-live')).toBe(
+      'devbox'
+    )
+
+    // A push for a known target takes the fast path instead of re-querying the
+    // link that is already failing to answer.
+    listTargetsCalls = 0
+    onStateChangedHandler?.({ targetId: 'ssh-live', state: connectingState('ssh-live') })
+    await settle()
+    expect({
+      listTargetsCalls,
+      status: useAppStore.getState().sshConnectionStates.get('ssh-live')?.status
+    }).toEqual({ listTargetsCalls: 0, status: 'connecting' })
+  })
+
+  it('keeps the target list and records the failure when removed labels are unavailable', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    stubWindow({
+      listTargets: () => Promise.resolve([{ id: 'ssh-live', label: 'devbox' }]),
+      listRemovedTargetLabels: () => Promise.reject(new Error('method not found')),
+      getState: () => Promise.resolve(null)
+    })
+
+    registerDirectSshStateIpcBridge(unsubs, bridgeRuntime())
+    await settle()
+
+    // Older paired hosts lack the RPC; the target list is the evidence that matters and must survive.
+    expect(useAppStore.getState().sshTargetLabels.get('ssh-live')).toBe('devbox')
+    expect(useAppStore.getState().sshTargetsHydrated).toBe(true)
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it('hydrates later targets when one target state lookup fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    stubWindow({
+      listTargets: () =>
+        Promise.resolve([
+          { id: 'ssh-unreachable', label: 'unreachable' },
+          { id: 'ssh-second', label: 'second' }
+        ]),
+      listRemovedTargetLabels: () => Promise.resolve({}),
+      getState: ({ targetId }) =>
+        targetId === 'ssh-unreachable'
+          ? Promise.reject(new Error('ssh state lookup timed out'))
+          : Promise.resolve(connectingState(targetId))
+    })
+
+    registerDirectSshStateIpcBridge(unsubs, bridgeRuntime())
+    await settle()
+
+    const state = useAppStore.getState()
+    expect(state.sshConnectionStates.get('ssh-second')?.status).toBe('connecting')
+    // A lookup that threw observes nothing: no synthesized state for the unreachable target.
+    expect(state.sshConnectionStates.has('ssh-unreachable')).toBe(false)
+    expect(warn).toHaveBeenCalled()
+  })
+
+  it('hydrates the target list without waiting on the removed-labels round trip', async () => {
+    stubWindow({
+      listTargets: () => Promise.resolve([{ id: 'ssh-live', label: 'devbox' }]),
+      // A wedged relay never answers the tombstone RPC; the loaded list is still evidence.
+      listRemovedTargetLabels: () => new Promise(() => {}),
+      getState: () => Promise.resolve(null)
+    })
+
+    registerDirectSshStateIpcBridge(unsubs, bridgeRuntime())
+    await settle()
+
+    expect({
+      label: useAppStore.getState().sshTargetLabels.get('ssh-live'),
+      hydrated: useAppStore.getState().sshTargetsHydrated
+    }).toEqual({ label: 'devbox', hydrated: true })
+  })
+
+  it('does not clobber a target that landed while removed labels were in flight', async () => {
+    let resolveRemovedLabels!: (labels: Record<string, string>) => void
+    let listTargetsCalls = 0
+    stubWindow({
+      listTargets: () => {
+        listTargetsCalls += 1
+        return Promise.resolve(
+          listTargetsCalls === 1
+            ? [{ id: 'ssh-alpha', label: 'alpha' }]
+            : [
+                { id: 'ssh-alpha', label: 'alpha' },
+                { id: 'ssh-bravo', label: 'bravo' }
+              ]
+        )
+      },
+      listRemovedTargetLabels: () =>
+        new Promise((resolve) => {
+          resolveRemovedLabels = resolve
+        }),
+      getState: () => Promise.resolve(null)
+    })
+
+    registerDirectSshStateIpcBridge(unsubs, bridgeRuntime())
+    await settle()
+
+    // A target added during the tombstone round trip pushes state and re-queries the list.
+    onStateChangedHandler?.({ targetId: 'ssh-bravo', state: connectingState('ssh-bravo') })
+    await settle()
+
+    resolveRemovedLabels({})
+    await settle()
+
+    const state = useAppStore.getState()
+    expect({
+      label: state.sshTargetLabels.get('ssh-bravo'),
+      hydrated: state.sshTargetsHydrated,
+      removed: selectRuntimeAwareSshTargetRemoved(state, null, 'ssh-bravo')
+    }).toEqual({ label: 'bravo', hydrated: true, removed: false })
+  })
+})

--- a/src/renderer/src/hooks/ipc-events/direct-ssh-initial-state-hydration.ts
+++ b/src/renderer/src/hooks/ipc-events/direct-ssh-initial-state-hydration.ts
@@ -1,0 +1,61 @@
+import type { SshConnectionState } from '../../../../shared/ssh-types'
+import { useAppStore } from '../../store'
+import type { DirectSshBridgeRuntime } from './direct-ssh-bridge-runtime'
+
+/** Why: an unanswered ssh.getState burns the full 30s runtime-RPC timeout, so a serial walk
+ * makes the last target wait (N-1) timeouts; a small pool keeps a wedged target from blocking
+ * the rest without bursting the IPC/runtime-RPC queue on a large imported target list. */
+const HYDRATION_FANOUT = 4
+
+export async function hydrateDirectSshInitialState(
+  runtime: DirectSshBridgeRuntime,
+  watermarkByTargetId: ReadonlyMap<string, number>,
+  applySshConnectionStateChange: (targetId: string, state: SshConnectionState) => void
+): Promise<void> {
+  try {
+    const targets = await window.api.ssh.listTargets()
+    if (runtime.isStopped()) {
+      return
+    }
+    // Why: the loaded list is the hydration evidence (#9911) — never gate it behind the
+    // best-effort tombstone RPC, whose await also lets concurrent target writes land.
+    useAppStore.getState().setSshTargetsMetadata(targets)
+    try {
+      const removedLabels = await window.api.ssh.listRemovedTargetLabels()
+      if (runtime.isStopped()) {
+        return
+      }
+      useAppStore.getState().setRemovedSshTargetLabels(removedLabels)
+    } catch (error) {
+      // Best-effort: a host without this RPC still gets its target list.
+      console.warn('[direct-ssh] failed to load removed SSH target labels:', error)
+    }
+    let nextIndex = 0
+    const drainTargets = async (): Promise<void> => {
+      while (nextIndex < targets.length && !runtime.isStopped()) {
+        const target = targets[nextIndex]
+        nextIndex += 1
+        const hydrationWatermark = watermarkByTargetId.get(target.id) ?? 0
+        try {
+          const state = await window.api.ssh.getState({ targetId: target.id })
+          if (
+            !runtime.isStopped() &&
+            state &&
+            (watermarkByTargetId.get(target.id) ?? 0) === hydrationWatermark
+          ) {
+            applySshConnectionStateChange(target.id, state as SshConnectionState)
+          }
+        } catch (error) {
+          // Why: a lookup that threw observed nothing, so this target stays unverifiable —
+          // never synthesize a status, and never abandon the targets queued behind it.
+          console.warn(`[direct-ssh] failed to hydrate SSH state for ${target.id}:`, error)
+        }
+      }
+    }
+    await Promise.all(
+      Array.from({ length: Math.min(HYDRATION_FANOUT, targets.length) }, drainTargets)
+    )
+  } catch (error) {
+    console.warn('[direct-ssh] failed to hydrate SSH targets:', error)
+  }
+}

--- a/src/renderer/src/hooks/ipc-events/direct-ssh-initial-state-hydration.ts
+++ b/src/renderer/src/hooks/ipc-events/direct-ssh-initial-state-hydration.ts
@@ -20,16 +20,18 @@ export async function hydrateDirectSshInitialState(
     // Why: the loaded list is the hydration evidence (#9911) — never gate it behind the
     // best-effort tombstone RPC, whose await also lets concurrent target writes land.
     useAppStore.getState().setSshTargetsMetadata(targets)
-    try {
-      const removedLabels = await window.api.ssh.listRemovedTargetLabels()
-      if (runtime.isStopped()) {
-        return
+    const hydrateRemovedLabels = async (): Promise<void> => {
+      try {
+        const removedLabels = await window.api.ssh.listRemovedTargetLabels()
+        if (!runtime.isStopped()) {
+          useAppStore.getState().setRemovedSshTargetLabels(removedLabels)
+        }
+      } catch (error) {
+        // Best-effort: a host without this RPC still gets its target list.
+        console.warn('[direct-ssh] failed to load removed SSH target labels:', error)
       }
-      useAppStore.getState().setRemovedSshTargetLabels(removedLabels)
-    } catch (error) {
-      // Best-effort: a host without this RPC still gets its target list.
-      console.warn('[direct-ssh] failed to load removed SSH target labels:', error)
     }
+    void hydrateRemovedLabels()
     let nextIndex = 0
     const drainTargets = async (): Promise<void> => {
       while (nextIndex < targets.length && !runtime.isStopped()) {

--- a/src/renderer/src/hooks/ipc-events/direct-ssh-state-ipc-bridge.ts
+++ b/src/renderer/src/hooks/ipc-events/direct-ssh-state-ipc-bridge.ts
@@ -9,6 +9,7 @@ import {
   type DirectSshConnectedStateOrigin
 } from '../direct-ssh-state-routing'
 import type { DirectSshBridgeRuntime } from './direct-ssh-bridge-runtime'
+import { hydrateDirectSshInitialState } from './direct-ssh-initial-state-hydration'
 export function registerDirectSshStateIpcBridge(
   unsubs: (() => void)[],
   runtime: DirectSshBridgeRuntime
@@ -54,33 +55,9 @@ export function registerDirectSshStateIpcBridge(
     state: SshConnectionState,
     origin: DirectSshConnectedStateOrigin
   ) => void
-  void (async () => {
-    try {
-      const targets = await window.api.ssh.listTargets()
-      if (runtime.isStopped()) {
-        return
-      }
-      useAppStore.getState().setSshTargetsMetadata(targets)
-      try {
-        const removedLabels = await window.api.ssh.listRemovedTargetLabels()
-        if (runtime.isStopped()) {
-          return
-        }
-        useAppStore.getState().setRemovedSshTargetLabels(removedLabels)
-      } catch {}
-      for (const target of targets) {
-        const hydrationWatermark = sshStateWatermarkByTargetId.get(target.id) ?? 0
-        const state = await window.api.ssh.getState({ targetId: target.id })
-        if (
-          !runtime.isStopped() &&
-          state &&
-          (sshStateWatermarkByTargetId.get(target.id) ?? 0) === hydrationWatermark
-        ) {
-          applySshConnectionStateChange(target.id, state as SshConnectionState, 'initial-hydration')
-        }
-      }
-    } catch {}
-  })()
+  void hydrateDirectSshInitialState(runtime, sshStateWatermarkByTargetId, (targetId, state) =>
+    applySshConnectionStateChange(targetId, state, 'initial-hydration')
+  )
   unsubs.push(
     window.api.ssh.onCredentialRequest((data) => {
       useAppStore.getState().enqueueSshCredentialRequest(data)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​345 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​345 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​69 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​28 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​41 |

<!-- /orca-pr-loc -->

## Description

`direct-ssh-state-ipc-bridge.ts` had a bare `catch {}` that left the store **half-written**, and the two halves are not independent — one of them is read as *evidence of removal*.

`setSshTargetsMetadata(targets)` ran **before** awaiting the tombstone fetch `ssh.listRemovedTargetLabels`. So for the whole round trip — and permanently, on failure — the store sat with `sshTargetsHydrated: true` and `removedSshTargetLabels` empty.

That combination is not neutral:
- `selectRuntimeAwareSshTargetRemoved` (`store/slices/runtime-environment-ssh.ts:346`) treats *"hydrated target list that lacks this id"* as **positive removal evidence**.
- `selectRuntimeAwareSshTargetLabel` needs the tombstone map to name it.

So the app asserts **"this host was removed"** while it can only print the raw `ssh-<ts>-<rand>` id.

**User-visible in:** `ForgetSshWorkspaceDialog` / `RemoveFolderDialog` titles, the `WorktreeCardSshHostControl` ghost glyph, `TerminalSshReconnectOverlay`, and the settings host-setup rows. The confirmed symptom is a removal claim rendered with a raw target id, flipping to the real name once the round trip lands — or staying raw forever if it never does.

This was found while hunting React #185, but it stands entirely on its own — an adversarial reviewer called it *"the one product defect this lane surfaced that stands up without the loop story."*

## Fix evidence

**BEFORE** (test written first):
```
FAIL direct-ssh-hydration-target-metadata.test.ts
  > never claims a target was removed before its tombstone label is in the store
AssertionError: expected { removed: true, label: 'ssh-ghost' }
              to deeply equal { removed: false, label: 'ssh-ghost' }
  -   "removed": false,
  +   "removed": true,
```
That is the bug stated precisely: the app claims removal it has no evidence for.

**AFTER:** all suites green (pre-fix state was 2 failed files / 3 failed of 7).

## ELI5

Two facts arrive separately: *which hosts exist* and *what the deleted ones were called*. The code wrote down the first, then went to fetch the second — and if that trip failed, it just shrugged and moved on.

But the app reads "not in the list of hosts that exist" as **proof a host was deleted**. So after a failed trip it would confidently tell you a host was removed, while only being able to call it by a meaningless internal id.

Now both facts land together or neither does, and a failed trip says so out loud instead of shrugging.

## Trade-offs

- **A new store action, not just reordering two `set` calls.** Adjacent writes are atomic enough for React's auto-batching, but a plain `useAppStore.subscribe` listener still observes the intermediate state. A single `set` is the only genuinely atomic option, and it puts the invariant where the next caller can reuse it. Cost: `setSshTargetMetadataSnapshot: vi.fn()` added to four mocked-store fixtures.
- **`setSshTargetsMetadata` is kept** — the push path (`handleSshStateChangedEvent`) and three components use it legitimately with no tombstone fetch.
- **New `console.warn` once per hydration pass** for a paired client on a host without the `ssh.listRemovedTargetLabels` RPC. Intentional — it is exactly the diagnostic the empty catch was hiding — and it stays out of the UI.
- **Failure ordering is still "targets survive, tombstones may not."** Fully all-or-nothing would mean losing the target list too, which is worse.
- **SSH boundary** (`docs/reference/ssh-execution-boundary.md`): the point of this fix is that loss of contact must not be rendered as a removal verdict. That is precisely the conflation being removed.

## Perf

`/perf` caught a real regression **introduced by the first cut of this fix**: it turned a short-circuiting hydration loop into a walk-all loop while leaving it serially awaited, so worst-case hydration latency grew from one runtime-RPC timeout to N of them. Fixed with a bounded fanout pool — **measured 204 ms → 53 ms at 8 targets**. Rest of the diff has no meaningful impact.

## Adversarial review

**Clean after 3 loops.**
