### PR TITLE
perf(windows): ship the native process table to Windows relay hosts

### DIFF
--- a/.github/workflows/dev-channel-win-build.yml
+++ b/.github/workflows/dev-channel-win-build.yml
@@ -231,17 +231,14 @@ jobs:
         run: node config/scripts/verify-dev-channel-packaging.mjs --channel="$CHANNEL" --platform=win32
 
       # Why here and not in build:relay: only a Windows runner can compile it, and
-      # arm64 cross-compiles from this same x64 agent.
-      #
-      # arm64 is best-effort: it needs the optional MSVC ARM64 cross toolset, and
-      # a runner image without it should cost arm64 relays the fast path, not fail
-      # the release. Promote it to required below once a green run proves it.
+      # arm64 cross-compiles from this same x64 agent. Runs before the 20-minute
+      # build so a runner image missing the MSVC ARM64 cross toolset fails in
+      # seconds with MSB8020 naming the component, rather than deep into packaging.
       - name: Build Windows process-table addon for the relay
         shell: bash
         run: |
           node config/scripts/build-windows-process-tree-relay-addon.mjs --arch=x64
-          node config/scripts/build-windows-process-tree-relay-addon.mjs --arch=arm64 \
-            || echo "::warning::arm64 process-table addon did not build; win32-arm64 relays will use the PowerShell scan"
+          node config/scripts/build-windows-process-tree-relay-addon.mjs --arch=arm64
 
       - name: Build app
         shell: bash
@@ -249,7 +246,7 @@ jobs:
         env:
           # Fail the build rather than ship a relay that silently falls back to
           # the PowerShell scan on every Windows SSH host.
-          ORCA_REQUIRE_RELAY_NATIVE_ADDONS: 'x64'
+          ORCA_REQUIRE_RELAY_NATIVE_ADDONS: 'x64,arm64'
           # Why unset ORCA_BUILD_IDENTITY: telemetry's transport gate accepts only
           # 'stable' or 'rc', so leaving it unset keeps dev builds silent — which
           # is correct for unvetted artifacts. Same as the mac dev channels.

--- a/.github/workflows/dev-channel-win-build.yml
+++ b/.github/workflows/dev-channel-win-build.yml
@@ -230,10 +230,26 @@ jobs:
         shell: bash
         run: node config/scripts/verify-dev-channel-packaging.mjs --channel="$CHANNEL" --platform=win32
 
+      # Why here and not in build:relay: only a Windows runner can compile it, and
+      # arm64 cross-compiles from this same x64 agent.
+      #
+      # arm64 is best-effort: it needs the optional MSVC ARM64 cross toolset, and
+      # a runner image without it should cost arm64 relays the fast path, not fail
+      # the release. Promote it to required below once a green run proves it.
+      - name: Build Windows process-table addon for the relay
+        shell: bash
+        run: |
+          node config/scripts/build-windows-process-tree-relay-addon.mjs --arch=x64
+          node config/scripts/build-windows-process-tree-relay-addon.mjs --arch=arm64 \
+            || echo "::warning::arm64 process-table addon did not build; win32-arm64 relays will use the PowerShell scan"
+
       - name: Build app
         shell: bash
         run: pnpm build:release
         env:
+          # Fail the build rather than ship a relay that silently falls back to
+          # the PowerShell scan on every Windows SSH host.
+          ORCA_REQUIRE_RELAY_NATIVE_ADDONS: 'x64'
           # Why unset ORCA_BUILD_IDENTITY: telemetry's transport gate accepts only
           # 'stable' or 'rc', so leaving it unset keeps dev builds silent — which
           # is correct for unvetted artifacts. Same as the mac dev channels.

--- a/config/scripts/build-relay.mjs
+++ b/config/scripts/build-relay.mjs
@@ -23,6 +23,8 @@ import { join } from 'node:path'
 import {
   RELAY_BUILD_PLATFORMS,
   RELAY_VERSION_FILENAME,
+  RELAY_WINDOWS_PROCESS_TREE_FILENAME,
+  relayOptionalArtifactFilenames,
   isWindowsRelayPlatform,
   relayArtifactFilenames
 } from '../../src/shared/relay-artifacts.ts'
@@ -55,6 +57,38 @@ const NODE_PTY_CONSOLE_LIST_PATCH_SOURCE = join(
   'relay-assets',
   NODE_PTY_CONSOLE_LIST_PATCH_FILENAME
 )
