### PR TITLE
fix(ai-vault): stop a whole opencode.db failure reading as one skipped transcript

### DIFF
--- a/src/main/ai-vault/session-list-result-validation.test.ts
+++ b/src/main/ai-vault/session-list-result-validation.test.ts
@@ -112,6 +112,39 @@ describe('parseAiVaultListResult', () => {
     })
   })
 
+  // #15036: a `kind` this build has never heard of used to fail the whole issue,
+  // and the fallback re-reported it as an unkinded entry — i.e. a newer host's
+  // whole-source failure came back to an older client as a skipped transcript.
+  it('keeps an issue whose kind this build does not know, as its own kinded row', () => {
+    const parsed = parseAiVaultListResult({
+      sessions: [validSession()],
+      issues: [
+        {
+          agent: 'opencode',
+          kind: 'source-from-a-newer-host',
+          path: '/home/ada/.local/share/opencode/opencode.db',
+          message: 'OpenCode history was skipped.'
+        }
+      ],
+      scannedAt: '2026-07-27T00:00:00.000Z'
+    })
+
+    expect(parsed.issues).toEqual([
+      expect.objectContaining({ kind: 'scope', message: 'OpenCode history was skipped.' })
+    ])
+    expect(parsed.issues.some((issue) => issue.message.includes('invalid'))).toBe(false)
+  })
+
+  it('leaves an unkinded issue unkinded so real skipped transcripts still count', () => {
+    const parsed = parseAiVaultListResult({
+      sessions: [validSession()],
+      issues: [{ agent: 'codex', path: '/bad.jsonl', message: 'Malformed transcript' }],
+      scannedAt: '2026-07-27T00:00:00.000Z'
+    })
+
+    expect(parsed.issues[0]?.kind).toBeUndefined()
+  })
+
   it('rejects a malformed result envelope', () => {
     expect(() => parseAiVaultListResult({ sessions: [] })).toThrow()
   })

