### PR TITLE
fix(explorer): reveal local worktrees even when a remote runtime is active

### DIFF
--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -3,6 +3,7 @@ import { useAppStore } from '@/store'
 import { useActiveWorktree, useRepoById } from '@/store/selectors'
 import { basename } from '@/lib/path'
 import { cn } from '@/lib/utils'
+import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { isGitRepoKind } from '../../../../shared/repo-kind'
 import { getVisibleFileExplorerWorktreePath } from './file-explorer-reset'
 import { FileExplorerBackgroundMenu } from './FileExplorerBackgroundMenu'
@@ -36,6 +37,9 @@ function FileExplorerFiles(): React.JSX.Element {
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
   const activeWorktree = useActiveWorktree()
   const activeRepo = useRepoById(activeWorktree?.repoId ?? null)
+  const runtimeEnvironmentId = useAppStore((s) =>
+    getExplicitRuntimeEnvironmentIdForWorktree(s, s.activeWorktreeId)
+  )
   const expandedDirs = useAppStore((s) => s.expandedDirs)
   const collapseAllDirs = useAppStore((s) => s.collapseAllDirs)
   const activeFileId = useAppStore((s) => s.activeFileId)
@@ -209,6 +213,7 @@ function FileExplorerFiles(): React.JSX.Element {
           repoName={repoName}
           worktreePath={worktreePath}
           connectionId={activeRepo?.connectionId ?? null}
+          runtimeEnvironmentId={runtimeEnvironmentId}
           refresh={manualRefresh}
           canRefresh={isFilesViewActive}
           canCollapseAll={canCollapseAll}

--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.actions.test.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.actions.test.tsx
@@ -94,6 +94,36 @@ describe('FileExplorerRow reveal in file manager', () => {
       )
     ).toBe(true)
   })
