### PR TITLE
fix(terminal): stop routing unowned workspaces to the focused runtime environment

### DIFF
--- a/src/renderer/src/components/tab-group/useTabGroupCreationCommands.local-shell.test.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupCreationCommands.local-shell.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { stubHeadlessReact } from '../tab-bar/tab-bar-windows-shell-launch-render-stubs'
+
+const mocks = vi.hoisted(() => ({
+  createTab: vi.fn(),
+  setActiveTab: vi.fn(),
+  setActiveTabType: vi.fn(),
+  setActiveWorktree: vi.fn(),
+  focusGroup: vi.fn(),
+  createBrowserTab: vi.fn(),
+  createEmptySplitGroup: vi.fn(),
+  openNewBrowserTabInActiveWorkspace: vi.fn(),
+  openNewMarkdownInActiveWorkspace: vi.fn(),
+  openNewTerminalTabInActiveWorkspace: vi.fn(),
+  getRuntimeEnvironmentIdForWorktree: vi.fn(),
+  focusTerminalTabSurface: vi.fn(),
+  runtimeCall: vi.fn()
+}))
+
+vi.mock('react', async () => await stubHeadlessReact())
+
+vi.mock('@/lib/worktree-runtime-owner', () => ({
+  getRuntimeEnvironmentIdForWorktree: mocks.getRuntimeEnvironmentIdForWorktree,
+  getRuntimeSessionMirrorEnvironmentIds: () => []
+}))
+
+vi.mock('../../lib/focus-terminal-tab-surface', () => ({
+  focusTerminalTabSurface: mocks.focusTerminalTabSurface
+}))
+
+const WORKTREE_ID = 'repo::C:/Users/neil/orca/workspaces/orca/aug23-triage'
+const GROUP_ID = 'group-1'
+const FOCUSED_ENVIRONMENT_ID = 'arch-dev'
+
+const storeState = {
+  settings: { activeRuntimeEnvironmentId: FOCUSED_ENVIRONMENT_ID },
+  activeWorktreeId: WORKTREE_ID,
+  activeWorkspaceExecutionHostId: 'local' as string | null,
+  browserTabsByWorktree: {},
+  browserPagesByWorkspace: {},
+  remoteBrowserPageHandlesByPageId: {},
+  createTab: mocks.createTab,
+  setActiveTab: mocks.setActiveTab,
+  setActiveTabType: mocks.setActiveTabType,
+  setActiveWorktree: mocks.setActiveWorktree,
+  focusGroup: mocks.focusGroup,
+  createBrowserTab: mocks.createBrowserTab,
+  createEmptySplitGroup: mocks.createEmptySplitGroup,
+  openNewBrowserTabInActiveWorkspace: mocks.openNewBrowserTabInActiveWorkspace,
+  openNewMarkdownInActiveWorkspace: mocks.openNewMarkdownInActiveWorkspace,
+  openNewTerminalTabInActiveWorkspace: mocks.openNewTerminalTabInActiveWorkspace
+}
+
+const useAppStore = Object.assign(
+  (selector?: (state: typeof storeState) => unknown) =>
+    selector ? selector(storeState) : storeState,
+  {
+    getState: () => storeState,
+    setState: vi.fn(),
+    subscribe: vi.fn()
+  }
+)
+
+vi.mock('../../store', () => ({ useAppStore }))
+
+/**
+ * The "+" menu's shell rows on a workspace that no runtime environment owns. The remote
+ * runtime is connected and focused, which is the whole trap: an unowned workspace must
+ * still open its shell locally instead of asking that runtime to resolve a selector it
+ * has never heard of (#16444).
+ */
+describe('tab group "+" menu shell launch on a locally-owned workspace', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    storeState.activeWorkspaceExecutionHostId = 'local'
+    mocks.getRuntimeEnvironmentIdForWorktree.mockReturnValue(null)
+    mocks.createTab.mockReturnValue({ id: 'local-tab-1' })
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: mocks.runtimeCall } } })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('opens the shell locally without consulting the focused runtime environment', async () => {
+    const { useTabGroupCreationCommands } = await import('./useTabGroupCreationCommands')
+    const commands = useTabGroupCreationCommands({
+      groupId: GROUP_ID,
+      worktreeId: WORKTREE_ID,
+      worktreeState: { mobileEmulatorEnabled: false } as never
+    })
+
+    commands.newTerminalWithShell('powershell.exe')
+    await vi.waitFor(() => expect(mocks.createTab).toHaveBeenCalled())
+
+    expect(mocks.runtimeCall).not.toHaveBeenCalled()
+    expect(mocks.createTab).toHaveBeenCalledWith(WORKTREE_ID, GROUP_ID, 'powershell.exe')
+    expect(mocks.setActiveTab).toHaveBeenCalledWith('local-tab-1')
+  })
+
+  it('leaves the workspace on its own execution host', async () => {
+    const { useTabGroupCreationCommands } = await import('./useTabGroupCreationCommands')
+    const commands = useTabGroupCreationCommands({
+      groupId: GROUP_ID,
+      worktreeId: WORKTREE_ID,
+      worktreeState: { mobileEmulatorEnabled: false } as never
+    })
+
+    commands.newTerminalWithShell('powershell.exe')
+    await vi.waitFor(() => expect(mocks.createTab).toHaveBeenCalled())
+
+    // Latching the workspace onto the focused runtime is what silently broke the next Ctrl+T.
+    expect(mocks.setActiveWorktree).not.toHaveBeenCalled()
+    expect(storeState.activeWorkspaceExecutionHostId).toBe('local')
+  })
+})

