### PR TITLE
fix(terminal): raise viewport column cap from 240 to 1024

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -96,6 +96,7 @@ import {
   TERMINAL_INPUT_TOO_LARGE_ERROR,
   iterateTerminalInputChunks
 } from '../../shared/terminal-input'
+import { clampTerminalViewport } from '../../shared/terminal-viewport-clamp'
 import {
   AGENT_PROMPT_BRACKETED_PASTE_END,
   AGENT_PROMPT_SUBMIT,
@@ -2626,14 +2627,6 @@ async function resolveCreateBranchName(
 
 function normalizeLocalBranchName(branchName: string | undefined): string {
   return branchName?.replace(/^refs\/heads\//, '') ?? ''
-}
-
-// Clamp terminal dimensions to the PTY's supported range (cols 20–240, rows 8–120).
-function clampTerminalViewport(cols: number, rows: number): { cols: number; rows: number } {
-  return {
-    cols: Math.max(20, Math.min(240, Math.round(cols))),
-    rows: Math.max(8, Math.min(120, Math.round(rows)))
-  }
 }
 
 // Subscribe a listener to a per-key Set, pruning the key's entry once its last

--- a/src/main/runtime/rpc/methods/terminal/viewport-schemas.ts
+++ b/src/main/runtime/rpc/methods/terminal/viewport-schemas.ts
@@ -1,4 +1,10 @@
 import { z } from 'zod'
+import {
+  TERMINAL_VIEWPORT_MAX_COLS,
+  TERMINAL_VIEWPORT_MAX_ROWS,
+  TERMINAL_VIEWPORT_MIN_COLS,
+  TERMINAL_VIEWPORT_MIN_ROWS
+} from '../../../../../shared/terminal-viewport-clamp'
 import { requiredString } from '../../schemas'
 
 const TerminalHandle = z.object({ terminal: requiredString('Missing terminal handle') })
@@ -39,8 +45,8 @@ export const TerminalUpdateViewport = TerminalHandle.extend({
     type: z.enum(['mobile', 'desktop']).default('mobile').optional()
   }),
   viewport: z.object({
-    cols: z.number().int().min(20).max(240),
-    rows: z.number().int().min(8).max(120)
+    cols: z.number().int().min(TERMINAL_VIEWPORT_MIN_COLS).max(TERMINAL_VIEWPORT_MAX_COLS),
+    rows: z.number().int().min(TERMINAL_VIEWPORT_MIN_ROWS).max(TERMINAL_VIEWPORT_MAX_ROWS)
   }),
   claim: z.boolean().optional()
 })

--- a/src/renderer/src/components/dashboard-popout/preview-grid-claim.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-grid-claim.ts
@@ -1,11 +1,12 @@
 import type { Terminal } from '@xterm/xterm'
+import {
+  TERMINAL_VIEWPORT_MAX_COLS,
+  TERMINAL_VIEWPORT_MAX_ROWS,
+  TERMINAL_VIEWPORT_MIN_COLS,
+  TERMINAL_VIEWPORT_MIN_ROWS
+} from '../../../../shared/terminal-viewport-clamp'
 
 const FIT_REQUEST_DEBOUNCE_MS = 200
-// Mirror the runtime's clampTerminalViewport so a request always matches what lands.
-const FIT_MIN_COLS = 20
-const FIT_MAX_COLS = 240
-const FIT_MIN_ROWS = 8
-const FIT_MAX_ROWS = 120
 
 function clampGridAxis(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value))
