### PR TITLE
draft(renderer): stop swallowed React #185 errors from keeping a render loop alive

### DIFF
--- a/src/main/ipc/crash-reporting-renderer-error-report.ts
+++ b/src/main/ipc/crash-reporting-renderer-error-report.ts
@@ -1,8 +1,9 @@
 import os from 'node:os'
 import { app } from 'electron'
-import type {
-  ReactErrorBoundaryReportArgs,
-  ReactErrorBoundaryReportResult
+import {
+  RENDERER_ERROR_DEDUPE_MS,
+  type ReactErrorBoundaryReportArgs,
+  type ReactErrorBoundaryReportResult
 } from '../../shared/crash-reporting'
 import {
   CRASH_REPORT_ATTRIBUTION_DETAIL_KEY,
@@ -16,7 +17,6 @@ import { getCrashBreadcrumbSnapshot } from '../crash-reporting/crash-breadcrumb-
 
 export const recentRendererErrorReportKeys = new Map<string, number>()
 
-const RENDERER_ERROR_DEDUPE_MS = 10 * 60 * 1000
 const MAX_RENDERER_ERROR_KEY_AGE_MS = RENDERER_ERROR_DEDUPE_MS * 2
 const MAX_RECENT_RENDERER_ERROR_REPORT_KEYS = 256
 

--- a/src/renderer/src/app-shell/use-app-startup-hydration.ts
+++ b/src/renderer/src/app-shell/use-app-startup-hydration.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { syncZoomCSSVar } from '@/lib/ui-zoom'
+import { escalateReactUpdateDepthError } from '@/lib/react-update-depth-escalation'
 import { installCodexDetachedPaneRestartExecutor } from '@/components/terminal-pane/codex-detached-pane-restart-scheduler'
 import { useAppStore } from '../store'
 import { WORKTREE_REFRESH_CONCURRENCY } from '../store/slices/worktrees'
@@ -33,6 +34,9 @@ import {
 } from '../../../shared/execution-host'
 import { mapWithConcurrency } from '../../../shared/map-with-concurrency'
 import type { OnboardingState } from '../../../shared/onboarding-state-types'
+
+const STARTUP_CATALOG_REFRESH_CATCH = 'startup-hydration.remote-catalog-refresh'
+const STARTUP_WORKTREE_REFRESH_CATCH = 'startup-hydration.deferred-worktree-refresh'
 
 async function listRuntimeSessionHostIdsForStartup(): Promise<ExecutionHostId[]> {
   try {
@@ -297,7 +301,10 @@ export function useAppStartupHydration(onOnboardingLoaded: (state: OnboardingSta
                   await actions.fetchFolderWorkspacesForAllHosts()
                 })
               } catch (err) {
-                console.warn('Remote startup catalog refresh failed:', err)
+                // A console.warn is no signal: a #185 swallowed here half-completes startup.
+                if (!escalateReactUpdateDepthError(err, STARTUP_CATALOG_REFRESH_CATCH)) {
+                  console.warn('Remote startup catalog refresh failed:', err)
+                }
               }
               if (!cancelled) {
                 try {
@@ -311,7 +318,9 @@ export function useAppStartupHydration(onOnboardingLoaded: (state: OnboardingSta
                     await actions.fetchWorktreeLineage()
                   })
                 } catch (err) {
-                  console.warn('Deferred startup worktree refresh failed:', err)
+                  if (!escalateReactUpdateDepthError(err, STARTUP_WORKTREE_REFRESH_CATCH)) {
+                    console.warn('Deferred startup worktree refresh failed:', err)
+                  }
                 }
               }
             } finally {

--- a/src/renderer/src/components/git-provider-rate-limit-update-depth-parity.test.tsx
+++ b/src/renderer/src/components/git-provider-rate-limit-update-depth-parity.test.tsx
@@ -1,0 +1,122 @@
+// @vitest-environment happy-dom
+
+/**
+ * Provider parity: both rate-limit hooks must escalate React #185 rather than paint it as a
+ * provider outage. A GitHub-only guard would leave GitLab users unprotected.
+ */
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useGitHubRateLimitSnapshot } from './github/github-rate-limit-display'
+import { useGitLabRateLimitSnapshot } from './gitlab/gitlab-rate-limit-display'
+import { clearReactErrorBoundaryReportingForTest } from '@/lib/react-error-boundary-reporting'
+import {
+  flushReactUpdateDepthEscalationsForTest,
+  resetReactUpdateDepthEscalationForTest
+} from '@/lib/react-update-depth-escalation'
+
+const REACT_185 =
+  'Minified React error #185; visit https://react.dev/errors/185 for the full message.'
+
+const mockStoreState = {
+  settings: {},
+  activeView: 'settings',
+  activeModal: 'settings',
+  activeTabType: null,
+  rightSidebarTab: null,
+  activeWorktreeId: null
+}
+
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign((selector: (state: unknown) => unknown) => selector(mockStoreState), {
+    getState: () => mockStoreState
+  })
+}))
+
+vi.mock('@/runtime/runtime-rpc-client', () => ({
+  getActiveRuntimeTarget: () => ({ kind: 'local' }),
+  callRuntimeRpc: vi.fn()
+}))
+
+const recordRendererError = vi.fn()
+const ghRateLimit = vi.fn()
+const glRateLimit = vi.fn()
+const roots: Root[] = []
+
+type HookResult = { hasError: boolean }
+
+function renderHook(useHook: () => HookResult): { current: HookResult | null } {
+  const ref: { current: HookResult | null } = { current: null }
+  function Probe(): null {
+    ref.current = useHook()
+    return null
+  }
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  roots.push(root)
+  act(() => {
+    root.render(<Probe />)
+  })
+  return ref
+}
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  recordRendererError.mockReset()
+  recordRendererError.mockResolvedValue({ ok: true, report: null, deduped: false })
+  ghRateLimit.mockReset().mockRejectedValue(new Error(REACT_185))
+  glRateLimit.mockReset().mockRejectedValue(new Error(REACT_185))
+  resetReactUpdateDepthEscalationForTest()
+  clearReactErrorBoundaryReportingForTest()
+  Object.assign(globalThis.window, {
+    api: {
+      gh: { rateLimit: ghRateLimit },
+      gl: { rateLimit: glRateLimit },
+      crashReports: { recordRendererError }
+    }
+  })
+})
+
+afterEach(() => {
+  act(() => {
+    for (const root of roots.splice(0)) {
+      root.unmount()
+    }
+  })
+})
+
+describe.each([
+  ['github', () => useGitHubRateLimitSnapshot({ autoRefresh: false })],
+  ['gitlab', () => useGitLabRateLimitSnapshot({ autoRefresh: false })]
+])('%s rate limit refresh', (provider, useHook) => {
+  it('escalates React #185 instead of reporting a provider error', async () => {
+    const hook = renderHook(useHook as () => HookResult)
+
+    await act(async () => {
+      await (hook.current as unknown as { refresh: () => Promise<void> }).refresh()
+    })
+    await flushReactUpdateDepthEscalationsForTest()
+
+    expect(hook.current?.hasError).toBe(false)
+    expect(recordRendererError).toHaveBeenCalledTimes(1)
+    expect(recordRendererError.mock.calls[0]?.[0]?.boundaryId).toContain(
+      `${provider}-rate-limit-display.refreshSnapshot`
+    )
+    expect(recordRendererError.mock.calls[0]?.[0]?.attribution).toBe('unreliable')
+  })
+
+  it('still reports an ordinary provider failure', async () => {
+    ghRateLimit.mockRejectedValue(new Error('gh: HTTP 503'))
+    glRateLimit.mockRejectedValue(new Error('glab: HTTP 503'))
+    const hook = renderHook(useHook as () => HookResult)
+
+    await act(async () => {
+      await (hook.current as unknown as { refresh: () => Promise<void> }).refresh()
+    })
+
+    expect(hook.current?.hasError).toBe(true)
+    expect(recordRendererError).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/github/github-rate-limit-display.tsx
+++ b/src/renderer/src/components/github/github-rate-limit-display.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { Gauge, RefreshCw } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { installWindowVisibilityInterval } from '@/lib/window-visibility-interval'
+import { escalateReactUpdateDepthError } from '@/lib/react-update-depth-escalation'
 import { useAppStore } from '@/store'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import type {
@@ -13,6 +14,7 @@ import { ProviderHostScopeControl } from '@/components/settings/ProviderHostScop
 import { translate } from '@/i18n/i18n'
 
 const REFRESH_INTERVAL_MS = 60_000
+const GITHUB_RATE_LIMIT_CATCH = 'github-rate-limit-display.refreshSnapshot'
 
 type BucketKey = 'core' | 'search' | 'graphql'
 
@@ -110,7 +112,12 @@ export function useGitHubRateLimitSnapshot(options?: { autoRefresh?: boolean }):
         } else {
           setHasError(true)
         }
-      } catch {
+      } catch (error) {
+        // Why first: the call can succeed and setSnapshot still throw #185; hasError would
+        // then read as a provider outage. Guarded on both providers by repo parity rule.
+        if (escalateReactUpdateDepthError(error, GITHUB_RATE_LIMIT_CATCH)) {
+          return
+        }
         if (token === latestToken.current) {
           setHasError(true)
         }

--- a/src/renderer/src/components/gitlab/gitlab-rate-limit-display.tsx
+++ b/src/renderer/src/components/gitlab/gitlab-rate-limit-display.tsx
@@ -3,6 +3,7 @@ import { Gauge, RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { installWindowVisibilityInterval } from '@/lib/window-visibility-interval'
+import { escalateReactUpdateDepthError } from '@/lib/react-update-depth-escalation'
 import { useAppStore } from '@/store'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import type {
@@ -14,6 +15,7 @@ import { ProviderHostScopeControl } from '@/components/settings/ProviderHostScop
 import { translate } from '@/i18n/i18n'
 
 const REFRESH_INTERVAL_MS = 60_000
+const GITLAB_RATE_LIMIT_CATCH = 'gitlab-rate-limit-display.refreshSnapshot'
 
 export function formatGitLabRateLimitReset(resetAt: number | null): string {
   if (resetAt === null) {
@@ -79,7 +81,12 @@ export function useGitLabRateLimitSnapshot(options?: { autoRefresh?: boolean }):
         } else {
           setHasError(true)
         }
-      } catch {
+      } catch (error) {
+        // Why first: the call can succeed and setSnapshot still throw #185; hasError would
+        // then read as a provider outage. Guarded on both providers by repo parity rule.
+        if (escalateReactUpdateDepthError(error, GITLAB_RATE_LIMIT_CATCH)) {
+          return
+        }
         if (token === latestToken.current) {
           setHasError(true)
         }

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.react185.test.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.react185.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment happy-dom
+
+/**
+ * openSetupTerminal awaits a caller-supplied onBeforeOpenTerminal that does setState-bearing work,
+ * so it is a landing site for React's nested-update throw. Its catch was written for setup failures.
+ */
+
+import { act, type ComponentProps } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { AgentSkillSetupPanel } from './AgentSkillSetupPanel'
+import { TooltipProvider } from '../ui/tooltip'
+import { clearReactErrorBoundaryReportingForTest } from '@/lib/react-error-boundary-reporting'
+import {
+  flushReactUpdateDepthEscalationsForTest,
+  resetReactUpdateDepthEscalationForTest
+} from '@/lib/react-update-depth-escalation'
+
+const REACT_185 =
+  'Minified React error #185; visit https://react.dev/errors/185 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.'
+
+const mockStoreState = {
+  activeView: 'settings',
+  activeModal: 'settings',
+  activeTabType: null,
+  rightSidebarTab: null,
+  activeWorktreeId: null
+}
+
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign((selector: (state: unknown) => unknown) => selector(mockStoreState), {
+    getState: () => mockStoreState
+  })
+}))
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+vi.mock('../onboarding/OnboardingInlineCommandTerminal', () => ({
+  OnboardingInlineCommandTerminal: (props: { command: string }) => (
+    <div data-testid="inline-command-terminal">{props.command}</div>
+  )
+}))
+
+const recordRendererError = vi.fn()
+const roots: Root[] = []
+let container: HTMLDivElement | null = null
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  recordRendererError.mockReset()
+  recordRendererError.mockResolvedValue({ ok: true, report: null, deduped: false })
+  resetReactUpdateDepthEscalationForTest()
+  clearReactErrorBoundaryReportingForTest()
+  Object.assign(globalThis.window, {
+    api: {
+      cli: { getInstallStatus: vi.fn().mockResolvedValue({ installed: true, inPath: true }) },
+      ui: { writeClipboardText: vi.fn() },
+      platform: { get: () => ({ platform: 'darwin' }) },
+      crashReports: { recordRendererError }
+    }
+  })
+})
+
+afterEach(() => {
+  act(() => {
+    for (const root of roots.splice(0)) {
+      root.unmount()
+    }
+  })
+  container?.remove()
+  container = null
+})
+
+function panelProps(
+  overrides: Partial<ComponentProps<typeof AgentSkillSetupPanel>> = {}
+): ComponentProps<typeof AgentSkillSetupPanel> {
+  return {
+    title: 'CLI skill',
+    description: 'Enables agents to use Orca workflows.',
+    command: 'npx skills add orca-cli --global',
+    terminalTitle: 'CLI skill setup',
+    terminalAriaLabel: 'CLI skill install terminal',
+    terminalWorktreeId: 'settings-cli-skill-terminal',
+    installed: false,
+    loading: false,
+    error: null,
+    onRecheck: vi.fn(),
+    ...overrides
+  }
+}
+
+async function renderPanel(
+  overrides: Partial<ComponentProps<typeof AgentSkillSetupPanel>> = {}
+): Promise<HTMLDivElement> {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  roots.push(root)
+  await act(async () => {
+    root.render(
+      <TooltipProvider>
+        <AgentSkillSetupPanel {...panelProps(overrides)} />
+      </TooltipProvider>
+    )
+  })
+  await act(async () => {})
+  return container
+}
+
+async function clickInstall(): Promise<void> {
+  const button = Array.from((container ?? document.body).querySelectorAll('button')).find(
+    (candidate) => candidate.textContent?.trim() === 'Install'
+  )
+  expect(button).toBeDefined()
+  await act(async () => {
+    button?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+  await act(async () => {})
+}
+
+describe('AgentSkillSetupPanel open-terminal catch', () => {
+  it('escalates a React #185 thrown by onBeforeOpenTerminal', async () => {
+    await renderPanel({
+      onBeforeOpenTerminal: async () => {
+        throw new Error(REACT_185)
+      }
+    })
+    await clickInstall()
+    await flushReactUpdateDepthEscalationsForTest()
+
+    expect(recordRendererError).toHaveBeenCalledTimes(1)
+    expect(recordRendererError.mock.calls[0]?.[0]?.attribution).toBe('unreliable')
+    expect(recordRendererError.mock.calls[0]?.[0]?.boundaryId).toContain('AgentSkillSetupPanel')
+  })
+
+  it('escalates a React #185 thrown while applying the pre-install notice', async () => {
+    await renderPanel({
+      preInstallNotice: <span>Install the Orca CLI first.</span>,
+      getPrerequisiteStatus: vi.fn().mockRejectedValue(new Error(REACT_185))
+    })
+    await flushReactUpdateDepthEscalationsForTest()
+
+    expect(recordRendererError).toHaveBeenCalledTimes(1)
+  })
+
+  it('still swallows an ordinary onBeforeOpenTerminal failure without opening the terminal', async () => {
+    await renderPanel({
+      onBeforeOpenTerminal: async () => {
+        throw new Error('runtime unavailable')
+      }
+    })
+    await clickInstall()
+    await flushReactUpdateDepthEscalationsForTest()
+
+    expect(container?.querySelector('[data-testid="inline-command-terminal"]')).toBeNull()
+    expect(recordRendererError).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
@@ -20,6 +20,7 @@ import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
 
 const PRE_INSTALL_NOTICE_CATCH = 'settings.AgentSkillSetupPanel.applyPreInstallNotice'
+const OPEN_TERMINAL_CATCH = 'settings.AgentSkillSetupPanel.openSetupTerminal'
 
 export function AgentSkillSetupPanel({
   title,
@@ -97,7 +98,9 @@ export function AgentSkillSetupPanel({
         await onBeforeOpenTerminal?.()
         await refreshPreInstallNotice()
         shouldOpenTerminal = true
-      } catch {
+      } catch (error) {
+        // onBeforeOpenTerminal is caller-supplied setState-bearing work, so #185 lands here too.
+        escalateReactUpdateDepthError(error, OPEN_TERMINAL_CATCH)
         shouldOpenTerminal = false
       } finally {
         if (mountedRef.current) {
@@ -151,7 +154,7 @@ export function AgentSkillSetupPanel({
           setPreInstallNoticeVisible(!isPrerequisiteAvailable(status))
         }
       } catch (error) {
-        // Why first: openSetupTerminal awaits this too, and its catch would swallow it again.
+        // Why first: the notice below is a setState that would feed the same runaway loop.
         if (escalateReactUpdateDepthError(error, PRE_INSTALL_NOTICE_CATCH)) {
           return
         }

--- a/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
+++ b/src/renderer/src/components/settings/AgentSkillSetupPanel.tsx
@@ -15,8 +15,11 @@ import {
   syncSurfacesAfterAgentSkillRecheck
 } from './agent-skill-recheck-surface-sync'
 import { isOrcaCliAvailableOnPath } from '@/lib/agent-skill-cli-prerequisite'
+import { escalateReactUpdateDepthError } from '@/lib/react-update-depth-escalation'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
+
+const PRE_INSTALL_NOTICE_CATCH = 'settings.AgentSkillSetupPanel.applyPreInstallNotice'
 
 export function AgentSkillSetupPanel({
   title,
@@ -138,6 +141,28 @@ export function AgentSkillSetupPanel({
     void (shouldRecheck && recheckSurfacesAfterAgentSkillTerminal(onRecheck, freshnessSkillName))
   }, [freshnessSkillName, mountedRef, onRecheck])
 
+  // Why shared: the focus listener and the pre-terminal refresh ran the same probe with
+  // different liveness guards, so one #185 escalation now covers both callers.
+  const applyPreInstallNotice = useCallback(
+    async (isLive: () => boolean): Promise<void> => {
+      try {
+        const status = await readPrerequisiteStatus()
+        if (isLive()) {
+          setPreInstallNoticeVisible(!isPrerequisiteAvailable(status))
+        }
+      } catch (error) {
+        // Why first: openSetupTerminal awaits this too, and its catch would swallow it again.
+        if (escalateReactUpdateDepthError(error, PRE_INSTALL_NOTICE_CATCH)) {
+          return
+        }
+        if (isLive()) {
+          setPreInstallNoticeVisible(true)
+        }
+      }
+    },
+    [isPrerequisiteAvailable, readPrerequisiteStatus]
+  )
+
   useEffect(() => {
     if (!preInstallNotice) {
       setPreInstallNoticeVisible(false)
@@ -145,18 +170,7 @@ export function AgentSkillSetupPanel({
     }
 
     let canceled = false
-    const refreshCliNotice = async (): Promise<void> => {
-      try {
-        const status = await readPrerequisiteStatus()
-        if (!canceled) {
-          setPreInstallNoticeVisible(!isPrerequisiteAvailable(status))
-        }
-      } catch {
-        if (!canceled) {
-          setPreInstallNoticeVisible(true)
-        }
-      }
-    }
+    const refreshCliNotice = (): Promise<void> => applyPreInstallNotice(() => !canceled)
 
     void refreshCliNotice()
     window.addEventListener('focus', refreshCliNotice)
@@ -164,21 +178,11 @@ export function AgentSkillSetupPanel({
       canceled = true
       window.removeEventListener('focus', refreshCliNotice)
     }
-  }, [isPrerequisiteAvailable, preInstallNotice, readPrerequisiteStatus])
+  }, [applyPreInstallNotice, preInstallNotice])
 
   const refreshPreInstallNotice = async (): Promise<void> => {
-    if (!preInstallNotice) {
-      return
-    }
-    try {
-      const status = await readPrerequisiteStatus()
-      if (mountedRef.current) {
-        setPreInstallNoticeVisible(!isPrerequisiteAvailable(status))
-      }
-    } catch {
-      if (mountedRef.current) {
-        setPreInstallNoticeVisible(true)
-      }
+    if (preInstallNotice) {
+      await applyPreInstallNotice(() => mountedRef.current)
     }
   }
 

--- a/src/renderer/src/components/settings/ReleaseChannelSection.react185.test.tsx
+++ b/src/renderer/src/components/settings/ReleaseChannelSection.react185.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment happy-dom
+
+/**
+ * Field sighting: #185 rendered as red inline text under the build picker while the app crawled.
+ * That text was `loadError`, not a boundary fallback — loadBuilds' catch swallowed the throw.
+ */
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ReleaseChannelSection } from './ReleaseChannelSection'
+import { TooltipProvider } from '../ui/tooltip'
+import { clearReactErrorBoundaryReportingForTest } from '@/lib/react-error-boundary-reporting'
+import {
+  flushReactUpdateDepthEscalationsForTest,
+  resetReactUpdateDepthEscalationForTest
+} from '@/lib/react-update-depth-escalation'
+
+const REACT_185 =
+  'Minified React error #185; visit https://react.dev/errors/185 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.'
+
+const mockStoreState = {
+  updateStatus: { state: 'idle' as const },
+  releaseChannelOverride: null,
+  setReleaseChannelOverride: vi.fn(),
+  activeView: 'settings',
+  activeModal: 'settings',
+  activeTabType: null,
+  rightSidebarTab: null,
+  activeWorktreeId: null
+}
+
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign((selector: (state: unknown) => unknown) => selector(mockStoreState), {
+    getState: () => mockStoreState
+  })
+}))
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }))
+
+const recordRendererError = vi.fn()
+const listBuilds = vi.fn()
+const roots: Root[] = []
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  recordRendererError.mockReset()
+  recordRendererError.mockResolvedValue({ ok: true, report: null, deduped: false })
+  listBuilds.mockReset()
+  resetReactUpdateDepthEscalationForTest()
+  clearReactErrorBoundaryReportingForTest()
+  Object.assign(globalThis.window, {
+    api: {
+      updater: {
+        getVersion: vi.fn().mockResolvedValue('1.4.163'),
+        listBuilds
+      },
+      crashReports: { recordRendererError }
+    }
+  })
+})
+
+afterEach(() => {
+  act(() => {
+    for (const root of roots.splice(0)) {
+      root.unmount()
+    }
+  })
+})
+
+async function render(): Promise<HTMLDivElement> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  roots.push(root)
+  await act(async () => {
+    root.render(
+      <TooltipProvider>
+        <ReleaseChannelSection />
+      </TooltipProvider>
+    )
+  })
+  return container
+}
+
+describe('ReleaseChannelSection build load', () => {
+  it('escalates a swallowed React #185 instead of painting it as a load error', async () => {
+    listBuilds.mockRejectedValue(new Error(REACT_185))
+
+    const container = await render()
+    await flushReactUpdateDepthEscalationsForTest()
+
+    expect(container.textContent).not.toContain('Minified React error #185')
+    expect(recordRendererError).toHaveBeenCalledTimes(1)
+    expect(recordRendererError.mock.calls[0]?.[0]?.attribution).toBe('unreliable')
+    expect(recordRendererError.mock.calls[0]?.[0]?.boundaryId).toContain('ReleaseChannelSection')
+  })
+
+  it('still shows an ordinary load failure inline', async () => {
+    listBuilds.mockRejectedValue(new Error('getaddrinfo ENOTFOUND api.github.com'))
+
+    const container = await render()
+    await flushReactUpdateDepthEscalationsForTest()
+
+    expect(container.textContent).toContain('getaddrinfo ENOTFOUND api.github.com')
+    expect(recordRendererError).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/settings/ReleaseChannelSection.tsx
+++ b/src/renderer/src/components/settings/ReleaseChannelSection.tsx
@@ -9,6 +9,7 @@ import { SettingsSegmentedControl, SettingsSubsectionHeader } from './SettingsFo
 import { Badge } from '../ui/badge'
 import { translate } from '@/i18n/i18n'
 import { getShortcutPlatform } from '@/lib/shortcut-platform'
+import { escalateReactUpdateDepthError } from '@/lib/react-update-depth-escalation'
 import {
   DEV_CHANNEL_PLATFORM_LABEL,
   RELEASE_CHANNELS,
@@ -22,6 +23,8 @@ import {
   type ReleaseBuild,
   type ReleaseChannel
 } from '../../../../shared/release-channel'
+
+const LOAD_BUILDS_CATCH = 'settings.ReleaseChannelSection.loadBuilds'
 
 const CHANNEL_DESCRIPTIONS: Record<ReleaseChannel, string> = {
   stable: 'Shipped releases. What everyone else is running.',
@@ -135,6 +138,11 @@ export function ReleaseChannelSection(): React.JSX.Element {
         setLoadError(result.message)
       }
     } catch (error) {
+      // Why first: listBuilds can succeed and the setState above it still throw React #185.
+      // Painting that as loadError showed the digest as red inline copy under "No builds found".
+      if (escalateReactUpdateDepthError(error, LOAD_BUILDS_CATCH)) {
+        return
+      }
       if (isStale()) {
         return
       }

--- a/src/renderer/src/components/settings/RuntimeEnvironmentsPane.react185.test.tsx
+++ b/src/renderer/src/components/settings/RuntimeEnvironmentsPane.react185.test.tsx
@@ -1,0 +1,193 @@
+// @vitest-environment happy-dom
+
+/**
+ * The probe seeds every row with `status: 'loading'` and only the probe's own continuation clears it.
+ * A #185 escalation returns from that continuation, so without a compensating write the row spins
+ * "Checking…" for the rest of the session — asserting a probe that is not running.
+ */
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RuntimeEnvironmentsPane } from './RuntimeEnvironmentsPane'
+import { TooltipProvider } from '../ui/tooltip'
+import { clearReactErrorBoundaryReportingForTest } from '@/lib/react-error-boundary-reporting'
+import {
+  flushReactUpdateDepthEscalationsForTest,
+  resetReactUpdateDepthEscalationForTest
+} from '@/lib/react-update-depth-escalation'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import { RUNTIME_PROTOCOL_VERSION } from '../../../../shared/protocol-version'
+
+const REACT_185 =
+  'Minified React error #185; visit https://react.dev/errors/185 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.'
+
+const setRuntimeEnvironments = vi.fn()
+const setRuntimeEnvironmentStatus = vi.fn()
+
+const mockStoreState = {
+  remoteServerUpdates: new Map(),
+  remoteServerUpdatesChecking: false,
+  remoteServerUpdatesRunning: false,
+  refreshRemoteServerUpdates: vi.fn(),
+  setRemoteServerUpdateDialogOpen: vi.fn(),
+  setRuntimeEnvironments,
+  setRuntimeEnvironmentStatus,
+  settingsSearchQuery: '',
+  activeView: 'settings',
+  activeModal: 'settings',
+  activeTabType: null,
+  rightSidebarTab: null,
+  activeWorktreeId: null
+}
+
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign((selector: (state: unknown) => unknown) => selector(mockStoreState), {
+    getState: () => mockStoreState
+  })
+}))
+
+const { toastError } = vi.hoisted(() => ({ toastError: vi.fn() }))
+vi.mock('sonner', () => ({ toast: { error: toastError, success: vi.fn() } }))
+
+const recordRendererError = vi.fn()
+const list = vi.fn()
+const getStatus = vi.fn()
+const roots: Root[] = []
+
+const ENVIRONMENT = {
+  id: 'env-1',
+  name: 'build-box',
+  source: 'pairing',
+  createdAt: 0,
+  lastSeenAt: 0,
+  preferredEndpointId: 'ep-1',
+  endpoints: [{ id: 'ep-1', kind: 'direct', url: 'https://build-box.example' }]
+}
+
+const RUNTIME_STATUS = {
+  ok: true,
+  version: '1.4.163',
+  protocolVersion: RUNTIME_PROTOCOL_VERSION,
+  runtimeProtocolVersion: RUNTIME_PROTOCOL_VERSION,
+  minCompatibleMobileVersion: RUNTIME_PROTOCOL_VERSION,
+  minCompatibleRuntimeClientVersion: RUNTIME_PROTOCOL_VERSION,
+  capabilities: []
+}
+
+const SETTINGS = { activeRuntimeEnvironmentId: null } as unknown as GlobalSettings
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true
+  recordRendererError.mockReset()
+  recordRendererError.mockResolvedValue({ ok: true, report: null, deduped: false })
+  list.mockReset()
+  list.mockResolvedValue([ENVIRONMENT])
+  getStatus.mockReset()
+  getStatus.mockResolvedValue({ ok: true, result: RUNTIME_STATUS })
+  toastError.mockReset()
+  setRuntimeEnvironments.mockReset()
+  setRuntimeEnvironmentStatus.mockReset()
+  resetReactUpdateDepthEscalationForTest()
+  clearReactErrorBoundaryReportingForTest()
+  Object.assign(globalThis.window, {
+    api: {
+      runtimeEnvironments: { list, getStatus },
+      crashReports: { recordRendererError }
+    }
+  })
+})
+
+afterEach(() => {
+  act(() => {
+    for (const root of roots.splice(0)) {
+      root.unmount()
+    }
+  })
+})
+
+async function render(): Promise<HTMLDivElement> {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  roots.push(root)
+  await act(async () => {
+    root.render(
+      <TooltipProvider>
+        <RuntimeEnvironmentsPane
+          settings={SETTINGS}
+          setActiveRuntimeEnvironmentPreference={vi.fn().mockResolvedValue(true)}
+        />
+      </TooltipProvider>
+    )
+  })
+  await act(async () => {
+    await Promise.resolve()
+  })
+  return container
+}
+
+describe('RuntimeEnvironmentsPane host probe', () => {
+  it('settles the row when a #185 escalation aborts the probe continuation', async () => {
+    setRuntimeEnvironmentStatus.mockImplementation(() => {
+      throw new Error(REACT_185)
+    })
+
+    const container = await render()
+    await flushReactUpdateDepthEscalationsForTest()
+
+    expect(recordRendererError).toHaveBeenCalledTimes(1)
+    expect(recordRendererError.mock.calls[0]?.[0]?.boundaryId).toContain('RuntimeEnvironmentsPane')
+    expect(container.textContent).not.toContain('Minified React error #185')
+    // No probe is running, so the row must not keep claiming one.
+    const row = container.querySelector('[data-settings-section="env-1"]')
+    expect(row?.textContent).not.toContain('Checking…')
+    expect(row?.querySelector('.animate-spin')).toBeNull()
+    // The probe itself answered before the loop threw, so its verdict survives.
+    expect(row?.textContent).toContain('Compatible')
+  })
+
+  it('settles the row on "Status unavailable" when the loop throws before the probe answers', async () => {
+    getStatus.mockImplementation(async () => {
+      throw new Error(REACT_185)
+    })
+
+    const container = await render()
+    await flushReactUpdateDepthEscalationsForTest()
+
+    expect(recordRendererError).toHaveBeenCalledTimes(1)
+    const row = container.querySelector('[data-settings-section="env-1"]')
+    expect(row?.textContent).not.toContain('Checking…')
+    expect(row?.querySelector('.animate-spin')).toBeNull()
+    expect(row?.textContent).toContain('Status unavailable')
+    // A local render loop is no evidence about the host, so the sidebar registry is left alone.
+    expect(setRuntimeEnvironmentStatus).not.toHaveBeenCalled()
+  })
+
+  it('escalates a #185 from the list catch instead of toasting the digest', async () => {
+    setRuntimeEnvironments.mockImplementation(() => {
+      throw new Error(REACT_185)
+    })
+
+    await render()
+    await flushReactUpdateDepthEscalationsForTest()
+
+    expect(recordRendererError).toHaveBeenCalledTimes(1)
+    expect(recordRendererError.mock.calls[0]?.[0]?.boundaryId).toContain('loadEnvironments')
+    expect(toastError).not.toHaveBeenCalled()
+  })
+
+  it('leaves an ordinary probe failure on its host-blaming error path', async () => {
+    getStatus.mockRejectedValue(new Error('connect ETIMEDOUT 10.0.0.4:443'))
+
+    const container = await render()
+    await flushReactUpdateDepthEscalationsForTest()
+
+    expect(recordRendererError).not.toHaveBeenCalled()
+    expect(setRuntimeEnvironmentStatus).toHaveBeenCalledWith(
+      'env-1',
+      expect.objectContaining({ status: null })
+    )
+    expect(container.textContent).toContain('connect ETIMEDOUT 10.0.0.4:443')
+  })
+})

--- a/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
+++ b/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
@@ -95,6 +95,24 @@ export function evaluateHostDetails(status: RuntimeStatus): RuntimeCompatVerdict
   })
 }
 
+function buildReadyHostDetails(runtimeStatus: RuntimeStatus): RuntimeHostDetails {
+  return {
+    status: 'ready',
+    runtimeStatus,
+    compatibility: evaluateHostDetails(runtimeStatus),
+    error: null
+  }
+}
+
+// Reads as "Status unavailable" with no description. Not 'loading' (nothing is checking) and not the
+// store's status:null either — a local render loop is no evidence about the host.
+const UNVERIFIED_HOST_DETAILS: RuntimeHostDetails = {
+  status: 'error',
+  runtimeStatus: null,
+  compatibility: null,
+  error: null
+}
+
 export function getHostDetailsSummary(details: RuntimeHostDetails | undefined): string {
   if (!details || details.status === 'loading') {
     return translate('auto.components.settings.RuntimeEnvironmentsPane.5120beaac6', 'Checking…')
@@ -298,6 +316,8 @@ export function RuntimeEnvironmentsPane({
     (state) => state.setRemoteServerUpdateDialogOpen
   )
   const consumedAddServerIntentSignalRef = useRef(0)
+  // The finally below needs these even when the setState that seeded them threw.
+  const probedEnvironmentIdsRef = useRef<string[]>([])
   const mountedRef = useMountedRef()
   const updateCheckHint = getUpdateCheckHint()
   const activeValue =
@@ -316,6 +336,24 @@ export function RuntimeEnvironmentsPane({
     ? getRuntimeEnvironmentsSearchEntry()
     : getWebRuntimeEnvironmentsSearchEntry()
 
+  // Every probe has settled by the time this runs, so a row still on its 'loading' seed has no check
+  // in flight — an escalated #185 (or any early return) left it there. Spinning "Checking…" forever
+  // asserts a probe that is not running; the manual refresh is the only other writer.
+  const settleUnprobedHostRows = useCallback(() => {
+    setDetailsByEnvironmentId((current) => {
+      const stranded = probedEnvironmentIdsRef.current.filter(
+        (environmentId) => (current[environmentId]?.status ?? 'loading') === 'loading'
+      )
+      if (stranded.length === 0) {
+        return current
+      }
+      return {
+        ...current,
+        ...Object.fromEntries(stranded.map((id) => [id, UNVERIFIED_HOST_DETAILS]))
+      }
+    })
+  }, [])
+
   const loadEnvironments = useCallback(
     async (verified?: { environmentId: string; runtimeStatus: RuntimeStatus }): Promise<void> => {
       if (mountedRef.current) {
@@ -324,6 +362,7 @@ export function RuntimeEnvironmentsPane({
       try {
         const nextEnvironments = await window.api.runtimeEnvironments.list()
         const visibleEnvironments = nextEnvironments.filter(isUserManagedRuntimeEnvironment)
+        probedEnvironmentIdsRef.current = visibleEnvironments.map((environment) => environment.id)
         // Why: drop store status for servers no longer saved so stale hosts don't
         // linger in the sidebar registry.
         useAppStore.getState().setRuntimeEnvironments(nextEnvironments)
@@ -340,12 +379,7 @@ export function RuntimeEnvironmentsPane({
             for (const environment of visibleEnvironments) {
               next[environment.id] =
                 verified?.environmentId === environment.id
-                  ? {
-                      status: 'ready',
-                      runtimeStatus: verified.runtimeStatus,
-                      compatibility: evaluateHostDetails(verified.runtimeStatus),
-                      error: null
-                    }
+                  ? buildReadyHostDetails(verified.runtimeStatus)
                   : (current[environment.id] ?? {
                       status: 'loading',
                       runtimeStatus: null,
@@ -360,12 +394,14 @@ export function RuntimeEnvironmentsPane({
           visibleEnvironments
             .filter((environment) => environment.id !== verified?.environmentId)
             .map(async (environment) => {
+              let probedRuntimeStatus: RuntimeStatus | null = null
               try {
                 const response = await window.api.runtimeEnvironments.getStatus({
                   selector: environment.id,
                   timeoutMs: 10_000
                 })
                 const runtimeStatus = unwrapRuntimeRpcResult<RuntimeStatus>(response)
+                probedRuntimeStatus = runtimeStatus
                 // Why: feed the live status into the store so sidebar host pickers
                 // reflect manual refreshes, not just the settings pane.
                 useAppStore.getState().setRuntimeEnvironmentStatus(environment.id, {
@@ -377,18 +413,22 @@ export function RuntimeEnvironmentsPane({
                 }
                 setDetailsByEnvironmentId((current) => ({
                   ...current,
-                  [environment.id]: {
-                    status: 'ready',
-                    runtimeStatus,
-                    compatibility: evaluateHostDetails(runtimeStatus),
-                    error: null
-                  }
+                  [environment.id]: buildReadyHostDetails(runtimeStatus)
                 }))
               } catch (error) {
                 // Why first: allSettled would swallow a #185 a second time, and the probe
                 // itself succeeded — status:null here blames the host for a local render
                 // loop and marks a reachable server unverifiable.
                 if (escalateReactUpdateDepthError(error, RUNTIME_PROBE_CATCH)) {
+                  // The probe already answered; keep its verdict rather than let the finally below
+                  // settle the row on "Status unavailable" for a failure that was never the host's.
+                  if (probedRuntimeStatus && mountedRef.current) {
+                    const readyDetails = buildReadyHostDetails(probedRuntimeStatus)
+                    setDetailsByEnvironmentId((current) => ({
+                      ...current,
+                      [environment.id]: readyDetails
+                    }))
+                  }
                   return
                 }
                 // Why: record the failed probe (null status) so the sidebar can
@@ -429,10 +469,11 @@ export function RuntimeEnvironmentsPane({
       } finally {
         if (mountedRef.current) {
           setIsLoading(false)
+          settleUnprobedHostRows()
         }
       }
     },
-    [mountedRef]
+    [mountedRef, settleUnprobedHostRows]
   )
 
   useEffect(() => {

--- a/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
+++ b/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
@@ -15,6 +15,7 @@ import {
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { useMountedRef } from '@/hooks/useMountedRef'
+import { escalateReactUpdateDepthError } from '@/lib/react-update-depth-escalation'
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import {
   isUserManagedRuntimeEnvironment,
@@ -62,6 +63,9 @@ import {
   RemoteServerUpdateStatus
 } from './RemoteServerUpdateStatus'
 import { RuntimeHostAccessForm, type RuntimeHostAccessFailure } from './RuntimeHostAccessForm'
+
+const RUNTIME_LOAD_CATCH = 'settings.RuntimeEnvironmentsPane.loadEnvironments'
+const RUNTIME_PROBE_CATCH = 'settings.RuntimeEnvironmentsPane.probeEnvironmentStatus'
 
 const LOCAL_RUNTIME_VALUE = '__local__'
 const NO_RUNTIME_VALUE = '__none__'
@@ -381,6 +385,12 @@ export function RuntimeEnvironmentsPane({
                   }
                 }))
               } catch (error) {
+                // Why first: allSettled would swallow a #185 a second time, and the probe
+                // itself succeeded — status:null here blames the host for a local render
+                // loop and marks a reachable server unverifiable.
+                if (escalateReactUpdateDepthError(error, RUNTIME_PROBE_CATCH)) {
+                  return
+                }
                 // Why: record the failed probe (null status) so the sidebar can
                 // distinguish unreachable from never-checked.
                 useAppStore.getState().setRuntimeEnvironmentStatus(environment.id, {
@@ -403,6 +413,9 @@ export function RuntimeEnvironmentsPane({
             })
         )
       } catch (error) {
+        if (escalateReactUpdateDepthError(error, RUNTIME_LOAD_CATCH)) {
+          return
+        }
         if (mountedRef.current) {
           toast.error(
             error instanceof Error

--- a/src/renderer/src/components/status-bar/use-resource-session-inventory.test.tsx
+++ b/src/renderer/src/components/status-bar/use-resource-session-inventory.test.tsx
@@ -4,6 +4,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { DaemonSession } from './resource-usage-merge-types'
 import { notifyDaemonSessionInventoryInvalidated } from './daemon-session-inventory-invalidation'
 import { useResourceSessionInventory } from './use-resource-session-inventory'
+import { clearReactErrorBoundaryReportingForTest } from '@/lib/react-error-boundary-reporting'
+import {
+  flushReactUpdateDepthEscalationsForTest,
+  resetReactUpdateDepthEscalationForTest
+} from '@/lib/react-update-depth-escalation'
 
 function session(id: string): DaemonSession {
   return { id, cwd: '/workspace', title: id, agentOwnership: 'absent' as const }
@@ -82,6 +87,29 @@ describe('useResourceSessionInventory', () => {
 
     expect(result.current.sessionInventory.sessions).toEqual([session('recovered')])
     expect(result.current.sessionsError).toBe(false)
+  })
+
+  it('escalates React #185 instead of flagging the PTY host as unreachable', async () => {
+    const recordRendererError = vi.fn().mockResolvedValue({ ok: true, report: null, deduped: false })
+    resetReactUpdateDepthEscalationForTest()
+    clearReactErrorBoundaryReportingForTest()
+    ;(window as unknown as { api: { crashReports: unknown } }).api.crashReports = {
+      recordRendererError
+    }
+    listSessions.mockRejectedValue(
+      new Error('Minified React error #185; visit https://react.dev/errors/185')
+    )
+
+    const { result } = renderHook(() => useResourceSessionInventory(true))
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+    await flushReactUpdateDepthEscalationsForTest()
+
+    expect(result.current.sessionsError).toBe(false)
+    expect(recordRendererError.mock.calls[0]?.[0]?.boundaryId).toContain(
+      'use-resource-session-inventory.refreshSessions'
+    )
   })
 
   it('refreshes for background spawns without depending on mounted pane state', async () => {

--- a/src/renderer/src/components/status-bar/use-resource-session-inventory.ts
+++ b/src/renderer/src/components/status-bar/use-resource-session-inventory.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useMountedRef } from '@/hooks/useMountedRef'
+import { escalateReactUpdateDepthError } from '@/lib/react-update-depth-escalation'
 import { subscribeDaemonSessionInventoryInvalidated } from './daemon-session-inventory-invalidation'
 import {
   EMPTY_DAEMON_SESSION_INVENTORY,
@@ -8,6 +9,8 @@ import {
   removeSessionsFromInventory,
   type DaemonSessionInventory
 } from './resource-session-inventory'
+
+const RESOURCE_SESSION_REFRESH_CATCH = 'status-bar.use-resource-session-inventory.refreshSessions'
 
 type ResourceSessionInventory = {
   sessionInventory: DaemonSessionInventory
@@ -79,7 +82,12 @@ export function useResourceSessionInventory(ready: boolean): ResourceSessionInve
         sessionInventory: inventoryFromSessions(liveSessions),
         sessionsError: false
       })
-    } catch {
+    } catch (error) {
+      // Why first: listSessions can succeed and the fresh-object setStoredState above still
+      // throw #185; sessionsError would then blame the PTY host for a local render loop.
+      if (escalateReactUpdateDepthError(error, RESOURCE_SESSION_REFRESH_CATCH)) {
+        return
+      }
       if (mountedRef.current && generation === refreshGenerationRef.current) {
         setStoredState((current) => ({ ...current, sessionsError: true }))
       }

--- a/src/renderer/src/lib/react-error-boundary-reporting.test.ts
+++ b/src/renderer/src/lib/react-error-boundary-reporting.test.ts
@@ -4,7 +4,7 @@ import {
   clearReactErrorBoundaryReportingForTest,
   reportReactErrorBoundaryCrash
 } from './react-error-boundary-reporting'
-import type { CrashReportRecord } from '../../../shared/crash-reporting'
+import { RENDERER_ERROR_DEDUPE_MS, type CrashReportRecord } from '../../../shared/crash-reporting'
 
 const mocks = vi.hoisted(() => ({
   recordRendererError: vi.fn(),
@@ -146,5 +146,57 @@ describe('react error boundary reporting', () => {
         hasActiveWorktree: true
       })
     )
+  })
+
+  it('re-reports an identical signature once the main-process dedupe window elapses', async () => {
+    vi.useFakeTimers()
+    try {
+      const report = () =>
+        reportReactErrorBoundaryCrash({
+          boundaryId: 'page.settings',
+          surface: 'page',
+          error: new Error('render failed'),
+          repeatAfterDedupeWindow: true
+        })
+      await report()
+      vi.setSystemTime(Date.now() + RENDERER_ERROR_DEDUPE_MS - 1)
+      await report()
+      expect(mocks.recordRendererError).toHaveBeenCalledTimes(1)
+
+      // Past the window the main process accepts the report again, so the renderer must not withhold it:
+      // its key set only evicts after 50 *distinct* other errors, which one recurring crash never produces.
+      vi.setSystemTime(Date.now() + 1)
+      await report()
+      expect(mocks.recordRendererError).toHaveBeenCalledTimes(2)
+      expect(mocks.dispatchEvent).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keeps a mounted boundary at one report per session so the crash dialog cannot re-open', async () => {
+    vi.useFakeTimers()
+    try {
+      // CrashReportDialog opens the modal for every non-deduped report, with no per-launch guard on
+      // that path; a resetKey-driven boundary re-catches the same signature indefinitely.
+      const report = () =>
+        reportReactErrorBoundaryCrash({
+          boundaryId: 'modal.quick-open',
+          surface: 'modal',
+          error: new Error('render failed')
+        })
+      await report()
+      for (let hour = 0; hour < 3; hour++) {
+        for (let tick = 0; tick < 6; tick++) {
+          vi.setSystemTime(Date.now() + RENDERER_ERROR_DEDUPE_MS)
+          await report()
+        }
+      }
+
+      expect(mocks.recordRendererError).toHaveBeenCalledTimes(1)
+      expect(mocks.dispatchEvent).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/src/renderer/src/lib/react-error-boundary-reporting.ts
+++ b/src/renderer/src/lib/react-error-boundary-reporting.ts
@@ -1,7 +1,8 @@
 import type React from 'react'
-import type {
-  CrashReportRecord,
-  ReactErrorBoundaryReportArgs
+import {
+  RENDERER_ERROR_DEDUPE_MS,
+  type CrashReportRecord,
+  type ReactErrorBoundaryReportArgs
 } from '../../../shared/crash-reporting'
 import { getReactErrorBoundaryAttribution } from '../../../shared/react-update-depth-attribution'
 
@@ -16,10 +17,18 @@ type BuildReportArgsInput = {
   error: unknown
   errorInfo?: React.ErrorInfo
   context?: RendererErrorContext
+  /** When the crash was observed; callers that throttle themselves pass their own instant so the two windows cannot drift. */
+  observedAt?: number
+  /**
+   * Opt in to re-reporting an identical signature once RENDERER_ERROR_DEDUPE_MS has passed. Off by
+   * default because a non-deduped report re-opens the modal crash dialog, and a mounted boundary
+   * with a resetKey re-catches the same signature for as long as the user keeps reopening its
+   * surface. Only self-throttled callers that need a runaway to stay visible should set it.
+   */
+  repeatAfterDedupeWindow?: boolean
 }
 
-const reportedRendererErrorKeys: string[] = []
-const reportedRendererErrorKeySet = new Set<string>()
+const reportedRendererErrorKeyTimes = new Map<string, number>()
 const MAX_REPORTED_RENDERER_ERROR_KEYS = 50
 let pendingReactErrorBoundaryReport: CrashReportRecord | null = null
 
@@ -88,17 +97,35 @@ export function buildReactErrorBoundaryReportArgs({
   }
 }
 
-function rememberRendererErrorKey(key: string): boolean {
-  if (reportedRendererErrorKeySet.has(key)) {
-    return false
-  }
-  reportedRendererErrorKeySet.add(key)
-  reportedRendererErrorKeys.push(key)
-  if (reportedRendererErrorKeys.length > MAX_REPORTED_RENDERER_ERROR_KEYS) {
-    const expiredKey = reportedRendererErrorKeys.shift()
-    if (expiredKey) {
-      reportedRendererErrorKeySet.delete(expiredKey)
+/**
+ * Default is once per session (the count cap is the only eviction), because every non-deduped report
+ * opens the modal crash dialog. `repeatAfterDedupeWindow` callers get the main process's own window
+ * instead, so a self-throttled runaway is never silently dropped on this side.
+ */
+function rememberRendererErrorKey(
+  key: string,
+  observedAt: number,
+  repeatAfterDedupeWindow: boolean
+): boolean {
+  const rememberedAt = reportedRendererErrorKeyTimes.get(key)
+  if (rememberedAt !== undefined) {
+    if (!repeatAfterDedupeWindow) {
+      return false
     }
+    const elapsed = observedAt - rememberedAt
+    // A backwards clock jump reads as negative; report rather than stay silent until the clock catches up.
+    if (elapsed >= 0 && elapsed < RENDERER_ERROR_DEDUPE_MS) {
+      return false
+    }
+  }
+  reportedRendererErrorKeyTimes.delete(key) // re-insert so the count cap evicts by last report, not first
+  reportedRendererErrorKeyTimes.set(key, observedAt)
+  while (reportedRendererErrorKeyTimes.size > MAX_REPORTED_RENDERER_ERROR_KEYS) {
+    const oldestKey = reportedRendererErrorKeyTimes.keys().next().value
+    if (oldestKey === undefined) {
+      return true
+    }
+    reportedRendererErrorKeyTimes.delete(oldestKey)
   }
   return true
 }
@@ -127,9 +154,16 @@ function notifyReactErrorBoundaryReportAvailable(report: CrashReportRecord): voi
 export async function reportReactErrorBoundaryCrash(
   input: Omit<BuildReportArgsInput, 'context'>
 ): Promise<void> {
+  const observedAt = input.observedAt ?? Date.now()
   const context = await collectRendererErrorContext()
   const args = buildReactErrorBoundaryReportArgs({ ...input, context })
-  if (!rememberRendererErrorKey(getRendererErrorKey(args))) {
+  if (
+    !rememberRendererErrorKey(
+      getRendererErrorKey(args),
+      observedAt,
+      input.repeatAfterDedupeWindow === true
+    )
+  ) {
     return
   }
 
@@ -148,7 +182,6 @@ export async function reportReactErrorBoundaryCrash(
 }
 
 export function clearReactErrorBoundaryReportingForTest(): void {
-  reportedRendererErrorKeys.length = 0
-  reportedRendererErrorKeySet.clear()
+  reportedRendererErrorKeyTimes.clear()
   pendingReactErrorBoundaryReport = null
 }

--- a/src/renderer/src/lib/react-update-depth-escalation.test.ts
+++ b/src/renderer/src/lib/react-update-depth-escalation.test.ts
@@ -6,7 +6,10 @@ import {
   flushReactUpdateDepthEscalationsForTest,
   resetReactUpdateDepthEscalationForTest
 } from './react-update-depth-escalation'
-import { clearReactErrorBoundaryReportingForTest } from './react-error-boundary-reporting'
+import {
+  clearReactErrorBoundaryReportingForTest,
+  REACT_ERROR_BOUNDARY_REPORT_AVAILABLE_EVENT
+} from './react-error-boundary-reporting'
 
 const REACT_185_MINIFIED =
   'Minified React error #185; visit https://react.dev/errors/185 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.'
@@ -101,6 +104,46 @@ describe('react update depth escalation', () => {
     await flushReactUpdateDepthEscalationsForTest()
     expect(recordRendererError).toHaveBeenCalledTimes(1)
     expect(captured).toHaveLength(1)
+  })
+
+  it('re-escalates the same site once the suppression window elapses', async () => {
+    vi.useFakeTimers()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    // A report the user can send is the surface the guard exists to feed, so count the dialog signal too.
+    recordRendererError.mockResolvedValue({
+      ok: true,
+      report: { id: 'react-report-1' },
+      deduped: false
+    })
+    const reportsAvailable = vi.fn()
+    window.addEventListener(REACT_ERROR_BOUNDARY_REPORT_AVAILABLE_EVENT, reportsAvailable)
+    try {
+      expect(escalateReactUpdateDepthError(new Error(REACT_185_MINIFIED), SITE)).toBe(true)
+      await flushReactUpdateDepthEscalationsForTest()
+      expect(recordRendererError).toHaveBeenCalledTimes(1)
+
+      // Inside the window the runaway loop's own re-entries stay suppressed.
+      vi.setSystemTime(Date.now() + 9 * 60 * 1000)
+      expect(escalateReactUpdateDepthError(new Error(REACT_185_MINIFIED), SITE)).toBe(true)
+      await flushReactUpdateDepthEscalationsForTest()
+      expect(recordRendererError).toHaveBeenCalledTimes(1)
+      expect(captured).toHaveLength(1)
+      expect(consoleError).toHaveBeenCalledTimes(1)
+
+      // A later, unrelated runaway at the same catch must not be silent. Nothing is cleared here:
+      // the report-key dedupe downstream has to expire on its own, or the window is decorative.
+      vi.setSystemTime(Date.now() + 2 * 60 * 1000)
+      expect(escalateReactUpdateDepthError(new Error(REACT_185_MINIFIED), SITE)).toBe(true)
+      await flushReactUpdateDepthEscalationsForTest()
+      expect(recordRendererError).toHaveBeenCalledTimes(2)
+      expect(captured).toHaveLength(2)
+      expect(consoleError).toHaveBeenCalledTimes(2)
+      expect(reportsAvailable).toHaveBeenCalledTimes(2)
+    } finally {
+      window.removeEventListener(REACT_ERROR_BOUNDARY_REPORT_AVAILABLE_EVENT, reportsAvailable)
+      consoleError.mockRestore()
+      vi.useRealTimers()
+    }
   })
 
   it('still escalates a second, distinct catching site', async () => {

--- a/src/renderer/src/lib/react-update-depth-escalation.test.ts
+++ b/src/renderer/src/lib/react-update-depth-escalation.test.ts
@@ -111,6 +111,23 @@ describe('react update depth escalation', () => {
     expect(captured).toHaveLength(2)
   })
 
+  it('leaves console evidence when the host cannot surface the report', async () => {
+    // The web preload shim answers every recordRendererError with report: null, deduped: true,
+    // and its recordBreadcrumb is a no-op, so the console is the only surface web users have.
+    const { createWebDiagnosticsApi } = await import('../web/preload-api/web-diagnostics-api')
+    window.api = createWebDiagnosticsApi() as unknown as typeof window.api
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    expect(escalateReactUpdateDepthError(new Error(REACT_185_MINIFIED), SITE)).toBe(true)
+    await flushReactUpdateDepthEscalationsForTest()
+
+    expect(consoleError).toHaveBeenCalledTimes(1)
+    const logged = consoleError.mock.calls[0]?.map(String).join(' ') ?? ''
+    expect(logged).toContain(SITE)
+    expect(logged).toContain('#185')
+    consoleError.mockRestore()
+  })
+
   it('never throws when the crash-report bridge is missing or fails', () => {
     window.api = undefined as unknown as typeof window.api
     expect(() => escalateReactUpdateDepthError(new Error(REACT_185_MINIFIED), SITE)).not.toThrow()

--- a/src/renderer/src/lib/react-update-depth-escalation.test.ts
+++ b/src/renderer/src/lib/react-update-depth-escalation.test.ts
@@ -1,0 +1,125 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  escalateReactUpdateDepthError,
+  flushReactUpdateDepthEscalationsForTest,
+  resetReactUpdateDepthEscalationForTest
+} from './react-update-depth-escalation'
+import { clearReactErrorBoundaryReportingForTest } from './react-error-boundary-reporting'
+
+const REACT_185_MINIFIED =
+  'Minified React error #185; visit https://react.dev/errors/185 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.'
+const REACT_185_LEGACY =
+  'Minified React error #185; visit https://reactjs.org/docs/error-decoder.html?invariant=185 for the full message.'
+const REACT_185_DEV =
+  'Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate.'
+
+const recordRendererError = vi.fn()
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => ({
+      activeView: 'settings',
+      activeModal: 'settings',
+      activeTabType: null,
+      rightSidebarTab: null,
+      activeWorktreeId: null
+    })
+  }
+}))
+
+const SITE = 'settings.ReleaseChannelSection.loadBuilds'
+
+let captured: ErrorEvent[] = []
+
+function captureHostError(event: Event): void {
+  captured.push(event as ErrorEvent)
+}
+
+beforeEach(() => {
+  captured = []
+  recordRendererError.mockReset()
+  recordRendererError.mockResolvedValue({ ok: true, report: null, deduped: false })
+  resetReactUpdateDepthEscalationForTest()
+  clearReactErrorBoundaryReportingForTest()
+  window.api = {
+    crashReports: { recordRendererError }
+  } as unknown as typeof window.api
+  window.addEventListener('error', captureHostError)
+})
+
+afterEach(() => {
+  window.removeEventListener('error', captureHostError)
+})
+
+describe('react update depth escalation', () => {
+  it('leaves ordinary errors to the catching site', () => {
+    expect(escalateReactUpdateDepthError(new TypeError('fetch failed'), SITE)).toBe(false)
+    expect(escalateReactUpdateDepthError('HTTP 500: rate limited', SITE)).toBe(false)
+    expect(escalateReactUpdateDepthError(null, SITE)).toBe(false)
+    expect(recordRendererError).not.toHaveBeenCalled()
+    expect(captured).toHaveLength(0)
+  })
+
+  it.each([
+    ['minified production digest', REACT_185_MINIFIED],
+    ['legacy invariant digest', REACT_185_LEGACY],
+    ['development message', REACT_185_DEV]
+  ])('escalates the %s', async (_label, message) => {
+    expect(escalateReactUpdateDepthError(new Error(message), SITE)).toBe(true)
+    await flushReactUpdateDepthEscalationsForTest()
+    expect(recordRendererError).toHaveBeenCalledTimes(1)
+    expect(recordRendererError.mock.calls[0]?.[0]).toMatchObject({
+      errorMessage: message,
+      attribution: 'unreliable'
+    })
+    // The catching site is the only attribution #185 has; any boundary that caught it names a bystander.
+    expect(recordRendererError.mock.calls[0]?.[0]?.boundaryId).toContain(
+      'settings.ReleaseChannelSection.loadBuilds'
+    )
+    expect(captured).toHaveLength(1)
+    expect(captured[0]?.error).toBeInstanceOf(Error)
+  })
+
+  it('does not match neighbouring React error numbers', () => {
+    for (const digest of ['#1850', '#1852', '#18', '#310']) {
+      expect(
+        escalateReactUpdateDepthError(
+          new Error(`Minified React error ${digest}; visit https://react.dev/errors/x`),
+          SITE
+        )
+      ).toBe(false)
+    }
+    expect(recordRendererError).not.toHaveBeenCalled()
+  })
+
+  it('reports a runaway site once, so the loop cannot flood the crash reporter', async () => {
+    for (let i = 0; i < 200; i += 1) {
+      expect(escalateReactUpdateDepthError(new Error(REACT_185_MINIFIED), SITE)).toBe(true)
+    }
+    await flushReactUpdateDepthEscalationsForTest()
+    expect(recordRendererError).toHaveBeenCalledTimes(1)
+    expect(captured).toHaveLength(1)
+  })
+
+  it('still escalates a second, distinct catching site', async () => {
+    escalateReactUpdateDepthError(new Error(REACT_185_MINIFIED), SITE)
+    escalateReactUpdateDepthError(new Error(REACT_185_MINIFIED), 'startup-hydration.catalog')
+    await flushReactUpdateDepthEscalationsForTest()
+    expect(recordRendererError).toHaveBeenCalledTimes(2)
+    expect(captured).toHaveLength(2)
+  })
+
+  it('never throws when the crash-report bridge is missing or fails', () => {
+    window.api = undefined as unknown as typeof window.api
+    expect(() => escalateReactUpdateDepthError(new Error(REACT_185_MINIFIED), SITE)).not.toThrow()
+
+    resetReactUpdateDepthEscalationForTest()
+    recordRendererError.mockImplementation(() => {
+      throw new Error('IPC bridge torn down')
+    })
+    window.api = { crashReports: { recordRendererError } } as unknown as typeof window.api
+    expect(() => escalateReactUpdateDepthError(new Error(REACT_185_DEV), SITE)).not.toThrow()
+  })
+})

--- a/src/renderer/src/lib/react-update-depth-escalation.ts
+++ b/src/renderer/src/lib/react-update-depth-escalation.ts
@@ -10,13 +10,18 @@
  * boundary that catches it names a bystander picked by commit order.
  */
 
+import { RENDERER_ERROR_DEDUPE_MS } from '../../../shared/crash-reporting'
 import { isReactUpdateDepthError } from '../../../shared/react-update-depth-attribution'
 import { reportReactErrorBoundaryCrash } from './react-error-boundary-reporting'
 
 // Marks the report as a swallowing catch rather than a mounted boundary; boundaryId caps at 120 chars.
 const ASYNC_CATCH_BOUNDARY_PREFIX = 'async-catch:'
 
-const escalatedSiteIds = new Set<string>()
+// The report-key windows downstream expire on the same clock, so a re-escalation is never dropped as
+// a duplicate; `observedAt` below keeps the awaits in between from shifting them apart.
+const ESCALATION_SUPPRESSION_MS = RENDERER_ERROR_DEDUPE_MS
+
+const lastEscalationAtBySiteId = new Map<string, number>()
 const pendingEscalations = new Set<Promise<void>>()
 
 /**
@@ -33,14 +38,19 @@ export function escalateReactUpdateDepthError(error: unknown, siteId: string): b
   if (!isReactUpdateDepthError(error)) {
     return false
   }
-  // Why once per site: the loop that produced this re-enters the same catch thousands of times a second.
-  if (escalatedSiteIds.has(siteId)) {
+  // Why throttled per site: the loop that produced this re-enters the same catch thousands of times a
+  // second. Why not once per site: a later, unrelated runaway at the same catch must not be silent.
+  const now = Date.now()
+  const sinceLastEscalation = now - (lastEscalationAtBySiteId.get(siteId) ?? -Infinity)
+  // A backwards clock jump reads as negative; escalate rather than suppress until the clock catches up.
+  if (sinceLastEscalation >= 0 && sinceLastEscalation < ESCALATION_SUPPRESSION_MS) {
     return true
   }
-  escalatedSiteIds.add(siteId)
+  forgetExpiredEscalations(now)
+  lastEscalationAtBySiteId.set(siteId, now)
   try {
     // Why unconditional: the web client stubs crash reporting to a no-op, so without this the
-    // guard would trade a mislabeled digest for total silence. Once per site, like the report.
+    // guard would trade a mislabeled digest for total silence. Throttled with the report.
     console.error(
       `[react-update-depth] React #185 (nested update limit) surfaced in the catch at ${siteId}; that site is a bystander, not the cause:`,
       error
@@ -50,7 +60,11 @@ export function escalateReactUpdateDepthError(error: unknown, siteId: string): b
         boundaryId: `${ASYNC_CATCH_BOUNDARY_PREFIX}${siteId}`,
         // No boundary caught this, so no boundary surface describes it; siteId carries the identity.
         surface: 'app-root',
-        error
+        error,
+        observedAt: now,
+        // Off by default so a recurring boundary crash cannot re-open the modal crash dialog; this
+        // site self-throttles on the same window, so opting in re-reports at most once per window.
+        repeatAfterDedupeWindow: true
       })
     )
     dispatchToHostErrorHandler(error, siteId)
@@ -59,6 +73,14 @@ export function escalateReactUpdateDepthError(error: unknown, siteId: string): b
     console.warn('[react-update-depth] Failed to escalate a swallowed #185:', escalationError)
   }
   return true
+}
+
+function forgetExpiredEscalations(now: number): void {
+  for (const [expiredSiteId, escalatedAt] of lastEscalationAtBySiteId) {
+    if (now - escalatedAt >= ESCALATION_SUPPRESSION_MS) {
+      lastEscalationAtBySiteId.delete(expiredSiteId)
+    }
+  }
 }
 
 function trackEscalation(escalation: Promise<void>): void {
@@ -86,6 +108,6 @@ export async function flushReactUpdateDepthEscalationsForTest(): Promise<void> {
 }
 
 export function resetReactUpdateDepthEscalationForTest(): void {
-  escalatedSiteIds.clear()
+  lastEscalationAtBySiteId.clear()
   pendingEscalations.clear()
 }

--- a/src/renderer/src/lib/react-update-depth-escalation.ts
+++ b/src/renderer/src/lib/react-update-depth-escalation.ts
@@ -20,8 +20,8 @@ const escalatedSiteIds = new Set<string>()
 const pendingEscalations = new Set<Promise<void>>()
 
 /**
- * Returns true when `error` is React's nested-update-limit throw, after routing it to the crash
- * reporter and the host error handler. Callers should then bail out of their catch rather than
+ * Returns true when `error` is React's nested-update-limit throw, after logging it and routing it
+ * to the crash reporter and the host error handler. Callers should then bail out of their catch rather than
  * apply their normal failure handling: the message is not a user-facing status, and the extra
  * setState calls would feed the same loop.
  *
@@ -39,6 +39,12 @@ export function escalateReactUpdateDepthError(error: unknown, siteId: string): b
   }
   escalatedSiteIds.add(siteId)
   try {
+    // Why unconditional: the web client stubs crash reporting to a no-op, so without this the
+    // guard would trade a mislabeled digest for total silence. Once per site, like the report.
+    console.error(
+      `[react-update-depth] React #185 (nested update limit) surfaced in the catch at ${siteId}; that site is a bystander, not the cause:`,
+      error
+    )
     trackEscalation(
       reportReactErrorBoundaryCrash({
         boundaryId: `${ASYNC_CATCH_BOUNDARY_PREFIX}${siteId}`,

--- a/src/renderer/src/lib/react-update-depth-escalation.ts
+++ b/src/renderer/src/lib/react-update-depth-escalation.ts
@@ -1,0 +1,85 @@
+/**
+ * A try/catch around an async setState is not an error boundary. When React's nested-update
+ * limit trips (#185), the throw surfaces wherever the next setState happened to run — often
+ * inside an awaited continuation whose catch was written for network failures. Swallowing it
+ * there hides the runaway loop, paints its message as ordinary UI copy, and lets React's
+ * module-global counter reset to 0 so the loop re-arms and throws again on a different fiber.
+ *
+ * React cannot be told about an error raised outside its call stack, so containment here means
+ * re-reporting with the *catching site's* identity — the only attribution #185 has, since any
+ * boundary that catches it names a bystander picked by commit order.
+ */
+
+import { isReactUpdateDepthError } from '../../../shared/react-update-depth-attribution'
+import { reportReactErrorBoundaryCrash } from './react-error-boundary-reporting'
+
+// Marks the report as a swallowing catch rather than a mounted boundary; boundaryId caps at 120 chars.
+const ASYNC_CATCH_BOUNDARY_PREFIX = 'async-catch:'
+
+const escalatedSiteIds = new Set<string>()
+const pendingEscalations = new Set<Promise<void>>()
+
+/**
+ * Returns true when `error` is React's nested-update-limit throw, after routing it to the crash
+ * reporter and the host error handler. Callers should then bail out of their catch rather than
+ * apply their normal failure handling: the message is not a user-facing status, and the extra
+ * setState calls would feed the same loop.
+ *
+ * Returns false — and does nothing — for every other error, so expected failures keep their path.
+ *
+ * `siteId` names the catch, e.g. `settings.ReleaseChannelSection.loadBuilds`.
+ */
+export function escalateReactUpdateDepthError(error: unknown, siteId: string): boolean {
+  if (!isReactUpdateDepthError(error)) {
+    return false
+  }
+  // Why once per site: the loop that produced this re-enters the same catch thousands of times a second.
+  if (escalatedSiteIds.has(siteId)) {
+    return true
+  }
+  escalatedSiteIds.add(siteId)
+  try {
+    trackEscalation(
+      reportReactErrorBoundaryCrash({
+        boundaryId: `${ASYNC_CATCH_BOUNDARY_PREFIX}${siteId}`,
+        // No boundary caught this, so no boundary surface describes it; siteId carries the identity.
+        surface: 'app-root',
+        error
+      })
+    )
+    dispatchToHostErrorHandler(error, siteId)
+  } catch (escalationError) {
+    // A guard that throws would replace the loop with a second, less informative failure.
+    console.warn('[react-update-depth] Failed to escalate a swallowed #185:', escalationError)
+  }
+  return true
+}
+
+function trackEscalation(escalation: Promise<void>): void {
+  pendingEscalations.add(escalation)
+  void escalation.catch(() => undefined).finally(() => pendingEscalations.delete(escalation))
+}
+
+/** Re-raises on the host so global renderer diagnostics see it; a synchronous rethrow would be re-swallowed. */
+function dispatchToHostErrorHandler(error: unknown, siteId: string): void {
+  if (typeof window === 'undefined' || typeof ErrorEvent !== 'function') {
+    return
+  }
+  const message = error instanceof Error ? error.message : String(error)
+  window.dispatchEvent(
+    new ErrorEvent('error', {
+      error,
+      message: `[${ASYNC_CATCH_BOUNDARY_PREFIX}${siteId}] ${message}`
+    })
+  )
+}
+
+/** Join point for tests: reporting is deliberately fire-and-forget in the app. */
+export async function flushReactUpdateDepthEscalationsForTest(): Promise<void> {
+  await Promise.allSettled(pendingEscalations)
+}
+
+export function resetReactUpdateDepthEscalationForTest(): void {
+  escalatedSiteIds.clear()
+  pendingEscalations.clear()
+}

--- a/src/shared/crash-reporting.ts
+++ b/src/shared/crash-reporting.ts
@@ -131,6 +131,10 @@ export type CrashReportCopyDiagnosticsArgs = {
   submissionFailure?: CrashReportCopySubmissionFailure
 }
 
+// Shared so the renderer's report-key memory expires exactly when the main process will accept the
+// same signature again; a renderer that forgets later silences every recurrence for the session.
+export const RENDERER_ERROR_DEDUPE_MS = 10 * 60 * 1000
+
 // User notes need a prose budget, separate from 240-character telemetry values.
 export const MAX_USER_NOTES_LENGTH = 8_000
 // Bound redaction work while allowing redacted input to contract into the output budget.

--- a/src/shared/react-update-depth-attribution.ts
+++ b/src/shared/react-update-depth-attribution.ts
@@ -31,10 +31,12 @@ function messageOf(error: unknown): string {
   return ''
 }
 
+export function isReactUpdateDepthError(error: unknown): boolean {
+  return REACT_UPDATE_DEPTH_ERROR.test(messageOf(error))
+}
+
 export function getReactErrorBoundaryAttribution(
   error: unknown
 ): CrashReportAttribution | undefined {
-  return REACT_UPDATE_DEPTH_ERROR.test(messageOf(error))
-    ? UNRELIABLE_BOUNDARY_ATTRIBUTION
-    : undefined
+  return isReactUpdateDepthError(error) ? UNRELIABLE_BOUNDARY_ATTRIBUTION : undefined
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​847 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​846 |
| Prod | 12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​319 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​67 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​252 |

<!-- /orca-pr-loc -->

> **Draft — do not merge.** 4 adversarial loops, did not converge. Two majors outstanding plus a measured perf regression the guard itself introduced. The diagnosis is solid; the delivery isn't.

## The defect

You photographed React #185 rendered as red inline text in Settings while the whole app crawled. That text is **not an error-boundary fallback** — it's `loadError` at `ReleaseChannelSection.tsx:348`, set by the `catch` in `loadBuilds`. `listBuilds` **succeeded**; its own `setBuilds()` threw #185, the catch swallowed it, and `setBuilds(null)` produced the "No builds found" placeholder.

**A `try/catch` around an async `setState` is not an error boundary.** React never learns the component threw, so it never unmounts the looping driver — the loop keeps burning the main thread — and the reset lets `nestedUpdateCount` go back to 0 so the loop re-arms and throws again elsewhere. Verified both directions: a loop caught by a *real* boundary is self-terminating; one swallowed by `try/catch` is not.

A census found ~45 such sites.

## Approach

Per reviewer guidance — *"a shared helper rather than 207 edits… editing sites one at a time is unbounded work with no way to know when you are done"* — this adds one guard (`react-update-depth-escalation.ts`) reusing #16153's existing detector, applied to the 6 highest-value sinks. GitHub **and** GitLab rate-limit displays fixed together per the provider-parity rule.

Note: an error boundary **cannot** fix this — an async continuation is outside React's call stack, so `getDerivedStateFromError` never sees it. The guard re-reports instead.

**Before:** the field sighting reproduced verbatim, including the exact rendered string ending `"…No builds foundSwitch to buildMinified React error #185; visit https://react.dev/errors/185…"`. Provider parity: both hooks reported `hasError === true`, i.e. a local render loop rendered as a **provider outage**.

**After:** 10 files / 75 tests. Wider sweep 212 files / 1382 tests. Providers 27 files / 172 tests. Typecheck clean on all three projects; every lint gate clean; max-lines ratchet OK with no suppression added.

Non-vacuity proven both ways: reverting `ReleaseChannelSection.tsx` alone reproduces the sighting verbatim; deleting the two rate-limit guards flips both provider tests back to `hasError === true`.

Two genuinely good catches in the diff worth keeping regardless of what happens to the rest:
- `RuntimeEnvironmentsPane`'s old catch wrote `setRuntimeEnvironmentStatus(id, { status: null })` on **any** throw. A #185 is a *local render loop*, not loss of contact — so it published a false "unverifiable" verdict for a server that answered fine, into **global** zustand, and the sidebar host picker inherited the lie.
- `use-resource-session-inventory` had the same shape: `listSessions()` resolves, the fresh-object `setStoredState` throws, and the catch set `sessionsError` — **blaming the PTY host** for a renderer bug.

## Why it is a draft

1. **Major:** the fix swapped the renderer's permanent report-key set for a 10-minute TTL, which changes behaviour for **every** React error boundary, not just #185 sites.
2. **Major (raised loops 2 and 3, still unfixed):** the `RuntimeEnvironmentsPane` probe catch is the only escalation site with neither a `finally` nor a compensating write, so the early return leaves state unwritten.
3. **Perf:** `/perf` measured a **crash-report ring exhaustion** regression — the guard can flood the ring — plus a minor re-render issue. The guard's own hot path is fine; the escalation volume is not.

Finding 3 is the important one: a guard that escalates #185 into the crash reporter must be rate-limited, or it turns one loop into a report storm and evicts the very evidence needed to diagnose it. That interacts directly with #15709.

## Suggested path

Split it. The two false-attribution fixes (`RuntimeEnvironmentsPane`, `use-resource-session-inventory`) are correct, self-contained, and valuable on their own merits — a renderer bug should never be reported as a remote-host outage. Land those separately. Then settle the escalation-volume and report-key-TTL questions before applying the guard broadly.
