### PR TITLE
Guide first-time users from the initial terminal

### DIFF
--- a/src/renderer/src/components/sidebar/NonGitFolderDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/NonGitFolderDialog.test.tsx
@@ -3,6 +3,7 @@ import type * as ReactModule from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
+import { getDefaultOnboardingState } from '../../../../shared/constants'
 
 type ButtonCapture = {
   label: string
@@ -25,10 +26,12 @@ const mocks = vi.hoisted(() => ({
     projectHostSetups: [],
     worktreesByRepo: {} as Record<string, Worktree[]>,
     fetchWorktrees: vi.fn(),
+    showFirstProjectTerminalWelcome: vi.fn(),
     settings: {}
   },
   addRemote: vi.fn(),
   onboardingGet: vi.fn(),
+  onboardingUpdate: vi.fn(),
   activateAndRevealWorktree: vi.fn()
 }))
 
@@ -129,10 +132,11 @@ describe('NonGitFolderDialog', () => {
     mocks.state.worktreesByRepo = {}
     mocks.state.fetchWorktrees.mockResolvedValue(true)
     mocks.onboardingGet.mockResolvedValue(null)
+    mocks.onboardingUpdate.mockResolvedValue(null)
     vi.stubGlobal('window', {
       api: {
         repos: { addRemote: mocks.addRemote },
-        onboarding: { get: mocks.onboardingGet }
+        onboarding: { get: mocks.onboardingGet, update: mocks.onboardingUpdate }
       }
     })
   })
@@ -203,6 +207,38 @@ describe('NonGitFolderDialog', () => {
     expect(mocks.activateAndRevealWorktree).not.toHaveBeenCalledWith(
       localWorktree.id,
       expect.anything()
+    )
+  })
+
+  it('shows the terminal welcome for the first SSH folder after completed onboarding', async () => {
+    const repo: Repo = {
+      id: 'ssh-folder',
+      path: '/srv/non-git',
+      displayName: 'SSH folder',
+      badgeColor: '#111',
+      addedAt: 1,
+      kind: 'folder',
+      connectionId: 'ssh-1'
+    }
+    const sshWorktree = makeWorktree('ssh-folder::/srv/non-git', '/srv/non-git', 'ssh:ssh-1')
+    mocks.state.modalData = { folderPath: '/srv/non-git', connectionId: 'ssh-1' }
+    mocks.addRemote.mockResolvedValue({ repo })
+    mocks.onboardingGet.mockResolvedValue({
+      ...getDefaultOnboardingState(),
+      closedAt: 1,
+      outcome: 'completed'
+    })
+    mocks.activateAndRevealWorktree.mockReturnValue({ primaryTabId: 'terminal-1' })
+    mocks.state.fetchWorktrees.mockImplementation(async () => {
+      mocks.state.worktreesByRepo = { [repo.id]: [sshWorktree] }
+      return true
+    })
+    renderToStaticMarkup(<NonGitFolderDialog />)
+
+    mocks.buttons.find((entry) => entry.label.includes('Open as Folder'))?.onClick?.()
+
+    await vi.waitFor(() =>
+      expect(mocks.state.showFirstProjectTerminalWelcome).toHaveBeenCalledWith('terminal-1')
     )
   })
 })

--- a/src/renderer/src/components/sidebar/NonGitFolderDialog.tsx
+++ b/src/renderer/src/components/sidebar/NonGitFolderDialog.tsx
@@ -14,6 +14,7 @@ import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { buildDismissedOnboardingFolderAgentStartup } from '@/lib/onboarding-folder-agent-startup'
 import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
 import { markOnboardingProjectAdded } from '@/lib/onboarding-project-checklist'
+import { shouldShowFirstProjectTerminalWelcome } from '@/lib/first-project-terminal-welcome'
 import { translate } from '@/i18n/i18n'
 import { upsertAddedRepoWithProjectHostSetup } from './add-repo-store-upsert'
 import { worktreeRefreshOptions } from './add-repo-runtime-owner'
@@ -68,7 +69,11 @@ const NonGitFolderDialog = React.memo(function NonGitFolderDialog() {
           })
           const state = useAppStore.getState()
           const hadProjectBeforeAdd = stateBeforeAdd.repos.length > 0
-          await markOnboardingProjectAdded('addedFolder')
+          const onboardingBeforeAdd = await markOnboardingProjectAdded('addedFolder')
+          const showFirstProjectTerminalWelcome = shouldShowFirstProjectTerminalWelcome({
+            onboarding: onboardingBeforeAdd,
+            projectCount: state.repos.length
+          })
           const ownerOptions = worktreeRefreshOptions(undefined, connectionId)
           await state.fetchWorktrees(repo.id, ownerOptions)
           // Why: mirror the local non-git folder flow — without this the