@@ -52,11 +53,15 @@ export function createPreviewGridClaim(args: {
     ) {
       return
     }
-    const cols = clampGridAxis(Math.floor(box.clientWidth / cellWidth), FIT_MIN_COLS, FIT_MAX_COLS)
+    const cols = clampGridAxis(
+      Math.floor(box.clientWidth / cellWidth),
+      TERMINAL_VIEWPORT_MIN_COLS,
+      TERMINAL_VIEWPORT_MAX_COLS
+    )
     const rows = clampGridAxis(
       Math.floor(box.clientHeight / cellHeight),
-      FIT_MIN_ROWS,
-      FIT_MAX_ROWS
+      TERMINAL_VIEWPORT_MIN_ROWS,
+      TERMINAL_VIEWPORT_MAX_ROWS
     )
     const fitKey = `${cols}x${rows}`
     if (fitKey === lastRequestedFit) {

--- a/src/shared/terminal-viewport-clamp.test.ts
+++ b/src/shared/terminal-viewport-clamp.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { clampTerminalViewport } from './terminal-viewport-clamp'
+
+describe('clampTerminalViewport', () => {
+  it('leaves 240 and 500 columns unclamped', () => {
+    expect(clampTerminalViewport(240, 24)).toEqual({ cols: 240, rows: 24 })
+    expect(clampTerminalViewport(500, 24)).toEqual({ cols: 500, rows: 24 })
+  })
+
+  it('leaves 1024 columns at the ceiling', () => {
+    expect(clampTerminalViewport(1024, 24)).toEqual({ cols: 1024, rows: 24 })
+  })
+
+  it('clamps 2000 columns to 1024', () => {
+    expect(clampTerminalViewport(2000, 24)).toEqual({ cols: 1024, rows: 24 })
+  })
+
+  it('clamps columns below 20 up to 20', () => {
+    expect(clampTerminalViewport(10, 24)).toEqual({ cols: 20, rows: 24 })
+  })
+
+  it('clamps rows below 8 up to 8', () => {
+    expect(clampTerminalViewport(80, 4)).toEqual({ cols: 80, rows: 8 })
+  })
+
+  it('clamps rows above 120 down to 120', () => {
+    expect(clampTerminalViewport(80, 200)).toEqual({ cols: 80, rows: 120 })
+  })
+})

--- a/src/shared/terminal-viewport-clamp.ts
+++ b/src/shared/terminal-viewport-clamp.ts
@@ -1,0 +1,18 @@
+export const TERMINAL_VIEWPORT_MIN_COLS = 20
+// Why: 240 left a blank pad on wide monitors; keep a ceiling so a bogus resize cannot grow unbounded.
+export const TERMINAL_VIEWPORT_MAX_COLS = 1024
+export const TERMINAL_VIEWPORT_MIN_ROWS = 8
+export const TERMINAL_VIEWPORT_MAX_ROWS = 120
+
+export function clampTerminalViewport(cols: number, rows: number): { cols: number; rows: number } {
+  return {
+    cols: Math.max(
+      TERMINAL_VIEWPORT_MIN_COLS,
+      Math.min(TERMINAL_VIEWPORT_MAX_COLS, Math.round(cols))
+    ),
+    rows: Math.max(
+      TERMINAL_VIEWPORT_MIN_ROWS,
+      Math.min(TERMINAL_VIEWPORT_MAX_ROWS, Math.round(rows))
+    )
+  }
+}


### PR DESCRIPTION
## Description
A full-width terminal pane was clamped at 240 columns, so wide monitors wrapped early and left a blank right pad. Split panes already sized to the real width.
The viewport clamp now allows up to 1024 columns.

## Focused fix
- In scope: raise `clampTerminalViewport` max cols 240 → 1024.
- Out of scope: removing the cap entirely; changing row limits; PTY emulator internals.

## Preserves
- Minimum cols 20 and rows 8–120 stay the same.
- The cap remains bounded (1024), not unbounded.

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/shared/terminal-viewport-clamp.test.ts src/renderer/src/components/dashboard-popout/preview-grid-claim.test.ts`
- Result: **8 passed**
- Cases: 240/500/1024 unclamped; 2000 → 1024; cols 10 → 20; rows 4 → 8; rows 200 → 120.

## User-regression-tradeoffs
Wider single panes use more GPU/grid cells. 1024 is a safety bound so this is not an open-ended size.

Fixes #16354
