### PR TITLE
draft(crash-reporting): raise the minidump module cap so POSIX dumps resolve a faulting module

### DIFF
--- a/src/main/crash-reporting/crashpad-capture.test.ts
+++ b/src/main/crash-reporting/crashpad-capture.test.ts
@@ -215,6 +215,67 @@ describe('captureMinidumpSignature', () => {
     expect(captured?.signature.processType).toBe('renderer')
   })
 
+  it('keeps a dump whose process type an unread annotation list left unknown', async () => {
+    const dumpPath = await writeDump(path.join('reports', 'unreadable.dmp'), CRASHED_AT + 100)
+    parseMinidumpCrashSignatureMock.mockReturnValue({
+      annotations: {},
+      annotationListStatus: 'unreadable'
+    })
+
+    const captured = await captureMinidumpSignature(CRASHED_AT, {
+      expectedProcessType: 'renderer',
+      timeoutMs: 0,
+      now: () => CRASHED_AT
+    })
+
+    expect(captured?.filePath).toBe(dumpPath)
+  })
+
+  it('prefers a dump that names this process over one an unread list left unknown', async () => {
+    const rendererDump = await writeDump(
+      path.join('reports', 'renderer.dmp'),
+      CRASHED_AT + 50,
+      Buffer.from('renderer')
+    )
+    // Newer, so it is examined first, and its annotation list never named a ptype.
+    await writeDump(path.join('reports', 'gpu.dmp'), CRASHED_AT + 80, Buffer.from('unreadable'))
+    parseMinidumpCrashSignatureMock.mockImplementation((dump: Buffer) =>
+      dump.toString('utf8') === 'unreadable'
+        ? { annotations: {}, annotationListStatus: 'unreadable' }
+        : { processType: dump.toString('utf8'), annotations: {} }
+    )
+
+    const captured = await captureMinidumpSignature(CRASHED_AT, {
+      expectedProcessType: 'renderer',
+      timeoutMs: 0,
+      now: () => CRASHED_AT
+    })
+
+    expect(captured?.filePath).toBe(rendererDump)
+  })
+
+  it('leaves an undetermined dump available for the process that owns it', async () => {
+    const dumpPath = await writeDump(path.join('reports', 'unreadable.dmp'), CRASHED_AT + 100)
+    parseMinidumpCrashSignatureMock.mockReturnValue({
+      annotations: {},
+      annotationListStatus: 'unreadable'
+    })
+
+    const renderer = await captureMinidumpSignature(CRASHED_AT, {
+      expectedProcessType: 'renderer',
+      timeoutMs: 0,
+      now: () => CRASHED_AT
+    })
+    const gpu = await captureMinidumpSignature(CRASHED_AT, {
+      expectedProcessType: 'gpu-process',
+      timeoutMs: 0,
+      now: () => CRASHED_AT
+    })
+
+    expect(renderer?.filePath).toBe(dumpPath)
+    expect(gpu?.filePath).toBe(dumpPath)
+  })
+
   it('leaves a mismatched dump available for its own process report', async () => {
     const gpuDump = await writeDump(
       path.join('reports', 'gpu.dmp'),

--- a/src/main/crash-reporting/crashpad-capture.ts
+++ b/src/main/crash-reporting/crashpad-capture.ts
@@ -44,7 +44,13 @@ type DumpCandidate = {
 let crashpadDumpDirectory: string | null = null
 let captureStarted = false
 let captureStartedAtMs: number | null = null
-const claimedDumpPaths = new Map<string, number>()
+type DumpClaim = {
+  readonly mtimeMs: number
+  /** False for a dump whose own process type went unread: it may still be another
+   * report's, so the claim only protects it from pruning, it does not reserve it. */
+  readonly exclusive: boolean
+}
+const claimedDumpPaths = new Map<string, DumpClaim>()
 const reservedDumpPaths = new Set<string>()
 let dumpPruneTimer: NodeJS.Timeout | null = null
 
@@ -217,8 +223,8 @@ function freshDumpCandidates(candidates: DumpCandidate[], crashedAtMs: number): 
     crashedAtMs - DUMP_RECENCY_WINDOW_MS,
     captureStartedAtMs ?? Number.NEGATIVE_INFINITY
   )
-  for (const [filePath, mtimeMs] of claimedDumpPaths) {
-    if (mtimeMs < floorMs) {
+  for (const [filePath, claim] of claimedDumpPaths) {
+    if (claim.mtimeMs < floorMs) {
       claimedDumpPaths.delete(filePath)
     }
   }
@@ -275,40 +281,78 @@ export type CapturedMinidump = {
   readonly signature: MinidumpCrashSignature
 }
 
+type DumpTriage = {
+  /** Not a minidump, or one that named a different process: never look again. */
+  readonly rejected: Set<string>
+  /** Process type left unread: worth one more read once the wait for a named one is over. */
+  readonly deferred: Set<string>
+}
+
+async function selectDump(
+  dump: DumpCandidate,
+  options: CrashMinidumpCaptureOptions,
+  triage: DumpTriage,
+  acceptUndeterminedProcess: boolean
+): Promise<CapturedMinidump | null> {
+  if (
+    triage.rejected.has(dump.filePath) ||
+    triage.deferred.has(dump.filePath) ||
+    claimedDumpPaths.get(dump.filePath)?.exclusive === true ||
+    reservedDumpPaths.has(dump.filePath)
+  ) {
+    return null
+  }
+  reservedDumpPaths.add(dump.filePath)
+  try {
+    const signature = parseMinidumpCrashSignature(await readFile(dump.filePath), {
+      expectedProcessType: options.expectedProcessType
+    })
+    if (!signature) {
+      triage.rejected.add(dump.filePath)
+      return null
+    }
+    const matches =
+      options.expectedProcessType === undefined ||
+      signature.processType === options.expectedProcessType
+    // A `processType` the annotation list left unread is undetermined, not a
+    // mismatch; rejecting it outright reports a dump we read as never written.
+    const undetermined =
+      signature.processType === undefined && signature.annotationListStatus === 'unreadable'
+    if (!matches && !(undetermined && acceptUndeterminedProcess)) {
+      const triaged = undetermined ? triage.deferred : triage.rejected
+      triaged.add(dump.filePath)
+      return null
+    }
+    // A dump that never named its process may still be another report's, so the
+    // claim only protects it from pruning; an exclusive one reserves it.
+    claimedDumpPaths.set(dump.filePath, { mtimeMs: dump.mtimeMs, exclusive: matches })
+    return { filePath: dump.filePath, sizeBytes: dump.size, signature }
+  } finally {
+    reservedDumpPaths.delete(dump.filePath)
+  }
+}
+
 /** Finds the dump for a crash and parses its signature. Never throws. */
 export async function captureMinidumpSignature(
   crashedAtMs: number,
   options: CrashMinidumpCaptureOptions = {}
 ): Promise<CapturedMinidump | null> {
-  const rejectedDumpPaths = new Set<string>()
+  const triage: DumpTriage = { rejected: new Set(), deferred: new Set() }
   try {
-    return await pollDumpCandidates(crashedAtMs, options, async (dump) => {
-      if (
-        rejectedDumpPaths.has(dump.filePath) ||
-        claimedDumpPaths.has(dump.filePath) ||
-        reservedDumpPaths.has(dump.filePath)
-      ) {
-        return null
-      }
-      reservedDumpPaths.add(dump.filePath)
-      try {
-        const signature = parseMinidumpCrashSignature(await readFile(dump.filePath), {
-          expectedProcessType: options.expectedProcessType
-        })
-        if (
-          !signature ||
-          (options.expectedProcessType !== undefined &&
-            signature.processType !== options.expectedProcessType)
-        ) {
-          rejectedDumpPaths.add(dump.filePath)
-          return null
-        }
-        claimedDumpPaths.set(dump.filePath, dump.mtimeMs)
-        return { filePath: dump.filePath, sizeBytes: dump.size, signature }
-      } finally {
-        reservedDumpPaths.delete(dump.filePath)
-      }
-    })
+    const named = await pollDumpCandidates(crashedAtMs, options, (dump) =>
+      selectDump(dump, options, triage, false)
+    )
+    if (named) {
+      return named
+    }
+    // Why a second sweep instead of taking it inline: a dump whose own process
+    // type went unread may be this crash's or another's, so it is the fallback,
+    // never the pick over a dump that names itself — and re-reading it now sees a
+    // dump that was merely mid-write before. `timeoutMs: 0` makes it one sweep.
+    triage.deferred.clear()
+    return await pollDumpCandidates(crashedAtMs, { ...options, timeoutMs: 0 }, (dump) =>
+      selectDump(dump, options, triage, true)
+    )
   } catch (error) {
     console.error('[crash-reporting] minidump signature capture failed:', error)
     return null

--- a/src/main/crash-reporting/minidump-crash-signature.test.ts
+++ b/src/main/crash-reporting/minidump-crash-signature.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { minidumpSignatureDetails, parseMinidumpCrashSignature } from './minidump-crash-signature'
+import { MAX_MODULES } from './minidump-stream-reader'
 
 const STREAM_TYPE_MODULE_LIST = 4
 const STREAM_TYPE_EXCEPTION = 6
@@ -77,6 +78,10 @@ function location(size: number, rva: number): Buffer {
 
 const EMPTY_LOCATION = location(0, 0)
 
+// A name region Crashpad has not written yet: the record's RVA lands past EOF,
+// which is what reading a dump mid-write looks like.
+const UNWRITTEN_NAME_RVA = 0xffff_0000
+
 type BuiltDump = { dump: Buffer }
 
 /**
@@ -88,7 +93,16 @@ function buildDump(options: {
   annotations?: Record<string, string>
   simpleAnnotations?: Record<string, string>
   exception?: { code: number; address: bigint }
-  modules?: { base: bigint; size: number; name: string }[]
+  /** `name: null` writes a record whose name region is missing from the dump. */
+  modules?: { base: bigint; size: number; name: string | null }[]
+  /** Declares more modules than the list carries, as a corrupt dump does. */
+  declaredModuleCount?: number
+  /** Stream-directory size for the module list, when it must disagree with the count. */
+  moduleListDeclaredSize?: number
+  /** Writes the 4-byte pad between NumberOfModules and Modules[0] that 64-bit ABIs emit. */
+  moduleListPadded?: boolean
+  /** Declared size of Crashpad's module-link list, when it must under-declare. */
+  crashpadModuleLinkListSize?: number
 }): BuiltDump {
   const streamCount =
     1 + (options.exception ? 1 : 0) + (options.modules && options.modules.length > 0 ? 1 : 0)
@@ -153,7 +167,7 @@ function buildDump(options: {
       return v
     })(),
     location(simpleBuf.length, simpleRva),
-    location(moduleLinkBuf.length, moduleLinkRva)
+    location(options.crashpadModuleLinkListSize ?? moduleLinkBuf.length, moduleLinkRva)
   ])
   const crashpadInfoRva = builder.append(crashpadInfoBuf)
   streams.push({
@@ -163,18 +177,21 @@ function buildDump(options: {
   })
 
   if (options.modules && options.modules.length > 0) {
-    const nameRvas = options.modules.map((module) => builder.utf16String(module.name))
-    const listBuf = Buffer.alloc(4 + options.modules.length * 108)
-    listBuf.writeUInt32LE(options.modules.length, 0)
+    const nameRvas = options.modules.map((module) =>
+      module.name === null ? UNWRITTEN_NAME_RVA : builder.utf16String(module.name)
+    )
+    const recordsAt = options.moduleListPadded ? 8 : 4
+    const listBuf = Buffer.alloc(recordsAt + options.modules.length * 108)
+    listBuf.writeUInt32LE(options.declaredModuleCount ?? options.modules.length, 0)
     options.modules.forEach((module, index) => {
-      const at = 4 + index * 108
+      const at = recordsAt + index * 108
       listBuf.writeBigUInt64LE(module.base, at)
       listBuf.writeUInt32LE(module.size, at + 8)
       listBuf.writeUInt32LE(nameRvas[index], at + 20)
     })
     streams.push({
       type: STREAM_TYPE_MODULE_LIST,
-      size: listBuf.length,
+      size: options.moduleListDeclaredSize ?? listBuf.length,
       rva: builder.append(listBuf)
     })
   }
@@ -212,6 +229,20 @@ describe('parseMinidumpCrashSignature', () => {
     expect(signature?.checkFile).toBe('render_frame_impl.cc')
     expect(signature?.checkLine).toBe(4821)
     expect(signature?.processType).toBe('renderer')
+  })
+
+  it('keeps parsing when an unread annotation list left the process type unknown', () => {
+    const { dump } = buildDump({
+      annotations: { LOG_FATAL: FATAL_LINE, ptype: 'renderer' },
+      // Room for zero links, so the carrier the count declares is never reached.
+      crashpadModuleLinkListSize: 4
+    })
+
+    const signature = parseMinidumpCrashSignature(dump, { expectedProcessType: 'renderer' })
+
+    expect(signature?.processType).toBeUndefined()
+    expect(signature?.annotationListStatus).toBe('unreadable')
+    expect(signature?.checkMessage).toContain('Check failed: !is_detached_.')
   })
 
   it('recovers a CHECK line from Electron 43 dump memory without LOG_FATAL', () => {
@@ -407,5 +438,195 @@ describe('minidumpSignatureDetails', () => {
     const details = minidumpSignatureDetails(parseMinidumpCrashSignature(dump)!)
 
     expect(details.minidumpAnnotation_LOG_FATAL).toBeUndefined()
+  })
+})
+
+describe('module list capacity', () => {
+  /** Measured image count of a real macOS renderer; the cap must clear it. */
+  const MACOS_RENDERER_IMAGE_COUNT = 1_042
+
+  function manyModules(count: number): { base: bigint; size: number; name: string }[] {
+    return Array.from({ length: count }, (_, index) => ({
+      base: BigInt(0x1_0000_0000 + index * 0x1_0000),
+      size: 0x1000,
+      name: `/opt/orca/lib/module-${index}.dylib`
+    }))
+  }
+
+  it('resolves the faulting module in a macOS renderer sized image list', () => {
+    const modules = manyModules(MACOS_RENDERER_IMAGE_COUNT)
+    const target = modules[MACOS_RENDERER_IMAGE_COUNT - 1]
+    const { dump } = buildDump({
+      exception: { code: 11, address: target.base + 0x24n },
+      modules
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe(`module-${MACOS_RENDERER_IMAGE_COUNT - 1}.dylib`)
+    expect(signature?.faultingModuleOffset).toBe('0x24')
+    expect(signature?.moduleListStatus).toBeUndefined()
+  })
+
+  it('reports truncation as a distinct state instead of an absent faulting module', () => {
+    const modules = manyModules(MAX_MODULES + 1)
+    const target = modules[MAX_MODULES]
+    const { dump } = buildDump({
+      exception: { code: 11, address: target.base + 0x8n },
+      modules
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.moduleListStatus).toBe('truncated')
+    expect(signature?.faultingModule).toBeUndefined()
+    expect(minidumpSignatureDetails(signature!).minidumpModuleListStatus).toBe('truncated')
+  })
+
+  it('reports an unreadable module list when records run past the end of the dump', () => {
+    const { dump } = buildDump({
+      exception: { code: 11, address: 0xdead_0000n },
+      modules: manyModules(8),
+      declaredModuleCount: 4_000,
+      // The stream claims room the file cannot back, so only EOF can stop the walk.
+      moduleListDeclaredSize: 4 + 4_000 * 108
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.moduleListStatus).toBe('unreadable')
+    expect(signature?.faultingModule).toBeUndefined()
+  })
+
+  it('stops at the declared stream size instead of reading trailing bytes as modules', () => {
+    const modules = [
+      { base: 0x1000_0000n, size: 0x1000, name: '/opt/orca/lib/real.dylib' },
+      { base: 0x2000_0000n, size: 0x1000, name: '/opt/orca/lib/fake.dylib' }
+    ]
+    const { dump } = buildDump({
+      exception: { code: 11, address: 0x2000_0024n },
+      modules,
+      // Honest for one record; the count says two, as a corrupt header does.
+      moduleListDeclaredSize: 4 + 108
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBeUndefined()
+    expect(signature?.moduleListStatus).toBe('truncated')
+  })
+
+  it('refuses to name a module whose name region is missing from the dump', () => {
+    const { dump } = buildDump({
+      exception: { code: 11, address: 0x1000_0024n },
+      modules: [{ base: 0x1000_0000n, size: 0x1000, name: null }]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBeUndefined()
+    expect(signature?.faultingModuleOffset).toBeUndefined()
+    expect(signature?.moduleListStatus).toBe('unreadable')
+    expect(minidumpSignatureDetails(signature!).minidumpModuleListStatus).toBe('unreadable')
+  })
+
+  it('still names the faulting module when an unrelated module name is unreadable', () => {
+    const { dump } = buildDump({
+      exception: { code: 11, address: 0x1000_0024n },
+      modules: [
+        { base: 0x2000_0000n, size: 0x1000, name: null },
+        { base: 0x1000_0000n, size: 0x1000, name: '/opt/orca/lib/real.dylib' }
+      ]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe('real.dylib')
+    expect(signature?.faultingModuleOffset).toBe('0x24')
+    expect(signature?.moduleListStatus).toBeUndefined()
+  })
+
+  it('keeps an unreadable name outside every image range from clouding absence', () => {
+    const { dump } = buildDump({
+      exception: { code: 11, address: 0x10n },
+      modules: [{ base: 0x2000_0000n, size: 0x1000, name: null }]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBeUndefined()
+    expect(signature?.moduleListStatus).toBeUndefined()
+  })
+
+  it('reads a module list padded to the 64-bit record alignment', () => {
+    const { dump } = buildDump({
+      exception: { code: 11, address: 0x1000_0024n },
+      modules: [{ base: 0x1000_0000n, size: 0x1000, name: '/opt/orca/lib/real.dylib' }],
+      moduleListPadded: true
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe('real.dylib')
+    expect(signature?.faultingModuleOffset).toBe('0x24')
+    expect(signature?.moduleListStatus).toBeUndefined()
+  })
+
+  it('refuses to call a list complete when its size matches no known layout', () => {
+    const { dump } = buildDump({
+      exception: { code: 11, address: 0x10n },
+      modules: [{ base: 0x1000_0000n, size: 0x1000, name: '/opt/orca/lib/real.dylib' }],
+      // Neither 4 + 108 nor 8 + 108: the record offsets are unknowable.
+      moduleListDeclaredSize: 6 + 108
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.moduleListStatus).toBe('unreadable')
+  })
+
+  it('refuses to call a list complete when its declared range runs into another stream', () => {
+    const { dump } = buildDump({
+      // Nothing in the dump covers this address; the reader must not be told so
+      // on the strength of a walk that read another stream as a module record.
+      exception: { code: 0x1000, address: 0x10n },
+      modules: [{ base: 0x1000_0000n, size: 0x1000, name: '/opt/orca/lib/real.dylib' }],
+      // Count and declared size over-declare in lockstep, so record #1 is the
+      // exception stream's bytes — the one corruption their agreement hides.
+      declaredModuleCount: 2,
+      moduleListDeclaredSize: 4 + 2 * 108
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.moduleListStatus).toBe('unreadable')
+    expect(minidumpSignatureDetails(signature!).minidumpModuleListStatus).toBe('unreadable')
+  })
+
+  it('does not name a module read at offsets it could not establish', () => {
+    const { dump } = buildDump({
+      exception: { code: 11, address: 0x1000_0024n },
+      modules: [{ base: 0x1000_0000n, size: 0x1000, name: '/opt/orca/lib/real.dylib' }],
+      // Neither 4 + 108 nor 8 + 108, so the record offset below is a guess.
+      moduleListDeclaredSize: 6 + 108
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBeUndefined()
+    expect(signature?.faultingModuleOffset).toBeUndefined()
+    expect(signature?.moduleListStatus).toBe('unreadable')
+  })
+
+  it('keeps a fully read list silent so a missing module still means absent', () => {
+    const { dump } = buildDump({
+      exception: { code: 11, address: 0x10n },
+      modules: [{ base: 0x7ff7_0000_0000n, size: 0x1000, name: '/opt/orca/orca' }]
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.moduleListStatus).toBeUndefined()
+    expect(minidumpSignatureDetails(signature!).minidumpModuleListStatus).toBeUndefined()
   })
 })

--- a/src/main/crash-reporting/minidump-crash-signature.ts
+++ b/src/main/crash-reporting/minidump-crash-signature.ts
@@ -11,13 +11,21 @@
 // rather than throwing: a truncated dump must degrade, not break crash
 // reporting.
 
-import { findStream, isMinidump, MAX_MODULES, MinidumpView } from './minidump-stream-reader'
+import {
+  findStream,
+  isMinidump,
+  MAX_MODULES,
+  MinidumpView,
+  overlapsOtherStream
+} from './minidump-stream-reader'
 import { readCrashpadAnnotations } from './minidump-crashpad-annotations'
 
 const STREAM_TYPE_MODULE_LIST = 4
 const STREAM_TYPE_EXCEPTION = 6
 
 const MODULE_RECORD_SIZE = 108
+const MODULE_LIST_HEADER_SIZE = 4
+const MODULE_LIST_PADDED_HEADER_SIZE = 8
 const MODULE_BASE_OFFSET = 0
 const MODULE_SIZE_OFFSET = 8
 const MODULE_NAME_RVA_OFFSET = 20
@@ -40,6 +48,15 @@ const CHECK_LOG_PATTERN =
   /^\[(?:\d+:){1,2}\d{4}\/\d{6}\.\d{3,6}:(FATAL|CHECK|DFATAL|ERROR)(?::[^:\]\r\n]{1,80})*:([^:\]\r\n]{1,512}?)(?:\((\d+)\)|:(\d+))\]\s*(.+)$/
 const ERROR_CHECK_PATTERN = /\b(?:Check failed:|D?CHECK failed:|Intentionally causing D?CHECK\b)/i
 
+/**
+ * How much of the MINIDUMP_MODULE_LIST backed `faultingModule`. `complete` says
+ * every record the list declared was read at an offset the dump corroborates —
+ * not that the producer was honest. A list we could not read in full is still
+ * not a list without the faulting module, so the two states stay distinct and
+ * never collapse into "no faulting module".
+ */
+export type ModuleListStatus = 'complete' | 'truncated' | 'unreadable'
+
 export type MinidumpCrashSignature = {
   /** Chromium's fatal log line, e.g. `[...:FATAL:node.cc(123)] Check failed: !x.` */
   readonly checkMessage?: string
@@ -54,6 +71,13 @@ export type MinidumpCrashSignature = {
   /** Module whose image range contains `exceptionAddress`. */
   readonly faultingModule?: string
   readonly faultingModuleOffset?: string
+  /** Set only when the module list was not read in full; absent means complete. */
+  readonly moduleListStatus?: Exclude<ModuleListStatus, 'complete'>
+  /**
+   * Set only when part of Crashpad's annotation walk went unread. `processType`
+   * missing under it means undetermined, not another process.
+   */
+  readonly annotationListStatus?: 'unreadable'
   /** Allowlisted Crashpad annotations, verbatim. */
   readonly annotations: Readonly<Record<string, string>>
 }
@@ -61,31 +85,59 @@ export type MinidumpCrashSignature = {
 type ModuleRecord = {
   readonly base: bigint
   readonly size: number
-  readonly name: string
+  /** Absent when the MINIDUMP_STRING could not be read; never a stand-in name. */
+  readonly name?: string
 }
 
-function readModules(view: MinidumpView): ModuleRecord[] {
+function readModules(view: MinidumpView): {
+  modules: ModuleRecord[]
+  status: ModuleListStatus
+} {
   const stream = findStream(view, STREAM_TYPE_MODULE_LIST)
   if (!stream) {
-    return []
+    return { modules: [], status: 'unreadable' }
   }
   const count = view.u32(stream.rva)
-  if (count === null || count > MAX_MODULES) {
-    return []
+  if (count === null) {
+    return { modules: [], status: 'unreadable' }
+  }
+  // Breakpad's ReadModuleList tolerates a 4-byte pad between NumberOfModules and
+  // Modules[0] on 64-bit ABIs; reading that layout at +4 shifts every field.
+  const headerSize =
+    stream.size === MODULE_LIST_PADDED_HEADER_SIZE + count * MODULE_RECORD_SIZE
+      ? MODULE_LIST_PADDED_HEADER_SIZE
+      : MODULE_LIST_HEADER_SIZE
+  // Records past the declared stream size are unrelated dump bytes; reading them
+  // would invent modules, so an over-declared count is truncation, not absence.
+  const declared = Math.floor((stream.size - headerSize) / MODULE_RECORD_SIZE)
+  const readable = Math.max(0, Math.min(count, MAX_MODULES, declared))
+  // `size` and `count` are one producer's word, so their agreement corroborates
+  // nothing. Reaching into another stream's bytes does: it proves the declared
+  // range is not the list's, and every offset derived from it with it.
+  const walkedEnd = stream.rva + headerSize + readable * MODULE_RECORD_SIZE
+  if (overlapsOtherStream(view, stream.rva, walkedEnd)) {
+    return { modules: [], status: 'unreadable' }
   }
   const modules: ModuleRecord[] = []
-  for (let index = 0; index < count; index += 1) {
-    const record = stream.rva + 4 + index * MODULE_RECORD_SIZE
+  for (let index = 0; index < readable; index += 1) {
+    const record = stream.rva + headerSize + index * MODULE_RECORD_SIZE
     const base = view.u64(record + MODULE_BASE_OFFSET)
     const size = view.u32(record + MODULE_SIZE_OFFSET)
     const nameRva = view.u32(record + MODULE_NAME_RVA_OFFSET)
     if (base === null || size === null || nameRva === null) {
-      break
+      return { modules, status: 'unreadable' }
     }
+    // The range still locates the module, so keep the record and drop only the name.
     const name = view.utf16String(nameRva, 2_048)
-    modules.push({ base, size, name: name ?? 'unknown' })
+    modules.push({ base, size, name: name ?? undefined })
   }
-  return modules
+  if (readable < count) {
+    return { modules, status: 'truncated' }
+  }
+  // A size matching neither packed nor padded layout makes every record offset a
+  // guess, so nothing walked at them may be published as a module either.
+  const layoutMatches = stream.size === headerSize + count * MODULE_RECORD_SIZE
+  return layoutMatches ? { modules, status: 'complete' } : { modules: [], status: 'unreadable' }
 }
 
 function moduleBasename(modulePath: string): string {
@@ -174,11 +226,11 @@ function parseCheckLocation(checkMessage: string): {
 function findFaultingModule(
   modules: ModuleRecord[],
   address: bigint
-): { name: string; offset: string } | undefined {
+): { name?: string; offset: string } | undefined {
   for (const module of modules) {
     if (address >= module.base && address < module.base + BigInt(module.size)) {
       return {
-        name: moduleBasename(module.name),
+        name: module.name === undefined ? undefined : moduleBasename(module.name),
         offset: toHex(address - module.base)
       }
     }
@@ -208,7 +260,7 @@ export function parseMinidumpCrashSignature(
     return null
   }
   const view = new MinidumpView(dump)
-  const annotations = readCrashpadAnnotations(view)
+  const { annotations, annotationsComplete } = readCrashpadAnnotations(view)
 
   const signature: {
     -readonly [K in keyof MinidumpCrashSignature]: MinidumpCrashSignature[K]
@@ -218,9 +270,19 @@ export function parseMinidumpCrashSignature(
   if (processType) {
     signature.processType = processType
   }
+  if (!annotationsComplete) {
+    signature.annotationListStatus = 'unreadable'
+  }
+  // A list we could not finish did not say the dump is another process's; it said
+  // nothing, and stopping here reports a dump we did read as never written.
+  const processTypeUndetermined = processType === undefined && !annotationsComplete
   // Annotations are bounded; the scans below are not. A renderer crash would
   // otherwise scan every fresh GPU/utility dump end to end before rejecting it.
-  if (options.expectedProcessType !== undefined && processType !== options.expectedProcessType) {
+  if (
+    options.expectedProcessType !== undefined &&
+    processType !== options.expectedProcessType &&
+    !processTypeUndetermined
+  ) {
     return signature
   }
 
@@ -246,10 +308,17 @@ export function parseMinidumpCrashSignature(
     }
     if (address !== null) {
       signature.exceptionAddress = toHex(address)
-      const faulting = findFaultingModule(readModules(view), address)
-      if (faulting) {
+      const { modules, status } = readModules(view)
+      const faulting = findFaultingModule(modules, address)
+      if (faulting?.name !== undefined) {
         signature.faultingModule = faulting.name
         signature.faultingModuleOffset = faulting.offset
+      }
+      // A module we located but could not name leaves `faultingModule` absent for
+      // a reason the status must carry, or silence reads as "no module covers it".
+      const listStatus = faulting && faulting.name === undefined ? 'unreadable' : status
+      if (listStatus !== 'complete') {
+        signature.moduleListStatus = listStatus
       }
     }
   }
@@ -285,6 +354,12 @@ export function minidumpSignatureDetails(
   }
   if (signature.faultingModuleOffset) {
     details.minidumpFaultingModuleOffset = signature.faultingModuleOffset
+  }
+  if (signature.moduleListStatus) {
+    details.minidumpModuleListStatus = signature.moduleListStatus
+  }
+  if (signature.annotationListStatus) {
+    details.minidumpAnnotationListStatus = signature.annotationListStatus
   }
   for (const [key, value] of Object.entries(signature.annotations)) {
     if (key === 'LOG_FATAL' || key === 'abort-message' || key === 'ptype') {

--- a/src/main/crash-reporting/minidump-crashpad-annotations.test.ts
+++ b/src/main/crash-reporting/minidump-crashpad-annotations.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from 'vitest'
+import { readCrashpadAnnotations } from './minidump-crashpad-annotations'
+import { MinidumpView } from './minidump-stream-reader'
+
+const STREAM_TYPE_CRASHPAD_INFO = 0x43500001
+const CRASHPAD_INFO_SIZE = 52
+const LINK_SIZE = 12
+const MODULE_INFO_SIZE = 28
+
+const FATAL_LINE = '[0101/000000.000000:FATAL:fabricated.cc(9)] Check failed: fabricated.'
+
+function utf8String(value: string): Buffer {
+  const data = Buffer.from(value, 'utf8')
+  const buf = Buffer.alloc(4 + data.length + 1)
+  buf.writeUInt32LE(data.length, 0)
+  data.copy(buf, 4)
+  return buf
+}
+
+function location(size: number, rva: number): Buffer {
+  const buf = Buffer.alloc(8)
+  buf.writeUInt32LE(size, 0)
+  buf.writeUInt32LE(rva, 4)
+  return buf
+}
+
+/**
+ * Crashpad info stream whose module-link list carries `writtenLinks` links, the
+ * last of which points at a `LOG_FATAL` + `ptype` module info and the rest at
+ * nothing, under a caller-chosen count and declared list size — the two a
+ * corrupt dump can disagree on.
+ */
+function buildCrashpadDump(options: {
+  declaredLinkCount: number
+  declaredListSize: number
+  writtenLinks?: number
+  /** Overrides the RVA the CrashpadInfo stream points the link list at. */
+  moduleListRva?: number
+  /** Overrides the stream size the directory declares for CrashpadInfo. */
+  declaredStreamSize?: number
+  /** Overrides the carrier link's declared MinidumpModuleCrashpadInfo size/RVA. */
+  carrierInfoSize?: number
+  carrierInfoRva?: number
+  /** Overrides the size the carrier's simple-annotation dictionary declares. */
+  declaredDictionarySize?: number
+  /** Points the LOG_FATAL key string past the end of the dump. */
+  unreadableFatalKey?: boolean
+}): Buffer {
+  const writtenLinks = options.writtenLinks ?? 2
+  const prefix = 32 + 12
+  const regions: Buffer[] = []
+  let cursor = prefix
+  const append = (buf: Buffer): number => {
+    const rva = cursor
+    regions.push(buf)
+    cursor += buf.length
+    return rva
+  }
+
+  const entries: [string, string][] = [
+    ['LOG_FATAL', FATAL_LINE],
+    ['ptype', 'renderer']
+  ]
+  const pairs = entries.map(([key, value]) => ({
+    keyRva:
+      key === 'LOG_FATAL' && options.unreadableFatalKey ? 0xffff_0000 : append(utf8String(key)),
+    valueRva: append(utf8String(value))
+  }))
+  const dictionary = Buffer.alloc(4 + pairs.length * 8)
+  dictionary.writeUInt32LE(pairs.length, 0)
+  pairs.forEach((pair, index) => {
+    dictionary.writeUInt32LE(pair.keyRva, 4 + index * 8)
+    dictionary.writeUInt32LE(pair.valueRva, 8 + index * 8)
+  })
+  const dictionaryRva = append(dictionary)
+
+  // MinidumpModuleCrashpadInfo: version, list_annotations, simple_annotations, objects.
+  const moduleInfo = Buffer.concat([
+    (() => {
+      const version = Buffer.alloc(4)
+      version.writeUInt32LE(1, 0)
+      return version
+    })(),
+    location(0, 0),
+    location(options.declaredDictionarySize ?? dictionary.length, dictionaryRva),
+    location(0, 0)
+  ])
+  expect(moduleInfo.length).toBe(MODULE_INFO_SIZE)
+  const moduleInfoRva = append(moduleInfo)
+
+  const links = Buffer.alloc(4 + writtenLinks * LINK_SIZE)
+  links.writeUInt32LE(options.declaredLinkCount, 0)
+  for (let index = 0; index < writtenLinks; index += 1) {
+    const at = 4 + index * LINK_SIZE
+    links.writeUInt32LE(index, at) // minidump module index
+    if (index === writtenLinks - 1) {
+      links.writeUInt32LE(options.carrierInfoSize ?? moduleInfo.length, at + 4)
+      links.writeUInt32LE(options.carrierInfoRva ?? moduleInfoRva, at + 8)
+    }
+  }
+  const linksRva = append(links)
+
+  const info = Buffer.concat([
+    Buffer.alloc(4 + 16 + 16), // version, report id, client id
+    location(0, 0), // process-level simple annotations
+    location(options.declaredListSize, options.moduleListRva ?? linksRva)
+  ])
+  expect(info.length).toBe(CRASHPAD_INFO_SIZE)
+  const infoRva = append(info)
+
+  const header = Buffer.alloc(32)
+  header.writeUInt32LE(0x504d444d, 0)
+  header.writeUInt32LE(0xa793, 4)
+  header.writeUInt32LE(1, 8)
+  header.writeUInt32LE(32, 12)
+  const directory = Buffer.alloc(12)
+  directory.writeUInt32LE(STREAM_TYPE_CRASHPAD_INFO, 0)
+  directory.writeUInt32LE(options.declaredStreamSize ?? info.length, 4)
+  directory.writeUInt32LE(infoRva, 8)
+
+  return Buffer.concat([header, directory, ...regions])
+}
+
+describe('readCrashpadAnnotations module link list', () => {
+  it('reads annotations from every link the list declares', () => {
+    const dump = buildCrashpadDump({
+      declaredLinkCount: 2,
+      declaredListSize: 4 + 2 * LINK_SIZE
+    })
+
+    const { annotations, annotationsComplete } = readCrashpadAnnotations(new MinidumpView(dump))
+
+    expect(annotations.LOG_FATAL).toBe(FATAL_LINE)
+    expect(annotationsComplete).toBe(true)
+  })
+
+  it('reports a link count the declared list size cannot hold as unread, not empty', () => {
+    const dump = buildCrashpadDump({
+      // Room for one link, but the count reaches into whatever follows.
+      declaredLinkCount: 2_000,
+      declaredListSize: 4 + LINK_SIZE
+    })
+
+    const { annotations, annotationsComplete } = readCrashpadAnnotations(new MinidumpView(dump))
+
+    expect(annotations.LOG_FATAL).toBeUndefined()
+    expect(annotationsComplete).toBe(false)
+  })
+
+  it('reads the links the declared size does hold under an over-declared count', () => {
+    const dump = buildCrashpadDump({
+      // Count reaches past the list, but both real links are inside the size.
+      declaredLinkCount: 2,
+      declaredListSize: 4 + 2 * LINK_SIZE,
+      writtenLinks: 2
+    })
+
+    const { annotations, annotationsComplete } = readCrashpadAnnotations(new MinidumpView(dump))
+
+    expect(annotations.LOG_FATAL).toBe(FATAL_LINE)
+    expect(annotationsComplete).toBe(true)
+  })
+
+  it('reports the list as unread when the carrier link sits past the declared size', () => {
+    const dump = buildCrashpadDump({
+      declaredLinkCount: 3,
+      declaredListSize: 4 + LINK_SIZE,
+      writtenLinks: 3
+    })
+
+    const { annotations, annotationsComplete } = readCrashpadAnnotations(new MinidumpView(dump))
+
+    expect(annotations.ptype).toBeUndefined()
+    expect(annotationsComplete).toBe(false)
+  })
+
+  it('reports a module-link list pointed past the end of the dump as unread', () => {
+    const dump = buildCrashpadDump({
+      declaredLinkCount: 2,
+      declaredListSize: 4 + 2 * LINK_SIZE,
+      moduleListRva: 0xffff_0000
+    })
+
+    const { annotations, annotationsComplete } = readCrashpadAnnotations(new MinidumpView(dump))
+
+    expect(annotations.ptype).toBeUndefined()
+    expect(annotationsComplete).toBe(false)
+  })
+
+  it('reports a CrashpadInfo stream too short to carry the list descriptor as unread', () => {
+    const dump = buildCrashpadDump({
+      declaredLinkCount: 2,
+      declaredListSize: 4 + 2 * LINK_SIZE,
+      declaredStreamSize: 40
+    })
+
+    const { annotations, annotationsComplete } = readCrashpadAnnotations(new MinidumpView(dump))
+
+    expect(annotations.ptype).toBeUndefined()
+    expect(annotationsComplete).toBe(false)
+  })
+
+  it('reports a link whose module info sits past the end of the dump as unread', () => {
+    const dump = buildCrashpadDump({
+      declaredLinkCount: 2,
+      declaredListSize: 4 + 2 * LINK_SIZE,
+      carrierInfoRva: 0xffff_0000
+    })
+
+    const { annotations, annotationsComplete } = readCrashpadAnnotations(new MinidumpView(dump))
+
+    expect(annotations.ptype).toBeUndefined()
+    expect(annotationsComplete).toBe(false)
+  })
+
+  it('reports a link whose module info is under the minimum size as unread', () => {
+    const dump = buildCrashpadDump({
+      declaredLinkCount: 2,
+      declaredListSize: 4 + 2 * LINK_SIZE,
+      carrierInfoSize: MODULE_INFO_SIZE - 8
+    })
+
+    const { annotations, annotationsComplete } = readCrashpadAnnotations(new MinidumpView(dump))
+
+    expect(annotations.ptype).toBeUndefined()
+    expect(annotationsComplete).toBe(false)
+  })
+
+  it('keeps a link the producer marked absent from making the list unread', () => {
+    // Every link but the carrier has a zero RVA: "this module has no info", read.
+    const dump = buildCrashpadDump({
+      declaredLinkCount: 4,
+      declaredListSize: 4 + 4 * LINK_SIZE,
+      writtenLinks: 4
+    })
+
+    const { annotations, annotationsComplete } = readCrashpadAnnotations(new MinidumpView(dump))
+
+    expect(annotations.ptype).toBe('renderer')
+    expect(annotationsComplete).toBe(true)
+  })
+  it('reports a dictionary whose count overruns its declared size as unread', () => {
+    const dump = buildCrashpadDump({
+      declaredLinkCount: 2,
+      declaredListSize: 4 + 2 * LINK_SIZE,
+      declaredDictionarySize: 8
+    })
+
+    const { annotations, annotationsComplete } = readCrashpadAnnotations(new MinidumpView(dump))
+
+    expect(annotations.ptype).toBeUndefined()
+    expect(annotationsComplete).toBe(false)
+  })
+
+  it('reports an annotation key pointed past the end of the dump as unread', () => {
+    const dump = buildCrashpadDump({
+      declaredLinkCount: 2,
+      declaredListSize: 4 + 2 * LINK_SIZE,
+      unreadableFatalKey: true
+    })
+
+    const { annotations, annotationsComplete } = readCrashpadAnnotations(new MinidumpView(dump))
+
+    // The entry after it still reads; one unreadable key is not an empty list.
+    expect(annotations.LOG_FATAL).toBeUndefined()
+    expect(annotations.ptype).toBe('renderer')
+    expect(annotationsComplete).toBe(false)
+  })
+})

--- a/src/main/crash-reporting/minidump-crashpad-annotations.ts
+++ b/src/main/crash-reporting/minidump-crashpad-annotations.ts
@@ -8,6 +8,7 @@ import {
   findStream,
   MAX_MODULES,
   type LocationDescriptor,
+  type LocationRead,
   type MinidumpView
 } from './minidump-stream-reader'
 
@@ -59,120 +60,194 @@ const ANNOTATION_ALLOWLIST = new Set([
   'gpu-generation-intel'
 ])
 
-/** MinidumpSimpleStringDictionary: u32 count, then {key rva, value rva} pairs. */
+/**
+ * MinidumpSimpleStringDictionary: u32 count, then {key rva, value rva} pairs.
+ * Returns false when any entry went unread, since an unread key could be `ptype`.
+ */
 function readSimpleAnnotations(
   view: MinidumpView,
-  location: LocationDescriptor | null,
+  read: LocationRead,
   into: Record<string, string>
-): void {
-  if (!location) {
-    return
+): boolean {
+  if (read.status !== 'present') {
+    return read.status === 'absent'
   }
+  const location = read.location
   const count = view.u32(location.rva)
   if (count === null || count > MAX_ANNOTATIONS || 4 + count * 8 > location.size) {
-    return
+    return false
   }
+  let allEntriesRead = true
   for (let index = 0; index < count; index += 1) {
     const entry = location.rva + 4 + index * 8
     const keyRva = view.u32(entry)
     const valueRva = view.u32(entry + 4)
     if (keyRva === null || valueRva === null) {
-      return
+      return false
     }
     const key = view.utf8String(keyRva, 256)
-    if (key === null || !ANNOTATION_ALLOWLIST.has(key)) {
+    if (key === null) {
+      allEntriesRead = false
+      continue
+    }
+    if (!ANNOTATION_ALLOWLIST.has(key)) {
       continue
     }
     const value = view.utf8String(valueRva)
-    if (value !== null) {
-      into[key] = value
+    if (value === null) {
+      allEntriesRead = false
+      continue
     }
+    into[key] = value
   }
+  return allEntriesRead
 }
 
-/** MinidumpAnnotationList: u32 count, then MinidumpAnnotation records. */
+/**
+ * MinidumpAnnotationList: u32 count, then MinidumpAnnotation records. Returns
+ * false when any record went unread, since an unread name could be `ptype`.
+ */
 function readAnnotationObjects(
   view: MinidumpView,
-  location: LocationDescriptor | null,
+  read: LocationRead,
   into: Record<string, string>
-): void {
-  if (!location) {
-    return
+): boolean {
+  if (read.status !== 'present') {
+    return read.status === 'absent'
   }
+  const location = read.location
   const count = view.u32(location.rva)
   if (
     count === null ||
     count > MAX_ANNOTATIONS ||
     4 + count * ANNOTATION_RECORD_SIZE > location.size
   ) {
-    return
+    return false
   }
+  let allRecordsRead = true
   for (let index = 0; index < count; index += 1) {
     const entry = location.rva + 4 + index * ANNOTATION_RECORD_SIZE
     const nameRva = view.u32(entry)
     const type = view.u16(entry + 4)
     const valueRva = view.u32(entry + 8)
     if (nameRva === null || type === null || valueRva === null) {
-      return
+      return false
     }
     if (type !== ANNOTATION_TYPE_STRING || valueRva === 0) {
       continue
     }
     const name = view.utf8String(nameRva, 256)
-    if (name === null || !ANNOTATION_ALLOWLIST.has(name)) {
+    if (name === null) {
+      allRecordsRead = false
+      continue
+    }
+    if (!ANNOTATION_ALLOWLIST.has(name)) {
       continue
     }
     const raw = view.byteArray(valueRva)
-    if (raw) {
-      // Annotation strings are not NUL-terminated; trim a trailing one anyway.
-      let value = raw.toString('utf8')
-      while (value.endsWith('\0')) {
-        value = value.slice(0, -1)
-      }
-      into[name] = value
+    if (!raw) {
+      allRecordsRead = false
+      continue
     }
+    // Annotation strings are not NUL-terminated; trim a trailing one anyway.
+    let value = raw.toString('utf8')
+    while (value.endsWith('\0')) {
+      value = value.slice(0, -1)
+    }
+    into[name] = value
   }
+  return allRecordsRead
 }
 
-export function readCrashpadAnnotations(view: MinidumpView): Record<string, string> {
-  const annotations: Record<string, string> = {}
-  const info = findStream(view, STREAM_TYPE_CRASHPAD_INFO)
-  if (!info || info.size < CRASHPAD_INFO_MIN_SIZE) {
-    return annotations
-  }
+export type CrashpadAnnotationRead = {
+  readonly annotations: Record<string, string>
+  /**
+   * False when any part of the annotation walk went unread: the CrashpadInfo
+   * stream, the module-link list, a link's info record, or a single annotation
+   * entry. What came back is then partial, so a key missing from it — `ptype`
+   * above all — is undetermined rather than absent.
+   */
+  readonly annotationsComplete: boolean
+}
 
-  readSimpleAnnotations(
-    view,
-    view.location(info.rva + CRASHPAD_INFO_SIMPLE_ANNOTATIONS_OFFSET),
-    annotations
-  )
-
-  const moduleList = view.location(info.rva + CRASHPAD_INFO_MODULE_LIST_OFFSET)
-  if (!moduleList) {
-    return annotations
-  }
-  const moduleCount = view.u32(moduleList.rva)
-  if (moduleCount === null || moduleCount > MAX_MODULES) {
-    return annotations
-  }
-  for (let index = 0; index < moduleCount; index += 1) {
+/**
+ * Walks the links, returning false if any link's MinidumpModuleCrashpadInfo went
+ * unread. Chromium attaches `ptype`/`LOG_FATAL` to exactly one module, so a
+ * single skipped link can be the one that carried them.
+ */
+function readModuleLinks(
+  view: MinidumpView,
+  moduleList: LocationDescriptor,
+  linkCount: number,
+  annotations: Record<string, string>
+): boolean {
+  let allLinksRead = true
+  for (let index = 0; index < linkCount; index += 1) {
     const link = moduleList.rva + 4 + index * MODULE_CRASHPAD_INFO_LINK_SIZE
-    const moduleInfo = view.location(link + 4)
-    if (!moduleInfo || moduleInfo.size < MODULE_CRASHPAD_INFO_MIN_SIZE) {
+    const moduleInfo = view.locationRead(link + 4)
+    if (moduleInfo.status === 'absent') {
+      continue
+    }
+    if (
+      moduleInfo.status === 'unreadable' ||
+      moduleInfo.location.size < MODULE_CRASHPAD_INFO_MIN_SIZE
+    ) {
+      allLinksRead = false
       continue
     }
     // Why: Chromium's crash keys land in annotation_objects on current
     // Crashpad, but older modules still populate the two legacy shapes.
-    readSimpleAnnotations(
+    const simpleRead = readSimpleAnnotations(
       view,
-      view.location(moduleInfo.rva + MODULE_CRASHPAD_INFO_SIMPLE_ANNOTATIONS_OFFSET),
+      view.locationRead(moduleInfo.location.rva + MODULE_CRASHPAD_INFO_SIMPLE_ANNOTATIONS_OFFSET),
       annotations
     )
-    readAnnotationObjects(
+    const objectsRead = readAnnotationObjects(
       view,
-      view.location(moduleInfo.rva + MODULE_CRASHPAD_INFO_ANNOTATION_OBJECTS_OFFSET),
+      view.locationRead(moduleInfo.location.rva + MODULE_CRASHPAD_INFO_ANNOTATION_OBJECTS_OFFSET),
       annotations
     )
+    allLinksRead = allLinksRead && simpleRead && objectsRead
   }
-  return annotations
+  return allLinksRead
+}
+
+export function readCrashpadAnnotations(view: MinidumpView): CrashpadAnnotationRead {
+  const annotations: Record<string, string> = {}
+  const info = findStream(view, STREAM_TYPE_CRASHPAD_INFO)
+  if (!info) {
+    return { annotations, annotationsComplete: true }
+  }
+  // A stream too short to reach module_list never said the list was empty.
+  if (info.size < CRASHPAD_INFO_MIN_SIZE) {
+    return { annotations, annotationsComplete: false }
+  }
+
+  const processLevelRead = readSimpleAnnotations(
+    view,
+    view.locationRead(info.rva + CRASHPAD_INFO_SIMPLE_ANNOTATIONS_OFFSET),
+    annotations
+  )
+
+  const moduleList = view.locationRead(info.rva + CRASHPAD_INFO_MODULE_LIST_OFFSET)
+  if (moduleList.status !== 'present') {
+    return {
+      annotations,
+      annotationsComplete: processLevelRead && moduleList.status === 'absent'
+    }
+  }
+  const moduleCount = view.u32(moduleList.location.rva)
+  if (moduleCount === null) {
+    return { annotations, annotationsComplete: false }
+  }
+  // Why clamp rather than bail: links past the declared list are unrelated dump
+  // bytes that would fabricate a LOG_FATAL headline, but the links the size does
+  // hold are still real, and dropping them loses the annotations we came for.
+  const declaredLinks = Math.floor((moduleList.location.size - 4) / MODULE_CRASHPAD_INFO_LINK_SIZE)
+  const readableLinks = Math.max(0, Math.min(moduleCount, MAX_MODULES, declaredLinks))
+  const allLinksRead = readModuleLinks(view, moduleList.location, readableLinks, annotations)
+  return {
+    annotations,
+    annotationsComplete: processLevelRead && allLinksRead && readableLinks >= moduleCount
+  }
 }

--- a/src/main/crash-reporting/minidump-stream-reader.ts
+++ b/src/main/crash-reporting/minidump-stream-reader.ts
@@ -14,12 +14,21 @@ const DIRECTORY_ENTRY_SIZE = 12
 const MAX_STREAMS = 4_096
 export const MAX_ANNOTATION_VALUE_BYTES = 8_192
 // Shared cap: both the MINIDUMP_MODULE_LIST and Crashpad's per-module info list.
-export const MAX_MODULES = 1_024
+// Why this high: a real macOS renderer loads 1042 images, so a 1_024 cap made
+// every POSIX module list over-large and unresolvable.
+export const MAX_MODULES = 8_192
 
 export type LocationDescriptor = {
   readonly size: number
   readonly rva: number
 }
+
+export type LocationRead =
+  | { readonly status: 'present'; readonly location: LocationDescriptor }
+  /** The producer wrote a zero RVA: there is no such sub-structure. */
+  | { readonly status: 'absent' }
+  /** The descriptor itself, or what it points at, lies past the end of the dump. */
+  | { readonly status: 'unreadable' }
 
 export class MinidumpView {
   constructor(private readonly buf: Buffer) {}
@@ -49,17 +58,30 @@ export class MinidumpView {
     return this.buf.readBigUInt64LE(offset)
   }
 
-  location(offset: number): LocationDescriptor | null {
+  /**
+   * A LOCATION_DESCRIPTOR read that keeps the producer's "absent" apart from our
+   * "could not read". Collapsing the two turns a truncated dump into a dump that
+   * declared the sub-structure missing.
+   */
+  locationRead(offset: number): LocationRead {
     const size = this.u32(offset)
     const rva = this.u32(offset + 4)
     if (size === null || rva === null) {
-      return null
+      return { status: 'unreadable' }
     }
     // A zero rva means "absent", which is normal for optional sub-structures.
-    if (rva === 0 || rva >= this.buf.length) {
-      return null
+    if (rva === 0) {
+      return { status: 'absent' }
     }
-    return { size, rva }
+    if (rva >= this.buf.length) {
+      return { status: 'unreadable' }
+    }
+    return { status: 'present', location: { size, rva } }
+  }
+
+  location(offset: number): LocationDescriptor | null {
+    const read = this.locationRead(offset)
+    return read.status === 'present' ? read.location : null
   }
 
   /** MinidumpUTF8String: u32 byte length, then NUL-terminated UTF-8. */
@@ -99,6 +121,34 @@ export class MinidumpView {
 
 export function isMinidump(dump: Buffer): boolean {
   return dump.length >= MINIDUMP_HEADER_SIZE && dump.readUInt32LE(0) === MINIDUMP_SIGNATURE
+}
+
+/**
+ * Whether `[rva, end)` reaches into bytes the directory hands to another stream.
+ *
+ * Why: a stream's own `size` and the counts inside it are one producer's word, so
+ * their agreement corroborates nothing. Streams are written disjointly, which
+ * makes an overlap the one in-file proof that a declared range is not the
+ * stream's own bytes.
+ */
+export function overlapsOtherStream(view: MinidumpView, rva: number, end: number): boolean {
+  const streamCount = view.u32(8)
+  const directoryRva = view.u32(12)
+  if (streamCount === null || directoryRva === null || streamCount > MAX_STREAMS) {
+    return false
+  }
+  for (let index = 0; index < streamCount; index += 1) {
+    const entry = directoryRva + index * DIRECTORY_ENTRY_SIZE
+    const size = view.u32(entry + 4)
+    const other = view.u32(entry + 8)
+    if (size === null || other === null || other === 0 || other === rva) {
+      continue
+    }
+    if (other < end && other + size > rva) {
+      return true
+    }
+  }
+  return false
 }
 
 /** Locates a stream by type in the header's directory, or null if absent. */

--- a/src/shared/crash-report-signature-lines.ts
+++ b/src/shared/crash-report-signature-lines.ts
@@ -12,12 +12,31 @@ export function appendMinidumpSignatureLines(
   lines: string[],
   details: Record<string, CrashReportDetailValue>
 ): void {
+  // Why: an unread annotation list left `ptype` unread too, so nothing lifted out
+  // of the dump is confirmed to be this process's — and a fatal line reads as this
+  // crash's diagnosis up here while the raw status sits in a detail list read past.
+  const unattributed =
+    details.minidumpAnnotationListStatus === 'unreadable' &&
+    typeof details.minidumpProcessType !== 'string'
   if (typeof details.minidumpCheckMessage === 'string') {
-    lines.push(`Check failure: ${details.minidumpCheckMessage}`)
+    const doubt = unattributed ? ' (process unconfirmed: annotation list unreadable)' : ''
+    lines.push(`Check failure: ${details.minidumpCheckMessage}${doubt}`)
+  } else if (unattributed) {
+    lines.push('Minidump process: unconfirmed (annotation list unreadable)')
   }
+  const status = details.minidumpModuleListStatus
   if (typeof details.minidumpFaultingModule === 'string') {
     const offset = details.minidumpFaultingModuleOffset
     const suffix = typeof offset === 'string' ? `+${offset}` : ''
-    lines.push(`Faulting module: ${details.minidumpFaultingModule}${suffix}`)
+    // Why beside the name: a name matched out of a list we never finished reads
+    // as verified up here, while the status alone sits in a list read past.
+    const doubt = typeof status === 'string' ? ` (module list ${status})` : ''
+    lines.push(`Faulting module: ${details.minidumpFaultingModule}${suffix}${doubt}`)
+    return
+  }
+  // Why: an unread module list cannot name the module, and silence there reads
+  // as "the address belongs to no module" — a claim the parser never made.
+  if (typeof status === 'string') {
+    lines.push(`Faulting module: unresolved (module list ${status})`)
   }
 }

--- a/src/shared/crash-reporting.test.ts
+++ b/src/shared/crash-reporting.test.ts
@@ -223,6 +223,148 @@ describe('crash-reporting shared helpers', () => {
     expect(text.indexOf('Check failure:')).toBeLessThan(text.indexOf('Details:'))
   })
 
+  it('says the module list was unread rather than implying no faulting module', () => {
+    const report: CrashReportRecord = {
+      id: 'crash-truncated-modules',
+      createdAt: '2026-08-15T01:00:00.000Z',
+      status: 'pending',
+      source: 'renderer',
+      processType: 'renderer',
+      reason: 'crashed',
+      exitCode: 11,
+      appVersion: '1.4.188',
+      platform: 'darwin',
+      osRelease: '24.6.0',
+      arch: 'arm64',
+      electronVersion: '43.1.0',
+      chromeVersion: '150.0.7871.47',
+      details: {
+        minidumpExceptionAddress: '0x7ff800001234',
+        minidumpModuleListStatus: 'truncated'
+      },
+      breadcrumbs: []
+    }
+
+    const text = formatCrashReportText(report)
+
+    expect(text).toContain('Faulting module: unresolved (module list truncated)')
+  })
+
+  it('qualifies the faulting module headline with the module list status', () => {
+    const report: CrashReportRecord = {
+      id: 'crash-partial-modules',
+      createdAt: '2026-08-15T01:00:00.000Z',
+      status: 'pending',
+      source: 'renderer',
+      processType: 'renderer',
+      reason: 'crashed',
+      exitCode: 11,
+      appVersion: '1.4.188',
+      platform: 'darwin',
+      osRelease: '24.6.0',
+      arch: 'arm64',
+      electronVersion: '43.1.0',
+      chromeVersion: '150.0.7871.47',
+      details: {
+        minidumpExceptionAddress: '0x7ff800001234',
+        minidumpFaultingModule: 'libGLESv2.dylib',
+        minidumpFaultingModuleOffset: '0x1234',
+        minidumpModuleListStatus: 'truncated'
+      },
+      breadcrumbs: []
+    }
+
+    const text = formatCrashReportText(report)
+
+    expect(text).toContain('Faulting module: libGLESv2.dylib+0x1234 (module list truncated)')
+  })
+
+  it('marks a fatal line lifted from a dump whose process type went unread', () => {
+    const report: CrashReportRecord = {
+      id: 'crash-unattributed',
+      createdAt: '2026-08-15T01:00:00.000Z',
+      status: 'pending',
+      source: 'renderer',
+      processType: 'renderer',
+      reason: 'crashed',
+      exitCode: 11,
+      appVersion: '1.4.188',
+      platform: 'darwin',
+      osRelease: '24.6.0',
+      arch: 'arm64',
+      electronVersion: '43.1.0',
+      chromeVersion: '150.0.7871.47',
+      details: {
+        minidumpCheckMessage: '[0101/000000.000000:FATAL:gpu_main.cc(9)] Check failed: false.',
+        minidumpAnnotationListStatus: 'unreadable'
+      },
+      breadcrumbs: []
+    }
+
+    const text = formatCrashReportText(report)
+
+    expect(text).toContain(
+      'Check failure: [0101/000000.000000:FATAL:gpu_main.cc(9)] Check failed: false. (process unconfirmed: annotation list unreadable)'
+    )
+  })
+
+  it('leaves the fatal line unqualified when the dump did name its process', () => {
+    const report: CrashReportRecord = {
+      id: 'crash-attributed',
+      createdAt: '2026-08-15T01:00:00.000Z',
+      status: 'pending',
+      source: 'renderer',
+      processType: 'renderer',
+      reason: 'crashed',
+      exitCode: 11,
+      appVersion: '1.4.188',
+      platform: 'darwin',
+      osRelease: '24.6.0',
+      arch: 'arm64',
+      electronVersion: '43.1.0',
+      chromeVersion: '150.0.7871.47',
+      details: {
+        minidumpCheckMessage: '[0101/000000.000000:FATAL:render_frame.cc(9)] Check failed: false.',
+        minidumpProcessType: 'renderer',
+        minidumpAnnotationListStatus: 'unreadable'
+      },
+      breadcrumbs: []
+    }
+
+    const text = formatCrashReportText(report)
+
+    expect(text).toContain(
+      'Check failure: [0101/000000.000000:FATAL:render_frame.cc(9)] Check failed: false.\n'
+    )
+  })
+
+  it('says the process is unconfirmed even with no fatal line to hang it on', () => {
+    const report: CrashReportRecord = {
+      id: 'crash-unattributed-no-check',
+      createdAt: '2026-08-15T01:00:00.000Z',
+      status: 'pending',
+      source: 'renderer',
+      processType: 'renderer',
+      reason: 'crashed',
+      exitCode: 11,
+      appVersion: '1.4.188',
+      platform: 'darwin',
+      osRelease: '24.6.0',
+      arch: 'arm64',
+      electronVersion: '43.1.0',
+      chromeVersion: '150.0.7871.47',
+      details: {
+        minidumpExceptionCode: '0x80000003',
+        minidumpAnnotationListStatus: 'unreadable'
+      },
+      breadcrumbs: []
+    }
+
+    const text = formatCrashReportText(report)
+
+    expect(text).toContain('Minidump process: unconfirmed (annotation list unreadable)')
+  })
+
   it('decodes POSIX wait statuses in the exit code line and leaves Windows codes raw', () => {
     const report = (overrides: Partial<CrashReportRecord>): CrashReportRecord => ({
       id: 'crash-wait-status',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​700 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​693 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​372 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​109 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​263 |

<!-- /orca-pr-loc -->

> **Draft.** 5 adversarial loops, 2 majors outstanding.

## The bug

`minidump-stream-reader.ts:17` caps `MAX_MODULES` below a real macOS renderer's image count — **measured at 1042 images with only 18 modules of margin**. So on POSIX the module list is truncated and faulting-module resolution silently degrades.

Evidence from the 1.4.188 batch (76 reports): **27 Windows reports carry a faulting module, zero POSIX reports do.**

Raises the cap and reports truncation as a distinct state. 23 files / 284 tests green. `/perf`: no meaningful impact (6.4 ms worst case at the 64 MiB ceiling, on an async path after a process has already died).

## Outstanding

1. **Major:** `moduleLinksComplete` covers only two of the five ways the Crashpad annotation walk can fail to read — e.g. a module-link list whose LOCATION_DESCRIPTOR is malformed is not one of them.
2. **Major:** a dump whose process type is undetermined is now accepted and `claimedDumpPaths`-claimed by whichever process polls first, and the headline it produces asserts more than was established.

Both are the effort's recurring bug class — *treating "we could not determine X" as an affirmative answer* — which is exactly what closed #16435 and #16154. Reviving this needs a shared three-state result (`Resolved | Unavailable | Unknown`, with `Unknown` carrying a reason) rather than hand-rolling it again.