### PR TITLE
fix(agent-hooks): silence progress before the policy bypass can autoload

### DIFF
--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -617,7 +617,7 @@ function expectedDecodedWindowsHookCommand(scriptPath: string): string {
   // Why: the execution-policy bypass rides in the payload, not on the command
   // line, so the launcher cannot spell the AV-blocked flag triple (#16003).
   // Why: PowerShell progress CLIXML corrupts consumers that merge stderr into JSON stdout.
-  return `try { Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction SilentlyContinue } catch {}; $ProgressPreference='SilentlyContinue'; if (Test-Path -LiteralPath ${quoted} -PathType Leaf) { & ${quoted}; exit $LASTEXITCODE }; [Console]::In.ReadToEnd() | Out-Null; exit 0`
+  return `$ProgressPreference='SilentlyContinue'; try { Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction SilentlyContinue } catch {}; if (Test-Path -LiteralPath ${quoted} -PathType Leaf) { & ${quoted}; exit $LASTEXITCODE }; [Console]::In.ReadToEnd() | Out-Null; exit 0`
 }
 
 describe('wrapWindowsHookCommand', () => {

--- a/src/main/agent-hooks/windows-powershell-hook-launcher.test.ts
+++ b/src/main/agent-hooks/windows-powershell-hook-launcher.test.ts
@@ -72,7 +72,25 @@ describe('windows PowerShell hook launcher', () => {
     ).toString('utf16le')
 
     expect(decoded).toBe(
-      "try { Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction SilentlyContinue } catch {}; $ProgressPreference='SilentlyContinue'; & $scriptPath"
+      "$ProgressPreference='SilentlyContinue'; try { Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force -ErrorAction SilentlyContinue } catch {}; & $scriptPath"
+    )
+  })
+
+  it('silences progress before anything that can autoload a module', () => {
+    // Set-ExecutionPolicy pulls in Microsoft.PowerShell.Security, and its
+    // "Preparing modules for first use." progress record is written before a
+    // later assignment can suppress it. Measured on Windows 11: bypass-first put
+    // 616 bytes of <Objs Version="1.1.0.1"> on stderr and made "#< CLIXML" the
+    // first merged line -- the exact corruption HOOK_PROGRESS_SILENCER exists to
+    // stop. Silencer-first measured 0 bytes.
+    const decoded = Buffer.from(
+      encodeWindowsPowerShellHookCommand('& $scriptPath'),
+      'base64'
+    ).toString('utf16le')
+
+    expect(decoded.indexOf("$ProgressPreference='SilentlyContinue'")).toBeGreaterThanOrEqual(0)
+    expect(decoded.indexOf("$ProgressPreference='SilentlyContinue'")).toBeLessThan(
+      decoded.indexOf('Set-ExecutionPolicy')
     )
   })
 })

--- a/src/main/agent-hooks/windows-powershell-hook-launcher.ts
+++ b/src/main/agent-hooks/windows-powershell-hook-launcher.ts
@@ -35,7 +35,12 @@ export function getWindowsPowerShellExecutablePath(): string {
  */
 export const WINDOWS_POWERSHELL_HOOK_SWITCHES = '-NoProfile -WindowStyle Hidden'
 
-// Why: redirected PowerShell progress becomes CLIXML that can corrupt merged JSON output.
+// Why: redirected PowerShell progress becomes CLIXML that can corrupt merged JSON
+// output. It must be the FIRST statement: Set-ExecutionPolicy autoloads
+// Microsoft.PowerShell.Security, whose "Preparing modules for first use."
+// progress record is emitted before any later assignment can suppress it.
+// Measured on Windows 11: bypass-first put 616 bytes of <Objs Version="1.1.0.1">
+// on stderr and made "#< CLIXML" the first merged line; silencer-first, 0 bytes.
 const HOOK_PROGRESS_SILENCER = "$ProgressPreference='SilentlyContinue'; "
 
 /**
@@ -60,7 +65,7 @@ const HOOK_EXECUTION_POLICY_BYPASS =
 // Why: encoding shields paths and switches from cmd.exe and MSYS rewriting (#6078, #14815).
 export function encodeWindowsPowerShellHookCommand(command: string): string {
   return Buffer.from(
-    `${HOOK_EXECUTION_POLICY_BYPASS}${HOOK_PROGRESS_SILENCER}${command}`,
+    `${HOOK_PROGRESS_SILENCER}${HOOK_EXECUTION_POLICY_BYPASS}${command}`,
     'utf16le'
   ).toString('base64')
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​20 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​18 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​7 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​5 |

<!-- /orca-pr-loc -->

Stacked on #16576. Found by exercising that PR on a real Windows 11 host — not by code review.

## The defect

`Set-ExecutionPolicy` autoloads `Microsoft.PowerShell.Security`, and that module's **"Preparing modules for first use."** progress record is written *before* any later statement can suppress it. #16576 put the bypass first, so the silencer on the very next statement was already too late.

Identical launcher flags, only payload order differs:

| order | stderr | first merged line |
|---|---|---|
| bypass first (#16576 as-is) | **616 bytes** `<Objs Version="1.1.0.1">` | `#< CLIXML` |
| silencer first (this PR) | **0 bytes** | `{"decision":"approve"}` |

That is exactly the corruption `HOOK_PROGRESS_SILENCER`'s own comment warns about — *"redirected PowerShell progress becomes CLIXML that can corrupt merged JSON output"* — so #16576 reintroduced the hazard it documents, one line below documenting it.

## Why the tests did not catch it

Both existing assertions hard-coded the broken order, so they **enforced** the bug rather than guarding against it. Reordered, plus a new test that pins the *ordering* (silencer index < `Set-ExecutionPolicy` index) rather than a literal string, because the string will drift again.

Mutation-verified: restoring bypass-first turns 2 tests red; restoring the fix returns them green.

## Trade-offs

None. Same two statements, same semantics — the bypass still applies before the caller command. Only the order changes.

## Verification

`pnpm lint` 0 · `pnpm typecheck` 0 · reliability gates 0 (97) · `src/main/agent-hooks` 730 passed / 6 skipped.

Note this does **not** address #16576's open question: whether the remaining `-NoProfile -WindowStyle Hidden` pair clears the Kaspersky signature was never measured. The `awin` host runs Defender only, with no ASR rules, and could not reproduce the denial across 15 CreateProcess calls of the exact triple. That claim is still unverified.