### PR TITLE
fix(orchestration): start argv workers with bound authority

### DIFF
--- a/src/main/runtime/orca-runtime-create-managed-remote-worktree.ts
+++ b/src/main/runtime/orca-runtime-create-managed-remote-worktree.ts
@@ -42,6 +42,18 @@ export class OrcaRuntimeWithCreateManagedRemoteWorktree extends OrcaRuntimeWithC
           defaultTabs,
           args.navigation
         ),
+      resolveDeferredStartup: async (worktreeId) => {
+        if (!args.startupPromptFactory || !args.startupAgent) {
+          return undefined
+        }
+        const startupPrompt = await args.startupPromptFactory(worktreeId)
+        return this.buildStartupForAgent(
+          repo,
+          args.startupAgent,
+          startupPrompt,
+          args.startupLaunchPreferences
+        )
+      },
       invalidateResolvedWorktrees: () => this.invalidateResolvedWorktreeCache(),
       invalidateWorktreeScan: (repoId) => this.invalidateWorktreeScanCacheForRepo(repoId),
       notifyWorktreesChanged: (repoId) => this.notifyWorktreesChanged(repoId)

--- a/src/main/runtime/orca-runtime-create-managed-worktree.ts
+++ b/src/main/runtime/orca-runtime-create-managed-worktree.ts
@@ -37,7 +37,7 @@ export class OrcaRuntimeWithCreateManagedWorktree extends OrcaRuntimeWithGetWork
       throw new Error('Selected agent is disabled. Choose an enabled agent before creating.')
     }
     const agentStartup =
-      !args.startup && args.startupAgent
+      !args.startup && args.startupAgent && !args.startupPromptFactory
         ? this.buildStartupForAgent(
             repo,
             args.startupAgent,
@@ -49,14 +49,31 @@ export class OrcaRuntimeWithCreateManagedWorktree extends OrcaRuntimeWithGetWork
       !args.startup && !agentStartup && args.startupDraft
         ? await this.buildStartupForDraft(repo, args.startupDraft, requestedAgent)
         : null
-    const effectiveStartup = args.startup ?? agentStartup?.startup ?? draftStartup?.startup
-    const effectiveStartupFollowup = agentStartup?.followup
+    let effectiveStartup = args.startup ?? agentStartup?.startup ?? draftStartup?.startup
+    let effectiveStartupFollowup = agentStartup?.followup
     const effectiveCreatedWithAgent = args.startup
       ? args.createdWithAgent
       : (agentStartup?.agent ??
         draftStartup?.agent ??
         (requestedAgentEnabled ? requestedAgent : undefined))
     const effectiveDraftPaste = args.startupDraftPaste ?? draftStartup?.draftPaste
+    // Why: an argv worker prompt names the worktree it runs in, so it can only be
+    // built once the record exists. Resolve it after create and before the startup
+    // terminal is planned, so the launch command carries the prompt.
+    const resolveDeferredStartup = async (worktreeId: string): Promise<void> => {
+      if (!args.startupPromptFactory || !args.startupAgent || effectiveStartup) {
+        return
+      }
+      const startupPrompt = await args.startupPromptFactory(worktreeId)
+      const startup = this.buildStartupForAgent(
+        repo,
+        args.startupAgent,
+        startupPrompt,
+        args.startupLaunchPreferences
+      )
+      effectiveStartup = startup.startup
+      effectiveStartupFollowup = startup.followup
+    }
     // Resolve the execution host once: SSH ownership has two spellings, and reading the raw
     // `connectionId` field routes an `executionHostId: 'ssh:*'`-only repo down the local path,
     // which runs `git worktree add` on the client against a remote path.
@@ -108,6 +125,13 @@ export class OrcaRuntimeWithCreateManagedWorktree extends OrcaRuntimeWithGetWork
           ...(effectiveStartup ? { startup: effectiveStartup } : {}),
           ...(effectiveStartupFollowup ? { startupFollowup: effectiveStartupFollowup } : {}),
           ...(effectiveCreatedWithAgent ? { createdWithAgent: effectiveCreatedWithAgent } : {}),
+          ...(args.startupPromptFactory
+            ? {
+                startupAgent: args.startupAgent,
+                startupLaunchPreferences: args.startupLaunchPreferences,
+                startupPromptFactory: args.startupPromptFactory
+              }
+            : {}),
           ...(effectiveDraftPaste ? { startupDraftPaste: effectiveDraftPaste } : {})
         }
       )
@@ -154,6 +178,10 @@ export class OrcaRuntimeWithCreateManagedWorktree extends OrcaRuntimeWithGetWork
         onWorktreeMetadataPersisted: (persistedWorktree) =>
           this.recordCreatedWorktreeLineage(persistedWorktree, lineageResolution)
       })
+    this.invalidateResolvedWorktreeCache()
+    this.invalidateWorktreeScanCacheForRepo(repo.id)
+    await resolveDeferredStartup(worktree.id)
+
     const settings = createSettings
     const { lineage, workspaceLineage, warnings: lineageWarnings } = metadataResult
 

--- a/src/main/runtime/orca-runtime-resolve-browser-network-execution-host-for-worktree.ts
+++ b/src/main/runtime/orca-runtime-resolve-browser-network-execution-host-for-worktree.ts
@@ -9,6 +9,7 @@ import {
 } from '../../shared/execution-host'
 import { resolveRuntimeBrowserNetworkExecutionHost } from './runtime-browser-network-execution-host'
 import { resolveLocalProjectRuntimeForWorktreeId } from '../local-project-runtime-resolution'
+import { resolveTerminalOrchestrationCliCommand } from './orchestration/cli-command'
 import { getRegisteredSshState } from '../ssh/ssh-target-registry'
 import { resolveWorktreeLaunchHost } from './worktree-launch-host-repo'
 import { folderWorkspaceKey, parseWorkspaceKey } from '../../shared/workspace-scope'
