### PR TITLE
fix(runtime): add authenticated Windows loopback fallback

### DIFF
--- a/src/cli/runtime/transport.test.ts
+++ b/src/cli/runtime/transport.test.ts
@@ -5,7 +5,7 @@ import { createServer, type Socket } from 'node:net'
 import { afterEach, describe, expect, it } from 'vitest'
 import type { RuntimeMetadata } from '../../shared/runtime-bootstrap'
 import { MAX_TIMER_DELAY_MS } from '../../shared/timer-delay'
-import { mapRuntimeConnectError, sendRequest } from './transport'
+import { mapRuntimeConnectError, sendRequest, shouldUseLocalTcpFallback } from './transport'
 import { RuntimeClientError } from './types'
 
 const servers = new Set<ReturnType<typeof createServer>>()
@@ -78,6 +78,28 @@ describe('runtime transport connection errors', () => {
     )
 
     expect(failure).toMatchObject({ code: 'runtime_unavailable' })
+  })
+})
+
+describe('local TCP fallback admission', () => {
+  const denied = new RuntimeClientError('runtime_permission_denied', 'denied')
+
+  it('admits only a loopback fallback after named-pipe permission denial', () => {
+    expect(shouldUseLocalTcpFallback(denied, 'named-pipe', 'tcp://127.0.0.1:54321')).toBe(true)
+  })
+
+  it.each([
+    [
+      new RuntimeClientError('runtime_unavailable', 'missing'),
+      'named-pipe',
+      'tcp://127.0.0.1:54321'
+    ],
+    [denied, 'unix', 'tcp://127.0.0.1:54321'],
+    [denied, 'named-pipe', 'tcp://0.0.0.0:54321'],
+    [denied, 'named-pipe', 'tcp://127.0.0.1:0'],
+    [denied, 'named-pipe', undefined]
+  ] as const)('rejects a non-permission or non-loopback fallback', (error, kind, endpoint) => {
+    expect(shouldUseLocalTcpFallback(error, kind, endpoint)).toBe(false)
   })
 })
 

--- a/src/cli/runtime/transport.ts
+++ b/src/cli/runtime/transport.ts
@@ -19,18 +19,36 @@ export async function sendRequest<TResult>(
       `Runtime request timeout must be an integer between 0 and ${MAX_TIMER_DELAY_MS}ms.`
     )
   }
