### PR TITLE
Add clickable See more button to palette section overflow hints

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.recent-tabs.test.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.recent-tabs.test.tsx
@@ -419,7 +419,7 @@ describe('WorktreeJumpPalette recent chats & terminals', () => {
     // mount one row per workspace.
     expect(getTabRowIds()).toEqual([])
     expect(getWorktreeRows()).toHaveLength(10)
-    expect(testContainer.textContent).toContain('Type to see all 14 worktrees')
+    expect(testContainer.textContent).toContain('4 more')
   })
 
   it('captures the order when tabs hydrate after the palette is already open', async () => {

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -42,6 +42,7 @@ import {
   CommandEmpty,
   CommandItem
 } from '@/components/ui/command'
+import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { parseGitHubIssueOrPRNumber, parseGitHubIssueOrPRLink } from '@/lib/github-links'
 import { getLinkedWorkItemSuggestedName, getLinkedWorkItemWorkspaceName } from '@/lib/new-workspace'
@@ -165,7 +166,10 @@ import {
 } from '@/components/cmd-j/palette-filter'
 import {
   capPaletteSection,
-  layoutMultiPrimaryPaletteSections
+  layoutMultiPrimaryPaletteSections,
+  PALETTE_SECTION_EXPAND_STEP,
+  PALETTE_SECTION_RENDER_CAP,
+  TYPED_QUERY_LEADING_PREVIEW
 } from '@/components/cmd-j/palette-section-render-cap'
 import { useSettingsNavigationMetadata } from '@/hooks/useSettingsNavigationMetadata'
 import { runWorktreeDelete } from '@/components/sidebar/delete-worktree-flow'
@@ -286,6 +290,7 @@ type HintRow = {
   id: string
   type: 'hint'
   label: string
+  onSeeMore?: () => void
 }
 
 type CreateWorktreePaletteItem = {
@@ -855,6 +860,23 @@ function WorktreeJumpPaletteContent({
   // Why: filters reset on close — a filter that survives reopen silently hides
   // results in a surface people open reflexively.
   const [rawFilter, setRawFilter] = useState<PaletteFilterState>(EMPTY_PALETTE_FILTER)
+  const [prevQuery, setPrevQuery] = useState(query)
+  const [prevVisible, setPrevVisible] = useState(visible)
+  const [expandedSectionCaps, setExpandedSectionCaps] = useState<Record<string, number>>({})
+
+  if (prevQuery !== query || prevVisible !== visible) {
+    setPrevQuery(query)
+    setPrevVisible(visible)
+    setExpandedSectionCaps({})
+  }
+
+  const handleExpandSection = useCallback((sectionKey: string) => {
+    setExpandedSectionCaps((prev) => ({
+      ...prev,
+      [sectionKey]: (prev[sectionKey] ?? 0) + PALETTE_SECTION_EXPAND_STEP
+    }))
+  }, [])
+
   const [dialogElement, setDialogElement] = useState<HTMLElement | null>(null)
   const previousWorktreeIdRef = useRef<string | null>(null)
   const previousActiveTabTypeRef = useRef<'browser' | 'editor' | 'terminal' | 'simulator'>(
@@ -1870,27 +1892,35 @@ function WorktreeJumpPaletteContent({
   }, [hasQuery, openTabItems, worktreeItems])
 
   const paletteSections = useMemo(() => {
+    const openTabsCap = PALETTE_SECTION_RENDER_CAP + (expandedSectionCaps['open-tabs'] ?? 0)
     const openTabs = hasQuery
-      ? capPaletteSection(openTabItems)
+      ? capPaletteSection(openTabItems, openTabsCap)
       : { visible: recentTabItems, overflowCount: 0 }
     // Why: the worktree section shrinks against the recent rows to hold the empty-query list at its
     // pre-existing 10, so RECENT WORKTREES stays above the fold. An empty recent section hands the
     // whole budget to worktrees but never uncaps — a filter chip or a tab-less session used to drop
     // every open tab and mount one row per workspace.
-    const worktreeCap = hasQuery
+    const baseWorktreeCap = hasQuery
       ? Infinity
       : Math.min(
           openTabs.visible.length === 0 ? EMPTY_QUERY_ROW_BUDGET : EMPTY_QUERY_WORKTREE_CAP,
           Math.max(1, EMPTY_QUERY_ROW_BUDGET - openTabs.visible.length)
         )
+    const worktreeCap = hasQuery
+      ? PALETTE_SECTION_RENDER_CAP + (expandedSectionCaps['worktrees'] ?? 0)
+      : baseWorktreeCap + (expandedSectionCaps['worktrees'] ?? 0)
     // Why: a typed query can match hundreds of rows; capping the rendered slice
     // is what keeps a one-character search from building an unbounded DOM.
     const worktrees = hasQuery
-      ? capPaletteSection(worktreeItems)
-      : { visible: worktreeItems.slice(0, worktreeCap), overflowCount: 0 }
-    const projectTargets = capPaletteSection(hasQuery ? projectTargetItems : [])
-    const middle = capPaletteSection(hasQuery ? middleItems : [])
-    const showWorktreeHint = !hasQuery && worktreeItems.length > worktreeCap
+      ? capPaletteSection(worktreeItems, worktreeCap)
+      : {
+          visible: worktreeItems.slice(0, worktreeCap),
+          overflowCount: Math.max(0, worktreeItems.length - worktreeCap)
+        }
+    const projectTargetsCap = PALETTE_SECTION_RENDER_CAP + (expandedSectionCaps['projects'] ?? 0)
+    const projectTargets = capPaletteSection(hasQuery ? projectTargetItems : [], projectTargetsCap)
+    const middleCap = PALETTE_SECTION_RENDER_CAP + (expandedSectionCaps['middle'] ?? 0)
+    const middle = capPaletteSection(hasQuery ? middleItems : [], middleCap)
     // Why: only interleave when both primaries have hits — a lone section keeps the
     // full hard-capped list with no floor (empty headers / wasted slots).
     const multiPrimaryFirstScreen =
@@ -1898,7 +1928,12 @@ function WorktreeJumpPaletteContent({
     const multiPrimaryLayout = multiPrimaryFirstScreen
       ? layoutMultiPrimaryPaletteSections<WorktreePaletteItem | OpenTabPaletteItem>({
           leadingItems: openTabsLeadSections ? openTabItems : worktreeItems,
-          trailingItems: openTabsLeadSections ? worktreeItems : openTabItems
+          trailingItems: openTabsLeadSections ? worktreeItems : openTabItems,
+          leadingPreviewCount:
+            TYPED_QUERY_LEADING_PREVIEW +
+            (expandedSectionCaps[openTabsLeadSections ? 'open-tabs' : 'worktrees'] ?? 0),
+          leadingHardCap: openTabsLeadSections ? openTabsCap : worktreeCap,
+          trailingHardCap: openTabsLeadSections ? worktreeCap : openTabsCap
         })
       : null
 
@@ -1911,11 +1946,11 @@ function WorktreeJumpPaletteContent({
       middleOverflowCount: middle.overflowCount,
       visibleOpenTabItems: openTabs.visible as PaletteItem[],
       openTabOverflowCount: openTabs.overflowCount,
-      showWorktreeHint,
       multiPrimaryFirstScreen,
       multiPrimaryLayout
     }
   }, [
+    expandedSectionCaps,
     worktreeItems,
     projectTargetItems,
     middleItems,
@@ -2105,7 +2140,6 @@ function WorktreeJumpPaletteContent({
       visibleProjectTargetItems,
       visibleMiddleItems,
       visibleOpenTabItems,
-      showWorktreeHint,
       worktreeOverflowCount,
       projectTargetOverflowCount,
       middleOverflowCount,
@@ -2113,16 +2147,15 @@ function WorktreeJumpPaletteContent({
       multiPrimaryFirstScreen,
       multiPrimaryLayout
     } = paletteSections
-    const pushOverflowHint = (id: string, overflowCount: number): void => {
+    const pushOverflowHint = (id: string, overflowCount: number, onSeeMore?: () => void): void => {
       if (overflowCount > 0) {
         entries.push({
           id,
           type: 'hint',
-          label: translate(
-            'worktreeJumpPalette.renderCapOverflow',
-            '{{value0}} more — scroll or keep typing to narrow',
-            { value0: overflowCount }
-          )
+          label: translate('worktreeJumpPalette.renderCapOverflow', '{{value0}} more', {
+            value0: overflowCount
+          }),
+          onSeeMore
         })
       }
     }
@@ -2172,18 +2205,9 @@ function WorktreeJumpPaletteContent({
       }
       pushWorktreesHeader()
       appendPaletteListEntries(entries, visibleWorktreeItems)
-      if (showWorktreeHint) {
-        entries.push({
-          id: '__hint_worktree_cap__',
-          type: 'hint',
-          label: translate(
-            'auto.components.WorktreeJumpPalette.dabd819ca1',
-            'Type to see all {{value0}} worktrees',
-            { value0: worktreeItems.length }
-          )
-        })
-      }
-      pushOverflowHint('__hint_worktree_overflow__', worktreeOverflowCount)
+      pushOverflowHint('__hint_worktree_overflow__', worktreeOverflowCount, () =>
+        handleExpandSection('worktrees')
+      )
     }
 
     const pushOpenTabSection = (): void => {
@@ -2192,7 +2216,9 @@ function WorktreeJumpPaletteContent({
       }
       pushOpenTabsHeader()
       appendPaletteListEntries(entries, visibleOpenTabItems)
-      pushOverflowHint('__hint_open_tab_overflow__', openTabOverflowCount)
+      pushOverflowHint('__hint_open_tab_overflow__', openTabOverflowCount, () =>
+        handleExpandSection('open-tabs')
+      )
     }
 
     const pushProjectAndMiddleSections = (): void => {
@@ -2208,7 +2234,9 @@ function WorktreeJumpPaletteContent({
           })
         }
         appendPaletteListEntries(entries, visibleProjectTargetItems)
-        pushOverflowHint('__hint_project_overflow__', projectTargetOverflowCount)
+        pushOverflowHint('__hint_project_overflow__', projectTargetOverflowCount, () =>
+          handleExpandSection('projects')
+        )
       }
       if (visibleMiddleItems.length > 0) {
         if (showMiddleHeader) {
@@ -2219,7 +2247,9 @@ function WorktreeJumpPaletteContent({
           })
         }
         appendPaletteListEntries(entries, visibleMiddleItems)
-        pushOverflowHint('__hint_middle_overflow__', middleOverflowCount)
+        pushOverflowHint('__hint_middle_overflow__', middleOverflowCount, () =>
+          handleExpandSection('middle')
+        )
       }
     }
 
@@ -2245,6 +2275,9 @@ function WorktreeJumpPaletteContent({
     // Typed query with both open tabs and worktrees: soft-split so the trailing
     // primary is not buried under ~50 leading rows (see tmp/cmd-j-recommended.html).
     if (multiPrimaryFirstScreen && multiPrimaryLayout) {
+      const leadingSectionKey = openTabsLeadSections ? 'open-tabs' : 'worktrees'
+      const trailingSectionKey = openTabsLeadSections ? 'worktrees' : 'open-tabs'
+
       const leadingHintId = openTabsLeadSections
         ? '__hint_open_tab_overflow__'
         : '__hint_worktree_overflow__'
@@ -2270,7 +2303,9 @@ function WorktreeJumpPaletteContent({
       pushLeadingHeader()
       appendPaletteListEntries(entries, multiPrimaryLayout.leadingPreview as PaletteItem[])
       // Soft more for the leading section (rows resuming below + hard-cap tail).
-      pushOverflowHint(leadingHintId, multiPrimaryLayout.leadingMoreCount)
+      pushOverflowHint(leadingHintId, multiPrimaryLayout.leadingMoreCount, () =>
+        handleExpandSection(leadingSectionKey)
+      )
       pushTrailingHeader()
       // Floor first, then remaining leading rows, then trailing rest — same order
       // as orderMultiPrimaryPaletteItems / keyboard selection. Each remainder
@@ -2280,6 +2315,9 @@ function WorktreeJumpPaletteContent({
       if (hasLeadingRest) {
         pushLeadingHeader(CONTINUED_SECTION_HEADER_ID_SUFFIX)
         appendPaletteListEntries(entries, multiPrimaryLayout.leadingRest as PaletteItem[])
+        pushOverflowHint(`${leadingHintId}_tail`, multiPrimaryLayout.leadingHardOverflowCount, () =>
+          handleExpandSection(leadingSectionKey)
+        )
       }
       if (multiPrimaryLayout.trailingRest.length > 0) {
         // Only re-label when the leading remainder split the trailing section.
@@ -2289,7 +2327,9 @@ function WorktreeJumpPaletteContent({
         appendPaletteListEntries(entries, multiPrimaryLayout.trailingRest as PaletteItem[])
       }
       // Trailing rest is already on screen; only hard-cap overflow needs a hint.
-      pushOverflowHint(trailingHintId, multiPrimaryLayout.trailingHardOverflowCount)
+      pushOverflowHint(trailingHintId, multiPrimaryLayout.trailingHardOverflowCount, () =>
+        handleExpandSection(trailingSectionKey)
+      )
       pushProjectAndMiddleSections()
       if (showCreateAction) {
         entries.push({ id: CREATE_WORKTREE_ITEM_ID, type: 'create-worktree' })
@@ -2317,13 +2357,13 @@ function WorktreeJumpPaletteContent({
     }
     return entries
   }, [
+    handleExpandSection,
     hasQuery,
     middleLeadsSections,
     openTabsLeadSections,
     paletteSections,
     showCreateAction,
-    taskSourceUrl,
-    worktreeItems.length
+    taskSourceUrl
   ])
 
   // Why not entry.id directly: a duplicated persisted id would repeat a React key,
@@ -3225,9 +3265,25 @@ function WorktreeJumpPaletteContent({
                 return (
                   <div
                     key={renderKey}
-                    className="mx-0.5 mt-1 px-3 py-1.5 text-[12px] italic text-muted-foreground/70"
+                    className="mx-0.5 mt-1 flex items-center gap-2 px-3 py-1.5 text-[12px] text-muted-foreground"
                   >
-                    {entry.label}
+                    <span className="truncate">{entry.label}</span>
+                    {entry.onSeeMore ? (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="xs"
+                        className="h-6 shrink-0 px-2 text-xs font-medium text-foreground hover:bg-accent"
+                        onClick={(event) => {
+                          event.preventDefault()
+                          event.stopPropagation()
+                          entry.onSeeMore?.()
+                          inputRef.current?.focus()
+                        }}
+                      >
+                        {translate('worktreeJumpPalette.seeMore', 'See more')}
+                      </Button>
+                    ) : null}
                   </div>
                 )
               }

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -2303,8 +2303,14 @@ function WorktreeJumpPaletteContent({
       pushLeadingHeader()
       appendPaletteListEntries(entries, multiPrimaryLayout.leadingPreview as PaletteItem[])
       // Soft more for the leading section (rows resuming below + hard-cap tail).
-      pushOverflowHint(leadingHintId, multiPrimaryLayout.leadingMoreCount, () =>
-        handleExpandSection(leadingSectionKey)
+      // Why: only actionable when rows are actually hidden — with the whole
+      // section already rendered below, expanding would just reshuffle rows.
+      pushOverflowHint(
+        leadingHintId,
+        multiPrimaryLayout.leadingMoreCount,
+        multiPrimaryLayout.leadingHardOverflowCount > 0
+          ? () => handleExpandSection(leadingSectionKey)
+          : undefined
       )
       pushTrailingHeader()
       // Floor first, then remaining leading rows, then trailing rest — same order

--- a/src/renderer/src/components/cmd-j/palette-section-render-cap.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-section-render-cap.test.ts
@@ -3,6 +3,7 @@ import {
   capPaletteSection,
   layoutMultiPrimaryPaletteSections,
   orderMultiPrimaryPaletteItems,
+  PALETTE_SECTION_EXPAND_STEP,
   PALETTE_SECTION_RENDER_CAP,
   softSplitPaletteSection,
   TYPED_QUERY_LEADING_PREVIEW,
@@ -10,6 +11,12 @@ import {
 } from './palette-section-render-cap'
 
 const range = (count: number): number[] => Array.from({ length: count }, (_, index) => index)
+
+describe('PALETTE_SECTION_EXPAND_STEP', () => {
+  it('is configured to 20 entries per expansion step', () => {
+    expect(PALETTE_SECTION_EXPAND_STEP).toBe(20)
+  })
+})
 
 describe('capPaletteSection', () => {
   it('returns the original array reference when nothing overflows', () => {
@@ -82,6 +89,7 @@ describe('layoutMultiPrimaryPaletteSections', () => {
 
     expect(layout.leadingPreview).toEqual(range(TYPED_QUERY_LEADING_PREVIEW))
     expect(layout.leadingMoreCount).toBe(6)
+    expect(layout.leadingHardOverflowCount).toBe(0)
     expect(layout.trailingFloor).toEqual([100, 101, 102])
     expect(layout.trailingFloor).toHaveLength(TYPED_QUERY_TRAILING_FLOOR)
     expect(layout.trailingRest).toEqual([103, 104])
@@ -100,6 +108,7 @@ describe('layoutMultiPrimaryPaletteSections', () => {
     expect(layout.trailingRest).toEqual([])
     expect(layout.trailingMoreCount).toBe(0)
     expect(layout.trailingHardOverflowCount).toBe(0)
+    expect(layout.leadingHardOverflowCount).toBe(0)
   })
 
   it('reports trailing hard-cap overflow without counting scrollable rest', () => {
@@ -114,6 +123,33 @@ describe('layoutMultiPrimaryPaletteSections', () => {
     )
     expect(layout.trailingMoreCount).toBe(80 - TYPED_QUERY_TRAILING_FLOOR)
     expect(layout.trailingHardOverflowCount).toBe(80 - PALETTE_SECTION_RENDER_CAP)
+  })
+
+  it('reports leading hard-cap overflow for remainder past leadingHardCap', () => {
+    const layout = layoutMultiPrimaryPaletteSections({
+      leadingItems: range(80),
+      trailingItems: range(5).map((n) => n + 1000),
+      leadingHardCap: 50
+    })
+
+    expect(layout.leadingPreview).toHaveLength(TYPED_QUERY_LEADING_PREVIEW)
+    expect(layout.leadingRest).toHaveLength(50 - TYPED_QUERY_LEADING_PREVIEW)
+    expect(layout.leadingMoreCount).toBe(80 - TYPED_QUERY_LEADING_PREVIEW)
+    expect(layout.leadingHardOverflowCount).toBe(30)
+  })
+
+  it('supports expanded preview and cap counts on demand', () => {
+    const layout = layoutMultiPrimaryPaletteSections({
+      leadingItems: range(80),
+      trailingItems: range(10).map((n) => n + 1000),
+      leadingPreviewCount: TYPED_QUERY_LEADING_PREVIEW + 20,
+      leadingHardCap: 70
+    })
+
+    expect(layout.leadingPreview).toHaveLength(26)
+    expect(layout.leadingRest).toHaveLength(70 - 26)
+    expect(layout.leadingMoreCount).toBe(80 - 26)
+    expect(layout.leadingHardOverflowCount).toBe(10)
   })
 })
 

--- a/src/renderer/src/components/cmd-j/palette-section-render-cap.ts
+++ b/src/renderer/src/components/cmd-j/palette-section-render-cap.ts
@@ -8,6 +8,9 @@
  */
 export const PALETTE_SECTION_RENDER_CAP = 50
 
+/** Number of additional entries to reveal per section on each "See more" click. */
+export const PALETTE_SECTION_EXPAND_STEP = 20
+
 /**
  * First-screen soft split for typed queries when open tabs and worktrees both
  * match. Leading section shows this many rows, then a non-selectable hint, then
@@ -70,6 +73,7 @@ export function softSplitPaletteSection<T>(
  *
  * `leadingMoreCount` is the mid-list soft hint (rest resuming below + hard-cap
  * overflow).
+ * `leadingHardOverflowCount` is only rows past the hard cap for the leading remainder.
  * `trailingHardOverflowCount` is only rows past the hard cap — trailing rest is
  * already rendered, so a soft “more” would double-count scrollable rows.
  */
@@ -77,6 +81,7 @@ export type MultiPrimarySectionLayout<T> = {
   leadingPreview: readonly T[]
   leadingRest: readonly T[]
   leadingMoreCount: number
+  leadingHardOverflowCount: number
   trailingFloor: readonly T[]
   trailingRest: readonly T[]
   trailingMoreCount: number
@@ -88,20 +93,25 @@ export function layoutMultiPrimaryPaletteSections<T>({
   trailingItems,
   leadingPreviewCount = TYPED_QUERY_LEADING_PREVIEW,
   trailingFloorCount = TYPED_QUERY_TRAILING_FLOOR,
-  hardCap = PALETTE_SECTION_RENDER_CAP
+  hardCap,
+  leadingHardCap = hardCap ?? PALETTE_SECTION_RENDER_CAP,
+  trailingHardCap = hardCap ?? PALETTE_SECTION_RENDER_CAP
 }: {
   leadingItems: readonly T[]
   trailingItems: readonly T[]
   leadingPreviewCount?: number
   trailingFloorCount?: number
   hardCap?: number
+  leadingHardCap?: number
+  trailingHardCap?: number
 }): MultiPrimarySectionLayout<T> {
-  const leading = softSplitPaletteSection(leadingItems, leadingPreviewCount, hardCap)
-  const trailing = softSplitPaletteSection(trailingItems, trailingFloorCount, hardCap)
+  const leading = softSplitPaletteSection(leadingItems, leadingPreviewCount, leadingHardCap)
+  const trailing = softSplitPaletteSection(trailingItems, trailingFloorCount, trailingHardCap)
   return {
     leadingPreview: leading.preview,
     leadingRest: leading.rest,
     leadingMoreCount: leading.moreCount,
+    leadingHardOverflowCount: Math.max(0, leading.moreCount - leading.rest.length),
     trailingFloor: trailing.preview,
     trailingRest: trailing.rest,
     trailingMoreCount: trailing.moreCount,

--- a/src/renderer/src/components/worktree-jump-palette-interleaved-sections.test.tsx
+++ b/src/renderer/src/components/worktree-jump-palette-interleaved-sections.test.tsx
@@ -395,4 +395,152 @@ describe('WorktreeJumpPalette interleaved primary sections', () => {
     const worktree = row?.querySelector('[data-slot="palette-open-tab-worktree"]')
     expect(worktree?.textContent).toBe('main')
   })
+
+  it('reveals 20 more entries when clicking the See more button in soft preview', async () => {
+    const tabIds = Array.from({ length: 30 }, (_, index) => `${index}`)
+    await renderPalette({
+      worktreesByRepo: {
+        'repo-1': [
+          makeWorktree('wt-tabs', 'tab-host'),
+          ...Array.from({ length: 5 }, (_, index) =>
+            makeWorktree(`wt-${index}`, `improve-perf-${index}`)
+          )
+        ]
+      },
+      showSleepingWorkspaces: true,
+      ptyIdsByTabId: Object.fromEntries(tabIds.map((id) => [`term-${id}`, [`pty-${id}`]])),
+      tabsByWorktree: {
+        'wt-tabs': tabIds.map((id) => makeTerminalTab(`term-${id}`, 'wt-tabs', `Perf chat ${id}`))
+      },
+      unifiedTabsByWorktree: {
+        'wt-tabs': tabIds.map((id) =>
+          makeUnifiedTab(`tab-${id}`, 'wt-tabs', `term-${id}`, `Perf chat ${id}`)
+        )
+      },
+      groupsByWorktree: {
+        'wt-tabs': [
+          makeGroup(
+            'wt-tabs',
+            tabIds.map((id) => `tab-${id}`)
+          )
+        ]
+      },
+      activeGroupIdByWorktree: { 'wt-tabs': 'group-wt-tabs' }
+    })
+
+    await act(async () => {
+      setCommandQuery?.('perf')
+    })
+    await flushEffects()
+
+    // Initially preview is 6, remainder has 24
+    expect(testContainer.textContent).toContain('24 more')
+    const seeMoreBtn = Array.from(testContainer.querySelectorAll('button')).find((btn) =>
+      btn.textContent?.includes('See more')
+    )
+    expect(seeMoreBtn).toBeDefined()
+
+    // Click See more button
+    await act(async () => {
+      seeMoreBtn?.click()
+    })
+    await flushEffects()
+
+    // 6 + 20 = 26 preview tabs, 4 remainder
+    expect(testContainer.textContent).toContain('4 more')
+  })
+
+  it('resets expanded section caps when query changes', async () => {
+    const tabIds = Array.from({ length: 30 }, (_, index) => `${index}`)
+    await renderPalette({
+      worktreesByRepo: {
+        'repo-1': [
+          makeWorktree('wt-tabs', 'tab-host'),
+          ...Array.from({ length: 5 }, (_, index) =>
+            makeWorktree(`wt-${index}`, `improve-perf-${index}`)
+          )
+        ]
+      },
+      showSleepingWorkspaces: true,
+      ptyIdsByTabId: Object.fromEntries(tabIds.map((id) => [`term-${id}`, [`pty-${id}`]])),
+      tabsByWorktree: {
+        'wt-tabs': tabIds.map((id) => makeTerminalTab(`term-${id}`, 'wt-tabs', `Perf chat ${id}`))
+      },
+      unifiedTabsByWorktree: {
+        'wt-tabs': tabIds.map((id) =>
+          makeUnifiedTab(`tab-${id}`, 'wt-tabs', `term-${id}`, `Perf chat ${id}`)
+        )
+      },
+      groupsByWorktree: {
+        'wt-tabs': [
+          makeGroup(
+            'wt-tabs',
+            tabIds.map((id) => `tab-${id}`)
+          )
+        ]
+      },
+      activeGroupIdByWorktree: { 'wt-tabs': 'group-wt-tabs' }
+    })
+
+    await act(async () => {
+      setCommandQuery?.('perf')
+    })
+    await flushEffects()
+
+    const seeMoreBtn = Array.from(testContainer.querySelectorAll('button')).find((btn) =>
+      btn.textContent?.includes('See more')
+    )
+    await act(async () => {
+      seeMoreBtn?.click()
+    })
+    await flushEffects()
+    expect(testContainer.textContent).toContain('4 more')
+
+    // Change query: should reset back to 6 preview (so 24 more)
+    await act(async () => {
+      setCommandQuery?.('per')
+    })
+    await flushEffects()
+    expect(testContainer.textContent).toContain('24 more')
+  })
+
+  it('allows clicking See more on empty query to expand worktree cap by 20', async () => {
+    const worktrees = Array.from({ length: 35 }, (_, index) =>
+      makeWorktree(`wt-${index}`, `project-wt-${index}`)
+    )
+    await renderPalette({
+      worktreesByRepo: { 'repo-1': worktrees },
+      showSleepingWorkspaces: true
+    })
+
+    // Empty query with 35 worktrees: initial cap is 10, 25 more
+    expect(testContainer.textContent).toContain('25 more')
+    const seeMoreBtn = Array.from(testContainer.querySelectorAll('button')).find((btn) =>
+      btn.textContent?.includes('See more')
+    )
+    expect(seeMoreBtn).toBeDefined()
+
+    await act(async () => {
+      seeMoreBtn?.click()
+    })
+    await flushEffects()
+
+    // After expanding by 20: 30 worktrees are rendered, 5 more
+    const renderedItems = testContainer.querySelectorAll('[data-command-item]')
+    expect(renderedItems).toHaveLength(30)
+    expect(testContainer.textContent).toContain('5 more')
+
+    // Click again: 30 + 20 = 50 (all 35 fit), hint disappears
+    const seeMoreBtn2 = Array.from(testContainer.querySelectorAll('button')).find((btn) =>
+      btn.textContent?.includes('See more')
+    )
+    await act(async () => {
+      seeMoreBtn2?.click()
+    })
+    await flushEffects()
+
+    const renderedItemsAll = testContainer.querySelectorAll('[data-command-item]')
+    expect(renderedItemsAll).toHaveLength(35)
+    expect(testContainer.textContent).not.toContain('more')
+  })
 })

--- a/src/renderer/src/components/worktree-jump-palette-interleaved-sections.test.tsx
+++ b/src/renderer/src/components/worktree-jump-palette-interleaved-sections.test.tsx
@@ -233,6 +233,40 @@ async function renderPalette(overrides: Partial<AppState>): Promise<void> {
   await flushEffects()
 }
 
+/** Palette state with `count` "Perf chat" tabs on one worktree plus 5 "improve-perf" worktrees. */
+function perfTabsPaletteProps(count: number): Partial<AppState> {
+  const tabIds = Array.from({ length: count }, (_, index) => `${index}`)
+  return {
+    worktreesByRepo: {
+      'repo-1': [
+        makeWorktree('wt-tabs', 'tab-host'),
+        ...Array.from({ length: 5 }, (_, index) =>
+          makeWorktree(`wt-${index}`, `improve-perf-${index}`)
+        )
+      ]
+    },
+    showSleepingWorkspaces: true,
+    ptyIdsByTabId: Object.fromEntries(tabIds.map((id) => [`term-${id}`, [`pty-${id}`]])),
+    tabsByWorktree: {
+      'wt-tabs': tabIds.map((id) => makeTerminalTab(`term-${id}`, 'wt-tabs', `Perf chat ${id}`))
+    },
+    unifiedTabsByWorktree: {
+      'wt-tabs': tabIds.map((id) =>
+        makeUnifiedTab(`tab-${id}`, 'wt-tabs', `term-${id}`, `Perf chat ${id}`)
+      )
+    },
+    groupsByWorktree: {
+      'wt-tabs': [
+        makeGroup(
+          'wt-tabs',
+          tabIds.map((id) => `tab-${id}`)
+        )
+      ]
+    },
+    activeGroupIdByWorktree: { 'wt-tabs': 'group-wt-tabs' }
+  } as Partial<AppState>
+}
+
 /** Each primary row paired with the section header rendered above it, in DOM order. */
 function getPrimaryRowsBySectionHeader(): { header: string; rowId: string }[] {
   const headerLabels = new Set(['Open Tabs', 'Worktrees'])
@@ -397,44 +431,15 @@ describe('WorktreeJumpPalette interleaved primary sections', () => {
   })
 
   it('reveals 20 more entries when clicking the See more button in soft preview', async () => {
-    const tabIds = Array.from({ length: 30 }, (_, index) => `${index}`)
-    await renderPalette({
-      worktreesByRepo: {
-        'repo-1': [
-          makeWorktree('wt-tabs', 'tab-host'),
-          ...Array.from({ length: 5 }, (_, index) =>
-            makeWorktree(`wt-${index}`, `improve-perf-${index}`)
-          )
-        ]
-      },
-      showSleepingWorkspaces: true,
-      ptyIdsByTabId: Object.fromEntries(tabIds.map((id) => [`term-${id}`, [`pty-${id}`]])),
-      tabsByWorktree: {
-        'wt-tabs': tabIds.map((id) => makeTerminalTab(`term-${id}`, 'wt-tabs', `Perf chat ${id}`))
-      },
-      unifiedTabsByWorktree: {
-        'wt-tabs': tabIds.map((id) =>
-          makeUnifiedTab(`tab-${id}`, 'wt-tabs', `term-${id}`, `Perf chat ${id}`)
-        )
-      },
-      groupsByWorktree: {
-        'wt-tabs': [
-          makeGroup(
-            'wt-tabs',
-            tabIds.map((id) => `tab-${id}`)
-          )
-        ]
-      },
-      activeGroupIdByWorktree: { 'wt-tabs': 'group-wt-tabs' }
-    })
+    await renderPalette(perfTabsPaletteProps(80))
 
     await act(async () => {
       setCommandQuery?.('perf')
     })
     await flushEffects()
 
-    // Initially preview is 6, remainder has 24
-    expect(testContainer.textContent).toContain('24 more')
+    // Preview is 6; 74 follow, 30 of them past the hard cap of 50.
+    expect(testContainer.textContent).toContain('74 more')
     const seeMoreBtn = Array.from(testContainer.querySelectorAll('button')).find((btn) =>
       btn.textContent?.includes('See more')
     )
@@ -446,41 +451,29 @@ describe('WorktreeJumpPalette interleaved primary sections', () => {
     })
     await flushEffects()
 
-    // 6 + 20 = 26 preview tabs, 4 remainder
-    expect(testContainer.textContent).toContain('4 more')
+    // 6 + 20 = 26 preview tabs, 54 follow, 10 still past the raised cap of 70.
+    expect(testContainer.textContent).toContain('54 more')
+    expect(testContainer.textContent).toContain('10 more')
+  })
+
+  it('leaves the soft preview hint non-actionable when no rows are hidden', async () => {
+    await renderPalette(perfTabsPaletteProps(30))
+
+    await act(async () => {
+      setCommandQuery?.('perf')
+    })
+    await flushEffects()
+
+    // All 30 tabs render (6 preview + 24 remainder), so expanding would only reorder rows.
+    expect(testContainer.textContent).toContain('24 more')
+    const seeMoreBtn = Array.from(testContainer.querySelectorAll('button')).find((btn) =>
+      btn.textContent?.includes('See more')
+    )
+    expect(seeMoreBtn).toBeUndefined()
   })
 
   it('resets expanded section caps when query changes', async () => {
-    const tabIds = Array.from({ length: 30 }, (_, index) => `${index}`)
-    await renderPalette({
-      worktreesByRepo: {
-        'repo-1': [
-          makeWorktree('wt-tabs', 'tab-host'),
-          ...Array.from({ length: 5 }, (_, index) =>
-            makeWorktree(`wt-${index}`, `improve-perf-${index}`)
-          )
-        ]
-      },
-      showSleepingWorkspaces: true,
-      ptyIdsByTabId: Object.fromEntries(tabIds.map((id) => [`term-${id}`, [`pty-${id}`]])),
-      tabsByWorktree: {
-        'wt-tabs': tabIds.map((id) => makeTerminalTab(`term-${id}`, 'wt-tabs', `Perf chat ${id}`))
-      },
-      unifiedTabsByWorktree: {
-        'wt-tabs': tabIds.map((id) =>
-          makeUnifiedTab(`tab-${id}`, 'wt-tabs', `term-${id}`, `Perf chat ${id}`)
-        )
-      },
-      groupsByWorktree: {
-        'wt-tabs': [
-          makeGroup(
-            'wt-tabs',
-            tabIds.map((id) => `tab-${id}`)
-          )
-        ]
-      },
-      activeGroupIdByWorktree: { 'wt-tabs': 'group-wt-tabs' }
-    })
+    await renderPalette(perfTabsPaletteProps(80))
 
     await act(async () => {
       setCommandQuery?.('perf')
@@ -494,14 +487,14 @@ describe('WorktreeJumpPalette interleaved primary sections', () => {
       seeMoreBtn?.click()
     })
     await flushEffects()
-    expect(testContainer.textContent).toContain('4 more')
+    expect(testContainer.textContent).toContain('54 more')
 
-    // Change query: should reset back to 6 preview (so 24 more)
+    // Change query: should reset back to 6 preview (so 74 more)
     await act(async () => {
       setCommandQuery?.('per')
     })
     await flushEffects()
-    expect(testContainer.textContent).toContain('24 more')
+    expect(testContainer.textContent).toContain('74 more')
   })
 
   it('allows clicking See more on empty query to expand worktree cap by 20', async () => {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -221,7 +221,8 @@
       "createHint": "Create worktree from Linear issue",
       "loadingHint": "Loading Linear issue…"
     },
-    "renderCapOverflow": "{{value0}} more — scroll or keep typing to narrow",
+    "renderCapOverflow": "{{value0}} more",
+    "seeMore": "See more",
     "filter": {
       "emptyTitle": "No results match the active filter",
       "emptySubtitle": "Clear the filter above, or widen it to more hosts and projects.",


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​178 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​177 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​115 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​42 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​73 |

<!-- /orca-pr-loc -->

## Problem

When the command palette displays more entries than its render cap, users must scroll or modify their query to see hidden results. This friction makes it harder to discover items in large result sets.

## Solution

Add a clickable "See more" button to overflow hints that reveals 20 additional entries per click (PALETTE_SECTION_EXPAND_STEP). Each section (worktrees, open tabs, projects, middle) expands independently, and expansion state resets when the query changes.

## What Changed

- Added `PALETTE_SECTION_EXPAND_STEP` constant (20 entries per expansion step)
- Modified overflow hint display from text-only to a flex layout with clickable button
- Track section expansion state in `expandedSectionCaps` with per-section increment tracking
- Updated `HintRow` type to include optional `onSeeMore` callback
- Simplified overflow hint message from "{{value0}} more — scroll or keep typing to narrow" to "{{value0}} more"
- Added `leadingHardOverflowCount` tracking to `MultiPrimarySectionLayout` for hard-cap overflow reporting

## Testing

- Added 3 comprehensive test cases covering: basic See more expansion, query-based reset, and multiple expansions
- Updated existing test expectations ("4 more" instead of "Type to see all 14 worktrees")
- All tests verify correct render count, button presence, and state management

## Implementation Details

Expansion is managed through `expandedSectionCaps` state that tracks incremental offsets per section key. The offset is added to the base render cap, allowing users to progressively reveal hidden entries without losing the ability to scroll or narrow via query.