### PR TITLE
fix(windows): restore a CIM fallback for relay hosts with no native binding

### DIFF
--- a/docs/reference/windows-process-enumeration.md
+++ b/docs/reference/windows-process-enumeration.md
@@ -37,6 +37,37 @@ Measured on Windows 11 with 1050 processes (p50 / p95):
 | + memory + command line | 30.6 ms | 33.7 ms |
 | `Get-CimInstance` via PowerShell | 706 ms | 723 ms |
 
+## The relay has no binding, and falls back
+
+Relay deployment installs only `node-pty` and `@parcel/watcher` on the remote
+host (`RELAY_NATIVE_DEPS` in `src/main/ssh/ssh-relay-deploy.ts`), so a Windows
+machine used as an SSH host has no `@vscode/windows-process-tree` at all. It is
+not added there on purpose: the package ships no prebuilds, so installing it
+would put a from-source `node-gyp` build — MSVC, the SDK, and the same
+Spectre-mitigated libraries described below — on the critical path of every
+Windows relay deploy, where today none is needed. pnpm patches also do not cross
+SSH, so the remote would get the unpatched 1024-process cap regardless.
+
+Instead, `windows-process-table.ts` falls back to
+`readWindowsProcessRowsWithCim` (`windows-process-table-cim-scan.ts`), the
+`Get-CimInstance` scan this module replaced. The gate is deliberately narrow:
+
+- it engages **only** when the module cannot be required, never when a loaded
+  module fails, wedges, or returns an unreadable table — a present-but-failing
+  reader must not silently start forking a shell at the caller's poll rate;
+- a fallback that also fails still rejects, so "unavailable" never degrades into
+  "nothing is running";
+- the scan applies the same self-presence guard as the native path.
+
+`src/main/ssh/relay-native-dependency-coverage.test.ts` asserts that every
+native addon reachable from the relay entry is either installed on relay hosts
+or listed there with the reason its absence is safe. That test exists because
+#15749 shipped this gap: the relay tests injected a fake module through
+`__setWindowsProcessTreeLoaderForTests`, so nothing exercised the real require.
+
+The native fast path stays unavailable on relay hosts until the toolchain or a
+prebuild story is solved. That is a real gap, tracked separately.
+
 ## Why the package is patched
 
 `config/patches/@vscode__windows-process-tree@0.8.0.patch` carries two hunks.

