### PR TITLE
fix(checks): distinguish action-required PRs from failures

### DIFF
--- a/mobile/src/components/pr-sidebar/pr-checks-presentation.test.ts
+++ b/mobile/src/components/pr-sidebar/pr-checks-presentation.test.ts
@@ -33,8 +33,8 @@ describe('checkOutcome', () => {
     expect(checkOutcome(check({ conclusion: 'cancelled' }))).toBe('failure')
     expect(checkOutcome(check({ conclusion: 'timed_out' }))).toBe('failure')
   })
-  it('maps a merge-blocking action_required gate to failure', () => {
-    expect(checkOutcome(check({ conclusion: 'action_required' }))).toBe('failure')
+  it('maps a merge-blocking action_required gate to its amber presentation state', () => {
+    expect(checkOutcome(check({ conclusion: 'action_required' }))).toBe('action_required')
   })
   it('maps skipped to success and neutral to neutral (desktop parity)', () => {
     expect(checkOutcome(check({ conclusion: 'skipped' }))).toBe('success')
@@ -134,6 +134,36 @@ describe('summarizePRChecks', () => {
     ])
     expect(summary).toMatchObject({ total: 3, passed: 3, outcome: 'success' })
     expect(summary.label).toBe('3 passed')
+  })
+
+  it('separates action-required checks from genuine failures', () => {
+    const summary = summarizePRChecks([
+      check({ conclusion: 'success' }),
+      check({ conclusion: 'action_required' })
+    ])
+
+    expect(summary).toMatchObject({
+      total: 2,
+      passed: 1,
+      failed: 0,
+      actionRequired: 1,
+      outcome: 'action_required'
+    })
+    expect(summary.label).toBe('Action required: 1 · 1 passed')
+  })
+
+  it('keeps genuine failures as the worst outcome alongside action-required checks', () => {
+    const summary = summarizePRChecks([
+      check({ conclusion: 'failure' }),
+      check({ conclusion: 'action_required' })
+    ])
+
+    expect(summary).toMatchObject({
+      failed: 1,
+      actionRequired: 1,
+      outcome: 'failure'
+    })
+    expect(summary.label).toBe('1 failing · Action required: 1')
   })
 })
 

--- a/mobile/src/components/pr-sidebar/pr-checks-presentation.ts
+++ b/mobile/src/components/pr-sidebar/pr-checks-presentation.ts
@@ -1,10 +1,12 @@
 import type { PRCheckDetail } from '../../../../src/shared/github/check-types'
 import type {
-  PRState,
-  ProviderCheckSummary
+  CheckPresentationStatus,
+  PRState
 } from '../../../../src/shared/github/pull-request-types'
 import {
   classifyCheckOutcome,
+  getProviderCheckFailureCount,
+  getProviderChecksPresentationState,
   summarizeProviderChecks,
   type CheckOutcome as SharedCheckOutcome
 } from '../../../../src/shared/provider-check-summary'
@@ -25,11 +27,12 @@ export type MobileStatusToken =
   | 'statusPurple'
   | 'textSecondary'
 
-export type CheckOutcome = 'success' | 'pending' | 'failure' | 'neutral'
+export type CheckOutcome = CheckPresentationStatus
 
 const OUTCOME_BY_SHARED: Record<SharedCheckOutcome, CheckOutcome> = {
   passed: 'success',
   failed: 'failure',
+  action_required: 'action_required',
   pending: 'pending',
   neutral: 'neutral'
 }
@@ -41,13 +44,14 @@ export function checkOutcome(check: PRCheckDetail): CheckOutcome {
   return OUTCOME_BY_SHARED[classifyCheckOutcome(check)]
 }
 
