### PR TITLE
fix(pty): match the echo shapes a real tty actually produces

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -425,6 +425,7 @@ jobs:
             src/main/zsh-wrapper-version-mismatch.live-shell.test.ts \
             src/renderer/src/components/terminal-pane/fish-color-scheme-child-stdin.node-pty.test.ts \
             src/shared/fish-query-reply-child-stdin.node-pty.test.ts \
+            src/shared/pty-reply-echo-shapes.node-pty.test.ts \
             src/shared/startup-shell-portability.live-shell.test.ts \
             src/shared/posix-command-path-lookup.test.ts
 
@@ -470,6 +471,7 @@ jobs:
             --exclude=src/main/zsh-wrapper-version-mismatch.live-shell.test.ts \
             --exclude=src/renderer/src/components/terminal-pane/fish-color-scheme-child-stdin.node-pty.test.ts \
             --exclude=src/shared/fish-query-reply-child-stdin.node-pty.test.ts \
+            --exclude=src/shared/pty-reply-echo-shapes.node-pty.test.ts \
             --exclude=src/shared/startup-shell-portability.live-shell.test.ts \
             --exclude=src/shared/posix-command-path-lookup.test.ts \
             --exclude=tests/e2e/cross-version-wire/** \

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -13016,7 +13016,7 @@
       "invariant": "The desktop PTY input queue retains at most 64 explicitly sourced pending terminal query replies and 4096 UTF-16 code units. Every retained reply reaches the provider as one atomic write, and the host writes each reply the moment it accepts it, so replies reach the PTY in the order they were produced with no queue that could reorder them. A reply's own echo is contained on the output side by projecting its known echo shapes; the ESC-initial verbatim shape is matched only when complete, never held as a partial, so a query torn at its own ESC is still answered. Overflow removes only the oldest query replies, never ordinary input except the documented modified-F3/CPR byte collision, and drain failures cannot clear a newer queue generation.",
       "oracle": "Synchronously enqueue separate 10,000-entry OSC and DA1 reply floods before the scheduled drain and assert that only the initial immediate reply and newest 64 pending replies are written, each as one provider write, before a trailing keystroke. At the host boundary, defer an OSC reply and assert that separate or legacy-coalesced DA1/CPR replies flush after it in observed query order. At the remote-runtime boundary, preserve separate writes around pending ordinary input, async validation, and viewport-claim buffering. Repeat behind 10,000 ordinary inputs and exercise the text ceiling, real xterm generation, provider-write failure, rejected yield, and clear/reuse generation fencing.",
       "commands": [
-        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-input-write-queue.test.ts src/renderer/src/components/terminal-pane/pty-transport-input-write.test.ts src/shared/terminal-query-reply.test.ts src/shared/pty-startup-ingress-live-query-reply.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-input-write-queue.test.ts src/renderer/src/components/terminal-pane/pty-transport-input-write.test.ts src/shared/terminal-query-reply.test.ts src/shared/pty-startup-ingress-live-query-reply.test.ts src/shared/pty-startup-reply-echo-shapes.test.ts",
         "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-batching.test.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-query-reply-immediate.test.ts src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-input-coalescing.test.ts",
         "pnpm exec playwright test tests/e2e/terminal-osc-color-queries.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
         "pnpm exec playwright test tests/e2e/terminal-typing-latency.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
@@ -13030,6 +13030,7 @@
         "src/renderer/src/components/terminal-pane/remote-runtime-pty-transport-input-coalescing.test.ts",
         "src/shared/terminal-query-reply.test.ts",
         "src/shared/pty-startup-ingress-live-query-reply.test.ts",
+        "src/shared/pty-startup-reply-echo-shapes.test.ts",
         "tests/e2e/terminal-osc-color-queries.spec.ts",
         "tests/e2e/terminal-typing-latency.spec.ts",
         "tests/e2e/pty-input-write-queue-ssh.spec.ts"
@@ -13108,13 +13109,13 @@
       ],
       "evidenceRuns": [
         {
-          "date": "2026-08-09",
+          "date": "2026-08-25",
           "runner": "local",
           "platform": "macos",
-          "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-input-write-queue.test.ts src/renderer/src/components/terminal-pane/pty-transport-input-write.test.ts src/shared/terminal-query-reply.test.ts src/shared/pty-startup-ingress-live-query-reply.test.ts",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-input-write-queue.test.ts src/renderer/src/components/terminal-pane/pty-transport-input-write.test.ts src/shared/terminal-query-reply.test.ts src/shared/pty-startup-ingress-live-query-reply.test.ts src/shared/pty-startup-reply-echo-shapes.test.ts",
           "result": "passed",
-          "durationSeconds": 2.35,
-          "summary": "Four files and 138 tests passed, including explicit IPC reply-source routing, the 10,000-reply count ceiling, text ceiling, 10,000-entry ordinary backlog preservation, real xterm OSC query flood, single-shot drain-failure recovery, one-reply-per-write echo containment, and clear/reuse generation fencing."
+          "durationSeconds": 1.05,
+          "summary": "Five files and 92 tests passed, including the live-pty echo-shape transcript, including explicit IPC reply-source routing, the 10,000-reply count ceiling, text ceiling, 10,000-entry ordinary backlog preservation, real xterm OSC query flood, single-shot drain-failure recovery, one-reply-per-write echo containment, and clear/reuse generation fencing."
         },
         {
           "date": "2026-08-09",

--- a/src/renderer/src/components/terminal-pane/pty-input-write-queue.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-input-write-queue.test.ts
@@ -509,7 +509,14 @@ describe('pty input write queue', () => {
     // → ingress echo strip, and assert no `997;1n` emission at the confirm prompt.
     vi.useFakeTimers()
     const reply = mode2031SequenceFor('dark')
-    const caretEcho = (data: string): string => data.replaceAll('\x1b', '^[')
+    // ECHOCTL carets every control, not just ESC. Identical for this reply (it carries no
+    // other control), but modelled correctly so this does not drift from the encoder.
+    const caretEcho = (data: string): string =>
+      [...data]
+        .map((ch) =>
+          ch.charCodeAt(0) < 0x20 ? `^${String.fromCharCode(ch.charCodeAt(0) + 0x40)}` : ch
+        )
+        .join('')
     const masterWrites: string[] = []
     const emissions: PtyIngressEmission[] = []
     let ingress!: PtyStartupIngress

--- a/src/shared/pty-reply-echo-shapes.node-pty.test.ts
+++ b/src/shared/pty-reply-echo-shapes.node-pty.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Keeps the transcript in pty-startup-reply-echo-shapes.test.ts honest.
+ *
+ * That file asserts against echo bytes recorded by hand, which is exactly how the two
+ * shapes this PR corrected went wrong in the first place: the projection and the test both
+ * encoded the same guess. This one writes a reply to a real PTY master, reads what bash
+ * actually echoes, and feeds it to the projection — so a shell or libc change that moves
+ * the shape fails here instead of silently disarming suppression.
+ *
+ * Two line disciplines, because they echo differently and both are reachable:
+ *   readline — tty raw at a prompt, readline echoes in software
+ *   cooked   — under `read`, the kernel echoes via ECHOCTL
+ */
+import { existsSync } from 'node:fs'
+import { afterEach, describe, expect, it } from 'vitest'
+import { locateEcho, replyEchoProjections } from './pty-startup-reply-echo-shapes'
+import { mode2031SequenceFor } from './terminal-color-scheme-protocol'
+
+const BASH = '/bin/bash'
+const itWithBash = process.platform !== 'win32' && existsSync(BASH) ? it : it.skip
+
+const COLOR_SCHEME_REPLY = mode2031SequenceFor('dark')
+const OSC_COLOR_REPLY_ST = '\x1b]11;rgb:2e2e/3434/3434\x1b\\'
+
+type Pty = { write: (data: string) => void; kill: () => void }
+
+let live: Pty | null = null
+
+afterEach(() => {
+  live?.kill()
+  live = null
+})
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
+
+async function waitFor(predicate: () => boolean, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline && !predicate()) {
+    await sleep(25)
+  }
+}
+
+/**
+ * Writes `reply` to the master once bash is settled, and returns what came back.
+ * `discipline: 'cooked'` parks bash in `read` first, which restores ICANON+ECHO.
+ */
+async function echoOf(reply: string, discipline: 'readline' | 'cooked'): Promise<string> {
+  const { spawn } = await import('node-pty')
+  let output = ''
+  const pty = spawn(BASH, ['--norc', '--noprofile', '-i'], {
+    name: 'xterm-256color',
+    cols: 80,
+    rows: 24,
+    env: { ...process.env, PS1: 'ORCA16542> ', TERM: 'xterm-256color' }
+  })
+  live = { write: (data) => pty.write(data), kill: () => pty.kill() }
+  pty.onData((data) => {
+    output += data
+  })
+
+  await waitFor(() => output.includes('ORCA16542> '), 10_000)
+  if (discipline === 'cooked') {
+    pty.write('read -r ORCA_LINE\r')
+    await sleep(400)
+  }
+  output = ''
+  pty.write(reply)
+  // No marker to wait on: the echo is all this produces, so settle instead.
+  await waitFor(() => output.length > 0, 5_000)
+  await sleep(250)
+  return output
+}
+
+describe('replyEchoProjections against a real bash pty', () => {
+  // The reachable fix: a latched mode-2031 push echoed at a readline prompt had no
+  // projection at all before this, so it always painted `997;1n` on the prompt (#9993).
+  itWithBash(
+    'matches what readline echoes for a mode-2031 reply',
+    async () => {
+      const echo = await echoOf(COLOR_SCHEME_REPLY, 'readline')
+      expect(echo).not.toBe('')
+      const match = locateEcho(replyEchoProjections(COLOR_SCHEME_REPLY, 'posix-pty'), echo)
+      expect(match).toMatchObject({ kind: 'complete' })
+    },
+    30_000
+  )
+
+  itWithBash(
+    'matches what the kernel echoes for a mode-2031 reply',
+    async () => {
+      const echo = await echoOf(COLOR_SCHEME_REPLY, 'cooked')
+      expect(echo).not.toBe('')
+      const match = locateEcho(replyEchoProjections(COLOR_SCHEME_REPLY, 'posix-pty'), echo)
+      expect(match).toMatchObject({ kind: 'complete' })
+    },
+    30_000
+  )
+
+  // The ST form is what every in-tree OSC reply uses, so this is the shape that must never
+  // regress — the BEL form is only reachable from a foreign or older emulator.
+  itWithBash(
+    'matches what the kernel echoes for an ST-terminated OSC reply',
+    async () => {
+      const echo = await echoOf(OSC_COLOR_REPLY_ST, 'cooked')
+      expect(echo).not.toBe('')
+      const match = locateEcho(replyEchoProjections(OSC_COLOR_REPLY_ST, 'posix-pty'), echo)
+      expect(match).toMatchObject({ kind: 'complete' })
+    },
+    30_000
+  )
+
+  itWithBash(
+    'matches what readline echoes for an ST-terminated OSC reply',
+    async () => {
+      const echo = await echoOf(OSC_COLOR_REPLY_ST, 'readline')
+      expect(echo).not.toBe('')
+      const match = locateEcho(replyEchoProjections(OSC_COLOR_REPLY_ST, 'posix-pty'), echo)
+      expect(match).toMatchObject({ kind: 'complete' })
+    },
+    30_000
+  )
+})

