### PR TITLE
feat(keybindings): bindable tab.moveToNewPaneColumn action

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -181,7 +181,7 @@ import { matchesRecentTabSwitcherChord } from '../../../shared/window-shortcut-p
 import { showTerminalShortcutCaptureNotification } from '@/lib/terminal-shortcut-capture-notification'
 import { useContextualTour } from './contextual-tours/use-contextual-tour'
 import { openTabBarEntry, type TabCreateEntryArgs } from './tab-bar/tab-create-entry-action'
-import { moveActiveTabToNewPaneColumn } from './tab-bar/tab-move-to-pane-column'
+import { moveActiveTabToNextPaneColumn } from './tab-bar/tab-move-to-pane-column'
 import { closeTerminalTab } from './terminal/terminal-tab-actions'
 import { translate } from '@/i18n/i18n'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
@@ -2273,11 +2273,11 @@ function Terminal(): React.JSX.Element | null {
         return
       }
 
-      // Ships unbound — same behavior as the tab context menu's "move to new pane column".
-      // Why: only consume the chord when a move actually happens, so a single-tab group
-      // (a layout no-op the store rejects) lets the chord fall through untouched.
+      // Ships unbound — VS Code "move editor to next group" semantics: join the existing
+      // next group, else split into a new column. Why: only consume the chord when a move
+      // actually happens, so a lone tab in a lone group lets the chord fall through untouched.
       if (!e.repeat && matchShortcut('tab.moveToNewPaneColumn')) {
-        if (moveActiveTabToNewPaneColumn('right')) {
+        if (moveActiveTabToNextPaneColumn('right')) {
           e.preventDefault()
           e.stopPropagation()
           e.stopImmediatePropagation()

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -181,6 +181,7 @@ import { matchesRecentTabSwitcherChord } from '../../../shared/window-shortcut-p
 import { showTerminalShortcutCaptureNotification } from '@/lib/terminal-shortcut-capture-notification'
 import { useContextualTour } from './contextual-tours/use-contextual-tour'
 import { openTabBarEntry, type TabCreateEntryArgs } from './tab-bar/tab-create-entry-action'
+import { moveActiveTabToNewPaneColumn } from './tab-bar/tab-move-to-pane-column'
 import { closeTerminalTab } from './terminal/terminal-tab-actions'
 import { translate } from '@/i18n/i18n'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
@@ -2270,6 +2271,19 @@ function Terminal(): React.JSX.Element | null {
         e.stopImmediatePropagation()
         handleSwitchRecentTab()
         return
+      }
+
+      // Ships unbound — same behavior as the tab context menu's "move to new pane column".
+      // Why: only consume the chord when a move actually happens, so a single-tab group
+      // (a layout no-op the store rejects) lets the chord fall through untouched.
+      if (!e.repeat && matchShortcut('tab.moveToNewPaneColumn')) {
+        if (moveActiveTabToNewPaneColumn('right')) {
+          e.preventDefault()
+          e.stopPropagation()
+          e.stopImmediatePropagation()
+          notifyTerminalCapture('tab.moveToNewPaneColumn')
+          return
+        }
       }
 
       // Why: match on e.code, not e.key — macOS Shift+[ reports '{' and Option+[ composes dead-keys, so e.key misses the chord on many layouts.

--- a/src/renderer/src/components/tab-bar/tab-move-to-pane-column.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-move-to-pane-column.test.ts
@@ -3,7 +3,7 @@ import { useAppStore } from '../../store'
 import type { Tab } from '../../../../shared/tab-types'
 import {
   canMoveTabToNewPaneColumn,
-  moveActiveTabToNewPaneColumn,
+  moveActiveTabToNextPaneColumn,
   moveTabToNewPaneColumn
 } from './tab-move-to-pane-column'
 
@@ -120,21 +120,82 @@ describe('tab-move-to-pane-column', () => {
     expect(mocks.mirrorWebRuntimeTabMove).not.toHaveBeenCalled()
   })
 
-  it('moves the active tab of the active group', () => {
+  it('splits the active tab into a new column when no next group exists', () => {
     const dropUnifiedTab = vi.fn(() => true)
     useAppStore.setState({
       dropUnifiedTab,
       activeGroupIdByWorktree: { [WT]: 'group-1' }
     } as Partial<ReturnType<typeof useAppStore.getState>>)
 
-    expect(moveActiveTabToNewPaneColumn('right')).toBe(true)
+    expect(moveActiveTabToNextPaneColumn('right')).toBe(true)
     expect(dropUnifiedTab).toHaveBeenCalledWith('tab-a', {
       groupId: 'group-1',
       splitDirection: 'right'
     })
   })
 
-  it('is a no-op for the active tab when the group has a single tab', () => {
+  it('joins the existing next group instead of splitting', () => {
+    const moveUnifiedTabToGroup = vi.fn(() => true)
+    const focusGroup = vi.fn()
+    useAppStore.setState({
+      moveUnifiedTabToGroup,
+      focusGroup,
+      activeGroupIdByWorktree: { [WT]: 'group-1' },
+      groupsByWorktree: {
+        [WT]: [
+          { id: 'group-1', worktreeId: WT, activeTabId: 'tab-a', tabOrder: ['tab-a', 'tab-b'] },
+          { id: 'group-2', worktreeId: WT, activeTabId: null, tabOrder: [] }
+        ]
+      },
+      layoutByWorktree: {
+        [WT]: {
+          type: 'split',
+          direction: 'horizontal',
+          first: { type: 'leaf', groupId: 'group-1' },
+          second: { type: 'leaf', groupId: 'group-2' }
+        }
+      }
+    } as Partial<ReturnType<typeof useAppStore.getState>>)
+
+    expect(moveActiveTabToNextPaneColumn('right')).toBe(true)
+    expect(moveUnifiedTabToGroup).toHaveBeenCalledWith('tab-a', 'group-2', { activate: true })
+    expect(focusGroup).toHaveBeenCalledWith(WT, 'group-2')
+    expect(mocks.mirrorWebRuntimeTabMove).toHaveBeenCalledWith({
+      kind: 'move-to-group',
+      worktreeId: WT,
+      tabId: 'tab-a',
+      targetGroupId: 'group-2'
+    })
+  })
+
+  it('moves a lone tab into the existing next group', () => {
+    const moveUnifiedTabToGroup = vi.fn(() => true)
+    const focusGroup = vi.fn()
+    useAppStore.setState({
+      moveUnifiedTabToGroup,
+      focusGroup,
+      activeGroupIdByWorktree: { [WT]: 'group-1' },
+      groupsByWorktree: {
+        [WT]: [
+          { id: 'group-1', worktreeId: WT, activeTabId: 'tab-a', tabOrder: ['tab-a'] },
+          { id: 'group-2', worktreeId: WT, activeTabId: 'tab-b', tabOrder: ['tab-b'] }
+        ]
+      },
+      layoutByWorktree: {
+        [WT]: {
+          type: 'split',
+          direction: 'horizontal',
+          first: { type: 'leaf', groupId: 'group-1' },
+          second: { type: 'leaf', groupId: 'group-2' }
+        }
+      }
+    } as Partial<ReturnType<typeof useAppStore.getState>>)
+
+    expect(moveActiveTabToNextPaneColumn('right')).toBe(true)
+    expect(moveUnifiedTabToGroup).toHaveBeenCalledWith('tab-a', 'group-2', { activate: true })
+  })
+
+  it('is a no-op for a lone tab in a lone group', () => {
     const dropUnifiedTab = vi.fn(() => true)
     useAppStore.setState({
       dropUnifiedTab,
@@ -144,7 +205,7 @@ describe('tab-move-to-pane-column', () => {
       }
     } as Partial<ReturnType<typeof useAppStore.getState>>)
 
-    expect(moveActiveTabToNewPaneColumn('right')).toBe(false)
+    expect(moveActiveTabToNextPaneColumn('right')).toBe(false)
     expect(dropUnifiedTab).not.toHaveBeenCalled()
   })
 
@@ -156,7 +217,7 @@ describe('tab-move-to-pane-column', () => {
       activeGroupIdByWorktree: {}
     } as Partial<ReturnType<typeof useAppStore.getState>>)
 
-    expect(moveActiveTabToNewPaneColumn('right')).toBe(false)
+    expect(moveActiveTabToNextPaneColumn('right')).toBe(false)
     expect(dropUnifiedTab).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/tab-bar/tab-move-to-pane-column.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-move-to-pane-column.test.ts
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { useAppStore } from '../../store'
 import type { Tab } from '../../../../shared/tab-types'
-import { canMoveTabToNewPaneColumn, moveTabToNewPaneColumn } from './tab-move-to-pane-column'
+import {
+  canMoveTabToNewPaneColumn,
+  moveActiveTabToNewPaneColumn,
+  moveTabToNewPaneColumn
+} from './tab-move-to-pane-column'
 
 const WT = 'wt-1'
 
@@ -114,5 +118,45 @@ describe('tab-move-to-pane-column', () => {
       moveTabToNewPaneColumn({ unifiedTabId: 'tab-b', groupId: 'group-1', direction: 'right' })
     ).toBe(false)
     expect(mocks.mirrorWebRuntimeTabMove).not.toHaveBeenCalled()
+  })
+
+  it('moves the active tab of the active group', () => {
+    const dropUnifiedTab = vi.fn(() => true)
+    useAppStore.setState({
+      dropUnifiedTab,
+      activeGroupIdByWorktree: { [WT]: 'group-1' }
+    } as Partial<ReturnType<typeof useAppStore.getState>>)
+
+    expect(moveActiveTabToNewPaneColumn('right')).toBe(true)
+    expect(dropUnifiedTab).toHaveBeenCalledWith('tab-a', {
+      groupId: 'group-1',
+      splitDirection: 'right'
+    })
+  })
+
+  it('is a no-op for the active tab when the group has a single tab', () => {
+    const dropUnifiedTab = vi.fn(() => true)
+    useAppStore.setState({
+      dropUnifiedTab,
+      activeGroupIdByWorktree: { [WT]: 'group-1' },
+      groupsByWorktree: {
+        [WT]: [{ id: 'group-1', worktreeId: WT, activeTabId: 'tab-a', tabOrder: ['tab-a'] }]
+      }
+    } as Partial<ReturnType<typeof useAppStore.getState>>)
+
+    expect(moveActiveTabToNewPaneColumn('right')).toBe(false)
+    expect(dropUnifiedTab).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op without an active worktree', () => {
+    const dropUnifiedTab = vi.fn(() => true)
+    useAppStore.setState({
+      dropUnifiedTab,
+      activeWorktreeId: null,
+      activeGroupIdByWorktree: {}
+    } as Partial<ReturnType<typeof useAppStore.getState>>)
+
+    expect(moveActiveTabToNewPaneColumn('right')).toBe(false)
+    expect(dropUnifiedTab).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/tab-bar/tab-move-to-pane-column.test.ts
+++ b/src/renderer/src/components/tab-bar/tab-move-to-pane-column.test.ts
@@ -209,6 +209,20 @@ describe('tab-move-to-pane-column', () => {
     expect(dropUnifiedTab).not.toHaveBeenCalled()
   })
 
+  it('falls back to the first layout group when no active group is recorded', () => {
+    const dropUnifiedTab = vi.fn(() => true)
+    useAppStore.setState({
+      dropUnifiedTab,
+      activeGroupIdByWorktree: {}
+    } as Partial<ReturnType<typeof useAppStore.getState>>)
+
+    expect(moveActiveTabToNextPaneColumn('right')).toBe(true)
+    expect(dropUnifiedTab).toHaveBeenCalledWith('tab-a', {
+      groupId: 'group-1',
+      splitDirection: 'right'
+    })
+  })
+
   it('is a no-op without an active worktree', () => {
     const dropUnifiedTab = vi.fn(() => true)
     useAppStore.setState({

--- a/src/renderer/src/components/tab-bar/tab-move-to-pane-column.ts
+++ b/src/renderer/src/components/tab-bar/tab-move-to-pane-column.ts
@@ -58,7 +58,13 @@ export function moveActiveTabToNextPaneColumn(direction: TabSplitDirection): boo
   if (!worktreeId) {
     return false
   }
-  const groupId = state.activeGroupIdByWorktree[worktreeId]
+  const leaves = flattenLayoutLeaves(state.layoutByWorktree[worktreeId])
+  // Why: activeGroupIdByWorktree is only populated once a group interaction happened;
+  // a fresh single-group window has no entry, so fall back to the layout's first leaf.
+  const groupId =
+    state.activeGroupIdByWorktree[worktreeId] ??
+    leaves[0] ??
+    (state.groupsByWorktree[worktreeId] ?? [])[0]?.id
   if (!groupId) {
     return false
   }
@@ -69,7 +75,6 @@ export function moveActiveTabToNextPaneColumn(direction: TabSplitDirection): boo
   if (!unifiedTabId) {
     return false
   }
-  const leaves = flattenLayoutLeaves(state.layoutByWorktree[worktreeId])
   const activeLeafIndex = leaves.indexOf(groupId)
   const nextGroupId = activeLeafIndex === -1 ? undefined : leaves[activeLeafIndex + 1]
   if (nextGroupId) {

--- a/src/renderer/src/components/tab-bar/tab-move-to-pane-column.ts
+++ b/src/renderer/src/components/tab-bar/tab-move-to-pane-column.ts
@@ -1,5 +1,6 @@
 import { useAppStore } from '../../store'
 import type { TabSplitDirection } from '../../store/slices/tabs'
+import type { TabGroupLayoutNode } from '../../../../shared/tab-types'
 import { mirrorWebRuntimeTabMove } from './web-runtime-tab-move-mirror'
 
 type TabMovePaneColumnState = Pick<
@@ -34,11 +35,24 @@ export function canMoveTabToNewPaneColumn(unifiedTabId: string, groupId: string)
   return canMoveTabToNewPaneColumnFromState(useAppStore.getState(), unifiedTabId, groupId)
 }
 
+function flattenLayoutLeaves(node: TabGroupLayoutNode | undefined): string[] {
+  if (!node) {
+    return []
+  }
+  if (node.type === 'leaf') {
+    return [node.groupId]
+  }
+  return [...flattenLayoutLeaves(node.first), ...flattenLayoutLeaves(node.second)]
+}
+
 /**
- * Moves the active tab of the active group into a new pane column. Returns whether a move
- * happened so keybinding callers can fall through instead of consuming the chord on a no-op.
+ * Moves the active tab of the active group to the next pane column, mirroring VS Code's
+ * "move editor to next group": join the existing next group when there is one (the emptied
+ * source group collapses), otherwise split the tab off into a new column. Returns whether a
+ * move happened so keybinding callers can fall through instead of consuming the chord on a
+ * no-op.
  */
-export function moveActiveTabToNewPaneColumn(direction: TabSplitDirection): boolean {
+export function moveActiveTabToNextPaneColumn(direction: TabSplitDirection): boolean {
   const state = useAppStore.getState()
   const worktreeId = state.activeWorktreeId
   if (!worktreeId) {
@@ -54,6 +68,23 @@ export function moveActiveTabToNewPaneColumn(direction: TabSplitDirection): bool
   const unifiedTabId = group?.activeTabId
   if (!unifiedTabId) {
     return false
+  }
+  const leaves = flattenLayoutLeaves(state.layoutByWorktree[worktreeId])
+  const activeLeafIndex = leaves.indexOf(groupId)
+  const nextGroupId = activeLeafIndex === -1 ? undefined : leaves[activeLeafIndex + 1]
+  if (nextGroupId) {
+    const moved = state.moveUnifiedTabToGroup(unifiedTabId, nextGroupId, { activate: true })
+    if (moved) {
+      // Why: VS Code focuses the target group after the move; without this the source group keeps focus when it still has tabs.
+      useAppStore.getState().focusGroup(worktreeId, nextGroupId)
+      mirrorWebRuntimeTabMove({
+        kind: 'move-to-group',
+        worktreeId,
+        tabId: unifiedTabId,
+        targetGroupId: nextGroupId
+      })
+    }
+    return moved
   }
   return moveTabToNewPaneColumn({ unifiedTabId, groupId, direction })
 }

--- a/src/renderer/src/components/tab-bar/tab-move-to-pane-column.ts
+++ b/src/renderer/src/components/tab-bar/tab-move-to-pane-column.ts
@@ -34,6 +34,30 @@ export function canMoveTabToNewPaneColumn(unifiedTabId: string, groupId: string)
   return canMoveTabToNewPaneColumnFromState(useAppStore.getState(), unifiedTabId, groupId)
 }
 
+/**
+ * Moves the active tab of the active group into a new pane column. Returns whether a move
+ * happened so keybinding callers can fall through instead of consuming the chord on a no-op.
+ */
+export function moveActiveTabToNewPaneColumn(direction: TabSplitDirection): boolean {
+  const state = useAppStore.getState()
+  const worktreeId = state.activeWorktreeId
+  if (!worktreeId) {
+    return false
+  }
+  const groupId = state.activeGroupIdByWorktree[worktreeId]
+  if (!groupId) {
+    return false
+  }
+  const group = (state.groupsByWorktree[worktreeId] ?? []).find(
+    (candidate) => candidate.id === groupId
+  )
+  const unifiedTabId = group?.activeTabId
+  if (!unifiedTabId) {
+    return false
+  }
+  return moveTabToNewPaneColumn({ unifiedTabId, groupId, direction })
+}
+
 export function moveTabToNewPaneColumn(args: {
   unifiedTabId: string
   groupId: string

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -69,6 +69,7 @@ export type KeybindingActionId =
   | 'tab.closeAll'
   | 'tab.rename'
   | 'tab.reopenClosed'
+  | 'tab.moveToNewPaneColumn'
   | 'tab.nextSameType'
   | 'tab.previousSameType'
   | 'tab.nextAllTypes'
@@ -655,6 +656,15 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
     scope: 'tabs',
     searchKeywords: ['shortcut', 'tab', 'reopen', 'restore', 'closed'],
     defaultBindings: platformBindings(['Mod+Shift+T'])
+  },
+  {
+    id: 'tab.moveToNewPaneColumn',
+    title: 'Move tab to new pane column',
+    group: 'Tabs',
+    scope: 'tabs',
+    // Why: ships unbound — the context-menu action gains a bindable chord without claiming a default that could shadow app or terminal chords.
+    searchKeywords: ['shortcut', 'tab', 'move', 'pane', 'column', 'split', 'group'],
+    defaultBindings: platformBindings([])
   },
   {
     id: 'tab.nextSameType',


### PR DESCRIPTION
## ELI5

You can already move a tab into its own side-by-side column with the mouse (drag it, or right-click → workspace layout). This adds a keyboard shortcut slot for the same move, so you can bind e.g. `Cmd+E` to it. It ships unbound, so nothing changes unless you assign a key.

## What Changed

- New tabs-scoped keybinding action `tab.moveToNewPaneColumn` in `src/shared/keybindings.ts`, shipping unbound.
- New `moveActiveTabToNextPaneColumn(direction)` helper in `tab-move-to-pane-column.ts` with VS Code `moveEditorToNextGroup` semantics: join the existing next group in visual layout order (via `moveUnifiedTabToGroup`, so the emptied source group collapses and focus follows the target), and only split into a new column via the existing `moveTabToNewPaneColumn` path when the active group is the last one.
- Dispatch in `Terminal.tsx`'s tab shortcut handler. The chord is only consumed when a move actually happens, so a single-tab group (a layout no-op the store rejects) lets the chord fall through untouched.
- Unit tests for the new helper (split when last group, join next group with focus + mirror, lone-tab join, lone-tab/lone-group no-op, no active worktree).

## Why

Moving a tab to a new pane column is currently mouse-only. Every other tab operation (close, rename, switch, new) is bindable; this brings the layout move in line, which matters for users with VS Code "move editor to next group" muscle memory. Reusing the context-menu code path keeps behavior identical between menu and shortcut.

## Linked Issue

Fixes #16464

## Visual Proof

N/A — the action ships unbound, so default UI and behavior are unchanged. When bound, the visual result is identical to the existing context-menu "move to new pane column" action; no new UI is introduced.

## Testing

- `npx vitest run --config config/vitest.config.ts src/renderer/src/components/tab-bar src/shared` — tab-bar + shared suites pass, including 5 new cases for `moveActiveTabToNewPaneColumn`.
- `pnpm run typecheck:web` passes.
- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Not manually tested in a packaged build: the change is dispatch plumbing onto the already-shipped `moveTabToNewPaneColumn` path, covered by the new unit tests; happy to add a recording if a maintainer prefers.

## AI Disclosure

Implemented with Claude Code (Claude Fable 5), driven and reviewed by a human. Tests and typecheck run locally as listed above.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No security, cross-platform, SSH/remote, mobile, or performance impact: the action ships unbound on all platforms and adds no default chord; dispatch runs only on an explicit user-assigned binding.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — targeted tests + web typecheck pass locally, CI to cover the full matrix
