### PR TITLE
fix(codex): run CLI updates from the system install context

### DIFF
--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-bash-rcfile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-bash-rcfile.txt
@@ -72,11 +72,17 @@ fi
 # Why || : twice — zsh alone aborts inside the substitution, but every shell's
 # assignment adopts its exit status, so an absent codex trips set -e in bash too.
 __orca_codex_binary="$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)"
-if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" ]]; then
+if [[ -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" && ( -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" || ( -n "${ORCA_CODEX_HOME:-}" && "${CODEX_HOME:-}" == "${ORCA_CODEX_HOME}" ) ) ]]; then
   # Why the function reserved word: it suppresses alias expansion of the name,
   # which otherwise rewrites this header at parse time and aborts the whole file.
   function codex {
-    "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+    if [[ "${1:-}" == "update" && -n "${ORCA_CODEX_HOME:-}" && "${CODEX_HOME:-}" == "${ORCA_CODEX_HOME}" ]]; then
+      command env -u CODEX_HOME -u ORCA_CODEX_HOME codex "$@"
+      return $?
+    fi
+    if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" ]]; then
+      "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+    fi
     command codex "$@"
   }
 fi

--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-fish-init.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-fish-init.txt
@@ -2,9 +2,17 @@ function __orca_shell_ready_marker --on-event fish_prompt
   builtin printf "\033]777;orca-shell-ready\007"
   functions -e __orca_shell_ready_marker
 end
-if test -n "$ORCA_CODEX_LAUNCH_PREFLIGHT"; and test (type -t codex 2>/dev/null) = file
-  function codex
-    command "$ORCA_CODEX_LAUNCH_PREFLIGHT" agent hooks prepare-codex >/dev/null 2>&1; or true
-    command codex $argv
+if test (type -t codex 2>/dev/null) = file
+  if test -n "$ORCA_CODEX_LAUNCH_PREFLIGHT"; or begin; test -n "$ORCA_CODEX_HOME"; and test "$CODEX_HOME" = "$ORCA_CODEX_HOME"; end
+    function codex
+      if test (count $argv) -gt 0; and test "$argv[1]" = update; and test -n "$ORCA_CODEX_HOME"; and test "$CODEX_HOME" = "$ORCA_CODEX_HOME"
+        command env -u CODEX_HOME -u ORCA_CODEX_HOME codex $argv
+        return $status
+      end
+      if test -n "$ORCA_CODEX_LAUNCH_PREFLIGHT"
+        command "$ORCA_CODEX_LAUNCH_PREFLIGHT" agent hooks prepare-codex >/dev/null 2>&1; or true
+      end
+      command codex $argv
+    end
   end
 end

--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zshenv.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zshenv.txt
@@ -110,11 +110,17 @@ __orca_deferred_init() {
     # Why || : twice — zsh alone aborts inside the substitution, but every shell's
     # assignment adopts its exit status, so an absent codex trips set -e in bash too.
     __orca_codex_binary="$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)"
-    if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" ]]; then
+    if [[ -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" && ( -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" || ( -n "${ORCA_CODEX_HOME:-}" && "${CODEX_HOME:-}" == "${ORCA_CODEX_HOME}" ) ) ]]; then
       # Why the function reserved word: it suppresses alias expansion of the name,
       # which otherwise rewrites this header at parse time and aborts the whole file.
       function codex {
-        "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+        if [[ "${1:-}" == "update" && -n "${ORCA_CODEX_HOME:-}" && "${CODEX_HOME:-}" == "${ORCA_CODEX_HOME}" ]]; then
+          command env -u CODEX_HOME -u ORCA_CODEX_HOME codex "$@"
+          return $?
+        fi
+        if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" ]]; then
+          "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+        fi
         command codex "$@"
       }
     fi

--- a/src/main/__fixtures__/shell-wrapper-snapshots/local-bash-rcfile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/local-bash-rcfile.txt
@@ -75,11 +75,17 @@ fi
 # Why || : twice — zsh alone aborts inside the substitution, but every shell's
 # assignment adopts its exit status, so an absent codex trips set -e in bash too.
 __orca_codex_binary="$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)"
