### PR TITLE
fix(codex): write runtime currentHash for mirrored hook trust

### DIFF
--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -39,6 +39,8 @@
     "../src/main/codex/codex-home-paths.ts",
     "../src/main/codex/codex-managed-home-resource-copy-marker.ts",
     "../src/main/codex/codex-managed-trust-grant-plan.ts",
+    "../src/main/codex/codex-mirrored-hook-runtime-trust-cache.ts",
+    "../src/main/codex/codex-mirrored-hook-runtime-trust.ts",
     "../src/main/codex/codex-path-observation.ts",
     "../src/main/codex/codex-hook-identity.ts",
     "../src/main/codex/codex-hook-trust-grant.ts",

--- a/src/main/codex/codex-mirrored-hook-runtime-trust-cache.ts
+++ b/src/main/codex/codex-mirrored-hook-runtime-trust-cache.ts
@@ -1,0 +1,51 @@
+import { createHash } from 'node:crypto'
+import type { CodexAppServerHostKey } from './codex-app-server-capability-cache'
+import { getCodexHookTrustSignature } from './codex-hook-identity'
+import {
+  getCodexTrustGrantHomeKey,
+  type CodexTrustGrantBinaryStamp
+} from './codex-trust-grant-ledger'
+import {
+  computeTrustKey,
+  normalizeHookTrustKeyForLookup,
+  readHookTrustEntries,
+  type CodexTrustEntry
+} from './config-toml-trust'
+
+export function getMirroredRuntimeTrustScopeKey(
+  hostKey: CodexAppServerHostKey,
+  runtimeHomePath: string
+): string {
+  return `${hostKey}\0${getCodexTrustGrantHomeKey(runtimeHomePath)}`
+}
+
+export function getMirroredRuntimeTrustFingerprint(
+  args: {
+    entries: readonly CodexTrustEntry[]
+    systemEntries: readonly CodexTrustEntry[]
+    tomlPath: string
+  },
+  binaryStamp: CodexTrustGrantBinaryStamp | null
+): string {
+  const actual = readHookTrustEntries(args.tomlPath)
+  const entries = args.entries
+    .map((entry) => {
+      const key = normalizeHookTrustKeyForLookup(computeTrustKey(entry))
+      return {
+        key,
+        signature: getCodexHookTrustSignature(entry),
+        approvedHash: entry.trustedHash ?? null,
+        enabled: entry.enabled !== false,
+        actual: actual.get(key) ?? null
+      }
+    })
+    .sort((left, right) => left.key.localeCompare(right.key))
+  const systemApprovals = args.systemEntries.map((entry) => ({
+    key: normalizeHookTrustKeyForLookup(computeTrustKey(entry)),
+    signature: getCodexHookTrustSignature(entry),
+    approvedHash: entry.trustedHash ?? null
+  }))
+  return createHash('sha256')
+    .update(JSON.stringify({ binaryStamp, entries, systemApprovals }))
+    .digest('hex')
+}

--- a/src/main/codex/codex-mirrored-hook-runtime-trust.test.ts
+++ b/src/main/codex/codex-mirrored-hook-runtime-trust.test.ts
@@ -56,6 +56,21 @@ describe('stampMirroredRuntimeTrustWithCurrentHashes', () => {
     )
     expect(stamped[0]?.trustedHash).toBe(SYSTEM_HASH)
   })
+
+  it('keeps the system hash when hooks/list omits command', () => {
+    const entry = windowsUserHookEntry()
+    const stamped = stampMirroredRuntimeTrustWithCurrentHashes(
+      [entry],
+      [
+        {
+          key: 'C:\\Users\\Rod\\AppData\\Roaming\\orca\\codex-runtime-home\\home\\hooks.json:pre_tool_use:1:0',
+          command: null,
+          currentHash: RUNTIME_HASH
+        }
+      ]
+    )
+    expect(stamped[0]?.trustedHash).toBe(SYSTEM_HASH)
+  })
 })
 
 describe('clearHookTrustKeySeparatorVariants', () => {

--- a/src/main/codex/codex-mirrored-hook-runtime-trust.test.ts
+++ b/src/main/codex/codex-mirrored-hook-runtime-trust.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  _internals,
+  clearHookTrustKeySeparatorVariants,
+  resolveMirroredRuntimeUserHookTrustEntries,
+  stampMirroredRuntimeTrustWithCurrentHashes
+} from './codex-mirrored-hook-runtime-trust'
+import {
+  getHookTrustKeyWriteVariants,
+  readHookTrustEntries,
+  upsertHookTrustEntries,
+  type CodexTrustEntry
+} from './config-toml-trust'
+
+const SYSTEM_HASH = 'sha256:system-source-hash'
+const RUNTIME_HASH = 'sha256:runtime-current-hash'
+
+function windowsUserHookEntry(trustedHash = SYSTEM_HASH): CodexTrustEntry {
+  return {
+    sourcePath: 'C:\\Users\\Rod\\AppData\\Roaming\\orca\\codex-runtime-home\\home\\hooks.json',
+    eventLabel: 'pre_tool_use',
+    groupIndex: 1,
+    handlerIndex: 0,
+    command: 'user-pre-tool-hook',
+    trustedHash
+  }
+}
+
+describe('stampMirroredRuntimeTrustWithCurrentHashes', () => {
+  it('replaces the system hash with the matching runtime currentHash', () => {
+    const entry = windowsUserHookEntry()
+    const slashKey =
+      'C:/Users/Rod/AppData/Roaming/orca/codex-runtime-home/home/hooks.json:pre_tool_use:1:0'
+    const stamped = stampMirroredRuntimeTrustWithCurrentHashes(
+      [entry],
+      [{ key: slashKey, command: 'user-pre-tool-hook', currentHash: RUNTIME_HASH }]
+    )
+    expect(stamped[0]?.trustedHash).toBe(RUNTIME_HASH)
+    expect(stamped[0]?.trustedHash).not.toBe(SYSTEM_HASH)
+  })
+
+  it('keeps the system hash when the listing command does not match', () => {
+    const entry = windowsUserHookEntry()
+    const stamped = stampMirroredRuntimeTrustWithCurrentHashes(
+      [entry],
+      [
+        {
+          key: 'C:\\Users\\Rod\\AppData\\Roaming\\orca\\codex-runtime-home\\home\\hooks.json:pre_tool_use:1:0',
+          command: 'some-other-hook',
+          currentHash: RUNTIME_HASH
+        }
+      ]
+    )
+    expect(stamped[0]?.trustedHash).toBe(SYSTEM_HASH)
+  })
+})
+
+describe('clearHookTrustKeySeparatorVariants', () => {
+  let tmpDir: string
+  let tomlPath: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'orca-mirrored-hook-trust-'))
+    tomlPath = join(tmpDir, 'config.toml')
+  })
+
+  afterEach(() => {
+    _internals.setListRunner(null)
+    _internals.resetRetryState()
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('clears both Windows separator variants then writes the runtime currentHash on both', () => {
+    const entry = windowsUserHookEntry()
+    const backslashKey =
+      'C:\\Users\\Rod\\AppData\\Roaming\\orca\\codex-runtime-home\\home\\hooks.json:pre_tool_use:1:0'
+    const slashKey =
+      'C:/Users/Rod/AppData/Roaming/orca/codex-runtime-home/home/hooks.json:pre_tool_use:1:0'
+    writeFileSync(
+      tomlPath,
+      [
+        `[hooks.state.'${backslashKey}']`,
+        'enabled = true',
+        `trusted_hash = "${SYSTEM_HASH}"`,
+        '',
+        `[hooks.state.'${slashKey}']`,
+        'enabled = true',
+        'trusted_hash = "sha256:other-separator-hash"',
+        ''
+      ].join('\n'),
+      'utf-8'
+    )
+
+    expect(getHookTrustKeyWriteVariants(backslashKey)).toEqual(
+      expect.arrayContaining([backslashKey, slashKey])
+    )
+    clearHookTrustKeySeparatorVariants(tomlPath, [backslashKey])
+    upsertHookTrustEntries(tomlPath, [{ ...entry, trustedHash: RUNTIME_HASH }])
+
+    const written = readFileSync(tomlPath, 'utf-8')
+    expect(written).toContain(`[hooks.state.'${backslashKey}']`)
+    expect(written).toContain(`[hooks.state.'${slashKey}']`)
+    expect((written.match(/trusted_hash = "sha256:runtime-current-hash"/g) ?? []).length).toBe(2)
+    expect(written).not.toContain(SYSTEM_HASH)
+    expect(written).not.toContain('sha256:other-separator-hash')
+    expect(readHookTrustEntries(tomlPath).get(slashKey)?.trustedHash).toBe(RUNTIME_HASH)
+  })
+
+  it('resolves mirrored entries with hooks/list currentHash instead of the system hash', () => {
+    mkdirSync(join(tmpDir, 'home'), { recursive: true })
+    const runtimeHomePath = join(tmpDir, 'home')
+    writeFileSync(tomlPath, 'model = "runtime"\n', 'utf-8')
+    const posixEntry: CodexTrustEntry = {
+      sourcePath: join(runtimeHomePath, 'hooks.json'),
+      eventLabel: 'pre_tool_use',
+      groupIndex: 1,
+      handlerIndex: 0,
+      command: 'user-pre-tool-hook',
+      trustedHash: SYSTEM_HASH
+    }
+    _internals.setListRunner(() => [
+      {
+        key: `${posixEntry.sourcePath}:pre_tool_use:1:0`,
+        command: 'user-pre-tool-hook',
+        currentHash: RUNTIME_HASH
+      }
+    ])
+
+    const resolved = resolveMirroredRuntimeUserHookTrustEntries({
+      entries: [posixEntry],
+      runtimeHomePath,
+      tomlPath
+    })
+    expect(resolved[0]?.trustedHash).toBe(RUNTIME_HASH)
+    expect(resolved[0]?.trustedHash).not.toBe(SYSTEM_HASH)
+  })
+})

--- a/src/main/codex/codex-mirrored-hook-runtime-trust.test.ts
+++ b/src/main/codex/codex-mirrored-hook-runtime-trust.test.ts
@@ -192,8 +192,10 @@ describe('mirrored runtime hook trust', () => {
     _internals.setSessionRunner(runner)
 
     const resolved = await resolveMirroredRuntimeUserHookTrustEntries(resolveArgs(entry))
+    const repeated = await resolveMirroredRuntimeUserHookTrustEntries(resolveArgs(entry))
 
     expect(resolved[0]?.trustedHash).toBe(SYSTEM_HASH)
+    expect(repeated[0]?.trustedHash).toBe(SYSTEM_HASH)
     expect(runner).toHaveBeenCalledTimes(1)
   })
 

--- a/src/main/codex/codex-mirrored-hook-runtime-trust.test.ts
+++ b/src/main/codex/codex-mirrored-hook-runtime-trust.test.ts
@@ -1,7 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { codexAppServerCapabilityCache } from './codex-app-server-capability-cache'
+import { CodexAppServerUnsupportedError } from './codex-app-server-session'
+import type { CodexUserHookTrustRebaseRequest } from './codex-user-hook-trust-rebase-client'
 import {
   _internals,
   clearHookTrustKeySeparatorVariants,
@@ -9,8 +12,8 @@ import {
   stampMirroredRuntimeTrustWithCurrentHashes
 } from './codex-mirrored-hook-runtime-trust'
 import {
+  computeTrustKey,
   getHookTrustKeyWriteVariants,
-  readHookTrustEntries,
   upsertHookTrustEntries,
   type CodexTrustEntry
 } from './config-toml-trust'
@@ -29,80 +32,109 @@ function windowsUserHookEntry(trustedHash = SYSTEM_HASH): CodexTrustEntry {
   }
 }
 