--- a/src/main/ssh/relay-native-dependency-coverage.test.ts
+++ b/src/main/ssh/relay-native-dependency-coverage.test.ts
@@ -1,0 +1,102 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { build } from 'esbuild'
+import { describe, expect, it } from 'vitest'
+import { RELAY_NATIVE_DEPS } from './ssh-relay-deploy'
+
+/**
+ * The relay is a bundle deployed to a host that has none of Orca's node_modules.
+ * Every native addon it reaches therefore has to be installed by
+ * `installNativeDeps`, or the relay silently loses that capability forever.
+ *
+ * This exists because #15749 moved the Windows process table onto
+ * `@vscode/windows-process-tree` without adding it here. The relay tests all
+ * passed: they inject a fake module through
+ * `__setWindowsProcessTreeLoaderForTests`, so nothing ever exercised the real
+ * require that the remote host would fail. Assert against the real graph.
+ */
+
+const REPO_ROOT = resolve(import.meta.dirname, '..', '..', '..')
+
+/**
+ * Native addons the relay imports but deliberately does NOT install, each with
+ * the reason its absence is safe. Adding an entry is a decision, not a default:
+ * anything not listed must appear in RELAY_NATIVE_DEPS.
+ */
+const DEGRADES_WITHOUT_INSTALL: Record<string, string> = {
+  '@vscode/windows-process-tree':
+    'Windows-only and ships no prebuilds, so installing it would put a from-source ' +
+    'node-gyp build (MSVC + SDK + Spectre-mitigated libs) on the critical path of ' +
+    'every Windows relay deploy — and pnpm patches do not cross SSH, so the remote ' +
+    'would get the unpatched 1024-process cap anyway. windows-process-table.ts ' +
+    'falls back to a Get-CimInstance scan when the binding is absent.'
+}
+
+/** Addons are the packages npm has to build or unpack a binary for. */
+function nativeDependencyNames(): string[] {
+  const pkg = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8')) as {
+    dependencies?: Record<string, string>
+    optionalDependencies?: Record<string, string>
+  }
+  const declared = new Set([
+    ...Object.keys(pkg.dependencies ?? {}),
+    ...Object.keys(pkg.optionalDependencies ?? {})
+  ])
+  return [...declared].filter((name) => {
+    const dir = join(REPO_ROOT, 'node_modules', name)
+    return existsSync(join(dir, 'binding.gyp')) || existsSync(join(dir, 'prebuilds'))
+  })
+}
+
+/**
+ * Source files reachable from the relay entry.
+ *
+ * Why the metafile and not the emitted bundle: the process table resolves its
+ * addon through `createRequire`, which esbuild cannot see and minification
+ * rewrites, so the specifier only survives reliably in the sources.
+ */
+async function relayReachableSources(): Promise<string[]> {
+  const result = await build({
+    entryPoints: [join(REPO_ROOT, 'src', 'relay', 'relay.ts')],
+    bundle: true,
+    platform: 'node',
+    target: 'node18',
+    format: 'cjs',
+    write: false,
+    metafile: true,
+    external: ['node-pty', '@parcel/watcher', 'electron'],
+    define: { 'process.env.NODE_ENV': '"production"' }
+  })
+  return Object.keys(result.metafile.inputs).filter((input) => !input.includes('node_modules'))
+}
+
+describe('relay native dependency coverage', () => {
+  it('installs every native addon the relay bundle imports', async () => {
+    const sources = await relayReachableSources()
+    const text = sources.map((file) => readFileSync(join(REPO_ROOT, file), 'utf8')).join('\n')
+
+    const imported = nativeDependencyNames().filter(
+      (name) => text.includes(`'${name}'`) || text.includes(`"${name}"`)
+    )
+    expect(imported.length).toBeGreaterThan(0)
+
+    const uncovered = imported.filter(
+      (name) => !(name in RELAY_NATIVE_DEPS) && !(name in DEGRADES_WITHOUT_INSTALL)
+    )
+    expect(uncovered).toEqual([])
+  }, 60_000)
+
+  it('keeps every installed native dep at the version the app depends on', () => {
+    const pkg = JSON.parse(readFileSync(join(REPO_ROOT, 'package.json'), 'utf8')) as {
+      dependencies?: Record<string, string>
+      optionalDependencies?: Record<string, string>
+    }
+    const declared = { ...pkg.dependencies, ...pkg.optionalDependencies }
+    for (const [name, version] of Object.entries(RELAY_NATIVE_DEPS)) {
+      // The relay pins exact versions where the app carries a range, so compare
+      // the base: a relay on a different version than the app marshals the same
+      // node-pty/watcher data through a binding nothing else cross-checks.
+      expect(declared[name]?.replace(/^[\^~]/, ''), `${name} matches the app`).toBe(version)
+    }
+  })
+})