+
+  it('blocks a detected SSH worktree that is absent from worktreesByRepo', () => {
+    expect(
+      isFileExplorerRevealBlocked(
+        {
+          settings: { activeRuntimeEnvironmentId: null },
+          repos: [{ id: 'ssh-repo', connectionId: 'ssh-1', executionHostId: 'ssh:ssh-1' }],
+          worktreesByRepo: {},
+          folderWorkspaces: [],
+          projectGroups: []
+        },
+        'ssh-repo::/home/neil/repo-feature'
+      )
+    ).toBe(true)
+  })
+
+  it('blocks reveal when the worktree owner cannot be resolved', () => {
+    expect(
+      isFileExplorerRevealBlocked(
+        {
+          settings: { activeRuntimeEnvironmentId: null },
+          repos: [],
+          worktreesByRepo: {},
+          folderWorkspaces: [],
+          projectGroups: []
+        },
+        'missing-repo::/home/neil/repo-feature'
+      )
+    ).toBe(true)
+  })
 })
 
 describe('FileExplorerRow collapse folder action', () => {

--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.actions.test.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.actions.test.tsx
@@ -9,6 +9,7 @@ import {
   shouldShowViewFileAction
 } from './file-explorer-row-action-visibility'
 import { directoryNode, fileNode } from './file-explorer-tree-node-test-fixtures'
+import { isFileExplorerRevealBlocked } from './file-explorer-row-reveal'
 import type * as RuntimeFileClient from '@/runtime/runtime-file-client'
 
 const { downloadRuntimeFileMock, toastErrorMock, toastSuccessMock } = vi.hoisted(() => ({
@@ -44,6 +45,55 @@ beforeEach(() => {
   toastErrorMock.mockReset()
   toastSuccessMock.mockReset()
   delete (globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__
+})
+
+describe('FileExplorerRow reveal in file manager', () => {
+  it('does not block a local worktree while a remote runtime is globally active', () => {
+    expect(
+      isFileExplorerRevealBlocked(
+        {
+          settings: { activeRuntimeEnvironmentId: 'env-1' },
+          repos: [{ id: 'local-repo', connectionId: null, executionHostId: 'local' }],
+          worktreesByRepo: {
+            'local-repo': [{ id: 'local-repo::wt-a', repoId: 'local-repo', hostId: 'local' }]
+          }
+        },
+        'local-repo::wt-a'
+      )
+    ).toBe(false)
+  })
+
+  it('blocks a remote-owned worktree even when the global runtime is local', () => {
+    expect(
+      isFileExplorerRevealBlocked(
+        {
+          settings: { activeRuntimeEnvironmentId: null },
+          repos: [{ id: 'runtime-repo', connectionId: null, executionHostId: 'runtime:env-1' }],
+          worktreesByRepo: {
+            'runtime-repo': [
+              { id: 'runtime-repo::wt-b', repoId: 'runtime-repo', hostId: 'runtime:env-1' }
+            ]
+          }
+        },
+        'runtime-repo::wt-b'
+      )
+    ).toBe(true)
+  })
+
+  it('blocks SSH-backed worktrees', () => {
+    expect(
+      isFileExplorerRevealBlocked(
+        {
+          settings: { activeRuntimeEnvironmentId: 'env-1' },
+          repos: [{ id: 'ssh-repo', connectionId: 'ssh-1', executionHostId: 'ssh:ssh-1' }],
+          worktreesByRepo: {
+            'ssh-repo': [{ id: 'ssh-repo::wt', repoId: 'ssh-repo', hostId: 'ssh:ssh-1' }]
+          }
+        },
+        'ssh-repo::wt'
+      )
+    ).toBe(true)
+  })
 })
 
 describe('FileExplorerRow collapse folder action', () => {

--- a/src/renderer/src/components/right-sidebar/FileExplorerToolbar.test.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerToolbar.test.tsx
@@ -302,7 +302,16 @@ describe('FileExplorerToolbar', () => {
     const openInItems = findOpenInMenuItems(element)
     expect(openInItems.props.worktreePath).toBe('/tmp/orca')
     expect(openInItems.props.connectionId).toBe('ssh-1')
+    expect(openInItems.props.runtimeEnvironmentId).toBeUndefined()
     expect(openInItems.props.labelPrefix).toBe('Open in ')
+  })
+
+  it('forwards the worktree runtime owner to open-in launchers', () => {
+    const element = makeToolbar({ connectionId: null, runtimeEnvironmentId: null })
+
+    const openInItems = findOpenInMenuItems(element)
+    expect(openInItems.props.connectionId).toBeNull()
+    expect(openInItems.props.runtimeEnvironmentId).toBeNull()
   })
 
   it('keeps the overflow menu as the last toolbar button', () => {

--- a/src/renderer/src/components/right-sidebar/FileExplorerToolbar.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerToolbar.tsx
@@ -17,6 +17,7 @@ type FileExplorerToolbarProps = {
   repoName: string
   worktreePath: string
   connectionId?: string | null
+  runtimeEnvironmentId?: string | null
   refresh: {
     isRefreshing: boolean
     showRefreshSpinner: boolean
@@ -36,6 +37,7 @@ export function FileExplorerToolbar({
   repoName,
   worktreePath,
   connectionId,
+  runtimeEnvironmentId,
   refresh,
   canRefresh,
   canCollapseAll,
@@ -173,6 +175,7 @@ export function FileExplorerToolbar({
           <WorktreeOpenInMenuItems
             worktreePath={worktreePath}
             connectionId={connectionId}
+            runtimeEnvironmentId={runtimeEnvironmentId}
             labelPrefix="Open in "
           />
         </DropdownMenuContent>

--- a/src/renderer/src/components/right-sidebar/file-explorer-row-context-menu.tsx
+++ b/src/renderer/src/components/right-sidebar/file-explorer-row-context-menu.tsx
@@ -26,7 +26,8 @@ import { useAppStore } from '@/store'
 import { useShortcutLabel } from '@/hooks/useShortcutLabel'
 import { detectLanguage } from '@/lib/language-detect'
 import { openFileInBrowserTab } from '@/lib/file-preview'
-import { isLocalPathOpenBlocked, showLocalPathOpenBlockedToast } from '@/lib/local-path-open-guard'
+import { showLocalPathOpenBlockedToast } from '@/lib/local-path-open-guard'
+import { isFileExplorerRevealBlocked } from './file-explorer-row-reveal'
 import { translate } from '@/i18n/i18n'
 import type { FileExplorerRowProps } from './FileExplorerRow'
 import {
@@ -272,17 +273,7 @@ export function FileExplorerRowContextMenu({
       <ContextMenuItem
         onSelect={() => {
           const state = useAppStore.getState()
-          const activeWorktree = Object.values(state.worktreesByRepo)
-            .flat()
-            .find((worktree) => worktree.id === activeWorktreeId)
-          const activeRepo = activeWorktree
-            ? state.repos.find((repo) => repo.id === activeWorktree.repoId)
-            : null
-          if (
-            isLocalPathOpenBlocked(state.settings, {
-              connectionId: activeRepo?.connectionId ?? null
-            })
-          ) {
+          if (isFileExplorerRevealBlocked(state, activeWorktreeId)) {
             showLocalPathOpenBlockedToast()
             return
           }

--- a/src/renderer/src/components/right-sidebar/file-explorer-row-reveal.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-row-reveal.ts
@@ -1,0 +1,22 @@
+import { isLocalPathOpenBlockedForRuntimeOwner } from '@/lib/local-path-open-guard'
+import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+
+export function isFileExplorerRevealBlocked(
+  state: Parameters<typeof getExplicitRuntimeEnvironmentIdForWorktree>[0] & {
+    repos?: readonly { id: string; connectionId?: string | null }[]
+    worktreesByRepo?: Record<string, readonly { id: string; repoId: string }[]>
+  },
+  worktreeId: string | null | undefined
+): boolean {
+  const activeWorktree = Object.values(state.worktreesByRepo ?? {})
+    .flat()
+    .find((worktree) => worktree.id === worktreeId)
+  const activeRepo = activeWorktree
+    ? state.repos?.find((repo) => repo.id === activeWorktree.repoId)
+    : null
+  return isLocalPathOpenBlockedForRuntimeOwner(
+    state.settings,
+    getExplicitRuntimeEnvironmentIdForWorktree(state, worktreeId),
+    { connectionId: activeRepo?.connectionId ?? null }
+  )
+}

--- a/src/renderer/src/components/right-sidebar/file-explorer-row-reveal.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-row-reveal.ts
@@ -1,22 +1,27 @@
+import { getConnectionIdFromState } from '@/lib/connection-context'
 import { isLocalPathOpenBlockedForRuntimeOwner } from '@/lib/local-path-open-guard'
 import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 
 export function isFileExplorerRevealBlocked(
-  state: Parameters<typeof getExplicitRuntimeEnvironmentIdForWorktree>[0] & {
-    repos?: readonly { id: string; connectionId?: string | null }[]
-    worktreesByRepo?: Record<string, readonly { id: string; repoId: string }[]>
-  },
+  state: Parameters<typeof getExplicitRuntimeEnvironmentIdForWorktree>[0],
   worktreeId: string | null | undefined
 ): boolean {
-  const activeWorktree = Object.values(state.worktreesByRepo ?? {})
-    .flat()
-    .find((worktree) => worktree.id === worktreeId)
-  const activeRepo = activeWorktree
-    ? state.repos?.find((repo) => repo.id === activeWorktree.repoId)
-    : null
+  const connectionId = getConnectionIdFromState(
+    {
+      folderWorkspaces: state.folderWorkspaces ?? [],
+      projectGroups: state.projectGroups ?? [],
+      repos: state.repos ?? [],
+      worktreesByRepo: state.worktreesByRepo ?? {}
+    },
+    worktreeId ?? null
+  )
+  // Why: an unresolved SSH worktree must not fall through to local openPath.
+  if (connectionId === undefined) {
+    return true
+  }
   return isLocalPathOpenBlockedForRuntimeOwner(
     state.settings,
     getExplicitRuntimeEnvironmentIdForWorktree(state, worktreeId),
-    { connectionId: activeRepo?.connectionId ?? null }
+    { connectionId }
   )
 }

--- a/src/renderer/src/components/right-sidebar/source-control-entry-context-menu.test.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control-entry-context-menu.test.tsx
@@ -46,6 +46,7 @@ vi.mock('@/lib/open-in-app-catalog', () => ({
 
 vi.mock('@/components/sidebar/WorktreeOpenInMenu', () => ({
   getWorktreeOpenInEntries: () => [],
+  getOpenInEntryAvailability: () => ({ disabled: false }),
   openOpenInAppsSettings: vi.fn(),
   openWorktreePath: vi.fn()
 }))

--- a/src/renderer/src/components/right-sidebar/source-control/listing/entry-context-menu.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/listing/entry-context-menu.tsx
@@ -11,6 +11,7 @@ import {
   ContextMenuTrigger
 } from '@/components/ui/context-menu'
 import { useAppStore } from '@/store'
+import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { OpenInApplicationIcon } from '@/lib/open-in-app-catalog'
 import { translate } from '@/i18n/i18n'
 import { getLocalFileManagerLabel } from '@/lib/local-file-manager-label'
@@ -47,6 +48,9 @@ export function SourceControlEntryContextMenu({
     (s) => s.settings?.openInApplications ?? NO_OPEN_IN_APPLICATIONS
   )
   const settings = useAppStore((s) => s.settings)
+  const runtimeEnvironmentId = useAppStore((s) =>
+    getExplicitRuntimeEnvironmentIdForWorktree(s, currentWorktreeId)
+  )
   const fileManagerLabel = getLocalFileManagerLabel()
   const openInEntries = React.useMemo(
     () => getWorktreeOpenInEntries(openInApplications, fileManagerLabel),
@@ -83,10 +87,11 @@ export function SourceControlEntryContextMenu({
         target,
         worktreePath: absolutePath,
         connectionId,
+        runtimeEnvironmentId,
         command
       })
     },
-    [absolutePath, connectionId]
+    [absolutePath, connectionId, runtimeEnvironmentId]
   )
 
   return (
@@ -120,7 +125,12 @@ export function SourceControlEntryContextMenu({
           </ContextMenuSubTrigger>
           <ContextMenuSubContent className="w-52">
             {openInEntries.map((entry) => {
-              const availability = getOpenInEntryAvailability(entry, settings, connectionId)
+              const availability = getOpenInEntryAvailability(
+                entry,
+                settings,
+                connectionId,
+                runtimeEnvironmentId
+              )
               return (
                 <ContextMenuItem
                   key={entry.id}

--- a/src/renderer/src/components/sidebar/WorktreeContextMenuView.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenuView.tsx
@@ -27,6 +27,8 @@ import {
   FolderTree
 } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { useAppStore } from '@/store'
+import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { WorktreeOpenInSubMenu } from './WorktreeOpenInMenu'
 import { WorktreeDeveloperMenu } from './WorktreeDeveloperMenu'
 import { WorkspaceSleepMenuItems } from './WorkspaceSleepMenuItems'
@@ -100,6 +102,9 @@ export default function WorktreeContextMenuView({ model }: { model: WorktreeCont
     worktree,
     workspaceStatuses
   } = model
+  const runtimeEnvironmentId = useAppStore((s) =>
+    getExplicitRuntimeEnvironmentIdForWorktree(s, worktree.id)
+  )
   const deleteShortcut = useOptionalShortcutLabel('workspace.delete')
   return (
     <div
@@ -175,6 +180,7 @@ export default function WorktreeContextMenuView({ model }: { model: WorktreeCont
               <WorktreeOpenInSubMenu
                 worktreePath={worktree.path}
                 connectionId={repo?.connectionId ?? null}
+                runtimeEnvironmentId={runtimeEnvironmentId}
                 disabled={isDeleting}
               />
               <DropdownMenuItem onSelect={handleCopyPath} disabled={isDeleting}>

--- a/src/renderer/src/components/sidebar/WorktreeOpenInMenu.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeOpenInMenu.test.tsx
@@ -137,13 +137,29 @@ describe('WorktreeOpenInMenu', () => {
     expect(stopPropagation).toHaveBeenCalled()
   })
 
-  it('uses the blocked-path toast without calling main IPC', async () => {
+  it('opens a local worktree in the file manager even while a remote runtime is globally active', async () => {
     mockState.settings = { activeRuntimeEnvironmentId: 'runtime-1', openInApplications: [] }
 
     await openWorktreePath({
       target: 'file-manager',
       worktreePath: '/tmp/workspace',
-      connectionId: null
+      connectionId: null,
+      runtimeEnvironmentId: null
+    })
+
+    expect(toastErrorMock).not.toHaveBeenCalled()
+    expect(openInFileManagerMock).toHaveBeenCalledWith('/tmp/workspace')
+    expect(openInExternalEditorMock).not.toHaveBeenCalled()
+  })
+
+  it('blocks file-manager open for a remote-owned worktree', async () => {
+    mockState.settings = { activeRuntimeEnvironmentId: null, openInApplications: [] }
+
+    await openWorktreePath({
+      target: 'file-manager',
+      worktreePath: '/tmp/workspace',
+      connectionId: null,
+      runtimeEnvironmentId: 'runtime-1'
     })
 
     expect(toastErrorMock).toHaveBeenCalledWith(
@@ -151,6 +167,22 @@ describe('WorktreeOpenInMenu', () => {
     )
     expect(openInFileManagerMock).not.toHaveBeenCalled()
     expect(openInExternalEditorMock).not.toHaveBeenCalled()
+  })
+
+  it('blocks file-manager open for SSH-backed worktrees', async () => {
+    mockState.settings = { activeRuntimeEnvironmentId: 'runtime-1', openInApplications: [] }
+
+    await openWorktreePath({
+      target: 'file-manager',
+      worktreePath: '/home/ada/project',
+      connectionId: 'ssh-1',
+      runtimeEnvironmentId: null
+    })
+
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      'Opening remote paths in the local OS is not available.'
+    )
+    expect(openInFileManagerMock).not.toHaveBeenCalled()
   })
 
   it('shows an actionable toast when the host launcher fails', async () => {
@@ -252,6 +284,15 @@ describe('WorktreeOpenInMenu', () => {
     expect(getOpenInEntryAvailability(entries[3], mockState.settings, 'ssh-1')).toEqual({
       disabled: true,
       metadata: 'Local only'
+    })
+  })
+
+  it('keeps the file manager available for a local worktree while a remote runtime is globally active', () => {
+    mockState.settings = { activeRuntimeEnvironmentId: 'runtime-1', openInApplications: [] }
+    const entries = getWorktreeOpenInEntries([], 'Finder')
+
+    expect(getOpenInEntryAvailability(entries[0], mockState.settings, null, null)).toEqual({
+      disabled: false
     })
   })
 

--- a/src/renderer/src/components/sidebar/WorktreeOpenInMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeOpenInMenu.tsx
@@ -9,7 +9,10 @@ import {
   DropdownMenuSubTrigger
 } from '@/components/ui/dropdown-menu'
 import { useAppStore } from '@/store'
-import { isLocalPathOpenBlocked, showLocalPathOpenBlockedToast } from '@/lib/local-path-open-guard'
+import {
+  isLocalPathOpenBlockedForRuntimeOwner,
+  showLocalPathOpenBlockedToast
+} from '@/lib/local-path-open-guard'
 import { getLocalFileManagerLabel } from '@/lib/local-file-manager-label'
 import { OpenInApplicationIcon } from '@/lib/open-in-app-catalog'
 import { getExternalEditorOpenCapability } from '@/lib/external-editor-open-capability'
@@ -24,6 +27,7 @@ export { getLocalFileManagerLabel } from '@/lib/local-file-manager-label'
 type WorktreeOpenInMenuItemsProps = {
   worktreePath: string
   connectionId?: string | null
+  runtimeEnvironmentId?: string | null
   disabled?: boolean
   labelPrefix?: string
 }
@@ -53,10 +57,13 @@ export function getWorktreeOpenInEntries(
 export function getOpenInEntryAvailability(
   entry: OpenInMenuEntry,
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
-  connectionId?: string | null
+  connectionId?: string | null,
+  runtimeEnvironmentId?: string | null
 ): { disabled: boolean; metadata?: string } {
   if (entry.target === 'file-manager') {
-    const disabled = isLocalPathOpenBlocked(settings, { connectionId })
+    const disabled = isLocalPathOpenBlockedForRuntimeOwner(settings, runtimeEnvironmentId ?? null, {
+      connectionId
+    })
     return disabled
       ? {
           disabled: true,
@@ -246,11 +253,16 @@ export async function openWorktreePath(args: {
   target: 'file-manager' | 'external-editor'
   worktreePath: string
   connectionId?: string | null
+  runtimeEnvironmentId?: string | null
   command?: string
 }): Promise<void> {
   const settings = useAppStore.getState().settings
   if (args.target === 'file-manager') {
-    if (isLocalPathOpenBlocked(settings, { connectionId: args.connectionId ?? null })) {
+    if (
+      isLocalPathOpenBlockedForRuntimeOwner(settings, args.runtimeEnvironmentId ?? null, {
+        connectionId: args.connectionId ?? null
+      })
+    ) {
       showLocalPathOpenBlockedToast()
       return
     }
@@ -284,26 +296,38 @@ export async function openWorktreePath(args: {
 
 function useOpenInWorktreePath({
   worktreePath,
-  connectionId
+  connectionId,
+  runtimeEnvironmentId
 }: WorktreeOpenInMenuItemsProps): (
   target: 'file-manager' | 'external-editor',
   command?: string
 ) => Promise<void> {
   return useCallback(
     async (target, command) => {
-      await openWorktreePath({ target, worktreePath, connectionId, command })
+      await openWorktreePath({
+        target,
+        worktreePath,
+        connectionId,
+        runtimeEnvironmentId,
+        command
+      })
     },
-    [connectionId, worktreePath]
+    [connectionId, runtimeEnvironmentId, worktreePath]
   )
 }
 
 export function WorktreeOpenInMenuItems({
   worktreePath,
   connectionId,
+  runtimeEnvironmentId,
   disabled,
   labelPrefix = ''
 }: WorktreeOpenInMenuItemsProps): React.JSX.Element {
-  const openInWorktreePath = useOpenInWorktreePath({ worktreePath, connectionId })
+  const openInWorktreePath = useOpenInWorktreePath({
+    worktreePath,
+    connectionId,
+    runtimeEnvironmentId
+  })
   const openInApplications = useAppStore(
     (s) => s.settings?.openInApplications ?? NO_OPEN_IN_APPLICATIONS
   )
@@ -314,7 +338,12 @@ export function WorktreeOpenInMenuItems({
   return (
     <>
       {entries.map((entry) => {
-        const availability = getOpenInEntryAvailability(entry, settings, connectionId)
+        const availability = getOpenInEntryAvailability(
+          entry,
+          settings,
+          connectionId,
+          runtimeEnvironmentId
+        )
         return (
           <DropdownMenuItem
             key={entry.id}
@@ -350,6 +379,7 @@ export function WorktreeOpenInMenuItems({
 export function WorktreeOpenInSubMenu({
   worktreePath,
   connectionId,
+  runtimeEnvironmentId,
   disabled
 }: WorktreeOpenInMenuItemsProps): React.JSX.Element {
   return (
@@ -366,6 +396,7 @@ export function WorktreeOpenInSubMenu({
         <WorktreeOpenInMenuItems
           worktreePath={worktreePath}
           connectionId={connectionId}
+          runtimeEnvironmentId={runtimeEnvironmentId}
           disabled={disabled}
         />
         <DropdownMenuSeparator />

--- a/src/renderer/src/lib/local-path-open-guard.test.ts
+++ b/src/renderer/src/lib/local-path-open-guard.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { isLocalPathOpenBlocked } from './local-path-open-guard'
+import {
+  isLocalPathOpenBlocked,
+  isLocalPathOpenBlockedForRuntimeOwner
+} from './local-path-open-guard'
 
 describe('isLocalPathOpenBlocked', () => {
   it('allows local paths without a runtime or SSH connection', () => {
@@ -13,6 +16,32 @@ describe('isLocalPathOpenBlocked', () => {
   it('blocks SSH-backed paths', () => {
     expect(
       isLocalPathOpenBlocked({ activeRuntimeEnvironmentId: null }, { connectionId: 'ssh-1' })
+    ).toBe(true)
+  })
+})
+
+describe('isLocalPathOpenBlockedForRuntimeOwner', () => {
+  it('does not block a local worktree while a remote runtime is globally active', () => {
+    expect(
+      isLocalPathOpenBlockedForRuntimeOwner({ activeRuntimeEnvironmentId: 'env-1' }, null, {
+        connectionId: null
+      })
+    ).toBe(false)
+  })
+
+  it('blocks a remote-owned worktree even when the global runtime is local', () => {
+    expect(
+      isLocalPathOpenBlockedForRuntimeOwner({ activeRuntimeEnvironmentId: null }, 'env-1', {
+        connectionId: null
+      })
+    ).toBe(true)
+  })
+
+  it('blocks SSH-backed paths even when the worktree runtime owner is local', () => {
+    expect(
+      isLocalPathOpenBlockedForRuntimeOwner({ activeRuntimeEnvironmentId: 'env-1' }, null, {
+        connectionId: 'ssh-1'
+      })
     ).toBe(true)
   })
 })

--- a/src/renderer/src/lib/local-path-open-guard.ts
+++ b/src/renderer/src/lib/local-path-open-guard.ts
@@ -1,12 +1,21 @@
 import { toast } from 'sonner'
 import type { GlobalSettings } from '../../../shared/global-settings-types'
 import { translate } from '@/i18n/i18n'
+import { settingsForRuntimeOwner } from '@/runtime/runtime-rpc-client'
 
 export function isLocalPathOpenBlocked(
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
   context?: { connectionId?: string | null }
 ): boolean {
   return Boolean(settings?.activeRuntimeEnvironmentId?.trim() || context?.connectionId?.trim())
+}
+
+export function isLocalPathOpenBlockedForRuntimeOwner(
+  settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
+  runtimeEnvironmentId: string | null | undefined,
+  context?: { connectionId?: string | null }
+): boolean {
+  return isLocalPathOpenBlocked(settingsForRuntimeOwner(settings, runtimeEnvironmentId), context)
 }
 
 export function showLocalPathOpenBlockedToast(): void {


### PR DESCRIPTION
## Description
Reveal in Finder / Open in file manager was treating local worktrees as remote after a paired host had been used, because the guard read the globally focused runtime instead of the target worktree host.
File Explorer, worktree Open in, and the source-control reveal path now scope that check to the worktree's own runtime owner and `connectionId`.

## Focused fix
- In scope: local OS reveal/open uses the **target worktree host**, not `settings.activeRuntimeEnvironmentId`.
- Out of scope: remote-path browsing, pairing, iCloud dataless files, dead worktree cleanup.

## Preserves
- SSH and runtime-owned paths still cannot open in the local OS.
- Editor tab local-open already used `settingsForRuntimeOwner`; this matches that contract.

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/local-path-open-guard.test.ts src/renderer/src/components/sidebar/WorktreeOpenInMenu.test.tsx src/renderer/src/components/right-sidebar/FileExplorerRow.actions.test.tsx src/renderer/src/components/right-sidebar/FileExplorerToolbar.test.tsx src/renderer/src/components/right-sidebar/source-control-entry-context-menu.test.tsx`
- Result: **54 passed**
- Regression: global `activeRuntimeEnvironmentId` set + local worktree + no `connectionId` is **not** blocked.

## User-regression-tradeoffs
None for local worktrees. Remote/SSH reveal remains blocked.

Fixes #16539
