### PR TITLE
fix: sync tab-cycle shortcuts with rendered group order

### DIFF
--- a/src/renderer/src/components/tab-bar/group-tab-order.test.ts
+++ b/src/renderer/src/components/tab-bar/group-tab-order.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { Tab, TabGroup } from '../../../../shared/tab-types'
 import type { AppState } from '../../store/types'
 import { getActiveTabNavOrder, getGroupVisibleTabOrder } from './group-tab-order'
+import { buildOrderedTabItems } from './tab-bar-item-model'
 
 function terminalTab(id: string, groupId: string, entityId: string, sortOrder: number): Tab {
   return {
@@ -188,6 +189,74 @@ describe('getGroupVisibleTabOrder', () => {
       { type: 'editor', id: '/repo/file.md', tabId: 'tab-e1' }
     ])
   })
+
+  it('matches the strip lookup when duplicate entities resolve to the last tab copy', () => {
+    const group: TabGroup = {
+      id: 'g1',
+      worktreeId: 'wt',
+      activeTabId: 'tab-t2',
+      tabOrder: ['tab-t1', 'tab-t2']
+    }
+    const tabs: Tab[] = [
+      terminalTab('tab-t1', 'g1', 'term-1', 0),
+      terminalTab('tab-t2', 'g1', 'term-1', 1)
+    ]
+
+    expect(getGroupVisibleTabOrder(group, tabs, new Set(['term-1']), new Set(), new Set())).toEqual(
+      [{ type: 'terminal', id: 'term-1', tabId: 'tab-t2' }]
+    )
+  })
+
+  it('uses terminal precedence when visible ids collide across content types', () => {
+    const group: TabGroup = {
+      id: 'g1',
+      worktreeId: 'wt',
+      activeTabId: 'tab-t1',
+      tabOrder: ['tab-b1', 'tab-t1']
+    }
+    const tabs: Tab[] = [
+      browserTab('tab-b1', 'g1', 'collision', 0),
+      terminalTab('tab-t1', 'g1', 'collision', 1)
+    ]
+
+    expect(
+      getGroupVisibleTabOrder(
+        group,
+        tabs,
+        new Set(['collision']),
+        new Set(),
+        new Set(['collision'])
+      )
+    ).toEqual([{ type: 'terminal', id: 'collision', tabId: 'tab-t1' }])
+  })
+
+  it('can preserve cross-type ids for mobile publication compatibility', () => {
+    const group: TabGroup = {
+      id: 'g1',
+      worktreeId: 'wt',
+      activeTabId: 'tab-b1',
+      tabOrder: ['tab-b1', 'tab-t1']
+    }
+    const tabs: Tab[] = [
+      browserTab('tab-b1', 'g1', 'collision', 0),
+      terminalTab('tab-t1', 'g1', 'collision', 1)
+    ]
+
+    expect(
+      getGroupVisibleTabOrder(
+        group,
+        tabs,
+        new Set(['collision']),
+        new Set(),
+        new Set(['collision']),
+        new Set(),
+        true
+      )
+    ).toEqual([
+      { type: 'browser', id: 'collision', tabId: 'tab-b1' },
+      { type: 'terminal', id: 'collision', tabId: 'tab-t1' }
+    ])
+  })
 })
 
 type NavState = Pick<
@@ -302,5 +371,103 @@ describe('getActiveTabNavOrder', () => {
       { type: 'editor', id: 'e1' },
       { type: 'terminal', id: 'term-2' }
     ])
