### PR TITLE
draft(editor): give oversized files an explanatory fallback, not a lowered cap

### DIFF
--- a/src/main/ai-vault/remote-session-scanner-test-fixtures.ts
+++ b/src/main/ai-vault/remote-session-scanner-test-fixtures.ts
@@ -7,6 +7,7 @@ export class MemoryRemoteProvider implements IFilesystemProvider {
   private readonly files = new Map<string, { content: string; mtimeMs: number }>()
   private readonly readDirErrors = new Map<string, Error>()
   private readonly statErrors = new Map<string, Error>()
+  private readonly readFileErrors = new Map<string, Error>()
   readonly readDirPaths: string[] = []
 
   addFile(path: string, content: string, mtimeMs: number): void {
@@ -15,6 +16,10 @@ export class MemoryRemoteProvider implements IFilesystemProvider {
 
   failStat(path: string, error: Error): void {
     this.statErrors.set(normalize(path), error)
+  }
+
+  failReadFile(path: string, error: Error): void {
+    this.readFileErrors.set(normalize(path), error)
   }
 
   failReadDir(path: string, error: Error): void {
@@ -52,6 +57,10 @@ export class MemoryRemoteProvider implements IFilesystemProvider {
   }
 
   async readFile(filePath: string): Promise<FileReadResult> {
+    const readFileError = this.readFileErrors.get(normalize(filePath))
+    if (readFileError) {
+      throw readFileError
+    }
     const file = this.files.get(normalize(filePath))
     if (!file) {
       throw new Error(`ENOENT: ${filePath}`)

--- a/src/main/ai-vault/remote-session-scanner.test.ts
+++ b/src/main/ai-vault/remote-session-scanner.test.ts
@@ -3,6 +3,7 @@ import { getRemoteHostPlatform } from '../ssh/ssh-remote-platform'
 import { scanRemoteAiVaultSessions } from './remote-session-scanner'
 import { MemoryRemoteProvider, jsonLines } from './remote-session-scanner-test-fixtures'
 import { primeAgentFixture } from './session-scanner-prime-agent-fixtures'
+import { formatFileTooLargeMessage } from '../../shared/editor-file-read-limit'
 
 describe('scanRemoteAiVaultSessions', () => {
   it('parses remote default and Orca-managed Codex homes with SSH host ids', async () => {
@@ -311,6 +312,40 @@ describe('scanRemoteAiVaultSessions', () => {
         agent: 'antigravity',
         path: deniedTranscript,
         message: expect.stringContaining('EACCES')
+      })
+    ])
+  })
+
+  // The relay serves these reads with the same function the editor uses, so its
+  // refusal arrives carrying the editor's machine marker. This row is rendered
+  // verbatim in the sidebar, so the marker must not survive the scan.
+  it('records an oversized transcript without the editor read marker', async () => {
+    const provider = new MemoryRemoteProvider()
+    const transcript = '/home/ada/.claude/projects/repo/huge.jsonl'
+    provider.addFile(transcript, jsonLines([{ type: 'user', message: { content: 'hi' } }]), 5)
+    provider.failReadFile(
+      transcript,
+      new Error(
+        formatFileTooLargeMessage({
+          byteLength: 13_002_342,
+          limitBytes: 10 * 1024 * 1024,
+          scope: 'ssh'
+        })
+      )
+    )
+
+    const result = await scanRemoteAiVaultSessions({
+      provider,
+      executionHostId: 'ssh:dev-box',
+      remoteHome: '/home/ada',
+      hostPlatform: getRemoteHostPlatform('linux-x64')
+    })
+
+    expect(result.issues).toEqual([
+      expect.objectContaining({
+        path: transcript,
+        message:
+          'File too large: 12.4 MB exceeds the 10.0 MB read limit for files on this SSH host.'
       })
     ])
   })

--- a/src/main/ai-vault/session-scan-issues.test.ts
+++ b/src/main/ai-vault/session-scan-issues.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { recordSessionScanIssue } from './session-scan-issues'
+import { formatFileTooLargeMessage } from '../../shared/editor-file-read-limit'
+import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
+
+describe('recordSessionScanIssue', () => {
+  // The relay's AI Vault provider reuses the editor's file reader, so its refusal
+  // carries the editor's machine-readable marker. The panel renders issue.message
+  // verbatim, so the marker has to be gone before it is recorded.
+  it('strips the editor read-limit marker from a transcript read failure', () => {
+    const issues: AiVaultScanIssue[] = []
+
+    recordSessionScanIssue(issues, {
+      agent: 'claude',
+      path: '/home/u/.claude/projects/x/session.jsonl',
+      message: formatFileTooLargeMessage({
+        byteLength: 13_002_342,
+        limitBytes: 10 * 1024 * 1024,
+        scope: 'ssh'
+      })
+    })
+
+    expect(issues[0]!.message).toBe(
+      'File too large: 12.4 MB exceeds the 10.0 MB read limit for files on this SSH host.'
+    )
+  })
+
+  it('strips the bare protocol marker a host with nothing to report emits', () => {
+    const issues: AiVaultScanIssue[] = []
+
+    recordSessionScanIssue(issues, {
+      agent: 'codex',
+      path: '/home/u/.codex/sessions/a.jsonl',
+      message: formatFileTooLargeMessage({})
+    })
+
+    expect(issues[0]!.message).toBe('File too large: over the read limit.')
+  })
+
+  it('leaves an unrelated failure untouched', () => {
+    const issues: AiVaultScanIssue[] = []
+
+    recordSessionScanIssue(issues, {
+      agent: 'codex',
+      path: '/home/u/.codex/sessions/a.jsonl',
+      message: 'EACCES: permission denied, open [/home/u/.codex]'
+    })
+
+    expect(issues[0]!.message).toBe('EACCES: permission denied, open [/home/u/.codex]')
+  })
+})

--- a/src/main/ai-vault/session-scan-issues.ts
+++ b/src/main/ai-vault/session-scan-issues.ts
@@ -1,4 +1,5 @@
 import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
+import { stripFileTooLargeMarker } from '../../shared/editor-file-read-limit'
 
 // Why: a stalled WSL distro or an unreachable remote host fails one probe per
 // discovered path, so an uncapped list ships one row per transcript file in the
@@ -6,10 +7,17 @@ import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
 // the same and both feed the same panel.
 const SCAN_ISSUE_LIMIT = 500
 
+// Why: the panel renders issue.message verbatim, and remote transcript reads go
+// through the same reader the editor uses, so its machine marker rides along.
+function toReadableIssue(issue: AiVaultScanIssue): AiVaultScanIssue {
+  const message = stripFileTooLargeMarker(issue.message)
+  return message === issue.message ? issue : { ...issue, message }
+}
+
 /** Append a scan issue, collapsing everything past the cap into one notice. */
 export function recordSessionScanIssue(issues: AiVaultScanIssue[], issue: AiVaultScanIssue): void {
   if (issues.length < SCAN_ISSUE_LIMIT - 1) {
-    issues.push(issue)
+    issues.push(toReadableIssue(issue))
     return
   }
   if (issues.length === SCAN_ISSUE_LIMIT - 1) {

--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -430,7 +430,29 @@ describe('registerFilesystemHandlers', () => {
 
     await expect(
       handlers.get('fs:readFile')!(null, { filePath: path.resolve('/workspace/repo/huge.json') })
-    ).rejects.toThrow('exceeds 50MB limit')
+    ).rejects.toThrow('[size=53477376 limit=52428800 scope=local]')
+
+    expect(readFileMock).not.toHaveBeenCalled()
+  })
+
+  // The size gate must not swallow the binary placeholder: an oversized archive
+  // is not "unreadable", it is simply not text, and the editor already has a
+  // view for that.
+  it('still reports oversized non-previewable binaries as binary', async () => {
+    statMock.mockResolvedValue({ size: 60 * 1024 * 1024, isDirectory: () => false, mtimeMs: 123 })
+    openMock.mockResolvedValue({
+      read: vi.fn(async (buffer: Buffer) => {
+        buffer[0] = 0x00
+        return { bytesRead: 1, buffer }
+      }),
+      close: vi.fn()
+    })
+
+    registerFilesystemHandlers(store as never)
+
+    await expect(
+      handlers.get('fs:readFile')!(null, { filePath: path.resolve('/workspace/repo/huge.bin') })
+    ).resolves.toEqual({ content: '', isBinary: true })
 
     expect(readFileMock).not.toHaveBeenCalled()
   })

--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -68,6 +68,7 @@ vi.mock(
   async () => (await import('./filesystem-test-harness')).pullRequestLinkedIssueMock
 )
 
+import { EDITOR_READ_OVERRIDE_CEILING_BYTES } from '../../shared/editor-file-read-limit'
 import { registerFilesystemHandlers } from './filesystem'
 import {
   registerWorktreeRootsForRepo,
@@ -433,6 +434,120 @@ describe('registerFilesystemHandlers', () => {
     ).rejects.toThrow('[size=53477376 limit=52428800 scope=local]')
 
     expect(readFileMock).not.toHaveBeenCalled()
+  })
+
+  // The local budget is a confirmation, not a hard ceiling — a local read has no
+  // shared transport to protect — so an explicit override reads the whole file.
+  it('reads a file past the editor budget when the caller overrides it', async () => {
+    const content = 'a'.repeat(51 * 1024 * 1024)
+    statMock.mockResolvedValue({ size: content.length, isDirectory: () => false, mtimeMs: 123 })
+    readFileMock.mockResolvedValue(Buffer.from(content))
+
+    registerFilesystemHandlers(store as never)
+
+    await expect(
+      handlers.get('fs:readFile')!(null, {
+        filePath: path.resolve('/workspace/repo/huge.json'),
+        allowLargeFile: true
+      })
+    ).resolves.toEqual({ content, isBinary: false })
+  })
+
+  it('reads a previewable binary past its budget when the caller overrides it', async () => {
+    const buf = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00])
+    statMock.mockResolvedValue({ size: 60 * 1024 * 1024, isDirectory: () => false, mtimeMs: 123 })
+    readFileMock.mockResolvedValue(buf)
+
+    registerFilesystemHandlers(store as never)
+
+    await expect(
+      handlers.get('fs:readFile')!(null, {
+        filePath: path.resolve('/workspace/repo/huge.png'),
+        allowLargeFile: true
+      })
+    ).resolves.toEqual({
+      content: buf.toString('base64'),
+      isBinary: true,
+      isImage: true,
+      mimeType: 'image/png'
+    })
+  })
+
+  // "Open Anyway" lifts the confirmation budget, not the transport's own ceiling.
+  // This path materializes the whole file as one main-process string and ships it
+  // whole over IPC, and V8 cannot hold a string past MAX_STRING_LENGTH — refusing
+  // by size keeps the failure a parseable refusal instead of an allocation throw.
+  it('still refuses an overridden text read past the ceiling the transport can hold', async () => {
+    statMock.mockResolvedValue({
+      size: EDITOR_READ_OVERRIDE_CEILING_BYTES + 1,
+      isDirectory: () => false,
+      mtimeMs: 123
+    })
+    openMock.mockResolvedValue({
+      read: vi.fn(async (buffer: Buffer) => {
+        buffer[0] = 0x61
+        return { bytesRead: 1, buffer }
+      }),
+      close: vi.fn()
+    })
+
+    registerFilesystemHandlers(store as never)
+
+    await expect(
+      handlers.get('fs:readFile')!(null, {
+        filePath: path.resolve('/workspace/repo/enormous.log'),
+        allowLargeFile: true
+      })
+    ).rejects.toThrow(`limit=${EDITOR_READ_OVERRIDE_CEILING_BYTES} scope=local`)
+
+    expect(readFileMock).not.toHaveBeenCalled()
+  })
+
+  it('still refuses an overridden previewable-binary read past the ceiling', async () => {
+    statMock.mockResolvedValue({
+      size: EDITOR_READ_OVERRIDE_CEILING_BYTES + 1,
+      isDirectory: () => false,
+      mtimeMs: 123
+    })
+
+    registerFilesystemHandlers(store as never)
+
+    await expect(
+      handlers.get('fs:readFile')!(null, {
+        filePath: path.resolve('/workspace/repo/enormous.png'),
+        allowLargeFile: true
+      })
+    ).rejects.toThrow(`limit=${EDITOR_READ_OVERRIDE_CEILING_BYTES} scope=local`)
+
+    expect(readFileMock).not.toHaveBeenCalled()
+  })
+
+  it('still refuses an overridden live-tail log read past the ceiling', async () => {
+    const close = vi.fn()
+    const readFile = vi.fn()
+    openMock.mockResolvedValue({
+      stat: vi.fn().mockResolvedValue({
+        size: EDITOR_READ_OVERRIDE_CEILING_BYTES + 1,
+        dev: 1,
+        ino: 2,
+        birthtimeMs: 3
+      }),
+      readFile,
+      close
+    })
+
+    registerFilesystemHandlers(store as never)
+
+    await expect(
+      handlers.get('fs:readFile')!(null, {
+        filePath: path.resolve('/workspace/repo/session.jsonl'),
+        includeLocalLogMetadata: true,
+        allowLargeFile: true
+      })
+    ).rejects.toThrow(`limit=${EDITOR_READ_OVERRIDE_CEILING_BYTES} scope=local`)
+
+    expect(readFile).not.toHaveBeenCalled()
+    expect(close).toHaveBeenCalledTimes(1)
   })
 
   // The size gate must not swallow the binary placeholder: an oversized archive

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -146,6 +146,7 @@ import {
 } from './git-status-upstream-ref-watch-request'
 import {
   EDITOR_PREVIEWABLE_BINARY_MAX_BYTES,
+  EDITOR_READ_OVERRIDE_CEILING_BYTES,
   EDITOR_TEXT_READ_LIMIT_BYTES,
   formatFileTooLargeMessage
 } from '../../shared/editor-file-read-limit'
@@ -174,7 +175,22 @@ function throwFileTooLarge(byteLength: number, limitBytes: number): never {
   throw new Error(formatFileTooLargeMessage({ byteLength, limitBytes, scope: 'local' }))
 }
 
-async function readLocalLogSnapshot(filePath: string): Promise<{
+/**
+ * The budget an overridden read still answers to. "Open Anyway" overrules the
+ * confirmation, not the transport: this handler hands the renderer one whole
+ * string, and past `EDITOR_READ_OVERRIDE_CEILING_BYTES` neither V8 nor the
+ * editor model can hold one — those throws carry no refusal marker, so the
+ * editor would show a raw allocation error and retry into it. Refusing by size
+ * keeps it a `file_too_large`.
+ */
+function localReadLimit(budgetBytes: number, allowLargeFile: boolean): number {
+  return allowLargeFile ? EDITOR_READ_OVERRIDE_CEILING_BYTES : budgetBytes
+}
+
+async function readLocalLogSnapshot(
+  filePath: string,
+  allowLargeFile: boolean
+): Promise<{
   content: string
   isBinary: boolean
   fileIdentity?: string
@@ -182,12 +198,13 @@ async function readLocalLogSnapshot(filePath: string): Promise<{
   const handle = await open(filePath, 'r')
   try {
     const stats = await handle.stat()
-    if (stats.size > MAX_TEXT_FILE_SIZE) {
-      throwFileTooLarge(stats.size, MAX_TEXT_FILE_SIZE)
+    const limit = localReadLimit(MAX_TEXT_FILE_SIZE, allowLargeFile)
+    if (stats.size > limit) {
+      throwFileTooLarge(stats.size, limit)
     }
     const buffer = await handle.readFile()
-    if (buffer.byteLength > MAX_TEXT_FILE_SIZE) {
-      throwFileTooLarge(buffer.byteLength, MAX_TEXT_FILE_SIZE)
+    if (buffer.byteLength > limit) {
+      throwFileTooLarge(buffer.byteLength, limit)
     }
     if (isBinaryBuffer(buffer)) {
       return { content: '', isBinary: true }
@@ -587,7 +604,13 @@ export function registerFilesystemHandlers(
     'fs:readFile',
     async (
       _event,
-      args: { filePath: string; connectionId?: string; includeLocalLogMetadata?: boolean }
+      args: {
+        filePath: string
+        connectionId?: string
+        includeLocalLogMetadata?: boolean
+        /** Caller overruled the local size budget; see LargeFileFallback. */
+        allowLargeFile?: boolean
+      }
     ): Promise<{
       content: string
       isBinary: boolean
@@ -600,17 +623,25 @@ export function registerFilesystemHandlers(
         return provider.readFile(args.filePath)
       }
       const filePath = await resolveAuthorizedPath(args.filePath, store)
+      // Why: the local budget is a confirmation, not a ceiling — no shared
+      // transport is at stake — but `localReadLimit` still bounds the override.
+      const allowLargeFile = args.allowLargeFile === true
       if (args.includeLocalLogMetadata === true) {
-        return readLocalLogSnapshot(filePath)
+        return readLocalLogSnapshot(filePath, allowLargeFile)
       }
       const stats = await stat(filePath)
       const mimeType = PREVIEWABLE_BINARY_MIME_TYPES[extname(filePath).toLowerCase()]
 
       if (mimeType) {
-        if (stats.size > MAX_PREVIEWABLE_BINARY_SIZE) {
-          throwFileTooLarge(stats.size, MAX_PREVIEWABLE_BINARY_SIZE)
+        const previewLimit = localReadLimit(MAX_PREVIEWABLE_BINARY_SIZE, allowLargeFile)
+        if (stats.size > previewLimit) {
+          throwFileTooLarge(stats.size, previewLimit)
         }
         const buffer = await readFile(filePath)
+        // Why: stat is advisory — the file may have grown before the read landed.
+        if (buffer.byteLength > previewLimit) {
+          throwFileTooLarge(buffer.byteLength, previewLimit)
+        }
         return {
           content: buffer.toString('base64'),
           isBinary: true,
@@ -627,13 +658,18 @@ export function registerFilesystemHandlers(
         return { content: '', isBinary: true }
       }
 
-      if (stats.size > MAX_TEXT_FILE_SIZE) {
-        throwFileTooLarge(stats.size, MAX_TEXT_FILE_SIZE)
+      const textLimit = localReadLimit(MAX_TEXT_FILE_SIZE, allowLargeFile)
+      if (stats.size > textLimit) {
+        throwFileTooLarge(stats.size, textLimit)
       }
 
       const buffer = await readFile(filePath)
       if (isBinaryBuffer(buffer)) {
         return { content: '', isBinary: true }
+      }
+      // Why: stat is advisory — an appending log can outgrow it before the read.
+      if (buffer.byteLength > textLimit) {
+        throwFileTooLarge(buffer.byteLength, textLimit)
       }
 
       return { content: buffer.toString('utf-8'), isBinary: false }

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -144,15 +144,20 @@ import {
   applyGitStatusUpstreamRefWatchRequest,
   type GitStatusUpstreamRefWatchRequest
 } from './git-status-upstream-ref-watch-request'
+import {
+  EDITOR_PREVIEWABLE_BINARY_MAX_BYTES,
+  EDITOR_TEXT_READ_LIMIT_BYTES,
+  formatFileTooLargeMessage
+} from '../../shared/editor-file-read-limit'
 
-// Why: Monaco degrades features on large files like VS Code, so a 5MB block would needlessly lock out ordinary JSON/log files.
-const MAX_TEXT_FILE_SIZE = 50 * 1024 * 1024 // 50MB
+// Why: the editor degrades features on large files, so a 5MB block would needlessly lock out ordinary JSON/log files.
+const MAX_TEXT_FILE_SIZE = EDITOR_TEXT_READ_LIMIT_BYTES.local
 const BINARY_PROBE_BYTES = 8192
 const FULL_GIT_OBJECT_ID_PATTERN = /^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$/
 // 32 visible matches plus one truncation sentinel stays below the legacy frame ceiling.
 const QUICK_OPEN_SSH_LEGACY_RESULT_LIMIT = 33
 // Why: previewable binaries are base64 blobs (not parsed as text), and local IPC has no frame limit (unlike the relay's 10MB), so 50MB is safe.
-const MAX_PREVIEWABLE_BINARY_SIZE = 50 * 1024 * 1024 // 50MB
+const MAX_PREVIEWABLE_BINARY_SIZE = EDITOR_PREVIEWABLE_BINARY_MAX_BYTES
 const PREVIEWABLE_BINARY_MIME_TYPES: Record<string, string> = {
   '.png': 'image/png',
   '.jpg': 'image/jpeg',
@@ -164,6 +169,11 @@ const PREVIEWABLE_BINARY_MIME_TYPES: Record<string, string> = {
   '.ico': 'image/x-icon',
   '.pdf': 'application/pdf'
 }
+
+function throwFileTooLarge(byteLength: number, limitBytes: number): never {
+  throw new Error(formatFileTooLargeMessage({ byteLength, limitBytes, scope: 'local' }))
+}
+
 async function readLocalLogSnapshot(filePath: string): Promise<{
   content: string
   isBinary: boolean
@@ -173,15 +183,11 @@ async function readLocalLogSnapshot(filePath: string): Promise<{
   try {
     const stats = await handle.stat()
     if (stats.size > MAX_TEXT_FILE_SIZE) {
-      throw new Error(
-        `File too large: ${(stats.size / 1024 / 1024).toFixed(1)}MB exceeds ${MAX_TEXT_FILE_SIZE / 1024 / 1024}MB limit`
-      )
+      throwFileTooLarge(stats.size, MAX_TEXT_FILE_SIZE)
     }
     const buffer = await handle.readFile()
     if (buffer.byteLength > MAX_TEXT_FILE_SIZE) {
-      throw new Error(
-        `File too large: ${(buffer.byteLength / 1024 / 1024).toFixed(1)}MB exceeds ${MAX_TEXT_FILE_SIZE / 1024 / 1024}MB limit`
-      )
+      throwFileTooLarge(buffer.byteLength, MAX_TEXT_FILE_SIZE)
     }
     if (isBinaryBuffer(buffer)) {
       return { content: '', isBinary: true }
@@ -599,14 +605,11 @@ export function registerFilesystemHandlers(
       }
       const stats = await stat(filePath)
       const mimeType = PREVIEWABLE_BINARY_MIME_TYPES[extname(filePath).toLowerCase()]
-      const sizeLimit = mimeType ? MAX_PREVIEWABLE_BINARY_SIZE : MAX_TEXT_FILE_SIZE
-      if (stats.size > sizeLimit) {
-        throw new Error(
-          `File too large: ${(stats.size / 1024 / 1024).toFixed(1)}MB exceeds ${sizeLimit / 1024 / 1024}MB limit`
-        )
-      }
 
       if (mimeType) {
+        if (stats.size > MAX_PREVIEWABLE_BINARY_SIZE) {
+          throwFileTooLarge(stats.size, MAX_PREVIEWABLE_BINARY_SIZE)
+        }
         const buffer = await readFile(filePath)
         return {
           content: buffer.toString('base64'),
@@ -617,9 +620,15 @@ export function registerFilesystemHandlers(
         }
       }
 
-      // Why: probe large unknown files first so archives aren't fully buffered only to discover they aren't editable text.
+      // Why: classify before the text budget applies. An oversized archive is not
+      // unreadable, it is not text — the binary placeholder is the right answer,
+      // and the probe reads 8KB so it never buffers the file to find out.
       if (stats.size > BINARY_PROBE_BYTES && (await isBinaryFilePrefix(filePath))) {
         return { content: '', isBinary: true }
+      }
+
+      if (stats.size > MAX_TEXT_FILE_SIZE) {
+        throwFileTooLarge(stats.size, MAX_TEXT_FILE_SIZE)
       }
 
       const buffer = await readFile(filePath)

--- a/src/main/runtime/orca-runtime-files-mobile-explorer-reads.test.ts
+++ b/src/main/runtime/orca-runtime-files-mobile-explorer-reads.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
   enoent,
+  openMock,
   readdirMock,
   resolveAuthorizedPathMock,
   statMock
@@ -94,6 +95,27 @@ describe('RuntimeFileCommands', () => {
       kind: 'markdown',
       opened: true
     })
+  })
+
+  // The read is capped at the budget, so `byteLength` describes the prefix, not
+  // the file. Only a stat the host actually performed may be reported as a size.
+  it('reports the observed file size when a local runtime read is truncated', async () => {
+    const { commands } = createRuntimeFileCommands({})
+    resolveAuthorizedPathMock.mockResolvedValue('/repo/docs/huge.log')
+    statMock.mockResolvedValue({ isDirectory: () => false, size: 4 * 1024 * 1024 * 1024 })
+    openMock.mockResolvedValue({
+      read: (buffer: Buffer, offset: number, length: number) => {
+        buffer.fill(0x78, offset, offset + length)
+        return Promise.resolve({ bytesRead: length })
+      },
+      close: () => Promise.resolve()
+    })
+
+    const result = await commands.readMobileFile('id:wt-1', 'docs/huge.log')
+
+    expect(result.truncated).toBe(true)
+    expect(result.byteLength).toBe(512 * 1024 + 1)
+    expect(result.totalByteLength).toBe(4 * 1024 * 1024 * 1024)
   })
 
   it('opens previewable images through the renderer host as an image tab', async () => {

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -817,10 +817,11 @@ export class RuntimeFileCommands {
     }
 
     const filePath = joinWorktreeRelativePath(worktree.path, relativePath)
-    const content = connectionId
-      ? await this.readRemoteMobileFile(filePath, connectionId)
+    // The SSH path refuses oversized files outright, so it never observes a size.
+    const observed: { content: string; totalByteLength?: number } = connectionId
+      ? { content: await this.readRemoteMobileFile(filePath, connectionId) }
       : await readLocalMobileFile(filePath, store)
-    const truncated = truncateMobileFilePreview(content)
+    const truncated = truncateMobileFilePreview(observed.content)
 
     return {
       worktree: worktree.id,
@@ -828,7 +829,8 @@ export class RuntimeFileCommands {
       content: truncated.content,
       truncated: truncated.truncated,
       byteLength: truncated.byteLength,
-      maxByteLength: MOBILE_FILE_READ_MAX_BYTES
+      maxByteLength: MOBILE_FILE_READ_MAX_BYTES,
+      totalByteLength: observed.totalByteLength
     }
   }
 
@@ -2574,7 +2576,10 @@ function rethrowRuntimeFileCreateError(error: unknown, targetPath: string): neve
   throw error
 }
 
-async function readLocalMobileFile(filePath: string, store: Store): Promise<string> {
+async function readLocalMobileFile(
+  filePath: string,
+  store: Store
+): Promise<{ content: string; totalByteLength: number }> {
   const authorizedPath = await resolveAuthorizedPath(filePath, store)
   const fileStat = await stat(authorizedPath)
   // Why: cap the read so opening a large file can't block the WebSocket (previews are read-only convenience views).
@@ -2583,7 +2588,11 @@ async function readLocalMobileFile(filePath: string, store: Store): Promise<stri
   try {
     const buffer = Buffer.alloc(readLimit)
     const { bytesRead } = await handle.read(buffer, 0, readLimit, 0)
-    return buffer.subarray(0, bytesRead).toString('utf8')
+    // Report the stat'd size separately: the text returned is only the prefix.
+    return {
+      content: buffer.subarray(0, bytesRead).toString('utf8'),
+      totalByteLength: fileStat.size
+    }
   } finally {
     await handle.close()
   }

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -827,7 +827,8 @@ export class RuntimeFileCommands {
       relativePath,
       content: truncated.content,
       truncated: truncated.truncated,
-      byteLength: truncated.byteLength
+      byteLength: truncated.byteLength,
+      maxByteLength: MOBILE_FILE_READ_MAX_BYTES
     }
   }
 
@@ -1260,7 +1261,8 @@ export class RuntimeFileCommands {
       relativePath: grant.absolutePath,
       content: truncated.content,
       truncated: truncated.truncated,
-      byteLength: truncated.byteLength
+      byteLength: truncated.byteLength,
+      maxByteLength: MOBILE_FILE_READ_MAX_BYTES
     }
   }
 

--- a/src/main/ssh/ssh-file-stream-read-cap.ts
+++ b/src/main/ssh/ssh-file-stream-read-cap.ts
@@ -1,10 +1,13 @@
 import type { FileReadLimits } from '../providers/types'
-
-const MAX_PREVIEWABLE_BINARY_SIZE = 50 * 1024 * 1024
-const MAX_TEXT_FILE_SIZE = 10 * 1024 * 1024
+import {
+  EDITOR_PREVIEWABLE_BINARY_MAX_BYTES,
+  EDITOR_TEXT_READ_LIMIT_BYTES
+} from '../../shared/editor-file-read-limit'
 
 export function sshFileStreamReadCap(isBinary: boolean, limits?: FileReadLimits): number {
-  const defaultCap = isBinary ? MAX_PREVIEWABLE_BINARY_SIZE : MAX_TEXT_FILE_SIZE
+  const defaultCap = isBinary
+    ? EDITOR_PREVIEWABLE_BINARY_MAX_BYTES
+    : EDITOR_TEXT_READ_LIMIT_BYTES.ssh
   const requestedCap = isBinary ? limits?.maxBinaryBytes : limits?.maxTextBytes
   return requestedCap === undefined ? defaultCap : Math.min(defaultCap, requestedCap)
 }

--- a/src/preload/api/filesystem-api.ts
+++ b/src/preload/api/filesystem-api.ts
@@ -28,6 +28,8 @@ export type FilesystemApi = {
       filePath: string
       connectionId?: string
       includeLocalLogMetadata?: boolean
+      /** Local reads only: the user overruled the editor size budget. */
+      allowLargeFile?: boolean
     }) => Promise<{
       content: string
       isBinary: boolean

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3293,6 +3293,8 @@ const api = {
       filePath: string
       connectionId?: string
       includeLocalLogMetadata?: boolean
+      /** Local reads only: the user overruled the editor size budget. */
+      allowLargeFile?: boolean
     }): Promise<{
       content: string
       isBinary: boolean

--- a/src/relay/fs-handler-file-read-size-gate.test.ts
+++ b/src/relay/fs-handler-file-read-size-gate.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const statMock = vi.hoisted(() => vi.fn())
+const readFileMock = vi.hoisted(() => vi.fn())
+const openMock = vi.hoisted(() => vi.fn())
+
+vi.mock('node:fs/promises', () => ({
+  stat: statMock,
+  readFile: readFileMock,
+  open: openMock
+}))
+
+import { readRelayFileContent } from './fs-handler-file-read'
+import { EDITOR_TEXT_READ_LIMIT_BYTES } from '../shared/editor-file-read-limit'
+
+function probeReturning(firstByte: number): void {
+  openMock.mockResolvedValue({
+    read: vi.fn(async (buffer: Buffer) => {
+      buffer[0] = firstByte
+      return { bytesRead: 1, buffer }
+    }),
+    close: vi.fn()
+  })
+}
+
+describe('readRelayFileContent size gate', () => {
+  beforeEach(() => {
+    statMock.mockReset()
+    readFileMock.mockReset()
+    openMock.mockReset()
+  })
+
+  // The remote budget must not swallow the binary placeholder either.
+  it('reports an oversized remote archive as binary instead of refusing it', async () => {
+    statMock.mockResolvedValue({ size: 40 * 1024 * 1024 })
+    probeReturning(0x00)
+
+    await expect(readRelayFileContent('/remote/repo/archive.bin')).resolves.toEqual({
+      content: '',
+      isBinary: true
+    })
+    expect(readFileMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses oversized remote text with the transport named in the message', async () => {
+    statMock.mockResolvedValue({ size: 12 * 1024 * 1024 })
+    probeReturning(0x61)
+
+    await expect(readRelayFileContent('/remote/repo/huge.json')).rejects.toThrow(
+      `[size=${12 * 1024 * 1024} limit=${EDITOR_TEXT_READ_LIMIT_BYTES.ssh} scope=ssh]`
+    )
+    expect(readFileMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/relay/fs-handler-file-read.ts
+++ b/src/relay/fs-handler-file-read.ts
@@ -12,24 +12,32 @@ import {
   isBinaryBuffer,
   isBinaryFilePrefix
 } from './fs-handler-utils'
+import { formatFileTooLargeMessage } from '../shared/editor-file-read-limit'
+
+function throwRelayFileTooLarge(byteLength: number, limitBytes: number): never {
+  throw new Error(formatFileTooLargeMessage({ byteLength, limitBytes, scope: 'ssh' }))
+}
 
 export async function readRelayFileContent(filePath: string) {
   const stats = await stat(filePath)
   const mimeType = IMAGE_MIME_TYPES[extname(filePath).toLowerCase()]
-  const sizeLimit = mimeType ? MAX_PREVIEWABLE_BINARY_SIZE : MAX_TEXT_FILE_SIZE
-  if (stats.size > sizeLimit) {
-    throw new Error(
-      `File too large: ${(stats.size / 1024 / 1024).toFixed(1)}MB exceeds ${sizeLimit / 1024 / 1024}MB limit`
-    )
-  }
 
   if (mimeType) {
+    if (stats.size > MAX_PREVIEWABLE_BINARY_SIZE) {
+      throwRelayFileTooLarge(stats.size, MAX_PREVIEWABLE_BINARY_SIZE)
+    }
     const buffer = await readFile(filePath)
     return { content: buffer.toString('base64'), isBinary: true, isImage: true, mimeType }
   }
 
+  // Why: classify before the text budget applies, so an oversized archive still
+  // reaches the binary placeholder instead of a "too large" refusal.
   if (stats.size > BINARY_PROBE_BYTES && (await isBinaryFilePrefix(filePath))) {
     return { content: '', isBinary: true }
+  }
+
+  if (stats.size > MAX_TEXT_FILE_SIZE) {
+    throwRelayFileTooLarge(stats.size, MAX_TEXT_FILE_SIZE)
   }
 
   const buffer = await readFile(filePath)
@@ -80,11 +88,8 @@ export async function readRelayFileStreamMetadata(
 ): Promise<StreamMetadata> {
   const stats = await stat(filePath)
   const mimeType = IMAGE_MIME_TYPES[extname(filePath).toLowerCase()]
-  const sizeLimit = mimeType ? MAX_PREVIEWABLE_BINARY_SIZE : MAX_TEXT_FILE_SIZE
-  if (stats.size > sizeLimit) {
-    throw new Error(
-      `File too large: ${(stats.size / 1024 / 1024).toFixed(1)}MB exceeds ${sizeLimit / 1024 / 1024}MB limit`
-    )
+  if (mimeType && stats.size > MAX_PREVIEWABLE_BINARY_SIZE) {
+    throwRelayFileTooLarge(stats.size, MAX_PREVIEWABLE_BINARY_SIZE)
   }
 
   if (stats.size === 0) {
@@ -98,9 +103,14 @@ export async function readRelayFileStreamMetadata(
   }
   // Why: unlike the legacy single-shot path, streaming does not read the full
   // buffer before classifying content. Probe every unknown file so small binary
-  // files do not get decoded as UTF-8 text over SSH.
+  // files do not get decoded as UTF-8 text over SSH — and so an oversized
+  // archive lands on the binary placeholder rather than the text budget.
   if (!mimeType && (await isBinaryFilePrefix(filePath))) {
     return { totalSize: 0, isBinary: true, empty: true }
+  }
+
+  if (!mimeType && stats.size > MAX_TEXT_FILE_SIZE) {
+    throwRelayFileTooLarge(stats.size, MAX_TEXT_FILE_SIZE)
   }
 
   // Why: reserved before the fd opens so a refusal costs nothing, and released only

--- a/src/relay/fs-handler-utils.ts
+++ b/src/relay/fs-handler-utils.ts
@@ -15,6 +15,10 @@ import {
   SEARCH_TIMEOUT_MS as SHARED_SEARCH_TIMEOUT_MS
 } from '../shared/text-search'
 import { IMAGE_FILE_MIME_TYPES } from '../shared/image-file-extensions'
+import {
+  EDITOR_PREVIEWABLE_BINARY_MAX_BYTES,
+  EDITOR_TEXT_READ_LIMIT_BYTES
+} from '../shared/editor-file-read-limit'
 import type { SearchResult as SharedSearchResult } from '../shared/code-search-types'
 import {
   absorbPendingRipgrepSpawnError,
@@ -27,13 +31,12 @@ import {
 // ─── Constants ───────────────────────────────────────────────────────
 
 // Why: remote reads still travel through bounded JSON-RPC frames, but matching
-// the old 5MB search cap would block common JSON/log files before Monaco's
+// the old 5MB search cap would block common JSON/log files before the editor's
 // large-file optimizations can handle them.
-export const MAX_TEXT_FILE_SIZE = 10 * 1024 * 1024
-// Why: matches the local cap (src/main/ipc/filesystem.ts MAX_PREVIEWABLE_BINARY_SIZE).
-// Reads above the legacy 16MB single-frame budget go through fs.readFileStream,
+export const MAX_TEXT_FILE_SIZE = EDITOR_TEXT_READ_LIMIT_BYTES.ssh
+// Why: reads above the legacy 16MB single-frame budget go through fs.readFileStream,
 // which chunks at STREAM_CHUNK_SIZE; see docs/relay-file-stream-design.md.
-export const MAX_PREVIEWABLE_BINARY_SIZE = 50 * 1024 * 1024
+export const MAX_PREVIEWABLE_BINARY_SIZE = EDITOR_PREVIEWABLE_BINARY_MAX_BYTES
 export const BINARY_PROBE_BYTES = 8192
 export const SEARCH_TIMEOUT_MS = SHARED_SEARCH_TIMEOUT_MS
 export const DEFAULT_MAX_RESULTS = 2000

--- a/src/renderer/src/components/editor/EditorConflictReviewSurface.tsx
+++ b/src/renderer/src/components/editor/EditorConflictReviewSurface.tsx
@@ -131,6 +131,7 @@ export function EditorConflictReviewSurface({
         <div className={className}>
           <EditorFileLoadErrorView
             message={fileContent.loadError}
+            filePath={contentFile.filePath}
             onRetry={() => reloadContent(contentFile)}
           />
         </div>

--- a/src/renderer/src/components/editor/EditorConflictReviewSurface.tsx
+++ b/src/renderer/src/components/editor/EditorConflictReviewSurface.tsx
@@ -7,7 +7,7 @@ import type { GitStatusEntry } from '../../../../shared/git-status-types'
 import { ConflictBanner, ConflictPlaceholderView, ConflictReviewPanel } from './ConflictComponents'
 import { ImageViewer, MonacoEditor } from './editor-lazy-views'
 import { EditorFileLoadErrorView } from './EditorFileLoadErrorView'
-import type { FileContent } from './editor-panel-content-types'
+import type { EditorContentReloadOptions, FileContent } from './editor-panel-content-types'
 import { translate } from '@/i18n/i18n'
 import type { EditorConflictNavigation } from './useEditorConflictNavigation'
 
@@ -34,7 +34,7 @@ export function EditorConflictReviewSurface({
   getConflictNavigation: (file: OpenFile, content: string) => EditorConflictNavigation | undefined
   handleContentChangeForFile: (file: OpenFile, content: string) => void
   handleSaveForFile: (file: OpenFile, content: string) => Promise<boolean>
-  reloadContent: (file: OpenFile) => void
+  reloadContent: (file: OpenFile, options?: EditorContentReloadOptions) => void
 }): React.JSX.Element {
   const openConflictReviewFile = useAppStore((s) => s.openConflictReviewFile)
   const openConflictReview = useAppStore((s) => s.openConflictReview)
@@ -133,6 +133,7 @@ export function EditorConflictReviewSurface({
             message={fileContent.loadError}
             filePath={contentFile.filePath}
             onRetry={() => reloadContent(contentFile)}
+            onOpenAnyway={() => reloadContent(contentFile, { allowLargeFile: true })}
           />
         </div>
       )

--- a/src/renderer/src/components/editor/EditorContent.test.tsx
+++ b/src/renderer/src/components/editor/EditorContent.test.tsx
@@ -10,6 +10,10 @@ vi.mock('@/lib/lazy-with-retry', () => ({
 }))
 
 import { EditorContent, getMarkdownSourceLineOffset } from './EditorContent'
+import {
+  EDITOR_TEXT_READ_LIMIT_BYTES,
+  formatFileTooLargeMessage
+} from '../../../../shared/editor-file-read-limit'
 
 function createOpenFile(overrides: Partial<OpenFile> = {}): OpenFile {
   return {
@@ -82,6 +86,51 @@ describe('EditorContent', () => {
     expect(html).toContain('Unable to load file')
     expect(html).toContain('Access denied')
     expect(html).not.toContain('Unable to render notebook')
+  })
+
+  // The fallback only draws the override when the surface hands it one; this pins
+  // the edit surface's wiring, without which the panel is a dead end.
+  it('offers the size-limit override on a local refusal in an edit tab', () => {
+    const activeFile = createOpenFile()
+    const html = renderToStaticMarkup(
+      <EditorContent
+        activeFile={activeFile}
+        viewStateScopeId={activeFile.id}
+        fileContents={{
+          [activeFile.id]: {
+            content: '',
+            isBinary: false,
+            loadError: formatFileTooLargeMessage({
+              byteLength: 53_477_376,
+              limitBytes: EDITOR_TEXT_READ_LIMIT_BYTES.local,
+              scope: 'local'
+            })
+          }
+        }}
+        diffContents={{}}
+        editBuffers={{}}
+        openFiles={[activeFile]}
+        worktreeEntries={[]}
+        resolvedLanguage="notebook"
+        isMarkdown={false}
+        isMermaid={false}
+        isCsv={false}
+        isNotebook
+        mdViewMode="rich"
+        isChangesMode={false}
+        sideBySide={false}
+        pendingEditorReveal={null}
+        handleContentChange={vi.fn()}
+        handleContentChangeForFile={vi.fn()}
+        handleDirtyStateHint={vi.fn()}
+        handleSave={vi.fn()}
+        handleSaveForFile={vi.fn()}
+        reloadContent={vi.fn()}
+      />
+    )
+
+    expect(html).toContain('data-testid="large-file-fallback"')
+    expect(html).toContain('Open Anyway')
   })
 
   it('shows the changed-on-disk banner above a dirty edit tab', () => {

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -185,6 +185,7 @@ export function EditorContent({
       return (
         <EditorFileLoadErrorView
           message={fileContent.loadError}
+          filePath={activeFile.filePath}
           onRetry={() => reloadContent(activeFile)}
         />
       )

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -8,7 +8,7 @@ import { EditorConflictReviewSurface } from './EditorConflictReviewSurface'
 import { EditorDiffFileSurface } from './EditorDiffFileSurface'
 import { EditorEditFileSurface } from './EditorEditFileSurface'
 import { EditorFileLoadErrorView } from './EditorFileLoadErrorView'
-import type { FileContent } from './editor-panel-content-types'
+import type { EditorContentReloadOptions, FileContent } from './editor-panel-content-types'
 import { translate } from '@/i18n/i18n'
 import { useEditorConflictNavigation } from './useEditorConflictNavigation'
 import { useMarkdownDocuments } from './useMarkdownDocuments'
@@ -86,7 +86,7 @@ export function EditorContent({
   handleDirtyStateHint: (dirty: boolean) => void
   handleSave: (content: string) => Promise<boolean>
   handleSaveForFile: (file: OpenFile, content: string) => Promise<boolean>
-  reloadContent: (file: OpenFile) => void
+  reloadContent: (file: OpenFile, options?: EditorContentReloadOptions) => void
 }): React.JSX.Element {
   const editorViewStateKey =
     viewStateScopeId === activeFile.id
@@ -187,6 +187,7 @@ export function EditorContent({
           message={fileContent.loadError}
           filePath={activeFile.filePath}
           onRetry={() => reloadContent(activeFile)}
+          onOpenAnyway={() => reloadContent(activeFile, { allowLargeFile: true })}
         />
       )
     }

--- a/src/renderer/src/components/editor/EditorDiffFileSurface.tsx
+++ b/src/renderer/src/components/editor/EditorDiffFileSurface.tsx
@@ -2,6 +2,7 @@ import { translate } from '@/i18n/i18n'
 import type { OpenFile } from '@/store/slices/editor'
 import type { GitDiffResult } from '../../../../shared/git-diff-compare-types'
 import { getDiffContentSignature } from './diff-content-signature'
+import type { EditorContentReloadOptions } from './editor-panel-content-types'
 import { DiffViewer, ImageDiffViewer, MarkdownPreview } from './editor-lazy-views'
 import { ExternalFileChangeBanner } from './ExternalFileChangeBanner'
 import type { useMarkdownDocuments } from './useMarkdownDocuments'
@@ -41,7 +42,7 @@ export function EditorDiffFileSurface({
   markdownDocuments: MarkdownDocumentsController
   onContentChange: (content: string) => void
   onSave: (content: string) => Promise<boolean>
-  reloadContent: (file: OpenFile) => void
+  reloadContent: (file: OpenFile, options?: EditorContentReloadOptions) => void
 }): React.JSX.Element {
   if (!diffContent) {
     return (

--- a/src/renderer/src/components/editor/EditorEditFileSurface.tsx
+++ b/src/renderer/src/components/editor/EditorEditFileSurface.tsx
@@ -13,7 +13,7 @@ import {
 } from './editor-lazy-views'
 import type { EditorConflictNavigation } from './useEditorConflictNavigation'
 import { EditorFileLoadErrorView } from './EditorFileLoadErrorView'
-import type { FileContent } from './editor-panel-content-types'
+import type { EditorContentReloadOptions, FileContent } from './editor-panel-content-types'
 import { ExternalFileChangeBanner } from './ExternalFileChangeBanner'
 import type { useMarkdownDocuments } from './useMarkdownDocuments'
 import { EditorMarkdownFileSurface } from './EditorMarkdownFileSurface'
@@ -82,7 +82,7 @@ export function EditorEditFileSurface({
   handleContentChange: (content: string) => void
   handleDirtyStateHint: (dirty: boolean) => void
   handleSave: (content: string) => Promise<boolean>
-  reloadContent: (file: OpenFile) => void
+  reloadContent: (file: OpenFile, options?: EditorContentReloadOptions) => void
 }): React.JSX.Element {
   if (activeFile.conflict?.kind === 'conflict-placeholder') {
     return <ConflictPlaceholderView file={activeFile} />
@@ -100,6 +100,7 @@ export function EditorEditFileSurface({
         message={fileContent.loadError}
         filePath={activeFile.filePath}
         onRetry={() => reloadContent(activeFile)}
+        onOpenAnyway={() => reloadContent(activeFile, { allowLargeFile: true })}
       />
     )
   }

--- a/src/renderer/src/components/editor/EditorEditFileSurface.tsx
+++ b/src/renderer/src/components/editor/EditorEditFileSurface.tsx
@@ -98,6 +98,7 @@ export function EditorEditFileSurface({
     return (
       <EditorFileLoadErrorView
         message={fileContent.loadError}
+        filePath={activeFile.filePath}
         onRetry={() => reloadContent(activeFile)}
       />
     )

--- a/src/renderer/src/components/editor/EditorFileLoadErrorView.test.tsx
+++ b/src/renderer/src/components/editor/EditorFileLoadErrorView.test.tsx
@@ -1,7 +1,10 @@
+// @vitest-environment happy-dom
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { EditorFileLoadErrorView } from './EditorFileLoadErrorView'
 import {
+  EDITOR_READ_OVERRIDE_CEILING_BYTES,
   EDITOR_TEXT_READ_LIMIT_BYTES,
   formatFileTooLargeMessage
 } from '../../../../shared/editor-file-read-limit'
@@ -13,6 +16,8 @@ const tooLarge = `Error invoking remote method 'fs:readFile': Error: ${formatFil
 })}`
 
 describe('EditorFileLoadErrorView', () => {
+  afterEach(cleanup)
+
   it('degrades an oversized file to the explanatory fallback', () => {
     const html = renderToStaticMarkup(
       <EditorFileLoadErrorView
@@ -26,6 +31,145 @@ describe('EditorFileLoadErrorView', () => {
     expect(html).toContain('/repo/generated.json')
     // Retry re-runs the same size check, so offering it is a guaranteed dead end.
     expect(html).not.toContain('Retry')
+  })
+
+  // The runtime host reads a bounded prefix, so it reports the budget but never
+  // the file's size. Showing the prefix length as "File size" told a user with a
+  // 4GB log that the file was 0.5MB.
+  it('omits the size row when the host never observed one', () => {
+    const html = renderToStaticMarkup(
+      <EditorFileLoadErrorView
+        message={formatFileTooLargeMessage({ limitBytes: 512 * 1024, scope: 'runtime' })}
+        filePath="/remote/repo/huge.log"
+        onRetry={vi.fn()}
+      />
+    )
+
+    expect(html).toContain('data-testid="large-file-fallback"')
+    expect(html).toContain('512.0 KB')
+    expect(html).not.toContain('File size')
+  })
+
+  it('degrades the bare file_too_large protocol token instead of printing it', () => {
+    const html = renderToStaticMarkup(
+      <EditorFileLoadErrorView
+        message="file_too_large"
+        filePath="/remote/repo/huge.log"
+        onRetry={vi.fn()}
+      />
+    )
+
+    expect(html).toContain('data-testid="large-file-fallback"')
+    expect(html).not.toContain('file_too_large')
+    expect(html).not.toContain('Retry')
+    // Nothing numeric was observed, so neither row may claim a number.
+    expect(html).not.toContain('File size')
+    expect(html).not.toContain('Read limit')
+  })
+
+  // The size cap is a confirmation, not a verdict: a local read has no transport
+  // to protect, so the user may overrule it. Without an action the panel is a
+  // dead end and the file is permanently unopenable.
+  it('offers an override for a local refusal and re-reads with the cap lifted', () => {
+    const onOpenAnyway = vi.fn()
+    render(
+      <EditorFileLoadErrorView
+        message={tooLarge}
+        filePath="/repo/generated.json"
+        onRetry={vi.fn()}
+        onOpenAnyway={onOpenAnyway}
+      />
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Open Anyway' }))
+
+    expect(onOpenAnyway).toHaveBeenCalledTimes(1)
+  })
+
+  // The SSH budget guards a transport the client cannot overrule, so promising an
+  // override there would be a button that silently refuses again.
+  it('withholds the override when the refusing transport cannot honour it', () => {
+    for (const scope of ['ssh', 'runtime'] as const) {
+      const html = renderToStaticMarkup(
+        <EditorFileLoadErrorView
+          message={formatFileTooLargeMessage({
+            byteLength: 13_002_342,
+            limitBytes: 10 * 1024 * 1024,
+            scope
+          })}
+          filePath="/remote/repo/huge.log"
+          onRetry={vi.fn()}
+          onOpenAnyway={vi.fn()}
+        />
+      )
+      expect(html).not.toContain('Open Anyway')
+    }
+  })
+
+  // The refusal already names the limit that stopped it. When that limit is the
+  // ceiling itself, the override has nothing left to lift and the button would
+  // only re-run the same refusal.
+  it('withholds the override once the refusing limit is the ceiling itself', () => {
+    const html = renderToStaticMarkup(
+      <EditorFileLoadErrorView
+        message={formatFileTooLargeMessage({
+          byteLength: EDITOR_READ_OVERRIDE_CEILING_BYTES + 1,
+          limitBytes: EDITOR_READ_OVERRIDE_CEILING_BYTES,
+          scope: 'local'
+        })}
+        filePath="/repo/enormous.log"
+        onRetry={vi.fn()}
+        onOpenAnyway={vi.fn()}
+      />
+    )
+
+    expect(html).toContain('data-testid="large-file-fallback"')
+    expect(html).not.toContain('Open Anyway')
+    // The copy must not promise the action the same render just withheld.
+    expect(html).not.toContain('You can open it anyway')
+    expect(html).toContain('largest size the editor can hold')
+  })
+
+  // The offer and the sentence that describes it are one decision.
+  it('promises the override only where it is actually offered', () => {
+    const html = renderToStaticMarkup(
+      <EditorFileLoadErrorView
+        message={tooLarge}
+        filePath="/repo/generated.json"
+        onRetry={vi.fn()}
+        onOpenAnyway={vi.fn()}
+      />
+    )
+
+    expect(html).toContain('Open Anyway')
+    expect(html).toContain('You can open it anyway')
+  })
+
+  // Nothing observed says the ceiling was reached, so the panel states the budget
+  // and stops there rather than guessing why the caller withheld the action.
+  it('claims neither the override nor the ceiling when the surface offers no action', () => {
+    const html = renderToStaticMarkup(
+      <EditorFileLoadErrorView message={tooLarge} filePath="/repo/generated.json" onRetry={vi.fn()} />
+    )
+
+    expect(html).toContain('largest budget Orca opens without asking')
+    expect(html).not.toContain('You can open it anyway')
+    expect(html).not.toContain('largest size the editor can hold')
+  })
+
+  // A bare protocol token names no transport, so nothing was observed that would
+  // justify claiming the cap is overridable.
+  it('withholds the override when no transport was reported', () => {
+    const html = renderToStaticMarkup(
+      <EditorFileLoadErrorView
+        message="file_too_large"
+        filePath="/remote/repo/huge.log"
+        onRetry={vi.fn()}
+        onOpenAnyway={vi.fn()}
+      />
+    )
+
+    expect(html).not.toContain('Open Anyway')
   })
 
   it('keeps the retryable error box for every other failure', () => {

--- a/src/renderer/src/components/editor/EditorFileLoadErrorView.test.tsx
+++ b/src/renderer/src/components/editor/EditorFileLoadErrorView.test.tsx
@@ -1,0 +1,43 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import { EditorFileLoadErrorView } from './EditorFileLoadErrorView'
+import {
+  EDITOR_TEXT_READ_LIMIT_BYTES,
+  formatFileTooLargeMessage
+} from '../../../../shared/editor-file-read-limit'
+
+const tooLarge = `Error invoking remote method 'fs:readFile': Error: ${formatFileTooLargeMessage({
+  byteLength: 53_477_376,
+  limitBytes: EDITOR_TEXT_READ_LIMIT_BYTES.local,
+  scope: 'local'
+})}`
+
+describe('EditorFileLoadErrorView', () => {
+  it('degrades an oversized file to the explanatory fallback', () => {
+    const html = renderToStaticMarkup(
+      <EditorFileLoadErrorView
+        message={tooLarge}
+        filePath="/repo/generated.json"
+        onRetry={vi.fn()}
+      />
+    )
+
+    expect(html).toContain('data-testid="large-file-fallback"')
+    expect(html).toContain('/repo/generated.json')
+    // Retry re-runs the same size check, so offering it is a guaranteed dead end.
+    expect(html).not.toContain('Retry')
+  })
+
+  it('keeps the retryable error box for every other failure', () => {
+    const html = renderToStaticMarkup(
+      <EditorFileLoadErrorView
+        message="EACCES: permission denied"
+        filePath="/repo/generated.json"
+        onRetry={vi.fn()}
+      />
+    )
+
+    expect(html).not.toContain('data-testid="large-file-fallback"')
+    expect(html).toContain('Retry')
+  })
+})

--- a/src/renderer/src/components/editor/EditorFileLoadErrorView.tsx
+++ b/src/renderer/src/components/editor/EditorFileLoadErrorView.tsx
@@ -1,22 +1,36 @@
 import { AlertCircle, RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { translate } from '@/i18n/i18n'
-import { parseFileTooLargeMessage } from '../../../../shared/editor-file-read-limit'
+import {
+  isOverridableFileTooLarge,
+  parseFileTooLargeMessage
+} from '../../../../shared/editor-file-read-limit'
 import { LargeFileFallback } from './LargeFileFallback'
 
 export function EditorFileLoadErrorView({
   message,
   filePath,
-  onRetry
+  onRetry,
+  onOpenAnyway
 }: {
   message: string
   filePath?: string
   onRetry: () => void
+  onOpenAnyway?: () => void
 }): React.JSX.Element {
   // Why: a size refusal is deterministic, so the generic retry box is a dead end.
   const tooLarge = parseFileTooLargeMessage(message)
   if (tooLarge) {
-    return <LargeFileFallback filePath={filePath ?? ''} detail={tooLarge} />
+    // Why: the override is only offered where the refusal says it could land —
+    // an unhonoured transport or a limit already at the ceiling is a button that
+    // silently refuses again.
+    return (
+      <LargeFileFallback
+        filePath={filePath ?? ''}
+        detail={tooLarge}
+        onOpenAnyway={isOverridableFileTooLarge(tooLarge) ? onOpenAnyway : undefined}
+      />
+    )
   }
 
   return (

--- a/src/renderer/src/components/editor/EditorFileLoadErrorView.tsx
+++ b/src/renderer/src/components/editor/EditorFileLoadErrorView.tsx
@@ -1,14 +1,24 @@
 import { AlertCircle, RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { translate } from '@/i18n/i18n'
+import { parseFileTooLargeMessage } from '../../../../shared/editor-file-read-limit'
+import { LargeFileFallback } from './LargeFileFallback'
 
 export function EditorFileLoadErrorView({
   message,
+  filePath,
   onRetry
 }: {
   message: string
+  filePath?: string
   onRetry: () => void
 }): React.JSX.Element {
+  // Why: a size refusal is deterministic, so the generic retry box is a dead end.
+  const tooLarge = parseFileTooLargeMessage(message)
+  if (tooLarge) {
+    return <LargeFileFallback filePath={filePath ?? ''} detail={tooLarge} />
+  }
+
   return (
     <div className="flex h-full items-center justify-center bg-editor-surface p-6 text-sm text-muted-foreground">
       <div className="flex max-w-xl items-start gap-3 rounded-md border border-border bg-background p-4">

--- a/src/renderer/src/components/editor/EditorPanelShell.tsx
+++ b/src/renderer/src/components/editor/EditorPanelShell.tsx
@@ -6,7 +6,11 @@ import { EditorContent } from './EditorContent'
 import { EditorPanelHeader } from './EditorPanelHeader'
 import { UntitledFileRenameDialog } from './UntitledFileRenameDialog'
 import type { getEditorPanelRenderModel } from './editor-panel-render-model'
-import type { DiffContent, FileContent } from './editor-panel-content-types'
+import type {
+  DiffContent,
+  EditorContentReloadOptions,
+  FileContent
+} from './editor-panel-content-types'
 import type { EditorToggleValue } from './EditorViewToggle'
 import { getUntitledFileRoot } from './untitled-file-rename-path'
 import { translate } from '@/i18n/i18n'
@@ -48,7 +52,7 @@ type EditorPanelShellProps = {
   onDirtyStateHint: (dirty: boolean) => void
   onSave: (content: string) => Promise<boolean>
   onSaveForFile: (file: OpenFile, content: string) => Promise<boolean>
-  onReloadContent: (file: OpenFile) => void
+  onReloadContent: (file: OpenFile, options?: EditorContentReloadOptions) => void
   onCloseMarkdownTableOfContents: () => void
   onCloseRenameDialog: () => void
   onRenameConfirm: (newRelPath: string) => Promise<void>

--- a/src/renderer/src/components/editor/LargeFileFallback.tsx
+++ b/src/renderer/src/components/editor/LargeFileFallback.tsx
@@ -1,0 +1,63 @@
+import { translate } from '@/i18n/i18n'
+import type { FileTooLargeDetail } from '../../../../shared/editor-file-read-limit'
+
+const numberFormatter = new Intl.NumberFormat()
+
+function formatMegabytes(bytes: number): string {
+  return `${numberFormatter.format(Math.round((bytes / 1024 / 1024) * 10) / 10)} MB`
+}
+
+function describeLimitOwner(scope: FileTooLargeDetail['scope']): string {
+  if (scope === 'ssh') {
+    return translate(
+      'auto.components.editor.LargeFileFallback.scopeSsh',
+      'Files read over SSH share the connection with your terminals, so they use a smaller budget than local files.'
+    )
+  }
+  if (scope === 'runtime') {
+    return translate(
+      'auto.components.editor.LargeFileFallback.scopeRuntime',
+      'Files read from a remote workspace travel over the workspace connection, so they use a smaller budget than local files.'
+    )
+  }
+  return translate(
+    'auto.components.editor.LargeFileFallback.scopeLocal',
+    'Local files use the largest budget Orca offers; beyond it the editor cannot hold the whole file in memory safely.'
+  )
+}
+
+export function LargeFileFallback({
+  filePath,
+  detail
+}: {
+  filePath: string
+  detail: FileTooLargeDetail
+}): React.JSX.Element {
+  return (
+    <div
+      data-testid="large-file-fallback"
+      className="flex h-full min-h-[120px] items-center justify-center border border-border bg-muted/10 px-4 py-6 text-muted-foreground"
+    >
+      <div className="max-w-xl space-y-3 text-center">
+        <div className="text-sm font-medium text-foreground">
+          {translate(
+            'auto.components.editor.LargeFileFallback.title',
+            'This file is too large to open in the editor.'
+          )}
+        </div>
+        <div className="break-all text-xs">{filePath}</div>
+        <div className="grid gap-1 text-xs sm:grid-cols-2 sm:text-left">
+          <div>
+            {translate('auto.components.editor.LargeFileFallback.size', 'File size')}:{' '}
+            {formatMegabytes(detail.byteLength)}
+          </div>
+          <div>
+            {translate('auto.components.editor.LargeFileFallback.limit', 'Read limit')}:{' '}
+            {formatMegabytes(detail.limitBytes)}
+          </div>
+        </div>
+        <div className="text-[11px]">{describeLimitOwner(detail.scope)}</div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/editor/LargeFileFallback.tsx
+++ b/src/renderer/src/components/editor/LargeFileFallback.tsx
@@ -1,13 +1,31 @@
+import { FileWarning } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 import { translate } from '@/i18n/i18n'
-import type { FileTooLargeDetail } from '../../../../shared/editor-file-read-limit'
+import {
+  EDITOR_READ_OVERRIDE_CEILING_BYTES,
+  formatFileReadBytes,
+  type FileTooLargeDetail
+} from '../../../../shared/editor-file-read-limit'
 
-const numberFormatter = new Intl.NumberFormat()
-
-function formatMegabytes(bytes: number): string {
-  return `${numberFormatter.format(Math.round((bytes / 1024 / 1024) * 10) / 10)} MB`
+// Why: a refusal that already names the ceiling as the limit it applied is the
+// second refusal — the budget was lifted and the read still would not fit.
+function refusedAtOverrideCeiling(detail: FileTooLargeDetail): boolean {
+  return (
+    detail.scope === 'local' &&
+    detail.limitBytes !== undefined &&
+    detail.limitBytes >= EDITOR_READ_OVERRIDE_CEILING_BYTES
+  )
 }
 
-function describeLimitOwner(scope: FileTooLargeDetail['scope']): string {
+// Why: no scope means the refusal arrived as the bare protocol token, so there
+// is no transport to attribute the budget to. The local paragraph is assembled
+// from what this render actually shows: promising the override in prose while
+// the button is withheld is a claim the same render just contradicted.
+function describeLimitOwner(detail: FileTooLargeDetail, canOpenAnyway: boolean): string | null {
+  const { scope } = detail
+  if (scope === undefined) {
+    return null
+  }
   if (scope === 'ssh') {
     return translate(
       'auto.components.editor.LargeFileFallback.scopeSsh',
@@ -20,19 +38,36 @@ function describeLimitOwner(scope: FileTooLargeDetail['scope']): string {
       'Files read from a remote workspace travel over the workspace connection, so they use a smaller budget than local files.'
     )
   }
-  return translate(
+  const budget = translate(
     'auto.components.editor.LargeFileFallback.scopeLocal',
-    'Local files use the largest budget Orca offers; beyond it the editor cannot hold the whole file in memory safely.'
+    'Local files use the largest budget Orca opens without asking.'
   )
+  if (canOpenAnyway) {
+    return `${budget} ${translate(
+      'auto.components.editor.LargeFileFallback.localOverridable',
+      'You can open it anyway, but the editor may become slow.'
+    )}`
+  }
+  if (refusedAtOverrideCeiling(detail)) {
+    return `${budget} ${translate(
+      'auto.components.editor.LargeFileFallback.localAtCeiling',
+      'This file is past the largest size the editor can hold, so opening it anyway would refuse again.'
+    )}`
+  }
+  return budget
 }
 
 export function LargeFileFallback({
   filePath,
-  detail
+  detail,
+  onOpenAnyway
 }: {
   filePath: string
   detail: FileTooLargeDetail
+  /** Absent when the transport that refused cannot honour an override. */
+  onOpenAnyway?: () => void
 }): React.JSX.Element {
+  const limitOwner = describeLimitOwner(detail, onOpenAnyway !== undefined)
   return (
     <div
       data-testid="large-file-fallback"
@@ -47,16 +82,26 @@ export function LargeFileFallback({
         </div>
         <div className="break-all text-xs">{filePath}</div>
         <div className="grid gap-1 text-xs sm:grid-cols-2 sm:text-left">
-          <div>
-            {translate('auto.components.editor.LargeFileFallback.size', 'File size')}:{' '}
-            {formatMegabytes(detail.byteLength)}
-          </div>
-          <div>
-            {translate('auto.components.editor.LargeFileFallback.limit', 'Read limit')}:{' '}
-            {formatMegabytes(detail.limitBytes)}
-          </div>
+          {detail.byteLength !== undefined && (
+            <div>
+              {translate('auto.components.editor.LargeFileFallback.size', 'File size')}:{' '}
+              {formatFileReadBytes(detail.byteLength)}
+            </div>
+          )}
+          {detail.limitBytes !== undefined && (
+            <div>
+              {translate('auto.components.editor.LargeFileFallback.limit', 'Read limit')}:{' '}
+              {formatFileReadBytes(detail.limitBytes)}
+            </div>
+          )}
         </div>
-        <div className="text-[11px]">{describeLimitOwner(detail.scope)}</div>
+        {limitOwner !== null && <div className="text-[11px]">{limitOwner}</div>}
+        {onOpenAnyway && (
+          <Button type="button" variant="outline" size="sm" onClick={onOpenAnyway}>
+            <FileWarning className="size-3.5" />
+            {translate('auto.components.editor.LargeFileFallback.openAnyway', 'Open Anyway')}
+          </Button>
+        )}
       </div>
     </div>
   )

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -21,6 +21,7 @@ import { useMonacoEditorDecorations } from './use-monaco-editor-decorations'
 import { useMonacoEditorMount } from './use-monaco-editor-mount'
 import { snapshotMonacoViewState } from './monaco-view-state-persistence'
 import { MonacoMarkdownAnnotationOverlay } from './MonacoMarkdownAnnotationOverlay'
+import { useMonacoLargeFileNotice } from './use-monaco-large-file-notice'
 
 type MonacoEditorProps = {
   fileId: string
@@ -165,6 +166,8 @@ export default function MonacoEditor({
       ...buildFileEditorWordWrapOptions(editorWordWrap)
     })
   }, [editorFontFamily, editorFontSize, editorWordWrap])
+
+  useMonacoLargeFileNotice(mountedEditor, filePath)
 
   const decorations = useMonacoEditorDecorations({
     editorRef,

--- a/src/renderer/src/components/editor/editor-panel-content-types.ts
+++ b/src/renderer/src/components/editor/editor-panel-content-types.ts
@@ -38,3 +38,6 @@ export type InFlightContentRead<T> = {
   externalEventGeneration?: number
   promise: Promise<T>
 }
+
+/** Per-read overrides a reload entry point accepts from the error fallback. */
+export type EditorContentReloadOptions = { allowLargeFile?: boolean }

--- a/src/renderer/src/components/editor/monaco-large-file-optimizations.test.ts
+++ b/src/renderer/src/components/editor/monaco-large-file-optimizations.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import type { editor } from 'monaco-editor'
 import { readMonacoLargeFileOptimizations } from './monaco-large-file-optimizations'
+import { MONACO_HEAP_OPERATION_LIMIT_BYTES } from '../../../../shared/editor-file-read-limit'
 
 function modelReporting(value: unknown): editor.ITextModel {
   return { isTooLargeForTokenization: () => value } as unknown as editor.ITextModel
@@ -26,5 +27,18 @@ describe('readMonacoLargeFileOptimizations', () => {
         }
       } as unknown as editor.ITextModel)
     ).toBe('unknown')
+  })
+})
+
+// Why: the read ceiling is sized so an overridden open can never build a model
+// the editor refuses whole-buffer reads on. That number lives in shared code
+// where monaco cannot be imported, so pin it against monaco's own constant here
+// — a version bump that moves the threshold has to move the ceiling with it.
+describe('monaco heap-operation limit', () => {
+  it('matches the byte ceiling shared code bounds reads with', async () => {
+    const { TextModel } = (await import(
+      'monaco-editor/esm/vs/editor/common/model/textModel.js'
+    )) as unknown as { TextModel: { LARGE_FILE_HEAP_OPERATION_THRESHOLD: number } }
+    expect(TextModel.LARGE_FILE_HEAP_OPERATION_THRESHOLD).toBe(MONACO_HEAP_OPERATION_LIMIT_BYTES)
   })
 })

--- a/src/renderer/src/components/editor/monaco-large-file-optimizations.test.ts
+++ b/src/renderer/src/components/editor/monaco-large-file-optimizations.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import type { editor } from 'monaco-editor'
+import { readMonacoLargeFileOptimizations } from './monaco-large-file-optimizations'
+
+function modelReporting(value: unknown): editor.ITextModel {
+  return { isTooLargeForTokenization: () => value } as unknown as editor.ITextModel
+}
+
+describe('readMonacoLargeFileOptimizations', () => {
+  it('reports applied only when the model itself says so', () => {
+    expect(readMonacoLargeFileOptimizations(modelReporting(true))).toBe('applied')
+    expect(readMonacoLargeFileOptimizations(modelReporting(false))).toBe('not-applied')
+  })
+
+  // The flag is @internal in monaco's public typings, so a version bump can
+  // remove it. "We could not read it" must never be reported as "off" — that
+  // would make the notice claim features are intact when they may not be.
+  it('reports unknown when the flag cannot be read', () => {
+    expect(readMonacoLargeFileOptimizations(null)).toBe('unknown')
+    expect(readMonacoLargeFileOptimizations({} as editor.ITextModel)).toBe('unknown')
+    expect(readMonacoLargeFileOptimizations(modelReporting('yes'))).toBe('unknown')
+    expect(
+      readMonacoLargeFileOptimizations({
+        isTooLargeForTokenization: () => {
+          throw new Error('disposed')
+        }
+      } as unknown as editor.ITextModel)
+    ).toBe('unknown')
+  })
+})

--- a/src/renderer/src/components/editor/monaco-large-file-optimizations.ts
+++ b/src/renderer/src/components/editor/monaco-large-file-optimizations.ts
@@ -1,0 +1,39 @@
+import type { editor } from 'monaco-editor'
+
+/**
+ * Above ~20MB of text or ~300k lines the editor permanently drops tokenization,
+ * folding, code lenses, sticky scroll, word highlighting and line wrapping for a
+ * model — decided once at model construction and never revisited. Orca inherits
+ * that silently, so the user sees features vanish with no explanation.
+ *
+ * The verdict is read from the model instead of recomputed from the byte length,
+ * because the model's own thresholds are internal and can move between editor
+ * versions; a recomputed guess would eventually describe a degradation that did
+ * not happen (or miss one that did).
+ */
+export type MonacoLargeFileOptimizations = 'applied' | 'not-applied' | 'unknown'
+
+type TokenizationSizeProbe = {
+  isTooLargeForTokenization?: () => unknown
+}
+
+export function readMonacoLargeFileOptimizations(
+  model: editor.ITextModel | null | undefined
+): MonacoLargeFileOptimizations {
+  const probe = (model as TokenizationSizeProbe | null | undefined)?.isTooLargeForTokenization
+  if (typeof probe !== 'function') {
+    // The flag is @internal in the public typings; not finding it means we do
+    // not know, which is never the same as "optimizations are off".
+    return 'unknown'
+  }
+  let verdict: unknown
+  try {
+    verdict = probe.call(model)
+  } catch {
+    return 'unknown'
+  }
+  if (typeof verdict !== 'boolean') {
+    return 'unknown'
+  }
+  return verdict ? 'applied' : 'not-applied'
+}

--- a/src/renderer/src/components/editor/use-monaco-large-file-notice.test.tsx
+++ b/src/renderer/src/components/editor/use-monaco-large-file-notice.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment happy-dom
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { editor } from 'monaco-editor'
+
+const toastMock = vi.hoisted(() => vi.fn())
+vi.mock('sonner', () => ({ toast: toastMock }))
+
+import { useMonacoLargeFileNotice } from './use-monaco-large-file-notice'
+
+function editorReporting(tooLarge: unknown): editor.IStandaloneCodeEditor {
+  return {
+    getModel: () => (tooLarge === undefined ? {} : { isTooLargeForTokenization: () => tooLarge })
+  } as unknown as editor.IStandaloneCodeEditor
+}
+
+describe('useMonacoLargeFileNotice', () => {
+  beforeEach(() => {
+    toastMock.mockClear()
+  })
+
+  it('explains the degradation the model reports, once per file', () => {
+    const { rerender } = renderHook(
+      ({ path }: { path: string }) =>
+        useMonacoLargeFileNotice(editorReporting(true), path),
+      { initialProps: { path: '/repo/generated.json' } }
+    )
+    rerender({ path: '/repo/generated.json' })
+
+    expect(toastMock).toHaveBeenCalledTimes(1)
+    expect(toastMock.mock.calls[0][0]).toContain('Large file')
+  })
+
+  it('stays silent when the model reports no degradation', () => {
+    renderHook(() => useMonacoLargeFileNotice(editorReporting(false), '/repo/small.json'))
+    expect(toastMock).not.toHaveBeenCalled()
+  })
+
+  // Claiming features are off because we could not read the flag would be a
+  // guess presented as an observation.
+  it('stays silent when the degradation flag cannot be read', () => {
+    renderHook(() => useMonacoLargeFileNotice(editorReporting(undefined), '/repo/unknown.json'))
+    expect(toastMock).not.toHaveBeenCalled()
+  })
+
+  it('stays silent before the editor mounts', () => {
+    renderHook(() => useMonacoLargeFileNotice(null, '/repo/generated.json'))
+    expect(toastMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/editor/use-monaco-large-file-notice.ts
+++ b/src/renderer/src/components/editor/use-monaco-large-file-notice.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef } from 'react'
+import { toast } from 'sonner'
+import type { editor } from 'monaco-editor'
+import { translate } from '@/i18n/i18n'
+import { readMonacoLargeFileOptimizations } from './monaco-large-file-optimizations'
+
+const LARGE_FILE_NOTICE_DURATION_MS = 12_000
+
+/**
+ * Tells the user why a large file lost tokenization, folding, wrapping, code
+ * lenses, sticky scroll and word highlighting. Fires only when the model itself
+ * reports the degradation — an unreadable flag stays silent rather than guessing.
+ */
+export function useMonacoLargeFileNotice(
+  mountedEditor: editor.IStandaloneCodeEditor | null,
+  filePath: string
+): void {
+  const noticedPathsRef = useRef(new Set<string>())
+
+  useEffect(() => {
+    if (!mountedEditor || noticedPathsRef.current.has(filePath)) {
+      return
+    }
+    if (readMonacoLargeFileOptimizations(mountedEditor.getModel()) !== 'applied') {
+      return
+    }
+    noticedPathsRef.current.add(filePath)
+    toast(
+      translate(
+        'auto.components.editor.MonacoEditor.largeFileOptimizations',
+        'Large file: syntax highlighting, folding and word wrap are off'
+      ),
+      {
+        description: translate(
+          'auto.components.editor.MonacoEditor.largeFileOptimizationsDescription',
+          'The editor disables these on very large files to avoid freezing. Editing and search still work.'
+        ),
+        duration: LARGE_FILE_NOTICE_DURATION_MS
+      }
+    )
+  }, [mountedEditor, filePath])
+}

--- a/src/renderer/src/components/editor/useEditorPanelContentState.ts
+++ b/src/renderer/src/components/editor/useEditorPanelContentState.ts
@@ -1,7 +1,11 @@
 import { useCallback, useLayoutEffect, useRef, useState } from 'react'
 import type { OpenFile } from '@/store/slices/editor'
 import type { useAppStore } from '@/store'
-import type { DiffContent, FileContent } from './editor-panel-content-types'
+import type {
+  DiffContent,
+  EditorContentReloadOptions,
+  FileContent
+} from './editor-panel-content-types'
 import {
   useEditorPanelExternalContentEvents,
   usePruneClosedEditorContent
@@ -28,7 +32,7 @@ type UseEditorPanelContentStateParams = {
 type UseEditorPanelContentStateResult = {
   fileContents: Record<string, FileContent>
   diffContents: Record<string, DiffContent>
-  reloadContent: (file: OpenFile) => void
+  reloadContent: (file: OpenFile, options?: EditorContentReloadOptions) => void
 }
 
 export function useEditorPanelContentState({
@@ -43,6 +47,9 @@ export function useEditorPanelContentState({
   const [diffContents, setDiffContents] = useState<Record<string, DiffContent>>({})
   const diffContentsRef = useRef(diffContents)
   const fileLoadRetryAttemptsRef = useRef<Record<string, number>>({})
+  // Why: the size override belongs to the tab, not to the click that made it —
+  // reloads carry no options, so the loader reads it from here.
+  const largeFileOverrideIdsRef = useRef<Set<string>>(new Set())
   // Why: per-tab read generations let a forced/external reload supersede an
   // older in-flight read so a slower stale promise cannot overwrite fresh state.
   const fileReadGenerationRef = useRef<Record<string, number>>({})
@@ -123,6 +130,7 @@ export function useEditorPanelContentState({
 
   const loadFileContent = useEditorPanelFileContentLoader({
     fileLoadRetryAttemptsRef,
+    largeFileOverrideIdsRef,
     fileReadGenerationCounterRef,
     fileReadGenerationRef,
     openFilesRef,
@@ -141,7 +149,7 @@ export function useEditorPanelContentState({
   // must refetch the diff body, not the plain file content — one entry point
   // branches on the tab mode so every consumer reloads the right store.
   const reloadContent = useCallback(
-    (file: OpenFile): void => {
+    (file: OpenFile, options?: EditorContentReloadOptions): void => {
       if (file.mode === 'diff') {
         setDiffContents((prev) => {
           if (!prev[file.id]) {
@@ -164,7 +172,8 @@ export function useEditorPanelContentState({
         return next
       })
       void loadFileContent(file.filePath, file.id, file.worktreeId, file.relativePath, {
-        force: true
+        force: true,
+        allowLargeFile: options?.allowLargeFile
       })
     },
     [loadDiffContent, loadFileContent]
@@ -225,6 +234,7 @@ export function useEditorPanelContentState({
   usePruneClosedEditorContent(
     openFiles,
     fileLoadRetryAttemptsRef,
+    largeFileOverrideIdsRef,
     fileReadGenerationRef,
     diffReadGenerationRef,
     setFileContents,

--- a/src/renderer/src/components/editor/useEditorPanelExternalContentEvents.ts
+++ b/src/renderer/src/components/editor/useEditorPanelExternalContentEvents.ts
@@ -16,6 +16,8 @@ type EditorViewModeByFile = ReturnType<typeof useAppStore.getState>['editorViewM
 export type EditorPanelContentLoadOptions = {
   force?: boolean
   externalEventGeneration?: number
+  /** The user overruled the size refusal for this one read. */
+  allowLargeFile?: boolean
 }
 
 type UseEditorPanelExternalContentEventsParams = {
@@ -182,6 +184,7 @@ function updateSavedPreviewTabs(
 export function usePruneClosedEditorContent(
   openFiles: OpenFile[],
   fileLoadRetryAttemptsRef: MutableRefObject<Record<string, number>>,
+  largeFileOverrideIdsRef: MutableRefObject<Set<string>>,
   fileReadGenerationRef: MutableRefObject<Record<string, number>>,
   diffReadGenerationRef: MutableRefObject<Record<string, number>>,
   setFileContents: Dispatch<SetStateAction<Record<string, FileContent>>>,
@@ -201,6 +204,12 @@ export function usePruneClosedEditorContent(
     }
     // Why: conflict-review entry loads use absolute paths as content ids; only
     // ids that have belonged to tabs are safe to prune as closed tabs.
+    // Reopening a closed tab is a fresh decision, so its override asks again.
+    for (const fileId of largeFileOverrideIdsRef.current) {
+      if (knownOpenFileIdsRef.current.has(fileId) && !openIds.has(fileId)) {
+        largeFileOverrideIdsRef.current.delete(fileId)
+      }
+    }
     for (const fileId of Object.keys(fileReadGenerationRef.current)) {
       if (knownOpenFileIdsRef.current.has(fileId) && !openIds.has(fileId)) {
         delete fileReadGenerationRef.current[fileId]
@@ -220,6 +229,7 @@ export function usePruneClosedEditorContent(
   }, [
     diffReadGenerationRef,
     fileLoadRetryAttemptsRef,
+    largeFileOverrideIdsRef,
     fileReadGenerationRef,
     knownOpenFileIdsRef,
     openFiles,

--- a/src/renderer/src/components/editor/useEditorPanelFileContentLoader.ts
+++ b/src/renderer/src/components/editor/useEditorPanelFileContentLoader.ts
@@ -31,6 +31,7 @@ export type EditorPanelFileContentLoader = (
 
 type UseEditorPanelFileContentLoaderParams = {
   fileLoadRetryAttemptsRef: MutableRefObject<Record<string, number>>
+  largeFileOverrideIdsRef: MutableRefObject<Set<string>>
   fileReadGenerationCounterRef: MutableRefObject<number>
   fileReadGenerationRef: MutableRefObject<Record<string, number>>
   openFilesRef: MutableRefObject<OpenFile[]>
@@ -57,12 +58,19 @@ function stampCleanTabDiskBaseline(id: string, result: FileContent): void {
   }
 }
 
-function inFlightReadKey(connectionId: string | undefined, filePath: string): string {
-  return `${connectionId ?? ''}::${filePath}`
+// Why: the budget is part of the identity of a read — a read started under the
+// confirmation budget must never be handed to a caller that overruled it.
+function inFlightReadKey(
+  connectionId: string | undefined,
+  filePath: string,
+  allowLargeFile: boolean
+): string {
+  return `${connectionId ?? ''}::${allowLargeFile ? 'full' : 'budgeted'}::${filePath}`
 }
 
 export function useEditorPanelFileContentLoader({
   fileLoadRetryAttemptsRef,
+  largeFileOverrideIdsRef,
   fileReadGenerationCounterRef,
   fileReadGenerationRef,
   openFilesRef,
@@ -81,6 +89,15 @@ export function useEditorPanelFileContentLoader({
       fileReadGenerationCounterRef.current = generation
       fileReadGenerationRef.current[id] = generation
       outstandingFileReadsRef.current[id] = generation
+      if (options?.allowLargeFile === true) {
+        largeFileOverrideIdsRef.current.add(id)
+      }
+      // Why: "Open Anyway" is this tab's budget from then on, not one read. Every
+      // later reload — an external write, a reveal after invalidation, a retry —
+      // passes no options, and re-imposing the budget there would swap the loaded
+      // file back to the too-large fallback on the next write to disk.
+      const allowLargeFile =
+        options?.allowLargeFile === true || largeFileOverrideIdsRef.current.has(id)
       try {
         const resolvedConnectionId = getConnectionIdForFile(worktreeId ?? null, filePath)
         const connectionId = resolvedConnectionId ?? undefined
@@ -163,7 +180,7 @@ export function useEditorPanelFileContentLoader({
           }
         }
         const readScope = getRuntimeFileReadScope(readSettings, readConnectionId)
-        const key = inFlightReadKey(readScope, filePath)
+        const key = inFlightReadKey(readScope, filePath, allowLargeFile)
         const registeredRead = inFlightFileReads.get(key)
         if (
           options?.force &&
@@ -183,7 +200,8 @@ export function useEditorPanelFileContentLoader({
             worktreeId: readWorktreeId,
             connectionId: readConnectionId,
             expectedExternalSshTargetId: restoredOpenFile?.externalSshTargetId,
-            includeLocalLogMetadata: isLiveTailLogTab
+            includeLocalLogMetadata: isLiveTailLogTab,
+            allowLargeFile
           }) as Promise<FileContent>
           pending = { externalEventGeneration: options?.externalEventGeneration, promise }
           inFlightFileReads.set(key, pending)
@@ -217,6 +235,7 @@ export function useEditorPanelFileContentLoader({
     },
     [
       fileLoadRetryAttemptsRef,
+      largeFileOverrideIdsRef,
       fileReadGenerationCounterRef,
       fileReadGenerationRef,
       openFilesRef,

--- a/src/renderer/src/components/editor/useEditorPanelFileLoadRetry.test.tsx
+++ b/src/renderer/src/components/editor/useEditorPanelFileLoadRetry.test.tsx
@@ -103,6 +103,16 @@ describe('useEditorPanelFileLoadRetry — owner-not-ready bounding (#6648)', () 
     expect(shouldRetryFileLoadError('Access denied: outside allowed directories')).toBe(false)
   })
 
+  // SSH-backed runtime reads refuse with the bare token, which has no spaces, so
+  // the prose substring check missed it and spent the whole backoff budget on a
+  // deterministic refusal.
+  it('treats the bare file_too_large protocol token as terminal', () => {
+    expect(shouldRetryFileLoadError('file_too_large')).toBe(false)
+    expect(
+      shouldRetryFileLoadError("Error invoking remote method 'files.read': Error: file_too_large")
+    ).toBe(false)
+  })
+
   it('does not spend retry budget when hiding cancels a pending retry', () => {
     setTimeoutSpy.mockRestore()
     setTimeoutSpy = vi.spyOn(window, 'setTimeout')

--- a/src/renderer/src/components/editor/useEditorPanelFileLoadRetry.ts
+++ b/src/renderer/src/components/editor/useEditorPanelFileLoadRetry.ts
@@ -1,5 +1,6 @@
 import { useEffect, type Dispatch, type MutableRefObject, type SetStateAction } from 'react'
 import type { OpenFile } from '@/store/slices/editor'
+import { parseFileTooLargeMessage } from '../../../../shared/editor-file-read-limit'
 import {
   WORKTREE_OWNER_NOT_READY_ERROR,
   WORKTREE_OWNER_UNREACHABLE_ERROR,
@@ -37,6 +38,12 @@ export function shouldRetryFileLoadError(message: string): boolean {
   // Terminal: the owner-not-ready budget is spent; only an explicit Retry should
   // restart it, never the automatic backoff.
   if (message === WORKTREE_OWNER_UNREACHABLE_ERROR) {
+    return false
+  }
+  // A size refusal is deterministic, so retrying only burns the budget. Match the
+  // parser so the bare `file_too_large` token counts too — it has no spaces, so
+  // the prose check below never saw it.
+  if (parseFileTooLargeMessage(message)) {
     return false
   }
   const lower = message.toLowerCase()

--- a/src/renderer/src/components/editor/useEditorPanelLargeFileOverride.test.tsx
+++ b/src/renderer/src/components/editor/useEditorPanelLargeFileOverride.test.tsx
@@ -1,0 +1,283 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { OpenFile } from '@/store/slices/editor'
+import type { GitStatusEntry } from '../../../../shared/git-status-types'
+import {
+  EDITOR_TEXT_READ_LIMIT_BYTES,
+  formatFileTooLargeMessage
+} from '../../../../shared/editor-file-read-limit'
+
+const mocks = vi.hoisted(() => ({
+  getState: vi.fn(),
+  readRuntimeFileContent: vi.fn()
+}))
+
+vi.mock('@/runtime/runtime-file-client', () => ({
+  getRuntimeFileReadScope: vi.fn(() => null),
+  readRuntimeFileContent: mocks.readRuntimeFileContent,
+  subscribeRuntimeFileChanges: vi.fn()
+}))
+
+vi.mock('@/runtime/runtime-git-client', () => ({
+  getRuntimeGitBranchDiff: vi.fn(),
+  getRuntimeGitCommitDiff: vi.fn(),
+  getRuntimeGitDiff: vi.fn(),
+  getRuntimeGitScope: vi.fn(() => null)
+}))
+
+vi.mock('@/lib/connection-context', () => ({
+  getConnectionId: vi.fn(),
+  getConnectionIdForFile: vi.fn(),
+  isWorktreeConnectionResolved: vi.fn(() => true)
+}))
+
+vi.mock('@/lib/runtime-workspace-file-route', () => ({
+  findWorkspaceFileRoute: vi.fn(() => null)
+}))
+
+vi.mock('@/store', () => ({ useAppStore: { getState: mocks.getState } }))
+
+import { ORCA_EDITOR_EXTERNAL_FILE_CHANGE_EVENT } from './editor-autosave'
+import type { EditorContentReloadOptions, FileContent } from './editor-panel-content-types'
+import { useEditorPanelContentState } from './useEditorPanelContentState'
+
+const REFUSAL = formatFileTooLargeMessage({
+  byteLength: 60 * 1024 * 1024,
+  limitBytes: EDITOR_TEXT_READ_LIMIT_BYTES.local,
+  scope: 'local'
+})
+
+const BIG_FILE: OpenFile = {
+  id: '/repo/build.log',
+  filePath: '/repo/build.log',
+  relativePath: 'build.log',
+  worktreeId: 'wt-1',
+  language: 'plaintext',
+  isDirty: false,
+  mode: 'edit'
+}
+
+const OTHER_FILE: OpenFile = { ...BIG_FILE, id: '/repo/other.ts', filePath: '/repo/other.ts' }
+
+// A conflict-review overview renders its rows from synthetic content files whose
+// ids are absolute paths; those ids never enter `openFiles`.
+const CONFLICT_PATH = '/repo/huge.sql'
+const REVIEW_FILE: OpenFile = {
+  id: 'conflict-review:/repo',
+  filePath: '/repo',
+  relativePath: '',
+  worktreeId: 'wt-1',
+  language: 'plaintext',
+  isDirty: false,
+  mode: 'conflict-review',
+  conflictReview: {
+    source: 'live-summary',
+    snapshotTimestamp: 1,
+    entries: [{ path: 'huge.sql', conflictKind: 'both_modified' }]
+  }
+}
+const REVIEW_CONTENT_FILE: OpenFile = {
+  id: CONFLICT_PATH,
+  filePath: CONFLICT_PATH,
+  relativePath: 'huge.sql',
+  worktreeId: 'wt-1',
+  language: 'sql',
+  isDirty: false,
+  mode: 'edit',
+  conflict: {
+    kind: 'conflict-editable',
+    conflictKind: 'both_modified',
+    conflictStatus: 'unresolved',
+    conflictStatusSource: 'git'
+  }
+}
+function conflictEntries(): GitStatusEntry[] {
+  return [
+    {
+      path: 'huge.sql',
+      status: 'modified',
+      area: 'unstaged',
+      conflictKind: 'both_modified',
+      conflictStatus: 'unresolved',
+      conflictStatusSource: 'git'
+    }
+  ]
+}
+
+let latestFileContents: Record<string, FileContent> = {}
+let latestReloadContent: (file: OpenFile, options?: EditorContentReloadOptions) => void = () => {}
+
+function HookProbe({
+  activeFile,
+  openFiles,
+  gitStatusEntries
+}: {
+  activeFile: OpenFile | null
+  openFiles: OpenFile[]
+  gitStatusEntries?: GitStatusEntry[]
+}): null {
+  const state = useEditorPanelContentState({
+    activeFile,
+    isChangesMode: false,
+    openFiles,
+    gitStatusEntries,
+    editorViewMode: {}
+  })
+  latestFileContents = state.fileContents
+  latestReloadContent = state.reloadContent
+  return null
+}
+
+describe('editor large-file override', () => {
+  let container: HTMLDivElement | null = null
+  let root: Root | null = null
+
+  beforeEach(() => {
+    latestFileContents = {}
+    ;(window as unknown as { api: unknown }).api = {
+      fs: { authorizeExternalPath: vi.fn().mockResolvedValue(undefined) }
+    }
+    mocks.getState.mockReset()
+    mocks.getState.mockReturnValue({
+      settings: null,
+      openFiles: [],
+      setLastKnownDiskSignature: vi.fn()
+    })
+    mocks.readRuntimeFileContent.mockReset()
+    mocks.readRuntimeFileContent.mockImplementation(
+      async ({ filePath, allowLargeFile }: { filePath: string; allowLargeFile?: boolean }) => {
+        if (filePath !== BIG_FILE.filePath && filePath !== CONFLICT_PATH) {
+          return { content: 'other content', isBinary: false }
+        }
+        if (allowLargeFile !== true) {
+          throw new Error(REFUSAL)
+        }
+        return { content: 'huge content', isBinary: false }
+      }
+    )
+  })
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount())
+    }
+    container?.remove()
+    container = null
+    root = null
+  })
+
+  async function renderProbe(
+    activeFile: OpenFile | null,
+    openFiles: OpenFile[],
+    gitStatusEntries?: GitStatusEntry[]
+  ): Promise<void> {
+    if (!root) {
+      container = document.createElement('div')
+      document.body.appendChild(container)
+      root = createRoot(container)
+    }
+    await act(async () => {
+      root?.render(
+        <HookProbe
+          activeFile={activeFile}
+          openFiles={openFiles}
+          gitStatusEntries={gitStatusEntries}
+        />
+      )
+    })
+  }
+
+  async function openAnyway(): Promise<void> {
+    await vi.waitFor(() => expect(latestFileContents[BIG_FILE.id]?.loadError).toBe(REFUSAL))
+    await act(async () => {
+      latestReloadContent(BIG_FILE, { allowLargeFile: true })
+    })
+    await vi.waitFor(() => expect(latestFileContents[BIG_FILE.id]?.content).toBe('huge content'))
+  }
+
+  // "Open Anyway" is this tab's budget from then on, not one read. A build log
+  // keeps growing, so the watcher forces a reload seconds later; re-imposing the
+  // budget there would swap the loaded file back to the too-large fallback.
+  it('carries the override into an external-change reload', async () => {
+    await renderProbe(BIG_FILE, [BIG_FILE])
+    await openAnyway()
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(ORCA_EDITOR_EXTERNAL_FILE_CHANGE_EVENT, {
+          detail: {
+            worktreeId: BIG_FILE.worktreeId,
+            worktreePath: '/repo',
+            relativePath: BIG_FILE.relativePath
+          }
+        })
+      )
+    })
+
+    await vi.waitFor(() => expect(mocks.readRuntimeFileContent).toHaveBeenCalledTimes(3))
+    expect(mocks.readRuntimeFileContent.mock.calls[2][0]).toMatchObject({ allowLargeFile: true })
+    expect(latestFileContents[BIG_FILE.id]?.content).toBe('huge content')
+    expect(latestFileContents[BIG_FILE.id]?.loadError).toBeUndefined()
+  })
+
+  // The background path: an invalidated tab reloads on reveal with no options at
+  // all, so the override has to live with the tab rather than with the click.
+  it('carries the override into a reload on reveal', async () => {
+    const openFiles = [BIG_FILE, OTHER_FILE]
+    await renderProbe(BIG_FILE, openFiles)
+    await openAnyway()
+
+    await renderProbe(OTHER_FILE, openFiles)
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(ORCA_EDITOR_EXTERNAL_FILE_CHANGE_EVENT, {
+          detail: {
+            worktreeId: BIG_FILE.worktreeId,
+            worktreePath: '/repo',
+            relativePath: BIG_FILE.relativePath
+          }
+        })
+      )
+    })
+    await vi.waitFor(() => expect(latestFileContents[BIG_FILE.id]?.isStale).toBe(true))
+
+    await renderProbe(BIG_FILE, openFiles)
+
+    await vi.waitFor(() => expect(latestFileContents[BIG_FILE.id]?.isStale).toBeUndefined())
+    expect(latestFileContents[BIG_FILE.id]?.content).toBe('huge content')
+    expect(latestFileContents[BIG_FILE.id]?.loadError).toBeUndefined()
+  })
+
+  // Reopening a closed tab is a fresh decision, so the confirmation comes back.
+  it('drops the override when the tab is closed', async () => {
+    await renderProbe(BIG_FILE, [BIG_FILE])
+    await openAnyway()
+
+    await renderProbe(null, [])
+    await renderProbe(BIG_FILE, [BIG_FILE])
+
+    await vi.waitFor(() => expect(latestFileContents[BIG_FILE.id]?.loadError).toBe(REFUSAL))
+  })
+
+  // A conflict-review row's content id is an absolute path that never belongs to
+  // `openFiles`, so pruning it as a "closed tab" made Open Anyway a one-shot that
+  // the next unrelated tab change reverted.
+  it('keeps the override for a conflict-review row when an unrelated tab opens', async () => {
+    await renderProbe(REVIEW_FILE, [REVIEW_FILE], conflictEntries())
+    await vi.waitFor(() => expect(latestFileContents[CONFLICT_PATH]?.loadError).toBe(REFUSAL))
+    await act(async () => {
+      latestReloadContent(REVIEW_CONTENT_FILE, { allowLargeFile: true })
+    })
+    await vi.waitFor(() => expect(latestFileContents[CONFLICT_PATH]?.content).toBe('huge content'))
+
+    // Opening another tab reruns the prune; a later status poll reloads the row.
+    await renderProbe(REVIEW_FILE, [REVIEW_FILE, OTHER_FILE], conflictEntries())
+    await renderProbe(REVIEW_FILE, [REVIEW_FILE, OTHER_FILE], conflictEntries())
+
+    await vi.waitFor(() => expect(latestFileContents[CONFLICT_PATH]?.content).toBe('huge content'))
+    expect(latestFileContents[CONFLICT_PATH]?.loadError).toBeUndefined()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/ai-vault-scan-issue-state.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-scan-issue-state.test.ts
@@ -6,6 +6,10 @@ import {
   skippedAiVaultTranscriptCount,
   skippedAiVaultTranscriptReasons
 } from './ai-vault-scan-issue-state'
+import {
+  formatFileTooLargeMessage,
+  stripFileTooLargeMarker
+} from '../../../../shared/editor-file-read-limit'
 
 describe('blockingAiVaultScanIssue', () => {
   it('surfaces the cause when a scan returns no sessions', () => {
@@ -97,7 +101,17 @@ describe('aiVaultScanNoticeIssues', () => {
 })
 
 describe('skippedAiVaultTranscriptReasons', () => {
+  // Built from the real refusal the scanner records, so the row cannot drift back
+  // into showing the editor's machine marker to a reader.
   it('surfaces the file-too-large reason behind a skipped transcript', () => {
+    const recorded = stripFileTooLargeMarker(
+      formatFileTooLargeMessage({
+        byteLength: 13_002_342,
+        limitBytes: 10 * 1024 * 1024,
+        scope: 'ssh'
+      })
+    )
+
     expect(
       skippedAiVaultTranscriptReasons(
         result(
@@ -106,12 +120,14 @@ describe('skippedAiVaultTranscriptReasons', () => {
             {
               agent: 'claude',
               path: '/home/dev/.claude/projects/a/huge.jsonl',
-              message: 'File too large: 12.4MB exceeds 10MB limit'
+              message: recorded
             }
           ]
         )
       )
-    ).toEqual(['File too large: 12.4MB exceeds 10MB limit'])
+    ).toEqual([
+      'File too large: 12.4 MB exceeds the 10.0 MB read limit for files on this SSH host.'
+    ])
   })
 
   it('leaves host and scope notices to their own rows', () => {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14519,7 +14519,10 @@
           "title": "This file is too large to open in the editor.",
           "size": "File size",
           "limit": "Read limit",
-          "scopeLocal": "Local files use the largest budget Orca offers; beyond it the editor cannot hold the whole file in memory safely.",
+          "openAnyway": "Open Anyway",
+          "scopeLocal": "Local files use the largest budget Orca opens without asking.",
+          "localOverridable": "You can open it anyway, but the editor may become slow.",
+          "localAtCeiling": "This file is past the largest size the editor can hold, so opening it anyway would refuse again.",
           "scopeSsh": "Files read over SSH share the connection with your terminals, so they use a smaller budget than local files.",
           "scopeRuntime": "Files read from a remote workspace travel over the workspace connection, so they use a smaller budget than local files."
         },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14256,7 +14256,9 @@
         "MonacoEditor": {
           "68cb83f4a7": "Add note on selected text",
           "fd68ae03b3": "Search in Files",
-          "largePasteTooLarge": "Paste is too large."
+          "largePasteTooLarge": "Paste is too large.",
+          "largeFileOptimizations": "Large file: syntax highlighting, folding and word wrap are off",
+          "largeFileOptimizationsDescription": "The editor disables these on very large files to avoid freezing. Editing and search still work."
         },
         "MonacoGutterContextMenu": {
           "7b57b1b468": "Copy Remote URL",
@@ -14512,6 +14514,14 @@
           "f1d136a163": "lines per side",
           "23433fcdea": "combined characters",
           "7944ed9fb8": "Not counted"
+        },
+        "LargeFileFallback": {
+          "title": "This file is too large to open in the editor.",
+          "size": "File size",
+          "limit": "Read limit",
+          "scopeLocal": "Local files use the largest budget Orca offers; beyond it the editor cannot hold the whole file in memory safely.",
+          "scopeSsh": "Files read over SSH share the connection with your terminals, so they use a smaller budget than local files.",
+          "scopeRuntime": "Files read from a remote workspace travel over the workspace connection, so they use a smaller budget than local files."
         },
         "DiffViewer": {
           "b5675b0694": "Save",

--- a/src/renderer/src/runtime/runtime-file-client.test.ts
+++ b/src/renderer/src/runtime/runtime-file-client.test.ts
@@ -9,6 +9,7 @@ import {
   writeRuntimeFile,
   type RuntimeReadableFileContent
 } from './runtime-file-client'
+import { parseFileTooLargeMessage } from '../../../shared/editor-file-read-limit'
 import {
   fsReadFile,
   fsWriteFile,
@@ -37,6 +38,25 @@ describe('runtime file client', () => {
 
     expect(fsReadFile).toHaveBeenCalledWith({ filePath: '/repo/readme.md', connectionId: 'ssh-1' })
     expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
+  })
+
+  // The fallback's override has to reach the host that applied the cap; dropping
+  // the flag here would render a button that silently refuses again.
+  it('forwards a large-file override to the local read', async () => {
+    const localResult: RuntimeReadableFileContent = { content: 'huge', isBinary: false }
+    fsReadFile.mockResolvedValue(localResult)
+
+    await readRuntimeFileContent({
+      settings: { activeRuntimeEnvironmentId: null },
+      filePath: '/repo/huge.log',
+      relativePath: 'huge.log',
+      worktreeId: 'wt-1',
+      allowLargeFile: true
+    })
+
+    expect(fsReadFile).toHaveBeenCalledWith(
+      expect.objectContaining({ filePath: '/repo/huge.log', allowLargeFile: true })
+    )
   })
 
   it('reads an external SSH file only from its owning target', async () => {
@@ -219,14 +239,20 @@ describe('runtime file client', () => {
       _meta: { runtimeId: 'remote-runtime' }
     })
 
-    await expect(
-      readRuntimeFileContent({
-        settings: { activeRuntimeEnvironmentId: 'env-1' },
-        filePath: '/remote/repo/large.log',
-        relativePath: 'large.log',
-        worktreeId: 'wt-1'
-      })
-    ).rejects.toThrow('Remote file is too large to open in the editor')
+    // A host predating both budget fields reported nothing measurable, so the
+    // refusal names no number at all — least of all the prefix length.
+    const message = await readRuntimeFileContent({
+      settings: { activeRuntimeEnvironmentId: 'env-1' },
+      filePath: '/remote/repo/large.log',
+      relativePath: 'large.log',
+      worktreeId: 'wt-1'
+    }).then(
+      () => 'resolved',
+      (error: Error) => error.message
+    )
+    expect(message).toContain('File too large')
+    expect(message).not.toContain('524288')
+    expect(parseFileTooLargeMessage(message)).toEqual({ scope: 'runtime' })
   })
 
   it('falls back to files.readPreview when a remote binary file is opened', async () => {
@@ -305,6 +331,62 @@ describe('runtime file client', () => {
     expect(runtimeEnvironmentCall).not.toHaveBeenCalledWith(
       expect.objectContaining({ method: 'files.readPreview' })
     )
+  })
+
+  function mockTruncatedRead(result: Record<string, unknown>): void {
+    runtimeEnvironmentCall.mockImplementation((args: { method: string }) => {
+      if (args.method === 'files.read') {
+        return Promise.resolve({
+          id: 'rpc-read',
+          ok: true,
+          result: {
+            worktree: 'wt-1',
+            relativePath: 'huge.log',
+            content: 'x'.repeat(8),
+            truncated: true,
+            ...result
+          },
+          _meta: { runtimeId: 'remote-runtime' }
+        })
+      }
+      throw new Error('files.readPreview should not be called')
+    })
+  }
+
+  async function readHugeLogError(): Promise<string> {
+    return await readRuntimeFileContent({
+      settings: { activeRuntimeEnvironmentId: 'env-1' },
+      filePath: '/remote/repo/huge.log',
+      relativePath: 'huge.log',
+      worktreeId: 'wt-1'
+    }).then(
+      () => 'resolved',
+      (error: Error) => error.message
+    )
+  }
+
+  // `byteLength` is the bounded prefix the host managed to read, not the file's
+  // size; reporting it as the size told a 4GB log's owner it was 0.5MB.
+  it('never reports the truncated prefix length as the file size', async () => {
+    mockTruncatedRead({ byteLength: 524_289, maxByteLength: 524_288 })
+
+    const message = await readHugeLogError()
+    expect(message).toContain('File too large')
+    expect(message).toContain('512.0 KB')
+    expect(message).not.toContain('524289')
+    expect(message).not.toContain('0.5')
+  })
+
+  it('reports the file size once the host actually observes one', async () => {
+    mockTruncatedRead({
+      byteLength: 524_289,
+      maxByteLength: 524_288,
+      totalByteLength: 4 * 1024 * 1024 * 1024
+    })
+
+    const message = await readHugeLogError()
+    expect(message).toContain('4.0 GB')
+    expect(message).toContain('512.0 KB')
   })
 
   it('propagates a files.readPreview failure during the binary fallback', async () => {

--- a/src/renderer/src/runtime/runtime-file-client.ts
+++ b/src/renderer/src/runtime/runtime-file-client.ts
@@ -63,6 +63,8 @@ export type RuntimeFileReadArgs = {
   connectionId?: string
   expectedExternalSshTargetId?: string
   includeLocalLogMetadata?: boolean
+  /** The user overruled the size refusal; only the local transport honours it. */
+  allowLargeFile?: boolean
 }
 
 export type RuntimeFileOperationArgs = {
@@ -256,15 +258,17 @@ export async function readRuntimeFileContent({
   worktreeId,
   connectionId,
   expectedExternalSshTargetId,
-  includeLocalLogMetadata
+  includeLocalLogMetadata,
+  allowLargeFile
 }: RuntimeFileReadArgs): Promise<RuntimeReadableFileContent> {
   assertExternalSshReadOwnership(settings, connectionId, expectedExternalSshTargetId)
   const target = getActiveRuntimeTarget(settings)
+  const readArgs = { filePath, connectionId, includeLocalLogMetadata, allowLargeFile }
   if (target.kind !== 'environment') {
-    return window.api.fs.readFile({ filePath, connectionId, includeLocalLogMetadata })
+    return window.api.fs.readFile(readArgs)
   }
   if (!worktreeId) {
-    return window.api.fs.readFile({ filePath, connectionId, includeLocalLogMetadata })
+    return window.api.fs.readFile(readArgs)
   }
   if (!canReadRelativeRuntimeFile(relativePath)) {
     throw new Error('Remote file is outside the owning runtime worktree')
@@ -296,15 +300,14 @@ export async function readRuntimeFileContent({
   if (result.truncated) {
     // Why: the runtime file RPC is preview-sized today; treating a truncated
     // payload as editable content would make saves overwrite the rest of the file.
-    // Older hosts do not report the budget, so only name a limit we were told.
+    // `byteLength` is only the capped prefix the host read, so the size comes from
+    // its stat or not at all; older hosts report neither and the message says so.
     throw new Error(
-      typeof result.maxByteLength === 'number'
-        ? formatFileTooLargeMessage({
-            byteLength: result.byteLength,
-            limitBytes: result.maxByteLength,
-            scope: 'runtime'
-          })
-        : `Remote file is too large to open in the editor (${result.byteLength} bytes)`
+      formatFileTooLargeMessage({
+        byteLength: result.totalByteLength,
+        limitBytes: result.maxByteLength,
+        scope: 'runtime'
+      })
     )
   }
   return { content: result.content, isBinary: false }

--- a/src/renderer/src/runtime/runtime-file-client.ts
+++ b/src/renderer/src/runtime/runtime-file-client.ts
@@ -22,6 +22,7 @@ import {
   unwrapRuntimeRpcResult
 } from './runtime-rpc-client'
 import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
+import { formatFileTooLargeMessage } from '../../../shared/editor-file-read-limit'
 import { basename, joinPath, normalizeRelativePath } from '@/lib/path'
 import {
   isWindowsAbsolutePathLike,
@@ -295,7 +296,16 @@ export async function readRuntimeFileContent({
   if (result.truncated) {
     // Why: the runtime file RPC is preview-sized today; treating a truncated
     // payload as editable content would make saves overwrite the rest of the file.
-    throw new Error(`Remote file is too large to open in the editor (${result.byteLength} bytes)`)
+    // Older hosts do not report the budget, so only name a limit we were told.
+    throw new Error(
+      typeof result.maxByteLength === 'number'
+        ? formatFileTooLargeMessage({
+            byteLength: result.byteLength,
+            limitBytes: result.maxByteLength,
+            scope: 'runtime'
+          })
+        : `Remote file is too large to open in the editor (${result.byteLength} bytes)`
+    )
   }
   return { content: result.content, isBinary: false }
 }

--- a/src/shared/editor-file-read-limit.test.ts
+++ b/src/shared/editor-file-read-limit.test.ts
@@ -1,7 +1,10 @@
+import { constants as bufferConstants } from 'node:buffer'
 import { describe, expect, it } from 'vitest'
 import {
   EDITOR_PREVIEWABLE_BINARY_MAX_BYTES,
+  EDITOR_READ_OVERRIDE_CEILING_BYTES,
   EDITOR_TEXT_READ_LIMIT_BYTES,
+  MONACO_HEAP_OPERATION_LIMIT_BYTES,
   formatFileTooLargeMessage,
   parseFileTooLargeMessage
 } from './editor-file-read-limit'
@@ -18,14 +21,41 @@ describe('editor file read limits', () => {
     expect(EDITOR_TEXT_READ_LIMIT_BYTES.ssh).toBe(10 * 1024 * 1024)
   })
 
+  // The override lifts the confirmation budget; it must still land under a
+  // ceiling, or the read dies on an unparseable V8 allocation throw instead.
+  it('keeps the override ceiling above every budget it lifts', () => {
+    expect(EDITOR_READ_OVERRIDE_CEILING_BYTES).toBeGreaterThan(EDITOR_TEXT_READ_LIMIT_BYTES.local)
+    expect(EDITOR_READ_OVERRIDE_CEILING_BYTES).toBeGreaterThan(EDITOR_PREVIEWABLE_BINARY_MAX_BYTES)
+  })
+
+  // Measured against the running V8, not a remembered number: the ceiling has to
+  // hold for base64 too, which inflates 3 bytes into 4 string characters.
+  it('keeps a ceiling-sized read representable as one string in this V8', () => {
+    const base64Length = Math.ceil(EDITOR_READ_OVERRIDE_CEILING_BYTES / 3) * 4
+    expect(base64Length).toBeLessThanOrEqual(bufferConstants.MAX_STRING_LENGTH)
+    // utf-8 decoding never yields more UTF-16 code units than input bytes.
+    expect(EDITOR_READ_OVERRIDE_CEILING_BYTES).toBeLessThanOrEqual(
+      bufferConstants.MAX_STRING_LENGTH
+    )
+  })
+
+  // Why: past this the editor's own model refuses every whole-buffer read
+  // (mount-time content sync and save both take one), so admitting more bytes
+  // buys a tab that throws instead of a tab that is merely slow.
+  it('keeps the override ceiling under the editor model heap-operation limit', () => {
+    expect(EDITOR_READ_OVERRIDE_CEILING_BYTES).toBeLessThanOrEqual(
+      MONACO_HEAP_OPERATION_LIMIT_BYTES
+    )
+  })
+
   it('round-trips the too-large message through an IPC wrapper prefix', () => {
     const message = formatFileTooLargeMessage({
       byteLength: 53_477_376,
       limitBytes: EDITOR_TEXT_READ_LIMIT_BYTES.local,
       scope: 'local'
     })
-    expect(message).toContain('51.0MB')
-    expect(message).toContain('50MB')
+    expect(message).toContain('51.0 MB')
+    expect(message).toContain('50.0 MB')
 
     const wrapped = `Error invoking remote method 'fs:readFile': Error: ${message}`
     expect(parseFileTooLargeMessage(wrapped)).toEqual({
@@ -43,6 +73,40 @@ describe('editor file read limits', () => {
         formatFileTooLargeMessage({ byteLength: 1, limitBytes: 1, scope }).toLowerCase()
       ).toContain('file too large')
     }
+  })
+
+  // Regression: Math.round(524288 / 1024 / 1024) labelled the 512KB runtime
+  // budget "1MB", so the sentence claimed 0.5MB exceeded 1MB.
+  it('labels a sub-megabyte limit in the unit it actually is', () => {
+    const message = formatFileTooLargeMessage({
+      byteLength: 524_289,
+      limitBytes: 512 * 1024,
+      scope: 'runtime'
+    })
+    expect(message).toContain('512.0 KB')
+    expect(message).not.toContain('1MB')
+    expect(message).not.toContain('1 MB')
+  })
+
+  // The runtime host only reads a bounded prefix, so it knows the budget but not
+  // the file's size. Naming a size it never observed is the bug this guards.
+  it('omits a size the caller could not observe', () => {
+    const message = formatFileTooLargeMessage({ limitBytes: 512 * 1024, scope: 'runtime' })
+    expect(message).not.toContain('exceeds')
+    expect(message).toContain('512.0 KB')
+    expect(parseFileTooLargeMessage(message)).toEqual({
+      limitBytes: 524_288,
+      scope: 'runtime'
+    })
+  })
+
+  // SSH-backed runtime reads refuse with the bare protocol token, which carries
+  // no numbers. It must still read as terminal, not as an unknown failure.
+  it('recognizes the bare file_too_large protocol token', () => {
+    expect(
+      parseFileTooLargeMessage("Error invoking remote method 'files.read': Error: file_too_large")
+    ).toEqual({})
+    expect(parseFileTooLargeMessage('file_too_large_variant')).toBeNull()
   })
 
   it('names the transport so the fallback never claims one shared limit', () => {

--- a/src/shared/editor-file-read-limit.test.ts
+++ b/src/shared/editor-file-read-limit.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import {
+  EDITOR_PREVIEWABLE_BINARY_MAX_BYTES,
+  EDITOR_TEXT_READ_LIMIT_BYTES,
+  formatFileTooLargeMessage,
+  parseFileTooLargeMessage
+} from './editor-file-read-limit'
+
+describe('editor file read limits', () => {
+  // Guards #1367 ("Allow large text files to open in editor") against a silent
+  // revert: a later consistency pass must not quietly shrink the local budget.
+  it('keeps the local text budget at 50MB', () => {
+    expect(EDITOR_TEXT_READ_LIMIT_BYTES.local).toBe(50 * 1024 * 1024)
+    expect(EDITOR_PREVIEWABLE_BINARY_MAX_BYTES).toBe(50 * 1024 * 1024)
+  })
+
+  it('keeps the lower SSH budget the transports actually enforce', () => {
+    expect(EDITOR_TEXT_READ_LIMIT_BYTES.ssh).toBe(10 * 1024 * 1024)
+  })
+
+  it('round-trips the too-large message through an IPC wrapper prefix', () => {
+    const message = formatFileTooLargeMessage({
+      byteLength: 53_477_376,
+      limitBytes: EDITOR_TEXT_READ_LIMIT_BYTES.local,
+      scope: 'local'
+    })
+    expect(message).toContain('51.0MB')
+    expect(message).toContain('50MB')
+
+    const wrapped = `Error invoking remote method 'fs:readFile': Error: ${message}`
+    expect(parseFileTooLargeMessage(wrapped)).toEqual({
+      byteLength: 53_477_376,
+      limitBytes: 52_428_800,
+      scope: 'local'
+    })
+  })
+
+  // The editor's automatic backoff keys off this prefix; a size refusal is
+  // deterministic, so retrying it just burns the budget.
+  it('keeps the prefix the retry gate treats as terminal', () => {
+    for (const scope of ['local', 'ssh', 'runtime'] as const) {
+      expect(
+        formatFileTooLargeMessage({ byteLength: 1, limitBytes: 1, scope }).toLowerCase()
+      ).toContain('file too large')
+    }
+  })
+
+  it('names the transport so the fallback never claims one shared limit', () => {
+    const ssh = formatFileTooLargeMessage({
+      byteLength: 12_000_000,
+      limitBytes: EDITOR_TEXT_READ_LIMIT_BYTES.ssh,
+      scope: 'ssh'
+    })
+    expect(parseFileTooLargeMessage(ssh)?.scope).toBe('ssh')
+    expect(parseFileTooLargeMessage('some unrelated read failure')).toBeNull()
+  })
+})

--- a/src/shared/editor-file-read-limit.ts
+++ b/src/shared/editor-file-read-limit.ts
@@ -1,0 +1,64 @@
+/**
+ * One definition of how many bytes the editor will pull over each transport,
+ * plus a machine-readable refusal so the renderer can degrade to an explanatory
+ * view instead of a dead "Unable to load file" box.
+ *
+ * The values deliberately differ per transport and are NOT converging: a local
+ * read is a page-cache copy, an SSH read crosses a bounded RPC transport where
+ * a large transfer stalls the interactive lanes. Reporting the transport in the
+ * refusal is what keeps that honest — the fallback names the limit that was
+ * actually applied rather than claiming one shared number.
+ */
+
+/** Transport that produced the bytes, not the workspace kind. */
+export type EditorFileReadScope = 'local' | 'ssh' | 'runtime'
+
+export const EDITOR_TEXT_READ_LIMIT_BYTES: Record<'local' | 'ssh', number> = {
+  local: 50 * 1024 * 1024,
+  ssh: 10 * 1024 * 1024
+}
+
+/** Previewable binaries are base64 blobs the editor never parses as text. */
+export const EDITOR_PREVIEWABLE_BINARY_MAX_BYTES = 50 * 1024 * 1024
+
+export type FileTooLargeDetail = {
+  byteLength: number
+  limitBytes: number
+  scope: EditorFileReadScope
+}
+
+const SCOPE_SUBJECT: Record<EditorFileReadScope, string> = {
+  local: 'local files',
+  ssh: 'files on this SSH host',
+  runtime: 'files on this remote workspace'
+}
+
+// Why: parsed out of a message rather than a typed error because the refusal
+// crosses ipcRenderer.invoke and the relay, both of which flatten errors to a
+// string and prepend their own wrapper text.
+const DETAIL_PATTERN = /\[size=(\d+) limit=(\d+) scope=(local|ssh|runtime)\]/
+
+function formatMegabytes(bytes: number): string {
+  return `${(bytes / 1024 / 1024).toFixed(1)}MB`
+}
+
+export function formatFileTooLargeMessage({
+  byteLength,
+  limitBytes,
+  scope
+}: FileTooLargeDetail): string {
+  const limitLabel = `${Math.round(limitBytes / 1024 / 1024)}MB`
+  return `File too large: ${formatMegabytes(byteLength)} exceeds the ${limitLabel} read limit for ${SCOPE_SUBJECT[scope]}. [size=${byteLength} limit=${limitBytes} scope=${scope}]`
+}
+
+export function parseFileTooLargeMessage(message: string): FileTooLargeDetail | null {
+  const match = DETAIL_PATTERN.exec(message)
+  if (!match) {
+    return null
+  }
+  return {
+    byteLength: Number(match[1]),
+    limitBytes: Number(match[2]),
+    scope: match[3] as EditorFileReadScope
+  }
+}

--- a/src/shared/editor-file-read-limit.ts
+++ b/src/shared/editor-file-read-limit.ts
@@ -21,10 +21,47 @@ export const EDITOR_TEXT_READ_LIMIT_BYTES: Record<'local' | 'ssh', number> = {
 /** Previewable binaries are base64 blobs the editor never parses as text. */
 export const EDITOR_PREVIEWABLE_BINARY_MAX_BYTES = 50 * 1024 * 1024
 
+/**
+ * The editor model decides at construction that it is too large for any
+ * whole-buffer read, and Orca takes one on every editor mount (content sync)
+ * and every save. Past this it throws instead of returning text. utf-8 never
+ * decodes to more UTF-16 code units than input bytes, so bounding bytes bounds
+ * characters. Pinned against the model's own constant in
+ * monaco-large-file-optimizations.test.ts.
+ */
+export const MONACO_HEAP_OPERATION_LIMIT_BYTES = 256 * 1024 * 1024
+
+/**
+ * Ceiling on a read whose budget the user overruled. The budgets above are
+ * confirmations — "this will be slow, proceed?" — but the local transport still
+ * materializes the whole file as one Buffer and one JS string that is cloned
+ * whole into the renderer, and V8 cannot represent a string past
+ * `buffer.constants.MAX_STRING_LENGTH`. Without a ceiling the override turns a
+ * parseable refusal into an allocation throw that the retry gate reads as
+ * transient, so it retries into the same wall.
+ *
+ * Derived, not chosen, from the two walls the overridden bytes have to clear:
+ * base64 turns 3 bytes into 4 characters, so V8's string cap fixes one bound;
+ * the model's heap-operation limit fixes the other, and it is the lower of the
+ * two. Admitting bytes between them buys a tab that throws on mount and on
+ * save rather than a tab that is merely slow.
+ */
+const V8_MAX_STRING_LENGTH = 536_870_888
+export const EDITOR_READ_OVERRIDE_CEILING_BYTES = Math.min(
+  Math.floor(V8_MAX_STRING_LENGTH / 4) * 3,
+  MONACO_HEAP_OPERATION_LIMIT_BYTES
+)
+
+/**
+ * Every field is optional because a refuser only reports what it measured: a
+ * host that caps its read knows the budget but never the file's size, and the
+ * bare `file_too_large` protocol token carries neither. Absent means unobserved,
+ * so the fallback omits the row rather than printing a number nobody checked.
+ */
 export type FileTooLargeDetail = {
-  byteLength: number
-  limitBytes: number
-  scope: EditorFileReadScope
+  byteLength?: number
+  limitBytes?: number
+  scope?: EditorFileReadScope
 }
 
 const SCOPE_SUBJECT: Record<EditorFileReadScope, string> = {
@@ -36,10 +73,31 @@ const SCOPE_SUBJECT: Record<EditorFileReadScope, string> = {
 // Why: parsed out of a message rather than a typed error because the refusal
 // crosses ipcRenderer.invoke and the relay, both of which flatten errors to a
 // string and prepend their own wrapper text.
-const DETAIL_PATTERN = /\[size=(\d+) limit=(\d+) scope=(local|ssh|runtime)\]/
+const MARKER_PATTERN = /\[((?:size|limit|scope)=[^\]]*)\]/
+// Hosts that cannot attach a marker refuse with this bare protocol token.
+const PROTOCOL_TOKEN_PATTERN = /(?<![A-Za-z0-9_])file_too_large(?![A-Za-z0-9_])/
+// Why: the marker is addressed to the editor's fallback, not to a reader. Any
+// surface that prints the raw refusal as prose has to drop it first.
+const APPENDED_MARKER_PATTERN = /\s*\[(?:file_too_large|(?:size|limit|scope)=[^\]]*)\]/g
 
-function formatMegabytes(bytes: number): string {
-  return `${(bytes / 1024 / 1024).toFixed(1)}MB`
+const BYTE_UNITS = [
+  { label: 'GB', bytes: 1024 * 1024 * 1024 },
+  { label: 'MB', bytes: 1024 * 1024 },
+  { label: 'KB', bytes: 1024 }
+] as const
+
+/**
+ * The one formatter for every byte count the editor shows a user. Fixing the
+ * unit at MB mislabelled sub-MB budgets ("0.5MB exceeds the 1MB read limit"),
+ * and a second formatter elsewhere let a size and its own limit disagree.
+ */
+export function formatFileReadBytes(bytes: number): string {
+  for (const unit of BYTE_UNITS) {
+    if (bytes >= unit.bytes) {
+      return `${(bytes / unit.bytes).toFixed(1)} ${unit.label}`
+    }
+  }
+  return `${Math.max(0, Math.round(bytes))} B`
 }
 
 export function formatFileTooLargeMessage({
@@ -47,18 +105,60 @@ export function formatFileTooLargeMessage({
   limitBytes,
   scope
 }: FileTooLargeDetail): string {
-  const limitLabel = `${Math.round(limitBytes / 1024 / 1024)}MB`
-  return `File too large: ${formatMegabytes(byteLength)} exceeds the ${limitLabel} read limit for ${SCOPE_SUBJECT[scope]}. [size=${byteLength} limit=${limitBytes} scope=${scope}]`
+  const limitClause =
+    limitBytes === undefined
+      ? 'the read limit'
+      : `the ${formatFileReadBytes(limitBytes)} read limit`
+  const subjectClause = scope === undefined ? '' : ` for ${SCOPE_SUBJECT[scope]}`
+  const sentence =
+    byteLength === undefined
+      ? `File too large: over ${limitClause}${subjectClause}.`
+      : `File too large: ${formatFileReadBytes(byteLength)} exceeds ${limitClause}${subjectClause}.`
+  const marker = [
+    byteLength === undefined ? null : `size=${byteLength}`,
+    limitBytes === undefined ? null : `limit=${limitBytes}`,
+    scope === undefined ? null : `scope=${scope}`
+  ]
+    .filter((part): part is string => part !== null)
+    .join(' ')
+  return `${sentence} [${marker === '' ? 'file_too_large' : marker}]`
+}
+
+/**
+ * Whether re-reading with the budget lifted could still succeed. A refusal names
+ * the limit that stopped it, so a limit already at the ceiling leaves the
+ * override nothing to lift, and only the local transport answers to this client
+ * at all — SSH and runtime caps bound a connection shared with the interactive
+ * lanes. An unreported scope named no transport, so nothing was observed that
+ * would justify offering the override.
+ */
+export function isOverridableFileTooLarge(detail: FileTooLargeDetail): boolean {
+  return (
+    detail.scope === 'local' &&
+    (detail.limitBytes === undefined || detail.limitBytes < EDITOR_READ_OVERRIDE_CEILING_BYTES)
+  )
 }
 
 export function parseFileTooLargeMessage(message: string): FileTooLargeDetail | null {
-  const match = DETAIL_PATTERN.exec(message)
-  if (!match) {
-    return null
+  const marker = MARKER_PATTERN.exec(message)
+  if (marker) {
+    const size = /(?:^|\s)size=(\d+)/.exec(marker[1])
+    const limit = /(?:^|\s)limit=(\d+)/.exec(marker[1])
+    const scope = /(?:^|\s)scope=(local|ssh|runtime)/.exec(marker[1])
+    return {
+      ...(size ? { byteLength: Number(size[1]) } : {}),
+      ...(limit ? { limitBytes: Number(limit[1]) } : {}),
+      ...(scope ? { scope: scope[1] as EditorFileReadScope } : {})
+    }
   }
-  return {
-    byteLength: Number(match[1]),
-    limitBytes: Number(match[2]),
-    scope: match[3] as EditorFileReadScope
-  }
+  return PROTOCOL_TOKEN_PATTERN.test(message) ? {} : null
+}
+
+/**
+ * Strip the machine marker so a refusal can be shown verbatim. The relay's file
+ * reader is shared with the AI Vault scanner, whose issue rows render the raw
+ * message, so the marker would otherwise appear in the sidebar.
+ */
+export function stripFileTooLargeMarker(message: string): string {
+  return message.replace(APPENDED_MARKER_PATTERN, '').trimEnd()
 }

--- a/src/shared/runtime-file-contracts.ts
+++ b/src/shared/runtime-file-contracts.ts
@@ -28,6 +28,8 @@ export type RuntimeFileReadResult = {
   content: string
   truncated: boolean
   byteLength: number
+  /** Budget that produced `truncated`. Absent on hosts predating this field. */
+  maxByteLength?: number
 }
 
 export type RuntimeTerminalPathOpenTarget =

--- a/src/shared/runtime-file-contracts.ts
+++ b/src/shared/runtime-file-contracts.ts
@@ -30,6 +30,11 @@ export type RuntimeFileReadResult = {
   byteLength: number
   /** Budget that produced `truncated`. Absent on hosts predating this field. */
   maxByteLength?: number
+  /**
+   * Size the host stat'd. `byteLength` only measures the capped prefix it read,
+   * so it must never be shown as the file's size. Absent when unobserved.
+   */
+  totalByteLength?: number
 }
 
 export type RuntimeTerminalPathOpenTarget =


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1152 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1141 |
| Prod | 28 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​640 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​74 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​566 |

<!-- /orca-pr-loc -->

> **Draft — do not merge.** 4 adversarial loops, did not converge; 2 majors outstanding. Replaces draft #16437, whose approach was wrong. The `/ref-oss` grounding is the valuable part here and it **killed the previous plan outright**.

## What `/ref-oss` established

Reference: `orca-ref-oss/vscode`. **A reviewer independently re-opened every cited file** — nothing fabricated.

**1. A local/remote size gap is the shipped design, not a bug.**
`src/vs/platform/files/common/files.ts:1630-1656`, `getLargeFileConfirmationLimit()`:
- local → `1024 * ByteSize.MB`, commented *"Local almost has no limit in file size"*
- remote → `10 * ByteSize.MB`, commented *"With a remote, pick a low limit to avoid potentially costly file transfers"*
- web → `50 * ByteSize.MB`

That's a **100× local/remote gap** in VS Code. Orca's is 5×. **This kills draft #16437's approach** — it "fixed" the inconsistency by cutting the local cap 50 MB → 10 MB, which silently reverted merged PR #1367. Upstream deliberately keeps them different for exactly the reason Orca's SSH path has a lower cap: transfer cost.

What Orca is *actually* missing isn't a matching number — it's that VS Code has **one** definition, consumed at `resourceEditorInput.ts:200` and `editorConfiguration.ts:210`. Hence `src/shared/editor-file-read-limit.ts` here.

**2. Exceeding the limit is a recoverable, explanatory view — never a bare error.**
`textFileEditor.ts:195-205` catches `FILE_TOO_LARGE` and names the size via `ByteSize.formatSize()`; `editor.ts:1057-1080` (`createTooLargeFileError`) attaches an **"Open Anyway"** action that re-opens with a raised limit. That's the shape adopted here — matching the in-repo `LargeDiffFallback` precedent.

## Honesty about the originating report

@CORCJO's *"I tried to opening a 14 mb json file"* is **not** established as the cause of that crash, and this PR doesn't claim it. Three reasons, stated in the diff's own trade-offs:

- Their report is **mis-filed against a Chromium utility process** (the V8 Proxy Resolver — draft #16434).
- That renderer had been **silent for 13.5 minutes** before dying (draft #16436).
- **14 MB is *under* VS Code's own 20 MB / 300k-line threshold** — upstream would give that file a fully-featured editor too. Nothing in this PR would have changed its handling.

The justification is the inconsistency, the missing fallback, and a **reproduced binary-placeholder regression** — all defects on their own merits, none requiring the crash story.

## Why it is a draft

1. **Major:** the large-file override is pruned for every content id not currently in `openFiles`, so **"Open Anyway" is one-shot** from a conflict-review overview row.
2. **Major:** `describeLimitOwner('local')` unconditionally renders *"You can open it anyway, but the editor may become slow"* even when `EditorFileLoadErrorView.tsx:30` has already ruled that out.

## Perf

`/perf` caught a real defect **introduced by this change**: the override read ceiling exceeded the editor model's own heap-operation limit — **−512 MB peak RSS per overridden read** once fixed, and it had removed a hard throw on mount/save. Everything else measured as no meaningful impact.

## Recommendation

Close #16437 in favour of this branch regardless of what happens next — its cap-lowering approach is disproven by upstream's own comments. The two majors here are contained and worth finishing.
