### PR TITLE
fix(jira): size issue list columns by panel width, not viewport

### DIFF
--- a/src/renderer/src/components/task-page-jira-issue-list.tsx
+++ b/src/renderer/src/components/task-page-jira-issue-list.tsx
@@ -126,24 +126,24 @@ function JiraIssueRow({
         }
       }}
       className={cn(
-        'group/row grid min-h-12 cursor-pointer grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-3 py-2 text-left transition hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring md:grid-cols-[90px_minmax(0,1fr)_128px_92px_80px_64px] lg:grid-cols-[96px_minmax(0,1.25fr)_132px_120px_136px_96px_64px] xl:grid-cols-[104px_minmax(0,1.45fr)_144px_132px_160px_128px_72px]',
+        'group/row grid min-h-12 cursor-pointer grid-cols-[minmax(0,1fr)_auto] items-center gap-3 px-3 py-2 text-left transition hover:bg-accent focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring @3xl:grid-cols-[90px_minmax(0,1fr)_128px_92px_80px_64px] @5xl:grid-cols-[96px_minmax(0,1.25fr)_132px_120px_136px_96px_64px] @7xl:grid-cols-[104px_minmax(0,1.45fr)_144px_132px_160px_128px_72px]',
         selected && 'bg-accent'
       )}
     >
-      <span className="block truncate font-mono text-[12px] text-muted-foreground max-md:!hidden">
+      <span className="block truncate font-mono text-[12px] text-muted-foreground @max-3xl:!hidden">
         {issue.key}
       </span>
 
       <div className="min-w-0">
         <div className="flex min-w-0 items-center gap-2">
-          <span className="shrink-0 font-mono text-[11px] text-muted-foreground md:hidden">
+          <span className="shrink-0 font-mono text-[11px] text-muted-foreground @3xl:hidden">
             {issue.key}
           </span>
           <h3 className="min-w-0 truncate text-[13px] font-medium text-foreground">
             {issue.title}
           </h3>
         </div>
