### PR TITLE
fix(composer): upload dropped files to remote Orca runtime worktrees

### DIFF
--- a/src/renderer/src/hooks/composer-drop-upload-route.test.ts
+++ b/src/renderer/src/hooks/composer-drop-upload-route.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest'
+import { getActiveRuntimeTarget } from '@/runtime/runtime-client-target'
+import {
+  resolveComposerDropUploadSettings,
+  shouldUploadComposerDropPaths
+} from './composer-drop-upload-route'
+
+describe('shouldUploadComposerDropPaths', () => {
+  it('uploads when a runtime environment is selected without SSH', () => {
+    expect(
+      shouldUploadComposerDropPaths({
+        settings: { activeRuntimeEnvironmentId: 'env-1' },
+        connectionId: null
+      })
+    ).toBe(true)
+  })
+
+  it('uploads when the selected repo execution host is a remote runtime without SSH', () => {
+    expect(
+      shouldUploadComposerDropPaths({
+        settings: { activeRuntimeEnvironmentId: null },
+        connectionId: null,
+        repo: { id: 'repo-1', connectionId: null, executionHostId: 'runtime:env-1' }
+      })
+    ).toBe(true)
+  })
+
+  it('uploads when the worktree execution host is a remote runtime without SSH', () => {
+    expect(
+      shouldUploadComposerDropPaths({
+        settings: { activeRuntimeEnvironmentId: null },
+        connectionId: null,
+        executionHostId: 'runtime:env-1'
+      })
+    ).toBe(true)
+  })
+
+  it('keeps local SSH-less drops local even while a runtime is focused', () => {
+    expect(
+      shouldUploadComposerDropPaths({
+        settings: { activeRuntimeEnvironmentId: 'focused-runtime' },
+        connectionId: null,
+        repo: { id: 'repo-1', connectionId: null, executionHostId: 'local' }
+      })
+    ).toBe(false)
+  })
+
+  it('uploads SSH targets without a runtime environment', () => {
+    expect(
+      shouldUploadComposerDropPaths({
+        settings: { activeRuntimeEnvironmentId: null },
+        connectionId: 'ssh-1'
+      })
+    ).toBe(true)
+  })
+})
+
+describe('resolveComposerDropUploadSettings', () => {
+  it('routes repo-owned remote runtimes so importExternalPathsToRuntime is not skipped', () => {
+    const settings = resolveComposerDropUploadSettings({
+      settings: { activeRuntimeEnvironmentId: null },
+      connectionId: null,
+      repo: { id: 'repo-1', connectionId: null, executionHostId: 'runtime:env-1' }
+    })
+
+    expect(settings).toEqual({ activeRuntimeEnvironmentId: 'env-1' })
+    expect(getActiveRuntimeTarget(settings)).toEqual({
+      kind: 'environment',
+      environmentId: 'env-1'
+    })
+  })
+
+  it('keeps explicit local repos on the local host', () => {
+    const settings = resolveComposerDropUploadSettings({
+      settings: { activeRuntimeEnvironmentId: 'focused-runtime' },
+      connectionId: null,
+      repo: { id: 'repo-1', connectionId: null, executionHostId: 'local' },
+      executionHostId: 'local'
+    })
+
+    expect(settings).toEqual({ activeRuntimeEnvironmentId: null })
+    expect(getActiveRuntimeTarget(settings)).toEqual({ kind: 'local' })
+  })
+})

--- a/src/renderer/src/hooks/composer-drop-upload-route.ts
+++ b/src/renderer/src/hooks/composer-drop-upload-route.ts
@@ -1,0 +1,46 @@
+import { parseExecutionHostId } from '../../../shared/execution-host'
+import type { GlobalSettings } from '../../../shared/global-settings-types'
+import type { Repo } from '../../../shared/repo-types'
+import { getSettingsForRepoRuntimeOwner } from '@/lib/repo-runtime-owner'
+import { shouldUploadRemoteEditorFileDrop } from './useGlobalFileDrop'
+
+export type ComposerDropUploadTarget = {
+  settings?: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null
+  connectionId?: string | null
+  repo?: Pick<Repo, 'id' | 'connectionId' | 'executionHostId'> | null
+  executionHostId?: string | null
+}
+
+export function resolveComposerDropUploadSettings(
+  target: ComposerDropUploadTarget
+): Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined {
+  const repoSettings = target.repo
+    ? getSettingsForRepoRuntimeOwner(
+        { repos: [target.repo], settings: target.settings },
+        target.repo.id
+      )
+    : target.settings
+  const parsedHost = parseExecutionHostId(target.executionHostId)
+  // Why: a paired runtime worktree can own the drop via `runtime:*` even when
+  // global focus and SSH connectionId are both unset (#16558).
+  if (parsedHost?.kind === 'runtime') {
+    return {
+      ...repoSettings,
+      activeRuntimeEnvironmentId: parsedHost.environmentId
+    }
+  }
+  if (parsedHost?.kind === 'local') {
+    return {
+      ...repoSettings,
+      activeRuntimeEnvironmentId: null
+    }
+  }
+  return repoSettings
+}
+
+export function shouldUploadComposerDropPaths(target: ComposerDropUploadTarget): boolean {
+  return shouldUploadRemoteEditorFileDrop(
+    resolveComposerDropUploadSettings(target),
+    target.connectionId
+  )
+}

--- a/src/renderer/src/hooks/composer-state/attachment-drop-state.ts
+++ b/src/renderer/src/hooks/composer-state/attachment-drop-state.ts
@@ -7,6 +7,8 @@ type AttachmentDropStateInput = Pick<
   | 'connectionId'
   | 'promptCaretFrameRef'
   | 'promptTextareaRef'
