### PR TITLE
fix(mobile): use the external display viewport

### DIFF
--- a/mobile/src/layout/responsive-layout-metrics.test.ts
+++ b/mobile/src/layout/responsive-layout-metrics.test.ts
@@ -28,6 +28,16 @@ describe('responsive layout metrics', () => {
     })
   })
 
+  it('uses the full available width on large landscape displays', () => {
+    expect(getResponsiveLayoutMetrics(1920, 1080)).toMatchObject({
+      isLandscape: true,
+      isTabletLayout: true,
+      isWideLayout: true,
+      contentMaxWidth: 1920,
+      horizontalPadding: spacing.xl
+    })
+  })
+
   it('keeps landscape phones out of wide tablet layout', () => {
     expect(getResponsiveLayoutMetrics(932, 430)).toMatchObject({
       isLandscape: true,

--- a/mobile/src/layout/responsive-layout-metrics.ts
+++ b/mobile/src/layout/responsive-layout-metrics.ts
@@ -8,7 +8,12 @@ const WIDE_LAYOUT_MIN_WIDTH = 700
 const TABLET_LAYOUT_MIN_SHORT_SIDE = 600
 
 const CONTENT_MAX_WIDTH = 720
+const EXTERNAL_DISPLAY_MIN_WIDTH = 1_200
 const MODAL_MAX_WIDTH = 480
+
+function contentMaxWidthForViewport(width: number, isLandscape: boolean): number {
+  return isLandscape && width >= EXTERNAL_DISPLAY_MIN_WIDTH ? width : CONTENT_MAX_WIDTH
+}
 
 export type ResponsiveLayoutMetrics = {
   width: number
@@ -27,16 +32,18 @@ export type ResponsiveLayoutMetrics = {
 }
 
 export function getResponsiveLayoutMetrics(width: number, height: number): ResponsiveLayoutMetrics {
+  const isLandscape = width > height
   const isTabletLayout = Math.min(width, height) >= TABLET_LAYOUT_MIN_SHORT_SIDE
   const isWideLayout = width >= WIDE_LAYOUT_MIN_WIDTH && isTabletLayout
 
   return {
     width,
     height,
-    isLandscape: width > height,
+    isLandscape,
     isWideLayout,
     isTabletLayout,
-    contentMaxWidth: CONTENT_MAX_WIDTH,
+    // Why: an external display has desktop-scale width; do not leave the home view inside a tablet cap.
+    contentMaxWidth: contentMaxWidthForViewport(width, isLandscape),
     modalMaxWidth: MODAL_MAX_WIDTH,
     // Roomier gutters once content is capped so it isn't glued to the edges.
     horizontalPadding: isWideLayout ? spacing.xl : spacing.lg


### PR DESCRIPTION
## Problem

On an XREAL / Android external display, the mobile dashboard was constrained to a `720dp` max-width column even when Android reported a real `1920×1080` viewport. This left large unused side borders and made the UI impractical for coding through XREAL glasses. It was previously tempting to compensate using Android display-density (`wm density`) overrides; that is not a correct or accessible fix.

## Solution

- Detect genuine large landscape canvases (`≥1200dp`).
- Use the actual external-display viewport width for the dashboard container, preserving the existing `24dp` gutter.
- Keep the established capped layout for phone-size landscape windows (including `932×430`), so phone usability and font/accessibility behavior are unchanged.
- Add regression coverage for a `1920×1080` external display.

## Evidence

| Before | After |
| --- | --- |
| Dashboard hard-capped at `720dp` on a `1920×1080` XREAL canvas — unused borders / clipped practical working area. | Dashboard uses the true viewport width on the same canvas, with the standard `24dp` gutter. |

The physical XREAL before/after captures will be appended here as soon as the Pixel is reconnected through Wireless debugging; the old wireless-debug endpoint expired before this PR could be published. No screenshot has been recreated or faked.

## Verification

- `pnpm exec vitest run src/layout/responsive-layout-metrics.test.ts` — passed
- `pnpm typecheck` — passed
- `git diff --check` — passed

## Disclosure

Implemented with AI assistance and independently validated through the targeted regression test and TypeScript check. The final device verification is explicitly pending the restored Wireless debugging connection.
