### PR TITLE
fix(tasks): render every failed-source repo instead of silently dropping it (#16473)

### DIFF
--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -10119,7 +10119,7 @@ export default function TaskPage(): React.JSX.Element {
                             "Couldn't load issues from"
                           )}{' '}
                           <span className="font-mono">
-                            {err.source.owner}/{err.source.repo}
+                            {err.source ? `${err.source.owner}/${err.source.repo}` : s.repoPath}
                           </span>{' '}
                           — {err.message}
                         </span>

--- a/src/renderer/src/store/github/cache-model.ts
+++ b/src/renderer/src/store/github/cache-model.ts
@@ -13,7 +13,10 @@ export type WorkItemsCacheSources = {
   upstreamCandidate: GitHubOwnerRepo | null
 }
 
-export type WorkItemsCacheError = ClassifiedError & { source: GitHubOwnerRepo }
+// `source` is optional: a fetch that throws before source resolution ever
+// completes (or never wrote an envelope at all, #16473) still needs a
+// renderable error entry, so the row falls back to the repo path.
+export type WorkItemsCacheError = ClassifiedError & { source?: GitHubOwnerRepo }
 
 export type CacheEntry<T> = {
   data: T | null

--- a/src/renderer/src/store/github/work-item-aggregate-actions.ts
+++ b/src/renderer/src/store/github/work-item-aggregate-actions.ts
@@ -14,7 +14,12 @@ import {
   isGitHubWorkItemsQueryTooLarge
 } from '../slices/github-work-items-query-bounds'
 import { workItemsCacheKey, workItemsInflightRequestKey } from './cache-identity'
-import { GITHUB_SEARCH_RESULT_WINDOW, isFresh, WORK_ITEMS_CACHE_TTL } from './cache-policy'
+import {
+  GITHUB_SEARCH_RESULT_WINDOW,
+  isFresh,
+  withBoundedCacheEntry,
+  WORK_ITEMS_CACHE_TTL
+} from './cache-policy'
 import {
   acquireProviderRequestSlot as acquireWorkItemSlot,
   inflightWorkItemsRequests,
@@ -22,6 +27,7 @@ import {
 } from './request-coordination'
 import { findRepoForGitHubOwner } from './repository-routing'
 import {
+  classifyWorkItemsFetchFailure,
   countGitHubWorkItemsForRepo,
   getGitHubWorkItemRequestContext,
   getGitHubWorkItemSourceSettings,
@@ -31,6 +37,7 @@ import {
 } from './work-item-routing'
 
 export const createWorkItemAggregateActions = (
+  set: Parameters<StateCreator<AppState>>[0],
   get: Parameters<StateCreator<AppState>>[1]
 ): Pick<
   GitHubSlice,
@@ -86,6 +93,23 @@ export const createWorkItemAggregateActions = (
           }
           console.warn(`[workItems] ${r.repoId} failed:`, err)
           failedCount += 1
+          // Why: without this, a repo whose fetch throws leaves no cache entry
+          // at all, so sources stay null and error stays null, satisfying
+          // neither the error-row nor the unresolved-source render branch and
+          // vanishing from the list while still counted in failedCount
+          // (#16473). Write a minimal error entry so the banner count and the
+          // rendered rows can't diverge.
+          set((s) => {
+            const previousEntry = s.workItemsCache[key]
+            return {
+              workItemsCache: withBoundedCacheEntry(s.workItemsCache, key, {
+                data: previousEntry?.data ?? null,
+                fetchedAt: Date.now(),
+                ...(previousEntry?.sources ? { sources: previousEntry.sources } : {}),
+                error: classifyWorkItemsFetchFailure(err)
+              })
+            }
+          })
           return [] as GitHubWorkItem[]
         }
       })

--- a/src/renderer/src/store/github/work-item-fetch-actions.ts
+++ b/src/renderer/src/store/github/work-item-fetch-actions.ts
@@ -138,17 +138,15 @@ export const createWorkItemFetchActions = (
         }
         // Why: only surface issues-side errors here; PR-side failures predate the issue-source split (#1076) and are out of scope for this banner (design doc §2).
         const issuesError = envelope.errors?.issues
