### PR TITLE
fix(editor): preserve untouched markdown bytes when saving from the rich editor (#16469)

### DIFF
--- a/src/renderer/src/components/editor/rich-markdown-line-merge.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-line-merge.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { mergeMarkdownSourceByLines } from './rich-markdown-line-merge'
+
+describe('mergeMarkdownSourceByLines', () => {
+  it('keeps untouched original bytes and applies the user edit', () => {
+    // base = canonical(original); the user appended to the last line only.
+    const original = 'a > b\n_c_\nkeep&this\nlast\n'
+    const base = 'a &gt; b\n*c*\nkeep&amp;this\nlast\n'
+    const edited = 'a &gt; b\n*c*\nkeep&amp;this\nlast EDITED\n'
+    expect(mergeMarkdownSourceByLines(original, base, edited)).toBe(
+      'a > b\n_c_\nkeep&this\nlast EDITED\n'
+    )
+  })
+
+  it('returns the original verbatim when the user made no edit', () => {
+    const original = 'a > b\n_c_\n'
+    const base = 'a &gt; b\n*c*\n'
+    expect(mergeMarkdownSourceByLines(original, base, base)).toBe(original)
+  })
+
+  it('applies a pure insertion without recanonicalizing surrounding lines', () => {
+    const original = 'x > y\nz\n'
+    const base = 'x &gt; y\nz\n'
+    const edited = 'x &gt; y\nNEW LINE\nz\n'
+    expect(mergeMarkdownSourceByLines(original, base, edited)).toBe('x > y\nNEW LINE\nz\n')
+  })
+
+  it('applies a deletion while preserving non-adjacent non-canonical lines', () => {
+    const original = 'top > line\nanchor\nmid&mid\nanchor2\nz_end\n'
+    const base = 'top &gt; line\nanchor\nmid&amp;mid\nanchor2\nz_end\n'
+    const edited = 'top &gt; line\nanchor\nanchor2\nz_end\n'
+    expect(mergeMarkdownSourceByLines(original, base, edited)).toBe(
+      'top > line\nanchor\nanchor2\nz_end\n'
+    )
+  })
+
+  it('bails to null when both sides collapse to a whole-document rewrite', () => {
+    // Single line that differs on every side: no stable anchor to preserve.
+    expect(mergeMarkdownSourceByLines('_a_', '*a*', '*a* b')).toBeNull()
+  })
+
+  it('matches a brute-force oracle across randomized edits (fuzz)', () => {
+    let seed = 987654321
+    const rand = (): number => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff
+      return seed / 0x7fffffff
+    }
+    for (let trial = 0; trial < 500; trial += 1) {
+      const n = 4 + Math.floor(rand() * 8)
+      const baseLines = Array.from({ length: n }, (_, i) => `L${i}`)
+      // Edit a contiguous window whose adjacent anchor lines stay base-identical so
+      // ours (style-only) and theirs (edit) regions never abut-merge into a conflict.
+      const lo = 1 + Math.floor(rand() * (n - 2))
+      const hi = lo + Math.floor(rand() * (n - lo - 1))
+      const oursLines = baseLines.map((l, i) =>
+        i === lo - 1 || i === hi ? l : rand() < 0.6 ? `${l}~` : l
+      )
+      const replacement =
+        rand() < 0.5
+          ? []
+          : Array.from({ length: 1 + Math.floor(rand() * 2) }, (_, k) => `E${lo}_${k}`)
+      const theirsLines = [...baseLines.slice(0, lo), ...replacement, ...baseLines.slice(hi)]
+      const oracle = [...oursLines.slice(0, lo), ...replacement, ...oursLines.slice(hi)]
+
+      const join = (lines: string[]): string => lines.map((l) => `${l}\n`).join('')
+      const merged = mergeMarkdownSourceByLines(join(oursLines), join(baseLines), join(theirsLines))
+      expect({ trial, merged }).toEqual({ trial, merged: join(oracle) })
+    }
+  })
+})

