### PR TITLE
test(git): isolate worktree-shared-directories git config portably (#15409)

### DIFF
--- a/src/main/git/worktree-shared-directories.test.ts
+++ b/src/main/git/worktree-shared-directories.test.ts
@@ -1,8 +1,8 @@
 import { execFileSync } from 'node:child_process'
 import { lstatSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
-import { devNull, tmpdir } from 'node:os'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   clearConfiguredWorktreeSharedDirectoriesCacheForTests,
   getConfiguredWorktreeSharedDirectories,
@@ -16,16 +16,50 @@ import {
 import { assertWorktreeCleanForRemoval } from './worktree'
 import { getStatus } from './status'
 
+// Why an empty file and not `os.devNull`: that constant is `\\.\nul` on win32, which
+// Git normalizes to `//./nul` and rejects — `fatal: unable to access '//./nul': Invalid
+// argument`. Every git call in this file then threw. POSIX resolves it to /dev/null,
+// which Git accepts, so CI never saw it. An empty file works on every platform and
+// matches how skill-git-tree-identity and skill-windows-workspace already isolate.
+//
+// Why process.env and not just this helper's env: resolveWorktreeSharedDirectories
+// runs its own `git check-ignore` through the production runner, which inherits
+// process.env. Overriding only the setup helper left the code under test reading the
+// host's real config, so a developer with core.excludesFile set saw a fixture that is
+// not gitignored come back as ignored.
+let gitConfigRoot: string
+let previousGitConfigGlobal: string | undefined
+let previousGitConfigNosystem: string | undefined
+
+beforeAll(() => {
+  gitConfigRoot = mkdtempSync(join(tmpdir(), 'orca-shared-dirs-gitconfig-'))
+  const emptyGlobalGitConfig = join(gitConfigRoot, 'global.gitconfig')
+  writeFileSync(emptyGlobalGitConfig, '')
+  previousGitConfigGlobal = process.env.GIT_CONFIG_GLOBAL
+  previousGitConfigNosystem = process.env.GIT_CONFIG_NOSYSTEM
+  process.env.GIT_CONFIG_GLOBAL = emptyGlobalGitConfig
+  process.env.GIT_CONFIG_NOSYSTEM = '1'
+})
+
+afterAll(() => {
+  restoreGitEnv('GIT_CONFIG_GLOBAL', previousGitConfigGlobal)
+  restoreGitEnv('GIT_CONFIG_NOSYSTEM', previousGitConfigNosystem)
+  rmSync(gitConfigRoot, { recursive: true, force: true })
+})
+
+function restoreGitEnv(
+  name: 'GIT_CONFIG_GLOBAL' | 'GIT_CONFIG_NOSYSTEM',
+  value: string | undefined
+): void {
+  if (value === undefined) {
+    delete process.env[name]
+    return
+  }
+  process.env[name] = value
+}
+
 const git = (args: string[], cwd: string): void => {
-  execFileSync('git', args, {
-    cwd,
-    stdio: 'ignore',
-    env: {
-      ...process.env,
-      GIT_CONFIG_GLOBAL: devNull,
-      GIT_CONFIG_SYSTEM: devNull
-    }
-  })
+  execFileSync('git', args, { cwd, stdio: 'ignore' })
 }
 
 describe('resolveWorktreeSharedDirectories', () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​45 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​34 |
| Prod | 0 | 0 | 0 | 0 |

<!-- /orca-pr-loc -->

## ELI5

This test file tried to stop Git from reading your personal Git settings by
pointing Git's config at "the black hole file". On Mac/Linux that file is
`/dev/null` and Git is happy. On Windows the same Node constant is `\\.\nul`,
which Git turns into `//./nul` and flatly refuses. So on Windows the very first
`git init` in `beforeEach` threw and **15 of the 19 tests failed** — while CI,
which is Linux, stayed green and never noticed.

Two separate things were wrong, and the second one bites on every platform:

1. The black-hole path is not portable.
2. The isolation was only applied to the suite's own little `git()` helper. The
   *code being tested* shells out to Git through the real production runner,
   which just inherits `process.env` — so it was reading your real global Git
   config the whole time.

## What changed

`src/main/git/worktree-shared-directories.test.ts` only.

- `GIT_CONFIG_GLOBAL` now points at a real **empty file** inside a private
  `mkdtempSync` directory, and `GIT_CONFIG_SYSTEM: devNull` becomes
  `GIT_CONFIG_NOSYSTEM=1`. Empty files work on every platform and every Git
  version, and this matches how `skill-git-tree-identity.test.ts` and
  `skill-windows-workspace.integration.test.ts` already isolate.
- Both variables are set on `process.env` in `beforeAll` and restored in
  `afterAll` (with the temp dir removed), following the existing convention in
  `src/relay/git-handler-pull-reconciliation.test.ts`. The per-call `env` on the
  `git()` helper goes away, because it never covered the system under test.

Why the second half matters: `resolveWorktreeSharedDirectories` reaches Git via
`checkIgnoredPaths` → `gitExecFileAsync`, and `GitRuntimeOptions` carries only
`wslDistro` and `signal` — no `env`. So the runner inherits `process.env`, and a
developer with `core.excludesFile` set could see a fixture that is *not* in
`.gitignore` come back as ignored.

## Verification

All exit codes, not grep.

| Check | Exit |
|---|---|
| `pnpm lint` | 0 |
| `pnpm typecheck` | 0 |
| `node config/scripts/check-reliability-gates.mjs` | 0 (97 gates) |
| `vitest run src/main/git/worktree-shared-directories.test.ts` | 0 — **19/19 pass** |

### Mutation-verified

The harness in this environment refuses a `GIT_CONFIG_GLOBAL=...` shell prefix,
so the hostile host config was injected *inside* the vitest process instead: a
throwaway probe test set `process.env.GIT_CONFIG_GLOBAL` to a config whose
`core.excludesFile` ignores the `shared-but-tracked` fixture, then imported this
suite. (Probe was deleted; it is not part of this diff.)

| Scenario | Result |
|---|---|
| Fix applied, hostile host config injected | **19/19 pass** |
| Reverted just the `process.env` half — kept the empty file, but applied it only to the `git()` helper's per-call `env` (i.e. the pre-existing shape) | **RED**: `× skips a directory that is not gitignored`, 1 failed / 18 passed |

That is the exact assertion flip described in the issue thread, and it proves
the `process.env` half is load-bearing rather than belt-and-braces.

The `os.devNull` half cannot be mutation-tested from macOS — `/dev/null` is
accepted there by design; that is the entire reason CI missed it. Confirmed
instead that `os.devNull` is `/dev/null` on this host vs `\\.\nul` on win32, and
that no `os.devNull` + `GIT_CONFIG_*` pairing remains anywhere in `src/`.
Windows-side confirmation of this exact empty-file form is already on the issue
(19/19 on Windows 11, Git for Windows 2.54.0).

### No regressions

Ran the touched areas against an `origin/main` baseline. Identical failure sets
both sides — 6 renderer-card timeouts in `src/renderer/src/components/sidebar/`
that are pre-existing flakes and pass in isolation. Baseline: 6 failed / 3608
passed. With this change: 6 failed / 3615 passed.

## Trade-offs

- `process.env` mutation is process-wide for the vitest worker. Scoped to
  `beforeAll`/`afterAll` with explicit restore of the prior values (including
  `delete` when previously unset), which is the convention already in the repo.
- `GIT_CONFIG_NOSYSTEM=1` rather than an empty system config file: one fewer
  file, same effect, and it is unambiguous on Windows where the system config
  location differs.

## Heads-up on overlap

Two open PRs already target this issue: #15410 and #15425. I found them after
the work was done. #15410 in particular reaches the same conclusion, including
the `process.env` half. **Happy for this to be closed in favour of either** —
the added value here is the mutation evidence above. Flagging rather than
quietly duplicating.

Fixes #15409
