### PR TITLE
fix(cli): surface runtime transport permission denial

### DIFF
--- a/src/cli/runtime/status.test.ts
+++ b/src/cli/runtime/status.test.ts
@@ -6,7 +6,8 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { getRuntimeMetadataPath } from '../../shared/runtime-bootstrap'
 import type { RuntimeStatus } from '../../shared/runtime-types'
 import { RuntimeClient } from './client'
-import { projectRemoteAppStatus } from './status'
+import { projectRemoteAppStatus, projectRuntimeConnectFailure } from './status'
+import { RuntimeClientError } from './types'
 
 const servers = new Set<ReturnType<typeof createServer>>()
 const sockets = new Set<Socket>()
@@ -140,5 +141,26 @@ describe('projectRemoteAppStatus', () => {
     expect(
       projectRemoteAppStatus(remoteStatus({ desktopWindowStatus: 'available' })).pid
     ).toBeNull()
+  })
+})
+
+describe('projectRuntimeConnectFailure', () => {
+  it('does not report a live permission-denied runtime as starting', () => {
+    expect(
+      projectRuntimeConnectFailure(
+        new RuntimeClientError('runtime_permission_denied', 'denied'),
+        true
+      )
+    ).toEqual({
+      runtimeState: 'stale_bootstrap',
+      graphState: 'not_running'
+    })
+  })
+
+  it('retains starting for a live transient connection failure', () => {
+    expect(projectRuntimeConnectFailure(new Error('not ready'), true)).toEqual({
+      runtimeState: 'starting',
+      graphState: 'starting'
+    })
   })
 })

--- a/src/cli/runtime/status.ts
+++ b/src/cli/runtime/status.ts
@@ -6,7 +6,11 @@ import {
   projectRemoteAppStatus,
   resolveDesktopWindowStatus
 } from '../../shared/cli-app-status-projection'
-import { RuntimeRpcFailureError, type RuntimeRpcSuccess } from './types'
+import {
+  RuntimeClientError,
+  RuntimeRpcFailureError,
+  type RuntimeRpcSuccess
+} from './types'
 
 export { projectRemoteAppStatus, resolveDesktopWindowStatus }
 
@@ -63,22 +67,41 @@ export async function getCliStatus(
         state: graphState
       }
     })
-  } catch {
+  } catch (error) {
     const running = isProcessRunning(metadata.pid)
+    const failure = projectRuntimeConnectFailure(error, running)
     return buildCliStatusResponse({
       app: {
         running,
         pid: running ? metadata.pid : null
       },
       runtime: {
-        state: running ? 'starting' : 'stale_bootstrap',
+        state: failure.runtimeState,
         reachable: false,
         runtimeId: null
       },
       graph: {
-        state: running ? 'starting' : 'not_running'
+        state: failure.graphState
       }
     })
+  }
+}
+
+export function projectRuntimeConnectFailure(
+  error: unknown,
+  running: boolean
+): {
+  runtimeState: 'starting' | 'stale_bootstrap'
+  graphState: 'starting' | 'not_running'
+} {
+  const permissionDenied =
+    error instanceof RuntimeClientError && error.code === 'runtime_permission_denied'
+  if (running && !permissionDenied) {
+    return { runtimeState: 'starting', graphState: 'starting' }
+  }
+  return {
+    runtimeState: 'stale_bootstrap',
+    graphState: 'not_running'
   }
 }
 

--- a/src/cli/runtime/transport.test.ts
+++ b/src/cli/runtime/transport.test.ts
@@ -5,7 +5,8 @@ import { createServer, type Socket } from 'node:net'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { RuntimeMetadata } from '../../shared/runtime-bootstrap'
 import { MAX_TIMER_DELAY_MS } from '../../shared/timer-delay'
-import { sendRequest } from './transport'
+import { mapRuntimeConnectError, sendRequest } from './transport'
+import { RuntimeClientError } from './types'
 
 const servers = new Set<ReturnType<typeof createServer>>()
 const sockets = new Set<Socket>()