--- a/src/renderer/src/components/editor/rich-markdown-line-merge.ts
+++ b/src/renderer/src/components/editor/rich-markdown-line-merge.ts
@@ -1,0 +1,190 @@
+import { DIFF_DELETE, DIFF_EQUAL, DIFF_INSERT, makeDiff } from '@sanity/diff-match-patch'
+
+// Three-way line merge used as the lossless fallback for markdown save reconciliation.
+// base = canonical serialization of the on-disk bytes; ours = the on-disk bytes;
+// theirs = canonical serialization after the user's edit. Regions the user did NOT
+// touch (base == theirs) emit `ours` verbatim, so untouched content keeps its exact
+// original bytes; regions the user DID touch emit `theirs` (canonical). No TipTap
+// re-parse, so cost scales with the line diff rather than O(n^2) document size.
+
+// Why: line diffs run only on the save/debounce fallback path, never per keystroke;
+// a 1s ceiling keeps a pathological input from stalling without truncating normal edits.
+const LINE_DIFF_TIMEOUT_SECONDS = 1
+
+type LineRegion = { baseLo: number; baseHi: number; sideLo: number; sideHi: number }
+
+/** Splits into lines that each retain their trailing "\n", so a plain join is lossless. */
+function splitLinesKeepingEol(text: string): string[] {
+  if (text === '') {
+    return []
+  }
+  return text.match(/[^\n]*\n|[^\n]+$/g) ?? []
+}
+
+/** Encodes each distinct line as one code point so a char diff behaves as a line diff. */
+function encodeLines(base: string[], side: string[]): { encodedBase: string; encodedSide: string } {
+  const lineToChar = new Map<string, string>()
+  const encode = (lines: string[]): string =>
+    lines
+      .map((line) => {
+        let char = lineToChar.get(line)
+        if (char === undefined) {
+          char = String.fromCodePoint(lineToChar.size)
+          lineToChar.set(line, char)
+        }
+        return char
+      })
+      .join('')
+  return { encodedBase: encode(base), encodedSide: encode(side) }
+}
+
+/**
+ * Regions where `base` and `side` differ, in base coordinates plus the aligned side
+ * range, and `baseToSide[i]` mapping every base index to its aligned side index (exact
+ * at equal boundaries — which is where merge regions begin and end).
+ */
+function diffLineRegions(
+  base: string[],
+  side: string[]
+): { regions: LineRegion[]; baseToSide: number[] } {
+  const { encodedBase, encodedSide } = encodeLines(base, side)
+  const diffs = makeDiff(encodedBase, encodedSide, { timeout: LINE_DIFF_TIMEOUT_SECONDS })
+
+  const regions: LineRegion[] = []
+  const baseToSide: number[] = Array.from({ length: base.length + 1 }, () => 0)
+  let baseIdx = 0
+  let sideIdx = 0
+  let pending: LineRegion | null = null
+  const flush = (): void => {
+    if (pending) {
+      regions.push(pending)
+      pending = null
+    }
+  }
+  for (const [op, chunk] of diffs) {
+    const count = chunk.length
+    if (op === DIFF_EQUAL) {
+      flush()
+      for (let i = 0; i < count; i += 1) {
+        baseToSide[baseIdx] = sideIdx
+        baseIdx += 1
+        sideIdx += 1
+      }
+    } else if (op === DIFF_DELETE) {
+      pending ??= { baseLo: baseIdx, baseHi: baseIdx, sideLo: sideIdx, sideHi: sideIdx }
+      for (let i = 0; i < count; i += 1) {
+        baseToSide[baseIdx] = sideIdx
+        baseIdx += 1
+      }
+      pending.baseHi = baseIdx
+      pending.sideHi = sideIdx
+    } else if (op === DIFF_INSERT) {
+      pending ??= { baseLo: baseIdx, baseHi: baseIdx, sideLo: sideIdx, sideHi: sideIdx }
+      sideIdx += count
+      pending.sideHi = sideIdx
+    }
+  }
+  flush()
+  baseToSide[baseIdx] = sideIdx
+  return { regions, baseToSide }
+}
+
+type Hunk = LineRegion & { side: 'ours' | 'theirs' }
+
+/**
+ * diff3 line merge. Returns null when a line diff timed out into a degenerate
+ * whole-document rewrite (protecting against silently dropping untouched content),
+ * so the caller can keep its existing canonical fallback.
+ */
+export function mergeMarkdownSourceByLines(
+  originalSource: string,
+  baseCanonical: string,
+  edited: string
+): string | null {
+  const baseLines = splitLinesKeepingEol(baseCanonical)
+  const oursLines = splitLinesKeepingEol(originalSource)
+  const theirsLines = splitLinesKeepingEol(edited)
+
+  const ours = diffLineRegions(baseLines, oursLines)
+  const theirs = diffLineRegions(baseLines, theirsLines)
+
+  // A single region spanning the whole base means the diff collapsed (e.g. timeout);
+  // merging would relocate untouched content, so bail to the caller's fallback.
+  const collapsed = (regions: LineRegion[]): boolean =>
+    baseLines.length > 0 &&
+    regions.length === 1 &&
+    regions[0].baseLo === 0 &&
+    regions[0].baseHi === baseLines.length
+  if (collapsed(ours.regions) && collapsed(theirs.regions)) {
+    return null
+  }
+
+  const hunks: Hunk[] = [
+    ...ours.regions.map((r) => ({ ...r, side: 'ours' as const })),
+    ...theirs.regions.map((r) => ({ ...r, side: 'theirs' as const }))
+  ].sort((a, b) => a.baseLo - b.baseLo || a.baseHi - b.baseHi)
+
+  // A region's aligned side range unions the stable-boundary mapping with any absorbed
+  // hunk ranges, so inserted lines sitting exactly at a boundary are not skipped.
+  const sideRange = (
+    lines: number[],
+    absorbed: Hunk[],
+    which: 'ours' | 'theirs',
+    regionLo: number,
+    regionHi: number
+  ): [number, number] => {
+    let lo = lines[regionLo]
+    let hi = lines[regionHi]
+    for (const hunk of absorbed) {
+      if (hunk.side === which) {
+        lo = Math.min(lo, hunk.sideLo)
+        hi = Math.max(hi, hunk.sideHi)
+      }
+    }
+    return [lo, hi]
+  }
+
+  const out: string[] = []
+  let baseCursor = 0
+  let hunkIdx = 0
+  while (hunkIdx < hunks.length) {
+    let regionLo = hunks[hunkIdx].baseLo
+    let regionHi = hunks[hunkIdx].baseHi
+    const absorbed: Hunk[] = [hunks[hunkIdx]]
+    hunkIdx += 1
+    // Absorb only hunks that truly overlap (share a base line) the growing region;
+    // hunks that merely abut a boundary stay independent so an ours style change and
+    // an adjacent theirs edit don't collapse into one theirs-wins conflict.
+    while (hunkIdx < hunks.length && hunks[hunkIdx].baseLo < regionHi) {
+      const hunk = hunks[hunkIdx]
+      regionLo = Math.min(regionLo, hunk.baseLo)
+      regionHi = Math.max(regionHi, hunk.baseHi)
+      absorbed.push(hunk)
+      hunkIdx += 1
+    }
+
+    // Stable gap before the region: base == ours == theirs, emit ours (original bytes).
+    for (let i = baseCursor; i < regionLo; i += 1) {
+      out.push(oursLines[ours.baseToSide[i]])
+    }
+
+    // Take theirs where the user edited (even overlapping a style-only change); take
+    // ours where only style differs, preserving the original bytes.
+    const sawTheirs = absorbed.some((hunk) => hunk.side === 'theirs')
+    const [lo, hi] = sawTheirs
+      ? sideRange(theirs.baseToSide, absorbed, 'theirs', regionLo, regionHi)
+      : sideRange(ours.baseToSide, absorbed, 'ours', regionLo, regionHi)
+    const source = sawTheirs ? theirsLines : oursLines
+    for (let i = lo; i < hi; i += 1) {
+      out.push(source[i])
+    }
+    baseCursor = regionHi
+  }
+
+  // Trailing stable region.
+  for (let i = baseCursor; i < baseLines.length; i += 1) {
+    out.push(oursLines[ours.baseToSide[i]])
+  }
+
+  return out.join('')
+}

