### PR TITLE
fix(codex): stop re-scanning all Codex session history on every launch (#16251)

### DIFF
--- a/src/main/codex-accounts/runtime-home-real-home-lane-routing.test.ts
+++ b/src/main/codex-accounts/runtime-home-real-home-lane-routing.test.ts
@@ -18,6 +18,18 @@ import {
   testState,
   writePaneRegistry
 } from './runtime-home-service-test-harness'
+import { hasCompletedCodexSessionBackfillMarker } from '../codex/codex-session-backfill-marker'
+import { getCodexSessionBackfillDate } from '../codex/codex-session-backfill-scan-dates'
+
+function expectBaselineKeptWithLaunchDatePending(markerPath: string): void {
+  const marker = JSON.parse(readFileSync(markerPath, 'utf-8')) as {
+    pendingScanDates?: unknown
+  }
+  expect(marker.pendingScanDates).toEqual([getCodexSessionBackfillDate()])
+  expect(
+    hasCompletedCodexSessionBackfillMarker(markerPath, join(getSystemCodexHomePath(), 'sessions'))
+  ).toBe(true)
+}
 
 vi.mock('electron', () => ({
   app: {
@@ -54,7 +66,9 @@ describe('CodexRuntimeHomeService', () => {
     const { CodexRuntimeHomeService } = await import('./runtime-home-service')
     const service = new CodexRuntimeHomeService(store as never)
     expect(service.prepareForCodexLaunch()).toBe(getRuntimeCodexHomePath())
-    expect(existsSync(markerPath)).toBe(false)
+    expect(
+      hasCompletedCodexSessionBackfillMarker(markerPath, join(getSystemCodexHomePath(), 'sessions'))
+    ).toBe(false)
     service.finishHostSystemDefaultSessionMigrationPass()
     expect(service.beginHostSystemDefaultSessionMigrationLaunch(getRuntimeCodexHomePath())).toBe(
       true
@@ -82,7 +96,7 @@ describe('CodexRuntimeHomeService', () => {
     expect(service.beginHostSystemDefaultSessionMigrationLaunch(getRuntimeCodexHomePath())).toBe(
       false
     )
-    expect(existsSync(markerPath)).toBe(false)
+    expectBaselineKeptWithLaunchDatePending(markerPath)
     service.prepareForCodexLaunch()
     expect(service.beginHostSystemDefaultSessionMigrationLaunch(getRuntimeCodexHomePath())).toBe(
       false
@@ -101,7 +115,7 @@ describe('CodexRuntimeHomeService', () => {
     expect(service.beginHostSystemDefaultSessionMigrationLaunch(null, { reattached: true })).toBe(
       false
     )
-    expect(existsSync(markerPath)).toBe(false)
+    expectBaselineKeptWithLaunchDatePending(markerPath)
     store.updateSettings({
       codexSessionSourceHome: { host: join(testState.fakeHomeDir, 'moved-history'), wsl: {} }
     })
@@ -140,7 +154,9 @@ describe('CodexRuntimeHomeService', () => {
     mkdirSync(join(testState.userDataDir, 'codex-session-backfill'), { recursive: true })
     writeFileSync(markerPath, '{}\n', 'utf-8')
     expect(service.prepareForCodexLaunch()).toBe(getRuntimeCodexHomePath())
-    expect(existsSync(markerPath)).toBe(false)
+    expect(
+      hasCompletedCodexSessionBackfillMarker(markerPath, join(getSystemCodexHomePath(), 'sessions'))
+    ).toBe(false)
     expect(service.beginHostSystemDefaultSessionMigrationLaunch(getRuntimeCodexHomePath())).toBe(
       true
     )

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -323,11 +323,14 @@ export class CodexRuntimeHomeService {
     }
     // Why: the launch creates rollouts for these dates; record them durably so a
     // force-quit recovers a bounded window instead of re-walking all history.
-    markCodexSessionBackfillMarkerPending(
+    const markerOwesFullScan = markCodexSessionBackfillMarkerPending(
       paths.markerPath,
       paths.systemSessionsRoot,
       scanDates.length > 0 ? scanDates : [getCodexSessionBackfillDate()]
     )
+    // Why: the marker is the only place an overflowed pending window survives a
+    // restart, so its demand has to reach this pass rather than die in the file.
+    this.pendingHostSystemDefaultSessionMigrationNeedsFullScan ||= markerOwesFullScan
     return this.pendingHostSystemDefaultSessionMigrationNeedsFullScan
   }
 

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -71,8 +71,10 @@ import { getDefaultWslDistro, getWslHome } from '../wsl'
 import { hasCustomCodexHomeOverrideForLaunch } from '../codex/codex-real-home-path'
 import {
   hasCompletedCodexSessionBackfillMarker,
-  invalidateCodexSessionBackfillMarker
+  markCodexSessionBackfillMarkerPending
 } from '../codex/codex-session-backfill-marker'
+import { getCodexSessionBackfillDate } from '../codex/codex-session-backfill-scan-dates'
+import type { CodexSessionBackfillDate } from '../codex/codex-session-backfill-types'
 import { resolveCodexSessionBackfillPaths } from '../codex/codex-session-backfill'
 import {
   ManagedCodexHomeTemporarilyUnavailableError,
@@ -305,18 +307,27 @@ export class CodexRuntimeHomeService {
     )
   }
 
-  prepareHostSystemDefaultSessionMigrationPass(): boolean {
+  prepareHostSystemDefaultSessionMigrationPass(
+    scanDates: readonly CodexSessionBackfillDate[] = []
+  ): boolean {
     const paths = resolveCodexSessionBackfillPaths(
       resolveHostCodexSessionSourceHome(this.store.getSettings())
     )
+    const target = normalizeRuntimePathForComparison(paths.systemSessionsRoot)
     if (
       this.hostSystemDefaultSessionMigrationPending &&
-      this.pendingHostSystemDefaultSessionMigrationTarget !== paths.systemSessionsRoot
+      this.pendingHostSystemDefaultSessionMigrationTarget !== target
     ) {
       this.pendingHostSystemDefaultSessionMigrationNeedsFullScan = true
-      this.pendingHostSystemDefaultSessionMigrationTarget = paths.systemSessionsRoot
+      this.pendingHostSystemDefaultSessionMigrationTarget = target
     }
-    invalidateCodexSessionBackfillMarker(paths.markerPath)
+    // Why: the launch creates rollouts for these dates; record them durably so a
+    // force-quit recovers a bounded window instead of re-walking all history.
+    markCodexSessionBackfillMarkerPending(
+      paths.markerPath,
+      paths.systemSessionsRoot,
+      scanDates.length > 0 ? scanDates : [getCodexSessionBackfillDate()]
+    )
     return this.pendingHostSystemDefaultSessionMigrationNeedsFullScan
   }
 
@@ -526,7 +537,9 @@ export class CodexRuntimeHomeService {
       )
       this.pendingHostSystemDefaultSessionMigrationNeedsFullScan =
         !hasCompletedCodexSessionBackfillMarker(paths.markerPath, paths.systemSessionsRoot)
-      this.pendingHostSystemDefaultSessionMigrationTarget = paths.systemSessionsRoot
+      this.pendingHostSystemDefaultSessionMigrationTarget = normalizeRuntimePathForComparison(
+        paths.systemSessionsRoot
+      )
       this.hostSystemDefaultSessionMigrationPending = true
     }
     return this.prepareHostSystemDefaultSessionMigrationPass()

--- a/src/main/codex-accounts/runtime-home-session-migration-pass.test.ts
+++ b/src/main/codex-accounts/runtime-home-session-migration-pass.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import type * as NodeOs from 'node:os'
+import { join } from 'node:path'
+import { createSettings } from './runtime-home-settings-test-fixtures'
+import {
+  createStore,
+  getRuntimeCodexHomePath,
+  setupRuntimeHomeTest,
+  teardownRuntimeHomeTest,
+  testState
+} from './runtime-home-service-test-harness'
+import { getCodexSessionBackfillDate } from '../codex/codex-session-backfill-scan-dates'
+import type { CodexSessionBackfillDate } from '../codex/codex-session-backfill-types'
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => testState.userDataDir
+  }
+}))
+
+vi.mock('node:os', async () => {
+  const actual = await vi.importActual<typeof NodeOs>('node:os')
+  return {
+    ...actual,
+    homedir: () => testState.fakeHomeDir
+  }
+})
+
+const CUSTOM_HISTORY_HOME = 'C:\\Users\\Me\\.codex'
+
+function getMarkerPath(): string {
+  return join(testState.userDataDir, 'codex-session-backfill', 'backfill-complete.json')
+}
+
+function writeBaselineMarker(systemCodexHomePath: string): void {
+  mkdirSync(join(testState.userDataDir, 'codex-session-backfill'), { recursive: true })
+  writeFileSync(
+    getMarkerPath(),
+    `${JSON.stringify({
+      version: 4,
+      systemSessionsRoot: join(systemCodexHomePath, 'sessions'),
+      coverage: 'full',
+      baselineScannedFiles: 5,
+      pendingScanDates: [],
+      needsFullScan: false,
+      summary: { scannedFiles: 5 }
+    })}\n`,
+    'utf-8'
+  )
+}
+
+function readPendingScanDates(): unknown {
+  return (JSON.parse(readFileSync(getMarkerPath(), 'utf-8')) as { pendingScanDates?: unknown })
+    .pendingScanDates
+}
+
+describe('host system default session migration pass preparation', () => {
+  beforeEach(() => {
+    setupRuntimeHomeTest()
+  })
+
+  afterEach(() => {
+    teardownRuntimeHomeTest()
+  })
+
+  it('records the launch date and keeps the baseline instead of deleting it', async () => {
+    writeBaselineMarker(CUSTOM_HISTORY_HOME)
+    const store = createStore(
+      createSettings({ codexSessionSourceHome: { host: CUSTOM_HISTORY_HOME, wsl: {} } })
+    )
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+
+    expect(service.prepareHostSystemDefaultSessionMigrationPass()).toBe(false)
+
+    expect(readPendingScanDates()).toEqual([getCodexSessionBackfillDate()])
+    expect(JSON.parse(readFileSync(getMarkerPath(), 'utf-8'))).toMatchObject({ coverage: 'full' })
+  })
+
+  it('persists every date a scheduled pass reports so a force-quit stays bounded', async () => {
+    writeBaselineMarker(CUSTOM_HISTORY_HOME)
+    const store = createStore(
+      createSettings({ codexSessionSourceHome: { host: CUSTOM_HISTORY_HOME, wsl: {} } })
+    )
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+    const spannedDates: CodexSessionBackfillDate[] = [
+      ['2026', '08', '05'],
+      ['2026', '08', '06']
+    ]
+
+    service.prepareHostSystemDefaultSessionMigrationPass(spannedDates)
+
+    expect(readPendingScanDates()).toEqual(spannedDates)
+  })
+
+  it('does not demand a full scan when the same history home is spelled differently', async () => {
+    writeBaselineMarker(CUSTOM_HISTORY_HOME)
+    const store = createStore(
+      createSettings({ codexSessionSourceHome: { host: CUSTOM_HISTORY_HOME, wsl: {} } })
+    )
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+    expect(service.beginHostSystemDefaultSessionMigrationLaunch(getRuntimeCodexHomePath())).toBe(
+      false
+    )
+
+    store.updateSettings({
+      codexSessionSourceHome: { host: 'c:/users/me/.codex', wsl: {} }
+    })
+
+    expect(service.prepareHostSystemDefaultSessionMigrationPass()).toBe(false)
+  })
+
+  it('still demands a full scan when the history home really moves', async () => {
+    writeBaselineMarker(CUSTOM_HISTORY_HOME)
+    const store = createStore(
+      createSettings({ codexSessionSourceHome: { host: CUSTOM_HISTORY_HOME, wsl: {} } })
+    )
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+    expect(service.beginHostSystemDefaultSessionMigrationLaunch(getRuntimeCodexHomePath())).toBe(
+      false
+    )
+
+    store.updateSettings({
+      codexSessionSourceHome: { host: 'C:\\Users\\Me\\moved-codex', wsl: {} }
+    })
+
+    expect(service.prepareHostSystemDefaultSessionMigrationPass()).toBe(true)
+  })
+})

--- a/src/main/codex-accounts/runtime-home-session-migration-pass.test.ts
+++ b/src/main/codex-accounts/runtime-home-session-migration-pass.test.ts
@@ -33,7 +33,7 @@ function getMarkerPath(): string {
   return join(testState.userDataDir, 'codex-session-backfill', 'backfill-complete.json')
 }
 
-function writeBaselineMarker(systemCodexHomePath: string): void {
+function writeBaselineMarker(systemCodexHomePath: string, needsFullScan = false): void {
   mkdirSync(join(testState.userDataDir, 'codex-session-backfill'), { recursive: true })
   writeFileSync(
     getMarkerPath(),
@@ -43,7 +43,7 @@ function writeBaselineMarker(systemCodexHomePath: string): void {
       coverage: 'full',
       baselineScannedFiles: 5,
       pendingScanDates: [],
-      needsFullScan: false,
+      needsFullScan,
       summary: { scannedFiles: 5 }
     })}\n`,
     'utf-8'
@@ -111,6 +111,22 @@ describe('host system default session migration pass preparation', () => {
     })
 
     expect(service.prepareHostSystemDefaultSessionMigrationPass()).toBe(false)
+  })
+
+  it('carries a full-scan demand persisted by an earlier launch into this pass', async () => {
+    writeBaselineMarker(CUSTOM_HISTORY_HOME, true)
+    const store = createStore(
+      createSettings({ codexSessionSourceHome: { host: CUSTOM_HISTORY_HOME, wsl: {} } })
+    )
+    const { CodexRuntimeHomeService } = await import('./runtime-home-service')
+    const service = new CodexRuntimeHomeService(store as never)
+
+    expect(service.prepareHostSystemDefaultSessionMigrationPass()).toBe(true)
+
+    // Recording this launch must not erase the demand the marker still carries.
+    expect(JSON.parse(readFileSync(getMarkerPath(), 'utf-8'))).toMatchObject({
+      needsFullScan: true
+    })
   })
 
   it('still demands a full scan when the history home really moves', async () => {

--- a/src/main/codex/codex-session-backfill-audit.ts
+++ b/src/main/codex/codex-session-backfill-audit.ts
@@ -1,9 +1,9 @@
 import { createHash, randomUUID } from 'node:crypto'
-import { createReadStream, type Stats } from 'node:fs'
+import type { Stats } from 'node:fs'
 import { appendFile, mkdir } from 'node:fs/promises'
 import { dirname } from 'node:path'
-import { createInterface } from 'node:readline'
 import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
+import { streamCodexSessionLedgerRecords } from './codex-session-ledger-stream'
 import type { CodexSessionBackfillSummary } from './codex-session-backfill-types'
 
 export type CodexSessionBackfillAuditWriter = (record: Record<string, unknown>) => Promise<boolean>
@@ -68,38 +68,23 @@ export async function readCodexSessionBackfillAuditCoverage(
     diagnosticEventIds: new Set<string>(),
     hasRunSummary: false
   }
-  const input = createReadStream(auditLogPath, { encoding: 'utf-8' })
-  const lines = createInterface({ input, crlfDelay: Infinity })
-  try {
-    for await (const raw of lines) {
-      try {
-        const parsed: unknown = JSON.parse(raw)
-        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-          continue
-        }
-        const record = parsed as Record<string, unknown>
-        coverage.hasRunSummary ||= record.action === 'run-summary'
-        if (
-          typeof record.action === 'string' &&
-          HEAL_AUDIT_ACTIONS.has(record.action) &&
-          typeof record.fileEventId === 'string'
-        ) {
-          coverage.fileEventIds.add(record.fileEventId)
-        }
-        if (
-          typeof record.action === 'string' &&
-          DIAGNOSTIC_AUDIT_ACTIONS.has(record.action) &&
-          typeof record.diagnosticEventId === 'string'
-        ) {
-          coverage.diagnosticEventIds.add(record.diagnosticEventId)
-        }
-      } catch {
-        // Torn audit tails are quarantined by the writer's leading newline.
-      }
+  for await (const record of streamCodexSessionLedgerRecords(auditLogPath, {
+    throwOnReadFailure: true
+  })) {
+    coverage.hasRunSummary ||= record.action === 'run-summary'
+    if (
+      typeof record.action === 'string' &&
+      HEAL_AUDIT_ACTIONS.has(record.action) &&
+      typeof record.fileEventId === 'string'
+    ) {
+      coverage.fileEventIds.add(record.fileEventId)
     }
-  } catch (error) {
-    if (!isNotFoundError(error)) {
-      throw error
+    if (
+      typeof record.action === 'string' &&
+      DIAGNOSTIC_AUDIT_ACTIONS.has(record.action) &&
+      typeof record.diagnosticEventId === 'string'
+    ) {
+      coverage.diagnosticEventIds.add(record.diagnosticEventId)
     }
   }
   return coverage
@@ -191,8 +176,4 @@ export async function recordExistingCodexSessionForHeal(
     target,
     ...(fileEventId ? { fileEventId } : {})
   })
-}
-
-function isNotFoundError(error: unknown): boolean {
-  return (error as NodeJS.ErrnoException | null)?.code === 'ENOENT'
 }

--- a/src/main/codex/codex-session-backfill-date.ts
+++ b/src/main/codex/codex-session-backfill-date.ts
@@ -1,17 +1,10 @@
 import { join, relative, sep } from 'node:path'
+import { isCodexSessionBackfillDate } from './codex-session-backfill-scan-dates'
 import { listCodexSessionJsonlFilesIncrementally } from './codex-session-file-listing'
 import type {
   CodexSessionBackfillDate,
   CodexSessionBackfillOptions
 } from './codex-session-backfill-types'
-
-export function getCodexSessionBackfillDate(date = new Date()): CodexSessionBackfillDate {
-  return [
-    String(date.getUTCFullYear()).padStart(4, '0'),
-    String(date.getUTCMonth() + 1).padStart(2, '0'),
-    String(date.getUTCDate()).padStart(2, '0')
-  ]
-}
 
 export function isCodexSessionRolloutPath(sessionsRoot: string, filePath: string): boolean {
   const pathParts = relative(sessionsRoot, filePath).split(sep)
@@ -19,12 +12,7 @@ export function isCodexSessionRolloutPath(sessionsRoot: string, filePath: string
     return false
   }
   const [year, month, day, fileName] = pathParts
-  return (
-    /^\d{4}$/.test(year) &&
-    /^\d{2}$/.test(month) &&
-    /^\d{2}$/.test(day) &&
-    /^rollout-.+\.jsonl$/.test(fileName)
-  )
+  return isCodexSessionBackfillDate([year, month, day]) && /^rollout-.+\.jsonl$/.test(fileName)
 }
 
 export async function* listCodexSessionBackfillFilesForDates(
@@ -54,9 +42,7 @@ function resolveCodexSessionBackfillDateRoots(
     return [sessionsRoot]
   }
   return scanDates
-    .filter(
-      ([year, month, day]) => /^\d{4}$/.test(year) && /^\d{2}$/.test(month) && /^\d{2}$/.test(day)
-    )
+    .filter(isCodexSessionBackfillDate)
     .map(([year, month, day]) => join(sessionsRoot, year, month, day))
 }
 

--- a/src/main/codex/codex-session-backfill-fs-mocks.ts
+++ b/src/main/codex/codex-session-backfill-fs-mocks.ts
@@ -1,0 +1,117 @@
+import type * as NodeFs from 'node:fs'
+import type * as NodeFsPromises from 'node:fs/promises'
+
+// Fault-injection doubles for the backfill tests. Kept out of the spec files so
+// several suites can drive the same failure modes from one switchboard.
+
+export const fsMockState = {
+  failLink: false,
+  failLinkTransiently: false,
+  failLinkPermission: false,
+  raceTargetIntoExistence: false,
+  failMarkerRm: false,
+  failMarkerReplacement: false,
+  failAuditMkdirOnce: false,
+  failAuditWrites: false,
+  failMkdirPath: null as string | null,
+  failDirectoryPath: null as string | null,
+  failLstatPath: null as string | null
+}
+
+export function resetCodexSessionBackfillFsMocks(): void {
+  fsMockState.failLink = false
+  fsMockState.failLinkTransiently = false
+  fsMockState.failLinkPermission = false
+  fsMockState.raceTargetIntoExistence = false
+  fsMockState.failMarkerRm = false
+  fsMockState.failMarkerReplacement = false
+  fsMockState.failAuditMkdirOnce = false
+  fsMockState.failAuditWrites = false
+  fsMockState.failMkdirPath = null
+  fsMockState.failDirectoryPath = null
+  fsMockState.failLstatPath = null
+}
+
+function errnoError(message: string, code: string): NodeJS.ErrnoException {
+  const error = new Error(message) as NodeJS.ErrnoException
+  error.code = code
+  return error
+}
+
+function isMarkerPath(value: unknown): boolean {
+  return (
+    String(value).includes('codex-session-backfill') &&
+    String(value).endsWith('backfill-complete.json')
+  )
+}
+
+export function createNodeFsMock(actual: typeof NodeFs): typeof NodeFs {
+  return {
+    ...actual,
+    existsSync: (...args: Parameters<typeof actual.existsSync>) =>
+      args[0] === fsMockState.failLstatPath ? false : actual.existsSync(...args),
+    rmSync: (...args: Parameters<typeof actual.rmSync>) => {
+      if (fsMockState.failMarkerRm && isMarkerPath(args[0])) {
+        throw errnoError('EACCES: marker removal failed', 'EACCES')
+      }
+      return actual.rmSync(...args)
+    },
+    renameSync: (...args: Parameters<typeof actual.renameSync>) => {
+      if (fsMockState.failMarkerReplacement && isMarkerPath(args[1])) {
+        throw errnoError('EACCES: marker replacement failed', 'EACCES')
+      }
+      return actual.renameSync(...args)
+    }
+  }
+}
+
+export function createNodeFsPromisesMock(actual: typeof NodeFsPromises): typeof NodeFsPromises {
+  return {
+    ...actual,
+    mkdir: (...args: Parameters<typeof actual.mkdir>) => {
+      if (args[0] === fsMockState.failMkdirPath) {
+        throw errnoError('EACCES: target directory inaccessible', 'EACCES')
+      }
+      if (fsMockState.failAuditMkdirOnce && String(args[0]).includes('codex-session-backfill')) {
+        fsMockState.failAuditMkdirOnce = false
+        throw errnoError('EACCES: transient audit directory failure', 'EACCES')
+      }
+      return actual.mkdir(...args)
+    },
+    appendFile: (...args: Parameters<typeof actual.appendFile>) => {
+      if (fsMockState.failAuditWrites && String(args[0]).includes('codex-session-backfill')) {
+        throw errnoError('ENOSPC: audit write failed', 'ENOSPC')
+      }
+      return actual.appendFile(...args)
+    },
+    lstat: (...args: Parameters<typeof actual.lstat>) => {
+      if (args[0] === fsMockState.failLstatPath) {
+        throw errnoError('EACCES: path inaccessible', 'EACCES')
+      }
+      return actual.lstat(...args)
+    },
+    link: async (...args: Parameters<typeof actual.link>) => {
+      if (fsMockState.raceTargetIntoExistence && String(args[0]).includes('codex-runtime-home')) {
+        fsMockState.raceTargetIntoExistence = false
+        await actual.writeFile(args[1], 'concurrent target\n', 'utf-8')
+        throw errnoError('EEXIST: concurrent target', 'EEXIST')
+      }
+      if (fsMockState.failLink && String(args[0]).includes('codex-runtime-home')) {
+        throw errnoError('EXDEV: cross-device link', 'EXDEV')
+      }
+      if (fsMockState.failLinkTransiently && String(args[0]).includes('codex-runtime-home')) {
+        throw errnoError('EIO: transient hardlink failure', 'EIO')
+      }
+      if (fsMockState.failLinkPermission && String(args[0]).includes('codex-runtime-home')) {
+        throw errnoError('EACCES: hardlink permission denied', 'EACCES')
+      }
+      return actual.link(...args)
+    },
+    opendir: (...args: Parameters<typeof actual.opendir>) => {
+      if (args[0] === fsMockState.failDirectoryPath) {
+        throw errnoError('EACCES: directory unreadable', 'EACCES')
+      }
+      return actual.opendir(...args)
+    }
+  } as typeof NodeFsPromises
+}

--- a/src/main/codex/codex-session-backfill-marker.test.ts
+++ b/src/main/codex/codex-session-backfill-marker.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  captureCodexSessionBackfillMarkerGeneration,
+  hasCompletedCodexSessionBackfillMarker,
+  markCodexSessionBackfillMarkerPending,
+  readCodexSessionBackfillBaseline,
+  writeCodexSessionBackfillMarker
+} from './codex-session-backfill-marker'
+import { getCodexSessionBackfillDate } from './codex-session-backfill-scan-dates'
+import type {
+  CodexSessionBackfillDate,
+  CodexSessionBackfillSummary
+} from './codex-session-backfill-types'
+
+const WINDOWS_ROOT = 'C:\\Users\\Me\\.codex\\sessions'
+const TODAY = getCodexSessionBackfillDate()
+const LAUNCH_DATE: CodexSessionBackfillDate = ['2026', '08', '05']
+
+let stateDir: string
+let markerPath: string
+
+function createSummary(scannedFiles = 3): CodexSessionBackfillSummary {
+  return {
+    stopped: false,
+    scannedFiles,
+    linkedFiles: scannedFiles,
+    copiedFiles: 0,
+    skippedExistingFiles: 0,
+    skippedUnexpectedFiles: 0,
+    skippedSymlinkFiles: 0,
+    skippedUnsupportedFilesystemFiles: 0,
+    failedDirectories: 0,
+    failedFiles: 0,
+    failedHealAuditRecords: 0
+  }
+}
+
+function writeFullBaseline(
+  root: string,
+  options: { coveredScanDates?: readonly CodexSessionBackfillDate[]; retain?: boolean } = {}
+): void {
+  writeCodexSessionBackfillMarker(
+    markerPath,
+    root,
+    createSummary(),
+    captureCodexSessionBackfillMarkerGeneration(),
+    {
+      coverage: 'full',
+      coveredScanDates: options.coveredScanDates ?? [],
+      retainPendingScanDates: options.retain
+    }
+  )
+}
+
+function readMarker(): Record<string, unknown> {
+  return JSON.parse(readFileSync(markerPath, 'utf-8')) as Record<string, unknown>
+}
+
+beforeEach(() => {
+  stateDir = mkdtempSync(join(tmpdir(), 'orca-codex-marker-'))
+  markerPath = join(stateDir, 'backfill-complete.json')
+})
+
+afterEach(() => {
+  rmSync(stateDir, { recursive: true, force: true })
+})
+
+describe('codex session backfill marker', () => {
+  it('treats Windows spellings of one directory as the same target', () => {
+    writeFullBaseline(WINDOWS_ROOT)
+
+    for (const alias of ['C:/Users/Me/.codex/sessions', 'c:\\users\\me\\.codex\\sessions']) {
+      expect(hasCompletedCodexSessionBackfillMarker(markerPath, alias)).toBe(true)
+    }
+    expect(
+      hasCompletedCodexSessionBackfillMarker(markerPath, 'C:\\Users\\Me\\other-codex\\sessions')
+    ).toBe(false)
+  })
+
+  it('reads a legacy v3 marker as a certified baseline with nothing pending', () => {
+    writeFileSync(
+      markerPath,
+      `${JSON.stringify({
+        version: 3,
+        systemSessionsRoot: WINDOWS_ROOT,
+        completedAt: Date.now(),
+        summary: { scannedFiles: 12 }
+      })}\n`,
+      'utf-8'
+    )
+
+    expect(readCodexSessionBackfillBaseline(markerPath, 'c:/users/me/.codex/sessions')).toEqual({
+      pendingScanDates: []
+    })
+  })
+
+  it('keeps honoring the v3 empty-source guard', () => {
+    writeFileSync(
+      markerPath,
+      `${JSON.stringify({
+        version: 3,
+        systemSessionsRoot: WINDOWS_ROOT,
+        summary: { scannedFiles: 0 }
+      })}\n`,
+      'utf-8'
+    )
+
+    expect(readCodexSessionBackfillBaseline(markerPath, WINDOWS_ROOT)).toBeNull()
+  })
+
+  it('does not treat a bounded pass that scanned nothing as an empty source', () => {
+    writeFullBaseline(WINDOWS_ROOT)
+    writeCodexSessionBackfillMarker(
+      markerPath,
+      WINDOWS_ROOT,
+      createSummary(0),
+      captureCodexSessionBackfillMarkerGeneration(),
+      { coverage: 'bounded', coveredScanDates: [LAUNCH_DATE] }
+    )
+
+    expect(readMarker()).toMatchObject({ baselineScannedFiles: 3 })
+    expect(hasCompletedCodexSessionBackfillMarker(markerPath, WINDOWS_ROOT)).toBe(true)
+  })
+
+  it('refuses to let a bounded pass invent a baseline it never verified', () => {
+    writeCodexSessionBackfillMarker(
+      markerPath,
+      WINDOWS_ROOT,
+      createSummary(),
+      captureCodexSessionBackfillMarkerGeneration(),
+      { coverage: 'bounded', coveredScanDates: [LAUNCH_DATE] }
+    )
+
+    expect(hasCompletedCodexSessionBackfillMarker(markerPath, WINDOWS_ROOT)).toBe(false)
+  })
+
+  it('records a launch date without destroying the historical baseline', () => {
+    writeFullBaseline(WINDOWS_ROOT)
+
+    markCodexSessionBackfillMarkerPending(markerPath, 'C:/Users/Me/.codex/sessions', [LAUNCH_DATE])
+
+    expect(readMarker()).toMatchObject({ coverage: 'full', pendingScanDates: [LAUNCH_DATE] })
+    expect(readCodexSessionBackfillBaseline(markerPath, WINDOWS_ROOT)).toEqual({
+      pendingScanDates: [LAUNCH_DATE]
+    })
+  })
+
+  it('leaves a marker for a different history untouched', () => {
+    writeFullBaseline(WINDOWS_ROOT)
+
+    markCodexSessionBackfillMarkerPending(markerPath, 'D:\\other\\.codex\\sessions', [LAUNCH_DATE])
+
+    expect(readMarker()).toMatchObject({ systemSessionsRoot: WINDOWS_ROOT, pendingScanDates: [] })
+  })
+
+  it('keeps a racing launch date pending when an older pass publishes', () => {
+    writeFullBaseline(WINDOWS_ROOT)
+    const staleGeneration = captureCodexSessionBackfillMarkerGeneration()
+    markCodexSessionBackfillMarkerPending(markerPath, WINDOWS_ROOT, [LAUNCH_DATE])
+
+    writeCodexSessionBackfillMarker(markerPath, WINDOWS_ROOT, createSummary(), staleGeneration, {
+      coverage: 'bounded',
+      coveredScanDates: [LAUNCH_DATE]
+    })
+
+    expect(readMarker()).toMatchObject({ pendingScanDates: [LAUNCH_DATE] })
+  })
+
+  it('keeps the pane date pending while the pane is still live', () => {
+    writeFullBaseline(WINDOWS_ROOT, { coveredScanDates: [LAUNCH_DATE], retain: true })
+
+    expect(readMarker()).toMatchObject({ launchActive: true, pendingScanDates: [LAUNCH_DATE] })
+  })
+
+  it('demands a full walk once the pending window outgrows its bound', () => {
+    writeFullBaseline(WINDOWS_ROOT)
+    const manyDates = Array.from(
+      { length: 40 },
+      (_unused, index): CodexSessionBackfillDate => ['2026', '08', String(index).padStart(2, '0')]
+    )
+
+    markCodexSessionBackfillMarkerPending(markerPath, WINDOWS_ROOT, manyDates)
+
+    expect(readMarker()).toMatchObject({ needsFullScan: true, pendingScanDates: [] })
+    expect(hasCompletedCodexSessionBackfillMarker(markerPath, WINDOWS_ROOT)).toBe(false)
+  })
+
+  it('persists a launch date even before any baseline exists', () => {
+    markCodexSessionBackfillMarkerPending(markerPath, WINDOWS_ROOT, [TODAY])
+
+    expect(readMarker()).toMatchObject({ coverage: 'bounded', pendingScanDates: [TODAY] })
+    expect(hasCompletedCodexSessionBackfillMarker(markerPath, WINDOWS_ROOT)).toBe(false)
+  })
+})

--- a/src/main/codex/codex-session-backfill-marker.test.ts
+++ b/src/main/codex/codex-session-backfill-marker.test.ts
@@ -9,7 +9,10 @@ import {
   readCodexSessionBackfillBaseline,
   writeCodexSessionBackfillMarker
 } from './codex-session-backfill-marker'
-import { getCodexSessionBackfillDate } from './codex-session-backfill-scan-dates'
+import {
+  getCodexSessionBackfillDate,
+  getCodexSessionBackfillDatesBetween
+} from './codex-session-backfill-scan-dates'
 import type {
   CodexSessionBackfillDate,
   CodexSessionBackfillSummary
@@ -52,6 +55,14 @@ function writeFullBaseline(
       coveredScanDates: options.coveredScanDates ?? [],
       retainPendingScanDates: options.retain
     }
+  )
+}
+
+/** More dates than MAX_PENDING_SCAN_DATES, so the marker gives up on bounding. */
+function overflowingDates(): CodexSessionBackfillDate[] {
+  return getCodexSessionBackfillDatesBetween(
+    new Date(Date.UTC(2026, 6, 1)),
+    new Date(Date.UTC(2026, 7, 9))
   )
 }
 
@@ -175,17 +186,59 @@ describe('codex session backfill marker', () => {
     expect(readMarker()).toMatchObject({ launchActive: true, pendingScanDates: [LAUNCH_DATE] })
   })
 
+  it('settles every pending date once a full walk covers them', () => {
+    writeFullBaseline(WINDOWS_ROOT)
+    markCodexSessionBackfillMarkerPending(markerPath, WINDOWS_ROOT, [LAUNCH_DATE])
+
+    writeFullBaseline(WINDOWS_ROOT)
+
+    // The walk looked at every date, so nothing is left to revisit.
+    expect(readMarker()).toMatchObject({ pendingScanDates: [] })
+  })
+
   it('demands a full walk once the pending window outgrows its bound', () => {
     writeFullBaseline(WINDOWS_ROOT)
-    const manyDates = Array.from(
-      { length: 40 },
-      (_unused, index): CodexSessionBackfillDate => ['2026', '08', String(index).padStart(2, '0')]
-    )
 
-    markCodexSessionBackfillMarkerPending(markerPath, WINDOWS_ROOT, manyDates)
+    expect(
+      markCodexSessionBackfillMarkerPending(markerPath, WINDOWS_ROOT, overflowingDates())
+    ).toBe(true)
 
     expect(readMarker()).toMatchObject({ needsFullScan: true, pendingScanDates: [] })
     expect(hasCompletedCodexSessionBackfillMarker(markerPath, WINDOWS_ROOT)).toBe(false)
+  })
+
+  it('keeps owing that full walk when the next launch records its own date', () => {
+    writeFullBaseline(WINDOWS_ROOT)
+    markCodexSessionBackfillMarkerPending(markerPath, WINDOWS_ROOT, overflowingDates())
+
+    expect(markCodexSessionBackfillMarkerPending(markerPath, WINDOWS_ROOT, [TODAY])).toBe(true)
+
+    expect(readMarker()).toMatchObject({ needsFullScan: true, pendingScanDates: [] })
+    expect(hasCompletedCodexSessionBackfillMarker(markerPath, WINDOWS_ROOT)).toBe(false)
+  })
+
+  it('keeps the full-walk demand when a later launch overtook the walk', () => {
+    writeFullBaseline(WINDOWS_ROOT)
+    const staleGeneration = captureCodexSessionBackfillMarkerGeneration()
+    markCodexSessionBackfillMarkerPending(markerPath, WINDOWS_ROOT, overflowingDates())
+
+    writeCodexSessionBackfillMarker(markerPath, WINDOWS_ROOT, createSummary(), staleGeneration, {
+      coverage: 'full',
+      coveredScanDates: []
+    })
+
+    // The walk may have passed those dates before their rollouts existed.
+    expect(readMarker()).toMatchObject({ needsFullScan: true })
+  })
+
+  it('clears the full-walk demand only once a full walk certifies the tree', () => {
+    writeFullBaseline(WINDOWS_ROOT)
+    markCodexSessionBackfillMarkerPending(markerPath, WINDOWS_ROOT, overflowingDates())
+
+    writeFullBaseline(WINDOWS_ROOT)
+
+    expect(readMarker()).toMatchObject({ needsFullScan: false, pendingScanDates: [] })
+    expect(hasCompletedCodexSessionBackfillMarker(markerPath, WINDOWS_ROOT)).toBe(true)
   })
 
   it('persists a launch date even before any baseline exists', () => {

--- a/src/main/codex/codex-session-backfill-marker.ts
+++ b/src/main/codex/codex-session-backfill-marker.ts
@@ -1,91 +1,246 @@
 import { mkdirSync, readFileSync, rmSync } from 'node:fs'
 import { dirname } from 'node:path'
+import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
 import { writeFileAtomically } from '../codex-accounts/fs-utils'
-import type { CodexSessionBackfillSummary } from './codex-session-backfill-types'
+import {
+  expandCodexSessionBackfillDatesThroughToday,
+  getCodexSessionBackfillDate,
+  mergeCodexSessionBackfillDates,
+  parseCodexSessionBackfillDates,
+  subtractCodexSessionBackfillDates
+} from './codex-session-backfill-scan-dates'
+import type {
+  CodexSessionBackfillDate,
+  CodexSessionBackfillSummary
+} from './codex-session-backfill-types'
 
 // Why: bump to re-run the backfill for every host after a layout or semantics
 // change; the run itself stays skip-existing so re-runs never overwrite.
-const CODEX_SESSION_BACKFILL_MARKER_VERSION = 3
+const CODEX_SESSION_BACKFILL_MARKER_VERSION = 4
+// Why: v3 was only ever written after a certified full-tree walk, so it reads
+// as a v4 baseline and existing installs never pay one more full scan.
+const MARKER_BASELINE_VERSIONS: ReadonlySet<number> = new Set([3, 4])
+// Why: bounds abnormal-exit recovery; past this many dates a full walk is the
+// cheaper certainty.
+const MAX_PENDING_SCAN_DATES = 31
+
 let markerInvalidationGeneration = 0
+
+export type CodexSessionBackfillBaseline = {
+  /** Dates whose managed rollouts may not be published yet, widened through today. */
+  pendingScanDates: readonly CodexSessionBackfillDate[]
+}
 
 export function captureCodexSessionBackfillMarkerGeneration(): number {
   return markerInvalidationGeneration
+}
+
+/**
+ * Reads the certified full-history baseline for this target, if one exists.
+ *
+ * Null means no usable baseline, which is the only state that justifies a
+ * full-tree walk. A baseline with pending dates still needs a bounded pass.
+ */
+export function readCodexSessionBackfillBaseline(
+  markerPath: string,
+  systemSessionsRoot: string,
+  today: CodexSessionBackfillDate = getCodexSessionBackfillDate()
+): CodexSessionBackfillBaseline | null {
+  const record = readMarkerRecord(markerPath)
+  if (!record?.hasBaseline || !matchesTargetRoot(record, systemSessionsRoot)) {
+    return null
+  }
+  // Why: an empty source can become populated after an early migration run;
+  // let the incremental async walk verify it without blocking the main thread.
+  if (record.baselineScannedFiles === 0 || record.needsFullScan) {
+    return null
+  }
+  // Why: only a pane that was still running when the pass ended can have written
+  // dates nobody recorded — a pane held open across midnight, then force-quit.
+  const pendingScanDates = record.launchActive
+    ? expandCodexSessionBackfillDatesThroughToday(
+        record.pendingScanDates,
+        today,
+        MAX_PENDING_SCAN_DATES
+      )
+    : record.pendingScanDates
+  return pendingScanDates ? { pendingScanDates } : null
 }
 
 export function hasCompletedCodexSessionBackfillMarker(
   markerPath: string,
   systemSessionsRoot: string
 ): boolean {
-  try {
-    const parsed: unknown = JSON.parse(readFileSync(markerPath, 'utf-8'))
-    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      return false
-    }
-    const marker = parsed as {
-      version?: unknown
-      systemSessionsRoot?: unknown
-      summary?: { scannedFiles?: unknown }
-    }
-    // Why: changing the configured real Codex home must backfill the new
-    // target instead of honoring a marker written for a different history.
-    const markerMatchesTarget =
-      marker.version === CODEX_SESSION_BACKFILL_MARKER_VERSION &&
-      marker.systemSessionsRoot === systemSessionsRoot
-    if (!markerMatchesTarget) {
-      return false
-    }
-    // Why: an empty source can become populated after an early migration run;
-    // let the incremental async walk verify it without blocking the main thread.
-    return marker.summary?.scannedFiles !== 0
-  } catch {
-    return false
-  }
+  return readCodexSessionBackfillBaseline(markerPath, systemSessionsRoot) !== null
 }
 
 export function writeCodexSessionBackfillMarker(
   markerPath: string,
   systemSessionsRoot: string,
   summary: CodexSessionBackfillSummary,
-  expectedGeneration: number
+  expectedGeneration: number,
+  options: {
+    /** A full pass certifies the whole tree; a bounded one may only extend that. */
+    coverage: 'full' | 'bounded'
+    coveredScanDates: readonly CodexSessionBackfillDate[]
+    /** A live Codex pane keeps writing into its own date, so it stays pending. */
+    retainPendingScanDates?: boolean
+  }
 ): void {
-  // Why: a launch can invalidate this pass before its delayed replacement begins.
-  if (expectedGeneration !== markerInvalidationGeneration) {
+  const record = readMarkerRecord(markerPath)
+  const current = record && matchesTargetRoot(record, systemSessionsRoot) ? record : null
+  // Why: a date-limited pass cannot certify the dates it never looked at, so
+  // without an existing baseline it must publish nothing at all.
+  if (options.coverage !== 'full' && !current?.hasBaseline) {
     return
   }
-  mkdirSync(dirname(markerPath), { recursive: true })
-  writeFileAtomically(
-    markerPath,
-    `${JSON.stringify(
-      {
-        version: CODEX_SESSION_BACKFILL_MARKER_VERSION,
-        systemSessionsRoot,
-        completedAt: Date.now(),
-        summary
-      },
-      null,
-      2
-    )}\n`
-  )
+  // Why: a launch that began during this pass can have written rollouts the
+  // walk had already gone past, so its dates must survive as pending.
+  const clearCovered =
+    expectedGeneration === markerInvalidationGeneration && options.retainPendingScanDates !== true
+  const pendingScanDates = clearCovered
+    ? subtractCodexSessionBackfillDates(current?.pendingScanDates ?? [], options.coveredScanDates)
+    : mergeCodexSessionBackfillDates(current?.pendingScanDates, options.coveredScanDates)
+  writeMarkerRecord(markerPath, {
+    ...current?.raw,
+    version: CODEX_SESSION_BACKFILL_MARKER_VERSION,
+    systemSessionsRoot,
+    coverage: 'full',
+    completedAt: Date.now(),
+    launchActive: options.retainPendingScanDates === true,
+    // Why: only a full walk can speak for the whole tree, so a bounded pass
+    // that legitimately scanned nothing must not read back as an empty source.
+    baselineScannedFiles:
+      options.coverage === 'full' ? summary.scannedFiles : current?.baselineScannedFiles,
+    summary,
+    ...describePendingScanDates(pendingScanDates)
+  })
 }
 
-export function invalidateCodexSessionBackfillMarker(markerPath: string): void {
+/**
+ * Records dates a launch may still be writing into, keeping the baseline.
+ *
+ * Why not delete: the marker is the only record that the full history was ever
+ * published. Dropping it makes every launch re-walk the whole sessions tree.
+ */
+export function markCodexSessionBackfillMarkerPending(
+  markerPath: string,
+  systemSessionsRoot: string,
+  scanDates: readonly CodexSessionBackfillDate[]
+): void {
+  // Why: an older in-flight pass must not clear dates recorded after it started.
   markerInvalidationGeneration += 1
+  const record = readMarkerRecord(markerPath)
+  // Why: a marker for a different history says nothing about this target, and
+  // the pass that recertifies this one will replace it wholesale.
+  if (record && !matchesTargetRoot(record, systemSessionsRoot)) {
+    return
+  }
+  const pendingScanDates = mergeCodexSessionBackfillDates(record?.pendingScanDates, scanDates)
+  if (pendingScanDates.length === record?.pendingScanDates.length) {
+    return
+  }
   try {
-    // Why: a managed-lane system-default launch can create new source
-    // rollouts, so a prior one-time marker must not suppress the next opt-in.
-    rmSync(markerPath, { force: true })
+    writeMarkerRecord(markerPath, {
+      version: CODEX_SESSION_BACKFILL_MARKER_VERSION,
+      systemSessionsRoot,
+      coverage: 'bounded',
+      ...record?.raw,
+      ...describePendingScanDates(pendingScanDates)
+    })
   } catch (error) {
-    console.warn('[codex-session-backfill] Failed to invalidate completion marker:', error)
+    console.warn('[codex-session-backfill] Failed to record pending scan dates:', error)
     try {
-      writeFileAtomically(
-        markerPath,
-        `${JSON.stringify({ version: 0, invalidatedAt: Date.now() })}\n`
-      )
+      // Why: fail closed — a full rescan costs one slow pass, while a silently
+      // unrecorded launch date hides its rollouts forever.
+      rmSync(markerPath, { force: true })
     } catch (fallbackError) {
       throw new AggregateError(
         [error, fallbackError],
-        'Failed to invalidate Codex session backfill marker'
+        'Failed to record pending Codex session backfill scan dates'
       )
     }
   }
+}
+
+type CodexSessionBackfillMarkerRecord = {
+  raw: Record<string, unknown>
+  systemSessionsRoot: string
+  hasBaseline: boolean
+  pendingScanDates: CodexSessionBackfillDate[]
+  needsFullScan: boolean
+  launchActive: boolean
+  /** Files the last full-tree walk saw; a bounded pass must not overwrite it. */
+  baselineScannedFiles: number | undefined
+}
+
+function readMarkerRecord(markerPath: string): CodexSessionBackfillMarkerRecord | null {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(markerPath, 'utf-8'))
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null
+    }
+    const marker = parsed as {
+      version?: unknown
+      systemSessionsRoot?: unknown
+      coverage?: unknown
+      pendingScanDates?: unknown
+      needsFullScan?: unknown
+      launchActive?: unknown
+      baselineScannedFiles?: unknown
+      summary?: { scannedFiles?: unknown }
+    }
+    if (
+      typeof marker.version !== 'number' ||
+      !MARKER_BASELINE_VERSIONS.has(marker.version) ||
+      typeof marker.systemSessionsRoot !== 'string'
+    ) {
+      return null
+    }
+    return {
+      raw: parsed as Record<string, unknown>,
+      systemSessionsRoot: marker.systemSessionsRoot,
+      // v3 predates `coverage` and was only written after a full-tree walk.
+      hasBaseline: marker.version === 3 || marker.coverage === 'full',
+      pendingScanDates: parseCodexSessionBackfillDates(marker.pendingScanDates),
+      needsFullScan: marker.needsFullScan === true,
+      launchActive: marker.launchActive === true,
+      // v3 wrote only one summary, and it was always a full-tree one.
+      baselineScannedFiles: readOptionalCount(
+        marker.baselineScannedFiles ?? marker.summary?.scannedFiles
+      )
+    }
+  } catch {
+    return null
+  }
+}
+
+/** Why: changing the configured real Codex home must backfill the new target
+ * instead of honoring a marker written for a different history — and Windows
+ * spells one directory several ways, so compare normalized. */
+function matchesTargetRoot(
+  record: CodexSessionBackfillMarkerRecord,
+  systemSessionsRoot: string
+): boolean {
+  return (
+    normalizeRuntimePathForComparison(record.systemSessionsRoot) ===
+    normalizeRuntimePathForComparison(systemSessionsRoot)
+  )
+}
+
+function readOptionalCount(value: unknown): number | undefined {
+  return typeof value === 'number' ? value : undefined
+}
+
+function describePendingScanDates(
+  pendingScanDates: readonly CodexSessionBackfillDate[]
+): Record<string, unknown> {
+  return pendingScanDates.length > MAX_PENDING_SCAN_DATES
+    ? { pendingScanDates: [], needsFullScan: true }
+    : { pendingScanDates, needsFullScan: false }
+}
+
+function writeMarkerRecord(markerPath: string, record: Record<string, unknown>): void {
+  mkdirSync(dirname(markerPath), { recursive: true })
+  writeFileAtomically(markerPath, `${JSON.stringify(record, null, 2)}\n`)
 }

--- a/src/main/codex/codex-session-backfill-marker.ts
+++ b/src/main/codex/codex-session-backfill-marker.ts
@@ -96,15 +96,22 @@ export function writeCodexSessionBackfillMarker(
   }
   // Why: a launch that began during this pass can have written rollouts the
   // walk had already gone past, so its dates must survive as pending.
-  const clearCovered =
-    expectedGeneration === markerInvalidationGeneration && options.retainPendingScanDates !== true
+  const generationCurrent = expectedGeneration === markerInvalidationGeneration
+  const clearCovered = generationCurrent && options.retainPendingScanDates !== true
+  const currentPendingScanDates = current?.pendingScanDates ?? []
+  // Why: a full walk speaks for every date, so it settles the whole pending set
+  // rather than only the dates a bounded pass was asked to look at.
+  const coveredScanDates =
+    options.coverage === 'full' ? currentPendingScanDates : options.coveredScanDates
   const pendingScanDates = clearCovered
-    ? subtractCodexSessionBackfillDates(current?.pendingScanDates ?? [], options.coveredScanDates)
-    : mergeCodexSessionBackfillDates(current?.pendingScanDates, options.coveredScanDates)
+    ? subtractCodexSessionBackfillDates(currentPendingScanDates, coveredScanDates)
+    : mergeCodexSessionBackfillDates(currentPendingScanDates, options.coveredScanDates)
   writeMarkerRecord(markerPath, {
     ...current?.raw,
     version: CODEX_SESSION_BACKFILL_MARKER_VERSION,
     systemSessionsRoot,
+    // Why: only reached with a baseline in hand, so this records that a baseline
+    // exists, not the scope of this particular pass.
     coverage: 'full',
     completedAt: Date.now(),
     launchActive: options.retainPendingScanDates === true,
@@ -113,7 +120,11 @@ export function writeCodexSessionBackfillMarker(
     baselineScannedFiles:
       options.coverage === 'full' ? summary.scannedFiles : current?.baselineScannedFiles,
     summary,
-    ...describePendingScanDates(pendingScanDates)
+    // Why: only a full walk that no later launch overtook can retire the demand.
+    ...describePendingScanDates(
+      pendingScanDates,
+      current?.needsFullScan === true && !(generationCurrent && options.coverage === 'full')
+    )
   })
 }
 
@@ -122,31 +133,37 @@ export function writeCodexSessionBackfillMarker(
  *
  * Why not delete: the marker is the only record that the full history was ever
  * published. Dropping it makes every launch re-walk the whole sessions tree.
+ *
+ * Returns whether a full walk is still owed for this target, so the caller can
+ * fold that demand into its own in-memory state instead of losing it.
  */
 export function markCodexSessionBackfillMarkerPending(
   markerPath: string,
   systemSessionsRoot: string,
   scanDates: readonly CodexSessionBackfillDate[]
-): void {
+): boolean {
   // Why: an older in-flight pass must not clear dates recorded after it started.
   markerInvalidationGeneration += 1
   const record = readMarkerRecord(markerPath)
-  // Why: a marker for a different history says nothing about this target, and
-  // the pass that recertifies this one will replace it wholesale.
+  // Why: a marker for a different history says nothing about this target, so
+  // only a full walk can certify it.
   if (record && !matchesTargetRoot(record, systemSessionsRoot)) {
-    return
+    return true
   }
   const pendingScanDates = mergeCodexSessionBackfillDates(record?.pendingScanDates, scanDates)
+  const pending = describePendingScanDates(pendingScanDates, record?.needsFullScan === true)
   if (pendingScanDates.length === record?.pendingScanDates.length) {
-    return
+    return record.needsFullScan
   }
   try {
     writeMarkerRecord(markerPath, {
       version: CODEX_SESSION_BACKFILL_MARKER_VERSION,
       systemSessionsRoot,
       coverage: 'bounded',
+      // Why: defaults only — an existing record keeps its own version and
+      // coverage, which is what preserves a v3 marker's implicit baseline.
       ...record?.raw,
-      ...describePendingScanDates(pendingScanDates)
+      ...pending
     })
   } catch (error) {
     console.warn('[codex-session-backfill] Failed to record pending scan dates:', error)
@@ -160,7 +177,9 @@ export function markCodexSessionBackfillMarkerPending(
         'Failed to record pending Codex session backfill scan dates'
       )
     }
+    return true
   }
+  return pending.needsFullScan
 }
 
 type CodexSessionBackfillMarkerRecord = {
@@ -197,6 +216,7 @@ function readMarkerRecord(markerPath: string): CodexSessionBackfillMarkerRecord 
     ) {
       return null
     }
+    const baselineScannedFiles = marker.baselineScannedFiles ?? marker.summary?.scannedFiles
     return {
       raw: parsed as Record<string, unknown>,
       systemSessionsRoot: marker.systemSessionsRoot,
@@ -206,9 +226,8 @@ function readMarkerRecord(markerPath: string): CodexSessionBackfillMarkerRecord 
       needsFullScan: marker.needsFullScan === true,
       launchActive: marker.launchActive === true,
       // v3 wrote only one summary, and it was always a full-tree one.
-      baselineScannedFiles: readOptionalCount(
-        marker.baselineScannedFiles ?? marker.summary?.scannedFiles
-      )
+      baselineScannedFiles:
+        typeof baselineScannedFiles === 'number' ? baselineScannedFiles : undefined
     }
   } catch {
     return null
@@ -228,14 +247,13 @@ function matchesTargetRoot(
   )
 }
 
-function readOptionalCount(value: unknown): number | undefined {
-  return typeof value === 'number' ? value : undefined
-}
-
+/** Why: an unmet full-scan demand outlives the launch that raised it — only a
+ * full walk may clear it, or the overflowed dates are never revisited. */
 function describePendingScanDates(
-  pendingScanDates: readonly CodexSessionBackfillDate[]
-): Record<string, unknown> {
-  return pendingScanDates.length > MAX_PENDING_SCAN_DATES
+  pendingScanDates: readonly CodexSessionBackfillDate[],
+  stillOwesFullScan: boolean
+): { pendingScanDates: readonly CodexSessionBackfillDate[]; needsFullScan: boolean } {
+  return pendingScanDates.length > MAX_PENDING_SCAN_DATES || stillOwesFullScan
     ? { pendingScanDates: [], needsFullScan: true }
     : { pendingScanDates, needsFullScan: false }
 }

--- a/src/main/codex/codex-session-backfill-scan-dates.test.ts
+++ b/src/main/codex/codex-session-backfill-scan-dates.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import {
+  compareCodexSessionBackfillDates,
+  expandCodexSessionBackfillDatesThroughToday,
+  getCodexSessionBackfillDate,
+  getCodexSessionBackfillDatesBetween,
+  isCodexSessionBackfillDate,
+  mergeCodexSessionBackfillDates,
+  parseCodexSessionBackfillDates,
+  subtractCodexSessionBackfillDates
+} from './codex-session-backfill-scan-dates'
+
+describe('codex session backfill scan dates', () => {
+  it('reads UTC parts so a local evening never lands on the wrong directory', () => {
+    expect(getCodexSessionBackfillDate(new Date('2026-08-05T23:59:59Z'))).toEqual([
+      '2026',
+      '08',
+      '05'
+    ])
+    expect(getCodexSessionBackfillDate(new Date('2026-01-02T00:00:00Z'))).toEqual([
+      '2026',
+      '01',
+      '02'
+    ])
+  })
+
+  it('rejects anything that is not a zero-padded YYYY/MM/DD triple', () => {
+    expect(isCodexSessionBackfillDate(['2026', '08', '05'])).toBe(true)
+    expect(isCodexSessionBackfillDate(['2026', '8', '05'])).toBe(false)
+    expect(isCodexSessionBackfillDate(['2026', '08'])).toBe(false)
+    expect(isCodexSessionBackfillDate('2026-08-05')).toBe(false)
+  })
+
+  it('merges and subtracts date sets by identity, not by reference', () => {
+    const merged = mergeCodexSessionBackfillDates(
+      [
+        ['2026', '08', '06'],
+        ['2026', '08', '05']
+      ],
+      [['2026', '08', '06']],
+      undefined
+    )
+
+    expect(merged).toEqual([
+      ['2026', '08', '05'],
+      ['2026', '08', '06']
+    ])
+    expect(subtractCodexSessionBackfillDates(merged, [['2026', '08', '05']])).toEqual([
+      ['2026', '08', '06']
+    ])
+    expect(compareCodexSessionBackfillDates(merged[0], merged[1])).toBeLessThan(0)
+  })
+
+  it('discards unparseable persisted dates instead of scanning bogus roots', () => {
+    expect(parseCodexSessionBackfillDates([['2026', '08', '05'], 'nope', ['2026'], null])).toEqual([
+      ['2026', '08', '05']
+    ])
+    expect(parseCodexSessionBackfillDates('not an array')).toEqual([])
+  })
+
+  it('walks every date a launch could have spanned, including across a month end', () => {
+    expect(
+      getCodexSessionBackfillDatesBetween(
+        new Date('2026-07-31T23:00:00Z'),
+        new Date('2026-08-02T01:00:00Z')
+      )
+    ).toEqual([
+      ['2026', '07', '31'],
+      ['2026', '08', '01'],
+      ['2026', '08', '02']
+    ])
+  })
+
+  it('widens a pending set into the contiguous window that ends today', () => {
+    expect(
+      expandCodexSessionBackfillDatesThroughToday([['2026', '08', '05']], ['2026', '08', '07'], 31)
+    ).toEqual([
+      ['2026', '08', '05'],
+      ['2026', '08', '06'],
+      ['2026', '08', '07']
+    ])
+  })
+
+  it('leaves an empty pending set empty rather than inventing today', () => {
+    expect(expandCodexSessionBackfillDatesThroughToday([], ['2026', '08', '07'], 31)).toEqual([])
+  })
+
+  it('gives up on a window wider than the bound so a full walk can recertify', () => {
+    expect(
+      expandCodexSessionBackfillDatesThroughToday([['2026', '01', '01']], ['2026', '08', '07'], 31)
+    ).toBeNull()
+  })
+})

--- a/src/main/codex/codex-session-backfill-scan-dates.test.ts
+++ b/src/main/codex/codex-session-backfill-scan-dates.test.ts
@@ -31,6 +31,15 @@ describe('codex session backfill scan dates', () => {
     expect(isCodexSessionBackfillDate('2026-08-05')).toBe(false)
   })
 
+  it('rejects dates the calendar never produced', () => {
+    expect(isCodexSessionBackfillDate(['2026', '99', '99'])).toBe(false)
+    expect(isCodexSessionBackfillDate(['2026', '02', '30'])).toBe(false)
+    expect(isCodexSessionBackfillDate(['2025', '02', '29'])).toBe(false)
+    expect(isCodexSessionBackfillDate(['2026', '00', '10'])).toBe(false)
+    expect(isCodexSessionBackfillDate(['2024', '02', '29'])).toBe(true)
+    expect(isCodexSessionBackfillDate(['2026', '12', '31'])).toBe(true)
+  })
+
   it('merges and subtracts date sets by identity, not by reference', () => {
     const merged = mergeCodexSessionBackfillDates(
       [

--- a/src/main/codex/codex-session-backfill-scan-dates.ts
+++ b/src/main/codex/codex-session-backfill-scan-dates.ts
@@ -13,12 +13,17 @@ export function getCodexSessionBackfillDate(date = new Date()): CodexSessionBack
 }
 
 export function isCodexSessionBackfillDate(value: unknown): value is CodexSessionBackfillDate {
+  if (!Array.isArray(value) || value.length !== 3) {
+    return false
+  }
+  const key = value.join('-')
+  // Why: shape alone accepts directories the calendar never produces (2026/99/99
+  // from a corrupted marker, 2025/02/29); a UTC round-trip rejects them for free.
+  // Deliberately no age or future bound — this also gates which managed rollouts
+  // get published, and a clock-skewed future directory holds real sessions.
   return (
-    Array.isArray(value) &&
-    value.length === 3 &&
-    /^\d{4}$/.test(String(value[0])) &&
-    /^\d{2}$/.test(String(value[1])) &&
-    /^\d{2}$/.test(String(value[2]))
+    /^\d{4}-\d{2}-\d{2}$/.test(key) &&
+    toCodexSessionBackfillDateKey(getCodexSessionBackfillDate(toUtcDate(value))) === key
   )
 }
 
@@ -98,7 +103,7 @@ export function expandCodexSessionBackfillDatesThroughToday(
   return range.length > maxDates ? null : range
 }
 
-function toUtcDate([year, month, day]: CodexSessionBackfillDate): Date {
+function toUtcDate([year, month, day]: readonly string[]): Date {
   return new Date(Date.UTC(Number(year), Number(month) - 1, Number(day)))
 }
 

--- a/src/main/codex/codex-session-backfill-scan-dates.ts
+++ b/src/main/codex/codex-session-backfill-scan-dates.ts
@@ -1,0 +1,107 @@
+import type { CodexSessionBackfillDate } from './codex-session-backfill-types'
+
+// Set algebra over the UTC date directories that make up a bounded backfill
+// pass. Kept apart from the walk itself so the durable marker, the scheduler,
+// and the pass all agree on identity, ordering, and range expansion.
+
+export function getCodexSessionBackfillDate(date = new Date()): CodexSessionBackfillDate {
+  return [
+    String(date.getUTCFullYear()).padStart(4, '0'),
+    String(date.getUTCMonth() + 1).padStart(2, '0'),
+    String(date.getUTCDate()).padStart(2, '0')
+  ]
+}
+
+export function isCodexSessionBackfillDate(value: unknown): value is CodexSessionBackfillDate {
+  return (
+    Array.isArray(value) &&
+    value.length === 3 &&
+    /^\d{4}$/.test(String(value[0])) &&
+    /^\d{2}$/.test(String(value[1])) &&
+    /^\d{2}$/.test(String(value[2]))
+  )
+}
+
+export function toCodexSessionBackfillDateKey(date: CodexSessionBackfillDate): string {
+  return date.join('-')
+}
+
+export function compareCodexSessionBackfillDates(
+  left: CodexSessionBackfillDate,
+  right: CodexSessionBackfillDate
+): number {
+  return toCodexSessionBackfillDateKey(left).localeCompare(toCodexSessionBackfillDateKey(right))
+}
+
+/** Deduplicated ascending union; invalid entries are dropped. */
+export function mergeCodexSessionBackfillDates(
+  ...groups: readonly (readonly CodexSessionBackfillDate[] | undefined)[]
+): CodexSessionBackfillDate[] {
+  const merged = new Map<string, CodexSessionBackfillDate>()
+  for (const group of groups) {
+    for (const date of group ?? []) {
+      if (isCodexSessionBackfillDate(date)) {
+        merged.set(toCodexSessionBackfillDateKey(date), date)
+      }
+    }
+  }
+  return [...merged.values()].sort(compareCodexSessionBackfillDates)
+}
+
+export function subtractCodexSessionBackfillDates(
+  dates: readonly CodexSessionBackfillDate[],
+  removed: readonly CodexSessionBackfillDate[]
+): CodexSessionBackfillDate[] {
+  const removedKeys = new Set(removed.map(toCodexSessionBackfillDateKey))
+  return dates.filter((date) => !removedKeys.has(toCodexSessionBackfillDateKey(date)))
+}
+
+/** Reads persisted marker dates; anything unrecognized is discarded. */
+export function parseCodexSessionBackfillDates(value: unknown): CodexSessionBackfillDate[] {
+  return Array.isArray(value)
+    ? mergeCodexSessionBackfillDates(value.filter(isCodexSessionBackfillDate))
+    : []
+}
+
+export function getCodexSessionBackfillDatesBetween(
+  startedAt: Date,
+  finishedAt: Date
+): CodexSessionBackfillDate[] {
+  const dates: CodexSessionBackfillDate[] = []
+  const cursor = toUtcMidnight(startedAt)
+  const last = toUtcMidnight(finishedAt)
+  while (cursor <= last) {
+    dates.push(getCodexSessionBackfillDate(cursor))
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+  }
+  return dates
+}
+
+/**
+ * Widens a pending set into the contiguous range that ends at `today`.
+ *
+ * Why: an abnormal exit or a pane held open across midnight leaves activity on
+ * dates nobody got to record. The gap between the oldest pending date and today
+ * is the smallest window that provably contains them. Returns null once that
+ * window outgrows `maxDates`, where a full walk is the cheaper certainty.
+ */
+export function expandCodexSessionBackfillDatesThroughToday(
+  dates: readonly CodexSessionBackfillDate[],
+  today: CodexSessionBackfillDate,
+  maxDates: number
+): CodexSessionBackfillDate[] | null {
+  if (dates.length === 0) {
+    return []
+  }
+  const bounds = mergeCodexSessionBackfillDates(dates, [today])
+  const range = getCodexSessionBackfillDatesBetween(toUtcDate(bounds[0]), toUtcDate(bounds.at(-1)!))
+  return range.length > maxDates ? null : range
+}
+
+function toUtcDate([year, month, day]: CodexSessionBackfillDate): Date {
+  return new Date(Date.UTC(Number(year), Number(month) - 1, Number(day)))
+}
+
+function toUtcMidnight(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()))
+}

--- a/src/main/codex/codex-session-backfill-types.ts
+++ b/src/main/codex/codex-session-backfill-types.ts
@@ -26,12 +26,12 @@ export type CodexSessionBackfillOptions = CodexSessionBridgeIncrementalOptions &
   shouldStop?: () => boolean
   /** Limits a launch-triggered pass to the date directories that can contain its rollouts. */
   scanDates?: readonly CodexSessionBackfillDate[]
-  /** A scheduled launch pass must not be suppressed by a marker it just invalidated. */
+  /** Forces recertification of the whole tree, ignoring any existing baseline. */
+  fullScanRequired?: boolean
+  /** A scheduled launch pass runs even when the baseline reports nothing pending. */
   ignoreCompletionMarker?: boolean
-  /** Active launch passes defer global completion until their final exit scan. */
-  writeCompletionMarker?: boolean
-  /** Final launch scans can extend a previously certified full-tree baseline. */
-  writeBoundedCompletionMarker?: boolean
+  /** A live Codex pane keeps writing into its own date, so it stays pending. */
+  retainPendingScanDates?: boolean
   /** Rechecks launch scheduling state immediately before marker publication. */
   canWriteCompletionMarker?: () => boolean
 }

--- a/src/main/codex/codex-session-backfill.test.ts
+++ b/src/main/codex/codex-session-backfill.test.ts
@@ -487,6 +487,8 @@ describe('startCodexSessionBackfillInBackground', () => {
   it('scans only the current date once a baseline exists', async () => {
     writeManagedSession(join('2026', '05', '26', 'rollout-a.jsonl'), '{"id":"a"}\n')
     await startCodexSessionBackfillInBackground()
+    // A second date directory: a full walk would report two scanned files.
+    writeManagedSession(join('2026', '06', '02', 'rollout-other.jsonl'), '{"id":"other"}\n')
     markLaunchPending()
 
     const scanned = await startCodexSessionBackfillInBackground({

--- a/src/main/codex/codex-session-backfill.test.ts
+++ b/src/main/codex/codex-session-backfill.test.ts
@@ -21,129 +21,16 @@ const { homedirMock } = vi.hoisted(() => ({
   homedirMock: vi.fn<() => string>()
 }))
 
-const { fsMockState } = vi.hoisted(() => ({
-  fsMockState: {
-    failLink: false,
-    failLinkTransiently: false,
-    failLinkPermission: false,
-    raceTargetIntoExistence: false,
-    failMarkerRm: false,
-    failMarkerReplacement: false,
-    failAuditMkdirOnce: false,
-    failAuditWrites: false,
-    failMkdirPath: null as string | null,
-    failDirectoryPath: null as string | null,
-    failLstatPath: null as string | null
-  }
-}))
-
 vi.mock('node:fs', async () => {
-  const actual = await vi.importActual<typeof NodeFs>('node:fs')
-  return {
-    ...actual,
-    existsSync: (...args: Parameters<typeof actual.existsSync>) => {
-      if (args[0] === fsMockState.failLstatPath) {
-        return false
-      }
-      return actual.existsSync(...args)
-    },
-    rmSync: (...args: Parameters<typeof actual.rmSync>) => {
-      if (
-        fsMockState.failMarkerRm &&
-        String(args[0]).includes('codex-session-backfill') &&
-        String(args[0]).endsWith('backfill-complete.json')
-      ) {
-        const error = new Error('EACCES: marker removal failed') as NodeJS.ErrnoException
-        error.code = 'EACCES'
-        throw error
-      }
-      return actual.rmSync(...args)
-    },
-    renameSync: (...args: Parameters<typeof actual.renameSync>) => {
-      if (
-        fsMockState.failMarkerReplacement &&
-        String(args[1]).includes('codex-session-backfill') &&
-        String(args[1]).endsWith('backfill-complete.json')
-      ) {
-        const error = new Error('EACCES: marker replacement failed') as NodeJS.ErrnoException
-        error.code = 'EACCES'
-        throw error
-      }
-      return actual.renameSync(...args)
-    }
-  }
+  const mocks = await import('./codex-session-backfill-fs-mocks')
+  return mocks.createNodeFsMock(await vi.importActual<typeof NodeFs>('node:fs'))
 })
 
 vi.mock('node:fs/promises', async () => {
-  const actual = await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
-  return {
-    ...actual,
-    mkdir: (...args: Parameters<typeof actual.mkdir>) => {
-      if (args[0] === fsMockState.failMkdirPath) {
-        const error = new Error('EACCES: target directory inaccessible') as NodeJS.ErrnoException
-        error.code = 'EACCES'
-        throw error
-      }
-      if (fsMockState.failAuditMkdirOnce && String(args[0]).includes('codex-session-backfill')) {
-        fsMockState.failAuditMkdirOnce = false
-        const error = new Error(
-          'EACCES: transient audit directory failure'
-        ) as NodeJS.ErrnoException
-        error.code = 'EACCES'
-        throw error
-      }
-      return actual.mkdir(...args)
-    },
-    appendFile: (...args: Parameters<typeof actual.appendFile>) => {
-      if (fsMockState.failAuditWrites && String(args[0]).includes('codex-session-backfill')) {
-        const error = new Error('ENOSPC: audit write failed') as NodeJS.ErrnoException
-        error.code = 'ENOSPC'
-        throw error
-      }
-      return actual.appendFile(...args)
-    },
-    lstat: (...args: Parameters<typeof actual.lstat>) => {
-      if (args[0] === fsMockState.failLstatPath) {
-        const error = new Error('EACCES: path inaccessible') as NodeJS.ErrnoException
-        error.code = 'EACCES'
-        throw error
-      }
-      return actual.lstat(...args)
-    },
-    link: async (...args: Parameters<typeof actual.link>) => {
-      if (fsMockState.raceTargetIntoExistence && String(args[0]).includes('codex-runtime-home')) {
-        fsMockState.raceTargetIntoExistence = false
-        await actual.writeFile(args[1], 'concurrent target\n', 'utf-8')
-        const error = new Error('EEXIST: concurrent target') as NodeJS.ErrnoException
-        error.code = 'EEXIST'
-        throw error
-      }
-      if (fsMockState.failLink && String(args[0]).includes('codex-runtime-home')) {
-        const error = new Error('EXDEV: cross-device link') as NodeJS.ErrnoException
-        error.code = 'EXDEV'
-        throw error
-      }
-      if (fsMockState.failLinkTransiently && String(args[0]).includes('codex-runtime-home')) {
-        const error = new Error('EIO: transient hardlink failure') as NodeJS.ErrnoException
-        error.code = 'EIO'
-        throw error
-      }
-      if (fsMockState.failLinkPermission && String(args[0]).includes('codex-runtime-home')) {
-        const error = new Error('EACCES: hardlink permission denied') as NodeJS.ErrnoException
-        error.code = 'EACCES'
-        throw error
-      }
-      return actual.link(...args)
-    },
-    opendir: (...args: Parameters<typeof actual.opendir>) => {
-      if (args[0] === fsMockState.failDirectoryPath) {
-        const error = new Error('EACCES: directory unreadable') as NodeJS.ErrnoException
-        error.code = 'EACCES'
-        throw error
-      }
-      return actual.opendir(...args)
-    }
-  }
+  const mocks = await import('./codex-session-backfill-fs-mocks')
+  return mocks.createNodeFsPromisesMock(
+    await vi.importActual<typeof NodeFsPromises>('node:fs/promises')
+  )
 })
 
 vi.mock('node:os', async () => {
@@ -159,7 +46,15 @@ import {
   resolveCodexSessionBackfillPaths,
   startCodexSessionBackfillInBackground
 } from './codex-session-backfill'
-import { invalidateCodexSessionBackfillMarker } from './codex-session-backfill-marker'
+import {
+  markCodexSessionBackfillMarkerPending,
+  readCodexSessionBackfillBaseline
+} from './codex-session-backfill-marker'
+import { fsMockState, resetCodexSessionBackfillFsMocks } from './codex-session-backfill-fs-mocks'
+import { getCodexSessionBackfillDate } from './codex-session-backfill-scan-dates'
+import type { CodexSessionBackfillDate } from './codex-session-backfill-types'
+
+const FIXTURE_LAUNCH_DATE: CodexSessionBackfillDate = ['2026', '05', '26']
 
 let fakeHomeDir: string
 let userDataDir: string
@@ -212,18 +107,21 @@ function readAuditActions(): string[] {
   return readBackfillAuditRecords().map((record) => record.action)
 }
 
+/** Stands in for a Codex pane launch: records its date without dropping the baseline. */
+function markLaunchPending(...scanDates: CodexSessionBackfillDate[]): void {
+  markCodexSessionBackfillMarkerPending(
+    getMarkerPath(),
+    getSystemSessionsRoot(),
+    scanDates.length > 0 ? scanDates : [FIXTURE_LAUNCH_DATE]
+  )
+}
+
+function readMarker(): Record<string, unknown> {
+  return JSON.parse(readFileSync(getMarkerPath(), 'utf-8')) as Record<string, unknown>
+}
+
 beforeEach(() => {
-  fsMockState.failLink = false
-  fsMockState.failLinkTransiently = false
-  fsMockState.failLinkPermission = false
-  fsMockState.raceTargetIntoExistence = false
-  fsMockState.failMarkerRm = false
-  fsMockState.failMarkerReplacement = false
-  fsMockState.failAuditMkdirOnce = false
-  fsMockState.failAuditWrites = false
-  fsMockState.failMkdirPath = null
-  fsMockState.failDirectoryPath = null
-  fsMockState.failLstatPath = null
+  resetCodexSessionBackfillFsMocks()
   fakeHomeDir = mkdtempSync(join(tmpdir(), 'orca-codex-backfill-home-'))
   userDataDir = mkdtempSync(join(tmpdir(), 'orca-codex-backfill-user-data-'))
   previousUserDataPath = process.env.ORCA_USER_DATA_PATH
@@ -557,18 +455,46 @@ describe('startCodexSessionBackfillInBackground', () => {
     expect(existsSync(getMarkerPath())).toBe(false)
   })
 
-  it('defers completion while a launch lease is active', async () => {
-    writeManagedSession(join('2026', '05', '26', 'rollout-a.jsonl'), '{"id":"a"}\n')
+  it('certifies the historical baseline while a launch lease is still active', async () => {
+    const today = getCodexSessionBackfillDate()
+    writeManagedSession(join('2026', '05', '26', 'rollout-history.jsonl'), 'history\n')
+    writeManagedSession(join(...today, 'rollout-live.jsonl'), 'live\n')
+    markLaunchPending(today)
 
     const active = await startCodexSessionBackfillInBackground({
-      writeCompletionMarker: false
+      ignoreCompletionMarker: true,
+      retainPendingScanDates: true
     })
-    expect(active).toMatchObject({ linkedFiles: 1 })
-    expect(existsSync(getMarkerPath())).toBe(false)
+
+    expect(active).toMatchObject({ scannedFiles: 2, linkedFiles: 2 })
+    // The baseline is certified despite the open pane; only its date stays pending.
+    expect(readMarker()).toMatchObject({
+      version: 4,
+      coverage: 'full',
+      launchActive: true,
+      pendingScanDates: [today]
+    })
+    expect(readCodexSessionBackfillBaseline(getMarkerPath(), getSystemSessionsRoot())).toEqual({
+      pendingScanDates: [today]
+    })
 
     const completed = await startCodexSessionBackfillInBackground()
-    expect(completed).toMatchObject({ skippedExistingFiles: 1 })
-    expect(existsSync(getMarkerPath())).toBe(true)
+    expect(completed).toMatchObject({ scannedFiles: 1, skippedExistingFiles: 1 })
+    expect(readMarker()).toMatchObject({ pendingScanDates: [], launchActive: false })
+    expect(await startCodexSessionBackfillInBackground()).toBeNull()
+  })
+
+  it('scans only the current date once a baseline exists', async () => {
+    writeManagedSession(join('2026', '05', '26', 'rollout-a.jsonl'), '{"id":"a"}\n')
+    await startCodexSessionBackfillInBackground()
+    markLaunchPending()
+
+    const scanned = await startCodexSessionBackfillInBackground({
+      ignoreCompletionMarker: true
+    })
+
+    // No scanDates were requested, so only the recorded pending date is walked.
+    expect(scanned).toMatchObject({ scannedFiles: 1, skippedExistingFiles: 1 })
   })
 
   it('rechecks launch state before publishing completion', async () => {
@@ -582,54 +508,93 @@ describe('startCodexSessionBackfillInBackground', () => {
     expect(existsSync(getMarkerPath())).toBe(false)
   })
 
-  it('keeps an invalidated active pass from recreating the completion marker', async () => {
+  it('keeps a racing launch date pending without discarding the baseline', async () => {
     writeManagedSession(join('2026', '05', '26', 'rollout-a.jsonl'), '{"id":"a"}\n')
-    let invalidated = false
+    let raceStarted = false
 
     const raced = await startCodexSessionBackfillInBackground({
       shouldStop: () => {
-        if (!invalidated) {
-          invalidated = true
-          invalidateCodexSessionBackfillMarker(getMarkerPath())
+        if (!raceStarted) {
+          raceStarted = true
+          markLaunchPending(['2026', '08', '05'])
         }
         return false
       }
     })
 
     expect(raced).toMatchObject({ linkedFiles: 1, stopped: false })
-    expect(existsSync(getMarkerPath())).toBe(false)
+    // The full walk still certifies history, but the racing launch's date stays pending.
+    expect(readMarker()).toMatchObject({
+      version: 4,
+      coverage: 'full',
+      pendingScanDates: [['2026', '08', '05']]
+    })
     const racedAudit = readFileSync(getAuditLogPath(), 'utf-8')
 
+    writeManagedSession(join('2026', '08', '05', 'rollout-raced.jsonl'), '{"id":"raced"}\n')
     const recovered = await startCodexSessionBackfillInBackground()
 
-    expect(recovered).toMatchObject({ skippedExistingFiles: 1, failedHealAuditRecords: 0 })
-    expect(existsSync(getMarkerPath())).toBe(true)
-    expect(readFileSync(getAuditLogPath(), 'utf-8')).toBe(racedAudit)
+    expect(recovered).toMatchObject({ scannedFiles: 1, linkedFiles: 1 })
+    expect(readMarker()).toMatchObject({ pendingScanDates: [] })
+    expect(readFileSync(getAuditLogPath(), 'utf-8')).not.toBe(racedAudit)
   })
 
-  it('replaces a stale marker when direct removal fails', async () => {
+  it('falls back to a full rescan when the pending rewrite fails', async () => {
     writeManagedSession(join('2026', '05', '26', 'rollout-a.jsonl'), '{"id":"a"}\n')
     await startCodexSessionBackfillInBackground()
-    fsMockState.failMarkerRm = true
+    fsMockState.failMarkerReplacement = true
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    invalidateCodexSessionBackfillMarker(getMarkerPath())
+    markLaunchPending(['2026', '08', '05'])
 
-    expect(JSON.parse(readFileSync(getMarkerPath(), 'utf-8'))).toMatchObject({ version: 0 })
+    // Fail closed: no marker at all beats a marker missing the launch's date.
+    expect(existsSync(getMarkerPath())).toBe(false)
+    fsMockState.failMarkerReplacement = false
     const recovered = await startCodexSessionBackfillInBackground()
     expect(recovered).toMatchObject({ skippedExistingFiles: 1 })
-    expect(JSON.parse(readFileSync(getMarkerPath(), 'utf-8'))).toMatchObject({ version: 3 })
+    expect(readMarker()).toMatchObject({ version: 4, coverage: 'full' })
+    expect(warnSpy).toHaveBeenCalled()
+    warnSpy.mockRestore()
   })
 
-  it('fails launch preparation when a stale marker cannot be invalidated', async () => {
+  it('fails launch preparation when the baseline can neither be updated nor cleared', async () => {
     writeManagedSession(join('2026', '05', '26', 'rollout-a.jsonl'), '{"id":"a"}\n')
     await startCodexSessionBackfillInBackground()
     fsMockState.failMarkerRm = true
     fsMockState.failMarkerReplacement = true
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
-    expect(() => invalidateCodexSessionBackfillMarker(getMarkerPath())).toThrow(
-      'Failed to invalidate Codex session backfill marker'
+    expect(() => markLaunchPending(['2026', '08', '05'])).toThrow(
+      'Failed to record pending Codex session backfill scan dates'
     )
-    expect(JSON.parse(readFileSync(getMarkerPath(), 'utf-8'))).toMatchObject({ version: 3 })
+    expect(readMarker()).toMatchObject({ version: 4 })
+    warnSpy.mockRestore()
+  })
+
+  it('reads a legacy v3 marker as a certified baseline', async () => {
+    writeManagedSession(join('2026', '05', '26', 'rollout-a.jsonl'), '{"id":"a"}\n')
+    mkdirSync(dirname(getMarkerPath()), { recursive: true })
+    writeFileSync(
+      getMarkerPath(),
+      `${JSON.stringify({
+        version: 3,
+        systemSessionsRoot: getSystemSessionsRoot(),
+        completedAt: Date.now(),
+        summary: { scannedFiles: 1 }
+      })}\n`,
+      'utf-8'
+    )
+
+    // No full walk on upgrade: the v3 baseline is honored as-is.
+    expect(await startCodexSessionBackfillInBackground()).toBeNull()
+    expect(existsSync(join(getSystemSessionsRoot(), '2026', '05', '26', 'rollout-a.jsonl'))).toBe(
+      false
+    )
+
+    markLaunchPending()
+    const bounded = await startCodexSessionBackfillInBackground()
+    expect(bounded).toMatchObject({ scannedFiles: 1, linkedFiles: 1 })
+    expect(readMarker()).toMatchObject({ version: 4, coverage: 'full' })
   })
 
   it('writes a completion marker and skips the walk on later runs', async () => {
@@ -638,7 +603,7 @@ describe('startCodexSessionBackfillInBackground', () => {
     const first = await startCodexSessionBackfillInBackground()
     expect(first).toMatchObject({ linkedFiles: 1, failedFiles: 0 })
     expect(existsSync(getMarkerPath())).toBe(true)
-    expect(JSON.parse(readFileSync(getMarkerPath(), 'utf-8'))).toMatchObject({ version: 3 })
+    expect(readMarker()).toMatchObject({ version: 4, coverage: 'full' })
 
     // An ordinary call remains a no-op; only a launch-scheduled pass bypasses the marker.
     writeManagedSession(join('2026', '07', '01', 'rollout-later.jsonl'), '{"id":"later"}\n')
@@ -655,11 +620,7 @@ describe('startCodexSessionBackfillInBackground', () => {
     expect(scheduled).toMatchObject({ scannedFiles: 1, linkedFiles: 1 })
   })
 
-  it('does not let a bounded pass certify older unscanned history', async () => {
-    writeManagedSession(join('2026', '05', '26', 'rollout-baseline.jsonl'), 'baseline\n')
-    await startCodexSessionBackfillInBackground()
-
-    invalidateCodexSessionBackfillMarker(getMarkerPath())
+  it('does not let a bounded pass certify history no baseline ever covered', async () => {
     const missedRelativePath = join('2026', '06', '01', 'rollout-missed.jsonl')
     writeManagedSession(missedRelativePath, 'missed\n')
     writeManagedSession(join('2026', '08', '05', 'rollout-launch.jsonl'), 'launch\n')
@@ -672,26 +633,61 @@ describe('startCodexSessionBackfillInBackground', () => {
     expect(existsSync(getMarkerPath())).toBe(false)
 
     const recovered = await startCodexSessionBackfillInBackground()
-    expect(recovered).toMatchObject({ scannedFiles: 3, linkedFiles: 1 })
+    expect(recovered).toMatchObject({ scannedFiles: 2, linkedFiles: 1 })
     expect(existsSync(join(getSystemSessionsRoot(), missedRelativePath))).toBe(true)
-    expect(existsSync(getMarkerPath())).toBe(true)
+    expect(readMarker()).toMatchObject({ version: 4, coverage: 'full' })
   })
 
-  it('lets an explicit bounded final pass restore a certified baseline', async () => {
+  it('lets a bounded launch pass extend a certified baseline', async () => {
     writeManagedSession(join('2026', '05', '26', 'rollout-baseline.jsonl'), 'baseline\n')
     await startCodexSessionBackfillInBackground()
 
-    invalidateCodexSessionBackfillMarker(getMarkerPath())
+    markLaunchPending(['2026', '08', '05'])
     writeManagedSession(join('2026', '08', '05', 'rollout-launch.jsonl'), 'launch\n')
 
     const bounded = await startCodexSessionBackfillInBackground({
       ignoreCompletionMarker: true,
-      scanDates: [['2026', '08', '05']],
-      writeBoundedCompletionMarker: true
+      scanDates: [['2026', '08', '05']]
     })
 
     expect(bounded).toMatchObject({ scannedFiles: 1, linkedFiles: 1 })
-    expect(existsSync(getMarkerPath())).toBe(true)
+    expect(readMarker()).toMatchObject({ coverage: 'full', pendingScanDates: [] })
+    expect(await startCodexSessionBackfillInBackground()).toBeNull()
+  })
+
+  it('recovers a bounded window after an abnormal exit instead of a full walk', async () => {
+    writeManagedSession(join('2026', '05', '26', 'rollout-baseline.jsonl'), 'baseline\n')
+    await startCodexSessionBackfillInBackground()
+
+    // A launch records its date, then the app dies before any pass runs.
+    markLaunchPending(['2026', '08', '05'])
+    writeManagedSession(join('2026', '06', '01', 'rollout-untouched.jsonl'), 'untouched\n')
+    writeManagedSession(join('2026', '08', '05', 'rollout-launch.jsonl'), 'launch\n')
+
+    const recovered = await startCodexSessionBackfillInBackground()
+
+    expect(recovered).toMatchObject({ scannedFiles: 1, linkedFiles: 1 })
+    expect(
+      existsSync(join(getSystemSessionsRoot(), '2026', '08', '05', 'rollout-launch.jsonl'))
+    ).toBe(true)
+  })
+
+  it('widens recovery across midnight when a pane was still live', async () => {
+    writeManagedSession(join('2026', '05', '26', 'rollout-baseline.jsonl'), 'baseline\n')
+    await startCodexSessionBackfillInBackground()
+    const launchDate = getCodexSessionBackfillDate(new Date(Date.now() - 2 * 24 * 60 * 60 * 1000))
+    await startCodexSessionBackfillInBackground({
+      scanDates: [launchDate],
+      ignoreCompletionMarker: true,
+      retainPendingScanDates: true
+    })
+
+    const baseline = readCodexSessionBackfillBaseline(getMarkerPath(), getSystemSessionsRoot())
+
+    // The pane could have written on every date from its launch through today.
+    expect(baseline?.pendingScanDates).toHaveLength(3)
+    expect(baseline?.pendingScanDates.at(0)).toEqual(launchDate)
+    expect(baseline?.pendingScanDates.at(-1)).toEqual(getCodexSessionBackfillDate())
   })
 
   it('records a new heal event when a linked rollout grows in place', async () => {
@@ -700,7 +696,7 @@ describe('startCodexSessionBackfillInBackground', () => {
     await startCodexSessionBackfillInBackground()
 
     const firstRecord = readBackfillAuditRecords().find((record) => record.action === 'hardlink')
-    invalidateCodexSessionBackfillMarker(getMarkerPath())
+    markLaunchPending()
     appendFileSync(managedPath, '{"event":"later"}\n', 'utf-8')
     await startCodexSessionBackfillInBackground()
 
@@ -720,7 +716,7 @@ describe('startCodexSessionBackfillInBackground', () => {
     const firstAudit = readFileSync(getAuditLogPath(), 'utf-8')
 
     for (let pass = 0; pass < 2; pass += 1) {
-      invalidateCodexSessionBackfillMarker(getMarkerPath())
+      markLaunchPending()
       const repeated = await startCodexSessionBackfillInBackground()
       expect(repeated).toMatchObject({
         linkedFiles: 0,
@@ -745,14 +741,15 @@ describe('startCodexSessionBackfillInBackground', () => {
     writeManagedSession(firstRelativePath, '{"id":"a"}\n')
     await startCodexSessionBackfillInBackground()
 
-    invalidateCodexSessionBackfillMarker(getMarkerPath())
+    markLaunchPending()
     writeManagedSession(secondRelativePath, '{"id":"b"}\n')
     fsMockState.failAuditWrites = true
 
     const interrupted = await startCodexSessionBackfillInBackground()
 
     expect(interrupted).toMatchObject({ linkedFiles: 1, failedHealAuditRecords: 1 })
-    expect(existsSync(getMarkerPath())).toBe(false)
+    // The failed pass certifies nothing, so its date stays queued for the retry.
+    expect(readMarker()).toMatchObject({ pendingScanDates: [FIXTURE_LAUNCH_DATE] })
     expect(
       readBackfillAuditRecords().filter((record) =>
         ['hardlink', 'copy', 'existing'].includes(record.action)
@@ -810,7 +807,7 @@ describe('startCodexSessionBackfillInBackground', () => {
     rmSync(getMarkerPath(), { recursive: true })
     const resumed = await startCodexSessionBackfillInBackground()
     expect(resumed).toMatchObject({ skippedExistingFiles: 1, failedHealAuditRecords: 0 })
-    expect(JSON.parse(readFileSync(getMarkerPath(), 'utf-8'))).toMatchObject({ version: 3 })
+    expect(readMarker()).toMatchObject({ version: 4 })
     expect(warnSpy).toHaveBeenCalled()
     warnSpy.mockRestore()
   })
@@ -841,7 +838,7 @@ describe('startCodexSessionBackfillInBackground', () => {
     expect(existsSync(getMarkerPath())).toBe(true)
 
     const firstAudit = readFileSync(getAuditLogPath(), 'utf-8')
-    invalidateCodexSessionBackfillMarker(getMarkerPath())
+    markLaunchPending()
     const repeated = await startCodexSessionBackfillInBackground()
 
     expect(repeated).toMatchObject({ skippedUnsupportedFilesystemFiles: 1, failedFiles: 0 })

--- a/src/main/codex/codex-session-backfill.ts
+++ b/src/main/codex/codex-session-backfill.ts
@@ -134,8 +134,11 @@ function resolveCodexSessionBackfillScanPlan(
   options: CodexSessionBackfillOptions
 ): { scanDates?: readonly CodexSessionBackfillDate[] } | null {
   const requestedScanDates = options.scanDates?.length ? options.scanDates : undefined
-  if (options.fullScanRequired || !baseline) {
-    return { scanDates: options.fullScanRequired ? undefined : requestedScanDates }
+  if (options.fullScanRequired) {
+    return {}
+  }
+  if (!baseline) {
+    return { scanDates: requestedScanDates }
   }
   const scanDates = mergeCodexSessionBackfillDates(baseline.pendingScanDates, requestedScanDates)
   if (scanDates.length > 0) {

--- a/src/main/codex/codex-session-backfill.ts
+++ b/src/main/codex/codex-session-backfill.ts
@@ -17,10 +17,16 @@ import {
 } from './codex-session-backfill-date'
 import {
   captureCodexSessionBackfillMarkerGeneration,
-  hasCompletedCodexSessionBackfillMarker,
-  writeCodexSessionBackfillMarker as writeBackfillMarker
+  readCodexSessionBackfillBaseline,
+  writeCodexSessionBackfillMarker as writeBackfillMarker,
+  type CodexSessionBackfillBaseline
 } from './codex-session-backfill-marker'
+import {
+  getCodexSessionBackfillDate,
+  mergeCodexSessionBackfillDates
+} from './codex-session-backfill-scan-dates'
 import type {
+  CodexSessionBackfillDate,
   CodexSessionBackfillOptions,
   CodexSessionBackfillPaths,
   CodexSessionBackfillSummary
@@ -88,28 +94,56 @@ async function runCodexSessionBackfillOncePerHost(
 ): Promise<CodexSessionBackfillSummary | null> {
   const paths = resolveCodexSessionBackfillPaths(systemCodexHomePathOverride)
   const markerGeneration = captureCodexSessionBackfillMarkerGeneration()
-  if (
-    !options.ignoreCompletionMarker &&
-    hasCompletedCodexSessionBackfillMarker(paths.markerPath, paths.systemSessionsRoot)
-  ) {
+  const baseline = readCodexSessionBackfillBaseline(paths.markerPath, paths.systemSessionsRoot)
+  const scanPlan = resolveCodexSessionBackfillScanPlan(baseline, options)
+  if (!scanPlan) {
     return null
   }
-  const summary = await backfillManagedCodexSessionsIntoSystemHome(paths, options)
-  // Why: file or heal-queue failures leave the marker unset so the next
+  const summary = await backfillManagedCodexSessionsIntoSystemHome(paths, {
+    ...options,
+    scanDates: scanPlan.scanDates
+  })
+  // Why: file or heal-queue failures leave the pass uncertified so the next
   // startup retries; skip-existing keeps those retries cheap.
   if (
     !summary.stopped &&
     options.shouldStop?.() !== true &&
-    options.writeCompletionMarker !== false &&
     options.canWriteCompletionMarker?.() !== false &&
-    (options.scanDates === undefined || options.writeBoundedCompletionMarker === true) &&
     summary.failedFiles === 0 &&
     summary.failedDirectories === 0 &&
     summary.failedHealAuditRecords === 0
   ) {
-    writeBackfillMarker(paths.markerPath, paths.systemSessionsRoot, summary, markerGeneration)
+    writeBackfillMarker(paths.markerPath, paths.systemSessionsRoot, summary, markerGeneration, {
+      coverage: scanPlan.scanDates ? 'bounded' : 'full',
+      coveredScanDates: scanPlan.scanDates ?? [],
+      retainPendingScanDates: options.retainPendingScanDates === true
+    })
   }
   return summary
+}
+
+/**
+ * Decides how much of the sessions tree this pass must walk.
+ *
+ * Null means the baseline already covers everything and there is nothing
+ * pending; an absent `scanDates` means a full walk, which is only ever needed
+ * when no certified baseline exists (or the caller demands recertification).
+ */
+function resolveCodexSessionBackfillScanPlan(
+  baseline: CodexSessionBackfillBaseline | null,
+  options: CodexSessionBackfillOptions
+): { scanDates?: readonly CodexSessionBackfillDate[] } | null {
+  const requestedScanDates = options.scanDates?.length ? options.scanDates : undefined
+  if (options.fullScanRequired || !baseline) {
+    return { scanDates: options.fullScanRequired ? undefined : requestedScanDates }
+  }
+  const scanDates = mergeCodexSessionBackfillDates(baseline.pendingScanDates, requestedScanDates)
+  if (scanDates.length > 0) {
+    return { scanDates }
+  }
+  // Why: a launch-scheduled pass exists to publish rollouts the running pane is
+  // creating right now, so with a baseline in hand the current date is enough.
+  return options.ignoreCompletionMarker ? { scanDates: [getCodexSessionBackfillDate()] } : null
 }
 
 /**

--- a/src/main/codex/codex-session-index-heal-state.test.ts
+++ b/src/main/codex/codex-session-index-heal-state.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  CODEX_SESSION_INDEX_HEAL_VERSION,
+  appendHealLedgerRecord,
+  collectPendingHealThreads,
+  isHealMarkerCurrent,
+  writeHealMarker,
+  type CodexSessionIndexHealPaths
+} from './codex-session-index-heal-state'
+
+const WINDOWS_SESSIONS_ROOT = 'C:\\Users\\Me\\.codex\\sessions'
+const THREAD_ID = '019f0000-1111-7222-8333-000000000001'
+
+let tempRoots: string[] = []
+
+afterEach(() => {
+  for (const root of tempRoots) {
+    rmSync(root, { recursive: true, force: true })
+  }
+  tempRoots = []
+})
+
+function createPaths(systemSessionsRoot = WINDOWS_SESSIONS_ROOT): CodexSessionIndexHealPaths {
+  const stateDir = mkdtempSync(join(tmpdir(), 'orca-codex-heal-state-'))
+  tempRoots.push(stateDir)
+  return {
+    auditLogPath: join(stateDir, 'audit.jsonl'),
+    systemSessionsRoot,
+    healLedgerPath: join(stateDir, 'index-heal-ledger.jsonl'),
+    healMarkerPath: join(stateDir, 'index-heal-complete.json')
+  }
+}
+
+function appendAuditRecord(paths: CodexSessionIndexHealPaths, target: string, recordId: string) {
+  // Mirrors the real writer's leading newline, which quarantines a torn tail.
+  appendFileSync(
+    paths.auditLogPath,
+    `\n${JSON.stringify({ action: 'hardlink', source: '/managed/x.jsonl', target, recordId })}\n`
+  )
+}
+
+function windowsRolloutTarget(root: string): string {
+  return `${root}\\2026\\07\\01\\rollout-2026-07-01T10-00-00-${THREAD_ID}.jsonl`
+}
+
+describe('codex session index heal state', () => {
+  it('keeps the heal marker current across Windows spellings of one target', () => {
+    const paths = createPaths()
+    writeHealMarker(paths, 42, { healedThreads: 1, missingThreads: 0, failedThreads: 0 })
+
+    for (const alias of ['C:/Users/Me/.codex/sessions', 'c:\\users\\me\\.codex\\sessions']) {
+      expect(isHealMarkerCurrent({ ...paths, systemSessionsRoot: alias }, 42)).toBe(true)
+    }
+  })
+
+  it('still re-heals when the real target path actually changes', () => {
+    const paths = createPaths()
+    writeHealMarker(paths, 42, { healedThreads: 1, missingThreads: 0, failedThreads: 0 })
+
+    expect(
+      isHealMarkerCurrent(
+        { ...paths, systemSessionsRoot: 'C:\\Users\\Me\\moved-codex\\sessions' },
+        42
+      )
+    ).toBe(false)
+  })
+
+  it('treats a heal record as processed regardless of how its root was spelled', async () => {
+    const paths = createPaths()
+    appendAuditRecord(paths, windowsRolloutTarget(WINDOWS_SESSIONS_ROOT), 'audit-1')
+    appendHealLedgerRecord(
+      { ...paths, systemSessionsRoot: 'c:/users/me/.codex/sessions' },
+      THREAD_ID,
+      'healed',
+      'audit-1'
+    )
+
+    expect(await collectPendingHealThreads(paths)).toEqual([])
+  })
+
+  it('re-heals a thread whose record belongs to a different real home', async () => {
+    const paths = createPaths()
+    appendAuditRecord(paths, windowsRolloutTarget(WINDOWS_SESSIONS_ROOT), 'audit-1')
+    appendHealLedgerRecord(
+      { ...paths, systemSessionsRoot: 'C:\\Users\\Me\\moved-codex\\sessions' },
+      THREAD_ID,
+      'healed',
+      'audit-1'
+    )
+
+    expect(await collectPendingHealThreads(paths)).toEqual([
+      expect.objectContaining({ threadId: THREAD_ID, auditRecordId: 'audit-1' })
+    ])
+  })
+
+  it('re-queues a thread when a later publication event supersedes a healed one', async () => {
+    const paths = createPaths()
+    appendAuditRecord(paths, windowsRolloutTarget(WINDOWS_SESSIONS_ROOT), 'audit-1')
+    appendHealLedgerRecord(paths, THREAD_ID, 'healed', 'audit-1')
+    appendAuditRecord(paths, windowsRolloutTarget(WINDOWS_SESSIONS_ROOT), 'audit-2')
+
+    expect(await collectPendingHealThreads(paths)).toEqual([
+      expect.objectContaining({ threadId: THREAD_ID, auditRecordId: 'audit-2' })
+    ])
+  })
+
+  it('leaves the main thread free while walking a large audit ledger', async () => {
+    const paths = createPaths()
+    for (let index = 0; index < 20_000; index += 1) {
+      appendAuditRecord(
+        paths,
+        `${WINDOWS_SESSIONS_ROOT}\\2026\\07\\01\\rollout-2026-07-01T10-00-00-019f0000-1111-7222-8333-${String(index).padStart(12, '0')}.jsonl`,
+        `audit-${index}`
+      )
+    }
+    let ticks = 0
+    const ticker = setInterval(() => {
+      ticks += 1
+    }, 1)
+
+    const pending = await collectPendingHealThreads(paths)
+    clearInterval(ticker)
+
+    expect(pending).toHaveLength(20_000)
+    // A blocking readFileSync + whole-file JSON.parse would starve every timer.
+    expect(ticks).toBeGreaterThan(0)
+  })
+
+  it('refuses to treat an unreadable audit ledger as an empty work queue', async () => {
+    const paths = createPaths()
+    // A directory in the audit's place surfaces EISDIR rather than ENOENT.
+    mkdirSync(paths.auditLogPath, { recursive: true })
+
+    await expect(collectPendingHealThreads(paths)).rejects.toThrow()
+  })
+
+  it('treats a missing audit ledger as no pending work', async () => {
+    await expect(collectPendingHealThreads(createPaths())).resolves.toEqual([])
+  })
+
+  it('skips torn ledger lines instead of failing the pass', async () => {
+    const paths = createPaths()
+    appendFileSync(paths.auditLogPath, '{"action":"hardlink","target":"/x/rollout')
+    appendAuditRecord(paths, windowsRolloutTarget(WINDOWS_SESSIONS_ROOT), 'audit-1')
+
+    expect(await collectPendingHealThreads(paths)).toEqual([
+      expect.objectContaining({ threadId: THREAD_ID })
+    ])
+    expect(CODEX_SESSION_INDEX_HEAL_VERSION).toBe(3)
+  })
+})

--- a/src/main/codex/codex-session-index-heal-state.ts
+++ b/src/main/codex/codex-session-index-heal-state.ts
@@ -5,6 +5,7 @@ import {
   normalizeRuntimePathForComparison
 } from '../../shared/cross-platform-path'
 import { writeFileAtomically } from '../codex-accounts/fs-utils'
+import { streamCodexSessionLedgerRecords } from './codex-session-ledger-stream'
 
 // State files for the session index heal: which backfilled rollouts exist
 // (the backfill audit ledger), which thread ids this pass already processed
@@ -50,10 +51,14 @@ export type HealMarkerSummary = {
  * Diffs the backfill audit ledger against the heal ledger: every hardlinked or
  * copied rollout whose thread id has not been processed yet, most recent first.
  */
-export function collectPendingHealThreads(paths: CodexSessionIndexHealPaths): PendingHealThread[] {
-  const processed = readProcessedHealThreads(paths)
+export async function collectPendingHealThreads(
+  paths: CodexSessionIndexHealPaths
+): Promise<PendingHealThread[]> {
+  const processed = await readProcessedHealThreads(paths)
   const pendingByThreadId = new Map<string, PendingHealThread>()
-  for (const line of readJsonlLines(paths.auditLogPath, true)) {
+  for await (const line of streamCodexSessionLedgerRecords(paths.auditLogPath, {
+    throwOnReadFailure: true
+  })) {
     if (line.action !== 'hardlink' && line.action !== 'copy' && line.action !== 'existing') {
       continue
     }
@@ -94,18 +99,18 @@ function lastPathSegment(filePath: string): string {
   return filePath.split(/[\\/]/).at(-1) ?? ''
 }
 
-function readProcessedHealThreads(paths: CodexSessionIndexHealPaths): {
+async function readProcessedHealThreads(paths: CodexSessionIndexHealPaths): Promise<{
   healedAuditRecords: Set<string>
   legacyHealedThreadIds: Set<string>
   missingAuditRecords: Set<string>
   legacyMissingThreadIds: Set<string>
-} {
+}> {
   const healedAuditRecords = new Set<string>()
   const legacyHealedThreadIds = new Set<string>()
   const missingAuditRecords = new Set<string>()
   const legacyMissingThreadIds = new Set<string>()
   const expectedRoot = normalizeRuntimePathForComparison(paths.systemSessionsRoot)
-  for (const line of readJsonlLines(paths.healLedgerPath)) {
+  for await (const line of streamCodexSessionLedgerRecords(paths.healLedgerPath)) {
     if (
       line.v === CODEX_SESSION_INDEX_HEAL_VERSION &&
       typeof line.threadId === 'string' &&
@@ -165,35 +170,6 @@ export function appendHealLedgerRecord(
   }
 }
 
-function readJsonlLines(filePath: string, throwOnReadFailure = false): Record<string, unknown>[] {
-  let contents: string
-  try {
-    contents = readFileSync(filePath, 'utf-8')
-  } catch (error) {
-    if (throwOnReadFailure && !isNotFoundError(error)) {
-      // Why: the audit is the heal work queue. Treating EACCES/EIO as empty
-      // would write a completion marker that permanently skips every session.
-      throw error
-    }
-    return []
-  }
-  const lines: Record<string, unknown>[] = []
-  for (const raw of contents.split('\n')) {
-    if (!raw.trim()) {
-      continue
-    }
-    try {
-      const parsed: unknown = JSON.parse(raw)
-      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        lines.push(parsed as Record<string, unknown>)
-      }
-    } catch {
-      // Skip torn/corrupt lines; both ledgers are append-only diagnostics.
-    }
-  }
-  return lines
-}
-
 export function readAuditLogSize(auditLogPath: string): number {
   try {
     return statSync(auditLogPath).size
@@ -225,9 +201,13 @@ export function isHealMarkerCurrent(
       unsupportedAt?: unknown
       retryableFailureAt?: unknown
     }
+    // Why: one Windows directory has several spellings (drive case, separators),
+    // so a raw compare re-drives the whole heal for what is the same target.
     if (
       marker.version !== CODEX_SESSION_INDEX_HEAL_VERSION ||
-      marker.systemSessionsRoot !== paths.systemSessionsRoot
+      typeof marker.systemSessionsRoot !== 'string' ||
+      normalizeRuntimePathForComparison(marker.systemSessionsRoot) !==
+        normalizeRuntimePathForComparison(paths.systemSessionsRoot)
     ) {
       return false
     }

--- a/src/main/codex/codex-session-index-heal.ts
+++ b/src/main/codex/codex-session-index-heal.ts
@@ -118,7 +118,7 @@ export async function runCodexSessionIndexHeal(
     }
   }
 
-  const pending = collectPendingHealThreads(paths)
+  const pending = await collectPendingHealThreads(paths)
   const summary: CodexSessionIndexHealSummary = {
     outcome: 'completed',
     pendingThreads: pending.length,

--- a/src/main/codex/codex-session-ledger-stream.ts
+++ b/src/main/codex/codex-session-ledger-stream.ts
@@ -1,0 +1,55 @@
+import { createReadStream } from 'node:fs'
+import { createInterface } from 'node:readline'
+
+/**
+ * Streams an append-only JSONL ledger one record at a time.
+ *
+ * Why: the backfill audit holds one line per published session file and neither
+ * ledger is ever compacted, so a large Codex history makes a `readFileSync` plus
+ * whole-file `JSON.parse` a multi-megabyte block of the Electron main thread.
+ * Reading chunk by chunk keeps the window responsive while the pass runs.
+ */
+export async function* streamCodexSessionLedgerRecords(
+  filePath: string,
+  options: { throwOnReadFailure?: boolean } = {}
+): AsyncGenerator<Record<string, unknown>> {
+  const lines = createInterface({
+    input: createReadStream(filePath, { encoding: 'utf-8' }),
+    crlfDelay: Infinity
+  })
+  try {
+    for await (const raw of lines) {
+      const record = parseLedgerRecord(raw)
+      if (record) {
+        yield record
+      }
+    }
+  } catch (error) {
+    if (options.throwOnReadFailure && !isNotFoundError(error)) {
+      // Why: the audit is the heal work queue. Treating EACCES/EIO as empty
+      // would write a completion marker that permanently skips every session.
+      throw error
+    }
+  } finally {
+    lines.close()
+  }
+}
+
+function parseLedgerRecord(raw: string): Record<string, unknown> | null {
+  if (!raw.trim()) {
+    return null
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    // Torn tails are quarantined by the writer's leading newline; skip them.
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null
+  } catch {
+    return null
+  }
+}
+
+function isNotFoundError(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException | null)?.code === 'ENOENT'
+}

--- a/src/main/codex/codex-session-migration-scheduler.test.ts
+++ b/src/main/codex/codex-session-migration-scheduler.test.ts
@@ -94,6 +94,57 @@ describe('createCodexSessionMigrationScheduler', () => {
     )
   })
 
+  it('publishes the baseline while a Codex pane is still open', async () => {
+    vi.setSystemTime(new Date('2026-08-05T10:00:00Z'))
+    const prepareScheduledRun = vi.fn()
+    const startBackfill = vi.fn().mockResolvedValue({ stopped: false })
+    const scheduler = createCodexSessionMigrationScheduler({
+      isEligible: () => true,
+      isQuitting: () => false,
+      resolveSystemCodexHomePathOverride: () => undefined,
+      prepareScheduledRun,
+      startBackfill,
+      startIndexHeal: vi.fn().mockResolvedValue(null),
+      initialDelayMs: 1_000
+    })
+
+    scheduler.beginLaunch('pty-1')
+    await vi.advanceTimersByTimeAsync(1_000)
+    await vi.waitFor(() => expect(startBackfill).toHaveBeenCalledOnce())
+
+    const options = startBackfill.mock.calls[0]?.[0]
+    // The open pane only holds its own date pending; publication is not blocked.
+    expect(options?.retainPendingScanDates).toBe(true)
+    expect(options?.canWriteCompletionMarker?.()).toBe(true)
+    // Preparation is handed the dates so it can persist them before the walk.
+    expect(prepareScheduledRun).toHaveBeenCalledWith([['2026', '08', '05']])
+  })
+
+  it('hands preparation every date a cross-midnight launch spanned', async () => {
+    vi.setSystemTime(new Date('2026-08-05T23:59:59Z'))
+    const prepareScheduledRun = vi.fn()
+    const scheduler = createCodexSessionMigrationScheduler({
+      isEligible: () => true,
+      isQuitting: () => false,
+      resolveSystemCodexHomePathOverride: () => undefined,
+      prepareScheduledRun,
+      startBackfill: vi.fn().mockResolvedValue({ stopped: false }),
+      startIndexHeal: vi.fn().mockResolvedValue(null),
+      initialDelayMs: 1_000
+    })
+
+    scheduler.beginLaunch('pty-1')
+    vi.setSystemTime(new Date('2026-08-07T01:00:00Z'))
+    scheduler.finishLaunch('pty-1')
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(prepareScheduledRun).toHaveBeenLastCalledWith([
+      ['2026', '08', '05'],
+      ['2026', '08', '06'],
+      ['2026', '08', '07']
+    ])
+  })
+
   it('keeps launch passes full when no completed baseline can cover older failures', async () => {
     const startBackfill = vi.fn().mockResolvedValue({ stopped: false })
     const scheduler = createCodexSessionMigrationScheduler({
@@ -375,7 +426,7 @@ describe('createCodexSessionMigrationScheduler', () => {
     await vi.advanceTimersByTimeAsync(1_000)
     await vi.waitFor(() => expect(startBackfill).toHaveBeenCalledOnce())
     expect(startBackfill).toHaveBeenLastCalledWith(
-      expect.objectContaining({ writeCompletionMarker: false }),
+      expect.objectContaining({ retainPendingScanDates: true }),
       undefined
     )
     expect(finishScheduledRun).not.toHaveBeenCalled()
@@ -392,8 +443,8 @@ describe('createCodexSessionMigrationScheduler', () => {
           ['2026', '08', '07']
         ],
         ignoreCompletionMarker: true,
-        writeCompletionMarker: true,
-        writeBoundedCompletionMarker: true
+        retainPendingScanDates: false,
+        fullScanRequired: false
       }),
       undefined
     )
@@ -421,7 +472,7 @@ describe('createCodexSessionMigrationScheduler', () => {
     await vi.advanceTimersByTimeAsync(1_000)
     await vi.waitFor(() => expect(startBackfill).toHaveBeenCalledOnce())
     expect(startBackfill).toHaveBeenLastCalledWith(
-      expect.objectContaining({ scanDates: undefined, writeBoundedCompletionMarker: false }),
+      expect.objectContaining({ scanDates: undefined, fullScanRequired: true }),
       undefined
     )
 
@@ -429,7 +480,7 @@ describe('createCodexSessionMigrationScheduler', () => {
     await vi.advanceTimersByTimeAsync(1_000)
     await vi.waitFor(() => expect(startBackfill).toHaveBeenCalledTimes(2))
     expect(startBackfill).toHaveBeenLastCalledWith(
-      expect.objectContaining({ scanDates: undefined, writeBoundedCompletionMarker: false }),
+      expect.objectContaining({ scanDates: undefined, fullScanRequired: true }),
       undefined
     )
     await vi.waitFor(() => expect(finishScheduledRun).toHaveBeenCalledOnce())
@@ -485,7 +536,7 @@ describe('createCodexSessionMigrationScheduler', () => {
     await vi.advanceTimersByTimeAsync(1_000)
 
     expect(startBackfill).toHaveBeenCalledWith(
-      expect.objectContaining({ scanDates: undefined, writeBoundedCompletionMarker: false }),
+      expect.objectContaining({ scanDates: undefined, fullScanRequired: true }),
       undefined
     )
     await vi.waitFor(() => expect(finishScheduledRun).toHaveBeenCalledOnce())
@@ -510,8 +561,8 @@ describe('createCodexSessionMigrationScheduler', () => {
     expect(startBackfill).toHaveBeenCalledWith(
       expect.objectContaining({
         scanDates: expect.any(Array),
-        writeCompletionMarker: false,
-        writeBoundedCompletionMarker: false
+        retainPendingScanDates: true,
+        fullScanRequired: false
       }),
       undefined
     )
@@ -536,8 +587,8 @@ describe('createCodexSessionMigrationScheduler', () => {
     expect(startBackfill).toHaveBeenCalledWith(
       expect.objectContaining({
         scanDates: expect.any(Array),
-        writeCompletionMarker: false,
-        writeBoundedCompletionMarker: false
+        retainPendingScanDates: true,
+        fullScanRequired: false
       }),
       undefined
     )
@@ -560,14 +611,14 @@ describe('createCodexSessionMigrationScheduler', () => {
     await vi.advanceTimersByTimeAsync(1_000)
 
     expect(startBackfill).toHaveBeenCalledWith(
-      expect.objectContaining({ writeCompletionMarker: false }),
+      expect.objectContaining({ retainPendingScanDates: true }),
       undefined
     )
 
     scheduler.finishLaunch('stable-pty', 4)
     await vi.advanceTimersByTimeAsync(1_000)
     expect(startBackfill).toHaveBeenLastCalledWith(
-      expect.objectContaining({ writeCompletionMarker: true }),
+      expect.objectContaining({ retainPendingScanDates: false }),
       undefined
     )
   })
@@ -588,14 +639,14 @@ describe('createCodexSessionMigrationScheduler', () => {
     scheduler.beginLaunch('stable-pty', false, new Date(), 2)
     await vi.advanceTimersByTimeAsync(61_000)
     expect(startBackfill).toHaveBeenLastCalledWith(
-      expect.objectContaining({ writeCompletionMarker: false }),
+      expect.objectContaining({ retainPendingScanDates: true }),
       undefined
     )
 
     scheduler.finishLaunch('stable-pty', 3)
     await vi.advanceTimersByTimeAsync(1_000)
     expect(startBackfill).toHaveBeenLastCalledWith(
-      expect.objectContaining({ writeCompletionMarker: true }),
+      expect.objectContaining({ retainPendingScanDates: false }),
       undefined
     )
   })
@@ -623,7 +674,7 @@ describe('createCodexSessionMigrationScheduler', () => {
     await vi.advanceTimersByTimeAsync(1_000)
     expect(startBackfill).toHaveBeenCalledTimes(2)
     expect(startBackfill).toHaveBeenLastCalledWith(
-      expect.objectContaining({ writeCompletionMarker: true }),
+      expect.objectContaining({ retainPendingScanDates: false }),
       undefined
     )
   })
@@ -646,7 +697,7 @@ describe('createCodexSessionMigrationScheduler', () => {
     scheduler.beginLaunch('stable-pty', false, new Date(), 5)
     await vi.advanceTimersByTimeAsync(1_000)
     expect(startBackfill).toHaveBeenLastCalledWith(
-      expect.objectContaining({ writeCompletionMarker: false }),
+      expect.objectContaining({ retainPendingScanDates: true }),
       undefined
     )
 
@@ -654,7 +705,7 @@ describe('createCodexSessionMigrationScheduler', () => {
     await vi.advanceTimersByTimeAsync(1_000)
     expect(startBackfill).toHaveBeenCalledTimes(2)
     expect(startBackfill).toHaveBeenLastCalledWith(
-      expect.objectContaining({ writeCompletionMarker: true }),
+      expect.objectContaining({ retainPendingScanDates: false }),
       undefined
     )
   })
@@ -675,7 +726,7 @@ describe('createCodexSessionMigrationScheduler', () => {
     await vi.advanceTimersByTimeAsync(1_000)
 
     expect(startBackfill).toHaveBeenCalledWith(
-      expect.objectContaining({ writeCompletionMarker: false }),
+      expect.objectContaining({ retainPendingScanDates: true }),
       undefined
     )
   })

--- a/src/main/codex/codex-session-migration-scheduler.ts
+++ b/src/main/codex/codex-session-migration-scheduler.ts
@@ -1,4 +1,9 @@
-import { getCodexSessionBackfillDate } from './codex-session-backfill-date'
+import {
+  compareCodexSessionBackfillDates,
+  getCodexSessionBackfillDate,
+  getCodexSessionBackfillDatesBetween,
+  toCodexSessionBackfillDateKey
+} from './codex-session-backfill-scan-dates'
 import { CodexSessionMigrationIgnoredLaunches } from './codex-session-migration-ignored-launches'
 import { CodexSessionMigrationRecentExits } from './codex-session-migration-recent-exits'
 import type {
@@ -29,7 +34,7 @@ export function createCodexSessionMigrationScheduler(args: {
   isEligible: () => boolean
   isQuitting: () => boolean
   resolveSystemCodexHomePathOverride: () => string | undefined
-  prepareScheduledRun?: () => boolean | void
+  prepareScheduledRun?: (scanDates: readonly CodexSessionBackfillDate[]) => boolean | void
   finishScheduledRun?: () => void
   startBackfill: MigrationRun
   startIndexHeal: MigrationRun
@@ -63,7 +68,7 @@ export function createCodexSessionMigrationScheduler(args: {
         pendingScheduledRunGeneration ?? requestedGeneration
       )
       for (const scanDate of requestedScanDates) {
-        pendingScanDates.set(scanDate.join('-'), scanDate)
+        pendingScanDates.set(toCodexSessionBackfillDateKey(scanDate), scanDate)
       }
       pendingFullScan ||= requestedFullScan
     }
@@ -77,17 +82,16 @@ export function createCodexSessionMigrationScheduler(args: {
     }
     const isScheduledRun = pendingScheduledRunGeneration !== null
     const activeScheduledRunGeneration = pendingScheduledRunGeneration
+    const runScanDates = [...pendingScanDates.values()].sort(compareCodexSessionBackfillDates)
     let preparationNeedsFullScan = false
     if (isScheduledRun) {
       pendingScheduledRunGeneration = null
-      // Why: an older active pass can rewrite the marker after launch invalidates it.
-      preparationNeedsFullScan = args.prepareScheduledRun?.() === true
+      // Why: preparation persists these dates so an abnormal exit still yields a
+      // bounded recovery window instead of another full-tree walk.
+      preparationNeedsFullScan = args.prepareScheduledRun?.(runScanDates) === true
     }
     const fullScanRequired = pendingFullScan || preparationNeedsFullScan
-    const scanDates =
-      !fullScanRequired && pendingScanDates.size > 0
-        ? [...pendingScanDates.values()].sort(compareBackfillDates)
-        : undefined
+    const scanDates = !fullScanRequired && runScanDates.length > 0 ? runScanDates : undefined
     pendingScanDates.clear()
     pendingFullScan = false
     activeRunStopObserved = false
@@ -105,12 +109,12 @@ export function createCodexSessionMigrationScheduler(args: {
         {
           shouldStop,
           scanDates,
+          fullScanRequired,
           ignoreCompletionMarker: isScheduledRun,
-          writeCompletionMarker: activeLaunches.size === 0,
-          writeBoundedCompletionMarker:
-            isScheduledRun && activeLaunches.size === 0 && !fullScanRequired,
+          // Why: a live pane keeps appending to its own date directory, so that
+          // date stays pending — but the historical baseline is still certified.
+          retainPendingScanDates: activeLaunches.size > 0,
           canWriteCompletionMarker: () =>
-            activeLaunches.size === 0 &&
             scheduledTimer === null &&
             pendingScheduledRunGeneration === null &&
             (!isScheduledRun || activeScheduledRunGeneration === scheduledRunGeneration)
@@ -144,7 +148,7 @@ export function createCodexSessionMigrationScheduler(args: {
           )
           pendingFullScan ||= fullScanRequired
           for (const scanDate of scanDates ?? []) {
-            pendingScanDates.set(scanDate.join('-'), scanDate)
+            pendingScanDates.set(toCodexSessionBackfillDateKey(scanDate), scanDate)
           }
         }
         if (
@@ -168,9 +172,9 @@ export function createCodexSessionMigrationScheduler(args: {
       scheduledTimer = null
       if (generation !== undefined) {
         const currentDate = getCodexSessionBackfillDate()
-        scheduledScanDates.set(currentDate.join('-'), currentDate)
+        scheduledScanDates.set(toCodexSessionBackfillDateKey(currentDate), currentDate)
       }
-      const scanDates = [...scheduledScanDates.values()].sort(compareBackfillDates)
+      const scanDates = [...scheduledScanDates.values()].sort(compareCodexSessionBackfillDates)
       scheduledScanDates.clear()
       const fullScanRequired = scheduledFullScan
       scheduledFullScan = false
@@ -186,7 +190,7 @@ export function createCodexSessionMigrationScheduler(args: {
     scheduledRunGeneration += 1
     scheduledFullScan ||= fullScanRequired
     const launchDate = getCodexSessionBackfillDate()
-    scheduledScanDates.set(launchDate.join('-'), launchDate)
+    scheduledScanDates.set(toCodexSessionBackfillDateKey(launchDate), launchDate)
     armScheduledRun(scheduledRunGeneration)
   }
 
@@ -235,7 +239,7 @@ export function createCodexSessionMigrationScheduler(args: {
         return
       }
       for (const scanDate of getCodexSessionBackfillDatesBetween(startedAt, new Date())) {
-        scheduledScanDates.set(scanDate.join('-'), scanDate)
+        scheduledScanDates.set(toCodexSessionBackfillDateKey(scanDate), scanDate)
       }
       scheduleRun()
     },
@@ -247,31 +251,6 @@ export function createCodexSessionMigrationScheduler(args: {
     scheduleRun,
     requestRun: () => requestRun()
   }
-}
-
-function getCodexSessionBackfillDatesBetween(
-  startedAt: Date,
-  finishedAt: Date
-): CodexSessionBackfillDate[] {
-  const dates: CodexSessionBackfillDate[] = []
-  const cursor = new Date(
-    Date.UTC(startedAt.getUTCFullYear(), startedAt.getUTCMonth(), startedAt.getUTCDate())
-  )
-  const last = new Date(
-    Date.UTC(finishedAt.getUTCFullYear(), finishedAt.getUTCMonth(), finishedAt.getUTCDate())
-  )
-  while (cursor <= last) {
-    dates.push(getCodexSessionBackfillDate(cursor))
-    cursor.setUTCDate(cursor.getUTCDate() + 1)
-  }
-  return dates
-}
-
-function compareBackfillDates(
-  left: CodexSessionBackfillDate,
-  right: CodexSessionBackfillDate
-): number {
-  return left.join('-').localeCompare(right.join('-'))
 }
 
 function isStoppedMigrationResult(result: unknown): boolean {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2588,7 +2588,8 @@ void app.whenReady().then(async () => {
     isQuitting: () => isQuitting,
     resolveSystemCodexHomePathOverride: () =>
       resolveHostCodexSessionSourceHome(store!.getSettings()),
-    prepareScheduledRun: () => codexRuntimeHome?.prepareHostSystemDefaultSessionMigrationPass(),
+    prepareScheduledRun: (scanDates) =>
+      codexRuntimeHome?.prepareHostSystemDefaultSessionMigrationPass(scanDates),
     finishScheduledRun: () => codexRuntimeHome?.finishHostSystemDefaultSessionMigrationPass(),
     startBackfill: startCodexSessionBackfillInBackground,
     startIndexHeal: startCodexSessionIndexHealInBackground


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​918 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​197 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​721 |
| Prod | 13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​648 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​211 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​437 |

<!-- /orca-pr-loc -->

## ELI5

Orca keeps a note saying "I have already filed away all of your old Codex chats." Every time you opened a Codex pane, Orca threw that note away, so it went back and re-filed the entire history from scratch — which on a big history made the window sit there looking frozen. Now Orca keeps the note and only writes down the handful of days it still needs to look at, so opening a pane checks today instead of everything you have ever done.

## What Changed

**v4 marker, backward compatible.** `MARKER_BASELINE_VERSIONS = {3, 4}` — a v3 marker was only ever written after a certified full-tree walk, so it reads as a v4 baseline and existing installs pay no extra full scan on upgrade. New fields separate the two things the old marker conflated: `coverage`, `pendingScanDates`, `needsFullScan`, `launchActive`, `baselineScannedFiles`.

- `readCodexSessionBackfillBaseline()` returns `null` **only** when a full walk is genuinely required. A baseline with pending dates still yields a bounded pass.
- A **bounded pass now returns early unless a full baseline already exists** — previously a date-limited pass could publish a *global* completion marker purely on a scheduler flag, certifying dates it never looked at.
- A **full pass certifies the baseline even while a pane is open**; only the live pane's own date stays pending.
- Launch preparation now **records pending dates instead of deleting the marker**, and persists them **before** the walk so an abnormal exit still yields a bounded window.
- The marker-generation guard now only suppresses *clearing* covered dates rather than discarding the whole write — otherwise a launch racing the full walk would again lose the baseline.
- `MAX_PENDING_SCAN_DATES = 31`; overflow sets `needsFullScan`, so the recovery window can never grow unbounded. A `markPending` write failure falls back to `rmSync` (fail closed) and still throws `AggregateError` if that also fails.
- `baselineScannedFiles` is kept separate from `summary.scannedFiles` so the preserved `scannedFiles !== 0` empty-source guard is not tripped by a bounded pass that legitimately scanned nothing.
- **Normalization** reuses the existing `normalizeRuntimePathForComparison` — the heal ledger already normalized; no new normalizer was written.
- **Streaming reads**: new `codex-session-ledger-stream.ts`; `collectPendingHealThreads` is now async and `readCodexSessionBackfillAuditCoverage` reuses the same reader.
- **Cross-midnight recovery**: if the marker was last written with a pane live (`launchActive`), the read widens pending into the contiguous range through today, bounded by the same cap.
- Two new shared modules keep this from duplicating logic: `codex-session-backfill-scan-dates.ts` (date-set algebra — the scheduler's private `getCodexSessionBackfillDatesBetween`/`compareBackfillDates` **moved** there rather than being copied) and the ledger streamer.

### Second commit (2273f264984), from review

- **The full-scan demand is now durable.** `markCodexSessionBackfillMarkerPending` used to spread a freshly computed `needsFullScan: false` over the record, so the next Codex launch silently erased a persisted "a full walk is still owed". `describePendingScanDates` now takes a `stillOwesFullScan` argument and ORs it in. Stricter than the review's suggested fix: the demand is retired **only** by a pass that is both `coverage === 'full'` **and** generation-current, because a stale full walk that a later launch overtook may have passed the overflowed dates before their rollouts were written. It converges on the next generation-current full pass.
- **The demand now reaches the scheduler.** `markCodexSessionBackfillMarkerPending` returns whether a full walk is still owed (true on a foreign-root marker and on the fail-closed `rmSync` path), and `CodexRuntimeHomeService.prepareHostSystemDefaultSessionMigrationPass` does `pendingHostSystemDefaultSessionMigrationNeedsFullScan ||= markerOwesFullScan`. Called unconditionally, not short-circuited, so the generation bump and date recording still happen when the flag is already set. This reporting channel is **inherited from @rumoii's #16252**.
- **A full pass now settles the whole pending set** instead of subtracting the empty set (`coveredScanDates` resolves to `current.pendingScanDates` when `coverage === 'full'`). Previously a full walk left today pending forever, forcing a pointless extra bounded pass on every startup and needlessly widening the `launchActive` cross-midnight range.
- **Real calendar validation of persisted dates**: `isCodexSessionBackfillDate` does a UTC round-trip, so a corrupted marker cannot carry `['2026','99','99']`, and `2025/02/29` is rejected while `2024/02/29` is accepted. Also **inherited from @rumoii's #16252**.
- Elegance: inlined the single-call-site `readOptionalCount`; split the doubled `options.fullScanRequired` test into two early returns; added the missing WHY on the always-`'full'` persisted coverage field (it records *baseline existence*, not this pass's scope) and on the load-bearing spread ordering in `markPending` (literals are defaults only — an existing v3 record keeps its own version/coverage).
- Six new/strengthened tests, including making `scans only the current date once a baseline exists` non-vacuous (it now writes a second managed session under `2026/06/02`, so `scannedFiles: 1` actually proves the other date was not walked).

### Preserved

Skip-existing non-destructive copy contract, append-only audit log, `shouldStop`/quit handling, failure counters gating marker writes, the empty-source guard, ignored/early PTY exit handling, and the WSL and managed-account lanes.

## Why

Five root causes, all confirmed present on `origin/main`:

| # | What was wrong |
|---|---|
| 1 | `src/main/codex-accounts/runtime-home-service.ts:319` called `invalidateCodexSessionBackfillMarker` → **`rmSync`** on every managed-lane Codex pane launch. It destroyed the historical baseline rather than marking it stale. |
| 2 | The marker could **never** be written while a Codex pane was open (`writeCompletionMarker: activeLaunches.size === 0`, re-checked in `canWriteCompletionMarker`). A user who keeps a pane open never established a baseline, so every launch re-derived `needsFullScan = true` and re-walked the entire tree. |
| 3 | All scheduler state (`scheduledScanDates`, `pendingScanDates`, `pendingFullScan`, `activeLaunches`) was **in-memory only**. A crash or force-quit lost it, and `scheduleInitialRun()` passes no generation, so `scanDates` came back `undefined` → full walk. No bounded recovery window existed. |
| 4 | The target root was compared with raw `===` in three places. `C:\Users\Me\.codex`, `C:/Users/Me/.codex` and `c:\users\me\.codex` are one directory but three marker keys, each invalidating the others. |
| 5 | `collectPendingHealThreads` did `readFileSync` + per-line `JSON.parse` (`src/main/codex/codex-session-index-heal-state.ts:171,186,217` on main) over the **whole** `audit.jsonl` **and** the whole `index-heal-ledger.jsonl`, twice per pass, on the Electron main thread. One audit line per session file, so a large history is a multi-megabyte blocking parse — a direct contributor to "the Orca window appeared hung". |

The review round confirmed the diff fixes the root cause rather than a symptom: the marker no longer conflates "a launch happened" with "the history was never published", the baseline can be certified while a pane is open, and pending state survives an abnormal exit.

## Risk & Trade-offs

**Merge risk: Low-medium.** It still changes the on-disk marker format that gates Codex session-history backfill (v3 → v4) and rewires when that marker is written, but all six on-disk transitions — including rollback to old code — have now been exercised on a real Windows 11 host against a real 746-file Codex history, so the migration behaviour is measured rather than reasoned. *(Was Medium-high; what moved it: rollback measured as one idempotent full walk with zero failures and no data loss, an interrupted pass proved unable to falsely certify a baseline, corrupt markers proved self-healing, and the Windows path-normalization fix confirmed against three real alternate spellings of the same root.)*

### What could go wrong

- **A user's old Codex sessions stop being linked into Orca.** Still the sharpest one, and now the *only* unconfirmed correctness bet. The marker is durable, so if it certifies a baseline that is wrong — a date the pending set never names again — those sessions are simply never revisited, and the pre-fix behaviour that quietly re-healed this (an `rmSync` on every launch) is gone. Most likely trigger is the still-unconfirmed **UTC vs local date directories** question in Review: if the Codex CLI names `sessions/YYYY/MM/DD` from local time, an evening session in a UTC-negative offset lands in a directory the bounded pass may skip. Surfaces as "my Codex history from last night isn't in Orca" — no error, no log line. Not self-healing until a full walk is forced. **The hardware run did not settle this**; it used real date directories but did not cross a local-vs-UTC boundary deliberately.
- ~~**Stale or corrupt marker causes a wrong-shaped scan.**~~ **Measured, not a residual risk.** Five corrupted forms — truncated JSON, binary garbage, zero-length file, JSON array, and bogus calendar dates — all degraded to a single full walk with no crash and self-healed to a valid v4. Bogus dates (`2026-99-99`, `2025-02-29`) are dropped individually rather than nuking the whole marker. `MAX_PENDING_SCAN_DATES = 31` was exercised at its exact boundary: 31 dates → 663 files scanned bounded; 32 dates → baseline `null` → full 746.
- ~~**An interrupted full pass could publish a baseline it never finished walking.**~~ **Disproved by measurement.** Killed by explicit PID 1.5 s into an 8 s full walk, the on-disk marker was `coverage: "bounded"` with no `baselineScannedFiles`, so the next launch correctly full-scanned. Four abnormal-exit variants total, all pass.
- **A user who deletes or moves `~/.codex/sessions` doesn't get it re-linked.** Deliberate consequence of durability, but a real behaviour change from today. Low frequency, silent, and the recovery is to delete the marker.
- **Windows path-case collision.** `normalizeRuntimePathForComparison` case-folds, so two `.codex` directories differing only by case on a per-directory case-sensitive NTFS volume now share one marker and would cross-certify each other. Rare, and the failure is silent mis-certification, not a crash. Weighed against a now-**measured** benefit: with `systemSessionsRoot` rewritten to three alternate spellings of the same real directory (lowercased, forward slashes, trailing separator), new code honoured all three and old code rejected all three and re-scanned — root cause 4 is a real Windows re-scan trigger, not a theoretical one.
- **The stall isn't actually gone for the reporter's flow.** Reattached panes still force a full walk (`codex-session-backfill.ts:137`, pre-existing #12611). A user who restarts Orca or reloads the window with retained Codex panes will still see the hang. Likely — it's the exact flow that was reported.
- **New, surfaced by the hardware run: a session that starts with *no* baseline runs the full walk twice** — once while the pane is live, once after it closes — because the service flag only clears in `finishHostSystemDefaultSessionMigrationPass`. Old code does exactly the same (2 × 746 observed side by side), so this is a pre-existing cost this PR does not fix rather than a regression. Worth a follow-up.

### What a user gets in exchange

Opening a Codex pane checks a handful of dates instead of walking the entire `~/.codex/sessions` tree. Measured on the real 746-file history: with a baseline present, a launch scanned **3 files instead of 746 (250×)**, and a launch needing nothing at all returned `null` in **1 ms with zero files walked**. The two multi-megabyte per-line `JSON.parse` passes over `audit.jsonl` and `index-heal-ledger.jsonl` on the Electron main thread — twice per pass — become streaming reads with an `auditBytes` fast path that re-reads nothing in steady state. Existing installs pay no upgrade cost: a v3 marker is accepted as a v4 baseline (confirmed on hardware — the v3 file was left byte-identical and zero files were walked), so nobody eats a one-time full scan on update.

### Trade-offs accepted

- **Reattach is out of scope.** Wiring it into the bounded window touches three more launch files and changes launch semantics; it needs its own PR. The linked issue is deliberately `Addresses`, not `Fixes`. **Follow-up owed.**
- **UTC/local date derivation was not confirmed against the real `codex-rs` recorder.** If it turns out to be local time, each pending date needs widening by ±1 day. This is now the single largest correctness bet remaining, and the hardware round did not close it.
- **Hardware verification covered the on-disk migration, not the whole app.** The six transitions ran against a Node harness importing the *real* scheduler, backfill and marker modules bundled straight from git — not the full packaged Electron app. Not exercised: the packaged/dev Electron app end to end, real Codex panes via the PTY lease path (`beginLaunch`/`finishLaunch` were driven on the real scheduler, but not by an actual codex process exiting), and the index-heal pass.
- **Age/future bounds on persisted dates were declined.** Only impossible calendar dates are rejected. A clock-skewed future or very old directory can hold real user sessions, and `isCodexSessionBackfillDate` also gates which rollouts get published at all — bounding it there would silently drop real data. Accepted gap: a skewed marker date is trusted.
- **Memory during a pass still scales with history size.** Streaming fixes the blocking read, not the growth: `audit.jsonl` is still append-only, one line per published file forever, and `readCodexSessionBackfillAuditCoverage` still materializes a `Set` of every `fileEventId`. Compaction cuts against the append-only audit constraint and is a separate change. **Follow-up owed.**
- **The full-scan demand retires conservatively** — only on a pass that is both `coverage === 'full'` and generation-current. That means some users will do one more full walk than strictly necessary. Chosen over the risk of retiring the demand while a stale walk missed overflowed dates.
- **Stricter than needed on empty results**: `baselineScannedFiles` is tracked separately from `summary.scannedFiles` purely to keep the old `scannedFiles !== 0` empty-source guard intact. Extra field, extra state to reason about.

### How to back it out

Clean code revert. **Measured, not reasoned:** it leaves a v4 marker on disk, and old code's strict `marker.version === 3` check reads that as "no marker" → one full 746-file rescan → then writes a clean v3. Every file came back `skippedExistingFiles` with `failedFiles: 0` / `failedDirectories: 0`, so the rollback walk is idempotent and destroys nothing, and the v3 it leaves behind is exactly what new code accepts as a baseline on roll-forward. **v4 → rollback → roll-forward therefore costs one extra full walk in total, then settles.** Old code ignores v4 rather than crashing on it or corrupting it. No migration script is needed in either direction. Full run in the PR comments.

## Linked Issue

Addresses #16251. Deliberately **not** `Fixes` — this closes the repeated-full-walk behaviour for the ordinary launch path (fresh pane, cross-midnight, crash recovery), but **reattached panes still pay a full walk**. `src/main/index.ts:487` passes `args.reattached === true || fullScanRequired` into `scheduler.beginLaunch`, and `spawn-early.ts` / `spawn-commit.ts` send `reattached: true` for every adopted stable pane, so `resolveCodexSessionBackfillScanPlan` honours `fullScanRequired` unconditionally and bypasses the new bounded machinery. That line is pre-existing (#12611) and untouched here; wiring reattach to the bounded window changes launch semantics in three more files and belongs in its own PR. **The reporter's "restart Orca / reload the window with retained Codex panes" flow is therefore not yet closed** — follow-up needed.

## Visual Proof

`N/A` — this is entirely main-process background work (marker file format, migration-pass scheduling, ledger reads); nothing rendered changes, and the only user-observable difference is the absence of a stall.

## Testing

### On real Windows 11 hardware, against a real Codex history

All six on-disk transitions were exercised on a Windows 11 host against a **real 746-file Codex history** — a hardlink copy of a live managed home (identical inodes verified), 34 date directories, 2.3 GB — pointed at scratch via `ORCA_USER_DATA_PATH`. The user's real `~/.codex` was never modified.

**Method, stated honestly:** a Node harness importing the *real* modules (esbuild-bundled straight from git), driving the real `createCodexSessionMigrationScheduler`, the real `startCodexSessionBackfillInBackground` and the real marker module — **not** the full Electron app. Only `CodexRuntimeHomeService`'s three small methods were replicated rather than imported (that file pulls in the whole Electron main graph); index-heal was stubbed. New = `2273f264984`; old = `1c9fb84b77b`, the commit immediately before this PR's first commit.

| # | Transition | Result |
|---|---|---|
| 1 | v3 → new code | **PASS** — `null` in 1 ms, **zero files walked**, v3 file left byte-identical. With a pane live: bounded pass scanned **3 files, not 746**, upgrading to v4 carrying `baselineScannedFiles: 746` forward. The v3 marker was written by actually running the pre-PR code, not hand-authored. |
| 2 | **v4 → old code (rollback)** | **PASS, with a measured cost** — one full 746-file rescan, every file `skippedExistingFiles`, `failedFiles: 0` / `failedDirectories: 0`, then a clean v3 written. One extra walk total across rollback + roll-forward. |
| 3 | Fresh install | **PASS** — one full walk (746 linked, 749 ms) → v4 `coverage: "full"`; second startup `null` in 1 ms. |
| 4 | Baseline + live pane | **PASS, bug reproduced side by side** — old code finishes the full walk and leaves the marker `<ABSENT>`; new code publishes mid-pane with only the live date pending. Next launch: **3 files instead of 746 (250×)**. |
| 5 | Abnormal exit | **PASS** — 4 variants, killed by explicit PID. Critically, **an interrupted full pass cannot falsely certify**: killed 1.5 s into an 8 s walk, the marker on disk was `coverage: "bounded"` with no `baselineScannedFiles`, so the next launch correctly full-scanned. |
| 6 | Corrupted marker | **PASS** — truncated JSON, binary garbage, zero-length, JSON array, bogus calendar dates: all → full walk, no crash, self-heals to a valid v4. |

Windows-specific: with `systemSessionsRoot` rewritten to three alternate spellings of the same real directory (lowercased, forward slashes, trailing separator), **new code honoured all three; old code rejected all three and re-scanned** — `normalizeRuntimePathForComparison` fixes a real re-scan trigger. `MAX_PENDING_SCAN_DATES = 31` was exercised at its exact boundary: 31 dates → 663 files bounded; 32 → full 746.

**Not exercised, stated rather than inferred:** the full packaged/dev Electron app end to end; real Codex panes via the PTY lease path; the index-heal pass. Full run in the PR comments.

### Automated, on the branch head

```
$ pnpm tc
TC_STATUS=0

$ pnpm test src/main/codex
 Test Files  113 passed | 1 skipped (114)
      Tests  1175 passed | 6 skipped (1181)
   Duration  8.63s
TEST_STATUS=0

$ npx oxlint --deny-warnings <8 changed files>
OXLINT_EXIT=0
```

Non-vacuity was verified by stashing the source files and keeping the new tests — 5 of the 6 new tests fail against pre-fix source:

```
 x rejects dates the calendar never produced
 x settles every pending date once a full walk covers them
 x demands a full walk once the pending window outgrows its bound
 x keeps owing that full walk when the next launch records its own date
 x carries a full-scan demand persisted by an earlier launch into this pass
 Tests  5 failed | 69 passed (74)
 x keeps the full-walk demand when a later launch overtook the walk  [separate targeted run]
```

The 6th (`scans only the current date once a baseline exists`) was proven by forcing the scan plan to a full walk: `AssertionError: -"scannedFiles": 1, +"scannedFiles": 2`.

Independently re-run by the reviewer on a clean checkout of the first commit (`dab32859adb`): `vitest run src/main/codex src/main/codex-accounts` → 113 files / 1169 tests passed (1 file / 6 tests skipped), `oxlint src/main/codex src/main/codex-accounts` exit 0, `tsc -p config/tsconfig.node.json` clean, and no `max-lines` disable added (`codex-session-backfill.test.ts` is 960 raw lines but passes the 800-line skipBlankLines/skipComments budget). The reviewer also reproduced both marker bugs empirically against that checkout before they were fixed.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Still **not** verified end-to-end through the real app: the UTC-vs-local date-directory question (see Review → Residual risk) remains open, and no run went through the packaged Electron app with live Codex panes.

## Review

### Credit

**@rumoii's #16252** independently identified the same root cause and landed on the same core design before this PR: a backward-compatible v4 marker that separates the certified historical baseline from launch-pending activity, keeping the baseline on launch instead of `rmSync`-ing it, publishing the baseline while a launch is still active, and bounded date-range recovery after cross-midnight or abnormal exits. They were first and they were right about the shape of the fix.

Two specific things they got right that this PR **adopted after review**:

1. **`markPending` reports back whether a full scan is still owed**, so the caller can `||=` it into the in-memory flag. Our `markCodexSessionBackfillMarkerPending` was `void`, which is exactly why the persisted `needsFullScan` could be silently erased by the next launch. Inherited from @rumoii's #16252.
2. **Real calendar validation of the persisted pending date** — their `parseBackfillDate` rejects `2026-02-29` and `0000-00-00`; ours only shape-checked `/^\d{4}$/`. Inherited from @rumoii's #16252.

Where this PR goes further than #16252: it normalizes the `systemSessionsRoot` compare (they kept the raw `===`, so root cause 4 is unfixed for their marker), it streams the `audit.jsonl` / `index-heal-ledger.jsonl` reads instead of `readFileSync` + per-line parse (root cause 5, untouched there), and its generation-mismatch guard suppresses only the *clear* rather than discarding the whole write (theirs loses the baseline when a launch races a full walk). Conversely, three things from #16252 were **deliberately not** inherited: their 366-day uncapped `pendingSince` expansion (ours caps at 31), their write-during-read v3→v4 migration inside the reader, and their full write suppression on generation mismatch.

### Declined from review, with reasons

- **Reattached panes still force a full walk** (`codex-session-backfill.ts:137`). Out of scope; see Linked Issue. This is the largest known gap.
- **Age/future bounds on persisted dates** (the other half of #16252's validation). `isCodexSessionBackfillDate` also gates `isCodexSessionRolloutPath`, i.e. which managed rollouts get published at all. A clock-skewed future directory or an old directory holds *real* user sessions, so rejecting them there would silently classify real rollouts as unexpected and never link them. An impossible calendar date cannot hold a real rollout, so only that check is safe.
- **Plumbing `startedAt` into `beginHostSystemDefaultSessionMigrationLaunch`** (#16252 inherit 3). Not a real gap here: `ctx.codexHomeLaunchStartedAt` is `new Date()` at `spawn-begin.ts:22` and `spawn-early.ts:17` — always "now", even for reattach — so it cannot differ from the prepare-time `getCodexSessionBackfillDate()`. The exit path already spans via `getCodexSessionBackfillDatesBetween(startedAt, now)`.
- **Replacing the `CodexSessionBackfillDate` tuple with `'YYYY-MM-DD'` strings** to retire the eight set-algebra helpers. The proposal itself calls it optional and larger than it looks; the tuple is pre-existing and consumed as a tuple by the walk (`join(root, y, m, d)`) and by `isCodexSessionRolloutPath`.

### Residual risk

- **UTC vs local date directories.** `getCodexSessionBackfillDate` has always been UTC, but the old frequent full walks masked any mismatch. Now that a certified baseline means only UTC-derived date directories are ever revisited, if the Codex CLI names `sessions/YYYY/MM/DD` from *local* time then evening sessions in a UTC-negative offset land in a directory the pending set may never name again. **Not confirmed against the real `codex-rs` recorder, and the Windows hardware round did not close it either.** If it is local, each pending date should be widened by ±1 day. This is the largest remaining correctness bet.
- **The marker is now genuinely durable**, so a user who deletes or relocates `~/.codex/sessions` no longer gets their managed history re-linked on the next launch. Pre-fix, the per-launch `rmSync` effectively re-healed that. This is an intended consequence of the goal, but it is a real behaviour change.
- **No ledger compaction.** Root cause 5 fixes the *blocking* read (streaming, plus the heal marker's `auditBytes` fast path means steady state re-reads nothing). `audit.jsonl` still grows one line per published file forever, and `readCodexSessionBackfillAuditCoverage` still materializes a `Set` of every `fileEventId`, so main-process memory during a pass still scales with history size. Compaction cuts against the "preserve the append-only audit log" constraint and deserves its own change.
- **Windows path case.** `normalizeRuntimePathForComparison` case-folds, so two directories differing only by case on a per-directory case-sensitive NTFS volume now share one marker. The shared helper documents that tradeoff. The upside is measured: three alternate spellings of the same real root (lowercased / forward slashes / trailing separator) were all honoured by new code and all rejected by old code on the Windows run.
- **A session that starts with no baseline runs the full walk twice** — once pane-live, once after close, because the service flag only clears in `finishHostSystemDefaultSessionMigrationPass`. Observed on hardware; old code does the same (2 × 746 side by side), so it is pre-existing rather than introduced here. Follow-up owed.
- Nothing here touches SSH/relay wire formats, IPC payloads, provider-specific code, or renderer state. The marker is desktop-local user data and round-trips safely across upgrade (v3 reads as a baseline) and rollback (an old build sees version 4, treats it as incomplete, does one full walk and rewrites v3 — measured on hardware, idempotent, zero failures).

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

`codex-session-backfill.test.ts` crossed the 800-line budget with the new cases; per AGENTS.md the fs fault-injection preamble was **extracted** into `codex-session-backfill-fs-mocks.ts`. **No `max-lines` disable was added anywhere.**

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` pass locally; `pnpm build` left to CI