### PR TITLE
perf(terminal): stop rebuilding parked-watcher keys on every overlay render

### DIFF
--- a/src/renderer/src/components/terminal-pane/sleeping-record-park-exemption.ts
+++ b/src/renderer/src/components/terminal-pane/sleeping-record-park-exemption.ts
@@ -2,24 +2,22 @@ import type { SleepingAgentSessionRecord } from '../../../../shared/agent-sessio
 import { isPassiveCompletedHibernationEvidence } from '../../lib/sleeping-agent-pane-ownership'
 
 const EMPTY_TAB_IDS: ReadonlySet<string> = new Set()
-const TAB_ID_SEPARATOR = '\u0000'
 
-/** Tab ids whose panes own a sleeping record a mount can actually consume, as a
- *  value-comparable key.
+/** Tab ids whose panes own a sleeping record a mount can actually consume.
  *  Why: a parked pane can never cold-restore, so per-tab parks must exempt
  *  these — but only these: blocked and passive-completed records never resume,
  *  and exempting them would pin a hidden pane mounted indefinitely.
- *  Why a key: the record map is app-global, so a subscriber must compare the
- *  worktree-scoped verdict, not the map. Iterates in place — `Object.values`
- *  would allocate every record on every store write. */
-export function selectSleepingRecordParkExemptTabIdsKey(
+ *  Callers subscribe through `useShallow`, which compares the set structurally,
+ *  so a write for another worktree cannot re-render this one. Iterates in place —
+ *  `Object.values` would allocate every record on every store write. */
+export function selectSleepingRecordParkExemptTabIds(
   sleepingAgentSessionsByPaneKey: Record<string, SleepingAgentSessionRecord> | undefined,
   worktreeId: string
-): string {
+): ReadonlySet<string> {
   if (!sleepingAgentSessionsByPaneKey) {
-    return ''
+    return EMPTY_TAB_IDS
   }
-  let owned: string[] | null = null
+  let owned: Set<string> | null = null
   for (const paneKey in sleepingAgentSessionsByPaneKey) {
     const record = sleepingAgentSessionsByPaneKey[paneKey]
     if (!record || record.worktreeId !== worktreeId) {
@@ -29,15 +27,10 @@ export function selectSleepingRecordParkExemptTabIdsKey(
       continue
     }
     const tabId = record.tabId ?? record.paneKey.slice(0, record.paneKey.indexOf(':'))
-    if (tabId && !owned?.includes(tabId)) {
-      owned ??= []
-      owned.push(tabId)
+    if (tabId) {
+      owned ??= new Set()
+      owned.add(tabId)
     }
   }
-  // Why sorted: record insertion order must not churn the key and the derived set.
-  return owned === null ? '' : owned.sort().join(TAB_ID_SEPARATOR)
-}
-
-export function parseSleepingRecordParkExemptTabIdsKey(key: string): ReadonlySet<string> {
-  return key === '' ? EMPTY_TAB_IDS : new Set(key.split(TAB_ID_SEPARATOR))
+  return owned ?? EMPTY_TAB_IDS
 }

--- a/src/renderer/src/components/terminal-pane/sleeping-record-park-exemption.ts
+++ b/src/renderer/src/components/terminal-pane/sleeping-record-park-exemption.ts
@@ -2,28 +2,42 @@ import type { SleepingAgentSessionRecord } from '../../../../shared/agent-sessio
 import { isPassiveCompletedHibernationEvidence } from '../../lib/sleeping-agent-pane-ownership'
 
 const EMPTY_TAB_IDS: ReadonlySet<string> = new Set()
+const TAB_ID_SEPARATOR = '\u0000'
 
-/** Tab ids whose panes own a sleeping record a mount can actually consume.
+/** Tab ids whose panes own a sleeping record a mount can actually consume, as a
+ *  value-comparable key.
  *  Why: a parked pane can never cold-restore, so per-tab parks must exempt
  *  these — but only these: blocked and passive-completed records never resume,
- *  and exempting them would pin a hidden pane mounted indefinitely. */
-export function selectSleepingRecordParkExemptTabIds(
+ *  and exempting them would pin a hidden pane mounted indefinitely.
+ *  Why a key: the record map is app-global, so a subscriber must compare the
+ *  worktree-scoped verdict, not the map. Iterates in place — `Object.values`
+ *  would allocate every record on every store write. */
+export function selectSleepingRecordParkExemptTabIdsKey(
   sleepingAgentSessionsByPaneKey: Record<string, SleepingAgentSessionRecord> | undefined,
   worktreeId: string
-): ReadonlySet<string> {
-  let owned: Set<string> | null = null
-  for (const record of Object.values(sleepingAgentSessionsByPaneKey ?? {})) {
-    if (record.worktreeId !== worktreeId) {
+): string {
+  if (!sleepingAgentSessionsByPaneKey) {
+    return ''
+  }
+  let owned: string[] | null = null
+  for (const paneKey in sleepingAgentSessionsByPaneKey) {
+    const record = sleepingAgentSessionsByPaneKey[paneKey]
+    if (!record || record.worktreeId !== worktreeId) {
       continue
     }
     if (record.automaticResumeBlockedBy || isPassiveCompletedHibernationEvidence(record)) {
       continue
     }
     const tabId = record.tabId ?? record.paneKey.slice(0, record.paneKey.indexOf(':'))
-    if (tabId) {
-      owned ??= new Set()
-      owned.add(tabId)
+    if (tabId && !owned?.includes(tabId)) {
+      owned ??= []
+      owned.push(tabId)
     }
   }
-  return owned ?? EMPTY_TAB_IDS
+  // Why sorted: record insertion order must not churn the key and the derived set.
+  return owned === null ? '' : owned.sort().join(TAB_ID_SEPARATOR)
+}
+
+export function parseSleepingRecordParkExemptTabIdsKey(key: string): ReadonlySet<string> {
+  return key === '' ? EMPTY_TAB_IDS : new Set(key.split(TAB_ID_SEPARATOR))
 }

--- a/src/renderer/src/components/terminal-pane/terminal-cold-park-subscription-narrowing.react185.test.tsx
+++ b/src/renderer/src/components/terminal-pane/terminal-cold-park-subscription-narrowing.react185.test.tsx
@@ -1,0 +1,129 @@
+/** @vitest-environment happy-dom */
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SleepingAgentSessionRecord } from '../../../../shared/agent-session-resume'
+import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const WORKTREE_ID = 'repo::/cold-park-narrowing'
+const OTHER_WORKTREE_ID = 'repo::/cold-park-narrowing-other'
+
+const harness = vi.hoisted(() => ({ renders: 0 }))
+
+vi.mock('../../store', async () => {
+  const { create } = await import('zustand')
+  const useAppStore = create(() => ({
+    pendingStartupByTabId: {} as Record<string, unknown>,
+    ptyIdsByTabId: {} as Record<string, string[]>,
+    runtimeStatusByEnvironmentId: new Map<string, unknown>(),
+    runtimePaneTitlesByTabId: {} as Record<string, Record<number, string>>,
+    settings: {} as Record<string, unknown>,
+    sleepingAgentSessionsByPaneKey: {} as Record<string, unknown>,
+    terminalLayoutsByTabId: {} as Record<string, unknown>
+  }))
+  return { useAppStore }
+})
+
+vi.mock('./terminal-parked-tab-watchers', () => ({
+  canWatcherCoverParkedTerminalTab: () => true,
+  disposeParkedTerminalWatchersForWorktree: vi.fn(),
+  syncParkedTerminalTabWatchers: vi.fn()
+}))
+
+vi.mock('@/lib/crash-breadcrumb-recorder', () => ({
+  recordRendererCrashBreadcrumb: vi.fn()
+}))
+
+import { useAppStore } from '../../store'
+import { useTerminalTabColdParking } from './use-terminal-tab-cold-parking'
+
+const terminalTabs = ['tab-1', 'tab-2'].map(
+  (id) => ({ id, ptyId: `${WORKTREE_ID}@@session-${id}` }) as TerminalTab
+)
+const assignments = new Map<string, { groupId: string; isActiveInGroup: boolean }>()
+
+function sleepingRecord(paneKey: string, worktreeId: string): SleepingAgentSessionRecord {
+  return { paneKey, worktreeId } as unknown as SleepingAgentSessionRecord
+}
+const activityTerminalPortals: never[] = []
+
+function ColdParkingHarness(): null {
+  harness.renders += 1
+  useTerminalTabColdParking({
+    worktreeId: WORKTREE_ID,
+    terminalTabs,
+    assignments,
+    isWorktreeActive: false,
+    activeTerminalTabId: null,
+    coldParkTerminalPanes: false,
+    shouldMeasureHiddenWorktree: false,
+    activityTerminalPortals,
+    activationDeferredMountTabIds: null
+  })
+  return null
+}
+
+describe('cold-park store subscription narrowing', () => {
+  let container: HTMLDivElement
+  let root: Root | undefined
+
+  beforeEach(() => {
+    harness.renders = 0
+    useAppStore.setState({ pendingStartupByTabId: {}, sleepingAgentSessionsByPaneKey: {} })
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+    act(() => {
+      root?.render(<ColdParkingHarness />)
+    })
+    harness.renders = 0
+  })
+
+  afterEach(() => {
+    act(() => root?.unmount())
+    root = undefined
+    container.remove()
+  })
+
+  // Why: these two maps are app-global, so before narrowing any write re-rendered
+  // every mounted worktree's overlay layer.
+  it('ignores a pending-startup write for another worktree tab', () => {
+    act(() => {
+      useAppStore.setState({ pendingStartupByTabId: { 'other-tab': { command: 'codex' } } })
+    })
+    expect(harness.renders).toBe(0)
+  })
+
+  it('ignores a sleeping-session write for another worktree', () => {
+    act(() => {
+      useAppStore.setState({
+        sleepingAgentSessionsByPaneKey: {
+          'other-tab:1': sleepingRecord('other-tab:1', OTHER_WORKTREE_ID)
+        }
+      })
+    })
+    expect(harness.renders).toBe(0)
+  })
+
+  it('still re-renders when this worktree gains a pending startup', () => {
+    act(() => {
+      useAppStore.setState({
+        pendingStartupByTabId: { 'tab-1': { command: 'claude' }, 'other-tab': { command: 'codex' } }
+      })
+    })
+    expect(harness.renders).toBeGreaterThan(0)
+  })
+
+  it('still re-renders when this worktree gains a sleeping-session record', () => {
+    act(() => {
+      useAppStore.setState({
+        sleepingAgentSessionsByPaneKey: {
+          'tab-1:1': sleepingRecord('tab-1:1', WORKTREE_ID)
+        }
+      })
+    })
+    expect(harness.renders).toBeGreaterThan(0)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-cold-park-subscription-narrowing.react185.test.tsx
+++ b/src/renderer/src/components/terminal-pane/terminal-cold-park-subscription-narrowing.react185.test.tsx
@@ -44,8 +44,12 @@ const terminalTabs = ['tab-1', 'tab-2'].map(
 )
 const assignments = new Map<string, { groupId: string; isActiveInGroup: boolean }>()
 
-function sleepingRecord(paneKey: string, worktreeId: string): SleepingAgentSessionRecord {
-  return { paneKey, worktreeId } as unknown as SleepingAgentSessionRecord
+function sleepingRecord(
+  paneKey: string,
+  worktreeId: string,
+  extra: Partial<SleepingAgentSessionRecord> = {}
+): SleepingAgentSessionRecord {
+  return { paneKey, worktreeId, ...extra } as unknown as SleepingAgentSessionRecord
 }
 const activityTerminalPortals: never[] = []
 
@@ -101,6 +105,21 @@ describe('cold-park store subscription narrowing', () => {
       useAppStore.setState({
         sleepingAgentSessionsByPaneKey: {
           'other-tab:1': sleepingRecord('other-tab:1', OTHER_WORKTREE_ID)
+        }
+      })
+    })
+    expect(harness.renders).toBe(0)
+  })
+
+  // Why: a blocked record never resumes, so it leaves the exempt set — and the
+  // narrowed subscription's compared value — unchanged.
+  it('ignores a sleeping-session write this worktree can never resume', () => {
+    act(() => {
+      useAppStore.setState({
+        sleepingAgentSessionsByPaneKey: {
+          'tab-1:1': sleepingRecord('tab-1:1', WORKTREE_ID, {
+            automaticResumeBlockedBy: 'legacy-orchestration-worker'
+          })
         }
       })
     })

--- a/src/renderer/src/components/terminal-pane/terminal-pending-startup-park-presence.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pending-startup-park-presence.ts
@@ -1,35 +1,25 @@
-import { useMemo } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 import { useAppStore } from '../../store'
 
 const EMPTY_PENDING_STARTUP: Readonly<Record<string, unknown>> = Object.freeze({})
-const TAB_ID_SEPARATOR = '\u0000'
 
 /** Park policy only asks whether *these* tabs have a pending startup, so this
- *  subscribes to a worktree-scoped presence key instead of the app-global record:
+ *  subscribes to a worktree-scoped presence record instead of the app-global one:
  *  a startup write for any other worktree then cannot re-render this one. Empty
  *  in the steady state, so the subscription allocates nothing. */
 export function usePendingStartupParkPresence(
   terminalTabs: readonly TerminalTab[]
 ): Readonly<Record<string, unknown>> {
-  const pendingStartupTabIdsKey = useAppStore((state) => {
-    const pendingStartup = state.pendingStartupByTabId
-    let key = ''
-    for (const tab of terminalTabs) {
-      if (pendingStartup[tab.id] !== undefined) {
-        key += key === '' ? tab.id : `${TAB_ID_SEPARATOR}${tab.id}`
+  return useAppStore(
+    useShallow((state) => {
+      let presence: Record<string, true> | null = null
+      for (const tab of terminalTabs) {
+        if (state.pendingStartupByTabId[tab.id] !== undefined) {
+          ;(presence ??= {})[tab.id] = true
+        }
       }
-    }
-    return key
-  })
-  return useMemo(() => {
-    if (pendingStartupTabIdsKey === '') {
-      return EMPTY_PENDING_STARTUP
-    }
-    const presence: Record<string, true> = {}
-    for (const tabId of pendingStartupTabIdsKey.split(TAB_ID_SEPARATOR)) {
-      presence[tabId] = true
-    }
-    return presence
-  }, [pendingStartupTabIdsKey])
+      return presence ?? EMPTY_PENDING_STARTUP
+    })
+  )
 }

--- a/src/renderer/src/components/terminal-pane/terminal-pending-startup-park-presence.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pending-startup-park-presence.ts
@@ -1,0 +1,35 @@
+import { useMemo } from 'react'
+import type { TerminalTab } from '../../../../shared/terminal-tab-types'
+import { useAppStore } from '../../store'
+
+const EMPTY_PENDING_STARTUP: Readonly<Record<string, unknown>> = Object.freeze({})
+const TAB_ID_SEPARATOR = '\u0000'
+
+/** Park policy only asks whether *these* tabs have a pending startup, so this
+ *  subscribes to a worktree-scoped presence key instead of the app-global record:
+ *  a startup write for any other worktree then cannot re-render this one. Empty
+ *  in the steady state, so the subscription allocates nothing. */
+export function usePendingStartupParkPresence(
+  terminalTabs: readonly TerminalTab[]
+): Readonly<Record<string, unknown>> {
+  const pendingStartupTabIdsKey = useAppStore((state) => {
+    const pendingStartup = state.pendingStartupByTabId
+    let key = ''
+    for (const tab of terminalTabs) {
+      if (pendingStartup[tab.id] !== undefined) {
+        key += key === '' ? tab.id : `${TAB_ID_SEPARATOR}${tab.id}`
+      }
+    }
+    return key
+  })
+  return useMemo(() => {
+    if (pendingStartupTabIdsKey === '') {
+      return EMPTY_PENDING_STARTUP
+    }
+    const presence: Record<string, true> = {}
+    for (const tabId of pendingStartupTabIdsKey.split(TAB_ID_SEPARATOR)) {
+      presence[tabId] = true
+    }
+    return presence
+  }, [pendingStartupTabIdsKey])
+}

--- a/src/renderer/src/components/terminal-pane/use-parked-terminal-watcher-synchronization.react185.test.tsx
+++ b/src/renderer/src/components/terminal-pane/use-parked-terminal-watcher-synchronization.react185.test.tsx
@@ -249,3 +249,174 @@ describe('parked terminal watcher synchronization', () => {
     expect(harness.syncCalls).toBe(syncCallsAfterMount)
   })
 })
+
+function ConfigurableWatcherSynchronizationHarness({
+  inputsKey,
+  assignmentsKey,
+  activationDeferredMountTabIds
+}: {
+  inputsKey: string
+  assignmentsKey: string
+  activationDeferredMountTabIds?: ReadonlySet<string> | null
+}): null {
+  useParkedTerminalWatcherSynchronization({
+    worktreeId: WORKTREE_ID,
+    terminalTabs,
+    inputsKey,
+    assignmentsKey,
+    parkedTabIds,
+    activationDeferredMountTabIds
+  })
+  return null
+}
+
+describe('parked terminal watcher synchronization key semantics', () => {
+  let container: HTMLDivElement
+  let root: Root | undefined
+
+  function renderHarness(props: {
+    inputsKey?: string
+    assignmentsKey?: string
+    activationDeferredMountTabIds?: ReadonlySet<string> | null
+  }): void {
+    act(() => {
+      root?.render(
+        <ConfigurableWatcherSynchronizationHarness
+          inputsKey={props.inputsKey ?? 'inputs'}
+          assignmentsKey={props.assignmentsKey ?? 'assignments'}
+          activationDeferredMountTabIds={props.activationDeferredMountTabIds ?? null}
+        />
+      )
+    })
+  }
+
+  beforeEach(() => {
+    harness.syncCalls = 0
+    harness.disposeCalls = 0
+    harness.watchedPtyIds.clear()
+    useAppStore.setState({
+      ptyIdsByTabId: { [TAB_ID]: [FIRST_PTY_ID, OLD_SECOND_PTY_ID] },
+      runtimePaneTitlesByTabId: { [TAB_ID]: { 1: 'active', 2: 'split' } },
+      terminalLayoutsByTabId: { [TAB_ID]: splitLayout(OLD_SECOND_PTY_ID) }
+    })
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root?.unmount())
+    root = undefined
+    capturedPanesByTabId.delete(TAB_ID)
+    container.remove()
+  })
+
+  it('does not resynchronize when nothing the key covers changed', () => {
+    renderHarness({})
+    expect(harness.syncCalls).toBe(1)
+    renderHarness({})
+    renderHarness({})
+    act(() => {
+      useAppStore.setState({ sortEpoch: 1 })
+    })
+    expect(harness.syncCalls).toBe(1)
+  })
+
+  // Why: a key that stopped covering one of these would strand a parked pane
+  // that never reconciles.
+  it.each([
+    ['pty ids', () => useAppStore.setState({ ptyIdsByTabId: { [TAB_ID]: [FIRST_PTY_ID] } })],
+    [
+      'layout root shape',
+      () =>
+        useAppStore.setState({
+          terminalLayoutsByTabId: {
+            [TAB_ID]: {
+              ...splitLayout(OLD_SECOND_PTY_ID),
+              root: {
+                type: 'split',
+                direction: 'horizontal',
+                first: { type: 'leaf', leafId: FIRST_LEAF_ID },
+                second: { type: 'leaf', leafId: SECOND_LEAF_ID }
+              }
+            }
+          }
+        })
+    ],
+    [
+      'layout active leaf',
+      () =>
+        useAppStore.setState({
+          terminalLayoutsByTabId: {
+            [TAB_ID]: { ...splitLayout(OLD_SECOND_PTY_ID), activeLeafId: SECOND_LEAF_ID }
+          }
+        })
+    ],
+    [
+      'layout leaf pty ids',
+      () =>
+        useAppStore.setState({
+          terminalLayoutsByTabId: { [TAB_ID]: splitLayout(NEW_SECOND_PTY_ID) }
+        })
+    ],
+    [
+      'runtime pane title slots',
+      () =>
+        useAppStore.setState({
+          runtimePaneTitlesByTabId: { [TAB_ID]: { 1: 'active', 2: 'split', 3: 'third' } }
+        })
+    ],
+    [
+      'captured pane registry',
+      () =>
+        captureParkedTerminalPaneCandidates(TAB_ID, WORKTREE_ID, [
+          { ptyId: FIRST_PTY_ID, paneId: 10, leafId: FIRST_LEAF_ID, drivesTabTitle: true }
+        ])
+    ]
+  ])('resynchronizes when %s changes', (_label, mutate) => {
+    renderHarness({})
+    expect(harness.syncCalls).toBe(1)
+    act(() => {
+      mutate()
+    })
+    // A registry mutation is not a store write, so drive the render it rides on.
+    renderHarness({})
+    expect(harness.syncCalls).toBe(2)
+  })
+
+  it('resynchronizes when a caller-supplied key or tab set changes', () => {
+    renderHarness({ inputsKey: 'a', assignmentsKey: 'b' })
+    expect(harness.syncCalls).toBe(1)
+    renderHarness({ inputsKey: 'a2', assignmentsKey: 'b' })
+    expect(harness.syncCalls).toBe(2)
+    renderHarness({ inputsKey: 'a2', assignmentsKey: 'b2' })
+    expect(harness.syncCalls).toBe(3)
+    renderHarness({
+      inputsKey: 'a2',
+      assignmentsKey: 'b2',
+      activationDeferredMountTabIds: new Set([TAB_ID])
+    })
+    expect(harness.syncCalls).toBe(4)
+  })
+
+  // Why: fragments are concatenated, so a scheme that let one field borrow a
+  // character from its neighbour would collide and skip a synchronization.
+  it('keeps adjacent key fragments from borrowing each other characters', () => {
+    renderHarness({ inputsKey: 'ab', assignmentsKey: 'c' })
+    expect(harness.syncCalls).toBe(1)
+    renderHarness({ inputsKey: 'a', assignmentsKey: 'bc' })
+    expect(harness.syncCalls).toBe(2)
+    renderHarness({
+      inputsKey: 'a',
+      assignmentsKey: 'bc',
+      activationDeferredMountTabIds: new Set(['x', 'y'])
+    })
+    expect(harness.syncCalls).toBe(3)
+    renderHarness({
+      inputsKey: 'a',
+      assignmentsKey: 'bc',
+      activationDeferredMountTabIds: new Set(['xy'])
+    })
+    expect(harness.syncCalls).toBe(4)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/use-parked-terminal-watcher-synchronization.ts
+++ b/src/renderer/src/components/terminal-pane/use-parked-terminal-watcher-synchronization.ts
@@ -145,18 +145,14 @@ export function useParkedTerminalWatcherSynchronization(args: {
     parkedTabIds,
     activationDeferredMountTabIds
   } = args
-  // Why memoized: a fresh selector identity invalidates the store subscription's
-  // memoized snapshot, so every render would re-run the projection below.
-  const hasParkedTabs = parkedTabIds.size > 0
-  const reconciliationSelector = useMemo(
-    () => (state: AppState) =>
+  const reconciliationStoreInputs = useAppStore(
+    useShallow((state: AppState) =>
       // Why: an empty committed park set has no live watcher state for store writes to reconcile.
-      hasParkedTabs
-        ? selectWatcherReconciliationStoreInputs(state, terminalTabs)
-        : EMPTY_WATCHER_RECONCILIATION_INPUTS,
-    [hasParkedTabs, terminalTabs]
+      parkedTabIds.size === 0
+        ? EMPTY_WATCHER_RECONCILIATION_INPUTS
+        : selectWatcherReconciliationStoreInputs(state, terminalTabs)
+    )
   )
-  const reconciliationStoreInputs = useAppStore(useShallow(reconciliationSelector))
   // Why memoized: serializing the split tree per tab is the dominant cost here,
   // and the shallow selector output only changes when the serialization would.
   const reconciliationStoreInputsKey = useMemo(

--- a/src/renderer/src/components/terminal-pane/use-parked-terminal-watcher-synchronization.ts
+++ b/src/renderer/src/components/terminal-pane/use-parked-terminal-watcher-synchronization.ts
@@ -1,7 +1,7 @@
-import { useEffect, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import type { TerminalLayoutSnapshot, TerminalTab } from '../../../../shared/terminal-tab-types'
-import { useAppStore } from '../../store'
+import { useAppStore, type AppState } from '../../store'
 import {
   disposeParkedTerminalWatchersForWorktree,
   syncParkedTerminalTabWatchers
@@ -23,6 +23,16 @@ type WatcherReconciliationStoreInputs = readonly (
 )[]
 
 const EMPTY_WATCHER_RECONCILIATION_INPUTS: WatcherReconciliationStoreInputs = Object.freeze([])
+
+/** Length-prefixed concatenation: injective for arbitrary fragments, and unlike
+ *  JSON.stringify it never rescans a fragment to escape characters it contains. */
+function joinKeyFragments(fragments: readonly string[]): string {
+  let key = ''
+  for (const fragment of fragments) {
+    key += `${fragment.length}:${fragment}`
+  }
+  return key
+}
 
 export function getTerminalParkingInputsKey(terminalTabs: readonly TerminalTab[]): string {
   return JSON.stringify(terminalTabs.map((tab) => [tab.id, tab.ptyId, tab.pendingActivationSpawn]))
@@ -48,50 +58,75 @@ function getWatcherSynchronizationKey(args: {
   activationDeferredMountTabIds?: ReadonlySet<string> | null
   reconciliationKey: string
 }): string {
-  return JSON.stringify([
+  return joinKeyFragments([
     args.worktreeId,
     args.inputsKey,
     args.assignmentsKey,
-    Array.from(args.parkedTabIds),
-    Array.from(args.activationDeferredMountTabIds ?? []).sort(),
+    joinKeyFragments(Array.from(args.parkedTabIds)),
+    joinKeyFragments(Array.from(args.activationDeferredMountTabIds ?? []).sort()),
     args.reconciliationKey
   ])
 }
 
-function getCapturedPaneKey(terminalTabs: readonly TerminalTab[]): unknown[] {
-  return terminalTabs.map((tab) => {
-    const capture = capturedPanesByTabId.get(tab.id)
-    return [
-      tab.id,
-      capture?.worktreeId ?? null,
-      capture?.panes.map((pane) => [pane.ptyId, pane.paneId, pane.leafId, pane.drivesTabTitle]) ??
-        []
-    ]
-  })
+function getCapturedPaneKey(terminalTabs: readonly TerminalTab[]): string {
+  return JSON.stringify(
+    terminalTabs.map((tab) => {
+      const capture = capturedPanesByTabId.get(tab.id)
+      return [
+        tab.id,
+        capture?.worktreeId ?? null,
+        capture?.panes.map((pane) => [pane.ptyId, pane.paneId, pane.leafId, pane.drivesTabTitle]) ??
+          []
+      ]
+    })
+  )
 }
 
-function getWatcherReconciliationKey(
+/** The store-derived half of the reconciliation key. Split out because it is a
+ *  pure function of shallow-stable selector output, so it memoizes; the captured
+ *  pane half reads a registry mutated outside React and cannot. */
+function getWatcherReconciliationStoreInputsKey(
   terminalTabs: readonly TerminalTab[],
   inputs: WatcherReconciliationStoreInputs
 ): string {
   if (inputs.length === 0) {
     return ''
   }
-  const tabs = terminalTabs.map((tab, index) => {
-    const offset = index * 3
-    const ptyIds = inputs[offset] as readonly string[]
-    const layout = inputs[offset + 1] as TerminalLayoutSnapshot | null
-    const titleSlotKey = inputs[offset + 2] as string
-    return [
-      tab.id,
-      ptyIds,
-      layout?.root ?? null,
-      layout?.activeLeafId ?? null,
-      layout?.ptyIdsByLeafId ?? null,
-      titleSlotKey
-    ]
-  })
-  return JSON.stringify([tabs, getCapturedPaneKey(terminalTabs)])
+  return JSON.stringify(
+    terminalTabs.map((tab, index) => {
+      const offset = index * 3
+      const layout = inputs[offset + 1] as TerminalLayoutSnapshot | null
+      return [
+        tab.id,
+        inputs[offset] as readonly string[],
+        layout?.root ?? null,
+        layout?.activeLeafId ?? null,
+        layout?.ptyIdsByLeafId ?? null,
+        inputs[offset + 2] as string
+      ]
+    })
+  )
+}
+
+function getWatcherReconciliationKey(
+  terminalTabs: readonly TerminalTab[],
+  storeInputsKey: string
+): string {
+  if (storeInputsKey === '') {
+    return ''
+  }
+  return joinKeyFragments([storeInputsKey, getCapturedPaneKey(terminalTabs)])
+}
+
+function selectWatcherReconciliationStoreInputs(
+  state: AppState,
+  terminalTabs: readonly TerminalTab[]
+): WatcherReconciliationStoreInputs {
+  return terminalTabs.flatMap((tab) => [
+    state.ptyIdsByTabId[tab.id] ?? EMPTY_PTY_IDS,
+    state.terminalLayoutsByTabId[tab.id] ?? null,
+    Object.keys(state.runtimePaneTitlesByTabId[tab.id] ?? {}).join(',')
+  ])
 }
 
 export function useParkedTerminalWatcherSynchronization(args: {
@@ -110,19 +145,25 @@ export function useParkedTerminalWatcherSynchronization(args: {
     parkedTabIds,
     activationDeferredMountTabIds
   } = args
-  const reconciliationStoreInputs = useAppStore(
-    useShallow((state) =>
+  // Why memoized: a fresh selector identity invalidates the store subscription's
+  // memoized snapshot, so every render would re-run the projection below.
+  const hasParkedTabs = parkedTabIds.size > 0
+  const reconciliationSelector = useMemo(
+    () => (state: AppState) =>
       // Why: an empty committed park set has no live watcher state for store writes to reconcile.
-      parkedTabIds.size === 0
-        ? EMPTY_WATCHER_RECONCILIATION_INPUTS
-        : terminalTabs.flatMap((tab) => [
-            state.ptyIdsByTabId[tab.id] ?? EMPTY_PTY_IDS,
-            state.terminalLayoutsByTabId[tab.id] ?? null,
-            Object.keys(state.runtimePaneTitlesByTabId[tab.id] ?? {}).join(',')
-          ])
-    )
-  ) as WatcherReconciliationStoreInputs
-  const reconciliationKey = getWatcherReconciliationKey(terminalTabs, reconciliationStoreInputs)
+      hasParkedTabs
+        ? selectWatcherReconciliationStoreInputs(state, terminalTabs)
+        : EMPTY_WATCHER_RECONCILIATION_INPUTS,
+    [hasParkedTabs, terminalTabs]
+  )
+  const reconciliationStoreInputs = useAppStore(useShallow(reconciliationSelector))
+  // Why memoized: serializing the split tree per tab is the dominant cost here,
+  // and the shallow selector output only changes when the serialization would.
+  const reconciliationStoreInputsKey = useMemo(
+    () => getWatcherReconciliationStoreInputsKey(terminalTabs, reconciliationStoreInputs),
+    [reconciliationStoreInputs, terminalTabs]
+  )
+  const reconciliationKey = getWatcherReconciliationKey(terminalTabs, reconciliationStoreInputsKey)
   const synchronizationKey = getWatcherSynchronizationKey({ ...args, reconciliationKey })
   const synchronizationKeyRef = useRef<string | null>(null)
 
@@ -152,14 +193,14 @@ export function useParkedTerminalWatcherSynchronization(args: {
       assignmentsKey,
       parkedTabIds,
       activationDeferredMountTabIds,
-      reconciliationKey: getWatcherReconciliationKey(terminalTabs, reconciliationStoreInputs)
+      reconciliationKey: getWatcherReconciliationKey(terminalTabs, reconciliationStoreInputsKey)
     })
   }, [
     activationDeferredMountTabIds,
     assignmentsKey,
     inputsKey,
     parkedTabIds,
-    reconciliationStoreInputs,
+    reconciliationStoreInputsKey,
     synchronizationKey,
     terminalTabs,
     worktreeId

--- a/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
@@ -29,7 +29,11 @@ import {
   selectEvictionExemptTerminalTabIds,
   selectEvictionExemptTerminalTabLayoutKey
 } from './terminal-eviction-exempt-tabs'
-import { selectSleepingRecordParkExemptTabIds } from './sleeping-record-park-exemption'
+import {
+  parseSleepingRecordParkExemptTabIdsKey,
+  selectSleepingRecordParkExemptTabIdsKey
+} from './sleeping-record-park-exemption'
+import { usePendingStartupParkPresence } from './terminal-pending-startup-park-presence'
 import { canWatcherCoverParkedTerminalTab } from './terminal-parked-tab-watchers'
 import { createTerminalTabActivationOrder } from './terminal-tab-activation-order'
 import { buildTerminalTabColdParkCandidates } from './terminal-tab-park-candidates'
@@ -90,15 +94,21 @@ export function useTerminalTabColdParking(args: {
     activityTerminalPortals,
     activationDeferredMountTabIds
   } = args
-  const terminalParkingInputsKey = getTerminalParkingInputsKey(terminalTabs)
-  const terminalParkingAssignmentsKey = getTerminalParkingAssignmentsKey(assignments)
+  const terminalParkingInputsKey = useMemo(
+    () => getTerminalParkingInputsKey(terminalTabs),
+    [terminalTabs]
+  )
+  const terminalParkingAssignmentsKey = useMemo(
+    () => getTerminalParkingAssignmentsKey(assignments),
+    [assignments]
+  )
   const terminalParkingTabsDependency = coldParkTerminalPanes
     ? terminalParkingInputsKey
     : terminalTabs
   const terminalParkingAssignmentsDependency = coldParkTerminalPanes
     ? terminalParkingAssignmentsKey
     : assignments
-  const pendingStartupByTabId = useAppStore((state) => state.pendingStartupByTabId)
+  const pendingStartupByTabId = usePendingStartupParkPresence(terminalTabs)
   const terminalParkingEnabled = useAppStore(
     (state) => state.settings?.terminalHiddenViewParking !== false
   )
@@ -108,12 +118,14 @@ export function useTerminalTabColdParking(args: {
   const pairedRuntimeParkingEnvironmentIds = useAppStore(
     selectPairedRuntimeParkingEnvironmentIdsFromState
   )
-  const sleepingAgentSessionsByPaneKey = useAppStore(
-    (state) => state.sleepingAgentSessionsByPaneKey
+  // Why a key, not the record map: the exemption is worktree-scoped, so a
+  // sleeping-record write for another worktree must not re-render this one.
+  const sleepingRecordOwnedTabIdsKey = useAppStore((state) =>
+    selectSleepingRecordParkExemptTabIdsKey(state.sleepingAgentSessionsByPaneKey, worktreeId)
   )
   const sleepingRecordOwnedTabIds = useMemo(
-    () => selectSleepingRecordParkExemptTabIds(sleepingAgentSessionsByPaneKey, worktreeId),
-    [sleepingAgentSessionsByPaneKey, worktreeId]
+    () => parseSleepingRecordParkExemptTabIdsKey(sleepingRecordOwnedTabIdsKey),
+    [sleepingRecordOwnedTabIdsKey]
   )
   const terminalTabHiddenSinceRef = useRef(new Map<string, number>())
   // Why: view switches hide every tab at once, so the park clock cannot rank them.

--- a/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-tab-cold-parking.ts
@@ -7,6 +7,7 @@
  * render a slot as null.
  */
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 import { useAppStore } from '../../store'
 import {
@@ -29,10 +30,7 @@ import {
   selectEvictionExemptTerminalTabIds,
   selectEvictionExemptTerminalTabLayoutKey
 } from './terminal-eviction-exempt-tabs'
-import {
-  parseSleepingRecordParkExemptTabIdsKey,
-  selectSleepingRecordParkExemptTabIdsKey
-} from './sleeping-record-park-exemption'
+import { selectSleepingRecordParkExemptTabIds } from './sleeping-record-park-exemption'
 import { usePendingStartupParkPresence } from './terminal-pending-startup-park-presence'
 import { canWatcherCoverParkedTerminalTab } from './terminal-parked-tab-watchers'
 import { createTerminalTabActivationOrder } from './terminal-tab-activation-order'
@@ -118,14 +116,12 @@ export function useTerminalTabColdParking(args: {
   const pairedRuntimeParkingEnvironmentIds = useAppStore(
     selectPairedRuntimeParkingEnvironmentIdsFromState
   )
-  // Why a key, not the record map: the exemption is worktree-scoped, so a
-  // sleeping-record write for another worktree must not re-render this one.
-  const sleepingRecordOwnedTabIdsKey = useAppStore((state) =>
-    selectSleepingRecordParkExemptTabIdsKey(state.sleepingAgentSessionsByPaneKey, worktreeId)
-  )
-  const sleepingRecordOwnedTabIds = useMemo(
-    () => parseSleepingRecordParkExemptTabIdsKey(sleepingRecordOwnedTabIdsKey),
-    [sleepingRecordOwnedTabIdsKey]
+  // Why the worktree-scoped set, not the record map: the map is app-global, so
+  // subscribing to it re-rendered this worktree on every other worktree's write.
+  const sleepingRecordOwnedTabIds = useAppStore(
+    useShallow((state) =>
+      selectSleepingRecordParkExemptTabIds(state.sleepingAgentSessionsByPaneKey, worktreeId)
+    )
   )
   const terminalTabHiddenSinceRef = useRef(new Map<string, number>())
   // Why: view switches hide every tab at once, so the park clock cannot rank them.


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​319 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​319 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​130 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​53 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​77 |

<!-- /orca-pr-loc -->

## ELI5

Orca keeps every worktree you've opened alive in the background, even the ones you can't see. Each of those hidden worktrees was re-doing a big pile of bookkeeping work over and over — and worse, a tiny change in *one* worktree woke up *all* of them to redo it. This change makes the bookkeeping cheap and makes each worktree only wake up for its own changes. Nothing looks different; the app just wastes a lot less effort while you work.

## What Changed

Two commits.

**`44ee0c0bbc6` — key cost.**

- Memoized the store-derived half of the parked-watcher reconciliation key (`getWatcherReconciliationStoreInputsKey`) on the shallow-stable selector output. The serialization is byte-identical to before — pure caching, zero semantic change. The captured-pane half still recomputes per render, because `capturedPanesByTabId` is mutated outside React and cannot be keyed on a React dep.
- Removed the double `JSON.stringify`. `getWatcherSynchronizationKey` used to stringify an array that already contained a serialized string, re-escaping it. It now uses `joinKeyFragments` — a length-prefixed join (`` `${fragment.length}:${fragment}` ``), injective for arbitrary strings, with no escaping pass.
- Memoized `getTerminalParkingInputsKey` / `getTerminalParkingAssignmentsKey` in `use-terminal-tab-cold-parking.ts`.
- Narrowed the two app-global subscriptions in the cold-parking hook so a write for another worktree no longer re-renders this one. `selectSleepingRecordParkExemptTabIds` also iterates in place instead of `Object.values()`-allocating every sleeping record in the app on every store write.

**`3223000bfe6` — review fixes (this is a real correction, not polish).**

The first commit implemented the subscription narrowing by hand-rolling `\0`-joined string keys and parsing them back out. Review showed zustand already does this: on the pinned build (5.0.14) `shallow` compares `Set`s structurally and order-insensitively — `shallow(new Set(['a','b']), new Set(['b','a'])) === true`, `shallow(new Set(['a']), new Set(['a','b'])) === false`. So the second commit:

- Restored the `Set`-returning `selectSleepingRecordParkExemptTabIds` and subscribes via `useShallow`. Deletes `TAB_ID_SEPARATOR`, the `.sort()`, an O(k²) `owned.includes` dedup, `parseSleepingRecordParkExemptTabIdsKey`, and the caller's `useMemo`.
- Replaced the pending-startup key-build + `useMemo`-split pair with a single `useAppStore(useShallow(...))` returning a presence record, falling back to a frozen `EMPTY_PENDING_STARTUP` singleton so the steady state allocates nothing.
- Deleted an **inert** `useMemo` around the reconciliation selector, plus the WHY comment justifying it, which was factually wrong: `useShallow` builds a fresh arrow every render (no `useCallback`) and `useStore` does `useCallback(() => selector(api.getState()), [api, selector])`, so memoizing the selector could never stabilise the snapshot identity. Kept the extracted `selectWatcherReconciliationStoreInputs` and the `reconciliationStoreInputsKey` memo — that one is the actual fix.
- Added `ignores a sleeping-session write this worktree can never resume` — a blocked (`automaticResumeBlockedBy`) record for *this* worktree must not re-render. Pins the blocked-record exemption, which had no coverage at all.

Net effect of the fix round: −25 lines of production code, +19 of test.

## Why

`TerminalPaneOverlayLayer` rebuilt its parked-watcher synchronization key from scratch on **every render**. On `origin/main`:

- `use-parked-terminal-watcher-synchronization.ts:125` calls `getWatcherReconciliationKey` unmemoized in the render body, and `:94` `JSON.stringify`s the whole split-tree root per tab.
- `:51` then `JSON.stringify`s an array whose third element is that already-serialized string — a second full pass that only re-escapes characters.

Separately, two app-global subscriptions meant a write for *any* tab in *any* worktree re-rendered *every* mounted overlay layer at once:

- `use-terminal-tab-cold-parking.ts:101` — `useAppStore((state) => state.pendingStartupByTabId)`, whose only downstream read is `[tab.id] !== undefined`.
- `use-terminal-tab-cold-parking.ts:111-116` — subscribes to the whole `sleepingAgentSessionsByPaneKey` map, then narrows in a `useMemo` (too late; the render already happened).

`TerminalPaneOverlayLayer` being `memo`'d does not help — the subscription is inside the hook. Hidden worktrees stay mounted (`Terminal.tsx`, `mountedWorktreeIdsRef`), so this scales with worktree count and with uptime.

### Measured

12 worktrees × 4 tabs × 4-leaf split tree, median of 5 rounds × 20,000 renders, against the first commit:

| | per worktree render |
| --- | ---: |
| before | **9.51 µs** |
| after | **1.30 µs** |

**7.3× cheaper, 86% removed.** A burst of 100 unrelated store writes re-rendering all 12 overlays: **11.4 ms → 1.6 ms**. These numbers came from the `reconciliationStoreInputsKey` memo and `joinKeyFragments`, both untouched by the fix commit, so they still stand.

The benchmark was deliberately not committed — checking it in would have hard-coded the removed implementation forever.

### Correction to the original analysis

`getTerminalParkingInputsKey` / `getTerminalParkingAssignmentsKey` do **not** serialize the pane tree — they stringify `[id, ptyId, pendingActivationSpawn]` per tab. So it was ~3 pane-tree passes per render, not 5. Memoizing them is still free.

## Linked Issue

Does **not** close #16241. This was found while investigating that issue and is an independent, measured renderer cost; **#16241's actual cause remains unattributed** and no PR yet claims it. Merge this as a standalone perf change, not as a fix for the reported freeze. See #16253 for the other independent hardening filed under the same issue.

## Visual Proof

`N/A` — renderer-internal derived state and store subscriptions only. Nothing rendered changes: the parked/unparked outcome for every pane is identical before and after, which is what the 12-case key-semantics suite exists to pin. There is no user-visible surface to capture.

## Testing

From the fix round, run on the pushed head `3223000bfe6`:

```
$ pnpm tc
(no output; TC_EXIT=0)

$ pnpm test src/renderer/src/components/terminal-pane
 Test Files  393 passed (393)
      Tests  3799 passed (3799)
   Duration  16.49s

$ npx oxlint <5 changed files>
OXLINT_EXIT=0
```

**Non-vacuity, checked empirically rather than argued.** Reverting the 3 production files to `HEAD~1` and deleting `terminal-pending-startup-park-presence.ts`, the narrowing suite fails 3 of 5:

```
 x ignores a pending-startup write for another worktree tab
 x ignores a sleeping-session write for another worktree
 x ignores a sleeping-session write this worktree can never resume
AssertionError: expected 2 to be +0   (x3)
```

Separately, replacing `` key += `${fragment.length}:${fragment}` `` with `key += fragment` fails the fragment-collision test; dropping `layout?.root` fails the root-shape case.

The 12-test key-semantics suite **passes against pre-fix code**, and that is intended — it is a behavior-preservation guard for a pure-caching change, not a regression test. Stated here so nobody mistakes it for proof of the fix.

**Independently re-run by the reviewer** on a clean scratch worktree at `44ee0c0bbc6`: `vitest src/renderer/src/components/terminal-pane` 393 files / 3798 green; `+ floating-terminal + store` 312 files / 3037 green (the other `useTerminalTabColdParking` caller); `tsc --noEmit -p config/tsconfig.web.json` exit 0; `oxlint` clean on all changed files.

Platform: macOS only. Renderer-local JS with no path, shell, process or IPC surface, so there is no platform-dependent behavior to test — but it was not run on Windows or Linux.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude (Opus 4.x / Sonnet 4.x via Claude Code) assisted with the investigation, the benchmark harness, the review, and the fix round.

## Review

### Credit

**@mrgoonie — #16253.** The other PR open against #16241, `fix(sidebar): defensive worktree selection hardening`, removing render-phase `setState` from `useSidebarWorktreeSelection` / `useWorkspaceKanbanSelection`. @mrgoonie got the framing right independently and first: renderer update-churn under #16241 is worth hardening on its own evidence, and a PR should say plainly that it does not claim the issue. That honesty boundary — and the `*.react185.test.tsx` suite shape — is the same methodology this PR follows. **No code was inherited**: zero file overlap (sidebar/kanban selection hooks vs. terminal-pane parking hooks), and the two stack cleanly and are independently mergeable. Credit is for being right about the approach, not for lines taken.

**@rumoii — #16442.** Surfaced in the `16241 in:body` search but targets #16441 (Codex trust grants off the Electron main thread) in the main process. Unrelated to renderer parked-watcher key cost; nothing to inherit. Noting it so a reviewer cross-referencing #16241 does not have to re-check.

### Declined

- **A structural hash for the reconciliation key.** Rejected on purpose: a collision means a parked pane that never reconciles, and there is no cheap hash provably collision-free over arbitrary pane trees. `joinKeyFragments` is injective instead.
- **A pure unit test for `selectSleepingRecordParkExemptTabIdsKey` pinning `.sort()` order-insensitivity** (review finding P2 #2). Moot after adopting the `useShallow`-over-`Set` alternative — the string key and its `.sort()` no longer exist, so the ordering invariant it asked to pin is gone. The blocked-record case the finding *also* flagged as untested was added, as a narrowing test rather than a unit test, because that form additionally fails against pre-narrowing code.

### Residual risk a reviewer should weigh

1. **Per-write selector cost was traded for re-render count and was NOT benchmarked.** `selectSleepingRecordParkExemptTabIds` now iterates the whole app-global `sleepingAgentSessionsByPaneKey` on *every* store write, per mounted overlay; before it was an O(1) property read with the work behind a `useMemo`. Same shape for `usePendingStartupParkPresence` (O(terminalTabs) per write per overlay). The 9.51 µs → 1.30 µs figures measure per-render key cost and say nothing about this. With N worktrees mounted, M sleeping records, and the store written at spinner cadence (runtime pane titles carry braille frames), the per-write term is N×M and grows with uptime. Almost certainly still a net win — the removed work is a full React render, the added work is a loop — but this is the one axis the benchmark does not cover.
2. **The new memos are sound only while the store keeps immutable-update discipline.** Confirmed today that `setTabLayout` replaces snapshots (the `terminalLayoutEqual` bail preserves the old ref) and every `tabsByWorktree[id]` write assigns a fresh array, so `useMemo(getTerminalParkingInputsKey, [terminalTabs])` and the shallow-compared reconciliation inputs cannot go stale. But the pre-fix code recomputed per render and was therefore immune. Any future in-place mutation of a `TerminalTab` or `TerminalLayoutSnapshot` would now silently strand a parked pane's watcher key, and nothing in the repo enforces that discipline. The captured-pane half is correctly left unmemoized and is pinned by the `captured pane registry` test case.
3. **The claimed larger win is behavioral, not wall-clock.** ~10 ms per 100 global writes is real but is not, on its own, 25% of a core. The bigger effect is that unrelated-worktree writes now produce no render at all — which removes the whole React render of every overlay layer, not just the key work. That is proven by the narrowing tests, **not** quantified in wall-clock, and is stated as such.
4. **Consumer audit came out clean.** `pendingStartupByTabId` reaches only `selectColdParkedTerminalTabs` → `canParkTerminalTabRenderer`, whose sole read is `[tab.id] !== undefined` over tabs already drawn from `terminalTabs`, and whose param type is already `Readonly<Record<string, unknown>>`. Other store consumers (`Terminal.tsx`, `use-manual-terminal-worktree-parking`, `TerminalPane`, `resume-sleeping-agent-session`, `agent-startup-delayed-delivery`) still read the real record and are untouched. The renamed exemption selector has no other callers.

## Agent skill upstream boundary

- [x] Not applicable — no skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation involved.

## Notes

Dimensions 01 (SSH/relay), 03 (security), 06 (persistence / wire compat) and 07 (cross-platform) are not engaged: renderer-local derived state with no IPC, RPC, stream frame, persisted schema, path, process or shell surface. No backwards-compatibility surface. `use-terminal-tab-cold-parking.ts` is 383 lines against an 800-line cap for its glob — no `max-lines` pressure and no disables added.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` pass locally; `pnpm build` left to CI