-  return await new Promise((resolve, reject) => {
-    const transport = findTransport(metadata, 'unix', 'named-pipe')
-    if (!transport) {
-      reject(
-        new RuntimeClientError(
-          'runtime_unavailable',
-          'No compatible transport found in Orca runtime metadata.'
-        )
-      )
-      return
+  const primary = findTransport(metadata, 'unix', 'named-pipe')
+  if (!primary) {
+    throw new RuntimeClientError(
+      'runtime_unavailable',
+      'No compatible transport found in Orca runtime metadata.'
+    )
+  }
+  try {
+    return await sendRequestUsingTransport(metadata, primary, method, params, timeoutMs, envelope)
+  } catch (error) {
+    const fallback = findTransport(metadata, 'local-tcp')
+    if (!shouldUseLocalTcpFallback(error, primary.kind, fallback?.endpoint)) {
+      throw error
     }
-    const socket = createConnection(transport.endpoint)
+    return await sendRequestUsingTransport(metadata, fallback!, method, params, timeoutMs, envelope)
+  }
+}
+
+function sendRequestUsingTransport<TResult>(
+  metadata: RuntimeMetadata,
+  transport: RuntimeMetadata['transports'][number],
+  method: string,
+  params: unknown,
+  timeoutMs: number,
+  envelope?: RuntimeOrchestrationEnvelope
+): Promise<RuntimeRpcResponse<TResult>> {
+  return new Promise((resolve, reject) => {
+    const endpoint = resolveLocalTransportEndpoint(transport)
+    const socket =
+      typeof endpoint === 'string' ? createConnection(endpoint) : createConnection(endpoint)
     let buffer = ''
     let settled = false
     const requestId = randomUUID()
@@ -211,4 +229,37 @@ export function mapRuntimeConnectError(
       ...(error.syscall ? { syscall: error.syscall } : {})
     }
   )
+}
+
+export function shouldUseLocalTcpFallback(
+  error: unknown,
+  primaryKind: RuntimeMetadata['transports'][number]['kind'],
+  fallbackEndpoint: string | undefined
+): boolean {
+  const endpointMatch = fallbackEndpoint
+    ? /^tcp:\/\/127\.0\.0\.1:(\d+)$/.exec(fallbackEndpoint)
+    : null
+  const port = endpointMatch ? Number(endpointMatch[1]) : 0
+  return (
+    primaryKind === 'named-pipe' &&
+    error instanceof RuntimeClientError &&
+    error.code === 'runtime_permission_denied' &&
+    Number.isInteger(port) &&
+    port >= 1 &&
+    port <= 65535
+  )
+}
+
+function resolveLocalTransportEndpoint(
+  transport: RuntimeMetadata['transports'][number]
+): string | { host: '127.0.0.1'; port: number } {
+  if (transport.kind !== 'local-tcp') {
+    return transport.endpoint
+  }
+  const match = /^tcp:\/\/127\.0\.0\.1:(\d+)$/.exec(transport.endpoint)
+  const port = match ? Number(match[1]) : 0
+  if (!match || !Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new RuntimeClientError('runtime_unavailable', 'Invalid local TCP runtime endpoint.')
+  }
+  return { host: '127.0.0.1', port }
 }

--- a/src/main/runtime/rpc/unix-socket-transport.test.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.test.ts
@@ -75,3 +75,16 @@ describe('UnixSocketTransport', () => {
     expect(socket.writes).toHaveLength(1)
   })
 })
+
+describe('loopback TCP transport', () => {
+  it('binds an OS-assigned port only on IPv4 loopback', async () => {
+    const transport = new UnixSocketTransport({
+      endpoint: { host: '127.0.0.1', port: 0 },
+      kind: 'local-tcp'
+    })
+
+    await transport.start()
+    expect(transport.resolvedEndpoint).toMatch(/^tcp:\/\/127\.0\.0\.1:\d+$/)
+    await transport.stop()
+  })
+})

--- a/src/main/runtime/rpc/unix-socket-transport.ts
+++ b/src/main/runtime/rpc/unix-socket-transport.ts
@@ -1,5 +1,5 @@
-// Why: this is the original Unix socket / named pipe transport extracted from
-// runtime-rpc.ts. It preserves the exact same behavior: newline-delimited JSON,
+// Why: local Unix, named-pipe, and loopback TCP endpoints share one authenticated
+// newline-delimited RPC lifecycle instead of drifting across fallback transports:
 // 30s idle timeout, 1MB max message, 32 max connections, chmod 0o600 on Unix.
 // It also owns the keepalive timer and per-connection abort signal so the
 // server-side handler can cancel long-poll dispatches when the client goes
@@ -14,8 +14,8 @@ const MAX_RUNTIME_RPC_CONNECTIONS = 32
 const DEFAULT_KEEPALIVE_INTERVAL_MS = 10_000
 
 export type UnixSocketTransportOptions = {
-  endpoint: string
-  kind: 'unix' | 'named-pipe'
+  endpoint: string | { host: '127.0.0.1'; port: number }
+  kind: 'unix' | 'named-pipe' | 'local-tcp'
   // Why: how often to write `{"_keepalive":true}\n` frames while a dispatch
   // is pending. Each write resets both the server-side idle timer and, once
   // the client honours them, the client-side idle timer. Tests override this
@@ -30,8 +30,8 @@ type MessageHandler = (
 ) => void
 
 export class UnixSocketTransport implements RpcTransport {
-  private readonly endpoint: string
-  private readonly kind: 'unix' | 'named-pipe'
+  private readonly endpoint: string | { host: '127.0.0.1'; port: number }
+  private readonly kind: 'unix' | 'named-pipe' | 'local-tcp'
   private readonly keepaliveIntervalMs: number
   private server: Server | null = null
   private messageHandler: MessageHandler | null = null
@@ -47,12 +47,23 @@ export class UnixSocketTransport implements RpcTransport {
     this.messageHandler = handler
   }
 
+  get resolvedEndpoint(): string {
+    if (this.kind !== 'local-tcp') {
+      return String(this.endpoint)
+    }
+    const address = this.server?.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('Loopback TCP transport is not listening.')
+    }
+    return `tcp://127.0.0.1:${address.port}`
+  }
+
   async start(): Promise<void> {
     if (this.server) {
       return
     }
 
-    if (this.kind === 'unix' && existsSync(this.endpoint)) {
+    if (this.kind === 'unix' && typeof this.endpoint === 'string' && existsSync(this.endpoint)) {
       rmSync(this.endpoint, { force: true })
     }
 
@@ -63,13 +74,17 @@ export class UnixSocketTransport implements RpcTransport {
 
     await new Promise<void>((resolve, reject) => {
       server.once('error', reject)
-      server.listen(this.endpoint, () => {
+      const listenTarget =
+        this.kind === 'local-tcp' && typeof this.endpoint !== 'string'
+          ? this.endpoint
+          : String(this.endpoint)
+      server.listen(listenTarget, () => {
         server.off('error', reject)
         resolve()
       })
     })
 
-    if (this.kind === 'unix') {
+    if (this.kind === 'unix' && typeof this.endpoint === 'string') {
       chmodSync(this.endpoint, 0o600)
     }
 
@@ -97,7 +112,7 @@ export class UnixSocketTransport implements RpcTransport {
       socket.destroy()
     }
     await closePromise
-    if (this.kind === 'unix' && existsSync(this.endpoint)) {
+    if (this.kind === 'unix' && typeof this.endpoint === 'string' && existsSync(this.endpoint)) {
       rmSync(this.endpoint, { force: true })
     }
   }

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -1140,32 +1140,47 @@ export class OrcaRuntimeRpcServer {
       keepaliveIntervalMs: this.keepaliveIntervalMs
     })
 
-    // Why: the `.catch` guarantees reply() always fires so a throw can't strand the client or leak the AbortController.
-    socketTransport.onMessage((msg, reply, context) => {
-      void this.handleMessage(msg, context)
-        .then((response) => {
-          reply(JSON.stringify(response))
-        })
-        .catch((error) => {
-          const message = error instanceof Error ? error.message : String(error)
-          // Why: best-effort id recovery so the client can correlate the error frame to its pending request.
-          let id = 'unknown'
-          try {
-            const parsed = JSON.parse(msg) as { id?: unknown }
-            if (typeof parsed.id === 'string' && parsed.id.length > 0) {
-              id = parsed.id
+    const attachLocalHandler = (transport: UnixSocketTransport): void => {
+      transport.onMessage((msg, reply, context) => {
+        void this.handleMessage(msg, context)
+          .then((response) => reply(JSON.stringify(response)))
+          .catch((error) => {
+            const message = error instanceof Error ? error.message : String(error)
+            let id = 'unknown'
+            try {
+              const parsed = JSON.parse(msg) as { id?: unknown }
+              if (typeof parsed.id === 'string' && parsed.id.length > 0) {
+                id = parsed.id
+              }
+            } catch {
+              // Best-effort id recovery.
             }
-          } catch {
-            // ignore — fall through with id='unknown'
-          }
-          reply(JSON.stringify(this.buildError(id, 'internal_error', message)))
-        })
-    })
+            reply(JSON.stringify(this.buildError(id, 'internal_error', message)))
+          })
+      })
+    }
+    attachLocalHandler(socketTransport)
 
     await socketTransport.start()
 
     const activeTransports: RpcTransport[] = [socketTransport]
     const transportsMeta: RuntimeTransportMetadata[] = [transportMeta]
+
+    if (this.platform === 'win32') {
+      const tcpTransport = new UnixSocketTransport({
+        endpoint: { host: '127.0.0.1', port: 0 },
+        kind: 'local-tcp',
+        keepaliveIntervalMs: this.keepaliveIntervalMs
+      })
+      attachLocalHandler(tcpTransport)
+      try {
+        await tcpTransport.start()
+        activeTransports.push(tcpTransport)
+        transportsMeta.push({ kind: 'local-tcp', endpoint: tcpTransport.resolvedEndpoint })
+      } catch (error) {
+        console.error('[runtime] Failed to start local TCP fallback transport:', error)
+      }
+    }
 
     // Why: WebSocket uses per-device tokens + E2EE (tweetnacl) instead of TLS since React Native can't pin self-signed certs.
     if (this.enableWebSocket) {

--- a/src/shared/runtime-bootstrap.ts
+++ b/src/shared/runtime-bootstrap.ts
@@ -13,6 +13,10 @@ export type RuntimeTransportMetadata =
       kind: 'websocket'
       endpoint: string
     }
+  | {
+      kind: 'local-tcp'
+      endpoint: string
+    }
 
 export type RuntimeMetadata = {
   runtimeId: string


### PR DESCRIPTION
## Summary

- publish a random-port IPv4 loopback RPC transport on Windows while keeping the named pipe primary
- retry through that endpoint only when the named-pipe connection fails with `EPERM`/`EACCES`
- reuse the runtime ID and auth-token RPC envelope; reject non-loopback and invalid endpoints

## Review structure

This is stacked on maintainer diagnostics/status PR #16697 (`b64b2890f2`) so this PR's diff contains only the six fallback files. Once #16697 lands, this branch can be rebased and retargeted to `main` without carrying duplicate diagnostics code.

## Security and scope

This is a best-effort compatibility path for restricted Windows clients. It is not a native named-pipe DACL fix and does not bind to LAN interfaces. The server listens on `127.0.0.1` with an OS-assigned port, and the existing per-runtime auth token remains mandatory.

Loopback availability differs by sandbox policy: the linked issue reporter's environment blocks it while the Surface reproduction used for this PR had a successful direct loopback positive control. No installed binary, runtime, pane, or environment variable was changed.

## Verification (Node 24.15.0, Windows)

Stacked head `825de6fe6315add027c8d956f297049292bc8416`.

- five focused suites including #16697 status tests and metadata lifecycle: 64 passed, 3 existing Windows Unix-socket skips
- `pnpm run tc:node`: passed
- `pnpm run tc:cli`: passed
- changed-file oxlint: passed
- `git diff --check`: passed

## Operational status

`CODE_VERIFIED / LIVE_UNVERIFIED / NO_CUTOVER`

Live Orca↔Herdr ACK/completion and the installed Surface binary remain unchanged until an approved build/cutover.