--- a/src/renderer/src/components/editor/rich-markdown-source-reconcile.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-source-reconcile.test.ts
@@ -92,13 +92,30 @@ describe('reconcileSerializedMarkdown', () => {
     expect(reconciled).toBe(originalSource)
   })
 
-  it('falls back to canonical when either string exceeds the size cap (branch 3)', () => {
-    const big = 'line of text\n'.repeat(9000) // ~117 KB, above the size cap
-    const originalSource = `${big}_x_\n`
-    const edited = `${big}*x* y\n`
+  it('preserves untouched non-canonical bytes above the size cap via the line merge (branch 3, #16469)', () => {
+    // A large doc (over the cap) whose untouched region carries non-canonical style;
+    // the user edits one line far away. The old behavior re-canonicalized the whole
+    // file, corrupting untouched content; the line merge keeps it byte-for-byte.
+    const head = '_keep this emphasis_\n* bullet item\n'
+    const filler = 'line of text\n'.repeat(9000) // pushes the doc over the size cap
+    const originalSource = `${head}${filler}_edit me_\n`
+    const baseCanonical = fakeCanonicalize(originalSource)
+    const edited = fakeCanonicalize(originalSource).replace('*edit me*', '*edit me* now')
 
-    // Non-canonical source + real semantic change, but oversize → canonical fallback.
-    expect(reconcileWithFake(originalSource, edited)).toBe(edited)
+    const reconciled = reconcileSerializedMarkdown({
+      originalSource,
+      baseCanonical,
+      edited,
+      roundTrip
+    })
+
+    // Untouched non-canonical bytes survive even though the doc is oversize.
+    expect(reconciled).toContain('_keep this emphasis_')
+    expect(reconciled).toContain('* bullet item')
+    expect(reconciled).not.toContain('*keep this emphasis*')
+    expect(reconciled).not.toContain('- bullet item')
+    // The far-away edit is applied.
+    expect(reconciled).toContain('*edit me* now')
   })
 
   it('bounds diff work for replacement-heavy edits instead of using the 1s library default', () => {
@@ -141,9 +158,10 @@ describe('reconcileSerializedMarkdown', () => {
       })
 
       expect(reconciled).toBe(edited)
-      // The dependency reads the clock when diffing; zero reads proves the
-      // repetitive-input preflight returned before its unbounded half-match scan.
-      expect(dateNow).not.toHaveBeenCalled()
+      // The repetitive-input preflight returns before the char-level half-match scan;
+      // the lossless line-merge fallback only runs a bounded line diff (a handful of
+      // clock reads), never the dependency's unbounded per-character scan.
+      expect(dateNow.mock.calls.length).toBeLessThan(10)
     } finally {
       dateNow.mockRestore()
     }

--- a/src/renderer/src/components/editor/rich-markdown-source-reconcile.ts
+++ b/src/renderer/src/components/editor/rich-markdown-source-reconcile.ts
@@ -9,8 +9,9 @@ import {
   getUtf8ByteLengthForCodePoint,
   readUtf8CodePointAt
 } from '../../../../shared/utf8-byte-limits'
+import { mergeMarkdownSourceByLines } from './rich-markdown-line-merge'
 
-// Why: cap document size in UTF-16 code units (`.length`) since re-parse cost scales with length — the per-commit throwaway TipTap safety re-parse (~50-67ms here) must stay under the 300ms serialize debounce so it can't stall the main thread on slow/SSH hosts.
+// Why: cap document size in UTF-16 code units (`.length`) since re-parse cost scales with length — the per-commit throwaway TipTap safety re-parse (~50-67ms here) must stay under the 300ms serialize debounce so it can't stall the main thread on slow/SSH hosts. Above the cap we still reconcile losslessly via the line merge (no re-parse), just skipping the char-level patch.
 const RECONCILE_SIZE_CAP_CODE_UNITS = 50_000
 
 // Why: dmp's default 1s search freezes the renderer on replacement-heavy paths; a coarse timed-out diff is safe since the round-trip proof below rejects bad placements.
@@ -65,18 +66,28 @@ export function reconcileSerializedMarkdown({
     return restoreEol(editedLf + originalTrailingNewlines, eol)
   }
 
-  // Branch 3: oversize → bounded-cost canonical fallback (today's behavior).
+  // Why: when the char-level patch is skipped or unsafe, fall back to a three-way
+  // line merge that keeps untouched lines byte-for-byte (no TipTap re-parse), instead
+  // of re-canonicalizing the whole document and corrupting content the user never
+  // touched (#16469). Canonical `editedLf` is the last resort only if the merge bails.
+  const losslessFallback = (): string => {
+    const merged = mergeMarkdownSourceByLines(originalSourceLf, baseLf, editedLf)
+    return restoreEol(merged ?? editedLf, eol)
+  }
+
+  // Branch 3: oversize → skip the char patch (its safety re-parse is O(n^2)); the line
+  // merge is bounded by the line diff, so it stays lossless without stalling.
   if (
     Math.max(originalSource.length, baseCanonical.length, edited.length) >
     RECONCILE_SIZE_CAP_CODE_UNITS
   ) {
-    return restoreEol(editedLf, eol)
+    return losslessFallback()
   }
 
   // Branch 4: run the divergent-base patch entirely in LF space.
-  // Why: dmp's half-match accelerator ignores the diff deadline (100ms+ on repeated seeds), so bail to canonical for highly repetitive replacements.
+  // Why: dmp's half-match accelerator ignores the diff deadline (100ms+ on repeated seeds), so bail to the line merge for highly repetitive replacements.
   if (hasRepeatedHalfMatchSeed(baseLf, editedLf)) {
-    return restoreEol(editedLf, eol)
+    return losslessFallback()
   }
   let diffs = makeDiff(baseLf, editedLf, {
     checkLines: true,
@@ -99,15 +110,15 @@ export function reconcileSerializedMarkdown({
   }
   const [reconciledLf, results] = applyPatches(patches, originalSourceLf)
 
-  // Branch 5: a hunk failed to locate in the non-canonical source → unreliable fuzzy match, fall back to canonical.
+  // Branch 5: a hunk failed to locate in the non-canonical source → unreliable fuzzy match, fall back to the lossless line merge.
   if (results.some((applied) => !applied)) {
-    return restoreEol(editedLf, eol)
+    return losslessFallback()
   }
 
-  // Branch 6: prove reconciled bytes render-equal the editor's document — any fuzzy misplacement changes canonical output and is caught here → canonical fallback.
+  // Branch 6: prove reconciled bytes render-equal the editor's document — any fuzzy misplacement changes canonical output and is caught here → lossless line merge.
   const reparsed = roundTrip(reconciledLf)
   if (reparsed === null || normalizeForSafety(reparsed) !== normalizeForSafety(editedLf)) {
-    return restoreEol(editedLf, eol)
+    return losslessFallback()
   }
 
   // Restore the detected EOL as the final step so reconciled CRLF stays CRLF.


### PR DESCRIPTION
## ELI5

Editing and saving a Markdown file in Orca's rich (WYSIWYG) editor could silently rewrite parts of the file you never touched. This makes saving preserve untouched bytes exactly.

## What Changed

The rich editor serializes via `editor.getMarkdown()`, which is lossy (double-encodes HTML entities, drops `\` escapes, re-nests `**\`code\`**`). A reconcile layer (`rich-markdown-source-reconcile.ts`) is meant to patch only the user's edit onto the original bytes, but all four of its fallback branches returned the fully canonicalized serialization, rewriting the whole document. The dominant trigger is the >50k-char cap (branch 3): a ~1650-line file trips it, so any edit re-canonicalizes everything.

New `src/renderer/src/components/editor/rich-markdown-line-merge.ts` does a three-way (diff3) line merge over `@sanity/diff-match-patch` line diffs: untouched lines emit the original on-disk bytes verbatim; only user-edited lines get canonical serialization. The four lossy fallbacks now route through this lossless merge (EOL restored via the existing `restoreEol`), using canonical output only as a last resort.

## Why

Silent data loss on save is the worst failure mode for an editor. The size cap couldn't simply be raised: branch 6's safety re-parse is O(n²) (measured 24s at 660k chars). The line merge preserves bytes without that cost (8-150ms on realistic docs).

## Linked Issue

Fixes #16469

## Visual Proof

N/A - not a UI change; the effect is byte-level file content on save. Repro: open a ~1650-line / >50k-char Markdown doc, edit one line far from the top, save, diff. Before: untouched lines rewritten (`Finance &gt; Invoices` became `Finance &amp;gt; Invoices`, etc.). After: byte-identical.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- New `rich-markdown-line-merge.test.ts`: edit/insert/delete preservation, no-op verbatim, collapse-to-null, 500-trial fuzz vs a brute-force oracle.
- Updated `rich-markdown-source-reconcile.test.ts`: a branch-3 regression that fails before the fix (canonicalized output) and passes after.
- `pnpm typecheck` exit 0; full editor dir 171 files / 1158 tests pass; oxlint clean.

## AI Disclosure

Implemented with Claude Code (Anthropic; Claude Opus). Root-cause analysis, the fix, and the tests were AI-generated and human-reviewed before opening.

## Review

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill-installer source, tests, fixtures, or docs are copied or translated.

## Notes

Reconcile runs in the renderer; the downstream write path (SSH/remote hosts, folder workspaces) is unchanged. EOL/CRLF handled via the existing `restoreEol`. No wire-format change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path impact considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` pass locally (CI covers build)

## Author

- X / Twitter: @bo_ns_ai
