### PR TITLE
fix(terminal): bound hidden-worktree retention by mounted panes, not worktrees

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -120,6 +120,7 @@ import {
   countEvictionExemptTabRoutes,
   formatEvictionExemptRouteCounts,
   createTerminalWorktreeTopologyProjection,
+  countMountedWorktreePanes,
   hasPendingRetentionSpawnWork,
   selectForceParkEvictableTabIds,
   selectRetentionForceParkedTerminalWorktrees,
@@ -1040,6 +1041,10 @@ function Terminal(): React.JSX.Element | null {
     // remote-runtime, uncoverable tabs) force-park beyond a count/TTL bound —
     // added AFTER the coverage veto because darkness for their uncoverable tabs
     // is the accepted cost of bounding retention.
+    // Why getState: this runs in the same pass that decides unmounts, so it is
+    // the current layout catalog; a dep would re-run the whole verdict on every
+    // split resize for a number that only counts leaves.
+    const retentionLayoutsByTabId = useAppStore.getState().terminalLayoutsByTabId
     const retentionBudgetCandidates: TerminalWorktreeRetentionCandidate[] = retentionCandidates.map(
       (candidate) => {
         const tabs = parkingTabsByWorktree[candidate.worktreeId] ?? []
@@ -1069,7 +1074,8 @@ function Terminal(): React.JSX.Element | null {
             parkEligible && worktreeTabsAreWatcherCovered(candidate.worktreeId, tabs),
           hasPendingSpawnWork: tabs.some((tab) =>
             hasPendingRetentionSpawnWork(tab, pendingStartupByTabId)
-          )
+          ),
+          mountedPaneCount: countMountedWorktreePanes(tabs, retentionLayoutsByTabId)
         }
       }
     )

--- a/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-hidden-view-parking.ts
@@ -27,6 +27,7 @@ export type TerminalColdParkPolicyOverrides = {
   hotRetainLimit?: number
   retentionTtlMs?: number
   retentionLimit?: number
+  retentionPaneLimit?: number
 }
 
 export type ColdParkableTerminalTab = Pick<TerminalTab, 'id' | 'ptyId' | 'pendingActivationSpawn'>

--- a/src/renderer/src/components/terminal-pane/terminal-hidden-worktree-retention.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-hidden-worktree-retention.test.ts
@@ -11,6 +11,7 @@ import {
   hasPendingRetentionSpawnWork,
   isEvictionExemptTerminalPty,
   selectForceParkEvictableTabIds,
+  countMountedWorktreePanes,
   selectRetentionForceParkedTerminalWorktrees,
   type TerminalWorktreeRetentionCandidate
 } from './terminal-hidden-worktree-retention'
@@ -323,5 +324,114 @@ describe('selectForceParkEvictableTabIds', () => {
   // the degenerate case a fleet-wide daemon fail-open produces, which the host logs.
   it('yields nothing when every tab is exempt', () => {
     expect(selectForceParkEvictableTabIds(tabs, () => true)).toEqual([])
+  })
+})
+
+describe('retention pane budget', () => {
+  const nowMs = 5_000_000
+  const MINUTE = 60_000
+
+  function paneCandidate(
+    worktreeId: string,
+    hiddenMinutesAgo: number,
+    mountedPaneCount: number
+  ): TerminalWorktreeRetentionCandidate {
+    return {
+      worktreeId,
+      hiddenSinceMs: nowMs - hiddenMinutesAgo * MINUTE,
+      isVisible: false,
+      shouldMeasureHiddenWorktree: false,
+      hasActivityTerminalPortal: false,
+      ordinaryParkingCovers: false,
+      hasPendingSpawnWork: false,
+      mountedPaneCount
+    }
+  }
+
+  const select = (
+    worktrees: TerminalWorktreeRetentionCandidate[],
+    retentionPaneLimit?: number
+  ): Set<string> =>
+    selectRetentionForceParkedTerminalWorktrees({
+      worktrees,
+      parkingEnabled: true,
+      retentionBudgetEnabled: true,
+      nowMs,
+      ...(retentionPaneLimit === undefined ? {} : { retentionPaneLimit })
+    })
+
+  it('leaves the ordinary working set alone', () => {
+    // Four hidden worktrees at one tab each is what the worktree cap was sized
+    // for; the pane budget must not touch it.
+    const worktrees = [1, 2, 3, 4].map((n) => paneCandidate(`wt-${n}`, n, 1))
+    expect(select(worktrees)).toEqual(new Set())
+  })
+
+  it('parks past the pane budget even when the worktree cap is satisfied', () => {
+    // The measured Windows case: 4 retained worktrees x 4 mounted panes = 16
+    // panes, which the count-based cap reports as within budget.
+    const worktrees = [1, 2, 3, 4].map((n) => paneCandidate(`wt-${n}`, n, 4))
+    // wt-1 (most recently hidden) keeps 4; wt-2 takes it to 8, still within;
+    // wt-3 and wt-4 cross it.
+    expect(select(worktrees)).toEqual(new Set(['wt-3', 'wt-4']))
+  })
+
+  it('never parks the worktree the user just left, however many panes it holds', () => {
+    // Why: remounting the view you just switched away from is the cost users
+    // actually notice, and one worktree can legitimately exceed the budget.
+    const worktrees = [paneCandidate('wt-huge', 1, 40), paneCandidate('wt-small', 2, 1)]
+    expect(select(worktrees)).toEqual(new Set(['wt-small']))
+  })
+
+  it('evicts least-recently-hidden first', () => {
+    const worktrees = [
+      paneCandidate('newest', 1, 5),
+      paneCandidate('middle', 5, 5),
+      paneCandidate('oldest', 9, 5)
+    ]
+    expect(select(worktrees)).toEqual(new Set(['middle', 'oldest']))
+  })
+
+  it('counts an unknown pane count as one rather than free', () => {
+    // Why: a worktree whose layout could not be read must never look costless,
+    // or a missing layout silently lifts the budget for everything after it.
+    const worktrees = [
+      paneCandidate('wt-1', 1, 8),
+      { ...paneCandidate('wt-2', 2, 1), mountedPaneCount: undefined }
+    ]
+    expect(select(worktrees)).toEqual(new Set(['wt-2']))
+  })
+
+  it('honours an explicit pane limit', () => {
+    const worktrees = [1, 2, 3].map((n) => paneCandidate(`wt-${n}`, n, 2))
+    expect(select(worktrees, 100)).toEqual(new Set())
+    expect(select(worktrees, 2)).toEqual(new Set(['wt-2', 'wt-3']))
+  })
+
+  it('stays off when the retention budget is disabled', () => {
+    const worktrees = [1, 2, 3, 4].map((n) => paneCandidate(`wt-${n}`, n, 10))
+    expect(
+      selectRetentionForceParkedTerminalWorktrees({
+        worktrees,
+        parkingEnabled: true,
+        retentionBudgetEnabled: false,
+        nowMs
+      })
+    ).toEqual(new Set())
+  })
+})
+
+describe('countMountedWorktreePanes', () => {
+  it('counts split leaves, and one pane for a tab with no layout row yet', () => {
+    expect(
+      countMountedWorktreePanes([{ id: 'split' }, { id: 'plain' }, { id: 'empty-layout' }], {
+        split: { ptyIdsByLeafId: { a: 'pty-a', b: 'pty-b', c: 'pty-c' } },
+        'empty-layout': { ptyIdsByLeafId: {} }
+      })
+    ).toBe(5)
+  })
+
+  it('is zero for a worktree with no tabs', () => {
+    expect(countMountedWorktreePanes([], {})).toBe(0)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-hidden-worktree-retention.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-hidden-worktree-retention.ts
@@ -30,6 +30,25 @@ import { createWorktreeTabBucketProjection } from '@/lib/worktree-tab-bucket-pro
 // eviction, not demotion.
 export const TERMINAL_HIDDEN_WORKTREE_RETENTION_LIMIT = 4
 export const TERMINAL_HIDDEN_WORKTREE_RETENTION_TTL_MS = 15 * 60_000
+/**
+ * Second bound, in the unit the cost is actually paid in.
+ *
+ * Why: the cap above counts WORKTREES, but a hidden worktree costs whatever its
+ * mounted panes hold, and nothing bounds panes-per-worktree. Measured on
+ * Windows against this app: 6 worktrees x 4 terminal tabs filled with 8000
+ * lines each left 24 mounted panes holding 19.3M buffer cells, and a renderer
+ * that idled at 566MB with only one worktree visible — the worktree cap had
+ * evicted 4 panes and then plateaued, exactly as designed and nowhere near
+ * enough. Four worktrees x N tabs x scrollback has no ceiling at all, and the
+ * scrollback setting goes to 50k rows.
+ *
+ * 8 panes is ~62MB of buffers at the 5k-row default (~12MB/pane measured at
+ * 8000 rows, ~7.7MB at 5k). It leaves the ordinary working set — four hidden
+ * worktrees at one or two tabs each — entirely untouched, and only engages for
+ * the many-pane tail. Tune it here; it is one number and it is not load-bearing
+ * for correctness.
+ */
+export const TERMINAL_HIDDEN_WORKTREE_RETENTION_PANE_LIMIT = 8
 
 export function createTerminalWorktreeTopologyProjection(
   onInspectBucket?: (worktreeId: string) => void
@@ -131,6 +150,24 @@ export function countEvictionExemptTabRoutes(
   return counts
 }
 
+/**
+ * Panes a worktree keeps mounted: split leaves where a layout exists, else one
+ * per tab. This is the unit the retention pane budget is spent in.
+ */
+export function countMountedWorktreePanes(
+  tabs: readonly Pick<TerminalTab, 'id'>[],
+  layoutsByTabId: Readonly<Record<string, { ptyIdsByLeafId?: Readonly<Record<string, string>> }>>
+): number {
+  let panes = 0
+  for (const tab of tabs) {
+    const leafIds = layoutsByTabId[tab.id]?.ptyIdsByLeafId
+    const leafCount = leafIds ? Object.keys(leafIds).length : 0
+    // An unsplit tab has no layout row yet; it still holds one mounted pane.
+    panes += leafCount > 0 ? leafCount : 1
+  }
+  return panes
+}
+
 export function formatEvictionExemptRouteCounts(counts: EvictionExemptRouteCounts): string {
   return `routes=fail-open:${counts.failOpen},foreign:${counts.foreignWorktree},capability:${counts.capabilityUnknown},split-pane:${counts.splitPane}`
 }
@@ -149,6 +186,12 @@ export type TerminalWorktreeRetentionCandidate = {
   ordinaryParkingCovers: boolean
   /** Pending startup or activation spawn — a mount is imminent; never evict. */
   hasPendingSpawnWork: boolean
+  /**
+   * Panes this worktree keeps mounted while hidden (split leaves, not tabs).
+   * Omitted means "unknown", which is counted as one pane rather than zero so a
+   * missing layout can never make a worktree look free to retain.
+   */
+  mountedPaneCount?: number
 }
 
 /**
@@ -178,6 +221,7 @@ export function selectRetentionForceParkedTerminalWorktrees(
   }
   const coldParkDelayMs = args.coldParkDelayMs ?? TERMINAL_WORKTREE_COLD_PARK_DELAY_MS
   const candidates: ColdParkRetainCandidate[] = []
+  const paneCountsById = new Map<string, number>()
   for (const worktree of args.worktrees) {
     if (
       worktree.hiddenSinceMs === null ||
@@ -192,6 +236,7 @@ export function selectRetentionForceParkedTerminalWorktrees(
       continue
     }
     candidates.push({ id: worktree.worktreeId, hiddenSinceMs: worktree.hiddenSinceMs })
+    paneCountsById.set(worktree.worktreeId, worktree.mountedPaneCount ?? 1)
   }
   const retentionTtlMs = args.retentionTtlMs ?? TERMINAL_HIDDEN_WORKTREE_RETENTION_TTL_MS
   const forceParkedIds = selectIdsBeyondHotRetain(candidates, {
@@ -207,7 +252,53 @@ export function selectRetentionForceParkedTerminalWorktrees(
       forceParkedIds.add(candidate.id)
     }
   }
+  addPaneBudgetForceParkedIds(
+    candidates,
+    paneCountsById,
+    forceParkedIds,
+    args.retentionPaneLimit ?? TERMINAL_HIDDEN_WORKTREE_RETENTION_PANE_LIMIT
+  )
   return forceParkedIds
+}
+
+/**
+ * Force-parks whatever the worktree cap left retained once its mounted panes
+ * exceed the pane budget, least-recently-hidden first.
+ *
+ * Why it runs after the cap rather than replacing it: the cap is what keeps the
+ * ordinary rotation warm, and one worktree can legitimately hold more panes
+ * than the budget. The most-recently-hidden worktree is spared here for the
+ * same reason it is spared there — it is the view the user just left, and
+ * remounting it is the cost they actually notice.
+ */
+function addPaneBudgetForceParkedIds(
+  candidates: readonly ColdParkRetainCandidate[],
+  paneCountsById: ReadonlyMap<string, number>,
+  forceParkedIds: Set<string>,
+  paneLimit: number
+): void {
+  const retained = candidates.filter((candidate) => !forceParkedIds.has(candidate.id))
+  if (retained.length <= 1) {
+    return
+  }
+  // Newest hidden first: the same ranking the cap evicts by, reversed.
+  const ranked = [...retained].sort((left, right) => {
+    if (left.hiddenSinceMs !== right.hiddenSinceMs) {
+      return right.hiddenSinceMs - left.hiddenSinceMs
+    }
+    const activationDelta = (right.lastActivatedSeq ?? -1) - (left.lastActivatedSeq ?? -1)
+    return activationDelta === 0 ? left.id.localeCompare(right.id) : activationDelta
+  })
+  let panes = 0
+  for (let index = 0; index < ranked.length; index += 1) {
+    const candidate = ranked[index]
+    // Why 1 and not 0 for an unknown count: a worktree whose layout we cannot
+    // read must never look free, or a missing layout silently lifts the budget.
+    panes += paneCountsById.get(candidate.id) ?? 1
+    if (index > 0 && panes > paneLimit) {
+      forceParkedIds.add(candidate.id)
+    }
+  }
 }
 
 // Why exported: an all-exempt force-park frees nothing, and that degenerate


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​110 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​110 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​99 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​98 |

<!-- /orca-pr-loc -->

## Why

The retention budget caps how many un-parkable hidden worktrees stay mounted (4) and how long (15 min). But a hidden worktree costs whatever its *mounted panes* hold, and nothing bounds panes-per-worktree — so 4 worktrees x N tabs x scrollback has no memory ceiling at all, and the scrollback setting goes to 50k rows.

Measured on Windows against this app: 6 worktrees x 4 terminal tabs, 8000 lines written into each mounted pane, then idled 4 minutes with a single worktree visible.

```
                       filled     +30s     +60s     +90s    +120s
mounted panes              24       20       20       20       20
xterm buffer cells      19.3M    16.1M    16.1M    16.1M    16.1M
renderer working set    569MB    567MB    570MB    566MB    564MB
usedJSHeapSize           45MB     45MB     45MB     45MB     45MB
```

The worktree cap evicted 4 of 24 panes and then plateaued, for as long as it was left alone. It behaved exactly as documented — the *unit* is what is wrong.

## What this changes

A second bound, in the unit the cost is actually paid in: once the worktrees the cap left retained exceed a mounted-pane budget, force-park the rest least-recently-hidden first. Panes are split leaves, not tabs, since a split tab holds one buffer per leaf.

It runs **after** the cap rather than replacing it, so the ordinary working set — four hidden worktrees at one or two tabs each — is untouched, and it only engages for the many-pane tail. It spares the most-recently-hidden worktree for the same reason the cap does: remounting the view you just left is the cost users actually notice, and one worktree can legitimately exceed the budget on its own.

A worktree whose layout cannot be read counts as one pane rather than zero, so a missing layout can never silently lift the budget.

## The constant

`TERMINAL_HIDDEN_WORKTREE_RETENTION_PANE_LIMIT = 8` — ~62MB of buffers at the 5k-row default (~12MB/pane measured at 8000 rows, ~7.7MB at 5k).

I want to flag this honestly: **the number is a starting point derived from one measured workload, not a validated optimum.** It is a single constant, it is overridable through the existing `TerminalColdParkPolicyOverrides`, and the whole bound stays behind the existing `terminalHiddenWorktreeRetentionBudget` setting. If someone who owns parking policy wants a different value or a byte budget instead of a pane count, that is a one-line change on top of this — the mechanism is the part worth reviewing.

Note the existing carve-outs still apply and are unchanged: eviction-exempt tabs keep their mounted panes through a force-park, so an all-exempt worktree still frees nothing (Terminal.tsx already logs that degenerate case).

## Tests

`terminal-hidden-worktree-retention.test.ts`, 9 new cases (5 fail without the change):

- four hidden worktrees at one tab each are left completely alone;
- 4 retained worktrees x 4 panes — which the count cap reports as within budget — parks the two oldest;
- the worktree the user just left is never parked, at 40 panes;
- eviction is least-recently-hidden first;
- an unknown pane count is charged as one, not zero;
- an explicit limit is honoured, and the whole bound is off when the retention budget setting is off;
- `countMountedWorktreePanes` counts split leaves and charges one pane for a tab with no layout row yet.

Typecheck, oxlint, oxfmt clean; the retention suite passes at 30 tests.

## Compatibility

Renderer-local policy. No RPC field, stream opcode, persisted data, Git command, or provider contract, so mixed client/server versions need no negotiation. Native, WSL, SSH, relay, folder-workspace and git-worktree candidates all enter the same selector.

## Related

Third of three from the Windows slowdown investigation — #16449 (renderer memory attribution, the prerequisite for seeing this in the field) and #16450 (Git subprocess churn).