### PR TITLE
fix(terminal): blur every suspended pane, not just the retained ones

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
+++ b/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
@@ -54,16 +54,18 @@ export function suspendPaneRendering(
   retention?: { owner: object; livePanes: () => Iterable<ManagedPaneInternal> }
 ): void {
   const suspended = Array.from(panes)
+  // Why: both branches must leave a suspended pane in the same state; only the retention
+  // branch below used to blur. Defence in depth, not a measured cost — display:none and
+  // inert both make Chromium blur the pane itself, and disposeWebgl kills the blink timer
+  // regardless. It only bites under opacity:0 without inert (TerminalOverlaySlot's startup
+  // probe), the one hide mode that keeps focus.
   for (const pane of suspended) {
     pane.webglAttachmentDeferred = true
+    pane.terminal.blur()
   }
   // Keep recent hidden worktrees on live WebGL so switch-back never presents
   // DOM-fallback frames; evicted/over-cap owners fall back to dispose.
   if (retention && tryRetainHiddenPanesWebgl(retention.owner, retention.livePanes)) {
-    // Why: retained WebGL keeps xterm's focused cursor timer alive behind the hidden surface.
-    for (const pane of suspended) {
-      pane.terminal.blur()
-    }
     return
   }
   for (const pane of suspended) {

--- a/src/renderer/src/lib/pane-manager/pane-webgl-refresh-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-refresh-lifecycle.test.ts
@@ -23,6 +23,7 @@ function createPane(
       buffer: { active: { type: 'normal', viewportY: 0, baseY: 0 } },
       refresh: vi.fn(),
       resize: vi.fn(),
+      blur: vi.fn(),
       dispose: vi.fn()
     } as never,
     container: {

--- a/src/renderer/src/lib/pane-manager/terminal-webgl-hidden-retention.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-webgl-hidden-retention.test.ts
@@ -47,7 +47,13 @@ describe('terminal-webgl-hidden-retention', () => {
     suspendPaneRendering(panes)
     expect(addon?.dispose).toHaveBeenCalled()
     expect(panes[0].webglAddon).toBeNull()
-    expect(panes[0].terminal.blur).not.toHaveBeenCalled()
+  })
+
+  // Why: the retained branch's blur is already pinned above; only the dispose branch changed.
+  it('blurs a suspended pane on the dispose branch', () => {
+    const panes = [createPane()]
+    suspendPaneRendering(panes)
+    expect(panes[0].terminal.blur).toHaveBeenCalledTimes(1)
   })
 
   it('evicts the least-recently-hidden owner over the context cap', () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​2 |

<!-- /orca-pr-loc -->

## ELI5

When Orca hides a terminal pane, it used to "let go" of that pane only sometimes — depending on whether the pane still had a GPU renderer attached. This makes it always let go, so hidden panes end up in the same state either way.

Originally filed claiming this saved CPU. **It does not** — that was measured and disproved before merging. It is kept as a small consistency fix, and the false claim has been removed from the code and commit message.

## What Changed

`suspendPaneRendering` called `pane.terminal.blur()` only on the WebGL-retention branch. The dispose branch — taken by every pane past `MAX_RETAINED_HIDDEN_WEBGL_CONTEXTS = 6`, and outright when one worktree holds more than 6 contexts — did not. Blur is now unconditional.

3 files, +14/−5.

## Why

Two branches left a suspended pane in different states for no stated reason. A pane the user cannot see should not hold focus.

**The original rationale was wrong and is retracted.** I claimed a focused xterm keeps a cursor-blink timer running behind `display:none`, one timer per hidden pane, growing with worktree count. Measured on Windows 11 against the exact shipped versions (`@xterm/xterm 6.1.0-beta.287`, `@xterm/addon-webgl 0.20.0-beta.286`), N = 12 panes, timer/rAF counters monkey-patched before any terminal was constructed:

| phase | interval fires/s | rAF fires/s | live intervals |
| --- | ---: | ---: | ---: |
| visible + focused + WebGL | 1.62 | 3.50 | 1 |
| `display:none`, **no blur** | **0** | **0** | **0** |
| `display:none` + `blur()` | 0 | 0 | 0 |
| `display:none` + WebGL disposed, no blur | 0 | 0 | 0 |
| same + `blur()` | 0 | 0 | 0 |

The claimed counterfactual is **0 vs 0**, on three independent grounds any one of which is fatal:

1. `display:none` and `inert` — both of Orca's hide modes (`Terminal.tsx:2621-2630`, `:2870-2880`, `TerminalOverlaySlot.tsx:196-206`) — make Chromium fire a real `blur` on the pane's helper textarea *before* `suspendPaneRendering` runs. That pauses xterm's WebGL blink `setInterval` on its own (`WebglRenderer.handleBlur()` → `CursorBlinkStateManager.pause()`).
2. `disposeWebgl()` disposes the addon, which disposes the blink manager — the dispose branch was already covered.
3. Focus is a **document-wide singleton**; at most one terminal is ever focused. "One timer per hidden pane" was structurally impossible.

The DOM renderer has no recurring blink timer at all — it is CSS `@keyframes` scoped under `.xterm-rows.xterm-focus`.

**What it still buys:** `opacity:0` *without* `inert` does not drop focus (measured: 1.62 fires/s retained). That configuration is live in the tree — `TerminalOverlaySlot.tsx:196-198`, the startup probe inside an *active* worktree, which the surface-level `inert` does not cover. Cheap insurance, honestly labelled.

## Linked Issue

Found while investigating #16241. **Does not fix it** — that cause remains unattributed.

## Visual Proof

N/A — no rendered output changes. A hidden pane is hidden either way; this only changes its focus state.

## Testing

- `pnpm test src/renderer/src/lib/pane-manager/` → 70 files / 775 passed, 1 skipped.
- `pnpm tc` clean.
- Windows 11 measurement above (harness reproducing each of Orca's hide modes against the shipped xterm build, not the full app — stated plainly).
- One existing test asserted `blur` was *not* called on the dispose path; it encoded the asymmetry, so it was updated rather than deleted. The new test covers only the dispose branch — the retained branch's blur is already pinned by `suspend retains live WebGL addons and still defers attachment`.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

## Review

Two review findings were applied before this was ready: the branch previously contained #16591's commit (rebased onto `main`, now one commit), and a repo-wide `pnpm format` run had leaked an unrelated doc file into the diff (removed).