### PR TITLE
fix(chat): keep transcript selections alive through pane pointerdown

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -3137,7 +3137,14 @@ function TerminalPane(
       />
       {effectiveChatViewMode && chatPane?.container
         ? createPortal(
-            <div className="absolute inset-0 z-10 flex min-h-0 min-w-0 bg-background">
+            <div
+              className="absolute inset-0 z-10 flex min-h-0 min-w-0 bg-background"
+              // Why: chat is portaled into the pane container, so the pane's own
+              // pointerdown would focus the hidden xterm helper textarea and wipe
+              // any transcript text selection before the browser can extend it
+              // (shift-click / shift-drag). The pane still becomes active.
+              data-pane-prevent-terminal-focus=""
+            >
               <NativeChatView
                 terminalTabId={tabId}
                 isVisible={isRendererVisible}

--- a/src/renderer/src/lib/pane-manager/pane-pointer-focus.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-pointer-focus.test.ts
@@ -39,6 +39,9 @@ describe('shouldFocusTerminalFromPanePointerDown', () => {
 })
 
 describe('shouldFocusTerminalFromPanePointerDown against real pane DOM', () => {
+  /** The real pane DOM shape: an xterm instance with its hidden helper textarea,
+   *  plus a sibling overlay portaled in beside it. `overlayAttributes` is where
+   *  the `data-pane-prevent-terminal-focus` opt-out is applied or omitted. */
   function paneContainer(overlayAttributes: string): HTMLElement {
     const container = document.createElement('div')
     container.innerHTML = `

--- a/src/renderer/src/lib/pane-manager/pane-pointer-focus.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-pointer-focus.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment happy-dom
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { shouldFocusTerminalFromPanePointerDown } from './pane-pointer-focus'
 
@@ -33,5 +35,40 @@ describe('shouldFocusTerminalFromPanePointerDown', () => {
     const target = new FakeElement(control)
 
     expect(shouldFocusTerminalFromPanePointerDown(target as unknown as Element)).toBe(false)
+  })
+})
+
+describe('shouldFocusTerminalFromPanePointerDown against real pane DOM', () => {
+  function paneContainer(overlayAttributes: string): HTMLElement {
+    const container = document.createElement('div')
+    container.innerHTML = `
+      <div class="xterm"><textarea class="xterm-helper-textarea"></textarea></div>
+      <div class="chat-overlay"${overlayAttributes}><p id="turn">Assistant turn text</p></div>
+    `
+    return container
+  }
+
+  it('leaves the terminal unfocused for text inside a pane-local overlay', () => {
+    // Why: the native chat transcript is portaled into the pane container. Without
+    // the opt-out the pane's pointerdown focuses the xterm helper textarea, which
+    // drops the document selection and kills shift-click range extension.
+    const container = paneContainer(' data-pane-prevent-terminal-focus=""')
+    const turn = container.querySelector('#turn')
+
+    expect(shouldFocusTerminalFromPanePointerDown(turn)).toBe(false)
+  })
+
+  it('still focuses the terminal for plain pane surface text', () => {
+    const container = paneContainer('')
+    const turn = container.querySelector('#turn')
+
+    expect(shouldFocusTerminalFromPanePointerDown(turn)).toBe(true)
+  })
+
+  it('still focuses the terminal from the xterm helper textarea itself', () => {
+    const container = paneContainer('')
+    const helper = container.querySelector('.xterm-helper-textarea')
+
+    expect(shouldFocusTerminalFromPanePointerDown(helper)).toBe(true)
   })
 })

--- a/tests/e2e/native-chat-transcript-shift-selection.spec.ts
+++ b/tests/e2e/native-chat-transcript-shift-selection.spec.ts
@@ -1,0 +1,150 @@
+import { randomUUID } from 'node:crypto'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import type { Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { waitForActivePaneHookDescriptor, waitForActiveTerminalManager } from './helpers/terminal'
+import type { GlobalSettings } from '../../src/shared/global-settings-types'
+
+const FIRST = 'Alpha alpha alpha alpha alpha alpha alpha alpha alpha alpha alpha.'
+const MIDDLE = 'Bravo bravo bravo bravo bravo bravo bravo bravo bravo bravo bravo.'
+const LAST = 'Charlie charlie charlie charlie charlie charlie charlie charlie.'
+
+async function enableNativeChatSetting(page: Page): Promise<void> {
+  await page.evaluate(async () => {
+    const nextSettings = await window.api.settings.set({ experimentalNativeChat: true })
+    window.__store?.setState({ settings: nextSettings as GlobalSettings })
+  })
+}
+
+async function seedIdleStatus(
+  page: Page,
+  args: { paneKey: string; worktreeId: string; sessionId: string; transcriptPath: string }
+): Promise<void> {
+  await page.evaluate(({ paneKey, worktreeId, sessionId, transcriptPath }) => {
+    window.__store
+      ?.getState()
+      .setAgentStatus(
+        paneKey,
+        { state: 'idle', prompt: 'shift selection repro', agentType: 'claude' },
+        'Claude',
+        undefined,
+        { worktreeId },
+        { providerSession: { key: 'session_id', id: sessionId, transcriptPath } }
+      )
+  }, args)
+}
+
+async function toggleTerminalTabToChatView(
+  page: Page,
+  args: { tabId: string; worktreeId: string }
+): Promise<void> {
+  await page.evaluate(({ tabId, worktreeId }) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('Store unavailable')
+    }
+    const state = store.getState()
+    const unifiedTab = (state.unifiedTabsByWorktree[worktreeId] ?? []).find(
+      (tab) => tab.contentType === 'terminal' && tab.entityId === tabId
+    )
+    if (!unifiedTab) {
+      throw new Error('Unified terminal tab not found for chat toggle')
+    }
+    state.toggleTabViewMode(unifiedTab.id)
+  }, args)
+}
+
+function transcript(sessionId: string): string {
+  const base = new Date()
+  const lines = [
+    {
+      sessionId,
+      uuid: `${sessionId}-user`,
+      timestamp: base.toISOString(),
+      type: 'user',
+      message: { role: 'user', content: [{ type: 'text', text: 'Say three things' }] }
+    },
+    ...[FIRST, MIDDLE, LAST].map((text, index) => ({
+      sessionId,
+      uuid: `${sessionId}-assistant-${index}`,
+      timestamp: new Date(base.getTime() + (index + 1) * 2_000).toISOString(),
+      type: 'assistant',
+      message: { model: 'claude-opus-4', content: [{ type: 'text', text }] }
+    }))
+  ]
+  return `${lines.map((line) => JSON.stringify(line)).join('\n')}\n`
+}
+
+test.describe('Native chat shift-click selection extension', () => {
+  test('shift+click extends an existing transcript selection', async ({ orcaPage }) => {
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+
+    const descriptor = await waitForActivePaneHookDescriptor(orcaPage)
+    const [tabId] = descriptor.paneKey.split(':')
+    const sessionId = `e2e-shift-selection-${randomUUID()}`
+    const scratchDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-shift-selection-'))
+    const transcriptPath = path.join(scratchDir, `${sessionId}.jsonl`)
+
+    try {
+      writeFileSync(transcriptPath, transcript(sessionId))
+      await enableNativeChatSetting(orcaPage)
+      await seedIdleStatus(orcaPage, {
+        paneKey: descriptor.paneKey,
+        worktreeId: descriptor.worktreeId,
+        sessionId,
+        transcriptPath
+      })
+      await toggleTerminalTabToChatView(orcaPage, { tabId, worktreeId: descriptor.worktreeId })
+
+      await expect(orcaPage.locator('[data-native-chat-root="true"]')).toBeVisible({
+        timeout: 15_000
+      })
+      const first = orcaPage.getByText(FIRST)
+      const last = orcaPage.getByText(LAST)
+      await expect(first).toBeVisible({ timeout: 30_000 })
+      await expect(last).toBeVisible({ timeout: 30_000 })
+
+      const firstBox = await first.boundingBox()
+      const lastBox = await last.boundingBox()
+      if (!firstBox || !lastBox) {
+        throw new Error('Transcript rows have no layout box')
+      }
+
+      // 1. Drag-select part of the first assistant turn.
+      await orcaPage.mouse.move(firstBox.x + 4, firstBox.y + firstBox.height / 2)
+      await orcaPage.mouse.down()
+      await orcaPage.mouse.move(firstBox.x + 120, firstBox.y + firstBox.height / 2, { steps: 10 })
+      await orcaPage.mouse.up()
+      const afterDrag = await orcaPage.evaluate(() => window.getSelection()?.toString() ?? '')
+      const activeAfterDrag = await orcaPage.evaluate(
+        () => document.activeElement?.tagName ?? 'none'
+      )
+
+      // 2. Shift+click below it — the selection should grow to cover the middle turn.
+      await orcaPage.keyboard.down('Shift')
+      await orcaPage.mouse.move(lastBox.x + 120, lastBox.y + lastBox.height / 2)
+      await orcaPage.mouse.down()
+      await orcaPage.mouse.up()
+      await orcaPage.keyboard.up('Shift')
+      const afterShift = await orcaPage.evaluate(() => window.getSelection()?.toString() ?? '')
+      const activeAfterShift = await orcaPage.evaluate(
+        () => document.activeElement?.tagName ?? 'none'
+      )
+
+      console.log(
+        JSON.stringify({ afterDrag, activeAfterDrag, afterShift, activeAfterShift }, null, 2)
+      )
+
+      expect(afterDrag.length).toBeGreaterThan(0)
+      expect(afterShift).toContain('Bravo')
+    } finally {
+      rmSync(scratchDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/tests/e2e/native-chat-transcript-shift-selection.spec.ts
+++ b/tests/e2e/native-chat-transcript-shift-selection.spec.ts
@@ -12,6 +12,8 @@ const FIRST = 'Alpha alpha alpha alpha alpha alpha alpha alpha alpha alpha alpha
 const MIDDLE = 'Bravo bravo bravo bravo bravo bravo bravo bravo bravo bravo bravo.'
 const LAST = 'Charlie charlie charlie charlie charlie charlie charlie charlie.'
 
+/** Turns on the experimental native chat view and mirrors the new settings into
+ *  the renderer store, so the pane can be toggled to chat without a restart. */
 async function enableNativeChatSetting(page: Page): Promise<void> {
   await page.evaluate(async () => {
     const nextSettings = await window.api.settings.set({ experimentalNativeChat: true })
@@ -19,6 +21,10 @@ async function enableNativeChatSetting(page: Page): Promise<void> {
   })
 }
 
+/** Points the pane at a finished agent session backed by `transcriptPath`. The
+ *  status is `idle` on purpose: a settled transcript keeps the selection test
+ *  free of streaming re-renders, so a lost selection can only come from pointer
+ *  handling. */
 async function seedIdleStatus(
   page: Page,
   args: { paneKey: string; worktreeId: string; sessionId: string; transcriptPath: string }
@@ -37,6 +43,8 @@ async function seedIdleStatus(
   }, args)
 }
 
+/** Flips the unified terminal tab into chat view, which is what portals the
+ *  native chat overlay into the terminal pane container. */
 async function toggleTerminalTabToChatView(
   page: Page,
   args: { tabId: string; worktreeId: string }
@@ -57,6 +65,10 @@ async function toggleTerminalTabToChatView(
   }, args)
 }
 
+/** A settled transcript whose three assistant turns are visually distinct
+ *  (FIRST / MIDDLE / LAST). The middle turn is the assertion target: it can only
+ *  appear in the selection if shift-click extended across it rather than
+ *  starting a new selection. */
 function transcript(sessionId: string): string {
   const base = new Date()
   const lines = [


### PR DESCRIPTION
## ELI5

When you select text in the chat and then Shift+click to grab more of it, the selection vanished instead of growing. That is because the chat panel lives inside a terminal pane, and clicking anywhere in the pane hands keyboard focus to the terminal's hidden input box. Handing focus away throws the selection out before the browser gets a chance to extend it. This tells the pane "this click landed on chat, don't touch the terminal's focus," so the selection survives and Shift+click extends it like anywhere else.

## What Changed

`src/renderer/src/components/terminal-pane/TerminalPane.tsx` — the native chat overlay that is portaled into the pane container now carries `data-pane-prevent-terminal-focus`, the existing opt-out honored by `shouldFocusTerminalFromPanePointerDown`.

That is the whole behavior change. The pane still becomes active on the click; only the `pane.terminal.focus()` call is skipped.

Tests:
- `tests/e2e/native-chat-transcript-shift-selection.spec.ts` — new Electron e2e that seeds a three-turn transcript, drag-selects the first turn, Shift+clicks the last one, and asserts the selection actually spans the middle turn.
- `src/renderer/src/lib/pane-manager/pane-pointer-focus.test.ts` — adds real-DOM cases for the predicate (the existing cases stub `Element`, so they never exercise the selector itself).

## Why

The chat view is portaled into the terminal pane container, so the pane's own `pointerdown` listener fires for clicks on chat prose:

```
panePointerDownHandler   src/renderer/src/lib/pane-manager/pane-dom-creation.ts:104
  -> PaneManager.setActivePane
    -> pane.terminal.focus()
      -> textarea.xterm-helper-textarea.focus()
```

Moving focus into the hidden xterm helper textarea drops the document selection before Chromium's `mousedown` selection logic runs, so the Shift+click has no anchor to extend from and collapses. Focus returns to the chat root immediately afterwards, which is why `document.activeElement` looks unchanged across the click and the cause is invisible from the chat components alone.

Instrumented event log from the failing shift-click (Electron e2e):

```
pointerdown:capture  target=P(chat prose)        active=DIV(chat root)
focusin:capture      -> TEXTAREA.xterm-helper-textarea
mousedown:capture                                active=TEXTAREA.xterm-helper-textarea
focusin:capture      -> DIV(chat root)
selectionchange      selection length 0
```

`shouldFocusTerminalFromPanePointerDown` already exists for exactly this class of bug — its comment names pane-local controls portaled into the pane container — and it already exposes `[data-pane-prevent-terminal-focus]` for surfaces that are not focusable controls. Chat transcript prose is plain `<p>` text, so it fell through. Using the existing opt-out keeps the fix to one attribute instead of widening the shared selector or adding chat-specific branching to the pane manager.

Rejected alternatives:
- Skipping the pane focus only when `event.shiftKey` is set: verified by A/B run — does **not** fix it, because the focus steal that matters happens on the same `pointerdown` regardless of the modifier. It would also leave shift+drag and any other selection gesture broken.
- Guarding inside `NativeChatView`'s `onPointerDownCapture`: that handler runs after the pane listener has already stolen focus, and stopping propagation there would suppress pane activation too.

## Linked Issue

Fixes #16467

## Visual Proof

Both captured from the same Electron e2e run, at the same moment: immediately after Shift+clicking the last transcript turn, having first drag-selected part of the first turn.

**Before** — the selection is gone; nothing is highlighted.

<img width="3840" height="2100" alt="before-shift-click" src="https://github.com/user-attachments/assets/1099e020-666f-40f9-b4ed-f3e3db868758" />

**After** — the selection spans all three turns.

<img width="3840" height="2100" alt="after-shift-click" src="https://github.com/user-attachments/assets/ab153daf-4b7a-4061-9c85-27a57acdcc68" />

The same difference as selection state:

```json
// before
{ "afterDrag": "Alpha alpha alpha ", "afterShift": "" }

// after
{ "afterDrag": "Alpha alpha alpha ",
  "afterShift": "Alpha alpha alpha alpha alpha alpha alpha alpha alpha alpha alpha.\n\n\n\nBravo bravo bravo bravo bravo bravo bravo bravo bravo bravo bravo.\n\n\n\nCharlie charlie cha" }
```

## Testing

Reproduced first, then fixed — the new e2e fails on `main` (`afterShift` is `""`) and passes with the attribute in place.

```
pnpm exec playwright test tests/e2e/native-chat-transcript-shift-selection.spec.ts \
  --config tests/playwright.config.ts --project=electron-headless --workers=1
```

- Before the fix: `1 failed` — `Expected substring: "Bravo" / Received string: ""`
- After the fix: `1 passed (31.5s)`

Also ran: `pnpm lint`, `pnpm typecheck`, `pnpm build`, and `vitest run src/renderer/src/lib/pane-manager/pane-pointer-focus.test.ts` (6 passed).

I also ran `tests/e2e/native-chat-ask-user-question-card.spec.ts`. It fails, but it fails identically on a clean `main` checkout (`element(s) not found`), so it is pre-existing and not caused by this change.

Platforms actually tested: macOS 26.5.2 (arm64), Electron headless e2e. Not tested on Linux/Windows/SSH — see the review notes for why the change is platform-neutral.

- [x] I manually tested these changes locally — to be precise: verified by driving a real local Electron build through the e2e harness (real trusted input events) and reading back both the live selection state and full-window screenshots. I did not additionally hand-drive a desktop session.
- [x] Automated tests added/updated, or explained why not below

## Author

X: [@menten4932](https://x.com/menten4932)

## AI Disclosure

Investigated and written with Claude Code (Claude Opus 5). The root cause was located by instrumenting `HTMLElement.prototype.focus` in an Electron e2e run to capture the stack trace of the focus steal; the fix, the e2e spec, and the unit cases were then written and verified by running them.

## Review

- **Cross-platform (macOS / Linux / Windows):** the change is a DOM attribute consumed by renderer-side pointer routing. No platform branches, no path handling, no keyboard accelerators. `shouldFocusTerminalFromPanePointerDown` has no platform-specific behavior, and the failure was reproduced in the platform-neutral Electron harness.
- **Remote / SSH / local:** pane focus routing is renderer-local and identical for local, remote, and SSH-backed sessions. Nothing here touches transports, PTYs, or IPC.
- **Mobile:** untouched; this is desktop pane-manager wiring only.
- **Agent / integration / git-provider neutrality:** no agent-, integration-, or provider-specific logic. The chat overlay is the same for every agent.
- **Performance:** one static attribute in JSX. The pane pointerdown path already calls `target.closest(APP_CONTROL_SELECTOR)`; this adds no new work per event.
- **Backwards compatibility:** clicking chat still activates the pane (`setActivePane` runs with `focusTerminal: false`), and the chat root still takes focus through `NativeChatView`'s own `onPointerDownCapture`, so typing redirection into the composer is unchanged. The only behavior removed is the transient focus bounce through the hidden xterm textarea.
- **Security:** no new input handling, no new IPC surface, no data leaving the renderer. Reduces focus movement into a hidden textarea rather than adding any.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The regression this guards against is subtle: any future surface portaled into the pane container that renders selectable, non-focusable content will hit the same focus steal. The e2e is the meaningful guard — the added unit cases pin the selector semantics but would not catch removal of the attribute from `TerminalPane.tsx` on their own.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots attached for the interaction change
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
