### PR TITLE
fix(native-chat): stop the skill picker cap from erasing whole scopes

### DIFF
--- a/src/renderer/src/components/native-chat/native-chat-composer-state.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-composer-state.test.ts
@@ -326,18 +326,29 @@ describe('native skill and command picker', () => {
     expect(names).toContain('home-skill-2')
   })
 
-  it('keeps ranked order when a query narrows a catalog past the cap', () => {
-    const skills = Array.from({ length: 600 }, (_, index) =>
-      skill({
-        name: `deploy-${String(index).padStart(4, '0')}`,
-        sourceKind: 'repo',
-        skillFilePath: `/repo/.agents/skills/deploy-${index}/SKILL.md`
-      })
-    )
-    const names = buildNativeChatPickerItems([], skills, 'deploy-0001', '/').map(
-      (item) => item.name
-    )
-    expect(names[0]).toBe('deploy-0001')
+  it('keeps a queried catalog in rank order rather than spreading it across scopes', () => {
+    // 600 prefix matches (rank 1) in repo vs 10 substring matches (rank 2) in home:
+    // rank order fills the cap with repo rows, a scope budget would interleave home rows.
+    const skills = [
+      ...Array.from({ length: 600 }, (_, index) =>
+        skill({
+          name: `deploy-${String(index).padStart(4, '0')}`,
+          sourceKind: 'repo',
+          skillFilePath: `/repo/.agents/skills/deploy-${index}/SKILL.md`
+        })
+      ),
+      ...Array.from({ length: 10 }, (_, index) =>
+        skill({
+          name: `alpha-deploy-${index}`,
+          sourceKind: 'home',
+          skillFilePath: `/home/.claude/skills/alpha-deploy-${index}/SKILL.md`
+        })
+      )
+    ]
+    const names = buildNativeChatPickerItems([], skills, 'deploy', '/').map((item) => item.name)
+    expect(names).toHaveLength(500)
+    expect(names.every((name) => name.startsWith('deploy-'))).toBe(true)
+    expect(names).not.toContain('alpha-deploy-0')
   })
 
   it('keeps a long token-safe name intact for insertion instead of truncating it', () => {

--- a/src/renderer/src/components/native-chat/native-chat-composer-state.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-composer-state.test.ts
@@ -277,6 +277,69 @@ describe('native skill and command picker', () => {
     ])
   })
 
+  it('keeps lower-priority scopes visible when one scope fills the unfiltered list', () => {
+    const skills = [
+      ...Array.from({ length: 61 }, (_, index) =>
+        skill({
+          name: `repo-skill-${String(index).padStart(3, '0')}`,
+          sourceKind: 'repo',
+          skillFilePath: `/repo/.agents/skills/repo-${index}/SKILL.md`
+        })
+      ),
+      ...Array.from({ length: 11 }, (_, index) =>
+        skill({
+          name: `home-skill-${String(index).padStart(3, '0')}`,
+          sourceKind: 'home',
+          skillFilePath: `/home/.claude/skills/home-${index}/SKILL.md`
+        })
+      )
+    ]
+    const items = buildNativeChatPickerItems([], skills, '', '/')
+    const names = items.map((item) => item.name)
+    expect(names).toHaveLength(72)
+    expect(names).toContain('home-skill-000')
+    expect(names).toContain('home-skill-010')
+    expect(names).toContain('repo-skill-060')
+  })
+
+  it('budgets truncation across scopes so a huge scope cannot erase a smaller one', () => {
+    const skills = [
+      ...Array.from({ length: 800 }, (_, index) =>
+        skill({
+          name: `repo-skill-${String(index).padStart(4, '0')}`,
+          sourceKind: 'repo',
+          skillFilePath: `/repo/.agents/skills/repo-${index}/SKILL.md`
+        })
+      ),
+      ...Array.from({ length: 3 }, (_, index) =>
+        skill({
+          name: `home-skill-${index}`,
+          sourceKind: 'home',
+          skillFilePath: `/home/.claude/skills/home-${index}/SKILL.md`
+        })
+      )
+    ]
+    const names = buildNativeChatPickerItems([], skills, '', '/').map((item) => item.name)
+    expect(names).toHaveLength(500)
+    expect(names).toContain('home-skill-0')
+    expect(names).toContain('home-skill-1')
+    expect(names).toContain('home-skill-2')
+  })
+
+  it('keeps ranked order when a query narrows a catalog past the cap', () => {
+    const skills = Array.from({ length: 600 }, (_, index) =>
+      skill({
+        name: `deploy-${String(index).padStart(4, '0')}`,
+        sourceKind: 'repo',
+        skillFilePath: `/repo/.agents/skills/deploy-${index}/SKILL.md`
+      })
+    )
+    const names = buildNativeChatPickerItems([], skills, 'deploy-0001', '/').map(
+      (item) => item.name
+    )
+    expect(names[0]).toBe('deploy-0001')
+  })
+
   it('keeps a long token-safe name intact for insertion instead of truncating it', () => {
     const longName = `skill-${'x'.repeat(100)}`
     const items = buildNativeChatPickerItems(

--- a/src/renderer/src/components/native-chat/native-chat-composer-state.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-composer-state.test.ts
@@ -321,9 +321,9 @@ describe('native skill and command picker', () => {
     ]
     const names = buildNativeChatPickerItems([], skills, '', '/').map((item) => item.name)
     expect(names).toHaveLength(500)
-    expect(names).toContain('home-skill-0')
-    expect(names).toContain('home-skill-1')
-    expect(names).toContain('home-skill-2')
+    // Budgeted rows still land in scope order, so the home rows sort last.
+    expect(names.slice(-3)).toEqual(['home-skill-0', 'home-skill-1', 'home-skill-2'])
+    expect(names.slice(0, -3).every((name) => name.startsWith('repo-skill-'))).toBe(true)
   })
 
   it('keeps a queried catalog in rank order rather than spreading it across scopes', () => {

--- a/src/renderer/src/components/native-chat/native-chat-picker-items.ts
+++ b/src/renderer/src/components/native-chat/native-chat-picker-items.ts
@@ -99,7 +99,12 @@ function limitSkillsAcrossScopes(
   const byScope = new Map<SkillSourceKind, Extract<NativeChatPickerItem, { kind: 'skill' }>[]>()
   for (const item of skills) {
     const scope = item.sources[0].sourceKind
-    byScope.set(scope, [...(byScope.get(scope) ?? []), item])
+    const queue = byScope.get(scope)
+    if (queue) {
+      queue.push(item)
+    } else {
+      byScope.set(scope, [item])
+    }
   }
   const queues = [...byScope.values()]
   const picked: Extract<NativeChatPickerItem, { kind: 'skill' }>[] = []

--- a/src/renderer/src/components/native-chat/native-chat-picker-items.ts
+++ b/src/renderer/src/components/native-chat/native-chat-picker-items.ts
@@ -38,7 +38,9 @@ export type NativeChatSkillDiscoverySnapshot = {
 // Why: a safety valve against pathological catalogs, not a display policy. The
 // menu scrolls, so a low cap only hid skills — and because rows are scope-sorted,
 // one large scope silently erased every smaller one (#14690).
-const PICKER_RESULT_LIMIT = 500
+const SKILL_RESULT_LIMIT = 500
+/** Commands are a small curated catalog; keep their original bound. */
+const COMMAND_RESULT_LIMIT = 50
 const SCOPE_PRIORITY: Record<SkillSourceKind, number> = {
   repo: 0,
   home: 1,
@@ -77,12 +79,12 @@ export function buildNativeChatPickerItems(
     query
   )
   return [
-    ...commandItems.slice(0, PICKER_RESULT_LIMIT),
+    ...commandItems.slice(0, COMMAND_RESULT_LIMIT),
     // Ranked results are ordered by relevance, so a plain slice keeps the best
     // matches; the unfiltered list is scope-ordered and needs a fair budget.
     ...(query
-      ? skillItems.slice(0, PICKER_RESULT_LIMIT)
-      : limitSkillsAcrossScopes(skillItems, PICKER_RESULT_LIMIT))
+      ? skillItems.slice(0, SKILL_RESULT_LIMIT)
+      : limitSkillsAcrossScopes(skillItems, SKILL_RESULT_LIMIT))
   ]
 }
 

--- a/src/renderer/src/components/native-chat/native-chat-picker-items.ts
+++ b/src/renderer/src/components/native-chat/native-chat-picker-items.ts
@@ -35,7 +35,10 @@ export type NativeChatSkillDiscoverySnapshot = {
   errorKind?: 'unavailable' | 'timeout' | 'host' | 'unknown'
 }
 
-const PICKER_RESULT_LIMIT = 50
+// Why: a safety valve against pathological catalogs, not a display policy. The
+// menu scrolls, so a low cap only hid skills — and because rows are scope-sorted,
+// one large scope silently erased every smaller one (#14690).
+const PICKER_RESULT_LIMIT = 500
 const SCOPE_PRIORITY: Record<SkillSourceKind, number> = {
   repo: 0,
   home: 1,
@@ -75,8 +78,46 @@ export function buildNativeChatPickerItems(
   )
   return [
     ...commandItems.slice(0, PICKER_RESULT_LIMIT),
-    ...skillItems.slice(0, PICKER_RESULT_LIMIT)
+    // Ranked results are ordered by relevance, so a plain slice keeps the best
+    // matches; the unfiltered list is scope-ordered and needs a fair budget.
+    ...(query
+      ? skillItems.slice(0, PICKER_RESULT_LIMIT)
+      : limitSkillsAcrossScopes(skillItems, PICKER_RESULT_LIMIT))
   ]
+}
+
+/** Spread the cap across scopes so a large scope cannot evict smaller ones. */
+function limitSkillsAcrossScopes(
+  skills: Extract<NativeChatPickerItem, { kind: 'skill' }>[],
+  limit: number
+): Extract<NativeChatPickerItem, { kind: 'skill' }>[] {
+  if (skills.length <= limit) {
+    return skills
+  }
+  const byScope = new Map<SkillSourceKind, Extract<NativeChatPickerItem, { kind: 'skill' }>[]>()
+  for (const item of skills) {
+    const scope = item.sources[0].sourceKind
+    byScope.set(scope, [...(byScope.get(scope) ?? []), item])
+  }
+  const queues = [...byScope.values()]
+  const picked: Extract<NativeChatPickerItem, { kind: 'skill' }>[] = []
+  for (let depth = 0; picked.length < limit; depth += 1) {
+    let advanced = false
+    for (const queue of queues) {
+      if (picked.length >= limit) {
+        break
+      }
+      const next = queue[depth]
+      if (next) {
+        picked.push(next)
+        advanced = true
+      }
+    }
+    if (!advanced) {
+      break
+    }
+  }
+  return picked.sort(comparePickerSkills)
 }
 
 function mergeNativeChatSkills(


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​74 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​74 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​51 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​48 |

<!-- /orca-pr-loc -->

Fixes #14690 (STA-4402).

## Problem

The Chat UI slash picker sorts skills by scope (`repo` → `home` → `bundled` → `plugin`) and then took the first 50. When a user has more repo skills than the cap, **every** home, bundled, and plugin skill is evicted from the unfiltered `/` list — matching the report that skills present in the Terminal view are missing in Chat UI.

The menu is already `max-h-72 overflow-y-auto` with keyboard scrolling, so the cap was never a layout need. No test asserted it.

## Reproduced live

macOS Electron dev build at `61c7b51c8c`, isolated profile, real user path (enable Chat UI → Claude session → type `/`):

| | before | after |
|---|---|---|
| skills discovered | 121 (repo 61, home 11, plugin 43, bundled 6) | 121 |
| skill rows rendered | **50** — all `Project` | **63** |
| `/vercel-cli-with-tokens` (home) | absent | present |
| `/user-support-dashboard-discord` (home) | absent | present |

63 rendered rows is exactly the number of Claude-provider skills in the catalog; the remaining 49 are codex-only plugin skills correctly excluded from a Claude session. Querying `/vercel` surfaced the skill even before the fix, confirming truncation — not discovery — was the cause.

## Fix

Raise the limit to a safety valve against pathological catalogs rather than a display policy, and budget it across scopes when it binds so no scope can be erased. Ranked (queried) results keep a plain slice so relevance order stands.

## Tests

Three regression tests in `native-chat-composer-state.test.ts`. Two fail against the pre-fix code (`expected length 72, got 50` / `expected 500, got 50`); the third guards the ranked path from regressing.

## Perf

- 121-skill catalog (real): **0.292 ms/build**
- 2000-skill catalog: 4.416 ms/build, result still bounded at 500
- Live frame pacing with the picker open: 13–18 ms (vsync), no long frames

## Scope

Desktop renderer only — mobile has its own picker and does not import this module. No wire, SSH, or platform-conditional behavior touched.