### PR TITLE
fix(browser): expose client-hosted tab placement (STA-5504)

### DIFF
--- a/src/cli/browser-format.test.ts
+++ b/src/cli/browser-format.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import type { BrowserTabInfo } from '../shared/runtime-types'
+import { formatTabList, formatTabShow } from './browser-format'
+
+function tab(overrides: Partial<BrowserTabInfo> = {}): BrowserTabInfo {
+  return {
+    browserPageId: 'page-1',
+    index: 0,
+    url: 'https://example.test',
+    title: 'Example',
+    active: true,
+    ...overrides
+  }
+}
+
+describe('browser tab placement formatting', () => {
+  it('marks client-hosted pages in list and show output', () => {
+    const clientTab = tab({
+      placement: {
+        kind: 'client',
+        browserHostClientId: 'host-a',
+        browserHostGeneration: 3,
+        pageHostGeneration: 9
+      }
+    })
+
+    expect(formatTabList({ tabs: [clientTab] })).toContain('[client-hosted]')
+    expect(formatTabShow({ tab: clientTab })).toContain('placement: client')
+  })
+
+  it('treats an old host response without placement as unknown', () => {
+    const legacyTab = tab()
+
+    expect(formatTabList({ tabs: [legacyTab] })).toContain('[placement-unknown]')
+    expect(formatTabShow({ tab: legacyTab })).toContain('placement: unknown')
+  })
+})

--- a/src/cli/browser-format.ts
+++ b/src/cli/browser-format.ts
@@ -34,7 +34,8 @@ export function formatTabListWithProfiles(
     .map((t) => {
       const marker = t.active ? '* ' : '  '
       const profile = showProfile ? `  [${t.profileLabel ?? t.profileId ?? 'Unknown'}]` : ''
-      return `${marker}[${t.index}] ${t.browserPageId}  ${t.title} — ${t.url}${profile}`
+      const placement = `[${formatBrowserPlacement(t.placement)}]`
+      return `${marker}[${t.index}] ${t.browserPageId}  ${t.title} — ${t.url}  ${placement}${profile}`
     })
     .join('\n')
 }
@@ -60,9 +61,22 @@ export function formatTabShow(result: BrowserTabShowResult | BrowserTabCurrentRe
     `title: ${tab.title}`,
     `url: ${tab.url}`,
     `active: ${tab.active}`,
+    `placement: ${tab.placement?.kind ?? 'unknown'}`,
     `worktree: ${tab.worktreeId ?? 'unknown'}`,
     `profile: ${tab.profileLabel ?? tab.profileId ?? 'unknown'}`
   ].join('\n')