--- a/src/renderer/src/runtime/web-runtime-session-terminal-workspace-routing.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session-terminal-workspace-routing.test.ts
@@ -1,0 +1,277 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ExecutionHostId } from '../../../shared/execution-host'
+import { createWebRuntimeSessionTerminal } from './web-runtime-session'
+import { resetWebSessionCloseIntentForTests } from './web-session-close-intent'
+import {
+  ENVIRONMENT_ID,
+  RUNTIME_EXECUTION_HOST_ID,
+  WORKTREE_ID,
+  makeSnapshot,
+  resetTerminalCreateEnvironment,
+  stubTerminalCreateEnvironment
+} from './web-runtime-session-test-harness'
+
+const mocks = vi.hoisted(() => ({
+  getState: vi.fn(),
+  setState: vi.fn(),
+  subscribe: vi.fn(),
+  setActiveWorktree: vi.fn(),
+  createBrowserTab: vi.fn(),
+  closeEmptyGroup: vi.fn(),
+  moveUnifiedTabToGroup: vi.fn(),
+  setRemoteBrowserPageHandle: vi.fn(),
+  focusBrowserTabInWorktree: vi.fn(),
+  applyWebSessionTabsSnapshot: vi.fn(),
+  decideWebSessionTabsSnapshot: vi.fn(() => ({ apply: true, settlesHostMirror: true })),
+  acceptReplayedWebSessionTabsSnapshot: vi.fn(),
+  resolveHostSessionTabIdForWebSessionTab: vi.fn(),
+  trackTerminalPaneSplit: vi.fn(),
+  deliverLaunchPromptToAgentTab: vi.fn(),
+  seedNativeChatLaunchDraftForAgentTab: vi.fn(),
+  getRuntimeEnvironmentIdForWorktree: vi.fn(),
+  hasMaterializedWebRuntimeBrowserPage: vi.fn()
+}))
+
+vi.mock('../store', () => ({
+  useAppStore: {
+    getState: mocks.getState,
+    setState: mocks.setState,
+    subscribe: mocks.subscribe
+  }
+}))
+
+vi.mock('./web-session-tabs-sync', () => ({
+  acceptReplayedWebSessionTabsSnapshot: mocks.acceptReplayedWebSessionTabsSnapshot,
+  applyWebSessionTabsSnapshot: mocks.applyWebSessionTabsSnapshot,
+  decideWebSessionTabsSnapshot: mocks.decideWebSessionTabsSnapshot,
+  applyWebSessionTabsStorePatch: (buildPatch: (state: unknown) => unknown) => {
+    mocks.setState(buildPatch)
+    return () => {}
+  },
+  resolveHostSessionTabIdForWebSessionTab: mocks.resolveHostSessionTabIdForWebSessionTab
+}))
+
+vi.mock('@/lib/feature-education-telemetry', () => ({
+  trackTerminalPaneSplit: mocks.trackTerminalPaneSplit
+}))
+
+vi.mock('@/lib/worktree-runtime-owner', () => ({
+  getRuntimeEnvironmentIdForWorktree: mocks.getRuntimeEnvironmentIdForWorktree
+}))
+
+vi.mock('@/lib/agent-launch-prompt-delivery', () => ({
+  deliverLaunchPromptToAgentTab: mocks.deliverLaunchPromptToAgentTab,
+  seedNativeChatLaunchDraftForAgentTab: mocks.seedNativeChatLaunchDraftForAgentTab
+}))
+
+vi.mock('./web-runtime-browser-materialization', () => ({
+  hasMaterializedWebRuntimeBrowserPage: mocks.hasMaterializedWebRuntimeBrowserPage
+}))
+
+const FOLDER_WORKSPACE_ID = 'folder:fw-1'
+
+type MutableSelection = {
+  activeWorktreeId: string | null
+  activeWorkspaceExecutionHostId: ExecutionHostId | null
+}
+
+/**
+ * The harness stub answers with a frozen object; the latch these tests are about
+ * only shows up when `setActiveWorktree` actually moves what the next read sees.
+ */
+function stubSelectableWorkspaceStore(selection: MutableSelection): void {
+  const base = mocks.getState() as Record<string, unknown>
+  mocks.getState.mockImplementation(() => ({ ...base, ...selection }))
+  mocks.setActiveWorktree.mockImplementation(
+    (worktreeId: string | null, executionHostId?: ExecutionHostId) => {
+      selection.activeWorktreeId = worktreeId
+      selection.activeWorkspaceExecutionHostId = executionHostId ?? null
+      return true
+    }
+  )
+}
+
+afterEach(() => resetWebSessionCloseIntentForTests())
+
+describe('web-runtime-session terminal workspace routing', () => {
+  beforeEach(() => {
+    stubTerminalCreateEnvironment(mocks)
+  })
+
+  afterEach(() => {
+    resetTerminalCreateEnvironment()
+  })
+
+  it('does not route a locally-owned workspace to the focused runtime environment', async () => {
+    const selection: MutableSelection = {
+      activeWorktreeId: WORKTREE_ID,
+      activeWorkspaceExecutionHostId: 'local'
+    }
+    stubSelectableWorkspaceStore(selection)
+    const runtimeCall = vi.fn()
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    // `environmentId: null` is the caller saying "I resolved ownership: nobody remote owns this".
+    const outcome = await createWebRuntimeSessionTerminal({
+      worktreeId: WORKTREE_ID,
+      environmentId: null,
+      command: 'powershell.exe',
+      activate: true
+    })
+
+    expect(outcome.status).toBe('failed')
+    expect(runtimeCall).not.toHaveBeenCalled()
+    expect(mocks.setActiveWorktree).not.toHaveBeenCalled()
+    expect(selection).toEqual({
+      activeWorktreeId: WORKTREE_ID,
+      activeWorkspaceExecutionHostId: 'local'
+    })
+  })
+
+  it('does not route a locally-owned folder workspace to the focused runtime environment', async () => {
+    const selection: MutableSelection = {
+      activeWorktreeId: FOLDER_WORKSPACE_ID,
+      activeWorkspaceExecutionHostId: 'local'
+    }
+    stubSelectableWorkspaceStore(selection)
+    const runtimeCall = vi.fn()
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    const outcome = await createWebRuntimeSessionTerminal({
+      worktreeId: FOLDER_WORKSPACE_ID,
+      environmentId: null,
+      activate: true
+    })
+
+    expect(outcome.status).toBe('failed')
+    expect(runtimeCall).not.toHaveBeenCalled()
+    expect(selection.activeWorkspaceExecutionHostId).toBe('local')
+  })
+
+  it('still falls back to the focused environment when the caller expressed no ownership', async () => {
+    const selection: MutableSelection = {
+      activeWorktreeId: WORKTREE_ID,
+      activeWorkspaceExecutionHostId: RUNTIME_EXECUTION_HOST_ID
+    }
+    stubSelectableWorkspaceStore(selection)
+    const runtimeCall = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: 'create',
+        ok: true,
+        result: { tab: { id: 'host-tab-1' }, publicationEpoch: 'epoch-1', snapshotVersion: 2 }
+      })
+      .mockResolvedValueOnce({ id: 'list', ok: true, result: makeSnapshot() })
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    const outcome = await createWebRuntimeSessionTerminal({
+      worktreeId: WORKTREE_ID,
+      activate: true
+    })
+
+    expect(outcome).toEqual({ status: 'created' })
+    expect(runtimeCall.mock.calls[0][0]).toMatchObject({
+      selector: ENVIRONMENT_ID,
+      method: 'session.tabs.createTerminal'
+    })
+  })
+
+  it('hands the workspace host selection back when the host never accepted the create', async () => {
+    const selection: MutableSelection = {
+      activeWorktreeId: WORKTREE_ID,
+      activeWorkspaceExecutionHostId: 'local'
+    }
+    stubSelectableWorkspaceStore(selection)
+    const runtimeCall = vi.fn().mockRejectedValue(new Error('selector_not_found'))
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    const outcome = await createWebRuntimeSessionTerminal({
+      worktreeId: WORKTREE_ID,
+      environmentId: ENVIRONMENT_ID,
+      activate: true
+    })
+
+    expect(outcome.status).toBe('failed')
+    expect(mocks.setActiveWorktree.mock.calls).toEqual([
+      [WORKTREE_ID, RUNTIME_EXECUTION_HOST_ID],
+      [WORKTREE_ID, 'local']
+    ])
+    // The latch is what silently reroutes the next Ctrl+T; it must not survive the failure.
+    expect(selection).toEqual({
+      activeWorktreeId: WORKTREE_ID,
+      activeWorkspaceExecutionHostId: 'local'
+    })
+  })
+
+  it('keeps the host selection after a create the host accepted', async () => {
+    const selection: MutableSelection = {
+      activeWorktreeId: WORKTREE_ID,
+      activeWorkspaceExecutionHostId: 'local'
+    }
+    stubSelectableWorkspaceStore(selection)
+    const runtimeCall = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: 'create',
+        ok: true,
+        result: { tab: { id: 'host-tab-1' }, publicationEpoch: 'epoch-1', snapshotVersion: 2 }
+      })
+      .mockRejectedValueOnce(new Error('list failed'))
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    const outcome = await createWebRuntimeSessionTerminal({
+      worktreeId: WORKTREE_ID,
+      environmentId: ENVIRONMENT_ID,
+      activate: true
+    })
+
+    expect(outcome).toEqual({ status: 'created' })
+    expect(mocks.setActiveWorktree.mock.calls).toEqual([[WORKTREE_ID, RUNTIME_EXECUTION_HOST_ID]])
+    expect(selection.activeWorkspaceExecutionHostId).toBe(RUNTIME_EXECUTION_HOST_ID)
+  })
+
+  it('leaves a selection the user moved during the failed create alone', async () => {
+    const selection: MutableSelection = {
+      activeWorktreeId: WORKTREE_ID,
+      activeWorkspaceExecutionHostId: 'local'
+    }
+    stubSelectableWorkspaceStore(selection)
+    const runtimeCall = vi.fn().mockImplementation(async () => {
+      // The user switched workspaces while the doomed create was in flight.
+      selection.activeWorktreeId = 'repo::/other'
+      selection.activeWorkspaceExecutionHostId = 'local'
+      throw new Error('selector_not_found')
+    })
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    const outcome = await createWebRuntimeSessionTerminal({
+      worktreeId: WORKTREE_ID,
+      environmentId: ENVIRONMENT_ID,
+      activate: true
+    })
+
+    expect(outcome.status).toBe('failed')
+    expect(mocks.setActiveWorktree.mock.calls).toEqual([[WORKTREE_ID, RUNTIME_EXECUTION_HOST_ID]])
+    expect(selection.activeWorktreeId).toBe('repo::/other')
+  })
+
+  it('does not touch the host selection when the caller opted out of selecting', async () => {
+    const selection: MutableSelection = {
+      activeWorktreeId: WORKTREE_ID,
+      activeWorkspaceExecutionHostId: 'local'
+    }
+    stubSelectableWorkspaceStore(selection)
+    const runtimeCall = vi.fn().mockRejectedValue(new Error('selector_not_found'))
+    vi.stubGlobal('window', { api: { runtimeEnvironments: { call: runtimeCall } } })
+
+    await createWebRuntimeSessionTerminal({
+      worktreeId: WORKTREE_ID,
+      environmentId: ENVIRONMENT_ID,
+      selectWorktree: false,
+      activate: true
+    })
+
+    expect(mocks.setActiveWorktree).not.toHaveBeenCalled()
+    expect(selection.activeWorkspaceExecutionHostId).toBe('local')
+  })
+})

