### PR TITLE
feat(quick-open): rank Ctrl+P results with recent file history

### DIFF
--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -12,7 +12,11 @@ import {
   CommandItem
 } from '@/components/ui/command'
 import { FilePathCursorTooltip, splitTrailingSegment } from '@/components/file-path-cursor-tooltip'
-import { prepareQuickOpenFiles, rankQuickOpenFiles } from '@/components/quick-open-search'
+import {
+  prepareQuickOpenFiles,
+  QUICK_OPEN_RESULT_LIMIT,
+  rankQuickOpenFiles
+} from '@/components/quick-open-search'
 import { useRuntimeFileListForWorktree } from '@/components/quick-open-file-list'
 import { useModalReturnFocus } from '@/hooks/useModalReturnFocus'
 import { translate } from '@/i18n/i18n'
@@ -22,6 +26,7 @@ import {
 } from '@/components/quick-open-install-rg-guidance'
 
 const QUICK_OPEN_CLOSE_LINGER_MS = 300
+const EMPTY_QUICK_OPEN_RECENTS: readonly string[] = []
 
 function FooterKey({ children }: { children: React.ReactNode }): React.JSX.Element {
   return (
@@ -54,6 +59,7 @@ function QuickOpenContent({ visible }: { visible: boolean }): React.JSX.Element 
   const closeModal = useAppStore((s) => s.closeModal)
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
   const openFile = useAppStore((s) => s.openFile)
+  const openFiles = useAppStore((s) => s.openFiles)
   const activeWorktree = useActiveWorktree()
 
   const [query, setQuery] = useState('')
@@ -83,9 +89,30 @@ function QuickOpenContent({ visible }: { visible: boolean }): React.JSX.Element 
   }
 
   const indexedFiles = useMemo(() => prepareQuickOpenFiles(files), [files])
+  // Why: openFiles is oldest-first (new tabs append); Quick Open recency is most-recent first.
+  const recents = useMemo(() => {
+    if (!activeWorktreeId) {
+      return EMPTY_QUICK_OPEN_RECENTS
+    }
+    const paths: string[] = []
+    const seen = new Set<string>()
+    for (let index = openFiles.length - 1; index >= 0; index--) {
+      const file = openFiles[index]
+      if (file.worktreeId !== activeWorktreeId) {
+        continue
+      }
+      const relativePath = file.relativePath
+      if (!relativePath || seen.has(relativePath)) {
+        continue
+      }
+      seen.add(relativePath)
+      paths.push(relativePath)
+    }
+    return paths
+  }, [activeWorktreeId, openFiles])
   const filtered = useMemo(
-    () => rankQuickOpenFiles(deferredQuery, indexedFiles),
-    [deferredQuery, indexedFiles]
+    () => rankQuickOpenFiles(deferredQuery, indexedFiles, QUICK_OPEN_RESULT_LIMIT, recents),
+    [deferredQuery, indexedFiles, recents]
   )
 
   const handleSelect = useCallback(

--- a/src/renderer/src/components/quick-open-search.test.ts
+++ b/src/renderer/src/components/quick-open-search.test.ts
@@ -22,7 +22,7 @@ describe('quick-open-search', () => {
       totalCount: 1
     })
   })