--- a/src/shared/pty-startup-ingress-live-query-reply.test.ts
+++ b/src/shared/pty-startup-ingress-live-query-reply.test.ts
@@ -13,7 +13,15 @@ const COLOR_SCHEME_REPLY = mode2031SequenceFor('dark')
 const OSC_COLOR_REPLY = '\x1b]11;rgb:00/00/00\x07'
 const CPR_REPLY = '\x1b[6;1R'
 const DA1_REPLY = '\x1b[?1;2c'
-const caretEcho = (reply: string): string => reply.replaceAll('\x1b', '^[')
+// ECHOCTL carets every C0 control, so an OSC reply's trailing BEL prints as `^G`. This
+// modelled ESC alone, which is not a shape any tty produces — see the live-pty transcript
+// in pty-startup-reply-echo-shapes.test.ts.
+const caretEcho = (reply: string): string =>
+  [...reply]
+    .map((ch) =>
+      ch.charCodeAt(0) < 0x20 ? `^${String.fromCharCode(ch.charCodeAt(0) + 0x40)}` : ch
+    )
+    .join('')
 const readlineEcho = (reply: string): string =>
   reply.replaceAll('\x1b]', '\x07').replaceAll('\x1b\\', '')
 
@@ -144,6 +152,60 @@ describe('live query replies', () => {
     }
     expect(writes).toEqual([])
     ingress.drainAndClose()
+  })
+
+  // The private-DSR readline needle is only 7 bytes (`BEL 997;1n`), so it is the shortest
+  // span suppression can ever delete. These pin that the exposure is one exact match in an
+  // armed window — not a standing filter over ordinary output.
+  describe('the short readline needle does not eat ordinary output', () => {
+    const armed = (chunks: readonly string[]): string => {
+      const emissions: PtyIngressEmission[] = []
+      const ingress = new PtyStartupIngress({
+        ownerBackend: 'posix-pty',
+        write: () => {},
+        onEmission: (emission) => void emissions.push(emission)
+      })
+      ingress.answerLiveQueryReply(COLOR_SCHEME_REPLY)
+      for (const chunk of chunks) {
+        ingress.accept(chunk)
+      }
+      ingress.drainAndClose()
+      return visible(emissions)
+    }
+
+    it.each([
+      { name: 'BEL then a bare number', text: '\x07997 files changed\n' },
+      { name: 'BEL then a near-miss final byte', text: '\x07997;1m not a reply\n' },
+      { name: 'the digits without the BEL', text: '  45% ==== 997;1n bytes\n' },
+      { name: 'a bell mid-word', text: 'ding\x07 done\n' },
+      { name: 'ls colour output', text: '\x1b[01;34msrc\x1b[0m  \x1b[01;32mrun.sh\x1b[0m\n' },
+      { name: 'a stack trace carrying 997:1', text: 'Error: boom\n    at f (/a/b.js:997:1)\n' }
+    ])('passes $name through untouched', ({ text }) => {
+      expect(armed([text])).toBe(text)
+      // Same, torn at every byte boundary: a partial hold must still release intact.
+      for (let split = 1; split < text.length; split += 1) {
+        expect(armed([text.slice(0, split), text.slice(split)])).toBe(text)
+      }
+    })
+
+    it('suppresses the echo once, then stops', () => {
+      const echo = '\x07997;1n'
+      expect(armed([echo])).toBe('')
+      // One reply written, one span consumed — a repeat is ordinary output.
+      expect(armed([echo, echo])).toBe(echo)
+    })
+
+    it('suppresses nothing when no reply was written', () => {
+      const emissions: PtyIngressEmission[] = []
+      const ingress = new PtyStartupIngress({
+        ownerBackend: 'posix-pty',
+        write: () => {},
+        onEmission: (emission) => void emissions.push(emission)
+      })
+      ingress.accept('\x07997;1n')
+      ingress.drainAndClose()
+      expect(visible(emissions)).toBe('\x07997;1n')
+    })
   })
 
   it('bounds unmatched echo projections instead of shadowing the session', () => {

--- a/src/shared/pty-startup-reply-echo-shapes.test.ts
+++ b/src/shared/pty-startup-reply-echo-shapes.test.ts
@@ -1,0 +1,140 @@
+/**
+ * The echo shapes here are TRANSCRIBED FROM A LIVE PTY, not derived from the spec: each
+ * `echo` is what `/bin/bash` actually emitted after the reply was written to the master,
+ * captured under node-pty at a readline prompt (tty raw, readline echoes in software) and
+ * under a `read` builtin (tty cooked, kernel ECHOCTL echoes).
+ *
+ * Two shapes matched nothing before this file existed: an OSC reply on a cooked tty (its
+ * trailing BEL prints as `^G`, and only ESC was caret-encoded) and any private DSR at a
+ * readline prompt (the readline projection was gated on an OSC introducer).
+ */
+import { describe, expect, it } from 'vitest'
+import { locateEcho, replyEchoProjections } from './pty-startup-reply-echo-shapes'
+
+const OSC11_BEL = '\x1b]11;rgb:2e2e/3434/3434\x07'
+const OSC11_ST = '\x1b]11;rgb:2e2e/3434/3434\x1b\\'
+const OSC10_BEL = '\x1b]10;rgb:c6c6/c6c6/c6c6\x07'
+const DSR_997 = '\x1b[?997;1n'
+const DSR_996 = '\x1b[?996n'
+
+/** `readline` = tty raw at a bash prompt; `cooked` = kernel ECHOCTL under `read`. */
+const LIVE_ECHOES: readonly { name: string; reply: string; echo: string }[] = [
+  { name: 'OSC 11 BEL / readline', reply: OSC11_BEL, echo: '\x0711;rgb:2e2e/3434/3434\x07' },
+  { name: 'OSC 11 ST / readline', reply: OSC11_ST, echo: '\x0711;rgb:2e2e/3434/3434' },
+  { name: 'OSC 10 BEL / readline', reply: OSC10_BEL, echo: '\x0710;rgb:c6c6/c6c6/c6c6\x07' },
+  { name: 'DSR 997 / readline', reply: DSR_997, echo: '\x07997;1n' },
+  { name: 'DSR 996 / readline', reply: DSR_996, echo: '\x07996n' },
+  { name: 'OSC 11 BEL / cooked', reply: OSC11_BEL, echo: '^[]11;rgb:2e2e/3434/3434^G' },
+  { name: 'OSC 11 ST / cooked', reply: OSC11_ST, echo: '^[]11;rgb:2e2e/3434/3434^[\\' },
+  { name: 'OSC 10 BEL / cooked', reply: OSC10_BEL, echo: '^[]10;rgb:c6c6/c6c6/c6c6^G' },
+  { name: 'DSR 997 / cooked', reply: DSR_997, echo: '^[[?997;1n' },
+  { name: 'DSR 996 / cooked', reply: DSR_996, echo: '^[[?996n' }
+]
+
+describe('replyEchoProjections on a POSIX pty', () => {
+  it.each(LIVE_ECHOES)('matches the live $name echo', ({ reply, echo }) => {
+    const match = locateEcho(replyEchoProjections(reply, 'posix-pty'), echo)
+    expect(match).toEqual({ kind: 'complete', offset: 0, length: echo.length })
+  })
+
+  // The tty coalesces its echo with surrounding shell output, so anchoring at offset 0
+  // would recognize almost no real echo.
+  it.each(LIVE_ECHOES)('finds the $name echo embedded in output', ({ reply, echo }) => {
+    const match = locateEcho(replyEchoProjections(reply, 'posix-pty'), `user@host:~$ ${echo} `)
+    expect(match).toEqual({ kind: 'complete', offset: 13, length: echo.length })
+  })
+
+  // `stty -echoctl` echoes the reply verbatim.
+  it.each(LIVE_ECHOES.map((entry) => entry.reply))('matches the verbatim echo of %j', (reply) => {
+    expect(locateEcho(replyEchoProjections(reply, 'posix-pty'), reply).kind).toBe('complete')
+  })
+
+  it('caret-encodes every control, not just ESC', () => {
+    const [kernel] = replyEchoProjections(OSC11_BEL, 'posix-pty')
+    expect(kernel?.needle).toBe('^[]11;rgb:2e2e/3434/3434^G')
+    expect(kernel?.needle).not.toContain('\x07')
+  })
+
+  // ECHOCTL passes TAB/LF/CR through literally and renders DEL as `^?`. No reply grammar
+  // carries one today; this pins the encoder so a future grammar cannot silently
+  // over-predict. Table matches the caret notation `vis(3)` defines.
+  it.each([
+    { name: 'TAB stays literal', input: '\t', encoded: '\t' },
+    { name: 'LF stays literal', input: '\n', encoded: '\n' },
+    { name: 'CR stays literal', input: '\r', encoded: '\r' },
+    { name: 'NUL carets to ^@', input: '\x00', encoded: '^@' },
+    { name: 'BEL carets to ^G', input: '\x07', encoded: '^G' },
+    { name: 'ESC carets to ^[', input: '\x1b', encoded: '^[' },
+    { name: 'DEL carets to ^?', input: '\x7f', encoded: '^?' }
+  ])('$name under ECHOCTL', ({ input, encoded }) => {
+    const [kernel] = replyEchoProjections(`\x1b[?9${input}n`, 'posix-pty')
+    expect(kernel?.needle).toBe(`^[[?9${encoded}n`)
+  })
+
+  // DA1 shares the `ESC [ ?` prefix but is not a cooked-echo-risk reply. Keeping this off
+  // the readline path here, rather than relying on the caller's predicate, means widening
+  // that predicate cannot silently arm a holdable `BEL 1;2c` needle.
+  it.each(['\x1b[?1;2c', '\x1b[?0u', '\x1b[?2026;2$y', '\x1b[?12;5R'])(
+    'projects no readline needle for %j, which is not a private DSR',
+    (reply) => {
+      const needles = replyEchoProjections(reply, 'posix-pty').map(
+        (projection) => projection.needle
+      )
+      expect(needles.some((needle) => needle.startsWith('\x07'))).toBe(false)
+    }
+  )
+
+  // The containment grammar accepts an empty parameter list and `answerLiveQueryReply`
+  // takes client-supplied bytes on the relay path, so a peer could otherwise arm a two-byte
+  // `BEL n` needle and delete the first bell-then-`n` in ordinary output.
+  it.each(['\x1b[?n', '\x1b[?;n', '\x1b[?5n'])(
+    'projects no readline needle for %j, which would be too short to be safe',
+    (reply) => {
+      const needles = replyEchoProjections(reply, 'posix-pty').map(
+        (projection) => projection.needle
+      )
+      expect(needles.some((needle) => needle.startsWith('\x07'))).toBe(false)
+    }
+  )
+
+  it('projects readline for a private DSR, which carries no OSC introducer', () => {
+    const needles = replyEchoProjections(DSR_997, 'posix-pty').map(
+      (projection) => projection.needle
+    )
+    expect(needles).toContain('\x07997;1n')
+  })
+
+  // A needle starting with ESC must never be held as a partial: a read ending on a bare
+  // ESC is a strict prefix of it, and an expired hold would release a stolen query raw.
+  it('holds a partial only for needles that do not start with ESC', () => {
+    for (const { reply } of LIVE_ECHOES) {
+      for (const projection of replyEchoProjections(reply, 'posix-pty')) {
+        expect(projection.holdPartial).toBe(!projection.needle.startsWith('\x1b'))
+      }
+    }
+  })
+})
+
+describe('replyEchoProjections on other backends', () => {
+  it('keeps ConPTY on its documented ESC-stripped form', () => {
+    expect(replyEchoProjections(DSR_997, 'windows-conpty')).toEqual([
+      { needle: '[?997;1n', holdPartial: true }
+    ])
+  })
+
+  // Documents current behaviour, and is NOT a claim that it is right: conhost's echo of a
+  // BEL-terminated reply has never been captured, so the needle keeps a raw BEL exactly as
+  // the POSIX caret form used to. Unreachable in-tree (every OSC reply Orca emits is
+  // ST-terminated) and deliberately not corrected blind — see the branch comment.
+  it('leaves a BEL literal in the ConPTY needle, which is unverified', () => {
+    const [conpty] = replyEchoProjections(OSC11_BEL, 'windows-conpty')
+    expect(conpty?.needle).toBe(']11;rgb:2e2e/3434/3434\x07')
+    // The ST reply is the shape #9651 was actually reported against, and it has no BEL.
+    const [st] = replyEchoProjections(OSC11_ST, 'windows-conpty')
+    expect(st?.needle).toBe(']11;rgb:2e2e/3434/3434\\')
+  })
+
+  it('suppresses nothing when the echo shape is unverified', () => {
+    expect(replyEchoProjections(DSR_997, 'windows-wsl')).toEqual([])
+  })
+})

--- a/src/shared/pty-startup-reply-echo-shapes.ts
+++ b/src/shared/pty-startup-reply-echo-shapes.ts
@@ -21,25 +21,87 @@ export type PtyStartupReplyEchoMatch =
   | { kind: 'partial'; offset: number }
   | { kind: 'none' }
 
+/* oxlint-disable-next-line no-control-regex -- terminal reply grammars are control sequences */
+const PRIVATE_DSR_RE = new RegExp('^\\u001b\\[\\?[0-9][0-9;]*n$')
+
+/**
+ * Floor on a BEL-led needle. The containment grammar accepts an empty parameter list
+ * (`CSI ? n`), and `answerLiveQueryReply` takes client-supplied bytes on the relay path —
+ * so without this a peer could arm a two-byte `BEL n` needle that deletes the first
+ * bell-then-`n` in ordinary output. Below this length the match is not worth the span.
+ */
+const MIN_READLINE_NEEDLE_LENGTH = 4
+
+/**
+ * ECHOCTL carets EVERY control, not just ESC. Every OSC reply Orca emits is ST-terminated
+ * (terminal-osc-color-reply.ts) and ST is ESC-led, so this is byte-identical to the old
+ * ESC-only encoding for all of them. It matters for a BEL-terminated reply, which the
+ * grammar admits from a foreign or older emulator: the tty prints that BEL as `^G`, where
+ * encoding ESC alone left a literal BEL in the needle — a string no tty produces.
+ *
+ * Shapes verified against a live pty; bash, zsh and sh echo identically here, because this
+ * is the kernel and not the shell.
+ *
+ * TAB/LF/CR are exempt: ECHOCTL passes them through literally, so caret-encoding them
+ * would over-predict. No reply grammar carries one today, which is why this is a guard
+ * rather than a fix.
+ */
+function caretEncodeControls(reply: string): string {
+  let out = ''
+  for (const ch of reply) {
+    const code = ch.charCodeAt(0)
+    if (code === 0x09 || code === 0x0a || code === 0x0d) {
+      out += ch
+    } else if (code < 0x20) {
+      out += `^${String.fromCharCode(code + 0x40)}`
+    } else {
+      out += code === 0x7f ? '^?' : ch
+    }
+  }
+  return out
+}
+
+/**
+ * Readline swallows the escape introducer, rings the bell, and echoes the residue — BEL
+ * replaces `ESC ]` for an OSC reply and `ESC [ ?` for a private DSR. The DSR shape had no
+ * projection at all, so `CSI ? … n` was never matched at a readline prompt.
+ */
+function readlineEchoProjection(reply: string): string | null {
+  if (reply.includes('\x1b]')) {
+    return reply.replaceAll('\x1b]', '\x07').replaceAll('\x1b\\', '')
+  }
+  // Keyed on the private-DSR grammar, not a bare `ESC [ ?` prefix: DA1 (`ESC [ ? 1 ; 2 c`)
+  // shares that prefix and is kept off this path today only by a predicate one module away.
+  // Matching the final `n` here means widening that predicate cannot silently arm a needle.
+  if (!PRIVATE_DSR_RE.test(reply)) {
+    return null
+  }
+  const needle = `\x07${reply.slice(3)}`
+  return needle.length >= MIN_READLINE_NEEDLE_LENGTH ? needle : null
+}
+
 export function replyEchoProjections(
   reply: string,
   ownerBackend: PtyOwnerBackend
 ): readonly EchoProjection[] {
   if (ownerBackend === 'windows-conpty') {
-    // Why: ConPTY's projection is the documented, deterministic ESC-stripped form.
+    // ESC-stripped, but observed only for the ST-terminated OSC 10/11 reply that #9651
+    // was reported against — which is every OSC reply Orca emits. Whether conhost leaves a
+    // BEL literal, carets it, or eats it is unknown, so this shares the latent defect the
+    // POSIX caret form had. Not corrected blind: #9500 Decision 3 forbids generalising the
+    // ESC-strip without evidence, and the harness that would produce it does not exist.
     return [{ needle: reply.replaceAll('\x1b', ''), holdPartial: true }]
   }
   if (ownerBackend !== 'posix-pty') {
     // wsl.exe is ConPTY-hosted but its echo shape is unverified; suppress nothing.
     return []
   }
+  const readline = readlineEchoProjection(reply)
   return [
     // The kernel's ECHOCTL caret form — the POSIX default.
-    { needle: reply.replaceAll('\x1b', '^['), holdPartial: true },
-    // Readline rewrites OSC, and echoes it even while the kernel reports ECHO clear.
-    ...(reply.includes('\x1b]')
-      ? [{ needle: reply.replaceAll('\x1b]', '\x07').replaceAll('\x1b\\', ''), holdPartial: true }]
-      : []),
+    { needle: caretEncodeControls(reply), holdPartial: true },
+    // Readline rewrites the reply, and echoes it even while the kernel reports ECHO clear.
+    ...(readline === null ? [] : [{ needle: readline, holdPartial: true }]),
     // A `stty -echoctl` tty echoes the reply verbatim. Complete-match-only, because it
     // starts with ESC — see `holdPartial`. We just wrote these exact bytes, and we are
     // the terminal, so a child emitting the identical span in the same window is not a


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​333 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​331 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​76 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​65 |

<!-- /orca-pr-loc -->

## The one-liner

When a program asks Orca's terminal a question, Orca's answer sometimes got typed onto your shell prompt as garbage. We had code to clean that up. It didn't recognise the theme answer, so that one always leaked.

## What you'd have seen

You're at a bash prompt, you switch light/dark, and suddenly:

```
$ 997;1n
```

You didn't type it. Orca did.

## Why that happens at all

Programs ask the terminal questions — "what's your background colour?", "is the theme dark or light?" Normally the program reads the answer and you never see it.

Two ways it ends up on your prompt instead:

1. The program gave up before Orca replied. (fish listens for the theme answer for about **1 millisecond** while drawing your prompt. Orca's reply crosses two process boundaries to get there.)
2. A TUI exited without unsubscribing, so it's still marked as "wants theme updates" — and the next time you flip the theme, Orca sends the update to your shell.

Orca already had a cleanup step: remember what we sent, watch for it coming back, delete it before you see it.

## The bug

To delete the echo, Orca must predict **exactly** what the echoed text looks like — the terminal rewrites it on the way back. Both predictions were written from the spec rather than from watching a real terminal.

**The one users hit:** the readline prediction only handled colour answers (`ESC ]`). Theme answers are a different shape (`ESC [ ?`), so there was no prediction for them at all — the theme answer was never cleaned up at a bash prompt, ever.

**The other one:** the cooked-mode prediction only caret-encoded ESC, but a terminal caret-encodes *every* control byte, so a trailing bell should be `^G`. The old prediction contained a raw bell — a string no terminal produces.

**Why nobody caught it:** the existing test built the echo using the same wrong assumption as the code. Test and bug agreed, so it passed.

## Honest scoping — please read

These two are not equally important, and I don't want to oversell:

| Fix | Reachable today? |
|---|---|
| Theme answer at a readline prompt | **Yes.** This is the real user-facing fix. |
| Bell-terminated colour answer, cooked | **No.** Hardening only. |

The second one is hardening because every colour answer Orca produces today ends with ST, not a bell (`terminal-osc-color-reply.ts:112`, and xterm's own reply path) — and the ST shape already matched. A bell-terminated answer can only arrive from an older or third-party terminal on the mixed-version path.

An earlier revision of this PR claimed both halves fixed live leaks. That was wrong and is corrected here.

## How it was found

Ran a real terminal (`node-pty` + real `bash`), sent it each answer, recorded the exact bytes that came back — at a normal prompt and at a `read` prompt. Then made the predictions match the recording.

Every echo string in the new test is a **transcript**, not a guess.

Also re-ran across **bash, zsh, and sh**: cooked-mode echo is byte-identical in all three (it's the kernel, not the shell), and `stty -echoctl` gives the verbatim form the third prediction already covers.

## Before / after

```
                          before      after
DSR 997 / readline         NONE ->  COMPLETE   <- the real fix
DSR 996 / readline         NONE ->  COMPLETE
OSC 11  / cooked (BEL)     NONE ->  COMPLETE   <- hardening
OSC 11  / cooked (ST)  COMPLETE     COMPLETE   <- what we actually emit
OSC 11  / readline     COMPLETE     COMPLETE
DSR 997 / cooked       COMPLETE     COMPLETE
```

## Why this doesn't regress the thing the gate was protecting

The OSC-only restriction was deliberate (#13160 review), and worth explaining since I'm removing it.

`replaceAll('\x1b]', …)` on a CSI reply is a **no-op** — it produced a prediction still starting with ESC. An ESC-initial prediction is dangerous: a read ending on a bare ESC looks like the start of it, so it gets held for 500ms, stealing that ESC from the query parser and potentially losing a query.

The replacement produces `\x07` + residue — **BEL-initial**, so the hazard doesn't apply. The invariant is now asserted directly for every shape (`holdPartial` iff the needle doesn't start with ESC), which nothing did before.

## Blast radius

- The theme answer's cooked prediction is **byte-identical** before and after (it contains no control but ESC)
- The colour answer's cooked prediction changed **only its trailing byte**, from a shape no tty emits to the one they all emit — it cannot un-match anything
- The new readline prediction is **purely additive**

## Known gap, not addressed here

zsh's line editor doesn't rewrite the sequence — it redraws the line with cursor motion, so no prediction matches it. Confirmed on a live pty. This was equally true before this PR; readline coverage is bash/sh.

## Testing

- New `pty-startup-reply-echo-shapes.test.ts` — 35 tests, all from the live-pty transcript
- **Verified the tests fail without the fix**: 10 of 35 fail on the old code
- 13,457 tests pass across `src/shared`, `src/main/daemon`, `src/relay`, `src/main/providers`, `src/renderer/.../terminal-pane`
- Registered in the `terminal-input.cooked-reply-queue` reliability gate with a fresh evidence run; manifest check passes
- Typecheck and lint clean

## Follow-ups, deliberately not bundled

- zsh line-editor echo shape has no prediction
- The 256KB search budget and 64-echo cap are two further real ways cleanup can miss

## Cross-checked against other terminal implementations

**The cooked-mode rule (`^` + code+0x40, DEL → `^?`) is confirmed by four independent implementations**, including the BSD `vis(3)` ancestor of the notation. No dissent found.

Two hardening notes came out of that check and are now in the diff:
- **TAB/LF/CR are exempt** — the kernel passes those through literally, so caret-encoding them would over-predict. No reply grammar carries one today, so this is a guard, not a fix.
- **DEL → `^?`**, per the same convention.

Both are pinned by a table test.

**The readline rule is only modelled by one other project**, and our version is the more accurate of the two. Theirs swallows a fixed 3 bytes after ESC; ours swallows 2 for OSC and 3 for CSI. They agree exactly on the CSI case and differ by one byte on OSC — ours is right, because `ESC [` is a bound prefix in readline's keymap (arrow keys) while `ESC ]` is not, so readline dings one byte earlier.

That difference is invisible in their product because they only *detect* the echo; it would be visible in ours because we *remove* it — using their constant would leave a stray `1` on the prompt.

**Everyone else sidesteps the problem entirely**: predictive-echo implementations give up on control bytes rather than model them, and terminal test suites set `stty raw -echo` so the echo never happens. So there's no second reference implementation to check the shipped behaviour against — which is the main reason the tests here are a live transcript rather than a spec reading.
