### PR TITLE
style(github): trim repo identity cache comments

### DIFF
--- a/src/main/github/github-repository-identity.signed-cache.test.ts
+++ b/src/main/github/github-repository-identity.signed-cache.test.ts
@@ -1,12 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as GitRunner from '../git/runner'
 
-// A resolved repo identity used to expire on a flat 30s clock, so a client
-// polling PR state re-ran `git remote get-url` for every repo every half
-// minute. On Windows that spawn costs 250-800ms in the field. The identity is
-// a read of `.git/config`, and the config signature already exists to say when
-// that file changed — so a signed answer is now held for the same five minutes
-// a signed negative already was, and revalidated against the signature.
+// Signed identities revalidate Git config instead of re-spawning Git every 30 seconds.
 
 const { gitExecFileAsyncMock, readLocalGitConfigSignatureMock } = vi.hoisted(() => ({
   gitExecFileAsyncMock: vi.fn(),
@@ -58,8 +53,7 @@ describe('owner/repo identity cache', () => {
     })
     expect(remoteGetUrlCalls()).toBe(1)
 
-    // Why 4 minutes: past the 30s unsigned TTL that forced the re-probe, and
-    // still inside the signed window this change introduces.
+    // Past the unsigned TTL, inside the signed TTL.
     vi.setSystemTime(Date.now() + FOUR_MINUTES)
     await expect(getOwnerRepoForRemote(REPO, 'origin')).resolves.toEqual({
       owner: 'stablyai',
@@ -78,8 +72,7 @@ describe('owner/repo identity cache', () => {
     readLocalGitConfigSignatureMock.mockImplementation(async () => 'sig-2')
     vi.setSystemTime(Date.now() + THIRTY_SECONDS)
 
-    // Why not "after the TTL": a `git remote set-url` must be visible on the
-    // very next lookup, which is what the longer hold is allowed to rely on.
+    // A signature change must invalidate before the TTL.
     await expect(getOwnerRepoForRemote(REPO, 'origin')).resolves.toEqual({
       owner: 'other-org',
       repo: 'orca'
@@ -94,8 +87,7 @@ describe('owner/repo identity cache', () => {
     await getOwnerRepoForRemote(REPO, 'origin')
     expect(remoteGetUrlCalls()).toBe(1)
 
-    // Why: with no signature nothing invalidates on change, so the entry must
-    // still expire on the clock rather than silently pinning a stale identity.
+    // Unsigned entries need a bounded lifetime.
     vi.setSystemTime(Date.now() + THIRTY_SECONDS + 1)
     await getOwnerRepoForRemote(REPO, 'origin')
     expect(remoteGetUrlCalls()).toBe(2)

--- a/src/main/github/github-repository-identity.ts
+++ b/src/main/github/github-repository-identity.ts
@@ -61,13 +61,7 @@ export function ghRepoExecOptions(context: GitHubRepoContext): {
 
 const OWNER_REPO_POSITIVE_CACHE_TTL_MS = 30_000
 const OWNER_REPO_NEGATIVE_CACHE_TTL_MS = 5 * 60_000
-/**
- * A signature-backed answer is held as long as a negative one. `git remote
- * get-url` reads `.git/config`, and the signature covers that file plus every
- * path it includes — so while the signature holds, a re-probe can only return
- * what is already cached. The short TTL above is the no-signature fallback
- * (remote runtimes, an unreadable gitdir), where nothing invalidates on change.
- */
+// Signed entries revalidate against Git config before reuse.
 const OWNER_REPO_SIGNED_CACHE_TTL_MS = 5 * 60_000
 const OWNER_REPO_CACHE_MAX_ENTRIES = 512
 
@@ -143,10 +137,7 @@ export async function getOwnerRepoForRemote(
   pruneOwnerRepoCache(now)
   const cached = ownerRepoCache.get(cacheKey)
   if (cached && cached.expiresAt > now) {
-    // Why every signed entry, not only the negatives: a positive identity is
-    // held for the same five minutes now, so the same revalidation is what
-    // keeps a `git remote set-url` visible within one lookup rather than five
-    // minutes. The signature read is fs stat/readFile, not a Git subprocess.
+    // Revalidate signed hits so remote changes are immediately visible.
     if (cached.configSignature !== undefined) {
       const currentSignature = await readLocalGitConfigSignature(context)
       if (currentSignature !== cached.configSignature) {
@@ -215,10 +206,7 @@ async function resolveOwnerRepoForRemote(
     // Why: PR mutations need the effective host behind an SSH alias.
     const classification = await classifyGitHubOwnerRepoFromRemoteUrl(remoteUrl, context)
     if (classification.kind === 'github') {
-      // Why store the signature: without it this entry can only expire on the
-      // clock, which put a `git remote get-url` (plus its ssh-alias probe) on
-      // every PR refresh cycle — the second most frequent Git subprocess in a
-      // Windows field trace, on a host spawning Git at ~250-800ms a call.
+      // Signed identities stay valid until Git config changes.
       ownerRepoCache.set(cacheKey, {
         value: classification.ownerRepo,
         expiresAt: now + getOwnerRepoCacheTtl(classification.ownerRepo, configSignature),


### PR DESCRIPTION
## ELI5

Follow-up to #16450: keep the cache rationale, remove the incident narrative from source comments.

## What Changed

- Condensed seven multi-line comments in the repository-identity cache and its tests to one-line invariants.
- No production behavior changed.

## Why

`AGENTS.md` requires concise, non-obvious comments. The original PR put performance measurements and PR-level explanation in code instead of the PR body.

## Linked Issue

Follow-up to #16450.

## Visual Proof

N/A — comments only.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests unchanged and rerun

`pnpm exec vitest run --config config/vitest.config.ts src/main/github/github-repository-identity.signed-cache.test.ts src/main/github/gh-utils.test.ts` — 40 tests passed.

Pre-commit oxlint, React Doctor lint, and oxfmt passed.

## AI Disclosure

<!-- Internal contributor; intentionally not filled. -->

## Review

Comments only; no runtime, compatibility, persistence, RPC, Git, SSH, WSL, or UI behavior changed.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

None.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Targeted tests and pre-commit checks pass; CI covers the full build