@@ -45,6 +46,39 @@ describe('runtime transport timeout validation', () => {
       )
     }
   )
+})
+
+describe('runtime transport connection errors', () => {
+  it.each(['EPERM', 'EACCES'] as const)(
+    'preserves %s instead of recommending a restart',
+    (code) => {
+      const failure = mapRuntimeConnectError(
+        Object.assign(new Error('denied'), { code, errno: -4048, syscall: 'connect' }),
+        'named-pipe'
+      )
+
+      expect(failure).toBeInstanceOf(RuntimeClientError)
+      expect(failure).toMatchObject({
+        code: 'runtime_permission_denied',
+        data: {
+          transportKind: 'named-pipe',
+          osErrorCode: code,
+          osErrorNumber: -4048,
+          syscall: 'connect'
+        }
+      })
+      expect(failure.message).not.toContain('Restart Orca and try again')
+    }
+  )
+
+  it('keeps a missing endpoint in the generic unavailable class', () => {
+    const failure = mapRuntimeConnectError(
+      Object.assign(new Error('missing'), { code: 'ENOENT', syscall: 'connect' }),
+      'named-pipe'
+    )
+
+    expect(failure).toMatchObject({ code: 'runtime_unavailable' })
+  })
 })
 
 // Why: these tests create Unix domain socket servers in temp directories.

--- a/src/cli/runtime/transport.ts
+++ b/src/cli/runtime/transport.ts
@@ -66,12 +66,12 @@ export async function sendRequest<TResult>(
     }
 
     socket.setEncoding('utf8')
-    socket.once('error', () => {
+    socket.once('error', (error: NodeJS.ErrnoException) => {
       finish({
         ok: false,
-        error: new RuntimeClientError(
-          'runtime_unavailable',
-          'Could not connect to the running Orca app. Restart Orca and try again.'
+        error: mapRuntimeConnectError(
+          error,
+          transport.kind === 'unix' ? 'unix' : 'named-pipe'
         )
       })
     })
@@ -195,4 +195,23 @@ export async function sendRequest<TResult>(
       )
     })
   })
+}
+
+export function mapRuntimeConnectError(
+  error: NodeJS.ErrnoException,
+  transportKind: 'unix' | 'named-pipe'
+): RuntimeClientError {
+  const permissionDenied = error.code === 'EPERM' || error.code === 'EACCES'
+  return new RuntimeClientError(
+    permissionDenied ? 'runtime_permission_denied' : 'runtime_unavailable',
+    permissionDenied
+      ? 'Permission denied while connecting to the Orca runtime transport. Restarting Orca will not change this transport permission.'
+      : 'Could not connect to the running Orca app. Restart Orca and try again.',
+    {
+      transportKind,
+      ...(error.code ? { osErrorCode: error.code } : {}),
+      ...(typeof error.errno === 'number' ? { osErrorNumber: error.errno } : {}),
+      ...(error.syscall ? { syscall: error.syscall } : {})
+    }
+  )
 }


### PR DESCRIPTION
## Summary
- preserve EPERM/EACCES and OS connect evidence from local runtime transports
- stop recommending an Orca restart for a permission-denied named pipe
- prevent a live but inaccessible runtime from remaining in starting forever

Closes the diagnostics half of #13539. This does not change the native Windows named-pipe DACL.

## Verification
- pnpm exec vitest run --config config/vitest.config.ts src/cli/runtime/transport.test.ts src/cli/runtime/status.test.ts --reporter=verbose: 17 passed, 3 existing Windows Unix-socket fixture skips
- changed-file oxlint: passed
- git diff --check: passed
- head 149902e8d2f0d1130725a1e083a2cfd028146bd, based on current main at verification

## Remaining boundary
Native least-privilege pipe ACL support remains unresolved and requires a Windows native CreateNamedPipe security descriptor path. Restarting the app recreates the same default DACL and is not a recovery.