### PR TITLE
fix(mobile): recover Relay connections after resume

### DIFF
--- a/mobile/src/components/StatusDot.test.ts
+++ b/mobile/src/components/StatusDot.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('react-native', () => ({
+  StyleSheet: { create: <T>(styles: T) => styles },
+  View: 'View'
+}))
+
+import { colors } from '../theme/mobile-theme'
+import { statusDotColor } from './StatusDot'
+
+describe('statusDotColor', () => {
+  it('keeps Relay progress amber when the raw state is disconnected', () => {
+    expect(statusDotColor('disconnected', { kind: 'normal', label: 'Connecting via Relay…' })).toBe(
+      colors.statusAmber
+    )
+  })
+
+  it('keeps an idle disconnected host gray', () => {
+    expect(statusDotColor('disconnected', { kind: 'normal', label: 'Disconnected' })).toBe(
+      colors.textMuted
+    )
+  })
+})

--- a/mobile/src/components/StatusDot.tsx
+++ b/mobile/src/components/StatusDot.tsx
@@ -12,6 +12,16 @@ const stateColors: Record<ConnectionState, string> = {
   'auth-failed': colors.statusRed
 }
 
+export function statusDotColor(state: ConnectionState, verdict?: ConnectionVerdict): string {
+  if (verdict?.kind === 'unreachable' || verdict?.kind === 'auth-failed') {
+    return colors.statusRed
+  }
+  if (verdict?.kind === 'warning' || (verdict?.kind === 'normal' && verdict.label.endsWith('…'))) {
+    return colors.statusAmber
+  }
+  return stateColors[state] ?? colors.textMuted
+}
+
 // Why: when caller passes a verdict, the dot color reflects the verdict's
 // severity instead of the raw transport state. This avoids the "amber dot
 // next to red 'Can't reach desktop' label" mismatch — the underlying
@@ -24,12 +34,7 @@ export function StatusDot({
   state: ConnectionState
   verdict?: ConnectionVerdict
 }) {
-  const color =
-    verdict?.kind === 'unreachable' || verdict?.kind === 'auth-failed'
-      ? colors.statusRed
-      : verdict?.kind === 'warning'
-        ? colors.statusAmber
-        : (stateColors[state] ?? colors.textMuted)
+  const color = statusDotColor(state, verdict)
   return <View style={[styles.dot, { backgroundColor: color }]} />
 }
 

--- a/mobile/src/transport/client-context.test.ts
+++ b/mobile/src/transport/client-context.test.ts
@@ -389,6 +389,39 @@ describe('useHostClient', () => {
     }
   })
 
