### PR TITLE
fix(worktrees): refresh paired clients after external discovery

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1638,12 +1638,17 @@
       "providers": ["local", "ssh"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["local", "ssh"],
-      "coverageNotes": "Local deterministic evidence covers git-common classification, desktop watcher debounce counts, non-overlapping poller semantics, macOS native-watch fallback, preload cleanup, Source Control active-visible repo filtering, the direct SSH five-slot fair scheduler, timeout barrier, aggregate privacy schema, coordinator-to-renderer telemetry wiring, host-catalog provenance rejection, and process generation-scope rollover across sibling targets. A macOS Electron client completed a direct SSH disconnect/reconnect against an ephemeral Linux Docker target with exact host/authority hydration and remote proof-file verification. Linux/Windows desktop clients, multi-target live fanout, paired-client, and WSL runs remain gaps.",
-      "motivatingLinks": ["https://github.com/stablyai/orca/pull/7086"],
-      "invariant": "Index-only Git activity below the common Git directory must not emit worktrees:changed, invalidate worktree caches, or trigger fetchWorktrees fanout; structural add/remove/HEAD/gitdir/locked/config.worktree changes must still refresh worktrees and nudge Source Control; external head moves (commit, amend, reset) must reach background worktree rows through spawn-free metadata reads, never through structural fanout. Direct SSH reconnect discovery must stay host- and authority-qualified, reject contradictory main-catalog provenance without returning rows, admit at most five locally unsettled provider calls, retain a retrying timeout barrier, and emit one identifier-free aggregate product event per target operation. A process generation-scope rollover revokes every direct SSH target and old-scope provider request, not only the target whose counter exhausted.",
-      "oracle": "Classify exact git-common paths as structural, status-only, or ignored; count notifications from debounced watcher events; force the Linux/Windows poll path to emit allowlisted leaf events, detect linked HEAD rewrites independent of entry-directory mtime, and surface in-place index rewrites via the backstop re-stat; diff head identities from metadata-file reads and notify only real head moves; assert Source Control subscribes to both structural and status-only signals with active-repo and visibility filters. For direct SSH, reject catalog rows whose explicit and legacy host provenance contradict, roll one exhausted target into a fresh process generation scope while invalidating sibling target tokens, count locally unsettled attempts and round-robin admissions, keep lineage blocked through the first timeout retry, distinguish timeout/rejection/cancel/stale results, and reject telemetry properties carrying target, repo, host, path, label, user, request, lease, terminal, or raw-error data.",
+      "coverageNotes": "Local deterministic evidence covers git-common classification, desktop watcher debounce counts, non-overlapping poller semantics, macOS native-watch fallback, preload cleanup, Source Control active-visible repo filtering, paired-runtime publication to two independent clients with reconnect and stale-cache checks, the direct SSH five-slot fair scheduler, timeout barrier, aggregate privacy schema, coordinator-to-renderer telemetry wiring, host-catalog provenance rejection, and process generation-scope rollover across sibling targets. A headed macOS Electron host and separate paired Electron client both rendered a worktree created through the real Git binary and watcher entry path without reconnect. A macOS Electron client also completed a direct SSH disconnect/reconnect against an ephemeral Linux Docker target with exact host/authority hydration and remote proof-file verification. Linux/Windows desktop clients, multi-target live fanout, and WSL runs remain gaps.",
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca/pull/7086",
+        "https://github.com/stablyai/orca/issues/16477"
+      ],
+      "invariant": "Index-only Git activity below the common Git directory must not emit worktrees:changed, invalidate worktree caches, or trigger fetchWorktrees fanout; structural add/remove/HEAD/gitdir/locked/config.worktree changes must still refresh worktrees and nudge Source Control. When the authoritative paired host accepts an external structural change for a uniquely identified server-local repo, each live client for that host must receive one existing host-scoped worktreesChanged invalidation and converge to the same repo/worktree identity without reconnect; duplicate watcher events must coalesce, stale cached or in-flight catalogs must not survive invalidation, and event-ignoring clients must remain compatible. Nested SSH watchers and colliding local/SSH repo IDs must not publish the host-blind event until existing semantics can carry owner identity. External head moves (commit, amend, reset) must reach background worktree rows through spawn-free metadata reads, never through structural fanout. Direct SSH reconnect discovery must stay host- and authority-qualified, reject contradictory main-catalog provenance without returning rows, admit at most five locally unsettled provider calls, retain a retrying timeout barrier, and emit one identifier-free aggregate product event per target operation. A process generation-scope rollover revokes every direct SSH target and old-scope provider request, not only the target whose counter exhausted.",
+      "oracle": "Classify exact git-common paths as structural, status-only, or ignored; count notifications from debounced watcher events; force the Linux/Windows poll path to emit allowlisted leaf events, detect linked HEAD rewrites independent of entry-directory mtime, and surface in-place index rewrites via the backstop re-stat; diff head identities from metadata-file reads and notify only real head moves; assert Source Control subscribes to both structural and status-only signals with active-repo and visibility filters. Join the real runtime RPC server to two independently authenticated E2EE clients plus an event-ignoring client, advance the host Git inventory, trigger duplicate structural watcher callbacks, and require one host renderer notification plus one runtime event and a refreshed catalog per subscribed client; require the event-ignoring client to refresh safely on explicit read. Hold a scan after it captures old inventory, join it from a second paired client, publish the watcher invalidation, advance Git independently, and require both overlapping RPCs to retry or join one fresh scan before returning. Disconnect one client, advance inventory again, and require reconnect to read current state without stale event replay. Give a watcher a nested SSH connection id or a local repo ID colliding with an SSH owner and require the host renderer refresh while the unqualified runtime event stays absent. Force the real path in isolated Electron apps with git worktree add, a host Git inventory assertion, store-subscription barriers, matching host/client worktree identity, and visible rows in both renderers. For direct SSH, reject catalog rows whose explicit and legacy host provenance contradict, roll one exhausted target into a fresh process generation scope while invalidating sibling target tokens, count locally unsettled attempts and round-robin admissions, keep lineage blocked through the first timeout retry, distinguish timeout/rejection/cancel/stale results, and reject telemetry properties carrying target, repo, host, path, label, user, request, lease, terminal, or raw-error data.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/worktree-base-directory-event-filter.test.ts src/main/ipc/worktree-base-directory-watcher.test.ts src/main/ipc/worktree-base-directory-poller.test.ts src/main/ipc/worktree-head-identity-reader.test.ts src/renderer/src/hooks/worktree-head-identity-apply.test.ts src/renderer/src/components/right-sidebar/git-status-push-signal-refresh.test.ts src/renderer/src/hooks/useIpcEvents-browser-tab-create.test.ts",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/watched-worktree-catalog-notification.test.ts src/main/runtime/external-worktree-paired-client-discovery.integration.test.ts src/main/window/attach-main-window-services.test.ts",
+        "ORCA_E2E_FORCE_HEADFUL=1 SKIP_BUILD=1 pnpm exec playwright test tests/e2e/paired-external-worktree-discovery.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
         "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/repos-remote.test.ts src/main/ssh/ssh-connection-generation.test.ts src/main/ssh/ssh-provider-authority.test.ts --reporter=dot",
         "pnpm exec vitest run --config config/vitest.config.ts src/shared/direct-ssh-reconnect-telemetry-schema.test.ts src/renderer/src/lib/direct-ssh-reconnect-product-telemetry.test.ts src/renderer/src/hooks/direct-ssh-worktree-refresh-scheduler.test.ts src/renderer/src/hooks/direct-ssh-reconnect-coordinator.test.ts src/renderer/src/hooks/useIpcEvents-agent-status-ssh-authority.test.ts --reporter=dot",
         "ORCA_E2E_SSH_DOCKER=1 SKIP_BUILD=1 pnpm exec playwright test tests/e2e/ssh-docker-relay-perf.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1"
