### PR TITLE
fix(mobile): make agent markdown text selectable

### DIFF
--- a/mobile/src/components/MobileMarkdown.selection.test.ts
+++ b/mobile/src/components/MobileMarkdown.selection.test.ts
@@ -67,4 +67,19 @@ describe('MobileMarkdown text selection', () => {
       ).toBe(true)
     }
   })
+
+  it('preserves the active paragraph Text while prose streams', () => {
+    act(() => {
+      renderer = create(createElement(MobileMarkdown, { content: 'Streaming response' }))
+    })
+    const initialParagraph = renderer!.root.findByType('Text' as never)
+
+    act(() => {
+      renderer!.update(createElement(MobileMarkdown, { content: 'Streaming response continues' }))
+    })
+
+    const updatedParagraph = renderer!.root.findByType('Text' as never)
+    expect(updatedParagraph).toBe(initialParagraph)
+    expect(flattenText(updatedParagraph)).toBe('Streaming response continues')
+  })
 })

--- a/mobile/src/components/MobileMarkdown.selection.test.ts
+++ b/mobile/src/components/MobileMarkdown.selection.test.ts
@@ -1,0 +1,70 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { MobileMarkdown } from './MobileMarkdown'
+
+vi.mock('react-native', () => ({
+  Linking: { openURL: vi.fn(() => Promise.resolve()) },
+  Pressable: 'Pressable',
+  ScrollView: 'ScrollView',
+  StyleSheet: { create: (styles: unknown) => styles, hairlineWidth: 1 },
+  Text: 'Text',
+  View: 'View'
+}))
+vi.mock('./pr-sidebar/MermaidDiagram', () => ({ MermaidDiagram: 'MermaidDiagram' }))
+
+function flattenText(node: ReactTestInstance): string {
+  return node.children
+    .map((child) => (typeof child === 'string' ? child : flattenText(child)))
+    .join('')
+}
+
+describe('MobileMarkdown text selection', () => {
+  let renderer: ReactTestRenderer | null = null
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+  })
+
+  it('makes every Markdown-visible Text path selectable', () => {
+    const content = [
+      'Ordinary agent prose.',
+      '# Agent heading',
+      '> Quoted guidance',
+      '- Listed action',
+      'Use `inlineCode` here.',
+      '```ts\nconst answer = 42\n```',
+      '| Name | State |\n| --- | --- |\n| Orca | Ready |',
+      '![Architecture diagram](https://example.com/diagram.png)'
+    ].join('\n\n')
+
+    act(() => {
+      renderer = create(createElement(MobileMarkdown, { content }))
+    })
+
+    const textNodes = renderer!.root.findAll((node) => node.type === ('Text' as never))
+    const visibleText = textNodes.map(flattenText)
+    expect(visibleText).toEqual(
+      expect.arrayContaining([
+        'Ordinary agent prose.',
+        'Agent heading',
+        'Quoted guidance',
+        'Listed action',
+        'inlineCode',
+        'ts',
+        'const answer = 42',
+        'Name',
+        'Orca',
+        'Architecture diagram',
+        'https://example.com/diagram.png'
+      ])
+    )
+    for (const node of textNodes) {
+      expect(
+        node.props.selectable,
+        `${JSON.stringify(flattenText(node))} should be selectable`
+      ).toBe(true)
+    }
+  })
+})

--- a/mobile/src/components/MobileMarkdown.tsx
+++ b/mobile/src/components/MobileMarkdown.tsx
@@ -209,7 +209,7 @@ function MobileMarkdownInner({ content, fallback = '', textScale = 1, onOpenFile
     ) : null
   }
   const mermaidSourceOccurrences = new Map<string, number>()
