### PR TITLE
fix(dashboard): let the agent drawer yield to the page the user just opened

### DIFF
--- a/src/renderer/src/components/sidebar/AgentDashboardSidebarHost.test.tsx
+++ b/src/renderer/src/components/sidebar/AgentDashboardSidebarHost.test.tsx
@@ -59,6 +59,40 @@ describe('AgentDashboardSidebarHost', () => {
     await waitFor(() => expect(closeWorkspaceBoard).toHaveBeenCalledOnce())
   })
 
+  it('yields to the page the user just asked for', async () => {
+    const props = {
+      sidebarOpen: true,
+      workspaceBoardOpen: false,
+      closeWorkspaceBoard: vi.fn(),
+      statusBarVisible: true
+    }
+    useAppStore.setState({ activeView: 'terminal', agentDashboardDrawerOpen: true })
+    const view = render(<AgentDashboardSidebarHost {...props} />)
+
+    act(() => useAppStore.getState().openAutomationsPage())
+    view.rerender(<AgentDashboardSidebarHost {...props} />)
+
+    await waitFor(() => expect(useAppStore.getState().agentDashboardDrawerOpen).toBe(false))
+  })
+
+  // Why: opening the drawer never touches activeView, so a rule keyed on the current view rather
+  // than on a change to it would close a drawer opened while standing on one of those pages.
+  it('stays open when opened while a page is already showing', async () => {
+    const props = {
+      sidebarOpen: true,
+      workspaceBoardOpen: false,
+      closeWorkspaceBoard: vi.fn(),
+      statusBarVisible: true
+    }
+    useAppStore.setState({ activeView: 'automations', agentDashboardDrawerOpen: false })
+    const view = render(<AgentDashboardSidebarHost {...props} />)
+
+    act(() => useAppStore.setState({ agentDashboardDrawerOpen: true }))
+    view.rerender(<AgentDashboardSidebarHost {...props} />)
+
+    await waitFor(() => expect(useAppStore.getState().agentDashboardDrawerOpen).toBe(true))
+  })
+
   it('clears an open dashboard when the sidebar closes', async () => {
     useAppStore.setState({ agentDashboardDrawerOpen: true })
     render(

--- a/src/renderer/src/components/sidebar/AgentDashboardSidebarHost.tsx
+++ b/src/renderer/src/components/sidebar/AgentDashboardSidebarHost.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useAppStore } from '@/store'
 import { AgentDashboardDrawer } from '@/components/dashboard/AgentDashboardDrawer'
 
@@ -18,6 +18,7 @@ export default function AgentDashboardSidebarHost({
   leftSidebarStyle,
   statusBarVisible
 }: AgentDashboardSidebarHostProps): React.JSX.Element | null {
+  const activeView = useAppStore((s) => s.activeView)
   const drawerOpen = useAppStore((s) => s.agentDashboardDrawerOpen)
   const setDrawerOpen = useAppStore((s) => s.setAgentDashboardDrawerOpen)
 
@@ -36,6 +37,22 @@ export default function AgentDashboardSidebarHost({
       setDrawerOpen(false)
     }
   }, [setDrawerOpen, workspaceBoardOpen])
+  // Why the drawer yields when the view changes: it is a non-modal sheet, so the sidebar stays
+  // clickable underneath it, and a click there is a request for a different surface. Leaving the
+  // drawer up paints it over the page the user just asked for. The workspace board already yields
+  // to the drawer above; this is the same rule for the pages reached through activeView.
+  //
+  // Why the previous value rather than the current one: opening the drawer does not touch
+  // activeView, so a plain "activeView is not terminal" test would also close a drawer opened
+  // while standing on one of those pages, which is a surface the user did ask for.
+  const previousViewRef = useRef(activeView)
+  useEffect(() => {
+    const changed = previousViewRef.current !== activeView
+    previousViewRef.current = activeView
+    if (changed) {
+      setDrawerOpen(false)
+    }
+  }, [activeView, setDrawerOpen])
 
   return sidebarOpen ? (
     <AgentDashboardDrawer leftSidebarStyle={leftSidebarStyle} statusBarVisible={statusBarVisible} />


### PR DESCRIPTION
## ELI5

The agent dashboard slides out next to the sidebar, and the sidebar stays clickable while it is open. So you can click Automations with the dashboard still up — but nothing closed the dashboard, so it stayed on top of the page you just asked for. You could see the automations list faintly underneath and its heading cut in half. Now the dashboard steps aside when you open a different page, the same way it already steps aside for the workspace board.

## What Changed

`AgentDashboardSidebarHost` closes the drawer when `activeView` changes.

## Why

The drawer is `<Sheet ... modal={false}>`, so the sidebar underneath keeps taking clicks. A click there is a request for a different surface, and leaving the drawer up paints it over that surface.

The host already arbitrates exactly this, in both directions, for the workspace board:

```ts
useEffect(() => {
  if (drawerOpen) closeWorkspaceBoard()
}, [closeWorkspaceBoard, drawerOpen])
useEffect(() => {
  if (workspaceBoardOpen) setDrawerOpen(false)
}, [setDrawerOpen, workspaceBoardOpen])
```

Pages reached through `activeView` — automations, tasks, skills, artifacts — had no equivalent, which is the reported overlap.

**Keyed on a change to `activeView`, not on its value.** Opening the drawer never touches `activeView`, so `if (activeView !== 'terminal') close()` would also close a drawer opened while already standing on one of those pages — a surface the user did ask for. I wrote that version first and it broke exactly that case in the running app, which is why the second test below exists.

## Linked Issue

Fixes #16092

## Visual Proof

**Before** — dashboard opened first, then Automations clicked. The dashboard's kanban stays on top; the automations rows ("매일 npm 검사", "월별 정리", "+ 새로 추가") show through underneath and the page heading is clipped behind the sheet:

<img width="1536" height="816" alt="before-dashboard-over-automations" src="https://github.com/user-attachments/assets/e451dc98-27b9-4900-b62e-9df673bd9272" />


**After** — same order, dashboard yields and only the automations page is shown:

<img width="1536" height="816" alt="after-automations-clean" src="https://github.com/user-attachments/assets/873c83a2-1caa-4b3d-8579-0c9c3fa68853" />


## Testing

Reproduced first on Windows 11 (the issue reports macOS), so this is not platform-specific.

Checked both orders in the running dev app on `main` at `5e900b10b3`:

| order | before | after |
|---|---|---|
| dashboard open → click Automations | overlap | **automations only** |
| Automations open → click dashboard | drawer opens over the page | **unchanged — still opens** |
| terminal → open dashboard | opens | **unchanged** |
| dashboard open → open workspace board | drawer closes | **unchanged** |

Two cases added to `AgentDashboardSidebarHost.test.tsx`, matching the file's existing one-case-per-rule shape:

- *yields to the page the user just asked for* — the bug.
- *stays open when opened while a page is already showing* — the regression the value-based form would have introduced.

Reverting the source change fails the first and leaves the second green, so the first case actually pins the fix.

`pnpm typecheck` exits 0, `oxlint` on both files exits 0, and the `dashboard` + `sidebar` suites run 335 files / 2835 tests green.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Claude Opus 5 via Claude Code was used to trace the cause, write the fix and its tests. Note that the first attempt keyed the rule on the current view; testing in the app caught the regression and the rule was changed to key on the transition.

## Review

- **Security**: none. Renderer view coordination; no new input, no IPC, no privileged path.
- **Cross-platform**: no platform-dependent code. Reproduced on Windows, reported on macOS.
- **Remote SSH / local**: untouched — this is local view state.
- **Agents and integrations**: provider-neutral. Nothing here is agent-specific; the drawer's contents are unchanged.
- **Mobile**: untouched.
- **Performance**: one `useEffect` on a value the component already subscribes to, plus a ref. No new subscription, no work in a hot path.
- **UI quality**: restores the styleguide's expectation that the surface the user selects is the one they see. No new tokens, colors or components.
- **Backwards compatibility**: no contract change. The drawer opens exactly as before; it now closes on a transition it previously ignored.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance — covered under **Review**.

One judgement call worth surfacing: a non-modal sheet staying up over a changing background is defensible in the abstract, and I considered that this might be intended. What decided it is that the same host already closes the drawer for the workspace board, and that the page underneath renders half-visible rather than deliberately dimmed. If the intent was for the drawer to persist across page changes, this should be closed instead.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — `typecheck` and the affected suites locally
