### PR TITLE
fix(terminal): stop xterm.js version text leaking into Codex

### DIFF
--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -428,18 +428,37 @@ describe('Session', () => {
     })
 
     it.each([
-      ['color', '\x1b[?997;1n'],
-      ['XTVERSION', '\x1bP>|xterm.js(6.1.0-beta.287)\x1b\\']
-    ])('contains live %s replies without releasing queued startup input', async (_name, reply) => {
+      ['color on POSIX', 'posix-pty', '\x1b[?997;1n'],
+      ['XTVERSION on POSIX', 'posix-pty', '\x1bP>|xterm.js(6.1.0-beta.287)\x1b\\'],
+      ['XTVERSION on ConPTY', 'windows-conpty', '\x1bP>|xterm.js(6.1.0-beta.287)\x1b\\'],
+      ['XTVERSION on WSL', 'windows-wsl', '\x1bP>|xterm.js(6.1.0-beta.287)\x1b\\']
+    ] as const)(
+      'contains live %s replies without releasing queued startup input',
+      async (_name, ownerBackend, reply) => {
+        createSession({ shellReadySupported: true, shellReadyTimeoutMs: 100, ownerBackend })
+        session.write('codex\n')
+
+        session.write(reply)
+        await vi.advanceTimersByTimeAsync(0)
+        expect(subprocess.written).toEqual([reply])
+
+        await vi.advanceTimersByTimeAsync(100)
+        expect(subprocess.written).toEqual([reply, 'codex\n'])
+      }
+    )
+
+    it('does not queue a failed live XTVERSION reply behind startup input', async () => {
+      const reply = '\x1bP>|xterm.js(6.1.0-beta.287)\x1b\\'
       createSession({ shellReadySupported: true, shellReadyTimeoutMs: 100 })
       session.write('codex\n')
+      vi.spyOn(subprocess, 'write').mockImplementationOnce(() => {
+        throw new Error('EIO')
+      })
 
       session.write(reply)
-      await vi.advanceTimersByTimeAsync(0)
-      expect(subprocess.written).toEqual([reply])
-
       await vi.advanceTimersByTimeAsync(100)
-      expect(subprocess.written).toEqual([reply, 'codex\n'])
+
+      expect(subprocess.written).toEqual(['codex\n'])
     })
 
     it('uses the short settle path when marker and prompt bytes arrive together', () => {

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -427,8 +427,10 @@ describe('Session', () => {
       expect(subprocess.written).toEqual(['first\n', 'second\n'])
     })
 
-    it('contains live color replies without releasing queued startup input', async () => {
-      const reply = '\x1b[?997;1n'
+    it.each([
+      ['color', '\x1b[?997;1n'],
+      ['XTVERSION', '\x1bP>|xterm.js(6.1.0-beta.287)\x1b\\']
+    ])('contains live %s replies without releasing queued startup input', async (_name, reply) => {
       createSession({ shellReadySupported: true, shellReadyTimeoutMs: 100 })
       session.write('codex\n')
 

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -144,9 +144,11 @@ export class Session {
       return
     }
 
-    // Daemon POSIX PTYs need the local provider's cooked-echo containment (#13137).
+    // Daemon PTYs need the local provider's cooked-echo containment (#13137).
     // DA1/CPR stay immediate unless an echo-risk reply is already held (#13892, #15559).
-    if (this.startupIngress.answerLiveQueryReply(data)) {
+    const liveQueryReply = this.startupIngress.deliverLiveQueryReply(data)
+    if (liveQueryReply !== 'unrecognized') {
+      // A failed responder write must not turn its reply into the next process's stdin.
       return
     }
 

--- a/src/main/providers/local-pty-provider-io-events.test.ts
+++ b/src/main/providers/local-pty-provider-io-events.test.ts
@@ -164,6 +164,17 @@ describe('LocalPtyProvider', () => {
       expect(mockProc.write).toHaveBeenCalledWith('hello')
     })
 
+    it('does not retry a failed live XTVERSION reply without echo containment', async () => {
+      const reply = '\x1bP>|xterm.js(6.1.0-beta.287)\x1b\\'
+      const { id } = await provider.spawn({ cols: 80, rows: 24 })
+      mockProc.write.mockImplementationOnce(() => {
+        throw new Error('EIO')
+      })
+
+      expect(provider.write(id, reply)).toBe(false)
+      expect(mockProc.write).toHaveBeenCalledTimes(1)
+    })
+
     it('is a no-op for unknown PTY ids', () => {
       expect(provider.write('nonexistent', 'hello')).toBe(false)
       expect(mockProc.write).not.toHaveBeenCalled()

--- a/src/main/providers/local-pty-session-operations.ts
+++ b/src/main/providers/local-pty-session-operations.ts
@@ -24,10 +24,13 @@ import type { LocalPtyProviderOptions } from './local-pty-provider-types'
 import type { PtyProcessInfo } from './types'
 
 export function writeLocalPty(id: string, data: string): boolean {
-  // Cooked PTYs echo private DSR/OSC replies; CPR/DA stay immediate unless one of
-  // those is still held, which they must not overtake (#13137, #7329, #15559).
-  if (startupIngressByPty.get(id)?.answerLiveQueryReply(data)) {
-    return true
+  // Cooked PTYs echo private DSR/OSC/XTVERSION replies; CPR/DA stay on the raw path.
+  const startupIngress = startupIngressByPty.get(id)
+  if (startupIngress) {
+    const liveQueryReply = startupIngress.deliverLiveQueryReply(data)
+    if (liveQueryReply !== 'unrecognized') {
+      return liveQueryReply === 'wrote'
+    }
   }
   const proc = ptyProcesses.get(id)
   if (!proc) {

--- a/src/main/runtime/orca-runtime-create-pty-headless-terminal-state.ts
+++ b/src/main/runtime/orca-runtime-create-pty-headless-terminal-state.ts
@@ -40,11 +40,8 @@ export class OrcaRuntimeWithCreatePtyHeadlessTerminalState extends OrcaRuntimeWi
           ) {
             return
           }
-          // Why this write is safe pre-shell-ready: daemon Session.write
-          // QUEUES (never drops) input while the POSIX shell-ready gate is
-          // pending and flushes at the ready marker or the 15s
-          // SHELL_READY_TIMEOUT_MS bound (session.ts) — a spawn-time query
-          // reply is delayed at most that bound, not lost.
+          // Why this is safe pre-shell-ready: provider-side startup ingress sends
+          // echo-risk replies immediately while the launch command remains gated.
           this.ptyController?.write(ptyId, reply)
         }
       }

--- a/src/relay/pty-handler-startup-command-delivery.test.ts
+++ b/src/relay/pty-handler-startup-command-delivery.test.ts
@@ -93,6 +93,19 @@ describe('PtyHandler', () => {
     expect(handler.retainedStartupCommandCount).toBe(0)
   })
 
+  it('does not retry a failed live XTVERSION reply without echo containment', async () => {
+    const reply = '\x1bP>|xterm.js(6.1.0-beta.287)\x1b\\'
+    const { id } = await spawnPty()
+    const term = mockPtySpawn.mock.results[0]?.value
+    term.write.mockImplementationOnce(() => {
+      throw new Error('EIO')
+    })
+
+    dispatcher.callNotification('pty.data', { id, data: reply })
+
+    expect(term.write).toHaveBeenCalledTimes(1)
+  })
+
   it.skipIf(process.platform === 'win32')(
     'emits shell-ready markers for renderer-delivered startup commands',
     async () => {

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -2181,8 +2181,11 @@ export class PtyHandler {
       this.interactiveOutputCharsByPty.set(id, 0)
       // Relay PTYs need the local provider's cooked-echo containment (#13137).
       // DA1/CPR stay immediate unless an echo-risk reply is already held (#13892, #15559).
-      if (managed.startupIngress?.answerLiveQueryReply(data)) {
-        return
+      if (managed.startupIngress) {
+        const liveQueryReply = managed.startupIngress.deliverLiveQueryReply(data)
+        if (liveQueryReply !== 'unrecognized') {
+          return
+        }
       }
       managed.pty.write(data)
     }

--- a/src/shared/pty-startup-ingress-live-query-reply.test.ts
+++ b/src/shared/pty-startup-ingress-live-query-reply.test.ts
@@ -62,11 +62,46 @@ describe('live query replies', () => {
     }
   )
 
-  it('answers repeated identical replies without collapsing them', () => {
-    const { ingress, writes } = harness()
-    expect(ingress.answerLiveQueryReply(COLOR_SCHEME_REPLY)).toBe(true)
-    expect(ingress.answerLiveQueryReply(COLOR_SCHEME_REPLY)).toBe(true)
-    expect(writes).toEqual([COLOR_SCHEME_REPLY, COLOR_SCHEME_REPLY])
+  it.each([COLOR_SCHEME_REPLY, XTVERSION_REPLY])(
+    'answers repeated identical replies without collapsing them',
+    (reply) => {
+      const { ingress, writes } = harness()
+      expect(ingress.answerLiveQueryReply(reply)).toBe(true)
+      expect(ingress.answerLiveQueryReply(reply)).toBe(true)
+      expect(writes).toEqual([reply, reply])
+      ingress.drainAndClose()
+    }
+  )
+
+  it('reports a recognized reply when its immediate write fails', () => {
+    const ingress = new PtyStartupIngress({
+      ownerBackend: 'posix-pty',
+      write: () => {
+        throw new Error('EIO')
+      },
+      onEmission: () => {}
+    })
+
+    expect(ingress.deliverLiveQueryReply(XTVERSION_REPLY)).toBe('write-failed')
+    ingress.drainAndClose()
+  })
+
+  it.each([0, 1])('claims a repeated payload when write %i fails', (failedWrite) => {
+    const writes: string[] = []
+    let writeIndex = 0
+    const ingress = new PtyStartupIngress({
+      ownerBackend: 'posix-pty',
+      write: (data) => {
+        if (writeIndex++ === failedWrite) {
+          throw new Error('EIO')
+        }
+        writes.push(data)
+      },
+      onEmission: () => {}
+    })
+
+    expect(ingress.answerLiveQueryReply(XTVERSION_REPLY + XTVERSION_REPLY)).toBe(true)
+    expect(writes).toEqual([XTVERSION_REPLY])
     ingress.drainAndClose()
   })
 
@@ -178,7 +213,14 @@ describe('live query replies', () => {
     // CPR and DA1 need no echo containment, so the delivery declines them and the host
     // writes them itself — which is what keeps them behind the daemon's post-ready flush
     // gate instead of splicing into a buffered startup command.
-    for (const reply of [CPR_REPLY, DA1_REPLY, OSC_COLOR_REPLY + DA1_REPLY]) {
+    for (const reply of [
+      CPR_REPLY,
+      DA1_REPLY,
+      OSC_COLOR_REPLY + DA1_REPLY,
+      XTVERSION_REPLY + DA1_REPLY,
+      XTVERSION_REPLY.slice(0, -2),
+      '>|xterm.js(6.1.0-beta.287)'
+    ]) {
       expect(ingress.answerLiveQueryReply(reply)).toBe(false)
     }
     expect(writes).toEqual([])

--- a/src/shared/pty-startup-ingress-live-query-reply.test.ts
+++ b/src/shared/pty-startup-ingress-live-query-reply.test.ts
@@ -11,6 +11,7 @@ import {
 
 const COLOR_SCHEME_REPLY = mode2031SequenceFor('dark')
 const OSC_COLOR_REPLY = '\x1b]11;rgb:00/00/00\x07'
+const XTVERSION_REPLY = '\x1bP>|xterm.js(6.1.0-beta.287)\x1b\\'
 const CPR_REPLY = '\x1b[6;1R'
 const DA1_REPLY = '\x1b[?1;2c'
 // ECHOCTL carets every C0 control, so an OSC reply's trailing BEL prints as `^G`. This
@@ -50,13 +51,16 @@ describe('live query replies', () => {
     expect(needsCookedEchoSafeQueryReply(mode2031SequenceFor('light'))).toBe(true)
   })
 
-  it('writes an echo-risk reply in the calling turn', () => {
-    const { ingress, writes } = harness()
-    expect(ingress.answerLiveQueryReply(OSC_COLOR_REPLY)).toBe(true)
-    // No timer advance: the whole point is that there is nothing to wait for.
-    expect(writes).toEqual([OSC_COLOR_REPLY])
-    ingress.drainAndClose()
-  })
+  it.each([OSC_COLOR_REPLY, XTVERSION_REPLY])(
+    'writes an echo-risk reply in the calling turn',
+    (reply) => {
+      const { ingress, writes } = harness()
+      expect(ingress.answerLiveQueryReply(reply)).toBe(true)
+      // No timer advance: the whole point is that there is nothing to wait for.
+      expect(writes).toEqual([reply])
+      ingress.drainAndClose()
+    }
+  )
 
   it('answers repeated identical replies without collapsing them', () => {
     const { ingress, writes } = harness()
@@ -91,6 +95,33 @@ describe('live query replies', () => {
       expect(visible(emissions), echoOf(OSC_COLOR_REPLY)).toBe('')
       ingress.drainAndClose()
     }
+  })
+
+  it('swallows a DCS reply echo under every POSIX shape', () => {
+    for (const echoOf of [caretEcho, (reply: string) => reply]) {
+      const { ingress, writes, emissions } = harness()
+      expect(ingress.answerLiveQueryReply(XTVERSION_REPLY)).toBe(true)
+      expect(writes).toEqual([XTVERSION_REPLY])
+      ingress.accept(echoOf(XTVERSION_REPLY))
+      expect(visible(emissions), echoOf(XTVERSION_REPLY)).toBe('')
+      ingress.drainAndClose()
+    }
+  })
+
+  it('swallows the ESC-stripped ConPTY echo of an XTVERSION reply', () => {
+    const writes: string[] = []
+    const emissions: PtyIngressEmission[] = []
+    const ingress = new PtyStartupIngress({
+      ownerBackend: 'windows-conpty',
+      write: (data) => void writes.push(data),
+      onEmission: (emission) => void emissions.push(emission)
+    })
+
+    expect(ingress.answerLiveQueryReply(XTVERSION_REPLY)).toBe(true)
+    expect(writes).toEqual([XTVERSION_REPLY])
+    ingress.accept(XTVERSION_REPLY.replaceAll('\x1b', ''))
+    expect(visible(emissions)).toBe('')
+    ingress.drainAndClose()
   })
 
   it('never holds a partial verbatim echo, so a torn query is still answered', () => {

--- a/src/shared/pty-startup-ingress.ts
+++ b/src/shared/pty-startup-ingress.ts
@@ -6,7 +6,10 @@ import {
 import type { PtyStartupIngressIntent } from './pty-startup-ingress-intent'
 import type { PtyOwnerBackend } from './pty-owner-backend'
 import { PtyStartupReplyDelivery } from './pty-startup-reply-delivery'
-import { deliverTerminalQueryReplyPayload } from './terminal-query-reply-delivery'
+import {
+  deliverTerminalQueryReplyPayload,
+  type TerminalQueryReplyPayloadDelivery
+} from './terminal-query-reply-delivery'
 import {
   combinePtyIngressSourceSpans,
   slicePtyIngressSourceSpan,
@@ -95,9 +98,14 @@ export class PtyStartupIngress {
 
   // Query replies stay ordered when an earlier cooked-echo-risk reply is held (#13137, #13892).
   answerLiveQueryReply(reply: string): boolean {
+    return this.deliverLiveQueryReply(reply) === 'wrote'
+  }
+
+  /** Separates recognition from write success for owners that must never queue a stale reply. */
+  deliverLiveQueryReply(reply: string): TerminalQueryReplyPayloadDelivery {
     return !this.closed && reply.length > 0
       ? deliverTerminalQueryReplyPayload(reply, this.delivery)
-      : false
+      : 'unrecognized'
   }
 
   drainAndClose(): number {

--- a/src/shared/terminal-query-reply-delivery.ts
+++ b/src/shared/terminal-query-reply-delivery.ts
@@ -4,8 +4,10 @@ import {
   needsCookedEchoSafeQueryReply
 } from './terminal-query-reply'
 
+export type TerminalQueryReplyPayloadDelivery = 'unrecognized' | 'wrote' | 'write-failed'
+
 /**
- * True when `delivery` wrote the WHOLE payload.
+ * Recognizes a whole reply payload and reports whether any write landed.
  *
  * Only a payload made entirely of cooked-echo-risk replies is taken. Those need their
  * echo shapes armed around the write, and they are what a program sits blocked on, so
@@ -20,14 +22,14 @@ import {
 export function deliverTerminalQueryReplyPayload(
   data: string,
   delivery: Pick<PtyStartupReplyDelivery, 'answer'>
-): boolean {
+): TerminalQueryReplyPayloadDelivery {
   const replies = extractOnlyTerminalQueryReplies(data)
   if (!replies || !replies.every(needsCookedEchoSafeQueryReply)) {
-    return false
+    return 'unrecognized'
   }
-  let accepted = false
+  let wroteAny = false
   for (const reply of replies) {
-    accepted = delivery.answer(reply) || accepted
+    wroteAny = delivery.answer(reply) || wroteAny
   }
-  return accepted
+  return wroteAny ? 'wrote' : 'write-failed'
 }

--- a/src/shared/terminal-query-reply.test.ts
+++ b/src/shared/terminal-query-reply.test.ts
@@ -71,10 +71,11 @@ describe('isTerminalQueryReply', () => {
   })
 
   it('routes only cooked-echo-risk replies through the ECHO-safe write path', () => {
-    // Color-scheme private DSR + OSC color — cooked prompt paint risk (#13137).
+    // Color replies and XTVERSION can echo or cross startup ownership.
     expect(needsCookedEchoSafeQueryReply('\x1b[?997;1n')).toBe(true)
     expect(needsCookedEchoSafeQueryReply('\x1b[?997;2n')).toBe(true)
     expect(needsCookedEchoSafeQueryReply('\x1b]11;rgb:00/00/00\x07')).toBe(true)
+    expect(needsCookedEchoSafeQueryReply('\x1bP>|xterm.js(6.1.0-beta.287)\x1b\\')).toBe(true)
     // Latency-critical CPR / public DSR / DA stay immediate (#7329).
     expect(needsCookedEchoSafeQueryReply('\x1b[3;1R')).toBe(false)
     expect(needsCookedEchoSafeQueryReply('\x1b[0n')).toBe(false)

--- a/src/shared/terminal-query-reply.ts
+++ b/src/shared/terminal-query-reply.ts
@@ -42,16 +42,20 @@ const KITTY_FLAGS_PREFIX_RE = new RegExp('^\\u001b\\[\\?[0-9]+u')
 const OSC_RESPONSE_PREFIX_RE = new RegExp(
   '^\\u001b\\][0-9]+;[^\\u0007\\u001b]*(?:\\u0007|\\u001b\\\\)'
 )
+const XTVERSION_DCS_BODY_PATTERN = '>\\|[^\\u001b]*'
 // DCS-framed reports xterm emits: DECRQSS "ESC P 1 $ r Pt ST" / "ESC P 0 $ r ST"
 // (vim queries cursor style this way) and XTVERSION "ESC P > | text ST".
 const DCS_RESPONSE_PREFIX_RE = new RegExp(
-  '^\\u001bP(?:[01]\\$r[^\\u001b]*|>\\|[^\\u001b]*)\\u001b\\\\'
+  `^\\u001bP(?:[01]\\$r[^\\u001b]*|${XTVERSION_DCS_BODY_PATTERN})\\u001b\\\\`
 )
 // Private-mode DSR (CSI ? … n) — e.g. color-scheme `?997;1n` — often lands cooked.
 // Prefix form peels consecutive replies out of one coalesced payload.
 const COOKED_ECHO_RISK_PRIVATE_DSR_PREFIX_RE = new RegExp('^\\u001b\\[\\?[0-9;]*n')
 const COOKED_ECHO_RISK_OSC_PREFIX_RE = new RegExp(
   '^\\u001b\\][0-9]+;[^\\u0007\\u001b]*(?:\\u0007|\\u001b\\\\)'
+)
+const COOKED_ECHO_RISK_XTVERSION_PREFIX_RE = new RegExp(
+  `^\\u001bP${XTVERSION_DCS_BODY_PATTERN}\\u001b\\\\`
 )
 const QUERY_REPLY_PREFIX_RES = [
   CPR_OR_DSR_PREFIX_RE,
@@ -106,6 +110,10 @@ function cookedEchoSafeReplyEnd(data: string, start: number): number {
   if (osc?.[0]) {
     return start + osc[0].length
   }
+  const xtversion = COOKED_ECHO_RISK_XTVERSION_PREFIX_RE.exec(slice)
+  if (xtversion?.[0]) {
+    return start + xtversion[0].length
+  }
   return -1
 }
 
@@ -152,8 +160,9 @@ export function extractOnlyTerminalQueryReplies(data: string): string[] | null {
 
 /**
  * Query replies that must use the ECHO-safe write path on POSIX PTYs so cooked
- * prompts do not paint reply bytes (e.g. `997;1n` on `npx` confirm, #13137).
- * Latency-critical CPR/DSR without `?` stay on the immediate write path.
+ * prompts do not paint reply bytes or deliver a startup XTVERSION response to
+ * the next process. Latency-critical CPR/DSR without `?` stay on the immediate
+ * write path.
  *
  * Whole-string only: a single complete reply. For repeated / write-queue
  * coalesced payloads use {@link extractOnlyCookedEchoSafeQueryReplies}.


### PR DESCRIPTION
## ELI5

When the terminal answered "what version are you?" during startup, Orca could hold that answer until Codex started and then hand it to Codex as if the user had typed it.

XTVERSION replies now use Orca's existing startup-safe reply path. The requesting process receives the reply while the Codex launch command remains gated, so Codex starts with a clean input area.

## What Changed

- Treat complete XTVERSION DCS replies as cooked-echo and startup-ownership risks.
- Deliver recognized echo-risk replies immediately while startup commands remain behind the shell-ready gate.
- Distinguish unrecognized, written, and failed replies so a failed protected write cannot fall through to queued stdin or an uncontained retry in daemon, local, or SSH/relay PTY owners.
- Preserve the existing raw path for ordinary input, CPR, DA, incomplete XTVERSION, and mixed reply payloads.
- Suppress the verified POSIX and native ConPTY echo forms and extend shared, daemon, local, relay, renderer-routing, and cross-version regression coverage.

## Why

Orca already recognized XTVERSION as a terminal query reply, but the startup-safe subset covered private DSR and OSC color replies only. An XTVERSION reply could therefore wait behind the shell-ready gate after its requester exited. Codex then received the queued reply as input and displayed the printable `xterm.js(...)` body.

The delivery result now separates recognition from write success. Each PTY owner can claim a recognized reply even when its protected write fails, instead of treating that reply as ordinary user input.

The fix extends the existing `PtyStartupIngress` path instead of adding a second responder, suppressing XTVERSION globally, or changing the general startup debounce.

## Linked Issue

https://github.com/stablyai/orca/issues/16489

## Visual Proof

### Before

<img width="3066" height="1416" alt="CleanShot 2026-08-25 at 21 18 36@2x" src="https://github.com/user-attachments/assets/084aed24-562f-4681-b90a-5cc80d937f6e" />

### After

<img width="2744" height="986" alt="CleanShot 2026-08-25 at 21 16 30@2x" src="https://github.com/user-attachments/assets/16ba3235-7d43-4e83-a28d-6fd2b9444d0a" />

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Passed locally on macOS against head `865c005aa33e4436172eb86e766ac93ca80a5af6`:

- `pnpm tc`
- `pnpm run check:code-quality:changed`: 0 new findings across 12 changed files
- Focused Vitest suite: 12 files and 308 tests passed
- `pnpm run build:desktop`

The focused suite covers positive XTVERSION delivery, write failures, repeated and partial payloads, negative and neighboring terminal replies, POSIX, native ConPTY, WSL startup ordering, local PTYs, daemon sessions, SSH/relay delivery, renderer routing, and cross-version wire behavior.

The full `pnpm test` and aggregate `pnpm build` commands were not rerun after the rebase; CI will cover the full repository checks. The current-head focused suite, typecheck, changed-code quality gate, and desktop build all pass.

## AI Disclosure

Codex (GPT-5) assisted with diagnosis, implementation, adversarial review, rebase maintenance, and test execution. The reporter manually confirmed the corrected behavior in Orca.

## Review

Start with `terminal-query-reply.ts`, `terminal-query-reply-delivery.ts`, and `pty-startup-ingress.ts`, then review the daemon, `local-pty-session-operations.ts`, and relay owner call sites. Only whole payloads composed of complete cooked-echo-risk replies take the startup-safe path. Ordinary input, CPR, DA, incomplete XTVERSION, and mixed payloads retain their existing raw routing. A recognized reply remains claimed if its protected write fails, so it cannot become input for the next process.

- Cross-platform: POSIX and native ConPTY echo containment have regression coverage. WSL startup ordering is covered, but its echo shape remains unverified and no WSL-specific projection was added.
- Local, remote, and SSH: the PTY-owning host remains authoritative. Local, daemon/headless, and SSH/relay owners use the same startup-ingress classification and do not retry a failed recognized reply through raw stdin.
- Agents and integrations: the behavior is terminal-protocol based. No Codex-specific routing, agent gate, integration behavior, or Git-provider behavior changed.
- Performance: the change adds no timer, polling loop, asynchronous queue, or recurring work. Delivery reports a primitive string-union result instead of allocating a result object on each input write.
- UI and security: no UI, authentication, authorization, secret, filesystem, or network surface changed. The existing screenshots demonstrate the visible before/after behavior.
- Compatibility: no RPC field, stream opcode, persisted schema, or dependency changed. The only deliberate failure-path change is that a recognized reply whose protected PTY write fails is dropped instead of being routed through normal input.

## Agent skill upstream boundary

- [x] Not applicable; no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation are copied or mechanically translated.

## Notes

- Author on X: @luisurrutia_dev
- No research or AI-generated documentation is included in the branch.
- Complete XTVERSION DCS replies join the existing startup-safe path; unrelated query replies keep their established routing.
- No dependency, persistence, mobile, or security boundary changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Fixes #16489
