### PR TITLE
fix(skills): recognize symlinks targeting canonical skill location as provider aliases

### DIFF
--- a/src/main/skills/skill-installation-topology.ts
+++ b/src/main/skills/skill-installation-topology.ts
@@ -125,9 +125,18 @@ export async function classifyHomeSkillTopology(
   const canonicalRoot = await realpath(canonicalRootPath).catch(() => resolve(canonicalRootPath))
   const homeBoundary = dirname(dirname(canonicalRootPath))
   const rootOrProviderParentLinked = await hasSymlinkedAncestor(root.path, homeBoundary)
+  const canonicalSkillPath = resolve(
+    canonicalRootPath,
+    normalize(unresolvedPath).split('/').pop() || ''
+  )
+  const resolvedCanonicalSkillPath = await realpath(canonicalSkillPath).catch(
+    () => canonicalSkillPath
+  )
   const isCanonicalTarget =
     normalizedSkillIdentityPath(dirname(resolvedPath)) ===
-    normalizedSkillIdentityPath(canonicalRoot)
+      normalizedSkillIdentityPath(canonicalRoot) ||
+    normalizedSkillIdentityPath(resolvedPath) ===
+      normalizedSkillIdentityPath(resolvedCanonicalSkillPath)
   let topology: SkillInstallationTopology
   if (linked) {
     topology = isCanonicalTarget ? 'provider-alias' : 'external-link'

--- a/src/main/skills/skill-installation-topology.ts
+++ b/src/main/skills/skill-installation-topology.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto'
 import { constants, type Stats } from 'node:fs'
 import { access, lstat, realpath, stat } from 'node:fs/promises'
-import { dirname, normalize, resolve } from 'node:path'
+import { basename, dirname, normalize, resolve } from 'node:path'
 import type { SkillInstallationTopology } from '../../shared/skill-freshness'
 import type { SkillScanRoot } from './skill-discovery-sources'
 
@@ -125,10 +125,7 @@ export async function classifyHomeSkillTopology(
   const canonicalRoot = await realpath(canonicalRootPath).catch(() => resolve(canonicalRootPath))
   const homeBoundary = dirname(dirname(canonicalRootPath))
   const rootOrProviderParentLinked = await hasSymlinkedAncestor(root.path, homeBoundary)
-  const canonicalSkillPath = resolve(
-    canonicalRootPath,
-    normalize(unresolvedPath).split('/').pop() || ''
-  )
+  const canonicalSkillPath = resolve(canonicalRootPath, basename(unresolvedPath))
   const resolvedCanonicalSkillPath = await realpath(canonicalSkillPath).catch(
     () => canonicalSkillPath
   )


### PR DESCRIPTION
### Summary

When agents share skills via symlinks (e.g. dotfile managers, shared toolchains, or package managers like `skills` CLI), `classifyHomeSkillTopology` previously checked:

```ts
isCanonicalTarget = normalizedSkillIdentityPath(dirname(resolvedPath)) === normalizedSkillIdentityPath(canonicalRoot)
```

If `~/.agents/skills/<skill>` and an agent root (e.g. `~/.cursor/skills/<skill>`) both resolve to the same underlying physical skill path, or when an agent directory symlinks directly to the canonical skill destination, `dirname(resolvedPath)` is not strictly `canonicalRoot`. Consequently, Orca classified the installation as `external-link` and skipped it during updates.

### Changes

- Check `resolvedPath === resolvedCanonicalSkillPath` in `classifyHomeSkillTopology`.
- If an agent symlink resolves to the same target as the canonical skill, treat it as a `provider-alias` rather than an `external-link`.

### Test Plan

1. Symlink `~/.agents/skills/orchestration` and `~/.cursor/skills/orchestration` to a shared skill directory.
2. Run inventory scan.
3. Verify Orca recognizes the installation as `provider-alias` (`current`) without marking it as a skipped `external-link`.