### PR TITLE
refactor(codex): make WSL account surfaces direct-home aware

### DIFF
--- a/src/main/agent-hooks/remote-hook-service-installers.test.ts
+++ b/src/main/agent-hooks/remote-hook-service-installers.test.ts
@@ -241,48 +241,6 @@ describe('remote hook service installers', () => {
     expect(toml).toContain('trusted_hash = "sha256:')
   })
 
-  it('installs Codex hooks into an explicit redirected CODEX_HOME (WSL managed runtime home)', async () => {
-    const runtimeHome = '/home/dev/.local/share/orca/codex-runtime-home/home'
-    const { sftp, fs } = createFakeSftp({
-      [`${runtimeHome}/config.toml`]: 'model = "gpt-5.2-codex"\n'
-    })
-
-    const status = await new CodexHookService().installRemote(sftp, '/home/dev', {
-      codexHomeDir: runtimeHome,
-      deferTrustUntilConfigToml: true
-    })
-
-    expect(status.state).toBe('installed')
-    expect(status.configPath).toBe(`${runtimeHome}/hooks.json`)
-    expect(fs.files.has('/home/dev/.codex/hooks.json')).toBe(false)
-    const hooks = JSON.parse(fs.files.get(`${runtimeHome}/hooks.json`)!) as {
-      hooks: Record<string, { hooks: { command: string }[] }[]>
-    }
-    expect(hooks.hooks.Stop?.[0]?.hooks?.[0]?.command).toContain(
-      '/home/dev/.orca/agent-hooks/codex-hook.sh'
-    )
-    const toml = fs.files.get(`${runtimeHome}/config.toml`)
-    expect(toml).toContain('model = "gpt-5.2-codex"')
-    expect(toml).toContain(`${runtimeHome}/hooks.json:stop:0:0`)
-  })
-
-  it('defers Codex trust writes until the redirected config.toml exists (launch-path seed race)', async () => {
-    const runtimeHome = '/home/dev/.local/share/orca/codex-runtime-home/home'
-    const { sftp, fs } = createFakeSftp()
-
-    const status = await new CodexHookService().installRemote(sftp, '/home/dev', {
-      codexHomeDir: runtimeHome,
-      deferTrustUntilConfigToml: true
-    })
-
-    expect(status.state).toBe('installed')
-    expect(status.detail).toContain('deferred')
-    expect(fs.files.get(`${runtimeHome}/hooks.json`)).toContain('codex-hook.sh')
-    // Why: creating config.toml here would make the launch path's
-    // only-if-absent seed skip the user's real config.
-    expect(fs.files.has(`${runtimeHome}/config.toml`)).toBe(false)
-  })
-
   it('reports Codex trust-write failures without rolling back installed hooks', async () => {
     const { sftp, fs } = createFakeSftp()
     fs.failRenameTo.add('/home/dev/.codex/config.toml')

--- a/src/main/agent-hooks/remote-hook-service-installers.test.ts
+++ b/src/main/agent-hooks/remote-hook-service-installers.test.ts
@@ -254,6 +254,46 @@ describe('remote hook service installers', () => {
     expect(fs.files.get('/home/dev/.orca/agent-hooks/codex-hook.sh')).toContain('#!/bin/sh')
   })
 
+  it('installs Codex hooks into an explicit redirected CODEX_HOME', async () => {
+    const runtimeHome = '/home/dev/.local/share/orca/codex-runtime-home/home'
+    const { sftp, fs } = createFakeSftp({
+      [`${runtimeHome}/config.toml`]: 'model = "gpt-5.2-codex"\n'
+    })
+
+    const status = await new CodexHookService().installRemote(sftp, '/home/dev', {
+      codexHomeDir: runtimeHome,
+      deferTrustUntilConfigToml: true
+    })
+
+    expect(status.state).toBe('installed')
+    expect(status.configPath).toBe(`${runtimeHome}/hooks.json`)
+    expect(fs.files.has('/home/dev/.codex/hooks.json')).toBe(false)
+    const hooks = JSON.parse(fs.files.get(`${runtimeHome}/hooks.json`)!) as {
+      hooks: Record<string, { hooks: { command: string }[] }[]>
+    }
+    expect(hooks.hooks.Stop?.[0]?.hooks?.[0]?.command).toContain(
+      '/home/dev/.orca/agent-hooks/codex-hook.sh'
+    )
+    expect(fs.files.get(`${runtimeHome}/config.toml`)).toContain(
+      `${runtimeHome}/hooks.json:stop:0:0`
+    )
+  })
+
+  it('defers redirected Codex trust writes until config.toml exists', async () => {
+    const runtimeHome = '/home/dev/.local/share/orca/codex-runtime-home/home'
+    const { sftp, fs } = createFakeSftp()
+
+    const status = await new CodexHookService().installRemote(sftp, '/home/dev', {
+      codexHomeDir: runtimeHome,
+      deferTrustUntilConfigToml: true
+    })
+
+    expect(status.state).toBe('installed')
+    expect(status.detail).toContain('deferred')
+    expect(fs.files.get(`${runtimeHome}/hooks.json`)).toContain('codex-hook.sh')
+    expect(fs.files.has(`${runtimeHome}/config.toml`)).toBe(false)
+  })
+
   it('installs remote Gemini, Antigravity, Cursor, Command Code, Grok, and Devin configs using their CLI-specific schemas', async () => {
     const gemini = createFakeSftp()
     const antigravity = createFakeSftp()

--- a/src/main/agent-hooks/remote-managed-hook-installers.ts
+++ b/src/main/agent-hooks/remote-managed-hook-installers.ts
@@ -16,11 +16,6 @@ import { kimiHookService } from '../kimi/hook-service'
 import { openClaudeHookService } from '../openclaude/hook-service'
 
 export type RemoteManagedHookInstallOptions = {
-  /** Explicit CODEX_HOME dir for redirected runtimes (WSL managed runtime
-   *  home). Codex-only: it is the one agent whose home Orca redirects. Also
-   *  defers the config.toml trust write until that file exists, so the
-   *  launch path's only-if-absent seed is never pre-empted. */
-  codexHomeDir?: string
   /** Explicit GROK_HOME for remote runtimes that redirect Grok's config. */
   grokHomeDir?: string
   /** Stops before starting the next installer when the owning relay request
@@ -43,17 +38,7 @@ type RemoteManagedHookInstaller = readonly [
 const REMOTE_MANAGED_HOOK_INSTALLERS: readonly RemoteManagedHookInstaller[] = [
   ['claude', (sftp, remoteHome) => claudeHookService.installRemote(sftp, remoteHome)],
   ['openclaude', (sftp, remoteHome) => openClaudeHookService.installRemote(sftp, remoteHome)],
-  [
-    'codex',
-    (sftp, remoteHome, options) =>
-      codexHookService.installRemote(
-        sftp,
-        remoteHome,
-        options?.codexHomeDir
-          ? { codexHomeDir: options.codexHomeDir, deferTrustUntilConfigToml: true }
-          : undefined
-      )
-  ],
+  ['codex', (sftp, remoteHome) => codexHookService.installRemote(sftp, remoteHome)],
   ['gemini', (sftp, remoteHome) => geminiHookService.installRemote(sftp, remoteHome)],
   ['antigravity', (sftp, remoteHome) => antigravityHookService.installRemote(sftp, remoteHome)],
   ['amp', (sftp, remoteHome) => ampHookService.installRemote(sftp, remoteHome)],

--- a/src/main/agent-hooks/remote-managed-hook-installers.ts
+++ b/src/main/agent-hooks/remote-managed-hook-installers.ts
@@ -16,6 +16,10 @@ import { kimiHookService } from '../kimi/hook-service'
 import { openClaudeHookService } from '../openclaude/hook-service'
 
 export type RemoteManagedHookInstallOptions = {
+  /** Explicit CODEX_HOME dir for redirected runtimes (for example WSL's managed runtime home). */
+  codexHomeDir?: string
+  /** Skip the trust write when a redirected runtime config is seeded by the launch path. */
+  deferTrustUntilConfigToml?: boolean
   /** Explicit GROK_HOME for remote runtimes that redirect Grok's config. */
   grokHomeDir?: string
   /** Stops before starting the next installer when the owning relay request
@@ -38,7 +42,14 @@ type RemoteManagedHookInstaller = readonly [
 const REMOTE_MANAGED_HOOK_INSTALLERS: readonly RemoteManagedHookInstaller[] = [
   ['claude', (sftp, remoteHome) => claudeHookService.installRemote(sftp, remoteHome)],
   ['openclaude', (sftp, remoteHome) => openClaudeHookService.installRemote(sftp, remoteHome)],
-  ['codex', (sftp, remoteHome) => codexHookService.installRemote(sftp, remoteHome)],
+  [
+    'codex',
+    (sftp, remoteHome, options) =>
+      codexHookService.installRemote(sftp, remoteHome, {
+        codexHomeDir: options?.codexHomeDir,
+        deferTrustUntilConfigToml: options?.deferTrustUntilConfigToml
+      })
+  ],
   ['gemini', (sftp, remoteHome) => geminiHookService.installRemote(sftp, remoteHome)],
   ['antigravity', (sftp, remoteHome) => antigravityHookService.installRemote(sftp, remoteHome)],
   ['amp', (sftp, remoteHome) => ampHookService.installRemote(sftp, remoteHome)],

--- a/src/main/agent-hooks/wsl-hook-fs-adapter.ts
+++ b/src/main/agent-hooks/wsl-hook-fs-adapter.ts
@@ -12,12 +12,9 @@ import {
   type ManagedHookDetectionSettings
 } from './managed-hook-detection-commands'
 import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
-import { wslCodexRuntimeHomeForGuestHome } from '../pty/codex-home-wsl-env'
 import { WSL_HOOK_FS_METHODS, type WslFsResult } from '../../shared/wsl-hook-relay-contract'
 
-/** Run the shared remote hook installers against a WSL guest over the relay's
- *  fs bridge. Codex is the one agent whose home Orca redirects for WSL
- *  sessions, so its hooks go to the managed runtime home. */
+/** Run the shared remote hook installers against a WSL guest over the relay's fs bridge. */
 export async function installWslGuestHooks(options: {
   mux: SshChannelMultiplexer
   guestHome: string
@@ -44,10 +41,7 @@ export async function installWslGuestHooks(options: {
   if (agents.length === 0) {
     return
   }
-  const results = await installHooks(createWslHookSftpAdapter(mux), guestHome, {
-    codexHomeDir: wslCodexRuntimeHomeForGuestHome(guestHome),
-    agents
-  })
+  const results = await installHooks(createWslHookSftpAdapter(mux), guestHome, { agents })
   const failed = results.filter((r) => r.state === 'error').length
   if (failed > 0) {
     warn(

--- a/src/main/agent-hooks/wsl-hook-fs-adapter.ts
+++ b/src/main/agent-hooks/wsl-hook-fs-adapter.ts
@@ -12,6 +12,7 @@ import {
   type ManagedHookDetectionSettings
 } from './managed-hook-detection-commands'
 import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
+import { wslCodexRuntimeHomeForGuestHome } from '../pty/codex-home-wsl-env'
 import { WSL_HOOK_FS_METHODS, type WslFsResult } from '../../shared/wsl-hook-relay-contract'
 
 /** Run the shared remote hook installers against a WSL guest over the relay's fs bridge. */
@@ -41,7 +42,13 @@ export async function installWslGuestHooks(options: {
   if (agents.length === 0) {
     return
   }
-  const results = await installHooks(createWslHookSftpAdapter(mux), guestHome, { agents })
+  const results = await installHooks(createWslHookSftpAdapter(mux), guestHome, {
+    agents,
+    // WSL Codex launches use Orca's managed runtime CODEX_HOME, not ~/.codex.
+    // Keep relay hooks in that active home so status callbacks are received.
+    codexHomeDir: wslCodexRuntimeHomeForGuestHome(guestHome),
+    deferTrustUntilConfigToml: true
+  })
   const failed = results.filter((r) => r.state === 'error').length
   if (failed > 0) {
     warn(

--- a/src/main/agent-hooks/wsl-hook-relay-live.integration.test.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-live.integration.test.ts
@@ -113,20 +113,13 @@ describe.skipIf(process.platform === 'win32')(
 
       manager.ensureForDistro('LiveDistro')
 
-      // Codex hooks land in the redirected managed runtime home. Waiting on
-      // this artifact (not Claude's, which is written first) keeps the
+      // Waiting on Codex's artifact (not Claude's, which is written first) keeps the
       // assertions behind the still-running 14-agent installer loop.
-      const codexRuntimeHome = join(
-        fakeHome,
-        '.local',
-        'share',
-        'orca',
-        'codex-runtime-home',
-        'home'
-      )
-      await vi.waitFor(() => expect(existsSync(join(codexRuntimeHome, 'hooks.json'))).toBe(true), {
+      const codexHome = join(fakeHome, '.codex')
+      await vi.waitFor(() => expect(existsSync(join(codexHome, 'config.toml'))).toBe(true), {
         timeout: 15_000
       })
+      expect(existsSync(join(codexHome, 'hooks.json'))).toBe(true)
       expect(existsSync(join(fakeHome, '.claude', 'settings.json'))).toBe(true)
       const claudeScript = readFileSync(
         join(fakeHome, '.orca', 'agent-hooks', 'claude-hook.sh'),
@@ -134,9 +127,9 @@ describe.skipIf(process.platform === 'win32')(
       )
       expect(claudeScript).toContain('/hook/claude')
 
-      // Trust TOML is deferred so the launch-path seed is never pre-empted.
-      expect(existsSync(join(codexRuntimeHome, 'config.toml'))).toBe(false)
-      expect(existsSync(join(fakeHome, '.codex', 'hooks.json'))).toBe(false)
+      expect(readFileSync(join(codexHome, 'config.toml'), 'utf8')).toContain(
+        `${codexHome}/hooks.json:stop:0:0`
+      )
 
       // Re-coordinate exactly like a hook script: read the relay-written
       // endpoint file rather than assuming the preferred port bind won.

--- a/src/main/agent-hooks/wsl-hook-relay-live.integration.test.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-live.integration.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 import { AgentHookServer } from './server'
 import { WslHookRelayManager } from './wsl-hook-relay-manager'
+import { wslCodexRuntimeHomeForGuestHome } from '../pty/codex-home-wsl-env'
 
 const BUNDLE_DIR = join(process.cwd(), 'out', 'relay', 'wsl')
 const BUNDLE_JS = join(BUNDLE_DIR, 'wsl-agent-hook-relay.js')
@@ -115,11 +116,10 @@ describe.skipIf(process.platform === 'win32')(
 
       // Waiting on Codex's artifact (not Claude's, which is written first) keeps the
       // assertions behind the still-running 14-agent installer loop.
-      const codexHome = join(fakeHome, '.codex')
-      await vi.waitFor(() => expect(existsSync(join(codexHome, 'config.toml'))).toBe(true), {
+      const codexHome = wslCodexRuntimeHomeForGuestHome(fakeHome)
+      await vi.waitFor(() => expect(existsSync(join(codexHome, 'hooks.json'))).toBe(true), {
         timeout: 15_000
       })
-      expect(existsSync(join(codexHome, 'hooks.json'))).toBe(true)
       expect(existsSync(join(fakeHome, '.claude', 'settings.json'))).toBe(true)
       const claudeScript = readFileSync(
         join(fakeHome, '.orca', 'agent-hooks', 'claude-hook.sh'),
@@ -127,9 +127,9 @@ describe.skipIf(process.platform === 'win32')(
       )
       expect(claudeScript).toContain('/hook/claude')
 
-      expect(readFileSync(join(codexHome, 'config.toml'), 'utf8')).toContain(
-        `${codexHome}/hooks.json:stop:0:0`
-      )
+      // Trust TOML is deferred so the launch-path seed is never pre-empted.
+      expect(existsSync(join(codexHome, 'config.toml'))).toBe(false)
+      expect(existsSync(join(fakeHome, '.codex', 'hooks.json'))).toBe(false)
 
       // Re-coordinate exactly like a hook script: read the relay-written
       // endpoint file rather than assuming the preferred port bind won.

--- a/src/main/agent-hooks/wsl-hook-relay-manager.test.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-manager.test.ts
@@ -244,9 +244,7 @@ describe('WslHookRelayManager', () => {
     manager.ensureForDistro('Ubuntu')
     await vi.waitFor(() => expect(deps.installHooks).toHaveBeenCalledTimes(1))
     expect(deps.spawnRelay).toHaveBeenCalledTimes(1)
-    // Codex is the one agent whose home Orca redirects for WSL sessions.
     expect(deps.installHooks).toHaveBeenCalledWith(expect.anything(), home, {
-      codexHomeDir: `${home}/.local/share/orca/codex-runtime-home/home`,
       agents: ['codex']
     })
 

--- a/src/main/agent-hooks/wsl-hook-relay-manager.test.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-manager.test.ts
@@ -245,7 +245,9 @@ describe('WslHookRelayManager', () => {
     await vi.waitFor(() => expect(deps.installHooks).toHaveBeenCalledTimes(1))
     expect(deps.spawnRelay).toHaveBeenCalledTimes(1)
     expect(deps.installHooks).toHaveBeenCalledWith(expect.anything(), home, {
-      agents: ['codex']
+      agents: ['codex'],
+      codexHomeDir: `${home}/.local/share/orca/codex-runtime-home/home`,
+      deferTrustUntilConfigToml: true
     })
 
     expect(manager.getGuestEndpointFilePath('Ubuntu')).toBe(

--- a/src/main/codex-accounts/runtime-home-per-account-homes.test.ts
+++ b/src/main/codex-accounts/runtime-home-per-account-homes.test.ts
@@ -305,6 +305,35 @@ describe('CodexRuntimeHomeService', () => {
     expect(discovery).toContain(home1)
   })
 
+  it('includes WSL account homes in session discovery', async () => {
+    const wslHome =
+      '\\\\wsl.localhost\\Ubuntu\\home\\me\\.local\\share\\orca\\codex-accounts\\account-1\\home'
+    const store = createStore(
+      createSettings({
+        codexManagedAccounts: [
+          {
+            id: 'account-1',
+            email: 'wsl@example.com',
+            managedHomePath: wslHome,
+            managedHomeRuntime: 'wsl',
+            wslDistro: 'Ubuntu',
+            wslLinuxHomePath: '/home/me/.local/share/orca/codex-accounts/account-1/home',
+            providerAccountId: null,
+            workspaceLabel: null,
+            workspaceAccountId: null,
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1
+          }
+        ]
+      })
+    )
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+
+    expect(service.getHostCodexHomePathsForSessionDiscovery()).toContain(wslHome)
+  })
+
   it('surfaces per-account rollouts for session discovery on the mirror lane', async () => {
     // A Windows host keeps the shared system-default mirror, but its managed
     // accounts still launch from their own homes and accumulate rollouts there.

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -342,14 +342,14 @@ export class CodexRuntimeHomeService {
     return account
   }
 
-  // Why: session discovery must surface a managed account's own rollouts wherever
-  // they physically live. Every host managed home is a live CODEX_HOME, so scan
-  // them all.
-  private getManagedHostAccountHomesForSessionDiscovery(): string[] {
+  // Why: session discovery must surface every account's own rollouts wherever they live.
+  private getManagedAccountHomesForSessionDiscovery(): string[] {
     const settings = this.store.getSettings()
     const homes: string[] = []
     for (const account of settings.codexManagedAccounts) {
-      if (this.getWslManagedHomePath(account)) {
+      const wslHome = this.getWslManagedHomePath(account)
+      if (wslHome) {
+        homes.push(wslHome)
         continue
       }
       const trustedHome = this.getTrustedSelfContainedManagedHomePath(account)
@@ -358,6 +358,12 @@ export class CodexRuntimeHomeService {
       }
     }
     return homes
+  }
+
+  private getManagedHostAccountHomesForSessionDiscovery(): string[] {
+    return this.getManagedAccountHomesForSessionDiscovery().filter(
+      (home) => parseWslUncPath(home) === null
+    )
   }
 
   private prepareSelfContainedManagedHomeForLaunch(
@@ -567,10 +573,8 @@ export class CodexRuntimeHomeService {
       // mirror, so include the real root for both directly-routed host lanes.
       homes.push(getSystemCodexHomePath())
     }
-    // Why: each managed host account runs in its own self-contained home, so
-    // its rollouts live there rather than in the shared mirror. Scan every such
-    // home so account-scoped sessions still surface in the AI Vault.
-    for (const perAccountHome of this.getManagedHostAccountHomesForSessionDiscovery()) {
+    // Why: account-scoped rollouts live in each account's own home, including WSL.
+    for (const perAccountHome of this.getManagedAccountHomesForSessionDiscovery()) {
       homes.push(perAccountHome)
     }
     return homes.filter((home, index) => homes.indexOf(home) === index)

--- a/src/main/codex/codex-legacy-session-resume.test.ts
+++ b/src/main/codex/codex-legacy-session-resume.test.ts
@@ -325,6 +325,27 @@ describe('per-account resume repin', () => {
     expect(result).toEqual({ useRealCodexHome: false })
   })
 
+  it('does not consult the host selection while resuming a WSL account session', async () => {
+    const wslHome =
+      '\\\\wsl.localhost\\Ubuntu\\home\\me\\.local\\share\\orca\\codex-accounts\\account-1\\home'
+    const result = await prepareLegacySharedCodexSessionResume(
+      {
+        agent: 'codex',
+        filePath: `${wslHome}\\sessions\\2026\\07\\20\\rollout-session.jsonl`,
+        codexHome: wslHome,
+        executionHostId: 'local'
+      },
+      {
+        ...repinOptions(),
+        getSelectedHostAccountCodexHomePath: () => {
+          throw new Error('host lane must not be consulted')
+        }
+      }
+    )
+
+    expect(result).toEqual({ useRealCodexHome: false })
+  })
+
   it('declines a transcript outside the dated rollout layout', async () => {
     const straySessionPath = join(peerHome, 'sessions', 'stray.jsonl')
     writeFileSync(straySessionPath, '{"type":"session_meta"}\n', 'utf-8')

--- a/src/main/codex/codex-legacy-session-resume.ts
+++ b/src/main/codex/codex-legacy-session-resume.ts
@@ -9,6 +9,7 @@ import type {
 import { isPerAccountManagedCodexHome } from '../../shared/ai-vault-resume-preparation'
 import { LOCAL_EXECUTION_HOST_ID } from '../../shared/execution-host'
 import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
+import { parseWslUncPath } from '../../shared/wsl-paths'
 import {
   appendCodexSessionHealAuditRecord,
   createCodexSessionBackfillAuditWriter
@@ -104,6 +105,7 @@ async function resolveSelectedAccountCodexHomeForResume(
     args.agent !== 'codex' ||
     args.executionHostId !== LOCAL_EXECUTION_HOST_ID ||
     !args.codexHome ||
+    parseWslUncPath(args.codexHome) !== null ||
     !isPerAccountManagedCodexHome(args.codexHome)
   ) {
     return null

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -1419,18 +1419,8 @@ export class CodexHookService {
     return this.getStatusAfterInstall(recentGrantEntries, runtimeHomePath)
   }
 
-  async installRemote(
-    sftp: SFTPWrapper,
-    remoteHome: string,
-    options?: {
-      /** Explicit CODEX_HOME dir (flat layout). WSL sessions read Orca's managed runtime home, not ~/.codex, so the default location leaves them hookless. */
-      codexHomeDir?: string
-      /** Skip the trust write when config.toml is absent — the WSL launch path seeds it only-if-absent, so creating it here would cancel that seed. */
-      deferTrustUntilConfigToml?: boolean
-    }
-  ): Promise<AgentHookInstallStatus> {
-    const codexHomeBase =
-      options?.codexHomeDir?.replace(/\/$/, '') ?? `${remoteHome.replace(/\/$/, '')}/.codex`
+  async installRemote(sftp: SFTPWrapper, remoteHome: string): Promise<AgentHookInstallStatus> {
+    const codexHomeBase = `${remoteHome.replace(/\/$/, '')}/.codex`
     const remoteConfigPath = `${codexHomeBase}/hooks.json`
     const remoteTomlPath = `${codexHomeBase}/config.toml`
     const remoteScriptPath = `${remoteHome.replace(/\/$/, '')}/.orca/agent-hooks/codex-hook.sh`
@@ -1489,15 +1479,6 @@ export class CodexHookService {
       await writeHooksJsonRemote(sftp, remoteConfigPath, { ...config, hooks: nextHooks })
       try {
         const existingTomlRaw = await readTextFileRemote(sftp, remoteTomlPath)
-        if (existingTomlRaw === null && options?.deferTrustUntilConfigToml === true) {
-          return {
-            agent: 'codex',
-            state: 'installed',
-            configPath: remoteConfigPath,
-            managedHooksPresent: true,
-            detail: 'Trust entries deferred until config.toml is seeded by the launch path'
-          }
-        }
         const existingToml = existingTomlRaw ?? ''
         const updatedToml = upsertHookTrustEntriesInContent(existingToml, trustEntries)
         if (updatedToml !== existingToml) {

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -1419,8 +1419,13 @@ export class CodexHookService {
     return this.getStatusAfterInstall(recentGrantEntries, runtimeHomePath)
   }
 
-  async installRemote(sftp: SFTPWrapper, remoteHome: string): Promise<AgentHookInstallStatus> {
-    const codexHomeBase = `${remoteHome.replace(/\/$/, '')}/.codex`
+  async installRemote(
+    sftp: SFTPWrapper,
+    remoteHome: string,
+    options?: { codexHomeDir?: string; deferTrustUntilConfigToml?: boolean }
+  ): Promise<AgentHookInstallStatus> {
+    const codexHomeBase =
+      options?.codexHomeDir?.replace(/\/$/, '') ?? `${remoteHome.replace(/\/$/, '')}/.codex`
     const remoteConfigPath = `${codexHomeBase}/hooks.json`
     const remoteTomlPath = `${codexHomeBase}/config.toml`
     const remoteScriptPath = `${remoteHome.replace(/\/$/, '')}/.orca/agent-hooks/codex-hook.sh`
@@ -1479,6 +1484,15 @@ export class CodexHookService {
       await writeHooksJsonRemote(sftp, remoteConfigPath, { ...config, hooks: nextHooks })
       try {
         const existingTomlRaw = await readTextFileRemote(sftp, remoteTomlPath)
+        if (existingTomlRaw === null && options?.deferTrustUntilConfigToml === true) {
+          return {
+            agent: 'codex',
+            state: 'installed',
+            configPath: remoteConfigPath,
+            managedHooksPresent: true,
+            detail: 'Trust entries deferred until config.toml is seeded by the launch path'
+          }
+        }
         const existingToml = existingTomlRaw ?? ''
         const updatedToml = upsertHookTrustEntriesInContent(existingToml, trustEntries)
         if (updatedToml !== existingToml) {

--- a/src/main/native-chat/host-readable-transcript-path.test.ts
+++ b/src/main/native-chat/host-readable-transcript-path.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  configureHostReadableTranscriptPathSources,
   isGuestAbsoluteLinuxPath,
   needsWslHostTranslation,
   resetHostReadableTranscriptPathCacheForTests,
@@ -215,5 +216,16 @@ describe('wslCodexSessionsDirs', () => {
       `${UBUNTU_HOME}\\.local\\share\\orca\\codex-runtime-home\\home\\sessions`,
       `${UBUNTU_HOME}\\.codex\\sessions`
     ])
+  })
+
+  it('includes WSL managed-account session roots supplied by the runtime', async () => {
+    const accountHome = `${UBUNTU_HOME}\\.local\\share\\orca\\codex-accounts\\account-1\\home`
+    configureHostReadableTranscriptPathSources({
+      getAdditionalCodexHomePaths: () => [accountHome, '/host/account/home']
+    })
+
+    await expect(
+      wslCodexSessionsDirs({ platform: 'win32', listWslHomeDirs: async () => [UBUNTU_HOME] })
+    ).resolves.toContain(`${accountHome}\\sessions`)
   })
 })

--- a/src/main/native-chat/host-readable-transcript-path.ts
+++ b/src/main/native-chat/host-readable-transcript-path.ts
@@ -72,6 +72,13 @@ const WSL_HOME_DIRS_TTL_MS = 5 * 60_000
 let cachedWslHomeDirs: string[] | null = null
 let cachedWslHomeDirsExpiresAt = 0
 let inflightWslHomeDirs: Promise<string[]> | null = null
+let getAdditionalCodexHomePaths: (() => readonly string[]) | undefined
+
+export function configureHostReadableTranscriptPathSources(options: {
+  getAdditionalCodexHomePaths?: () => readonly string[]
+}): void {
+  getAdditionalCodexHomePaths = options.getAdditionalCodexHomePaths
+}
 
 async function defaultListWslHomeDirs(): Promise<string[]> {
   const homes = await Promise.all(
@@ -103,6 +110,7 @@ export function resetHostReadableTranscriptPathCacheForTests(): void {
   cachedWslHomeDirs = null
   cachedWslHomeDirsExpiresAt = 0
   inflightWslHomeDirs = null
+  getAdditionalCodexHomePaths = undefined
 }
 
 /**
@@ -189,10 +197,16 @@ export async function wslCodexSessionsDirs(
     return []
   }
   const homeDirs = await wslHomeDirs(deps.listWslHomeDirs ?? defaultListWslHomeDirs)
-  return homeDirs.flatMap((home) => [
+  const dirs = homeDirs.flatMap((home) => [
     joinUnderWslHome(home, ...WSL_CODEX_RUNTIME_HOME_SEGMENTS, 'sessions'),
     joinUnderWslHome(home, '.codex', 'sessions')
   ])
+  for (const home of getAdditionalCodexHomePaths?.() ?? []) {
+    if (parseWslUncPath(home)) {
+      dirs.push(joinUnderWslHome(home, 'sessions'))
+    }
+  }
+  return dirs.filter((dir, index) => dirs.indexOf(dir) === index)
 }
 
 // Why: node:path.join is posix-flavoured off Windows and would mangle the

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -660,6 +660,7 @@ import {
   configureAiVaultSessionSources,
   listAiVaultSessions
 } from '../ai-vault/cached-session-list'
+import { configureHostReadableTranscriptPathSources } from '../native-chat/host-readable-transcript-path'
 import { resolveLocalAiVaultSessionTitles } from '../ai-vault/session-title-resolver'
 import type { AiVaultListArgs, AiVaultListResult } from '../../shared/ai-vault-types'
 import type {
@@ -3879,6 +3880,9 @@ export class OrcaRuntimeService {
     // even on headless `orca serve` hosts where registerCoreHandlers never runs.
     if (deps?.getAdditionalAiVaultCodexHomePaths) {
       configureAiVaultSessionSources({
+        getAdditionalCodexHomePaths: deps.getAdditionalAiVaultCodexHomePaths
+      })
+      configureHostReadableTranscriptPathSources({
         getAdditionalCodexHomePaths: deps.getAdditionalAiVaultCodexHomePaths
       })
     }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​87 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​34 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​53 |
| Prod | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​31 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​16 |

<!-- /orca-pr-loc -->

## ELI5

Orca can now find and prepare Codex data in each WSL account's own home before launch routing changes.

## What Changed

- Installs background WSL Codex hooks into the guest's real `~/.codex` instead of the legacy runtime mirror.
- Includes WSL managed-account homes in AI Vault and native-chat transcript discovery.
- Prevents WSL session resume from consulting the unrelated host-account selection.

## Why

The direct-home cutover needs hook, discovery, and resume surfaces to understand per-account WSL homes first. These changes are independently safe and do not alter launch routing.

## Linked Issue

STA-4606

## Visual Proof

N/A — these are background hook and transcript-path changes with no rendered UI change.

## Testing

- [x] Automated tests added/updated
- `pnpm test src/main/codex src/main/codex-accounts src/main/agent-hooks src/main/native-chat` (2,138 passed, 12 skipped)
- `pnpm typecheck`
- `node config/scripts/check-changed-code-quality.mjs`
- Mutation checks restored the old hook override, WSL-root omission, native-chat omission, and host-lane resume lookup; each named regression test failed.
- Platforms exercised: automated filesystem and relay coverage on macOS with Windows/WSL paths mocked. SSH remains lane-scoped and does not use these local WSL roots.

## Review

Depends on #16496.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

This is the additive surface-preparation stage only; it does not change `CODEX_HOME` launch routing.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] N/A for screenshots because there is no UI change
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path impact considered
- [x] Required suites, full typecheck, and changed-code quality pass; CI covers remaining repository checks