@@ -1656,6 +1661,10 @@
         "src/renderer/src/hooks/worktree-head-identity-apply.test.ts",
         "src/renderer/src/components/right-sidebar/git-status-push-signal-refresh.test.ts",
         "src/renderer/src/hooks/useIpcEvents-browser-tab-create.test.ts",
+        "src/main/ipc/watched-worktree-catalog-notification.test.ts",
+        "src/main/runtime/external-worktree-paired-client-discovery.integration.test.ts",
+        "src/main/window/attach-main-window-services.test.ts",
+        "tests/e2e/paired-external-worktree-discovery.spec.ts",
         "src/renderer/src/hooks/useIpcEvents-agent-status-ssh-authority.test.ts",
         "src/main/ipc/repos-remote.test.ts",
         "src/main/ssh/ssh-connection-generation.test.ts",
@@ -1727,6 +1736,32 @@
           "file": "src/renderer/src/hooks/useIpcEvents-agent-status-ssh-authority.test.ts",
           "assertions": [
             "direct SSH coordinator telemetry is wired through the fail-soft product adapter"
+          ]
+        },
+        {
+          "file": "src/main/runtime/external-worktree-paired-client-discovery.integration.test.ts",
+          "assertions": [
+            "duplicate host watcher callbacks coalesce to one local notification and one worktreesChanged event for each of two live paired clients",
+            "host inventory and both paired catalogs advance to the same worktree identity after runtime cache invalidation",
+            "an invalidated in-flight host scan and a second client's joined read converge through one fresh retry before either can return stale data",
+            "a disconnected client reconnects to current catalog state without replaying a stale invalidation",
+            "an event-ignoring client remains compatible, and nested SSH or colliding local/SSH owners do not publish an owner-blind event",
+            "the shared runtime publication remains valid without a headed renderer notifier"
+          ]
+        },
+        {
+          "file": "src/main/ipc/watched-worktree-catalog-notification.test.ts",
+          "assertions": [
+            "the watcher authority refreshes the host renderer and paired clients from one boundary",
+            "remote publication failure cannot suppress the host renderer refresh",
+            "nested SSH discoveries remain host-local until the existing event can preserve their owner identity"
+          ]
+        },
+        {
+          "file": "tests/e2e/paired-external-worktree-discovery.spec.ts",
+          "assertions": [
+            "a real git worktree add advances the authoritative host inventory",
+            "the headed host and separate paired Electron client render the same new worktree without reconnect"
           ]
         },
         {

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1758,10 +1758,17 @@
           ]
         },
         {
+          "file": "src/main/window/attach-main-window-services.test.ts",
+          "assertions": [
+            "main-window wiring installs the runtime as the watched-worktree remote-client notifier alongside the existing repo notifier"
+          ]
+        },
+        {
           "file": "tests/e2e/paired-external-worktree-discovery.spec.ts",
           "assertions": [
             "a real git worktree add advances the authoritative host inventory",
-            "the headed host and separate paired Electron client render the same new worktree without reconnect"
+            "the headed host and separate paired Electron client render the same new worktree identity",
+            "the paired client's main-process shared-control transport keeps one connection epoch while converging and compares Windows paths case-insensitively"
           ]
         },
         {
@@ -1859,6 +1866,24 @@
           "result": "passed",
           "durationSeconds": 66,
           "summary": "Four Electron Docker SSH tests passed: two typing/performance paths, one concurrent file/Git load path, and exact-authority disconnect/reconnect with a container-visible remote proof file."
+        },
+        {
+          "date": "2026-08-26",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/watched-worktree-catalog-notification.test.ts src/main/runtime/external-worktree-paired-client-discovery.integration.test.ts src/main/window/attach-main-window-services.test.ts",
+          "result": "passed",
+          "durationSeconds": 6.19,
+          "summary": "Three watcher/runtime/wiring files passed with 38 tests, including two-client publication, reconnect, stale scan fencing, headless parity, owner-collision suppression, failure isolation, and main-window notifier wiring."
+        },
+        {
+          "date": "2026-08-26",
+          "runner": "local",
+          "platform": "macos",
+          "command": "ORCA_E2E_FORCE_HEADFUL=1 SKIP_BUILD=1 pnpm exec playwright test tests/e2e/paired-external-worktree-discovery.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
+          "result": "passed",
+          "durationSeconds": 17.96,
+          "summary": "One forced-visible paired Electron test passed: real Git inventory, matching visible host/client rows, and one unchanged main-process shared-control transport epoch during convergence."
         }
       ],
       "runtimeBudget": {
@@ -1867,7 +1892,7 @@
       },
       "flakeHistory": {
         "status": "unknown",
-        "evidence": "Three deterministic local macOS runs cover the original watcher lane, main catalog/authority lane, and direct SSH scheduler/telemetry lane; CI soak is still unavailable."
+        "evidence": "Four focused deterministic local macOS runs cover the original watcher lane, paired-runtime publication lane, main catalog/authority lane, and direct SSH scheduler/telemetry lane; two live Electron runs cover paired external discovery and Docker SSH, while CI soak is still unavailable."
       },
       "redGreenEvidence": {
         "status": "partial",

--- a/src/main/ipc/watched-worktree-catalog-notification.test.ts
+++ b/src/main/ipc/watched-worktree-catalog-notification.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('./worktree-remote', () => ({
+  notifyWorktreesChanged: vi.fn()
+}))
+
+import { notifyWorktreesChanged } from './worktree-remote'
+import {
+  notifyWatchedWorktreeCatalogChanged,
+  setWorktreeCatalogRemoteClientNotifier
+} from './watched-worktree-catalog-notification'
+
+const mainWindow = { isDestroyed: () => false, webContents: { send: vi.fn() } }
+
+describe('watched worktree catalog notifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setWorktreeCatalogRemoteClientNotifier(null)
+  })
+
+  it('refreshes the host and paired clients once', () => {
+    const notifyRemote = vi.fn()
+    setWorktreeCatalogRemoteClientNotifier({
+      notifyWorktreeCatalogChangedForRemoteClients: notifyRemote
+    })
+
+    notifyWatchedWorktreeCatalogChanged(mainWindow as never, 'repo-1')
+
+    expect(notifyWorktreesChanged).toHaveBeenCalledWith(mainWindow, 'repo-1')
+    expect(notifyRemote).toHaveBeenCalledOnce()
+    expect(notifyRemote).toHaveBeenCalledWith('repo-1')
+  })
+
+  it('keeps the host refresh when remote publication fails', () => {
+    const error = new Error('stream unavailable')
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    setWorktreeCatalogRemoteClientNotifier({
+      notifyWorktreeCatalogChangedForRemoteClients: () => {
+        throw error
+      }
+    })
+
+    expect(() => notifyWatchedWorktreeCatalogChanged(mainWindow as never, 'repo-1')).not.toThrow()
+    expect(notifyWorktreesChanged).toHaveBeenCalledWith(mainWindow, 'repo-1')
+    expect(consoleError).toHaveBeenCalledWith(
+      '[worktrees] failed to notify remote clients of watched catalog change',
+      error
+    )
+  })
+
+  it('keeps nested SSH discoveries local until the event can carry owner identity', () => {
+    const notifyRemote = vi.fn()
+    setWorktreeCatalogRemoteClientNotifier({
+      notifyWorktreeCatalogChangedForRemoteClients: notifyRemote
+    })
+
+    notifyWatchedWorktreeCatalogChanged(mainWindow as never, 'repo-1', 'ssh-target-1')
+
+    expect(notifyWorktreesChanged).toHaveBeenCalledWith(mainWindow, 'repo-1')
+    expect(notifyRemote).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/watched-worktree-catalog-notification.ts
+++ b/src/main/ipc/watched-worktree-catalog-notification.ts
@@ -1,0 +1,33 @@
+import type { BrowserWindow } from 'electron'
+import type { OrcaRuntimeService } from '../runtime/orca-runtime'
+import { notifyWorktreesChanged } from './worktree-remote'
+
+type WorktreeCatalogRemoteClientNotifier = Pick<
+  OrcaRuntimeService,
+  'notifyWorktreeCatalogChangedForRemoteClients'
+>
+
+let remoteClientNotifier: WorktreeCatalogRemoteClientNotifier | null = null
+
+export function setWorktreeCatalogRemoteClientNotifier(
+  notifier: WorktreeCatalogRemoteClientNotifier | null
+): void {
+  remoteClientNotifier = notifier
+}
+
+export function notifyWatchedWorktreeCatalogChanged(
+  mainWindow: BrowserWindow,
+  repoId: string,
+  connectionId?: string
+): void {
+  notifyWorktreesChanged(mainWindow, repoId)
+  if (connectionId) {
+    return
+  }
+  try {
+    remoteClientNotifier?.notifyWorktreeCatalogChangedForRemoteClients(repoId)
+  } catch (error) {
+    // Why: remote fanout must not block the host renderer's watcher refresh.
+    console.error('[worktrees] failed to notify remote clients of watched catalog change', error)
+  }
+}

--- a/src/main/ipc/worktree-base-directory-notifications.ts
+++ b/src/main/ipc/worktree-base-directory-notifications.ts
@@ -5,7 +5,8 @@ import {
   refreshWorktreeHeadIdentities,
   type WorktreeHeadIdentityRefreshState
 } from './worktree-head-identity-refresh'
-import { notifyWorktreeGitStatusMetadataChanged, notifyWorktreesChanged } from './worktree-remote'
+import { notifyWorktreeGitStatusMetadataChanged } from './worktree-remote'
+import { notifyWatchedWorktreeCatalogChanged } from './watched-worktree-catalog-notification'
 
 export type WorktreeBaseNotificationWatch = WorktreeBaseWatchTarget & {
   mainWindow: BrowserWindow
@@ -63,7 +64,7 @@ export function scheduleWorktreeBaseNotification(
     const emitHeadIdentities = pendingStructure.length === 0
     clearPendingWorktreeBaseNotifications(watch)
     for (const repoId of pendingStructure) {
-      notifyWorktreesChanged(watch.mainWindow, repoId)
+      notifyWatchedWorktreeCatalogChanged(watch.mainWindow, repoId, watch.connectionId)
     }
     for (const repoId of sourceControlRepoIds) {
       notifyWorktreeGitStatusMetadataChanged(watch.mainWindow, repoId)

--- a/src/main/runtime/external-worktree-paired-client-discovery.integration.test.ts
+++ b/src/main/runtime/external-worktree-paired-client-discovery.integration.test.ts
@@ -1,0 +1,567 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { listWorktrees, listWorktreesStrict } from '../git/worktree'
+import { scheduleWorktreeBaseNotification } from '../ipc/worktree-base-directory-notifications'
+import { createWorktreeHeadIdentityRefreshState } from '../ipc/worktree-head-identity-refresh'
+import { setWorktreeCatalogRemoteClientNotifier } from '../ipc/watched-worktree-catalog-notification'
+import { OrcaRuntimeService } from './orca-runtime'
+import {
+  authenticate,
+  createReader,
+  makeStore,
+  REPO_ID,
+  resultType,
+  send,
+  type PairedSession,
+  type ResponseReader
+} from './paired-client-navigation-test-harness'
+import { OrcaRuntimeRpcServer } from './runtime-rpc'
+
+vi.mock('../git/worktree', () => ({
+  listWorktrees: vi.fn(),
+  listWorktreesStrict: vi.fn()
+}))
+
+const initialWorktreePath = join(tmpdir(), 'repo')
+const externalWorktreePath = join(tmpdir(), 'external-worktree')
+const initialWorktree = {
+  path: initialWorktreePath,
+  head: 'initial-head',
+  branch: 'refs/heads/main',
+  isBare: false,
+  isMainWorktree: true
+}
+const externalWorktree = {
+  path: externalWorktreePath,
+  head: 'external-head',
+  branch: 'refs/heads/external-worktree',
+  isBare: false,
+  isMainWorktree: false
+}
+const reconnectedWorktree = {
+  path: join(tmpdir(), 'reconnected-worktree'),
+  head: 'reconnected-head',
+  branch: 'refs/heads/reconnected-worktree',
+  isBare: false,
+  isMainWorktree: false
+}
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+function catalogPaths(response: Record<string, unknown>): string[] {
+  return ((response.result as { worktrees?: { path: string }[] } | undefined)?.worktrees ?? []).map(
+    (worktree) => worktree.path
+  )
+}
+
+describe('external worktree discovery for paired clients', () => {
+  const servers: OrcaRuntimeRpcServer[] = []
+  const sessions: PairedSession[] = []
+  const readers: ResponseReader[] = []
+  const tempDirs: string[] = []
+
+  afterEach(async () => {
+    vi.useRealTimers()
+    setWorktreeCatalogRemoteClientNotifier(null)
+    for (const reader of readers.splice(0)) {
+      reader.dispose()
+    }
+    for (const session of sessions.splice(0)) {
+      session.ws.close()
+    }
+    await Promise.all(servers.splice(0).map((server) => server.stop()))
+    for (const path of tempDirs.splice(0)) {
+      rmSync(path, { recursive: true, force: true })
+    }
+    vi.clearAllMocks()
+  })
+
+  it('publishes one host-scoped catalog invalidation to two paired clients', async () => {
+    vi.mocked(listWorktrees).mockResolvedValue([initialWorktree])
+    vi.mocked(listWorktreesStrict).mockResolvedValue([initialWorktree])
+    vi.mocked(listWorktreesStrict).mockResolvedValue([initialWorktree])
+    const runtime = new OrcaRuntimeService(makeStore() as never)
+    setWorktreeCatalogRemoteClientNotifier(runtime)
+    const userDataPath = mkdtempSync(join(tmpdir(), 'o-ewd-'))
+    tempDirs.push(userDataPath)
+    const server = new OrcaRuntimeRpcServer({
+      runtime,
+      userDataPath,
+      enableWebSocket: true,
+      wsPort: 0
+    })
+    servers.push(server)
+    await server.start()
+
+    const pairingUrls: string[] = []
+    for (const name of ['client-a', 'client-b']) {
+      const offer = server.createPairingOffer({ address: '127.0.0.1', name, scope: 'runtime' })
+      if (!offer.available) {
+        throw new Error('pairing_unavailable')
+      }
+      pairingUrls.push(offer.pairingUrl)
+      const client = await authenticate(offer.pairingUrl)
+      sessions.push(client)
+      readers.push(createReader(client))
+    }
+
+    for (const [index, session] of sessions.entries()) {
+      send(session, { id: `events-${index}`, method: 'runtime.clientEvents.subscribe' })
+      await readers[index]!.next(`events-${index}`, (response) => resultType(response) === 'ready')
+      send(session, {
+        id: `initial-catalog-${index}`,
+        method: 'worktree.list',
+        params: { repo: REPO_ID, limit: 100 }
+      })
+      expect(catalogPaths(await readers[index]!.next(`initial-catalog-${index}`))).toEqual([
+        initialWorktreePath
+      ])
+    }
+
+    const legacyOffer = server.createPairingOffer({
+      address: '127.0.0.1',
+      name: 'event-ignoring-client',
+      scope: 'runtime'
+    })
+    if (!legacyOffer.available) {
+      throw new Error('pairing_unavailable')
+    }
+    const legacyClient = await authenticate(legacyOffer.pairingUrl)
+    const legacyReader = createReader(legacyClient)
+    sessions.push(legacyClient)
+    readers.push(legacyReader)
+    send(legacyClient, {
+      id: 'legacy-initial-catalog',
+      method: 'worktree.list',
+      params: { repo: REPO_ID, limit: 100 }
+    })
+    expect(catalogPaths(await legacyReader.next('legacy-initial-catalog'))).toEqual([
+      initialWorktreePath
+    ])
+
+    vi.mocked(listWorktrees).mockResolvedValue([initialWorktree, externalWorktree])
+    vi.mocked(listWorktreesStrict).mockResolvedValue([initialWorktree, externalWorktree])
+    expect(
+      (await listWorktreesStrict({ path: initialWorktreePath } as never)).map((w) => w.path)
+    ).toEqual([initialWorktreePath, externalWorktreePath])
+
+    const sendToHostRenderer = vi.fn()
+    const watch = {
+      key: 'base:repo-1',
+      kind: 'base' as const,
+      path: tmpdir(),
+      repos: new Map(),
+      mainWindow: {
+        isDestroyed: () => false,
+        webContents: { send: sendToHostRenderer }
+      },
+      notifyTimer: null,
+      pendingStructureRepoIds: new Set<string>(),
+      pendingGitStatusRepoIds: new Set<string>(),
+      pendingHeadIdentityRepoIds: new Set<string>(),
+      headIdentityRefresh: createWorktreeHeadIdentityRefreshState(),
+      disposed: false
+    }
+    vi.useFakeTimers()
+    scheduleWorktreeBaseNotification(watch as never, { structureRepoIds: [REPO_ID] })
+    scheduleWorktreeBaseNotification(watch as never, { structureRepoIds: [REPO_ID] })
+    await vi.advanceTimersByTimeAsync(250)
+    vi.useRealTimers()
+
+    expect(sendToHostRenderer).toHaveBeenCalledTimes(1)
+    expect(sendToHostRenderer).toHaveBeenCalledWith('worktrees:changed', { repoId: REPO_ID })
+
+    runtime.notifyReposChangedForRemoteClients()
+    for (const [index, reader] of readers.slice(0, 2).entries()) {
+      const observed: string[] = []
+      for (;;) {
+        const type = resultType(await reader.next(`events-${index}`)) ?? 'unknown'
+        observed.push(type)
+        if (type === 'reposChanged') {
+          break
+        }
+      }
+      expect(observed).toEqual(['worktreesChanged', 'reposChanged'])
+    }
+
+    for (const [index, session] of sessions.slice(0, 2).entries()) {
+      send(session, {
+        id: `refreshed-catalog-${index}`,
+        method: 'worktree.list',
+        params: { repo: REPO_ID, limit: 100 }
+      })
+      expect(catalogPaths(await readers[index]!.next(`refreshed-catalog-${index}`))).toEqual([
+        initialWorktreePath,
+        externalWorktreePath
+      ])
+    }
+
+    send(legacyClient, {
+      id: 'legacy-explicit-refresh',
+      method: 'worktree.list',
+      params: { repo: REPO_ID, limit: 100 }
+    })
+    expect(catalogPaths(await legacyReader.next('legacy-explicit-refresh'))).toEqual([
+      initialWorktreePath,
+      externalWorktreePath
+    ])
+
+    const disconnectedSession = sessions.splice(1, 1)[0]!
+    const disconnectedReader = readers.splice(1, 1)[0]!
+    disconnectedReader.dispose()
+    await new Promise<void>((resolve) => {
+      disconnectedSession.ws.once('close', () => resolve())
+      disconnectedSession.ws.close()
+    })
+    vi.mocked(listWorktrees).mockResolvedValue([
+      initialWorktree,
+      externalWorktree,
+      reconnectedWorktree
+    ])
+    vi.mocked(listWorktreesStrict).mockResolvedValue([
+      initialWorktree,
+      externalWorktree,
+      reconnectedWorktree
+    ])
+
+    vi.useFakeTimers()
+    scheduleWorktreeBaseNotification(watch as never, { structureRepoIds: [REPO_ID] })
+    await vi.advanceTimersByTimeAsync(250)
+    vi.useRealTimers()
+    await expect(
+      readers[0]!.next('events-0', (response) => resultType(response) === 'worktreesChanged')
+    ).resolves.toMatchObject({ result: { repoId: REPO_ID } })
+
+    const reconnectedSession = await authenticate(pairingUrls[1]!)
+    const reconnectedReader = createReader(reconnectedSession)
+    sessions.push(reconnectedSession)
+    readers.push(reconnectedReader)
+    send(reconnectedSession, {
+      id: 'events-reconnected',
+      method: 'runtime.clientEvents.subscribe'
+    })
+    await reconnectedReader.next(
+      'events-reconnected',
+      (response) => resultType(response) === 'ready'
+    )
+    send(reconnectedSession, {
+      id: 'reconnected-catalog',
+      method: 'worktree.list',
+      params: { repo: REPO_ID, limit: 100 }
+    })
+    expect(catalogPaths(await reconnectedReader.next('reconnected-catalog'))).toEqual([
+      initialWorktreePath,
+      externalWorktreePath,
+      reconnectedWorktree.path
+    ])
+
+    runtime.notifyReposChangedForRemoteClients()
+    expect(resultType(await reconnectedReader.next('events-reconnected'))).toBe('reposChanged')
+  })
+
+  it('retries invalidated owner and joined scans before returning their stale snapshot', async () => {
+    const firstScanStarted = deferred<void>()
+    const releaseFirstScan = deferred<void>()
+    let scanCount = 0
+    vi.mocked(listWorktrees).mockResolvedValue([initialWorktree])
+    vi.mocked(listWorktreesStrict).mockResolvedValue([initialWorktree, externalWorktree])
+    const runtime = new OrcaRuntimeService(makeStore() as never)
+    setWorktreeCatalogRemoteClientNotifier(runtime)
+    const userDataPath = mkdtempSync(join(tmpdir(), 'o-ewd-race-'))
+    tempDirs.push(userDataPath)
+    const server = new OrcaRuntimeRpcServer({
+      runtime,
+      userDataPath,
+      enableWebSocket: true,
+      wsPort: 0
+    })
+    servers.push(server)
+    await server.start()
+    const clients: PairedSession[] = []
+    const raceReaders: ResponseReader[] = []
+    for (const name of ['race-client-a', 'race-client-b']) {
+      const offer = server.createPairingOffer({ address: '127.0.0.1', name, scope: 'runtime' })
+      if (!offer.available) {
+        throw new Error('pairing_unavailable')
+      }
+      const client = await authenticate(offer.pairingUrl)
+      const reader = createReader(client)
+      clients.push(client)
+      raceReaders.push(reader)
+      sessions.push(client)
+      readers.push(reader)
+    }
+    for (const [index, client] of clients.entries()) {
+      send(client, { id: `race-events-${index}`, method: 'runtime.clientEvents.subscribe' })
+      await raceReaders[index].next(
+        `race-events-${index}`,
+        (response) => resultType(response) === 'ready'
+      )
+    }
+
+    runtime.notifyWorktreeCatalogChangedForRemoteClients(REPO_ID)
+    await Promise.all(
+      raceReaders.map((reader, index) =>
+        reader.next(
+          `race-events-${index}`,
+          (response) => resultType(response) === 'worktreesChanged'
+        )
+      )
+    )
+    let inventory = [initialWorktree]
+    vi.mocked(listWorktreesStrict).mockClear()
+    vi.mocked(listWorktreesStrict).mockImplementation(async () => {
+      scanCount += 1
+      if (scanCount === 1) {
+        const captured = [...inventory]
+        firstScanStarted.resolve()
+        await releaseFirstScan.promise
+        return captured
+      }
+      return inventory
+    })
+
+    for (const [index, client] of clients.entries()) {
+      send(client, {
+        id: `overlapping-catalog-${index}`,
+        method: 'worktree.list',
+        params: { repo: REPO_ID, limit: 100 }
+      })
+    }
+    await firstScanStarted.promise
+    inventory = [initialWorktree, externalWorktree]
+    expect(listWorktreesStrict).toHaveBeenCalledOnce()
+
+    const watch = {
+      key: 'base:repo-race',
+      kind: 'base' as const,
+      path: tmpdir(),
+      repos: new Map(),
+      mainWindow: {
+        isDestroyed: () => false,
+        webContents: { send: vi.fn() }
+      },
+      notifyTimer: null,
+      pendingStructureRepoIds: new Set<string>(),
+      pendingGitStatusRepoIds: new Set<string>(),
+      pendingHeadIdentityRepoIds: new Set<string>(),
+      headIdentityRefresh: createWorktreeHeadIdentityRefreshState(),
+      disposed: false
+    }
+    vi.useFakeTimers()
+    scheduleWorktreeBaseNotification(watch as never, { structureRepoIds: [REPO_ID] })
+    await vi.advanceTimersByTimeAsync(250)
+    vi.useRealTimers()
+    await Promise.all(
+      raceReaders.map((reader, index) =>
+        expect(
+          reader.next(
+            `race-events-${index}`,
+            (response) => resultType(response) === 'worktreesChanged'
+          )
+        ).resolves.toMatchObject({ result: { repoId: REPO_ID } })
+      )
+    )
+
+    releaseFirstScan.resolve()
+    await Promise.all(
+      raceReaders.map(async (reader, index) => {
+        expect(catalogPaths(await reader.next(`overlapping-catalog-${index}`))).toEqual([
+          initialWorktreePath,
+          externalWorktreePath
+        ])
+      })
+    )
+    expect(listWorktreesStrict).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not publish an owner-blind event for colliding local and SSH repo IDs', async () => {
+    const store = makeStore()
+    const localRepo = store.getRepos().find((repo) => repo.id === REPO_ID)
+    if (!localRepo) {
+      throw new Error('local_repo_missing')
+    }
+    const collidingRepos = [
+      ...store.getRepos(),
+      { ...localRepo, path: '/remote/repo', connectionId: 'ssh-target-1' }
+    ]
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getRepo: (id: string) => collidingRepos.find((repo) => repo.id === id),
+      getRepos: () => collidingRepos
+    } as never)
+    setWorktreeCatalogRemoteClientNotifier(runtime)
+    const userDataPath = mkdtempSync(join(tmpdir(), 'o-ewd-collision-'))
+    tempDirs.push(userDataPath)
+    const server = new OrcaRuntimeRpcServer({
+      runtime,
+      userDataPath,
+      enableWebSocket: true,
+      wsPort: 0
+    })
+    servers.push(server)
+    await server.start()
+    const offer = server.createPairingOffer({
+      address: '127.0.0.1',
+      name: 'collision-client',
+      scope: 'runtime'
+    })
+    if (!offer.available) {
+      throw new Error('pairing_unavailable')
+    }
+    const client = await authenticate(offer.pairingUrl)
+    const reader = createReader(client)
+    sessions.push(client)
+    readers.push(reader)
+    send(client, { id: 'collision-events', method: 'runtime.clientEvents.subscribe' })
+    await reader.next('collision-events', (response) => resultType(response) === 'ready')
+
+    const sendToHostRenderer = vi.fn()
+    const watch = {
+      key: 'base:local-repo-collision',
+      kind: 'base' as const,
+      path: tmpdir(),
+      repos: new Map(),
+      mainWindow: {
+        isDestroyed: () => false,
+        webContents: { send: sendToHostRenderer }
+      },
+      notifyTimer: null,
+      pendingStructureRepoIds: new Set<string>(),
+      pendingGitStatusRepoIds: new Set<string>(),
+      pendingHeadIdentityRepoIds: new Set<string>(),
+      headIdentityRefresh: createWorktreeHeadIdentityRefreshState(),
+      disposed: false
+    }
+    vi.useFakeTimers()
+    scheduleWorktreeBaseNotification(watch as never, { structureRepoIds: [REPO_ID] })
+    await vi.advanceTimersByTimeAsync(250)
+    vi.useRealTimers()
+
+    expect(sendToHostRenderer).toHaveBeenCalledWith('worktrees:changed', { repoId: REPO_ID })
+    runtime.notifyReposChangedForRemoteClients()
+    expect(resultType(await reader.next('collision-events'))).toBe('reposChanged')
+  })
+
+  it('does not publish a host-blind event for a nested SSH watcher', async () => {
+    const runtime = new OrcaRuntimeService(makeStore() as never)
+    setWorktreeCatalogRemoteClientNotifier(runtime)
+    const userDataPath = mkdtempSync(join(tmpdir(), 'o-ewd-ssh-owner-'))
+    tempDirs.push(userDataPath)
+    const server = new OrcaRuntimeRpcServer({
+      runtime,
+      userDataPath,
+      enableWebSocket: true,
+      wsPort: 0
+    })
+    servers.push(server)
+    await server.start()
+    const offer = server.createPairingOffer({
+      address: '127.0.0.1',
+      name: 'nested-ssh-client',
+      scope: 'runtime'
+    })
+    if (!offer.available) {
+      throw new Error('pairing_unavailable')
+    }
+    const client = await authenticate(offer.pairingUrl)
+    const reader = createReader(client)
+    sessions.push(client)
+    readers.push(reader)
+    send(client, { id: 'ssh-events', method: 'runtime.clientEvents.subscribe' })
+    await reader.next('ssh-events', (response) => resultType(response) === 'ready')
+
+    const sendToHostRenderer = vi.fn()
+    const watch = {
+      key: 'ssh:repo-collision',
+      kind: 'base' as const,
+      path: '/remote/worktrees',
+      connectionId: 'ssh-target-1',
+      repos: new Map(),
+      mainWindow: {
+        isDestroyed: () => false,
+        webContents: { send: sendToHostRenderer }
+      },
+      notifyTimer: null,
+      pendingStructureRepoIds: new Set<string>(),
+      pendingGitStatusRepoIds: new Set<string>(),
+      pendingHeadIdentityRepoIds: new Set<string>(),
+      headIdentityRefresh: createWorktreeHeadIdentityRefreshState(),
+      disposed: false
+    }
+    vi.useFakeTimers()
+    scheduleWorktreeBaseNotification(watch as never, { structureRepoIds: [REPO_ID] })
+    await vi.advanceTimersByTimeAsync(250)
+    vi.useRealTimers()
+
+    expect(sendToHostRenderer).toHaveBeenCalledWith('worktrees:changed', { repoId: REPO_ID })
+    runtime.notifyReposChangedForRemoteClients()
+    expect(resultType(await reader.next('ssh-events'))).toBe('reposChanged')
+  })
+
+  it('keeps the shared runtime publication valid without a headed renderer', async () => {
+    vi.mocked(listWorktrees).mockResolvedValue([initialWorktree])
+    vi.mocked(listWorktreesStrict).mockResolvedValue([initialWorktree])
+    const runtime = new OrcaRuntimeService(makeStore() as never)
+    const userDataPath = mkdtempSync(join(tmpdir(), 'o-ewd-h-'))
+    tempDirs.push(userDataPath)
+    const server = new OrcaRuntimeRpcServer({
+      runtime,
+      userDataPath,
+      enableWebSocket: true,
+      wsPort: 0
+    })
+    servers.push(server)
+    await server.start()
+    const offer = server.createPairingOffer({
+      address: '127.0.0.1',
+      name: 'headless-client',
+      scope: 'runtime'
+    })
+    if (!offer.available) {
+      throw new Error('pairing_unavailable')
+    }
+    const client = await authenticate(offer.pairingUrl)
+    const reader = createReader(client)
+    sessions.push(client)
+    readers.push(reader)
+    send(client, { id: 'headless-events', method: 'runtime.clientEvents.subscribe' })
+    await reader.next('headless-events', (response) => resultType(response) === 'ready')
+    send(client, {
+      id: 'headless-initial-catalog',
+      method: 'worktree.list',
+      params: { repo: REPO_ID, limit: 100 }
+    })
+    expect(catalogPaths(await reader.next('headless-initial-catalog'))).toEqual([
+      initialWorktreePath
+    ])
+
+    vi.mocked(listWorktrees).mockResolvedValue([initialWorktree, externalWorktree])
+    vi.mocked(listWorktreesStrict).mockResolvedValue([initialWorktree, externalWorktree])
+    runtime.notifyWorktreeCatalogChangedForRemoteClients(REPO_ID)
+
+    await expect(
+      reader.next('headless-events', (response) => resultType(response) === 'worktreesChanged')
+    ).resolves.toMatchObject({ result: { repoId: REPO_ID } })
+    send(client, {
+      id: 'headless-refreshed-catalog',
+      method: 'worktree.list',
+      params: { repo: REPO_ID, limit: 100 }
+    })
+    expect(catalogPaths(await reader.next('headless-refreshed-catalog'))).toEqual([
+      initialWorktreePath,
+      externalWorktreePath
+    ])
+  })
+})

--- a/src/main/runtime/external-worktree-paired-client-discovery.integration.test.ts
+++ b/src/main/runtime/external-worktree-paired-client-discovery.integration.test.ts
@@ -90,7 +90,6 @@ describe('external worktree discovery for paired clients', () => {
   it('publishes one host-scoped catalog invalidation to two paired clients', async () => {
     vi.mocked(listWorktrees).mockResolvedValue([initialWorktree])
     vi.mocked(listWorktreesStrict).mockResolvedValue([initialWorktree])
-    vi.mocked(listWorktreesStrict).mockResolvedValue([initialWorktree])
     const runtime = new OrcaRuntimeService(makeStore() as never)
     setWorktreeCatalogRemoteClientNotifier(runtime)
     const userDataPath = mkdtempSync(join(tmpdir(), 'o-ewd-'))
@@ -152,9 +151,6 @@ describe('external worktree discovery for paired clients', () => {
 
     vi.mocked(listWorktrees).mockResolvedValue([initialWorktree, externalWorktree])
     vi.mocked(listWorktreesStrict).mockResolvedValue([initialWorktree, externalWorktree])
-    expect(
-      (await listWorktreesStrict({ path: initialWorktreePath } as never)).map((w) => w.path)
-    ).toEqual([initialWorktreePath, externalWorktreePath])
 
     const sendToHostRenderer = vi.fn()
     const watch = {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -6742,6 +6742,16 @@ export class OrcaRuntimeService {
     this.emitClientEvent({ type: 'worktreesChanged', repoId })
   }
 
+  // Why: structural catalog changes require a fresh Git scan; renderer metadata edits do not.
+  notifyWorktreeCatalogChangedForRemoteClients(repoId: string): void {
+    this.invalidateWorktreeScanCacheForRepo(repoId)
+    const matchingRepos = this.store?.getRepos().filter((repo) => repo.id === repoId) ?? []
+    if (matchingRepos.length !== 1 || matchingRepos[0]?.connectionId) {
+      return
+    }
+    this.notifyWorktreesChangedForRemoteClients(repoId)
+  }
+
   // Why: host-local repo IPC mutations never enter runtime methods, so paired
   // clients need an explicit catalog invalidation; the local renderer already
   // got its own repos:changed and must not be re-notified (#11994).
@@ -32556,7 +32566,11 @@ export class OrcaRuntimeService {
     }
     const inFlight = this.worktreeScanInFlight.get(scanScopeKey)
     if (inFlight?.generation === generation && inFlight.runtimeKey === runtimeKey) {
-      return (await inFlight.promise).result
+      const refresh = await inFlight.promise
+      if (generation !== (this.worktreeScanGenerations.get(scanScopeKey) ?? 0)) {
+        return this.listRepoWorktreesForResolution(repo, projectRuntimeByRepoId)
+      }
+      return refresh.result
     }
     const reusableCached =
       cached?.generation === generation && cached.runtimeKey === runtimeKey ? cached : null
@@ -32564,10 +32578,13 @@ export class OrcaRuntimeService {
     this.worktreeScanInFlight.set(scanScopeKey, { generation, runtimeKey, promise })
     try {
       const refresh = await promise
+      // Why: fence the caller as well as cache writeback, or an event refresh can consume a stale scan.
+      if (generation !== (this.worktreeScanGenerations.get(scanScopeKey) ?? 0)) {
+        return this.listRepoWorktreesForResolution(repo, projectRuntimeByRepoId)
+      }
       // Why: back off local spawn failures under resource pressure while disconnected SSH can recover on the next poll.
       if (
         (refresh.result.ok || !repo.connectionId) &&
-        generation === (this.worktreeScanGenerations.get(scanScopeKey) ?? 0) &&
         this.worktreeScanInFlight.get(scanScopeKey)?.promise === promise
       ) {
         const entry: RuntimeWorktreeScanCache = {

--- a/src/main/window/attach-main-window-services.test.ts
+++ b/src/main/window/attach-main-window-services.test.ts
@@ -13,6 +13,7 @@ const {
   systemPreferencesGetMediaAccessStatusMock,
   registerRepoHandlersMock,
   setRepoRemoteClientNotifierMock,
+  setWorktreeCatalogRemoteClientNotifierMock,
   registerWorktreeHandlersMock,
   registerPtyHandlersMock,
   hydrateLocalPtyRegistryAtBootMock,
@@ -35,6 +36,7 @@ const {
   systemPreferencesGetMediaAccessStatusMock: vi.fn(),
   registerRepoHandlersMock: vi.fn(),
   setRepoRemoteClientNotifierMock: vi.fn(),
+  setWorktreeCatalogRemoteClientNotifierMock: vi.fn(),
   registerWorktreeHandlersMock: vi.fn(),
   registerPtyHandlersMock: vi.fn(),
   hydrateLocalPtyRegistryAtBootMock: vi.fn(),
@@ -73,6 +75,10 @@ vi.mock('../ipc/repos', () => ({
 
 vi.mock('../ipc/repos/repos-changed-notification', () => ({
   setRepoRemoteClientNotifier: setRepoRemoteClientNotifierMock
+}))
+
+vi.mock('../ipc/watched-worktree-catalog-notification', () => ({
+  setWorktreeCatalogRemoteClientNotifier: setWorktreeCatalogRemoteClientNotifierMock
 }))
 
 vi.mock('../ipc/worktrees', () => ({
@@ -227,6 +233,7 @@ describe('attachMainWindowServices', () => {
     systemPreferencesGetMediaAccessStatusMock.mockReset()
     registerRepoHandlersMock.mockReset()
     setRepoRemoteClientNotifierMock.mockReset()
+    setWorktreeCatalogRemoteClientNotifierMock.mockReset()
     registerWorktreeHandlersMock.mockReset()
     registerPtyHandlersMock.mockReset()
     hydrateLocalPtyRegistryAtBootMock.mockReset()
@@ -240,13 +247,13 @@ describe('attachMainWindowServices', () => {
     systemPreferencesGetMediaAccessStatusMock.mockReturnValue('granted')
   })
 
-  // #11994: without this wiring, host-local repo IPC mutations never reach paired clients.
-  it('gives the repo IPC handlers the runtime so repo changes reach paired clients', () => {
+  it('gives host-local catalog notifiers the runtime', () => {
     const runtime = createRuntime()
 
     attachMainWindowServices(createMainWindow() as never, createStore(), runtime as never)
 
     expect(setRepoRemoteClientNotifierMock).toHaveBeenCalledWith(runtime)
+    expect(setWorktreeCatalogRemoteClientNotifierMock).toHaveBeenCalledWith(runtime)
   })
 
   it('reloads the app renderer through main and marks expected renderer teardown', async () => {

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -16,6 +16,7 @@ import {
 } from '../macos-tcc-prompt-notice'
 import { registerRepoHandlers } from '../ipc/repos'
 import { setRepoRemoteClientNotifier } from '../ipc/repos/repos-changed-notification'
+import { setWorktreeCatalogRemoteClientNotifier } from '../ipc/watched-worktree-catalog-notification'
 import { registerWorktreeHandlers } from '../ipc/worktrees'
 import { registerWorkspaceCleanupHandlers } from '../ipc/workspace-cleanup'
 import {
@@ -112,6 +113,7 @@ export function attachMainWindowServices(
   registerRepoHandlers(mainWindow, store)
   // Why: repo IPC mutations must also invalidate paired clients' catalogs (#11994).
   setRepoRemoteClientNotifier(runtime)
+  setWorktreeCatalogRemoteClientNotifier(runtime)
   registerWorktreeHandlers(mainWindow, store, runtime, {
     onWorktreeLifecycle: options?.onWorktreeLifecycle
   })

--- a/tests/e2e/paired-external-worktree-discovery.spec.ts
+++ b/tests/e2e/paired-external-worktree-discovery.spec.ts
@@ -3,6 +3,7 @@ import path from 'node:path'
 import type { Page } from '@stablyai/playwright-test'
 import { gitExecFileAsync } from '../../src/main/git/runner'
 import { listWorktreesStrict } from '../../src/main/git/worktree'
+import { areWorktreePathsEqual } from '../../src/main/ipc/worktree-path-comparison'
 import { expect, test } from './helpers/orca-app'
 import {
   createRuntimeDesktopPairingOffer,
@@ -13,6 +14,9 @@ import { worktreeRow } from './worktree-row-locators'
 
 function equivalentTestPaths(value: string): string[] {
   const normalized = path.normalize(value)
+  if (process.platform === 'win32') {
+    return [normalized.replaceAll('\\', '/').toLowerCase()]
+  }
   if (process.platform !== 'darwin') {
     return [normalized]
   }
@@ -22,19 +26,22 @@ function equivalentTestPaths(value: string): string[] {
 }
 
 function pathsMatch(left: string, right: string): boolean {
-  return equivalentTestPaths(left).includes(path.normalize(right))
+  return equivalentTestPaths(left).some((candidate) => areWorktreePathsEqual(candidate, right))
 }
 
 function waitForCatalogWorktree(page: Page, repoId: string, worktreePath: string): Promise<string> {
   return page.evaluate(
-    ({ expectedPaths, expectedRepoId }) => {
+    ({ expectedPaths, expectedRepoId, windows }) => {
+      const comparablePath = (value: string): string =>
+        windows ? value.replaceAll('\\', '/').toLowerCase() : value
       const findId = (): string | undefined =>
         window.__store
           ?.getState()
           .allWorktrees()
           .find(
             (worktree) =>
-              worktree.repoId === expectedRepoId && expectedPaths.includes(worktree.path)
+              worktree.repoId === expectedRepoId &&
+              expectedPaths.includes(comparablePath(worktree.path))
           )?.id
       const existing = findId()
       if (existing) {
@@ -50,8 +57,32 @@ function waitForCatalogWorktree(page: Page, repoId: string, worktreePath: string
         })
       })
     },
-    { expectedPaths: equivalentTestPaths(worktreePath), expectedRepoId: repoId }
+    {
+      expectedPaths: equivalentTestPaths(worktreePath),
+      expectedRepoId: repoId,
+      windows: process.platform === 'win32'
+    }
   )
+}
+
+async function readRuntimeTransportContinuity(page: Page, environmentId: string) {
+  const remoteControl = await page.evaluate(async (selector) => {
+    const response = await window.api.runtimeEnvironments.getStatus({ selector })
+    if (!response.ok) {
+      throw new Error(response.error.message)
+    }
+    return response.result.remoteControl ?? null
+  }, environmentId)
+  if (!remoteControl || remoteControl.state !== 'ready' || remoteControl.lastConnectedAt === null) {
+    throw new Error('Paired client shared-control transport is not ready')
+  }
+  return {
+    state: remoteControl.state,
+    lastConnectedAt: remoteControl.lastConnectedAt,
+    lastClose: remoteControl.lastClose,
+    lastError: remoteControl.lastError,
+    reconnectAttempt: remoteControl.reconnectAttempt
+  }
 }
 
 test('shows an externally created worktree on a paired client without reconnect', async ({
@@ -89,17 +120,28 @@ test('shows an externally created worktree on a paired client without reconnect'
       'External worktree discovery'
     )
     await client.page.waitForFunction(
-      ({ expectedPaths, expectedRepoId }) =>
+      ({ expectedPaths, expectedRepoId, windows }) =>
         window.__store
           ?.getState()
           .allWorktrees()
           .some(
             (worktree) =>
-              worktree.repoId === expectedRepoId && expectedPaths.includes(worktree.path)
+              worktree.repoId === expectedRepoId &&
+              expectedPaths.includes(
+                windows ? worktree.path.replaceAll('\\', '/').toLowerCase() : worktree.path
+              )
           ) ?? false,
-      { expectedPaths: equivalentTestPaths(testRepoPath), expectedRepoId: repoId }
+      {
+        expectedPaths: equivalentTestPaths(testRepoPath),
+        expectedRepoId: repoId,
+        windows: process.platform === 'win32'
+      }
     )
 
+    const clientTransportBefore = await readRuntimeTransportContinuity(
+      client.page,
+      client.environmentId
+    )
     const hostCatalogUpdate = waitForCatalogWorktree(sharedPage, repoId, externalPath)
     const clientCatalogUpdate = waitForCatalogWorktree(client.page, repoId, externalPath)
     await gitExecFileAsync(['worktree', 'add', '--quiet', '-b', branch, externalPath], {
@@ -119,6 +161,9 @@ test('shows an externally created worktree on a paired client without reconnect'
     expect(clientWorktreeId).toBe(hostWorktreeId)
     await expect(worktreeRow(sharedPage, hostWorktreeId)).toBeVisible()
     await expect(worktreeRow(client.page, clientWorktreeId)).toBeVisible()
+    expect(await readRuntimeTransportContinuity(client.page, client.environmentId)).toEqual(
+      clientTransportBefore
+    )
   } finally {
     await client?.dispose()
   }

--- a/tests/e2e/paired-external-worktree-discovery.spec.ts
+++ b/tests/e2e/paired-external-worktree-discovery.spec.ts
@@ -1,0 +1,125 @@
+import { rmSync } from 'node:fs'
+import path from 'node:path'
+import type { Page } from '@stablyai/playwright-test'
+import { gitExecFileAsync } from '../../src/main/git/runner'
+import { listWorktreesStrict } from '../../src/main/git/worktree'
+import { expect, test } from './helpers/orca-app'
+import {
+  createRuntimeDesktopPairingOffer,
+  launchPairedElectronClient,
+  type PairedElectronClient
+} from './helpers/paired-electron-client'
+import { worktreeRow } from './worktree-row-locators'
+
+function equivalentTestPaths(value: string): string[] {
+  const normalized = path.normalize(value)
+  if (process.platform !== 'darwin') {
+    return [normalized]
+  }
+  return normalized.startsWith('/private/var/')
+    ? [normalized, normalized.slice('/private'.length)]
+    : [normalized, `/private${normalized}`]
+}
+
+function pathsMatch(left: string, right: string): boolean {
+  return equivalentTestPaths(left).includes(path.normalize(right))
+}
+
+function waitForCatalogWorktree(page: Page, repoId: string, worktreePath: string): Promise<string> {
+  return page.evaluate(
+    ({ expectedPaths, expectedRepoId }) => {
+      const findId = (): string | undefined =>
+        window.__store
+          ?.getState()
+          .allWorktrees()
+          .find(
+            (worktree) =>
+              worktree.repoId === expectedRepoId && expectedPaths.includes(worktree.path)
+          )?.id
+      const existing = findId()
+      if (existing) {
+        return existing
+      }
+      return new Promise<string>((resolve) => {
+        const unsubscribe = window.__store!.subscribe(() => {
+          const id = findId()
+          if (id) {
+            unsubscribe()
+            resolve(id)
+          }
+        })
+      })
+    },
+    { expectedPaths: equivalentTestPaths(worktreePath), expectedRepoId: repoId }
+  )
+}
+
+test('shows an externally created worktree on a paired client without reconnect', async ({
+  registerPostElectronShutdownCleanup,
+  sharedPage,
+  testRepoPath
+}, testInfo) => {
+  test.setTimeout(120_000)
+  const suffix = `${Date.now()}-${testInfo.workerIndex}`
+  const branch = `e2e-paired-external-${suffix}`
+  const externalPath = path.join(path.dirname(testRepoPath), branch)
+  let client: PairedElectronClient | undefined
+  let worktreeCreated = false
+  registerPostElectronShutdownCleanup(async () => {
+    if (worktreeCreated) {
+      await gitExecFileAsync(['worktree', 'remove', '--force', externalPath], {
+        cwd: testRepoPath
+      }).catch(() => undefined)
+      await gitExecFileAsync(['branch', '-D', branch], { cwd: testRepoPath }).catch(() => undefined)
+    }
+    rmSync(externalPath, { recursive: true, force: true })
+  })
+
+  try {
+    const repos = await sharedPage.evaluate(
+      () => window.__store?.getState().repos.map((repo) => ({ id: repo.id, path: repo.path })) ?? []
+    )
+    const repoId = repos.find((repo) => pathsMatch(repo.path, testRepoPath))?.id
+    if (!repoId) {
+      throw new Error(`Headed host did not catalog ${testRepoPath}`)
+    }
+    client = await launchPairedElectronClient(
+      await createRuntimeDesktopPairingOffer(sharedPage),
+      testInfo,
+      'External worktree discovery'
+    )
+    await client.page.waitForFunction(
+      ({ expectedPaths, expectedRepoId }) =>
+        window.__store
+          ?.getState()
+          .allWorktrees()
+          .some(
+            (worktree) =>
+              worktree.repoId === expectedRepoId && expectedPaths.includes(worktree.path)
+          ) ?? false,
+      { expectedPaths: equivalentTestPaths(testRepoPath), expectedRepoId: repoId }
+    )
+
+    const hostCatalogUpdate = waitForCatalogWorktree(sharedPage, repoId, externalPath)
+    const clientCatalogUpdate = waitForCatalogWorktree(client.page, repoId, externalPath)
+    await gitExecFileAsync(['worktree', 'add', '--quiet', '-b', branch, externalPath], {
+      cwd: testRepoPath
+    })
+    worktreeCreated = true
+
+    expect(
+      (await listWorktreesStrict(testRepoPath)).some((worktree) =>
+        pathsMatch(worktree.path, externalPath)
+      )
+    ).toBe(true)
+    const [hostWorktreeId, clientWorktreeId] = await Promise.all([
+      hostCatalogUpdate,
+      clientCatalogUpdate
+    ])
+    expect(clientWorktreeId).toBe(hostWorktreeId)
+    await expect(worktreeRow(sharedPage, hostWorktreeId)).toBeVisible()
+    await expect(worktreeRow(client.page, clientWorktreeId)).toBeVisible()
+  } finally {
+    await client?.dispose()
+  }
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​804 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​802 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​122 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​113 |

<!-- /orca-pr-loc -->

## ELI5

When a remote Orca host notices a worktree created outside Orca, its own window updates, but paired desktops can keep showing the old list. The host now sends the already-supported “worktrees changed” signal so connected desktops refresh too.

## What Changed

- Publish the existing `worktreesChanged` runtime event when the authoritative local watcher discovers an external structural worktree change.
- Invalidate raw/resolved worktree scan caches and generation-fence both scan owners and joined concurrent readers.
- Preserve the host renderer refresh when remote fanout fails, and fail closed for nested SSH or colliding local/SSH repo identities that the repo-only event cannot represent.
- Add deterministic paired-runtime and real Electron regression coverage.

## Why

Latest-main reproduction proved that the host inventory and host renderer advanced from one to two worktrees while two independently paired clients received no invalidation and remained cached at one. Publishing at the watcher/runtime authority boundary reuses the existing mixed-version-safe event semantics without adding polling, a new opcode, or a protocol bump.

## Linked Issue

Related to #16477. This intentionally does not auto-close the issue pending explicit confirmation.

## Visual Proof

N/A — this corrects cross-runtime catalog synchronization without changing layout or visual design. The headed Electron regression asserts that both host and paired-client rows become visible after a real `git worktree add`.

## Testing

Deterministic topology: one real `OrcaRuntimeRpcServer`, two independently authenticated E2EE clients, the authoritative watcher callback, host Git inventory advancing from 1→2, and an ordered event barrier with no sleep-based oracle.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

Validation:

- focused watcher/runtime/wiring suite: 38/38
- related watcher gate: 76/76
- runtime worktree scan-cache selection: 15/15
- runtime event consumers: 7/7
- `pnpm tc`
- `pnpm run check:code-quality:changed`
- `pnpm run check:reliability-gates`
- `git diff --check`
- paired Electron E2E, hidden and forced-visible, using real `git worktree add`, matching visible host/client identities, and an unchanged main-process shared-control connection epoch without reconnect
- CI: typecheck, static analysis, Node 24/26 test shards, Git compatibility, cross-version wire compatibility, Electron changed-spec E2E, macOS packaging, and Windows packaging

The repository-wide `pnpm run typecheck:e2e` currently reports numerous unrelated existing spec errors; the new spec builds and passes through Playwright.

## AI Disclosure

<!-- Internal StablyAI contributor; section intentionally left blank per template. -->

## Review

Internal review-until-clean and a fresh adversarial review completed before opening. Three independent OpenCode reviewers completed authority/wire, cache/concurrency, and product-boundary audits. Authority/wire and cache/concurrency returned CLEAN. Product-boundary review found two legitimate oracle gaps (transport continuity and Windows path comparison) plus duplicate test setup; those were fixed, the main-process continuity oracle passed in headed and hidden Electron, and all three returned clean/no remaining findings. A theoretical continuous-invalidation starvation concern was rejected because a capped retry would return a stale catalog and continuous mutation has no stable snapshot.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No new opcode, field, polling loop, capability, or protocol bump. Event-aware clients refresh; event-ignoring clients safely recover on explicit read/reconnect. New clients paired to old hosts retain the original limitation. Nested SSH watcher discoveries and same-ID local/SSH collisions remain host-local until owner identity can be represented safely.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Visual proof is N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and compatibility impact considered
- [x] Local focused checks pass; full CI is green


