### PR TITLE
fix(worktree): stop push-target rollback deleting a sibling's remote

### DIFF
--- a/src/main/ipc/worktree-push-target-setup.test.ts
+++ b/src/main/ipc/worktree-push-target-setup.test.ts
@@ -238,4 +238,26 @@ describe('prepareWorktreePushTargetWithExec rollback', () => {
     expect(callsMatching(exec, ['remote', 'remove'])).toEqual([])
     expect(remotes.existing).toBe(FORK_SSH)
   })
+
+  // Regression: the rollback used to fire on inherited ownership, deleting a
+  // remote a live sibling worktree was still pushing through.
+  it('keeps a reused remote a sibling worktree owns when the fetch fails', async () => {
+    const remotes: Record<string, string> = {
+      origin: 'git@github.com:stablyai/orca.git',
+      'pr-contributor-orca': FORK_HTTPS
+    }
+    const exec = vi.fn<GitRemoteExec>(async (args: string[]) => {
+      if (args[0] === 'fetch') {
+        throw new Error('network unreachable')
+      }
+      return makeRepoExec(remotes)(args, REPO)
+    })
+
+    await expect(
+      prepareWorktreePushTargetWithExec(exec, REPO, forkTarget(), () => true)
+    ).rejects.toThrow('network unreachable')
+
+    expect(callsMatching(exec, ['remote', 'remove'])).toEqual([])
+    expect(remotes['pr-contributor-orca']).toBe(FORK_HTTPS)
+  })
 })

