### PR TITLE
fix(sidebar): hide bare repository backing stores from workspace list

### DIFF
--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -837,6 +837,43 @@ describe('computeVisibleWorktreeIds', () => {
     expect(result).toEqual([child.id])
   })
 
+  it('hides a bare repository backing store while keeping the linked checkout', () => {
+    const bare = { ...makeWorktree('bare'), isBare: true, isMainWorktree: true, branch: '' }
+    const linked = makeWorktree('linked')
+    expect(
+      computeVisibleWorktreeIds({ repo1: [bare, linked] }, [bare.id, linked.id], visibleOptions())
+    ).toEqual([linked.id])
+  })
+
+  it('does not resurrect a bare lineage parent as a sidebar card', () => {
+    const parent = {
+      ...makeWorktree('bare-parent'),
+      isBare: true,
+      isMainWorktree: true,
+      branch: ''
+    }
+    const child = makeWorktree('child')
+    const result = computeVisibleWorktreeIds(
+      { repo1: [parent, child] },
+      [child.id, parent.id],
+      visibleOptions({
+        showSleepingWorkspaces: false,
+        tabsByWorktree: { [child.id]: [makeTab('t-child', child.id, 'p-child')] },
+        ptyIdsByTabId: { 't-child': ['p-child'] },
+        worktreeLineageById: { [child.id]: makeWorktreeLineage(child, parent) }
+      })
+    )
+    expect(result).toEqual([child.id])
+  })
+
+  it('keeps a non-bare main worktree visible as a primary checkout', () => {
+    const main = { ...makeWorktree('main'), isMainWorktree: true }
+    const linked = makeWorktree('linked')
+    expect(
+      computeVisibleWorktreeIds({ repo1: [main, linked] }, [main.id, linked.id], visibleOptions())
+    ).toEqual([main.id, linked.id])
+  })
+
   it('includes default-branch parents hidden by the explicit setting when a visible child needs them', () => {
     const parent = makeWorktree('parent')
     parent.isMainWorktree = true

--- a/src/renderer/src/components/sidebar/visible-worktrees.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.ts
@@ -94,8 +94,12 @@ export function computeVisibleWorktrees(
   // Filter archived
   all = all.filter((w) => !w.isArchived)
 
-  // Why: sidebar lineage is structural. Archived workspaces stay hidden, but
-  // every other valid ancestor can bypass filters so children never orphan.
+  // Bare GIT_COMMON_DIR is storage, not a checkout (#16553).
+  all = all.filter((w) => !w.isBare)
+
+  // Why: sidebar lineage is structural. Archived and bare workspaces stay
+  // hidden, but every other valid ancestor can bypass filters so children
+  // never orphan.
   const lineageAncestorById = new Map(all.map((w) => [w.id, w]))
 
   if (opts.hideWorkspacesFromOtherDevices) {


### PR DESCRIPTION
## Description
Bare `GIT_COMMON_DIR` backing stores were rendered as primary sidebar workspaces because `git worktree list` reports them as the main worktree.
The sidebar visibility pipeline now excludes `isBare` rows and does not resurrect them as lineage ancestors.

## Focused fix
- In scope: hide bare repository backing stores from the Projects sidebar workspace list.
- Out of scope: Git command parsing, worktree create/remove, assigning a different primary among linked checkouts.

## Preserves
- Non-bare main checkouts still appear as workspaces (including primary).
- The bare repo remains the project's Git store internally; this is UI filter only (Git 2.25 compatible).

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/visible-worktrees.test.ts`
- Result: **43 passed**
- Cases: bare + linked shows only the checkout; lineage does not re-add a bare parent; non-bare `isMainWorktree` still visible.

## User-regression-tradeoffs
Users who registered the bare path as a project will no longer see a dead "primary" row with no working tree. Linked worktrees remain.

Fixes #16553
