### PR TITLE
fix(build): don't hand a non-JS npm_execpath to node in build:native

### DIFF
--- a/config/scripts/build-native-for-platform.mjs
+++ b/config/scripts/build-native-for-platform.mjs
@@ -1,30 +1,27 @@
 #!/usr/bin/env node
 
 import { spawnSync } from 'node:child_process'
+import { resolve } from 'node:path'
 
-if (process.platform === 'win32') {
-  runNodeScript('config/scripts/build-windows-cli-launcher.mjs')
-  process.exit(0)
+export function resolvePnpmInvocation(scriptName, npmExecPath, platform) {
+  // npm_execpath is only runnable by node when it is a JS entrypoint. pnpm's
+  // standalone build points it at a platform binary, so fall back to PATH.
+  const runnableByNode = Boolean(npmExecPath) && /\.[cm]?js$/.test(npmExecPath)
+  if (runnableByNode) {
+    return { command: process.execPath, args: [npmExecPath, 'run', scriptName] }
+  }
+  return {
+    command: platform === 'win32' ? 'pnpm.cmd' : 'pnpm',
+    args: ['run', scriptName]
+  }
 }
-
-if (process.platform !== 'darwin') {
-  console.log(`[native-build] no macOS native computer build required on ${process.platform}`)
-  process.exit(0)
-}
-
-runPnpmScript('build:computer-macos')
-runPnpmScript('build:keyboard-layout-macos')
-runPnpmScript('build:notification-status-macos')
-process.exit(0)
 
 function runPnpmScript(scriptName) {
-  const npmExecPath = process.env.npm_execpath
-  const command = npmExecPath
-    ? process.execPath
-    : process.platform === 'win32'
-      ? 'pnpm.cmd'
-      : 'pnpm'
-  const args = npmExecPath ? [npmExecPath, 'run', scriptName] : ['run', scriptName]
+  const { command, args } = resolvePnpmInvocation(
+    scriptName,
+    process.env.npm_execpath,
+    process.platform
+  )
   const result = spawnSync(command, args, { stdio: 'inherit' })
 
   if (result.signal) {
@@ -43,4 +40,21 @@ function runNodeScript(scriptPath) {
   if (result.status !== 0 || result.error) {
     process.exit(result.status ?? 1)
   }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === resolve(import.meta.filename)) {
+  if (process.platform === 'win32') {
+    runNodeScript('config/scripts/build-windows-cli-launcher.mjs')
+    process.exit(0)
+  }
+
+  if (process.platform !== 'darwin') {
+    console.log(`[native-build] no macOS native computer build required on ${process.platform}`)
+    process.exit(0)
+  }
+
+  runPnpmScript('build:computer-macos')
+  runPnpmScript('build:keyboard-layout-macos')
+  runPnpmScript('build:notification-status-macos')
+  process.exit(0)
 }

--- a/config/scripts/build-native-for-platform.test.mjs
+++ b/config/scripts/build-native-for-platform.test.mjs
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { resolvePnpmInvocation } from './build-native-for-platform.mjs'
+
+describe('resolvePnpmInvocation', () => {
+  it('runs a JS npm_execpath through the current node binary', () => {
+    expect(
+      resolvePnpmInvocation('build:computer-macos', '/somewhere/pnpm/bin/pnpm.cjs', 'darwin')
+    ).toEqual({
+      command: process.execPath,
+      args: ['/somewhere/pnpm/bin/pnpm.cjs', 'run', 'build:computer-macos']
+    })
+    expect(
+      resolvePnpmInvocation('build:x', '/somewhere/npm/bin/npm-cli.js', 'darwin').command
+    ).toBe(process.execPath)
+  })
+
+  it('falls back to pnpm on PATH when npm_execpath is a platform binary', () => {
+    // pnpm's standalone build sets npm_execpath to the executable it ran, which
+    // node cannot parse as a module.
+    expect(
+      resolvePnpmInvocation(
+        'build:computer-macos',
+        '/Users/me/Library/pnpm/.tools/@pnpm+macos-arm64/10.24.0/node_modules/@pnpm/macos-arm64/pnpm',
+        'darwin'
+      )
+    ).toEqual({ command: 'pnpm', args: ['run', 'build:computer-macos'] })
+  })
+
+  it('falls back to pnpm on PATH when npm_execpath is unset', () => {
+    expect(resolvePnpmInvocation('build:x', undefined, 'darwin')).toEqual({
+      command: 'pnpm',
+      args: ['run', 'build:x']
+    })
+    expect(resolvePnpmInvocation('build:x', '', 'darwin')).toEqual({
+      command: 'pnpm',
+      args: ['run', 'build:x']
+    })
+  })
+
+  it('uses pnpm.cmd on windows when falling back', () => {
+    expect(resolvePnpmInvocation('build:x', undefined, 'win32')).toEqual({
+      command: 'pnpm.cmd',
+      args: ['run', 'build:x']
+    })
+  })
+})


### PR DESCRIPTION
## Author

X: [@skythediver](https://x.com/skythediver)

## In short

`pnpm build` fails on machines where pnpm was installed as its standalone binary rather than through Corepack or npm. The native build step tries to run that binary as if it were a JavaScript file. This makes it check first, and fall back to plain `pnpm` when it isn't.

## ELI5

When one script wants to run another, it asks the package manager to do it. It finds the package manager through an environment variable that usually points at a JavaScript file, so the script hands that file to Node.

pnpm has two shapes. Most installs are the JavaScript one. The standalone install is a compiled program instead, and the variable then points at that program. Node gets handed a compiled binary, tries to read it as source code, and gives up on the first byte.

The fix is to look at what the variable actually points to. If it isn't JavaScript, use `pnpm` from `PATH`, which is what the script already did when the variable was missing entirely.

## What Changed

- `resolvePnpmInvocation` is extracted and exported from `config/scripts/build-native-for-platform.mjs`, choosing `node <npm_execpath>` only when that path ends in `.js`, `.cjs` or `.mjs`, and otherwise `pnpm` (or `pnpm.cmd` on Windows).
- The top-level platform dispatch now runs only when the script is executed directly, using the same `process.argv[1] === import.meta.filename` guard as `config/scripts/build-mac-local.mjs`, so the module can be imported by a test without starting a build.
- New `config/scripts/build-native-for-platform.test.mjs` covering the JS, binary, unset, and Windows cases.

No behavior change for anyone whose `npm_execpath` is already JavaScript.

## Why

`npm_execpath` is not guaranteed to be JavaScript. pnpm sets it to whatever it actually executed, and the standalone distribution is a platform binary. On this machine, a standalone pnpm that self-managed to 10.24.0 to honor `packageManager` produced:

```
/Users/<me>/Library/pnpm/.tools/@pnpm+macos-arm64/10.24.0/node_modules/@pnpm/macos-arm64/pnpm
```

Handing that to `node` produced a screenful of Mach-O bytes and:

```
SyntaxError: Invalid or unexpected token
    at wrapSafe (node:internal/modules/cjs/loader:1804:18)
```

The script already had the right behavior for this situation. Its `else` branch spawns `pnpm` from `PATH` and works fine. Only the presence of `npm_execpath` routed around it.

## Linked Issue

Fixes #16655

## Visual Proof

`N/A`. Build tooling only, no UI or interaction change.

## Testing

Before this change, on macOS with a standalone pnpm, `pnpm build` fails at `build:native` with the `SyntaxError` above. After it, `pnpm run build:native` completes all three native sub-builds:

```
> orca@1.4.178-rc.2 build:computer-macos
Build complete! (0.57s)
... replacing existing signature
> orca@1.4.178-rc.2 build:keyboard-layout-macos
> orca@1.4.178-rc.2 build:notification-status-macos
```

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Local checks on macOS (Darwin 25.5.0, arm64, Node 24.19.0, standalone pnpm 10.24.0):

- `pnpm typecheck` passes
- `pnpm lint` passes
- `pnpm vitest run config/scripts/build-native-for-platform.test.mjs` passes, 4 of 4
- `pnpm run build:native` passes, which is the command that previously failed

Not tested on Windows or Linux. The Windows path is covered by a unit test but not exercised on a real machine; note that `build:native` on Windows goes through `runNodeScript`, which this change does not touch, and on other platforms it exits early before reaching `runPnpmScript` at all.

## AI Disclosure

Written with Claude (Opus 5) in Claude Code, reviewed by me before submission.

## Review

Cross-platform: the fallback keeps the existing `pnpm.cmd` versus `pnpm` split, and platform is now an argument rather than read from `process.platform` inside the helper, so both branches are covered by tests. Windows and Linux still exit before `runPnpmScript` runs, exactly as before.

SSH, remote, and local: build-time only, runs on the machine doing the build. No runtime, IPC, or worktree behavior involved.

Agent, integration, and git provider neutrality: none involved.

Backwards compatibility: a JavaScript `npm_execpath` resolves to the identical command and args as before. The only changed outcome is the case that previously crashed.

Performance: one regex test per spawned sub-build, three times per macOS build.

Security: no new I/O or privileges. The regex only inspects a path already used to spawn a process, and the fallback resolves `pnpm` through `PATH`, which is how the script behaved when `npm_execpath` was unset.

Correctness risk: the import guard is the piece worth a look. `build:native` is invoked as `node config/scripts/build-native-for-platform.mjs`, so `process.argv[1]` matches `import.meta.filename` and the dispatch runs as it always did. I verified this by running the real command rather than only the unit test.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

I have not audited whether other scripts under `config/scripts/` make the same assumption about `npm_execpath`. A grep for it showed this as the only occurrence, but I did not verify every spawn path.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