+function grantFor(entry: CodexTrustEntry, currentHash = RUNTIME_HASH) {
+  return { key: computeTrustKey(entry), command: entry.command, currentHash }
+}
+
+function inspected(request: CodexUserHookTrustRebaseRequest, currentHash = SYSTEM_HASH) {
+  if (request.operation !== 'inspect-user-hook-trust') {
+    throw new Error('expected system trust inspection')
+  }
+  return {
+    outcome: 'inspected' as const,
+    moves: request.moves.map((move) => ({
+      ...move,
+      reportedOldKey: move.oldKey,
+      currentHash,
+      wasTrusted: true,
+      enabled: true
+    }))
+  }
+}
+
 describe('stampMirroredRuntimeTrustWithCurrentHashes', () => {
-  it('replaces the system hash with the matching runtime currentHash', () => {
+  it('replaces the approved system hash only for an exact runtime key and command match', () => {
     const entry = windowsUserHookEntry()
     const slashKey =
       'C:/Users/Rod/AppData/Roaming/orca/codex-runtime-home/home/hooks.json:pre_tool_use:1:0'
-    const stamped = stampMirroredRuntimeTrustWithCurrentHashes(
-      [entry],
-      [{ key: slashKey, command: 'user-pre-tool-hook', currentHash: RUNTIME_HASH }]
-    )
-    expect(stamped[0]?.trustedHash).toBe(RUNTIME_HASH)
-    expect(stamped[0]?.trustedHash).not.toBe(SYSTEM_HASH)
-  })
-
-  it('keeps the system hash when the listing command does not match', () => {
-    const entry = windowsUserHookEntry()
-    const stamped = stampMirroredRuntimeTrustWithCurrentHashes(
-      [entry],
-      [
-        {
-          key: 'C:\\Users\\Rod\\AppData\\Roaming\\orca\\codex-runtime-home\\home\\hooks.json:pre_tool_use:1:0',
-          command: 'some-other-hook',
-          currentHash: RUNTIME_HASH
-        }
-      ]
-    )
-    expect(stamped[0]?.trustedHash).toBe(SYSTEM_HASH)
-  })
-
-  it('keeps the system hash when hooks/list omits command', () => {
-    const entry = windowsUserHookEntry()
-    const stamped = stampMirroredRuntimeTrustWithCurrentHashes(
-      [entry],
-      [
-        {
-          key: 'C:\\Users\\Rod\\AppData\\Roaming\\orca\\codex-runtime-home\\home\\hooks.json:pre_tool_use:1:0',
-          command: null,
-          currentHash: RUNTIME_HASH
-        }
-      ]
-    )
-    expect(stamped[0]?.trustedHash).toBe(SYSTEM_HASH)
+    expect(
+      stampMirroredRuntimeTrustWithCurrentHashes(
+        [entry],
+        [{ key: slashKey, command: entry.command, currentHash: RUNTIME_HASH }]
+      )[0]?.trustedHash
+    ).toBe(RUNTIME_HASH)
+    expect(
+      stampMirroredRuntimeTrustWithCurrentHashes(
+        [entry],
+        [{ key: slashKey, command: 'some-other-hook', currentHash: RUNTIME_HASH }]
+      )[0]?.trustedHash
+    ).toBe(SYSTEM_HASH)
   })
 })
 
-describe('clearHookTrustKeySeparatorVariants', () => {
+describe('mirrored runtime hook trust', () => {
   let tmpDir: string
   let tomlPath: string
+  let runtimeHomePath: string
+  let systemHomePath: string
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), 'orca-mirrored-hook-trust-'))
-    tomlPath = join(tmpDir, 'config.toml')
+    runtimeHomePath = join(tmpDir, 'home')
+    systemHomePath = join(tmpDir, 'system-home')
+    tomlPath = join(runtimeHomePath, 'config.toml')
+    mkdirSync(runtimeHomePath, { recursive: true })
+    writeFileSync(tomlPath, 'model = "runtime"\n', 'utf-8')
+    codexAppServerCapabilityCache.clear()
+    _internals.resetState()
+    _internals.setHostResolver(async (host) => ({
+      binaryStamp:
+        host.kind === 'native'
+          ? { kind: 'native', path: '/codex', size: 1, mtimeMs: 1 }
+          : { kind: 'wsl', distro: host.distro, path: '/usr/bin/codex', version: '1' },
+      buildRequest: (input) => ({
+        invocation: { command: 'codex', cliPath: null, args: [], timeoutMs: 1_000 },
+        hooksListCwd: input.runtimeHomePath,
+        expectedTrustKeys: input.expectedTrustKeys,
+        managedCommand: input.managedCommand
+      })
+    }))
   })
 
+  function systemEntryFor(entry: CodexTrustEntry): CodexTrustEntry {
+    return { ...entry, sourcePath: join(systemHomePath, 'hooks.json') }
+  }
+
+  function resolveArgs(entry: CodexTrustEntry, home = runtimeHomePath, config = tomlPath) {
+    return {
+      entries: [entry],
+      systemEntries: [systemEntryFor(entry)],
+      systemHomePath,
+      runtimeHomePath: home,
+      tomlPath: config
+    }
+  }
+
   afterEach(() => {
-    _internals.setListRunner(null)
-    _internals.resetRetryState()
+    _internals.setSessionRunner(null)
+    _internals.setHostResolver(null)
+    _internals.setConfigRestorer(null)
+    _internals.resetState()
+    codexAppServerCapabilityCache.clear()
     rmSync(tmpDir, { recursive: true, force: true })
   })
 
-  it('clears both Windows separator variants then writes the runtime currentHash on both', () => {
+  it('clears both Windows separator variants before writing the verified runtime hash', () => {
     const entry = windowsUserHookEntry()
-    const backslashKey =
-      'C:\\Users\\Rod\\AppData\\Roaming\\orca\\codex-runtime-home\\home\\hooks.json:pre_tool_use:1:0'
-    const slashKey =
-      'C:/Users/Rod/AppData/Roaming/orca/codex-runtime-home/home/hooks.json:pre_tool_use:1:0'
+    const backslashKey = computeTrustKey(entry)
+    const slashKey = backslashKey.replaceAll('\\', '/')
     writeFileSync(
       tomlPath,
       [
         `[hooks.state.'${backslashKey}']`,
-        'enabled = true',
         `trusted_hash = "${SYSTEM_HASH}"`,
         '',
         `[hooks.state.'${slashKey}']`,
-        'enabled = true',
         'trusted_hash = "sha256:other-separator-hash"',
         ''
       ].join('\n'),
@@ -116,19 +148,13 @@ describe('clearHookTrustKeySeparatorVariants', () => {
     upsertHookTrustEntries(tomlPath, [{ ...entry, trustedHash: RUNTIME_HASH }])
 
     const written = readFileSync(tomlPath, 'utf-8')
-    expect(written).toContain(`[hooks.state.'${backslashKey}']`)
-    expect(written).toContain(`[hooks.state.'${slashKey}']`)
     expect((written.match(/trusted_hash = "sha256:runtime-current-hash"/g) ?? []).length).toBe(2)
     expect(written).not.toContain(SYSTEM_HASH)
     expect(written).not.toContain('sha256:other-separator-hash')
-    expect(readHookTrustEntries(tomlPath).get(slashKey)?.trustedHash).toBe(RUNTIME_HASH)
   })
 
-  it('resolves mirrored entries with hooks/list currentHash instead of the system hash', () => {
-    mkdirSync(join(tmpDir, 'home'), { recursive: true })
-    const runtimeHomePath = join(tmpDir, 'home')
-    writeFileSync(tomlPath, 'model = "runtime"\n', 'utf-8')
-    const posixEntry: CodexTrustEntry = {
+  it('returns only a hash verified through the app-server grant session', async () => {
+    const entry: CodexTrustEntry = {
       sourcePath: join(runtimeHomePath, 'hooks.json'),
       eventLabel: 'pre_tool_use',
       groupIndex: 1,
@@ -136,20 +162,210 @@ describe('clearHookTrustKeySeparatorVariants', () => {
       command: 'user-pre-tool-hook',
       trustedHash: SYSTEM_HASH
     }
-    _internals.setListRunner(() => [
-      {
-        key: `${posixEntry.sourcePath}:pre_tool_use:1:0`,
-        command: 'user-pre-tool-hook',
-        currentHash: RUNTIME_HASH
+    const runner = vi.fn(async (request: CodexUserHookTrustRebaseRequest) => {
+      if (request.operation === 'inspect-user-hook-trust') {
+        return inspected(request)
       }
-    ])
-
-    const resolved = resolveMirroredRuntimeUserHookTrustEntries({
-      entries: [posixEntry],
-      runtimeHomePath,
-      tomlPath
+      upsertHookTrustEntries(tomlPath, [{ ...entry, trustedHash: RUNTIME_HASH }])
+      return { outcome: 'mirrored-granted' as const, entries: [grantFor(entry)] }
     })
+    _internals.setSessionRunner(runner)
+
+    const resolved = await resolveMirroredRuntimeUserHookTrustEntries(resolveArgs(entry))
+
     expect(resolved[0]?.trustedHash).toBe(RUNTIME_HASH)
-    expect(resolved[0]?.trustedHash).not.toBe(SYSTEM_HASH)
+    expect(runner).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not grant runtime trust when the stored system hash is stale for edited content', async () => {
+    const entry: CodexTrustEntry = {
+      sourcePath: join(runtimeHomePath, 'hooks.json'),
+      eventLabel: 'stop',
+      groupIndex: 1,
+      handlerIndex: 0,
+      command: 'edited-user-hook',
+      trustedHash: SYSTEM_HASH
+    }
+    const runner = vi.fn(async (request: CodexUserHookTrustRebaseRequest) =>
+      inspected(request, 'sha256:edited-system-current-hash')
+    )
+    _internals.setSessionRunner(runner)
+
+    const resolved = await resolveMirroredRuntimeUserHookTrustEntries(resolveArgs(entry))
+
+    expect(resolved[0]?.trustedHash).toBe(SYSTEM_HASH)
+    expect(runner).toHaveBeenCalledTimes(1)
+  })
+
+  it('restores the exact runtime TOML snapshot when the verified grant fails', async () => {
+    const entry: CodexTrustEntry = {
+      sourcePath: join(runtimeHomePath, 'hooks.json'),
+      eventLabel: 'stop',
+      groupIndex: 1,
+      handlerIndex: 0,
+      command: 'user-stop-hook',
+      trustedHash: SYSTEM_HASH
+    }
+    const original = 'model = "runtime"\r\n# keep exact bytes\r\n'
+    writeFileSync(tomlPath, original, 'utf-8')
+    _internals.setSessionRunner(async (request) => {
+      if (request.operation === 'inspect-user-hook-trust') {
+        return inspected(request)
+      }
+      upsertHookTrustEntries(tomlPath, [{ ...entry, trustedHash: RUNTIME_HASH }])
+      throw new Error('post-write verification failed')
+    })
+
+    await resolveMirroredRuntimeUserHookTrustEntries(resolveArgs(entry))
+
+    expect(readFileSync(tomlPath, 'utf-8')).toBe(original)
+  })
+
+  it('surfaces a rollback failure instead of accepting the partially written hash', async () => {
+    const entry: CodexTrustEntry = {
+      sourcePath: join(runtimeHomePath, 'hooks.json'),
+      eventLabel: 'stop',
+      groupIndex: 1,
+      handlerIndex: 0,
+      command: 'user-stop-hook',
+      trustedHash: SYSTEM_HASH
+    }
+    _internals.setSessionRunner(async (request) => {
+      if (request.operation === 'inspect-user-hook-trust') {
+        return inspected(request)
+      }
+      upsertHookTrustEntries(tomlPath, [{ ...entry, trustedHash: RUNTIME_HASH }])
+      throw new Error('post-write verification failed')
+    })
+    _internals.setConfigRestorer(() => {
+      throw new Error('restore failed')
+    })
+
+    await expect(resolveMirroredRuntimeUserHookTrustEntries(resolveArgs(entry))).rejects.toThrow(
+      'failed to restore runtime hook trust'
+    )
+  })
+
+  it('reuses a verified fingerprint but isolates it by managed account home', async () => {
+    const entry: CodexTrustEntry = {
+      sourcePath: join(runtimeHomePath, 'hooks.json'),
+      eventLabel: 'stop',
+      groupIndex: 1,
+      handlerIndex: 0,
+      command: 'user-stop-hook',
+      trustedHash: SYSTEM_HASH
+    }
+    let activeTomlPath = tomlPath
+    let activeEntry = entry
+    const runner = vi.fn(async (request: CodexUserHookTrustRebaseRequest) => {
+      if (request.operation === 'inspect-user-hook-trust') {
+        return inspected(request)
+      }
+      upsertHookTrustEntries(activeTomlPath, [{ ...activeEntry, trustedHash: RUNTIME_HASH }])
+      return { outcome: 'mirrored-granted' as const, entries: [grantFor(activeEntry)] }
+    })
+    _internals.setSessionRunner(runner)
+
+    await resolveMirroredRuntimeUserHookTrustEntries(resolveArgs(entry))
+    await resolveMirroredRuntimeUserHookTrustEntries(resolveArgs(entry))
+    expect(runner).toHaveBeenCalledTimes(2)
+
+    const secondHome = join(tmpDir, 'second-home')
+    const secondToml = join(secondHome, 'config.toml')
+    mkdirSync(secondHome, { recursive: true })
+    writeFileSync(secondToml, 'model = "runtime"\n', 'utf-8')
+    activeTomlPath = secondToml
+    activeEntry = { ...entry, sourcePath: join(secondHome, 'hooks.json') }
+    await resolveMirroredRuntimeUserHookTrustEntries(
+      resolveArgs(activeEntry, secondHome, secondToml)
+    )
+    expect(runner).toHaveBeenCalledTimes(4)
+  })
+
+  it('does not reuse a verified fingerprint without a binary identity', async () => {
+    const entry: CodexTrustEntry = {
+      sourcePath: join(runtimeHomePath, 'hooks.json'),
+      eventLabel: 'stop',
+      groupIndex: 1,
+      handlerIndex: 0,
+      command: 'user-stop-hook',
+      trustedHash: SYSTEM_HASH
+    }
+    _internals.setHostResolver(async () => ({
+      binaryStamp: null,
+      buildRequest: (input) => ({
+        invocation: { command: 'codex', cliPath: null, args: [], timeoutMs: 1_000 },
+        hooksListCwd: input.runtimeHomePath,
+        expectedTrustKeys: input.expectedTrustKeys,
+        managedCommand: input.managedCommand
+      })
+    }))
+    const runner = vi.fn(async (request: CodexUserHookTrustRebaseRequest) => {
+      if (request.operation === 'inspect-user-hook-trust') {
+        return inspected(request)
+      }
+      upsertHookTrustEntries(tomlPath, [{ ...entry, trustedHash: RUNTIME_HASH }])
+      return { outcome: 'mirrored-granted' as const, entries: [grantFor(entry)] }
+    })
+    _internals.setSessionRunner(runner)
+
+    await resolveMirroredRuntimeUserHookTrustEntries(resolveArgs(entry))
+    await resolveMirroredRuntimeUserHookTrustEntries(resolveArgs(entry))
+
+    expect(runner).toHaveBeenCalledTimes(4)
+  })
+
+  it('keeps transient cooldown isolated by account and unsupported cooldown isolated by host', async () => {
+    const entry: CodexTrustEntry = {
+      sourcePath: join(runtimeHomePath, 'hooks.json'),
+      eventLabel: 'stop',
+      groupIndex: 1,
+      handlerIndex: 0,
+      command: 'user-stop-hook',
+      trustedHash: SYSTEM_HASH
+    }
+    let transient = true
+    const runner = vi.fn(async (request: CodexUserHookTrustRebaseRequest) => {
+      if (transient) {
+        transient = false
+        throw new Error('transient')
+      }
+      if (request.operation === 'inspect-user-hook-trust') {
+        return inspected(request)
+      }
+      return { outcome: 'mirrored-granted' as const, entries: [grantFor(entry)] }
+    })
+    _internals.setSessionRunner(runner)
+
+    await resolveMirroredRuntimeUserHookTrustEntries(resolveArgs(entry))
+    await resolveMirroredRuntimeUserHookTrustEntries(resolveArgs(entry))
+    expect(runner).toHaveBeenCalledTimes(1)
+
+    const secondHome = join(tmpDir, 'second-home')
+    const secondToml = join(secondHome, 'config.toml')
+    mkdirSync(secondHome, { recursive: true })
+    writeFileSync(secondToml, 'model = "runtime"\n', 'utf-8')
+    const secondEntry = { ...entry, sourcePath: join(secondHome, 'hooks.json') }
+    await resolveMirroredRuntimeUserHookTrustEntries(
+      resolveArgs(secondEntry, secondHome, secondToml)
+    )
+    expect(runner).toHaveBeenCalledTimes(3)
+
+    _internals.resetState()
+    codexAppServerCapabilityCache.clear()
+    runner.mockImplementation(async () => {
+      throw new CodexAppServerUnsupportedError('method not found')
+    })
+    await resolveMirroredRuntimeUserHookTrustEntries(resolveArgs(entry))
+    await resolveMirroredRuntimeUserHookTrustEntries(
+      resolveArgs(secondEntry, secondHome, secondToml)
+    )
+    expect(runner).toHaveBeenCalledTimes(4)
+
+    await resolveMirroredRuntimeUserHookTrustEntries({
+      ...resolveArgs(secondEntry, secondHome, secondToml),
+      host: { kind: 'wsl', distro: 'Ubuntu', linuxRuntimeHome: '/home/rod/.codex' }
+    })
+    expect(runner).toHaveBeenCalledTimes(5)
   })
 })

--- a/src/main/codex/codex-mirrored-hook-runtime-trust.ts
+++ b/src/main/codex/codex-mirrored-hook-runtime-trust.ts
@@ -2,11 +2,25 @@ import {
   codexAppServerCapabilityCache,
   getCodexAppServerHostKey
 } from './codex-app-server-capability-cache'
-import { runCodexUserHookTrustRebaseSessionSync } from './codex-app-server-grant-bridge'
 import { isCodexAppServerUnsupportedError } from './codex-app-server-session'
 import { CODEX_TRUST_GRANT_TRANSIENT_RETRY_INTERVAL_MS } from './codex-hook-trust-grant'
-import { resolveCodexTrustGrantHost } from './codex-trust-grant-host'
-import type { CodexHookCurrentHashListing } from './codex-user-hook-trust-rebase-client'
+import {
+  resolveCodexTrustGrantHost,
+  type CodexTrustGrantHost,
+  type ResolvedCodexTrustGrantHost
+} from './codex-trust-grant-host'
+import { captureCodexTrustConfig, restoreCodexTrustConfig } from './codex-trust-config-rollback'
+import { runExclusivelyForCodexTrustConfig } from './codex-trust-config-mutation-queue'
+import {
+  getMirroredRuntimeTrustFingerprint,
+  getMirroredRuntimeTrustScopeKey
+} from './codex-mirrored-hook-runtime-trust-cache'
+import {
+  runCodexUserHookTrustRebaseSession,
+  type CodexMirroredHookTrustGrant,
+  type CodexUserHookTrustRebaseRequest,
+  type CodexUserHookTrustRebaseResult
+} from './codex-user-hook-trust-rebase-client'
 import {
   computeTrustKey,
   getHookTrustKeyWriteVariants,
@@ -16,36 +30,39 @@ import {
   type CodexTrustEntry
 } from './config-toml-trust'
 
-export type { CodexHookCurrentHashListing }
+export type { CodexMirroredHookTrustGrant }
 
-type MirroredHookCurrentHashListRunner = (
-  runtimeHomePath: string
-) => readonly CodexHookCurrentHashListing[]
+type MirroredHookTrustSessionRunner = (
+  request: CodexUserHookTrustRebaseRequest
+) => Promise<CodexUserHookTrustRebaseResult>
 
-let listRunner: MirroredHookCurrentHashListRunner | null = null
-const listRetryAfterByHost = new Map<string, number>()
+type VerifiedRuntimeTrust = {
+  fingerprint: string
+  grants: readonly CodexMirroredHookTrustGrant[]
+}
+
+class MirroredRuntimeTrustRollbackError extends Error {}
+
+let runSession: MirroredHookTrustSessionRunner = runCodexUserHookTrustRebaseSession
+let resolveHost = resolveCodexTrustGrantHost
+let restoreConfig = restoreCodexTrustConfig
+const retryAfterByScope = new Map<string, number>()
+const verifiedRuntimeTrustByScope = new Map<string, VerifiedRuntimeTrust>()
 
 export function stampMirroredRuntimeTrustWithCurrentHashes(
   entries: readonly CodexTrustEntry[],
-  listings: readonly CodexHookCurrentHashListing[]
+  grants: readonly CodexMirroredHookTrustGrant[]
 ): CodexTrustEntry[] {
-  const listingByKey = new Map<string, CodexHookCurrentHashListing>()
-  for (const listing of listings) {
-    const normalizedKey = normalizeHookTrustKeyForLookup(listing.key)
-    if (!listingByKey.has(normalizedKey)) {
-      listingByKey.set(normalizedKey, listing)
+  const grantByKey = new Map<string, CodexMirroredHookTrustGrant>()
+  for (const grant of grants) {
+    const normalizedKey = normalizeHookTrustKeyForLookup(grant.key)
+    if (!grantByKey.has(normalizedKey)) {
+      grantByKey.set(normalizedKey, grant)
     }
   }
   return entries.map((entry) => {
-    const listing = listingByKey.get(normalizeHookTrustKeyForLookup(computeTrustKey(entry)))
-    if (!listing) {
-      return entry
-    }
-    // Why: command:null is an incomplete hooks/list record, not a match.
-    if (listing.command !== entry.command) {
-      return entry
-    }
-    return { ...entry, trustedHash: listing.currentHash }
+    const grant = grantByKey.get(normalizeHookTrustKeyForLookup(computeTrustKey(entry)))
+    return grant?.command === entry.command ? { ...entry, trustedHash: grant.currentHash } : entry
   })
 }
 
@@ -62,19 +79,169 @@ export function clearHookTrustKeySeparatorVariants(
   )
 }
 
-export function resolveMirroredRuntimeUserHookTrustEntries(args: {
+export async function resolveMirroredRuntimeUserHookTrustEntries(args: {
   entries: readonly CodexTrustEntry[]
+  systemEntries: readonly CodexTrustEntry[]
+  systemHomePath: string
   runtimeHomePath: string
   tomlPath: string
-}): CodexTrustEntry[] {
+  host?: CodexTrustGrantHost
+}): Promise<CodexTrustEntry[]> {
   if (args.entries.length === 0) {
     return []
   }
-  const listings = tryListMirroredHookCurrentHashes(args.runtimeHomePath)
-  if (listings) {
-    return stampMirroredRuntimeTrustWithCurrentHashes(args.entries, listings)
+  if (args.systemEntries.length !== args.entries.length) {
+    return preserveExistingRuntimeHashes(args.entries, args.tomlPath)
   }
-  return preserveExistingRuntimeHashes(args.entries, args.tomlPath)
+  const host = args.host ?? { kind: 'native' as const }
+  const hostKey = getCodexAppServerHostKey(host)
+  const scopeKey = getMirroredRuntimeTrustScopeKey(hostKey, args.runtimeHomePath)
+  if (isCoolingDown(scopeKey)) {
+    return preserveExistingRuntimeHashes(args.entries, args.tomlPath)
+  }
+  let resolvedHost: ResolvedCodexTrustGrantHost
+  try {
+    resolvedHost = await resolveHost(host)
+  } catch {
+    startRetryCooldown(scopeKey)
+    return preserveExistingRuntimeHashes(args.entries, args.tomlPath)
+  }
+  return runExclusivelyForCodexTrustConfig(args.tomlPath, async () => {
+    const fingerprint = getMirroredRuntimeTrustFingerprint(args, resolvedHost.binaryStamp)
+    const cached = verifiedRuntimeTrustByScope.get(scopeKey)
+    if (resolvedHost.binaryStamp && cached?.fingerprint === fingerprint) {
+      return stampMirroredRuntimeTrustWithCurrentHashes(
+        preserveExistingRuntimeHashes(args.entries, args.tomlPath),
+        cached.grants
+      )
+    }
+    verifiedRuntimeTrustByScope.delete(scopeKey)
+    if (isCoolingDown(scopeKey)) {
+      return preserveExistingRuntimeHashes(args.entries, args.tomlPath)
+    }
+    try {
+      return await codexAppServerCapabilityCache.runWithFallback(
+        hostKey,
+        () => grantAndVerifyMirroredRuntimeTrust(args, resolvedHost, scopeKey),
+        async () => preserveExistingRuntimeHashes(args.entries, args.tomlPath),
+        isCodexAppServerUnsupportedError
+      )
+    } catch (error) {
+      if (error instanceof MirroredRuntimeTrustRollbackError) {
+        throw error
+      }
+      startRetryCooldown(scopeKey)
+      return preserveExistingRuntimeHashes(args.entries, args.tomlPath)
+    }
+  })
+}
+
+async function grantAndVerifyMirroredRuntimeTrust(
+  args: {
+    entries: readonly CodexTrustEntry[]
+    systemEntries: readonly CodexTrustEntry[]
+    systemHomePath: string
+    runtimeHomePath: string
+    tomlPath: string
+  },
+  resolvedHost: ResolvedCodexTrustGrantHost,
+  scopeKey: string
+): Promise<CodexTrustEntry[]> {
+  const snapshot = captureCodexTrustConfig(args.tomlPath)
+  try {
+    const approvedIndexes = await inspectApprovedSystemHooks(args, resolvedHost)
+    const fallbackEntries = preserveExistingRuntimeHashes(args.entries, args.tomlPath)
+    if (approvedIndexes.length === 0) {
+      return fallbackEntries
+    }
+    const approvedEntries = approvedIndexes.map((index) => args.entries[index]!)
+    clearHookTrustKeySeparatorVariants(
+      args.tomlPath,
+      approvedEntries.map((entry) => computeTrustKey(entry))
+    )
+    const request = resolvedHost.buildRequest({
+      runtimeHomePath: args.runtimeHomePath,
+      managedCommand: '',
+      expectedTrustKeys: []
+    })
+    const result = await runSession({
+      operation: 'grant-mirrored-runtime-hook-trust',
+      invocation: request.invocation,
+      hooksListCwd: request.hooksListCwd,
+      targets: approvedEntries.map((entry) => ({
+        key: computeTrustKey(entry),
+        command: entry.command,
+        enabled: entry.enabled !== false
+      }))
+    })
+    if (result.outcome !== 'mirrored-granted') {
+      throw new Error('unexpected mirrored hook trust grant result')
+    }
+    const grantsByKey = new Map(
+      result.entries.map((entry) => [normalizeHookTrustKeyForLookup(entry.key), entry.command])
+    )
+    if (
+      grantsByKey.size !== approvedEntries.length ||
+      approvedEntries.some(
+        (entry) =>
+          grantsByKey.get(normalizeHookTrustKeyForLookup(computeTrustKey(entry))) !== entry.command
+      )
+    ) {
+      throw new Error('verified mirrored hook grant did not cover every approved entry')
+    }
+    const stamped = stampMirroredRuntimeTrustWithCurrentHashes(fallbackEntries, result.entries)
+    retryAfterByScope.delete(scopeKey)
+    if (resolvedHost.binaryStamp) {
+      verifiedRuntimeTrustByScope.set(scopeKey, {
+        fingerprint: getMirroredRuntimeTrustFingerprint(args, resolvedHost.binaryStamp),
+        grants: result.entries
+      })
+    }
+    return stamped
+  } catch (error) {
+    verifiedRuntimeTrustByScope.delete(scopeKey)
+    try {
+      restoreConfig(args.tomlPath, snapshot)
+    } catch (rollbackError) {
+      throw new MirroredRuntimeTrustRollbackError(
+        'failed to restore runtime hook trust after mirrored grant failure',
+        { cause: new AggregateError([error, rollbackError], 'grant and rollback both failed') }
+      )
+    }
+    throw error
+  }
+}
+
+async function inspectApprovedSystemHooks(
+  args: {
+    entries: readonly CodexTrustEntry[]
+    systemEntries: readonly CodexTrustEntry[]
+    systemHomePath: string
+  },
+  resolvedHost: ResolvedCodexTrustGrantHost
+): Promise<number[]> {
+  const request = resolvedHost.buildRequest({
+    runtimeHomePath: args.systemHomePath,
+    managedCommand: '',
+    expectedTrustKeys: [],
+    useDefaultCodexHome: true
+  })
+  const result = await runSession({
+    operation: 'inspect-user-hook-trust',
+    invocation: request.invocation,
+    hooksListCwd: request.hooksListCwd,
+    moves: args.systemEntries.map((entry, index) => ({
+      oldKey: computeTrustKey(entry),
+      newKey: computeTrustKey(args.entries[index]!),
+      command: entry.command
+    }))
+  })
+  if (result.outcome !== 'inspected' || result.moves.length !== args.entries.length) {
+    throw new Error('unexpected mirrored system hook trust inspection result')
+  }
+  return result.moves.flatMap((move, index) =>
+    move.currentHash === args.systemEntries[index]?.trustedHash ? [index] : []
+  )
 }
 
 function preserveExistingRuntimeHashes(
@@ -84,60 +251,39 @@ function preserveExistingRuntimeHashes(
   const existing = readHookTrustEntries(tomlPath)
   return entries.map((entry) => {
     const trustedHash = existing.get(computeTrustKey(entry))?.trustedHash
+    // Why: a stale incoming hash preserves the old safe fallback; Codex trusts it only if it matches runtime currentHash.
     return trustedHash ? { ...entry, trustedHash } : entry
   })
 }
 
-function tryListMirroredHookCurrentHashes(
-  runtimeHomePath: string
-): readonly CodexHookCurrentHashListing[] | null {
-  if (listRunner) {
-    return listRunner(runtimeHomePath)
+function isCoolingDown(scopeKey: string): boolean {
+  const retryAfter = retryAfterByScope.get(scopeKey)
+  if (retryAfter === undefined) {
+    return false
   }
-  const hostKey = getCodexAppServerHostKey({ kind: 'native' })
-  if (!codexAppServerCapabilityCache.shouldTry(hostKey)) {
-    return null
+  if (Date.now() < retryAfter) {
+    return true
   }
-  const retryAfterMs = listRetryAfterByHost.get(hostKey)
-  if (retryAfterMs !== undefined) {
-    if (Date.now() < retryAfterMs) {
-      return null
-    }
-    listRetryAfterByHost.delete(hostKey)
-  }
-  try {
-    const request = resolveCodexTrustGrantHost({ kind: 'native' }).buildRequest({
-      runtimeHomePath,
-      managedCommand: '',
-      expectedTrustKeys: []
-    })
-    const result = runCodexUserHookTrustRebaseSessionSync({
-      operation: 'list-hook-current-hashes',
-      invocation: request.invocation,
-      hooksListCwd: request.hooksListCwd
-    })
-    if (result.outcome !== 'listed') {
-      return null
-    }
-    listRetryAfterByHost.delete(hostKey)
-    codexAppServerCapabilityCache.rememberSupported(hostKey)
-    return result.listings
-  } catch (error) {
-    if (isCodexAppServerUnsupportedError(error)) {
-      listRetryAfterByHost.delete(hostKey)
-      codexAppServerCapabilityCache.rememberUnsupported(hostKey)
-      return null
-    }
-    listRetryAfterByHost.set(hostKey, Date.now() + CODEX_TRUST_GRANT_TRANSIENT_RETRY_INTERVAL_MS)
-    return null
-  }
+  retryAfterByScope.delete(scopeKey)
+  return false
+}
+
+function startRetryCooldown(scopeKey: string): void {
+  retryAfterByScope.set(scopeKey, Date.now() + CODEX_TRUST_GRANT_TRANSIENT_RETRY_INTERVAL_MS)
 }
 
 export const _internals = {
-  setListRunner(runner: MirroredHookCurrentHashListRunner | null): void {
-    listRunner = runner
+  setSessionRunner(runner: MirroredHookTrustSessionRunner | null): void {
+    runSession = runner ?? runCodexUserHookTrustRebaseSession
   },
-  resetRetryState(): void {
-    listRetryAfterByHost.clear()
+  setHostResolver(resolver: typeof resolveCodexTrustGrantHost | null): void {
+    resolveHost = resolver ?? resolveCodexTrustGrantHost
+  },
+  setConfigRestorer(restorer: typeof restoreCodexTrustConfig | null): void {
+    restoreConfig = restorer ?? restoreCodexTrustConfig
+  },
+  resetState(): void {
+    retryAfterByScope.clear()
+    verifiedRuntimeTrustByScope.clear()
   }
 }

--- a/src/main/codex/codex-mirrored-hook-runtime-trust.ts
+++ b/src/main/codex/codex-mirrored-hook-runtime-trust.ts
@@ -1,0 +1,142 @@
+import {
+  codexAppServerCapabilityCache,
+  getCodexAppServerHostKey
+} from './codex-app-server-capability-cache'
+import { runCodexUserHookTrustRebaseSessionSync } from './codex-app-server-grant-bridge'
+import { isCodexAppServerUnsupportedError } from './codex-app-server-session'
+import { CODEX_TRUST_GRANT_TRANSIENT_RETRY_INTERVAL_MS } from './codex-hook-trust-grant'
+import { resolveCodexTrustGrantHost } from './codex-trust-grant-host'
+import type { CodexHookCurrentHashListing } from './codex-user-hook-trust-rebase-client'
+import {
+  computeTrustKey,
+  getHookTrustKeyWriteVariants,
+  normalizeHookTrustKeyForLookup,
+  readHookTrustEntries,
+  removeHookTrustEntries,
+  type CodexTrustEntry
+} from './config-toml-trust'
+
+export type { CodexHookCurrentHashListing }
+
+type MirroredHookCurrentHashListRunner = (
+  runtimeHomePath: string
+) => readonly CodexHookCurrentHashListing[]
+
+let listRunner: MirroredHookCurrentHashListRunner | null = null
+const listRetryAfterByHost = new Map<string, number>()
+
+export function stampMirroredRuntimeTrustWithCurrentHashes(
+  entries: readonly CodexTrustEntry[],
+  listings: readonly CodexHookCurrentHashListing[]
+): CodexTrustEntry[] {
+  const listingByKey = new Map<string, CodexHookCurrentHashListing>()
+  for (const listing of listings) {
+    const normalizedKey = normalizeHookTrustKeyForLookup(listing.key)
+    if (!listingByKey.has(normalizedKey)) {
+      listingByKey.set(normalizedKey, listing)
+    }
+  }
+  return entries.map((entry) => {
+    const listing = listingByKey.get(normalizeHookTrustKeyForLookup(computeTrustKey(entry)))
+    if (!listing) {
+      return entry
+    }
+    if (listing.command !== null && listing.command !== entry.command) {
+      return entry
+    }
+    return { ...entry, trustedHash: listing.currentHash }
+  })
+}
+
+export function clearHookTrustKeySeparatorVariants(
+  tomlPath: string,
+  keys: readonly string[]
+): void {
+  if (keys.length === 0) {
+    return
+  }
+  removeHookTrustEntries(
+    tomlPath,
+    keys.flatMap((key) => getHookTrustKeyWriteVariants(key))
+  )
+}
+
+export function resolveMirroredRuntimeUserHookTrustEntries(args: {
+  entries: readonly CodexTrustEntry[]
+  runtimeHomePath: string
+  tomlPath: string
+}): CodexTrustEntry[] {
+  if (args.entries.length === 0) {
+    return []
+  }
+  const listings = tryListMirroredHookCurrentHashes(args.runtimeHomePath)
+  if (listings) {
+    return stampMirroredRuntimeTrustWithCurrentHashes(args.entries, listings)
+  }
+  return preserveExistingRuntimeHashes(args.entries, args.tomlPath)
+}
+
+function preserveExistingRuntimeHashes(
+  entries: readonly CodexTrustEntry[],
+  tomlPath: string
+): CodexTrustEntry[] {
+  const existing = readHookTrustEntries(tomlPath)
+  return entries.map((entry) => {
+    const trustedHash = existing.get(computeTrustKey(entry))?.trustedHash
+    return trustedHash ? { ...entry, trustedHash } : entry
+  })
+}
+
+function tryListMirroredHookCurrentHashes(
+  runtimeHomePath: string
+): readonly CodexHookCurrentHashListing[] | null {
+  if (listRunner) {
+    return listRunner(runtimeHomePath)
+  }
+  const hostKey = getCodexAppServerHostKey({ kind: 'native' })
+  if (!codexAppServerCapabilityCache.shouldTry(hostKey)) {
+    return null
+  }
+  const retryAfterMs = listRetryAfterByHost.get(hostKey)
+  if (retryAfterMs !== undefined) {
+    if (Date.now() < retryAfterMs) {
+      return null
+    }
+    listRetryAfterByHost.delete(hostKey)
+  }
+  try {
+    const request = resolveCodexTrustGrantHost({ kind: 'native' }).buildRequest({
+      runtimeHomePath,
+      managedCommand: '',
+      expectedTrustKeys: []
+    })
+    const result = runCodexUserHookTrustRebaseSessionSync({
+      operation: 'list-hook-current-hashes',
+      invocation: request.invocation,
+      hooksListCwd: request.hooksListCwd
+    })
+    if (result.outcome !== 'listed') {
+      return null
+    }
+    listRetryAfterByHost.delete(hostKey)
+    codexAppServerCapabilityCache.rememberSupported(hostKey)
+    return result.listings
+  } catch (error) {
+    if (isCodexAppServerUnsupportedError(error)) {
+      listRetryAfterByHost.delete(hostKey)
+      codexAppServerCapabilityCache.rememberUnsupported(hostKey)
+      return null
+    }
+    listRetryAfterByHost.set(hostKey, Date.now() + CODEX_TRUST_GRANT_TRANSIENT_RETRY_INTERVAL_MS)
+    return null
+  }
+}
+
+export const _internals = {
+  setListRunner(runner: MirroredHookCurrentHashListRunner | null): void {
+    listRunner = runner
+  },
+  resetRetryState(): void {
+    listRetryAfterByHost.clear()
+  }
+}

--- a/src/main/codex/codex-mirrored-hook-runtime-trust.ts
+++ b/src/main/codex/codex-mirrored-hook-runtime-trust.ts
@@ -41,7 +41,8 @@ export function stampMirroredRuntimeTrustWithCurrentHashes(
     if (!listing) {
       return entry
     }
-    if (listing.command !== null && listing.command !== entry.command) {
+    // Why: command:null is an incomplete hooks/list record, not a match.
+    if (listing.command !== entry.command) {
       return entry
     }
     return { ...entry, trustedHash: listing.currentHash }

--- a/src/main/codex/codex-mirrored-hook-runtime-trust.ts
+++ b/src/main/codex/codex-mirrored-hook-runtime-trust.ts
@@ -152,6 +152,13 @@ async function grantAndVerifyMirroredRuntimeTrust(
     const approvedIndexes = await inspectApprovedSystemHooks(args, resolvedHost)
     const fallbackEntries = preserveExistingRuntimeHashes(args.entries, args.tomlPath)
     if (approvedIndexes.length === 0) {
+      retryAfterByScope.delete(scopeKey)
+      if (resolvedHost.binaryStamp) {
+        verifiedRuntimeTrustByScope.set(scopeKey, {
+          fingerprint: getMirroredRuntimeTrustFingerprint(args, resolvedHost.binaryStamp),
+          grants: []
+        })
+      }
       return fallbackEntries
     }
     const approvedEntries = approvedIndexes.map((index) => args.entries[index]!)

--- a/src/main/codex/codex-trust-grant-main-thread-boundary.test.ts
+++ b/src/main/codex/codex-trust-grant-main-thread-boundary.test.ts
@@ -54,6 +54,8 @@ describe('codex trust grant main-thread boundary', () => {
     expect(grant).toContain('export async function grantManagedCodexHookTrust(')
     const host = readFileSync(join(CODEX_DIR, 'codex-trust-grant-host.ts'), 'utf8')
     expect(host).toContain('export async function resolveCodexTrustGrantHost(')
+    const mirrored = readFileSync(join(CODEX_DIR, 'codex-mirrored-hook-runtime-trust.ts'), 'utf8')
+    expect(mirrored).toContain('export async function resolveMirroredRuntimeUserHookTrustEntries(')
     const realHome = readFileSync(join(CODEX_DIR, 'codex-real-home-hook-install.ts'), 'utf8')
     expect(realHome).toContain('}): Promise<RealHomeCodexHookLane> {')
   })

--- a/src/main/codex/codex-user-hook-trust-rebase-client.test.ts
+++ b/src/main/codex/codex-user-hook-trust-rebase-client.test.ts
@@ -142,6 +142,48 @@ describe('Codex user hook trust rebase RPCs', () => {
     expect(edits).toContainEqual(expect.objectContaining({ value: { enabled: false } }))
   })
 
+  it('clears both Windows separator variants when repairing moved trust', async () => {
+    const oldBackslashKey = 'C:\\runtime\\hooks.json:stop:1:0'
+    const oldSlashKey = 'C:/runtime/hooks.json:stop:1:0'
+    const newBackslashKey = 'C:\\runtime\\hooks.json:stop:0:0'
+    const newSlashKey = 'C:/runtime/hooks.json:stop:0:0'
+    const postMutation = listing(newBackslashKey, 'user-stop-hook', 'untrusted')
+    const verified = listing(newBackslashKey, 'user-stop-hook', 'trusted')
+    requestRpcMock
+      .mockResolvedValueOnce(listResult([postMutation, { ...postMutation, key: newSlashKey }]))
+      .mockResolvedValueOnce({ status: 'ok' })
+      .mockResolvedValueOnce(listResult([verified, { ...verified, key: newSlashKey }]))
+
+    await runCodexUserHookTrustRebaseSession({
+      operation: 'repair-user-hook-trust',
+      invocation,
+      hooksListCwd: 'C:\\runtime',
+      moves: [
+        {
+          oldKey: oldBackslashKey,
+          newKey: newBackslashKey,
+          command: 'user-stop-hook',
+          reportedOldKey: oldBackslashKey,
+          wasTrusted: true,
+          enabled: true
+        }
+      ]
+    })
+
+    const edits = (
+      requestRpcMock.mock.calls[1]![1] as {
+        edits: { keyPath: string; value: unknown }[]
+      }
+    ).edits
+    const clearedKeyPaths = edits.filter((edit) => edit.value === null).map((edit) => edit.keyPath)
+    expect(clearedKeyPaths).toEqual([
+      'hooks.state."C:\\\\runtime\\\\hooks.json:stop:1:0"',
+      `hooks.state."${oldSlashKey}"`,
+      'hooks.state."C:\\\\runtime\\\\hooks.json:stop:0:0"',
+      `hooks.state."${newSlashKey}"`
+    ])
+  })
+
   it('writes runtime currentHash for approved mirrored hooks and verifies by re-list', async () => {
     const preToolKey = '/runtime/hooks.json:pre_tool_use:1:0'
     const postToolKey = '/runtime/hooks.json:post_tool_use:1:0'

--- a/src/main/codex/codex-user-hook-trust-rebase-client.test.ts
+++ b/src/main/codex/codex-user-hook-trust-rebase-client.test.ts
@@ -52,11 +52,41 @@ describe('Codex user hook trust rebase RPCs', () => {
     expect(result).toEqual({
       outcome: 'inspected',
       moves: [
-        expect.objectContaining({ command: 'trusted-user', wasTrusted: true, enabled: true }),
-        expect.objectContaining({ command: 'untrusted-user', wasTrusted: false, enabled: false })
+        expect.objectContaining({
+          command: 'trusted-user',
+          currentHash: `sha256:${oldTrusted}`,
+          wasTrusted: true,
+          enabled: true
+        }),
+        expect.objectContaining({
+          command: 'untrusted-user',
+          currentHash: `sha256:${oldUntrusted}`,
+          wasTrusted: false,
+          enabled: false
+        })
       ]
     })
     expect(requestRpcMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects conflicting Windows variants during system trust inspection', async () => {
+    const backslashKey = 'C:\\system\\hooks.json:stop:0:0'
+    const slashKey = 'C:/system/hooks.json:stop:0:0'
+    requestRpcMock.mockResolvedValueOnce(
+      listResult([
+        listing(backslashKey, 'user-stop-hook', 'trusted'),
+        listing(slashKey, 'user-stop-hook', 'modified')
+      ])
+    )
+
+    await expect(
+      runCodexUserHookTrustRebaseSession({
+        operation: 'inspect-user-hook-trust',
+        invocation,
+        hooksListCwd: 'C:\\system',
+        moves: [{ oldKey: backslashKey, newKey: newTrusted, command: 'user-stop-hook' }]
+      })
+    ).rejects.toThrow('ambiguous hook key variants')
   })
 
   it('clears shifted states, re-grants only prior trust, and verifies by re-list', async () => {
@@ -112,36 +142,92 @@ describe('Codex user hook trust rebase RPCs', () => {
     expect(edits).toContainEqual(expect.objectContaining({ value: { enabled: false } }))
   })
 
-  it('lists currentHash for each reported hook without writing config', async () => {
-    requestRpcMock.mockResolvedValueOnce(
-      listResult([
-        listing('/runtime/hooks.json:pre_tool_use:1:0', 'user-pre-tool-hook', 'modified'),
-        listing('/runtime/hooks.json:post_tool_use:1:0', 'user-post-tool-hook', 'trusted')
-      ])
-    )
+  it('writes runtime currentHash for approved mirrored hooks and verifies by re-list', async () => {
+    const preToolKey = '/runtime/hooks.json:pre_tool_use:1:0'
+    const postToolKey = '/runtime/hooks.json:post_tool_use:1:0'
+    requestRpcMock
+      .mockResolvedValueOnce(
+        listResult([
+          listing(preToolKey, 'user-pre-tool-hook', 'modified'),
+          listing(postToolKey, 'user-post-tool-hook', 'modified', false)
+        ])
+      )
+      .mockResolvedValueOnce({ status: 'ok' })
+      .mockResolvedValueOnce(
+        listResult([
+          listing(preToolKey, 'user-pre-tool-hook', 'trusted'),
+          listing(postToolKey, 'user-post-tool-hook', 'trusted', false)
+        ])
+      )
 
     await expect(
       runCodexUserHookTrustRebaseSession({
-        operation: 'list-hook-current-hashes',
+        operation: 'grant-mirrored-runtime-hook-trust',
         invocation,
-        hooksListCwd: '/tmp'
+        hooksListCwd: '/tmp',
+        targets: [
+          { key: preToolKey, command: 'user-pre-tool-hook', enabled: true },
+          { key: postToolKey, command: 'user-post-tool-hook', enabled: false }
+        ]
       })
     ).resolves.toEqual({
-      outcome: 'listed',
-      listings: [
+      outcome: 'mirrored-granted',
+      entries: [
         {
-          key: '/runtime/hooks.json:pre_tool_use:1:0',
+          key: preToolKey,
           command: 'user-pre-tool-hook',
-          currentHash: 'sha256:/runtime/hooks.json:pre_tool_use:1:0'
+          currentHash: `sha256:${preToolKey}`
         },
         {
-          key: '/runtime/hooks.json:post_tool_use:1:0',
+          key: postToolKey,
           command: 'user-post-tool-hook',
-          currentHash: 'sha256:/runtime/hooks.json:post_tool_use:1:0'
+          currentHash: `sha256:${postToolKey}`
         }
       ]
     })
-    expect(requestRpcMock).toHaveBeenCalledTimes(1)
-    expect(requestRpcMock).toHaveBeenCalledWith('hooks/list', { cwds: ['/tmp'] })
+    expect(requestRpcMock).toHaveBeenCalledTimes(3)
+    const batch = requestRpcMock.mock.calls[1]
+    expect(batch?.[0]).toBe('config/batchWrite')
+    expect(batch).toBeDefined()
+    const edits = (batch![1] as { edits: { value: unknown }[] }).edits
+    expect(edits).toContainEqual(
+      expect.objectContaining({
+        value: { trusted_hash: `sha256:${preToolKey}` }
+      })
+    )
+    expect(edits).toContainEqual(
+      expect.objectContaining({
+        value: { trusted_hash: `sha256:${postToolKey}`, enabled: false }
+      })
+    )
+  })
+
+  it('accepts equivalent Windows separator variants reported by hooks/list', async () => {
+    const backslashKey = 'C:\\runtime\\hooks.json:pre_tool_use:1:0'
+    const slashKey = 'C:/runtime/hooks.json:pre_tool_use:1:0'
+    const before = listing(backslashKey, 'user-pre-tool-hook', 'modified')
+    const after = listing(backslashKey, 'user-pre-tool-hook', 'trusted')
+    requestRpcMock
+      .mockResolvedValueOnce(listResult([before, { ...before, key: slashKey }]))
+      .mockResolvedValueOnce({ status: 'ok' })
+      .mockResolvedValueOnce(listResult([after, { ...after, key: slashKey }]))
+
+    await expect(
+      runCodexUserHookTrustRebaseSession({
+        operation: 'grant-mirrored-runtime-hook-trust',
+        invocation,
+        hooksListCwd: 'C:\\runtime',
+        targets: [{ key: backslashKey, command: 'user-pre-tool-hook', enabled: true }]
+      })
+    ).resolves.toEqual({
+      outcome: 'mirrored-granted',
+      entries: [
+        {
+          key: backslashKey,
+          command: 'user-pre-tool-hook',
+          currentHash: before.currentHash
+        }
+      ]
+    })
   })
 })

--- a/src/main/codex/codex-user-hook-trust-rebase-client.test.ts
+++ b/src/main/codex/codex-user-hook-trust-rebase-client.test.ts
@@ -111,4 +111,37 @@ describe('Codex user hook trust rebase RPCs', () => {
     )
     expect(edits).toContainEqual(expect.objectContaining({ value: { enabled: false } }))
   })
+
+  it('lists currentHash for each reported hook without writing config', async () => {
+    requestRpcMock.mockResolvedValueOnce(
+      listResult([
+        listing('/runtime/hooks.json:pre_tool_use:1:0', 'user-pre-tool-hook', 'modified'),
+        listing('/runtime/hooks.json:post_tool_use:1:0', 'user-post-tool-hook', 'trusted')
+      ])
+    )
+
+    await expect(
+      runCodexUserHookTrustRebaseSession({
+        operation: 'list-hook-current-hashes',
+        invocation,
+        hooksListCwd: '/tmp'
+      })
+    ).resolves.toEqual({
+      outcome: 'listed',
+      listings: [
+        {
+          key: '/runtime/hooks.json:pre_tool_use:1:0',
+          command: 'user-pre-tool-hook',
+          currentHash: 'sha256:/runtime/hooks.json:pre_tool_use:1:0'
+        },
+        {
+          key: '/runtime/hooks.json:post_tool_use:1:0',
+          command: 'user-post-tool-hook',
+          currentHash: 'sha256:/runtime/hooks.json:post_tool_use:1:0'
+        }
+      ]
+    })
+    expect(requestRpcMock).toHaveBeenCalledTimes(1)
+    expect(requestRpcMock).toHaveBeenCalledWith('hooks/list', { cwds: ['/tmp'] })
+  })
 })

--- a/src/main/codex/codex-user-hook-trust-rebase-client.ts
+++ b/src/main/codex/codex-user-hook-trust-rebase-client.ts
@@ -52,6 +52,7 @@ export type CodexUserHookTrustMove = {
 
 export type CodexCapturedUserHookTrustMove = CodexUserHookTrustMove & {
   reportedOldKey: string
+  currentHash?: string
   wasTrusted: boolean
   enabled: boolean
 }
@@ -71,25 +72,32 @@ export type CodexUserHookTrustRepairRequest = CodexUserHookTrustRebaseRequestBas
   moves: CodexCapturedUserHookTrustMove[]
 }
 
-export type CodexUserHookCurrentHashListRequest = CodexUserHookTrustRebaseRequestBase & {
-  operation: 'list-hook-current-hashes'
+export type CodexMirroredHookTrustTarget = {
+  key: string
+  command: string
+  enabled: boolean
 }
 
-export type CodexHookCurrentHashListing = {
+export type CodexMirroredHookTrustGrant = {
   key: string
-  command: string | null
+  command: string
   currentHash: string
+}
+
+export type CodexMirroredHookTrustGrantRequest = CodexUserHookTrustRebaseRequestBase & {
+  operation: 'grant-mirrored-runtime-hook-trust'
+  targets: CodexMirroredHookTrustTarget[]
 }
 
 export type CodexUserHookTrustRebaseRequest =
   | CodexUserHookTrustInspectRequest
   | CodexUserHookTrustRepairRequest
-  | CodexUserHookCurrentHashListRequest
+  | CodexMirroredHookTrustGrantRequest
 
 export type CodexUserHookTrustRebaseResult =
   | { outcome: 'inspected'; moves: CodexCapturedUserHookTrustMove[] }
   | { outcome: 'repaired'; repaired: number }
-  | { outcome: 'listed'; listings: CodexHookCurrentHashListing[] }
+  | { outcome: 'mirrored-granted'; entries: CodexMirroredHookTrustGrant[] }
 
 function matchingListings(
   listings: readonly CodexHookListing[],
@@ -99,12 +107,28 @@ function matchingListings(
   const expected = new Map(
     moves.map((move) => [normalizeHookTrustKeyForLookup(move[key]), move.command])
   )
-  return new Map(
-    listings
-      .filter(
-        (listing) => expected.get(normalizeHookTrustKeyForLookup(listing.key)) === listing.command
-      )
-      .map((listing) => [normalizeHookTrustKeyForLookup(listing.key), listing])
+  const matched = new Map<string, CodexHookListing>()
+  for (const listing of listings) {
+    const normalizedKey = normalizeHookTrustKeyForLookup(listing.key)
+    if (expected.get(normalizedKey) !== listing.command) {
+      continue
+    }
+    const existing = matched.get(normalizedKey)
+    if (existing && !hookListingStatesAgree(existing, listing)) {
+      throw new Error('hooks/list reported ambiguous hook key variants')
+    }
+    if (!existing) {
+      matched.set(normalizedKey, listing)
+    }
+  }
+  return matched
+}
+
+function hookListingStatesAgree(left: CodexHookListing, right: CodexHookListing): boolean {
+  return (
+    left.currentHash === right.currentHash &&
+    left.trustStatus === right.trustStatus &&
+    left.enabled === right.enabled
   )
 }
 
@@ -131,6 +155,7 @@ async function inspectUserHookTrust(
         return {
           ...move,
           reportedOldKey: listing.key,
+          currentHash: listing.currentHash,
           wasTrusted: listing.trustStatus === 'trusted',
           enabled: listing.enabled
         }
@@ -208,18 +233,81 @@ async function repairUserHookTrust(
   })
 }
 
-async function listHookCurrentHashes(
-  request: CodexUserHookCurrentHashListRequest
+function matchMirroredHookTargets(
+  listings: readonly CodexHookListing[],
+  targets: readonly CodexMirroredHookTrustTarget[]
+): Map<string, CodexHookListing> {
+  const expected = new Map(
+    targets.map((target) => [normalizeHookTrustKeyForLookup(target.key), target.command])
+  )
+  if (expected.size !== targets.length) {
+    throw new Error('mirrored hook trust request contains duplicate normalized keys')
+  }
+  const matched = new Map<string, CodexHookListing>()
+  for (const listing of listings) {
+    const normalizedKey = normalizeHookTrustKeyForLookup(listing.key)
+    if (expected.get(normalizedKey) !== listing.command) {
+      continue
+    }
+    const existing = matched.get(normalizedKey)
+    if (existing && !hookListingStatesAgree(existing, listing)) {
+      throw new Error('hooks/list reported ambiguous mirrored hook key variants')
+    }
+    if (!existing) {
+      matched.set(normalizedKey, listing)
+    }
+  }
+  if (matched.size !== targets.length) {
+    throw new Error(
+      `hooks/list matched ${matched.size} of ${targets.length} approved mirrored hooks`
+    )
+  }
+  return matched
+}
+
+async function grantMirroredRuntimeHookTrust(
+  request: CodexMirroredHookTrustGrantRequest
 ): Promise<CodexUserHookTrustRebaseResult> {
   return runCodexAppServerSession(request.invocation, async ({ request: requestRpc }) => {
-    const result = await requestRpc('hooks/list', { cwds: [request.hooksListCwd] })
+    const listed = await requestRpc('hooks/list', { cwds: [request.hooksListCwd] })
+    const byKey = matchMirroredHookTargets(collectCodexHookListings(listed), request.targets)
+    const edits = request.targets.map((target) => {
+      const listing = byKey.get(normalizeHookTrustKeyForLookup(target.key))!
+      return {
+        keyPath: quotedKeyPath(listing.key),
+        value: {
+          trusted_hash: listing.currentHash,
+          ...(target.enabled ? {} : { enabled: false })
+        },
+        mergeStrategy: 'replace' as const
+      }
+    })
+    await requestRpc('config/batchWrite', { edits, reloadUserConfig: true })
+
+    const verified = await requestRpc('hooks/list', { cwds: [request.hooksListCwd] })
+    const verifiedByKey = matchMirroredHookTargets(
+      collectCodexHookListings(verified),
+      request.targets
+    )
+    const invalid = request.targets.find((target) => {
+      const normalizedKey = normalizeHookTrustKeyForLookup(target.key)
+      const before = byKey.get(normalizedKey)!
+      const after = verifiedByKey.get(normalizedKey)!
+      return (
+        after.currentHash !== before.currentHash ||
+        after.trustStatus !== 'trusted' ||
+        after.enabled !== target.enabled
+      )
+    })
+    if (invalid) {
+      throw new Error('post-write hooks/list verification failed for mirrored hook trust')
+    }
     return {
-      outcome: 'listed' as const,
-      listings: collectCodexHookListings(result).map((listing) => ({
-        key: listing.key,
-        command: listing.command,
-        currentHash: listing.currentHash
-      }))
+      outcome: 'mirrored-granted',
+      entries: request.targets.map((target) => {
+        const listing = verifiedByKey.get(normalizeHookTrustKeyForLookup(target.key))!
+        return { key: listing.key, command: target.command, currentHash: listing.currentHash }
+      })
     }
   })
 }
@@ -233,5 +321,5 @@ export function runCodexUserHookTrustRebaseSession(
   if (request.operation === 'repair-user-hook-trust') {
     return repairUserHookTrust(request)
   }
-  return listHookCurrentHashes(request)
+  return grantMirroredRuntimeHookTrust(request)
 }

--- a/src/main/codex/codex-user-hook-trust-rebase-client.ts
+++ b/src/main/codex/codex-user-hook-trust-rebase-client.ts
@@ -71,13 +71,25 @@ export type CodexUserHookTrustRepairRequest = CodexUserHookTrustRebaseRequestBas
   moves: CodexCapturedUserHookTrustMove[]
 }
 
+export type CodexUserHookCurrentHashListRequest = CodexUserHookTrustRebaseRequestBase & {
+  operation: 'list-hook-current-hashes'
+}
+
+export type CodexHookCurrentHashListing = {
+  key: string
+  command: string | null
+  currentHash: string
+}
+
 export type CodexUserHookTrustRebaseRequest =
   | CodexUserHookTrustInspectRequest
   | CodexUserHookTrustRepairRequest
+  | CodexUserHookCurrentHashListRequest
 
 export type CodexUserHookTrustRebaseResult =
   | { outcome: 'inspected'; moves: CodexCapturedUserHookTrustMove[] }
   | { outcome: 'repaired'; repaired: number }
+  | { outcome: 'listed'; listings: CodexHookCurrentHashListing[] }
 
 function matchingListings(
   listings: readonly CodexHookListing[],
@@ -196,10 +208,30 @@ async function repairUserHookTrust(
   })
 }
 
+async function listHookCurrentHashes(
+  request: CodexUserHookCurrentHashListRequest
+): Promise<CodexUserHookTrustRebaseResult> {
+  return runCodexAppServerSession(request.invocation, async ({ request: requestRpc }) => {
+    const result = await requestRpc('hooks/list', { cwds: [request.hooksListCwd] })
+    return {
+      outcome: 'listed' as const,
+      listings: collectCodexHookListings(result).map((listing) => ({
+        key: listing.key,
+        command: listing.command,
+        currentHash: listing.currentHash
+      }))
+    }
+  })
+}
+
 export function runCodexUserHookTrustRebaseSession(
   request: CodexUserHookTrustRebaseRequest
 ): Promise<CodexUserHookTrustRebaseResult> {
-  return request.operation === 'inspect-user-hook-trust'
-    ? inspectUserHookTrust(request)
-    : repairUserHookTrust(request)
+  if (request.operation === 'inspect-user-hook-trust') {
+    return inspectUserHookTrust(request)
+  }
+  if (request.operation === 'repair-user-hook-trust') {
+    return repairUserHookTrust(request)
+  }
+  return listHookCurrentHashes(request)
 }

--- a/src/main/codex/codex-user-hook-trust-rebase-client.ts
+++ b/src/main/codex/codex-user-hook-trust-rebase-client.ts
@@ -1,5 +1,5 @@
 import { runCodexAppServerSession, type CodexAppServerInvocation } from './codex-app-server-session'
-import { normalizeHookTrustKeyForLookup } from './config-toml-trust'
+import { getHookTrustKeyWriteVariants, normalizeHookTrustKeyForLookup } from './config-toml-trust'
 
 type CodexHookListing = {
   key: string
@@ -176,10 +176,9 @@ async function repairUserHookTrust(
       )
     }
 
-    const keysToClear = new Set([
-      ...request.moves.map((move) => move.reportedOldKey),
-      ...Array.from(byNewKey.values(), (listing) => listing.key)
-    ])
+    const oldKeys = request.moves.map((move) => move.reportedOldKey)
+    const newKeys = Array.from(byNewKey.values(), (listing) => listing.key)
+    const keysToClear = new Set([...oldKeys, ...newKeys].flatMap(getHookTrustKeyWriteVariants))
     const edits: { keyPath: string; value: unknown; mergeStrategy: 'replace' }[] = Array.from(
       keysToClear,
       (key) => ({

--- a/src/main/codex/codex-user-hook-trust-rebase.ts
+++ b/src/main/codex/codex-user-hook-trust-rebase.ts
@@ -17,7 +17,8 @@ import {
 import { runExclusivelyForCodexTrustConfig } from './codex-trust-config-mutation-queue'
 import { computeTrustKey, type CodexTrustEntry } from './config-toml-trust'
 import type {
-  CodexUserHookTrustRebaseRequest,
+  CodexUserHookTrustInspectRequest,
+  CodexUserHookTrustRepairRequest,
   CodexUserHookTrustRebaseResult,
   CodexUserHookTrustMove
 } from './codex-user-hook-trust-rebase-client'
@@ -25,7 +26,7 @@ import type {
 type HooksByEvent = Record<string, HookDefinition[]>
 
 type RebaseSessionRunner = (
-  request: CodexUserHookTrustRebaseRequest
+  request: CodexUserHookTrustInspectRequest | CodexUserHookTrustRepairRequest
 ) => Promise<CodexUserHookTrustRebaseResult>
 
 // Why (#16441): the session runs in-process; forking it through spawnSync

--- a/src/main/codex/config-toml-hook-trust-edit.ts
+++ b/src/main/codex/config-toml-hook-trust-edit.ts
@@ -27,7 +27,7 @@ export function upsertHookTrustContent(
   for (const entry of entries) {
     updated = upsertTrustBlocks(
       updated,
-      getTrustKeyWriteVariants(computeCodexTrustKey(entry)),
+      getHookTrustKeyWriteVariants(computeCodexTrustKey(entry)),
       entry.trustedHash ?? computeCodexTrustedHash(entry),
       entry.enabled
     )
@@ -129,7 +129,7 @@ function formatHookStateTableKey(key: string): string {
   return `"${escapeTomlBasicString(key)}"`
 }
 
-function getTrustKeyWriteVariants(key: string): string[] {
+export function getHookTrustKeyWriteVariants(key: string): string[] {
   const parsed = parseCodexTrustKey(key)
   if (!parsed || !usesWindowsCodexPathSeparators(parsed.sourcePath)) {
     return [key]

--- a/src/main/codex/config-toml-trust-api-parity.test.ts
+++ b/src/main/codex/config-toml-trust-api-parity.test.ts
@@ -29,6 +29,7 @@ describe('config-toml-trust public API', () => {
         'computeTrustedHash',
         'escapeTomlString',
         'getCodexExplicitHomeHookSourcePath',
+        'getHookTrustKeyWriteVariants',
         'normalizeCodexHookSourcePath',
         'normalizeCodexProjectPathForLookup',
         'normalizeCodexProjectPathForRevocationLookup',

--- a/src/main/codex/config-toml-trust-hook-removal.test.ts
+++ b/src/main/codex/config-toml-trust-hook-removal.test.ts
@@ -9,9 +9,11 @@ import {
   writeFileSync
 } from 'node:fs'
 import { join } from 'node:path'
+import { clearHookTrustKeySeparatorVariants } from './codex-mirrored-hook-runtime-trust'
 import {
   computeTrustKey,
   escapeTomlString,
+  getHookTrustKeyWriteVariants,
   readHookTrustEntries,
   removeHookTrustEntries,
   upsertHookTrustEntries,
@@ -196,6 +198,64 @@ describe('removeHookTrustEntries', () => {
     const written = readFileSync(configPath, 'utf-8')
     expect(written).not.toContain(`[hooks.state.'${key}']`)
     expect(written).not.toContain(`[hooks.state."${escapeTomlString(key)}"]`)
+  })
+
+  it('clears both Windows slash and backslash trust-key variants together', () => {
+    const backslashKey =
+      'C:\\Users\\Rod\\AppData\\Roaming\\orca\\codex-runtime-home\\home\\hooks.json:pre_tool_use:1:0'
+    const slashKey =
+      'C:/Users/Rod/AppData/Roaming/orca/codex-runtime-home/home/hooks.json:pre_tool_use:1:0'
+    writeFileSync(
+      configPath,
+      [
+        `[hooks.state.'${backslashKey}']`,
+        'enabled = true',
+        'trusted_hash = "sha256:system-source-hash"',
+        '',
+        `[hooks.state."${slashKey}"]`,
+        'enabled = true',
+        'trusted_hash = "sha256:other-separator-hash"',
+        ''
+      ].join('\n'),
+      'utf-8'
+    )
+
+    expect(getHookTrustKeyWriteVariants(backslashKey)).toEqual(
+      expect.arrayContaining([backslashKey, slashKey])
+    )
+    clearHookTrustKeySeparatorVariants(configPath, [backslashKey])
+
+    const written = readFileSync(configPath, 'utf-8')
+    expect(written).not.toContain(backslashKey)
+    expect(written).not.toContain(slashKey)
+    expect(written).not.toContain('sha256:system-source-hash')
+    expect(written).not.toContain('sha256:other-separator-hash')
+  })
+
+  it('clears both WSL UNC separator variants together', () => {
+    const backslashKey = '\\\\wsl$\\Ubuntu\\home\\user\\.orca\\hooks.json:post_tool_use:1:0'
+    const slashKey = '//wsl$/Ubuntu/home/user/.orca/hooks.json:post_tool_use:1:0'
+    writeFileSync(
+      configPath,
+      [
+        `[hooks.state.'${backslashKey}']`,
+        'enabled = true',
+        'trusted_hash = "sha256:system-source-hash"',
+        '',
+        `[hooks.state.'${slashKey}']`,
+        'enabled = true',
+        'trusted_hash = "sha256:other-separator-hash"',
+        ''
+      ].join('\n'),
+      'utf-8'
+    )
+
+    clearHookTrustKeySeparatorVariants(configPath, [slashKey])
+
+    const written = readFileSync(configPath, 'utf-8')
+    expect(written).not.toContain('post_tool_use')
+    expect(written).not.toContain('sha256:system-source-hash')
+    expect(written).not.toContain('sha256:other-separator-hash')
   })
 
   it('does not remove the target hook header text inside a multi-line string', () => {

--- a/src/main/codex/config-toml-trust-hook-upsert.test.ts
+++ b/src/main/codex/config-toml-trust-hook-upsert.test.ts
@@ -5,6 +5,7 @@ import { escapeRegex } from '../../shared/string-utils'
 import {
   computeTrustedHash,
   escapeTomlString,
+  getHookTrustKeyWriteVariants,
   upsertHookTrustEntries,
   type CodexTrustEntry
 } from './config-toml-trust'
@@ -611,6 +612,50 @@ describe('upsertHookTrustEntries', () => {
     const headerCount = (written.match(/\[hooks\.state\."/g) ?? []).length
     expect(headerCount).toBe(1)
     expect(written).not.toContain('sha256:OLD')
+  })
+
+  it('replaces both Windows separator variants together when writing a runtime currentHash', () => {
+    const backslashPath =
+      'C:\\Users\\Rod\\AppData\\Roaming\\orca\\codex-runtime-home\\home\\hooks.json'
+    const slashPath = 'C:/Users/Rod/AppData/Roaming/orca/codex-runtime-home/home/hooks.json'
+    const backslashKey = `${backslashPath}:pre_tool_use:1:0`
+    const slashKey = `${slashPath}:pre_tool_use:1:0`
+    writeFileSync(
+      configPath,
+      [
+        `[hooks.state.'${backslashKey}']`,
+        'enabled = true',
+        'trusted_hash = "sha256:system-source-hash"',
+        '',
+        `[hooks.state."${slashKey}"]`,
+        'enabled = true',
+        'trusted_hash = "sha256:other-separator-hash"',
+        ''
+      ].join('\n'),
+      'utf-8'
+    )
+
+    const runtimeHash = 'sha256:runtime-current-hash'
+    upsertHookTrustEntries(configPath, [
+      {
+        sourcePath: backslashPath,
+        eventLabel: 'pre_tool_use',
+        groupIndex: 1,
+        handlerIndex: 0,
+        command: 'user-pre-tool-hook',
+        trustedHash: runtimeHash
+      }
+    ])
+
+    const written = readFileSync(configPath, 'utf-8')
+    const variants = getHookTrustKeyWriteVariants(backslashKey)
+    expect(variants).toEqual(expect.arrayContaining([backslashKey, slashKey]))
+    expect((written.match(/\[hooks\.state\./g) ?? []).length).toBe(2)
+    expect(written).toContain(`[hooks.state.'${backslashKey}']`)
+    expect(written).toContain(`[hooks.state.'${slashKey}']`)
+    expect((written.match(/trusted_hash = "sha256:runtime-current-hash"/g) ?? []).length).toBe(2)
+    expect(written).not.toContain('sha256:system-source-hash')
+    expect(written).not.toContain('sha256:other-separator-hash')
   })
 
   it('finds and replaces a legacy forward-slash block when Orca upserts with native backslash key', () => {

--- a/src/main/codex/config-toml-trust-key.test.ts
+++ b/src/main/codex/config-toml-trust-key.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path'
 import {
   computeTrustKey,
   getCodexExplicitHomeHookSourcePath,
+  getHookTrustKeyWriteVariants,
   normalizeCodexHookSourcePath,
   parseTrustKey,
   type CodexTrustEntry
@@ -96,6 +97,23 @@ describe('computeTrustKey', () => {
     })
     expect(key).toContain('\\')
     expect(key.startsWith('C:\\Users\\Rod\\AppData\\Roaming\\orca\\hooks.json:')).toBe(true)
+  })
+
+  it('returns both slash and backslash variants for Windows and WSL trust keys', () => {
+    expect(
+      getHookTrustKeyWriteVariants(
+        'C:\\Users\\Rod\\AppData\\Roaming\\orca\\hooks.json:pre_tool_use:1:0'
+      )
+    ).toEqual([
+      'C:\\Users\\Rod\\AppData\\Roaming\\orca\\hooks.json:pre_tool_use:1:0',
+      'C:/Users/Rod/AppData/Roaming/orca/hooks.json:pre_tool_use:1:0'
+    ])
+    expect(
+      getHookTrustKeyWriteVariants('//wsl$/Ubuntu/home/user/.orca/hooks.json:post_tool_use:1:0')
+    ).toEqual([
+      '\\\\wsl$\\Ubuntu\\home\\user\\.orca\\hooks.json:post_tool_use:1:0',
+      '//wsl$/Ubuntu/home/user/.orca/hooks.json:post_tool_use:1:0'
+    ])
   })
 
   it('preserves literal backslashes in non-Windows-style fallback paths', () => {

--- a/src/main/codex/config-toml-trust.ts
+++ b/src/main/codex/config-toml-trust.ts
@@ -11,7 +11,11 @@ import {
   parseCodexTrustKey
 } from './codex-trust-identity'
 import { writeTomlConfigAtomically } from './config-toml-atomic-write'
-import { removeHookTrustContent, upsertHookTrustContent } from './config-toml-hook-trust-edit'
+import {
+  getHookTrustKeyWriteVariants,
+  removeHookTrustContent,
+  upsertHookTrustContent
+} from './config-toml-hook-trust-edit'
 import { CodexHookTrustEntryMap, readHookTrustContent } from './config-toml-hook-trust-read'
 import { upsertProjectTrustContent } from './config-toml-project-trust'
 import { escapeTomlBasicString, parseProjectTomlHeaderPath } from './config-toml-syntax'
@@ -145,6 +149,8 @@ export function escapeTomlString(value: string): string {
 export function normalizeHookTrustKeyForLookup(key: string): string {
   return normalizeCodexHookTrustLookupKey(key)
 }
+
+export { getHookTrustKeyWriteVariants }
 
 export function parseCodexProjectHeaderPath(line: string): string | null {
   return parseProjectTomlHeaderPath(line)

--- a/src/main/codex/hook-service-test-harness.ts
+++ b/src/main/codex/hook-service-test-harness.ts
@@ -8,6 +8,7 @@ import {
   normalizeCodexHookSourcePath
 } from './config-toml-trust'
 import { _internals as grantInternals } from './codex-hook-trust-grant'
+import { _internals as mirroredTrustInternals } from './codex-mirrored-hook-runtime-trust'
 import { _internals as rebaseInternals } from './codex-user-hook-trust-rebase'
 
 // Why (#16441): the grant/rebase sessions now run in-process instead of in a
@@ -28,12 +29,17 @@ export type CodexHookHomes = {
 /** Applies the stub above; for suites that build their own temp homes. */
 export function stubCodexTrustSessionsForTests(): void {
   grantInternals.setGrantSessionRunner(stubMissingCodexBinary)
+  mirroredTrustInternals.setSessionRunner(stubMissingCodexBinary)
   rebaseInternals.setSessionRunner(stubMissingCodexBinary)
 }
 
 export function restoreCodexTrustSessionsForTests(): void {
   grantInternals.setGrantSessionRunner(null)
   grantInternals.resetDiagnostics()
+  mirroredTrustInternals.setSessionRunner(null)
+  mirroredTrustInternals.setHostResolver(null)
+  mirroredTrustInternals.setConfigRestorer(null)
+  mirroredTrustInternals.resetState()
   rebaseInternals.setSessionRunner(null)
   rebaseInternals.resetRetryState()
 }

--- a/src/main/codex/hook-service-user-hook-mirroring.test.ts
+++ b/src/main/codex/hook-service-user-hook-mirroring.test.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import type * as Os from 'node:os'
 import { join } from 'node:path'
-import { upsertHookTrustEntriesInContent } from './config-toml-trust'
+import { _internals as mirroredTrustInternals } from './codex-mirrored-hook-runtime-trust'
+import {
+  getCodexExplicitHomeHookSourcePath,
+  readHookTrustEntries,
+  upsertHookTrustEntriesInContent
+} from './config-toml-trust'
 import {
   hookTrustHeader,
   isCodexManagedCommand,
@@ -31,6 +36,11 @@ vi.mock('os', async (importOriginal) => {
 import { CodexHookService } from './hook-service'
 
 const homes = setupCodexHookHomes(homedirMock, getPathMock)
+
+afterEach(() => {
+  mirroredTrustInternals.setListRunner(null)
+  mirroredTrustInternals.resetRetryState()
+})
 
 function seedSystemUserHook(command: string): {
   systemHooksPath: string
@@ -577,5 +587,58 @@ describe('CodexHookService', () => {
       `${hookTrustHeader(`${managedHooksPath}:stop:0:0`)}\nenabled = false`
     )
     expect(runtimeToml).not.toContain(':permission_request:0:0')
+  })
+
+  it('writes Codex runtime currentHash for an approved mirrored user hook, not the system hash', () => {
+    const systemCodexHome = join(homes.tmpHome, '.codex')
+    const systemHooksPath = join(systemCodexHome, 'hooks.json')
+    const systemHash = 'sha256:system-source-hash'
+    const runtimeHash = 'sha256:runtime-current-hash'
+    mkdirSync(systemCodexHome, { recursive: true })
+    writeFileSync(
+      systemHooksPath,
+      `${JSON.stringify({
+        hooks: {
+          PreToolUse: [{ hooks: [{ type: 'command', command: 'user-pre-tool-hook' }] }]
+        }
+      })}\n`,
+      'utf-8'
+    )
+    writeFileSync(
+      join(systemCodexHome, 'config.toml'),
+      upsertHookTrustEntriesInContent('model = "system-model"\n', [
+        {
+          sourcePath: systemHooksPath,
+          eventLabel: 'pre_tool_use',
+          groupIndex: 0,
+          handlerIndex: 0,
+          command: 'user-pre-tool-hook',
+          trustedHash: systemHash
+        }
+      ]),
+      'utf-8'
+    )
+    mirroredTrustInternals.setListRunner((runtimeHomePath) => {
+      const runtimeHooksPath = getCodexExplicitHomeHookSourcePath(
+        join(runtimeHomePath, 'hooks.json')
+      )
+      return [
+        {
+          key: `${runtimeHooksPath}:pre_tool_use:1:0`,
+          command: 'user-pre-tool-hook',
+          currentHash: runtimeHash
+        }
+      ]
+    })
+
+    expect(new CodexHookService().install().state).toBe('installed')
+
+    const managedCodexHome = join(homes.userDataDir, 'codex-runtime-home', 'home')
+    const runtimeHooksPath = getCodexExplicitHomeHookSourcePath(
+      join(managedCodexHome, 'hooks.json')
+    )
+    const runtimeTrust = readHookTrustEntries(join(managedCodexHome, 'config.toml'))
+    expect(runtimeTrust.get(`${runtimeHooksPath}:pre_tool_use:1:0`)?.trustedHash).toBe(runtimeHash)
+    expect(readFileSync(join(managedCodexHome, 'config.toml'), 'utf-8')).not.toContain(systemHash)
   })
 })

--- a/src/main/codex/hook-service-user-hook-mirroring.test.ts
+++ b/src/main/codex/hook-service-user-hook-mirroring.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import type * as Os from 'node:os'
 import { join } from 'node:path'
@@ -36,11 +36,6 @@ vi.mock('os', async (importOriginal) => {
 import { CodexHookService } from './hook-service'
 
 const homes = setupCodexHookHomes(homedirMock, getPathMock)
-
-afterEach(() => {
-  mirroredTrustInternals.setListRunner(null)
-  mirroredTrustInternals.resetRetryState()
-})
 
 function seedSystemUserHook(command: string): {
   systemHooksPath: string
@@ -589,7 +584,7 @@ describe('CodexHookService', () => {
     expect(runtimeToml).not.toContain(':permission_request:0:0')
   })
 
-  it('writes Codex runtime currentHash for an approved mirrored user hook, not the system hash', () => {
+  it('writes Codex runtime currentHash for an approved mirrored user hook, not the system hash', async () => {
     const systemCodexHome = join(homes.tmpHome, '.codex')
     const systemHooksPath = join(systemCodexHome, 'hooks.json')
     const systemHash = 'sha256:system-source-hash'
@@ -618,20 +613,36 @@ describe('CodexHookService', () => {
       ]),
       'utf-8'
     )
-    mirroredTrustInternals.setListRunner((runtimeHomePath) => {
-      const runtimeHooksPath = getCodexExplicitHomeHookSourcePath(
-        join(runtimeHomePath, 'hooks.json')
-      )
-      return [
-        {
-          key: `${runtimeHooksPath}:pre_tool_use:1:0`,
-          command: 'user-pre-tool-hook',
-          currentHash: runtimeHash
+    mirroredTrustInternals.setSessionRunner(async (request) => {
+      if (request.operation === 'inspect-user-hook-trust') {
+        return {
+          outcome: 'inspected',
+          moves: request.moves.map((move) => ({
+            ...move,
+            reportedOldKey: move.oldKey,
+            currentHash: systemHash,
+            wasTrusted: true,
+            enabled: true
+          }))
         }
-      ]
+      }
+      expect(request.operation).toBe('grant-mirrored-runtime-hook-trust')
+      if (request.operation !== 'grant-mirrored-runtime-hook-trust') {
+        throw new Error('unexpected repair operation')
+      }
+      return {
+        outcome: 'mirrored-granted',
+        entries: [
+          {
+            key: request.targets[0]!.key,
+            command: 'user-pre-tool-hook',
+            currentHash: runtimeHash
+          }
+        ]
+      }
     })
 
-    expect(new CodexHookService().install().state).toBe('installed')
+    expect((await new CodexHookService().install()).state).toBe('installed')
 
     const managedCodexHome = join(homes.userDataDir, 'codex-runtime-home', 'home')
     const runtimeHooksPath = getCodexExplicitHomeHookSourcePath(
@@ -640,5 +651,57 @@ describe('CodexHookService', () => {
     const runtimeTrust = readHookTrustEntries(join(managedCodexHome, 'config.toml'))
     expect(runtimeTrust.get(`${runtimeHooksPath}:pre_tool_use:1:0`)?.trustedHash).toBe(runtimeHash)
     expect(readFileSync(join(managedCodexHome, 'config.toml'), 'utf-8')).not.toContain(systemHash)
+  })
+
+  it('keeps a stale system hash so edited hook content still requires review', async () => {
+    const systemCodexHome = join(homes.tmpHome, '.codex')
+    const systemHooksPath = join(systemCodexHome, 'hooks.json')
+    const systemHash = 'sha256:previously-approved-system-hash'
+    mkdirSync(systemCodexHome, { recursive: true })
+    writeFileSync(
+      systemHooksPath,
+      `${JSON.stringify({
+        hooks: { Stop: [{ hooks: [{ type: 'command', command: 'edited-user-hook' }] }] }
+      })}\n`,
+      'utf-8'
+    )
+    writeFileSync(
+      join(systemCodexHome, 'config.toml'),
+      upsertHookTrustEntriesInContent('model = "system-model"\n', [
+        {
+          sourcePath: systemHooksPath,
+          eventLabel: 'stop',
+          groupIndex: 0,
+          handlerIndex: 0,
+          command: 'edited-user-hook',
+          trustedHash: systemHash
+        }
+      ]),
+      'utf-8'
+    )
+    mirroredTrustInternals.setSessionRunner(async (request) => {
+      if (request.operation !== 'inspect-user-hook-trust') {
+        throw new Error('stale system approval must not reach the runtime grant')
+      }
+      return {
+        outcome: 'inspected',
+        moves: request.moves.map((move) => ({
+          ...move,
+          reportedOldKey: move.oldKey,
+          currentHash: 'sha256:edited-system-current-hash',
+          wasTrusted: false,
+          enabled: true
+        }))
+      }
+    })
+
+    expect((await new CodexHookService().install()).state).toBe('installed')
+
+    const managedHome = join(homes.userDataDir, 'codex-runtime-home', 'home')
+    const runtimeHooksPath = getCodexExplicitHomeHookSourcePath(join(managedHome, 'hooks.json'))
+    expect(
+      readHookTrustEntries(join(managedHome, 'config.toml')).get(`${runtimeHooksPath}:stop:1:0`)
+        ?.trustedHash
+    ).toBe(systemHash)
   })
 })

--- a/src/main/codex/hook-service-user-hook-mirroring.test.ts
+++ b/src/main/codex/hook-service-user-hook-mirroring.test.ts
@@ -3,9 +3,12 @@ import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import type * as Os from 'node:os'
 import { join } from 'node:path'
 import { _internals as mirroredTrustInternals } from './codex-mirrored-hook-runtime-trust'
+import type { CodexUserHookTrustRebaseRequest } from './codex-user-hook-trust-rebase-client'
 import {
   getCodexExplicitHomeHookSourcePath,
+  parseTrustKey,
   readHookTrustEntries,
+  upsertHookTrustEntries,
   upsertHookTrustEntriesInContent
 } from './config-toml-trust'
 import {
@@ -584,7 +587,7 @@ describe('CodexHookService', () => {
     expect(runtimeToml).not.toContain(':permission_request:0:0')
   })
 
-  it('writes Codex runtime currentHash for an approved mirrored user hook, not the system hash', async () => {
+  it('writes runtime currentHash while preserving a disabled mirrored hook and cache hit', async () => {
     const systemCodexHome = join(homes.tmpHome, '.codex')
     const systemHooksPath = join(systemCodexHome, 'hooks.json')
     const systemHash = 'sha256:system-source-hash'
@@ -608,21 +611,22 @@ describe('CodexHookService', () => {
           groupIndex: 0,
           handlerIndex: 0,
           command: 'user-pre-tool-hook',
-          trustedHash: systemHash
+          trustedHash: systemHash,
+          enabled: false
         }
       ]),
       'utf-8'
     )
-    mirroredTrustInternals.setSessionRunner(async (request) => {
+    const runner = vi.fn(async (request: CodexUserHookTrustRebaseRequest) => {
       if (request.operation === 'inspect-user-hook-trust') {
         return {
-          outcome: 'inspected',
+          outcome: 'inspected' as const,
           moves: request.moves.map((move) => ({
             ...move,
             reportedOldKey: move.oldKey,
             currentHash: systemHash,
             wasTrusted: true,
-            enabled: true
+            enabled: false
           }))
         }
       }
@@ -630,8 +634,14 @@ describe('CodexHookService', () => {
       if (request.operation !== 'grant-mirrored-runtime-hook-trust') {
         throw new Error('unexpected repair operation')
       }
+      const target = request.targets[0]!
+      expect(target.enabled).toBe(false)
+      const parsed = parseTrustKey(target.key)!
+      upsertHookTrustEntries(join(homes.userDataDir, 'codex-runtime-home', 'home', 'config.toml'), [
+        { ...parsed, command: target.command, trustedHash: runtimeHash, enabled: target.enabled }
+      ])
       return {
-        outcome: 'mirrored-granted',
+        outcome: 'mirrored-granted' as const,
         entries: [
           {
             key: request.targets[0]!.key,
@@ -641,8 +651,19 @@ describe('CodexHookService', () => {
         ]
       }
     })
+    mirroredTrustInternals.setHostResolver(async () => ({
+      binaryStamp: { kind: 'native', path: '/codex', size: 1, mtimeMs: 1 },
+      buildRequest: (input) => ({
+        invocation: { command: 'codex', cliPath: null, args: [], timeoutMs: 1_000 },
+        hooksListCwd: input.runtimeHomePath,
+        expectedTrustKeys: input.expectedTrustKeys,
+        managedCommand: input.managedCommand
+      })
+    }))
+    mirroredTrustInternals.setSessionRunner(runner)
 
-    expect((await new CodexHookService().install()).state).toBe('installed')
+    const service = new CodexHookService()
+    expect((await service.install()).state).toBe('installed')
 
     const managedCodexHome = join(homes.userDataDir, 'codex-runtime-home', 'home')
     const runtimeHooksPath = getCodexExplicitHomeHookSourcePath(
@@ -650,7 +671,11 @@ describe('CodexHookService', () => {
     )
     const runtimeTrust = readHookTrustEntries(join(managedCodexHome, 'config.toml'))
     expect(runtimeTrust.get(`${runtimeHooksPath}:pre_tool_use:1:0`)?.trustedHash).toBe(runtimeHash)
+    expect(runtimeTrust.get(`${runtimeHooksPath}:pre_tool_use:1:0`)?.enabled).toBe(false)
     expect(readFileSync(join(managedCodexHome, 'config.toml'), 'utf-8')).not.toContain(systemHash)
+
+    expect((await service.install()).state).toBe('installed')
+    expect(runner).toHaveBeenCalledTimes(2)
   })
 
   it('keeps a stale system hash so edited hook content still requires review', async () => {

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -1409,7 +1409,7 @@ export class CodexHookService {
       hookPlan.trustEntries
     )
     const mirroredTrustEntries: CodexTrustEntry[] = mirroredUserTrustEntries.map(
-      ({ entry }) => entry
+      ({ entry, enabled }) => ({ ...entry, enabled })
     )
     const managedTrustEntries: CodexTrustEntry[] = []
     const trustSourcePath = getCodexExplicitHomeHookSourcePath(configPath)
@@ -1664,7 +1664,7 @@ export class CodexHookService {
         systemHomePath: getSystemCodexHomePath()
       })
       const trustEntries = await resolveMirroredRuntimeUserHookTrustEntries({
-        entries: hookPlan.trustEntries.map(({ entry }) => entry),
+        entries: hookPlan.trustEntries.map(({ entry, enabled }) => ({ ...entry, enabled })),
         systemEntries: hookPlan.trustEntries.map(({ systemEntry }) => systemEntry),
         systemHomePath: getSystemCodexHomePath(),
         runtimeHomePath,

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -85,10 +85,7 @@ import {
 } from './codex-managed-trust-reconciliation'
 import type { CodexTrustGrantLedgerHome } from './codex-trust-grant-ledger'
 import { mutateRealHomeHooksPreservingUserTrust } from './codex-user-hook-trust-rebase'
-import {
-  clearHookTrustKeySeparatorVariants,
-  resolveMirroredRuntimeUserHookTrustEntries
-} from './codex-mirrored-hook-runtime-trust'
+import { resolveMirroredRuntimeUserHookTrustEntries } from './codex-mirrored-hook-runtime-trust'
 
 // Why: Pre/PostToolUse feed the live in-flight-tool readout; PermissionRequest exits with no decision so Codex still shows its approval UI while Orca flips the pane to waiting.
 const CODEX_EVENTS = [
@@ -144,6 +141,7 @@ const LEGACY_ORCA_PROFILE_BLOCK_END = '# END ORCA AGENT STATUS HOOKS'
 
 type MirroredRuntimeUserHookTrustEntry = {
   entry: CodexTrustEntry
+  systemEntry: CodexTrustEntry
   enabled: boolean
 }
 
@@ -356,6 +354,7 @@ function getRuntimeHooksWithSystemUserHooks(
 }
 
 type TrustedSystemHookSignatureState = {
+  approvalEntry: CodexTrustEntry
   enabled: boolean
   trustedHash: string
 }
@@ -419,15 +418,19 @@ function resolveTrustedSystemHookState(
   const expectedHash = computeTrustedHash(entry)
   const state = trustEntries.get(computeTrustKey(entry))
   if (state?.trustedHash === expectedHash) {
-    return { enabled: state.enabled !== false, trustedHash: expectedHash }
+    return { approvalEntry: entry, enabled: state.enabled !== false, trustedHash: expectedHash }
   }
   const reorderedEnabled = trustedHashesByEvent.get(entry.eventLabel)?.get(expectedHash)
   if (reorderedEnabled !== undefined) {
-    return { enabled: reorderedEnabled, trustedHash: expectedHash }
+    return { approvalEntry: entry, enabled: reorderedEnabled, trustedHash: expectedHash }
   }
   if (state?.trustedHash) {
     // Why: approval match only — #7110 re-approval loops if we recompute; runtime writes use Codex currentHash.
-    return { enabled: state.enabled !== false, trustedHash: state.trustedHash }
+    return {
+      approvalEntry: entry,
+      enabled: state.enabled !== false,
+      trustedHash: state.trustedHash
+    }
   }
   return null
 }
@@ -498,6 +501,7 @@ function collectMirroredRuntimeUserHookTrustEntries(
         if (state !== undefined) {
           entries.push({
             entry: { ...entry, trustedHash: state.trustedHash },
+            systemEntry: { ...state.approvalEntry, trustedHash: state.trustedHash },
             enabled: state.enabled
           })
         }
@@ -510,12 +514,13 @@ function collectMirroredRuntimeUserHookTrustEntries(
 function moveMirroredRuntimeUserTrustAfterManagedStatusHook(
   entries: readonly MirroredRuntimeUserHookTrustEntry[]
 ): MirroredRuntimeUserHookTrustEntry[] {
-  return entries.map(({ entry, enabled }) => {
+  return entries.map(({ entry, systemEntry, enabled }) => {
     if (!CODEX_MANAGED_EVENT_LABELS.has(entry.eventLabel)) {
-      return { entry, enabled }
+      return { entry, systemEntry, enabled }
     }
     return {
       entry: { ...entry, groupIndex: entry.groupIndex + 1 },
+      systemEntry,
       enabled
     }
   })
@@ -548,7 +553,7 @@ function buildHookTrustHeaderKeyPattern(key: string): string {
 
 function applyMirroredRuntimeUserHookTrustStates(
   tomlPath: string,
-  entries: readonly MirroredRuntimeUserHookTrustEntry[]
+  entries: readonly { entry: CodexTrustEntry; enabled: boolean }[]
 ): void {
   if (entries.length === 0 || !existsSync(tomlPath)) {
     return
@@ -1456,15 +1461,13 @@ export class CodexHookService {
         host: { kind: 'native' },
         telemetryLane: 'managed'
       })
-      const resolvedMirroredTrustEntries = resolveMirroredRuntimeUserHookTrustEntries({
+      const resolvedMirroredTrustEntries = await resolveMirroredRuntimeUserHookTrustEntries({
         entries: mirroredTrustEntries,
+        systemEntries: mirroredUserTrustEntries.map(({ systemEntry }) => systemEntry),
+        systemHomePath: getSystemCodexHomePath(),
         runtimeHomePath,
         tomlPath
       })
-      clearHookTrustKeySeparatorVariants(
-        tomlPath,
-        resolvedMirroredTrustEntries.map((entry) => computeTrustKey(entry))
-      )
       if (grant.lane === 'rpc') {
         recentGrantEntries = grant.entries
         upsertHookTrustEntries(tomlPath, resolvedMirroredTrustEntries)
@@ -1660,8 +1663,10 @@ export class CodexHookService {
         runtimeHomePath,
         systemHomePath: getSystemCodexHomePath()
       })
-      const trustEntries = resolveMirroredRuntimeUserHookTrustEntries({
+      const trustEntries = await resolveMirroredRuntimeUserHookTrustEntries({
         entries: hookPlan.trustEntries.map(({ entry }) => entry),
+        systemEntries: hookPlan.trustEntries.map(({ systemEntry }) => systemEntry),
+        systemHomePath: getSystemCodexHomePath(),
         runtimeHomePath,
         tomlPath
       })
@@ -1669,10 +1674,6 @@ export class CodexHookService {
       // runtime CODEX_HOME should keep user hooks, but not Orca-managed trust.
       // Write current mirrored user trust first so stale cleanup compares
       // against runtime current hashes while deleting old managed hook keys.
-      clearHookTrustKeySeparatorVariants(
-        tomlPath,
-        trustEntries.map((entry) => computeTrustKey(entry))
-      )
       upsertHookTrustEntries(tomlPath, trustEntries)
       removeStaleRuntimeHookTrustEntries(tomlPath, configPath, trustEntries)
       applyMirroredRuntimeUserHookTrustStates(

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -42,6 +42,7 @@ import {
   computeTrustedHash,
   escapeTomlString,
   getCodexExplicitHomeHookSourcePath,
+  getHookTrustKeyWriteVariants,
   normalizeCodexHookSourcePath,
   normalizeCodexProjectPathForLookup,
   normalizeHookTrustKeyForLookup,
@@ -84,6 +85,10 @@ import {
 } from './codex-managed-trust-reconciliation'
 import type { CodexTrustGrantLedgerHome } from './codex-trust-grant-ledger'
 import { mutateRealHomeHooksPreservingUserTrust } from './codex-user-hook-trust-rebase'
+import {
+  clearHookTrustKeySeparatorVariants,
+  resolveMirroredRuntimeUserHookTrustEntries
+} from './codex-mirrored-hook-runtime-trust'
 
 // Why: Pre/PostToolUse feed the live in-flight-tool readout; PermissionRequest exits with no decision so Codex still shows its approval UI while Orca flips the pane to waiting.
 const CODEX_EVENTS = [
@@ -275,7 +280,7 @@ function removeStaleRuntimeHookTrustEntries(
     if (expectedHashes.get(normalizeHookTrustKeyForLookup(key)) === state.trustedHash) {
       continue
     }
-    staleKeys.push(key)
+    staleKeys.push(...getHookTrustKeyWriteVariants(key))
   }
   if (staleKeys.length > 0) {
     removeHookTrustEntries(tomlPath, staleKeys)
@@ -421,7 +426,7 @@ function resolveTrustedSystemHookState(
     return { enabled: reorderedEnabled, trustedHash: expectedHash }
   }
   if (state?.trustedHash) {
-    // Why: carry a key-matched system hash verbatim — recomputing caused #7110 re-approval loops since Codex owns its hash algorithm.
+    // Why: approval match only — #7110 re-approval loops if we recompute; runtime writes use Codex currentHash.
     return { enabled: state.enabled !== false, trustedHash: state.trustedHash }
   }
   return null
@@ -1424,7 +1429,6 @@ export class CodexHookService {
         timeoutSec: MANAGED_HOOK_TIMEOUT_SECONDS
       })
     }
-    const trustEntries: CodexTrustEntry[] = [...mirroredTrustEntries, ...managedTrustEntries]
     let recentGrantEntries: readonly CodexTrustEntry[] = []
 
     config.hooks = nextHooks
@@ -1442,8 +1446,8 @@ export class CodexHookService {
       // managed entries are granted through codex app-server RPCs (verified by
       // re-list) whenever the installed CLI supports them; the granted entries
       // then carry Codex's verbatim hashes into stale cleanup so it cannot
-      // delete what Codex just wrote. Mirrored user trust keeps its existing
-      // verbatim-carry lane either way.
+      // delete what Codex just wrote. Mirrored user trust is approved by
+      // signature, then written with runtime currentHash from hooks/list.
       const grant = await grantManagedCodexHookTrust({
         runtimeHomePath,
         tomlPath,
@@ -1452,11 +1456,20 @@ export class CodexHookService {
         host: { kind: 'native' },
         telemetryLane: 'managed'
       })
+      const resolvedMirroredTrustEntries = resolveMirroredRuntimeUserHookTrustEntries({
+        entries: mirroredTrustEntries,
+        runtimeHomePath,
+        tomlPath
+      })
+      clearHookTrustKeySeparatorVariants(
+        tomlPath,
+        resolvedMirroredTrustEntries.map((entry) => computeTrustKey(entry))
+      )
       if (grant.lane === 'rpc') {
         recentGrantEntries = grant.entries
-        upsertHookTrustEntries(tomlPath, mirroredTrustEntries)
+        upsertHookTrustEntries(tomlPath, resolvedMirroredTrustEntries)
         removeStaleRuntimeHookTrustEntries(tomlPath, configPath, [
-          ...mirroredTrustEntries,
+          ...resolvedMirroredTrustEntries,
           ...grant.entries
         ])
       } else {
@@ -1465,10 +1478,17 @@ export class CodexHookService {
         // all old runtime [hooks.state.*] blocks would keep Orca Codex trusted.
         // Upsert first so duplicate repair can preserve a disabled managed copy
         // before stale cleanup removes old managed hook keys.
-        upsertHookTrustEntries(tomlPath, trustEntries)
-        removeStaleRuntimeHookTrustEntries(tomlPath, configPath, trustEntries)
+        const resolvedTrustEntries = [...resolvedMirroredTrustEntries, ...managedTrustEntries]
+        upsertHookTrustEntries(tomlPath, resolvedTrustEntries)
+        removeStaleRuntimeHookTrustEntries(tomlPath, configPath, resolvedTrustEntries)
       }
-      applyMirroredRuntimeUserHookTrustStates(tomlPath, mirroredUserTrustEntries)
+      applyMirroredRuntimeUserHookTrustStates(
+        tomlPath,
+        mirroredUserTrustEntries.map((item, index) => ({
+          entry: resolvedMirroredTrustEntries[index] ?? item.entry,
+          enabled: item.enabled
+        }))
+      )
     } catch (error) {
       return {
         agent: 'codex',
@@ -1636,18 +1656,32 @@ export class CodexHookService {
 
     try {
       const tomlPath = getCodexConfigTomlPath(runtimeHomePath)
-      const trustEntries = hookPlan.trustEntries.map(({ entry }) => entry)
       syncSystemConfigIntoManagedCodexHome({
         runtimeHomePath,
         systemHomePath: getSystemCodexHomePath()
       })
+      const trustEntries = resolveMirroredRuntimeUserHookTrustEntries({
+        entries: hookPlan.trustEntries.map(({ entry }) => entry),
+        runtimeHomePath,
+        tomlPath
+      })
       // Why: this path is used when Orca status hooks are disabled. The
       // runtime CODEX_HOME should keep user hooks, but not Orca-managed trust.
       // Write current mirrored user trust first so stale cleanup compares
-      // against current hashes while deleting old managed hook keys.
+      // against runtime current hashes while deleting old managed hook keys.
+      clearHookTrustKeySeparatorVariants(
+        tomlPath,
+        trustEntries.map((entry) => computeTrustKey(entry))
+      )
       upsertHookTrustEntries(tomlPath, trustEntries)
       removeStaleRuntimeHookTrustEntries(tomlPath, configPath, trustEntries)
-      applyMirroredRuntimeUserHookTrustStates(tomlPath, hookPlan.trustEntries)
+      applyMirroredRuntimeUserHookTrustStates(
+        tomlPath,
+        hookPlan.trustEntries.map((item, index) => ({
+          entry: trustEntries[index] ?? item.entry,
+          enabled: item.enabled
+        }))
+      )
     } catch (error) {
       return {
         agent: 'codex',

--- a/src/main/codex/hook-trust-promotion.test.ts
+++ b/src/main/codex/hook-trust-promotion.test.ts
@@ -67,8 +67,6 @@ beforeEach(() => {
 
 afterEach(() => {
   restoreCodexTrustSessionsForTests()
-  mirroredTrustInternals.setListRunner(null)
-  mirroredTrustInternals.resetRetryState()
   rmSync(tmpHome, { recursive: true, force: true })
   rmSync(userDataDir, { recursive: true, force: true })
   if (previousUserDataPath === undefined) {
@@ -278,13 +276,33 @@ describe('codex hook trust write-back promotion', () => {
       join(systemCodexDir(), 'config.toml'),
       upsertHookTrustEntriesInContent('', [{ ...systemUserStopEntry(), trustedHash: systemHash }])
     )
-    mirroredTrustInternals.setListRunner((runtimeHomePath) => [
-      {
-        key: `${getCodexExplicitHomeHookSourcePath(join(runtimeHomePath, 'hooks.json'))}:stop:1:0`,
-        command: USER_HOOK_COMMAND,
-        currentHash: runtimeHash
+    mirroredTrustInternals.setSessionRunner(async (request) => {
+      if (request.operation === 'inspect-user-hook-trust') {
+        return {
+          outcome: 'inspected',
+          moves: request.moves.map((move) => ({
+            ...move,
+            reportedOldKey: move.oldKey,
+            currentHash: systemHash,
+            wasTrusted: true,
+            enabled: true
+          }))
+        }
       }
-    ])
+      if (request.operation !== 'grant-mirrored-runtime-hook-trust') {
+        throw new Error('unexpected repair operation')
+      }
+      return {
+        outcome: 'mirrored-granted',
+        entries: [
+          {
+            key: request.targets[0]!.key,
+            command: USER_HOOK_COMMAND,
+            currentHash: runtimeHash
+          }
+        ]
+      }
+    })
 
     const service = new CodexHookService()
     expect((await service.install()).state).toBe('installed')

--- a/src/main/codex/hook-trust-promotion.test.ts
+++ b/src/main/codex/hook-trust-promotion.test.ts
@@ -43,6 +43,7 @@ import {
   restoreCodexTrustSessionsForTests,
   stubCodexTrustSessionsForTests
 } from './hook-service-test-harness'
+import { _internals as mirroredTrustInternals } from './codex-mirrored-hook-runtime-trust'
 import { CodexHookService } from './hook-service'
 
 let tmpHome: string
@@ -66,6 +67,8 @@ beforeEach(() => {
 
 afterEach(() => {
   restoreCodexTrustSessionsForTests()
+  mirroredTrustInternals.setListRunner(null)
+  mirroredTrustInternals.resetRetryState()
   rmSync(tmpHome, { recursive: true, force: true })
   rmSync(userDataDir, { recursive: true, force: true })
   if (previousUserDataPath === undefined) {
@@ -265,6 +268,43 @@ describe('codex hook trust write-back promotion', () => {
     expect(systemState?.enabled).toBe(false)
     // The mirrored runtime entry reflects the disable on the next launch too.
     expect(readHookTrustEntries(runtimeTomlPath).get(approvalKey)?.enabled).toBe(false)
+  })
+
+  it('does not promote a remapped runtime currentHash over the approved system hash', async () => {
+    const systemHash = 'sha256:system-source-hash'
+    const runtimeHash = 'sha256:runtime-current-hash'
+    writeSystemUserHook()
+    writeFileSync(
+      join(systemCodexDir(), 'config.toml'),
+      upsertHookTrustEntriesInContent('', [{ ...systemUserStopEntry(), trustedHash: systemHash }])
+    )
+    mirroredTrustInternals.setListRunner((runtimeHomePath) => [
+      {
+        key: `${getCodexExplicitHomeHookSourcePath(join(runtimeHomePath, 'hooks.json'))}:stop:1:0`,
+        command: USER_HOOK_COMMAND,
+        currentHash: runtimeHash
+      }
+    ])
+
+    const service = new CodexHookService()
+    expect((await service.install()).state).toBe('installed')
+
+    const runtimeKey = computeTrustKey(runtimeUserStopEntry())
+    const systemKey = computeTrustKey(systemUserStopEntry())
+    expect(
+      readHookTrustEntries(join(runtimeHomeDir(), 'config.toml')).get(runtimeKey)?.trustedHash
+    ).toBe(runtimeHash)
+    expect(
+      readHookTrustEntries(join(systemCodexDir(), 'config.toml')).get(systemKey)?.trustedHash
+    ).toBe(systemHash)
+
+    await service.install()
+    expect(
+      readHookTrustEntries(join(runtimeHomeDir(), 'config.toml')).get(runtimeKey)?.trustedHash
+    ).toBe(runtimeHash)
+    expect(
+      readHookTrustEntries(join(systemCodexDir(), 'config.toml')).get(systemKey)?.trustedHash
+    ).toBe(systemHash)
   })
 
   it('carries a Codex-written hash verbatim when it differs from the reproduced hash', async () => {


### PR DESCRIPTION
## ELI5

Orca mirrors user Codex hooks into a managed `CODEX_HOME`. On Windows, the same approved hook can have a different runtime hash and slash spelling, so Codex repeatedly asks to review it. This change asks Codex for the runtime hash, writes it through app-server RPC, and verifies the result without weakening approval checks.

## What Changed

- Preserve signature-based system approval, then require the system `hooks/list` current hash to match the stored approved hash.
- Clear both Windows slash/backslash trust-key variants before granting or repairing runtime trust.
- Use `hooks/list` → `config/batchWrite` → `hooks/list` with exact normalized key, command, trusted status, enabled state, and unchanged current hash verification.
- Preserve disabled mirrored hooks through RPC verification and cache reuse.
- Restore the exact TOML snapshot on failure and surface rollback failures.
- Scope verified fingerprints and transient cooldowns by execution host and managed account home; cache unchanged stale approvals without granting them, and avoid cache reuse without a binary identity.
- Keep unsupported app-server fallback behavior conservative so Codex still prompts when a runtime hash cannot be verified.

## Why

Copying the system `trusted_hash` into Orca's remapped runtime home leaves Codex seeing a modified hook on every launch. Trust must instead use Codex's runtime `currentHash`, but only after proving the current system hook is still the one the user approved.

## Linked Issue

Fixes #16428

Linear: STA-5443

## Visual Proof

N/A — this is a non-visual Windows app-server/config trust flow with no renderer UI change.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, including stale approval, disabled state, Windows key variants, rollback, cache/cooldown isolation, and exact post-write verification

Node 24 verification at `e156bd72a073bc06f3ff53fcf6d6dde74696a1e6`:

- `vitest ... src/main/codex`: 1,221 passed; 6 expected skips
- Focused trust/mirroring slice: 28 passed across 3 files
- `pnpm tc`: passed
- `pnpm run check:code-quality:changed`: passed
- `pnpm run check:max-lines-ratchet`: passed
- `oxfmt --check` on review-modified files: passed
- `git diff --check`: passed

Live Windows/WSL/SSH Codex binaries were not available in this macOS worktree; those environments remain a CI/manual QA gap.

## AI Disclosure

## Review

A fresh adversarial review-until-clean pass plus independent correctness, platform, and performance reviews completed at the exact head. Proven disabled-state propagation, stale-approval negative-cache, and Windows moved-hook separator-cleanup issues were fixed; the final pass found no remaining in-scope issues.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

No wire, provider, renderer, telemetry, credential, or remote protocol shape changes. SSH/folder workspaces are unaffected; Windows and WSL path normalization are covered by unit tests.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Exact-head CI result

At `e156bd72a073bc06f3ff53fcf6d6dde74696a1e6`, `PR test LoC` passed and 42 `PR Checks` jobs passed, including Windows packaging/boundaries, static analysis, typecheck, managed hooks on Node 18, Git compatibility, shell contracts, and cross-version wire compatibility. The overall `PR Checks` workflow is red from two deterministic runtime export-parity failures on Node 24/26 and one Node 26-only WebRTC egress Electron probe failure; all implicated files are byte-identical to base `026389a3bc03` and outside the Codex PR diff.