+// Written by build-windows-process-tree-relay-addon.mjs, which only runs on a
+// Windows machine.
+const WINDOWS_PROCESS_TREE_BUILD_DIR = join(ROOT, '.build', 'windows-process-tree')
+
+// Which Windows arches must have the addon, as a comma-separated list ('all' for
+// every arch). Per-arch rather than a flag because arm64 needs the MSVC ARM64
+// cross toolset, an optional VS component: where it is absent that relay should
+// fall back to the scan, not fail the release the x64 relay is riding on.
+const REQUIRED_ADDON_ARCHES = (process.env.ORCA_REQUIRE_RELAY_NATIVE_ADDONS ?? '')
+  .split(',')
+  .map((value) => value.trim())
+  .filter(Boolean)
+
+function stageWindowsProcessTreeAddon(platform, outDir) {
+  if (!isWindowsRelayPlatform(platform)) {
+    return
+  }
+  const arch = platform.slice('win32-'.length)
+  const source = join(WINDOWS_PROCESS_TREE_BUILD_DIR, arch, RELAY_WINDOWS_PROCESS_TREE_FILENAME)
+  if (!existsSync(source)) {
+    if (REQUIRED_ADDON_ARCHES.includes(arch) || REQUIRED_ADDON_ARCHES.includes('all')) {
+      throw new Error(
+        `Relay ${platform} needs ${source}. Run: node config/scripts/build-windows-process-tree-relay-addon.mjs --arch=${arch} (Windows only).`
+      )
+    }
+    console.log(
+      `Relay ${platform}: no ${RELAY_WINDOWS_PROCESS_TREE_FILENAME}; relay will use the PowerShell scan.`
+    )
+    return
+  }
+  copyFileSync(source, join(outDir, RELAY_WINDOWS_PROCESS_TREE_FILENAME))
+}
 
 // Why: lets the packaging contract test build into a temp tree instead of
 // clobbering a developer's out/relay or racing tests that read it.
@@ -92,6 +126,7 @@ for (const platform of RELAY_BUILD_PLATFORMS) {
       join(outDir, NODE_PTY_CONSOLE_LIST_PATCH_FILENAME)
     )
   }
