### PR TITLE
perf(terminal): avoid full CJK refresh for synchronized WebGL frames

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection-renderer-risk-repaint.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-renderer-risk-repaint.test.ts
@@ -284,6 +284,45 @@ describe('connectPanePty', () => {
     expect(refresh).toHaveBeenCalledWith(0, 39, true)
   })
 
+  it('keeps synchronized CJK frames on the normal non-Windows WebGL render path', async () => {
+    const restoreNavigator = temporarilySetNavigatorUserAgent('Mozilla/5.0 (Macintosh)')
+    try {
+      const { connectPanePty } = await import('./pty-connection')
+      const transport = createMockTransport()
+      const capturedDataCallback: { current: ((data: string) => void) | null } = {
+        current: null
+      }
+      transport.connect.mockImplementation(
+        async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+          capturedDataCallback.current = callbacks.onData ?? null
+          return 'pty-id'
+        }
+      )
+      transportFactoryQueue.push(transport)
+
+      const pane = createPane(1)
+      const manager = createManager(1)
+      manager.hasWebglRenderer.mockReturnValue(true)
+      const refresh = vi.fn()
+      const terminal = pane.terminal as typeof pane.terminal & { refresh: typeof refresh }
+      terminal.refresh = refresh
+      terminal.write = vi.fn((_data: string, callback?: () => void) => {
+        callback?.()
+      })
+
+      connectPanePty(pane as never, manager as never, createDeps() as never)
+      await flushAsyncTicks(6)
+
+      capturedDataCallback.current?.('\x1b[?20')
+      capturedDataCallback.current?.('26h中文整屏')
+      capturedDataCallback.current?.('更新\x1b[?2026l')
+
+      expect(refresh).not.toHaveBeenCalled()
+    } finally {
+      restoreNavigator()
+    }
+  })
+
   it('refreshes renderer-risk output without clearing the shared glyph atlas', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport()

--- a/src/renderer/src/components/terminal-pane/pty-connection/foreground-output-refresh.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/foreground-output-refresh.ts
@@ -257,7 +257,10 @@ export function bindForegroundOutputRefresh(session: ConnectPanePtySession): voi
     return decision.prefersRenderRefresh
   }
 
