### PR TITLE
perf(source-control): stop re-running every git read on each file selection (#15036)

### DIFF
--- a/src/main/diagnostics/main-thread-churn-probe.test.ts
+++ b/src/main/diagnostics/main-thread-churn-probe.test.ts
@@ -1,10 +1,19 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { writeStartupDiagnosticLineMock } = vi.hoisted(() => ({
+  writeStartupDiagnosticLineMock: vi.fn()
+}))
+vi.mock('../startup/startup-diagnostics', () => ({
+  writeStartupDiagnosticLine: writeStartupDiagnosticLineMock
+}))
+
 import {
   MAIN_THREAD_DIAGNOSTICS_ENV,
   classifySubprocessCommand,
   drainSubprocessSpawnStats,
   isMainThreadDiagnosticsEnabled,
-  recordSubprocessSpawn
+  recordSubprocessSpawn,
+  startMainThreadChurnProbe
 } from './main-thread-churn-probe'
 
 afterEach(() => {
@@ -85,5 +94,26 @@ describe('recordSubprocessSpawn', () => {
       'git rev-list': { count: 1, blockMsTotal: 1.5, blockMsMax: 1.5 }
     })
     expect(drainSubprocessSpawnStats()).toEqual({})
+  })
+})
+
+describe('startMainThreadChurnProbe', () => {
+  // Counters nothing reads are counters nobody can act on: the probe report is what makes
+  // "the diff cache never hit" visible outside a test run.
+  it('folds caller-contributed counters into the report line', async () => {
+    vi.stubEnv(MAIN_THREAD_DIAGNOSTICS_ENV, '1')
+    writeStartupDiagnosticLineMock.mockClear()
+    vi.useFakeTimers()
+    try {
+      startMainThreadChurnProbe({ extraStats: () => ({ diffCache: { hits: 3, misses: 1 } }) })
+      await vi.advanceTimersByTimeAsync(5_100)
+    } finally {
+      vi.useRealTimers()
+    }
+
+    const line = String(writeStartupDiagnosticLineMock.mock.calls.at(-1)?.[0] ?? '')
+    expect(JSON.parse(line.replace('[main-thread] ', ''))).toMatchObject({
+      diffCache: { hits: 3, misses: 1 }
+    })
   })
 })

--- a/src/main/diagnostics/main-thread-churn-probe.ts
+++ b/src/main/diagnostics/main-thread-churn-probe.ts
@@ -136,14 +136,20 @@ export function writeMainThreadDiagnosticMarker(marker: string): void {
   )
 }
 
+export type MainThreadChurnProbeOptions = {
+  /** Extra counters folded into each report line, sampled once per window. */
+  extraStats?: () => Record<string, unknown>
+}
+
 /**
  * Long-running main-process jank probe for benchmarks and field diagnosis of
  * issue #7576. Every 5s emits one `[main-thread] {json}` stderr line with the
- * window's worst event-loop stall, stall counts over 50/250ms, and drained
- * subprocess spawn stats. Unlike the startup stall probe this never stops:
- * the churn it measures (git status polling, updater retries) is steady-state.
+ * window's worst event-loop stall, stall counts over 50/250ms, drained subprocess
+ * spawn stats, and any counters the caller contributes. Unlike the startup stall
+ * probe this never stops: the churn it measures (git status polling, updater
+ * retries) is steady-state.
  */