--- a/src/main/ai-vault/session-list-result-validation.ts
+++ b/src/main/ai-vault/session-list-result-validation.ts
@@ -80,7 +80,13 @@ const aiVaultSessionSchema = z.object({
 const aiVaultScanIssueSchema = z.object({
   executionHostId: executionHostIdSchema.optional(),
   agent: z.string().min(1),
-  kind: z.enum(['host', 'scope', 'notice']).optional(),
+  // Why (#15036): a `kind` this build has never heard of used to fail the whole
+  // issue, which the fallback re-reported as an *unkinded* "invalid entry" — i.e.
+  // a newer host's source-level failure came back as a skipped transcript. An
+  // unknown kind degrades to 'scope' (its own muted row); absent stays absent.
+  kind: z
+    .union([z.enum(['host', 'scope', 'notice']), z.string().transform(() => 'scope' as const)])
+    .optional(),
   path: z.string(),
   message: z.string()
 })

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-list.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-list.ts
@@ -3,9 +3,12 @@ import {
   buildOpenCodeSqliteCandidatePath,
   splitOpenCodeSqliteCandidate
 } from './session-scanner-opencode-sqlite-paths'
+import {
+  openCodeDatabaseScanIssue,
+  readOpenCodeDatabase
+} from './session-scanner-opencode-sqlite-open'
 import type { SessionFileCandidate } from './session-scanner-types'
-import { errorMessage } from './session-scanner-values'
-import SyncDatabase from '../sqlite/sync-database'
+import type SyncDatabase from '../sqlite/sync-database'
 import { columnExists, tableExists } from '../opencode-usage/schema-helpers'
 
 // Why: the SQLite session-list query + reader lives in its own electron-free
@@ -16,12 +19,6 @@ type SessionRow = {
   id: string
   time_created: number
   time_updated: number
-}
-
-function openReadonlyDatabase(dbPath: string): SyncDatabase {
-  const db = new SyncDatabase(dbPath, { readonly: true, fileMustExist: true })
-  db.pragma('query_only = ON')
-  return db
 }
 
 function canReadOpenCodeSessions(db: SyncDatabase): boolean {
@@ -46,6 +43,15 @@ function buildSessionListQuery(db: SyncDatabase, limited: boolean): string {
           WHERE 1=1 ${parentIdPredicate} ${archivedPredicate}
           ORDER BY CASE WHEN time_updated > 0 THEN time_updated ELSE time_created END DESC
           ${limited ? 'LIMIT ?' : ''}`
+}
+
+function readSessionRows(db: SyncDatabase, limit: number): SessionRow[] {
+  if (!canReadOpenCodeSessions(db)) {
+    return []
+  }
+  const limited = Number.isFinite(limit)
+  const statement = db.prepare(buildSessionListQuery(db, limited))
+  return (limited ? statement.all(limit) : statement.all()) as SessionRow[]
 }
 
 function rowToCandidate(row: SessionRow, dbPath: string): SessionFileCandidate {
@@ -99,26 +105,17 @@ export async function listOpenCodeSqliteSessions(args: {
 }): Promise<SessionFileCandidate[]> {
   const candidates: SessionFileCandidate[] = []
   for (const dbPath of args.dbPaths) {
-    let db: SyncDatabase | null = null
     try {
-      db = openReadonlyDatabase(dbPath)
-      if (!canReadOpenCodeSessions(db)) {
-        continue
-      }
-      const limited = Number.isFinite(args.limit)
-      const statement = db.prepare(buildSessionListQuery(db, limited))
-      const rows = (limited ? statement.all(args.limit) : statement.all()) as SessionRow[]
+      const rows = readOpenCodeDatabase({
+        dbPath,
+        read: (db) => readSessionRows(db, args.limit)
+      })
       for (const row of rows) {
         candidates.push(rowToCandidate(row, dbPath))
       }
     } catch (err) {
-      args.issues.push({
-        agent: 'opencode',
-        path: dbPath,
-        message: errorMessage(err)
-      })
-    } finally {
-      db?.close()
+      // A whole DB failed, not one transcript: kinded so the panel says so.
+      args.issues.push(openCodeDatabaseScanIssue(dbPath, err))
     }
   }
   return dedupeAndSortSqliteCandidates(candidates)

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-open.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-open.test.ts
@@ -7,6 +7,7 @@ import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
 import Database from '../sqlite/sync-database'
 import { listOpenCodeSqliteSessions } from './session-scanner-opencode-sqlite-list'
 import {
+  openCodeBusyTimeoutMs,
   openCodeDatabaseScanIssue,
   readOpenCodeDatabase
 } from './session-scanner-opencode-sqlite-open'
@@ -159,6 +160,23 @@ describe('readOpenCodeDatabase', () => {
       })
     ).toThrow('read blew up')
     expect(() => captured!.prepare('SELECT 1')).toThrow(/not open/i)
+  })
+})
+
+describe('openCodeBusyTimeoutMs', () => {
+  // Measured on a real Windows host against a real distro: a read over
+  // \\wsl.localhost fails whatever the timeout, and the wait is not bounded by
+  // it -- 1500 took ~2400 ms, 5000 took ~7250 ms, 0 failed in ~21 ms. Waiting
+  // there is dead time on every scan, and enough such databases would spend the
+  // list worker's whole deadline.
+  it('does not wait on a share where the wait provably cannot succeed', () => {
+    expect(openCodeBusyTimeoutMs('\\\\wsl.localhost\\Ubuntu\\home\\ada\\opencode.db')).toBe(0)
+    expect(openCodeBusyTimeoutMs('\\\\wsl$\\Ubuntu\\home\\ada\\opencode.db')).toBe(0)
+  })
+
+  it('still waits on a path where a writer really can be holding the lock', () => {
+    expect(openCodeBusyTimeoutMs('C:\\Users\\ada\\opencode.db')).toBe(1_500)
+    expect(openCodeBusyTimeoutMs('/home/ada/.local/share/opencode/opencode.db')).toBe(1_500)
   })
 })
 

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-open.test.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-open.test.ts
@@ -1,0 +1,220 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Worker } from 'node:worker_threads'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
+import Database from '../sqlite/sync-database'
+import { listOpenCodeSqliteSessions } from './session-scanner-opencode-sqlite-list'
+import {
+  openCodeDatabaseScanIssue,
+  readOpenCodeDatabase
+} from './session-scanner-opencode-sqlite-open'
+
+// Reproduces #15036: OpenCode holds opencode.db open while it runs, so a scan
+// lands mid-write. The reader had no busy timeout, failed in ~1 ms with the bare
+// driver string "database is locked", and one failed DB emptied both scopes.
+
+let tempDirs: string[] = []
+let lockHolders: Worker[] = []
+
+afterEach(async () => {
+  await Promise.all(lockHolders.splice(0).map((worker) => worker.terminate()))
+  lockHolders = []
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+  tempDirs = []
+})
+
+const SCHEMA = `
+  CREATE TABLE session (
+    id TEXT PRIMARY KEY,
+    parent_id TEXT,
+    time_created INTEGER NOT NULL,
+    time_updated INTEGER NOT NULL
+  )
+`
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-opencode-open-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+function seededDatabase(name: string, sessionId: string): string {
+  const path = join(tempDir(), name)
+  const db = new Database(path)
+  db.exec('PRAGMA journal_mode=DELETE')
+  db.exec(SCHEMA)
+  db.prepare('INSERT INTO session (id, time_created, time_updated) VALUES (?, ?, ?)').run(
+    sessionId,
+    1_700_000_000_000,
+    1_700_000_001_000
+  )
+  db.close()
+  return path
+}
+
+// The lock holder must live on another thread: sqlite3_busy_timeout sleeps
+// synchronously, so a same-thread timer could never fire to release it.
+const LOCK_HOLDER_SOURCE = `
+  const { parentPort, workerData } = require('node:worker_threads')
+  const { DatabaseSync } = require('node:sqlite')
+  const db = new DatabaseSync(workerData.path)
+  db.exec('BEGIN EXCLUSIVE')
+  db.exec("INSERT INTO session (id, time_created, time_updated) VALUES ('locked-write', 1, 1)")
+  parentPort.postMessage('locked')
+  setTimeout(() => {
+    db.exec('ROLLBACK')
+    db.close()
+    parentPort.postMessage('released')
+  }, workerData.holdMs)
+`
+
+async function holdWriteLock(path: string, holdMs: number): Promise<void> {
+  const worker = new Worker(LOCK_HOLDER_SOURCE, { eval: true, workerData: { path, holdMs } })
+  lockHolders.push(worker)
+  await new Promise<void>((resolve, reject) => {
+    worker.once('message', () => resolve())
+    worker.once('error', reject)
+  })
+}
+
+describe('listOpenCodeSqliteSessions against a database OpenCode is writing to', () => {
+  it('reports the failure as a whole source, not as a skipped transcript', async () => {
+    const path = seededDatabase('opencode.db', 'session-a')
+    await holdWriteLock(path, 60_000)
+    const issues: AiVaultScanIssue[] = []
+
+    const candidates = await listOpenCodeSqliteSessions({ dbPaths: [path], limit: 10, issues })
+
+    expect(candidates).toEqual([])
+    expect(issues).toHaveLength(1)
+    // The panel counts only unkinded issues as skipped transcripts.
+    expect(issues[0]?.kind).toBe('scope')
+    expect(issues[0]?.message).toContain('OpenCode is writing to opencode.db')
+    expect(issues[0]?.message).not.toBe('database is locked')
+  })
+
+  it('still returns sessions from every other database', async () => {
+    const contended = seededDatabase('opencode.db', 'session-a')
+    const healthy = seededDatabase('opencode-alt.db', 'session-b')
+    await holdWriteLock(contended, 60_000)
+    const issues: AiVaultScanIssue[] = []
+
+    const candidates = await listOpenCodeSqliteSessions({
+      dbPaths: [contended, healthy],
+      limit: 10,
+      issues
+    })
+
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0]?.file.path).toContain('session-b')
+    expect(issues).toHaveLength(1)
+  })
+
+  it('reads the sessions once the write finishes inside the busy timeout', async () => {
+    const path = seededDatabase('opencode.db', 'session-a')
+    // Long enough that only a real busy timeout — not a lucky fast open — survives it.
+    await holdWriteLock(path, 900)
+    const issues: AiVaultScanIssue[] = []
+
+    const candidates = await listOpenCodeSqliteSessions({ dbPaths: [path], limit: 10, issues })
+
+    expect(issues).toEqual([])
+    expect(candidates).toHaveLength(1)
+    expect(candidates[0]?.file.path).toContain('session-a')
+  })
+})
+
+describe('readOpenCodeDatabase', () => {
+  it('closes the handle on the success path', () => {
+    const path = seededDatabase('opencode.db', 'session-a')
+    let captured: Database.Database | null = null
+
+    const rows = readOpenCodeDatabase({
+      dbPath: path,
+      read: (db) => {
+        captured = db
+        return db.prepare('SELECT id FROM session').all()
+      }
+    })
+
+    expect(rows).toEqual([{ id: 'session-a' }])
+    expect(() => captured!.prepare('SELECT 1')).toThrow(/not open/i)
+  })
+
+  it('closes the handle when the read throws', () => {
+    const path = seededDatabase('opencode.db', 'session-a')
+    let captured: Database.Database | null = null
+
+    expect(() =>
+      readOpenCodeDatabase({
+        dbPath: path,
+        read: (db) => {
+          captured = db
+          throw new Error('read blew up')
+        }
+      })
+    ).toThrow('read blew up')
+    expect(() => captured!.prepare('SELECT 1')).toThrow(/not open/i)
+  })
+})
+
+describe('openCodeDatabaseScanIssue', () => {
+  const cantOpen = Object.assign(new Error('unable to open database file'), { errcode: 14 })
+
+  it('names the wal-index over a WSL share rather than repeating the driver string', () => {
+    const issue = openCodeDatabaseScanIssue(
+      '\\\\wsl.localhost\\Ubuntu\\home\\ada\\.local\\share\\opencode\\opencode.db',
+      cantOpen
+    )
+
+    expect(issue.kind).toBe('scope')
+    expect(issue.message).toContain('\\\\wsl.localhost')
+    // Checkpointing cannot fix a share that refuses SQLite's locks, so the copy
+    // must not send the user after the write-ahead log.
+    expect(issue.message).not.toContain('write-ahead log')
+  })
+
+  it('keeps the advice generic for a non-WSL path', () => {
+    const issue = openCodeDatabaseScanIssue('/home/ada/.local/share/opencode/opencode.db', cantOpen)
+
+    expect(issue.message).not.toContain('wsl.localhost')
+    expect(issue.message).toContain('write-ahead log')
+  })
+
+  // Measured against a real Ubuntu-24.04 distro: Windows cannot take SQLite's
+  // locks over \\wsl.localhost at all. An idle, never-WAL database answers
+  // SQLITE_BUSY the same way, while the identical bytes read fine once copied
+  // to local disk — so no busy timeout and no journal mode changes the outcome.
+  it('does not blame a live writer for a lock-family error over a WSL share', () => {
+    const busy = Object.assign(new Error('database is locked'), { errcode: 5 })
+    const issue = openCodeDatabaseScanIssue(
+      '\\\\wsl.localhost\\Ubuntu\\home\\ada\\.local\\share\\opencode\\opencode.db',
+      busy
+    )
+
+    expect(issue.message).not.toContain('is writing to')
+    expect(issue.message).toContain('inside the distro')
+  })
+
+  it('still blames a live writer for the same error on a local path', () => {
+    const busy = Object.assign(new Error('database is locked'), { errcode: 5 })
+    const issue = openCodeDatabaseScanIssue('/home/ada/.local/share/opencode/opencode.db', busy)
+
+    expect(issue.message).toContain('is writing to')
+  })
+
+  it('reports anything else with its underlying cause', () => {
+    const issue = openCodeDatabaseScanIssue(
+      '/home/ada/.local/share/opencode/opencode.db',
+      Object.assign(new Error('database disk image is malformed'), { errcode: 11 })
+    )
+
+    expect(issue.kind).toBe('scope')
+    expect(issue.message).not.toContain('write-ahead log')
+    expect(issue.message).toContain('database disk image is malformed')
+  })
+})

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-open.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-open.ts
@@ -1,0 +1,89 @@
+import { basename } from 'node:path'
+import type { AiVaultScanIssue } from '../../shared/ai-vault-types'
+import { isWslUncPath } from '../../shared/wsl-paths'
+import SyncDatabase from '../sqlite/sync-database'
+import { classifySqliteReadFailure } from '../sqlite/sqlite-read-failure'
+import { errorMessage } from './session-scanner-values'
+
+// Why (#15036): the read used to inherit sqlite3's 0 ms busy timeout, so a
+// genuinely contended open failed in ~1 ms. WAL readers almost never block on a
+// writer, so this is insurance rather than the fix -- it stays a single bounded
+// open, with no retry loop on top of sqlite's own busy handler.
+const OPENCODE_SQLITE_BUSY_TIMEOUT_MS = 1_500
+
+/**
+ * Open one OpenCode database for reading.
+ *
+ * Read-only, plus `query_only` as a belt-and-suspenders guard so a bug in a
+ * SELECT list can never mutate the user's opencode.db.
+ * @param dbPath - Absolute path to an opencode.db file.
+ * @returns An open handle the caller must close.
+ */
+function openOpenCodeDatabaseReadonly(dbPath: string): SyncDatabase {
+  const db = new SyncDatabase(dbPath, {
+    readonly: true,
+    fileMustExist: true,
+    timeout: OPENCODE_SQLITE_BUSY_TIMEOUT_MS
+  })
+  db.pragma('query_only = ON')
+  return db
+}
+
+/**
+ * Run one synchronous read against an OpenCode database.
+ * @param args.dbPath - Absolute path to an opencode.db file.
+ * @param args.read - Synchronous reader; its result must be fully materialized.
+ * @returns The reader's value; rethrows whatever SQLite raised.
+ */
+export function readOpenCodeDatabase<T>(args: {
+  dbPath: string
+  read: (db: SyncDatabase) => T
+}): T {
+  const db = openOpenCodeDatabaseReadonly(args.dbPath)
+  try {
+    return args.read(db)
+  } finally {
+    db.close()
+  }
+}
+
+/**
+ * Describe a whole-database read failure as a scan issue.
+ *
+ * Kinded so the panel renders this copy instead of counting a failed *source*
+ * as a skipped *transcript*; `scope` rather than a new member — see
+ * `aiVaultScanIssueSchema` in session-list-result-validation.ts.
+ * @param dbPath - Absolute path to the opencode.db that could not be read.
+ * @param error - The thrown value from the read.
+ * @returns A kinded scan issue with actionable copy.
+ */
+export function openCodeDatabaseScanIssue(dbPath: string, error: unknown): AiVaultScanIssue {
+  const name = basename(dbPath)
+  // `fileMustExist` already proved the database file is there before SQLite ran,
+  // so this needs no fs probe of its own — an extra sync stat on a 9p share is
+  // exactly the hang the WSL transcript gate exists to prevent.
+  const kind = classifySqliteReadFailure({ error, databaseFileExists: true })
+  // Why: measured against a real distro. Windows cannot take SQLite's file locks
+  // over \\wsl.localhost at all — an idle, never-WAL, nothing-attached database
+  // answers SQLITE_BUSY just the same, and a 5 s busy timeout does not change it,
+  // while the identical bytes copied to local disk open fine. So on this share a
+  // lock-family error never means "a writer holds it", and no timeout can help.
+  const overWslShare = isWslUncPath(dbPath)
+  const detail =
+    kind === 'contended' && !overWslShare
+      ? `OpenCode is writing to ${name} right now, so its history was skipped. It is read again on the next refresh.`
+      : kind === 'unreadable'
+        ? `OpenCode history in ${name} could not be read: ${errorMessage(error)}`
+        : `OpenCode history in ${name} could not be read. ${unreadableShareAdvice(dbPath)}`
+  return { agent: 'opencode', kind: 'scope', path: dbPath, message: detail }
+}
+
+function unreadableShareAdvice(dbPath: string): string {
+  // Named only when the evidence supports it; a generic share gets generic copy.
+  // Deliberately not "flush the write-ahead log": checkpointing changes nothing
+  // here, and telling the user to try it would send them after a fix that cannot
+  // work. The share itself is the blocker.
+  return isWslUncPath(dbPath)
+    ? 'Windows cannot open SQLite databases over the \\\\wsl.localhost share, so this history has to be read from inside the distro.'
+    : 'Its write-ahead log cannot be opened read-only on this filesystem. Exit OpenCode cleanly to flush the log.'
+}

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-open.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-open.ts
@@ -19,11 +19,27 @@ const OPENCODE_SQLITE_BUSY_TIMEOUT_MS = 1_500
  * @param dbPath - Absolute path to an opencode.db file.
  * @returns An open handle the caller must close.
  */
+/**
+ * Busy timeout for one database.
+ *
+ * Zero over the WSL share because waiting there is provably useless: Windows
+ * cannot take SQLite's locks over \\wsl.localhost at all, so the open fails
+ * whatever the timeout. Measured on a real host, the wait is not even bounded
+ * by the value — timeout 1500 took ~2400 ms and timeout 5000 took ~7250 ms,
+ * while 0 failed in ~21 ms. Paying that per database, per scan, buys nothing
+ * and enough such databases would spend the list worker's whole 30 s deadline.
+ * @param dbPath - Absolute path to an opencode.db file.
+ * @returns Milliseconds to let SQLite's busy handler wait.
+ */
+export function openCodeBusyTimeoutMs(dbPath: string): number {
+  return isWslUncPath(dbPath) ? 0 : OPENCODE_SQLITE_BUSY_TIMEOUT_MS
+}
+
 function openOpenCodeDatabaseReadonly(dbPath: string): SyncDatabase {
   const db = new SyncDatabase(dbPath, {
     readonly: true,
     fileMustExist: true,
-    timeout: OPENCODE_SQLITE_BUSY_TIMEOUT_MS
+    timeout: openCodeBusyTimeoutMs(dbPath)
   })
   db.pragma('query_only = ON')
   return db

--- a/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite-worker-client.ts
@@ -94,8 +94,10 @@ export class OpenCodeSqliteWorkerClient {
       return value.candidates
     } catch (err) {
       if (err instanceof OpenCodeSqliteWorkerUnavailableError) {
+        // Kinded: a whole source failed, not a transcript.
         args.issues.push({
           agent: 'opencode',
+          kind: 'scope',
           path: args.dbPaths[0] ?? 'opencode.db',
           message:
             'OpenCode history was skipped because its background scanner could not start; the app remains responsive.'
@@ -106,6 +108,7 @@ export class OpenCodeSqliteWorkerClient {
       // scan, surfaced as one scan issue rather than an unbounded stall.
       args.issues.push({
         agent: 'opencode',
+        kind: 'scope',
         path: args.dbPaths[0] ?? 'opencode.db',
         message: `OpenCode history scan did not complete: ${errorMessage(err)}`
       })

--- a/src/main/ai-vault/session-scanner-opencode-sqlite.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite.ts
@@ -9,8 +9,9 @@ import {
   normalizeFullFirstUserPromptText,
   shouldCaptureFullFirstUserPrompt
 } from './session-scanner-first-user-prompt'
+import { readOpenCodeDatabase } from './session-scanner-opencode-sqlite-open'
 import { normalizeTitleText } from './session-scanner-values'
-import SyncDatabase from '../sqlite/sync-database'
+import type SyncDatabase from '../sqlite/sync-database'
 import { columnExists, tableExists } from '../opencode-usage/schema-helpers'
 
 // Why: OpenCode 1.17.x migrated session storage from per-session JSON files
@@ -51,14 +52,6 @@ type PreviewRow = {
   time_created: number
   summary_title: string | null
   summary_body: string | null
-}
-
-function openReadonlyDatabase(dbPath: string): SyncDatabase {
-  const db = new SyncDatabase(dbPath, { readonly: true, fileMustExist: true })
-  // Why: belt-and-suspenders guard so a bug in the SELECT list can never
-  // mutate the user's opencode.db.
-  db.pragma('query_only = ON')
-  return db
 }
 
 function canReadOpenCodeSessions(db: SyncDatabase): boolean {
@@ -256,90 +249,97 @@ export async function parseOpenCodeSqliteSession(args: {
   sessionId: string
   platform: NodeJS.Platform
 }): Promise<AiVaultSession | null> {
-  const { dbPath, sessionId, platform } = args
-  let db: SyncDatabase | null = null
-  try {
-    db = openReadonlyDatabase(dbPath)
-    if (!canReadOpenCodeSessions(db)) {
-      return null
-    }
-    const row = db.prepare(buildSessionQuery(db)).get(sessionId) as SessionRow | undefined
-    if (!row || row.id !== sessionId) {
-      return null
-    }
+  return readOpenCodeDatabase({
+    dbPath: args.dbPath,
+    read: (db) => readSession({ db, ...args })
+  })
+}
 
-    const mtimeMs =
-      typeof row.time_updated === 'number' && row.time_updated > 0
-        ? row.time_updated
-        : row.time_created
-    // Why: discovery uses a synthetic db#session path only for parser routing.
-    // The UI's log open/reveal actions need a real filesystem path.
-    const accumulator = createAccumulator({
-      agent: 'opencode',
-      file: {
-        path: dbPath,
-        mtimeMs,
-        modifiedAt: new Date(mtimeMs).toISOString()
-      },
-      sessionId
-    })
-    accumulator.title = normalizeTitleText(row.title ?? '')
-    accumulator.cwd = row.directory
-    accumulator.model = extractModelId(row.model_json)
-    accumulator.totalTokens =
-      (row.tokens_input ?? 0) + (row.tokens_output ?? 0) + (row.tokens_reasoning ?? 0)
-    accumulator.messageCount = row.message_count ?? 0
-    updateTimeline(accumulator, row.time_created)
-    updateTimeline(accumulator, row.time_updated)
-
-    const previewSql = buildPreviewQuery(db)
-    if (previewSql) {
-      // Why: SQL already dropped anything older than the newest-N window, so the
-      // accumulator never shifts and cannot detect the truncation itself. Ask for
-      // one extra row so an exactly-full window is not mistaken for a trimmed one.
-      const probedRows = db
-        .prepare(previewSql)
-        .all(sessionId, OPENCODE_SQLITE_PREVIEW_LIMIT + 1) as PreviewRow[]
-      if (probedRows.length > OPENCODE_SQLITE_PREVIEW_LIMIT) {
-        accumulator.previewMessagesTruncated = true
-      }
-      // Newest-first, so the probe row to drop is the oldest one at the tail.
-      const previewRows = probedRows.slice(0, OPENCODE_SQLITE_PREVIEW_LIMIT)
-      // Why: query returns newest-first; push in chronological order so the
-      // accumulator's ring buffer keeps the newest OPENCODE_SQLITE_PREVIEW_LIMIT
-      // messages.
-      for (let i = previewRows.length - 1; i >= 0; i--) {
-        const previewRow = previewRows[i]
-        if (!previewRow) {
-          continue
-        }
-        const text = extractPartText(previewRow.part_data)
-        if (!text) {
-          continue
-        }
-        addPreviewMessage(accumulator, {
-          role: mapPreviewRole(previewRow.role),
-          text,
-          timestamp: previewRow.time_created,
-          // Preview window is newest-N; first-prompt is loaded separately below.
-          seedFirstUserPrompt: false
-        })
-        if (previewRow.role === 'user' && !accumulator.title) {
-          accumulator.title =
-            normalizeTitleText(previewRow.summary_title ?? '') ||
-            normalizeTitleText(previewRow.summary_body ?? '')
-        }
-      }
-    }
-
-    // Why: list preview only joins the newest messages. On-demand copy needs the
-    // session's earliest real user text part, not a later turn still in the window.
-    if (shouldCaptureFullFirstUserPrompt()) {
-      accumulator.firstUserPrompt = readFirstUserPromptFromOpenCodeDb(db, sessionId)
-    }
-
-    return finalizeSession(accumulator, platform)
-  } finally {
-    db?.close()
+// Extracted so the bounded busy-timeout open/retry wrapper owns the handle.
+function readSession(args: {
+  db: SyncDatabase
+  dbPath: string
+  sessionId: string
+  platform: NodeJS.Platform
+}): AiVaultSession | null {
+  const { db, dbPath, sessionId, platform } = args
+  if (!canReadOpenCodeSessions(db)) {
+    return null
   }
+  const row = db.prepare(buildSessionQuery(db)).get(sessionId) as SessionRow | undefined
+  if (!row || row.id !== sessionId) {
+    return null
+  }
+
+  const mtimeMs =
+    typeof row.time_updated === 'number' && row.time_updated > 0
+      ? row.time_updated
+      : row.time_created
+  // Why: discovery uses a synthetic db#session path only for parser routing.
+  // The UI's log open/reveal actions need a real filesystem path.
+  const accumulator = createAccumulator({
+    agent: 'opencode',
+    file: {
+      path: dbPath,
+      mtimeMs,
+      modifiedAt: new Date(mtimeMs).toISOString()
+    },
+    sessionId
+  })
+  accumulator.title = normalizeTitleText(row.title ?? '')
+  accumulator.cwd = row.directory
+  accumulator.model = extractModelId(row.model_json)
+  accumulator.totalTokens =
+    (row.tokens_input ?? 0) + (row.tokens_output ?? 0) + (row.tokens_reasoning ?? 0)
+  accumulator.messageCount = row.message_count ?? 0
+  updateTimeline(accumulator, row.time_created)
+  updateTimeline(accumulator, row.time_updated)
+
+  const previewSql = buildPreviewQuery(db)
+  if (previewSql) {
+    // Why: SQL already dropped anything older than the newest-N window, so the
+    // accumulator never shifts and cannot detect the truncation itself. Ask for
+    // one extra row so an exactly-full window is not mistaken for a trimmed one.
+    const probedRows = db
+      .prepare(previewSql)
+      .all(sessionId, OPENCODE_SQLITE_PREVIEW_LIMIT + 1) as PreviewRow[]
+    if (probedRows.length > OPENCODE_SQLITE_PREVIEW_LIMIT) {
+      accumulator.previewMessagesTruncated = true
+    }
+    // Newest-first, so the probe row to drop is the oldest one at the tail.
+    const previewRows = probedRows.slice(0, OPENCODE_SQLITE_PREVIEW_LIMIT)
+    // Why: query returns newest-first; push in chronological order so the
+    // accumulator's ring buffer keeps the newest OPENCODE_SQLITE_PREVIEW_LIMIT
+    // messages.
+    for (let i = previewRows.length - 1; i >= 0; i--) {
+      const previewRow = previewRows[i]
+      if (!previewRow) {
+        continue
+      }
+      const text = extractPartText(previewRow.part_data)
+      if (!text) {
+        continue
+      }
+      addPreviewMessage(accumulator, {
+        role: mapPreviewRole(previewRow.role),
+        text,
+        timestamp: previewRow.time_created,
+        // Preview window is newest-N; first-prompt is loaded separately below.
+        seedFirstUserPrompt: false
+      })
+      if (previewRow.role === 'user' && !accumulator.title) {
+        accumulator.title =
+          normalizeTitleText(previewRow.summary_title ?? '') ||
+          normalizeTitleText(previewRow.summary_body ?? '')
+      }
+    }
+  }
+
+  // Why: list preview only joins the newest messages. On-demand copy needs the
+  // session's earliest real user text part, not a later turn still in the window.
+  if (shouldCaptureFullFirstUserPrompt()) {
+    accumulator.firstUserPrompt = readFirstUserPromptFromOpenCodeDb(db, sessionId)
+  }
+
+  return finalizeSession(accumulator, platform)
 }

--- a/src/main/ai-vault/session-scanner-opencode-sqlite.ts
+++ b/src/main/ai-vault/session-scanner-opencode-sqlite.ts
@@ -255,7 +255,7 @@ export async function parseOpenCodeSqliteSession(args: {
   })
 }
 
-// Extracted so the bounded busy-timeout open/retry wrapper owns the handle.
+// Extracted so the open wrapper owns the handle's lifetime.
 function readSession(args: {
   db: SyncDatabase
   dbPath: string

--- a/src/main/codex/codex-session-index-heal.ts
+++ b/src/main/codex/codex-session-index-heal.ts
@@ -1,5 +1,6 @@
 import { dirname, join } from 'node:path'
 import { resolveCodexCommand } from '../codex-cli/command'
+import { isTransientSqliteContention } from '../sqlite/sqlite-read-failure'
 import { getSpawnArgsForWindows } from '../win32-utils'
 import { getCodexSessionBackfillStateDirPath } from './codex-home-paths'
 import { resolveCodexSessionBackfillPaths } from './codex-session-backfill'
@@ -231,7 +232,7 @@ async function healOneThread(
       recordHealOutcome(paths, thread, 'missing')
       return
     }
-    if (/SQLITE_(?:BUSY|LOCKED)|database (?:is )?(?:busy|locked)/i.test(message)) {
+    if (isTransientSqliteContention(message)) {
       // Why: an active Codex process can briefly own sqlite; leave the id off
       // the ledger and abort this pass so a later startup resumes it.
       throw error

--- a/src/main/sqlite/sqlite-read-failure.test.ts
+++ b/src/main/sqlite/sqlite-read-failure.test.ts
@@ -1,0 +1,113 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import SyncDatabase from './sync-database'
+import { classifySqliteReadFailure, isTransientSqliteContention } from './sqlite-read-failure'
+
+// Error codes here are the ones a real node:sqlite open produces: a contended
+// database reports errcode 5 ("database is locked"), while a read-only WAL open
+// with no usable -shm reports errcode 14 ("unable to open database file"). The
+// two need opposite responses, so the classifier must never conflate them.
+
+let tempDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+  tempDirs = []
+})
+
+function contendedDatabase(): { path: string; release: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-sqlite-failure-'))
+  tempDirs.push(dir)
+  const path = join(dir, 'contended.db')
+  const writer = new SyncDatabase(path)
+  writer.exec('PRAGMA journal_mode=DELETE')
+  writer.exec('CREATE TABLE session (id TEXT PRIMARY KEY)')
+  writer.exec('BEGIN EXCLUSIVE')
+  writer.exec("INSERT INTO session VALUES ('a')")
+  return {
+    path,
+    release: () => {
+      writer.exec('COMMIT')
+      writer.close()
+    }
+  }
+}
+
+describe('isTransientSqliteContention', () => {
+  it('recognizes a real SQLITE_BUSY thrown by a read-only open', () => {
+    const contended = contendedDatabase()
+    let thrown: unknown
+    try {
+      new SyncDatabase(contended.path, { readonly: true, timeout: 0 })
+        .prepare('SELECT id FROM session')
+        .all()
+    } catch (error) {
+      thrown = error
+    } finally {
+      contended.release()
+    }
+
+    expect((thrown as { errcode?: number }).errcode).toBe(5)
+    expect(isTransientSqliteContention(thrown)).toBe(true)
+  })
+
+  it('recognizes a relayed message with no errcode, as the Codex heal pass sees it', () => {
+    expect(
+      isTransientSqliteContention('codex app-server thread/read failed: database is locked')
+    ).toBe(true)
+    expect(isTransientSqliteContention(new Error('SQLITE_LOCKED: table is locked'))).toBe(true)
+  })
+
+  it('reads extended result codes through their primary code', () => {
+    // SQLITE_BUSY_SNAPSHOT (517) and SQLITE_BUSY_RECOVERY (261) both pack 5.
+    expect(isTransientSqliteContention({ errcode: 517, message: 'busy snapshot' })).toBe(true)
+    expect(isTransientSqliteContention({ errcode: 261, message: 'recovery' })).toBe(true)
+  })
+
+  it('does not treat an unreadable or absent database as contention', () => {
+    expect(isTransientSqliteContention(new Error('file is not a database'))).toBe(false)
+    expect(
+      isTransientSqliteContention({ errcode: 14, message: 'unable to open database file' })
+    ).toBe(false)
+  })
+})
+
+describe('classifySqliteReadFailure', () => {
+  it('classifies contention as retryable regardless of the file evidence', () => {
+    const error = { errcode: 5, message: 'database is locked' }
+
+    expect(classifySqliteReadFailure({ error, databaseFileExists: true })).toBe('contended')
+    expect(classifySqliteReadFailure({ error, databaseFileExists: false })).toBe('contended')
+  })
+
+  it('classifies SQLITE_CANTOPEN against a present database as an unreachable wal-index', () => {
+    expect(
+      classifySqliteReadFailure({
+        error: { errcode: 14, message: 'unable to open database file' },
+        databaseFileExists: true
+      })
+    ).toBe('wal-index-unavailable')
+  })
+
+  it('does not blame the wal-index when the database file itself is gone', () => {
+    expect(
+      classifySqliteReadFailure({
+        error: { errcode: 14, message: 'unable to open database file' },
+        databaseFileExists: false
+      })
+    ).toBe('unreadable')
+  })
+
+  it('falls back to unreadable for anything else', () => {
+    expect(
+      classifySqliteReadFailure({
+        error: { errcode: 11, message: 'database disk image is malformed' },
+        databaseFileExists: true
+      })
+    ).toBe('unreadable')
+  })
+})

--- a/src/main/sqlite/sqlite-read-failure.ts
+++ b/src/main/sqlite/sqlite-read-failure.ts
@@ -1,0 +1,77 @@
+// Why (#15036): a read-only SQLite open can fail for reasons that demand
+// opposite responses, and both arrive as an opaque driver string. Contention is
+// transient — retry later, never persist it as a permanent failure. A missing
+// wal-index is structural — retrying forever cannot fix it.
+
+/** Primary result codes; extended codes pack the primary code in the low byte. */
+const SQLITE_BUSY = 5
+const SQLITE_LOCKED = 6
+const SQLITE_CANTOPEN = 14
+
+// Shared with the Codex index-heal pass, which only ever sees a relayed message
+// string (app-server RPC drops `errcode`), so message matching is not optional.
+const CONTENTION_MESSAGE = /SQLITE_(?:BUSY|LOCKED)|database (?:is )?(?:busy|locked)/i
+
+function primaryErrcode(error: unknown): number | null {
+  if (!error || typeof error !== 'object' || !('errcode' in error)) {
+    return null
+  }
+  const errcode = (error as { errcode?: unknown }).errcode
+  return typeof errcode === 'number' && Number.isFinite(errcode) ? errcode & 0xff : null
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+/**
+ * True when a SQLite failure means "someone else holds the database right now".
+ * @param error - The thrown value from a `node:sqlite` call or a relayed message.
+ * @returns Whether the caller should retry later rather than record a failure.
+ */
+export function isTransientSqliteContention(error: unknown): boolean {
+  const errcode = primaryErrcode(error)
+  if (errcode === SQLITE_BUSY || errcode === SQLITE_LOCKED) {
+    return true
+  }
+  return CONTENTION_MESSAGE.test(errorText(error))
+}
+
+export type SqliteReadFailureKind =
+  /** Another connection holds the lock; the same read can succeed later. */
+  | 'contended'
+  /**
+   * The database file itself is present, but SQLite still could not open the
+   * set of files it needs — in practice the `-wal`/`-shm` pair a read-only WAL
+   * open requires, which shares that cannot host SQLite shared memory (9p
+   * `\\wsl.localhost`, SMB, SSHFS) refuse. Retrying cannot fix it.
+   */
+  | 'wal-index-unavailable'
+  /** Anything else: corrupt file, wrong schema, permissions. */
+  | 'unreadable'
+
+/**
+ * Classify why a read-only SQLite open or query failed.
+ *
+ * Pure: the caller supplies the "does the database file exist" evidence, so
+ * neither branch needs a filesystem probe of its own. That matters on a WSL 9p
+ * share, where an extra sync stat is exactly the hang the transcript gate exists
+ * to prevent.
+ * @param args.error - The thrown value.
+ * @param args.databaseFileExists - Whether the main database file was present.
+ * @returns Which of the three failure modes the error represents.
+ */
+export function classifySqliteReadFailure(args: {
+  error: unknown
+  databaseFileExists: boolean
+}): SqliteReadFailureKind {
+  if (isTransientSqliteContention(args.error)) {
+    return 'contended'
+  }
+  // SQLITE_CANTOPEN against a database that is right there names a companion
+  // file — the wal-index a read-only WAL open needs — not the database itself.
+  if (primaryErrcode(args.error) === SQLITE_CANTOPEN && args.databaseFileExists) {
+    return 'wal-index-unavailable'
+  }
+  return 'unreadable'
+}

--- a/src/main/sqlite/sync-database.test.ts
+++ b/src/main/sqlite/sync-database.test.ts
@@ -1,11 +1,13 @@
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { Worker } from 'node:worker_threads'
 import { afterEach, describe, expect, it } from 'vitest'
 import SyncDatabase from './sync-database'
 
 const temporaryDirectories: string[] = []
 const openDatabases: SyncDatabase.Database[] = []
+const lockHolders: Worker[] = []
 
 async function createDatabase(): Promise<SyncDatabase.Database> {
   const directory = await mkdtemp(join(tmpdir(), 'orca-sync-database-'))
@@ -20,6 +22,7 @@ async function createDatabase(): Promise<SyncDatabase.Database> {
 }
 
 afterEach(async () => {
+  await Promise.all(lockHolders.splice(0).map((worker) => worker.terminate()))
   for (const db of openDatabases.splice(0)) {
     try {
       db.close()
@@ -149,5 +152,82 @@ describe('SyncDatabase statement cache', () => {
     expect(() => new SyncDatabase(join(directory, 'absent.db'), { fileMustExist: true })).toThrow(
       /does not exist/
     )
+  })
+})
+
+// Why (#15036): the OpenCode readers opened read-only with no busy timeout, so a
+// contended DB failed in ~1 ms and emptied the whole panel. These pin that the
+// wrapper really forwards `timeout` into sqlite3_busy_timeout.
+describe('SyncDatabase read-only opens under contention', () => {
+  // The lock holder must live on another thread: sqlite3_busy_timeout sleeps
+  // synchronously, so a same-thread timer could never fire to release it.
+  const WRITER_SOURCE = `
+    const { parentPort, workerData } = require('node:worker_threads')
+    const { DatabaseSync } = require('node:sqlite')
+    const db = new DatabaseSync(workerData.path)
+    db.exec('PRAGMA journal_mode=DELETE')
+    db.exec("CREATE TABLE items (id TEXT PRIMARY KEY); INSERT INTO items VALUES ('a')")
+    db.exec('BEGIN EXCLUSIVE')
+    db.exec("INSERT INTO items VALUES ('b')")
+    parentPort.postMessage('locked')
+    setTimeout(() => {
+      db.exec('COMMIT')
+      db.close()
+      parentPort.postMessage('released')
+    }, workerData.holdMs)
+  `
+
+  async function contendedDatabase(holdMs: number): Promise<{ path: string }> {
+    const directory = await mkdtemp(join(tmpdir(), 'orca-sync-database-busy-'))
+    temporaryDirectories.push(directory)
+    const path = join(directory, 'contended.db')
+    const worker = new Worker(WRITER_SOURCE, { eval: true, workerData: { path, holdMs } })
+    lockHolders.push(worker)
+    await new Promise<void>((resolve, reject) => {
+      worker.once('message', () => resolve())
+      worker.once('error', reject)
+    })
+    return { path }
+  }
+
+  it('fails immediately with SQLITE_BUSY when no timeout is given', async () => {
+    const contended = await contendedDatabase(10_000)
+    const startedAt = Date.now()
+
+    let thrown: unknown
+    try {
+      new SyncDatabase(contended.path, { readonly: true }).prepare('SELECT id FROM items').all()
+    } catch (error) {
+      thrown = error
+    }
+
+    expect((thrown as { errcode?: number }).errcode).toBe(5)
+    expect((thrown as Error).message).toContain('database is locked')
+    expect(Date.now() - startedAt).toBeLessThan(200)
+  })
+
+  it('waits for the configured busy timeout before giving up', async () => {
+    const contended = await contendedDatabase(10_000)
+    const startedAt = Date.now()
+
+    expect(() =>
+      new SyncDatabase(contended.path, { readonly: true, timeout: 400 })
+        .prepare('SELECT id FROM items')
+        .all()
+    ).toThrow(/database is locked/)
+
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(350)
+  })
+
+  it('succeeds once the writer commits inside the busy timeout', async () => {
+    const contended = await contendedDatabase(150)
+
+    const reader = new SyncDatabase(contended.path, { readonly: true, timeout: 5_000 })
+    openDatabases.push(reader)
+
+    expect(reader.prepare('SELECT id FROM items ORDER BY id').all()).toEqual([
+      { id: 'a' },
+      { id: 'b' }
+    ])
   })
 })

--- a/src/renderer/src/components/right-sidebar/ai-vault-scan-issue-state.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-scan-issue-state.test.ts
@@ -78,6 +78,24 @@ describe('aiVaultScanNoticeIssues', () => {
     expect(skippedAiVaultTranscriptCount(partial)).toBe(1)
   })
 
+  // #15036: a locked opencode.db holds every OpenCode session, so reporting it
+  // as "1 transcript skipped" both understates the loss and buries the cause in
+  // a bare driver string.
+  it('gives an unreadable OpenCode database its own row instead of a skipped count', () => {
+    const sourceIssue = {
+      agent: 'opencode' as const,
+      kind: 'scope' as const,
+      path: '\\\\wsl.localhost\\Ubuntu\\home\\ada\\.local\\share\\opencode\\opencode.db',
+      message:
+        'OpenCode is writing to opencode.db right now, so its history was skipped. It is read again on the next refresh.'
+    }
+    const empty = result([], [sourceIssue])
+
+    expect(skippedAiVaultTranscriptCount(empty)).toBe(0)
+    expect(skippedAiVaultTranscriptReasons(empty)).toEqual([])
+    expect(aiVaultScanNoticeIssues(empty)).toEqual([sourceIssue])
+  })
+
   it('does not repeat the blocking issue as a notice row', () => {
     const hostIssue = {
       executionHostId: 'ssh:dev-box' as const,

--- a/src/renderer/src/components/right-sidebar/ai-vault-scan-issue-state.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-scan-issue-state.ts
@@ -12,7 +12,9 @@ export function blockingAiVaultScanIssue(
 // Host and scope issues carry their own scanner-authored copy, so they get their
 // own rows instead of being counted as skipped transcripts — a partial scan
 // (one SSH host down, rest fine) must not report a connectivity failure as a
-// skipped transcript file.
+// skipped transcript file, and an unreadable *source* (a whole locked
+// opencode.db holding every OpenCode session) must not read as "1 transcript
+// skipped".
 export function aiVaultScanNoticeIssues(result: AiVaultListResult | null): AiVaultScanIssue[] {
   if (!result) {
     return []


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​482 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​482 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​305 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​114 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​191 |

<!-- /orca-pr-loc -->

Fixes the reporting half of #15036, and replaces this PR's original theory with what a real Windows + WSL2 machine actually does.

## ELI5

Orca reads OpenCode's history out of a SQLite file. When that read failed, Orca said **"1 transcript skipped"** — as if one chat was missing. In reality *every* OpenCode session was gone, because the whole database failed to open. Wrong number, wrong noun, and it pointed the user at the wrong problem.

Now a whole-database failure says a whole database failed, and — on WSL — says the true reason instead of a guess.

## What changed

1. **A failed source is no longer counted as a failed file.** The panel counts unkinded issues as skipped transcripts, so the database failure is now kinded `scope` and gets its own row.
2. **An unknown `kind` from a newer host degrades to `scope`** instead of failing validation and coming back unkinded. A mixed-version remote host used to turn a source-level failure into a phantom skipped transcript.
3. **The read gets a bounded busy timeout** (it inherited sqlite3's 0 ms, so a contended open died in ~1 ms).
4. **The retry loop, retry delay, contention budget and per-database backoff are gone** — see below.
5. **The WSL copy names the real blocker** rather than blaming a writer that does not exist.

## Why the retry machinery was removed

An earlier revision of this PR added retries, a 12 s pass budget and a 15 s per-database backoff. Measured, that machinery was defending against something that does not happen:

- **547/547** cross-process reads succeeded at `timeout: 0` — the exact pre-fix condition — while a separate process held open write transactions and ran passive checkpoints. WAL readers do not block on a writer. That is the point of WAL.
- SQLite's own busy handler already blocks and retries internally for the whole `timeout`, so an outer retry loop mostly just multiplies the wait.

The busy timeout stays as cheap insurance for a genuinely contended non-WAL database. The loop around it earned nothing.

## What actually breaks WSL (measured on a real distro)

The reporter's symptom survived a reboot **and** a reinstall, which no live lock-holder can. Testing against a real Ubuntu-24.04 distro from Windows explains why:

| What was read over `\\wsl.localhost` | Result |
|---|---|
| WAL database | **FAIL** — `SQLITE_BUSY (5)` |
| Plain `journal_mode=DELETE` database, never WAL | **FAIL** — `SQLITE_BUSY (5)` |
| Idle, cleanly checkpointed, no `-wal`/`-shm` on disk | **FAIL** — `SQLITE_BUSY (5)` |
| Same, with `timeout: 5000` | **FAIL**, 3/3 |
| Raw bytes of the same file | **OK** (8192 bytes) |
| The identical bytes copied to local NTFS | **OK**, 200 rows |
| Read from *inside* the distro | **OK**, 200 rows |

So the file is healthy and the share is readable — **Windows simply cannot take SQLite's file locks over `\\wsl.localhost`**. It is structural, not stateful, which is exactly why reinstalling changed nothing. No journal mode, no busy timeout, and no retry count can fix it.

That is why the copy no longer mentions the write-ahead log: checkpointing cannot help, and saying otherwise sends the user after a fix that cannot work.

### Why not `immutable=1`

It appears to work and is a data-loss trap. On a database holding 150 rows — 100 checkpointed, 50 still in the `-wal`:

```
plain UNC     FAIL errcode=5
nolock=1      FAIL errcode=14
immutable=1   "OK"  rows=100      <-- silently drops 50
in-distro     OK    rows=150
```

In a session-history panel the rows it drops are the newest sessions — the ones the user is looking for.

## Cost of failing on that share

Review raised aggregate scan latency, and measuring it showed the timeout does not even bound the wait:

| `timeout` | time to fail over `\\wsl.localhost` |
|---|---|
| 0 | ~21 ms |
| 1500 | **~2400 ms** |
| 5000 | **~7250 ms** |

So every scan paid ~2.4 s per WSL database waiting for a lock that can never be acquired, and enough such databases would spend the list worker's whole 30 s deadline — which discards the healthy databases' results too.

Since waiting there is provably useless, the fix is not a budget but not waiting: `openCodeBusyTimeoutMs()` returns 0 for `\wsl.localhost` and `\wsl$` paths, and the full 1500 ms everywhere a writer really can hold the lock. Measured through the shipped path on Windows afterwards: **31.4, 31.1, 31.6 ms**.

## Verified on Windows

Run against a real WSL database on a Windows host, through the shipped code path:

```
OBSERVED_ERRCODE 5
OBSERVED_KIND    scope
OBSERVED_MESSAGE OpenCode history in oc.db could not be read. Windows cannot open
                 SQLite databases over the \\wsl.localhost share, so this history
                 has to be read from inside the distro.
```

`session-scanner-opencode-sqlite-open.test.ts` also passes on Windows. The two new WSL assertions were proven non-vacuous by reverting the guard and confirming they fail.

## Risk and user-facing trade-offs

**Risk: low.** The read path got strictly smaller — one bounded open, no loop, no persistent state. The removed backoff map was the only stateful piece and it is gone.

**What this does not do:** a WSL user's OpenCode sessions are still missing. This PR makes Orca *tell the truth* about why instead of claiming one transcript was skipped. Restoring those sessions requires reading inside the distro, which is a separate change — verified working above (`rows=150`) and filed as a follow-up.

**Trade-off:** on a genuinely contended local database, a scan can now block up to 1.5 s on the open instead of failing in ~1 ms. That is the intended exchange, and it is bounded per database.