--- a/src/main/ssh/ssh-relay-deploy.ts
+++ b/src/main/ssh/ssh-relay-deploy.ts
@@ -697,7 +697,10 @@ function uploadStageNamespaceIfSupported(
 
 const NODE_PTY_VERSION = '1.1.0'
 const NODE_PTY_CONSOLE_LIST_PATCH_FILENAME = 'node-pty-1.1.0-console-list-agent-patch.cjs'
-const RELAY_NATIVE_DEPS = {
+// Exported for the relay-native-dependency-coverage test, which asserts every
+// native addon the relay bundle imports is either installed here or explicitly
+// declared as degrading without it.
+export const RELAY_NATIVE_DEPS = {
   'node-pty': NODE_PTY_VERSION,
   '@parcel/watcher': '2.5.6'
 } as const

--- a/src/main/windows/windows-process-table-cim-scan.test.ts
+++ b/src/main/windows/windows-process-table-cim-scan.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { parseWindowsCimProcessRows } from './windows-process-table-cim-scan'
+
+describe('parseWindowsCimProcessRows', () => {
+  it('reads the array form ConvertTo-Json emits for a real table', () => {
+    const stdout = JSON.stringify([
+      { CommandLine: 'node relay.js', Name: 'node.exe', ParentProcessId: 4, ProcessId: 100 },
+      { CommandLine: 'claude --resume', Name: 'claude.exe', ParentProcessId: 100, ProcessId: 200 }
+    ])
+    expect(parseWindowsCimProcessRows(stdout)).toEqual([
+      { pid: 100, ppid: 4, name: 'node.exe', command: 'node relay.js' },
+      { pid: 200, ppid: 100, name: 'claude.exe', command: 'claude --resume' }
+    ])
+  })
+
+  it('reads the bare-object form ConvertTo-Json emits for a single row', () => {
+    const stdout = JSON.stringify({
+      CommandLine: 'node relay.js',
+      Name: 'node.exe',
+      ParentProcessId: 4,
+      ProcessId: 100
+    })
+    expect(parseWindowsCimProcessRows(stdout)).toEqual([
+      { pid: 100, ppid: 4, name: 'node.exe', command: 'node relay.js' }
+    ])
+  })
+
+  it('falls back to the image name when a process denied its command line', () => {
+    const stdout = JSON.stringify([
+      { CommandLine: null, Name: 'lsass.exe', ParentProcessId: 4, ProcessId: 700 }
+    ])
+    expect(parseWindowsCimProcessRows(stdout)).toEqual([
+      { pid: 700, ppid: 4, name: 'lsass.exe', command: 'lsass.exe' }
+    ])
+  })
+
+  it('keeps a command line containing newlines on its own row', () => {
+    // The reason this reads JSON and not PowerShell's Key=Value list form.
+    const stdout = JSON.stringify([
+      {
+        CommandLine: 'app.exe "a\nProcessId=9\nb"',
+        Name: 'app.exe',
+        ParentProcessId: 4,
+        ProcessId: 5
+      }
+    ])
+    expect(parseWindowsCimProcessRows(stdout)).toEqual([
+      { pid: 5, ppid: 4, name: 'app.exe', command: 'app.exe "a\nProcessId=9\nb"' }
+    ])
+  })
+
+  it('drops rows with no usable pid rather than inventing one', () => {
+    const stdout = JSON.stringify([
+      { Name: 'ghost.exe', ParentProcessId: 4 },
+      { Name: 'real.exe', ParentProcessId: 4, ProcessId: 5 }
+    ])
+    expect(parseWindowsCimProcessRows(stdout)).toEqual([
+      { pid: 5, ppid: 4, name: 'real.exe', command: 'real.exe' }
+    ])
+  })
+
+  it('returns null on unparseable output so the caller can reject it', () => {
+    // A policy banner or an error on stdout must not read as an idle machine.
+    expect(parseWindowsCimProcessRows('Access is denied.')).toBeNull()
+  })
+})

--- a/src/main/windows/windows-process-table-cim-scan.ts
+++ b/src/main/windows/windows-process-table-cim-scan.ts
@@ -1,0 +1,101 @@
+import { runProcess } from '../../shared/child-process/run-process'
+import { windowsPowerShellPath } from '../../shared/child-process/windows-system-binary'
+import type { WindowsProcessRow } from './windows-process-table'
+
+/**
+ * The `Get-CimInstance Win32_Process` scan, kept only for hosts where the
+ * native Toolhelp32 binding is not installed.
+ *
+ * Why this still exists after #15749 retired it: the relay bundle is deployed to
+ * SSH hosts that only ever receive `node-pty` and `@parcel/watcher`, so
+ * `@vscode/windows-process-tree` is absent there and every native read rejects.
+ * Callers read that as "no evidence" and agent panes identify as powershell.exe
+ * forever. This restores the v1.4.188 answer on exactly those hosts; the local
+ * app ships the addon and never reaches this path.
+ */
+
+const WINDOWS_CIM_QUERY_TIMEOUT_MS = 3_000
+const WINDOWS_CIM_MAX_OUTPUT_BYTES = 8 * 1024 * 1024
+
+// Why JSON and not the `Key=Value` list form: CommandLine can itself contain
+// CR/LF, so an argument could otherwise masquerade as another row's field.
+const POWERSHELL_PROCESS_QUERY =
+  '[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; ' +
+  'Get-CimInstance -ClassName Win32_Process -Property CommandLine,Name,ParentProcessId,ProcessId | ' +
+  'Select-Object CommandLine,Name,ParentProcessId,ProcessId | ' +
+  'ConvertTo-Json -Compress'
+
+type CimProcessRow = {
+  CommandLine?: unknown
+  Name?: unknown
+  ParentProcessId?: unknown
+  ProcessId?: unknown
+}
+
+function fieldAsString(value: unknown): string {
+  if (typeof value === 'string') {
+    return value
+  }
+  return value === null || value === undefined ? '' : String(value)
+}
+
+function fieldAsNumber(value: unknown): number {
+  if (typeof value === 'number') {
+    return value
+  }
+  return typeof value === 'string' ? Number.parseInt(value, 10) : Number.NaN
+}
+
+export function parseWindowsCimProcessRows(stdout: string): WindowsProcessRow[] | null {
+  const trimmed = stdout.trim()
+  if (!trimmed) {
+    return []
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch {
+    return null
+  }
+  const items = Array.isArray(parsed) ? parsed : [parsed]
+  return items.flatMap((item) => {
+    if (!item || typeof item !== 'object') {
+      return []
+    }
+    const row = item as CimProcessRow
+    const pid = fieldAsNumber(row.ProcessId)
+    const ppid = fieldAsNumber(row.ParentProcessId)
+    if (!Number.isFinite(pid) || !Number.isFinite(ppid)) {
+      return []
+    }
+    const name = fieldAsString(row.Name)
+    // memoryBytes stays undefined: Win32_Process reports WorkingSetSize, but no
+    // caller reads it off this table and asking widens an already costly scan.
+    return [{ pid, ppid, name, command: fieldAsString(row.CommandLine) || name }]
+  })
+}
+
+/**
+ * Read the whole process table through PowerShell.
+ *
+ * Throws rather than returning `[]` on any failure: an empty table is a claim
+ * that nothing is running, and callers act on that by declaring a tree dead.
+ */
+export async function readWindowsProcessRowsWithCim(): Promise<WindowsProcessRow[]> {
+  const result = await runProcess({
+    program: windowsPowerShellPath(),
+    args: ['-NoProfile', '-NonInteractive', '-Command', POWERSHELL_PROCESS_QUERY],
+    timeoutMs: WINDOWS_CIM_QUERY_TIMEOUT_MS,
+    maxOutputBytes: WINDOWS_CIM_MAX_OUTPUT_BYTES
+  })
+  if (result.timedOut || result.code !== 0) {
+    throw new Error(
+      `windows process table CIM scan failed (code=${result.code} timedOut=${result.timedOut})`
+    )
+  }
+  const rows = parseWindowsCimProcessRows(result.stdout)
+  if (!rows || rows.length === 0) {
+    throw new Error('windows process table CIM scan returned no rows')
+  }
+  return rows
+}

--- a/src/main/windows/windows-process-table.test.ts
+++ b/src/main/windows/windows-process-table.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  __setWindowsProcessTableCimScanForTests,
   __setWindowsProcessTreeLoaderForTests,
   isWindowsProcessTableAvailable,
   readWindowsProcessTable,
@@ -66,9 +67,13 @@ describe('windows process table', () => {
 
   it('rejects rather than reporting an empty machine when the module is absent', async () => {
     // A caller that reads "no processes" acts on it -- by declaring a tree dead,
-    // or by concluding a shell has no children. Absence must not look like that.
+    // or by concluding a shell has no children. Absence must not look like that,
+    // and neither must a fallback that also fails.
     __setWindowsProcessTreeLoaderForTests(() => null)
-    await expect(readWindowsProcessTableFresh()).rejects.toThrow(/unavailable/)
+    __setWindowsProcessTableCimScanForTests(async () => {
+      throw new Error('powershell unavailable')
+    })
+    await expect(readWindowsProcessTableFresh()).rejects.toThrow(/powershell unavailable/)
     expect(isWindowsProcessTableAvailable()).toBe(false)
   })
 
@@ -104,6 +109,77 @@ describe('windows process table', () => {
     Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
     __setWindowsProcessTreeLoaderForTests()
     expect(isWindowsProcessTableAvailable()).toBe(false)
+  })
+})
+
+// Why this path exists: relay deployment installs only node-pty and
+// @parcel/watcher, so a Windows SSH host has no native binding and every read
+// used to reject -- which agent recognition reads as "no evidence" forever.
+describe('PowerShell fallback when the native binding is absent', () => {
+  let platform: PropertyDescriptor | undefined
+  const cimScan = vi.fn()
+  const CIM_ROWS = [
+    { pid: process.pid, ppid: 0, name: 'node.exe', command: 'node relay.js' },
+    { pid: 200, ppid: process.pid, name: 'claude.exe', command: 'claude --resume' }
+  ]
+
+  beforeEach(() => {
+    platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    cimScan.mockReset()
+    cimScan.mockResolvedValue(CIM_ROWS)
+    __setWindowsProcessTableCimScanForTests(cimScan)
+  })
+
+  afterEach(() => {
+    __setWindowsProcessTableCimScanForTests()
+    __setWindowsProcessTreeLoaderForTests()
+    if (platform) {
+      Object.defineProperty(process, 'platform', platform)
+    }
+  })
+
+  it('engages when the module cannot be required', async () => {
+    __setWindowsProcessTreeLoaderForTests(() => null)
+    await expect(readWindowsProcessTableFresh()).resolves.toEqual(CIM_ROWS)
+    expect(cimScan).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not engage when the native binding is present', async () => {
+    const getAllProcesses = vi.fn()
+    getAllProcesses.mockImplementation((cb: (rows: unknown) => void) => cb(NATIVE))
+    __setWindowsProcessTreeLoaderForTests(() => ({
+      ProcessDataFlag: { None: 0, Memory: 1, CommandLine: 2 },
+      getAllProcesses
+    }))
+    await readWindowsProcessTableFresh()
+    expect(cimScan).not.toHaveBeenCalled()
+  })
+
+  it('does not engage when a present binding fails its read', async () => {
+    // A wedged or blocked reader must not silently start forking a shell at the
+    // caller's poll rate; only absence is unrecoverable.
+    const getAllProcesses = vi.fn()
+    getAllProcesses.mockImplementation((cb: (rows: unknown) => void) => cb([]))
+    __setWindowsProcessTreeLoaderForTests(() => ({
+      ProcessDataFlag: { None: 0, Memory: 1, CommandLine: 2 },
+      getAllProcesses
+    }))
+    await expect(readWindowsProcessTableFresh()).rejects.toThrow(/unreadable/)
+    expect(cimScan).not.toHaveBeenCalled()
+  })
+
+  it('rejects a scan missing our own pid instead of reporting an idle machine', async () => {
+    __setWindowsProcessTreeLoaderForTests(() => null)
+    cimScan.mockResolvedValue([{ pid: 200, ppid: 4, name: 'claude.exe', command: 'claude' }])
+    await expect(readWindowsProcessTableFresh()).rejects.toThrow(/unreadable/)
+  })
+
+  it('stays off Windows-only: darwin still reports unavailable', async () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+    __setWindowsProcessTreeLoaderForTests(() => null)
+    await expect(readWindowsProcessTableFresh()).rejects.toThrow(/unavailable/)
+    expect(cimScan).not.toHaveBeenCalled()
   })
 })
 

--- a/src/main/windows/windows-process-table.ts
+++ b/src/main/windows/windows-process-table.ts
@@ -1,5 +1,6 @@
 import { createRequire } from 'node:module'
 import { createProcessTableSnapshotReader } from '../../shared/process-table-snapshot'
+import { readWindowsProcessRowsWithCim } from './windows-process-table-cim-scan'
 
 /**
  * The only place Orca reads the Windows process table.
@@ -54,6 +55,7 @@ const requireFromMain = createRequire(__filename)
 
 let cachedModule: WindowsProcessTreeModule | null | undefined
 let moduleLoader: () => WindowsProcessTreeModule | null = loadWindowsProcessTree
+let cimScan: () => Promise<WindowsProcessRow[]> = readWindowsProcessRowsWithCim
 
 /**
  * Resolve the native module, or null where it cannot be used.
@@ -110,6 +112,14 @@ let readGeneration = 0
 function readNativeRows(): Promise<WindowsProcessRow[]> {
   const native = moduleLoader()
   if (!native) {
+    if (process.platform === 'win32') {
+      // Why only when the module is absent: a binding that loads is the fast
+      // path even when a read fails or wedges, so a failing native reader must
+      // never silently start forking shells at the caller's poll rate. Absence
+      // is the one condition that can never resolve itself — see
+      // docs/reference/windows-process-enumeration.md.
+      return readCimRows()
+    }
     // Reject rather than resolve empty: an empty table is a claim that nothing
     // is running, and callers act on that by force-killing or by declaring a
     // tree dead. "Unavailable" has to stay distinguishable from "empty".
@@ -186,6 +196,21 @@ function readNativeRows(): Promise<WindowsProcessRow[]> {
   })
 }
 
+/**
+ * Whole-table read for hosts with no native binding (the relay).
+ *
+ * Applies the same self-presence guard as the native path: a scan that omits
+ * our own pid is truncated or permission-filtered, not empty, and must reject
+ * so nothing downstream reads it as proof a process died.
+ */
+async function readCimRows(): Promise<WindowsProcessRow[]> {
+  const rows = await cimScan()
+  if (!rows.some((row) => row.pid === process.pid)) {
+    throw new Error('windows process table is unreadable')
+  }
+  return rows
+}
+
 // Why still cache: the snapshot is cheap but not free, and a worktree delete
 // tears down PTYs 32-wide. The shared TTL + single-in-flight reader collapses
 // that burst into one scan, exactly as the PowerShell path had to.
@@ -227,6 +252,14 @@ export function __setWindowsProcessTreeLoaderForTests(
   moduleLoader = loader ?? loadWindowsProcessTree
   cachedModule = undefined
   wedgedUntilMs = 0
+  snapshotReader.reset()
+}
+
+/** Test-only: substitute the no-binding PowerShell scan, which spawns a child. */
+export function __setWindowsProcessTableCimScanForTests(
+  scan?: () => Promise<WindowsProcessRow[]>
+): void {
+  cimScan = scan ?? readWindowsProcessRowsWithCim
   snapshotReader.reset()
 }
 


### PR DESCRIPTION
## ELI5

Orca needs to know **what program is actually running inside a terminal pane** — is that Claude, or Codex, or just a plain shell sitting at a prompt? On Windows the only way to answer that is to ask the OS for the list of every running process and look at what's underneath the pane's shell.

There are two ways to ask Windows for that list:

1. **The fast way** — a small compiled C++ add-on (`@vscode/windows-process-tree`) that asks the OS directly. Takes ~16 ms.
2. **The slow way** — launch `powershell.exe` and have it run a `Get-CimInstance Win32_Process` query. Takes ~1.4 s and starts a whole extra process every time.

Orca used to do it the slow way. #15749 switched it to the fast way, which was the right call — the slow way was causing real damage (see "Why the fast way exists" below).

**Here's what got missed.** When you use Orca against a remote machine over SSH, Orca ships a small program called the *relay* to that machine and runs it there. The relay only installs two native add-ons on the remote host: `node-pty` and `@parcel/watcher`. Nobody added the new process-table add-on to that list.

So on a Windows machine used as an SSH host, the fast way **isn't there at all**. The code asks for it, doesn't find it, gives up — and because the slow way had been deleted, there's no way left to answer the question. Every pane on that machine falls back to reporting the shell's name instead of the agent's. Forever, until the relay restarts (and then it fails again).

**This PR puts the slow way back**, but *only* as a parachute: it's used exclusively on machines where the fast add-on isn't installed. Your local Windows machine still uses the fast way and is completely unaffected.

An analogy: #15749 replaced the stairs with an elevator. Great — except the elevator was never installed in the remote building, and the stairs had already been demolished. This rebuilds the stairs, and only in buildings with no elevator.

---

## The bug in detail

#15749 moved the Windows process table onto `@vscode/windows-process-tree`. Relay deployment installs only `node-pty` and `@parcel/watcher` (`RELAY_NATIVE_DEPS`, `src/main/ssh/ssh-relay-deploy.ts:700`), and the addon isn't in the relay bundle's esbuild externals either (`config/scripts/build-relay.mjs:81`) — it's resolved at runtime through `createRequire`, so esbuild can't see it and the build succeeds while the runtime require fails.

The chain on a Windows SSH host:

```
src/relay/pty-shell-utils.ts:294,310   getForegroundProcessName
  → resolveWindowsAgentForegroundProcess
  → queryWindowsPaneProcessInventory     windows-foreground-process-rows.ts:56-68
  → readWindowsProcessTable              rejects: "windows process table unavailable"
  → catch → return null
  → falls back to node-pty's reported name
```

`cachedModule` latches `null` on first failure with no production re-probe, so it never recovers within the life of the relay process.

#15749 is **not** in `v1.4.188` (`git merge-base --is-ancestor 057fbfcffc9 v1.4.188` → false). It's in `origin/adhoc/1.4.189-cherrypicks` and is the only windows-process-table commit in that delta, so 1.4.189 is the first release that would carry this.

## Verified on real Windows hardware

Windows 11 x64, 1486 processes, run from the **actual deployed relay directory** on a Windows SSH host (`~/.orca-remote/relay-*`, whose `node_modules` contains only `@parcel/watcher`, `node-pty` and transitives — no `@vscode` scope at all):

| | result |
|---|---|
| `createRequire(...)('@vscode/windows-process-tree')` | `MODULE_NOT_FOUND` |
| `require('node-pty')` (control) | resolves |
| **before** — `windows-process-table.ts` from `main`, bundled with the relay's esbuild externals | `nativeAvailable=false`; rejects in **0 ms**, `"windows process table unavailable"`, every call |
| **after** — same bundle, with this change | `nativeAvailable=false`; **1485 rows in 1.1–1.35 s**, own pid present, `claude.exe` rows with full command lines |

Also checked on that host: `windowsPowerShellPath()` resolves (`SystemRoot=C:\WINDOWS`), the absolute `powershell.exe` path exists and executes from the relay process, and the function has no Electron dependency. Separately, `out/relay/win32-x64/relay.js` was built and grepped to confirm the module really is in the shipped bundle with the require left as a runtime call.

## Why not just add it to `RELAY_NATIVE_DEPS`

- The package ships **no prebuilds** for arbitrary hosts, so it builds from source via `node-gyp` and needs MSVC + the Windows SDK + Python + Spectre-mitigated libs on *every* Windows SSH host. `installNativeDeps` throws on failure and the toolchain-skip retry is Linux-gated (`ssh-relay-deploy.ts:1026` → `throw` at `:1071`), so Windows relay deploy would break outright.
- pnpm patches don't cross SSH. Even where it built, the remote would get the **unpatched 1024-process enumeration cap** — the exact truncation #15749 was written to remove.

## Why the fast way exists (what we must not undo)

The header of `windows-process-table.ts` records what the PowerShell reader cost. Seven independent readers each forked `powershell.exe`:

- a PowerShell Transcription Group Policy recorded **~289 GB across 1.4 million files** because one scan ran every ~2 s (#15209);
- a Group Policy or AV block turned a query into "unavailable", which callers read as "no evidence" — how a PTY tree survived its own teardown (#9045, #10475);
- the scan cost ~700 ms and ran per pane (#15036).

**None of that changes for local Windows.** This PR reintroduces PowerShell on relay hosts only, where the alternative is no answer at all.

## The fix

Restore the `Get-CimInstance Win32_Process` scan in `src/main/windows/windows-process-table-cim-scan.ts`, engaged from `windows-process-table.ts` **only when the module cannot be required**. The gate is deliberately narrow:

- **absence only** — a binding that loads but fails, wedges, or returns an unreadable table still rejects, so a blocked reader never starts forking a shell at the caller's poll rate;
- a fallback that also fails **still rejects**, so "unavailable" never degrades into "nothing is running";
- the scan keeps the native path's **self-presence guard** — a table missing our own pid is truncated or permission-filtered, not empty, and is rejected.

Constants (`timeoutMs: 3000`, `maxOutputBytes: 8 MiB`) match the pre-#15749 reader exactly (`git show 057fbfcffc9^:src/main/providers/windows-foreground-process-rows.ts` lines 6, 230–231). The scan goes through `runProcess`, which pins `windowsHide` (no flashing console windows) and kills the child on timeout — so it self-heals and doesn't need the native path's 30 s wedge cooldown, which guards a different failure mode (the vendored addon latches a global flag and leaks a callback per call).

`memoryBytes` is undefined on this path. It has **zero consumers** — `grep` finds only an unrelated local in `src/main/memory/collector.ts`.

## The ratchet

`src/main/ssh/relay-native-dependency-coverage.test.ts` reads the **real esbuild module graph** from the relay entry and asserts every native addon it reaches is either in `RELAY_NATIVE_DEPS` or listed with the reason its absence is safe.

This is the test that should have existed before #15749. Its relay tests passed because they inject a fake module through `__setWindowsProcessTreeLoaderForTests`, so nothing ever exercised the real require.

**Confirmed non-vacuous:** removing the `DEGRADES_WITHOUT_INSTALL` entry fails it with `expected [ '@vscode/windows-process-tree' ] to deeply equal []`.

---

## User-facing trade-offs

**Who is affected:** only people using a **Windows machine as an SSH remote host**. Local Windows, macOS, and Linux behavior is byte-for-byte unchanged — the native path is still taken everywhere it exists.

**What gets better on those hosts:**
- Agent panes identify correctly again (`claude`, `codex`, …) instead of showing the shell name. This also restores anything keyed off agent identity — pane titles, agent status, and idle/working detection.
- Port-panel rows regain process-name and command-line attribution (`local-workspace-port-scanner.ts:499`).
- `verifyWindowsTreeKillTarget` can answer again, so the `taskkill /T /F` at `pty-descendant-termination.ts:275` resumes running. On `main` it always answers `unknown`, which is not permission to kill, so descendants that escaped the pane's job object survive teardown. (The job-object path runs first and normally covers this, so it's a secondary effect.)

**What gets worse on those hosts — the real cost:**

| Trade-off | Detail |
|---|---|
| **A `powershell.exe` spawn every ~1.4–1.9 s** | Only while agent panes are actively being watched. Bounded by a 500 ms TTL + single-flight cache, so the ceiling is roughly 30–45 scans/min no matter how many panes are open. |
| **CPU on the remote host** | Each scan is a PowerShell cold start plus a WMI query — ~1.4 s of work at 1486 processes. Noticeable on a small or busy remote box. |
| **PowerShell Transcription logging** | If the host has Transcription enabled by Group Policy, every one of those scans gets written to disk. This is the #15209 exposure, and it returns **on relay hosts only**. Orgs running that policy on their SSH hosts should know. |
| **Slower identity refresh** | Agent detection on relay hosts refreshes off a ~1.4 s scan rather than a ~16 ms one, so a pane's title can lag a fast agent switch. |
| **No console windows** | Not a trade-off — `runProcess` pins `windowsHide`, so nothing flashes on screen. |

**Where it still degrades (no worse than `main`):** on a very busy host the scan can exceed the 3 s timeout or the 8 MiB output cap. At 1486 processes I measured **1.36 s** and **4.76 MiB**, so headroom is ~2× on time and ~1.7× on bytes. On overflow, `createOutputSink` truncates silently, the truncated JSON fails to parse, and the read **rejects** — degrading to today's behavior rather than reporting a wrong table. Both limits are exact 1.4.188 parity, not new.

**The honest summary:** this trades ~1.4 s of remote CPU every couple of seconds for agent recognition working at all on Windows SSH hosts. The native fast path stays unavailable there until prebuilds or a remote toolchain story is solved; that gap is documented in `docs/reference/windows-process-enumeration.md`.

---

## Risk and rollback

Low. The change is additive and gated on a condition that is **false on every machine that has the addon** — local Windows takes an identical code path to `main`. On macOS/Linux the `process.platform === 'win32'` guard means the fallback is never even constructed.

To roll back, revert this commit; relay hosts return to reporting shell names.

## Validation

- `pnpm tc` clean
- 821 tests pass across `src/main/windows/`, the new ratchet, `src/relay/pty-shell-utils.test.ts`, `src/main/providers/`, and the child-process import boundary
- `oxlint` clean
- full CI green, including `package (windows)`, all 16 shards, e2e, and SSH docker watcher isolation
- real-hardware before/after above

## Scope note

This branch previously carried three unrelated changes at `616d2a4ec8c` (now replaced): a worktree push-target remote-rollback fix, a dropdown-menu shadow CSS fix, and their tests. They were dropped so this stays a clean cherry-pick into the release.

The dropdown CSS bug is real and **still on `main`** — `shadow-[0_12px_28px_rgba(0,0,0,0.22)],inset_...]` has a stray `)]` that breaks the light-mode shadow, at `src/renderer/src/components/ui/dropdown-menu.tsx:35` and `:211`. Both dropped changes deserve their own PRs.

## Follow-ups (deliberately not in this PR)

1. **No failure cooldown on the CIM path.** If PowerShell is blocked by policy, the scan retries at the caller's poll rate rather than backing off. Not added here because it's a deviation from the 1.4.188 behavior this PR is restoring, which is the whole safety argument for cherry-picking it. Worth adding on `main`.
2. **Widen the timeout / output cap.** ~2× and ~1.7× headroom is thinner than the docs' 706 ms figure implies.
3. **Solve prebuilds** for `@vscode/windows-process-tree` so relay hosts can have the fast path too.
4. **Stale doc figure.** `windows-process-enumeration.md` quotes 706 ms p50 for the CIM scan, measured at 1050 processes; at 1486 it's 1.36 s.