### PR TITLE
fix(windows): let a build with no job exports still retire a dead agent

### DIFF
--- a/src/main/daemon/pty-subprocess-cwd-cancel-identity.test.ts
+++ b/src/main/daemon/pty-subprocess-cwd-cancel-identity.test.ts
@@ -43,7 +43,8 @@ vi.mock('../providers/agent-foreground-process', () => ({
 }))
 
 vi.mock('../providers/windows-pty-job-membership', () => ({
-  readWindowsPtyJobProcessIds: () => new Set([12345])
+  readWindowsPtyJobProcessIds: () => new Set([12345]),
+  isWindowsPtyJobReadable: () => true
 }))
 
 import { createPtySubprocess } from './pty-subprocess'

--- a/src/main/daemon/pty-subprocess-env-inheritance.test.ts
+++ b/src/main/daemon/pty-subprocess-env-inheritance.test.ts
@@ -71,7 +71,8 @@ vi.mock('../providers/agent-foreground-process', () => ({
 // to its existing retirement logic (the degraded-scan behavior itself is
 // covered in pty-subprocess-foreground-degraded-scan.test.ts).
 vi.mock('../providers/windows-pty-job-membership', () => ({
-  readWindowsPtyJobProcessIds: () => new Set([12345])
+  readWindowsPtyJobProcessIds: () => new Set([12345]),
+  isWindowsPtyJobReadable: () => true
 }))
 
 import { createPtySubprocess } from './pty-subprocess'

--- a/src/main/daemon/pty-subprocess-foreground-degraded-scan.test.ts
+++ b/src/main/daemon/pty-subprocess-foreground-degraded-scan.test.ts
@@ -8,12 +8,13 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-const { spawnMock, isPwshAvailableMock, resolveAgentForegroundProcessMock, readConptyMock } =
+const { spawnMock, isPwshAvailableMock, resolveAgentForegroundProcessMock, readConptyMock, jobReadableMock } =
   vi.hoisted(() => ({
     spawnMock: vi.fn(),
     isPwshAvailableMock: vi.fn(),
     resolveAgentForegroundProcessMock: vi.fn(),
-    readConptyMock: vi.fn()
+    readConptyMock: vi.fn(),
+    jobReadableMock: vi.fn()
   }))
 
 vi.mock('node-pty', () => ({ spawn: spawnMock }))
@@ -38,7 +39,8 @@ vi.mock('../providers/agent-foreground-process', () => ({
 }))
 
 vi.mock('../providers/windows-pty-job-membership', () => ({
-  readWindowsPtyJobProcessIds: (...args: unknown[]) => readConptyMock(...args)
+  readWindowsPtyJobProcessIds: (...args: unknown[]) => readConptyMock(...args),
+  isWindowsPtyJobReadable: () => jobReadableMock()
 }))
 
 import { createPtySubprocess } from './pty-subprocess'
@@ -85,6 +87,8 @@ describe('daemon pty foreground degraded-scan handling', () => {
     resolveAgentForegroundProcessMock.mockReset()
     readConptyMock.mockReset()
     readConptyMock.mockReturnValue(null)
+    jobReadableMock.mockReset()
+    jobReadableMock.mockReturnValue(true)
     previousUserDataPath = process.env.ORCA_USER_DATA_PATH
     userDataPath = mkdtempSync(join(tmpdir(), 'daemon-pty-degraded-scan-test-'))
     process.env.ORCA_USER_DATA_PATH = userDataPath
@@ -262,6 +266,22 @@ describe('daemon pty foreground degraded-scan handling', () => {
 
     await readForegroundAt(handle, 0)
     await readForegroundAt(handle, 1_000) // refresh sees the foreign anchor and clears
+    expect(await readForegroundAt(handle, 1_100)).toBe('powershell.exe')
+  })
+
+  it('retires on a shipped build whose node-pty cannot answer job queries', async () => {
+    // The real Windows fleet today: no job exports (#16059), so the read is null
+    // for every user. Treating that as unverifiable held a dead agent forever.
+    // With nothing to ask, the available scan that already found no agent decides.
+    jobReadableMock.mockReturnValue(false)
+    readConptyMock.mockReturnValue(null)
+    resolveAgentForegroundProcessMock
+      .mockResolvedValueOnce({ available: true, processName: 'claude' })
+      .mockResolvedValue({ available: true, processName: null })
+    const { handle } = await spawnWindowsShell()
+
+    await readForegroundAt(handle, 0)
+    await readForegroundAt(handle, 1_000) // this refresh retires it
     expect(await readForegroundAt(handle, 1_100)).toBe('powershell.exe')
   })
 

--- a/src/main/daemon/pty-subprocess-foreground-identity.test.ts
+++ b/src/main/daemon/pty-subprocess-foreground-identity.test.ts
@@ -70,7 +70,8 @@ vi.mock('../providers/agent-foreground-process', () => ({
 // to its existing retirement logic (the degraded-scan behavior itself is
 // covered in pty-subprocess-foreground-degraded-scan.test.ts).
 vi.mock('../providers/windows-pty-job-membership', () => ({
-  readWindowsPtyJobProcessIds: () => new Set([12345])
+  readWindowsPtyJobProcessIds: () => new Set([12345]),
+  isWindowsPtyJobReadable: () => true
 }))
 
 import { createPtySubprocess } from './pty-subprocess'

--- a/src/main/daemon/pty-subprocess-git-credential-guard.test.ts
+++ b/src/main/daemon/pty-subprocess-git-credential-guard.test.ts
@@ -70,7 +70,8 @@ vi.mock('../providers/agent-foreground-process', () => ({
 // to its existing retirement logic (the degraded-scan behavior itself is
 // covered in pty-subprocess-foreground-degraded-scan.test.ts).
 vi.mock('../providers/windows-pty-job-membership', () => ({
-  readWindowsPtyJobProcessIds: () => new Set([12345])
+  readWindowsPtyJobProcessIds: () => new Set([12345]),
+  isWindowsPtyJobReadable: () => true
 }))
 
 import { createPtySubprocess } from './pty-subprocess'

--- a/src/main/daemon/pty-subprocess-handle-lifecycle.test.ts
+++ b/src/main/daemon/pty-subprocess-handle-lifecycle.test.ts
@@ -70,7 +70,8 @@ vi.mock('../providers/agent-foreground-process', () => ({
 // to its existing retirement logic (the degraded-scan behavior itself is
 // covered in pty-subprocess-foreground-degraded-scan.test.ts).
 vi.mock('../providers/windows-pty-job-membership', () => ({
-  readWindowsPtyJobProcessIds: () => new Set([12345])
+  readWindowsPtyJobProcessIds: () => new Set([12345]),
+  isWindowsPtyJobReadable: () => true
 }))
 
 import { createPtySubprocess } from './pty-subprocess'

--- a/src/main/daemon/pty-subprocess-managed-agent-env.test.ts
+++ b/src/main/daemon/pty-subprocess-managed-agent-env.test.ts
@@ -70,7 +70,8 @@ vi.mock('../providers/agent-foreground-process', () => ({
 // to its existing retirement logic (the degraded-scan behavior itself is
 // covered in pty-subprocess-foreground-degraded-scan.test.ts).
 vi.mock('../providers/windows-pty-job-membership', () => ({
-  readWindowsPtyJobProcessIds: () => new Set([12345])
+  readWindowsPtyJobProcessIds: () => new Set([12345]),
+  isWindowsPtyJobReadable: () => true
 }))
 
 import { createPtySubprocess } from './pty-subprocess'

--- a/src/main/daemon/pty-subprocess-windows-shell-launch.test.ts
+++ b/src/main/daemon/pty-subprocess-windows-shell-launch.test.ts
@@ -70,7 +70,8 @@ vi.mock('../providers/agent-foreground-process', () => ({
 // to its existing retirement logic (the degraded-scan behavior itself is
 // covered in pty-subprocess-foreground-degraded-scan.test.ts).
 vi.mock('../providers/windows-pty-job-membership', () => ({
-  readWindowsPtyJobProcessIds: () => new Set([12345])
+  readWindowsPtyJobProcessIds: () => new Set([12345]),
+  isWindowsPtyJobReadable: () => true
 }))
 
 import { createPtySubprocess } from './pty-subprocess'

--- a/src/main/daemon/pty-subprocess-wsl-launch.test.ts
+++ b/src/main/daemon/pty-subprocess-wsl-launch.test.ts
@@ -73,7 +73,8 @@ vi.mock('../providers/agent-foreground-process', () => ({
 // to its existing retirement logic (the degraded-scan behavior itself is
 // covered in pty-subprocess-foreground-degraded-scan.test.ts).
 vi.mock('../providers/windows-pty-job-membership', () => ({
-  readWindowsPtyJobProcessIds: () => new Set([12345])
+  readWindowsPtyJobProcessIds: () => new Set([12345]),
+  isWindowsPtyJobReadable: () => true
 }))
 
 import { createPtySubprocess } from './pty-subprocess'

--- a/src/main/daemon/pty-subprocess.test.ts
+++ b/src/main/daemon/pty-subprocess.test.ts
@@ -73,7 +73,8 @@ vi.mock('../providers/agent-foreground-process', () => ({
 // to its existing retirement logic (the degraded-scan behavior itself is
 // covered in pty-subprocess-foreground-degraded-scan.test.ts).
 vi.mock('../providers/windows-pty-job-membership', () => ({
-  readWindowsPtyJobProcessIds: () => new Set([12345])
+  readWindowsPtyJobProcessIds: () => new Set([12345]),
+  isWindowsPtyJobReadable: () => true
 }))
 
 import { createPtySubprocess, checkPtySpawnHealth } from './pty-subprocess'

--- a/src/main/daemon/pty-subprocess/foreground-process-tracker.ts
+++ b/src/main/daemon/pty-subprocess/foreground-process-tracker.ts
@@ -5,7 +5,11 @@ import {
   judgeCachedAgentJobEvidence,
   WINDOWS_DETACHED_DESCENDANT_IDENTITY_MAX_AGE_MS
 } from '../../providers/windows-cached-agent-revalidation'
-import { readWindowsPtyJobProcessIds } from '../../providers/windows-pty-job-membership'
+import {
+  isWindowsPtyJobReadable,
+  readWindowsPtyJobProcessIds
+} from '../../providers/windows-pty-job-membership'
+
 import { readWindowsConsoleAttachedProcessIds } from '../../providers/windows-console-attached-processes'
 import {
   isAgentForegroundWrapperProcess,
@@ -145,12 +149,20 @@ export function createPtyForegroundProcessTracker(args: {
             // Job, not console: needs no console attachment, so no fork (#10857).
             const verdict = judgeCachedAgentJobEvidence({
               jobProcessIds: readWindowsPtyJobProcessIds(proc),
+              jobSupported: isWindowsPtyJobReadable(),
               shellPid: proc.pid,
               anchorProcessId: cachedAgentForeground.pid,
               identityAgeMs: Date.now() - cachedAgentForeground.refreshedAt
             })
             // Unverifiable is never exit proof (ssh-execution-boundary.md): hold.
             if (verdict === 'unavailable') {
+              return
+            }
+            if (verdict === 'unsupported') {
+              // No job to consult on this build, and the scan that got here was
+              // available and found no agent. Trust it, as every other platform
+              // does, rather than holding a dead name forever (#16059).
+              retireStaleForegroundIdentity()
               return
             }
             if (verdict === 'confirmed' || verdict === 'recheck') {

--- a/src/main/providers/local-pty-provider-foreground-process.test.ts
+++ b/src/main/providers/local-pty-provider-foreground-process.test.ts
@@ -85,7 +85,8 @@ vi.mock('./agent-foreground-process', () => ({
 }))
 
 vi.mock('./windows-pty-job-membership', () => ({
-  readWindowsPtyJobProcessIds: (...args: unknown[]) => readWindowsPtyJobProcessIdsMock(...args)
+  readWindowsPtyJobProcessIds: (...args: unknown[]) => readWindowsPtyJobProcessIdsMock(...args),
+  isWindowsPtyJobReadable: () => true
 }))
 
 vi.mock('../wsl', () => ({

--- a/src/main/providers/local-pty-provider-io-events.test.ts
+++ b/src/main/providers/local-pty-provider-io-events.test.ts
@@ -85,7 +85,8 @@ vi.mock('./agent-foreground-process', () => ({
 }))
 
 vi.mock('./windows-pty-job-membership', () => ({
-  readWindowsPtyJobProcessIds: (...args: unknown[]) => readWindowsPtyJobProcessIdsMock(...args)
+  readWindowsPtyJobProcessIds: (...args: unknown[]) => readWindowsPtyJobProcessIdsMock(...args),
+  isWindowsPtyJobReadable: () => true
 }))
 
 vi.mock('../wsl', () => ({

--- a/src/main/providers/local-pty-provider-session-inventory.test.ts
+++ b/src/main/providers/local-pty-provider-session-inventory.test.ts
@@ -85,7 +85,8 @@ vi.mock('./agent-foreground-process', () => ({
 }))
 
 vi.mock('./windows-pty-job-membership', () => ({
-  readWindowsPtyJobProcessIds: (...args: unknown[]) => readWindowsPtyJobProcessIdsMock(...args)
+  readWindowsPtyJobProcessIds: (...args: unknown[]) => readWindowsPtyJobProcessIdsMock(...args),
+  isWindowsPtyJobReadable: () => true
 }))
 
 vi.mock('../wsl', () => ({

--- a/src/main/providers/local-pty-provider-shell-readiness.test.ts
+++ b/src/main/providers/local-pty-provider-shell-readiness.test.ts
@@ -85,7 +85,8 @@ vi.mock('./agent-foreground-process', () => ({
 }))
 
 vi.mock('./windows-pty-job-membership', () => ({
-  readWindowsPtyJobProcessIds: (...args: unknown[]) => readWindowsPtyJobProcessIdsMock(...args)
+  readWindowsPtyJobProcessIds: (...args: unknown[]) => readWindowsPtyJobProcessIdsMock(...args),
+  isWindowsPtyJobReadable: () => true
 }))
 
 vi.mock('../wsl', () => ({

--- a/src/main/providers/local-pty-provider-shutdown.test.ts
+++ b/src/main/providers/local-pty-provider-shutdown.test.ts
@@ -85,7 +85,8 @@ vi.mock('./agent-foreground-process', () => ({
 }))
 
 vi.mock('./windows-pty-job-membership', () => ({
-  readWindowsPtyJobProcessIds: (...args: unknown[]) => readWindowsPtyJobProcessIdsMock(...args)
+  readWindowsPtyJobProcessIds: (...args: unknown[]) => readWindowsPtyJobProcessIdsMock(...args),
+  isWindowsPtyJobReadable: () => true
 }))
 
 vi.mock('../wsl', () => ({

--- a/src/main/providers/local-pty-provider-spawn-cwd-safety.test.ts
+++ b/src/main/providers/local-pty-provider-spawn-cwd-safety.test.ts
@@ -85,7 +85,8 @@ vi.mock('./agent-foreground-process', () => ({
 }))
 
 vi.mock('./windows-pty-job-membership', () => ({
-  readWindowsPtyJobProcessIds: (...args: unknown[]) => readWindowsPtyJobProcessIdsMock(...args)
+  readWindowsPtyJobProcessIds: (...args: unknown[]) => readWindowsPtyJobProcessIdsMock(...args),
+  isWindowsPtyJobReadable: () => true
 }))
 
 vi.mock('../wsl', () => ({

--- a/src/main/providers/local-pty-provider-spawn-env.test.ts
+++ b/src/main/providers/local-pty-provider-spawn-env.test.ts
@@ -87,7 +87,8 @@ vi.mock('./agent-foreground-process', () => ({
 }))
 
 vi.mock('./windows-pty-job-membership', () => ({
-  readWindowsPtyJobProcessIds: (...args: unknown[]) => readWindowsPtyJobProcessIdsMock(...args)
+  readWindowsPtyJobProcessIds: (...args: unknown[]) => readWindowsPtyJobProcessIdsMock(...args),
+  isWindowsPtyJobReadable: () => true
 }))
 
 vi.mock('../wsl', () => ({

--- a/src/main/providers/local-pty-provider-spawn-session.test.ts
+++ b/src/main/providers/local-pty-provider-spawn-session.test.ts
@@ -85,7 +85,8 @@ vi.mock('./agent-foreground-process', () => ({
 }))
 
 vi.mock('./windows-pty-job-membership', () => ({
-  readWindowsPtyJobProcessIds: (...args: unknown[]) => readWindowsPtyJobProcessIdsMock(...args)
+  readWindowsPtyJobProcessIds: (...args: unknown[]) => readWindowsPtyJobProcessIdsMock(...args),
+  isWindowsPtyJobReadable: () => true
 }))
 
 vi.mock('../wsl', () => ({

--- a/src/main/providers/local-pty-provider-windows-shell-launch.test.ts
+++ b/src/main/providers/local-pty-provider-windows-shell-launch.test.ts
@@ -86,7 +86,8 @@ vi.mock('./agent-foreground-process', () => ({
 }))
 
 vi.mock('./windows-pty-job-membership', () => ({
-  readWindowsPtyJobProcessIds: (...args: unknown[]) => readWindowsPtyJobProcessIdsMock(...args)
+  readWindowsPtyJobProcessIds: (...args: unknown[]) => readWindowsPtyJobProcessIdsMock(...args),
+  isWindowsPtyJobReadable: () => true
 }))
 
 vi.mock('../wsl', () => ({

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -64,7 +64,7 @@ import { resolveStableForegroundProcess } from './stable-foreground-process'
 import { getAgentForegroundContextPaths } from './agent-foreground-context-paths'
 import { recognizeAgentProcessFromCommandLine } from '../../shared/agent-process-recognition'
 import { killWithDescendantSweep } from '../pty-descendant-termination'
-import { readWindowsPtyJobProcessIds } from './windows-pty-job-membership'
+import { isWindowsPtyJobReadable, readWindowsPtyJobProcessIds } from './windows-pty-job-membership'
 import { readWindowsConsoleAttachedProcessIds } from './windows-console-attached-processes'
 import { terminatePtyJob } from '../windows/windows-pty-job'
 import {
@@ -1434,6 +1434,7 @@ export class LocalPtyProvider implements IPtyProvider {
         }
         const verdict = judgeCachedAgentJobEvidence({
           jobProcessIds: paneProcessIds,
+          jobSupported: isWindowsPtyJobReadable(),
           shellPid: proc.pid,
           anchorProcessId: cachedEntry?.pid ?? null,
           identityAgeMs: Date.now() - (cachedEntry?.at ?? 0)

--- a/src/main/providers/windows-cached-agent-revalidation.test.ts
+++ b/src/main/providers/windows-cached-agent-revalidation.test.ts
@@ -47,9 +47,38 @@ describe('judgeCachedAgentJobEvidence', () => {
       identityAgeMs
     })
 
+  it('defers to the scan when the build has no job exports to consult', () => {
+    // Every shipped Windows release still ships a node-pty without them
+    // (#16059), so the read is null for ALL real users today. Calling that
+    // 'unavailable' means the retire path never fires for any of them -- worse
+    // than the forked probe it replaced, which at least retired. 'unsupported'
+    // is "nothing to ask", not "asked and could not", so the scan decides.
+    const unsupported = (anchorProcessId: number | null, identityAgeMs: number) =>
+      judgeCachedAgentJobEvidence({
+        jobProcessIds: null,
+        jobSupported: false,
+        shellPid: SHELL,
+        anchorProcessId,
+        identityAgeMs
+      })
+
+    expect(unsupported(AGENT, FRESH)).toBe('unsupported')
+    expect(unsupported(null, AGED)).toBe('unsupported')
+  })
+
   it('is unavailable without a job answer, never exit proof', () => {
+    // Supported-but-null is genuine loss of contact and must still hold.
     expect(judge(null, AGENT, FRESH)).toBe('unavailable')
     expect(judge(null, null, AGED)).toBe('unavailable')
+    expect(
+      judgeCachedAgentJobEvidence({
+        jobProcessIds: null,
+        jobSupported: true,
+        shellPid: SHELL,
+        anchorProcessId: AGENT,
+        identityAgeMs: AGED
+      })
+    ).toBe('unavailable')
   })
 
   it('confirms a fresh anchored identity whose pid is still in the job', () => {

--- a/src/main/providers/windows-cached-agent-revalidation.ts
+++ b/src/main/providers/windows-cached-agent-revalidation.ts
@@ -33,6 +33,14 @@ export function canRevalidateCachedAgentWithoutScan(
 }
 
 export type WindowsCachedAgentJobVerdict =
+  /**
+   * This build's node-pty has no job exports, so there is no job evidence to
+   * weigh -- and every shipped Windows release is still such a build (#16059).
+   * Distinct from 'unavailable': that means "we could have asked and could not",
+   * which must never retire. This means "there is nothing to ask", so the
+   * authoritative scan decides alone, exactly as it does off Windows.
+   */
+  | 'unsupported'
   /** Anchor pid alive in the job, recently confirmed: identity stands, no scan. */
   | 'confirmed'
   /** Anchor pid alive but past the age bound: scan for drift; a silent scan keeps it. */
@@ -64,12 +72,13 @@ export type WindowsCachedAgentJobVerdict =
  */
 export function judgeCachedAgentJobEvidence(args: {
   jobProcessIds: ReadonlySet<number> | null
+  jobSupported?: boolean
   shellPid: number
   anchorProcessId: number | null
   identityAgeMs: number
 }): WindowsCachedAgentJobVerdict {
   if (args.jobProcessIds === null) {
-    return 'unavailable'
+    return args.jobSupported === false ? 'unsupported' : 'unavailable'
   }
   const withinAgeBound = args.identityAgeMs <= WINDOWS_DETACHED_DESCENDANT_IDENTITY_MAX_AGE_MS
   // A shell-pid "anchor" proves nothing about a child; treat it as unanchored.

--- a/src/main/providers/windows-pty-job-membership.ts
+++ b/src/main/providers/windows-pty-job-membership.ts
@@ -1,5 +1,5 @@
 import type { IPty } from 'node-pty'
-import { listPtyJobProcessIds } from '../windows/windows-pty-job'
+import { isPtyJobOwnershipAvailable, listPtyJobProcessIds } from '../windows/windows-pty-job'
 
 /**
  * Processes still running under a pane, or null when there is no answer.
@@ -31,4 +31,14 @@ export function readWindowsPtyJobProcessIds(
   // Without the shell, a size-1 set would read as "shell alone, retire" when it
   // means the opposite. The forked probe this replaced refused the same way.
   return membership.has(proc.pid) ? membership : null
+}
+
+/**
+ * Whether this build's node-pty exports the job reads at all.
+ *
+ * Lives beside the read because callers must not confuse "asked and got no
+ * answer" with "there was nothing to ask" -- only the former is unverifiable.
+ */
+export function isWindowsPtyJobReadable(): boolean {
+  return isPtyJobOwnershipAvailable()
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 20 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​88 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​21 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​67 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​32 |

<!-- /orca-pr-loc -->

Follow-up to #16419 (`a1ec0479e21`). Found while triaging Windows issues, not reported by a user — but it affects every Windows user today.

## ELI5

#16419 moved the foreground poll's "is this agent still alive?" question from a **forked helper** to the pane's **Win32 job object** — the #10857 fix. When the job read returns `null`, the verdict is `'unavailable'`, and per `docs/reference/ssh-execution-boundary.md` that must never be read as death. So the code holds the cached identity.

Correct rule, wrong case. **Every shipped Windows release returns `null` here**, because the node-pty patch that adds `listJobProcessIds` is in **no `v1.4.*` tag**, 1.4.188 included (#16059 — I confirmed with `git tag --contains`).

So for the entire current Windows fleet:

| | before #16419 | after #16419 | this PR |
|---|---|---|---|
| forks a helper per poll | yes | no | no |
| can retire a dead agent | **yes** | **no, ever** | **yes** |

Two user-visible symptoms today: a pane keeps showing an agent's name indefinitely after it exits, and because a non-null cache makes `idleNoEvidenceShell` false, the refresh stays pinned at the **1 s** TTL instead of backing off to 15 s — so every pane that ever ran an agent rescans the process table once a second, forever.

## The fix

The verdict was missing a distinction:

- **"we could have asked and could not"** — a patched build whose tree is no longer tracked. Genuinely unverifiable. Still `'unavailable'`, still holds. Unchanged.
- **"there is nothing to ask"** — a build with no job exports at all. That is not loss of contact; there is simply no evidence source. Now `'unsupported'`, and the authoritative scan decides alone, exactly as it already does on macOS and Linux.

The scan that reaches this branch has already reported `available` and found no agent, so trusting it costs nothing extra.

## Two things I deliberately did NOT do

**No fallback to the forked console probe.** That is the #10857 storm this path exists to eliminate, and re-forking per poll for the whole current fleet would be a worse trade than the bug being fixed.

**No age-based retirement.** My first draft returned `'unproven'`/`'expired'` on age alone. That is wrong: `'unproven'` short-circuits the scan, so a **live** agent that a scan would have confirmed gets retired at 30 s. Deferring to the scan has neither problem.

## A testing trap worth flagging

`isWindowsPtyJobReadable()` is exported from `windows-pty-job-membership.ts`, beside the read, rather than imported from `windows-pty-job.ts`. That is not cosmetic: `isPtyJobOwnershipAvailable()` returns `false` off Windows, so on a macOS runner **every Windows-simulating test would have silently taken the unsupported path** — the suite would have been green about a configuration no Windows user has. Co-locating it means the module mock those 19 test files already use controls both facts, and each now declares which build it is simulating.

## Verification

- New verdict tests pin both directions; **mutation-verified** — collapsing `'unsupported'` back into `'unavailable'` turns them red.
- End-to-end test in `pty-subprocess-foreground-degraded-scan.test.ts` drives a shipped-fleet build (no job exports) and asserts the identity actually retires. Also mutation-verified.
- Lint 0, typecheck 0, 97/97 reliability gates.
- `src/main` + `src/shared` diffed against an `origin/main` baseline run in a scratch worktree: **no regressions**. Six files differed; all six pass in isolation, and `setup-agent-sequencing` is flakier on `main` (2/3 runs fail there, 0/3 here).

## Note on release ordering

This makes the code correct on both build kinds, so it does not depend on when the node-pty patch ships. But #16059's first item still stands independently: until a release is cut from a commit containing the patch, Windows users get no job-object teardown at all, and this PR only restores retirement for them — not the job mechanism itself.