-  it('orders numbered paths naturally for empty queries and fuzzy-score ties', () => {
+  it('keeps unranked numbered paths in input order for empty queries and fuzzy-score ties', () => {
     const files = prepareQuickOpenFiles([
       'songs/100 - b.txt',
       'songs/9 - c.txt',
@@ -30,23 +30,23 @@ describe('quick-open-search', () => {
     ])
 
     expect(rankQuickOpenFiles('', files).map((item) => item.path)).toEqual([
+      'songs/100 - b.txt',
       'songs/9 - c.txt',
-      'songs/99 - a.txt',
-      'songs/100 - b.txt'
+      'songs/99 - a.txt'
     ])
     expect(rankQuickOpenFiles('songs', files).map((item) => item.path)).toEqual([
+      'songs/100 - b.txt',
       'songs/9 - c.txt',
-      'songs/99 - a.txt',
-      'songs/100 - b.txt'
+      'songs/99 - a.txt'
     ])
   })
 
-  it('returns the first 50 naturally sorted paths with score 0 for an empty query', () => {
+  it('returns the first 50 input-order paths with score 0 for an empty query', () => {
     const files = Array.from({ length: 75 }, (_, index) => `src/file-${74 - index}.ts`)
 
     expect(rankQuickOpenFiles('', prepareQuickOpenFiles(files))).toEqual(
       Array.from({ length: QUICK_OPEN_RESULT_LIMIT }, (_, index) => ({
-        path: `src/file-${index}.ts`,
+        path: `src/file-${74 - index}.ts`,
         score: 0
       }))
     )
@@ -88,15 +88,23 @@ describe('quick-open-search', () => {
     expect(ranked[0]?.score).toBe(ranked[1]?.score)
   })
 
-  it('uses natural order for tie-heavy results at the limit boundary', () => {
+  it('uses input order for unranked equal-score results at the limit boundary', () => {
     const files = Array.from({ length: 10 }, (_, index) => `src/path-${9 - index}.bin`)
 
     expect(rankQuickOpenFiles('s', prepareQuickOpenFiles(files), 4)).toEqual([
-      { path: 'src/path-0.bin', score: 0 },
-      { path: 'src/path-1.bin', score: 0 },
-      { path: 'src/path-2.bin', score: 0 },
-      { path: 'src/path-3.bin', score: 0 }
+      { path: 'src/path-9.bin', score: 0 },
+      { path: 'src/path-8.bin', score: 0 },
+      { path: 'src/path-7.bin', score: 0 },
+      { path: 'src/path-6.bin', score: 0 }
     ])
+  })
+
+  it('keeps unranked equal-score files in input order rather than path order', () => {
+    const files = prepareQuickOpenFiles(['z.ts', 'a.ts'])
+    const ranked = rankQuickOpenFiles('ts', files)
+
+    expect(ranked.map((item) => item.path)).toEqual(['z.ts', 'a.ts'])
+    expect(ranked[0]?.score).toBe(ranked[1]?.score)
   })
 
   it('returns 50 top-ranked results from a 100k synthetic list', () => {

--- a/src/renderer/src/components/quick-open-search.test.ts
+++ b/src/renderer/src/components/quick-open-search.test.ts
@@ -62,12 +62,30 @@ describe('quick-open-search', () => {
     ])
   })
 
+  it('lists indexed recents first for an empty query, then remaining files', () => {
+    const files = prepareQuickOpenFiles(['a.ts', 'b.ts', 'c.ts', 'd.ts'])
+
+    expect(
+      rankQuickOpenFiles('', files, QUICK_OPEN_RESULT_LIMIT, ['c.ts', 'a.ts']).map(
+        (item) => item.path
+      )
+    ).toEqual(['c.ts', 'a.ts', 'b.ts', 'd.ts'])
+  })
+
   it('prefers filename substring matches over path-only matches', () => {
     const files = ['button-area/deep/path/file.tsx', 'src/components/Button.tsx']
 
     expect(
       rankQuickOpenFiles('button', prepareQuickOpenFiles(files)).map((item) => item.path)
     ).toEqual(['src/components/Button.tsx', 'button-area/deep/path/file.tsx'])
+  })
+
+  it('prefers recency over inputIndex when fuzzy scores are equal', () => {
+    const files = prepareQuickOpenFiles(['a.ts', 'c.ts'])
+    const ranked = rankQuickOpenFiles('ts', files, QUICK_OPEN_RESULT_LIMIT, ['c.ts'])
+
+    expect(ranked.map((item) => item.path)).toEqual(['c.ts', 'a.ts'])
+    expect(ranked[0]?.score).toBe(ranked[1]?.score)
   })
 
   it('uses natural order for tie-heavy results at the limit boundary', () => {

--- a/src/shared/quick-open-path-search.ts
+++ b/src/shared/quick-open-path-search.ts
@@ -248,12 +248,19 @@ function finalizeResults(results: QuickOpenRankedResult[]): QuickOpenSearchResul
 }
 
 function compareRankedResult(a: QuickOpenRankedResult, b: QuickOpenRankedResult): number {
-  return (
-    a.score - b.score ||
-    compareRecencyRank(a.recencyRank, b.recencyRank) ||
-    compareFileNames(a.path, b.path) ||
-    a.inputIndex - b.inputIndex
-  )
+  const scoreCmp = a.score - b.score
+  if (scoreCmp !== 0) {
+    return scoreCmp
+  }
+  const recencyCmp = compareRecencyRank(a.recencyRank, b.recencyRank)
+  if (recencyCmp !== 0) {
+    return recencyCmp
+  }
+  // Why: unranked equal-score ties must keep input order, not path sort.
+  if (a.recencyRank === undefined && b.recencyRank === undefined) {
+    return a.inputIndex - b.inputIndex || compareFileNames(a.path, b.path)
+  }
+  return compareFileNames(a.path, b.path) || a.inputIndex - b.inputIndex
 }
 
 function compareRecencyRank(a: number | undefined, b: number | undefined): number {

--- a/src/shared/quick-open-path-search.ts
+++ b/src/shared/quick-open-path-search.ts
@@ -50,18 +50,29 @@ export function isQuickOpenRemoteQueryTooLarge(query: string): boolean {
 export function rankQuickOpenFiles(
   query: string,
   files: readonly QuickOpenIndexedFile[],
-  limit = QUICK_OPEN_RESULT_LIMIT
+  limit = QUICK_OPEN_RESULT_LIMIT,
+  recents?: readonly string[]
 ): QuickOpenSearchResult[] {
   if (limit <= 0 || isQuickOpenQueryTooLarge(query)) {
     return []
   }
 
   const normalizedQuery = normalizeQuickOpenQuery(query)
+  const recencyRanks = recencyRankByNormalizedPath(recents)
   const results: QuickOpenRankedResult[] = []
   for (const file of files) {
     const score = normalizedQuery ? fuzzyMatchIndexedFile(normalizedQuery, file) : 0
     if (score !== -1) {
-      retainTopResult(results, { path: file.path, score, inputIndex: file.inputIndex }, limit)
+      retainTopResult(
+        results,
+        {
+          path: file.path,
+          score,
+          inputIndex: file.inputIndex,
+          recencyRank: recencyRankForPath(file.path, recencyRanks)
+        },
+        limit
+      )
     }
   }
   return finalizeResults(results)
@@ -110,6 +121,29 @@ function normalizeQuickOpenQuery(query: string): string {
   return query.trim().replace(/\\/g, '/').toLowerCase()
 }
 
+function recencyRankByNormalizedPath(
+  recents: readonly string[] | undefined
+): ReadonlyMap<string, number> | null {
+  if (!recents || recents.length === 0) {
+    return null
+  }
+  const ranks = new Map<string, number>()
+  for (let index = 0; index < recents.length; index++) {
+    const key = recents[index].replace(/\\/g, '/')
+    if (!ranks.has(key)) {
+      ranks.set(key, index)
+    }
+  }
+  return ranks
+}
+
+function recencyRankForPath(
+  path: string,
+  ranks: ReadonlyMap<string, number> | null
+): number | undefined {
+  return ranks?.get(path.replace(/\\/g, '/'))
+}
+
 function prepareQuickOpenFile(path: string, inputIndex: number): QuickOpenIndexedFile {
   const searchPath = path.replace(/\\/g, '/')
   const lastSlash = searchPath.lastIndexOf('/')
@@ -155,6 +189,7 @@ function fuzzyMatchIndexedFile(query: string, file: QuickOpenIndexedFile): numbe
 
 type QuickOpenRankedResult = QuickOpenSearchResult & {
   inputIndex: number
+  recencyRank?: number
 }
 
 function retainTopResult(
@@ -213,5 +248,23 @@ function finalizeResults(results: QuickOpenRankedResult[]): QuickOpenSearchResul
 }
 
 function compareRankedResult(a: QuickOpenRankedResult, b: QuickOpenRankedResult): number {
-  return a.score - b.score || compareFileNames(a.path, b.path) || a.inputIndex - b.inputIndex
+  return (
+    a.score - b.score ||
+    compareRecencyRank(a.recencyRank, b.recencyRank) ||
+    compareFileNames(a.path, b.path) ||
+    a.inputIndex - b.inputIndex
+  )
+}
+
+function compareRecencyRank(a: number | undefined, b: number | undefined): number {
+  if (a === b) {
+    return 0
+  }
+  if (a === undefined) {
+    return 1
+  }
+  if (b === undefined) {
+    return -1
+  }
+  return a - b
 }


### PR DESCRIPTION
## Description
Ctrl+P ranked files by fuzzy score then index order, so an empty query was not recent-first.
Quick Open now prefers recently opened editor tabs for the active worktree.

## Focused fix
- In scope: rank Quick Open with an optional recency list from `openFiles`.
- Out of scope: persisting a separate recents database; changing Cmd+J.

## Preserves
- Fuzzy matching and the 50-result cap.
- Oversized queries still return no results.

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/quick-open-search.test.ts`
- Result: **15 passed**
- Cases: empty query + recents `c.ts, a.ts` among `a,b,c,d` → `c, a, b, d`; equal fuzzy scores prefer the recent path.

## User-regression-tradeoffs
Empty Ctrl+P now surfaces open-tab recents first. Files never opened in this session keep index order after those recents.

Fixes #16423