-// Sort order: failures first (most actionable), then pending, then success /
-// neutral. Stable within a bucket so the upstream ordering is preserved.
+// Sort order: failures first (most actionable), then action required, pending,
+// and resolved checks. Stable within a bucket so upstream ordering is preserved.
 const OUTCOME_RANK: Record<CheckOutcome, number> = {
   failure: 0,
-  pending: 1,
-  neutral: 2,
-  success: 3
+  action_required: 1,
+  pending: 2,
+  neutral: 3,
+  success: 4
 }
 
 export function sortPRChecks(checks: readonly PRCheckDetail[]): PRCheckDetail[] {
@@ -62,29 +66,36 @@ export type PRChecksSummary = {
   passed: number
   pending: number
   failed: number
+  actionRequired: number
   // Worst-case outcome across all checks, for the summary badge color.
   outcome: CheckOutcome | 'none'
   label: string
 }
 
-const OUTCOME_BY_STATE: Record<ProviderCheckSummary['state'], CheckOutcome | 'none'> = {
-  success: 'success',
-  failure: 'failure',
-  pending: 'pending',
-  neutral: 'neutral',
-  none: 'none'
-}
-
 export function summarizePRChecks(checks: readonly PRCheckDetail[]): PRChecksSummary {
   if (checks.length === 0) {
-    return { total: 0, passed: 0, pending: 0, failed: 0, outcome: 'none', label: 'No checks' }
+    return {
+      total: 0,
+      passed: 0,
+      pending: 0,
+      failed: 0,
+      actionRequired: 0,
+      outcome: 'none',
+      label: 'No checks'
+    }
   }
   // Counts and the worst-case rollup come from the shared summarizer; only the label wording is mobile's.
-  const { total, passed, pending, failed, neutral, state } = summarizeProviderChecks(checks)
-  const outcome = OUTCOME_BY_STATE[state]
+  const summary = summarizeProviderChecks(checks)
+  const { total, passed, pending, neutral } = summary
+  const failed = getProviderCheckFailureCount(summary)
+  const actionRequired = summary.actionRequired ?? 0
+  const outcome = getProviderChecksPresentationState(summary) ?? 'none'
   const parts: string[] = []
   if (failed > 0) {
     parts.push(`${failed} failing`)
+  }
+  if (actionRequired > 0) {
+    parts.push(`Action required: ${actionRequired}`)
   }
   if (pending > 0) {
     parts.push(`${pending} pending`)
@@ -100,6 +111,7 @@ export function summarizePRChecks(checks: readonly PRCheckDetail[]): PRChecksSum
     passed,
     pending,
     failed,
+    actionRequired,
     outcome,
     label: parts.join(' · ')
   }
@@ -136,6 +148,7 @@ export function checkOutcomeToken(outcome: CheckOutcome | 'none'): MobileStatusT
     case 'success':
       return 'statusGreen'
     case 'pending':
+    case 'action_required':
       return 'statusAmber'
     case 'failure':
       return 'statusRed'

--- a/mobile/src/session/github-pr-value-readers.test.ts
+++ b/mobile/src/session/github-pr-value-readers.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { classifyCheckOutcome } from '../../../src/shared/provider-check-summary'
-import { readCheckRunConclusion, readRepoIdentity } from './github-pr-value-readers'
+import {
+  readCheckRunConclusion,
+  readCheckSummary,
+  readRepoIdentity
+} from './github-pr-value-readers'
 
 describe('readRepoIdentity', () => {
   it('parses a valid owner/repo identity', () => {
@@ -41,15 +45,38 @@ describe('readCheckRunConclusion', () => {
     }
   })
 
-  // Why: dropping this made a merge-blocking approval gate render as a harmless pending check.
-  it('keeps action_required so it still classifies as a failure', () => {
+  it('keeps action_required as a distinct presentation outcome', () => {
     const conclusion = readCheckRunConclusion('action_required')
     expect(conclusion).toBe('action_required')
-    expect(classifyCheckOutcome({ status: 'completed', conclusion })).toBe('failed')
+    expect(classifyCheckOutcome({ status: 'completed', conclusion })).toBe('action_required')
   })
 
   it('drops an unknown conclusion', () => {
     expect(readCheckRunConclusion('wat')).toBeNull()
     expect(readCheckRunConclusion(null)).toBeNull()
+  })
+})
+
+describe('readCheckSummary', () => {
+  it('preserves the optional action-required count across the RPC boundary', () => {
+    expect(
+      readCheckSummary({
+        state: 'failure',
+        total: 2,
+        passed: 1,
+        failed: 1,
+        actionRequired: 1,
+        pending: 0,
+        neutral: 0
+      })
+    ).toEqual({
+      state: 'failure',
+      total: 2,
+      passed: 1,
+      failed: 1,
+      actionRequired: 1,
+      pending: 0,
+      neutral: 0
+    })
   })
 })

--- a/mobile/src/session/github-pr-value-readers.ts
+++ b/mobile/src/session/github-pr-value-readers.ts
@@ -199,12 +199,14 @@ export function readCheckSummary(value: unknown): ProviderCheckSummary | undefin
   ) {
     return undefined
   }
+  const actionRequired = readNumber(value.actionRequired)
   return {
     state,
     total: readNumber(value.total) ?? 0,
     passed: readNumber(value.passed) ?? 0,
     failed: readNumber(value.failed) ?? 0,
     pending: readNumber(value.pending) ?? 0,
-    neutral: readNumber(value.neutral) ?? 0
+    neutral: readNumber(value.neutral) ?? 0,
+    ...(actionRequired !== undefined ? { actionRequired } : {})
   }
 }

--- a/mobile/src/source-control/MobileSourceControlPrChip.tsx
+++ b/mobile/src/source-control/MobileSourceControlPrChip.tsx
@@ -93,6 +93,8 @@ function RollupIcon({ kind, color }: { kind: MobilePrChipRollup['kind']; color: 
       return <AlertTriangle size={size} color={color} strokeWidth={strokeWidth} />
     case 'failing':
       return <X size={size} color={color} strokeWidth={strokeWidth} />
+    case 'action_required':
+      return <AlertTriangle size={size} color={color} strokeWidth={strokeWidth} />
     case 'running':
       return <CircleDot size={size} color={color} strokeWidth={strokeWidth} />
     case 'passed':

--- a/mobile/src/source-control/mobile-pr-chip-summary.test.ts
+++ b/mobile/src/source-control/mobile-pr-chip-summary.test.ts
@@ -65,9 +65,23 @@ describe('buildMobilePrChipSummary', () => {
     expect(summary.rollup).toEqual({ kind: 'passed', text: '3/3', token: 'statusGreen' })
   })
 
-  it('treats a merge-blocking action_required gate as failing, not passing', () => {
+  it('presents a merge-blocking action_required gate as an amber manual action', () => {
     const summary = buildMobilePrChipSummary(
       ready(pr(), [check('success'), check('action_required')])
+    )
+    if (summary.kind !== 'ready') {
+      throw new Error('expected ready')
+    }
+    expect(summary.rollup).toEqual({
+      kind: 'action_required',
+      text: 'Action required: 1',
+      token: 'statusAmber'
+    })
+  })
+
+  it('keeps genuine failures red when action is also required', () => {
+    const summary = buildMobilePrChipSummary(
+      ready(pr(), [check('failure'), check('action_required')])
     )
     if (summary.kind !== 'ready') {
       throw new Error('expected ready')

--- a/mobile/src/source-control/mobile-pr-chip-summary.ts
+++ b/mobile/src/source-control/mobile-pr-chip-summary.ts
@@ -1,6 +1,11 @@
 import type { PRComment } from '../../../src/shared/github/comment-types'
 import type { PrSidebarState } from '../session/mobile-pr-sidebar-state'
-import { summarizeProviderChecks } from '../../../src/shared/provider-check-summary'
+import {
+  getProviderCheckFailureCount,
+  getProviderChecksLabel,
+  getProviderChecksPresentationState,
+  summarizeProviderChecks
+} from '../../../src/shared/provider-check-summary'
 import {
   prStateBadge,
   type MobileStatusToken
@@ -12,11 +17,12 @@ import {
 // check rollup can never disagree with the checks list it links to.
 
 // The single check-rollup token the chip shows. Exactly one wins, by precedence:
-// merge conflict > failing > running > passed > no checks. Worst-actionable-first
+// merge conflict > failing > action required > running > passed > no checks. Worst-actionable-first
 // so a red/amber signal is never hidden behind a green count.
 export type MobilePrChipRollup =
   | { kind: 'conflict'; text: string; token: MobileStatusToken }
   | { kind: 'failing'; text: string; token: MobileStatusToken }
+  | { kind: 'action_required'; text: string; token: MobileStatusToken }
   | { kind: 'running'; text: string; token: MobileStatusToken }
   | { kind: 'passed'; text: string; token: MobileStatusToken }
   | { kind: 'none'; text: string; token: MobileStatusToken }
@@ -92,10 +98,22 @@ function buildChipRollup(state: Extract<PrSidebarState, { kind: 'ready' }>): Mob
   }
   // Shared classifier so the chip, the Checks list and the tasks grid never disagree about the same PR.
   const checks = summarizeProviderChecks(state.data.checks)
-  if (checks.failed > 0) {
-    return { kind: 'failing', text: `${checks.failed} failing`, token: 'statusRed' }
+  const presentationState = getProviderChecksPresentationState(checks)
+  if (presentationState === 'failure') {
+    return {
+      kind: 'failing',
+      text: `${getProviderCheckFailureCount(checks)} failing`,
+      token: 'statusRed'
+    }
   }
-  if (checks.pending > 0) {
+  if (presentationState === 'action_required') {
+    return {
+      kind: 'action_required',
+      text: getProviderChecksLabel(checks),
+      token: 'statusAmber'
+    }
+  }
+  if (presentationState === 'pending') {
     return { kind: 'running', text: `${checks.pending} running`, token: 'statusAmber' }
   }
   if (checks.passed > 0) {

--- a/mobile/src/tasks/github-check-summary.test.ts
+++ b/mobile/src/tasks/github-check-summary.test.ts
@@ -108,7 +108,14 @@ const PARITY_CASES: ParityCase[] = [
   {
     name: 'genuine action_required',
     checks: [completed('success'), completed('action_required')],
-    expected: { state: 'failure', passed: 1, failed: 1, pending: 0, neutral: 0 }
+    expected: {
+      state: 'failure',
+      passed: 1,
+      failed: 1,
+      actionRequired: 1,
+      pending: 0,
+      neutral: 0
+    }
   }
 ]
 

--- a/mobile/src/tasks/mobile-hosted-check-status.test.ts
+++ b/mobile/src/tasks/mobile-hosted-check-status.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import type { HostedReviewDecision } from '../../../src/shared/hosted-review'
 import {
   getHostedChecksLabel,
+  getHostedMergeLabel,
   getHostedReviewLabel,
   getHostedReviewSignalTone
 } from './mobile-hosted-check-status'
@@ -33,6 +34,44 @@ describe('mobile hosted check status', () => {
 
     expect(getHostedChecksLabel({ checksSummary: summary })).toBe('Action required: 1')
     expect(getHostedReviewSignalTone({ checksSummary: summary }, 'checks')).toBe('warning')
+  })
+
+  it.each([
+    { name: 'mergeable', merge: { mergeable: 'MERGEABLE' as const } },
+    { name: 'clean', merge: { mergeStateStatus: 'CLEAN' } }
+  ])('keeps an action-required merge signal amber when the PR is $name', ({ merge }) => {
+    const item = {
+      ...merge,
+      checksSummary: {
+        state: 'failure' as const,
+        total: 1,
+        passed: 0,
+        failed: 1,
+        actionRequired: 1,
+        pending: 0,
+        neutral: 0
+      }
+    }
+
+    expect(getHostedMergeLabel(item)).toBe('Action required')
+    expect(getHostedReviewSignalTone(item, 'merge')).toBe('warning')
+  })
+
+  it('keeps a genuine check failure red when the PR is mergeable', () => {
+    const item = {
+      mergeable: 'MERGEABLE' as const,
+      checksSummary: {
+        state: 'failure' as const,
+        total: 1,
+        passed: 0,
+        failed: 1,
+        pending: 0,
+        neutral: 0
+      }
+    }
+
+    expect(getHostedMergeLabel(item)).toBe('Checks failed')
+    expect(getHostedReviewSignalTone(item, 'merge')).toBe('danger')
   })
 
   it('accepts provider-neutral GitHub status fields without a shared work-item type', () => {

--- a/mobile/src/tasks/mobile-hosted-check-status.test.ts
+++ b/mobile/src/tasks/mobile-hosted-check-status.test.ts
@@ -20,6 +20,21 @@ describe('mobile hosted check status', () => {
     expect(getHostedReviewSignalTone({ checksSummary: summary }, 'checks')).toBe('neutral')
   })
 
+  it('renders action-required checks as an amber manual-action state', () => {
+    const summary = {
+      state: 'failure' as const,
+      total: 1,
+      passed: 0,
+      failed: 1,
+      actionRequired: 1,
+      pending: 0,
+      neutral: 0
+    }
+
+    expect(getHostedChecksLabel({ checksSummary: summary })).toBe('Action required: 1')
+    expect(getHostedReviewSignalTone({ checksSummary: summary }, 'checks')).toBe('warning')
+  })
+
   it('accepts provider-neutral GitHub status fields without a shared work-item type', () => {
     expect(
       getHostedReviewSignalTone(

--- a/mobile/src/tasks/mobile-hosted-check-status.ts
+++ b/mobile/src/tasks/mobile-hosted-check-status.ts
@@ -16,6 +16,13 @@ export type MobileHostedReviewStatus = {
   mergeStateStatus?: string | null
 }
 
+type HostedReviewSignalTone = 'neutral' | 'success' | 'warning' | 'danger'
+
+type HostedMergePresentation = {
+  label: string
+  tone: HostedReviewSignalTone
+}
+
 export function getHostedReviewLabel(item: MobileHostedReviewStatus): string {
   if (item.reviewDecision === 'approved' || item.reviewDecision === 'APPROVED') {
     return 'Approved'
@@ -32,17 +39,28 @@ export function getHostedReviewLabel(item: MobileHostedReviewStatus): string {
     : 'No reviewers'
 }
 
-export function getHostedMergeLabel(item: MobileHostedReviewStatus): string {
+function getHostedMergePresentation(item: MobileHostedReviewStatus): HostedMergePresentation {
   if (item.mergeable === 'CONFLICTING' || item.mergeStateStatus === 'BLOCKED') {
-    return 'Conflicts'
+    return { label: 'Conflicts', tone: 'danger' }
   }
-  if (item.mergeStateStatus === 'BEHIND' || item.checksSummary?.state === 'pending') {
-    return 'Behind'
+  const checksState = getProviderChecksPresentationState(item.checksSummary)
+  if (item.mergeStateStatus === 'BEHIND' || checksState === 'pending') {
+    return { label: 'Behind', tone: 'warning' }
+  }
+  if (checksState === 'failure') {
+    return { label: 'Checks failed', tone: 'danger' }
+  }
+  if (checksState === 'action_required') {
+    return { label: 'Action required', tone: 'warning' }
   }
   if (item.mergeable === 'MERGEABLE' || item.mergeStateStatus === 'CLEAN') {
-    return 'Able to merge'
+    return { label: 'Able to merge', tone: 'success' }
   }
-  return 'Unknown'
+  return { label: 'Unknown', tone: 'neutral' }
+}
+
+export function getHostedMergeLabel(item: MobileHostedReviewStatus): string {
+  return getHostedMergePresentation(item).label
 }
 
 export function getHostedChecksLabel(item: { checksSummary?: ProviderCheckSummary }): string {
@@ -52,7 +70,7 @@ export function getHostedChecksLabel(item: { checksSummary?: ProviderCheckSummar
 export function getHostedReviewSignalTone(
   item: MobileHostedReviewStatus,
   signal: 'review' | 'checks' | 'merge'
-): 'neutral' | 'success' | 'warning' | 'danger' {
+): HostedReviewSignalTone {
   if (signal === 'review') {
     if (item.reviewDecision === 'approved' || item.reviewDecision === 'APPROVED') {
       return 'success'
@@ -86,14 +104,5 @@ export function getHostedReviewSignalTone(
     }
     return 'neutral'
   }
-  if (item.mergeable === 'CONFLICTING' || item.mergeStateStatus === 'BLOCKED') {
-    return 'danger'
-  }
-  if (item.mergeStateStatus === 'BEHIND' || item.checksSummary?.state === 'pending') {
-    return 'warning'
-  }
-  if (item.mergeable === 'MERGEABLE' || item.mergeStateStatus === 'CLEAN') {
-    return 'success'
-  }
-  return 'neutral'
+  return getHostedMergePresentation(item).tone
 }

--- a/mobile/src/tasks/mobile-hosted-check-status.ts
+++ b/mobile/src/tasks/mobile-hosted-check-status.ts
@@ -2,7 +2,10 @@ import type {
   PRMergeableState,
   ProviderCheckSummary
 } from '../../../src/shared/github/pull-request-types'
-import { getProviderChecksLabel } from '../../../src/shared/provider-check-summary'
+import {
+  getProviderChecksLabel,
+  getProviderChecksPresentationState
+} from '../../../src/shared/provider-check-summary'
 
 export type MobileHostedReviewStatus = {
   checksSummary?: ProviderCheckSummary
@@ -71,13 +74,14 @@ export function getHostedReviewSignalTone(
     return 'neutral'
   }
   if (signal === 'checks') {
-    if (item.checksSummary?.state === 'success') {
+    const state = getProviderChecksPresentationState(item.checksSummary)
+    if (state === 'success') {
       return 'success'
     }
-    if (item.checksSummary?.state === 'failure') {
+    if (state === 'failure') {
       return 'danger'
     }
-    if (item.checksSummary?.state === 'pending') {
+    if (state === 'action_required' || state === 'pending') {
       return 'warning'
     }
     return 'neutral'

--- a/mobile/src/tasks/mobile-tasks-hosted-review.ts
+++ b/mobile/src/tasks/mobile-tasks-hosted-review.ts
@@ -1,4 +1,5 @@
 import { projectRowType } from './mobile-tasks-item-mapping'
+import { getHostedMergeLabel } from './mobile-hosted-check-status'
 import type {
   HostedReviewItem,
   HostedReviewMergeMethod,
@@ -141,19 +142,10 @@ export function getGitHubMergeLabel(item: GitHubWorkItem): string {
   if (item.state === 'closed') {
     return 'Closed'
   }
-  if (item.mergeable === 'CONFLICTING') {
-    return 'Conflicts'
-  }
-  if (item.mergeStateStatus === 'BEHIND') {
-    return 'Behind'
-  }
   if (item.mergeStateStatus === 'BLOCKED') {
     return 'Blocked'
   }
-  if (item.mergeable === 'MERGEABLE' || item.mergeStateStatus === 'CLEAN') {
-    return 'Able to merge'
-  }
-  return 'Unknown'
+  return getHostedMergeLabel(item)
 }
 
 export function getHostedReviewMergeMethodLabel(method: HostedReviewMergeMethod): string {

--- a/mobile/src/tasks/mobile-tasks-refactor-parity.test.ts
+++ b/mobile/src/tasks/mobile-tasks-refactor-parity.test.ts
@@ -19,8 +19,8 @@ const hash = (parts: string[] | string): string =>
 const PRE_REFACTOR_SCREEN_HOOKS = '42174315a76c475d09dcb7209af4481f01258c4c9dc012127ff07a893d8cd291'
 const PRE_REFACTOR_DIFF_HOOKS = '93c7189b32bed8456cc51814fffa8ce80cf62011ef968a9d53ddec2b9686f58f'
 const PRE_REFACTOR_STATEMENTS = '9323fbee7c3806f37de42578ba73ce659c786c0ed5f8b6bcbc321b201ca50a73'
-const PRE_REFACTOR_DECLARATIONS = 'cff54172af17a877789be1479c2eb6ca97d83c3e31dd831cd59395962f2b4c4a'
-const PRE_REFACTOR_SEMANTICS = '5219d210d6f274e9ce2716a37c4c6fc4860a736a80f059ab6e89da6123043263'
+const PRE_REFACTOR_DECLARATIONS = '45db7679c0c46d755dfe7d1e56b45611711edcf55a5d5f1e6b9cc7ce2195e4b0'
+const PRE_REFACTOR_SEMANTICS = '804dbac3d387c41d2d38508aa861552b374adca9f575bd9543cec85e7b411d10'
 const PRE_REFACTOR_STYLES = '1db6af69c791d9963928541ad5310942fcbda6d984b422c90b6eb92b6816579a'
 const PRE_REFACTOR_RENDER_TREE = '2111145136b1e4fbca150d4792d735a90e992488e9934cfc1a8b8f3be981f39f'
 
@@ -49,7 +49,7 @@ describe('Mobile Tasks refactor parity', () => {
 
   it('preserves RPC calls, runtime strings, and JSX host signatures', () => {
     const semantics = readMobileTasksSemanticSource()
-    expect(semantics.split('\n')).toHaveLength(3_499)
+    expect(semantics.split('\n')).toHaveLength(3_491)
     expect(hash(semantics)).toBe(PRE_REFACTOR_SEMANTICS)
   })
 

--- a/src/main/github/client-pr-checks.test.ts
+++ b/src/main/github/client-pr-checks.test.ts
@@ -85,6 +85,7 @@ vi.mock('./rate-limit', () => ({
 }))
 
 import { getPRChecks, rerunPRChecks, _resetOwnerRepoCache } from './client'
+import { getPRChecksWithExistingOperationPermit } from './client/check/get-pr-checks'
 
 import { _resetOriginGitHubApiRepositoryCache } from './github-api-repository'
 
@@ -259,6 +260,19 @@ describe('getPRChecks', () => {
         workflowRunId: 1
       }
     ])
+  })
+
+  it('reuses an operation permit held by the caller', async () => {
+    getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockResolvedValueOnce(
+      graphQLChecksResponse({ contexts: [graphQLCheckRun()] })
+    )
+
+    const checks = await getPRChecksWithExistingOperationPermit('/repo-root', 42, 'head-oid')
+
+    expect(checks).toHaveLength(1)
+    expect(acquireMock).not.toHaveBeenCalled()
+    expect(releaseMock).not.toHaveBeenCalled()
   })
 
   it('merges rollup check-runs with legacy commit status contexts', async () => {

--- a/src/main/github/client-pr-linked-lookup.test.ts
+++ b/src/main/github/client-pr-linked-lookup.test.ts
@@ -284,7 +284,7 @@ describe('getPRForBranch', () => {
     )
   })
 
-  it('hydrates action-required checks when the exact PR rollup is empty and unstable', async () => {
+  it('hydrates action-required checks when the exact PR rollup is partial and unstable', async () => {
     getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock.mockImplementation(async (args: string[]) => {
       if (args[0] === 'pr') {
@@ -294,7 +294,15 @@ describe('getPRForBranch', () => {
             title: 'Approval required',
             state: 'OPEN',
             url: 'https://github.com/acme/widgets/pull/99',
-            statusCheckRollup: [],
+            statusCheckRollup: [
+              {
+                __typename: 'CheckRun',
+                name: 'track-community-pr',
+                status: 'COMPLETED',
+                conclusion: 'SUCCESS',
+                detailsUrl: 'https://github.com/acme/widgets/actions/runs/1'
+              }
+            ],
             updatedAt: '2026-08-26T10:00:00Z',
             isDraft: false,
             mergeable: 'MERGEABLE',

--- a/src/main/github/client-pr-linked-lookup.test.ts
+++ b/src/main/github/client-pr-linked-lookup.test.ts
@@ -284,6 +284,97 @@ describe('getPRForBranch', () => {
     )
   })
 
+  it('hydrates action-required checks when the exact PR rollup is empty and unstable', async () => {
+    getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+    ghExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'pr') {
+        return {
+          stdout: JSON.stringify({
+            number: 99,
+            title: 'Approval required',
+            state: 'OPEN',
+            url: 'https://github.com/acme/widgets/pull/99',
+            statusCheckRollup: [],
+            updatedAt: '2026-08-26T10:00:00Z',
+            isDraft: false,
+            mergeable: 'MERGEABLE',
+            reviewDecision: '',
+            mergeStateStatus: 'UNSTABLE',
+            autoMergeRequest: null,
+            baseRefName: 'main',
+            headRefName: 'feature',
+            headRefOid: 'head-oid'
+          })
+        }
+      }
+      const query = args.find((arg) => arg.startsWith('query=')) ?? ''
+      if (query.includes('pullRequest(number: $pr)')) {
+        return {
+          stdout: JSON.stringify({
+            data: {
+              repository: {
+                pullRequest: {
+                  headRefOid: 'head-oid',
+                  commits: {
+                    nodes: [
+                      {
+                        commit: {
+                          statusCheckRollup: { contexts: { nodes: [] } },
+                          checkSuites: {
+                            nodes: [
+                              {
+                                databaseId: 123,
+                                status: 'COMPLETED',
+                                conclusion: 'ACTION_REQUIRED',
+                                url: 'https://github.com/acme/widgets/commit/head-oid/checks?check_suite_id=123',
+                                app: { name: 'GitHub Actions', slug: 'github-actions' }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          })
+        }
+      }
+      if (args[1] === 'graphql') {
+        return {
+          stdout: JSON.stringify({ data: { repository: { mergeQueue: null } } })
+        }
+      }
+      return {
+        stdout: JSON.stringify({
+          number: 99,
+          title: 'Approval required',
+          state: 'open',
+          html_url: 'https://github.com/acme/widgets/pull/99',
+          updated_at: '2026-08-26T10:00:00Z',
+          mergeable_state: 'clean',
+          base: { ref: 'main' },
+          head: { ref: 'feature', sha: 'head-oid' }
+        })
+      }
+    })
+
+    const pr = await getPRForBranch('/repo-root', 'feature', 99)
+
+    expect(pr).toMatchObject({
+      checksStatus: 'failure',
+      checksPresentationStatus: 'action_required'
+    })
+    expect(
+      ghExecFileAsyncMock.mock.calls.some(([args]) =>
+        (args as string[]).some(
+          (arg) => arg.startsWith('query=') && arg.includes('pullRequest(number: $pr)')
+        )
+      )
+    ).toBe(true)
+  })
+
   it('isolates viewer-dependent merge metadata across SSH connections', async () => {
     getOwnerRepoMock.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
     let metadataProbe = 0

--- a/src/main/github/client/check/get-pr-checks.ts
+++ b/src/main/github/client/check/get-pr-checks.ts
@@ -22,11 +22,34 @@ import {
   getPendingApprovalCheckSuiteUrl
 } from './pr-checks-response-mapping'
 import { parseActionsRunId } from './check-detail-field-mapping'
-export async function getPRChecksViaRestFallback(
+
+type GetPRChecksOptions = {
+  noCache?: boolean
+}
+
+type PRChecksOperationPermit = 'acquire' | 'held'
+
+async function runWithPRChecksOperationPermit<T>(
+  operationPermit: PRChecksOperationPermit,
+  operation: () => Promise<T>
+): Promise<T> {
+  if (operationPermit === 'held') {
+    return operation()
+  }
+  await acquire()
+  try {
+    return await operation()
+  } finally {
+    release()
+  }
+}
+
+async function getPRChecksViaRestFallback(
   ownerRepo: GitHubApiRepository,
   headSha: string | undefined,
   ghOptions: GhExecOptions,
-  noCache?: boolean
+  noCache?: boolean,
+  operationPermit: PRChecksOperationPermit = 'acquire'
 ): Promise<PRCheckDetail[] | null> {
   if (!headSha) {
     return null
@@ -38,80 +61,81 @@ export async function getPRChecksViaRestFallback(
     return null
   }
 
-  await acquire()
   try {
-    const cacheArgs = noCache ? [] : ['--cache', '60s']
-    const encodedHeadSha = encodeURIComponent(headSha)
-    const { stdout } = await ghExecFileAsync(
-      [
-        'api',
-        ...cacheArgs,
-        `repos/${ownerRepo.owner}/${ownerRepo.repo}/commits/${encodedHeadSha}/check-runs?per_page=100`
-      ],
-      ghOptions
-    )
-    noteRepositoryRateLimitSpend(ownerRepo, 'core', 1, ghOptions)
-    const checkRunData = JSON.parse(stdout) as {
-      check_runs?: RestCheckRun[]
-    }
-    const checkRuns = (checkRunData.check_runs ?? []).map(mapRestCheckRun)
-    const checkRunNames = new Set(checkRuns.map((check) => check.name))
-
-    let legacyStatuses: PRCheckDetail[] = []
-    try {
-      const statusResult = await ghExecFileAsync(
+    return await runWithPRChecksOperationPermit(operationPermit, async () => {
+      const cacheArgs = noCache ? [] : ['--cache', '60s']
+      const encodedHeadSha = encodeURIComponent(headSha)
+      const { stdout } = await ghExecFileAsync(
         [
           'api',
           ...cacheArgs,
-          `repos/${ownerRepo.owner}/${ownerRepo.repo}/commits/${encodedHeadSha}/status?per_page=100`
+          `repos/${ownerRepo.owner}/${ownerRepo.repo}/commits/${encodedHeadSha}/check-runs?per_page=100`
         ],
         ghOptions
       )
       noteRepositoryRateLimitSpend(ownerRepo, 'core', 1, ghOptions)
-      const statusData = JSON.parse(statusResult.stdout) as {
-        statuses?: RestCommitStatus[]
+      const checkRunData = JSON.parse(stdout) as {
+        check_runs?: RestCheckRun[]
       }
-      legacyStatuses = (statusData.statuses ?? [])
-        .map(mapRestCommitStatus)
-        .filter((check): check is PRCheckDetail => check !== null && !checkRunNames.has(check.name))
-    } catch (err) {
-      // Why: REST fallback is already degraded; keep the richer check-run rows if legacy-status enrichment fails.
-      console.warn('getPRChecks REST status fallback failed:', err)
-    }
+      const checkRuns = (checkRunData.check_runs ?? []).map(mapRestCheckRun)
+      const checkRunNames = new Set(checkRuns.map((check) => check.name))
 
-    let pendingApprovalChecks: PRCheckDetail[] = []
-    try {
-      const suitesResult = await ghExecFileAsync(
-        [
-          'api',
-          ...cacheArgs,
-          `repos/${ownerRepo.owner}/${ownerRepo.repo}/commits/${encodedHeadSha}/check-suites?per_page=100`
-        ],
-        ghOptions
-      )
-      noteRepositoryRateLimitSpend(ownerRepo, 'core', 1, ghOptions)
-      const suitesData = JSON.parse(suitesResult.stdout) as {
-        check_suites?: RestCheckSuite[]
+      let legacyStatuses: PRCheckDetail[] = []
+      try {
+        const statusResult = await ghExecFileAsync(
+          [
+            'api',
+            ...cacheArgs,
+            `repos/${ownerRepo.owner}/${ownerRepo.repo}/commits/${encodedHeadSha}/status?per_page=100`
+          ],
+          ghOptions
+        )
+        noteRepositoryRateLimitSpend(ownerRepo, 'core', 1, ghOptions)
+        const statusData = JSON.parse(statusResult.stdout) as {
+          statuses?: RestCommitStatus[]
+        }
+        legacyStatuses = (statusData.statuses ?? [])
+          .map(mapRestCommitStatus)
+          .filter(
+            (check): check is PRCheckDetail => check !== null && !checkRunNames.has(check.name)
+          )
+      } catch (err) {
+        // Why: REST fallback is already degraded; keep the richer check-run rows if legacy-status enrichment fails.
+        console.warn('getPRChecks REST status fallback failed:', err)
       }
-      pendingApprovalChecks = (suitesData.check_suites ?? [])
-        .filter((suite) => suite.conclusion?.toLowerCase() === 'action_required')
-        .map((suite, index) => ({
-          name: getPendingApprovalCheckSuiteName(suite, headSha, index),
-          status: 'completed' as const,
-          conclusion: 'action_required' as const,
-          url: getPendingApprovalCheckSuiteUrl(ownerRepo, headSha, suite.id)
-        }))
-    } catch (err) {
-      console.warn('getPRChecks REST check-suite fallback failed:', err)
-    }
 
-    const checks = [...checkRuns, ...legacyStatuses, ...pendingApprovalChecks]
-    return checks.length > 0 ? checks : null
+      let pendingApprovalChecks: PRCheckDetail[] = []
+      try {
+        const suitesResult = await ghExecFileAsync(
+          [
+            'api',
+            ...cacheArgs,
+            `repos/${ownerRepo.owner}/${ownerRepo.repo}/commits/${encodedHeadSha}/check-suites?per_page=100`
+          ],
+          ghOptions
+        )
+        noteRepositoryRateLimitSpend(ownerRepo, 'core', 1, ghOptions)
+        const suitesData = JSON.parse(suitesResult.stdout) as {
+          check_suites?: RestCheckSuite[]
+        }
+        pendingApprovalChecks = (suitesData.check_suites ?? [])
+          .filter((suite) => suite.conclusion?.toLowerCase() === 'action_required')
+          .map((suite, index) => ({
+            name: getPendingApprovalCheckSuiteName(suite, headSha, index),
+            status: 'completed' as const,
+            conclusion: 'action_required' as const,
+            url: getPendingApprovalCheckSuiteUrl(ownerRepo, headSha, suite.id)
+          }))
+      } catch (err) {
+        console.warn('getPRChecks REST check-suite fallback failed:', err)
+      }
+
+      const checks = [...checkRuns, ...legacyStatuses, ...pendingApprovalChecks]
+      return checks.length > 0 ? checks : null
+    })
   } catch (err) {
     console.warn('getPRChecks via REST fallback failed, falling back to gh pr checks:', err)
     return null
-  } finally {
-    release()
   }
 }
 
@@ -120,14 +144,15 @@ export async function getPRChecksViaRestFallback(
  * Uses GitHub's combined GraphQL rollup so check runs and legacy commit statuses
  * arrive in one cached request; suite-only approval blockers are included too.
  */
-export async function getPRChecks(
+async function getPRChecksWithOperationPermit(
   repoPath: string,
   prNumber: number,
   headSha?: string,
   prRepo?: GitHubApiRepository | null,
-  options?: { noCache?: boolean },
+  options?: GetPRChecksOptions,
   connectionId?: string | null,
-  localGitOptions: LocalGitExecOptions = {}
+  localGitOptions: LocalGitExecOptions = {},
+  operationPermit: PRChecksOperationPermit = 'acquire'
 ): Promise<PRCheckDetail[]> {
   void headSha
   const { ownerRepo, ghOptions } = await resolveGitHubRepoExecution(
@@ -141,8 +166,7 @@ export async function getPRChecks(
   }
   const fallbackToPRChecks = async (): Promise<PRCheckDetail[]> => {
     await assertRateLimitBudget('graphql', ownerRepo, ghOptions)
-    await acquire()
-    try {
+    return runWithPRChecksOperationPermit(operationPermit, async () => {
       const fallbackArgs = ['pr', 'checks', String(prNumber), '--json', 'name,state,link']
       if (ownerRepo) {
         fallbackArgs.push('--repo', `${ownerRepo.owner}/${ownerRepo.repo}`)
@@ -164,9 +188,7 @@ export async function getPRChecks(
         url: d.link || null,
         workflowRunId: parseActionsRunId(d.link)
       }))
-    } finally {
-      release()
-    }
+    })
   }
 
   if (ownerRepo) {
@@ -178,46 +200,46 @@ export async function getPRChecks(
       console.warn('getPRChecks skipped GraphQL rollup, falling back to gh pr checks:', err)
     }
     if (canUseGraphQLRollup) {
-      await acquire()
       try {
-        // Why: --cache 60s saves rate-limit budget during polling; explicit refresh skips it for fresh data.
-        const cacheArgs = options?.noCache ? [] : ['--cache', '60s']
-        const { stdout } = await ghExecFileAsync(
-          [
-            'api',
-            'graphql',
-            ...cacheArgs,
-            '-f',
-            `owner=${ownerRepo.owner}`,
-            '-f',
-            `repo=${ownerRepo.repo}`,
-            '-F',
-            `pr=${prNumber}`,
-            '-f',
-            `query=${PR_CHECKS_ROLLUP_QUERY}`
-          ],
-          ghOptions
-        )
-        noteRepositoryRateLimitSpend(ownerRepo, 'graphql', 1, ghOptions)
-        const checks = mapGraphQLPRChecksResponse(
-          ownerRepo,
-          JSON.parse(stdout) as GraphQLPRChecksResponse
-        )
+        const checks = await runWithPRChecksOperationPermit(operationPermit, async () => {
+          // Why: --cache 60s saves rate-limit budget during polling; explicit refresh skips it for fresh data.
+          const cacheArgs = options?.noCache ? [] : ['--cache', '60s']
+          const { stdout } = await ghExecFileAsync(
+            [
+              'api',
+              'graphql',
+              ...cacheArgs,
+              '-f',
+              `owner=${ownerRepo.owner}`,
+              '-f',
+              `repo=${ownerRepo.repo}`,
+              '-F',
+              `pr=${prNumber}`,
+              '-f',
+              `query=${PR_CHECKS_ROLLUP_QUERY}`
+            ],
+            ghOptions
+          )
+          noteRepositoryRateLimitSpend(ownerRepo, 'graphql', 1, ghOptions)
+          return mapGraphQLPRChecksResponse(
+            ownerRepo,
+            JSON.parse(stdout) as GraphQLPRChecksResponse
+          )
+        })
         if (checks !== null) {
           return checks
         }
       } catch (err) {
         // Why: fall back to older `gh pr checks` when GitHub's richer rollup query is unavailable.
         console.warn('getPRChecks via GraphQL rollup failed, falling back to gh pr checks:', err)
-      } finally {
-        release()
       }
     }
     const restChecks = await getPRChecksViaRestFallback(
       ownerRepo,
       headSha,
       ghOptions,
-      options?.noCache
+      options?.noCache,
+      operationPermit
     )
     if (restChecks !== null) {
       return restChecks
@@ -230,4 +252,45 @@ export async function getPRChecks(
     console.warn('getPRChecks failed:', err)
     throw err
   }
+}
+
+export async function getPRChecks(
+  repoPath: string,
+  prNumber: number,
+  headSha?: string,
+  prRepo?: GitHubApiRepository | null,
+  options?: GetPRChecksOptions,
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): Promise<PRCheckDetail[]> {
+  return getPRChecksWithOperationPermit(
+    repoPath,
+    prNumber,
+    headSha,
+    prRepo,
+    options,
+    connectionId,
+    localGitOptions,
+    'acquire'
+  )
+}
+
+export async function getPRChecksWithExistingOperationPermit(
+  repoPath: string,
+  prNumber: number,
+  headSha?: string,
+  prRepo?: GitHubApiRepository | null,
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {}
+): Promise<PRCheckDetail[]> {
+  return getPRChecksWithOperationPermit(
+    repoPath,
+    prNumber,
+    headSha,
+    prRepo,
+    undefined,
+    connectionId,
+    localGitOptions,
+    'held'
+  )
 }

--- a/src/main/github/client/lookup/branch-lookup-resolution.ts
+++ b/src/main/github/client/lookup/branch-lookup-resolution.ts
@@ -23,7 +23,7 @@ import {
 import { lookupPRByBranchName } from './pr-branch-lookup'
 import { lookupPRByNumber } from './pr-number-lookup'
 import { derivePRRefreshData } from './branch-lookup-derived-data'
-import { hydrateMissingUnstablePRCheckRollup } from './missing-unstable-pr-check-rollup'
+import { hydrateUnstablePRCheckRollup } from './unstable-pr-check-rollup'
 import { assemblePRRefreshFoundOutcome } from './pr-refresh-outcome-assembly'
 import { shouldRetryTrackedUpstreamBranch } from './tracked-upstream-cache'
 import { getTrackedUpstreamBranch } from './tracked-upstream-branch'
@@ -270,7 +270,7 @@ export async function resolvePRForBranchOutcome(input: {
     return { kind: 'no-pr', fetchedAt: Date.now() }
   }
 
-  data = await hydrateMissingUnstablePRCheckRollup(data, {
+  data = await hydrateUnstablePRCheckRollup(data, {
     repoPath,
     dataRepo,
     connectionId,

--- a/src/main/github/client/lookup/branch-lookup-resolution.ts
+++ b/src/main/github/client/lookup/branch-lookup-resolution.ts
@@ -23,6 +23,7 @@ import {
 import { lookupPRByBranchName } from './pr-branch-lookup'
 import { lookupPRByNumber } from './pr-number-lookup'
 import { derivePRRefreshData } from './branch-lookup-derived-data'
+import { hydrateMissingUnstablePRCheckRollup } from './missing-unstable-pr-check-rollup'
 import { assemblePRRefreshFoundOutcome } from './pr-refresh-outcome-assembly'
 import { shouldRetryTrackedUpstreamBranch } from './tracked-upstream-cache'
 import { getTrackedUpstreamBranch } from './tracked-upstream-branch'
@@ -268,6 +269,13 @@ export async function resolvePRForBranchOutcome(input: {
   ) {
     return { kind: 'no-pr', fetchedAt: Date.now() }
   }
+
+  data = await hydrateMissingUnstablePRCheckRollup(data, {
+    repoPath,
+    dataRepo,
+    connectionId,
+    localGitOptions
+  })
 
   const { mergeable, stack, stackMergeQueueRequired, conflictSummary } = await derivePRRefreshData({
     data,

--- a/src/main/github/client/lookup/missing-unstable-pr-check-rollup.test.ts
+++ b/src/main/github/client/lookup/missing-unstable-pr-check-rollup.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PullRequestLookupData } from './pull-request-lookup-data'
+import { hydrateMissingUnstablePRCheckRollup } from './missing-unstable-pr-check-rollup'
+
+const getPRChecksWithExistingOperationPermitMock = vi.hoisted(() => vi.fn())
+
+vi.mock('./../check/get-pr-checks', () => ({
+  getPRChecksWithExistingOperationPermit: getPRChecksWithExistingOperationPermitMock
+}))
+
+function createPullRequest(overrides: Partial<PullRequestLookupData> = {}): PullRequestLookupData {
+  return {
+    number: 42,
+    title: 'Manual approval',
+    state: 'OPEN',
+    url: 'https://github.com/acme/widgets/pull/42',
+    statusCheckRollup: [],
+    updatedAt: '2026-08-26T10:00:00Z',
+    mergeable: 'MERGEABLE',
+    mergeStateStatus: 'UNSTABLE',
+    headRefOid: 'head-oid',
+    ...overrides
+  }
+}
+
+const lookupArgs = {
+  repoPath: '/repo-root',
+  dataRepo: { host: 'github.com', owner: 'acme', repo: 'widgets' },
+  connectionId: null,
+  localGitOptions: {}
+}
+
+describe('hydrateMissingUnstablePRCheckRollup', () => {
+  beforeEach(() => {
+    getPRChecksWithExistingOperationPermitMock.mockReset()
+  })
+
+  it('reuses the PR lookup operation permit for the detailed request', async () => {
+    getPRChecksWithExistingOperationPermitMock.mockResolvedValue([
+      {
+        name: 'GitHub Actions',
+        status: 'completed',
+        conclusion: 'action_required',
+        url: null
+      }
+    ])
+
+    await hydrateMissingUnstablePRCheckRollup(createPullRequest(), lookupArgs)
+
+    expect(getPRChecksWithExistingOperationPermitMock).toHaveBeenCalledWith(
+      '/repo-root',
+      42,
+      'head-oid',
+      lookupArgs.dataRepo,
+      null,
+      {}
+    )
+  })
+
+  it('loads suite-only checks for an open unstable PR with an empty rollup', async () => {
+    const loadChecks = vi.fn().mockResolvedValue([
+      {
+        name: 'GitHub Actions',
+        status: 'completed',
+        conclusion: 'action_required',
+        url: 'https://github.com/acme/widgets/commit/head-oid/checks'
+      }
+    ])
+
+    const result = await hydrateMissingUnstablePRCheckRollup(
+      createPullRequest(),
+      lookupArgs,
+      loadChecks
+    )
+
+    expect(loadChecks).toHaveBeenCalledOnce()
+    expect(result.statusCheckRollup).toEqual([
+      expect.objectContaining({ conclusion: 'action_required' })
+    ])
+  })
+
+  it.each([
+    ['a populated rollup', { statusCheckRollup: [{ conclusion: 'failure' }] }],
+    ['a stable merge state', { mergeStateStatus: 'CLEAN' }],
+    ['a closed PR', { state: 'CLOSED' }]
+  ])('does not load detailed checks for %s', async (_label, overrides) => {
+    const loadChecks = vi.fn()
+
+    const result = await hydrateMissingUnstablePRCheckRollup(
+      createPullRequest(overrides),
+      lookupArgs,
+      loadChecks
+    )
+
+    expect(loadChecks).not.toHaveBeenCalled()
+    expect(result).toEqual(createPullRequest(overrides))
+  })
+
+  it('keeps the PR summary when detailed checks cannot be loaded', async () => {
+    const error = new Error('rate limited')
+    const loadChecks = vi.fn().mockRejectedValue(error)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const data = createPullRequest()
+
+    const result = await hydrateMissingUnstablePRCheckRollup(data, lookupArgs, loadChecks)
+
+    expect(result).toBe(data)
+    expect(warn).toHaveBeenCalledWith('Unable to hydrate unstable PR checks:', error)
+    warn.mockRestore()
+  })
+})

--- a/src/main/github/client/lookup/missing-unstable-pr-check-rollup.ts
+++ b/src/main/github/client/lookup/missing-unstable-pr-check-rollup.ts
@@ -1,0 +1,44 @@
+import type { PRCheckDetail } from '../../../../shared/github/check-types'
+import type { OwnerRepo } from '../../gh-utils'
+import { getPRChecksWithExistingOperationPermit } from './../check/get-pr-checks'
+import type { HostedReviewLocalGitOptions } from './../github-exec-scope'
+import { mapPRState } from '../../mappers'
+import type { PullRequestLookupData } from './pull-request-lookup-data'
+
+type DetailedCheckLoader = () => Promise<PRCheckDetail[]>
+
+export async function hydrateMissingUnstablePRCheckRollup(
+  data: PullRequestLookupData,
+  args: {
+    repoPath: string
+    dataRepo: OwnerRepo | null
+    connectionId?: string | null
+    localGitOptions: HostedReviewLocalGitOptions
+  },
+  loadChecks: DetailedCheckLoader = () =>
+    getPRChecksWithExistingOperationPermit(
+      args.repoPath,
+      data.number,
+      data.headRefOid,
+      args.dataRepo,
+      args.connectionId,
+      args.localGitOptions
+    )
+): Promise<PullRequestLookupData> {
+  if (
+    data.statusCheckRollup.length > 0 ||
+    data.mergeStateStatus?.toUpperCase() !== 'UNSTABLE' ||
+    mapPRState(data.state, data.isDraft) !== 'open'
+  ) {
+    return data
+  }
+
+  try {
+    const checks = await loadChecks()
+    return checks.length > 0 ? { ...data, statusCheckRollup: checks } : data
+  } catch (error) {
+    // Detailed checks are additive; keep the PR visible when their fallback lookup fails.
+    console.warn('Unable to hydrate unstable PR checks:', error)
+    return data
+  }
+}

--- a/src/main/github/client/lookup/pr-refresh-outcome-assembly.test.ts
+++ b/src/main/github/client/lookup/pr-refresh-outcome-assembly.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+import { assemblePRRefreshFoundOutcome } from './pr-refresh-outcome-assembly'
+import type { PullRequestLookupData } from './pull-request-lookup-data'
+
+describe('assemblePRRefreshFoundOutcome', () => {
+  it('publishes action-required presentation without changing the legacy failure status', () => {
+    const data = {
+      number: 42,
+      title: 'Approve workflows',
+      state: 'OPEN',
+      url: 'https://github.com/acme/orca/pull/42',
+      statusCheckRollup: [{ state: 'ACTION_REQUIRED' }],
+      updatedAt: '2026-08-26T00:00:00.000Z',
+      mergeable: 'UNKNOWN',
+      headRefOid: 'abc123'
+    } satisfies PullRequestLookupData
+
+    const outcome = assemblePRRefreshFoundOutcome({
+      data,
+      dataRepo: null,
+      dataHeadRepo: null,
+      stack: undefined,
+      mergeable: 'UNKNOWN',
+      stackMergeQueueRequired: undefined,
+      confirmedContainedHeadOid: null,
+      headDivergedFromMergedPRAtOid: null,
+      conflictSummary: undefined
+    })
+
+    expect(outcome).toMatchObject({
+      kind: 'found',
+      pr: {
+        checksStatus: 'failure',
+        checksPresentationStatus: 'action_required'
+      }
+    })
+  })
+})

--- a/src/main/github/client/lookup/pr-refresh-outcome-assembly.ts
+++ b/src/main/github/client/lookup/pr-refresh-outcome-assembly.ts
@@ -4,7 +4,7 @@ import type {
   PRMergeableState,
   GitHubPRStack
 } from '../../../../shared/github/pull-request-types'
-import { deriveCheckStatus, mapPRState } from '../../mappers'
+import { deriveCheckStatuses, mapPRState } from '../../mappers'
 import type { OwnerRepo } from '../../gh-utils'
 import type { PullRequestLookupData } from './pull-request-lookup-data'
 
@@ -30,6 +30,7 @@ export function assemblePRRefreshFoundOutcome(args: {
     headDivergedFromMergedPRAtOid,
     conflictSummary
   } = args
+  const checkStatuses = deriveCheckStatuses(data.statusCheckRollup)
   return {
     kind: 'found',
     fetchedAt: Date.now(),
@@ -38,7 +39,8 @@ export function assemblePRRefreshFoundOutcome(args: {
       title: data.title,
       state: mapPRState(data.state, data.isDraft),
       url: data.url,
-      checksStatus: deriveCheckStatus(data.statusCheckRollup),
+      checksStatus: checkStatuses.status,
+      checksPresentationStatus: checkStatuses.presentationStatus,
       updatedAt: data.updatedAt,
       mergeable,
       ...(data.reviewDecision !== undefined ? { reviewDecision: data.reviewDecision } : {}),

--- a/src/main/github/client/lookup/unstable-pr-check-rollup.test.ts
+++ b/src/main/github/client/lookup/unstable-pr-check-rollup.test.ts
@@ -108,9 +108,33 @@ describe('hydrateUnstablePRCheckRollup', () => {
     ])
   })
 
+  it('loads a suite-only blocker while another visible check is pending', async () => {
+    const pendingCheck = { name: 'build', status: 'IN_PROGRESS', conclusion: null }
+    const loadChecks = vi.fn().mockResolvedValue([
+      pendingCheck,
+      {
+        name: 'GitHub Actions',
+        status: 'completed',
+        conclusion: 'action_required',
+        url: null
+      }
+    ])
+
+    const result = await hydrateUnstablePRCheckRollup(
+      createPullRequest({ statusCheckRollup: [pendingCheck] }),
+      lookupArgs,
+      loadChecks
+    )
+
+    expect(loadChecks).toHaveBeenCalledOnce()
+    expect(result.statusCheckRollup).toEqual([
+      pendingCheck,
+      expect.objectContaining({ conclusion: 'action_required' })
+    ])
+  })
+
   it.each([
     ['a failing rollup', { statusCheckRollup: [{ conclusion: 'failure' }] }],
-    ['a pending rollup', { statusCheckRollup: [{ status: 'IN_PROGRESS' }] }],
     ['an action-required rollup', { statusCheckRollup: [{ conclusion: 'action_required' }] }],
     ['a stable merge state', { mergeStateStatus: 'CLEAN' }],
     ['a closed PR', { state: 'CLOSED' }]
@@ -151,6 +175,21 @@ describe('hydrateUnstablePRCheckRollup', () => {
     const result = await hydrateUnstablePRCheckRollup(data, lookupArgs, loadChecks)
 
     expect(result.statusCheckRollup).toEqual([])
+    expect(warn).toHaveBeenCalledWith('Unable to hydrate unstable PR checks:', error)
+    warn.mockRestore()
+  })
+
+  it('keeps a visible pending check when detailed checks cannot be loaded', async () => {
+    const error = new Error('rate limited')
+    const loadChecks = vi.fn().mockRejectedValue(error)
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    const data = createPullRequest({
+      statusCheckRollup: [{ name: 'build', status: 'IN_PROGRESS', conclusion: null }]
+    })
+
+    const result = await hydrateUnstablePRCheckRollup(data, lookupArgs, loadChecks)
+
+    expect(result).toBe(data)
     expect(warn).toHaveBeenCalledWith('Unable to hydrate unstable PR checks:', error)
     warn.mockRestore()
   })

--- a/src/main/github/client/lookup/unstable-pr-check-rollup.test.ts
+++ b/src/main/github/client/lookup/unstable-pr-check-rollup.test.ts
@@ -108,10 +108,14 @@ describe('hydrateUnstablePRCheckRollup', () => {
     ])
   })
 
-  it('loads a suite-only blocker while another visible check is pending', async () => {
-    const pendingCheck = { name: 'build', status: 'IN_PROGRESS', conclusion: null }
+  it('replaces a partial passing rollup when GitHub reports an unknown merge state', async () => {
     const loadChecks = vi.fn().mockResolvedValue([
-      pendingCheck,
+      {
+        name: 'track-community-pr',
+        status: 'completed',
+        conclusion: 'success',
+        url: null
+      },
       {
         name: 'GitHub Actions',
         status: 'completed',
@@ -121,23 +125,66 @@ describe('hydrateUnstablePRCheckRollup', () => {
     ])
 
     const result = await hydrateUnstablePRCheckRollup(
-      createPullRequest({ statusCheckRollup: [pendingCheck] }),
+      createPullRequest({
+        mergeStateStatus: 'UNKNOWN',
+        statusCheckRollup: [
+          { name: 'track-community-pr', status: 'COMPLETED', conclusion: 'SUCCESS' }
+        ]
+      }),
       lookupArgs,
       loadChecks
     )
 
     expect(loadChecks).toHaveBeenCalledOnce()
     expect(result.statusCheckRollup).toEqual([
-      pendingCheck,
+      expect.objectContaining({ conclusion: 'success' }),
       expect.objectContaining({ conclusion: 'action_required' })
     ])
   })
 
+  it.each(['UNSTABLE', 'UNKNOWN'])(
+    'loads a suite-only blocker while another visible check is pending for %s',
+    async (mergeStateStatus) => {
+      const pendingCheck = { name: 'build', status: 'IN_PROGRESS', conclusion: null }
+      const loadChecks = vi.fn().mockResolvedValue([
+        pendingCheck,
+        {
+          name: 'GitHub Actions',
+          status: 'completed',
+          conclusion: 'action_required',
+          url: null
+        }
+      ])
+
+      const result = await hydrateUnstablePRCheckRollup(
+        createPullRequest({ mergeStateStatus, statusCheckRollup: [pendingCheck] }),
+        lookupArgs,
+        loadChecks
+      )
+
+      expect(loadChecks).toHaveBeenCalledOnce()
+      expect(result.statusCheckRollup).toEqual([
+        pendingCheck,
+        expect.objectContaining({ conclusion: 'action_required' })
+      ])
+    }
+  )
+
   it.each([
     ['a failing rollup', { statusCheckRollup: [{ conclusion: 'failure' }] }],
     ['an action-required rollup', { statusCheckRollup: [{ conclusion: 'action_required' }] }],
+    [
+      'an unknown merge state with a failing rollup',
+      { mergeStateStatus: 'UNKNOWN', statusCheckRollup: [{ conclusion: 'failure' }] }
+    ],
+    [
+      'an unknown merge state with an action-required rollup',
+      { mergeStateStatus: 'UNKNOWN', statusCheckRollup: [{ conclusion: 'action_required' }] }
+    ],
     ['a stable merge state', { mergeStateStatus: 'CLEAN' }],
-    ['a closed PR', { state: 'CLOSED' }]
+    ['a draft PR', { isDraft: true }],
+    ['a closed PR', { state: 'CLOSED' }],
+    ['a merged PR', { state: 'MERGED', mergeStateStatus: 'UNKNOWN' }]
   ])('does not load detailed checks for %s', async (_label, overrides) => {
     const loadChecks = vi.fn()
 
@@ -175,7 +222,7 @@ describe('hydrateUnstablePRCheckRollup', () => {
     const result = await hydrateUnstablePRCheckRollup(data, lookupArgs, loadChecks)
 
     expect(result.statusCheckRollup).toEqual([])
-    expect(warn).toHaveBeenCalledWith('Unable to hydrate unstable PR checks:', error)
+    expect(warn).toHaveBeenCalledWith('Unable to hydrate incomplete PR checks:', error)
     warn.mockRestore()
   })
 
@@ -190,7 +237,7 @@ describe('hydrateUnstablePRCheckRollup', () => {
     const result = await hydrateUnstablePRCheckRollup(data, lookupArgs, loadChecks)
 
     expect(result).toBe(data)
-    expect(warn).toHaveBeenCalledWith('Unable to hydrate unstable PR checks:', error)
+    expect(warn).toHaveBeenCalledWith('Unable to hydrate incomplete PR checks:', error)
     warn.mockRestore()
   })
 })

--- a/src/main/github/client/lookup/unstable-pr-check-rollup.test.ts
+++ b/src/main/github/client/lookup/unstable-pr-check-rollup.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { PullRequestLookupData } from './pull-request-lookup-data'
-import { hydrateMissingUnstablePRCheckRollup } from './missing-unstable-pr-check-rollup'
+import { hydrateUnstablePRCheckRollup } from './unstable-pr-check-rollup'
 
 const getPRChecksWithExistingOperationPermitMock = vi.hoisted(() => vi.fn())
 
@@ -30,7 +30,7 @@ const lookupArgs = {
   localGitOptions: {}
 }
 
-describe('hydrateMissingUnstablePRCheckRollup', () => {
+describe('hydrateUnstablePRCheckRollup', () => {
   beforeEach(() => {
     getPRChecksWithExistingOperationPermitMock.mockReset()
   })
@@ -45,7 +45,7 @@ describe('hydrateMissingUnstablePRCheckRollup', () => {
       }
     ])
 
-    await hydrateMissingUnstablePRCheckRollup(createPullRequest(), lookupArgs)
+    await hydrateUnstablePRCheckRollup(createPullRequest(), lookupArgs)
 
     expect(getPRChecksWithExistingOperationPermitMock).toHaveBeenCalledWith(
       '/repo-root',
@@ -67,11 +67,7 @@ describe('hydrateMissingUnstablePRCheckRollup', () => {
       }
     ])
 
-    const result = await hydrateMissingUnstablePRCheckRollup(
-      createPullRequest(),
-      lookupArgs,
-      loadChecks
-    )
+    const result = await hydrateUnstablePRCheckRollup(createPullRequest(), lookupArgs, loadChecks)
 
     expect(loadChecks).toHaveBeenCalledOnce()
     expect(result.statusCheckRollup).toEqual([
@@ -79,14 +75,49 @@ describe('hydrateMissingUnstablePRCheckRollup', () => {
     ])
   })
 
+  it('replaces a partial passing rollup with detailed checks for an open unstable PR', async () => {
+    const loadChecks = vi.fn().mockResolvedValue([
+      {
+        name: 'track-community-pr',
+        status: 'completed',
+        conclusion: 'success',
+        url: null
+      },
+      {
+        name: 'GitHub Actions',
+        status: 'completed',
+        conclusion: 'action_required',
+        url: null
+      }
+    ])
+
+    const result = await hydrateUnstablePRCheckRollup(
+      createPullRequest({
+        statusCheckRollup: [
+          { name: 'track-community-pr', status: 'COMPLETED', conclusion: 'SUCCESS' }
+        ]
+      }),
+      lookupArgs,
+      loadChecks
+    )
+
+    expect(loadChecks).toHaveBeenCalledOnce()
+    expect(result.statusCheckRollup).toEqual([
+      expect.objectContaining({ conclusion: 'success' }),
+      expect.objectContaining({ conclusion: 'action_required' })
+    ])
+  })
+
   it.each([
-    ['a populated rollup', { statusCheckRollup: [{ conclusion: 'failure' }] }],
+    ['a failing rollup', { statusCheckRollup: [{ conclusion: 'failure' }] }],
+    ['a pending rollup', { statusCheckRollup: [{ status: 'IN_PROGRESS' }] }],
+    ['an action-required rollup', { statusCheckRollup: [{ conclusion: 'action_required' }] }],
     ['a stable merge state', { mergeStateStatus: 'CLEAN' }],
     ['a closed PR', { state: 'CLOSED' }]
   ])('does not load detailed checks for %s', async (_label, overrides) => {
     const loadChecks = vi.fn()
 
-    const result = await hydrateMissingUnstablePRCheckRollup(
+    const result = await hydrateUnstablePRCheckRollup(
       createPullRequest(overrides),
       lookupArgs,
       loadChecks
@@ -96,15 +127,30 @@ describe('hydrateMissingUnstablePRCheckRollup', () => {
     expect(result).toEqual(createPullRequest(overrides))
   })
 
-  it('keeps the PR summary when detailed checks cannot be loaded', async () => {
+  it('keeps a partial passing rollup neutral when detailed checks are empty', async () => {
+    const data = createPullRequest({
+      statusCheckRollup: [{ name: 'track-community-pr', conclusion: 'SUCCESS' }]
+    })
+    const loadChecks = vi.fn().mockResolvedValue([])
+
+    const result = await hydrateUnstablePRCheckRollup(data, lookupArgs, loadChecks)
+
+    expect(loadChecks).toHaveBeenCalledOnce()
+    expect(result.statusCheckRollup).toEqual([])
+    expect(data.statusCheckRollup).toHaveLength(1)
+  })
+
+  it('keeps a partial passing rollup neutral when detailed checks cannot be loaded', async () => {
     const error = new Error('rate limited')
     const loadChecks = vi.fn().mockRejectedValue(error)
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
-    const data = createPullRequest()
+    const data = createPullRequest({
+      statusCheckRollup: [{ name: 'track-community-pr', conclusion: 'SUCCESS' }]
+    })
 
-    const result = await hydrateMissingUnstablePRCheckRollup(data, lookupArgs, loadChecks)
+    const result = await hydrateUnstablePRCheckRollup(data, lookupArgs, loadChecks)
 
-    expect(result).toBe(data)
+    expect(result.statusCheckRollup).toEqual([])
     expect(warn).toHaveBeenCalledWith('Unable to hydrate unstable PR checks:', error)
     warn.mockRestore()
   })

--- a/src/main/github/client/lookup/unstable-pr-check-rollup.ts
+++ b/src/main/github/client/lookup/unstable-pr-check-rollup.ts
@@ -29,13 +29,13 @@ export async function hydrateUnstablePRCheckRollup(
   if (
     data.mergeStateStatus?.toUpperCase() !== 'UNSTABLE' ||
     mapPRState(data.state, data.isDraft) !== 'open' ||
-    (data.statusCheckRollup.length > 0 && rollupStatus !== 'success')
+    rollupStatus === 'failure' ||
+    rollupStatus === 'action_required'
   ) {
     return data
   }
 
-  const neutralFallback =
-    data.statusCheckRollup.length > 0 ? { ...data, statusCheckRollup: [] } : data
+  const neutralFallback = rollupStatus === 'success' ? { ...data, statusCheckRollup: [] } : data
   try {
     const checks = await loadChecks()
     return checks.length > 0 ? { ...data, statusCheckRollup: checks } : neutralFallback

--- a/src/main/github/client/lookup/unstable-pr-check-rollup.ts
+++ b/src/main/github/client/lookup/unstable-pr-check-rollup.ts
@@ -26,8 +26,12 @@ export async function hydrateUnstablePRCheckRollup(
     )
 ): Promise<PullRequestLookupData> {
   const rollupStatus = deriveCheckStatuses(data.statusCheckRollup).presentationStatus
+  const mergeStateStatus = data.mergeStateStatus?.toUpperCase()
+  // GitHub can report UNKNOWN with a passing rollup that omits suite-only blockers.
+  const rollupMayOmitSuiteOnlyChecks =
+    mergeStateStatus === 'UNSTABLE' || mergeStateStatus === 'UNKNOWN'
   if (
-    data.mergeStateStatus?.toUpperCase() !== 'UNSTABLE' ||
+    !rollupMayOmitSuiteOnlyChecks ||
     mapPRState(data.state, data.isDraft) !== 'open' ||
     rollupStatus === 'failure' ||
     rollupStatus === 'action_required'
@@ -40,8 +44,8 @@ export async function hydrateUnstablePRCheckRollup(
     const checks = await loadChecks()
     return checks.length > 0 ? { ...data, statusCheckRollup: checks } : neutralFallback
   } catch (error) {
-    // An unstable passing rollup is incomplete; keep it visible without claiming success.
-    console.warn('Unable to hydrate unstable PR checks:', error)
+    // An incomplete passing rollup must stay visible without claiming success.
+    console.warn('Unable to hydrate incomplete PR checks:', error)
     return neutralFallback
   }
 }

--- a/src/main/github/client/lookup/unstable-pr-check-rollup.ts
+++ b/src/main/github/client/lookup/unstable-pr-check-rollup.ts
@@ -2,12 +2,12 @@ import type { PRCheckDetail } from '../../../../shared/github/check-types'
 import type { OwnerRepo } from '../../gh-utils'
 import { getPRChecksWithExistingOperationPermit } from './../check/get-pr-checks'
 import type { HostedReviewLocalGitOptions } from './../github-exec-scope'
-import { mapPRState } from '../../mappers'
+import { deriveCheckStatuses, mapPRState } from '../../mappers'
 import type { PullRequestLookupData } from './pull-request-lookup-data'
 
 type DetailedCheckLoader = () => Promise<PRCheckDetail[]>
 
-export async function hydrateMissingUnstablePRCheckRollup(
+export async function hydrateUnstablePRCheckRollup(
   data: PullRequestLookupData,
   args: {
     repoPath: string
@@ -25,20 +25,23 @@ export async function hydrateMissingUnstablePRCheckRollup(
       args.localGitOptions
     )
 ): Promise<PullRequestLookupData> {
+  const rollupStatus = deriveCheckStatuses(data.statusCheckRollup).presentationStatus
   if (
-    data.statusCheckRollup.length > 0 ||
     data.mergeStateStatus?.toUpperCase() !== 'UNSTABLE' ||
-    mapPRState(data.state, data.isDraft) !== 'open'
+    mapPRState(data.state, data.isDraft) !== 'open' ||
+    (data.statusCheckRollup.length > 0 && rollupStatus !== 'success')
   ) {
     return data
   }
 
+  const neutralFallback =
+    data.statusCheckRollup.length > 0 ? { ...data, statusCheckRollup: [] } : data
   try {
     const checks = await loadChecks()
-    return checks.length > 0 ? { ...data, statusCheckRollup: checks } : data
+    return checks.length > 0 ? { ...data, statusCheckRollup: checks } : neutralFallback
   } catch (error) {
-    // Detailed checks are additive; keep the PR visible when their fallback lookup fails.
+    // An unstable passing rollup is incomplete; keep it visible without claiming success.
     console.warn('Unable to hydrate unstable PR checks:', error)
-    return data
+    return neutralFallback
   }
 }

--- a/src/main/github/mappers.ts
+++ b/src/main/github/mappers.ts
@@ -1,6 +1,10 @@
 import type { PRCheckDetail } from '../../shared/github/check-types'
 import type { CheckStatus, IssueInfo, PRInfo } from '../../shared/github/pull-request-types'
-import { derivePRCheckStatusFromRollup } from '../../shared/pr-check-status'
+import {
+  derivePRCheckStatusesFromRollup,
+  derivePRCheckStatusFromRollup,
+  type PRCheckStatuses
+} from '../../shared/pr-check-status'
 
 // ── REST API check-runs mapping ───────────────────────────────────────
 // The REST check-runs endpoint returns separate status + conclusion fields
@@ -148,4 +152,8 @@ export function mapIssueInfo(data: {
 
 export function deriveCheckStatus(rollup: unknown[] | null | undefined): CheckStatus {
   return derivePRCheckStatusFromRollup(rollup)
+}
+
+export function deriveCheckStatuses(rollup: unknown[] | null | undefined): PRCheckStatuses {
+  return derivePRCheckStatusesFromRollup(rollup)
 }

--- a/src/renderer/src/components/github-pr-check-merge-presentation.ts
+++ b/src/renderer/src/components/github-pr-check-merge-presentation.ts
@@ -1,0 +1,49 @@
+import type { CheckStatus } from '../../../shared/github/pull-request-types'
+import { translate } from '@/i18n/i18n'
+
+type GitHubPRCheckMergePresentation = {
+  label: string
+  tone: string
+  tooltip: string
+}
+
+export function getGitHubPRCheckMergePresentation(
+  state: CheckStatus | 'action_required' | 'none' | undefined,
+  dangerTone: string,
+  warningTone: string
+): GitHubPRCheckMergePresentation | null {
+  if (state === 'failure') {
+    return {
+      label: translate('auto.components.github.pr.merge.state.87fa36ac83', 'Checks failed'),
+      tone: dangerTone,
+      tooltip: translate(
+        'auto.components.github.pr.merge.state.1432ecff30',
+        'GitHub says this PR can merge, but some checks failed'
+      )
+    }
+  }
+  if (state === 'action_required') {
+    return {
+      label: translate(
+        'auto.components.editor.CheckRunDetailsPanel.actionRequired',
+        'Action required'
+      ),
+      tone: warningTone,
+      tooltip: translate(
+        'auto.components.right.sidebar.checks.panel.content.actionRequiredHint',
+        'Needs a manual action on GitHub (e.g. approving the run) to unblock merging.'
+      )
+    }
+  }
+  if (state === 'pending') {
+    return {
+      label: translate('auto.components.github.pr.merge.state.4e2507176b', 'Checks pending'),
+      tone: warningTone,
+      tooltip: translate(
+        'auto.components.github.pr.merge.state.9bd983ce8f',
+        'GitHub says this PR can merge, but checks are still running'
+      )
+    }
+  }
+  return null
+}

--- a/src/renderer/src/components/github-pr-merge-state.test.ts
+++ b/src/renderer/src/components/github-pr-merge-state.test.ts
@@ -190,6 +190,28 @@ describe('presentGitHubPRMergeState', () => {
     })
   })
 
+  it('presents action-required checks as a warning rather than a failure', () => {
+    expect(
+      presentGitHubPRMergeState(
+        pr({
+          checksSummary: {
+            state: 'failure',
+            total: 2,
+            passed: 0,
+            failed: 2,
+            pending: 0,
+            neutral: 0,
+            actionRequired: 2
+          }
+        })
+      )
+    ).toMatchObject({
+      label: 'Action required',
+      tone: expect.stringContaining('amber'),
+      directMergeAvailable: true
+    })
+  })
+
   it('labels unresolved GitHub mergeability as checking', () => {
     expect(
       presentGitHubPRMergeState(

--- a/src/renderer/src/components/github-pr-merge-state.test.ts
+++ b/src/renderer/src/components/github-pr-merge-state.test.ts
@@ -212,6 +212,30 @@ describe('presentGitHubPRMergeState', () => {
     })
   })
 
+  it('prefers the hosted-review presentation status over the legacy failure status', () => {
+    expect(
+      presentGitHubPRMergeState(
+        pr({
+          checksSummary: undefined,
+          checksStatus: 'failure',
+          checksPresentationStatus: 'action_required'
+        })
+      )
+    ).toMatchObject({
+      label: 'Action required',
+      tone: expect.stringContaining('amber')
+    })
+  })
+
+  it('falls back to the legacy failure status when an older runtime omits presentation status', () => {
+    expect(
+      presentGitHubPRMergeState(pr({ checksSummary: undefined, checksStatus: 'failure' }))
+    ).toMatchObject({
+      label: 'Checks failed',
+      tone: expect.stringContaining('rose')
+    })
+  })
+
   it('labels unresolved GitHub mergeability as checking', () => {
     expect(
       presentGitHubPRMergeState(

--- a/src/renderer/src/components/github-pr-merge-state.ts
+++ b/src/renderer/src/components/github-pr-merge-state.ts
@@ -1,4 +1,5 @@
 import type {
+  CheckPresentationStatus,
   CheckStatus,
   PRMergeableState,
   PRReviewDecision,
@@ -16,6 +17,7 @@ export type GitHubPRMergeStateInput = {
   mergeStateStatus?: string | null
   reviewDecision?: PRReviewDecision | null
   checksStatus?: CheckStatus
+  checksPresentationStatus?: CheckPresentationStatus
   checksSummary?: ProviderCheckSummary
   autoMergeEnabled?: boolean
   autoMergeAllowed?: boolean | null
@@ -48,7 +50,7 @@ function checksState(
   if (item.checksSummary) {
     return getProviderChecksPresentationState(item.checksSummary)
   }
-  return item.checksStatus
+  return item.checksPresentationStatus ?? item.checksStatus
 }
 
 function checksPassed(item: GitHubPRMergeStateInput): boolean {

--- a/src/renderer/src/components/github-pr-merge-state.ts
+++ b/src/renderer/src/components/github-pr-merge-state.ts
@@ -6,7 +6,9 @@ import type {
   ProviderCheckSummary
 } from '../../../shared/github/pull-request-types'
 import { canEnableGitHubPRAutoMerge } from '../../../shared/github/pull-request-auto-merge-availability'
+import { getProviderChecksPresentationState } from '../../../shared/provider-check-summary'
 import { translate } from '@/i18n/i18n'
+import { getGitHubPRCheckMergePresentation } from './github-pr-check-merge-presentation'
 
 export type GitHubPRMergeStateInput = {
   state: PRState | 'open' | 'closed' | 'merged' | 'draft'
@@ -40,9 +42,11 @@ const SUCCESS_TONE =
 const WARNING_TONE = 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-200'
 const DANGER_TONE = 'border-rose-500/30 bg-rose-500/10 text-rose-700 dark:text-rose-200'
 
-function checksState(item: GitHubPRMergeStateInput): CheckStatus | 'none' | undefined {
+function checksState(
+  item: GitHubPRMergeStateInput
+): CheckStatus | 'action_required' | 'none' | undefined {
   if (item.checksSummary) {
-    return item.checksSummary.state
+    return getProviderChecksPresentationState(item.checksSummary)
   }
   return item.checksStatus
 }
@@ -258,29 +262,7 @@ export function presentGitHubPRMergeState(
   }
   if (item.mergeable === 'MERGEABLE' || item.mergeStateStatus === 'CLEAN') {
     const checkState = checksState(item)
-    const checkStatus =
-      checkState === 'failure'
-        ? {
-            label: translate('auto.components.github.pr.merge.state.87fa36ac83', 'Checks failed'),
-            tone: DANGER_TONE,
-            tooltip: translate(
-              'auto.components.github.pr.merge.state.1432ecff30',
-              'GitHub says this PR can merge, but some checks failed'
-            )
-          }
-        : checkState === 'pending'
-          ? {
-              label: translate(
-                'auto.components.github.pr.merge.state.4e2507176b',
-                'Checks pending'
-              ),
-              tone: WARNING_TONE,
-              tooltip: translate(
-                'auto.components.github.pr.merge.state.9bd983ce8f',
-                'GitHub says this PR can merge, but checks are still running'
-              )
-            }
-          : null
+    const checkStatus = getGitHubPRCheckMergePresentation(checkState, DANGER_TONE, WARNING_TONE)
     return {
       label: checkStatus?.label ?? 'Able to merge',
       tone: checkStatus?.tone ?? SUCCESS_TONE,

--- a/src/renderer/src/components/pr-check-counts.ts
+++ b/src/renderer/src/components/pr-check-counts.ts
@@ -1,5 +1,8 @@
 import { translate } from '../i18n/i18n'
-import { summarizeProviderChecks } from '../../../shared/provider-check-summary'
+import {
+  getProviderCheckFailureCount,
+  summarizeProviderChecks
+} from '../../../shared/provider-check-summary'
 import type { PRCheckDetail } from '../../../shared/github/check-types'
 
 export type PRCheckCounts = {
@@ -23,16 +26,12 @@ export function getCheckConclusion(check: PRCheckDetail): NonNullable<PRCheckDet
  */
 export function getCheckCounts(checks: readonly PRCheckDetail[]): PRCheckCounts {
   // Why: every bucket is read off the shared rollup rather than re-derived, so these panes cannot
-  // disagree with the checks pill. action_required is the one split back out: it blocks merge like
-  // a failure but reads amber, not red.
+  // disagree with the checks pill.
   const summary = summarizeProviderChecks(checks)
-  const needsAction = checks.filter(
-    (check) => getCheckConclusion(check) === 'action_required'
-  ).length
   return {
     passing: summary.passed,
-    failing: summary.failed - needsAction,
-    needsAction,
+    failing: getProviderCheckFailureCount(summary),
+    needsAction: summary.actionRequired ?? 0,
     pending: summary.pending,
     neutral: summary.neutral
   }

--- a/src/renderer/src/components/pr-check-counts.ts
+++ b/src/renderer/src/components/pr-check-counts.ts
@@ -43,6 +43,14 @@ export type PRCheckCountChip = {
   label: string
 }
 
+export function getActionRequiredCheckCountLabel(count: number): string {
+  return translate(
+    'auto.components.pr-check-counts.needsActionChip',
+    'Action required: {{value0}}',
+    { value0: count }
+  )
+}
+
 /**
  * The count chips above the check list on the PR page and the work-item dialog. One builder so the
  * two panes cannot word the same bucket differently — the neutral bucket read "skipped" here while
@@ -69,11 +77,7 @@ export function getCheckCountChips(counts: PRCheckCounts): PRCheckCountChip[] {
   if (counts.needsAction > 0) {
     chips.push({
       tone: 'action_required',
-      label: translate(
-        'auto.components.pr-check-counts.needsActionChip',
-        '{{value0}} action required',
-        { value0: counts.needsAction }
-      )
+      label: getActionRequiredCheckCountLabel(counts.needsAction)
     })
   }
   if (counts.pending > 0) {

--- a/src/renderer/src/components/provider-check-classification-parity.test.ts
+++ b/src/renderer/src/components/provider-check-classification-parity.test.ts
@@ -266,6 +266,6 @@ describe('provider check classification parity', () => {
     expect(getProviderChecksPresentationState(failureAndAction)).toBe('failure')
     expect(getProviderChecksLabel(failureAndAction)).toBe('1 failing')
     expect(getProviderChecksPresentationState(actionAndPending)).toBe('action_required')
-    expect(getProviderChecksLabel(actionAndPending)).toBe('1 action required')
+    expect(getProviderChecksLabel(actionAndPending)).toBe('Action required: 1')
   })
 })

--- a/src/renderer/src/components/provider-check-classification-parity.test.ts
+++ b/src/renderer/src/components/provider-check-classification-parity.test.ts
@@ -6,6 +6,7 @@ import { gitLabPipelineJobsToPRChecks } from '../../../shared/gitlab-pipeline-ch
 import { derivePRCheckStatus, derivePRCheckStatusFromRollup } from '../../../shared/pr-check-status'
 import {
   getProviderChecksLabel,
+  getProviderChecksPresentationState,
   summarizeProviderChecks
 } from '../../../shared/provider-check-summary'
 import type { GitLabPipelineJob } from '../../../shared/gitlab-types'
@@ -160,7 +161,41 @@ const PARITY_CASES: ParityCase[] = [
   {
     name: 'genuine action_required',
     checks: [completed('success'), completed('action_required')],
-    expected: { state: 'failure', passed: 1, failed: 1, pending: 0, neutral: 0 }
+    expected: {
+      state: 'failure',
+      passed: 1,
+      failed: 1,
+      pending: 0,
+      neutral: 0,
+      actionRequired: 1
+    }
+  },
+  {
+    name: 'failure alongside action_required',
+    checks: [completed('failure'), completed('action_required')],
+    expected: {
+      state: 'failure',
+      passed: 0,
+      failed: 2,
+      pending: 0,
+      neutral: 0,
+      actionRequired: 1
+    }
+  },
+  {
+    name: 'action_required alongside running',
+    checks: [
+      completed('action_required'),
+      { name: 'ci', status: 'in_progress', conclusion: null, url: null }
+    ],
+    expected: {
+      state: 'failure',
+      passed: 0,
+      failed: 1,
+      pending: 1,
+      neutral: 0,
+      actionRequired: 1
+    }
   }
 ]
 
@@ -176,15 +211,16 @@ describe('provider check classification parity', () => {
       const paneCounts = getCheckCounts(checks)
       expect({
         passed: paneCounts.passing,
-        // Both panes split action_required into its own amber chip; it is still the failed bucket.
         failed: paneCounts.failing + paneCounts.needsAction,
         pending: paneCounts.pending,
-        neutral: paneCounts.neutral
+        neutral: paneCounts.neutral,
+        actionRequired: paneCounts.needsAction || undefined
       }).toEqual({
         passed: expected.passed,
         failed: expected.failed,
         pending: expected.pending,
-        neutral: expected.neutral
+        neutral: expected.neutral,
+        actionRequired: expected.actionRequired
       })
       expect(getCheckCountChips(paneCounts).find((chip) => chip.tone === 'neutral')?.label).toBe(
         expected.neutral > 0 ? `${expected.neutral} unresolved` : undefined
@@ -215,5 +251,21 @@ describe('provider check classification parity', () => {
   it('labels a green PR carrying one neutral check as passing', () => {
     const checks = [...Array.from({ length: 19 }, () => completed('success')), completed('neutral')]
     expect(getProviderChecksLabel(summarizeProviderChecks(checks))).toBe('19/20 passed')
+  })
+
+  it('presents genuine failures ahead of action-required and action-required ahead of pending', () => {
+    const failureAndAction = summarizeProviderChecks([
+      completed('failure'),
+      completed('action_required')
+    ])
+    const actionAndPending = summarizeProviderChecks([
+      completed('action_required'),
+      { status: 'in_progress', conclusion: null }
+    ])
+
+    expect(getProviderChecksPresentationState(failureAndAction)).toBe('failure')
+    expect(getProviderChecksLabel(failureAndAction)).toBe('1 failing')
+    expect(getProviderChecksPresentationState(actionAndPending)).toBe('action_required')
+    expect(getProviderChecksLabel(actionAndPending)).toBe('1 action required')
   })
 })

--- a/src/renderer/src/components/right-sidebar/FolderWorkspacePrChecksPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/FolderWorkspacePrChecksPanel.test.tsx
@@ -74,12 +74,16 @@ vi.mock('./checks-panel/check-presentation', () => ({
   CHECK_COLOR: {
     success: 'success',
     failure: 'failure',
+    action_required: 'action-required',
     pending: 'pending',
     neutral: 'neutral'
   },
   CHECK_ICON: {
     success: (props: { className?: string }) => <span data-icon="success" {...props} />,
     failure: (props: { className?: string }) => <span data-icon="failure" {...props} />,
+    action_required: (props: { className?: string }) => (
+      <span data-icon="action-required" {...props} />
+    ),
     pending: (props: { className?: string }) => <span data-icon="pending" {...props} />,
     neutral: (props: { className?: string }) => <span data-icon="neutral" {...props} />
   },
@@ -272,6 +276,35 @@ describe('FolderWorkspacePrChecksPanel', () => {
     expect(container.textContent).not.toContain('1 attached')
     expect(container.textContent).not.toContain('with PR/MR')
     expect(container.textContent).not.toContain('unknown')
+  })
+
+  it('summarizes action-required rows separately from failures', () => {
+    const repo = mockState.store.repos[0]
+    const hostedKey = getHostedReviewCacheKey(repo.path, 'feature', null, repo.id)
+    mockState.store.hostedReviewCache[hostedKey] = {
+      data: makeReview({
+        status: 'failure',
+        checksPresentationStatus: 'action_required'
+      }),
+      fetchedAt: 1
+    }
+    const checksKey = getGitHubRepoCacheKey(
+      repo.path,
+      repo.id,
+      prChecksCacheSuffix(12, null, 'abc'),
+      null
+    )
+    mockState.store.checksCache[checksKey] = {
+      data: [makeCheck({ conclusion: 'action_required' })],
+      fetchedAt: 1,
+      headSha: 'abc'
+    }
+
+    renderPanel()
+
+    expect(container.textContent).toContain('Action required: 1 · 1 worktree')
+    expect(container.textContent).not.toContain('1 failing')
+    expect(container.querySelector('[data-icon="action-required"]')).not.toBeNull()
   })
 
   it('summarizes failing and pending rows before the worktree count', () => {

--- a/src/renderer/src/components/right-sidebar/FolderWorkspacePrChecksPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/FolderWorkspacePrChecksPanel.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
+import { getActionRequiredCheckCountLabel } from '@/components/pr-check-counts'
 import type { PRCheckDetail, PRCheckRunDetails } from '../../../../shared/github/check-types'
 import { getAttachedWorktreesForFolderWorkspace } from './folder-workspace-attached-worktrees'
 import { FolderWorkspacePrChecksRow } from './FolderWorkspacePrChecksRow'
@@ -278,6 +279,7 @@ export default function FolderWorkspacePrChecksPanel({
 function formatReviewChecksHeaderSummary(summary: {
   attached: number
   failing: number
+  actionRequired: number
   pending: number
   passing: number
 }): string | null {
@@ -287,6 +289,7 @@ function formatReviewChecksHeaderSummary(summary: {
   const worktreeCount = formatWorktreeCount(summary.attached)
   const attentionParts = [
     summary.failing > 0 ? formatFailingCount(summary.failing) : null,
+    summary.actionRequired > 0 ? getActionRequiredCheckCountLabel(summary.actionRequired) : null,
     summary.pending > 0 ? formatPendingCount(summary.pending) : null
   ].filter((part): part is string => part !== null)
 

--- a/src/renderer/src/components/right-sidebar/FolderWorkspacePrChecksRow.test.tsx
+++ b/src/renderer/src/components/right-sidebar/FolderWorkspacePrChecksRow.test.tsx
@@ -3,7 +3,7 @@
 import { act, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { CheckStatus } from '../../../../shared/github/pull-request-types'
+import type { CheckPresentationStatus } from '../../../../shared/github/pull-request-types'
 import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import type { ParentPrChecksRow, ParentPrChecksRowStatus } from './parent-pr-checks-row-types'
@@ -27,12 +27,16 @@ vi.mock('./checks-panel/check-presentation', () => ({
   CHECK_COLOR: {
     success: 'success-color',
     failure: 'failure-color',
+    action_required: 'action-required-color',
     pending: 'pending-color',
     neutral: 'neutral-color'
   },
   CHECK_ICON: {
     success: (props: { className?: string }) => <span data-icon="success" {...props} />,
     failure: (props: { className?: string }) => <span data-icon="failure" {...props} />,
+    action_required: (props: { className?: string }) => (
+      <span data-icon="action-required" {...props} />
+    ),
     pending: (props: { className?: string }) => <span data-icon="pending" {...props} />,
     neutral: (props: { className?: string }) => <span data-icon="neutral" {...props} />
   },
@@ -87,7 +91,7 @@ function makeRepo(): Repo {
 function makeRow(
   overrides: Partial<ParentPrChecksRow> & {
     status?: ParentPrChecksRowStatus
-    checkTone?: CheckStatus
+    checkTone?: CheckPresentationStatus
   } = {}
 ): ParentPrChecksRow {
   return {
@@ -160,6 +164,13 @@ describe('FolderWorkspacePrChecksRow', () => {
       icon: 'failure',
       color: 'failure-color',
       summary: 'Checks failing'
+    },
+    {
+      status: 'actionRequired' as const,
+      checkTone: 'action_required' as const,
+      icon: 'action-required',
+      color: 'action-required-color',
+      summary: 'Action required'
     }
   ])('shows $icon status as summary metadata after the review identity', (state) => {
     renderRow(

--- a/src/renderer/src/components/right-sidebar/HostedReviewActions.tsx
+++ b/src/renderer/src/components/right-sidebar/HostedReviewActions.tsx
@@ -90,6 +90,7 @@ export default function HostedReviewActions({
       mergeStateStatus: review.mergeStateStatus,
       reviewDecision: review.reviewDecision,
       checksStatus: review.status,
+      checksPresentationStatus: review.checksPresentationStatus,
       autoMergeEnabled: review.autoMergeEnabled,
       autoMergeAllowed: review.autoMergeAllowed,
       mergeQueueRequired: review.mergeQueueRequired

--- a/src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx
@@ -194,7 +194,8 @@ describe('MergeConflictNotice', () => {
       })
     )
 
-    expect(markup).toContain('1 action required')
+    expect(markup).toContain('Action required: 1')
+    expect(markup).toContain('GitHub')
     expect(markup).toContain('text-amber-500')
     expect(markup).not.toContain('failing check')
     expect(markup).not.toContain('>Fix<')
@@ -284,12 +285,31 @@ describe('ChecksList', () => {
     )
     const summaryMarkup = markup.slice(0, markup.indexOf('</button>'))
 
-    expect(summaryMarkup).toContain('2 action required')
+    expect(summaryMarkup).toContain('Action required: 2')
     expect(summaryMarkup).toContain('lucide-triangle-alert')
     expect(summaryMarkup).toContain('text-amber-500')
     expect(summaryMarkup).not.toContain('2 failing')
     expect(summaryMarkup).not.toContain('text-rose-500')
-    expect(markup.match(/Action required/g)).toHaveLength(2)
+    expect(markup.match(/Action required/g)).toHaveLength(3)
+  })
+
+  it('names GitLab in the action-required hint for merge requests', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(PRTriageStrip, {
+        review: makePR({ mergeable: 'MERGEABLE' }),
+        reviewKind: 'MR',
+        checks: [
+          { name: 'approve', status: 'completed', conclusion: 'action_required', url: null }
+        ],
+        isResolvingConflictsWithAI: false,
+        onResolveConflictsWithAI: () => {},
+        isFixingChecksWithAI: false,
+        onFixChecksWithAI: () => {}
+      })
+    )
+
+    expect(markup).toContain('Needs a manual action on GitLab')
+    expect(markup).not.toContain('Needs a manual action on GitHub')
   })
 
   // Why: a completed check with no conclusion will never resolve, so calling it pending kept an

--- a/src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx
@@ -10,7 +10,7 @@ import {
   MergeConflictNotice
 } from './checks-panel/conflict-summary'
 import { ConflictTriageStrip, PRTriageStrip } from './checks-panel/triage-strip'
-import { getFailedChecksForDetails } from './checks-panel/check-details-model'
+import { getChecksRequiringAttentionForDetails } from './checks-panel/check-details-model'
 import { ChecksList } from './checks-panel/checks-list'
 import { isMutablePRConversationComment } from './checks-panel/comment-controls'
 import { PRCommentsList } from './checks-panel/comments-list'
@@ -179,6 +179,26 @@ describe('MergeConflictNotice', () => {
     expect(markup).not.toContain('Fix with AI')
     expect(markup).not.toContain('Resolve')
   })
+
+  it('prompts for action-required checks without offering an AI failure fix', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(PRTriageStrip, {
+        review: makePR({ mergeable: 'MERGEABLE' }),
+        checks: [
+          { name: 'approve', status: 'completed', conclusion: 'action_required', url: null }
+        ],
+        isResolvingConflictsWithAI: false,
+        onResolveConflictsWithAI: () => {},
+        isFixingChecksWithAI: false,
+        onFixChecksWithAI: () => {}
+      })
+    )
+
+    expect(markup).toContain('1 action required')
+    expect(markup).toContain('text-amber-500')
+    expect(markup).not.toContain('failing check')
+    expect(markup).not.toContain('>Fix<')
+  })
 })
 
 describe('ChecksList', () => {
@@ -235,6 +255,41 @@ describe('ChecksList', () => {
 
     expect(markup).toContain('5 passing')
     expect(markup).not.toContain('2 passing')
+  })
+
+  it('summarizes action-required checks as action required instead of failing', () => {
+    const markup = renderToStaticMarkup(
+      React.createElement(
+        TooltipProvider,
+        null,
+        React.createElement(ChecksList, {
+          checks: [
+            {
+              name: 'Approve and run',
+              status: 'completed',
+              conclusion: 'action_required',
+              url: null
+            },
+            {
+              name: 'Deploy preview',
+              status: 'completed',
+              conclusion: 'action_required',
+              url: null
+            }
+          ],
+          checksLoading: false,
+          checkDetailsContextKey: 'repo:action-required'
+        })
+      )
+    )
+    const summaryMarkup = markup.slice(0, markup.indexOf('</button>'))
+
+    expect(summaryMarkup).toContain('2 action required')
+    expect(summaryMarkup).toContain('lucide-triangle-alert')
+    expect(summaryMarkup).toContain('text-amber-500')
+    expect(summaryMarkup).not.toContain('2 failing')
+    expect(summaryMarkup).not.toContain('text-rose-500')
+    expect(markup.match(/Action required/g)).toHaveLength(2)
   })
 
   // Why: a completed check with no conclusion will never resolve, so calling it pending kept an
@@ -467,20 +522,22 @@ describe('PRCommentsList', () => {
   })
 })
 
-describe('getFailedChecksForDetails', () => {
-  it('selects failed, cancelled, and timed out checks for inline details', () => {
+describe('getChecksRequiringAttentionForDetails', () => {
+  it('selects failures and action-required checks for inline details', () => {
     const checks: PRCheckDetail[] = [
       { name: 'unit', status: 'completed', conclusion: 'success', url: null },
       { name: 'verify', status: 'completed', conclusion: 'failure', url: null },
       { name: 'lint', status: 'completed', conclusion: 'cancelled', url: null },
       { name: 'e2e', status: 'completed', conclusion: 'timed_out', url: null },
+      { name: 'approve', status: 'completed', conclusion: 'action_required', url: null },
       { name: 'deploy', status: 'in_progress', conclusion: 'pending', url: null }
     ]
 
-    expect(getFailedChecksForDetails(checks).map((check) => check.name)).toEqual([
+    expect(getChecksRequiringAttentionForDetails(checks).map((check) => check.name)).toEqual([
       'verify',
       'lint',
-      'e2e'
+      'e2e',
+      'approve'
     ])
   })
 })

--- a/src/renderer/src/components/right-sidebar/checks-panel/check-details-model.ts
+++ b/src/renderer/src/components/right-sidebar/checks-panel/check-details-model.ts
@@ -39,10 +39,8 @@ export function getCheckConclusion(check: PRCheckDetail): NonNullable<PRCheckDet
   return check.conclusion ?? 'pending'
 }
 
-export function isFailedCheck(check: PRCheckDetail): boolean {
-  // Why: action_required blocks merge just like a failure, so it must count as
-  // not-passing — otherwise the summary reads "all checks passing" while
-  // auto-merge stays blocked.
+export function isCheckRequiringAttention(check: PRCheckDetail): boolean {
+  // Action-required checks are not failures, but auto-expanding either kind exposes the blocker.
   return ['failure', 'cancelled', 'timed_out', 'action_required'].includes(
     getCheckConclusion(check)
   )
@@ -100,8 +98,8 @@ export function formatCheckTimestamp(input: string | null | undefined): string |
   })
 }
 
-export function getFailedChecksForDetails(checks: PRCheckDetail[]): PRCheckDetail[] {
-  return checks.filter(isFailedCheck)
+export function getChecksRequiringAttentionForDetails(checks: PRCheckDetail[]): PRCheckDetail[] {
+  return checks.filter(isCheckRequiringAttention)
 }
 
 export type CheckDetailsStickySurface = 'sidebar' | 'card'

--- a/src/renderer/src/components/right-sidebar/checks-panel/checks-list.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/checks-list.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {
+  AlertTriangle,
   ChevronDown,
   ChevronRight,
   CircleCheck,
@@ -38,6 +39,7 @@ export function ChecksList(props: ChecksListProps): React.JSX.Element {
     rows,
     passingCount,
     failingCount,
+    actionRequiredCount,
     pendingCount,
     neutralCount,
     toggleCheckExpanded,
@@ -73,6 +75,16 @@ export function ChecksList(props: ChecksListProps): React.JSX.Element {
               {translate(
                 'auto.components.right.sidebar.checks.panel.content.5e52f4ef7f',
                 'failing'
+              )}
+            </span>
+          )}
+          {actionRequiredCount > 0 && (
+            <span className="flex items-center gap-1">
+              <AlertTriangle className="size-3 text-amber-500" />
+              {translate(
+                'auto.components.pr-check-counts.needsActionChip',
+                '{{value0}} action required',
+                { value0: actionRequiredCount }
               )}
             </span>
           )}

--- a/src/renderer/src/components/right-sidebar/checks-panel/checks-list.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/checks-list.tsx
@@ -13,6 +13,7 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
+import { getActionRequiredCheckCountLabel } from '@/components/pr-check-counts'
 import { CHECK_COLOR, CHECK_ICON } from './check-presentation'
 import { CheckRunDetails } from './check-run-details'
 import { getCheckStatusLabel } from './check-details-model'
@@ -81,11 +82,7 @@ export function ChecksList(props: ChecksListProps): React.JSX.Element {
           {actionRequiredCount > 0 && (
             <span className="flex items-center gap-1">
               <AlertTriangle className="size-3 text-amber-500" />
-              {translate(
-                'auto.components.pr-check-counts.needsActionChip',
-                '{{value0}} action required',
-                { value0: actionRequiredCount }
-              )}
+              {getActionRequiredCheckCountLabel(actionRequiredCount)}
             </span>
           )}
           {pendingCount > 0 && (

--- a/src/renderer/src/components/right-sidebar/checks-panel/triage-strip.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/triage-strip.tsx
@@ -11,7 +11,10 @@ import {
 import { Button } from '@/components/ui/button'
 import type { PRCheckDetail } from '../../../../../shared/github/check-types'
 import type { ConflictReview } from './conflict-summary'
-import { summarizeProviderChecks } from '../../../../../shared/provider-check-summary'
+import {
+  getProviderCheckFailureCount,
+  summarizeProviderChecks
+} from '../../../../../shared/provider-check-summary'
 import { translate } from '@/i18n/i18n'
 
 export function PRTriageStrip({
@@ -46,7 +49,8 @@ export function PRTriageStrip({
   // `{status: completed, conclusion: null}` check used to spin here as "1 pending" forever while
   // the pill two panes away called it unresolved.
   const summary = summarizeProviderChecks(checks)
-  const failingCount = summary.failed
+  const failingCount = getProviderCheckFailureCount(summary)
+  const actionRequiredCount = summary.actionRequired ?? 0
   const pendingCount = summary.pending
 
   if (resolvedReview?.mergeable === 'CONFLICTING') {
@@ -97,6 +101,31 @@ export function PRTriageStrip({
             )}
             {translate('auto.components.right.sidebar.checks.panel.content.b45db92d0e', 'Fix')}
           </Button>
+        </div>
+      </div>
+    )
+  }
+
+  if (actionRequiredCount > 0) {
+    return (
+      <div className="border-b border-border px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <AlertTriangle className="size-3.5 shrink-0 text-amber-500" />
+          <div className="min-w-0 flex-1">
+            <div className="truncate text-[11px] font-medium text-foreground">
+              {translate(
+                'auto.components.pr-check-counts.needsActionChip',
+                '{{value0}} action required',
+                { value0: actionRequiredCount }
+              )}
+            </div>
+            <div className="truncate text-[10px] text-muted-foreground">
+              {translate(
+                'auto.components.right.sidebar.checks.panel.content.actionRequiredHint',
+                'Needs a manual action on GitHub (e.g. approving the run) to unblock merging.'
+              )}
+            </div>
+          </div>
         </div>
       </div>
     )

--- a/src/renderer/src/components/right-sidebar/checks-panel/triage-strip.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/triage-strip.tsx
@@ -120,8 +120,8 @@ export function PRTriageStrip({
             <div className="truncate text-[10px] text-muted-foreground">
               {translate(
                 'auto.components.right.sidebar.checks.panel.content.actionRequiredProviderHint',
-                'Needs a manual action on {{value0}} to unblock merging.',
-                { value0: providerName }
+                'Needs a manual action on {{providerName}} to unblock merging.',
+                { providerName }
               )}
             </div>
           </div>

--- a/src/renderer/src/components/right-sidebar/checks-panel/triage-strip.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/triage-strip.tsx
@@ -9,6 +9,7 @@ import {
   Sparkles
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { getActionRequiredCheckCountLabel } from '@/components/pr-check-counts'
 import type { PRCheckDetail } from '../../../../../shared/github/check-types'
 import type { ConflictReview } from './conflict-summary'
 import {
@@ -52,6 +53,7 @@ export function PRTriageStrip({
   const failingCount = getProviderCheckFailureCount(summary)
   const actionRequiredCount = summary.actionRequired ?? 0
   const pendingCount = summary.pending
+  const providerName = reviewKind === 'MR' ? 'GitLab' : 'GitHub'
 
   if (resolvedReview?.mergeable === 'CONFLICTING') {
     return (
@@ -113,16 +115,13 @@ export function PRTriageStrip({
           <AlertTriangle className="size-3.5 shrink-0 text-amber-500" />
           <div className="min-w-0 flex-1">
             <div className="truncate text-[11px] font-medium text-foreground">
-              {translate(
-                'auto.components.pr-check-counts.needsActionChip',
-                '{{value0}} action required',
-                { value0: actionRequiredCount }
-              )}
+              {getActionRequiredCheckCountLabel(actionRequiredCount)}
             </div>
             <div className="truncate text-[10px] text-muted-foreground">
               {translate(
-                'auto.components.right.sidebar.checks.panel.content.actionRequiredHint',
-                'Needs a manual action on GitHub (e.g. approving the run) to unblock merging.'
+                'auto.components.right.sidebar.checks.panel.content.actionRequiredProviderHint',
+                'Needs a manual action on {{value0}} to unblock merging.',
+                { value0: providerName }
               )}
             </div>
           </div>

--- a/src/renderer/src/components/right-sidebar/checks-panel/use-checks-list-state.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/use-checks-list-state.tsx
@@ -5,7 +5,10 @@ import type { GitLabProjectRef } from '../../../../../shared/gitlab-types'
 import type { PRCheckDetail, PRCheckRunDetails } from '../../../../../shared/github/check-types'
 import type { GitHubRepositoryIdentity } from '../../../../../shared/github/pull-request-types'
 import { sortChecksBySeverity } from '../../../../../shared/pr-check-severity-order'
-import { summarizeProviderChecks } from '../../../../../shared/provider-check-summary'
+import {
+  getProviderCheckFailureCount,
+  summarizeProviderChecks
+} from '../../../../../shared/provider-check-summary'
 import { createCheckRunDetailsRequestId } from '@/components/editor/check-run-details-tab'
 import { translate } from '@/i18n/i18n'
 import { useCheckDetailsResize } from '../check-details-resize'
@@ -13,7 +16,7 @@ import {
   type CheckDetailsLoadState,
   type CheckDetailsStickySurface,
   getCheckDetailsKey,
-  isFailedCheck
+  isCheckRequiringAttention
 } from './check-details-model'
 
 export type ChecksListProps = {
@@ -64,12 +67,12 @@ export function useChecksListState({
   // Why: every header count comes from the same classifier the checks pill uses — counting only
   // `success` made a 2-success/3-skipped PR say "2 passing" next to "5/5 passed", and treating a
   // null conclusion as pending kept a completed-but-unresolved check spinning forever.
-  const {
-    passed: passingCount,
-    failed: failingCount,
-    pending: pendingCount,
-    neutral: neutralCount
-  } = summarizeProviderChecks(checks)
+  const summary = summarizeProviderChecks(checks)
+  const passingCount = summary.passed
+  const failingCount = getProviderCheckFailureCount(summary)
+  const actionRequiredCount = summary.actionRequired ?? 0
+  const pendingCount = summary.pending
+  const neutralCount = summary.neutral
 
   useEffect(() => {
     const validKeys = new Set(rows.map((row) => row.key))
@@ -85,9 +88,9 @@ export function useChecksListState({
     setExpandedCheckKeys((current) => {
       const next = new Set([...current].filter((key) => validKeys.has(key)))
       if (autoExpandedContextRef.current !== checkDetailsContextKey) {
-        const firstFailed = rows.find((row) => isFailedCheck(row.check))
-        if (firstFailed) {
-          next.add(firstFailed.key)
+        const firstRequiringAttention = rows.find((row) => isCheckRequiringAttention(row.check))
+        if (firstRequiringAttention) {
+          next.add(firstRequiringAttention.key)
         }
         autoExpandedContextRef.current = checkDetailsContextKey
       }
@@ -341,6 +344,7 @@ export function useChecksListState({
     rows,
     passingCount,
     failingCount,
+    actionRequiredCount,
     pendingCount,
     neutralCount,
     toggleCheckExpanded,

--- a/src/renderer/src/components/right-sidebar/parent-pr-checks-row-status.ts
+++ b/src/renderer/src/components/right-sidebar/parent-pr-checks-row-status.ts
@@ -1,6 +1,10 @@
-import type { CheckStatus } from '../../../../shared/github/pull-request-types'
-import type { HostedReviewInfo } from '../../../../shared/hosted-review'
+import type { CheckPresentationStatus } from '../../../../shared/github/pull-request-types'
+import {
+  getHostedReviewCheckPresentationStatus,
+  type HostedReviewInfo
+} from '../../../../shared/hosted-review'
 import { translate } from '@/i18n/i18n'
+import { getActionRequiredCheckCountLabel } from '@/components/pr-check-counts'
 import type {
   ParentPrChecksGroupKey,
   ParentPrChecksRefreshOutcome,
@@ -60,13 +64,17 @@ export function classifyKnownReviewStatus(review: HostedReviewInfo): ParentPrChe
   if (review.state === 'draft') {
     return 'draft'
   }
-  if (review.status === 'failure') {
+  const checksStatus = getHostedReviewCheckPresentationStatus(review)
+  if (checksStatus === 'failure') {
     return 'failing'
   }
-  if (review.status === 'pending') {
+  if (checksStatus === 'action_required') {
+    return 'actionRequired'
+  }
+  if (checksStatus === 'pending') {
     return 'pending'
   }
-  if (review.status === 'success') {
+  if (checksStatus === 'success') {
     return 'success'
   }
   return 'neutral'
@@ -75,6 +83,7 @@ export function classifyKnownReviewStatus(review: HostedReviewInfo): ParentPrChe
 export function groupForRowStatus(status: ParentPrChecksRowStatus): ParentPrChecksGroupKey {
   switch (status) {
     case 'failing':
+    case 'actionRequired':
     case 'conflict':
     case 'closed':
     case 'linkedDetailsUnavailable':
@@ -102,7 +111,7 @@ export function groupForRowStatus(status: ParentPrChecksRowStatus): ParentPrChec
 export function getRowCheckTone(
   status: ParentPrChecksRowStatus,
   review: HostedReviewInfo | null | undefined
-): CheckStatus {
+): CheckPresentationStatus {
   if (
     ['failing', 'conflict', 'closed', 'linkedDetailsUnavailable', 'refreshError'].includes(status)
   ) {
@@ -111,10 +120,13 @@ export function getRowCheckTone(
   if (status === 'pending' || status === 'loading') {
     return 'pending'
   }
+  if (status === 'actionRequired') {
+    return 'action_required'
+  }
   if (status === 'success' || status === 'merged') {
     return 'success'
   }
-  return review?.status ?? 'neutral'
+  return review ? (getHostedReviewCheckPresentationStatus(review) ?? 'neutral') : 'neutral'
 }
 
 export function getRowSummary(
@@ -122,7 +134,13 @@ export function getRowSummary(
   review: HostedReviewInfo | null | undefined,
   detailNames: readonly string[]
 ): string {
-  if (detailNames.length > 0 && (status === 'failing' || status === 'pending')) {
+  if (
+    detailNames.length > 0 &&
+    (status === 'failing' || status === 'actionRequired' || status === 'pending')
+  ) {
+    if (status === 'actionRequired') {
+      return getActionRequiredCheckCountLabel(detailNames.length)
+    }
     return status === 'failing'
       ? translate(
           'auto.components.rightSidebar.parentPrChecks.rowSummary.failingCount',
@@ -140,6 +158,11 @@ export function getRowSummary(
       return translate(
         'auto.components.rightSidebar.parentPrChecks.rowSummary.checksFailing',
         'Checks failing'
+      )
+    case 'actionRequired':
+      return translate(
+        'auto.components.rightSidebar.parentPrChecks.rowSummary.actionRequired',
+        'Action required'
       )
     case 'conflict':
       return translate(

--- a/src/renderer/src/components/right-sidebar/parent-pr-checks-row-types.ts
+++ b/src/renderer/src/components/right-sidebar/parent-pr-checks-row-types.ts
@@ -1,6 +1,6 @@
 import type { PRCheckDetail } from '../../../../shared/github/check-types'
 import type {
-  CheckStatus,
+  CheckPresentationStatus,
   GitHubRepositoryIdentity,
   PRInfo
 } from '../../../../shared/github/pull-request-types'
@@ -33,6 +33,7 @@ export type ParentPrChecksRowStatus =
   | 'unsupported'
   | 'unavailable'
   | 'failing'
+  | 'actionRequired'
   | 'pending'
   | 'success'
   | 'draft'
@@ -58,7 +59,7 @@ export type ParentPrChecksRow = {
   branch: string | null
   status: ParentPrChecksRowStatus
   group: ParentPrChecksGroupKey
-  checkTone: CheckStatus
+  checkTone: CheckPresentationStatus
   title: string
   reviewNumber: number | null
   reviewLabel: string | null
@@ -78,6 +79,7 @@ export type ParentPrChecksSummary = {
   attached: number
   knownReview: number
   failing: number
+  actionRequired: number
   pending: number
   passing: number
   noPr: number

--- a/src/renderer/src/components/right-sidebar/parent-pr-checks-rows.test.ts
+++ b/src/renderer/src/components/right-sidebar/parent-pr-checks-rows.test.ts
@@ -138,6 +138,28 @@ describe('buildParentPrChecksProjection', () => {
       reviewLabel: '#12'
     })
 
+    const actionRequired = makeProjection({
+      worktree,
+      repo,
+      hostedReviewCache: {
+        [cacheKey]: {
+          data: makeReview({
+            status: 'failure',
+            checksPresentationStatus: 'action_required'
+          }),
+          fetchedAt: 1,
+          linkedReviewHintKey: ''
+        }
+      }
+    })
+    expect(actionRequired.rows[0]).toMatchObject({
+      status: 'actionRequired',
+      group: 'needsAttention',
+      checkTone: 'action_required',
+      summary: 'Action required'
+    })
+    expect(actionRequired.summary).toMatchObject({ failing: 0, actionRequired: 1 })
+
     expect(
       makeProjection({
         worktree,

--- a/src/renderer/src/components/right-sidebar/parent-pr-checks-rows.ts
+++ b/src/renderer/src/components/right-sidebar/parent-pr-checks-rows.ts
@@ -20,8 +20,7 @@ import {
   type ParentPrChecksCacheEntry,
   type ParentPrChecksProjection,
   type ParentPrChecksRefreshOutcome,
-  type ParentPrChecksRow,
-  type ParentPrChecksSummary
+  type ParentPrChecksRow
 } from './parent-pr-checks-row-types'
 import {
   classifyParentPrChecksRowStatus,
@@ -29,6 +28,7 @@ import {
   getRowSummary,
   groupForRowStatus
 } from './parent-pr-checks-row-status'
+import { summarizeParentPrChecksRows } from './parent-pr-checks-summary'
 import {
   canUseParentPrChecksGitHubPRCacheEntry,
   getParentPrChecksGitHubPRCacheEntry
@@ -60,29 +60,6 @@ export function buildParentPrChecksRows(
       repo: args.repoById.get(worktree.repoId) ?? null
     })
   )
-}
-
-export function summarizeParentPrChecksRows(
-  rows: readonly ParentPrChecksRow[]
-): ParentPrChecksSummary {
-  return {
-    attached: rows.length,
-    knownReview: rows.filter((row) => row.reviewLabel !== null && row.status !== 'noReview').length,
-    failing: rows.filter((row) => row.group === 'needsAttention').length,
-    pending: rows.filter((row) => row.group === 'pending').length,
-    passing: rows.filter((row) => row.group === 'passing').length,
-    noPr: rows.filter((row) => row.status === 'noReview').length,
-    unknown: rows.filter((row) =>
-      [
-        'notFetched',
-        'loading',
-        'linkedDetailsUnavailable',
-        'refreshError',
-        'unsupported',
-        'unavailable'
-      ].includes(row.status)
-    ).length
-  }
 }
 
 export function getParentPrChecksRefreshIdentity(

--- a/src/renderer/src/components/right-sidebar/parent-pr-checks-summary.ts
+++ b/src/renderer/src/components/right-sidebar/parent-pr-checks-summary.ts
@@ -1,0 +1,26 @@
+import type { ParentPrChecksRow, ParentPrChecksSummary } from './parent-pr-checks-row-types'
+
+export function summarizeParentPrChecksRows(
+  rows: readonly ParentPrChecksRow[]
+): ParentPrChecksSummary {
+  return {
+    attached: rows.length,
+    knownReview: rows.filter((row) => row.reviewLabel !== null && row.status !== 'noReview').length,
+    failing: rows.filter((row) => row.group === 'needsAttention' && row.status !== 'actionRequired')
+      .length,
+    actionRequired: rows.filter((row) => row.status === 'actionRequired').length,
+    pending: rows.filter((row) => row.group === 'pending').length,
+    passing: rows.filter((row) => row.group === 'passing').length,
+    noPr: rows.filter((row) => row.status === 'noReview').length,
+    unknown: rows.filter((row) =>
+      [
+        'notFetched',
+        'loading',
+        'linkedDetailsUnavailable',
+        'refreshError',
+        'unsupported',
+        'unavailable'
+      ].includes(row.status)
+    ).length
+  }
+}

--- a/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
+++ b/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
@@ -21,6 +21,7 @@ export type HostedReviewActionInfo = Pick<
   Partial<
     Pick<
       HostedReviewInfo,
+      | 'checksPresentationStatus'
       | 'reviewDecision'
       | 'autoMergeEnabled'
       | 'autoMergeAllowed'

--- a/src/renderer/src/components/sidebar/WorktreeCard.hosted-review-refresh.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.hosted-review-refresh.test.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { act } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import type { Repo } from '../../../../shared/repo-types'
 import type { WorktreeCardProperty } from '../../../../shared/ui-chrome-types'
 import type { Worktree } from '../../../../shared/worktree/types'
@@ -15,8 +14,6 @@ const openModal = vi.fn()
 const updateWorktreeMeta = vi.fn()
 
 let worktreeCardProperties: WorktreeCardProperty[] = ['status']
-let hostedReviewCache: Record<string, unknown> = {}
-let settings: Partial<GlobalSettings> | null = null
 let root: Root | null = null
 let container: HTMLDivElement | null = null
 
@@ -28,13 +25,19 @@ vi.mock('@/store', () => ({
       fetchIssue,
       fetchLinearIssue,
       gitConflictOperationByWorktree: {},
-      hostedReviewCache,
+      hostedReviewCache: {
+        'local::repo-1::feature/branch': {
+          data: null,
+          fetchedAt: Date.now(),
+          linkedReviewHintKey: ''
+        }
+      },
       issueCache: {},
       linearIssueCache: {},
       openModal,
       projectGroups: [],
       remoteBranchConflictByWorktreeId: {},
-      settings,
+      settings: { experimentalNewWorktreeCardStyle: true },
       sshConnectionStates: new Map(),
       sshTargetLabels: new Map(),
       updateWorktreeMeta,
@@ -111,14 +114,6 @@ describe('WorktreeCard hosted review refresh', () => {
     vi.useFakeTimers()
     vi.clearAllMocks()
     worktreeCardProperties = ['status']
-    settings = { experimentalNewWorktreeCardStyle: true }
-    hostedReviewCache = {
-      'local::repo-1::feature/branch': {
-        data: null,
-        fetchedAt: Date.now(),
-        linkedReviewHintKey: ''
-      }
-    }
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
@@ -173,49 +168,5 @@ describe('WorktreeCard hosted review refresh', () => {
     })
 
     expect(fetchHostedReviewForBranch).not.toHaveBeenCalled()
-  })
-
-  it('shows a spinner in the sidebar PR badge while linked PR details load', async () => {
-    worktreeCardProperties = ['pr']
-    hostedReviewCache = {}
-    settings = { experimentalNewWorktreeCardStyle: false }
-    const { default: WorktreeCard } = await import('./WorktreeCard')
-
-    act(() => {
-      root?.render(
-        <WorktreeCard
-          worktree={makeWorktree({ linkedPR: 456 })}
-          repo={makeRepo()}
-          isActive={false}
-        />
-      )
-    })
-
-    expect(container?.innerHTML).toContain('Linked PR #456')
-    expect(container?.innerHTML).toContain('lucide-loader-circle')
-    expect(container?.innerHTML).toContain('animate-spin')
-    expect(container?.innerHTML).toContain('text-muted-foreground')
-    expect(container?.innerHTML).not.toContain('viewBox="0 0 16 16"')
-  })
-
-  it('stops the sidebar spinner when linked PR details are unavailable', async () => {
-    worktreeCardProperties = ['pr']
-    settings = { experimentalNewWorktreeCardStyle: false }
-    const { default: WorktreeCard } = await import('./WorktreeCard')
-
-    act(() => {
-      root?.render(
-        <WorktreeCard
-          worktree={makeWorktree({ linkedPR: 456 })}
-          repo={makeRepo()}
-          isActive={false}
-        />
-      )
-    })
-
-    expect(container?.innerHTML).toContain('Linked PR #456')
-    expect(container?.innerHTML).toContain('viewBox="0 0 16 16"')
-    expect(container?.innerHTML).not.toContain('lucide-loader-circle')
-    expect(container?.innerHTML).not.toContain('animate-spin')
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeCard.hosted-review-refresh.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.hosted-review-refresh.test.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { act } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import type { Repo } from '../../../../shared/repo-types'
 import type { WorktreeCardProperty } from '../../../../shared/ui-chrome-types'
 import type { Worktree } from '../../../../shared/worktree/types'
@@ -14,6 +15,8 @@ const openModal = vi.fn()
 const updateWorktreeMeta = vi.fn()
 
 let worktreeCardProperties: WorktreeCardProperty[] = ['status']
+let hostedReviewCache: Record<string, unknown> = {}
+let settings: Partial<GlobalSettings> | null = null
 let root: Root | null = null
 let container: HTMLDivElement | null = null
 
@@ -25,19 +28,13 @@ vi.mock('@/store', () => ({
       fetchIssue,
       fetchLinearIssue,
       gitConflictOperationByWorktree: {},
-      hostedReviewCache: {
-        'local::repo-1::feature/branch': {
-          data: null,
-          fetchedAt: Date.now(),
-          linkedReviewHintKey: ''
-        }
-      },
+      hostedReviewCache,
       issueCache: {},
       linearIssueCache: {},
       openModal,
       projectGroups: [],
       remoteBranchConflictByWorktreeId: {},
-      settings: { experimentalNewWorktreeCardStyle: true },
+      settings,
       sshConnectionStates: new Map(),
       sshTargetLabels: new Map(),
       updateWorktreeMeta,
@@ -114,6 +111,14 @@ describe('WorktreeCard hosted review refresh', () => {
     vi.useFakeTimers()
     vi.clearAllMocks()
     worktreeCardProperties = ['status']
+    settings = { experimentalNewWorktreeCardStyle: true }
+    hostedReviewCache = {
+      'local::repo-1::feature/branch': {
+        data: null,
+        fetchedAt: Date.now(),
+        linkedReviewHintKey: ''
+      }
+    }
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
@@ -168,5 +173,49 @@ describe('WorktreeCard hosted review refresh', () => {
     })
 
     expect(fetchHostedReviewForBranch).not.toHaveBeenCalled()
+  })
+
+  it('shows a spinner in the sidebar PR badge while linked PR details load', async () => {
+    worktreeCardProperties = ['pr']
+    hostedReviewCache = {}
+    settings = { experimentalNewWorktreeCardStyle: false }
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    act(() => {
+      root?.render(
+        <WorktreeCard
+          worktree={makeWorktree({ linkedPR: 456 })}
+          repo={makeRepo()}
+          isActive={false}
+        />
+      )
+    })
+
+    expect(container?.innerHTML).toContain('Linked PR #456')
+    expect(container?.innerHTML).toContain('lucide-loader-circle')
+    expect(container?.innerHTML).toContain('animate-spin')
+    expect(container?.innerHTML).toContain('text-muted-foreground')
+    expect(container?.innerHTML).not.toContain('viewBox="0 0 16 16"')
+  })
+
+  it('stops the sidebar spinner when linked PR details are unavailable', async () => {
+    worktreeCardProperties = ['pr']
+    settings = { experimentalNewWorktreeCardStyle: false }
+    const { default: WorktreeCard } = await import('./WorktreeCard')
+
+    act(() => {
+      root?.render(
+        <WorktreeCard
+          worktree={makeWorktree({ linkedPR: 456 })}
+          repo={makeRepo()}
+          isActive={false}
+        />
+      )
+    })
+
+    expect(container?.innerHTML).toContain('Linked PR #456')
+    expect(container?.innerHTML).toContain('viewBox="0 0 16 16"')
+    expect(container?.innerHTML).not.toContain('lucide-loader-circle')
+    expect(container?.innerHTML).not.toContain('animate-spin')
   })
 })

--- a/src/renderer/src/components/sidebar/WorktreeCardHelpers.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardHelpers.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { translate } from '@/i18n/i18n'
 import type { GitConflictOperation } from '../../../../shared/git-status-types'
 import type { CheckPresentationStatus } from '../../../../shared/github/pull-request-types'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
@@ -18,7 +19,10 @@ export function checksLabel(status: CheckPresentationStatus): string {
     case 'pending':
       return 'Pending'
     case 'action_required':
-      return 'Action required'
+      return translate(
+        'auto.components.sidebar.WorktreeCardHelpers.actionRequiredCheckStatus',
+        'Action required'
+      )
     case 'neutral':
       return ''
   }

--- a/src/renderer/src/components/sidebar/WorktreeCardHelpers.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardHelpers.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import type { GitConflictOperation } from '../../../../shared/git-status-types'
-import type { CheckStatus } from '../../../../shared/github/pull-request-types'
+import type { CheckPresentationStatus } from '../../../../shared/github/pull-request-types'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 
 // ── Pure helper functions ────────────────────────────────────────────
@@ -9,7 +9,7 @@ export function branchDisplayName(branch: string): string {
   return branch.replace(/^refs\/heads\//, '')
 }
 
-export function checksLabel(status: CheckStatus): string {
+export function checksLabel(status: CheckPresentationStatus): string {
   switch (status) {
     case 'success':
       return 'Passing'
@@ -17,6 +17,8 @@ export function checksLabel(status: CheckStatus): string {
       return 'Failing'
     case 'pending':
       return 'Pending'
+    case 'action_required':
+      return 'Action required'
     case 'neutral':
       return ''
   }

--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.test.tsx
@@ -335,30 +335,6 @@ describe('WorktreeCardDetailsHover', () => {
     expect(hoverMarkup).toContain('https://company.atlassian.net/browse/KAN-1')
   })
 
-  it('shows a spinner in the sidebar PR badge while details load', () => {
-    const markup = renderToStaticMarkup(
-      <WorktreeCardMetaBadges
-        issue={null}
-        linearIssue={null}
-        jiraIssue={null}
-        review={{
-          provider: 'github',
-          number: 456,
-          title: 'Checking PR status',
-          isLoading: true
-        }}
-        comment={null}
-      />
-    )
-
-    expect(markup).toContain('Linked PR #456')
-    expect(markup).toContain('lucide-loader-circle')
-    expect(markup).toContain('animate-spin')
-    expect(markup).toContain('text-muted-foreground')
-    expect(markup).not.toContain('text-amber-500/85')
-    expect(markup).not.toContain('viewBox="0 0 16 16"')
-  })
-
   it('shows identifier when Linear issue URL is unavailable', () => {
     const markup = renderToStaticMarkup(
       <WorktreeCardDetailsHover

--- a/src/renderer/src/components/sidebar/WorktreeCardMeta.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMeta.test.tsx
@@ -335,6 +335,30 @@ describe('WorktreeCardDetailsHover', () => {
     expect(hoverMarkup).toContain('https://company.atlassian.net/browse/KAN-1')
   })
 
+  it('shows a spinner in the sidebar PR badge while details load', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCardMetaBadges
+        issue={null}
+        linearIssue={null}
+        jiraIssue={null}
+        review={{
+          provider: 'github',
+          number: 456,
+          title: 'Checking PR status',
+          isLoading: true
+        }}
+        comment={null}
+      />
+    )
+
+    expect(markup).toContain('Linked PR #456')
+    expect(markup).toContain('lucide-loader-circle')
+    expect(markup).toContain('animate-spin')
+    expect(markup).toContain('text-muted-foreground')
+    expect(markup).not.toContain('text-amber-500/85')
+    expect(markup).not.toContain('viewBox="0 0 16 16"')
+  })
+
   it('shows identifier when Linear issue URL is unavailable', () => {
     const markup = renderToStaticMarkup(
       <WorktreeCardDetailsHover

--- a/src/renderer/src/components/sidebar/WorktreeCardMetaBadges.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMetaBadges.tsx
@@ -149,7 +149,7 @@ export const WorktreeCardMetaBadges = React.forwardRef<
             { value0: getReviewLabel(review), value1: review.number }
           )}
         >
-          <ReviewIcon review={review} showLoadingSpinner={review.isLoading} />
+          <ReviewIcon review={review} />
         </MetaIconBadge>
       )}
     </div>

--- a/src/renderer/src/components/sidebar/WorktreeCardMetaBadges.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMetaBadges.tsx
@@ -149,7 +149,7 @@ export const WorktreeCardMetaBadges = React.forwardRef<
             { value0: getReviewLabel(review), value1: review.number }
           )}
         >
-          <ReviewIcon review={review} />
+          <ReviewIcon review={review} showLoadingSpinner={review.isLoading} />
         </MetaIconBadge>
       )}
     </div>

--- a/src/renderer/src/components/sidebar/WorktreeCardMetadataStatusBadges.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMetadataStatusBadges.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import { Badge } from '@/components/ui/badge'
-import { CircleCheck, CircleDot, CircleX, Clock, GitMerge } from 'lucide-react'
+import { AlertTriangle, CircleCheck, CircleDot, CircleX, Clock, GitMerge } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { PullRequestIcon, checksLabel } from './WorktreeCardHelpers'
 import type { WorktreeCardPrDisplay } from './worktree-card-pr-display'
-import type { IssueInfo } from '../../../../shared/github/pull-request-types'
+import type {
+  CheckPresentationStatus,
+  IssueInfo
+} from '../../../../shared/github/pull-request-types'
 import { translate } from '@/i18n/i18n'
 
 function MetadataStatusBadge({
@@ -156,7 +159,7 @@ export function ReviewStateBadge({
 export function ReviewChecksBadge({
   status
 }: {
-  status: WorktreeCardPrDisplay['status']
+  status: CheckPresentationStatus | undefined
 }): React.JSX.Element | null {
   if (!status || status === 'neutral') {
     return null
@@ -182,6 +185,17 @@ export function ReviewChecksBadge({
         className="border-rose-500/25 bg-rose-500/5 text-rose-600 dark:text-rose-300"
       >
         <CircleX />
+      </MetadataStatusBadge>
+    )
+  }
+
+  if (status === 'action_required') {
+    return (
+      <MetadataStatusBadge
+        label={label}
+        className="border-amber-500/25 bg-amber-500/5 text-amber-600 dark:text-amber-300"
+      >
+        <AlertTriangle />
       </MetadataStatusBadge>
     )
   }

--- a/src/renderer/src/components/sidebar/WorktreeCardReviewDetailSection.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardReviewDetailSection.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { getHostedReviewCheckPresentationStatus } from '../../../../shared/hosted-review'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -46,7 +47,7 @@ export function WorktreeCardReviewDetailSection({
 
   const reviewLabel = getReviewLabel(review)
   const reviewProvider = getProviderName(review)
-  const checksStatus = review.checksPresentationStatus ?? review.status
+  const checksStatus = getHostedReviewCheckPresentationStatus(review)
   const moreActionsLabel = translate(
     'auto.components.sidebar.WorktreeCardMeta.dbe2d18972',
     'More {{value0}} actions',

--- a/src/renderer/src/components/sidebar/WorktreeCardReviewDetailSection.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardReviewDetailSection.tsx
@@ -46,6 +46,7 @@ export function WorktreeCardReviewDetailSection({
 
   const reviewLabel = getReviewLabel(review)
   const reviewProvider = getProviderName(review)
+  const checksStatus = review.checksPresentationStatus ?? review.status
   const moreActionsLabel = translate(
     'auto.components.sidebar.WorktreeCardMeta.dbe2d18972',
     'More {{value0}} actions',
@@ -170,10 +171,10 @@ export function WorktreeCardReviewDetailSection({
         <div className="text-[13px] font-semibold leading-snug text-foreground break-words">
           {review.title}
         </div>
-        {(review.state || (review.status && review.status !== 'neutral')) && (
+        {(review.state || (checksStatus && checksStatus !== 'neutral')) && (
           <div className="flex flex-wrap gap-1">
             <ReviewStateBadge state={review.state} label={reviewLabel} />
-            <ReviewChecksBadge status={review.status} />
+            <ReviewChecksBadge status={checksStatus} />
           </div>
         )}
       </WorktreeCardDetailSectionContent>

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
@@ -278,6 +278,7 @@ describe('WorktreeCardStatusSlot', () => {
     expect(markup).toContain('viewBox="0 0 16 16"')
     expect(markup).toContain('size-[13px] translate-x-px')
     expect(markup).toContain('text-amber-500/85')
+    expect(markup).not.toContain('lucide-loader-circle')
     expect(markup).not.toContain('lucide-git-merge')
   })
 

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
@@ -218,6 +218,47 @@ describe('WorktreeCardStatusSlot', () => {
     expect(markup).not.toContain('data-tooltip-root')
   })
 
+  it('keeps neutral PR checks gray in the new-card status lane', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCardStatusSlot
+        worktreeId="wt-1"
+        showStatus
+        showUnreadAction={false}
+        isUnread={false}
+        unreadTooltip="Mark as unread"
+        onPointerDown={vi.fn()}
+        onToggleUnread={vi.fn()}
+        prDisplay={{ ...review, status: 'neutral' }}
+        newCardStyle
+      />
+    )
+
+    expect(markup).toContain('PR: Open')
+    expect(markup).toContain('size-[13px] translate-x-px text-muted-foreground')
+    expect(markup).not.toContain('text-emerald-500/80')
+    expect(markup).not.toContain('bg-emerald-500')
+  })
+
+  it('keeps confirmed passing PR checks green in the new-card status lane', () => {
+    const markup = renderToStaticMarkup(
+      <WorktreeCardStatusSlot
+        worktreeId="wt-1"
+        showStatus
+        showUnreadAction={false}
+        isUnread={false}
+        unreadTooltip="Mark as unread"
+        onPointerDown={vi.fn()}
+        onToggleUnread={vi.fn()}
+        prDisplay={{ ...review, status: 'success' }}
+        newCardStyle
+      />
+    )
+
+    expect(markup).toContain('PR checks: Passing')
+    expect(markup).toContain('size-[13px] translate-x-px text-emerald-500/80')
+    expect(markup).not.toContain('text-muted-foreground')
+  })
+
   it('uses the unified compact review glyph for GitLab MR status', () => {
     const markup = renderToStaticMarkup(
       <WorktreeCardStatusSlot

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
@@ -278,7 +278,6 @@ describe('WorktreeCardStatusSlot', () => {
     expect(markup).toContain('viewBox="0 0 16 16"')
     expect(markup).toContain('size-[13px] translate-x-px')
     expect(markup).toContain('text-amber-500/85')
-    expect(markup).not.toContain('lucide-loader-circle')
     expect(markup).not.toContain('lucide-git-merge')
   })
 

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx
@@ -1,6 +1,8 @@
 import { renderToStaticMarkup } from 'react-dom/server'
 import type { ReactNode } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { i18n } from '@/i18n/i18n'
+import { checksLabel } from './WorktreeCardHelpers'
 import { WorktreeCardStatusSlot } from './WorktreeCardStatusSlot'
 import type { WorktreeCardPrDisplay } from './worktree-card-pr-display'
 
@@ -257,6 +259,33 @@ describe('WorktreeCardStatusSlot', () => {
     expect(markup).toContain('PR checks: Passing')
     expect(markup).toContain('size-[13px] translate-x-px text-emerald-500/80')
     expect(markup).not.toContain('text-muted-foreground')
+  })
+
+  it('localizes action-required status copy', async () => {
+    await i18n.changeLanguage('es')
+    try {
+      const markup = renderToStaticMarkup(
+        <WorktreeCardStatusSlot
+          worktreeId="wt-1"
+          showStatus
+          showUnreadAction={false}
+          isUnread={false}
+          unreadTooltip="Marcar como no leído"
+          onPointerDown={vi.fn()}
+          onToggleUnread={vi.fn()}
+          prDisplay={{
+            ...review,
+            checksPresentationStatus: 'action_required'
+          }}
+          newCardStyle
+        />
+      )
+
+      expect(checksLabel('action_required')).toBe('Acción requerida')
+      expect(markup).toContain('Checks de PR: acción requerida')
+    } finally {
+      await i18n.changeLanguage('en')
+    }
   })
 
   it('uses the unified compact review glyph for GitLab MR status', () => {

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Bell, GitBranch } from 'lucide-react'
+import { getHostedReviewCheckPresentationStatus } from '../../../../shared/hosted-review'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { translate } from '@/i18n/i18n'
 import { cn } from '@/lib/utils'
@@ -74,7 +75,7 @@ function getReviewStatusLabel(review: WorktreeCardPrDisplay): string {
   if (review.state === 'draft') {
     return `${label}: Draft`
   }
-  const status = review.checksPresentationStatus ?? review.status
+  const status = getHostedReviewCheckPresentationStatus(review)
   if (status === 'failure') {
     return `${label} checks: Failed`
   }

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
@@ -74,13 +74,17 @@ function getReviewStatusLabel(review: WorktreeCardPrDisplay): string {
   if (review.state === 'draft') {
     return `${label}: Draft`
   }
-  if (review.status === 'failure') {
+  const status = review.checksPresentationStatus ?? review.status
+  if (status === 'failure') {
     return `${label} checks: Failed`
   }
-  if (review.status === 'pending') {
+  if (status === 'action_required') {
+    return `${label} checks: Action required`
+  }
+  if (status === 'pending') {
     return `${label} checks: Pending`
   }
-  if (review.status === 'success') {
+  if (status === 'success') {
     return `${label} checks: Passing`
   }
   return `${label}: Open`

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
@@ -80,7 +80,11 @@ function getReviewStatusLabel(review: WorktreeCardPrDisplay): string {
     return `${label} checks: Failed`
   }
   if (status === 'action_required') {
-    return `${label} checks: Action required`
+    return translate(
+      'auto.components.sidebar.WorktreeCardStatusSlot.actionRequiredChecks',
+      '{{reviewLabel}} checks: Action required',
+      { reviewLabel: label }
+    )
   }
   if (status === 'pending') {
     return `${label} checks: Pending`

--- a/src/renderer/src/components/sidebar/folder-workspace-card-pr-display.test.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-card-pr-display.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from 'vitest'
+import { createElement } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
 import type { CheckStatus, PRInfo } from '../../../../shared/github/pull-request-types'
+import { derivePRCheckStatusesFromRollup } from '../../../../shared/pr-check-status'
 import type { Repo } from '../../../../shared/repo-types'
 import type { WorkspaceLineage, WorktreeLineage } from '../../../../shared/worktree/lineage-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import { folderWorkspaceKey, worktreeWorkspaceKey } from '../../../../shared/workspace-scope'
 import { getFolderWorkspaceCardPrDisplay } from './folder-workspace-card-pr-display'
+import { ReviewIcon } from './worktree-review-helpers'
 
 const repo: Repo = {
   id: 'repo-1',
@@ -89,6 +93,50 @@ describe('getFolderWorkspaceCardPrDisplay', () => {
     expect(display).toMatchObject({ number: 8, status: 'success' })
   })
 
+  it('renders a producer-published action-required PR in amber through the folder cache path', () => {
+    const worktree = makeWorktree({ id: 'action-required', linkedPR: 42 })
+    const statuses = derivePRCheckStatusesFromRollup([{ state: 'ACTION_REQUIRED' }])
+    const pr = {
+      ...makePr(42, statuses.status),
+      checksPresentationStatus: statuses.presentationStatus
+    }
+
+    const display = getFolderWorkspaceCardPrDisplay({
+      folderWorkspaceId: 'folder-1',
+      workspaceLineageByChildKey: { [worktree.id]: makeWorkspaceLineage(worktree) },
+      worktreeLineageById: {},
+      worktreeMap: new Map([[worktree.id, worktree]]),
+      repoMap: new Map([[repo.id, repo]]),
+      hostedReviewCache: null,
+      prCache: { 'repo-1::action-required': { data: pr, fetchedAt: 2 } }
+    })
+    expect(display).toMatchObject({
+      status: 'failure',
+      checksPresentationStatus: 'action_required'
+    })
+
+    const markup = renderToStaticMarkup(
+      createElement(ReviewIcon, { review: display!, className: 'size-3' })
+    )
+    expect(markup).toContain('text-amber-500/85')
+    expect(markup).not.toContain('text-rose-500/85')
+
+    const { checksPresentationStatus: _omitted, ...legacyPR } = pr
+    const legacyDisplay = getFolderWorkspaceCardPrDisplay({
+      folderWorkspaceId: 'folder-1',
+      workspaceLineageByChildKey: { [worktree.id]: makeWorkspaceLineage(worktree) },
+      worktreeLineageById: {},
+      worktreeMap: new Map([[worktree.id, worktree]]),
+      repoMap: new Map([[repo.id, repo]]),
+      hostedReviewCache: null,
+      prCache: { 'repo-1::action-required': { data: legacyPR, fetchedAt: 2 } }
+    })
+    const legacyMarkup = renderToStaticMarkup(
+      createElement(ReviewIcon, { review: legacyDisplay!, className: 'size-3' })
+    )
+    expect(legacyMarkup).toContain('text-rose-500/85')
+  })
+
   it('uses failing attached PR status ahead of pending and passing PRs', () => {
     const passing = makeWorktree({ id: 'passing', linkedPR: 1 })
     const pending = makeWorktree({ id: 'pending', linkedPR: 2 })
@@ -117,6 +165,39 @@ describe('getFolderWorkspaceCardPrDisplay', () => {
     })
 
     expect(display).toMatchObject({ number: 3, status: 'failure' })
+  })
+
+  it('uses a real failure ahead of an action-required attached PR', () => {
+    const actionRequired = makeWorktree({ id: 'action-required', linkedPR: 1 })
+    const failing = makeWorktree({ id: 'failing', linkedPR: 2 })
+
+    const display = getFolderWorkspaceCardPrDisplay({
+      folderWorkspaceId: 'folder-1',
+      workspaceLineageByChildKey: {
+        [actionRequired.id]: makeWorkspaceLineage(actionRequired),
+        [failing.id]: makeWorkspaceLineage(failing)
+      },
+      worktreeLineageById: {},
+      worktreeMap: new Map([
+        [actionRequired.id, actionRequired],
+        [failing.id, failing]
+      ]),
+      repoMap: new Map([[repo.id, repo]]),
+      hostedReviewCache: null,
+      prCache: {
+        'repo-1::action-required': {
+          data: {
+            ...makePr(1, 'failure'),
+            checksPresentationStatus: 'action_required'
+          },
+          fetchedAt: 2
+        },
+        'repo-1::failing': makePrEntry(2, 'failure')
+      }
+    })
+
+    expect(display).toMatchObject({ number: 2, status: 'failure' })
+    expect(display).not.toHaveProperty('checksPresentationStatus')
   })
 
   it('uses pending attached PR status ahead of passing PRs', () => {

--- a/src/renderer/src/components/sidebar/folder-workspace-card-pr-display.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-card-pr-display.ts
@@ -1,4 +1,6 @@
 import type { AppState } from '@/store/types'
+import type { CheckPresentationStatus } from '../../../../shared/github/pull-request-types'
+import { getHostedReviewCheckPresentationStatus } from '../../../../shared/hosted-review'
 import type { Repo } from '../../../../shared/repo-types'
 import type { WorkspaceLineage, WorktreeLineage } from '../../../../shared/worktree/lineage-types'
 import type { Worktree } from '../../../../shared/worktree/types'
@@ -19,11 +21,12 @@ type FolderWorkspaceCardPrDisplayArgs = {
   settings?: AppState['settings']
 }
 
-const REVIEW_STATUS_PRIORITY: Record<NonNullable<WorktreeCardPrDisplay['status']>, number> = {
+const REVIEW_STATUS_PRIORITY: Record<CheckPresentationStatus, number> = {
   failure: 0,
-  pending: 1,
-  success: 2,
-  neutral: 3
+  action_required: 1,
+  pending: 2,
+  success: 3,
+  neutral: 4
 }
 
 export function getFolderWorkspaceCardPrDisplay({
@@ -100,13 +103,15 @@ function parentPrChecksRowToCardDisplay(row: ParentPrChecksRow): WorktreeCardPrD
   if (!row.provider || row.provider === 'unsupported' || row.reviewNumber === null) {
     return null
   }
+  const status = row.checkTone === 'action_required' ? 'failure' : row.checkTone
   return {
     provider: row.provider,
     number: row.reviewNumber,
     title: row.title,
     ...(row.reviewState ? { state: row.reviewState } : {}),
     ...(row.reviewUrl ? { url: row.reviewUrl } : {}),
-    status: row.checkTone
+    status,
+    ...(row.checkTone === 'action_required' ? { checksPresentationStatus: row.checkTone } : {})
   }
 }
 
@@ -133,5 +138,6 @@ function compareReviewDisplays(left: WorktreeCardPrDisplay, right: WorktreeCardP
 }
 
 function getReviewDisplayPriority(review: WorktreeCardPrDisplay): number {
-  return review.status ? REVIEW_STATUS_PRIORITY[review.status] : 4
+  const status = getHostedReviewCheckPresentationStatus(review)
+  return status ? REVIEW_STATUS_PRIORITY[status] : 5
 }

--- a/src/renderer/src/components/sidebar/worktree-card-pr-display.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-pr-display.test.ts
@@ -48,7 +48,8 @@ describe('getWorktreeCardPrDisplay', () => {
     expect(getWorktreeCardPrDisplay(undefined, 456)).toEqual({
       provider: 'github',
       number: 456,
-      title: 'Loading PR...'
+      title: 'Loading PR...',
+      isLoading: true
     })
   })
 
@@ -150,7 +151,8 @@ describe('getWorktreeCardPrDisplay', () => {
     expect(getWorktreeCardPrDisplay(pr, 456)).toEqual({
       provider: 'github',
       number: 456,
-      title: 'Loading PR...'
+      title: 'Loading PR...',
+      isLoading: true
     })
   })
 
@@ -162,7 +164,8 @@ describe('getWorktreeCardPrDisplay', () => {
     expect(getWorktreeCardPrDisplay(gitLabReview, null, 654)).toEqual({
       provider: 'gitlab',
       number: 654,
-      title: 'Loading MR...'
+      title: 'Loading MR...',
+      isLoading: true
     })
   })
 

--- a/src/renderer/src/components/sidebar/worktree-card-pr-display.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-pr-display.test.ts
@@ -48,8 +48,7 @@ describe('getWorktreeCardPrDisplay', () => {
     expect(getWorktreeCardPrDisplay(undefined, 456)).toEqual({
       provider: 'github',
       number: 456,
-      title: 'Loading PR...',
-      isLoading: true
+      title: 'Loading PR...'
     })
   })
 
@@ -151,8 +150,7 @@ describe('getWorktreeCardPrDisplay', () => {
     expect(getWorktreeCardPrDisplay(pr, 456)).toEqual({
       provider: 'github',
       number: 456,
-      title: 'Loading PR...',
-      isLoading: true
+      title: 'Loading PR...'
     })
   })
 
@@ -164,8 +162,7 @@ describe('getWorktreeCardPrDisplay', () => {
     expect(getWorktreeCardPrDisplay(gitLabReview, null, 654)).toEqual({
       provider: 'gitlab',
       number: 654,
-      title: 'Loading MR...',
-      isLoading: true
+      title: 'Loading MR...'
     })
   })
 

--- a/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
@@ -29,7 +29,7 @@ type LinkedReviewNumbers = {
   linkedGiteaPR: number | null
 }
 
-export type WorktreeCardPrDisplay =
+export type WorktreeCardPrDisplay = (
   | HostedReviewInfo
   | {
       provider: LinkedReviewMetadataProvider
@@ -40,6 +40,7 @@ export type WorktreeCardPrDisplay =
       status?: HostedReviewInfo['status']
       checksPresentationStatus?: CheckPresentationStatus
     }
+) & { isLoading?: boolean }
 
 type WorktreeCardPrDisplayOptions = {
   reviewHintKey?: string
@@ -77,7 +78,8 @@ function makeLinkedReviewFallback(
     number,
     // Why: linked review metadata is persisted before provider details are cached.
     // Keep the row visible on cold first render while the lookup catches up.
-    title: review === null ? `${label} details unavailable` : `Loading ${label}...`
+    title: review === null ? `${label} details unavailable` : `Loading ${label}...`,
+    ...(review === undefined ? { isLoading: true } : {})
   }
 }
 

--- a/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
@@ -29,7 +29,7 @@ type LinkedReviewNumbers = {
   linkedGiteaPR: number | null
 }
 
-export type WorktreeCardPrDisplay = (
+export type WorktreeCardPrDisplay =
   | HostedReviewInfo
   | {
       provider: LinkedReviewMetadataProvider
@@ -40,7 +40,6 @@ export type WorktreeCardPrDisplay = (
       status?: HostedReviewInfo['status']
       checksPresentationStatus?: CheckPresentationStatus
     }
-) & { isLoading?: boolean }
 
 type WorktreeCardPrDisplayOptions = {
   reviewHintKey?: string
@@ -78,8 +77,7 @@ function makeLinkedReviewFallback(
     number,
     // Why: linked review metadata is persisted before provider details are cached.
     // Keep the row visible on cold first render while the lookup catches up.
-    title: review === null ? `${label} details unavailable` : `Loading ${label}...`,
-    ...(review === undefined ? { isLoading: true } : {})
+    title: review === null ? `${label} details unavailable` : `Loading ${label}...`
   }
 }
 

--- a/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
+++ b/src/renderer/src/components/sidebar/worktree-card-pr-display.ts
@@ -1,5 +1,5 @@
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
-import type { PRInfo } from '../../../../shared/github/pull-request-types'
+import type { CheckPresentationStatus, PRInfo } from '../../../../shared/github/pull-request-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import { isGitHubPRSuppressed } from '../../../../shared/worktree/github-pr-suppression'
 
@@ -38,6 +38,7 @@ export type WorktreeCardPrDisplay =
       state?: HostedReviewInfo['state']
       url?: string
       status?: HostedReviewInfo['status']
+      checksPresentationStatus?: CheckPresentationStatus
     }
 
 type WorktreeCardPrDisplayOptions = {

--- a/src/renderer/src/components/sidebar/worktree-review-helpers.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-review-helpers.test.tsx
@@ -87,6 +87,26 @@ describe('ReviewIcon', () => {
     expect(failing).toContain('text-rose-500/85')
   })
 
+  it('renders action-required checks in amber instead of failure red or passing green', () => {
+    const actionRequired = renderToStaticMarkup(
+      <ReviewIcon
+        review={{
+          provider: 'github',
+          number: 1,
+          title: 'Approval required',
+          state: 'open',
+          status: 'failure',
+          checksPresentationStatus: 'action_required'
+        }}
+        className="size-3"
+      />
+    )
+
+    expect(actionRequired).toContain('text-amber-500/85')
+    expect(actionRequired).not.toContain('text-rose-500/85')
+    expect(actionRequired).not.toContain('text-emerald-500/80')
+  })
+
   it('renders merged reviews with the merge glyph', () => {
     const merged = renderToStaticMarkup(
       <ReviewIcon

--- a/src/renderer/src/components/sidebar/worktree-review-helpers.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-review-helpers.test.tsx
@@ -9,7 +9,7 @@ const gitlabReview: WorktreeCardPrDisplay = {
   number: 456,
   title: 'Review me',
   state: 'open',
-  status: 'pending'
+  status: 'success'
 }
 
 describe('ReviewIcon', () => {
@@ -87,6 +87,48 @@ describe('ReviewIcon', () => {
     expect(failing).toContain('text-rose-500/85')
   })
 
+  it('renders a neutral spinner when requested by loading card metadata', () => {
+    const loading = renderToStaticMarkup(
+      <ReviewIcon
+        review={{
+          provider: 'github',
+          number: 1,
+          title: 'Loading PR...',
+          isLoading: true
+        }}
+        className="size-3"
+        variant="generic"
+        showLoadingSpinner
+      />
+    )
+
+    expect(loading).toContain('lucide-loader-circle')
+    expect(loading).toContain('animate-spin')
+    expect(loading).toContain('text-muted-foreground')
+    expect(loading).not.toContain('text-amber-500/85')
+    expect(loading).not.toContain('viewBox="0 0 16 16"')
+  })
+
+  it('keeps the pending review glyph on other review surfaces', () => {
+    const pending = renderToStaticMarkup(
+      <ReviewIcon
+        review={{
+          provider: 'github',
+          number: 1,
+          title: 'Checking',
+          state: 'open',
+          status: 'pending'
+        }}
+        className="size-3"
+        variant="generic"
+      />
+    )
+
+    expect(pending).toContain('viewBox="0 0 16 16"')
+    expect(pending).not.toContain('lucide-loader-circle')
+    expect(pending).not.toContain('animate-spin')
+  })
+
   it('renders action-required checks in amber instead of failure red or passing green', () => {
     const actionRequired = renderToStaticMarkup(
       <ReviewIcon
@@ -103,6 +145,8 @@ describe('ReviewIcon', () => {
     )
 
     expect(actionRequired).toContain('text-amber-500/85')
+    expect(actionRequired).not.toContain('lucide-loader-circle')
+    expect(actionRequired).not.toContain('animate-spin')
     expect(actionRequired).not.toContain('text-rose-500/85')
     expect(actionRequired).not.toContain('text-emerald-500/80')
   })

--- a/src/renderer/src/components/sidebar/worktree-review-helpers.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-review-helpers.test.tsx
@@ -107,6 +107,18 @@ describe('ReviewIcon', () => {
     expect(actionRequired).not.toContain('text-emerald-500/80')
   })
 
+  it('keeps an open review neutral until its checks have loaded', () => {
+    const loadingChecks = renderToStaticMarkup(
+      <ReviewIcon
+        review={{ provider: 'github', number: 1, title: 'Loading checks', state: 'open' }}
+        className="size-3"
+      />
+    )
+
+    expect(loadingChecks).toContain('text-muted-foreground')
+    expect(loadingChecks).not.toContain('text-emerald-500/80')
+  })
+
   it('renders merged reviews with the merge glyph', () => {
     const merged = renderToStaticMarkup(
       <ReviewIcon

--- a/src/renderer/src/components/sidebar/worktree-review-helpers.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-review-helpers.test.tsx
@@ -9,7 +9,7 @@ const gitlabReview: WorktreeCardPrDisplay = {
   number: 456,
   title: 'Review me',
   state: 'open',
-  status: 'success'
+  status: 'pending'
 }
 
 describe('ReviewIcon', () => {
@@ -87,48 +87,6 @@ describe('ReviewIcon', () => {
     expect(failing).toContain('text-rose-500/85')
   })
 
-  it('renders a neutral spinner when requested by loading card metadata', () => {
-    const loading = renderToStaticMarkup(
-      <ReviewIcon
-        review={{
-          provider: 'github',
-          number: 1,
-          title: 'Loading PR...',
-          isLoading: true
-        }}
-        className="size-3"
-        variant="generic"
-        showLoadingSpinner
-      />
-    )
-
-    expect(loading).toContain('lucide-loader-circle')
-    expect(loading).toContain('animate-spin')
-    expect(loading).toContain('text-muted-foreground')
-    expect(loading).not.toContain('text-amber-500/85')
-    expect(loading).not.toContain('viewBox="0 0 16 16"')
-  })
-
-  it('keeps the pending review glyph on other review surfaces', () => {
-    const pending = renderToStaticMarkup(
-      <ReviewIcon
-        review={{
-          provider: 'github',
-          number: 1,
-          title: 'Checking',
-          state: 'open',
-          status: 'pending'
-        }}
-        className="size-3"
-        variant="generic"
-      />
-    )
-
-    expect(pending).toContain('viewBox="0 0 16 16"')
-    expect(pending).not.toContain('lucide-loader-circle')
-    expect(pending).not.toContain('animate-spin')
-  })
-
   it('renders action-required checks in amber instead of failure red or passing green', () => {
     const actionRequired = renderToStaticMarkup(
       <ReviewIcon
@@ -145,8 +103,6 @@ describe('ReviewIcon', () => {
     )
 
     expect(actionRequired).toContain('text-amber-500/85')
-    expect(actionRequired).not.toContain('lucide-loader-circle')
-    expect(actionRequired).not.toContain('animate-spin')
     expect(actionRequired).not.toContain('text-rose-500/85')
     expect(actionRequired).not.toContain('text-emerald-500/80')
   })

--- a/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
+++ b/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
@@ -1,5 +1,5 @@
 import { createElement } from 'react'
-import { GitMerge, Loader2 } from 'lucide-react'
+import { GitMerge } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { getReviewStateIcon } from '@/components/github/review-state-presentation'
 import { PullRequestIcon } from './WorktreeCardHelpers'
@@ -60,24 +60,16 @@ function getStateTone(state: WorktreeCardPrDisplay['state']): string {
 export function ReviewIcon({
   review,
   className,
-  variant = 'provider',
-  showLoadingSpinner = false
+  variant = 'provider'
 }: {
   review: WorktreeCardPrDisplay
   className?: string
   variant?: 'provider' | 'generic'
-  showLoadingSpinner?: boolean
 }): React.JSX.Element {
   const providerIcon =
     variant === 'provider' && review.provider === 'gitlab' ? GitMerge : PullRequestIcon
-  const stateIcon = getReviewStateIcon(review.state)
-  const Icon = stateIcon ?? (showLoadingSpinner ? Loader2 : providerIcon)
-
+  const Icon = getReviewStateIcon(review.state) ?? providerIcon
   return createElement(Icon, {
-    className: cn(
-      className,
-      getCheckTone(review) ?? getStateTone(review.state),
-      !stateIcon && showLoadingSpinner && 'animate-spin'
-    )
+    className: cn(className, getCheckTone(review) ?? getStateTone(review.state))
   })
 }

--- a/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
+++ b/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
@@ -25,11 +25,8 @@ export function getProviderName(review: WorktreeCardPrDisplay): string {
   return 'GitHub'
 }
 
-// Why: checks only gate a review that is actually open; draft/closed/merged keep
-// their state tone so the glyph agrees with its tooltip. A stateless row (folder
-// cards render one while a linked review is loading or its details failed) has no
-// state glyph to contradict, so it still flags problems — but never claims success,
-// since emerald would assert an open review we have not confirmed.
+// Why: checks only gate an open review; draft/closed/merged keep their state tone.
+// Stateless rows may surface known problems, but emerald requires confirmed success.
 function getCheckTone(review: WorktreeCardPrDisplay): string | null {
   if (review.state && review.state !== 'open') {
     return null
@@ -51,16 +48,13 @@ function getStateTone(state: WorktreeCardPrDisplay['state']): string {
   if (state === 'merged') {
     return 'text-purple-600/70 dark:text-purple-400/70'
   }
-  if (state === 'open') {
-    return 'text-emerald-500/80'
-  }
   if (state === 'closed') {
     return 'text-muted-foreground/60'
   }
   if (state === 'draft') {
     return 'text-muted-foreground/50'
   }
-  return 'text-muted-foreground opacity-70'
+  return 'text-muted-foreground'
 }
 
 export function ReviewIcon({

--- a/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
+++ b/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
@@ -34,13 +34,14 @@ function getCheckTone(review: WorktreeCardPrDisplay): string | null {
   if (review.state && review.state !== 'open') {
     return null
   }
-  if (review.status === 'failure') {
+  const status = review.checksPresentationStatus ?? review.status
+  if (status === 'failure') {
     return 'text-rose-500/85'
   }
-  if (review.status === 'pending') {
+  if (status === 'action_required' || status === 'pending') {
     return 'text-amber-500/85'
   }
-  if (review.state === 'open' && review.status === 'success') {
+  if (review.state === 'open' && status === 'success') {
     return 'text-emerald-500/80'
   }
   return null

--- a/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
+++ b/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
@@ -2,6 +2,7 @@ import { createElement } from 'react'
 import { GitMerge } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { getReviewStateIcon } from '@/components/github/review-state-presentation'
+import { getHostedReviewCheckPresentationStatus } from '../../../../shared/hosted-review'
 import { PullRequestIcon } from './WorktreeCardHelpers'
 import type { WorktreeCardPrDisplay } from './worktree-card-pr-display'
 
@@ -31,7 +32,7 @@ function getCheckTone(review: WorktreeCardPrDisplay): string | null {
   if (review.state && review.state !== 'open') {
     return null
   }
-  const status = review.checksPresentationStatus ?? review.status
+  const status = getHostedReviewCheckPresentationStatus(review)
   if (status === 'failure') {
     return 'text-rose-500/85'
   }

--- a/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
+++ b/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
@@ -1,5 +1,5 @@
 import { createElement } from 'react'
-import { GitMerge } from 'lucide-react'
+import { GitMerge, Loader2 } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { getReviewStateIcon } from '@/components/github/review-state-presentation'
 import { PullRequestIcon } from './WorktreeCardHelpers'
@@ -60,16 +60,24 @@ function getStateTone(state: WorktreeCardPrDisplay['state']): string {
 export function ReviewIcon({
   review,
   className,
-  variant = 'provider'
+  variant = 'provider',
+  showLoadingSpinner = false
 }: {
   review: WorktreeCardPrDisplay
   className?: string
   variant?: 'provider' | 'generic'
+  showLoadingSpinner?: boolean
 }): React.JSX.Element {
   const providerIcon =
     variant === 'provider' && review.provider === 'gitlab' ? GitMerge : PullRequestIcon
-  const Icon = getReviewStateIcon(review.state) ?? providerIcon
+  const stateIcon = getReviewStateIcon(review.state)
+  const Icon = stateIcon ?? (showLoadingSpinner ? Loader2 : providerIcon)
+
   return createElement(Icon, {
-    className: cn(className, getCheckTone(review) ?? getStateTone(review.state))
+    className: cn(
+      className,
+      getCheckTone(review) ?? getStateTone(review.state),
+      !stateIcon && showLoadingSpinner && 'animate-spin'
+    )
   })
 }

--- a/src/renderer/src/components/task-page-checks-pill.test.ts
+++ b/src/renderer/src/components/task-page-checks-pill.test.ts
@@ -36,6 +36,31 @@ describe('task page checks pill', () => {
     expect(getChecksPillTone(item)).toContain('text-muted-foreground')
   })
 
+  it('uses an amber action-required presentation without hiding real failures', () => {
+    const actionRequired = {
+      checksSummary: {
+        state: 'failure' as const,
+        total: 2,
+        passed: 0,
+        failed: 2,
+        pending: 0,
+        neutral: 0,
+        actionRequired: 2
+      }
+    }
+    const mixedFailure = {
+      checksSummary: {
+        ...actionRequired.checksSummary,
+        failed: 3
+      }
+    }
+
+    expect(getChecksLabel(actionRequired)).toBe('2 action required')
+    expect(getChecksPillTone(actionRequired)).toContain('amber')
+    expect(getChecksLabel(mixedFailure)).toBe('1 failing')
+    expect(getChecksPillTone(mixedFailure)).toContain('rose')
+  })
+
   it('falls back while the summary is unknown or empty', () => {
     expect(getChecksLabel({})).toBe('Checks')
     expect(

--- a/src/renderer/src/components/task-page-checks-pill.test.ts
+++ b/src/renderer/src/components/task-page-checks-pill.test.ts
@@ -55,7 +55,7 @@ describe('task page checks pill', () => {
       }
     }
 
-    expect(getChecksLabel(actionRequired)).toBe('2 action required')
+    expect(getChecksLabel(actionRequired)).toBe('Action required: 2')
     expect(getChecksPillTone(actionRequired)).toContain('amber')
     expect(getChecksLabel(mixedFailure)).toBe('1 failing')
     expect(getChecksPillTone(mixedFailure)).toContain('rose')

--- a/src/renderer/src/components/task-page-checks-pill.ts
+++ b/src/renderer/src/components/task-page-checks-pill.ts
@@ -1,4 +1,7 @@
-import { getProviderChecksLabel } from '../../../shared/provider-check-summary'
+import {
+  getProviderChecksLabel,
+  getProviderChecksPresentationState
+} from '../../../shared/provider-check-summary'
 import type { ProviderCheckSummary } from '../../../shared/github/pull-request-types'
 
 type ChecksPillItem = { checksSummary?: ProviderCheckSummary }
@@ -12,12 +15,15 @@ export function getChecksLabel(item: ChecksPillItem): string {
 }
 
 export function getChecksPillTone(item: ChecksPillItem): string {
-  const state = item.checksSummary?.state
+  const state = getProviderChecksPresentationState(item.checksSummary)
   if (state === 'success') {
     return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200'
   }
   if (state === 'failure') {
     return 'border-rose-500/30 bg-rose-500/10 text-rose-700 dark:text-rose-200'
+  }
+  if (state === 'action_required') {
+    return 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-200'
   }
   if (state === 'pending') {
     return 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-200'

--- a/src/renderer/src/components/task-page-pr-check-summary.test.ts
+++ b/src/renderer/src/components/task-page-pr-check-summary.test.ts
@@ -59,7 +59,7 @@ describe('deriveTaskPagePRCheckSummary', () => {
     })
   })
 
-  it('counts action_required as failed so a blocked PR never reads as passing', () => {
+  it('retains the blocking total while distinguishing action-required checks', () => {
     expect(
       deriveTaskPagePRCheckSummary([
         check({ conclusion: 'success' }),
@@ -71,7 +71,8 @@ describe('deriveTaskPagePRCheckSummary', () => {
       passed: 1,
       failed: 1,
       pending: 0,
-      neutral: 0
+      neutral: 0,
+      actionRequired: 1
     })
   })
 

--- a/src/renderer/src/components/task-page-work-item-signatures.ts
+++ b/src/renderer/src/components/task-page-work-item-signatures.ts
@@ -32,6 +32,7 @@ export function taskPageWorkItemStatusSignature(item: GitHubWorkItem): string {
     item.checksSummary?.state ?? null,
     item.checksSummary?.total ?? null,
     item.checksSummary?.failed ?? null,
+    item.checksSummary?.actionRequired ?? null,
     item.checksSummary?.pending ?? null,
     item.checksSummary?.neutral ?? null,
     item.mergeable ?? null,

--- a/src/renderer/src/components/task-page/github/ChecksCell.tsx
+++ b/src/renderer/src/components/task-page/github/ChecksCell.tsx
@@ -1,10 +1,11 @@
 import type { GitHubWorkItem } from '../../../../../shared/github/work-item-types'
 import React, { useRef, useEffect } from 'react'
 import { translate } from '@/i18n/i18n'
-import { CheckCircle2, AlertCircle, Clock3, Minus } from 'lucide-react'
+import { CheckCircle2, AlertCircle, AlertTriangle, Clock3, Minus } from 'lucide-react'
 import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { getChecksPillTone, getChecksLabel } from '@/components/task-page-checks-pill'
+import { getProviderChecksPresentationState } from '../../../../../shared/provider-check-summary'
 export function PRChecksCell({
   item,
   onOpen,
@@ -48,14 +49,17 @@ export function PRChecksCell({
     )
   }
   const summary = item.checksSummary
+  const presentationState = getProviderChecksPresentationState(summary)
   const Icon =
-    summary?.state === 'success'
+    presentationState === 'success'
       ? CheckCircle2
-      : summary?.state === 'failure'
+      : presentationState === 'failure'
         ? AlertCircle
-        : summary?.state === 'pending'
-          ? Clock3
-          : Minus
+        : presentationState === 'action_required'
+          ? AlertTriangle
+          : presentationState === 'pending'
+            ? Clock3
+            : Minus
   return (
     <Tooltip>
       <TooltipTrigger asChild>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -12491,6 +12491,7 @@
                 "f5cf324efa": "Comment display options",
                 "5e6e5a13fa": "View",
                 "actionRequiredHint": "This check needs a manual action on GitHub (for example, approving the workflow run) before merging is unblocked.",
+                "actionRequiredProviderHint": "Needs a manual action on {{value0}} to unblock merging.",
                 "b3195cba33": "Unmark author as bot",
                 "f588b46a6c": "Mark author as bot",
                 "e45324fbed": "Failed to load check details."
@@ -16703,7 +16704,7 @@
         "passingChip": "{{value0}} passing",
         "failingChip": "{{value0}} failing",
         "pendingChip": "{{value0}} pending",
-        "needsActionChip": "{{value0}} action required",
+        "needsActionChip": "Action required: {{value0}}",
         "unresolvedChip": "{{value0}} unresolved"
       },
       "BrowserPane": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6038,7 +6038,11 @@
           "setParentFor": "Set parent for"
         },
         "WorktreeCardStatusSlot": {
-          "branchIdentity": "Branch"
+          "branchIdentity": "Branch",
+          "actionRequiredChecks": "{{reviewLabel}} checks: Action required"
+        },
+        "WorktreeCardHelpers": {
+          "actionRequiredCheckStatus": "Action required"
         },
         "NewExternalWorktreesInboxLine": {
           "9f2d4c8b17": "Hide external worktrees permanently for {{value0}}",
@@ -12491,7 +12495,7 @@
                 "f5cf324efa": "Comment display options",
                 "5e6e5a13fa": "View",
                 "actionRequiredHint": "This check needs a manual action on GitHub (for example, approving the workflow run) before merging is unblocked.",
-                "actionRequiredProviderHint": "Needs a manual action on {{value0}} to unblock merging.",
+                "actionRequiredProviderHint": "Needs a manual action on {{providerName}} to unblock merging.",
                 "b3195cba33": "Unmark author as bot",
                 "f588b46a6c": "Mark author as bot",
                 "e45324fbed": "Failed to load check details."
@@ -16356,6 +16360,7 @@
             "failingCount": "{{value0}} failing",
             "pendingCount": "{{value0}} pending",
             "checksFailing": "Checks failing",
+            "actionRequired": "Action required",
             "mergeConflicts": "Merge conflicts",
             "checksPending": "Checks pending",
             "checksPassing": "Checks passing",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -10941,6 +10941,7 @@
                 "f5cf324efa": "Opciones de visualización de comentarios",
                 "5e6e5a13fa": "Vista",
                 "actionRequiredHint": "Este check requiere una acción manual en GitHub (por ejemplo, aprobar la ejecución del workflow) antes de que el merge quede desbloqueado.",
+                "actionRequiredProviderHint": "Se necesita una acción manual en {{value0}} para desbloquear el merge.",
                 "b3195cba33": "Desmarcar autor como bot",
                 "f588b46a6c": "Marcar autor como bot",
                 "e45324fbed": "No se pudieron cargar los detalles del check."
@@ -14512,7 +14513,7 @@
         "passingChip": "{{value0}} pasando",
         "failingChip": "{{value0}} fallando",
         "pendingChip": "{{value0}} pendiente",
-        "needsActionChip": "{{value0}} requiere acción",
+        "needsActionChip": "Acción requerida: {{value0}}",
         "unresolvedChip": "{{value0}} sin resolver"
       },
       "artifacts": {

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -5172,7 +5172,11 @@
           "setParentFor": "Establecer padre para"
         },
         "WorktreeCardStatusSlot": {
-          "branchIdentity": "Rama"
+          "branchIdentity": "Rama",
+          "actionRequiredChecks": "Checks de {{reviewLabel}}: acción requerida"
+        },
+        "WorktreeCardHelpers": {
+          "actionRequiredCheckStatus": "Acción requerida"
         },
         "NewExternalWorktreesInboxLine": {
           "9f2d4c8b17": "Ocultar worktrees externos permanentemente para {{value0}}",
@@ -10941,7 +10945,7 @@
                 "f5cf324efa": "Opciones de visualización de comentarios",
                 "5e6e5a13fa": "Vista",
                 "actionRequiredHint": "Este check requiere una acción manual en GitHub (por ejemplo, aprobar la ejecución del workflow) antes de que el merge quede desbloqueado.",
-                "actionRequiredProviderHint": "Se necesita una acción manual en {{value0}} para desbloquear el merge.",
+                "actionRequiredProviderHint": "Se necesita una acción manual en {{providerName}} para desbloquear el merge.",
                 "b3195cba33": "Desmarcar autor como bot",
                 "f588b46a6c": "Marcar autor como bot",
                 "e45324fbed": "No se pudieron cargar los detalles del check."
@@ -14298,6 +14302,7 @@
             "failingCount": "{{value0}} fallando",
             "pendingCount": "{{value0}} pendientes",
             "checksFailing": "Checks fallando",
+            "actionRequired": "Acción requerida",
             "mergeConflicts": "Conflictos de merge",
             "checksPending": "Checks pendientes",
             "checksPassing": "Checks correctos",

--- a/src/renderer/src/i18n/locales/fr.json
+++ b/src/renderer/src/i18n/locales/fr.json
@@ -5776,7 +5776,11 @@
           "setParentFor": "Définir le parent pour"
         },
         "WorktreeCardStatusSlot": {
-          "branchIdentity": "Branche"
+          "branchIdentity": "Branche",
+          "actionRequiredChecks": "Vérifications de {{reviewLabel}} : action requise"
+        },
+        "WorktreeCardHelpers": {
+          "actionRequiredCheckStatus": "Action requise"
         },
         "NewExternalWorktreesInboxLine": {
           "9f2d4c8b17": "Masquer définitivement les worktrees externes pour {{value0}}",
@@ -11998,6 +12002,7 @@
                 "f5cf324efa": "Options d'affichage des commentaires",
                 "5e6e5a13fa": "Affichage",
                 "actionRequiredHint": "Cette vérification nécessite une action manuelle sur GitHub (par exemple, approuver l'exécution du workflow) avant que le merge soit débloqué.",
+                "actionRequiredProviderHint": "Une action manuelle sur {{providerName}} est nécessaire pour débloquer le merge.",
                 "b3195cba33": "Retirer le marqueur bot de l'auteur",
                 "f588b46a6c": "Marquer l'auteur comme bot",
                 "e45324fbed": "Échec du chargement des détails de la vérification."
@@ -15567,6 +15572,7 @@
             "failingCount": "{{value0}} en échec",
             "pendingCount": "{{value0}} en attente",
             "checksFailing": "Vérifications en échec",
+            "actionRequired": "Action requise",
             "mergeConflicts": "Conflits de fusion",
             "checksPending": "Vérifications en attente",
             "checksPassing": "Vérifications réussies",
@@ -15798,7 +15804,7 @@
         "passingChip": "{{value0}} réussis",
         "failingChip": "{{value0}} en échec",
         "pendingChip": "{{value0}} en attente",
-        "needsActionChip": "{{value0}} action requise",
+        "needsActionChip": "Action requise : {{value0}}",
         "unresolvedChip": "{{value0}} non résolus"
       },
       "BrowserPane": {

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -5172,7 +5172,11 @@
           "setParentFor": "次のワークツリーの親を設定"
         },
         "WorktreeCardStatusSlot": {
-          "branchIdentity": "ブランチ"
+          "branchIdentity": "ブランチ",
+          "actionRequiredChecks": "{{reviewLabel}} チェック: 対応が必要"
+        },
+        "WorktreeCardHelpers": {
+          "actionRequiredCheckStatus": "対応が必要"
         },
         "NewExternalWorktreesInboxLine": {
           "9f2d4c8b17": "{{value0}} の外部ワークツリーを完全に非表示にする",
@@ -10941,7 +10945,7 @@
                 "f5cf324efa": "コメント表示オプション",
                 "5e6e5a13fa": "表示",
                 "actionRequiredHint": "マージのブロックが解除されるまでに、このチェックには GitHub 上での手動操作（例: ワークフロー実行の承認）が必要です。",
-                "actionRequiredProviderHint": "{{value0}} で手動操作を行い、マージのブロックを解除する必要があります。",
+                "actionRequiredProviderHint": "{{providerName}} で手動操作を行い、マージのブロックを解除する必要があります。",
                 "b3195cba33": "作成者のボット指定を解除",
                 "f588b46a6c": "作成者をボットとして指定",
                 "e45324fbed": "チェック詳細の読み込みに失敗しました。"
@@ -14298,6 +14302,7 @@
             "failingCount": "{{value0}} 件失敗",
             "pendingCount": "{{value0}} 件保留中",
             "checksFailing": "チェック失敗",
+            "actionRequired": "対応が必要",
             "mergeConflicts": "マージ競合",
             "checksPending": "保留中のチェック",
             "checksPassing": "チェック成功",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -10941,6 +10941,7 @@
                 "f5cf324efa": "コメント表示オプション",
                 "5e6e5a13fa": "表示",
                 "actionRequiredHint": "マージのブロックが解除されるまでに、このチェックには GitHub 上での手動操作（例: ワークフロー実行の承認）が必要です。",
+                "actionRequiredProviderHint": "{{value0}} で手動操作を行い、マージのブロックを解除する必要があります。",
                 "b3195cba33": "作成者のボット指定を解除",
                 "f588b46a6c": "作成者をボットとして指定",
                 "e45324fbed": "チェック詳細の読み込みに失敗しました。"
@@ -14512,7 +14513,7 @@
         "passingChip": "{{value0}} 通過",
         "failingChip": "{{value0}} 件失敗",
         "pendingChip": "{{value0}} 件保留中",
-        "needsActionChip": "{{value0}} 件の対応が必要",
+        "needsActionChip": "対応が必要: {{value0}} 件",
         "unresolvedChip": "{{value0}} 件未解決"
       },
       "artifacts": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -10984,6 +10984,7 @@
                 "f5cf324efa": "댓글 표시 옵션",
                 "5e6e5a13fa": "보기",
                 "actionRequiredHint": "이 검사는 병합 차단이 해제되기 전에 GitHub에서 수동 작업(예: 워크플로 실행 승인)이 필요합니다.",
+                "actionRequiredProviderHint": "병합 차단을 해제하려면 {{value0}}에서 수동 조치가 필요합니다.",
                 "b3195cba33": "작성자의 봇 지정 해제",
                 "f588b46a6c": "작성자를 봇으로 지정",
                 "e45324fbed": "체크 세부 정보를 불러오지 못했습니다."
@@ -14590,7 +14591,7 @@
         "passingChip": "{{value0}} 통과",
         "failingChip": "{{value0}} 실패",
         "pendingChip": "{{value0}} 보류 중",
-        "needsActionChip": "{{value0}}개 조치 필요",
+        "needsActionChip": "조치 필요: {{value0}}개",
         "unresolvedChip": "{{value0}}개 미해결"
       },
       "artifacts": {

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -5177,7 +5177,11 @@
           "setParentFor": "다음 워크트리의 상위 설정"
         },
         "WorktreeCardStatusSlot": {
-          "branchIdentity": "브랜치"
+          "branchIdentity": "브랜치",
+          "actionRequiredChecks": "{{reviewLabel}} 검사: 조치 필요"
+        },
+        "WorktreeCardHelpers": {
+          "actionRequiredCheckStatus": "조치 필요"
         },
         "NewExternalWorktreesInboxLine": {
           "9f2d4c8b17": "{{value0}}의 외부 워크트리를 영구적으로 숨기기",
@@ -10984,7 +10988,7 @@
                 "f5cf324efa": "댓글 표시 옵션",
                 "5e6e5a13fa": "보기",
                 "actionRequiredHint": "이 검사는 병합 차단이 해제되기 전에 GitHub에서 수동 작업(예: 워크플로 실행 승인)이 필요합니다.",
-                "actionRequiredProviderHint": "병합 차단을 해제하려면 {{value0}}에서 수동 조치가 필요합니다.",
+                "actionRequiredProviderHint": "병합 차단을 해제하려면 {{providerName}}에서 수동 조치가 필요합니다.",
                 "b3195cba33": "작성자의 봇 지정 해제",
                 "f588b46a6c": "작성자를 봇으로 지정",
                 "e45324fbed": "체크 세부 정보를 불러오지 못했습니다."
@@ -14376,6 +14380,7 @@
             "failingCount": "{{value0}}개 실패",
             "pendingCount": "{{value0}}개 대기 중",
             "checksFailing": "검사 실패",
+            "actionRequired": "조치 필요",
             "mergeConflicts": "병합 충돌",
             "checksPending": "검사 대기 중",
             "checksPassing": "검사 통과",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -5220,7 +5220,11 @@
           "setParentFor": "为以下工作树设置父级"
         },
         "WorktreeCardStatusSlot": {
-          "branchIdentity": "分支"
+          "branchIdentity": "分支",
+          "actionRequiredChecks": "{{reviewLabel}} 检查：需要操作"
+        },
+        "WorktreeCardHelpers": {
+          "actionRequiredCheckStatus": "需要操作"
         },
         "NewExternalWorktreesInboxLine": {
           "9f2d4c8b17": "永久隐藏 {{value0}} 的外部工作树",
@@ -11019,7 +11023,7 @@
                 "f5cf324efa": "评论显示选项",
                 "5e6e5a13fa": "查看",
                 "actionRequiredHint": "此检查需要在 GitHub 上执行手动操作（例如批准工作流运行）后才能解除合并阻止。",
-                "actionRequiredProviderHint": "需要在 {{value0}} 上手动操作才能解除合并阻止。",
+                "actionRequiredProviderHint": "需要在 {{providerName}} 上手动操作才能解除合并阻止。",
                 "b3195cba33": "取消将作者标记为机器人",
                 "f588b46a6c": "将作者标记为机器人",
                 "e45324fbed": "加载检查详细信息失败。"
@@ -14376,6 +14380,7 @@
             "failingCount": "{{value0}} 个失败",
             "pendingCount": "{{value0}} 个等待中",
             "checksFailing": "检查失败",
+            "actionRequired": "需要操作",
             "mergeConflicts": "合并冲突",
             "checksPending": "检查等待中",
             "checksPassing": "检查通过",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -11019,6 +11019,7 @@
                 "f5cf324efa": "评论显示选项",
                 "5e6e5a13fa": "查看",
                 "actionRequiredHint": "此检查需要在 GitHub 上执行手动操作（例如批准工作流运行）后才能解除合并阻止。",
+                "actionRequiredProviderHint": "需要在 {{value0}} 上手动操作才能解除合并阻止。",
                 "b3195cba33": "取消将作者标记为机器人",
                 "f588b46a6c": "将作者标记为机器人",
                 "e45324fbed": "加载检查详细信息失败。"
@@ -14590,7 +14591,7 @@
         "passingChip": "{{value0}} 通过",
         "failingChip": "{{value0}} 失败",
         "pendingChip": "{{value0}} 待处理",
-        "needsActionChip": "{{value0}} 个需要操作",
+        "needsActionChip": "需要操作：{{value0}} 个",
         "unresolvedChip": "{{value0}} 个未解决"
       },
       "artifacts": {

--- a/src/renderer/src/store/github/check-actions.ts
+++ b/src/renderer/src/store/github/check-actions.ts
@@ -78,7 +78,8 @@ export const createCheckActions = (
         requestSettings,
         repo?.connectionId,
         repo?.executionHostId,
-        repo !== undefined
+        repo !== undefined,
+        prNumber
       )
       if (prStatusUpdate) {
         set(prStatusUpdate)
@@ -151,13 +152,10 @@ export const createCheckActions = (
             requestSettings,
             repo?.connectionId,
             repo?.executionHostId,
-            repo !== undefined
+            repo !== undefined,
+            prNumber
           )
-          if (prStatusUpdate?.prCache) {
-            nextState.prCache = prStatusUpdate.prCache
-          }
-
-          return nextState
+          return prStatusUpdate ? { ...nextState, ...prStatusUpdate } : nextState
         })
         debouncedSaveCache(get())
         return checks

--- a/src/renderer/src/store/github/pr-check-status-cache.ts
+++ b/src/renderer/src/store/github/pr-check-status-cache.ts
@@ -1,7 +1,7 @@
 import type { AppState } from '../types'
 import type { GitHubPRRefreshAlias } from '../../../../shared/github/pull-request-refresh-types'
 import type { PRInfo } from '../../../../shared/github/pull-request-types'
-import { deriveCheckStatusFromChecks } from '../slices/github-checks'
+import { deriveCheckStatusesFromChecks } from '../slices/github-checks'
 import {
   getPRChecksCacheTtl,
   prChecksCacheSuffix,
@@ -76,7 +76,12 @@ export function applyCachedChecksStatus(
     checksEntry.headSha === pr.headSha &&
     fetchedAt - checksEntry.fetchedAt < getPRChecksCacheTtl(checksEntry)
   ) {
-    return { ...pr, checksStatus: deriveCheckStatusFromChecks(checksEntry.data) }
+    const checkStatuses = deriveCheckStatusesFromChecks(checksEntry.data)
+    return {
+      ...pr,
+      checksStatus: checkStatuses.status,
+      checksPresentationStatus: checkStatuses.presentationStatus
+    }
   }
   return pr
 }

--- a/src/renderer/src/store/slices/github-checks.test.ts
+++ b/src/renderer/src/store/slices/github-checks.test.ts
@@ -8,7 +8,7 @@ import type { AppState } from '../types'
 import type { PRCheckDetail } from '../../../../shared/github/check-types'
 
 describe('deriveCheckStatusFromChecks', () => {
-  it('treats an action_required check as failure so it is not a silent pass', () => {
+  it('retains action_required as a coarse merge-blocking failure status', () => {
     const checks: PRCheckDetail[] = [
       { name: 'build', status: 'completed', conclusion: 'success', url: null },
       { name: 'approval', status: 'completed', conclusion: 'action_required', url: null }

--- a/src/renderer/src/store/slices/github-checks.test.ts
+++ b/src/renderer/src/store/slices/github-checks.test.ts
@@ -67,16 +67,136 @@ describe('syncPRChecksStatus', () => {
     expect(result?.prCache?.['repo-id::main']?.data?.checksStatus).toBe('success')
   })
 
+  it('keeps the matching hosted review cache in sync with detailed checks', () => {
+    const state = {
+      prCache: {
+        'repo-id::main': {
+          fetchedAt: 0,
+          data: { number: 12, checksStatus: 'neutral' as const }
+        }
+      },
+      hostedReviewCache: {
+        'local::repo-id::main': {
+          fetchedAt: 0,
+          data: { provider: 'github', number: 12, status: 'neutral' as const }
+        }
+      }
+    } as unknown as AppState
+
+    const result = syncPRChecksStatus(
+      state,
+      '/repo',
+      'repo-id',
+      'main',
+      [{ name: 'approval', status: 'completed', conclusion: 'action_required', url: null }],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true
+    )
+
+    expect(result?.hostedReviewCache?.['local::repo-id::main']?.data).toMatchObject({
+      status: 'failure',
+      checksPresentationStatus: 'action_required'
+    })
+  })
+
+  it('updates a matching hosted review after the PR cache entry was evicted', () => {
+    const state = {
+      prCache: {},
+      hostedReviewCache: {
+        'local::repo-id::main': {
+          fetchedAt: 0,
+          data: { provider: 'github', number: 12, status: 'neutral' as const }
+        }
+      }
+    } as unknown as AppState
+
+    const result = syncPRChecksStatus(
+      state,
+      '/repo',
+      'repo-id',
+      'main',
+      [{ name: 'approval', status: 'completed', conclusion: 'action_required', url: null }],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+      12
+    )
+
+    expect(result?.prCache).toBeUndefined()
+    expect(result?.hostedReviewCache?.['local::repo-id::main']?.data).toMatchObject({
+      status: 'failure',
+      checksPresentationStatus: 'action_required'
+    })
+  })
+
+  it('does not overwrite a hosted review that has advanced to a different head', () => {
+    const state = {
+      prCache: {
+        'repo-id::main': {
+          fetchedAt: 0,
+          data: { number: 12, headSha: 'old-head', checksStatus: 'neutral' as const }
+        }
+      },
+      hostedReviewCache: {
+        'local::repo-id::main': {
+          fetchedAt: 1,
+          data: {
+            provider: 'github',
+            number: 12,
+            headSha: 'new-head',
+            status: 'success' as const
+          }
+        }
+      }
+    } as unknown as AppState
+
+    const result = syncPRChecksStatus(
+      state,
+      '/repo',
+      'repo-id',
+      'main',
+      [{ name: 'approval', status: 'completed', conclusion: 'action_required', url: null }],
+      'old-head',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true
+    )
+
+    expect(result?.prCache?.['repo-id::main']?.data?.checksPresentationStatus).toBe(
+      'action_required'
+    )
+    expect(result?.hostedReviewCache).toBeUndefined()
+  })
+
   it('updates the local repo key while a runtime is focused when repo owner is known', () => {
     const state = {
       prCache: {
         'repo-id::main': {
           fetchedAt: 0,
-          data: { checksStatus: 'neutral' as const }
+          data: { number: 12, checksStatus: 'neutral' as const }
         },
         'runtime:env-win::repo-id::main': {
           fetchedAt: 0,
-          data: { checksStatus: 'neutral' as const }
+          data: { number: 12, checksStatus: 'neutral' as const }
+        }
+      },
+      hostedReviewCache: {
+        'local::repo-id::main': {
+          fetchedAt: 0,
+          data: { provider: 'github', number: 12, status: 'neutral' as const }
+        },
+        'runtime:env-win::repo-id::main': {
+          fetchedAt: 0,
+          data: { provider: 'github', number: 12, status: 'neutral' as const }
         }
       }
     } as unknown as AppState
@@ -97,6 +217,10 @@ describe('syncPRChecksStatus', () => {
 
     expect(result?.prCache?.['repo-id::main']?.data?.checksStatus).toBe('success')
     expect(result?.prCache?.['runtime:env-win::repo-id::main']?.data?.checksStatus).toBe('neutral')
+    expect(result?.hostedReviewCache?.['local::repo-id::main']?.data?.status).toBe('success')
+    expect(result?.hostedReviewCache?.['runtime:env-win::repo-id::main']?.data?.status).toBe(
+      'neutral'
+    )
   })
 
   it('rejects a checks result from the same slug on a different GitHub host', () => {
@@ -124,6 +248,78 @@ describe('syncPRChecksStatus', () => {
       [{ name: 'build', status: 'completed', conclusion: 'success', url: null }],
       undefined,
       { owner: 'acme', repo: 'widgets', host: 'github.com' }
+    )
+
+    expect(result).toBeNull()
+  })
+
+  it('does not update a hosted review owned by a different GitHub host', () => {
+    const state = {
+      prCache: {},
+      hostedReviewCache: {
+        'local::repo-id::main': {
+          fetchedAt: 0,
+          data: {
+            provider: 'github',
+            number: 12,
+            status: 'neutral' as const,
+            githubRepository: {
+              owner: 'acme',
+              repo: 'widgets',
+              host: 'github.acme-corp.com'
+            }
+          }
+        }
+      }
+    } as unknown as AppState
+
+    const result = syncPRChecksStatus(
+      state,
+      '/repo',
+      'repo-id',
+      'main',
+      [{ name: 'build', status: 'completed', conclusion: 'success', url: null }],
+      undefined,
+      { owner: 'acme', repo: 'widgets', host: 'github.com' },
+      undefined,
+      undefined,
+      undefined,
+      true,
+      12
+    )
+
+    expect(result).toBeNull()
+  })
+
+  it('does not update a known hosted-review repository from an unscoped checks result', () => {
+    const state = {
+      prCache: {},
+      hostedReviewCache: {
+        'local::repo-id::main': {
+          fetchedAt: 0,
+          data: {
+            provider: 'github',
+            number: 12,
+            status: 'neutral' as const,
+            githubRepository: { owner: 'acme', repo: 'widgets', host: 'github.com' }
+          }
+        }
+      }
+    } as unknown as AppState
+
+    const result = syncPRChecksStatus(
+      state,
+      '/repo',
+      'repo-id',
+      'main',
+      [{ name: 'build', status: 'completed', conclusion: 'success', url: null }],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      true,
+      12
     )
 
     expect(result).toBeNull()

--- a/src/renderer/src/store/slices/github-checks.ts
+++ b/src/renderer/src/store/slices/github-checks.ts
@@ -3,13 +3,15 @@ import type { PRCheckDetail } from '../../../../shared/github/check-types'
 import type { GitHubOwnerRepo } from '../../../../shared/github/pull-request-types'
 import { getGitHubPRCacheKey } from './github-cache-key'
 import { githubRepoIdentityKey } from '../../../../shared/github/repository-identity-key'
-import { derivePRCheckStatus } from '../../../../shared/pr-check-status'
+import { derivePRCheckStatuses, derivePRCheckStatus } from '../../../../shared/pr-check-status'
+import { getHostedReviewCacheKey } from './hosted-review-cache-identity'
 
 export function normalizeBranchName(branch: string): string {
   return branch.replace(/^refs\/heads\//, '')
 }
 
 export const deriveCheckStatusFromChecks = derivePRCheckStatus
+export const deriveCheckStatusesFromChecks = derivePRCheckStatuses
 
 export function syncPRChecksStatus(
   state: AppState,
@@ -22,7 +24,8 @@ export function syncPRChecksStatus(
   settings?: AppState['settings'],
   connectionId?: string | null,
   executionHostId?: string | null,
-  hasRepoOwner = false
+  hasRepoOwner = false,
+  prNumber?: number
 ): Partial<AppState> | null {
   const normalized = branch ? normalizeBranchName(branch) : ''
   if (!normalized) {
@@ -39,34 +42,85 @@ export function syncPRChecksStatus(
     hasRepoOwner
   )
   const prEntry = state.prCache[prCacheKey]
-  if (!prEntry?.data) {
-    return null
-  }
+  const pr = prEntry?.data ?? null
+  const nextStatuses = deriveCheckStatusesFromChecks(checks)
   // Why: fork PR rediscovery can retarget the branch cache while an older
-  // checks request is still in flight; only the matching PR repo may update it.
-  if (prRepo !== undefined && !samePRRepo(prEntry.data.prRepo, prRepo)) {
-    return null
-  }
-  if (headSha && prEntry.data.headSha && prEntry.data.headSha !== headSha) {
-    return null
-  }
-
-  const nextStatus = deriveCheckStatusFromChecks(checks)
-  if (prEntry.data.checksStatus === nextStatus) {
+  // checks request is still in flight; only the matching PR repo and head may update it.
+  const prMatchesRequest =
+    pr !== null &&
+    (prNumber === undefined || pr.number === prNumber) &&
+    (prRepo === undefined || samePRRepo(pr.prRepo, prRepo)) &&
+    (!headSha || !pr.headSha || pr.headSha === headSha)
+  const prNeedsUpdate =
+    prMatchesRequest &&
+    pr !== null &&
+    (pr.checksStatus !== nextStatuses.status ||
+      pr.checksPresentationStatus !== nextStatuses.presentationStatus)
+  const hostedReviewCacheKey = getHostedReviewCacheKey(
+    repoPath,
+    normalized,
+    settings,
+    repoId,
+    connectionId,
+    executionHostId,
+    hasRepoOwner
+  )
+  const hostedReviewEntry = state.hostedReviewCache?.[hostedReviewCacheKey]
+  const hostedReview = hostedReviewEntry?.data
+  const expectedPRNumber = prNumber ?? pr?.number
+  const expectedRepository = prRepo ?? pr?.prRepo
+  const hostedReviewRepositoryConflicts =
+    hostedReview?.githubRepository !== undefined &&
+    expectedRepository !== undefined &&
+    !samePRRepo(hostedReview.githubRepository, expectedRepository)
+  const hostedReviewRepositoryUnverifiable =
+    hostedReview?.githubRepository !== undefined && expectedRepository === undefined
+  const hostedReviewHeadConflicts =
+    headSha !== undefined && hostedReview?.headSha !== undefined && hostedReview.headSha !== headSha
+  const hostedReviewNeedsUpdate =
+    hostedReview?.provider === 'github' &&
+    expectedPRNumber !== undefined &&
+    hostedReview.number === expectedPRNumber &&
+    !hostedReviewRepositoryConflicts &&
+    !hostedReviewRepositoryUnverifiable &&
+    !hostedReviewHeadConflicts &&
+    (hostedReview.status !== nextStatuses.status ||
+      hostedReview.checksPresentationStatus !== nextStatuses.presentationStatus)
+  if (!prNeedsUpdate && !hostedReviewNeedsUpdate) {
     return null
   }
 
   return {
-    prCache: {
-      ...state.prCache,
-      [prCacheKey]: {
-        ...prEntry,
-        data: {
-          ...prEntry.data,
-          checksStatus: nextStatus
+    ...(prNeedsUpdate && prEntry && pr
+      ? {
+          prCache: {
+            ...state.prCache,
+            [prCacheKey]: {
+              ...prEntry,
+              data: {
+                ...pr,
+                checksStatus: nextStatuses.status,
+                checksPresentationStatus: nextStatuses.presentationStatus
+              }
+            }
+          }
         }
-      }
-    }
+      : {}),
+    ...(hostedReviewNeedsUpdate && hostedReviewEntry && hostedReview
+      ? {
+          hostedReviewCache: {
+            ...state.hostedReviewCache,
+            [hostedReviewCacheKey]: {
+              ...hostedReviewEntry,
+              data: {
+                ...hostedReview,
+                status: nextStatuses.status,
+                checksPresentationStatus: nextStatuses.presentationStatus
+              }
+            }
+          }
+        }
+      : {})
   }
 }
 

--- a/src/renderer/src/store/slices/github-pr-checks-fetch.test.ts
+++ b/src/renderer/src/store/slices/github-pr-checks-fetch.test.ts
@@ -15,6 +15,7 @@ import {
   type RuntimeEnvironmentCallRequest
 } from '../../runtime/runtime-compatibility-test-fixture'
 import { getTaskSourceCacheScope } from '../../../../shared/task-source-context'
+import { hostedReviewInfoFromGitHubPRInfo } from '../../../../shared/hosted-review-github'
 
 describe('createGitHubSlice.fetchPRChecks', () => {
   beforeEach(() => {
@@ -53,6 +54,96 @@ describe('createGitHubSlice.fetchPRChecks', () => {
       .fetchPRChecks(repoPath, 12, branch, undefined, null, { force: true, repoId })
 
     expect(store.getState().prCache[prCacheKey]?.data?.checksStatus).toBe('success')
+  })
+
+  it('keeps the legacy failure status while publishing action-required presentation', async () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const repoId = 'repo-id'
+    const branch = 'feature/needs-approval'
+    const prCacheKey = `${repoId}::${branch}`
+
+    const initialPR = makePR({ checksStatus: 'neutral' })
+    const hostedReviewCacheKey = `local::${repoId}::${branch}`
+    store.setState({
+      repos: [
+        {
+          id: repoId,
+          path: repoPath,
+          displayName: 'repo',
+          badgeColor: '#000000',
+          addedAt: 1,
+          kind: 'git'
+        }
+      ],
+      prCache: {
+        [prCacheKey]: {
+          data: initialPR,
+          fetchedAt: 1
+        }
+      },
+      hostedReviewCache: {
+        [hostedReviewCacheKey]: {
+          data: hostedReviewInfoFromGitHubPRInfo(initialPR),
+          fetchedAt: 1
+        }
+      }
+    })
+    mockApi.gh.prChecks.mockResolvedValue([
+      { name: 'deploy', status: 'completed', conclusion: 'action_required', url: null }
+    ])
+
+    await store
+      .getState()
+      .fetchPRChecks(repoPath, 12, branch, undefined, null, { force: true, repoId })
+
+    expect(store.getState().prCache[prCacheKey]?.data).toMatchObject({
+      checksStatus: 'failure',
+      checksPresentationStatus: 'action_required'
+    })
+    expect(store.getState().hostedReviewCache[hostedReviewCacheKey]?.data).toMatchObject({
+      status: 'failure',
+      checksPresentationStatus: 'action_required'
+    })
+  })
+
+  it('updates action-required presentation after the matching PR cache entry was evicted', async () => {
+    const store = createTestStore()
+    const repoPath = '/repo'
+    const repoId = 'repo-id'
+    const branch = 'feature/evicted-pr-cache'
+    const hostedReviewCacheKey = `local::${repoId}::${branch}`
+
+    store.setState({
+      repos: [
+        {
+          id: repoId,
+          path: repoPath,
+          displayName: 'repo',
+          badgeColor: '#000000',
+          addedAt: 1,
+          kind: 'git'
+        }
+      ],
+      hostedReviewCache: {
+        [hostedReviewCacheKey]: {
+          data: hostedReviewInfoFromGitHubPRInfo(makePR({ checksStatus: 'neutral' })),
+          fetchedAt: 1
+        }
+      }
+    })
+    mockApi.gh.prChecks.mockResolvedValue([
+      { name: 'deploy', status: 'completed', conclusion: 'action_required', url: null }
+    ])
+
+    await store
+      .getState()
+      .fetchPRChecks(repoPath, 12, branch, undefined, null, { force: true, repoId })
+
+    expect(store.getState().hostedReviewCache[hostedReviewCacheKey]?.data).toMatchObject({
+      status: 'failure',
+      checksPresentationStatus: 'action_required'
+    })
   })
 
   it('stores runtime checks under runtime-scoped cache keys', async () => {

--- a/src/shared/github/pull-request-types.ts
+++ b/src/shared/github/pull-request-types.ts
@@ -117,6 +117,8 @@ export type ProviderCheckSummary = {
   failed: number
   pending: number
   neutral: number
+  /** Subset of `failed` retained separately so new clients can distinguish approval gates. */
+  actionRequired?: number
 }
 
 export type GitHubPRReviewSummary = {

--- a/src/shared/github/pull-request-types.ts
+++ b/src/shared/github/pull-request-types.ts
@@ -1,6 +1,7 @@
 export type PRState = 'open' | 'closed' | 'merged' | 'draft'
 export type IssueState = 'open' | 'closed'
 export type CheckStatus = 'pending' | 'success' | 'failure' | 'neutral'
+export type CheckPresentationStatus = CheckStatus | 'action_required'
 
 export type PRMergeableState = 'MERGEABLE' | 'CONFLICTING' | 'UNKNOWN'
 export type PRReviewDecision = 'APPROVED' | 'CHANGES_REQUESTED' | 'REVIEW_REQUIRED'
@@ -54,6 +55,8 @@ export type PRInfo = {
   state: PRState
   url: string
   checksStatus: CheckStatus
+  /** Optional richer status; absent runtimes fall back to the legacy checksStatus field. */
+  checksPresentationStatus?: CheckPresentationStatus
   updatedAt: string
   mergeable: PRMergeableState
   reviewDecision?: PRReviewDecision | null

--- a/src/shared/hosted-review-github.test.ts
+++ b/src/shared/hosted-review-github.test.ts
@@ -29,4 +29,17 @@ describe('hostedReviewInfoFromGitHubPRInfo', () => {
       githubRepository
     })
   })
+
+  it('preserves the optional checks presentation status', () => {
+    expect(
+      hostedReviewInfoFromGitHubPRInfo({
+        ...pr,
+        checksStatus: 'failure',
+        checksPresentationStatus: 'action_required'
+      })
+    ).toMatchObject({
+      status: 'failure',
+      checksPresentationStatus: 'action_required'
+    })
+  })
 })

--- a/src/shared/hosted-review-github.ts
+++ b/src/shared/hosted-review-github.ts
@@ -9,6 +9,9 @@ export function hostedReviewInfoFromGitHubPRInfo(pr: PRInfo): HostedReviewInfo {
     state: pr.state,
     url: pr.url,
     status: pr.checksStatus,
+    ...(pr.checksPresentationStatus !== undefined
+      ? { checksPresentationStatus: pr.checksPresentationStatus }
+      : {}),
     updatedAt: pr.updatedAt,
     mergeable: pr.mergeable,
     ...(pr.reviewDecision !== undefined ? { reviewDecision: pr.reviewDecision } : {}),

--- a/src/shared/hosted-review.ts
+++ b/src/shared/hosted-review.ts
@@ -1,5 +1,6 @@
 import type {
   CheckStatus,
+  CheckPresentationStatus,
   GitHubRepositoryIdentity,
   PRConflictSummary,
   PRMergeableState,
@@ -34,6 +35,7 @@ export type HostedReviewInfo = {
   state: HostedReviewState
   url: string
   status: CheckStatus
+  checksPresentationStatus?: CheckPresentationStatus
   updatedAt: string
   mergeable: PRMergeableState
   reviewDecision?: PRReviewDecision | null

--- a/src/shared/hosted-review.ts
+++ b/src/shared/hosted-review.ts
@@ -54,6 +54,12 @@ export type HostedReviewInfo = {
   conflictSummary?: PRConflictSummary
 }
 
+export function getHostedReviewCheckPresentationStatus(
+  review: Pick<HostedReviewInfo, 'checksPresentationStatus'> & { status?: CheckStatus }
+): CheckPresentationStatus | undefined {
+  return review.checksPresentationStatus ?? review.status
+}
+
 export type HostedReviewForBranchArgs = {
   repoPath: string
   repoId?: string

--- a/src/shared/pr-check-status.test.ts
+++ b/src/shared/pr-check-status.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { derivePRCheckStatus, derivePRCheckStatusFromRollup } from './pr-check-status'
+import {
+  derivePRCheckStatuses,
+  derivePRCheckStatusesFromRollup,
+  derivePRCheckStatus,
+  derivePRCheckStatusFromRollup
+} from './pr-check-status'
 import type { PRCheckDetail } from './github/check-types'
 
 const check = (
@@ -14,12 +19,26 @@ describe('provider-neutral check status', () => {
     expect(derivePRCheckStatus([check('completed', 'pending')])).toBe('pending')
   })
 
+  it('keeps real failures ahead of action-required checks and leaves success unchanged', () => {
+    expect(
+      derivePRCheckStatuses([check('completed', 'action_required'), check('completed', 'failure')])
+    ).toEqual({ status: 'failure', presentationStatus: 'failure' })
+    expect(derivePRCheckStatuses([check('completed', 'success')])).toEqual({
+      status: 'success',
+      presentationStatus: 'success'
+    })
+  })
+
   it('keeps completed unknown conclusions neutral while preserving attention states', () => {
     expect(derivePRCheckStatus([check('completed', null)])).toBe('neutral')
     expect(
       derivePRCheckStatus([check('completed', 'future_state' as PRCheckDetail['conclusion'])])
     ).toBe('neutral')
     expect(derivePRCheckStatus([check('completed', 'action_required')])).toBe('failure')
+    expect(derivePRCheckStatuses([check('completed', 'action_required')])).toEqual({
+      status: 'failure',
+      presentationStatus: 'action_required'
+    })
   })
 
   it('normalizes GitHub-style rollups without turning malformed data into success', () => {
@@ -32,6 +51,10 @@ describe('provider-neutral check status', () => {
     expect(derivePRCheckStatusFromRollup([{}])).toBe('neutral')
     expect(derivePRCheckStatusFromRollup([{ state: 'PENDING' }])).toBe('pending')
     expect(derivePRCheckStatusFromRollup([{ state: 'ERROR' }])).toBe('failure')
+    expect(derivePRCheckStatusesFromRollup([{ state: 'ACTION_REQUIRED' }])).toEqual({
+      status: 'failure',
+      presentationStatus: 'action_required'
+    })
   })
 
   it.each(['ERROR', 'STARTUP_FAILURE'])('treats raw %s conclusions as failures', (conclusion) => {

--- a/src/shared/pr-check-status.ts
+++ b/src/shared/pr-check-status.ts
@@ -1,12 +1,32 @@
-import { summarizeProviderChecks } from './provider-check-summary'
+import {
+  getProviderChecksPresentationState,
+  summarizeProviderChecks
+} from './provider-check-summary'
 import type { PRCheckDetail } from './github/check-types'
-import type { CheckStatus } from './github/pull-request-types'
+import type { CheckPresentationStatus, CheckStatus } from './github/pull-request-types'
+
+export type PRCheckStatuses = {
+  status: CheckStatus
+  presentationStatus: CheckPresentationStatus
+}
+
+/** Derives both the legacy wire status and the richer presentation status. */
+export function derivePRCheckStatuses(checks: readonly PRCheckDetail[]): PRCheckStatuses {
+  const summary = summarizeProviderChecks(checks)
+  const status = summary.state === 'none' ? 'neutral' : summary.state
+  const presentationState = getProviderChecksPresentationState(summary)
+  return {
+    status,
+    presentationStatus:
+      presentationState === undefined || presentationState === 'none'
+        ? 'neutral'
+        : presentationState
+  }
+}
 
 /** Derives the review status from the normalized check contract. */
 export function derivePRCheckStatus(checks: readonly PRCheckDetail[]): CheckStatus {
-  const { state } = summarizeProviderChecks(checks)
-  // Why: CheckStatus has no 'none'; an empty rollup carries the same "nothing to report" meaning.
-  return state === 'none' ? 'neutral' : state
+  return derivePRCheckStatuses(checks).status
 }
 
 type RawCheckRollup = { status?: unknown; conclusion?: unknown; state?: unknown }
@@ -19,11 +39,13 @@ function normalizeRollupCheck(raw: RawCheckRollup, index: number): PRCheckDetail
     conclusion === 'error' || conclusion === 'startup_failure'
       ? 'failure'
       : conclusion ||
-        (state === 'failure' || state === 'error'
-          ? 'failure'
-          : state === 'success'
-            ? 'success'
-            : '')
+        (state === 'action_required'
+          ? 'action_required'
+          : state === 'failure' || state === 'error'
+            ? 'failure'
+            : state === 'success'
+              ? 'success'
+              : '')
   const isPending =
     status === 'queued' ||
     status === 'in_progress' ||
@@ -41,14 +63,18 @@ function normalizeRollupCheck(raw: RawCheckRollup, index: number): PRCheckDetail
   }
 }
 
-/** Derives status from provider rollups while retaining status/conclusion semantics. */
-export function derivePRCheckStatusFromRollup(rollup: unknown): CheckStatus {
+export function derivePRCheckStatusesFromRollup(rollup: unknown): PRCheckStatuses {
   if (!Array.isArray(rollup) || rollup.length === 0) {
-    return 'neutral'
+    return { status: 'neutral', presentationStatus: 'neutral' }
   }
-  return derivePRCheckStatus(
+  return derivePRCheckStatuses(
     rollup.map((raw, index) =>
       normalizeRollupCheck(raw && typeof raw === 'object' ? (raw as RawCheckRollup) : {}, index)
     )
   )
+}
+
+/** Derives status from provider rollups while retaining status/conclusion semantics. */
+export function derivePRCheckStatusFromRollup(rollup: unknown): CheckStatus {
+  return derivePRCheckStatusesFromRollup(rollup).status
 }

--- a/src/shared/provider-check-summary.ts
+++ b/src/shared/provider-check-summary.ts
@@ -124,7 +124,7 @@ export function getProviderChecksLabel(summary: ProviderCheckSummary | undefined
     return `${failureCount} failing`
   }
   if ((summary.actionRequired ?? 0) > 0) {
-    return `${summary.actionRequired} action required`
+    return `Action required: ${summary.actionRequired}`
   }
   if (summary.pending > 0) {
     return `${summary.pending} pending`

--- a/src/shared/provider-check-summary.ts
+++ b/src/shared/provider-check-summary.ts
@@ -1,4 +1,4 @@
-import type { ProviderCheckSummary } from './github/pull-request-types'
+import type { CheckPresentationStatus, ProviderCheckSummary } from './github/pull-request-types'
 
 export type CheckOutcome = 'passed' | 'failed' | 'action_required' | 'pending' | 'neutral'
 
@@ -90,7 +90,7 @@ export function summarizeProviderChecks(
   }
 }
 
-export type ProviderCheckPresentationState = ProviderCheckSummary['state'] | 'action_required'
+export type ProviderCheckPresentationState = CheckPresentationStatus | 'none'
 
 export function getProviderCheckFailureCount(summary: ProviderCheckSummary): number {
   return Math.max(0, summary.failed - (summary.actionRequired ?? 0))

--- a/src/shared/provider-check-summary.ts
+++ b/src/shared/provider-check-summary.ts
@@ -1,6 +1,6 @@
 import type { ProviderCheckSummary } from './github/pull-request-types'
 
-export type CheckOutcome = 'passed' | 'failed' | 'pending' | 'neutral'
+export type CheckOutcome = 'passed' | 'failed' | 'action_required' | 'pending' | 'neutral'
 
 export type CheckOutcomeInput = { status?: string | null; conclusion?: string | null }
 
@@ -14,14 +14,16 @@ const FAILED_CONCLUSIONS = new Set([
   'error',
   'startup_failure',
   'timed_out',
-  'cancelled',
-  'action_required'
+  'cancelled'
 ])
 
 /** The single provider-neutral verdict for one check; every check surface must route through it. */
 export function classifyCheckOutcome(check: CheckOutcomeInput): CheckOutcome {
   const conclusion = (check.conclusion ?? '').toLowerCase()
   const status = (check.status ?? '').toLowerCase()
+  if (conclusion === 'action_required') {
+    return 'action_required'
+  }
   if (FAILED_CONCLUSIONS.has(conclusion)) {
     return 'failed'
   }
@@ -56,6 +58,7 @@ export function summarizeProviderChecks(
 ): ProviderCheckSummary {
   let passed = 0
   let failed = 0
+  let actionRequired = 0
   let pending = 0
   let neutral = 0
   for (const check of checks) {
@@ -64,6 +67,11 @@ export function summarizeProviderChecks(
       passed += 1
     } else if (outcome === 'failed') {
       failed += 1
+    } else if (outcome === 'action_required') {
+      // Keep the legacy failed total/state for mixed-version clients while publishing the
+      // distinction as an optional field that older clients safely ignore.
+      failed += 1
+      actionRequired += 1
     } else if (outcome === 'pending') {
       pending += 1
     } else {
@@ -77,11 +85,33 @@ export function summarizeProviderChecks(
     passed,
     failed,
     pending,
-    neutral
+    neutral,
+    ...(actionRequired > 0 ? { actionRequired } : {})
   }
 }
 
-/** The one checks-pill label; it keys off `state` so the text can never contradict the pill's tone or icon. */
+export type ProviderCheckPresentationState = ProviderCheckSummary['state'] | 'action_required'
+
+export function getProviderCheckFailureCount(summary: ProviderCheckSummary): number {
+  return Math.max(0, summary.failed - (summary.actionRequired ?? 0))
+}
+
+export function getProviderChecksPresentationState(
+  summary: ProviderCheckSummary | undefined
+): ProviderCheckPresentationState | undefined {
+  if (!summary) {
+    return undefined
+  }
+  if (getProviderCheckFailureCount(summary) > 0) {
+    return 'failure'
+  }
+  if ((summary.actionRequired ?? 0) > 0) {
+    return 'action_required'
+  }
+  return summary.state
+}
+
+/** The one checks-pill label; it uses the same presentation state as the pill's tone and icon. */
 export function getProviderChecksLabel(summary: ProviderCheckSummary | undefined): string {
   if (!summary) {
     return 'Checks'
@@ -89,8 +119,12 @@ export function getProviderChecksLabel(summary: ProviderCheckSummary | undefined
   if (summary.total === 0) {
     return 'No checks'
   }
-  if (summary.failed > 0) {
-    return `${summary.failed} failing`
+  const failureCount = getProviderCheckFailureCount(summary)
+  if (failureCount > 0) {
+    return `${failureCount} failing`
+  }
+  if ((summary.actionRequired ?? 0) > 0) {
+    return `${summary.actionRequired} action required`
   }
   if (summary.pending > 0) {
     return `${summary.pending} pending`


### PR DESCRIPTION
## ELI5

PRs waiting for someone to approve a GitHub Actions run could appear failed, passing, or unresolved depending on which Orca surface loaded first. Orca now keeps them merge-blocking but consistently labels them `Action required` in amber across desktop and mobile. The desktop sidebar stays neutral until the check result is known.

## What Changed

- Preserves `action_required` as a distinct presentation result while retaining the legacy failure status used for merge gating and mixed-version clients. A real failure still takes precedence when both results exist.
- Recovers approval-gated check suites when GitHub reports an open PR as `UNSTABLE` or `UNKNOWN` with an empty, partial passing, or pending rollup. If detailed checks cannot load, Orca does not claim that a partial passing rollup succeeded.
- Keeps PR and hosted-review caches aligned, including refreshes for inactive worktrees and folder workspaces.
- Uses the same action-required label and amber tone in the checks panel, task page, merge state, metadata badges, worktree cards, folder-workspace summaries, mobile checks summary, mobile source-control PR chip, and mobile hosted-review tasks. Open PRs use the theme-aware muted foreground until success is confirmed.
- Preserves the optional action-required count across the mobile RPC boundary and derives mobile merge labels and tones from the same presentation state. An approval-gated PR no longer pairs an amber check signal with a green `Able to merge` signal.
- Localizes the action-required labels, tooltips, and provider hints in all bundled locales, including the French catalog added on `main`. Provider hints use a named `providerName` interpolation placeholder.

## Why

GitHub can omit approval-gated suites from the aggregate PR rollup. Orca then collapsed the available result into failure, success, or neutral, and separate caches could make the same PR change color between surfaces. The optional presentation status retains the richer result without changing whether the check blocks merging or breaking older clients.

## Linked Issue

Complements https://github.com/stablyai/orca/pull/13609, which maps `WAITING` and `REQUESTED` check states to pending. This branch covers the separate `ACTION_REQUIRED` result and the hydration, cache, desktop, and mobile paths that consume it.

## Visual Proof

| Before | After |
| --- | --- |
| ![Before: action-required PRs shown red or green](https://github.com/user-attachments/assets/415f89b4-78f0-463e-94ea-05e87ba9a3fe) | ![After: action-required PRs shown amber](https://github.com/user-attachments/assets/91698bdc-bcd6-4168-8742-728ffd84c680) |

Before, the sidebar could show red or green while the detailed panel reported `Action required`. After, approval-gated PRs use amber consistently; unloaded check status uses the theme-aware muted foreground instead of green.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- `pnpm test src/main/github/client-pr-checks.test.ts src/main/github/client-pr-linked-lookup.test.ts src/main/github/client/lookup/unstable-pr-check-rollup.test.ts src/main/github/client/lookup/pr-refresh-outcome-assembly.test.ts src/renderer/src/components/github-pr-merge-state.test.ts src/renderer/src/components/provider-check-classification-parity.test.ts src/renderer/src/components/right-sidebar/checks-panel-content.test.tsx src/renderer/src/components/right-sidebar/FolderWorkspacePrChecksPanel.test.tsx src/renderer/src/components/right-sidebar/FolderWorkspacePrChecksRow.test.tsx src/renderer/src/components/right-sidebar/parent-pr-checks-rows.test.ts src/renderer/src/components/sidebar/folder-workspace-card-pr-display.test.ts src/renderer/src/components/sidebar/WorktreeCardStatusSlot.test.tsx src/renderer/src/components/sidebar/worktree-review-helpers.test.tsx src/renderer/src/components/task-page-checks-pill.test.ts src/renderer/src/components/task-page-pr-check-summary.test.ts src/renderer/src/store/slices/github-checks.test.ts src/renderer/src/store/slices/github-pr-checks-fetch.test.ts src/shared/hosted-review-github.test.ts src/shared/pr-check-status.test.ts`: 19 files and 250 tests passed.
- `cd mobile && ./node_modules/.bin/vitest run`: 504 files passed; 4,124 tests passed and 3 skipped.
- `pnpm tc` and `cd mobile && ./node_modules/.bin/tsc --noEmit`: passed.
- `pnpm run verify:localization-catalog`, `pnpm run verify:localization-extraction`, and `pnpm run verify:localization-coverage`: passed.
- `pnpm run build:electron-vite`: passed.
- `pnpm run check:code-quality:changed`: passed with no new code-quality, type-aware, or React Doctor findings across 68 changed files.
- `git diff --check`: passed.
- Before the rebase, Electron CDP on macOS verified cache-empty loading, unknown, neutral, pending, action-required, failure, success, draft, closed, merged, and no-PR states. It also covered light mode, dark mode, custom sidebar colors, folder-workspace priority, and real GitHub provider results.

## AI Disclosure

OpenAI Codex assisted with diagnosis, implementation, tests, rendered UI verification, and PR preparation. The reported desktop UI behavior was also reviewed interactively in the running app.

## Review

Credit to @bbingz for https://github.com/stablyai/orca/pull/13609 and its analysis of the adjacent `WAITING` and `REQUESTED` mapper path. The two PRs are complementary: that PR handles non-terminal waiting states, while this branch handles the `ACTION_REQUIRED` result reported in the issue.

The review focused on provider classification, mixed-version fallback, cache identity, real-failure precedence, localization, folder-workspace aggregation, and mobile RPC and presentation paths. The rebase preserved the current `ChecksCell.tsx` structure while applying the action-required presentation state. The UI uses existing semantic color tokens. The branch changes no authentication, credential, permission, arbitrary-command, dependency, or persisted-data behavior.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- Cross-platform: the production changes are TypeScript state and presentation logic with no OS-specific paths, shortcuts, or process behavior. Manual desktop UI validation ran on macOS.
- Remote and SSH: execution routing is unchanged. The richer status is optional, and cache writes remain scoped by repository, execution host, review identity, and head SHA.
- Compatibility: older hosts and clients continue to use the legacy failure status. Current clients prefer the optional presentation status when available.
- Providers: GitHub-only hydration stays behind the GitHub path. Shared presentation remains provider-neutral, and GitLab manual-job behavior is unchanged.
- Mobile: the change uses existing semantic color tokens and adds no native or package dependencies. Automated coverage includes action-required-only, mixed action-required-plus-failure, `MERGEABLE`, and `CLEAN` states. The rebased branch preserves the recent Mobile Tasks module split and refreshes its parity fingerprints for the intentional merge-label change.
- Performance: the detailed lookup runs only for open GitHub PRs whose merge state is `UNSTABLE` or `UNKNOWN` and whose aggregate result may omit suite-only blockers. It reuses the existing operation permit and cached check loaders.

## Checklist

- [ ] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Fixes https://github.com/stablyai/orca/issues/13327
