### PR TITLE
fix(automations): scope project refs to destination host

### DIFF
--- a/src/main/runtime/orca-runtime-automations.test.ts
+++ b/src/main/runtime/orca-runtime-automations.test.ts
@@ -102,6 +102,84 @@ describe('OrcaRuntimeService automation methods', () => {
     expect(automation.id).toBe('auto-1')
   })
 
+  it('rejects a run context that names a different repo path', async () => {
+    const store = makeStore()
+    const runtime = new OrcaRuntimeService(store as never)
+
+    await expect(
+      runtime.createAutomation({
+        name: 'Mismatched review',
+        prompt: 'Review changes',
+        agentId: 'codex',
+        repo: 'id:repo-1',
+        runContext: {
+          kind: 'workspace-run',
+          projectId: 'project-1',
+          hostId: 'local',
+          projectHostSetupId: 'setup-1',
+          repoId: 'repo-1',
+          path: '/other/repo'
+        },
+        workspaceMode: 'new_per_run',
+        setupDecision: 'skip',
+        rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+        dtstart: 1
+      })
+    ).rejects.toThrow('Automation project does not match its run context.')
+    expect(store.createAutomation).not.toHaveBeenCalled()
+  })
+
+  it('rejects a mismatched run context when the workspace is the machine selector', async () => {
+    const store = makeStore()
+    const runtime = new OrcaRuntimeService(store as never)
+    vi.spyOn(runtime, 'showManagedWorktree').mockResolvedValue({
+      id: 'repo-1::/tmp/orca',
+      repoId: 'repo-1',
+      path: '/tmp/orca'
+    } as never)
+
+    await expect(
+      runtime.createAutomation({
+        name: 'Workspace review',
+        prompt: 'Review changes',
+        agentId: 'codex',
+        workspace: 'id:repo-1::/tmp/orca',
+        runContext: {
+          kind: 'workspace-run',
+          projectId: 'project-1',
+          hostId: 'local',
+          projectHostSetupId: 'setup-1',
+          repoId: 'repo-1',
+          path: '/other/repo'
+        },
+        workspaceMode: 'existing',
+        setupDecision: 'skip',
+        rrule: 'FREQ=DAILY;BYHOUR=9;BYMINUTE=0',
+        dtstart: 1
+      })
+    ).rejects.toThrow('Automation project does not match its run context.')
+    expect(store.createAutomation).not.toHaveBeenCalled()
+  })
+
+  it('rejects a run-context-only update that names a different repo path', async () => {
+    const store = makeStore([existingAutomation])
+    const runtime = new OrcaRuntimeService(store as never)
+
+    await expect(
+      runtime.updateAutomation('auto-1', {
+        runContext: {
+          kind: 'workspace-run',
+          projectId: 'project-1',
+          hostId: 'local',
+          projectHostSetupId: 'setup-1',
+          repoId: 'repo-1',
+          path: '/other/repo'
+        }
+      })
+    ).rejects.toThrow('Automation project does not match its run context.')
+    expect(store.updateAutomation).not.toHaveBeenCalled()
+  })
+
   it('updates and deletes existing automations through the shared store', async () => {
     const store = makeStore([existingAutomation])
     const runtime = new OrcaRuntimeService(store as never)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1428,6 +1428,18 @@ export type RuntimeAutomationUpdateInput = Omit<
   workspace?: string
 }
 
+function assertAutomationRunContextMatchesRepo(
+  runContext: AutomationCreateInput['runContext'],
+  repo: Repo | null
+): void {
+  if (!runContext || !repo) {
+    return
+  }
+  if (runContext.repoId !== repo.id || runContext.path !== repo.path) {
+    throw new Error('Automation project does not match its run context.')
+  }
+}
+
 function normalizeSparsePresetName(name: string): string {
   const trimmed = name.trim()
   if (!trimmed) {
@@ -4233,6 +4245,7 @@ export class OrcaRuntimeService {
       throw new Error('runtime_unavailable')
     }
     const target = await this.resolveAutomationTarget(input)
+    assertAutomationRunContextMatchesRepo(input.runContext, target.repo)
     if (input.reuseSession && target.workspaceMode !== 'existing') {
       throw new Error('Session reuse requires an existing workspace target.')
     }
@@ -4311,6 +4324,7 @@ export class OrcaRuntimeService {
       hasRuntimeAutomationUpdateValue(updates, 'workspaceMode')
     if (targetChanged) {
       const target = await this.resolveAutomationTarget(updates, current)
+      assertAutomationRunContextMatchesRepo(updates.runContext, target.repo)
       if (patch.reuseSession === true && target.workspaceMode !== 'existing') {
         throw new Error('Session reuse requires an existing workspace target.')
       }
@@ -4320,6 +4334,9 @@ export class OrcaRuntimeService {
       if (target.workspaceMode !== 'existing') {
         patch.reuseSession = false
       }
+    } else if (hasRuntimeAutomationUpdateValue(updates, 'runContext') && current.projectId) {
+      const currentRepo = await this.showRepo(`id:${current.projectId}`)
+      assertAutomationRunContextMatchesRepo(updates.runContext, currentRepo)
     }
     if (!targetChanged && patch.reuseSession && current.workspaceMode !== 'existing') {
       throw new Error('Session reuse requires an existing workspace target.')
@@ -4355,6 +4372,7 @@ export class OrcaRuntimeService {
     projectId: string
     workspaceMode: AutomationWorkspaceMode
     workspaceId?: string | null
+    repo: Repo | null
   }> {
     const hasRepo = input.repo !== undefined
     const hasWorkspace = input.workspace !== undefined
@@ -4369,7 +4387,14 @@ export class OrcaRuntimeService {
       )
     }
     const workspace = input.workspace ? await this.showManagedWorktree(input.workspace) : null
-    const repo = input.repo ? await this.showRepo(input.repo) : null
+    const repoSelector =
+      input.repo ??
+      (workspace?.repoId
+        ? `id:${workspace.repoId}`
+        : current?.projectId
+          ? `id:${current.projectId}`
+          : null)
+    const repo = repoSelector ? await this.showRepo(repoSelector) : null
     const workspaceMode =
       input.workspaceMode ??
       (workspace
@@ -4386,13 +4411,13 @@ export class OrcaRuntimeService {
       if (!workspaceId || !projectId) {
         throw new Error('Existing-workspace automation requires --workspace.')
       }
-      return { projectId, workspaceMode, workspaceId }
+      return { projectId, workspaceMode, workspaceId, repo }
     }
     const projectId = repo?.id ?? workspace?.repoId ?? current?.projectId
     if (!projectId) {
       throw new Error('Automation requires --repo or --workspace.')
     }
-    return { projectId, workspaceMode: 'new_per_run', workspaceId: null }
+    return { projectId, workspaceMode: 'new_per_run', workspaceId: null, repo }
   }
 
   // Why: lazy initialization — the DB path depends on userData, which on the desktop

--- a/src/renderer/src/components/automations/AutomationEditorDialog.tsx
+++ b/src/renderer/src/components/automations/AutomationEditorDialog.tsx
@@ -69,6 +69,7 @@ type AutomationEditorDialogProps = {
   draft: AutomationDraft
   onProjectChange: (projectId: string) => void
   getRepoHostLabel?: (repo: Repo) => string | null | undefined
+  allowAddProject?: boolean
   onCreateTargetChange: (target: AutomationCreateTarget) => void
   onOpenChange: (open: boolean) => void
   onDraftChange: (updater: (current: AutomationDraft) => AutomationDraft) => void
@@ -94,6 +95,7 @@ export function AutomationEditorDialog({
   draft,
   onProjectChange,
   getRepoHostLabel,
+  allowAddProject,
   onCreateTargetChange,
   onOpenChange,
   onDraftChange,
@@ -186,6 +188,7 @@ export function AutomationEditorDialog({
             segmentedItemClassName={AUTOMATION_EDITOR_SEGMENTED_ITEM_CLASS}
             onProjectChange={onProjectChange}
             getRepoHostLabel={getRepoHostLabel}
+            allowAddProject={allowAddProject}
             onDraftChange={onDraftChange}
             onSetupDecisionTouched={onSetupDecisionTouched}
           />

--- a/src/renderer/src/components/automations/AutomationEditorSettingsSidebar.tsx
+++ b/src/renderer/src/components/automations/AutomationEditorSettingsSidebar.tsx
@@ -38,6 +38,7 @@ type AutomationEditorSettingsSidebarProps = {
   segmentedItemClassName: string
   onProjectChange: (projectId: string) => void
   getRepoHostLabel?: (repo: Repo) => string | null | undefined
+  allowAddProject?: boolean
   onDraftChange: (updater: (current: AutomationDraft) => AutomationDraft) => void
   onSetupDecisionTouched: () => void
 }
@@ -59,6 +60,7 @@ export function AutomationEditorSettingsSidebar({
   segmentedItemClassName,
   onProjectChange,
   getRepoHostLabel,
+  allowAddProject,
   onDraftChange,
   onSetupDecisionTouched
 }: AutomationEditorSettingsSidebarProps): React.JSX.Element {
@@ -123,6 +125,7 @@ export function AutomationEditorSettingsSidebar({
             )}
             triggerClassName={`h-9 w-full min-w-0 ${pickerTriggerClassName}`}
             getRepoHostLabel={getRepoHostLabel}
+            allowAddProject={allowAddProject}
           />
         </Field>
         <div className="mb-4">

--- a/src/renderer/src/components/automations/AutomationListToolbar.tsx
+++ b/src/renderer/src/components/automations/AutomationListToolbar.tsx
@@ -20,7 +20,8 @@ export function AutomationListToolbar({
   onFilterChange,
   onRefresh,
   isRefreshing,
-  openCreateDialog
+  openCreateDialog,
+  canCreateAutomation
 }: {
   listSearchQuery: string
   isListSearchQueryTooLarge: boolean
@@ -31,6 +32,7 @@ export function AutomationListToolbar({
   onRefresh: () => void
   isRefreshing: boolean
   openCreateDialog: (template?: AutomationTemplate) => void
+  canCreateAutomation: boolean
 }): React.JSX.Element {
   return (
     <div className="flex shrink-0 items-start justify-between gap-3">
@@ -80,6 +82,7 @@ export function AutomationListToolbar({
         size="sm"
         className="shrink-0"
         onClick={() => openCreateDialog()}
+        disabled={!canCreateAutomation}
         data-contextual-tour-target="automations-create"
       >
         <Plus className="size-4" />

--- a/src/renderer/src/components/automations/AutomationProjectCombobox.tsx
+++ b/src/renderer/src/components/automations/AutomationProjectCombobox.tsx
@@ -25,6 +25,7 @@ type AutomationProjectComboboxProps = {
   placeholder?: string
   triggerClassName?: string
   getRepoHostLabel?: (repo: Repo) => string | null | undefined
+  allowAddProject?: boolean
 }
 
 function getRepoDetail(repo: Repo, hostLabel?: string | null): string {
@@ -53,7 +54,8 @@ export default function AutomationProjectCombobox({
   onValueChange,
   placeholder = 'Select project',
   triggerClassName,
-  getRepoHostLabel
+  getRepoHostLabel,
+  allowAddProject = true
 }: AutomationProjectComboboxProps): React.JSX.Element {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
@@ -375,30 +377,32 @@ export default function AutomationProjectCombobox({
               )
             })}
           </CommandList>
-          <div className="border-t border-border">
-            <Button
-              type="button"
-              variant="ghost"
-              disabled={isAdding}
-              onClick={() => void handleAddFolder()}
-              onMouseDown={(event) => event.preventDefault()}
-              onMouseEnter={() => setCommandValue('')}
-              className="h-8 w-full justify-start rounded-none px-3 text-xs font-normal"
-            >
-              <FolderPlus className="size-3.5 text-muted-foreground" />
-              <span>
-                {isAdding
-                  ? translate(
-                      'auto.components.automations.AutomationProjectCombobox.adding',
-                      'Adding project…'
-                    )
-                  : translate(
-                      'auto.components.automations.AutomationProjectCombobox.addProject',
-                      'Add project'
-                    )}
-              </span>
-            </Button>
-          </div>
+          {allowAddProject ? (
+            <div className="border-t border-border">
+              <Button
+                type="button"
+                variant="ghost"
+                disabled={isAdding}
+                onClick={() => void handleAddFolder()}
+                onMouseDown={(event) => event.preventDefault()}
+                onMouseEnter={() => setCommandValue('')}
+                className="h-8 w-full justify-start rounded-none px-3 text-xs font-normal"
+              >
+                <FolderPlus className="size-3.5 text-muted-foreground" />
+                <span>
+                  {isAdding
+                    ? translate(
+                        'auto.components.automations.AutomationProjectCombobox.adding',
+                        'Adding project…'
+                      )
+                    : translate(
+                        'auto.components.automations.AutomationProjectCombobox.addProject',
+                        'Add project'
+                      )}
+                </span>
+              </Button>
+            </div>
+          ) : null}
         </Command>
       </PopoverContent>
     </Popover>

--- a/src/renderer/src/components/automations/AutomationsListPanel.tsx
+++ b/src/renderer/src/components/automations/AutomationsListPanel.tsx
@@ -81,6 +81,7 @@ type AutomationsListPanelProps = {
   ) => void
   openEditExternalDialog: (manager: ExternalAutomationManager, job: ExternalAutomationJob) => void
   openCreateDialog: (template?: AutomationTemplate) => void
+  canCreateAutomation: boolean
   onOpenDetail: () => void
   onRefresh: () => void
   isRefreshing: boolean
@@ -122,6 +123,7 @@ export function AutomationsListPanel({
   requestExternalAction,
   openEditExternalDialog,
   openCreateDialog,
+  canCreateAutomation,
   onOpenDetail,
   onRefresh,
   isRefreshing
@@ -205,6 +207,7 @@ export function AutomationsListPanel({
                 key={template.id}
                 type="button"
                 onClick={() => openCreateDialog(template)}
+                disabled={!canCreateAutomation}
                 className="rounded-md border border-border/70 bg-background px-3 py-2 text-left shadow-xs transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
               >
                 <div className="text-[11px] font-medium uppercase text-muted-foreground">
@@ -221,6 +224,7 @@ export function AutomationsListPanel({
               variant="outline"
               className="mt-1 w-full justify-start"
               onClick={() => openCreateDialog()}
+              disabled={!canCreateAutomation}
             >
               <Plus className="size-4" />
               {translate('auto.components.automations.AutomationsPage.25060635c6', 'Add new')}
@@ -239,6 +243,7 @@ export function AutomationsListPanel({
             onRefresh={onRefresh}
             isRefreshing={isRefreshing}
             openCreateDialog={openCreateDialog}
+            canCreateAutomation={canCreateAutomation}
           />
 
           <div

--- a/src/renderer/src/components/automations/AutomationsPage.tsx
+++ b/src/renderer/src/components/automations/AutomationsPage.tsx
@@ -64,7 +64,10 @@ import type { AutomationTemplate } from './automation-templates'
 import { getAutomationTargetAvailability } from './automation-target-availability'
 import { getAutomationCreateAvailability } from './automation-create-admission'
 import { buildAutomationRunContextForRepo } from './automation-run-context'
-import { repoMatchesExternalAutomationTarget } from './automation-external-target-match'
+import {
+  repoMatchesExternalAutomationTarget,
+  getExternalAutomationTargetForRepo
+} from './automation-external-target-match'
 import { ensureHooksConfirmed } from '@/lib/ensure-hooks-confirmed'
 import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
 import { checkRuntimeHooks } from '@/runtime/runtime-hooks-client'
@@ -1376,10 +1379,7 @@ export default function AutomationsPage(): React.JSX.Element {
           return
         }
         const target =
-          editingExternalTarget?.manager.target ??
-          (repo.connectionId
-            ? { type: 'ssh' as const, connectionId: repo.connectionId }
-            : { type: 'local' as const })
+          editingExternalTarget?.manager.target ?? getExternalAutomationTargetForRepo(repo)
         const repoTargetMatches = repoMatchesExternalAutomationTarget(repo, target)
         if (!repoTargetMatches) {
           toast.error(

--- a/src/renderer/src/components/automations/AutomationsPage.tsx
+++ b/src/renderer/src/components/automations/AutomationsPage.tsx
@@ -64,6 +64,7 @@ import type { AutomationTemplate } from './automation-templates'
 import { getAutomationTargetAvailability } from './automation-target-availability'
 import { getAutomationCreateAvailability } from './automation-create-admission'
 import { buildAutomationRunContextForRepo } from './automation-run-context'
+import { repoMatchesExternalAutomationTarget } from './automation-external-target-match'
 import { ensureHooksConfirmed } from '@/lib/ensure-hooks-confirmed'
 import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
 import { checkRuntimeHooks } from '@/runtime/runtime-hooks-client'
@@ -1212,18 +1213,12 @@ export default function AutomationsPage(): React.JSX.Element {
         .find((worktree) => {
           const repo = repoMap.get(worktree.repoId)
           const repoTargetMatches =
-            manager.target.type === 'local'
-              ? !repo?.connectionId
-              : repo?.connectionId === manager.target.connectionId
+            repo !== undefined && repoMatchesExternalAutomationTarget(repo, manager.target)
           return repoTargetMatches && job.workdir !== null && worktree.path === job.workdir
         }) ?? null
     const localRepos = getAutomationCreateRepos(repos, { kind: 'local' })
     const fallbackRepo =
-      localRepos.find((repo) =>
-        manager.target.type === 'local'
-          ? !repo.connectionId
-          : repo.connectionId === manager.target.connectionId
-      ) ??
+      localRepos.find((repo) => repoMatchesExternalAutomationTarget(repo, manager.target)) ??
       localRepos[0] ??
       null
     const fallbackWorktree = fallbackRepo
@@ -1385,8 +1380,7 @@ export default function AutomationsPage(): React.JSX.Element {
           (repo.connectionId
             ? { type: 'ssh' as const, connectionId: repo.connectionId }
             : { type: 'local' as const })
-        const repoTargetMatches =
-          target.type === 'local' ? !repo.connectionId : repo.connectionId === target.connectionId
+        const repoTargetMatches = repoMatchesExternalAutomationTarget(repo, target)
         if (!repoTargetMatches) {
           toast.error(
             translate(

--- a/src/renderer/src/components/automations/AutomationsPage.tsx
+++ b/src/renderer/src/components/automations/AutomationsPage.tsx
@@ -62,6 +62,7 @@ import {
 } from './automation-setup-decision'
 import type { AutomationTemplate } from './automation-templates'
 import { getAutomationTargetAvailability } from './automation-target-availability'
+import { getAutomationCreateAvailability } from './automation-create-admission'
 import { buildAutomationRunContextForRepo } from './automation-run-context'
 import { ensureHooksConfirmed } from '@/lib/ensure-hooks-confirmed'
 import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
@@ -85,6 +86,7 @@ import {
   runAutomationNowForTarget,
   updateAutomationForTarget
 } from './automation-host-client'
+import { getAutomationCreateRepos } from './automation-create-projects'
 import type { FetchExternalAutomationRuns } from './ExternalAutomationRunTable'
 import {
   AUTOMATION_DEFAULT_TIME,
@@ -753,19 +755,46 @@ export default function AutomationsPage(): React.JSX.Element {
   }, [activePaneTab, selected, selectedExternal])
 
   const getDefaultTarget = useCallback(() => {
+    const destinationTarget = getAutomationListTarget(settings)
+    const eligibleRepos = getAutomationCreateRepos(repos, destinationTarget)
     const activeWorktree = activeWorktreeId ? worktreeMap.get(activeWorktreeId) : null
     const activeRepo = activeWorktree ? (repoMap.get(activeWorktree.repoId) ?? null) : null
-    const fallbackRepo = activeRepo ?? repos[0] ?? null
+    const fallbackRepo =
+      (activeRepo &&
+      eligibleRepos.some(
+        (repo) =>
+          repo.id === activeRepo.id &&
+          getRepoExecutionHostId(repo) === getRepoExecutionHostId(activeRepo)
+      )
+        ? activeRepo
+        : null) ??
+      eligibleRepos[0] ??
+      null
     const fallbackWorktrees = fallbackRepo ? (worktreesByRepo[fallbackRepo.id] ?? []) : []
     // Why: automation-created workspaces can be active; new automations should start from
     // the repo's stable main worktree unless the user explicitly chooses otherwise.
-    const targetWorktree = getDefaultWorktree(fallbackWorktrees) ?? activeWorktree
-    const targetProjectId = fallbackRepo?.id ?? targetWorktree?.repoId ?? ''
+    const targetWorktree = fallbackRepo ? getDefaultWorktree(fallbackWorktrees) : null
+    const targetProjectId = fallbackRepo?.id ?? ''
     return {
       projectId: targetProjectId,
       workspaceId: targetWorktree?.id ?? ''
     }
-  }, [activeWorktreeId, repoMap, repos, worktreeMap, worktreesByRepo])
+  }, [activeWorktreeId, repoMap, repos, settings, worktreeMap, worktreesByRepo])
+
+  const canCreateAutomation = getAutomationCreateAvailability({
+    automationHostTarget: getAutomationListTarget(settings),
+    runtimeStatusByEnvironmentId
+  }).canRunNow
+  const editingAutomation = editingAutomationId
+    ? (automations.find((automation) => automation.id === editingAutomationId) ?? null)
+    : null
+  const automationDialogTarget = editingAutomation
+    ? getAutomationOwnerTarget(editingAutomation, automationHostTarget)
+    : getAutomationListTarget(settings)
+  const isOrcaForm = createTarget === 'orca' && editingExternalTarget === null
+  const dialogRepos = isOrcaForm
+    ? getAutomationCreateRepos(repos, automationDialogTarget)
+    : getAutomationCreateRepos(repos, { kind: 'local' })
 
   const refresh = useCallback(async () => {
     setIsLoading(true)
@@ -1046,18 +1075,38 @@ export default function AutomationsPage(): React.JSX.Element {
     }))
   }, [])
 
-  const handleCreateTargetChange = useCallback((target: AutomationCreateTarget): void => {
-    setCreateTarget(target)
-    if (target === 'hermes') {
-      setDraft((current) => ({
-        ...current,
-        agentId: 'hermes',
-        workspaceMode: 'existing',
-        setupDecision: undefined,
-        reuseSession: false
-      }))
-    }
-  }, [])
+  const handleCreateTargetChange = useCallback(
+    (target: AutomationCreateTarget): void => {
+      setCreateTarget(target)
+      if (target === 'hermes') {
+        const localRepos = getAutomationCreateRepos(repos, { kind: 'local' })
+        setDraft((current) => {
+          const currentRepo = repos.find((repo) => repo.id === current.projectId)
+          const currentRepoIsLocal =
+            currentRepo !== undefined &&
+            localRepos.some(
+              (repo) =>
+                repo.id === currentRepo.id &&
+                getRepoExecutionHostId(repo) === getRepoExecutionHostId(currentRepo)
+            )
+          const nextRepo = currentRepoIsLocal ? currentRepo : localRepos[0]
+          const nextWorkspace = nextRepo
+            ? getDefaultWorktree(worktreesByRepo[nextRepo.id] ?? [])
+            : null
+          return {
+            ...current,
+            agentId: 'hermes',
+            projectId: nextRepo?.id ?? '',
+            workspaceId: nextWorkspace?.id ?? '',
+            workspaceMode: 'existing',
+            setupDecision: undefined,
+            reuseSession: false
+          }
+        })
+      }
+    },
+    [repos, worktreesByRepo]
+  )
 
   const openCreateDialog = (template?: AutomationTemplate): void => {
     editRequestRef.current += 1
@@ -1168,9 +1217,20 @@ export default function AutomationsPage(): React.JSX.Element {
               : repo?.connectionId === manager.target.connectionId
           return repoTargetMatches && job.workdir !== null && worktree.path === job.workdir
         }) ?? null
-    const fallbackTarget = getDefaultTarget()
-    const projectId = targetWorktree?.repoId ?? fallbackTarget.projectId
-    const workspaceId = targetWorktree?.id ?? fallbackTarget.workspaceId
+    const localRepos = getAutomationCreateRepos(repos, { kind: 'local' })
+    const fallbackRepo =
+      localRepos.find((repo) =>
+        manager.target.type === 'local'
+          ? !repo.connectionId
+          : repo.connectionId === manager.target.connectionId
+      ) ??
+      localRepos[0] ??
+      null
+    const fallbackWorktree = fallbackRepo
+      ? getDefaultWorktree(worktreesByRepo[fallbackRepo.id] ?? [])
+      : null
+    const projectId = targetWorktree?.repoId ?? fallbackRepo?.id ?? ''
+    const workspaceId = targetWorktree?.id ?? fallbackWorktree?.id ?? ''
     const nextDraft: AutomationDraft = {
       name: job.name,
       prompt: job.prompt ?? job.promptPreview,
@@ -1263,6 +1323,20 @@ export default function AutomationsPage(): React.JSX.Element {
         translate(
           'auto.components.automations.AutomationsPage.6e91dab317',
           'Enter a valid advanced schedule before saving.'
+        )
+      )
+      return
+    }
+    if (
+      editingAutomationId === null &&
+      editingExternalTarget === null &&
+      createTarget === 'orca' &&
+      !canCreateAutomation
+    ) {
+      toast.error(
+        translate(
+          'auto.components.automations.AutomationsPage.destinationUnavailable',
+          'The selected automation destination is not ready. Reconnect it and try again.'
         )
       )
       return
@@ -1362,6 +1436,15 @@ export default function AutomationsPage(): React.JSX.Element {
                 'auto.components.automations.AutomationsPage.77b81bc4ac',
                 'Hermes automation created.'
               )
+        )
+        return
+      }
+      if (isOrcaForm && !dialogRepos.some((repo) => repo.id === draft.projectId)) {
+        toast.error(
+          translate(
+            'auto.components.automations.AutomationsPage.destinationProjectUnavailable',
+            'Choose a project owned by the selected automation destination.'
+          )
         )
         return
       }
@@ -1927,7 +2010,7 @@ export default function AutomationsPage(): React.JSX.Element {
         canSave={canSaveDraft}
         isEditingExternal={editingExternalTarget !== null}
         createTarget={createTarget}
-        repos={repos}
+        repos={dialogRepos}
         projectHostSetups={projectHostSetups}
         automationYamlHooksByRepoKey={automationYamlHooksByRepoKey}
         getAutomationHooksCacheKey={getAutomationHooksCacheKey}
@@ -1937,6 +2020,7 @@ export default function AutomationsPage(): React.JSX.Element {
         draft={draft}
         onProjectChange={handleProjectChange}
         getRepoHostLabel={getAutomationRepoHostLabel}
+        allowAddProject={!isOrcaForm || automationDialogTarget.kind === 'local'}
         onCreateTargetChange={handleCreateTargetChange}
         onOpenChange={setCreateOpen}
         onDraftChange={setDraft}
@@ -2071,6 +2155,7 @@ export default function AutomationsPage(): React.JSX.Element {
           requestExternalAction={requestExternalAction}
           openEditExternalDialog={openEditExternalDialog}
           openCreateDialog={openCreateDialog}
+          canCreateAutomation={canCreateAutomation}
           onOpenDetail={() => setIsDetailOpen(true)}
           onRefresh={() => void refresh()}
           isRefreshing={isLoading}

--- a/src/renderer/src/components/automations/automation-create-admission.ts
+++ b/src/renderer/src/components/automations/automation-create-admission.ts
@@ -1,0 +1,22 @@
+import type { RuntimeStatus } from '../../../../shared/runtime-types'
+import type { AutomationHostTarget } from './automation-host-client'
+import {
+  getRuntimeAutomationAvailability,
+  type AutomationTargetAvailability
+} from './automation-target-availability'
+
+export function getAutomationCreateAvailability(args: {
+  automationHostTarget: AutomationHostTarget
+  runtimeStatusByEnvironmentId?: ReadonlyMap<
+    string,
+    { status: RuntimeStatus | null; checkedAt: number }
+  >
+}): AutomationTargetAvailability {
+  if (args.automationHostTarget.kind === 'local') {
+    return { canRunNow: true, reason: 'available', message: null }
+  }
+  return getRuntimeAutomationAvailability(
+    args.automationHostTarget.environmentId,
+    args.runtimeStatusByEnvironmentId
+  )
+}

--- a/src/renderer/src/components/automations/automation-create-projects.test.ts
+++ b/src/renderer/src/components/automations/automation-create-projects.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import type { Repo } from '../../../../shared/repo-types'
+import { getAutomationCreateRepos } from './automation-create-projects'
+
+function repo(id: string, executionHostId: Repo['executionHostId']): Repo {
+  return {
+    id,
+    path: `/${id}`,
+    displayName: id,
+    badgeColor: '#000000',
+    addedAt: 1,
+    executionHostId
+  }
+}
+
+describe('getAutomationCreateRepos', () => {
+  const repos = [
+    repo('local', 'local'),
+    repo('remote', 'runtime:env-1'),
+    repo('ssh', 'ssh:builder')
+  ]
+
+  it('selects only the destination runtime catalog', () => {
+    expect(
+      getAutomationCreateRepos(repos, { kind: 'environment', environmentId: 'env-1' })
+    ).toEqual([repos[1]])
+  })
+
+  it('keeps local and direct SSH rows but excludes paired-runtime rows', () => {
+    expect(getAutomationCreateRepos(repos, { kind: 'local' })).toEqual([repos[0], repos[2]])
+  })
+
+  it('fails closed when the destination runtime has no project', () => {
+    expect(
+      getAutomationCreateRepos(repos, { kind: 'environment', environmentId: 'missing' })
+    ).toEqual([])
+  })
+})

--- a/src/renderer/src/components/automations/automation-create-projects.ts
+++ b/src/renderer/src/components/automations/automation-create-projects.ts
@@ -1,0 +1,24 @@
+import {
+  getRepoExecutionHostId,
+  parseExecutionHostId,
+  toRuntimeExecutionHostId
+} from '../../../../shared/execution-host'
+import type { Repo } from '../../../../shared/repo-types'
+import type { AutomationHostTarget } from './automation-host-client'
+
+/**
+ * Runtime-host automation creation must choose from that host's repo catalog.
+ * Local automation storage intentionally keeps the existing SSH-capable catalog.
+ */
+export function getAutomationCreateRepos(
+  repos: readonly Repo[],
+  target: AutomationHostTarget
+): Repo[] {
+  if (target.kind !== 'environment') {
+    return repos.filter(
+      (repo) => parseExecutionHostId(getRepoExecutionHostId(repo))?.kind !== 'runtime'
+    )
+  }
+  const hostId = toRuntimeExecutionHostId(target.environmentId)
+  return repos.filter((repo) => getRepoExecutionHostId(repo) === hostId)
+}

--- a/src/renderer/src/components/automations/automation-external-target-match.test.ts
+++ b/src/renderer/src/components/automations/automation-external-target-match.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import type { ExternalAutomationTarget } from '../../../../shared/automations-types'
+import { toSshExecutionHostId } from '../../../../shared/execution-host'
+import type { Repo } from '../../../../shared/repo-types'
+import { repoMatchesExternalAutomationTarget } from './automation-external-target-match'
+
+function repo(
+  overrides: Partial<Pick<Repo, 'connectionId' | 'executionHostId'>> = {}
+): Pick<Repo, 'connectionId' | 'executionHostId'> {
+  return { connectionId: undefined, executionHostId: undefined, ...overrides }
+}
+
+const sshTarget: ExternalAutomationTarget = { type: 'ssh', connectionId: 'conn-1' }
+const localTarget: ExternalAutomationTarget = { type: 'local' }
+
+describe('repoMatchesExternalAutomationTarget', () => {
+  it('matches a plain local repo against the local target', () => {
+    expect(repoMatchesExternalAutomationTarget(repo(), localTarget)).toBe(true)
+  })
+
+  it('derives the ssh host from connectionId when executionHostId is unset', () => {
+    expect(repoMatchesExternalAutomationTarget(repo({ connectionId: 'conn-1' }), sshTarget)).toBe(
+      true
+    )
+  })
+
+  it('rejects an ssh repo whose executionHostId points at another host despite matching connectionId', () => {
+    expect(
+      repoMatchesExternalAutomationTarget(
+        repo({ connectionId: 'conn-1', executionHostId: toSshExecutionHostId('conn-2') }),
+        sshTarget
+      )
+    ).toBe(false)
+  })
+
+  it('accepts an explicit executionHostId equal to the target host id', () => {
+    expect(
+      repoMatchesExternalAutomationTarget(
+        repo({ connectionId: 'other-conn', executionHostId: toSshExecutionHostId('conn-1') }),
+        sshTarget
+      )
+    ).toBe(true)
+  })
+
+  it('treats a runtime-owned execution host as not local even without a connectionId', () => {
+    expect(
+      repoMatchesExternalAutomationTarget(repo({ executionHostId: 'runtime:env-1' }), localTarget)
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/automations/automation-external-target-match.test.ts
+++ b/src/renderer/src/components/automations/automation-external-target-match.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest'
 import type { ExternalAutomationTarget } from '../../../../shared/automations-types'
 import { toSshExecutionHostId } from '../../../../shared/execution-host'
 import type { Repo } from '../../../../shared/repo-types'
-import { repoMatchesExternalAutomationTarget } from './automation-external-target-match'
+import {
+  repoMatchesExternalAutomationTarget,
+  getExternalAutomationTargetForRepo
+} from './automation-external-target-match'
 
 function repo(
   overrides: Partial<Pick<Repo, 'connectionId' | 'executionHostId'>> = {}
@@ -46,5 +49,36 @@ describe('repoMatchesExternalAutomationTarget', () => {
     expect(
       repoMatchesExternalAutomationTarget(repo({ executionHostId: 'runtime:env-1' }), localTarget)
     ).toBe(false)
+  })
+})
+
+describe('getExternalAutomationTargetForRepo', () => {
+  it('prefers an explicit executionHostId over a disagreeing connectionId', () => {
+    expect(
+      getExternalAutomationTargetForRepo(
+        repo({ connectionId: 'conn-1', executionHostId: toSshExecutionHostId('conn-2') })
+      )
+    ).toEqual({ type: 'ssh', connectionId: 'conn-2' })
+  })
+
+  it('derives the ssh target from connectionId when executionHostId is unset', () => {
+    expect(getExternalAutomationTargetForRepo(repo({ connectionId: 'conn-1' }))).toEqual({
+      type: 'ssh',
+      connectionId: 'conn-1'
+    })
+  })
+
+  it('round-trips connection ids that need host-id encoding', () => {
+    expect(getExternalAutomationTargetForRepo(repo({ connectionId: 'user@host:22' }))).toEqual({
+      type: 'ssh',
+      connectionId: 'user@host:22'
+    })
+  })
+
+  it('returns the local target for a plain local repo and for non-ssh hosts', () => {
+    expect(getExternalAutomationTargetForRepo(repo())).toEqual({ type: 'local' })
+    expect(getExternalAutomationTargetForRepo(repo({ executionHostId: 'runtime:env-1' }))).toEqual({
+      type: 'local'
+    })
   })
 })

--- a/src/renderer/src/components/automations/automation-external-target-match.ts
+++ b/src/renderer/src/components/automations/automation-external-target-match.ts
@@ -1,0 +1,20 @@
+import type { ExternalAutomationTarget } from '../../../../shared/automations-types'
+import {
+  getRepoExecutionHostId,
+  parseExecutionHostId,
+  toSshExecutionHostId
+} from '../../../../shared/execution-host'
+import type { Repo } from '../../../../shared/repo-types'
+
+// Why: connectionId alone can disagree with the repo's pinned executionHostId;
+// the execution host is the authority for which Hermes target owns a repo.
+export function repoMatchesExternalAutomationTarget(
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'>,
+  target: ExternalAutomationTarget
+): boolean {
+  const repoHostId = getRepoExecutionHostId(repo)
+  if (target.type === 'local') {
+    return parseExecutionHostId(repoHostId)?.kind === 'local'
+  }
+  return repoHostId === toSshExecutionHostId(target.connectionId)
+}

--- a/src/renderer/src/components/automations/automation-external-target-match.ts
+++ b/src/renderer/src/components/automations/automation-external-target-match.ts
@@ -18,3 +18,12 @@ export function repoMatchesExternalAutomationTarget(
   }
   return repoHostId === toSshExecutionHostId(target.connectionId)
 }
+
+// Why: the manager target must name the repo's authoritative execution host,
+// not a possibly-stale connectionId.
+export function getExternalAutomationTargetForRepo(
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'>
+): ExternalAutomationTarget {
+  const parsed = parseExecutionHostId(getRepoExecutionHostId(repo))
+  return parsed?.kind === 'ssh' ? { type: 'ssh', connectionId: parsed.targetId } : { type: 'local' }
+}

--- a/src/renderer/src/components/automations/automation-host-client.test.ts
+++ b/src/renderer/src/components/automations/automation-host-client.test.ts
@@ -114,7 +114,7 @@ describe('automation host client', () => {
       { kind: 'environment', environmentId: 'gpu' },
       'automation.create',
       expect.objectContaining({
-        repo: 'repo-1',
+        repo: 'id:repo-1',
         workspace: undefined,
         setupDecision: 'run',
         runContext: automation.runContext
@@ -126,6 +126,40 @@ describe('automation host client', () => {
       { kind: 'environment', environmentId: 'gpu' },
       'automation.runNow',
       { id: automation.id },
+      { timeoutMs: 15_000 }
+    )
+  })
+
+  it('uses an exact machine selector for an existing runtime workspace', async () => {
+    const automation = makeAutomation({
+      workspaceMode: 'existing',
+      workspaceId: 'repo-1::/srv/orca'
+    })
+    const input: AutomationCreateInput = {
+      name: automation.name,
+      prompt: automation.prompt,
+      precheck: null,
+      agentId: automation.agentId,
+      runContext: automation.runContext,
+      projectId: automation.projectId,
+      workspaceMode: 'existing',
+      workspaceId: automation.workspaceId,
+      setupDecision: 'skip',
+      timezone: automation.timezone,
+      rrule: automation.rrule,
+      dtstart: automation.dtstart
+    }
+    vi.mocked(callRuntimeRpc).mockResolvedValueOnce({ automation })
+
+    await createAutomationForTarget(input)
+
+    expect(callRuntimeRpc).toHaveBeenCalledWith(
+      { kind: 'environment', environmentId: 'gpu' },
+      'automation.create',
+      expect.objectContaining({
+        repo: 'id:repo-1',
+        workspace: 'id:repo-1::/srv/orca'
+      }),
       { timeoutMs: 15_000 }
     )
   })

--- a/src/renderer/src/components/automations/automation-host-client.ts
+++ b/src/renderer/src/components/automations/automation-host-client.ts
@@ -76,8 +76,9 @@ function toRuntimeAutomationCreateInput(
   const { projectId, workspaceId, ...rest } = input
   return {
     ...rest,
-    repo: projectId,
-    workspace: input.workspaceMode === 'existing' ? (workspaceId ?? undefined) : undefined
+    // Machine selectors must not fall back to path/name matching on a remote host.
+    repo: `id:${projectId}`,
+    workspace: input.workspaceMode === 'existing' && workspaceId ? `id:${workspaceId}` : undefined
   }
 }
 
@@ -87,8 +88,10 @@ function toRuntimeAutomationUpdateInput(
   const { projectId, workspaceId, ...rest } = input
   return {
     ...rest,
-    ...(projectId !== undefined ? { repo: projectId } : {}),
-    ...(workspaceId !== undefined ? { workspace: workspaceId ?? undefined } : {})
+    ...(projectId !== undefined ? { repo: `id:${projectId}` } : {}),
+    ...(workspaceId !== undefined
+      ? { workspace: workspaceId ? `id:${workspaceId}` : undefined }
+      : {})
   }
 }
 

--- a/src/renderer/src/components/automations/automation-run-context.test.ts
+++ b/src/renderer/src/components/automations/automation-run-context.test.ts
@@ -3,14 +3,19 @@ import type { ProjectHostSetup } from '../../../../shared/project-types'
 import type { Repo } from '../../../../shared/repo-types'
 import { buildAutomationRunContextForRepo } from './automation-run-context'
 
-function repo(id: string, path = `/repos/${id}`): Repo {
+function repo(id: string, path = `/repos/${id}`, executionHostId?: Repo['executionHostId']): Repo {
   return {
     id,
     path,
     displayName: id,
     badgeColor: '#000000',
-    addedAt: 1
+    addedAt: 1,
+    executionHostId
   }
+}
+
+function remoteRepo(id: string, path = `/repos/${id}`): Repo {
+  return { ...repo(id, path), executionHostId: 'runtime:env-1' }
 }
 
 function setup(overrides: Partial<ProjectHostSetup> = {}): ProjectHostSetup {
@@ -34,7 +39,10 @@ describe('buildAutomationRunContextForRepo', () => {
     expect(
       buildAutomationRunContextForRepo({
         repoId: 'repo-builder',
-        repos: [repo('repo-local', '/local/orca'), repo('repo-builder', '/remote/orca')],
+        repos: [
+          repo('repo-local', '/local/orca'),
+          repo('repo-builder', '/remote/orca', 'ssh:builder')
+        ],
         projectHostSetups: [
           setup({
             id: 'setup-local',
@@ -69,6 +77,16 @@ describe('buildAutomationRunContextForRepo', () => {
         repoId: 'repo-builder',
         repos: [],
         projectHostSetups: [setup()]
+      })
+    ).toBeNull()
+  })
+
+  it('fails closed when the same repo id exists on more than one authority', () => {
+    expect(
+      buildAutomationRunContextForRepo({
+        repoId: 'same-id',
+        repos: [repo('same-id', '/local/orca'), remoteRepo('same-id', '/remote/orca')],
+        projectHostSetups: []
       })
     ).toBeNull()
   })

--- a/src/renderer/src/components/automations/automation-run-context.ts
+++ b/src/renderer/src/components/automations/automation-run-context.ts
@@ -4,20 +4,26 @@ import {
 } from '../../../../shared/task-source-context'
 import type { ProjectHostSetup } from '../../../../shared/project-types'
 import type { Repo } from '../../../../shared/repo-types'
+import { getRepoExecutionHostId } from '../../../../shared/execution-host'
 
 export function buildAutomationRunContextForRepo(args: {
   repoId: string
   repos: readonly Repo[]
   projectHostSetups: readonly ProjectHostSetup[]
 }): WorkspaceRunContext | null {
-  const setup = args.projectHostSetups.find(
-    (candidate) => candidate.repoId === args.repoId && candidate.setupState === 'ready'
-  )
-  if (!setup) {
+  const matchingRepos = args.repos.filter((candidate) => candidate.id === args.repoId)
+  if (matchingRepos.length !== 1) {
     return null
   }
-  const repo = args.repos.find((candidate) => candidate.id === setup.repoId)
-  if (!repo) {
+  const repo = matchingRepos[0]
+  const hostId = getRepoExecutionHostId(repo)
+  const setup = args.projectHostSetups.find(
+    (candidate) =>
+      candidate.repoId === repo.id &&
+      candidate.hostId === hostId &&
+      candidate.setupState === 'ready'
+  )
+  if (!setup) {
     return null
   }
   return buildWorkspaceRunContext({

--- a/src/renderer/src/components/automations/automation-target-availability.test.ts
+++ b/src/renderer/src/components/automations/automation-target-availability.test.ts
@@ -5,6 +5,7 @@ import type { ProjectHostSetup } from '../../../../shared/project-types'
 import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import { getAutomationTargetAvailability } from './automation-target-availability'
+import { getAutomationCreateAvailability } from './automation-create-admission'
 
 function makeAutomation(overrides: Partial<Automation> = {}): Automation {
   return {
@@ -87,6 +88,21 @@ function makeRuntimeStatus(overrides: Partial<RuntimeStatus> = {}): RuntimeStatu
 }
 
 describe('automation target availability', () => {
+  it('blocks create admission for a missing or degraded runtime', () => {
+    const target = { kind: 'environment' as const, environmentId: 'env-1' }
+    expect(getAutomationCreateAvailability({ automationHostTarget: target }).reason).toBe(
+      'runtime-checking'
+    )
+    expect(
+      getAutomationCreateAvailability({
+        automationHostTarget: target,
+        runtimeStatusByEnvironmentId: new Map([
+          ['env-1', { status: makeRuntimeStatus({ graphStatus: 'unavailable' }), checkedAt: 1 }]
+        ])
+      }).reason
+    ).toBe('runtime-unavailable')
+  })
+
   it('allows local automations with an available existing workspace', () => {
     expect(
       getAutomationTargetAvailability({

--- a/src/renderer/src/components/automations/automation-target-availability.ts
+++ b/src/renderer/src/components/automations/automation-target-availability.ts
@@ -72,6 +72,7 @@ export function getAutomationTargetAvailability({
   if (!repo) {
     return unavailable('missing-project', 'The target project is no longer available.')
   }
+
   if (automation.runContext) {
     const parsedHost = parseExecutionHostId(automation.runContext.hostId)
     if (parsedHost?.kind === 'runtime') {
@@ -264,7 +265,7 @@ function getAutomationSourceProviderLabel(provider: TaskSourceContext['provider'
   }
 }
 
-function getRuntimeAutomationAvailability(
+export function getRuntimeAutomationAvailability(
   environmentId: string,
   runtimeStatusByEnvironmentId:
     | ReadonlyMap<string, { status: RuntimeStatus | null; checkedAt: number }>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -15396,7 +15396,9 @@
           "newAutomation": "New Automation",
           "rowActions": "Automation actions",
           "tableLastRun": "Last run",
-          "noListMatches": "No automations match."
+          "noListMatches": "No automations match.",
+          "destinationUnavailable": "The selected automation destination is not ready. Reconnect it and try again.",
+          "destinationProjectUnavailable": "Choose a project owned by the selected automation destination."
         },
         "AutomationsPageSkeleton": {
           "55527b7bcf": "Loading automations"


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​272 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​268 |
| Prod | 14 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​278 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​69 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​209 |

<!-- /orca-pr-loc -->

## Summary

- Scope automation project catalogs to the destination/owner host.
- Send exact `id:` repo/workspace selectors over runtime RPC.
- Validate run-context identity at runtime and gate unavailable destinations.
- Preserve local, folder/WSL, direct-SSH, Hermes, and mixed-version behavior.

## Validation

- 35 focused Vitest tests passed.
- `pnpm tc:web`
- `pnpm tc:node`
- Changed-code quality, oxlint, and React Doctor.
- Electron/CDP fixture with colliding same-name/path repos.

## STA-5542

Latest main reproduced the local-repo leak; the fix keeps remote project selection destination-scoped and fails closed on foreign identity.

## Follow-up

A fully authority-qualified wire project reference remains a separate compatibility-gated follow-up for exact UUID collisions across authorities.
