### PR TITLE
feat(editor): highlight XAML files as XML

### DIFF
--- a/src/renderer/src/lib/language-detect.test.ts
+++ b/src/renderer/src/lib/language-detect.test.ts
@@ -14,6 +14,11 @@ describe('detectLanguage', () => {
     expect(detectLanguage('src/routes/index.astro')).toBe('astro')
   })
 
+  it('maps XAML files to the Monaco built-in xml language id (case-insensitive)', () => {
+    expect(detectLanguage('src/App.xaml')).toBe('xml')
+    expect(detectLanguage('C:\\repo\\Views\\MAINWINDOW.XAML')).toBe('xml')
+  })
+
   it('maps Nim files to the nim language id', () => {
     expect(detectLanguage('src/main.nim')).toBe('nim')
     expect(detectLanguage('tasks/build.nims')).toBe('nim')

--- a/src/renderer/src/lib/language-detect.ts
+++ b/src/renderer/src/lib/language-detect.ts
@@ -43,6 +43,7 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
   // lookup below covers the compound form, so the single entry is enough.
   '.liquid': 'liquid',
   '.xml': 'xml',
+  '.xaml': 'xml',
   '.svg': 'xml',
   '.py': 'python',
   '.rs': 'rust',


### PR DESCRIPTION
## ELI5

Orca currently opens XAML files as plain text. This teaches the editor to treat `.xaml` files as XML so Monaco's built-in XML highlighting can color their tags, attributes, values, and comments.

## What Changed

- Map `.xaml` to Monaco's built-in `xml` language id.
- Cover a normal XAML path and a case-insensitive Windows path with a focused regression test.

## Why

XAML is XML, so the existing built-in XML support provides useful highlighting without adding a grammar, dependency, icon mapping, or language registration.

## Linked Issue

Fixes #16396

## Visual Proof

Rendered Electron QA passed through the repository's Playwright Electron fixture:

- Opened a real `MainWindow.xaml` from Orca's File Explorer.
- Confirmed the active Monaco model language is `xml`.
- Confirmed Monaco rendered six distinct token styles across XAML element names, attributes, values, and comments.
- Captured and visually inspected the screenshot below.

<img width="5120" height="2636" alt="orca-xaml-syntax-highlighting" src="https://github.com/user-attachments/assets/6458362d-35df-4c9e-bc96-71df21c46008" />

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below
- [x] `pnpm lint` — passed
- [x] `pnpm typecheck` — passed
- [ ] Full `pnpm test` — 60,979 passed and 248 skipped, with one unrelated interactive-zsh portability test failing under full-suite load; the exact file passes when focused
- [x] `pnpm build` — passed

Validated on macOS with Node 24.18.0 and pnpm 10.24.0:

- `pnpm test src/renderer/src/lib/language-detect.test.ts` — 16 tests passed.
- `pnpm tc:web` — passed.
- `pnpm run check:code-quality:changed` — passed with 0 new findings across 2 changed files.
- Repository Playwright Electron QA — 1 test passed in 24.0s; Monaco language `xml`, six distinct token styles.
- Clean full-suite run with `HISTFILE` unset, `ZDOTDIR=/var/empty`, and `--maxWorkers=2` — 6,546 files passed, 42 skipped, and 1 unrelated file failed; 60,979 tests passed, 248 skipped, and 1 failed. The prior Electron H3 egress timeout did not recur.
- Focused rerun of `src/shared/startup-shell-portability.live-shell.test.ts` — 171 passed and 16 skipped, including the exact zsh case that failed in the full run.
- A reduced `--maxWorkers=1` diagnostic rerun stalled in the same interactive zsh case; a process stack sample showed `/bin/zsh -i` waiting for input in ZLE, so the run was stopped rather than reported as passing.

The remaining full-suite failure is isolated from this PR's two language-detection files, and no unrelated source change was made.

Windows behavior was covered by the case-insensitive `C:\\...\\MAINWINDOW.XAML` regression path; Windows, Linux, and SSH were not manually tested.

## AI Disclosure

OpenAI Codex was used for implementation, validation, and PR preparation under user direction.

## Review

Ready for maintainer review.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- This is a renderer-only extension mapping. It does not change remote wire behavior, SSH execution, mobile behavior, security boundaries, or runtime performance.
- #16421 also edits the two language-detection files for unrelated OCaml support, but its hunks are disjoint and this PR includes none of that scope.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