+  it('rebuilds a pairing-rejected Relay client so re-pairing credentials are re-read', async () => {
+    const rejectedRelayClient = makeFakeClient('disconnected', 'relay')
+    const replacement = makeFakeClient('connecting', 'tailscale')
+    connectMock.mockReturnValueOnce(rejectedRelayClient).mockReturnValueOnce(replacement)
+    loadHostsMock.mockResolvedValue([HOST])
+
+    let forceReconnect: ((hostId: string) => Promise<void>) | null = null
+    let renderer: ReactTestRenderer | null = null
+    function Probe(): null {
+      forceReconnect = useForceReconnect()
+      useHostClient(HOST.id)
+      return null
+    }
+
+    try {
+      await act(async () => {
+        renderer = create(createElement(RpcClientProvider, null, createElement(Probe)))
+        await Promise.resolve()
+      })
+      act(() => rejectedRelayClient.emitPairingRejected(true))
+
+      await act(async () => {
+        await forceReconnect?.(HOST.id)
+      })
+
+      expect(rejectedRelayClient.closeMock).toHaveBeenCalled()
+      expect(rejectedRelayClient.notifyForeground).not.toHaveBeenCalled()
+      expect(connectMock).toHaveBeenCalledTimes(2)
+    } finally {
+      act(() => renderer?.unmount())
+    }
+  })
+
   it('does not open a client after the host is closed during an in-flight lookup', async () => {
     let resolveHosts: ((hosts: (typeof HOST)[]) => void) | null = null
     const hostLookup = new Promise<(typeof HOST)[]>((resolve) => {

--- a/mobile/src/transport/client-context.test.ts
+++ b/mobile/src/transport/client-context.test.ts
@@ -38,7 +38,10 @@ type FakeClient = RpcClient & {
   closeMock: ReturnType<typeof vi.fn>
 }
 
-function makeFakeClient(initialState: ConnectionState): FakeClient {
+function makeFakeClient(
+  initialState: ConnectionState,
+  activePath: MobileConnectionPath = 'tailscale'
+): FakeClient {
   let state = initialState
   let pendingPath: MobileConnectionPath | null = null
   let pairingRejected = false
@@ -52,7 +55,7 @@ function makeFakeClient(initialState: ConnectionState): FakeClient {
     getState: () => state,
     getReconnectAttempt: () => 0,
     getLastConnectedAt: () => null,
-    getActivePath: () => 'tailscale',
+    getActivePath: () => activePath,
     getPendingPath: () => pendingPath,
     isPairingRejected: () => pairingRejected,
     onConnectionPathChange: (listener: () => void) => {
@@ -350,6 +353,37 @@ describe('useHostClient', () => {
       expect(first.closeMock).toHaveBeenCalled()
       expect(states.at(-1)).toBe('connecting')
       expect(states).not.toContain('disconnected')
+    } finally {
+      act(() => renderer?.unmount())
+    }
+  })
+
+  it('nudges an existing Relay session instead of starting a fresh direct dial', async () => {
+    const relayClient = makeFakeClient('disconnected', 'relay')
+    connectMock.mockReturnValue(relayClient)
+    loadHostsMock.mockResolvedValue([HOST])
+
+    let forceReconnect: ((hostId: string) => Promise<void>) | null = null
+    let renderer: ReactTestRenderer | null = null
+    function Probe(): null {
+      forceReconnect = useForceReconnect()
+      useHostClient(HOST.id)
+      return null
+    }
+
+    try {
+      await act(async () => {
+        renderer = create(createElement(RpcClientProvider, null, createElement(Probe)))
+        await Promise.resolve()
+      })
+
+      await act(async () => {
+        await forceReconnect?.(HOST.id)
+      })
+
+      expect(relayClient.closeMock).not.toHaveBeenCalled()
+      expect(relayClient.notifyForeground).toHaveBeenCalledWith('app-resume')
+      expect(connectMock).toHaveBeenCalledOnce()
     } finally {
       act(() => renderer?.unmount())
     }

--- a/mobile/src/transport/client-context.tsx
+++ b/mobile/src/transport/client-context.tsx
@@ -11,6 +11,7 @@ import {
   type ReactNode
 } from 'react'
 import type { RpcClient } from './rpc-client'
+import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
 import { subscribeConnectionRevivalTriggers } from './connection-revival-triggers'
 import { HostClientOpenRegistry } from './host-client-open-registry'
 import {
@@ -238,6 +239,13 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
   const forceReconnect = useCallback(
     async (hostId: string) => {
       const entry = storeRef.current.get(hostId)
+      const logical = entry?.client as Partial<StableLogicalRpcClient> | undefined
+      if (entry && entry.state !== 'auth-failed' && logical?.getActivePath?.() === 'relay') {
+        // Keep a Relay-active host on its existing recovery state; rebuilding the
+        // facade starts the unreachable direct endpoint before Relay can race it.
+        entry.client.notifyForeground('app-resume')
+        return
+      }
       // Why: ownership survives explicit close/re-pair while observers never become synthetic owners.
       const savedRefCount = acquisitionsRef.current.count(hostId)
       manualDemandRef.current.add(hostId)

--- a/mobile/src/transport/client-context.tsx
+++ b/mobile/src/transport/client-context.tsx
@@ -240,7 +240,12 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
     async (hostId: string) => {
       const entry = storeRef.current.get(hostId)
       const logical = entry?.client as Partial<StableLogicalRpcClient> | undefined
-      if (entry && entry.state !== 'auth-failed' && logical?.getActivePath?.() === 'relay') {
+      if (
+        entry &&
+        entry.state !== 'auth-failed' &&
+        !logical?.isPairingRejected?.() &&
+        logical?.getActivePath?.() === 'relay'
+      ) {
         // Keep a Relay-active host on its existing recovery state; rebuilding the
         // facade starts the unreachable direct endpoint before Relay can race it.
         entry.client.notifyForeground('app-resume')

--- a/mobile/src/transport/client-context.tsx
+++ b/mobile/src/transport/client-context.tsx
@@ -20,6 +20,7 @@ import {
 } from './host-client-acquisition-registry'
 import { HostOpenRetryScheduler } from './host-open-retry-scheduler'
 import { openHostClientEntry, type HostClientStoreEntry } from './host-entry-opener'
+import { shouldPreserveActiveRelay } from './relay-reconnect-preservation'
 import {
   createHostClientSelectors,
   listHostClients,
@@ -240,12 +241,7 @@ export function RpcClientProvider({ children }: { children: ReactNode }) {
     async (hostId: string) => {
       const entry = storeRef.current.get(hostId)
       const logical = entry?.client as Partial<StableLogicalRpcClient> | undefined
-      if (
-        entry &&
-        entry.state !== 'auth-failed' &&
-        !logical?.isPairingRejected?.() &&
-        logical?.getActivePath?.() === 'relay'
-      ) {
+      if (entry && shouldPreserveActiveRelay(entry, logical)) {
         // Keep a Relay-active host on its existing recovery state; rebuilding the
         // facade starts the unreachable direct endpoint before Relay can race it.
         entry.client.notifyForeground('app-resume')

--- a/mobile/src/transport/connection-health.test.ts
+++ b/mobile/src/transport/connection-health.test.ts
@@ -127,6 +127,18 @@ describe('classifyConnection Tailscale hint', () => {
     })
     expect(verdictDisplayLabel(verdict)).not.toContain('Tailscale')
   })
+
+  it('does not call an idle Relay path Connecting when no retry is active', () => {
+    const verdict = classifyConnection({
+      state: 'disconnected',
+      reconnectAttempts: 0,
+      lastConnectedAt: 1_000,
+      pendingPath: 'relay',
+      nowMs: 1_000_000
+    })
+
+    expect(verdict).toEqual({ kind: 'normal', label: 'Disconnected' })
+  })
 })
 
 // Issue #10119: every redial re-enters 'connecting', which used to revert an

--- a/mobile/src/transport/connection-health.ts
+++ b/mobile/src/transport/connection-health.ts
@@ -70,7 +70,10 @@ export function classifyConnection(args: {
     return { kind: 'normal', label: 'Connected' }
   }
 
-  if (args.pendingPath === 'relay') {
+  // A disconnected pending path can survive a cleared retry timer during a
+  // lifecycle race. Only narrate Relay while dialing or after a retry has
+  // recorded progress; otherwise the idle transport must read Disconnected.
+  if (args.pendingPath === 'relay' && (state !== 'disconnected' || reconnectAttempts > 0)) {
     if (reconnectAttempts >= UNREACHABLE_ATTEMPTS) {
       if (lastConnectedAt == null) {
         return { kind: 'unreachable', label: "Can't connect via Relay", reason: 'never-connected' }

--- a/mobile/src/transport/mobile-endpoint-supervisor-nudge.test.ts
+++ b/mobile/src/transport/mobile-endpoint-supervisor-nudge.test.ts
@@ -89,6 +89,33 @@ describe('mobile endpoint supervisor nudges', () => {
     supervisor.stop()
   })
 
+  it('restarts a disconnected Relay immediately on an app-resume retry', async () => {
+    const logical = new FakeLogicalClient('disconnected', 'relay')
+    const openRelay = vi
+      .fn()
+      .mockReturnValueOnce(new FakeRelaySession('disconnected', new RelayOuterError(4408)))
+      .mockReturnValueOnce(new FakeRelaySession('connected'))
+    const deps = dependencies({
+      openRelay,
+      openDirect: vi.fn(() => new FakeSession('disconnected')),
+      randomBytes: () => new Uint8Array([128, 0])
+    })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(openRelay).toHaveBeenCalledOnce()
+
+    // Manual retry uses the same app-resume nudge as a background/foreground cycle.
+    supervisor.nudge('app-resume')
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(openRelay).toHaveBeenCalledTimes(2)
+    expect(logical.getState()).toBe('connected')
+    expect(logical.getActivePath()).toBe('relay')
+    supervisor.stop()
+  })
+
   it('leaves physical relay probing to the session watchdog', async () => {
     const logical = new FakeLogicalClient('connected', 'relay')
     const deps = dependencies()

--- a/mobile/src/transport/mobile-relay-pairing-rejection-escalation.test.ts
+++ b/mobile/src/transport/mobile-relay-pairing-rejection-escalation.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { classifyConnection, type ConnectionVerdict } from './connection-health'
 import { MobileEndpointSupervisor } from './mobile-endpoint-supervisor'
 import {
+  bundle,
   dependencies,
   FakeRelaySession,
   FakeSession,
@@ -56,9 +57,11 @@ describe('continuous Relay pairing-rejection escalation', () => {
       return session
     })
     openRelay.mockImplementationOnce(() => activeRelay)
+    const readBundle = vi.fn(async () => bundle)
     const deps = dependencies({
       openDirect: vi.fn(() => new FakeSession('disconnected')),
       openRelay,
+      readBundle,
       randomBytes: () => new Uint8Array([0, 0]),
       onLog: () => {}
     })
@@ -124,6 +127,27 @@ describe('continuous Relay pairing-rejection escalation', () => {
 
     expect(logical.isPairingRejected()).toBe(true)
     expect(verdict(logical)).toMatchObject({ kind: 'auth-failed' })
+    supervisor.stop()
+    logical.close()
+  })
+
+  it('recovers a latched rejection through the manual app-resume nudge', async () => {
+    const { activeRelay, logical, openRelay, supervisor } = harness(
+      new MobileE2EEAuthenticationError()
+    )
+
+    await supervisor.start()
+    activeRelay.publishState('disconnected')
+    await vi.advanceTimersByTimeAsync(FOUR_HOURS_MS)
+    expect(logical.isPairingRejected()).toBe(true)
+
+    openRelay.mockImplementation(() => new FakeRelaySession('connected'))
+    supervisor.nudge('app-resume')
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(openRelay.mock.calls.length).toBeGreaterThan(3)
+    expect(logical.getState()).toBe('connected')
+    expect(logical.isPairingRejected()).toBe(false)
     supervisor.stop()
     logical.close()
   })

--- a/mobile/src/transport/mobile-relay-reconnect-controller.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.ts
@@ -81,11 +81,8 @@ export class RelayReconnectController {
       this.liftGate()
     }
     // Manual app-resume retries bypass transport cooldown, but never a fresh-credential gate.
-    if (
-      reason === 'app-resume' &&
-      logical.getState() === 'disconnected' &&
-      this.recoveryGate !== 'fresh-credential'
-    ) {
+    const disconnectedOnResume = reason === 'app-resume' && logical.getState() === 'disconnected'
+    if (disconnectedOnResume && this.recoveryGate !== 'fresh-credential') {
       this.reset()
     }
     if (

--- a/mobile/src/transport/mobile-relay-reconnect-controller.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.ts
@@ -80,6 +80,14 @@ export class RelayReconnectController {
     if (this.recoveryGate === 'external-signal') {
       this.liftGate()
     }
+    // Manual app-resume retries bypass transport cooldown, but never a fresh-credential gate.
+    if (
+      reason === 'app-resume' &&
+      logical.getState() === 'disconnected' &&
+      this.recoveryGate !== 'fresh-credential'
+    ) {
+      this.reset()
+    }
     if (
       this.recoveryGate !== 'fresh-credential' &&
       logical.getActivePath() === 'relay' &&

--- a/mobile/src/transport/mobile-relay-runtime-failover.test.ts
+++ b/mobile/src/transport/mobile-relay-runtime-failover.test.ts
@@ -430,6 +430,46 @@ describe('relay runtime recovery without direct connectivity', () => {
     expect(logical.getActivePath()).toBe('relay')
     supervisor.stop()
   })
+
+  it('restarts Relay promptly when an active Relay session resumes from background', async () => {
+    const logical = new FakeLogicalClient('connected', 'relay')
+    const deps = dependencies({ openDirect: vi.fn(() => new FakeSession('disconnected')) })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    expect(deps.openRelay).not.toHaveBeenCalled()
+
+    supervisor.setForeground(false)
+    expect(logical.getState()).toBe('disconnected')
+    expect(logical.getPendingPath()).toBeNull()
+
+    supervisor.setForeground(true)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(deps.openRelay).toHaveBeenCalledOnce()
+    expect(logical.getState()).toBe('connected')
+    expect(logical.getPendingPath()).toBeNull()
+    supervisor.stop()
+  })
+
+  it('recovers a suspended Relay through the app-resume nudge used by manual retry', async () => {
+    const logical = new FakeLogicalClient('connected', 'relay')
+    const deps = dependencies({ openDirect: vi.fn(() => new FakeSession('disconnected')) })
+    const supervisor = new MobileEndpointSupervisor(logical, host, deps)
+
+    await supervisor.start()
+    supervisor.setForeground(false)
+    expect(logical.getState()).toBe('disconnected')
+
+    supervisor.nudge('app-resume')
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(deps.openRelay).toHaveBeenCalledOnce()
+    expect(logical.getActivePath()).toBe('relay')
+    expect(logical.getState()).toBe('connected')
+    expect(logical.getPendingPath()).toBeNull()
+    supervisor.stop()
+  })
 })
 
 // The field failure's first symptom: a real direct rpc-client dialing an

--- a/mobile/src/transport/relay-reconnect-preservation.ts
+++ b/mobile/src/transport/relay-reconnect-preservation.ts
@@ -1,0 +1,14 @@
+import type { HostClientStoreEntry } from './host-entry-opener'
+import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
+
+export function shouldPreserveActiveRelay(
+  entry: HostClientStoreEntry | undefined,
+  logical: Partial<StableLogicalRpcClient> | undefined
+): boolean {
+  return Boolean(
+    entry &&
+    entry.state !== 'auth-failed' &&
+    !logical?.isPairingRejected?.() &&
+    logical?.getActivePath?.() === 'relay'
+  )
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​195 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​193 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 |

<!-- /orca-pr-loc -->

## Summary
- preserve an existing Relay logical client on manual reconnect instead of rebuilding through an unreachable direct endpoint
- restart Relay recovery after background suspension/app resume
- avoid stale idle “Connecting via Relay…” labels and show active Relay progress as amber

## Reproduction
On Android 0.0.44, backgrounding and reopening could leave the UI gray while the logical transport was disconnected. Manual Connect then incurred the direct endpoint's 10-second timeout before Relay was retried.

## Validation
- baseline targeted suites: 66/66 passed before the injected regression
- same oracle with fix disabled: 3 intended failures / 83 passed
- restored focused oracle: 88/88 passed
- full mobile suite: 462 files, 3,707 passed, 3 skipped
- `pnpm typecheck`
- `pnpm lint`
- changed-file quality / React Doctor: 0 findings
- reliability manifest: 93 gates passed
- formatting and `git diff --check`

No production systems were changed. This PR is not merged or deployed.