+  })
+})
+
+// The keyboard cycle must match the rendered strip; reconcileTabOrder appends missing group tabs.
+describe('group order matches the rendered tab strip', () => {
+  function renderedStripIds(group: TabGroup, tabs: Tab[]): string[] {
+    const groupTabs = tabs.filter((tab) => tab.groupId === group.id)
+    const tabBarOrder = group.tabOrder.map((tabId) => {
+      const tab = groupTabs.find((candidate) => candidate.id === tabId)
+      if (!tab) {
+        return tabId
+      }
+      return tab.contentType === 'terminal' || tab.contentType === 'browser' ? tab.entityId : tab.id
+    })
+    const terminalMap = new Map(
+      groupTabs
+        .filter((tab) => tab.contentType === 'terminal')
+        .map((tab) => [tab.entityId, { id: tab.entityId, unifiedTabId: tab.id }])
+    )
+    return buildOrderedTabItems({
+      tabBarOrder,
+      terminalIds: groupTabs
+        .filter((tab) => tab.contentType === 'terminal')
+        .map((tab) => tab.entityId),
+      editorFileIds: [],
+      browserTabIds: [],
+      simulatorTabIds: [],
+      terminalMap: terminalMap as never,
+      editorMap: new Map(),
+      browserMap: new Map(),
+      unifiedTabByVisibleId: new Map()
+    }).map((item) => item.id)
+  }
+
+  it('cycles a tab that hydrated into the group before group.tabOrder learned about it', () => {
+    const group: TabGroup = {
+      id: 'g1',
+      worktreeId: 'wt',
+      activeTabId: 'tab-t1',
+      // Hydration race: tab-t2 is in the group but not yet in the persisted order.
+      tabOrder: ['tab-t1']
+    }
+    const tabs: Tab[] = [
+      terminalTab('tab-t1', 'g1', 'term-1', 0),
+      terminalTab('tab-t2', 'g1', 'term-2', 1)
+    ]
+
+    expect(renderedStripIds(group, tabs)).toEqual(['term-1', 'term-2'])
+    expect(
+      getGroupVisibleTabOrder(group, tabs, new Set(['term-1', 'term-2']), new Set(), new Set()).map(
+        (entry) => entry.id
+      )
+    ).toEqual(['term-1', 'term-2'])
+  })
+
+  it('keeps drag-reordered positions and appends only the unknown tail', () => {
+    const group: TabGroup = {
+      id: 'g1',
+      worktreeId: 'wt',
+      activeTabId: 'tab-t2',
+      tabOrder: ['tab-t3', 'tab-t2'],
+      recentTabIds: []
+    }
+    const tabs: Tab[] = [
+      terminalTab('tab-t1', 'g1', 'term-1', 0),
+      terminalTab('tab-t2', 'g1', 'term-2', 1),
+      terminalTab('tab-t3', 'g1', 'term-3', 2)
+    ]
+
+    expect(renderedStripIds(group, tabs)).toEqual(['term-3', 'term-2', 'term-1'])
+    expect(
+      getGroupVisibleTabOrder(
+        group,
+        tabs,
+        new Set(['term-1', 'term-2', 'term-3']),
+        new Set(),
+        new Set()
+      ).map((entry) => entry.id)
+    ).toEqual(['term-3', 'term-2', 'term-1'])
+  })
+
+  it('still drops tabs whose backing entity is gone, exactly as the strip does', () => {
+    const group: TabGroup = {
+      id: 'g1',
+      worktreeId: 'wt',
+      activeTabId: 'tab-t1',
+      tabOrder: ['tab-t1']
+    }
+    const tabs: Tab[] = [
+      terminalTab('tab-t1', 'g1', 'term-1', 0),
+      editorTab('tab-e1', 'g1', '/repo/closed.md', 1)
+    ]
+
+    expect(
+      getGroupVisibleTabOrder(group, tabs, new Set(['term-1']), new Set(), new Set()).map(
+        (entry) => entry.id
+      )
+    ).toEqual(['term-1'])
   })
 })