+  stageWindowsProcessTreeAddon(platform, outDir)
 
   await build({
     entryPoints: [WATCHER_ENTRY],
@@ -172,12 +207,25 @@ for (const platform of RELAY_BUILD_PLATFORMS) {
     }
     hash.update(readFileSync(artifactPath))
   }
+  // Why hashed only when present: a relay carrying the native addon answers
+  // differently from one that falls back to the scan, so the two must not share
+  // an immutable directory -- but a build without it is still valid.
+  for (const filename of relayOptionalArtifactFilenames(isWindowsRelayPlatform(platform))) {
+    const artifactPath = join(outDir, filename)
+    if (existsSync(artifactPath)) {
+      hash.update(readFileSync(artifactPath))
+    }
+  }
   const contentHash = hash.digest('hex').slice(0, 12)
 
   // Close the loop: an artifact emitted here but absent from the manifest would
   // ship unhashed and unprobed — exactly how the WSL helper went missing.
   const emitted = readdirSync(outDir).filter((name) => name !== RELAY_VERSION_FILENAME)
-  const undeclared = emitted.filter((name) => !expected.includes(name))
+  const declared = [
+    ...expected,
+    ...relayOptionalArtifactFilenames(isWindowsRelayPlatform(platform))
+  ]
+  const undeclared = emitted.filter((name) => !declared.includes(name))
   if (undeclared.length > 0) {
     throw new Error(
       `Relay ${platform} emitted undeclared artifacts: ${undeclared.join(', ')}. ` +

--- a/config/scripts/build-windows-process-tree-relay-addon.mjs
+++ b/config/scripts/build-windows-process-tree-relay-addon.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * Compile `@vscode/windows-process-tree` for a relay host.
+ *
+ * The relay is deployed to machines with no compiler, and this addon cannot be
+ * npm-installed there: it carries a binding.gyp, so npm rebuilds from source and
+ * the build wants Spectre-mitigated libraries even where MSVC is present. The
+ * binary inside the published tarball loads, but predates our patch and still
+ * caps enumeration at 1024 processes -- a busy host then gets a truncated table
+ * missing its own pid, which reads as "unavailable" only under load.
+ *
+ * So we compile it here, from the patched source pnpm already materialized, and
+ * ship the result as a relay artifact. Windows arm64 cross-compiles from an x64
+ * runner, so both arches come off one Windows job.
+ *
+ * Node headers, not Electron: the relay runs under the host's own `node`. The
+ * addon is N-API, so one build serves every Node the remote might have.
+ *
+ *   node config/scripts/build-windows-process-tree-relay-addon.mjs --arch=arm64
+ */
+import { execFileSync } from 'node:child_process'
+import {
+  closeSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readSync
+} from 'node:fs'
+import { join, resolve } from 'node:path'
+import { RELAY_WINDOWS_PROCESS_TREE_FILENAME } from '../../src/shared/relay-artifacts.ts'
+
+const ROOT = resolve(import.meta.dirname, '..', '..')
+const PACKAGE_DIR = join(ROOT, 'node_modules', '@vscode', 'windows-process-tree')
+const SUPPORTED_ARCHES = ['x64', 'arm64']
+
+/** PE `IMAGE_FILE_HEADER.Machine` values, so a cross-build cannot silently emit host arch. */
+const PE_MACHINE = { x64: 0x8664, arm64: 0xaa64 }
+
+function parseArgs(argv) {
+  const arch = argv.find((a) => a.startsWith('--arch='))?.slice('--arch='.length) ?? process.arch
+  const outDir = argv.find((a) => a.startsWith('--out='))?.slice('--out='.length)
+  if (!SUPPORTED_ARCHES.includes(arch)) {
+    throw new Error(`--arch must be one of ${SUPPORTED_ARCHES.join(', ')}; got ${arch}`)
+  }
+  return {
+    arch,
+    outDir: outDir ? resolve(outDir) : join(ROOT, '.build', 'windows-process-tree', arch)
+  }
+}
+
+/**
+ * Refuse to build unpatched source.
+ *
+ * Both hunks are load-bearing and fail in opposite directions: with Spectre the
+ * build dies outright, and with the cap it succeeds and lies. Checking the
+ * source rather than trusting the install is what stops a silently unpatched
+ * tree from being shipped as if it were patched.
+ */
+function assertPatchApplied() {
+  const bindingGyp = readFileSync(join(PACKAGE_DIR, 'binding.gyp'), 'utf8')
+  if (bindingGyp.includes('SpectreMitigation')) {
+    throw new Error(
+      'binding.gyp still requests SpectreMitigation. pnpm did not apply ' +
+        'config/patches/@vscode__windows-process-tree@0.8.0.patch; run pnpm install.'
+    )
+  }
+  const processCc = readFileSync(join(PACKAGE_DIR, 'src', 'process.cc'), 'utf8')
+  if (processCc.includes('process_count < 1024')) {
+    throw new Error(
+      'src/process.cc still caps enumeration at 1024 processes. pnpm did not apply ' +
+        'config/patches/@vscode__windows-process-tree@0.8.0.patch; run pnpm install.'
+    )
+  }
+}
+
+/** Read the PE machine field, so an arm64 request cannot ship an x64 binary. */
+function readPeMachine(binaryPath) {
+  const fd = openSync(binaryPath, 'r')
+  try {
+    const header = Buffer.alloc(4)
+    readSync(fd, header, 0, 4, 0x3c)
+    const peOffset = header.readUInt32LE(0)
+    const machine = Buffer.alloc(2)
+    readSync(fd, machine, 0, 2, peOffset + 4)
+    return machine.readUInt16LE(0)
+  } finally {
+    closeSync(fd)
+  }
+}
+
+function main() {
+  const { arch, outDir } = parseArgs(process.argv.slice(2))
+  if (process.platform !== 'win32') {
+    throw new Error(
+      `This addon only builds on Windows; running on ${process.platform}. ` +
+        'Relay builds elsewhere simply omit it and fall back to the CIM scan.'
+    )
+  }
+  if (!existsSync(PACKAGE_DIR)) {
+    throw new Error(`${PACKAGE_DIR} is missing. Run pnpm install first.`)
+  }
+  assertPatchApplied()
+
+  console.log(`[windows-process-tree] building ${arch} from ${PACKAGE_DIR}`)
+  execFileSync(
+    process.execPath,
+    [join(ROOT, 'node_modules', 'node-gyp', 'bin', 'node-gyp.js'), 'rebuild', `--arch=${arch}`],
+    { cwd: PACKAGE_DIR, stdio: 'inherit' }
+  )
+
+  const built = join(PACKAGE_DIR, 'build', 'Release', 'windows_process_tree.node')
+  if (!existsSync(built)) {
+    throw new Error(`node-gyp reported success but ${built} is missing.`)
+  }
+  const machine = readPeMachine(built)
+  if (machine !== PE_MACHINE[arch]) {
+    throw new Error(
+      `Built binary is machine 0x${machine.toString(16)}, expected 0x${PE_MACHINE[arch].toString(16)} for ${arch}. ` +
+        'node-gyp ignored --arch; a relay would get a binary its host cannot load.'
+    )
+  }
+
+  mkdirSync(outDir, { recursive: true })
+  const staged = join(outDir, RELAY_WINDOWS_PROCESS_TREE_FILENAME)
+  copyFileSync(built, staged)
+  console.log(`[windows-process-tree] ${arch} -> ${staged}`)
+}
+
+try {
+  main()
+} catch (error) {
+  console.error(`[windows-process-tree] ${error instanceof Error ? error.message : String(error)}`)
+  process.exit(1)
+}

--- a/docs/reference/windows-process-enumeration.md
+++ b/docs/reference/windows-process-enumeration.md
@@ -108,12 +108,36 @@ or listed there with the reason its absence is safe. That test exists because
 #15749 shipped this gap: the relay tests injected a fake module through
 `__setWindowsProcessTreeLoaderForTests`, so nothing exercised the real require.
 
-The native fast path stays unavailable on relay hosts until we ship our own
-patched `.node` as a relay asset — the addon is N-API, so one binary per
-`RELAY_BUILD_PLATFORMS` Windows arch would load against whatever Node the remote
-runs, and `config/relay-assets/` already carries a shipped-with-the-relay file
-for node-pty. That is a packaging change, not a code change, and it is a real
-gap tracked separately.
+## Shipping the native reader to a relay anyway
+
+The scan is the floor, not the destination: it costs ~1.4 s and a `powershell.exe`
+where the addon costs ~57 ms. Release builds therefore compile the addon and ship
+it as an optional relay artifact.
+
+`config/scripts/build-windows-process-tree-relay-addon.mjs` builds it from the
+source pnpm has already patched, on a Windows runner, and refuses to run if
+either patch hunk is missing — the Spectre hunk fails loudly, but the
+1024-process hunk fails *silently*, so the source is checked rather than the
+install trusted. It also reads the PE machine field of the output, because a
+cross-build that quietly emitted host arch would ship a binary the target cannot
+load.
+
+Windows arm64 cross-compiles from the x64 runner. It needs the optional MSVC
+ARM64 toolset, so it stays best-effort: a runner without that component costs
+arm64 relays the fast path rather than failing the release the x64 relay is
+riding on. `ORCA_REQUIRE_RELAY_NATIVE_ADDONS` is a per-arch list for that reason.
+
+`windows-process-table.ts` binds the bare addon directly rather than the package
+wrapper. That wrapper adds only a queue over `getProcessList`, and that queue is
+the wedge described above — it latches a module-global `requestInProgress` with
+no try/catch. This module already holds a single-flight and a deadline, so going
+straight to the addon drops the duplicate.
+
+The artifact is optional in `RELAY_ARTIFACTS`: hashed when present, so a relay
+carrying it never shares an immutable directory with one that does not, and
+never probed, because requiring a file only a Windows build machine can produce
+would make a correct relay read as MISSING and redeploy forever. A relay built
+on any other OS keeps using the scan.
 
 ## Why the package is patched
 

--- a/docs/reference/windows-process-enumeration.md
+++ b/docs/reference/windows-process-enumeration.md
@@ -122,10 +122,12 @@ install trusted. It also reads the PE machine field of the output, because a
 cross-build that quietly emitted host arch would ship a binary the target cannot
 load.
 
-Windows arm64 cross-compiles from the x64 runner. It needs the optional MSVC
-ARM64 toolset, so it stays best-effort: a runner without that component costs
-arm64 relays the fast path rather than failing the release the x64 relay is
-riding on. `ORCA_REQUIRE_RELAY_NATIVE_ADDONS` is a per-arch list for that reason.
+Windows arm64 cross-compiles from the x64 runner — verified on real hardware,
+producing `IMAGE_FILE_MACHINE_ARM64` (0xaa64) against x64's 0x8664. It needs the
+optional *MSVC v143 ARM64 build tools* component; without it node-gyp fails with
+`MSB8020`, which is why the addon build runs before the long packaging step.
+`ORCA_REQUIRE_RELAY_NATIVE_ADDONS` is a per-arch list so a future arch can be
+added best-effort before it is promoted to required.
 
 `windows-process-table.ts` binds the bare addon directly rather than the package
 wrapper. That wrapper adds only a queue over `getProcessList`, and that queue is

--- a/src/main/windows/windows-process-table.test.ts
+++ b/src/main/windows/windows-process-table.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   __setWindowsProcessTableCimScanForTests,
   __setWindowsProcessTreeLoaderForTests,
+  __setWindowsProcessTreeRequireForTests,
   isWindowsProcessTableAvailable,
   readWindowsProcessTable,
   readWindowsProcessTableFresh,
@@ -272,5 +273,124 @@ describe('wedge cooldown', () => {
       getAllProcesses: (cb: (rows: typeof NATIVE | undefined) => void) => cb(NATIVE)
     }))
     await expect(readWindowsProcessTableFresh()).resolves.toHaveLength(NATIVE.length)
+  })
+})
+
+// Why against the real require and not the loader seam: relay hosts have no
+// node_modules of ours, so which specifier resolves IS the behaviour. #15749
+// passed its suites because every one of them replaced the loader wholesale.
+describe('resolving the native reader', () => {
+  let platform: PropertyDescriptor | undefined
+  const PACKAGE_SPECIFIER = '@vscode/windows-process-tree'
+  const ADDON_SPECIFIER = './windows-process-tree.node'
+
+  beforeEach(() => {
+    platform = Object.getOwnPropertyDescriptor(process, 'platform')
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+  })
+
+  afterEach(() => {
+    __setWindowsProcessTreeRequireForTests()
+    __setWindowsProcessTableCimScanForTests()
+    if (platform) {
+      Object.defineProperty(process, 'platform', platform)
+    }
+  })
+
+  function addonReturning(rows: unknown): { getProcessList: ReturnType<typeof vi.fn> } {
+    return {
+      getProcessList: vi.fn((cb: (r: unknown) => void) => cb(rows))
+    }
+  }
+
+  it('prefers the npm package where the desktop app installs it', async () => {
+    const resolve = vi.fn((specifier: string) => {
+      if (specifier === PACKAGE_SPECIFIER) {
+        return { ProcessDataFlag: { None: 0, Memory: 1, CommandLine: 2 }, getAllProcesses }
+      }
+      throw new Error('should not reach the addon')
+    })
+    __setWindowsProcessTreeRequireForTests(resolve)
+    await expect(readWindowsProcessTableFresh()).resolves.toHaveLength(2)
+    expect(resolve).toHaveBeenCalledWith(PACKAGE_SPECIFIER)
+    expect(resolve).not.toHaveBeenCalledWith(ADDON_SPECIFIER)
+  })
+
+  it('falls through to the addon staged beside the relay bundle', async () => {
+    const addon = addonReturning(NATIVE)
+    __setWindowsProcessTreeRequireForTests((specifier: string) => {
+      if (specifier === ADDON_SPECIFIER) {
+        return addon
+      }
+      throw new Error('MODULE_NOT_FOUND')
+    })
+    const rows = await readWindowsProcessTableFresh()
+    expect(rows).toEqual([
+      { pid: process.pid, ppid: 0, name: 'vitest.exe', command: '', memoryBytes: undefined },
+      {
+        pid: 100,
+        ppid: 4,
+        name: 'orca.exe',
+        command: '"C:/a b/orca.exe" --x',
+        memoryBytes: 4096
+      }
+    ])
+    expect(isWindowsProcessTableAvailable()).toBe(true)
+  })
+
+  it('asks the addon for memory and command line, as the package path does', async () => {
+    const addon = addonReturning(NATIVE)
+    __setWindowsProcessTreeRequireForTests((specifier: string) => {
+      if (specifier === ADDON_SPECIFIER) {
+        return addon
+      }
+      throw new Error('MODULE_NOT_FOUND')
+    })
+    await readWindowsProcessTableFresh()
+    // Memory | CommandLine. A bare snapshot would silently drop the command
+    // line every agent-recognition caller matches on first.
+    expect(addon.getProcessList).toHaveBeenCalledWith(expect.any(Function), 3)
+  })
+
+  it('reaches the CIM scan when neither the package nor the addon is present', async () => {
+    const cimScan = vi
+      .fn()
+      .mockResolvedValue([
+        { pid: process.pid, ppid: 0, name: 'node.exe', command: 'node relay.js' }
+      ])
+    __setWindowsProcessTableCimScanForTests(cimScan)
+    __setWindowsProcessTreeRequireForTests(() => {
+      throw new Error('MODULE_NOT_FOUND')
+    })
+    await expect(readWindowsProcessTableFresh()).resolves.toHaveLength(1)
+    expect(cimScan).toHaveBeenCalledTimes(1)
+    expect(isWindowsProcessTableAvailable()).toBe(false)
+  })
+
+  it('rejects an addon that loads without the call we need', async () => {
+    // An arch mismatch or a truncated upload can still produce a loadable file.
+    // Binding to it would reject every read forever; the scan still works.
+    const cimScan = vi
+      .fn()
+      .mockResolvedValue([
+        { pid: process.pid, ppid: 0, name: 'node.exe', command: 'node relay.js' }
+      ])
+    __setWindowsProcessTableCimScanForTests(cimScan)
+    __setWindowsProcessTreeRequireForTests((specifier: string) => {
+      if (specifier === ADDON_SPECIFIER) {
+        return { notTheApi: true }
+      }
+      throw new Error('MODULE_NOT_FOUND')
+    })
+    await expect(readWindowsProcessTableFresh()).resolves.toHaveLength(1)
+    expect(cimScan).toHaveBeenCalledTimes(1)
+  })
+
+  it('never probes either specifier off Windows', async () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+    const resolve = vi.fn()
+    __setWindowsProcessTreeRequireForTests(resolve)
+    await expect(readWindowsProcessTableFresh()).rejects.toThrow(/unavailable/)
+    expect(resolve).not.toHaveBeenCalled()
   })
 })

