### PR TITLE
draft(terminal): tell the user why a new terminal did not open

### DIFF
--- a/src/main/ipc/runtime-environment-connectivity-handlers.ts
+++ b/src/main/ipc/runtime-environment-connectivity-handlers.ts
@@ -3,7 +3,8 @@ import {
   addEnvironmentFromPairingCode,
   listEnvironments,
   removeEnvironment,
-  resolveEnvironment
+  resolveEnvironment,
+  RuntimeEnvironmentStoreError
 } from '../../shared/runtime-environment-store'
 import {
   redactRuntimeEnvironment,
@@ -26,18 +27,33 @@ import {
 
 const manuallyDisconnectedEnvironmentIds = new Set<string>()
 
-function manuallyDisconnectedResponse(
-  environment: ReturnType<typeof resolveEnvironment>
+function manualDisconnectResponse(
+  environment: ReturnType<typeof resolveEnvironment>,
+  code: 'runtime_manually_disconnected' | 'runtime_manually_disconnected_after_reply'
 ): RuntimeRpcResponse<never> {
   return {
     id: 'runtime.manualDisconnect',
     ok: false,
-    error: {
-      code: 'runtime_manually_disconnected',
-      message: 'Runtime environment is manually disconnected.'
-    },
+    error: { code, message: 'Runtime environment is manually disconnected.' },
     _meta: { runtimeId: environment.runtimeId }
   }
+}
+
+/** The call never left this process, so whatever it asked for definitely did not happen. */
+function manuallyDisconnectedResponse(
+  environment: ReturnType<typeof resolveEnvironment>
+): RuntimeRpcResponse<never> {
+  return manualDisconnectResponse(environment, 'runtime_manually_disconnected')
+}
+
+/**
+ * Discarding a reply the runtime already sent is not the same as refusing to dispatch: the discarded
+ * reply may have been `ok:true`, so callers must read this as "outcome unknown", not "did not happen".
+ */
+function manuallyDisconnectedAfterReplyResponse(
+  environment: ReturnType<typeof resolveEnvironment>
+): RuntimeRpcResponse<never> {
+  return manualDisconnectResponse(environment, 'runtime_manually_disconnected_after_reply')
 }
 
 export function isRuntimeEnvironmentManuallyDisconnected(environmentId: string): boolean {
@@ -161,7 +177,7 @@ function registerPassiveStatusHandler(getUserDataPath: () => string): void {
         args.timeoutMs
       )
       return isRuntimeEnvironmentManuallyDisconnected(environment.id)
-        ? manuallyDisconnectedResponse(environment)
+        ? manuallyDisconnectedAfterReplyResponse(environment)
         : response
     }
   )
@@ -186,6 +202,19 @@ function runtimeEnvironmentCallFailure(
   }
 }
 
+/**
+ * Electron IPC drops the error code on a rejection, so a selector the main process already refused
+ * would reach the renderer as an unclassifiable string it could only treat as "outcome unknown".
+ */
+function runtimeEnvironmentSelectorFailure(
+  method: string,
+  error: unknown
+): RuntimeRpcFailure | null {
+  return error instanceof RuntimeEnvironmentStoreError
+    ? { id: method, ok: false, error: { code: error.code, message: error.message } }
+    : null
+}
+
 function registerPassiveCallHandler(getUserDataPath: () => string): void {
   ipcMain.handle(
     'runtimeEnvironments:call',
@@ -199,7 +228,16 @@ function registerPassiveCallHandler(getUserDataPath: () => string): void {
         expectedEnvironmentPairingRevision?: number
       }
     ): Promise<RuntimeRpcResponse<unknown>> => {
-      const environment = resolveEnvironment(getUserDataPath(), args.selector)
+      let environment: ReturnType<typeof resolveEnvironment>
+      try {
+        environment = resolveEnvironment(getUserDataPath(), args.selector)
+      } catch (error) {
+        const failure = runtimeEnvironmentSelectorFailure(args.method, error)
+        if (failure) {
+          return failure
+        }
+        throw error
+      }
       if (isRuntimeEnvironmentManuallyDisconnected(environment.id)) {
         return manuallyDisconnectedResponse(environment)
       }
@@ -221,7 +259,7 @@ function registerPassiveCallHandler(getUserDataPath: () => string): void {
         throw error
       }
       return isRuntimeEnvironmentManuallyDisconnected(environment.id)
-        ? manuallyDisconnectedResponse(environment)
+        ? manuallyDisconnectedAfterReplyResponse(environment)
         : response
     }
   )

--- a/src/main/ipc/runtime-environments-call-routing.test.ts
+++ b/src/main/ipc/runtime-environments-call-routing.test.ts
@@ -448,6 +448,80 @@ describe('registerRuntimeEnvironmentHandlers', () => {
     }
   )
 
+  it('returns a coded refusal when the selector names no saved environment', async () => {
+    registerRuntimeEnvironmentHandlers(store as never)
+    const call = handler<{ selector: string; method: string }, RuntimeRpcResponse<unknown>>(
+      'runtimeEnvironments:call'
+    )
+
+    // Why: Electron IPC drops the error code on a rejection, so a renderer could not tell this
+    // refusal — the call never left the client — from a reply that was lost in transit.
+    const response = structuredClone(
+      await call(null, { selector: 'env-1', method: 'session.tabs.createTerminal' })
+    )
+    expect(response.ok).toBe(false)
+    if (response.ok === false) {
+      expect(response.error).toEqual({
+        code: 'invalid_argument',
+        message: 'Unknown environment: env-1'
+      })
+    }
+    expect(sendRemoteRuntimeRequestMock).not.toHaveBeenCalled()
+  })
+
+  it('separates a pre-dispatch manual disconnect from one that discards a delivered reply', async () => {
+    registerRuntimeEnvironmentHandlers(store as never)
+    const add = handler<
+      { name: string; pairingCode: string },
+      { environment: { id: string; name: string } }
+    >('runtimeEnvironments:addFromPairingCode')
+    await add(null, { name: 'desk', pairingCode: pairingCode() })
+    const disconnect = handler<{ selector: string }, unknown>('runtimeEnvironments:disconnect')
+    const call = handler<{ selector: string; method: string }, RuntimeRpcResponse<unknown>>(
+      'runtimeEnvironments:call'
+    )
+
+    // Why: the request never left the client, so the terminal definitely was not created.
+    await disconnect(null, { selector: 'desk' })
+    const beforeDispatch = structuredClone(
+      await call(null, { selector: 'desk', method: 'session.tabs.createTerminal' })
+    )
+    expect(beforeDispatch.ok).toBe(false)
+    if (beforeDispatch.ok === false) {
+      expect(beforeDispatch.error.code).toBe('runtime_manually_disconnected')
+    }
+    expect(sendRemoteRuntimeRequestMock).not.toHaveBeenCalled()
+
+    // Why: the discarded reply may have said ok:true, so this outcome is unknown, not a refusal.
+    sendRemoteRuntimeRequestMock.mockImplementation(async (_pairing, method) => {
+      if (method === 'status.get') {
+        return {
+          id: 'status',
+          ok: true,
+          result: { runtimeId: 'runtime-remote', capabilities: [] },
+          _meta: { runtimeId: 'runtime-remote' }
+        }
+      }
+      await disconnect(null, { selector: 'desk' })
+      return {
+        id: 'rpc-1',
+        ok: true,
+        result: { tab: { id: 'host-tab-1' } },
+        _meta: { runtimeId: 'runtime-remote' }
+      }
+    })
+    await handler<{ selector: string }, unknown>('runtimeEnvironments:connect')(null, {
+      selector: 'desk'
+    })
+    const afterReply = structuredClone(
+      await call(null, { selector: 'desk', method: 'session.tabs.createTerminal' })
+    )
+    expect(afterReply.ok).toBe(false)
+    if (afterReply.ok === false) {
+      expect(afterReply.error.code).toBe('runtime_manually_disconnected_after_reply')
+    }
+  })
+
   it('keeps uncoded call failures on the rejected IPC fallback path', async () => {
     registerRuntimeEnvironmentHandlers(store as never)
     sendRemoteRuntimeRequestMock.mockRejectedValue(new Error('shared down'))

--- a/src/renderer/src/components/Terminal.tsx
+++ b/src/renderer/src/components/Terminal.tsx
@@ -190,6 +190,10 @@ import {
 } from './terminal-pane/use-manual-terminal-worktree-parking'
 import { EDITOR_TAB_CONTENT_TYPES, getEditorCmdSaveFileId } from './editor/editor-cmd-save-target'
 import { getClientCreationActionPolicy } from '@/lib/client-creation-action-policy'
+import {
+  reportTerminalCreateOutcome,
+  reportTerminalCreateRejection
+} from '@/lib/terminal-create-routing-outcome'
 import type { WorktreeTabBucketProjection } from '@/lib/worktree-tab-bucket-projection'
 
 const EditorPanel = lazy(() => import('./editor/EditorPanel'))
@@ -1571,10 +1575,14 @@ function Terminal(): React.JSX.Element | null {
           command: shellOverride,
           activate: true
         })
+          .then(reportTerminalCreateOutcome)
+          .catch(reportTerminalCreateRejection)
         return
       }
       if (!shellOverride && targetGroupId) {
         void openNewTerminalTabInActiveWorkspace(targetGroupId)
+          .then(reportTerminalCreateOutcome)
+          .catch(reportTerminalCreateRejection)
         return
       }
       const newTab = createTab(activeWorktreeId, undefined, shellOverride)

--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -109,6 +109,7 @@ import {
 } from '@/lib/palette-repo-resolution'
 import { activateBrowserPagePaletteResult } from '@/lib/browser-page-palette-activation'
 import { activateSimulatorTabPaletteResult } from '@/lib/simulator-tab-palette-activation'
+import { reportTerminalCreateOutcome } from '@/lib/terminal-create-routing-outcome'
 import {
   buildSearchableSimulatorTabs,
   searchSimulatorTabs,
@@ -822,6 +823,13 @@ function WorktreeJumpPaletteContent({
   const openNewMarkdownInActiveWorkspace = useAppStore((s) => s.openNewMarkdownInActiveWorkspace)
   const openNewTerminalTabInActiveWorkspace = useAppStore(
     (s) => s.openNewTerminalTabInActiveWorkspace
+  )
+  // Why: quick actions report through thrown errors; the terminal action reports a routing outcome instead.
+  const openNewTerminalTabWithFailureNotice = useCallback(
+    async (groupId: string) => {
+      reportTerminalCreateOutcome(await openNewTerminalTabInActiveWorkspace(groupId))
+    },
+    [openNewTerminalTabInActiveWorkspace]
   )
   const settingsSections = useSettingsNavigationMetadata()
 
@@ -1785,7 +1793,7 @@ function WorktreeJumpPaletteContent({
         activeGroupSnapshot: activeGroupSnapshotRef.current,
         openNewBrowserTab: openNewBrowserTabInActiveWorkspace,
         openNewMarkdownFile: openNewMarkdownInActiveWorkspace,
-        openNewTerminalTab: openNewTerminalTabInActiveWorkspace,
+        openNewTerminalTab: openNewTerminalTabWithFailureNotice,
         openCreateWorkspace: openCreateWorkspaceAction,
         deleteActiveWorkspace: deleteActiveWorkspaceAction,
         openAddQuickCommand: openAddQuickCommandAction
@@ -1796,7 +1804,7 @@ function WorktreeJumpPaletteContent({
       openCreateWorkspaceAction,
       openNewBrowserTabInActiveWorkspace,
       openNewMarkdownInActiveWorkspace,
-      openNewTerminalTabInActiveWorkspace
+      openNewTerminalTabWithFailureNotice
     ]
   )
 
@@ -2731,15 +2739,18 @@ function WorktreeJumpPaletteContent({
           recordFeatureInteraction('cmd-j-quick-action')
         })
         .catch((error: unknown) => {
-          if (!action.id.startsWith('plugin:')) {
-            throw error
-          }
-          toast.error(
-            translate(
-              'auto.components.WorktreeJumpPalette.pluginCommandFailed',
-              'Could not run the plugin command.'
+          if (action.id.startsWith('plugin:')) {
+            toast.error(
+              translate(
+                'auto.components.WorktreeJumpPalette.pluginCommandFailed',
+                'Could not run the plugin command.'
+              )
             )
-          )
+            return
+          }
+          // Why: the rethrow feeds crash breadcrumbs, but the user still needs to learn why nothing opened.
+          toast.error(error instanceof Error ? error.message : String(error))
+          throw error
         })
     },
     [buildQuickActionContext, closeModal, recordFeatureInteraction]

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-launch-actions.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-launch-actions.ts
@@ -6,6 +6,7 @@ import {
   type AiVaultResumeStartup
 } from '@/lib/ai-vault-resume-command'
 import { launchAiVaultSessionInNewTab } from '@/lib/launch-ai-vault-session'
+import { agentLaunchFailureMessage } from '@/lib/terminal-create-routing-outcome'
 import {
   activateAndRevealFolderWorkspace,
   activateAndRevealWorktree
@@ -122,15 +123,17 @@ export function useAiVaultSessionLaunchActions({
           })
           if (launchResult.tabId === null) {
             void launchResult.runtimeLaunch.then((outcome) => {
-              if (outcome.status === 'failed') {
-                toast.error(
-                  outcome.message ||
-                    translate(
-                      'auto.lib.launch.agent.in.new.tab.11cce5cc77',
-                      'Could not launch {{value0}} in a new terminal.',
-                      { value0: agentLabel(session.agent) }
-                    )
-                )
+              const failureMessage = agentLaunchFailureMessage(outcome, agentLabel(session.agent))
+              if (failureMessage) {
+                toast.error(failureMessage)
+                // Why: an unconfirmed launch may already be live on the host, so put the user
+                // where "check the workspace" is actionable instead of inviting a duplicate retry.
+                if (
+                  outcome.status === 'unverifiable' &&
+                  useAppStore.getState().activeWorktreeId !== targetId.worktreeId
+                ) {
+                  activateAiVaultResumeWorkspace(targetId.worktreeId)
+                }
                 return
               }
               if (useAppStore.getState().activeWorktreeId !== targetId.worktreeId) {

--- a/src/renderer/src/components/tab-group/AiVaultSessionDropLayer.tsx
+++ b/src/renderer/src/components/tab-group/AiVaultSessionDropLayer.tsx
@@ -17,6 +17,7 @@ import {
   getAiVaultAgentProviderSession
 } from '@/lib/ai-vault-resume-command'
 import { launchAiVaultSessionInNewTab } from '@/lib/launch-ai-vault-session'
+import { agentLaunchFailureMessage } from '@/lib/terminal-create-routing-outcome'
 import { aiVaultSessionNeedsResumePreparation } from '@/lib/ai-vault-session-resume-preparation'
 import { useAppStore } from '@/store'
 import { resolveDropZone } from './tab-drop-zone'
@@ -270,15 +271,9 @@ export default function AiVaultSessionDropLayer({
           })
           if (launchResult.tabId === null) {
             void launchResult.runtimeLaunch.then((outcome) => {
-              if (outcome.status === 'failed') {
-                toast.error(
-                  outcome.message ||
-                    translate(
-                      'auto.lib.launch.agent.in.new.tab.11cce5cc77',
-                      'Could not launch {{value0}} in a new terminal.',
-                      { value0: payload.agent }
-                    )
-                )
+              const failureMessage = agentLaunchFailureMessage(outcome, payload.agent)
+              if (failureMessage) {
+                toast.error(failureMessage)
                 return
               }
               showQueuedToast()

--- a/src/renderer/src/components/tab-group/useTabGroupCreationCommands.test.tsx
+++ b/src/renderer/src/components/tab-group/useTabGroupCreationCommands.test.tsx
@@ -1,0 +1,85 @@
+// @vitest-environment happy-dom
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TerminalCreateRoutingOutcome } from '@/lib/terminal-create-routing-outcome'
+
+const mocks = vi.hoisted(() => ({
+  toastError: vi.fn(),
+  createWebRuntimeSessionBrowserTab: vi.fn(),
+  createWebRuntimeSessionTerminal: vi.fn(),
+  isWebRuntimeSessionActive: vi.fn(() => false)
+}))
+
+vi.mock('sonner', () => ({ toast: { error: mocks.toastError } }))
+vi.mock('../../runtime/web-runtime-session', () => ({
+  createWebRuntimeSessionBrowserTab: mocks.createWebRuntimeSessionBrowserTab,
+  createWebRuntimeSessionTerminal: mocks.createWebRuntimeSessionTerminal,
+  isWebRuntimeSessionActive: mocks.isWebRuntimeSessionActive
+}))
+
+import { useAppStore } from '../../store'
+import { useTabGroupCreationCommands } from './useTabGroupCreationCommands'
+
+function renderCommands() {
+  return renderHook(() =>
+    useTabGroupCreationCommands({
+      groupId: 'group-1',
+      worktreeId: 'wt-1',
+      worktreeState: { mobileEmulatorEnabled: false } as never
+    })
+  )
+}
+
+function seedTerminalOutcome(outcome: TerminalCreateRoutingOutcome): void {
+  useAppStore.setState({
+    openNewTerminalTabInActiveWorkspace: vi.fn(async () => outcome)
+  })
+}
+
+describe('useTabGroupCreationCommands new terminal failures', () => {
+  beforeEach(() => {
+    mocks.toastError.mockReset()
+  })
+
+  it('tells the user why a routed terminal never opened', async () => {
+    seedTerminalOutcome({
+      status: 'failed',
+      message: 'The workspace is not connected to a remote Orca host.'
+    })
+    const { result } = renderCommands()
+
+    result.current.newTerminalTab()
+    await vi.waitFor(() => expect(mocks.toastError).toHaveBeenCalledTimes(1))
+
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      'Could not open a new terminal. The workspace is not connected to a remote Orca host.'
+    )
+  })
+
+  it('explains unroutable ownership without claiming the host is gone', async () => {
+    seedTerminalOutcome({
+      status: 'unroutable',
+      message: 'Orca cannot tell which execution host owns this workspace.'
+    })
+    const { result } = renderCommands()
+
+    result.current.newTerminalTab()
+    await vi.waitFor(() => expect(mocks.toastError).toHaveBeenCalledTimes(1))
+
+    expect(mocks.toastError.mock.calls[0]?.[0]).not.toMatch(/\b(exited|dead|stopped|offline)\b/i)
+  })
+
+  it('stays silent when the terminal opened or no workspace was active', async () => {
+    for (const outcome of [
+      { status: 'created' },
+      { status: 'no-active-workspace' }
+    ] as TerminalCreateRoutingOutcome[]) {
+      seedTerminalOutcome(outcome)
+      const { result } = renderCommands()
+      result.current.newTerminalTab()
+      await Promise.resolve()
+    }
+
+    await vi.waitFor(() => expect(mocks.toastError).not.toHaveBeenCalled())
+  })
+})

--- a/src/renderer/src/components/tab-group/useTabGroupCreationCommands.ts
+++ b/src/renderer/src/components/tab-group/useTabGroupCreationCommands.ts
@@ -15,6 +15,10 @@ import { buildDuplicatedBrowserTabOptions } from '@/lib/duplicate-browser-tab-op
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { browserWorkspaceHasRemoteOwner } from '@/runtime/remote-browser-tab-ownership'
 import { getClientCreationActionPolicy } from '@/lib/client-creation-action-policy'
+import {
+  reportTerminalCreateOutcome,
+  reportTerminalCreateRejection
+} from '@/lib/terminal-create-routing-outcome'
 import type { TabGroupWorktreeSnapshot } from './useTabGroupItemProjections'
 
 export function recordTerminalTabGroupSplit(createdTerminal: TerminalTab | null | undefined): void {
@@ -145,6 +149,8 @@ export function useTabGroupCreationCommands({
     },
     newTerminalTab: () => {
       void openNewTerminalTabInActiveWorkspace(groupId)
+        .then(reportTerminalCreateOutcome)
+        .catch(reportTerminalCreateRejection)
     },
     newTerminalWithShell: (shellOverride: string) => {
       void (async () => {
@@ -156,7 +162,12 @@ export function useTabGroupCreationCommands({
           command: shellOverride,
           activate: true
         })
-        if (outcome.status === 'created' || isWebRuntimeSessionActive(environmentId)) {
+        if (outcome.status === 'created') {
+          return
+        }
+        // Why: an owning runtime keeps ownership on failure (no local fallback), so say why nothing opened.
+        if (isWebRuntimeSessionActive(environmentId)) {
+          reportTerminalCreateOutcome(outcome)
           return
         }
         const terminal = createTab(worktreeId, groupId, shellOverride)

--- a/src/renderer/src/hooks/ipc-events/tab-lifecycle-ipc-bridge.ts
+++ b/src/renderer/src/hooks/ipc-events/tab-lifecycle-ipc-bridge.ts
@@ -1,5 +1,6 @@
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { reportTerminalCreateOutcome } from '@/lib/terminal-create-routing-outcome'
 import {
   createWebRuntimeSessionTerminal,
   isWebRuntimeSessionActive
@@ -54,7 +55,12 @@ export function registerTabLifecycleIpcBridge(unsubs: (() => void)[]): void {
           environmentId,
           activate: true
         })
-        if (outcome.status === 'created' || isWebRuntimeSessionActive(environmentId)) {
+        if (outcome.status === 'created') {
+          return
+        }
+        // Why: an owning runtime keeps ownership on failure (no local fallback), so say why nothing opened.
+        if (isWebRuntimeSessionActive(environmentId)) {
+          reportTerminalCreateOutcome(outcome)
           return
         }
         const newTab = store.createTab(worktreeId)

--- a/src/renderer/src/hooks/ipc-events/tab-lifecycle-new-terminal-failure.test.ts
+++ b/src/renderer/src/hooks/ipc-events/tab-lifecycle-new-terminal-failure.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  toastError: vi.fn(),
+  createWebRuntimeSessionTerminal: vi.fn(),
+  isWebRuntimeSessionActive: vi.fn(() => true),
+  getRuntimeEnvironmentIdForWorktree: vi.fn(() => 'runtime-1' as string | null),
+  createTab: vi.fn(() => ({ id: 'tab-1' }))
+}))
+
+vi.mock('sonner', () => ({ toast: { error: mocks.toastError } }))
+vi.mock('@/runtime/web-runtime-session', () => ({
+  createWebRuntimeSessionTerminal: mocks.createWebRuntimeSessionTerminal,
+  isWebRuntimeSessionActive: mocks.isWebRuntimeSessionActive
+}))
+vi.mock('@/lib/worktree-runtime-owner', () => ({
+  getRuntimeEnvironmentIdForWorktree: mocks.getRuntimeEnvironmentIdForWorktree
+}))
+vi.mock('@/lib/focus-terminal-tab-surface', () => ({ focusTerminalTabSurface: vi.fn() }))
+vi.mock('@/lib/floating-workspace-terminal-actions', () => ({
+  createFloatingWorkspaceTerminalTab: vi.fn(),
+  isEmptyFloatingWorkspacePanelVisible: () => false,
+  isFloatingWorkspacePanelFocused: () => false,
+  resolveFloatingWorkspaceBrowserWorkspaceId: () => null,
+  switchFloatingWorkspaceTab: vi.fn()
+}))
+
+import { useAppStore } from '../../store'
+import { registerTabLifecycleIpcBridge } from './tab-lifecycle-ipc-bridge'
+
+function registerAndCaptureNewTerminalHandler(): () => void {
+  let handler: () => void = () => {}
+  const noopUnsubscribe = (): void => {}
+  const listen = (): (() => void) => noopUnsubscribe
+  ;(window as unknown as { api: unknown }).api = {
+    ui: {
+      onNewTerminalTab: (callback: () => void) => {
+        handler = callback
+        return noopUnsubscribe
+      },
+      onCloseActiveTab: listen,
+      onCloseFloatingItem: listen,
+      onSelectFloatingIndex: listen,
+      onSwitchTab: listen,
+      onSwitchTabAcrossAllTypes: listen,
+      onSwitchRecentTab: listen,
+      onSwitchTerminalTab: listen
+    }
+  }
+  registerTabLifecycleIpcBridge([])
+  return () => handler()
+}
+
+describe('menu New Terminal Tab failures', () => {
+  beforeEach(() => {
+    mocks.toastError.mockReset()
+    mocks.createTab.mockClear()
+    mocks.isWebRuntimeSessionActive.mockReturnValue(true)
+    useAppStore.setState({ activeWorktreeId: 'wt-1', createTab: mocks.createTab as never })
+  })
+
+  it('explains why the owning runtime opened nothing', async () => {
+    mocks.createWebRuntimeSessionTerminal.mockResolvedValue({
+      status: 'failed',
+      message: 'The workspace is not connected to a remote Orca host.'
+    })
+
+    registerAndCaptureNewTerminalHandler()()
+    await vi.waitFor(() => expect(mocks.toastError).toHaveBeenCalledTimes(1))
+
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      'Could not open a new terminal. The workspace is not connected to a remote Orca host.'
+    )
+    expect(mocks.createTab).not.toHaveBeenCalled()
+  })
+
+  it('keeps the silent local fallback when no runtime owns the workspace', async () => {
+    mocks.createWebRuntimeSessionTerminal.mockResolvedValue({
+      status: 'failed',
+      message: 'The workspace is not connected to a remote Orca host.'
+    })
+    mocks.isWebRuntimeSessionActive.mockReturnValue(false)
+
+    registerAndCaptureNewTerminalHandler()()
+    await vi.waitFor(() => expect(mocks.createTab).toHaveBeenCalledTimes(1))
+
+    expect(mocks.toastError).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -16835,5 +16835,13 @@
   },
   "quickOpen": {
     "moreMatchesAvailable": "More matches may be available. Refine your search to narrow the results."
+  },
+  "terminalCreation": {
+    "failed": "Could not open a new terminal. {{message}}",
+    "unverified": "Orca could not confirm whether the new terminal opened. {{message}} Check the workspace before trying again.",
+    "unverifiedAgentLaunch": "Orca could not confirm whether {{agent}} launched in a new terminal. {{message}} Check the workspace before trying again.",
+    "ambiguousOwner": "More than one execution host claims this workspace, so Orca cannot tell where the terminal belongs. Select the workspace host explicitly, then try again.",
+    "unknownOwner": "Orca cannot tell which execution host owns this workspace, so it has nowhere to open the terminal. The host may still be connecting or out of contact; reopen the workspace and try again.",
+    "webClientNeedsPairedRuntime": "This workspace is not routed to a paired runtime, and the web client cannot open a terminal on the local machine. Pair its runtime or open the workspace in the Orca desktop app."
   }
 }

--- a/src/renderer/src/lib/folder-workspace-runtime-owner.ts
+++ b/src/renderer/src/lib/folder-workspace-runtime-owner.ts
@@ -134,11 +134,17 @@ export function getExplicitRuntimeEnvironmentIdForFolderWorkspace(
   return getRestoredRuntimeHostForFolderWorkspace(state, folderWorkspaceId)?.environmentId ?? null
 }
 
-export function getExecutionHostIdForFolderWorkspace(
+type FolderWorkspaceExecutionHost = {
+  hostId: ExecutionHostId
+  /** False when `local` is only the last-resort default and nothing actually named an owner. */
+  named: boolean
+}
+
+function resolveFolderWorkspaceExecutionHost(
   state: FolderWorkspaceRuntimeOwnerState,
   folderWorkspaceId: string,
   executionHostId?: ExecutionHostId
-): ExecutionHostId {
+): FolderWorkspaceExecutionHost {
   const preferredHostId = getPreferredFolderExecutionHostId(
     state,
     folderWorkspaceId,
@@ -150,19 +156,44 @@ export function getExecutionHostIdForFolderWorkspace(
     folderWorkspace?.executionHostId ?? projectGroup?.executionHostId
   )
   if (parsed) {
-    return parsed.id
+    return { hostId: parsed.id, named: true }
   }
   const connectionId = folderWorkspace?.connectionId?.trim() || projectGroup?.connectionId?.trim()
   if (connectionId) {
-    return toSshExecutionHostId(connectionId)
-  }
-  if (preferredHostId && folderWorkspace) {
-    return preferredHostId
+    return { hostId: toSshExecutionHostId(connectionId), named: true }
   }
   const restoredRuntimeHost = getRestoredRuntimeHostForFolderWorkspace(state, folderWorkspaceId)
-  if (restoredRuntimeHost) {
-    return restoredRuntimeHost.id
+  const focusedEnvironmentId = getSingleFocusedRuntimeEnvironmentId(state)
+  if (preferredHostId && folderWorkspace) {
+    // Why: `local` is exactly what folderWorkspaceToWorktree defaults to when a row names nothing,
+    // and a sidebar click records that default as the active host — so it is not owner evidence.
+    const preferenceNamesOwner = parseExecutionHostId(preferredHostId)?.kind !== 'local'
+    return {
+      hostId: preferredHostId,
+      named: preferenceNamesOwner || Boolean(restoredRuntimeHost) || Boolean(focusedEnvironmentId)
+    }
   }
-  const environmentId = getSingleFocusedRuntimeEnvironmentId(state)
-  return environmentId ? `runtime:${encodeURIComponent(environmentId)}` : 'local'
+  if (restoredRuntimeHost) {
+    return { hostId: restoredRuntimeHost.id, named: true }
+  }
+  return focusedEnvironmentId
+    ? { hostId: `runtime:${encodeURIComponent(focusedEnvironmentId)}`, named: true }
+    : { hostId: 'local', named: false }
+}
+
+export function getExecutionHostIdForFolderWorkspace(
+  state: FolderWorkspaceRuntimeOwnerState,
+  folderWorkspaceId: string,
+  executionHostId?: ExecutionHostId
+): ExecutionHostId {
+  return resolveFolderWorkspaceExecutionHost(state, folderWorkspaceId, executionHostId).hostId
+}
+
+/** Whether any row, session partition or focused runtime actually named this folder's host. */
+export function hasNamedFolderWorkspaceExecutionHost(
+  state: FolderWorkspaceRuntimeOwnerState,
+  folderWorkspaceId: string,
+  executionHostId?: ExecutionHostId
+): boolean {
+  return resolveFolderWorkspaceExecutionHost(state, folderWorkspaceId, executionHostId).named
 }

--- a/src/renderer/src/lib/launch-agent-web-host-tab.test.ts
+++ b/src/renderer/src/lib/launch-agent-web-host-tab.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AgentStartupPlan } from '@/lib/tui-agent-startup'
+
+const mocks = vi.hoisted(() => ({
+  createWebRuntimeSessionTerminal: vi.fn(),
+  toastError: vi.fn(),
+  setActiveTabType: vi.fn(),
+  closeTab: vi.fn()
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => ({
+      tabsByWorktree: {},
+      closeTab: mocks.closeTab,
+      setActiveTabType: mocks.setActiveTabType
+    })
+  }
+}))
+vi.mock('sonner', () => ({ toast: { error: mocks.toastError } }))
+vi.mock('@/runtime/web-runtime-session', () => ({
+  createWebRuntimeAgentSessionTerminal: vi.fn(),
+  createWebRuntimeAgentSessionTerminalWithLaunchDraft: vi.fn(),
+  createWebRuntimeSessionTerminal: mocks.createWebRuntimeSessionTerminal,
+  isWebTerminalSurfaceTabId: vi.fn(() => false)
+}))
+
+const launch = {
+  agent: 'claude' as const,
+  worktreeId: 'wt-1',
+  environmentId: 'env-1',
+  groupId: 'group-1',
+  startupPlan: { launchCommand: 'claude' } as AgentStartupPlan,
+  prompt: '',
+  promptDelivery: 'auto-submit' as const,
+  pastePromptAfterReady: null,
+  submitPastedPrompt: false
+}
+
+describe('launchAgentInWebHostTab unconfirmed launches', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not report an unverifiable launch as a definite failure', async () => {
+    mocks.createWebRuntimeSessionTerminal.mockResolvedValue({
+      status: 'unverifiable',
+      message: 'relay connection reset'
+    })
+    const { launchAgentInWebHostTab } = await import('./launch-agent-web-host-tab')
+
+    const result = await launchAgentInWebHostTab(launch)
+
+    expect(result).toEqual({ delivered: false, failureNotified: true })
+    const message = mocks.toastError.mock.calls[0]?.[0] as string
+    expect(message).toMatch(/could not confirm/i)
+    expect(message).toMatch(/relay connection reset/)
+    expect(message).toMatch(/before trying again/i)
+    expect(message).not.toMatch(/^Could not launch/i)
+  })
+
+  it('still reports a delivered refusal as a definite failure', async () => {
+    mocks.createWebRuntimeSessionTerminal.mockResolvedValue({
+      status: 'failed',
+      message: 'worktree is required'
+    })
+    const { launchAgentInWebHostTab } = await import('./launch-agent-web-host-tab')
+
+    await launchAgentInWebHostTab(launch)
+
+    expect(mocks.toastError).toHaveBeenCalledWith('worktree is required')
+  })
+})

--- a/src/renderer/src/lib/launch-agent-web-host-tab.ts
+++ b/src/renderer/src/lib/launch-agent-web-host-tab.ts
@@ -10,7 +10,7 @@ import type { AgentStartupPlan } from '@/lib/tui-agent-startup'
 import type { Tab } from '../../../shared/tab-types'
 import type { TuiAgent } from '../../../shared/tui-agent'
 import type { AgentPromptDelivery } from '../../../shared/agent-session-host-authority'
-import { translate } from '@/i18n/i18n'
+import { agentLaunchFailureMessage } from '@/lib/terminal-create-routing-outcome'
 import { toAgentLaunchPreferences } from '@/runtime/agent-session-create-operation'
 
 function removeStaleLocalAgentTabsForWebHostLaunch(worktreeId: string): void {
@@ -104,15 +104,9 @@ export function launchAgentInWebHostTab(args: {
     // Why: created means the host accepted the launch, not that a local tab
     // exists; keep pruning stale local rows until the snapshot mirrors.
     removeStaleLocalAgentTabsForWebHostLaunch(worktreeId)
-    if (outcome.status === 'failed') {
-      toast.error(
-        outcome.message ||
-          translate(
-            'auto.lib.launch.agent.in.new.tab.11cce5cc77',
-            'Could not launch {{value0}} in a new terminal.',
-            { value0: agent }
-          )
-      )
+    const failureMessage = agentLaunchFailureMessage(outcome, agent)
+    if (failureMessage) {
+      toast.error(failureMessage)
       return { delivered: false, failureNotified: true }
     }
     useAppStore.getState().setActiveTabType('terminal')

--- a/src/renderer/src/lib/terminal-create-routing-outcome.test.ts
+++ b/src/renderer/src/lib/terminal-create-routing-outcome.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import {
+  terminalCreateFailureMessage,
+  unpairedWebClientWorkspaceOutcome,
+  unroutableWorkspaceOutcome
+} from './terminal-create-routing-outcome'
+
+// Why: the SSH execution boundary forbids reporting loss of contact as a definite outcome.
+const DEFINITE_FAILURE_RE = /could not open a new terminal/i
+
+describe('terminalCreateFailureMessage', () => {
+  it('stays silent for created and no-active-workspace', () => {
+    expect(terminalCreateFailureMessage({ status: 'created' })).toBeNull()
+    expect(terminalCreateFailureMessage({ status: 'no-active-workspace' })).toBeNull()
+  })
+
+  it('does not claim a definite failure when the create was never confirmed', () => {
+    const message = terminalCreateFailureMessage({
+      status: 'unverifiable',
+      message: 'The paired runtime did not confirm whether the terminal was created.'
+    })
+
+    expect(message).not.toBeNull()
+    expect(message).not.toMatch(DEFINITE_FAILURE_RE)
+    expect(message).toContain(
+      'The paired runtime did not confirm whether the terminal was created.'
+    )
+  })
+
+  it('states a definite failure only when the host refused the create', () => {
+    expect(
+      terminalCreateFailureMessage({
+        status: 'failed',
+        message: 'worktree is required'
+      })
+    ).toMatch(DEFINITE_FAILURE_RE)
+    expect(terminalCreateFailureMessage(unroutableWorkspaceOutcome({ kind: 'missing' }))).toMatch(
+      DEFINITE_FAILURE_RE
+    )
+    expect(terminalCreateFailureMessage(unpairedWebClientWorkspaceOutcome())).toMatch(
+      DEFINITE_FAILURE_RE
+    )
+  })
+})

--- a/src/renderer/src/lib/terminal-create-routing-outcome.ts
+++ b/src/renderer/src/lib/terminal-create-routing-outcome.ts
@@ -1,0 +1,102 @@
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
+import type { WorktreeOperationRouteResolution } from './worktree-operation-route'
+import type { WebRuntimeTerminalCreateOutcome } from '@/runtime/web-runtime-session'
+
+/**
+ * `unroutable` means Orca could not pick or reach an owner for the workspace. Per
+ * docs/reference/ssh-execution-boundary.md that is never evidence the host or its
+ * processes ended, so the copy below stays in unknown-ownership terms.
+ */
+export type TerminalCreateRoutingOutcome =
+  | WebRuntimeTerminalCreateOutcome
+  | { status: 'unroutable'; message: string }
+  | { status: 'no-active-workspace' }
+
+export function unroutableWorkspaceOutcome(
+  resolution: Exclude<WorktreeOperationRouteResolution, { kind: 'resolved' }>
+): TerminalCreateRoutingOutcome {
+  return {
+    status: 'unroutable',
+    message:
+      resolution.kind === 'ambiguous'
+        ? translate(
+            'terminalCreation.ambiguousOwner',
+            'More than one execution host claims this workspace, so Orca cannot tell where the terminal belongs. Select the workspace host explicitly, then try again.'
+          )
+        : translate(
+            'terminalCreation.unknownOwner',
+            'Orca cannot tell which execution host owns this workspace, so it has nowhere to open the terminal. The host may still be connecting or out of contact; reopen the workspace and try again.'
+          )
+  }
+}
+
+export function unpairedWebClientWorkspaceOutcome(): TerminalCreateRoutingOutcome {
+  return {
+    status: 'unroutable',
+    message: translate(
+      'terminalCreation.webClientNeedsPairedRuntime',
+      'This workspace is not routed to a paired runtime, and the web client cannot open a terminal on the local machine. Pair its runtime or open the workspace in the Orca desktop app.'
+    )
+  }
+}
+
+/**
+ * Agent launches share the create verdicts, so an unconfirmed one must keep the "may exist" framing:
+ * a definite-failure toast invites a retry that duplicates a live agent on the same worktree.
+ */
+export function agentLaunchFailureMessage(
+  outcome: WebRuntimeTerminalCreateOutcome,
+  agentLabel: string
+): string | null {
+  if (outcome.status === 'created') {
+    return null
+  }
+  const message =
+    outcome.message ||
+    translate(
+      'auto.lib.launch.agent.in.new.tab.11cce5cc77',
+      'Could not launch {{value0}} in a new terminal.',
+      { value0: agentLabel }
+    )
+  return outcome.status === 'unverifiable'
+    ? translate(
+        'terminalCreation.unverifiedAgentLaunch',
+        'Orca could not confirm whether {{agent}} launched in a new terminal. {{message}} Check the workspace before trying again.',
+        { agent: agentLabel, message }
+      )
+    : message
+}
+
+/** Null for outcomes the user asked for and got, plus the benign no-active-workspace no-op. */
+export function terminalCreateFailureMessage(outcome: TerminalCreateRoutingOutcome): string | null {
+  if (outcome.status === 'created' || outcome.status === 'no-active-workspace') {
+    return null
+  }
+  if (outcome.status === 'unverifiable') {
+    // Why: the host may have created the PTY, so a definite-failure toast invites a duplicate retry.
+    return translate(
+      'terminalCreation.unverified',
+      'Orca could not confirm whether the new terminal opened. {{message}} Check the workspace before trying again.',
+      { message: outcome.message }
+    )
+  }
+  return translate('terminalCreation.failed', 'Could not open a new terminal. {{message}}', {
+    message: outcome.message
+  })
+}
+
+export function reportTerminalCreateOutcome(outcome: TerminalCreateRoutingOutcome): void {
+  const message = terminalCreateFailureMessage(outcome)
+  if (message) {
+    toast.error(message)
+  }
+}
+
+export function reportTerminalCreateRejection(error: unknown): void {
+  toast.error(
+    translate('terminalCreation.failed', 'Could not open a new terminal. {{message}}', {
+      message: error instanceof Error ? error.message : String(error)
+    })
+  )
+}

--- a/src/renderer/src/lib/worktree-operation-route.ts
+++ b/src/renderer/src/lib/worktree-operation-route.ts
@@ -12,6 +12,7 @@ import { resolveExplicitWorktreeOperationRouteResult } from './worktree-operatio
 import {
   findFolderWorkspaceOwner,
   getExecutionHostIdForFolderWorkspace,
+  hasNamedFolderWorkspaceExecutionHost,
   type FolderWorkspaceRuntimeOwnerState
 } from './folder-workspace-runtime-owner'
 
@@ -110,6 +111,49 @@ export function resolveWorktreeOperationRouteForHost(
   return resolution.kind === 'resolved' ? resolution.route : null
 }
 
+function selectedHostRuntimeOwnerEnvironmentIds(
+  state: WorktreeOperationRouteState,
+  worktreeId: string,
+  sshHostId: `ssh:${string}`
+): Set<string> {
+  const environmentIds = new Set<string>()
+  for (const owner of ownerRecordsOnHost(state, worktreeId, sshHostId)) {
+    const resolution = resolveExactWorktreeRoute(state, owner)
+    if (resolution.kind === 'resolved' && resolution.route.runtimeEnvironmentId) {
+      environmentIds.add(resolution.route.runtimeEnvironmentId)
+    }
+  }
+  return environmentIds
+}
+
+/**
+ * Why a resolved route carries no runtime owner. `resolveSelectedHostRoute` flattens "rival HUBs
+ * claim this host" and "no owner row has landed yet" into the same null, so a caller that cannot
+ * execute locally must not read that null as proof no runtime is paired.
+ */
+export function resolveRouteRuntimeOwner(
+  state: WorktreeOperationRouteState,
+  worktreeId: string,
+  route: WorktreeOperationRoute
+): WorktreeOperationRouteResolution {
+  const host = parseExecutionHostId(route.executionHostId)
+  if (route.runtimeEnvironmentId) {
+    return { kind: 'resolved', route }
+  }
+  if (host?.kind !== 'ssh') {
+    // Why: a folder route reads `local` both when a row named it and when nothing named anything
+    // (rows predating executionHostId/connectionId); only the first is evidence of an owner.
+    const workspaceScope = parseWorkspaceKey(worktreeId)
+    const namedFolderHost =
+      workspaceScope?.type !== 'folder' ||
+      hasNamedFolderWorkspaceExecutionHost(state, workspaceScope.folderWorkspaceId)
+    return namedFolderHost ? { kind: 'resolved', route } : { kind: 'missing' }
+  }
+  return selectedHostRuntimeOwnerEnvironmentIds(state, worktreeId, host.id).size > 1
+    ? { kind: 'ambiguous' }
+    : { kind: 'missing' }
+}
+
 function resolveSelectedHostRoute(
   state: WorktreeOperationRouteState,
   worktreeId: string,
@@ -122,13 +166,7 @@ function resolveSelectedHostRoute(
   if (selectedHost.kind !== 'ssh') {
     return { executionHostId: selectedHost.id, runtimeEnvironmentId: null }
   }
-  const environmentIds = new Set<string>()
-  for (const owner of ownerRecordsOnHost(state, worktreeId, selectedHost.id)) {
-    const resolution = resolveExactWorktreeRoute(state, owner)
-    if (resolution.kind === 'resolved' && resolution.route.runtimeEnvironmentId) {
-      environmentIds.add(resolution.route.runtimeEnvironmentId)
-    }
-  }
+  const environmentIds = selectedHostRuntimeOwnerEnvironmentIds(state, worktreeId, selectedHost.id)
   const environmentId = environmentIds.values().next().value
   return {
     executionHostId: selectedHost.id,

--- a/src/renderer/src/runtime/web-runtime-session-terminal-create-verdict.test.ts
+++ b/src/renderer/src/runtime/web-runtime-session-terminal-create-verdict.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createWebRuntimeSessionTerminal } from './web-runtime-session'
+import { resetWebSessionCloseIntentForTests } from './web-session-close-intent'
+import {
+  WORKTREE_ID,
+  makeSnapshot,
+  resetTerminalCreateEnvironment,
+  stubTerminalCreateEnvironment
+} from './web-runtime-session-test-harness'
+
+const mocks = vi.hoisted(() => ({
+  getState: vi.fn(),
+  setState: vi.fn(),
+  subscribe: vi.fn(),
+  setActiveWorktree: vi.fn(),
+  createBrowserTab: vi.fn(),
+  closeEmptyGroup: vi.fn(),
+  moveUnifiedTabToGroup: vi.fn(),
+  setRemoteBrowserPageHandle: vi.fn(),
+  focusBrowserTabInWorktree: vi.fn(),
+  applyWebSessionTabsSnapshot: vi.fn(),
+  decideWebSessionTabsSnapshot: vi.fn(() => ({
+    apply: true,
+    settlesHostMirror: true
+  })),
+  acceptReplayedWebSessionTabsSnapshot: vi.fn(),
+  resolveHostSessionTabIdForWebSessionTab: vi.fn(),
+  trackTerminalPaneSplit: vi.fn(),
+  deliverLaunchPromptToAgentTab: vi.fn(),
+  seedNativeChatLaunchDraftForAgentTab: vi.fn(),
+  getRuntimeEnvironmentIdForWorktree: vi.fn(),
+  hasMaterializedWebRuntimeBrowserPage: vi.fn()
+}))
+
+vi.mock('../store', () => ({
+  useAppStore: {
+    getState: mocks.getState,
+    setState: mocks.setState,
+    subscribe: mocks.subscribe
+  }
+}))
+
+vi.mock('./web-session-tabs-sync', () => ({
+  acceptReplayedWebSessionTabsSnapshot: mocks.acceptReplayedWebSessionTabsSnapshot,
+  applyWebSessionTabsSnapshot: mocks.applyWebSessionTabsSnapshot,
+  decideWebSessionTabsSnapshot: mocks.decideWebSessionTabsSnapshot,
+  applyWebSessionTabsStorePatch: (buildPatch: (state: unknown) => unknown) => {
+    mocks.setState(buildPatch)
+    return () => {}
+  },
+  resolveHostSessionTabIdForWebSessionTab: mocks.resolveHostSessionTabIdForWebSessionTab
+}))
+
+vi.mock('@/lib/feature-education-telemetry', () => ({
+  trackTerminalPaneSplit: mocks.trackTerminalPaneSplit
+}))
+
+vi.mock('@/lib/worktree-runtime-owner', () => ({
+  getRuntimeEnvironmentIdForWorktree: mocks.getRuntimeEnvironmentIdForWorktree
+}))
+
+vi.mock('@/lib/agent-launch-prompt-delivery', () => ({
+  deliverLaunchPromptToAgentTab: mocks.deliverLaunchPromptToAgentTab,
+  seedNativeChatLaunchDraftForAgentTab: mocks.seedNativeChatLaunchDraftForAgentTab
+}))
+
+vi.mock('./web-runtime-browser-materialization', () => ({
+  hasMaterializedWebRuntimeBrowserPage: mocks.hasMaterializedWebRuntimeBrowserPage
+}))
+
+afterEach(() => resetWebSessionCloseIntentForTests())
+
+describe('createWebRuntimeSessionTerminal create verdict', () => {
+  beforeEach(() => {
+    stubTerminalCreateEnvironment(mocks)
+  })
+
+  afterEach(() => {
+    resetTerminalCreateEnvironment()
+  })
+
+  it('reports a lost reply as unverifiable rather than a definite failure', async () => {
+    // Why: transport errors reject; the host may already have created the PTY.
+    const runtimeCall = vi.fn().mockRejectedValue(new Error('runtime call timed out'))
+    vi.stubGlobal('window', {
+      api: { runtimeEnvironments: { call: runtimeCall } }
+    })
+
+    const outcome = await createWebRuntimeSessionTerminal({
+      worktreeId: WORKTREE_ID,
+      activate: true
+    })
+
+    expect(outcome).toEqual({
+      status: 'unverifiable',
+      message: 'runtime call timed out'
+    })
+  })
+
+  it('reports a host rejection with a definitive code as failed', async () => {
+    const runtimeCall = vi.fn().mockResolvedValue({
+      id: 'create-terminal',
+      ok: false,
+      error: { code: 'invalid_params', message: 'worktree is required' }
+    })
+    vi.stubGlobal('window', {
+      api: { runtimeEnvironments: { call: runtimeCall } }
+    })
+
+    const outcome = await createWebRuntimeSessionTerminal({
+      worktreeId: WORKTREE_ID,
+      activate: true
+    })
+
+    expect(outcome).toEqual({
+      status: 'failed',
+      message: 'worktree is required'
+    })
+  })
+
+  it('reports a pre-call manual-disconnect envelope as failed, not unverifiable', async () => {
+    // Why: the main handler and both web preload call paths return this envelope BEFORE dispatching,
+    // so the request never left the client and no PTY can exist.
+    const runtimeCall = vi.fn().mockResolvedValue({
+      id: 'runtime.manualDisconnect',
+      ok: false,
+      error: {
+        code: 'runtime_manually_disconnected',
+        message: 'Runtime environment is manually disconnected.'
+      }
+    })
+    vi.stubGlobal('window', {
+      api: { runtimeEnvironments: { call: runtimeCall } }
+    })
+
+    const outcome = await createWebRuntimeSessionTerminal({
+      worktreeId: WORKTREE_ID,
+      activate: true
+    })
+
+    expect(outcome).toEqual({
+      status: 'failed',
+      message: 'Runtime environment is manually disconnected.'
+    })
+  })
+
+  it('reports a post-reply manual-disconnect substitution as unverifiable', async () => {
+    // Why: this envelope replaces a reply the client already received, so the discarded reply may
+    // have been `ok:true` — indistinguishable from a create the host completed.
+    const runtimeCall = vi.fn().mockResolvedValue({
+      id: 'runtime.manualDisconnect',
+      ok: false,
+      error: {
+        code: 'runtime_manually_disconnected_after_reply',
+        message: 'Runtime environment is manually disconnected.'
+      }
+    })
+    vi.stubGlobal('window', {
+      api: { runtimeEnvironments: { call: runtimeCall } }
+    })
+
+    const outcome = await createWebRuntimeSessionTerminal({
+      worktreeId: WORKTREE_ID,
+      activate: true
+    })
+
+    expect(outcome.status).toBe('unverifiable')
+  })
+
+  it('reports a re-wrapped refusal token as failed when the transport dropped the cause', async () => {
+    // Why: Electron IPC/relay re-wrap the reply into a plain message and drop the cause
+    // (runtime-rpc-result.ts), so the code token in the text is the only surviving proof.
+    const runtimeCall = vi
+      .fn()
+      .mockRejectedValue(
+        new Error(
+          "Error invoking remote method 'runtimeEnvironments:call': Error: selector_not_found"
+        )
+      )
+    vi.stubGlobal('window', {
+      api: { runtimeEnvironments: { call: runtimeCall } }
+    })
+
+    const outcome = await createWebRuntimeSessionTerminal({
+      worktreeId: WORKTREE_ID,
+      activate: true
+    })
+
+    expect(outcome.status).toBe('failed')
+  })
+
+  it('still reports created when the host confirmed and only reconciliation failed', async () => {
+    const runtimeCall = vi
+      .fn()
+      .mockResolvedValueOnce({
+        id: 'create-terminal',
+        ok: true,
+        result: {
+          tab: { id: 'host-tab-2::leaf-1', leafId: 'leaf-1' },
+          publicationEpoch: 'epoch-1',
+          snapshotVersion: 2
+        }
+      })
+      .mockRejectedValueOnce(new Error('snapshot refresh timed out'))
+    vi.stubGlobal('window', {
+      api: { runtimeEnvironments: { call: runtimeCall } }
+    })
+    mocks.applyWebSessionTabsSnapshot.mockReturnValue(makeSnapshot())
+
+    const outcome = await createWebRuntimeSessionTerminal({
+      worktreeId: WORKTREE_ID,
+      activate: true
+    })
+
+    expect(outcome).toEqual({ status: 'created' })
+  })
+})

--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -37,7 +37,11 @@ import type { TuiAgent } from '../../../shared/tui-agent'
 import { createBrowserUuid } from '../lib/browser-uuid'
 import { getRuntimeEnvironmentIdForWorktree } from '../lib/worktree-runtime-owner'
 import { useAppStore } from '../store'
-import { hasRuntimeRpcErrorCode, unwrapRuntimeRpcResult } from './runtime-rpc-client'
+import {
+  hasRuntimeRpcErrorCode,
+  RuntimeRpcCallError,
+  unwrapRuntimeRpcResult
+} from './runtime-rpc-client'
 import {
   createAgentSessionCreateOperation,
   withAgentSessionCreateOperationId
@@ -125,6 +129,69 @@ export function isWebRuntimeSessionActive(
 export type WebRuntimeTerminalCreateOutcome =
   | { status: 'created' }
   | { status: 'failed'; message: string }
+  /** The host never confirmed either way, so the PTY may exist. Never report this as a failure. */
+  | { status: 'unverifiable'; message: string }
+
+/**
+ * Reply codes that report the host's own loss of contact with the executor rather than a refusal,
+ * so the create is as unknown as a call that never got a reply at all.
+ */
+const UNVERIFIABLE_TERMINAL_CREATE_CODES: ReadonlySet<string> = new Set([
+  'invalid_runtime_response',
+  // Why: the call paths substitute this envelope for an already-received reply, so it is
+  // indistinguishable from a create the host answered `ok:true` before the disconnect landed. The
+  // plain `runtime_manually_disconnected` code is the pre-dispatch refusal and stays a definite failure.
+  'runtime_manually_disconnected_after_reply',
+  'relay_request_superseded',
+  'remote_runtime_unavailable',
+  'runtime_timeout',
+  'runtime_unavailable',
+  'timeout'
+])
+
+function findRuntimeRpcCallError(error: unknown): RuntimeRpcCallError | null {
+  const seen = new Set<unknown>()
+  let current: unknown = error
+  while (current && typeof current === 'object' && !seen.has(current)) {
+    if (current instanceof RuntimeRpcCallError) {
+      return current
+    }
+    seen.add(current)
+    current = (current as { cause?: unknown }).cause
+  }
+  return null
+}
+
+/**
+ * Refusal codes a cause-dropping transport can only carry as a bare token in the message. Absent
+ * one, the create stays unverifiable — an unreadable error is not evidence the host refused.
+ */
+const DEFINITIVE_TERMINAL_CREATE_FAILURE_CODES = [
+  'capability_unsupported',
+  'forbidden',
+  'invalid_argument',
+  'invalid_params',
+  'method_not_found',
+  'runtime_rpc_queue_overloaded',
+  'selector_ambiguous',
+  'selector_not_found',
+  'unauthorized'
+] as const
+
+/** Only a delivered `ok:false` reply proves the host refused; a lost or timed-out call proves nothing. */
+function classifyTerminalCreateFailure(error: unknown): 'failed' | 'unverifiable' {
+  const reply = findRuntimeRpcCallError(error)
+  if (reply) {
+    return UNVERIFIABLE_TERMINAL_CREATE_CODES.has(reply.code) ? 'unverifiable' : 'failed'
+  }
+  // Why: Electron IPC and relay re-throws re-wrap the reply and drop the cause (runtime-rpc-result.ts),
+  // so a refusal token in the message is the only surviving proof the call was answered.
+  return DEFINITIVE_TERMINAL_CREATE_FAILURE_CODES.some((code) =>
+    hasRuntimeRpcErrorCode(error, code)
+  )
+    ? 'failed'
+    : 'unverifiable'
+}
 
 const DEFINITIVE_BROWSER_CREATE_FAILURE_CODES = [
   'browser_error',
@@ -233,7 +300,7 @@ export async function createWebRuntimeAgentSessionTerminal(
   promptDelivered: boolean
 }> {
   const created = await createWebRuntimeSessionTerminalResult(args)
-  if (created.outcome.status === 'failed' || !created.hostTabId) {
+  if (created.outcome.status !== 'created' || !created.hostTabId) {
     return { outcome: created.outcome, promptDelivered: false }
   }
 
@@ -259,7 +326,7 @@ export async function createWebRuntimeAgentSessionTerminalWithLaunchDraft(
   }
 ): Promise<WebRuntimeTerminalCreateOutcome> {
   const created = await createWebRuntimeSessionTerminalResult(args)
-  if (created.outcome.status !== 'failed' && created.hostTabId) {
+  if (created.outcome.status === 'created' && created.hostTabId) {
     seedNativeChatLaunchDraftForAgentTab({
       tabId: toWebTerminalSurfaceTabId(created.hostTabId),
       agent: args.agent,
@@ -503,7 +570,9 @@ async function createWebRuntimeSessionTerminalResult(
     // Why: once the host accepted creation, reporting failure invites the user
     // to retry with a new operation ID and can duplicate a fresh agent.
     return {
-      outcome: hostCreated ? { status: 'created' } : { status: 'failed', message },
+      outcome: hostCreated
+        ? { status: 'created' }
+        : { status: classifyTerminalCreateFailure(error), message },
       ...(createdTabId ? { hostTabId: createdTabId } : {})
     }
   }

--- a/src/renderer/src/store/terminals/terminal-actions.ts
+++ b/src/renderer/src/store/terminals/terminal-actions.ts
@@ -21,6 +21,7 @@ import type {
   DirectSshPaneRetryResult
 } from '../slices/direct-ssh-terminal-recovery'
 import type { NativeChatLaunchDraft, NativeChatLaunchPrompt } from '@/lib/native-chat-launch-prompt'
+import type { TerminalCreateRoutingOutcome } from '@/lib/terminal-create-routing-outcome'
 import type { AgentStatusWorktreeShutdownReason } from '../slices/agent-status'
 import type {
   TerminalTabCloseReason,
@@ -76,7 +77,8 @@ export type TerminalActions = {
       forceHostRuntime?: boolean
     }
   ) => TerminalTab
-  openNewTerminalTabInActiveWorkspace: (groupId: string) => Promise<void>
+  /** Callers must surface a non-created outcome; a routed creation that fails is otherwise invisible. */
+  openNewTerminalTabInActiveWorkspace: (groupId: string) => Promise<TerminalCreateRoutingOutcome>
   /** Synchronous retirement: provider teardown starts before state removal but is never awaited. */
   closeTab: (
     tabId: string,

--- a/src/renderer/src/store/terminals/terminal-active-workspace-creation.test.ts
+++ b/src/renderer/src/store/terminals/terminal-active-workspace-creation.test.ts
@@ -1,0 +1,461 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import { folderWorkspaceKey } from '../../../../shared/workspace-scope'
+import type { AppState } from '../types'
+import { createTestStore, makeWorktree, seedStore, TEST_REPO } from '../slices/store-test-helpers'
+
+const createWebRuntimeSessionTerminalMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/runtime/web-runtime-session', () => ({
+  createWebRuntimeSessionTerminal: createWebRuntimeSessionTerminalMock
+}))
+
+vi.mock('@/lib/focus-terminal-tab-surface', () => ({
+  focusTerminalTabSurface: vi.fn()
+}))
+
+vi.mock('@/lib/web-client-location', () => ({
+  isWebClientLocation: () =>
+    Boolean((globalThis as { __ORCA_WEB_CLIENT__?: boolean }).__ORCA_WEB_CLIENT__)
+}))
+
+const pairedWebFlag = globalThis as { __ORCA_WEB_CLIENT__?: boolean }
+
+// Why: the SSH execution boundary forbids reporting loss of contact as process death.
+const DEATH_CLAIM_RE = /\b(exited|dead|died|killed|stopped|terminated|crashed|offline)\b/i
+
+function seedActiveWorkspace(store: ReturnType<typeof createTestStore>): void {
+  seedStore(store, {
+    activeWorktreeId: 'wt-1',
+    settings: {
+      activeRuntimeEnvironmentId: 'runtime-1'
+    } as AppState['settings'],
+    worktreesByRepo: {
+      [TEST_REPO.id]: [
+        makeWorktree({
+          id: 'wt-1',
+          repoId: TEST_REPO.id,
+          hostId: 'runtime:runtime-1',
+          runtimeOwnerEnvironmentId: 'runtime-1'
+        })
+      ]
+    },
+    groupsByWorktree: {
+      'wt-1': [{ id: 'group-1', worktreeId: 'wt-1', activeTabId: null, tabOrder: [] }]
+    },
+    activeGroupIdByWorktree: { 'wt-1': 'group-1' }
+  })
+}
+
+describe('openNewTerminalTabInActiveWorkspace routing outcome', () => {
+  beforeEach(() => {
+    createWebRuntimeSessionTerminalMock.mockReset()
+  })
+
+  afterEach(() => {
+    delete pairedWebFlag.__ORCA_WEB_CLIENT__
+  })
+
+  it('reports the owning runtime failure instead of silently doing nothing', async () => {
+    createWebRuntimeSessionTerminalMock.mockResolvedValue({
+      status: 'failed',
+      message: 'The workspace is not connected to a remote Orca host.'
+    })
+    const store = createTestStore()
+    seedActiveWorkspace(store)
+
+    const outcome = await store.getState().openNewTerminalTabInActiveWorkspace('group-1')
+
+    expect(outcome).toEqual({
+      status: 'failed',
+      message: 'The workspace is not connected to a remote Orca host.'
+    })
+    expect(store.getState().tabsByWorktree['wt-1'] ?? []).toEqual([])
+  })
+
+  it('reports unresolved ownership as unroutable without claiming the host is gone', async () => {
+    const store = createTestStore()
+    seedActiveWorkspace(store)
+    store.setState({
+      repos: [
+        { ...TEST_REPO, executionHostId: 'runtime:hub-a' },
+        { ...TEST_REPO, executionHostId: 'runtime:hub-b' }
+      ],
+      worktreesByRepo: {
+        [TEST_REPO.id]: [makeWorktree({ id: 'wt-1', repoId: TEST_REPO.id })]
+      },
+      settings: { activeRuntimeEnvironmentId: 'hub-b' } as AppState['settings']
+    })
+
+    const outcome = await store.getState().openNewTerminalTabInActiveWorkspace('group-1')
+
+    expect(outcome.status).toBe('unroutable')
+    expect(outcome.status === 'unroutable' ? outcome.message : '').not.toMatch(DEATH_CLAIM_RE)
+    expect(createWebRuntimeSessionTerminalMock).not.toHaveBeenCalled()
+  })
+
+  it('reports unroutable when a web client has no paired runtime for the workspace', async () => {
+    pairedWebFlag.__ORCA_WEB_CLIENT__ = true
+    const store = createTestStore()
+    seedActiveWorkspace(store)
+    store.setState({
+      repos: [{ ...TEST_REPO, executionHostId: 'local' }],
+      worktreesByRepo: {
+        [TEST_REPO.id]: [makeWorktree({ id: 'wt-1', repoId: TEST_REPO.id, hostId: 'local' })]
+      },
+      settings: { activeRuntimeEnvironmentId: null } as AppState['settings']
+    })
+
+    const outcome = await store.getState().openNewTerminalTabInActiveWorkspace('group-1')
+
+    expect(outcome.status).toBe('unroutable')
+    expect(outcome.status === 'unroutable' ? outcome.message : '').not.toMatch(DEATH_CLAIM_RE)
+    expect(store.getState().tabsByWorktree['wt-1'] ?? []).toEqual([])
+  })
+
+  it('reports unresolved folder ownership as unknown, not as an unpaired workspace', async () => {
+    pairedWebFlag.__ORCA_WEB_CLIENT__ = true
+    const workspaceKey = folderWorkspaceKey('folder-1')
+    const store = createTestStore()
+    // Why: the folder catalog has not hydrated, so no row says who owns this workspace.
+    seedStore(store, {
+      activeWorktreeId: workspaceKey,
+      settings: { activeRuntimeEnvironmentId: null } as AppState['settings'],
+      folderWorkspaces: [],
+      projectGroups: [],
+      groupsByWorktree: {
+        [workspaceKey]: [
+          {
+            id: 'group-1',
+            worktreeId: workspaceKey,
+            activeTabId: null,
+            tabOrder: []
+          }
+        ]
+      },
+      activeGroupIdByWorktree: { [workspaceKey]: 'group-1' }
+    })
+
+    const outcome = await store.getState().openNewTerminalTabInActiveWorkspace('group-1')
+
+    expect(outcome.status).toBe('unroutable')
+    const message = outcome.status === 'unroutable' ? outcome.message : ''
+    expect(message).not.toMatch(DEATH_CLAIM_RE)
+    expect(message).not.toMatch(/not routed to a paired runtime/i)
+    expect(message).toMatch(/cannot tell which execution host owns this workspace/i)
+    expect(store.getState().tabsByWorktree[workspaceKey] ?? []).toEqual([])
+  })
+
+  it('keeps the unpaired-runtime copy when the folder catalog names a local owner', async () => {
+    pairedWebFlag.__ORCA_WEB_CLIENT__ = true
+    const workspaceKey = folderWorkspaceKey('folder-1')
+    const store = createTestStore()
+    seedStore(store, {
+      activeWorktreeId: workspaceKey,
+      settings: { activeRuntimeEnvironmentId: null } as AppState['settings'],
+      folderWorkspaces: [
+        {
+          id: 'folder-1',
+          projectGroupId: 'pg-1',
+          name: 'Folder workspace',
+          folderPath: '/tmp/folder',
+          connectionId: null,
+          executionHostId: 'local',
+          linkedTask: null,
+          comment: '',
+          isArchived: false,
+          isUnread: false,
+          isPinned: false,
+          sortOrder: 1,
+          lastActivityAt: 0,
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ] as AppState['folderWorkspaces'],
+      groupsByWorktree: {
+        [workspaceKey]: [
+          {
+            id: 'group-1',
+            worktreeId: workspaceKey,
+            activeTabId: null,
+            tabOrder: []
+          }
+        ]
+      },
+      activeGroupIdByWorktree: { [workspaceKey]: 'group-1' }
+    })
+
+    const outcome = await store.getState().openNewTerminalTabInActiveWorkspace('group-1')
+
+    expect(outcome.status).toBe('unroutable')
+    expect(outcome.status === 'unroutable' ? outcome.message : '').toMatch(
+      /not routed to a paired runtime/i
+    )
+  })
+
+  it('reports a folder row that names no host as unknown, not as an unpaired workspace', async () => {
+    pairedWebFlag.__ORCA_WEB_CLIENT__ = true
+    const workspaceKey = folderWorkspaceKey('folder-1')
+    const store = createTestStore()
+    // Why: a HUB that predates the host/connection fields projects rows that name no owner at all.
+    seedStore(store, {
+      activeWorktreeId: workspaceKey,
+      settings: { activeRuntimeEnvironmentId: null } as AppState['settings'],
+      folderWorkspaces: [
+        {
+          id: 'folder-1',
+          projectGroupId: 'pg-1',
+          name: 'Folder workspace',
+          folderPath: '/tmp/folder',
+          linkedTask: null,
+          comment: '',
+          isArchived: false,
+          isUnread: false,
+          isPinned: false,
+          sortOrder: 1,
+          lastActivityAt: 0,
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ] as AppState['folderWorkspaces'],
+      projectGroups: [
+        {
+          id: 'pg-1',
+          name: 'Folder group',
+          parentPath: '/tmp',
+          parentGroupId: null,
+          createdFrom: 'manual',
+          tabOrder: 0,
+          isCollapsed: false,
+          color: null,
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ] as AppState['projectGroups'],
+      groupsByWorktree: {
+        [workspaceKey]: [
+          {
+            id: 'group-1',
+            worktreeId: workspaceKey,
+            activeTabId: null,
+            tabOrder: []
+          }
+        ]
+      },
+      activeGroupIdByWorktree: { [workspaceKey]: 'group-1' }
+    })
+
+    const outcome = await store.getState().openNewTerminalTabInActiveWorkspace('group-1')
+
+    expect(outcome.status).toBe('unroutable')
+    const message = outcome.status === 'unroutable' ? outcome.message : ''
+    expect(message).not.toMatch(DEATH_CLAIM_RE)
+    expect(message).not.toMatch(/not routed to a paired runtime/i)
+    expect(message).toMatch(/cannot tell which execution host owns this workspace/i)
+    expect(store.getState().tabsByWorktree[workspaceKey] ?? []).toEqual([])
+  })
+
+  it('keeps the unknown verdict when the sidebar launders the pseudo-worktree local default', async () => {
+    pairedWebFlag.__ORCA_WEB_CLIENT__ = true
+    const workspaceKey = folderWorkspaceKey('folder-1')
+    const store = createTestStore()
+    // Why: folderWorkspaceToWorktree defaults hostId to 'local', and the sidebar click records that
+    // default as the active host — the same missing evidence must not read as a named local owner.
+    seedStore(store, {
+      activeWorktreeId: workspaceKey,
+      settings: { activeRuntimeEnvironmentId: null } as AppState['settings'],
+      folderWorkspaces: [
+        {
+          id: 'folder-1',
+          projectGroupId: 'pg-1',
+          name: 'Folder workspace',
+          folderPath: '/tmp/folder',
+          linkedTask: null,
+          comment: '',
+          isArchived: false,
+          isUnread: false,
+          isPinned: false,
+          sortOrder: 1,
+          lastActivityAt: 0,
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ] as AppState['folderWorkspaces'],
+      projectGroups: [
+        {
+          id: 'pg-1',
+          name: 'Folder group',
+          parentPath: '/tmp',
+          parentGroupId: null,
+          createdFrom: 'manual',
+          tabOrder: 0,
+          isCollapsed: false,
+          color: null,
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ] as AppState['projectGroups'],
+      groupsByWorktree: {
+        [workspaceKey]: [
+          {
+            id: 'group-1',
+            worktreeId: workspaceKey,
+            activeTabId: null,
+            tabOrder: []
+          }
+        ]
+      },
+      activeGroupIdByWorktree: { [workspaceKey]: 'group-1' }
+    })
+    store.setState({ activeWorkspaceExecutionHostId: 'local' })
+
+    const outcome = await store.getState().openNewTerminalTabInActiveWorkspace('group-1')
+
+    expect(outcome.status).toBe('unroutable')
+    const message = outcome.status === 'unroutable' ? outcome.message : ''
+    expect(message).not.toMatch(DEATH_CLAIM_RE)
+    expect(message).not.toMatch(/not routed to a paired runtime/i)
+    expect(message).toMatch(/cannot tell which execution host owns this workspace/i)
+  })
+
+  it('reports an ssh-hosted folder owner as unknown, not as an unpaired workspace', async () => {
+    pairedWebFlag.__ORCA_WEB_CLIENT__ = true
+    const workspaceKey = folderWorkspaceKey('folder-1')
+    const store = createTestStore()
+    // Why: an ssh host names the target, not the HUB proxying it, so no row says a runtime is unpaired.
+    seedStore(store, {
+      activeWorktreeId: workspaceKey,
+      settings: { activeRuntimeEnvironmentId: null } as AppState['settings'],
+      folderWorkspaces: [
+        {
+          id: 'folder-1',
+          projectGroupId: 'pg-1',
+          name: 'Folder workspace',
+          folderPath: '/tmp/folder',
+          connectionId: 'conn-1',
+          executionHostId: 'ssh:conn-1',
+          linkedTask: null,
+          comment: '',
+          isArchived: false,
+          isUnread: false,
+          isPinned: false,
+          sortOrder: 1,
+          lastActivityAt: 0,
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ] as AppState['folderWorkspaces'],
+      groupsByWorktree: {
+        [workspaceKey]: [
+          {
+            id: 'group-1',
+            worktreeId: workspaceKey,
+            activeTabId: null,
+            tabOrder: []
+          }
+        ]
+      },
+      activeGroupIdByWorktree: { [workspaceKey]: 'group-1' }
+    })
+
+    const outcome = await store.getState().openNewTerminalTabInActiveWorkspace('group-1')
+
+    expect(outcome.status).toBe('unroutable')
+    const message = outcome.status === 'unroutable' ? outcome.message : ''
+    expect(message).not.toMatch(DEATH_CLAIM_RE)
+    expect(message).not.toMatch(/not routed to a paired runtime/i)
+    expect(message).toMatch(/cannot tell which execution host owns this workspace/i)
+    expect(createWebRuntimeSessionTerminalMock).not.toHaveBeenCalled()
+  })
+
+  it('reports rival HUB owners as ambiguous, not as an unpaired workspace', async () => {
+    pairedWebFlag.__ORCA_WEB_CLIENT__ = true
+    const store = createTestStore()
+    seedActiveWorkspace(store)
+    store.setState({
+      activeWorkspaceExecutionHostId: 'ssh:conn-1',
+      repos: [],
+      worktreesByRepo: {
+        'repo-a': [
+          makeWorktree({
+            id: 'wt-1',
+            repoId: 'repo-a',
+            hostId: 'ssh:conn-1',
+            runtimeOwnerEnvironmentId: 'hub-a'
+          })
+        ],
+        'repo-b': [
+          makeWorktree({
+            id: 'wt-1',
+            repoId: 'repo-b',
+            hostId: 'ssh:conn-1',
+            runtimeOwnerEnvironmentId: 'hub-b'
+          })
+        ]
+      },
+      settings: { activeRuntimeEnvironmentId: null } as AppState['settings']
+    })
+
+    const outcome = await store.getState().openNewTerminalTabInActiveWorkspace('group-1')
+
+    expect(outcome.status).toBe('unroutable')
+    const message = outcome.status === 'unroutable' ? outcome.message : ''
+    expect(message).not.toMatch(DEATH_CLAIM_RE)
+    expect(message).not.toMatch(/not routed to a paired runtime/i)
+    expect(message).toMatch(/More than one execution host claims this workspace/i)
+  })
+
+  it('reports an unhydrated worktree owner as unknown, not as an unpaired workspace', async () => {
+    pairedWebFlag.__ORCA_WEB_CLIENT__ = true
+    const store = createTestStore()
+    seedActiveWorkspace(store)
+    // Why: no owner row has landed yet, so nothing says whether a runtime is paired.
+    store.setState({
+      activeWorkspaceExecutionHostId: 'ssh:conn-1',
+      repos: [],
+      worktreesByRepo: {},
+      settings: { activeRuntimeEnvironmentId: null } as AppState['settings']
+    })
+
+    const outcome = await store.getState().openNewTerminalTabInActiveWorkspace('group-1')
+
+    expect(outcome.status).toBe('unroutable')
+    const message = outcome.status === 'unroutable' ? outcome.message : ''
+    expect(message).not.toMatch(DEATH_CLAIM_RE)
+    expect(message).not.toMatch(/not routed to a paired runtime/i)
+    expect(message).toMatch(/cannot tell which execution host owns this workspace/i)
+  })
+
+  it('reports created for a local desktop terminal', async () => {
+    const store = createTestStore()
+    seedStore(store, {
+      activeWorktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+      settings: { activeRuntimeEnvironmentId: null } as AppState['settings'],
+      groupsByWorktree: {
+        [FLOATING_TERMINAL_WORKTREE_ID]: [
+          {
+            id: 'group-1',
+            worktreeId: FLOATING_TERMINAL_WORKTREE_ID,
+            activeTabId: null,
+            tabOrder: []
+          }
+        ]
+      },
+      activeGroupIdByWorktree: { [FLOATING_TERMINAL_WORKTREE_ID]: 'group-1' }
+    })
+
+    const outcome = await store.getState().openNewTerminalTabInActiveWorkspace('group-1')
+
+    expect(outcome).toEqual({ status: 'created' })
+    expect(store.getState().tabsByWorktree[FLOATING_TERMINAL_WORKTREE_ID] ?? []).toHaveLength(1)
+  })
+
+  it('stays silent when no workspace is active', async () => {
+    const store = createTestStore()
+    seedStore(store, { activeWorktreeId: null })
+
+    const outcome = await store.getState().openNewTerminalTabInActiveWorkspace('group-1')
+
+    expect(outcome).toEqual({ status: 'no-active-workspace' })
+  })
+})

--- a/src/renderer/src/store/terminals/terminal-active-workspace-creation.ts
+++ b/src/renderer/src/store/terminals/terminal-active-workspace-creation.ts
@@ -2,8 +2,15 @@ import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
 import { focusTerminalTabSurface } from '@/lib/focus-terminal-tab-surface'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
-import { resolveWorktreeOperationRouteResult } from '@/lib/worktree-operation-route'
+import {
+  resolveRouteRuntimeOwner,
+  resolveWorktreeOperationRouteResult
+} from '@/lib/worktree-operation-route'
 import { isWebClientLocation } from '@/lib/web-client-location'
+import {
+  unpairedWebClientWorkspaceOutcome,
+  unroutableWorkspaceOutcome
+} from '@/lib/terminal-create-routing-outcome'
 import type { TerminalSlice, TerminalStoreGet, TerminalStoreSet } from './terminal-state'
 
 export function createActiveWorkspaceTerminalActions(
@@ -15,7 +22,7 @@ export function createActiveWorkspaceTerminalActions(
       const state = get()
       const worktreeId = state.activeWorktreeId
       if (!worktreeId) {
-        return
+        return { status: 'no-active-workspace' }
       }
       const workspaceScope = parseWorkspaceKey(worktreeId)
       const worktreeRoute =
@@ -23,23 +30,33 @@ export function createActiveWorkspaceTerminalActions(
           ? null
           : resolveWorktreeOperationRouteResult(state, worktreeId)
       if (worktreeRoute && worktreeRoute.kind !== 'resolved') {
-        return
+        return unroutableWorkspaceOutcome(worktreeRoute)
       }
       const runtimeEnvironmentId = worktreeRoute
         ? worktreeRoute.route.runtimeEnvironmentId
         : getRuntimeEnvironmentIdForWorktree(state, worktreeId)
       if (runtimeEnvironmentId) {
         const { createWebRuntimeSessionTerminal } = await import('@/runtime/web-runtime-session')
-        await createWebRuntimeSessionTerminal({
+        return await createWebRuntimeSessionTerminal({
           worktreeId,
           environmentId: runtimeEnvironmentId,
           targetGroupId: groupId,
           activate: true
         })
-        return
       }
       if (isWebClientLocation() && worktreeId !== FLOATING_TERMINAL_WORKTREE_ID) {
-        return
+        // Why: a null runtime owner only means "unpaired" when the store actually named one.
+        // Folder workspaces skip the route above, and an ssh route flattens undeterminable HUB
+        // ownership into the same null — both turn missing evidence into an absence claim.
+        const routeResolution =
+          worktreeRoute ?? resolveWorktreeOperationRouteResult(state, worktreeId)
+        if (routeResolution.kind !== 'resolved') {
+          return unroutableWorkspaceOutcome(routeResolution)
+        }
+        const ownerResolution = resolveRouteRuntimeOwner(state, worktreeId, routeResolution.route)
+        return ownerResolution.kind !== 'resolved'
+          ? unroutableWorkspaceOutcome(ownerResolution)
+          : unpairedWebClientWorkspaceOutcome()
       }
       const terminal = get().createTab(worktreeId, groupId)
       get().setActiveTab(terminal.id)
@@ -64,6 +81,7 @@ export function createActiveWorkspaceTerminalActions(
       // Why: Cmd+J shares the titlebar-button creation path, so append the new terminal after mixed editor/browser tabs, not first.
       get().setTabBarOrder(worktreeId, [...base.filter((id) => id !== terminal.id), terminal.id])
       focusTerminalTabSurface(terminal.id)
+      return { status: 'created' }
     }
   }
 }

--- a/src/renderer/src/web/preload-api/web-runtime-calls.ts
+++ b/src/renderer/src/web/preload-api/web-runtime-calls.ts
@@ -6,6 +6,7 @@ import type { RuntimeStatus } from '../../../../shared/runtime-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import {
   getClientForEnvironment,
+  manuallyDisconnectedAfterReplyResponse,
   manuallyDisconnectedEnvironmentIds,
   manuallyDisconnectedResponse,
   requireActiveEnvironment,
@@ -35,14 +36,19 @@ export async function callRuntimeEnvelope<TResult = unknown>(
   if (manuallyDisconnectedEnvironmentIds.has(environment.id)) {
     return manuallyDisconnectedResponse(environment)
   }
+  let dispatched = false
   const response = await runtimeCallQueuePool.enqueue(environment.id, method, () => {
     if (manuallyDisconnectedEnvironmentIds.has(environment.id)) {
       return Promise.resolve(manuallyDisconnectedResponse(environment))
     }
+    dispatched = true
     return getClientForEnvironment(environment).call(method, params, { timeoutMs })
   })
   if (manuallyDisconnectedEnvironmentIds.has(environment.id)) {
-    return manuallyDisconnectedResponse(environment)
+    // Why: only a dispatched call can already have been answered; a queued one definitely was not.
+    return dispatched
+      ? manuallyDisconnectedAfterReplyResponse(environment)
+      : manuallyDisconnectedResponse(environment)
   }
   updateEnvironmentFromResponse(environment, response)
   return response as RuntimeRpcResponse<TResult>
@@ -58,14 +64,19 @@ export async function callEnvironmentEnvelope<TResult = unknown>(
   if (manuallyDisconnectedEnvironmentIds.has(environment.id)) {
     return manuallyDisconnectedResponse(environment)
   }
+  let dispatched = false
   const response = await runtimeCallQueuePool.enqueue(environment.id, method, () => {
     if (manuallyDisconnectedEnvironmentIds.has(environment.id)) {
       return Promise.resolve(manuallyDisconnectedResponse(environment))
     }
+    dispatched = true
     return getClientForEnvironment(environment).call(method, params, { timeoutMs })
   })
   if (manuallyDisconnectedEnvironmentIds.has(environment.id)) {
-    return manuallyDisconnectedResponse(environment)
+    // Why: only a dispatched call can already have been answered; a queued one definitely was not.
+    return dispatched
+      ? manuallyDisconnectedAfterReplyResponse(environment)
+      : manuallyDisconnectedResponse(environment)
   }
   updateEnvironmentFromResponse(environment, response)
   return response as RuntimeRpcResponse<TResult>

--- a/src/renderer/src/web/preload-api/web-runtime-session.ts
+++ b/src/renderer/src/web/preload-api/web-runtime-session.ts
@@ -73,14 +73,15 @@ export function removeActiveRuntimeEnvironment(): void {
   webRuntimeState.activeEnvironment = null
 }
 
-export function manuallyDisconnectedResponse(
-  environment: StoredWebRuntimeEnvironment
+function manualDisconnectResponse(
+  environment: StoredWebRuntimeEnvironment,
+  code: 'runtime_manually_disconnected' | 'runtime_manually_disconnected_after_reply'
 ): RuntimeRpcResponse<never> {
   return {
     id: 'runtime.manualDisconnect',
     ok: false,
     error: {
-      code: 'runtime_manually_disconnected',
+      code,
       message: translate(
         'auto.web.webPreloadApi.runtimeEnvironmentManuallyDisconnected',
         'Runtime environment is manually disconnected.'
@@ -88,6 +89,23 @@ export function manuallyDisconnectedResponse(
     },
     _meta: { runtimeId: environment.runtimeId }
   }
+}
+
+/** The call never left this client, so whatever it asked for definitely did not happen. */
+export function manuallyDisconnectedResponse(
+  environment: StoredWebRuntimeEnvironment
+): RuntimeRpcResponse<never> {
+  return manualDisconnectResponse(environment, 'runtime_manually_disconnected')
+}
+
+/**
+ * Discarding a reply the runtime already sent is not the same as refusing to dispatch: the discarded
+ * reply may have been `ok:true`, so callers must read this as "outcome unknown", not "did not happen".
+ */
+export function manuallyDisconnectedAfterReplyResponse(
+  environment: StoredWebRuntimeEnvironment
+): RuntimeRpcResponse<never> {
+  return manualDisconnectResponse(environment, 'runtime_manually_disconnected_after_reply')
 }
 
 export function resolveEnvironment(selector: string): StoredWebRuntimeEnvironment {

--- a/src/renderer/src/web/web-preload-api-runtime-environment.test.ts
+++ b/src/renderer/src/web/web-preload-api-runtime-environment.test.ts
@@ -273,9 +273,11 @@ describe('web runtime environment identity', () => {
       _meta: { runtimeId: 'runtime-1' }
     })
 
+    // Why: the call was dispatched and answered, so the substitution reports an unknown outcome
+    // rather than the pre-dispatch refusal.
     await expect(status).resolves.toMatchObject({
       ok: false,
-      error: { code: 'runtime_manually_disconnected' }
+      error: { code: 'runtime_manually_disconnected_after_reply' }
     })
   })
 
@@ -338,7 +340,7 @@ describe('web runtime environment identity', () => {
         Array.from({ length: 8 }, () =>
           expect.objectContaining({
             ok: false,
-            error: expect.objectContaining({ code: 'runtime_manually_disconnected' })
+            error: expect.objectContaining({ code: 'runtime_manually_disconnected_after_reply' })
           })
         )
       )


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1048 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​1046 |
| Prod | 17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​445 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​82 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​363 |

<!-- /orca-pr-loc -->

> **Draft.** 5 adversarial loops, 1 blocker + 1 major outstanding.

## The bug

@qkdtp12 (macOS 25.3.0, 1.4.188) reported: *"새로운 터미널, 새로운 브라우저창이 안열림"* — new terminal and new browser window do not open.

When terminal creation cannot be routed, the user gets **nothing**: no toast, no error, no explanation. The action silently does nothing — exactly what they described.

## What was refuted, and stays refuted

- `openNewTerminalTabInActiveWorkspace` returning `Promise<void>` is the **declared contract**, not a defect.
- Refusing a local fallback when the owning runtime fails is a **documented deliberate contract**, asserted green in `cmd-j-create-actions.test.ts`. Untouched.

Only the observability gap survived, and that is all this addresses.

## Outstanding

1. **Blocker:** the recurring bug class, still live for **folder workspaces** at loop 5 — the `hasNamedFolderWorkspaceExecutionHost` guard added in loop 4 is neutralized by the sibling branch.
2. **Major — over-correction, mirror image of the same bug:** `runtime_manually_disconnected` is now blanket-`unverifiable`, but three of its four producers return a verdict that *is* established. Per `docs/reference/ssh-execution-boundary.md` the vocabulary is live / unverifiable / exited — and calling a known state unverifiable is as wrong as calling an unknown one dead.

The gap is real and worth fixing; this shape isn't there yet.