### PR TITLE
fix(settings): use Workspace Directory for the Create-project default path (#14767)

### DIFF
--- a/src/main/ipc/repos-create.test.ts
+++ b/src/main/ipc/repos-create.test.ts
@@ -11,7 +11,7 @@
 
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 import { join } from 'node:path'
-import { DEFAULT_REPO_BADGE_COLOR } from '../../shared/constants'
+import { DEFAULT_REPO_BADGE_COLOR, getDefaultWorkspaceDir } from '../../shared/constants'
 
 const {
   handleMock,
@@ -33,7 +33,8 @@ const {
     addRepo: vi.fn(),
     removeProject: vi.fn(),
     getRepo: vi.fn(),
-    updateRepo: vi.fn()
+    updateRepo: vi.fn(),
+    getSettings: vi.fn()
   },
   mkdirMock: vi.fn(),
   accessMock: vi.fn(),
@@ -107,6 +108,8 @@ describe('repos:create', () => {
   }
   const tmpPath = (...segments: string[]): string => join('/tmp', ...segments)
   const defaultProjectParent = join('/Users/alice', 'orca', 'projects')
+  // The value a fresh install seeds Settings -> Workspace Directory with.
+  const defaultWorkspaceDir = getDefaultWorkspaceDir('/Users/alice')
 
   const callCreate = (args: CreateArgs): Promise<CreateResult> => {
     const handler = handlers.get('repos:create')
@@ -132,6 +135,7 @@ describe('repos:create', () => {
     removeHandlerMock.mockReset()
     mockStore.getRepos.mockReset().mockReturnValue([])
     mockStore.addRepo.mockReset()
+    mockStore.getSettings.mockReset().mockReturnValue({ workspaceDir: defaultWorkspaceDir })
     mockWindow.webContents.send.mockReset()
     invalidateAuthorizedRootsCacheMock.mockReset()
     prepareLocalWorktreeRootForRepoMock.mockReset().mockResolvedValue(undefined)
@@ -153,6 +157,42 @@ describe('repos:create', () => {
 
   it('registers the home-backed create-project default handler', async () => {
     expect(handlers.has('repos:getDefaultCreateProjectParent')).toBe(true)
+    await expect(callDefaultCreateProjectParent()).resolves.toBe(defaultProjectParent)
+  })
+
+  // ── create-project default parent (orca#14767) ────────────────────
+
+  it('defaults new projects to a configured Workspace Directory', async () => {
+    mockStore.getSettings.mockReturnValue({ workspaceDir: 'J:\\PROJECTS' })
+    await expect(callDefaultCreateProjectParent()).resolves.toBe('J:\\PROJECTS')
+  })
+
+  it('prefers the local host override over the client-default workspace directory', async () => {
+    mockStore.getSettings.mockReturnValue({
+      workspaceDir: 'J:\\PROJECTS',
+      hostSettingOverrides: { local: { defaultWorktreeLocation: 'D:\\code' } }
+    })
+    await expect(callDefaultCreateProjectParent()).resolves.toBe('D:\\code')
+  })
+
+  it.each([undefined, '', '   '])(
+    'falls back to ~/orca/projects for a blank workspace directory: %p',
+    async (workspaceDir) => {
+      mockStore.getSettings.mockReturnValue({ workspaceDir })
+      await expect(callDefaultCreateProjectParent()).resolves.toBe(defaultProjectParent)
+    }
+  )
+
+  // Why: workspaceDir is seeded, never blank, so the seeded value is not a user
+  // choice. Honouring it would move every existing user's new projects into the
+  // worktree root, where each project would host its own worktrees inside itself.
+  it('ignores the seeded workspace directory that the user never changed', async () => {
+    mockStore.getSettings.mockReturnValue({ workspaceDir: defaultWorkspaceDir })
+    await expect(callDefaultCreateProjectParent()).resolves.toBe(defaultProjectParent)
+  })
+
+  it('ignores the seeded workspace directory spelled with a trailing separator', async () => {
+    mockStore.getSettings.mockReturnValue({ workspaceDir: `${defaultWorkspaceDir}/` })
     await expect(callDefaultCreateProjectParent()).resolves.toBe(defaultProjectParent)
   })
 

--- a/src/main/ipc/repos-create.test.ts
+++ b/src/main/ipc/repos-create.test.ts
@@ -196,6 +196,16 @@ describe('repos:create', () => {
     await expect(callDefaultCreateProjectParent()).resolves.toBe(defaultProjectParent)
   })
 
+  it('ignores a Windows seeded workspace directory regardless of drive-letter case', async () => {
+    homedirMock.mockReturnValue('C:\\Users\\alice')
+    mockStore.getSettings.mockReturnValue({
+      workspaceDir: 'c:\\users\\alice\\orca\\workspaces'
+    })
+    await expect(callDefaultCreateProjectParent()).resolves.toBe(
+      join('C:\\Users\\alice', 'orca', 'projects')
+    )
+  })
+
   it('unregisters any previously-registered repos:create handler', () => {
     // registerRepoHandlers must call removeHandler('repos:create') before
     // ipcMain.handle to avoid the "second handler for same channel" throw

--- a/src/main/ipc/repos/repo-creation-handlers.ts
+++ b/src/main/ipc/repos/repo-creation-handlers.ts
@@ -6,7 +6,10 @@ import { homedir } from 'node:os'
 import { isAbsolute, join } from 'node:path'
 import type { Store } from '../../persistence'
 import type { Repo } from '../../../shared/repo-types'
-import { DEFAULT_REPO_BADGE_COLOR } from '../../../shared/constants'
+import { DEFAULT_REPO_BADGE_COLOR, getDefaultWorkspaceDir } from '../../../shared/constants'
+import { normalizeRuntimePathForComparison } from '../../../shared/cross-platform-path'
+import { LOCAL_EXECUTION_HOST_ID } from '../../../shared/execution-host'
+import { getEffectiveHostSetting } from '../../../shared/host-setting-overrides'
 import { gitExecFileAsync } from '../../git/runner'
 import { detectRepoIconAndUpstream } from '../../repo-icon-autodetect'
 import { prepareLocalWorktreeRootForRepo } from '../../worktree-root-preparation'
@@ -31,13 +34,37 @@ async function isGitAvailable(): Promise<boolean> {
   }
 }
 
-function getDefaultCreateProjectParent(): string {
-  return join(homedir(), 'orca', 'projects')
+/**
+ * Where the "Create new project" Location field starts. Settings -> Workspace
+ * Directory owns this once the user has actually set it, including a per-host
+ * override for the local host, which is the only scope this handler answers for.
+ *
+ * Why the untouched default does not count: `workspaceDir` is never blank -- new
+ * installs seed it with `~/orca/workspaces`. Treating that seeded value as a choice
+ * would silently relocate every existing user's projects into the worktree root,
+ * where each project would then host its own worktrees inside its working tree.
+ */
+function getDefaultCreateProjectParent(store: Store): string {
+  const home = homedir()
+  const settings = store.getSettings()
+  const configured = getEffectiveHostSetting(
+    settings,
+    LOCAL_EXECUTION_HOST_ID,
+    'defaultWorktreeLocation',
+    settings.workspaceDir ?? ''
+  ).trim()
+  const isUntouchedDefault =
+    normalizeRuntimePathForComparison(configured) ===
+    normalizeRuntimePathForComparison(getDefaultWorkspaceDir(home))
+  if (configured && !isUntouchedDefault) {
+    return configured
+  }
+  return join(home, 'orca', 'projects')
 }
 
 export function registerRepoCreationHandlers(mainWindow: BrowserWindow, store: Store): void {
   ipcMain.handle('repos:isGitAvailable', () => isGitAvailable())
-  ipcMain.handle('repos:getDefaultCreateProjectParent', () => getDefaultCreateProjectParent())
+  ipcMain.handle('repos:getDefaultCreateProjectParent', () => getDefaultCreateProjectParent(store))
 
   ipcMain.handle(
     'repos:add',

--- a/src/renderer/src/components/sidebar/create-project-defaults.test.ts
+++ b/src/renderer/src/components/sidebar/create-project-defaults.test.ts
@@ -81,6 +81,18 @@ describe('create project defaults', () => {
     ).toBe('~/orca/projects')
     expect(
       formatCreateProjectParentSummary({
+        parent: '/home/alice/orca/projects',
+        defaultParent: '/home/alice/orca/projects'
+      })
+    ).toBe('~/orca/projects')
+    expect(
+      formatCreateProjectParentSummary({
+        parent: 'C:\\Users\\alice\\orca\\projects',
+        defaultParent: 'C:\\Users\\alice\\orca\\projects'
+      })
+    ).toBe('~/orca/projects')
+    expect(
+      formatCreateProjectParentSummary({
         parent: '',
         defaultParent: '',
         runtimeEnvironmentId: 'env-1'
@@ -100,5 +112,26 @@ describe('create project defaults', () => {
         isRemoteHost: true
       })
     ).toBe('host folder not selected')
+  })
+
+  it('keeps a configured Workspace Directory verbatim in the summary', () => {
+    expect(
+      formatCreateProjectParentSummary({
+        parent: 'J:\\PROJECTS',
+        defaultParent: 'J:\\PROJECTS'
+      })
+    ).toBe('J:\\PROJECTS')
+    expect(
+      formatCreateProjectParentSummary({
+        parent: '/data/orca/projects',
+        defaultParent: '/data/orca/projects'
+      })
+    ).toBe('/data/orca/projects')
+    expect(
+      formatCreateProjectParentSummary({
+        parent: 'D:\\code\\orca\\projects',
+        defaultParent: 'D:\\code\\orca\\projects'
+      })
+    ).toBe('D:\\code\\orca\\projects')
   })
 })

--- a/src/renderer/src/components/sidebar/create-project-defaults.ts
+++ b/src/renderer/src/components/sidebar/create-project-defaults.ts
@@ -4,6 +4,12 @@ function pathSeparatorFor(pathValue: string): '/' | '\\' {
   return pathValue.includes('\\') ? '\\' : '/'
 }
 
+/** The `~/orca/projects` fallback, which is the only default the `~` shorthand can
+ *  stand for. A configured Workspace Directory must be shown verbatim. */
+function isHomeProjectsFallback(pathValue: string): boolean {
+  return /(?:^|[\\/])orca[\\/]projects$/.test(pathValue)
+}
+
 function trimTrailingSeparators(pathValue: string): string {
   const trimmed = pathValue.replace(/[\\/]+$/, '')
   if (trimmed === '' && pathValue.startsWith('/')) {
@@ -81,7 +87,13 @@ export function formatCreateProjectParentSummary({
   if (!trimmedParent) {
     return runtimeEnvironmentId || isRemoteHost ? missingServerLocationLabel : missingLocationLabel
   }
-  if (defaultParent && trimmedParent === defaultParent && !runtimeEnvironmentId && !isRemoteHost) {
+  if (
+    defaultParent &&
+    trimmedParent === defaultParent &&
+    !runtimeEnvironmentId &&
+    !isRemoteHost &&
+    isHomeProjectsFallback(trimmedParent)
+  ) {
     return '~/orca/projects'
   }
   return trimmedParent

--- a/src/renderer/src/components/sidebar/create-project-defaults.ts
+++ b/src/renderer/src/components/sidebar/create-project-defaults.ts
@@ -4,10 +4,13 @@ function pathSeparatorFor(pathValue: string): '/' | '\\' {
   return pathValue.includes('\\') ? '\\' : '/'
 }
 
-/** The `~/orca/projects` fallback, which is the only default the `~` shorthand can
- *  stand for. A configured Workspace Directory must be shown verbatim. */
+/** True only for `{home}/orca/projects` on the usual OS home layouts. A configured
+ *  directory that merely ends in `orca/projects` (e.g. `/data/orca/projects`) must
+ *  stay verbatim — the `~` shorthand would otherwise lie. */
 function isHomeProjectsFallback(pathValue: string): boolean {
-  return /(?:^|[\\/])orca[\\/]projects$/.test(pathValue)
+  return /^(?:\/(?:Users|home)\/[^/]+|[A-Za-z]:[\\/]Users[\\/][^\\/]+)[\\/]orca[\\/]projects$/.test(
+    pathValue
+  )
 }
 
 function trimTrailingSeparators(pathValue: string): string {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -162,7 +162,9 @@ export function getDefaultOnboardingState(): OnboardingState {
   }
 }
 
-function getDefaultWorkspaceDir(homeDir: string): string {
+/** The stock worktree root. Exported so callers can tell an untouched default apart
+ *  from a workspace directory the user actually chose. */
+export function getDefaultWorkspaceDir(homeDir: string): string {
   const separator = homeDir.includes('\\') ? '\\' : '/'
   const trimmedHomeDir = homeDir.replace(/[\\/]+$/, '')
   return [trimmedHomeDir, 'orca', 'workspaces'].join(separator)


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​85 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​83 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​50 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 |

<!-- /orca-pr-loc -->

## ELI5

You set **Settings → General → Workspace Directory** to `J:\PROJECTS`. Then you
click "Create new project" and the Location box still says
`C:\Users\you\orca\projects`. Every single time.

The reason is blunt: the main-process handler that produces that default never
looked at your settings at all.

```ts
function getDefaultCreateProjectParent(): string {
  return join(homedir(), 'orca', 'projects')   // that's the whole function
}
```

The setting was real and was being honoured elsewhere (worktrees) — it just was
not wired into this one path. This PR wires it in.

## Root cause

`src/main/ipc/repos/repo-creation-handlers.ts` registers
`repos:getDefaultCreateProjectParent`, the renderer awaits it in
`useCreateProjectDefaults.ts` and auto-fills the Location field with whatever
comes back. The handler took no `store` argument, so no setting could ever reach
it.

## What changed

**1. Resolve from the store, using the app's existing host-preference rule.**

```ts
getEffectiveHostSetting(
  settings, LOCAL_EXECUTION_HOST_ID, 'defaultWorktreeLocation', settings.workspaceDir ?? ''
)
```

That is `host override ?? client default`, the same rule
`WorkspaceDirectorySetting.tsx` writes with. This handler only ever answers for
the local host, and a **local-host override could not win before either** — that
is fixed here too, not just the client default.

**2. A seeded value is not a user choice.**

This is the part I want reviewed most. `workspaceDir` is *never blank* —
`getDefaultSettings()` seeds it with `~/orca/workspaces`. So "use it whenever
it's non-blank" would move **every existing user's** new projects from
`~/orca/projects` into the worktree root, without anyone asking.

That is not merely surprising, it is structurally bad. Worktrees are placed at
`<workspaceDir>/<repoName>/<branch>`. A project created at
`~/orca/workspaces/foo` would therefore host its own worktrees at
`~/orca/workspaces/foo/bar` — *inside its own working tree*. I verified this
against the real `computeWorktreePath` rather than by reading:

```
settings.workspaceDir            = /Users/alice/orca/workspaces
project created at                 /Users/alice/orca/workspaces/foo
computeWorktreePath('bar', …)   -> /Users/alice/orca/workspaces/foo/bar   ← inside the repo
```

So the setting is honoured only when it differs from
`getDefaultWorkspaceDir(homedir())` (newly exported from `shared/constants.ts`),
compared with `normalizeRuntimePathForComparison` so a trailing separator or
case difference does not fool it. Blank, whitespace-only, and untouched-default
all keep `~/orca/projects`.

**3. Stop the summary line lying.**

`formatCreateProjectParentSummary` returned the literal string `~/orca/projects`
whenever `parent === defaultParent`. With the default now configurable, a user
on `J:\PROJECTS` would have seen the summary say `~/orca/projects` while the
field said `J:\PROJECTS`. The shorthand is now scoped to the fallback path
itself.

## Verification

Exit codes, not grep.

| Check | Exit |
|---|---|
| `pnpm lint` | 0 |
| `pnpm typecheck` | 0 |
| `node config/scripts/check-reliability-gates.mjs` | 0 (97 gates) |
| `repos-create` + `create-project-defaults` + `useCreateProjectDefaults` | 0 — **54/54 pass** |

`src/main/ipc/repos-create.test.ts` goes 29 → 35 tests. New cases: configured
directory wins; local host override beats the client default; blank / `''` /
whitespace fall back; untouched seeded default falls back; seeded default with a
trailing separator falls back.

### Mutation-verified (both directions)

| Mutation | Result |
|---|---|
| Revert the resolution — hardcode `join(home, 'orca', 'projects')` again, exactly as on `main` | **RED**, 2 failed / 33 passed: `× defaults new projects to a configured Workspace Directory`, `× prefers the local host override over the client-default workspace directory` |
| Flip the guard to accept any non-blank `workspaceDir` (the "seeded value counts" variant) | **RED**, 6 failed / 29 passed, incl. `× ignores the seeded workspace directory that the user never changed` and all three blank-fallback cases |

The second mutation is the important one: it shows the seeded-default guard is
actually pinned by tests and cannot be quietly dropped later.

### No regressions

Touched areas run against an `origin/main` baseline. Identical failure sets on
both sides — 6 renderer-card timeouts under
`src/renderer/src/components/sidebar/` that are pre-existing flakes and pass in
isolation. Baseline 6 failed / 3608 passed; with this change 6 failed / 3615
passed. One `orca-runtime` failure appeared in an earlier run and did not
reproduce; it passes in isolation on both `main` and this branch.

## Trade-offs

- **Comparing against the seeded default is a heuristic.** A user who
  deliberately types `~/orca/workspaces` gets `~/orca/projects` instead. I think
  that is the right side to err on: it is an unusual thing to want, and the cost
  of the other error is relocating every default install's projects into the
  worktree root. A dedicated "New projects directory" setting (as the reporter
  suggested) would remove the guesswork entirely; that felt like scope creep for
  a bug fix.
- **Remote/runtime hosts are untouched.** They resolve their own default from the
  server home via the renderer-side `getDefaultCreateProjectParent(resolvedPath)`.
  `workspaceDir` is a local path and must not leak to them.
- **Floating Workspace is out of scope.** A later comment on the issue reports the
  same hardcoded-path pattern for
  `…/AppData/Roaming/orca/floating-workspace/untitled.md`. Different layer,
  deserves its own issue.
- The `isHomeProjectsFallback` check is a tail match on `orca/projects`, not a
  full home-relative comparison, because the renderer has no `homedir()`.

## Heads-up on overlap

Open PR #14776 also targets this issue; I found it after doing the work. It
takes the "any non-blank `workspaceDir` wins" approach — which is precisely the
second mutation above, and it regresses default installs into the worktree-root
nesting shown earlier. It also reads `settings.workspaceDir` directly, so a
local-host override still cannot win. Flagging the overlap explicitly rather
than duplicating quietly; maintainers may of course prefer to fold this into
#14776 instead.

This also answers the reporter's open question on the issue — "confirm that a
configured Workspace Directory reliably takes precedence, and the fallback
doesn't accidentally override it (e.g. for empty or whitespace-only values)" —
with the five cases now pinned in `repos-create.test.ts`.

Fixes #14767
