### PR TITLE
perf(sleep): park idle agents in the worktree you are working in (#16211)

### DIFF
--- a/src/renderer/src/lib/agent-hibernation-coordinator.test.ts
+++ b/src/renderer/src/lib/agent-hibernation-coordinator.test.ts
@@ -297,7 +297,9 @@ describe('agent sleep coordinator', () => {
     startAgentHibernationCoordinator({ intervalMs: 1000, now: () => NOW })
 
     await vi.advanceTimersByTimeAsync(1000)
-    useAppStore.setState({ activeWorktreeId: 'wt-bg' })
+    // Why: returning to the tab between the plan and the confirm is the eligibility change this
+    // must observe. The active worktree is no longer skipped wholesale, so it is no longer a lever.
+    setForegroundTerminalTabIds(['tab-1'])
     await vi.advanceTimersByTimeAsync(1000)
 
     expect(shutdown).not.toHaveBeenCalled()
@@ -631,7 +633,7 @@ describe('agent sleep coordinator', () => {
 
     await vi.advanceTimersByTimeAsync(1000)
     await vi.advanceTimersByTimeAsync(1000)
-    useAppStore.setState({ activeWorktreeId: 'wt-bg' })
+    setForegroundTerminalTabIds(['tab-1'])
     delayed.resolve(runtimeListResult(['pty-1']))
     await Promise.resolve()
 

--- a/src/renderer/src/lib/agent-hibernation-planner.test.ts
+++ b/src/renderer/src/lib/agent-hibernation-planner.test.ts
@@ -87,7 +87,7 @@ function plannedPaneKeys(input: AgentHibernationPlannerSnapshot): string[] {
 }
 
 describe('agent sleep planner', () => {
-  it('selects nothing when disabled, active, or foreground', () => {
+  it('selects nothing when disabled or foreground', () => {
     expect(
       plannedWorktrees(
         snapshot({
@@ -98,7 +98,6 @@ describe('agent sleep planner', () => {
         })
       )
     ).toEqual([])
-    expect(plannedWorktrees(snapshot({ activeWorktreeId: 'wt-bg' }))).toEqual([])
     expect(plannedWorktrees(snapshot({ foregroundTerminalTabIds: ['tab-1'] }))).toEqual([])
   })
 
@@ -359,6 +358,9 @@ describe('agent sleep planner', () => {
     ).toEqual([])
   })
 
+  // Why: `activeWorktreeId` is the worktree under test, so this also pins #16211 — the planner
+  // used to skip the active tree wholesale and this case would return []. Lever from @sanshengai's
+  // #16214; it fails against the pre-fix planner, where a standalone background-worktree case does not.
   it('does not let one foreground terminal tab reset a sibling tab in the same worktree', () => {
     const siblingEntry = entry({
       paneKey: `tab-2:${OTHER_LEAF}`,
@@ -369,6 +371,7 @@ describe('agent sleep planner', () => {
     expect(
       plannedPaneKeys(
         snapshot({
+          activeWorktreeId: 'wt-bg',
           foregroundTerminalTabIds: ['tab-1'],
           foregroundTerminalLastSeenAtByTabId: {
             'tab-1': NOW

--- a/src/renderer/src/lib/agent-hibernation-planner.ts
+++ b/src/renderer/src/lib/agent-hibernation-planner.ts
@@ -112,7 +112,11 @@ export function planAgentHibernationCandidates(
   const agentEntriesByTabId = getAgentEntriesByTabId(snapshot.agentStatusByPaneKey)
   const candidates: AgentHibernationCandidate[] = []
   for (const [worktreeId, tabs] of Object.entries(snapshot.tabsByWorktree)) {
-    if (!worktreeId || worktreeId === snapshot.activeWorktreeId || tabs.length === 0) {
+    // Why: the tab on screen is `foregroundTerminalTabIds` below, and a tab just left is held by
+    // the `foregroundTerminalLastSeenAtByTabId` floor in getEligiblePane. Skipping the whole active
+    // worktree on top of that parked nothing in the tree a user actually works in — where a 16 GB
+    // host accumulates its idle agents (#16211).
+    if (!worktreeId || tabs.length === 0) {
       continue
     }
     if (


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​9 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |

<!-- /orca-pr-loc -->

> **Recommendation: close this in favour of #16214 by @sanshengai.** See "Review" at the bottom. Kept open only so the comparison is on the record.

## ELI5

Orca can put idle, finished agent panes to sleep to save memory. It was skipping *every* pane in the worktree you're currently looking at — including background tabs you haven't touched in hours. On a 16 GB Windows machine that's exactly where the memory piles up. Now only the tab actually on screen (and one you left recently) is protected.

## What Changed

Removed `worktreeId === snapshot.activeWorktreeId` from the planner's skip condition, so the existing per-tab foreground guard applies to every worktree.

## Why

`planAgentHibernationCandidates` skipped the whole active worktree:

```ts
if (!worktreeId || worktreeId === snapshot.activeWorktreeId || tabs.length === 0) {
```

The reporter in #16211 keeps four long-lived product worktrees with 1–3 agent tabs each and works in one of them. Sibling-tab idle already worked for the *inactive* trees; the active one — the one accumulating idle Codex/Grok panes and their MCP descendants — was exempt wholesale.

Removing it is safe because the two remaining guards are the more precise boundary and both already existed: `foregroundTerminalTabIds` covers the tab on screen, and the `foregroundTerminalLastSeenAtByTabId` floor in `getEligiblePane` is anchored to the *end* of a foreground visit, so a tab left inside the idle window cannot be parked. Everything else in `getEligiblePane` is untouched.

## Linked Issue

Addresses #16211 (the hibernation half). The diagnostics half is #16589.

## Visual Proof

N/A — no UI change. Behaviour is a background scheduler decision; covered by unit tests instead.

## Testing

- `pnpm test src/renderer/src/lib src/renderer/src/store` → 755 files / 7310 passed.
- `pnpm tc` clean.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

## Review

Two review findings, both material, and together they change my recommendation:

**1. A repo-wide `pnpm format` had leaked into this commit** — 32 files touched for a 6-file change, rewriting three canonical skill guides without regenerating their bundled artifacts. Confirmed P1 under adversarial verification. Fixed: the branch is rebuilt on `origin/main` as a single 6-file commit.

**2. My added tests were vacuous.** They used worktree `wt-bg` while the fixture's `activeWorktreeId` was `wt-active`, so the worktree was never the active one and the tests passed unchanged against pre-fix code. Worse, I had *removed* `activeWorktreeId` from the planner snapshot — which makes the pre-fix condition impossible to express in a test at all.

**@sanshengai's #16214 does this correctly and did it first.** Same one-line planner change, but it keeps `activeWorktreeId` on the snapshot and sets it to the worktree under test inside the *existing* sibling-tab regression — one added line, and it genuinely fails against pre-fix code. That is smaller and strictly stronger than what I wrote.

So: **merge #16214, close this.** If the now-dead `activeWorktreeId` field is worth removing, that belongs in a separate follow-up *after* a non-vacuous test exists — not bundled with the behaviour change that needs it.

Credit: @sanshengai identified and fixed this exact root cause first in #16214, against issue #16211's own proposed slice 3. They are also working the same #16211 umbrella from the orchestration side in #16217 (auto-releasing completed worker terminals), which is complementary and fills a gap none of my PRs address.