### PR TITLE
ci(mobile): publish the Android APK as orca-app-release.apk

### DIFF
--- a/.github/workflows/mobile-android-release.yml
+++ b/.github/workflows/mobile-android-release.yml
@@ -70,11 +70,20 @@ jobs:
       - name: Build Android release APK
         run: cd android && ./gradlew assembleRelease
 
+      # Why: Gradle names every React Native release build `app-release.apk`, so
+      # the file a user sideloads is indistinguishable from any other app once it
+      # lands in Downloads. Rename before any step publishes it.
+      - name: Name the release APK for Orca
+        run: |
+          set -euo pipefail
+          cd android/app/build/outputs/apk/release
+          mv app-release.apk orca-app-release.apk
+
       - name: Upload APK artifact
         uses: actions/upload-artifact@v7
         with:
           name: orca-mobile-apk
-          path: mobile/android/app/build/outputs/apk/release/*.apk
+          path: mobile/android/app/build/outputs/apk/release/orca-app-release.apk
 
       - name: Ensure GitHub release tag
         if: steps.release.outputs.publish_release == 'true' && !startsWith(github.ref, 'refs/tags/mobile-android-v')
@@ -102,7 +111,7 @@ jobs:
             gh release upload "$tag" \
               --repo "$GITHUB_REPOSITORY" \
               --clobber \
-              android/app/build/outputs/apk/release/*.apk
+              android/app/build/outputs/apk/release/orca-app-release.apk
           else
             gh release create "$tag" \
               --repo "$GITHUB_REPOSITORY" \
@@ -110,5 +119,5 @@ jobs:
               --prerelease \
               --latest=false \
               --generate-notes \
-              android/app/build/outputs/apk/release/*.apk
+              android/app/build/outputs/apk/release/orca-app-release.apk
           fi

--- a/config/scripts/mobile-android-apk-asset-name.test.mjs
+++ b/config/scripts/mobile-android-apk-asset-name.test.mjs
@@ -34,8 +34,12 @@ describe('Orca Android release APK asset name', () => {
     expect(upload).toBeGreaterThan(rename)
 
     const run = stepNamed(RENAME_STEP).run
-    expect(run).toContain(`cd ${APK_OUTPUT_DIR}`)
-    expect(run).toContain(`mv ${GRADLE_APK_NAME} ${ORCA_APK_NAME}`)
+    const lines = run.split('\n').map((line) => line.trim())
+    const cdLine = lines.indexOf(`cd ${APK_OUTPUT_DIR}`)
+    const mvLine = lines.indexOf(`mv ${GRADLE_APK_NAME} ${ORCA_APK_NAME}`)
+
+    expect(cdLine).toBeGreaterThanOrEqual(0)
+    expect(mvLine).toBeGreaterThan(cdLine)
   })
 
   // `upload-artifact` resolves `path` from the workspace root, while `run` steps

--- a/config/scripts/mobile-android-apk-asset-name.test.mjs
+++ b/config/scripts/mobile-android-apk-asset-name.test.mjs
@@ -8,6 +8,11 @@ const projectDir = resolve(import.meta.dirname, '../..')
 const ORCA_APK_NAME = 'orca-app-release.apk'
 const GRADLE_APK_NAME = 'app-release.apk'
 const RENAME_STEP = 'Name the release APK for Orca'
+// Gradle's own output directory. The rename writes here and every publish reads
+// from here, so pinning it once is what keeps those two ends pointing at the
+// same file.
+const APK_OUTPUT_DIR = 'android/app/build/outputs/apk/release'
+const ORCA_APK_PATH = `${APK_OUTPUT_DIR}/${ORCA_APK_NAME}`
 
 const workflow = () =>
   parse(readFileSync(join(projectDir, '.github/workflows/mobile-android-release.yml'), 'utf8'))
@@ -27,22 +32,30 @@ describe('Orca Android release APK asset name', () => {
     expect(build).toBeGreaterThanOrEqual(0)
     expect(rename).toBeGreaterThan(build)
     expect(upload).toBeGreaterThan(rename)
-    expect(stepNamed(RENAME_STEP).run).toContain(`mv ${GRADLE_APK_NAME} ${ORCA_APK_NAME}`)
+
+    const run = stepNamed(RENAME_STEP).run
+    expect(run).toContain(`cd ${APK_OUTPUT_DIR}`)
+    expect(run).toContain(`mv ${GRADLE_APK_NAME} ${ORCA_APK_NAME}`)
   })
 
-  // Why not a glob: `*.apk` keeps passing while publishing whatever Gradle
-  // emitted, so a rename that silently stopped running would ship the generic
-  // name again with every check still green.
-  it('publishes the renamed APK by exact path rather than a glob', () => {
-    const published = [
-      stepNamed('Upload APK artifact').with.path,
-      stepNamed('Create GitHub Release').run
-    ]
+  // `upload-artifact` resolves `path` from the workspace root, while `run` steps
+  // inherit the job's `mobile` working directory. Both spellings of the one file
+  // are pinned so a future edit cannot "correct" either into the other, and so a
+  // publish cannot drift to a directory the rename never wrote to.
+  it('publishes the renamed APK from the directory the rename wrote it to', () => {
+    expect(stepNamed('Upload APK artifact').with.path).toBe(`mobile/${ORCA_APK_PATH}`)
+  })
 
-    for (const reference of published) {
-      expect(reference).toContain(ORCA_APK_NAME)
-      expect(reference).not.toContain('*.apk')
-    }
+  // Why the count: the step publishes through `gh release upload` for a tag that
+  // already exists and `gh release create` for one that does not. Asserting the
+  // path appears twice catches a branch that kept a glob or was left behind.
+  it('publishes the same exact path from both release branches', () => {
+    const run = stepNamed('Create GitHub Release').run
+
+    expect(run.split(ORCA_APK_PATH).length - 1).toBe(2)
+    expect(run).toContain('gh release upload')
+    expect(run).toContain('gh release create')
+    expect(run).not.toContain('*.apk')
   })
 
   // The rename is the one legitimate mention of the Gradle name. Anywhere else

--- a/config/scripts/mobile-android-apk-asset-name.test.mjs
+++ b/config/scripts/mobile-android-apk-asset-name.test.mjs
@@ -1,0 +1,57 @@
+import { readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { parse } from 'yaml'
+
+const projectDir = resolve(import.meta.dirname, '../..')
+
+const ORCA_APK_NAME = 'orca-app-release.apk'
+const GRADLE_APK_NAME = 'app-release.apk'
+const RENAME_STEP = 'Name the release APK for Orca'
+
+const workflow = () =>
+  parse(readFileSync(join(projectDir, '.github/workflows/mobile-android-release.yml'), 'utf8'))
+const steps = () => workflow().jobs['android-build'].steps
+const stepNamed = (name) => steps().find((step) => step.name === name)
+
+describe('Orca Android release APK asset name', () => {
+  // A GitHub release asset is named after the file's basename, and Gradle emits
+  // `app-release.apk` for every React Native app. Renaming the build output is
+  // the only thing that decides what a user ends up with in Downloads.
+  it('renames the Gradle output between the build and the first publish', () => {
+    const names = steps().map((step) => step.name)
+    const build = names.indexOf('Build Android release APK')
+    const rename = names.indexOf(RENAME_STEP)
+    const upload = names.indexOf('Upload APK artifact')
+
+    expect(build).toBeGreaterThanOrEqual(0)
+    expect(rename).toBeGreaterThan(build)
+    expect(upload).toBeGreaterThan(rename)
+    expect(stepNamed(RENAME_STEP).run).toContain(`mv ${GRADLE_APK_NAME} ${ORCA_APK_NAME}`)
+  })
+
+  // Why not a glob: `*.apk` keeps passing while publishing whatever Gradle
+  // emitted, so a rename that silently stopped running would ship the generic
+  // name again with every check still green.
+  it('publishes the renamed APK by exact path rather than a glob', () => {
+    const published = [
+      stepNamed('Upload APK artifact').with.path,
+      stepNamed('Create GitHub Release').run
+    ]
+
+    for (const reference of published) {
+      expect(reference).toContain(ORCA_APK_NAME)
+      expect(reference).not.toContain('*.apk')
+    }
+  })
+
+  // The rename is the one legitimate mention of the Gradle name. Anywhere else
+  // is a path left pointing at a file that no longer exists by the time it runs.
+  it('leaves no other step referring to the Gradle output name', () => {
+    const bareGradleName = /(?<!orca-)app-release\.apk/
+
+    for (const step of steps().filter((step) => step.name !== RENAME_STEP)) {
+      expect(JSON.stringify(step)).not.toMatch(bareGradleName)
+    }
+  })
+})


### PR DESCRIPTION
## ELI5

When you download Orca for Android, the file that lands in your Downloads folder is called `app-release.apk`. That is Gradle's default name for *every* React Native app — Orca never picked it. This makes the build name the file `orca-app-release.apk` instead, so what you download is obviously Orca.

## What Changed

`.github/workflows/mobile-android-release.yml`:

- Added a `Name the release APK for Orca` step that renames Gradle's `app-release.apk` to `orca-app-release.apk`, placed between the build and the first step that publishes anything.
- Pointed the artifact upload and both `gh release upload` / `gh release create` calls at that exact filename instead of a `*.apk` glob.

`config/scripts/mobile-android-apk-asset-name.test.mjs` (new): a workflow contract test in the same shape as the existing `dev-channel-windows-workflow-contract.test.mjs`. It pins the Gradle output directory once and asserts it on both ends — the rename step `cd`s into it, the artifact upload names the file exactly, and the release step references that same path from both the `gh release upload` and `gh release create` branches — plus a guard that no other step is left pointing at the Gradle name.

## Why

A GitHub release asset takes the basename of the uploaded file, and the browser download keeps it, so the Gradle output name is what the user actually ends up with:

```
https://github.com/stablyai/orca/releases/download/mobile-android-v0.0.44/app-release.apk
```

- **Unidentifiable once downloaded.** In Downloads it is indistinguishable from any other RN app's release build.
- **Weakest trust signal at the riskiest moment.** Sideloading already asks the user to clear "install unknown apps"; a generic filename is exactly what users are warned to be suspicious of.
- **Ambiguous in support threads.** "I installed app-release.apk" identifies neither the app nor the build.

Desktop already gets this right — the Windows installer publishes as `orca-windows-setup.exe`. Android was the odd one out.

**Why the rename lives in the workflow rather than Gradle:** `mobile/android/` is generated by `expo prebuild` and never committed, so changing the Gradle output name means an Expo config plugin running on every build to fix a name that only matters on the published asset. The workflow step is three lines and cannot affect the app that gets built.

**Why exact paths instead of keeping `*.apk`:** a glob keeps passing while publishing whatever Gradle emitted, so a rename that silently stopped running would ship the generic name again with CI still green.

**Scope note — no download links are changed in this PR.** Release assets are immutable, so `mobile-android-v0.0.44` keeps `app-release.apk` forever. Re-pointing the README, the translated READMEs, `mobile-platform-copy.ts`, and `MobileSettingsPane.tsx` now would 404. Those move with the usual per-release link bump, on the first release that actually carries the new filename.

## Linked Issue

Fixes #16602

## Visual Proof

`N/A` — no UI or interaction change. The only user-visible difference is the filename of a future release asset, and the URLs the app links to are untouched by this PR.

## Testing

- `npx vitest run --config config/vitest.config.ts config/scripts/mobile-android-apk-asset-name.test.mjs` → **4 passed**.
- **Negative control:** restored the pre-change workflow and re-ran the same test → **3 of 4 failed**, confirming the assertions are not vacuous. (The fourth guards against a future stale path and correctly passes on both.)
- `npx vitest run --config config/vitest.config.ts config/scripts` → `128 files / 934 tests`, **10 files / 5 tests failing**. The same suite on the base commit: `127 files / 930 tests`, **the identical 10 files / 5 tests failing**. All pre-existing and unrelated (Windows path separators, and native modules that need Node 24 — my local Node is 22). This PR adds 4 passing tests and changes no existing result.
- **Mutation-tested** after review feedback: moving the artifact path, either release branch, or the rename step's `cd` to a sibling directory each fails the suite. The pre-review assertions passed all three — see the [review thread](https://github.com/stablyai/orca/pull/16606#discussion_r3861152679).
- `npx oxlint config/scripts/mobile-android-apk-asset-name.test.mjs` → clean.
- `npx oxfmt --check config/scripts/mobile-android-apk-asset-name.test.mjs` → "All matched files use the correct format."
- `npx tsc --noEmit -p config/tsconfig.node.json --composite false` → exit 0.
- Not run locally: `pnpm build`. It is a full Electron package, and this branch touches only a workflow YAML and a `.mjs` test — no build surface. Leaving it to CI.
- The renamed APK itself is produced only by the Android release workflow, so end-to-end proof is a `workflow_dispatch` run on this branch with `publish_github_release: false`. Happy to trigger one, or for a maintainer to, if you want the artifact name confirmed before merge.

## AI Disclosure

Claude Opus 5, via Claude Code. The investigation, the rename step, the contract test, and this description were produced with it and reviewed before opening.

## Review

- **Cross-platform (macOS / Linux / Windows):** the rename runs only inside `mobile-android-release.yml`, whose job is pinned to `ubuntu-latest`. `mv` and `set -euo pipefail` are POSIX, and the step is `bash` by default on that runner. No contributor's local build is affected — `./gradlew assembleRelease` still writes `app-release.apk` locally, which is exactly why the workflow, not Gradle, does the renaming. The new test is pure `readFileSync` plus a YAML parse, with no path-separator or shell assumptions; it passes on Windows.
- **SSH / remote / local:** nothing in this change runs on a user's machine, an execution host, or over the client-to-host wire. No RPC params, stream frames, or published content are touched.
- **Remote wire compatibility:** none — no client/host exchange is involved.
- **Agent / integration / git-provider compatibility:** no provider-specific or GitHub-only concept is introduced beyond the release workflow, which was already GitHub-specific.
- **Backward compatibility:** this is the one real risk surface, and it is handled by scope. Already-published assets are immutable and keep `app-release.apk`, so every existing download link — README, translated READMEs, `mobile-platform-copy.ts`, `MobileSettingsPane.tsx`, and any external mirror — continues to resolve. Nothing in the app resolves a release asset by name at runtime (I grepped `.apk` across `src/`, `mobile/`, and `config/`; the only hits are the unrelated emulator `adb install` paths), so no client code needs to change in lockstep. **Follow-up for maintainers:** the next per-release link bump should use `orca-app-release.apk`, and #7583's rolling `android-latest` proposal would want the same.
- **Performance:** one `mv` of a local file in CI. Not measurable.
- **UI quality:** N/A, no UI change.
- **Security:** no new inputs, secrets, permissions, or network calls. The rename uses fixed literal filenames with no interpolation of workflow inputs, so there is no injection surface. Tightening the publish paths from `*.apk` to an exact filename narrows what the job can upload into a release, which is a small improvement over the glob. Job permissions are unchanged (`contents: write`, as before).

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

One judgement call worth flagging: `orca-app-release.apk` keeps Gradle's `-app-release` suffix and carries no version, so a user who downloads two builds gets `orca-app-release (1).apk`. `orca-<version>.apk` would avoid both, at the cost of a name that churns every release — and the version is already in the tag and the URL path. I went with the plain branded name, but I am happy to switch to the versioned form if you would rather have it, especially since #7583's rolling `android-latest` URL would drop the version from the path.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — lint, typecheck and the affected tests run clean locally; see Testing for the two I left to CI and why
