### PR TITLE
draft(agent-output): give agent images a definite box before load

### DIFF
--- a/src/renderer/src/components/editor/ImageViewer.test.tsx
+++ b/src/renderer/src/components/editor/ImageViewer.test.tsx
@@ -164,13 +164,38 @@ async function renderExpandedImageViewer(
 const SVG_BASE64 = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" />').toString('base64')
 
 function pngBase64(width: number): string {
-  const bytes = Buffer.alloc(24)
+  const bytes = Buffer.alloc(41)
   Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]).copy(bytes)
   bytes.writeUInt32BE(13, 8)
   bytes.write('IHDR', 12, 'ascii')
   bytes.writeUInt32BE(width, 16)
   bytes.writeUInt32BE(1, 20)
+  bytes.write('IDAT', 37, 'ascii')
   return bytes.toString('base64')
+}
+
+/** A landscape JPEG frame whose EXIF orientation makes a browser render it portrait. */
+function rotatedJpegBase64(width: number, height: number): string {
+  const tiff = Buffer.alloc(26)
+  tiff.write('MM', 0, 'ascii')
+  tiff.writeUInt16BE(42, 2)
+  tiff.writeUInt32BE(8, 4)
+  tiff.writeUInt16BE(1, 8)
+  tiff.writeUInt16BE(0x0112, 10)
+  tiff.writeUInt16BE(3, 12)
+  tiff.writeUInt32BE(1, 14)
+  tiff.writeUInt16BE(6, 18)
+  const payload = Buffer.concat([Buffer.from('Exif\0\0', 'latin1'), tiff])
+  const app1 = Buffer.alloc(4)
+  app1.writeUInt16BE(0xffe1)
+  app1.writeUInt16BE(payload.byteLength + 2, 2)
+  const sof = Buffer.alloc(11)
+  sof.writeUInt16BE(0xffc0)
+  sof.writeUInt16BE(8, 2)
+  sof[4] = 8
+  sof.writeUInt16BE(height, 5)
+  sof.writeUInt16BE(width, 7)
+  return Buffer.concat([Buffer.from([0xff, 0xd8]), app1, payload, sof]).toString('base64')
 }
 
 async function renderPdfViewerProps(
@@ -281,6 +306,23 @@ describe('ImageViewer pre-load layout box', () => {
       findElementsByType(rendered, 'div').some((element) => {
         const style = element.props.style as { width?: string; height?: string } | undefined
         return style?.width === '4px' && style?.height === '1px'
+      })
+    ).toBe(true)
+  })
+
+  // Why: Chromium applies EXIF orientation to naturalWidth/naturalHeight, so a portrait phone
+  // photo stored landscape must get its portrait box now — otherwise onLoad transposes it.
+  it('fits the pre-load box to the EXIF-rotated axes, not the stored ones', async () => {
+    const content = rotatedJpegBase64(4032, 3024)
+    const first = await renderExpandedImageViewer(content, 'image/jpeg')
+    attachSurface(findSurfaceRefs(first)[0], 700, 800)
+
+    const rendered = await renderExpandedImageViewer(content, 'image/jpeg')
+
+    expect(
+      findElementsByType(rendered, 'div').some((element) => {
+        const style = element.props.style as { width?: string; height?: string } | undefined
+        return style?.width === '576px' && style?.height === '768px'
       })
     ).toBe(true)
   })

--- a/src/renderer/src/components/editor/ImageViewer.test.tsx
+++ b/src/renderer/src/components/editor/ImageViewer.test.tsx
@@ -146,17 +146,22 @@ function attachSurface(
   setSurfaceRef({ clientWidth, clientHeight, addEventListener() {}, removeEventListener() {} })
 }
 
