### PR TITLE
fix(updater): surface and degrade renderer shutdown checkpoint failures (STA-5505)

### DIFF
--- a/src/renderer/src/app-shell/shutdown-checkpoint-persist.test.ts
+++ b/src/renderer/src/app-shell/shutdown-checkpoint-persist.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  runShutdownCheckpointPersist,
+  type ShutdownCheckpointPersistDeps
+} from './shutdown-checkpoint-persist'
+
+function makeDeps(
+  overrides: Partial<ShutdownCheckpointPersistDeps> = {}
+): ShutdownCheckpointPersistDeps {
+  return {
+    shouldCaptureSession: () => true,
+    captureTerminalBuffers: vi.fn(),
+    captureSleepingAgentSessions: vi.fn(),
+    buildSessionSnapshots: () => [{ state: { activeTabId: 't1' } }] as never,
+    buildUiPatch: () => ({ activeView: 'workspace' }) as never,
+    hasDirtyOpenFiles: () => false,
+    isIntentionalAppRestartInProgress: () => true,
+    stageBeforeUnloadSync: vi.fn(),
+    ...overrides
+  }
+}
+
+describe('runShutdownCheckpointPersist', () => {
+  it('does not fail the checkpoint when the sleeping-agent quit capture throws (STA-5505)', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const deps = makeDeps({
+      captureSleepingAgentSessions: () => {
+        throw new Error('capture exploded')
+      }
+    })
+
+    expect(() => runShutdownCheckpointPersist(deps)).not.toThrow()
+    // The full snapshot must still be staged — losing at most one minute of
+    // resume records is strictly better than blocking the update.
+    expect(deps.stageBeforeUnloadSync).toHaveBeenCalledWith({
+      sessions: [{ state: { activeTabId: 't1' } }],
+      ui: { activeView: 'workspace' }
+    })
+    vi.restoreAllMocks()
+  })
+
+  it('degrades to durable-only staging when full staging throws during an intentional restart (STA-5505)', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const stageBeforeUnloadSync = vi.fn((args: { sessions: unknown[] }) => {
+      if (args.sessions.length > 0) {
+        throw new Error('sync IPC staging failed')
+      }
+    })
+    const deps = makeDeps({ stageBeforeUnloadSync })
+
+    expect(() => runShutdownCheckpointPersist(deps)).not.toThrow()
+    expect(stageBeforeUnloadSync).toHaveBeenCalledTimes(2)
+    expect(stageBeforeUnloadSync).toHaveBeenLastCalledWith({
+      sessions: [],
+      ui: { activeView: 'workspace' }
+    })
+    vi.restoreAllMocks()
+  })
+
+  it('still fails the checkpoint when staging throws and dirty editor buffers exist', () => {
+    const deps = makeDeps({
+      hasDirtyOpenFiles: () => true,
+      stageBeforeUnloadSync: vi.fn(() => {
+        throw new Error('sync IPC staging failed')
+      })
+    })
+
+    expect(() => runShutdownCheckpointPersist(deps)).toThrow('sync IPC staging failed')
+  })
+
+  it('still fails the checkpoint when staging throws outside an intentional restart', () => {
+    const deps = makeDeps({
+      isIntentionalAppRestartInProgress: () => false,
+      stageBeforeUnloadSync: vi.fn(() => {
+        throw new Error('sync IPC staging failed')
+      })
+    })
+
+    expect(() => runShutdownCheckpointPersist(deps)).toThrow('sync IPC staging failed')
+  })
+
+  it('fails the checkpoint when even durable-only staging throws', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const deps = makeDeps({
+      buildSessionSnapshots: () => {
+        throw new Error('snapshot build failed')
+      },
+      stageBeforeUnloadSync: vi.fn(() => {
+        throw new Error('durable staging failed')
+      })
+    })
+
+    expect(() => runShutdownCheckpointPersist(deps)).toThrow('durable staging failed')
+    vi.restoreAllMocks()
+  })
+
+  it('keeps the durable-session fallback for snapshot build failures', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const deps = makeDeps({
+      buildSessionSnapshots: () => {
+        throw new Error('snapshot build failed')
+      }
+    })
+
+    expect(() => runShutdownCheckpointPersist(deps)).not.toThrow()
+    expect(deps.stageBeforeUnloadSync).toHaveBeenCalledTimes(1)
+    expect(deps.stageBeforeUnloadSync).toHaveBeenCalledWith({
+      sessions: [],
+      ui: { activeView: 'workspace' }
+    })
+    vi.restoreAllMocks()
+  })
+
+  it('rethrows snapshot build failures when dirty editor buffers exist', () => {
+    const deps = makeDeps({
+      hasDirtyOpenFiles: () => true,
+      buildSessionSnapshots: () => {
+        throw new Error('snapshot build failed')
+      }
+    })
+
+    expect(() => runShutdownCheckpointPersist(deps)).toThrow('snapshot build failed')
+    expect(deps.stageBeforeUnloadSync).not.toHaveBeenCalled()
+  })
+
+  it('skips capture and stages empty sessions before hydration completes', () => {
+    const deps = makeDeps({ shouldCaptureSession: () => false })
+
+    runShutdownCheckpointPersist(deps)
+
+    expect(deps.captureTerminalBuffers).not.toHaveBeenCalled()
+    expect(deps.captureSleepingAgentSessions).not.toHaveBeenCalled()
+    expect(deps.stageBeforeUnloadSync).toHaveBeenCalledWith({
+      sessions: [],
+      ui: { activeView: 'workspace' }
+    })
+  })
+})

--- a/src/renderer/src/app-shell/shutdown-checkpoint-persist.test.ts
+++ b/src/renderer/src/app-shell/shutdown-checkpoint-persist.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
-  runShutdownCheckpointPersist,
+  createShutdownCheckpointPersist,
   type ShutdownCheckpointPersistDeps
 } from './shutdown-checkpoint-persist'
 
@@ -20,7 +20,7 @@ function makeDeps(
   }
 }
 
-describe('runShutdownCheckpointPersist', () => {
+describe('createShutdownCheckpointPersist', () => {
   it('does not fail the checkpoint when the sleeping-agent quit capture throws (STA-5505)', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
     const deps = makeDeps({
@@ -29,9 +29,9 @@ describe('runShutdownCheckpointPersist', () => {
       }
     })
 
-    expect(() => runShutdownCheckpointPersist(deps)).not.toThrow()
-    // The full snapshot must still be staged — losing at most one minute of
-    // resume records is strictly better than blocking the update.
+    expect(createShutdownCheckpointPersist(deps)).not.toThrow()
+    // The full snapshot must still be staged — a weaker resume record for done
+    // panes is strictly better than blocking the update.
     expect(deps.stageBeforeUnloadSync).toHaveBeenCalledWith({
       sessions: [{ state: { activeTabId: 't1' } }],
       ui: { activeView: 'workspace' }
@@ -39,22 +39,52 @@ describe('runShutdownCheckpointPersist', () => {
     vi.restoreAllMocks()
   })
 
-  it('degrades to durable-only staging when full staging throws during an intentional restart (STA-5505)', () => {
+  it('keeps the first full-staging failure a visible, retryable error (STA-5505)', () => {
+    const stageBeforeUnloadSync = vi.fn(() => {
+      throw new Error('sync IPC staging failed')
+    })
+    const persist = createShutdownCheckpointPersist(makeDeps({ stageBeforeUnloadSync }))
+
+    // A transient failure must not silently cost the full snapshot on attempt one.
+    expect(persist).toThrow('sync IPC staging failed')
+    expect(stageBeforeUnloadSync).toHaveBeenCalledTimes(1)
+  })
+
+  it('degrades to durable-only staging when full staging fails again on retry (STA-5505)', () => {
     vi.spyOn(console, 'error').mockImplementation(() => {})
     const stageBeforeUnloadSync = vi.fn((args: { sessions: unknown[] }) => {
       if (args.sessions.length > 0) {
         throw new Error('sync IPC staging failed')
       }
     })
-    const deps = makeDeps({ stageBeforeUnloadSync })
+    const persist = createShutdownCheckpointPersist(makeDeps({ stageBeforeUnloadSync }))
 
-    expect(() => runShutdownCheckpointPersist(deps)).not.toThrow()
-    expect(stageBeforeUnloadSync).toHaveBeenCalledTimes(2)
+    expect(persist).toThrow('sync IPC staging failed')
+    expect(persist).not.toThrow()
+    expect(stageBeforeUnloadSync).toHaveBeenCalledTimes(3)
     expect(stageBeforeUnloadSync).toHaveBeenLastCalledWith({
       sessions: [],
       ui: { activeView: 'workspace' }
     })
     vi.restoreAllMocks()
+  })
+
+  it('stages the full snapshot when a retry after a transient staging failure succeeds', () => {
+    let calls = 0
+    const stageBeforeUnloadSync = vi.fn(() => {
+      calls += 1
+      if (calls === 1) {
+        throw new Error('transient staging failure')
+      }
+    })
+    const persist = createShutdownCheckpointPersist(makeDeps({ stageBeforeUnloadSync }))
+
+    expect(persist).toThrow('transient staging failure')
+    expect(persist).not.toThrow()
+    expect(stageBeforeUnloadSync).toHaveBeenLastCalledWith({
+      sessions: [{ state: { activeTabId: 't1' } }],
+      ui: { activeView: 'workspace' }
+    })
   })
 
   it('still fails the checkpoint when staging throws and dirty editor buffers exist', () => {
@@ -64,8 +94,10 @@ describe('runShutdownCheckpointPersist', () => {
         throw new Error('sync IPC staging failed')
       })
     })
+    const persist = createShutdownCheckpointPersist(deps)
 
-    expect(() => runShutdownCheckpointPersist(deps)).toThrow('sync IPC staging failed')
+    expect(persist).toThrow('sync IPC staging failed')
+    expect(persist).toThrow('sync IPC staging failed')
   })
 
   it('still fails the checkpoint when staging throws outside a degradable shutdown', () => {
@@ -75,8 +107,10 @@ describe('runShutdownCheckpointPersist', () => {
         throw new Error('sync IPC staging failed')
       })
     })
+    const persist = createShutdownCheckpointPersist(deps)
 
-    expect(() => runShutdownCheckpointPersist(deps)).toThrow('sync IPC staging failed')
+    expect(persist).toThrow('sync IPC staging failed')
+    expect(persist).toThrow('sync IPC staging failed')
   })
 
   it('fails the checkpoint when even durable-only staging throws', () => {
@@ -90,7 +124,7 @@ describe('runShutdownCheckpointPersist', () => {
       })
     })
 
-    expect(() => runShutdownCheckpointPersist(deps)).toThrow('durable staging failed')
+    expect(createShutdownCheckpointPersist(deps)).toThrow('durable staging failed')
     vi.restoreAllMocks()
   })
 
@@ -102,7 +136,7 @@ describe('runShutdownCheckpointPersist', () => {
       }
     })
 
-    expect(() => runShutdownCheckpointPersist(deps)).not.toThrow()
+    expect(createShutdownCheckpointPersist(deps)).not.toThrow()
     expect(deps.stageBeforeUnloadSync).toHaveBeenCalledTimes(1)
     expect(deps.stageBeforeUnloadSync).toHaveBeenCalledWith({
       sessions: [],
@@ -119,14 +153,14 @@ describe('runShutdownCheckpointPersist', () => {
       }
     })
 
-    expect(() => runShutdownCheckpointPersist(deps)).toThrow('snapshot build failed')
+    expect(createShutdownCheckpointPersist(deps)).toThrow('snapshot build failed')
     expect(deps.stageBeforeUnloadSync).not.toHaveBeenCalled()
   })
 
   it('skips capture and stages empty sessions before hydration completes', () => {
     const deps = makeDeps({ shouldCaptureSession: () => false })
 
-    runShutdownCheckpointPersist(deps)
+    createShutdownCheckpointPersist(deps)()
 
     expect(deps.captureTerminalBuffers).not.toHaveBeenCalled()
     expect(deps.captureSleepingAgentSessions).not.toHaveBeenCalled()

--- a/src/renderer/src/app-shell/shutdown-checkpoint-persist.test.ts
+++ b/src/renderer/src/app-shell/shutdown-checkpoint-persist.test.ts
@@ -29,7 +29,7 @@ describe('createShutdownCheckpointPersist', () => {
       }
     })
 
-    expect(createShutdownCheckpointPersist(deps)).not.toThrow()
+    expect(createShutdownCheckpointPersist(deps).run).not.toThrow()
     // The full snapshot must still be staged — a weaker resume record for done
     // panes is strictly better than blocking the update.
     expect(deps.stageBeforeUnloadSync).toHaveBeenCalledWith({
@@ -39,11 +39,24 @@ describe('createShutdownCheckpointPersist', () => {
     vi.restoreAllMocks()
   })
 
+  it('keeps sleeping-capture diagnostics non-throwing for unstringifiable values', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const deps = makeDeps({
+      captureSleepingAgentSessions: () => {
+        throw Object.create(null)
+      }
+    })
+
+    expect(createShutdownCheckpointPersist(deps).run).not.toThrow()
+    expect(deps.stageBeforeUnloadSync).toHaveBeenCalledTimes(1)
+    vi.restoreAllMocks()
+  })
+
   it('keeps the first full-staging failure a visible, retryable error (STA-5505)', () => {
     const stageBeforeUnloadSync = vi.fn(() => {
       throw new Error('sync IPC staging failed')
     })
-    const persist = createShutdownCheckpointPersist(makeDeps({ stageBeforeUnloadSync }))
+    const { run: persist } = createShutdownCheckpointPersist(makeDeps({ stageBeforeUnloadSync }))
 
     // A transient failure must not silently cost the full snapshot on attempt one.
     expect(persist).toThrow('sync IPC staging failed')
@@ -57,7 +70,7 @@ describe('createShutdownCheckpointPersist', () => {
         throw new Error('sync IPC staging failed')
       }
     })
-    const persist = createShutdownCheckpointPersist(makeDeps({ stageBeforeUnloadSync }))
+    const { run: persist } = createShutdownCheckpointPersist(makeDeps({ stageBeforeUnloadSync }))
 
     expect(persist).toThrow('sync IPC staging failed')
     expect(persist).not.toThrow()
@@ -77,7 +90,7 @@ describe('createShutdownCheckpointPersist', () => {
         throw new Error('transient staging failure')
       }
     })
-    const persist = createShutdownCheckpointPersist(makeDeps({ stageBeforeUnloadSync }))
+    const { run: persist } = createShutdownCheckpointPersist(makeDeps({ stageBeforeUnloadSync }))
 
     expect(persist).toThrow('transient staging failure')
     expect(persist).not.toThrow()
@@ -94,7 +107,7 @@ describe('createShutdownCheckpointPersist', () => {
         throw new Error('sync IPC staging failed')
       })
     })
-    const persist = createShutdownCheckpointPersist(deps)
+    const { run: persist } = createShutdownCheckpointPersist(deps)
 
     expect(persist).toThrow('sync IPC staging failed')
     expect(persist).toThrow('sync IPC staging failed')
@@ -107,7 +120,7 @@ describe('createShutdownCheckpointPersist', () => {
         throw new Error('sync IPC staging failed')
       })
     })
