### PR TITLE
fix(terminal): create plus-menu tabs in the active group

### DIFF
--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -1573,11 +1573,11 @@ function Terminal(): React.JSX.Element | null {
         })
         return
       }
-      if (!shellOverride && targetGroupId) {
-        void openNewTerminalTabInActiveWorkspace(targetGroupId)
+      if (targetGroupId) {
+        void openNewTerminalTabInActiveWorkspace(targetGroupId, shellOverride)
         return
       }
-      const newTab = createTab(activeWorktreeId, undefined, shellOverride)
+      const newTab = createTab(activeWorktreeId, targetGroupId, shellOverride)
       setActiveTabType('terminal')
       // Why: persist tab-bar order with the new terminal appended; else reconcileOrder falls back to terminals-first and jumps it to index 0 before editor tabs.
       const state = useAppStore.getState()
@@ -1601,7 +1601,6 @@ function Terminal(): React.JSX.Element | null {
       const order = base.filter((id) => id !== newTab.id)
       order.push(newTab.id)
       setTabBarOrder(activeWorktreeId, order)
-      // Why: shell-specific creation still uses the legacy path; keep focus here until the lifted action accepts shell overrides.
       focusTerminalTabSurface(newTab.id)
     },
     [

--- a/src/renderer/src/components/tab-group/useTabGroupCreationCommands.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupCreationCommands.ts
@@ -2,12 +2,7 @@ import { useCallback } from 'react'
 import { toast } from 'sonner'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 import { useAppStore } from '../../store'
-import { focusTerminalTabSurface } from '../../lib/focus-terminal-tab-surface'
-import {
-  createWebRuntimeSessionBrowserTab,
-  createWebRuntimeSessionTerminal,
-  isWebRuntimeSessionActive
-} from '../../runtime/web-runtime-session'
+import { createWebRuntimeSessionBrowserTab } from '../../runtime/web-runtime-session'
 import { openTabBarEntry, type TabCreateEntryArgs } from '../tab-bar/tab-create-entry-action'
 import { openMobileEmulatorTab } from '@/lib/open-mobile-emulator-tab'
 import { ensureSimulatorTab, getSimulatorTabForWorktree } from '@/lib/ensure-simulator-tab'
@@ -147,23 +142,7 @@ export function useTabGroupCreationCommands({
       void openNewTerminalTabInActiveWorkspace(groupId)
     },
     newTerminalWithShell: (shellOverride: string) => {
-      void (async () => {
-        const environmentId = getRuntimeEnvironmentIdForWorktree(useAppStore.getState(), worktreeId)
-        const outcome = await createWebRuntimeSessionTerminal({
-          worktreeId,
-          environmentId,
-          targetGroupId: groupId,
-          command: shellOverride,
-          activate: true
-        })
-        if (outcome.status === 'created' || isWebRuntimeSessionActive(environmentId)) {
-          return
-        }
-        const terminal = createTab(worktreeId, groupId, shellOverride)
-        setActiveTab(terminal.id)
-        setActiveTabType('terminal')
-        focusTerminalTabSurface(terminal.id)
-      })()
+      void openNewTerminalTabInActiveWorkspace(groupId, shellOverride)
     }
   }
 }

--- a/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   isWebRuntimeSessionActive: vi.fn(() => false),
   makePreviewFilePermanent: vi.fn(),
   openFile: vi.fn(),
+  openNewTerminalTabInActiveWorkspace: vi.fn(),
   pinFile: vi.fn(),
   recordFeatureInteraction: vi.fn(),
   setActiveBrowserTab: vi.fn(),
@@ -151,6 +152,7 @@ function resetStore(): void {
     focusGroup: mocks.focusGroup,
     makePreviewFilePermanent: mocks.makePreviewFilePermanent,
     openFile: mocks.openFile,
+    openNewTerminalTabInActiveWorkspace: mocks.openNewTerminalTabInActiveWorkspace,
     pinFile: mocks.pinFile,
     recordFeatureInteraction: mocks.recordFeatureInteraction,
     setActiveBrowserTab: mocks.setActiveBrowserTab,
@@ -197,16 +199,20 @@ describe('useTabGroupWorkspaceModel terminal activation focus', () => {
     expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('terminal-1', null)
   })
 
-  it('falls back to a local shell when the typed remote-create outcome is unavailable', async () => {
-    mocks.createTab.mockReturnValue({ id: 'terminal-new' })
+  it('creates plus-menu shell tabs through the same active-workspace group path as Ctrl+T', async () => {
     const { useTabGroupWorkspaceModel } = await import('./useTabGroupWorkspaceModel')
     const model = useTabGroupWorkspaceModel({ groupId: 'group-1', worktreeId: 'wt-1' })
 
-    model.commands.newTerminalWithShell('zsh')
-    await vi.waitFor(() => expect(mocks.createTab).toHaveBeenCalled())
+    model.commands.newTerminalTab()
+    model.commands.newTerminalWithShell('pwsh.exe')
 
-    expect(mocks.createTab).toHaveBeenCalledWith('wt-1', 'group-1', 'zsh')
-    expect(mocks.setActiveTab).toHaveBeenCalledWith('terminal-new')
+    expect(mocks.openNewTerminalTabInActiveWorkspace).toHaveBeenNthCalledWith(1, 'group-1')
+    expect(mocks.openNewTerminalTabInActiveWorkspace).toHaveBeenNthCalledWith(
+      2,
+      'group-1',
+      'pwsh.exe'
+    )
+    expect(mocks.createTab).not.toHaveBeenCalled()
   })
 
   it('returns keyboard focus to the active split pane leaf when a terminal tab is activated', async () => {

--- a/src/renderer/src/store/slices/cmd-j-create-actions.test.ts
+++ b/src/renderer/src/store/slices/cmd-j-create-actions.test.ts
@@ -318,4 +318,76 @@ describe('Cmd+J lifted creation actions', () => {
     expect(createWebRuntimeSessionTerminalMock).not.toHaveBeenCalled()
     expect(store.getState().tabsByWorktree['wt-1'] ?? []).toHaveLength(1)
   })
+
+  it.each(['pwsh.exe', 'git-bash', 'wsl.exe'] as const)(
+    'creates plus-menu %s tabs in the requested group, not a stale active group',
+    async (shellOverride) => {
+      // Why: Windows plus-menu used createTab(worktreeId, undefined, shell); a stale
+      // activeGroupId then attached the tab to the wrong group (issue #16444).
+      delete pairedWebFlag.__ORCA_WEB_CLIENT__
+      const store = createTestStore()
+      seedActiveWorkspace(store)
+      store.setState({
+        repos: [{ ...TEST_REPO, executionHostId: 'local' }],
+        worktreesByRepo: {
+          [TEST_REPO.id]: [makeWorktree({ id: 'wt-1', repoId: TEST_REPO.id, hostId: 'local' })]
+        },
+        settings: { activeRuntimeEnvironmentId: null } as AppState['settings'],
+        groupsByWorktree: {
+          'wt-1': [
+            { id: 'stale-group', worktreeId: 'wt-1', activeTabId: null, tabOrder: [] },
+            { id: 'group-1', worktreeId: 'wt-1', activeTabId: null, tabOrder: [] }
+          ]
+        },
+        activeGroupIdByWorktree: { 'wt-1': 'stale-group' }
+      })
+      const createTab = store.getState().createTab
+      const createTabSpy = vi.fn(createTab)
+      store.setState({ createTab: createTabSpy })
+
+      await store.getState().openNewTerminalTabInActiveWorkspace('group-1')
+      await store.getState().openNewTerminalTabInActiveWorkspace('group-1', shellOverride)
+
+      expect(createWebRuntimeSessionTerminalMock).not.toHaveBeenCalled()
+      expect(createTabSpy).toHaveBeenCalledTimes(2)
+      expect(createTabSpy.mock.calls[0]?.[1]).toBe('group-1')
+      expect(createTabSpy.mock.calls[1]?.[1]).toBe('group-1')
+      expect(createTabSpy.mock.calls[1]?.[2]).toBe(shellOverride)
+      const tabs = store.getState().tabsByWorktree['wt-1'] ?? []
+      expect(tabs).toHaveLength(2)
+      expect(tabs[1]?.shellOverride).toBe(shellOverride)
+      const requestedGroup = store
+        .getState()
+        .groupsByWorktree['wt-1']?.find((group) => group.id === 'group-1')
+      const staleGroup = store
+        .getState()
+        .groupsByWorktree['wt-1']?.find((group) => group.id === 'stale-group')
+      expect(requestedGroup?.tabOrder).toEqual([tabs[0]?.id, tabs[1]?.id])
+      expect(staleGroup?.tabOrder).toEqual([])
+    }
+  )
+
+  it('forwards plus-menu shell overrides on the same web runtime group path as Ctrl+T', async () => {
+    createWebRuntimeSessionTerminalMock.mockResolvedValue(false)
+    const store = createTestStore()
+    seedActiveWorkspace(store)
+
+    await store.getState().openNewTerminalTabInActiveWorkspace('group-1')
+    await store.getState().openNewTerminalTabInActiveWorkspace('group-1', 'pwsh.exe')
+
+    expect(createWebRuntimeSessionTerminalMock).toHaveBeenNthCalledWith(1, {
+      worktreeId: 'wt-1',
+      environmentId: 'runtime-1',
+      targetGroupId: 'group-1',
+      activate: true
+    })
+    expect(createWebRuntimeSessionTerminalMock).toHaveBeenNthCalledWith(2, {
+      worktreeId: 'wt-1',
+      environmentId: 'runtime-1',
+      targetGroupId: 'group-1',
+      command: 'pwsh.exe',
+      activate: true
+    })
+    expect(store.getState().tabsByWorktree['wt-1'] ?? []).toEqual([])
+  })
 })

--- a/src/renderer/src/store/terminals/terminal-actions.ts
+++ b/src/renderer/src/store/terminals/terminal-actions.ts
@@ -76,7 +76,7 @@ export type TerminalActions = {
       forceHostRuntime?: boolean
     }
   ) => TerminalTab
-  openNewTerminalTabInActiveWorkspace: (groupId: string) => Promise<void>
+  openNewTerminalTabInActiveWorkspace: (groupId: string, shellOverride?: string) => Promise<void>
   /** Synchronous retirement: provider teardown starts before state removal but is never awaited. */
   closeTab: (
     tabId: string,

--- a/src/renderer/src/store/terminals/terminal-active-workspace-creation.ts
+++ b/src/renderer/src/store/terminals/terminal-active-workspace-creation.ts
@@ -11,7 +11,7 @@ export function createActiveWorkspaceTerminalActions(
   get: TerminalStoreGet
 ): Pick<TerminalSlice, 'openNewTerminalTabInActiveWorkspace'> {
   return {
-    openNewTerminalTabInActiveWorkspace: async (groupId) => {
+    openNewTerminalTabInActiveWorkspace: async (groupId, shellOverride) => {
       const state = get()
       const worktreeId = state.activeWorktreeId
       if (!worktreeId) {
@@ -34,6 +34,7 @@ export function createActiveWorkspaceTerminalActions(
           worktreeId,
           environmentId: runtimeEnvironmentId,
           targetGroupId: groupId,
+          ...(shellOverride ? { command: shellOverride } : {}),
           activate: true
         })
         return
@@ -41,7 +42,7 @@ export function createActiveWorkspaceTerminalActions(
       if (isWebClientLocation() && worktreeId !== FLOATING_TERMINAL_WORKTREE_ID) {
         return
       }
-      const terminal = get().createTab(worktreeId, groupId)
+      const terminal = get().createTab(worktreeId, groupId, shellOverride)
       get().setActiveTab(terminal.id)
       get().setActiveTabType('terminal')
       const latest = get()


### PR DESCRIPTION
## Description
On Windows the tab-bar plus menu created a terminal with no active group id, unlike Ctrl+T. That could attach to a stale group, return `selector_not_found`, and then break Ctrl+T until a workspace switch.
Plus-menu shell creation now uses the same active-workspace/group path as Ctrl+T.

## Focused fix
- In scope: plus-menu / shell-specific new terminal uses `openNewTerminalTabInActiveWorkspace(groupId, shellOverride?)`.
- Out of scope: changing Windows shell detection; SSH/WSL icon mapping.

## Preserves
- Ctrl+T path.
- Shell override values (`pwsh.exe` / Git Bash / WSL).
- Web runtime still forwards `command` with `targetGroupId`.

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/cmd-j-create-actions.test.ts src/renderer/src/components/tab-group/useTabGroupWorkspaceModel.focus.test.ts src/renderer/src/components/tab-bar/TabBar.windows-shell-launch.test.ts src/renderer/src/components/tab-bar/TabBar.windows-shell-ssh-host.test.ts`
- Result: **30 passed**
- Regression: plus-menu create is invoked with the active `groupId` even when stored `activeGroupId` is stale.

## User-regression-tradeoffs
None for Ctrl+T. Plus-menu tabs should land in the focused group instead of a stale one.

Fixes #16444
