### PR TITLE
fix(worktrees): stop a stale scan from pruning lineage created mid-scan

### DIFF
--- a/src/main/ipc/worktrees/listing/detected-provider-listing.ts
+++ b/src/main/ipc/worktrees/listing/detected-provider-listing.ts
@@ -43,6 +43,7 @@ export async function listDetectedWorktreesForCapturedRepo(
   try {
     let gitWorktrees: GitWorktreeInfo[]
     let freshScan = true
+    const scanStartedAt = Date.now()
     if (isFolderRepo(repo)) {
       if (!isCurrent()) {
         return null
@@ -111,7 +112,7 @@ export async function listDetectedWorktreesForCapturedRepo(
     }
     if (freshScan) {
       rememberLocalWorktreeRoots(store, repo, gitWorktrees)
-      pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
+      pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees, scanStartedAt)
     }
     loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
     return {

--- a/src/main/ipc/worktrees/listing/register-worktree-catalog-handlers.ts
+++ b/src/main/ipc/worktrees/listing/register-worktree-catalog-handlers.ts
@@ -58,6 +58,7 @@ export function registerWorktreeCatalogHandlers(context: WorktreeIpcContext): vo
       try {
         let gitWorktrees
         let freshScan = true
+        const scanStartedAt = Date.now()
         if (isFolderRepo(repo)) {
           return listVisibleFolderWorkspaces(store, repo)
         } else if (repo.connectionId) {
@@ -89,7 +90,7 @@ export function registerWorktreeCatalogHandlers(context: WorktreeIpcContext): vo
         }
         if (freshScan) {
           rememberLocalWorktreeRoots(store, repo, gitWorktrees)
-          pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
+          pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees, scanStartedAt)
         }
         loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
         return buildDetectedGitWorktrees(store, repo, gitWorktrees)
@@ -130,6 +131,7 @@ export function registerWorktreeCatalogHandlers(context: WorktreeIpcContext): vo
     try {
       let gitWorktrees
       let freshScan = true
+      const scanStartedAt = Date.now()
       if (isFolderRepo(repo)) {
         return listVisibleFolderWorkspaces(store, repo)
       } else if (repo.connectionId) {
@@ -161,7 +163,7 @@ export function registerWorktreeCatalogHandlers(context: WorktreeIpcContext): vo
       }
       if (freshScan) {
         rememberLocalWorktreeRoots(store, repo, gitWorktrees)
-        pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
+        pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees, scanStartedAt)
       }
       loggedWorktreeListFailures.delete(`${repo.id}:${repo.path}`)
       return buildDetectedGitWorktrees(store, repo, gitWorktrees)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -23922,13 +23922,14 @@ export class OrcaRuntimeService {
       }
     }
     let scan: RuntimeWorktreeScanResult
+    const scanStartedAt = Date.now()
     try {
       scan = await this.listRepoWorktreesForResolution(repo)
     } catch {
       scan = { ok: false, worktrees: [] }
     }
     if (scan.ok) {
-      pruneLineageForMissingRepoWorktrees(store, repo, scan.worktrees)
+      pruneLineageForMissingRepoWorktrees(store, repo, scan.worktrees, scanStartedAt)
     }
     const worktreeVisibilitySourceMatcher = createWorktreeVisibilitySourceMatcher(
       [repo.path, ...scan.worktrees.map((worktree) => worktree.path)],

--- a/src/main/runtime/repo-worktree-row-resolution.ts
+++ b/src/main/runtime/repo-worktree-row-resolution.ts
@@ -114,6 +114,7 @@ export async function resolveRepoWorktreeRows(
   // first for `null` to mean "timed out" only. A stall never reached a verdict, so restore persisted rows
   // instead of publishing a healthy-looking empty catalog; a rejection is a real answer and keeps its
   // shipped zero-row semantics.
+  const scanStartedAt = Date.now()
   const scan: RuntimeWorktreeScanResult = (await withTimeout<RuntimeWorktreeScanResult | null>(
     deps
       .scanRepo(repo, projectRuntimeByRepoId)
@@ -123,7 +124,7 @@ export async function resolveRepoWorktreeRows(
   )) ?? { ok: false, worktrees: listStoredWorktreeRowsForRepo(store, repo, repoOwnerCount) }
   const gitWorktrees = scan.worktrees
   if (scan.ok) {
-    pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)
+    pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees, scanStartedAt)
   }
   const expectedHostId = getRepoExecutionHostId(repo)
   return gitWorktrees.map((gitWorktree) => {

--- a/src/main/worktree-lineage-pruning.test.ts
+++ b/src/main/worktree-lineage-pruning.test.ts
@@ -13,7 +13,7 @@ const repo: Repo = {
   addedAt: 1
 }
 
-function lineage(childId: string, parentId: string): WorktreeLineage {
+function lineage(childId: string, parentId: string, createdAt = 1): WorktreeLineage {
   return {
     worktreeId: childId,
     worktreeInstanceId: `${childId}-instance`,
@@ -21,11 +21,11 @@ function lineage(childId: string, parentId: string): WorktreeLineage {
     parentWorktreeInstanceId: `${parentId}-instance`,
     origin: 'manual',
     capture: { source: 'manual-action', confidence: 'explicit' },
-    createdAt: 1
+    createdAt
   }
 }
 
-function workspaceLineage(childId: string, parentId: string): WorkspaceLineage {
+function workspaceLineage(childId: string, parentId: string, createdAt = 1): WorkspaceLineage {
   return {
     childWorkspaceKey: worktreeWorkspaceKey(childId),
     childInstanceId: `${childId}-instance`,
@@ -33,7 +33,7 @@ function workspaceLineage(childId: string, parentId: string): WorkspaceLineage {
     parentInstanceId: `${parentId}-instance`,
     origin: 'manual',
     capture: { source: 'manual-action', confidence: 'explicit' },
-    createdAt: 1
+    createdAt
   }
 }
 
@@ -125,5 +125,97 @@ describe('pruneLineageForMissingRepoWorktrees', () => {
     expect(metaById[missingParentId].instanceId).not.toBe(
       missingParentEdge.parentWorktreeInstanceId
     )
+  })
+
+  it('keeps lineage registered after the scan started, then prunes it once a later scan misses it', () => {
+    const liveParentId = 'repo-1::/repo/live-parent'
+    const newChildId = 'repo-1::/repo/new-child'
+    const scanStartedAt = 1_000
+    const newChildEdge = lineage(newChildId, liveParentId, scanStartedAt + 1)
+    const worktreeLineageById = { [newChildId]: newChildEdge }
+    const workspaceLineageByChildKey = {
+      [worktreeWorkspaceKey(newChildId)]: workspaceLineage(
+        newChildId,
+        liveParentId,
+        scanStartedAt + 1
+      )
+    }
+    const metaById = {
+      [liveParentId]: { instanceId: newChildEdge.parentWorktreeInstanceId } as WorktreeMeta
+    }
+    const store = createStore(worktreeLineageById, workspaceLineageByChildKey, metaById)
+    const staleScan = [
+      {
+        path: '/repo/live-parent',
+        head: 'a',
+        branch: 'main',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ]
+
+    pruneLineageForMissingRepoWorktrees(store as never, repo, staleScan, scanStartedAt)
+
+    expect(store.removeWorktreeLineage).not.toHaveBeenCalled()
+    expect(store.removeWorkspaceLineage).not.toHaveBeenCalled()
+    expect(worktreeLineageById[newChildId]).toBe(newChildEdge)
+
+    pruneLineageForMissingRepoWorktrees(store as never, repo, staleScan, scanStartedAt + 2)
+
+    expect(store.removeWorktreeLineage).toHaveBeenCalledWith(newChildId)
+    expect(worktreeLineageById[newChildId]).toBeUndefined()
+  })
+
+  it('leaves a mid-scan parent identity alone instead of rotating it', () => {
+    const newParentId = 'repo-1::/repo/new-parent'
+    const newChildId = 'repo-1::/repo/new-child'
+    const scanStartedAt = 1_000
+    const newEdge = lineage(newChildId, newParentId, scanStartedAt + 1)
+    const worktreeLineageById = { [newChildId]: newEdge }
+    const metaById = {
+      [newParentId]: { instanceId: newEdge.parentWorktreeInstanceId } as WorktreeMeta
+    }
+    const store = createStore(worktreeLineageById, {}, metaById)
+
+    pruneLineageForMissingRepoWorktrees(
+      store as never,
+      repo,
+      [
+        {
+          path: '/repo/unrelated',
+          head: 'a',
+          branch: 'main',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ],
+      scanStartedAt
+    )
+
+    expect(store.setWorktreeMeta).not.toHaveBeenCalled()
+    expect(metaById[newParentId].instanceId).toBe(newEdge.parentWorktreeInstanceId)
+  })
+
+  it('prunes on a trusted scan when no scan start time is supplied', () => {
+    const liveParentId = 'repo-1::/repo/live-parent'
+    const missingChildId = 'repo-1::/repo/missing-child'
+    const edge = lineage(missingChildId, liveParentId, Number.MAX_SAFE_INTEGER)
+    const worktreeLineageById = { [missingChildId]: edge }
+    const metaById = {
+      [liveParentId]: { instanceId: edge.parentWorktreeInstanceId } as WorktreeMeta
+    }
+    const store = createStore(worktreeLineageById, {}, metaById)
+
+    pruneLineageForMissingRepoWorktrees(store as never, repo, [
+      {
+        path: '/repo/live-parent',
+        head: 'a',
+        branch: 'main',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    expect(store.removeWorktreeLineage).toHaveBeenCalledWith(missingChildId)
   })
 })

--- a/src/main/worktree-lineage-pruning.ts
+++ b/src/main/worktree-lineage-pruning.ts
@@ -34,10 +34,18 @@ function hasStoredRepoLineage(
   )
 }
 
+function registeredBeforeScan(
+  createdAt: number | undefined,
+  scanStartedAt: number | undefined
+): boolean {
+  return scanStartedAt === undefined || createdAt === undefined || createdAt <= scanStartedAt
+}
+
 export function pruneLineageForMissingRepoWorktrees(
   store: Store,
   repo: Repo,
-  gitWorktrees: GitWorktreeInfo[]
+  gitWorktrees: GitWorktreeInfo[],
+  scanStartedAt?: number
 ): void {
   if (
     typeof store.getAllWorktreeLineage !== 'function' ||
@@ -62,7 +70,10 @@ export function pruneLineageForMissingRepoWorktrees(
     const hostId = store.getWorktreeMeta(worktreeId)?.hostId
     return hostId ? hostId === expectedHostId : repoOwners.length === 1
   }
-  for (const childWorkspaceKey of Object.keys(workspaceLineage)) {
+  for (const [childWorkspaceKey, edge] of Object.entries(workspaceLineage)) {
+    if (!registeredBeforeScan(edge.createdAt, scanStartedAt)) {
+      continue
+    }
     const childScope = parseWorkspaceKey(childWorkspaceKey)
     if (
       childScope?.type === 'worktree' &&
@@ -75,6 +86,9 @@ export function pruneLineageForMissingRepoWorktrees(
     }
   }
   for (const [childId, lineage] of Object.entries(worktreeLineage)) {
+    if (!registeredBeforeScan(lineage.createdAt, scanStartedAt)) {
+      continue
+    }
     if (
       worktreeIdBelongsToRepo(childId, repoPrefix) &&
       canMutateWorktree(childId) &&


### PR DESCRIPTION
## Author

X: [@skythediver](https://x.com/skythediver)

## In short

When several Orca worktrees are created back to back, one of them can silently lose its parent and jump to the top level of the sidebar. The worktree itself is fine; only the record of who its parent was gets deleted. This makes that stop happening.

## ELI5

Orca periodically asks git "what worktrees exist?" and uses the answer to clean up parent/child links whose worktree is gone. The problem is that the answer can be out of date by the time it is used. If you create a worktree while that question is still being answered, the reply comes back without it, and the cleanup concludes the brand new worktree does not exist and deletes its parent link.

The fix is to note when the question was asked, and ignore any link created after that moment. An old answer no longer gets to judge something it never had a chance to see.

## What Changed

- `pruneLineageForMissingRepoWorktrees` takes an optional `scanStartedAt` and skips any lineage edge whose `createdAt` is newer than it.
- The five call sites capture `Date.now()` before their scan begins and pass it through.
- Three tests added to the existing `worktree-lineage-pruning.test.ts`.

The parameter is optional and omitting it preserves today's behavior exactly, so no caller is forced to change.

## Why

`pruneLineageForMissingRepoWorktrees` removes any lineage edge whose child is absent from the `gitWorktrees` list it is handed. That list comes from a `git worktree list` that may have started before the worktree existed, so the absence proves nothing. The window is real in practice: creating three worktrees a few seconds apart reproduced the loss on 2 of 3 attempts, and the victim varied with timing rather than position.

Only lineage is removed, never `worktreeMeta`, which is why the symptom is a worktree that still appears but has been orphaned to the top level.

This continues the guards already in this function. It refuses an empty scan, and `scan.ok` refuses a failed scan. The stale-but-non-empty scan is the remaining case.

I considered checking the child path on disk instead of using timestamps, and rejected it: this function also runs for SSH and remote repos, where a local filesystem probe would be wrong.

## Linked Issue

Fixes #16654

## Visual Proof

`N/A`. No UI code changes. The user-visible effect is that a worktree keeps the parent it was created with, so the sidebar shows it nested rather than at the top level.

## Testing

Reproduced first, then fixed.

Repro on 1.4.188, using a repo with an existing worktree as the parent:

1. Create three worktrees back to back, no pause, each with `--parent-worktree active`:
   `orca worktree create --repo "id:<repo-id>" --name probe-1 --base-branch main --setup skip --parent-worktree active --json`
   (repeat for `probe-2`, `probe-3`)
2. Each response reports the parent correctly, which is why this looks fine at creation time.
3. Read them back: `orca worktree show --worktree "path:<path>" --json`
4. One or more comes back with `parentWorktreeId: null`, and the record is gone from `worktreeLineageById` in the profile store while its `worktreeMeta` entry is still present.

Across three bursts of three, two bursts lost one worktree each, and the position of the loser varied. `orca worktree set --parent-worktree` afterwards is reliable, 24 for 24, since no create is in flight to start a competing scan.

Automated coverage: the two new tests that exercise the stale scan fail on `main` and pass with this change. The third pins the no-argument path so the shipped behavior stays covered.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Checks run locally on macOS (Darwin 25.5.0, Node 24.19.0, pnpm 10.24.0):

- `pnpm typecheck` passes
- `pnpm lint` passes
- `pnpm vitest run src/main/worktree-lineage-pruning.test.ts` passes, 5 of 5
- `pnpm test` in full is not reported here. `src/main/persistence-pane-identity-migration.test.ts` fails on an unmodified checkout of `main` on this machine, so it is unrelated to this change, and a fuzz case in `terminal-output-frame-chunks-equivalence.test.ts` failed once under heavy load and passed on rerun. Happy to post a clean full run on a quiet machine if useful.
- `pnpm build` completes. `build:native` has to be run as its three underlying node scripts directly, because of an unrelated bug in `config/scripts/build-native-for-platform.mjs` that assumes `npm_execpath` is a JavaScript file and breaks under a standalone pnpm install. Unrelated to this change.

Not tested on Linux, Windows, or against an SSH remote. See the note below on why the change is platform-neutral.

## AI Disclosure

Written with Claude (Opus 5) in Claude Code, reviewed by me before submission.

## Review

Cross-platform: no platform-specific code. `Date.now()` and a numeric comparison only, no paths, shells, or processes involved.

SSH, remote, and local: the guard deliberately avoids any filesystem check so it behaves identically for local, remote, and SSH-backed repos. All five call sites cover both the provider and local scan branches.

Agent, integration, and git provider neutrality: the change is inside generic lineage bookkeeping and adds no provider-specific behavior.

Backwards compatibility: `scanStartedAt` is optional. Omitted, `registeredBeforeScan` returns `true` and every edge is evaluated exactly as before. A missing `createdAt` is treated the same way.

Performance: one `Date.now()` per scan and one numeric comparison per lineage edge, both negligible against the `git worktree list` the function already depends on. The workspace loop moved from `Object.keys` to `Object.entries` on a map that is already fully iterated, so no additional traversal.

Security: no new I/O, no new privileges, no user input reaching this path.

Correctness risk: the guard can only make the prune more conservative. It can skip a removal, never cause one. A genuinely deleted worktree is still pruned by the next scan, which starts after the edge was written, and the first new test asserts exactly that follow-up behavior.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The clean-up path deletes only lineage and leaves `worktreeMeta` in place, which is what makes this present as a UI-only oddity rather than a broken worktree. Recovery for anyone already affected is `orca worktree set --worktree <selector> --parent-worktree <selector>`, which is unaffected by this bug.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — see the Testing section for the one full-suite test that fails on an unmodified checkout, and the unrelated `build:native` workaround