-if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" ]]; then
+if [[ -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" && ( -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" || ( -n "${ORCA_CODEX_HOME:-}" && "${CODEX_HOME:-}" == "${ORCA_CODEX_HOME}" ) ) ]]; then
   # Why the function reserved word: it suppresses alias expansion of the name,
   # which otherwise rewrites this header at parse time and aborts the whole file.
   function codex {
-    "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+    if [[ "${1:-}" == "update" && -n "${ORCA_CODEX_HOME:-}" && "${CODEX_HOME:-}" == "${ORCA_CODEX_HOME}" ]]; then
+      command env -u CODEX_HOME -u ORCA_CODEX_HOME codex "$@"
+      return $?
+    fi
+    if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" ]]; then
+      "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+    fi
     command codex "$@"
   }
 fi

--- a/src/main/__fixtures__/shell-wrapper-snapshots/local-fish-init.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/local-fish-init.txt
@@ -2,9 +2,17 @@ function __orca_shell_ready_marker --on-event fish_prompt
   builtin printf "\033]777;orca-shell-ready\007"
   functions -e __orca_shell_ready_marker
 end
-if test -n "$ORCA_CODEX_LAUNCH_PREFLIGHT"; and test (type -t codex 2>/dev/null) = file
-  function codex
-    command "$ORCA_CODEX_LAUNCH_PREFLIGHT" agent hooks prepare-codex >/dev/null 2>&1; or true
-    command codex $argv
+if test (type -t codex 2>/dev/null) = file
+  if test -n "$ORCA_CODEX_LAUNCH_PREFLIGHT"; or begin; test -n "$ORCA_CODEX_HOME"; and test "$CODEX_HOME" = "$ORCA_CODEX_HOME"; end
+    function codex
+      if test (count $argv) -gt 0; and test "$argv[1]" = update; and test -n "$ORCA_CODEX_HOME"; and test "$CODEX_HOME" = "$ORCA_CODEX_HOME"
+        command env -u CODEX_HOME -u ORCA_CODEX_HOME codex $argv
+        return $status
+      end
+      if test -n "$ORCA_CODEX_LAUNCH_PREFLIGHT"
+        command "$ORCA_CODEX_LAUNCH_PREFLIGHT" agent hooks prepare-codex >/dev/null 2>&1; or true
+      end
+      command codex $argv
+    end
   end
 end

--- a/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zshenv.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zshenv.txt
@@ -110,11 +110,17 @@ __orca_deferred_init() {
     # Why || : twice — zsh alone aborts inside the substitution, but every shell's
     # assignment adopts its exit status, so an absent codex trips set -e in bash too.
     __orca_codex_binary="$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)"
-    if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" ]]; then
+    if [[ -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" && ( -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" || ( -n "${ORCA_CODEX_HOME:-}" && "${CODEX_HOME:-}" == "${ORCA_CODEX_HOME}" ) ) ]]; then
       # Why the function reserved word: it suppresses alias expansion of the name,
       # which otherwise rewrites this header at parse time and aborts the whole file.
       function codex {
-        "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+        if [[ "${1:-}" == "update" && -n "${ORCA_CODEX_HOME:-}" && "${CODEX_HOME:-}" == "${ORCA_CODEX_HOME}" ]]; then
+          command env -u CODEX_HOME -u ORCA_CODEX_HOME codex "$@"
+          return $?
+        fi
+        if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" ]]; then
+          "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+        fi
         command codex "$@"
       }
     fi

--- a/src/main/daemon/pty-subprocess/shell-launch-plan.ts
+++ b/src/main/daemon/pty-subprocess/shell-launch-plan.ts
@@ -124,7 +124,8 @@ export function createPtyShellLaunchPlan(
         resolveSafePtyDefaultCwd(),
         resolvedWslContext,
         opts.command,
-        env.ORCA_CODEX_LAUNCH_PREFLIGHT
+        env.ORCA_CODEX_LAUNCH_PREFLIGHT,
+        Boolean(env.ORCA_CODEX_HOME)
       )
       shellArgs = resolved.shellArgs
       spawnCwd = resolved.effectiveCwd
