### PR TITLE
test(perf): warm palette matcher before timing

### DIFF
--- a/src/renderer/src/lib/palette-match/palette-match-performance.test.ts
+++ b/src/renderer/src/lib/palette-match/palette-match-performance.test.ts
@@ -113,9 +113,7 @@ describe('palette matcher performance budget', () => {
       return
     }
 
-    const samples: number[] = []
-    for (let run = 0; run < 10; run += 1) {
-      const start = performance.now()
+    const matchAllDocuments = (): void => {
       for (const document of documents.values()) {
         matchPaletteDocument({
           document,
@@ -123,6 +121,14 @@ describe('palette matcher performance budget', () => {
           normalizedQuery: prepared.normalized
         })
       }
+    }
+
+    // Warm the matcher before timing so JIT compilation is not part of p95.
+    matchAllDocuments()
+    const samples: number[] = []
+    for (let run = 0; run < 10; run += 1) {
+      const start = performance.now()
+      matchAllDocuments()
       samples.push(performance.now() - start)
     }
     expect(percentile95(samples)).toBeLessThan(PALETTE_MATCH_BUDGET.warmMatchP95Ms)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## Summary

- Warm the palette matcher once before collecting performance samples.
- Keep the existing 220 ms p95 budget unchanged.

The benchmark's first measured pass could include JIT compilation and make the ten-sample p95 effectively report a startup outlier. This caused the unrelated Node 24 shard failure at 231.9 ms despite the matcher being within its steady-state budget.

## Verification

- Palette performance test passed repeatedly (5 consecutive runs, 3 tests each).
- `oxlint --deny-warnings` passed.
- oxfmt and pre-commit hooks passed.
- `git diff --check` passed.