@@ -90,11 +95,19 @@ const NonGitFolderDialog = React.memo(function NonGitFolderDialog() {
               hadProjectBeforeAdd,
               isNativeChatTranscriptLocalReadable(connectionId)
             )
-            activateAndRevealWorktree(folderWorktree.id, {
+            const activationResult = activateAndRevealWorktree(folderWorktree.id, {
               sidebarRevealBehavior: 'auto',
               executionHostId: ownerOptions.executionHostId,
               ...(startup ? { startup } : {})
             })
+            if (
+              !startup &&
+              showFirstProjectTerminalWelcome &&
+              activationResult &&
+              activationResult.primaryTabId
+            ) {
+              state.showFirstProjectTerminalWelcome(activationResult.primaryTabId)
+            }
           }
         } catch (err) {
           // This code path calls addRemote directly (not through the store),

--- a/src/renderer/src/components/sidebar/project-added-default-checkout.test.ts
+++ b/src/renderer/src/components/sidebar/project-added-default-checkout.test.ts
@@ -9,9 +9,9 @@ import type {
 import {
   finishProjectAddWithDefaultCheckout,
   getProjectDefaultCheckout,
-  openProjectDefaultCheckout,
-  shouldShowFirstProjectTerminalWelcome
+  openProjectDefaultCheckout
 } from './project-added-default-checkout'
+import { shouldShowFirstProjectTerminalWelcome } from '@/lib/first-project-terminal-welcome'
 
 const mocks = vi.hoisted(() => ({
   state: {

--- a/src/renderer/src/components/sidebar/project-added-default-checkout.test.ts
+++ b/src/renderer/src/components/sidebar/project-added-default-checkout.test.ts
@@ -9,7 +9,8 @@ import type {
 import {
   finishProjectAddWithDefaultCheckout,
   getProjectDefaultCheckout,
-  openProjectDefaultCheckout
+  openProjectDefaultCheckout,
+  shouldShowFirstProjectTerminalWelcome
 } from './project-added-default-checkout'
 
 const mocks = vi.hoisted(() => ({
@@ -26,7 +27,8 @@ const mocks = vi.hoisted(() => ({
     setShowActiveOnly: vi.fn(),
     setHideDefaultBranchWorkspace: vi.fn(),
     updateRepo: vi.fn(),
-    fetchWorktrees: vi.fn()
+    fetchWorktrees: vi.fn(),
+    showFirstProjectTerminalWelcome: vi.fn()
   },
   activateAndRevealWorktree: vi.fn(),
   onboardingGet: vi.fn(),
@@ -120,6 +122,44 @@ describe('getProjectDefaultCheckout', () => {
   })
 })
 
+describe('shouldShowFirstProjectTerminalWelcome', () => {
+  const completedOnboarding = {
+    ...getDefaultOnboardingState(),
+    closedAt: 1,
+    outcome: 'completed' as const
+  }
+
+  it('offers the handoff only for the first project after onboarding closes', () => {
+    expect(
+      shouldShowFirstProjectTerminalWelcome({
+        onboarding: completedOnboarding,
+        projectCount: 1
+      })
+    ).toBe(true)
+    expect(
+      shouldShowFirstProjectTerminalWelcome({
+        onboarding: { ...completedOnboarding, closedAt: null, outcome: null },
+        projectCount: 1
+      })
+    ).toBe(false)
+    expect(
+      shouldShowFirstProjectTerminalWelcome({
+        onboarding: completedOnboarding,
+        projectCount: 2
+      })
+    ).toBe(false)
+    expect(
+      shouldShowFirstProjectTerminalWelcome({
+        onboarding: {
+          ...completedOnboarding,
+          checklist: { ...completedOnboarding.checklist, addedFolder: true }
+        },
+        projectCount: 1
+      })
+    ).toBe(false)
+  })
+})
+
 describe('finishProjectAddWithDefaultCheckout', () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -132,6 +172,7 @@ describe('finishProjectAddWithDefaultCheckout', () => {
     mocks.state.detectedWorktreesByRepo = {}
     mocks.state.updateRepo.mockResolvedValue(true)
     mocks.state.fetchWorktrees.mockResolvedValue(true)
+    mocks.activateAndRevealWorktree.mockReturnValue({ primaryTabId: 'terminal-1' })
     mocks.onboardingGet.mockResolvedValue(getDefaultOnboardingState())
     mocks.onboardingUpdate.mockResolvedValue(getDefaultOnboardingState())
     vi.stubGlobal('window', {
@@ -174,6 +215,34 @@ describe('finishProjectAddWithDefaultCheckout', () => {
       reason: 'loaded_default_checkout'
     })
     expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith('repo-1::/repo')
+  })
+
+  it('shows the terminal welcome after opening the first post-onboarding Git project', async () => {
+    const onboarding = {
+      ...getDefaultOnboardingState(),
+      closedAt: 1,
+      outcome: 'completed' as const
+    }
+    mocks.onboardingGet.mockResolvedValue(onboarding)
+    mocks.state.repos = [
+      {
+        id: 'repo-1',
+        path: '/repo',
+        displayName: 'orca',
+        badgeColor: '#111',
+        addedAt: 1
+      }
+    ]
+    mocks.state.worktreesByRepo = { 'repo-1': [makeWorktree()] }
+
+    await finishProjectAddWithDefaultCheckout({
+      repoId: 'repo-1',
+      source: 'local_folder_picker',
+      closeModal: vi.fn(),
+      setHideDefaultBranchWorkspace: vi.fn()
+    })
+
+    expect(mocks.state.showFirstProjectTerminalWelcome).toHaveBeenCalledWith('terminal-1')
   })
 
   it('activates only the captured host default checkout when repo IDs collide', async () => {

--- a/src/renderer/src/components/sidebar/project-added-default-checkout.ts
+++ b/src/renderer/src/components/sidebar/project-added-default-checkout.ts
@@ -10,11 +10,28 @@ import { relativePathInsideRoot } from '../../../../shared/cross-platform-path'
 import { markOnboardingProjectAdded } from '@/lib/onboarding-project-checklist'
 import { finalizeImportedRepoAfterSkip } from './add-repo-skip-finalization'
 import { parseExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
+import type { OnboardingState } from '../../../../shared/onboarding-state-types'
 
 type DefaultCheckoutHandoffReason = EventProps<'add_repo_default_checkout_handoff'>['reason']
 
 export function getProjectDefaultCheckout(worktrees: readonly Worktree[]): Worktree | null {
   return worktrees.find((worktree) => worktree.isMainWorktree) ?? null
+}
+
+export function shouldShowFirstProjectTerminalWelcome({
+  onboarding,
+  projectCount
+}: {
+  onboarding: OnboardingState | null
+  projectCount: number
+}): boolean {
+  return Boolean(
+    onboarding &&
+    onboarding.closedAt !== null &&
+    !onboarding.checklist.addedRepo &&
+    !onboarding.checklist.addedFolder &&
+    projectCount === 1
+  )
 }
 
 function getProjectWorktreesForHost<T extends Worktree>(
@@ -181,13 +198,15 @@ export async function openProjectDefaultCheckout({
   source,
   selectedPath,
   setHideDefaultBranchWorkspace,
-  executionHostId
+  executionHostId,
+  showFirstProjectTerminalWelcome = false
 }: {
   repoId: string
   source: AddRepoDefaultCheckoutHandoffSource
   selectedPath?: string
   setHideDefaultBranchWorkspace: (value: boolean) => void
   executionHostId?: ExecutionHostId
+  showFirstProjectTerminalWelcome?: boolean
 }): Promise<void> {
   let defaultCheckout = getProjectDefaultCheckout(
     getProjectWorktreesForHost(
@@ -228,13 +247,17 @@ export async function openProjectDefaultCheckout({
       reason
     })
     const initialCwd = resolveInitialCwdForDefaultCheckout(defaultCheckout, selectedPath)
-    if (initialCwd || executionHostId) {
-      activateAndRevealWorktree(defaultCheckout.id, {
-        ...(initialCwd ? { initialCwd } : {}),
-        ...(executionHostId ? { executionHostId } : {})
-      })
-    } else {
-      activateAndRevealWorktree(defaultCheckout.id)
+    const activationResult =
+      initialCwd || executionHostId
+        ? activateAndRevealWorktree(defaultCheckout.id, {
+            ...(initialCwd ? { initialCwd } : {}),
+            ...(executionHostId ? { executionHostId } : {})
+          })
+        : activateAndRevealWorktree(defaultCheckout.id)
+    if (showFirstProjectTerminalWelcome && activationResult && activationResult.primaryTabId) {
+      // Why: attach before React paints the just-created terminal so first-time
+      // users see guidance instead of a one-frame blank shell.
+      useAppStore.getState().showFirstProjectTerminalWelcome(activationResult.primaryTabId)
     }
     return
   }
@@ -262,13 +285,18 @@ export async function finishProjectAddWithDefaultCheckout({
   setHideDefaultBranchWorkspace: (value: boolean) => void
   executionHostId?: ExecutionHostId
 }): Promise<void> {
-  await markOnboardingProjectAdded('addedRepo')
+  const onboardingBeforeAdd = await markOnboardingProjectAdded('addedRepo')
+  const showFirstProjectTerminalWelcome = shouldShowFirstProjectTerminalWelcome({
+    onboarding: onboardingBeforeAdd,
+    projectCount: useAppStore.getState().repos.length
+  })
   closeModal()
   await openProjectDefaultCheckout({
     repoId,
     source,
     selectedPath,
     executionHostId,
+    showFirstProjectTerminalWelcome,
     setHideDefaultBranchWorkspace
   })
 }

--- a/src/renderer/src/components/sidebar/project-added-default-checkout.ts
+++ b/src/renderer/src/components/sidebar/project-added-default-checkout.ts
@@ -10,28 +10,12 @@ import { relativePathInsideRoot } from '../../../../shared/cross-platform-path'
 import { markOnboardingProjectAdded } from '@/lib/onboarding-project-checklist'
 import { finalizeImportedRepoAfterSkip } from './add-repo-skip-finalization'
 import { parseExecutionHostId, type ExecutionHostId } from '../../../../shared/execution-host'
-import type { OnboardingState } from '../../../../shared/onboarding-state-types'
+import { shouldShowFirstProjectTerminalWelcome } from '@/lib/first-project-terminal-welcome'
 
 type DefaultCheckoutHandoffReason = EventProps<'add_repo_default_checkout_handoff'>['reason']
 
 export function getProjectDefaultCheckout(worktrees: readonly Worktree[]): Worktree | null {
   return worktrees.find((worktree) => worktree.isMainWorktree) ?? null
-}
-
-export function shouldShowFirstProjectTerminalWelcome({
-  onboarding,
-  projectCount
-}: {
-  onboarding: OnboardingState | null
-  projectCount: number
-}): boolean {
-  return Boolean(
-    onboarding &&
-    onboarding.closedAt !== null &&
-    !onboarding.checklist.addedRepo &&
-    !onboarding.checklist.addedFolder &&
-    projectCount === 1
-  )
 }
 
 function getProjectWorktreesForHost<T extends Worktree>(

--- a/src/renderer/src/components/terminal-pane/FirstProjectTerminalWelcome.test.tsx
+++ b/src/renderer/src/components/terminal-pane/FirstProjectTerminalWelcome.test.tsx
@@ -1,0 +1,205 @@
+/** @vitest-environment happy-dom */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FirstProjectTerminalWelcome } from './FirstProjectTerminalWelcome'
+
+const mocks = vi.hoisted(() => ({
+  closeTab: vi.fn(),
+  detectedIds: ['claude'] as string[] | null,
+  dismissFirstProjectTerminalWelcome: vi.fn(),
+  focusTerminalTabSurface: vi.fn(),
+  launchAgentInNewTab: vi.fn(() => ({ tabId: 'agent-tab' })),
+  openModal: vi.fn(),
+  recordFeatureInteraction: vi.fn(),
+  state: {
+    settings: {
+      defaultTuiAgent: 'claude',
+      disabledTuiAgents: []
+    },
+    unifiedTabsByWorktree: {
+      'worktree-1': [
+        {
+          contentType: 'terminal',
+          entityId: 'terminal-1',
+          groupId: 'group-1'
+        }
+      ]
+    }
+  }
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign(
+    (selector: (state: unknown) => unknown) =>
+      selector({
+        ...mocks.state,
+        closeTab: mocks.closeTab,
+        dismissFirstProjectTerminalWelcome: mocks.dismissFirstProjectTerminalWelcome,
+        openModal: mocks.openModal,
+        recordFeatureInteraction: mocks.recordFeatureInteraction
+      }),
+    {
+      getState: () => ({
+        ...mocks.state,
+        closeTab: mocks.closeTab,
+        dismissFirstProjectTerminalWelcome: mocks.dismissFirstProjectTerminalWelcome,
+        openModal: mocks.openModal,
+        recordFeatureInteraction: mocks.recordFeatureInteraction
+      })
+    }
+  )
+}))
+
+vi.mock('@/store/selectors', () => ({
+  useRepoById: () => ({ id: 'repo-1', displayName: 'orca', path: '/repo' }),
+  useWorktreeById: () => ({
+    id: 'worktree-1',
+    repoId: 'repo-1',
+    branch: 'refs/heads/main',
+    displayName: 'main'
+  })
+}))
+
+vi.mock('@/hooks/useAgentDetectionTarget', () => ({
+  useAgentDetectionTargetForWorktree: () => ({ kind: 'local' })
+}))
+
+vi.mock('@/hooks/useDetectedAgents', () => ({
+  useDetectedAgents: () => ({
+    detectedIds: mocks.detectedIds,
+    isLoading: false
+  })
+}))
+
+vi.mock('@/hooks/useShortcutLabel', () => ({
+  useOptionalShortcutLabel: () => 'Ctrl+N'
+}))
+
+vi.mock('@/lib/agent-catalog', () => ({
+  getAgentCatalog: () => [{ id: 'claude', label: 'Claude Code' }]
+}))
+
+vi.mock('@/lib/focus-terminal-tab-surface', () => ({
+  focusTerminalTabSurface: mocks.focusTerminalTabSurface
+}))
+
+vi.mock('@/lib/launch-agent-in-new-tab', () => ({
+  launchAgentInNewTab: mocks.launchAgentInNewTab
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string, params?: { value0?: string }) =>
+    fallback.replace('{{value0}}', params?.value0 ?? '')
+}))
+
+function renderWelcome(
+  colors = { background: '#f8f8f8', foreground: '#202020', accent: '#16823c' }
+) {
+  return render(
+    <FirstProjectTerminalWelcome
+      tabId="terminal-1"
+      worktreeId="worktree-1"
+      backgroundColor={colors.background}
+      foregroundColor={colors.foreground}
+      accentColor={colors.accent}
+      fontFamily="Test Mono"
+      fontSize={14}
+    />
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.detectedIds = ['claude']
+  mocks.launchAgentInNewTab.mockReturnValue({ tabId: 'agent-tab' })
+})
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('FirstProjectTerminalWelcome', () => {
+  it('uses the supplied terminal palette in both light and dark themes', () => {
+    const view = renderWelcome()
+    let dialog = screen.getByRole('dialog', { name: 'ORCA' })
+
+    expect(dialog.style.backgroundColor).toBe('#f8f8f8')
+    expect(dialog.style.color).toBe('#202020')
+    expect(dialog.style.getPropertyValue('--orca-welcome-accent')).toBe('#16823c')
+    expect(screen.getByText('Project opened: orca')).toBeTruthy()
+    expect(screen.getByText('Branch: main')).toBeTruthy()
+
+    view.rerender(
+      <FirstProjectTerminalWelcome
+        tabId="terminal-1"
+        worktreeId="worktree-1"
+        backgroundColor="#0b0f14"
+        foregroundColor="#e6edf3"
+        accentColor="#56d364"
+        fontFamily="Test Mono"
+        fontSize={14}
+      />
+    )
+    dialog = screen.getByRole('dialog', { name: 'ORCA' })
+    expect(dialog.style.backgroundColor).toBe('#0b0f14')
+    expect(dialog.style.color).toBe('#e6edf3')
+    expect(dialog.style.getPropertyValue('--orca-welcome-accent')).toBe('#56d364')
+  })
+
+  it('opens preselected workspace setup when the user presses 1', () => {
+    renderWelcome()
+
+    fireEvent.keyDown(screen.getByRole('dialog', { name: 'ORCA' }), { key: '1' })
+
+    expect(mocks.dismissFirstProjectTerminalWelcome).toHaveBeenCalledWith('terminal-1')
+    expect(mocks.recordFeatureInteraction).toHaveBeenCalledWith('workspace-creation')
+    expect(mocks.openModal).toHaveBeenCalledWith('new-workspace-composer', {
+      initialRepoId: 'repo-1',
+      telemetrySource: 'onboarding'
+    })
+  })
+
+  it('dismisses to the normal shell on Enter', () => {
+    renderWelcome()
+
+    fireEvent.keyDown(screen.getByRole('dialog', { name: 'ORCA' }), { key: 'Enter' })
+
+    expect(mocks.dismissFirstProjectTerminalWelcome).toHaveBeenCalledWith('terminal-1')
+    expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('terminal-1')
+  })
+
+  it('replaces the blank shell with the detected default agent in the same group', () => {
+    renderWelcome()
+
+    fireEvent.click(screen.getByRole('button', { name: /Launch Claude Code in this checkout/i }))
+
+    expect(mocks.launchAgentInNewTab).toHaveBeenCalledWith({
+      agent: 'claude',
+      worktreeId: 'worktree-1',
+      groupId: 'group-1',
+      launchSource: 'onboarding'
+    })
+    expect(mocks.closeTab).toHaveBeenCalledWith('terminal-1', {
+      captureRecentlyClosed: false,
+      reason: 'cleanup',
+      recordInteraction: false
+    })
+    expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('agent-tab')
+  })
+
+  it('explains and disables direct launch when the default agent is unavailable', () => {
+    mocks.detectedIds = []
+    renderWelcome()
+
+    expect(
+      (
+        screen.getByRole('button', {
+          name: /Launch Claude Code in this checkout/i
+        }) as HTMLButtonElement
+      ).disabled
+    ).toBe(true)
+    expect(
+      screen.getByText('No default agent is available here. Choose one in workspace setup.')
+    ).toBeTruthy()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/FirstProjectTerminalWelcome.test.tsx
+++ b/src/renderer/src/components/terminal-pane/FirstProjectTerminalWelcome.test.tsx
@@ -11,6 +11,12 @@ const mocks = vi.hoisted(() => ({
   launchAgentInNewTab: vi.fn(() => ({ tabId: 'agent-tab' })),
   openModal: vi.fn(),
   recordFeatureInteraction: vi.fn(),
+  repo: {
+    id: 'repo-1',
+    displayName: 'orca',
+    path: '/repo',
+    kind: 'git' as 'git' | 'folder'
+  },
   state: {
     settings: {
       defaultTuiAgent: 'claude',
@@ -51,7 +57,7 @@ vi.mock('@/store', () => ({
 }))
 
 vi.mock('@/store/selectors', () => ({
-  useRepoById: () => ({ id: 'repo-1', displayName: 'orca', path: '/repo' }),
+  useRepoById: () => mocks.repo,
   useWorktreeById: () => ({
     id: 'worktree-1',
     repoId: 'repo-1',
@@ -111,6 +117,7 @@ function renderWelcome(
 beforeEach(() => {
   vi.clearAllMocks()
   mocks.detectedIds = ['claude']
+  mocks.repo.kind = 'git'
   mocks.launchAgentInNewTab.mockReturnValue({ tabId: 'agent-tab' })
 })
 
@@ -185,6 +192,26 @@ describe('FirstProjectTerminalWelcome', () => {
       recordInteraction: false
     })
     expect(mocks.focusTerminalTabSurface).toHaveBeenCalledWith('agent-tab')
+  })
+
+  it('orients a non-Git folder and launches its agent with option 1', () => {
+    mocks.repo.kind = 'folder'
+    renderWelcome()
+
+    expect(screen.getByText('Folder opened: orca')).toBeTruthy()
+    expect(screen.queryByText('Branch: main')).toBeNull()
+    expect(screen.queryByRole('button', { name: /Create an isolated workspace/i })).toBeNull()
+    expect(screen.getByText(/This is a normal terminal opened in orca/i)).toBeTruthy()
+
+    fireEvent.keyDown(screen.getByRole('dialog', { name: 'ORCA' }), { key: '1' })
+
+    expect(mocks.launchAgentInNewTab).toHaveBeenCalledWith({
+      agent: 'claude',
+      worktreeId: 'worktree-1',
+      groupId: 'group-1',
+      launchSource: 'onboarding'
+    })
+    expect(mocks.openModal).not.toHaveBeenCalled()
   })
 
   it('explains and disables direct launch when the default agent is unavailable', () => {

--- a/src/renderer/src/components/terminal-pane/FirstProjectTerminalWelcome.tsx
+++ b/src/renderer/src/components/terminal-pane/FirstProjectTerminalWelcome.tsx
@@ -71,6 +71,7 @@ export function FirstProjectTerminalWelcome({
     [defaultAgent]
   )
   const projectLabel = repo?.displayName || repo?.path || worktree?.displayName || worktreeId
+  const isGitProject = repo?.kind !== 'folder'
   const branchLabel = worktree ? branchName(worktree.branch) || 'HEAD' : 'HEAD'
 
   useEffect(() => {
@@ -137,10 +138,14 @@ export function FirstProjectTerminalWelcome({
       }
       if (event.key === '1') {
         event.preventDefault()
-        openWorkspaceComposer()
+        if (isGitProject) {
+          openWorkspaceComposer()
+        } else if (defaultAgentAvailable) {
+          launchDefaultAgent()
+        }
         return
       }
-      if (event.key === '2' && defaultAgentAvailable) {
+      if (event.key === '2' && isGitProject && defaultAgentAvailable) {
         event.preventDefault()
         launchDefaultAgent()
         return
@@ -155,24 +160,56 @@ export function FirstProjectTerminalWelcome({
         dismissToTerminal()
       }
     },
-    [defaultAgentAvailable, dismissToTerminal, launchDefaultAgent, openWorkspaceComposer]
+    [
+      defaultAgentAvailable,
+      dismissToTerminal,
+      isGitProject,
+      launchDefaultAgent,
+      openWorkspaceComposer
+    ]
   )
 
-  const optionTwoDescription = agentsLoading
+  const agentOptionDescription = agentsLoading
     ? translate(
         'auto.components.terminalPane.FirstProjectTerminalWelcome.checkingAgent',
         'Checking whether {{value0}} is available here…',
         { value0: defaultAgentLabel ?? 'your default agent' }
       )
-    : defaultAgentAvailable
+    : defaultAgentAvailable && isGitProject
       ? translate(
           'auto.components.terminalPane.FirstProjectTerminalWelcome.currentCheckoutWarning',
           'Changes will be made directly on {{value0}}.',
           { value0: branchLabel }
         )
+      : defaultAgentAvailable
+        ? translate(
+            'auto.components.terminalPane.FirstProjectTerminalWelcome.currentFolderWarning',
+            'Changes will be made directly in this folder.'
+          )
+        : translate(
+            'auto.components.terminalPane.FirstProjectTerminalWelcome.agentUnavailable',
+            'No default agent is available here. Choose one in workspace setup.'
+          )
+  const agentOptionLabel = defaultAgentLabel
+    ? isGitProject
+      ? translate(
+          'auto.components.terminalPane.FirstProjectTerminalWelcome.launchAgent',
+          'Launch {{value0}} in this checkout',
+          { value0: defaultAgentLabel }
+        )
       : translate(
-          'auto.components.terminalPane.FirstProjectTerminalWelcome.agentUnavailable',
-          'No default agent is available here. Choose one in workspace setup.'
+          'auto.components.terminalPane.FirstProjectTerminalWelcome.launchAgentInFolder',
+          'Launch {{value0}} in this folder',
+          { value0: defaultAgentLabel }
+        )
+    : isGitProject
+      ? translate(
+          'auto.components.terminalPane.FirstProjectTerminalWelcome.launchAgentGeneric',
+          'Launch an agent in this checkout'
+        )
+      : translate(
+          'auto.components.terminalPane.FirstProjectTerminalWelcome.launchAgentInFolderGeneric',
+          'Launch an agent in this folder'
         )
   const style: WelcomeSurfaceStyle = {
     '--orca-welcome-accent': accentColor,
@@ -210,50 +247,66 @@ export function FirstProjectTerminalWelcome({
         </h2>
         <div className="mb-5 space-y-0.5">
           <p>
-            {translate(
-              'auto.components.terminalPane.FirstProjectTerminalWelcome.projectOpened',
-              'Project opened: {{value0}}',
-              { value0: projectLabel }
-            )}
+            {isGitProject
+              ? translate(
+                  'auto.components.terminalPane.FirstProjectTerminalWelcome.projectOpened',
+                  'Project opened: {{value0}}',
+                  { value0: projectLabel }
+                )
+              : translate(
+                  'auto.components.terminalPane.FirstProjectTerminalWelcome.folderOpened',
+                  'Folder opened: {{value0}}',
+                  { value0: projectLabel }
+                )}
           </p>
-          <p>
-            {translate(
-              'auto.components.terminalPane.FirstProjectTerminalWelcome.branch',
-              'Branch: {{value0}}',
-              { value0: branchLabel }
-            )}
-          </p>
+          {isGitProject ? (
+            <p>
+              {translate(
+                'auto.components.terminalPane.FirstProjectTerminalWelcome.branch',
+                'Branch: {{value0}}',
+                { value0: branchLabel }
+              )}
+            </p>
+          ) : null}
         </div>
         <p
           id="first-project-terminal-welcome-description"
           className="mb-5 max-w-2xl"
           style={{ color: optionDescriptionColor() }}
         >
-          {translate(
-            'auto.components.terminalPane.FirstProjectTerminalWelcome.explanation',
-            'This is a normal terminal. Orca works best when each task gets a separate Git worktree, so changes stay off {{value0}}.',
-            { value0: branchLabel }
-          )}
+          {isGitProject
+            ? translate(
+                'auto.components.terminalPane.FirstProjectTerminalWelcome.explanation',
+                'This is a normal terminal. Orca works best when each task gets a separate Git worktree, so changes stay off {{value0}}.',
+                { value0: branchLabel }
+              )
+            : translate(
+                'auto.components.terminalPane.FirstProjectTerminalWelcome.folderExplanation',
+                'This is a normal terminal opened in {{value0}}. Launch your coding agent here, or enter any shell command.',
+                { value0: projectLabel }
+              )}
         </p>
 
         <div className="-mx-2 space-y-1">
-          <button type="button" className={optionClassName} onClick={openWorkspaceComposer}>
-            <span className="w-4 shrink-0 font-bold text-[var(--orca-welcome-accent)]">1</span>
-            <span>
-              <span className="block font-semibold">
-                {translate(
-                  'auto.components.terminalPane.FirstProjectTerminalWelcome.isolatedWorkspace',
-                  'Create an isolated workspace (recommended)'
-                )}
+          {isGitProject ? (
+            <button type="button" className={optionClassName} onClick={openWorkspaceComposer}>
+              <span className="w-4 shrink-0 font-bold text-[var(--orca-welcome-accent)]">1</span>
+              <span>
+                <span className="block font-semibold">
+                  {translate(
+                    'auto.components.terminalPane.FirstProjectTerminalWelcome.isolatedWorkspace',
+                    'Create an isolated workspace (recommended)'
+                  )}
+                </span>
+                <span className="block" style={{ color: optionDescriptionColor() }}>
+                  {translate(
+                    'auto.components.terminalPane.FirstProjectTerminalWelcome.isolatedWorkspaceDescription',
+                    'Choose a task name and agent before Orca creates the worktree.'
+                  )}
+                </span>
               </span>
-              <span className="block" style={{ color: optionDescriptionColor() }}>
-                {translate(
-                  'auto.components.terminalPane.FirstProjectTerminalWelcome.isolatedWorkspaceDescription',
-                  'Choose a task name and agent before Orca creates the worktree.'
-                )}
-              </span>
-            </span>
-          </button>
+            </button>
+          ) : null}
 
           <button
             type="button"
@@ -261,22 +314,13 @@ export function FirstProjectTerminalWelcome({
             disabled={!defaultAgentAvailable}
             onClick={launchDefaultAgent}
           >
-            <span className="w-4 shrink-0 font-bold text-[var(--orca-welcome-accent)]">2</span>
+            <span className="w-4 shrink-0 font-bold text-[var(--orca-welcome-accent)]">
+              {isGitProject ? '2' : '1'}
+            </span>
             <span>
-              <span className="block font-semibold">
-                {defaultAgentLabel
-                  ? translate(
-                      'auto.components.terminalPane.FirstProjectTerminalWelcome.launchAgent',
-                      'Launch {{value0}} in this checkout',
-                      { value0: defaultAgentLabel }
-                    )
-                  : translate(
-                      'auto.components.terminalPane.FirstProjectTerminalWelcome.launchAgentGeneric',
-                      'Launch an agent in this checkout'
-                    )}
-              </span>
+              <span className="block font-semibold">{agentOptionLabel}</span>
               <span className="block" style={{ color: optionDescriptionColor() }}>
-                {optionTwoDescription}
+                {agentOptionDescription}
               </span>
             </span>
           </button>
@@ -300,7 +344,7 @@ export function FirstProjectTerminalWelcome({
           </button>
         </div>
 
-        {workspaceShortcut ? (
+        {isGitProject && workspaceShortcut ? (
           <p className="mt-5" style={{ color: optionDescriptionColor() }}>
             {translate(
               'auto.components.terminalPane.FirstProjectTerminalWelcome.shortcut',

--- a/src/renderer/src/components/terminal-pane/FirstProjectTerminalWelcome.tsx
+++ b/src/renderer/src/components/terminal-pane/FirstProjectTerminalWelcome.tsx
@@ -1,0 +1,315 @@
+import { useCallback, useEffect, useMemo, useRef, type CSSProperties } from 'react'
+import { toast } from 'sonner'
+import { useAgentDetectionTargetForWorktree } from '@/hooks/useAgentDetectionTarget'
+import { useDetectedAgents } from '@/hooks/useDetectedAgents'
+import { useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
+import { getAgentCatalog } from '@/lib/agent-catalog'
+import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
+import { branchName } from '@/lib/git-utils'
+import { launchAgentInNewTab } from '@/lib/launch-agent-in-new-tab'
+import { useAppStore } from '@/store'
+import { useRepoById, useWorktreeById } from '@/store/selectors'
+import { translate } from '@/i18n/i18n'
+import type { TuiAgent } from '../../../../shared/tui-agent'
+import {
+  DEFAULT_DISABLED_TUI_AGENTS,
+  isTuiAgentEnabled
+} from '../../../../shared/tui-agent-selection'
+
+type FirstProjectTerminalWelcomeProps = {
+  tabId: string
+  worktreeId: string
+  backgroundColor: string
+  foregroundColor: string
+  accentColor: string
+  fontFamily: string
+  fontSize: number
+}
+
+type WelcomeSurfaceStyle = CSSProperties & {
+  '--orca-welcome-accent': string
+  '--orca-welcome-foreground': string
+}
+
+const optionClassName =
+  'group flex w-full items-start gap-3 rounded-sm px-2 py-2 text-left transition-colors hover:bg-[color:color-mix(in_srgb,var(--orca-welcome-foreground)_7%,transparent)] focus-visible:bg-[color:color-mix(in_srgb,var(--orca-welcome-foreground)_10%,transparent)] focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-45'
+
+function optionDescriptionColor(): string {
+  return 'color-mix(in srgb, var(--orca-welcome-foreground) 62%, transparent)'
+}
+
+export function FirstProjectTerminalWelcome({
+  tabId,
+  worktreeId,
+  backgroundColor,
+  foregroundColor,
+  accentColor,
+  fontFamily,
+  fontSize
+}: FirstProjectTerminalWelcomeProps): React.JSX.Element {
+  const rootRef = useRef<HTMLDivElement>(null)
+  const worktree = useWorktreeById(worktreeId)
+  const repo = useRepoById(worktree?.repoId ?? null)
+  const settings = useAppStore((state) => state.settings)
+  const workspaceShortcut = useOptionalShortcutLabel('workspace.create')
+  const agentDetectionTarget = useAgentDetectionTargetForWorktree(worktreeId)
+  const { detectedIds, isLoading: agentsLoading } = useDetectedAgents(agentDetectionTarget)
+  const configuredAgent = settings?.defaultTuiAgent
+  const disabledAgents = settings?.disabledTuiAgents ?? DEFAULT_DISABLED_TUI_AGENTS
+  const defaultAgent: TuiAgent | null =
+    configuredAgent &&
+    configuredAgent !== 'blank' &&
+    isTuiAgentEnabled(configuredAgent, disabledAgents)
+      ? configuredAgent
+      : null
+  const defaultAgentAvailable = Boolean(defaultAgent && detectedIds?.includes(defaultAgent))
+  const defaultAgentLabel = useMemo(
+    () =>
+      defaultAgent
+        ? (getAgentCatalog().find((agent) => agent.id === defaultAgent)?.label ?? defaultAgent)
+        : null,
+    [defaultAgent]
+  )
+  const projectLabel = repo?.displayName || repo?.path || worktree?.displayName || worktreeId
+  const branchLabel = worktree ? branchName(worktree.branch) || 'HEAD' : 'HEAD'
+
+  useEffect(() => {
+    rootRef.current?.focus({ preventScroll: true })
+  }, [])
+
+  const dismissToTerminal = useCallback(() => {
+    useAppStore.getState().dismissFirstProjectTerminalWelcome(tabId)
+    focusTerminalTabSurface(tabId)
+  }, [tabId])
+
+  const openWorkspaceComposer = useCallback(() => {
+    const state = useAppStore.getState()
+    state.dismissFirstProjectTerminalWelcome(tabId)
+    state.recordFeatureInteraction('workspace-creation')
+    state.openModal('new-workspace-composer', {
+      ...(worktree?.repoId ? { initialRepoId: worktree.repoId } : {}),
+      telemetrySource: 'onboarding'
+    })
+  }, [tabId, worktree?.repoId])
+
+  const launchDefaultAgent = useCallback(() => {
+    if (!defaultAgent || !defaultAgentAvailable) {
+      return
+    }
+    const state = useAppStore.getState()
+    const groupId = state.unifiedTabsByWorktree[worktreeId]?.find(
+      (tab) => tab.contentType === 'terminal' && tab.entityId === tabId
+    )?.groupId
+    const result = launchAgentInNewTab({
+      agent: defaultAgent,
+      worktreeId,
+      ...(groupId ? { groupId } : {}),
+      launchSource: 'onboarding'
+    })
+    if (!result) {
+      toast.error(
+        translate(
+          'auto.components.terminalPane.FirstProjectTerminalWelcome.launchFailed',
+          'Could not build launch command for {{value0}}.',
+          { value0: defaultAgentLabel ?? defaultAgent }
+        )
+      )
+      return
+    }
+
+    state.dismissFirstProjectTerminalWelcome(tabId)
+    if (result.tabId) {
+      // Why: launching into a fresh tab and retiring the unexplained blank shell
+      // preserves the pane while using the shared local/SSH startup path.
+      state.closeTab(tabId, {
+        captureRecentlyClosed: false,
+        reason: 'cleanup',
+        recordInteraction: false
+      })
+      focusTerminalTabSurface(result.tabId)
+    }
+  }, [defaultAgent, defaultAgentAvailable, defaultAgentLabel, tabId, worktreeId])
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.metaKey || event.ctrlKey || event.altKey) {
+        return
+      }
+      if (event.key === '1') {
+        event.preventDefault()
+        openWorkspaceComposer()
+        return
+      }
+      if (event.key === '2' && defaultAgentAvailable) {
+        event.preventDefault()
+        launchDefaultAgent()
+        return
+      }
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        dismissToTerminal()
+        return
+      }
+      if (event.key === 'Enter' && event.target === event.currentTarget) {
+        event.preventDefault()
+        dismissToTerminal()
+      }
+    },
+    [defaultAgentAvailable, dismissToTerminal, launchDefaultAgent, openWorkspaceComposer]
+  )
+
+  const optionTwoDescription = agentsLoading
+    ? translate(
+        'auto.components.terminalPane.FirstProjectTerminalWelcome.checkingAgent',
+        'Checking whether {{value0}} is available here…',
+        { value0: defaultAgentLabel ?? 'your default agent' }
+      )
+    : defaultAgentAvailable
+      ? translate(
+          'auto.components.terminalPane.FirstProjectTerminalWelcome.currentCheckoutWarning',
+          'Changes will be made directly on {{value0}}.',
+          { value0: branchLabel }
+        )
+      : translate(
+          'auto.components.terminalPane.FirstProjectTerminalWelcome.agentUnavailable',
+          'No default agent is available here. Choose one in workspace setup.'
+        )
+  const style: WelcomeSurfaceStyle = {
+    '--orca-welcome-accent': accentColor,
+    '--orca-welcome-foreground': foregroundColor,
+    backgroundColor,
+    color: foregroundColor,
+    fontFamily,
+    fontSize: `${fontSize}px`
+  }
+
+  return (
+    <div
+      ref={rootRef}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="first-project-terminal-welcome-title"
+      aria-describedby="first-project-terminal-welcome-description"
+      data-first-project-terminal-welcome
+      tabIndex={-1}
+      className="absolute inset-0 z-[45] overflow-auto outline-none scrollbar-sleek"
+      style={style}
+      onKeyDown={handleKeyDown}
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          rootRef.current?.focus({ preventScroll: true })
+        }
+      }}
+    >
+      <div className="w-full max-w-3xl px-6 py-7 leading-relaxed sm:px-8 sm:py-9">
+        <h2
+          id="first-project-terminal-welcome-title"
+          className="mb-4 text-[1.05em] font-bold tracking-[0.18em] text-[var(--orca-welcome-accent)]"
+        >
+          {translate('auto.components.terminalPane.FirstProjectTerminalWelcome.brand', 'ORCA')}
+        </h2>
+        <div className="mb-5 space-y-0.5">
+          <p>
+            {translate(
+              'auto.components.terminalPane.FirstProjectTerminalWelcome.projectOpened',
+              'Project opened: {{value0}}',
+              { value0: projectLabel }
+            )}
+          </p>
+          <p>
+            {translate(
+              'auto.components.terminalPane.FirstProjectTerminalWelcome.branch',
+              'Branch: {{value0}}',
+              { value0: branchLabel }
+            )}
+          </p>
+        </div>
+        <p
+          id="first-project-terminal-welcome-description"
+          className="mb-5 max-w-2xl"
+          style={{ color: optionDescriptionColor() }}
+        >
+          {translate(
+            'auto.components.terminalPane.FirstProjectTerminalWelcome.explanation',
+            'This is a normal terminal. Orca works best when each task gets a separate Git worktree, so changes stay off {{value0}}.',
+            { value0: branchLabel }
+          )}
+        </p>
+
+        <div className="-mx-2 space-y-1">
+          <button type="button" className={optionClassName} onClick={openWorkspaceComposer}>
+            <span className="w-4 shrink-0 font-bold text-[var(--orca-welcome-accent)]">1</span>
+            <span>
+              <span className="block font-semibold">
+                {translate(
+                  'auto.components.terminalPane.FirstProjectTerminalWelcome.isolatedWorkspace',
+                  'Create an isolated workspace (recommended)'
+                )}
+              </span>
+              <span className="block" style={{ color: optionDescriptionColor() }}>
+                {translate(
+                  'auto.components.terminalPane.FirstProjectTerminalWelcome.isolatedWorkspaceDescription',
+                  'Choose a task name and agent before Orca creates the worktree.'
+                )}
+              </span>
+            </span>
+          </button>
+
+          <button
+            type="button"
+            className={optionClassName}
+            disabled={!defaultAgentAvailable}
+            onClick={launchDefaultAgent}
+          >
+            <span className="w-4 shrink-0 font-bold text-[var(--orca-welcome-accent)]">2</span>
+            <span>
+              <span className="block font-semibold">
+                {defaultAgentLabel
+                  ? translate(
+                      'auto.components.terminalPane.FirstProjectTerminalWelcome.launchAgent',
+                      'Launch {{value0}} in this checkout',
+                      { value0: defaultAgentLabel }
+                    )
+                  : translate(
+                      'auto.components.terminalPane.FirstProjectTerminalWelcome.launchAgentGeneric',
+                      'Launch an agent in this checkout'
+                    )}
+              </span>
+              <span className="block" style={{ color: optionDescriptionColor() }}>
+                {optionTwoDescription}
+              </span>
+            </span>
+          </button>
+
+          <button type="button" className={optionClassName} onClick={dismissToTerminal}>
+            <span className="w-4 shrink-0 text-[var(--orca-welcome-accent)]">↵</span>
+            <span>
+              <span className="block font-semibold">
+                {translate(
+                  'auto.components.terminalPane.FirstProjectTerminalWelcome.useTerminal',
+                  'Use this terminal as-is'
+                )}
+              </span>
+              <span className="block" style={{ color: optionDescriptionColor() }}>
+                {translate(
+                  'auto.components.terminalPane.FirstProjectTerminalWelcome.useTerminalDescription',
+                  'Press Enter or Escape, then run any shell command.'
+                )}
+              </span>
+            </span>
+          </button>
+        </div>
+
+        {workspaceShortcut ? (
+          <p className="mt-5" style={{ color: optionDescriptionColor() }}>
+            {translate(
+              'auto.components.terminalPane.FirstProjectTerminalWelcome.shortcut',
+              'Create another workspace anytime with {{value0}}.',
+              { value0: workspaceShortcut }
+            )}
+          </p>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -197,6 +197,7 @@ import { restoreTerminalFitToDesktop, restoreTerminalFitsToDesktop } from './ter
 import { useVisibleTerminalTabClaim } from './use-visible-terminal-tab-claim'
 import { TerminalSshReconnectOverlay } from './TerminalSshReconnectOverlay'
 import { TerminalRemoteRuntimeReconnectBanner } from './TerminalRemoteRuntimeReconnectBanner'
+import { FirstProjectTerminalWelcome } from './FirstProjectTerminalWelcome'
 import { selectTerminalTabAgentTypesByLeaf } from './terminal-tab-agent-type-index'
 import { resolveProtectedMultilinePasteOptionsForPane } from './terminal-agent-paste-bracketing'
 import { resolveTerminalInputHostPlatform } from './terminal-input-host-platform'
@@ -730,6 +731,9 @@ function TerminalPane(
   const openSpacePage = useAppStore((store) => store.openSpacePage)
   const refreshWorkspaceSpace = useAppStore((store) => store.refreshWorkspaceSpace)
   const settings = useAppStore((store) => store.settings)
+  const showFirstProjectTerminalWelcome = useAppStore(
+    (store) => store.firstProjectTerminalWelcomeTabId === tabId
+  )
   const updateSettings = useAppStore((store) => store.updateSettings)
   const requestLinkRoutingPreference = useLinkRoutingPreferenceDialog()
   const keybindings = useAppStore((store) => store.keybindings)
@@ -2902,6 +2906,16 @@ function TerminalPane(
       appSurface: effectiveAppearance?.mode,
       backgroundOpacity: settings?.terminalBackgroundOpacity
     }) ?? (titleUsesLightSurface ? '#ffffff' : '#000000')
+  const terminalForeground =
+    settings?.terminalColorOverrides?.foreground ??
+    effectiveAppearance?.theme?.foreground ??
+    (titleUsesLightSurface ? '#18181b' : '#f4f4f5')
+  const terminalAccent =
+    settings?.terminalColorOverrides?.brightGreen ??
+    settings?.terminalColorOverrides?.green ??
+    effectiveAppearance?.theme?.brightGreen ??
+    effectiveAppearance?.theme?.green ??
+    terminalForeground
 
   const terminalContentVisible = isVisible || shouldMeasureHiddenStartup
   const hiddenStartupStyle: CSSProperties = shouldMeasureHiddenStartup
@@ -3052,6 +3066,17 @@ function TerminalPane(
           })
         }}
       />
+      {showFirstProjectTerminalWelcome && isVisible && isWorktreeActive && settings ? (
+        <FirstProjectTerminalWelcome
+          tabId={tabId}
+          worktreeId={worktreeId}
+          backgroundColor={paneTitleBackground}
+          foregroundColor={terminalForeground}
+          accentColor={terminalAccent}
+          fontFamily={settings.terminalFontFamily}
+          fontSize={settings.terminalFontSize}
+        />
+      ) : null}
       {managedPanes.map((pane) => {
         const ptyId =
           paneTransportsRef.current.get(pane.id)?.getPtyId() ??

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16026,7 +16026,12 @@
           "projectOpened": "Project opened: {{value0}}",
           "shortcut": "Create another workspace anytime with {{value0}}.",
           "useTerminal": "Use this terminal as-is",
-          "useTerminalDescription": "Press Enter or Escape, then run any shell command."
+          "useTerminalDescription": "Press Enter or Escape, then run any shell command.",
+          "currentFolderWarning": "Changes will be made directly in this folder.",
+          "launchAgentInFolder": "Launch {{value0}} in this folder",
+          "launchAgentInFolderGeneric": "Launch an agent in this folder",
+          "folderOpened": "Folder opened: {{value0}}",
+          "folderExplanation": "This is a normal terminal opened in {{value0}}. Launch your coding agent here, or enter any shell command."
         },
         "useManualTerminalWorktreeParking": {
           "cannotPark": "These terminals cannot be parked safely."

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16011,6 +16011,23 @@
         }
       },
       "terminalPane": {
+        "FirstProjectTerminalWelcome": {
+          "agentUnavailable": "No default agent is available here. Choose one in workspace setup.",
+          "brand": "ORCA",
+          "branch": "Branch: {{value0}}",
+          "checkingAgent": "Checking whether {{value0}} is available here…",
+          "currentCheckoutWarning": "Changes will be made directly on {{value0}}.",
+          "explanation": "This is a normal terminal. Orca works best when each task gets a separate Git worktree, so changes stay off {{value0}}.",
+          "isolatedWorkspace": "Create an isolated workspace (recommended)",
+          "isolatedWorkspaceDescription": "Choose a task name and agent before Orca creates the worktree.",
+          "launchAgent": "Launch {{value0}} in this checkout",
+          "launchAgentGeneric": "Launch an agent in this checkout",
+          "launchFailed": "Could not build launch command for {{value0}}.",
+          "projectOpened": "Project opened: {{value0}}",
+          "shortcut": "Create another workspace anytime with {{value0}}.",
+          "useTerminal": "Use this terminal as-is",
+          "useTerminalDescription": "Press Enter or Escape, then run any shell command."
+        },
         "useManualTerminalWorktreeParking": {
           "cannotPark": "These terminals cannot be parked safely."
         }

--- a/src/renderer/src/lib/first-project-terminal-welcome.ts
+++ b/src/renderer/src/lib/first-project-terminal-welcome.ts
@@ -1,0 +1,17 @@
+import type { OnboardingState } from '../../../shared/onboarding-state-types'
+
+export function shouldShowFirstProjectTerminalWelcome({
+  onboarding,
+  projectCount
+}: {
+  onboarding: OnboardingState | null
+  projectCount: number
+}): boolean {
+  return Boolean(
+    onboarding &&
+    onboarding.closedAt !== null &&
+    !onboarding.checklist.addedRepo &&
+    !onboarding.checklist.addedFolder &&
+    projectCount === 1
+  )
+}

--- a/src/renderer/src/lib/onboarding-project-checklist.ts
+++ b/src/renderer/src/lib/onboarding-project-checklist.ts
@@ -5,13 +5,13 @@ export type OnboardingProjectChecklistItem = 'addedRepo' | 'addedFolder'
 
 export async function markOnboardingProjectAdded(
   item: OnboardingProjectChecklistItem
-): Promise<void> {
+): Promise<OnboardingState | null> {
   if (typeof window === 'undefined' || !window.api?.onboarding) {
-    return
+    return null
   }
   const onboarding = await window.api.onboarding.get().catch(() => null)
   if (!onboarding || onboarding.checklist[item]) {
-    return
+    return onboarding
   }
 
   const checklist: Partial<OnboardingState['checklist']> = {}
@@ -20,11 +20,14 @@ export async function markOnboardingProjectAdded(
     await window.api.onboarding.update({ checklist })
   } catch (err) {
     console.warn('[onboarding] Failed to update project checklist item:', err)
-    return
+    return onboarding
   }
 
   track('activation_checklist_item_completed', {
     item,
     time_since_completed_ms: 0
   })
+  // Why: callers that hand off from onboarding need the pre-update checklist
+  // to distinguish the first project from every later add.
+  return onboarding
 }

--- a/src/renderer/src/store/repos/repo-add-actions.ts
+++ b/src/renderer/src/store/repos/repo-add-actions.ts
@@ -8,6 +8,7 @@ import { callRuntimeRpc, getActiveRuntimeTarget } from '../../runtime/runtime-rp
 import { buildDismissedOnboardingFolderAgentStartup } from '@/lib/onboarding-folder-agent-startup'
 import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
 import { markOnboardingProjectAdded } from '@/lib/onboarding-project-checklist'
+import { shouldShowFirstProjectTerminalWelcome } from '@/lib/first-project-terminal-welcome'
 import { translate } from '@/i18n/i18n'
 import {
   getRepoExecutionHostId,
@@ -162,7 +163,11 @@ export function createRepoAddActions(
         if (!repo) {
           return null
         }
-        await markOnboardingProjectAdded('addedFolder')
+        const onboardingBeforeAdd = await markOnboardingProjectAdded('addedFolder')
+        const showFirstProjectTerminalWelcome = shouldShowFirstProjectTerminalWelcome({
+          onboarding: onboardingBeforeAdd,
+          projectCount: get().repos.length
+        })
         // Why: focus the new folder so the add is visible; lazy-import worktree-activation to avoid a circular module load (it imports the store root).
         const executionHostId =
           options?.runtimeEnvironmentId === undefined
@@ -184,11 +189,21 @@ export function createRepoAddActions(
             hadProjectBeforeAdd,
             isNativeChatTranscriptLocalReadable(repo.connectionId)
           )
-          activateAndRevealWorktree(folderWorktree.id, {
+          const activationResult = activateAndRevealWorktree(folderWorktree.id, {
             sidebarRevealBehavior: 'auto',
             ...(executionHostId ? { executionHostId } : {}),
             ...(startup ? { startup } : {})
           })
+          if (
+            !startup &&
+            showFirstProjectTerminalWelcome &&
+            activationResult &&
+            activationResult.primaryTabId
+          ) {
+            // Why: non-Git folders bypass the Git default-checkout handoff, but
+            // their first blank terminal needs the same one-time orientation.
+            get().showFirstProjectTerminalWelcome(activationResult.primaryTabId)
+          }
         }
         return repo
       } catch (err) {

--- a/src/renderer/src/store/slices/repos-onboarding-folder-startup.test.ts
+++ b/src/renderer/src/store/slices/repos-onboarding-folder-startup.test.ts
@@ -13,17 +13,19 @@ vi.mock('../../lib/worktree-activation', () => ({
 const reposAdd = vi.fn()
 const worktreesList = vi.fn()
 const onboardingGet = vi.fn()
+const onboardingUpdate = vi.fn()
 
 beforeEach(() => {
   reposAdd.mockReset()
   worktreesList.mockReset()
   onboardingGet.mockReset()
+  onboardingUpdate.mockReset()
   worktreeActivation.activateAndRevealWorktree.mockReset()
   vi.stubGlobal('window', {
     api: {
       repos: { add: reposAdd },
       worktrees: { list: worktreesList },
-      onboarding: { get: onboardingGet }
+      onboarding: { get: onboardingGet, update: onboardingUpdate }
     }
   })
 })
@@ -80,5 +82,30 @@ describe('repo slice skipped-onboarding folder startup', () => {
       'folder-2::/folder',
       { sidebarRevealBehavior: 'auto' }
     )
+  })
+
+  it('shows the terminal welcome for the first folder after completed onboarding', async () => {
+    reposAdd.mockResolvedValue({
+      repo: {
+        id: 'folder-1',
+        path: '/first',
+        displayName: 'First',
+        addedAt: 1,
+        kind: 'folder'
+      }
+    })
+    worktreesList.mockResolvedValue([makeWorktree({ id: 'folder-1::/first', repoId: 'folder-1' })])
+    onboardingGet.mockResolvedValue({
+      ...getDefaultOnboardingState(),
+      closedAt: 1,
+      outcome: 'completed'
+    })
+    worktreeActivation.activateAndRevealWorktree.mockReturnValue({ primaryTabId: 'terminal-1' })
+    const store = createTestStore()
+
+    await store.getState().addNonGitFolder('/first')
+
+    expect(onboardingUpdate).toHaveBeenCalledWith({ checklist: { addedFolder: true } })
+    expect(store.getState().firstProjectTerminalWelcomeTabId).toBe('terminal-1')
   })
 })

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -18,6 +18,7 @@ import { createTerminalLayoutActions } from '../terminals/terminal-layout-state'
 import { createTerminalStartupQueueActions } from '../terminals/terminal-startup-queues'
 import { createWorkspaceTerminalHydrationActions } from '../terminals/workspace-terminal-hydration'
 import { createWorkspaceTerminalReconnectActions } from '../terminals/workspace-terminal-reconnect'
+import { createTerminalFirstProjectWelcomeActions } from '../terminals/terminal-first-project-welcome-state'
 
 export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> = (set, get) => ({
   tabsByWorktree: {},
@@ -28,6 +29,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   unreadTerminalTabs: {},
   unreadTerminalPanes: {},
   unreadAgentCompletionPanes: {},
+  firstProjectTerminalWelcomeTabId: null,
   suppressedPtyExitIds: {},
   pendingPtyShutdownIds: {},
   pendingCodexPaneRestartIds: {},
@@ -61,6 +63,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
   cacheTimerByKey: {},
   lastTerminalInputAtByPaneKey: {},
   recentQuickCommandIdByGroup: {},
+  ...createTerminalFirstProjectWelcomeActions(set, get),
   ...createTerminalEphemeralActions(set, get),
   ...createTerminalTabCreationActions(set, get),
   ...createActiveWorkspaceTerminalActions(set, get),

--- a/src/renderer/src/store/slices/worktrees-purge-terminal-state.test.ts
+++ b/src/renderer/src/store/slices/worktrees-purge-terminal-state.test.ts
@@ -53,6 +53,7 @@ describe('purgeWorktreeTerminalState direct (design §4.4)', () => {
       expandedPaneByTabId: { 'tab-1': true, 'tab-2': false, 'tab-3': true },
       canExpandPaneByTabId: { 'tab-1': true, 'tab-2': true, 'tab-3': false },
       runtimePaneTitlesByTabId: { 'tab-1': 'claude', 'tab-3': 'bash' },
+      firstProjectTerminalWelcomeTabId: 'tab-1',
       automaticAgentResumeClaimsByTabId: {
         'tab-1': {
           worktreeId: 'repoA::/a/wt1',
@@ -124,6 +125,7 @@ describe('purgeWorktreeTerminalState direct (design §4.4)', () => {
     expect(s.expandedPaneByTabId).toEqual({ 'tab-3': true })
     expect(s.canExpandPaneByTabId).toEqual({ 'tab-3': false })
     expect(s.runtimePaneTitlesByTabId).toEqual({ 'tab-3': 'bash' })
+    expect(s.firstProjectTerminalWelcomeTabId).toBeNull()
     expect(s.automaticAgentResumeClaimsByTabId).toEqual({
       'tab-3': {
         worktreeId: 'repoA::/a/wt2',

--- a/src/renderer/src/store/slices/worktrees/teardown/worktree-purge-state.ts
+++ b/src/renderer/src/store/slices/worktrees/teardown/worktree-purge-state.ts
@@ -72,6 +72,11 @@ export function buildWorktreePurgeState(
     automaticAgentResumeClaimsByTabId: omitByTabId(s.automaticAgentResumeClaimsByTabId),
     nativeChatLaunchPromptByTabId: omitByTabId(s.nativeChatLaunchPromptByTabId),
     nativeChatLaunchDraftByTabId: omitByTabId(s.nativeChatLaunchDraftByTabId),
+    firstProjectTerminalWelcomeTabId:
+      s.firstProjectTerminalWelcomeTabId &&
+      doomed.doomedTabIds.has(s.firstProjectTerminalWelcomeTabId)
+        ? null
+        : s.firstProjectTerminalWelcomeTabId,
     // Why: bulk/hydration purge runs no terminal teardown, so it must drop the per-tab pane-expand flags itself.
     expandedPaneByTabId: omitByTabId(s.expandedPaneByTabId),
     canExpandPaneByTabId: omitByTabId(s.canExpandPaneByTabId),

--- a/src/renderer/src/store/terminals/terminal-actions.ts
+++ b/src/renderer/src/store/terminals/terminal-actions.ts
@@ -34,6 +34,8 @@ import type {
 } from './terminal-contracts'
 
 export type TerminalActions = {
+  showFirstProjectTerminalWelcome: (tabId: string) => void
+  dismissFirstProjectTerminalWelcome: (tabId: string) => void
   setRecentQuickCommandForGroup: (groupId: string, quickCommandId: string) => void
   claimAutomaticAgentResume: (tabId: string, claim: AutomaticAgentResumeClaim) => void
   seedNativeChatLaunchPrompt: (prompt: NativeChatLaunchPrompt) => void

--- a/src/renderer/src/store/terminals/terminal-first-project-welcome-state.ts
+++ b/src/renderer/src/store/terminals/terminal-first-project-welcome-state.ts
@@ -1,0 +1,19 @@
+import type { TerminalSlice, TerminalStoreGet, TerminalStoreSet } from './terminal-state'
+
+export function createTerminalFirstProjectWelcomeActions(
+  set: TerminalStoreSet,
+  _get: TerminalStoreGet
+): Pick<TerminalSlice, 'showFirstProjectTerminalWelcome' | 'dismissFirstProjectTerminalWelcome'> {
+  return {
+    showFirstProjectTerminalWelcome: (tabId) => {
+      set({ firstProjectTerminalWelcomeTabId: tabId })
+    },
+    dismissFirstProjectTerminalWelcome: (tabId) => {
+      set((state) =>
+        state.firstProjectTerminalWelcomeTabId === tabId
+          ? { firstProjectTerminalWelcomeTabId: null }
+          : {}
+      )
+    }
+  }
+}

--- a/src/renderer/src/store/terminals/terminal-state.ts
+++ b/src/renderer/src/store/terminals/terminal-state.ts
@@ -30,6 +30,8 @@ export type TerminalState = {
   unreadTerminalTabs: Record<string, true>
   unreadTerminalPanes: Record<string, true>
   unreadAgentCompletionPanes: Record<string, true>
+  /** Runtime-only first-project handoff; never persisted or replayed after restart. */
+  firstProjectTerminalWelcomeTabId: string | null
   /** Scoped exit suppression and reference-counted shutdown ownership prevent teardown races. */
   suppressedPtyExitIds: Record<string, true>
   pendingPtyShutdownIds: Record<string, number>

--- a/src/renderer/src/store/terminals/terminal-tab-close.ts
+++ b/src/renderer/src/store/terminals/terminal-tab-close.ts
@@ -195,6 +195,10 @@ export function createTerminalTabCloseActions(
         return {
           tabsByWorktree: next,
           activeTabId: s.activeTabId === tabId ? null : s.activeTabId,
+          firstProjectTerminalWelcomeTabId:
+            s.firstProjectTerminalWelcomeTabId === tabId
+              ? null
+              : s.firstProjectTerminalWelcomeTabId,
           activeTabIdByWorktree: nextActiveTabIdByWorktree,
           ptyIdsByTabId: nextPtyIdsByTabId,
           lastKnownRelayPtyIdByTabId: nextLastKnownRelay,

--- a/tests/e2e/add-project-default-checkout.spec.ts
+++ b/tests/e2e/add-project-default-checkout.spec.ts
@@ -189,3 +189,51 @@ test.describe('Add project default checkout', () => {
       })
   })
 })
+
+test.describe('First project terminal handoff', () => {
+  test.use({ seedTestRepo: false })
+
+  test('explains the dark terminal and opens isolated workspace setup from the keyboard', async ({
+    orcaPage,
+    registerPostElectronShutdownCleanup
+  }) => {
+    await waitForSessionReady(orcaPage)
+    const fixture = await createLinkedWorktreeFixture()
+    const fixtureRoot = path.dirname(fixture.mainPath)
+    const fixtureRootIndex = tempRoots.indexOf(fixtureRoot)
+    if (fixtureRootIndex !== -1) {
+      tempRoots.splice(fixtureRootIndex, 1)
+    }
+    // Why: the active terminal keeps the checkout open on Windows until the
+    // Electron fixture shuts down; remove this fixture only after that release.
+    registerPostElectronShutdownCleanup(async () => {
+      rmSync(fixtureRoot, { recursive: true, force: true })
+    })
+    await orcaPage.evaluate(async () => {
+      await window.__store?.getState().updateSettings({ theme: 'dark' })
+    })
+    await expect(orcaPage.locator('html')).toHaveClass(/dark/)
+
+    await orcaPage.evaluate((folderPath) => {
+      window.__store?.getState().openModal('confirm-add-project-from-folder', { folderPath })
+    }, fixture.mainPath)
+    const addProjectDialog = orcaPage.getByRole('dialog', { name: /^Add Project$/i })
+    await expect(addProjectDialog).toBeVisible()
+    await addProjectDialog.getByRole('button', { name: /^Add Project$/ }).click()
+
+    const terminalWelcome = orcaPage.getByRole('dialog', { name: 'ORCA' })
+    await expect(terminalWelcome).toBeVisible({ timeout: 30_000 })
+    await expect(terminalWelcome).toContainText(
+      `Project opened: ${path.basename(fixture.mainPath)}`
+    )
+    await expect(terminalWelcome).toContainText('Branch: main')
+    await expect(terminalWelcome).toContainText('separate Git worktree')
+    await expect(
+      terminalWelcome.getByRole('button', { name: /Launch an agent in this checkout/i })
+    ).toBeDisabled()
+    await terminalWelcome.press('1')
+
+    await expect(terminalWelcome).toBeHidden()
+    await expect(orcaPage.getByRole('dialog', { name: /Create worktree/i })).toBeVisible()
+  })
+})

--- a/tests/e2e/add-project-default-checkout.spec.ts
+++ b/tests/e2e/add-project-default-checkout.spec.ts
@@ -73,6 +73,15 @@ async function createLinkedWorktreeFixture(): Promise<{
   return { mainPath, siblingPath }
 }
 
+async function createFolderFixture(): Promise<string> {
+  const folderPath = realpathSync(
+    await mkdtemp(path.join(os.tmpdir(), 'orca-e2e-first-project-folder-'))
+  )
+  tempRoots.push(folderPath)
+  writeFileSync(path.join(folderPath, 'README.md'), '# Non-Git folder\n')
+  return folderPath
+}
+
 test.afterEach(() => {
   for (const root of tempRoots.splice(0)) {
     rmSync(root, { recursive: true, force: true })
@@ -235,5 +244,57 @@ test.describe('First project terminal handoff', () => {
 
     await expect(terminalWelcome).toBeHidden()
     await expect(orcaPage.getByRole('dialog', { name: /Create worktree/i })).toBeVisible()
+  })
+
+  test('orients the first non-Git folder terminal without worktree guidance', async ({
+    orcaPage,
+    registerPostElectronShutdownCleanup
+  }) => {
+    await waitForSessionReady(orcaPage)
+    const folderPath = await createFolderFixture()
+    const folderPathIndex = tempRoots.indexOf(folderPath)
+    if (folderPathIndex !== -1) {
+      tempRoots.splice(folderPathIndex, 1)
+    }
+    registerPostElectronShutdownCleanup(async () => {
+      rmSync(folderPath, { recursive: true, force: true })
+    })
+
+    await orcaPage.evaluate((selectedPath) => {
+      window.__store?.getState().openModal('confirm-add-project-from-folder', {
+        folderPath: selectedPath
+      })
+    }, folderPath)
+    const addProjectDialog = orcaPage.getByRole('dialog', { name: /^Add Project$/i })
+    await expect(addProjectDialog).toBeVisible()
+    await addProjectDialog.getByRole('button', { name: /^Add Project$/ }).click()
+
+    const openAsFolderDialog = orcaPage.getByRole('dialog', { name: /Open as Folder/i })
+    await expect(openAsFolderDialog).toBeVisible()
+    await openAsFolderDialog.getByRole('button', { name: /Open as Folder/i }).click()
+
+    const terminalWelcome = orcaPage.getByRole('dialog', { name: 'ORCA' })
+    await expect(terminalWelcome).toBeVisible({ timeout: 30_000 })
+    await expect(terminalWelcome).toContainText(`Folder opened: ${path.basename(folderPath)}`)
+    await expect(terminalWelcome).toContainText('This is a normal terminal opened in')
+    await expect(terminalWelcome).not.toContainText('Branch:')
+    await expect(
+      terminalWelcome.getByRole('button', { name: /Launch an agent in this folder/i })
+    ).toBeDisabled()
+    await expect(
+      terminalWelcome.getByRole('button', { name: /Create an isolated workspace/i })
+    ).toHaveCount(0)
+    await expect
+      .poll(() =>
+        orcaPage.evaluate(() => {
+          const state = window.__store?.getState()
+          return Boolean(
+            state?.activeTabId &&
+            state.firstProjectTerminalWelcomeTabId === state.activeTabId &&
+            state.repos[0]?.kind === 'folder'
+          )
+        })
+      )
+      .toBe(true)
   })
 })


### PR DESCRIPTION
## ELI5

After onboarding, Orca can open a first Git project or ordinary folder directly into a blank-looking terminal. This adds a one-time terminal welcome that explains the screen and gives the user an immediate next action without unexpectedly running a command.

## What Changed

- Show a terminal-native welcome only when onboarding hands off to the user's first project.
- For Git projects, display the project and branch, let `1` open the isolated-workspace composer, and let `2` launch the detected default agent in the current checkout.
- For non-Git folders, avoid branch/worktree claims and let `1` launch the detected default agent in that folder.
- Let Enter or Escape dismiss either welcome and focus the normal shell.
- Use the active terminal's light/dark palette and font settings.
- Cover local, runtime-hosted, and SSH folder-add entry points.
- Keep the handoff runtime-only and clear it when its terminal or worktree is removed, so it never replays on restored sessions.

## Why

The first project terminal is valid, but it does not explain Orca's workflow or what the user can do next. A first-time user can therefore read the initial screen as an impasse.

This approach keeps the explanation in the context the user is already looking at, reuses Orca's existing workspace composer and agent launcher, and avoids injecting shell-specific commands or unexpectedly starting an agent.

## Linked Issue

Fixes #16607

## Visual Proof

**Before**

The first project opens to an unexplained terminal; reproduction and expected behavior are documented in #16607.

**After — dark terminal theme**

<img width="1748" height="899" alt="first-project-terminal-welcome-dark" src="https://github.com/user-attachments/assets/d80294dc-ea3e-4b3b-befe-4be9725173c6" />

## Testing

- [x] Fresh-profile manual Electron run: completed onboarding, added a real non-Git folder, and confirmed the welcome automatically matched the active terminal tab with no console errors.
- [x] Focused Vitest suites: 29 passed across Git/folder eligibility, local/SSH folder handoff, component behavior, and lifecycle coverage.
- [x] Focused Electron Playwright non-Git handoff: 1 passed, exercising the real “Open as Folder” confirmation and active-terminal binding.
- [x] Existing focused Electron Git handoff passed twice, including dark theme and keyboard-opened workspace composer.
- [x] `npm run typecheck` passed.
- [x] `electron-vite build --mode e2e` passed.
- [x] Default, native-plugin, and type-aware changed-file oxlint passed.
- [x] Localization extraction, catalog, and coverage gates passed.
- [x] Reliability, max-lines, and runtime-Electron ratchets passed.
- [x] `git diff --check` passed.

The full lint chain reached and passed code-quality/reliability ratchets, then stopped on unrelated pre-existing stale generated skill-manifest artifacts. Those unrelated files were not regenerated or included here.

## AI Disclosure

OpenAI Codex was used to research the flow, implement the change, add tests, run verification, and draft this PR. The UX report and direction came from the contributor. Image generation was used only to remove an unrelated clipped toast from the locally captured visual-proof screenshot; the Orca UI content was not intentionally changed.

## Review

- Cross-platform: renderer-only UI and shared keyboard labels; no OS-specific production branch.
- SSH/remote: local, runtime, and SSH folder paths use the same pure first-project eligibility rule and attach only to a returned renderable terminal tab; agent launch reuses the host-aware shared launcher.
- Session compatibility: the runtime-only marker is not persisted and is cleared on tab close/worktree purge.
- Security: no shell text injection, command interpolation, new IPC, permissions, or external data flow.
- Accessibility: named dialog surface, semantic buttons, visible disabled explanation, and keyboard paths for every outcome.
- Performance: one derived boolean store subscription on terminal panes; detection reuses the existing agent-detection hook and appears once.

## Agent skill upstream boundary

- [x] Not applicable; this change copies or translates no upstream skill-installer source.

## Notes

The default agent is never launched automatically by this welcome. Direct launch is offered only when the configured agent is enabled and detected. Git projects keep isolated workspace creation as the recommended first option; non-Git folders clearly warn that agent changes are made directly in the folder.

This PR is intentionally kept in Draft while the contributor reviews the fresh-profile result.

## Checklist

- [x] This PR is small and focused.
- [x] I explained what changed and why (including ELI5).
- [x] Before/after evidence is attached for the UI change.
- [x] Self-reviewed for correctness, security, and performance.
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered.
- [x] Targeted lint, typecheck, tests, build, and Electron E2E pass.
