### PR TITLE
fix(sidebar): preserve hidden rows in manual order

### DIFF
--- a/src/main/ipc/worktree-git-common-watch.test.ts
+++ b/src/main/ipc/worktree-git-common-watch.test.ts
@@ -564,8 +564,8 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
     await mkdir(worktreesDir)
     await vi.waitFor(() => {
       expect(subscribeMock).toHaveBeenCalledTimes(2)
+      expect(received.flat()).toContainEqual({ type: 'create', path: worktreesDir })
     })
-    expect(received.flat()).toContainEqual({ type: 'create', path: worktreesDir })
   })
 
   it('drops both visibility subscriptions on dispose', async () => {
@@ -637,7 +637,9 @@ describe('worktree git-common narrow watch (local native platforms)', () => {
 
       await replaceWorktreesRoot(commonDir, worktreesDir, retainedEntry)
       await vi.advanceTimersByTimeAsync(POLL_MS * RECONCILIATION_TICKS * 4)
-      expect(subscribeMock).toHaveBeenCalledTimes(3)
+      await vi.waitFor(() => {
+        expect(subscribeMock).toHaveBeenCalledTimes(3)
+      })
       expect(staleSubscription.unsubscribe).toHaveBeenCalledOnce()
 
       const beforeStaleEvent = received.length

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -20,6 +20,7 @@ import { useWorkspaceKanbanBoardProjection } from './use-workspace-kanban-board-
 import { useWorkspaceKanbanNativeDrag } from './use-workspace-kanban-native-drag'
 import { useWorkspaceKanbanRenderLifecycle } from './use-workspace-kanban-render-lifecycle'
 import { useWorkspaceKanbanDrawerLingering } from './use-workspace-kanban-drawer-lingering'
+import { buildWorktreeManualOrderCatalog } from './worktree-manual-order-catalog'
 
 type WorkspaceKanbanDrawerProps = {
   leftSidebarStyle?: React.CSSProperties
@@ -52,6 +53,7 @@ function WorkspaceKanbanDrawerContent({
   onMenuOpenChange
 }: WorkspaceKanbanDrawerProps): React.JSX.Element {
   const allWorktrees = useAllWorktrees()
+  const folderWorkspaces = useAppStore((s) => s.folderWorkspaces)
   const repoMap = useRepoMap()
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
   const activeWorkspaceExecutionHostId = useAppStore((s) => s.activeWorkspaceExecutionHostId)
@@ -73,6 +75,10 @@ function WorkspaceKanbanDrawerContent({
   const laneScrollerRef = useRef<HTMLDivElement>(null)
   const areaSelectionOverlayRef = useRef<HTMLDivElement>(null)
   const { createWorktreeForStatus } = useWorkspaceKanbanCreateWorktree()
+  const manualOrderCatalog = useMemo(
+    () => buildWorktreeManualOrderCatalog({ worktrees: allWorktrees, folderWorkspaces }),
+    [allWorktrees, folderWorkspaces]
+  )
   const {
     activeWorktreeIdentity,
     boardDragGroups,
@@ -135,7 +141,7 @@ function WorkspaceKanbanDrawerContent({
     updateWorktreesMeta,
     workspaceStatuses,
     worktreeById,
-    allWorktreeIds: boardWorktrees.map((worktree) => worktree.id),
+    manualOrderCatalog,
     worktreesByStatus
   })
   // Why: dragging or right-clicking one visible match must not silently move

--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.tsx
@@ -135,6 +135,7 @@ function WorkspaceKanbanDrawerContent({
     updateWorktreesMeta,
     workspaceStatuses,
     worktreeById,
+    allWorktreeIds: boardWorktrees.map((worktree) => worktree.id),
     worktreesByStatus
   })
   // Why: dragging or right-clicking one visible match must not silently move

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -36,6 +36,7 @@ import { useSidebarWorktreeSortOrder } from './worktree-list/listing/use-sort-or
 import { useVisibleSidebarWorktrees } from './worktree-list/listing/use-visible-worktrees'
 import { useWorktreeStatusMutations } from './worktree-list/drag/use-status-mutations'
 import { shouldFiltersHideAllRows } from './sidebar-empty-state-gate'
+import { buildWorktreeManualOrderCatalog } from './worktree-manual-order-catalog'
 
 type WorktreeListProps = {
   scrollOffsetRef: React.MutableRefObject<number>
@@ -105,6 +106,10 @@ const WorktreeList = React.memo(function WorktreeList({
   const agentSendTargetWorktreeId = useAgentSendTargetWorktreeId()
   const { filterState, hasFilters, clearFilters } = useSidebarWorktreeFilters()
   const sortedIds = useSidebarWorktreeSortOrder({ allWorktrees, repoMap, sortBy })
+  const manualOrderCatalog = useMemo(
+    () => buildWorktreeManualOrderCatalog({ worktrees: allWorktrees, folderWorkspaces }),
+    [allWorktrees, folderWorkspaces]
+  )
   const { visibleWorktrees, pairedDeviceIdsByEnvironment } = useVisibleSidebarWorktrees({
     filterState,
     sortBy,
@@ -174,7 +179,7 @@ const WorktreeList = React.memo(function WorktreeList({
     pinnedDisplayPolicy
   })
   const statusMutations = useWorktreeStatusMutations({
-    allWorktreeIds: sortedIds,
+    manualOrderCatalog,
     worktreeMap,
     workspaceStatuses,
     sortBy

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -173,7 +173,12 @@ const WorktreeList = React.memo(function WorktreeList({
     sectionRows: rowModel.sectionRows,
     pinnedDisplayPolicy
   })
-  const statusMutations = useWorktreeStatusMutations({ worktreeMap, workspaceStatuses, sortBy })
+  const statusMutations = useWorktreeStatusMutations({
+    allWorktreeIds: sortedIds,
+    worktreeMap,
+    workspaceStatuses,
+    sortBy
+  })
   const projectGroupDialogs = useProjectGroupDialogs({ repos, repoMap, projectGroups })
 
   const handleImmediateWorktreeActivate = useCallback((worktreeId: string, rowKey?: string) => {

--- a/src/renderer/src/components/sidebar/use-workspace-kanban-worktree-actions.ts
+++ b/src/renderer/src/components/sidebar/use-workspace-kanban-worktree-actions.ts
@@ -9,6 +9,7 @@ import {
 } from './worktree-manual-order'
 import type { WorktreeMeta } from '../../../../shared/worktree/meta-types'
 import type { WorkspaceStatus, Worktree } from '../../../../shared/worktree/types'
+import type { WorktreeManualOrderCatalog } from './worktree-manual-order-catalog'
 
 type LaneView = { items: readonly Worktree[] }
 
@@ -23,7 +24,7 @@ export function useWorkspaceKanbanWorktreeActions(args: {
   updateWorktreesMeta: ReturnType<typeof useAppStore.getState>['updateWorktreesMeta']
   workspaceStatuses: ReturnType<typeof useAppStore.getState>['workspaceStatuses']
   worktreeById: ReadonlyMap<string, Worktree>
-  allWorktreeIds: readonly string[]
+  manualOrderCatalog: WorktreeManualOrderCatalog
   worktreesByStatus: ReadonlyMap<string, readonly Worktree[]>
 }) {
   const recordInteraction = (): void => {
@@ -89,16 +90,6 @@ export function useWorkspaceKanbanWorktreeActions(args: {
       const updates = new Map<string, Partial<WorktreeMeta>>()
       const writeManualOrder =
         drop.writeManualOrder ?? shouldWriteDropManualOrder(drop.worktreeIds, drop.status)
-      const rankByWorktreeId = writeManualOrder
-        ? new Map(
-            args.allWorktreeIds.flatMap((worktreeId) => {
-              const worktree = args.worktreeById.get(worktreeId)
-              return worktree?.manualOrder !== undefined
-                ? [[worktreeId, worktree.manualOrder] as const]
-                : []
-            })
-          )
-        : undefined
       const order = writeManualOrder
         ? buildManualOrderUpdatesForGroupDrop({
             groups: args.boardDragGroups,
@@ -106,8 +97,8 @@ export function useWorkspaceKanbanWorktreeActions(args: {
             draggedIds: drop.worktreeIds,
             dropIndex: drop.dropIndex,
             now: Date.now(),
-            rankByWorktreeId,
-            allWorktreeIds: args.allWorktreeIds
+            rankByWorktreeId: args.manualOrderCatalog.rankByWorktreeId,
+            allWorktreeIds: args.manualOrderCatalog.orderedIds
           })
         : { changed: false, updates: new Map<string, { manualOrder: number }>() }
       for (const worktreeId of drop.worktreeIds) {

--- a/src/renderer/src/components/sidebar/use-workspace-kanban-worktree-actions.ts
+++ b/src/renderer/src/components/sidebar/use-workspace-kanban-worktree-actions.ts
@@ -23,6 +23,7 @@ export function useWorkspaceKanbanWorktreeActions(args: {
   updateWorktreesMeta: ReturnType<typeof useAppStore.getState>['updateWorktreesMeta']
   workspaceStatuses: ReturnType<typeof useAppStore.getState>['workspaceStatuses']
   worktreeById: ReadonlyMap<string, Worktree>
+  allWorktreeIds: readonly string[]
   worktreesByStatus: ReadonlyMap<string, readonly Worktree[]>
 }) {
   const recordInteraction = (): void => {
@@ -90,12 +91,12 @@ export function useWorkspaceKanbanWorktreeActions(args: {
         drop.writeManualOrder ?? shouldWriteDropManualOrder(drop.worktreeIds, drop.status)
       const rankByWorktreeId = writeManualOrder
         ? new Map(
-            args.boardDragGroups.flatMap((group) =>
-              group.worktreeIds.flatMap((worktreeId) => {
-                const worktree = args.worktreeById.get(worktreeId)
-                return worktree ? [[worktreeId, worktree.manualOrder ?? worktree.sortOrder]] : []
-              })
-            )
+            args.allWorktreeIds.flatMap((worktreeId) => {
+              const worktree = args.worktreeById.get(worktreeId)
+              return worktree?.manualOrder !== undefined
+                ? [[worktreeId, worktree.manualOrder] as const]
+                : []
+            })
           )
         : undefined
       const order = writeManualOrder
@@ -105,7 +106,8 @@ export function useWorkspaceKanbanWorktreeActions(args: {
             draggedIds: drop.worktreeIds,
             dropIndex: drop.dropIndex,
             now: Date.now(),
-            rankByWorktreeId
+            rankByWorktreeId,
+            allWorktreeIds: args.allWorktreeIds
           })
         : { changed: false, updates: new Map<string, { manualOrder: number }>() }
       for (const worktreeId of drop.worktreeIds) {

--- a/src/renderer/src/components/sidebar/workspace-kanban-sidebar-drop.test.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-sidebar-drop.test.ts
@@ -566,6 +566,8 @@ describe('workspace kanban sidebar drop updates', () => {
         { key: 'doing', worktreeIds: ['doing-a'] }
       ],
       worktreeById,
+      allWorktreeIds: [...worktreeById.keys()],
+      rankByWorktreeId: new Map(),
       workspaceStatuses,
       sortBy: 'recent',
       now: 10_000
@@ -591,6 +593,8 @@ describe('workspace kanban sidebar drop updates', () => {
         { key: 'doing', worktreeIds: ['doing-a', 'doing-b'] }
       ],
       worktreeById,
+      allWorktreeIds: [...worktreeById.keys()],
+      rankByWorktreeId: new Map(),
       workspaceStatuses,
       sortBy: 'manual',
       now: 10_000
@@ -603,5 +607,63 @@ describe('workspace kanban sidebar drop updates', () => {
     })
     expect(result.updates.get('doing-a')).toEqual({ manualOrder: 10_000 })
     expect(result.updates.get('doing-b')).toEqual({ manualOrder: 8000 })
+  })
+
+  it('keeps board drops sparse when filtered rows already have durable ranks', () => {
+    const worktreeById = new Map([
+      [
+        'todo-a',
+        worktree({
+          id: 'todo-a',
+          workspaceStatus: 'todo',
+          sortOrder: 4000,
+          manualOrder: 4000
+        })
+      ],
+      [
+        'doing-a',
+        worktree({
+          id: 'doing-a',
+          workspaceStatus: 'doing',
+          sortOrder: 2000,
+          manualOrder: 2000
+        })
+      ],
+      [
+        'doing-b',
+        worktree({
+          id: 'doing-b',
+          workspaceStatus: 'doing',
+          sortOrder: 1000,
+          manualOrder: 1000
+        })
+      ]
+    ])
+    const rankByWorktreeId = new Map([
+      ['todo-a', 4000],
+      ['filtered', 3000],
+      ['doing-a', 2000],
+      ['doing-b', 1000]
+    ])
+
+    const result = buildWorkspaceKanbanSidebarDropUpdates({
+      worktreeIds: ['todo-a'],
+      status: 'doing',
+      dropIndex: 1,
+      groups: [
+        { key: 'todo', worktreeIds: ['todo-a'] },
+        { key: 'doing', worktreeIds: ['doing-a', 'doing-b'] }
+      ],
+      worktreeById,
+      allWorktreeIds: ['todo-a', 'filtered', 'doing-a', 'doing-b'],
+      rankByWorktreeId,
+      workspaceStatuses,
+      sortBy: 'manual',
+      now: 10_000
+    })
+
+    expect([...result.updates]).toEqual([
+      ['todo-a', { workspaceStatus: 'doing', manualOrder: 1500 }]
+    ])
   })
 })

--- a/src/renderer/src/components/sidebar/workspace-kanban-sidebar-drop.test.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-sidebar-drop.test.ts
@@ -599,7 +599,9 @@ describe('workspace kanban sidebar drop updates', () => {
     expect(result.shouldSwitchToManual).toBe(true)
     expect(result.updates.get('todo-a')).toEqual({
       workspaceStatus: 'doing',
-      manualOrder: 1500
+      manualOrder: 9000
     })
+    expect(result.updates.get('doing-a')).toEqual({ manualOrder: 10_000 })
+    expect(result.updates.get('doing-b')).toEqual({ manualOrder: 8000 })
   })
 })

--- a/src/renderer/src/components/sidebar/workspace-kanban-sidebar-drop.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-sidebar-drop.ts
@@ -215,7 +215,8 @@ export function buildWorkspaceKanbanSidebarDropUpdates(args: {
   dropIndex: number
   groups: readonly WorktreeDragGroup[]
   worktreeById: ReadonlyMap<string, Worktree>
-  allWorktreeIds?: readonly string[]
+  allWorktreeIds: readonly string[]
+  rankByWorktreeId: ReadonlyMap<string, number>
   workspaceStatuses: readonly WorkspaceStatusDefinition[]
   sortBy: string
   now: number
@@ -232,22 +233,6 @@ export function buildWorkspaceKanbanSidebarDropUpdates(args: {
     sourceGroupKeys,
     targetGroupKey: args.status
   })
-  const rankByWorktreeId = writeManualOrder
-    ? (() => {
-        const ranks = new Map<string, number>()
-        for (const group of args.groups) {
-          for (const worktreeId of group.worktreeIds) {
-            const worktree = args.worktreeById.get(worktreeId)
-            if (worktree) {
-              if (worktree.manualOrder !== undefined) {
-                ranks.set(worktreeId, worktree.manualOrder)
-              }
-            }
-          }
-        }
-        return ranks
-      })()
-    : undefined
   const order = writeManualOrder
     ? buildManualOrderUpdatesForGroupDrop({
         groups: args.groups,
@@ -255,7 +240,7 @@ export function buildWorkspaceKanbanSidebarDropUpdates(args: {
         draggedIds: args.worktreeIds,
         dropIndex: args.dropIndex,
         now: args.now,
-        rankByWorktreeId,
+        rankByWorktreeId: args.rankByWorktreeId,
         allWorktreeIds: args.allWorktreeIds
       })
     : { changed: false, updates: new Map<string, { manualOrder: number }>() }

--- a/src/renderer/src/components/sidebar/workspace-kanban-sidebar-drop.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-sidebar-drop.ts
@@ -215,6 +215,7 @@ export function buildWorkspaceKanbanSidebarDropUpdates(args: {
   dropIndex: number
   groups: readonly WorktreeDragGroup[]
   worktreeById: ReadonlyMap<string, Worktree>
+  allWorktreeIds?: readonly string[]
   workspaceStatuses: readonly WorkspaceStatusDefinition[]
   sortBy: string
   now: number
@@ -238,7 +239,9 @@ export function buildWorkspaceKanbanSidebarDropUpdates(args: {
           for (const worktreeId of group.worktreeIds) {
             const worktree = args.worktreeById.get(worktreeId)
             if (worktree) {
-              ranks.set(worktreeId, worktree.manualOrder ?? worktree.sortOrder)
+              if (worktree.manualOrder !== undefined) {
+                ranks.set(worktreeId, worktree.manualOrder)
+              }
             }
           }
         }
@@ -252,7 +255,8 @@ export function buildWorkspaceKanbanSidebarDropUpdates(args: {
         draggedIds: args.worktreeIds,
         dropIndex: args.dropIndex,
         now: args.now,
-        rankByWorktreeId
+        rankByWorktreeId,
+        allWorktreeIds: args.allWorktreeIds
       })
     : { changed: false, updates: new Map<string, { manualOrder: number }>() }
 

--- a/src/renderer/src/components/sidebar/worktree-list/drag/use-status-mutations.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/drag/use-status-mutations.ts
@@ -19,14 +19,21 @@ import type { WorktreeStatusDropAtIndexArgs } from './drop-commit-context'
 
 function buildRankByWorktreeId(
   groups: readonly WorktreeDragGroup[],
-  worktreeMap: Map<string, Worktree>
+  worktreeMap: Map<string, Worktree>,
+  allWorktreeIds: readonly string[]
 ): Map<string, number> {
   const rankByWorktreeId = new Map<string, number>()
+  for (const worktreeId of allWorktreeIds) {
+    const worktree = worktreeMap.get(worktreeId)
+    if (worktree?.manualOrder !== undefined) {
+      rankByWorktreeId.set(worktreeId, worktree.manualOrder)
+    }
+  }
   for (const group of groups) {
     for (const worktreeId of group.worktreeIds) {
       const worktree = worktreeMap.get(worktreeId)
-      if (worktree) {
-        rankByWorktreeId.set(worktreeId, worktree.manualOrder ?? worktree.sortOrder)
+      if (worktree?.manualOrder !== undefined) {
+        rankByWorktreeId.set(worktreeId, worktree.manualOrder)
       }
     }
   }
@@ -36,10 +43,11 @@ function buildRankByWorktreeId(
 // Every write a sidebar drop can make: status changes, pin, manual order, and the board lane drop.
 export function useWorktreeStatusMutations(args: {
   worktreeMap: Map<string, Worktree>
+  allWorktreeIds: readonly string[]
   workspaceStatuses: readonly WorkspaceStatusDefinition[]
   sortBy: SortBy
 }) {
-  const { worktreeMap, workspaceStatuses, sortBy } = args
+  const { allWorktreeIds, worktreeMap, workspaceStatuses, sortBy } = args
   const updateWorktreeMeta = useAppStore((s) => s.updateWorktreeMeta)
   const updateWorktreesMeta = useAppStore((s) => s.updateWorktreesMeta)
   const setSortBy = useAppStore((s) => s.setSortBy)
@@ -81,7 +89,8 @@ export function useWorktreeStatusMutations(args: {
         draggedIds: dropArgs.worktreeIds,
         dropIndex: dropArgs.dropIndex,
         now: Date.now(),
-        rankByWorktreeId: buildRankByWorktreeId(dropArgs.groups, worktreeMap)
+        rankByWorktreeId: buildRankByWorktreeId(dropArgs.groups, worktreeMap, allWorktreeIds),
+        allWorktreeIds
       })
       const updates = new Map<string, Partial<WorktreeMeta>>()
       for (const worktreeId of dropArgs.worktreeIds) {
@@ -112,7 +121,7 @@ export function useWorktreeStatusMutations(args: {
       }
       void updateWorktreesMeta(updates)
     },
-    [setSortBy, updateWorktreesMeta, worktreeMap, workspaceStatuses]
+    [allWorktreeIds, setSortBy, updateWorktreesMeta, worktreeMap, workspaceStatuses]
   )
 
   const pinWorktree = useCallback(
@@ -139,7 +148,8 @@ export function useWorktreeStatusMutations(args: {
       const result = buildManualOrderUpdatesForVisibleGroups({
         ...reorderArgs,
         now: Date.now(),
-        rankByWorktreeId: buildRankByWorktreeId(reorderArgs.groups, worktreeMap)
+        rankByWorktreeId: buildRankByWorktreeId(reorderArgs.groups, worktreeMap, allWorktreeIds),
+        allWorktreeIds
       })
       if (!result.changed) {
         return
@@ -148,7 +158,7 @@ export function useWorktreeStatusMutations(args: {
       setSortBy('manual')
       void updateWorktreesMeta(result.updates)
     },
-    [setSortBy, updateWorktreesMeta, worktreeMap]
+    [allWorktreeIds, setSortBy, updateWorktreesMeta, worktreeMap]
   )
 
   const shouldShowWorkspaceBoardDropIndicator = useCallback(
@@ -173,7 +183,8 @@ export function useWorktreeStatusMutations(args: {
         worktreeById: worktreeMap,
         workspaceStatuses,
         sortBy,
-        now: Date.now()
+        now: Date.now(),
+        allWorktreeIds
       })
       if (result.updates.size === 0) {
         return
@@ -185,7 +196,7 @@ export function useWorktreeStatusMutations(args: {
       useAppStore.getState().recordFeatureInteraction('workspace-board-actions')
       void updateWorktreesMeta(result.updates)
     },
-    [setSortBy, sortBy, updateWorktreesMeta, worktreeMap, workspaceStatuses]
+    [allWorktreeIds, setSortBy, sortBy, updateWorktreesMeta, worktreeMap, workspaceStatuses]
   )
 
   return {

--- a/src/renderer/src/components/sidebar/worktree-list/drag/use-status-mutations.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/drag/use-status-mutations.ts
@@ -16,38 +16,16 @@ import {
 import { buildWorkspaceKanbanSidebarDropUpdates } from '../../workspace-kanban-sidebar-drop'
 import type { SortBy } from '../../smart-sort'
 import type { WorktreeStatusDropAtIndexArgs } from './drop-commit-context'
-
-function buildRankByWorktreeId(
-  groups: readonly WorktreeDragGroup[],
-  worktreeMap: Map<string, Worktree>,
-  allWorktreeIds: readonly string[]
-): Map<string, number> {
-  const rankByWorktreeId = new Map<string, number>()
-  for (const worktreeId of allWorktreeIds) {
-    const worktree = worktreeMap.get(worktreeId)
-    if (worktree?.manualOrder !== undefined) {
-      rankByWorktreeId.set(worktreeId, worktree.manualOrder)
-    }
-  }
-  for (const group of groups) {
-    for (const worktreeId of group.worktreeIds) {
-      const worktree = worktreeMap.get(worktreeId)
-      if (worktree?.manualOrder !== undefined) {
-        rankByWorktreeId.set(worktreeId, worktree.manualOrder)
-      }
-    }
-  }
-  return rankByWorktreeId
-}
+import type { WorktreeManualOrderCatalog } from '../../worktree-manual-order-catalog'
 
 // Every write a sidebar drop can make: status changes, pin, manual order, and the board lane drop.
 export function useWorktreeStatusMutations(args: {
   worktreeMap: Map<string, Worktree>
-  allWorktreeIds: readonly string[]
+  manualOrderCatalog: WorktreeManualOrderCatalog
   workspaceStatuses: readonly WorkspaceStatusDefinition[]
   sortBy: SortBy
 }) {
-  const { allWorktreeIds, worktreeMap, workspaceStatuses, sortBy } = args
+  const { manualOrderCatalog, worktreeMap, workspaceStatuses, sortBy } = args
   const updateWorktreeMeta = useAppStore((s) => s.updateWorktreeMeta)
   const updateWorktreesMeta = useAppStore((s) => s.updateWorktreesMeta)
   const setSortBy = useAppStore((s) => s.setSortBy)
@@ -89,8 +67,8 @@ export function useWorktreeStatusMutations(args: {
         draggedIds: dropArgs.worktreeIds,
         dropIndex: dropArgs.dropIndex,
         now: Date.now(),
-        rankByWorktreeId: buildRankByWorktreeId(dropArgs.groups, worktreeMap, allWorktreeIds),
-        allWorktreeIds
+        rankByWorktreeId: manualOrderCatalog.rankByWorktreeId,
+        allWorktreeIds: manualOrderCatalog.orderedIds
       })
       const updates = new Map<string, Partial<WorktreeMeta>>()
       for (const worktreeId of dropArgs.worktreeIds) {
@@ -121,7 +99,7 @@ export function useWorktreeStatusMutations(args: {
       }
       void updateWorktreesMeta(updates)
     },
-    [allWorktreeIds, setSortBy, updateWorktreesMeta, worktreeMap, workspaceStatuses]
+    [manualOrderCatalog, setSortBy, updateWorktreesMeta, worktreeMap, workspaceStatuses]
   )
 
   const pinWorktree = useCallback(
@@ -148,8 +126,8 @@ export function useWorktreeStatusMutations(args: {
       const result = buildManualOrderUpdatesForVisibleGroups({
         ...reorderArgs,
         now: Date.now(),
-        rankByWorktreeId: buildRankByWorktreeId(reorderArgs.groups, worktreeMap, allWorktreeIds),
-        allWorktreeIds
+        rankByWorktreeId: manualOrderCatalog.rankByWorktreeId,
+        allWorktreeIds: manualOrderCatalog.orderedIds
       })
       if (!result.changed) {
         return
@@ -158,7 +136,7 @@ export function useWorktreeStatusMutations(args: {
       setSortBy('manual')
       void updateWorktreesMeta(result.updates)
     },
-    [allWorktreeIds, setSortBy, updateWorktreesMeta, worktreeMap]
+    [manualOrderCatalog, setSortBy, updateWorktreesMeta]
   )
 
   const shouldShowWorkspaceBoardDropIndicator = useCallback(
@@ -184,7 +162,8 @@ export function useWorktreeStatusMutations(args: {
         workspaceStatuses,
         sortBy,
         now: Date.now(),
-        allWorktreeIds
+        allWorktreeIds: manualOrderCatalog.orderedIds,
+        rankByWorktreeId: manualOrderCatalog.rankByWorktreeId
       })
       if (result.updates.size === 0) {
         return
@@ -196,7 +175,7 @@ export function useWorktreeStatusMutations(args: {
       useAppStore.getState().recordFeatureInteraction('workspace-board-actions')
       void updateWorktreesMeta(result.updates)
     },
-    [allWorktreeIds, setSortBy, sortBy, updateWorktreesMeta, worktreeMap, workspaceStatuses]
+    [manualOrderCatalog, setSortBy, sortBy, updateWorktreesMeta, worktreeMap, workspaceStatuses]
   )
 
   return {

--- a/src/renderer/src/components/sidebar/worktree-manual-order-catalog.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-manual-order-catalog.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
+import type { Worktree } from '../../../../shared/worktree/types'
+import { worktree } from './worktree-list-groups-test-fixtures'
+import { buildWorktreeManualOrderCatalog } from './worktree-manual-order-catalog'
+
+function row(id: string, overrides: Partial<Worktree> = {}): Worktree {
+  return { ...worktree, id, displayName: id, ...overrides }
+}
+
+function folder(overrides: Partial<FolderWorkspace> = {}): FolderWorkspace {
+  return {
+    id: 'folder-1',
+    projectGroupId: 'group-1',
+    name: 'Folder',
+    folderPath: '/tmp/folder',
+    linkedTask: null,
+    comment: '',
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 200,
+    lastActivityAt: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+describe('buildWorktreeManualOrderCatalog', () => {
+  it('includes filtered-capable git and folder rows in fallback order', () => {
+    const catalog = buildWorktreeManualOrderCatalog({
+      worktrees: [row('low', { sortOrder: 100 }), row('high', { sortOrder: 300 })],
+      folderWorkspaces: [folder()]
+    })
+
+    expect(catalog.orderedIds).toEqual(['high', 'folder:folder-1', 'low'])
+    expect(catalog.rankByWorktreeId.size).toBe(0)
+  })
+
+  it('treats a same-id host cluster as durable only when every owner agrees', () => {
+    const sameId = 'repo::/same'
+    const complete = buildWorktreeManualOrderCatalog({
+      worktrees: [
+        row(sameId, { hostId: 'local', manualOrder: 900 }),
+        row(sameId, { hostId: 'ssh:openclaw', manualOrder: 900 })
+      ],
+      folderWorkspaces: []
+    })
+    const incomplete = buildWorktreeManualOrderCatalog({
+      worktrees: [
+        row(sameId, { hostId: 'local', manualOrder: 900 }),
+        row(sameId, { hostId: 'ssh:openclaw', manualOrder: undefined })
+      ],
+      folderWorkspaces: []
+    })
+
+    expect(complete.orderedIds).toEqual([sameId])
+    expect(complete.rankByWorktreeId.get(sameId)).toBe(900)
+    expect(incomplete.rankByWorktreeId.has(sameId)).toBe(false)
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-manual-order-catalog.ts
+++ b/src/renderer/src/components/sidebar/worktree-manual-order-catalog.ts
@@ -1,0 +1,49 @@
+import type { FolderWorkspace } from '../../../../shared/folder-workspace-types'
+import { folderWorkspaceToWorktree } from '../../../../shared/folder-workspace-worktree'
+import type { Worktree } from '../../../../shared/worktree/types'
+import { compareWorktreeSortLabel } from './smart-sort'
+
+export type WorktreeManualOrderCatalog = {
+  orderedIds: readonly string[]
+  rankByWorktreeId: ReadonlyMap<string, number>
+}
+
+export function buildWorktreeManualOrderCatalog(args: {
+  worktrees: readonly Worktree[]
+  folderWorkspaces: readonly FolderWorkspace[]
+}): WorktreeManualOrderCatalog {
+  const rows = [
+    ...args.worktrees,
+    ...args.folderWorkspaces.map((workspace) => folderWorkspaceToWorktree(workspace))
+  ]
+    .filter((row) => !row.isArchived)
+    .sort(
+      (left, right) =>
+        (right.manualOrder ?? right.sortOrder) - (left.manualOrder ?? left.sortOrder) ||
+        compareWorktreeSortLabel(left, right)
+    )
+  const rowsById = new Map<string, Worktree[]>()
+  for (const row of rows) {
+    const matches = rowsById.get(row.id)
+    if (matches) {
+      matches.push(row)
+    } else {
+      rowsById.set(row.id, [row])
+    }
+  }
+
+  const orderedIds = [...rowsById.keys()]
+  const rankByWorktreeId = new Map<string, number>()
+  for (const [worktreeId, matches] of rowsById) {
+    const ranks = matches.map((row) => row.manualOrder)
+    const rank = ranks[0]
+    if (
+      typeof rank === 'number' &&
+      Number.isFinite(rank) &&
+      ranks.every((candidate) => candidate === rank)
+    ) {
+      rankByWorktreeId.set(worktreeId, rank)
+    }
+  }
+  return { orderedIds, rankByWorktreeId }
+}

--- a/src/renderer/src/components/sidebar/worktree-manual-order-ranks.ts
+++ b/src/renderer/src/components/sidebar/worktree-manual-order-ranks.ts
@@ -15,6 +15,30 @@ function buildFallbackManualOrderUpdates(
   return updates
 }
 
+function mergeVisibleOrderIntoKnownOrder(
+  knownIds: readonly string[],
+  visibleOrder: readonly string[]
+): string[] {
+  const visibleSet = new Set(visibleOrder)
+  if (!knownIds.some((id) => visibleSet.has(id))) {
+    return [...knownIds, ...visibleOrder.filter((id) => !knownIds.includes(id))]
+  }
+
+  const merged: string[] = []
+  let visibleIndex = 0
+  for (let index = 0; index < knownIds.length; index++) {
+    const id = knownIds[index]!
+    if (visibleSet.has(id)) {
+      merged.push(visibleOrder[visibleIndex] ?? id)
+      visibleIndex++
+      continue
+    }
+    merged.push(id)
+  }
+  merged.push(...visibleOrder.slice(visibleIndex).filter((id) => !knownIds.includes(id)))
+  return merged
+}
+
 function getManualOrderRank(
   rankByWorktreeId: ReadonlyMap<string, number>,
   worktreeId: string | undefined
@@ -30,6 +54,8 @@ export function buildSparseManualOrderUpdates(args: {
   orderedIds: readonly string[]
   movedIds: readonly string[]
   rankByWorktreeId?: ReadonlyMap<string, number>
+  /** Current order of every known row, including filtered/collapsed rows. */
+  allWorktreeIds?: readonly string[]
   now: number
 }): Map<string, WorktreeManualOrderUpdate> {
   const movedSet = new Set(args.movedIds)
@@ -39,6 +65,19 @@ export function buildSparseManualOrderUpdates(args: {
   }
   if (!args.rankByWorktreeId) {
     return buildFallbackManualOrderUpdates(args.orderedIds, args.now)
+  }
+
+  // Why: Manual is a durable sequence, not a rank for only the rendered slice.
+  // Materialize every known row once when any row is still on the mutable
+  // sortOrder fallback; subsequent drags can use sparse ranks again.
+  if (
+    args.allWorktreeIds &&
+    args.allWorktreeIds.some((id) => getManualOrderRank(args.rankByWorktreeId!, id) === null)
+  ) {
+    return buildFallbackManualOrderUpdates(
+      mergeVisibleOrderIntoKnownOrder(args.allWorktreeIds, args.orderedIds),
+      args.now
+    )
   }
 
   const firstMovedIndex = args.orderedIds.findIndex((id) => movedSet.has(id))

--- a/src/renderer/src/components/sidebar/worktree-manual-order-ranks.ts
+++ b/src/renderer/src/components/sidebar/worktree-manual-order-ranks.ts
@@ -89,10 +89,16 @@ export function buildSparseManualOrderUpdates(args: {
   const nextRanks: number[] = []
 
   if (beforeId !== undefined && beforeRank === null) {
-    return buildFallbackManualOrderUpdates(args.orderedIds, args.now)
+    return buildFallbackManualOrderUpdates(
+      mergeVisibleOrderIntoKnownOrder(args.allWorktreeIds, args.orderedIds),
+      args.now
+    )
   }
   if (afterId !== undefined && afterRank === null) {
-    return buildFallbackManualOrderUpdates(args.orderedIds, args.now)
+    return buildFallbackManualOrderUpdates(
+      mergeVisibleOrderIntoKnownOrder(args.allWorktreeIds, args.orderedIds),
+      args.now
+    )
   }
 
   if (beforeRank === null && afterRank === null) {
@@ -113,7 +119,10 @@ export function buildSparseManualOrderUpdates(args: {
     // Why: repeated sparse inserts can eventually exhaust the numeric gap.
     // Re-index only in that rare dense case; ordinary drags persist moved rows.
     if (gap <= orderedMovedIds.length) {
-      return buildFallbackManualOrderUpdates(args.orderedIds, args.now)
+      return buildFallbackManualOrderUpdates(
+        mergeVisibleOrderIntoKnownOrder(args.allWorktreeIds, args.orderedIds),
+        args.now
+      )
     }
     const step = gap / (orderedMovedIds.length + 1)
     for (let index = 0; index < orderedMovedIds.length; index++) {

--- a/src/renderer/src/components/sidebar/worktree-manual-order-ranks.ts
+++ b/src/renderer/src/components/sidebar/worktree-manual-order-ranks.ts
@@ -19,23 +19,23 @@ function mergeVisibleOrderIntoKnownOrder(
   knownIds: readonly string[],
   visibleOrder: readonly string[]
 ): string[] {
-  const visibleSet = new Set(visibleOrder)
-  if (!knownIds.some((id) => visibleSet.has(id))) {
-    return [...knownIds, ...visibleOrder.filter((id) => !knownIds.includes(id))]
-  }
+  const uniqueKnownIds = [...new Set(knownIds)]
+  const knownSet = new Set(uniqueKnownIds)
+  const uniqueVisibleOrder = [...new Set(visibleOrder)]
+  const knownVisibleOrder = uniqueVisibleOrder.filter((id) => knownSet.has(id))
+  const visibleSet = new Set(knownVisibleOrder)
 
   const merged: string[] = []
   let visibleIndex = 0
-  for (let index = 0; index < knownIds.length; index++) {
-    const id = knownIds[index]!
+  for (const id of uniqueKnownIds) {
     if (visibleSet.has(id)) {
-      merged.push(visibleOrder[visibleIndex] ?? id)
+      merged.push(knownVisibleOrder[visibleIndex] ?? id)
       visibleIndex++
       continue
     }
     merged.push(id)
   }
-  merged.push(...visibleOrder.slice(visibleIndex).filter((id) => !knownIds.includes(id)))
+  merged.push(...uniqueVisibleOrder.filter((id) => !knownSet.has(id)))
   return merged
 }
 
@@ -55,7 +55,7 @@ export function buildSparseManualOrderUpdates(args: {
   movedIds: readonly string[]
   rankByWorktreeId?: ReadonlyMap<string, number>
   /** Current order of every known row, including filtered/collapsed rows. */
-  allWorktreeIds?: readonly string[]
+  allWorktreeIds: readonly string[]
   now: number
 }): Map<string, WorktreeManualOrderUpdate> {
   const movedSet = new Set(args.movedIds)
@@ -64,16 +64,16 @@ export function buildSparseManualOrderUpdates(args: {
     return new Map()
   }
   if (!args.rankByWorktreeId) {
-    return buildFallbackManualOrderUpdates(args.orderedIds, args.now)
+    return buildFallbackManualOrderUpdates(
+      mergeVisibleOrderIntoKnownOrder(args.allWorktreeIds, args.orderedIds),
+      args.now
+    )
   }
 
   // Why: Manual is a durable sequence, not a rank for only the rendered slice.
   // Materialize every known row once when any row is still on the mutable
   // sortOrder fallback; subsequent drags can use sparse ranks again.
-  if (
-    args.allWorktreeIds &&
-    args.allWorktreeIds.some((id) => getManualOrderRank(args.rankByWorktreeId!, id) === null)
-  ) {
+  if (args.allWorktreeIds.some((id) => getManualOrderRank(args.rankByWorktreeId!, id) === null)) {
     return buildFallbackManualOrderUpdates(
       mergeVisibleOrderIntoKnownOrder(args.allWorktreeIds, args.orderedIds),
       args.now

--- a/src/renderer/src/components/sidebar/worktree-manual-order.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-manual-order.test.ts
@@ -57,6 +57,39 @@ describe('buildSparseManualOrderUpdates durable migration', () => {
 
     expect([...result.keys()]).toEqual(['b', 'a', 'hidden', 'c', 'unknown'])
   })
+
+  it('preserves hidden rows when dense ranks require a full reindex', () => {
+    const result = buildSparseManualOrderUpdates({
+      orderedIds: ['a', 'c', 'b'],
+      movedIds: ['c'],
+      allWorktreeIds: ['a', 'hidden', 'b', 'c'],
+      rankByWorktreeId: new Map([
+        ['a', 3],
+        ['hidden', 2.5],
+        ['b', 2],
+        ['c', 1]
+      ]),
+      now: 10_000
+    })
+
+    expect([...result.keys()]).toEqual(['a', 'hidden', 'c', 'b'])
+  })
+
+  it('preserves hidden rows when a stale neighbor requires a full reindex', () => {
+    const result = buildSparseManualOrderUpdates({
+      orderedIds: ['stale', 'b', 'a'],
+      movedIds: ['b'],
+      allWorktreeIds: ['a', 'hidden', 'b'],
+      rankByWorktreeId: new Map([
+        ['a', 3000],
+        ['hidden', 2000],
+        ['b', 1000]
+      ]),
+      now: 10_000
+    })
+
+    expect([...result.keys()]).toEqual(['b', 'hidden', 'a', 'stale'])
+  })
 })
 
 describe('expandDraggedWorktreeIdsForVisibleLineage', () => {

--- a/src/renderer/src/components/sidebar/worktree-manual-order.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-manual-order.test.ts
@@ -7,6 +7,45 @@ import {
   moveWorktreeIdsWithinGroup,
   shouldWriteManualOrderForGroupDrop
 } from './worktree-manual-order'
+import { buildSparseManualOrderUpdates } from './worktree-manual-order-ranks'
+
+describe('buildSparseManualOrderUpdates durable migration', () => {
+  it('materializes filtered rows when the first drag creates Manual order', () => {
+    const result = buildSparseManualOrderUpdates({
+      orderedIds: ['a', 'c', 'b'],
+      movedIds: ['b'],
+      allWorktreeIds: ['a', 'b', 'hidden', 'c'],
+      rankByWorktreeId: new Map([
+        ['a', 4000],
+        ['b', 3000],
+        ['c', 1000]
+      ]),
+      now: 10_000
+    })
+
+    expect([...result.keys()]).toEqual(['a', 'c', 'hidden', 'b'])
+    expect([...result.values()].map((update) => update.manualOrder)).toEqual([
+      10_000, 9000, 8000, 7000
+    ])
+  })
+
+  it('keeps sparse updates after every known row has a durable rank', () => {
+    const result = buildSparseManualOrderUpdates({
+      orderedIds: ['a', 'c', 'b'],
+      movedIds: ['b'],
+      allWorktreeIds: ['a', 'b', 'hidden', 'c'],
+      rankByWorktreeId: new Map([
+        ['a', 4000],
+        ['b', 3000],
+        ['hidden', 2000],
+        ['c', 1000]
+      ]),
+      now: 10_000
+    })
+
+    expect([...result]).toEqual([['b', { manualOrder: 0 }]])
+  })
+})
 
 describe('expandDraggedWorktreeIdsForVisibleLineage', () => {
   it('expands an expanded lineage parent to its visible descendants for reordering', () => {

--- a/src/renderer/src/components/sidebar/worktree-manual-order.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-manual-order.test.ts
@@ -45,6 +45,18 @@ describe('buildSparseManualOrderUpdates durable migration', () => {
 
     expect([...result]).toEqual([['b', { manualOrder: 0 }]])
   })
+
+  it('never drops known rows when a stale visible sequence contains unknowns or duplicates', () => {
+    const result = buildSparseManualOrderUpdates({
+      orderedIds: ['unknown', 'b', 'b', 'a'],
+      movedIds: ['b'],
+      allWorktreeIds: ['a', 'b', 'hidden', 'c', 'c'],
+      rankByWorktreeId: new Map(),
+      now: 10_000
+    })
+
+    expect([...result.keys()]).toEqual(['b', 'a', 'hidden', 'c', 'unknown'])
+  })
 })
 
 describe('expandDraggedWorktreeIdsForVisibleLineage', () => {
@@ -277,6 +289,7 @@ describe('buildManualOrderUpdatesForVisibleGroups', () => {
       sourceGroupKey: 'workspace-status:todo',
       draggedIds: ['todo-b'],
       dropIndex: 0,
+      allWorktreeIds: ['todo-a', 'todo-b', 'done-a', 'done-b'],
       now: 10_000
     })
 
@@ -296,6 +309,7 @@ describe('buildManualOrderUpdatesForVisibleGroups', () => {
       sourceGroupKey: 'repo:one',
       draggedIds: ['a'],
       dropIndex: 1,
+      allWorktreeIds: ['a', 'b'],
       now: 10_000
     })
 
@@ -309,6 +323,7 @@ describe('buildManualOrderUpdatesForVisibleGroups', () => {
       sourceGroupKey: 'repo:one',
       draggedIds: ['b'],
       dropIndex: 4,
+      allWorktreeIds: ['a', 'b', 'c', 'd'],
       now: 10_000,
       rankByWorktreeId: new Map([
         ['a', 4000],
@@ -328,6 +343,7 @@ describe('buildManualOrderUpdatesForVisibleGroups', () => {
       sourceGroupKey: 'all',
       draggedIds: ['parent', 'child'],
       dropIndex: 3,
+      allWorktreeIds: ['parent', 'child', 'other'],
       now: 10_000,
       rankByWorktreeId: new Map([
         ['parent', 3000],
@@ -354,6 +370,7 @@ describe('buildManualOrderUpdatesForVisibleGroups', () => {
       sourceGroupKey: 'all',
       draggedIds: ['wt-0'],
       dropIndex: ids.length,
+      allWorktreeIds: ids,
       now: 10_000,
       rankByWorktreeId
     })
@@ -376,6 +393,7 @@ describe('buildManualOrderUpdatesForGroupDrop', () => {
       targetGroupKey: 'doing',
       draggedIds: ['todo-b'],
       dropIndex: 1,
+      allWorktreeIds: ['todo-a', 'todo-b', 'doing-a', 'doing-b'],
       now: 10_000
     })
 
@@ -398,6 +416,7 @@ describe('buildManualOrderUpdatesForGroupDrop', () => {
       targetGroupKey: 'doing',
       draggedIds: ['d', 'b'],
       dropIndex: 0,
+      allWorktreeIds: ['a', 'b', 'c', 'd'],
       now: 10_000
     })
 
@@ -410,6 +429,7 @@ describe('buildManualOrderUpdatesForGroupDrop', () => {
       targetGroupKey: 'doing',
       draggedIds: ['a'],
       dropIndex: 1,
+      allWorktreeIds: ['a', 'b'],
       now: 10_000
     })
 
@@ -426,6 +446,7 @@ describe('buildManualOrderUpdatesForGroupDrop', () => {
       targetGroupKey: 'doing',
       draggedIds: ['todo-b'],
       dropIndex: 1,
+      allWorktreeIds: ['todo-a', 'todo-b', 'doing-a', 'doing-b'],
       now: 10_000,
       rankByWorktreeId: new Map([
         ['todo-a', 4000],

--- a/src/renderer/src/components/sidebar/worktree-manual-order.ts
+++ b/src/renderer/src/components/sidebar/worktree-manual-order.ts
@@ -119,7 +119,7 @@ export function buildManualOrderUpdatesForVisibleGroups(args: {
   dropIndex: number
   now: number
   rankByWorktreeId?: ReadonlyMap<string, number>
-  allWorktreeIds?: readonly string[]
+  allWorktreeIds: readonly string[]
 }): {
   changed: boolean
   orderedIds: string[]
@@ -163,7 +163,7 @@ export function buildManualOrderUpdatesForGroupDrop(args: {
   dropIndex: number
   now: number
   rankByWorktreeId?: ReadonlyMap<string, number>
-  allWorktreeIds?: readonly string[]
+  allWorktreeIds: readonly string[]
 }): {
   changed: boolean
   orderedIds: string[]

--- a/src/renderer/src/components/sidebar/worktree-manual-order.ts
+++ b/src/renderer/src/components/sidebar/worktree-manual-order.ts
@@ -119,6 +119,7 @@ export function buildManualOrderUpdatesForVisibleGroups(args: {
   dropIndex: number
   now: number
   rankByWorktreeId?: ReadonlyMap<string, number>
+  allWorktreeIds?: readonly string[]
 }): {
   changed: boolean
   orderedIds: string[]
@@ -149,6 +150,7 @@ export function buildManualOrderUpdatesForVisibleGroups(args: {
       orderedIds,
       movedIds: args.draggedIds,
       rankByWorktreeId: args.rankByWorktreeId,
+      allWorktreeIds: args.allWorktreeIds,
       now: args.now
     })
   }
@@ -161,6 +163,7 @@ export function buildManualOrderUpdatesForGroupDrop(args: {
   dropIndex: number
   now: number
   rankByWorktreeId?: ReadonlyMap<string, number>
+  allWorktreeIds?: readonly string[]
 }): {
   changed: boolean
   orderedIds: string[]
@@ -226,6 +229,7 @@ export function buildManualOrderUpdatesForGroupDrop(args: {
       orderedIds,
       movedIds: orderedDraggedIds,
       rankByWorktreeId: args.rankByWorktreeId,
+      allWorktreeIds: args.allWorktreeIds,
       now: args.now
     })
   }

--- a/src/renderer/src/store/slices/folder-workspace-owner-routed-mutations.test.ts
+++ b/src/renderer/src/store/slices/folder-workspace-owner-routed-mutations.test.ts
@@ -7,6 +7,7 @@ import {
 } from '../../runtime/runtime-compatibility-test-fixture'
 import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
 import { createTestStore } from './store-test-helpers'
+import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
 
 const folderWorkspacesUpdate = vi.fn()
 const folderWorkspacesDelete = vi.fn()
@@ -69,6 +70,28 @@ beforeEach(() => {
 })
 
 describe('folder workspace owner-routed mutations', () => {
+  it('persists manual rank through the shared batch metadata boundary', async () => {
+    const folderWorkspace = makeFolderWorkspace()
+    folderWorkspacesUpdate.mockResolvedValue({ ...folderWorkspace, manualOrder: 9000 })
+    const store = createTestStore()
+    store.setState({
+      projectGroups: [{ ...projectGroup, executionHostId: 'local' }],
+      folderWorkspaces: [folderWorkspace]
+    })
+
+    await store
+      .getState()
+      .updateWorktreesMeta(
+        new Map([[folderWorkspaceKey(folderWorkspace.id), { manualOrder: 9000 }]])
+      )
+
+    expect(folderWorkspacesUpdate).toHaveBeenCalledWith({
+      folderWorkspaceId: folderWorkspace.id,
+      updates: { manualOrder: 9000 }
+    })
+    expect(store.getState().folderWorkspaces[0]?.manualOrder).toBe(9000)
+  })
+
   it('updates a local folder locally while another runtime is focused', async () => {
     const folderWorkspace = makeFolderWorkspace()
     folderWorkspacesUpdate.mockResolvedValue({ ...folderWorkspace, comment: 'Ready' })

--- a/src/renderer/src/store/slices/worktrees-metadata-persistence.test.ts
+++ b/src/renderer/src/store/slices/worktrees-metadata-persistence.test.ts
@@ -394,4 +394,38 @@ describe('worktree remote runtime mutations', () => {
     expect(subscriber).toHaveBeenCalledTimes(1)
     expect(mockApi.worktrees.updateMeta).toHaveBeenCalledTimes(2)
   })
+
+  it('persists a same-id manual rank to every owning host', async () => {
+    const store = createTestStore()
+    const worktreeId = 'repo1::/same/path'
+    const local = makeWorktree({ id: worktreeId, repoId: 'repo1', hostId: 'local' })
+    const remote = makeWorktree({
+      id: worktreeId,
+      repoId: 'repo1',
+      hostId: 'runtime:env-1'
+    })
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-set-manual-order',
+      ok: true,
+      result: { worktree: { ...remote, manualOrder: 9000 } },
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+    store.setState({ worktreesByRepo: { repo1: [local, remote] } } as Partial<AppState>)
+
+    await store.getState().updateWorktreesMeta(new Map([[worktreeId, { manualOrder: 9000 }]]))
+
+    expect(store.getState().worktreesByRepo.repo1.map((row) => row.manualOrder)).toEqual([
+      9000, 9000
+    ])
+    expect(mockApi.worktrees.updateMeta).toHaveBeenCalledWith({
+      worktreeId,
+      updates: { manualOrder: 9000 }
+    })
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-1',
+      method: 'worktree.set',
+      params: { worktree: `id:${worktreeId}`, manualOrder: 9000 },
+      timeoutMs: 15_000
+    })
+  })
 })

--- a/src/renderer/src/store/slices/worktrees/listing/worktree-owner-settings.ts
+++ b/src/renderer/src/store/slices/worktrees/listing/worktree-owner-settings.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../../../../shared/execution-host'
 import {
   resolveWorktreeOperationRoute,
+  resolveWorktreeOperationRouteForHost,
   settingsForWorktreeOperationRoute
 } from '@/lib/worktree-operation-route'
 import { WORKTREE_REMOVAL_AMBIGUOUS_ERROR } from './worktree-slice-constants'
@@ -97,9 +98,12 @@ export function trySettingsForWorktreeOwner(
     | 'runtimeEnvironmentCatalogHydrated'
     | 'removedRuntimeEnvironmentIds'
   >,
-  worktreeId: string
+  worktreeId: string,
+  executionHostId?: ExecutionHostId
 ): AppState['settings'] | null {
-  const route = resolveWorktreeOperationRoute(state, worktreeId)
+  const route = executionHostId
+    ? resolveWorktreeOperationRouteForHost(state, worktreeId, executionHostId)
+    : resolveWorktreeOperationRoute(state, worktreeId)
   if (!route) {
     return null
   }
@@ -108,9 +112,10 @@ export function trySettingsForWorktreeOwner(
 
 export function settingsForWorktreeOwner(
   state: Parameters<typeof trySettingsForWorktreeOwner>[0],
-  worktreeId: string
+  worktreeId: string,
+  executionHostId?: ExecutionHostId
 ) {
-  const settings = trySettingsForWorktreeOwner(state, worktreeId)
+  const settings = trySettingsForWorktreeOwner(state, worktreeId, executionHostId)
   if (!settings) {
     throw new Error(WORKTREE_REMOVAL_AMBIGUOUS_ERROR)
   }

--- a/src/renderer/src/store/slices/worktrees/metadata/update-worktrees-meta.ts
+++ b/src/renderer/src/store/slices/worktrees/metadata/update-worktrees-meta.ts
@@ -1,10 +1,31 @@
 import type { WorktreeSlice } from '../../worktree-helpers'
 import type { WorktreeSliceGet, WorktreeSliceSet } from '../listing/worktree-slice-types'
 import { applyWorktreeUpdates, getRepoIdFromWorktreeId } from '../../worktree-helpers'
-import { applyDetectedWorktreeUpdates } from '../listing/detected-worktree-meta'
+import {
+  applyDetectedWorktreeUpdates,
+  getFolderWorkspaceMetaUpdates
+} from '../listing/detected-worktree-meta'
 import { persistWorktreeMeta } from './worktree-meta-persist'
 import { isRuntimeSelectorNotFoundError } from '../listing/runtime-worktree-rpc-errors'
 import { settingsForWorktreeOwner } from '../listing/worktree-owner-settings'
+import { parseWorkspaceKey } from '../../../../../../shared/workspace-scope'
+import { parseExecutionHostId, type ExecutionHostId } from '../../../../../../shared/execution-host'
+import { getIndexedWorktreesById } from '../../../worktree-repo-index'
+import type { WorktreeMeta } from '../../../../../../shared/worktree/meta-types'
+
+function getKnownOwnerHostIds(
+  state: ReturnType<WorktreeSliceGet>,
+  worktreeId: string
+): ExecutionHostId[] {
+  const hostIds = new Set<ExecutionHostId>()
+  for (const worktree of getIndexedWorktreesById(state.worktreesByRepo, worktreeId)) {
+    const hostId = parseExecutionHostId(worktree.hostId)?.id
+    if (hostId) {
+      hostIds.add(hostId)
+    }
+  }
+  return [...hostIds]
+}
 
 export function createUpdateWorktreesMeta(
   set: WorktreeSliceSet,
@@ -15,10 +36,30 @@ export function createUpdateWorktreesMeta(
       return
     }
 
+    const gitWorktreeUpdates = new Map<string, Partial<WorktreeMeta>>()
+    const folderWorkspaceUpdates: {
+      folderWorkspaceId: string
+      updates: ReturnType<typeof getFolderWorkspaceMetaUpdates>
+    }[] = []
+    for (const [worktreeId, updates] of updatesByWorktreeId) {
+      const scope = parseWorkspaceKey(worktreeId)
+      if (scope?.type === 'folder') {
+        const folderUpdates = getFolderWorkspaceMetaUpdates(updates)
+        if (Object.keys(folderUpdates).length > 0) {
+          folderWorkspaceUpdates.push({
+            folderWorkspaceId: scope.folderWorkspaceId,
+            updates: folderUpdates
+          })
+        }
+      } else {
+        gitWorktreeUpdates.set(worktreeId, updates)
+      }
+    }
+
     set((s) => {
       let nextWorktrees = s.worktreesByRepo
       let nextDetectedWorktrees = s.detectedWorktreesByRepo
-      for (const [worktreeId, updates] of updatesByWorktreeId) {
+      for (const [worktreeId, updates] of gitWorktreeUpdates) {
         nextWorktrees = applyWorktreeUpdates(nextWorktrees, worktreeId, updates)
         nextDetectedWorktrees = applyDetectedWorktreeUpdates(
           nextDetectedWorktrees,
@@ -39,14 +80,25 @@ export function createUpdateWorktreesMeta(
           }
     })
 
-    await Promise.all(
-      Array.from(updatesByWorktreeId, async ([worktreeId, updates]) => {
+    await Promise.all([
+      ...folderWorkspaceUpdates.map(({ folderWorkspaceId, updates }) =>
+        get().updateFolderWorkspace(folderWorkspaceId, updates)
+      ),
+      ...Array.from(gitWorktreeUpdates, async ([worktreeId, updates]) => {
         try {
-          await persistWorktreeMeta(
-            settingsForWorktreeOwner(get(), worktreeId),
-            worktreeId,
-            updates
-          )
+          const state = get()
+          const ownerHostIds = getKnownOwnerHostIds(state, worktreeId)
+          await (ownerHostIds.length === 0
+            ? persistWorktreeMeta(settingsForWorktreeOwner(state, worktreeId), worktreeId, updates)
+            : Promise.all(
+                ownerHostIds.map((hostId) =>
+                  persistWorktreeMeta(
+                    settingsForWorktreeOwner(state, worktreeId, hostId),
+                    worktreeId,
+                    updates
+                  )
+                )
+              ))
         } catch (err) {
           if (isRuntimeSelectorNotFoundError(err)) {
             void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
@@ -56,6 +108,6 @@ export function createUpdateWorktreesMeta(
           void get().fetchWorktrees(getRepoIdFromWorktreeId(worktreeId))
         }
       })
-    )
+    ])
   }
 }

--- a/tests/e2e/manual-worktree-order-persistence.spec.ts
+++ b/tests/e2e/manual-worktree-order-persistence.spec.ts
@@ -1,0 +1,190 @@
+import { expect, test } from './helpers/orca-app'
+import type { Page } from '@stablyai/playwright-test'
+import { attachRepoAndOpenTerminal, createRestartSession } from './helpers/orca-restart'
+import { waitForSessionReady } from './helpers/store'
+
+async function visibleWorktreeIds(page: Page): Promise<string[]> {
+  return page
+    .locator('[data-worktree-sidebar] [role="option"][data-worktree-id]')
+    .evaluateAll((elements) =>
+      elements
+        .map((element) => ({
+          id: element.getAttribute('data-worktree-id') ?? '',
+          top: element.getBoundingClientRect().top
+        }))
+        .sort((left, right) => left.top - right.top)
+        .map((entry) => entry.id)
+    )
+}
+
+async function dragBefore(page: Page, sourceId: string, targetId: string): Promise<void> {
+  const source = page.locator(`[data-worktree-id=${JSON.stringify(sourceId)}]`).first()
+  const target = page.locator(`[data-worktree-id=${JSON.stringify(targetId)}]`).first()
+  await expect(source).toBeVisible()
+  await expect(target).toBeVisible()
+  const sourceBox = await source.boundingBox()
+  const targetBox = await target.boundingBox()
+  if (!sourceBox || !targetBox) {
+    throw new Error('Manual-order drag geometry was unavailable')
+  }
+  await page.mouse.move(sourceBox.x + sourceBox.width / 2, sourceBox.y + sourceBox.height / 2)
+  await page.mouse.down()
+  await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + 3, { steps: 8 })
+  await page.mouse.up()
+}
+
+test('manual drag survives activity and persisted-profile reload', async ({
+  testRepoPath
+}, testInfo) => {
+  test.setTimeout(240_000)
+  const session = createRestartSession(testInfo)
+  let firstApp: Awaited<ReturnType<typeof session.launch>>['app'] | null = null
+  let secondApp: Awaited<ReturnType<typeof session.launch>>['app'] | null = null
+  let createdIds: string[] = []
+
+  try {
+    const first = await session.launch()
+    firstApp = first.app
+    await waitForSessionReady(first.page)
+    await attachRepoAndOpenTerminal(first.page, testRepoPath)
+    createdIds = await first.page.evaluate(async () => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('store unavailable')
+      }
+      const state = store.getState()
+      state.setGroupBy('none')
+      state.setSortBy('recent')
+      state.setShowSleepingWorkspaces(true)
+      const repoId = state.allWorktrees()[0]?.repoId
+      if (!repoId) {
+        throw new Error('seed repo was not loaded')
+      }
+      const names = ['manual-order-a', 'manual-order-b', 'manual-order-c']
+      const created = []
+      for (const name of names) {
+        created.push((await state.createWorktree(repoId, name, undefined, 'skip')).worktree.id)
+      }
+      return created
+    })
+
+    await expect
+      .poll(
+        () =>
+          first.page
+            .locator('[data-worktree-sidebar] [role="option"][data-worktree-id]')
+            .evaluateAll(
+              (elements, ids) =>
+                ids.every((id) =>
+                  elements.some((element) => element.getAttribute('data-worktree-id') === id)
+                ),
+              createdIds
+            ),
+        { timeout: 30_000 }
+      )
+      .toBe(true)
+    const initialOrder = (await visibleWorktreeIds(first.page)).filter((id) =>
+      createdIds.includes(id)
+    )
+    const sourceId = createdIds.at(-1)!
+    const targetId = initialOrder.find((id) => id !== sourceId)!
+    await dragBefore(first.page, sourceId, targetId)
+
+    const manualOrderAfterDrag = await first.page.evaluate((ids) => {
+      const state = window.__store?.getState()
+      if (!state) {
+        throw new Error('store unavailable')
+      }
+      return {
+        sortBy: state.sortBy,
+        rows: state
+          .allWorktrees()
+          .map((worktree) => ({
+            id: worktree.id,
+            manualOrder: worktree.manualOrder,
+            sortOrder: worktree.sortOrder
+          }))
+          .filter((row) => ids.includes(row.id))
+      }
+    }, createdIds)
+    expect(manualOrderAfterDrag.sortBy).toBe('manual')
+    expect(manualOrderAfterDrag.rows.every((row) => Number.isFinite(row.manualOrder))).toBe(true)
+    const expectedOrder = [...manualOrderAfterDrag.rows]
+      .sort((left, right) => (right.manualOrder ?? 0) - (left.manualOrder ?? 0))
+      .map((row) => row.id)
+    expect((await visibleWorktreeIds(first.page)).filter((id) => createdIds.includes(id))).toEqual(
+      expectedOrder
+    )
+
+    await first.page.evaluate(async (activityId) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('store unavailable')
+      }
+      store.getState().bumpWorktreeActivity(activityId)
+      await window.api.worktrees.persistSortOrder({ orderedIds: [activityId] })
+    }, targetId)
+    await expect
+      .poll(() =>
+        visibleWorktreeIds(first.page).then((ids) => ids.filter((id) => createdIds.includes(id)))
+      )
+      .toEqual(expectedOrder)
+
+    // Allow the persisted UI preference and metadata writes to settle before relaunch.
+    await first.page.waitForTimeout(1_000)
+
+    await session.close(firstApp)
+    firstApp = null
+    const second = await session.launch()
+    secondApp = second.app
+    await waitForSessionReady(second.page)
+    const reloadedState = await second.page.evaluate((ids) => {
+      const state = window.__store?.getState()
+      if (!state) {
+        throw new Error('store unavailable')
+      }
+      return {
+        sortBy: state.sortBy,
+        rows: state
+          .allWorktrees()
+          .filter((worktree) => ids.includes(worktree.id))
+          .map((worktree) => ({ id: worktree.id, manualOrder: worktree.manualOrder }))
+      }
+    }, createdIds)
+    expect(reloadedState.sortBy).toBe('manual')
+    const reloadedRows = reloadedState.rows
+    expect(reloadedRows.every((row) => Number.isFinite(row.manualOrder))).toBe(true)
+    expect(reloadedRows.map((row) => row.id).sort()).toEqual(expectedOrder.slice().sort())
+    expect(new Map(reloadedRows.map((row) => [row.id, row.manualOrder]))).toEqual(
+      new Map(manualOrderAfterDrag.rows.map((row) => [row.id, row.manualOrder]))
+    )
+    await expect
+      .poll(
+        () =>
+          visibleWorktreeIds(second.page).then((ids) =>
+            ids.filter((id) => createdIds.includes(id))
+          ),
+        { timeout: 30_000 }
+      )
+      .toEqual(expectedOrder)
+  } finally {
+    if (secondApp && createdIds.length > 0) {
+      await secondApp
+        .firstWindow()
+        .then((page) =>
+          page.evaluate(async (ids) => {
+            for (const id of ids) {
+              await window.__store?.getState().removeWorktree(id, true)
+            }
+          }, createdIds)
+        )
+        .catch(() => undefined)
+    }
+    for (const app of [secondApp, firstApp]) {
+      if (app) {
+        await session.close(app).catch(() => undefined)
+      }
+    }
+    await session.dispose()
+  }
+})

--- a/tests/e2e/manual-worktree-order-persistence.spec.ts
+++ b/tests/e2e/manual-worktree-order-persistence.spec.ts
@@ -54,14 +54,14 @@ test('manual drag survives activity and persisted-profile reload', async ({
       }
       const state = store.getState()
       state.setGroupBy('none')
-      state.setSortBy('recent')
+      state.setSortBy('smart')
       state.setShowSleepingWorkspaces(true)
       const repoId = state.allWorktrees()[0]?.repoId
       if (!repoId) {
         throw new Error('seed repo was not loaded')
       }
       const names = ['manual-order-a', 'manual-order-b', 'manual-order-c']
-      const created = []
+      const created: string[] = []
       for (const name of names) {
         created.push((await state.createWorktree(repoId, name, undefined, 'skip')).worktree.id)
       }
@@ -116,14 +116,34 @@ test('manual drag survives activity and persisted-profile reload', async ({
       expectedOrder
     )
 
+    const sortOrdersBeforeActivity = new Map(
+      manualOrderAfterDrag.rows.map((row) => [row.id, row.sortOrder])
+    )
     await first.page.evaluate(async (activityId) => {
       const store = window.__store
       if (!store) {
         throw new Error('store unavailable')
       }
       store.getState().bumpWorktreeActivity(activityId)
-      await window.api.worktrees.persistSortOrder({ orderedIds: [activityId] })
+      const orderedIds = store
+        .getState()
+        .allWorktrees()
+        .map((worktree) => worktree.id)
+        .filter((id) => id !== activityId)
+      await window.api.worktrees.persistSortOrder({ orderedIds: [activityId, ...orderedIds] })
+      await store.getState().fetchAllWorktrees()
     }, targetId)
+    await expect
+      .poll(() =>
+        first.page.evaluate((activityId) => {
+          const row = window.__store
+            ?.getState()
+            .allWorktrees()
+            .find((worktree) => worktree.id === activityId)
+          return row?.sortOrder
+        }, targetId)
+      )
+      .not.toBe(sortOrdersBeforeActivity.get(targetId))
     await expect
       .poll(() =>
         visibleWorktreeIds(first.page).then((ids) => ids.filter((id) => createdIds.includes(id)))
@@ -174,7 +194,7 @@ test('manual drag survives activity and persisted-profile reload', async ({
         .then((page) =>
           page.evaluate(async (ids) => {
             for (const id of ids) {
-              await window.__store?.getState().removeWorktree(id, true)
+              await window.__store?.getState().removeWorktree({ id, executionHostId: null }, true)
             }
           }, createdIds)
         )

--- a/tests/e2e/manual-worktree-order-persistence.spec.ts
+++ b/tests/e2e/manual-worktree-order-persistence.spec.ts
@@ -150,8 +150,29 @@ test('manual drag survives activity and persisted-profile reload', async ({
       )
       .toEqual(expectedOrder)
 
-    // Allow the persisted UI preference and metadata writes to settle before relaunch.
-    await first.page.waitForTimeout(1_000)
+    await expect
+      .poll(async () => {
+        const [ui, worktrees] = await first.page.evaluate(async (ids) => {
+          const [persistedUi, persistedWorktrees] = await Promise.all([
+            window.api.ui.get(),
+            window.api.worktrees.listAll()
+          ])
+          return [
+            persistedUi,
+            persistedWorktrees
+              .filter((worktree) => ids.includes(worktree.id))
+              .map((worktree) => ({ id: worktree.id, manualOrder: worktree.manualOrder }))
+          ] as const
+        }, createdIds)
+        return {
+          sortBy: ui.sortBy,
+          ranks: Object.fromEntries(worktrees.map((row) => [row.id, row.manualOrder]))
+        }
+      })
+      .toEqual({
+        sortBy: 'manual',
+        ranks: Object.fromEntries(manualOrderAfterDrag.rows.map((row) => [row.id, row.manualOrder]))
+      })
 
     await session.close(firstApp)
     firstApp = null


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​512 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​509 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​215 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​68 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​147 |

<!-- /orca-pr-loc -->

## ELI5

Manual order could still depend on Smart-sort metadata for rows hidden by filters or collapsed groups. Those rows could jump when revealed. This change gives every known row a durable manual rank the first time a real drag establishes Manual order, while preserving hidden rows in their existing slots.

## What Changed

- Build one complete manual-order catalog from every known non-archived Git and folder workspace, independent of filters, collapse, or Board lane visibility.
- Treat a same-ID host cluster as durably ranked only when every owner agrees on the same finite `manualOrder`.
- On the first real reorder with missing ranks, merge the visible move into the complete sequence and materialize all known rows once; later reorders stay sparse.
- Share the same catalog and rank map across the left sidebar and Workspace Board.
- Route folder ranks through the folder-workspace persistence API and fan same-ID Git updates out to every explicit local, paired-runtime, or SSH owner.
- Harden stale/duplicate visible-order merging so it cannot drop known rows.
- Add unit and persisted-profile Electron coverage for hidden rows, Smart → Manual, activity-driven `sortOrder` writes, reload, folder rows, and duplicate host ownership.
## Why

Manual uses `manualOrder ?? sortOrder`. `sortOrder` is mutable Smart-sort state, so leaving filtered or collapsed rows without `manualOrder` means the displayed Manual order is not fully user-owned. PR #14284 backfills only rendered rows and also targets an older Board persistence path; this branch applies the stronger complete-known-row behavior to current main.

## Linked Issue

[STA-3921](https://linear.app/stably/issue/STA-3921/agents-list-manual-order-jumps-when-an-agent-receives-new-activity)

Related hypothesis: #14284

## Visual Proof

N/A — this fixes ordering persistence without changing component visuals. A real Electron drag/reload flow is covered by `manual-worktree-order-persistence.spec.ts`.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

Passed after rebasing onto latest `origin/main`:

- `pnpm -s typecheck`
- Oxlint on every changed file
- Focused Vitest: 5 files, 74 tests
- Electron E2E: `manual drag survives activity and persisted-profile reload` (1/1)
- Manual Electron/CDP: rendered order remained `a → c → b` after a persisted Smart reorder and full process restart; all four rows, including a collapsed row, retained finite `manualOrder`
- Physical-host persistence boundary: disposable rows were written to and read back from m4 Air's and Windows 2's own `orca-data.json`; openclaw's SSH row was read back from the client-owned profile with the correct SSH `hostId`; all three fixtures were removed
- Revert oracle: removing complete-catalog materialization makes the hidden-row regression test fail

`pnpm -s typecheck:e2e` remains red on unrelated repository-wide pre-existing errors; it reports no error from this spec.
## Review

Three fresh same-worktree OpenCode reviews covered persistence boundary/efficiency, product semantics, and migration/regression compatibility. Their initial blockers led to the shared complete catalog, required rank inputs, defensive merge, same-ID host fan-out, folder support, and a stronger E2E refresh oracle. All three final verdicts are READY.

Invariant: after a real user reorder establishes Manual mode, Manual is one durable order for every known non-archived workspace. Filters and collapsed groups are presentation-only; they do not remove rows from that order.
## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- A direct Smart → Manual selection without a drag does not invent a new order; the first real reorder establishes the durable sequence.
- Rows created in Manual mode receive a rank at creation. Any later incomplete catalog is materialized at the next real reorder.
- Same bare IDs across hosts move as one cluster, matching the existing ID-only drag identity.
- The migration is a bounded one-time O(N) write; steady-state reorders remain sparse.
- No remote wire shape or opcode changes.
## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (targeted checks passed; full E2E typecheck has unrelated existing failures)
