### PR TITLE
Highlight incomplete onboarding progress in the sidebar

### DIFF
--- a/src/renderer/src/components/sidebar/SetupGuideSidebarEntry.test.tsx
+++ b/src/renderer/src/components/sidebar/SetupGuideSidebarEntry.test.tsx
@@ -41,7 +41,9 @@ vi.mock('@/components/ui/context-menu', () => ({
 }))
 
 vi.mock('../setup-guide/SetupGuideProgressRing', () => ({
-  SetupGuideProgressRing: () => <span data-testid="setup-progress-ring" />
+  SetupGuideProgressRing: ({ className }: { className?: string }) => (
+    <span data-testid="setup-progress-ring" className={className} />
+  )
 }))
 
 function makeProgress(overrides: Partial<FeatureWallSetupProgress> = {}): FeatureWallSetupProgress {
@@ -179,7 +181,10 @@ describe('SetupGuideSidebarEntry', () => {
   })
 
   it('renders after persisted UI and setup progress are ready when setup is incomplete', () => {
-    expect(renderToStaticMarkup(<SetupGuideSidebarEntry />)).toContain('Onboarding checklist')
+    const markup = renderToStaticMarkup(<SetupGuideSidebarEntry />)
+
+    expect(markup).toContain('Onboarding checklist')
+    expect(markup).toContain('text-green-600 dark:text-green-300')
   })
 
   it('keeps the visible entry mounted during transient setup progress refreshes', async () => {

--- a/src/renderer/src/components/sidebar/SetupGuideSidebarEntry.tsx
+++ b/src/renderer/src/components/sidebar/SetupGuideSidebarEntry.tsx
@@ -98,6 +98,7 @@ export function SetupGuideSidebarEntry(): React.JSX.Element | null {
           <SetupGuideProgressRing
             done={renderedProgress.coreDoneCount}
             total={renderedProgress.coreTotal}
+            className="text-green-600 dark:text-green-300"
             sizeClassName="size-4"
           />
           <span className="flex min-w-0 flex-1 flex-col">

--- a/tests/e2e/setup-guide-sidebar.spec.ts
+++ b/tests/e2e/setup-guide-sidebar.spec.ts
@@ -16,6 +16,29 @@ test.describe('Setup guide sidebar entry', () => {
     await waitForActiveWorktree(orcaPage)
   })
 
+  test('matches incomplete sidebar progress to the setup guide progress color', async ({
+    orcaPage
+  }) => {
+    await seedIncompleteSetupProgress(orcaPage)
+    const sidebarEntry = orcaPage.locator('[data-contextual-tour-target="setup-guide-entry"]')
+    const sidebarProgress = sidebarEntry.locator('[aria-label*="setup steps complete"]')
+
+    await expect(sidebarEntry).toBeVisible()
+    await expect(sidebarProgress).toBeVisible()
+    const sidebarProgressColor = await sidebarProgress.evaluate(
+      (element) => window.getComputedStyle(element).color
+    )
+
+    await sidebarEntry.click()
+    const setupGuide = orcaPage.getByRole('dialog')
+    await expect(setupGuide.getByRole('heading', { name: 'Getting started' })).toBeVisible()
+    const modalProgress = setupGuide.locator('[aria-label*="setup steps complete"]')
+    await expect(modalProgress).toBeVisible()
+    expect(await modalProgress.evaluate((element) => window.getComputedStyle(element).color)).toBe(
+      sidebarProgressColor
+    )
+  })
+
   test('does not flash while completed setup waits for capability readiness', async ({
     electronApp,
     orcaPage
@@ -64,6 +87,34 @@ test.describe('Setup guide sidebar entry', () => {
     })
   })
 })
+
+async function seedIncompleteSetupProgress(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('window.__store is not available')
+    }
+    const state = store.getState()
+    store.setState({
+      settings: state.settings
+        ? {
+            ...state.settings,
+            defaultTuiAgent: 'blank',
+            notifications: {
+              ...state.settings.notifications,
+              enabled: false,
+              agentTaskComplete: false
+            }
+          }
+        : null,
+      featureInteractions: {},
+      setupGuideSidebarDismissed: false,
+      setupGuideBrowserMilestoneMigrated: true,
+      setupGuideBrowserMilestoneLegacyComplete: false,
+      persistedUIReady: true
+    })
+  })
+}
 
 async function setActiveViewForFlashProbe(
   page: Page,


### PR DESCRIPTION
## ELI5

The incomplete onboarding checklist used a muted gray progress ring in the sidebar even though the same ring is green after opening **Getting started**. This makes the sidebar ring green too, so first-time users can spot that setup still needs attention.

## What Changed

- Apply the existing **Getting started** green progress treatment to the incomplete sidebar ring.
- Keep the sidebar label and row background neutral so the progress cue stays focused.
- Add component coverage for the light/dark color classes.
- Add an Electron Playwright regression that compares the rendered sidebar and modal progress colors.

## Why

After initial onboarding, a first-time user can land in a project workspace without knowing what to do next. The incomplete checklist is nested in the sidebar and its muted progress ring is easy to overlook. Matching the modal's established progress color gives the incomplete state a consistent, visible cue without adding a new color or callout pattern.

The sidebar's regular icons should remain consistently neutral because they represent persistent navigation. The onboarding ring serves a different purpose: it communicates a temporary, one-time state that still needs attention. Giving that status indicator greater visual salience is therefore a deliberate exception, not a broader proposal to colorize the sidebar. Green is also already part of the sidebar's status language through the repository-online indicator, so this reuses an established accent while matching the existing **Getting started** progress treatment.

## Linked Issue

Fixes #16545

## Visual Proof

**Light theme — before**

<img width="389" height="47" alt="onboarding-progress-before" src="https://github.com/user-attachments/assets/b9de5589-2cee-4e10-9627-de89f1ca81cb" />

**Light theme — after**

<img width="389" height="47" alt="onboarding-progress-after" src="https://github.com/user-attachments/assets/73443351-80d7-41ad-87b7-ea0a0cf4c893" />

**Dark theme — before**

<img width="389" height="47" alt="onboarding-progress-before-dark" src="https://github.com/user-attachments/assets/83e1a2d8-95a9-4c07-b4a7-cdbaa91560c4" />

**Dark theme — after**

<img width="389" height="47" alt="onboarding-progress-after-dark" src="https://github.com/user-attachments/assets/8540f5e5-d362-457c-9c16-bf4bded27a15" />

## Testing

- [x] I manually inspected tightly cropped light- and dark-theme before/after screenshots from the rendered Electron app on Windows.
- [x] Automated tests added/updated.
- `pnpm test src/renderer/src/components/sidebar/SetupGuideSidebarEntry.test.tsx` — 8 passed.
- `playwright test tests/e2e/setup-guide-sidebar.spec.ts --project electron-headless --workers=1` — 2 passed.
- Renderer TypeScript project — passed.
- Changed-file oxlint, React quality rules, formatting, and `git diff --check` — passed.
- `electron-vite build --mode e2e` — passed.
- macOS, Linux, and SSH were not run locally; this is a renderer-only class change with no platform, host, or runtime branching.

## AI Disclosure

OpenAI Codex was used to trace the UI, implement the change, add tests, and run verification.

## Review

- Cross-platform: uses the same existing Tailwind light/dark classes as the sibling modal progress ring.
- SSH/remote/local: presentation-only renderer change; no execution or remote state behavior changes.
- Agents/integrations: no provider-specific behavior changes.
- Performance: one static class assignment; no additional effects, subscriptions, or calculations.
- UI/accessibility: the existing visible label, numeric tooltip, and aria-label remain unchanged; color is an additional consistency and visibility cue.
- Visual hierarchy: persistent navigation icons remain neutral; only the temporary incomplete-onboarding status receives the established green status accent.
- Security: no new inputs, data flows, permissions, or IPC.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or translates no upstream skill-installer source.

## Checklist

- [x] This PR is small and focused.
- [x] I explained what changed and why.
- [x] Light- and dark-theme before/after screenshots attached.
- [x] Self-reviewed for correctness, security, and performance.
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered.
- [x] Targeted checks pass; CI will cover the full repository suites.
