### PR TITLE
fix(web): sync agent default launch settings to paired runtime

### DIFF
--- a/src/renderer/src/web/preload-api/web-preferences-store.ts
+++ b/src/renderer/src/web/preload-api/web-preferences-store.ts
@@ -18,6 +18,11 @@ import {
 } from '../../../../shared/pr-bot-author-overrides'
 import { normalizeTerminalCursorStyleDefault } from '../../../../shared/terminal-cursor-style-settings'
 import { normalizeTerminalCustomThemes } from '../../../../shared/terminal-custom-themes'
+import {
+  normalizeTuiAgentArgsRecord,
+  normalizeTuiAgentEnvRecord
+} from '../../../../shared/tui-agent-launch-defaults'
+import { normalizeDisabledTuiAgents } from '../../../../shared/tui-agent-selection'
 import { normalizeUiLanguage } from '../../../../shared/ui-language'
 import { readStoredWebRuntimeEnvironment } from '../web-runtime-environment'
 import { mergeSettings, mergeWebUIState } from './web-preference-normalization'
@@ -208,6 +213,21 @@ export async function syncRuntimeBackedSettings(
     runtimeUpdates.prBotAuthorOverrides = normalizePRBotAuthorOverrides(
       updates.prBotAuthorOverrides
     )
+  }
+  if ('agentDefaultArgs' in updates) {
+    runtimeUpdates.agentDefaultArgs = normalizeTuiAgentArgsRecord(updates.agentDefaultArgs)
+  }
+  if ('agentDefaultEnv' in updates) {
+    runtimeUpdates.agentDefaultEnv = normalizeTuiAgentEnvRecord(updates.agentDefaultEnv)
+  }
+  if ('defaultTuiAgent' in updates) {
+    runtimeUpdates.defaultTuiAgent = updates.defaultTuiAgent
+  }
+  if ('disabledTuiAgents' in updates) {
+    runtimeUpdates.disabledTuiAgents = normalizeDisabledTuiAgents(updates.disabledTuiAgents)
+  }
+  if (typeof updates.agentStatusHooksEnabled === 'boolean') {
+    runtimeUpdates.agentStatusHooksEnabled = updates.agentStatusHooksEnabled
   }
   if (Object.keys(runtimeUpdates).length === 0) {
     return localNext

--- a/src/renderer/src/web/web-preload-api-settings.test.ts
+++ b/src/renderer/src/web/web-preload-api-settings.test.ts
@@ -698,6 +698,42 @@ describe('web settings preload API', () => {
     ])
   }, 15_000)
 
+  it('forwards agent default launch args updates to a paired runtime', async () => {
+    const runtimeCalls: { method: string; params: unknown }[] = []
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(method: string, params?: unknown): Promise<RuntimeRpcResponse<unknown>> {
+          runtimeCalls.push({ method, params })
+          return Promise.resolve({
+            id: `call-${runtimeCalls.length}`,
+            ok: true,
+            result: { settings: { agentDefaultArgs: { gemini: '--approval-mode=yolo' } } },
+            _meta: { runtimeId: 'runtime-1' }
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage)
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    const settings = await globals.window.api.settings.set({
+      agentDefaultArgs: { gemini: '--approval-mode=yolo' }
+    })
+
+    expect(settings.agentDefaultArgs?.gemini).toBe('--approval-mode=yolo')
+    expect(runtimeCalls).toEqual([
+      {
+        method: 'settings.update',
+        params: { agentDefaultArgs: { gemini: '--approval-mode=yolo' } }
+      }
+    ])
+  })
+
   it('forwards new worktree card style updates to a paired runtime', async () => {
     const runtimeCalls: { method: string; params: unknown }[] = []
     vi.doMock('./web-runtime-client', () => ({


### PR DESCRIPTION
## Description
Paired Web settings updates for agent launch defaults were stored only in `orca.web.settings.v1`, so the connected runtime kept the previous `agentDefaultArgs`.
`syncRuntimeBackedSettings` now forwards host-owned agent launch fields through the existing `settings.update` RPC.

## Focused fix
- In scope: Web → runtime sync for `agentDefaultArgs`, `agentDefaultEnv`, `defaultTuiAgent`, `disabledTuiAgents`, `agentStatusHooksEnabled`.
- Out of scope: a general settings-ownership framework; Web-only presentation preferences.

## Preserves
- Unpaired/offline Web clients still persist locally on RPC failure.
- Presentation settings already excluded from `runtimeUpdates` stay local.

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/web/web-preload-api-settings.test.ts`
- Result: **28 passed**
- Regression: `settings.set({ agentDefaultArgs: { gemini: '--approval-mode=yolo' } })` calls runtime `settings.update` with that payload.

## User-regression-tradeoffs
None. Host-executed launches now see the same agent defaults the Web UI shows.

Fixes #16501
