### PR TITLE
fix(codex): preserve install context for updates

### DIFF
--- a/src/cli/codex-shell-launch.test.ts
+++ b/src/cli/codex-shell-launch.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+import { buildCodexShellLaunchEnv } from './codex-shell-launch'
+
+describe('Codex cmd.exe shell launch', () => {
+  it('routes update through the installation home', () => {
+    expect(
+      buildCodexShellLaunchEnv(['update'], {
+        CODEX_HOME: 'C:\\Orca\\account',
+        ORCA_CODEX_HOME: 'C:\\Orca\\account',
+        ORCA_CODEX_INSTALL_HOME: 'C:\\Users\\Ada\\.codex',
+        ELECTRON_RUN_AS_NODE: '1'
+      })
+    ).toEqual({
+      CODEX_HOME: 'C:\\Users\\Ada\\.codex',
+      ORCA_CODEX_INSTALL_HOME: 'C:\\Users\\Ada\\.codex'
+    })
+  })
+
+  it('keeps normal commands on the account home', () => {
+    expect(
+      buildCodexShellLaunchEnv(['resume', '--last'], {
+        CODEX_HOME: 'C:\\Orca\\account',
+        ORCA_CODEX_HOME: 'C:\\Orca\\account'
+      })
+    ).toEqual({
+      CODEX_HOME: 'C:\\Orca\\account',
+      ORCA_CODEX_HOME: 'C:\\Orca\\account'
+    })
+  })
+})