--- a/src/renderer/src/runtime/web-runtime-session-workspace-routing.ts
+++ b/src/renderer/src/runtime/web-runtime-session-workspace-routing.ts
@@ -1,0 +1,57 @@
+import type { ExecutionHostId } from '../../../shared/execution-host'
+
+/**
+ * Which runtime environment a web-runtime-session call targets.
+ *
+ * `undefined` means the caller never resolved ownership, so the focused
+ * environment is the only candidate it can have meant. An explicit `null` (or a
+ * blank string) is the opposite claim: the caller DID resolve ownership and
+ * found no runtime environment — a local, SSH-owned, or otherwise
+ * client-executed workspace. Collapsing the two (`args.environmentId?.trim() ??
+ * focused`) silently routed those workspaces to whatever remote happened to be
+ * focused, which is how a local Windows workspace ended up asking an Arch dev
+ * container to open its terminal and got `selector_not_found` (#16444).
+ */
+export function resolveWebRuntimeSessionEnvironmentId(
+  requested: string | null | undefined,
+  focused: string | null | undefined
+): string | null {
+  if (requested === undefined) {
+    return focused?.trim() || null
+  }
+  return requested?.trim() || null
+}
+
+export type WebRuntimeSessionWorkspaceSelection = {
+  worktreeId: string | null
+  executionHostId: ExecutionHostId | null
+}
+
+function selectionsMatch(
+  a: WebRuntimeSessionWorkspaceSelection,
+  b: WebRuntimeSessionWorkspaceSelection
+): boolean {
+  return a.worktreeId === b.worktreeId && a.executionHostId === b.executionHostId
+}
+
+/**
+ * Whether a create that the host never accepted should hand the workspace's
+ * host selection back.
+ *
+ * Selecting the host is a side effect of creating, not evidence that the host
+ * owns the workspace. Leaving the selection behind latches the workspace to a
+ * runtime that just refused it, and every later owner-routed action — the next
+ * Ctrl+T included — follows the latch instead of the real owner (#16444).
+ *
+ * Restores only when nothing else moved the selection since; a user who
+ * navigated during the failed create outranks the rollback.
+ */
+export function shouldRestoreWebRuntimeSessionWorkspaceSelection(args: {
+  previous: WebRuntimeSessionWorkspaceSelection
+  applied: WebRuntimeSessionWorkspaceSelection
+  current: WebRuntimeSessionWorkspaceSelection
+}): boolean {
+  return (
+    selectionsMatch(args.current, args.applied) && !selectionsMatch(args.previous, args.applied)
+  )
+}

