### PR TITLE
ci: rename cross-platform adhoc workflow

### DIFF
--- a/.github/workflows/adhoc-mac-build.yml
+++ b/.github/workflows/adhoc-mac-build.yml
@@ -1,16 +1,15 @@
-name: Adhoc macOS Dev Build
+name: Adhoc macOS + Windows Dev Build
 
-# Why: lets anyone cut a signed macOS build of an unlanded branch so the team can
-# actually run an experimental feature for a few days, instead of reasoning about
-# it from a diff. Hourly covers main; this covers everything that is not main yet.
+# Why: lets anyone cut installable macOS and Windows builds of a trusted repo ref
+# so the team can run an experimental feature instead of reasoning from a diff.
+# Hourly covers current main; this covers experiments and on-demand validation.
 #
-# Deliberately narrow scope, same trade as hourly:
-#   - macOS only. Other platforms keep using RC/stable.
+# Deliberately narrow scope:
+#   - macOS and Windows desktop installers. Linux keeps using RC/stable.
 #   - No tests, no lint, no e2e. PR CI and release-cut remain the gates.
-#   - Signed AND notarized, exactly like a release. macOS anchors a notarized
-#     app's TCC grants on identifier + team rather than on its cdhash, so those
-#     grants survive an update; an unnotarized build reads as a new client and
-#     silently loses file access under Documents/Desktop/Downloads.
+#   - macOS is signed and notarized so TCC grants survive updates.
+#   - Windows is unsigned; the published release notes explain the one-time
+#     SmartScreen/manual-install requirement.
 #
 # Artifacts publish to stablyai/orca-adhoc — separate from both orca and
 # orca-hourly. Separate from orca because the main repo's releases atom feed
@@ -310,7 +309,6 @@ jobs:
           (SmartScreen will warn about an unknown publisher). Every later switch,
           including back to Stable, works in-app from there."
           echo "tag=$TAG" >>"$GITHUB_OUTPUT"
-
 
       - name: Publish adhoc macOS artifacts
         uses: nick-fields/retry@v4


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 0 | 0 | 0 | 0 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

The ad-hoc workflow now builds both macOS and Windows, but the Actions UI still calls it “Adhoc macOS Dev Build.” Rename it so the button describes what it actually produces.

## What Changed

- Rename the workflow to `Adhoc macOS + Windows Dev Build`.
- Update the workflow header to describe signed macOS and unsigned Windows artifacts accurately.
- State explicitly that Linux is not part of this ad-hoc channel.

## Why

The stale macOS-only name and comments make a successful Windows leg look accidental and make the dispatch action hard to discover.

## Linked Issue

Follow-up to #16419 and #10857.

## Visual Proof

N/A — GitHub Actions metadata and comments only.

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts config/scripts/dev-channel-windows-workflow-contract.test.mjs` — 21 passed
- [x] `pnpm exec oxfmt --check .github/workflows/adhoc-mac-build.yml`

## Review

The workflow filename, job IDs, environment name, dispatch inputs, release channel, and macOS-to-Windows dependency remain unchanged.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

No runtime, packaging, signing, release, or artifact behavior changes.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Visual proof is N/A with a reason
- [x] Self-reviewed for correctness and performance
- [x] Cross-platform impact considered
- [x] Focused checks pass