-  session.shouldForceForegroundRenderRefresh = function (data: string): {
+  session.shouldForceForegroundRenderRefresh = function (
+    data: string,
+    includeEastAsianRendererRisk = true
+  ): {
     refresh: boolean
     inPlaceRewrite: boolean
   } {
@@ -266,7 +269,9 @@ export function bindForegroundOutputRefresh(session: ConnectPanePtySession): voi
     const recentInput =
       performance.now() - session.lastInteractiveRedrawInputAt <=
       FOREGROUND_INTERACTIVE_REDRAW_WINDOW_MS
-    if (session.foregroundRendererRiskOutputPrefersRenderRefresh(data)) {
+    if (
+      session.foregroundRendererRiskOutputPrefersRenderRefresh(data, includeEastAsianRendererRisk)
+    ) {
       return {
         refresh: true,
         inPlaceRewrite: rewriteOutputPrefersRenderRefresh

--- a/src/renderer/src/components/terminal-pane/pty-connection/fresh-spawn-follow-reset.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/fresh-spawn-follow-reset.ts
@@ -82,7 +82,10 @@ export function bindFreshSpawnFollowReset(session: ConnectPanePtySession): void 
     return tail.slice(0, TERMINAL_RENDERER_RISK_SCAN_TAIL_CHARS)
   }
 
-  session.foregroundRendererRiskOutputPrefersRenderRefresh = function (data: string): boolean {
+  session.foregroundRendererRiskOutputPrefersRenderRefresh = function (
+    data: string,
+    includeEastAsian = true
+  ): boolean {
     if (!data) {
       return false
     }
@@ -91,7 +94,7 @@ export function bindFreshSpawnFollowReset(session: ConnectPanePtySession): void 
       : data
     const prefersRefresh =
       (scanData.includes('\x1b[') || session.containsNonAsciiOutput(scanData)) &&
-      terminalOutputPrefersRenderRefresh(scanData)
+      terminalOutputPrefersRenderRefresh(scanData, { includeEastAsian })
     session.foregroundRefreshRiskScanTail = trailingIncompleteCsiSequence(scanData)
     return prefersRefresh
   }

--- a/src/renderer/src/components/terminal-pane/pty-connection/write-pty-output-to-xterm.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/write-pty-output-to-xterm.ts
@@ -29,14 +29,13 @@ export function bindWritePtyOutputToXterm(session: ConnectPanePtySession): void 
       session.canUseHiddenOutputSnapshot(session.transport.getPtyId()) &&
       session.shouldSnapshotHiddenCodexOutput &&
       (opts?.hiddenStartupRendererQuery === true || containsHiddenStartupRendererQuery(data))
-    const synchronizedForegroundScan =
-      session.shouldProtectNativeWindowsSynchronizedOutput && foreground
-        ? scanSynchronizedForegroundOutput(
-            data,
-            session.synchronizedForegroundMarkerTail,
-            session.synchronizedForegroundOutputActive
-          )
-        : null
+    const synchronizedForegroundScan = foreground
+      ? scanSynchronizedForegroundOutput(
+          data,
+          session.synchronizedForegroundMarkerTail,
+          session.synchronizedForegroundOutputActive
+        )
+      : null
     const synchronizedOutputStarted = synchronizedForegroundScan?.started === true
     const synchronizedOutputEnded = synchronizedForegroundScan?.ended === true
     const synchronizedForegroundOutput =
@@ -45,6 +44,8 @@ export function bindWritePtyOutputToXterm(session: ConnectPanePtySession): void 
         synchronizedOutputStarted ||
         synchronizedOutputEnded)
     const nextSynchronizedForegroundOutputActive = synchronizedForegroundScan?.active === true
+    const protectedSynchronizedForegroundOutput =
+      session.shouldProtectNativeWindowsSynchronizedOutput && synchronizedForegroundOutput
     // Why: xterm's DOM renderer draws the cursor as row content, so Windows cursor-only restores need row invalidation even outside DEC 2026.
     const nativeWindowsCursorRestore =
       session.shouldProtectNativeWindowsSynchronizedOutput &&
@@ -54,8 +55,14 @@ export function bindWritePtyOutputToXterm(session: ConnectPanePtySession): void 
     if (foreground) {
       session.scheduleForegroundGridDriftCheck()
     }
+    // Why: xterm already tracks dirty rows inside an atomic DEC 2026 frame. On
+    // non-Windows WebGL, widening CJK output to the full viewport only adds GPU work.
+    const includeEastAsianRendererRisk =
+      !synchronizedForegroundOutput ||
+      session.shouldApplyWindowsRendererUnicodeRefresh ||
+      session.shouldRefreshForegroundSynchronously()
     const renderRefreshDecision = foregroundOutput
-      ? session.shouldForceForegroundRenderRefresh(data)
+      ? session.shouldForceForegroundRenderRefresh(data, includeEastAsianRendererRisk)
       : { refresh: false, inPlaceRewrite: false }
     const foregroundRenderRefreshNeeded = renderRefreshDecision.refresh
     // Why: Claude Code's in-place prompt redraws on Windows ConPTY can paint one frame late; a follow-up repaint fixes the column desync without a resize.
@@ -65,7 +72,7 @@ export function bindWritePtyOutputToXterm(session: ConnectPanePtySession): void 
       isInPlaceRewrite: renderRefreshDecision.inPlaceRewrite
     })
     // Why: recompute the latch on every synchronized START so each frame's interactivity is judged by its own open time and can't leak across a same-chunk close+open; clear only on leaving synchronized output.
-    if (synchronizedForegroundOutput && synchronizedOutputStarted) {
+    if (protectedSynchronizedForegroundOutput && synchronizedOutputStarted) {
       session.synchronizedForegroundFrameInteractive =
         performance.now() - session.lastTerminalInputAt <=
         FOREGROUND_SYNCHRONIZED_FRAME_INTERACTIVE_WINDOW_MS
@@ -74,7 +81,7 @@ export function bindWritePtyOutputToXterm(session: ConnectPanePtySession): void 
     }
     // Why: ConPTY can split a submit repaint's closing chunk past the 150ms window, so treat a keystroke-opened frame as latency-sensitive to drain it fast (~16-32ms) not the 1s coalesce fallback.
     const synchronizedFrameLatencySensitive =
-      synchronizedForegroundOutput && session.synchronizedForegroundFrameInteractive
+      protectedSynchronizedForegroundOutput && session.synchronizedForegroundFrameInteractive
     session.synchronizedForegroundOutputActive = nextSynchronizedForegroundOutputActive
     session.synchronizedForegroundMarkerTail = synchronizedForegroundScan?.markerTail ?? ''
     writeTerminalOutput(session.pane.terminal, data, {
@@ -89,15 +96,16 @@ export function bindWritePtyOutputToXterm(session: ConnectPanePtySession): void 
           : synchronizedFrameLatencySensitive || session.isLatencySensitiveForegroundOutput(data),
       forceForegroundRefresh:
         foregroundOutput &&
-        (synchronizedForegroundOutput ||
+        (protectedSynchronizedForegroundOutput ||
           nativeWindowsCursorRestore ||
           foregroundRenderRefreshNeeded),
       followupForegroundRefresh: nativeWindowsCursorRestore || nativeWindowsInPlaceRewriteFollowup,
       // Why: xterm already queued a WebGL frame parsing this chunk; merge the repair into it instead of rendering the grid twice.
       shouldRefreshForegroundSynchronously: session.shouldRefreshForegroundSynchronously,
       stripTransientCursorShows: session.shouldProtectNativeWindowsSynchronizedOutput && foreground,
-      coalesceForeground: synchronizedForegroundOutput && synchronizedOutputEnded,
-      holdForeground: synchronizedForegroundOutput && nextSynchronizedForegroundOutputActive
+      coalesceForeground: protectedSynchronizedForegroundOutput && synchronizedOutputEnded,
+      holdForeground:
+        protectedSynchronizedForegroundOutput && nextSynchronizedForegroundOutputActive
     })
   }
 

--- a/src/renderer/src/lib/pane-manager/terminal-complex-script.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-complex-script.test.ts
@@ -27,6 +27,16 @@ describe('terminalOutputPrefersRenderRefresh', () => {
     expect(terminalOutputPrefersRenderRefresh('Fullwidth: ＡＢＣ１２３')).toBe(true)
   })
 
+  it('can exclude only East Asian risk from an already synchronized WebGL frame', () => {
+    expect(
+      terminalOutputPrefersRenderRefresh('中文、ターミナル、터미널', { includeEastAsian: false })
+    ).toBe(false)
+    expect(terminalOutputPrefersRenderRefresh('中文 🚀', { includeEastAsian: false })).toBe(true)
+    expect(
+      terminalOutputPrefersRenderRefresh('\x1b[44m中文\x1b[0m', { includeEastAsian: false })
+    ).toBe(true)
+  })
+
   it('keeps terminal drawing glyphs on WebGL', () => {
     expect(terminalOutputPrefersRenderRefresh('⠋ Working')).toBe(false)
     expect(terminalOutputPrefersRenderRefresh('├─ file.ts')).toBe(false)

--- a/src/renderer/src/lib/pane-manager/terminal-complex-script.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-complex-script.ts
@@ -230,7 +230,10 @@ export function nativeWindowsRewriteNeedsFollowupRenderRefresh(args: {
   return args.isNativeWindowsConpty && args.isForeground && args.isInPlaceRewrite
 }
 
-export function terminalOutputPrefersRenderRefresh(data: string): boolean {
+export function terminalOutputPrefersRenderRefresh(
+  data: string,
+  options: { includeEastAsian?: boolean } = {}
+): boolean {
   if (containsBackgroundSgr(data)) {
     return true
   }
@@ -256,7 +259,10 @@ export function terminalOutputPrefersRenderRefresh(data: string): boolean {
     if (codePoint === undefined) {
       continue
     }
-    if (isRendererRiskCodePoint(codePoint)) {
+    if (
+      isRendererRiskCodePoint(codePoint) &&
+      (options.includeEastAsian !== false || !isEastAsianRendererRiskCodePoint(codePoint))
+    ) {
       return true
     }
     if (codePoint > 0xffff) {

--- a/tests/e2e/terminal-foreground-redraw-freeze.spec.ts
+++ b/tests/e2e/terminal-foreground-redraw-freeze.spec.ts
@@ -85,7 +85,7 @@ async function readSchedulerDebug(page: Page): Promise<SchedulerDebugSnapshot> {
 
 async function measureRendererDuringBurst(page: Page, paneKey: string): Promise<BurstMeasurement> {
   const frames = Array.from({ length: REDRAW_FRAME_COUNT }, (_, frame) => {
-    const text = `OpenTUI active redraw #${String(frame).padStart(4, '0')}`
+    const text = `OpenTUI 中文整屏更新 #${String(frame).padStart(4, '0')}`
     const payload = 'x'.repeat(REDRAW_PAYLOAD_CHARS)
     return (
       '\x1b[?2026h' +
@@ -408,16 +408,38 @@ test.describe('Terminal foreground redraw freeze repro', () => {
 
     const { paneKey } = await waitForActivePaneHookDescriptor(orcaPage)
     await waitForTerminalPtyDataInjector(orcaPage, paneKey)
-    await resetSchedulerDebug(orcaPage)
-    const measurement = await measureRendererDuringBurst(orcaPage, paneKey)
-    const scheduler = await readSchedulerDebug(orcaPage)
-    annotateMeasurement(testInfo, measurement, scheduler)
+    const webglAttached = await forceActivePaneWebglRenderer(orcaPage)
+    if (webglAttached) {
+      await installActivePaneRefreshProbe(orcaPage)
+    }
+    try {
+      const refreshBaseline = webglAttached ? await readRefreshProbe(orcaPage) : null
+      await resetSchedulerDebug(orcaPage)
+      const measurement = await measureRendererDuringBurst(orcaPage, paneKey)
+      const scheduler = await readSchedulerDebug(orcaPage)
+      annotateMeasurement(testInfo, measurement, scheduler)
 
-    expect(measurement.injectedFrames).toBe(REDRAW_FRAME_COUNT)
-    expect(measurement.maxTimerDriftMs).toBeLessThan(MAX_RENDERER_TIMER_DRIFT_MS)
-    // Why: this is the PR #4558 contract. Once the foreground immediate budget
-    // is exhausted, throughput redraws must enter the async foreground drain.
-    expect(scheduler.deferredForegroundEnqueueCount).toBeGreaterThan(0)
+      expect(measurement.injectedFrames).toBe(REDRAW_FRAME_COUNT)
+      expect(measurement.maxTimerDriftMs).toBeLessThan(MAX_RENDERER_TIMER_DRIFT_MS)
+      // Why: this is the PR #4558 contract. Once the foreground immediate budget
+      // is exhausted, throughput redraws must enter the async foreground drain.
+      expect(scheduler.deferredForegroundEnqueueCount).toBeGreaterThan(0)
+      if (refreshBaseline) {
+        const refresh = await readRefreshProbe(orcaPage)
+        const refreshDelta = subtractRefreshProbe(refresh, refreshBaseline)
+        testInfo.annotations.push({
+          type: 'terminal-synchronized-cjk-refresh-probe',
+          description: `syncWebgl=${refreshDelta.synchronousWebgl} debouncedWebgl=${refreshDelta.debouncedWebgl}`
+        })
+        expect(refreshDelta.synchronousWebgl).toBe(0)
+        expect(refreshDelta.debouncedWebgl).toBe(0)
+      }
+      await expect(orcaPage.locator('.xterm-screen:visible').first()).toBeVisible()
+    } finally {
+      if (webglAttached) {
+        await disposeActivePaneRefreshProbe(orcaPage)
+      }
+    }
   })
 
   test('captured OpenCode/OpenTUI redraw bytes do not monopolize foreground writes', async ({


### PR DESCRIPTION
## Summary

- track DEC 2026 synchronized-output state for foreground terminals on every platform
- let xterm's normal dirty-row WebGL render handle East Asian glyphs inside an atomic synchronized frame
- preserve the existing full-viewport repair for plain CJK output, DOM rendering, Windows ConPTY, background-color SGR, emoji, RTL text, and rewrite-sensitive output

## Why

The complex-script repair classifies every CJK payload as renderer-risky. Codex/OpenTUI emits most frames inside DEC 2026 synchronized-output markers, so the WebGL path widens xterm's dirty range to the entire viewport for nearly every frame. That repeats a full-grid render even though synchronized output already presents the completed frame atomically.

This keeps the conservative repair where it is still needed while avoiding that redundant full-grid work for non-Windows WebGL synchronized frames.

## Performance regression coverage

The updated real Electron test emits 270 OpenTUI-style synchronized frames containing Chinese text and probes public full-grid refresh requests.

- upstream `main`: 215 debounced full-grid WebGL refreshes
- this branch: 0 synchronous and 0 debounced full-grid WebGL refreshes
- final visible `.xterm-screen` assertion still passes

This is refresh-count evidence rather than a claim about device-specific watts.

## Validation

- focused Vitest suite: 58 tests passed
- `pnpm tc:web`
- `pnpm run check:code-quality:changed`
- `pnpm run check:max-lines-ratchet`
- production Electron build
- targeted Playwright Electron test: 1 passed

Follow-up to the terminal renderer repair work in #6949, #8178, and #13657.

Closes #16645