-        // Why: errors.issues without sources.issues has no slug for the banner, so it's dropped from the cache; log it so this rare case is visible in devtools.
-        if (issuesError && !envelope.sources.issues) {
-          console.warn(
-            '[workItems] dropping issues-side error with no resolved source:',
-            issuesError
-          )
-        }
-        const errorForCache: WorkItemsCacheError | undefined =
-          issuesError && envelope.sources.issues
-            ? { ...issuesError, source: envelope.sources.issues }
-            : undefined
+        // Why: `source` is optional (#16473); errors.issues without sources.issues
+        // still renders (falling back to the repo path) instead of being
+        // silently dropped from the cache.
+        const errorForCache: WorkItemsCacheError | undefined = issuesError
+          ? {
+              ...issuesError,
+              ...(envelope.sources.issues ? { source: envelope.sources.issues } : {})
+            }
+          : undefined
         const currentRepo = findRepoForGitHubOwner(get(), repoId, repoPath)
         const currentHostId = getGitHubWorkItemSourceHostId(
           get(),

--- a/src/renderer/src/store/github/work-item-routing.ts
+++ b/src/renderer/src/store/github/work-item-routing.ts
@@ -1,5 +1,6 @@
 import type { AppState } from '../types'
 import type { Repo } from '../../../../shared/repo-types'
+import type { ClassifiedError } from '../../../../shared/classified-error'
 import type { GitHubWorkItem, ListWorkItemsResult } from '../../../../shared/github/work-item-types'
 import {
   getTaskSourceCacheScope,
@@ -220,4 +221,16 @@ export function isGitHubUnavailableWorkItemsError(error: unknown): boolean {
   }
   const message = error instanceof Error ? error.message : String(error)
   return classifyGitHubUnavailable(message) !== null
+}
+
+// Why: a repo whose fetch rejects outright (no envelope, so no per-side
+// classified error) still needs a renderable reason (#16473's invisible
+// failed-count entries). Bucket it the same way the banner distinguishes an
+// outage from any other failure.
+export function classifyWorkItemsFetchFailure(error: unknown): ClassifiedError {
+  const message = error instanceof Error ? error.message : String(error)
+  return {
+    type: isGitHubUnavailableWorkItemsError(error) ? 'network_error' : 'unknown',
+    message
+  }
 }

--- a/src/renderer/src/store/slices/github-work-items-error-envelope.test.ts
+++ b/src/renderer/src/store/slices/github-work-items-error-envelope.test.ts
@@ -497,4 +497,53 @@ describe('createGitHubSlice.fetchWorkItems source/error envelope', () => {
       consoleWarn.mockRestore()
     }
   })
+
+  it('writes a visible error entry for a repo counted as failed with no cache to fall back to (#16473)', async () => {
+    // Why: a repo whose first-ever fetch throws previously left the cache
+    // entry unwritten, and `sources: null, error: null` satisfies neither the
+    // error-row nor the unresolved-source render branch, so it vanished from
+    // the Tasks list while still incrementing `failedCount`. The cache entry
+    // must now carry an `error` so callers (TaskPage's perRepoSourceState)
+    // can render it.
+    const store = createTestStore()
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    mockApi.gh.listWorkItems.mockRejectedValueOnce(new Error('boom: totally unexpected failure'))
+
+    try {
+      const result = await store
+        .getState()
+        .fetchWorkItemsAcrossRepos(
+          [{ repoId: 'never-cached-repo', path: '/server/never-cached-repo' }],
+          24,
+          100,
+          ''
+        )
+
+      expect(result.failedCount).toBe(1)
+      const { error } = store.getState().getWorkItemsSourcesAndError('never-cached-repo', 24, '')
+      expect(error).not.toBeNull()
+      expect(error?.message).toContain('boom: totally unexpected failure')
+    } finally {
+      consoleWarn.mockRestore()
+    }
+  })
+
+  it('surfaces an issues-side error even when its source never resolved', async () => {
+    // Why: previously an issues-side error with no resolved `sources.issues`
+    // was logged and dropped instead of cached, so the repo rendered as a
+    // silent zero. `source` is now optional on the cache error, so the row
+    // falls back to the repo path instead of disappearing (#16473).
+    const store = createTestStore()
+    mockApi.gh.listWorkItems.mockResolvedValueOnce({
+      items: [],
+      sources: { issues: null, prs: null, originCandidate: null, upstreamCandidate: null },
+      errors: { issues: { type: 'unknown', message: 'search unavailable' } }
+    })
+
+    await store.getState().fetchWorkItems('repo-id', '/repo', 24, '')
+
+    const result = store.getState().getWorkItemsSourcesAndError('repo-id', 24, '')
+    expect(result.error).toMatchObject({ type: 'unknown', message: 'search unavailable' })
+    expect(result.error?.source).toBeUndefined()
+  })
 })