-        <div className="mt-1 flex min-w-0 items-center gap-1.5 md:!hidden">
+        <div className="mt-1 flex min-w-0 items-center gap-1.5 @3xl:!hidden">
           <span
             className={cn(
               'inline-flex min-w-0 items-center rounded-full border px-1.5 py-0.5 text-[11px] font-medium',
@@ -161,8 +161,8 @@ function JiraIssueRow({
               translate('auto.components.TaskPage.42a9160321', 'Unassigned')}
           </span>
         </div>
-        <div className="mt-1 flex min-w-0 items-center gap-1 max-lg:!hidden">
-          <span className="max-w-[160px] truncate text-[10px] text-muted-foreground xl:!hidden">
+        <div className="mt-1 flex min-w-0 items-center gap-1 @max-5xl:!hidden">
+          <span className="max-w-[160px] truncate text-[10px] text-muted-foreground @7xl:!hidden">
             {contextLabel}
           </span>
           {labels.map((label) => (
@@ -181,7 +181,7 @@ function JiraIssueRow({
         </div>
       </div>
 
-      <div className="flex min-w-0 max-md:!hidden">
+      <div className="flex min-w-0 @max-3xl:!hidden">
         <span
           className={cn(
             'inline-flex max-w-full items-center rounded-full border px-2 py-0.5 text-[11px] font-medium',
@@ -192,11 +192,11 @@ function JiraIssueRow({
         </span>
       </div>
 
-      <span className="block truncate text-[12px] text-muted-foreground max-md:!hidden">
+      <span className="block truncate text-[12px] text-muted-foreground @max-3xl:!hidden">
         {issue.priority?.name ?? translate('auto.components.TaskPage.713179dfdc', 'No priority')}
       </span>
 
-      <div className="flex min-w-0 items-center gap-2 text-[12px] text-muted-foreground max-lg:!hidden">
+      <div className="flex min-w-0 items-center gap-2 text-[12px] text-muted-foreground @max-5xl:!hidden">
         {issue.assignee?.avatarUrl ? (
           <img
             src={issue.assignee.avatarUrl}
@@ -216,7 +216,7 @@ function JiraIssueRow({
 
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="block min-w-0 truncate text-[12px] text-muted-foreground max-md:!hidden">
+          <div className="block min-w-0 truncate text-[12px] text-muted-foreground @max-3xl:!hidden">
             {formatUpdatedAt(issue.updatedAt)}
           </div>
         </TooltipTrigger>
@@ -225,7 +225,7 @@ function JiraIssueRow({
         </TooltipContent>
       </Tooltip>
 
-      <div className="flex shrink-0 items-center justify-end gap-1 md:opacity-0 md:transition-opacity md:group-hover/row:opacity-100 md:group-focus-within/row:opacity-100">
+      <div className="flex shrink-0 items-center justify-end gap-1 @3xl:opacity-0 @3xl:transition-opacity @3xl:group-hover/row:opacity-100 @3xl:group-focus-within/row:opacity-100">
         <Tooltip>
           <TooltipTrigger asChild>
             <Button

--- a/src/renderer/src/components/task-page-jira-sort-controls.test.tsx
+++ b/src/renderer/src/components/task-page-jira-sort-controls.test.tsx
@@ -33,7 +33,7 @@ describe('TaskPage Jira sort controls', () => {
       'aria-pressed',
       'true'
     )
-    expect(screen.getByRole('button', { name: 'Assignee' })).toHaveClass('flex', 'max-lg:!hidden')
+    expect(screen.getByRole('button', { name: 'Assignee' })).toHaveClass('flex', '@max-5xl:!hidden')
     expect(screen.getByRole('button', { name: 'Assignee' })).not.toHaveClass('block')
 
     await user.click(screen.getByRole('button', { name: 'Key' }))
@@ -45,7 +45,7 @@ describe('TaskPage Jira sort controls', () => {
     const onSort = vi.fn()
     renderControls(onSort)
 
-    expect(screen.getByTestId('jira-mobile-sort-controls')).toHaveClass('hidden', 'max-md:!flex')
+    expect(screen.getByTestId('jira-mobile-sort-controls')).toHaveClass('hidden', '@max-3xl:!flex')
     await user.click(screen.getByRole('combobox', { name: 'Sort by' }))
     await user.click(screen.getByRole('option', { name: 'Priority' }))
     expect(onSort).toHaveBeenCalledWith('priority')

--- a/src/renderer/src/components/task-page-jira-sort-controls.tsx
+++ b/src/renderer/src/components/task-page-jira-sort-controls.tsx
@@ -34,7 +34,7 @@ function getJiraSortColumns(): JiraSortColumn[] {
     {
       id: 'assignee',
       label: translate('auto.components.TaskPage.d2a876ca53', 'Assignee'),
-      className: 'max-lg:!hidden'
+      className: '@max-5xl:!hidden'
     },
     { id: 'updated', label: translate('auto.components.TaskPage.f362667d55', 'Updated') }
   ]
@@ -63,7 +63,7 @@ export function TaskPageJiraSortControls({
 
   return (
     <>
-      <div className="grid h-8 flex-none grid-cols-[90px_minmax(0,1fr)_128px_92px_80px_64px] items-center gap-3 border-b border-border/50 bg-muted/25 px-3 text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground max-md:!hidden lg:grid-cols-[96px_minmax(0,1.25fr)_132px_120px_136px_96px_64px] xl:grid-cols-[104px_minmax(0,1.45fr)_144px_132px_160px_128px_72px]">
+      <div className="grid h-8 flex-none grid-cols-[90px_minmax(0,1fr)_128px_92px_80px_64px] items-center gap-3 border-b border-border/50 bg-muted/25 px-3 text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground @max-3xl:!hidden @5xl:grid-cols-[96px_minmax(0,1.25fr)_132px_120px_136px_96px_64px] @7xl:grid-cols-[104px_minmax(0,1.45fr)_144px_132px_160px_128px_72px]">
         {columns.map((column) => (
           <button
             key={column.id}
@@ -90,7 +90,7 @@ export function TaskPageJiraSortControls({
 
       <div
         data-testid="jira-mobile-sort-controls"
-        className="hidden h-10 flex-none items-center gap-2 border-b border-border/50 bg-muted/25 px-3 max-md:!flex"
+        className="hidden h-10 flex-none items-center gap-2 border-b border-border/50 bg-muted/25 px-3 @max-3xl:!flex"
       >
         <span className="shrink-0 text-[11px] font-semibold tracking-[0.05em] text-muted-foreground uppercase">
           {sortByLabel}

--- a/src/renderer/src/components/task-page/jira/jira-issue-list-host.tsx
+++ b/src/renderer/src/components/task-page/jira/jira-issue-list-host.tsx
@@ -101,7 +101,7 @@ export function JiraIssueListHost({
   }
 
   return (
-    <div className="flex min-h-0 max-h-full flex-col overflow-hidden rounded-md rounded-t-none border border-t-0 border-border/50 bg-background shadow-sm">
+    <div className="@container flex min-h-0 max-h-full flex-col overflow-hidden rounded-md rounded-t-none border border-t-0 border-border/50 bg-background shadow-sm">
       <div className="flex h-10 flex-none items-center justify-between gap-3 border-b border-border/50 bg-muted/35 px-3">
         <div className="min-w-0 text-[11px] font-medium uppercase tracking-[0.12em] text-muted-foreground">
           {translate('auto.components.TaskPage.63b2abd3aa', 'Jira issues')}


### PR DESCRIPTION
## ELI5

On a portrait screen the Jira task list squeezed the issue title down to a few characters because it was choosing its column widths based on how wide the *window* is, not how wide the *panel* is. It now measures the panel.

## What Changed

- Mark the Jira list container as a CSS container (`@container`) in `jira-issue-list-host.tsx`.
- Replace the viewport variants `md:` / `lg:` / `xl:` (and `max-md:` / `max-lg:`) in the Jira header and row grid with the container-query variants `@3xl:` / `@5xl:` / `@7xl:` (`@max-3xl:` / `@max-5xl:`). These map to the same 768 / 1024 / 1280px thresholds, so behavior is unchanged when the panel is as wide as the window.
- Update the existing sort-controls test to assert the new class names.

## Why

The grid tracks are fixed px widths (up to ~740px of fixed columns at `xl`). When the panel is ~780px wide inside a wider window — a portrait display, or the sidebar plus a detail pane — the `xl` tracks apply and the only flexible track (the issue title) collapses to ~40px. Measuring the panel with container queries is the smallest change that fixes this without touching the column design; Tailwind v4 ships container queries natively, so no new dependency.

## Linked Issue

Fixes #16625

## Visual Proof

Before / after on a portrait display (panel ≈ 780px wide):

<!-- before: title column truncated to 3-4 chars -->
<img width="830" height="1832" alt="Capture d’écran 2026-08-26 à 14 02 42" src="https://github.com/user-attachments/assets/86f24a31-57c3-4a0d-b660-3563415524db" />

<!-- after: compact layout, full titles -->
<img width="1067" height="1839" alt="Capture d’écran 2026-08-26 à 14 16 22" src="https://github.com/user-attachments/assets/97d0cde9-1486-4541-b7e0-30c8c5f291ef" />


## Testing

- `pnpm test src/renderer/src/components/task-page-jira-sort-controls.test.tsx` — 2/2
- `pnpm tc:web`
- `pnpm run check:code-quality:changed` — 0 new findings
- Manually tested on macOS (dev build, portrait 1080px-wide display): panel now falls back to the compact layout with full titles; wide window unchanged.
- Not tested on Linux / Windows / SSH — pure CSS change in the renderer, no platform-specific code path.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Diagnosis and patch drafted with Claude Code (Claude Fable 5); reviewed and manually verified by me.

## Review

Self-reviewed. The header grid and row grid must stay in sync — both were updated with the same mapping.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Renderer-only CSS change. No wire, SSH, mobile, or persistence impact. `@container` on the list host has no effect on the GitHub / Linear task surfaces.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)