@@ -152,7 +153,8 @@ export function createPtyShellLaunchPlan(
               resolveSafePtyDefaultCwd(),
               { distro: codexHomeWslInfo.distro },
               opts.command,
-              env.ORCA_CODEX_LAUNCH_PREFLIGHT
+              env.ORCA_CODEX_LAUNCH_PREFLIGHT,
+              Boolean(env.ORCA_CODEX_HOME)
             )
             shellArgs = resolved.shellArgs
             spawnCwd = resolved.effectiveCwd

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -798,9 +798,12 @@ export class LocalPtyProvider implements IPtyProvider {
 
       const shellBasename = pathWin32.basename(shellPath).toLowerCase()
       const codexLaunchPreflightCommand = finalEnv.ORCA_CODEX_LAUNCH_PREFLIGHT
+      const needsGitBashCodexWrapper =
+        isWindowsGitBashShellPath(shellPath) &&
+        Boolean(codexLaunchPreflightCommand || finalEnv.ORCA_CODEX_HOME)
       if (
-        codexLaunchPreflightCommand &&
-        (shellBasename === 'cmd.exe' || isWindowsGitBashShellPath(shellPath))
+        (codexLaunchPreflightCommand && shellBasename === 'cmd.exe') ||
+        needsGitBashCodexWrapper
       ) {
         if (shellBasename === 'cmd.exe') {
           // Why: node-pty backslash-escapes argv quotes; expand the quote inside cmd.exe instead.
@@ -812,7 +815,8 @@ export class LocalPtyProvider implements IPtyProvider {
           defaultCwd,
           launchWslContext,
           args.command,
-          codexLaunchPreflightCommand
+          codexLaunchPreflightCommand,
+          Boolean(finalEnv.ORCA_CODEX_HOME)
         )
         shellArgs = resolved.shellArgs
         effectiveCwd = resolved.effectiveCwd

--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -308,6 +308,21 @@ describe('resolveWindowsShellLaunchArgs', () => {
     expect(result.startupCommandDeliveredInShellArgs).toBeUndefined()
   })
 
+  it('loads Codex update routing in Git Bash when hook preflight is disabled', () => {
+    const result = resolveWindowsShellLaunchArgs(
+      'C:\\Program Files\\Git\\bin\\bash.exe',
+      'C:\\Users\\alice',
+      'C:\\Users\\alice',
+      undefined,
+      undefined,
+      undefined,
+      true
+    )
+
+    const rcfilePath = getGitBashRcfilePath(result.shellArgs[1])
+    expect(readFileSync(rcfilePath, 'utf8')).toContain('env -u CODEX_HOME -u ORCA_CODEX_HOME codex')
+  })
+
   it('quotes a spaced preflight path through each shell environment', () => {
     const cmd = resolveWindowsShellLaunchArgs(
       'cmd.exe',

--- a/src/main/providers/windows-shell-args.ts
+++ b/src/main/providers/windows-shell-args.ts
@@ -28,8 +28,11 @@ const CMD_CODEX_LAUNCH_PREFLIGHT = `if defined ORCA_CODEX_LAUNCH_PREFLIGHT call 
 // `&&`) keeps startup working even if chcp.com is missing.
 const GIT_BASH_UTF8_LOGIN_COMMAND = 'chcp.com 65001 >/dev/null 2>&1; exec "$BASH" --login -i'
 
-function getGitBashLaunchCommand(codexLaunchPreflightCommand?: string): string {
-  if (!codexLaunchPreflightCommand) {
+function getGitBashLaunchCommand(
+  codexLaunchPreflightCommand?: string,
+  routeCodexUpdates = false
+): string {
+  if (!codexLaunchPreflightCommand && !routeCodexUpdates) {
     return GIT_BASH_UTF8_LOGIN_COMMAND
   }
 
@@ -178,7 +181,8 @@ export function resolveWindowsShellLaunchArgs(
   defaultCwd: string,
   wslContext?: WindowsShellWslContext,
   startupCommand?: string,
-  codexLaunchPreflightCommand?: string
+  codexLaunchPreflightCommand?: string,
+  routeCodexUpdates = false
 ): WindowsShellLaunchArgs {
   const shellBasename = pathWin32.basename(shellPath).toLowerCase()
   const nativeCwd = normalizeWindowsTerminalCwd(cwd)
@@ -214,7 +218,7 @@ export function resolveWindowsShellLaunchArgs(
 
   if (isWindowsGitBashShellPath(shellPath)) {
     return {
-      shellArgs: ['-c', getGitBashLaunchCommand(codexLaunchPreflightCommand)],
+      shellArgs: ['-c', getGitBashLaunchCommand(codexLaunchPreflightCommand, routeCodexUpdates)],
       effectiveCwd: nativeCwd,
       validationCwd: nativeCwd
     }

--- a/src/main/pty/codex-shell-launch-preflight.test.ts
+++ b/src/main/pty/codex-shell-launch-preflight.test.ts
@@ -79,6 +79,37 @@ function runAliasLaunch(
   ).trim()
 }
 
+function runManagedHomeCommands(root: string, wrapper: string, shell = '/bin/bash'): string[] {
+  const home = join(root, 'managed-home')
+  const bin = join(root, 'bin')
+  mkdirSync(home)
+  mkdirSync(bin)
+  writeExecutable(
+    join(bin, 'codex'),
+    '#!/bin/sh\nprintf "%s|%s|%s\\n" "${CODEX_HOME-unset}" "${ORCA_CODEX_HOME-unset}" "$*"\n'
+  )
+  const isZsh = shell.endsWith('/zsh')
+  return execFileSync(
+    shell,
+    [
+      ...(isZsh ? ['-f'] : ['--noprofile', '--norc']),
+      '-c',
+      [wrapper, 'codex update', 'codex doctor'].join('\n')
+    ],
+    {
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        PATH: `${bin}:${process.env.PATH ?? ''}`,
+        CODEX_HOME: home,
+        ORCA_CODEX_HOME: home
+      }
+    }
+  )
+    .trim()
+    .split('\n')
+}
+
 /** Launches a startup file that aliases the very name Orca wraps, then asserts the
  *  wrapper installed, the preflight ran, and the user's alias still applies. */
 function expectNamedAliasSurvives(shell: string, enableAliases: string): void {
@@ -161,6 +192,48 @@ describe.skipIf(process.platform === 'win32')('Codex shell launch preflight', ()
     expectNamedAliasSurvives('/bin/bash', 'shopt -s expand_aliases')
   })
 
+  for (const shell of ['/bin/bash', '/bin/zsh']) {
+    it.skipIf(!existsSync(shell))(
+      `routes ${shell} updates through the system install context only`,
+      () => {
+        const root = mkdtempSync(join(tmpdir(), 'orca-codex-update-routing-'))
+        roots.push(root)
+
+        expect(runManagedHomeCommands(root, getPosixCodexShellLaunchPreflight(), shell)).toEqual([
+          'unset|unset|update',
+          `${join(root, 'managed-home')}|${join(root, 'managed-home')}|doctor`
+        ])
+      }
+    )
+  }
+
+  it('preserves a user-owned CODEX_HOME for updates', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-codex-custom-home-update-'))
+    const bin = join(root, 'bin')
+    roots.push(root)
+    mkdirSync(bin)
+    writeExecutable(
+      join(bin, 'codex'),
+      '#!/bin/sh\nprintf "%s|%s\\n" "$CODEX_HOME" "$ORCA_CODEX_HOME"\n'
+    )
+
+    const output = execFileSync(
+      '/bin/bash',
+      ['--noprofile', '--norc', '-c', `${getPosixCodexShellLaunchPreflight()}\ncodex update`],
+      {
+        encoding: 'utf-8',
+        env: {
+          ...process.env,
+          PATH: `${bin}:${process.env.PATH ?? ''}`,
+          CODEX_HOME: join(root, 'user-home'),
+          ORCA_CODEX_HOME: join(root, 'managed-home')
+        }
+      }
+    )
+
+    expect(output.trim()).toBe(`${join(root, 'user-home')}|${join(root, 'managed-home')}`)
+  })
+
   it('still launches Codex when the best-effort preflight fails', () => {
     const root = mkdtempSync(join(tmpdir(), 'orca-codex-preflight-failure-'))
     roots.push(root)
@@ -218,6 +291,16 @@ describe.skipIf(process.platform === 'win32')('Codex shell launch preflight', ()
 
     expect(output.trim()).toBe('custom-codex')
   })
+
+  it.skipIf(!fishAvailable)('routes fish updates through the system install context only', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-codex-update-routing-fish-'))
+    roots.push(root)
+
+    expect(runManagedHomeCommands(root, getFishCodexShellLaunchPreflight(), 'fish')).toEqual([
+      'unset|unset|update',
+      `${join(root, 'managed-home')}|${join(root, 'managed-home')}|doctor`
+    ])
+  })
 })
 
 describe('PowerShell Codex shell launch preflight', () => {
@@ -268,6 +351,47 @@ describe('PowerShell Codex shell launch preflight', () => {
     expect(result.status, result.stderr).toBe(0)
     expect(result.stdout.trim()).toBe('launched')
   })
+
+  it.skipIf(!pwshAvailable)(
+    'routes PowerShell updates through the system install context only',
+    () => {
+      const root = mkdtempSync(join(tmpdir(), 'orca-codex-update-routing-pwsh-'))
+      const home = join(root, 'managed-home')
+      const bin = join(root, 'bin')
+      roots.push(root)
+      mkdirSync(home)
+      mkdirSync(bin)
+      writeExecutable(
+        join(bin, 'codex'),
+        '#!/bin/sh\nprintf "%s|%s|%s\\n" "${CODEX_HOME-unset}" "${ORCA_CODEX_HOME-unset}" "$*"\n'
+      )
+
+      const result = spawnSync(
+        'pwsh',
+        [
+          '-NoLogo',
+          '-NoProfile',
+          '-Command',
+          `${getPowerShellCodexShellLaunchPreflight()}\ncodex update\ncodex doctor`
+        ],
+        {
+          encoding: 'utf-8',
+          env: {
+            ...process.env,
+            PATH: `${bin}${delimiter}${process.env.PATH ?? ''}`,
+            CODEX_HOME: home,
+            ORCA_CODEX_HOME: home
+          }
+        }
+      )
+
+      expect(result.status, result.stderr).toBe(0)
+      expect(result.stdout.trim().split('\n')).toEqual([
+        'unset|unset|update',
+        `${home}|${home}|doctor`
+      ])
+    }
+  )
 })
 
 describe('Codex shell launch preflight command', () => {

--- a/src/main/pty/codex-shell-launch-preflight.ts
+++ b/src/main/pty/codex-shell-launch-preflight.ts
@@ -65,11 +65,17 @@ export function getPosixCodexShellLaunchPreflight(): string {
 # Why || : twice — zsh alone aborts inside the substitution, but every shell's
 # assignment adopts its exit status, so an absent codex trips set -e in bash too.
 __orca_codex_binary="$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)"
-if [[ -n "\${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "\${__orca_codex_binary:-}" && -x "\${__orca_codex_binary}" ]]; then
+if [[ -n "\${__orca_codex_binary:-}" && -x "\${__orca_codex_binary}" && ( -n "\${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" || ( -n "\${ORCA_CODEX_HOME:-}" && "\${CODEX_HOME:-}" == "\${ORCA_CODEX_HOME}" ) ) ]]; then
   # Why the function reserved word: it suppresses alias expansion of the name,
   # which otherwise rewrites this header at parse time and aborts the whole file.
   function codex {
-    "\${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+    if [[ "\${1:-}" == "update" && -n "\${ORCA_CODEX_HOME:-}" && "\${CODEX_HOME:-}" == "\${ORCA_CODEX_HOME}" ]]; then
+      command env -u CODEX_HOME -u ORCA_CODEX_HOME codex "$@"
+      return $?
+    fi
+    if [[ -n "\${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" ]]; then
+      "\${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+    fi
     command codex "$@"
   }
 fi
@@ -78,28 +84,56 @@ unset __orca_codex_binary
 }
 
 export function getFishCodexShellLaunchPreflight(): string {
-  return `if test -n "$ORCA_CODEX_LAUNCH_PREFLIGHT"; and test (type -t codex 2>/dev/null) = file
-  function codex
-    command "$ORCA_CODEX_LAUNCH_PREFLIGHT" agent hooks prepare-codex >/dev/null 2>&1; or true
-    command codex $argv
+  return `if test (type -t codex 2>/dev/null) = file
+  if test -n "$ORCA_CODEX_LAUNCH_PREFLIGHT"; or begin; test -n "$ORCA_CODEX_HOME"; and test "$CODEX_HOME" = "$ORCA_CODEX_HOME"; end
+    function codex
+      if test (count $argv) -gt 0; and test "$argv[1]" = update; and test -n "$ORCA_CODEX_HOME"; and test "$CODEX_HOME" = "$ORCA_CODEX_HOME"
+        command env -u CODEX_HOME -u ORCA_CODEX_HOME codex $argv
+        return $status
+      end
+      if test -n "$ORCA_CODEX_LAUNCH_PREFLIGHT"
+        command "$ORCA_CODEX_LAUNCH_PREFLIGHT" agent hooks prepare-codex >/dev/null 2>&1; or true
+      end
+      command codex $argv
+    end
   end
 end`
 }
 
 export function getPowerShellCodexShellLaunchPreflight(): string {
   return `$orcaCodexCommand = Get-Command codex -ErrorAction SilentlyContinue | Select-Object -First 1
-if ($env:ORCA_CODEX_LAUNCH_PREFLIGHT -and $orcaCodexCommand -and
+if ($orcaCodexCommand -and
+    ($env:ORCA_CODEX_LAUNCH_PREFLIGHT -or
+     ($env:ORCA_CODEX_HOME -and $env:CODEX_HOME -eq $env:ORCA_CODEX_HOME)) -and
     $orcaCodexCommand.CommandType -in @("Application", "ExternalScript")) {
     function Global:codex {
-        try {
-            & $env:ORCA_CODEX_LAUNCH_PREFLIGHT agent hooks prepare-codex *> $null
-        } catch {
-        }
         $orcaCodexExecutable = Get-Command codex -CommandType Application,ExternalScript -ErrorAction SilentlyContinue | Select-Object -First 1
         if (-not $orcaCodexExecutable) {
             Write-Error "codex executable not found"
             $global:LASTEXITCODE = 127
             return
+        }
+        if ($args.Count -gt 0 -and $args[0] -eq "update" -and
+            $env:ORCA_CODEX_HOME -and $env:CODEX_HOME -eq $env:ORCA_CODEX_HOME) {
+            $orcaManagedCodexHome = $env:ORCA_CODEX_HOME
+            $orcaRoutedCodexHome = $env:CODEX_HOME
+            Remove-Item Env:CODEX_HOME -ErrorAction SilentlyContinue
+            Remove-Item Env:ORCA_CODEX_HOME -ErrorAction SilentlyContinue
+            try {
+                & $orcaCodexExecutable.Source @args
+                $orcaCodexExitCode = $LASTEXITCODE
+            } finally {
+                $env:CODEX_HOME = $orcaRoutedCodexHome
+                $env:ORCA_CODEX_HOME = $orcaManagedCodexHome
+            }
+            $global:LASTEXITCODE = $orcaCodexExitCode
+            return
+        }
+        if ($env:ORCA_CODEX_LAUNCH_PREFLIGHT) {
+            try {
+                & $env:ORCA_CODEX_LAUNCH_PREFLIGHT agent hooks prepare-codex *> $null
+            } catch {
+            }
         }
         & $orcaCodexExecutable.Source @args
         $global:LASTEXITCODE = $LASTEXITCODE


### PR DESCRIPTION
## ELI5

Normal Codex commands keep using the selected Orca account. Only `codex update` steps outside that account home so Codex can see how the execution host's shared CLI was installed.

## What Changed

- Route `codex update` without Orca-owned `CODEX_HOME` markers in bash, zsh, fish, and PowerShell wrappers.
- Keep normal commands and user-owned custom homes unchanged, including local, daemon, Git Bash, WSL, and SSH wrapper generation.

## Why

Orca account homes isolate authentication and sessions, but the standalone CLI is installed once per execution host. Pointing install detection at an account home makes a healthy standalone install look unknown.

## Linked Issue

Fixes #16512

## Visual Proof

N/A — shell environment routing only; automated tests assert the before/after environment.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- `pnpm lint`
- `pnpm typecheck`
- 5 targeted Vitest files: 90 passed, 6 platform-skipped
- Full `pnpm test` was stopped after unrelated sandbox failures in Electron, FSEvents, and global shell-wrapper-path tests; CI will run the complete suite.

## AI Disclosure

Codex (GPT-5) was used to investigate, implement, and test this change.

## Review

The update branch activates only when `CODEX_HOME` matches Orca's private `ORCA_CODEX_HOME` marker. Other Codex commands and mismatched user-owned homes keep their existing environment.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The execution host remains authoritative: native, WSL, and SSH runtimes update their own CLI installation. No remote-wire or UI changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