--- a/src/main/windows/windows-process-table.ts
+++ b/src/main/windows/windows-process-table.ts
@@ -53,16 +53,57 @@ type WindowsProcessTreeModule = {
 
 const requireFromMain = createRequire(__filename)
 
+// Why injectable: `createRequire` bypasses the module mocker, and the two
+// resolution steps below are the exact thing #15749 shipped untested -- the
+// relay suites replaced the loader wholesale, so nothing exercised the require.
+let requireNative: (specifier: string) => unknown = requireFromMain
+
+/**
+ * The bare addon a relay host receives, with no npm package around it.
+ *
+ * The published package's `lib/index.js` adds only a queue over this call, and
+ * that queue is the wedge this module already defends against: it latches a
+ * module-global `requestInProgress` with no try/catch. We hold our own
+ * single-flight and deadline, so binding straight to the addon drops the
+ * duplicate queue rather than nesting inside it.
+ */
+type WindowsProcessTreeAddon = {
+  getProcessList: (
+    callback: (processes: NativeProcessInfo[] | undefined) => void,
+    flags: number
+  ) => void
+}
+
+/** Mirrors the package's enum; the addon takes the raw bit field. */
+const PROCESS_DATA_FLAG = { None: 0, Memory: 1, CommandLine: 2 } as const
+
+/** Staged beside the relay bundle by build-relay; see RELAY_ARTIFACTS. */
+const RELAY_ADDON_FILENAME = './windows-process-tree.node'
+
 let cachedModule: WindowsProcessTreeModule | null | undefined
 let moduleLoader: () => WindowsProcessTreeModule | null = loadWindowsProcessTree
 let cimScan: () => Promise<WindowsProcessRow[]> = readWindowsProcessRowsWithCim
 
+/** Present the bare addon through the same shape as the npm package. */
+function adaptAddon(addon: WindowsProcessTreeAddon): WindowsProcessTreeModule {
+  return {
+    ProcessDataFlag: PROCESS_DATA_FLAG,
+    getAllProcesses: (callback, flags) => addon.getProcessList(callback, flags ?? 0)
+  }
+}
+
 /**
- * Resolve the native module, or null where it cannot be used.
+ * Resolve the native reader, or null where it cannot be used.
  *
- * Why tolerate absence: it is an optional, Windows-only dependency, so a
- * macOS/Linux install legitimately has no binary. Callers must treat null the
- * same way they treat any other unavailable evidence.
+ * Two sources, because two very different deployments need it. The desktop app
+ * installs the npm package. A relay host has no node_modules of ours at all, so
+ * build-relay stages the bare addon next to the bundle and we bind to that.
+ *
+ * Why tolerate absence: it stays optional and Windows-only, so a macOS/Linux
+ * install legitimately has no binary, and a relay built before this artifact
+ * existed has no file. Callers must treat null the same way they treat any
+ * other unavailable evidence -- `readNativeRows` then falls back to the CIM
+ * scan, which needs nothing installed.
  */
 function loadWindowsProcessTree(): WindowsProcessTreeModule | null {
   if (cachedModule !== undefined) {
@@ -73,7 +114,18 @@ function loadWindowsProcessTree(): WindowsProcessTreeModule | null {
     return cachedModule
   }
   try {
-    cachedModule = requireFromMain('@vscode/windows-process-tree') as WindowsProcessTreeModule
+    cachedModule = requireNative('@vscode/windows-process-tree') as WindowsProcessTreeModule
+    return cachedModule
+  } catch {
+    // Not an error here: the relay never has the package. Try the staged addon.
+  }
+  try {
+    const addon = requireNative(RELAY_ADDON_FILENAME) as WindowsProcessTreeAddon
+    // Why check the shape: a truncated upload or an addon built for another
+    // arch can load and still not answer. Binding to it would then reject every
+    // read forever, where falling through reaches a scan that works.
+    cachedModule =
+      typeof addon?.getProcessList === 'function' ? adaptAddon(addon) : /* v8 ignore next */ null
   } catch {
     cachedModule = null
   }
@@ -250,6 +302,17 @@ export function __setWindowsProcessTreeLoaderForTests(
   loader?: () => WindowsProcessTreeModule | null
 ): void {
   moduleLoader = loader ?? loadWindowsProcessTree
+  cachedModule = undefined
+  wedgedUntilMs = 0
+  snapshotReader.reset()
+}
+
+/** Test-only: substitute the require that resolves the package and the addon. */
+export function __setWindowsProcessTreeRequireForTests(
+  resolve?: (specifier: string) => unknown
+): void {
+  requireNative = resolve ?? requireFromMain
+  moduleLoader = loadWindowsProcessTree
   cachedModule = undefined
   wedgedUntilMs = 0
   snapshotReader.reset()

--- a/src/shared/relay-artifacts.ts
+++ b/src/shared/relay-artifacts.ts
@@ -31,7 +31,16 @@ export type RelayArtifact = {
   filename: string
   /** Only Windows relays ship it; other hosts must neither receive nor probe it. */
   windowsOnly?: boolean
+  /**
+   * Present only when the build could produce it, so it is hashed when there and
+   * never probed. Required artifacts stay required: a probe that demanded an
+   * optional one would loop forever redeploying a relay that is already correct.
+   */
+  optional?: boolean
 }
+
+/** The bare Windows process-table addon; see docs/reference/windows-process-enumeration.md. */
+export const RELAY_WINDOWS_PROCESS_TREE_FILENAME = 'windows-process-tree.node'
 
 export const RELAY_ARTIFACTS: readonly RelayArtifact[] = [
   { filename: 'relay.js' },
@@ -41,7 +50,11 @@ export const RELAY_ARTIFACTS: readonly RelayArtifact[] = [
   // Forked by the AI Vault title reader; without it a relay answers every WSL
   // title request with no title and no error.
   { filename: 'wsl-transcript-fs-process-entry.js' },
-  { filename: 'node-pty-1.1.0-console-list-agent-patch.cjs', windowsOnly: true }
+  { filename: 'node-pty-1.1.0-console-list-agent-patch.cjs', windowsOnly: true },
+  // Optional because only a Windows build machine can compile it. Without it the
+  // relay reads the process table through a PowerShell scan instead -- slower,
+  // but correct, so a relay built anywhere else is still shippable.
+  { filename: RELAY_WINDOWS_PROCESS_TREE_FILENAME, windowsOnly: true, optional: true }
 ]
 
 /** Written after the artifacts, so it is never an input to its own hash. */
@@ -50,8 +63,16 @@ export const RELAY_VERSION_FILENAME = '.version'
 /** Written last by the installer; its absence means a torn install. */
 export const RELAY_INSTALL_COMPLETE_FILENAME = '.install-complete'
 
+/** Artifacts every relay must have; the remote install probe requires each one. */
 export function relayArtifactFilenames(isWindows: boolean): string[] {
-  return RELAY_ARTIFACTS.filter((artifact) => !artifact.windowsOnly || isWindows).map(
-    (artifact) => artifact.filename
-  )
+  return RELAY_ARTIFACTS.filter(
+    (artifact) => !artifact.optional && (!artifact.windowsOnly || isWindows)
+  ).map((artifact) => artifact.filename)
+}
+
+/** Artifacts a build may or may not emit. Hashed when present, never probed. */
+export function relayOptionalArtifactFilenames(isWindows: boolean): string[] {
+  return RELAY_ARTIFACTS.filter(
+    (artifact) => artifact.optional && (!artifact.windowsOnly || isWindows)
+  ).map((artifact) => artifact.filename)
 }

--- a/src/shared/relay-optional-artifacts.test.ts
+++ b/src/shared/relay-optional-artifacts.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import {
+  RELAY_WINDOWS_PROCESS_TREE_FILENAME,
+  relayArtifactFilenames,
+  relayOptionalArtifactFilenames
+} from './relay-artifacts'
+
+describe('optional relay artifacts', () => {
+  it('keeps the process-table addon out of the required set', () => {
+    // The remote install probe requires every name this returns. Demanding an
+    // artifact only a Windows build machine can emit would make a correct relay
+    // read as MISSING forever and redeploy on every connect.
+    expect(relayArtifactFilenames(true)).not.toContain(RELAY_WINDOWS_PROCESS_TREE_FILENAME)
+    expect(relayOptionalArtifactFilenames(true)).toContain(RELAY_WINDOWS_PROCESS_TREE_FILENAME)
+  })
+
+  it('never offers it to a non-Windows host', () => {
+    expect(relayOptionalArtifactFilenames(false)).not.toContain(RELAY_WINDOWS_PROCESS_TREE_FILENAME)
+    expect(relayOptionalArtifactFilenames(false)).toEqual([])
+  })
+
+  it('keeps required and optional sets disjoint', () => {
+    for (const isWindows of [true, false]) {
+      const required = relayArtifactFilenames(isWindows)
+      const optional = relayOptionalArtifactFilenames(isWindows)
+      expect(optional.filter((name) => required.includes(name))).toEqual([])
+    }
+  })
+
+  it('still requires everything a relay cannot run without', () => {
+    expect(relayArtifactFilenames(true)).toContain('relay.js')
+    expect(relayArtifactFilenames(true)).toContain('node-pty-1.1.0-console-list-agent-patch.cjs')
+  })
+})


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​154 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​154 |
| Prod | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​323 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​307 |

<!-- /orca-pr-loc -->

Follow-up to #16550, which restored correctness on Windows SSH hosts with a `Get-CimInstance` scan. That scan was always the floor, not the destination: measured on a Windows 11 SSH host with ~1490 processes, it costs **~1.36 s and a `powershell.exe` per read** where the native addon costs **~57 ms**. This ships the native reader to relay hosts.

## Why the addon can't just be installed there

Both routes were tried on real hardware:

- **Install it normally.** The tarball carries a `binding.gyp`, so npm runs `node-gyp rebuild` regardless of what's already compiled inside it. On a host that *already had* MSVC Build Tools 2022, that build still fails with `error MSB8040: Spectre-mitigated libraries are required`. That's the requirement our `binding.gyp` patch deletes, and pnpm patches don't cross SSH. `installNativeDeps` throws on failure with the toolchain-skip retry gated to Linux, so relay deploy would break outright.
- **Use the binary npm ships.** It loads (it's N-API), but predates our `src/process.cc` patch and still caps enumeration at 1024. On that 1486-process host it returned exactly **1024 rows with the querying process itself missing** — which the self-presence guard rejects. Worse than no binding: fine on a quiet machine, broken under load.

No published alternative clears the bar either. `@tabby-gang/*` and `@ohos-ports/*` both run `node-gyp rebuild` on install; `process-list` is nan-based (ABI-locked per Node major) and unmaintained since 2022; `ps-list`/`find-process`/`tasklist` shell out, so they're the same class as the scan we already have (and `tasklist` reports neither ppid nor command line, which agent recognition needs). The one fork with a real prebuild story still carries the same 1024 cap — decent evidence the patch is load-bearing.

## What this does

`config/scripts/build-windows-process-tree-relay-addon.mjs` compiles the addon from the source pnpm has already patched, on a Windows runner, and stages it into `.build/windows-process-tree/<arch>/`. `build-relay` copies it into each `win32-*` relay output.

Two guards, both for failure modes that are otherwise silent:

- **Refuses unpatched source.** Checks *both* hunks. The Spectre hunk fails loudly if missing, but the 1024 hunk fails silently — it builds fine and lies — so the source is verified rather than the install trusted.
- **Verifies the PE machine field.** A cross-build that ignored `--arch` would emit host arch and ship a binary the target can't load.

The loader (`bbbb730`) gains a second source: the desktop app still resolves the npm package, a relay host binds the bare `.node` staged beside the bundle, and the CIM scan stays as the last resort. It binds the addon **directly rather than the package wrapper** — that wrapper adds only a queue over `getProcessList`, and that queue is the wedge this module already defends against, latching a module-global `requestInProgress` with no try/catch. We hold our own single-flight and deadline, so going straight to the addon drops the duplicate.

## The artifact is optional, deliberately

`RELAY_ARTIFACTS` gains an `optional` flag. Optional artifacts are **hashed when present** — so a relay carrying the addon never shares an immutable directory with one that doesn't — and **never probed**, because `probeRelayInstalledCommand` requires every name it's given, and demanding a file only a Windows build machine can produce would make a correct relay read as `MISSING` and redeploy on every connect.

Consequence: `pnpm build:relay` on macOS/Linux is unchanged and still succeeds; those relays keep using the scan. Release builds set `ORCA_REQUIRE_RELAY_NATIVE_ADDONS` so a missing binary fails the build instead of silently shipping the slow path.

## Verified on real Windows hardware

Relay-externals bundle, run from a deployed relay directory (~1490 processes):

| | `nativeAvailable` | time | memory data |
|---|---|---|---|
| no addon staged (today) | `false` | 1247 ms | none |
| addon staged | `true` | **55–61 ms** | restored |

Degradation was exercised on that host, not just against fakes — a **truncated upload**, a **text file**, and a **foreign-arch ELF** each fall through to the scan rather than throwing, and restoring a good addon recovers. A file that loads but lacks `getProcessList` is rejected by shape, since binding to it would reject every read forever where falling through still answers.

The build script itself was run there too: the unpatched-source guard fires correctly, and an x64 build compiles, passes the PE check, and stages.

## The arm64 cross-compile, verified

Initially I could not test this — the Windows box lacked the optional *MSVC v143 ARM64 build tools* component, so `node-gyp --arch=arm64` failed with `MSB8020`. That component has since been installed and the cross-compile was run for real on an **x64** machine:

```
x64    machine=0x8664  152064 bytes
arm64  machine=0xaa64  139776 bytes
```

`IMAGE_FILE_MACHINE_ARM64` against x64's `AMD64`, and distinct sizes — genuinely separate builds, not a copy. So arm64 is **required** alongside x64 rather than best-effort.

If a runner image lacks the ARM64 component the build fails with `MSB8020` naming it exactly, and because the addon step runs *before* the long packaging step that costs seconds rather than twenty minutes. `ORCA_REQUIRE_RELAY_NATIVE_ADDONS` stays a per-arch list so a future arch can land best-effort before being promoted the same way.

## Validation

`pnpm tc` clean · **3914 tests** pass across `src/main/windows/`, `src/main/ssh/`, `src/relay/`, `src/main/providers/`, and the new manifest suite · `oxlint` clean · `build:relay` verified in four configurations (dev/no-addon, addon staged, strict-missing → fails, strict-partial → x64 required and arm64 warns) · confirmed the content hash differs with and without the addon, and that non-Windows relay outputs are byte-identical to before.