--- a/src/renderer/src/store/slices/github.ts
+++ b/src/renderer/src/store/slices/github.ts
@@ -74,7 +74,7 @@ export const createGitHubSlice: StateCreator<AppState, [], [], GitHubSlice> = (s
   ...createProjectActions(set, get),
   ...createProjectRowActions(set, get),
   ...createWorkItemFetchActions(set, get),
-  ...createWorkItemAggregateActions(get),
+  ...createWorkItemAggregateActions(set, get),
   ...createPullRequestActions(set, get),
   ...createIssueActions(set, get),
   ...createCheckActions(set, get),


### PR DESCRIPTION
## ELI5

The Tasks page banner could say "N projects failed" but render fewer than N rows: a repo whose fetch failed with nothing cached vanished from the list while still being counted. This makes every counted repo render a row.

## What Changed

When a repo's work-items fetch rejects outright with no cached fallback, the aggregate fetch incremented `failedCount` but wrote **nothing** to the work-items cache. Downstream, `task-page-cache-selectors` then saw `sources: null, error: null` for that repo - a shape that satisfies neither the error-row branch (needs `error`) nor the unresolved-source branch (needs `sources`), so the repo disappeared from every rendered row while still counted in the amber banner. A second instance: an issues-side error with no resolved `sources.issues` was logged and dropped instead of cached.

Fix (ported onto current main's post-split `store/github/` modules):
- `store/github/cache-model.ts`: `WorkItemsCacheError.source` is now optional.
- `store/github/work-item-routing.ts`: new `classifyWorkItemsFetchFailure(error)` (network_error vs unknown).
- `store/github/work-item-aggregate-actions.ts`: the `failedCount += 1` catch branch now also writes a minimal cache entry (preserving any prior `data`/`sources`) with a classified error, so count and rendered rows can't diverge.
- `store/github/work-item-fetch-actions.ts`: a sourceless `errors.issues` is now cached (source omitted) instead of dropped.
- `components/TaskPage.tsx`: the error row falls back to the repo path when the error has no `source`.

## Why

Count-vs-render divergence is confusing and hides real failures. Writing a renderable error entry for every counted failure - matching the issue's own suggested fix - keeps the banner and the list consistent.

## Linked Issue

Fixes #16473

## Visual Proof

N/A for a static shot (the bug is an absent row). Repro: configure the Tasks page with a repo whose issue fetch throws and has no cache; before, the banner counts it but no row appears; after, a "Couldn't load issues from X / Retry" row renders for it.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- `github-work-items-error-envelope.test.ts` (+2): a repo whose fetch throws with no prior cache gets a renderable non-null error; a sourceless issues error is cached with `source` undefined rather than dropped. Verified failing before / passing after.
- `pnpm tc:web` clean; `github` store slice suite 273/273; `task-page` 322/322; oxlint clean on all touched files.

## AI Disclosure

Implemented with Claude Code (Anthropic; Claude Sonnet). Root-cause analysis, the fix, and the tests were AI-generated and human-reviewed before opening.

## Review

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill-installer source, tests, fixtures, or docs are copied or translated.

## Notes

Scope is #16473 only. The sibling issue #16474 (Tasks "upstream" source not falling back to origin) was investigated separately and **could not be reproduced** on current code - the `upstream -> origin` fallback already works for HTTPS/SSH/no-remote repos and is unchanged since #1317 - so it is not addressed here.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path impact considered (or N/A)
- [x] `pnpm typecheck`, tests, lint pass locally (CI covers build)

## Author

- X / Twitter: @bo_ns_ai