-  const paragraphSourceOccurrences = new Map<string, number>()
+  let paragraphOccurrence = 0
 
   return (
     <View style={styles.root}>
@@ -338,13 +338,10 @@ function MobileMarkdownInner({ content, fallback = '', textScale = 1, onOpenFile
         if (block.type === 'rule') {
           return <View key={index} style={styles.rule} />
         }
-        const occurrence = paragraphSourceOccurrences.get(block.text) ?? 0
-        paragraphSourceOccurrences.set(block.text, occurrence + 1)
+        const paragraphKey = `paragraph:${paragraphOccurrence}`
+        paragraphOccurrence += 1
         return (
-          <SelectableMarkdownText
-            key={`${block.text}:${occurrence}`}
-            style={[styles.paragraph, proseScale]}
-          >
+          <SelectableMarkdownText key={paragraphKey} style={[styles.paragraph, proseScale]}>
             {block.text.split('\n').map((line, lineIndex) => (
               <Fragment key={lineIndex}>
                 {lineIndex > 0 ? '\n' : null}

--- a/mobile/src/components/MobileMarkdown.tsx
+++ b/mobile/src/components/MobileMarkdown.tsx
@@ -1,5 +1,12 @@
 import { Fragment, memo, useMemo, type ReactNode } from 'react'
-import { Linking, Pressable, ScrollView, Text, View } from 'react-native'
+import {
+  Linking,
+  Pressable,
+  ScrollView,
+  Text as NativeText,
+  type TextProps,
+  View
+} from 'react-native'
 import { normalizeMobileMarkdownPreviewHtml } from './mobile-markdown-preview-html'
 import { styles } from './mobile-markdown-styles'
 import {
@@ -34,6 +41,10 @@ const MAX_TABLE_COLUMNS = 8
 /** Prose base size — passed to MermaidDiagram fallback mono text. */
 const MERMAID_BASE = 13
 
+function SelectableMarkdownText({ selectable = true, ...props }: TextProps) {
+  return <NativeText selectable={selectable} {...props} />
+}
+
 // Web/mail hrefs open the system handler; file-target hrefs (file: URIs and
 // scheme-less paths — the entire desktop file-link contract) go to onOpenFile.
 function openMarkdownHref(href: string, onOpenFile?: (pathText: string) => void): void {
@@ -64,13 +75,13 @@ function renderTextRun(
   return segments.map((segment, segmentIndex) => {
     if (segment.type === 'file') {
       return (
-        <Text
+        <SelectableMarkdownText
           key={`${keyPrefix}:${segmentIndex}`}
           style={styles.link}
           onPress={() => onOpenFile(segment.path)}
         >
           {segment.value}
-        </Text>
+        </SelectableMarkdownText>
       )
     }
     return <Fragment key={`${keyPrefix}:${segmentIndex}`}>{segment.value}</Fragment>
@@ -105,22 +116,34 @@ function renderInline(text: string, onOpenFile?: (pathText: string) => void): Re
     const link = token.match(/^\[([^\]]+)\]\(([^)]+)\)$/)
     if (image) {
       parts.push(
-        <Text key={key} style={styles.link} onPress={() => openMarkdownHref(image[2]!, onOpenFile)}>
+        <SelectableMarkdownText
+          key={key}
+          style={styles.link}
+          onPress={() => openMarkdownHref(image[2]!, onOpenFile)}
+        >
           {image[1] || 'image'}
-        </Text>
+        </SelectableMarkdownText>
       )
     } else if (link) {
       parts.push(
-        <Text key={key} style={styles.link} onPress={() => openMarkdownHref(link[2]!, onOpenFile)}>
+        <SelectableMarkdownText
+          key={key}
+          style={styles.link}
+          onPress={() => openMarkdownHref(link[2]!, onOpenFile)}
+        >
           {link[1]}
-        </Text>
+        </SelectableMarkdownText>
       )
     } else if (/^https?:\/\//i.test(token)) {
       const { url, trailing } = trimAutolinkTrailingPunctuation(token)
       parts.push(
-        <Text key={key} style={styles.link} onPress={() => openMarkdownHref(url, onOpenFile)}>
+        <SelectableMarkdownText
+          key={key}
+          style={styles.link}
+          onPress={() => openMarkdownHref(url, onOpenFile)}
+        >
           {url}
-        </Text>
+        </SelectableMarkdownText>
       )
       if (trailing) {
         parts.push(<Fragment key={`${key}p`}>{trailing}</Fragment>)
@@ -129,38 +152,38 @@ function renderInline(text: string, onOpenFile?: (pathText: string) => void): Re
       const code = token.slice(1, -1)
       if (onOpenFile && isFilePathCodeSpan(code)) {
         parts.push(
-          <Text
+          <SelectableMarkdownText
             key={key}
             style={[styles.inlineCode, styles.inlineCodeLink]}
             onPress={() => onOpenFile(normalizeFilePath(code.trim()))}
           >
             {code}
-          </Text>
+          </SelectableMarkdownText>
         )
       } else {
         parts.push(
-          <Text key={key} style={styles.inlineCode}>
+          <SelectableMarkdownText key={key} style={styles.inlineCode}>
             {code}
-          </Text>
+          </SelectableMarkdownText>
         )
       }
     } else if (token.startsWith('~~')) {
       parts.push(
-        <Text key={key} style={styles.strike}>
+        <SelectableMarkdownText key={key} style={styles.strike}>
           {renderTextRun(token.slice(2, -2), `${key}i`, onOpenFile)}
-        </Text>
+        </SelectableMarkdownText>
       )
     } else if (token.startsWith('**') || token.startsWith('__')) {
       parts.push(
-        <Text key={key} style={styles.bold}>
+        <SelectableMarkdownText key={key} style={styles.bold}>
           {renderTextRun(token.slice(2, -2), `${key}i`, onOpenFile)}
-        </Text>
+        </SelectableMarkdownText>
       )
     } else {
       parts.push(
-        <Text key={key} style={styles.italic}>
+        <SelectableMarkdownText key={key} style={styles.italic}>
           {renderTextRun(token.slice(1, -1), `${key}i`, onOpenFile)}
-        </Text>
+        </SelectableMarkdownText>
       )
     }
   }
@@ -181,27 +204,32 @@ function MobileMarkdownInner({ content, fallback = '', textScale = 1, onOpenFile
   const proseScale = scaled(13)
   const listScale = scaled(14)
   if (!text) {
-    return fallback ? <Text style={styles.paragraph}>{fallback}</Text> : null
+    return fallback ? (
+      <SelectableMarkdownText style={styles.paragraph}>{fallback}</SelectableMarkdownText>
+    ) : null
   }
   const mermaidSourceOccurrences = new Map<string, number>()
+  const paragraphSourceOccurrences = new Map<string, number>()
 
   return (
     <View style={styles.root}>
       {blocks.map((block, index) => {
         if (block.type === 'heading') {
           return (
-            <Text
+            <SelectableMarkdownText
               key={index}
               style={[styles.heading, block.level <= 2 ? styles.headingLarge : null]}
             >
               {renderInline(block.text, onOpenFile)}
-            </Text>
+            </SelectableMarkdownText>
           )
         }
         if (block.type === 'quote') {
           return (
             <View key={index} style={styles.quote}>
-              <Text style={styles.quoteText}>{renderInline(block.text, onOpenFile)}</Text>
+              <SelectableMarkdownText style={styles.quoteText}>
+                {renderInline(block.text, onOpenFile)}
+              </SelectableMarkdownText>
             </View>
           )
         }
@@ -222,8 +250,12 @@ function MobileMarkdownInner({ content, fallback = '', textScale = 1, onOpenFile
           }
           return (
             <View key={index} style={styles.codeBlock}>
-              {block.language ? <Text style={styles.codeLanguage}>{block.language}</Text> : null}
-              <Text style={styles.codeText}>{block.text}</Text>
+              {block.language ? (
+                <SelectableMarkdownText style={styles.codeLanguage}>
+                  {block.language}
+                </SelectableMarkdownText>
+              ) : null}
+              <SelectableMarkdownText style={styles.codeText}>{block.text}</SelectableMarkdownText>
             </View>
           )
         }
@@ -234,10 +266,12 @@ function MobileMarkdownInner({ content, fallback = '', textScale = 1, onOpenFile
               style={styles.imageFrame}
               onPress={() => openMarkdownHref(block.url, onOpenFile)}
             >
-              <Text style={styles.link}>{block.alt || 'Open image'}</Text>
-              <Text style={styles.imageCaption} numberOfLines={1}>
+              <SelectableMarkdownText style={styles.link}>
+                {block.alt || 'Open image'}
+              </SelectableMarkdownText>
+              <SelectableMarkdownText style={styles.imageCaption} numberOfLines={1}>
                 {block.url}
-              </Text>
+              </SelectableMarkdownText>
             </Pressable>
           )
         }
@@ -251,26 +285,29 @@ function MobileMarkdownInner({ content, fallback = '', textScale = 1, onOpenFile
               <View style={styles.table}>
                 <View style={styles.tableRow}>
                   {visibleHeaders.map((header, cellIndex) => (
-                    <Text key={cellIndex} style={[styles.tableCell, styles.tableHeader]}>
+                    <SelectableMarkdownText
+                      key={cellIndex}
+                      style={[styles.tableCell, styles.tableHeader]}
+                    >
                       {renderInline(header, onOpenFile)}
-                    </Text>
+                    </SelectableMarkdownText>
                   ))}
                 </View>
                 {visibleRows.map((row, rowIndex) => (
                   <View key={rowIndex} style={styles.tableRow}>
                     {visibleHeaders.map((_, cellIndex) => (
-                      <Text key={cellIndex} style={styles.tableCell}>
+                      <SelectableMarkdownText key={cellIndex} style={styles.tableCell}>
                         {renderInline(row[cellIndex] ?? '', onOpenFile)}
-                      </Text>
+                      </SelectableMarkdownText>
                     ))}
                   </View>
                 ))}
                 {hiddenRows > 0 || hiddenColumns > 0 ? (
-                  <Text style={styles.tableTruncated}>
+                  <SelectableMarkdownText style={styles.tableTruncated}>
                     {hiddenRows > 0 ? `${hiddenRows} more rows` : ''}
                     {hiddenRows > 0 && hiddenColumns > 0 ? ' · ' : ''}
                     {hiddenColumns > 0 ? `${hiddenColumns} more columns` : ''}
-                  </Text>
+                  </SelectableMarkdownText>
                 ) : null}
               </View>
             </ScrollView>
@@ -281,7 +318,7 @@ function MobileMarkdownInner({ content, fallback = '', textScale = 1, onOpenFile
             <View key={index} style={styles.list}>
               {block.items.map((item, itemIndex) => (
                 <View key={itemIndex} style={styles.listItem}>
-                  <Text style={styles.listMarker}>
+                  <SelectableMarkdownText style={styles.listMarker}>
                     {item.checked == null
                       ? block.ordered
                         ? `${itemIndex + 1}.`
@@ -289,10 +326,10 @@ function MobileMarkdownInner({ content, fallback = '', textScale = 1, onOpenFile
                       : item.checked
                         ? '[x]'
                         : '[ ]'}
-                  </Text>
-                  <Text style={[styles.listText, listScale]}>
+                  </SelectableMarkdownText>
+                  <SelectableMarkdownText style={[styles.listText, listScale]}>
                     {renderInline(item.text, onOpenFile)}
-                  </Text>
+                  </SelectableMarkdownText>
                 </View>
               ))}
             </View>
@@ -301,15 +338,20 @@ function MobileMarkdownInner({ content, fallback = '', textScale = 1, onOpenFile
         if (block.type === 'rule') {
           return <View key={index} style={styles.rule} />
         }
+        const occurrence = paragraphSourceOccurrences.get(block.text) ?? 0
+        paragraphSourceOccurrences.set(block.text, occurrence + 1)
         return (
-          <Text key={index} style={[styles.paragraph, proseScale]}>
+          <SelectableMarkdownText
+            key={`${block.text}:${occurrence}`}
+            style={[styles.paragraph, proseScale]}
+          >
             {block.text.split('\n').map((line, lineIndex) => (
               <Fragment key={lineIndex}>
                 {lineIndex > 0 ? '\n' : null}
                 {renderInline(line, onOpenFile)}
               </Fragment>
             ))}
-          </Text>
+          </SelectableMarkdownText>
         )
       })}
     </View>


### PR DESCRIPTION
## ELI5

Agent Markdown messages now opt into the native text-selection behavior that React Native leaves disabled by default. Long-press selection can therefore operate on individual prose, code, table, list, and image-label text instead of requiring whole-message copy.

## What Changed

- Added a local `SelectableMarkdownText` wrapper that defaults `selectable` to `true` while forwarding the existing React Native `TextProps`, including `onPress`.
- Used the wrapper for every Markdown-visible `Text` path: fallback text, prose, headings, block quotes, list markers/items, inline and fenced code, tables, image labels/captions, links, and detected file paths.
- Added a renderer regression covering representative visible Markdown paths without changing parsing, styling, clipboard behavior, terminal selection, or outgoing user bubbles.
- Kept paragraph keys independent of mutable content so streamed prose updates preserve the existing `Text` instance instead of forcing a remount.

## Why

React Native `Text` is not selectable unless the prop is enabled. `MobileMarkdown` renders agent output but none of its visible text nodes opted in, so iOS could not show native selection handles or the Select/Copy menu.

## Linked Issue

Fixes #16492

## Visual Proof

Local reproduction only: Expo Go on iOS 26.4 using an iPhone 17 Pro, importing the actual `MobileMarkdown` source from this worktree. This is not a full Orca dev-client or authenticated agent-chat QA run.

### Before — selection disabled in the local baseline wrapper

<img width="390" alt="Before: identical Markdown after the Orca long-press gesture with no Copy menu" src="https://github.com/user-attachments/assets/cc6320fe-c363-4996-bb0a-f8d5ecff8c63" />

For the baseline only, the local reproduction wrapper default was temporarily set to `selectable=false`. The Markdown content and Orca long-press gesture were identical; no native Copy menu appeared. The worktree source was not changed.

### After — selection enabled at PR HEAD

<img width="390" alt="After: identical Markdown after the Orca long-press gesture with the native Copy menu" src="https://github.com/user-attachments/assets/7777724a-9aac-4adc-b381-9d14c8789994" />

After restoring the PR HEAD behavior (`selectable=true`), the same Markdown and long-press gesture produced the native iOS Copy menu.

### Ordinary-link compatibility

<img width="390" alt="Compatibility proof: tapping an ordinary Markdown link opened example.com in Safari" src="https://github.com/user-attachments/assets/e768fa47-0e02-4841-a9c8-77c8168d65d6" />

An ordinary Markdown link tap still opened Safari at `example.com`.

## QA

- PASS — automated Simulator reproduction: Expo Go, iOS 26.4, iPhone 17 Pro, importing this worktree's actual `MobileMarkdown` source and interacting through `orca emulator`.
- PASS — before/after isolation: only the local wrapper default changed for the baseline; Markdown content and the long-press gesture stayed identical.
- PASS — native selection: PR HEAD displayed the iOS Copy menu after the same automated `orca emulator` long-press gesture on prose.
- PASS — link compatibility: an automated `orca emulator` tap on an ordinary Markdown link opened Safari at `example.com`.
- PASS — focused automated validation: `MobileMarkdown.selection`, `MobileMarkdown.file-links`, and `mobile-markdown-mermaid-routing` passed — 3 files and 21 tests.
- NOT RUN — full Orca dev-client and authenticated agent-chat QA.
- NOT RUN — human/manual long-press validation in the full Orca dev-client authenticated agent-chat route.
- BLOCKED — the full native dev-client build: Xcode 26.6 SDK build `23F81a` expects an unavailable iOS 26.5.1 runtime, while the downloaded iOS 26.5 runtime build `23F73` is incompatible.

## Testing

- RED: `volta run --node 24.18.0 --pnpm 10.24.0 pnpm test src/components/MobileMarkdown.selection.test.ts` failed on ordinary prose with `expected undefined to be true`, confirming the missing `selectable` behavior rather than test setup.
- RED (review follow-up): the same selection test failed when streamed prose changed from `Streaming response` to `Streaming response continues` because the rendered `Text` instance was replaced, confirming the content-derived key remounted the paragraph.
- PASS: `volta run --node 24.18.0 --pnpm 10.24.0 pnpm test src/components/MobileMarkdown.selection.test.ts src/components/MobileMarkdown.file-links.test.ts src/components/mobile-markdown-mermaid-routing.test.ts` — 3 files, 21 tests passed; this covers stable streamed paragraph identity plus existing link/file-path `onPress` and Mermaid identity behavior.
- PASS: `volta run --node 24.18.0 --pnpm 10.24.0 pnpm typecheck` from `mobile/`.
- PASS: `volta run --node 24.18.0 --pnpm 10.24.0 pnpm exec oxfmt --check src/components/MobileMarkdown.tsx src/components/MobileMarkdown.selection.test.ts`.
- PASS: `volta run --node 24.18.0 --pnpm 10.24.0 pnpm exec oxlint src/components/MobileMarkdown.tsx src/components/MobileMarkdown.selection.test.ts`.
- PASS: `volta run --node 24.18.0 --pnpm 10.24.0 pnpm run check:code-quality:changed` from the repository root — 0 code-quality, type-aware, or React Doctor findings.
- PASS: `volta run --node 24.18.0 --pnpm 10.24.0 pnpm lint` from the repository root — the full lint, audit, max-lines, bundled-skills, and localization checks passed.
- PASS: `volta run --node 24.18.0 --pnpm 10.24.0 pnpm typecheck` from the repository root.
- PASS: `env -u HISTFILE -u ORCA_HISTFILE GIT_CONFIG_GLOBAL=/dev/null ZDOTDIR=/tmp/orca-pr-16534-zdotdir.4zfZ7w volta run --node 24.18.0 --pnpm 10.24.0 pnpm test` from the repository root — 6,546 files and 60,975 tests passed; 43 files and 252 tests skipped. The clean environment isolates user Git hooks, shell history, and zsh startup files without changing repository or user settings.
- PASS: `volta run --node 24.18.0 --pnpm 10.24.0 pnpm build` from the repository root — renderer/web projection, built-skills CLI verification, native macOS components, and supporting builds completed successfully.
- BLOCKED: full native dev-client build — Xcode 26.6 SDK build `23F81a` expects an unavailable iOS 26.5.1 runtime; the downloaded iOS 26.5 runtime build `23F73` is incompatible.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated

## AI Disclosure

## Review

- Scope: only `MobileMarkdown` selection and its focused renderer regression; no terminal, clipboard, outgoing-message, parser, desktop, dependency, or style changes.
- Cross-platform: uses the standard React Native `TextProps.selectable` API and preserves all existing props and press handlers. No path, shortcut, SSH, folder-workspace, remote-wire, or provider behavior changes.
- Review follow-up: paragraph occurrence keys remain stable while the current block's text streams; the regression asserts that React preserves the same rendered `Text` test instance across the update.
- Current overlap recheck: no open PR mentions #16492 or implements `selectable` in `MobileMarkdown`. #15652 remains limited to outgoing user text. Open PRs that touch the same Markdown files cover localization/theme/file links/WebView routing or stale broad branches, and their current target patches contain no `selectable` implementation.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

This PR is ready for maintainer review and remains unmerged. Automated local Expo Go interaction evidence is attached; human/manual validation in the full Orca dev-client authenticated agent-chat route remains unverified because of the native runtime incompatibility documented above.

- X / Twitter handle: No public handle is linked to this GitHub account.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

