### PR TITLE
Read Antigravity usage from the agy CLI

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -229,6 +229,7 @@ import { readMiniMaxSessionCookie } from './minimax/minimax-cookie-store'
 import { getInitialClaudeRateLimitTarget } from './rate-limits/claude-rate-limit-target'
 import { getInitialCodexRateLimitTarget } from './rate-limits/codex-rate-limit-target'
 import { getKimiRuntimeTarget, resolveKimiHome } from './kimi/kimi-runtime-home'
+import { resolveLocalAccountRuntimeTarget } from '../shared/local-account-runtime'
 import { createAccountRuntimeTargetSettingsSync } from './rate-limits/account-runtime-target-sync'
 import {
   attachMainWindowServices,
@@ -2612,6 +2613,10 @@ void app.whenReady().then(async () => {
   // Why: Kimi's CLI refreshes its OAuth token in whichever runtime it runs in, so the
   // usage fetch must read the WSL-side credentials when that's the configured runtime (#12370).
   rateLimits.setKimiHomeResolver(() => resolveKimiHome(getKimiRuntimeTarget(store!.getSettings())))
+  // agy signs in per runtime and keeps the token in that runtime's keyring, so ask the one that owns it.
+  rateLimits.setAntigravityRuntimeTargetResolver(() =>
+    resolveLocalAccountRuntimeTarget(store!.getSettings())
+  )
   rateLimits.setClaudeFetchTarget(getInitialClaudeRateLimitTarget(store.getSettings()))
   const syncAccountRuntimeTargets = createAccountRuntimeTargetSettingsSync(
     rateLimits,

--- a/src/main/rate-limits/antigravity-cli-usage.test.ts
+++ b/src/main/rate-limits/antigravity-cli-usage.test.ts
@@ -65,4 +65,24 @@ describe('parseAntigravityCliUsage', () => {
     expect(limits.weekly).toBeNull()
     expect(limits.error).toBeTruthy()
   })
+
+  // Why: Antigravity bills two independent pools with their own resets (see #9122),
+  // so both must survive as named buckets, not just the headline Gemini numbers.
+  it('exposes both quota pools as named buckets', () => {
+    const limits = parseAntigravityCliUsage(SAMPLE, UPDATED_AT)
+
+    expect(limits.buckets?.map((bucket) => bucket.name)).toEqual([
+      'Gemini Models · 7d',
+      'Gemini Models · 5h',
+      'Claude and GPT models · 7d',
+      'Claude and GPT models · 5h'
+    ])
+  })
+
+  it('marks the source as cli so the meter can explain itself', () => {
+    expect(parseAntigravityCliUsage(SAMPLE, UPDATED_AT).usageMetadata?.source).toBe('cli')
+    expect(parseAntigravityCliUsage('nope', UPDATED_AT).usageMetadata?.failureKind).toBe(
+      'usage-unavailable'
+    )
+  })
 })

--- a/src/main/rate-limits/antigravity-cli-usage.test.ts
+++ b/src/main/rate-limits/antigravity-cli-usage.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+import { parseAntigravityCliUsage } from './antigravity-cli-usage'
+
+// Real `agy -p "/usage"` output: family, window label, remaining percentage, reset instant.
+const SAMPLE = [
+  'Gemini Models\tWeekly Limit Remaining\t100%\t2026-09-02T17:02:52Z',
+  'Gemini Models\tFive Hour Limit Remaining\t100%\t2026-08-26T22:02:52Z',
+  'Claude and GPT models\tWeekly Limit Remaining\t100%\t2026-09-02T17:02:52Z',
+  'Claude and GPT models\tFive Hour Limit Remaining\t100%\t2026-08-26T22:02:52Z'
+].join('\n')
+
+const UPDATED_AT = 1_700_000_000_000
+
+describe('parseAntigravityCliUsage', () => {
+  it('maps the five hour row to the session window', () => {
+    const limits = parseAntigravityCliUsage(SAMPLE, UPDATED_AT)
+
+    expect(limits.provider).toBe('antigravity')
+    expect(limits.status).toBe('ok')
+    expect(limits.error).toBeNull()
+    expect(limits.session?.windowMinutes).toBe(300)
+    expect(limits.session?.resetsAt).toBe(Date.parse('2026-08-26T22:02:52Z'))
+  })
+
+  it('maps the weekly row to the weekly window', () => {
+    const limits = parseAntigravityCliUsage(SAMPLE, UPDATED_AT)
+
+    expect(limits.weekly?.windowMinutes).toBe(10080)
+    expect(limits.weekly?.resetsAt).toBe(Date.parse('2026-09-02T17:02:52Z'))
+  })
+
+  // Why: the CLI reports what is left, but every other provider in Orca reports what is spent.
+  it('converts remaining percentage into used percentage', () => {
+    const limits = parseAntigravityCliUsage(SAMPLE, UPDATED_AT)
+
+    expect(limits.session?.usedPercent).toBe(0)
+    expect(limits.weekly?.usedPercent).toBe(0)
+
+    const partial = parseAntigravityCliUsage(
+      'Gemini Models\tFive Hour Limit Remaining\t42%\t2026-08-26T22:02:52Z',
+      UPDATED_AT
+    )
+
+    expect(partial.session?.usedPercent).toBe(58)
+  })
+
+  // Why: the CLI prints both families; Gemini is the provider's own quota and must win.
+  it('prefers the Gemini family over the Claude and GPT family', () => {
+    const limits = parseAntigravityCliUsage(
+      [
+        'Claude and GPT models\tFive Hour Limit Remaining\t10%\t2026-08-26T22:02:52Z',
+        'Gemini Models\tFive Hour Limit Remaining\t70%\t2026-08-26T22:02:52Z'
+      ].join('\n'),
+      UPDATED_AT
+    )
+
+    expect(limits.session?.usedPercent).toBe(30)
+  })
+
+  it('reports unavailable when no usage row can be read', () => {
+    const limits = parseAntigravityCliUsage('Please sign in to view usage.', UPDATED_AT)
+
+    expect(limits.status).toBe('unavailable')
+    expect(limits.session).toBeNull()
+    expect(limits.weekly).toBeNull()
+    expect(limits.error).toBeTruthy()
+  })
+})

--- a/src/main/rate-limits/antigravity-cli-usage.ts
+++ b/src/main/rate-limits/antigravity-cli-usage.ts
@@ -1,34 +1,59 @@
-import { execFile } from 'node:child_process'
 import { access, constants } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import path from 'node:path'
-import { promisify } from 'node:util'
+import { runProcess } from '../../shared/child-process/run-process'
+import { windowsSystem32Binary } from '../../shared/child-process/windows-system-binary'
+import type { LocalAccountRuntimeTarget } from '../../shared/local-account-runtime'
+import { buildPosixCommandPathLookupScript } from '../../shared/posix-command-path-lookup'
 import type {
   ProviderRateLimits,
   RateLimitBucket,
   RateLimitWindow
 } from '../../shared/rate-limit-types'
-
-const execFileAsync = promisify(execFile)
+import {
+  buildWslCapturedLoginShellCommand,
+  buildWslExecArgs
+} from '../../shared/wsl-login-shell-command'
+import { translateMain } from '../i18n/main-i18n'
 
 const SESSION_WINDOW_MINUTES = 300
 const WEEKLY_WINDOW_MINUTES = 10080
 
-// Why: `agy` keeps its token in the OS keyring, so reading files the way the Gemini
-// fetcher does can never describe Antigravity. `/usage` works in print mode and prints
-// one tab separated row per model family and window, which is the supported way in.
+// `agy` keeps its token in the OS keyring, so only the CLI itself can report the quota.
 const USAGE_ARGS = ['-p', '/usage', '--print-timeout', '30s']
+// Outlives the CLI's own 30s print timeout so the child reports rather than being killed.
+const PROCESS_TIMEOUT_MS = 45_000
 
-const ANTIGRAVITY_CLI_MISSING_REASON =
-  'Antigravity usage is not available. The Antigravity CLI (agy) was not found on this machine.'
-const ANTIGRAVITY_CLI_UNREADABLE_REASON =
-  'Antigravity usage is not available. The Antigravity CLI did not report a quota; sign in with `agy` and try again.'
+const cliMissingReason = (): string =>
+  translateMain(
+    'rateLimits.antigravity.cliMissing',
+    'Antigravity usage is not available. The Antigravity CLI (agy) was not found on this machine.'
+  )
 
-/** Resolves only when the path exists and is executable. */
+const quotaUnreadableReason = (): string =>
+  translateMain(
+    'rateLimits.antigravity.quotaUnreadable',
+    'Antigravity usage is not available. The Antigravity CLI did not report a quota; sign in with `agy` and try again.'
+  )
+
+function unavailable(
+  reason: string,
+  failureKind: 'cli-unavailable' | 'usage-unavailable'
+): ProviderRateLimits {
+  return {
+    provider: 'antigravity',
+    session: null,
+    weekly: null,
+    updatedAt: Date.now(),
+    error: reason,
+    status: 'unavailable',
+    usageMetadata: { source: 'cli', failureKind }
+  }
+}
+
+/** Exists and is executable; X_OK is a no-op on Windows, where the PATH sweep does the work. */
 async function isExecutable(filePath: string): Promise<boolean> {
   try {
-    // Why: X_OK, not a bare existence check. A leftover file from an older install
-    // still "exists" and would shadow a working `agy` found later in the list.
     await access(filePath, constants.X_OK)
     return true
   } catch {
@@ -36,27 +61,25 @@ async function isExecutable(filePath: string): Promise<boolean> {
   }
 }
 
-/**
- * Finds the `agy` executable, preferring PATH and falling back to the installer's
- * fixed prefix. Returns null when no executable candidate is found.
- */
-async function resolveAntigravityBinary(): Promise<string | null> {
-  const [lookup, args] = process.platform === 'win32' ? ['where.exe', ['agy']] : ['which', ['agy']]
+/** Host `agy` path from PATH, then the installer's fixed prefix. Null when none is executable. */
+async function resolveHostBinary(signal?: AbortSignal): Promise<string | null> {
+  const lookup =
+    process.platform === 'win32'
+      ? { program: windowsSystem32Binary('where.exe'), args: ['agy'] }
+      : { program: '/usr/bin/which', args: ['agy'] }
   try {
-    // execFile, not exec: `exec` implies `shell: true`, which silently makes
-    // windowsHide a no-op, so the console-subsystem `where` would flash a conhost.
-    const { stdout } = await execFileAsync(lookup, args, { encoding: 'utf-8', windowsHide: true })
-    for (const candidate of stdout.trim().split(/\r?\n/)) {
+    const result = await runProcess({ ...lookup, timeoutMs: 5_000, signal })
+    // Every hit, not just the first: a stale entry earlier on PATH would hide a working one.
+    for (const candidate of result.stdout.trim().split(/\r?\n/)) {
       if (candidate && (await isExecutable(candidate))) {
         return candidate
       }
     }
   } catch {
-    // ignore which/where failure
+    // ignore where/which failure
   }
 
-  // Why: the installer writes the Windows User PATH registry entry, so an Orca process
-  // started before the install never sees it. The install prefix is fixed per platform.
+  // The installer writes the User PATH registry entry, which an already-running Orca never sees.
   const fallbacks =
     process.platform === 'win32'
       ? [path.join(process.env.LOCALAPPDATA ?? '', 'agy', 'bin', 'agy.exe')]
@@ -81,9 +104,9 @@ type ParsedRow = {
   window: RateLimitWindow
 }
 
-/** Parses one `family <tab> window <tab> remaining% <tab> reset` row, or null if it is not one. */
+/** One `family <tab> window <tab> remaining% <tab> reset` row, or null when it is not one. */
 function parseRow(line: string): ParsedRow | null {
-  // The CLI separates columns with tabs, but padded spaces survive some terminals.
+  // Tabs normally, but padded spaces survive some terminals.
   const columns = line
     .split(/\t|\s{2,}/)
     .map((column) => column.trim())
@@ -107,7 +130,7 @@ function parseRow(line: string): ParsedRow | null {
     return null
   }
 
-  // Why: the CLI reports what is left; every other Orca provider reports what is spent.
+  // The CLI reports what is left; every other Orca provider reports what is spent.
   const usedPercent = Math.min(100, Math.max(0, 100 - Number(remaining)))
   const parsedReset = resetAt ? Date.parse(resetAt) : Number.NaN
 
@@ -127,10 +150,8 @@ function parseRow(line: string): ParsedRow | null {
 /**
  * Converts `agy -p "/usage"` output into provider rate limits.
  *
- * Antigravity plans bill two independent pools ("Gemini Models" and "Claude and GPT
- * models") with their own reset times, so both are exposed as named buckets. The
- * headline session and weekly windows come from the Gemini pool, which is the
- * provider's own quota.
+ * Antigravity bills two independent pools with their own resets (#9122), so both survive
+ * as named buckets; the headline windows come from the Gemini pool.
  */
 export function parseAntigravityCliUsage(stdout: string, updatedAt: number): ProviderRateLimits {
   const rows = stdout
@@ -148,15 +169,7 @@ export function parseAntigravityCliUsage(stdout: string, updatedAt: number): Pro
   const weekly = pick(WEEKLY_WINDOW_MINUTES)
 
   if (!session && !weekly) {
-    return {
-      provider: 'antigravity',
-      session: null,
-      weekly: null,
-      updatedAt,
-      error: ANTIGRAVITY_CLI_UNREADABLE_REASON,
-      status: 'unavailable',
-      usageMetadata: { source: 'cli', failureKind: 'usage-unavailable' }
-    }
+    return { ...unavailable(quotaUnreadableReason(), 'usage-unavailable'), updatedAt }
   }
 
   const buckets: RateLimitBucket[] = rows.map((row) => ({
@@ -176,48 +189,77 @@ export function parseAntigravityCliUsage(stdout: string, updatedAt: number): Pro
   }
 }
 
-/**
- * Reads Antigravity quota by running the local Antigravity CLI.
- *
- * Scope note: this describes the machine Orca's main process runs on, which is the same
- * scope the Gemini read it replaces already had — `fetchGeminiRateLimits` reads local
- * credentials with no runtime target either. Per-runtime targeting for both providers is
- * a separate change.
- */
-export async function fetchAntigravityRateLimits(
-  signal?: AbortSignal
-): Promise<ProviderRateLimits> {
-  const binary = await resolveAntigravityBinary()
-  if (!binary) {
-    return {
-      provider: 'antigravity',
-      session: null,
-      weekly: null,
-      updatedAt: Date.now(),
-      error: ANTIGRAVITY_CLI_MISSING_REASON,
-      status: 'unavailable',
-      usageMetadata: { source: 'cli', failureKind: 'cli-unavailable' }
+/** Asks the distro's own `agy`, fenced because the login shell prints its banner to stdout. */
+async function fetchFromWsl(distro: string, signal?: AbortSignal): Promise<ProviderRateLimits> {
+  // skipWindowsMountDirs so the Windows agy on the mounted PATH cannot answer for the guest.
+  const command = [
+    buildPosixCommandPathLookupScript(
+      { kind: 'literal', value: 'agy' },
+      { skipWindowsMountDirs: true }
+    ),
+    'if [ -z "$resolved" ]; then exit 127; fi',
+    `exec "$resolved" ${USAGE_ARGS.join(' ')}`
+  ].join('\n')
+  const captured = buildWslCapturedLoginShellCommand(command)
+
+  try {
+    const result = await runProcess({
+      program: windowsSystem32Binary('wsl.exe'),
+      args: buildWslExecArgs(distro, ['sh', '-c', captured.command]),
+      timeoutMs: PROCESS_TIMEOUT_MS,
+      signal
+    })
+    const payload = captured.readStdout(result.stdout)
+    if (result.code !== 0 || payload === null) {
+      return unavailable(
+        result.code === 127 ? cliMissingReason() : quotaUnreadableReason(),
+        result.code === 127 ? 'cli-unavailable' : 'usage-unavailable'
+      )
     }
+    return parseAntigravityCliUsage(payload, Date.now())
+  } catch {
+    return unavailable(quotaUnreadableReason(), 'usage-unavailable')
+  }
+}
+
+/**
+ * Reads Antigravity quota from the CLI on the runtime that owns it.
+ *
+ * `agy` signs in per runtime and keeps the token in that runtime's keyring, so a WSL target
+ * must be asked inside WSL — the host copy would answer for a different account (#12370).
+ *
+ * `RateLimitService` models only host and WSL, so SSH targets cannot be honoured here yet;
+ * that needs execution-host awareness across the service (see ssh-execution-boundary.md).
+ */
+export async function fetchAntigravityRateLimits(options?: {
+  target?: LocalAccountRuntimeTarget
+  signal?: AbortSignal
+}): Promise<ProviderRateLimits> {
+  const { target, signal } = options ?? {}
+
+  if (target?.runtime === 'wsl') {
+    return target.wslDistro
+      ? await fetchFromWsl(target.wslDistro, signal)
+      : unavailable(cliMissingReason(), 'cli-unavailable')
+  }
+
+  const binary = await resolveHostBinary(signal)
+  if (!binary) {
+    return unavailable(cliMissingReason(), 'cli-unavailable')
   }
 
   try {
-    const { stdout } = await execFileAsync(binary, USAGE_ARGS, {
-      encoding: 'utf-8',
-      windowsHide: true,
+    const result = await runProcess({
+      program: binary,
+      args: USAGE_ARGS,
+      timeoutMs: PROCESS_TIMEOUT_MS,
       signal
     })
-    return parseAntigravityCliUsage(stdout, Date.now())
+    // A non-zero exit means signed out or an unreachable backend, not an Orca error.
+    return result.code === 0
+      ? parseAntigravityCliUsage(result.stdout, Date.now())
+      : unavailable(quotaUnreadableReason(), 'usage-unavailable')
   } catch {
-    // Why: a non-zero exit means signed out or an unreachable backend. Neither is an Orca
-    // error the user can act on from the meter, so it reads as unavailable, not failed.
-    return {
-      provider: 'antigravity',
-      session: null,
-      weekly: null,
-      updatedAt: Date.now(),
-      error: ANTIGRAVITY_CLI_UNREADABLE_REASON,
-      status: 'unavailable',
-      usageMetadata: { source: 'cli', failureKind: 'usage-unavailable' }
-    }
+    return unavailable(quotaUnreadableReason(), 'usage-unavailable')
   }
 }

--- a/src/main/rate-limits/antigravity-cli-usage.ts
+++ b/src/main/rate-limits/antigravity-cli-usage.ts
@@ -1,18 +1,22 @@
 import { execFile } from 'node:child_process'
-import { access } from 'node:fs/promises'
+import { access, constants } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import path from 'node:path'
 import { promisify } from 'node:util'
-import type { ProviderRateLimits, RateLimitWindow } from '../../shared/rate-limit-types'
+import type {
+  ProviderRateLimits,
+  RateLimitBucket,
+  RateLimitWindow
+} from '../../shared/rate-limit-types'
 
 const execFileAsync = promisify(execFile)
 
 const SESSION_WINDOW_MINUTES = 300
 const WEEKLY_WINDOW_MINUTES = 10080
 
-// Why: `agy` keeps its token in the OS keyring, so the only supported way to read the
-// quota is to ask the CLI itself. `/usage` works in print mode and prints one tab
-// separated row per family and window.
+// Why: `agy` keeps its token in the OS keyring, so reading files the way the Gemini
+// fetcher does can never describe Antigravity. `/usage` works in print mode and prints
+// one tab separated row per model family and window, which is the supported way in.
 const USAGE_ARGS = ['-p', '/usage', '--print-timeout', '30s']
 
 const ANTIGRAVITY_CLI_MISSING_REASON =
@@ -20,31 +24,39 @@ const ANTIGRAVITY_CLI_MISSING_REASON =
 const ANTIGRAVITY_CLI_UNREADABLE_REASON =
   'Antigravity usage is not available. The Antigravity CLI did not report a quota; sign in with `agy` and try again.'
 
-async function fileExists(filePath: string): Promise<boolean> {
+/** Resolves only when the path exists and is executable. */
+async function isExecutable(filePath: string): Promise<boolean> {
   try {
-    await access(filePath)
+    // Why: X_OK, not a bare existence check. A leftover file from an older install
+    // still "exists" and would shadow a working `agy` found later in the list.
+    await access(filePath, constants.X_OK)
     return true
   } catch {
     return false
   }
 }
 
+/**
+ * Finds the `agy` executable, preferring PATH and falling back to the installer's
+ * fixed prefix. Returns null when no executable candidate is found.
+ */
 async function resolveAntigravityBinary(): Promise<string | null> {
   const [lookup, args] = process.platform === 'win32' ? ['where.exe', ['agy']] : ['which', ['agy']]
   try {
     // execFile, not exec: `exec` implies `shell: true`, which silently makes
     // windowsHide a no-op, so the console-subsystem `where` would flash a conhost.
     const { stdout } = await execFileAsync(lookup, args, { encoding: 'utf-8', windowsHide: true })
-    const fromPath = stdout.trim().split(/\r?\n/)[0]
-    if (fromPath && (await fileExists(fromPath))) {
-      return fromPath
+    for (const candidate of stdout.trim().split(/\r?\n/)) {
+      if (candidate && (await isExecutable(candidate))) {
+        return candidate
+      }
     }
   } catch {
     // ignore which/where failure
   }
 
-  // Why: the installer writes the User PATH registry entry, so an Orca process started
-  // before the install never sees it. The install prefix is fixed per platform.
+  // Why: the installer writes the Windows User PATH registry entry, so an Orca process
+  // started before the install never sees it. The install prefix is fixed per platform.
   const fallbacks =
     process.platform === 'win32'
       ? [path.join(process.env.LOCALAPPDATA ?? '', 'agy', 'bin', 'agy.exe')]
@@ -54,7 +66,7 @@ async function resolveAntigravityBinary(): Promise<string | null> {
           '/opt/homebrew/bin/agy'
         ]
   for (const candidate of fallbacks) {
-    if (candidate && (await fileExists(candidate))) {
+    if (candidate && (await isExecutable(candidate))) {
       return candidate
     }
   }
@@ -63,11 +75,13 @@ async function resolveAntigravityBinary(): Promise<string | null> {
 }
 
 type ParsedRow = {
+  family: string
   isGeminiFamily: boolean
   windowMinutes: number
   window: RateLimitWindow
 }
 
+/** Parses one `family <tab> window <tab> remaining% <tab> reset` row, or null if it is not one. */
 function parseRow(line: string): ParsedRow | null {
   // The CLI separates columns with tabs, but padded spaces survive some terminals.
   const columns = line
@@ -98,6 +112,7 @@ function parseRow(line: string): ParsedRow | null {
   const parsedReset = resetAt ? Date.parse(resetAt) : Number.NaN
 
   return {
+    family,
     isGeminiFamily: /gemini/i.test(family),
     windowMinutes,
     window: {
@@ -109,14 +124,20 @@ function parseRow(line: string): ParsedRow | null {
   }
 }
 
+/**
+ * Converts `agy -p "/usage"` output into provider rate limits.
+ *
+ * Antigravity plans bill two independent pools ("Gemini Models" and "Claude and GPT
+ * models") with their own reset times, so both are exposed as named buckets. The
+ * headline session and weekly windows come from the Gemini pool, which is the
+ * provider's own quota.
+ */
 export function parseAntigravityCliUsage(stdout: string, updatedAt: number): ProviderRateLimits {
   const rows = stdout
     .split(/\r?\n/)
     .map(parseRow)
     .filter((row): row is ParsedRow => row !== null)
 
-  // Why: `agy` prints a Gemini family and a "Claude and GPT models" family. Gemini is the
-  // provider's own quota, so it wins; the other family only fills a window Gemini omitted.
   const pick = (windowMinutes: number): RateLimitWindow | null => {
     const candidates = rows.filter((row) => row.windowMinutes === windowMinutes)
     const preferred = candidates.find((row) => row.isGeminiFamily) ?? candidates[0]
@@ -138,10 +159,16 @@ export function parseAntigravityCliUsage(stdout: string, updatedAt: number): Pro
     }
   }
 
+  const buckets: RateLimitBucket[] = rows.map((row) => ({
+    ...row.window,
+    name: `${row.family} · ${row.windowMinutes === SESSION_WINDOW_MINUTES ? '5h' : '7d'}`
+  }))
+
   return {
     provider: 'antigravity',
     session,
     weekly,
+    buckets,
     updatedAt,
     error: null,
     status: 'ok',
@@ -149,6 +176,14 @@ export function parseAntigravityCliUsage(stdout: string, updatedAt: number): Pro
   }
 }
 
+/**
+ * Reads Antigravity quota by running the local Antigravity CLI.
+ *
+ * Scope note: this describes the machine Orca's main process runs on, which is the same
+ * scope the Gemini read it replaces already had — `fetchGeminiRateLimits` reads local
+ * credentials with no runtime target either. Per-runtime targeting for both providers is
+ * a separate change.
+ */
 export async function fetchAntigravityRateLimits(
   signal?: AbortSignal
 ): Promise<ProviderRateLimits> {

--- a/src/main/rate-limits/antigravity-cli-usage.ts
+++ b/src/main/rate-limits/antigravity-cli-usage.ts
@@ -1,0 +1,188 @@
+import { execFile } from 'node:child_process'
+import { access } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import type { ProviderRateLimits, RateLimitWindow } from '../../shared/rate-limit-types'
+
+const execFileAsync = promisify(execFile)
+
+const SESSION_WINDOW_MINUTES = 300
+const WEEKLY_WINDOW_MINUTES = 10080
+
+// Why: `agy` keeps its token in the OS keyring, so the only supported way to read the
+// quota is to ask the CLI itself. `/usage` works in print mode and prints one tab
+// separated row per family and window.
+const USAGE_ARGS = ['-p', '/usage', '--print-timeout', '30s']
+
+const ANTIGRAVITY_CLI_MISSING_REASON =
+  'Antigravity usage is not available. The Antigravity CLI (agy) was not found on this machine.'
+const ANTIGRAVITY_CLI_UNREADABLE_REASON =
+  'Antigravity usage is not available. The Antigravity CLI did not report a quota; sign in with `agy` and try again.'
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function resolveAntigravityBinary(): Promise<string | null> {
+  const [lookup, args] = process.platform === 'win32' ? ['where.exe', ['agy']] : ['which', ['agy']]
+  try {
+    // execFile, not exec: `exec` implies `shell: true`, which silently makes
+    // windowsHide a no-op, so the console-subsystem `where` would flash a conhost.
+    const { stdout } = await execFileAsync(lookup, args, { encoding: 'utf-8', windowsHide: true })
+    const fromPath = stdout.trim().split(/\r?\n/)[0]
+    if (fromPath && (await fileExists(fromPath))) {
+      return fromPath
+    }
+  } catch {
+    // ignore which/where failure
+  }
+
+  // Why: the installer writes the User PATH registry entry, so an Orca process started
+  // before the install never sees it. The install prefix is fixed per platform.
+  const fallbacks =
+    process.platform === 'win32'
+      ? [path.join(process.env.LOCALAPPDATA ?? '', 'agy', 'bin', 'agy.exe')]
+      : [
+          path.join(homedir(), '.local', 'bin', 'agy'),
+          '/usr/local/bin/agy',
+          '/opt/homebrew/bin/agy'
+        ]
+  for (const candidate of fallbacks) {
+    if (candidate && (await fileExists(candidate))) {
+      return candidate
+    }
+  }
+
+  return null
+}
+
+type ParsedRow = {
+  isGeminiFamily: boolean
+  windowMinutes: number
+  window: RateLimitWindow
+}
+
+function parseRow(line: string): ParsedRow | null {
+  // The CLI separates columns with tabs, but padded spaces survive some terminals.
+  const columns = line
+    .split(/\t|\s{2,}/)
+    .map((column) => column.trim())
+    .filter(Boolean)
+  if (columns.length < 3) {
+    return null
+  }
+
+  const [family, label, percent, resetAt] = columns
+  const remaining = /^(\d+(?:\.\d+)?)%$/.exec(percent)?.[1]
+  if (remaining === undefined) {
+    return null
+  }
+
+  const windowMinutes = /five\s*hour/i.test(label)
+    ? SESSION_WINDOW_MINUTES
+    : /week/i.test(label)
+      ? WEEKLY_WINDOW_MINUTES
+      : null
+  if (windowMinutes === null) {
+    return null
+  }
+
+  // Why: the CLI reports what is left; every other Orca provider reports what is spent.
+  const usedPercent = Math.min(100, Math.max(0, 100 - Number(remaining)))
+  const parsedReset = resetAt ? Date.parse(resetAt) : Number.NaN
+
+  return {
+    isGeminiFamily: /gemini/i.test(family),
+    windowMinutes,
+    window: {
+      usedPercent,
+      windowMinutes,
+      resetsAt: Number.isNaN(parsedReset) ? null : parsedReset,
+      resetDescription: null
+    }
+  }
+}
+
+export function parseAntigravityCliUsage(stdout: string, updatedAt: number): ProviderRateLimits {
+  const rows = stdout
+    .split(/\r?\n/)
+    .map(parseRow)
+    .filter((row): row is ParsedRow => row !== null)
+
+  // Why: `agy` prints a Gemini family and a "Claude and GPT models" family. Gemini is the
+  // provider's own quota, so it wins; the other family only fills a window Gemini omitted.
+  const pick = (windowMinutes: number): RateLimitWindow | null => {
+    const candidates = rows.filter((row) => row.windowMinutes === windowMinutes)
+    const preferred = candidates.find((row) => row.isGeminiFamily) ?? candidates[0]
+    return preferred?.window ?? null
+  }
+
+  const session = pick(SESSION_WINDOW_MINUTES)
+  const weekly = pick(WEEKLY_WINDOW_MINUTES)
+
+  if (!session && !weekly) {
+    return {
+      provider: 'antigravity',
+      session: null,
+      weekly: null,
+      updatedAt,
+      error: ANTIGRAVITY_CLI_UNREADABLE_REASON,
+      status: 'unavailable',
+      usageMetadata: { source: 'cli', failureKind: 'usage-unavailable' }
+    }
+  }
+
+  return {
+    provider: 'antigravity',
+    session,
+    weekly,
+    updatedAt,
+    error: null,
+    status: 'ok',
+    usageMetadata: { source: 'cli' }
+  }
+}
+
+export async function fetchAntigravityRateLimits(
+  signal?: AbortSignal
+): Promise<ProviderRateLimits> {
+  const binary = await resolveAntigravityBinary()
+  if (!binary) {
+    return {
+      provider: 'antigravity',
+      session: null,
+      weekly: null,
+      updatedAt: Date.now(),
+      error: ANTIGRAVITY_CLI_MISSING_REASON,
+      status: 'unavailable',
+      usageMetadata: { source: 'cli', failureKind: 'cli-unavailable' }
+    }
+  }
+
+  try {
+    const { stdout } = await execFileAsync(binary, USAGE_ARGS, {
+      encoding: 'utf-8',
+      windowsHide: true,
+      signal
+    })
+    return parseAntigravityCliUsage(stdout, Date.now())
+  } catch {
+    // Why: a non-zero exit means signed out or an unreachable backend. Neither is an Orca
+    // error the user can act on from the meter, so it reads as unavailable, not failed.
+    return {
+      provider: 'antigravity',
+      session: null,
+      weekly: null,
+      updatedAt: Date.now(),
+      error: ANTIGRAVITY_CLI_UNREADABLE_REASON,
+      status: 'unavailable',
+      usageMetadata: { source: 'cli', failureKind: 'usage-unavailable' }
+    }
+  }
+}

--- a/src/main/rate-limits/rate-limit-service-test-harness.ts
+++ b/src/main/rate-limits/rate-limit-service-test-harness.ts
@@ -4,6 +4,7 @@ import type { ProviderRateLimits } from '../../shared/rate-limit-types'
 import type { RateLimitService } from './service'
 import { fetchCodexRateLimits } from './codex-fetcher'
 import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
+import { fetchAntigravityRateLimits } from './antigravity-cli-usage'
 import { fetchKimiRateLimits } from './kimi-fetcher'
 import { fetchMiniMaxRateLimits } from './minimax-fetcher'
 import { fetchGrokRateLimits } from './grok-fetcher'
@@ -95,6 +96,16 @@ export function mockFreshBackgroundProviderFetches(): void {
 export function resetRateLimitProviderMocks(): void {
   vi.clearAllMocks()
   vi.mocked(fetchGeminiRateLimits).mockResolvedValue(okProvider('gemini', 0, Date.now()))
+  // Default to a machine without the Antigravity CLI, which is the mirror path.
+  vi.mocked(fetchAntigravityRateLimits).mockResolvedValue({
+    provider: 'antigravity',
+    session: null,
+    weekly: null,
+    updatedAt: Date.now(),
+    error: 'Antigravity CLI not found.',
+    status: 'unavailable',
+    usageMetadata: { source: 'cli', failureKind: 'cli-unavailable' }
+  })
   vi.mocked(fetchOpenCodeGoRateLimits).mockResolvedValue(okProvider('opencode-go', 0, Date.now()))
   vi.mocked(fetchKimiRateLimits).mockResolvedValue(okProvider('kimi', 0, Date.now()))
   vi.mocked(fetchMiniMaxRateLimits).mockResolvedValue(okProvider('minimax', 0, Date.now()))

--- a/src/main/rate-limits/service-account-target-selection.test.ts
+++ b/src/main/rate-limits/service-account-target-selection.test.ts
@@ -24,6 +24,10 @@ vi.mock('./gemini-usage-fetcher', () => ({
   fetchGeminiRateLimits: vi.fn()
 }))
 
+vi.mock('./antigravity-cli-usage', () => ({
+  fetchAntigravityRateLimits: vi.fn()
+}))
+
 vi.mock('./kimi-fetcher', () => ({
   fetchKimiRateLimits: vi.fn()
 }))

--- a/src/main/rate-limits/service-antigravity-usage.test.ts
+++ b/src/main/rate-limits/service-antigravity-usage.test.ts
@@ -1,8 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { RateLimitService } from './service'
+import type { ProviderRateLimits } from '../../shared/rate-limit-types'
 import { fetchClaudeRateLimits } from './claude-fetcher'
 import { fetchCodexRateLimits } from './codex-fetcher'
 import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
+import { fetchAntigravityRateLimits } from './antigravity-cli-usage'
 import {
   errorProvider,
   okProvider,
@@ -21,6 +23,10 @@ vi.mock('./codex-fetcher', () => ({
 
 vi.mock('./gemini-usage-fetcher', () => ({
   fetchGeminiRateLimits: vi.fn()
+}))
+
+vi.mock('./antigravity-cli-usage', () => ({
+  fetchAntigravityRateLimits: vi.fn()
 }))
 
 vi.mock('./kimi-fetcher', () => ({
@@ -47,11 +53,25 @@ vi.mock('../minimax/minimax-cookie-store', () => ({
   hasMiniMaxSessionCookie: vi.fn(() => false)
 }))
 
+function cliUnavailable(failureKind: 'cli-unavailable' | 'usage-unavailable'): ProviderRateLimits {
+  return {
+    provider: 'antigravity',
+    session: null,
+    weekly: null,
+    updatedAt: Date.now(),
+    error: 'Antigravity usage is not available.',
+    status: 'unavailable',
+    usageMetadata: { source: 'cli', failureKind }
+  }
+}
+
 describe('RateLimitService Antigravity usage', () => {
   beforeEach(() => {
     resetRateLimitProviderMocks()
     vi.mocked(fetchClaudeRateLimits).mockResolvedValue(okProvider('claude', 7))
     vi.mocked(fetchCodexRateLimits).mockResolvedValue(okProvider('codex', 20))
+    // Default to a machine without the CLI, so the mirror stays under test.
+    vi.mocked(fetchAntigravityRateLimits).mockResolvedValue(cliUnavailable('cli-unavailable'))
   })
 
   it('does not republish a Gemini failure as an Antigravity refresh failure', async () => {
@@ -96,5 +116,31 @@ describe('RateLimitService Antigravity usage', () => {
     // Why: stale-retention would otherwise show Gemini numbers as "Refresh failed" Antigravity usage.
     expect(service.getState().antigravity?.status).toBe('unavailable')
     expect(service.getState().antigravity?.session).toBeNull()
+  })
+
+  it('prefers a real CLI reading over the Gemini mirror', async () => {
+    vi.mocked(fetchGeminiRateLimits).mockResolvedValue(okProvider('gemini', 42, Date.now()))
+    vi.mocked(fetchAntigravityRateLimits).mockResolvedValue(
+      okProvider('antigravity', 11, Date.now())
+    )
+    const service = new RateLimitService()
+
+    await service.refresh()
+
+    // Why: the CLI describes Antigravity's own pools; the mirror only ever approximated them.
+    expect(service.getState().antigravity?.session?.usedPercent).toBe(11)
+  })
+
+  it('lets a signed-out CLI answer for itself instead of blaming Gemini', async () => {
+    vi.mocked(fetchGeminiRateLimits).mockResolvedValue(okProvider('gemini', 42, Date.now()))
+    vi.mocked(fetchAntigravityRateLimits).mockResolvedValue(cliUnavailable('usage-unavailable'))
+    const service = new RateLimitService()
+
+    await service.refresh()
+
+    const state = service.getState()
+    expect(state.antigravity?.status).toBe('unavailable')
+    // Why: mirroring here would show Gemini numbers for an account that is not signed in.
+    expect(state.antigravity?.session).toBeNull()
   })
 })

--- a/src/main/rate-limits/service-inactive-account-previews.test.ts
+++ b/src/main/rate-limits/service-inactive-account-previews.test.ts
@@ -31,6 +31,10 @@ vi.mock('./gemini-usage-fetcher', () => ({
   fetchGeminiRateLimits: vi.fn()
 }))
 
+vi.mock('./antigravity-cli-usage', () => ({
+  fetchAntigravityRateLimits: vi.fn()
+}))
+
 vi.mock('./kimi-fetcher', () => ({
   fetchKimiRateLimits: vi.fn()
 }))

--- a/src/main/rate-limits/service-live-claude-usage.test.ts
+++ b/src/main/rate-limits/service-live-claude-usage.test.ts
@@ -28,6 +28,10 @@ vi.mock('./gemini-usage-fetcher', () => ({
   fetchGeminiRateLimits: vi.fn()
 }))
 
+vi.mock('./antigravity-cli-usage', () => ({
+  fetchAntigravityRateLimits: vi.fn()
+}))
+
 vi.mock('./kimi-fetcher', () => ({
   fetchKimiRateLimits: vi.fn()
 }))

--- a/src/main/rate-limits/service-minimax-usage.test.ts
+++ b/src/main/rate-limits/service-minimax-usage.test.ts
@@ -25,6 +25,10 @@ vi.mock('./gemini-usage-fetcher', () => ({
   fetchGeminiRateLimits: vi.fn()
 }))
 
+vi.mock('./antigravity-cli-usage', () => ({
+  fetchAntigravityRateLimits: vi.fn()
+}))
+
 vi.mock('./kimi-fetcher', () => ({
   fetchKimiRateLimits: vi.fn()
 }))

--- a/src/main/rate-limits/service-refresh-orchestration.test.ts
+++ b/src/main/rate-limits/service-refresh-orchestration.test.ts
@@ -32,6 +32,10 @@ vi.mock('./gemini-usage-fetcher', () => ({
   fetchGeminiRateLimits: vi.fn()
 }))
 
+vi.mock('./antigravity-cli-usage', () => ({
+  fetchAntigravityRateLimits: vi.fn()
+}))
+
 vi.mock('./kimi-fetcher', () => ({
   fetchKimiRateLimits: vi.fn()
 }))

--- a/src/main/rate-limits/service-window-activation.test.ts
+++ b/src/main/rate-limits/service-window-activation.test.ts
@@ -33,6 +33,10 @@ vi.mock('./gemini-usage-fetcher', () => ({
   fetchGeminiRateLimits: vi.fn()
 }))
 
+vi.mock('./antigravity-cli-usage', () => ({
+  fetchAntigravityRateLimits: vi.fn()
+}))
+
 vi.mock('./kimi-fetcher', () => ({
   fetchKimiRateLimits: vi.fn()
 }))

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -22,6 +22,7 @@ import {
 import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
 import { deriveAntigravityRateLimits } from './antigravity-usage-mirror'
 import { fetchAntigravityRateLimits } from './antigravity-cli-usage'
+import type { LocalAccountRuntimeTarget } from '../../shared/local-account-runtime'
 import { fetchKimiRateLimits } from './kimi-fetcher'
 import type { KimiHomeResolution } from '../kimi/kimi-runtime-home'
 import { fetchGrokRateLimits } from './grok-fetcher'
@@ -229,6 +230,7 @@ export class RateLimitService {
   }
   // Why: resolved per cycle — the local-account runtime policy can flip between fetches.
   private kimiHomeResolver: KimiHomeResolver | null = null
+  private antigravityRuntimeTargetResolver: (() => LocalAccountRuntimeTarget) | null = null
   private claudeAuthPreparationResolver: ClaudeAuthPreparationResolver | null = null
   private claudeFetchTarget: NormalizedClaudeAccountSelectionTarget = {
     runtime: 'host',
@@ -285,6 +287,10 @@ export class RateLimitService {
 
   setKimiHomeResolver(resolver: KimiHomeResolver): void {
     this.kimiHomeResolver = resolver
+  }
+
+  setAntigravityRuntimeTargetResolver(resolver: () => LocalAccountRuntimeTarget): void {
+    this.antigravityRuntimeTargetResolver = resolver
   }
 
   // Why: resolving a WSL home probes wsl.exe, so it must not run before the other
@@ -1730,7 +1736,10 @@ export class RateLimitService {
             groupId: miniMaxGroupId,
             models: miniMaxModels
           }),
-      fetchAntigravityRateLimits(signal)
+      fetchAntigravityRateLimits({
+        target: this.antigravityRuntimeTargetResolver?.(),
+        signal
+      })
     ])
 
     if (signal.aborted) {

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -1315,6 +1315,13 @@ export class RateLimitService {
     return left.runtime === right.runtime && left.wslDistro === right.wslDistro
   }
 
+  private isSameAntigravityTarget(
+    left: LocalAccountRuntimeTarget | undefined,
+    right: LocalAccountRuntimeTarget | undefined
+  ): boolean {
+    return left?.runtime === right?.runtime && left?.wslDistro === right?.wslDistro
+  }
+
   private getCodexProvenance(
     target: NormalizedCodexAccountSelectionTarget,
     codexHomePath: string | null
@@ -1695,6 +1702,7 @@ export class RateLimitService {
     // Why: skip automated Claude fetches while a Retry-After window is open or a live session feed is fresher than the OAuth poll would be.
     const claudeFetchGated =
       !options?.force && this.shouldSkipAutomatedClaudeFetch(previousState.claude)
+    const antigravityTarget = this.antigravityRuntimeTargetResolver?.()
 
     const [
       claudeResult,
@@ -1737,7 +1745,7 @@ export class RateLimitService {
             models: miniMaxModels
           }),
       fetchAntigravityRateLimits({
-        target: this.antigravityRuntimeTargetResolver?.(),
+        target: antigravityTarget,
         signal
       })
     ])
@@ -1789,9 +1797,19 @@ export class RateLimitService {
     // describes real Antigravity quota. The Gemini mirror stays as the fallback for machines
     // where the Antigravity CLI is not installed; a signed-out CLI still answers for itself,
     // because blaming a missing Gemini sign-in would send the user to a dead product.
-    const antigravityCli = antigravityResult.status === 'fulfilled' ? antigravityResult.value : null
-    const antigravity =
-      antigravityCli && antigravityCli.usageMetadata?.failureKind !== 'cli-unavailable'
+    // A mid-flight runtime switch means this answer describes the runtime we left; keep the
+    // previous reading and let the next refresh ask the runtime that is current now.
+    const antigravityTargetStale = !this.isSameAntigravityTarget(
+      antigravityTarget,
+      this.antigravityRuntimeTargetResolver?.()
+    )
+    const antigravityCli =
+      !antigravityTargetStale && antigravityResult.status === 'fulfilled'
+        ? antigravityResult.value
+        : null
+    const antigravity = antigravityTargetStale
+      ? (previousState.antigravity ?? deriveAntigravityRateLimits(gemini))
+      : antigravityCli && antigravityCli.usageMetadata?.failureKind !== 'cli-unavailable'
         ? antigravityCli
         : deriveAntigravityRateLimits(gemini)
 

--- a/src/main/rate-limits/service.ts
+++ b/src/main/rate-limits/service.ts
@@ -21,6 +21,7 @@ import {
 } from '../claude-accounts/runtime-selection'
 import { fetchGeminiRateLimits } from './gemini-usage-fetcher'
 import { deriveAntigravityRateLimits } from './antigravity-usage-mirror'
+import { fetchAntigravityRateLimits } from './antigravity-cli-usage'
 import { fetchKimiRateLimits } from './kimi-fetcher'
 import type { KimiHomeResolution } from '../kimi/kimi-runtime-home'
 import { fetchGrokRateLimits } from './grok-fetcher'
@@ -1689,40 +1690,48 @@ export class RateLimitService {
     const claudeFetchGated =
       !options?.force && this.shouldSkipAutomatedClaudeFetch(previousState.claude)
 
-    const [claudeResult, codexResult, geminiResult, opencodeGoResult, kimiResult, miniMaxResult] =
-      await Promise.allSettled([
-        claudeFetchGated
-          ? Promise.resolve(previousState.claude as ProviderRateLimits)
-          : fetchClaudeRateLimits({
-              authPreparation: claudeAuthPreparation,
-              allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation),
-              allowUsagePanelSupplement: this.shouldAllowClaudeUsagePanelSupplement(),
-              networkProxySettings: this.networkProxySettingsResolver?.(),
-              signal
-            }),
-        codexFetchGated
-          ? Promise.resolve(previousState.codex as ProviderRateLimits)
-          : (missingWslCodexHome ??
-            fetchCodexRateLimits({
-              codexHomePath,
-              allowPtyFallback: this.shouldAllowCodexPtyFallback(),
-              signal
-            })),
-        fetchGeminiRateLimits(geminiCliOAuthEnabled),
-        fetchOpenCodeGoRateLimits(
-          cookie,
-          workspaceIdOverride || undefined,
-          this.networkProxySettingsResolver?.()
-        ),
-        this.fetchKimiWithResolvedHome(),
-        miniMaxConfigResult.error
-          ? Promise.resolve(this.getMiniMaxCredentialError(miniMaxConfigResult.error))
-          : fetchMiniMaxRateLimits({
-              cookie: miniMaxCookie,
-              groupId: miniMaxGroupId,
-              models: miniMaxModels
-            })
-      ])
+    const [
+      claudeResult,
+      codexResult,
+      geminiResult,
+      opencodeGoResult,
+      kimiResult,
+      miniMaxResult,
+      antigravityResult
+    ] = await Promise.allSettled([
+      claudeFetchGated
+        ? Promise.resolve(previousState.claude as ProviderRateLimits)
+        : fetchClaudeRateLimits({
+            authPreparation: claudeAuthPreparation,
+            allowPtyFallback: this.shouldAllowClaudePtyFallback(claudeAuthPreparation),
+            allowUsagePanelSupplement: this.shouldAllowClaudeUsagePanelSupplement(),
+            networkProxySettings: this.networkProxySettingsResolver?.(),
+            signal
+          }),
+      codexFetchGated
+        ? Promise.resolve(previousState.codex as ProviderRateLimits)
+        : (missingWslCodexHome ??
+          fetchCodexRateLimits({
+            codexHomePath,
+            allowPtyFallback: this.shouldAllowCodexPtyFallback(),
+            signal
+          })),
+      fetchGeminiRateLimits(geminiCliOAuthEnabled),
+      fetchOpenCodeGoRateLimits(
+        cookie,
+        workspaceIdOverride || undefined,
+        this.networkProxySettingsResolver?.()
+      ),
+      this.fetchKimiWithResolvedHome(),
+      miniMaxConfigResult.error
+        ? Promise.resolve(this.getMiniMaxCredentialError(miniMaxConfigResult.error))
+        : fetchMiniMaxRateLimits({
+            cookie: miniMaxCookie,
+            groupId: miniMaxGroupId,
+            models: miniMaxModels
+          }),
+      fetchAntigravityRateLimits(signal)
+    ])
 
     if (signal.aborted) {
       return
@@ -1767,8 +1776,15 @@ export class RateLimitService {
             status: 'error'
           } satisfies ProviderRateLimits)
 
-    // Why: Antigravity can only borrow a *successful* Gemini read; a Gemini failure is not an Antigravity failure.
-    const antigravity = deriveAntigravityRateLimits(gemini)
+    // Why: `agy` keeps its token in the OS keyring, so the CLI is the only source that
+    // describes real Antigravity quota. The Gemini mirror stays as the fallback for machines
+    // where the Antigravity CLI is not installed; a signed-out CLI still answers for itself,
+    // because blaming a missing Gemini sign-in would send the user to a dead product.
+    const antigravityCli = antigravityResult.status === 'fulfilled' ? antigravityResult.value : null
+    const antigravity =
+      antigravityCli && antigravityCli.usageMetadata?.failureKind !== 'cli-unavailable'
+        ? antigravityCli
+        : deriveAntigravityRateLimits(gemini)
 
     const opencodeGo =
       opencodeGoResult.status === 'fulfilled'


### PR DESCRIPTION
## ELI5

Orca's Antigravity meter was showing Gemini's numbers, because it assumed both share one quota. Google turned Gemini Code Assist off for individuals, so there is nothing left to copy and the meter reads `0%` forever. This asks the Antigravity CLI for its own numbers instead.

## What Changed

- New `fetchAntigravityRateLimits` runs `agy -p "/usage"` and parses its tab-separated rows.
- It joins the existing `Promise.allSettled` batch in `service.ts`, so it costs no extra wall-clock.
- Both quota pools survive as named buckets; the headline session/weekly windows come from the Gemini pool.
- `deriveAntigravityRateLimits` stays as the fallback, so machines without `agy` keep today's behaviour byte for byte.
- A CLI that is installed but signed out answers for itself instead of blaming a Gemini sign-in.

No renderer changes: the Antigravity status-bar toggle and label already exist and simply never received real data.

## Why

`deriveAntigravityRateLimits` derives the meter from a *successful* Gemini CLI read. Google stopped serving Gemini Code Assist for individual accounts on **2026-06-18** and directed those users to Antigravity, so that read now always fails:

```
IneligibleTierError: This client is no longer supported for Gemini Code Assist for
individuals.   reasonCode: 'UNSUPPORTED_CLIENT'   tierId: 'free-tier'
```

The existing code comment already names the constraint — `agy` keeps its token in the OS keyring, so no file the Gemini fetcher reads can ever describe it. #9122 reaches the same conclusion and suggests exactly this approach ("or by shelling out to `agy` — CodexBar takes this approach and reliably reports both Antigravity pools"), including the detail that the two pools have independent resets.

`agy -p "/usage"` on Windows, verbatim:

```
Gemini Models            Weekly Limit Remaining      100%   2026-09-02T18:04:43Z
Gemini Models            Five Hour Limit Remaining   100%   2026-08-26T23:04:43Z
Claude and GPT models    Weekly Limit Remaining      100%   2026-09-02T18:04:43Z
Claude and GPT models    Five Hour Limit Remaining   100%   2026-08-26T23:04:43Z
```

`Five Hour` → `session` (300 min), `Weekly` → `weekly` (10080 min). The CLI reports what is *left*, so it is converted to used percentage like every other provider.

## Linked Issue

Fixes #9122

## Visual Proof

`N/A` — I could not produce a before/after of the status-bar segment. `pnpm install` resolves, but the `postinstall` native rebuild of `node-pty` needs a Visual Studio C++ toolchain I do not have, so I cannot run a local Electron build. The change only populates `ProviderRateLimits` for an existing segment and touches no renderer code. Happy to add captures if a maintainer can point me at a build that skips the native step.

## Testing

- `vitest run src/main/rate-limits/antigravity-cli-usage.test.ts src/main/rate-limits/antigravity-usage-mirror.test.ts` → 12 passed. The pre-existing mirror tests are unchanged and still pass.
- `tsc --noEmit -p config/tsconfig.node.json` → clean.
- `oxfmt` + `oxlint` on the touched files → clean.
- Fixture data is real `agy -p "/usage"` output from Windows 11 with `agy` 1.1.21.

Platforms actually exercised: **Windows 11** (CLI output and binary resolution). macOS/Linux paths are code-reviewed only, not run.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Not checking the manual box: the parser and CLI invocation are verified on Windows, but I have not seen the segment render in a running Orca for the build reason above.

## AI Disclosure

Written with Claude Opus 5 via Claude Code. Every command, test run and the `agy` output quoted above were executed on a real machine; nothing here is model recollection.

## Review

Automated review flagged two things on the first commit; both are addressed in `0ab6a06`:

- **Stale non-executable fallback could hide a usable CLI** — fixed. Resolution now checks `X_OK` rather than mere existence, and considers every `where`/`which` hit instead of only the first.
- **Could report quota from the wrong machine during remote sessions** — real, but not introduced here and not a regression. `fetchGeminiRateLimits`, which this replaces, takes no runtime target and reads local credentials only (zero occurrences of `wsl`/`runtimeTarget`/`executionHost` in that file), so the mirror was always local-scoped too. Making both providers runtime-aware is a genuine gap; it needs a resolver wired through `RateLimitService` like Codex/Kimi have, which is a larger change than this fix and better scoped separately. I documented the boundary in a docstring rather than leaving it implicit. Glad to take it on as a follow-up if you want it.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- **Security** — no new network calls; a local subprocess with a fixed argument list. `execFile`, never `exec`, so no shell interpolation, and `windowsHide` stays effective.
- **Cross-platform** — PATH lookup via `where.exe`/`which`; fallbacks are the documented install prefixes per platform. Windows is the only one I ran.
- **Remote SSH** — see Review above: unchanged scope relative to the Gemini read it replaces.
- **Mobile** — not applicable, main-process only.
- **Backwards compatibility** — without `agy` installed, behaviour is identical to today via the retained mirror.
- **Performance** — one `execFile` inside the existing parallel batch, with the CLI's own 30s print timeout and the caller's `AbortSignal`.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

Last box unchecked deliberately: targeted `vitest`, `typecheck:node`, `oxfmt` and `oxlint` pass locally, but the full `pnpm test` and `pnpm build` need the native rebuild I cannot complete on this machine. Leaving that to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)