### PR TITLE
test(github): lock in upstream->origin API repository fallback (#16474)

### DIFF
--- a/src/main/github/github-api-repository-upstream-fallback.test.ts
+++ b/src/main/github/github-api-repository-upstream-fallback.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  _resetOriginGitHubApiRepositoryCache,
+  resolveIssueGitHubApiRepositorySource
+} from './github-api-repository'
+import { resolvePrWorkItemSource } from './client/list/work-item-list-request'
+import { _resetOwnerRepoCache } from './gh-utils'
+
+// Why: #16474 — the 'upstream' issue-source preference must fall back to
+// `origin` when a repo has no `upstream` remote, instead of hard-failing on
+// git's "No such remote" exit. These tests run real `git remote` commands
+// against a throwaway repo (no gh, no mocked git runner) so a future change to
+// the "no such remote" matching in `isStableMissingGitRemoteError` /
+// `getOwnerRepoForRemote` can't silently reintroduce the hard-fail the way a
+// fully-mocked resolver test would miss.
+describe('resolveIssueGitHubApiRepositorySource / resolvePrWorkItemSource — upstream fallback (real git)', () => {
+  let repoPath: string
+
+  beforeEach(async () => {
+    _resetOriginGitHubApiRepositoryCache()
+    _resetOwnerRepoCache()
+    repoPath = await mkdtemp(join(tmpdir(), 'orca-upstream-fallback-'))
+    execFileSync('git', ['init', '-q'], { cwd: repoPath })
+  })
+
+  afterEach(async () => {
+    await rm(repoPath, { recursive: true, force: true })
+  })
+
+  it('falls back to origin when preference is upstream and no upstream remote exists (HTTPS origin)', async () => {
+    execFileSync('git', ['remote', 'add', 'origin', 'https://github.com/octocat/Hello-World.git'], {
+      cwd: repoPath
+    })
+
+    const result = await resolveIssueGitHubApiRepositorySource(repoPath, 'upstream')
+
+    expect(result).toEqual({
+      source: { owner: 'octocat', repo: 'Hello-World', host: 'github.com' },
+      fellBack: true
+    })
+  })
+
+  it('falls back to origin when preference is upstream and no upstream remote exists (SSH origin)', async () => {
+    execFileSync('git', ['remote', 'add', 'origin', 'git@github.com:octocat/Hello-World.git'], {
+      cwd: repoPath
+    })
+
+    const result = await resolveIssueGitHubApiRepositorySource(repoPath, 'upstream')
+
+    expect(result).toEqual({
+      source: { owner: 'octocat', repo: 'Hello-World', host: 'github.com' },
+      fellBack: true
+    })
+  })
+
+  it('resolves upstream directly when the upstream remote exists', async () => {
+    execFileSync('git', ['remote', 'add', 'origin', 'https://github.com/octocat/fork.git'], {
+      cwd: repoPath
+    })
+    execFileSync(
+      'git',
+      ['remote', 'add', 'upstream', 'https://github.com/octocat/Hello-World.git'],
+      { cwd: repoPath }
+    )
+
+    const result = await resolveIssueGitHubApiRepositorySource(repoPath, 'upstream')
+
+    expect(result).toEqual({
+      source: { owner: 'octocat', repo: 'Hello-World', host: 'github.com' },
+      fellBack: false
+    })
+  })
+
+  it('resolves to null without throwing when the repo has no remotes at all', async () => {
+    const result = await resolveIssueGitHubApiRepositorySource(repoPath, 'upstream')
+
+    expect(result).toEqual({ source: null, fellBack: false })
+  })
+
+  it('falls back PR-side resolution to origin the same way', async () => {
+    execFileSync('git', ['remote', 'add', 'origin', 'https://github.com/octocat/Hello-World.git'], {
+      cwd: repoPath
+    })
+
+    const result = await resolvePrWorkItemSource(repoPath, 'upstream')
+
+    expect(result).toEqual({
+      source: { owner: 'octocat', repo: 'Hello-World', host: 'github.com' },
+      originCandidate: { owner: 'octocat', repo: 'Hello-World', host: 'github.com' },
+      upstreamCandidate: null
+    })
+  })
+})


### PR DESCRIPTION
## ELI5

Adds a regression test that pins Orca's "use the `upstream` remote, else fall back to `origin`" behavior when resolving a repo's GitHub API source. No product code changes.

## What Changed

New `src/main/github/github-api-repository-upstream-fallback.test.ts`: drives `resolveIssueGitHubApiRepositorySource` against real temp git repos (HTTPS `origin`, SSH `origin`, no remotes) with `preference: 'upstream'` and no `upstream` remote, asserting it returns the `origin` source with `fellBack: true` and never throws. Real `git` binary, no mocks, no `gh`.

## Why

Issue #16474 reports this fallback failing, but it could not be reproduced on current `main` - the fallback has worked since #1317 and no existing test exercised the real git-error path (everything was mocked at the resolver boundary). This locks in the behavior so a future regression is caught.

## Linked Issue

Refs #16474 (adds a regression guard; see the issue comment for the not-reproducible analysis). Not a `Fixes` - there is no product code change.

## Visual Proof

N/A - test-only, no UI or behavior change.

## Testing

- [x] Automated tests added
- `vitest` on the new file: 5/5 pass against current `main` (real git subprocess).

## AI Disclosure

Written with Claude Code (Anthropic; Claude Sonnet), human-reviewed before opening.

## Review

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill-installer source, tests, fixtures, or docs are copied or translated.

## Notes

Test-only; no product code touched. Real-binary git test, so it needs `git` on PATH (CI has it). Cross-platform: uses `node:path`/`node:os` and invokes git via `execFileSync`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path impact considered (or N/A)
- [x] tests pass locally (CI covers build)

## Author

- X / Twitter: @bo_ns_ai
