### PR TITLE
fix(mobile): stop live output jumping off-screen

### DIFF
--- a/mobile/src/session/MobileNativeChatView.test.ts
+++ b/mobile/src/session/MobileNativeChatView.test.ts
@@ -151,6 +151,31 @@ describe('MobileNativeChatView', () => {
     })
   }
 
+  it('keeps streaming output pinned after the user jumps to latest', async () => {
+    const folded = [assistantTurn('a1', 'Older output')]
+    await render({ folded, streaming: 'First streaming chunk' })
+    const list = renderer!.root.find((node) => node.type === 'FlatList')
+    await act(async () => {
+      list.props.onScroll({
+        nativeEvent: {
+          contentOffset: { y: 0 },
+          contentSize: { height: 1_000 },
+          layoutMeasurement: { height: 200 }
+        }
+      })
+    })
+    const jumpButton = renderer!.root.find(
+      (node) => node.props.accessibilityLabel === 'Scroll to latest'
+    )
+
+    await act(async () => jumpButton.props.onPress())
+    await update({ folded, streaming: 'First streaming chunk with more output' })
+
+    expect(
+      renderer!.root.findAll((node) => node.props.accessibilityLabel === 'Scroll to latest')
+    ).toHaveLength(0)
+  })
+
   it('renders the route-reported failure verbatim', async () => {
     await render({ sendErrorMessage: 'Permission reply failed' })
 

--- a/mobile/src/session/MobileNativeChatView.test.ts
+++ b/mobile/src/session/MobileNativeChatView.test.ts
@@ -94,15 +94,19 @@ function chatViewElement(overrides: Overrides): ReturnType<typeof createElement>
 
 describe('MobileNativeChatView', () => {
   let renderer: ReactTestRenderer | null = null
+  const scrollToEnd = vi.fn()
 
   afterEach(() => {
     act(() => renderer?.unmount())
     renderer = null
+    scrollToEnd.mockReset()
   })
 
   async function render(overrides: Overrides = {}): Promise<void> {
     await act(async () => {
-      renderer = create(chatViewElement(overrides))
+      renderer = create(chatViewElement(overrides), {
+        createNodeMock: (element) => (element.type === 'FlatList' ? { scrollToEnd } : null)
+      })
     })
   }
 
@@ -169,8 +173,15 @@ describe('MobileNativeChatView', () => {
     )
 
     await act(async () => jumpButton.props.onPress())
-    await update({ folded, streaming: 'First streaming chunk with more output' })
+    expect(scrollToEnd).toHaveBeenCalledWith({ animated: false })
+    scrollToEnd.mockClear()
 
+    await update({ folded, streaming: 'First streaming chunk with more output' })
+    const updatedList = renderer!.root.find((node) => node.type === 'FlatList')
+    await act(async () => updatedList.props.onContentSizeChange())
+
+    expect(scrollToEnd).toHaveBeenCalledOnce()
+    expect(scrollToEnd).toHaveBeenCalledWith({ animated: false })
     expect(
       renderer!.root.findAll((node) => node.props.accessibilityLabel === 'Scroll to latest')
     ).toHaveLength(0)

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -237,6 +237,11 @@ export function MobileNativeChatView({
     [hasMore, loadingEarlier, onLoadEarlier]
   )
 
+  const jumpToLatest = useCallback(() => {
+    setAtBottom(true)
+    listRef.current?.scrollToEnd({ animated: false })
+  }, [])
+
   // Align a single message's top to the top of the viewport.
   const onScrollToMessage = useCallback((index: number) => {
     listRef.current?.scrollToIndex({ index, viewPosition: 0, animated: true })
@@ -343,7 +348,7 @@ export function MobileNativeChatView({
             <Pressable
               accessibilityLabel="Scroll to latest"
               style={[styles.fab, styles.fabBottom]}
-              onPress={() => listRef.current?.scrollToEnd({ animated: true })}
+              onPress={jumpToLatest}
             >
               <ArrowDown size={18} color={colors.textPrimary} strokeWidth={2.2} />
             </Pressable>


### PR DESCRIPTION
## ELI5

During a live agent response, the down-arrow could move the chat to the bottom without actually turning bottom-follow back on. The next streamed chunks could then push the newest output off-screen again. This change reattaches bottom-follow before jumping, so continued output stays visible.

## What Changed

- Mark the mobile native-chat list as bottom-pinned before executing the jump-to-latest action.
- Use an immediate jump instead of an animated transition, preventing intermediate scroll events from detaching the list again while output is streaming.
- Add a regression test that starts with a streaming row, detaches the viewport, jumps to latest, grows the same streaming row, and verifies bottom-follow remains active.

## Why

The jump button only called `scrollToEnd`; it left `atBottom` false until a later scroll event. `onContentSizeChange` therefore ignored in-place streaming growth during that window, and the viewport could rebound above the live tail. Updating the pin state first makes the existing content-size follow behavior authoritative.

## Linked Issue

Fixes #11638

## Visual Proof

N/A — no styling or layout changes. The interaction-only fix was verified on iOS during active streamed output: scroll up, tap jump-to-latest, and subsequent chunks remain pinned at the visible tail.

## Testing

- [x] Manually tested on iOS during active streamed agent output
- [x] Automated regression coverage added
- `mobile`: `vitest run src/session/MobileNativeChatView.test.ts` — 8 passed
- `mobile`: full `vitest run` on supported Node 24 — 466 files passed, 3,737 tests passed, 3 skipped
- `mobile`: `tsc --noEmit` — passed
- `mobile`: `pnpm run lint` — passed
- Root: `pnpm run typecheck:node` — passed
- Root: `pnpm run check:code-quality:changed` — 0 findings across 2 changed files
- iOS: Expo native simulator build on iPhone 17 Pro / iOS 26.5 — succeeded

Platform notes: iOS was manually verified. The changed React Native list logic is shared with Android and contains no platform-specific API. Desktop, SSH/remote transport, and host execution paths are unchanged.

## AI Disclosure

OpenAI Codex (GPT-5.6) was used for investigation, implementation, regression coverage, verification, and PR preparation.

## Review

- **Correctness:** The state transition now precedes the imperative scroll; continued in-place streaming growth uses the existing pinned `onContentSizeChange` path.
- **Cross-platform:** Platform-neutral React Native code; no path, shortcut, or native API changes. iOS verified; Android uses the same component path.
- **SSH / remote / local:** View-local scroll state only. No RPC, stream-frame, host-authority, or execution-boundary changes.
- **Agents / integrations / providers:** Independent of agent and provider payloads; the fix operates on rendered streaming growth.
- **Performance:** One state update on an explicit user tap; no new work in the streaming hot path.
- **UI quality:** No visual changes. Removing animation from this recovery action prevents a visible rebound and restores predictable chat behavior.
- **Security:** No authentication, authorization, persistence, or sensitive-data changes.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Author

- GitHub: @xcjy8bao
- X (Twitter): N/A — no X account

## Notes

No protocol-version change is required; this is local mobile UI state only.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Relevant local checks pass; repository-wide `pnpm lint`, `pnpm test`, and `pnpm build` are left to CI