### PR TITLE
fix(worktrees): resolve id: worktree selectors by path equivalence (#16243)

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -31514,6 +31514,7 @@ export class OrcaRuntimeService {
     return worktreeId
   }
 
+  /** Resolves one workspace or throws `selector_not_found` / `selector_ambiguous` — never picks a winner. */
   private async resolveWorktreeSelector(selector: string): Promise<ResolvedWorktree> {
     const explicitWorktreeId = this.getValidatedExplicitWorktreeIdSelector(selector)
     // Why only `id:`: every other selector kind is matched across the whole fleet, and their

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -509,7 +509,8 @@ import {
   WORKTREE_ID_SEPARATOR,
   getRepoIdFromWorktreeId,
   splitWorktreeId,
-  splitWorktreeIdForFilesystem
+  splitWorktreeIdForFilesystem,
+  worktreeIdComparisonKey
 } from '../../shared/worktree/id'
 import {
   getProjectIdForProviderIdentity,
@@ -31535,6 +31536,16 @@ export class OrcaRuntimeService {
       const worktreeId = explicitWorktreeId ?? selector.slice(3)
       candidates = worktrees.filter((worktree) => worktree.id === worktreeId)
       if (candidates.length === 0) {
+        // Why (#16243): `id:` is the only shape the renderer can send, and a stored id can spell
+        // its path differently from the scan — the divergence `path:` has always absorbed.
+        // The bare unprefixed branch below stays byte-exact on purpose: only `id:` reaches a
+        // renderer caller, so `id:repo::p/` folds here while bare `repo::p/` still misses.
+        const comparisonKey = worktreeIdComparisonKey(worktreeId)
+        candidates = comparisonKey
+          ? worktrees.filter((worktree) => worktreeIdComparisonKey(worktree.id) === comparisonKey)
+          : candidates
+      }
+      if (candidates.length === 0) {
         const parsed = splitWorktreeIdForFilesystem(worktreeId)
         const repo = parsed ? this.store?.getRepo(parsed.repoId) : null
         const fallback =
@@ -40544,12 +40555,8 @@ function runtimePathsEqual(left: string, right: string): boolean {
  * Windows/WSL/SSH ids still match themselves across hosts.
  */
 function runtimeWorktreeIdsEqual(left: string, right: string): boolean {
-  const parsedLeft = splitWorktreeId(left)
-  const parsedRight = splitWorktreeId(right)
-  return parsedLeft && parsedRight
-    ? parsedLeft.repoId === parsedRight.repoId &&
-        runtimePathsEqual(parsedLeft.worktreePath, parsedRight.worktreePath)
-    : left === right
+  const leftKey = worktreeIdComparisonKey(left)
+  return leftKey === null ? left === right : leftKey === worktreeIdComparisonKey(right)
 }
 
 function runtimeWorktreeIdentityKey(worktreeId: string): string {

--- a/src/main/runtime/repo-worktree-row-resolution.test.ts
+++ b/src/main/runtime/repo-worktree-row-resolution.test.ts
@@ -200,3 +200,68 @@ describe('host-qualified scoped worktree resolution', () => {
     expect(getRepos).not.toHaveBeenCalled()
   })
 })
+
+/**
+ * #16243: the renderer can only address a workspace by `id:<repoId>::<path>`, and this scoped
+ * lookup is what a host-qualified removal resolves through. It matched the id byte for byte while a
+ * `path:` selector has always compared through `normalizeRuntimePathForComparison`, so a stored id
+ * spelling its path differently from `git worktree list` resolved for the CLI and not for the UI.
+ */
+describe('scoped worktree id resolution across path spellings (#16243)', () => {
+  it.each([
+    ['a trailing slash', '/same/worktree', 'shared::/same/worktree/'],
+    ['a doubled separator', '/same/worktree', 'shared::/same//worktree'],
+    ['an NFD name', '/same/café', `shared::${'/same/café'.normalize('NFD')}`]
+  ])(
+    'resolves the scanned row when the id carries %s',
+    async (_label, scannedPath, worktreeId) => {
+      const owner = repo('shared', '/local/repo', { executionHostId: 'local' })
+      const deps = createDeps([owner])
+      deps.scanRepo.mockImplementation(async () => ({
+        ok: true,
+        worktrees: [gitWorktree(scannedPath)]
+      }))
+
+      await expect(resolveScopedWorktreeIdRow(deps, worktreeId, 'local')).resolves.toMatchObject({
+        id: `shared::${scannedPath}`,
+        path: scannedPath
+      })
+    }
+  )
+
+  it('still refuses the same path under a different repo id', async () => {
+    const deps = createDeps([
+      repo('shared', '/local/repo', { executionHostId: 'local' }),
+      repo('unrelated', '/unrelated/repo', { executionHostId: 'local' })
+    ])
+
+    await expect(
+      resolveScopedWorktreeIdRow(deps, 'unrelated::/same/worktree/', 'local')
+    ).resolves.toBeNull()
+  })
+
+  it('refuses rather than guessing when two rows spell one path', async () => {
+    const owner = repo('shared', '/local/repo', { executionHostId: 'local' })
+    const deps = createDeps([owner])
+    deps.scanRepo.mockImplementation(async () => ({
+      ok: true,
+      worktrees: [gitWorktree('/same/worktree'), gitWorktree('/same//worktree')]
+    }))
+
+    await expect(resolveScopedWorktreeIdRow(deps, 'shared::/same/worktree/', 'local')).resolves
+      .toBeNull()
+  })
+
+  it('prefers the exactly matching row over an equivalent spelling', async () => {
+    const owner = repo('shared', '/local/repo', { executionHostId: 'local' })
+    const deps = createDeps([owner])
+    deps.scanRepo.mockImplementation(async () => ({
+      ok: true,
+      worktrees: [gitWorktree('/same//worktree'), gitWorktree('/same/worktree')]
+    }))
+
+    await expect(
+      resolveScopedWorktreeIdRow(deps, 'shared::/same//worktree', 'local')
+    ).resolves.toMatchObject({ id: 'shared::/same//worktree' })
+  })
+})

--- a/src/main/runtime/repo-worktree-row-resolution.test.ts
+++ b/src/main/runtime/repo-worktree-row-resolution.test.ts
@@ -212,22 +212,19 @@ describe('scoped worktree id resolution across path spellings (#16243)', () => {
     ['a trailing slash', '/same/worktree', 'shared::/same/worktree/'],
     ['a doubled separator', '/same/worktree', 'shared::/same//worktree'],
     ['an NFD name', '/same/café', `shared::${'/same/café'.normalize('NFD')}`]
-  ])(
-    'resolves the scanned row when the id carries %s',
-    async (_label, scannedPath, worktreeId) => {
-      const owner = repo('shared', '/local/repo', { executionHostId: 'local' })
-      const deps = createDeps([owner])
-      deps.scanRepo.mockImplementation(async () => ({
-        ok: true,
-        worktrees: [gitWorktree(scannedPath)]
-      }))
+  ])('resolves the scanned row when the id carries %s', async (_label, scannedPath, worktreeId) => {
+    const owner = repo('shared', '/local/repo', { executionHostId: 'local' })
+    const deps = createDeps([owner])
+    deps.scanRepo.mockImplementation(async () => ({
+      ok: true,
+      worktrees: [gitWorktree(scannedPath)]
+    }))
 
-      await expect(resolveScopedWorktreeIdRow(deps, worktreeId, 'local')).resolves.toMatchObject({
-        id: `shared::${scannedPath}`,
-        path: scannedPath
-      })
-    }
-  )
+    await expect(resolveScopedWorktreeIdRow(deps, worktreeId, 'local')).resolves.toMatchObject({
+      id: `shared::${scannedPath}`,
+      path: scannedPath
+    })
+  })
 
   it('still refuses the same path under a different repo id', async () => {
     const deps = createDeps([
@@ -248,8 +245,9 @@ describe('scoped worktree id resolution across path spellings (#16243)', () => {
       worktrees: [gitWorktree('/same/worktree'), gitWorktree('/same//worktree')]
     }))
 
-    await expect(resolveScopedWorktreeIdRow(deps, 'shared::/same/worktree/', 'local')).resolves
-      .toBeNull()
+    await expect(
+      resolveScopedWorktreeIdRow(deps, 'shared::/same/worktree/', 'local')
+    ).resolves.toBeNull()
   })
 
   it('prefers the exactly matching row over an equivalent spelling', async () => {

--- a/src/main/runtime/repo-worktree-row-resolution.test.ts
+++ b/src/main/runtime/repo-worktree-row-resolution.test.ts
@@ -262,4 +262,26 @@ describe('scoped worktree id resolution across path spellings (#16243)', () => {
       resolveScopedWorktreeIdRow(deps, 'shared::/same//worktree', 'local')
     ).resolves.toMatchObject({ id: 'shared::/same//worktree' })
   })
+
+  // #15598/#15616: the backslash spelling is what a pre-restart Windows registration recorded.
+  it('resolves a Windows backslash id against the forward-slash spelling git reports', async () => {
+    const path = 'D:/Agentic/game2/battle-core'
+    const owner = repo('shared', 'D:/Agentic/game2', { executionHostId: 'runtime:windows' })
+    const deps = createDeps([owner])
+    deps.scanRepo.mockImplementation(async () => ({ ok: true, worktrees: [gitWorktree(path)] }))
+
+    await expect(
+      resolveScopedWorktreeIdRow(deps, 'shared::D:\\Agentic\\game2\\battle-core', 'runtime:windows')
+    ).resolves.toMatchObject({ id: `shared::${path}`, path })
+  })
+
+  it.each([
+    ['no repo boundary', 'not-an-id'],
+    ['an empty path', 'shared::']
+  ])('keeps exact matching for a malformed id with %s', async (_label, worktreeId) => {
+    const deps = createDeps([repo('shared', '/local/repo', { executionHostId: 'local' })])
+
+    await expect(resolveScopedWorktreeIdRow(deps, worktreeId, 'local')).resolves.toBeNull()
+    expect(deps.scanRepo).not.toHaveBeenCalled()
+  })
 })

--- a/src/main/runtime/repo-worktree-row-resolution.ts
+++ b/src/main/runtime/repo-worktree-row-resolution.ts
@@ -1,4 +1,8 @@
-import { splitWorktreeId, splitWorktreeIdForFilesystem } from '../../shared/worktree/id'
+import {
+  splitWorktreeId,
+  splitWorktreeIdForFilesystem,
+  worktreeIdComparisonKey
+} from '../../shared/worktree/id'
 import { getRepoExecutionHostId, type ExecutionHostId } from '../../shared/execution-host'
 import { isFolderRepo } from '../../shared/repo-kind'
 import { projectResolvedWorktreeLineage } from '../../shared/resolved-worktree-lineage'
@@ -195,5 +199,18 @@ export async function resolveScopedWorktreeIdRow(
     resolveLocalProjectRuntimesForRepos(store, [repo])
   )
   const projected = projectResolvedWorktreeLineage(rows, store.getAllWorktreeLineage?.() ?? {})
-  return projected.find((worktree) => worktree.id === worktreeId) ?? null
+  const exact = projected.find((worktree) => worktree.id === worktreeId)
+  if (exact) {
+    return exact
+  }
+  // Why (#16243): the scan can spell this id's path differently — the divergence `path:` absorbs.
+  // One equivalent row may stand in; two is an ambiguity a scoped lookup must refuse, not guess.
+  const comparisonKey = worktreeIdComparisonKey(worktreeId)
+  if (comparisonKey === null) {
+    return null
+  }
+  const equivalent = projected.filter(
+    (worktree) => worktreeIdComparisonKey(worktree.id) === comparisonKey
+  )
+  return equivalent.length === 1 ? equivalent[0] : null
 }

--- a/src/main/runtime/worktree-rm-id-selector-path-spelling.test.ts
+++ b/src/main/runtime/worktree-rm-id-selector-path-spelling.test.ts
@@ -9,8 +9,12 @@
  * answered `selector_not_found` for the UI, which read that as a stale local mirror, ran
  * `forgetLocal`, reported success, and let the row return on the next refresh: a silent no-op.
  *
- * The contract pinned here is parity: an `id:` selector resolves what the same workspace's `path:`
- * selector resolves, and refuses what it refuses.
+ * The contract pinned here is path-SPELLING parity, not dedup parity: an `id:` selector folds the
+ * same path spellings a `path:` selector folds, and refuses the spellings it refuses. Where two
+ * same-host rows spell one directory, `path:` collapses them to the first while `id:` refuses as
+ * ambiguous — deliberately, because this resolver also serves delete. Parity covers plain worktree
+ * ids; a folder-workspace id keeps a trailing slash placed before the `::workspace:<uuid>` suffix,
+ * so that one spelling stays exact-match-only.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -47,21 +51,24 @@ import { LOCAL_EXECUTION_HOST_ID } from '../../shared/execution-host'
 import { OrcaRuntimeService } from './orca-runtime'
 
 const REPO_ID = 'repo-local'
-const REPO_PATH = '/data/projects/app'
+const REPO_PATH = '/srv/projects/app'
 /** The spelling `git worktree list` reports. */
-const WORKTREE_PATH = '/data/projects/workspaces/headlamp-plugin'
+const WORKTREE_PATH = '/srv/projects/workspaces/plugin-host'
 const CANONICAL_ID = `${REPO_ID}::${WORKTREE_PATH}`
 
 /** One directory, other spellings a stored id can legitimately carry. */
-const ID_SPELLINGS: [label: string, worktreePath: string][] = [
+const ID_SPELLINGS: [label: string, worktreePath: string, repoPath?: string][] = [
   ['a trailing slash', `${WORKTREE_PATH}/`],
-  ['a doubled separator', '/data/projects//workspaces/headlamp-plugin'],
-  ['an NFD workspace name', '/data/projects/workspaces/café-plugin'.normalize('NFD')]
+  ['a doubled separator', '/srv/projects//workspaces/plugin-host'],
+  ['an NFD workspace name', '/srv/projects/workspaces/café-plugin'.normalize('NFD')],
+  // #15598/#15616: a Windows registration records backslashes; git reports forward slashes.
+  ['a backslash Windows spelling', 'D:\\Agentic\\game2\\battle-core', 'D:/Agentic/game2']
 ]
 
 /** What a scan reports for a stored id: the same directory, canonically spelled. */
 function scannedSpellingOf(storedPath: string): string {
-  return storedPath.normalize('NFC').replace(/\/+/g, '/').replace(/\/$/, '')
+  const slashed = /^[A-Za-z]:[\\/]/.test(storedPath) ? storedPath.replace(/\\/g, '/') : storedPath
+  return slashed.normalize('NFC').replace(/\/+/g, '/').replace(/\/$/, '')
 }
 
 function makeStore(repoPath: string = REPO_PATH) {
@@ -118,9 +125,9 @@ beforeEach(() => {
 describe('worktree id selectors vs. the path spelling git reports (#16243)', () => {
   it.each(ID_SPELLINGS)(
     'resolves through the fleet path what `path:` resolves when the id carries %s',
-    async (_label, storedPath) => {
-      scanReports(scannedSpellingOf(storedPath))
-      const runtime = new OrcaRuntimeService(makeStore() as never)
+    async (_label, storedPath, repoPath) => {
+      scanReports(scannedSpellingOf(storedPath), repoPath)
+      const runtime = new OrcaRuntimeService(makeStore(repoPath) as never)
 
       // The CLI's shape, and the live data point: `path:` already resolves it.
       const byPath = await runtime.showManagedWorktree(`path:${storedPath}`)
@@ -133,9 +140,9 @@ describe('worktree id selectors vs. the path spelling git reports (#16243)', () 
 
   it.each(ID_SPELLINGS)(
     'resolves a host-qualified removal target when the id carries %s',
-    async (_label, storedPath) => {
-      scanReports(scannedSpellingOf(storedPath))
-      const runtime = new OrcaRuntimeService(makeStore() as never)
+    async (_label, storedPath, repoPath) => {
+      scanReports(scannedSpellingOf(storedPath), repoPath)
+      const runtime = new OrcaRuntimeService(makeStore(repoPath) as never)
       const internals = runtime as unknown as RemovalInternals
 
       // The scoped path the UI's delete takes must agree with the fleet path above.
@@ -153,7 +160,7 @@ describe('worktree id selectors vs. the path spelling git reports (#16243)', () 
     const runtime = new OrcaRuntimeService(makeStore() as never)
 
     await expect(
-      runtime.showManagedWorktree(`id:${REPO_ID}::/data/projects/workspaces/other-plugin`)
+      runtime.showManagedWorktree(`id:${REPO_ID}::/srv/projects/workspaces/other-plugin`)
     ).rejects.toThrow('selector_not_found')
   })
 
@@ -180,7 +187,7 @@ describe('worktree id selectors vs. the path spelling git reports (#16243)', () 
   it('keeps `id:` and `path:` agreeing on a dot segment neither canonicalizes', async () => {
     scanReports(WORKTREE_PATH)
     const runtime = new OrcaRuntimeService(makeStore() as never)
-    const dotted = '/data/projects/./workspaces/headlamp-plugin'
+    const dotted = '/srv/projects/./workspaces/plugin-host'
 
     await expect(runtime.showManagedWorktree(`path:${dotted}`)).rejects.toThrow(
       'selector_not_found'
@@ -191,40 +198,28 @@ describe('worktree id selectors vs. the path spelling git reports (#16243)', () 
   })
 
   // #15598/#15616: on Windows one checkout is recorded under both spellings, and git reports the
-  // forward-slash one. The same divergence class, reaching the selector instead of a purge check.
+  // forward-slash one. The backslash id itself rides the ID_SPELLINGS rows above; these pin the
+  // folding limits around it.
   describe('Windows drive-letter spellings', () => {
     const WINDOWS_REPO = 'D:/Agentic/game2'
     const WINDOWS_WORKTREE = 'D:/Agentic/game2/battle-core'
-    const BACKSLASH_ID = `${REPO_ID}::D:\\Agentic\\game2\\battle-core`
-
-    it('resolves a backslash id against the forward-slash spelling git reports', async () => {
-      scanReports(WINDOWS_WORKTREE, WINDOWS_REPO)
-      const runtime = new OrcaRuntimeService(makeStore(WINDOWS_REPO) as never)
-
-      await expect(runtime.showManagedWorktree(`id:${BACKSLASH_ID}`)).resolves.toMatchObject({
-        id: `${REPO_ID}::${WINDOWS_WORKTREE}`,
-        path: WINDOWS_WORKTREE
-      })
-    })
-
-    it('resolves a host-qualified removal target for the backslash id', async () => {
-      scanReports(WINDOWS_WORKTREE, WINDOWS_REPO)
-      const runtime = new OrcaRuntimeService(makeStore(WINDOWS_REPO) as never)
-      const internals = runtime as unknown as RemovalInternals
-
-      await expect(
-        internals.resolveWorktreeRemovalTarget(`id:${BACKSLASH_ID}`, LOCAL_EXECUTION_HOST_ID)
-      ).resolves.toMatchObject({ repoId: REPO_ID, path: WINDOWS_WORKTREE })
-    })
 
     it('folds drive-letter case only for Windows paths, never for a POSIX path', async () => {
       scanReports(WINDOWS_WORKTREE, WINDOWS_REPO)
-      const runtime = new OrcaRuntimeService(makeStore(WINDOWS_REPO) as never)
+      const windowsRuntime = new OrcaRuntimeService(makeStore(WINDOWS_REPO) as never)
 
       // A Windows root is case-insensitive, as `path:` already treats it.
       await expect(
-        runtime.showManagedWorktree(`id:${REPO_ID}::d:/agentic/game2/battle-core`)
+        windowsRuntime.showManagedWorktree(`id:${REPO_ID}::d:/agentic/game2/battle-core`)
       ).resolves.toMatchObject({ path: WINDOWS_WORKTREE })
+
+      // A POSIX root is not: folding case there would merge distinct directories for a delete.
+      scanReports(WORKTREE_PATH)
+      const posixRuntime = new OrcaRuntimeService(makeStore() as never)
+
+      await expect(
+        posixRuntime.showManagedWorktree(`id:${REPO_ID}::/SRV/projects/workspaces/plugin-host`)
+      ).rejects.toThrow('selector_not_found')
     })
 
     it('does not fold a backslash inside a POSIX path, where it is a valid filename character', async () => {
@@ -232,9 +227,43 @@ describe('worktree id selectors vs. the path spelling git reports (#16243)', () 
       const runtime = new OrcaRuntimeService(makeStore() as never)
 
       await expect(
-        runtime.showManagedWorktree(`id:${REPO_ID}::/data/projects\\workspaces\\headlamp-plugin`)
+        runtime.showManagedWorktree(`id:${REPO_ID}::/srv/projects\\workspaces\\plugin-host`)
       ).rejects.toThrow('selector_not_found')
     })
+  })
+
+  // The fail-closed guard on a delete-capable resolver: two rows spelling one directory must not
+  // let a folded id pick one. `path:` collapses same-host duplicates; `id:` deliberately refuses.
+  it('refuses a folded id when two same-repo rows spell one directory', async () => {
+    listWorktreesStrictMock.mockResolvedValue([
+      { path: REPO_PATH, head: 'abc', branch: 'main', isBare: false, isMainWorktree: true },
+      { path: WORKTREE_PATH, head: 'def', branch: 'feature', isBare: false, isMainWorktree: false },
+      {
+        path: '/srv/projects//workspaces/plugin-host',
+        head: 'ghi',
+        branch: 'feature-2',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    const runtime = new OrcaRuntimeService(makeStore() as never)
+
+    // Matches neither row exactly, folds to both.
+    await expect(runtime.showManagedWorktree(`id:${CANONICAL_ID}/`)).rejects.toThrow(
+      'selector_ambiguous'
+    )
+  })
+
+  // Live-proof limit, pinned so nobody "fixes" the trimming: a folder-workspace id only trims a
+  // trailing slash at end of string, so one placed before the instance suffix stays exact-only.
+  it('keeps a folder-workspace id exact when a slash precedes the instance suffix', async () => {
+    const instanceSuffix = '::workspace:123e4567-e89b-12d3-a456-426614174000'
+    scanReports(WORKTREE_PATH)
+    const runtime = new OrcaRuntimeService(makeStore() as never)
+
+    await expect(
+      runtime.showManagedWorktree(`id:${REPO_ID}::${WORKTREE_PATH}/${instanceSuffix}`)
+    ).rejects.toThrow('selector_not_found')
   })
 
   // #15616 guarantees malformed ids keep exact-match behavior; both sites must honour that too.

--- a/src/main/runtime/worktree-rm-id-selector-path-spelling.test.ts
+++ b/src/main/runtime/worktree-rm-id-selector-path-spelling.test.ts
@@ -74,7 +74,7 @@ function makeStore() {
     getAllWorktreeMeta: vi.fn(() => metaById),
     getWorktreeMeta: (id: string) => metaById[id],
     setWorktreeMeta: (id: string, meta: Record<string, unknown>) => {
-      metaById[id] = { ...(metaById[id] ?? {}), ...meta }
+      metaById[id] = { ...metaById[id], ...meta }
       return metaById[id]
     },
     removeWorktreeMeta: () => {},
@@ -182,7 +182,9 @@ describe('worktree id selectors vs. the path spelling git reports (#16243)', () 
     const runtime = new OrcaRuntimeService(makeStore() as never)
     const dotted = '/data/projects/./workspaces/headlamp-plugin'
 
-    await expect(runtime.showManagedWorktree(`path:${dotted}`)).rejects.toThrow('selector_not_found')
+    await expect(runtime.showManagedWorktree(`path:${dotted}`)).rejects.toThrow(
+      'selector_not_found'
+    )
     await expect(runtime.showManagedWorktree(`id:${REPO_ID}::${dotted}`)).rejects.toThrow(
       'selector_not_found'
     )

--- a/src/main/runtime/worktree-rm-id-selector-path-spelling.test.ts
+++ b/src/main/runtime/worktree-rm-id-selector-path-spelling.test.ts
@@ -64,12 +64,12 @@ function scannedSpellingOf(storedPath: string): string {
   return storedPath.normalize('NFC').replace(/\/+/g, '/').replace(/\/$/, '')
 }
 
-function makeStore() {
+function makeStore(repoPath: string = REPO_PATH) {
   const metaById: Record<string, Record<string, unknown>> = {}
   const store = {
     getRepo: (id: string) => store.getRepos().find((repo) => repo.id === id),
     getRepos: () => [
-      { id: REPO_ID, path: REPO_PATH, displayName: 'app', badgeColor: 'blue', addedAt: 1 }
+      { id: REPO_ID, path: repoPath, displayName: 'app', badgeColor: 'blue', addedAt: 1 }
     ],
     getAllWorktreeMeta: vi.fn(() => metaById),
     getWorktreeMeta: (id: string) => metaById[id],
@@ -96,9 +96,9 @@ function makeStore() {
 }
 
 /** `git worktree list` output: the main checkout plus one workspace at `worktreePath`. */
-function scanReports(worktreePath: string): void {
+function scanReports(worktreePath: string, repoPath: string = REPO_PATH): void {
   listWorktreesStrictMock.mockResolvedValue([
-    { path: REPO_PATH, head: 'abc', branch: 'main', isBare: false, isMainWorktree: true },
+    { path: repoPath, head: 'abc', branch: 'main', isBare: false, isMainWorktree: true },
     { path: worktreePath, head: 'def', branch: 'feature', isBare: false, isMainWorktree: false }
   ])
 }
@@ -188,5 +188,69 @@ describe('worktree id selectors vs. the path spelling git reports (#16243)', () 
     await expect(runtime.showManagedWorktree(`id:${REPO_ID}::${dotted}`)).rejects.toThrow(
       'selector_not_found'
     )
+  })
+
+  // #15598/#15616: on Windows one checkout is recorded under both spellings, and git reports the
+  // forward-slash one. The same divergence class, reaching the selector instead of a purge check.
+  describe('Windows drive-letter spellings', () => {
+    const WINDOWS_REPO = 'D:/Agentic/game2'
+    const WINDOWS_WORKTREE = 'D:/Agentic/game2/battle-core'
+    const BACKSLASH_ID = `${REPO_ID}::D:\\Agentic\\game2\\battle-core`
+
+    it('resolves a backslash id against the forward-slash spelling git reports', async () => {
+      scanReports(WINDOWS_WORKTREE, WINDOWS_REPO)
+      const runtime = new OrcaRuntimeService(makeStore(WINDOWS_REPO) as never)
+
+      await expect(runtime.showManagedWorktree(`id:${BACKSLASH_ID}`)).resolves.toMatchObject({
+        id: `${REPO_ID}::${WINDOWS_WORKTREE}`,
+        path: WINDOWS_WORKTREE
+      })
+    })
+
+    it('resolves a host-qualified removal target for the backslash id', async () => {
+      scanReports(WINDOWS_WORKTREE, WINDOWS_REPO)
+      const runtime = new OrcaRuntimeService(makeStore(WINDOWS_REPO) as never)
+      const internals = runtime as unknown as RemovalInternals
+
+      await expect(
+        internals.resolveWorktreeRemovalTarget(`id:${BACKSLASH_ID}`, LOCAL_EXECUTION_HOST_ID)
+      ).resolves.toMatchObject({ repoId: REPO_ID, path: WINDOWS_WORKTREE })
+    })
+
+    it('folds drive-letter case only for Windows paths, never for a POSIX path', async () => {
+      scanReports(WINDOWS_WORKTREE, WINDOWS_REPO)
+      const runtime = new OrcaRuntimeService(makeStore(WINDOWS_REPO) as never)
+
+      // A Windows root is case-insensitive, as `path:` already treats it.
+      await expect(
+        runtime.showManagedWorktree(`id:${REPO_ID}::d:/agentic/game2/battle-core`)
+      ).resolves.toMatchObject({ path: WINDOWS_WORKTREE })
+    })
+
+    it('does not fold a backslash inside a POSIX path, where it is a valid filename character', async () => {
+      scanReports(WORKTREE_PATH)
+      const runtime = new OrcaRuntimeService(makeStore() as never)
+
+      await expect(
+        runtime.showManagedWorktree(`id:${REPO_ID}::/data/projects\\workspaces\\headlamp-plugin`)
+      ).rejects.toThrow('selector_not_found')
+    })
+  })
+
+  // #15616 guarantees malformed ids keep exact-match behavior; both sites must honour that too.
+  it.each([
+    ['no repo boundary', 'not-an-id'],
+    ['an empty path', `${REPO_ID}::`]
+  ])('keeps exact matching for a malformed id with %s', async (_label, malformedId) => {
+    scanReports(WORKTREE_PATH)
+    const runtime = new OrcaRuntimeService(makeStore() as never)
+    const internals = runtime as unknown as RemovalInternals
+
+    await expect(runtime.showManagedWorktree(`id:${malformedId}`)).rejects.toThrow(
+      'selector_not_found'
+    )
+    await expect(
+      internals.resolveWorktreeRemovalTarget(`id:${malformedId}`, LOCAL_EXECUTION_HOST_ID)
+    ).rejects.toThrow('selector_not_found')
   })
 })

--- a/src/main/runtime/worktree-rm-id-selector-path-spelling.test.ts
+++ b/src/main/runtime/worktree-rm-id-selector-path-spelling.test.ts
@@ -1,0 +1,190 @@
+/**
+ * #16243: "Delete Workspace" in the sidebar resolves nothing on a paired runtime while
+ * `orca worktree rm --worktree "path:<dir>" --force` removes the very same workspace.
+ *
+ * The renderer can only address a workspace by its id (`toRuntimeWorktreeSelector` always emits
+ * `id:<repoId>::<path>`), and the runtime matched that id by exact string equality — while a
+ * `path:` selector has always compared through `normalizeRuntimePathForComparison`. A stored id
+ * spelling its path differently from `git worktree list` therefore resolved for the CLI and
+ * answered `selector_not_found` for the UI, which read that as a stale local mirror, ran
+ * `forgetLocal`, reported success, and let the row return on the next refresh: a silent no-op.
+ *
+ * The contract pinned here is parity: an `id:` selector resolves what the same workspace's `path:`
+ * selector resolves, and refuses what it refuses.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const electronMocks = vi.hoisted(() => {
+  const ipcMain = {
+    on: vi.fn(() => ipcMain),
+    removeListener: vi.fn(() => ipcMain),
+    emit: vi.fn(() => true)
+  }
+  return {
+    BrowserWindow: { fromId: vi.fn((): unknown => null) },
+    webContents: { fromId: vi.fn((): unknown => null) },
+    ipcMain,
+    app: { getPath: vi.fn(() => '/tmp'), isPackaged: false }
+  }
+})
+vi.mock('electron', () => electronMocks)
+
+const getSshGitProviderMock = vi.hoisted(() => vi.fn())
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: getSshGitProviderMock,
+  getSshGitProviderGeneration: vi.fn(() => 0),
+  SSH_GIT_PROVIDER_UNAVAILABLE_MESSAGE: 'unavailable',
+  requireSshGitProvider: (connectionId: string) => getSshGitProviderMock(connectionId)
+}))
+
+const listWorktreesStrictMock = vi.hoisted(() => vi.fn())
+vi.mock('../git/worktree', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  listWorktreesStrict: listWorktreesStrictMock
+}))
+
+import { LOCAL_EXECUTION_HOST_ID } from '../../shared/execution-host'
+import { OrcaRuntimeService } from './orca-runtime'
+
+const REPO_ID = 'repo-local'
+const REPO_PATH = '/data/projects/app'
+/** The spelling `git worktree list` reports. */
+const WORKTREE_PATH = '/data/projects/workspaces/headlamp-plugin'
+const CANONICAL_ID = `${REPO_ID}::${WORKTREE_PATH}`
+
+/** One directory, other spellings a stored id can legitimately carry. */
+const ID_SPELLINGS: [label: string, worktreePath: string][] = [
+  ['a trailing slash', `${WORKTREE_PATH}/`],
+  ['a doubled separator', '/data/projects//workspaces/headlamp-plugin'],
+  ['an NFD workspace name', '/data/projects/workspaces/café-plugin'.normalize('NFD')]
+]
+
+/** What a scan reports for a stored id: the same directory, canonically spelled. */
+function scannedSpellingOf(storedPath: string): string {
+  return storedPath.normalize('NFC').replace(/\/+/g, '/').replace(/\/$/, '')
+}
+
+function makeStore() {
+  const metaById: Record<string, Record<string, unknown>> = {}
+  const store = {
+    getRepo: (id: string) => store.getRepos().find((repo) => repo.id === id),
+    getRepos: () => [
+      { id: REPO_ID, path: REPO_PATH, displayName: 'app', badgeColor: 'blue', addedAt: 1 }
+    ],
+    getAllWorktreeMeta: vi.fn(() => metaById),
+    getWorktreeMeta: (id: string) => metaById[id],
+    setWorktreeMeta: (id: string, meta: Record<string, unknown>) => {
+      metaById[id] = { ...(metaById[id] ?? {}), ...meta }
+      return metaById[id]
+    },
+    removeWorktreeMeta: () => {},
+    getAllWorktreeLineage: () => ({}),
+    getAllWorkspaceLineage: () => ({}),
+    removeWorktreeLineage: vi.fn(),
+    removeWorkspaceLineage: vi.fn(),
+    getGitHubCache: () => undefined as never,
+    getSettings: () => ({
+      workspaceDir: '/tmp/workspaces',
+      nestWorkspaces: false,
+      refreshLocalBaseRefOnWorktreeCreate: false,
+      branchPrefix: 'none',
+      branchPrefixCustom: ''
+    }),
+    getProjects: () => []
+  }
+  return store
+}
+
+/** `git worktree list` output: the main checkout plus one workspace at `worktreePath`. */
+function scanReports(worktreePath: string): void {
+  listWorktreesStrictMock.mockResolvedValue([
+    { path: REPO_PATH, head: 'abc', branch: 'main', isBare: false, isMainWorktree: true },
+    { path: worktreePath, head: 'def', branch: 'feature', isBare: false, isMainWorktree: false }
+  ])
+}
+
+type RemovalInternals = {
+  resolveWorktreeRemovalTarget: (
+    worktreeSelector: string,
+    requiredHostId?: string
+  ) => Promise<{ id: string; repoId: string; path: string }>
+}
+
+beforeEach(() => {
+  getSshGitProviderMock.mockReset()
+  listWorktreesStrictMock.mockReset()
+})
+
+describe('worktree id selectors vs. the path spelling git reports (#16243)', () => {
+  it.each(ID_SPELLINGS)(
+    'resolves through the fleet path what `path:` resolves when the id carries %s',
+    async (_label, storedPath) => {
+      scanReports(scannedSpellingOf(storedPath))
+      const runtime = new OrcaRuntimeService(makeStore() as never)
+
+      // The CLI's shape, and the live data point: `path:` already resolves it.
+      const byPath = await runtime.showManagedWorktree(`path:${storedPath}`)
+      // The only shape the renderer can send must resolve the SAME workspace.
+      await expect(
+        runtime.showManagedWorktree(`id:${REPO_ID}::${storedPath}`)
+      ).resolves.toMatchObject({ id: byPath.id, path: byPath.path })
+    }
+  )
+
+  it.each(ID_SPELLINGS)(
+    'resolves a host-qualified removal target when the id carries %s',
+    async (_label, storedPath) => {
+      scanReports(scannedSpellingOf(storedPath))
+      const runtime = new OrcaRuntimeService(makeStore() as never)
+      const internals = runtime as unknown as RemovalInternals
+
+      // The scoped path the UI's delete takes must agree with the fleet path above.
+      await expect(
+        internals.resolveWorktreeRemovalTarget(
+          `id:${REPO_ID}::${storedPath}`,
+          LOCAL_EXECUTION_HOST_ID
+        )
+      ).resolves.toMatchObject({ repoId: REPO_ID, path: scannedSpellingOf(storedPath) })
+    }
+  )
+
+  it('still refuses an id whose path names a different workspace', async () => {
+    scanReports(WORKTREE_PATH)
+    const runtime = new OrcaRuntimeService(makeStore() as never)
+
+    await expect(
+      runtime.showManagedWorktree(`id:${REPO_ID}::/data/projects/workspaces/other-plugin`)
+    ).rejects.toThrow('selector_not_found')
+  })
+
+  // STA-4343: matching across repo ids would delete a workspace the caller never confirmed.
+  it('still refuses the same path under a different repo id', async () => {
+    scanReports(WORKTREE_PATH)
+    const runtime = new OrcaRuntimeService(makeStore() as never)
+
+    await expect(runtime.showManagedWorktree(`id:other-repo::${WORKTREE_PATH}/`)).rejects.toThrow(
+      'selector_not_found'
+    )
+  })
+
+  it('still refuses a removal qualified to a host that does not own the repo id', async () => {
+    scanReports(WORKTREE_PATH)
+    const runtime = new OrcaRuntimeService(makeStore() as never)
+    const internals = runtime as unknown as RemovalInternals
+
+    await expect(
+      internals.resolveWorktreeRemovalTarget(`id:${CANONICAL_ID}/`, 'runtime:env-b')
+    ).rejects.toThrow('selector_not_found')
+  })
+
+  it('keeps `id:` and `path:` agreeing on a dot segment neither canonicalizes', async () => {
+    scanReports(WORKTREE_PATH)
+    const runtime = new OrcaRuntimeService(makeStore() as never)
+    const dotted = '/data/projects/./workspaces/headlamp-plugin'
+
+    await expect(runtime.showManagedWorktree(`path:${dotted}`)).rejects.toThrow('selector_not_found')
+    await expect(runtime.showManagedWorktree(`id:${REPO_ID}::${dotted}`)).rejects.toThrow(
+      'selector_not_found'
+    )
+  })
+})

--- a/src/main/runtime/worktree-rm-id-selector-path-spelling.test.ts
+++ b/src/main/runtime/worktree-rm-id-selector-path-spelling.test.ts
@@ -1,20 +1,7 @@
 /**
- * #16243: "Delete Workspace" in the sidebar resolves nothing on a paired runtime while
- * `orca worktree rm --worktree "path:<dir>" --force` removes the very same workspace.
- *
- * The renderer can only address a workspace by its id (`toRuntimeWorktreeSelector` always emits
- * `id:<repoId>::<path>`), and the runtime matched that id by exact string equality — while a
- * `path:` selector has always compared through `normalizeRuntimePathForComparison`. A stored id
- * spelling its path differently from `git worktree list` therefore resolved for the CLI and
- * answered `selector_not_found` for the UI, which read that as a stale local mirror, ran
- * `forgetLocal`, reported success, and let the row return on the next refresh: a silent no-op.
- *
- * The contract pinned here is path-SPELLING parity, not dedup parity: an `id:` selector folds the
- * same path spellings a `path:` selector folds, and refuses the spellings it refuses. Where two
- * same-host rows spell one directory, `path:` collapses them to the first while `id:` refuses as
- * ambiguous — deliberately, because this resolver also serves delete. Parity covers plain worktree
- * ids; a folder-workspace id keeps a trailing slash placed before the `::workspace:<uuid>` suffix,
- * so that one spelling stays exact-match-only.
+ * Pins path-SPELLING parity between an `id:` selector and `path:`, deliberately not dedupe parity:
+ * where two same-host rows spell one directory, `path:` collapses them to the first while `id:`
+ * refuses as ambiguous, because this resolver also serves delete (#16243).
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -71,6 +58,7 @@ function scannedSpellingOf(storedPath: string): string {
   return slashed.normalize('NFC').replace(/\/+/g, '/').replace(/\/$/, '')
 }
 
+/** One registered repo whose worktree meta is writable, so a delete's `forgetLocal` is observable. */
 function makeStore(repoPath: string = REPO_PATH) {
   const metaById: Record<string, Record<string, unknown>> = {}
   const store = {

--- a/src/shared/worktree/id.test.ts
+++ b/src/shared/worktree/id.test.ts
@@ -144,6 +144,17 @@ describe('worktreeIdComparisonKey path-spelling parity for id: selectors (#16243
     expect(key('repo-123::/data/./workspaces/plugin')).not.toBe(key(canonical))
   })
 
+  // #15598/#15616: the same Windows checkout is recorded with both separators.
+  it('folds Windows separator and drive-letter case, as `path:` already does', () => {
+    const windows = 'repo-123::D:/Agentic/game2'
+    expect(key('repo-123::D:\\Agentic\\game2')).toBe(key(windows))
+    expect(key('repo-123::d:/agentic/game2')).toBe(key(windows))
+    // A backslash is a valid POSIX filename character, so a POSIX path never folds it.
+    expect(key('repo-123::/data\\workspaces')).not.toBe(key('repo-123::/data/workspaces'))
+    // POSIX roots stay case-sensitive.
+    expect(key('repo-123::/data/Workspaces')).not.toBe(key('repo-123::/data/workspaces'))
+  })
+
   it('never merges different repos, workspaces, or folder sessions', () => {
     // STA-4343: the repo id stays exact, or a removal lands on a repo the caller never confirmed.
     expect(key('repo-999::/data/workspaces/plugin')).not.toBe(key(canonical))

--- a/src/shared/worktree/id.test.ts
+++ b/src/shared/worktree/id.test.ts
@@ -126,22 +126,22 @@ describe('getWorktreePathBasenameFromId', () => {
  * exactly the path spellings a `path:` selector already folds — and nothing more.
  */
 describe('worktreeIdComparisonKey path-spelling parity for id: selectors (#16243)', () => {
-  const canonical = 'repo-123::/data/workspaces/plugin'
+  const canonical = 'repo-123::/srv/workspaces/plugin'
   const key = (worktreeId: string): string | null => worktreeIdComparisonKey(worktreeId)
 
   it('folds the path spellings a `path:` selector already accepts', () => {
-    expect(key('repo-123::/data/workspaces/plugin/')).toBe(key(canonical))
-    expect(key('repo-123::/data//workspaces/plugin')).toBe(key(canonical))
-    expect(key('repo-123::/data/workspaces/Café'.normalize('NFD'))).toBe(
-      key('repo-123::/data/workspaces/Café'.normalize('NFC'))
+    expect(key('repo-123::/srv/workspaces/plugin/')).toBe(key(canonical))
+    expect(key('repo-123::/srv//workspaces/plugin')).toBe(key(canonical))
+    expect(key('repo-123::/srv/workspaces/Café'.normalize('NFD'))).toBe(
+      key('repo-123::/srv/workspaces/Café'.normalize('NFC'))
     )
   })
 
   it('folds no more loosely than `path:` does', () => {
     // A leading `//` is a UNC root, not a doubled separator.
-    expect(key('repo-123://data/workspaces/plugin')).not.toBe(key(canonical))
+    expect(key('repo-123://srv/workspaces/plugin')).not.toBe(key(canonical))
     // Dot segments are not canonicalized, so `id:` and `path:` still agree on refusing them.
-    expect(key('repo-123::/data/./workspaces/plugin')).not.toBe(key(canonical))
+    expect(key('repo-123::/srv/./workspaces/plugin')).not.toBe(key(canonical))
   })
 
   // #15598/#15616: the same Windows checkout is recorded with both separators.
@@ -150,23 +150,35 @@ describe('worktreeIdComparisonKey path-spelling parity for id: selectors (#16243
     expect(key('repo-123::D:\\Agentic\\game2')).toBe(key(windows))
     expect(key('repo-123::d:/agentic/game2')).toBe(key(windows))
     // A backslash is a valid POSIX filename character, so a POSIX path never folds it.
-    expect(key('repo-123::/data\\workspaces')).not.toBe(key('repo-123::/data/workspaces'))
+    expect(key('repo-123::/srv\\workspaces')).not.toBe(key('repo-123::/srv/workspaces'))
     // POSIX roots stay case-sensitive.
-    expect(key('repo-123::/data/Workspaces')).not.toBe(key('repo-123::/data/workspaces'))
+    expect(key('repo-123::/srv/Workspaces')).not.toBe(key('repo-123::/srv/workspaces'))
+  })
+
+  it('keeps a UNC or WSL root distinct from a drive-letter location', () => {
+    // Different roots naming different filesystems must never collapse into one key.
+    expect(key('repo-123://server/share/game2')).not.toBe(key('repo-123::D:/server/share/game2'))
+    expect(key('repo-123://wsl.localhost/Ubuntu/home/dev/game2')).not.toBe(
+      key('repo-123::D:/home/dev/game2')
+    )
+    // The two UNC aliases Windows exposes for one WSL distro are the same location.
+    expect(key('repo-123://wsl.localhost/Ubuntu/home/dev/game2')).toBe(
+      key('repo-123://wsl$/Ubuntu/home/dev/game2')
+    )
   })
 
   it('never merges different repos, workspaces, or folder sessions', () => {
     // STA-4343: the repo id stays exact, or a removal lands on a repo the caller never confirmed.
-    expect(key('repo-999::/data/workspaces/plugin')).not.toBe(key(canonical))
-    expect(key('repo-123::/data/workspaces/other')).not.toBe(key(canonical))
-    expect(key('repo-a::/data/folder::workspace:123e4567-e89b-12d3-a456-426614174000')).not.toBe(
-      key('repo-a::/data/folder::workspace:123e4567-e89b-12d3-a456-426614174001')
+    expect(key('repo-999::/srv/workspaces/plugin')).not.toBe(key(canonical))
+    expect(key('repo-123::/srv/workspaces/other')).not.toBe(key(canonical))
+    expect(key('repo-a::/srv/folder::workspace:123e4567-e89b-12d3-a456-426614174000')).not.toBe(
+      key('repo-a::/srv/folder::workspace:123e4567-e89b-12d3-a456-426614174001')
     )
   })
 
   it('returns null for ids with no repo boundary so callers keep exact matching', () => {
     expect(key('repo-a')).toBeNull()
     expect(key('repo-a::')).toBeNull()
-    expect(key('/data/workspaces/plugin')).toBeNull()
+    expect(key('/srv/workspaces/plugin')).toBeNull()
   })
 })

--- a/src/shared/worktree/id.test.ts
+++ b/src/shared/worktree/id.test.ts
@@ -4,7 +4,8 @@ import {
   getRepoIdFromWorktreeId,
   getWorktreePathBasenameFromId,
   splitWorktreeId,
-  splitWorktreeIdForFilesystem
+  splitWorktreeIdForFilesystem,
+  worktreeIdComparisonKey
 } from './id'
 
 describe('WORKTREE_ID_SEPARATOR', () => {
@@ -117,5 +118,44 @@ describe('getWorktreePathBasenameFromId', () => {
   it('returns null when no worktree path is available', () => {
     expect(getWorktreePathBasenameFromId('repo-123')).toBeNull()
     expect(getWorktreePathBasenameFromId('repo-123::')).toBeNull()
+  })
+})
+
+/**
+ * #16243: the renderer can only address a workspace by `id:<repoId>::<path>`, so the key must fold
+ * exactly the path spellings a `path:` selector already folds — and nothing more.
+ */
+describe('worktreeIdComparisonKey path-spelling parity for id: selectors (#16243)', () => {
+  const canonical = 'repo-123::/data/workspaces/plugin'
+  const key = (worktreeId: string): string | null => worktreeIdComparisonKey(worktreeId)
+
+  it('folds the path spellings a `path:` selector already accepts', () => {
+    expect(key('repo-123::/data/workspaces/plugin/')).toBe(key(canonical))
+    expect(key('repo-123::/data//workspaces/plugin')).toBe(key(canonical))
+    expect(key('repo-123::/data/workspaces/Café'.normalize('NFD'))).toBe(
+      key('repo-123::/data/workspaces/Café'.normalize('NFC'))
+    )
+  })
+
+  it('folds no more loosely than `path:` does', () => {
+    // A leading `//` is a UNC root, not a doubled separator.
+    expect(key('repo-123://data/workspaces/plugin')).not.toBe(key(canonical))
+    // Dot segments are not canonicalized, so `id:` and `path:` still agree on refusing them.
+    expect(key('repo-123::/data/./workspaces/plugin')).not.toBe(key(canonical))
+  })
+
+  it('never merges different repos, workspaces, or folder sessions', () => {
+    // STA-4343: the repo id stays exact, or a removal lands on a repo the caller never confirmed.
+    expect(key('repo-999::/data/workspaces/plugin')).not.toBe(key(canonical))
+    expect(key('repo-123::/data/workspaces/other')).not.toBe(key(canonical))
+    expect(key('repo-a::/data/folder::workspace:123e4567-e89b-12d3-a456-426614174000')).not.toBe(
+      key('repo-a::/data/folder::workspace:123e4567-e89b-12d3-a456-426614174001')
+    )
+  })
+
+  it('returns null for ids with no repo boundary so callers keep exact matching', () => {
+    expect(key('repo-a')).toBeNull()
+    expect(key('repo-a::')).toBeNull()
+    expect(key('/data/workspaces/plugin')).toBeNull()
   })
 })

--- a/src/shared/worktree/id.ts
+++ b/src/shared/worktree/id.ts
@@ -1,3 +1,4 @@
+import { normalizeRuntimePathForComparison } from '../cross-platform-path'
 import { WORKTREE_ID_SEPARATOR } from '../pty-session-id-format'
 
 export { WORKTREE_ID_SEPARATOR } from '../pty-session-id-format'
@@ -15,6 +16,27 @@ const FOLDER_WORKSPACE_INSTANCE_SUFFIX = new RegExp(
 export function getRepoIdFromWorktreeId(worktreeId: string): string {
   const separatorIdx = worktreeId.indexOf(WORKTREE_ID_SEPARATOR)
   return separatorIdx === -1 ? worktreeId : worktreeId.slice(0, separatorIdx)
+}
+
+/**
+ * Canonical comparison form of a worktree id: one repo, one filesystem location, one
+ * folder-workspace instance — regardless of how the path is spelled.
+ *
+ * Why (#16243): a `path:` selector has always compared through `normalizeRuntimePathForComparison`
+ * while an id compared byte for byte, so a stored id spelling its path differently from
+ * `git worktree list` resolved for the CLI and not for the UI, which can only address a workspace
+ * by id. Comparison only — never persist or return this key.
+ *
+ * Null for malformed ids so callers keep exact matching for them.
+ */
+export function worktreeIdComparisonKey(worktreeId: string): string | null {
+  const parsed = splitWorktreeId(worktreeId)
+  if (!parsed || !parsed.repoId || !parsed.worktreePath) {
+    return null
+  }
+  return `${parsed.repoId}${WORKTREE_ID_SEPARATOR}${normalizeRuntimePathForComparison(
+    parsed.worktreePath
+  )}`
 }
 
 export function splitWorktreeId(worktreeId: string): ParsedWorktreeId | null {

--- a/src/shared/worktree/id.ts
+++ b/src/shared/worktree/id.ts
@@ -19,15 +19,10 @@ export function getRepoIdFromWorktreeId(worktreeId: string): string {
 }
 
 /**
- * Canonical comparison form of a worktree id: one repo, one filesystem location, one
- * folder-workspace instance — regardless of how the path is spelled.
- *
- * Why (#16243): a `path:` selector has always compared through `normalizeRuntimePathForComparison`
- * while an id compared byte for byte, so a stored id spelling its path differently from
- * `git worktree list` resolved for the CLI and not for the UI, which can only address a workspace
- * by id. Comparison only — never persist or return this key.
- *
- * Null for malformed ids so callers keep exact matching for them.
+ * Canonical comparison form of a worktree id: the repoId is compared EXACT and only the path folds,
+ * through the same `normalizeRuntimePathForComparison` a `path:` selector has always applied and
+ * byte-exact id matching denied the renderer (#16243). Null for a malformed id, so callers keep
+ * exact matching for it. Comparison only — never persist or return this key.
  */
 export function worktreeIdComparisonKey(worktreeId: string): string | null {
   const parsed = splitWorktreeId(worktreeId)


### PR DESCRIPTION
Partially addresses #16243 — deliberately no closing keyword; see *Linked Issue*.

## ELI5

Deleting a workspace from the sidebar did nothing, while deleting the same workspace from the CLI
worked. The UI can only ask for a workspace by its **id**, and the runtime matched that id letter for
letter — so if the id spelled the folder path even slightly differently from what `git worktree list`
reports (a trailing slash, a doubled slash, a Mac-composed accent), the runtime said "no such
workspace". The UI read that as "this row is stale junk", quietly forgot it locally, reported success,
and the row came back on the next refresh. A `path:` selector never had this problem, because it has
always compared paths through a normalizer. This PR makes an `id:` selector compare its path the same
way `path:` already does — and nothing more.

## What Changed

- `src/shared/worktree/id.ts`: adds `worktreeIdComparisonKey(worktreeId)` — the canonical comparison
  form of an id: repo id **exact**, path folded through the existing
  `normalizeRuntimePathForComparison`, folder-workspace instance suffix kept as part of the path.
  Returns `null` for malformed ids so callers keep exact matching for them.
- `src/main/runtime/orca-runtime.ts`: the `id:` branch of `resolveWorktreeSelector` tries the exact
  match first and consults the comparison key **only when nothing matched exactly**.
- `src/main/runtime/repo-worktree-row-resolution.ts`: `resolveScopedWorktreeIdRow` — the lookup a
  host-qualified removal takes — does the same, and accepts an equivalent row only when there is
  exactly one.
- `src/main/runtime/orca-runtime.ts`: the pre-existing private `runtimeWorktreeIdsEqual` now derives
  from the same key, so the runtime has one normalizer instead of a parallel one. Its ~25 PTY- and
  session-identity callers are unchanged.

No renderer, CLI, or owner-routing changes. Six files, +473/-10, in six commits: the parity tests
(committed red), the production fix, an oxfmt/oxlint fixup on the new tests, then two review-driven
test commits — Windows spellings and malformed-id exactness, then the `ID_SPELLINGS` Windows row, the
fleet `selector_ambiguous` refusal, UNC/WSL key cases and the folder-workspace slash pin. The sixth
answers review feedback on this PR: it trims the test header to the one-line, why-not-how form
`AGENTS.md` asks for and adds short why-first JSDoc to `worktreeIdComparisonKey` and
`resolveWorktreeSelector`, so the two comparison entry points explain themselves at the call site.

## Why

### The mechanism

The renderer cannot address a workspace by path. `toRuntimeWorktreeSelector`
(`src/renderer/src/runtime/runtime-worktree-selector.ts`) always emits `id:<repoId>::<path>`, sent at
`dispatch-worktree-removal.ts`. The runtime resolved `id:` by exact string equality, while the `path:`
branch a few lines below has always compared through `normalizeRuntimePathForComparison`. Any
path-spelling divergence between the stored id and the scan therefore yielded `selector_not_found`
for the UI and a clean removal for the CLI. The renderer's removal path reads `selector_not_found` as
a stale local mirror, calls `forgetLocal`, and returns `ok: true` — no toast, and the row returns on
the next catalog refresh.

### Regression origin

`b82a8791f5` — *perf(runtime): resolve an explicit worktree id without scanning every repo (#14399)*,
2026-08-14, first tag **v1.4.186** — made `id:` the only selector kind not matched across the fleet,
resolving it by exact equality with no fallback. `64de8dd637` — *(STA-4343) (#15013)*, 2026-08-17 —
then routed removal through that scoped resolver, turning a scoped miss into a hard
`selector_not_found`.

### Live before/after

A/B against one variable: the same CLI, built from this branch, drove **two** runtimes on separate
ports with separate `--user-data-dir`s and their own throwaway repo and worktree — the installed
released **1.4.188** binary, and an `orcad` runtime built from this branch
(`node config/scripts/build-orcad.mjs` + `tsc -p config/tsconfig.cli.json`). Only the runtime version
differs between the two columns.

| Selector | 1.4.188 (before) | This branch (after) |
| --- | --- | --- |
| `show id:<repo>::<path>` | `ok: true` | `ok: true` |
| `show id:<repo>::<path>/` | `selector_not_found` | `ok: true`, resolving to the canonical id |
| `show path:<path>/` | `ok: true` | `ok: true` |
| `show id:<foreign-repo>::<path>` | `selector_not_found` (correct) | `selector_not_found` (still refuses) |
| `rm id:<repo>::<path>/` | `selector_not_found`, **and the worktree was still there afterwards** — a follow-up `show` of the exact id returned `ok: true` | `removed: true`, and a follow-up `show` of the exact id returns `selector_not_found`, so it really went |
| `rm path:<path>/` | `removed: true` | `removed: true` |
| `rm id:<repo>::<path>` | `removed: true` | `removed: true` |
| `rm id:<foreign-repo>::<path>` | `selector_not_found` | `selector_not_found` |

The two columns differ in exactly the two trailing-slash `id:` rows. `worktree show` missed on the
same input `worktree rm` did, so this is the shared selector resolver, not something specific to
removal.

Dot-segment spellings (`id:<repo>::<path>/.`, `id:<repo>::/srv/projects/./workspaces/…`) were **not** part of this
A/B. They were refused on 1.4.188 when first probed and they are still refused here, by both `id:`
and `path:` — see *dot segments* below. This PR does not fix them and does not claim to.

The field report that started this — a Windows client 1.4.188 paired to a Linux headless
`orca serve`, where the sidebar delete silently no-oped and the CLI delete worked — matches the
`before` column. The `after` artifact is the Node `orcad` runtime bundle: it executes the same
`src/main/runtime` code path a desktop client's runtime does, but it is **not** a packaged or signed
client build.

### What stays fail-closed

- **Repo id compares exactly.** Matching across repo ids would delete a workspace the caller never
  confirmed — the STA-4343 boundary.
- **Host qualification is untouched.** A removal qualified to a host that does not own the repo id
  still refuses; the scoped resolver's `owners.length !== 1` guard is unchanged.
- **Folder workspaces stay distinct.** The `::workspace:<uuid>` instance suffix stays part of the
  compared path, so sibling sessions in one directory never merge. Scope note: the parity this
  delivers is for **plain worktree ids**. In a folder-workspace id, a trailing slash placed *before*
  the instance suffix (`<repo>::/a/b/::workspace:<uuid>`) does not fold, because
  `trimRuntimePathTrailingSlash` only trims at end-of-string — that spelling keeps exact-match-only
  behaviour. It fails closed rather than matching the wrong workspace, and widening it is the same
  out-of-scope normalizer change as dot segments.
- **Ambiguity refuses.** If two scanned rows spell one path, the scoped lookup returns `null` rather
  than guessing, and the fleet path rejects `selector_ambiguous`. Pinned by *refuses a folded id when
  two same-repo rows spell one directory* in `worktree-rm-id-selector-path-spelling.test.ts` — three
  reported rows, two of them spelling one directory (`/srv/projects/workspaces/plugin-host` and
  `/srv/projects//workspaces/plugin-host`), and a trailing-slash id matching neither exactly.
  This is a deliberate remaining asymmetry with `path:`, which dedupes equivalent rows on one host and
  resolves: `id:` keeps refusing, because this resolver is the one a destructive delete goes through
  and picking a winner there means deleting a workspace the caller never confirmed. Adopting `path:`'s
  dedupe for `id:` is out of scope.
- **Dot segments are not canonicalized.** `normalizeRuntimePathForComparison` does not resolve `/./`,
  so `id:` and `path:` still agree on refusing it. The contract here is parity with `path:`, not
  universal path canonicalization — widening the normalizer would change every path comparison in the
  app and is deliberately out of scope.
- **The unstoppable-PTY invariant is upstream-independent.** This change only affects whether a
  selector resolves; the destructive-delete gate runs after resolution. A provider-visible PTY that
  cannot be proven stopped still blocks a non-forced delete — pinned by
  `src/main/runtime/worktree-teardown-unstopped-pty.test.ts` (e.g. *names the blocking PTYs and the
  escape hatch when one is still live*, *still fails closed on a sweep-level failure without force*),
  which passes unchanged. If anything, this makes that gate reachable in cases where the delete
  previously never got that far. Relevant to the open **#11073**, which strengthens that same
  invariant; nothing here routes around it.

### Performance (#14399 preserved)

The exact match is tried first and still wins outright, so a resolvable id costs exactly what it does
today. Neither site adds a scan: the fleet branch re-filters the array it had already listed, and the
scoped lookup re-filters the single owning repo's already-projected rows. An explicit `id:` still
never scans every repo.

### Relationship to open PRs

- **#16295 (open)** adds a `throw error` in the renderer's removal path so the miss fails visibly. It
  does not change resolution. The two are complementary: #16295 surfaces the miss, this removes it. No
  overlapping files.
- **#15616 (open)** introduces `worktreeIdComparisonKey` in `src/shared/worktree/id.ts` — the same
  file, the same helper name — and applies it to `getRemovedWorktreeIdsAfterAuthoritativeScan` and
  `pruneLineageForMissingRepoWorktrees` for the same class of divergence (#15598). **This PR and
  #15616 will therefore conflict in that file, whichever lands second.** We chose #15616's name
  deliberately instead of adding a competing helper, and comparing the two diffs directly confirms
  the choice: **#15616's implementation of the helper is byte-identical to this one** — same null
  guard, same key construction. The conflict is therefore a doc comment citing a different issue, not
  a design disagreement. Resolution is mechanical: keep one definition and let both sets of callers
  use it. Happy to rebase on top of #15616 if you would rather land that first — say the word and
  this becomes a call-site-only diff. What must not happen is two normalizers with different names
  doing the same folding.

Checked against upstream tip `bc98655a39` before opening: `worktreeIdComparisonKey` does not exist in
`src/shared/worktree/id.ts` yet, and no fix for #16243 has landed, so this is still needed.

### What this does not explain

#16243 contains **two different observations**, and this PR only accounts for one of them. The
difference matters, so here it is plainly.

**The reporter and the first confirmer show a delete that never reached the runtime.** The OP's
runtime trace grew by three `git.exec` lines with **no `worktree.remove` span**, where a successful
removal on that same host emits `worktree.remove`, `worktree.remove.trash_rename` and
`worktree.remove.branch_delete`. The macOS confirmer went further: in one instrumented ~90-second
session, a UI *create* reached the runtime and did 4.2 s of real `git worktree add` work, and the two
UI *deletes* seconds later produced **not one line** of runtime trace, while the CLI then removed the
same workspace with the expected spans. A selector miss cannot produce that: resolution happens
*inside* the runtime, so a miss requires the call to arrive. **For those two reports, the delete was
never dispatched, and this PR does not fix that.**

**The third report is the one this PR fixes.** A Windows client against a Linux headless
`orca serve`, both 1.4.188, captured the selector shapes directly against the runtime: the exact
`id:` form removed the workspace, the same path with a trailing slash answered `selector_not_found`,
and the `path:` form of that same trailing-slash path resolved. That is the asymmetry the A/B above
reproduces and this change removes.

So this closes one mechanism in that thread and leaves the other open. Nobody captured the selector
string the OP's or the confirmer's clients sent, and their traces argue their failures were something
else — most likely a renderer-side dispatch failure, which is a different fix in a different process.
**#16243 should stay open until the non-dispatch reports are explained**, which is why the reference
below is deliberately not a closing keyword.

## Linked Issue

Partially addresses #16243.

Written without a closing keyword on purpose, so merging this cannot auto-close an issue whose other
reported mechanism is still unexplained (see *What this does not explain*). One consequence worth
naming so it does not read as an oversight: GitHub's **Linked issues** sidebar populates only from a
closing keyword, so it is intentionally empty here — the relationship lives in this reference and in
the cross-link on #16243's own timeline. Once the zero-runtime-trace reports are accounted for,
whoever closes #16243 can do it deliberately rather than have a merge do it silently, and adding the
keyword then is the right move.

## Visual Proof

`N/A` — backend selector resolution only. There is no new or altered UI surface; the user-visible
difference is that a delete which silently no-oped now completes. #16295 is the PR that changes what
the UI *says* when a selector misses.

## Testing

Written test-first: the tests were committed red, then the production change turned them green.

Reproduce (a reviewer can run all of this):

```
# Targeted. orca-runtime.test.ts is NOT modified by this branch — it is included deliberately
# because it holds #14399's no-fleet-scan guards, which this change must not break.
pnpm test \
  src/main/runtime/orca-runtime.test.ts \
  src/main/runtime/repo-worktree-row-resolution.test.ts \
  src/main/runtime/worktree-rm-id-selector-path-spelling.test.ts \
  src/shared/worktree/id.test.ts
# Test Files 4 passed (4) · Tests 1257 passed | 1 skipped (1258)

# Same run without pnpm. The --config flag is required either way: without it the `@/` alias
# does not resolve in this repo.
# npx vitest run --config config/vitest.config.ts <the four paths above>

npx vitest run --config config/vitest.config.ts src/main/runtime
# 393 files, 4798 passed | 9 skipped

npx vitest run --config config/vitest.config.ts src/shared/worktree src/main/worktree-lineage-pruning.test.ts
# 16 files, 199 passed

pnpm typecheck   # exit 0 (also exit 0 on the base commit, for comparison)
pnpm lint        # exit 0 — oxlint, code-quality native + type-aware, reliability gates,
                 # max-lines ratchet, runtime-electron ratchet, skill/localization verifiers
```

`pnpm lint` and `oxfmt --check` were **not** clean when the fix was first committed: oxlint flagged
`unicorn(no-useless-fallback-in-spread)` in one new test, and both new test files were unformatted.
That is what the third commit fixes, so the green lint result above holds at the tip of the branch,
not at the fix commit. `oxfmt --check` reports the same 34 pre-existing offenders as the base commit —
this branch adds none.

Guard tests specifically re-run and green, unmodified: `src/main/runtime/orca-runtime.test.ts`
(including *rejects a qualified removal when only another host has persisted ownership* and its
no-fleet-scan assertion), `worktree-teardown-unstopped-pty.test.ts`, `worktree-teardown.test.ts`,
`repo-worktree-resolution-scan.test.ts`, `worktree-scan-admin-fingerprint-gate.test.ts`,
`runtime-rpc-worktree-queries.test.ts`, `worktree-lineage-pruning.test.ts`.

**Non-vacuity, and what it does *not* cover.** Two neutralization experiments, production files
restored byte-identical after each:

- Neutralize **both** `id:` fallbacks — i.e. restore pre-fix behaviour — and **10 tests** in
  `worktree-rm-id-selector-path-spelling.test.ts` go red, including both new Windows rows and the
  ambiguity refusal.
- Make the fleet fallback **pick the first folded match instead of refusing**, and the ambiguity test
  goes red on its own.

Stated plainly because a reviewer would work it out anyway: **four cases pass against pre-fix code
too** — malformed ids, dot segments, the POSIX backslash, and the folder-workspace mid-id slash pin.
Those are guards against *widening* the comparison, not evidence that this fix does anything. Only the
first bullet's ten are.

Platforms: this is platform-independent path comparison, and the spellings it folds — POSIX, Windows
drive and UNC, WSL aliases — are the ones `normalizeRuntimePathForComparison` already folds for
`path:`. Exercised on Linux (unit suites and the live runtime above); the reported scenario is a
Windows client against a Linux headless runtime over SSH.

Windows spellings are covered as a first-class axis, not by inference (#15598's defect class): the
comparison key, the fleet branch, and the scoped removal lookup each resolve a
`repo::D:\Agentic\game2\battle-core` id against the `D:/Agentic/game2/battle-core` spelling git
reports. The support is `isWindowsAbsolutePathLike` (`src/shared/cross-platform-path.ts:6`,
`/^[A-Za-z]:[\\/]/`), which gates separator folding and lowercasing at that module's lines 48 and 56.
The sites inherit `normalizeRuntimePathForComparison`'s *guarantees*, including its deliberate
restraint. Pinned by name in `src/shared/worktree/id.test.ts`: *folds Windows separator and
drive-letter case, as `path:` already does* and *keeps a UNC or WSL root distinct from a drive-letter
location*; and at runtime level, *folds drive-letter case only for Windows paths, never for a POSIX
path* and *does not fold a backslash inside a POSIX path, where it is a valid filename character*.
The case-fold test asserts **both** halves its name promises: a Windows-rooted path folds case
(`d:/agentic/game2/battle-core` resolves against the `D:/Agentic/game2/battle-core` row) while a
POSIX-rooted one does **not** (`/SRV/projects/workspaces/plugin-host` refuses with
`selector_not_found`). No production change was needed for that second half — POSIX case folding was
deliberately never introduced, because lowercasing would merge `/srv/Foo` with `/srv/foo` on Linux,
where they are two directories. The
fold is gated on platform semantics, not applied blindly.

All four invariants #15616 claims for the shared key hold here, tested at both sites and then
**re-checked live** on an isolated runtime against two real git repos with real worktrees:

- **Distinct repos stay distinct.** Repo B's id against repo A's real path refuses, with and without
  a trailing slash; an `rm` attempted that way refused, and A stayed resolvable afterwards.
- **Distinct paths stay distinct.** Prefix-overlapping sibling worktrees each resolve to themselves
  and never to each other.
- **Malformed ids keep exact-match behaviour.** Pinned by `src/shared/worktree/id.test.ts` —
  *returns null for ids with no repo boundary so callers keep exact matching*: `repo-a`, `repo-a::`
  and a bare `/srv/workspaces/plugin` all key to `null` — and at both entry points by
  `it.each('keeps exact matching for a malformed id with %s')`, covering `showManagedWorktree` and
  `resolveWorktreeRemovalTarget`. `repo-worktree-row-resolution.ts` returns `null` on a null key and
  `orca-runtime.ts` leaves the empty exact-match candidate set alone. Live, all four malformed shapes
  refuse, and the scoped lookup refuses without scanning.
- **POSIX case is deliberately not folded.** An uppercased POSIX path refuses — observed live and now
  asserted, per the case-fold test above.

The other three invariants are pinned by *never merges different repos, workspaces, or folder
sessions* in the same file — distinct repo, distinct path, distinct `::workspace:<uuid>` instance.

At the function level, against the real bundled source: `D:\Agentic\game2\battle-core`,
`D:/Agentic/game2/battle-core` and `d:/agentic/game2/battle-core` all fold to one key — so this
inherits #15616's separator, drive-letter and
drive-case guarantees — two folder instances of the same folder keep distinct keys, and dot segments
are not folded, which is exactly why the `/./` spellings still refuse.

- [x] I manually tested these changes locally — the runtime A/B above: released 1.4.188 refuses the
      selector and leaves the worktree in place, a runtime built from this branch removes it. Linux
      host; the artifact was the Node `orcad` runtime bundle, not a packaged desktop client, so a
      client-side regression is covered by tests rather than by a live client build.
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Written with AI agents throughout — investigation, the tests, the fix, and the live probes — driven by
xAI Grok 4.5 inside Orca's own agent harness. Every number, command, and matrix row in this PR was
produced by running it, not by asking a model to predict it. *What this does not explain* and the
*unchanged and intended* dot-segment note are there because those checks did **not** come out in this
change's favour.

## Review

- **Security**: the widening is bounded by an exact repo id, unchanged host qualification, and a
  refusal on ambiguity, so no id can now resolve a workspace on a host or repo the caller did not
  name. No new I/O, process, or external input; the destructive-delete gate is untouched and runs
  after resolution.
- **Cross-platform**: no platform branch added. Path folding is delegated to the existing
  `normalizeRuntimePathForComparison`, which is what `path:` already uses on all three platforms, so
  `id:` and `path:` cannot diverge per-OS.
- **Remote SSH / local / paired runtime**: host-side resolution only — no RPC params, stream frames,
  or published content change, so a new client against an old host and an old client against a new
  host both behave exactly as they do today (an old host keeps failing the divergent id; nothing
  breaks). SSH repos take the same `listRepoWorktreesForResolution` path as before, and #14399's
  `buildResolvedWorktreeFromId` fallback is preserved.
- **Folder workspaces**: the `::workspace:<uuid>` suffix stays inside the compared path, so two
  sessions in one directory stay two workspaces.
- **Agents / integrations / git providers**: none touched. This is selector-string comparison; no
  agent, provider, or Git command is involved, and no Git version boundary is crossed.
- **UI quality**: no UI change (see Visual Proof).
- **Performance**: measured reasoning above — exact match first, no added scan at either site.
- **Backwards compatibility**: nothing persisted or serialized changes. Ids that resolve today resolve
  identically; only previously-failing ids now resolve.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

The one behavioural widening a reviewer should weigh: an `id:` whose path spelling differs from the
scan now resolves instead of failing. That is the point of the change, and it is fenced by an exact
repo id, unchanged host qualification, an ambiguity refusal, and no change to dot-segment handling.

## Author

No X account.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint` and `pnpm typecheck` pass locally at the tip of the branch; the `src/main/runtime`
      and `src/shared/worktree` suites pass locally. `pnpm build` was not run locally — CI covers it.
