### PR TITLE
fix(agent-hooks): stop the Windows hook launcher spelling the AV-denied flag triple

### DIFF
--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -604,7 +604,7 @@ describe('wrapPosixHookCommand', () => {
 })
 
 const qualifiedWindowsPowerShellCommand =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -EncodedCommand \S+$/
 
 function decodeWindowsHookCommand(command: string): string {
   const encodedCommand = command.match(/ -EncodedCommand (\S+)$/)?.[1]
@@ -617,7 +617,7 @@ function expectedDecodedWindowsHookCommand(scriptPath: string): string {
   // Why: the execution-policy bypass rides in the payload, not on the command
   // line, so the launcher cannot spell the AV-blocked flag triple (#16003).
   // Why: PowerShell progress CLIXML corrupts consumers that merge stderr into JSON stdout.
-  return `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction SilentlyContinue; $ProgressPreference='SilentlyContinue'; if (Test-Path -LiteralPath ${quoted} -PathType Leaf) { & ${quoted}; exit $LASTEXITCODE }; [Console]::In.ReadToEnd() | Out-Null; exit 0`
+  return `try { Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction SilentlyContinue } catch {}; $ProgressPreference='SilentlyContinue'; if (Test-Path -LiteralPath ${quoted} -PathType Leaf) { & ${quoted}; exit $LASTEXITCODE }; [Console]::In.ReadToEnd() | Out-Null; exit 0`
 }
 
 describe('wrapWindowsHookCommand', () => {

--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -604,7 +604,7 @@ describe('wrapPosixHookCommand', () => {
 })
 
 const qualifiedWindowsPowerShellCommand =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
 
 function decodeWindowsHookCommand(command: string): string {
   const encodedCommand = command.match(/ -EncodedCommand (\S+)$/)?.[1]
@@ -743,6 +743,17 @@ describe('wrapRuntimeHomeHookCommand', () => {
       expect(command).not.toMatch(/\$\{[A-Za-z_][A-Za-z0-9_]*\}/)
     }
   )
+
+  it('hides the console on the Git Bash branch too, and still avoids the denied triple', () => {
+    // Why: this branch launches PowerShell from bash, where the parent has no
+    // console to inherit — Windows allocates a fresh one per hook event unless
+    // the switch says otherwise (#14815), and the AV verdict on the flag triple
+    // applies to the exact same string (#16003).
+    const command = wrapRuntimeHomeHookCommand('claude-hook')
+
+    expect(command).toContain('powershell.exe" -NoProfile -WindowStyle Hidden -EncodedCommand ')
+    expect(command).not.toMatch(/-ExecutionPolicy/i)
+  })
 
   it('rejects a script base name that could inject shell syntax', () => {
     expect(() => wrapRuntimeHomeHookCommand('claude-hook; echo injected')).toThrow(

--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -604,7 +604,7 @@ describe('wrapPosixHookCommand', () => {
 })
 
 const qualifiedWindowsPowerShellCommand =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
 
 function decodeWindowsHookCommand(command: string): string {
   const encodedCommand = command.match(/ -EncodedCommand (\S+)$/)?.[1]
@@ -614,8 +614,10 @@ function decodeWindowsHookCommand(command: string): string {
 
 function expectedDecodedWindowsHookCommand(scriptPath: string): string {
   const quoted = `'${scriptPath.replaceAll("'", "''")}'`
+  // Why: the execution-policy bypass rides in the payload, not on the command
+  // line, so the launcher cannot spell the AV-blocked flag triple (#16003).
   // Why: PowerShell progress CLIXML corrupts consumers that merge stderr into JSON stdout.
-  return `$ProgressPreference='SilentlyContinue'; if (Test-Path -LiteralPath ${quoted} -PathType Leaf) { & ${quoted}; exit $LASTEXITCODE }; [Console]::In.ReadToEnd() | Out-Null; exit 0`
+  return `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction SilentlyContinue; $ProgressPreference='SilentlyContinue'; if (Test-Path -LiteralPath ${quoted} -PathType Leaf) { & ${quoted}; exit $LASTEXITCODE }; [Console]::In.ReadToEnd() | Out-Null; exit 0`
 }
 
 describe('wrapWindowsHookCommand', () => {

--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -617,7 +617,7 @@ function expectedDecodedWindowsHookCommand(scriptPath: string): string {
   // Why: the execution-policy bypass rides in the payload, not on the command
   // line, so the launcher cannot spell the AV-blocked flag triple (#16003).
   // Why: PowerShell progress CLIXML corrupts consumers that merge stderr into JSON stdout.
-  return `try { Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction SilentlyContinue } catch {}; $ProgressPreference='SilentlyContinue'; if (Test-Path -LiteralPath ${quoted} -PathType Leaf) { & ${quoted}; exit $LASTEXITCODE }; [Console]::In.ReadToEnd() | Out-Null; exit 0`
+  return `$ProgressPreference='SilentlyContinue'; try { Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction SilentlyContinue } catch {}; if (Test-Path -LiteralPath ${quoted} -PathType Leaf) { & ${quoted}; exit $LASTEXITCODE }; [Console]::In.ReadToEnd() | Out-Null; exit 0`
 }
 
 describe('wrapWindowsHookCommand', () => {

--- a/src/main/agent-hooks/runtime-home-hook-command.ts
+++ b/src/main/agent-hooks/runtime-home-hook-command.ts
@@ -24,7 +24,7 @@ export function wrapRuntimeHomeHookCommand(
   const powershellFallback = options.neutralJsonWhenMissing ? "; Write-Output '{}'" : ''
   const powershellCommand = `$homePath = $env:HOME -replace '^/([A-Za-z])/', '$1:/'; $scriptPath = Join-Path $homePath '.orca\\agent-hooks\\${scriptBaseName}.cmd'; if (Test-Path -LiteralPath $scriptPath -PathType Leaf) { & $scriptPath; exit $LASTEXITCODE }; [Console]::In.ReadToEnd() | Out-Null${powershellFallback}; exit 0`
   const encodedCommand = encodeWindowsPowerShellHookCommand(powershellCommand)
-  // Why: the Git Bash and native Windows launchers must suppress windows identically (#14815).
+  // Why: the Git Bash and native Windows launchers must spell the same switches — an AV verdict on one shape hits both (#16003).
   const powershellInvocation = `${powershell} ${WINDOWS_POWERSHELL_HOOK_SWITCHES} -EncodedCommand ${encodedCommand}`
   const encodedWindowsBranch = `if [ -f ${powershell} ]; then ${powershellInvocation}; else ${missingScriptFallback}; fi`
   const windowsBranch = `if [ -f ${windowsScript} ]; then case "\${HOME-}" in ${WINDOWS_GIT_BASH_RUNTIME_HOME_UNSAFE}) ${encodedWindowsBranch} ;; *) ${windowsScript} ;; esac; else ${missingScriptFallback}; fi`

--- a/src/main/agent-hooks/runtime-home-hook-command.ts
+++ b/src/main/agent-hooks/runtime-home-hook-command.ts
@@ -24,7 +24,7 @@ export function wrapRuntimeHomeHookCommand(
   const powershellFallback = options.neutralJsonWhenMissing ? "; Write-Output '{}'" : ''
   const powershellCommand = `$homePath = $env:HOME -replace '^/([A-Za-z])/', '$1:/'; $scriptPath = Join-Path $homePath '.orca\\agent-hooks\\${scriptBaseName}.cmd'; if (Test-Path -LiteralPath $scriptPath -PathType Leaf) { & $scriptPath; exit $LASTEXITCODE }; [Console]::In.ReadToEnd() | Out-Null${powershellFallback}; exit 0`
   const encodedCommand = encodeWindowsPowerShellHookCommand(powershellCommand)
-  // Why: the Git Bash and native Windows launchers must spell the same switches — an AV verdict on one shape hits both (#16003).
+  // Why: the Git Bash and native Windows launchers must spell the same switches — window suppression (#14815) and an AV verdict on the shape (#16003) both hit either path.
   const powershellInvocation = `${powershell} ${WINDOWS_POWERSHELL_HOOK_SWITCHES} -EncodedCommand ${encodedCommand}`
   const encodedWindowsBranch = `if [ -f ${powershell} ]; then ${powershellInvocation}; else ${missingScriptFallback}; fi`
   const windowsBranch = `if [ -f ${windowsScript} ]; then case "\${HOME-}" in ${WINDOWS_GIT_BASH_RUNTIME_HOME_UNSAFE}) ${encodedWindowsBranch} ;; *) ${windowsScript} ;; esac; else ${missingScriptFallback}; fi`

--- a/src/main/agent-hooks/windows-powershell-hook-launcher.test.ts
+++ b/src/main/agent-hooks/windows-powershell-hook-launcher.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import {
+  encodeWindowsPowerShellHookCommand,
+  WINDOWS_POWERSHELL_HOOK_SWITCHES,
+  wrapWindowsPowerShellEncodedCommand
+} from './windows-powershell-hook-launcher'
+
+function decodePayload(command: string): string {
+  const encoded = command.match(/ -EncodedCommand (\S+)$/)?.[1]
+  expect(encoded).toBeTruthy()
+  return Buffer.from(encoded!, 'base64').toString('utf16le')
+}
+
+/*
+ * #16003: endpoint security (reproduced with Kaspersky, but the shape is the
+ * generic "hidden encoded PowerShell" signature) denies process creation for
+ * `-ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand` regardless of
+ * what the payload decodes to. Every Orca-injected hook then failed with
+ * `powershell.exe: Permission denied` on every turn, and no AV exclusion
+ * re-enabled it. Dropping any one of the three flags clears the signature.
+ */
+describe('windows PowerShell hook launcher', () => {
+  it('never spells the denied flag triple on the command line', () => {
+    const command = wrapWindowsPowerShellEncodedCommand('exit 0')
+
+    expect(WINDOWS_POWERSHELL_HOOK_SWITCHES).not.toMatch(/-ExecutionPolicy/i)
+    expect(command).not.toMatch(/-ExecutionPolicy/i)
+    // The two remaining flags are what make the launcher useful; keep them.
+    expect(command).toContain('-WindowStyle Hidden')
+    expect(command).toContain('-EncodedCommand')
+  })
+
+  it('keeps the execution-policy bypass, in the payload where AV cannot read it', () => {
+    // Why it must survive somewhere: Copilot's managed hook is a .ps1, which a
+    // Restricted or AllSigned machine policy refuses to run without a bypass.
+    // Process scope is exactly what the switch used to set.
+    expect(decodePayload(wrapWindowsPowerShellEncodedCommand('exit 0'))).toContain(
+      'Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction SilentlyContinue;'
+    )
+  })
+
+  it('applies the bypass before the caller command and keeps progress silenced', () => {
+    const decoded = Buffer.from(
+      encodeWindowsPowerShellHookCommand('& $scriptPath'),
+      'base64'
+    ).toString('utf16le')
+
+    expect(decoded).toMatch(
+      /^Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction SilentlyContinue; \$ProgressPreference='SilentlyContinue'; & \$scriptPath$/
+    )
+  })
+})

--- a/src/main/agent-hooks/windows-powershell-hook-launcher.test.ts
+++ b/src/main/agent-hooks/windows-powershell-hook-launcher.test.ts
@@ -12,22 +12,32 @@ function decodePayload(command: string): string {
 }
 
 /*
- * #16003: endpoint security (reproduced with Kaspersky, but the shape is the
- * generic "hidden encoded PowerShell" signature) denies process creation for
- * `-ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand` regardless of
- * what the payload decodes to. Every Orca-injected hook then failed with
- * `powershell.exe: Permission denied` on every turn, and no AV exclusion
- * re-enabled it. Dropping any one of the three flags clears the signature.
+ * #16003: endpoint security (reproduced with Kaspersky Premium on Windows 11)
+ * denies process creation for `-ExecutionPolicy Bypass -WindowStyle Hidden
+ * -EncodedCommand` regardless of what the payload decodes to, and no AV
+ * exclusion re-enabled it. The reporter measured exactly four command lines;
+ * the only encoded one that ran was `-NoProfile -EncodedCommand <b64>`. No
+ * measurement exists for a shape that drops just one flag, so the launcher must
+ * emit the measured-passing shape rather than an interpolated one.
  */
 describe('windows PowerShell hook launcher', () => {
-  it('never spells the denied flag triple on the command line', () => {
+  it('emits only the encoded command line the affected host measured as allowed', () => {
     const command = wrapWindowsPowerShellEncodedCommand('exit 0')
 
+    expect(WINDOWS_POWERSHELL_HOOK_SWITCHES).toBe('-NoProfile')
+    expect(command).toMatch(/ -NoProfile -EncodedCommand [A-Za-z0-9+/=]+$/)
+  })
+
+  it('spells neither flag of the denied "hidden encoded PowerShell" pair', () => {
+    // -WindowStyle Hidden alongside -EncodedCommand *is* the signature the
+    // denial is named for; unmeasured on the affected host, so it cannot ship.
+    const command = wrapWindowsPowerShellEncodedCommand('exit 0')
+
+    expect(WINDOWS_POWERSHELL_HOOK_SWITCHES).not.toMatch(/-WindowStyle/i)
     expect(WINDOWS_POWERSHELL_HOOK_SWITCHES).not.toMatch(/-ExecutionPolicy/i)
-    expect(command).not.toMatch(/-ExecutionPolicy/i)
-    // The two remaining flags are what make the launcher useful; keep them.
-    expect(command).toContain('-WindowStyle Hidden')
-    expect(command).toContain('-EncodedCommand')
+    expect(command.replace(/ -EncodedCommand \S+$/, '')).not.toMatch(
+      /-WindowStyle|-ExecutionPolicy/i
+    )
   })
 
   it('keeps the execution-policy bypass, in the payload where AV cannot read it', () => {
@@ -35,8 +45,18 @@ describe('windows PowerShell hook launcher', () => {
     // Restricted or AllSigned machine policy refuses to run without a bypass.
     // Process scope is exactly what the switch used to set.
     expect(decodePayload(wrapWindowsPowerShellEncodedCommand('exit 0'))).toContain(
-      'Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction SilentlyContinue;'
+      'Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction SilentlyContinue'
     )
+  })
+
+  it('swallows a terminating execution-policy failure, not just a non-terminating one', () => {
+    // A GPO MachinePolicy/UserPolicy scope makes the cmdlet complain that the
+    // process scope did not take. -ErrorAction covers only the non-terminating
+    // half; the switch this replaced printed nothing either way, and an
+    // ErrorRecord on stderr corrupts consumers that merge our streams into JSON.
+    const decoded = decodePayload(wrapWindowsPowerShellEncodedCommand('exit 0'))
+
+    expect(decoded).toMatch(/try \{[^}]*Set-ExecutionPolicy[^}]*\} catch \{\}/)
   })
 
   it('applies the bypass before the caller command and keeps progress silenced', () => {
@@ -45,8 +65,8 @@ describe('windows PowerShell hook launcher', () => {
       'base64'
     ).toString('utf16le')
 
-    expect(decoded).toMatch(
-      /^Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction SilentlyContinue; \$ProgressPreference='SilentlyContinue'; & \$scriptPath$/
+    expect(decoded).toBe(
+      "try { Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction SilentlyContinue } catch {}; $ProgressPreference='SilentlyContinue'; & $scriptPath"
     )
   })
 })

--- a/src/main/agent-hooks/windows-powershell-hook-launcher.test.ts
+++ b/src/main/agent-hooks/windows-powershell-hook-launcher.test.ts
@@ -12,32 +12,38 @@ function decodePayload(command: string): string {
 }
 
 /*
- * #16003: endpoint security (reproduced with Kaspersky Premium on Windows 11)
- * denies process creation for `-ExecutionPolicy Bypass -WindowStyle Hidden
- * -EncodedCommand` regardless of what the payload decodes to, and no AV
- * exclusion re-enabled it. The reporter measured exactly four command lines;
- * the only encoded one that ran was `-NoProfile -EncodedCommand <b64>`. No
- * measurement exists for a shape that drops just one flag, so the launcher must
- * emit the measured-passing shape rather than an interpolated one.
+ * Two reproduced Windows failures constrain this one string, in opposite
+ * directions:
+ *
+ * #16003 — endpoint security (Kaspersky Premium, Windows 11) denies process
+ * creation for `-ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand`
+ * whatever the payload decodes to, and no exclusion re-enabled it. The triple
+ * must stop being spelled.
+ *
+ * #14815 (+ #14828, #15117, #15447, #15767) — without `-WindowStyle Hidden`
+ * every hook event allocates a console that takes foreground and eats the
+ * user's keystrokes, and strands a visible window outright when the hook blocks
+ * on stdin. Window suppression must stay.
+ *
+ * Both hold only if the flag that leaves the command line is the policy bypass,
+ * which is the one with an exact in-payload equivalent.
  */
 describe('windows PowerShell hook launcher', () => {
-  it('emits only the encoded command line the affected host measured as allowed', () => {
+  it('never spells the denied flag triple on the command line', () => {
     const command = wrapWindowsPowerShellEncodedCommand('exit 0')
 
-    expect(WINDOWS_POWERSHELL_HOOK_SWITCHES).toBe('-NoProfile')
-    expect(command).toMatch(/ -NoProfile -EncodedCommand [A-Za-z0-9+/=]+$/)
+    expect(WINDOWS_POWERSHELL_HOOK_SWITCHES).not.toMatch(/-ExecutionPolicy/i)
+    expect(command.replace(/ -EncodedCommand \S+$/, '')).not.toMatch(/-ExecutionPolicy/i)
   })
 
-  it('spells neither flag of the denied "hidden encoded PowerShell" pair', () => {
-    // -WindowStyle Hidden alongside -EncodedCommand *is* the signature the
-    // denial is named for; unmeasured on the affected host, so it cannot ship.
+  it('keeps hiding the console window on every hook event (#14815)', () => {
+    // Dropping this flag is not a cosmetic flash: the console takes foreground
+    // and swallows what the user is typing into Orca (#14828), and never closes
+    // at all when the hook blocks reading stdin (#14815).
     const command = wrapWindowsPowerShellEncodedCommand('exit 0')
 
-    expect(WINDOWS_POWERSHELL_HOOK_SWITCHES).not.toMatch(/-WindowStyle/i)
-    expect(WINDOWS_POWERSHELL_HOOK_SWITCHES).not.toMatch(/-ExecutionPolicy/i)
-    expect(command.replace(/ -EncodedCommand \S+$/, '')).not.toMatch(
-      /-WindowStyle|-ExecutionPolicy/i
-    )
+    expect(WINDOWS_POWERSHELL_HOOK_SWITCHES).toBe('-NoProfile -WindowStyle Hidden')
+    expect(command).toMatch(/ -NoProfile -WindowStyle Hidden -EncodedCommand [A-Za-z0-9+/=]+$/)
   })
 
   it('keeps the execution-policy bypass, in the payload where AV cannot read it', () => {

--- a/src/main/agent-hooks/windows-powershell-hook-launcher.test.ts
+++ b/src/main/agent-hooks/windows-powershell-hook-launcher.test.ts
@@ -72,7 +72,25 @@ describe('windows PowerShell hook launcher', () => {
     ).toString('utf16le')
 
     expect(decoded).toBe(
-      "try { Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction SilentlyContinue } catch {}; $ProgressPreference='SilentlyContinue'; & $scriptPath"
+      "$ProgressPreference='SilentlyContinue'; try { Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction SilentlyContinue } catch {}; & $scriptPath"
+    )
+  })
+
+  it('silences progress before anything that can autoload a module', () => {
+    // Set-ExecutionPolicy pulls in Microsoft.PowerShell.Security, and its
+    // "Preparing modules for first use." progress record is written before a
+    // later assignment can suppress it. Measured on Windows 11: bypass-first put
+    // 616 bytes of <Objs Version="1.1.0.1"> on stderr and made "#< CLIXML" the
+    // first merged line -- the exact corruption HOOK_PROGRESS_SILENCER exists to
+    // stop. Silencer-first measured 0 bytes.
+    const decoded = Buffer.from(
+      encodeWindowsPowerShellHookCommand('& $scriptPath'),
+      'base64'
+    ).toString('utf16le')
+
+    expect(decoded.indexOf("$ProgressPreference='SilentlyContinue'")).toBeGreaterThanOrEqual(0)
+    expect(decoded.indexOf("$ProgressPreference='SilentlyContinue'")).toBeLessThan(
+      decoded.indexOf('Set-ExecutionPolicy')
     )
   })
 })

--- a/src/main/agent-hooks/windows-powershell-hook-launcher.ts
+++ b/src/main/agent-hooks/windows-powershell-hook-launcher.ts
@@ -14,28 +14,26 @@ export function getWindowsPowerShellExecutablePath(): string {
  * Switches for the PowerShell that relays hook output and exit status
  * (#14818 — conhost does neither).
  *
- * Only `-NoProfile` survives on the command line, because `-NoProfile
- * -EncodedCommand <b64>` is the one encoded shape the #16003 reporter actually
- * ran on the affected machine (Kaspersky Premium, Windows 11) and saw exit 0.
- * The four measured rows there were:
+ * `-WindowStyle Hidden` stays. It is the shipped fix for #14815 and its four
+ * duplicates (#14828, #15117, #15447, #15767): without it Windows allocates a
+ * console per hook event, which steals foreground from whatever the user is
+ * typing into, and strands a permanently visible window whenever a hook blocks
+ * reading stdin (see hook-stdin-contract.ts). Those are reported, reproduced
+ * user-facing failures on every hook event of every managed agent.
  *
- *   -NoProfile -WindowStyle Hidden -Command 'exit 0'                     -> 0
- *   -NoProfile -EncodedCommand <b64>                                     -> 0
- *   -NoProfile -ExecutionPolicy Bypass -Command 'exit 0'                 -> 0
- *   -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand -> 126
+ * `-ExecutionPolicy Bypass` is the flag that leaves the command line, because
+ * it is the only one of the three with an exact in-payload equivalent (below):
+ * it costs nothing to move. #16003 measured `-NoProfile -ExecutionPolicy Bypass
+ * -WindowStyle Hidden -EncodedCommand` as denied at CreateProcess (exit 126,
+ * Kaspersky Premium on Windows 11) no matter what the payload decodes to, so
+ * the triple has to stop being spelled; dropping the policy flag breaks it.
  *
- * Every passing row drops two of the three flags; none drops exactly one, so
- * "drop any one flag" is extrapolation, not measurement. `-WindowStyle Hidden
- * -EncodedCommand` is itself the "hidden encoded PowerShell" shape the denial
- * is named for, so keeping it would be a guess. Dropping it costs at most a
- * console flash where the parent has no console to inherit; keeping
- * `-Command` instead of `-EncodedCommand` would cost path and switch integrity
- * across cmd.exe and MSYS (#6078, #14815), which is a correctness loss.
- *
- * `-ExecutionPolicy Bypass` moves into the encoded payload below, where it is
- * the same process-scope setting with the same power.
+ * What is not established: that the remaining pair clears that AV signature —
+ * the reporter measured no two-flag encoded shape. If it turns out not to, the
+ * answer is another launcher shape that still suppresses the window, not
+ * trading a reproduced regression for an unmeasured hope.
  */
-export const WINDOWS_POWERSHELL_HOOK_SWITCHES = '-NoProfile'
+export const WINDOWS_POWERSHELL_HOOK_SWITCHES = '-NoProfile -WindowStyle Hidden'
 
 // Why: redirected PowerShell progress becomes CLIXML that can corrupt merged JSON output.
 const HOOK_PROGRESS_SILENCER = "$ProgressPreference='SilentlyContinue'; "

--- a/src/main/agent-hooks/windows-powershell-hook-launcher.ts
+++ b/src/main/agent-hooks/windows-powershell-hook-launcher.ts
@@ -10,16 +10,43 @@ export function getWindowsPowerShellExecutablePath(): string {
   return getWindowsSystem32Path('WindowsPowerShell/v1.0/powershell.exe')
 }
 
-// Why: unlike conhost, hidden PowerShell relays hook output and exit status (#14818).
-export const WINDOWS_POWERSHELL_HOOK_SWITCHES =
-  '-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden'
+/**
+ * Switches for the hidden PowerShell that relays hook output and exit status
+ * (#14818 — conhost does neither).
+ *
+ * `-ExecutionPolicy Bypass` is deliberately absent. Spelled on the command line
+ * it completes `-ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand`,
+ * the textbook "hidden encoded PowerShell" malware shape, and endpoint security
+ * denies that combination at process creation whatever the payload decodes to —
+ * even `exit 0`. Users saw every hook fail with `powershell.exe: Permission
+ * denied` (exit 126 from bash's execve, i.e. EACCES) on every turn, with no
+ * exclusion that re-enabled it (#16003). Dropping any one of the three flags
+ * clears the signature, so the bypass moves into the encoded payload below,
+ * where it is the same process-scope setting with the same power.
+ */
+export const WINDOWS_POWERSHELL_HOOK_SWITCHES = '-NoProfile -WindowStyle Hidden'
 
 // Why: redirected PowerShell progress becomes CLIXML that can corrupt merged JSON output.
 const HOOK_PROGRESS_SILENCER = "$ProgressPreference='SilentlyContinue'; "
 
+/**
+ * Process-scope stand-in for the `-ExecutionPolicy Bypass` switch (#16003).
+ *
+ * Equivalent by construction: the switch sets the Process scope too, and both
+ * lose to a Group Policy scope. `-EncodedCommand` itself is never policy-gated,
+ * so this always gets to run; it is what lets the managed `.ps1` hooks (Copilot)
+ * execute under a Restricted or AllSigned machine policy. Failures are swallowed
+ * because a hook must still answer its agent when the policy is locked down.
+ */
+const HOOK_EXECUTION_POLICY_BYPASS =
+  'Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction SilentlyContinue; '
+
 // Why: encoding shields paths and switches from cmd.exe and MSYS rewriting (#6078, #14815).
 export function encodeWindowsPowerShellHookCommand(command: string): string {
-  return Buffer.from(`${HOOK_PROGRESS_SILENCER}${command}`, 'utf16le').toString('base64')
+  return Buffer.from(
+    `${HOOK_EXECUTION_POLICY_BYPASS}${HOOK_PROGRESS_SILENCER}${command}`,
+    'utf16le'
+  ).toString('base64')
 }
 
 export function wrapWindowsPowerShellEncodedCommand(command: string): string {

--- a/src/main/agent-hooks/windows-powershell-hook-launcher.ts
+++ b/src/main/agent-hooks/windows-powershell-hook-launcher.ts
@@ -35,7 +35,12 @@ export function getWindowsPowerShellExecutablePath(): string {
  */
 export const WINDOWS_POWERSHELL_HOOK_SWITCHES = '-NoProfile -WindowStyle Hidden'
 
-// Why: redirected PowerShell progress becomes CLIXML that can corrupt merged JSON output.
+// Why: redirected PowerShell progress becomes CLIXML that can corrupt merged JSON
+// output. It must be the FIRST statement: Set-ExecutionPolicy autoloads
+// Microsoft.PowerShell.Security, whose "Preparing modules for first use."
+// progress record is emitted before any later assignment can suppress it.
+// Measured on Windows 11: bypass-first put 616 bytes of <Objs Version="1.1.0.1">
+// on stderr and made "#< CLIXML" the first merged line; silencer-first, 0 bytes.
 const HOOK_PROGRESS_SILENCER = "$ProgressPreference='SilentlyContinue'; "
 
 /**
@@ -60,7 +65,7 @@ const HOOK_EXECUTION_POLICY_BYPASS =
 // Why: encoding shields paths and switches from cmd.exe and MSYS rewriting (#6078, #14815).
 export function encodeWindowsPowerShellHookCommand(command: string): string {
   return Buffer.from(
-    `${HOOK_EXECUTION_POLICY_BYPASS}${HOOK_PROGRESS_SILENCER}${command}`,
+    `${HOOK_PROGRESS_SILENCER}${HOOK_EXECUTION_POLICY_BYPASS}${command}`,
     'utf16le'
   ).toString('base64')
 }

--- a/src/main/agent-hooks/windows-powershell-hook-launcher.ts
+++ b/src/main/agent-hooks/windows-powershell-hook-launcher.ts
@@ -1,4 +1,4 @@
-// Why: centralizing the launcher keeps window suppression consistent across installers (#14815).
+// Why: centralizing the launcher keeps every installer on one command shape; #14815 and #16003 both turned on which shape it is.
 
 // Why: an absolute forward-slash path avoids PATH hijacking and survives cmd.exe and Git Bash.
 export function getWindowsSystem32Path(relativePath: string): string {
@@ -11,20 +11,31 @@ export function getWindowsPowerShellExecutablePath(): string {
 }
 
 /**
- * Switches for the hidden PowerShell that relays hook output and exit status
+ * Switches for the PowerShell that relays hook output and exit status
  * (#14818 — conhost does neither).
  *
- * `-ExecutionPolicy Bypass` is deliberately absent. Spelled on the command line
- * it completes `-ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand`,
- * the textbook "hidden encoded PowerShell" malware shape, and endpoint security
- * denies that combination at process creation whatever the payload decodes to —
- * even `exit 0`. Users saw every hook fail with `powershell.exe: Permission
- * denied` (exit 126 from bash's execve, i.e. EACCES) on every turn, with no
- * exclusion that re-enabled it (#16003). Dropping any one of the three flags
- * clears the signature, so the bypass moves into the encoded payload below,
- * where it is the same process-scope setting with the same power.
+ * Only `-NoProfile` survives on the command line, because `-NoProfile
+ * -EncodedCommand <b64>` is the one encoded shape the #16003 reporter actually
+ * ran on the affected machine (Kaspersky Premium, Windows 11) and saw exit 0.
+ * The four measured rows there were:
+ *
+ *   -NoProfile -WindowStyle Hidden -Command 'exit 0'                     -> 0
+ *   -NoProfile -EncodedCommand <b64>                                     -> 0
+ *   -NoProfile -ExecutionPolicy Bypass -Command 'exit 0'                 -> 0
+ *   -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand -> 126
+ *
+ * Every passing row drops two of the three flags; none drops exactly one, so
+ * "drop any one flag" is extrapolation, not measurement. `-WindowStyle Hidden
+ * -EncodedCommand` is itself the "hidden encoded PowerShell" shape the denial
+ * is named for, so keeping it would be a guess. Dropping it costs at most a
+ * console flash where the parent has no console to inherit; keeping
+ * `-Command` instead of `-EncodedCommand` would cost path and switch integrity
+ * across cmd.exe and MSYS (#6078, #14815), which is a correctness loss.
+ *
+ * `-ExecutionPolicy Bypass` moves into the encoded payload below, where it is
+ * the same process-scope setting with the same power.
  */
-export const WINDOWS_POWERSHELL_HOOK_SWITCHES = '-NoProfile -WindowStyle Hidden'
+export const WINDOWS_POWERSHELL_HOOK_SWITCHES = '-NoProfile'
 
 // Why: redirected PowerShell progress becomes CLIXML that can corrupt merged JSON output.
 const HOOK_PROGRESS_SILENCER = "$ProgressPreference='SilentlyContinue'; "
@@ -35,11 +46,18 @@ const HOOK_PROGRESS_SILENCER = "$ProgressPreference='SilentlyContinue'; "
  * Equivalent by construction: the switch sets the Process scope too, and both
  * lose to a Group Policy scope. `-EncodedCommand` itself is never policy-gated,
  * so this always gets to run; it is what lets the managed `.ps1` hooks (Copilot)
- * execute under a Restricted or AllSigned machine policy. Failures are swallowed
- * because a hook must still answer its agent when the policy is locked down.
+ * execute under a Restricted or AllSigned machine policy.
+ *
+ * try/catch as well as `-ErrorAction SilentlyContinue`: under a MachinePolicy or
+ * UserPolicy GPO the cmdlet reports that the process scope did not take, and
+ * `-ErrorAction` only governs the non-terminating half of that. The switch this
+ * replaces printed nothing at all in the same situation, and an ErrorRecord on
+ * stderr is a live corruption risk for the consumers that merge our streams into
+ * JSON stdout (see the progress silencer above). A hook must still answer its
+ * agent when the policy is locked down.
  */
 const HOOK_EXECUTION_POLICY_BYPASS =
-  'Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction SilentlyContinue; '
+  'try { Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction SilentlyContinue } catch {}; '
 
 // Why: encoding shields paths and switches from cmd.exe and MSYS rewriting (#6078, #14815).
 export function encodeWindowsPowerShellHookCommand(command: string): string {

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -40,9 +40,7 @@ describe('getWindowsManagedLifecycleHook', () => {
     const hook = getWindowsManagedLifecycleHook(scriptPath)
 
     expect(hook.args).toBeUndefined()
-    expect(hook.command).toMatch(
-      /\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden /
-    )
+    expect(hook.command).toMatch(/\/powershell\.exe -NoProfile -WindowStyle Hidden /)
     expect(hook.command).not.toContain(scriptPath)
     // Why: Git Bash/MSYS mangles backslash paths and slash-prefixed switches.
     expect(hook.command.replace(/-EncodedCommand \S+$/, '')).not.toMatch(/\\| \/[a-zA-Z]+( |$)/)
@@ -384,9 +382,7 @@ describe('ClaudeHookService.install', () => {
         for (const eventName of ['UserPromptSubmit', 'Stop', 'StopFailure']) {
           const hook = settings.hooks[eventName]?.[0]?.hooks?.[0]
           expect(hook?.args).toBeUndefined()
-          expect(hook?.command).toMatch(
-            /\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden /
-          )
+          expect(hook?.command).toMatch(/\/powershell\.exe -NoProfile -WindowStyle Hidden /)
           expect(hook?.command).not.toContain(scriptPath)
 
           const encoded = hook?.command.match(/-EncodedCommand (\S+)$/)?.[1]

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -40,7 +40,9 @@ describe('getWindowsManagedLifecycleHook', () => {
     const hook = getWindowsManagedLifecycleHook(scriptPath)
 
     expect(hook.args).toBeUndefined()
-    expect(hook.command).toMatch(/\/powershell\.exe -NoProfile -EncodedCommand /)
+    expect(hook.command).toMatch(
+      /\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand /
+    )
     expect(hook.command).not.toContain(scriptPath)
     // Why: Git Bash/MSYS mangles backslash paths and slash-prefixed switches.
     expect(hook.command.replace(/-EncodedCommand \S+$/, '')).not.toMatch(/\\| \/[a-zA-Z]+( |$)/)
@@ -382,7 +384,9 @@ describe('ClaudeHookService.install', () => {
         for (const eventName of ['UserPromptSubmit', 'Stop', 'StopFailure']) {
           const hook = settings.hooks[eventName]?.[0]?.hooks?.[0]
           expect(hook?.args).toBeUndefined()
-          expect(hook?.command).toMatch(/\/powershell\.exe -NoProfile -EncodedCommand /)
+          expect(hook?.command).toMatch(
+            /\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand /
+          )
           expect(hook?.command).not.toContain(scriptPath)
 
           const encoded = hook?.command.match(/-EncodedCommand (\S+)$/)?.[1]

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -40,7 +40,7 @@ describe('getWindowsManagedLifecycleHook', () => {
     const hook = getWindowsManagedLifecycleHook(scriptPath)
 
     expect(hook.args).toBeUndefined()
-    expect(hook.command).toMatch(/\/powershell\.exe -NoProfile -WindowStyle Hidden /)
+    expect(hook.command).toMatch(/\/powershell\.exe -NoProfile -EncodedCommand /)
     expect(hook.command).not.toContain(scriptPath)
     // Why: Git Bash/MSYS mangles backslash paths and slash-prefixed switches.
     expect(hook.command.replace(/-EncodedCommand \S+$/, '')).not.toMatch(/\\| \/[a-zA-Z]+( |$)/)
@@ -382,7 +382,7 @@ describe('ClaudeHookService.install', () => {
         for (const eventName of ['UserPromptSubmit', 'Stop', 'StopFailure']) {
           const hook = settings.hooks[eventName]?.[0]?.hooks?.[0]
           expect(hook?.args).toBeUndefined()
-          expect(hook?.command).toMatch(/\/powershell\.exe -NoProfile -WindowStyle Hidden /)
+          expect(hook?.command).toMatch(/\/powershell\.exe -NoProfile -EncodedCommand /)
           expect(hook?.command).not.toContain(scriptPath)
 
           const encoded = hook?.command.match(/-EncodedCommand (\S+)$/)?.[1]

--- a/src/main/codex/hook-service-managed-install.test.ts
+++ b/src/main/codex/hook-service-managed-install.test.ts
@@ -30,7 +30,7 @@ vi.mock('os', async (importOriginal) => {
 import { CodexHookService } from './hook-service'
 
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
 
 const homes = setupCodexHookHomes(homedirMock, getPathMock)
 

--- a/src/main/codex/hook-service-managed-install.test.ts
+++ b/src/main/codex/hook-service-managed-install.test.ts
@@ -30,7 +30,7 @@ vi.mock('os', async (importOriginal) => {
 import { CodexHookService } from './hook-service'
 
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
 
 const homes = setupCodexHookHomes(homedirMock, getPathMock)
 

--- a/src/main/codex/hook-service-managed-install.test.ts
+++ b/src/main/codex/hook-service-managed-install.test.ts
@@ -30,7 +30,7 @@ vi.mock('os', async (importOriginal) => {
 import { CodexHookService } from './hook-service'
 
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -EncodedCommand \S+$/
 
 const homes = setupCodexHookHomes(homedirMock, getPathMock)
 

--- a/src/main/command-code/hook-service.test.ts
+++ b/src/main/command-code/hook-service.test.ts
@@ -21,7 +21,7 @@ vi.mock('os', async () => {
 import { CommandCodeHookService } from './hook-service'
 
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
 
 describe('CommandCodeHookService', () => {
   let homeDir: string

--- a/src/main/command-code/hook-service.test.ts
+++ b/src/main/command-code/hook-service.test.ts
@@ -21,7 +21,7 @@ vi.mock('os', async () => {
 import { CommandCodeHookService } from './hook-service'
 
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -EncodedCommand \S+$/
 
 describe('CommandCodeHookService', () => {
   let homeDir: string

--- a/src/main/command-code/hook-service.test.ts
+++ b/src/main/command-code/hook-service.test.ts
@@ -21,7 +21,7 @@ vi.mock('os', async () => {
 import { CommandCodeHookService } from './hook-service'
 
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
 
 describe('CommandCodeHookService', () => {
   let homeDir: string

--- a/src/main/cursor/hook-service.test.ts
+++ b/src/main/cursor/hook-service.test.ts
@@ -31,7 +31,7 @@ const CURSOR_EVENTS = [
 
 const CURSOR_SCRIPT_FILE_NAME = process.platform === 'win32' ? 'cursor-hook.cmd' : 'cursor-hook.sh'
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
 
 describe('CursorHookService', () => {
   let homeDir: string

--- a/src/main/cursor/hook-service.test.ts
+++ b/src/main/cursor/hook-service.test.ts
@@ -31,7 +31,7 @@ const CURSOR_EVENTS = [
 
 const CURSOR_SCRIPT_FILE_NAME = process.platform === 'win32' ? 'cursor-hook.cmd' : 'cursor-hook.sh'
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
 
 describe('CursorHookService', () => {
   let homeDir: string

--- a/src/main/cursor/hook-service.test.ts
+++ b/src/main/cursor/hook-service.test.ts
@@ -31,7 +31,7 @@ const CURSOR_EVENTS = [
 
 const CURSOR_SCRIPT_FILE_NAME = process.platform === 'win32' ? 'cursor-hook.cmd' : 'cursor-hook.sh'
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -EncodedCommand \S+$/
 
 describe('CursorHookService', () => {
   let homeDir: string

--- a/src/main/droid/hook-service.test.ts
+++ b/src/main/droid/hook-service.test.ts
@@ -25,7 +25,7 @@ vi.mock('os', async () => {
 import { DroidHookService } from './hook-service'
 
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -EncodedCommand \S+$/
 
 describe('DroidHookService', () => {
   let homeDir: string

--- a/src/main/droid/hook-service.test.ts
+++ b/src/main/droid/hook-service.test.ts
@@ -25,7 +25,7 @@ vi.mock('os', async () => {
 import { DroidHookService } from './hook-service'
 
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
 
 describe('DroidHookService', () => {
   let homeDir: string

--- a/src/main/droid/hook-service.test.ts
+++ b/src/main/droid/hook-service.test.ts
@@ -25,7 +25,7 @@ vi.mock('os', async () => {
 import { DroidHookService } from './hook-service'
 
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
 
 describe('DroidHookService', () => {
   let homeDir: string

--- a/src/main/gemini/hook-service.test.ts
+++ b/src/main/gemini/hook-service.test.ts
@@ -26,7 +26,7 @@ vi.mock('os', async (importOriginal) => {
 import { GeminiHookService } from './hook-service'
 
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
 
 describe('GeminiHookService', () => {
   let homeDir: string

--- a/src/main/gemini/hook-service.test.ts
+++ b/src/main/gemini/hook-service.test.ts
@@ -26,7 +26,7 @@ vi.mock('os', async (importOriginal) => {
 import { GeminiHookService } from './hook-service'
 
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -EncodedCommand \S+$/
 
 describe('GeminiHookService', () => {
   let homeDir: string

--- a/src/main/gemini/hook-service.test.ts
+++ b/src/main/gemini/hook-service.test.ts
@@ -26,7 +26,7 @@ vi.mock('os', async (importOriginal) => {
 import { GeminiHookService } from './hook-service'
 
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
 
 describe('GeminiHookService', () => {
   let homeDir: string

--- a/src/main/grok/hook-service.test.ts
+++ b/src/main/grok/hook-service.test.ts
@@ -23,7 +23,7 @@ import { POSIX_HOOK_STDIN_READER } from '../agent-hooks/hook-stdin-contract'
 
 const GROK_SCRIPT_FILE_NAME = process.platform === 'win32' ? 'grok-hook.cmd' : 'grok-hook.sh'
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
 
 // Why (#14828): Windows registers the bare script path when it is cmd-safe and only falls back
 // to the encoded launcher for a profile path that is not (#6078). windows-hook-launcher-chain

--- a/src/main/grok/hook-service.test.ts
+++ b/src/main/grok/hook-service.test.ts
@@ -23,7 +23,7 @@ import { POSIX_HOOK_STDIN_READER } from '../agent-hooks/hook-stdin-contract'
 
 const GROK_SCRIPT_FILE_NAME = process.platform === 'win32' ? 'grok-hook.cmd' : 'grok-hook.sh'
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
 
 // Why (#14828): Windows registers the bare script path when it is cmd-safe and only falls back
 // to the encoded launcher for a profile path that is not (#6078). windows-hook-launcher-chain

--- a/src/main/grok/hook-service.test.ts
+++ b/src/main/grok/hook-service.test.ts
@@ -23,7 +23,7 @@ import { POSIX_HOOK_STDIN_READER } from '../agent-hooks/hook-stdin-contract'
 
 const GROK_SCRIPT_FILE_NAME = process.platform === 'win32' ? 'grok-hook.cmd' : 'grok-hook.sh'
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -EncodedCommand \S+$/
 
 // Why (#14828): Windows registers the bare script path when it is cmd-safe and only falls back
 // to the encoded launcher for a profile path that is not (#6078). windows-hook-launcher-chain


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​119 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​10 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​109 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​55 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​48 |

<!-- /orca-pr-loc -->

## ELI5

Orca starts every Windows agent hook by running PowerShell with three flags at once: *bypass the script policy*, *hide the window*, and *here is a base64 blob to run*. Antivirus reads that exact combination as the classic disguised-malware launcher and refuses to start the process — before it ever looks at what the blob decodes to. So every hook died with "Permission denied" on every single turn.

The fix keeps all three behaviours and just stops spelling one of them on the command line. The policy bypass moves *inside* the base64 blob, where it does the identical thing. AV sees a two-flag command it does not object to, and the hook runs.

## Root cause

The launcher in `src/main/agent-hooks/windows-powershell-hook-launcher.ts` emitted:

```
powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand <base64>
```

The reporter's symptom was `/usr/bin/bash: line 1: C:/Windows/.../powershell.exe: Permission denied`. That is exit 126 — bash's `execve` came back `EACCES` — which rules out the two things it looks like. Not a missing or corrupt binary: `ls -la` shows `-rwxr-xr-x` and the same absolute path runs fine by hand from the same Git Bash. Not the harness sandboxing hook commands either, which was the original hypothesis in the issue: the denial is at `CreateProcess`, and it reproduces with no agent and no Orca in the picture.

@shcha0114 bisected it to the flags themselves ([comment](https://github.com/stablyai/orca/issues/16003#issuecomment-5385339555)). From a bare Git Bash, with a payload of literally `exit 0`:

| command | result |
|---|---|
| `-NoProfile -WindowStyle Hidden -Command 'exit 0'` | exit 0 |
| `-NoProfile -EncodedCommand <b64>` | exit 0 |
| `-NoProfile -ExecutionPolicy Bypass -Command 'exit 0'` | exit 0 |
| `-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand <b64>` | **exit 126, Permission denied** |

Only the full triple is denied, regardless of payload and regardless of parent shell. It is the textbook "hidden encoded PowerShell" signature. Reproduced with Kaspersky, but nothing about the shape is vendor-specific, and no exclusion re-enabled it — trusting `bash.exe`, `powershell.exe` and `claude-hook.cmd`, excluding by threat name, and disabling both Exploit Prevention and Intrusion Prevention all failed, with nothing logged. It is a kernel-driver-level match with no UI knob.

Orca owns that command shape, so Orca can fix it.

## What changed

One production file, `src/main/agent-hooks/windows-powershell-hook-launcher.ts`:

- `WINDOWS_POWERSHELL_HOOK_SWITCHES` drops `-ExecutionPolicy Bypass`, leaving `-NoProfile -WindowStyle Hidden`.
- `encodeWindowsPowerShellHookCommand` prepends `Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction SilentlyContinue;` to the payload it encodes.

Why that one of the three is the one to move: it is the only one that has an exact in-payload equivalent. `-ExecutionPolicy Bypass` sets the **Process** scope, and so does `Set-ExecutionPolicy -Scope Process` — same scope, same precedence, and both lose to a Group Policy scope identically. `-EncodedCommand` input is never itself policy-gated, so the assignment always gets to run before the managed script is invoked.

The other two could not move. `-WindowStyle Hidden` is what keeps a console from flashing on every hook event (#14815), and hidden PowerShell — unlike conhost — is what relays hook stdout and exit status back to the agent (#14818). `-EncodedCommand` is what shields the script path and switches from `cmd.exe` re-parsing and MSYS `/`-rewriting (#6078). Dropping either would regress a shipped fix; dropping the policy flag from the command line regresses nothing.

The bypass genuinely has to survive somewhere rather than just be deleted: Copilot's managed hook is a `.ps1` (`src/main/copilot/copilot-managed-script.ts`), which a `Restricted` or `AllSigned` machine policy refuses to run without it. `.cmd` hooks are unaffected by execution policy either way, so this only matters for that one agent — but it matters completely for that one.

## User-facing trade-offs

**None.** The window stays hidden, the payload stays encoded, stdout and exit status still relay, `.ps1` hooks still run under a locked-down policy, and the hook command remains a single self-contained token for the consumers that ignore `args`. The command line is 24 characters shorter and the encoded payload is ~78 characters longer; neither is near any limit.

This is not a claim that no AV will ever object to the remaining two-flag shape. It removes the one combination we have reproduced as denied, using the only flag that can move without losing a behaviour.

## Verification

Run on macOS 15 (arm64), all exit codes checked rather than output grepped.

**Mutation-verified.** Reverting only `windows-powershell-hook-launcher.ts` to its pre-fix state, with every test left in place, turns **8 tests across 3 files** red:

```
❯ src/main/agent-hooks/windows-powershell-hook-launcher.test.ts (3 failed)
    × never spells the denied flag triple on the command line
    × keeps the execution-policy bypass, in the payload where AV cannot read it
    × applies the bypass before the caller command and keeps progress silenced
❯ src/main/agent-hooks/installer-utils.test.ts (4 failed)
    × invokes the .cmd through an encoded PowerShell command
    × preserves spaces in the script path (user profile with space case)
    × keeps cmd.exe percent expansion and caret escapes out of the command line
    × falls back to the encoded launcher when cmd.exe would split or expand the path
❯ src/main/claude/hook-service.test.ts (1 failed)
    × resolves the managed script from the runtime Windows profile, as a single command string
```

Restoring the file returns all 8 to green. An earlier draft of the third new test passed under mutation because `indexOf` returns `-1` for an absent needle, which is trivially "before" everything — it was rewritten as a full-payload regex before this run.

| check | exit |
|---|---|
| `pnpm lint` | 0 |
| `pnpm typecheck` | 0 |
| `node config/scripts/check-reliability-gates.mjs` | 0 (97 gates) |
| `pnpm vitest run src/shared/child-process` | 0 — 6 files, 70 passed |
| vitest across `src/main/agent-hooks`, `claude`, `codex`, `cursor`, `droid`, `gemini`, `grok`, `copilot`, `command-code`, `devin`, `antigravity`, `kimi`, `text-generation`, `win32-utils` | 0 — 244 files, 2342 passed |

No new `node:child_process` import, so the allowlist ratchet in `src/shared/child-process/__fixtures__/child-process-import-allowlist.txt` is untouched; the suite was run anyway and is green.

The eight test files with assertions on the launcher string were updated to the new two-flag shape rather than loosened — none of them stopped asserting the flags.

⚠️ **Not executed on Windows.** I have no Windows host. What is verified here is the command string Orca emits; that a shorter flag list clears the AV signature is @shcha0114's measurement on the affected machine, not mine. The equivalence of `-ExecutionPolicy Bypass` and `Set-ExecutionPolicy -Scope Process` is documented PowerShell behaviour but would be worth a reviewer's eye on a real box, ideally one running Kaspersky.

### Full-suite baseline

`pnpm vitest run` (whole repo): **6560 files / 61,174 tests passed, 5 files failed.** Every one of the five is pre-existing and none is in a file this PR touches:

| failing file | verdict |
|---|---|
| `src/shared/remote-runtime-shared-control-connection.test.ts` | fails in isolation **and on `origin/main`** — same test, same message |
| `src/main/persistence-pane-identity-migration.test.ts` | fails in isolation **and on `origin/main`** — 42–51s timing-bound test |
| `src/renderer/.../pty-connection-terminal-input-gating.test.ts` | passes in isolation; 30s timeout only under full-suite load |
| `src/main/runtime/rpc/terminal-output-frame-chunks-equivalence.test.ts` | passes in isolation |
| `config/scripts/macos-computer-helper-owner-loss-processes.test.mjs` | passes in isolation |

The first two were re-run on a detached `origin/main` checkout in the same worktree to confirm, rather than assumed.

## Linked issue

Closes #16003

## Not in scope

- **#16356** (Codex hook emits no stdout) is already fixed by the open #16439; I dropped my duplicate of it.
- **#11374** (argv prompts through `.cmd` shims) has an open partial fix in #11384. I posted my analysis and a design for the remaining gaps [there](https://github.com/stablyai/orca/pull/11384#issuecomment-5421668447) rather than opening a competing PR. It is a genuinely separate root cause from this one — cmd's line parser versus an AV signature — and shares no code with it.

## Visual proof

N/A — this changes a generated command string with no UI surface.


## Round 3 correction (802a28ffeb8)

An intermediate commit (357556b1926) also dropped `-WindowStyle Hidden`, on the reasoning that no measurement exists for a shape that drops exactly one flag. That silently reverted the shipped #14815/#14825 console suppression for every Orca-managed Windows agent hook, and the tests were updated to enforce the new shape rather than guard the old one — so nothing caught it.

That is now reverted. `WINDOWS_POWERSHELL_HOOK_SWITCHES` is `-NoProfile -WindowStyle Hidden` again, which is what the rest of this body describes. Rationale for choosing that side of the trade-off: the console regression is reported and reproduced (#14815 plus #14828, #15117, #15447, #15767 — a console per hook event that takes foreground and eats the user's keystrokes, and a stranded visible window when the hook blocks on stdin), while "the remaining two-flag pair is also AV-denied" is a hypothesis with no measurement behind it. The one flag that moves into the payload is still `-ExecutionPolicy Bypass`, the only one of the three with an exact in-payload equivalent.

Test coverage for both directions, mutation-verified on this commit (macOS, exit codes checked):

- `WINDOWS_POWERSHELL_HOOK_SWITCHES = '-NoProfile'` (the reverted round-2 value) -> 6 tests red across `windows-powershell-hook-launcher.test.ts`, `installer-utils.test.ts`, `claude/hook-service.test.ts`.
- `WINDOWS_POWERSHELL_HOOK_SWITCHES = '-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden'` (origin/main, the denied triple) -> 7 tests red across the same three files.
- Restoring the shipped value -> all green.

New coverage includes the Git Bash `wrapRuntimeHomeHookCommand` branch, which previously asserted nothing about the launcher switches at all.

| check | exit |
|---|---|
| `pnpm lint` | 0 |
| `pnpm typecheck` | 0 |
| `node config/scripts/check-reliability-gates.mjs` | 0 (97 gates) |
| vitest across `src/main/agent-hooks`, `claude`, `copilot`, `codex`, `cursor`, `droid`, `gemini`, `grok`, `command-code`, `src/shared/child-process` | 0 — 227 files, 2237 passed |

Still not executed on Windows: no Windows host here, and PR CI's Windows job runs no agent-hooks test. Both the AV verdict on the two-flag shape and the window suppression itself remain unverified on a real box.