@@ -91,6 +92,20 @@ export class OrcaRuntimeWithResolveBrowserNetworkExecutionHostForWorktree extend
     selector: string
   ): Promise<TerminalWorkspaceLaunchScope> {
     return (await this.resolveTerminalWorkspaceLaunchTarget(selector)).scope
+  }
+
+  // Why: argv-injected prompts are built BEFORE a terminal exists, so the CLI
+  // name must come from the target workspace rather than a pane handle. This
+  // preserves `orca-ide` for WSL worktrees and bare `orca` for SSH/native.
+  async getWorktreeOrchestrationCliCommand(worktreeId: string): Promise<'orca' | 'orca-ide'> {
+    const workspace = await this.resolveTerminalWorkspaceLaunchScope(`id:${worktreeId}`)
+    return resolveTerminalOrchestrationCliCommand({
+      connectionId: workspace.connectionId,
+      isWsl: null,
+      worktreeId: workspace.id,
+      worktreePath: workspace.path,
+      projectRuntime: this.resolveProjectRuntimeForWorktree(workspace.id)
+    })
   }
 
   protected async resolveTerminalWorkspaceLaunchTarget(

--- a/src/main/runtime/orca-runtime-resolve-worktree-removal-target.ts
+++ b/src/main/runtime/orca-runtime-resolve-worktree-removal-target.ts
@@ -200,7 +200,7 @@ export class OrcaRuntimeWithResolveWorktreeRemovalTarget extends OrcaRuntimeWith
     const sessionOptions = this.toAgentSessionOptions(opts.launchPreferences)
     const startupPlan = buildAgentStartupPlan({
       agent,
-      prompt: '',
+      prompt: opts.agentPrompt ?? '',
       cmdOverrides: settings.agentCmdOverrides ?? {},
       agentArgs: resolveTuiAgentLaunchArgs(agent, settings.agentDefaultArgs),
       agentEnv: resolveTuiAgentLaunchEnv(agent, settings.agentDefaultEnv),
@@ -218,6 +218,14 @@ export class OrcaRuntimeWithResolveWorktreeRemovalTarget extends OrcaRuntimeWith
         throw new Error(`Could not build launch command for ${opts.startupAgent}.`)
       }
       return opts
+    }
+
+    // Why: a deferred followupPrompt means the plan could NOT embed the prompt
+    // in the launch and expects a post-start paste — exactly the submission
+    // race agentPrompt exists to avoid. Refuse loudly instead of silently
+    // degrading to the paste path.
+    if (opts.agentPrompt && startupPlan.followupPrompt) {
+      throw new Error(`Agent ${agent} cannot embed a startup prompt in its launch command.`)
     }
 
     await this.markWorkspaceTrustedForAgent(agent, workspace.connectionId, workspace.path)

--- a/src/main/runtime/orca-runtime-tests/worktree-selector-resolution.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/worktree-selector-resolution.spec.ts
@@ -412,12 +412,14 @@ describe('OrcaRuntimeService', () => {
       .mockResolvedValue([...MOCK_GIT_WORKTREES, createdWorktree])
 
     const staleLookup = runtime.showManagedWorktree(TEST_WORKTREE_ID)
+    let startupPromptFactoryRan = false
     const result = await runtime.createManagedWorktree({
       repoSelector: 'id:repo-1',
       name: 'nautilus',
       nameWasGenerated: true,
       startupAgent: 'codex',
       startupPromptFactory: async (worktreeId) => {
+        startupPromptFactoryRan = true
         const resolved = await runtime.showManagedWorktree(`id:${worktreeId}`)
         expect(resolved.id).toBe(worktreeId)
         const cliCommand = await runtime.getWorktreeOrchestrationCliCommand(worktreeId)
@@ -425,6 +427,7 @@ describe('OrcaRuntimeService', () => {
         return `worker startup via ${cliCommand}`
       }
     })
+    expect(startupPromptFactoryRan).toBe(true)
     const freshLookup = runtime.showManagedWorktree(result.worktree.id)
 
     staleScan.resolve(MOCK_GIT_WORKTREES)

--- a/src/main/runtime/orca-runtime-tests/worktree-selector-resolution.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/worktree-selector-resolution.spec.ts
@@ -407,13 +407,23 @@ describe('OrcaRuntimeService', () => {
     vi.mocked(listWorktrees)
       .mockImplementationOnce(() => staleScan.promise)
       .mockResolvedValueOnce([createdWorktree])
-      .mockResolvedValueOnce([...MOCK_GIT_WORKTREES, createdWorktree])
+      // Why: the deferred startup prompt resolves the fresh worktree during create,
+      // so every scan after the stale one must already see it.
+      .mockResolvedValue([...MOCK_GIT_WORKTREES, createdWorktree])
 
     const staleLookup = runtime.showManagedWorktree(TEST_WORKTREE_ID)
     const result = await runtime.createManagedWorktree({
       repoSelector: 'id:repo-1',
       name: 'nautilus',
-      nameWasGenerated: true
+      nameWasGenerated: true,
+      startupAgent: 'codex',
+      startupPromptFactory: async (worktreeId) => {
+        const resolved = await runtime.showManagedWorktree(`id:${worktreeId}`)
+        expect(resolved.id).toBe(worktreeId)
+        const cliCommand = await runtime.getWorktreeOrchestrationCliCommand(worktreeId)
+        expect(cliCommand).toBe('orca')
+        return `worker startup via ${cliCommand}`
+      }
     })
     const freshLookup = runtime.showManagedWorktree(result.worktree.id)
 

--- a/src/main/runtime/orchestration/cli-command.test.ts
+++ b/src/main/runtime/orchestration/cli-command.test.ts
@@ -38,6 +38,14 @@ describe('resolveTerminalOrchestrationCliCommand', () => {
         worktreeId: 'repo::\\\\wsl.localhost\\Ubuntu\\home\\alice\\repo'
       })
     ).toBe('orca-ide')
+    expect(
+      resolveTerminalOrchestrationCliCommand({
+        connectionId: null,
+        isWsl: null,
+        worktreeId: 'folder:workspace-1',
+        worktreePath: '\\\\wsl.localhost\\Ubuntu\\home\\alice\\repo'
+      })
+    ).toBe('orca-ide')
   })
 
   it('preserves native and SSH bare-orca commands', () => {

--- a/src/main/runtime/orchestration/cli-command.ts
+++ b/src/main/runtime/orchestration/cli-command.ts
@@ -8,6 +8,10 @@ export function resolveTerminalOrchestrationCliCommand(args: {
   connectionId: string | null
   isWsl: boolean | null | undefined
   worktreeId: string
+  // Why: pre-spawn callers know the resolved workspace path but may not have
+  // a repo-shaped worktree id (folder workspaces use opaque ids). Prefer this
+  // explicit fact over decoding the id.
+  worktreePath?: string
   projectRuntime?: ProjectExecutionRuntimeResolution
 }): OrchestrationCliCommand {
   if (args.connectionId) {
@@ -20,6 +24,7 @@ export function resolveTerminalOrchestrationCliCommand(args: {
     return 'orca-ide'
   }
 
-  const worktreePath = splitWorktreeIdForFilesystem(args.worktreeId)?.worktreePath
+  const worktreePath =
+    args.worktreePath ?? splitWorktreeIdForFilesystem(args.worktreeId)?.worktreePath
   return worktreePath && isWslUncPath(worktreePath) ? 'orca-ide' : 'orca'
 }

--- a/src/main/runtime/orchestration/db/attach-orchestration-db-methods.ts
+++ b/src/main/runtime/orchestration/db/attach-orchestration-db-methods.ts
@@ -48,6 +48,7 @@ import { attachTaskStore } from './tasks/task-store'
 import { attachTaskStatusTransition } from './tasks/task-status-transition'
 import { attachFederatedWorkerStartReconcile } from './worker-dispatch/federated-worker-start-reconcile'
 import { attachWorkerDispatchAbandon } from './worker-dispatch/worker-dispatch-abandon'
+import { attachWorkerDispatchArgvAuthority } from './worker-dispatch/worker-dispatch-argv-authority'
 import { attachWorkerDispatchAuthority } from './worker-dispatch/worker-dispatch-authority'
 import { attachWorkerDispatchOutcome } from './worker-dispatch/worker-dispatch-outcome'
 import { attachWorkerDispatchStage } from './worker-dispatch/worker-dispatch-stage'
@@ -94,6 +95,7 @@ export function attachOrchestrationDbMethods(ctor: { prototype: object }): void 
   attachWorkerDispatchStart(ctor)
   attachWorkerDispatchStage(ctor)
   attachWorkerDispatchAuthority(ctor)
+  attachWorkerDispatchArgvAuthority(ctor)
   attachWorkerDispatchOutcome(ctor)
   attachFederatedWorkerStartReconcile(ctor)
   attachWorkerTerminalRecovery(ctor)

--- a/src/main/runtime/orchestration/db/orchestration-db-methods.ts
+++ b/src/main/runtime/orchestration/db/orchestration-db-methods.ts
@@ -48,6 +48,7 @@ import type { TaskStoreMethods } from './tasks/task-store'
 import type { TaskStatusTransitionMethods } from './tasks/task-status-transition'
 import type { FederatedWorkerStartReconcileMethods } from './worker-dispatch/federated-worker-start-reconcile'
 import type { WorkerDispatchAbandonMethods } from './worker-dispatch/worker-dispatch-abandon'
+import type { WorkerDispatchArgvAuthorityMethods } from './worker-dispatch/worker-dispatch-argv-authority'
 import type { WorkerDispatchAuthorityMethods } from './worker-dispatch/worker-dispatch-authority'
 import type { WorkerDispatchOutcomeMethods } from './worker-dispatch/worker-dispatch-outcome'
 import type { WorkerDispatchStageMethods } from './worker-dispatch/worker-dispatch-stage'
@@ -93,6 +94,7 @@ export type OrchestrationDbMethods = CreateTablesMethods &
   WorkerDispatchStartMethods &
   WorkerDispatchStageMethods &
   WorkerDispatchAuthorityMethods &
+  WorkerDispatchArgvAuthorityMethods &
   WorkerDispatchOutcomeMethods &
   FederatedWorkerStartReconcileMethods &
   WorkerTerminalRecoveryMethods &

--- a/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-argv-authority.test.ts
+++ b/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-argv-authority.test.ts
@@ -17,7 +17,12 @@ describe('argv worker authority: mint before spawn, bind after', () => {
   function startDispatch() {
     db = new OrchestrationDb(':memory:')
     const task = db.createTask({ spec: 'argv worker' })
-    const started = db.createStartingWorkerDispatch({ taskId: task.id, startOptions: {} })
+    const started = db.createStartingWorkerDispatch({
+      creator: { kind: 'system' },
+      maxDepth: Number.MAX_SAFE_INTEGER,
+      taskId: task.id,
+      startOptions: {}
+    })
     return { d: db, dispatchId: started.dispatch.id }
   }
 
@@ -189,7 +194,12 @@ describe('argv worker authority: mint before spawn, bind after', () => {
     d.markWorkerDispatchReady(dispatchId)
 
     const rival = d.createTask({ spec: 'rival argv worker' })
-    const second = d.createStartingWorkerDispatch({ taskId: rival.id, startOptions: {} })
+    const second = d.createStartingWorkerDispatch({
+      creator: { kind: 'system' },
+      maxDepth: Number.MAX_SAFE_INTEGER,
+      taskId: rival.id,
+      startOptions: {}
+    })
     d.commitDispatchLaunchTokenHash(second.dispatch.id, TOKEN_HASH)
     d.mintStartingWorkerCapability({ dispatchId: second.dispatch.id })
     expect(() => d.bindStartingWorkerAuthority(bindParams(second.dispatch.id))).toThrow(

--- a/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-argv-authority.test.ts
+++ b/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-argv-authority.test.ts
@@ -79,15 +79,48 @@ describe('argv worker authority: mint before spawn, bind after', () => {
     )
   })
 
+  it('refuses to bind when the durable launch-token commitment is absent', () => {
+    const { d, dispatchId } = startDispatch()
+    const capability = d.mintStartingWorkerCapability({ dispatchId })
+    expect(() => d.bindStartingWorkerAuthority(bindParams(dispatchId))).toThrow(
+      /launch-token commitment does not match/
+    )
+    expect(d.getDispatchContextById(dispatchId)).toMatchObject({
+      assignee_handle: null,
+      assignee_pane_key: null,
+      process_incarnation: null
+    })
+    expect(
+      d.verifyDispatchCapability({
+        dispatchId,
+        capability,
+        paneKey: PANE,
+        processIncarnation: INCARNATION
+      })
+    ).toMatchObject({ valid: false })
+  })
+
   it('refuses to bind a pane whose launch token does not match the commitment', () => {
     const { d, dispatchId } = startDispatch()
     d.commitDispatchLaunchTokenHash(dispatchId, TOKEN_HASH)
-    d.mintStartingWorkerCapability({ dispatchId })
+    const capability = d.mintStartingWorkerCapability({ dispatchId })
     const wrongHash = createHash('sha256').update('some-other-token').digest('hex')
     expect(() =>
       d.bindStartingWorkerAuthority(bindParams(dispatchId, { launchTokenHash: wrongHash }))
     ).toThrow(/launch-token commitment does not match/)
-    expect(d.getDispatchContextById(dispatchId)).toMatchObject({ assignee_pane_key: null })
+    expect(d.getDispatchContextById(dispatchId)).toMatchObject({
+      assignee_handle: null,
+      assignee_pane_key: null,
+      process_incarnation: null
+    })
+    expect(
+      d.verifyDispatchCapability({
+        dispatchId,
+        capability,
+        paneKey: PANE,
+        processIncarnation: INCARNATION
+      })
+    ).toMatchObject({ valid: false })
   })
 
   it('refuses to bind a pane that presents no launch token when one was committed', () => {

--- a/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-argv-authority.test.ts
+++ b/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-argv-authority.test.ts
@@ -1,0 +1,166 @@
+import { createHash } from 'node:crypto'
+import { afterEach, describe, expect, it } from 'vitest'
+import { OrchestrationDb } from '../orchestration-db'
+
+const PANE = 'tab_worker:11111111-1111-4111-8111-111111111111'
+const OTHER_PANE = 'tab_other:22222222-2222-4222-8222-222222222222'
+const INCARNATION = 'runtime:pty:1'
+const TOKEN_HASH = createHash('sha256').update('launch-token').digest('hex')
+
+describe('argv worker authority: mint before spawn, bind after', () => {
+  let db: OrchestrationDb | undefined
+
+  afterEach(() => {
+    db?.close()
+  })
+
+  function startDispatch() {
+    db = new OrchestrationDb(':memory:')
+    const task = db.createTask({ spec: 'argv worker' })
+    const started = db.createStartingWorkerDispatch({ taskId: task.id, startOptions: {} })
+    return { d: db, dispatchId: started.dispatch.id }
+  }
+
+  function bindParams(dispatchId: string, overrides?: { launchTokenHash?: string }) {
+    return {
+      dispatchId,
+      handle: 'term_worker',
+      paneKey: PANE,
+      processIncarnation: INCARNATION,
+      launchTokenHash: overrides?.launchTokenHash ?? TOKEN_HASH,
+      worktreeId: 'repo::worktree',
+      setupState: 'not_applicable',
+      effects: [{ kind: 'terminal', action: 'created', id: 'term_worker' }],
+      terminalOwnership: 'created' as const
+    }
+  }
+
+  it('mints an unbound capability that authorizes nothing until bind', () => {
+    const { d, dispatchId } = startDispatch()
+    const capability = d.mintStartingWorkerCapability({ dispatchId })
+    expect(capability).toMatch(/^dcap_/)
+    expect(d.getDispatchContextById(dispatchId)).toMatchObject({
+      status: 'pending',
+      assignee_handle: null,
+      assignee_pane_key: null,
+      process_incarnation: null
+    })
+    // Why: the whole pre-spawn mint is safe only because an unbound
+    // capability is inert — this is the invariant the argv path leans on.
+    expect(
+      d.verifyDispatchCapability({
+        dispatchId,
+        capability,
+        paneKey: PANE,
+        processIncarnation: INCARNATION
+      })
+    ).toMatchObject({ valid: false, reason: 'The caller is not the Dispatch pane.' })
+  })
+
+  it('refuses a second mint instead of silently rotating the argv-baked capability', () => {
+    const { d, dispatchId } = startDispatch()
+    d.mintStartingWorkerCapability({ dispatchId })
+    expect(() => d.mintStartingWorkerCapability({ dispatchId })).toThrow(
+      /already has a lifecycle capability/
+    )
+  })
+
+  it('refuses to mint for a dispatch that is not starting', () => {
+    const { d, dispatchId } = startDispatch()
+    d.failWorkerStart(dispatchId, 'terminal_create', 'spawn failed')
+    expect(() => d.mintStartingWorkerCapability({ dispatchId })).toThrow(/is not starting/)
+  })
+
+  it('refuses to bind when nothing was minted', () => {
+    const { d, dispatchId } = startDispatch()
+    d.commitDispatchLaunchTokenHash(dispatchId, TOKEN_HASH)
+    expect(() => d.bindStartingWorkerAuthority(bindParams(dispatchId))).toThrow(
+      /has no minted capability to bind/
+    )
+  })
+
+  it('refuses to bind a pane whose launch token does not match the commitment', () => {
+    const { d, dispatchId } = startDispatch()
+    d.commitDispatchLaunchTokenHash(dispatchId, TOKEN_HASH)
+    d.mintStartingWorkerCapability({ dispatchId })
+    const wrongHash = createHash('sha256').update('some-other-token').digest('hex')
+    expect(() =>
+      d.bindStartingWorkerAuthority(bindParams(dispatchId, { launchTokenHash: wrongHash }))
+    ).toThrow(/launch-token commitment does not match/)
+    expect(d.getDispatchContextById(dispatchId)).toMatchObject({ assignee_pane_key: null })
+  })
+
+  it('refuses to bind a pane that presents no launch token when one was committed', () => {
+    const { d, dispatchId } = startDispatch()
+    d.commitDispatchLaunchTokenHash(dispatchId, TOKEN_HASH)
+    d.mintStartingWorkerCapability({ dispatchId })
+    const params = bindParams(dispatchId)
+    const { launchTokenHash: _omitted, ...withoutToken } = params
+    expect(() => d.bindStartingWorkerAuthority(withoutToken)).toThrow(
+      /launch-token commitment does not match/
+    )
+  })
+
+  it('never resurrects a capability revoked between mint and bind', () => {
+    const { d, dispatchId } = startDispatch()
+    d.commitDispatchLaunchTokenHash(dispatchId, TOKEN_HASH)
+    d.mintStartingWorkerCapability({ dispatchId })
+    d.revokeDispatchCapability(dispatchId)
+    expect(() => d.bindStartingWorkerAuthority(bindParams(dispatchId))).toThrow(
+      /capability is revoked/
+    )
+    // Why: the atomic prepare path clears capability_revoked_at because
+    // nothing can revoke inside one transaction. Across two transactions
+    // that reset would resurrect a revocation, so bind must keep it.
+    expect(d.getDispatchContextById(dispatchId)?.capability_revoked_at).not.toBeNull()
+  })
+
+  it('binds the spawned pane and only then makes the capability valid for that exact pane', () => {
+    const { d, dispatchId } = startDispatch()
+    d.commitDispatchLaunchTokenHash(dispatchId, TOKEN_HASH)
+    const capability = d.mintStartingWorkerCapability({ dispatchId })
+    d.bindStartingWorkerAuthority(bindParams(dispatchId))
+    expect(d.getDispatchContextById(dispatchId)).toMatchObject({
+      assignee_handle: 'term_worker',
+      assignee_pane_key: PANE,
+      process_incarnation: INCARNATION,
+      launch_token_hash: TOKEN_HASH
+    })
+    expect(
+      d.verifyDispatchCapability({
+        dispatchId,
+        capability,
+        paneKey: PANE,
+        processIncarnation: INCARNATION
+      })
+    ).toEqual({ valid: true })
+    expect(
+      d.verifyDispatchCapability({
+        dispatchId,
+        capability,
+        paneKey: OTHER_PANE,
+        processIncarnation: INCARNATION
+      })
+    ).toMatchObject({ valid: false })
+    expect(d.getWorkerTerminalResourceByOwner(dispatchId)).toMatchObject({
+      terminal_handle: 'term_worker',
+      pane_key: PANE
+    })
+  })
+
+  it('refuses to bind a pane that already carries another active dispatch', () => {
+    const { d, dispatchId } = startDispatch()
+    d.commitDispatchLaunchTokenHash(dispatchId, TOKEN_HASH)
+    d.mintStartingWorkerCapability({ dispatchId })
+    d.bindStartingWorkerAuthority(bindParams(dispatchId))
+    d.markWorkerDispatchReady(dispatchId)
+
+    const rival = d.createTask({ spec: 'rival argv worker' })
+    const second = d.createStartingWorkerDispatch({ taskId: rival.id, startOptions: {} })
+    d.commitDispatchLaunchTokenHash(second.dispatch.id, TOKEN_HASH)
+    d.mintStartingWorkerCapability({ dispatchId: second.dispatch.id })
+    expect(() => d.bindStartingWorkerAuthority(bindParams(second.dispatch.id))).toThrow(
+      /already has an active dispatch/
+    )
+  })
+})

--- a/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-argv-authority.ts
+++ b/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-argv-authority.ts
@@ -1,0 +1,222 @@
+import { randomBytes } from 'node:crypto'
+import { OrchestrationError } from '../../orchestration-error'
+import { hashDispatchCapability } from '../dispatch-capability-hash'
+import type { OrchestrationDb } from '../orchestration-db'
+
+// Why: argv-injected worker starts need the capability text BEFORE the worker
+// terminal exists — the dispatch preamble is baked into the agent's launch
+// argv, so it cannot wait for a pane. Minting is safe pre-bind because
+// verifyDispatchCapability refuses any use until assignee_pane_key and
+// process_incarnation are bound: an unbound capability authorizes nothing.
+export function mintStartingWorkerCapability(
+  this: OrchestrationDb,
+  params: { dispatchId: string }
+): string {
+  this.db.exec('BEGIN IMMEDIATE')
+  try {
+    const dispatch = this.getDispatchContextById(params.dispatchId)
+    const worker = this.getWorkerDispatch(params.dispatchId)
+    if (!dispatch || dispatch.status !== 'pending' || worker?.state !== 'starting') {
+      throw new OrchestrationError(
+        'dispatch_inactive',
+        `Dispatch ${params.dispatchId} is not starting.`
+      )
+    }
+    // Why: the plaintext is returned exactly once; a second mint could not
+    // reproduce it and would silently orphan the capability already baked
+    // into a launch argv. Refuse instead of rotating.
+    if (dispatch.capability_hash) {
+      throw new OrchestrationError(
+        'request_mismatch',
+        `Dispatch ${params.dispatchId} already has a lifecycle capability.`
+      )
+    }
+    if (dispatch.capability_revoked_at) {
+      throw new OrchestrationError(
+        'dispatch_inactive',
+        `Dispatch ${params.dispatchId} capability is revoked.`
+      )
+    }
+    const capability = `dcap_${randomBytes(32).toString('base64url')}`
+    const contextUpdate = this.db
+      .prepare(
+        `UPDATE dispatch_contexts
+         SET capability_hash = ?
+         WHERE id = ? AND status = 'pending' AND capability_hash IS NULL`
+      )
+      .run(hashDispatchCapability(capability), params.dispatchId)
+    if (contextUpdate.changes !== 1) {
+      throw new OrchestrationError(
+        'dispatch_inactive',
+        `Dispatch ${params.dispatchId} is not starting.`
+      )
+    }
+    this.db.exec('COMMIT')
+    return capability
+  } catch (error) {
+    this.db.exec('ROLLBACK')
+    throw error
+  }
+}
+
+// Why: the post-spawn half of an argv worker start. Everything
+// prepareStartingWorkerAuthority does EXCEPT capability generation, plus two
+// hardened guards: the launch-token commitment is REQUIRED to match (it is the
+// only proof the binding pane is the exact process that received
+// ORCA_AGENT_LAUNCH_TOKEN at spawn), and a revoked capability is never
+// resurrected — the atomic mint+bind clears capability_revoked_at because
+// nothing can revoke inside one transaction; across two transactions that
+// reset would resurrect a capability revoked between mint and bind.
+export function bindStartingWorkerAuthority(
+  this: OrchestrationDb,
+  params: {
+    dispatchId: string
+    handle: string
+    paneKey: string
+    processIncarnation: string
+    launchTokenHash?: string
+    worktreeId: string
+    effects: unknown[]
+    setupState: string
+    hostScope?: string | null
+    terminalOwnership?: 'created' | 'external'
+  }
+): void {
+  this.db.exec('BEGIN IMMEDIATE')
+  try {
+    const dispatch = this.getDispatchContextById(params.dispatchId)
+    const worker = this.getWorkerDispatch(params.dispatchId)
+    if (!dispatch || dispatch.status !== 'pending' || worker?.state !== 'starting') {
+      throw new OrchestrationError(
+        'dispatch_inactive',
+        `Dispatch ${params.dispatchId} is not starting.`
+      )
+    }
+    if (!dispatch.capability_hash) {
+      throw new OrchestrationError(
+        'request_mismatch',
+        `Dispatch ${params.dispatchId} has no minted capability to bind.`
+      )
+    }
+    if (dispatch.capability_revoked_at) {
+      throw new OrchestrationError(
+        'dispatch_inactive',
+        `Dispatch ${params.dispatchId} capability is revoked.`
+      )
+    }
+    if (
+      dispatch.launch_token_hash &&
+      dispatch.launch_token_hash !== (params.launchTokenHash ?? null)
+    ) {
+      throw new OrchestrationError(
+        'request_mismatch',
+        `Dispatch ${params.dispatchId} launch-token commitment does not match the binding pane.`
+      )
+    }
+    const existing = this.findActiveDispatchForAssignee(params.handle, params.paneKey)
+    if (existing && existing.id !== params.dispatchId) {
+      throw new Error(
+        `Terminal ${params.handle} already has an active dispatch (${existing.id} for task ${existing.task_id})`
+      )
+    }
+    const contextUpdate = this.db
+      .prepare(
+        `UPDATE dispatch_contexts
+         SET assignee_handle = ?, assignee_pane_key = ?, process_incarnation = ?
+         WHERE id = ? AND status = 'pending' AND capability_revoked_at IS NULL`
+      )
+      .run(params.handle, params.paneKey, params.processIncarnation, params.dispatchId)
+    if (contextUpdate.changes !== 1) {
+      throw new OrchestrationError(
+        'dispatch_inactive',
+        `Dispatch ${params.dispatchId} is not starting.`
+      )
+    }
+    const workerUpdate = this.db
+      .prepare(
+        `UPDATE worker_dispatches
+         SET stage = 'authority_attached', worktree_id = ?, agent_terminal_handle = ?,
+             setup_state = ?, effects = ?, residual_resources = ?, updated_at = datetime('now')
+         WHERE dispatch_id = ? AND state = 'starting'`
+      )
+      .run(
+        params.worktreeId,
+        params.handle,
+        params.setupState,
+        JSON.stringify(params.effects),
+        JSON.stringify(
+          params.effects.filter((effect) =>
+            Boolean(
+              effect &&
+              typeof effect === 'object' &&
+              ((effect as { action?: string }).action?.startsWith('created') ||
+                (effect as { action?: string }).action === 'reused_agent_terminal')
+            )
+          )
+        ),
+        params.dispatchId
+      )
+    if (workerUpdate.changes !== 1) {
+      throw new OrchestrationError(
+        'dispatch_inactive',
+        `Dispatch ${params.dispatchId} is not starting.`
+      )
+    }
+    if (params.terminalOwnership && !this.getWorkerTerminalResourceByOwner(params.dispatchId)) {
+      if (params.terminalOwnership === 'created') {
+        this.createWorkerTerminalResourceStatement({
+          dispatchId: params.dispatchId,
+          worktreeId: params.worktreeId,
+          terminalHandle: params.handle,
+          paneKey: params.paneKey,
+          processIncarnation: params.processIncarnation,
+          hostScope: params.hostScope,
+          ownership: 'owned'
+        })
+      } else {
+        const transferable = this.findTransferableWorkerTerminalResource({
+          terminalHandle: params.handle,
+          paneKey: params.paneKey,
+          processIncarnation: params.processIncarnation,
+          hostScope: params.hostScope ?? null
+        })
+        if (transferable) {
+          this.transferWorkerTerminalResourceStatement({
+            resourceId: transferable.id,
+            toDispatchId: params.dispatchId,
+            terminalHandle: params.handle,
+            paneKey: params.paneKey,
+            processIncarnation: params.processIncarnation,
+            hostScope: params.hostScope ?? null
+          })
+        } else {
+          this.createWorkerTerminalResourceStatement({
+            dispatchId: params.dispatchId,
+            worktreeId: params.worktreeId,
+            terminalHandle: params.handle,
+            paneKey: params.paneKey,
+            processIncarnation: params.processIncarnation,
+            hostScope: params.hostScope,
+            ownership: 'external'
+          })
+        }
+      }
+    }
+    this.db.exec('COMMIT')
+  } catch (error) {
+    this.db.exec('ROLLBACK')
+    throw error
+  }
+}
+
+export type WorkerDispatchArgvAuthorityMethods = {
+  mintStartingWorkerCapability: typeof mintStartingWorkerCapability
+  bindStartingWorkerAuthority: typeof bindStartingWorkerAuthority
+}
+
+export function attachWorkerDispatchArgvAuthority(ctor: { prototype: object }): void {
+  Object.assign(ctor.prototype, {
+    mintStartingWorkerCapability,
+    bindStartingWorkerAuthority
+  })
+}

--- a/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-argv-authority.ts
+++ b/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-argv-authority.ts
@@ -162,7 +162,26 @@ export function bindStartingWorkerAuthority(
         `Dispatch ${params.dispatchId} is not starting.`
       )
     }
-    if (params.terminalOwnership && !this.getWorkerTerminalResourceByOwner(params.dispatchId)) {
+    const existingResource = this.getWorkerTerminalResourceByOwner(params.dispatchId)
+    if (existingResource) {
+      if (
+        existingResource.terminal_handle !== params.handle ||
+        existingResource.ownership_state !== 'owned'
+      ) {
+        throw new OrchestrationError(
+          'request_mismatch',
+          `Dispatch ${params.dispatchId} terminal resource does not match the binding pane.`
+        )
+      }
+      this.bindWorkerTerminalResourceStatement({
+        dispatchId: params.dispatchId,
+        worktreeId: params.worktreeId,
+        terminalHandle: params.handle,
+        paneKey: params.paneKey,
+        processIncarnation: params.processIncarnation,
+        hostScope: params.hostScope ?? null
+      })
+    } else if (params.terminalOwnership) {
       if (params.terminalOwnership === 'created') {
         this.createWorkerTerminalResourceStatement({
           dispatchId: params.dispatchId,

--- a/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-argv-authority.ts
+++ b/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-argv-authority.ts
@@ -105,7 +105,7 @@ export function bindStartingWorkerAuthority(
       )
     }
     if (
-      dispatch.launch_token_hash &&
+      !dispatch.launch_token_hash ||
       dispatch.launch_token_hash !== (params.launchTokenHash ?? null)
     ) {
       throw new OrchestrationError(

--- a/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-outcome.ts
+++ b/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-outcome.ts
@@ -47,7 +47,7 @@ export function failWorkerStart(
   try {
     const dispatch = this.getDispatchContextById(dispatchId)
     const worker = this.getWorkerDispatch(dispatchId)
-    if (!dispatch || !worker || worker.state !== 'starting') {
+    if (!dispatch || !worker || !['starting', 'ready'].includes(worker.state)) {
       throw new OrchestrationError('dispatch_inactive', `Dispatch ${dispatchId} is not starting.`)
     }
     this.db

--- a/src/main/runtime/orchestration/db/worker-terminal/worker-terminal-resource-store.ts
+++ b/src/main/runtime/orchestration/db/worker-terminal/worker-terminal-resource-store.ts
@@ -106,6 +106,44 @@ export function getWorkerTerminalResourceByOwner(
     .get(dispatchId) as WorkerTerminalResourceRow | undefined
 }
 
+// No transaction: composes inside worker authority binding's transaction.
+export function bindWorkerTerminalResourceStatement(
+  this: OrchestrationDb,
+  params: {
+    dispatchId: string
+    worktreeId: string | null
+    terminalHandle: string
+    paneKey: string | null
+    processIncarnation: string | null
+    hostScope: string | null
+  }
+): WorkerTerminalResourceRow {
+  const resource = this.getWorkerTerminalResourceByOwner(params.dispatchId)
+  if (!resource) {
+    throw new OrchestrationError(
+      'dispatch_not_found',
+      `Worker terminal resource for Dispatch ${params.dispatchId} was not found.`
+    )
+  }
+  this.db
+    .prepare(
+      `UPDATE worker_terminal_resources
+       SET worktree_id = ?, terminal_handle = ?, pane_key = ?, process_incarnation = ?,
+           host_scope = ?, updated_at = datetime('now')
+       WHERE id = ? AND owner_dispatch_id = ? AND ownership_state = 'owned'`
+    )
+    .run(
+      params.worktreeId,
+      params.terminalHandle,
+      params.paneKey,
+      params.processIncarnation,
+      params.hostScope,
+      resource.id,
+      params.dispatchId
+    )
+  return this.getWorkerTerminalResource(resource.id) as WorkerTerminalResourceRow
+}
+
 export function getWorkerTerminalResourceFormerlyOwnedBy(
   this: OrchestrationDb,
   dispatchId: string
@@ -169,6 +207,7 @@ export type WorkerTerminalResourceStoreMethods = {
   createWorkerTerminalResourceStatement: typeof createWorkerTerminalResourceStatement
   getWorkerTerminalResource: typeof getWorkerTerminalResource
   getWorkerTerminalResourceByOwner: typeof getWorkerTerminalResourceByOwner
+  bindWorkerTerminalResourceStatement: typeof bindWorkerTerminalResourceStatement
   getWorkerTerminalResourceFormerlyOwnedBy: typeof getWorkerTerminalResourceFormerlyOwnedBy
   transferWorkerTerminalResourceStatement: typeof transferWorkerTerminalResourceStatement
 }
@@ -179,6 +218,7 @@ export function attachWorkerTerminalResourceStore(ctor: { prototype: object }): 
     createWorkerTerminalResourceStatement,
     getWorkerTerminalResource,
     getWorkerTerminalResourceByOwner,
+    bindWorkerTerminalResourceStatement,
     getWorkerTerminalResourceFormerlyOwnedBy,
     transferWorkerTerminalResourceStatement
   })

--- a/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { RpcContext } from '../core'
 import { createOrchestrationRpcHarness } from './orchestration-rpc-test-harness'
@@ -25,11 +26,17 @@ describe('orchestration RPC methods', () => {
   }
 
   describe('composed workers', () => {
-    function mockCurrentWorkerStart(options?: { ready?: boolean }): void {
+    function mockCurrentWorkerStart(options?: { ready?: boolean; terminalWarning?: string }): void {
+      // Why: the argv worker-start path pre-allocates the handle and mints the
+      // launch token BEFORE createTerminal. Real createTerminal adopts both;
+      // a mock that ignored them would trip the handle-substitution guard and
+      // the launch-token bind guard, testing a runtime that cannot exist.
+      let workerHandle = 'term_worker'
+      let workerLaunchTokenHash: string | null = null
       vi.mocked(runtime.getTerminalPaneKey).mockImplementation((handle) =>
         handle === 'term_coord'
           ? coordinatorPaneKey
-          : handle === 'term_worker'
+          : handle === workerHandle
             ? 'tab_worker:leaf_worker'
             : null
       )
@@ -43,22 +50,49 @@ describe('orchestration RPC methods', () => {
       vi.spyOn(runtime, 'showManagedTerminalWorkspace').mockResolvedValue({
         id: 'repo::worktree'
       } as never)
-      vi.spyOn(runtime, 'createTerminal').mockResolvedValue({
-        handle: 'term_worker',
-        worktreeId: 'repo::worktree',
-        title: 'worker'
+      vi.spyOn(runtime, 'createTerminal').mockImplementation(async (_selector, opts) => {
+        workerHandle = opts?.preAllocatedHandle ?? 'term_worker'
+        workerLaunchTokenHash = opts?.launchToken
+          ? createHash('sha256').update(opts.launchToken).digest('hex')
+          : null
+        return {
+          handle: workerHandle,
+          worktreeId: 'repo::worktree',
+          title: 'worker',
+          ...(options?.terminalWarning
+            ? { surface: 'background' as const, warning: options.terminalWarning }
+            : {})
+        } as never
       })
-      vi.spyOn(runtime, 'waitForTerminal').mockResolvedValue({
-        handle: 'term_worker',
-        condition: 'tui-idle',
-        satisfied: options?.ready !== false,
-        status: 'running',
-        exitCode: null
-      })
+      vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockImplementation((handle) =>
+        handle === workerHandle && workerLaunchTokenHash
+          ? ({
+              runtimeId: runtime.getRuntimeId(),
+              terminalHandle: workerHandle,
+              ptyId: 'pty_worker',
+              worktreeId: 'repo::worktree',
+              paneKey: 'tab_worker:leaf_worker',
+              processIncarnation: 'runtime_test:term_worker:1',
+              launchTokenHash: workerLaunchTokenHash,
+              hostScope: null
+            } as never)
+          : null
+      )
+      vi.spyOn(runtime, 'waitForTerminal').mockImplementation(
+        async (handle) =>
+          ({
+            handle,
+            condition: 'tui-idle',
+            satisfied: options?.ready !== false,
+            status: 'running',
+            exitCode: null
+          }) as never
+      )
       vi.mocked(runtime.getTerminalProcessIncarnation).mockImplementation((handle) =>
-        handle === 'term_worker' ? 'runtime_test:term_worker:1' : null
+        handle === workerHandle ? 'runtime_test:term_worker:1' : null
       )
       vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
+      vi.spyOn(runtime, 'getWorktreeOrchestrationCliCommand').mockResolvedValue('orca')
       vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockResolvedValue({
         handle: 'term_worker',
         accepted: true,
@@ -154,17 +188,36 @@ describe('orchestration RPC methods', () => {
       // the tab without scrolling the sidebar to the worker's workspace.
       expect(runtime.createTerminal).toHaveBeenCalledWith('id:repo::worktree', {
         startupAgent: 'codex',
+        preAllocatedHandle: expect.stringMatching(/^term_/),
+        launchToken: expect.any(String),
+        // Why: the preamble travels in the launch argv — the capability the
+        // worker presents later must be the one baked in at spawn.
+        agentPrompt: expect.stringContaining('--dispatch-capability dcap_'),
         title: `worker-${task.id}`,
         surfaceOwner: false
       })
-      expect(runtime.sendTerminalAgentPrompt).toHaveBeenCalledWith(
-        'term_worker',
-        expect.stringContaining('--dispatch-capability dcap_')
-      )
+      expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
     })
 
+    it('embeds the WSL CLI name before the worker pane exists', async () => {
+      setup()
+      mockCurrentWorkerStart()
+      vi.mocked(runtime.getWorktreeOrchestrationCliCommand).mockResolvedValueOnce('orca-ide')
+      const task = db.createTask({ spec: 'report from WSL' })
+
+      await call('orchestration.workerStart', {
+        task: task.id,
+        from: 'term_coord',
+        agent: 'codex'
+      })
+
+      const createOptions = vi.mocked(runtime.createTerminal).mock.calls.at(-1)?.[1]
+      expect(createOptions?.agentPrompt).toContain('orca-ide orchestration send')
+      expect(runtime.getWorktreeOrchestrationCliCommand).toHaveBeenCalledWith('repo::worktree')
+    })
     it('applies and reports opaque per-invocation model preferences', async () => {
       setup()
+
       mockCurrentWorkerStart()
       const task = db.createTask({ spec: 'launch a custom model' })
 
@@ -244,16 +297,6 @@ describe('orchestration RPC methods', () => {
     it('commits the launched worker token with its durable authority', async () => {
       setup()
       mockCurrentWorkerStart()
-      vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockReturnValue({
-        runtimeId: runtime.getRuntimeId(),
-        terminalHandle: 'term_worker',
-        ptyId: 'pty_worker',
-        worktreeId: 'repo::worktree',
-        paneKey: 'tab_worker:leaf_worker',
-        processIncarnation: 'runtime_test:term_worker:1',
-        launchTokenHash: 'worker-launch-token-hash',
-        hostScope: { kind: 'local', hostId: 'local' }
-      })
       const task = db.createTask({ spec: 'persist worker identity' })
 
       const result = (await call('orchestration.workerStart', {
@@ -262,20 +305,20 @@ describe('orchestration RPC methods', () => {
         agent: 'codex'
       })) as { dispatchId: string }
 
+      // Why: the token handed to the spawn is the ONLY identity proof the
+      // binding pane can present; the context must carry exactly its hash.
+      const createOptions = vi.mocked(runtime.createTerminal).mock.calls.at(-1)?.[1]
+      const launchToken = createOptions?.launchToken
+      expect(launchToken).toBeTruthy()
       expect(db.getDispatchContextById(result.dispatchId)?.launch_token_hash).toBe(
-        'worker-launch-token-hash'
+        createHash('sha256').update(launchToken!).digest('hex')
       )
     })
 
     it('surfaces a worker terminal reveal failure without discarding the live worker', async () => {
       setup()
-      mockCurrentWorkerStart()
-      vi.mocked(runtime.createTerminal).mockResolvedValue({
-        handle: 'term_worker',
-        worktreeId: 'repo::worktree',
-        title: 'worker',
-        surface: 'background',
-        warning: 'Terminal term_worker is running but could not be revealed.'
+      mockCurrentWorkerStart({
+        terminalWarning: 'Terminal term_worker is running but could not be revealed.'
       })
       const task = db.createTask({ spec: 'keep working if reveal fails' })
 
@@ -300,7 +343,9 @@ describe('orchestration RPC methods', () => {
           warning: 'Terminal term_worker is running but could not be revealed.'
         })
       )
-      expect(runtime.sendTerminalAgentPrompt).toHaveBeenCalled()
+      expect(result.effects).toContainEqual(
+        expect.objectContaining({ kind: 'dispatch_input', state: 'accepted' })
+      )
     })
 
     it('starts in an exact existing worktree from a floating coordinator', async () => {
@@ -410,6 +455,8 @@ describe('orchestration RPC methods', () => {
       expect(createWorktree).not.toHaveBeenCalled()
     })
 
+    // Why: agents without launch-embedded prompts still take the paste path,
+    // where tui-idle readiness gates the brief; its timeout stays a failure.
     it('returns a failed receipt and preserves a created terminal as residual', async () => {
       setup()
       mockCurrentWorkerStart({ ready: false })
@@ -418,7 +465,7 @@ describe('orchestration RPC methods', () => {
       const result = (await call('orchestration.workerStart', {
         task: task.id,
         from: 'term_coord',
-        agent: 'codex'
+        agent: 'goose'
       })) as { state: string; failedStage: string; residualResources: { id: string }[] }
 
       expect(result).toMatchObject({ state: 'failed', failedStage: 'agent_readiness' })
@@ -447,6 +494,7 @@ describe('orchestration RPC methods', () => {
       expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
     })
 
+    // Why: prompt paste (and its rejection) only exists on the non-argv path.
     it('preserves the exact attached terminal when task input is rejected', async () => {
       setup()
       mockCurrentWorkerStart()
@@ -458,7 +506,7 @@ describe('orchestration RPC methods', () => {
       const result = (await call('orchestration.workerStart', {
         task: task.id,
         from: 'term_coord',
-        agent: 'codex'
+        agent: 'goose'
       })) as {
         state: string
         failedStage: string
@@ -472,7 +520,7 @@ describe('orchestration RPC methods', () => {
     })
 
     it.each(['codex-update-prompt', 'codex-trust-workspace'] as const)(
-      'returns a truthful readiness failure for %s',
+      'reports a blocked startup screen without failing the ready dispatch for %s',
       async (blockedReason) => {
         setup()
         mockCurrentWorkerStart()
@@ -484,19 +532,31 @@ describe('orchestration RPC methods', () => {
           exitCode: null,
           blockedReason
         })
+        const notify = vi.spyOn(runtime, 'notifyMessageArrived').mockImplementation(() => {})
+        const insertMessage = vi.spyOn(db, 'insertMessage')
         const task = db.createTask({ spec: 'blocked startup prompt' })
 
         const result = (await call('orchestration.workerStart', {
           task: task.id,
           from: 'term_coord',
           agent: 'codex'
-        })) as { state: string; failedStage: string; lastError: string }
+        })) as { state: string; dispatchId: string }
 
-        expect(result).toMatchObject({
-          state: 'failed',
-          failedStage: 'agent_readiness',
-          lastError: `Agent startup blocked: ${blockedReason}`
+        // Why: the brief is already delivered via argv and the capability is
+        // bound — failing the start would revoke a capability the worker
+        // presents after a human clears the screen. Ready stands; the blocked
+        // screen surfaces as durable high-priority evidence to the Run.
+        expect(result.state).toBe('ready')
+        await vi.waitFor(() => {
+          expect(insertMessage).toHaveBeenCalledWith(
+            expect.objectContaining({
+              priority: 'high',
+              subject: expect.stringContaining(`startup blocked: ${blockedReason}`)
+            })
+          )
         })
+        expect(notify).toHaveBeenCalled()
+        expect(db.getWorkerDispatch(result.dispatchId)?.state).toBe('ready')
         expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
       }
     )

--- a/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
@@ -685,6 +685,51 @@ describe('orchestration RPC methods', () => {
       }
     )
 
+    it('reports an argv readiness timeout with a fallback without revoking capability', async () => {
+      setup()
+      mockCurrentWorkerStart()
+      vi.mocked(runtime.waitForTerminal).mockResolvedValueOnce({
+        handle: 'term_worker',
+        condition: 'tui-idle',
+        satisfied: false,
+        status: 'running',
+        exitCode: null
+      })
+      const insertMessage = vi.spyOn(db, 'insertMessage')
+      const notify = vi.spyOn(runtime, 'notifyMessageArrived').mockImplementation(() => {})
+      const task = db.createTask({ spec: 'argv readiness timeout' })
+
+      const result = (await call('orchestration.workerStart', {
+        task: task.id,
+        from: 'term_coord',
+        agent: 'codex'
+      })) as { state: string; dispatchId: string }
+
+      expect(result.state).toBe('ready')
+      expect(db.getTask(task.id)?.status).toBe('dispatched')
+      expect(db.getDispatchContextById(result.dispatchId)).toMatchObject({
+        status: 'dispatched',
+        capability_revoked_at: null,
+        capability_hash: expect.any(String)
+      })
+      expect(insertMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          priority: 'high',
+          subject: expect.stringContaining(
+            'startup blocked: Terminal readiness wait was not satisfied.'
+          )
+        })
+      )
+      const blockedMessage = insertMessage.mock.calls.at(-1)?.[0]
+      expect(JSON.parse(blockedMessage?.payload ?? '{}')).toMatchObject({
+        dispatchId: result.dispatchId,
+        blockedReason: 'Terminal readiness wait was not satisfied.',
+        terminalHandle: 'term_worker'
+      })
+      expect(notify).toHaveBeenCalled()
+      expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
+    })
+
     it('creates a child worktree agent-first with setup run by default', async () => {
       setup()
       mockCurrentWorkerStart()

--- a/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
@@ -54,6 +54,7 @@ describe('orchestration RPC methods', () => {
       let workerHandle = 'term_worker'
       let actualWorkerHandle = 'term_worker'
       let workerLaunchTokenHash: string | null = null
+      vi.spyOn(runtime, 'createPreAllocatedTerminalHandle').mockReturnValue('term_worker')
       vi.mocked(runtime.getTerminalPaneKey).mockImplementation((handle) =>
         handle === 'term_coord'
           ? coordinatorPaneKey
@@ -695,7 +696,7 @@ describe('orchestration RPC methods', () => {
         id: 'repo',
         kind: 'git'
       } as never)
-      const create = vi.spyOn(runtime, 'createManagedWorktree').mockResolvedValue({
+      const createdWorktree = {
         worktree: { id: 'repo::child', repoId: 'repo' },
         startupTerminal: { spawned: true, handle: 'term_worker' },
         setupReceipt: {
@@ -705,7 +706,27 @@ describe('orchestration RPC methods', () => {
           state: 'running',
           terminalHandle: 'term_setup'
         }
-      } as never)
+      } as never
+      const create = vi.spyOn(runtime, 'createManagedWorktree').mockImplementation(async (args) => {
+        const launchTokenHash = args.startupLaunchToken
+          ? createHash('sha256').update(args.startupLaunchToken).digest('hex')
+          : null
+        vi.mocked(runtime.getOrchestrationDispatchAuthority).mockReturnValue(
+          launchTokenHash
+            ? ({
+                runtimeId: runtime.getRuntimeId(),
+                terminalHandle: 'term_worker',
+                ptyId: 'pty_worker',
+                worktreeId: 'repo::child',
+                paneKey: 'tab_worker:leaf_worker',
+                processIncarnation: 'runtime_test:term_worker:1',
+                launchTokenHash,
+                hostScope: null
+              } as never)
+            : null
+        )
+        return createdWorktree
+      })
       vi.spyOn(runtime, 'listTerminals').mockResolvedValue({
         terminals: [
           { handle: 'term_worker', title: 'Codex' },
@@ -750,7 +771,7 @@ describe('orchestration RPC methods', () => {
       )
       expect(result.effects).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ role: 'agent', action: 'reused_agent_terminal' }),
+          expect.objectContaining({ role: 'agent', action: 'created' }),
           expect.objectContaining({ role: 'setup', action: 'created' }),
           expect.objectContaining({ role: 'configured_tab', action: 'created' })
         ])

--- a/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
@@ -25,13 +25,34 @@ describe('orchestration RPC methods', () => {
     return h.call(name, params, ctx)
   }
 
+  function ownedResourceCount(dispatchId: string): number {
+    const raw = (
+      db as unknown as {
+        db: { prepare: (sql: string) => { get: (...args: unknown[]) => { count: number } } }
+      }
+    ).db
+    return raw
+      .prepare(
+        `SELECT COUNT(*) AS count
+             FROM worker_terminal_resources
+            WHERE owner_dispatch_id = ?`
+      )
+      .get(dispatchId).count
+  }
+
   describe('composed workers', () => {
-    function mockCurrentWorkerStart(options?: { ready?: boolean; terminalWarning?: string }): void {
+    function mockCurrentWorkerStart(options?: {
+      ready?: boolean
+      terminalWarning?: string
+      terminalHandle?: string
+      authorityLaunchTokenHash?: string
+    }): void {
       // Why: the argv worker-start path pre-allocates the handle and mints the
       // launch token BEFORE createTerminal. Real createTerminal adopts both;
       // a mock that ignored them would trip the handle-substitution guard and
       // the launch-token bind guard, testing a runtime that cannot exist.
       let workerHandle = 'term_worker'
+      let actualWorkerHandle = 'term_worker'
       let workerLaunchTokenHash: string | null = null
       vi.mocked(runtime.getTerminalPaneKey).mockImplementation((handle) =>
         handle === 'term_coord'
@@ -52,11 +73,12 @@ describe('orchestration RPC methods', () => {
       } as never)
       vi.spyOn(runtime, 'createTerminal').mockImplementation(async (_selector, opts) => {
         workerHandle = opts?.preAllocatedHandle ?? 'term_worker'
+        actualWorkerHandle = options?.terminalHandle ?? workerHandle
         workerLaunchTokenHash = opts?.launchToken
           ? createHash('sha256').update(opts.launchToken).digest('hex')
           : null
         return {
-          handle: workerHandle,
+          handle: actualWorkerHandle,
           worktreeId: 'repo::worktree',
           title: 'worker',
           ...(options?.terminalWarning
@@ -65,15 +87,15 @@ describe('orchestration RPC methods', () => {
         } as never
       })
       vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockImplementation((handle) =>
-        handle === workerHandle && workerLaunchTokenHash
+        handle === actualWorkerHandle && workerLaunchTokenHash
           ? ({
               runtimeId: runtime.getRuntimeId(),
-              terminalHandle: workerHandle,
+              terminalHandle: actualWorkerHandle,
               ptyId: 'pty_worker',
               worktreeId: 'repo::worktree',
               paneKey: 'tab_worker:leaf_worker',
               processIncarnation: 'runtime_test:term_worker:1',
-              launchTokenHash: workerLaunchTokenHash,
+              launchTokenHash: options?.authorityLaunchTokenHash ?? workerLaunchTokenHash,
               hostScope: null
             } as never)
           : null
@@ -89,7 +111,7 @@ describe('orchestration RPC methods', () => {
           }) as never
       )
       vi.mocked(runtime.getTerminalProcessIncarnation).mockImplementation((handle) =>
-        handle === workerHandle ? 'runtime_test:term_worker:1' : null
+        handle === actualWorkerHandle ? 'runtime_test:term_worker:1' : null
       )
       vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
       vi.spyOn(runtime, 'getWorktreeOrchestrationCliCommand').mockResolvedValue('orca')
@@ -182,8 +204,12 @@ describe('orchestration RPC methods', () => {
           expect.objectContaining({ kind: 'dispatch_input', state: 'accepted' })
         ])
       )
+      expect(
+        result.effects.filter((effect) => effect.kind === 'terminal' && effect.role === 'agent')
+      ).toHaveLength(1)
       expect(db.getTask(task.id)?.status).toBe('dispatched')
       expect(db.getWorkerDispatch(result.dispatchId)?.state).toBe('ready')
+      expect(ownedResourceCount(result.dispatchId)).toBe(1)
       // Why: dispatching a worker is background work — surfaceOwner:false adopts
       // the tab without scrolling the sidebar to the worker's workspace.
       expect(runtime.createTerminal).toHaveBeenCalledWith('id:repo::worktree', {
@@ -197,6 +223,93 @@ describe('orchestration RPC methods', () => {
         surfaceOwner: false
       })
       expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
+    })
+
+    it('persists the substituted argv terminal before rejecting its identity', async () => {
+      setup()
+      mockCurrentWorkerStart({ terminalHandle: 'term_adopted' })
+      const task = db.createTask({ spec: 'reject substituted worker terminal' })
+
+      const result = (await call('orchestration.workerStart', {
+        task: task.id,
+        from: 'term_coord',
+        agent: 'codex'
+      })) as {
+        dispatchId: string
+        state: string
+        failedStage: string
+        effects: { kind: string; role?: string; action?: string; id?: string }[]
+        residualResources: { kind: string; role?: string; action?: string; id?: string }[]
+      }
+
+      expect(result).toMatchObject({
+        state: 'failed',
+        failedStage: 'authority_bind'
+      })
+      expect(result.effects).toContainEqual(
+        expect.objectContaining({
+          kind: 'terminal',
+          role: 'agent',
+          action: 'created',
+          id: 'term_adopted'
+        })
+      )
+      expect(result.residualResources).toContainEqual(
+        expect.objectContaining({
+          kind: 'terminal',
+          role: 'agent',
+          action: 'created',
+          id: 'term_adopted'
+        })
+      )
+      expect(db.getWorkerTerminalResourceByOwner(result.dispatchId)).toMatchObject({
+        ownership_state: 'owned',
+        release_state: 'not_requested',
+        terminal_handle: 'term_adopted',
+        pane_key: 'tab_worker:leaf_worker',
+        process_incarnation: 'runtime_test:term_worker:1'
+      })
+      expect(ownedResourceCount(result.dispatchId)).toBe(1)
+    })
+
+    it('retains terminal ownership when authority binding fails after creation', async () => {
+      setup()
+      mockCurrentWorkerStart({ authorityLaunchTokenHash: 'wrong-launch-token-hash' })
+      const task = db.createTask({ spec: 'retain worker after bind rejection' })
+
+      const result = (await call('orchestration.workerStart', {
+        task: task.id,
+        from: 'term_coord',
+        agent: 'codex'
+      })) as {
+        dispatchId: string
+        state: string
+        failedStage: string
+        effects: { kind: string; role?: string; action?: string; id?: string }[]
+        residualResources: { kind: string; role?: string; action?: string; id?: string }[]
+      }
+
+      expect(result).toMatchObject({
+        state: 'failed',
+        failedStage: 'authority_bind'
+      })
+      const terminalEffect = result.effects.find(
+        (effect) => effect.kind === 'terminal' && effect.role === 'agent'
+      )
+      expect(terminalEffect?.id).toBeTruthy()
+      expect(result.effects).toContainEqual(
+        expect.objectContaining({ kind: 'terminal', role: 'agent', id: terminalEffect?.id })
+      )
+      expect(result.residualResources).toContainEqual(
+        expect.objectContaining({ kind: 'terminal', role: 'agent', id: terminalEffect?.id })
+      )
+      expect(db.getWorkerTerminalResourceByOwner(result.dispatchId)).toMatchObject({
+        ownership_state: 'owned',
+        terminal_handle: terminalEffect?.id,
+        pane_key: 'tab_worker:leaf_worker',
+        process_incarnation: 'runtime_test:term_worker:1'
+      })
+      expect(ownedResourceCount(result.dispatchId)).toBe(1)
     })
 
     it('embeds the WSL CLI name before the worker pane exists', async () => {
@@ -484,13 +597,23 @@ describe('orchestration RPC methods', () => {
         task: task.id,
         from: 'term_coord',
         agent: 'codex'
-      })) as { state: string; failedStage: string; residualResources: unknown[] }
+      })) as {
+        dispatchId: string
+        state: string
+        failedStage: string
+        effects: { kind: string }[]
+        residualResources: unknown[]
+      }
 
       expect(result).toMatchObject({
         state: 'failed',
         failedStage: 'terminal_create',
         residualResources: []
       })
+      expect(result.effects).not.toEqual(
+        expect.arrayContaining([expect.objectContaining({ kind: 'terminal' })])
+      )
+      expect(ownedResourceCount(result.dispatchId)).toBe(0)
       expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
     })
 

--- a/src/main/runtime/rpc/methods/orchestration-worker-argv-start.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-argv-start.test.ts
@@ -1,0 +1,174 @@
+import { createHash } from 'node:crypto'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import { OrchestrationDb } from '../../orchestration/db'
+import { reconcileLifecycleMessage } from '../../orchestration/lifecycle-reconciliation'
+import { startArgvWorkerDispatch } from './orchestration-worker-argv-start'
+
+type TerminalWait = Awaited<ReturnType<OrcaRuntimeService['waitForTerminal']>>
+
+describe('argv worker startup readiness monitor', () => {
+  let db: OrchestrationDb | undefined
+
+  afterEach(() => {
+    db?.close()
+    db = undefined
+  })
+
+  function startDispatch() {
+    db = new OrchestrationDb(':memory:')
+    const run = db.createRun({
+      objective: 'argv startup monitor',
+      coordinatorHandle: 'term-coord',
+      coordinatorPaneKey: 'tab-coord:leaf-coord'
+    })
+    const task = db.createTask({ spec: 'argv startup task', runId: run.id })
+    const started = db.createStartingWorkerDispatch({
+      creator: { kind: 'system' },
+      maxDepth: Number.MAX_SAFE_INTEGER,
+      taskId: task.id,
+      startOptions: {}
+    })
+    return { run, task, dispatchId: started.dispatch.id }
+  }
+
+  function startMonitor(
+    dispatchId: string,
+    waitForTerminal: () => Promise<TerminalWait>,
+    options: { insertMessage?: ReturnType<typeof vi.fn>; settle?: () => void } = {}
+  ) {
+    const insertMessage = options.insertMessage ?? vi.spyOn(db!, 'insertMessage')
+    let launchTokenHash: string | null = null
+    const runtime = {
+      createPreAllocatedTerminalHandle: vi.fn(() => 'term-worker'),
+      getTerminalPaneKey: vi.fn(() => 'tab-worker:leaf-worker'),
+      getTerminalProcessIncarnation: vi.fn(() => 'runtime:worker:1'),
+      getOrchestrationDispatchAuthority: vi.fn(() => ({
+        paneKey: 'tab-worker:leaf-worker',
+        processIncarnation: 'runtime:worker:1',
+        ...(launchTokenHash ? { launchTokenHash } : {})
+      })),
+      createTerminal: vi.fn(async (_selector: string, opts?: { launchToken?: string }) => {
+        launchTokenHash = opts?.launchToken
+          ? createHash('sha256').update(opts.launchToken).digest('hex')
+          : null
+        return { handle: 'term-worker', worktreeId: 'repo::worker' }
+      }),
+      getWorktreeOrchestrationCliCommand: vi.fn(async () => 'orca'),
+      waitForTerminal: vi.fn(waitForTerminal),
+      notifyMessageArrived: vi.fn()
+    } as unknown as OrcaRuntimeService
+    const task = db!.getTask(db!.getDispatchContextById(dispatchId)!.task_id)!
+    const pending = startArgvWorkerDispatch({
+      runtime,
+      db: db!,
+      runId: task.run_id,
+      task,
+      dispatchId,
+      coordinatorHandle: 'term-coord',
+      timeoutMs: 1_000,
+      agent: 'codex',
+      launchReceipt: {} as never,
+      worktreeId: 'repo::worker',
+      effects: [],
+      setupReceipt: {
+        requested: 'not_applicable',
+        effective: 'not_applicable',
+        source: 'existing_worktree',
+        hookFound: false,
+        startupPolicy: 'start-immediately',
+        state: 'not_applicable'
+      },
+      onStage: () => undefined
+    })
+    return { pending, runtime, insertMessage }
+  }
+
+  it('does not publish after worker_done settles before an unsatisfied wait returns', async () => {
+    const { run, task, dispatchId } = startDispatch()
+    let finishWait!: (value: TerminalWait) => void
+    const insertMessage = vi.spyOn(db!, 'insertMessage')
+    const { pending } = startMonitor(
+      dispatchId,
+      () => new Promise((resolve) => (finishWait = resolve)),
+      { insertMessage }
+    )
+    const started = await pending
+    const message = db!.insertMessage({
+      runId: run.id,
+      from: 'term-worker',
+      to: `run:${run.id}`,
+      subject: 'Completed immediately',
+      type: 'worker_done',
+      payload: JSON.stringify({ taskId: task.id, dispatchId, outcome: 'succeeded' }),
+      senderPaneKey: 'tab-worker:leaf-worker'
+    })
+    expect(reconcileLifecycleMessage(db!, message)).toMatchObject({ action: 'completed' })
+    insertMessage.mockClear()
+    finishWait({
+      handle: 'term-worker',
+      condition: 'tui-idle',
+      satisfied: false,
+      status: 'running',
+      exitCode: null
+    })
+    await vi.waitFor(() => expect(db!.getDispatchContextById(dispatchId)?.status).toBe('completed'))
+    await Promise.resolve()
+    expect(insertMessage).not.toHaveBeenCalled()
+    expect(started.state).toBe('ready')
+  })
+
+  it('publishes a timeout rejection as durable blocked evidence while ready', async () => {
+    const { dispatchId } = startDispatch()
+    const insertMessage = vi.spyOn(db!, 'insertMessage')
+    startMonitor(dispatchId, () => Promise.reject(new Error('timeout')), { insertMessage })
+
+    await vi.waitFor(() => {
+      expect(insertMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          priority: 'high',
+          payload: expect.stringContaining('Terminal readiness wait failed: timeout')
+        })
+      )
+    })
+  })
+
+  it('publishes terminal exit as durable blocked evidence while ready', async () => {
+    const { dispatchId } = startDispatch()
+    const insertMessage = vi.spyOn(db!, 'insertMessage')
+    startMonitor(
+      dispatchId,
+      () =>
+        Promise.resolve({
+          handle: 'term-worker',
+          condition: 'tui-idle',
+          satisfied: false,
+          status: 'exited',
+          exitCode: 1
+        }),
+      { insertMessage }
+    )
+
+    await vi.waitFor(() => {
+      expect(insertMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          priority: 'high',
+          payload: expect.stringContaining('Terminal readiness wait failed: terminal_exited')
+        })
+      )
+    })
+  })
+
+  it.each(['request_aborted', 'terminal_handle_stale'] as const)(
+    'does not publish a %s rejection',
+    async (reason) => {
+      const { dispatchId } = startDispatch()
+      const insertMessage = vi.spyOn(db!, 'insertMessage')
+      startMonitor(dispatchId, () => Promise.reject(new Error(reason)), { insertMessage })
+
+      await Promise.resolve()
+      await Promise.resolve()
+      expect(insertMessage).not.toHaveBeenCalled()
+    }
+  )
+})

--- a/src/main/runtime/rpc/methods/orchestration-worker-argv-start.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-argv-start.ts
@@ -194,14 +194,51 @@ function monitorArgvStartupBlocked(args: {
       if (wait.satisfied) {
         return
       }
+      if (!isReadyWorkerDispatch(args.db, args.dispatchId)) {
+        return
+      }
       publishWorkerStartupBlocked({
         runtime: args.runtime,
         db: args.db,
         runId: args.runId,
         dispatchId: args.dispatchId,
         terminalHandle: args.terminalHandle,
-        blockedReason: wait.blockedReason ?? 'Terminal readiness wait was not satisfied.'
+        blockedReason: readinessFailureReason(wait)
       })
     })
-    .catch(() => undefined)
+    .catch((error: unknown) => {
+      const reason = error instanceof Error ? error.message : String(error)
+      if (reason === 'request_aborted' || reason === 'terminal_handle_stale') {
+        return
+      }
+      if (!isReadyWorkerDispatch(args.db, args.dispatchId)) {
+        return
+      }
+      publishWorkerStartupBlocked({
+        runtime: args.runtime,
+        db: args.db,
+        runId: args.runId,
+        dispatchId: args.dispatchId,
+        terminalHandle: args.terminalHandle,
+        blockedReason: `Terminal readiness wait failed: ${reason}`
+      })
+    })
+}
+
+function isReadyWorkerDispatch(db: OrchestrationDb, dispatchId: string): boolean {
+  return (
+    db.getDispatchContextById(dispatchId)?.status === 'dispatched' &&
+    db.getWorkerDispatch(dispatchId)?.state === 'ready'
+  )
+}
+
+function readinessFailureReason(
+  wait: Awaited<ReturnType<OrcaRuntimeService['waitForTerminal']>>
+): string {
+  if (wait.blockedReason) {
+    return wait.blockedReason
+  }
+  return wait.status === 'exited'
+    ? 'Terminal readiness wait failed: terminal_exited'
+    : 'Terminal readiness wait was not satisfied.'
 }

--- a/src/main/runtime/rpc/methods/orchestration-worker-argv-start.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-argv-start.ts
@@ -1,0 +1,225 @@
+import { createHash, randomUUID } from 'node:crypto'
+import { setTimeout as delay } from 'node:timers/promises'
+import type { TuiAgent } from '../../../../shared/tui-agent'
+import type { AgentLaunchPreferences } from '../../../../shared/agent-session-host-authority'
+import { buildDispatchPreamble } from '../../orchestration/preamble'
+import type { OrchestrationDb } from '../../orchestration/db'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import {
+  monitorWorkerSetup,
+  requireWorkerAuthority,
+  type WorkerEffect,
+  type WorkerSetupReceipt
+} from './orchestration-worker-topology'
+import {
+  persistGatedSetupSpawnFailure,
+  persistWorkerReadinessStage
+} from './orchestration-worker-setup-gate'
+import type { OrchestrationWorkerLaunchReceipt } from './orchestration-worker-launch-preferences'
+
+// Why: agents whose promptInjectionMode is 'argv' start the first turn WITH
+// the process — the dispatch preamble travels in the launch command, so
+// there is no paste, no Enter, no submission verification window, and no
+// agent_prompt_stalled revocation of a healthy worker. The capability and
+// preamble exist before the terminal; the pane proves it is the exact
+// spawned process by echoing the launch token it received in its
+// environment. Nothing timing-based ever sits between spawn, bind and
+// ready: a fast completion is settled, never refused.
+export async function startArgvWorkerDispatch(args: {
+  runtime: OrcaRuntimeService
+  db: OrchestrationDb
+  runId: string
+  task: { id: string; spec: string }
+  dispatchId: string
+  coordinatorHandle: string
+  devMode?: boolean
+  timeoutMs: number
+  agent: TuiAgent
+  launchPreferences?: AgentLaunchPreferences
+  launchReceipt: OrchestrationWorkerLaunchReceipt
+  worktreeId: string
+  effects: WorkerEffect[]
+  setupReceipt: WorkerSetupReceipt
+  // Why: the caller's catch settles the dispatch with the stage that was
+  // active when the failure happened; this callback keeps that ledger
+  // accurate without threading a mutable variable through the module.
+  onStage: (stage: string) => void
+}): Promise<Record<string, unknown>> {
+  const { runtime, db, effects } = args
+  const preAllocatedHandle = runtime.createPreAllocatedTerminalHandle()
+  const workerLaunchToken = randomUUID()
+  db.commitDispatchLaunchTokenHash(
+    args.dispatchId,
+    createHash('sha256').update(workerLaunchToken).digest('hex')
+  )
+  const capability = db.mintStartingWorkerCapability({ dispatchId: args.dispatchId })
+  const cliCommand = await runtime.getWorktreeOrchestrationCliCommand(args.worktreeId)
+  const preamble = buildDispatchPreamble({
+    taskId: args.task.id,
+    dispatchId: args.dispatchId,
+    taskSpec: args.task.spec,
+    coordinatorHandle: args.coordinatorHandle,
+    workerHandle: preAllocatedHandle,
+    dispatchCapability: capability,
+    devMode: args.devMode,
+    cliCommand
+  })
+  const terminal = await runtime.createTerminal(`id:${args.worktreeId}`, {
+    startupAgent: args.agent,
+    ...(args.launchPreferences ? { launchPreferences: args.launchPreferences } : {}),
+    preAllocatedHandle,
+    launchToken: workerLaunchToken,
+    agentPrompt: preamble,
+    title: `worker-${args.task.id}`,
+    // Why: dispatching a worker is background work; it must not pull the
+    // sidebar to the worker's workspace while the user reads somewhere else.
+    surfaceOwner: false
+  })
+  effects.push({
+    kind: 'terminal',
+    role: 'agent',
+    action: 'created',
+    id: terminal.handle,
+    surface: terminal.surface,
+    warning: terminal.warning
+  })
+  args.onStage('authority_bind')
+  // Why: adoption paths can substitute a canonical surface handle
+  // (agentSessionEnsure/stablePaneOwner). The preamble already names
+  // preAllocatedHandle as the worker's identity; a substituted handle would
+  // make the worker self-identify wrongly forever.
+  if (terminal.handle !== preAllocatedHandle) {
+    throw new Error(
+      `Worker terminal adopted handle ${terminal.handle} instead of the pre-allocated ${preAllocatedHandle}.`
+    )
+  }
+  const setupStage = {
+    db,
+    dispatchId: args.dispatchId,
+    worktreeId: args.worktreeId,
+    terminalHandle: terminal.handle,
+    setup: args.setupReceipt,
+    effects
+  }
+  if (persistGatedSetupSpawnFailure(setupStage)) {
+    args.onStage('setup_start')
+    throw new Error('Setup terminal failed to start before the gated agent launch.')
+  }
+  persistWorkerReadinessStage(setupStage)
+  const boundAuthority = await requireWorkerAuthorityAfterSpawn(runtime, terminal.handle)
+  db.bindStartingWorkerAuthority({
+    dispatchId: args.dispatchId,
+    handle: terminal.handle,
+    ...boundAuthority,
+    worktreeId: args.worktreeId,
+    effects,
+    setupState: args.setupReceipt.state,
+    terminalOwnership: 'created'
+  })
+  // Why: nothing may sit between bind and ready — the dispatch context stays
+  // 'pending' until markWorkerDispatchReady, and worker_done settlement
+  // refuses a pending dispatch, so any gate here would reject a fast
+  // completion. Blocked-screen detection is detached below.
+  effects.push({
+    kind: 'dispatch_input',
+    role: 'agent',
+    id: terminal.handle,
+    state: 'accepted'
+  })
+  const worker = db.markWorkerDispatchReady(args.dispatchId, effects)
+  monitorWorkerSetup({
+    runtime,
+    db,
+    runId: args.runId,
+    dispatchId: args.dispatchId,
+    setupReceipt: args.setupReceipt,
+    effects
+  })
+  monitorArgvStartupBlocked({
+    runtime,
+    db,
+    runId: args.runId,
+    dispatchId: args.dispatchId,
+    terminalHandle: terminal.handle,
+    timeoutMs: args.timeoutMs
+  })
+  return {
+    runId: args.runId,
+    taskId: args.task.id,
+    dispatchId: args.dispatchId,
+    state: worker.state,
+    stage: worker.stage,
+    setup: args.setupReceipt,
+    launch: args.launchReceipt,
+    timeoutMs: args.timeoutMs,
+    effects,
+    residualResources: [],
+    ...(terminal.warning ? { warning: terminal.warning } : {})
+  }
+}
+
+// Why: createTerminal resolution is the identity barrier for a freshly
+// spawned worker — handle registration, launch token and paneKey are stored
+// before it resolves. The bounded retry covers only create variants whose
+// registration timing differs; any other error is real and thrown as-is.
+async function requireWorkerAuthorityAfterSpawn(
+  runtime: OrcaRuntimeService,
+  terminalHandle: string
+) {
+  const deadline = Date.now() + 5_000
+  for (;;) {
+    try {
+      return requireWorkerAuthority(runtime, terminalHandle)
+    } catch (error) {
+      const paneStillRegistering =
+        error instanceof Error && error.message === 'stable_pane_required' && Date.now() < deadline
+      if (!paneStillRegistering) {
+        throw error
+      }
+      await delay(100)
+    }
+  }
+}
+
+// Why: an argv worker's brief is delivered at spawn, so a trust menu or
+// update prompt that renders instead of the first turn must NOT fail the
+// start — the dispatch identity is sound, and once the screen is cleared
+// the agent runs the brief with a still-valid capability. Failing here
+// would revoke that capability and orphan the recovered work; a timing
+// gate before ready would refuse a fast completion. The scan is therefore
+// detached evidence: ready returns immediately, and a detected blocked
+// screen becomes a high-priority message to the Run.
+function monitorArgvStartupBlocked(args: {
+  runtime: OrcaRuntimeService
+  db: OrchestrationDb
+  runId: string
+  dispatchId: string
+  terminalHandle: string
+  timeoutMs: number
+}): void {
+  void args.runtime
+    .waitForTerminal(args.terminalHandle, {
+      condition: 'tui-idle',
+      timeoutMs: args.timeoutMs
+    })
+    .then((wait) => {
+      if (!wait.blockedReason) {
+        return
+      }
+      const message = args.db.insertMessage({
+        runId: args.runId,
+        from: `dispatch:${args.dispatchId}`,
+        to: `run:${args.runId}`,
+        subject: `Worker ${args.dispatchId} startup blocked: ${wait.blockedReason}`,
+        type: 'status',
+        priority: 'high',
+        payload: JSON.stringify({
+          dispatchId: args.dispatchId,
+          blockedReason: wait.blockedReason,
+          terminalHandle: args.terminalHandle
+        })
+      })
+      args.runtime.notifyMessageArrived(message.to_handle, message.type)
+    })
+    .catch(() => undefined)
+}

--- a/src/main/runtime/rpc/methods/orchestration-worker-argv-start.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-argv-start.ts
@@ -9,10 +9,7 @@ import {
   type WorkerEffect,
   type WorkerSetupReceipt
 } from './orchestration-worker-topology'
-import {
-  persistGatedSetupSpawnFailure,
-  persistWorkerReadinessStage
-} from './orchestration-worker-setup-gate'
+import { persistGatedSetupSpawnFailure } from './orchestration-worker-setup-gate'
 import type { OrchestrationWorkerLaunchReceipt } from './orchestration-worker-launch-preferences'
 import {
   createArgvLaunchCredentials,
@@ -80,7 +77,6 @@ export async function startArgvWorkerDispatch(args: {
     args.onStage('setup_start')
     throw new Error('Setup terminal failed to start before the gated agent launch.')
   }
-  persistWorkerReadinessStage(setupStage)
   const boundAuthority = await requireWorkerAuthorityAfterSpawn(runtime, terminal.handle)
   db.bindStartingWorkerAuthority({
     dispatchId: args.dispatchId,

--- a/src/main/runtime/rpc/methods/orchestration-worker-argv-start.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-argv-start.ts
@@ -83,6 +83,35 @@ export async function startArgvWorkerDispatch(args: {
     surface: terminal.surface,
     warning: terminal.warning
   })
+  const terminalAuthority = runtime.getOrchestrationDispatchAuthority(terminal.handle)
+  const setupStage = {
+    db,
+    dispatchId: args.dispatchId,
+    worktreeId: args.worktreeId,
+    terminalHandle: terminal.handle,
+    setup: args.setupReceipt,
+    effects
+  }
+  // Why: createTerminal is the ownership boundary. Persist the exact returned
+  // handle and its releasable resource before any identity, setup, or authority
+  // check can reject the start and hide a live agent from its failure receipt.
+  persistWorkerReadinessStage(setupStage)
+  if (!db.getWorkerTerminalResourceByOwner(args.dispatchId)) {
+    db.createWorkerTerminalResourceStatement({
+      dispatchId: args.dispatchId,
+      worktreeId: args.worktreeId,
+      terminalHandle: terminal.handle,
+      paneKey:
+        terminal.paneKey ??
+        terminalAuthority?.paneKey ??
+        runtime.getTerminalPaneKey(terminal.handle),
+      processIncarnation:
+        terminalAuthority?.processIncarnation ??
+        runtime.getTerminalProcessIncarnation(terminal.handle),
+      hostScope: terminalAuthority?.hostScope ? JSON.stringify(terminalAuthority.hostScope) : null,
+      ownership: 'owned'
+    })
+  }
   args.onStage('authority_bind')
   // Why: adoption paths can substitute a canonical surface handle
   // (agentSessionEnsure/stablePaneOwner). The preamble already names
@@ -92,14 +121,6 @@ export async function startArgvWorkerDispatch(args: {
     throw new Error(
       `Worker terminal adopted handle ${terminal.handle} instead of the pre-allocated ${preAllocatedHandle}.`
     )
-  }
-  const setupStage = {
-    db,
-    dispatchId: args.dispatchId,
-    worktreeId: args.worktreeId,
-    terminalHandle: terminal.handle,
-    setup: args.setupReceipt,
-    effects
   }
   if (persistGatedSetupSpawnFailure(setupStage)) {
     args.onStage('setup_start')

--- a/src/main/runtime/rpc/methods/orchestration-worker-argv-start.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-argv-start.ts
@@ -191,7 +191,7 @@ function monitorArgvStartupBlocked(args: {
       timeoutMs: args.timeoutMs
     })
     .then((wait) => {
-      if (!wait.blockedReason) {
+      if (wait.satisfied) {
         return
       }
       publishWorkerStartupBlocked({
@@ -200,7 +200,7 @@ function monitorArgvStartupBlocked(args: {
         runId: args.runId,
         dispatchId: args.dispatchId,
         terminalHandle: args.terminalHandle,
-        blockedReason: wait.blockedReason
+        blockedReason: wait.blockedReason ?? 'Terminal readiness wait was not satisfied.'
       })
     })
     .catch(() => undefined)

--- a/src/main/runtime/rpc/methods/orchestration-worker-argv-start.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-argv-start.ts
@@ -1,8 +1,6 @@
-import { createHash, randomUUID } from 'node:crypto'
 import { setTimeout as delay } from 'node:timers/promises'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import type { AgentLaunchPreferences } from '../../../../shared/agent-session-host-authority'
-import { buildDispatchPreamble } from '../../orchestration/preamble'
 import type { OrchestrationDb } from '../../orchestration/db'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import {
@@ -16,7 +14,10 @@ import {
   persistWorkerReadinessStage
 } from './orchestration-worker-setup-gate'
 import type { OrchestrationWorkerLaunchReceipt } from './orchestration-worker-launch-preferences'
-import { persistArgvWorkerTerminalOwnership } from './orchestration-worker-authority'
+import {
+  createArgvLaunchCredentials,
+  persistArgvWorkerTerminalOwnership
+} from './orchestration-worker-authority'
 
 // Why: argv agents receive the preamble and launch token in the spawn command;
 // binding proves the returned pane is the exact process with no paste race.
@@ -39,30 +40,14 @@ export async function startArgvWorkerDispatch(args: {
   onStage: (stage: string) => void
 }): Promise<Record<string, unknown>> {
   const { runtime, db, effects } = args
-  const preAllocatedHandle = runtime.createPreAllocatedTerminalHandle()
-  const workerLaunchToken = randomUUID()
-  db.commitDispatchLaunchTokenHash(
-    args.dispatchId,
-    createHash('sha256').update(workerLaunchToken).digest('hex')
-  )
-  const capability = db.mintStartingWorkerCapability({ dispatchId: args.dispatchId })
   const cliCommand = await runtime.getWorktreeOrchestrationCliCommand(args.worktreeId)
-  const preamble = buildDispatchPreamble({
-    taskId: args.task.id,
-    dispatchId: args.dispatchId,
-    taskSpec: args.task.spec,
-    coordinatorHandle: args.coordinatorHandle,
-    workerHandle: preAllocatedHandle,
-    dispatchCapability: capability,
-    devMode: args.devMode,
-    cliCommand
-  })
+  const credentials = createArgvLaunchCredentials(args)
   const terminal = await runtime.createTerminal(`id:${args.worktreeId}`, {
     startupAgent: args.agent,
     ...(args.launchPreferences ? { launchPreferences: args.launchPreferences } : {}),
-    preAllocatedHandle,
-    launchToken: workerLaunchToken,
-    agentPrompt: preamble,
+    preAllocatedHandle: credentials.startupPreAllocatedHandle,
+    launchToken: credentials.startupLaunchToken,
+    agentPrompt: credentials.buildStartupPrompt(cliCommand),
     title: `worker-${args.task.id}`,
     // Background worker: do not pull the sidebar to its workspace.
     surfaceOwner: false
@@ -86,9 +71,9 @@ export async function startArgvWorkerDispatch(args: {
   }
   args.onStage('authority_bind')
   // The preamble names preAllocatedHandle; a substituted handle is unsafe.
-  if (terminal.handle !== preAllocatedHandle) {
+  if (terminal.handle !== credentials.startupPreAllocatedHandle) {
     throw new Error(
-      `Worker terminal adopted handle ${terminal.handle} instead of the pre-allocated ${preAllocatedHandle}.`
+      `Worker terminal adopted handle ${terminal.handle} instead of the pre-allocated ${credentials.startupPreAllocatedHandle}.`
     )
   }
   if (persistGatedSetupSpawnFailure(setupStage)) {
@@ -145,6 +130,30 @@ export async function startArgvWorkerDispatch(args: {
   }
 }
 
+export function publishWorkerStartupBlocked(args: {
+  runtime: OrcaRuntimeService
+  db: OrchestrationDb
+  runId: string
+  dispatchId: string
+  terminalHandle: string
+  blockedReason: string
+}): void {
+  const message = args.db.insertMessage({
+    runId: args.runId,
+    from: `dispatch:${args.dispatchId}`,
+    to: `run:${args.runId}`,
+    subject: `Worker ${args.dispatchId} startup blocked: ${args.blockedReason}`,
+    type: 'status',
+    priority: 'high',
+    payload: JSON.stringify({
+      dispatchId: args.dispatchId,
+      blockedReason: args.blockedReason,
+      terminalHandle: args.terminalHandle
+    })
+  })
+  args.runtime.notifyMessageArrived(message.to_handle, message.type)
+}
+
 // Why: createTerminal resolution is the identity barrier for a freshly
 // spawned worker — handle registration, launch token and paneKey are stored
 // before it resolves. The bounded retry covers only create variants whose
@@ -185,20 +194,14 @@ function monitorArgvStartupBlocked(args: {
       if (!wait.blockedReason) {
         return
       }
-      const message = args.db.insertMessage({
+      publishWorkerStartupBlocked({
+        runtime: args.runtime,
+        db: args.db,
         runId: args.runId,
-        from: `dispatch:${args.dispatchId}`,
-        to: `run:${args.runId}`,
-        subject: `Worker ${args.dispatchId} startup blocked: ${wait.blockedReason}`,
-        type: 'status',
-        priority: 'high',
-        payload: JSON.stringify({
-          dispatchId: args.dispatchId,
-          blockedReason: wait.blockedReason,
-          terminalHandle: args.terminalHandle
-        })
+        dispatchId: args.dispatchId,
+        terminalHandle: args.terminalHandle,
+        blockedReason: wait.blockedReason
       })
-      args.runtime.notifyMessageArrived(message.to_handle, message.type)
     })
     .catch(() => undefined)
 }

--- a/src/main/runtime/rpc/methods/orchestration-worker-argv-start.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-argv-start.ts
@@ -16,15 +16,10 @@ import {
   persistWorkerReadinessStage
 } from './orchestration-worker-setup-gate'
 import type { OrchestrationWorkerLaunchReceipt } from './orchestration-worker-launch-preferences'
+import { persistArgvWorkerTerminalOwnership } from './orchestration-worker-authority'
 
-// Why: agents whose promptInjectionMode is 'argv' start the first turn WITH
-// the process — the dispatch preamble travels in the launch command, so
-// there is no paste, no Enter, no submission verification window, and no
-// agent_prompt_stalled revocation of a healthy worker. The capability and
-// preamble exist before the terminal; the pane proves it is the exact
-// spawned process by echoing the launch token it received in its
-// environment. Nothing timing-based ever sits between spawn, bind and
-// ready: a fast completion is settled, never refused.
+// Why: argv agents receive the preamble and launch token in the spawn command;
+// binding proves the returned pane is the exact process with no paste race.
 export async function startArgvWorkerDispatch(args: {
   runtime: OrcaRuntimeService
   db: OrchestrationDb
@@ -40,9 +35,7 @@ export async function startArgvWorkerDispatch(args: {
   worktreeId: string
   effects: WorkerEffect[]
   setupReceipt: WorkerSetupReceipt
-  // Why: the caller's catch settles the dispatch with the stage that was
-  // active when the failure happened; this callback keeps that ledger
-  // accurate without threading a mutable variable through the module.
+  // Caller catch records the active failure stage.
   onStage: (stage: string) => void
 }): Promise<Record<string, unknown>> {
   const { runtime, db, effects } = args
@@ -71,19 +64,18 @@ export async function startArgvWorkerDispatch(args: {
     launchToken: workerLaunchToken,
     agentPrompt: preamble,
     title: `worker-${args.task.id}`,
-    // Why: dispatching a worker is background work; it must not pull the
-    // sidebar to the worker's workspace while the user reads somewhere else.
+    // Background worker: do not pull the sidebar to its workspace.
     surfaceOwner: false
   })
-  effects.push({
-    kind: 'terminal',
-    role: 'agent',
-    action: 'created',
-    id: terminal.handle,
-    surface: terminal.surface,
-    warning: terminal.warning
+  persistArgvWorkerTerminalOwnership({
+    runtime,
+    db,
+    dispatchId: args.dispatchId,
+    worktreeId: args.worktreeId,
+    terminal,
+    setupReceipt: args.setupReceipt,
+    effects
   })
-  const terminalAuthority = runtime.getOrchestrationDispatchAuthority(terminal.handle)
   const setupStage = {
     db,
     dispatchId: args.dispatchId,
@@ -92,31 +84,8 @@ export async function startArgvWorkerDispatch(args: {
     setup: args.setupReceipt,
     effects
   }
-  // Why: createTerminal is the ownership boundary. Persist the exact returned
-  // handle and its releasable resource before any identity, setup, or authority
-  // check can reject the start and hide a live agent from its failure receipt.
-  persistWorkerReadinessStage(setupStage)
-  if (!db.getWorkerTerminalResourceByOwner(args.dispatchId)) {
-    db.createWorkerTerminalResourceStatement({
-      dispatchId: args.dispatchId,
-      worktreeId: args.worktreeId,
-      terminalHandle: terminal.handle,
-      paneKey:
-        terminal.paneKey ??
-        terminalAuthority?.paneKey ??
-        runtime.getTerminalPaneKey(terminal.handle),
-      processIncarnation:
-        terminalAuthority?.processIncarnation ??
-        runtime.getTerminalProcessIncarnation(terminal.handle),
-      hostScope: terminalAuthority?.hostScope ? JSON.stringify(terminalAuthority.hostScope) : null,
-      ownership: 'owned'
-    })
-  }
   args.onStage('authority_bind')
-  // Why: adoption paths can substitute a canonical surface handle
-  // (agentSessionEnsure/stablePaneOwner). The preamble already names
-  // preAllocatedHandle as the worker's identity; a substituted handle would
-  // make the worker self-identify wrongly forever.
+  // The preamble names preAllocatedHandle; a substituted handle is unsafe.
   if (terminal.handle !== preAllocatedHandle) {
     throw new Error(
       `Worker terminal adopted handle ${terminal.handle} instead of the pre-allocated ${preAllocatedHandle}.`
@@ -137,10 +106,7 @@ export async function startArgvWorkerDispatch(args: {
     setupState: args.setupReceipt.state,
     terminalOwnership: 'created'
   })
-  // Why: nothing may sit between bind and ready — the dispatch context stays
-  // 'pending' until markWorkerDispatchReady, and worker_done settlement
-  // refuses a pending dispatch, so any gate here would reject a fast
-  // completion. Blocked-screen detection is detached below.
+  // Bind before ready so fast completion cannot race a pending dispatch.
   effects.push({
     kind: 'dispatch_input',
     role: 'agent',
@@ -202,14 +168,6 @@ async function requireWorkerAuthorityAfterSpawn(
   }
 }
 
-// Why: an argv worker's brief is delivered at spawn, so a trust menu or
-// update prompt that renders instead of the first turn must NOT fail the
-// start — the dispatch identity is sound, and once the screen is cleared
-// the agent runs the brief with a still-valid capability. Failing here
-// would revoke that capability and orphan the recovered work; a timing
-// gate before ready would refuse a fast completion. The scan is therefore
-// detached evidence: ready returns immediately, and a detected blocked
-// screen becomes a high-priority message to the Run.
 function monitorArgvStartupBlocked(args: {
   runtime: OrcaRuntimeService
   db: OrchestrationDb

--- a/src/main/runtime/rpc/methods/orchestration-worker-authority.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-authority.ts
@@ -1,0 +1,198 @@
+import { createHash, randomUUID } from 'node:crypto'
+import { buildDispatchPreamble } from '../../orchestration/preamble'
+import { TUI_AGENT_CONFIG } from '../../../../shared/tui-agent-config'
+import type { TuiAgent } from '../../../../shared/tui-agent'
+import type { OrchestrationDb } from '../../orchestration/db'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import {
+  requireWorkerAuthority,
+  type WorkerEffect,
+  type WorkerSetupReceipt
+} from './orchestration-worker-topology'
+import { persistWorkerReadinessStage } from './orchestration-worker-setup-gate'
+
+export type ArgvWorkerTerminal = {
+  handle: string
+  tabId?: string
+  paneKey?: string | null
+  ptyId?: string | null
+  surface?: 'background' | 'visible'
+  warning?: string
+}
+
+export type ArgvWorktreeLaunch = {
+  startupPrompt: string
+  startupLaunchToken: string
+  startupPreAllocatedHandle: string
+  assertTerminalHandle: (terminalHandle: string) => void
+  persistAgentTerminalOwnership: (
+    terminal: ArgvWorkerTerminal,
+    setupReceipt: WorkerSetupReceipt,
+    worktreeId: string
+  ) => void
+}
+
+export function createArgvWorktreeLaunch(args: {
+  runtime: OrcaRuntimeService
+  db: OrchestrationDb
+  task: { id: string; spec: string }
+  dispatchId: string
+  coordinatorHandle: string
+  devMode?: boolean
+  effects: WorkerEffect[]
+}): ArgvWorktreeLaunch {
+  const preAllocatedHandle = args.runtime.createPreAllocatedTerminalHandle()
+  const launchToken = randomUUID()
+  args.db.commitDispatchLaunchTokenHash(
+    args.dispatchId,
+    createHash('sha256').update(launchToken).digest('hex')
+  )
+  const dispatchCapability = args.db.mintStartingWorkerCapability({
+    dispatchId: args.dispatchId
+  })
+  const startupPrompt = buildDispatchPreamble({
+    taskId: args.task.id,
+    dispatchId: args.dispatchId,
+    taskSpec: args.task.spec,
+    coordinatorHandle: args.coordinatorHandle,
+    workerHandle: preAllocatedHandle,
+    dispatchCapability,
+    devMode: args.devMode,
+    cliCommand: args.runtime.getTerminalOrchestrationCliCommand(args.coordinatorHandle)
+  })
+  return {
+    startupPrompt,
+    startupLaunchToken: launchToken,
+    startupPreAllocatedHandle: preAllocatedHandle,
+    assertTerminalHandle: (terminalHandle) => {
+      if (terminalHandle !== preAllocatedHandle) {
+        throw new Error(
+          `Worker terminal adopted handle ${terminalHandle} instead of the pre-allocated ${preAllocatedHandle}.`
+        )
+      }
+    },
+    persistAgentTerminalOwnership: (terminal, setupReceipt, worktreeId) =>
+      persistArgvWorkerTerminalOwnership({
+        runtime: args.runtime,
+        db: args.db,
+        dispatchId: args.dispatchId,
+        worktreeId,
+        terminal,
+        setupReceipt,
+        effects: args.effects
+      })
+  }
+}
+
+export function persistArgvWorkerTerminalOwnership(args: {
+  runtime: OrcaRuntimeService
+  db: OrchestrationDb
+  dispatchId: string
+  worktreeId: string
+  terminal: ArgvWorkerTerminal
+  setupReceipt: WorkerSetupReceipt
+  effects: WorkerEffect[]
+}): void {
+  const { runtime, db, effects, terminal } = args
+  effects.push({
+    kind: 'terminal',
+    role: 'agent',
+    action: 'created',
+    id: terminal.handle,
+    surface: terminal.surface,
+    warning: terminal.warning
+  })
+  const terminalAuthority = runtime.getOrchestrationDispatchAuthority(terminal.handle)
+  persistWorkerReadinessStage({
+    db,
+    dispatchId: args.dispatchId,
+    worktreeId: args.worktreeId,
+    terminalHandle: terminal.handle,
+    setup: args.setupReceipt,
+    effects
+  })
+  if (!db.getWorkerTerminalResourceByOwner(args.dispatchId)) {
+    db.createWorkerTerminalResourceStatement({
+      dispatchId: args.dispatchId,
+      worktreeId: args.worktreeId,
+      terminalHandle: terminal.handle,
+      paneKey:
+        terminal.paneKey ??
+        terminalAuthority?.paneKey ??
+        runtime.getTerminalPaneKey(terminal.handle),
+      processIncarnation:
+        terminalAuthority?.processIncarnation ??
+        runtime.getTerminalProcessIncarnation(terminal.handle),
+      hostScope: terminalAuthority?.hostScope ? JSON.stringify(terminalAuthority.hostScope) : null,
+      ownership: 'owned'
+    })
+  }
+}
+
+export function resolveArgvWorktreeLaunch(args: {
+  creationWorktree: boolean
+  agent?: TuiAgent
+  runtime: OrcaRuntimeService
+  db: OrchestrationDb
+  task: { id: string; spec: string }
+  dispatchId: string
+  coordinatorHandle: string
+  devMode?: boolean
+  effects: WorkerEffect[]
+}): ArgvWorktreeLaunch | undefined {
+  if (!args.creationWorktree || !args.agent) {
+    return undefined
+  }
+  return TUI_AGENT_CONFIG[args.agent].promptInjectionMode === 'argv'
+    ? createArgvWorktreeLaunch(args)
+    : undefined
+}
+
+export async function attachWorkerAuthority(args: {
+  runtime: OrcaRuntimeService
+  db: OrchestrationDb
+  dispatchId: string
+  terminalHandle: string
+  worktreeId: string
+  effects: WorkerEffect[]
+  setupState: string
+  terminalOwnership: 'created' | 'external'
+  task: { id: string; spec: string }
+  coordinatorHandle: string
+  devMode?: boolean
+  argv: boolean
+}): Promise<void> {
+  const terminalAuthority = requireWorkerAuthority(args.runtime, args.terminalHandle)
+  if (args.argv) {
+    args.db.bindStartingWorkerAuthority({
+      dispatchId: args.dispatchId,
+      handle: args.terminalHandle,
+      ...terminalAuthority,
+      worktreeId: args.worktreeId,
+      effects: args.effects,
+      setupState: args.setupState,
+      terminalOwnership: args.terminalOwnership
+    })
+    return
+  }
+  const capability = args.db.prepareStartingWorkerAuthority({
+    dispatchId: args.dispatchId,
+    handle: args.terminalHandle,
+    ...terminalAuthority,
+    worktreeId: args.worktreeId,
+    effects: args.effects,
+    setupState: args.setupState,
+    terminalOwnership: args.terminalOwnership
+  })
+  const preamble = buildDispatchPreamble({
+    taskId: args.task.id,
+    dispatchId: args.dispatchId,
+    taskSpec: args.task.spec,
+    coordinatorHandle: args.coordinatorHandle,
+    workerHandle: args.terminalHandle,
+    dispatchCapability: capability,
+    devMode: args.devMode,
+    cliCommand: args.runtime.getTerminalOrchestrationCliCommand(args.terminalHandle)
+  })
+  await args.runtime.sendTerminalAgentPrompt(args.terminalHandle, preamble)
+}

--- a/src/main/runtime/rpc/methods/orchestration-worker-authority.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-authority.ts
@@ -5,6 +5,7 @@ import type { TuiAgent } from '../../../../shared/tui-agent'
 import type { OrchestrationDb } from '../../orchestration/db'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import {
+  monitorWorkerSetup,
   requireWorkerAuthority,
   type WorkerEffect,
   type WorkerSetupReceipt
@@ -30,6 +31,52 @@ export type ArgvWorktreeLaunch = {
     setupReceipt: WorkerSetupReceipt,
     worktreeId: string
   ) => void
+}
+
+export async function bindAndMarkArgvWorkerReady(args: {
+  runtime: OrcaRuntimeService
+  db: OrchestrationDb
+  runId: string
+  dispatchId: string
+  terminalHandle: string
+  worktreeId: string
+  effects: WorkerEffect[]
+  setupReceipt: WorkerSetupReceipt
+  terminalOwnership: 'created' | 'external'
+  task: { id: string; spec: string }
+  coordinatorHandle: string
+  devMode?: boolean
+}) {
+  await attachWorkerAuthority({
+    runtime: args.runtime,
+    db: args.db,
+    dispatchId: args.dispatchId,
+    terminalHandle: args.terminalHandle,
+    worktreeId: args.worktreeId,
+    effects: args.effects,
+    setupState: args.setupReceipt.state,
+    terminalOwnership: args.terminalOwnership,
+    task: args.task,
+    coordinatorHandle: args.coordinatorHandle,
+    devMode: args.devMode,
+    argv: true
+  })
+  args.effects.push({
+    kind: 'dispatch_input',
+    role: 'agent',
+    id: args.terminalHandle,
+    state: 'accepted'
+  })
+  const worker = args.db.markWorkerDispatchReady(args.dispatchId, args.effects)
+  monitorWorkerSetup({
+    runtime: args.runtime,
+    db: args.db,
+    runId: args.runId,
+    dispatchId: args.dispatchId,
+    setupReceipt: args.setupReceipt,
+    effects: args.effects
+  })
+  return worker
 }
 
 export function createArgvWorktreeLaunch(args: {

--- a/src/main/runtime/rpc/methods/orchestration-worker-authority.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-authority.ts
@@ -22,15 +22,52 @@ export type ArgvWorkerTerminal = {
 }
 
 export type ArgvWorktreeLaunch = {
-  startupPrompt: string
   startupLaunchToken: string
   startupPreAllocatedHandle: string
+  buildStartupPrompt: (cliCommand: 'orca' | 'orca-ide') => string
   assertTerminalHandle: (terminalHandle: string) => void
   persistAgentTerminalOwnership: (
     terminal: ArgvWorkerTerminal,
     setupReceipt: WorkerSetupReceipt,
     worktreeId: string
   ) => void
+}
+
+export function createArgvLaunchCredentials(args: {
+  runtime: OrcaRuntimeService
+  db: OrchestrationDb
+  task: { id: string; spec: string }
+  dispatchId: string
+  coordinatorHandle: string
+  devMode?: boolean
+}): Pick<
+  ArgvWorktreeLaunch,
+  'startupLaunchToken' | 'startupPreAllocatedHandle' | 'buildStartupPrompt'
+> {
+  const preAllocatedHandle = args.runtime.createPreAllocatedTerminalHandle()
+  const launchToken = randomUUID()
+  args.db.commitDispatchLaunchTokenHash(
+    args.dispatchId,
+    createHash('sha256').update(launchToken).digest('hex')
+  )
+  const dispatchCapability = args.db.mintStartingWorkerCapability({
+    dispatchId: args.dispatchId
+  })
+  return {
+    startupLaunchToken: launchToken,
+    startupPreAllocatedHandle: preAllocatedHandle,
+    buildStartupPrompt: (cliCommand) =>
+      buildDispatchPreamble({
+        taskId: args.task.id,
+        dispatchId: args.dispatchId,
+        taskSpec: args.task.spec,
+        coordinatorHandle: args.coordinatorHandle,
+        workerHandle: preAllocatedHandle,
+        dispatchCapability,
+        devMode: args.devMode,
+        cliCommand
+      })
+  }
 }
 
 export async function bindAndMarkArgvWorkerReady(args: {
@@ -88,33 +125,13 @@ export function createArgvWorktreeLaunch(args: {
   devMode?: boolean
   effects: WorkerEffect[]
 }): ArgvWorktreeLaunch {
-  const preAllocatedHandle = args.runtime.createPreAllocatedTerminalHandle()
-  const launchToken = randomUUID()
-  args.db.commitDispatchLaunchTokenHash(
-    args.dispatchId,
-    createHash('sha256').update(launchToken).digest('hex')
-  )
-  const dispatchCapability = args.db.mintStartingWorkerCapability({
-    dispatchId: args.dispatchId
-  })
-  const startupPrompt = buildDispatchPreamble({
-    taskId: args.task.id,
-    dispatchId: args.dispatchId,
-    taskSpec: args.task.spec,
-    coordinatorHandle: args.coordinatorHandle,
-    workerHandle: preAllocatedHandle,
-    dispatchCapability,
-    devMode: args.devMode,
-    cliCommand: args.runtime.getTerminalOrchestrationCliCommand(args.coordinatorHandle)
-  })
+  const credentials = createArgvLaunchCredentials(args)
   return {
-    startupPrompt,
-    startupLaunchToken: launchToken,
-    startupPreAllocatedHandle: preAllocatedHandle,
+    ...credentials,
     assertTerminalHandle: (terminalHandle) => {
-      if (terminalHandle !== preAllocatedHandle) {
+      if (terminalHandle !== credentials.startupPreAllocatedHandle) {
         throw new Error(
-          `Worker terminal adopted handle ${terminalHandle} instead of the pre-allocated ${preAllocatedHandle}.`
+          `Worker terminal adopted handle ${terminalHandle} instead of the pre-allocated ${credentials.startupPreAllocatedHandle}.`
         )
       }
     },
@@ -190,9 +207,10 @@ export function resolveArgvWorktreeLaunch(args: {
   if (!args.creationWorktree || !args.agent) {
     return undefined
   }
-  return TUI_AGENT_CONFIG[args.agent].promptInjectionMode === 'argv'
-    ? createArgvWorktreeLaunch(args)
-    : undefined
+  if (TUI_AGENT_CONFIG[args.agent].promptInjectionMode !== 'argv') {
+    return undefined
+  }
+  return createArgvWorktreeLaunch(args)
 }
 
 export async function attachWorkerAuthority(args: {

--- a/src/main/runtime/rpc/methods/orchestration-worker-readiness.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-readiness.ts
@@ -1,0 +1,119 @@
+import type { OrchestrationDb } from '../../orchestration/db'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import { attachWorkerAuthority, bindAndMarkArgvWorkerReady } from './orchestration-worker-authority'
+import {
+  monitorWorkerSetup,
+  type WorkerEffect,
+  type WorkerSetupReceipt
+} from './orchestration-worker-topology'
+import {
+  persistGatedSetupSpawnFailure,
+  persistWorkerReadinessStage,
+  persistWorkerSetupWaitOutcome
+} from './orchestration-worker-setup-gate'
+
+export async function attachWorkerAndAwaitReadiness(args: {
+  runtime: OrcaRuntimeService
+  db: OrchestrationDb
+  runId: string
+  dispatchId: string
+  terminalHandle: string
+  worktreeId: string
+  effects: WorkerEffect[]
+  setupReceipt: WorkerSetupReceipt
+  terminalOwnership: 'created' | 'external'
+  task: { id: string; spec: string }
+  coordinatorHandle: string
+  devMode?: boolean
+  argv: boolean
+  timeoutMs: number
+  onStage: (stage: string) => void
+}): Promise<NonNullable<ReturnType<OrchestrationDb['getWorkerDispatch']>>> {
+  const setupStage = {
+    db: args.db,
+    dispatchId: args.dispatchId,
+    worktreeId: args.worktreeId,
+    terminalHandle: args.terminalHandle,
+    setup: args.setupReceipt,
+    effects: args.effects
+  }
+  if (persistGatedSetupSpawnFailure(setupStage)) {
+    args.onStage('setup_start')
+    throw new Error('Setup terminal failed to start before the gated agent launch.')
+  }
+  persistWorkerReadinessStage(setupStage)
+
+  let worker
+  if (args.argv) {
+    worker = await bindAndMarkArgvWorkerReady({
+      runtime: args.runtime,
+      db: args.db,
+      runId: args.runId,
+      dispatchId: args.dispatchId,
+      terminalHandle: args.terminalHandle,
+      worktreeId: args.worktreeId,
+      effects: args.effects,
+      setupReceipt: args.setupReceipt,
+      terminalOwnership: args.terminalOwnership,
+      task: args.task,
+      coordinatorHandle: args.coordinatorHandle,
+      devMode: args.devMode
+    })
+  }
+
+  args.onStage('agent_readiness')
+  const wait = await args.runtime.waitForTerminal(args.terminalHandle, {
+    condition: 'tui-idle',
+    timeoutMs: args.timeoutMs
+  })
+  persistWorkerSetupWaitOutcome({ ...setupStage, wait })
+  if (worker) {
+    worker = args.db.getWorkerDispatch(args.dispatchId) ?? worker
+  }
+  if (!wait.satisfied) {
+    if (args.setupReceipt.state === 'failed' && worker?.state !== 'succeeded') {
+      args.onStage('setup_wait')
+    }
+    if (worker && ['succeeded', 'failed'].includes(worker.state)) {
+      return worker
+    }
+    throw new Error(
+      wait.blockedReason
+        ? `Agent startup blocked: ${wait.blockedReason}`
+        : `Agent did not become ready (${wait.status}).`
+    )
+  }
+  if (!worker) {
+    args.onStage('dispatch_input')
+    await attachWorkerAuthority({
+      runtime: args.runtime,
+      db: args.db,
+      dispatchId: args.dispatchId,
+      terminalHandle: args.terminalHandle,
+      worktreeId: args.worktreeId,
+      effects: args.effects,
+      setupState: args.setupReceipt.state,
+      terminalOwnership: args.terminalOwnership,
+      task: args.task,
+      coordinatorHandle: args.coordinatorHandle,
+      devMode: args.devMode,
+      argv: false
+    })
+    args.effects.push({
+      kind: 'dispatch_input',
+      role: 'agent',
+      id: args.terminalHandle,
+      state: 'accepted'
+    })
+    worker = args.db.markWorkerDispatchReady(args.dispatchId, args.effects)
+    monitorWorkerSetup({
+      runtime: args.runtime,
+      db: args.db,
+      runId: args.runId,
+      dispatchId: args.dispatchId,
+      setupReceipt: args.setupReceipt,
+      effects: args.effects
+    })
+  }
+  return worker
+}

--- a/src/main/runtime/rpc/methods/orchestration-worker-readiness.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-readiness.ts
@@ -1,6 +1,7 @@
 import type { OrchestrationDb } from '../../orchestration/db'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import { attachWorkerAuthority, bindAndMarkArgvWorkerReady } from './orchestration-worker-authority'
+import { publishWorkerStartupBlocked } from './orchestration-worker-argv-start'
 import {
   monitorWorkerSetup,
   type WorkerEffect,
@@ -75,6 +76,21 @@ export async function attachWorkerAndAwaitReadiness(args: {
       args.onStage('setup_wait')
     }
     if (worker && ['succeeded', 'failed'].includes(worker.state)) {
+      return worker
+    }
+    if (
+      args.argv &&
+      worker?.state === 'ready' &&
+      args.setupReceipt.startupPolicy !== 'wait-for-setup'
+    ) {
+      publishWorkerStartupBlocked({
+        runtime: args.runtime,
+        db: args.db,
+        runId: args.runId,
+        dispatchId: args.dispatchId,
+        terminalHandle: args.terminalHandle,
+        blockedReason: wait.blockedReason ?? 'Terminal readiness wait was not satisfied.'
+      })
       return worker
     }
     throw new Error(

--- a/src/main/runtime/rpc/methods/orchestration-worker-release-recovery.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release-recovery.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { OrchestrationDb } from '../../orchestration/db'
 import { reconcileRequestedWorkerTerminalReleases } from '../../orchestration/worker-terminal-release-reconciliation'
@@ -34,12 +35,19 @@ describe('orchestration worker release recovery', () => {
     vi.spyOn(runtime, 'getTerminalProcessIncarnation').mockImplementation((handle) =>
       handle === 'term_worker' ? 'runtime_test:term_worker:1' : null
     )
+    // Why: the argv worker-start path pre-allocates the handle and hands the
+    // spawn a launch token; the pane's authority must echo that token's hash
+    // or the bind guard (rightly) refuses the pane. Pinning the pre-allocated
+    // handle keeps every 'term_worker'-keyed fixture in this file valid.
+    let workerLaunchTokenHash: string | null = null
+    vi.spyOn(runtime, 'createPreAllocatedTerminalHandle').mockReturnValue('term_worker')
     vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockImplementation((handle) =>
       handle === 'term_worker'
         ? ({
             terminalHandle: handle,
             paneKey: workerPaneKey,
             processIncarnation: 'runtime_test:term_worker:1',
+            ...(workerLaunchTokenHash ? { launchTokenHash: workerLaunchTokenHash } : {}),
             hostScope: { kind: 'local', hostId: 'local' }
           } as never)
         : null
@@ -51,10 +59,15 @@ describe('orchestration worker release recovery', () => {
     vi.spyOn(runtime, 'showManagedTerminalWorkspace').mockResolvedValue({
       id: 'repo::worktree'
     } as never)
-    vi.spyOn(runtime, 'createTerminal').mockResolvedValue({
-      handle: 'term_worker',
-      worktreeId: 'repo::worktree',
-      title: 'worker'
+    vi.spyOn(runtime, 'createTerminal').mockImplementation(async (_selector, opts) => {
+      workerLaunchTokenHash = opts?.launchToken
+        ? createHash('sha256').update(opts.launchToken).digest('hex')
+        : null
+      return {
+        handle: opts?.preAllocatedHandle ?? 'term_worker',
+        worktreeId: 'repo::worktree',
+        title: 'worker'
+      } as never
     })
     vi.spyOn(runtime, 'waitForTerminal').mockResolvedValue({
       handle: 'term_worker',
@@ -64,6 +77,7 @@ describe('orchestration worker release recovery', () => {
       exitCode: null
     })
     vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
+    vi.spyOn(runtime, 'getWorktreeOrchestrationCliCommand').mockResolvedValue('orca')
     vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockResolvedValue({
       handle: 'term_worker',
       accepted: true,

--- a/src/main/runtime/rpc/methods/orchestration-worker-release.test-support.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release.test-support.ts
@@ -1,0 +1,94 @@
+import { createHash } from 'node:crypto'
+import { vi } from 'vitest'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+
+export function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+  return { promise, resolve }
+}
+
+/** Installs the shared worker-release runtime fixture and returns the liveness probe spy. */
+export function installWorkerReleaseRuntimeMocks(
+  runtime: OrcaRuntimeService,
+  paneKeys: { coordinator: string; worker: string }
+): ReturnType<typeof vi.fn> {
+  const inspectProcessLiveness = vi.fn().mockResolvedValue('live')
+  ;(
+    runtime as unknown as {
+      inspectTerminalProcessIncarnationLiveness: typeof inspectProcessLiveness
+    }
+  ).inspectTerminalProcessIncarnationLiveness = inspectProcessLiveness
+  vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) =>
+    handle === 'term_coord'
+      ? paneKeys.coordinator
+      : handle === 'term_worker' || handle === 'term_reminted'
+        ? paneKeys.worker
+        : null
+  )
+  vi.spyOn(runtime, 'getTerminalProcessIncarnation').mockImplementation((handle) =>
+    handle === 'term_worker' || handle === 'term_reminted' ? 'runtime_test:term_worker:1' : null
+  )
+  // Why: the argv worker-start path pre-allocates the handle and hands the
+  // spawn a launch token; the pane's authority must echo that token's hash
+  // or the bind guard (rightly) refuses the pane. Pinning the pre-allocated
+  // handle keeps every 'term_worker'-keyed fixture in this file valid.
+  let workerLaunchTokenHash: string | null = null
+  vi.spyOn(runtime, 'createPreAllocatedTerminalHandle').mockReturnValue('term_worker')
+  vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockImplementation((handle) =>
+    handle === 'term_worker' || handle === 'term_reminted'
+      ? ({
+          terminalHandle: handle,
+          paneKey: paneKeys.worker,
+          processIncarnation: 'runtime_test:term_worker:1',
+          ...(workerLaunchTokenHash ? { launchTokenHash: workerLaunchTokenHash } : {}),
+          hostScope: { kind: 'local', hostId: 'local' }
+        } as never)
+      : null
+  )
+  vi.spyOn(runtime, 'validateOrchestrationAgentLauncher').mockImplementation(() => {})
+  vi.spyOn(runtime, 'showTerminal').mockImplementation(
+    async (handle) => ({ handle, worktreeId: 'repo::worktree', status: 'running' }) as never
+  )
+  vi.spyOn(runtime, 'showManagedTerminalWorkspace').mockResolvedValue({
+    id: 'repo::worktree'
+  } as never)
+  vi.spyOn(runtime, 'createTerminal').mockImplementation(async (_selector, opts) => {
+    workerLaunchTokenHash = opts?.launchToken
+      ? createHash('sha256').update(opts.launchToken).digest('hex')
+      : null
+    return { handle: 'term_worker', worktreeId: 'repo::worktree', title: 'worker' } as never
+  })
+  vi.spyOn(runtime, 'waitForTerminal').mockResolvedValue({
+    handle: 'term_worker',
+    condition: 'tui-idle',
+    satisfied: true,
+    status: 'running',
+    exitCode: null
+  })
+  vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
+  vi.spyOn(runtime, 'getWorktreeOrchestrationCliCommand').mockResolvedValue('orca')
+  vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockResolvedValue({
+    handle: 'term_worker',
+    accepted: true,
+    bytesWritten: 1
+  })
+  vi.spyOn(runtime, 'isTerminalRunningAgent').mockResolvedValue(true)
+  vi.spyOn(runtime, 'getExactWorkerProviderSession').mockReturnValue(null)
+  vi.spyOn(runtime, 'readTerminal').mockResolvedValue({
+    handle: 'term_worker',
+    status: 'running',
+    tail: ['worker output line 1', 'worker output line 2'],
+    truncated: false,
+    nextCursor: '2'
+  })
+  vi.spyOn(runtime, 'closeTerminal').mockResolvedValue({
+    handle: 'term_worker',
+    tabId: 'tab-worker',
+    ptyKilled: true
+  } as never)
+  vi.spyOn(runtime, 'notifyMessageArrived').mockImplementation(() => {})
+  return inspectProcessLiveness
+}

--- a/src/main/runtime/rpc/methods/orchestration-worker-release.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release.test.ts
@@ -6,14 +6,10 @@ import { ORCHESTRATION_METHODS } from './orchestration'
 import type { RpcContext } from '../core'
 import { OrchestrationDb } from '../../orchestration/db'
 import { OrcaRuntimeService } from '../../orca-runtime'
-
-function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
-  let resolve!: (value: T) => void
-  const promise = new Promise<T>((promiseResolve) => {
-    resolve = promiseResolve
-  })
-  return { promise, resolve }
-}
+import {
+  deferred,
+  installWorkerReleaseRuntimeMocks
+} from './orchestration-worker-release.test-support'
 
 describe('orchestration worker release', () => {
   let db: OrchestrationDb
@@ -31,72 +27,10 @@ describe('orchestration worker release', () => {
     dbOpen = true
     runtime = new OrcaRuntimeService()
     runtime.setOrchestrationDb(db)
-    inspectProcessLiveness = vi.fn().mockResolvedValue('live')
-    ;(
-      runtime as unknown as {
-        inspectTerminalProcessIncarnationLiveness: typeof inspectProcessLiveness
-      }
-    ).inspectTerminalProcessIncarnationLiveness = inspectProcessLiveness
-    vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) =>
-      handle === 'term_coord'
-        ? coordinatorPaneKey
-        : handle === 'term_worker' || handle === 'term_reminted'
-          ? workerPaneKey
-          : null
-    )
-    vi.spyOn(runtime, 'getTerminalProcessIncarnation').mockImplementation((handle) =>
-      handle === 'term_worker' || handle === 'term_reminted' ? 'runtime_test:term_worker:1' : null
-    )
-    vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockImplementation((handle) =>
-      handle === 'term_worker' || handle === 'term_reminted'
-        ? ({
-            terminalHandle: handle,
-            paneKey: workerPaneKey,
-            processIncarnation: 'runtime_test:term_worker:1',
-            hostScope: { kind: 'local', hostId: 'local' }
-          } as never)
-        : null
-    )
-    vi.spyOn(runtime, 'validateOrchestrationAgentLauncher').mockImplementation(() => {})
-    vi.spyOn(runtime, 'showTerminal').mockImplementation(
-      async (handle) => ({ handle, worktreeId: 'repo::worktree', status: 'running' }) as never
-    )
-    vi.spyOn(runtime, 'showManagedTerminalWorkspace').mockResolvedValue({
-      id: 'repo::worktree'
-    } as never)
-    vi.spyOn(runtime, 'createTerminal').mockResolvedValue({
-      handle: 'term_worker',
-      worktreeId: 'repo::worktree',
-      title: 'worker'
+    inspectProcessLiveness = installWorkerReleaseRuntimeMocks(runtime, {
+      coordinator: coordinatorPaneKey,
+      worker: workerPaneKey
     })
-    vi.spyOn(runtime, 'waitForTerminal').mockResolvedValue({
-      handle: 'term_worker',
-      condition: 'tui-idle',
-      satisfied: true,
-      status: 'running',
-      exitCode: null
-    })
-    vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
-    vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockResolvedValue({
-      handle: 'term_worker',
-      accepted: true,
-      bytesWritten: 1
-    })
-    vi.spyOn(runtime, 'isTerminalRunningAgent').mockResolvedValue(true)
-    vi.spyOn(runtime, 'getExactWorkerProviderSession').mockReturnValue(null)
-    vi.spyOn(runtime, 'readTerminal').mockResolvedValue({
-      handle: 'term_worker',
-      status: 'running',
-      tail: ['worker output line 1', 'worker output line 2'],
-      truncated: false,
-      nextCursor: '2'
-    })
-    vi.spyOn(runtime, 'closeTerminal').mockResolvedValue({
-      handle: 'term_worker',
-      tabId: 'tab-worker',
-      ptyKilled: true
-    } as never)
-    vi.spyOn(runtime, 'notifyMessageArrived').mockImplementation(() => {})
     activeRunId = db.createRun({
       objective: 'Release test Run',
       coordinatorHandle: 'term_coord',

--- a/src/main/runtime/rpc/methods/orchestration-worker-start-prompt-contract.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-start-prompt-contract.test.ts
@@ -162,6 +162,7 @@ async function createPromptContractHarness(
     } as never
   })
   vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
+  vi.spyOn(runtime, 'getWorktreeOrchestrationCliCommand').mockResolvedValue('orca')
 
   return {
     db,
@@ -340,13 +341,14 @@ describe('orchestration worker-start prompt contract', () => {
     }
     const dispatchId = (response.result as { dispatchId: string }).dispatchId
     const startup = vi.mocked(harness.runtime.createManagedWorktree).mock.calls[0]?.[0]
+    const startupPrompt = await startup?.startupPromptFactory?.('repo::created')
     expect(startup).toMatchObject({
       startupAgent: 'codex',
-      startupPrompt: expect.stringMatching(/--dispatch-capability dcap_[A-Za-z0-9_-]+/),
       startupLaunchToken: expect.any(String),
       startupPreAllocatedHandle: harness.handle,
       lineage: { parentWorktree: 'repo::parent', noParent: false }
     })
+    expect(startupPrompt).toMatch(/--dispatch-capability dcap_[A-Za-z0-9_-]+/)
     expect(harness.runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
     expect(waitForTerminal).toHaveBeenCalledTimes(1)
     expect(waitForTerminal).toHaveBeenCalledWith(harness.handle, {

--- a/src/main/runtime/rpc/methods/orchestration-worker-start-prompt-contract.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-start-prompt-contract.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -12,6 +13,7 @@ import { OrchestrationDb } from '../../orchestration/db'
 import type { RpcRequest } from '../core'
 import { RpcDispatcher } from '../dispatcher'
 import { ORCHESTRATION_METHODS } from './orchestration'
+import type { TuiAgent } from '../../../../shared/tui-agent'
 
 vi.mock('../../../git/worktree', () => ({
   listWorktrees: vi.fn().mockResolvedValue([
@@ -51,10 +53,13 @@ type PromptContractHarness = {
   startedTurns: () => number
   prematureSubmits: () => number
   writes: string[]
+  runtime: Awaited<ReturnType<typeof createAgentPromptSubmissionRuntime>>['runtime']
+  handle: string
 }
 
 async function createPromptContractHarness(
-  outcome: 'accepted' | 'swallowed'
+  outcome: 'accepted' | 'swallowed',
+  launchAgent: TuiAgent = 'aider'
 ): Promise<PromptContractHarness> {
   let composerReady = false
   let submittedTurns = 0
@@ -62,10 +67,10 @@ async function createPromptContractHarness(
   let prematureSubmits = 0
   const fixture = await createAgentPromptSubmissionRuntime((runtime, data) => {
     if (data.includes(AGENT_PROMPT_BRACKETED_PASTE_END)) {
+      composerReady = true
       setTimeout(() => runtime.onPtyData('pty-prompt', 'partial composer frame', Date.now()), 650)
       setTimeout(() => runtime.onPtyData('pty-prompt', '\x1b[?25h', Date.now()), 750)
       setTimeout(() => {
-        composerReady = true
         runtime.onPtyData('pty-prompt', 'final composer frame', Date.now())
       }, 1_000)
       return
@@ -81,7 +86,7 @@ async function createPromptContractHarness(
       startedTurns += 1
       runtime.onPtyData('pty-prompt', '\x1b]0;Codex working\x07', Date.now())
     }
-  }, 'codex')
+  }, launchAgent)
   const { runtime, handle } = fixture
   runtime.onPtyData('pty-prompt', '\x1b]0;Codex idle\x07', Date.now())
 
@@ -118,16 +123,44 @@ async function createPromptContractHarness(
     repoId: 'repo-1'
   } as never)
   vi.spyOn(runtime, 'showRepo').mockResolvedValue({ id: 'repo-1', kind: 'git' } as never)
-  vi.spyOn(runtime, 'createManagedWorktree').mockResolvedValue({
-    worktree: { id: AGENT_PROMPT_TEST_WORKTREE_ID, repoId: 'repo-1' },
-    startupTerminal: { spawned: true, handle },
-    setupReceipt: {
-      requested: 'run',
-      hookFound: false,
-      startupPolicy: 'start-immediately',
-      state: 'not_configured'
-    }
-  } as never)
+  let launchTokenHash: string | null = null
+  if (launchAgent === 'codex') {
+    vi.spyOn(runtime, 'createPreAllocatedTerminalHandle').mockReturnValue(handle)
+    vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockImplementation((candidate) =>
+      candidate === handle && launchTokenHash
+        ? ({
+            runtimeId: runtime.getRuntimeId(),
+            terminalHandle: handle,
+            ptyId: 'pty-prompt',
+            worktreeId: AGENT_PROMPT_TEST_WORKTREE_ID,
+            paneKey: WORKER_PANE_KEY,
+            processIncarnation: `runtime_test:${handle}:1`,
+            launchTokenHash,
+            hostScope: { kind: 'local', hostId: 'local' }
+          } as never)
+        : null
+    )
+    vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockResolvedValue({
+      handle,
+      accepted: true,
+      bytesWritten: 1
+    } as never)
+  }
+  vi.spyOn(runtime, 'createManagedWorktree').mockImplementation(async (args) => {
+    launchTokenHash = args.startupLaunchToken
+      ? createHash('sha256').update(args.startupLaunchToken).digest('hex')
+      : null
+    return {
+      worktree: { id: AGENT_PROMPT_TEST_WORKTREE_ID, repoId: 'repo-1' },
+      startupTerminal: { spawned: true, handle },
+      setupReceipt: {
+        requested: 'run',
+        hookFound: false,
+        startupPolicy: 'start-immediately',
+        state: 'not_configured'
+      }
+    } as never
+  })
   vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
 
   return {
@@ -145,7 +178,7 @@ async function createPromptContractHarness(
         from: 'term_coord',
         worktree: 'new-child',
         name: `prompt-contract-${outcome}`,
-        agent: 'codex'
+        agent: launchAgent
       }
     },
     requestId: `${REQUEST_ID}_${outcome}`,
@@ -153,7 +186,9 @@ async function createPromptContractHarness(
     submittedTurns: () => submittedTurns,
     startedTurns: () => startedTurns,
     prematureSubmits: () => prematureSubmits,
-    writes: fixture.writes
+    writes: fixture.writes,
+    runtime,
+    handle
   }
 }
 
@@ -274,6 +309,63 @@ describe('orchestration worker-start prompt contract', () => {
       state: 'failed',
       failedStage: 'dispatch_input',
       lastError: 'agent_prompt_stalled'
+    })
+  })
+
+  it('launches a Codex new-child worker with argv authority and no prompt submission', async () => {
+    const harness = await createPromptContractHarness('accepted', 'codex')
+    const waitForTerminal = vi.spyOn(harness.runtime, 'waitForTerminal').mockResolvedValue({
+      handle: harness.handle,
+      condition: 'tui-idle',
+      satisfied: true,
+      status: 'running',
+      exitCode: null
+    })
+
+    const response = await harness.dispatcher.dispatch(harness.request)
+
+    expect(response).toMatchObject({
+      ok: true,
+      result: {
+        state: 'ready',
+        stage: 'input_accepted',
+        effects: expect.arrayContaining([
+          expect.objectContaining({ kind: 'terminal', role: 'agent', action: 'created' }),
+          expect.objectContaining({ kind: 'dispatch_input', state: 'accepted' })
+        ])
+      }
+    })
+    if (!response.ok) {
+      throw new Error(response.error.message)
+    }
+    const dispatchId = (response.result as { dispatchId: string }).dispatchId
+    const startup = vi.mocked(harness.runtime.createManagedWorktree).mock.calls[0]?.[0]
+    expect(startup).toMatchObject({
+      startupAgent: 'codex',
+      startupPrompt: expect.stringMatching(/--dispatch-capability dcap_[A-Za-z0-9_-]+/),
+      startupLaunchToken: expect.any(String),
+      startupPreAllocatedHandle: harness.handle,
+      lineage: { parentWorktree: 'repo::parent', noParent: false }
+    })
+    expect(harness.runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
+    expect(waitForTerminal).toHaveBeenCalledTimes(1)
+    expect(waitForTerminal).toHaveBeenCalledWith(harness.handle, {
+      condition: 'tui-idle',
+      timeoutMs: 60_000
+    })
+    expect(harness.writes.filter((data) => data === '\r')).toHaveLength(0)
+    expect(harness.db.getDispatchContextById(dispatchId)).toMatchObject({
+      launch_token_hash: createHash('sha256')
+        .update(startup?.startupLaunchToken as string)
+        .digest('hex'),
+      assignee_pane_key: WORKER_PANE_KEY,
+      process_incarnation: `runtime_test:${harness.handle}:1`
+    })
+    expect(harness.db.getWorkerTerminalResourceByOwner(dispatchId)).toMatchObject({
+      ownership_state: 'owned',
+      terminal_handle: harness.handle,
+      pane_key: WORKER_PANE_KEY,
+      process_incarnation: `runtime_test:${harness.handle}:1`
     })
   })
 })

--- a/src/main/runtime/rpc/methods/orchestration-worker-start-receipt.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-start-receipt.ts
@@ -8,6 +8,19 @@ import type { OrchestrationWorkerLaunchReceipt } from './orchestration-worker-la
 import { isAgentSessionPtyWriteRefusedError } from '../../../../shared/agent-session-pty-write-admission'
 import { structuredChatPtyWriteRefusalCopy } from '../../../../shared/agent-session-pty-write-refusal-copy'
 
+export function createWorkerStartupCleanupError(
+  worktreeId: string,
+  startupError: unknown,
+  cleanupError: unknown
+): AggregateError {
+  const startupMessage = startupError instanceof Error ? startupError.message : String(startupError)
+  const cleanupMessage = cleanupError instanceof Error ? cleanupError.message : String(cleanupError)
+  return new AggregateError(
+    [startupError, cleanupError],
+    `Failed to prepare startup prompt for worktree ${worktreeId}: ${startupMessage}; cleanup failed: ${cleanupMessage}`
+  )
+}
+
 export function failWorkerStartWithReceipt(args: {
   db: OrchestrationDb
   runId: string

--- a/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
@@ -3,6 +3,7 @@ import type { ArgvWorktreeLaunch } from './orchestration-worker-authority'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import type { OrchestrationDb } from '../../orchestration/db'
+import { createWorkerStartupCleanupError } from './orchestration-worker-start-receipt'
 
 export type WorkerEffect = {
   kind: 'worktree' | 'terminal' | 'setup' | 'dispatch_input'
@@ -149,9 +150,21 @@ export async function createWorkerWorktree(args: {
     ...(args.launchPreferences ? { startupLaunchPreferences: args.launchPreferences } : {}),
     ...(args.argvWorktreeLaunch
       ? {
-          startupPrompt: args.argvWorktreeLaunch.startupPrompt,
           startupLaunchToken: args.argvWorktreeLaunch.startupLaunchToken,
-          startupPreAllocatedHandle: args.argvWorktreeLaunch.startupPreAllocatedHandle
+          startupPreAllocatedHandle: args.argvWorktreeLaunch.startupPreAllocatedHandle,
+          startupPromptFactory: async (worktreeId: string) => {
+            try {
+              const cli = await runtime.getWorktreeOrchestrationCliCommand(worktreeId)
+              return args.argvWorktreeLaunch!.buildStartupPrompt(cli)
+            } catch (error) {
+              try {
+                await runtime.removeManagedWorktree(`id:${worktreeId}`, true, false, true)
+              } catch (cleanupError) {
+                throw createWorkerStartupCleanupError(worktreeId, error, cleanupError)
+              }
+              throw error
+            }
+          }
         }
       : {}),
     activate: false,
@@ -284,19 +297,4 @@ export function monitorWorkerSetup(args: {
       args.runtime.notifyMessageArrived(message.to_handle, message.type)
     })
     .catch(() => undefined)
-}
-
-export function isUnknownWorkerStartOutcome(error: unknown, stage: string): boolean {
-  const code =
-    error && typeof error === 'object' && typeof (error as { code?: unknown }).code === 'string'
-      ? (error as { code: string }).code
-      : ''
-  if (code === 'operation_unknown') {
-    return true
-  }
-  if (stage !== 'worktree_create') {
-    return false
-  }
-  const message = error instanceof Error ? error.message : String(error)
-  return /connection|disconnect|timed?\s*out|runtime changed|outcome unknown/i.test(message)
 }

--- a/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
@@ -298,3 +298,18 @@ export function monitorWorkerSetup(args: {
     })
     .catch(() => undefined)
 }
+
+export function isUnknownWorkerStartOutcome(error: unknown, stage: string): boolean {
+  const code =
+    error && typeof error === 'object' && typeof (error as { code?: unknown }).code === 'string'
+      ? (error as { code: string }).code
+      : ''
+  if (code === 'operation_unknown') {
+    return true
+  }
+  if (stage !== 'worktree_create') {
+    return false
+  }
+  const message = error instanceof Error ? error.message : String(error)
+  return /connection|disconnect|timed?\s*out|runtime changed|outcome unknown/i.test(message)
+}

--- a/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
@@ -1,4 +1,5 @@
 import type { AgentLaunchPreferences } from '../../../../shared/agent-session-host-authority'
+import type { ArgvWorktreeLaunch } from './orchestration-worker-authority'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import type { OrchestrationDb } from '../../orchestration/db'
@@ -121,6 +122,7 @@ export async function createWorkerWorktree(args: {
   }
   agent: TuiAgent
   launchPreferences?: AgentLaunchPreferences
+  argvWorktreeLaunch?: ArgvWorktreeLaunch
   effects: WorkerEffect[]
 }): Promise<{
   worktree: Awaited<ReturnType<OrcaRuntimeService['showManagedWorktree']>>
@@ -145,6 +147,13 @@ export async function createWorkerWorktree(args: {
     createdWithAgent: args.agent,
     startupAgent: args.agent,
     ...(args.launchPreferences ? { startupLaunchPreferences: args.launchPreferences } : {}),
+    ...(args.argvWorktreeLaunch
+      ? {
+          startupPrompt: args.argvWorktreeLaunch.startupPrompt,
+          startupLaunchToken: args.argvWorktreeLaunch.startupLaunchToken,
+          startupPreAllocatedHandle: args.argvWorktreeLaunch.startupPreAllocatedHandle
+        }
+      : {}),
     activate: false,
     lineage: {
       parentWorktree: requestedWorktree === 'new-child' ? coordinatorWorktree.id : undefined,
@@ -153,6 +162,24 @@ export async function createWorkerWorktree(args: {
     }
   })
   const terminalHandle = created.startupTerminal?.handle
+  const setupReceipt = {
+    requested: setupDecision,
+    effective: setupDecision,
+    source: params.setup ? 'explicit_request' : 'orchestration_default',
+    hookFound: created.setupReceipt?.hookFound ?? false,
+    startupPolicy: created.setupReceipt?.startupPolicy ?? 'start-immediately',
+    state: created.setupReceipt?.state ?? 'not_configured'
+  }
+  if (!terminalHandle) {
+    throw new Error(created.warning ?? 'Agent-first worktree creation returned no terminal.')
+  }
+  if (args.argvWorktreeLaunch && created.startupTerminal) {
+    args.argvWorktreeLaunch.persistAgentTerminalOwnership(
+      { ...created.startupTerminal, handle: terminalHandle },
+      setupReceipt,
+      created.worktree.id
+    )
+  }
   effects.push({
     kind: 'worktree',
     action: requestedWorktree === 'new-child' ? 'created_child' : 'created_top_level',
@@ -165,22 +192,14 @@ export async function createWorkerWorktree(args: {
     effects,
     residualResources: effects
   })
-  const setupReceipt = {
-    requested: setupDecision,
-    effective: setupDecision,
-    source: params.setup ? 'explicit_request' : 'orchestration_default',
-    hookFound: created.setupReceipt?.hookFound ?? false,
-    startupPolicy: created.setupReceipt?.startupPolicy ?? 'start-immediately',
-    state: created.setupReceipt?.state ?? 'not_configured'
-  }
-  if (!terminalHandle) {
-    throw new Error(created.warning ?? 'Agent-first worktree creation returned no terminal.')
-  }
   const listed = await runtime.listTerminals(`id:${created.worktree.id}`, undefined, {
     includeVisualLayouts: false
   })
   const setupTerminalHandle = created.setupReceipt?.terminalHandle
   for (const terminal of listed.terminals) {
+    if (terminal.handle === terminalHandle && args.argvWorktreeLaunch) {
+      continue
+    }
     effects.push({
       kind: 'terminal',
       role:

--- a/src/main/runtime/rpc/methods/orchestration-workers-new-worktree-argv.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers-new-worktree-argv.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { OrcaRuntimeService } from '../../orca-runtime'
+import type { OrchestrationDb } from '../../orchestration/db'
+import { reconcileLifecycleMessage } from '../../orchestration/lifecycle-reconciliation'
+import {
+  createNewWorktreeTestSupport,
+  type NewWorktreeTestState
+} from './orchestration-workers-new-worktree.test-support'
+
+describe('orchestration new-worktree argv workers', () => {
+  let db: OrchestrationDb
+  let runtime: OrcaRuntimeService
+  let runId: string
+  let workerLaunchTokenHash: string | null
+  const paths: string[] = []
+  const support = createNewWorktreeTestSupport({
+    getWorkerLaunchTokenHash: () => workerLaunchTokenHash,
+    setWorkerLaunchTokenHash: (hash) => {
+      workerLaunchTokenHash = hash
+    }
+  })
+
+  beforeEach(() => {
+    const state = support.setup()
+    db = state.db
+    runtime = state.runtime
+    runId = state.runId
+  })
+
+  afterEach(() => support.cleanup(db, paths))
+
+  function state(): NewWorktreeTestState {
+    return { db, runtime, runId }
+  }
+
+  function startWorker(overrides: Record<string, unknown> = {}) {
+    return support.startWorker(state(), overrides)
+  }
+
+  function mockCreatedWorktree(): void {
+    support.mockCreatedWorktree(state())
+  }
+
+  function ownedResourceCount(dispatchId: string): number {
+    return support.ownedResourceCount(db, dispatchId)
+  }
+
+  it('creates an independent top-level worktree and reuses its agent terminal', async () => {
+    mockCreatedWorktree()
+
+    const { result } = await startWorker({ worktree: 'new-top-level' })
+
+    expect(runtime.createManagedWorktree).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startupAgent: 'codex',
+        awaitTerminalProvisioning: true,
+        observeSetupCompletion: true,
+        lineage: expect.objectContaining({ noParent: true, parentWorktree: undefined })
+      })
+    )
+    expect(result).toMatchObject({ state: 'ready' })
+    expect(result).toHaveProperty(
+      'effects',
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'worktree',
+          action: 'created_top_level',
+          id: 'repo::created'
+        }),
+        expect.objectContaining({
+          kind: 'terminal',
+          role: 'agent',
+          action: 'created',
+          id: 'term_worker'
+        })
+      ])
+    )
+    expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
+    const createOptions = vi.mocked(runtime.createManagedWorktree).mock.calls[0]?.[0]
+    expect(await createOptions?.startupPromptFactory?.('repo::created')).toMatch(
+      /--dispatch-capability dcap_[A-Za-z0-9_-]+/
+    )
+    expect(ownedResourceCount((result as { dispatchId: string }).dispatchId)).toBe(1)
+    expect(runtime.createTerminal).not.toHaveBeenCalled()
+  })
+
+  it('launches an argv worker in a new child worktree without prompt submission', async () => {
+    mockCreatedWorktree()
+
+    const { result } = await startWorker({ worktree: 'new-child' })
+
+    expect(result).toMatchObject({ state: 'ready' })
+    expect(runtime.createManagedWorktree).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startupAgent: 'codex',
+        startupLaunchToken: expect.any(String),
+        startupPreAllocatedHandle: 'term_worker',
+        lineage: expect.objectContaining({ parentWorktree: 'repo::parent', noParent: false })
+      })
+    )
+    const createOptions = vi.mocked(runtime.createManagedWorktree).mock.calls[0]?.[0]
+    expect(await createOptions?.startupPromptFactory?.('repo::created')).toMatch(
+      /--dispatch-capability dcap_[A-Za-z0-9_-]+/
+    )
+    expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
+    expect(
+      (result as { effects: { kind: string; role?: string; action?: string }[] }).effects.filter(
+        (effect) => effect.kind === 'terminal' && effect.role === 'agent'
+      )
+    ).toHaveLength(1)
+    expect(ownedResourceCount((result as { dispatchId: string }).dispatchId)).toBe(1)
+  })
+
+  it('accepts worker_done sent while argv startup is waiting for terminal readiness', async () => {
+    mockCreatedWorktree()
+    vi.mocked(runtime.waitForTerminal).mockImplementationOnce(async () => {
+      const task = db.listTasks()[0]!
+      const dispatch = db.getDispatchContext(task.id)!
+      const message = db.insertMessage({
+        from: 'term_worker',
+        to: `run:${runId}`,
+        subject: 'Completed immediately',
+        type: 'worker_done',
+        payload: JSON.stringify({
+          taskId: task.id,
+          dispatchId: dispatch.id,
+          outcome: 'succeeded'
+        }),
+        senderPaneKey: 'tab_worker:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+        runId
+      })
+
+      expect(reconcileLifecycleMessage(db, message)).toEqual({
+        action: 'completed',
+        taskId: task.id,
+        dispatchId: dispatch.id
+      })
+      return {
+        handle: 'term_worker',
+        condition: 'tui-idle',
+        satisfied: true,
+        status: 'running',
+        exitCode: null
+      }
+    })
+
+    const { result, task } = await startWorker({ worktree: 'new-child' })
+
+    expect(result).toMatchObject({
+      state: 'succeeded',
+      stage: 'settled',
+      taskId: task.id,
+      effects: expect.arrayContaining([
+        expect.objectContaining({ kind: 'dispatch_input', state: 'accepted' })
+      ])
+    })
+    expect(db.getTask(task.id)).toMatchObject({ status: 'completed' })
+  })
+
+  it('keeps a bound argv worker ready and reports a blocked startup screen', async () => {
+    mockCreatedWorktree()
+    const blockedReason = 'trust prompt is waiting for confirmation'
+    vi.mocked(runtime.waitForTerminal).mockResolvedValueOnce({
+      handle: 'term_worker',
+      condition: 'tui-idle',
+      satisfied: false,
+      status: 'running',
+      blockedReason,
+      exitCode: null
+    } as never)
+    const insertMessage = vi.spyOn(db, 'insertMessage')
+    const notify = vi.spyOn(runtime, 'notifyMessageArrived').mockImplementation(() => {})
+
+    const { result, task } = await startWorker({ worktree: 'new-child' })
+
+    expect(result).toMatchObject({ state: 'ready', taskId: task.id })
+    expect(db.getWorkerDispatch((result as { dispatchId: string }).dispatchId)).toMatchObject({
+      state: 'ready'
+    })
+    expect(insertMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        priority: 'high',
+        subject: expect.stringContaining(`startup blocked: ${blockedReason}`)
+      })
+    )
+    expect(notify).toHaveBeenCalled()
+  })
+
+  it('keeps a bound argv worker ready when readiness has no blocked reason', async () => {
+    mockCreatedWorktree()
+    vi.mocked(runtime.waitForTerminal).mockResolvedValueOnce({
+      handle: 'term_worker',
+      condition: 'tui-idle',
+      satisfied: false,
+      status: 'running',
+      exitCode: null
+    } as never)
+    const insertMessage = vi.spyOn(db, 'insertMessage')
+
+    const { result, task } = await startWorker({ worktree: 'new-child' })
+    const dispatchId = (result as { dispatchId: string }).dispatchId
+
+    expect(result).toMatchObject({ state: 'ready' })
+    expect(db.getTask(task.id)?.status).toBe('dispatched')
+    expect(db.getDispatchContextById(dispatchId)).toMatchObject({
+      status: 'dispatched',
+      capability_revoked_at: null,
+      capability_hash: expect.any(String)
+    })
+    expect(db.getWorkerDispatch(dispatchId)).toMatchObject({
+      state: 'ready',
+      stage: 'input_accepted'
+    })
+    expect(insertMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: expect.stringContaining(
+          'startup blocked: Terminal readiness wait was not satisfied.'
+        )
+      })
+    )
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test-support.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test-support.ts
@@ -1,0 +1,185 @@
+import { createHash } from 'node:crypto'
+import { rmSync } from 'node:fs'
+import { vi } from 'vitest'
+import { OrcaRuntimeService } from '../../orca-runtime'
+import { OrchestrationDb } from '../../orchestration/db'
+import { ORCHESTRATION_METHODS } from './orchestration'
+
+export const coordinatorPaneKey = 'tab_coord:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+
+export type CreateWorktreeResult = Awaited<ReturnType<OrcaRuntimeService['createManagedWorktree']>>
+
+type MockCreatedWorktreeOptions = {
+  hookFound?: boolean
+  startupPolicy?: 'start-immediately' | 'wait-for-setup'
+  state?: 'running' | 'skipped' | 'not_configured' | 'spawn_failed'
+  terminals?: { handle: string; title: string }[]
+  setupTerminalHandle?: string
+}
+
+export type NewWorktreeTestState = {
+  db: OrchestrationDb
+  runtime: OrcaRuntimeService
+  runId: string
+}
+
+export function createNewWorktreeTestSupport(args: {
+  getWorkerLaunchTokenHash: () => string | null
+  setWorkerLaunchTokenHash: (hash: string | null) => void
+}) {
+  function setup(): NewWorktreeTestState {
+    const db = new OrchestrationDb(':memory:')
+    const runtime = new OrcaRuntimeService()
+    runtime.setOrchestrationDb(db)
+    const runId = db.createRun({
+      objective: 'Test new-worktree workers',
+      coordinatorHandle: 'term_coord',
+      coordinatorPaneKey
+    }).id
+    args.setWorkerLaunchTokenHash(null)
+    vi.spyOn(runtime, 'createPreAllocatedTerminalHandle').mockReturnValue('term_worker')
+    vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) =>
+      handle === 'term_coord'
+        ? coordinatorPaneKey
+        : handle === 'term_worker'
+          ? 'tab_worker:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+          : null
+    )
+    vi.spyOn(runtime, 'getTerminalProcessIncarnation').mockImplementation((handle) =>
+      handle === 'term_worker' ? 'runtime_test:term_worker:1' : null
+    )
+    vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockImplementation((handle) =>
+      handle === 'term_worker' && args.getWorkerLaunchTokenHash()
+        ? ({
+            runtimeId: runtime.getRuntimeId(),
+            terminalHandle: handle,
+            ptyId: 'pty_worker',
+            worktreeId: 'repo::created',
+            paneKey: 'tab_worker:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+            processIncarnation: 'runtime_test:term_worker:1',
+            launchTokenHash: args.getWorkerLaunchTokenHash(),
+            hostScope: { kind: 'local', hostId: 'local' }
+          } as never)
+        : null
+    )
+    vi.spyOn(runtime, 'validateOrchestrationAgentLauncher').mockImplementation(() => {})
+    vi.spyOn(runtime, 'showTerminal').mockResolvedValue({
+      handle: 'term_coord',
+      worktreeId: 'repo::parent',
+      status: 'running'
+    } as never)
+    vi.spyOn(runtime, 'showManagedWorktree').mockResolvedValue({
+      id: 'repo::parent',
+      repoId: 'repo'
+    } as never)
+    vi.spyOn(runtime, 'showRepo').mockResolvedValue({
+      id: 'repo',
+      kind: 'git'
+    } as never)
+    vi.spyOn(runtime, 'createTerminal')
+    vi.spyOn(runtime, 'listTerminals').mockResolvedValue({
+      terminals: [{ handle: 'term_worker', title: 'Codex' }],
+      totalCount: 1,
+      truncated: false
+    } as never)
+    vi.spyOn(runtime, 'waitForTerminal').mockResolvedValue({
+      handle: 'term_worker',
+      condition: 'tui-idle',
+      satisfied: true,
+      status: 'running',
+      exitCode: null
+    })
+    vi.spyOn(runtime, 'waitForSetupTerminalCompletion').mockReturnValue(
+      new Promise(() => undefined)
+    )
+    vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
+    vi.spyOn(runtime, 'getWorktreeOrchestrationCliCommand').mockResolvedValue('orca')
+    vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockResolvedValue({
+      handle: 'term_worker',
+      accepted: true,
+      bytesWritten: 1
+    })
+    return { db, runtime, runId }
+  }
+
+  function cleanup(db: OrchestrationDb, paths: string[]): void {
+    db.close()
+    for (const path of paths.splice(0)) {
+      rmSync(path, { recursive: true, force: true })
+    }
+  }
+
+  async function startWorker(state: NewWorktreeTestState, overrides: Record<string, unknown> = {}) {
+    const task = state.db.createTask({ spec: 'new-worktree task', runId: state.runId })
+    const method = ORCHESTRATION_METHODS.find(
+      (candidate) => candidate.name === 'orchestration.workerStart'
+    )
+    if (!method) {
+      throw new Error('workerStart method is not registered')
+    }
+    const params = method.params!.parse({
+      task: task.id,
+      from: 'term_coord',
+      worktree: 'new-child',
+      name: 'new-worker',
+      agent: 'codex',
+      ...overrides
+    })
+    const result = await method.handler(params, { runtime: state.runtime })
+    return { result, task }
+  }
+
+  function ownedResourceCount(db: OrchestrationDb, dispatchId: string): number {
+    const raw = (
+      db as unknown as {
+        db: { prepare: (sql: string) => { get: (...args: unknown[]) => { count: number } } }
+      }
+    ).db
+    return raw
+      .prepare(
+        `SELECT COUNT(*) AS count
+           FROM worker_terminal_resources
+          WHERE owner_dispatch_id = ?`
+      )
+      .get(dispatchId).count
+  }
+
+  function mockCreatedWorktree(
+    state: NewWorktreeTestState,
+    options?: MockCreatedWorktreeOptions
+  ): void {
+    const hookFound = options?.hookFound ?? true
+    const stateValue = options?.state ?? (hookFound ? 'running' : 'not_configured')
+    const created = {
+      worktree: { id: 'repo::created', repoId: 'repo' },
+      startupTerminal: { spawned: true, handle: 'term_worker' },
+      setupReceipt: {
+        requested: stateValue === 'skipped' ? 'skip' : 'run',
+        hookFound,
+        startupPolicy: options?.startupPolicy ?? 'start-immediately',
+        state: stateValue,
+        terminalHandle:
+          options?.setupTerminalHandle ??
+          options?.terminals?.find((terminal) => terminal.title === 'Setup')?.handle
+      }
+    } as never
+    vi.spyOn(state.runtime, 'createManagedWorktree').mockImplementation(async (createArgs) => {
+      args.setWorkerLaunchTokenHash(
+        createArgs.startupLaunchToken
+          ? createHash('sha256').update(createArgs.startupLaunchToken).digest('hex')
+          : null
+      )
+      await createArgs.startupPromptFactory?.('repo::created')
+      return created
+    })
+    if (options?.terminals) {
+      vi.mocked(state.runtime.listTerminals).mockResolvedValue({
+        terminals: options.terminals,
+        totalCount: options.terminals.length,
+        truncated: false
+      } as never)
+    }
+  }
+
+  return { setup, cleanup, startWorker, ownedResourceCount, mockCreatedWorktree }
+}

--- a/src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts
@@ -1,138 +1,43 @@
-import { createHash } from 'node:crypto'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ORCHESTRATION_CONTRACT_VERSION } from '../../../../shared/protocol-version'
 import { OrcaRuntimeService } from '../../orca-runtime'
 import { OrchestrationDb } from '../../orchestration/db'
-import { reconcileLifecycleMessage } from '../../orchestration/lifecycle-reconciliation'
 import { RpcDispatcher } from '../dispatcher'
 import type { RpcRequest } from '../core'
 import { ORCHESTRATION_METHODS } from './orchestration'
+import {
+  coordinatorPaneKey,
+  createNewWorktreeTestSupport,
+  type CreateWorktreeResult
+} from './orchestration-workers-new-worktree.test-support'
 
 describe('orchestration new-worktree workers', () => {
-  type CreateWorktreeResult = Awaited<ReturnType<OrcaRuntimeService['createManagedWorktree']>>
-  const coordinatorPaneKey = 'tab_coord:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
   let db: OrchestrationDb
   let runtime: OrcaRuntimeService
   let runId: string
   let workerLaunchTokenHash: string | null
   const paths: string[] = []
+  const support = createNewWorktreeTestSupport({
+    getWorkerLaunchTokenHash: () => workerLaunchTokenHash,
+    setWorkerLaunchTokenHash: (hash) => {
+      workerLaunchTokenHash = hash
+    }
+  })
 
   beforeEach(() => {
-    db = new OrchestrationDb(':memory:')
-    runtime = new OrcaRuntimeService()
-    runtime.setOrchestrationDb(db)
-    runId = db.createRun({
-      objective: 'Test new-worktree workers',
-      coordinatorHandle: 'term_coord',
-      coordinatorPaneKey
-    }).id
-    workerLaunchTokenHash = null
-    vi.spyOn(runtime, 'createPreAllocatedTerminalHandle').mockReturnValue('term_worker')
-    vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) =>
-      handle === 'term_coord'
-        ? coordinatorPaneKey
-        : handle === 'term_worker'
-          ? 'tab_worker:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
-          : null
-    )
-    vi.spyOn(runtime, 'getTerminalProcessIncarnation').mockImplementation((handle) =>
-      handle === 'term_worker' ? 'runtime_test:term_worker:1' : null
-    )
-    vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockImplementation((handle) =>
-      handle === 'term_worker' && workerLaunchTokenHash
-        ? ({
-            runtimeId: runtime.getRuntimeId(),
-            terminalHandle: handle,
-            ptyId: 'pty_worker',
-            worktreeId: 'repo::created',
-            paneKey: 'tab_worker:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
-            processIncarnation: 'runtime_test:term_worker:1',
-            launchTokenHash: workerLaunchTokenHash,
-            hostScope: { kind: 'local', hostId: 'local' }
-          } as never)
-        : null
-    )
-    vi.spyOn(runtime, 'validateOrchestrationAgentLauncher').mockImplementation(() => {})
-    vi.spyOn(runtime, 'showTerminal').mockResolvedValue({
-      handle: 'term_coord',
-      worktreeId: 'repo::parent',
-      status: 'running'
-    } as never)
-    vi.spyOn(runtime, 'showManagedWorktree').mockResolvedValue({
-      id: 'repo::parent',
-      repoId: 'repo'
-    } as never)
-    vi.spyOn(runtime, 'showRepo').mockResolvedValue({
-      id: 'repo',
-      kind: 'git'
-    } as never)
-    vi.spyOn(runtime, 'createTerminal')
-    vi.spyOn(runtime, 'listTerminals').mockResolvedValue({
-      terminals: [{ handle: 'term_worker', title: 'Codex' }],
-      totalCount: 1,
-      truncated: false
-    } as never)
-    vi.spyOn(runtime, 'waitForTerminal').mockResolvedValue({
-      handle: 'term_worker',
-      condition: 'tui-idle',
-      satisfied: true,
-      status: 'running',
-      exitCode: null
-    })
-    vi.spyOn(runtime, 'waitForSetupTerminalCompletion').mockReturnValue(
-      new Promise(() => undefined)
-    )
-    vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
-    vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockResolvedValue({
-      handle: 'term_worker',
-      accepted: true,
-      bytesWritten: 1
-    })
+    const state = support.setup()
+    db = state.db
+    runtime = state.runtime
+    runId = state.runId
   })
 
-  afterEach(() => {
-    db.close()
-    for (const path of paths.splice(0)) {
-      rmSync(path, { recursive: true, force: true })
-    }
-  })
+  afterEach(() => support.cleanup(db, paths))
 
   async function startWorker(overrides: Record<string, unknown> = {}) {
-    const task = db.createTask({ spec: 'new-worktree task', runId })
-    const method = ORCHESTRATION_METHODS.find(
-      (candidate) => candidate.name === 'orchestration.workerStart'
-    )
-    if (!method) {
-      throw new Error('workerStart method is not registered')
-    }
-    const params = method.params!.parse({
-      task: task.id,
-      from: 'term_coord',
-      worktree: 'new-child',
-      name: 'new-worker',
-      agent: 'codex',
-      ...overrides
-    })
-    const result = await method.handler(params, { runtime })
-    return { result, task }
-  }
-
-  function ownedResourceCount(dispatchId: string): number {
-    const raw = (
-      db as unknown as {
-        db: { prepare: (sql: string) => { get: (...args: unknown[]) => { count: number } } }
-      }
-    ).db
-    return raw
-      .prepare(
-        `SELECT COUNT(*) AS count
-           FROM worker_terminal_resources
-          WHERE owner_dispatch_id = ?`
-      )
-      .get(dispatchId).count
+    return support.startWorker({ db, runtime, runId }, overrides)
   }
 
   function mockCreatedWorktree(options?: {
@@ -142,143 +47,8 @@ describe('orchestration new-worktree workers', () => {
     terminals?: { handle: string; title: string }[]
     setupTerminalHandle?: string
   }) {
-    const hookFound = options?.hookFound ?? true
-    const state = options?.state ?? (hookFound ? 'running' : 'not_configured')
-    const created = {
-      worktree: { id: 'repo::created', repoId: 'repo' },
-      startupTerminal: { spawned: true, handle: 'term_worker' },
-      setupReceipt: {
-        requested: state === 'skipped' ? 'skip' : 'run',
-        hookFound,
-        startupPolicy: options?.startupPolicy ?? 'start-immediately',
-        state,
-        terminalHandle:
-          options?.setupTerminalHandle ??
-          options?.terminals?.find((terminal) => terminal.title === 'Setup')?.handle
-      }
-    } as never
-    vi.spyOn(runtime, 'createManagedWorktree').mockImplementation(async (args) => {
-      workerLaunchTokenHash = args.startupLaunchToken
-        ? createHash('sha256').update(args.startupLaunchToken).digest('hex')
-        : null
-      return created
-    })
-    if (options?.terminals) {
-      vi.mocked(runtime.listTerminals).mockResolvedValue({
-        terminals: options.terminals,
-        totalCount: options.terminals.length,
-        truncated: false
-      } as never)
-    }
+    support.mockCreatedWorktree({ db, runtime, runId }, options)
   }
-
-  it('creates an independent top-level worktree and reuses its agent terminal', async () => {
-    mockCreatedWorktree()
-
-    const { result } = await startWorker({ worktree: 'new-top-level' })
-
-    expect(runtime.createManagedWorktree).toHaveBeenCalledWith(
-      expect.objectContaining({
-        startupAgent: 'codex',
-        awaitTerminalProvisioning: true,
-        observeSetupCompletion: true,
-        lineage: expect.objectContaining({ noParent: true, parentWorktree: undefined })
-      })
-    )
-    expect(result).toMatchObject({ state: 'ready' })
-    expect(result).toHaveProperty(
-      'effects',
-      expect.arrayContaining([
-        expect.objectContaining({
-          kind: 'worktree',
-          action: 'created_top_level',
-          id: 'repo::created'
-        }),
-        expect.objectContaining({
-          kind: 'terminal',
-          role: 'agent',
-          action: 'created',
-          id: 'term_worker'
-        })
-      ])
-    )
-    expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
-    expect(vi.mocked(runtime.createManagedWorktree).mock.calls[0]?.[0].startupPrompt).toMatch(
-      /--dispatch-capability dcap_[A-Za-z0-9_-]+/
-    )
-    expect(ownedResourceCount((result as { dispatchId: string }).dispatchId)).toBe(1)
-    expect(runtime.createTerminal).not.toHaveBeenCalled()
-  })
-
-  it('launches an argv worker in a new child worktree without prompt submission', async () => {
-    mockCreatedWorktree()
-
-    const { result } = await startWorker({ worktree: 'new-child' })
-
-    expect(result).toMatchObject({ state: 'ready' })
-    expect(runtime.createManagedWorktree).toHaveBeenCalledWith(
-      expect.objectContaining({
-        startupAgent: 'codex',
-        startupPrompt: expect.stringMatching(/--dispatch-capability dcap_[A-Za-z0-9_-]+/),
-        startupLaunchToken: expect.any(String),
-        startupPreAllocatedHandle: 'term_worker',
-        lineage: expect.objectContaining({ parentWorktree: 'repo::parent', noParent: false })
-      })
-    )
-    expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
-    expect(
-      (result as { effects: { kind: string; role?: string; action?: string }[] }).effects.filter(
-        (effect) => effect.kind === 'terminal' && effect.role === 'agent'
-      )
-    ).toHaveLength(1)
-    expect(ownedResourceCount((result as { dispatchId: string }).dispatchId)).toBe(1)
-  })
-
-  it('accepts worker_done sent while argv startup is waiting for terminal readiness', async () => {
-    mockCreatedWorktree()
-    vi.mocked(runtime.waitForTerminal).mockImplementationOnce(async () => {
-      const task = db.listTasks()[0]!
-      const dispatch = db.getDispatchContext(task.id)!
-      const message = db.insertMessage({
-        from: 'term_worker',
-        to: `run:${runId}`,
-        subject: 'Completed immediately',
-        type: 'worker_done',
-        payload: JSON.stringify({
-          taskId: task.id,
-          dispatchId: dispatch.id,
-          outcome: 'succeeded'
-        }),
-        senderPaneKey: 'tab_worker:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
-        runId
-      })
-
-      expect(reconcileLifecycleMessage(db, message)).toEqual({
-        action: 'completed',
-        taskId: task.id,
-        dispatchId: dispatch.id
-      })
-      return {
-        handle: 'term_worker',
-        condition: 'tui-idle',
-        satisfied: true,
-        status: 'running',
-        exitCode: null
-      }
-    })
-
-    const { result, task } = await startWorker({ worktree: 'new-child' })
-
-    expect(result).toMatchObject({
-      state: 'succeeded',
-      stage: 'settled',
-      taskId: task.id,
-      effects: expect.arrayContaining([
-        expect.objectContaining({ kind: 'dispatch_input', state: 'accepted' })
-      ])
-    })
-    expect(db.getTask(task.id)).toMatchObject({ status: 'completed' })
-  })
 
   it('keeps prompt submission for a non-argv new-worktree agent', async () => {
     mockCreatedWorktree()
@@ -287,13 +57,10 @@ describe('orchestration new-worktree workers', () => {
 
     expect(result).toMatchObject({ state: 'ready' })
     expect(runtime.sendTerminalAgentPrompt).toHaveBeenCalledOnce()
-    expect(runtime.createManagedWorktree).toHaveBeenCalledWith(
-      expect.not.objectContaining({
-        startupPrompt: expect.anything(),
-        startupLaunchToken: expect.anything(),
-        startupPreAllocatedHandle: expect.anything()
-      })
-    )
+    const createOptions = vi.mocked(runtime.createManagedWorktree).mock.calls[0]?.[0]
+    expect(createOptions).not.toHaveProperty('startupPrompt')
+    expect(createOptions).not.toHaveProperty('startupLaunchToken')
+    expect(createOptions).not.toHaveProperty('startupPreAllocatedHandle')
   })
 
   it('passes launch preferences into agent-first worktree creation', async () => {
@@ -356,14 +123,70 @@ describe('orchestration new-worktree workers', () => {
 
   it('injects the execution host CLI command and Dispatch capability together', async () => {
     mockCreatedWorktree()
-    vi.mocked(runtime.getTerminalOrchestrationCliCommand).mockReturnValue('orca-ide')
+    vi.mocked(runtime.getTerminalOrchestrationCliCommand).mockReturnValue('orca')
+    vi.mocked(runtime.getWorktreeOrchestrationCliCommand).mockResolvedValue('orca-ide')
 
     await startWorker({ worktree: 'new-top-level' })
 
-    const prompt = vi.mocked(runtime.createManagedWorktree).mock.calls[0]?.[0].startupPrompt ?? ''
+    const createOptions = vi.mocked(runtime.createManagedWorktree).mock.calls[0]?.[0]
+    const prompt = (await createOptions?.startupPromptFactory?.('repo::created')) ?? ''
     expect(prompt).toContain('orca-ide orchestration send')
     expect(prompt).toMatch(/--dispatch-capability dcap_[A-Za-z0-9_-]+/)
     expect(prompt).not.toMatch(/(^|\s)orca orchestration send/)
+    expect(runtime.getWorktreeOrchestrationCliCommand).toHaveBeenCalledWith('repo::created')
+    expect(runtime.getWorktreeOrchestrationCliCommand).not.toHaveBeenCalledWith('repo::parent')
+    expect(runtime.getTerminalOrchestrationCliCommand).not.toHaveBeenCalled()
+  })
+
+  it('cleans the created worktree when target CLI resolution fails', async () => {
+    mockCreatedWorktree()
+    vi.mocked(runtime.getWorktreeOrchestrationCliCommand).mockRejectedValueOnce(
+      new Error('target runtime unavailable')
+    )
+    const removeWorktree = vi.spyOn(runtime, 'removeManagedWorktree').mockResolvedValue({
+      deleted: true
+    } as never)
+
+    const { result, task } = await startWorker({ worktree: 'new-child' })
+    const dispatchId = (result as { dispatchId: string }).dispatchId
+
+    expect(result).toMatchObject({ state: 'failed', failedStage: 'worktree_create' })
+    expect(removeWorktree).toHaveBeenCalledWith('id:repo::created', true, false, true)
+    expect(db.getTask(task.id)?.status).toBe('failed')
+    expect(db.getDispatchContextById(dispatchId)).toMatchObject({
+      status: 'failed',
+      capability_revoked_at: expect.any(String)
+    })
+    expect(db.getWorkerDispatch(dispatchId)).toMatchObject({
+      state: 'failed',
+      stage: 'worktree_create'
+    })
+    expect(runtime.createTerminal).not.toHaveBeenCalled()
+  })
+
+  it('surfaces startup and cleanup failures while closing the Dispatch', async () => {
+    mockCreatedWorktree()
+    const startupError = new Error('target runtime unavailable')
+    const cleanupError = new Error('worktree cleanup permission denied')
+    vi.mocked(runtime.getWorktreeOrchestrationCliCommand).mockRejectedValueOnce(startupError)
+    const removeWorktree = vi
+      .spyOn(runtime, 'removeManagedWorktree')
+      .mockRejectedValueOnce(cleanupError)
+
+    const { result, task } = await startWorker({ worktree: 'new-child' })
+    const dispatchId = (result as { dispatchId: string }).dispatchId
+    const lastError = (result as { lastError: string }).lastError
+
+    expect(removeWorktree).toHaveBeenCalledWith('id:repo::created', true, false, true)
+    expect(lastError).toContain('repo::created')
+    expect(lastError).toContain(startupError.message)
+    expect(lastError).toContain(cleanupError.message)
+    expect(db.getTask(task.id)?.status).toBe('failed')
+    expect(db.getDispatchContextById(dispatchId)).toMatchObject({ status: 'failed' })
+    expect(db.getWorkerDispatch(dispatchId)).toMatchObject({
+      state: 'failed',
+      stage: 'worktree_create'
+    })
   })
 
   it('passes exact repo, base, metadata, lineage, and setup choices to worktree creation', async () => {
@@ -617,7 +440,7 @@ describe('orchestration new-worktree workers', () => {
       status: 'exited',
       exitCode: 1
     })
-    const durableEffect = await startWorker({ name: 'durable-effect' })
+    const durableEffect = await startWorker({ name: 'durable-effect', agent: 'goose' })
     expect(durableEffect.result).toMatchObject({
       state: 'failed',
       failedStage: 'agent_readiness',

--- a/src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ORCHESTRATION_CONTRACT_VERSION } from '../../../../shared/protocol-version'
 import { OrcaRuntimeService } from '../../orca-runtime'
 import { OrchestrationDb } from '../../orchestration/db'
+import { reconcileLifecycleMessage } from '../../orchestration/lifecycle-reconciliation'
 import { RpcDispatcher } from '../dispatcher'
 import type { RpcRequest } from '../core'
 import { ORCHESTRATION_METHODS } from './orchestration'
@@ -231,6 +232,52 @@ describe('orchestration new-worktree workers', () => {
       )
     ).toHaveLength(1)
     expect(ownedResourceCount((result as { dispatchId: string }).dispatchId)).toBe(1)
+  })
+
+  it('accepts worker_done sent while argv startup is waiting for terminal readiness', async () => {
+    mockCreatedWorktree()
+    vi.mocked(runtime.waitForTerminal).mockImplementationOnce(async () => {
+      const task = db.listTasks()[0]!
+      const dispatch = db.getDispatchContext(task.id)!
+      const message = db.insertMessage({
+        from: 'term_worker',
+        to: `run:${runId}`,
+        subject: 'Completed immediately',
+        type: 'worker_done',
+        payload: JSON.stringify({
+          taskId: task.id,
+          dispatchId: dispatch.id,
+          outcome: 'succeeded'
+        }),
+        senderPaneKey: 'tab_worker:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+        runId
+      })
+
+      expect(reconcileLifecycleMessage(db, message)).toEqual({
+        action: 'completed',
+        taskId: task.id,
+        dispatchId: dispatch.id
+      })
+      return {
+        handle: 'term_worker',
+        condition: 'tui-idle',
+        satisfied: true,
+        status: 'running',
+        exitCode: null
+      }
+    })
+
+    const { result, task } = await startWorker({ worktree: 'new-child' })
+
+    expect(result).toMatchObject({
+      state: 'succeeded',
+      stage: 'settled',
+      taskId: task.id,
+      effects: expect.arrayContaining([
+        expect.objectContaining({ kind: 'dispatch_input', state: 'accepted' })
+      ])
+    })
+    expect(db.getTask(task.id)).toMatchObject({ status: 'completed' })
   })
 
   it('keeps prompt submission for a non-argv new-worktree agent', async () => {

--- a/src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers-new-worktree.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -15,6 +16,7 @@ describe('orchestration new-worktree workers', () => {
   let db: OrchestrationDb
   let runtime: OrcaRuntimeService
   let runId: string
+  let workerLaunchTokenHash: string | null
   const paths: string[] = []
 
   beforeEach(() => {
@@ -26,6 +28,8 @@ describe('orchestration new-worktree workers', () => {
       coordinatorHandle: 'term_coord',
       coordinatorPaneKey
     }).id
+    workerLaunchTokenHash = null
+    vi.spyOn(runtime, 'createPreAllocatedTerminalHandle').mockReturnValue('term_worker')
     vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) =>
       handle === 'term_coord'
         ? coordinatorPaneKey
@@ -35,6 +39,20 @@ describe('orchestration new-worktree workers', () => {
     )
     vi.spyOn(runtime, 'getTerminalProcessIncarnation').mockImplementation((handle) =>
       handle === 'term_worker' ? 'runtime_test:term_worker:1' : null
+    )
+    vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockImplementation((handle) =>
+      handle === 'term_worker' && workerLaunchTokenHash
+        ? ({
+            runtimeId: runtime.getRuntimeId(),
+            terminalHandle: handle,
+            ptyId: 'pty_worker',
+            worktreeId: 'repo::created',
+            paneKey: 'tab_worker:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+            processIncarnation: 'runtime_test:term_worker:1',
+            launchTokenHash: workerLaunchTokenHash,
+            hostScope: { kind: 'local', hostId: 'local' }
+          } as never)
+        : null
     )
     vi.spyOn(runtime, 'validateOrchestrationAgentLauncher').mockImplementation(() => {})
     vi.spyOn(runtime, 'showTerminal').mockResolvedValue({
@@ -101,6 +119,21 @@ describe('orchestration new-worktree workers', () => {
     return { result, task }
   }
 
+  function ownedResourceCount(dispatchId: string): number {
+    const raw = (
+      db as unknown as {
+        db: { prepare: (sql: string) => { get: (...args: unknown[]) => { count: number } } }
+      }
+    ).db
+    return raw
+      .prepare(
+        `SELECT COUNT(*) AS count
+           FROM worker_terminal_resources
+          WHERE owner_dispatch_id = ?`
+      )
+      .get(dispatchId).count
+  }
+
   function mockCreatedWorktree(options?: {
     hookFound?: boolean
     startupPolicy?: 'start-immediately' | 'wait-for-setup'
@@ -110,7 +143,7 @@ describe('orchestration new-worktree workers', () => {
   }) {
     const hookFound = options?.hookFound ?? true
     const state = options?.state ?? (hookFound ? 'running' : 'not_configured')
-    vi.spyOn(runtime, 'createManagedWorktree').mockResolvedValue({
+    const created = {
       worktree: { id: 'repo::created', repoId: 'repo' },
       startupTerminal: { spawned: true, handle: 'term_worker' },
       setupReceipt: {
@@ -122,7 +155,13 @@ describe('orchestration new-worktree workers', () => {
           options?.setupTerminalHandle ??
           options?.terminals?.find((terminal) => terminal.title === 'Setup')?.handle
       }
-    } as never)
+    } as never
+    vi.spyOn(runtime, 'createManagedWorktree').mockImplementation(async (args) => {
+      workerLaunchTokenHash = args.startupLaunchToken
+        ? createHash('sha256').update(args.startupLaunchToken).digest('hex')
+        : null
+      return created
+    })
     if (options?.terminals) {
       vi.mocked(runtime.listTerminals).mockResolvedValue({
         terminals: options.terminals,
@@ -157,12 +196,57 @@ describe('orchestration new-worktree workers', () => {
         expect.objectContaining({
           kind: 'terminal',
           role: 'agent',
-          action: 'reused_agent_terminal',
+          action: 'created',
           id: 'term_worker'
         })
       ])
     )
+    expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
+    expect(vi.mocked(runtime.createManagedWorktree).mock.calls[0]?.[0].startupPrompt).toMatch(
+      /--dispatch-capability dcap_[A-Za-z0-9_-]+/
+    )
+    expect(ownedResourceCount((result as { dispatchId: string }).dispatchId)).toBe(1)
     expect(runtime.createTerminal).not.toHaveBeenCalled()
+  })
+
+  it('launches an argv worker in a new child worktree without prompt submission', async () => {
+    mockCreatedWorktree()
+
+    const { result } = await startWorker({ worktree: 'new-child' })
+
+    expect(result).toMatchObject({ state: 'ready' })
+    expect(runtime.createManagedWorktree).toHaveBeenCalledWith(
+      expect.objectContaining({
+        startupAgent: 'codex',
+        startupPrompt: expect.stringMatching(/--dispatch-capability dcap_[A-Za-z0-9_-]+/),
+        startupLaunchToken: expect.any(String),
+        startupPreAllocatedHandle: 'term_worker',
+        lineage: expect.objectContaining({ parentWorktree: 'repo::parent', noParent: false })
+      })
+    )
+    expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
+    expect(
+      (result as { effects: { kind: string; role?: string; action?: string }[] }).effects.filter(
+        (effect) => effect.kind === 'terminal' && effect.role === 'agent'
+      )
+    ).toHaveLength(1)
+    expect(ownedResourceCount((result as { dispatchId: string }).dispatchId)).toBe(1)
+  })
+
+  it('keeps prompt submission for a non-argv new-worktree agent', async () => {
+    mockCreatedWorktree()
+
+    const { result } = await startWorker({ worktree: 'new-top-level', agent: 'goose' })
+
+    expect(result).toMatchObject({ state: 'ready' })
+    expect(runtime.sendTerminalAgentPrompt).toHaveBeenCalledOnce()
+    expect(runtime.createManagedWorktree).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        startupPrompt: expect.anything(),
+        startupLaunchToken: expect.anything(),
+        startupPreAllocatedHandle: expect.anything()
+      })
+    )
   })
 
   it('passes launch preferences into agent-first worktree creation', async () => {
@@ -229,7 +313,7 @@ describe('orchestration new-worktree workers', () => {
 
     await startWorker({ worktree: 'new-top-level' })
 
-    const prompt = vi.mocked(runtime.sendTerminalAgentPrompt).mock.calls[0]?.[1] ?? ''
+    const prompt = vi.mocked(runtime.createManagedWorktree).mock.calls[0]?.[0].startupPrompt ?? ''
     expect(prompt).toContain('orca-ide orchestration send')
     expect(prompt).toMatch(/--dispatch-capability dcap_[A-Za-z0-9_-]+/)
     expect(prompt).not.toMatch(/(^|\s)orca orchestration send/)
@@ -335,7 +419,7 @@ describe('orchestration new-worktree workers', () => {
         expect.objectContaining({ kind: 'dispatch_input', state: 'accepted' })
       ])
     )
-    expect(runtime.sendTerminalAgentPrompt).toHaveBeenCalledOnce()
+    expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
     expect(db.getInbox(10).filter((message) => message.run_id === runId)).toEqual(
       expect.arrayContaining([expect.objectContaining({ type: 'status', priority: 'high' })])
     )
@@ -380,9 +464,7 @@ describe('orchestration new-worktree workers', () => {
         expect.objectContaining({ kind: 'dispatch_input', state: 'accepted' })
       ])
     })
-    expect(vi.mocked(runtime.waitForTerminal).mock.invocationCallOrder[0]).toBeLessThan(
-      vi.mocked(runtime.sendTerminalAgentPrompt).mock.invocationCallOrder[0]!
-    )
+    expect(runtime.sendTerminalAgentPrompt).not.toHaveBeenCalled()
     expect(JSON.parse(db.getWorkerDispatch(dispatchId)?.effects ?? '[]')).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ kind: 'dispatch_input', state: 'accepted' })
@@ -544,7 +626,7 @@ describe('orchestration new-worktree workers', () => {
         from: 'term_coord',
         worktree: 'new-child',
         name: 'atomic-worker',
-        agent: 'codex'
+        agent: 'goose'
       }
     }
 
@@ -611,7 +693,7 @@ describe('orchestration new-worktree workers', () => {
         from: 'term_coord',
         worktree: 'new-child',
         name: 'recover-input-worker',
-        agent: 'codex'
+        agent: 'goose'
       }
     }
 
@@ -699,7 +781,7 @@ describe('orchestration new-worktree workers', () => {
         })
     )
 
-    const pending = startWorker({ name: 'staged-worker' })
+    const pending = startWorker({ name: 'staged-worker', agent: 'goose' })
     await vi.waitFor(() => {
       const task = db.listTasks()[0]
       const dispatch = task ? db.getDispatchContext(task.id) : undefined

--- a/src/main/runtime/rpc/methods/orchestration-workers.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers.ts
@@ -1,9 +1,11 @@
+import { TUI_AGENT_CONFIG } from '../../../../shared/tui-agent-config'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import { buildDispatchPreamble } from '../../orchestration/preamble'
 import { OrchestrationError } from '../../orchestration/orchestration-error'
 import { defineMethod, type RpcMethod } from '../core'
 import { startFederatedWorker } from './orchestration-federated-worker-start'
 import { assertOrchestrationWorktreeCreationSupported } from './orchestration-folder-worktree-placement'
+import { startArgvWorkerDispatch } from './orchestration-worker-argv-start'
 import { WorkerStartParams } from './orchestration-worker-start-schema'
 import {
   createExistingWorktreeWorkerTerminal,
@@ -181,6 +183,31 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
             worktreeId: resolvedWorktree!.id,
             effects
           })
+          // Why: agents that embed the prompt in their launch argv start the
+          // first turn WITH the process — no paste, no Enter, no submission
+          // verification, no agent_prompt_stalled revocation of a healthy
+          // worker. The whole path lives in orchestration-worker-argv-start.
+          if (agent && TUI_AGENT_CONFIG[agent].promptInjectionMode === 'argv') {
+            return await startArgvWorkerDispatch({
+              runtime,
+              db,
+              runId: run.id,
+              task,
+              dispatchId: started.dispatch.id,
+              coordinatorHandle: params.from,
+              devMode: params.devMode,
+              timeoutMs: params.timeoutMs ?? 60_000,
+              agent,
+              launchPreferences: launch.preferences,
+              launchReceipt: launch.receipt,
+              worktreeId: resolvedWorktree!.id,
+              effects,
+              setupReceipt,
+              onStage: (stage) => {
+                failedStage = stage
+              }
+            })
+          }
           const terminal = await createExistingWorktreeWorkerTerminal({
             runtime,
             worktreeId: resolvedWorktree!.id,

--- a/src/main/runtime/rpc/methods/orchestration-workers.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers.ts
@@ -4,21 +4,16 @@ import { OrchestrationError } from '../../orchestration/orchestration-error'
 import { defineMethod, type RpcMethod } from '../core'
 import { startFederatedWorker } from './orchestration-federated-worker-start'
 import { assertOrchestrationWorktreeCreationSupported } from './orchestration-folder-worktree-placement'
-import { attachWorkerAuthority, resolveArgvWorktreeLaunch } from './orchestration-worker-authority'
+import { resolveArgvWorktreeLaunch } from './orchestration-worker-authority'
 import { startArgvWorkerDispatch } from './orchestration-worker-argv-start'
+import { attachWorkerAndAwaitReadiness } from './orchestration-worker-readiness'
 import { WorkerStartParams } from './orchestration-worker-start-schema'
 import {
   createExistingWorktreeWorkerTerminal,
   createWorkerWorktree,
-  monitorWorkerSetup,
   type WorkerEffect,
   type WorkerSetupReceipt
 } from './orchestration-worker-topology'
-import {
-  persistGatedSetupSpawnFailure,
-  persistWorkerReadinessStage,
-  persistWorkerSetupWaitOutcome
-} from './orchestration-worker-setup-gate'
 import { failWorkerStartWithReceipt } from './orchestration-worker-start-receipt'
 import { prepareLocalWorkerStart } from './orchestration-worker-start-validation'
 import { resolveDispatchCreator } from './orchestration-dispatch-creator'
@@ -205,7 +200,7 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
               dispatchId: started.dispatch.id,
               coordinatorHandle: params.from,
               devMode: params.devMode,
-              timeoutMs: params.timeoutMs ?? 60_000,
+              timeoutMs: readinessTimeoutMs,
               agent,
               launchPreferences: launch.preferences,
               launchReceipt: launch.receipt,
@@ -238,65 +233,24 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
         if (!resolvedWorktree || !terminalHandle) {
           throw new Error('Worker topology did not resolve an agent terminal and worktree.')
         }
-        const setupStage = {
-          db,
-          dispatchId: started.dispatch.id,
-          worktreeId: resolvedWorktree.id,
-          terminalHandle,
-          setup: setupReceipt,
-          effects
-        }
-        if (persistGatedSetupSpawnFailure(setupStage)) {
-          failedStage = 'setup_start'
-          throw new Error('Setup terminal failed to start before the gated agent launch.')
-        }
-        persistWorkerReadinessStage(setupStage)
-
-        failedStage = 'agent_readiness'
-        const wait = await runtime.waitForTerminal(terminalHandle, {
-          condition: 'tui-idle',
-          timeoutMs: readinessTimeoutMs
-        })
-        persistWorkerSetupWaitOutcome({ ...setupStage, wait })
-        if (!wait.satisfied) {
-          if (setupReceipt.state === 'failed') {
-            failedStage = 'setup_wait'
-          }
-          throw new Error(
-            wait.blockedReason
-              ? `Agent startup blocked: ${wait.blockedReason}`
-              : `Agent did not become ready (${wait.status}).`
-          )
-        }
-        failedStage = argvWorktreeLaunch ? failedStage : 'dispatch_input'
-        await attachWorkerAuthority({
-          runtime,
-          db,
-          dispatchId: started.dispatch.id,
-          terminalHandle,
-          worktreeId: resolvedWorktree.id,
-          effects,
-          setupState: setupReceipt.state,
-          terminalOwnership: params.terminal ? 'external' : 'created',
-          task,
-          coordinatorHandle: params.from,
-          devMode: params.devMode,
-          argv: Boolean(argvWorktreeLaunch)
-        })
-        effects.push({
-          kind: 'dispatch_input',
-          role: 'agent',
-          id: terminalHandle,
-          state: 'accepted'
-        })
-        const worker = db.markWorkerDispatchReady(started.dispatch.id, effects)
-        monitorWorkerSetup({
+        const worker = await attachWorkerAndAwaitReadiness({
           runtime,
           db,
           runId: run.id,
           dispatchId: started.dispatch.id,
+          terminalHandle,
+          worktreeId: resolvedWorktree.id,
+          effects,
           setupReceipt,
-          effects
+          terminalOwnership: params.terminal ? 'external' : 'created',
+          task,
+          coordinatorHandle: params.from,
+          devMode: params.devMode,
+          argv: Boolean(argvWorktreeLaunch),
+          timeoutMs: readinessTimeoutMs,
+          onStage: (stage) => {
+            failedStage = stage
+          }
         })
         return {
           runId: run.id,

--- a/src/main/runtime/rpc/methods/orchestration-workers.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers.ts
@@ -1,17 +1,16 @@
 import { TUI_AGENT_CONFIG } from '../../../../shared/tui-agent-config'
 import type { TuiAgent } from '../../../../shared/tui-agent'
-import { buildDispatchPreamble } from '../../orchestration/preamble'
 import { OrchestrationError } from '../../orchestration/orchestration-error'
 import { defineMethod, type RpcMethod } from '../core'
 import { startFederatedWorker } from './orchestration-federated-worker-start'
 import { assertOrchestrationWorktreeCreationSupported } from './orchestration-folder-worktree-placement'
+import { attachWorkerAuthority, resolveArgvWorktreeLaunch } from './orchestration-worker-authority'
 import { startArgvWorkerDispatch } from './orchestration-worker-argv-start'
 import { WorkerStartParams } from './orchestration-worker-start-schema'
 import {
   createExistingWorktreeWorkerTerminal,
   createWorkerWorktree,
   monitorWorkerSetup,
-  requireWorkerAuthority,
   type WorkerEffect,
   type WorkerSetupReceipt
 } from './orchestration-worker-topology'
@@ -142,6 +141,17 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
         mutationReceipt: orchestrationMutation
       })
       const effects: WorkerEffect[] = []
+      const argvWorktreeLaunch = resolveArgvWorktreeLaunch({
+        creationWorktree: Boolean(creationWorktree),
+        agent,
+        runtime,
+        db,
+        task,
+        dispatchId: started.dispatch.id,
+        coordinatorHandle: params.from,
+        devMode: params.devMode,
+        effects
+      })
       if (resolvedWorktree) {
         effects.push(
           { kind: 'worktree', action: 'reused', id: resolvedWorktree.id },
@@ -171,11 +181,14 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
             params,
             agent: agent as TuiAgent,
             launchPreferences: launch.preferences,
+            argvWorktreeLaunch,
             effects
           })
           resolvedWorktree = created.worktree
           terminalHandle = created.terminalHandle
           setupReceipt = created.setupReceipt
+          failedStage = argvWorktreeLaunch ? 'authority_bind' : failedStage
+          argvWorktreeLaunch?.assertTerminalHandle(terminalHandle)
         } else if (!terminalHandle) {
           db.recordWorkerStage({
             dispatchId: started.dispatch.id,
@@ -183,10 +196,6 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
             worktreeId: resolvedWorktree!.id,
             effects
           })
-          // Why: agents that embed the prompt in their launch argv start the
-          // first turn WITH the process — no paste, no Enter, no submission
-          // verification, no agent_prompt_stalled revocation of a healthy
-          // worker. The whole path lives in orchestration-worker-argv-start.
           if (agent && TUI_AGENT_CONFIG[agent].promptInjectionMode === 'argv') {
             return await startArgvWorkerDispatch({
               runtime,
@@ -259,30 +268,21 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
               : `Agent did not become ready (${wait.status}).`
           )
         }
-        const terminalAuthority = requireWorkerAuthority(runtime, terminalHandle)
-        const capability = db.prepareStartingWorkerAuthority({
+        failedStage = argvWorktreeLaunch ? failedStage : 'dispatch_input'
+        await attachWorkerAuthority({
+          runtime,
+          db,
           dispatchId: started.dispatch.id,
-          handle: terminalHandle,
-          ...terminalAuthority,
+          terminalHandle,
           worktreeId: resolvedWorktree.id,
           effects,
           setupState: setupReceipt.state,
-          terminalOwnership: params.terminal ? 'external' : 'created'
-        })
-
-        failedStage = 'dispatch_input'
-        const preamble = buildDispatchPreamble({
-          canDispatchSubWorkers: started.dispatch.depth < runtime.getNestedWorkerMaxDepth(),
-          taskId: task.id,
-          dispatchId: started.dispatch.id,
-          taskSpec: task.spec,
+          terminalOwnership: params.terminal ? 'external' : 'created',
+          task,
           coordinatorHandle: params.from,
-          workerHandle: terminalHandle,
-          dispatchCapability: capability,
           devMode: params.devMode,
-          cliCommand: runtime.getTerminalOrchestrationCliCommand(terminalHandle)
+          argv: Boolean(argvWorktreeLaunch)
         })
-        await runtime.sendTerminalAgentPrompt(terminalHandle, preamble)
         effects.push({
           kind: 'dispatch_input',
           role: 'agent',

--- a/src/main/runtime/rpc/terminal-output-frame-chunks-equivalence.test.ts
+++ b/src/main/runtime/rpc/terminal-output-frame-chunks-equivalence.test.ts
@@ -485,16 +485,24 @@ describe('iterateTerminalOutputFrameChunks equivalence with the pre-optimization
     }
   })
 
-  it('fuzzes 800 near-cap payloads whose split point lands in the random region', () => {
-    const random = makeRandom(0x1234_5eed)
-    for (let trial = 0; trial < 800; trial += 1) {
-      const fillerLength = TERMINAL_STREAM_CHUNK_BYTES - 6 + Math.floor(random() * 12)
-      const data = 'q'.repeat(fillerLength) + randomText(random, 1 + Math.floor(random() * 24))
-      expectEquivalent(data, undefined, `fuzz-cap trial=${trial}`)
-      expectEquivalent(data, { seq: 88_888, rawLength: data.length }, `fuzz-cap seq trial=${trial}`)
-      expectEquivalent(data, { seq: 88_888 }, `fuzz-cap delayed trial=${trial}`)
+  it(
+    'fuzzes 800 near-cap payloads whose split point lands in the random region',
+    { timeout: 60_000 },
+    () => {
+      const random = makeRandom(0x1234_5eed)
+      for (let trial = 0; trial < 800; trial += 1) {
+        const fillerLength = TERMINAL_STREAM_CHUNK_BYTES - 6 + Math.floor(random() * 12)
+        const data = 'q'.repeat(fillerLength) + randomText(random, 1 + Math.floor(random() * 24))
+        expectEquivalent(data, undefined, `fuzz-cap trial=${trial}`)
+        expectEquivalent(
+          data,
+          { seq: 88_888, rawLength: data.length },
+          `fuzz-cap seq trial=${trial}`
+        )
+        expectEquivalent(data, { seq: 88_888 }, `fuzz-cap delayed trial=${trial}`)
+      }
     }
-  }, 30_000)
+  )
 
   it('keeps every emitted frame within the wire cap and reassembles to the input', () => {
     const data = `${'a'.repeat(200 * 1024)}${SURROGATE_PAIR.repeat(4096)}${LONE_HIGH}`

--- a/src/main/runtime/rpc/terminal-output-frame-chunks-equivalence.test.ts
+++ b/src/main/runtime/rpc/terminal-output-frame-chunks-equivalence.test.ts
@@ -485,24 +485,16 @@ describe('iterateTerminalOutputFrameChunks equivalence with the pre-optimization
     }
   })
 
-  it(
-    'fuzzes 800 near-cap payloads whose split point lands in the random region',
-    { timeout: 60_000 },
-    () => {
-      const random = makeRandom(0x1234_5eed)
-      for (let trial = 0; trial < 800; trial += 1) {
-        const fillerLength = TERMINAL_STREAM_CHUNK_BYTES - 6 + Math.floor(random() * 12)
-        const data = 'q'.repeat(fillerLength) + randomText(random, 1 + Math.floor(random() * 24))
-        expectEquivalent(data, undefined, `fuzz-cap trial=${trial}`)
-        expectEquivalent(
-          data,
-          { seq: 88_888, rawLength: data.length },
-          `fuzz-cap seq trial=${trial}`
-        )
-        expectEquivalent(data, { seq: 88_888 }, `fuzz-cap delayed trial=${trial}`)
-      }
+  it('fuzzes 800 near-cap payloads whose split point lands in the random region', () => {
+    const random = makeRandom(0x1234_5eed)
+    for (let trial = 0; trial < 800; trial += 1) {
+      const fillerLength = TERMINAL_STREAM_CHUNK_BYTES - 6 + Math.floor(random() * 12)
+      const data = 'q'.repeat(fillerLength) + randomText(random, 1 + Math.floor(random() * 24))
+      expectEquivalent(data, undefined, `fuzz-cap trial=${trial}`)
+      expectEquivalent(data, { seq: 88_888, rawLength: data.length }, `fuzz-cap seq trial=${trial}`)
+      expectEquivalent(data, { seq: 88_888 }, `fuzz-cap delayed trial=${trial}`)
     }
-  )
+  }, 30_000)
 
   it('keeps every emitted frame within the wire cap and reassembles to the input', () => {
     const data = `${'a'.repeat(200 * 1024)}${SURROGATE_PAIR.repeat(4096)}${LONE_HIGH}`

--- a/src/main/runtime/runtime-local-worktree-terminal-startup.ts
+++ b/src/main/runtime/runtime-local-worktree-terminal-startup.ts
@@ -107,7 +107,6 @@ export async function startRuntimeLocalWorktreeTerminals(args: {
         ...(request.startupPreAllocatedHandle
           ? { preAllocatedHandle: request.startupPreAllocatedHandle }
           : {}),
-        ...(request.startupPrompt ? { agentPrompt: request.startupPrompt } : {}),
         ...(sequencedStartup.viewMode ? { viewMode: sequencedStartup.viewMode } : {}),
         startupCommandDelivery: sequencedStartup.startupCommandDelivery,
         telemetry: sequencedStartup.telemetry,

--- a/src/main/runtime/runtime-local-worktree-terminal-startup.ts
+++ b/src/main/runtime/runtime-local-worktree-terminal-startup.ts
@@ -103,6 +103,11 @@ export async function startRuntimeLocalWorktreeTerminals(args: {
         env: sequencedStartup.env,
         ...(sequencedStartup.launchConfig ? { launchConfig: sequencedStartup.launchConfig } : {}),
         ...(args.createdWithAgent ? { launchAgent: args.createdWithAgent } : {}),
+        ...(request.startupLaunchToken ? { launchToken: request.startupLaunchToken } : {}),
+        ...(request.startupPreAllocatedHandle
+          ? { preAllocatedHandle: request.startupPreAllocatedHandle }
+          : {}),
+        ...(request.startupPrompt ? { agentPrompt: request.startupPrompt } : {}),
         ...(sequencedStartup.viewMode ? { viewMode: sequencedStartup.viewMode } : {}),
         startupCommandDelivery: sequencedStartup.startupCommandDelivery,
         telemetry: sequencedStartup.telemetry,

--- a/src/main/runtime/runtime-managed-worktree-create-types.ts
+++ b/src/main/runtime/runtime-managed-worktree-create-types.ts
@@ -51,6 +51,7 @@ export type RuntimeManagedWorktreeCreateArgs = {
   startupAgent?: TuiAgent
   startupLaunchPreferences?: AgentLaunchPreferences
   startupPrompt?: string
+  startupPromptFactory?: (worktreeId: string) => Promise<string>
   startupLaunchToken?: string
   startupPreAllocatedHandle?: string
   pendingFirstAgentMessageRename?: boolean

--- a/src/main/runtime/runtime-managed-worktree-create-types.ts
+++ b/src/main/runtime/runtime-managed-worktree-create-types.ts
@@ -51,6 +51,8 @@ export type RuntimeManagedWorktreeCreateArgs = {
   startupAgent?: TuiAgent
   startupLaunchPreferences?: AgentLaunchPreferences
   startupPrompt?: string
+  startupLaunchToken?: string
+  startupPreAllocatedHandle?: string
   pendingFirstAgentMessageRename?: boolean
   automationProvenance?: AutomationWorkspaceProvenance
   cliProvenance?: CliWorkspaceProvenance

--- a/src/main/runtime/runtime-remote-managed-worktree-create.ts
+++ b/src/main/runtime/runtime-remote-managed-worktree-create.ts
@@ -44,6 +44,15 @@ type Dependencies = {
     startup?: RuntimeRemoteWorktreeCreateArgs['startup'],
     defaultTabs?: CreateWorktreeResult['defaultTabs']
   ): void
+  // Why: an argv worker prompt names the worktree it runs in, so the remote path
+  // can only build the launch after the create returns an id.
+  resolveDeferredStartup?(worktreeId: string): Promise<
+    | {
+        startup: RuntimeRemoteWorktreeCreateArgs['startup']
+        followup?: WorktreeStartupFollowup
+      }
+    | undefined
+  >
   invalidateResolvedWorktrees(): void
   invalidateWorktreeScan(repoId: string): void
   notifyWorktreesChanged(repoId: string): void
@@ -84,20 +93,30 @@ export async function createRuntimeRemoteManagedWorktree(
   let startupTerminalPaneKey: string | null = null
   let startupTerminalPtyId: string | null = null
 
-  let sequencedStartup = args.startup
+  let effectiveStartup = args.startup
+  let effectiveStartupFollowup = args.startupFollowup
+  if (!effectiveStartup && args.startupPromptFactory && args.startupAgent) {
+    const deferred = await deps.resolveDeferredStartup?.(result.worktree.id)
+    effectiveStartup = deferred?.startup
+    effectiveStartupFollowup = deferred?.followup
+  }
+
+  let sequencedStartup = effectiveStartup
   let wrappedSetupCommandStr: string | undefined
-  if (args.startup && result.setup?.waitForAgentStartup === true) {
+  if (effectiveStartup && result.setup?.waitForAgentStartup === true) {
     const platform = setupPlatform(result.setup)
     const sequenced = createSequencedSetupAgentCommands({
       runnerScriptPath: result.setup.runnerScriptPath,
-      startupCommand: args.startup.command,
+      startupCommand: effectiveStartup.command,
       platform,
       shell: result.setup.shell
     })
     sequencedStartup = {
-      ...args.startup,
+      ...effectiveStartup,
       command: sequenced.startupCommand,
-      ...(sequenced.startupEnv ? { env: { ...args.startup.env, ...sequenced.startupEnv } } : {})
+      ...(sequenced.startupEnv
+        ? { env: { ...effectiveStartup.env, ...sequenced.startupEnv } }
+        : {})
     }
     wrappedSetupCommandStr = sequenced.setupCommand
   }
@@ -110,8 +129,8 @@ export async function createRuntimeRemoteManagedWorktree(
       }
       const terminal = await deps.createTerminal(`path:${result.worktree.path}`, {
         command: sequencedStartup.command,
-        ...(result.setup && args.startup
-          ? { claudeAgentTeamsSourceCommand: args.startup.command }
+        ...(result.setup && effectiveStartup
+          ? { claudeAgentTeamsSourceCommand: effectiveStartup.command }
           : {}),
         env: sequencedStartup.env,
         ...(sequencedStartup.launchConfig ? { launchConfig: sequencedStartup.launchConfig } : {}),
@@ -128,8 +147,8 @@ export async function createRuntimeRemoteManagedWorktree(
       if (args.startupDraftPaste) {
         deps.pasteDraft(terminal.handle, args.startupDraftPaste)
       }
-      if (args.startupFollowup) {
-        deps.sendFollowup(terminal.handle, args.startupFollowup)
+      if (effectiveStartupFollowup) {
+        deps.sendFollowup(terminal.handle, effectiveStartupFollowup)
       }
       didSpawnStartup = true
       startupTerminalHandle = terminal.handle
@@ -181,12 +200,12 @@ export async function createRuntimeRemoteManagedWorktree(
           }
         : undefined
     const activationDefaultTabs = runtimeWillProvisionTerminals ? undefined : result.defaultTabs
-    if (args.startup && !didSpawnStartup) {
+    if (effectiveStartup && !didSpawnStartup) {
       deps.activate(
         repo.id,
         result.worktree.id,
         activationSetup,
-        args.startup,
+        effectiveStartup,
         activationDefaultTabs
       )
     } else {

--- a/src/main/runtime/runtime-remote-managed-worktree-create.ts
+++ b/src/main/runtime/runtime-remote-managed-worktree-create.ts
@@ -116,6 +116,10 @@ export async function createRuntimeRemoteManagedWorktree(
         env: sequencedStartup.env,
         ...(sequencedStartup.launchConfig ? { launchConfig: sequencedStartup.launchConfig } : {}),
         ...(args.createdWithAgent ? { launchAgent: args.createdWithAgent } : {}),
+        ...(args.startupLaunchToken ? { launchToken: args.startupLaunchToken } : {}),
+        ...(args.startupPreAllocatedHandle
+          ? { preAllocatedHandle: args.startupPreAllocatedHandle }
+          : {}),
         ...(sequencedStartup.viewMode ? { viewMode: sequencedStartup.viewMode } : {}),
         startupCommandDelivery: sequencedStartup.startupCommandDelivery,
         telemetry: sequencedStartup.telemetry,

--- a/src/main/runtime/runtime-terminal-contracts.ts
+++ b/src/main/runtime/runtime-terminal-contracts.ts
@@ -29,6 +29,11 @@ export type TerminalCreateOptions = {
   launchToken?: string
   launchAgent?: TuiAgent
   startupAgent?: TuiAgent
+  // Why: only meaningful with startupAgent. The prompt is embedded in the
+  // agent's launch (argv/flag per promptInjectionMode) so the first turn
+  // starts with the process — no paste, no submission verification. Agents
+  // whose plan would defer the prompt to a post-start paste are refused.
+  agentPrompt?: string
   launchPreferences?: AgentLaunchPreferences
   terminalColorQueryReplies?: TerminalOscColorQueryReplyColors
   viewMode?: 'terminal' | 'chat'

--- a/tests/e2e/completed-worker-retirement-resume.spec.ts
+++ b/tests/e2e/completed-worker-retirement-resume.spec.ts
@@ -269,7 +269,7 @@ for (const closeMode of ['terminal-close-cli', 'worker-release'] as const) {
 
     const expectedRecovery = {
       origin: 'live',
-      state: 'working',
+      state: 'done',
       providerSessionId: PROVIDER_SESSION_ID
     }
     await expect

--- a/tests/e2e/completed-worker-retirement-resume.spec.ts
+++ b/tests/e2e/completed-worker-retirement-resume.spec.ts
@@ -487,6 +487,7 @@ for (const closeMode of ['terminal-close-cli', 'worker-release'] as const) {
     await expect
       .poll(() => orcaPage.evaluate(() => window.__store?.getState().activeWorktreeId))
       .toBe(targetWorktreeId)
+    await ensureTerminalVisible(orcaPage)
     await waitForActiveTerminalManager(orcaPage)
     await waitForActivePanePtyId(orcaPage)
     const activatedPane = await waitForActivePaneHookDescriptor(orcaPage)

--- a/tests/e2e/helpers/completed-worker-retirement-fixture.ts
+++ b/tests/e2e/helpers/completed-worker-retirement-fixture.ts
@@ -33,9 +33,19 @@ if (args.includes('app-server')) {
   process.stderr.write("error: unrecognized subcommand 'app-server'\\n")
   process.exit(2)
 }
+let acknowledged = false
+const argvPreamble = args.find((argument) =>
+  argument.includes('You are working inside Orca, a multi-agent IDE. You are a dispatched worker.')
+)
 append({ event: 'spawn', args })
 process.stdout.write('\\u001b]0;Codex Ready\\u0007OpenAI Codex\\nmodel: e2e\\ndirectory: e2e\\n')
 ${FAKE_AGENT_PASTE_END_SCANNER_SOURCE}
+if (argvPreamble) {
+  acknowledged = true
+  append({ event: 'ack', mode: 'bracketed' })
+  process.stdout.write('\\u001b]0;Codex Working\\u0007ACK\\n')
+  setTimeout(() => process.stdout.write('\\u001b]0;Codex Ready\\u0007'), 10)
+}
 process.stdin.on('data', (chunk) => {
   const input = chunk.toString()
   const pasteEndScan = scanFakeAgentPasteEnd(fakeAgentPasteEndTail, input)
@@ -48,12 +58,15 @@ process.stdin.on('data', (chunk) => {
     append({ event: 'normal-exit' })
     process.exit(0)
   }
-  fakeAgentMaybeAck(pasteEndScan, input, (mode) => {
-    append({ event: 'ack', mode })
-    const message = mode === 'bracketed' ? 'ACK' : 'PASTE_PROTOCOL_ERROR'
-    process.stdout.write('\\u001b]0;Codex Working\\u0007' + message + '\\n')
-    setTimeout(() => process.stdout.write('\\u001b]0;Codex Ready\\u0007'), 10)
-  })
+  if (!acknowledged) {
+    fakeAgentMaybeAck(pasteEndScan, input, (mode) => {
+      acknowledged = true
+      append({ event: 'ack', mode })
+      const message = mode === 'bracketed' ? 'ACK' : 'PASTE_PROTOCOL_ERROR'
+      process.stdout.write('\\u001b]0;Codex Working\\u0007' + message + '\\n')
+      setTimeout(() => process.stdout.write('\\u001b]0;Codex Ready\\u0007'), 10)
+    })
+  }
 })
 process.stdin.setRawMode?.(true)
 process.stdin.resume()
@@ -115,6 +128,14 @@ export function readCompletedWorkerLedger(): LifecycleEvent[] {
 }
 
 export function readCompletedWorkerDispatchCapability(): string | null {
+  const argv = readCompletedWorkerLedger()
+    .filter((event) => event.event === 'spawn')
+    .flatMap((event) => event.args ?? [])
+    .join(' ')
+  const argvCapability = argv.match(/--dispatch-capability\s+(\S+)/)?.[1]
+  if (argvCapability) {
+    return argvCapability
+  }
   const input = readCompletedWorkerLedger()
     .filter((event) => event.event === 'input')
     .map((event) => event.input ?? '')

--- a/tests/e2e/orchestration-worker-settlement-release-cli.spec.ts
+++ b/tests/e2e/orchestration-worker-settlement-release-cli.spec.ts
@@ -30,7 +30,16 @@ if (process.argv.slice(2).includes('app-server')) {
 let capability = null
 let acknowledged = false
 ${FAKE_AGENT_PASTE_END_SCANNER_SOURCE}
+const argvPreamble = process.argv.slice(2).find((argument) =>
+  argument.includes('You are working inside Orca, a multi-agent IDE. You are a dispatched worker.')
+)
 process.stdout.write('\\u001b]0;Codex Ready\\u0007OpenAI Codex\\nmodel: e2e\\ndirectory: e2e\\n')
+if (argvPreamble) {
+  capability = argvPreamble.match(/--dispatch-capability (dcap_[A-Za-z0-9_-]+)/)?.[1] || null
+  acknowledged = true
+  process.stdout.write('\\u001b]0;Codex Working\\u0007ACK\\n')
+  setTimeout(() => process.stdout.write('\\u001b]0;Codex Ready\\u0007'), 10)
+}
 process.stdin.on('data', (chunk) => {
   const input = chunk.toString()
   const pasteEndScan = scanFakeAgentPasteEnd(fakeAgentPasteEndTail, input)

--- a/tests/e2e/orchestration-worker-settlement-release-cli.spec.ts
+++ b/tests/e2e/orchestration-worker-settlement-release-cli.spec.ts
@@ -33,10 +33,21 @@ ${FAKE_AGENT_PASTE_END_SCANNER_SOURCE}
 const argvPreamble = process.argv.slice(2).find((argument) =>
   argument.includes('You are working inside Orca, a multi-agent IDE. You are a dispatched worker.')
 )
-process.stdout.write('\\u001b]0;Codex Ready\\u0007OpenAI Codex\\nmodel: e2e\\ndirectory: e2e\\n')
 if (argvPreamble) {
-  capability = argvPreamble.match(/--dispatch-capability (dcap_[A-Za-z0-9_-]+)/)?.[1] || null
+  const argvCapability = argvPreamble.match(/--dispatch-capability (dcap_[A-Za-z0-9_-]+)/)?.[1] || null
+  const hasTaskMarker =
+    /Your task ID is: \\S+/.test(argvPreamble) && /--task-id \\S+/.test(argvPreamble)
+  const hasDispatchMarker = /--dispatch-id \\S+/.test(argvPreamble)
+  const hasTaskSection = argvPreamble.includes('=== TASK ===')
+  if (!argvCapability || !hasTaskMarker || !hasDispatchMarker || !hasTaskSection) {
+    process.stderr.write('argv worker preamble is incomplete\\n')
+    process.exit(3)
+  }
+  capability = argvCapability
   acknowledged = true
+}
+process.stdout.write('\\u001b]0;Codex Ready\\u0007OpenAI Codex\\nmodel: e2e\\ndirectory: e2e\\n')
+if (acknowledged) {
   process.stdout.write('\\u001b]0;Codex Working\\u0007ACK\\n')
   setTimeout(() => process.stdout.write('\\u001b]0;Codex Ready\\u0007'), 10)
 }


### PR DESCRIPTION
## ELI5

Orca now starts argv-capable orchestration workers with their instructions and launch credentials already attached to the process command. It binds the exact terminal before readiness monitoring, so a healthy worker is not mistaken for a stalled worker and stripped of its capability while it is still running.

## What Changed

- Start argv-capable workers with the orchestration preamble embedded in the process command.
- Require a durable launch-token commitment before terminal creation.
- Mint one capability/handle/token set per dispatch and reuse the same authority contract across existing and new worktrees.
- Persist exact terminal ownership before setup, authority binding, or readiness can fail.
- Bind authority before readiness monitoring, including immediate `worker_done`.
- Preserve a ready worker and publish durable status when argv readiness is not observed, with or without a provider-specific blocked reason.
- Resolve the orchestration CLI only after the actual worker worktree ID exists, using the execution scope of that worktree rather than the coordinator.
- Roll back a created worktree when deferred startup construction fails, preserving startup and cleanup causes when rollback also fails.
- Preserve paste delivery for agents without argv startup support.
- Remove inert new-worktree `agentPrompt` forwarding and strengthen absence assertions.
- Add regression coverage for authority, new worktrees, cross-scope command selection, release/recovery, and settlement.
- Restore the frame-chunk fuzz test exactly to the upstream `main` contract; it is no longer part of this PR diff.

## Why

The previous startup sequence could launch a real worker, then time out while observing readiness. Orca revoked the dispatch capability even though the worker had already received its launch brief, so a valid later `worker_done` was rejected and resources could remain retained.

The corrected sequence makes startup transactional: the launch commitment exists before spawn, the returned terminal must match the preallocated handle, ownership is durable before later failure points, and an argv worker that already received its brief remains authorized while readiness diagnostics are surfaced.

## Linked Issue

Fixes #16377

Related: #15920, #15976, #16095

This preserves the original contribution from #16425 and adds the authority, ownership, new-worktree, cross-host, and cleanup corrections found during verification.

## Visual Proof

N/A — this changes orchestration startup, terminal authority, worktree cleanup, and recovery behavior. It has no visual UI surface.

## Testing

- [x] Focused orchestration/runtime suite after rebase: 1,329 passed, 1 skipped across 10 files.
- [x] Current-worktree readiness regression: 19/19 passed.
- [x] Strengthened scratch contract: 20/20 passed.
- [x] Reversion mutant for the readiness guard/fallback was killed.
- [x] Electron settlement/release and completed-retirement E2E after rebase: 3/3 passed with temporary repository cleanup.
- [x] Node 24 `typecheck:node`: PASS.
- [x] Changed-code quality: 0 findings, including type-aware analysis and React Doctor.
- [x] Oxfmt and `git diff --check`: PASS.
- [x] Pre-commit hook: PASS with no max-lines disable.
- [x] Independent Verifier: PASS on remediation HEAD `4e4faf6e60`.
- [ ] Native Linux, Windows, WSL, and SSH E2E were not available locally. Cross-scope selection is covered by unit/runtime tests and remains subject to upstream CI.

## AI Disclosure

This PR was developed with AI coding assistance. The submitting account owner directed the scope and explicitly authorized publication. Automated gates and fresh independent Verifier sessions were used to challenge the implementation, including fault-injection sensors.

## Review

The review covered:

- Correctness: readiness timeout, immediate completion, startup failure, release, recovery, and unknown outcomes.
- Security: launch-token commitment, capability uniqueness, exact terminal-handle matching, and authority binding order.
- Local/folder/remote execution: deferred startup uses the created worker worktree ID before terminal spawn.
- SSH and remote behavior: execution-host ownership is preserved and no RPC or wire schema changed.
- Agent compatibility: argv-capable agents use embedded startup input; non-argv agents retain paste delivery.
- Cleanup: deferred startup failures attempt exact worktree removal; combined startup/cleanup failures retain the worktree ID and both causes.
- Performance: no readiness-window extension and no unrelated fuzz timeout change.
- UI: no renderer or visual behavior changed.

## Agent skill upstream boundary

- [x] Not applicable. This PR does not copy or translate upstream skill-installer source, fixtures, registry entries, or documentation.

## Notes

- The frame-chunk fuzz file has zero diff from the current upstream base.
- CodeRabbit docstring coverage is a heuristic, not a configured repository gate. New comments document only non-obvious authority, host-scope, and cleanup contracts, following the repository concise-comment rule.
- Release/version changes are intentionally omitted; maintainers control releases.
- No deploy, production mutation, database migration, force-push, or direct push to `main` is included.
- This PR supersedes #16425.

## Checklist

- [x] The change is focused on one orchestration startup defect and its required lifecycle contracts.
- [x] The behavior and motivation are explained in plain language.
- [x] Visual proof is marked N/A with a reason.
- [x] Correctness, security, performance, cross-platform, SSH/remote, and agent integration were reviewed.
- [x] Tests were added or strengthened for every remediated finding.
- [x] Local typecheck, focused tests, quality, formatting, build, E2E, and pre-commit gates are recorded above.
- [x] No unrelated production behavior or compatibility shim was added.