+  | 'selectedRepo'
+  | 'selectedRepoExecutionHostId'
   | 'selectedRepoPath'
   | 'selectedRepoSettings'
   | 'setAgentPrompt'
@@ -24,6 +26,10 @@ import {
   collectComposerDropUploadResult,
   shouldReportComposerDropUploadFailure
 } from '../composer-drop-upload-result'
+import {
+  resolveComposerDropUploadSettings,
+  shouldUploadComposerDropPaths
+} from '../composer-drop-upload-route'
 import { applyComposerNativeFileDrop } from '../composer-native-file-drop'
 import { useComposerDropListener } from './composer-drop-listener'
 
@@ -34,6 +40,8 @@ export function useAttachmentDropState(input: AttachmentDropStateInput) {
     connectionId,
     promptCaretFrameRef,
     promptTextareaRef,
+    selectedRepo,
+    selectedRepoExecutionHostId,
     selectedRepoPath,
     selectedRepoSettings,
     setAgentPrompt,
@@ -110,9 +118,16 @@ export function useAttachmentDropState(input: AttachmentDropStateInput) {
       targetRepoPath: string | null | undefined = selectedRepoPath,
       canReportFailure: () => boolean = () => true
     ): Promise<{ filePaths: string[]; folderPaths: string[] } | null> => {
-      if (!targetSettings?.activeRuntimeEnvironmentId?.trim() && !targetConnectionId) {
+      const uploadTarget = {
+        settings: targetSettings,
+        connectionId: targetConnectionId,
+        repo: selectedRepo,
+        executionHostId: selectedRepoExecutionHostId
+      }
+      if (!shouldUploadComposerDropPaths(uploadTarget)) {
         return null
       }
+      const uploadSettings = resolveComposerDropUploadSettings(uploadTarget)
       if (!targetRepoPath) {
         if (canReportFailure()) {
           toast.error(
@@ -129,7 +144,7 @@ export function useAttachmentDropState(input: AttachmentDropStateInput) {
         ? captureDirectSshMutationExpectation(
             useAppStore.getState(),
             targetConnectionId,
-            targetSettings?.activeRuntimeEnvironmentId
+            uploadSettings?.activeRuntimeEnvironmentId
           )
         : {
             expectedExecutionHostId: 'local' as const,
@@ -141,7 +156,7 @@ export function useAttachmentDropState(input: AttachmentDropStateInput) {
             const current = captureDirectSshMutationExpectation(
               useAppStore.getState(),
               targetConnectionId,
-              targetSettings?.activeRuntimeEnvironmentId
+              uploadSettings?.activeRuntimeEnvironmentId
             )
             if (
               current.expectedSshTargetId !== sshExpectation.expectedSshTargetId ||
@@ -154,7 +169,7 @@ export function useAttachmentDropState(input: AttachmentDropStateInput) {
         : undefined
       const { results } = await importExternalPathsToRuntime(
         {
-          settings: targetSettings,
+          settings: uploadSettings,
           worktreeId: targetRepoPath,
           worktreePath: targetRepoPath,
           connectionId: targetConnectionId ?? undefined,
@@ -175,7 +190,13 @@ export function useAttachmentDropState(input: AttachmentDropStateInput) {
       }
       return { filePaths: uploadResult.filePaths, folderPaths: uploadResult.folderPaths }
     },
-    [connectionId, selectedRepoPath, selectedRepoSettings]
+    [
+      connectionId,
+      selectedRepo,
+      selectedRepoExecutionHostId,
+      selectedRepoPath,
+      selectedRepoSettings
+    ]
   )
 
   const handleAddAttachment = useCallback(async (): Promise<void> => {

--- a/src/renderer/src/hooks/composer-state/composer-source-state.ts
+++ b/src/renderer/src/hooks/composer-state/composer-source-state.ts
@@ -55,6 +55,8 @@ export function useComposerSourceState(
     connectionId: target.workspaceIdentityState.connectionId,
     promptCaretFrameRef: target.asyncComposerState.promptCaretFrameRef,
     promptTextareaRef: target.asyncComposerState.promptTextareaRef,
+    selectedRepo: target.runtimeTargetSelection.selectedRepo,
+    selectedRepoExecutionHostId: target.runtimeTargetSelection.selectedRepoExecutionHostId,
     selectedRepoPath: target.asyncComposerState.selectedRepoPath,
     selectedRepoSettings: target.runtimeTargetSelection.selectedRepoSettings,
     setAgentPrompt: target.sourceContextState.setAgentPrompt,


### PR DESCRIPTION
## Description
Drag-and-drop onto an agent prompt uploaded into `.orca/drops` over SSH, but a Remote Orca Server target fell through to pasting client-local paths.
Composer drops now resolve the selected repo/worktree owner and reuse the editor remote/SSH upload predicate.

## Focused fix
- In scope: composer/agent-prompt file drops to remote Orca runtime worktrees.
- Out of scope: editor file-open drops beyond sharing the existing remote predicate.

## Preserves
- Local SSH-less drops still apply locally.
- SSH `connectionId` uploads still work.

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/composer-drop-upload-route.test.ts src/renderer/src/hooks/composer-native-file-drop.test.ts src/renderer/src/hooks/useGlobalFileDrop.test.ts src/renderer/src/hooks/composer-drop-upload-result.test.ts`
- Result: **22 passed**
- Cases: runtime env without SSH → upload; `runtime:*` execution host without SSH → upload; local stays local.

## User-regression-tradeoffs
None for local drops. Remote Orca Server drops now land in the server worktree `.orca/drops` like SSH.

Fixes #16558
