### PR TITLE
fix(runtime): retire timed-out provider snapshot acquisitions

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -19066,6 +19066,42 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('retires a timed-out visible provider snapshot instead of rejoining it', async () => {
+    vi.useFakeTimers()
+    try {
+      const serializeProviderBuffer = vi.fn(() => new Promise<never>(() => undefined))
+      const runtime = new OrcaRuntimeService(store)
+      runtime.setPtyController({
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess: async () => null,
+        serializeProviderBuffer,
+        hasRendererSerializer: () => false
+      })
+      syncSinglePty(runtime)
+      runtime.onPtyData('pty-1', 'shell history\r\n', 100)
+      runtime.synchronizePtyOutputSequenceFromProvider(
+        'pty-1',
+        { value: 900, generation: 'continued' },
+        0
+      )
+      const [terminal] = (await runtime.listTerminals()).terminals
+
+      const firstRead = runtime.readTerminal(terminal.handle)
+      await vi.advanceTimersByTimeAsync(750)
+      await expect(firstRead).resolves.toMatchObject({ tail: ['shell history'] })
+      expect(serializeProviderBuffer).toHaveBeenCalledOnce()
+
+      await vi.advanceTimersByTimeAsync(1_000)
+      await expect(runtime.readTerminal(terminal.handle)).resolves.toMatchObject({
+        tail: ['shell history']
+      })
+      expect(serializeProviderBuffer).toHaveBeenCalledOnce()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('discards a provider frame when the PTY generation resets during capture', async () => {
     type Snapshot = {
       data: string

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -13785,7 +13785,7 @@ export class OrcaRuntimeService {
     const snapshot = await this.serializeProviderTerminalBuffer(
       ptyId,
       { scrollbackRows: 0 },
-      { timeoutMs: VISIBLE_TERMINAL_SNAPSHOT_TIMEOUT_MS }
+      { timeoutMs: VISIBLE_TERMINAL_SNAPSHOT_TIMEOUT_MS, retireOnTimeout: true }
     )
     if (!snapshot || this.getPtyLifecycleGeneration(ptyId) !== generation) {
       this.providerVisibleRetryAtByPtyId.set(ptyId, Date.now() + VISIBLE_TERMINAL_SNAPSHOT_RETRY_MS)


### PR DESCRIPTION
## Description
Visible terminal snapshot reads timed out without retiring the in-flight provider buffer acquisition, so the next read rejoined the same hung promise.
`readVisibleTerminalState` now passes `retireOnTimeout: true` with the existing 750ms bound.

## Focused fix
- In scope: retire the timed-out provider snapshot acquisition used by `readVisibleTerminalState`.
- Out of scope: spawn/listProcesses, snapshot parsing, provider mode tracking.

## Preserves
- Timeout still returns null; healthy in-flight captures still share one acquisition.
- The existing `finally()` identity-delete is unchanged.

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts`
- Result: **1207 passed**, 1 skipped
- New case `retires a timed-out visible provider snapshot instead of rejoining it` fails without the one-line change.

## User-regression-tradeoffs
None. A hung provider read already timed out; it can now retry instead of sticking to the dead promise.

Fixes #16531
