### PR TITLE
fix(tab-bar): correct active-tab surface in light mode (#16283)

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -108,6 +108,8 @@
   --color-workspace-status-progress: var(--workspace-status-progress);
   --color-tab-group-split-divider: var(--tab-group-split-divider);
   --color-tab-group-split-divider-strong: var(--tab-group-split-divider-strong);
+  --color-tab-strip-active-surface: var(--tab-strip-active-surface);
+  --color-tab-strip-inactive-surface: var(--tab-strip-inactive-surface);
   --color-git-graph-ref: var(--git-graph-ref);
   --color-git-graph-remote-ref: var(--git-graph-remote-ref);
   --color-git-graph-base-ref: var(--git-graph-base-ref);
@@ -245,6 +247,13 @@
      meet >=3:1 against `--card`, not only the hover/drag strong state. */
   --tab-group-split-divider: #868690;
   --tab-group-split-divider-strong: #71717a;
+  /* Why: the active tab must read lighter than inactive ones in both themes.
+     `--card` is already max-lightness in light mode, so there's no way to
+     lighten it further — the 6% mix has to darken the *inactive* tab instead
+     (opposite of dark mode below, where mixing foreground into card
+     lightens the *active* tab). See #16283. */
+  --tab-strip-active-surface: var(--card);
+  --tab-strip-inactive-surface: color-mix(in srgb, var(--foreground) 6%, var(--card));
 }
 
 /* ── Dark Mode ───────────────────────────────────────── */
@@ -355,6 +364,10 @@
   /* Brighter than terminal defaults so the always-visible line clears 3:1 on `--card`. */
   --tab-group-split-divider: #71717a;
   --tab-group-split-divider-strong: #a1a1aa;