+}
+
+export function formatBrowserPlacement(
+  placement: BrowserTabListResult['tabs'][number]['placement']
+): 'server-hosted' | 'client-hosted' | 'placement-unknown' {
+  if (placement?.kind === 'server') {
+    return 'server-hosted'
+  }
+  if (placement?.kind === 'client') {
+    return 'client-hosted'
+  }
+  return 'placement-unknown'
 }
 
 export function formatTabProfileShow(result: BrowserTabProfileShowResult): string {

--- a/src/cli/browser.test.ts
+++ b/src/cli/browser.test.ts
@@ -239,8 +239,8 @@ describe('orca cli browser page targeting', () => {
     expect(callMock).toHaveBeenCalledTimes(1)
     expect(callMock).toHaveBeenCalledWith('browser.tabList', { worktree: undefined })
     expect(logSpy).toHaveBeenCalledWith(
-      '* [0] page-1  Example — https://example.com  [Default]\n' +
-        '  [1] page-2  Mail — https://mail.example.com  [Work]'
+      '* [0] page-1  Example — https://example.com  [placement-unknown]  [Default]\n' +
+        '  [1] page-2  Mail — https://mail.example.com  [placement-unknown]  [Work]'
     )
   })
 

--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -10,6 +10,7 @@ import type { RuntimeRpcFailure, RuntimeRpcSuccess } from './runtime-client'
 import { RuntimeClientError, RuntimeRpcFailureError } from './runtime/types'
 
 export {
+  formatBrowserPlacement,
   formatBrowserProfileList,
   formatScreenshot,
   formatSnapshot,

--- a/src/cli/handlers/browser-tab.ts
+++ b/src/cli/handlers/browser-tab.ts
@@ -5,7 +5,13 @@ import type {
   BrowserTabSwitchResult
 } from '../../shared/runtime-types'
 import type { CommandHandler } from '../dispatch'
-import { formatTabList, formatTabListWithProfiles, formatTabShow, printResult } from '../format'
+import {
+  formatBrowserPlacement,
+  formatTabList,
+  formatTabListWithProfiles,
+  formatTabShow,
+  printResult
+} from '../format'
 import {
   getOptionalNonNegativeIntegerFlag,
   getOptionalStringFlag,
@@ -54,7 +60,12 @@ export const BROWSER_TAB_HANDLERS: Record<string, CommandHandler> = {
       ...(flags.has('focus') ? { focus: true } : {}),
       ...target
     })
-    printResult(result, json, (v) => `Switched to tab ${v.switched} (${v.browserPageId})`)
+    printResult(
+      result,
+      json,
+      (v) =>
+        `Switched to tab ${v.switched} (${v.browserPageId}) [${formatBrowserPlacement(v.placement)}]`
+    )
   },
   'tab create': async ({ flags, client, cwd, json }) => {
     const url = getOptionalStringFlag(flags, 'url')

--- a/src/main/runtime/browser-tab-create-publication.test.ts
+++ b/src/main/runtime/browser-tab-create-publication.test.ts
@@ -740,7 +740,11 @@ describe('browser tab-switch placement census', () => {
 
       await expect(
         commands.browserTabSwitch({ worktree: 'id:wt-1', page: 'page-b', focus: true })
-      ).resolves.toEqual({ switched: 1, browserPageId: 'page-b' })
+      ).resolves.toMatchObject({
+        switched: 1,
+        browserPageId: 'page-b',
+        placement: { kind: 'client' }
+      })
       expect(registry.getPage('page-b')?.active).toBe(true)
       expect(markHeadlessBrowserSessionTabActive).toHaveBeenCalledWith('wt-1', 'page-b', {
         focusesHost: true

--- a/src/main/runtime/orca-runtime-browser-client-hosted.test.ts
+++ b/src/main/runtime/orca-runtime-browser-client-hosted.test.ts
@@ -472,16 +472,26 @@ describe('RuntimeBrowserCommands client-hosted routing', () => {
           url: 'https://client.test/',
           title: 'Client page',
           active: true,
-          worktreeId: 'folder:folder-1'
+          worktreeId: 'folder:folder-1',
+          placement: {
+            kind: 'client',
+            browserHostClientId: 'host-a',
+            browserHostGeneration: 3,
+            pageHostGeneration: 9
+          }
         }
       ]
     })
     await expect(
       commands.browserTabShow({ worktree: 'id:folder:folder-1', page: 'page-client' })
-    ).resolves.toMatchObject({ tab: { browserPageId: 'page-client' } })
+    ).resolves.toMatchObject({
+      tab: { browserPageId: 'page-client', placement: { kind: 'client' } }
+    })
     await expect(
       commands.browserTabCurrent({ worktree: 'id:folder:folder-1' })
-    ).resolves.toMatchObject({ tab: { browserPageId: 'page-client' } })
+    ).resolves.toMatchObject({
+      tab: { browserPageId: 'page-client', placement: { kind: 'client' } }
+    })
   })
 
   it('switches logical client pages without invoking the server bridge', async () => {
@@ -501,7 +511,11 @@ describe('RuntimeBrowserCommands client-hosted routing', () => {
 
     await expect(
       commands.browserTabSwitch({ worktree: 'id:wt-1', page: 'page-b' })
-    ).resolves.toEqual({ switched: 1, browserPageId: 'page-b' })
+    ).resolves.toMatchObject({
+      switched: 1,
+      browserPageId: 'page-b',
+      placement: { kind: 'client' }
+    })
     expect(registry.getPage('page-a')?.active).toBe(false)
     expect(registry.getPage('page-b')?.active).toBe(true)
     expect(notify).toHaveBeenCalledWith('wt-1')
@@ -562,13 +576,14 @@ describe('RuntimeBrowserCommands client-hosted routing', () => {
     )
 
     await expect(commands.browserTabSwitch({ page: 'page-server' })).resolves.toMatchObject({
-      browserPageId: 'page-server'
+      browserPageId: 'page-server',
+      placement: { kind: 'server' }
     })
     expect(registry.listPages().every((page) => !page.active)).toBe(true)
     expect(registry.listPages('wt-1')[0]?.active).toBe(true)
     expect(registry.listPages('wt-2')[0]?.active).toBe(true)
     await expect(commands.browserTabCurrent({})).resolves.toMatchObject({
-      tab: { browserPageId: 'page-server' }
+      tab: { browserPageId: 'page-server', placement: { kind: 'server' } }
     })
   })
 

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -877,7 +877,11 @@ export class RuntimeBrowserCommands {
         worktreeId: clientPage.workspaceId,
         focus: params.focus
       })
-      return { switched: switchedIndex, browserPageId: clientPage.browserPageId }
+      return {
+        switched: switchedIndex,
+        browserPageId: clientPage.browserPageId,
+        placement: clientPage.placement
+      }
     }
     const bridge = this.requireAgentBrowserBridge()
     const worktreeId =
@@ -903,7 +907,7 @@ export class RuntimeBrowserCommands {
     if (params.focus) {
       this.notifyRendererBrowserPaneFocus(focusWorktreeId, result.browserPageId)
     }
-    return { ...result, switched: switchedIndex }
+    return { ...result, switched: switchedIndex, placement: { kind: 'server' } }
   }
 
   async browserHover(
@@ -2124,7 +2128,8 @@ export class RuntimeBrowserCommands {
       ...tab,
       worktreeId: browserManager.getWorktreeIdForTab(tab.browserPageId) ?? null,
       profileId: profile.id,
-      profileLabel: profile.label
+      profileLabel: profile.label,
+      placement: { kind: 'server' }
     }
   }
 
@@ -2155,7 +2160,8 @@ export class RuntimeBrowserCommands {
         certificateFailure: null,
         worktreeId: page.workspaceId,
         profileId: profile.id,
-        profileLabel: profile.label
+        profileLabel: profile.label,
+        placement: page.placement
       }
     })
     const tabs = [...serverTabs, ...clientTabs]

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -51709,7 +51709,8 @@ describe('OrcaRuntimeService', () => {
 
       await expect(runtime.browserTabSwitch({ page: 'page-2' })).resolves.toEqual({
         switched: 2,
-        browserPageId: 'page-2'
+        browserPageId: 'page-2',
+        placement: { kind: 'server' }
       })
       await expect(runtime.browserCaptureStart({ page: 'page-2' })).resolves.toEqual({
         capturing: true
@@ -51736,7 +51737,8 @@ describe('OrcaRuntimeService', () => {
 
       await expect(runtime.browserTabSwitch({ page: 'page-1', focus: true })).resolves.toEqual({
         switched: 0,
-        browserPageId: 'page-1'
+        browserPageId: 'page-1',
+        placement: { kind: 'server' }
       })
       // Bridge is unchanged — focus is delivered to the renderer via IPC, not threaded through bridge state.
       expect(tabSwitchMock).toHaveBeenCalledWith(undefined, undefined, 'page-1')

--- a/src/main/runtime/rpc/methods/browser.test.ts
+++ b/src/main/runtime/rpc/methods/browser.test.ts
@@ -12,12 +12,52 @@ import { BROWSER_CORE_METHODS } from './browser-core'
 import { BROWSER_EXTRA_METHODS } from './browser-extras'
 import { BROWSER_SCREENCAST_METHODS } from './browser-screencast'
 import { ClipboardWrite, Fill, KeyboardInsert, ProfileCreate, Type } from './browser-schemas'
+import { BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY } from '../../../../shared/protocol-version'
 
 function makeRequest(method: string, params?: unknown): RpcRequest {
   return { id: 'req-1', authToken: 'tok', method, params }
 }
 
 describe('browser RPC methods', () => {
+  it.each([
+    ['capable', [BROWSER_CLIENT_HOST_RUNTIME_CAPABILITY]],
+    ['incapable', []]
+  ] as const)('publishes client placement to a %s caller', async (_label, clientCapabilities) => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      browserTabList: vi.fn().mockResolvedValue({
+        tabs: [
+          {
+            browserPageId: 'page-client',
+            index: 0,
+            url: 'https://example.test',
+            title: 'Client page',
+            active: true,
+            placement: {
+              kind: 'client',
+              browserHostClientId: 'host-a',
+              browserHostGeneration: 3,
+              pageHostGeneration: 9
+            }
+          }
+        ]
+      })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: BROWSER_CORE_METHODS })
+    const replies: string[] = []
+
+    await dispatcher.dispatchStreaming(
+      makeRequest('browser.tabList', {}),
+      (reply) => replies.push(reply),
+      { clientKind: 'runtime', clientCapabilities }
+    )
+
+    expect(JSON.parse(replies[0]!)).toMatchObject({
+      ok: true,
+      result: { tabs: [{ placement: { kind: 'client' } }] }
+    })
+  })
+
   it('passes authenticated caller identity to client page creation outside the payload', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/shared/runtime-browser-contracts.ts
+++ b/src/shared/runtime-browser-contracts.ts
@@ -6,6 +6,7 @@ import type {
   BrowserSessionProfileSource
 } from './browser-workspace-types'
 import type { BROWSER_UNAVAILABLE_ERROR_CODE } from './runtime-session-contracts'
+import type { RuntimeBrowserPlacement } from './runtime-browser-placement'
 
 export type BrowserSnapshotRef = { ref: string; role: string; name: string }
 
@@ -60,10 +61,15 @@ export type BrowserTabInfo = {
   worktreeId?: string | null
   profileId?: string | null
   profileLabel?: string | null
+  placement?: RuntimeBrowserPlacement
 }
 
 export type BrowserTabListResult = { tabs: BrowserTabInfo[] }
-export type BrowserTabSwitchResult = { switched: number; browserPageId: string }
+export type BrowserTabSwitchResult = {
+  switched: number
+  browserPageId: string
+  placement?: RuntimeBrowserPlacement
+}
 
 export type BrowserTabSetProfileResult = {
   browserPageId: string


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​109 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​98 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​46 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 |

<!-- /orca-pr-loc -->

## ELI5

Remote-workspace browser tabs can run on either the Orca server or the paired desktop. The browser RPC now labels which side hosts each tab, so CLI agents can explain or wait for an unavailable client-hosted page instead of treating it like a broken server tab.

## What Changed

- Added an optional placement field to browser tab list, show, current, and switch results.
- Projected exact client placement for client-hosted pages and server placement for bridge-hosted pages.
- Updated CLI text output to distinguish server-hosted, client-hosted, and placement-unknown old-host responses.
- Applied the existing session-tab visibility gate to session.tabs.closeLifecycle.
- Added capable, incapable, and mixed-version unit coverage.

## Why

Option 2 from STA-5504 preserves the complete browser inventory that CLI-driven agents need for diagnosis and recovery. The field is optional, so older clients ignore it and newer clients treat an absent value from an older host as unknown rather than server-hosted.

## Linked Issue

[STA-5504](https://linear.app/stably/issue/STA-5504/gate-or-mark-client-hosted-pages-in-the-browsertablist-rpc-family)

Follow-up to #15448.

## Visual Proof

N/A — this changes the RPC contract and CLI text output, not rendered Orca UI.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Verified after rebasing onto efa3b972c2:

- Changed test files: 1,324 passed, 1 skipped
- pnpm tc
- pnpm run check:code-quality:changed
- git diff --check

Tested on macOS. The implementation is platform-neutral and the unit coverage includes capable, incapable, and old-host-shaped responses; CI will cover the remaining platforms and full suite.

## AI Disclosure

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows docs/reference/agent-skill-sharing-upstream-boundary.md and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No path, subprocess, Git, SSH execution, renderer, or performance behavior changed. Mixed client/host versions remain supported because placement is additive and optional.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] pnpm lint, pnpm typecheck, pnpm test, and pnpm build pass (or CI will cover; local preferred)