-export function startMainThreadChurnProbe(): void {
+export function startMainThreadChurnProbe(options: MainThreadChurnProbeOptions = {}): void {
   if (!isMainThreadDiagnosticsEnabled()) {
     return
   }
@@ -176,7 +182,8 @@ export function startMainThreadChurnProbe(): void {
       gapsOver50Ms,
       gapsOver250Ms,
       spawnCount: Object.values(spawns).reduce((sum, s) => sum + s.count, 0),
-      spawns
+      spawns,
+      ...options.extraStats?.()
     }
     windowMaxGapMs = 0
     gapsOver50Ms = 0

--- a/src/main/git/command-runner/git-command-resolution.ts
+++ b/src/main/git/command-runner/git-command-resolution.ts
@@ -1,9 +1,12 @@
+import { waitForPromiseWithSignal } from '../../../shared/abort-signal-reason'
+import { withTimeout } from '../../../shared/promise-timeout-fallback'
 import { parseWslPath } from '../../wsl'
 import { isWslDirectGitReadCommand } from '../wsl-direct-git-read-commands'
 import {
   disableWslGitReadEnvironment,
   getWslGitReadEnvironment,
   invalidateWslGitReadEnvironment,
+  isWslGitReadEnvironmentSettled,
   peekWslGitReadEnvironment,
   WSL_GIT_READ_ENVIRONMENT_WAIT_MS
 } from '../wsl-git-read-environment'
@@ -91,21 +94,18 @@ export function pendingWslDirectGitReadEnvironment(
 ): Promise<unknown> | null {
   // Why null rather than a resolved promise: every non-WSL git call goes through here, and
   // awaiting even an already-settled promise would push the spawn into a later microtask.
+  // A settled probe — including a distro whose direct route was permanently disabled — has
+  // nothing left to wait for, and neither does a read that is already aborted.
   const distro = directWslGitReadDistro(args, options, false)
-  if (!distro || peekWslGitReadEnvironment(distro)) {
+  if (!distro || isWslGitReadEnvironmentSettled(distro) || options.signal?.aborted) {
     return null
   }
-  let timer: ReturnType<typeof setTimeout> | undefined
-  return Promise.race([
-    getWslGitReadEnvironment(distro),
-    new Promise((resolve) => {
-      timer = setTimeout(resolve, WSL_GIT_READ_ENVIRONMENT_WAIT_MS)
-    })
-  ]).finally(() => {
-    if (timer) {
-      clearTimeout(timer)
-    }
-  })
+  // withTimeout also absorbs rejection, so a probe failure can never become a read failure.
+  return withTimeout(
+    waitForPromiseWithSignal(getWslGitReadEnvironment(distro), options.signal),
+    WSL_GIT_READ_ENVIRONMENT_WAIT_MS,
+    null
+  )
 }
 
 export function resolveGitCommandWithoutProbe(

--- a/src/main/git/command-runner/git-command-resolution.ts
+++ b/src/main/git/command-runner/git-command-resolution.ts
@@ -4,7 +4,8 @@ import {
   disableWslGitReadEnvironment,
   getWslGitReadEnvironment,
   invalidateWslGitReadEnvironment,
-  peekWslGitReadEnvironment
+  peekWslGitReadEnvironment,
+  WSL_GIT_READ_ENVIRONMENT_WAIT_MS
 } from '../wsl-git-read-environment'
 import { usesHostGitForWslLinkedWorktree } from '../wsl-linked-worktree-git-routing'
 import { resolveCommand, type ResolvedCommand } from './wsl-command-resolution'
@@ -27,21 +28,37 @@ export function resolveGitCommand(
     // Why: WSL Git resolves a Windows-authored linked-worktree pointer relative to cwd.
     return { binary: 'git', args, cwd: options.cwd, wsl: null, wslMode: null }
   }
-  if (!forceLoginShell && shouldAttemptWslDirectGit(args, options)) {
-    const distro = wslDistroForCommand(options.cwd, options.wslDistro)
-    const environment = distro ? peekWslGitReadEnvironment(distro) : undefined
+  const distro = directWslGitReadDistro(args, options, forceLoginShell)
+  if (distro) {
+    const environment = peekWslGitReadEnvironment(distro)
     if (environment) {
-      return resolveCommand('git', args, options.cwd, options.wslDistro, {
+      return resolveCommand('git', args, options.cwd, distro, {
         wslGitReadEnvironment: environment,
         env: options.env,
         terminationBarrier: options.terminationBarrier
       })
     }
-    if (distro) {
-      void getWslGitReadEnvironment(distro)
-    }
+    void getWslGitReadEnvironment(distro)
   }
   return resolveGitCommandWithoutProbe(args, options, captureLoginShellOutput)
+}
+
+/**
+ * The distro this command could run shell-free in, or null when it can't.
+ *
+ * Why cwd counts: a `\\wsl.localhost\<distro>\...` worktree names its distro in
+ * the path, so requiring the caller to have resolved a WSL project runtime first
+ * left every diff read on the login shell — one rc run per `git show`.
+ */
+function directWslGitReadDistro(
+  args: string[],
+  options: GitExecOptions,
+  forceLoginShell: boolean
+): string | null {
+  if (forceLoginShell || !shouldAttemptWslDirectGit(args, options)) {
+    return null
+  }
+  return wslDistroForCommand(options.cwd, options.wslDistro)
 }
 
 function shouldAttemptWslDirectGit(args: string[], options: GitExecOptions): boolean {
@@ -55,9 +72,40 @@ function shouldAttemptWslDirectGit(args: string[], options: GitExecOptions): boo
     !Object.entries(options.env ?? {}).some(
       ([key, value]) =>
         key.startsWith('GIT_') && key !== 'GIT_OPTIONAL_LOCKS' && value !== process.env[key]
-    ) &&
-    options.wslDistro
+    )
   )
+}
+
+/**
+ * Give a read the chance to take the shell-free route instead of silently
+ * falling back while the probe is still resolving.
+ *
+ * The probe is one `wsl.exe` call, shared per distro and reused by every later
+ * command, so waiting costs at most once. Bounded because a cold or wedged
+ * distro must not hold a read behind it — past the bound the login-shell route
+ * runs exactly as it did before.
+ */
+export function pendingWslDirectGitReadEnvironment(
+  args: string[],
+  options: GitExecOptions
+): Promise<unknown> | null {
+  // Why null rather than a resolved promise: every non-WSL git call goes through here, and
+  // awaiting even an already-settled promise would push the spawn into a later microtask.
+  const distro = directWslGitReadDistro(args, options, false)
+  if (!distro || peekWslGitReadEnvironment(distro)) {
+    return null
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined
+  return Promise.race([
+    getWslGitReadEnvironment(distro),
+    new Promise((resolve) => {
+      timer = setTimeout(resolve, WSL_GIT_READ_ENVIRONMENT_WAIT_MS)
+    })
+  ]).finally(() => {
+    if (timer) {
+      clearTimeout(timer)
+    }
+  })
 }
 
 export function resolveGitCommandWithoutProbe(

--- a/src/main/git/command-runner/git-exec-file.ts
+++ b/src/main/git/command-runner/git-exec-file.ts
@@ -13,6 +13,7 @@ import { resolveCommand, type ResolvedCommand } from './wsl-command-resolution'
 import type { GitExecOptions } from './git-exec-options'
 import { execFileCapture, execFileCaptureToTermination } from './exec-file-capture'
 import {
+  pendingWslDirectGitReadEnvironment,
   directWslGitExitCode,
   disableDirectWslGitAfterSuccessfulFallback,
   invalidateMissingDirectWslGit,
@@ -38,6 +39,10 @@ async function gitExecFileAsyncUnlocked(
         await prepareWslLinkedWorktreeGitRouting(options.cwd, options.wslDistro, {
           signal: options.signal
         })
+      }
+      const readEnvironmentReady = pendingWslDirectGitReadEnvironment(args, options)
+      if (readEnvironmentReady) {
+        await readEnvironmentReady
       }
       let resolved = resolveGitCommand(args, options, false, options.captureWslLoginShellOutput)
       const environmentReady = prepareWindowsHostGitEnvironment(
@@ -127,10 +132,14 @@ export function gitExecFileAsync(
  */
 export async function gitExecFileAsyncBuffer(
   args: string[],
-  options: { cwd: string; maxBuffer?: number; wslDistro?: string }
+  options: { cwd: string; maxBuffer?: number; wslDistro?: string; preferWslDirectGit?: boolean }
 ): Promise<{ stdout: Buffer }> {
   if (isWslLinkedWorktreeGitRoutingCandidate(options.cwd, options.wslDistro)) {
     await prepareWslLinkedWorktreeGitRouting(options.cwd, options.wslDistro)
+  }
+  const readEnvironmentReady = pendingWslDirectGitReadEnvironment(args, options)
+  if (readEnvironmentReady) {
+    await readEnvironmentReady
   }
   // `git show` is a read, so this normally runs with no shell at all. The fence
   // still matters for the login-shell fallback: these are raw blob bytes going

--- a/src/main/git/command-runner/git-stream-stdout.ts
+++ b/src/main/git/command-runner/git-stream-stdout.ts
@@ -11,6 +11,7 @@ import { killSpawnedCommandTree } from './spawned-command-tree-kill'
 import type { ResolvedCommand } from './wsl-command-resolution'
 import { DEFAULT_GIT_MAX_BUFFER, type GitExecOptions } from './git-exec-options'
 import {
+  pendingWslDirectGitReadEnvironment,
   directWslGitExitCode,
   disableDirectWslGitAfterSuccessfulFallback,
   invalidateMissingDirectWslGit,
@@ -63,6 +64,10 @@ export async function gitStreamStdout(
       ...(options.wslDistro ? { wslDistro: options.wslDistro } : {}),
       ...(options.preferWslDirectGit ? { preferWslDirectGit: true } : {}),
       ...(options.signal ? { signal: options.signal } : {})
+    }
+    const readEnvironmentReady = pendingWslDirectGitReadEnvironment(args, gitOptions)
+    if (readEnvironmentReady) {
+      await readEnvironmentReady
     }
     let resolved = resolveGitCommand(args, gitOptions)
     const environmentReady = prepareWindowsHostGitEnvironment(

--- a/src/main/git/git-runtime-options.ts
+++ b/src/main/git/git-runtime-options.ts
@@ -14,7 +14,13 @@ export function gitOptionsForWorktree(
   }
 }
 
-export function gitStatusReadOptionsForWorktree(
+/**
+ * Options for a git invocation that only reads. Opting in explicitly keeps the
+ * shell-free WSL route from depending on `wsl-direct-git-read-commands`
+ * classifying the argv, which is a heuristic these call sites already know the
+ * answer to.
+ */
+export function gitReadOptionsForWorktree(
   cwd: string,
   options: GitRuntimeOptions = {}
 ): {

--- a/src/main/git/runner-wsl-direct-read.test.ts
+++ b/src/main/git/runner-wsl-direct-read.test.ts
@@ -17,8 +17,10 @@ vi.mock('../observability/instrumentation', () => ({
 }))
 vi.mock('../diagnostics/main-thread-churn-probe', () => ({ recordSubprocessSpawn: vi.fn() }))
 
+import { pendingWslDirectGitReadEnvironment } from './command-runner/git-command-resolution'
 import { gitExecFileAsync, gitSpawn, gitStreamStdout } from './runner'
 import {
+  disableWslGitReadEnvironment,
   getWslGitReadEnvironment,
   resetWslGitReadEnvironmentForTests,
   seedWslGitReadEnvironmentForTests,
@@ -434,6 +436,57 @@ describe('WSL direct Git reads', () => {
         const resolved = execFileMock.mock.calls.at(-1)?.[1] ?? []
         expect(resolved.slice(3, 5)).toEqual(['bash', '-c'])
         expect(resolved).not.toContain('/usr/bin/env')
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+  })
+
+  // Once the route is disabled the answer is already known, so paying for a timer and two
+  // extra microtask hops on every later read is pure overhead on the host this PR targets.
+  it('stops deferring reads once the direct route is disabled for the distro', async () => {
+    await withPlatform('win32', async () => {
+      seedWslGitReadEnvironmentForTests(DISTRO, LOGIN_ENVIRONMENT)
+      disableWslGitReadEnvironment(DISTRO)
+
+      expect(
+        pendingWslDirectGitReadEnvironment(['show', ':src/file.ts'], {
+          cwd: String.raw`\\wsl.localhost\Ubuntu\repo`
+        })
+      ).toBeNull()
+    })
+  })
+
+  it('never waits on the probe for an already-aborted read', async () => {
+    await withPlatform('win32', async () => {
+      const controller = new AbortController()
+      controller.abort()
+
+      expect(
+        pendingWslDirectGitReadEnvironment(['show', ':src/file.ts'], {
+          cwd: String.raw`\\wsl.localhost\Ubuntu\repo`,
+          signal: controller.signal
+        })
+      ).toBeNull()
+      expect(execFileMock).not.toHaveBeenCalled()
+    })
+  })
+
+  it('stops waiting for a cold probe as soon as the read aborts', async () => {
+    await withPlatform('win32', async () => {
+      vi.useFakeTimers()
+      try {
+        // The probe never answers, so only the abort can end the wait.
+        execFileMock.mockImplementation(() => createMockChild())
+        const controller = new AbortController()
+
+        const pending = pendingWslDirectGitReadEnvironment(['show', ':src/file.ts'], {
+          cwd: String.raw`\\wsl.localhost\Ubuntu\repo`,
+          signal: controller.signal
+        })
+        controller.abort()
+
+        await expect(pending).resolves.toBeNull()
       } finally {
         vi.useRealTimers()
       }

--- a/src/main/git/runner-wsl-direct-read.test.ts
+++ b/src/main/git/runner-wsl-direct-read.test.ts
@@ -21,7 +21,8 @@ import { gitExecFileAsync, gitSpawn, gitStreamStdout } from './runner'
 import {
   getWslGitReadEnvironment,
   resetWslGitReadEnvironmentForTests,
-  seedWslGitReadEnvironmentForTests
+  seedWslGitReadEnvironmentForTests,
+  WSL_GIT_READ_ENVIRONMENT_WAIT_MS
 } from './wsl-git-read-environment'
 import {
   prepareWslLinkedWorktreeGitRouting,
@@ -349,7 +350,9 @@ describe('WSL direct Git reads', () => {
     })
   })
 
-  it('leaves override-less WSL UNC routing on its existing non-login shell', async () => {
+  // A UNC worktree names its distro in the path, so a read there needs no resolved WSL project
+  // runtime to skip the shell -- requiring one is what kept every diff read on the login shell.
+  it('takes the direct read route for an override-less WSL UNC cwd', async () => {
     await withPlatform('win32', async () => {
       seedWslGitReadEnvironmentForTests(DISTRO, LOGIN_ENVIRONMENT)
       succeedExecFile()
@@ -359,7 +362,81 @@ describe('WSL direct Git reads', () => {
         preferWslDirectGit: true
       })
 
-      expect(execFileMock.mock.calls[0]?.[1]?.slice(3, 5)).toEqual(['bash', '-c'])
+      const resolved = execFileMock.mock.calls[0]?.[1] ?? []
+      expect(resolved).toContain('--exec')
+      expect(resolved).toContain(`PATH=${LOGIN_ENVIRONMENT.path}`)
+      expect(resolved).not.toContain('bash')
+    })
+  })
+
+  // The classifier already recognizes `show`, so the blob reads behind every diff take the
+  // direct route from the cwd alone -- no caller-supplied distro, no explicit opt-in.
+  it('takes the direct read route for an unclassified-caller blob read on a UNC cwd', async () => {
+    await withPlatform('win32', async () => {
+      seedWslGitReadEnvironmentForTests(DISTRO, LOGIN_ENVIRONMENT)
+      succeedExecFile()
+
+      await gitExecFileAsync(['show', ':src/file.ts'], {
+        cwd: String.raw`\\wsl.localhost\Ubuntu\repo`
+      })
+
+      expect(execFileMock.mock.calls[0]?.[1]).toContain('--exec')
+    })
+  })
+
+  // Kicking the probe off and resolving without it left the reads issued before it
+  // answered on the login shell -- the slow route, chosen by nothing but timing.
+  it('waits for a cold probe so the first read already skips the shell', async () => {
+    await withPlatform('win32', async () => {
+      execFileMock.mockImplementation((_command, args, _options, callback) => {
+        const child = createMockChild()
+        if (String(args).includes('_orca_git_path')) {
+          setTimeout(
+            () => callback?.(null, fencedProbeStdout(args, LOGIN_ENVIRONMENT_FIELDS), ''),
+            0
+          )
+        } else {
+          queueMicrotask(() => callback?.(null, 'ok', ''))
+        }
+        return child
+      })
+
+      await gitExecFileAsync(['show', ':src/file.ts'], {
+        cwd: String.raw`\\wsl.localhost\Ubuntu\repo`
+      })
+
+      expect(execFileMock.mock.calls.at(-1)?.[1]).toContain('--exec')
+      expect(execFileMock.mock.calls.at(-1)?.[1]).toContain(`PATH=${LOGIN_ENVIRONMENT.path}`)
+    })
+  })
+
+  it('stops waiting for a wedged probe and reads through the shell route', async () => {
+    await withPlatform('win32', async () => {
+      vi.useFakeTimers()
+      try {
+        execFileMock.mockImplementation((_command, args, _options, callback) => {
+          const child = createMockChild()
+          // The probe never answers; only the git command itself does.
+          if (!String(args).includes('_orca_git_path')) {
+            queueMicrotask(() => callback?.(null, 'ok', ''))
+          }
+          return child
+        })
+
+        const pending = gitExecFileAsync(['show', ':src/file.ts'], {
+          cwd: String.raw`\\wsl.localhost\Ubuntu\repo`
+        })
+        await vi.advanceTimersByTimeAsync(WSL_GIT_READ_ENVIRONMENT_WAIT_MS)
+        await pending
+
+        // Exactly the routing this read had before the wait existed: an unanswered
+        // probe must cost the bound and nothing else.
+        const resolved = execFileMock.mock.calls.at(-1)?.[1] ?? []
+        expect(resolved.slice(3, 5)).toEqual(['bash', '-c'])
+        expect(resolved).not.toContain('/usr/bin/env')
+      } finally {
+        vi.useRealTimers()
+      }
     })
   })
 

--- a/src/main/git/settled-diff-cache-bounds.test.ts
+++ b/src/main/git/settled-diff-cache-bounds.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import type { GitDiffResult } from '../../shared/git-diff-compare-types'
+import {
+  MAX_SETTLED_DIFF_CACHE_ENTRIES,
+  MAX_SETTLED_DIFF_CACHE_RESULT_CHARACTERS,
+  MAX_SETTLED_DIFF_CACHE_TOTAL_CHARACTERS,
+  SettledDiffCache
+} from './source-control/settled-diff-cache'
+import type { WorktreeDiffStamp } from './source-control/worktree-diff-stamp'
+
+function settledStamp(value: string): WorktreeDiffStamp {
+  // Old enough that the racy-write margin is satisfied.
+  return { value, newestMtimeMs: Date.now() - 60_000, capturedAtMs: Date.now() }
+}
+
+function diffOfSize(characters: number): GitDiffResult {
+  return {
+    kind: 'text',
+    originalContent: '',
+    modifiedContent: 'x'.repeat(characters),
+    originalIsBinary: false,
+    modifiedIsBinary: false
+  }
+}
+
+describe('SettledDiffCache bounds', () => {
+  it('evicts the least recently used entry past the entry cap', () => {
+    const cache = new SettledDiffCache()
+    for (let index = 0; index <= MAX_SETTLED_DIFF_CACHE_ENTRIES; index += 1) {
+      cache.set(`key-${index}`, settledStamp(`stamp-${index}`), diffOfSize(1), cache.beginRead())
+    }
+
+    expect(cache.stats().entries).toBe(MAX_SETTLED_DIFF_CACHE_ENTRIES)
+    expect(cache.get('key-0', settledStamp('stamp-0'))).toBeUndefined()
+    expect(
+      cache.get(
+        `key-${MAX_SETTLED_DIFF_CACHE_ENTRIES}`,
+        settledStamp(`stamp-${MAX_SETTLED_DIFF_CACHE_ENTRIES}`)
+      )
+    ).toBeDefined()
+  })
+
+  it('keeps a re-read entry alive by refreshing its LRU position', () => {
+    const cache = new SettledDiffCache()
+    cache.set('hot', settledStamp('hot-stamp'), diffOfSize(1), cache.beginRead())
+    for (let index = 0; index < MAX_SETTLED_DIFF_CACHE_ENTRIES; index += 1) {
+      cache.get('hot', settledStamp('hot-stamp'))
+      cache.set(`cold-${index}`, settledStamp(`cold-${index}`), diffOfSize(1), cache.beginRead())
+    }
+
+    expect(cache.get('hot', settledStamp('hot-stamp'))).toBeDefined()
+  })
+
+  // One entry can legitimately hold megabytes, so an entry count alone bounds nothing.
+  it('holds total retained content under the character budget', () => {
+    const cache = new SettledDiffCache()
+    const chunk = MAX_SETTLED_DIFF_CACHE_RESULT_CHARACTERS
+    const needed = Math.ceil(MAX_SETTLED_DIFF_CACHE_TOTAL_CHARACTERS / chunk) + 2
+
+    for (let index = 0; index < needed; index += 1) {
+      cache.set(
+        `key-${index}`,
+        settledStamp(`stamp-${index}`),
+        diffOfSize(chunk),
+        cache.beginRead()
+      )
+    }
+
+    expect(cache.stats().retainedCharacters).toBeLessThanOrEqual(
+      MAX_SETTLED_DIFF_CACHE_TOTAL_CHARACTERS
+    )
+  })
+
+  it('declines a single result larger than the per-entry cap', () => {
+    const cache = new SettledDiffCache()
+
+    cache.set(
+      'huge',
+      settledStamp('huge-stamp'),
+      diffOfSize(MAX_SETTLED_DIFF_CACHE_RESULT_CHARACTERS + 1),
+      cache.beginRead()
+    )
+
+    expect(cache.stats().entries).toBe(0)
+    expect(cache.stats().retainedCharacters).toBe(0)
+  })
+
+  it('releases retained characters when a key is overwritten', () => {
+    const cache = new SettledDiffCache()
+    cache.set('key', settledStamp('first'), diffOfSize(1_000), cache.beginRead())
+    cache.set('key', settledStamp('second'), diffOfSize(10), cache.beginRead())
+
+    expect(cache.stats().entries).toBe(1)
+    expect(cache.stats().retainedCharacters).toBe(10)
+    expect(cache.get('key', settledStamp('first'))).toBeUndefined()
+    expect(cache.get('key', settledStamp('second'))).toBeDefined()
+  })
+
+  it('drops everything and refuses in-flight stores after a clear', () => {
+    const cache = new SettledDiffCache()
+    const readGeneration = cache.beginRead()
+    cache.clear()
+    cache.set('key', settledStamp('stamp'), diffOfSize(1), readGeneration)
+
+    expect(cache.stats().entries).toBe(0)
+    expect(cache.stats().invalidatedDuringRead).toBe(1)
+  })
+})

--- a/src/main/git/settled-diff-cache-bounds.test.ts
+++ b/src/main/git/settled-diff-cache-bounds.test.ts
@@ -106,3 +106,49 @@ describe('SettledDiffCache bounds', () => {
     expect(cache.stats().invalidatedDuringRead).toBe(1)
   })
 })
+
+// Why (#15036 review): the margin compares this host's clock to mtimes the WSL guest
+// wrote. A guest running ahead refuses every store for as long as the skew lasts, and
+// without its own counter that is indistinguishable from a repo nobody has touched.
+describe('settled diff cache clock skew', () => {
+  const result: GitDiffResult = diffOfSize(10)
+
+  it('counts a future-dated mtime separately from an ordinary racy write', () => {
+    const cache = new SettledDiffCache()
+    const now = Date.now()
+
+    // Honestly fresh: written just now, margin not yet satisfied.
+    cache.set(
+      'fresh',
+      { value: 'a', newestMtimeMs: now, capturedAtMs: now },
+      result,
+      cache.beginRead()
+    )
+    // Skewed: mtime in this host's future, which no local write can produce.
+    cache.set(
+      'skewed',
+      { value: 'b', newestMtimeMs: now + 60_000, capturedAtMs: now },
+      result,
+      cache.beginRead()
+    )
+
+    const stats = cache.stats()
+    expect(stats.racyWrites).toBe(2)
+    expect(stats.clockSkewedWrites).toBe(1)
+    expect(stats.stores).toBe(0)
+  })
+
+  it('does not flag a stamp whose components were all absent', () => {
+    const cache = new SettledDiffCache()
+    const now = Date.now()
+
+    cache.set(
+      'absent',
+      { value: 'c', newestMtimeMs: Number.NEGATIVE_INFINITY, capturedAtMs: now },
+      result,
+      cache.beginRead()
+    )
+
+    expect(cache.stats().clockSkewedWrites).toBe(0)
+  })
+})

--- a/src/main/git/source-control/effective-upstream-status-probe.ts
+++ b/src/main/git/source-control/effective-upstream-status-probe.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../shared/git-effective-upstream'
 import { createGitConfigSnapshotRunner } from '../../../shared/git-config-snapshot-runner'
 import type { GitRuntimeOptions } from '../git-runtime-options'
-import { gitStatusReadOptionsForWorktree } from '../git-runtime-options'
+import { gitReadOptionsForWorktree } from '../git-runtime-options'
 import { gitExecFileAsync } from '../runner'
 import {
   MAX_EFFECTIVE_UPSTREAM_NEGATIVE_CACHE_ENTRIES,
@@ -90,7 +90,7 @@ async function probeOrRevalidateEffectiveUpstreamStatus(
   } else if (cached) {
     try {
       const status = await getGitUpstreamStatusForUpstreamName(
-        (args) => gitExecFileAsync(args, gitStatusReadOptionsForWorktree(worktreePath, options)),
+        (args) => gitExecFileAsync(args, gitReadOptionsForWorktree(worktreePath, options)),
         cached.upstreamName
       )
       return { status, probedSameNameOriginRef: false }
@@ -127,7 +127,7 @@ async function probeEffectiveUpstreamStatus(
 ): Promise<{ status: GitUpstreamStatus; probedSameNameOriginRef: boolean }> {
   let probedSameNameOriginRef = false
   const snapshotRunner = createGitConfigSnapshotRunner((args) =>
-    gitExecFileAsync(args, gitStatusReadOptionsForWorktree(worktreePath, options))
+    gitExecFileAsync(args, gitReadOptionsForWorktree(worktreePath, options))
   )
   const status = await getEffectiveGitUpstreamStatus((args) => {
     if (args[0] === 'rev-parse' && args.includes(`refs/remotes/origin/${branchName}`)) {

--- a/src/main/git/source-control/file-diff.ts
+++ b/src/main/git/source-control/file-diff.ts
@@ -3,7 +3,8 @@ import type { GitDiffResult } from '../../../shared/git-diff-compare-types'
 import { stableInFlightKey } from '../../../shared/in-flight-promise-dedupe'
 import type { GitRuntimeOptions } from '../git-runtime-options'
 import { gitRuntimeOptionsKey } from './git-runtime-options-cache-key'
-import { gitDiffReadDedupe } from './git-read-cache-invalidation'
+import { gitDiffReadDedupe, settledDiffCache } from './git-read-cache-invalidation'
+import { readWorktreeDiffStamp } from './worktree-diff-stamp'
 import { buildDiffResult } from './diff-result'
 import {
   readGitBlobAtIndexPath,
@@ -33,19 +34,64 @@ export async function getDiff(
   compareAgainstHead = false,
   options: GitRuntimeOptions = {}
 ): Promise<GitDiffResult> {
-  // Why: register the dedupe synchronously (before any await) so concurrent identical reads coalesce.
-  return gitDiffReadDedupe.run(
-    stableInFlightKey([
-      'diff',
+  const readKey = stableInFlightKey([
+    'diff',
+    worktreePath,
+    filePath,
+    staged,
+    compareAgainstHead,
+    ...gitRuntimeOptionsKey(options)
+  ])
+  // Why: register the dedupe synchronously (before any await) so concurrent identical reads
+  // coalesce — including on the settled-cache lookup, which is itself I/O.
+  return gitDiffReadDedupe.run(readKey, () =>
+    loadDiffThroughSettledCache(
+      readKey,
       worktreePath,
       filePath,
       staged,
       compareAgainstHead,
-      ...gitRuntimeOptionsKey(options)
-    ]),
-    () => loadDiff(worktreePath, filePath, staged, compareAgainstHead, options)
+      options
+    )
   )
 }
+
+/**
+ * Serve a settled diff when the git state it was built from is provably
+ * unchanged, otherwise read and — only if the read proved everything it touched
+ * — record it under the stamp taken *before* the read.
+ *
+ * Stamping first is what makes staleness impossible: anything that moves during
+ * or after the read leaves the stored stamp behind, so the next lookup misses.
+ */
+async function loadDiffThroughSettledCache(
+  readKey: string,
+  worktreePath: string,
+  filePath: string,
+  staged: boolean,
+  compareAgainstHead: boolean,
+  options: GitRuntimeOptions
+): Promise<GitDiffResult> {
+  // A staged diff compares HEAD to the index, so the working tree is not one of its inputs.
+  const stamp = await readWorktreeDiffStamp(worktreePath, filePath, !staged)
+  const cached = settledDiffCache.get(readKey, stamp)
+  if (cached) {
+    return cached
+  }
+  const readGeneration = settledDiffCache.beginRead()
+  const loaded = await loadDiff(worktreePath, filePath, staged, compareAgainstHead, options)
+  if (loaded.reusable) {
+    settledDiffCache.set(readKey, stamp, loaded.result, readGeneration)
+  }
+  return loaded.result
+}
+
+/**
+ * `reusable` is false when the result cannot be proven to describe the stamped
+ * state: a submodule route, whose inputs live in another repo and are stamped by
+ * that repo's own read, or a blob read that failed rather than proving absence.
+ */
+type LoadedDiff = { result: GitDiffResult; reusable: boolean }
 
 async function loadDiff(
   worktreePath: string,
@@ -53,7 +99,7 @@ async function loadDiff(
   staged: boolean,
   compareAgainstHead: boolean,
   options: GitRuntimeOptions
-): Promise<GitDiffResult> {
+): Promise<LoadedDiff> {
   // Why: gitlink paths can't be read as blobs, so route submodule diffs explicitly (root → pointer, inner → recurse).
   const submodulePaths = await listSubmodulePaths(worktreePath, options)
   if (submodulePaths.length > 0) {
@@ -63,13 +109,15 @@ async function loadDiff(
       const submoduleWorktreePath = resolveSubmoduleWorktreePath(worktreePath, matchedSubmodule)
       const normalizedFilePath = filePath.replace(/\\/g, '/').replace(/\/+$/, '')
       if (normalizedFilePath === matchedSubmodule) {
-        return buildSubmodulePointerDiff(
-          worktreePath,
-          matchedSubmodule,
-          staged,
-          compareAgainstHead,
-          options,
-          submoduleWorktreePath
+        return notReusable(
+          await buildSubmodulePointerDiff(
+            worktreePath,
+            matchedSubmodule,
+            staged,
+            compareAgainstHead,
+            options,
+            submoduleWorktreePath
+          )
         )
       }
       const innerPath = normalizedFilePath.slice(matchedSubmodule.length + 1)
@@ -82,15 +130,20 @@ async function loadDiff(
         : await readWorkingSubmoduleHead(submoduleWorktreePath, options)
       // Why: a moved gitlink with a clean submodule worktree means the change is committed — diff the two commits.
       if (fromOid && toOid && fromOid !== toOid) {
-        return buildSubmoduleInnerCommitRangeDiff(
-          submoduleWorktreePath,
-          innerPath,
-          fromOid,
-          toOid,
-          options
+        return notReusable(
+          await buildSubmoduleInnerCommitRangeDiff(
+            submoduleWorktreePath,
+            innerPath,
+            fromOid,
+            toOid,
+            options
+          )
         )
       }
-      return getDiff(submoduleWorktreePath, innerPath, staged, compareAgainstHead, options)
+      // The inner read stamps and caches against the submodule's own repo state.
+      return notReusable(
+        await getDiff(submoduleWorktreePath, innerPath, staged, compareAgainstHead, options)
+      )
     }
   }
 
@@ -99,6 +152,7 @@ async function loadDiff(
   let originalIsBinary = false
   let modifiedIsBinary = false
   let modifiedDeleted = false
+  let readFailed = false
 
   try {
     if (staged) {
@@ -113,6 +167,7 @@ async function loadDiff(
       modifiedContent = rightBlob.content
       modifiedIsBinary = rightBlob.isBinary
       modifiedDeleted = !rightBlob.exists
+      readFailed = leftBlob.failed === true || rightBlob.failed === true
     } else {
       // The left chain (index→HEAD) is sequential within itself, but the working
       // tree read is a plain fs read that does not depend on it.
@@ -127,9 +182,11 @@ async function loadDiff(
       modifiedContent = workingTreeBlob.content
       modifiedIsBinary = workingTreeBlob.isBinary
       modifiedDeleted = !workingTreeBlob.exists
+      readFailed = leftBlob.failed === true || workingTreeBlob.failed === true
     }
   } catch {
     // Fallback
+    readFailed = true
   }
 
   const result = buildDiffResult(
@@ -141,7 +198,11 @@ async function loadDiff(
   )
   // Why: mark a proven deletion so previewers don't mistake a read failure's empty side for one.
   if (result.kind === 'binary' && modifiedDeleted) {
-    return { ...result, modifiedDeleted: true }
+    return { result: { ...result, modifiedDeleted: true }, reusable: !readFailed }
   }
-  return result
+  return { result, reusable: !readFailed }
+}
+
+function notReusable(result: GitDiffResult): LoadedDiff {
+  return { result, reusable: false }
 }

--- a/src/main/git/source-control/file-diff.ts
+++ b/src/main/git/source-control/file-diff.ts
@@ -72,13 +72,15 @@ async function loadDiffThroughSettledCache(
   compareAgainstHead: boolean,
   options: GitRuntimeOptions
 ): Promise<GitDiffResult> {
+  // Why before the stamp read: the stamp is itself several awaited stats, and a mutation that
+  // lands entirely inside that window would otherwise leave the fence covering only the git read.
+  const readGeneration = settledDiffCache.beginRead()
   // A staged diff compares HEAD to the index, so the working tree is not one of its inputs.
   const stamp = await readWorktreeDiffStamp(worktreePath, filePath, !staged)
   const cached = settledDiffCache.get(readKey, stamp)
   if (cached) {
     return cached
   }
-  const readGeneration = settledDiffCache.beginRead()
   const loaded = await loadDiff(worktreePath, filePath, staged, compareAgainstHead, options)
   if (loaded.reusable) {
     settledDiffCache.set(readKey, stamp, loaded.result, readGeneration)

--- a/src/main/git/source-control/git-blob-read.ts
+++ b/src/main/git/source-control/git-blob-read.ts
@@ -2,7 +2,7 @@ import { readFile, stat } from 'node:fs/promises'
 import * as path from 'node:path'
 import { isBinaryBuffer } from '../../../shared/binary-buffer'
 import type { GitRuntimeOptions } from '../git-runtime-options'
-import { gitOptionsForWorktree } from '../git-runtime-options'
+import { gitReadOptionsForWorktree } from '../git-runtime-options'
 import { gitExecFileAsyncBuffer } from '../runner'
 import { isMaxBufferOverflowError } from '../max-buffer-overflow'
 import { MAX_GIT_SHOW_BYTES } from './git-show-max-bytes'
@@ -12,6 +12,21 @@ export type GitBlobReadResult = {
   content: string
   isBinary: boolean
   exists: boolean
+  /**
+   * The read did not complete: the blob is neither known-present nor proven
+   * absent. Callers must not persist a diff built on one, because the empty side
+   * it produces is indistinguishable from a genuinely new file.
+   */
+  failed?: boolean
+}
+
+/**
+ * Tell "Git ran and said the path is not there" apart from "the read never got
+ * an answer". Git exits 128 for a missing path in a tree or the index; a WSL
+ * relay that never reached Git exits with anything else, or with a spawn errno.
+ */
+function isProvenAbsentError(error: unknown): boolean {
+  return (error as { code?: unknown } | null)?.code === 128
 }
 
 export async function readUnstagedLeftBlob(
@@ -24,7 +39,9 @@ export async function readUnstagedLeftBlob(
     return indexBlob
   }
 
-  return readGitBlobAtOidPath(worktreePath, 'HEAD', filePath, options)
+  const headBlob = await readGitBlobAtOidPath(worktreePath, 'HEAD', filePath, options)
+  // Why: if the index read never got an answer, falling back to HEAD is a guess, not a proof.
+  return indexBlob.failed ? { ...headBlob, failed: true } : headBlob
 }
 
 export async function readGitBlobAtIndexPath(
@@ -36,7 +53,7 @@ export async function readGitBlobAtIndexPath(
   const gitPath = filePath.replace(/\\/g, '/')
   try {
     const { stdout } = await gitExecFileAsyncBuffer(['show', `:${gitPath}`], {
-      ...gitOptionsForWorktree(worktreePath, options),
+      ...gitReadOptionsForWorktree(worktreePath, options),
       maxBuffer: MAX_GIT_SHOW_BYTES
     })
 
@@ -45,7 +62,7 @@ export async function readGitBlobAtIndexPath(
     if (isMaxBufferOverflowError(error)) {
       return { content: '', isBinary: true, exists: true }
     }
-    return { content: '', isBinary: false, exists: false }
+    return { content: '', isBinary: false, exists: false, failed: !isProvenAbsentError(error) }
   }
 }
 
@@ -61,7 +78,7 @@ export async function readGitBlobAtOidPath(
     const { stdout } = await gitExecFileAsyncBuffer(
       ['show', '--end-of-options', `${oid}:${gitPath}`],
       {
-        ...gitOptionsForWorktree(worktreePath, options),
+        ...gitReadOptionsForWorktree(worktreePath, options),
         maxBuffer: MAX_GIT_SHOW_BYTES
       }
     )
@@ -71,7 +88,7 @@ export async function readGitBlobAtOidPath(
     if (isMaxBufferOverflowError(error)) {
       return { content: '', isBinary: true, exists: true }
     }
-    return { content: '', isBinary: false, exists: false }
+    return { content: '', isBinary: false, exists: false, failed: !isProvenAbsentError(error) }
   }
 }
 
@@ -81,11 +98,8 @@ export async function readWorkingTreeFile(filePath: string): Promise<GitBlobRead
     fileStat = await stat(filePath)
   } catch (error) {
     // Why: only ENOENT is a real deletion; other stat errors are read failures, not absence.
-    return {
-      content: '',
-      isBinary: false,
-      exists: (error as NodeJS.ErrnoException)?.code !== 'ENOENT'
-    }
+    const missing = (error as NodeJS.ErrnoException)?.code === 'ENOENT'
+    return { content: '', isBinary: false, exists: !missing, ...(missing ? {} : { failed: true }) }
   }
   if (!fileStat.isFile()) {
     return { content: '', isBinary: false, exists: false }
@@ -99,7 +113,7 @@ export async function readWorkingTreeFile(filePath: string): Promise<GitBlobRead
     return bufferToBlob(buffer, filePath)
   } catch {
     // Why: the file exists but could not be read — a read failure, not a deletion.
-    return { content: '', isBinary: false, exists: true }
+    return { content: '', isBinary: false, exists: true, failed: true }
   }
 }
 

--- a/src/main/git/source-control/git-conflict-operation.ts
+++ b/src/main/git/source-control/git-conflict-operation.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs'
+import { access } from 'node:fs/promises'
 import * as path from 'node:path'
 import type { GitConflictOperation } from '../../../shared/git-status-types'
 import type { GitRuntimeOptions } from '../git-runtime-options'
@@ -16,17 +16,12 @@ export async function detectConflictOperation(worktreePath: string): Promise<Git
   const rebaseMergeDir = path.join(gitDir, 'rebase-merge')
   const rebaseApplyDir = path.join(gitDir, 'rebase-apply')
 
-  let hasMergeHead = false
-  let hasCherryPickHead = false
-  let hasRebaseDir = false
-
-  try {
-    hasMergeHead = existsSync(mergeHead)
-    hasCherryPickHead = existsSync(cherryPickHead)
-    hasRebaseDir = existsSync(rebaseMergeDir) || existsSync(rebaseApplyDir)
-  } catch {
-    return 'unknown'
-  }
+  // Why async and concurrent: this runs on every status poll, and on a WSL/UNC git dir each
+  // probe is a 9p round trip — four of them synchronously blocked the Electron main thread.
+  const [hasMergeHead, hasCherryPickHead, hasRebaseMergeDir, hasRebaseApplyDir] = await Promise.all(
+    [mergeHead, cherryPickHead, rebaseMergeDir, rebaseApplyDir].map(pathExists)
+  )
+  const hasRebaseDir = hasRebaseMergeDir || hasRebaseApplyDir
 
   if (hasMergeHead) {
     return 'merge'
@@ -38,6 +33,16 @@ export async function detectConflictOperation(worktreePath: string): Promise<Git
     return 'cherry-pick'
   }
   return 'unknown'
+}
+
+/** Mirrors existsSync: any failure to reach the path reads as absent, never as a throw. */
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await access(target)
+    return true
+  } catch {
+    return false
+  }
 }
 
 export async function abortMerge(

--- a/src/main/git/source-control/git-read-cache-invalidation.ts
+++ b/src/main/git/source-control/git-read-cache-invalidation.ts
@@ -7,8 +7,12 @@ import { GitStatusReadLeaseOwner } from '../git-status-read-lease-owner'
 import { invalidateGitUpstreamStatusReads } from '../upstream'
 import { clearSubmodulePathsCache } from './submodule-paths'
 import { resolvedUpstreamNameCache } from './resolved-upstream-name-cache'
+import { SettledDiffCache } from './settled-diff-cache'
 
 export const gitDiffReadDedupe = new InFlightPromiseDedupe<GitDiffResult>()
+
+/** Settled diff results, valid only while their stamped git state holds. */
+export const settledDiffCache = new SettledDiffCache()
 
 export const statusReadLeaseOwner = new GitStatusReadLeaseOwner<GitStatusResult>()
 
@@ -16,6 +20,7 @@ export const statusReadLeaseOwner = new GitStatusReadLeaseOwner<GitStatusResult>
 // getStatus() join a pre-mutation read and publish it as current.
 export function invalidateGitReadCaches(): void {
   gitDiffReadDedupe.clear()
+  settledDiffCache.clear()
   statusReadLeaseOwner.invalidate()
   invalidateGitBranchLineTotalInFlight()
   invalidateGitUpstreamStatusReads()

--- a/src/main/git/source-control/settled-diff-cache.ts
+++ b/src/main/git/source-control/settled-diff-cache.ts
@@ -1,3 +1,4 @@
+import { BoundedMap } from '../../../shared/bounded-map'
 import type { GitDiffResult } from '../../../shared/git-diff-compare-types'
 import { canProveUnchangedByStamp, type WorktreeDiffStamp } from './worktree-diff-stamp'
 
@@ -38,8 +39,12 @@ export type SettledDiffCacheStats = {
 type CacheEntry = { stamp: string; result: GitDiffResult; characters: number }
 
 export class SettledDiffCache {
-  private readonly entries = new Map<string, CacheEntry>()
-  private retainedCharacters = 0
+  private readonly entries = new BoundedMap<string, CacheEntry>({
+    maxEntries: MAX_SETTLED_DIFF_CACHE_ENTRIES,
+    maxBytes: MAX_SETTLED_DIFF_CACHE_TOTAL_CHARACTERS,
+    maxEntryBytes: MAX_SETTLED_DIFF_CACHE_RESULT_CHARACTERS,
+    sizeOf: (entry) => entry.characters
+  })
   private generation = 0
   private hits = 0
   private misses = 0
@@ -62,14 +67,12 @@ export class SettledDiffCache {
       this.unprovable += 1
       return undefined
     }
+    // BoundedMap.get() already refreshes the LRU position.
     const entry = this.entries.get(key)
     if (!entry || entry.stamp !== stamp.value) {
       this.misses += 1
       return undefined
     }
-    // Refresh LRU position.
-    this.entries.delete(key)
-    this.entries.set(key, entry)
     this.hits += 1
     return entry.result
   }
@@ -92,36 +95,13 @@ export class SettledDiffCache {
       return
     }
     const characters = resultCharacterCount(result)
-    if (characters > MAX_SETTLED_DIFF_CACHE_RESULT_CHARACTERS) {
-      return
-    }
-    this.evict(key)
-    this.entries.set(key, { stamp: stamp.value, result, characters })
-    this.retainedCharacters += characters
-    this.stores += 1
-    while (
-      this.entries.size > MAX_SETTLED_DIFF_CACHE_ENTRIES ||
-      this.retainedCharacters > MAX_SETTLED_DIFF_CACHE_TOTAL_CHARACTERS
-    ) {
-      const oldestKey = this.entries.keys().next().value
-      if (oldestKey === undefined || oldestKey === key) {
-        break
-      }
-      this.evict(oldestKey)
-    }
-  }
-
-  private evict(key: string): void {
-    const existing = this.entries.get(key)
-    if (existing) {
-      this.retainedCharacters -= existing.characters
-      this.entries.delete(key)
+    if (this.entries.set(key, { stamp: stamp.value, result, characters })) {
+      this.stores += 1
     }
   }
 
   clear(): void {
     this.entries.clear()
-    this.retainedCharacters = 0
     // Why: bump so a read that started pre-mutation can't repopulate the invalidated cache.
     this.generation += 1
   }
@@ -140,7 +120,7 @@ export class SettledDiffCache {
       racyWrites: this.racyWrites,
       invalidatedDuringRead: this.invalidatedDuringRead,
       entries: this.entries.size,
-      retainedCharacters: this.retainedCharacters
+      retainedCharacters: this.entries.retainedBytes
     }
   }
 

--- a/src/main/git/source-control/settled-diff-cache.ts
+++ b/src/main/git/source-control/settled-diff-cache.ts
@@ -1,0 +1,159 @@
+import type { GitDiffResult } from '../../../shared/git-diff-compare-types'
+import { canProveUnchangedByStamp, type WorktreeDiffStamp } from './worktree-diff-stamp'
+
+/**
+ * Diff results that survive their read, guarded by a stamp of the git state they
+ * were built from.
+ *
+ * Why this is not a TTL: nothing here expires on a clock, so no window exists in
+ * which a stale diff can be served. An entry is returned only when a freshly
+ * taken stamp equals the one captured *before* the read that produced it, which
+ * means no input moved from then until now. Everything else — an unprovable
+ * stamp, a write too recent for its mtime to be conclusive, a read that failed
+ * partway, a mutation that ran while the read was in flight — declines to cache
+ * rather than risk it.
+ */
+
+// A diff result carries whole file contents on both sides, so an entry count alone bounds
+// nothing: the real budget is characters, and one entry can legitimately be huge.
+export const MAX_SETTLED_DIFF_CACHE_ENTRIES = 32
+export const MAX_SETTLED_DIFF_CACHE_RESULT_CHARACTERS = 1_000_000
+export const MAX_SETTLED_DIFF_CACHE_TOTAL_CHARACTERS = 8_000_000
+
+export type SettledDiffCacheStats = {
+  hits: number
+  /** Stamp was taken but no entry matched it. */
+  misses: number
+  /** No stamp could be taken, so the read could never be cached. */
+  unprovable: number
+  stores: number
+  /** Store declined because a write was too recent for its mtime to be conclusive. */
+  racyWrites: number
+  /** Store declined because a mutation invalidated the cache while the read ran. */
+  invalidatedDuringRead: number
+  entries: number
+  retainedCharacters: number
+}
+
+type CacheEntry = { stamp: string; result: GitDiffResult; characters: number }
+
+export class SettledDiffCache {
+  private readonly entries = new Map<string, CacheEntry>()
+  private retainedCharacters = 0
+  private generation = 0
+  private hits = 0
+  private misses = 0
+  private unprovable = 0
+  private stores = 0
+  private racyWrites = 0
+  private invalidatedDuringRead = 0
+
+  /**
+   * Take before starting a read; hand back to `set`. A mutation that lands while
+   * the read is in flight bumps the generation, and the store is refused — the
+   * result describes pre-mutation state and must not outlive it.
+   */
+  beginRead(): number {
+    return this.generation
+  }
+
+  get(key: string, stamp: WorktreeDiffStamp | null): GitDiffResult | undefined {
+    if (!stamp) {
+      this.unprovable += 1
+      return undefined
+    }
+    const entry = this.entries.get(key)
+    if (!entry || entry.stamp !== stamp.value) {
+      this.misses += 1
+      return undefined
+    }
+    // Refresh LRU position.
+    this.entries.delete(key)
+    this.entries.set(key, entry)
+    this.hits += 1
+    return entry.result
+  }
+
+  set(
+    key: string,
+    stamp: WorktreeDiffStamp | null,
+    result: GitDiffResult,
+    readGeneration: number
+  ): void {
+    if (!stamp) {
+      return
+    }
+    if (readGeneration !== this.generation) {
+      this.invalidatedDuringRead += 1
+      return
+    }
+    if (!canProveUnchangedByStamp(stamp)) {
+      this.racyWrites += 1
+      return
+    }
+    const characters = resultCharacterCount(result)
+    if (characters > MAX_SETTLED_DIFF_CACHE_RESULT_CHARACTERS) {
+      return
+    }
+    this.evict(key)
+    this.entries.set(key, { stamp: stamp.value, result, characters })
+    this.retainedCharacters += characters
+    this.stores += 1
+    while (
+      this.entries.size > MAX_SETTLED_DIFF_CACHE_ENTRIES ||
+      this.retainedCharacters > MAX_SETTLED_DIFF_CACHE_TOTAL_CHARACTERS
+    ) {
+      const oldestKey = this.entries.keys().next().value
+      if (oldestKey === undefined || oldestKey === key) {
+        break
+      }
+      this.evict(oldestKey)
+    }
+  }
+
+  private evict(key: string): void {
+    const existing = this.entries.get(key)
+    if (existing) {
+      this.retainedCharacters -= existing.characters
+      this.entries.delete(key)
+    }
+  }
+
+  clear(): void {
+    this.entries.clear()
+    this.retainedCharacters = 0
+    // Why: bump so a read that started pre-mutation can't repopulate the invalidated cache.
+    this.generation += 1
+  }
+
+  /**
+   * Why exposed: a stamp that can never match — an inode or mtime the filesystem
+   * reports unstably — looks exactly like having no cache at all. These counters
+   * are what tells a miss storm apart from a cold start.
+   */
+  stats(): SettledDiffCacheStats {
+    return {
+      hits: this.hits,
+      misses: this.misses,
+      unprovable: this.unprovable,
+      stores: this.stores,
+      racyWrites: this.racyWrites,
+      invalidatedDuringRead: this.invalidatedDuringRead,
+      entries: this.entries.size,
+      retainedCharacters: this.retainedCharacters
+    }
+  }
+
+  resetStatsForTests(): void {
+    this.hits = 0
+    this.misses = 0
+    this.unprovable = 0
+    this.stores = 0
+    this.racyWrites = 0
+    this.invalidatedDuringRead = 0
+  }
+}
+
+function resultCharacterCount(result: GitDiffResult): number {
+  return result.originalContent.length + result.modifiedContent.length
+}

--- a/src/main/git/source-control/settled-diff-cache.ts
+++ b/src/main/git/source-control/settled-diff-cache.ts
@@ -1,6 +1,10 @@
 import { BoundedMap } from '../../../shared/bounded-map'
 import type { GitDiffResult } from '../../../shared/git-diff-compare-types'
-import { canProveUnchangedByStamp, type WorktreeDiffStamp } from './worktree-diff-stamp'
+import {
+  canProveUnchangedByStamp,
+  isDiffStampClockSkewed,
+  type WorktreeDiffStamp
+} from './worktree-diff-stamp'
 
 /**
  * Diff results that survive their read, guarded by a stamp of the git state they
@@ -30,6 +34,12 @@ export type SettledDiffCacheStats = {
   stores: number
   /** Store declined because a write was too recent for its mtime to be conclusive. */
   racyWrites: number
+  /**
+   * Subset of `racyWrites` where a component's mtime was in this host's future, so
+   * the clocks disagree and the refusal will persist until they converge. A nonzero
+   * count here means the cache is off for a reason no amount of idling will fix.
+   */
+  clockSkewedWrites: number
   /** Store declined because a mutation invalidated the cache while the read ran. */
   invalidatedDuringRead: number
   entries: number
@@ -51,6 +61,7 @@ export class SettledDiffCache {
   private unprovable = 0
   private stores = 0
   private racyWrites = 0
+  private clockSkewedWrites = 0
   private invalidatedDuringRead = 0
 
   /**
@@ -92,6 +103,9 @@ export class SettledDiffCache {
     }
     if (!canProveUnchangedByStamp(stamp)) {
       this.racyWrites += 1
+      if (isDiffStampClockSkewed(stamp)) {
+        this.clockSkewedWrites += 1
+      }
       return
     }
     const characters = resultCharacterCount(result)
@@ -118,6 +132,7 @@ export class SettledDiffCache {
       unprovable: this.unprovable,
       stores: this.stores,
       racyWrites: this.racyWrites,
+      clockSkewedWrites: this.clockSkewedWrites,
       invalidatedDuringRead: this.invalidatedDuringRead,
       entries: this.entries.size,
       retainedCharacters: this.entries.retainedBytes
@@ -130,6 +145,7 @@ export class SettledDiffCache {
     this.unprovable = 0
     this.stores = 0
     this.racyWrites = 0
+    this.clockSkewedWrites = 0
     this.invalidatedDuringRead = 0
   }
 }

--- a/src/main/git/source-control/status-branch-line-total-input.ts
+++ b/src/main/git/source-control/status-branch-line-total-input.ts
@@ -6,7 +6,7 @@ import {
   type GitBranchLineTotal
 } from '../../../shared/git-branch-line-total'
 import type { GitRuntimeOptions } from '../git-runtime-options'
-import { gitStatusReadOptionsForWorktree } from '../git-runtime-options'
+import { gitReadOptionsForWorktree } from '../git-runtime-options'
 import { gitExecFileAsync, gitOptionalLocksDisabledEnv } from '../runner'
 import type { GetStatusOptions } from './get-status-options'
 
@@ -36,7 +36,7 @@ export function createBranchLineTotalInput(
           .map((entry) => entry.path),
         runDiffNumstat: (args, signal) =>
           gitExecFileAsync(args, {
-            ...gitStatusReadOptionsForWorktree(worktreePath, options),
+            ...gitReadOptionsForWorktree(worktreePath, options),
             // Why: after the spread, so the shared lease signal wins over this caller's own.
             signal,
             env: gitOptionalLocksDisabledEnv(),

--- a/src/main/git/source-control/status-line-stats.ts
+++ b/src/main/git/source-control/status-line-stats.ts
@@ -6,7 +6,7 @@ import {
   type GitLineStats
 } from '../../../shared/git-uncommitted-line-stats'
 import type { GitRuntimeOptions } from '../git-runtime-options'
-import { gitStatusReadOptionsForWorktree } from '../git-runtime-options'
+import { gitReadOptionsForWorktree } from '../git-runtime-options'
 import { gitExecFileAsync, gitOptionalLocksDisabledEnv } from '../runner'
 
 async function runNumstat(
@@ -26,7 +26,7 @@ async function runNumstat(
         '-M'
       ],
       {
-        ...gitStatusReadOptionsForWorktree(worktreePath, options),
+        ...gitReadOptionsForWorktree(worktreePath, options),
         env: gitOptionalLocksDisabledEnv()
       }
     )

--- a/src/main/git/source-control/status-read.ts
+++ b/src/main/git/source-control/status-read.ts
@@ -15,7 +15,7 @@ import {
 import { gitOptionalLocksDisabledEnv, gitStreamStdout } from '../runner'
 import { findExistingWorktreeSymlinkPaths } from '../worktree-symlink-detection'
 import type { GetStatusOptions } from './get-status-options'
-import { gitDiffReadDedupe, statusReadLeaseOwner } from './git-read-cache-invalidation'
+import { statusReadLeaseOwner } from './git-read-cache-invalidation'
 import { detectConflictOperation } from './git-conflict-operation'
 import { parseUnmergedEntry } from './status-conflict-entries'
 import { getEffectiveUpstreamStatusCacheKey } from './effective-upstream-status-cache'
@@ -37,8 +37,10 @@ export async function getStatus(
   worktreePath: string,
   options: GetStatusOptions = {}
 ): Promise<GitStatusResult> {
-  gitDiffReadDedupe.clear()
-  // Why: dedupe only concurrent identical reads; after settle, callers must run a fresh read.
+  // Why nothing is cleared here: a status poll is a read. Dropping the in-flight diff entry
+  // mid-read only made a concurrent identical request start duplicate git work, and the
+  // settled diff cache is keyed on stamped git state, which a read cannot change anyway.
+  // Mutations invalidate both, through invalidateGitReadCaches.
   const cacheKey = getStatusReadKey(worktreePath, options)
   return statusReadLeaseOwner.lease(cacheKey, options.signal, (sharedSignal) =>
     runGetStatus(worktreePath, { ...options, signal: sharedSignal })

--- a/src/main/git/source-control/worktree-diff-stamp.ts
+++ b/src/main/git/source-control/worktree-diff-stamp.ts
@@ -60,10 +60,11 @@ export async function readWorktreeDiffStamp(
     const gitDir = await resolveGitDir(worktreePath)
     const [head, index, gitmodules, workingTree] = await Promise.all([
       readHeadComponent(gitDir),
-      // Over-invalidates on purpose: `git status` can refresh a stat-dirty index and rewrite
-      // this file without changing a single blob, which costs one re-read. That is the safe
-      // direction — do not "fix" it by dropping the index from the stamp, because `git add`
-      // then becomes invisible and the cache serves a pre-staging diff.
+      // Over-invalidates on purpose: git run outside Orca (a terminal `git status`/`git add`)
+      // can refresh a stat-dirty index and rewrite this file without changing a single blob,
+      // which costs one re-read. That is the safe direction — do not "fix" it by dropping the
+      // index from the stamp, because `git add` then becomes invisible and the cache serves a
+      // pre-staging diff.
       readFileStampComponent(path.join(gitDir, 'index')),
       readFileStampComponent(path.join(worktreePath, '.gitmodules')),
       includeWorkingTree

--- a/src/main/git/source-control/worktree-diff-stamp.ts
+++ b/src/main/git/source-control/worktree-diff-stamp.ts
@@ -1,0 +1,210 @@
+import { readFile, stat } from 'node:fs/promises'
+import * as path from 'node:path'
+import { resolveGitDir } from './resolve-git-dir'
+
+/**
+ * Subprocess-free proof of every input one working-tree file diff is built from:
+ * the HEAD tree, the index, `.gitmodules` (which decides submodule routing) and
+ * the working-tree file itself.
+ *
+ * Two equal stamps mean `git show HEAD:<path>`, `git show :<path>` and the
+ * working-tree bytes would still return what they returned when the stamp was
+ * taken, so a caller may reuse a settled diff instead of respawning Git — on a
+ * WSL/UNC worktree that trades two `wsl.exe` spawns for a handful of 9p stats.
+ *
+ * `null` means "cannot prove unchanged" — not a repo, an unreadable layout, or a
+ * filesystem that reports no usable mtime — and callers must not cache.
+ */
+export type WorktreeDiffStamp = {
+  /** Opaque; compare for equality only. */
+  value: string
+  /** Newest mtime any component reported, or -Infinity when every one was absent. */
+  newestMtimeMs: number
+  capturedAtMs: number
+}
+
+/**
+ * How long after a component's mtime the stamp has to be taken before a later
+ * write is guaranteed to move that mtime.
+ *
+ * Why 2s: FAT/exFAT truncate mtime to a 2s bucket, the coarsest granularity a
+ * repo can realistically sit on. Below the margin a second write inside the same
+ * bucket would leave the stamp identical, so the read stays uncached instead.
+ */
+export const DIFF_STAMP_RACY_WRITE_MARGIN_MS = 2_000
+
+const MISSING = '-'
+const ABSENT: StampComponent = { text: MISSING, mtimeMs: Number.NEGATIVE_INFINITY }
+
+type StampComponent = { text: string; mtimeMs: number }
+
+/**
+ * A write that lands in the same timestamp bucket as the stamp is invisible, so
+ * only a stamp taken a full bucket after its newest component can be trusted.
+ */
+export function canProveUnchangedByStamp(stamp: WorktreeDiffStamp): boolean {
+  return stamp.capturedAtMs - stamp.newestMtimeMs >= DIFF_STAMP_RACY_WRITE_MARGIN_MS
+}
+
+/**
+ * Stamp the inputs of one file diff. Pass `includeWorkingTree: false` for a
+ * staged diff, which compares HEAD to the index and never reads the working tree.
+ */
+export async function readWorktreeDiffStamp(
+  worktreePath: string,
+  filePath: string,
+  includeWorkingTree: boolean
+): Promise<WorktreeDiffStamp | null> {
+  const capturedAtMs = Date.now()
+  try {
+    const gitDir = await resolveGitDir(worktreePath)
+    const [head, index, gitmodules, workingTree] = await Promise.all([
+      readHeadComponent(gitDir),
+      // Over-invalidates on purpose: `git status` can refresh a stat-dirty index and rewrite
+      // this file without changing a single blob, which costs one re-read. That is the safe
+      // direction — do not "fix" it by dropping the index from the stamp, because `git add`
+      // then becomes invisible and the cache serves a pre-staging diff.
+      readFileStampComponent(path.join(gitDir, 'index')),
+      readFileStampComponent(path.join(worktreePath, '.gitmodules')),
+      includeWorkingTree
+        ? readWorkingTreeComponent(path.join(worktreePath, filePath))
+        : Promise.resolve(ABSENT)
+    ])
+    if (!head) {
+      return null
+    }
+    const components = [head, index, gitmodules, workingTree]
+    return {
+      // Why JSON: a path or a ref can contain any separator character, and an ambiguous
+      // join is a stamp collision — two different states that compare equal.
+      value: JSON.stringify([
+        worktreePath,
+        filePath,
+        ...components.map((component) => component.text)
+      ]),
+      newestMtimeMs: Math.max(...components.map((component) => component.mtimeMs)),
+      capturedAtMs
+    }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Identify the commit HEAD resolves to. Reading the tip is what makes a plain
+ * commit visible: it rewrites `refs/heads/<branch>` and leaves HEAD untouched.
+ *
+ * A loose tip is recorded by content, so it needs no mtime margin. Only when no
+ * loose ref exists at all — packed refs, the reftable backend, or an unborn
+ * branch — does this fall back to the coarser stamps of the files a packed tip
+ * moves, and the recorded "no loose ref" marker still catches the ref appearing.
+ */
+async function readHeadComponent(gitDir: string): Promise<StampComponent | null> {
+  const [head, commonDirEntry] = await Promise.all([
+    readTrimmedFile(path.join(gitDir, 'HEAD')),
+    readTrimmedFile(path.join(gitDir, 'commondir'))
+  ])
+  if (!head) {
+    return null
+  }
+  const commonDir = commonDirEntry ? path.resolve(gitDir, commonDirEntry) : gitDir
+  const refName = head.match(/^ref:\s*(.+?)\s*$/)?.[1]
+  if (!refName || !isSafeRefName(refName)) {
+    // Detached HEAD already holds the object id; an unrecognized HEAD is covered by its own text.
+    return { text: head, mtimeMs: Number.NEGATIVE_INFINITY }
+  }
+  // Per-worktree refs (`refs/bisect`, `refs/worktree`) live beside the checkout; branches are shared.
+  const [perWorktreeTip, sharedTip] = await Promise.all([
+    readTrimmedFile(path.join(gitDir, refName)),
+    commonDir === gitDir ? Promise.resolve(null) : readTrimmedFile(path.join(commonDir, refName))
+  ])
+  const looseTip = perWorktreeTip ?? sharedTip
+  if (looseTip) {
+    // A loose ref shadows any packed entry, so its bytes settle the tip on their own.
+    return {
+      text: JSON.stringify([head, 'loose', perWorktreeTip ? 'worktree' : 'common', looseTip]),
+      mtimeMs: Number.NEGATIVE_INFINITY
+    }
+  }
+  const [packedRefs, reftable] = await Promise.all([
+    readFileStampComponent(path.join(commonDir, 'packed-refs')),
+    readFileStampComponent(path.join(commonDir, 'reftable'))
+  ])
+  return {
+    text: JSON.stringify([head, 'packed', packedRefs.text, reftable.text]),
+    mtimeMs: Math.max(packedRefs.mtimeMs, reftable.mtimeMs)
+  }
+}
+
+/** Keep a hand-edited HEAD from steering the stamp outside the repo's ref store. */
+function isSafeRefName(refName: string): boolean {
+  const segments = refName.split(/[\\/]/)
+  return (
+    segments[0] === 'refs' &&
+    segments.length > 1 &&
+    segments.every((segment) => segment.length > 0 && segment !== '.' && segment !== '..') &&
+    !path.isAbsolute(refName)
+  )
+}
+
+async function readTrimmedFile(filePath: string): Promise<string | null> {
+  try {
+    const trimmed = (await readFile(filePath, 'utf-8')).trim()
+    return trimmed.length > 0 ? trimmed : null
+  } catch (error) {
+    if (isMissingEntryError(error)) {
+      return null
+    }
+    throw error
+  }
+}
+
+async function readFileStampComponent(filePath: string): Promise<StampComponent> {
+  try {
+    const stats = await stat(filePath)
+    return { text: `${requireMtimeMs(stats.mtimeMs)}:${stats.size}`, mtimeMs: stats.mtimeMs }
+  } catch (error) {
+    if (isMissingEntryError(error)) {
+      return ABSENT
+    }
+    throw error
+  }
+}
+
+async function readWorkingTreeComponent(filePath: string): Promise<StampComponent> {
+  try {
+    const stats = await stat(filePath)
+    // Why ino is optional: an atomic-rename save can keep both the size and the mtime bucket,
+    // so a changed inode is extra proof — but Windows reports 0 for it on the network
+    // redirector behind `\\wsl.localhost`, and requiring an unstable 0 to match would make
+    // the stamp never hit on exactly the host this cache exists for. Fold it in only when
+    // the filesystem gives a real one.
+    const inode = isUsableInode(stats.ino) ? String(stats.ino) : MISSING
+    return {
+      text: `${requireMtimeMs(stats.mtimeMs)}:${stats.size}:${inode}`,
+      mtimeMs: stats.mtimeMs
+    }
+  } catch (error) {
+    if (isMissingEntryError(error)) {
+      return ABSENT
+    }
+    throw error
+  }
+}
+
+function isUsableInode(ino: unknown): boolean {
+  return typeof ino === 'number' && Number.isFinite(ino) && ino !== 0
+}
+
+/** A filesystem (or a stub) that reports no usable mtime cannot prove anything unchanged. */
+function requireMtimeMs(mtimeMs: unknown): number {
+  if (typeof mtimeMs !== 'number' || !Number.isFinite(mtimeMs)) {
+    throw new Error('stat reported no usable mtime')
+  }
+  return mtimeMs
+}
+
+function isMissingEntryError(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | null)?.code
+  return code === 'ENOENT' || code === 'ENOTDIR'
+}

--- a/src/main/git/source-control/worktree-diff-stamp.ts
+++ b/src/main/git/source-control/worktree-diff-stamp.ts
@@ -41,9 +41,24 @@ type StampComponent = { text: string; mtimeMs: number }
 /**
  * A write that lands in the same timestamp bucket as the stamp is invisible, so
  * only a stamp taken a full bucket after its newest component can be trusted.
+ *
+ * The margin compares two clocks: `capturedAtMs` is this host's, while the mtimes
+ * come from whatever wrote the files. On a `\\wsl.localhost` worktree the guest
+ * sets them, and a guest running ahead pushes every recently-touched file past the
+ * margin — silently, and for as long as the skew lasts. `isDiffStampClockSkewed`
+ * separates that from an honestly-too-fresh file so the caller can count it.
  */
 export function canProveUnchangedByStamp(stamp: WorktreeDiffStamp): boolean {
   return stamp.capturedAtMs - stamp.newestMtimeMs >= DIFF_STAMP_RACY_WRITE_MARGIN_MS
+}
+
+/**
+ * True when a component's mtime is in this host's future, which no local write can
+ * produce — so the margin above is measuring skew, not freshness, and will keep
+ * refusing to store until the clocks converge.
+ */
+export function isDiffStampClockSkewed(stamp: WorktreeDiffStamp): boolean {
+  return Number.isFinite(stamp.newestMtimeMs) && stamp.newestMtimeMs > stamp.capturedAtMs
 }
 
 /**

--- a/src/main/git/status-conflict-operations.test.ts
+++ b/src/main/git/status-conflict-operations.test.ts
@@ -15,7 +15,7 @@ const {
   readFileMock,
   statMock,
   rmMock,
-  existsSyncMock
+  accessMock
 } = vi.hoisted(() => ({
   gitExecFileAsyncMock: vi.fn(),
   gitExecFileAsyncBufferMock: vi.fn(),
@@ -25,7 +25,7 @@ const {
   readFileMock: vi.fn(),
   statMock: vi.fn(),
   rmMock: vi.fn(),
-  existsSyncMock: vi.fn()
+  accessMock: vi.fn()
 }))
 
 vi.mock('./runner', () =>
@@ -37,12 +37,15 @@ vi.mock('./runner', () =>
 )
 
 vi.mock('fs/promises', () =>
-  createFsPromisesModuleMock({ lstatMock, realpathMock, readFileMock, statMock, rmMock })
+  createFsPromisesModuleMock({
+    lstatMock,
+    realpathMock,
+    readFileMock,
+    statMock,
+    rmMock,
+    accessMock
+  })
 )
-
-vi.mock('fs', () => ({
-  existsSync: existsSyncMock
-}))
 
 vi.mock('../../shared/node-bounded-file-reader', async (importOriginal) =>
   createBoundedFileReaderModuleMock(await importOriginal<typeof BoundedFileReader>(), {
@@ -83,32 +86,65 @@ describe('abortRebase', () => {
 describe('detectConflictOperation', () => {
   beforeEach(() => {
     readFileMock.mockReset()
-    existsSyncMock.mockReset()
+    accessMock.mockReset()
   })
 
   it('ignores a stale REBASE_HEAD when no rebase directory exists', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockImplementation((target: string) => {
-      if (target.endsWith('MERGE_HEAD')) {
-        return false
-      }
-      if (target.endsWith('CHERRY_PICK_HEAD')) {
-        return false
-      }
-      if (target.endsWith('rebase-merge')) {
-        return false
-      }
-      if (target.endsWith('rebase-apply')) {
-        return false
-      }
+    accessMock.mockImplementation(async (target: string) => {
+      // Only REBASE_HEAD is present: the marker git leaves behind after a rebase finishes.
       if (target.endsWith('REBASE_HEAD')) {
-        return true
+        return undefined
       }
-      return false
+      throw Object.assign(new Error(`ENOENT: ${target}`), { code: 'ENOENT' })
     })
 
     const result = await detectConflictOperation('/repo')
 
     expect(result).toBe('unknown')
+  })
+
+  it.each([
+    ['MERGE_HEAD', 'merge'],
+    ['rebase-merge', 'rebase'],
+    ['rebase-apply', 'rebase'],
+    ['CHERRY_PICK_HEAD', 'cherry-pick']
+  ])('reports %s as %s', async (marker, expected) => {
+    readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
+    accessMock.mockImplementation(async (target: string) => {
+      if (target.endsWith(marker)) {
+        return undefined
+      }
+      throw Object.assign(new Error(`ENOENT: ${target}`), { code: 'ENOENT' })
+    })
+
+    await expect(detectConflictOperation('/repo')).resolves.toBe(expected)
+  })
+
+  // The four markers are independent, so serializing them costs four round trips
+  // on a UNC git dir for something one wave answers.
+  it('probes every marker concurrently', async () => {
+    readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
+    let concurrent = 0
+    let peakConcurrent = 0
+    accessMock.mockImplementation(async () => {
+      concurrent += 1
+      peakConcurrent = Math.max(peakConcurrent, concurrent)
+      await Promise.resolve()
+      concurrent -= 1
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
+
+    await detectConflictOperation('/repo')
+
+    expect(accessMock).toHaveBeenCalledTimes(4)
+    expect(peakConcurrent).toBe(4)
+  })
+
+  it('reads as unknown when the git dir cannot be reached at all', async () => {
+    readFileMock.mockRejectedValue(Object.assign(new Error('EIO'), { code: 'EIO' }))
+    accessMock.mockRejectedValue(Object.assign(new Error('EIO'), { code: 'EIO' }))
+
+    await expect(detectConflictOperation('/repo')).resolves.toBe('unknown')
   })
 })

--- a/src/main/git/status-diff-settled-cache.test.ts
+++ b/src/main/git/status-diff-settled-cache.test.ts
@@ -208,6 +208,32 @@ describe('settled diff cache', () => {
     expect(second).toMatchObject({ originalContent: 'post-mutation\n' })
   })
 
+  // The stamp is itself several awaited stats, so a mutation can begin and end entirely
+  // inside it — leaving a stamp torn across the mutation that no later stamp can match.
+  it('refuses to store a result for a mutation that landed inside the stamp read', async () => {
+    const baseStat = statMock.getMockImplementation()
+    if (!baseStat) {
+      throw new Error('the fake filesystem lost its stat implementation')
+    }
+    let invalidated = false
+    statMock.mockImplementation(async (target: string) => {
+      if (!invalidated && target === INDEX_PATH) {
+        invalidated = true
+        invalidateGitReadCaches()
+      }
+      return baseStat(target)
+    })
+    try {
+      await getDiff(REPO, FILE, false)
+    } finally {
+      statMock.mockImplementation(baseStat)
+    }
+
+    expect(invalidated).toBe(true)
+    expect(settledDiffCache.stats().invalidatedDuringRead).toBe(1)
+    expect(settledDiffCache.stats().entries).toBe(0)
+  })
+
   // A write inside the mtime granularity window could be overwritten again without
   // moving the timestamp, so that read is not allowed to become a cache entry.
   it('refuses to store a diff of a file written moments ago', async () => {

--- a/src/main/git/status-diff-settled-cache.test.ts
+++ b/src/main/git/status-diff-settled-cache.test.ts
@@ -1,0 +1,305 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as BoundedFileReader from '../../shared/node-bounded-file-reader'
+import { createBoundedFileReaderModuleMock, createGitRunnerModuleMock } from './status-test-harness'
+
+const {
+  gitExecFileAsyncMock,
+  gitExecFileAsyncBufferMock,
+  gitStreamOptionsMock,
+  lstatMock,
+  realpathMock,
+  rmMock,
+  existsSyncMock
+} = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn(),
+  gitExecFileAsyncBufferMock: vi.fn(),
+  gitStreamOptionsMock: vi.fn(),
+  lstatMock: vi.fn(),
+  realpathMock: vi.fn(),
+  rmMock: vi.fn(),
+  existsSyncMock: vi.fn()
+}))
+
+/**
+ * A tiny in-memory filesystem, because every assertion here is about what the
+ * cache does when one specific path's mtime or bytes move. Sequenced
+ * `mockResolvedValueOnce` stacks cannot express that: the stamp and the diff
+ * read touch overlapping paths in an order the test should not have to know.
+ */
+type FakeFile = { content: Buffer; mtimeMs: number; ino: number }
+
+const { files } = vi.hoisted(() => ({ files: new Map<string, FakeFile>() }))
+
+const { readFileMock, statMock, accessMock } = vi.hoisted(() => {
+  const missing = (target: string): NodeJS.ErrnoException =>
+    Object.assign(new Error(`ENOENT: ${target}`), { code: 'ENOENT' })
+  return {
+    readFileMock: vi.fn(async (target: string, encoding?: BufferEncoding) => {
+      const file = files.get(target)
+      if (!file) {
+        throw missing(target)
+      }
+      return encoding ? file.content.toString(encoding) : file.content
+    }),
+    statMock: vi.fn(async (target: string) => {
+      const file = files.get(target)
+      if (!file) {
+        throw missing(target)
+      }
+      return {
+        isFile: () => true,
+        size: file.content.byteLength,
+        mtimeMs: file.mtimeMs,
+        ino: file.ino
+      }
+    }),
+    accessMock: vi.fn(async (target: string) => {
+      if (!files.has(target)) {
+        throw missing(target)
+      }
+    })
+  }
+})
+
+vi.mock('./runner', () =>
+  createGitRunnerModuleMock({
+    gitExecFileAsyncMock,
+    gitExecFileAsyncBufferMock,
+    gitStreamOptionsMock
+  })
+)
+
+vi.mock('fs/promises', () => ({
+  lstat: lstatMock,
+  realpath: realpathMock,
+  readFile: readFileMock,
+  stat: statMock,
+  rm: rmMock,
+  access: accessMock
+}))
+
+vi.mock('fs', () => ({ existsSync: existsSyncMock }))
+
+vi.mock('../../shared/node-bounded-file-reader', async (importOriginal) =>
+  createBoundedFileReaderModuleMock(await importOriginal<typeof BoundedFileReader>(), {
+    readFileMock,
+    statMock
+  })
+)
+
+import { getDiff, getStatus, invalidateGitReadCaches, stageFile } from './status'
+import { settledDiffCache } from './source-control/git-read-cache-invalidation'
+
+const REPO = '/repo'
+const FILE = 'src/file.ts'
+const WORKING_TREE_PATH = `${REPO}/${FILE}`
+const HEAD_PATH = `${REPO}/.git/HEAD`
+const REF_PATH = `${REPO}/.git/refs/heads/main`
+const INDEX_PATH = `${REPO}/.git/index`
+const GITMODULES_PATH = `${REPO}/.gitmodules`
+
+// Old enough that a further write is guaranteed to move the mtime, which is what
+// lets the cache store at all.
+const SETTLED_MTIME_MS = Date.now() - 60_000
+let nextInode = 100
+
+function writeFile(target: string, content: string, mtimeMs = SETTLED_MTIME_MS): void {
+  files.set(target, { content: Buffer.from(content), mtimeMs, ino: (nextInode += 1) })
+}
+
+function blobReadCount(): number {
+  return gitExecFileAsyncBufferMock.mock.calls.length
+}
+
+function seedRepo(): void {
+  files.clear()
+  // No `.git` file entry: `.git` is a directory, so reading it as a pointer misses.
+  writeFile(HEAD_PATH, 'ref: refs/heads/main\n')
+  writeFile(REF_PATH, `${'a'.repeat(40)}\n`)
+  writeFile(INDEX_PATH, 'index-bytes')
+  writeFile(WORKING_TREE_PATH, 'working-tree-content')
+}
+
+describe('settled diff cache', () => {
+  beforeEach(() => {
+    gitExecFileAsyncMock.mockReset()
+    gitExecFileAsyncBufferMock.mockReset()
+    gitStreamOptionsMock.mockReset()
+    readFileMock.mockClear()
+    statMock.mockClear()
+    accessMock.mockClear()
+    existsSyncMock.mockReset()
+    invalidateGitReadCaches()
+    settledDiffCache.resetStatsForTests()
+    seedRepo()
+    // `.gitmodules` is absent, so submodule routing resolves to "no submodules".
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
+    gitExecFileAsyncBufferMock.mockResolvedValue({ stdout: Buffer.from('index-content\n') })
+  })
+
+  it('serves the second read of an unchanged file without respawning git', async () => {
+    const first = await getDiff(REPO, FILE, false)
+    const spawnsAfterFirst = blobReadCount()
+
+    const second = await getDiff(REPO, FILE, false)
+
+    expect(spawnsAfterFirst).toBeGreaterThan(0)
+    expect(blobReadCount()).toBe(spawnsAfterFirst)
+    expect(second).toEqual(first)
+    expect(settledDiffCache.stats().hits).toBe(1)
+  })
+
+  // The four invalidation axes, one per diff input. Each proves the stale result is
+  // never served, which matters more than any of the hits above.
+  it.each([
+    [
+      'the working tree file is edited',
+      () => writeFile(WORKING_TREE_PATH, 'edited-in-another-editor')
+    ],
+    ['the index is rewritten by git add', () => writeFile(INDEX_PATH, 'index-bytes-after-add')],
+    ['HEAD moves to a new commit', () => writeFile(REF_PATH, `${'b'.repeat(40)}\n`)],
+    ['HEAD is detached onto another commit', () => writeFile(HEAD_PATH, `${'c'.repeat(40)}\n`)],
+    ['.gitmodules appears', () => writeFile(GITMODULES_PATH, '[submodule "vendor"]\n')]
+  ])('re-reads after %s', async (_name, mutate) => {
+    await getDiff(REPO, FILE, false)
+    const spawnsAfterFirst = blobReadCount()
+
+    mutate()
+    gitExecFileAsyncBufferMock.mockResolvedValue({ stdout: Buffer.from('fresh-index-content\n') })
+    const second = await getDiff(REPO, FILE, false)
+
+    expect(blobReadCount()).toBeGreaterThan(spawnsAfterFirst)
+    expect(second).toMatchObject({ originalContent: 'fresh-index-content\n' })
+  })
+
+  it('re-reads after a mutation runs through the shared invalidation point', async () => {
+    await getDiff(REPO, FILE, false)
+    const spawnsAfterFirst = blobReadCount()
+
+    await stageFile(REPO, FILE)
+    await getDiff(REPO, FILE, false)
+
+    expect(blobReadCount()).toBeGreaterThan(spawnsAfterFirst)
+  })
+
+  // The dangerous ordering: the read observed pre-mutation state, so storing its
+  // result after the mutation would pin a diff that was already wrong.
+  it('refuses to store a result for a read that a mutation overtook', async () => {
+    let releaseBlob = (): void => {}
+    const blocked = new Promise<{ stdout: Buffer }>((resolve) => {
+      releaseBlob = () => resolve({ stdout: Buffer.from('pre-mutation\n') })
+    })
+    gitExecFileAsyncBufferMock.mockReturnValue(blocked)
+
+    const inFlight = getDiff(REPO, FILE, false)
+    await vi.waitFor(() => expect(blobReadCount()).toBeGreaterThan(0))
+    invalidateGitReadCaches()
+    releaseBlob()
+    await inFlight
+
+    expect(settledDiffCache.stats().invalidatedDuringRead).toBe(1)
+    expect(settledDiffCache.stats().entries).toBe(0)
+
+    const spawnsAfterFirst = blobReadCount()
+    gitExecFileAsyncBufferMock.mockResolvedValue({ stdout: Buffer.from('post-mutation\n') })
+    const second = await getDiff(REPO, FILE, false)
+
+    expect(blobReadCount()).toBeGreaterThan(spawnsAfterFirst)
+    expect(second).toMatchObject({ originalContent: 'post-mutation\n' })
+  })
+
+  // A write inside the mtime granularity window could be overwritten again without
+  // moving the timestamp, so that read is not allowed to become a cache entry.
+  it('refuses to store a diff of a file written moments ago', async () => {
+    writeFile(WORKING_TREE_PATH, 'just-saved', Date.now())
+
+    await getDiff(REPO, FILE, false)
+    const spawnsAfterFirst = blobReadCount()
+    await getDiff(REPO, FILE, false)
+
+    expect(blobReadCount()).toBeGreaterThan(spawnsAfterFirst)
+    expect(settledDiffCache.stats().racyWrites).toBeGreaterThan(0)
+    expect(settledDiffCache.stats().entries).toBe(0)
+  })
+
+  // A folder workspace, or any path that is not a git checkout, cannot be stamped.
+  it('never caches when the repo layout cannot be stamped', async () => {
+    files.delete(HEAD_PATH)
+
+    await getDiff(REPO, FILE, false)
+    const spawnsAfterFirst = blobReadCount()
+    await getDiff(REPO, FILE, false)
+
+    expect(blobReadCount()).toBeGreaterThan(spawnsAfterFirst)
+    expect(settledDiffCache.stats().unprovable).toBeGreaterThan(0)
+    expect(settledDiffCache.stats().entries).toBe(0)
+  })
+
+  // A WSL relay that never reached git returns the same empty left side as a new
+  // file does, so persisting it would pin a wrong diff until something else moved.
+  it('refuses to store a diff whose blob read failed rather than proved absence', async () => {
+    gitExecFileAsyncBufferMock.mockRejectedValue(
+      Object.assign(new Error('wsl.exe failed'), { code: 1 })
+    )
+
+    await getDiff(REPO, FILE, false)
+    const spawnsAfterFirst = blobReadCount()
+    await getDiff(REPO, FILE, false)
+
+    expect(blobReadCount()).toBeGreaterThan(spawnsAfterFirst)
+    expect(settledDiffCache.stats().entries).toBe(0)
+  })
+
+  it('caches a new file whose absence from the index git actually reported', async () => {
+    gitExecFileAsyncBufferMock.mockRejectedValue(
+      Object.assign(new Error("fatal: path 'src/file.ts' does not exist"), { code: 128 })
+    )
+
+    await getDiff(REPO, FILE, false)
+    const spawnsAfterFirst = blobReadCount()
+    await getDiff(REPO, FILE, false)
+
+    expect(blobReadCount()).toBe(spawnsAfterFirst)
+    expect(settledDiffCache.stats().hits).toBe(1)
+  })
+
+  it('keeps staged and unstaged diffs of one file in separate entries', async () => {
+    await getDiff(REPO, FILE, false)
+    const spawnsAfterUnstaged = blobReadCount()
+
+    await getDiff(REPO, FILE, true)
+
+    expect(blobReadCount()).toBeGreaterThan(spawnsAfterUnstaged)
+  })
+
+  // A staged diff compares HEAD to the index, so a working-tree edit must not evict it.
+  it('keeps a staged diff across a working-tree edit', async () => {
+    await getDiff(REPO, FILE, true)
+    const spawnsAfterFirst = blobReadCount()
+
+    writeFile(WORKING_TREE_PATH, 'edited-after-staging')
+    await getDiff(REPO, FILE, true)
+
+    expect(blobReadCount()).toBe(spawnsAfterFirst)
+  })
+
+  it('does not let a status poll drop the in-flight diff read', async () => {
+    let releaseBlob = (): void => {}
+    const blocked = new Promise<{ stdout: Buffer }>((resolve) => {
+      releaseBlob = () => resolve({ stdout: Buffer.from('index-content\n') })
+    })
+    gitExecFileAsyncBufferMock.mockReturnValue(blocked)
+
+    const first = getDiff(REPO, FILE, false)
+    await vi.waitFor(() => expect(blobReadCount()).toBeGreaterThan(0))
+    const spawnsBeforePoll = blobReadCount()
+
+    await getStatus(REPO)
+    const second = getDiff(REPO, FILE, false)
+    releaseBlob()
+    await Promise.all([first, second])
+
+    // Why exactly equal: the second read must join the first, not start its own spawns.
+    expect(blobReadCount()).toBe(spawnsBeforePoll)
+  })
+})

--- a/src/main/git/status-diff.test.ts
+++ b/src/main/git/status-diff.test.ts
@@ -102,7 +102,8 @@ describe('getDiff', () => {
 
     expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(['show', ':src/file.ts'], {
       cwd: '/repo',
-      maxBuffer: 10 * 1024 * 1024
+      maxBuffer: 10 * 1024 * 1024,
+      preferWslDirectGit: true
     })
     expect(readFileMock).toHaveBeenCalledWith(path.join('/repo', 'src/file.ts'))
     expect(result).toEqual({
@@ -122,7 +123,8 @@ describe('getDiff', () => {
 
     expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(['show', ':src/file.ts'], {
       cwd: '/repo',
-      maxBuffer: 10 * 1024 * 1024
+      maxBuffer: 10 * 1024 * 1024,
+      preferWslDirectGit: true
     })
   })
 
@@ -139,7 +141,8 @@ describe('getDiff', () => {
       ['show', '--end-of-options', 'HEAD:src/file.ts'],
       {
         cwd: '/repo',
-        maxBuffer: 10 * 1024 * 1024
+        maxBuffer: 10 * 1024 * 1024,
+        preferWslDirectGit: true
       }
     )
     expect(result.originalContent).toBe('head-content\n')
@@ -158,15 +161,19 @@ describe('getDiff', () => {
   })
 
   it('does not read oversized working-tree files into memory', async () => {
+    const workingTreePath = path.join('/repo', 'dist/large.log')
     gitExecFileAsyncBufferMock.mockResolvedValueOnce({ stdout: Buffer.from('index-content\n') })
-    statMock.mockResolvedValueOnce({
-      isFile: () => true,
-      size: 10 * 1024 * 1024 + 1
-    })
+    // Why by path: the diff also stats git-dir entries to stamp its inputs, so a
+    // one-shot queue would hand the oversized size to whichever stat ran first.
+    statMock.mockImplementation(async (target: string) =>
+      target === workingTreePath
+        ? { isFile: () => true, size: 10 * 1024 * 1024 + 1 }
+        : { isFile: () => true, size: 12 }
+    )
 
     const result = await getDiff('/repo', 'dist/large.log', false)
 
-    expect(readFileMock).not.toHaveBeenCalled()
+    expect(readFileMock).not.toHaveBeenCalledWith(workingTreePath)
     expect(result.kind).toBe('binary')
     expect(result.modifiedIsBinary).toBe(true)
     expect(result.modifiedContent).toBe('')
@@ -259,8 +266,14 @@ describe('getDiff', () => {
 
   it('flags a deleted image so previewers can fall back to the original bytes', async () => {
     const pngBuffer = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00])
+    const workingTreePath = path.join('/repo', 'assets/deleted.png')
     gitExecFileAsyncBufferMock.mockResolvedValueOnce({ stdout: pngBuffer })
-    statMock.mockRejectedValueOnce(Object.assign(new Error('missing'), { code: 'ENOENT' }))
+    statMock.mockImplementation(async (target: string) => {
+      if (target === workingTreePath) {
+        throw Object.assign(new Error('missing'), { code: 'ENOENT' })
+      }
+      return { isFile: () => true, size: 12 }
+    })
 
     const result = await getDiff('/repo', 'assets/deleted.png', false)
 
@@ -275,9 +288,15 @@ describe('getDiff', () => {
 
   it('does not treat an unreadable working-tree image as a deletion', async () => {
     const pngBuffer = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x00])
+    const workingTreePath = path.join('/repo', 'assets/unreadable.png')
     gitExecFileAsyncBufferMock.mockResolvedValueOnce({ stdout: pngBuffer })
-    statMock.mockResolvedValueOnce({ isFile: () => true, size: 5 })
-    readFileMock.mockRejectedValueOnce(new Error('EIO'))
+    statMock.mockImplementation(async () => ({ isFile: () => true, size: 5 }))
+    readFileMock.mockImplementation(async (target: string) => {
+      if (target === workingTreePath) {
+        throw new Error('EIO')
+      }
+      return Buffer.from('')
+    })
 
     const result = await getDiff('/repo', 'assets/unreadable.png', false)
 

--- a/src/main/git/status-submodule.test.ts
+++ b/src/main/git/status-submodule.test.ts
@@ -123,11 +123,11 @@ describe('submodule diff routing', () => {
 
     expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(
       ['show', '--end-of-options', `${OLD_OID}:lib/main.dart`],
-      { cwd: SUBMODULE, maxBuffer: 10 * 1024 * 1024 }
+      { cwd: SUBMODULE, maxBuffer: 10 * 1024 * 1024, preferWslDirectGit: true }
     )
     expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(
       ['show', '--end-of-options', `${NEW_OID}:lib/main.dart`],
-      { cwd: SUBMODULE, maxBuffer: 10 * 1024 * 1024 }
+      { cwd: SUBMODULE, maxBuffer: 10 * 1024 * 1024, preferWslDirectGit: true }
     )
     expect(result.kind).toBe('text')
     expect(result.originalContent).toBe('v1\n')
@@ -167,11 +167,11 @@ describe('submodule diff routing', () => {
 
     expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(
       ['show', '--end-of-options', `${OLD_OID}:lib/main.dart`],
-      { cwd: SUBMODULE, maxBuffer: 10 * 1024 * 1024 }
+      { cwd: SUBMODULE, maxBuffer: 10 * 1024 * 1024, preferWslDirectGit: true }
     )
     expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(
       ['show', '--end-of-options', `${NEW_OID}:lib/main.dart`],
-      { cwd: SUBMODULE, maxBuffer: 10 * 1024 * 1024 }
+      { cwd: SUBMODULE, maxBuffer: 10 * 1024 * 1024, preferWslDirectGit: true }
     )
     expect(result.kind).toBe('text')
     expect(result.originalContent).toBe('v1\n')
@@ -202,7 +202,8 @@ describe('submodule diff routing', () => {
 
     expect(gitExecFileAsyncBufferMock).toHaveBeenCalledWith(['show', ':lib/main.dart'], {
       cwd: SUBMODULE,
-      maxBuffer: 10 * 1024 * 1024
+      maxBuffer: 10 * 1024 * 1024,
+      preferWslDirectGit: true
     })
     expect(readFileMock).toHaveBeenCalledWith(path.join(SUBMODULE, 'lib/main.dart'))
     expect(result.kind).toBe('text')

--- a/src/main/git/status-test-harness.ts
+++ b/src/main/git/status-test-harness.ts
@@ -15,6 +15,8 @@ export type FsPromisesMocks = {
   readFileMock: MockFn
   statMock: MockFn
   rmMock: MockFn
+  /** Optional: defaults to "nothing exists", which is what most git-read tests assume. */
+  accessMock?: MockFn
 }
 
 export function createGitRunnerModuleMock(mocks: GitRunnerMocks): Record<string, unknown> {
@@ -49,7 +51,12 @@ export function createFsPromisesModuleMock(mocks: FsPromisesMocks): Record<strin
     realpath: mocks.realpathMock,
     readFile: mocks.readFileMock,
     stat: mocks.statMock,
-    rm: mocks.rmMock
+    rm: mocks.rmMock,
+    access:
+      mocks.accessMock ??
+      (async (target: string) => {
+        throw Object.assign(new Error(`ENOENT: ${target}`), { code: 'ENOENT' })
+      })
   }
 }
 

--- a/src/main/git/status.test.ts
+++ b/src/main/git/status.test.ts
@@ -15,6 +15,7 @@ const {
   readFileMock,
   statMock,
   rmMock,
+  accessMock,
   existsSyncMock
 } = vi.hoisted(() => ({
   gitExecFileAsyncMock: vi.fn(),
@@ -25,6 +26,7 @@ const {
   readFileMock: vi.fn(),
   statMock: vi.fn(),
   rmMock: vi.fn(),
+  accessMock: vi.fn(),
   existsSyncMock: vi.fn()
 }))
 
@@ -37,9 +39,17 @@ vi.mock('./runner', () =>
 )
 
 vi.mock('fs/promises', () =>
-  createFsPromisesModuleMock({ lstatMock, realpathMock, readFileMock, statMock, rmMock })
+  createFsPromisesModuleMock({
+    lstatMock,
+    realpathMock,
+    readFileMock,
+    statMock,
+    rmMock,
+    accessMock
+  })
 )
 
+// Why still here: unmerged-entry parsing probes the working tree through node:fs directly.
 vi.mock('fs', () => ({
   existsSync: existsSyncMock
 }))
@@ -62,6 +72,8 @@ describe('getStatus', () => {
     lstatMock.mockReset()
     readFileMock.mockReset()
     existsSyncMock.mockReset()
+    accessMock.mockReset()
+    accessMock.mockRejectedValue(Object.assign(new Error('ENOENT'), { code: 'ENOENT' }))
     // Why: untracked line counting stats a file before reading it; any
     // under-limit size routes the read to readFileMock.
     statMock.mockReset()
@@ -75,7 +87,12 @@ describe('getStatus', () => {
 
   it('parses unmerged porcelain v2 entries into unresolved conflict rows', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockImplementation((target: string) => target.endsWith('MERGE_HEAD'))
+    accessMock.mockImplementation(async (target: string) => {
+      if (target.endsWith('MERGE_HEAD')) {
+        return undefined
+      }
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    })
     gitExecFileAsyncMock.mockResolvedValueOnce({
       stdout:
         'u UU N... 100644 100644 100644 100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb cccccccccccccccccccccccccccccccccccccccc src/app.ts\n'
@@ -97,7 +114,6 @@ describe('getStatus', () => {
 
   it('maps deleted conflicts to deleted when the working tree file is absent', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(false)
     gitExecFileAsyncMock.mockResolvedValueOnce({
       stdout:
         'u UD N... 100644 100644 000000 100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb cccccccccccccccccccccccccccccccccccccccc src/deleted.ts\n'
@@ -132,7 +148,6 @@ describe('getStatus', () => {
 
   it('passes core.quotePath=false and round-trips UTF-8 paths', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(false)
     gitExecFileAsyncMock.mockResolvedValueOnce({
       stdout:
         '1 .M N... 100644 100644 100644 ce013625030ba8dba906f756967f9e9ca394464a ce013625030ba8dba906f756967f9e9ca394464a docs/日本語/sample.md\n'
@@ -159,7 +174,6 @@ describe('getStatus', () => {
 
   it('preserves porcelain v2 submodule dirtiness flags on status rows', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(false)
     gitExecFileAsyncMock.mockResolvedValueOnce({
       stdout:
         '1 AM S..U 000000 160000 160000 0000000000000000000000000000000000000000 7844cb64e631f17a9ca5b548f3500ef7cecd2f17 nested-repo\n'
@@ -185,7 +199,6 @@ describe('getStatus', () => {
 
   it('omits ignored files by default and parses them when requested', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(false)
     gitExecFileAsyncMock.mockResolvedValueOnce({
       stdout: '! dist/\n! generated/file.js\n'
     })
@@ -206,7 +219,6 @@ describe('getStatus', () => {
 
   it('parses branch identity from porcelain v2 branch headers', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(false)
     gitExecFileAsyncMock.mockResolvedValueOnce({
       stdout:
         '# branch.oid abcdef1234567890\n# branch.head feature/prompts\n1 .M N... 100644 100644 100644 ce013625030ba8dba906f756967f9e9ca394464a ce013625030ba8dba906f756967f9e9ca394464a src/app.ts\n'
@@ -222,7 +234,6 @@ describe('getStatus', () => {
 
   it('folds upstream ahead/behind from porcelain v2 into the status result', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(false)
     gitExecFileAsyncMock.mockResolvedValueOnce({
       stdout:
         '# branch.oid abcdef1234567890\n# branch.head feature/prompts\n# branch.upstream origin/feature/prompts\n# branch.ab +2 -3\n'
@@ -241,7 +252,6 @@ describe('getStatus', () => {
 
   it('reports no upstream from porcelain v2 status when no same-name origin branch exists', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(false)
     gitExecFileAsyncMock.mockImplementation((args: string[]) => {
       if (args[0] === '-c' && args.includes('status')) {
         return Promise.resolve({
@@ -274,7 +284,6 @@ describe('getStatus', () => {
 
   it('uses same-name origin branch status for legacy base-tracking worktrees', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(false)
     gitExecFileAsyncMock
       .mockResolvedValueOnce({
         stdout:
@@ -297,7 +306,6 @@ describe('getStatus', () => {
 
   it('omits --ignored and ignoredPaths when includeIgnored is not requested', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(false)
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' })
 
     const result = await getStatus('/repo')
@@ -315,7 +323,6 @@ describe('getStatus', () => {
 
   it('parses ! porcelain v2 records into ignoredPaths when includeIgnored is true', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(false)
     gitExecFileAsyncMock.mockResolvedValueOnce({
       stdout: '! dist/\n! .env\n! coverage/\n'
     })
@@ -337,7 +344,6 @@ describe('getStatus', () => {
 
   it('attaches per-area line counts from staged and unstaged numstat', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(false)
     gitExecFileAsyncMock.mockImplementation((args: string[]) => {
       if (args.includes('status')) {
         return Promise.resolve({
@@ -364,7 +370,6 @@ describe('getStatus', () => {
 
   it('reuses unchanged line stats only when the safety hint is present', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(false)
     gitExecFileAsyncMock.mockImplementation((args: string[]) => {
       if (args.includes('status')) {
         return Promise.resolve({
@@ -392,7 +397,6 @@ describe('getStatus', () => {
 
   it('recomputes after a scan whose numstat failed instead of pinning missing counts', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(false)
     let failNumstat = true
     gitExecFileAsyncMock.mockImplementation((args: string[]) => {
       if (args.includes('status')) {
@@ -422,7 +426,6 @@ describe('getStatus', () => {
 
   it('invalidates safety reuse for a new head and for known mutations', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(false)
     let head = 'head-1'
     gitExecFileAsyncMock.mockImplementation((args: string[]) => {
       if (args.includes('status')) {
@@ -450,7 +453,6 @@ describe('getStatus', () => {
 
   it('isolates line-stat reuse between WSL distributions', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(false)
     gitExecFileAsyncMock.mockImplementation((args: string[]) => {
       if (args.includes('status')) {
         return Promise.resolve({
@@ -474,7 +476,6 @@ describe('getStatus', () => {
 
   it('attaches numstat counts for literal paths containing rename markers', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(false)
     gitExecFileAsyncMock.mockImplementation((args: string[]) => {
       if (args.includes('status')) {
         return Promise.resolve({
@@ -503,7 +504,6 @@ describe('getStatus', () => {
 
   it('attaches staged rename counts to the new path', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(false)
     gitExecFileAsyncMock.mockImplementation((args: string[]) => {
       if (args.includes('status')) {
         return Promise.resolve({
@@ -531,7 +531,6 @@ describe('getStatus', () => {
   })
 
   it('counts untracked file contents as additions', async () => {
-    existsSyncMock.mockReturnValue(false)
     lstatMock.mockResolvedValue({
       size: 14,
       mtimeMs: 1,
@@ -555,7 +554,6 @@ describe('getStatus', () => {
 
   it('leaves binary working-tree changes without counts', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(false)
     gitExecFileAsyncMock.mockImplementation((args: string[]) => {
       if (args.includes('status')) {
         return Promise.resolve({
@@ -578,7 +576,6 @@ describe('getStatus', () => {
 
   it('skips numstat entirely for a clean working tree', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(false)
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' })
 
     await getStatus('/repo')
@@ -588,7 +585,6 @@ describe('getStatus', () => {
 
   it('truncates and flags didHitLimit when entries exceed the limit', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(false)
     const stdout = `${Array.from({ length: 25 }, (_, i) => `? file${i}.txt`).join('\n')}\n`
     gitExecFileAsyncMock.mockReset()
     gitExecFileAsyncMock.mockResolvedValue({ stdout: '' })
@@ -651,7 +647,6 @@ describe('getStatus', () => {
 
   it('does not flag didHitLimit for a normal repo under the limit', async () => {
     readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
-    existsSyncMock.mockReturnValue(false)
     gitExecFileAsyncMock.mockReset()
     gitExecFileAsyncMock.mockResolvedValue({ stdout: '' })
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '? a.txt\n? b.txt\n' })

--- a/src/main/git/wsl-git-read-environment.ts
+++ b/src/main/git/wsl-git-read-environment.ts
@@ -16,7 +16,9 @@ export const WSL_GIT_READ_ENVIRONMENT_WAIT_MS = 1_500
 const PROBE_MAX_BUFFER = 64 * 1024
 const TRANSIENT_PROBE_RETRY_MS = 30_000
 const environmentByDistro = new Map<string, Promise<WslGitReadEnvironment | null>>()
-const resolvedEnvironmentByDistro = new Map<string, WslGitReadEnvironment>()
+// Why the null entries matter: a settled "no direct route" answer is what lets a read skip the
+// bounded probe wait entirely instead of racing an already-decided promise on every call.
+const settledEnvironmentByDistro = new Map<string, WslGitReadEnvironment | null>()
 const transientRetryAfterByDistro = new Map<string, number>()
 
 type ProbeOutcome =
@@ -82,6 +84,7 @@ export function getWslGitReadEnvironment(distro: string): Promise<WslGitReadEnvi
   const retryAfter = transientRetryAfterByDistro.get(distro)
   if (retryAfter !== undefined && Date.now() >= retryAfter) {
     environmentByDistro.delete(distro)
+    settledEnvironmentByDistro.delete(distro)
     transientRetryAfterByDistro.delete(distro)
   }
   let environment = environmentByDistro.get(distro)
@@ -91,10 +94,11 @@ export function getWslGitReadEnvironment(distro: string): Promise<WslGitReadEnvi
         return outcome.kind === 'resolved' ? outcome.environment : null
       }
       if (outcome.kind === 'resolved') {
-        resolvedEnvironmentByDistro.set(distro, outcome.environment)
+        settledEnvironmentByDistro.set(distro, outcome.environment)
         transientRetryAfterByDistro.delete(distro)
         return outcome.environment
       }
+      settledEnvironmentByDistro.set(distro, null)
       if (outcome.kind === 'transient') {
         transientRetryAfterByDistro.set(distro, Date.now() + TRANSIENT_PROBE_RETRY_MS)
       }
@@ -105,25 +109,36 @@ export function getWslGitReadEnvironment(distro: string): Promise<WslGitReadEnvi
   return environment
 }
 
-export function peekWslGitReadEnvironment(distro: string): WslGitReadEnvironment | undefined {
-  return resolvedEnvironmentByDistro.get(distro)
+/**
+ * What the shared probe settled to: the environment, `null` for a distro with no
+ * usable direct route, `undefined` while nothing has been decided yet.
+ */
+export function peekWslGitReadEnvironment(
+  distro: string
+): WslGitReadEnvironment | null | undefined {
+  return settledEnvironmentByDistro.get(distro)
+}
+
+/** True once the probe has decided either way, so a read has nothing left to wait for. */
+export function isWslGitReadEnvironmentSettled(distro: string): boolean {
+  return settledEnvironmentByDistro.has(distro)
 }
 
 export function invalidateWslGitReadEnvironment(distro: string): void {
   environmentByDistro.delete(distro)
-  resolvedEnvironmentByDistro.delete(distro)
+  settledEnvironmentByDistro.delete(distro)
   transientRetryAfterByDistro.delete(distro)
 }
 
 export function disableWslGitReadEnvironment(distro: string): void {
   environmentByDistro.set(distro, Promise.resolve(null))
-  resolvedEnvironmentByDistro.delete(distro)
+  settledEnvironmentByDistro.set(distro, null)
   transientRetryAfterByDistro.delete(distro)
 }
 
 export function resetWslGitReadEnvironmentForTests(): void {
   environmentByDistro.clear()
-  resolvedEnvironmentByDistro.clear()
+  settledEnvironmentByDistro.clear()
   transientRetryAfterByDistro.clear()
 }
 
@@ -132,6 +147,6 @@ export function seedWslGitReadEnvironmentForTests(
   environment: WslGitReadEnvironment
 ): void {
   environmentByDistro.set(distro, Promise.resolve(environment))
-  resolvedEnvironmentByDistro.set(distro, environment)
+  settledEnvironmentByDistro.set(distro, environment)
   transientRetryAfterByDistro.delete(distro)
 }

--- a/src/main/git/wsl-git-read-environment.ts
+++ b/src/main/git/wsl-git-read-environment.ts
@@ -7,6 +7,12 @@ import {
 export type WslGitReadEnvironment = { gitPath: string; home: string; path: string }
 
 const PROBE_TIMEOUT_MS = 10_000
+/**
+ * How long a read may wait for a cold probe before taking the login shell.
+ * Short enough that a wedged distro cannot stall the panel, long enough that a
+ * healthy one resolves and every later read runs shell-free.
+ */
+export const WSL_GIT_READ_ENVIRONMENT_WAIT_MS = 1_500
 const PROBE_MAX_BUFFER = 64 * 1024
 const TRANSIENT_PROBE_RETRY_MS = 30_000
 const environmentByDistro = new Map<string, Promise<WslGitReadEnvironment | null>>()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -209,6 +209,7 @@ import {
 } from './startup/single-instance-lock'
 import { startEventLoopStallProbe } from './startup/event-loop-stall-probe'
 import { startMainThreadChurnProbe } from './diagnostics/main-thread-churn-probe'
+import { settledDiffCache } from './git/source-control/git-read-cache-invalidation'
 import { parseSkillShareId } from '../shared/skill-share-link'
 import { SkillShareDeepLinkState } from './startup/skill-share-deep-link-state'
 import {
@@ -736,7 +737,9 @@ if (startupDiagnosticsEnabled) {
   startEventLoopStallProbe()
 }
 // Self-gated on ORCA_MAIN_THREAD_DIAGNOSTICS; runs the whole session to catch steady-state churn (issue #7576).
-startMainThreadChurnProbe()
+// Why the diff-cache counters ride along: a stamp the filesystem reports unstably makes the cache
+// look exactly like a cold start, and only the hit/miss/unprovable split tells the two apart.
+startMainThreadChurnProbe({ extraStats: () => ({ diffCache: settledDiffCache.stats() }) })
 
 function focusExistingWindow(): void {
   focusExistingMainWindow({


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​763 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​67 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​696 |
| Prod | 18 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​662 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​86 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​576 |

<!-- /orca-pr-loc -->

## ELI5

On Windows, when your project lives inside WSL, opening the Source Control panel took more than five seconds, and clicking from one changed file to the next left you staring at "Loading diff…" for over three. The app was asking WSL the same questions over and over — once for every click — and each question meant starting a whole new little Linux program. Now it asks in a cheaper way, and it remembers the answer for a file until something about that file actually changes. Clicking back to a file you already looked at shows the diff immediately.

One late catch: the "has this file changed?" check compares a timestamp Windows wrote down against timestamps that the *Linux* side wrote. If the two sides' clocks disagree, every file looks like it was just edited a moment ago, and the app quietly decides it is never safe to remember anything — so nothing gets faster and nothing says why. That case is now recognised and counted, so it shows up instead of hiding. The rule itself did not change.

## What Changed

Five commits, reviewable in order. The first two are cheap and independent of the cache.

**1. `perf(source-control): stop blocking main on four sync git-dir probes per status poll`**
`detectConflictOperation` made four synchronous `existsSync` calls on the Electron main process against the (UNC) git dir on every status read. They are now concurrent async `access` calls.

**2. `perf(wsl): let git reads take the shell-free route from a cwd-derived distro`**
`wsl-command-resolution.ts` has three routes by cost: shell-free `--exec`, non-login `bash -c`, and login `sh -lc`. Two things kept reads off the fast route:
- `shouldAttemptWslDirectGit` required `options.wslDistro`, even though `wslDistroForCommand` can derive the distro from `cwd`. This was the sole blocker.
- The direct route was taken only if the probe was already warm; `peekWslGitReadEnvironment` is a sync cache read and the probe was merely kicked off as a side effect, so early reads silently fell back. The wait is now bounded (1.5 s) rather than fire-and-forget.

The explicit `preferWslDirectGit` opt-in (via `gitReadOptionsForWorktree`, renamed from `gitStatusReadOptionsForWorktree` — it was never status-specific) is belt-and-braces: the diff path's commands (`show`, `config --file .gitmodules --get-regexp`, `ls-files`, `rev-parse`) were already matched by `isWslDirectGitReadCommand`.

**3. `perf(source-control): give diff reads a settled cache keyed on stamped git state`**
Adds `worktree-diff-stamp.ts` (subprocess-free stamp of exactly the diff's inputs) and `settled-diff-cache.ts`, plus a `failed`-vs-absent distinction in `git-blob-read.ts`. Also drops `gitDiffReadDedupe.clear()` from `getStatus` — a status poll is a read, and all that call did was destroy a live coalescing entry so a concurrent identical request started duplicate git work.

**4. `perf(source-control): reuse BoundedMap and stop the WSL probe wait from outliving its answer`** — the fix round on top of review. It:
- Stops a permanently-disabled distro from paying for the probe wait. `disableWslGitReadEnvironment` used to delete the resolved entry, so `peek` returned `undefined` forever and every later git read still built a `Promise.race` + 1.5 s timer. `resolvedEnvironmentByDistro` is now `settledEnvironmentByDistro: Map<string, WslGitReadEnvironment | null>` (`undefined` = undecided, `null` = known-unavailable) with an `isWslGitReadEnvironmentSettled` guard. The transient-retry path clears the settled entry when the 30 s window expires, so a re-probe is still waited on.
- Makes the bounded probe wait honour `options.signal`: an already-aborted read returns `null` with no promise and no timer; a mid-wait abort ends the wait via `waitForPromiseWithSignal`.
- Moves `settledDiffCache.beginRead()` to the first statement of `loadDiffThroughSettledCache` (`file-diff.ts:77`), so the generation fence covers the stamp read itself, not just the git read.
- Gives the cache counters a real production consumer: `startMainThreadChurnProbe` takes an optional `extraStats` callback folded into its 5 s report line, and `src/main/index.ts` passes `() => ({ diffCache: settledDiffCache.stats() })`.
- Backs `SettledDiffCache` with `src/shared/bounded-map.ts`'s `BoundedMap` (maxEntries 32, maxBytes 8_000_000, maxEntryBytes 1_000_000, `sizeOf: entry.characters`), deleting the hand-rolled Map + retained-character ledger + LRU refresh + evict loop.
- Replaces the hand-rolled `Promise.race` + `clearTimeout` in `git-command-resolution.ts` with `withTimeout` from `src/shared/promise-timeout-fallback.ts`, which also absorbs a probe rejection that would otherwise have surfaced as a git-read failure at three call sites.
- Rewords the index over-invalidation comment in `worktree-diff-stamp.ts:62` to attribute the index rewrite to git run *outside* Orca — Orca's own poll sets `GIT_OPTIONAL_LOCKS=0` (`status-read.ts:135`), so the old premise was disprovable from the repo.

**5. `fix(source-control): tell WSL clock skew apart from a genuinely fresh write`** (`58554d8c0ea`) — a defect found by the second review round, in the racy-write margin itself. `canProveUnchangedByStamp` compares `capturedAtMs`, taken from *this host's* clock, against mtimes written by *whatever wrote the files* — on a `\\wsl.localhost` worktree, the guest. A guest running ahead pushes every recently-touched file past the 2 s margin, so the cache refuses to store: silently, on every file, for as long as the skew lasts, on exactly the platform this cache exists for. A permanently cold cache was indistinguishable from a cold start.

`isDiffStampClockSkewed` flags the one thing no local write can produce — an mtime in this host's *future* — and `SettledDiffCache` counts those as `clockSkewedWrites`, a subset of `racyWrites`, surfaced through the same `stats()` line already wired into the churn probe. **Behaviour is unchanged**; the store is still refused. What changed is that "the clocks disagree and this will not resolve on its own" is now distinguishable from "the file was genuinely just edited". 3 files, +78/−1.

## Why

On Windows 11 with a project opened over WSL2 (`\\wsl.localhost\...`), switching to Source Control took **>5 s every time** and switching between uncommitted files showed "Loading diff…" for **>3 s**. Three separate causes:

1. **Sync FS on the main thread.** `git-conflict-operation.ts` called `existsSync` four times per status read; against a `\\wsl.localhost` git dir each is a redirector round trip on the Electron main thread, serialized.
2. **Shell-per-spawn on WSL reads.** `shouldAttemptWslDirectGit` ended with `&& options.wslDistro`, so an override-less UNC cwd could never take the shell-free `--exec` route. Correction to the earlier draft of this description: the override-less UNC fallback is the **non-login `bash -c`** route, not the login `sh -lc` one — `resolveGitCommandWithoutProbe` gates the login shell on `Boolean(options.wslDistro)`, undefined in exactly this case. So the pre-fix cost was one non-login shell per `git show`, not an rc run per command. That gate is deliberately left alone: "fixing" it would push override-less UNC reads *onto* the login shell.
3. **No settled diff cache at all.** `in-flight-promise-dedupe.ts` removes its entry in `.finally()` — only in-flight coalescing existed. Every file selection re-ran the whole read: a `git config --get-regexp` spawn, one or two `git show` spawns, plus a working-tree `stat` + `readFile`, each git spawn being a `wsl.exe` invocation on this host.

### Why it cannot serve a stale diff

- **The stamp is captured before the read** (`worktree-diff-stamp.ts:58`) and stored alongside the result. Any input that moves during or after the read leaves the stored stamp behind, so the next lookup misses. No TTL, no clock expiry.
- The stamp covers HEAD (by **resolved tip content**, so a plain commit is visible even though HEAD's own bytes never move — with commondir, packed-refs/reftable fallback, and an unborn-branch marker), `.git/index` (mtime+size), `.gitmodules`, and the working-tree file.
- **A store is refused unless `capturedAt − newestMtime >= 2000 ms`.** 2 s is FAT/exFAT granularity, the coarsest a repo can realistically sit on; below that a second write inside the same mtime bucket would be invisible. This is git's own racy-index rule, and `capturedAtMs` being taken before the stats makes it a lower bound. As of commit 5, a refusal caused by a *future-dated* mtime — i.e. cross-clock skew rather than freshness — is counted separately as `clockSkewedWrites`.
- **`null` stamp = "cannot prove" = never cache.** Covers folder workspaces, non-repos, unreadable layouts, and any filesystem reporting no usable mtime.
- **Non-reusable reads are never stored.** Submodule routes (their inputs live in another repo), and reads that *failed* rather than *proved absence*. That last one needed a real change: a `wsl.exe` hiccup produces the same empty left side a new file does, so `git-blob-read.ts` now distinguishes git exit 128 ("path is not there") from anything else. Without it, one transient WSL failure would have pinned a wrong diff indefinitely.
- **`invalidateGitReadCaches()` clears the cache and bumps a generation**, and `beginRead()` now fences from before the stamp read, so a read that started pre-mutation cannot store post-mutation.
- **`ino` is optional rather than required-to-match.** Windows reports `0` for the redirector behind `\\wsl.localhost`; requiring an unstable `0` to match would have made the cache silently never hit on the exact host it exists for. The cost of that concession is a narrow stale-hit edge, listed under residual risk below.

## Risk & Trade-offs

**Merge risk: Medium.** The cache still decides on its own when a diff is valid, and a wrong stamp shows a diff that does not match the file — but the design has now been independently reviewed and approved as-is, the one defect that review found is fixed, and every remaining failure mode is either bounded and self-correcting or fails toward "never cache" rather than toward a wrong answer. (Was **Medium-high**; what moved it is the design review's approve-as-is verdict on the stamp itself plus commit 5 closing the one silent-failure path it turned up.)

### What the design review concluded

A fable design pass judged the change **approve as-is**: the stamp is close to the cheapest sufficient one for the invariant it defends, and no component of it is dead weight. Recording HEAD by **content** rather than by `stat` is the load-bearing choice — a diff read immediately after a commit is cacheable at once instead of falling into the 2 s racy-write blind window, which is precisely when a user is most likely to be clicking through files. The cost side holds too: a cache hit is single-digit milliseconds of `stat` calls against the 100+ ms of `wsl.exe` spawns it avoids, so the stamp read is not close to eating the win. (An order-of-magnitude design judgment, not a stopwatch on the reporter's host — see Testing.)

### What could go wrong

- ~~**The racy-write margin is silently permanent on WSL.**~~ **Found and fixed in commit 5.** `capturedAtMs` (this host's clock) was compared against mtimes the WSL guest wrote; a guest running ahead pushed every recently-touched file past the 2 s margin, so the cache refused every store — invisibly, indefinitely, on the target platform. Behaviour is deliberately unchanged (refusing is still correct), but `isDiffStampClockSkewed` now flags an mtime in this host's future — which no local write can produce — and `clockSkewedWrites` reports it through the churn probe. A nonzero count means the cache is off for a reason idling will not fix.
- **A stale diff on WSL, because Windows reported an old mtime.** The design assumes that when a Linux-side process writes a file, a Windows-side `stat` through `\\wsl.localhost` immediately reports the new mtime. If the 9p redirector serves a cached attribute for even a short window, the stamp still matches, the cache hits, and the user sees the diff from before their edit. **This remains unverified** — P9RDR attribute-cache behaviour was never tested, and the design review did not change that. Likelihood: unknown, which is the problem. What surfaces it: edit a file from a WSL shell, immediately re-click it in Source Control; if the old diff appears, this is real. Self-healing only once some other input in the stamp moves, so it can persist across several clicks.
- **A stale hit on a retargeted symlink.** `stat` follows symlinks, and `ino` is dropped when the 9p redirector reports `0`, so a symlink repointed at a different file whose size matches and whose mtime is *older* produces an identical stamp and a hit on the previous target's diff. Narrow — it needs a size collision, a backwards mtime and a symlink in the changed set — but it is the concrete price of the `ino` concession above, and it does not self-heal until another stamp input moves.
- **A stale diff from a read that was joined mid-flight.** Dropping `gitDiffReadDedupe.clear()` from `getStatus` means a second caller can attach to an in-flight read and get content captured before an edit that landed during that read, without going through the stamp check. Pre-existing behaviour, marginally widened. Bounded by one read duration and correct again on the next request.
- **A stale diff after a transient WSL probe outcome is treated as settled.** A read issued right after the 30 s retry window can observe the settled entry before the re-probe re-decides. Bounded and self-correcting; still flagged as worth a second look.
- **The cache silently never hits, and the PR delivers nothing.** Two known routes to this: `resolveGitDir` does `path.resolve(worktreePath, gitdirPointer)`, and a `.git` file authored by WSL git holds a Linux absolute path, which on win32 resolves to a bogus path — HEAD lookup misses, stamp is `null`, nothing is cached; and the clock-skew case above. Safe but a total loss of the win. Both are now **observable rather than inferred**: `unprovable` and `clockSkewedWrites` in the 5 s churn probe line separate them from each other and from a genuinely cold cache.
- **A first git read on a cold or wedged distro feels slower than before.** The probe wait is now bounded at 1.5 s rather than fire-and-forget, so that latency is new, recurring once per 30 s retry window. It should overlap the read's own `wsl.exe` spawn waiting for the same boot — but that overlap was reasoned about, not measured.
- **Review churn on a big changeset evicts your own history.** The cache is 32 entries global across every worktree and project; clicking through a 50-file changeset evicts the files you started with, so re-clicking them pays full cost again. Low severity, visible as inconsistent snappiness.

### What a user gets in exchange

On Windows 11 with a project opened over WSL2, the reporter measured **>5 s to open Source Control** and **>3 s of "Loading diff…" on every file-to-file switch**. This removes, per file selection, a `git config --get-regexp` spawn, one or two `git show` spawns (each a full `wsl.exe` invocation), and a working-tree `stat` + `readFile`; removes four synchronous `existsSync` calls on the Electron main process per status poll against a UNC git dir; and moves WSL git reads off a per-spawn `bash -c` shell onto the shell-free `--exec` route. Re-selecting a file you already viewed becomes an in-memory hit — single-digit ms of `stat` in place of 100+ ms of spawns, per the design review's cost estimate. **No stopwatch number after the change exists** — the improvement is inferred from removed spawns plus unit tests asserting no re-spawn, not measured on the reporter's host.

### Trade-offs accepted

- **Correctness bought with cache misses.** A `null` stamp means "cannot prove", and that means never cache — folder workspaces, non-repos, unreadable layouts, any filesystem with no usable mtime. Same for submodule routes and reads that failed rather than proved absence. These paths get zero benefit and one extra stamp read.
- **A store is refused unless `capturedAt − newestMtime >= 2000 ms`.** Files edited in the last two seconds are never cached, so the rapid edit-then-look loop — arguably the most frequent one — stays slow, and the file you are actively editing still pays 1–2 `wsl.exe` spawns per look. That is git's own racy-index rule and it is deliberate; commit 5 does not relax it, it only makes the cross-clock variant of the refusal visible.
- **Index over-invalidation is kept on purpose.** An external `git status`/`git add` rewrites `.git/index` and evicts a still-valid diff. The safe direction; dropping the index from the stamp would make `git add` invisible.
- **No end-to-end verification on the target host.** Still not manually exercised on Windows + WSL2 — manual testing was macOS only, and no before/after capture or screen recording on the reporter's host exists. That recording is still owed.
- **Commits were validated as a final tree, not individually.** File splits were sequenced so each should stand alone, but that was not checked out and tested.
- **Relay/SSH gets none of this.** `src/relay/git-handler.ts` keeps its own diff implementation with in-flight coalescing only. Not a regression, but the two diff paths have diverged further and remote hosts stay slow.
- **Scope expansion in commit 4.** Three of its ten files (`src/main/index.ts`, `main-thread-churn-probe.ts`, its test) exist only to give `settledDiffCache.stats()` a production consumer. Commit 5 leans on exactly that wiring to report `clockSkewedWrites`, so reverting those three now also removes the only signal that would catch a permanently-cold cache. The other six fixes still stand alone.
- **Two review items were declined:** the #16587 community item (nothing actionable beyond the PR-body ordering note, which was applied) and "shrink `stats()` to three fields" (factually wrong — the tests assert on six of them, and commit 5 has since added a seventh).
- **`pnpm run check:code-quality:changed` could not run** in the fix-round environment; `npx oxlint` on the changed files directly exits 0.

### How to back it out

Clean revert. No persisted state, no migration, no IPC or wire-contract change — the cache is in-memory and dies with the process, and the one new type field (`GitBlobReadResult.failed`) is optional and main-process-internal. Reverting commits 3–5 removes the cache and its stale-diff risk while keeping the two independent wins in commits 1 and 2.

## Linked Issue

Partially addresses #15036 — the **source-control latency** half. The OpenCode SQLite "database is locked" half of that issue is covered by #16587. **#15036 should stay open until both land**; do not auto-close it from this PR.

## Visual Proof

N/A — every change here is in the Electron main process (git command routing, filesystem stamping, an in-memory cache) and produces no new or altered rendered output; the only user-visible effect is that existing panels finish loading sooner. Worth stating plainly: **no before/after timing capture on the reporter's Windows+WSL2 host exists yet** — the >5 s / >3 s numbers above are the reporter's original measurements, and a screen recording of Source Control panel open and file-to-file switching on that host is still owed as the end-to-end confirmation.

## Testing

Second review round (commit `58554d8c0ea`, the clock-skew fix): 2 new tests in `settled-diff-cache-bounds.test.ts` — `counts a future-dated mtime separately from an ordinary racy write` and `does not flag a stamp whose components were all absent`. Both were proven non-vacuous by neutering the detector (making `isDiffStampClockSkewed` return `false` unconditionally), which fails the first and leaves the second passing, i.e. the second is the guard against over-counting rather than a restatement of the first. Typecheck and the `src/main/git` suite were re-run on the tree with commit 5 applied and stayed clean.

Fix-round run (in a clean worktree of this branch at `/tmp/fixwt-16600`):

```
$ pnpm tc
> node config/scripts/run-typecheck-projects-in-parallel.mjs
(clean exit, no diagnostics)

$ pnpm test src/main/git
 Test Files  170 passed | 2 skipped (172)
      Tests  1962 passed | 4 skipped (1966)
   Duration  13.53s

$ pnpm test src/main/git src/main/diagnostics
 Test Files  171 passed | 2 skipped (173)
      Tests  1973 passed | 4 skipped (1977)
   Duration  5.83s

$ npx oxlint <10 changed files>
exit=0 (no diagnostics)
```

Each new fix-round test was verified non-vacuous by stashing the production file and keeping the test:

```
x refuses to store a result for a mutation that landed inside the stamp read -- expected +0 to be 1
x stops deferring reads once the direct route is disabled for the distro   -- expected Promise{…} to be null
x never waits on the probe for an already-aborted read                     -- expected Promise{…} to be null
x stops waiting for a cold probe as soon as the read aborts                -- Test timed out in 30000ms
x folds caller-contributed counters into the report line                   -- expected { t: 5000, … } to match { diffCache: { hits: 3, misses: 1 } }
```

Reviewer, on the pre-fix tree, independently re-ran `pnpm tc` (clean), `pnpm test src/main/git` (170 files / 1958 tests passed, 2 skipped) on a clean checkout, `oxlint` on all 23 changed files (exit 0), and `oxfmt --check` (clean). A broader sweep `pnpm test src/main src/shared src/relay` gave 33,257 passed with one failure — `run-electron-vite-dev.test.ts > rebuilds the copied Electron app`, timed out at 30 s. Flake, not this change: macOS-only Electron-copy test in `src/main/startup/`, passed in an earlier identical sweep, and passes in isolation (15.11 s under a 30 s limit). **The reviewer's independent sweep predates commits 4 and 5**; the later numbers above are the author's.

New tests: 15 in `status-diff-settled-cache.test.ts` (five invalidation axes, mutation-overtakes-read, racy write, unprovable stamp, failed-vs-absent read, staged/unstaged isolation, and the status-poll-doesn't-drop-coalescing regression), 8 in `settled-diff-cache-bounds.test.ts` (6 bounds tests, all passing unchanged after the `BoundedMap` swap, plus the 2 clock-skew tests from commit 5), conflict-operation concurrency/detection tests, and WSL routing tests. `runner-wsl-direct-read.test.ts`'s "leaves override-less WSL UNC routing on its existing non-login shell" was rewritten — it encoded the bug, asserting `['bash','-c']` for the very input that now asserts `--exec` + `PATH=`.

Kept correct for folder workspaces, SSH-backed repos and native Windows repos — not only the WSL/UNC case that motivated it.

**Still not run on the target hardware.** No Windows 11 + WSL2 execution of any kind — no timing capture, no 9p attribute-cache probe, no observation of the `diffCache` counters against a real `\\wsl.localhost` worktree. Everything above is macOS + unit tests.

- [x] I manually tested these changes locally — on macOS only. **Not manually exercised on Windows + WSL2**, which is the host the PR targets.
- [x] Automated tests added/updated

## Review

### Credit

- **@nwparker's #16587** is the sibling half of #15036 and got the split right: it identified and is fixing the OpenCode SQLite "database is locked" symptom in `src/main/ai-vault`, which shares no file, type or cache with this diff. Nothing was inherited from it — the only thing that carries over is the ordering constraint, which is why the Linked Issue section above refuses to close #15036. For the record, `gh pr list --search "15036 in:body" --state all` returns no third-party PRs against this issue: the other hits (#15749, #16550, #12474) match on unrelated body text and are already merged. Being first on the other half still counts, and the reviewer's search is the reason this PR does not claim the whole issue.

### Design review (round 2): approve as-is

A fable design pass looked for a cheaper sufficient stamp and did not find one: every component defends an input the diff actually reads, and dropping any of them admits a wrong answer. It called out recording HEAD **by resolved tip content rather than by `stat`** as the load-bearing decision — it is what makes a post-commit read cacheable immediately instead of landing in the 2 s racy-write blind window — and confirmed the cost balance (single-digit ms of `stat` per hit against the 100+ ms of `wsl.exe` spawns avoided). No component was judged dead weight. Verdict: approve as-is, no redesign requested.

### Defect found and fixed in round 2

- **Cross-clock racy-write margin** (`58554d8c0ea`). See What Changed §5 and the first "What could go wrong" bullet. Short version: the margin compared this host's `Date.now()` against guest-written mtimes, so on a skewed WSL guest the cache refused every store, permanently and silently, on exactly the platform it exists for. Fixed as observability — `isDiffStampClockSkewed` + `clockSkewedWrites` — not as a behaviour change; the refusal is still correct, it is now attributable. Non-vacuity proven by neutering the detector.

### Declined in the fix round

- **Community item #16587** — declined as a code change (correctly): `inherit` names nothing concrete, so the only actionable part was the PR-body ordering note, applied above.
- **Elegance suggestion "shrink `stats()` to three fields"** — declined and inverted, because the suggestion was factually wrong: the tests assert on `hits`, `unprovable`, `racyWrites`, `invalidatedDuringRead`, `entries` and `retainedCharacters`; only `misses` and `stores` were unused, and `misses` is the counter the doc comment is about. Wiring `stats()` into the churn probe was chosen instead — and commit 5 then used that wiring to surface `clockSkewedWrites`, which the shrink would have made impossible.

### Residual risk a reviewer should weigh

- **9p attribute caching — the biggest unproven assumption.** The whole design rests on Windows-side `stat` seeing a fresh mtime for a file a Linux-side process wrote. If the `\\wsl.localhost` redirector serves a cached attribute for a window, the stamp matches while the content has moved, and a stale diff is served. Pre-fix code re-read content through the same redirector so it was equally exposed on the modified side, but the cache extends the exposure to the whole diff. **P9RDR attribute-cache behaviour was not verified**, and the design review did not touch it. Cheapest way to close it: on the reporter's host, edit a file from a WSL shell and immediately re-select it in Source Control.
- **Retargeted-symlink stale hit.** `stat` follows symlinks and `ino` is dropped when the redirector reports `0`, so a symlink repointed at a file of the same size with an *older* mtime stamps identically and hits the previous target's cached diff. Narrow and contrived, but real, and it does not self-heal until another stamp input moves.
- **The 2 s margin costs the hottest read.** The file you are actively editing is by construction always inside the margin, so it never caches and still pays 1–2 `wsl.exe` spawns per look. The cache wins on re-selection and on files you are not currently typing in; that is the shape of the benefit, and it is worth being explicit that the highest-frequency read is not the one being sped up.
- **Scope expansion in commit 4.** Three of its ten files (`src/main/index.ts`, `src/main/diagnostics/main-thread-churn-probe.ts` and its test) exist solely to give `settledDiffCache.stats()` a production consumer. Reverting just those three leaves the other six fixes intact — but also removes the only channel by which `clockSkewedWrites` and `unprovable` reach anyone.
- **Transient-probe settling.** Marking a transient probe outcome as settled means a read issued right after the 30 s `TRANSIENT_PROBE_RETRY_MS` window can observe the settled entry before the re-probe re-decides. Bounded and self-correcting, but still worth a second look.
- **`resolveGitDir` on WSL-authored linked worktrees.** Unchanged code, now on the stamp path: it does `path.resolve(worktreePath, gitdirPointer)`. A `.git` file authored by WSL git holds a Linux absolute path, which on win32 resolves to a bogus drive-relative path; HEAD then misses and the stamp is `null`. Result is "cache never hits for that layout" — safe, but it would silently negate the main win. `stats().unprovable` is what would surface it, now distinguishable from the clock-skew route to the same outcome.
- **Cold/wedged distro cost.** The 1.5 s bounded wait is latency that did not exist when the probe was fire-and-forget, recurring once per 30 s retry window. On a cold distro the read's own `wsl.exe` spawn must wait for the same boot, so it largely overlaps rather than adds — but that overlap was reasoned about, not measured.
- **Cache sizing.** 32 entries is global across all worktrees and projects; clicking through a 50-file changeset of small files evicts the head of your own review.
- **Coalescing window.** Dropping `gitDiffReadDedupe.clear()` from `getStatus` is right, but a caller that joins an in-flight read bypasses the stamp check and can receive content from before an external edit that landed mid-read. Pre-existing, marginally widened; bounded by one read duration and self-corrects on the next request.
- **Relay/SSH parity.** `src/relay/git-handler.ts` keeps its own diff implementation with in-flight coalescing only, so remote hosts get none of this. Not a regression, but the two diff paths have diverged further.
- **Index over-invalidation is kept on purpose.** External `git status`/`git add` rewrites `.git/index` and evicts a still-valid diff. That is the safe direction; dropping the index from the stamp would make `git add` invisible. The comment says not to "fix" it.

### Not verified

- The five commits were validated as a final tree; they were not checked out and tested individually, though the file splits were sequenced so each should stand alone.
- No end-to-end timing measurement on Windows + WSL2 after the change, and no run on that hardware at all. The claimed improvement is inferred from spawn/round-trip removal, the design review's cost estimate, and unit tests asserting no re-spawn — not from a stopwatch on the reporter's host.
- The clock-skew path is covered by unit tests with synthetic stamps only; no observation of `clockSkewedWrites` against a real skewed WSL guest.
- `pnpm run check:code-quality:changed` could not run in the fix-round environment (the script `JSON.parse`s oxlint stdout and a pnpm engine warning — node v26 vs. wanted 24 — is prepended to it). `npx oxlint` on the changed files directly exits 0.

## Notes

Security: no new IPC surface, no persisted state, no wire contract change. Cross-platform: the WSL routing changes are Windows-only paths; the cache and stamp are platform-agnostic and degrade to "never cache" where mtime is unprovable or the clocks disagree. Remote SSH: unchanged (`src/relay/git-handler.ts` untouched — see parity note). Mobile: unaffected. Backwards compatibility: the only new type field, `GitBlobReadResult.failed`, is optional, main-process-internal, and its three other consumers (branch-diff, commit-diff, submodule-diff) ignore it safely. `SettledDiffCacheStats.clockSkewedWrites` is an added field on a main-process-internal stats object with no external consumer.

## Agent skill upstream boundary

- [x] Not applicable — this change touches no skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm typecheck` and `pnpm test` pass locally; `oxlint` clean; `pnpm build` left to CI