+  /* Why: here the 6% mix already lightens `--card` correctly, so the active
+     tab keeps the mix and the inactive tab stays plain `--card`. */
+  --tab-strip-active-surface: color-mix(in srgb, var(--foreground) 6%, var(--card));
+  --tab-strip-inactive-surface: var(--card);
 }
 
 .plugin-security-chrome {

--- a/src/renderer/src/components/tab-bar/drop-indicator.test.ts
+++ b/src/renderer/src/components/tab-bar/drop-indicator.test.ts
@@ -47,9 +47,9 @@ describe('ACTIVE_TAB_INDICATOR_CLASSES', () => {
     expect(ACTIVE_TAB_INDICATOR_CLASSES).toContain('absolute')
     expect(ACTIVE_TAB_INDICATOR_CLASSES).toContain('bottom-0')
     expect(ACTIVE_TAB_INDICATOR_CLASSES).toContain('h-[2px]')
-    expect(ACTIVE_TAB_INDICATOR_CLASSES).toContain(
-      'bg-[color-mix(in_srgb,var(--foreground)_60%,var(--card))]'
-    )
+    // Why: `ring` is a fixed per-theme gray (STYLEGUIDE.md: "active selection
+    // halos"), unlike a foreground/card mix which flips direction across themes.
+    expect(ACTIVE_TAB_INDICATOR_CLASSES).toContain('bg-ring')
     expect(ACTIVE_TAB_INDICATOR_CLASSES).toContain('pointer-events-none')
     expect(ACTIVE_TAB_INDICATOR_CLASSES).not.toContain('-top-px')
     expect(ACTIVE_TAB_INDICATOR_CLASSES).not.toContain('bg-[#1e3d9c]')
@@ -73,14 +73,14 @@ describe('getTabStripBorderClasses', () => {
 describe('getTabRootStateClasses', () => {
   it('returns the shared selected-tab surface treatment', () => {
     const classes = getTabRootStateClasses(true)
-    expect(classes).toContain('bg-[color-mix(in_srgb,var(--foreground)_6%,var(--card))]')
+    expect(classes).toContain('bg-[var(--tab-strip-active-surface)]')
     expect(classes).toContain('text-foreground')
     expect(classes).not.toContain('hover:text-foreground')
   })
 
   it('returns the shared inactive-tab surface treatment', () => {
     const classes = getTabRootStateClasses(false)
-    expect(classes).toContain('bg-card')
+    expect(classes).toContain('bg-[var(--tab-strip-inactive-surface)]')
     expect(classes).toContain('text-muted-foreground')
     expect(classes).toContain('hover:text-foreground')
   })

--- a/src/renderer/src/components/tab-bar/drop-indicator.ts
+++ b/src/renderer/src/components/tab-bar/drop-indicator.ts
@@ -15,23 +15,27 @@ export function getDropIndicatorClasses(dropIndicator: DropIndicator): string {
 }
 
 // Why: a 2px bar on the active tab's BOTTOM edge, bridging the tab into the
-// panel it owns. The active tab also lifts its background with a very subtle
-// color-mix wash (uniform in light and dark, unlike `accent` whose contrast
-// against `card` is lopsided across themes); this bar is the crisp selection
-// marker layered on top. Mixing `foreground` with `card` keeps the marker
-// neutral and visible without overpowering the quiet tab chrome. z-10 keeps it
-// above the bg lift and the
-// unread amber wash. Horizontal inset is 0 (not -1px): negative insets on the
-// last tab bleed into the strip's scrollWidth, so clicking between active tabs
-// flips the strip between "fits exactly" and "overflows by 1px", which jitters
-// every tab by 1px because the browser preserves scrollLeft near the end.
+// panel it owns — the crisp selection marker layered on top of the lifted
+// background. `ring` is the documented token for "active selection halos"
+// (STYLEGUIDE.md), and unlike a `foreground`/`card` mix it's a fixed
+// per-theme gray, so it can't flip direction between light and dark (#16283).
+// z-10 keeps it above the bg lift and the unread amber wash. Horizontal inset
+// is 0 (not -1px): negative insets on the last tab bleed into the strip's
+// scrollWidth, so clicking between active tabs flips the strip between "fits
+// exactly" and "overflows by 1px", which jitters every tab by 1px because the
+// browser preserves scrollLeft near the end.
 export const ACTIVE_TAB_INDICATOR_CLASSES =
-  'pointer-events-none absolute inset-x-0 bottom-0 h-[2px] bg-[color-mix(in_srgb,var(--foreground)_60%,var(--card))] z-10'
+  'pointer-events-none absolute inset-x-0 bottom-0 h-[2px] bg-ring z-10'
 
+// Why: `--tab-strip-active/inactive-surface` (main.css) swap which side gets
+// the foreground/card mix per theme so the active tab always reads lighter
+// than the inactive one — `--card` is already max-lightness in light mode,
+// so the mix has to darken the inactive tab there instead of lightening the
+// active one like it does in dark mode (#16283).
 export function getTabRootStateClasses(isActive: boolean): string {
   return isActive
-    ? 'bg-[color-mix(in_srgb,var(--foreground)_6%,var(--card))] text-foreground'
-    : 'bg-card text-muted-foreground hover:text-foreground'
+    ? 'bg-[var(--tab-strip-active-surface)] text-foreground'
+    : 'bg-[var(--tab-strip-inactive-surface)] text-muted-foreground hover:text-foreground'
 }
 
 export function getTabStripBorderClasses(


### PR DESCRIPTION
## ELI5

In light mode the selected tab looked *darker* than the unselected ones, so the active tab appeared receded and an inactive tab looked selected. This makes the active tab read as active in both themes.

## What Changed

The active tab used `color-mix(in srgb, var(--foreground) X%, var(--card))` to highlight itself. In dark mode `--foreground` (#fafafa) is lighter than `--card` (#171717), so the mix lightens the active tab (correct). In light mode `--foreground` is #0a0a0a and `--card` is #fff (already max lightness), so the same mix *darkens* the active tab below the untouched-white inactive tabs (backwards). The bottom selection bar had the same problem at 60% mix.

Fix (tokens only, no new colors):
- `main.css`: theme-scoped `--tab-strip-active-surface` / `--tab-strip-inactive-surface`. In light mode the mix moves to the *inactive* tab (active stays pure `--card` white); in dark mode it stays on the active tab exactly as before - same 6% magnitude, applied to the correct side per theme so active is always lighter than inactive.
- `drop-indicator.ts`: tab classes read the new tokens; the active-indicator bar uses `bg-ring` (STYLEGUIDE.md's documented token for active selection halos, a fixed per-theme gray) instead of the color-mix, so it can't flip direction.

All three tab types (`SortableTab`, `EditorFileTab`, `BrowserTab`) share these helpers, so the fix applies uniformly.

## Why

Per STYLEGUIDE.md, use existing tokens rather than inventing values. The bug was a color-mix formula that is only correct when `--foreground` is lighter than `--card`; scoping the surface tokens per theme fixes the direction without new color values.

## Linked Issue

Fixes #16283

## Visual Proof

Validated on a static HTML mockup reproducing the exact `:root`/`.dark` tokens and Tailwind classes (before/after, both themes), rendered in-browser: light-mode active tab is now the brighter one with a subtle ring-gray underline; dark mode is visually unchanged. **Real-app before/after screenshots still to attach (@BorjaLL).**

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- Updated `drop-indicator.test.ts` assertions to the new tokens.
- `pnpm typecheck` exit 0; `oxlint src/renderer/src` clean; `vitest run` on `tab-bar` = 49 files / 391 tests pass.

## AI Disclosure

Implemented with Claude Code (Anthropic; Claude Sonnet). Root-cause analysis, the fix, and the tests were AI-generated and human-reviewed before opening.

## Review

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill-installer source, tests, fixtures, or docs are copied or translated.

## Notes

Tokens only; no component structure change. Light and dark both verified against the styleguide's surface roles.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots for UI changes attached (mockup validated; real-app capture pending)
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path impact considered (or N/A)
- [x] `pnpm typecheck`, lint, tests pass locally (CI covers build)

## Author

- X / Twitter: @bo_ns_ai