--- a/src/main/ipc/worktree-push-target-setup.ts
+++ b/src/main/ipc/worktree-push-target-setup.ts
@@ -81,6 +81,9 @@ export async function prepareWorktreePushTargetWithExec(
   const { remoteCreated: _ignoredRemoteCreated, ...sanitizedTarget } = target
   let remoteName = target.remoteName
   let remoteCreated = false
+  // Why: ownership above is inherited from sibling worktrees, so it can be true
+  // for a remote this call did not create. Only rollback needs that distinction.
+  let remoteAddedHere = false
   if (target.remoteUrl) {
     const existingRemote = await findRemoteForUrl(execGit, repoPath, target.remoteUrl)
     if (existingRemote) {
@@ -92,6 +95,7 @@ export async function prepareWorktreePushTargetWithExec(
       remoteName = await ensureUniqueRemoteName(execGit, repoPath, target.remoteName)
       await execGit(['remote', 'add', remoteName, target.remoteUrl], repoPath)
       remoteCreated = true
+      remoteAddedHere = true
     }
   }
 
@@ -107,8 +111,9 @@ export async function prepareWorktreePushTargetWithExec(
   } catch (error) {
     // Why: the create this remote was added for is failing; leaving it behind
     // orphans a pr-* remote nothing will ever clean up (cleanup runs on worktree
-    // removal, and no worktree exists).
-    if (remoteCreated) {
+    // removal, and no worktree exists). A reused remote is still in use by the
+    // sibling worktree that owns it, so removing it would break that worktree.
+    if (remoteAddedHere) {
       await execGit(['remote', 'remove', remoteName], repoPath).catch(() => {})
     }
     throw error

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -1083,6 +1083,9 @@ async function prepareWorktreePushTargetSsh(
   await provider.exec(['check-ref-format', '--branch', target.branchName], repoPath)
   let remoteName = target.remoteName
   let remoteCreated = false
+  // Why: ownership above is inherited from sibling worktrees, so it can be true
+  // for a remote this call did not create. Only rollback needs that distinction.
+  let remoteAddedHere = false
   if (target.remoteUrl) {
     const existingRemote = await findRemoteForUrl(execGit, repoPath, target.remoteUrl)
     if (existingRemote) {
@@ -1112,6 +1115,7 @@ async function prepareWorktreePushTargetSsh(
         throw error
       }
       remoteCreated = true
+      remoteAddedHere = true
     }
   }
   try {
@@ -1124,7 +1128,8 @@ async function prepareWorktreePushTargetSsh(
   } catch (error) {
     // Why: mirrors the local path — a fetch failure aborts the create, so the
     // remote we just added on the host would be orphaned with no owner to clean it.
-    if (remoteCreated) {
+    // A reused remote belongs to a live sibling worktree; removing it breaks that one.
+    if (remoteAddedHere) {
       await provider.exec(['remote', 'remove', remoteName], repoPath).catch(() => {})
     }
     throw error

--- a/src/main/ipc/worktrees-ssh-fork-push-target-remote.test.ts
+++ b/src/main/ipc/worktrees-ssh-fork-push-target-remote.test.ts
@@ -269,4 +269,83 @@ describe('registerWorktreeHandlers', () => {
     expect(exec).toHaveBeenCalledWith(['remote', 'remove', 'pr-contributor-orca'], '/remote/repo')
     expect(provider.addWorktree).not.toHaveBeenCalled()
   })
+
+  // Regression: the rollback used to fire on ownership inherited from a sibling
+  // worktree, deleting the remote that worktree was still pushing through.
+  it('keeps a reused fork remote a sibling worktree owns when the SSH head fetch fails', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    const exec = vi.fn().mockImplementation(async (args: string[]) => {
+      validateGitExecArgs(args)
+      if (args[0] === 'remote' && args[1] === 'get-url') {
+        return {
+          stdout:
+            args[2] === 'pr-contributor-orca'
+              ? 'git@github.com:contributor/orca.git\n'
+              : 'git@github.com:stablyai/orca.git\n',
+          stderr: ''
+        }
+      }
+      if (args[0] === 'remote' && args.length === 1) {
+        return { stdout: 'origin\npr-contributor-orca\n', stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+    const provider = {
+      exec,
+      fetchRemoteTrackingRef: vi
+        .fn()
+        .mockImplementation(async (_repoPath: string, remote: string) => {
+          if (remote === 'pr-contributor-orca') {
+            throw new Error('network unreachable')
+          }
+        }),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([])
+    }
+    const mux = { request: vi.fn().mockResolvedValue(undefined), notify: vi.fn() }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    store.getAllWorktreeMeta.mockReturnValue({
+      'repo-ssh::/remote/repo-sibling': {
+        pushTarget: {
+          remoteName: 'pr-contributor-orca',
+          branchName: 'contributor/other',
+          remoteUrl: 'https://github.com/contributor/orca.git',
+          remoteCreated: true
+        }
+      }
+    })
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue(mux)
+
+    await expect(
+      handlers['worktrees:create'](null, {
+        repoId: 'repo-ssh',
+        name: 'contributor-fix',
+        branchNameOverride: 'contributor/fix',
+        pushTarget: {
+          remoteName: 'pr-contributor-orca',
+          branchName: 'contributor/fix',
+          remoteUrl: 'https://github.com/contributor/orca.git'
+        }
+      })
+    ).rejects.toThrow('network unreachable')
+
+    expect(exec).not.toHaveBeenCalledWith(
+      ['remote', 'remove', 'pr-contributor-orca'],
+      '/remote/repo'
+    )
+    expect(exec).not.toHaveBeenCalledWith(
+      ['remote', 'add', 'pr-contributor-orca', 'https://github.com/contributor/orca.git'],
+      '/remote/repo'
+    )
+  })
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​101 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​101 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​13 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​10 |

<!-- /orca-pr-loc -->

Split out of `616d2a4ec8c`, which also carried the Windows relay fix that shipped as #16550. Original work by @AmethystLiang; I dropped it from that branch so the release cherry-pick stayed minimal, and this is it getting its own PR. Unrelated to Windows.

## The bug

When a push target reuses an existing Orca-created fork remote, it deliberately **inherits ownership** of it, so that the last worktree using it can clean it up:

```ts
// Why: if a later PR worktree reuses an Orca-created fork remote, it
// must inherit ownership so deleting the final user can remove it.
remoteCreated = isRemoteCreatedByKnownWorktree(existingRemote)
```

Rollback then reused that same flag to decide whether to undo its own work:

```ts
} catch (error) {
  if (remoteCreated) {
    await execGit(['remote', 'remove', remoteName], repoPath).catch(() => {})
  }
  throw error
}
```

But `remoteCreated` being true doesn't mean *this call* added the remote — it can equally mean a sibling worktree added it and is still pushing to it. So if the fetch fails while creating a worktree that reused a sibling's fork remote, rollback deletes that remote out from under the sibling.

The two meanings were never separable from one flag: cleanup needs "does anyone own this," rollback needs "did I add this."

## The fix

Track `remoteAddedHere` alongside `remoteCreated`. Ownership semantics are unchanged — cleanup still inherits. Rollback now only removes a remote this call actually ran `remote add` for.

The local path (`worktree-push-target-setup.ts`) and the SSH path (`worktree-remote.ts`) had the same bug independently, so both are fixed.

## Validation

Both regression tests were confirmed to catch the bug — reverting just the production change while keeping the tests fails exactly the two new cases:

```
FAIL  worktree-push-target-setup.test.ts > keeps a reused remote a sibling worktree owns when the fetch fails
  AssertionError: expected [ [ 'remote', 'remove', …(1) ] ] to deeply equal []
FAIL  worktrees-ssh-fork-push-target-remote.test.ts > keeps a reused fork remote a sibling worktree owns when the SSH head fetch fails
  AssertionError: expected "vi.fn()" to not be called with arguments: [ [ 'remote', 'remove', …(1) ], …(1) ]
```

With the fix: 17/17 pass. `pnpm tc` clean, oxlint clean.