-    const persist = createShutdownCheckpointPersist(deps)
+    const { run: persist } = createShutdownCheckpointPersist(deps)
 
     expect(persist).toThrow('sync IPC staging failed')
     expect(persist).toThrow('sync IPC staging failed')
@@ -124,7 +137,7 @@ describe('createShutdownCheckpointPersist', () => {
       })
     })
 
-    expect(createShutdownCheckpointPersist(deps)).toThrow('durable staging failed')
+    expect(createShutdownCheckpointPersist(deps).run).toThrow('durable staging failed')
     vi.restoreAllMocks()
   })
 
@@ -136,7 +149,7 @@ describe('createShutdownCheckpointPersist', () => {
       }
     })
 
-    expect(createShutdownCheckpointPersist(deps)).not.toThrow()
+    expect(createShutdownCheckpointPersist(deps).run).not.toThrow()
     expect(deps.stageBeforeUnloadSync).toHaveBeenCalledTimes(1)
     expect(deps.stageBeforeUnloadSync).toHaveBeenCalledWith({
       sessions: [],
@@ -153,14 +166,14 @@ describe('createShutdownCheckpointPersist', () => {
       }
     })
 
-    expect(createShutdownCheckpointPersist(deps)).toThrow('snapshot build failed')
+    expect(createShutdownCheckpointPersist(deps).run).toThrow('snapshot build failed')
     expect(deps.stageBeforeUnloadSync).not.toHaveBeenCalled()
   })
 
   it('skips capture and stages empty sessions before hydration completes', () => {
     const deps = makeDeps({ shouldCaptureSession: () => false })
 
-    createShutdownCheckpointPersist(deps)()
+    createShutdownCheckpointPersist(deps).run()
 
     expect(deps.captureTerminalBuffers).not.toHaveBeenCalled()
     expect(deps.captureSleepingAgentSessions).not.toHaveBeenCalled()
@@ -168,5 +181,17 @@ describe('createShutdownCheckpointPersist', () => {
       sessions: [],
       ui: { activeView: 'workspace' }
     })
+  })
+
+  it('forgets a failed attempt when an aborted shutdown resets the lifecycle', () => {
+    const stageBeforeUnloadSync = vi.fn(() => {
+      throw new Error('sync IPC staging failed')
+    })
+    const persist = createShutdownCheckpointPersist(makeDeps({ stageBeforeUnloadSync }))
+
+    expect(persist.run).toThrow('sync IPC staging failed')
+    persist.reset()
+    expect(persist.run).toThrow('sync IPC staging failed')
+    expect(stageBeforeUnloadSync).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/renderer/src/app-shell/shutdown-checkpoint-persist.test.ts
+++ b/src/renderer/src/app-shell/shutdown-checkpoint-persist.test.ts
@@ -190,7 +190,7 @@ describe('createShutdownCheckpointPersist', () => {
     const persist = createShutdownCheckpointPersist(makeDeps({ stageBeforeUnloadSync }))
 
     expect(persist.run).toThrow('sync IPC staging failed')
-    persist.reset()
+    persist.abandonAttempt()
     expect(persist.run).toThrow('sync IPC staging failed')
     expect(stageBeforeUnloadSync).toHaveBeenCalledTimes(2)
   })

--- a/src/renderer/src/app-shell/shutdown-checkpoint-persist.test.ts
+++ b/src/renderer/src/app-shell/shutdown-checkpoint-persist.test.ts
@@ -14,7 +14,7 @@ function makeDeps(
     buildSessionSnapshots: () => [{ state: { activeTabId: 't1' } }] as never,
     buildUiPatch: () => ({ activeView: 'workspace' }) as never,
     hasDirtyOpenFiles: () => false,
-    isIntentionalAppRestartInProgress: () => true,
+    isDegradableShutdownInProgress: () => true,
     stageBeforeUnloadSync: vi.fn(),
     ...overrides
   }
@@ -68,9 +68,9 @@ describe('runShutdownCheckpointPersist', () => {
     expect(() => runShutdownCheckpointPersist(deps)).toThrow('sync IPC staging failed')
   })
 
-  it('still fails the checkpoint when staging throws outside an intentional restart', () => {
+  it('still fails the checkpoint when staging throws outside a degradable shutdown', () => {
     const deps = makeDeps({
-      isIntentionalAppRestartInProgress: () => false,
+      isDegradableShutdownInProgress: () => false,
       stageBeforeUnloadSync: vi.fn(() => {
         throw new Error('sync IPC staging failed')
       })

--- a/src/renderer/src/app-shell/shutdown-checkpoint-persist.ts
+++ b/src/renderer/src/app-shell/shutdown-checkpoint-persist.ts
@@ -1,4 +1,5 @@
 import type { PersistedUIState } from '../../../shared/persisted-ui-state-types'
+import { formatShutdownCheckpointFailureReason } from '../../../shared/renderer-shutdown-events'
 import type { WorkspaceSessionHostSnapshot } from '../lib/workspace-session-host-persistence'
 import { recordRendererCrashBreadcrumb } from '../lib/crash-breadcrumb-recorder'
 
@@ -21,16 +22,23 @@ export type ShutdownCheckpointPersistDeps = {
   stageBeforeUnloadSync: (args: ShutdownCheckpointStageArgs) => void
 }
 
-/** Returns the synchronous body of the shutdown checkpoint: capture renderer-owned
- *  state, then stage everything durable through one main-process call. Throwing
- *  fails the checkpoint and blocks the restart, so only unstageable data may throw.
+export type ShutdownCheckpointPersist = {
+  run: () => void
+  reset: () => void
+}
+
+/** Returns the shutdown checkpoint attempt lifecycle. Running it captures renderer-owned
+ *  state, then stages everything durable through one main-process call; reset discards
+ *  retry state when that shutdown attempt is abandoned. Only unstageable data may throw.
  *
  *  A factory rather than a bare function so full-session staging failures can stay
  *  visible-and-retryable on the first attempt and only degrade on a repeat: a
  *  transient failure gets its retry, a deterministic one can't strand the user. */
-export function createShutdownCheckpointPersist(deps: ShutdownCheckpointPersistDeps): () => void {
+export function createShutdownCheckpointPersist(
+  deps: ShutdownCheckpointPersistDeps
+): ShutdownCheckpointPersist {
   let fullStagingFailedOnPriorAttempt = false
-  return (): void => {
+  const run = (): void => {
     const shouldCaptureSession = deps.shouldCaptureSession()
     if (shouldCaptureSession) {
       deps.captureTerminalBuffers()
@@ -43,7 +51,7 @@ export function createShutdownCheckpointPersist(deps: ShutdownCheckpointPersistD
         // alternative (no update, or a SIGKILL'd quit losing the whole snapshot).
         console.error('[app] Sleeping-agent quit capture failed; continuing checkpoint', error)
         recordRendererCrashBreadcrumb('renderer_shutdown_sleeping_capture_failed', {
-          message: error instanceof Error ? error.message : String(error)
+          message: formatShutdownCheckpointFailureReason(error)
         })
       }
     }
@@ -91,5 +99,11 @@ export function createShutdownCheckpointPersist(deps: ShutdownCheckpointPersistD
       deps.stageBeforeUnloadSync({ sessions: [], ui: deps.buildUiPatch() })
     }
     fullStagingFailedOnPriorAttempt = false
+  }
+  return {
+    run,
+    reset: () => {
+      fullStagingFailedOnPriorAttempt = false
+    }
   }
 }

--- a/src/renderer/src/app-shell/shutdown-checkpoint-persist.ts
+++ b/src/renderer/src/app-shell/shutdown-checkpoint-persist.ts
@@ -75,9 +75,12 @@ export function createShutdownCheckpointPersist(deps: ShutdownCheckpointPersistD
       // Why retry-then-degrade: the first staging failure stays a visible,
       // retryable error — degrading immediately would silently drop just-captured
       // scrollback that a retry may well save. Only a repeat failure trades the
-      // full snapshot for an unblocked shutdown.
+      // full snapshot for an unblocked shutdown. Non-degradable failures never
+      // arm the flag, so an unrelated unload can't burn a later restart's retry.
       const keepBlocking = !fullStagingFailedOnPriorAttempt || !canDegradeToDurableSession()
-      fullStagingFailedOnPriorAttempt = true
+      if (canDegradeToDurableSession()) {
+        fullStagingFailedOnPriorAttempt = true
+      }
       if (keepBlocking) {
         throw error
       }

--- a/src/renderer/src/app-shell/shutdown-checkpoint-persist.ts
+++ b/src/renderer/src/app-shell/shutdown-checkpoint-persist.ts
@@ -1,5 +1,6 @@
 import type { PersistedUIState } from '../../../shared/persisted-ui-state-types'
 import type { WorkspaceSessionHostSnapshot } from '../lib/workspace-session-host-persistence'
+import { recordRendererCrashBreadcrumb } from '../lib/crash-breadcrumb-recorder'
 
 export type ShutdownCheckpointStageArgs = {
   sessions: WorkspaceSessionHostSnapshot[]
@@ -20,47 +21,72 @@ export type ShutdownCheckpointPersistDeps = {
   stageBeforeUnloadSync: (args: ShutdownCheckpointStageArgs) => void
 }
 
-/** The synchronous body of the shutdown checkpoint: capture renderer-owned state,
- *  then stage everything durable through one main-process call. Throwing here fails
- *  the checkpoint and blocks the restart, so only unstageable data may throw. */
-export function runShutdownCheckpointPersist(deps: ShutdownCheckpointPersistDeps): void {
-  const shouldCaptureSession = deps.shouldCaptureSession()
-  if (shouldCaptureSession) {
-    deps.captureTerminalBuffers()
+/** Returns the synchronous body of the shutdown checkpoint: capture renderer-owned
+ *  state, then stage everything durable through one main-process call. Throwing
+ *  fails the checkpoint and blocks the restart, so only unstageable data may throw.
+ *
+ *  A factory rather than a bare function so full-session staging failures can stay
+ *  visible-and-retryable on the first attempt and only degrade on a repeat: a
+ *  transient failure gets its retry, a deterministic one can't strand the user. */
+export function createShutdownCheckpointPersist(deps: ShutdownCheckpointPersistDeps): () => void {
+  let fullStagingFailedOnPriorAttempt = false
+  return (): void => {
+    const shouldCaptureSession = deps.shouldCaptureSession()
+    if (shouldCaptureSession) {
+      deps.captureTerminalBuffers()
+      try {
+        deps.captureSleepingAgentSessions()
+      } catch (error) {
+        // Why: blocking the shutdown here is what stranded STA-5505. The cost of
+        // continuing is real but bounded — done panes keep their weaker live-origin
+        // record instead of a durable quit capture — and strictly smaller than the
+        // alternative (no update, or a SIGKILL'd quit losing the whole snapshot).
+        console.error('[app] Sleeping-agent quit capture failed; continuing checkpoint', error)
+        recordRendererCrashBreadcrumb('renderer_shutdown_sleeping_capture_failed', {
+          message: error instanceof Error ? error.message : String(error)
+        })
+      }
+    }
+    // Why: dirty drafts exist only in the full session snapshot, so their loss is the
+    // one thing this checkpoint may never trade away for an update.
+    const canDegradeToDurableSession = (): boolean =>
+      deps.isDegradableShutdownInProgress() && !deps.hasDirtyOpenFiles()
+    let sessionSnapshots: WorkspaceSessionHostSnapshot[] = []
+    let degraded = false
     try {
-      deps.captureSleepingAgentSessions()
+      sessionSnapshots = shouldCaptureSession ? deps.buildSessionSnapshots() : []
     } catch (error) {
-      // Why: the periodic capture refreshes resume records every minute, so a failed
-      // quit capture costs at most that window — never strand the restart on it.
-      console.error('[app] Sleeping-agent quit capture failed; continuing checkpoint', error)
+      if (!canDegradeToDurableSession()) {
+        throw error
+      }
+      console.error('[app] Full renderer session snapshot failed; using durable session', error)
+      degraded = true
     }
-  }
-  // Why: dirty drafts exist only in the full session snapshot, so their loss is the
-  // one thing this checkpoint may never trade away for an update.
-  const canDegradeToDurableSession = (): boolean =>
-    deps.isDegradableShutdownInProgress() && !deps.hasDirtyOpenFiles()
-  let sessionSnapshots: WorkspaceSessionHostSnapshot[] = []
-  let degraded = false
-  try {
-    sessionSnapshots = shouldCaptureSession ? deps.buildSessionSnapshots() : []
-  } catch (error) {
-    if (!canDegradeToDurableSession()) {
-      throw error
+    try {
+      deps.stageBeforeUnloadSync({
+        sessions: degraded ? [] : sessionSnapshots,
+        ui: deps.buildUiPatch()
+      })
+    } catch (error) {
+      // A durable-only stage has nothing safer left to fall back to.
+      if (degraded) {
+        throw error
+      }
+      // Why retry-then-degrade: the first staging failure stays a visible,
+      // retryable error — degrading immediately would silently drop just-captured
+      // scrollback that a retry may well save. Only a repeat failure trades the
+      // full snapshot for an unblocked shutdown.
+      const keepBlocking = !fullStagingFailedOnPriorAttempt || !canDegradeToDurableSession()
+      fullStagingFailedOnPriorAttempt = true
+      if (keepBlocking) {
+        throw error
+      }
+      console.error(
+        '[app] Staging the full renderer session failed again; using durable session',
+        error
+      )
+      deps.stageBeforeUnloadSync({ sessions: [], ui: deps.buildUiPatch() })
     }
-    console.error('[app] Full renderer session snapshot failed; using durable session', error)
-    degraded = true
-  }
-  try {
-    deps.stageBeforeUnloadSync({
-      sessions: degraded ? [] : sessionSnapshots,
-      ui: deps.buildUiPatch()
-    })
-  } catch (error) {
-    // A durable-only stage has nothing safer left to fall back to.
-    if (degraded || !canDegradeToDurableSession()) {
-      throw error
-    }
-    console.error('[app] Staging the full renderer session failed; using durable session', error)
-    deps.stageBeforeUnloadSync({ sessions: [], ui: deps.buildUiPatch() })
+    fullStagingFailedOnPriorAttempt = false
   }
 }

--- a/src/renderer/src/app-shell/shutdown-checkpoint-persist.ts
+++ b/src/renderer/src/app-shell/shutdown-checkpoint-persist.ts
@@ -24,12 +24,13 @@ export type ShutdownCheckpointPersistDeps = {
 
 export type ShutdownCheckpointPersist = {
   run: () => void
-  reset: () => void
+  abandonAttempt: () => void
 }
 
 /** Returns the shutdown checkpoint attempt lifecycle. Running it captures renderer-owned
- *  state, then stages everything durable through one main-process call; reset discards
- *  retry state when that shutdown attempt is abandoned. Only unstageable data may throw.
+ *  state, then stages everything durable through one main-process call;
+ *  abandonAttempt discards retry state when a shutdown is independently canceled.
+ *  Only unstageable data may throw.
  *
  *  A factory rather than a bare function so full-session staging failures can stay
  *  visible-and-retryable on the first attempt and only degrade on a repeat: a
@@ -102,7 +103,7 @@ export function createShutdownCheckpointPersist(
   }
   return {
     run,
-    reset: () => {
+    abandonAttempt: () => {
       fullStagingFailedOnPriorAttempt = false
     }
   }

--- a/src/renderer/src/app-shell/shutdown-checkpoint-persist.ts
+++ b/src/renderer/src/app-shell/shutdown-checkpoint-persist.ts
@@ -1,0 +1,64 @@
+import type { PersistedUIState } from '../../../shared/persisted-ui-state-types'
+import type { WorkspaceSessionHostSnapshot } from '../lib/workspace-session-host-persistence'
+
+export type ShutdownCheckpointStageArgs = {
+  sessions: WorkspaceSessionHostSnapshot[]
+  ui: Partial<PersistedUIState>
+}
+
+export type ShutdownCheckpointPersistDeps = {
+  shouldCaptureSession: () => boolean
+  /** Per-pane failures are already swallowed inside the capture loop. */
+  captureTerminalBuffers: () => void
+  captureSleepingAgentSessions: () => void
+  buildSessionSnapshots: () => WorkspaceSessionHostSnapshot[]
+  buildUiPatch: () => Partial<PersistedUIState>
+  hasDirtyOpenFiles: () => boolean
+  isIntentionalAppRestartInProgress: () => boolean
+  stageBeforeUnloadSync: (args: ShutdownCheckpointStageArgs) => void
+}
+
+/** The synchronous body of the shutdown checkpoint: capture renderer-owned state,
+ *  then stage everything durable through one main-process call. Throwing here fails
+ *  the checkpoint and blocks the restart, so only unstageable data may throw. */
+export function runShutdownCheckpointPersist(deps: ShutdownCheckpointPersistDeps): void {
+  const shouldCaptureSession = deps.shouldCaptureSession()
+  if (shouldCaptureSession) {
+    deps.captureTerminalBuffers()
+    try {
+      deps.captureSleepingAgentSessions()
+    } catch (error) {
+      // Why: the periodic capture refreshes resume records every minute, so a failed
+      // quit capture costs at most that window — never strand the restart on it.
+      console.error('[app] Sleeping-agent quit capture failed; continuing checkpoint', error)
+    }
+  }
+  // Why: dirty drafts exist only in the full session snapshot, so their loss is the
+  // one thing this checkpoint may never trade away for an update.
+  const canDegradeToDurableSession = (): boolean =>
+    deps.isIntentionalAppRestartInProgress() && !deps.hasDirtyOpenFiles()
+  let sessionSnapshots: WorkspaceSessionHostSnapshot[] = []
+  let degraded = false
+  try {
+    sessionSnapshots = shouldCaptureSession ? deps.buildSessionSnapshots() : []
+  } catch (error) {
+    if (!canDegradeToDurableSession()) {
+      throw error
+    }
+    console.error('[app] Full renderer session snapshot failed; using durable session', error)
+    degraded = true
+  }
+  try {
+    deps.stageBeforeUnloadSync({
+      sessions: degraded ? [] : sessionSnapshots,
+      ui: deps.buildUiPatch()
+    })
+  } catch (error) {
+    // A durable-only stage has nothing safer left to fall back to.
+    if (degraded || !canDegradeToDurableSession()) {
+      throw error
+    }
+    console.error('[app] Staging the full renderer session failed; using durable session', error)
+    deps.stageBeforeUnloadSync({ sessions: [], ui: deps.buildUiPatch() })
+  }
+}

--- a/src/renderer/src/app-shell/shutdown-checkpoint-persist.ts
+++ b/src/renderer/src/app-shell/shutdown-checkpoint-persist.ts
@@ -14,7 +14,9 @@ export type ShutdownCheckpointPersistDeps = {
   buildSessionSnapshots: () => WorkspaceSessionHostSnapshot[]
   buildUiPatch: () => Partial<PersistedUIState>
   hasDirtyOpenFiles: () => boolean
-  isIntentionalAppRestartInProgress: () => boolean
+  /** True during an intentional restart or an app-level quit/close — the unloads
+   *  where losing the full snapshot beats blocking the shutdown outright. */
+  isDegradableShutdownInProgress: () => boolean
   stageBeforeUnloadSync: (args: ShutdownCheckpointStageArgs) => void
 }
 
@@ -36,7 +38,7 @@ export function runShutdownCheckpointPersist(deps: ShutdownCheckpointPersistDeps
   // Why: dirty drafts exist only in the full session snapshot, so their loss is the
   // one thing this checkpoint may never trade away for an update.
   const canDegradeToDurableSession = (): boolean =>
-    deps.isIntentionalAppRestartInProgress() && !deps.hasDirtyOpenFiles()
+    deps.isDegradableShutdownInProgress() && !deps.hasDirtyOpenFiles()
   let sessionSnapshots: WorkspaceSessionHostSnapshot[] = []
   let degraded = false
   try {

--- a/src/renderer/src/app-shell/shutdown-checkpoint-restart-lifecycle.test.ts
+++ b/src/renderer/src/app-shell/shutdown-checkpoint-restart-lifecycle.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  ORCA_APP_RESTART_ABORTED_EVENT,
+  ORCA_APP_RESTART_STARTED_EVENT,
+  ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT,
+  ORCA_UPDATER_QUIT_AND_INSTALL_STARTED_EVENT
+} from '../../../shared/updater-renderer-events'
+import {
+  ORCA_RENDERER_SHUTDOWN_CHECKPOINT_ABORTED_EVENT,
+  ORCA_RENDERER_UNLOAD_PREVENTED_EVENT
+} from '../../../shared/renderer-shutdown-events'
+import { prepareRendererForAppRestart } from '../../../shared/renderer-restart-preparation'
+import {
+  createShutdownCheckpointBeforeUnloadHandler,
+  createShutdownCheckpointGuard
+} from '../lib/shutdown-checkpoint-guard'
+import {
+  isIntentionalAppRestartInProgress,
+  registerUpdaterBeforeUnloadBypass
+} from '../lib/updater-beforeunload'
+import { createShutdownCheckpointPersist } from './shutdown-checkpoint-persist'
+
+type LifecycleHarness = {
+  cleanup: () => void
+  prepare: () => Promise<void>
+  stageBeforeUnloadSync: ReturnType<typeof vi.fn>
+}
+
+function createLifecycleHarness(
+  startedEventName: string,
+  abortedEventName: string
+): LifecycleHarness {
+  const stageBeforeUnloadSync = vi.fn((args: { sessions: unknown[] }) => {
+    if (args.sessions.length > 0) {
+      throw new Error('deterministic full-stage failure')
+    }
+  })
+  const persist = createShutdownCheckpointPersist({
+    shouldCaptureSession: () => true,
+    captureTerminalBuffers: vi.fn(),
+    captureSleepingAgentSessions: vi.fn(),
+    buildSessionSnapshots: () => [{ state: { activeTabId: 't1' } }] as never,
+    buildUiPatch: () => ({ activeView: 'workspace' }) as never,
+    hasDirtyOpenFiles: () => false,
+    isDegradableShutdownInProgress: isIntentionalAppRestartInProgress,
+    stageBeforeUnloadSync
+  })
+  const guard = createShutdownCheckpointGuard(persist.run, persist.abandonAttempt)
+  const checkpoint = createShutdownCheckpointBeforeUnloadHandler(guard)
+  const cleanupRestartTracking = registerUpdaterBeforeUnloadBypass()
+  window.addEventListener('beforeunload', checkpoint)
+  window.addEventListener(
+    ORCA_RENDERER_SHUTDOWN_CHECKPOINT_ABORTED_EVENT,
+    guard.abortAfterCheckpointFailure
+  )
+  window.addEventListener(abortedEventName, guard.abandonAttempt)
+  window.addEventListener(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT, guard.abandonAttempt)
+  return {
+    stageBeforeUnloadSync,
+    prepare: () =>
+      prepareRendererForAppRestart(window, {
+        startedEventName,
+        abortedEventName,
+        awaitCheckpoint: () => Promise.resolve()
+      }),
+    cleanup: () => {
+      cleanupRestartTracking()
+      window.removeEventListener('beforeunload', checkpoint)
+      window.removeEventListener(
+        ORCA_RENDERER_SHUTDOWN_CHECKPOINT_ABORTED_EVENT,
+        guard.abortAfterCheckpointFailure
+      )
+      window.removeEventListener(abortedEventName, guard.abandonAttempt)
+      window.removeEventListener(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT, guard.abandonAttempt)
+    }
+  }
+}
+
+describe('shutdown checkpoint restart lifecycle', () => {
+  const cleanupFns: (() => void)[] = []
+
+  afterEach(() => {
+    cleanupFns.splice(0).forEach((cleanup) => cleanup())
+    vi.restoreAllMocks()
+  })
+
+  it.each([
+    {
+      lifecycle: 'app restart',
+      startedEventName: ORCA_APP_RESTART_STARTED_EVENT,
+      abortedEventName: ORCA_APP_RESTART_ABORTED_EVENT
+    },
+    {
+      lifecycle: 'updater install',
+      startedEventName: ORCA_UPDATER_QUIT_AND_INSTALL_STARTED_EVENT,
+      abortedEventName: ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT
+    }
+  ])(
+    'preserves retry-then-degrade across a checkpoint-caused $lifecycle abort',
+    async ({ startedEventName, abortedEventName }) => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      const harness = createLifecycleHarness(startedEventName, abortedEventName)
+      cleanupFns.push(harness.cleanup)
+
+      await expect(harness.prepare()).rejects.toThrow('deterministic full-stage failure')
+      expect(isIntentionalAppRestartInProgress()).toBe(false)
+      await expect(harness.prepare()).resolves.toBeUndefined()
+
+      expect(harness.stageBeforeUnloadSync).toHaveBeenCalledTimes(3)
+      expect(harness.stageBeforeUnloadSync).toHaveBeenLastCalledWith({
+        sessions: [],
+        ui: { activeView: 'workspace' }
+      })
+    }
+  )
+
+  it('abandons retry state when a later restart attempt is independently canceled', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const harness = createLifecycleHarness(
+      ORCA_APP_RESTART_STARTED_EVENT,
+      ORCA_APP_RESTART_ABORTED_EVENT
+    )
+    cleanupFns.push(harness.cleanup)
+
+    await expect(harness.prepare()).rejects.toThrow('deterministic full-stage failure')
+    window.dispatchEvent(new Event(ORCA_APP_RESTART_STARTED_EVENT))
+    window.dispatchEvent(new Event(ORCA_APP_RESTART_ABORTED_EVENT))
+    await expect(harness.prepare()).rejects.toThrow('deterministic full-stage failure')
+
+    expect(harness.stageBeforeUnloadSync).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/renderer/src/app-shell/use-app-session-persistence.ts
+++ b/src/renderer/src/app-shell/use-app-session-persistence.ts
@@ -22,7 +22,10 @@ import {
 } from '../lib/shutdown-checkpoint-guard'
 import { runShutdownCheckpointPersist } from './shutdown-checkpoint-persist'
 import { shutdownBufferCaptures } from '../components/terminal-pane/shutdown-buffer-captures'
-import { dispatchWindowCloseRequest } from '../components/window-close-request-coordinator'
+import {
+  dispatchWindowCloseRequest,
+  isWindowCloseCheckpointInProgress
+} from '../components/window-close-request-coordinator'
 import {
   ORCA_APP_RESTART_ABORTED_EVENT,
   ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT
@@ -148,7 +151,10 @@ export function useAppSessionPersistence(): void {
         },
         buildUiPatch: () => buildActiveViewUnloadPatch(useAppStore.getState()),
         hasDirtyOpenFiles: () => useAppStore.getState().openFiles.some((file) => file.isDirty),
-        isIntentionalAppRestartInProgress,
+        // Why: an app-level quit degrades too — the pre-fix alternative was a quit
+        // the user could only complete with SIGKILL, which loses strictly more (#15352).
+        isDegradableShutdownInProgress: () =>
+          isIntentionalAppRestartInProgress() || isWindowCloseCheckpointInProgress(),
         stageBeforeUnloadSync: (args) => window.api.app.stageBeforeUnloadSync(args)
       })
     )

--- a/src/renderer/src/app-shell/use-app-session-persistence.ts
+++ b/src/renderer/src/app-shell/use-app-session-persistence.ts
@@ -30,7 +30,10 @@ import {
   ORCA_APP_RESTART_ABORTED_EVENT,
   ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT
 } from '../../../shared/updater-renderer-events'
-import { ORCA_RENDERER_UNLOAD_PREVENTED_EVENT } from '../../../shared/renderer-shutdown-events'
+import {
+  ORCA_RENDERER_SHUTDOWN_CHECKPOINT_ABORTED_EVENT,
+  ORCA_RENDERER_UNLOAD_PREVENTED_EVENT
+} from '../../../shared/renderer-shutdown-events'
 import type { RemoteWorkspacePatchResult } from '../../../shared/remote-workspace-types'
 
 // Why: bound the resume-record loss window on a hard kill to ~1 min; capture skips unchanged records so per-tick cost is negligible.
@@ -158,21 +161,35 @@ export function useAppSessionPersistence(): void {
     })
     const shutdownCheckpoint = createShutdownCheckpointGuard(
       shutdownCheckpointPersist.run,
-      shutdownCheckpointPersist.reset
+      shutdownCheckpointPersist.abandonAttempt
     )
     const persistBeforeUnload = createShutdownCheckpointBeforeUnloadHandler(shutdownCheckpoint)
     window.addEventListener('beforeunload', persistBeforeUnload)
-    window.addEventListener(ORCA_APP_RESTART_ABORTED_EVENT, shutdownCheckpoint.reset)
-    window.addEventListener(ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT, shutdownCheckpoint.reset)
-    window.addEventListener(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT, shutdownCheckpoint.reset)
+    window.addEventListener(
+      ORCA_RENDERER_SHUTDOWN_CHECKPOINT_ABORTED_EVENT,
+      shutdownCheckpoint.abortAfterCheckpointFailure
+    )
+    window.addEventListener(ORCA_APP_RESTART_ABORTED_EVENT, shutdownCheckpoint.abandonAttempt)
+    window.addEventListener(
+      ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT,
+      shutdownCheckpoint.abandonAttempt
+    )
+    window.addEventListener(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT, shutdownCheckpoint.abandonAttempt)
     return () => {
       window.removeEventListener('beforeunload', persistBeforeUnload)
-      window.removeEventListener(ORCA_APP_RESTART_ABORTED_EVENT, shutdownCheckpoint.reset)
+      window.removeEventListener(
+        ORCA_RENDERER_SHUTDOWN_CHECKPOINT_ABORTED_EVENT,
+        shutdownCheckpoint.abortAfterCheckpointFailure
+      )
+      window.removeEventListener(ORCA_APP_RESTART_ABORTED_EVENT, shutdownCheckpoint.abandonAttempt)
       window.removeEventListener(
         ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT,
-        shutdownCheckpoint.reset
+        shutdownCheckpoint.abandonAttempt
       )
-      window.removeEventListener(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT, shutdownCheckpoint.reset)
+      window.removeEventListener(
+        ORCA_RENDERER_UNLOAD_PREVENTED_EVENT,
+        shutdownCheckpoint.abandonAttempt
+      )
     }
   }, [])
 

--- a/src/renderer/src/app-shell/use-app-session-persistence.ts
+++ b/src/renderer/src/app-shell/use-app-session-persistence.ts
@@ -20,7 +20,7 @@ import {
   createShutdownCheckpointBeforeUnloadHandler,
   createShutdownCheckpointGuard
 } from '../lib/shutdown-checkpoint-guard'
-import { runShutdownCheckpointPersist } from './shutdown-checkpoint-persist'
+import { createShutdownCheckpointPersist } from './shutdown-checkpoint-persist'
 import { shutdownBufferCaptures } from '../components/terminal-pane/shutdown-buffer-captures'
 import {
   dispatchWindowCloseRequest,
@@ -121,8 +121,8 @@ export function useAppSessionPersistence(): void {
     // two firings, PTY exit events can arrive and unmount TerminalPanes,
     // emptying shutdownBufferCaptures. The guard prevents the second call
     // from overwriting the good session data with an empty snapshot.
-    const shutdownCheckpoint = createShutdownCheckpointGuard(() =>
-      runShutdownCheckpointPersist({
+    const shutdownCheckpoint = createShutdownCheckpointGuard(
+      createShutdownCheckpointPersist({
         shouldCaptureSession: () => shouldPersistWorkspaceSession(useAppStore.getState()),
         captureTerminalBuffers: () => {
           for (const capture of shutdownBufferCaptures.values()) {

--- a/src/renderer/src/app-shell/use-app-session-persistence.ts
+++ b/src/renderer/src/app-shell/use-app-session-persistence.ts
@@ -121,42 +121,44 @@ export function useAppSessionPersistence(): void {
     // two firings, PTY exit events can arrive and unmount TerminalPanes,
     // emptying shutdownBufferCaptures. The guard prevents the second call
     // from overwriting the good session data with an empty snapshot.
-    const shutdownCheckpoint = createShutdownCheckpointGuard(
-      createShutdownCheckpointPersist({
-        shouldCaptureSession: () => shouldPersistWorkspaceSession(useAppStore.getState()),
-        captureTerminalBuffers: () => {
-          for (const capture of shutdownBufferCaptures.values()) {
-            try {
-              capture({ includeLocalBuffers: false })
-            } catch {
-              // Don't let one pane's failure block the rest.
-            }
+    const shutdownCheckpointPersist = createShutdownCheckpointPersist({
+      shouldCaptureSession: () => shouldPersistWorkspaceSession(useAppStore.getState()),
+      captureTerminalBuffers: () => {
+        for (const capture of shutdownBufferCaptures.values()) {
+          try {
+            capture({ includeLocalBuffers: false })
+          } catch {
+            // Don't let one pane's failure block the rest.
           }
-        },
-        // Why: agent provider session ids live only in agentStatusByPaneKey,
-        // which is in-memory. Capture them into the persisted sleeping-session
-        // map so a daemon/session death while the app is closed can still
-        // cold-restore via the agent's resume command (#5232).
-        captureSleepingAgentSessions: () =>
-          useAppStore.getState().captureAllSleepingAgentSessions('quit'),
-        // Why: re-read state after capture() calls populated scrollback buffers
-        // into the store via Zustand setters. The shouldCaptureSession read is
-        // only for the gating flags and would miss those updates.
-        buildSessionSnapshots: () => {
-          const freshState = useAppStore.getState()
-          return buildWorkspaceSessionHostSnapshots(
-            buildWorkspaceSessionPayload(freshState),
-            freshState
-          )
-        },
-        buildUiPatch: () => buildActiveViewUnloadPatch(useAppStore.getState()),
-        hasDirtyOpenFiles: () => useAppStore.getState().openFiles.some((file) => file.isDirty),
-        // Why: an app-level quit degrades too — the pre-fix alternative was a quit
-        // the user could only complete with SIGKILL, which loses strictly more (#15352).
-        isDegradableShutdownInProgress: () =>
-          isIntentionalAppRestartInProgress() || isWindowCloseCheckpointInProgress(),
-        stageBeforeUnloadSync: (args) => window.api.app.stageBeforeUnloadSync(args)
-      })
+        }
+      },
+      // Why: agent provider session ids live only in agentStatusByPaneKey,
+      // which is in-memory. Capture them into the persisted sleeping-session
+      // map so a daemon/session death while the app is closed can still
+      // cold-restore via the agent's resume command (#5232).
+      captureSleepingAgentSessions: () =>
+        useAppStore.getState().captureAllSleepingAgentSessions('quit'),
+      // Why: re-read state after capture() calls populated scrollback buffers
+      // into the store via Zustand setters. The shouldCaptureSession read is
+      // only for the gating flags and would miss those updates.
+      buildSessionSnapshots: () => {
+        const freshState = useAppStore.getState()
+        return buildWorkspaceSessionHostSnapshots(
+          buildWorkspaceSessionPayload(freshState),
+          freshState
+        )
+      },
+      buildUiPatch: () => buildActiveViewUnloadPatch(useAppStore.getState()),
+      hasDirtyOpenFiles: () => useAppStore.getState().openFiles.some((file) => file.isDirty),
+      // Why: an app-level quit degrades too — the pre-fix alternative was a quit
+      // the user could only complete with SIGKILL, which loses strictly more (#15352).
+      isDegradableShutdownInProgress: () =>
+        isIntentionalAppRestartInProgress() || isWindowCloseCheckpointInProgress(),
+      stageBeforeUnloadSync: (args) => window.api.app.stageBeforeUnloadSync(args)
+    })
+    const shutdownCheckpoint = createShutdownCheckpointGuard(
+      shutdownCheckpointPersist.run,
+      shutdownCheckpointPersist.reset
     )
     const persistBeforeUnload = createShutdownCheckpointBeforeUnloadHandler(shutdownCheckpoint)
     window.addEventListener('beforeunload', persistBeforeUnload)

--- a/src/renderer/src/app-shell/use-app-session-persistence.ts
+++ b/src/renderer/src/app-shell/use-app-session-persistence.ts
@@ -20,6 +20,7 @@ import {
   createShutdownCheckpointBeforeUnloadHandler,
   createShutdownCheckpointGuard
 } from '../lib/shutdown-checkpoint-guard'
+import { runShutdownCheckpointPersist } from './shutdown-checkpoint-persist'
 import { shutdownBufferCaptures } from '../components/terminal-pane/shutdown-buffer-captures'
 import { dispatchWindowCloseRequest } from '../components/window-close-request-coordinator'
 import {
@@ -117,51 +118,40 @@ export function useAppSessionPersistence(): void {
     // two firings, PTY exit events can arrive and unmount TerminalPanes,
     // emptying shutdownBufferCaptures. The guard prevents the second call
     // from overwriting the good session data with an empty snapshot.
-    const shutdownCheckpoint = createShutdownCheckpointGuard(() => {
-      const shouldCaptureSession = shouldPersistWorkspaceSession(useAppStore.getState())
-      if (shouldCaptureSession) {
-        for (const capture of shutdownBufferCaptures.values()) {
-          try {
-            capture({ includeLocalBuffers: false })
-          } catch {
-            // Don't let one pane's failure block the rest.
+    const shutdownCheckpoint = createShutdownCheckpointGuard(() =>
+      runShutdownCheckpointPersist({
+        shouldCaptureSession: () => shouldPersistWorkspaceSession(useAppStore.getState()),
+        captureTerminalBuffers: () => {
+          for (const capture of shutdownBufferCaptures.values()) {
+            try {
+              capture({ includeLocalBuffers: false })
+            } catch {
+              // Don't let one pane's failure block the rest.
+            }
           }
-        }
+        },
         // Why: agent provider session ids live only in agentStatusByPaneKey,
         // which is in-memory. Capture them into the persisted sleeping-session
         // map so a daemon/session death while the app is closed can still
         // cold-restore via the agent's resume command (#5232).
-        useAppStore.getState().captureAllSleepingAgentSessions('quit')
-      }
-      // Why: re-read state after capture() calls populated scrollback buffers
-      // into the store via Zustand setters. The earlier read is only for the
-      // gating flags and would miss those updates.
-      const freshState = useAppStore.getState()
-      let sessionSnapshots: ReturnType<typeof buildWorkspaceSessionHostSnapshots> = []
-      try {
-        sessionSnapshots = shouldCaptureSession
-          ? buildWorkspaceSessionHostSnapshots(buildWorkspaceSessionPayload(freshState), freshState)
-          : []
-      } catch (error) {
-        // Why: dirty drafts exist only in the full session snapshot.
-        if (
-          !isIntentionalAppRestartInProgress() ||
-          freshState.openFiles.some((file) => file.isDirty)
-        ) {
-          throw error
-        }
-        console.error('[app] Full renderer session snapshot failed; using durable session', error)
-        window.api.app.stageBeforeUnloadSync({
-          sessions: [],
-          ui: buildActiveViewUnloadPatch(freshState)
-        })
-        return
-      }
-      window.api.app.stageBeforeUnloadSync({
-        sessions: sessionSnapshots,
-        ui: buildActiveViewUnloadPatch(freshState)
+        captureSleepingAgentSessions: () =>
+          useAppStore.getState().captureAllSleepingAgentSessions('quit'),
+        // Why: re-read state after capture() calls populated scrollback buffers
+        // into the store via Zustand setters. The shouldCaptureSession read is
+        // only for the gating flags and would miss those updates.
+        buildSessionSnapshots: () => {
+          const freshState = useAppStore.getState()
+          return buildWorkspaceSessionHostSnapshots(
+            buildWorkspaceSessionPayload(freshState),
+            freshState
+          )
+        },
+        buildUiPatch: () => buildActiveViewUnloadPatch(useAppStore.getState()),
+        hasDirtyOpenFiles: () => useAppStore.getState().openFiles.some((file) => file.isDirty),
+        isIntentionalAppRestartInProgress,
+        stageBeforeUnloadSync: (args) => window.api.app.stageBeforeUnloadSync(args)
       })
-    })
+    )
     const persistBeforeUnload = createShutdownCheckpointBeforeUnloadHandler(shutdownCheckpoint)
     window.addEventListener('beforeunload', persistBeforeUnload)
     window.addEventListener(ORCA_APP_RESTART_ABORTED_EVENT, shutdownCheckpoint.reset)

--- a/src/renderer/src/app-startup-routing.test.ts
+++ b/src/renderer/src/app-startup-routing.test.ts
@@ -488,7 +488,7 @@ describe('renderer startup runtime routing', () => {
   it('checkpoints activeView and all session snapshots through one beforeunload handler (#9002)', () => {
     const source = readSource(SESSION_PERSISTENCE_PATH)
     const checkpointStart = source.indexOf(
-      'const shutdownCheckpoint = createShutdownCheckpointGuard('
+      'const shutdownCheckpointPersist = createShutdownCheckpointPersist({'
     )
     const checkpointEnd = source.indexOf(
       'const persistBeforeUnload = createShutdownCheckpointBeforeUnloadHandler(shutdownCheckpoint)',
@@ -498,9 +498,11 @@ describe('renderer startup runtime routing', () => {
     expect(checkpointEnd).toBeGreaterThan(checkpointStart)
     const checkpointBlock = source.slice(checkpointStart, checkpointEnd)
 
-    expect(checkpointBlock).toContain('createShutdownCheckpointPersist({')
     expect(checkpointBlock).toContain(
-      'buildWorkspaceSessionHostSnapshots(\n            buildWorkspaceSessionPayload(freshState),\n            freshState\n          )'
+      'const shutdownCheckpointPersist = createShutdownCheckpointPersist({'
+    )
+    expect(checkpointBlock).toContain(
+      'buildWorkspaceSessionHostSnapshots(\n          buildWorkspaceSessionPayload(freshState),\n          freshState\n        )'
     )
     expect(checkpointBlock).toContain('buildUiPatch: () => buildActiveViewUnloadPatch(')
     // Why pin the exact gate: the degrade tiers must arm only for intentional
@@ -514,6 +516,8 @@ describe('renderer startup runtime routing', () => {
     expect(checkpointBlock).toContain(
       'stageBeforeUnloadSync: (args) => window.api.app.stageBeforeUnloadSync(args)'
     )
+    expect(checkpointBlock).toContain('shutdownCheckpointPersist.run')
+    expect(checkpointBlock).toContain('shutdownCheckpointPersist.reset')
     expect(source).toContain(
       'window.addEventListener(ORCA_APP_RESTART_ABORTED_EVENT, shutdownCheckpoint.reset)'
     )

--- a/src/renderer/src/app-startup-routing.test.ts
+++ b/src/renderer/src/app-startup-routing.test.ts
@@ -498,12 +498,16 @@ describe('renderer startup runtime routing', () => {
     expect(checkpointEnd).toBeGreaterThan(checkpointStart)
     const checkpointBlock = source.slice(checkpointStart, checkpointEnd)
 
-    expect(checkpointBlock).toContain('runShutdownCheckpointPersist({')
+    expect(checkpointBlock).toContain('createShutdownCheckpointPersist({')
     expect(checkpointBlock).toContain(
       'buildWorkspaceSessionHostSnapshots(\n            buildWorkspaceSessionPayload(freshState),\n            freshState\n          )'
     )
     expect(checkpointBlock).toContain('buildUiPatch: () => buildActiveViewUnloadPatch(')
-    expect(checkpointBlock).toContain('isIntentionalAppRestartInProgress')
+    // Why pin the exact gate: the degrade tiers must arm only for intentional
+    // restarts and app-level closes, never for arbitrary unloads.
+    expect(checkpointBlock).toContain(
+      'isIntentionalAppRestartInProgress() || isWindowCloseCheckpointInProgress()'
+    )
     expect(checkpointBlock).toContain(
       'useAppStore.getState().openFiles.some((file) => file.isDirty)'
     )

--- a/src/renderer/src/app-startup-routing.test.ts
+++ b/src/renderer/src/app-startup-routing.test.ts
@@ -498,20 +498,17 @@ describe('renderer startup runtime routing', () => {
     expect(checkpointEnd).toBeGreaterThan(checkpointStart)
     const checkpointBlock = source.slice(checkpointStart, checkpointEnd)
 
+    expect(checkpointBlock).toContain('runShutdownCheckpointPersist({')
     expect(checkpointBlock).toContain(
-      'let sessionSnapshots: ReturnType<typeof buildWorkspaceSessionHostSnapshots> = []'
+      'buildWorkspaceSessionHostSnapshots(\n            buildWorkspaceSessionPayload(freshState),\n            freshState\n          )'
+    )
+    expect(checkpointBlock).toContain('buildUiPatch: () => buildActiveViewUnloadPatch(')
+    expect(checkpointBlock).toContain('isIntentionalAppRestartInProgress')
+    expect(checkpointBlock).toContain(
+      'useAppStore.getState().openFiles.some((file) => file.isDirty)'
     )
     expect(checkpointBlock).toContain(
-      'buildWorkspaceSessionHostSnapshots(buildWorkspaceSessionPayload(freshState), freshState)'
-    )
-    expect(checkpointBlock).toContain('window.api.app.stageBeforeUnloadSync({')
-    expect(checkpointBlock).toContain('sessions: sessionSnapshots')
-    expect(checkpointBlock).toContain('ui: buildActiveViewUnloadPatch(freshState)')
-    expect(checkpointBlock).toContain('!isIntentionalAppRestartInProgress()')
-    expect(checkpointBlock).toContain('freshState.openFiles.some((file) => file.isDirty)')
-    expect(checkpointBlock).toContain('sessions: []')
-    expect(checkpointBlock).toContain(
-      'return\n      }\n      window.api.app.stageBeforeUnloadSync({\n        sessions: sessionSnapshots'
+      'stageBeforeUnloadSync: (args) => window.api.app.stageBeforeUnloadSync(args)'
     )
     expect(source).toContain(
       'window.addEventListener(ORCA_APP_RESTART_ABORTED_EVENT, shutdownCheckpoint.reset)'

--- a/src/renderer/src/app-startup-routing.test.ts
+++ b/src/renderer/src/app-startup-routing.test.ts
@@ -517,12 +517,15 @@ describe('renderer startup runtime routing', () => {
       'stageBeforeUnloadSync: (args) => window.api.app.stageBeforeUnloadSync(args)'
     )
     expect(checkpointBlock).toContain('shutdownCheckpointPersist.run')
-    expect(checkpointBlock).toContain('shutdownCheckpointPersist.reset')
+    expect(checkpointBlock).toContain('shutdownCheckpointPersist.abandonAttempt')
     expect(source).toContain(
-      'window.addEventListener(ORCA_APP_RESTART_ABORTED_EVENT, shutdownCheckpoint.reset)'
+      'window.addEventListener(ORCA_APP_RESTART_ABORTED_EVENT, shutdownCheckpoint.abandonAttempt)'
     )
     expect(source).toContain(
-      'window.addEventListener(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT, shutdownCheckpoint.reset)'
+      'ORCA_RENDERER_SHUTDOWN_CHECKPOINT_ABORTED_EVENT,\n      shutdownCheckpoint.abortAfterCheckpointFailure'
+    )
+    expect(source).toContain(
+      'window.addEventListener(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT, shutdownCheckpoint.abandonAttempt)'
     )
     expect(source).toContain("window.addEventListener('beforeunload', persistBeforeUnload)")
     expect(source.match(/window\.addEventListener\('beforeunload'/g) ?? []).toHaveLength(1)

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -143,7 +143,11 @@ import {
 } from './terminal-pane/terminal-parked-tab-watchers'
 import { isMainTerminalSideEffectAuthorityForPty } from './terminal-pane/terminal-side-effect-facts-handler'
 import { appendUniqueOpenFileIds } from './terminal/unsaved-close-queue'
-import { setWindowCloseRequestHandler } from './window-close-request-coordinator'
+import {
+  runWithWindowCloseCheckpointScope,
+  setWindowCloseRequestHandler
+} from './window-close-request-coordinator'
+import { consumeShutdownCheckpointFailureReason } from '../../../shared/renderer-shutdown-events'
 import {
   findActivityTerminalPortal,
   useActivityTerminalPortals,
@@ -526,8 +530,17 @@ function Terminal(): React.JSX.Element | null {
   const confirmNativeWindowClose = useCallback(() => {
     // Why: capture only after every close guard has committed. A canceled child-
     // process prompt must not consume App's synthetic/native unload guard.
-    const accepted = window.dispatchEvent(new Event('beforeunload', { cancelable: true }))
+    const accepted = runWithWindowCloseCheckpointScope(() =>
+      window.dispatchEvent(new Event('beforeunload', { cancelable: true }))
+    )
     if (!accepted) {
+      // Why: a checkpoint-vetoed quit used to die here with no dialog and no log,
+      // leaving SIGKILL as the only exit (#15352). The dirty-file veto publishes
+      // no reason — its deferred dialog flow already gives the user a surface.
+      const reason = consumeShutdownCheckpointFailureReason()
+      if (reason) {
+        toast.error(`Quit canceled: the session snapshot could not be saved (${reason}).`)
+      }
       return
     }
     window.api.ui.confirmWindowClose()

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -539,7 +539,13 @@ function Terminal(): React.JSX.Element | null {
       // no reason — its deferred dialog flow already gives the user a surface.
       const reason = consumeShutdownCheckpointFailureReason()
       if (reason) {
-        toast.error(`Quit canceled: the session snapshot could not be saved (${reason}).`)
+        toast.error(
+          translate(
+            'auto.components.Terminal.quitSnapshotSaveFailed',
+            'Quit canceled: the session snapshot could not be saved ({{value0}}).',
+            { value0: reason }
+          )
+        )
       }
       return
     }

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -147,7 +147,7 @@ import {
   runWithWindowCloseCheckpointScope,
   setWindowCloseRequestHandler
 } from './window-close-request-coordinator'
-import { consumeShutdownCheckpointFailureReason } from '../../../shared/renderer-shutdown-events'
+import { showShutdownCheckpointFailureToast } from '@/lib/shutdown-checkpoint-failure-toast'
 import {
   findActivityTerminalPortal,
   useActivityTerminalPortals,
@@ -537,16 +537,7 @@ function Terminal(): React.JSX.Element | null {
       // Why: a checkpoint-vetoed quit used to die here with no dialog and no log,
       // leaving SIGKILL as the only exit (#15352). The dirty-file veto publishes
       // no reason — its deferred dialog flow already gives the user a surface.
-      const reason = consumeShutdownCheckpointFailureReason()
-      if (reason) {
-        toast.error(
-          translate(
-            'auto.components.Terminal.quitSnapshotSaveFailed',
-            'Quit canceled: the session snapshot could not be saved ({{value0}}).',
-            { value0: reason }
-          )
-        )
-      }
+      showShutdownCheckpointFailureToast()
       return
     }
     window.api.ui.confirmWindowClose()

--- a/src/renderer/src/components/window-close-request-coordinator.test.ts
+++ b/src/renderer/src/components/window-close-request-coordinator.test.ts
@@ -6,6 +6,10 @@ import {
   publishShutdownCheckpointFailureReason
 } from '../../../shared/renderer-shutdown-events'
 import {
+  createShutdownCheckpointBeforeUnloadHandler,
+  createShutdownCheckpointGuard
+} from '../lib/shutdown-checkpoint-guard'
+import {
   dispatchWindowCloseRequest,
   getWindowCloseRequestHandler,
   isWindowCloseCheckpointInProgress,
@@ -99,6 +103,25 @@ describe('window-close-request-coordinator', () => {
       'Quit canceled: the session snapshot could not be saved (sendSync payload rejected).'
     )
     expect(consumeShutdownCheckpointFailureReason()).toBeNull()
+  })
+
+  it('shows a fallback reason when a Terminal-less checkpoint throws an empty Error', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const error = new Error('placeholder')
+    error.message = ''
+    const guard = createShutdownCheckpointGuard(() => {
+      throw error
+    })
+    window.addEventListener('beforeunload', createShutdownCheckpointBeforeUnloadHandler(guard), {
+      once: true
+    })
+
+    await dispatchWindowCloseRequest({ isQuitting: true })
+
+    expect(confirmWindowClose).not.toHaveBeenCalled()
+    expect(toast.error).toHaveBeenCalledWith(
+      'Quit canceled: the session snapshot could not be saved (Unknown shutdown checkpoint failure).'
+    )
   })
 
   it('delegates to the rich handler and does NOT confirm directly when one is registered', async () => {

--- a/src/renderer/src/components/window-close-request-coordinator.test.ts
+++ b/src/renderer/src/components/window-close-request-coordinator.test.ts
@@ -1,4 +1,10 @@
+// @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { toast } from 'sonner'
+import {
+  consumeShutdownCheckpointFailureReason,
+  publishShutdownCheckpointFailureReason
+} from '../../../shared/renderer-shutdown-events'
 import {
   dispatchWindowCloseRequest,
   getWindowCloseRequestHandler,
@@ -7,6 +13,8 @@ import {
   runWithWindowCloseCheckpointScope,
   setWindowCloseRequestHandler
 } from './window-close-request-coordinator'
+
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }))
 
 describe('window-close-request-coordinator', () => {
   const confirmWindowClose = vi.fn()
@@ -18,6 +26,7 @@ describe('window-close-request-coordinator', () => {
 
   beforeEach(() => {
     confirmWindowClose.mockClear()
+    vi.mocked(toast.error).mockClear()
     // Why: dispatch falls back to the preload bridge when no rich handler is
     // registered; stub just the surface it touches.
     const windowTarget = new EventTarget() as EventTarget & {
@@ -30,6 +39,7 @@ describe('window-close-request-coordinator', () => {
   afterEach(() => {
     setWindowCloseRequestHandler(null)
     unregisterFns.splice(0).forEach((fn) => fn())
+    consumeShutdownCheckpointFailureReason()
   })
 
   it('has no handler by default, so the App root falls back to confirming the close', () => {
@@ -68,7 +78,27 @@ describe('window-close-request-coordinator', () => {
 
     expect(beforeUnload).toHaveBeenCalledTimes(1)
     expect(confirmWindowClose).not.toHaveBeenCalled()
+    expect(toast.error).not.toHaveBeenCalled()
     expect(isWindowCloseCheckpointInProgress()).toBe(false)
+  })
+
+  it('surfaces the checkpoint failure reason when the Terminal-less close is vetoed', async () => {
+    window.addEventListener(
+      'beforeunload',
+      (event) => {
+        publishShutdownCheckpointFailureReason('sendSync payload rejected')
+        event.preventDefault()
+      },
+      { once: true }
+    )
+
+    await dispatchWindowCloseRequest({ isQuitting: true })
+
+    expect(confirmWindowClose).not.toHaveBeenCalled()
+    expect(toast.error).toHaveBeenCalledWith(
+      'Quit canceled: the session snapshot could not be saved (sendSync payload rejected).'
+    )
+    expect(consumeShutdownCheckpointFailureReason()).toBeNull()
   })
 
   it('delegates to the rich handler and does NOT confirm directly when one is registered', async () => {
@@ -93,6 +123,7 @@ describe('window-close-request-coordinator', () => {
 
     expect(confirmWindowClose).not.toHaveBeenCalled()
     expect(handler).not.toHaveBeenCalled()
+    expect(toast.error).not.toHaveBeenCalled()
   })
 
   it('proceeds to confirm when all guards allow the close', async () => {

--- a/src/renderer/src/components/window-close-request-coordinator.test.ts
+++ b/src/renderer/src/components/window-close-request-coordinator.test.ts
@@ -2,7 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   dispatchWindowCloseRequest,
   getWindowCloseRequestHandler,
+  isWindowCloseCheckpointInProgress,
   registerWindowCloseGuard,
+  runWithWindowCloseCheckpointScope,
   setWindowCloseRequestHandler
 } from './window-close-request-coordinator'
 
@@ -126,5 +128,21 @@ describe('window-close-request-coordinator', () => {
 
     expect(guard).not.toHaveBeenCalled()
     expect(confirmWindowClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('scopes the window-close checkpoint flag to the wrapped dispatch (STA-5505)', () => {
+    expect(isWindowCloseCheckpointInProgress()).toBe(false)
+    const seen = runWithWindowCloseCheckpointScope(() => isWindowCloseCheckpointInProgress())
+    expect(seen).toBe(true)
+    expect(isWindowCloseCheckpointInProgress()).toBe(false)
+  })
+
+  it('clears the window-close checkpoint flag when the wrapped dispatch throws', () => {
+    expect(() =>
+      runWithWindowCloseCheckpointScope(() => {
+        throw new Error('listener exploded')
+      })
+    ).toThrow('listener exploded')
+    expect(isWindowCloseCheckpointInProgress()).toBe(false)
   })
 })

--- a/src/renderer/src/components/window-close-request-coordinator.test.ts
+++ b/src/renderer/src/components/window-close-request-coordinator.test.ts
@@ -20,9 +20,11 @@ describe('window-close-request-coordinator', () => {
     confirmWindowClose.mockClear()
     // Why: dispatch falls back to the preload bridge when no rich handler is
     // registered; stub just the surface it touches.
-    ;(
-      globalThis as unknown as { window: { api: { ui: { confirmWindowClose: () => void } } } }
-    ).window = { api: { ui: { confirmWindowClose } } }
+    const windowTarget = new EventTarget() as EventTarget & {
+      api: { ui: { confirmWindowClose: () => void } }
+    }
+    windowTarget.api = { ui: { confirmWindowClose } }
+    ;(globalThis as unknown as { window: typeof windowTarget }).window = windowTarget
   })
 
   afterEach(() => {
@@ -53,6 +55,20 @@ describe('window-close-request-coordinator', () => {
     await dispatchWindowCloseRequest({ isQuitting: true })
 
     expect(confirmWindowClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs the Terminal-less close checkpoint in the degradable close scope', async () => {
+    const beforeUnload = vi.fn((event: Event) => {
+      expect(isWindowCloseCheckpointInProgress()).toBe(true)
+      event.preventDefault()
+    })
+    window.addEventListener('beforeunload', beforeUnload, { once: true })
+
+    await dispatchWindowCloseRequest({ isQuitting: true })
+
+    expect(beforeUnload).toHaveBeenCalledTimes(1)
+    expect(confirmWindowClose).not.toHaveBeenCalled()
+    expect(isWindowCloseCheckpointInProgress()).toBe(false)
   })
 
   it('delegates to the rich handler and does NOT confirm directly when one is registered', async () => {

--- a/src/renderer/src/components/window-close-request-coordinator.ts
+++ b/src/renderer/src/components/window-close-request-coordinator.ts
@@ -86,5 +86,10 @@ export async function dispatchWindowCloseRequest(data: { isQuitting: boolean }):
     activeHandler(data)
     return
   }
-  window.api.ui.confirmWindowClose()
+  const accepted = runWithWindowCloseCheckpointScope(() =>
+    window.dispatchEvent(new Event('beforeunload', { cancelable: true }))
+  )
+  if (accepted) {
+    window.api.ui.confirmWindowClose()
+  }
 }

--- a/src/renderer/src/components/window-close-request-coordinator.ts
+++ b/src/renderer/src/components/window-close-request-coordinator.ts
@@ -9,6 +9,8 @@
 // Git AI Author prompt editors) register a guard so quitting prompts the user to
 // save/discard instead of being silently vetoed by a beforeunload handler.
 
+import { showShutdownCheckpointFailureToast } from '@/lib/shutdown-checkpoint-failure-toast'
+
 export type WindowCloseRequestHandler = (data: { isQuitting: boolean }) => void
 
 /** Returns true to allow the close to proceed, false to cancel it (e.g. the user
@@ -91,5 +93,7 @@ export async function dispatchWindowCloseRequest(data: { isQuitting: boolean }):
   )
   if (accepted) {
     window.api.ui.confirmWindowClose()
+    return
   }
+  showShutdownCheckpointFailureToast()
 }

--- a/src/renderer/src/components/window-close-request-coordinator.ts
+++ b/src/renderer/src/components/window-close-request-coordinator.ts
@@ -16,6 +16,23 @@ export type WindowCloseRequestHandler = (data: { isQuitting: boolean }) => void
 export type WindowCloseGuard = () => boolean | Promise<boolean>
 
 let activeHandler: WindowCloseRequestHandler | null = null
+// Why: lets the shutdown checkpoint tell an app-level quit/close (durable-session
+// degradation is acceptable — the alternative is a quit the user can only complete
+// with SIGKILL, #15352) from an arbitrary unload, where it must stay strict.
+let windowCloseCheckpointInProgress = false
+
+export function isWindowCloseCheckpointInProgress(): boolean {
+  return windowCloseCheckpointInProgress
+}
+
+export function runWithWindowCloseCheckpointScope<T>(fn: () => T): T {
+  windowCloseCheckpointInProgress = true
+  try {
+    return fn()
+  } finally {
+    windowCloseCheckpointInProgress = false
+  }
+}
 const closeGuards = new Set<WindowCloseGuard>()
 // Why: a guard can await a dialog; ignore re-entrant close requests (main resends
 // 'window:close-requested' on each attempt) so we don't stack duplicate prompts.

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2099,7 +2099,8 @@
         "61ed600d29": "\"{{value0}}\" has unsaved changes. Do you want to save before closing?",
         "cdc9ac4b2d": "editor",
         "e57db40c11": "Could not build launch command for {{value0}}.",
-        "5b2c1a9e44": "No agent CLI detected — install one or pick a default agent in Settings."
+        "5b2c1a9e44": "No agent CLI detected — install one or pick a default agent in Settings.",
+        "quitSnapshotSaveFailed": "Quit canceled: the session snapshot could not be saved ({{value0}})."
       },
       "TerminalSearch": {
         "db234b7519": "Close",

--- a/src/renderer/src/lib/shutdown-checkpoint-failure-toast.ts
+++ b/src/renderer/src/lib/shutdown-checkpoint-failure-toast.ts
@@ -1,0 +1,17 @@
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
+import { consumeShutdownCheckpointFailureReason } from '../../../shared/renderer-shutdown-events'
+
+export function showShutdownCheckpointFailureToast(): void {
+  const reason = consumeShutdownCheckpointFailureReason()
+  if (!reason) {
+    return
+  }
+  toast.error(
+    translate(
+      'auto.components.Terminal.quitSnapshotSaveFailed',
+      'Quit canceled: the session snapshot could not be saved ({{value0}}).',
+      { value0: reason }
+    )
+  )
+}

--- a/src/renderer/src/lib/shutdown-checkpoint-guard.test.ts
+++ b/src/renderer/src/lib/shutdown-checkpoint-guard.test.ts
@@ -84,6 +84,25 @@ describe('createShutdownCheckpointGuard', () => {
     expect(consumeShutdownCheckpointFailureReason()).toBeNull()
   })
 
+  it('keeps failure reporting non-throwing for unstringifiable thrown values', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const guard = createShutdownCheckpointGuard(() => {
+      throw Object.create(null)
+    })
+
+    expect(guard.persistOnce()).toBe(false)
+    expect(consumeShutdownCheckpointFailureReason()).toBe('Unknown shutdown checkpoint failure')
+  })
+
+  it('resets state owned by the persist attempt lifecycle', () => {
+    const resetPersistAttempt = vi.fn()
+    const guard = createShutdownCheckpointGuard(vi.fn(), resetPersistAttempt)
+
+    guard.reset()
+
+    expect(resetPersistAttempt).toHaveBeenCalledTimes(1)
+  })
+
   it('reports checkpoint failure separately from the unload verdict', () => {
     const eventTarget = new EventTarget()
     const failed = vi.fn()

--- a/src/renderer/src/lib/shutdown-checkpoint-guard.test.ts
+++ b/src/renderer/src/lib/shutdown-checkpoint-guard.test.ts
@@ -35,7 +35,7 @@ describe('createShutdownCheckpointGuard', () => {
     const guard = createShutdownCheckpointGuard(persist)
 
     expect(guard.persistOnce()).toBe(true)
-    guard.reset()
+    guard.abandonAttempt()
     expect(guard.persistOnce()).toBe(true)
 
     expect(persist).toHaveBeenCalledTimes(2)
@@ -95,12 +95,21 @@ describe('createShutdownCheckpointGuard', () => {
   })
 
   it('resets state owned by the persist attempt lifecycle', () => {
-    const resetPersistAttempt = vi.fn()
-    const guard = createShutdownCheckpointGuard(vi.fn(), resetPersistAttempt)
+    const abandonPersistAttempt = vi.fn()
+    const guard = createShutdownCheckpointGuard(vi.fn(), abandonPersistAttempt)
 
-    guard.reset()
+    guard.abandonAttempt()
 
-    expect(resetPersistAttempt).toHaveBeenCalledTimes(1)
+    expect(abandonPersistAttempt).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves persist retry state when the checkpoint itself aborts the restart', () => {
+    const abandonPersistAttempt = vi.fn()
+    const guard = createShutdownCheckpointGuard(vi.fn(), abandonPersistAttempt)
+
+    guard.abortAfterCheckpointFailure()
+
+    expect(abandonPersistAttempt).not.toHaveBeenCalled()
   })
 
   it('reports checkpoint failure separately from the unload verdict', () => {
@@ -126,7 +135,7 @@ describe('createShutdownCheckpointGuard', () => {
     eventTarget.addEventListener('beforeunload', preventReload)
 
     expect(eventTarget.dispatchEvent(new Event('beforeunload', { cancelable: true }))).toBe(false)
-    guard.reset()
+    guard.abandonAttempt()
     eventTarget.removeEventListener('beforeunload', preventReload)
     expect(eventTarget.dispatchEvent(new Event('beforeunload', { cancelable: true }))).toBe(true)
 
@@ -157,7 +166,7 @@ describe('createShutdownCheckpointGuard', () => {
     }
     eventTarget.addEventListener('beforeunload', preventReload)
     eventTarget.addEventListener('beforeunload', createShutdownCheckpointBeforeUnloadHandler(guard))
-    eventTarget.addEventListener(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT, guard.reset)
+    eventTarget.addEventListener(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT, guard.abandonAttempt)
 
     expect(eventTarget.dispatchEvent(new Event('beforeunload', { cancelable: true }))).toBe(false)
     await Promise.resolve()
@@ -180,8 +189,7 @@ describe('createShutdownCheckpointGuard', () => {
     // Why pin: without the scope, a persist failure blocks quit with no degradable
     // tier; without the toast, the vetoed quit is silent and SIGKILL-only (#15352).
     expect(closeBlock).toContain('runWithWindowCloseCheckpointScope(() =>')
-    expect(closeBlock).toContain('consumeShutdownCheckpointFailureReason()')
-    expect(closeBlock).toContain('toast.error(')
+    expect(closeBlock).toContain('showShutdownCheckpointFailureToast()')
   })
 
   it('wires dirty editor unload vetoes to the paired-web checkpoint reset', () => {

--- a/src/renderer/src/lib/shutdown-checkpoint-guard.test.ts
+++ b/src/renderer/src/lib/shutdown-checkpoint-guard.test.ts
@@ -148,6 +148,23 @@ describe('createShutdownCheckpointGuard', () => {
     expect(persist).toHaveBeenCalledTimes(2)
   })
 
+  it('runs the quit checkpoint inside the window-close scope and surfaces a vetoed quit (STA-5505/#15352)', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/renderer/src/components/Terminal.tsx'),
+      'utf8'
+    )
+    const closeStart = source.indexOf('const confirmNativeWindowClose = useCallback(() => {')
+    const closeEnd = source.indexOf('window.api.ui.confirmWindowClose()', closeStart)
+    expect(closeStart).toBeGreaterThanOrEqual(0)
+    expect(closeEnd).toBeGreaterThan(closeStart)
+    const closeBlock = source.slice(closeStart, closeEnd)
+    // Why pin: without the scope, a persist failure blocks quit with no degradable
+    // tier; without the toast, the vetoed quit is silent and SIGKILL-only (#15352).
+    expect(closeBlock).toContain('runWithWindowCloseCheckpointScope(() =>')
+    expect(closeBlock).toContain('consumeShutdownCheckpointFailureReason()')
+    expect(closeBlock).toContain('toast.error(')
+  })
+
   it('wires dirty editor unload vetoes to the paired-web checkpoint reset', () => {
     const source = readFileSync(
       join(process.cwd(), 'src/renderer/src/components/Terminal.tsx'),

--- a/src/renderer/src/lib/shutdown-checkpoint-guard.test.ts
+++ b/src/renderer/src/lib/shutdown-checkpoint-guard.test.ts
@@ -1,17 +1,25 @@
+// @vitest-environment happy-dom
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   createShutdownCheckpointBeforeUnloadHandler,
   createShutdownCheckpointGuard,
   preventUnloadAndScheduleShutdownCheckpointReset
 } from './shutdown-checkpoint-guard'
 import {
+  consumeShutdownCheckpointFailureReason,
   ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT,
   ORCA_RENDERER_UNLOAD_PREVENTED_EVENT
 } from '../../../shared/renderer-shutdown-events'
 
 describe('createShutdownCheckpointGuard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    delete (window as unknown as { api?: unknown }).api
+    consumeShutdownCheckpointFailureReason()
+  })
+
   it('dedupes the synthetic and native unload events in one close attempt', () => {
     const persist = vi.fn()
     const guard = createShutdownCheckpointGuard(persist)
@@ -43,6 +51,37 @@ describe('createShutdownCheckpointGuard', () => {
     expect(guard.persistOnce()).toBe(true)
 
     expect(persist).toHaveBeenCalledTimes(2)
+  })
+
+  it('publishes the failure cause and records a crash breadcrumb (STA-5505)', () => {
+    const recordBreadcrumb = vi.fn()
+    ;(window as unknown as { api: unknown }).api = { crashReports: { recordBreadcrumb } }
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const guard = createShutdownCheckpointGuard(() => {
+      throw new Error('sendSync payload rejected')
+    })
+
+    expect(guard.persistOnce()).toBe(false)
+
+    expect(consumeShutdownCheckpointFailureReason()).toBe('sendSync payload rejected')
+    expect(recordBreadcrumb).toHaveBeenCalledWith({
+      name: 'renderer_shutdown_checkpoint_failed',
+      data: { message: 'sendSync payload rejected' }
+    })
+  })
+
+  it('clears a stale failure cause once a later checkpoint succeeds (STA-5505)', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const guard = createShutdownCheckpointGuard(
+      vi.fn().mockImplementationOnce(() => {
+        throw new Error('disk full')
+      })
+    )
+
+    expect(guard.persistOnce()).toBe(false)
+    expect(guard.persistOnce()).toBe(true)
+
+    expect(consumeShutdownCheckpointFailureReason()).toBeNull()
   })
 
   it('reports checkpoint failure separately from the unload verdict', () => {

--- a/src/renderer/src/lib/shutdown-checkpoint-guard.test.ts
+++ b/src/renderer/src/lib/shutdown-checkpoint-guard.test.ts
@@ -94,6 +94,18 @@ describe('createShutdownCheckpointGuard', () => {
     expect(consumeShutdownCheckpointFailureReason()).toBe('Unknown shutdown checkpoint failure')
   })
 
+  it('uses a fallback reason when an Error has an empty message', () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    const error = new Error('placeholder')
+    error.message = ''
+    const guard = createShutdownCheckpointGuard(() => {
+      throw error
+    })
+
+    expect(guard.persistOnce()).toBe(false)
+    expect(consumeShutdownCheckpointFailureReason()).toBe('Unknown shutdown checkpoint failure')
+  })
+
   it('resets state owned by the persist attempt lifecycle', () => {
     const abandonPersistAttempt = vi.fn()
     const guard = createShutdownCheckpointGuard(vi.fn(), abandonPersistAttempt)

--- a/src/renderer/src/lib/shutdown-checkpoint-guard.ts
+++ b/src/renderer/src/lib/shutdown-checkpoint-guard.ts
@@ -1,5 +1,6 @@
 import {
   clearShutdownCheckpointFailureReason,
+  formatShutdownCheckpointFailureReason,
   ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT,
   ORCA_RENDERER_UNLOAD_PREVENTED_EVENT,
   publishShutdownCheckpointFailureReason
@@ -15,12 +16,15 @@ export type ShutdownCheckpointGuard = {
 // build behind an error that names the symptom while the cause is swallowed (STA-5505).
 function reportShutdownCheckpointFailure(error: unknown): void {
   console.error('[app] Shutdown checkpoint persist failed:', error)
-  const message = error instanceof Error ? error.message : String(error)
+  const message = formatShutdownCheckpointFailureReason(error)
   publishShutdownCheckpointFailureReason(message)
   recordRendererCrashBreadcrumb('renderer_shutdown_checkpoint_failed', { message })
 }
 
-export function createShutdownCheckpointGuard(persist: () => void): ShutdownCheckpointGuard {
+export function createShutdownCheckpointGuard(
+  persist: () => void,
+  resetPersistAttempt?: () => void
+): ShutdownCheckpointGuard {
   let persisted = false
   return {
     persistOnce(): boolean {
@@ -41,6 +45,7 @@ export function createShutdownCheckpointGuard(persist: () => void): ShutdownChec
     },
     reset(): void {
       persisted = false
+      resetPersistAttempt?.()
     }
   }
 }

--- a/src/renderer/src/lib/shutdown-checkpoint-guard.ts
+++ b/src/renderer/src/lib/shutdown-checkpoint-guard.ts
@@ -9,7 +9,8 @@ import { recordRendererCrashBreadcrumb } from './crash-breadcrumb-recorder'
 
 export type ShutdownCheckpointGuard = {
   persistOnce: () => boolean
-  reset: () => void
+  abortAfterCheckpointFailure: () => void
+  abandonAttempt: () => void
 }
 
 // Why: without this, a reproducible checkpoint failure strands the user on an old
@@ -23,7 +24,7 @@ function reportShutdownCheckpointFailure(error: unknown): void {
 
 export function createShutdownCheckpointGuard(
   persist: () => void,
-  resetPersistAttempt?: () => void
+  abandonPersistAttempt?: () => void
 ): ShutdownCheckpointGuard {
   let persisted = false
   return {
@@ -43,9 +44,12 @@ export function createShutdownCheckpointGuard(
       clearShutdownCheckpointFailureReason()
       return true
     },
-    reset(): void {
+    abortAfterCheckpointFailure(): void {
       persisted = false
-      resetPersistAttempt?.()
+    },
+    abandonAttempt(): void {
+      persisted = false
+      abandonPersistAttempt?.()
     }
   }
 }

--- a/src/renderer/src/lib/shutdown-checkpoint-guard.ts
+++ b/src/renderer/src/lib/shutdown-checkpoint-guard.ts
@@ -1,11 +1,23 @@
 import {
+  clearShutdownCheckpointFailureReason,
   ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT,
-  ORCA_RENDERER_UNLOAD_PREVENTED_EVENT
+  ORCA_RENDERER_UNLOAD_PREVENTED_EVENT,
+  publishShutdownCheckpointFailureReason
 } from '../../../shared/renderer-shutdown-events'
+import { recordRendererCrashBreadcrumb } from './crash-breadcrumb-recorder'
 
 export type ShutdownCheckpointGuard = {
   persistOnce: () => boolean
   reset: () => void
+}
+
+// Why: without this, a reproducible checkpoint failure strands the user on an old
+// build behind an error that names the symptom while the cause is swallowed (STA-5505).
+function reportShutdownCheckpointFailure(error: unknown): void {
+  console.error('[app] Shutdown checkpoint persist failed:', error)
+  const message = error instanceof Error ? error.message : String(error)
+  publishShutdownCheckpointFailureReason(message)
+  recordRendererCrashBreadcrumb('renderer_shutdown_checkpoint_failed', { message })
 }
 
 export function createShutdownCheckpointGuard(persist: () => void): ShutdownCheckpointGuard {
@@ -17,12 +29,14 @@ export function createShutdownCheckpointGuard(persist: () => void): ShutdownChec
       }
       try {
         persist()
-      } catch {
+      } catch (error) {
         // Why: browser event targets swallow listener exceptions. Returning a
         // failure lets the caller cancel unload and keep this attempt retryable.
+        reportShutdownCheckpointFailure(error)
         return false
       }
       persisted = true
+      clearShutdownCheckpointFailureReason()
       return true
     },
     reset(): void {

--- a/src/renderer/src/lib/updater-beforeunload.test.ts
+++ b/src/renderer/src/lib/updater-beforeunload.test.ts
@@ -10,6 +10,7 @@ import {
   ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT,
   ORCA_UPDATER_QUIT_AND_INSTALL_STARTED_EVENT
 } from '../../../shared/updater-renderer-events'
+import { ORCA_RENDERER_SHUTDOWN_CHECKPOINT_ABORTED_EVENT } from '../../../shared/renderer-shutdown-events'
 
 type WindowEventStub = Pick<Window, 'addEventListener' | 'removeEventListener' | 'dispatchEvent'>
 
@@ -53,6 +54,16 @@ describe('registerUpdaterBeforeUnloadBypass', () => {
     window.dispatchEvent(new Event(ORCA_APP_RESTART_ABORTED_EVENT))
     expect(isIntentionalAppRestartInProgress()).toBe(false)
 
+    cleanup()
+  })
+
+  it('ends restart progress when the shutdown checkpoint aborts preparation', () => {
+    const cleanup = registerUpdaterBeforeUnloadBypass()
+
+    window.dispatchEvent(new Event(ORCA_APP_RESTART_STARTED_EVENT))
+    window.dispatchEvent(new Event(ORCA_RENDERER_SHUTDOWN_CHECKPOINT_ABORTED_EVENT))
+
+    expect(isIntentionalAppRestartInProgress()).toBe(false)
     cleanup()
   })
 

--- a/src/renderer/src/lib/updater-beforeunload.ts
+++ b/src/renderer/src/lib/updater-beforeunload.ts
@@ -4,6 +4,7 @@ import {
   ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT,
   ORCA_UPDATER_QUIT_AND_INSTALL_STARTED_EVENT
 } from '../../../shared/updater-renderer-events'
+import { ORCA_RENDERER_SHUTDOWN_CHECKPOINT_ABORTED_EVENT } from '../../../shared/renderer-shutdown-events'
 
 let intentionalAppRestartInProgress = false
 
@@ -27,12 +28,14 @@ export function registerUpdaterBeforeUnloadBypass(): () => void {
   window.addEventListener(ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT, clearInProgress)
   window.addEventListener(ORCA_APP_RESTART_STARTED_EVENT, markInProgress)
   window.addEventListener(ORCA_APP_RESTART_ABORTED_EVENT, clearInProgress)
+  window.addEventListener(ORCA_RENDERER_SHUTDOWN_CHECKPOINT_ABORTED_EVENT, clearInProgress)
 
   return () => {
     window.removeEventListener(ORCA_UPDATER_QUIT_AND_INSTALL_STARTED_EVENT, markInProgress)
     window.removeEventListener(ORCA_UPDATER_QUIT_AND_INSTALL_ABORTED_EVENT, clearInProgress)
     window.removeEventListener(ORCA_APP_RESTART_STARTED_EVENT, markInProgress)
     window.removeEventListener(ORCA_APP_RESTART_ABORTED_EVENT, clearInProgress)
+    window.removeEventListener(ORCA_RENDERER_SHUTDOWN_CHECKPOINT_ABORTED_EVENT, clearInProgress)
     // Why: hot reloads can re-register this listener inside the same renderer.
     // Reset the module flag on cleanup so a failed earlier restart attempt
     // cannot silently suppress future unsaved-change prompts.

--- a/src/shared/renderer-restart-preparation.test.ts
+++ b/src/shared/renderer-restart-preparation.test.ts
@@ -1,6 +1,10 @@
+// @vitest-environment happy-dom
 import { describe, expect, it, vi } from 'vitest'
 import type { UpdateStatus } from './update-status-types'
-import { ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT } from './renderer-shutdown-events'
+import {
+  ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT,
+  publishShutdownCheckpointFailureReason
+} from './renderer-shutdown-events'
 import {
   createUpdaterQuitAbortRelay,
   prepareRendererForAppRestart
@@ -30,6 +34,24 @@ describe('prepareRendererForAppRestart', () => {
     expect(started).toHaveBeenCalledTimes(1)
     expect(checkpoint).toHaveBeenCalledTimes(1)
     expect(aborted).toHaveBeenCalledTimes(1)
+  })
+
+  it('names the published failure cause in the thrown checkpoint error (STA-5505)', async () => {
+    const eventTarget = new EventTarget()
+    eventTarget.addEventListener('beforeunload', (event) => {
+      // Mirrors the checkpoint guard: publish the cause, then fail the checkpoint.
+      publishShutdownCheckpointFailureReason('sendSync payload rejected')
+      event.currentTarget?.dispatchEvent(new Event(ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT))
+      event.preventDefault()
+    })
+
+    await expect(
+      prepareRendererForAppRestart(eventTarget, {
+        startedEventName: 'restart-started',
+        abortedEventName: 'restart-aborted',
+        awaitCheckpoint: () => Promise.resolve()
+      })
+    ).rejects.toThrow('Renderer shutdown checkpoint was not completed: sendSync payload rejected')
   })
 
   it('does not mistake an unrelated unload veto for checkpoint failure', async () => {

--- a/src/shared/renderer-restart-preparation.test.ts
+++ b/src/shared/renderer-restart-preparation.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { UpdateStatus } from './update-status-types'
 import {
+  ORCA_RENDERER_SHUTDOWN_CHECKPOINT_ABORTED_EVENT,
   ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT,
   publishShutdownCheckpointFailureReason
 } from './renderer-shutdown-events'
@@ -15,12 +16,14 @@ describe('prepareRendererForAppRestart', () => {
     const eventTarget = new EventTarget()
     const started = vi.fn()
     const aborted = vi.fn()
+    const independentlyAborted = vi.fn()
     const checkpoint = vi.fn((event: Event) => {
       event.currentTarget?.dispatchEvent(new Event(ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT))
       event.preventDefault()
     })
     eventTarget.addEventListener('restart-started', started)
-    eventTarget.addEventListener('restart-aborted', aborted)
+    eventTarget.addEventListener(ORCA_RENDERER_SHUTDOWN_CHECKPOINT_ABORTED_EVENT, aborted)
+    eventTarget.addEventListener('restart-aborted', independentlyAborted)
     eventTarget.addEventListener('beforeunload', checkpoint)
 
     await expect(
@@ -34,6 +37,7 @@ describe('prepareRendererForAppRestart', () => {
     expect(started).toHaveBeenCalledTimes(1)
     expect(checkpoint).toHaveBeenCalledTimes(1)
     expect(aborted).toHaveBeenCalledTimes(1)
+    expect(independentlyAborted).not.toHaveBeenCalled()
   })
 
   it('names the published failure cause in the thrown checkpoint error (STA-5505)', async () => {

--- a/src/shared/renderer-restart-preparation.ts
+++ b/src/shared/renderer-restart-preparation.ts
@@ -2,7 +2,10 @@ import {
   ORCA_EDITOR_PREPARE_HOT_EXIT_EVENT,
   type EditorPrepareHotExitDetail
 } from './editor-save-events'
-import { ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT } from './renderer-shutdown-events'
+import {
+  consumeShutdownCheckpointFailureReason,
+  ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT
+} from './renderer-shutdown-events'
 import type { UpdateStatus } from './update-status-types'
 
 export type AppRestartPrepOptions = {
@@ -63,7 +66,14 @@ export async function prepareRendererForAppRestart(
       )
     }
     if (checkpointFailed) {
-      throw new Error('Renderer shutdown checkpoint was not completed.')
+      // Why: the guard publishes the swallowed persist error out-of-band; naming it
+      // here is the only way the update-error dialog can say what actually failed.
+      const reason = consumeShutdownCheckpointFailureReason()
+      throw new Error(
+        reason
+          ? `Renderer shutdown checkpoint was not completed: ${reason}`
+          : 'Renderer shutdown checkpoint was not completed.'
+      )
     }
     // Why: the checkpoint only stages synchronously. Navigating before that
     // write lands loses the session snapshot to a crash or power loss.

--- a/src/shared/renderer-restart-preparation.ts
+++ b/src/shared/renderer-restart-preparation.ts
@@ -4,6 +4,7 @@ import {
 } from './editor-save-events'
 import {
   consumeShutdownCheckpointFailureReason,
+  ORCA_RENDERER_SHUTDOWN_CHECKPOINT_ABORTED_EVENT,
   ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT
 } from './renderer-shutdown-events'
 import type { UpdateStatus } from './update-status-types'
@@ -45,10 +46,10 @@ export async function prepareRendererForAppRestart(
   { startedEventName, abortedEventName, awaitCheckpoint }: AppRestartPrepOptions
 ): Promise<void> {
   eventTarget.dispatchEvent(new Event(startedEventName))
+  let checkpointFailed = false
 
   try {
     await requestEditorHotExitBackup(eventTarget)
-    let checkpointFailed = false
     const markCheckpointFailed = (): void => {
       checkpointFailed = true
     }
@@ -79,7 +80,13 @@ export async function prepareRendererForAppRestart(
     // write lands loses the session snapshot to a crash or power loss.
     await awaitCheckpoint()
   } catch (error) {
-    eventTarget.dispatchEvent(new Event(abortedEventName))
+    // A checkpoint failure ends the current restart without abandoning the
+    // retry-then-degrade budget that the next user attempt must consume.
+    eventTarget.dispatchEvent(
+      new Event(
+        checkpointFailed ? ORCA_RENDERER_SHUTDOWN_CHECKPOINT_ABORTED_EVENT : abortedEventName
+      )
+    )
     throw error
   }
 }

--- a/src/shared/renderer-shutdown-events.ts
+++ b/src/shared/renderer-shutdown-events.ts
@@ -13,7 +13,8 @@ export const ORCA_SHUTDOWN_CHECKPOINT_FAILURE_REASON_ATTRIBUTE =
 
 export function formatShutdownCheckpointFailureReason(error: unknown): string {
   try {
-    return String(error instanceof Error ? error.message : error)
+    const reason = String(error instanceof Error ? error.message : error)
+    return reason || 'Unknown shutdown checkpoint failure'
   } catch {
     return 'Unknown shutdown checkpoint failure'
   }

--- a/src/shared/renderer-shutdown-events.ts
+++ b/src/shared/renderer-shutdown-events.ts
@@ -1,3 +1,45 @@
 export const ORCA_RENDERER_UNLOAD_PREVENTED_EVENT = 'orca:renderer-unload-prevented'
 export const ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT =
   'orca:renderer-shutdown-checkpoint-failed'
+
+// Why a DOM attribute: the checkpoint guard runs in the renderer's main world while
+// prepareRendererForAppRestart runs in the context-isolated preload world. Events
+// cross worlds but their JS payloads don't; document attributes are shared platform
+// state, so this is the one channel that carries the failure reason to the thrower.
+export const ORCA_SHUTDOWN_CHECKPOINT_FAILURE_REASON_ATTRIBUTE =
+  'data-orca-shutdown-checkpoint-failure'
+
+export function publishShutdownCheckpointFailureReason(reason: string): void {
+  try {
+    globalThis.document?.documentElement?.setAttribute(
+      ORCA_SHUTDOWN_CHECKPOINT_FAILURE_REASON_ATTRIBUTE,
+      reason
+    )
+  } catch {
+    // Best-effort diagnostics; the checkpoint verdict itself is carried by the event.
+  }
+}
+
+export function clearShutdownCheckpointFailureReason(): void {
+  try {
+    globalThis.document?.documentElement?.removeAttribute(
+      ORCA_SHUTDOWN_CHECKPOINT_FAILURE_REASON_ATTRIBUTE
+    )
+  } catch {
+    // Best-effort diagnostics only.
+  }
+}
+
+/** Read and clear the published reason so a stale one can't label a later failure. */
+export function consumeShutdownCheckpointFailureReason(): string | null {
+  try {
+    const root = globalThis.document?.documentElement
+    const reason = root?.getAttribute(ORCA_SHUTDOWN_CHECKPOINT_FAILURE_REASON_ATTRIBUTE)
+    if (reason) {
+      root?.removeAttribute(ORCA_SHUTDOWN_CHECKPOINT_FAILURE_REASON_ATTRIBUTE)
+    }
+    return reason || null
+  } catch {
+    return null
+  }
+}

--- a/src/shared/renderer-shutdown-events.ts
+++ b/src/shared/renderer-shutdown-events.ts
@@ -9,6 +9,14 @@ export const ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT =
 export const ORCA_SHUTDOWN_CHECKPOINT_FAILURE_REASON_ATTRIBUTE =
   'data-orca-shutdown-checkpoint-failure'
 
+export function formatShutdownCheckpointFailureReason(error: unknown): string {
+  try {
+    return String(error instanceof Error ? error.message : error)
+  } catch {
+    return 'Unknown shutdown checkpoint failure'
+  }
+}
+
 export function publishShutdownCheckpointFailureReason(reason: string): void {
   try {
     globalThis.document?.documentElement?.setAttribute(

--- a/src/shared/renderer-shutdown-events.ts
+++ b/src/shared/renderer-shutdown-events.ts
@@ -1,6 +1,8 @@
 export const ORCA_RENDERER_UNLOAD_PREVENTED_EVENT = 'orca:renderer-unload-prevented'
 export const ORCA_RENDERER_SHUTDOWN_CHECKPOINT_FAILED_EVENT =
   'orca:renderer-shutdown-checkpoint-failed'
+export const ORCA_RENDERER_SHUTDOWN_CHECKPOINT_ABORTED_EVENT =
+  'orca:renderer-shutdown-checkpoint-aborted'
 
 // Why a DOM attribute: the checkpoint guard runs in the renderer's main world while
 // prepareRendererForAppRestart runs in the context-isolated preload world. Events


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​580 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​22 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​558 |
| Prod | 10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​332 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​57 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​275 |

<!-- /orca-pr-loc -->

Fixes the STA-5505 stranding mode: the in-app updater refused to install with `Renderer shutdown checkpoint was not completed.` while the actual error thrown inside the shutdown persist was swallowed by a bare `catch {}` — no log, no dialog detail, no recovery.

## Root-cause findings (full details on STA-5505)

- The only producer of the checkpoint-failed event is the `beforeunload` persist handler; the error fires when `persist()` throws synchronously.
- On the reproducing workspace, main-process traces show the first install attempt (13:30:57, pre-restart process) **passed** the checkpoint and invoked the native installer; every attempt in the freshly restored process (13:36+) died renderer-side before its IPC ever reached main (`updater_quit_and_install_started` never recorded).
- Demonstrated mechanism class (live rig, real 5.8MB profile copy): **synchronous Zustand subscribers throw through `setState`** — `session-write-subscriber` and `use-runtime-graph-sync` (paired-host publication) both run projections inside every `set()`, including the `captureAllSleepingAgentSessions('quit')` call in the shutdown checkpoint. Any state shape one projection chokes on turns into a deterministic, unexplained update refusal.
- The guard's tradeoff (block the update rather than lose the session snapshot) is preserved; this PR makes the failure explained, field-diagnosable, and degradable where a safe tier exists.

## Changes

1. **Surface the cause** — the guard now logs the swallowed error, records a `renderer_shutdown_checkpoint_failed` crash breadcrumb (lands in `main.trace.ndjson`), and publishes the message via a DOM attribute so the context-isolated preload can name it in the thrown error. The Update Error dialog now reads e.g. `Renderer shutdown checkpoint was not completed: entries.map is not a function`.
2. **Stop failing the checkpoint on sleeping-agent quit-capture errors** — the periodic capture refreshes resume records every 60s, so the loss window is bounded; blocking the update on it was strictly worse.
3. **Extend the existing durable-session degradation** (already codified for snapshot-build failures) to full-session staging failures, under the same conditions: intentional restart in progress and no dirty editor buffers. Dirty drafts still hard-block, and a failed durable-only stage still fails the checkpoint.

The persist body moved verbatim from the inline closure in `use-app-session-persistence.ts` to `shutdown-checkpoint-persist.ts` with injected deps so the flow is directly testable.

## Red/green

Tests written against the extracted (behavior-identical) pre-fix logic, then the fix applied:

```
RED (pre-fix):
 ❯ src/renderer/src/app-shell/shutdown-checkpoint-persist.test.ts (8 tests | 2 failed)
     × does not fail the checkpoint when the sleeping-agent quit capture throws (STA-5505)
     × degrades to durable-only staging when full staging throws during an intentional restart (STA-5505)
 ❯ src/renderer/src/lib/shutdown-checkpoint-guard.test.ts — 1 failed | 9 passed
     × publishes the failure cause and records a crash breadcrumb (STA-5505)
 ❯ src/shared/renderer-restart-preparation.test.ts — 1 failed | 7 passed
     × names the published failure cause in the thrown checkpoint error (STA-5505)

GREEN (post-fix):
 shutdown-checkpoint-persist.test.ts   Tests  8 passed (8)
 shutdown-checkpoint-guard.test.ts     Tests  10 passed (10)
 renderer-restart-preparation.test.ts  Tests  8 passed (8)
```

End-to-end proof in an isolated dev rig hydrated from a copy of the reproducing 5.8MB profile (475 sleeping agents): forcing a persist failure with a dirty buffer present makes the real `window.api.app.restart()` reject with `Renderer shutdown checkpoint was not completed: entries.map is not a function` — cause named, restart correctly blocked.

Also verified: `pnpm typecheck:web`, `pnpm tc:node`, both oxlint scans (plain + type-aware) clean; adjacent suites `renderer-shutdown-checkpoint.test.ts` (8), `quit-path-durable-write-blocking.test.ts` (14), `app-startup-routing.test.ts` (23), `session-write-subscriber.test.ts` (24) all pass.

## Not addressed here (separate finding)

The trace also shows the 13:30:57 install **passed** the checkpoint, invoked Squirrel, relaunched — and came back on the old version with `ShipIt` still running 20 minutes later. That is a second, independent stranding cause (native installer hang) and deserves its own ticket.


## Addendum: same root cause as #15352 (macOS quit silently ignored)

Open issue #15352 (quit accepted, nothing happens, renderer healthy, SIGKILL-only, v1.4.184) is the **same defect through the silent door**: `confirmNativeWindowClose` dispatches the same synthetic `beforeunload`; when the checkpoint guard's `persist()` throws, it `preventDefault()`s and the close path hit `if (!accepted) { return }` — quit dropped with no dialog and no log line, exactly matching that issue's evidence (healthy renderer, empty trace). This also dates the defect to at least 1.4.184 (2026-08-18), supporting state-dependence over a fresh code regression.

Second commit completes the quit door:
- the quit checkpoint runs inside a window-close scope, so full-session staging failures degrade to the durable tier for app-level closes too (dirty editor drafts still hard-block, and the dirty-file veto's dialog flow is unchanged — it publishes no failure reason);
- if the checkpoint still vetoes the quit, the published cause is shown in a toast instead of the quit dying silently, and the `renderer_shutdown_checkpoint_failed` breadcrumb lands in `main.trace.ndjson` — directly closing #15352's "nothing is logged" gap.

Additional green: `shutdown-checkpoint-persist.test.ts` (8), `shutdown-checkpoint-guard.test.ts` (11), `window-close-request-coordinator.test.ts` (12), `app-startup-routing.test.ts` (23); `typecheck:web` and both oxlint scans clean.


## Addendum 2: review-pass hardening (commit 15c72d40c7)

An adversarial review of the first pass surfaced three refinements, applied:
- **Retry-then-degrade for staging**: the first full-session staging failure stays a visible, retryable error (naming the cause); only a repeat failure trades the full snapshot for an unblocked shutdown. A transient IPC failure therefore keeps its retry instead of silently costing just-captured scrollback.
- The sleeping-capture continue-on-failure comment now states the real cost (periodic capture skips done panes and never stamps quit origin — the loss is a weaker live-origin resume record, still strictly better than a blocked update or SIGKILL'd quit), and the swallowed failure records a `renderer_shutdown_sleeping_capture_failed` breadcrumb.
- The source-shape test pins the exact degradable-shutdown gate (`isIntentionalAppRestartInProgress() || isWindowCloseCheckpointInProgress()`) so a rewiring cannot arm the degrade tiers on arbitrary unloads while suites stay green.