--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -75,6 +75,11 @@ import { getRuntimeEnvironmentRevision } from './runtime-environment-revision'
 import { parsePaneKey } from '../../../shared/stable-pane-id'
 import { toRuntimeExecutionHostId } from '../../../shared/execution-host'
 import {
+  resolveWebRuntimeSessionEnvironmentId,
+  shouldRestoreWebRuntimeSessionWorkspaceSelection,
+  type WebRuntimeSessionWorkspaceSelection
+} from './web-runtime-session-workspace-routing'
+import {
   forgetWebSessionTerminalPlacement,
   recordWebSessionTerminalPlacement,
   webTerminalPlacementParentTabId
@@ -272,10 +277,10 @@ export async function createWebRuntimeAgentSessionTerminalWithLaunchDraft(
 async function createWebRuntimeSessionTerminalResult(
   args: CreateWebRuntimeSessionTerminalArgs
 ): Promise<CreatedWebRuntimeSessionTerminal> {
-  const environmentId =
-    args.environmentId?.trim() ??
-    useAppStore.getState().settings?.activeRuntimeEnvironmentId?.trim() ??
-    null
+  const environmentId = resolveWebRuntimeSessionEnvironmentId(
+    args.environmentId,
+    useAppStore.getState().settings?.activeRuntimeEnvironmentId
+  )
   if (!environmentId || !isWebRuntimeSessionActive(environmentId)) {
     return {
       outcome: {
@@ -290,8 +295,17 @@ async function createWebRuntimeSessionTerminalResult(
   const intentOwner = captureWebSessionIntentOwner(environmentId)
   const callEnvironment = captureRuntimeEnvironmentCall(environmentId, intentOwner.pairingRevision)
 
+  let workspaceSelectionRollback: WebRuntimeSessionWorkspaceSelectionRollback | null = null
   if (args.selectWorktree !== false) {
+    const previous = readActiveWorkspaceSelection()
     selectWebRuntimeSessionWorktree(args.worktreeId, environmentId)
+    workspaceSelectionRollback = {
+      previous,
+      applied: {
+        worktreeId: args.worktreeId,
+        executionHostId: toRuntimeExecutionHostId(environmentId)
+      }
+    }
   }
   let hostCreated = false
   let createdTabId: string | undefined
@@ -499,6 +513,9 @@ async function createWebRuntimeSessionTerminalResult(
         worktreeId: args.worktreeId,
         hostTabId: webTerminalPlacementParentTabId(createdTabId)
       })
+    }
+    if (!hostCreated && workspaceSelectionRollback) {
+      restoreActiveWorkspaceSelection(workspaceSelectionRollback)
     }
     // Why: once the host accepted creation, reporting failure invites the user
     // to retry with a new operation ID and can duplicate a fresh agent.
@@ -1001,6 +1018,35 @@ export async function createWebRuntimeSessionBrowserTab(args: {
 
 function selectWebRuntimeSessionWorktree(worktreeId: string, environmentId: string): void {
   useAppStore.getState().setActiveWorktree(worktreeId, toRuntimeExecutionHostId(environmentId))
+}
+
+type WebRuntimeSessionWorkspaceSelectionRollback = {
+  previous: WebRuntimeSessionWorkspaceSelection
+  applied: WebRuntimeSessionWorkspaceSelection
+}
+
+function readActiveWorkspaceSelection(): WebRuntimeSessionWorkspaceSelection {
+  const state = useAppStore.getState()
+  return {
+    worktreeId: state.activeWorktreeId ?? null,
+    executionHostId: state.activeWorkspaceExecutionHostId ?? null
+  }
+}
+
+function restoreActiveWorkspaceSelection(
+  rollback: WebRuntimeSessionWorkspaceSelectionRollback
+): void {
+  if (
+    !shouldRestoreWebRuntimeSessionWorkspaceSelection({
+      ...rollback,
+      current: readActiveWorkspaceSelection()
+    })
+  ) {
+    return
+  }
+  useAppStore
+    .getState()
+    .setActiveWorktree(rollback.previous.worktreeId, rollback.previous.executionHostId ?? undefined)
 }
 
 function selectWebRuntimeSessionBrowserWorktree(worktreeId: string, environmentId: string): void {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​393 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​393 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​107 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​103 |

<!-- /orca-pr-loc -->

Fixes #16444.

## ELI5 of the root cause

Orca asks "who runs this workspace's shell?" before opening a terminal. The answer is either the name of a paired remote Orca host, or **`null` — nobody remote, run it here**.

The function that actually creates the terminal read that answer like this:

```ts
const environmentId =
  args.environmentId?.trim() ??            // null?.trim() === undefined ...
  useAppStore.getState().settings?.activeRuntimeEnvironmentId?.trim() ??  // ... so we land here
  null
```

`null?.trim()` evaluates to `undefined`, so `??` does **not** stop there. A caller that said "nobody remote owns this — run it locally" was treated identically to a caller that never answered at all, and the code silently substituted **whatever remote runtime happened to be focused globally**.

The reporter had a remote Orca server whose default environment is an Arch dev container. So clicking **+ → PowerShell** on a local Windows workspace sent `session.tabs.createTerminal { worktree: "id:<windows-repo>::C:/Users/neil/..." }` to the **Arch container**, which had never heard of that worktree and correctly answered `selector_not_found`. That is also why the reporter saw `arch-dev`'s `lastUsedAt` tick on every failed attempt, and why the problem appeared right after the remote server was set up: before that there was nothing for the fallback to pick.

**Why Ctrl+T worked and + did not.** Both paths compute ownership the same way and both get `null` for a local workspace. The difference is what they do next:

| Path | Guard before calling |
| --- | --- |
| Ctrl+T (`Terminal.tsx` `handleNewTab`) | `if (isWebRuntimeSessionActive(runtimeEnvironmentId))` — `null` is false, so it takes the local path |
| Ctrl+T (`openNewTerminalTabInActiveWorkspace`) | `if (runtimeEnvironmentId) { ... }` — same |
| **+ → \<shell\>** (`useTabGroupCreationCommands.newTerminalWithShell`) | **none** — calls straight through with `null` |
| Ctrl+T while a browser guest has focus (`tab-lifecycle-ipc-bridge`) | **none** — same shape |

Ctrl+T never handed a `null` to the buggy line. The `+` shell rows did, every time.

**Why one failed `+` click then wedged Ctrl+T.** Before issuing the create, the same function does:

```ts
selectWebRuntimeSessionWorktree(args.worktreeId, environmentId)
// → useAppStore.getState().setActiveWorktree(worktreeId, `runtime:${environmentId}`)
```

That runs *outside* the `try`, and the `catch` never undoes it. So the failed click left `activeWorkspaceExecutionHostId = "runtime:arch-dev"` on a local workspace. `resolveActiveWorkspaceRoute` treats the active host selection as authoritative and short-circuits every other ownership strategy, so `getRuntimeEnvironmentIdForWorktree` now answered **`arch-dev`** for that local workspace. The next Ctrl+T's guard therefore passed, took the remote branch, failed the same way — and because `createWebRuntimeSessionTerminalResult` swallows errors into a returned `{ status: 'failed' }` that this caller `void`s, the user saw nothing at all. Switching workspaces and back calls `setActiveWorktree` with the real host, clearing the latch. Exactly the reported sequence.

## What changed

Two things, both in the renderer's web-runtime-session create path.

1. **`resolveWebRuntimeSessionEnvironmentId`** (new, `src/renderer/src/runtime/web-runtime-session-workspace-routing.ts`) distinguishes the two answers that were being collapsed. `undefined` (caller expressed nothing) still falls back to the focused environment; an explicit `null`/blank (caller resolved ownership and found none) resolves to `null` and the create returns "not connected to a remote host" **before touching any shared state**. Its two unguarded callers — the `+` shell rows and the guest-focus Ctrl+T relay — then take their existing local-`createTab` fallback, which is what they always intended.

2. **Selection rollback.** The create now snapshots `{ activeWorktreeId, activeWorkspaceExecutionHostId }` before selecting the runtime host, and hands it back in the `catch` when `hostCreated === false`. `shouldRestoreWebRuntimeSessionWorkspaceSelection` restores only when the live selection is still exactly the one this create applied, so a user who navigated during the failed create outranks the rollback. This is defence in depth: it un-wedges *any* create the host never accepted (offline runtime, timeout, refused selector), not just this one.

Scope: this is the renderer's shared runtime path, so the fix is platform-independent and covers git worktrees, folder workspaces (`folder:<id>` keys route through the same function), and SSH/remote-owned workspaces. No wire format, RPC parameter, stream opcode, or published content changed, so there is nothing for mixed client/host versions to negotiate. The main-process selector grammar in `orca-runtime.ts` is untouched — it was answering correctly; it was being asked by the wrong host.

**Not the same bug** (checked, refuted): the CLI repro `orca terminal create --worktree <bare-name>` failing while `--worktree path:...` succeeds is unrelated. `normalizeWorktreeSelector` passes a bare token through untouched, and `resolveWorktreeSelector`'s bare-selector branch matches on id, path, and branch — never `displayName`, which is only reachable via `name:`. That is the documented selector grammar refusing a name it never accepted bare, on the correct host; it involves no environment misrouting and no shared state. Left alone here.

## User-facing trade-offs

- **A caller that passes `environmentId: null` no longer reaches the focused runtime.** That substitution was the bug, and every in-repo caller derives the value from owner resolution, so this only removes misroutes. The `undefined` fallback is preserved and covered by a test, so callers that genuinely express no ownership are unaffected.
- **A failed create can now move the workspace's host selection back.** Only when the host accepted nothing and only when nothing else moved the selection since. The visible effect is that a workspace stops appearing to belong to a runtime that just refused it.
- **Not addressed here:** a create that fails against a workspace's *genuine* remote owner is still silent (the outcome is `void`ed at four call sites and only reaches `console.warn`). That gap predates this change and is unrelated to the misroute; surfacing it needs its own pass so the agent-launch path does not double-toast. The four sibling functions in this file (`createWebRuntimeSessionBrowserTab`, `activateWebRuntimeSessionWorktree`, `moveWebRuntimeSessionTab`, `callWebRuntimeSessionTabMethod`) share the `??` shape, but every current caller guards ownership before calling them, so none can reach it today; tightening them is a separate, larger caller audit.

## Verification

**Mutation-verified.** Every test was checked by reverting the production change, confirming red, and restoring:

| Mutation | Result |
| --- | --- |
| Restore `args.environmentId?.trim() ?? focused ?? null` | 2 red in `web-runtime-session-terminal-workspace-routing.test.ts` (worktree + folder workspace) |
| Same mutation, caller-level test | 2 red in `useTabGroupCreationCommands.local-shell.test.ts` — and the first fails by **timing out** waiting for a tab that never appears, which is precisely the reported "nothing happens" |
| Delete the `catch` rollback | 1 red (`hands the workspace host selection back...`) |
| Drop the staleness guard in `shouldRestoreWebRuntimeSessionWorkspaceSelection` | 1 red (`leaves a selection the user moved during the failed create alone`) |

All restored to green afterwards.

Nine new tests across two files: explicit-`null` on a git worktree and on a folder workspace, the preserved `undefined` fallback, rollback on host-refused create, no rollback after an accepted create, no rollback when the user navigated, `selectWorktree: false` untouched, plus the two caller-level `+`-menu tests that assert a local shell tab is created and the workspace stays on its own execution host.

```
pnpm lint        exit 0
pnpm typecheck   exit 0
pnpm check:max-lines-ratchet   exit 0  (117 grandfathered, no new bypasses)
```

Vitest, exit codes checked:

- `src/renderer/src/runtime` + `components/tab-group` + `components/tab-bar` + `store/terminals` + `hooks` — 339 files. First run: 2 timeouts. **Baselined against a stashed working tree**: the same selection re-run on `main` also fails (`BrowserTab.test.tsx`, a different file), and a second run *with* the change failed a third, disjoint set. Every one is a 30s timeout, all pass in isolation, and none touch the changed code — this is the suite's known load-dependent flakiness, not this change. A targeted co-run of the new files plus every file that flaked in any run passes 8/8, 26 tests.
- `src/renderer/src/lib` + `src/renderer/src/store` — 755 files, 1 failure: `palette-match-performance.test.ts`, a perf budget that passes in isolation and shares no code with this change.