-async function renderExpandedImageViewer(content: string): Promise<unknown> {
+async function renderExpandedImageViewer(
+  content: string,
+  mimeType = 'image/png'
+): Promise<unknown> {
   reactHookRuntime.index = 0
   const module = await import('./ImageViewer')
   return expandNode(
     module.default({
       content,
       filePath: '/repo/preview.png',
-      mimeType: 'image/png'
+      mimeType
     })
   )
 }
+
+const SVG_BASE64 = Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" />').toString('base64')
 
 function pngBase64(width: number): string {
   const bytes = Buffer.alloc(24)
@@ -261,15 +266,34 @@ describe('ImageViewer pre-load layout box', () => {
     vi.clearAllMocks()
   })
 
-  // Why: before onLoad there is no measured natural size, and the surface's `w-max`/`h-max`
-  // inner box makes percentage maxes resolve to `none` — so an uncapped image lays out and
-  // rasters at full natural resolution. The surface itself is already measured, and in a
-  // split pane it is a fraction of the viewport, so the cap has to come from it.
-  it('caps the inline preview with the measured surface box before the image loads', async () => {
+  // Why: the natural size is already in the base64 header, so a raster preview gets its exact
+  // fit box on the first render instead of a heuristic cap that onLoad then relays out.
+  it('sizes a raster preview from its header dimensions before onLoad', async () => {
     const first = await renderExpandedImageViewer(pngBase64(4))
     attachSurface(findSurfaceRefs(first)[0], 700, 800)
 
     const rendered = await renderExpandedImageViewer(pngBase64(4))
+    const image = findPreviewImage(rendered)
+
+    expect(image.props.className).toBe('object-contain block h-full w-full')
+    expect(image.props.style).toBeUndefined()
+    expect(
+      findElementsByType(rendered, 'div').some((element) => {
+        const style = element.props.style as { width?: string; height?: string } | undefined
+        return style?.width === '4px' && style?.height === '1px'
+      })
+    ).toBe(true)
+  })
+
+  // Why: before onLoad an unparsed mime has no natural size, and the surface's `w-max`/`h-max`
+  // inner box makes percentage maxes resolve to `none` — so an uncapped image lays out and
+  // rasters at full natural resolution. The surface itself is already measured, and in a
+  // split pane it is a fraction of the viewport, so the cap has to come from it.
+  it('caps an unmeasurable preview with the measured surface box before the image loads', async () => {
+    const first = await renderExpandedImageViewer(SVG_BASE64, 'image/svg+xml')
+    attachSurface(findSurfaceRefs(first)[0], 700, 800)
+
+    const rendered = await renderExpandedImageViewer(SVG_BASE64, 'image/svg+xml')
     const image = findPreviewImage(rendered)
 
     expect(image.props.className).toBe('object-contain block')
@@ -277,19 +301,31 @@ describe('ImageViewer pre-load layout box', () => {
   })
 
   it('caps the full-size popup preview from its own surface, not the viewport', async () => {
-    const first = await renderExpandedImageViewer(pngBase64(4))
+    const first = await renderExpandedImageViewer(SVG_BASE64, 'image/svg+xml')
     attachSurface(findSurfaceRefs(first)[1], 1200, 900)
 
-    const rendered = await renderExpandedImageViewer(pngBase64(4))
+    const rendered = await renderExpandedImageViewer(SVG_BASE64, 'image/svg+xml')
     const popupImage = findElementsByType(rendered, 'img').find((element) => !element.props.onError)
 
     expect(popupImage?.props.className).toBe('object-contain block')
     expect(popupImage?.props.style).toEqual({ maxWidth: '1168px', maxHeight: '868px' })
   })
 
+  // Why: a surface the user dragged to 30px was measured — the viewport is not a bound it implies.
+  it('caps an unmeasurable preview at a surface too short for its own padding', async () => {
+    const first = await renderExpandedImageViewer(SVG_BASE64, 'image/svg+xml')
+    attachSurface(findSurfaceRefs(first)[0], 700, 30)
+
+    const rendered = await renderExpandedImageViewer(SVG_BASE64, 'image/svg+xml')
+    const image = findPreviewImage(rendered)
+
+    expect(image.props.className).toBe('object-contain block')
+    expect(image.props.style).toEqual({ maxWidth: '668px', maxHeight: '30px' })
+  })
+
   // Why: an unmeasured surface is not an unbounded one.
   it('falls back to viewport lengths while no surface has been measured', async () => {
-    const rendered = await renderExpandedImageViewer(pngBase64(4))
+    const rendered = await renderExpandedImageViewer(SVG_BASE64, 'image/svg+xml')
 
     expect(findPreviewImage(rendered).props.className).toBe(
       'object-contain block max-h-[100vh] max-w-[100vw]'

--- a/src/renderer/src/components/editor/ImageViewer.test.tsx
+++ b/src/renderer/src/components/editor/ImageViewer.test.tsx
@@ -239,3 +239,29 @@ describe('ImageViewer preview source retry', () => {
     expect(findElementsByType(rendered, 'img')).toHaveLength(0)
   })
 })
+
+describe('ImageViewer pre-load layout box', () => {
+  beforeEach(() => {
+    reactHookRuntime.states = []
+    reactHookRuntime.index = 0
+    vi.clearAllMocks()
+  })
+
+  // Why: before onLoad there is no measured size, and the surface's `w-max`/`h-max` inner
+  // box makes percentage maxes resolve to `none` — so an uncapped image lays out and
+  // rasters at full natural resolution before any constraint applies.
+  it('caps the inline preview with viewport lengths before the image loads', async () => {
+    const rendered = await renderExpandedImageViewer(pngBase64(4))
+
+    expect(findPreviewImage(rendered).props.className).toBe(
+      'object-contain block max-h-[100vh] max-w-[100vw]'
+    )
+  })
+
+  it('caps the full-size popup preview the same way', async () => {
+    const rendered = await renderExpandedImageViewer(pngBase64(4))
+    const popupImage = findElementsByType(rendered, 'img').find((element) => !element.props.onError)
+
+    expect(popupImage?.props.className).toBe('object-contain block max-h-[100vh] max-w-[100vw]')
+  })
+})

--- a/src/renderer/src/components/editor/ImageViewer.test.tsx
+++ b/src/renderer/src/components/editor/ImageViewer.test.tsx
@@ -132,6 +132,20 @@ function findPreviewImage(node: unknown): ReactElementLike {
   return image
 }
 
+function findSurfaceRefs(node: unknown): ((surface: unknown) => void)[] {
+  return findElementsByType(node, 'div')
+    .map((element) => element.props.ref)
+    .filter((ref): ref is (surface: unknown) => void => typeof ref === 'function')
+}
+
+function attachSurface(
+  setSurfaceRef: (surface: unknown) => void,
+  clientWidth: number,
+  clientHeight: number
+): void {
+  setSurfaceRef({ clientWidth, clientHeight, addEventListener() {}, removeEventListener() {} })
+}
+
 async function renderExpandedImageViewer(content: string): Promise<unknown> {
   reactHookRuntime.index = 0
   const module = await import('./ImageViewer')
@@ -247,21 +261,38 @@ describe('ImageViewer pre-load layout box', () => {
     vi.clearAllMocks()
   })
 
-  // Why: before onLoad there is no measured size, and the surface's `w-max`/`h-max` inner
-  // box makes percentage maxes resolve to `none` — so an uncapped image lays out and
-  // rasters at full natural resolution before any constraint applies.
-  it('caps the inline preview with viewport lengths before the image loads', async () => {
+  // Why: before onLoad there is no measured natural size, and the surface's `w-max`/`h-max`
+  // inner box makes percentage maxes resolve to `none` — so an uncapped image lays out and
+  // rasters at full natural resolution. The surface itself is already measured, and in a
+  // split pane it is a fraction of the viewport, so the cap has to come from it.
+  it('caps the inline preview with the measured surface box before the image loads', async () => {
+    const first = await renderExpandedImageViewer(pngBase64(4))
+    attachSurface(findSurfaceRefs(first)[0], 700, 800)
+
+    const rendered = await renderExpandedImageViewer(pngBase64(4))
+    const image = findPreviewImage(rendered)
+
+    expect(image.props.className).toBe('object-contain block')
+    expect(image.props.style).toEqual({ maxWidth: '668px', maxHeight: '768px' })
+  })
+
+  it('caps the full-size popup preview from its own surface, not the viewport', async () => {
+    const first = await renderExpandedImageViewer(pngBase64(4))
+    attachSurface(findSurfaceRefs(first)[1], 1200, 900)
+
+    const rendered = await renderExpandedImageViewer(pngBase64(4))
+    const popupImage = findElementsByType(rendered, 'img').find((element) => !element.props.onError)
+
+    expect(popupImage?.props.className).toBe('object-contain block')
+    expect(popupImage?.props.style).toEqual({ maxWidth: '1168px', maxHeight: '868px' })
+  })
+
+  // Why: an unmeasured surface is not an unbounded one.
+  it('falls back to viewport lengths while no surface has been measured', async () => {
     const rendered = await renderExpandedImageViewer(pngBase64(4))
 
     expect(findPreviewImage(rendered).props.className).toBe(
       'object-contain block max-h-[100vh] max-w-[100vw]'
     )
-  })
-
-  it('caps the full-size popup preview the same way', async () => {
-    const rendered = await renderExpandedImageViewer(pngBase64(4))
-    const popupImage = findElementsByType(rendered, 'img').find((element) => !element.props.onError)
-
-    expect(popupImage?.props.className).toBe('object-contain block max-h-[100vh] max-w-[100vw]')
   })
 })

--- a/src/renderer/src/components/editor/ImageViewer.tsx
+++ b/src/renderer/src/components/editor/ImageViewer.tsx
@@ -9,6 +9,7 @@ import {
   applyAnchoredImageViewerZoomChange,
   applyImageSurfaceWheel,
   getElementSurfaceSize,
+  getImageElementSizeClassName,
   getImageLayoutStyle
 } from './image-viewer-dom-zoom'
 import {
@@ -289,9 +290,7 @@ export default function ImageViewer({
                   'object-contain',
                   isIntrinsicLayout
                     ? 'block h-auto max-h-none max-w-full'
-                    : inlineImageLayoutSize
-                      ? 'block h-full w-full'
-                      : 'block max-h-full max-w-full'
+                    : getImageElementSizeClassName(inlineImageLayoutSize)
                 )}
                 onLoad={(event) => {
                   const img = event.currentTarget

--- a/src/renderer/src/components/editor/ImageViewer.tsx
+++ b/src/renderer/src/components/editor/ImageViewer.tsx
@@ -21,7 +21,7 @@ import {
   getZoomedImageLayoutSize
 } from './image-viewer-zoom'
 import { translate } from '@/i18n/i18n'
-import { buildImageDataUri } from '../../../../shared/image-data-uri'
+import { buildRasterImagePreview } from '../../../../shared/image-data-uri'
 
 const FALLBACK_IMAGE_MIME_TYPE = 'image/png'
 
@@ -64,10 +64,13 @@ export default function ImageViewer({
   }
   const isPdf = mimeType === 'application/pdf'
   const isIntrinsicLayout = layout === 'intrinsic'
-  const previewSrc = useMemo(
-    () => buildImageDataUri(mimeType, cleanedContent),
+  // Why: one decode pass yields both the data URI and the header's natural size, so the first
+  // render can lay out the real fit box instead of a cap onLoad would immediately replace.
+  const rasterPreview = useMemo(
+    () => buildRasterImagePreview(mimeType, cleanedContent),
     [cleanedContent, mimeType]
   )
+  const previewSrc = rasterPreview.dataUri
   const imageError =
     (previewSrc === null && cleanedContent.length > 0) ||
     (previewSrc !== null && failedPreviewSrc === previewSrc)
@@ -82,25 +85,26 @@ export default function ImageViewer({
     return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
   }, [cleanedContent])
   const inlineZoomPercent = Math.round(inlineZoom * 100)
+  const naturalImageDimensions = imageDimensions ?? rasterPreview.dimensions
   const inlineImageLayoutSize = useMemo(
     () =>
       isIntrinsicLayout
         ? null
         : getZoomedImageLayoutSize({
-            imageDimensions,
+            imageDimensions: naturalImageDimensions,
             surfaceSize: inlineSurfaceSize,
             zoom: inlineZoom
           }),
-    [imageDimensions, inlineSurfaceSize, inlineZoom, isIntrinsicLayout]
+    [naturalImageDimensions, inlineSurfaceSize, inlineZoom, isIntrinsicLayout]
   )
   const popupImageLayoutSize = useMemo(
     () =>
       getZoomedImageLayoutSize({
-        imageDimensions,
+        imageDimensions: naturalImageDimensions,
         surfaceSize: popupSurfaceSize,
         zoom: popupZoom
       }),
-    [imageDimensions, popupSurfaceSize, popupZoom]
+    [naturalImageDimensions, popupSurfaceSize, popupZoom]
   )
   const inlineImageLayoutStyle = useMemo(
     () => getImageLayoutStyle(inlineImageLayoutSize),

--- a/src/renderer/src/components/editor/ImageViewer.tsx
+++ b/src/renderer/src/components/editor/ImageViewer.tsx
@@ -9,7 +9,7 @@ import {
   applyAnchoredImageViewerZoomChange,
   applyImageSurfaceWheel,
   getElementSurfaceSize,
-  getImageElementSizeClassName,
+  getImageElementSizing,
   getImageLayoutStyle
 } from './image-viewer-dom-zoom'
 import {
@@ -105,6 +105,10 @@ export default function ImageViewer({
   const inlineImageLayoutStyle = useMemo(
     () => getImageLayoutStyle(inlineImageLayoutSize),
     [inlineImageLayoutSize]
+  )
+  const inlineImageSizing = useMemo(
+    () => getImageElementSizing(inlineImageLayoutSize, inlineSurfaceSize),
+    [inlineImageLayoutSize, inlineSurfaceSize]
   )
   const popupImageLayoutStyle = useMemo(
     () => getImageLayoutStyle(popupImageLayoutSize),
@@ -290,8 +294,9 @@ export default function ImageViewer({
                   'object-contain',
                   isIntrinsicLayout
                     ? 'block h-auto max-h-none max-w-full'
-                    : getImageElementSizeClassName(inlineImageLayoutSize)
+                    : inlineImageSizing.className
                 )}
+                style={isIntrinsicLayout ? undefined : inlineImageSizing.style}
                 onLoad={(event) => {
                   const img = event.currentTarget
                   setImageDimensions({ width: img.naturalWidth, height: img.naturalHeight })
@@ -358,6 +363,7 @@ export default function ImageViewer({
         onOpenChange={handlePopupOpenChange}
         previewUrl={previewSrc}
         setSurfaceRef={setPopupSurfaceRef}
+        surfaceSize={popupSurfaceSize}
         zoomPercent={Math.round(popupZoom * 100)}
       />
     </>

--- a/src/renderer/src/components/editor/ImageViewerPopup.tsx
+++ b/src/renderer/src/components/editor/ImageViewerPopup.tsx
@@ -2,6 +2,7 @@ import { X } from 'lucide-react'
 import type { CSSProperties, JSX } from 'react'
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
+import { getImageElementSizeClassName } from './image-viewer-dom-zoom'
 import type { ImageViewerImageDimensions } from './image-viewer-zoom'
 import { translate } from '@/i18n/i18n'
 
@@ -59,10 +60,7 @@ export default function ImageViewerPopup({
               <img
                 src={previewUrl}
                 alt={filename}
-                className={cn(
-                  'object-contain',
-                  imageLayoutSize ? 'block h-full w-full' : 'block max-h-full max-w-full'
-                )}
+                className={cn('object-contain', getImageElementSizeClassName(imageLayoutSize))}
               />
             </div>
           </div>

--- a/src/renderer/src/components/editor/ImageViewerPopup.tsx
+++ b/src/renderer/src/components/editor/ImageViewerPopup.tsx
@@ -2,8 +2,8 @@ import { X } from 'lucide-react'
 import type { CSSProperties, JSX } from 'react'
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
 import { cn } from '@/lib/utils'
-import { getImageElementSizeClassName } from './image-viewer-dom-zoom'
-import type { ImageViewerImageDimensions } from './image-viewer-zoom'
+import { getImageElementSizing } from './image-viewer-dom-zoom'
+import type { ImageViewerImageDimensions, ImageViewerSurfaceSize } from './image-viewer-zoom'
 import { translate } from '@/i18n/i18n'
 
 type ImageViewerPopupProps = {
@@ -15,6 +15,7 @@ type ImageViewerPopupProps = {
   imageLayoutStyle: CSSProperties | undefined
   onOpenChange: (open: boolean) => void
   setSurfaceRef: (surface: HTMLDivElement | null) => void
+  surfaceSize: ImageViewerSurfaceSize | null
 }
 
 export default function ImageViewerPopup({
@@ -25,8 +26,11 @@ export default function ImageViewerPopup({
   imageLayoutSize,
   imageLayoutStyle,
   onOpenChange,
-  setSurfaceRef
+  setSurfaceRef,
+  surfaceSize
 }: ImageViewerPopupProps): JSX.Element {
+  const imageSizing = getImageElementSizing(imageLayoutSize, surfaceSize)
+
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
@@ -60,7 +64,8 @@ export default function ImageViewerPopup({
               <img
                 src={previewUrl}
                 alt={filename}
-                className={cn('object-contain', getImageElementSizeClassName(imageLayoutSize))}
+                className={cn('object-contain', imageSizing.className)}
+                style={imageSizing.style}
               />
             </div>
           </div>

--- a/src/renderer/src/components/editor/image-viewer-dom-zoom.test.ts
+++ b/src/renderer/src/components/editor/image-viewer-dom-zoom.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { getImageElementSizeClassName } from './image-viewer-dom-zoom'
+
+describe('getImageElementSizeClassName', () => {
+  it('fills the measured wrapper box once the natural size is known', () => {
+    expect(getImageElementSizeClassName({ width: 800, height: 600 })).toBe('block h-full w-full')
+  })
+
+  // Why: the scroll surface's inner box is `w-max`/`h-max`, so percentage maxes on the
+  // image resolve to `none` and an unmeasured image lays out at natural resolution.
+  it('caps an unmeasured image with viewport lengths, not percentages', () => {
+    const className = getImageElementSizeClassName(null)
+
+    expect(className).toContain('max-h-[100vh]')
+    expect(className).toContain('max-w-[100vw]')
+    expect(className).not.toContain('max-h-full')
+    expect(className).not.toContain('max-w-full')
+  })
+})

--- a/src/renderer/src/components/editor/image-viewer-dom-zoom.test.ts
+++ b/src/renderer/src/components/editor/image-viewer-dom-zoom.test.ts
@@ -30,26 +30,34 @@ describe('getImageElementSizing', () => {
     })
   })
 
-  // Why: an axis we could not use is not evidence the other axis is unbounded — a surface too
-  // narrow to cap the width still measured a height, so keep it and fall back only on that axis.
-  it('keeps the measured height when the surface is narrower than its own padding', () => {
+  // Why: padding eating an axis is not evidence that axis is unbounded — the surface was still
+  // measured, and it, not the viewport, is what the image cannot exceed.
+  it('keeps the measured surface length on an axis whose padding leaves no content box', () => {
+    expect(getImageElementSizing(null, { width: 700, height: 30 })).toEqual({
+      className: 'block',
+      style: { maxWidth: '668px', maxHeight: '30px' }
+    })
+  })
+
+  it('keeps the measured surface length when the surface is narrower than its own padding', () => {
     expect(getImageElementSizing(null, { width: 24, height: 800 })).toEqual({
-      className: 'block max-w-[100vw]',
-      style: { maxHeight: '768px' }
+      className: 'block',
+      style: { maxWidth: '24px', maxHeight: '768px' }
     })
   })
 
-  it('keeps the measured width when the surface is shorter than its own padding', () => {
-    expect(getImageElementSizing(null, { width: 900, height: 24 })).toEqual({
-      className: 'block max-h-[100vh]',
-      style: { maxWidth: '868px' }
-    })
-  })
-
-  it('falls back to viewport lengths when neither surface axis clears its padding', () => {
+  it('keeps both measured lengths when neither axis clears its padding', () => {
     expect(getImageElementSizing(null, { width: 24, height: 24 })).toEqual({
-      className: 'block max-h-[100vh] max-w-[100vw]',
-      style: undefined
+      className: 'block',
+      style: { maxWidth: '24px', maxHeight: '24px' }
+    })
+  })
+
+  // Why: a collapsed ancestor reports 0, and a 0-length surface still bounds the image.
+  it('keeps a zero-length measured axis rather than widening it to the viewport', () => {
+    expect(getImageElementSizing(null, { width: 0, height: 0 })).toEqual({
+      className: 'block',
+      style: { maxWidth: '0px', maxHeight: '0px' }
     })
   })
 })

--- a/src/renderer/src/components/editor/image-viewer-dom-zoom.test.ts
+++ b/src/renderer/src/components/editor/image-viewer-dom-zoom.test.ts
@@ -30,8 +30,24 @@ describe('getImageElementSizing', () => {
     })
   })
 
-  it('falls back to viewport lengths when the surface is smaller than its own padding', () => {
+  // Why: an axis we could not use is not evidence the other axis is unbounded — a surface too
+  // narrow to cap the width still measured a height, so keep it and fall back only on that axis.
+  it('keeps the measured height when the surface is narrower than its own padding', () => {
     expect(getImageElementSizing(null, { width: 24, height: 800 })).toEqual({
+      className: 'block max-w-[100vw]',
+      style: { maxHeight: '768px' }
+    })
+  })
+
+  it('keeps the measured width when the surface is shorter than its own padding', () => {
+    expect(getImageElementSizing(null, { width: 900, height: 24 })).toEqual({
+      className: 'block max-h-[100vh]',
+      style: { maxWidth: '868px' }
+    })
+  })
+
+  it('falls back to viewport lengths when neither surface axis clears its padding', () => {
+    expect(getImageElementSizing(null, { width: 24, height: 24 })).toEqual({
       className: 'block max-h-[100vh] max-w-[100vw]',
       style: undefined
     })

--- a/src/renderer/src/components/editor/image-viewer-dom-zoom.test.ts
+++ b/src/renderer/src/components/editor/image-viewer-dom-zoom.test.ts
@@ -1,19 +1,39 @@
 import { describe, expect, it } from 'vitest'
-import { getImageElementSizeClassName } from './image-viewer-dom-zoom'
+import { getImageElementSizing } from './image-viewer-dom-zoom'
 
-describe('getImageElementSizeClassName', () => {
+describe('getImageElementSizing', () => {
   it('fills the measured wrapper box once the natural size is known', () => {
-    expect(getImageElementSizeClassName({ width: 800, height: 600 })).toBe('block h-full w-full')
+    expect(getImageElementSizing({ width: 800, height: 600 }, { width: 700, height: 800 })).toEqual(
+      {
+        className: 'block h-full w-full',
+        style: undefined
+      }
+    )
   })
 
-  // Why: the scroll surface's inner box is `w-max`/`h-max`, so percentage maxes on the
-  // image resolve to `none` and an unmeasured image lays out at natural resolution.
-  it('caps an unmeasured image with viewport lengths, not percentages', () => {
-    const className = getImageElementSizeClassName(null)
+  // Why: the scroll surface's inner box is `w-max`/`h-max`, so percentage maxes on the image
+  // resolve to `none` and an unmeasured image lays out at natural resolution; the surface is
+  // already measured by then, and it is far tighter than the viewport in a split pane.
+  it('caps an unmeasured image with the measured surface box minus its padding', () => {
+    expect(getImageElementSizing(null, { width: 700, height: 800 })).toEqual({
+      className: 'block',
+      style: { maxWidth: '668px', maxHeight: '768px' }
+    })
+  })
 
-    expect(className).toContain('max-h-[100vh]')
-    expect(className).toContain('max-w-[100vw]')
-    expect(className).not.toContain('max-h-full')
-    expect(className).not.toContain('max-w-full')
+  // Why: a null surface means "not measured yet", not "unbounded" — fall back to a definite
+  // viewport cap rather than letting the natural size through.
+  it('falls back to viewport lengths while the surface is unmeasured', () => {
+    expect(getImageElementSizing(null, null)).toEqual({
+      className: 'block max-h-[100vh] max-w-[100vw]',
+      style: undefined
+    })
+  })
+
+  it('falls back to viewport lengths when the surface is smaller than its own padding', () => {
+    expect(getImageElementSizing(null, { width: 24, height: 800 })).toEqual({
+      className: 'block max-h-[100vh] max-w-[100vw]',
+      style: undefined
+    })
   })
 })

--- a/src/renderer/src/components/editor/image-viewer-dom-zoom.ts
+++ b/src/renderer/src/components/editor/image-viewer-dom-zoom.ts
@@ -35,6 +35,18 @@ export function getImageLayoutStyle(
   }
 }
 
+/**
+ * Sizing classes for the preview `<img>`.
+ *
+ * A null size means the natural size has not been measured yet, not that the image is small.
+ * The scroll surface's inner box is `w-max`/`h-max`, so percentage maxes there resolve to `none`
+ * and an unmeasured image would lay out — and raster — at full natural resolution before onLoad.
+ * Viewport lengths are definite without measuring anything, so they cap that first layout.
+ */
+export function getImageElementSizeClassName(size: ImageViewerImageDimensions | null): string {
+  return size ? 'block h-full w-full' : 'block max-h-[100vh] max-w-[100vw]'
+}
+
 export function applyAnchoredImageViewerZoomChange(
   surface: HTMLDivElement | null,
   setZoom: Dispatch<SetStateAction<number>>,

--- a/src/renderer/src/components/editor/image-viewer-dom-zoom.ts
+++ b/src/renderer/src/components/editor/image-viewer-dom-zoom.ts
@@ -6,7 +6,7 @@ import {
   type ImageViewerZoomAnchor,
   clampImageViewerZoom,
   getAnchoredImageViewerScrollOffset,
-  getAvailableImageSurfaceBox,
+  getAvailableImageSurfaceLength,
   getNextWheelImageViewerZoom,
   shouldHandleImageZoomWheel
 } from './image-viewer-zoom'
@@ -50,6 +50,9 @@ export type ImageElementSizing = {
  * The surface itself is already measured by then, and in a split pane or side-by-side image diff
  * it is a fraction of the viewport, so cap against it; viewport lengths are only the fallback for
  * a surface we have not measured, which is not the same as an unbounded one.
+ *
+ * Each axis falls back on its own: a surface too narrow to yield a width cap still measured a
+ * height, and discarding it would hand the smallest surfaces the loosest box.
  */
 export function getImageElementSizing(
   layoutSize: ImageViewerImageDimensions | null,
@@ -59,14 +62,25 @@ export function getImageElementSizing(
     return { className: 'block h-full w-full', style: undefined }
   }
 
-  const available = getAvailableImageSurfaceBox(surfaceSize)
-  if (!available) {
-    return { className: 'block max-h-[100vh] max-w-[100vw]', style: undefined }
+  const maxWidth = getAvailableImageSurfaceLength(surfaceSize?.width)
+  const maxHeight = getAvailableImageSurfaceLength(surfaceSize?.height)
+  const style: CSSProperties = {}
+  if (maxWidth !== null) {
+    style.maxWidth = `${maxWidth}px`
+  }
+  if (maxHeight !== null) {
+    style.maxHeight = `${maxHeight}px`
   }
 
   return {
-    className: 'block',
-    style: { maxWidth: `${available.width}px`, maxHeight: `${available.height}px` }
+    className: [
+      'block',
+      maxHeight === null ? 'max-h-[100vh]' : null,
+      maxWidth === null ? 'max-w-[100vw]' : null
+    ]
+      .filter(Boolean)
+      .join(' '),
+    style: maxWidth === null && maxHeight === null ? undefined : style
   }
 }
 

--- a/src/renderer/src/components/editor/image-viewer-dom-zoom.ts
+++ b/src/renderer/src/components/editor/image-viewer-dom-zoom.ts
@@ -42,17 +42,28 @@ export type ImageElementSizing = {
 }
 
 /**
+ * Max length for one axis: its padded content box, or the raw measured surface when padding leaves
+ * no content box. Only an axis we never measured falls through to the viewport — a 30px pane is a
+ * tighter bound than the window, and widening it to the viewport would give the smallest surfaces
+ * the loosest box.
+ */
+function getImageAxisMaxLength(surfaceLength: number | undefined): number | null {
+  if (surfaceLength === undefined || !Number.isFinite(surfaceLength) || surfaceLength < 0) {
+    return null
+  }
+
+  return getAvailableImageSurfaceLength(surfaceLength) ?? surfaceLength
+}
+
+/**
  * Sizing for the preview `<img>`.
  *
- * A null `layoutSize` means the natural size is not measured yet, not that the image is small.
+ * A null `layoutSize` means the natural size is not known yet, not that the image is small.
  * The scroll surface's inner box is `w-max`/`h-max`, so percentage maxes there resolve to `none`
  * and an unmeasured image would lay out — and raster — at full natural resolution before onLoad.
  * The surface itself is already measured by then, and in a split pane or side-by-side image diff
  * it is a fraction of the viewport, so cap against it; viewport lengths are only the fallback for
  * a surface we have not measured, which is not the same as an unbounded one.
- *
- * Each axis falls back on its own: a surface too narrow to yield a width cap still measured a
- * height, and discarding it would hand the smallest surfaces the loosest box.
  */
 export function getImageElementSizing(
   layoutSize: ImageViewerImageDimensions | null,
@@ -62,8 +73,8 @@ export function getImageElementSizing(
     return { className: 'block h-full w-full', style: undefined }
   }
 
-  const maxWidth = getAvailableImageSurfaceLength(surfaceSize?.width)
-  const maxHeight = getAvailableImageSurfaceLength(surfaceSize?.height)
+  const maxWidth = getImageAxisMaxLength(surfaceSize?.width)
+  const maxHeight = getImageAxisMaxLength(surfaceSize?.height)
   const style: CSSProperties = {}
   if (maxWidth !== null) {
     style.maxWidth = `${maxWidth}px`

--- a/src/renderer/src/components/editor/image-viewer-dom-zoom.ts
+++ b/src/renderer/src/components/editor/image-viewer-dom-zoom.ts
@@ -6,6 +6,7 @@ import {
   type ImageViewerZoomAnchor,
   clampImageViewerZoom,
   getAnchoredImageViewerScrollOffset,
+  getAvailableImageSurfaceBox,
   getNextWheelImageViewerZoom,
   shouldHandleImageZoomWheel
 } from './image-viewer-zoom'
@@ -35,16 +36,38 @@ export function getImageLayoutStyle(
   }
 }
 
+export type ImageElementSizing = {
+  className: string
+  style: CSSProperties | undefined
+}
+
 /**
- * Sizing classes for the preview `<img>`.
+ * Sizing for the preview `<img>`.
  *
- * A null size means the natural size has not been measured yet, not that the image is small.
+ * A null `layoutSize` means the natural size is not measured yet, not that the image is small.
  * The scroll surface's inner box is `w-max`/`h-max`, so percentage maxes there resolve to `none`
  * and an unmeasured image would lay out — and raster — at full natural resolution before onLoad.
- * Viewport lengths are definite without measuring anything, so they cap that first layout.
+ * The surface itself is already measured by then, and in a split pane or side-by-side image diff
+ * it is a fraction of the viewport, so cap against it; viewport lengths are only the fallback for
+ * a surface we have not measured, which is not the same as an unbounded one.
  */
-export function getImageElementSizeClassName(size: ImageViewerImageDimensions | null): string {
-  return size ? 'block h-full w-full' : 'block max-h-[100vh] max-w-[100vw]'
+export function getImageElementSizing(
+  layoutSize: ImageViewerImageDimensions | null,
+  surfaceSize: ImageViewerSurfaceSize | null
+): ImageElementSizing {
+  if (layoutSize) {
+    return { className: 'block h-full w-full', style: undefined }
+  }
+
+  const available = getAvailableImageSurfaceBox(surfaceSize)
+  if (!available) {
+    return { className: 'block max-h-[100vh] max-w-[100vw]', style: undefined }
+  }
+
+  return {
+    className: 'block',
+    style: { maxWidth: `${available.width}px`, maxHeight: `${available.height}px` }
+  }
 }
 
 export function applyAnchoredImageViewerZoomChange(

--- a/src/renderer/src/components/editor/image-viewer-zoom.test.ts
+++ b/src/renderer/src/components/editor/image-viewer-zoom.test.ts
@@ -105,6 +105,17 @@ describe('image viewer zoom helpers', () => {
     ).toBeNull()
   })
 
+  // Why: fitting needs both axes, so an axis fully eaten by padding leaves no fit to compute.
+  it('returns no layout size when a surface axis is smaller than its padding', () => {
+    expect(
+      getZoomedImageLayoutSize({
+        imageDimensions: { width: 200, height: 100 },
+        surfaceSize: { width: 900, height: 24 },
+        zoom: 1
+      })
+    ).toBeNull()
+  })
+
   it('keeps the zoom anchor stable by moving the scroll offset', () => {
     expect(
       getAnchoredImageViewerScrollOffset({

--- a/src/renderer/src/components/editor/image-viewer-zoom.ts
+++ b/src/renderer/src/components/editor/image-viewer-zoom.ts
@@ -64,19 +64,29 @@ export function getNextWheelImageViewerZoom(
   return clampImageViewerZoom(currentZoom * getPinchZoomFactor(deltaY, deltaMode))
 }
 
-/** Content box the image may occupy, or null when the surface is unmeasured or too small. */
+/** Content length one axis offers, or null when that axis is unmeasured or eaten by padding. */
+export function getAvailableImageSurfaceLength(
+  surfaceLength: number | undefined,
+  padding: number = IMAGE_VIEWER_SURFACE_PADDING
+): number | null {
+  if (surfaceLength === undefined || !Number.isFinite(surfaceLength)) {
+    return null
+  }
+
+  const available = surfaceLength - padding * 2
+
+  return available > 0 ? available : null
+}
+
+/** Content box the image may occupy; null unless both axes are usable, since fitting needs both. */
 export function getAvailableImageSurfaceBox(
   surfaceSize: ImageViewerSurfaceSize | null,
   padding: number = IMAGE_VIEWER_SURFACE_PADDING
 ): ImageViewerSurfaceSize | null {
-  if (!surfaceSize) {
-    return null
-  }
+  const width = getAvailableImageSurfaceLength(surfaceSize?.width, padding)
+  const height = getAvailableImageSurfaceLength(surfaceSize?.height, padding)
 
-  const width = surfaceSize.width - padding * 2
-  const height = surfaceSize.height - padding * 2
-
-  return width > 0 && height > 0 ? { width, height } : null
+  return width !== null && height !== null ? { width, height } : null
 }
 
 export function getZoomedImageLayoutSize({

--- a/src/renderer/src/components/editor/image-viewer-zoom.ts
+++ b/src/renderer/src/components/editor/image-viewer-zoom.ts
@@ -64,6 +64,21 @@ export function getNextWheelImageViewerZoom(
   return clampImageViewerZoom(currentZoom * getPinchZoomFactor(deltaY, deltaMode))
 }
 
+/** Content box the image may occupy, or null when the surface is unmeasured or too small. */
+export function getAvailableImageSurfaceBox(
+  surfaceSize: ImageViewerSurfaceSize | null,
+  padding: number = IMAGE_VIEWER_SURFACE_PADDING
+): ImageViewerSurfaceSize | null {
+  if (!surfaceSize) {
+    return null
+  }
+
+  const width = surfaceSize.width - padding * 2
+  const height = surfaceSize.height - padding * 2
+
+  return width > 0 && height > 0 ? { width, height } : null
+}
+
 export function getZoomedImageLayoutSize({
   imageDimensions,
   surfaceSize,
@@ -75,27 +90,15 @@ export function getZoomedImageLayoutSize({
   zoom: number
   padding?: number
 }): ImageViewerImageDimensions | null {
-  if (
-    !imageDimensions ||
-    !surfaceSize ||
-    imageDimensions.width <= 0 ||
-    imageDimensions.height <= 0 ||
-    surfaceSize.width <= 0 ||
-    surfaceSize.height <= 0
-  ) {
-    return null
-  }
-
-  const availableWidth = Math.max(0, surfaceSize.width - padding * 2)
-  const availableHeight = Math.max(0, surfaceSize.height - padding * 2)
-  if (availableWidth <= 0 || availableHeight <= 0) {
+  const available = getAvailableImageSurfaceBox(surfaceSize, padding)
+  if (!imageDimensions || !available || imageDimensions.width <= 0 || imageDimensions.height <= 0) {
     return null
   }
 
   const fitScale = Math.min(
     1,
-    availableWidth / imageDimensions.width,
-    availableHeight / imageDimensions.height
+    available.width / imageDimensions.width,
+    available.height / imageDimensions.height
   )
   const boundedZoom = clampImageViewerZoom(zoom)
 

--- a/src/shared/image-data-uri.ts
+++ b/src/shared/image-data-uri.ts
@@ -1,5 +1,5 @@
 import type { RasterImageDimensions } from './raster-image-dimensions'
-import { readRasterImageBase64Dimensions } from './raster-image-base64-preview'
+import { readRasterImageBase64Header } from './raster-image-base64-preview'
 import {
   isKnownRasterImageMimeType,
   isRasterImagePreviewDimensions
@@ -7,7 +7,7 @@ import {
 
 export type RasterImagePreview = {
   dataUri: string | null
-  /** Natural size read from the encoded header; null means unreadable, never a guess. */
+  /** Size a browser reports as naturalWidth/naturalHeight; null means unreadable, never a guess. */
   dimensions: RasterImageDimensions | null
 }
 
@@ -33,11 +33,13 @@ export function buildRasterImagePreview(
   }
   // Only suppress when the header says the image is too large to render safely. An unreadable
   // header is not evidence of an oversized image, and the decoder handles formats we cannot parse.
-  const dimensions = readRasterImageBase64Dimensions(cleaned, mimeType)
-  if (dimensions !== null && !isRasterImagePreviewDimensions(dimensions)) {
+  const header = readRasterImageBase64Header(cleaned, mimeType)
+  // Limits gate on the stored size (a pixel budget neither axis order changes); layout needs the
+  // oriented one, which can stay unknown on an image whose stored size we read fine.
+  if (header.encoded !== null && !isRasterImagePreviewDimensions(header.encoded)) {
     return { dataUri: null, dimensions: null }
   }
-  return { dataUri: `data:${mimeType};base64,${cleaned}`, dimensions }
+  return { dataUri: `data:${mimeType};base64,${cleaned}`, dimensions: header.natural }
 }
 
 export function buildImageDataUri(

--- a/src/shared/image-data-uri.ts
+++ b/src/shared/image-data-uri.ts
@@ -1,30 +1,50 @@
-import { exceedsRasterImagePreviewLimits } from './raster-image-base64-preview'
-import { isKnownRasterImageMimeType } from './raster-image-preview-limits'
+import type { RasterImageDimensions } from './raster-image-dimensions'
+import { readRasterImageBase64Dimensions } from './raster-image-base64-preview'
+import {
+  isKnownRasterImageMimeType,
+  isRasterImagePreviewDimensions
+} from './raster-image-preview-limits'
+
+export type RasterImagePreview = {
+  dataUri: string | null
+  /** Natural size read from the encoded header; null means unreadable, never a guess. */
+  dimensions: RasterImageDimensions | null
+}
 
 // Builds an inline `data:` URI for base64 image bytes, shared by the desktop
 // editor ImageViewer and the mobile file preview so both decode images the same
 // way. Strips whitespace from the payload (base64 from git diffs and SSH streams
 // can arrive line-wrapped) and returns null when there is nothing an <img>/RN
 // <Image> can show — empty content or a non-image mime (PDF, octet-stream, …).
+// Returns the header dimensions from the same decode pass so callers that size
+// layout before the image loads do not pay for a second one.
+export function buildRasterImagePreview(
+  mimeType: string | undefined,
+  base64Content: string
+): RasterImagePreview {
+  // Only image/* renders in an <img>/RN <Image>; reject every other mime
+  // (application/pdf, application/octet-stream, …), not just PDF.
+  if (!mimeType?.startsWith('image/')) {
+    return { dataUri: null, dimensions: null }
+  }
+  const cleaned = base64Content.replace(/\s/g, '')
+  if (!cleaned) {
+    return { dataUri: null, dimensions: null }
+  }
+  // Only suppress when the header says the image is too large to render safely. An unreadable
+  // header is not evidence of an oversized image, and the decoder handles formats we cannot parse.
+  const dimensions = readRasterImageBase64Dimensions(cleaned, mimeType)
+  if (dimensions !== null && !isRasterImagePreviewDimensions(dimensions)) {
+    return { dataUri: null, dimensions: null }
+  }
+  return { dataUri: `data:${mimeType};base64,${cleaned}`, dimensions }
+}
+
 export function buildImageDataUri(
   mimeType: string | undefined,
   base64Content: string
 ): string | null {
-  // Only image/* renders in an <img>/RN <Image>; reject every other mime
-  // (application/pdf, application/octet-stream, …), not just PDF.
-  if (!mimeType?.startsWith('image/')) {
-    return null
-  }
-  const cleaned = base64Content.replace(/\s/g, '')
-  if (!cleaned) {
-    return null
-  }
-  // Only suppress when the header says the image is too large to render safely. An unreadable
-  // header is not evidence of an oversized image, and the decoder handles formats we cannot parse.
-  if (exceedsRasterImagePreviewLimits(cleaned, mimeType)) {
-    return null
-  }
-  return `data:${mimeType};base64,${cleaned}`
+  return buildRasterImagePreview(mimeType, base64Content).dataUri
 }
 
 /** Preserves non-raster data URIs and rejects unsafe known-raster data URIs. */

--- a/src/shared/raster-image-base64-preview.test.ts
+++ b/src/shared/raster-image-base64-preview.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { readRasterImageBase64Dimensions } from './raster-image-base64-preview'
+
+function pngBase64(width: number, height: number): string {
+  const bytes = Buffer.alloc(24)
+  Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]).copy(bytes)
+  bytes.writeUInt32BE(13, 8)
+  bytes.write('IHDR', 12, 'ascii')
+  bytes.writeUInt32BE(width, 16)
+  bytes.writeUInt32BE(height, 20)
+  return bytes.toString('base64')
+}
+
+describe('readRasterImageBase64Dimensions', () => {
+  it('reads the natural size straight from the encoded header', () => {
+    expect(readRasterImageBase64Dimensions(pngBase64(640, 480), 'image/png')).toEqual({
+      width: 640,
+      height: 480
+    })
+  })
+
+  // Why: callers size layout from this — an unreadable header must stay "unknown", never a size.
+  it('returns null for a mime whose header this cannot parse', () => {
+    expect(
+      readRasterImageBase64Dimensions(
+        Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" />').toString('base64'),
+        'image/svg+xml'
+      )
+    ).toBeNull()
+  })
+
+  it('returns null for a truncated header', () => {
+    expect(readRasterImageBase64Dimensions(pngBase64(640, 480).slice(0, 8), 'image/png')).toBeNull()
+  })
+})

--- a/src/shared/raster-image-base64-preview.test.ts
+++ b/src/shared/raster-image-base64-preview.test.ts
@@ -1,35 +1,163 @@
 import { describe, expect, it } from 'vitest'
-import { readRasterImageBase64Dimensions } from './raster-image-base64-preview'
+import { readRasterImageBase64Header } from './raster-image-base64-preview'
 
 function pngBase64(width: number, height: number): string {
-  const bytes = Buffer.alloc(24)
+  const bytes = Buffer.alloc(41)
   Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]).copy(bytes)
   bytes.writeUInt32BE(13, 8)
   bytes.write('IHDR', 12, 'ascii')
   bytes.writeUInt32BE(width, 16)
   bytes.writeUInt32BE(height, 20)
+  bytes.write('IDAT', 37, 'ascii')
   return bytes.toString('base64')
 }
 
-describe('readRasterImageBase64Dimensions', () => {
+/** APP1 carrying an EXIF IFD0 with only an Orientation tag. */
+function exifApp1(orientation: number): Buffer {
+  const tiff = Buffer.alloc(26)
+  tiff.write('MM', 0, 'ascii')
+  tiff.writeUInt16BE(42, 2)
+  tiff.writeUInt32BE(8, 4)
+  tiff.writeUInt16BE(1, 8)
+  tiff.writeUInt16BE(0x0112, 10)
+  tiff.writeUInt16BE(3, 12)
+  tiff.writeUInt32BE(1, 14)
+  tiff.writeUInt16BE(orientation, 18)
+  const payload = Buffer.concat([Buffer.from('Exif\0\0', 'latin1'), tiff])
+  const header = Buffer.alloc(4)
+  header.writeUInt16BE(0xffe1)
+  header.writeUInt16BE(payload.byteLength + 2, 2)
+  return Buffer.concat([header, payload])
+}
+
+function jpegBase64(width: number, height: number, orientation?: number): string {
+  const sof = Buffer.alloc(11)
+  sof.writeUInt16BE(0xffc0)
+  sof.writeUInt16BE(8, 2)
+  sof[4] = 8
+  sof.writeUInt16BE(height, 5)
+  sof.writeUInt16BE(width, 7)
+  return Buffer.concat([
+    Buffer.from([0xff, 0xd8]),
+    orientation === undefined ? Buffer.alloc(0) : exifApp1(orientation),
+    sof
+  ]).toString('base64')
+}
+
+/** A BMP-encoded ICO entry: its DIB header stores the XOR bitmap plus the AND mask, so biHeight is
+ * twice the icon's height. */
+function icoBmpEntry(width: number, height: number): Buffer {
+  const dib = Buffer.alloc(40)
+  dib.writeUInt32LE(40, 0)
+  dib.writeInt32LE(width, 4)
+  dib.writeInt32LE(height * 2, 8)
+  dib.writeUInt16LE(1, 12)
+  dib.writeUInt16LE(32, 14)
+  const xor = Buffer.alloc(width * height * 4)
+  const mask = Buffer.alloc(Math.ceil(width / 32) * 4 * height)
+  return Buffer.concat([dib, xor, mask])
+}
+
+function icoBase64(sizes: readonly (readonly [number, number])[]): string {
+  const payloads = sizes.map(([width, height]) => icoBmpEntry(width, height))
+  const directory = Buffer.alloc(6 + sizes.length * 16)
+  directory.writeUInt16LE(1, 2)
+  directory.writeUInt16LE(sizes.length, 4)
+  let payloadOffset = directory.byteLength
+  sizes.forEach(([width, height], index) => {
+    const entry = 6 + index * 16
+    // A 0 axis byte encodes 256, the largest size a directory entry can express.
+    directory[entry] = width % 256
+    directory[entry + 1] = height % 256
+    directory.writeUInt16LE(1, entry + 4)
+    directory.writeUInt16LE(32, entry + 6)
+    directory.writeUInt32LE(payloads[index]!.byteLength, entry + 8)
+    directory.writeUInt32LE(payloadOffset, entry + 12)
+    payloadOffset += payloads[index]!.byteLength
+  })
+  return Buffer.concat([directory, ...payloads]).toString('base64')
+}
+
+describe('readRasterImageBase64Header', () => {
+  // Why: Chromium reports naturalWidth/naturalHeight with EXIF orientation applied, so a portrait
+  // phone photo (stored landscape, Orientation=6) must measure portrait here too.
+  it('transposes the axes for an EXIF orientation that rotates the image', () => {
+    expect(readRasterImageBase64Header(jpegBase64(4032, 3024, 6), 'image/jpeg')).toEqual({
+      encoded: { width: 4032, height: 3024 },
+      natural: { width: 3024, height: 4032 }
+    })
+  })
+
+  it('keeps the encoded axes for a JPEG with no EXIF block', () => {
+    expect(readRasterImageBase64Header(jpegBase64(4032, 3024), 'image/jpeg')).toEqual({
+      encoded: { width: 4032, height: 3024 },
+      natural: { width: 4032, height: 3024 }
+    })
+  })
+
   it('reads the natural size straight from the encoded header', () => {
-    expect(readRasterImageBase64Dimensions(pngBase64(640, 480), 'image/png')).toEqual({
-      width: 640,
-      height: 480
+    expect(readRasterImageBase64Header(pngBase64(640, 480), 'image/png')).toEqual({
+      encoded: { width: 640, height: 480 },
+      natural: { width: 640, height: 480 }
     })
   })
 
   // Why: callers size layout from this — an unreadable header must stay "unknown", never a size.
-  it('returns null for a mime whose header this cannot parse', () => {
+  it('reports both sizes unknown for a mime whose header this cannot parse', () => {
     expect(
-      readRasterImageBase64Dimensions(
+      readRasterImageBase64Header(
         Buffer.from('<svg xmlns="http://www.w3.org/2000/svg" />').toString('base64'),
         'image/svg+xml'
       )
-    ).toBeNull()
+    ).toEqual({ encoded: null, natural: null })
   })
 
-  it('returns null for a truncated header', () => {
-    expect(readRasterImageBase64Dimensions(pngBase64(640, 480).slice(0, 8), 'image/png')).toBeNull()
+  it('reports both sizes unknown for a truncated header', () => {
+    expect(readRasterImageBase64Header(pngBase64(640, 480).slice(0, 8), 'image/png')).toEqual({
+      encoded: null,
+      natural: null
+    })
+  })
+
+  // Why: Chromium 151 reports naturalWidth/naturalHeight of 32x32, 48x48 and 256x256 for these
+  // exact bytes. The stored read is a deliberate over-estimate — a BMP ICO entry's doubled
+  // AND-mask height, maximised per axis across entries — so it may never size layout.
+  it('measures an ICO from the entry the decoder renders, not the stored budget', () => {
+    expect(readRasterImageBase64Header(icoBase64([[32, 32]]), 'image/x-icon')).toEqual({
+      encoded: { width: 32, height: 64 },
+      natural: { width: 32, height: 32 }
+    })
+    expect(
+      readRasterImageBase64Header(
+        icoBase64([
+          [16, 16],
+          [48, 48]
+        ]),
+        'image/x-icon'
+      )
+    ).toEqual({
+      encoded: { width: 48, height: 96 },
+      natural: { width: 48, height: 48 }
+    })
+    expect(
+      readRasterImageBase64Header(icoBase64([[256, 256]]), 'image/vnd.microsoft.icon')
+    ).toEqual({
+      encoded: { width: 256, height: 512 },
+      natural: { width: 256, height: 256 }
+    })
+  })
+
+  // Why: Blink breaks an equal-area tie on bit depth, which leaves two differently shaped entries
+  // unordered — so the rendered size is unproven and must not be guessed from either one.
+  it('reports an ICO natural size unknown when differently shaped entries tie on area', () => {
+    expect(
+      readRasterImageBase64Header(
+        icoBase64([
+          [16, 48],
+          [48, 16]
+        ]),
+        'image/x-icon'
+      )
+    ).toEqual({ encoded: { width: 48, height: 96 }, natural: null })
   })
 })

--- a/src/shared/raster-image-base64-preview.ts
+++ b/src/shared/raster-image-base64-preview.ts
@@ -1,7 +1,6 @@
-import { readRasterImageDimensions } from './raster-image-dimensions'
+import { readRasterImageDimensions, type RasterImageDimensions } from './raster-image-dimensions'
 import {
   isKnownRasterImageMimeType,
-  isRasterImagePreviewDimensions,
   RASTER_IMAGE_PREVIEW_HEADER_MAX_BYTES
 } from './raster-image-preview-limits'
 
@@ -122,23 +121,16 @@ function decodeBase64Prefix(content: string, maxBytes: number): Uint8Array | nul
 }
 
 /**
- * Whether the encoded dimensions are known to exceed the preview limits.
- *
- * Distinct from a failed read: an unrecognized or truncated header means we could not measure the
- * image, not that it is too large. Treating those the same blanks out valid images that no decoder
- * has trouble with, so only a confident over-limit answer should suppress a preview.
+ * Natural size encoded in a base64 raster payload, or null when it cannot be read — an SVG, an
+ * unrecognized header, or a truncated one. Null means unknown, never "small".
  */
-export function exceedsRasterImagePreviewLimits(
+export function readRasterImageBase64Dimensions(
   content: string,
   mimeType: string | undefined
-): boolean {
+): RasterImageDimensions | null {
   if (!isKnownRasterImageMimeType(mimeType)) {
-    return false
+    return null
   }
   const prefix = decodeBase64Prefix(content, RASTER_IMAGE_PREVIEW_HEADER_MAX_BYTES)
-  if (!prefix) {
-    return false
-  }
-  const dimensions = readRasterImageDimensions(prefix)
-  return dimensions !== null && !isRasterImagePreviewDimensions(dimensions)
+  return prefix ? readRasterImageDimensions(prefix) : null
 }

--- a/src/shared/raster-image-base64-preview.ts
+++ b/src/shared/raster-image-base64-preview.ts
@@ -1,4 +1,9 @@
-import { readRasterImageDimensions, type RasterImageDimensions } from './raster-image-dimensions'
+import {
+  readRasterImageDimensions,
+  readRenderedRasterImageDimensions,
+  type RasterImageDimensions
+} from './raster-image-dimensions'
+import { applyRasterImageAxisSwap, readRasterImageAxisSwap } from './raster-image-orientation'
 import {
   isKnownRasterImageMimeType,
   RASTER_IMAGE_PREVIEW_HEADER_MAX_BYTES
@@ -120,17 +125,38 @@ function decodeBase64Prefix(content: string, maxBytes: number): Uint8Array | nul
   return output.subarray(0, outputLength)
 }
 
+export type RasterImageBase64Header = {
+  /** Size as stored in the header, before EXIF orientation — the axis-independent pixel budget. */
+  encoded: RasterImageDimensions | null
+  /** Size a browser reports as naturalWidth/naturalHeight, EXIF orientation applied. */
+  natural: RasterImageDimensions | null
+}
+
+const UNREADABLE_HEADER: RasterImageBase64Header = {
+  encoded: null,
+  natural: null
+}
+
 /**
- * Natural size encoded in a base64 raster payload, or null when it cannot be read — an SVG, an
- * unrecognized header, or a truncated one. Null means unknown, never "small".
+ * Sizes carried by a base64 raster payload. A null field means we could not read it — an SVG, an
+ * unrecognized header, a truncated one, or (for `natural`) an orientation or ICO entry choice the
+ * bytes never settled. Null means unknown, never "small" and never "unrotated".
  */
-export function readRasterImageBase64Dimensions(
+export function readRasterImageBase64Header(
   content: string,
   mimeType: string | undefined
-): RasterImageDimensions | null {
+): RasterImageBase64Header {
   if (!isKnownRasterImageMimeType(mimeType)) {
-    return null
+    return UNREADABLE_HEADER
   }
   const prefix = decodeBase64Prefix(content, RASTER_IMAGE_PREVIEW_HEADER_MAX_BYTES)
-  return prefix ? readRasterImageDimensions(prefix) : null
+  if (!prefix) {
+    return UNREADABLE_HEADER
+  }
+  // The stored read over-estimates an ICO on purpose, so layout takes the rendered read instead.
+  const rendered = readRenderedRasterImageDimensions(prefix)
+  return {
+    encoded: readRasterImageDimensions(prefix),
+    natural: rendered ? applyRasterImageAxisSwap(rendered, readRasterImageAxisSwap(prefix)) : null
+  }
 }

--- a/src/shared/raster-image-dimensions.test.ts
+++ b/src/shared/raster-image-dimensions.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { readRasterImageDimensions } from './raster-image-dimensions'
+import {
+  readRasterImageDimensions,
+  readRenderedRasterImageDimensions
+} from './raster-image-dimensions'
 
 function pngHeader(width: number, height: number): Buffer {
   const png = Buffer.alloc(24)
@@ -77,6 +80,15 @@ describe('readRasterImageDimensions', () => {
       width: 40_000,
       height: 2
     })
+  })
+
+  // Why: verified against Chromium 151 — img.naturalWidth/naturalHeight for these bytes is 1x1.
+  // The budget must stay forgery-resistant, but layout has to follow the entry the decoder picks.
+  it('renders an ICO at its directory size while the stored read keeps the payload budget', () => {
+    const forged = icoWithPayload(pngHeader(40_000, 2))
+
+    expect(readRasterImageDimensions(forged)).toEqual({ width: 40_000, height: 2 })
+    expect(readRenderedRasterImageDimensions(forged)).toEqual({ width: 1, height: 1 })
   })
 
   it('reads a Uint8Array view without depending on its backing-buffer offset', () => {

--- a/src/shared/raster-image-dimensions.ts
+++ b/src/shared/raster-image-dimensions.ts
@@ -95,9 +95,21 @@ function readGifDimensions(bytes: Uint8Array): RasterImageDimensions | null {
   return positiveDimensions(readUint16Le(bytes, 6), readUint16Le(bytes, 8))
 }
 
-function readJpegDimensions(bytes: Uint8Array): RasterImageDimensions | null {
+export function isJpegStartOfFrameMarker(marker: number): boolean {
+  return JPEG_START_OF_FRAME_MARKERS.has(marker)
+}
+
+/**
+ * Walks JPEG marker segments from SOI, passing each one's length-field offset and length to
+ * `visit`. Returns the first result `visit` gives, or undefined when the scan runs out of
+ * segments — which includes a truncated buffer, so undefined never means "the segment is absent".
+ */
+export function scanJpegSegments<T>(
+  bytes: Uint8Array,
+  visit: (marker: number, lengthOffset: number, segmentLength: number) => T | undefined
+): T | undefined {
   if (!hasBytes(bytes, 0, 4) || bytes[0] !== 0xff || bytes[1] !== 0xd8) {
-    return null
+    return undefined
   }
   let offset = 2
   const scanEnd = bytes.byteLength
@@ -108,26 +120,40 @@ function readJpegDimensions(bytes: Uint8Array): RasterImageDimensions | null {
     const marker = bytes[offset]
     offset += 1
     if (marker === undefined || marker === 0x00 || marker === 0xd9 || marker === 0xda) {
-      return null
+      return undefined
     }
     if (marker === 0x01 || (marker >= 0xd0 && marker <= 0xd8)) {
       continue
     }
     if (!hasBytes(bytes, offset, 2)) {
-      return null
+      return undefined
     }
     const segmentLength = readUint16Be(bytes, offset)
     if (segmentLength < 2 || offset + segmentLength > scanEnd) {
-      return null
+      return undefined
     }
-    if (JPEG_START_OF_FRAME_MARKERS.has(marker)) {
-      return segmentLength >= 7
-        ? positiveDimensions(readUint16Be(bytes, offset + 5), readUint16Be(bytes, offset + 3))
-        : null
+    const visited = visit(marker, offset, segmentLength)
+    if (visited !== undefined) {
+      return visited
     }
     offset += segmentLength
   }
-  return null
+  return undefined
+}
+
+function readJpegDimensions(bytes: Uint8Array): RasterImageDimensions | null {
+  return (
+    scanJpegSegments<RasterImageDimensions | null>(bytes, (marker, lengthOffset, segmentLength) =>
+      isJpegStartOfFrameMarker(marker)
+        ? segmentLength >= 7
+          ? positiveDimensions(
+              readUint16Be(bytes, lengthOffset + 5),
+              readUint16Be(bytes, lengthOffset + 3)
+            )
+          : null
+        : undefined
+    ) ?? null
+  )
 }
 
 function readWebpDimensions(bytes: Uint8Array): RasterImageDimensions | null {
@@ -208,12 +234,24 @@ function readBmpDimensions(bytes: Uint8Array): RasterImageDimensions | null {
   return matchesAscii(bytes, 0, 'BM') ? readDibDimensions(bytes, 14) : null
 }
 
-function readIcoDimensions(bytes: Uint8Array): RasterImageDimensions | null {
-  if (!hasBytes(bytes, 0, 6) || readUint16Le(bytes, 0) !== 0 || readUint16Le(bytes, 2) !== 1) {
-    return null
+function isIcoHeader(bytes: Uint8Array): boolean {
+  return hasBytes(bytes, 0, 6) && readUint16Le(bytes, 0) === 0 && readUint16Le(bytes, 2) === 1
+}
+
+/** Entry count, or 0 when this is not an ICO whose directory table is fully present. */
+function readIcoImageCount(bytes: Uint8Array): number {
+  if (!isIcoHeader(bytes)) {
+    return 0
   }
   const imageCount = readUint16Le(bytes, 4)
-  if (imageCount <= 0 || imageCount > ICO_MAX_IMAGES || !hasBytes(bytes, 6, imageCount * 16)) {
+  return imageCount > 0 && imageCount <= ICO_MAX_IMAGES && hasBytes(bytes, 6, imageCount * 16)
+    ? imageCount
+    : 0
+}
+
+function readIcoDimensions(bytes: Uint8Array): RasterImageDimensions | null {
+  const imageCount = readIcoImageCount(bytes)
+  if (imageCount === 0) {
     return null
   }
 
@@ -237,7 +275,44 @@ function readIcoDimensions(bytes: Uint8Array): RasterImageDimensions | null {
   return positiveDimensions(maxWidth, maxHeight)
 }
 
-/** Reads encoded raster dimensions without invoking a native or browser image decoder. */
+/**
+ * Size a browser renders an ICO at: Chromium 151 decodes the largest-area directory entry at the
+ * size that entry states, ignoring both the payload's own header and the doubled AND-mask height a
+ * BMP entry stores. Null when differently shaped entries tie on area, because Blink then orders
+ * them by bit depth and leaves the choice unproven.
+ */
+function readIcoRenderedDimensions(bytes: Uint8Array): RasterImageDimensions | null {
+  const imageCount = readIcoImageCount(bytes)
+  let rendered: RasterImageDimensions | null = null
+  let tied = false
+  for (let index = 0; index < imageCount; index += 1) {
+    const entryOffset = 6 + index * 16
+    // A 0 axis byte encodes 256, the largest size a directory entry can express.
+    const size = {
+      width: bytes[entryOffset] || 256,
+      height: bytes[entryOffset + 1] || 256
+    }
+    const renderedArea = rendered ? rendered.width * rendered.height : 0
+    const area = size.width * size.height
+    if (!rendered || area > renderedArea) {
+      rendered = size
+      tied = false
+    } else if (area === renderedArea && size.width !== rendered.width) {
+      tied = true
+    }
+  }
+  return tied ? null : rendered
+}
+
+/**
+ * Size the decoder renders, before EXIF orientation. Differs from the stored read only for ICO,
+ * whose stored read is a forgery-resistant over-estimate rather than any size a browser reports.
+ */
+export function readRenderedRasterImageDimensions(bytes: Uint8Array): RasterImageDimensions | null {
+  return isIcoHeader(bytes) ? readIcoRenderedDimensions(bytes) : readRasterImageDimensions(bytes)
+}
+
+/** Reads raster dimensions as stored, before EXIF orientation, without invoking a decoder. */
 export function readRasterImageDimensions(bytes: Uint8Array): RasterImageDimensions | null {
   return (
     readPngDimensions(bytes) ??

--- a/src/shared/raster-image-orientation.test.ts
+++ b/src/shared/raster-image-orientation.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest'
+import { applyRasterImageAxisSwap, readRasterImageAxisSwap } from './raster-image-orientation'
+
+/** A TIFF header whose IFD0 holds only an Orientation tag. */
+function exifTiff(orientation: number): Buffer {
+  const tiff = Buffer.alloc(26)
+  tiff.write('MM', 0, 'ascii')
+  tiff.writeUInt16BE(42, 2)
+  tiff.writeUInt32BE(8, 4)
+  tiff.writeUInt16BE(1, 8)
+  tiff.writeUInt16BE(0x0112, 10)
+  tiff.writeUInt16BE(3, 12)
+  tiff.writeUInt32BE(1, 14)
+  tiff.writeUInt16BE(orientation, 18)
+  return tiff
+}
+
+function jpeg({ orientation, frame = true }: { orientation?: number; frame?: boolean }): Buffer {
+  const parts = [Buffer.from([0xff, 0xd8])]
+  if (orientation !== undefined) {
+    const payload = Buffer.concat([Buffer.from('Exif\0\0', 'latin1'), exifTiff(orientation)])
+    const header = Buffer.alloc(4)
+    header.writeUInt16BE(0xffe1)
+    header.writeUInt16BE(payload.byteLength + 2, 2)
+    parts.push(header, payload)
+  }
+  if (frame) {
+    const sof = Buffer.alloc(11)
+    sof.writeUInt16BE(0xffc0)
+    sof.writeUInt16BE(8, 2)
+    sof[4] = 8
+    sof.writeUInt16BE(20, 5)
+    sof.writeUInt16BE(40, 7)
+    parts.push(sof)
+  }
+  return Buffer.concat(parts)
+}
+
+function pngChunk(type: string, data: Buffer): Buffer {
+  const header = Buffer.alloc(8)
+  header.writeUInt32BE(data.byteLength)
+  header.write(type, 4, 'ascii')
+  return Buffer.concat([header, data, Buffer.alloc(4)])
+}
+
+function png(chunks: Buffer[]): Buffer {
+  return Buffer.concat([
+    Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]),
+    pngChunk('IHDR', Buffer.alloc(13)),
+    ...chunks
+  ])
+}
+
+function webpRiff(chunk?: Buffer): Buffer {
+  const parts = [Buffer.from('RIFF', 'latin1'), Buffer.alloc(4), Buffer.from('WEBP', 'latin1')]
+  return Buffer.concat(chunk ? [...parts, chunk] : parts)
+}
+
+function webpExtended(flags: number): Buffer {
+  const chunk = Buffer.alloc(18)
+  chunk.write('VP8X', 0, 'ascii')
+  chunk.writeUInt32LE(10, 4)
+  chunk[8] = flags
+  return webpRiff(chunk)
+}
+
+/** A simple (non-extended) container, which has no room for metadata at all. */
+function webpSimple(): Buffer {
+  const chunk = Buffer.alloc(8)
+  chunk.write('VP8 ', 0, 'ascii')
+  return webpRiff(chunk)
+}
+
+describe('readRasterImageAxisSwap', () => {
+  it('reports a quarter-turn JPEG orientation as swapped and a flip as unswapped', () => {
+    expect(readRasterImageAxisSwap(jpeg({ orientation: 6 }))).toBe('swapped')
+    expect(readRasterImageAxisSwap(jpeg({ orientation: 8 }))).toBe('swapped')
+    expect(readRasterImageAxisSwap(jpeg({ orientation: 3 }))).toBe('unswapped')
+  })
+
+  // Why: Exif APP1 has to precede the frame header, so a scan that reached SOF proves there is none.
+  it('treats a JPEG that reaches its frame header without EXIF as unswapped', () => {
+    expect(readRasterImageAxisSwap(jpeg({}))).toBe('unswapped')
+  })
+
+  // Why: the orientation may sit in the bytes we never saw — absent from the prefix is not absent.
+  it('stays unknown for a JPEG truncated before its frame header', () => {
+    expect(readRasterImageAxisSwap(jpeg({ frame: false }))).toBe('unknown')
+  })
+
+  it('reads a PNG eXIf chunk that precedes the image data', () => {
+    expect(
+      readRasterImageAxisSwap(
+        png([pngChunk('eXIf', exifTiff(6)), pngChunk('IDAT', Buffer.alloc(1))])
+      )
+    ).toBe('swapped')
+  })
+
+  // Why: verified against Chromium — it only applies an eXIf chunk seen ahead of the image data.
+  it('ignores a PNG eXIf chunk that trails the image data', () => {
+    expect(
+      readRasterImageAxisSwap(
+        png([pngChunk('IDAT', Buffer.alloc(1)), pngChunk('eXIf', exifTiff(6))])
+      )
+    ).toBe('unswapped')
+  })
+
+  it('stays unknown for a PNG whose chunks run out before the image data', () => {
+    expect(readRasterImageAxisSwap(png([]))).toBe('unknown')
+  })
+
+  // Why: a WebP EXIF chunk trails the image data, so the VP8X flag is the only thing the header
+  // gives us and it says nothing about the orientation itself.
+  it('stays unknown for a WebP that declares EXIF metadata', () => {
+    expect(readRasterImageAxisSwap(webpExtended(0x08))).toBe('unknown')
+    expect(readRasterImageAxisSwap(webpExtended(0x10))).toBe('unswapped')
+    expect(readRasterImageAxisSwap(webpSimple())).toBe('unswapped')
+  })
+
+  // Why: a prefix that stops before the first chunk never showed us the container type, and an
+  // extended container is exactly what carries EXIF — so "not VP8X" is a claim we cannot make.
+  it('stays unknown for a WebP truncated before its first chunk', () => {
+    expect(readRasterImageAxisSwap(webpRiff())).toBe('unknown')
+  })
+
+  it('reports formats with no orientation record as unswapped', () => {
+    expect(readRasterImageAxisSwap(Buffer.from('GIF89a\0\0\0\0', 'latin1'))).toBe('unswapped')
+  })
+})
+
+describe('applyRasterImageAxisSwap', () => {
+  it('returns null rather than a guess when the orientation is unknown', () => {
+    expect(applyRasterImageAxisSwap({ width: 40, height: 20 }, 'unknown')).toBeNull()
+    expect(applyRasterImageAxisSwap({ width: 40, height: 20 }, 'swapped')).toEqual({
+      width: 20,
+      height: 40
+    })
+    expect(applyRasterImageAxisSwap({ width: 40, height: 20 }, 'unswapped')).toEqual({
+      width: 40,
+      height: 20
+    })
+  })
+})

--- a/src/shared/raster-image-orientation.ts
+++ b/src/shared/raster-image-orientation.ts
@@ -1,0 +1,162 @@
+import {
+  isJpegStartOfFrameMarker,
+  scanJpegSegments,
+  type RasterImageDimensions
+} from './raster-image-dimensions'
+
+/**
+ * Whether the rendered image swaps the encoded axes.
+ *
+ * `unknown` means the header never said — a metadata block we could not reach or parse. It is not
+ * the same as `unswapped`, because guessing "no rotation" transposes every portrait phone photo.
+ */
+export type RasterImageAxisSwap = 'swapped' | 'unswapped' | 'unknown'
+
+const EXIF_ORIENTATION_TAG = 0x0112
+const EXIF_SHORT_TYPE = 3
+const EXIF_IDENTIFIER = 'Exif\0\0'
+const EXIF_APP1_MARKER = 0xe1
+const TIFF_MAGIC = 42
+// Orientations 5-8 rotate a quarter turn, so the rendered axes are the encoded ones swapped.
+const AXIS_SWAPPING_ORIENTATIONS = new Set([5, 6, 7, 8])
+const PNG_EXIF_CHUNK = 'eXIf'
+const PNG_IMAGE_DATA_CHUNK = 'IDAT'
+const WEBP_EXIF_FLAG = 0x08
+
+function asciiAt(bytes: Uint8Array, offset: number, length: number): string {
+  if (offset < 0 || offset + length > bytes.byteLength) {
+    return ''
+  }
+  let text = ''
+  for (let index = 0; index < length; index += 1) {
+    text += String.fromCharCode(bytes[offset + index]!)
+  }
+  return text
+}
+
+function viewOf(bytes: Uint8Array): DataView {
+  return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+}
+
+/** Reads IFD0's Orientation tag from a TIFF header spanning [start, end). */
+function readTiffAxisSwap(bytes: Uint8Array, start: number, end: number): RasterImageAxisSwap {
+  const byteOrder = asciiAt(bytes, start, 2)
+  const littleEndian = byteOrder === 'II'
+  if ((!littleEndian && byteOrder !== 'MM') || start + 8 > end) {
+    return 'unknown'
+  }
+  const view = viewOf(bytes)
+  const readUint16 = (offset: number): number => view.getUint16(offset, littleEndian)
+  const readUint32 = (offset: number): number => view.getUint32(offset, littleEndian)
+  if (readUint16(start + 2) !== TIFF_MAGIC) {
+    return 'unknown'
+  }
+  const directory = start + readUint32(start + 4)
+  if (directory < start || directory + 2 > end) {
+    return 'unknown'
+  }
+  const entryCount = readUint16(directory)
+  if (directory + 2 + entryCount * 12 > end) {
+    return 'unknown'
+  }
+  for (let index = 0; index < entryCount; index += 1) {
+    const entry = directory + 2 + index * 12
+    if (readUint16(entry) !== EXIF_ORIENTATION_TAG) {
+      continue
+    }
+    if (readUint16(entry + 2) !== EXIF_SHORT_TYPE || readUint32(entry + 4) !== 1) {
+      return 'unknown'
+    }
+    return AXIS_SWAPPING_ORIENTATIONS.has(readUint16(entry + 8)) ? 'swapped' : 'unswapped'
+  }
+  // EXIF that carries no Orientation tag means orientation 1, which the spec defines as unrotated.
+  return 'unswapped'
+}
+
+function readJpegAxisSwap(bytes: Uint8Array): RasterImageAxisSwap {
+  // Exif APP1 precedes the frame header, so reaching SOF without one proves there is none.
+  return (
+    scanJpegSegments<RasterImageAxisSwap>(bytes, (marker, lengthOffset, segmentLength) => {
+      if (isJpegStartOfFrameMarker(marker)) {
+        return 'unswapped'
+      }
+      if (
+        marker !== EXIF_APP1_MARKER ||
+        asciiAt(bytes, lengthOffset + 2, EXIF_IDENTIFIER.length) !== EXIF_IDENTIFIER
+      ) {
+        return undefined
+      }
+      return readTiffAxisSwap(
+        bytes,
+        lengthOffset + 2 + EXIF_IDENTIFIER.length,
+        lengthOffset + segmentLength
+      )
+    }) ?? 'unknown'
+  )
+}
+
+function readPngAxisSwap(bytes: Uint8Array): RasterImageAxisSwap {
+  const view = viewOf(bytes)
+  let offset = 8
+  while (offset + 8 <= bytes.byteLength) {
+    const chunkLength = view.getUint32(offset)
+    const chunkType = asciiAt(bytes, offset + 4, 4)
+    const data = offset + 8
+    if (chunkType === PNG_EXIF_CHUNK) {
+      return data + chunkLength <= bytes.byteLength
+        ? readTiffAxisSwap(bytes, data, data + chunkLength)
+        : 'unknown'
+    }
+    // Chromium only applies an eXIf chunk it saw ahead of the image data; a trailing one is inert.
+    if (chunkType === PNG_IMAGE_DATA_CHUNK) {
+      return 'unswapped'
+    }
+    offset = data + chunkLength + 4
+  }
+  return 'unknown'
+}
+
+function readWebpAxisSwap(bytes: Uint8Array): RasterImageAxisSwap {
+  // Only an extended container carries metadata, and its EXIF chunk trails the image data rather
+  // than the header we decode — so the flag is all we get, and it only tells us we cannot know.
+  const chunkType = asciiAt(bytes, 12, 4)
+  // A prefix that stopped before the first chunk never showed us whether this is the extended
+  // container that can carry EXIF at all.
+  if (chunkType === '') {
+    return 'unknown'
+  }
+  if (chunkType !== 'VP8X') {
+    return 'unswapped'
+  }
+  const flags = bytes[20]
+  if (flags === undefined) {
+    return 'unknown'
+  }
+  return (flags & WEBP_EXIF_FLAG) === 0 ? 'unswapped' : 'unknown'
+}
+
+/** Whether a browser will render the encoded axes swapped, read without decoding the image. */
+export function readRasterImageAxisSwap(bytes: Uint8Array): RasterImageAxisSwap {
+  if (bytes[0] === 137 && asciiAt(bytes, 1, 3) === 'PNG') {
+    return readPngAxisSwap(bytes)
+  }
+  if (bytes[0] === 0xff && bytes[1] === 0xd8) {
+    return readJpegAxisSwap(bytes)
+  }
+  if (asciiAt(bytes, 0, 4) === 'RIFF' && asciiAt(bytes, 8, 4) === 'WEBP') {
+    return readWebpAxisSwap(bytes)
+  }
+  // GIF, BMP and ICO have no orientation record, so their encoded axes are the rendered ones.
+  return 'unswapped'
+}
+
+/** Encoded size as the browser will report it, or null when the orientation stayed unknown. */
+export function applyRasterImageAxisSwap(
+  dimensions: RasterImageDimensions,
+  swap: RasterImageAxisSwap
+): RasterImageDimensions | null {
+  if (swap === 'unknown') {
+    return null
+  }
+  return swap === 'swapped' ? { width: dimensions.height, height: dimensions.width } : dimensions
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​531 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​527 |
| Prod | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​431 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​69 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​362 |

<!-- /orca-pr-loc -->

> **Draft.** 5 adversarial loops, 1 blocker outstanding.

## Origin, and an important correction

@mikeascendx (Windows, 1.4.188, `oom`) wrote: *"I just click the image generated by codex and it was crashed"*.

**The causal link is unproven, and this PR does not claim it.** An independent reviewer consulted `gone-time-system-memory.ts` — the field built expressly to separate *"renderer grew huge"* from *"machine out of memory"*. Across all 76 reports in the batch:

```
systemMemorySwapFreeMB < 2000 MB:  oom     13/14  (median 455 MB, min 30)
                                   killed   0/15  (Windows)
```

So the `oom` cluster correlates with **machine-level memory pressure**, not with a renderer that ballooned. **This does not fix those 14 reports.**

## What it does fix

The inline image had **no definite box before `onLoad`**, so it laid out at natural resolution first — the surface inner class `h-max min-h-full w-max min-w-full items-center p-4`. A large agent-generated image forced a full-resolution layout and decode before any constraint applied. Measured: the pre-load layout box shrinks from **6000×4000** to the constrained size, at a cost of 1.2-1.7 µs of header parsing on a path that already costs 32-161 ms.

Justified on layout and decode cost, not on the crash.

## Outstanding

**Blocker:** `natural` is labelled *"Size a browser reports as naturalWidth/naturalHeight"* but is derived from `readRasterImageDimensions`, whose ICO branch does not match that contract — so the field can carry a value the label says it cannot.