--- a/src/cli/codex-shell-launch.ts
+++ b/src/cli/codex-shell-launch.ts
@@ -1,0 +1,31 @@
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { spawnProcess } from '../shared/child-process/run-process'
+import { resolveCliCommand } from '../shared/node-cli-command-resolution'
+import { stripElectronRunAsNode } from './runtime/launch'
+
+export function buildCodexShellLaunchEnv(
+  args: readonly string[],
+  sourceEnv: NodeJS.ProcessEnv = process.env
+): NodeJS.ProcessEnv {
+  const env = stripElectronRunAsNode(sourceEnv)
+  if (args[0] !== 'update' || !env.ORCA_CODEX_HOME) {
+    return env
+  }
+  env.CODEX_HOME = env.ORCA_CODEX_INSTALL_HOME?.trim() || join(homedir(), '.codex')
+  delete env.ORCA_CODEX_HOME
+  return env
+}
+
+/** Runs Codex for cmd.exe, whose interactive shell has no function wrapper. */
+export async function runCodexShellLaunch(args: readonly string[]): Promise<void> {
+  const env = buildCodexShellLaunchEnv(args)
+  const command = resolveCliCommand('codex', {
+    pathEnv: env.PATH ?? env.Path ?? null
+  })
+  process.exitCode = await new Promise<number>((resolve, reject) => {
+    const child = spawnProcess({ program: command, args, env, stdio: 'inherit' })
+    child.once('error', reject)
+    child.once('exit', (code, signal) => resolve(typeof code === 'number' ? code : signal ? 1 : 0))
+  })
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -66,6 +66,11 @@ export async function main(
     await runClaudeTeams(argv.slice(1), cwd)
     return
   }
+  if (argv[0] === 'codex-shell-launch') {
+    const { runCodexShellLaunch } = await import('./codex-shell-launch.js')
+    await runCodexShellLaunch(argv.slice(1))
+    return
+  }
   const parsed = normalizeCommandPositionals(COMMAND_SPECS, parseArgs(argv, COMMAND_PATHS))
   const helpPath = resolveHelpPath(parsed)
   if (helpPath !== null) {

--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-bash-rcfile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-bash-rcfile.txt
@@ -64,6 +64,13 @@ if [[ -n "${ORCA_OMP_STATUS_EXTENSION:-}" ]]; then
   function omp { __orca_omp "$@"; }
 fi
 
+# Why: account selection owns CODEX_HOME; retain the user's pre-overlay home for updater discovery.
+if [[ -n "${ORCA_CODEX_HOME:-}" ]]; then
+  if [[ -n "${CODEX_HOME:-}" && "${CODEX_HOME}" != "${ORCA_CODEX_HOME}" ]]; then
+    export ORCA_CODEX_INSTALL_HOME="${CODEX_HOME}"
+  fi
+  [[ -n "${ORCA_CODEX_INSTALL_HOME:-}" ]] || export ORCA_CODEX_INSTALL_HOME="${HOME}/.codex"
+fi
 # Why: Codex must keep using Orca's runtime CODEX_HOME after profile scripts.
 [[ -n "${ORCA_CODEX_HOME:-}" ]] && export CODEX_HOME="${ORCA_CODEX_HOME}"
 # Why: a typed alias expands inside the shell, after pane launch prep.
@@ -72,11 +79,17 @@ fi
 # Why || : twice — zsh alone aborts inside the substitution, but every shell's
 # assignment adopts its exit status, so an absent codex trips set -e in bash too.
 __orca_codex_binary="$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)"
-if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" ]]; then
+if [[ -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" && ( -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" || -n "${ORCA_CODEX_HOME:-}" ) ]]; then
   # Why the function reserved word: it suppresses alias expansion of the name,
   # which otherwise rewrites this header at parse time and aborts the whole file.
   function codex {
-    "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+    if [[ "${1:-}" == update && -n "${ORCA_CODEX_HOME:-}" ]]; then
+      command env -u ORCA_CODEX_HOME CODEX_HOME="${ORCA_CODEX_INSTALL_HOME:-${HOME}/.codex}" codex "$@"
+      return $?
+    fi
+    if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" ]]; then
+      "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+    fi
     command codex "$@"
   }
 fi

--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-fish-init.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-fish-init.txt
@@ -2,9 +2,23 @@ function __orca_shell_ready_marker --on-event fish_prompt
   builtin printf "\033]777;orca-shell-ready\007"
   functions -e __orca_shell_ready_marker
 end
-if test -n "$ORCA_CODEX_LAUNCH_PREFLIGHT"; and test (type -t codex 2>/dev/null) = file
+if test -n "$ORCA_CODEX_HOME"
+  if test -n "$CODEX_HOME"; and test "$CODEX_HOME" != "$ORCA_CODEX_HOME"
+    set -gx ORCA_CODEX_INSTALL_HOME "$CODEX_HOME"
+  else if not set -q ORCA_CODEX_INSTALL_HOME
+    set -gx ORCA_CODEX_INSTALL_HOME "$HOME/.codex"
+  end
+  set -gx CODEX_HOME "$ORCA_CODEX_HOME"
+end
+if test (type -t codex 2>/dev/null) = file; and begin; test -n "$ORCA_CODEX_LAUNCH_PREFLIGHT"; or test -n "$ORCA_CODEX_HOME"; end
   function codex
-    command "$ORCA_CODEX_LAUNCH_PREFLIGHT" agent hooks prepare-codex >/dev/null 2>&1; or true
+    if test (count $argv) -gt 0; and test "$argv[1]" = update; and test -n "$ORCA_CODEX_HOME"
+      command env -u ORCA_CODEX_HOME CODEX_HOME="$ORCA_CODEX_INSTALL_HOME" codex $argv
+      return $status
+    end
+    if test -n "$ORCA_CODEX_LAUNCH_PREFLIGHT"
+      command "$ORCA_CODEX_LAUNCH_PREFLIGHT" agent hooks prepare-codex >/dev/null 2>&1; or true
+    end
     command codex $argv
   end
 end

--- a/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zshenv.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/daemon-zsh-zshenv.txt
@@ -102,6 +102,13 @@ __orca_deferred_init() {
       function omp { __orca_omp "$@"; }
     fi
 
+    # Why: account selection owns CODEX_HOME; retain the user's pre-overlay home for updater discovery.
+    if [[ -n "${ORCA_CODEX_HOME:-}" ]]; then
+      if [[ -n "${CODEX_HOME:-}" && "${CODEX_HOME}" != "${ORCA_CODEX_HOME}" ]]; then
+        export ORCA_CODEX_INSTALL_HOME="${CODEX_HOME}"
+      fi
+      [[ -n "${ORCA_CODEX_INSTALL_HOME:-}" ]] || export ORCA_CODEX_INSTALL_HOME="${HOME}/.codex"
+    fi
     # Why: Codex must keep using Orca's runtime CODEX_HOME after rc files.
     [[ -n "${ORCA_CODEX_HOME:-}" ]] && export CODEX_HOME="${ORCA_CODEX_HOME}"
     # Why: a typed alias expands inside the shell, after pane launch prep.
@@ -110,11 +117,17 @@ __orca_deferred_init() {
     # Why || : twice — zsh alone aborts inside the substitution, but every shell's
     # assignment adopts its exit status, so an absent codex trips set -e in bash too.
     __orca_codex_binary="$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)"
-    if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" ]]; then
+    if [[ -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" && ( -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" || -n "${ORCA_CODEX_HOME:-}" ) ]]; then
       # Why the function reserved word: it suppresses alias expansion of the name,
       # which otherwise rewrites this header at parse time and aborts the whole file.
       function codex {
-        "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+        if [[ "${1:-}" == update && -n "${ORCA_CODEX_HOME:-}" ]]; then
+          command env -u ORCA_CODEX_HOME CODEX_HOME="${ORCA_CODEX_INSTALL_HOME:-${HOME}/.codex}" codex "$@"
+          return $?
+        fi
+        if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" ]]; then
+          "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+        fi
         command codex "$@"
       }
     fi

--- a/src/main/__fixtures__/shell-wrapper-snapshots/local-bash-rcfile.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/local-bash-rcfile.txt
@@ -67,6 +67,13 @@ if [[ -n "${ORCA_OMP_STATUS_EXTENSION:-}" ]]; then
   function omp { __orca_omp "$@"; }
 fi
 
+# Why: account selection owns CODEX_HOME; retain the user's pre-overlay home for updater discovery.
+if [[ -n "${ORCA_CODEX_HOME:-}" ]]; then
+  if [[ -n "${CODEX_HOME:-}" && "${CODEX_HOME}" != "${ORCA_CODEX_HOME}" ]]; then
+    export ORCA_CODEX_INSTALL_HOME="${CODEX_HOME}"
+  fi
+  [[ -n "${ORCA_CODEX_INSTALL_HOME:-}" ]] || export ORCA_CODEX_INSTALL_HOME="${HOME}/.codex"
+fi
 # Why: Codex must keep using Orca's runtime CODEX_HOME after profile scripts.
 [[ -n "${ORCA_CODEX_HOME:-}" ]] && export CODEX_HOME="${ORCA_CODEX_HOME}"
 # Why: a typed alias expands inside the shell, after pane launch prep.
@@ -75,11 +82,17 @@ fi
 # Why || : twice — zsh alone aborts inside the substitution, but every shell's
 # assignment adopts its exit status, so an absent codex trips set -e in bash too.
 __orca_codex_binary="$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)"
-if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" ]]; then
+if [[ -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" && ( -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" || -n "${ORCA_CODEX_HOME:-}" ) ]]; then
   # Why the function reserved word: it suppresses alias expansion of the name,
   # which otherwise rewrites this header at parse time and aborts the whole file.
   function codex {
-    "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+    if [[ "${1:-}" == update && -n "${ORCA_CODEX_HOME:-}" ]]; then
+      command env -u ORCA_CODEX_HOME CODEX_HOME="${ORCA_CODEX_INSTALL_HOME:-${HOME}/.codex}" codex "$@"
+      return $?
+    fi
+    if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" ]]; then
+      "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+    fi
     command codex "$@"
   }
 fi

--- a/src/main/__fixtures__/shell-wrapper-snapshots/local-fish-init.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/local-fish-init.txt
@@ -2,9 +2,23 @@ function __orca_shell_ready_marker --on-event fish_prompt
   builtin printf "\033]777;orca-shell-ready\007"
   functions -e __orca_shell_ready_marker
 end
-if test -n "$ORCA_CODEX_LAUNCH_PREFLIGHT"; and test (type -t codex 2>/dev/null) = file
+if test -n "$ORCA_CODEX_HOME"
+  if test -n "$CODEX_HOME"; and test "$CODEX_HOME" != "$ORCA_CODEX_HOME"
+    set -gx ORCA_CODEX_INSTALL_HOME "$CODEX_HOME"
+  else if not set -q ORCA_CODEX_INSTALL_HOME
+    set -gx ORCA_CODEX_INSTALL_HOME "$HOME/.codex"
+  end
+  set -gx CODEX_HOME "$ORCA_CODEX_HOME"
+end
+if test (type -t codex 2>/dev/null) = file; and begin; test -n "$ORCA_CODEX_LAUNCH_PREFLIGHT"; or test -n "$ORCA_CODEX_HOME"; end
   function codex
-    command "$ORCA_CODEX_LAUNCH_PREFLIGHT" agent hooks prepare-codex >/dev/null 2>&1; or true
+    if test (count $argv) -gt 0; and test "$argv[1]" = update; and test -n "$ORCA_CODEX_HOME"
+      command env -u ORCA_CODEX_HOME CODEX_HOME="$ORCA_CODEX_INSTALL_HOME" codex $argv
+      return $status
+    end
+    if test -n "$ORCA_CODEX_LAUNCH_PREFLIGHT"
+      command "$ORCA_CODEX_LAUNCH_PREFLIGHT" agent hooks prepare-codex >/dev/null 2>&1; or true
+    end
     command codex $argv
   end
 end

--- a/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zshenv.txt
+++ b/src/main/__fixtures__/shell-wrapper-snapshots/local-zsh-zshenv.txt
@@ -102,6 +102,13 @@ __orca_deferred_init() {
       function omp { __orca_omp "$@"; }
     fi
 
+    # Why: account selection owns CODEX_HOME; retain the user's pre-overlay home for updater discovery.
+    if [[ -n "${ORCA_CODEX_HOME:-}" ]]; then
+      if [[ -n "${CODEX_HOME:-}" && "${CODEX_HOME}" != "${ORCA_CODEX_HOME}" ]]; then
+        export ORCA_CODEX_INSTALL_HOME="${CODEX_HOME}"
+      fi
+      [[ -n "${ORCA_CODEX_INSTALL_HOME:-}" ]] || export ORCA_CODEX_INSTALL_HOME="${HOME}/.codex"
+    fi
     # Why: Codex must keep using Orca's runtime CODEX_HOME after rc files.
     [[ -n "${ORCA_CODEX_HOME:-}" ]] && export CODEX_HOME="${ORCA_CODEX_HOME}"
     # Why: a typed alias expands inside the shell, after pane launch prep.
@@ -110,11 +117,17 @@ __orca_deferred_init() {
     # Why || : twice — zsh alone aborts inside the substitution, but every shell's
     # assignment adopts its exit status, so an absent codex trips set -e in bash too.
     __orca_codex_binary="$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)"
-    if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" ]]; then
+    if [[ -n "${__orca_codex_binary:-}" && -x "${__orca_codex_binary}" && ( -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" || -n "${ORCA_CODEX_HOME:-}" ) ]]; then
       # Why the function reserved word: it suppresses alias expansion of the name,
       # which otherwise rewrites this header at parse time and aborts the whole file.
       function codex {
-        "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+        if [[ "${1:-}" == update && -n "${ORCA_CODEX_HOME:-}" ]]; then
+          command env -u ORCA_CODEX_HOME CODEX_HOME="${ORCA_CODEX_INSTALL_HOME:-${HOME}/.codex}" codex "$@"
+          return $?
+        fi
+        if [[ -n "${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" ]]; then
+          "${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+        fi
         command codex "$@"
       }
     fi

--- a/src/main/codex/codex-installation-home.test.ts
+++ b/src/main/codex/codex-installation-home.test.ts
@@ -1,0 +1,46 @@
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { getSystemCodexHomePath } from './codex-home-paths'
+import {
+  ORCA_CODEX_INSTALL_HOME_ENV,
+  resolveCodexInstallationHomeForLaunch
+} from './codex-installation-home'
+
+describe('Codex installation home', () => {
+  it('uses the execution host default independently of an account home', () => {
+    expect(
+      resolveCodexInstallationHomeForLaunch({
+        HOME: process.env.HOME,
+        CODEX_HOME: undefined,
+        ORCA_CODEX_HOME: undefined
+      })
+    ).toBe(getSystemCodexHomePath())
+  })
+
+  it('preserves a user-owned custom home', () => {
+    const customHome = join(getSystemCodexHomePath(), '..', 'custom-codex')
+    expect(
+      resolveCodexInstallationHomeForLaunch({
+        HOME: process.env.HOME,
+        CODEX_HOME: customHome,
+        ORCA_CODEX_HOME: undefined
+      })
+    ).toBe(customHome)
+  })
+
+  it('carries an installation home through nested Orca panes', () => {
+    expect(
+      resolveCodexInstallationHomeForLaunch({
+        CODEX_HOME: '/orca/account/home',
+        ORCA_CODEX_HOME: '/orca/account/home',
+        [ORCA_CODEX_INSTALL_HOME_ENV]: '/user/codex/home'
+      })
+    ).toBe('/user/codex/home')
+  })
+
+  it('leaves WSL installation-home resolution to the guest', () => {
+    expect(
+      resolveCodexInstallationHomeForLaunch({ CODEX_HOME: 'C:\\Users\\Ada\\.codex' }, true)
+    ).toBeUndefined()
+  })
+})

--- a/src/main/codex/codex-installation-home.ts
+++ b/src/main/codex/codex-installation-home.ts
@@ -1,0 +1,30 @@
+import { getSystemCodexHomePath } from './codex-home-paths'
+import { getCustomCodexHomeOverrideForLaunch } from './codex-real-home-path'
+
+export const ORCA_CODEX_INSTALL_HOME_ENV = 'ORCA_CODEX_INSTALL_HOME'
+
+function launchEnvValue(launchEnv: NodeJS.ProcessEnv | undefined, key: string): string | undefined {
+  return launchEnv && Object.hasOwn(launchEnv, key) ? launchEnv[key] : process.env[key]
+}
+
+/** Resolves the execution host's Codex home before Orca selects an account home. */
+export function resolveCodexInstallationHomeForLaunch(
+  launchEnv?: NodeJS.ProcessEnv,
+  isWsl = false
+): string | undefined {
+  // Why: Windows cannot resolve the guest user's home; the in-guest shell adapter owns it.
+  if (isWsl) {
+    return undefined
+  }
+
+  const codexHome = launchEnvValue(launchEnv, 'CODEX_HOME')
+  const orcaCodexHome = launchEnvValue(launchEnv, 'ORCA_CODEX_HOME')
+  const inheritedInstallationHome = launchEnvValue(launchEnv, ORCA_CODEX_INSTALL_HOME_ENV)?.trim()
+  if (inheritedInstallationHome && orcaCodexHome && codexHome === orcaCodexHome) {
+    return inheritedInstallationHome
+  }
+
+  return (
+    getCustomCodexHomeOverrideForLaunch(launchEnv)?.context.codexHome ?? getSystemCodexHomePath()
+  )
+}

--- a/src/main/daemon/daemon-bash-shell-ready-rcfile.ts
+++ b/src/main/daemon/daemon-bash-shell-ready-rcfile.ts
@@ -1,5 +1,8 @@
 import { getPosixOmpShellWrapper } from '../pty/omp-shell-wrapper'
-import { getPosixCodexShellLaunchPreflight } from '../pty/codex-shell-launch-preflight'
+import {
+  getPosixCodexInstallationHomeCapture,
+  getPosixCodexShellLaunchPreflight
+} from '../pty/codex-shell-launch-preflight'
 import { BASH_PROMPT_COMMAND_COMPOSITION_BLOCK } from '../bash-prompt-command-composition'
 import { BASH_FEATURE_CHANNEL_BLOCK, SHELL_STARTUP_IDENTITY_MARKER_BLOCK } from '../shell-templates'
 import { SHELL_READY_MARKER } from './daemon-shell-ready-marker'
@@ -40,6 +43,7 @@ __orca_restore_agent_teams_path
 [[ -n "\${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="\${ORCA_OPENCODE_CONFIG_DIR}"
 [[ -n "\${ORCA_MIMOCODE_HOME:-}" ]] && export MIMOCODE_HOME="\${ORCA_MIMOCODE_HOME}"
 ${getPosixOmpShellWrapper()}
+${getPosixCodexInstallationHomeCapture()}
 # Why: Codex must keep using Orca's runtime CODEX_HOME after profile scripts.
 [[ -n "\${ORCA_CODEX_HOME:-}" ]] && export CODEX_HOME="\${ORCA_CODEX_HOME}"
 ${getPosixCodexShellLaunchPreflight()}

--- a/src/main/daemon/pty-subprocess/shell-launch-plan.ts
+++ b/src/main/daemon/pty-subprocess/shell-launch-plan.ts
@@ -99,7 +99,7 @@ export function createPtyShellLaunchPlan(
     }
     if (
       pathWin32.basename(shellPath).toLowerCase() === 'cmd.exe' &&
-      env.ORCA_CODEX_LAUNCH_PREFLIGHT
+      (env.ORCA_CODEX_LAUNCH_PREFLIGHT || env.ORCA_CODEX_HOME)
     ) {
       env[ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE_ENV] = '"'
     }
@@ -124,7 +124,8 @@ export function createPtyShellLaunchPlan(
         resolveSafePtyDefaultCwd(),
         resolvedWslContext,
         opts.command,
-        env.ORCA_CODEX_LAUNCH_PREFLIGHT
+        env.ORCA_CODEX_LAUNCH_PREFLIGHT,
+        env.ORCA_CODEX_HOME
       )
       shellArgs = resolved.shellArgs
       spawnCwd = resolved.effectiveCwd
@@ -152,7 +153,8 @@ export function createPtyShellLaunchPlan(
               resolveSafePtyDefaultCwd(),
               { distro: codexHomeWslInfo.distro },
               opts.command,
-              env.ORCA_CODEX_LAUNCH_PREFLIGHT
+              env.ORCA_CODEX_LAUNCH_PREFLIGHT,
+              env.ORCA_CODEX_HOME
             )
             shellArgs = resolved.shellArgs
             spawnCwd = resolved.effectiveCwd

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -226,12 +226,16 @@ describePosix('daemon shell-ready launch config', () => {
     expect(init).toContain('functions -e __orca_shell_ready_marker')
   })
 
-  it('keeps markerless fish spawns unwrapped', async () => {
+  it('wraps markerless fish only to restore the managed Codex overlay', async () => {
     const { getMarkerlessShellLaunchConfig } = await importFreshShellReady()
 
     const config = getMarkerlessShellLaunchConfig('/opt/homebrew/bin/fish')
 
-    expect(config).toEqual({ args: null, env: {}, supportsReadyMarker: false })
+    expect(config.args?.slice(0, 2)).toEqual(['-l', '-C'])
+    expect(config.args?.[2]).toContain('ORCA_CODEX_INSTALL_HOME')
+    expect(config.args?.[2]).not.toContain('--on-event fish_prompt')
+    expect(config.env).toEqual({})
+    expect(config.supportsReadyMarker).toBe(false)
   })
 
   itWithFish(

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -180,17 +180,15 @@ export function getShellLaunchConfig(
     }
   }
 
-  // Why: mirrors local-pty-shell-ready.ts; markerless fish stays unwrapped. The
-  // selection is baked into the init command, so fish needs no feature env var.
-  if (shellName === 'fish' && features.includes('ready')) {
+  // Why: fish applies -C after user config, so this is also its overlay restore point.
+  if (shellName === 'fish' && (features.includes('ready') || features.includes('overlay'))) {
+    const readyInit = features.includes('ready')
+      ? `${getFishShellReadyInitCommand(SHELL_READY_MARKER)}\n`
+      : ''
     return {
-      args: [
-        '-l',
-        '-C',
-        `${getFishShellReadyInitCommand(SHELL_READY_MARKER)}\n${getFishCodexShellLaunchPreflight()}`
-      ],
+      args: ['-l', '-C', `${readyInit}${getFishCodexShellLaunchPreflight()}`],
       env: {},
-      supportsReadyMarker: true
+      supportsReadyMarker: features.includes('ready')
     }
   }
 

--- a/src/main/ipc/pty-spawn-env-codex-home-routing.test.ts
+++ b/src/main/ipc/pty-spawn-env-codex-home-routing.test.ts
@@ -207,6 +207,7 @@ describe('registerPtyHandlers', () => {
       )
       expect(env.CODEX_HOME).toBe(TEST_CODEX_HOME)
       expect(env.ORCA_CODEX_HOME).toBe(TEST_CODEX_HOME)
+      expect(env.ORCA_CODEX_INSTALL_HOME).toBe('/tmp/system-codex-home')
     })
     it('waits for managed Codex auth before spawning a local PTY', async () => {
       vi.useFakeTimers()
@@ -355,6 +356,7 @@ describe('registerPtyHandlers', () => {
       )
       expect(env.CODEX_HOME).toBeUndefined()
       expect(env.ORCA_CODEX_HOME).toBeUndefined()
+      expect(env.ORCA_CODEX_INSTALL_HOME).toBeUndefined()
     })
     it('preserves a user-owned CODEX_HOME for system default when the real-home flag is ON', async () => {
       const env = await spawnAndGetEnv(
@@ -386,6 +388,7 @@ describe('registerPtyHandlers', () => {
       expect(resolvedCodexHome).toBe(customHome)
       expect(env.CODEX_HOME).toBe(TEST_CODEX_HOME)
       expect(env.ORCA_CODEX_HOME).toBe(TEST_CODEX_HOME)
+      expect(env.ORCA_CODEX_INSTALL_HOME).toBe(customHome)
     })
     it('injects explicit proxy settings into local PTY env', async () => {
       const env = await spawnAndGetEnv(undefined, undefined, undefined, () => ({

--- a/src/main/ipc/pty/host-env/assembly.ts
+++ b/src/main/ipc/pty/host-env/assembly.ts
@@ -13,8 +13,16 @@ import { piTitlebarExtensionService } from '../../../pi/titlebar-extension-servi
 import { ensureLinuxTerminalOrcaCliShimDir } from '../../../cli/linux-terminal-orca-cli-shim'
 import { stripLegacyTerminalShimEnv } from '../../../pty/legacy-terminal-shim-dir'
 import { resolvePathEnvKey, mergePersistedWindowsPath } from '../../../pty/windows-environment-path'
-import { resolveCodexShellLaunchPreflightCommand } from '../../../pty/codex-shell-launch-preflight'
+import {
+  ORCA_CODEX_COMMAND_ROUTER_ENV,
+  resolveCodexShellCommandRouterCommand,
+  resolveCodexShellLaunchPreflightCommand
+} from '../../../pty/codex-shell-launch-preflight'
 import { buildConfiguredProxyEnv } from '../../../../shared/network-proxy'
+import {
+  ORCA_CODEX_INSTALL_HOME_ENV,
+  resolveCodexInstallationHomeForLaunch
+} from '../../../codex/codex-installation-home'
 import type { BuildPtyHostEnvOptions } from './types'
 import { readInheritedPath } from './path'
 import { stripInheritedOrcaCodexHomeOverride } from './codex-home'
@@ -199,11 +207,31 @@ export function buildPtyHostEnv(
   if (opts.skipCodexHomeEnv) {
     delete baseEnv.CODEX_HOME
     delete baseEnv.ORCA_CODEX_HOME
+    delete baseEnv[ORCA_CODEX_INSTALL_HOME_ENV]
+    delete baseEnv[ORCA_CODEX_COMMAND_ROUTER_ENV]
     delete baseEnv.ORCA_CODEX_LAUNCH_PREFLIGHT
   } else if (opts.selectedCodexHomePath) {
+    const installationHome = resolveCodexInstallationHomeForLaunch(baseEnv, opts.isWsl)
     baseEnv.CODEX_HOME = opts.selectedCodexHomePath
     // Why: user startup files may re-export CODEX_HOME; shell-ready wrappers restore this runtime home before Codex launches.
     baseEnv.ORCA_CODEX_HOME = opts.selectedCodexHomePath
+    if (installationHome) {
+      baseEnv[ORCA_CODEX_INSTALL_HOME_ENV] = installationHome
+    } else {
+      delete baseEnv[ORCA_CODEX_INSTALL_HOME_ENV]
+    }
+    const commandRouter = resolveCodexShellCommandRouterCommand({
+      isPackaged: opts.isPackaged,
+      isWsl: opts.isWsl,
+      managedHomePath: opts.selectedCodexHomePath,
+      userDataPath: opts.userDataPath,
+      resourcesPath: opts.resourcesPath
+    })
+    if (commandRouter) {
+      baseEnv[ORCA_CODEX_COMMAND_ROUTER_ENV] = commandRouter
+    } else {
+      delete baseEnv[ORCA_CODEX_COMMAND_ROUTER_ENV]
+    }
     const preflightCommand = resolveCodexShellLaunchPreflightCommand({
       hooksEnabled: opts.codexStatusHooksEnabled ?? opts.agentStatusHooksEnabled,
       isPackaged: opts.isPackaged,
@@ -219,8 +247,12 @@ export function buildPtyHostEnv(
     }
   } else if (opts.stripInheritedOrcaCodexHome) {
     stripInheritedOrcaCodexHomeOverride(baseEnv)
+    delete baseEnv[ORCA_CODEX_INSTALL_HOME_ENV]
+    delete baseEnv[ORCA_CODEX_COMMAND_ROUTER_ENV]
     delete baseEnv.ORCA_CODEX_LAUNCH_PREFLIGHT
   } else {
+    delete baseEnv[ORCA_CODEX_INSTALL_HOME_ENV]
+    delete baseEnv[ORCA_CODEX_COMMAND_ROUTER_ENV]
     delete baseEnv.ORCA_CODEX_LAUNCH_PREFLIGHT
   }
 

--- a/src/main/ipc/pty/host-env/codex-home.ts
+++ b/src/main/ipc/pty/host-env/codex-home.ts
@@ -51,7 +51,12 @@ export function shouldStripInheritedOrcaCodexHome(args: {
   )
 }
 
-export const CODEX_HOME_ENV_KEYS = ['CODEX_HOME', 'ORCA_CODEX_HOME'] as const
+export const CODEX_HOME_ENV_KEYS = [
+  'CODEX_HOME',
+  'ORCA_CODEX_HOME',
+  'ORCA_CODEX_INSTALL_HOME',
+  'ORCA_CODEX_COMMAND_ROUTER'
+] as const
 
 // Why: system-default real-home routing runs Codex on the user's own ~/.codex.
 // Nested Orca panes inherit the parent's Orca-owned override; strip only that

--- a/src/main/powershell-osc133-bootstrap.ts
+++ b/src/main/powershell-osc133-bootstrap.ts
@@ -7,7 +7,15 @@ const POWERSHELL_OSC133_BOOTSTRAP = `# Orca OSC 133 shell integration for PowerS
 # Restore managed ownership before the shell-integration compatibility guard.
 if ($env:ORCA_OPENCODE_CONFIG_DIR) { $env:OPENCODE_CONFIG_DIR = $env:ORCA_OPENCODE_CONFIG_DIR }
 if ($env:ORCA_MIMOCODE_HOME) { $env:MIMOCODE_HOME = $env:ORCA_MIMOCODE_HOME }
+if ($env:ORCA_CODEX_HOME -and $env:CODEX_HOME -and $env:CODEX_HOME -ne $env:ORCA_CODEX_HOME) {
+    $env:ORCA_CODEX_INSTALL_HOME = $env:CODEX_HOME
+}
+if ($env:ORCA_CODEX_HOME -and -not $env:ORCA_CODEX_INSTALL_HOME) {
+    $env:ORCA_CODEX_INSTALL_HOME = Join-Path $HOME ".codex"
+}
 if ($env:ORCA_CODEX_HOME) { $env:CODEX_HOME = $env:ORCA_CODEX_HOME }
+
+${getPowerShellCodexShellLaunchPreflight()}
 
 if ($ExecutionContext.SessionState.LanguageMode -eq "FullLanguage" -and
     ((-not (Test-Path variable:global:__OrcaOsc133State)) -or
@@ -23,7 +31,6 @@ if ($ExecutionContext.SessionState.LanguageMode -eq "FullLanguage" -and
     } catch { Write-Error $_ -ErrorAction Continue }
 
 ${getPowerShellOmpShellWrapper()}
-${getPowerShellCodexShellLaunchPreflight()}
 
     $Global:__OrcaOsc133State = @{
         OriginalPrompt = $function:prompt

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -807,8 +807,9 @@ export class LocalPtyProvider implements IPtyProvider {
 
       const shellBasename = pathWin32.basename(shellPath).toLowerCase()
       const codexLaunchPreflightCommand = finalEnv.ORCA_CODEX_LAUNCH_PREFLIGHT
+      const managedCodexHomePath = finalEnv.ORCA_CODEX_HOME
       if (
-        codexLaunchPreflightCommand &&
+        (codexLaunchPreflightCommand || managedCodexHomePath) &&
         (shellBasename === 'cmd.exe' || isWindowsGitBashShellPath(shellPath))
       ) {
         if (shellBasename === 'cmd.exe') {
@@ -821,7 +822,8 @@ export class LocalPtyProvider implements IPtyProvider {
           defaultCwd,
           launchWslContext,
           args.command,
-          codexLaunchPreflightCommand
+          codexLaunchPreflightCommand,
+          managedCodexHomePath
         )
         shellArgs = resolved.shellArgs
         effectiveCwd = resolved.effectiveCwd

--- a/src/main/providers/local-pty-shell-ready-bash-rcfile.ts
+++ b/src/main/providers/local-pty-shell-ready-bash-rcfile.ts
@@ -6,7 +6,10 @@
  */
 import { BASH_PROMPT_COMMAND_COMPOSITION_BLOCK } from '../bash-prompt-command-composition'
 import { getPosixOmpShellWrapper } from '../pty/omp-shell-wrapper'
-import { getPosixCodexShellLaunchPreflight } from '../pty/codex-shell-launch-preflight'
+import {
+  getPosixCodexInstallationHomeCapture,
+  getPosixCodexShellLaunchPreflight
+} from '../pty/codex-shell-launch-preflight'
 import { BASH_FEATURE_CHANNEL_BLOCK, SHELL_STARTUP_IDENTITY_MARKER_BLOCK } from '../shell-templates'
 import { SHELL_READY_MARKER_ESCAPED } from './local-pty-shell-ready-marker'
 
@@ -49,6 +52,7 @@ __orca_restore_agent_teams_path
 [[ -n "\${ORCA_OPENCODE_CONFIG_DIR:-}" ]] && export OPENCODE_CONFIG_DIR="\${ORCA_OPENCODE_CONFIG_DIR}"
 [[ -n "\${ORCA_MIMOCODE_HOME:-}" ]] && export MIMOCODE_HOME="\${ORCA_MIMOCODE_HOME}"
 ${getPosixOmpShellWrapper()}
+${getPosixCodexInstallationHomeCapture()}
 # Why: Codex must keep using Orca's runtime CODEX_HOME after profile scripts.
 [[ -n "\${ORCA_CODEX_HOME:-}" ]] && export CODEX_HOME="\${ORCA_CODEX_HOME}"
 ${getPosixCodexShellLaunchPreflight()}

--- a/src/main/providers/local-pty-shell-ready-wrapper-generation.test.ts
+++ b/src/main/providers/local-pty-shell-ready-wrapper-generation.test.ts
@@ -176,12 +176,16 @@ describePosix('local PTY shell-ready launch config', () => {
     expect(init).toContain('functions -e __orca_shell_ready_marker')
   })
 
-  it('keeps markerless fish spawns unwrapped', async () => {
+  it('wraps markerless fish only to restore the managed Codex overlay', async () => {
     const { getMarkerlessShellLaunchConfig } = await importFreshLocalPtyShellReady()
 
     const config = getMarkerlessShellLaunchConfig('/opt/homebrew/bin/fish')
 
-    expect(config).toEqual({ args: null, env: {}, supportsReadyMarker: false })
+    expect(config.args?.slice(0, 2)).toEqual(['-l', '-C'])
+    expect(config.args?.[2]).toContain('ORCA_CODEX_INSTALL_HOME')
+    expect(config.args?.[2]).not.toContain('--on-event fish_prompt')
+    expect(config.env).toEqual({})
+    expect(config.supportsReadyMarker).toBe(false)
   })
 
   it('falls back to HOME for ORCA_ORIG_ZDOTDIR when inherited ZDOTDIR points at a wrapper dir', async () => {

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -118,17 +118,15 @@ export function getShellLaunchConfig(
     }
   }
 
-  // Why: mirrors daemon/shell-ready.ts; markerless fish stays unwrapped. The
-  // selection is baked into the init command, so fish needs no feature env var.
-  if (shellName === 'fish' && features.includes('ready')) {
+  // Why: fish applies -C after user config, so this is also its overlay restore point.
+  if (shellName === 'fish' && (features.includes('ready') || features.includes('overlay'))) {
+    const readyInit = features.includes('ready')
+      ? `${getFishShellReadyInitCommand(SHELL_READY_MARKER_ESCAPED)}\n`
+      : ''
     return {
-      args: [
-        '-l',
-        '-C',
-        `${getFishShellReadyInitCommand(SHELL_READY_MARKER_ESCAPED)}\n${getFishCodexShellLaunchPreflight()}`
-      ],
+      args: ['-l', '-C', `${readyInit}${getFishCodexShellLaunchPreflight()}`],
       env: {},
-      supportsReadyMarker: true
+      supportsReadyMarker: features.includes('ready')
     }
   }
 

--- a/src/main/providers/windows-shell-args.test.ts
+++ b/src/main/providers/windows-shell-args.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { buildWslInteractiveLoginShellCommand } from '../../shared/wsl-login-shell-command'
 import { resolveSetupRunnerCommand } from '../../shared/setup-runner-command'
+import { getFishCodexShellLaunchPreflight } from '../pty/codex-shell-launch-preflight'
 import { resolveWindowsShellLaunchArgs } from './windows-shell-args'
 // Why resolved rather than hardcoded: the wrapper tree is content-addressed.
 import { getShellReadyWrapperRoot } from './local-pty-shell-ready-wrapper-root'
@@ -11,9 +12,10 @@ import { getShellReadyWrapperRoot } from './local-pty-shell-ready-wrapper-root'
 const CODEX_LAUNCH_PREFLIGHT = 'C:\\Program Files\\Orca\\orca.exe'
 const CMD_CODEX_LAUNCH_PREFLIGHT =
   'if defined ORCA_CODEX_LAUNCH_PREFLIGHT call %ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE%%ORCA_CODEX_LAUNCH_PREFLIGHT%%ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE% agent hooks prepare-codex > nul 2>&1'
+const MANAGED_CODEX_HOME = 'C:\\Orca\\account'
 
 function expectedWslArgs(linuxCwd: string, distro?: string): string[] {
-  const command = `cd '${linuxCwd}' && export PATH="$HOME/.local/bin:$PATH" && ${buildWslInteractiveLoginShellCommand()}`
+  const command = `cd '${linuxCwd}' && export PATH="$HOME/.local/bin:$PATH" && ${buildWslInteractiveLoginShellCommand({ fishInitCommand: getFishCodexShellLaunchPreflight() })}`
   // Why spelled out rather than calling buildWslExecArgs: deriving the
   // expectation from the helper under test would still pass if it regressed
   // to the `--` separator.
@@ -70,6 +72,23 @@ describe('resolveWindowsShellLaunchArgs', () => {
     expect(result.startupCommandDeliveredInShellArgs).toBeUndefined()
     expect(result.effectiveCwd).toBe('C:\\Users\\alice')
     expect(result.validationCwd).toBe('C:\\Users\\alice')
+  })
+
+  it('routes cmd.exe Codex commands without replacing a user macro', () => {
+    const result = resolveWindowsShellLaunchArgs(
+      'cmd.exe',
+      'C:\\Users\\alice',
+      'C:\\Users\\alice',
+      undefined,
+      undefined,
+      undefined,
+      MANAGED_CODEX_HOME
+    )
+
+    expect(result.shellArgs[1]).toContain('doskey /macros')
+    expect(result.shellArgs[1]).toContain('findstr.exe /b /i /l codex=')
+    expect(result.shellArgs[1]).toContain('ORCA_CODEX_COMMAND_ROUTER')
+    expect(result.shellArgs[1]).toContain('codex-shell-launch $*')
   })
 
   it('embeds short cmd.exe startup commands in shell args', () => {
@@ -291,6 +310,23 @@ describe('resolveWindowsShellLaunchArgs', () => {
     const bashRcfile = readFileSync(getGitBashRcfilePath(bashCommand), 'utf8')
     expect(bashRcfile).toContain('"${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex')
     expect(bashRcfile).not.toContain(CODEX_LAUNCH_PREFLIGHT)
+  })
+
+  it('wraps Git Bash for a managed Codex home when hooks are disabled', () => {
+    const result = resolveWindowsShellLaunchArgs(
+      'C:\\Program Files\\Git\\bin\\bash.exe',
+      'C:\\Users\\alice',
+      'C:\\Users\\alice',
+      undefined,
+      undefined,
+      undefined,
+      MANAGED_CODEX_HOME
+    )
+
+    expect(result.shellArgs[1]).toContain('--rcfile')
+    expect(readFileSync(getGitBashRcfilePath(result.shellArgs[1]), 'utf8')).toContain(
+      'ORCA_CODEX_INSTALL_HOME'
+    )
   })
 
   it('keeps Git Bash startup commands on stdin delivery with the preflight wrapper', () => {

--- a/src/main/providers/windows-shell-args.ts
+++ b/src/main/providers/windows-shell-args.ts
@@ -8,6 +8,7 @@ import {
 } from '../../shared/wsl-login-shell-command'
 import { getBashWrapperLaunchArgs } from './local-pty-shell-ready'
 import { ensureShellReadyWrappersAt } from './local-pty-shell-ready-wrapper-generation'
+import { getFishCodexShellLaunchPreflight } from '../pty/codex-shell-launch-preflight'
 import {
   encodePowerShellCommand,
   getPowerShellOsc133Bootstrap
@@ -20,6 +21,7 @@ const POWERSHELL_ENCODED_COMMAND_ARG_MAX_CHARS = 28_000
 const CMD_UTF8_SETUP_COMMAND = 'chcp 65001 > nul'
 export const ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE_ENV = 'ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE'
 const CMD_CODEX_LAUNCH_PREFLIGHT = `if defined ORCA_CODEX_LAUNCH_PREFLIGHT call %${ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE_ENV}%%ORCA_CODEX_LAUNCH_PREFLIGHT%%${ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE_ENV}% agent hooks prepare-codex > nul 2>&1`
+const CMD_CODEX_COMMAND_ROUTER = `if defined ORCA_CODEX_COMMAND_ROUTER (doskey /macros | %SystemRoot%\\System32\\findstr.exe /b /i /l codex= > nul 2>&1 || doskey codex=call %${ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE_ENV}%%ORCA_CODEX_COMMAND_ROUTER%%${ORCA_CODEX_LAUNCH_PREFLIGHT_CMD_QUOTE_ENV}% codex-shell-launch $*)`
 // Why: Git for Windows' bash inherits the ConPTY console's OEM code page
 // (CP437), so a TUI that writes UTF-8 bytes straight to the console — agents
 // like Claude Code use WriteFile, not WriteConsoleW — renders as mojibake
@@ -28,8 +30,11 @@ const CMD_CODEX_LAUNCH_PREFLIGHT = `if defined ORCA_CODEX_LAUNCH_PREFLIGHT call 
 // `&&`) keeps startup working even if chcp.com is missing.
 const GIT_BASH_UTF8_LOGIN_COMMAND = 'chcp.com 65001 >/dev/null 2>&1; exec "$BASH" --login -i'
 
-function getGitBashLaunchCommand(codexLaunchPreflightCommand?: string): string {
-  if (!codexLaunchPreflightCommand) {
+function getGitBashLaunchCommand(
+  codexLaunchPreflightCommand?: string,
+  managedCodexHomePath?: string
+): string {
+  if (!codexLaunchPreflightCommand && !managedCodexHomePath) {
     return GIT_BASH_UTF8_LOGIN_COMMAND
   }
 
@@ -142,7 +147,9 @@ function buildWslShellArgs(linuxCwd: string, distro?: string): string[] {
   const setupCommand = [
     `cd ${quotePosixShell(linuxCwd)}`,
     'export PATH="$HOME/.local/bin:$PATH"',
-    buildWslInteractiveLoginShellCommand()
+    buildWslInteractiveLoginShellCommand({
+      fishInitCommand: getFishCodexShellLaunchPreflight()
+    })
   ].join(' && ')
   // Why: WSL users often customize zsh rather than bash; launch the distro's
   // login shell so terminal PATH matches the environment Orca detects.
@@ -178,7 +185,8 @@ export function resolveWindowsShellLaunchArgs(
   defaultCwd: string,
   wslContext?: WindowsShellWslContext,
   startupCommand?: string,
-  codexLaunchPreflightCommand?: string
+  codexLaunchPreflightCommand?: string,
+  managedCodexHomePath?: string
 ): WindowsShellLaunchArgs {
   const shellBasename = pathWin32.basename(shellPath).toLowerCase()
   const nativeCwd = normalizeWindowsTerminalCwd(cwd)
@@ -188,6 +196,7 @@ export function resolveWindowsShellLaunchArgs(
     const startupCommands = [
       CMD_UTF8_SETUP_COMMAND,
       ...(codexLaunchPreflightCommand ? [CMD_CODEX_LAUNCH_PREFLIGHT] : []),
+      ...(managedCodexHomePath ? [CMD_CODEX_COMMAND_ROUTER] : []),
       ...(shellArgStartupCommand ? [shellArgStartupCommand] : [])
     ]
     return {
@@ -214,7 +223,7 @@ export function resolveWindowsShellLaunchArgs(
 
   if (isWindowsGitBashShellPath(shellPath)) {
     return {
-      shellArgs: ['-c', getGitBashLaunchCommand(codexLaunchPreflightCommand)],
+      shellArgs: ['-c', getGitBashLaunchCommand(codexLaunchPreflightCommand, managedCodexHomePath)],
       effectiveCwd: nativeCwd,
       validationCwd: nativeCwd
     }

--- a/src/main/pty/codex-shell-launch-preflight.ts
+++ b/src/main/pty/codex-shell-launch-preflight.ts
@@ -18,6 +18,8 @@ export type CodexShellLaunchPreflightCommandOptions = {
   platform?: NodeJS.Platform
 }
 
+export const ORCA_CODEX_COMMAND_ROUTER_ENV = 'ORCA_CODEX_COMMAND_ROUTER'
+
 /** Absolute path of the Orca CLI the preflight must execute, or null to skip it.
  *
  *  Why absolute: the value rides in ORCA_CODEX_LAUNCH_PREFLIGHT and is invoked
@@ -32,6 +34,23 @@ export function resolveCodexShellLaunchPreflightCommand(
   if (!options.hooksEnabled || options.isWsl || !options.managedHomePath) {
     return null
   }
+  return resolveVerifiedOrcaCliLauncher(options)
+}
+
+/** Absolute Orca CLI path used by cmd.exe's Codex macro, or null off native Windows. */
+export function resolveCodexShellCommandRouterCommand(
+  options: Omit<CodexShellLaunchPreflightCommandOptions, 'hooksEnabled'>
+): string | null {
+  const platform = options.platform ?? process.platform
+  if (platform !== 'win32' || options.isWsl || !options.managedHomePath) {
+    return null
+  }
+  return resolveVerifiedOrcaCliLauncher(options)
+}
+
+function resolveVerifiedOrcaCliLauncher(
+  options: Omit<CodexShellLaunchPreflightCommandOptions, 'hooksEnabled'>
+): string | null {
   const platform = options.platform ?? process.platform
   const candidate = options.isPackaged
     ? options.resourcesPath
@@ -58,6 +77,16 @@ function isExecutableFileOnDisk(path: string, platform: NodeJS.Platform): boolea
   }
 }
 
+export function getPosixCodexInstallationHomeCapture(): string {
+  return `# Why: account selection owns CODEX_HOME; retain the user's pre-overlay home for updater discovery.
+if [[ -n "\${ORCA_CODEX_HOME:-}" ]]; then
+  if [[ -n "\${CODEX_HOME:-}" && "\${CODEX_HOME}" != "\${ORCA_CODEX_HOME}" ]]; then
+    export ORCA_CODEX_INSTALL_HOME="\${CODEX_HOME}"
+  fi
+  [[ -n "\${ORCA_CODEX_INSTALL_HOME:-}" ]] || export ORCA_CODEX_INSTALL_HOME="\${HOME}/.codex"
+fi`
+}
+
 export function getPosixCodexShellLaunchPreflight(): string {
   return `# Why: a typed alias expands inside the shell, after pane launch prep.
 # Why unalias inside the substitution: an alias named codex makes command -v
@@ -65,11 +94,17 @@ export function getPosixCodexShellLaunchPreflight(): string {
 # Why || : twice — zsh alone aborts inside the substitution, but every shell's
 # assignment adopts its exit status, so an absent codex trips set -e in bash too.
 __orca_codex_binary="$(unalias codex 2>/dev/null || :; command -v codex 2>/dev/null || :)"
-if [[ -n "\${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" && -n "\${__orca_codex_binary:-}" && -x "\${__orca_codex_binary}" ]]; then
+if [[ -n "\${__orca_codex_binary:-}" && -x "\${__orca_codex_binary}" && ( -n "\${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" || -n "\${ORCA_CODEX_HOME:-}" ) ]]; then
   # Why the function reserved word: it suppresses alias expansion of the name,
   # which otherwise rewrites this header at parse time and aborts the whole file.
   function codex {
-    "\${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+    if [[ "\${1:-}" == update && -n "\${ORCA_CODEX_HOME:-}" ]]; then
+      command env -u ORCA_CODEX_HOME CODEX_HOME="\${ORCA_CODEX_INSTALL_HOME:-\${HOME}/.codex}" codex "$@"
+      return $?
+    fi
+    if [[ -n "\${ORCA_CODEX_LAUNCH_PREFLIGHT:-}" ]]; then
+      "\${ORCA_CODEX_LAUNCH_PREFLIGHT}" agent hooks prepare-codex >/dev/null 2>&1 || :
+    fi
     command codex "$@"
   }
 fi
@@ -78,9 +113,23 @@ unset __orca_codex_binary
 }
 
 export function getFishCodexShellLaunchPreflight(): string {
-  return `if test -n "$ORCA_CODEX_LAUNCH_PREFLIGHT"; and test (type -t codex 2>/dev/null) = file
+  return `if test -n "$ORCA_CODEX_HOME"
+  if test -n "$CODEX_HOME"; and test "$CODEX_HOME" != "$ORCA_CODEX_HOME"
+    set -gx ORCA_CODEX_INSTALL_HOME "$CODEX_HOME"
+  else if not set -q ORCA_CODEX_INSTALL_HOME
+    set -gx ORCA_CODEX_INSTALL_HOME "$HOME/.codex"
+  end
+  set -gx CODEX_HOME "$ORCA_CODEX_HOME"
+end
+if test (type -t codex 2>/dev/null) = file; and begin; test -n "$ORCA_CODEX_LAUNCH_PREFLIGHT"; or test -n "$ORCA_CODEX_HOME"; end
   function codex
-    command "$ORCA_CODEX_LAUNCH_PREFLIGHT" agent hooks prepare-codex >/dev/null 2>&1; or true
+    if test (count $argv) -gt 0; and test "$argv[1]" = update; and test -n "$ORCA_CODEX_HOME"
+      command env -u ORCA_CODEX_HOME CODEX_HOME="$ORCA_CODEX_INSTALL_HOME" codex $argv
+      return $status
+    end
+    if test -n "$ORCA_CODEX_LAUNCH_PREFLIGHT"
+      command "$ORCA_CODEX_LAUNCH_PREFLIGHT" agent hooks prepare-codex >/dev/null 2>&1; or true
+    end
     command codex $argv
   end
 end`
@@ -88,18 +137,39 @@ end`
 
 export function getPowerShellCodexShellLaunchPreflight(): string {
   return `$orcaCodexCommand = Get-Command codex -ErrorAction SilentlyContinue | Select-Object -First 1
-if ($env:ORCA_CODEX_LAUNCH_PREFLIGHT -and $orcaCodexCommand -and
+if (($env:ORCA_CODEX_LAUNCH_PREFLIGHT -or $env:ORCA_CODEX_HOME) -and $orcaCodexCommand -and
     $orcaCodexCommand.CommandType -in @("Application", "ExternalScript")) {
     function Global:codex {
-        try {
-            & $env:ORCA_CODEX_LAUNCH_PREFLIGHT agent hooks prepare-codex *> $null
-        } catch {
-        }
         $orcaCodexExecutable = Get-Command codex -CommandType Application,ExternalScript -ErrorAction SilentlyContinue | Select-Object -First 1
         if (-not $orcaCodexExecutable) {
             Write-Error "codex executable not found"
             $global:LASTEXITCODE = 127
             return
+        }
+        if ($args.Count -gt 0 -and $args[0] -eq "update" -and $env:ORCA_CODEX_HOME) {
+            $orcaManagedCodexHome = $env:ORCA_CODEX_HOME
+            $orcaAccountCodexHome = $env:CODEX_HOME
+            if ($env:ORCA_CODEX_INSTALL_HOME) {
+                $env:CODEX_HOME = $env:ORCA_CODEX_INSTALL_HOME
+            } else {
+                $env:CODEX_HOME = Join-Path $HOME ".codex"
+            }
+            Remove-Item Env:ORCA_CODEX_HOME -ErrorAction SilentlyContinue
+            try {
+                & $orcaCodexExecutable.Source @args
+                $orcaCodexExitCode = $LASTEXITCODE
+            } finally {
+                $env:CODEX_HOME = $orcaAccountCodexHome
+                $env:ORCA_CODEX_HOME = $orcaManagedCodexHome
+            }
+            $global:LASTEXITCODE = $orcaCodexExitCode
+            return
+        }
+        if ($env:ORCA_CODEX_LAUNCH_PREFLIGHT) {
+            try {
+                & $env:ORCA_CODEX_LAUNCH_PREFLIGHT agent hooks prepare-codex *> $null
+            } catch {
+            }
         }
         & $orcaCodexExecutable.Source @args
         $global:LASTEXITCODE = $LASTEXITCODE

--- a/src/main/pty/codex-update-home-routing.test.ts
+++ b/src/main/pty/codex-update-home-routing.test.ts
@@ -1,0 +1,169 @@
+import { execFileSync, spawnSync } from 'node:child_process'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  getFishCodexShellLaunchPreflight,
+  getPosixCodexInstallationHomeCapture,
+  getPosixCodexShellLaunchPreflight,
+  getPowerShellCodexShellLaunchPreflight,
+  resolveCodexShellCommandRouterCommand
+} from './codex-shell-launch-preflight'
+
+const roots: string[] = []
+const fishAvailable = spawnSync('fish', ['--version']).status === 0
+const pwshAvailable =
+  spawnSync('pwsh', ['-NoLogo', '-NoProfile', '-Command', 'exit 0']).status === 0
+
+function makeProbe(prefix: string): { bin: string; installHome: string; managedHome: string } {
+  const root = mkdtempSync(join(tmpdir(), prefix))
+  roots.push(root)
+  const bin = join(root, 'bin')
+  const installHome = join(root, 'install-home')
+  const managedHome = join(root, 'managed-home')
+  mkdirSync(bin)
+  mkdirSync(installHome)
+  mkdirSync(managedHome)
+  const codex = join(bin, process.platform === 'win32' ? 'codex.cmd' : 'codex')
+  writeFileSync(
+    codex,
+    process.platform === 'win32'
+      ? '@echo off\necho home=%CODEX_HOME%\nif defined ORCA_CODEX_HOME (echo managed=%ORCA_CODEX_HOME%) else echo managed=unset\necho args=%*\n'
+      : '#!/bin/sh\nprintf "home=%s\\nmanaged=%s\\nargs=%s\\n" "$CODEX_HOME" "${ORCA_CODEX_HOME-unset}" "$*"\n'
+  )
+  if (process.platform !== 'win32') {
+    chmodSync(codex, 0o755)
+  }
+  return { bin, installHome, managedHome }
+}
+
+function probeEnv(probe: ReturnType<typeof makeProbe>): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    PATH: `${probe.bin}${delimiter}${process.env.PATH ?? ''}`,
+    CODEX_HOME: probe.managedHome,
+    ORCA_CODEX_HOME: probe.managedHome,
+    ORCA_CODEX_INSTALL_HOME: probe.installHome
+  }
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe.skipIf(process.platform === 'win32')('POSIX Codex update home routing', () => {
+  it('does not publish an installation home without a managed account', () => {
+    const output = execFileSync(
+      '/bin/bash',
+      [
+        '--noprofile',
+        '--norc',
+        '-c',
+        `${getPosixCodexInstallationHomeCapture()}\nprintf %s "\${ORCA_CODEX_INSTALL_HOME-unset}"`
+      ],
+      { encoding: 'utf-8', env: { ...process.env, ORCA_CODEX_HOME: undefined } }
+    )
+
+    expect(output).toBe('unset')
+  })
+
+  it('captures a guest installation home before restoring the account home', () => {
+    const probe = makeProbe('orca-codex-guest-route-')
+    const env = probeEnv(probe)
+    env.CODEX_HOME = probe.installHome
+    delete env.ORCA_CODEX_INSTALL_HOME
+    const output = execFileSync(
+      '/bin/bash',
+      [
+        '--noprofile',
+        '--norc',
+        '-c',
+        `${getPosixCodexInstallationHomeCapture()}\nexport CODEX_HOME="$ORCA_CODEX_HOME"\n${getPosixCodexShellLaunchPreflight()}\ncodex update`
+      ],
+      { encoding: 'utf-8', env }
+    )
+
+    expect(output).toBe(`home=${probe.installHome}\nmanaged=unset\nargs=update\n`)
+  })
+
+  for (const shell of ['/bin/bash', '/bin/zsh']) {
+    it.skipIf(!existsSync(shell))(`routes ${shell} update to the installation home`, () => {
+      const probe = makeProbe('orca-codex-posix-route-')
+      const shellArgs = shell.endsWith('/zsh') ? ['-f', '-c'] : ['--noprofile', '--norc', '-c']
+      const output = execFileSync(
+        shell,
+        [...shellArgs, `${getPosixCodexShellLaunchPreflight()}\ncodex update`],
+        { encoding: 'utf-8', env: probeEnv(probe) }
+      )
+
+      expect(output).toBe(`home=${probe.installHome}\nmanaged=unset\nargs=update\n`)
+    })
+  }
+
+  it('keeps normal commands on the account home', () => {
+    const probe = makeProbe('orca-codex-account-route-')
+    const output = execFileSync(
+      '/bin/bash',
+      ['--noprofile', '--norc', '-c', `${getPosixCodexShellLaunchPreflight()}\ncodex resume`],
+      { encoding: 'utf-8', env: probeEnv(probe) }
+    )
+
+    expect(output).toBe(`home=${probe.managedHome}\nmanaged=${probe.managedHome}\nargs=resume\n`)
+  })
+
+  it.skipIf(!fishAvailable)('routes fish update to the installation home', () => {
+    const probe = makeProbe('orca-codex-fish-route-')
+    const output = execFileSync(
+      'fish',
+      ['--no-config', '-c', `${getFishCodexShellLaunchPreflight()}\ncodex update`],
+      { encoding: 'utf-8', env: probeEnv(probe) }
+    )
+
+    expect(output).toBe(`home=${probe.installHome}\nmanaged=unset\nargs=update\n`)
+  })
+})
+
+describe('Windows Codex update home routing', () => {
+  it.skipIf(!pwshAvailable)('routes PowerShell update to the installation home', () => {
+    const probe = makeProbe('orca-codex-pwsh-route-')
+    const result = spawnSync(
+      'pwsh',
+      [
+        '-NoLogo',
+        '-NoProfile',
+        '-Command',
+        `${getPowerShellCodexShellLaunchPreflight()}\ncodex update`
+      ],
+      { encoding: 'utf-8', env: probeEnv(probe) }
+    )
+
+    expect(result.status, result.stderr).toBe(0)
+    expect(result.stdout.replaceAll('\r\n', '\n')).toBe(
+      `home=${probe.installHome}\nmanaged=unset\nargs=update\n`
+    )
+  })
+
+  it('resolves the cmd.exe router without enabling hook preflight', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-codex-cmd-router-'))
+    roots.push(root)
+    const userDataPath = join(root, 'user-data')
+    const resourcesPath = join(root, 'resources')
+    const launcher = join(resourcesPath, 'bin', 'orca.exe')
+    mkdirSync(join(userDataPath, 'cli', 'bin'), { recursive: true })
+    mkdirSync(join(resourcesPath, 'bin'), { recursive: true })
+    writeFileSync(launcher, '')
+
+    expect(
+      resolveCodexShellCommandRouterCommand({
+        isPackaged: true,
+        managedHomePath: 'C:\\Orca\\account',
+        userDataPath,
+        resourcesPath,
+        platform: 'win32'
+      })
+    ).toBe(launcher)
+  })
+})

--- a/src/main/pty/wsl-orca-env.test.ts
+++ b/src/main/pty/wsl-orca-env.test.ts
@@ -32,6 +32,18 @@ describe('addOrcaWslInteropEnv', () => {
     expect(env.WSLENV?.split(':')).toContain('ORCA_SHELL_READY_ROOT/p')
   })
 
+  it('publishes the managed Codex overlay features for the guest shell', () => {
+    const env: Record<string, string> = {
+      CODEX_HOME: '/home/ada/.orca/codex-account',
+      ORCA_CODEX_HOME: '/home/ada/.orca/codex-account'
+    }
+
+    addOrcaWslInteropEnv(env)
+
+    expect(env.ORCA_SHELL_FEATURES).toBe('overlay,history,markers')
+    expect(env.WSLENV?.split(':')).toContain('ORCA_SHELL_FEATURES/u')
+  })
+
   it('imports setup-gated startup env into WSL without path translation', () => {
     const env: Record<string, string> = {
       [SETUP_AGENT_SEQUENCE_STARTUP_COMMAND_ENV]: 'codex',

--- a/src/main/pty/wsl-orca-env.ts
+++ b/src/main/pty/wsl-orca-env.ts
@@ -9,6 +9,7 @@ import {
   SETUP_AGENT_SEQUENCE_STARTUP_SCRIPT_ENV
 } from '../../shared/setup-agent-sequencing'
 import { getShellReadyWrapperRoot } from '../providers/local-pty-shell-ready-wrapper-root'
+import { encodeShellStartupFeatures, selectShellStartupFeatures } from '../shell-startup-features'
 
 const WSLENV_ENTRY_SEPARATOR = ':'
 
@@ -58,6 +59,18 @@ export function addOrcaWslInteropEnv(env: Record<string, string>): void {
   // are always the local file set -- windows-shell-args.ts is shared by the
   // in-process provider and the daemon spawner, so both resolve the same tree.
   env.ORCA_SHELL_READY_ROOT = getShellReadyWrapperRoot()
+  if (env.ORCA_CODEX_HOME) {
+    env.ORCA_SHELL_FEATURES = encodeShellStartupFeatures(
+      selectShellStartupFeatures({
+        // Why zsh: its wrapper needs the history guard; bash and fish ignore that token.
+        shellPath: 'zsh',
+        env,
+        hasStartupCommand: false,
+        waitsForShellReady: false,
+        emitsStartupIdentity: false
+      })
+    )
+  }
   // Why: the endpoint is a Windows path (/p-translated so the guest reads it
   // via /mnt/c) until the WSL hook relay reports the guest home — then it is
   // already a guest-side POSIX path and must cross untranslated.
@@ -76,6 +89,7 @@ export function addOrcaWslInteropEnv(env: Record<string, string>): void {
     // Why /p: the guest reads the content-addressed wrapper tree through /mnt/c,
     // and it cannot derive the hash segment from ORCA_USER_DATA_PATH alone.
     'ORCA_SHELL_READY_ROOT/p',
+    'ORCA_SHELL_FEATURES/u',
     'ORCA_CLI_COMMAND/u',
     'ORCA_PANE_KEY/u',
     'ORCA_TAB_ID/u',

--- a/src/main/zsh-startup-wrapper-builder.ts
+++ b/src/main/zsh-startup-wrapper-builder.ts
@@ -27,7 +27,10 @@
  * hook restores zsh option semantics for the body at call time.
  */
 import { getPosixOmpShellWrapper } from './pty/omp-shell-wrapper'
-import { getPosixCodexShellLaunchPreflight } from './pty/codex-shell-launch-preflight'
+import {
+  getPosixCodexInstallationHomeCapture,
+  getPosixCodexShellLaunchPreflight
+} from './pty/codex-shell-launch-preflight'
 import {
   getZshShellReadyMarkerRegistrationBlock,
   SHELL_STARTUP_IDENTITY_MARKER_BLOCK,
@@ -122,6 +125,7 @@ function getOverlayRestoreBlocks(spec: ZshStartupHookSpec): (string | null)[] {
     MIMOCODE_HOME_RESTORE,
     spec.restores.remoteCliBinDir ? REMOTE_CLI_BIN_DIR_RESTORE : null,
     getPosixOmpShellWrapper(),
+    spec.restores.codexHome ? getPosixCodexInstallationHomeCapture() : null,
     spec.restores.codexHome ? CODEX_HOME_RESTORE : null,
     spec.restores.codexLaunchPreflight ? getPosixCodexShellLaunchPreflight() : null
   ]

--- a/src/shared/wsl-login-shell-command.test.ts
+++ b/src/shared/wsl-login-shell-command.test.ts
@@ -306,6 +306,14 @@ describe('wsl login shell command helpers', () => {
     expect(command).toContain('exec "$_orca_wsl_shell" -l')
     expectValidShSyntax(command)
   })
+
+  it('can install a fish post-profile command', () => {
+    const command = buildWslInteractiveLoginShellCommand({ fishInitCommand: 'echo routed' })
+
+    expect(command).toContain('fish)')
+    expect(command).toContain(`exec "$_orca_wsl_shell" -l -C 'echo routed'`)
+    expectValidShSyntax(command)
+  })
 })
 
 describe('in-guest wrapper root resolution', () => {

--- a/src/shared/wsl-login-shell-command.ts
+++ b/src/shared/wsl-login-shell-command.ts
@@ -104,7 +104,9 @@ export function buildWslCapturedLoginShellCommand(
   }
 }
 
-export function buildWslInteractiveLoginShellCommand(): string {
+export function buildWslInteractiveLoginShellCommand(options?: {
+  fishInitCommand?: string
+}): string {
   return [
     '_orca_wsl_shell=$(getent passwd "$(id -un)" 2>/dev/null | cut -d: -f7)',
     'if [ -z "$_orca_wsl_shell" ] || [ ! -x "$_orca_wsl_shell" ]; then',
@@ -135,6 +137,13 @@ export function buildWslInteractiveLoginShellCommand(): string {
     '      export ZDOTDIR="${_orca_shell_ready_root}/zsh"',
     '    fi',
     '    ;;',
+    ...(options?.fishInitCommand
+      ? [
+          '  fish)',
+          `    exec "$_orca_wsl_shell" -l -C ${quotePosixShell(options.fishInitCommand)}`,
+          '    ;;'
+        ]
+      : []),
     'esac',
     'exec "$_orca_wsl_shell" -l'
   ].join('\n')


### PR DESCRIPTION
## ELI5

Orca keeps each Codex account separate, but updates Codex from the shared installation that owns the binary.

## What Changed

- Preserve the execution host Codex home before applying the account-scoped CODEX_HOME.
- Route the direct codex update command through that installation home in supported shells and WSL.
- Keep every other Codex command on the selected account home.

## Why

Account-scoped CODEX_HOME makes the standalone updater classify its installation as other. Separating account state from installation context restores updater detection without merging account data.

## Linked Issue

Fixes #16512

## Visual Proof

N/A — shell environment routing only; no UI change.

## Testing

- 200 focused shell-wrapper, home-routing, WSL interop, and Windows command-generation tests passed.
- Node and CLI typechecks passed.
- Changed-code quality, max-lines, runtime-Electron, and diff checks passed.
- Full lint, test, and build remain for CI.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

## Review

Self-reviewed for environment ownership, restoration after update, and shell-specific behavior.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows docs/reference/agent-skill-sharing-upstream-boundary.md and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The routing contract is the direct codex update form. Other invocations retain the selected account home. No remote wire shape changes are introduced.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] pnpm lint, pnpm typecheck, pnpm test, and pnpm build pass (or CI will cover; local preferred)