### PR TITLE
feat: add an opt-in Parallel Search MCP preset

### DIFF
--- a/src/renderer/src/components/settings/McpConfigSection.test.tsx
+++ b/src/renderer/src/components/settings/McpConfigSection.test.tsx
@@ -118,6 +118,31 @@ describe('McpConfigSection Parallel preset', () => {
     )
   })
 
+  it.each([
+    ['Add Parallel Search', 'Add MCP config', PARALLEL_SEARCH_MCP_CONFIG],
+    ['Add MCP config', 'Add Parallel Search', MCP_STARTER_CONFIG]
+  ])('does not allow %s to race another preset write', async (first, second, content) => {
+    let finishWrite: (() => void) | undefined
+    mocks.writeFile.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        finishWrite = resolve
+      })
+    )
+    await renderSection()
+    const firstButton = screen.getByRole('button', { name: first })
+    const secondButton = screen.getByRole('button', { name: second })
+    fireEvent.click(firstButton)
+    fireEvent.click(firstButton)
+    fireEvent.click(secondButton)
+    fireEvent.click(secondButton)
+    await act(async () => finishWrite?.())
+    expect(mocks.writeFile).toHaveBeenCalledExactlyOnceWith({
+      filePath: '/test/workspace/.mcp.json',
+      content,
+      connectionId: undefined
+    })
+  })
+
   it('hides both creation actions when an existing config is detected', async () => {
     mocks.readDir.mockResolvedValue([{ name: '.mcp.json', isDirectory: false }])
     await renderSection()
@@ -126,5 +151,38 @@ describe('McpConfigSection Parallel preset', () => {
     )
     expect(screen.queryByRole('button', { name: 'Add MCP config' })).not.toBeInTheDocument()
     expect(mocks.writeFile).not.toHaveBeenCalled()
+  })
+
+  it('does not write while an existing config is still being inspected', async () => {
+    let finishInspection: ((entries: { name: string; isDirectory: boolean }[]) => void) | undefined
+    mocks.readDir.mockReturnValue(
+      new Promise((resolve) => {
+        finishInspection = resolve
+      })
+    )
+    await renderSection()
+    const button = screen.getByRole('button', { name: 'Add Parallel Search' })
+    fireEvent.click(button)
+    fireEvent.click(button)
+    await act(async () => finishInspection?.([{ name: '.mcp.json', isDirectory: false }]))
+    expect(mocks.writeFile).not.toHaveBeenCalled()
+  })
+
+  it('allows another preset after a failed write', async () => {
+    mocks.writeFile.mockRejectedValueOnce(new Error('Permission denied'))
+    await renderSection()
+    fireEvent.click(screen.getByRole('button', { name: 'Add Parallel Search' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Parallel Search' }))
+    const emptyButton = screen.getByRole('button', { name: 'Add MCP config' })
+    await waitFor(() => expect(emptyButton).toBeEnabled())
+    fireEvent.click(emptyButton)
+    fireEvent.click(emptyButton)
+    await waitFor(() =>
+      expect(mocks.writeFile).toHaveBeenLastCalledWith({
+        filePath: '/test/workspace/.mcp.json',
+        content: MCP_STARTER_CONFIG,
+        connectionId: undefined
+      })
+    )
   })
 })

--- a/src/renderer/src/components/settings/McpConfigSection.test.tsx
+++ b/src/renderer/src/components/settings/McpConfigSection.test.tsx
@@ -153,6 +153,24 @@ describe('McpConfigSection Parallel preset', () => {
     expect(mocks.writeFile).not.toHaveBeenCalled()
   })
 
+  it.each(['.mcp.json', '.cursor'])(
+    'does not offer a preset when %s cannot be inspected',
+    async (name) => {
+      const error = new Error('EACCES: permission denied')
+      mocks.readDir.mockResolvedValueOnce([{ name, isDirectory: name === '.cursor' }])
+      if (name === '.cursor') {
+        mocks.readDir.mockRejectedValueOnce(error)
+      } else {
+        mocks.readFile.mockRejectedValueOnce(error)
+      }
+      await renderSection()
+      await screen.findByText(error.message)
+      expect(screen.queryByRole('button', { name: 'Add Parallel Search' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: 'Add MCP config' })).not.toBeInTheDocument()
+      expect(mocks.writeFile).not.toHaveBeenCalled()
+    }
+  )
+
   it('does not write while an existing config is still being inspected', async () => {
     let finishInspection: ((entries: { name: string; isDirectory: boolean }[]) => void) | undefined
     mocks.readDir.mockReturnValue(

--- a/src/renderer/src/components/settings/McpConfigSection.test.tsx
+++ b/src/renderer/src/components/settings/McpConfigSection.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/repo-types'
+import { MCP_STARTER_CONFIG, PARALLEL_SEARCH_MCP_CONFIG } from '../../../../shared/mcp-config'
+
+const mocks = vi.hoisted(() => ({
+  state: {
+    activeWorktreeId: null,
+    worktreesByRepo: {},
+    sshConnectionStates: new Map(),
+    openFile: vi.fn(),
+    setActiveView: vi.fn(),
+    setActiveWorktree: vi.fn(),
+    ensureWorktreeRootGroup: vi.fn(() => 'root')
+  },
+  readDir: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn()
+}))
+
+vi.mock('../../store', () => ({
+  useAppStore: Object.assign(
+    (selector: (state: typeof mocks.state) => unknown) => selector(mocks.state),
+    { getState: () => mocks.state }
+  )
+}))
+vi.mock('@/i18n/i18n', () => ({ translate: (_key: string, fallback: string) => fallback }))
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+
+import { McpConfigSection } from './McpConfigSection'
+
+const repo: Repo = {
+  id: 'test-repo',
+  path: '/test/workspace',
+  displayName: 'Test',
+  badgeColor: '',
+  addedAt: 0
+}
+const disclosure =
+  'When an agent uses these tools, search objectives, queries, and fetched URLs are sent to Parallel. No API key is required.'
+
+async function renderSection(): Promise<void> {
+  render(<McpConfigSection repo={repo} />)
+  await waitFor(() => expect(mocks.readDir).toHaveBeenCalled())
+}
+
+describe('McpConfigSection Parallel preset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.readDir.mockResolvedValue([])
+    mocks.readFile.mockResolvedValue({ content: MCP_STARTER_CONFIG, isBinary: false })
+    mocks.writeFile.mockResolvedValue(undefined)
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        shell: { pathExists: vi.fn().mockResolvedValue(true) },
+        fs: {
+          readDir: mocks.readDir,
+          readFile: mocks.readFile,
+          writeFile: mocks.writeFile
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.useRealTimers()
+  })
+
+  it('shows and associates the disclosure before confirmation', async () => {
+    await renderSection()
+    expect(screen.getByText(disclosure)).toBeVisible()
+    expect(screen.getByRole('button', { name: 'Add Parallel Search' })).toHaveAccessibleDescription(
+      disclosure
+    )
+    expect(mocks.writeFile).not.toHaveBeenCalled()
+  })
+
+  it('creates the Parallel preset only after a second click', async () => {
+    await renderSection()
+    fireEvent.click(screen.getByRole('button', { name: 'Add Parallel Search' }))
+    expect(mocks.writeFile).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm Parallel Search' }))
+    await waitFor(() =>
+      expect(mocks.writeFile).toHaveBeenCalledExactlyOnceWith({
+        filePath: '/test/workspace/.mcp.json',
+        content: PARALLEL_SEARCH_MCP_CONFIG,
+        connectionId: undefined
+      })
+    )
+  })
+
+  it('lets confirmation expire without writing a config', async () => {
+    await renderSection()
+    vi.useFakeTimers()
+    fireEvent.click(screen.getByRole('button', { name: 'Add Parallel Search' }))
+    act(() => vi.advanceTimersByTime(3000))
+    expect(screen.getByRole('button', { name: 'Add Parallel Search' })).toBeInTheDocument()
+    expect(mocks.writeFile).not.toHaveBeenCalled()
+  })
+
+  it('requires separate confirmation when switching to the neutral starter', async () => {
+    await renderSection()
+    fireEvent.click(screen.getByRole('button', { name: 'Add Parallel Search' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Add MCP config' }))
+    expect(mocks.writeFile).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByRole('button', { name: 'Create empty config' }))
+    await waitFor(() =>
+      expect(mocks.writeFile).toHaveBeenCalledExactlyOnceWith({
+        filePath: '/test/workspace/.mcp.json',
+        content: MCP_STARTER_CONFIG,
+        connectionId: undefined
+      })
+    )
+  })
+
+  it('hides both creation actions when an existing config is detected', async () => {
+    mocks.readDir.mockResolvedValue([{ name: '.mcp.json', isDirectory: false }])
+    await renderSection()
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: 'Add Parallel Search' })).not.toBeInTheDocument()
+    )
+    expect(screen.queryByRole('button', { name: 'Add MCP config' })).not.toBeInTheDocument()
+    expect(mocks.writeFile).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/settings/McpConfigSection.tsx
+++ b/src/renderer/src/components/settings/McpConfigSection.tsx
@@ -46,6 +46,7 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
   )
   const [configs, setConfigs] = useState<LoadedMcpConfigInspection[]>([])
   const [loading, setLoading] = useState(true)
+  const [creating, setCreating] = useState(false)
   const [createConfirm, setCreateConfirm] = useState<'empty' | 'parallel' | null>(null)
   const createConfirmResetTimerRef = useRef<number | null>(null)
   const mountedRef = useMountedRef()
@@ -181,10 +182,10 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
     setActiveView('terminal')
   }
 
-  const handleCreateStarter = async (
-    preset: 'empty' | 'parallel',
-    content: string
-  ): Promise<void> => {
+  const handleCreateStarter = async (preset: 'empty' | 'parallel'): Promise<void> => {
+    if (!canCreateStarter || loading || creating) {
+      return
+    }
     if (createConfirm !== preset) {
       clearCreateConfirmResetTimer()
       setCreateConfirm(preset)
@@ -198,6 +199,7 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
     }
 
     const target = joinPath(targetRootPath, '.mcp.json')
+    setCreating(true)
     try {
       const sshExpectation = connectionId
         ? captureDirectSshMutationExpectation(useAppStore.getState(), connectionId)
@@ -206,7 +208,7 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
       // guess per-agent directory layouts or mutate agent-specific files.
       await window.api.fs.writeFile({
         filePath: target,
-        content,
+        content: preset === 'parallel' ? PARALLEL_SEARCH_MCP_CONFIG : MCP_STARTER_CONFIG,
         connectionId,
         ...sshExpectation
       })
@@ -239,6 +241,10 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
       )
     } catch (error) {
       toast.error(extractIpcErrorMessage(error, 'Failed to create MCP config.'))
+    } finally {
+      if (mountedRef.current) {
+        setCreating(false)
+      }
     }
   }
 
@@ -268,6 +274,7 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
           <Button
             variant="ghost"
             size="icon-sm"
+            disabled={loading || creating}
             onClick={() => void loadConfigs()}
             aria-label={translate(
               'auto.components.settings.McpConfigSection.f34c152dc0',
@@ -286,7 +293,8 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
                 variant={createConfirm === 'parallel' ? 'default' : 'outline'}
                 size="sm"
                 className="gap-1.5"
-                onClick={() => void handleCreateStarter('parallel', PARALLEL_SEARCH_MCP_CONFIG)}
+                disabled={loading || creating}
+                onClick={() => void handleCreateStarter('parallel')}
                 aria-describedby={parallelDisclosureId}
               >
                 <Plus className="size-3.5" />
@@ -304,7 +312,8 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
                 variant={createConfirm === 'empty' ? 'default' : 'outline'}
                 size="sm"
                 className="gap-1.5"
-                onClick={() => void handleCreateStarter('empty', MCP_STARTER_CONFIG)}
+                disabled={loading || creating}
+                onClick={() => void handleCreateStarter('empty')}
               >
                 <Plus className="size-3.5" />
                 {createConfirm === 'empty'

--- a/src/renderer/src/components/settings/McpConfigSection.tsx
+++ b/src/renderer/src/components/settings/McpConfigSection.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { AlertCircle, FileCode2, LoaderCircle, Plus, RefreshCw } from 'lucide-react'
 import { toast } from 'sonner'
 import { useMountedRef } from '@/hooks/useMountedRef'
@@ -34,6 +34,7 @@ function countServers(configs: LoadedMcpConfigInspection[]): number {
 }
 
 export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Element {
+  const parallelDisclosureId = useId()
   const openFile = useAppStore((state) => state.openFile)
   const setActiveView = useAppStore((state) => state.setActiveView)
   const setActiveWorktree = useAppStore((state) => state.setActiveWorktree)
@@ -285,13 +286,8 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
                 variant={createConfirm === 'parallel' ? 'default' : 'outline'}
                 size="sm"
                 className="gap-1.5"
-                onClick={() =>
-                  void handleCreateStarter('parallel', PARALLEL_SEARCH_MCP_CONFIG)
-                }
-                title={translate(
-                  'auto.components.settings.McpConfigSection.parallelDisclosure',
-                  'Search objectives, queries, and fetched URLs are sent to Parallel.'
-                )}
+                onClick={() => void handleCreateStarter('parallel', PARALLEL_SEARCH_MCP_CONFIG)}
+                aria-describedby={parallelDisclosureId}
               >
                 <Plus className="size-3.5" />
                 {createConfirm === 'parallel'
@@ -325,6 +321,15 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
           ) : null}
         </div>
       </div>
+
+      {canCreateStarter ? (
+        <p id={parallelDisclosureId} className="text-xs text-muted-foreground">
+          {translate(
+            'auto.components.settings.McpConfigSection.parallelDisclosure',
+            'When an agent uses these tools, search objectives, queries, and fetched URLs are sent to Parallel. No API key is required.'
+          )}
+        </p>
+      ) : null}
 
       <div className="rounded-md border border-border/50 bg-muted/20">
         <div className="flex items-center justify-between border-b border-border/50 px-3 py-2 text-xs text-muted-foreground">

--- a/src/renderer/src/components/settings/McpConfigSection.tsx
+++ b/src/renderer/src/components/settings/McpConfigSection.tsx
@@ -9,7 +9,8 @@ import {
   canInspectLocalMcpConfigRoot,
   inspectMcpConfigContent,
   MCP_CONFIG_CANDIDATES,
-  MCP_STARTER_CONFIG
+  MCP_STARTER_CONFIG,
+  PARALLEL_SEARCH_MCP_CONFIG
 } from '../../../../shared/mcp-config'
 import { useAppStore } from '../../store'
 import { joinPath } from '../../lib/path'
@@ -44,7 +45,7 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
   )
   const [configs, setConfigs] = useState<LoadedMcpConfigInspection[]>([])
   const [loading, setLoading] = useState(true)
-  const [createConfirm, setCreateConfirm] = useState(false)
+  const [createConfirm, setCreateConfirm] = useState<'empty' | 'parallel' | null>(null)
   const createConfirmResetTimerRef = useRef<number | null>(null)
   const mountedRef = useMountedRef()
   const [inspectionUnavailableMessage, setInspectionUnavailableMessage] = useState<string | null>(
@@ -179,14 +180,17 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
     setActiveView('terminal')
   }
 
-  const handleCreateStarter = async (): Promise<void> => {
-    if (!createConfirm) {
+  const handleCreateStarter = async (
+    preset: 'empty' | 'parallel',
+    content: string
+  ): Promise<void> => {
+    if (createConfirm !== preset) {
       clearCreateConfirmResetTimer()
-      setCreateConfirm(true)
+      setCreateConfirm(preset)
       createConfirmResetTimerRef.current = window.setTimeout(() => {
         createConfirmResetTimerRef.current = null
         if (mountedRef.current) {
-          setCreateConfirm(false)
+          setCreateConfirm(null)
         }
       }, 3000)
       return
@@ -201,13 +205,13 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
       // guess per-agent directory layouts or mutate agent-specific files.
       await window.api.fs.writeFile({
         filePath: target,
-        content: MCP_STARTER_CONFIG,
+        content,
         connectionId,
         ...sshExpectation
       })
       clearCreateConfirmResetTimer()
       if (mountedRef.current) {
-        setCreateConfirm(false)
+        setCreateConfirm(null)
       }
       await loadConfigs()
       setActiveWorktree(targetWorktreeId)
@@ -276,23 +280,48 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
             )}
           </Button>
           {canCreateStarter ? (
-            <Button
-              variant={createConfirm ? 'default' : 'outline'}
-              size="sm"
-              className="gap-1.5"
-              onClick={() => void handleCreateStarter()}
-            >
-              <Plus className="size-3.5" />
-              {createConfirm
-                ? translate(
-                    'auto.components.settings.McpConfigSection.0a5c1ead54',
-                    'Create empty config'
-                  )
-                : translate(
-                    'auto.components.settings.McpConfigSection.82436439eb',
-                    'Add MCP config'
-                  )}
-            </Button>
+            <>
+              <Button
+                variant={createConfirm === 'parallel' ? 'default' : 'outline'}
+                size="sm"
+                className="gap-1.5"
+                onClick={() =>
+                  void handleCreateStarter('parallel', PARALLEL_SEARCH_MCP_CONFIG)
+                }
+                title={translate(
+                  'auto.components.settings.McpConfigSection.parallelDisclosure',
+                  'Search objectives, queries, and fetched URLs are sent to Parallel.'
+                )}
+              >
+                <Plus className="size-3.5" />
+                {createConfirm === 'parallel'
+                  ? translate(
+                      'auto.components.settings.McpConfigSection.confirmParallel',
+                      'Confirm Parallel Search'
+                    )
+                  : translate(
+                      'auto.components.settings.McpConfigSection.addParallel',
+                      'Add Parallel Search'
+                    )}
+              </Button>
+              <Button
+                variant={createConfirm === 'empty' ? 'default' : 'outline'}
+                size="sm"
+                className="gap-1.5"
+                onClick={() => void handleCreateStarter('empty', MCP_STARTER_CONFIG)}
+              >
+                <Plus className="size-3.5" />
+                {createConfirm === 'empty'
+                  ? translate(
+                      'auto.components.settings.McpConfigSection.0a5c1ead54',
+                      'Create empty config'
+                    )
+                  : translate(
+                      'auto.components.settings.McpConfigSection.82436439eb',
+                      'Add MCP config'
+                    )}
+              </Button>
+            </>
           ) : null}
         </div>
       </div>

--- a/src/renderer/src/components/settings/McpConfigSection.tsx
+++ b/src/renderer/src/components/settings/McpConfigSection.tsx
@@ -102,7 +102,8 @@ export function McpConfigSection({ repo }: McpConfigSectionProps): React.JSX.Ele
     [targetRootPath]
   )
   const serverCount = useMemo(() => countServers(configs), [configs])
-  const canCreateStarter = detectedCount === 0 && !inspectionUnavailable
+  const canCreateStarter =
+    !inspectionUnavailable && configs.every((config) => config.status === 'missing')
 
   const loadConfigs = useCallback(async (): Promise<void> => {
     if (!mountedRef.current) {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -7255,7 +7255,7 @@
           "1f3665e35a": "MCP config created",
           "82436439eb": "Add MCP config",
           "0a5c1ead54": "Create empty config",
-          "parallelDisclosure": "Search objectives, queries, and fetched URLs are sent to Parallel.",
+          "parallelDisclosure": "When an agent uses these tools, search objectives, queries, and fetched URLs are sent to Parallel. No API key is required.",
           "confirmParallel": "Confirm Parallel Search",
           "addParallel": "Add Parallel Search"
         },

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -7254,7 +7254,10 @@
           "9ee215caf6": ".mcp.json",
           "1f3665e35a": "MCP config created",
           "82436439eb": "Add MCP config",
-          "0a5c1ead54": "Create empty config"
+          "0a5c1ead54": "Create empty config",
+          "parallelDisclosure": "Search objectives, queries, and fetched URLs are sent to Parallel.",
+          "confirmParallel": "Confirm Parallel Search",
+          "addParallel": "Add Parallel Search"
         },
         "MobileEmulatorAgentControlRow": {
           "1861982430": "Failed to load CLI status.",

--- a/src/shared/mcp-config.test.ts
+++ b/src/shared/mcp-config.test.ts
@@ -7,6 +7,7 @@ import {
   maskMcpEnv,
   MCP_CONFIG_CANDIDATES,
   MCP_STARTER_CONFIG,
+  PARALLEL_SEARCH_MCP_CONFIG,
   selectExistingMcpConfigCandidates
 } from './mcp-config'
 import {
@@ -150,6 +151,22 @@ describe('mcp-config', () => {
       status: 'valid',
       servers: []
     })
+  })
+
+  it('provides an anonymous Parallel Search HTTP preset', () => {
+    expect(inspectMcpConfigContent(workspaceCandidate, PARALLEL_SEARCH_MCP_CONFIG)).toMatchObject({
+      exists: true,
+      status: 'valid',
+      servers: [
+        {
+          name: 'parallel-search',
+          transport: 'http',
+          status: 'enabled',
+          url: 'https://search.parallel.ai/mcp'
+        }
+      ]
+    })
+    expect(PARALLEL_SEARCH_MCP_CONFIG).not.toMatch(/authorization|api[_-]?key|token/i)
   })
 
   it('parses the exact input boundary and rejects +1 before JSON parsing', () => {

--- a/src/shared/mcp-config.ts
+++ b/src/shared/mcp-config.ts
@@ -74,6 +74,16 @@ export const MCP_STARTER_CONFIG = `{
 }
 `
 
+export const PARALLEL_SEARCH_MCP_CONFIG = `{
+  "mcpServers": {
+    "parallel-search": {
+      "type": "http",
+      "url": "https://search.parallel.ai/mcp"
+    }
+  }
+}
+`
+
 export function getMcpConfigParentDirs(
   candidates: readonly McpConfigCandidate[] = MCP_CONFIG_CANDIDATES
 ): string[] {


### PR DESCRIPTION
## ELI5

Orca can now create a ready-to-use Parallel Search MCP workspace configuration when a user explicitly chooses and confirms that preset. Existing workspaces and the neutral empty-config action are unchanged.

## What Changed

- Added a confirmed **Add Parallel Search** action to the existing MCP Configs settings surface.
- Reused Orca's native `.mcp.json` creation path for local and SSH workspaces.
- Waits for config inspection and prevents overlapping preset writes.
- Configured the anonymous Streamable HTTP endpoint at `https://search.parallel.ai/mcp` without credentials or authorization headers.
- Added focused coverage for the exact native configuration and anonymous default.

Search objectives and queries reach Parallel when an agent invokes `web_search`. Requested URLs reach Parallel when an agent invokes the exposed `web_fetch` tool.

## Why

This gives Orca users an explicit no-key web research option while preserving all current defaults, existing MCP providers, and user-owned configuration.

## Linked Issue

N/A. Focused external contribution.

## Testing

Local checks on macOS with Node 24:

- Focused MCP settings, config, filesystem, SSH mutation, and path tests: 69 passed; one Windows-only test skipped.
- Competing-write and unreadable-file regressions failed before their fixes and passed afterward.
- Real-file smoke checks passed for confirmed config creation and preservation of unreadable config contents. SSH routing was checked with a mock.
- Web typechecking, focused oxlint, formatting, changed-code quality, and all three localization checks passed.
- `git diff --check`: passed.

Validation gaps:

- GitHub workflows still need maintainer approval before they can run.
- Native Electron UI checks were not run locally. No before/after screenshots are attached.
- Anonymous endpoint smoke testing returned Cloudflare HTTP 403/1010 from this host. The access block was not retried.
- Linux, Windows, and a live SSH workspace were not tested manually.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated and passed


## Review

No platform-specific paths or shell behavior were added. The existing local/SSH filesystem mutation path is preserved. Existing agents, MCP providers, and user configurations remain unchanged unless a user selects and confirms the preset. The preset contains no secret, header, or identifier; network disclosure is shown on the action. The change adds no background work or runtime dependency.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

Security, cross-platform behavior, remote SSH, mobile, backward compatibility, and performance were reviewed. There is no mobile-specific change and no work occurs until explicit opt-in.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [ ] Full lint, typecheck, test, and build suite (focused checks passed; GitHub workflows need maintainer approval)

## Author

X: @georgeatparallel

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.