--- a/src/renderer/src/components/tab-bar/group-tab-order.ts
+++ b/src/renderer/src/components/tab-bar/group-tab-order.ts
@@ -16,36 +16,12 @@ export type ActiveTabNavOrderIds = {
 }
 
 /**
- * Compute the visible tab-strip order for a single group.
+ * One group's visible tab-strip order, via the same `reconcileTabOrder` pass TabBar renders with
+ * so keyboard cycling always walks what the user sees. STA-3475: dropping a tab that hydrated
+ * before `group.tabOrder` knew it left the cycle a silent no-op until a click.
  *
- * Why: keyboard tab-cycle actions and the IPC switch-tab shortcut must walk
- * tabs in the same order the TabBar renders them. The
- * TabBar derives its order from `group.tabOrder` (the canonical split-group
- * state, updated by drag/drop via `reorderUnifiedTabs`). Reading from the
- * legacy `tabBarOrderByWorktree` drifts out of sync because that store is
- * only written when tabs are created/closed — drag-reordering updates
- * `group.tabOrder` but not the legacy flat order, which surfaces as
- * keyboard nav cycling tabs in a stale sequence (e.g. 3 → 1 → 2 instead of
- * 3 → 2 → 1). This helper returns the exact ids TabBar uses, with a dual-id
- * contract for active-group entries: `id` always carries the backing
- * entity/file id used by legacy activation APIs, while `tabId` preserves the
- * unified tab id for exact split-group selection. That keeps both code paths
- * on the same order without collapsing the identifier domains.
- *
- * Note: TabBar's reconciler appends entities present in state but missing
- * from `group.tabOrder` (an invariant-repair fallback). This helper
- * intentionally does not mirror that append — appending silently would
- * reintroduce the class of order-drift this change fixes. In practice
- * `group.tabOrder` is kept in sync on tab create/close, so the divergence
- * only matters during hydration races and is preferable to cycling tabs
- * in a phantom order.
- *
- * Scope is intentionally per-group: with split layouts each group has its
- * own tab strip, and users expect the shortcut to cycle within the strip
- * they're looking at. Tabs that belong to the group but lack a matching
- * entity (e.g. terminal-runtime tab still being hydrated, or an editor
- * whose file has been closed) are skipped so navigation never lands on a
- * phantom tab.
+ * `id` is the backing entity/file id legacy activation APIs take; `tabId` is the unified tab id
+ * that picks the right split copy. Tabs whose entity is gone are skipped.
  */
 export function getGroupVisibleTabOrder(
   group: TabGroup,
@@ -53,50 +29,104 @@ export function getGroupVisibleTabOrder(
   terminalEntityIds: ReadonlySet<string>,
   editorEntityIds: ReadonlySet<string>,
   browserEntityIds: ReadonlySet<string>,
-  simulatorTabIds: ReadonlySet<string> = new Set()
+  simulatorTabIds: ReadonlySet<string> = new Set(),
+  preserveTypeCollisions = false
 ): VisibleTabRef[] {
   const tabsById = new Map(groupTabs.map((t) => [t.id, t]))
-  const result: VisibleTabRef[] = []
-  // Dedupe per category: terminal/browser key by entityId (multiple tabs
-  // can theoretically point at the same runtime entity), editor keys by
-  // unified tab id. Keeping the keyspaces separate avoids a cross-type
-  // collision from dropping a legitimate tab.
-  const seenTerminals = new Set<string>()
-  const seenBrowsers = new Set<string>()
-  const seenEditors = new Set<string>()
-  const seenSimulators = new Set<string>()
-  for (const unifiedId of group.tabOrder) {
+  const toRef = (tab: Tab): VisibleTabRef | null => {
+    if (tab.contentType === 'terminal') {
+      return terminalEntityIds.has(tab.entityId)
+        ? { type: 'terminal', id: tab.entityId, tabId: tab.id }
+        : null
+    }
+    if (tab.contentType === 'browser') {
+      return browserEntityIds.has(tab.entityId)
+        ? { type: 'browser', id: tab.entityId, tabId: tab.id }
+        : null
+    }
+    if (tab.contentType === 'simulator') {
+      return simulatorTabIds.has(tab.id) ? { type: 'simulator', id: tab.id, tabId: tab.id } : null
+    }
+    return editorEntityIds.has(tab.entityId)
+      ? { type: 'editor', id: tab.entityId, tabId: tab.id }
+      : null
+  }
+  // Why: the strip keys terminals/browsers by entity id and editors/simulators by unified tab id
+  // (see useTabGroupItemProjections) — reconcileTabOrder must see that same id domain.
+  const visibleIdOf = (tab: Tab): string =>
+    tab.contentType === 'terminal' || tab.contentType === 'browser' ? tab.entityId : tab.id
+
+  if (preserveTypeCollisions) {
+    const seenByType = {
+      terminal: new Set<string>(),
+      editor: new Set<string>(),
+      browser: new Set<string>(),
+      simulator: new Set<string>()
+    }
+    const result: VisibleTabRef[] = []
+    for (const unifiedId of group.tabOrder) {
+      const tab = tabsById.get(unifiedId)
+      if (!tab) {
+        continue
+      }
+      const ref = toRef(tab)
+      if (!ref || seenByType[ref.type].has(visibleIdOf(tab))) {
+        continue
+      }
+      seenByType[ref.type].add(visibleIdOf(tab))
+      result.push(ref)
+    }
+    return result
+  }
+
+  // Why: the strip's per-type maps are last-write-wins, so a duplicate entity resolves to the
+  // last declared tab while the reconciled visible id still occupies one position.
+  const declaredTabs = group.tabOrder.flatMap((unifiedId) => {
     const tab = tabsById.get(unifiedId)
-    if (!tab) {
+    return tab ? [tab] : []
+  })
+  const refByVisibleId = new Map<string, VisibleTabRef>()
+  const terminalIds: string[] = []
+  const editorIds: string[] = []
+  const browserIds: string[] = []
+  const simulatorIds: string[] = []
+  const idsByType = {
+    terminal: terminalIds,
+    editor: editorIds,
+    browser: browserIds,
+    simulator: simulatorIds
+  }
+  for (const tab of [...declaredTabs, ...groupTabs]) {
+    const visibleId = visibleIdOf(tab)
+    const ref = toRef(tab)
+    if (!ref) {
       continue
     }
-    if (tab.contentType === 'terminal') {
-      if (!terminalEntityIds.has(tab.entityId) || seenTerminals.has(tab.entityId)) {
+    const existing = refByVisibleId.get(visibleId)
+    if (existing) {
+      // Keep the same type precedence as buildOrderedTabItems, whose terminal map wins over
+      // editor/browser/simulator maps when visible ids collide across content types.
+      const priority = { terminal: 0, editor: 1, browser: 2, simulator: 3 } as const
+      if (priority[ref.type] > priority[existing.type]) {
         continue
       }
-      seenTerminals.add(tab.entityId)
-      result.push({ type: 'terminal', id: tab.entityId, tabId: tab.id })
-    } else if (tab.contentType === 'browser') {
-      if (!browserEntityIds.has(tab.entityId) || seenBrowsers.has(tab.entityId)) {
-        continue
-      }
-      seenBrowsers.add(tab.entityId)
-      result.push({ type: 'browser', id: tab.entityId, tabId: tab.id })
-    } else if (tab.contentType === 'simulator') {
-      if (!simulatorTabIds.has(tab.id) || seenSimulators.has(tab.id)) {
-        continue
-      }
-      seenSimulators.add(tab.id)
-      result.push({ type: 'simulator', id: tab.id, tabId: tab.id })
-    } else {
-      if (!editorEntityIds.has(tab.entityId) || seenEditors.has(tab.id)) {
-        continue
-      }
-      seenEditors.add(tab.id)
-      result.push({ type: 'editor', id: tab.entityId, tabId: tab.id })
+      refByVisibleId.set(visibleId, ref)
+      continue
     }
+    refByVisibleId.set(visibleId, ref)
+    idsByType[ref.type].push(visibleId)
   }
-  return result
+
+  return reconcileTabOrder(
+    declaredTabs.map(visibleIdOf),
+    terminalIds,
+    editorIds,
+    browserIds,
+    simulatorIds
+  ).flatMap((visibleId) => {
+    const ref = refByVisibleId.get(visibleId)
+    return ref ? [ref] : []
+  })
 }
 
 /**
@@ -147,10 +177,16 @@ export function getActiveTabNavOrder(
     const groupTabs = (state.unifiedTabsByWorktree[worktreeId] ?? []).filter(
       (tab) => tab.groupId === group.id
     )
+    // The group strip renders unified terminal tabs before their legacy runtime rows hydrate.
+    // Keep those tabs keyboard-cyclable; activation can hydrate/reconnect the backing runtime.
+    const groupTerminalIds = new Set([
+      ...terminalIds,
+      ...groupTabs.filter((tab) => tab.contentType === 'terminal').map((tab) => tab.entityId)
+    ])
     return getGroupVisibleTabOrder(
       group,
       groupTabs,
-      new Set(terminalIds),
+      groupTerminalIds,
       new Set(editorIds),
       new Set(browserIds),
       new Set(simulatorIds)

--- a/src/renderer/src/components/tab-bar/recent-tab-switching.test.ts
+++ b/src/renderer/src/components/tab-bar/recent-tab-switching.test.ts
@@ -28,7 +28,8 @@ function tab(id: string, entityId: string, label: string): Tab {
 function stateWithTabs(
   tabOrder: string[],
   recentTabIds: string[],
-  activeTabId: string
+  activeTabId: string,
+  hydratingTabIds: string[] = []
 ): Pick<
   AppState,
   | 'activeBrowserTabId'
@@ -43,11 +44,13 @@ function stateWithTabs(
   | 'tabsByWorktree'
   | 'unifiedTabsByWorktree'
 > {
+  // Why: only tabs the group actually holds — a group tab missing from tabOrder is a hydration
+  // race the strip repairs by appending, so listing extras here would not model "one tab open".
   const tabs = [
     tab('tab-a', 'file-a', 'A'),
     tab('tab-b', 'file-b', 'B'),
     tab('tab-c', 'file-c', 'C')
-  ]
+  ].filter((entry) => tabOrder.includes(entry.id) || hydratingTabIds.includes(entry.id))
   return {
     activeBrowserTabId: null,
     activeFileId: tabs.find((entry) => entry.id === activeTabId)?.entityId ?? null,
@@ -109,6 +112,17 @@ describe('buildRecentTabSwitcherModel', () => {
     )
 
     expect(model).toBeNull()
+  })
+
+  it('includes a unified tab that has not yet entered persisted group order', () => {
+    const model = buildRecentTabSwitcherModel(
+      stateWithTabs(['tab-a'], [], 'tab-a', ['tab-b']),
+      WT,
+      'sequential'
+    )
+
+    expect(model?.items.map((item) => item.label)).toEqual(['A', 'B'])
+    expect(model?.activeIndex).toBe(0)
   })
 })
 

--- a/src/renderer/src/hooks/ipc-tab-switch-group-order-hydration.test.ts
+++ b/src/renderer/src/hooks/ipc-tab-switch-group-order-hydration.test.ts
@@ -1,0 +1,111 @@
+// STA-3475: the tab-cycle chord runs through the real group order helper here (no mock), because
+// the bug was the seam between them — a group tab the strip renders but group.tabOrder had not
+// learned about yet left the cycle with <=1 tab, so Terminal.tsx consumed the chord and nothing
+// moved until a mouse click rewrote the group state.
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Tab } from '../../../shared/tab-types'
+
+const { getStateMock } = vi.hoisted(() => ({ getStateMock: vi.fn() }))
+
+vi.mock('../store', () => ({ useAppStore: { getState: getStateMock } }))
+
+import {
+  handleSwitchTab,
+  handleSwitchTabAcrossAllTypes,
+  handleSwitchTerminalTab
+} from './ipc-tab-switch'
+
+const WT = 'wt-1'
+const GROUP = 'group-1'
+
+function terminalTab(id: string, entityId: string, sortOrder: number): Tab {
+  return {
+    id,
+    entityId,
+    groupId: GROUP,
+    worktreeId: WT,
+    contentType: 'terminal',
+    label: entityId,
+    customLabel: null,
+    color: null,
+    sortOrder,
+    createdAt: sortOrder
+  }
+}
+
+function stateWithGroupOrder(tabOrder: string[]) {
+  const tabs = [
+    terminalTab('tab-1', 'term-1', 0),
+    terminalTab('tab-2', 'term-2', 1),
+    terminalTab('tab-3', 'term-3', 2)
+  ]
+  return {
+    activeWorktreeId: WT,
+    activeTabType: 'terminal' as const,
+    activeTabId: 'term-1',
+    activeFileId: null,
+    activeBrowserTabId: null,
+    activeGroupIdByWorktree: { [WT]: GROUP },
+    groupsByWorktree: {
+      [WT]: [{ id: GROUP, worktreeId: WT, activeTabId: 'tab-1', tabOrder, recentTabIds: [] }]
+    },
+    unifiedTabsByWorktree: { [WT]: tabs },
+    tabBarOrderByWorktree: {},
+    tabsByWorktree: { [WT]: [{ id: 'term-1' }, { id: 'term-2' }, { id: 'term-3' }] },
+    openFiles: [],
+    browserTabsByWorktree: {},
+    setActiveTab: vi.fn(),
+    setActiveFile: vi.fn(),
+    setActiveBrowserTab: vi.fn(),
+    setActiveTabType: vi.fn(),
+    activateTab: vi.fn()
+  }
+}
+
+describe('tab-cycle chord against a group whose tabOrder is still hydrating', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('switches to the group tab that group.tabOrder has not recorded yet', () => {
+    const store = stateWithGroupOrder(['tab-1'])
+    getStateMock.mockReturnValue(store)
+
+    expect(handleSwitchTab(1)).toBe(true)
+    expect(store.setActiveTab).toHaveBeenCalledWith('term-2')
+  })
+
+  it('switches across all types in the same hydrating state', () => {
+    const store = stateWithGroupOrder(['tab-1'])
+    getStateMock.mockReturnValue(store)
+
+    expect(handleSwitchTabAcrossAllTypes(-1)).toBe(true)
+    expect(store.setActiveTab).toHaveBeenCalledWith('term-3')
+  })
+
+  it('still cycles in the recorded order once tabOrder is complete', () => {
+    const store = stateWithGroupOrder(['tab-2', 'tab-1', 'tab-3'])
+    getStateMock.mockReturnValue(store)
+
+    expect(handleSwitchTab(1)).toBe(true)
+    expect(store.setActiveTab).toHaveBeenCalledWith('term-3')
+  })
+
+  it('cycles a terminal-only shortcut while the runtime row is still hydrating', () => {
+    const store = stateWithGroupOrder(['tab-1'])
+    store.tabsByWorktree = { [WT]: [{ id: 'term-1' }] }
+    getStateMock.mockReturnValue(store)
+
+    expect(handleSwitchTab(1)).toBe(true)
+    expect(store.setActiveTab).toHaveBeenCalledWith('term-2')
+  })
+
+  it('cycles Ctrl+PageUp/PageDown through a unified terminal before its runtime row hydrates', () => {
+    const store = stateWithGroupOrder(['tab-1'])
+    store.tabsByWorktree = { [WT]: [{ id: 'term-1' }] }
+    getStateMock.mockReturnValue(store)
+
+    expect(handleSwitchTerminalTab(1)).toBe(true)
+    expect(store.setActiveTab).toHaveBeenCalledWith('term-2')
+  })
+})

--- a/src/renderer/src/hooks/ipc-tab-switch.test.ts
+++ b/src/renderer/src/hooks/ipc-tab-switch.test.ts
@@ -186,11 +186,12 @@ describe('handleSwitchTab', () => {
       { type: 'terminal', id: 'term-1' },
       { type: 'editor', id: 'file-1', tabId: 'tab-editor-1' },
       { type: 'browser', id: 'browser-1', tabId: 'tab-browser-1' },
-      { type: 'terminal', id: 'term-2' }
+      { type: 'terminal', id: 'term-2', tabId: 'tab-terminal-2' }
     ])
 
     expect(handleSwitchTab(1)).toBe(true)
     expect(store.setActiveTab).toHaveBeenCalledWith('term-2')
+    expect(store.activateTab).toHaveBeenCalledWith('tab-terminal-2')
     expect(store.setActiveFile).not.toHaveBeenCalled()
     expect(store.setActiveBrowserTab).not.toHaveBeenCalled()
     expect(store.setActiveTabType).toHaveBeenCalledWith('terminal')

--- a/src/renderer/src/hooks/ipc-tab-switch.ts
+++ b/src/renderer/src/hooks/ipc-tab-switch.ts
@@ -61,6 +61,11 @@ function resolveCycleContext(): CycleContext | null {
 export function activateCyclableTab(store: AppStoreState, next: TypeCyclableTab): void {
   if (next.type === 'terminal') {
     store.setActiveTab(next.id)
+    // Terminal entities can be open in multiple split groups. setActiveTab uses the legacy
+    // entity id and therefore may pick the first copy; the unified id restores the exact target.
+    if (next.tabId) {
+      store.activateTab?.(next.tabId)
+    }
     store.setActiveTabType('terminal')
   } else if (next.type === 'browser') {
     store.setActiveBrowserTab(next.id)

--- a/src/renderer/src/runtime/sync-runtime-graph.ts
+++ b/src/renderer/src/runtime/sync-runtime-graph.ts
@@ -1739,7 +1739,9 @@ function buildMobileSessionGroupProjection(
       groupTabs,
       terminalIds,
       editorIds,
-      browserIds
+      browserIds,
+      new Set(),
+      true
     )
     if (visibleOrder.length === 0) {
       continue


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​296 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​293 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​107 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​64 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​43 |

<!-- /orca-pr-loc -->

## Problem

Keyboard tab-cycling shortcuts drift out of sync with the rendered tab bar. When tabs are drag-reordered, `group.tabOrder` updates but the keyboard cycle relied on a stale `tabBarOrderByWorktree` store. Additionally, unified terminal tabs that hydrate in the render strip before `group.tabOrder` catches up become invisible to keyboard cycling — a silent no-op until a click rewrites the group state. This is especially common in remote scenarios with timing variability.

## Solution

Keyboard tab-cycle now uses the same `getGroupVisibleTabOrder` helper and `reconcileTabOrder` logic that TabBar uses to render, ensuring keyboard cycling always walks tabs in the order the user sees. For split groups with the same entity in multiple tabs, the unified tab ID is used to activate the correct copy.

## What Changed

- Enhanced `getGroupVisibleTabOrder()` to reconcile the order exactly as TabBar renders
- Updated `activateCyclableTab()` to use unified tab IDs for terminal tabs in split groups
- Added tests verifying keyboard cycle matches rendered strip order (drag-reorder, hydration races, duplicate entities)

## Why

Keyboard shortcuts must follow the visual order, or the mental model breaks and users encounter silent failures.

## Linked Issue

Fixes #

## Visual Proof

N/A – keyboard shortcut behavior fix, no visual changes

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated: comprehensive tests cover drag-reordering, hydration races, duplicate entities, and cross-type collisions

## AI Disclosure

N/A

## Review

## Agent skill upstream boundary

- [x] Not applicable

## Notes

Cross-platform (Linux, Windows, Mac), SSH/remote, and backwards compatibility verified.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] N/A – no visual changes
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and shortcut impact considered
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass