### PR TITLE
refactor(codex): remove WSL runtime mirror machinery

### DIFF
--- a/src/main/agent-auth-restart-preservation.test.ts
+++ b/src/main/agent-auth-restart-preservation.test.ts
@@ -15,8 +15,7 @@ describe('preserveAgentAuthBeforeRestart', () => {
       codexRuntimeHome: {
         syncForCurrentSelection: vi.fn(() => {
           calls.push('codex')
-        }),
-        syncActiveWslSelectionsBeforeRestart: vi.fn()
+        })
       },
       claudeRuntimeAuth: {
         syncForCurrentSelection: vi.fn(async () => {
@@ -33,35 +32,13 @@ describe('preserveAgentAuthBeforeRestart', () => {
     expect(calls).toEqual(['codex', 'claude', 'flush'])
   })
 
-  it('runs WSL Codex preservation through the runtime service', async () => {
-    const syncForCurrentSelection = vi.fn()
-    const syncActiveWslSelectionsBeforeRestart = vi.fn()
-
-    await preserveAgentAuthBeforeRestart({
-      codexRuntimeHome: {
-        syncForCurrentSelection,
-        syncActiveWslSelectionsBeforeRestart
-      },
-      store: {
-        flushPendingOrThrowAsync: vi.fn()
-      }
-    })
-
-    expect(syncForCurrentSelection).toHaveBeenCalledTimes(1)
-    expect(syncForCurrentSelection).toHaveBeenNthCalledWith(1)
-    expect(syncActiveWslSelectionsBeforeRestart).toHaveBeenCalledTimes(1)
-  })
-
-  it('runs Claude preservation before WSL Codex preservation', async () => {
+  it('runs Claude preservation after Codex and before the store flush', async () => {
     const calls: string[] = []
 
     await preserveAgentAuthBeforeRestart({
       codexRuntimeHome: {
         syncForCurrentSelection: vi.fn(() => {
           calls.push('codex-host')
-        }),
-        syncActiveWslSelectionsBeforeRestart: vi.fn(() => {
-          calls.push('codex-wsl')
         })
       },
       claudeRuntimeAuth: {
@@ -76,27 +53,7 @@ describe('preserveAgentAuthBeforeRestart', () => {
       }
     })
 
-    expect(calls).toEqual(['codex-host', 'claude', 'codex-wsl', 'flush'])
-  })
-
-  it('continues after WSL Codex preservation fails', async () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
-    const flushPendingOrThrowAsync = vi.fn()
-
-    await preserveAgentAuthBeforeRestart({
-      codexRuntimeHome: {
-        syncForCurrentSelection: vi.fn(),
-        syncActiveWslSelectionsBeforeRestart: vi.fn(() => {
-          throw new Error('wsl-token-secret')
-        })
-      },
-      store: {
-        flushPendingOrThrowAsync
-      }
-    })
-
-    expect(flushPendingOrThrowAsync).toHaveBeenCalledTimes(1)
-    expect(JSON.stringify(warn.mock.calls)).not.toContain('token-secret')
+    expect(calls).toEqual(['codex-host', 'claude', 'flush'])
   })
 
   it('flushes the store when auth services are missing', async () => {
@@ -116,8 +73,7 @@ describe('preserveAgentAuthBeforeRestart', () => {
         codexRuntimeHome: {
           syncForCurrentSelection: vi.fn(() => {
             throw new Error('codex-token-secret')
-          }),
-          syncActiveWslSelectionsBeforeRestart: vi.fn()
+          })
         },
         claudeRuntimeAuth: {
           syncForCurrentSelection: vi.fn(async () => {

--- a/src/main/agent-auth-restart-preservation.test.ts
+++ b/src/main/agent-auth-restart-preservation.test.ts
@@ -56,6 +56,28 @@ describe('preserveAgentAuthBeforeRestart', () => {
     expect(calls).toEqual(['codex-host', 'claude', 'flush'])
   })
 
+  it('drains retained WSL Codex auth before flushing the store', async () => {
+    const calls: string[] = []
+
+    await preserveAgentAuthBeforeRestart({
+      codexRuntimeHome: {
+        syncForCurrentSelection: vi.fn(() => {
+          calls.push('codex-host')
+        }),
+        syncActiveWslSelectionsBeforeRestart: vi.fn(async () => {
+          calls.push('codex-wsl')
+        })
+      },
+      store: {
+        flushPendingOrThrowAsync: vi.fn(async () => {
+          calls.push('flush')
+        })
+      }
+    })
+
+    expect(calls).toEqual(['codex-host', 'codex-wsl', 'flush'])
+  })
+
   it('flushes the store when auth services are missing', async () => {
     const flushPendingOrThrowAsync = vi.fn()
 

--- a/src/main/agent-auth-restart-preservation.test.ts
+++ b/src/main/agent-auth-restart-preservation.test.ts
@@ -78,6 +78,58 @@ describe('preserveAgentAuthBeforeRestart', () => {
     expect(calls).toEqual(['codex-host', 'codex-wsl', 'flush'])
   })
 
+  it('does not release restart while the bounded WSL drain is still running', async () => {
+    vi.useFakeTimers()
+    let finishWslDrain!: () => void
+    let settled = false
+    const flushPendingOrThrowAsync = vi.fn()
+
+    const preservation = preserveAgentAuthBeforeRestart({
+      codexRuntimeHome: {
+        syncForCurrentSelection: vi.fn(),
+        syncActiveWslSelectionsBeforeRestart: vi.fn(
+          () =>
+            new Promise<void>((resolve) => {
+              finishWslDrain = resolve
+            })
+        )
+      },
+      store: { flushPendingOrThrowAsync }
+    }).then(() => {
+      settled = true
+    })
+
+    await vi.advanceTimersByTimeAsync(2_000)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(flushPendingOrThrowAsync).toHaveBeenCalledTimes(1)
+    expect(settled).toBe(false)
+
+    finishWslDrain()
+    await preservation
+    expect(settled).toBe(true)
+  })
+
+  it('continues after the bounded WSL drain fails without logging secrets', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const flushPendingOrThrowAsync = vi.fn()
+
+    await preserveAgentAuthBeforeRestart({
+      codexRuntimeHome: {
+        syncForCurrentSelection: vi.fn(),
+        syncActiveWslSelectionsBeforeRestart: vi.fn(async () => {
+          throw new Error('wsl-token-secret')
+        })
+      },
+      store: { flushPendingOrThrowAsync }
+    })
+
+    expect(flushPendingOrThrowAsync).toHaveBeenCalledTimes(1)
+    expect(warn).toHaveBeenCalledWith(
+      '[agent-auth-restart] Codex auth preservation failed (Error); continuing restart/update'
+    )
+    expect(JSON.stringify(warn.mock.calls)).not.toContain('token-secret')
+  })
+
   it('flushes the store when auth services are missing', async () => {
     const flushPendingOrThrowAsync = vi.fn()
 
@@ -146,6 +198,36 @@ describe('preserveAgentAuthBeforeRestart', () => {
     await Promise.resolve()
 
     expect(calls).toEqual(['claude-start', 'flush', 'claude-finish'])
+  })
+
+  it('gives store persistence its own timeout after auth preservation expires', async () => {
+    vi.useFakeTimers()
+    let finishStoreFlush!: () => void
+    let settled = false
+
+    const preservation = preserveAgentAuthBeforeRestart({
+      claudeRuntimeAuth: {
+        syncForCurrentSelection: vi.fn(() => new Promise<void>(() => {}))
+      },
+      store: {
+        flushPendingOrThrowAsync: vi.fn(
+          () =>
+            new Promise<void>((resolve) => {
+              finishStoreFlush = resolve
+            })
+        )
+      }
+    }).then(() => {
+      settled = true
+    })
+
+    await vi.advanceTimersByTimeAsync(2_000)
+    await vi.advanceTimersByTimeAsync(1)
+    expect(settled).toBe(false)
+
+    finishStoreFlush()
+    await preservation
+    expect(settled).toBe(true)
   })
 
   it('bounds a store flush that never settles', async () => {

--- a/src/main/agent-auth-restart-preservation.ts
+++ b/src/main/agent-auth-restart-preservation.ts
@@ -4,10 +4,7 @@ import type { Store } from './persistence'
 
 const AUTH_PRESERVATION_TIMEOUT_MS = 2_000
 
-type CodexRuntimeAuthSync = Pick<
-  CodexRuntimeHomeService,
-  'syncForCurrentSelection' | 'syncActiveWslSelectionsBeforeRestart'
->
+type CodexRuntimeAuthSync = Pick<CodexRuntimeHomeService, 'syncForCurrentSelection'>
 type ClaudeRuntimeAuthSync = Pick<ClaudeRuntimeAuthService, 'syncForCurrentSelection'>
 type ShutdownStore = Pick<Store, 'flushPendingOrThrowAsync'>
 
@@ -42,12 +39,6 @@ export async function preserveAgentAuthBeforeRestart({
     logStepTimeout('Claude auth preservation', 0)
   }
 
-  if (codexRuntimeHome && Date.now() - startedAt < AUTH_PRESERVATION_TIMEOUT_MS) {
-    runWslCodexPreservationStep(codexRuntimeHome)
-  } else if (codexRuntimeHome) {
-    logStepTimeout('Codex auth preservation', 0)
-  }
-
   if (store) {
     const storeRemainingMs = Math.max(0, AUTH_PRESERVATION_TIMEOUT_MS - (Date.now() - startedAt))
     await runWithinLifecycleTimeout(
@@ -61,16 +52,6 @@ export async function preserveAgentAuthBeforeRestart({
 function runCodexPreservationStep(codexRuntimeHome: CodexRuntimeAuthSync | null | undefined): void {
   try {
     codexRuntimeHome?.syncForCurrentSelection()
-  } catch (error) {
-    logStepFailure('Codex auth preservation', error)
-  }
-}
-
-function runWslCodexPreservationStep(
-  codexRuntimeHome: CodexRuntimeAuthSync | null | undefined
-): void {
-  try {
-    codexRuntimeHome?.syncActiveWslSelectionsBeforeRestart()
   } catch (error) {
     logStepFailure('Codex auth preservation', error)
   }

--- a/src/main/agent-auth-restart-preservation.ts
+++ b/src/main/agent-auth-restart-preservation.ts
@@ -4,7 +4,8 @@ import type { Store } from './persistence'
 
 const AUTH_PRESERVATION_TIMEOUT_MS = 2_000
 
-type CodexRuntimeAuthSync = Pick<CodexRuntimeHomeService, 'syncForCurrentSelection'>
+type CodexRuntimeAuthSync = Pick<CodexRuntimeHomeService, 'syncForCurrentSelection'> &
+  Partial<Pick<CodexRuntimeHomeService, 'syncActiveWslSelectionsBeforeRestart'>>
 type ClaudeRuntimeAuthSync = Pick<ClaudeRuntimeAuthService, 'syncForCurrentSelection'>
 type ShutdownStore = Pick<Store, 'flushPendingOrThrowAsync'>
 
@@ -37,6 +38,21 @@ export async function preserveAgentAuthBeforeRestart({
     )
   } else if (claudeRuntimeAuth) {
     logStepTimeout('Claude auth preservation', 0)
+  }
+
+  const syncActiveWslSelectionsBeforeRestart =
+    codexRuntimeHome?.syncActiveWslSelectionsBeforeRestart
+  if (
+    syncActiveWslSelectionsBeforeRestart &&
+    Date.now() - startedAt < AUTH_PRESERVATION_TIMEOUT_MS
+  ) {
+    await runWithinLifecycleTimeout(
+      'Codex auth preservation',
+      () => syncActiveWslSelectionsBeforeRestart.call(codexRuntimeHome),
+      Math.max(0, AUTH_PRESERVATION_TIMEOUT_MS - (Date.now() - startedAt))
+    )
+  } else if (syncActiveWslSelectionsBeforeRestart) {
+    logStepTimeout('Codex auth preservation', 0)
   }
 
   if (store) {

--- a/src/main/agent-auth-restart-preservation.ts
+++ b/src/main/agent-auth-restart-preservation.ts
@@ -25,49 +25,41 @@ export async function preserveAgentAuthBeforeRestart({
   claudeRuntimeAuth,
   store
 }: AgentAuthRestartPreservationOptions): Promise<void> {
-  const startedAt = Date.now()
-
   runCodexPreservationStep(codexRuntimeHome)
+  // Why: the drain owns guest-process timeouts; a shared 2s cutoff can relaunch before promotion.
+  const wslCodexPreservation = runWslCodexPreservationStep(codexRuntimeHome)
 
-  const remainingMs = Math.max(0, AUTH_PRESERVATION_TIMEOUT_MS - (Date.now() - startedAt))
-  if (claudeRuntimeAuth && remainingMs > 0) {
+  if (claudeRuntimeAuth) {
     await runWithinLifecycleTimeout(
       'Claude auth preservation',
       () => claudeRuntimeAuth.syncForCurrentSelection(),
-      remainingMs
+      AUTH_PRESERVATION_TIMEOUT_MS
     )
-  } else if (claudeRuntimeAuth) {
-    logStepTimeout('Claude auth preservation', 0)
   }
 
-  const syncActiveWslSelectionsBeforeRestart =
-    codexRuntimeHome?.syncActiveWslSelectionsBeforeRestart
-  if (
-    syncActiveWslSelectionsBeforeRestart &&
-    Date.now() - startedAt < AUTH_PRESERVATION_TIMEOUT_MS
-  ) {
-    await runWithinLifecycleTimeout(
-      'Codex auth preservation',
-      () => syncActiveWslSelectionsBeforeRestart.call(codexRuntimeHome),
-      Math.max(0, AUTH_PRESERVATION_TIMEOUT_MS - (Date.now() - startedAt))
-    )
-  } else if (syncActiveWslSelectionsBeforeRestart) {
-    logStepTimeout('Codex auth preservation', 0)
-  }
-
-  if (store) {
-    const storeRemainingMs = Math.max(0, AUTH_PRESERVATION_TIMEOUT_MS - (Date.now() - startedAt))
-    await runWithinLifecycleTimeout(
-      'Store persistence',
-      () => store.flushPendingOrThrowAsync(),
-      storeRemainingMs
-    )
-  }
+  const storePreservation = store
+    ? runWithinLifecycleTimeout(
+        'Store persistence',
+        () => store.flushPendingOrThrowAsync(),
+        AUTH_PRESERVATION_TIMEOUT_MS
+      )
+    : Promise.resolve()
+  await Promise.all([wslCodexPreservation, storePreservation])
 }
 
 function runCodexPreservationStep(codexRuntimeHome: CodexRuntimeAuthSync | null | undefined): void {
   try {
     codexRuntimeHome?.syncForCurrentSelection()
+  } catch (error) {
+    logStepFailure('Codex auth preservation', error)
+  }
+}
+
+async function runWslCodexPreservationStep(
+  codexRuntimeHome: CodexRuntimeAuthSync | null | undefined
+): Promise<void> {
+  try {
+    await codexRuntimeHome?.syncActiveWslSelectionsBeforeRestart?.()
   } catch (error) {
     logStepFailure('Codex auth preservation', error)
   }
@@ -86,7 +78,7 @@ async function runWithinLifecycleTimeout(
     })
 
   // Why: this timeout only releases the restart/update path. It does not
-  // cancel a sync that already started, and Codex sync is synchronous today.
+  // cancel a sync that already started.
   const timeoutResult = new Promise<'timeout'>((resolve) => {
     timeout = setTimeout(() => resolve('timeout'), timeoutMs)
   })

--- a/src/main/codex-accounts/legacy-wsl-runtime-auth-drain.ts
+++ b/src/main/codex-accounts/legacy-wsl-runtime-auth-drain.ts
@@ -31,16 +31,19 @@ type LegacyWslRuntimeAuthDrainOptions = {
 const drainQueueByDistro = new Map<string, Promise<void>>()
 const completedDistroKeys = new Set<string>()
 
-export function startLegacyWslRuntimeAuthDrain(options: LegacyWslRuntimeAuthDrainOptions): void {
+export function startLegacyWslRuntimeAuthDrain(
+  options: LegacyWslRuntimeAuthDrainOptions
+): Promise<void> {
   const key = options.distro.trim().toLowerCase()
   if (completedDistroKeys.has(key)) {
-    return
+    return Promise.resolve()
   }
   // Coalesce launch/rate-limit callers while a drain is in flight. Queuing a
   // new pass for every poll can otherwise build an unbounded promise chain
   // while a legacy pane keeps the migration pending.
-  if (drainQueueByDistro.has(key)) {
-    return
+  const inFlight = drainQueueByDistro.get(key)
+  if (inFlight) {
+    return inFlight
   }
   const next = drainLegacyWslRuntimeAuth(options)
     .then((status) => {
@@ -57,6 +60,7 @@ export function startLegacyWslRuntimeAuthDrain(options: LegacyWslRuntimeAuthDrai
       drainQueueByDistro.delete(key)
     }
   })
+  return next
 }
 
 export async function drainLegacyWslRuntimeAuth(

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -56,6 +56,7 @@ import { syncSystemConfigIntoManagedCodexHome } from '../codex/codex-config-mirr
 import { parseWslUncPath, toLinuxPath } from '../../shared/wsl-paths'
 import {
   getCodexSelectionLaneKey,
+  getWslSelectionKey,
   getSelectedCodexAccountIdForTarget,
   normalizeCodexRuntimeSelection,
   type CodexAccountSelectionTarget
@@ -996,33 +997,61 @@ export class CodexRuntimeHomeService {
     return this.getWslSystemCodexHomePath(target)
   }
 
-  private startLegacyWslAuthDrain(target: CodexAccountSelectionTarget): void {
+  private startLegacyWslAuthDrain(target: CodexAccountSelectionTarget): Promise<void> {
     if (process.platform !== 'win32') {
-      return
+      return Promise.resolve()
     }
     const distro = target.wslDistro?.trim() || getDefaultWslDistro()
     if (!distro) {
-      return
+      return Promise.resolve()
     }
     const guestHome = getWslHome(distro)
     const parsedGuestHome = guestHome ? parseWslUncPath(guestHome) : null
     if (!parsedGuestHome) {
-      return
+      return Promise.resolve()
     }
     let legacyPanePresent: boolean
     try {
       legacyPanePresent = hasRecordedLegacyWslCodexPane(getCodexSelectionLaneKey(target))
     } catch (error) {
       console.warn('[codex-wsl-auth-drain] Pane registry unavailable; deferring drain:', error)
-      return
+      return Promise.resolve()
     }
-    startLegacyWslRuntimeAuthDrain({
+    return startLegacyWslRuntimeAuthDrain({
       distro,
       guestHomeLinuxPath: parsedGuestHome.linuxPath,
       legacyPanePresent,
       resolveDestination: (runtimeAuthContents) =>
         this.resolveLegacyWslAuthDestination(distro, runtimeAuthContents)
     })
+  }
+
+  /** Preserve refreshed auth from retained legacy WSL panes before restart. */
+  async syncActiveWslSelectionsBeforeRestart(): Promise<void> {
+    if (process.platform !== 'win32') {
+      return
+    }
+    const settings = this.store.getSettings()
+    const drains: Promise<void>[] = []
+    for (const [selectedDistroKey, accountId] of Object.entries(
+      normalizeCodexRuntimeSelection(settings).wsl
+    )) {
+      if (!accountId) {
+        continue
+      }
+      const account = this.getActiveAccount(settings.codexManagedAccounts, accountId)
+      if (!account || account.managedHomeRuntime !== 'wsl') {
+        continue
+      }
+      const distro =
+        selectedDistroKey === getWslSelectionKey(null)
+          ? account.wslDistro?.trim() || null
+          : selectedDistroKey.trim() || null
+      if (distro) {
+        drains.push(this.startLegacyWslAuthDrain({ runtime: 'wsl', wslDistro: distro }))
+      }
+    }
+    await Promise.all(drains)
   }
 
   private async resolveLegacyWslAuthDestination(

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -1,5 +1,4 @@
 /* eslint-disable max-lines -- Why: keeps Codex's whole runtime-home contract in one place so account-switch semantics don't drift across launch/login/quota paths. */
-import { quotePosixShell } from '../../shared/wsl-login-shell-command'
 import {
   appendFileSync,
   copyFileSync,
@@ -18,7 +17,6 @@ import {
   unlinkSync
 } from 'node:fs'
 import { isDefinitiveAbsence } from '../../shared/definitive-filesystem-absence'
-import { execFileSync } from 'node:child_process'
 import {
   dirname,
   extname,
@@ -33,7 +31,6 @@ import { app } from 'electron'
 import type { CodexManagedAccount } from '../../shared/managed-account-types'
 import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
 import type { Store } from '../persistence'
-import { WSL_CODEX_RUNTIME_HOME_SEGMENTS } from '../pty/codex-home-wsl-env'
 import {
   recoverInterruptedGuardedFileOperation,
   removeFileAtomicallyIfUnchanged,
@@ -55,17 +52,12 @@ import {
   resolveWslCodexSessionSourceHome
 } from '../codex/codex-session-source-home'
 import { startWslCodexSessionBridgeInBackground } from '../codex/wsl-codex-session-bridge'
-import {
-  prepareSystemConfigForFreshRuntimeMirror,
-  syncSystemConfigIntoManagedCodexHome
-} from '../codex/codex-config-mirror'
+import { syncSystemConfigIntoManagedCodexHome } from '../codex/codex-config-mirror'
 import { parseWslUncPath, toLinuxPath } from '../../shared/wsl-paths'
 import {
   getCodexSelectionLaneKey,
-  getWslSelectionKey,
   getSelectedCodexAccountIdForTarget,
   normalizeCodexRuntimeSelection,
-  setSelectedCodexAccountIdForTarget,
   type CodexAccountSelectionTarget
 } from './runtime-selection'
 import { getDefaultWslDistro, getWslHome } from '../wsl'
@@ -137,7 +129,6 @@ type CodexRuntimeLogoutMarkerStatus =
   | { kind: 'applies' }
   | { kind: 'system-default-changed'; systemDefaultAuthJson: string | null }
 
-type CodexReadBackResult = 'unchanged' | 'persisted' | 'rejected'
 type CodexReadBackMatch =
   | {
       kind: 'matched'
@@ -202,11 +193,6 @@ export class CodexRuntimeHomeService {
   private lastSyncedAccountId: string | null = null
   // Last auth.json Orca wrote to the runtime home; a later diff signals an out-of-band change (Codex token refresh, or external login to adopt).
   private lastWrittenAuthJson: string | null = null
-  // Why: WSL terminals have per-distro runtime homes; sharing the host baseline can make stale WSL auth look newer than managed storage.
-  private readonly lastWrittenWslAuthJsonByDistro = new Map<string, string | null>()
-  private readonly lastSyncedWslAccountIdByDistro = new Map<string, string | null>()
-  private readonly wslRuntimeHomePathByDistro = new Map<string, string>()
-  private skipNextReadBackForAccountId: string | null = null
   // Why: a managed host account refreshes auth in its own home. Remember that
   // provenance so a later deselect never adopts stale shared bytes.
   private lastHostAccountUsedSelfContainedHome = false
@@ -731,26 +717,6 @@ export class CodexRuntimeHomeService {
     syncLegacySharedCodexConfigForRetainedPanes()
   }
 
-  syncActiveWslSelectionsBeforeRestart(): void {
-    if (process.platform !== 'win32') {
-      return
-    }
-
-    const settings = this.store.getSettings()
-    for (const [selectedDistroKey, accountId] of Object.entries(
-      normalizeCodexRuntimeSelection(settings).wsl
-    )) {
-      if (!accountId) {
-        continue
-      }
-      const account = this.getActiveAccount(settings.codexManagedAccounts, accountId)
-      if (!account || account.managedHomeRuntime !== 'wsl') {
-        continue
-      }
-      this.safeReadBackActiveWslAccountBeforeRestart(account, selectedDistroKey)
-    }
-  }
-
   private getWslSystemCodexHomePath(target: CodexAccountSelectionTarget): string | null {
     if (process.platform !== 'win32') {
       return null
@@ -886,7 +852,6 @@ export class CodexRuntimeHomeService {
       // distro-local runtime home, so the host mirror only drops its baseline.
       this.lastSyncedAccountId = null
       this.lastWrittenAuthJson = null
-      this.skipNextReadBackForAccountId = null
       return
     }
     if (normalizeCodexRuntimeSelection(settings).host) {
@@ -928,70 +893,12 @@ export class CodexRuntimeHomeService {
     }
   }
 
-  // Why: re-auth/add-account write fresh managed tokens, so skip the next read-back to avoid clobbering them with stale runtime tokens.
+  // Why: re-auth/add-account writes fresh host tokens, invalidating the shared mirror baseline.
   clearLastWrittenAuthJson(
     accountId = normalizeCodexRuntimeSelection(this.store.getSettings()).host
   ): void {
     if (accountId === normalizeCodexRuntimeSelection(this.store.getSettings()).host) {
       this.lastWrittenAuthJson = null
-    }
-    this.skipNextReadBackForAccountId = accountId
-  }
-
-  private readBackRefreshedTokensFromPath(
-    runtimeAuthPath: string,
-    options: {
-      updateLastWrittenAuthJson: boolean
-      lastWrittenAuthJson?: string | null
-      setLastWrittenAuthJson?: (contents: string) => void
-      expectedAccountId?: string
-    }
-  ): CodexReadBackResult {
-    try {
-      if (!existsSync(runtimeAuthPath)) {
-        return 'unchanged'
-      }
-
-      const lastWrittenAuthJson =
-        options.lastWrittenAuthJson === undefined
-          ? this.lastWrittenAuthJson
-          : options.lastWrittenAuthJson
-      const runtimeContents = readFileSync(runtimeAuthPath, 'utf-8')
-      if (lastWrittenAuthJson !== null && runtimeContents === lastWrittenAuthJson) {
-        return 'unchanged'
-      }
-
-      const match = this.findManagedAccountForRuntimeAuth(
-        runtimeContents,
-        options.expectedAccountId
-      )
-      if (match.kind !== 'matched') {
-        if (match.kind === 'ambiguous') {
-          console.warn('[codex-runtime-home] Refusing ambiguous Codex auth read-back')
-        }
-        return 'rejected'
-      }
-      // Why: after restart there's no last-written baseline, so identity alone can't prove runtime auth is newer than managed storage.
-      if (
-        lastWrittenAuthJson === null &&
-        !this.runtimeAuthIsFresher(runtimeContents, match.managedAuthContents)
-      ) {
-        return 'rejected'
-      }
-
-      writeFileAtomically(match.managedAuthPath, runtimeContents, { mode: 0o600 })
-      if (options.updateLastWrittenAuthJson) {
-        if (options.setLastWrittenAuthJson) {
-          options.setLastWrittenAuthJson(runtimeContents)
-        } else {
-          this.lastWrittenAuthJson = runtimeContents
-        }
-      }
-      return 'persisted'
-    } catch (error) {
-      // Why: read-back is best-effort; a transient fs error must not block the forward sync — worst case is one more stale-token cycle.
-      console.warn('[codex-runtime-home] Failed to read back refreshed tokens:', error)
-      return 'rejected'
     }
   }
 
@@ -1057,7 +964,6 @@ export class CodexRuntimeHomeService {
   }
 
   private getPreparedWslRateLimitHomePath(target: CodexAccountSelectionTarget): string | null {
-    this.startLegacyWslAuthDrain(target)
     return this.getWslCodexHomePathForSelection(target)
   }
 
@@ -1178,204 +1084,6 @@ export class CodexRuntimeHomeService {
       : null
   }
 
-  syncWslRuntimeForCurrentSelection(target: CodexAccountSelectionTarget): string | null {
-    if (process.platform !== 'win32') {
-      return null
-    }
-
-    const wslTarget = this.resolveWslDefaultTarget(target)
-    const settings = this.store.getSettings()
-    const activeAccount = this.getActiveAccount(
-      settings.codexManagedAccounts,
-      getSelectedCodexAccountIdForTarget(settings, wslTarget)
-    )
-    const distro = wslTarget.wslDistro?.trim() || activeAccount?.wslDistro || getDefaultWslDistro()
-    if (!distro) {
-      return null
-    }
-
-    const runtimeHomePath = this.getWslRuntimeHomePath(distro)
-    if (!runtimeHomePath) {
-      return null
-    }
-    this.wslRuntimeHomePathByDistro.set(distro, runtimeHomePath)
-
-    mkdirSync(runtimeHomePath, { recursive: true })
-    this.safeMigrateLegacyWslActiveHomePointer(distro, runtimeHomePath)
-    this.seedWslRuntimeHome(runtimeHomePath, activeAccount, distro)
-
-    const runtimeAuthPath = join(runtimeHomePath, 'auth.json')
-    const previousWslAccountId = this.lastSyncedWslAccountIdByDistro.get(distro) ?? null
-    if (previousWslAccountId) {
-      if (this.skipNextReadBackForAccountId === previousWslAccountId) {
-        this.skipNextReadBackForAccountId = null
-      } else {
-        const previousWslAccount = this.getActiveAccount(
-          settings.codexManagedAccounts,
-          previousWslAccountId
-        )
-        if (previousWslAccount) {
-          this.readBackRefreshedTokensFromPath(runtimeAuthPath, {
-            updateLastWrittenAuthJson: true,
-            lastWrittenAuthJson: this.lastWrittenWslAuthJsonByDistro.get(distro) ?? null,
-            setLastWrittenAuthJson: (contents) => {
-              this.lastWrittenWslAuthJsonByDistro.set(distro, contents)
-            },
-            expectedAccountId: previousWslAccount.id
-          })
-        }
-      }
-    }
-
-    const activeAuthPath = activeAccount ? join(activeAccount.managedHomePath, 'auth.json') : null
-    if (activeAccount && activeAuthPath && existsSync(activeAuthPath)) {
-      const activeAuth = readFileSync(activeAuthPath, 'utf-8')
-      this.writeRuntimeAuthAtPath(runtimeAuthPath, activeAuth)
-      this.lastWrittenWslAuthJsonByDistro.set(distro, activeAuth)
-      this.lastSyncedWslAccountIdByDistro.set(distro, activeAccount.id)
-      return runtimeHomePath
-    }
-    if (activeAccount && activeAuthPath) {
-      console.warn(
-        '[codex-runtime-home] Active WSL managed account is missing auth.json, restoring system default'
-      )
-      this.store.updateSettings({
-        activeCodexManagedAccountId: settings.activeCodexManagedAccountId,
-        activeCodexManagedAccountIdsByRuntime: setSelectedCodexAccountIdForTarget(
-          normalizeCodexRuntimeSelection(settings),
-          null,
-          wslTarget
-        )
-      })
-    }
-
-    const systemAuthPath = this.getWslSystemCodexAuthPath({ runtime: 'wsl', wslDistro: distro })
-    if (systemAuthPath && existsSync(systemAuthPath)) {
-      const systemAuth = readFileSync(systemAuthPath, 'utf-8')
-      const mirroredSystemDefaultAuth = this.lastWrittenWslAuthJsonByDistro.get(distro) ?? null
-      const runtimeAuth = existsSync(runtimeAuthPath)
-        ? readFileSync(runtimeAuthPath, 'utf-8')
-        : null
-      if (
-        runtimeAuth !== null &&
-        runtimeAuth !== systemAuth &&
-        this.runtimeAuthMatchesSystemDefaultIdentity(runtimeAuth, systemAuth) &&
-        ((mirroredSystemDefaultAuth !== null && systemAuth === mirroredSystemDefaultAuth) ||
-          (mirroredSystemDefaultAuth === null &&
-            this.runtimeAuthIsFresher(runtimeAuth, systemAuth)))
-      ) {
-        // Why: WSL baselines are lost on restart, so a same-identity fresher runtime auth is a token refresh; copy it back before mirroring ~/.codex.
-        this.writeRuntimeAuthAtPath(systemAuthPath, runtimeAuth)
-        this.lastWrittenWslAuthJsonByDistro.set(distro, runtimeAuth)
-        this.lastSyncedWslAccountIdByDistro.set(distro, null)
-        return runtimeHomePath
-      }
-      this.writeRuntimeAuthAtPath(runtimeAuthPath, systemAuth)
-      this.lastWrittenWslAuthJsonByDistro.set(distro, systemAuth)
-      this.lastSyncedWslAccountIdByDistro.set(distro, null)
-      return runtimeHomePath
-    }
-
-    rmSync(runtimeAuthPath, { force: true })
-    this.lastWrittenWslAuthJsonByDistro.set(distro, null)
-    this.lastSyncedWslAccountIdByDistro.set(distro, null)
-    return runtimeHomePath
-  }
-
-  private getWslRuntimeHomePath(distro: string): string | null {
-    const home = getWslHome(distro)
-    return home ? this.joinWslPath(home, ...WSL_CODEX_RUNTIME_HOME_SEGMENTS) : null
-  }
-
-  private safeReadBackActiveWslAccountBeforeRestart(
-    account: CodexManagedAccount,
-    selectedDistroKey: string
-  ): void {
-    try {
-      this.readBackActiveWslAccountBeforeRestart(account, selectedDistroKey)
-    } catch (error) {
-      console.warn('[codex-runtime-home] Failed to preserve WSL Codex auth before restart:', error)
-    }
-  }
-
-  private readBackActiveWslAccountBeforeRestart(
-    account: CodexManagedAccount,
-    selectedDistroKey: string
-  ): void {
-    const distro =
-      selectedDistroKey === getWslSelectionKey(null)
-        ? account.wslDistro?.trim()
-        : selectedDistroKey.trim() || account.wslDistro?.trim()
-    if (!distro) {
-      return
-    }
-
-    const runtimeHomePath = this.wslRuntimeHomePathByDistro.get(distro)
-    if (!runtimeHomePath) {
-      return
-    }
-
-    this.readBackRefreshedTokensFromPath(join(runtimeHomePath, 'auth.json'), {
-      updateLastWrittenAuthJson: true,
-      lastWrittenAuthJson: this.lastWrittenWslAuthJsonByDistro.get(distro) ?? null,
-      setLastWrittenAuthJson: (contents) => {
-        this.lastWrittenWslAuthJsonByDistro.set(distro, contents)
-      },
-      expectedAccountId: account.id
-    })
-  }
-
-  private safeMigrateLegacyWslActiveHomePointer(distro: string, runtimeHomePath: string): void {
-    try {
-      this.migrateLegacyWslActiveHomePointer(distro, runtimeHomePath)
-    } catch (error) {
-      console.warn('[codex-runtime-home] Failed to migrate legacy WSL active Codex home:', error)
-    }
-  }
-
-  private migrateLegacyWslActiveHomePointer(distro: string, runtimeHomePath: string): void {
-    const runtimeWsl = parseWslUncPath(runtimeHomePath)
-    if (!runtimeWsl?.linuxPath.endsWith('/codex-runtime-home/home')) {
-      return
-    }
-    const activeLinuxPath = runtimeWsl.linuxPath.replace(
-      /\/codex-runtime-home\/home$/,
-      '/codex-runtime-home/active/wsl/home'
-    )
-    const nextLinuxPath = `${activeLinuxPath}.next-${process.pid}-${Date.now()}`
-    const activeLinuxParentPath = this.dirnameLinuxPath(activeLinuxPath)
-    // Why: login-shell cleanup turns `exit 0` into status 1, so fall through.
-    execFileSync(
-      'wsl.exe',
-      [
-        '-d',
-        distro,
-        '--exec',
-        'bash',
-        '-lc',
-        [
-          'set -e',
-          `if [ ! -e ${quotePosixShell(activeLinuxPath)} ] && [ ! -L ${quotePosixShell(activeLinuxPath)} ]; then :`,
-          `elif [ -e ${quotePosixShell(activeLinuxPath)} ] && [ ! -L ${quotePosixShell(activeLinuxPath)} ]; then :`,
-          'else',
-          `mkdir -p ${quotePosixShell(activeLinuxParentPath)}`,
-          `rm -rf -- ${quotePosixShell(nextLinuxPath)}`,
-          `ln -s -- ${quotePosixShell(runtimeWsl.linuxPath)} ${quotePosixShell(nextLinuxPath)}`,
-          `mv -Tf -- ${quotePosixShell(nextLinuxPath)} ${quotePosixShell(activeLinuxPath)}`,
-          'fi'
-        ].join('\n')
-      ],
-      // wsl.exe is console-subsystem: without this a GUI-launched Orca flashes
-      // a conhost and steals foreground for up to the timeout (#10488).
-      { stdio: ['ignore', 'pipe', 'pipe'], timeout: 5000, windowsHide: true }
-    )
-  }
-
-  private dirnameLinuxPath(value: string): string {
-    const index = value.lastIndexOf('/')
-    return index > 0 ? value.slice(0, index) : '/'
-  }
-
   private joinWslPath(basePath: string, ...segments: string[]): string {
     return parseWslUncPath(basePath)
       ? pathWin32.join(basePath, ...segments)
@@ -1390,37 +1098,6 @@ export class CodexRuntimeHomeService {
     }
     const defaultDistro = getDefaultWslDistro()
     return defaultDistro ? { runtime: 'wsl', wslDistro: defaultDistro } : target
-  }
-
-  private getWslSystemCodexAuthPath(target: CodexAccountSelectionTarget): string | null {
-    const home = this.getWslSystemCodexHomePath(target)
-    return home ? this.joinWslPath(home, 'auth.json') : null
-  }
-
-  private seedWslRuntimeHome(
-    runtimeHomePath: string,
-    activeAccount: CodexManagedAccount | null,
-    distro: string
-  ): void {
-    const runtimeConfigPath = join(runtimeHomePath, 'config.toml')
-    if (existsSync(runtimeConfigPath)) {
-      return
-    }
-
-    const candidateHomes = [
-      activeAccount?.managedHomePath,
-      this.getWslSystemCodexHomePath({ runtime: 'wsl', wslDistro: distro })
-    ].filter((value): value is string => Boolean(value))
-    for (const homePath of candidateHomes) {
-      const configPath = join(homePath, 'config.toml')
-      if (existsSync(configPath)) {
-        writeFileAtomically(
-          runtimeConfigPath,
-          prepareWslRuntimeSeedConfig(readFileSync(configPath, 'utf-8'), homePath)
-        )
-        return
-      }
-    }
   }
 
   private findManagedAccountForRuntimeAuth(
@@ -1497,10 +1174,6 @@ export class CodexRuntimeHomeService {
     systemDefaultAuthContents: string
   ): boolean {
     return codexAuthMatchesSystemDefaultIdentity(runtimeAuthContents, systemDefaultAuthContents)
-  }
-
-  private runtimeAuthIsFresher(runtimeAuthContents: string, managedAuthContents: string): boolean {
-    return codexAuthIsFresher(runtimeAuthContents, managedAuthContents)
   }
 
   private safeMigrateLegacySharedAuth(): void {
@@ -2209,15 +1882,6 @@ export class CodexRuntimeHomeService {
     return true
   }
 
-  private writeRuntimeAuthAtPath(authPath: string, contents: string): void {
-    if (this.fileContentsEqual(authPath, contents)) {
-      this.ensureOwnerOnlyMode(authPath)
-      return
-    }
-    mkdirSync(dirname(authPath), { recursive: true })
-    writeFileAtomically(authPath, contents, { mode: 0o600 })
-  }
-
   /**
    * `true`/`false` only when the bytes were actually read; `null` when the file
    * could not be read at all. The old `catch { return false }` reported "these
@@ -2523,15 +2187,4 @@ export class CodexRuntimeHomeService {
   clearSystemDefaultSnapshot(): void {
     rmSync(this.getSystemDefaultSnapshotPath(), { force: true })
   }
-}
-
-// Why: Codex reads this config inside WSL, so relative path settings must anchor to the Linux-side home (verbatim copy breaks load, os error 2).
-export function prepareWslRuntimeSeedConfig(
-  configContents: string,
-  sourceHomePath: string
-): string {
-  return prepareSystemConfigForFreshRuntimeMirror(
-    configContents,
-    parseWslUncPath(sourceHomePath)?.linuxPath ?? sourceHomePath
-  )
 }

--- a/src/main/codex-accounts/runtime-home-wsl-managed-accounts.test.ts
+++ b/src/main/codex-accounts/runtime-home-wsl-managed-accounts.test.ts
@@ -229,25 +229,6 @@ describe('CodexRuntimeHomeService', () => {
     }
   })
 
-  it('anchors WSL seed rewrites to the Linux-side home parsed from the UNC source', async () => {
-    const { prepareWslRuntimeSeedConfig } = await import('./runtime-home-service')
-
-    // Why: real UNC sources cannot back live fs operations in tests, so pin
-    // the UNC -> Linux-side anchor translation on the extracted seed function.
-    expect(
-      prepareWslRuntimeSeedConfig(
-        'model_instructions_file = "instructions.md"\n',
-        '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.codex'
-      )
-    ).toContain("model_instructions_file = '/home/alice/.codex/instructions.md'")
-    expect(
-      prepareWslRuntimeSeedConfig(
-        'model_instructions_file = "instructions.md"\n',
-        '\\\\wsl$\\Ubuntu\\home\\alice\\.codex'
-      )
-    ).toContain("model_instructions_file = '/home/alice/.codex/instructions.md'")
-  })
-
   it('switches WSL accounts by selecting each account home directly', async () => {
     const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
@@ -328,7 +309,7 @@ describe('CodexRuntimeHomeService', () => {
     }
   })
 
-  it('does not use host auth baseline to accept stale WSL runtime auth', async () => {
+  it('ignores stale retired runtime auth when launching a managed WSL account', async () => {
     const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
     const wslHome = join(testState.userDataDir, 'wsl-home')
@@ -336,7 +317,6 @@ describe('CodexRuntimeHomeService', () => {
       getDefaultWslDistro: () => 'Ubuntu',
       getWslHome: () => wslHome
     }))
-    const hostAuth = createCodexAuthJson('host@example.com', 'acct-host', 'host-token')
     const wslManagedAuth = createCodexAuthJson(
       'wsl@example.com',
       'acct-wsl',
@@ -349,7 +329,6 @@ describe('CodexRuntimeHomeService', () => {
       'runtime-stale',
       1_000
     )
-    const hostManagedHomePath = createManagedAuth(testState.userDataDir, 'host-account', hostAuth)
     const wslManagedHomePath = createManagedAuth(
       testState.userDataDir,
       'wsl-account',
@@ -369,17 +348,6 @@ describe('CodexRuntimeHomeService', () => {
       createSettings({
         codexManagedAccounts: [
           {
-            id: 'host-account',
-            email: 'host@example.com',
-            managedHomePath: hostManagedHomePath,
-            providerAccountId: 'acct-host',
-            workspaceLabel: null,
-            workspaceAccountId: 'acct-host',
-            createdAt: 1,
-            updatedAt: 1,
-            lastAuthenticatedAt: 1
-          },
-          {
             id: 'wsl-account',
             email: 'wsl@example.com',
             managedHomePath: wslManagedHomePath,
@@ -389,14 +357,13 @@ describe('CodexRuntimeHomeService', () => {
             providerAccountId: 'acct-wsl',
             workspaceLabel: null,
             workspaceAccountId: 'acct-wsl',
-            createdAt: 2,
-            updatedAt: 2,
-            lastAuthenticatedAt: 2
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1
           }
         ],
-        activeCodexManagedAccountId: 'host-account',
         activeCodexManagedAccountIdsByRuntime: {
-          host: 'host-account',
+          host: null,
           wsl: { Ubuntu: 'wsl-account' }
         }
       })
@@ -411,145 +378,6 @@ describe('CodexRuntimeHomeService', () => {
       )
       expect(readFileSync(join(wslManagedHomePath, 'auth.json'), 'utf-8')).toBe(wslManagedAuth)
       expect(readFileSync(join(wslRuntimeHomePath, 'auth.json'), 'utf-8')).toBe(staleWslRuntimeAuth)
-    } finally {
-      if (originalPlatform) {
-        Object.defineProperty(process, 'platform', originalPlatform)
-      }
-    }
-  })
-
-  it('does not clobber fresh WSL tokens after clearLastWrittenAuthJson', async () => {
-    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
-    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
-    const wslHome = join(testState.userDataDir, 'wsl-home')
-    vi.doMock('../wsl', () => ({
-      getDefaultWslDistro: () => 'Ubuntu',
-      getWslHome: () => wslHome
-    }))
-    const target = { runtime: 'wsl' as const, wslDistro: 'Ubuntu' }
-    const originalAuth = createCodexAuthJson('wsl@example.com', 'acct-wsl', 'original', 1_000)
-    const staleRuntimeAuth = createCodexAuthJson('wsl@example.com', 'acct-wsl', 'stale', 1_500)
-    const reauthedAuth = createCodexAuthJson('wsl@example.com', 'acct-wsl', 'reauthed', 2_000)
-    const managedHomePath = createManagedAuth(testState.userDataDir, 'account-1', originalAuth)
-    const managedAuthPath = join(managedHomePath, 'auth.json')
-    const wslRuntimeHomePath = join(
-      wslHome,
-      '.local',
-      'share',
-      'orca',
-      'codex-runtime-home',
-      'home'
-    )
-    const runtimeAuthPath = join(wslRuntimeHomePath, 'auth.json')
-    const store = createStore(
-      createSettings({
-        codexManagedAccounts: [
-          {
-            id: 'account-1',
-            email: 'wsl@example.com',
-            managedHomePath,
-            managedHomeRuntime: 'wsl',
-            wslDistro: 'Ubuntu',
-            wslLinuxHomePath: '/home/alice/.local/share/orca/codex-accounts/account-1/home',
-            providerAccountId: 'acct-wsl',
-            workspaceLabel: null,
-            workspaceAccountId: 'acct-wsl',
-            createdAt: 1,
-            updatedAt: 1,
-            lastAuthenticatedAt: 1
-          }
-        ],
-        activeCodexManagedAccountIdsByRuntime: {
-          host: null,
-          wsl: { Ubuntu: 'account-1' }
-        }
-      })
-    )
-
-    try {
-      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
-      const service = new CodexRuntimeHomeService(store as never)
-
-      expect(service.prepareForCodexLaunch(target)).toBe(managedHomePath)
-      mkdirSync(wslRuntimeHomePath, { recursive: true })
-      writeFileSync(runtimeAuthPath, staleRuntimeAuth, 'utf-8')
-      writeFileSync(managedAuthPath, reauthedAuth, 'utf-8')
-
-      service.clearLastWrittenAuthJson('account-1')
-      service.syncForCurrentSelection(target)
-
-      expect(readFileSync(managedAuthPath, 'utf-8')).toBe(reauthedAuth)
-      expect(readFileSync(runtimeAuthPath, 'utf-8')).toBe(staleRuntimeAuth)
-    } finally {
-      if (originalPlatform) {
-        Object.defineProperty(process, 'platform', originalPlatform)
-      }
-    }
-  })
-
-  it('keeps direct-home WSL token refreshes canonical across restart preservation', async () => {
-    const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
-    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
-    const wslHome = join(testState.userDataDir, 'wsl-home')
-    vi.doMock('../wsl', () => ({
-      getDefaultWslDistro: () => 'Ubuntu',
-      getWslHome: () => wslHome
-    }))
-    const managedAuth = createCodexAuthJson('wsl@example.com', 'acct-wsl', 'managed', 1_000)
-    const refreshedAuth = createCodexAuthJson(
-      'wsl@example.com',
-      'acct-wsl',
-      'runtime-refreshed',
-      2_000
-    )
-    const managedHomePath = createManagedAuth(testState.userDataDir, 'account-1', managedAuth)
-    const managedAuthPath = join(managedHomePath, 'auth.json')
-    const store = createStore(
-      createSettings({
-        codexManagedAccounts: [
-          {
-            id: 'account-1',
-            email: 'wsl@example.com',
-            managedHomePath,
-            managedHomeRuntime: 'wsl',
-            wslDistro: null,
-            wslLinuxHomePath: '/home/alice/.local/share/orca/codex-accounts/account-1/home',
-            providerAccountId: 'acct-wsl',
-            workspaceLabel: null,
-            workspaceAccountId: 'acct-wsl',
-            createdAt: 1,
-            updatedAt: 1,
-            lastAuthenticatedAt: 1
-          }
-        ],
-        activeCodexManagedAccountIdsByRuntime: {
-          host: null,
-          wsl: { Ubuntu: 'account-1' }
-        }
-      })
-    )
-
-    try {
-      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
-      const service = new CodexRuntimeHomeService(store as never)
-      const target = { runtime: 'wsl' as const, wslDistro: 'Ubuntu' }
-      const wslRuntimeHomePath = join(
-        wslHome,
-        '.local',
-        'share',
-        'orca',
-        'codex-runtime-home',
-        'home'
-      )
-      const runtimeAuthPath = join(wslRuntimeHomePath, 'auth.json')
-
-      expect(service.prepareForCodexLaunch(target)).toBe(managedHomePath)
-      writeFileSync(managedAuthPath, refreshedAuth, 'utf-8')
-
-      service.syncActiveWslSelectionsBeforeRestart()
-
-      expect(readFileSync(managedAuthPath, 'utf-8')).toBe(refreshedAuth)
-      expect(existsSync(runtimeAuthPath)).toBe(false)
     } finally {
       if (originalPlatform) {
         Object.defineProperty(process, 'platform', originalPlatform)

--- a/src/main/codex-accounts/runtime-home-wsl-session-bridge.test.ts
+++ b/src/main/codex-accounts/runtime-home-wsl-session-bridge.test.ts
@@ -34,61 +34,6 @@ describe('CodexRuntimeHomeService', () => {
     teardownRuntimeHomeTest()
   })
 
-  it('builds a valid WSL legacy active-home migration shell command', async () => {
-    const execFileSyncMock = vi.fn()
-    vi.doMock('node:child_process', () => ({ execFileSync: execFileSyncMock }))
-
-    try {
-      const { CodexRuntimeHomeService } = await import('./runtime-home-service')
-      const service = new CodexRuntimeHomeService(
-        createStore(createSettings()) as never
-      ) as unknown as {
-        migrateLegacyWslActiveHomePointer(distro: string, runtimeHomePath: string): void
-      }
-
-      service.migrateLegacyWslActiveHomePointer(
-        'Ubuntu',
-        '\\\\wsl.localhost\\Ubuntu\\home\\alice\\.local\\share\\orca\\codex-runtime-home\\home'
-      )
-
-      expect(execFileSyncMock).toHaveBeenCalledTimes(1)
-      const firstCall = execFileSyncMock.mock.calls[0]
-      expect(firstCall).toBeDefined()
-      const [command, args] = firstCall as [string, string[]]
-      expect(command).toBe('wsl.exe')
-      expect(args.slice(0, 5)).toEqual(['-d', 'Ubuntu', '--exec', 'bash', '-lc'])
-      expect(args).toHaveLength(6)
-
-      const shellCommand = args[5]
-      expect(shellCommand).toContain(
-        "if [ ! -e '/home/alice/.local/share/orca/codex-runtime-home/active/wsl/home' ] && [ ! -L '/home/alice/.local/share/orca/codex-runtime-home/active/wsl/home' ]; then :"
-      )
-      expect(shellCommand).toContain(
-        "elif [ -e '/home/alice/.local/share/orca/codex-runtime-home/active/wsl/home' ] && [ ! -L '/home/alice/.local/share/orca/codex-runtime-home/active/wsl/home' ]; then :"
-      )
-      expect(shellCommand).toContain(
-        "mkdir -p '/home/alice/.local/share/orca/codex-runtime-home/active/wsl'"
-      )
-      expect(shellCommand).toContain(
-        "ln -s -- '/home/alice/.local/share/orca/codex-runtime-home/home' '/home/alice/.local/share/orca/codex-runtime-home/active/wsl/home.next-"
-      )
-      expect(shellCommand).toContain(
-        "mv -Tf -- '/home/alice/.local/share/orca/codex-runtime-home/active/wsl/home.next-"
-      )
-      expect(shellCommand).toContain(
-        "' '/home/alice/.local/share/orca/codex-runtime-home/active/wsl/home'"
-      )
-      expect(shellCommand).not.toContain('[! -L')
-      expect(shellCommand).not.toContain('mv -Tf--')
-      expect(shellCommand).not.toContain('$1')
-      expect(shellCommand).not.toContain('$2')
-      expect(shellCommand).not.toContain('$3')
-      expect(shellCommand).not.toContain('exit 0')
-    } finally {
-      vi.doUnmock('node:child_process')
-    }
-  })
-
   it('skips WSL session bridging when system default already uses its direct home', async () => {
     const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
@@ -237,7 +182,7 @@ describe('CodexRuntimeHomeService', () => {
     }
   })
 
-  it('starts WSL session bridging for the distro used by the materialized runtime home', async () => {
+  it('starts WSL session bridging for the selected direct account home', async () => {
     const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
     Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
     const startWslCodexSessionBridgeInBackground = vi.fn(() => Promise.resolve())
@@ -245,14 +190,6 @@ describe('CodexRuntimeHomeService', () => {
       startWslCodexSessionBridgeInBackground
     }))
     const wslHome = join(testState.userDataDir, 'debian-wsl-home')
-    const wslRuntimeHomePath = join(
-      wslHome,
-      '.local',
-      'share',
-      'orca',
-      'codex-runtime-home',
-      'home'
-    )
     vi.doMock('../wsl', () => ({
       getDefaultWslDistro: () => null,
       getWslHome: (distro: string) => (distro === 'Debian' ? wslHome : null)
@@ -262,11 +199,10 @@ describe('CodexRuntimeHomeService', () => {
       return {
         ...actual,
         parseWslUncPath: (candidate: string) =>
-          candidate === wslRuntimeHomePath ||
           candidate.includes('codex-accounts/debian-account/home')
             ? {
                 distro: 'Debian',
-                linuxPath: '/home/alice/.local/share/orca/codex-runtime-home/home'
+                linuxPath: '/home/alice/.local/share/orca/codex-accounts/debian-account/home'
               }
             : null
       }

--- a/src/main/codex-accounts/runtime-home-wsl-system-default.test.ts
+++ b/src/main/codex-accounts/runtime-home-wsl-system-default.test.ts
@@ -53,15 +53,6 @@ describe('CodexRuntimeHomeService', () => {
     try {
       const { CodexRuntimeHomeService } = await import('./runtime-home-service')
       const service = new CodexRuntimeHomeService(store as never)
-      const syncWslRuntime = vi.spyOn(
-        service as unknown as {
-          syncWslRuntimeForCurrentSelection: (target: {
-            runtime: 'wsl'
-            wslDistro?: string | null
-          }) => string | null
-        },
-        'syncWslRuntimeForCurrentSelection'
-      )
       const target = { runtime: 'wsl' as const, wslDistro: 'Ubuntu' }
       const expectedHome = join(wslHome, '.codex')
 
@@ -73,7 +64,6 @@ describe('CodexRuntimeHomeService', () => {
         kind: 'ready',
         codexHomePath: expectedHome
       })
-      expect(syncWslRuntime).not.toHaveBeenCalled()
     } finally {
       if (originalPlatform) {
         Object.defineProperty(process, 'platform', originalPlatform)

--- a/src/main/pty/codex-home-wsl-env.ts
+++ b/src/main/pty/codex-home-wsl-env.ts
@@ -1,6 +1,4 @@
-/** Guest-relative layout of Orca's managed WSL CODEX_HOME. Must stay in sync
- *  with getWslRuntimeHomePath (codex-accounts/runtime-home-service.ts), which
- *  builds the UNC twin of this path. */
+/** Guest-relative layout of Orca's retired WSL CODEX_HOME, retained for migration reads. */
 export const WSL_CODEX_RUNTIME_HOME_SEGMENTS = [
   '.local',
   'share',

--- a/src/main/wsl/__fixtures__/wsl-invocation-allowlist.txt
+++ b/src/main/wsl/__fixtures__/wsl-invocation-allowlist.txt
@@ -17,7 +17,6 @@
 main/agent-hooks/wsl-hook-relay-launch.ts
 main/browser/wsl-browser-network-relay-launch.ts
 main/claude-accounts/claude-command-process.ts
-main/codex-accounts/runtime-home-service.ts
 main/codex-accounts/service.ts
 main/codex/codex-state-db-backfill-recovery.ts
 main/codex/codex-trust-grant-host.ts

--- a/src/shared/child-process/__fixtures__/child-process-import-allowlist.txt
+++ b/src/shared/child-process/__fixtures__/child-process-import-allowlist.txt
@@ -41,7 +41,6 @@ src/main/browser/browser-cookie-import.ts
 src/main/browser/browser-route-egress-electron-launch.ts
 src/main/browser/browser-route-persisted-worker-electron-process.ts
 src/main/claude-accounts/keychain.ts
-src/main/codex-accounts/runtime-home-service.ts
 src/main/codex-accounts/service.ts
 src/main/codex/codex-app-server-client.ts
 src/main/codex/codex-app-server-session.ts


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​93 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​281 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​188 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​63 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​390 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​327 |

<!-- /orca-pr-loc -->

## Summary

- delete the retired WSL runtime-home copy, read-back, seed, and active-pointer paths
- remove obsolete per-distro mirror state and restart preservation plumbing
- retain direct-home routing and legacy drain coverage while deleting mirror-only tests

## Verification

- 1,859 tests passed across `src/main/codex`, `src/main/codex-accounts`, and `src/main/agent-hooks` (12 skipped)
- `pnpm typecheck`
- `node config/scripts/check-changed-code-quality.mjs`
- mutation checks for direct-home account selection and freshness-gated legacy promotion