### PR TITLE
test(shared): stop two suites asserting POSIX separators on Windows

### DIFF
--- a/src/shared/git-fetch-head-lock.test.ts
+++ b/src/shared/git-fetch-head-lock.test.ts
@@ -26,13 +26,15 @@ describe('runWithGitFetchHeadLock', () => {
     expect(resolveGitFetchHeadCommand(args, '/repo').needsLock).toBe(expected)
   })
 
+  // Why resolve() rather than a literal: the subject resolves these through path.resolve, so a
+  // POSIX literal asserts the separator of the machine running the suite instead of the behaviour.
   it('resolves -C and --git-dir before deriving the lock identity', () => {
     expect(resolveGitFetchHeadCommand(['-C', 'repo', 'fetch'], '/tmp')).toMatchObject({
-      cwd: '/tmp/repo',
+      cwd: path.resolve('/tmp', 'repo'),
       needsLock: true
     })
     expect(resolveGitFetchHeadCommand(['--git-dir=/repo/.git', 'fetch'], '/tmp')).toMatchObject({
-      gitDir: '/repo/.git',
+      gitDir: path.resolve('/tmp', '/repo/.git'),
       needsLock: true
     })
   })

--- a/src/shared/node-markdown-document-discovery.test.ts
+++ b/src/shared/node-markdown-document-discovery.test.ts
@@ -1,4 +1,5 @@
 import type { Dirent } from 'node:fs'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { MarkdownDocumentListingCapacityError } from './markdown-document-listing-limits'
 import { discoverMarkdownRelativePaths } from './node-markdown-document-discovery'
@@ -22,6 +23,8 @@ function reader(entriesByPath: Record<string, Dirent[]>) {
 
 describe('bounded Markdown document discovery', () => {
   it('preserves depth-first discovery and skips excluded and symlinked directories', async () => {
+    // Why join() for the child key: the subject descends with path.join, so a '/repo/docs'
+    // literal never matches on Windows and the walk silently stops at the root.
     const result = await discoverMarkdownRelativePaths('/repo', {
       readDirectory: reader({
         '/repo': [
@@ -30,7 +33,7 @@ describe('bounded Markdown document discovery', () => {
           entry('docs', 'directory'),
           entry('linked', 'symlink')
         ],
-        '/repo/docs': [entry('guide.mdx'), entry('app.ts')]
+        [join('/repo', 'docs')]: [entry('guide.mdx'), entry('app.ts')]
       }),
       shouldDescend: (_relativePath, name) => name !== '.git'
     })
@@ -65,7 +68,7 @@ describe('bounded Markdown document discovery', () => {
         limits: { maxDepth: 1 },
         readDirectory: reader({
           '/repo': [entry('one', 'directory')],
-          '/repo/one': [entry('two', 'directory')]
+          [join('/repo', 'one')]: [entry('two', 'directory')]
         }),
         shouldDescend: () => true
       })


### PR DESCRIPTION
## ELI5

Two test files write file paths the Mac/Linux way, with forward slashes. The code they test builds paths the way each operating system wants them, so on Windows the two never line up. One test then compares mismatched strings and fails loudly; the other quietly explores an empty folder and concludes there is nothing there — which is worse, because that is also what a broken traversal looks like. This makes both tests describe paths the way the code does.

## What Changed

- `node-markdown-document-discovery.test.ts` keys its fake directory tree with `join` instead of `'/repo/docs'` and `'/repo/one'` literals.
- `git-fetch-head-lock.test.ts` asserts `path.resolve(...)` instead of the literal `'/tmp/repo'`.

Test-only. No production file changes.

## Why

Both subjects compose paths through `node:path`; both suites described them with POSIX literals.

**Discovery walked nothing.** `discoverMarkdownRelativePaths` descends with

```ts
await visitDirectory(join(absoluteDirectoryPath, entry.name), relativePath, nextDepth)
```

so on win32 it asks for `\repo\docs` while the fake tree only answers to `/repo/docs`. `readDirectory` yields nothing, recursion ends at the root, and two cases fail for one reason:

```
AssertionError: expected [ 'README.md' ] to deeply equal [ 'README.md', 'docs/guide.mdx' ]
AssertionError: promise resolved "[]" instead of rejecting
```

The second is the one worth pausing on. A depth limit that is never reached resolves `[]`, which is indistinguishable from a correct walk over an empty tree — on this platform the suite could not tell a broken traversal from a working one.

**The lock test compared a resolved path to a literal.** `resolveGitFetchHeadCommand` returns `path.resolve(cwd, args[index + 1])`:

```
-   "cwd": "/tmp/repo",
+   "cwd": "C:\tmp\repo",
```

Asserting through `path.resolve` pins what the function promises — that `-C` and `--git-dir` resolve against the cwd — rather than the separator of whichever machine runs the suite.

Neither is visible to CI: `join` and `resolve` emit `/` on Linux and macOS.

## Linked Issue

Fixes #16509

## Visual Proof

`N/A` — test-only change, no user-facing surface.

## Testing

Windows 11 Pro (26200), Node 24.15.0, on `main` at `cac538854`:

| | before | after |
|---|---|---|
| the two files together | 3 failed / 12 passed | **14 passed, 1 skipped** |
| `src/shared` (551 files) | 9 failed | **no regression**; the 3 fixed cases are gone from the failure list |

`pnpm typecheck` exits 0 and `oxlint` on both files exits 0.

The remaining `src/shared` failures on Windows are `setup-agent-sequencing` losing a prompt with special characters through a real `cmd.exe` spawn — a different mechanism, noted at the bottom of #16509 and deliberately not touched here.

Full `pnpm lint` and `pnpm test` still cannot complete on a stock Windows checkout for reasons that predate this change: #14479, #15200, and `node-pty` now requiring a from-source rebuild since `build(windows): refuse unpatched node-pty prebuilds`.

- [x] I manually tested these changes locally
- [ ] Automated tests added/updated, or explained why not below

No new test. The change *is* the test correction — three cases go from red to green on Windows and keep passing elsewhere, which is the regression signal.

## AI Disclosure

Claude Opus 5 via Claude Code was used to find the failures, isolate the cause, and write the fix.

## Review

- **Security**: none. Two test files; no production path, no new input.
- **Cross-platform**: the point of the change. `join`/`resolve` return the same values on macOS and Linux as the literals did, so those platforms are unaffected; Windows stops disagreeing.
- **Remote SSH / local**: untouched.
- **Agents and integrations**: untouched, provider-neutral.
- **Mobile**: untouched.
- **Performance**: none.
- **UI quality**: N/A.
- **Backwards compatibility**: no contract changes; the same behaviour is asserted on one more platform.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance — covered under **Review**.

#15994 is a much larger Windows-suite sweep and touches neither file, so these do not overlap.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — `typecheck` and the affected suites locally; `lint`/`test` blocked on Windows by the pre-existing issues named under Testing, so CI covers them
