### PR TITLE
fix(codex): preserve WSL account home trust

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -59,7 +59,7 @@ import {
   prepareSystemConfigForFreshRuntimeMirror,
   syncSystemConfigIntoManagedCodexHome
 } from '../codex/codex-config-mirror'
-import { parseWslUncPath } from '../../shared/wsl-paths'
+import { parseWslUncPath, toLinuxPath } from '../../shared/wsl-paths'
 import {
   getWslSelectionKey,
   getSelectedCodexAccountIdForTarget,
@@ -757,7 +757,11 @@ export class CodexRuntimeHomeService {
       systemHomePath,
       managedHomePath: runtimeHomePath
     })
-    syncSystemConfigIntoManagedCodexHome({ runtimeHomePath, systemHomePath })
+    syncSystemConfigIntoManagedCodexHome({
+      runtimeHomePath,
+      systemHomePath,
+      systemConfigDir: toLinuxPath(systemHomePath)
+    })
   }
 
   // Why: `null` is a real value here — it means "use the system-default lane".

--- a/src/main/codex-accounts/runtime-home-wsl-session-bridge.test.ts
+++ b/src/main/codex-accounts/runtime-home-wsl-session-bridge.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { existsSync, lstatSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import type * as WslPaths from '../../shared/wsl-paths'
 import { createSettings } from './runtime-home-settings-test-fixtures'
 import {
   createManagedAuth,
@@ -281,15 +282,19 @@ describe('CodexRuntimeHomeService', () => {
       getDefaultWslDistro: () => null,
       getWslHome: (distro: string) => (distro === 'Debian' ? wslHome : null)
     }))
-    vi.doMock('../../shared/wsl-paths', () => ({
-      parseWslUncPath: (candidate: string) =>
-        candidate === wslRuntimeHomePath
-          ? {
-              distro: 'Debian',
-              linuxPath: '/home/alice/.local/share/orca/codex-runtime-home/home'
-            }
-          : null
-    }))
+    vi.doMock('../../shared/wsl-paths', async (importOriginal) => {
+      const actual = await importOriginal<typeof WslPaths>()
+      return {
+        ...actual,
+        parseWslUncPath: (candidate: string) =>
+          candidate === wslRuntimeHomePath
+            ? {
+                distro: 'Debian',
+                linuxPath: '/home/alice/.local/share/orca/codex-runtime-home/home'
+              }
+            : null
+      }
+    })
     const managedHomePath = createManagedAuth(
       testState.userDataDir,
       'debian-account',

--- a/src/main/codex-accounts/runtime-home-wsl-system-default.test.ts
+++ b/src/main/codex-accounts/runtime-home-wsl-system-default.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
+import type * as CodexConfigMirror from '../codex/codex-config-mirror'
 import { createSettings } from './runtime-home-settings-test-fixtures'
 import {
   createCodexAuthJson,
@@ -321,6 +322,49 @@ describe('CodexRuntimeHomeService', () => {
       expect(service.prepareForCodexLaunch(target)).toBe(wslRuntimeHomePath)
       expect(readFileSync(join(systemCodexHomePath, 'auth.json'), 'utf-8')).toBe(refreshedAuth)
       expect(readFileSync(join(wslRuntimeHomePath, 'auth.json'), 'utf-8')).toBe(refreshedAuth)
+    } finally {
+      if (originalPlatform) {
+        Object.defineProperty(process, 'platform', originalPlatform)
+      }
+    }
+  })
+
+  it('passes the Linux source config directory for mounted-drive WSL homes', async () => {
+    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    vi.doMock('../wsl', () => ({
+      getDefaultWslDistro: () => 'Ubuntu',
+      getWslHome: () => 'C:\\Users\\alice'
+    }))
+    const syncConfig = vi.fn()
+    vi.doMock('../codex/codex-config-mirror', async () => ({
+      ...(await vi.importActual<typeof CodexConfigMirror>('../codex/codex-config-mirror')),
+      syncSystemConfigIntoManagedCodexHome: syncConfig
+    }))
+
+    try {
+      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+      const service = new CodexRuntimeHomeService(createStore(createSettings()) as never)
+      const syncWslConfig = (
+        service as unknown as {
+          syncWslConfigAndGlobalInstructionsForLaunch: (
+            target: { runtime: 'wsl'; wslDistro?: string | null },
+            runtimeHomePath: string | null
+          ) => void
+        }
+      ).syncWslConfigAndGlobalInstructionsForLaunch
+
+      syncWslConfig.call(
+        service,
+        { runtime: 'wsl', wslDistro: 'Ubuntu' },
+        join(testState.userDataDir, 'runtime-home')
+      )
+
+      expect(syncConfig).toHaveBeenCalledWith({
+        runtimeHomePath: join(testState.userDataDir, 'runtime-home'),
+        systemHomePath: 'C:\\Users\\alice/.codex',
+        systemConfigDir: '/mnt/c/Users/alice/.codex'
+      })
     } finally {
       if (originalPlatform) {
         Object.defineProperty(process, 'platform', originalPlatform)

--- a/src/main/codex-accounts/service-wsl-accounts.test.ts
+++ b/src/main/codex-accounts/service-wsl-accounts.test.ts
@@ -45,6 +45,78 @@ function wslFailed(code: number, stderr = ''): WslResult {
 describe('CodexAccountService config sync', () => {
   registerCodexAccountsTestHomes()
 
+  it('preserves WSL account-home project trust while refreshing canonical settings', async () => {
+    const wslManagedHomePath = join(testState.userDataDir, 'wsl-account', 'home')
+    const wslCanonicalHomePath = join(testState.userDataDir, 'wsl-home', '.codex')
+    const wslLinuxHomePath = '/home/alice/.local/share/orca/codex-accounts/account-1/home'
+    const wslLinuxCanonicalHomePath = '/home/alice/.codex'
+    mkdirSync(wslManagedHomePath, { recursive: true })
+    mkdirSync(wslCanonicalHomePath, { recursive: true })
+    writeFileSync(join(wslManagedHomePath, '.orca-managed-home'), 'account-1\n', 'utf-8')
+    writeFileSync(
+      join(wslManagedHomePath, 'config.toml'),
+      'approval_policy = "untrusted"\n[projects."/workspace"]\ntrust_level = "trusted"\n',
+      'utf-8'
+    )
+    writeFileSync(
+      join(wslCanonicalHomePath, 'config.toml'),
+      'sandbox_mode = "danger-full-access"\n',
+      'utf-8'
+    )
+
+    vi.doMock('../../shared/wsl-paths', () => ({
+      parseWslUncPath: (path: string) => {
+        if (path === wslManagedHomePath) {
+          return { distro: 'Ubuntu', linuxPath: wslLinuxHomePath }
+        }
+        if (path === wslCanonicalHomePath) {
+          return { distro: 'Ubuntu', linuxPath: wslLinuxCanonicalHomePath }
+        }
+        return null
+      }
+    }))
+    vi.doMock('../wsl', () => ({
+      toWindowsWslPath: (linuxPath: string) =>
+        linuxPath === wslLinuxCanonicalHomePath ||
+        linuxPath === `${wslLinuxCanonicalHomePath}/config.toml`
+          ? linuxPath.endsWith('/config.toml')
+            ? join(wslCanonicalHomePath, 'config.toml')
+            : wslCanonicalHomePath
+          : wslManagedHomePath
+    }))
+
+    const settings = createSettings({
+      codexManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'wsl@example.com',
+          managedHomePath: wslManagedHomePath,
+          managedHomeRuntime: 'wsl',
+          wslDistro: 'Ubuntu',
+          wslLinuxHomePath,
+          providerAccountId: null,
+          workspaceLabel: null,
+          workspaceAccountId: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ]
+    })
+
+    const { CodexAccountService } = await import('./service')
+    new CodexAccountService(
+      createStore(settings) as never,
+      createRateLimits() as never,
+      createRuntimeHome() as never
+    )
+
+    expect(readFileSync(join(wslManagedHomePath, 'config.toml'), 'utf-8')).toBe(
+      'sandbox_mode = "danger-full-access"\n\n' +
+        '[projects."/workspace"]\ntrust_level = "trusted"\n'
+    )
+  })
+
   it('adds a managed Codex account inside WSL when the account context is WSL', async () => {
     vi.resetModules()
     const originalPlatform = process.platform
@@ -54,8 +126,10 @@ describe('CodexAccountService config sync', () => {
     })
 
     const wslManagedHomePath = join(testState.userDataDir, 'wsl-managed-home')
-    const wslConfigPath = join(testState.userDataDir, 'wsl-config.toml')
+    const wslConfigHomePath = join(testState.userDataDir, 'wsl-config-home')
+    const wslConfigPath = join(wslConfigHomePath, 'config.toml')
     const wslLinuxHomePath = '/home/alice/.local/share/orca/codex-accounts/account-id-for-test/home'
+    mkdirSync(wslConfigHomePath, { recursive: true })
     writeFileSync(
       wslConfigPath,
       'sandbox_mode = "danger-full-access"\nmodel_instructions_file = "instructions.md"\n',
@@ -130,11 +204,19 @@ describe('CodexAccountService config sync', () => {
     vi.doMock('../wsl/wsl-runner', () => ({ runWslProcess: runWslProcessMock }))
     vi.doMock('../../shared/wsl-paths', () => ({
       parseWslUncPath: (path: string) =>
-        path === wslManagedHomePath ? { distro: 'Debian', linuxPath: wslLinuxHomePath } : null
+        path === wslManagedHomePath
+          ? { distro: 'Debian', linuxPath: wslLinuxHomePath }
+          : path === wslConfigHomePath
+            ? { distro: 'Debian', linuxPath: '/home/alice/.codex' }
+            : null
     }))
     vi.doMock('../wsl', () => ({
       toWindowsWslPath: (linuxPath: string) =>
-        linuxPath.endsWith('/.codex/config.toml') ? wslConfigPath : wslManagedHomePath
+        linuxPath.endsWith('/.codex/config.toml')
+          ? wslConfigPath
+          : linuxPath.endsWith('/.codex')
+            ? wslConfigHomePath
+            : wslManagedHomePath
     }))
 
     const settings = createSettings()

--- a/src/main/codex-accounts/service-wsl-accounts.test.ts
+++ b/src/main/codex-accounts/service-wsl-accounts.test.ts
@@ -117,6 +117,76 @@ describe('CodexAccountService config sync', () => {
     )
   })
 
+  it('keeps Linux-relative config paths when a WSL home is under a mounted drive', async () => {
+    vi.resetModules()
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+
+    const wslManagedHomePath = join(testState.userDataDir, 'wsl-account', 'home')
+    const wslCanonicalHomePath = join(testState.userDataDir, 'wsl-home', '.codex')
+    const wslCanonicalConfigPath = join(wslCanonicalHomePath, 'config.toml')
+    const wslLinuxHomePath = '/mnt/c/Users/alice/.local/share/orca/codex-accounts/account-1/home'
+    const wslLinuxCanonicalHomePath = '/mnt/c/Users/alice/.codex'
+    mkdirSync(wslManagedHomePath, { recursive: true })
+    mkdirSync(wslCanonicalHomePath, { recursive: true })
+    writeFileSync(join(wslManagedHomePath, '.orca-managed-home'), 'account-1\n', 'utf-8')
+    writeFileSync(wslCanonicalConfigPath, 'model_instructions_file = "instructions.md"\n', 'utf-8')
+
+    vi.doMock('node:child_process', () => ({
+      execFileSync: vi.fn(() => `${wslLinuxHomePath}\n`),
+      spawn: vi.fn()
+    }))
+    vi.doMock('../../shared/wsl-paths', () => ({
+      parseWslUncPath: (path: string) =>
+        path === wslManagedHomePath ? { distro: 'Ubuntu', linuxPath: wslLinuxHomePath } : null
+    }))
+    vi.doMock('../wsl', () => ({
+      toWindowsWslPath: (linuxPath: string) =>
+        linuxPath.endsWith('/config.toml')
+          ? wslCanonicalConfigPath
+          : linuxPath === wslLinuxCanonicalHomePath
+            ? wslCanonicalHomePath
+            : wslManagedHomePath
+    }))
+
+    const settings = createSettings({
+      codexManagedAccounts: [
+        {
+          id: 'account-1',
+          email: 'wsl@example.com',
+          managedHomePath: wslManagedHomePath,
+          managedHomeRuntime: 'wsl',
+          wslDistro: 'Ubuntu',
+          wslLinuxHomePath,
+          providerAccountId: null,
+          workspaceLabel: null,
+          workspaceAccountId: null,
+          createdAt: 1,
+          updatedAt: 1,
+          lastAuthenticatedAt: 1
+        }
+      ]
+    })
+
+    try {
+      const { CodexAccountService } = await import('./service')
+      new CodexAccountService(
+        createStore(settings) as never,
+        createRateLimits() as never,
+        createRuntimeHome() as never
+      )
+
+      expect(readFileSync(join(wslManagedHomePath, 'config.toml'), 'utf-8')).toContain(
+        "model_instructions_file = '/mnt/c/Users/alice/.codex/instructions.md'"
+      )
+    } finally {
+      Object.defineProperty(process, 'platform', {
+        configurable: true,
+        value: originalPlatform
+      })
+    }
+  })
+
   it('adds a managed Codex account inside WSL when the account context is WSL', async () => {
     vi.resetModules()
     const originalPlatform = process.platform

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -32,12 +32,8 @@ import type {
 } from '../../shared/codex-reset-credit-attempt-ledger'
 import type { CodexRuntimeHomeService } from './runtime-home-service'
 import { writeFileAtomically } from './fs-utils'
-import { rewriteRelativePathConfigValues } from '../codex/codex-config-path-reference-rewrite'
-import { stripCodexManagedHookTrustEntriesFromConfig } from '../codex/codex-managed-trust-reconciliation'
-import { getCodexManagedHookInstallMaterial } from '../codex/hook-service'
 import { syncSystemConfigIntoManagedCodexHome } from '../codex/codex-config-mirror'
 import { getSystemCodexHomePath } from '../codex/codex-home-paths'
-import { MANAGED_HOOK_TIMEOUT_SECONDS } from '../agent-hooks/installer-utils'
 import { readCodexTopLevelModelProvider } from '../codex/codex-model-provider-config'
 import { resolveCodexCommand } from '../codex-cli/command'
 import { withCliRuntimeOnPath } from '../../shared/node-cli-command-resolution'
@@ -93,9 +89,8 @@ type ResolvedCodexIdentity = {
 
 type CanonicalCodexConfig = {
   contents: string
-  /** Home the config was read from, in the path style Codex sees (Linux-side for WSL); relative settings resolve against it. */
+  /** Host-readable source home; the mirror resolves WSL UNC paths to their Linux spelling. */
   sourceHomePath: string
-  sourceHooksPath: string
 }
 
 export type CodexAccountAddTarget = {
@@ -1303,12 +1298,6 @@ export class CodexAccountService {
     }
   }
 
-  private isSelfContainedHostManagedHome(managedHomePath: string): boolean {
-    // Why: each host account home is its own launch CODEX_HOME. WSL homes keep
-    // their distro-local seed lane.
-    return !parseWslUncPath(managedHomePath)
-  }
-
   private syncCanonicalConfigIntoManagedHome(
     managedHomePath: string,
     canonicalConfig = this.readCanonicalConfigForManagedHome(managedHomePath),
@@ -1319,36 +1308,12 @@ export class CodexAccountService {
     }
 
     const trustedManagedHomePath = this.assertManagedHomePath(managedHomePath, expectedAccountId)
-    if (this.isSelfContainedHostManagedHome(trustedManagedHomePath)) {
-      // Why: this home is codex's live CODEX_HOME, so mirror config with the
-      // trust-preserving merge — the plain overwrite below would wipe the
-      // hook/project trust codex granted in this home, forcing a re-approval and
-      // an app-server re-grant on every account switch.
-      syncSystemConfigIntoManagedCodexHome({
-        runtimeHomePath: trustedManagedHomePath,
-        systemHomePath: getSystemCodexHomePath()
-      })
-      return
-    }
-    // Why: Orca account switching is meant to swap Codex credentials and quota
-    // identity, not silently fork the user's sandbox/config defaults. Syncing
-    // one canonical config into every managed home keeps auth isolated per
-    // account while preserving consistent Codex behavior. Managed homes are
-    // real CODEX_HOMEs for `codex login`, so relative path-valued settings
-    // must keep resolving against the home the config was read from.
-    const material = getCodexManagedHookInstallMaterial()
-    // Why: source-home Orca trust is foreign to each managed home's hooks.json.
-    const sanitizedConfig = stripCodexManagedHookTrustEntriesFromConfig(canonicalConfig.contents, {
-      runtimeHomePath: canonicalConfig.sourceHomePath,
-      sourcePath: canonicalConfig.sourceHooksPath,
-      command: material.command,
-      managedEventLabels: new Set(Object.values(material.eventLabel)),
-      timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
+    // Why: every account home is Codex's own CODEX_HOME. Preserve trust Codex
+    // granted there while refreshing ordinary settings from the lane's source.
+    syncSystemConfigIntoManagedCodexHome({
+      runtimeHomePath: trustedManagedHomePath,
+      systemHomePath: canonicalConfig.sourceHomePath
     })
-    this.writeManagedConfig(
-      trustedManagedHomePath,
-      rewriteRelativePathConfigValues(sanitizedConfig, canonicalConfig.sourceHomePath)
-    )
   }
 
   private readCanonicalConfig(): CanonicalCodexConfig | null {
@@ -1361,8 +1326,7 @@ export class CodexAccountService {
     try {
       return {
         contents: readFileSync(primaryConfigPath, 'utf-8'),
-        sourceHomePath,
-        sourceHooksPath: join(sourceHomePath, 'hooks.json')
+        sourceHomePath
       }
     } catch (error) {
       console.warn('[codex-accounts] Failed to read canonical config:', error)
@@ -1392,8 +1356,7 @@ export class CodexAccountService {
       // path rewrites must anchor to the Linux-side ~/.codex, not the UNC path.
       return {
         contents: readFileSync(configPath, 'utf-8'),
-        sourceHomePath: `${wslHome}/.codex`,
-        sourceHooksPath: `${wslHome}/.codex/hooks.json`
+        sourceHomePath: toWindowsWslPath(`${wslHome}/.codex`, wslInfo.distro)
       }
     } catch (error) {
       console.warn('[codex-accounts] Failed to read WSL canonical config:', error)
@@ -1414,18 +1377,6 @@ export class CodexAccountService {
     throw new Error(
       `Orca cannot add a Codex OAuth account while ~/.codex/config.toml pins the custom provider ${JSON.stringify(modelProvider)}. Keep using the system-default account for this provider, or remove model_provider (or set it to "openai") before adding an OAuth account. Orca left your config unchanged.`
     )
-  }
-
-  private writeManagedConfig(managedHomePath: string, contents: string): void {
-    const configPath = join(managedHomePath, 'config.toml')
-    try {
-      if (existsSync(configPath) && readFileSync(configPath, 'utf-8') === contents) {
-        return
-      }
-    } catch {
-      // Why: a read error must not make a stale config look current; atomic write owns ACL repair and error surfacing.
-    }
-    writeFileAtomically(configPath, contents)
   }
 
   private getManagedAccountsRoot(): string {

--- a/src/main/codex-accounts/service.ts
+++ b/src/main/codex-accounts/service.ts
@@ -91,6 +91,8 @@ type CanonicalCodexConfig = {
   contents: string
   /** Host-readable source home; the mirror resolves WSL UNC paths to their Linux spelling. */
   sourceHomePath: string
+  /** Preserve Linux path semantics when WSL $HOME is under /mnt/<drive>. */
+  sourceConfigDir?: string
 }
 
 export type CodexAccountAddTarget = {
@@ -1312,7 +1314,8 @@ export class CodexAccountService {
     // granted there while refreshing ordinary settings from the lane's source.
     syncSystemConfigIntoManagedCodexHome({
       runtimeHomePath: trustedManagedHomePath,
-      systemHomePath: canonicalConfig.sourceHomePath
+      systemHomePath: canonicalConfig.sourceHomePath,
+      systemConfigDir: canonicalConfig.sourceConfigDir
     })
   }
 
@@ -1356,7 +1359,8 @@ export class CodexAccountService {
       // path rewrites must anchor to the Linux-side ~/.codex, not the UNC path.
       return {
         contents: readFileSync(configPath, 'utf-8'),
-        sourceHomePath: toWindowsWslPath(`${wslHome}/.codex`, wslInfo.distro)
+        sourceHomePath: toWindowsWslPath(`${wslHome}/.codex`, wslInfo.distro),
+        sourceConfigDir: `${wslHome}/.codex`
       }
     } catch (error) {
       console.warn('[codex-accounts] Failed to read WSL canonical config:', error)

--- a/src/main/codex/codex-config-mirror.test.ts
+++ b/src/main/codex/codex-config-mirror.test.ts
@@ -768,6 +768,15 @@ describe('syncSystemConfigIntoLegacySharedCodexHome', () => {
 })
 
 describe('prepareSystemConfigForFreshRuntimeMirror', () => {
+  it('allows WSL callers to retain Linux semantics for mounted-drive homes', () => {
+    expect(
+      resolveCodexConfigMirrorSourceDirectory(
+        'C:\\Users\\alice\\.codex',
+        '/mnt/c/Users/alice/.codex'
+      )
+    ).toBe('/mnt/c/Users/alice/.codex')
+  })
+
   it('uses the Linux-side directory for WSL UNC source homes', () => {
     const sourceDir = resolveCodexConfigMirrorSourceDirectory(
       '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.codex'

--- a/src/main/codex/codex-config-mirror.ts
+++ b/src/main/codex/codex-config-mirror.ts
@@ -155,7 +155,7 @@ type CodexConfigMirrorResult =
   | { status: 'mirrored'; preservedConflictKeys: ReadonlySet<string> }
 
 function syncSystemConfigIntoManagedCodexHomeUnsafe(
-  { runtimeHomePath, systemHomePath }: CodexSettingsPromotionHomes,
+  { runtimeHomePath, systemHomePath, systemConfigDir }: CodexSettingsPromotionHomes,
   promotionPlan: CodexSettingsPromotionPlan
 ): CodexConfigMirrorResult {
   const systemConfigPath = join(systemHomePath, 'config.toml')
@@ -184,7 +184,7 @@ function syncSystemConfigIntoManagedCodexHomeUnsafe(
       : { status: 'mirrored', preservedConflictKeys: new Set() }
   }
 
-  const sourceConfigDir = resolveCodexConfigMirrorSourceDirectory(systemHomePath)
+  const sourceConfigDir = resolveCodexConfigMirrorSourceDirectory(systemHomePath, systemConfigDir)
   if (!runtimeConfigExists) {
     writeFileAtomically(
       runtimeConfigPath,
@@ -207,8 +207,15 @@ function syncSystemConfigIntoManagedCodexHomeUnsafe(
   return { status: 'mirrored', preservedConflictKeys: preserved.keys }
 }
 
-export function resolveCodexConfigMirrorSourceDirectory(systemHomePath: string): string {
-  return parseWslUncPath(systemHomePath)?.linuxPath ?? dirname(join(systemHomePath, 'config.toml'))
+export function resolveCodexConfigMirrorSourceDirectory(
+  systemHomePath: string,
+  systemConfigDir?: string
+): string {
+  return (
+    systemConfigDir ??
+    parseWslUncPath(systemHomePath)?.linuxPath ??
+    dirname(join(systemHomePath, 'config.toml'))
+  )
 }
 
 function prepareSystemConfigForRuntimeMirror(config: string, systemConfigDir: string): string {

--- a/src/main/codex/config-settings-promotion.ts
+++ b/src/main/codex/config-settings-promotion.ts
@@ -184,6 +184,8 @@ export function snapshotCodexRuntimeSettingsBaseline(
 export type CodexSettingsPromotionHomes = {
   runtimeHomePath: string
   systemHomePath: string
+  /** Linux spelling of the source config directory when its host path is a drvfs drive. */
+  systemConfigDir?: string
 }
 
 export type CodexSettingsPromotionPlan = {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​222 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​210 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​31 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​63 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​32 |

<!-- /orca-pr-loc -->

## ELI5

WSL account homes now keep Codex's project and hook approvals when Orca refreshes their settings.

## What Changed

- Routes every per-account Codex home through the trust-preserving config mirror.
- Gives WSL config mirroring a host-readable source path while preserving Linux path resolution.
- Adds WSL coverage for retained project trust and keeps fresh-home seeding coverage.

## Why

WSL account homes will become the live `CODEX_HOME`. A plain overwrite would erase trust Codex recorded there after each config sync.

## Linked Issue

STA-4606

## Visual Proof

N/A — config synchronization has no rendered UI change.

## Testing

- [x] Automated tests added/updated
- `pnpm test src/main/codex src/main/codex-accounts src/main/agent-hooks` (1,855 passed, 12 skipped)
- `pnpm typecheck`
- `node config/scripts/check-changed-code-quality.mjs`
- Mutation check: restoring the WSL overwrite made `preserves WSL account-home project trust while refreshing canonical settings` fail.
- Platforms exercised: automated filesystem coverage on macOS; Windows/WSL behavior is mocked. SSH is unaffected because this is local WSL account configuration.

## Review

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

This is the prerequisite trust-safety stage only; it does not change WSL launch routing.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] N/A for screenshots because there is no UI change
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path impact considered
- [x] Required focused suites, full typecheck, and changed-code quality pass; CI covers remaining repository checks
