### PR TITLE
feat(github): surface merge-queue state as a distinct queued PR state

### DIFF
--- a/mobile/src/components/pr-sidebar/pr-checks-presentation.ts
+++ b/mobile/src/components/pr-sidebar/pr-checks-presentation.ts
@@ -178,7 +178,8 @@ const PR_STATE_LABELS: Record<PRState, string> = {
   open: 'Open',
   merged: 'Merged',
   draft: 'Draft',
-  closed: 'Closed'
+  closed: 'Closed',
+  queued: 'Queued'
 }
 
 // State-badge color comes from the shared prStateToken so the sidebar badge and

--- a/src/main/daemon/pty-subprocess-foreground-degraded-scan.test.ts
+++ b/src/main/daemon/pty-subprocess-foreground-degraded-scan.test.ts
@@ -8,14 +8,19 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-const { spawnMock, isPwshAvailableMock, resolveAgentForegroundProcessMock, readConptyMock, jobReadableMock } =
-  vi.hoisted(() => ({
-    spawnMock: vi.fn(),
-    isPwshAvailableMock: vi.fn(),
-    resolveAgentForegroundProcessMock: vi.fn(),
-    readConptyMock: vi.fn(),
-    jobReadableMock: vi.fn()
-  }))
+const {
+  spawnMock,
+  isPwshAvailableMock,
+  resolveAgentForegroundProcessMock,
+  readConptyMock,
+  jobReadableMock
+} = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+  isPwshAvailableMock: vi.fn(),
+  resolveAgentForegroundProcessMock: vi.fn(),
+  readConptyMock: vi.fn(),
+  jobReadableMock: vi.fn()
+}))
 
 vi.mock('node-pty', () => ({ spawn: spawnMock }))
 vi.mock('../pwsh', () => ({ isPwshAvailable: isPwshAvailableMock }))

--- a/src/main/github/client-merge-queue-auto-merge.test.ts
+++ b/src/main/github/client-merge-queue-auto-merge.test.ts
@@ -388,8 +388,14 @@ describe('GitHub GraphQL rate-limit guard', () => {
       mergePR('/repo-root', 7, 'squash', undefined, { owner: 'stablyai', repo: 'orca' })
     ).resolves.toMatchObject({ ok: false })
 
+    // Why: the per-PR merge-queue-entry probe is a second GraphQL call on queue
+    // repos, so scope this to the repository merge-metadata query it names.
     expect(
-      ghExecFileAsyncMock.mock.calls.filter((call) => call[0].includes('graphql'))
+      ghExecFileAsyncMock.mock.calls.filter(
+        (call) =>
+          call[0].includes('graphql') &&
+          call[0].some((arg: string) => arg.includes('mergeQueue(branch: $branch)'))
+      )
     ).toHaveLength(1)
     expect(ghExecFileAsyncMock.mock.calls[2]?.[0]).toEqual(
       expect.arrayContaining(['-f', 'owner=stablyai', '-f', 'repo=orca', '-f', 'branch=true'])

--- a/src/main/github/client/detect/pull-request-merge-queue-entry.test.ts
+++ b/src/main/github/client/detect/pull-request-merge-queue-entry.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { ghExecFileAsyncMock, rateLimitGuardMock, noteSpendMock } = vi.hoisted(() => ({
+  ghExecFileAsyncMock: vi.fn(),
+  rateLimitGuardMock: vi.fn(),
+  noteSpendMock: vi.fn()
+}))
+
+vi.mock('../../gh-utils', () => ({ ghExecFileAsync: ghExecFileAsyncMock }))
+vi.mock('../../rate-limit', () => ({
+  repositoryRateLimitGuard: rateLimitGuardMock,
+  noteRepositoryRateLimitSpend: noteSpendMock
+}))
+vi.mock('../../github-api-repository', () => ({ githubHostExecOptions: () => ({}) }))
+
+import { detectPullRequestMergeQueueEntry } from './pull-request-merge-queue-entry'
+
+const ownerRepo = { owner: 'stablyai', repo: 'orca' }
+
+function graphqlResponse(pullRequest: unknown): { stdout: string } {
+  return { stdout: JSON.stringify({ data: { repository: { pullRequest } } }) }
+}
+
+describe('detectPullRequestMergeQueueEntry', () => {
+  beforeEach(() => {
+    ghExecFileAsyncMock.mockReset()
+    rateLimitGuardMock.mockReset()
+    rateLimitGuardMock.mockReturnValue({ blocked: false })
+    noteSpendMock.mockReset()
+  })
+
+  it('returns the queue entry when the PR is in the merge queue', async () => {
+    ghExecFileAsyncMock.mockResolvedValue(
+      graphqlResponse({
+        isInMergeQueue: true,
+        mergeQueueEntry: {
+          state: 'QUEUED',
+          position: 3,
+          estimatedTimeToMerge: 600,
+          enqueuedAt: '2026-08-26T00:00:00Z'
+        }
+      })
+    )
+    await expect(detectPullRequestMergeQueueEntry(ownerRepo, 42, {})).resolves.toEqual({
+      mergeQueueEntry: {
+        state: 'QUEUED',
+        position: 3,
+        estimatedTimeToMerge: 600,
+        enqueuedAt: '2026-08-26T00:00:00Z'
+      }
+    })
+    expect(noteSpendMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('nulls out non-numeric position and ETA rather than passing them through', async () => {
+    ghExecFileAsyncMock.mockResolvedValue(
+      graphqlResponse({
+        isInMergeQueue: true,
+        mergeQueueEntry: { state: 'AWAITING_CHECKS', position: null, estimatedTimeToMerge: null }
+      })
+    )
+    await expect(detectPullRequestMergeQueueEntry(ownerRepo, 42, {})).resolves.toEqual({
+      mergeQueueEntry: {
+        state: 'AWAITING_CHECKS',
+        position: null,
+        estimatedTimeToMerge: null,
+        enqueuedAt: null
+      }
+    })
+  })
+
+  it('synthesises an entry when GitHub reports membership without one', async () => {
+    ghExecFileAsyncMock.mockResolvedValue(
+      graphqlResponse({ isInMergeQueue: true, mergeQueueEntry: null })
+    )
+    await expect(detectPullRequestMergeQueueEntry(ownerRepo, 42, {})).resolves.toEqual({
+      mergeQueueEntry: {
+        state: 'QUEUED',
+        position: null,
+        estimatedTimeToMerge: null,
+        enqueuedAt: null
+      }
+    })
+  })
+
+  it('reports not-queued when GitHub says the PR is not in the queue', async () => {
+    ghExecFileAsyncMock.mockResolvedValue(
+      graphqlResponse({ isInMergeQueue: false, mergeQueueEntry: null })
+    )
+    await expect(detectPullRequestMergeQueueEntry(ownerRepo, 42, {})).resolves.toEqual({})
+  })
+
+  it('degrades to not-queued when the probe throws', async () => {
+    ghExecFileAsyncMock.mockRejectedValue(new Error('gh exploded'))
+    await expect(detectPullRequestMergeQueueEntry(ownerRepo, 42, {})).resolves.toEqual({})
+  })
+
+  it('spends nothing when the rate-limit guard is blocked', async () => {
+    rateLimitGuardMock.mockReturnValue({ blocked: true })
+    await expect(detectPullRequestMergeQueueEntry(ownerRepo, 42, {})).resolves.toEqual({})
+    expect(ghExecFileAsyncMock).not.toHaveBeenCalled()
+    expect(noteSpendMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/github/client/detect/pull-request-merge-queue-entry.ts
+++ b/src/main/github/client/detect/pull-request-merge-queue-entry.ts
@@ -1,0 +1,97 @@
+import type { PullRequestMergeQueueEntry } from '../../../../shared/github/pull-request-types'
+import { ghExecFileAsync } from '../../gh-utils'
+import { githubHostExecOptions, type GitHubApiRepository } from '../../github-api-repository'
+import { noteRepositoryRateLimitSpend, repositoryRateLimitGuard } from '../../rate-limit'
+import type { GhExecOptions } from './../github-exec-scope'
+
+/**
+ * `mergeQueueEntry` present ⇒ the PR is in the queue. Keeping presence as the one
+ * discriminator (rather than a separate boolean) is what lets the wire carry
+ * `open` + entry and the client derive `queued` with no second signal to keep in sync.
+ */
+export type PullRequestMergeQueueMembership = {
+  mergeQueueEntry?: PullRequestMergeQueueEntry
+}
+
+const NOT_QUEUED: PullRequestMergeQueueMembership = {}
+
+const MERGE_QUEUE_ENTRY_QUERY = `query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      isInMergeQueue
+      mergeQueueEntry { state position estimatedTimeToMerge enqueuedAt }
+    }
+  }
+}`
+
+function coerceNullableNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+/**
+ * Per-PR GraphQL probe for GitHub merge-queue membership. `state`/`mergeStateStatus`
+ * cannot express it, so this is the only source. Callers must gate on the base
+ * branch actually requiring a merge queue — repos without one pay nothing.
+ * Any failure degrades to "not queued" so a PR refresh never breaks on it.
+ */
+export async function detectPullRequestMergeQueueEntry(
+  ownerRepo: GitHubApiRepository,
+  prNumber: number,
+  ghOptions: GhExecOptions
+): Promise<PullRequestMergeQueueMembership> {
+  const guard = repositoryRateLimitGuard(ownerRepo, 'graphql', ghOptions)
+  if (guard.blocked) {
+    return NOT_QUEUED
+  }
+  try {
+    noteRepositoryRateLimitSpend(ownerRepo, 'graphql', 1, ghOptions)
+    const { stdout } = await ghExecFileAsync(
+      [
+        'api',
+        'graphql',
+        '-f',
+        `query=${MERGE_QUEUE_ENTRY_QUERY}`,
+        '-f',
+        `owner=${ownerRepo.owner}`,
+        '-f',
+        `repo=${ownerRepo.repo}`,
+        '-F',
+        `number=${prNumber}`
+      ],
+      { ...ghOptions, ...githubHostExecOptions(ownerRepo) }
+    )
+    const parsed = JSON.parse(stdout) as {
+      data?: {
+        repository?: {
+          pullRequest?: {
+            isInMergeQueue?: unknown
+            mergeQueueEntry?: {
+              state?: unknown
+              position?: unknown
+              estimatedTimeToMerge?: unknown
+              enqueuedAt?: unknown
+            } | null
+          } | null
+        } | null
+      }
+    }
+    const pullRequest = parsed.data?.repository?.pullRequest
+    if (pullRequest?.isInMergeQueue !== true) {
+      return NOT_QUEUED
+    }
+    // Why: GitHub can report membership without an entry payload; synthesise one so
+    // presence stays a faithful discriminator instead of silently reading as not-queued.
+    const entry = pullRequest.mergeQueueEntry
+    return {
+      mergeQueueEntry: {
+        state: typeof entry?.state === 'string' ? entry.state : 'QUEUED',
+        position: coerceNullableNumber(entry?.position),
+        estimatedTimeToMerge: coerceNullableNumber(entry?.estimatedTimeToMerge),
+        enqueuedAt: typeof entry?.enqueuedAt === 'string' ? entry.enqueuedAt : null
+      }
+    }
+  } catch {
+    // Why: a failed probe must not demote a PR or abort the refresh; "not queued" is the safe default.
+    return NOT_QUEUED
+  }
+}

--- a/src/main/github/client/detect/pull-request-merge-queue-probe-callers.test.ts
+++ b/src/main/github/client/detect/pull-request-merge-queue-probe-callers.test.ts
@@ -1,0 +1,59 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const REPO_ROOT = fileURLToPath(new URL('../../../../..', import.meta.url))
+const SCAN_ROOT = join(REPO_ROOT, 'src')
+
+/**
+ * Why this ratchet: the per-PR queue probe is one extra GraphQL call. It is only
+ * affordable because every caller is a SINGLE-PR lookup gated on
+ * `mergeQueueRequired === true`. Wiring it into a list path would fan out N calls
+ * per refresh and blow the rate limit — a queued PR reading as `open` in a list
+ * row is the correct, intended degradation instead.
+ */
+const ALLOWED_CALLERS = [
+  'src/main/github/client/lookup/pull-request-lookup-hydration.ts',
+  'src/main/github/client/fetch/work-item-fetch.ts'
+]
+
+const PROBE_MODULE = 'pull-request-merge-queue-entry'
+
+function sourceFilesUnder(dir: string): string[] {
+  const found: string[] = []
+  for (const name of readdirSync(dir)) {
+    if (name === 'node_modules' || name === 'dist' || name === 'out') {
+      continue
+    }
+    const full = join(dir, name)
+    if (statSync(full).isDirectory()) {
+      found.push(...sourceFilesUnder(full))
+      continue
+    }
+    if (/\.tsx?$/.test(name) && !/\.test\.tsx?$/.test(name)) {
+      found.push(full)
+    }
+  }
+  return found
+}
+
+describe('merge-queue probe call sites', () => {
+  it('is imported only by single-PR lookups, never by a list path', () => {
+    const importers = sourceFilesUnder(SCAN_ROOT)
+      .filter((file) => !file.endsWith(`${PROBE_MODULE}.ts`))
+      .filter((file) => readFileSync(file, 'utf8').includes(PROBE_MODULE))
+      .map((file) => relative(REPO_ROOT, file).split('\\').join('/'))
+      .sort()
+    expect(importers).toEqual([...ALLOWED_CALLERS].sort())
+  })
+
+  it('keeps the list-path merge-metadata hydration probe-free', () => {
+    const listHydration = readFileSync(
+      join(SCAN_ROOT, 'main/github/client/detect/hydrate-work-item-merge-metadata.ts'),
+      'utf8'
+    )
+    expect(listHydration).not.toContain(PROBE_MODULE)
+    expect(listHydration).not.toContain('mergeQueueEntry')
+  })
+})

--- a/src/main/github/client/fetch/work-item-fetch-merge-queue.test.ts
+++ b/src/main/github/client/fetch/work-item-fetch-merge-queue.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  ghExecFileAsyncMock,
+  detectRepositoryMergeMetadataMock,
+  detectPullRequestMergeQueueEntryMock
+} = vi.hoisted(() => ({
+  ghExecFileAsyncMock: vi.fn(),
+  detectRepositoryMergeMetadataMock: vi.fn(),
+  detectPullRequestMergeQueueEntryMock: vi.fn()
+}))
+
+vi.mock('../../gh-utils', () => ({
+  ghExecFileAsync: ghExecFileAsyncMock,
+  classifyGhError: () => ({ type: 'unknown' }),
+  ghRepoExecOptions: () => ({}),
+  githubRepoContext: () => ({})
+}))
+vi.mock('../../github-api-repository', () => ({ githubHostExecOptions: () => ({}) }))
+vi.mock('./../detect/repository-merge-metadata', () => ({
+  detectRepositoryMergeMetadata: detectRepositoryMergeMetadataMock
+}))
+vi.mock('./../detect/pull-request-merge-queue-entry', () => ({
+  detectPullRequestMergeQueueEntry: detectPullRequestMergeQueueEntryMock
+}))
+
+import { fetchPullRequestWorkItem } from './work-item-fetch'
+
+const ownerRepo = { owner: 'stablyai', repo: 'orca' }
+const mergeQueueEntry = { state: 'QUEUED', position: 2 }
+
+function prViewPayload(overrides: Record<string, unknown> = {}): { stdout: string } {
+  return {
+    stdout: JSON.stringify({
+      number: 7,
+      title: 'A pull request',
+      state: 'OPEN',
+      url: 'https://github.com/stablyai/orca/pull/7',
+      baseRefName: 'main',
+      ...overrides
+    })
+  }
+}
+
+describe('fetchPullRequestWorkItem merge-queue probe', () => {
+  beforeEach(() => {
+    ghExecFileAsyncMock.mockReset()
+    detectRepositoryMergeMetadataMock.mockReset()
+    detectPullRequestMergeQueueEntryMock.mockReset()
+    ghExecFileAsyncMock.mockResolvedValue(prViewPayload())
+    detectRepositoryMergeMetadataMock.mockResolvedValue({
+      mergeQueueRequired: false,
+      autoMergeAllowed: true
+    })
+    detectPullRequestMergeQueueEntryMock.mockResolvedValue({ mergeQueueEntry })
+  })
+
+  it('does not probe when the base branch does not require a merge queue', async () => {
+    const item = await fetchPullRequestWorkItem('/repo', ownerRepo, 7)
+    expect(detectPullRequestMergeQueueEntryMock).not.toHaveBeenCalled()
+    expect(item?.mergeQueueEntry).toBeUndefined()
+  })
+
+  it('does not probe for a draft PR', async () => {
+    detectRepositoryMergeMetadataMock.mockResolvedValue({
+      mergeQueueRequired: true,
+      autoMergeAllowed: true
+    })
+    ghExecFileAsyncMock.mockResolvedValue(prViewPayload({ isDraft: true }))
+    await fetchPullRequestWorkItem('/repo', ownerRepo, 7)
+    expect(detectPullRequestMergeQueueEntryMock).not.toHaveBeenCalled()
+  })
+
+  it('probes and publishes open + the entry when the base branch requires a queue', async () => {
+    detectRepositoryMergeMetadataMock.mockResolvedValue({
+      mergeQueueRequired: true,
+      autoMergeAllowed: true
+    })
+    const item = await fetchPullRequestWorkItem('/repo', ownerRepo, 7)
+    expect(detectPullRequestMergeQueueEntryMock).toHaveBeenCalledWith(ownerRepo, 7, {})
+    // Why: `queued` is client-derived — the host publishes the wire value only.
+    expect(item?.state).toBe('open')
+    expect(item?.mergeQueueEntry).toEqual(mergeQueueEntry)
+  })
+
+  it('leaves the item unqueued when the probe degrades', async () => {
+    detectRepositoryMergeMetadataMock.mockResolvedValue({
+      mergeQueueRequired: true,
+      autoMergeAllowed: true
+    })
+    detectPullRequestMergeQueueEntryMock.mockResolvedValue({})
+    const item = await fetchPullRequestWorkItem('/repo', ownerRepo, 7)
+    expect(item?.mergeQueueEntry).toBeUndefined()
+  })
+})

--- a/src/main/github/client/fetch/work-item-fetch.ts
+++ b/src/main/github/client/fetch/work-item-fetch.ts
@@ -10,6 +10,7 @@ import { githubHostExecOptions, type GitHubApiRepository } from '../../github-ap
 import type { GhExecOptions } from './../github-exec-scope'
 import { resolvePullRequestLookupCandidates } from './../pull-request-lookup-candidates'
 import { detectRepositoryMergeMetadata } from './../detect/repository-merge-metadata'
+import { detectPullRequestMergeQueueEntry } from './../detect/pull-request-merge-queue-entry'
 import {
   WORK_ITEM_PR_DETAIL_JSON_FIELDS,
   usersFromUnknown,
@@ -119,9 +120,16 @@ export async function fetchPullRequestWorkItem(
       const baseRefName = typeof item.baseRefName === 'string' ? item.baseRefName : undefined
       try {
         const mergeMetadata = await detectRepositoryMergeMetadata(ownerRepo, baseRefName, ghOptions)
+        // Why: single-item fetch only, and only once the base branch is known to
+        // require a queue — the list path must never fan this out per row (#12316).
+        const membership =
+          mergeMetadata.mergeQueueRequired === true && mapped.state === 'open'
+            ? await detectPullRequestMergeQueueEntry(ownerRepo, number, ghOptions)
+            : undefined
         return {
           ...mapped,
           mergeQueueRequired: mergeMetadata.mergeQueueRequired,
+          ...(membership?.mergeQueueEntry ? { mergeQueueEntry: membership.mergeQueueEntry } : {}),
           ...(mergeMetadata.autoMergeAllowed !== null
             ? { autoMergeAllowed: mergeMetadata.autoMergeAllowed }
             : {}),

--- a/src/main/github/client/lookup/pr-refresh-outcome-assembly.ts
+++ b/src/main/github/client/lookup/pr-refresh-outcome-assembly.ts
@@ -52,6 +52,7 @@ export function assemblePRRefreshFoundOutcome(args: {
                 : data.mergeQueueRequired
           }
         : {}),
+      ...(data.mergeQueueEntry ? { mergeQueueEntry: data.mergeQueueEntry } : {}),
       ...(data.mergeMethodSettings !== undefined
         ? { mergeMethodSettings: data.mergeMethodSettings }
         : {}),

--- a/src/main/github/client/lookup/pull-request-lookup-data.ts
+++ b/src/main/github/client/lookup/pull-request-lookup-data.ts
@@ -1,5 +1,6 @@
 import type {
   GitHubPRMergeMethodSettings,
+  PullRequestMergeQueueEntry,
   GitHubPRStack,
   PRMergeableState,
   PRReviewDecision
@@ -30,6 +31,7 @@ export type PullRequestLookupData = {
   autoMergeEnabled?: boolean
   autoMergeAllowed?: boolean | null
   mergeQueueRequired?: boolean | null
+  mergeQueueEntry?: PullRequestMergeQueueEntry
   mergeMethodSettings?: GitHubPRMergeMethodSettings
   mergeStateStatus?: string | null
   baseRefName?: string

--- a/src/main/github/client/lookup/pull-request-lookup-hydration.test.ts
+++ b/src/main/github/client/lookup/pull-request-lookup-hydration.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { detectRepositoryMergeMetadataMock, detectPullRequestMergeQueueEntryMock } = vi.hoisted(
+  () => ({
+    detectRepositoryMergeMetadataMock: vi.fn(),
+    detectPullRequestMergeQueueEntryMock: vi.fn()
+  })
+)
+
+vi.mock('./../detect/repository-merge-metadata', () => ({
+  detectRepositoryMergeMetadata: detectRepositoryMergeMetadataMock
+}))
+vi.mock('./../detect/pull-request-merge-queue-entry', () => ({
+  detectPullRequestMergeQueueEntry: detectPullRequestMergeQueueEntryMock
+}))
+
+import { hydratePullRequestLookupData } from './pull-request-lookup-hydration'
+import type { PullRequestLookupData } from './pull-request-lookup-data'
+
+const ownerRepo = { owner: 'stablyai', repo: 'orca' }
+
+function lookupData(overrides: Partial<PullRequestLookupData> = {}): PullRequestLookupData {
+  return {
+    number: 42,
+    title: 'A pull request',
+    state: 'OPEN',
+    url: 'https://github.com/stablyai/orca/pull/42',
+    statusCheckRollup: [],
+    updatedAt: '2026-08-26T00:00:00Z',
+    mergeable: 'MERGEABLE',
+    mergeStateStatus: 'CLEAN',
+    ...overrides
+  }
+}
+
+describe('hydratePullRequestLookupData merge-queue probe gating', () => {
+  beforeEach(() => {
+    detectRepositoryMergeMetadataMock.mockReset()
+    detectPullRequestMergeQueueEntryMock.mockReset()
+    detectRepositoryMergeMetadataMock.mockResolvedValue({
+      mergeQueueRequired: false,
+      autoMergeAllowed: true
+    })
+    detectPullRequestMergeQueueEntryMock.mockResolvedValue({})
+  })
+
+  it('does not probe when the base branch does not require a merge queue', async () => {
+    const hydrated = await hydratePullRequestLookupData(ownerRepo, lookupData(), {}, 'default')
+    expect(detectPullRequestMergeQueueEntryMock).not.toHaveBeenCalled()
+    expect(hydrated.mergeQueueEntry).toBeUndefined()
+  })
+
+  it('does not probe for a draft PR', async () => {
+    detectRepositoryMergeMetadataMock.mockResolvedValue({
+      mergeQueueRequired: true,
+      autoMergeAllowed: true
+    })
+    await hydratePullRequestLookupData(ownerRepo, lookupData({ isDraft: true }), {}, 'default')
+    expect(detectPullRequestMergeQueueEntryMock).not.toHaveBeenCalled()
+  })
+
+  it('does not probe for a merged PR', async () => {
+    detectRepositoryMergeMetadataMock.mockResolvedValue({
+      mergeQueueRequired: true,
+      autoMergeAllowed: true
+    })
+    await hydratePullRequestLookupData(ownerRepo, lookupData({ state: 'MERGED' }), {}, 'default')
+    expect(detectPullRequestMergeQueueEntryMock).not.toHaveBeenCalled()
+  })
+
+  it('probes and carries the queue entry when the base branch requires a merge queue', async () => {
+    detectRepositoryMergeMetadataMock.mockResolvedValue({
+      mergeQueueRequired: true,
+      autoMergeAllowed: true
+    })
+    detectPullRequestMergeQueueEntryMock.mockResolvedValue({
+      mergeQueueEntry: { state: 'QUEUED', position: 2, estimatedTimeToMerge: 900, enqueuedAt: null }
+    })
+    const hydrated = await hydratePullRequestLookupData(ownerRepo, lookupData(), {}, 'default')
+    expect(detectPullRequestMergeQueueEntryMock).toHaveBeenCalledWith(ownerRepo, 42, {})
+    expect(hydrated.mergeQueueEntry).toEqual({
+      state: 'QUEUED',
+      position: 2,
+      estimatedTimeToMerge: 900,
+      enqueuedAt: null
+    })
+  })
+
+  it('leaves the PR unqueued when the probe degrades', async () => {
+    detectRepositoryMergeMetadataMock.mockResolvedValue({
+      mergeQueueRequired: true,
+      autoMergeAllowed: true
+    })
+    const hydrated = await hydratePullRequestLookupData(ownerRepo, lookupData(), {}, 'default')
+    expect(hydrated.mergeQueueEntry).toBeUndefined()
+  })
+})

--- a/src/main/github/client/lookup/pull-request-lookup-hydration.ts
+++ b/src/main/github/client/lookup/pull-request-lookup-hydration.ts
@@ -1,6 +1,8 @@
 import type { OwnerRepo } from '../../gh-utils'
 import type { GhExecOptions } from './../github-exec-scope'
 import { detectRepositoryMergeMetadata } from './../detect/repository-merge-metadata'
+import { detectPullRequestMergeQueueEntry } from './../detect/pull-request-merge-queue-entry'
+import { mapPRState } from '../../mappers'
 import {
   normalizePullRequestLookupData,
   type PullRequestLookupData
@@ -22,8 +24,16 @@ export async function hydratePullRequestLookupData(
         executionScope
       )
     : undefined
+  // Why: the per-PR queue probe is a second GraphQL call, so only spend it where a
+  // merge queue actually exists and the PR is still live enough to be sitting in it.
+  const resolvedState = mapPRState(normalized.state, normalized.isDraft)
+  const membership =
+    mergeMetadata?.mergeQueueRequired === true && resolvedState === 'open'
+      ? await detectPullRequestMergeQueueEntry(ownerRepo, normalized.number, ghOptions)
+      : undefined
   return {
     ...normalized,
+    ...(membership?.mergeQueueEntry ? { mergeQueueEntry: membership.mergeQueueEntry } : {}),
     ...(mergeMetadata ? { mergeQueueRequired: mergeMetadata.mergeQueueRequired } : {}),
     ...(mergeMetadata ? { autoMergeAllowed: mergeMetadata.autoMergeAllowed } : {}),
     ...(mergeMetadata?.mergeMethodSettings

--- a/src/main/github/client/map/work-item-field-coercion.ts
+++ b/src/main/github/client/map/work-item-field-coercion.ts
@@ -1,11 +1,17 @@
 import type {
   PRMergeableState,
-  PRReviewDecision
+  PRReviewDecision,
+  PRWireState
 } from '../../../../shared/github/pull-request-types'
 import type { GitHubWorkItem } from '../../../../shared/github/work-item-types'
 import { summarizeProviderChecks } from '../../../../shared/provider-check-summary'
 // Why: omit repoId — the main process only has the path; the renderer stamps repoId after IPC.
-export type MainWorkItem = Omit<GitHubWorkItem, 'repoId'>
+// Why the narrowed state: this type is what `github.listWorkItems` / `workItem` /
+// `workItemDetails` publish, and `queued` must never cross the wire. Queue
+// membership travels as `mergeQueueEntry`; the client derives `queued` from it
+// (see `pull-request-queue-state.ts`), so an older client reads `open` — which
+// a queued PR genuinely is.
+export type MainWorkItem = Omit<GitHubWorkItem, 'repoId' | 'state'> & { state: PRWireState }
 
 export const WORK_ITEM_PR_LIST_JSON_FIELDS =
   'number,title,state,url,labels,updatedAt,author,isDraft,headRefName,baseRefName,headRefOid,headRepositoryOwner,reviewRequests'

--- a/src/main/github/mappers-pr-state.test.ts
+++ b/src/main/github/mappers-pr-state.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { mapPRState } from './mappers'
+import {
+  isQueuedPullRequest,
+  toPullRequestWireState,
+  withDerivedPullRequestQueueState
+} from '../../shared/github/pull-request-queue-state'
+
+const entry = { state: 'QUEUED', position: 3 }
+
+describe('mapPRState', () => {
+  it('never derives queued — that value is client-side only', () => {
+    expect(mapPRState('OPEN', false)).toBe('open')
+    expect(mapPRState('open')).toBe('open')
+  })
+
+  it('maps merged, closed, and draft as before', () => {
+    expect(mapPRState('MERGED', false)).toBe('merged')
+    expect(mapPRState('CLOSED', false)).toBe('closed')
+    expect(mapPRState('OPEN', true)).toBe('draft')
+  })
+})
+
+describe('client-side queued derivation', () => {
+  it('derives queued only for an open PR carrying a queue entry', () => {
+    expect(withDerivedPullRequestQueueState({ state: 'open', mergeQueueEntry: entry })).toEqual({
+      state: 'queued',
+      mergeQueueEntry: entry
+    })
+    expect(withDerivedPullRequestQueueState({ state: 'open' })).toEqual({ state: 'open' })
+  })
+
+  it('lets merged, closed, and draft win over a stale queue entry', () => {
+    for (const state of ['merged', 'closed', 'draft'] as const) {
+      expect(withDerivedPullRequestQueueState({ state, mergeQueueEntry: entry })).toEqual({
+        state,
+        mergeQueueEntry: entry
+      })
+      expect(isQueuedPullRequest({ state, mergeQueueEntry: entry })).toBe(false)
+    }
+  })
+
+  it('narrows queued back to open for the wire', () => {
+    expect(toPullRequestWireState('queued')).toBe('open')
+    expect(toPullRequestWireState('draft')).toBe('draft')
+  })
+})

--- a/src/main/github/mappers.ts
+++ b/src/main/github/mappers.ts
@@ -1,5 +1,5 @@
 import type { PRCheckDetail } from '../../shared/github/check-types'
-import type { CheckStatus, IssueInfo, PRInfo } from '../../shared/github/pull-request-types'
+import type { CheckStatus, IssueInfo, PRWireState } from '../../shared/github/pull-request-types'
 import { derivePRCheckStatusFromRollup } from '../../shared/pr-check-status'
 
 // ── REST API check-runs mapping ───────────────────────────────────────
@@ -109,7 +109,9 @@ export function mapCheckConclusion(state: string): PRCheckDetail['conclusion'] {
   return null
 }
 
-export function mapPRState(state: string, isDraft?: boolean): PRInfo['state'] {
+// Why: returns the wire contract only. `queued` is never derived here — it is
+// carried as `open` + `mergeQueueEntry` and re-derived client-side.
+export function mapPRState(state: string, isDraft?: boolean): PRWireState {
   const s = state?.toUpperCase()
   if (s === 'MERGED') {
     return 'merged'

--- a/src/main/github/pr-refresh-candidate-policy.ts
+++ b/src/main/github/pr-refresh-candidate-policy.ts
@@ -5,6 +5,7 @@ import type {
   GitHubPRRefreshSkippedReason,
   PRRefreshOutcome
 } from '../../shared/github/pull-request-refresh-types'
+import { isQueuedPullRequest } from '../../shared/github/pull-request-queue-state'
 import type { GitHubPRBranchLookupOptions } from './client'
 import { NO_REVIEW_REFRESH_INTERVAL_MS } from '../source-control/hosted-review-refresh-pacing'
 
@@ -138,7 +139,8 @@ export function visibleCandidateAfterOutcome(
     cachedPRState: outcome.kind === 'found' ? outcome.pr.state : null,
     cachedChecksStatus: outcome.kind === 'found' ? outcome.pr.checksStatus : null,
     cachedMergeable: outcome.kind === 'found' ? outcome.pr.mergeable : null,
-    cachedMergeStateStatus: outcome.kind === 'found' ? (outcome.pr.mergeStateStatus ?? null) : null
+    cachedMergeStateStatus: outcome.kind === 'found' ? (outcome.pr.mergeStateStatus ?? null) : null,
+    cachedMergeQueued: outcome.kind === 'found' ? isQueuedPullRequest(outcome.pr) : false
   }
 }
 
@@ -148,6 +150,13 @@ function refreshIntervalForCandidate(candidate: GitHubPRRefreshCandidate): numbe
   }
   if (candidate.cachedHasPR === false) {
     return NO_REVIEW_REFRESH_INTERVAL_MS
+  }
+  // Why: a queued PR advances, merges, or is evicted within minutes, and its position/ETA
+  // copy is only useful while current, so poll it faster than any checks cadence.
+  // `cachedMergeQueued` is the derived flag hosts set; `cachedPRState` is also checked
+  // because the renderer sends its already-derived cache state on client-initiated refreshes.
+  if (candidate.cachedMergeQueued === true || candidate.cachedPRState === 'queued') {
+    return 30_000
   }
   if (
     candidate.cachedHasPR === true &&
@@ -176,7 +185,7 @@ function hasResolvedMergeStateStatus(status: string | null | undefined): boolean
 export function isMergeabilityPendingOutcome(outcome: PRRefreshOutcome): boolean {
   return (
     outcome.kind === 'found' &&
-    outcome.pr.state === 'open' &&
+    (outcome.pr.state === 'open' || outcome.pr.state === 'queued') &&
     outcome.pr.mergeable === 'UNKNOWN' &&
     !hasResolvedMergeStateStatus(outcome.pr.mergeStateStatus)
   )

--- a/src/main/source-control/forge-provider.ts
+++ b/src/main/source-control/forge-provider.ts
@@ -1,7 +1,7 @@
 import type {
   CreateHostedReviewInput,
   CreateHostedReviewResult,
-  HostedReviewInfo,
+  HostedReviewWireInfo,
   HostedReviewProvider
 } from '../../shared/hosted-review'
 import {
@@ -67,8 +67,9 @@ export type ForgeProvider = {
   id: ForgeProviderId
   supportsReviewCreation: boolean
   resolveRepository(context: ForgeProviderRepositoryContext): Promise<unknown>
-  getReviewForBranch(input: ForgeReviewForBranchInput): Promise<HostedReviewInfo | null>
-  getReviewByNumber(input: ForgeReviewByNumberInput): Promise<HostedReviewInfo | null>
+  // Why: wire-typed at the interface so a sixth provider cannot sidestep the guard.
+  getReviewForBranch(input: ForgeReviewForBranchInput): Promise<HostedReviewWireInfo | null>
+  getReviewByNumber(input: ForgeReviewByNumberInput): Promise<HostedReviewWireInfo | null>
   createReview?(
     repoPath: string,
     input: CreateHostedReviewInput,
@@ -121,7 +122,7 @@ const gitLabForgeProvider = {
 // mirroring how the PR refresh coordinator keeps cache on upstream-error.
 function unwrapGitHubPRForBranchOutcome(
   outcome: Awaited<ReturnType<typeof getPRForBranchOutcome>>
-): HostedReviewInfo | null {
+): HostedReviewWireInfo | null {
   if (outcome.kind === 'upstream-error') {
     throw new Error(`GitHub PR lookup failed (${outcome.errorType}): ${outcome.message}`)
   }

--- a/src/main/source-control/forge-review-mappers.ts
+++ b/src/main/source-control/forge-review-mappers.ts
@@ -1,23 +1,30 @@
-import type { HostedReviewInfo } from '../../shared/hosted-review'
+import type { HostedReviewWireInfo } from '../../shared/hosted-review'
 import { hostedReviewInfoFromGitHubPRInfo } from '../../shared/hosted-review-github'
+import { toPullRequestWireState } from '../../shared/github/pull-request-queue-state'
 import type { PRInfo } from '../../shared/github/pull-request-types'
 import type { MRInfo } from '../../shared/gitlab-types'
 import type { AzureDevOpsPullRequestInfo } from '../azure-devops/pull-request-mappers'
 import type { BitbucketPullRequestInfo } from '../bitbucket/pull-request-mappers'
 import type { GiteaPullRequestInfo } from '../gitea/pull-request-mappers'
 
-export function mapGitHubReview(pr: PRInfo): HostedReviewInfo {
-  return hostedReviewInfoFromGitHubPRInfo(pr)
+// Why: every mapper here returns the wire contract, so no provider — present or
+// future — can publish a state an older client cannot read. Queue membership
+// still travels, as `mergeQueueEntry`; the client re-derives `queued` from it
+// (see `pull-request-queue-state.ts`). A provider gaining merge-queue or
+// merge-train support must keep returning `HostedReviewWireInfo` and let the
+// client derive `queued`, never widen this type.
+export function mapGitHubReview(pr: PRInfo): HostedReviewWireInfo {
+  return { ...hostedReviewInfoFromGitHubPRInfo(pr), state: toPullRequestWireState(pr.state) }
 }
 
-function mapGitLabReviewState(state: MRInfo['state']): HostedReviewInfo['state'] {
+function mapGitLabReviewState(state: MRInfo['state']): HostedReviewWireInfo['state'] {
   if (state === 'opened' || state === 'locked') {
     return 'open'
   }
   return state
 }
 
-export function mapGitLabReview(mr: MRInfo): HostedReviewInfo {
+export function mapGitLabReview(mr: MRInfo): HostedReviewWireInfo {
   return {
     provider: 'gitlab',
     number: mr.number,
@@ -33,7 +40,7 @@ export function mapGitLabReview(mr: MRInfo): HostedReviewInfo {
   }
 }
 
-export function mapBitbucketReview(pr: BitbucketPullRequestInfo): HostedReviewInfo {
+export function mapBitbucketReview(pr: BitbucketPullRequestInfo): HostedReviewWireInfo {
   return {
     provider: 'bitbucket',
     number: pr.number,
@@ -47,7 +54,7 @@ export function mapBitbucketReview(pr: BitbucketPullRequestInfo): HostedReviewIn
   }
 }
 
-export function mapAzureDevOpsReview(pr: AzureDevOpsPullRequestInfo): HostedReviewInfo {
+export function mapAzureDevOpsReview(pr: AzureDevOpsPullRequestInfo): HostedReviewWireInfo {
   return {
     provider: 'azure-devops',
     number: pr.number,
@@ -61,7 +68,7 @@ export function mapAzureDevOpsReview(pr: AzureDevOpsPullRequestInfo): HostedRevi
   }
 }
 
-export function mapGiteaReview(pr: GiteaPullRequestInfo): HostedReviewInfo {
+export function mapGiteaReview(pr: GiteaPullRequestInfo): HostedReviewWireInfo {
   return {
     provider: 'gitea',
     number: pr.number,

--- a/src/main/source-control/hosted-review-branch-cache.test.ts
+++ b/src/main/source-control/hosted-review-branch-cache.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { HostedReviewInfo } from '../../shared/hosted-review'
+import type { HostedReviewWireInfo } from '../../shared/hosted-review'
 import {
   __resetHostedReviewBranchCacheForTests,
   invalidateHostedReviewBranchCache,
@@ -20,11 +20,11 @@ const START = 1_000_000
 
 /** A lookup that never settles — the wedged provider this file's deadline exists for. */
 function stuckLookup() {
-  let resolve: (review: HostedReviewInfo | null) => void = () => {}
+  let resolve: (review: HostedReviewWireInfo | null) => void = () => {}
   let reject: (error: unknown) => void = () => {}
   const lookup = vi.fn(
     () =>
-      new Promise<HostedReviewInfo | null>((settle, fail) => {
+      new Promise<HostedReviewWireInfo | null>((settle, fail) => {
         resolve = settle
         reject = fail
       })
@@ -37,7 +37,7 @@ function stuckLookup() {
  * the size cap alone — no deadline, so it is a straggler that never timed out —
  * and leaves a fresh lookup owning the key.
  */
-function evictInflightRecord(evictedLookup: () => Promise<HostedReviewInfo | null>) {
+function evictInflightRecord(evictedLookup: () => Promise<HostedReviewWireInfo | null>) {
   const swallow = (promise: Promise<unknown>): void => {
     void promise.catch(() => {})
   }
@@ -59,7 +59,7 @@ function evictInflightRecord(evictedLookup: () => Promise<HostedReviewInfo | nul
   return { request, resolve: successor.resolve, reject: successor.reject }
 }
 
-const openReview: HostedReviewInfo = {
+const openReview: HostedReviewWireInfo = {
   provider: 'github',
   number: 7,
   title: 'Open PR',
@@ -70,7 +70,7 @@ const openReview: HostedReviewInfo = {
   mergeable: 'MERGEABLE'
 }
 
-const mergedReview: HostedReviewInfo = { ...openReview, state: 'merged' }
+const mergedReview: HostedReviewWireInfo = { ...openReview, state: 'merged' }
 
 describe('hosted review branch cache (#11532)', () => {
   beforeEach(() => {
@@ -135,10 +135,10 @@ describe('hosted review branch cache (#11532)', () => {
   })
 
   it('collapses concurrent callers onto one lookup', async () => {
-    let resolveLookup: (value: HostedReviewInfo | null) => void = () => {}
+    let resolveLookup: (value: HostedReviewWireInfo | null) => void = () => {}
     const lookup = vi.fn(
       () =>
-        new Promise<HostedReviewInfo | null>((resolve) => {
+        new Promise<HostedReviewWireInfo | null>((resolve) => {
           resolveLookup = resolve
         })
     )
@@ -192,7 +192,7 @@ describe('hosted review branch cache (#11532)', () => {
 
   it('serves the last known review from the failure itself, not only the backoff', async () => {
     const lookup = vi
-      .fn<() => Promise<HostedReviewInfo | null>>()
+      .fn<() => Promise<HostedReviewWireInfo | null>>()
       .mockResolvedValueOnce(openReview)
       .mockRejectedValueOnce(new Error('transient'))
 
@@ -213,7 +213,7 @@ describe('hosted review branch cache (#11532)', () => {
 
   it('resets the escalation once a lookup succeeds', async () => {
     const lookup = vi
-      .fn<() => Promise<HostedReviewInfo | null>>()
+      .fn<() => Promise<HostedReviewWireInfo | null>>()
       .mockRejectedValueOnce(new Error('first'))
       .mockResolvedValueOnce(openReview)
       .mockRejectedValueOnce(new Error('second'))
@@ -243,7 +243,7 @@ describe('hosted review branch cache (#11532)', () => {
 
   it('retires a cached no-review answer when Orca opens a review', async () => {
     const lookup = vi
-      .fn<() => Promise<HostedReviewInfo | null>>()
+      .fn<() => Promise<HostedReviewWireInfo | null>>()
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(openReview)
 
@@ -257,12 +257,12 @@ describe('hosted review branch cache (#11532)', () => {
   })
 
   it('discards a lookup that was already in flight when Orca opened a review', async () => {
-    let resolveLookup: (value: HostedReviewInfo | null) => void = () => {}
+    let resolveLookup: (value: HostedReviewWireInfo | null) => void = () => {}
     const lookup = vi
-      .fn<() => Promise<HostedReviewInfo | null>>()
+      .fn<() => Promise<HostedReviewWireInfo | null>>()
       .mockImplementationOnce(
         () =>
-          new Promise<HostedReviewInfo | null>((resolve) => {
+          new Promise<HostedReviewWireInfo | null>((resolve) => {
             resolveLookup = resolve
           })
       )
@@ -282,11 +282,11 @@ describe('hosted review branch cache (#11532)', () => {
   })
 
   it('leaves another repo in-flight lookup cacheable across an invalidation', async () => {
-    let resolveLookup: (value: HostedReviewInfo | null) => void = () => {}
+    let resolveLookup: (value: HostedReviewWireInfo | null) => void = () => {}
     const other = { ...identity, repoPath: '/other' }
-    const lookup = vi.fn<() => Promise<HostedReviewInfo | null>>().mockImplementationOnce(
+    const lookup = vi.fn<() => Promise<HostedReviewWireInfo | null>>().mockImplementationOnce(
       () =>
-        new Promise<HostedReviewInfo | null>((resolve) => {
+        new Promise<HostedReviewWireInfo | null>((resolve) => {
           resolveLookup = resolve
         })
     )

--- a/src/main/source-control/hosted-review-branch-cache.ts
+++ b/src/main/source-control/hosted-review-branch-cache.ts
@@ -1,4 +1,6 @@
-import type { HostedReviewInfo } from '../../shared/hosted-review'
+// Why: this cache only ever holds host-produced reviews, so the wire type is the
+// honest one — and typing it so keeps the publish narrowing intact end to end.
+import type { HostedReviewWireInfo } from '../../shared/hosted-review'
 import {
   __resetHostedReviewActiveClaimsForTests,
   isActiveBranch,
@@ -51,7 +53,7 @@ const FOUND_REVIEW_TTL_MS = 60_000
 const MAX_ENTRIES = MAX_BRANCH_MAP_ENTRIES
 
 type CacheEntry = {
-  review: HostedReviewInfo | null
+  review: HostedReviewWireInfo | null
   fetchedAt: number
   headOid: string | null
   /** When the lookup that produced this answer began, for straggler ordering. */
@@ -62,7 +64,7 @@ type InflightRecord = {
   /** Identity, so a detached lookup can only ever clear its own entry. */
   token: object
   startedAt: number
-  promise: Promise<HostedReviewInfo | null>
+  promise: Promise<HostedReviewWireInfo | null>
   /** Releases the callers and unpins the branch; idempotent. */
   expire: () => void
 }
@@ -264,17 +266,17 @@ function startLookup(
   key: string,
   scope: string,
   headOid: string | null,
-  lookup: () => Promise<HostedReviewInfo | null>
-): Promise<HostedReviewInfo | null> {
+  lookup: () => Promise<HostedReviewWireInfo | null>
+): Promise<HostedReviewWireInfo | null> {
   const startedAt = Date.now()
   const generation = scopeGeneration(scope)
   const token = {}
   /** The deadline released the callers; the lookup itself runs on, detached. */
   let timedOut = false
   let completed = false
-  let release: (review: HostedReviewInfo | null) => void = () => {}
+  let release: (review: HostedReviewWireInfo | null) => void = () => {}
   let fail: (error: unknown) => void = () => {}
-  const promise = new Promise<HostedReviewInfo | null>((resolve, reject) => {
+  const promise = new Promise<HostedReviewWireInfo | null>((resolve, reject) => {
     release = resolve
     fail = reject
   })
@@ -388,8 +390,8 @@ function startLookup(
 export async function withHostedReviewBranchCache(
   identity: HostedReviewBranchCacheIdentity,
   options: HostedReviewBranchCacheOptions,
-  lookup: () => Promise<HostedReviewInfo | null>
-): Promise<HostedReviewInfo | null> {
+  lookup: () => Promise<HostedReviewWireInfo | null>
+): Promise<HostedReviewWireInfo | null> {
   const key = hostedReviewBranchCacheKey(identity)
   const headOid = options.headOid
   // Why: sweep first, so a lookup whose deadline never fired cannot be joined —

--- a/src/main/source-control/hosted-review.ts
+++ b/src/main/source-control/hosted-review.ts
@@ -1,4 +1,4 @@
-import type { HostedReviewInfo } from '../../shared/hosted-review'
+import type { HostedReviewWireInfo } from '../../shared/hosted-review'
 import { assertRemoteUrlReadable } from '../git/remote-url-probe'
 import { getForgeProviderForRepository, type ForgeProviderId } from './forge-provider'
 import { withHostedReviewBranchCache } from './hosted-review-branch-cache'
@@ -46,7 +46,7 @@ export async function getHostedReviewForBranch(
      */
     active?: boolean
   } & HostedReviewExecutionOptions
-): Promise<HostedReviewInfo | null> {
+): Promise<HostedReviewWireInfo | null> {
   const branchName = input.branch.replace(/^refs\/heads\//, '')
   // Why: detached HEAD cannot use branch lookup, but provider-specific exact
   // ids can still resolve the review without probing an empty branch name.

--- a/src/main/source-control/merge-queue-wire-contract.test.ts
+++ b/src/main/source-control/merge-queue-wire-contract.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import { mapGitHubReview } from './forge-review-mappers'
+import { assemblePRRefreshFoundOutcome } from '../github/client/lookup/pr-refresh-outcome-assembly'
+import { mapPullRequestWorkItem } from '../github/client/map/work-item'
+import type { MainWorkItem } from '../github/client/map/work-item-field-coercion'
+import type { HostedReviewWireInfo } from '../../shared/hosted-review'
+import type { PRInfo, PRWireState } from '../../shared/github/pull-request-types'
+import {
+  isQueuedPullRequest,
+  withDerivedPRInfoQueueState,
+  withDerivedPullRequestQueueState
+} from '../../shared/github/pull-request-queue-state'
+
+// Why: a host publishing `queued` would be silently dropped or mis-branched by an
+// older client. These assertions fail at compile time if the wire types ever widen.
+type HasNoQueued<T> = [Extract<T, 'queued'>] extends [never] ? true : false
+const WIRE_TYPES_EXCLUDE_QUEUED: [
+  HasNoQueued<PRWireState>,
+  HasNoQueued<HostedReviewWireInfo['state']>,
+  HasNoQueued<MainWorkItem['state']>
+] = [true, true, true]
+
+const mergeQueueEntry = { state: 'QUEUED', position: 2, estimatedTimeToMerge: 600 }
+
+function queuedPRInfo(): PRInfo {
+  return {
+    number: 7,
+    title: 'A pull request',
+    // Why: only a client ever holds this value; construct it here to prove the
+    // publish boundary narrows it rather than forwarding it.
+    state: 'queued',
+    url: 'https://github.com/stablyai/orca/pull/7',
+    checksStatus: 'success',
+    updatedAt: '2026-08-26T00:00:00Z',
+    mergeable: 'MERGEABLE',
+    mergeQueueEntry
+  }
+}
+
+describe('merge-queue wire contract', () => {
+  it('excludes queued from every published state type', () => {
+    expect(WIRE_TYPES_EXCLUDE_QUEUED).toEqual([true, true, true])
+  })
+
+  it('publishes a queued review as open, carrying the queue entry', () => {
+    const wire = mapGitHubReview(queuedPRInfo())
+    expect(wire.state).toBe('open')
+    expect(wire.mergeQueueEntry).toEqual(mergeQueueEntry)
+  })
+
+  it('never assembles a queued PR state from a lookup carrying a queue entry', () => {
+    const outcome = assemblePRRefreshFoundOutcome({
+      data: {
+        number: 7,
+        title: 'A pull request',
+        state: 'OPEN',
+        url: 'https://github.com/stablyai/orca/pull/7',
+        statusCheckRollup: [],
+        updatedAt: '2026-08-26T00:00:00Z',
+        mergeable: 'MERGEABLE',
+        mergeQueueEntry
+      },
+      dataRepo: null,
+      dataHeadRepo: null,
+      stack: undefined,
+      mergeable: 'MERGEABLE',
+      stackMergeQueueRequired: undefined,
+      confirmedContainedHeadOid: null,
+      headDivergedFromMergedPRAtOid: null,
+      conflictSummary: undefined
+    })
+    expect(outcome.kind).toBe('found')
+    if (outcome.kind !== 'found') {
+      return
+    }
+    expect(outcome.pr.state).toBe('open')
+    expect(outcome.pr.mergeQueueEntry).toEqual(mergeQueueEntry)
+    // Why: the wire value is what an old client renders; a new client re-derives.
+    expect(isQueuedPullRequest(outcome.pr)).toBe(true)
+    expect(withDerivedPRInfoQueueState(outcome.pr)?.state).toBe('queued')
+  })
+
+  it('publishes a queued work item as open, carrying the queue entry', () => {
+    const mapped: MainWorkItem = {
+      ...mapPullRequestWorkItem({ number: 7, title: 'A pull request', state: 'OPEN' }),
+      mergeQueueEntry
+    }
+    expect(mapped.state).toBe('open')
+    // Why: the client re-derives; the host never publishes the refinement itself.
+    expect(isQueuedPullRequest(mapped)).toBe(true)
+    expect(withDerivedPullRequestQueueState(mapped)?.state).toBe('queued')
+  })
+
+  it('round-trips a client-derived queued state back to the wire value', () => {
+    const derived = withDerivedPRInfoQueueState({ ...queuedPRInfo(), state: 'open' })
+    expect(derived?.state).toBe('queued')
+    expect(mapGitHubReview(derived!).state).toBe('open')
+  })
+})

--- a/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanCard.tsx
@@ -5,7 +5,8 @@ import {
   GitMerge,
   GitPullRequest,
   GitPullRequestClosed,
-  GitPullRequestDraft
+  GitPullRequestDraft,
+  ListOrdered
 } from 'lucide-react'
 import { AgentIcon } from '@/lib/agent-catalog'
 import { agentTypeToIconAgent, formatAgentTypeLabel } from '@/lib/agent-status'
@@ -118,6 +119,10 @@ const REVIEW_PRESENTATION = {
     icon: GitPullRequest,
     className: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
   },
+  queued: {
+    icon: ListOrdered,
+    className: 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-300'
+  },
   draft: {
     icon: GitPullRequestDraft,
     className: 'border-border bg-muted/60 text-muted-foreground'
@@ -142,6 +147,8 @@ function ReviewPill({ card }: { card: DashboardCard }): React.JSX.Element | null
     switch (card.review.state) {
       case 'open':
         return translate('dashboardPopout.card.review.open', 'Open review')
+      case 'queued':
+        return translate('dashboardPopout.card.review.queued', 'Queued review')
       case 'draft':
         return translate('dashboardPopout.card.review.draft', 'Draft review')
       case 'merged':

--- a/src/renderer/src/components/dashboard-popout/agent-dashboard-filter-options.ts
+++ b/src/renderer/src/components/dashboard-popout/agent-dashboard-filter-options.ts
@@ -97,6 +97,7 @@ export function reviewCountsByState(cards: DashboardCard[]): Map<string, number>
 
 export const REVIEW_OPTIONS: readonly DashboardReviewFilter[] = [
   'open',
+  'queued',
   'draft',
   'merged',
   'closed',
@@ -107,6 +108,8 @@ export function reviewStateLabel(state: DashboardReviewFilter): string {
   switch (state) {
     case 'open':
       return translate('dashboardPopout.filters.review.open', 'Open')
+    case 'queued':
+      return translate('dashboardPopout.filters.review.queued', 'Queued')
     case 'draft':
       return translate('dashboardPopout.filters.review.draft', 'Draft')
     case 'merged':

--- a/src/renderer/src/components/github-item-dialog/load-item-details/work-item-state-badge.tsx
+++ b/src/renderer/src/components/github-item-dialog/load-item-details/work-item-state-badge.tsx
@@ -14,6 +14,9 @@ export function getStateTone(item: GitHubWorkItem): string {
     if (item.state === 'closed') {
       return 'border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-300'
     }
+    if (item.state === 'queued') {
+      return 'border-blue-500/30 bg-blue-500/10 text-blue-600 dark:text-blue-300'
+    }
     return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300'
   }
   if (item.state === 'closed') {

--- a/src/renderer/src/components/github-pr-auto-merge-action.ts
+++ b/src/renderer/src/components/github-pr-auto-merge-action.ts
@@ -1,0 +1,61 @@
+import { canEnableGitHubPRAutoMerge } from '../../../shared/github/pull-request-auto-merge-availability'
+import { translate } from '@/i18n/i18n'
+import type { GitHubPRMergeStateInput } from './github-pr-merge-state'
+
+export type GitHubPRAutoMergeAction = {
+  kind: 'enable' | 'disable'
+  label: string
+  tooltip: string
+}
+
+// Why: GitHub rejects enabling auto-merge on a conflicting PR, so offering it
+// there only yields an error toast. Repos can also disable auto-merge entirely,
+// so suppress the action when GitHub explicitly reports that setting is off.
+function canEnableAutoMerge(item: GitHubPRMergeStateInput): boolean {
+  return canEnableGitHubPRAutoMerge(item)
+}
+
+/**
+ * The auto-merge toggle offered alongside a PR's merge state. Keeps the original
+ * `auto.components.github.pr.merge.state.*` message ids so catalogs stay stable.
+ */
+export function resolveGitHubPRAutoMergeAction(
+  item: GitHubPRMergeStateInput
+): GitHubPRAutoMergeAction | null {
+  // Why: only a plain open PR can take an auto-merge request — a queued PR is
+  // already in the queue, and merged/closed/draft have nothing to schedule.
+  if (item.state !== 'open') {
+    return null
+  }
+  if (item.autoMergeEnabled === true) {
+    return {
+      kind: 'disable',
+      label: translate('auto.components.github.pr.merge.state.48d75ae118', 'Disable auto-merge'),
+      tooltip: translate(
+        'auto.components.github.pr.merge.state.62703b1dc4',
+        'GitHub auto-merge is enabled for this pull request'
+      )
+    }
+  }
+  if (item.mergeQueueRequired === true) {
+    return {
+      kind: 'enable',
+      label: translate('auto.components.github.pr.merge.state.b169f943e1', 'Merge when ready'),
+      tooltip: translate(
+        'auto.components.github.pr.merge.state.331ebe1170',
+        'Add this pull request to the GitHub merge queue'
+      )
+    }
+  }
+  if (canEnableAutoMerge(item)) {
+    return {
+      kind: 'enable',
+      label: translate('auto.components.github.pr.merge.state.4ab19a62ef', 'Enable auto-merge'),
+      tooltip: translate(
+        'auto.components.github.pr.merge.state.8f6cb3772f',
+        'Merge this pull request automatically once requirements are met'
+      )
+    }
+  }
+  return null
+}

--- a/src/renderer/src/components/github-pr-merge-queue-presentation.ts
+++ b/src/renderer/src/components/github-pr-merge-queue-presentation.ts
@@ -1,0 +1,88 @@
+import type { PullRequestMergeQueueEntry } from '../../../shared/github/pull-request-types'
+import { formatResetDuration } from '../../../shared/rate-limit-reset-format'
+import { translate } from '@/i18n/i18n'
+
+/** Human place in line, or null when GitHub gave no usable position. */
+function queuePlaceText(entry: PullRequestMergeQueueEntry | undefined): string | null {
+  const position = entry?.position
+  if (typeof position !== 'number' || !Number.isFinite(position) || position < 1) {
+    return null
+  }
+  if (position === 1) {
+    return translate(
+      'auto.components.github.pr.merge.queue.presentation.e77682f1ad',
+      'next to merge'
+    )
+  }
+  return translate(
+    'auto.components.github.pr.merge.queue.presentation.54e43b657c',
+    '#{{position}} in line',
+    { position }
+  )
+}
+
+/** `estimatedTimeToMerge` is a GraphQL Int in seconds; render it as a compact duration. */
+function queueEtaText(entry: PullRequestMergeQueueEntry | undefined): string | null {
+  const seconds = entry?.estimatedTimeToMerge
+  if (typeof seconds !== 'number' || !Number.isFinite(seconds) || seconds <= 0) {
+    return null
+  }
+  return translate(
+    'auto.components.github.pr.merge.queue.presentation.aed8678f01',
+    '~{{duration}}',
+    {
+      // Why: the shared formatter floors to whole minutes, so a sub-minute ETA would
+      // read "~0m"; clamp to a minute so the copy stays truthful about "very soon".
+      duration: formatResetDuration(Math.max(seconds, 60) * 1000)
+    }
+  )
+}
+
+/**
+ * Badge/button copy for a PR sitting in the merge queue. Position and ETA are
+ * primary copy, not tooltip-only — but every part degrades away independently so
+ * a missing field never renders a placeholder.
+ */
+export function getGitHubPRMergeQueueLabel(entry: PullRequestMergeQueueEntry | undefined): string {
+  const queued = translate(
+    'auto.components.github.pr.merge.queue.presentation.0cabcd9e02',
+    'Queued'
+  )
+  const parts = [queuePlaceText(entry), queueEtaText(entry)].filter(
+    (part): part is string => part !== null
+  )
+  return parts.length > 0 ? `${queued} · ${parts.join(' · ')}` : queued
+}
+
+export function getGitHubPRMergeQueueTooltip(
+  entry: PullRequestMergeQueueEntry | undefined
+): string {
+  const base = translate(
+    'auto.components.github.pr.merge.queue.presentation.5c1debcfb8',
+    'Added to the GitHub merge queue.'
+  )
+  const place = queuePlaceText(entry)
+  const eta = queueEtaText(entry)
+  if (place && eta) {
+    return translate(
+      'auto.components.github.pr.merge.queue.presentation.6c286b2fe3',
+      '{{base}} It is {{place}} (ETA {{eta}}).',
+      { base, place, eta }
+    )
+  }
+  if (place) {
+    return translate(
+      'auto.components.github.pr.merge.queue.presentation.cd9e09f8b7',
+      '{{base}} It is {{place}}.',
+      { base, place }
+    )
+  }
+  if (eta) {
+    return translate(
+      'auto.components.github.pr.merge.queue.presentation.d1a73d2387',
+      '{{base}} ETA {{eta}}.',
+      { base, eta }
+    )
+  }
+  return base
+}

--- a/src/renderer/src/components/github-pr-merge-state.test.ts
+++ b/src/renderer/src/components/github-pr-merge-state.test.ts
@@ -24,6 +24,38 @@ describe('presentGitHubPRMergeState', () => {
     })
   })
 
+  it('reports a queued PR as queued instead of offering to enqueue it again', () => {
+    const presentation = presentGitHubPRMergeState(
+      pr({
+        state: 'queued',
+        mergeQueueRequired: true,
+        mergeQueueEntry: { state: 'QUEUED', position: 3, estimatedTimeToMerge: 600 }
+      })
+    )
+    expect(presentation.label).toContain('Queued')
+    expect(presentation.label).toContain('#3 in line')
+    expect(presentation.label).not.toContain('Merge when ready')
+    expect(presentation.directMergeAvailable).toBe(false)
+    expect(presentation.autoMergeAction).toBeNull()
+  })
+
+  it('phrases the head of the queue as next to merge and degrades without position or ETA', () => {
+    expect(
+      presentGitHubPRMergeState(
+        pr({ state: 'queued', mergeQueueEntry: { state: 'MERGEABLE', position: 1 } })
+      ).label
+    ).toContain('next to merge')
+    const bare = presentGitHubPRMergeState(
+      pr({
+        state: 'queued',
+        mergeQueueEntry: { state: 'QUEUED', position: null, estimatedTimeToMerge: null }
+      })
+    )
+    expect(bare.label).toBe('Queued')
+    expect(bare.label).not.toMatch(/undefined|null|NaN/)
+    expect(presentGitHubPRMergeState(pr({ state: 'queued' })).label).toBe('Queued')
+  })
+
   it('uses the merge-queue label for auto-merge when a queue is required', () => {
     expect(presentGitHubPRMergeState(pr({ mergeQueueRequired: true }))).toMatchObject({
       label: 'Merge when ready',

--- a/src/renderer/src/components/github-pr-merge-state.ts
+++ b/src/renderer/src/components/github-pr-merge-state.ts
@@ -1,15 +1,23 @@
 import type {
   CheckStatus,
+  PullRequestMergeQueueEntry,
   PRMergeableState,
   PRReviewDecision,
   PRState,
   ProviderCheckSummary
 } from '../../../shared/github/pull-request-types'
-import { canEnableGitHubPRAutoMerge } from '../../../shared/github/pull-request-auto-merge-availability'
+import {
+  getGitHubPRMergeQueueLabel,
+  getGitHubPRMergeQueueTooltip
+} from './github-pr-merge-queue-presentation'
+import {
+  resolveGitHubPRAutoMergeAction,
+  type GitHubPRAutoMergeAction
+} from './github-pr-auto-merge-action'
 import { translate } from '@/i18n/i18n'
 
 export type GitHubPRMergeStateInput = {
-  state: PRState | 'open' | 'closed' | 'merged' | 'draft'
+  state: PRState
   mergeable?: PRMergeableState
   mergeStateStatus?: string | null
   reviewDecision?: PRReviewDecision | null
@@ -18,13 +26,10 @@ export type GitHubPRMergeStateInput = {
   autoMergeEnabled?: boolean
   autoMergeAllowed?: boolean | null
   mergeQueueRequired?: boolean | null
+  mergeQueueEntry?: PullRequestMergeQueueEntry
 }
 
-export type GitHubPRAutoMergeAction = {
-  kind: 'enable' | 'disable'
-  label: string
-  tooltip: string
-}
+export type { GitHubPRAutoMergeAction }
 
 export type GitHubPRMergeStatePresentation = {
   label: string
@@ -55,13 +60,6 @@ function hasFullMergeMetadata(item: GitHubPRMergeStateInput): boolean {
   return item.mergeable !== undefined || item.mergeStateStatus !== undefined
 }
 
-// Why: GitHub rejects enabling auto-merge on a conflicting PR, so offering it
-// there only yields an error toast. Repos can also disable auto-merge entirely,
-// so suppress the action when GitHub explicitly reports that setting is off.
-function canEnableAutoMerge(item: GitHubPRMergeStateInput): boolean {
-  return canEnableGitHubPRAutoMerge(item)
-}
-
 // Why: when GitHub already allows a direct merge, offering "Enable auto-merge"
 // only yields a "clean status" rejection. Keep the Disable action so users can
 // still turn off an existing auto-merge request; merge-queue "Merge when ready"
@@ -90,46 +88,7 @@ function passedChecksMergePresentation(
 export function presentGitHubPRMergeState(
   item: GitHubPRMergeStateInput
 ): GitHubPRMergeStatePresentation {
-  const autoMergeAction =
-    item.state !== 'open'
-      ? null
-      : item.autoMergeEnabled === true
-        ? {
-            kind: 'disable' as const,
-            label: translate(
-              'auto.components.github.pr.merge.state.48d75ae118',
-              'Disable auto-merge'
-            ),
-            tooltip: translate(
-              'auto.components.github.pr.merge.state.62703b1dc4',
-              'GitHub auto-merge is enabled for this pull request'
-            )
-          }
-        : item.mergeQueueRequired === true
-          ? {
-              kind: 'enable' as const,
-              label: translate(
-                'auto.components.github.pr.merge.state.b169f943e1',
-                'Merge when ready'
-              ),
-              tooltip: translate(
-                'auto.components.github.pr.merge.state.331ebe1170',
-                'Add this pull request to the GitHub merge queue'
-              )
-            }
-          : canEnableAutoMerge(item)
-            ? {
-                kind: 'enable' as const,
-                label: translate(
-                  'auto.components.github.pr.merge.state.4ab19a62ef',
-                  'Enable auto-merge'
-                ),
-                tooltip: translate(
-                  'auto.components.github.pr.merge.state.8f6cb3772f',
-                  'Merge this pull request automatically once requirements are met'
-                )
-              }
-            : null
+  const autoMergeAction = resolveGitHubPRAutoMergeAction(item)
 
   if (item.state === 'merged') {
     return {
@@ -165,6 +124,17 @@ export function presentGitHubPRMergeState(
       ),
       directMergeAvailable: false,
       autoMergeAction
+    }
+  }
+  // Why: must precede the mergeQueueRequired branch — that branch cannot tell
+  // "base branch uses a queue" from "this PR is already sitting in it" (#12316).
+  if (item.state === 'queued') {
+    return {
+      label: getGitHubPRMergeQueueLabel(item.mergeQueueEntry),
+      tone: WARNING_TONE,
+      tooltip: getGitHubPRMergeQueueTooltip(item.mergeQueueEntry),
+      directMergeAvailable: false,
+      autoMergeAction: null
     }
   }
   if (item.reviewDecision === 'REVIEW_REQUIRED') {

--- a/src/renderer/src/components/github-pr-merge-state.ts
+++ b/src/renderer/src/components/github-pr-merge-state.ts
@@ -7,9 +7,9 @@ import type {
   ProviderCheckSummary
 } from '../../../shared/github/pull-request-types'
 import {
-  getGitHubPRMergeQueueLabel,
-  getGitHubPRMergeQueueTooltip
-} from './github-pr-merge-queue-presentation'
+  getPullRequestMergeQueueLabel,
+  getPullRequestMergeQueueTooltip
+} from './pull-request-merge-queue-presentation'
 import {
   resolveGitHubPRAutoMergeAction,
   type GitHubPRAutoMergeAction
@@ -130,9 +130,9 @@ export function presentGitHubPRMergeState(
   // "base branch uses a queue" from "this PR is already sitting in it" (#12316).
   if (item.state === 'queued') {
     return {
-      label: getGitHubPRMergeQueueLabel(item.mergeQueueEntry),
+      label: getPullRequestMergeQueueLabel(item.mergeQueueEntry),
       tone: WARNING_TONE,
-      tooltip: getGitHubPRMergeQueueTooltip(item.mergeQueueEntry),
+      tooltip: getPullRequestMergeQueueTooltip(item.mergeQueueEntry),
       directMergeAvailable: false,
       autoMergeAction: null
     }

--- a/src/renderer/src/components/github/work-item-state-presentation.tsx
+++ b/src/renderer/src/components/github/work-item-state-presentation.tsx
@@ -19,6 +19,9 @@ export function getStateLabel(item: GitHubWorkItem): string {
     if (item.state === 'closed') {
       return 'Closed'
     }
+    if (item.state === 'queued') {
+      return 'Queued'
+    }
     return 'Open'
   }
   return item.state === 'closed' ? 'Closed' : 'Open'

--- a/src/renderer/src/components/pull-request-merge-queue-presentation.ts
+++ b/src/renderer/src/components/pull-request-merge-queue-presentation.ts
@@ -43,7 +43,9 @@ function queueEtaText(entry: PullRequestMergeQueueEntry | undefined): string | n
  * primary copy, not tooltip-only — but every part degrades away independently so
  * a missing field never renders a placeholder.
  */
-export function getGitHubPRMergeQueueLabel(entry: PullRequestMergeQueueEntry | undefined): string {
+export function getPullRequestMergeQueueLabel(
+  entry: PullRequestMergeQueueEntry | undefined
+): string {
   const queued = translate(
     'auto.components.github.pr.merge.queue.presentation.0cabcd9e02',
     'Queued'
@@ -54,7 +56,7 @@ export function getGitHubPRMergeQueueLabel(entry: PullRequestMergeQueueEntry | u
   return parts.length > 0 ? `${queued} · ${parts.join(' · ')}` : queued
 }
 
-export function getGitHubPRMergeQueueTooltip(
+export function getPullRequestMergeQueueTooltip(
   entry: PullRequestMergeQueueEntry | undefined
 ): string {
   const base = translate(

--- a/src/renderer/src/components/pull-request-page/page/surface.tsx
+++ b/src/renderer/src/components/pull-request-page/page/surface.tsx
@@ -4,7 +4,8 @@ import {
   GitMerge,
   GitPullRequest,
   GitPullRequestClosed,
-  GitPullRequestDraft
+  GitPullRequestDraft,
+  ListOrdered
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { useAppStore } from '@/store'
@@ -181,7 +182,9 @@ export default function PullRequestPage({
           ? GitPullRequestClosed
           : localState === 'draft'
             ? GitPullRequestDraft
-            : GitPullRequest
+            : localState === 'queued'
+              ? ListOrdered
+              : GitPullRequest
       : CircleDot
   const displayWorkItem = useMemo<GitHubWorkItem | null>(() => {
     if (!workItem) {

--- a/src/renderer/src/components/pull-request-page/presentation/state-badge.tsx
+++ b/src/renderer/src/components/pull-request-page/presentation/state-badge.tsx
@@ -14,6 +14,9 @@ export function getStateTone(item: GitHubWorkItem): string {
     if (item.state === 'closed') {
       return 'border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-300'
     }
+    if (item.state === 'queued') {
+      return 'border-blue-500/30 bg-blue-500/10 text-blue-600 dark:text-blue-300'
+    }
     return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300'
   }
   if (item.state === 'closed') {
@@ -30,6 +33,9 @@ export function getSolidStateTone(item: GitHubWorkItem): string {
     }
     if (item.state === 'draft') {
       return 'bg-slate-500 text-white'
+    }
+    if (item.state === 'queued') {
+      return 'bg-blue-600 text-white'
     }
   }
   return item.state === 'closed' ? 'bg-rose-600 text-white' : 'bg-emerald-600 text-white'

--- a/src/renderer/src/components/right-sidebar/HostedReviewActions.tsx
+++ b/src/renderer/src/components/right-sidebar/HostedReviewActions.tsx
@@ -91,7 +91,10 @@ export default function HostedReviewActions({
       checksStatus: review.status,
       autoMergeEnabled: review.autoMergeEnabled,
       autoMergeAllowed: review.autoMergeAllowed,
-      mergeQueueRequired: review.mergeQueueRequired
+      mergeQueueRequired: review.mergeQueueRequired,
+      // Why: the review carries the queue entry on hosted-review-only lookups where
+      // `githubPR` is null — without it the queued label loses position/ETA.
+      mergeQueueEntry: review.mergeQueueEntry ?? githubPR?.mergeQueueEntry
     })
     if (!githubPR?.stack || !stackMergeScope) {
       return presentation
@@ -155,7 +158,7 @@ export default function HostedReviewActions({
     runWorktreeDelete(worktree.id, worktree.hostId ? { expectedHostId: worktree.hostId } : {})
   }, [worktree.hostId, worktree.id])
 
-  if (review.state === 'open') {
+  if (review.state === 'open' || review.state === 'queued') {
     return (
       <div className="space-y-1.5">
         <TooltipProvider delayDuration={300}>

--- a/src/renderer/src/components/right-sidebar/HostedReviewActions.tsx
+++ b/src/renderer/src/components/right-sidebar/HostedReviewActions.tsx
@@ -32,10 +32,10 @@ import {
 } from './right-sidebar-primary-action-layout'
 import { translate } from '@/i18n/i18n'
 import {
-  getGitHubPRStackMergeBlocker,
   getGitHubPRStackMergeScope,
   isGitHubPRStackMergeQueueRequired
 } from './github-pr-stack-merge'
+import { composeStackMergePresentation } from './hosted-review-stack-merge-presentation'
 
 export default function HostedReviewActions({
   review,
@@ -96,29 +96,16 @@ export default function HostedReviewActions({
       // `githubPR` is null — without it the queued label loses position/ETA.
       mergeQueueEntry: review.mergeQueueEntry ?? githubPR?.mergeQueueEntry
     })
-    if (!githubPR?.stack || !stackMergeScope) {
-      return presentation
-    }
-    const stackBlocker = getGitHubPRStackMergeBlocker(stackMergeScope)
-    return {
-      ...presentation,
-      label: stackMergeLabel ?? stackMergeScope.label,
-      tooltip:
-        stackBlocker ??
-        (stackUsesMergeQueue
-          ? translate(
-              'auto.components.right.sidebar.HostedReviewActions.3de88351c5',
-              'GitHub will add this pull request and every pull request below it to the merge queue.'
-            )
-          : translate(
-              'auto.components.right.sidebar.HostedReviewActions.a32fe6dba6',
-              'GitHub will merge this pull request and every pull request below it in the stack.'
-            )),
-      directMergeAvailable:
-        !stackBlocker &&
-        (stackMergeScope.complete || presentation.directMergeAvailable || stackUsesMergeQueue),
-      autoMergeAction: null
-    }
+    // Why: a queued PR is already in the queue, stack or not. The stack override below
+    // forces `directMergeAvailable` on for `stackUsesMergeQueue`, which would re-offer
+    // enqueue — and re-running merge on a queued PR exits 0 without doing anything.
+    return composeStackMergePresentation(presentation, {
+      isQueued: review.state === 'queued',
+      stackMergeScope,
+      hasStack: Boolean(githubPR?.stack),
+      stackMergeLabel,
+      stackUsesMergeQueue
+    })
   }, [githubPR, isGitLab, review, stackMergeLabel, stackMergeScope, stackUsesMergeQueue])
   const mergeMethods = useMemo(
     () => resolveGitHubPRMergeMethods(isGitLab ? null : (githubPR?.mergeMethodSettings ?? null)),

--- a/src/renderer/src/components/right-sidebar/checks-panel/check-presentation.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel/check-presentation.tsx
@@ -46,5 +46,7 @@ export function prStateColor(state: PRInfo['state']): string {
       return 'bg-muted text-muted-foreground/70 border-border'
     case 'open':
       return 'bg-emerald-500/15 text-emerald-500 border-emerald-500/20'
+    case 'queued':
+      return 'bg-blue-500/15 text-blue-500 border-blue-500/20'
   }
 }

--- a/src/renderer/src/components/right-sidebar/hosted-review-stack-merge-presentation.test.ts
+++ b/src/renderer/src/components/right-sidebar/hosted-review-stack-merge-presentation.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { composeStackMergePresentation } from './hosted-review-stack-merge-presentation'
+import type { GitHubPRStackMergeScope } from './github-pr-stack-merge'
+import type { GitHubPRMergeStatePresentation } from '@/components/github-pr-merge-state'
+
+const queuedPresentation: GitHubPRMergeStatePresentation = {
+  label: 'Queued · #3 in line',
+  tone: 'tone',
+  tooltip: 'Added to the GitHub merge queue.',
+  directMergeAvailable: false,
+  autoMergeAction: null
+}
+
+const readyPresentation: GitHubPRMergeStatePresentation = {
+  ...queuedPresentation,
+  label: 'Able to merge',
+  directMergeAvailable: true
+}
+
+const completeScope: GitHubPRStackMergeScope = {
+  count: 2,
+  complete: true,
+  entries: [],
+  label: 'Merge through #7 · 2 PRs'
+}
+
+describe('composeStackMergePresentation', () => {
+  it('keeps a queued stack PR non-actionable instead of re-offering enqueue', () => {
+    const result = composeStackMergePresentation(queuedPresentation, {
+      isQueued: true,
+      stackMergeScope: completeScope,
+      hasStack: true,
+      stackMergeLabel: 'Queue through #7 · 2 PRs',
+      stackUsesMergeQueue: true
+    })
+
+    // Without the queued guard, `stackUsesMergeQueue` forces this true and the
+    // merge button re-enqueues a PR that is already in the queue.
+    expect(result.directMergeAvailable).toBe(false)
+    expect(result).toEqual(queuedPresentation)
+  })
+
+  it('still applies the stack override for a non-queued PR', () => {
+    const result = composeStackMergePresentation(readyPresentation, {
+      isQueued: false,
+      stackMergeScope: completeScope,
+      hasStack: true,
+      stackMergeLabel: 'Queue through #7 · 2 PRs',
+      stackUsesMergeQueue: true
+    })
+
+    expect(result.label).toBe('Queue through #7 · 2 PRs')
+    expect(result.directMergeAvailable).toBe(true)
+    expect(result.autoMergeAction).toBeNull()
+  })
+
+  it('passes the presentation through when there is no stack', () => {
+    expect(
+      composeStackMergePresentation(readyPresentation, {
+        isQueued: false,
+        stackMergeScope: null,
+        hasStack: false,
+        stackUsesMergeQueue: false
+      })
+    ).toEqual(readyPresentation)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/hosted-review-stack-merge-presentation.ts
+++ b/src/renderer/src/components/right-sidebar/hosted-review-stack-merge-presentation.ts
@@ -1,0 +1,56 @@
+import type { GitHubPRMergeStatePresentation } from '@/components/github-pr-merge-state'
+import { getGitHubPRStackMergeBlocker, type GitHubPRStackMergeScope } from './github-pr-stack-merge'
+import { translate } from '@/i18n/i18n'
+
+type StackMergeOverrideOptions = {
+  /** True when the PR is already sitting in a merge queue. */
+  isQueued: boolean
+  stackMergeScope: GitHubPRStackMergeScope | null
+  hasStack: boolean
+  stackMergeLabel?: string
+  stackUsesMergeQueue: boolean
+}
+
+/**
+ * Layers stack-wide merge copy over a single-PR merge presentation.
+ *
+ * Why the queued guard comes first: the override below forces
+ * `directMergeAvailable` on whenever the stack uses a merge queue, which for an
+ * already-queued PR would re-offer enqueue. Re-running merge on a queued PR
+ * exits 0 without doing anything, so the button would report success and change
+ * nothing — the exact failure the queued state exists to prevent.
+ */
+export function composeStackMergePresentation(
+  presentation: GitHubPRMergeStatePresentation,
+  {
+    isQueued,
+    stackMergeScope,
+    hasStack,
+    stackMergeLabel,
+    stackUsesMergeQueue
+  }: StackMergeOverrideOptions
+): GitHubPRMergeStatePresentation {
+  if (isQueued || !hasStack || !stackMergeScope) {
+    return presentation
+  }
+  const stackBlocker = getGitHubPRStackMergeBlocker(stackMergeScope)
+  return {
+    ...presentation,
+    label: stackMergeLabel ?? stackMergeScope.label,
+    tooltip:
+      stackBlocker ??
+      (stackUsesMergeQueue
+        ? translate(
+            'auto.components.right.sidebar.HostedReviewActions.3de88351c5',
+            'GitHub will add this pull request and every pull request below it to the merge queue.'
+          )
+        : translate(
+            'auto.components.right.sidebar.HostedReviewActions.a32fe6dba6',
+            'GitHub will merge this pull request and every pull request below it in the stack.'
+          )),
+    directMergeAvailable:
+      !stackBlocker &&
+      (stackMergeScope.complete || presentation.directMergeAvailable || stackUsesMergeQueue),
+    autoMergeAction: null
+  }
+}

--- a/src/renderer/src/components/right-sidebar/source-control-dropdown-action-context.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-dropdown-action-context.ts
@@ -62,7 +62,7 @@ export function deriveDropdownActionContext(inputs: DropdownActionInputs): Dropd
   // Why: undefined upstreamStatus means loading (transient after a worktree switch), not unpublished — treating it as hasUpstream=false would re-enable Publish Branch and clobber the real upstream.
   const upstreamLoading = upstreamStatus === undefined
   const hasUpstream = upstreamStatus?.hasUpstream ?? false
-  const hasOpenHostedReview = prState === 'open' || prState === 'draft'
+  const hasOpenHostedReview = prState === 'open' || prState === 'queued' || prState === 'draft'
   const canPushUntrackedHostedReview =
     !hasUpstream &&
     hasOpenHostedReview &&

--- a/src/renderer/src/components/right-sidebar/source-control/review/hosted-review-header-chrome.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control/review/hosted-review-header-chrome.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { GitMerge, GitPullRequestClosed, GitPullRequestDraft } from 'lucide-react'
+import { GitMerge, GitPullRequestClosed, GitPullRequestDraft, ListOrdered } from 'lucide-react'
 import type { HostedReviewInfo } from '../../../../../../shared/hosted-review'
 import { cn } from '@/lib/utils'
 import { PullRequestIcon } from '../../checks-panel/check-presentation'
@@ -10,6 +10,9 @@ function hostedReviewStateClass(review: HostedReviewInfo): string {
   }
   if (review.state === 'open') {
     return 'text-emerald-500/80'
+  }
+  if (review.state === 'queued') {
+    return 'text-blue-500/85'
   }
   if (review.state === 'closed') {
     return 'text-muted-foreground/60'
@@ -30,6 +33,9 @@ function hostedReviewStateIcon(
   }
   if (review.state === 'draft') {
     return GitPullRequestDraft
+  }
+  if (review.state === 'queued') {
+    return ListOrdered
   }
   return null
 }

--- a/src/renderer/src/components/right-sidebar/source-control/review/hosted-review-push-target.ts
+++ b/src/renderer/src/components/right-sidebar/source-control/review/hosted-review-push-target.ts
@@ -1,6 +1,6 @@
 import type { GitUpstreamStatus } from '../../../../../../shared/git-status-types'
 import type { GitPushTarget } from '../../../../../../shared/worktree/types'
-import type { HostedReviewState } from '../../../../../../shared/hosted-review'
+import type { HostedReviewDisplayState } from '../../../../../../shared/hosted-review'
 import { isPositiveHostedReviewNumber } from '../../../../../../shared/hosted-review'
 import { getPublishTargetDisplayName } from '../../../../../../shared/git-publish-target-status'
 import { gitRefTargetsBranchName } from '../../../../../../shared/git-remote-branch-name'
@@ -71,7 +71,7 @@ export function hasPositiveHostedReviewNumberLink(args: {
 export function resolveHostedReviewActionUpstreamStatus(args: {
   hasHostedReviewLink: boolean
   hasResolvableHostedReviewPushTargetLink: boolean
-  hostedReviewState?: HostedReviewState | null
+  hostedReviewState?: HostedReviewDisplayState | null
   isHostedReviewStateLoading: boolean
   canUseHostedReviewPushTarget: boolean
   upstreamStatus?: GitUpstreamStatus
@@ -82,6 +82,7 @@ export function resolveHostedReviewActionUpstreamStatus(args: {
     (args.hasResolvableHostedReviewPushTargetLink && !args.hostedReviewState) ||
     args.isHostedReviewStateLoading ||
     args.hostedReviewState === 'open' ||
+    args.hostedReviewState === 'queued' ||
     args.hostedReviewState === 'draft'
   if (
     args.hasHostedReviewLink &&
@@ -96,9 +97,9 @@ export function resolveHostedReviewActionUpstreamStatus(args: {
 }
 
 export function resolveHostedReviewStateForActions(args: {
-  hostedReviewState?: HostedReviewState | null
+  hostedReviewState?: HostedReviewDisplayState | null
   hasResolvableHostedReviewPushTargetLink: boolean
-}): HostedReviewState | null {
+}): HostedReviewDisplayState | null {
   if (args.hostedReviewState) {
     return args.hostedReviewState
   }

--- a/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
+++ b/src/renderer/src/components/right-sidebar/use-hosted-review-actions.ts
@@ -24,6 +24,7 @@ export type HostedReviewActionInfo = Pick<
       | 'autoMergeEnabled'
       | 'autoMergeAllowed'
       | 'mergeQueueRequired'
+      | 'mergeQueueEntry'
       | 'mergeStateStatus'
     >
   >

--- a/src/renderer/src/components/right-sidebar/useHostedReviewStackParent.ts
+++ b/src/renderer/src/components/right-sidebar/useHostedReviewStackParent.ts
@@ -69,7 +69,8 @@ export function useHostedReviewStackParent({
             return
           }
           const openGitHubReview =
-            review?.provider === 'github' && (review.state === 'open' || review.state === 'draft')
+            review?.provider === 'github' &&
+            (review.state === 'open' || review.state === 'queued' || review.state === 'draft')
               ? { number: review.number, url: review.url }
               : null
           setSettled({ key: lookupKey, review: openGitHubReview })

--- a/src/renderer/src/components/sidebar/WorktreeCardMetadataStatusBadges.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardMetadataStatusBadges.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Badge } from '@/components/ui/badge'
-import { CircleCheck, CircleDot, CircleX, Clock, GitMerge } from 'lucide-react'
+import { CircleCheck, CircleDot, CircleX, Clock, GitMerge, ListOrdered } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { PullRequestIcon, checksLabel } from './WorktreeCardHelpers'
 import type { WorktreeCardPrDisplay } from './worktree-card-pr-display'
@@ -121,6 +121,20 @@ export function ReviewStateBadge({
         className="border-rose-500/25 bg-rose-500/5 text-rose-600 dark:text-rose-300"
       >
         <CircleX />
+      </MetadataStatusBadge>
+    )
+  }
+
+  if (state === 'queued') {
+    return (
+      <MetadataStatusBadge
+        label={translate(
+          'auto.components.sidebar.WorktreeCardMetadataStatusBadges.66d63eaedd',
+          'State: Queued'
+        )}
+        className="border-blue-500/25 bg-blue-500/5 text-blue-600 dark:text-blue-300"
+      >
+        <ListOrdered />
       </MetadataStatusBadge>
     )
   }

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
@@ -9,7 +9,7 @@ import StatusIndicator from './StatusIndicator'
 import { useWorktreeActivityStatus } from './use-worktree-activity-status'
 import type { WorktreeCardPrDisplay } from './worktree-card-pr-display'
 import { getReviewLabel, ReviewIcon } from './worktree-review-helpers'
-import { getGitHubPRMergeQueueLabel } from '@/components/github-pr-merge-queue-presentation'
+import { getPullRequestMergeQueueLabel } from '@/components/pull-request-merge-queue-presentation'
 
 type WorktreeCardStatusSlotProps = {
   worktreeId: string
@@ -76,7 +76,7 @@ function getReviewStatusTooltip(review: WorktreeCardPrDisplay): string {
     return `${label}: Draft`
   }
   if (review.state === 'queued') {
-    return `${label}: ${getGitHubPRMergeQueueLabel('mergeQueueEntry' in review ? review.mergeQueueEntry : undefined)}`
+    return `${label}: ${getPullRequestMergeQueueLabel('mergeQueueEntry' in review ? review.mergeQueueEntry : undefined)}`
   }
   if (review.status === 'failure') {
     return `${label} checks: Failed`

--- a/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardStatusSlot.tsx
@@ -9,6 +9,7 @@ import StatusIndicator from './StatusIndicator'
 import { useWorktreeActivityStatus } from './use-worktree-activity-status'
 import type { WorktreeCardPrDisplay } from './worktree-card-pr-display'
 import { getReviewLabel, ReviewIcon } from './worktree-review-helpers'
+import { getGitHubPRMergeQueueLabel } from '@/components/github-pr-merge-queue-presentation'
 
 type WorktreeCardStatusSlotProps = {
   worktreeId: string
@@ -73,6 +74,9 @@ function getReviewStatusTooltip(review: WorktreeCardPrDisplay): string {
   }
   if (review.state === 'draft') {
     return `${label}: Draft`
+  }
+  if (review.state === 'queued') {
+    return `${label}: ${getGitHubPRMergeQueueLabel('mergeQueueEntry' in review ? review.mergeQueueEntry : undefined)}`
   }
   if (review.status === 'failure') {
     return `${label} checks: Failed`

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/group-keys.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/group-keys.ts
@@ -156,6 +156,7 @@ export function getPRGroupKey(
   if (pr.state === 'draft') {
     return 'in-progress'
   }
+  // Why: 'queued' falls through to in-review — it is an open PR awaiting merge.
   return 'in-review'
 }
 

--- a/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
+++ b/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
@@ -1,4 +1,4 @@
-import { GitMerge, GitPullRequestClosed, GitPullRequestDraft } from 'lucide-react'
+import { GitMerge, GitPullRequestClosed, GitPullRequestDraft, ListOrdered } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { PullRequestIcon } from './WorktreeCardHelpers'
 import type { WorktreeCardPrDisplay } from './worktree-card-pr-display'
@@ -37,6 +37,9 @@ function getStateIcon(
   if (state === 'draft') {
     return GitPullRequestDraft
   }
+  if (state === 'queued') {
+    return ListOrdered
+  }
   return null
 }
 
@@ -46,6 +49,7 @@ function getStateIcon(
 // state glyph to contradict, so it still flags problems — but never claims success,
 // since emerald would assert an open review we have not confirmed.
 function getCheckTone(review: WorktreeCardPrDisplay): string | null {
+  // Why: queued is an open PR, but its own tone carries the queue signal.
   if (review.state && review.state !== 'open') {
     return null
   }
@@ -67,6 +71,9 @@ function getStateTone(state: WorktreeCardPrDisplay['state']): string {
   }
   if (state === 'open') {
     return 'text-emerald-500/80'
+  }
+  if (state === 'queued') {
+    return 'text-blue-500/85'
   }
   if (state === 'closed') {
     return 'text-muted-foreground/60'

--- a/src/renderer/src/components/task-page-github-work-item-filter-membership.test.ts
+++ b/src/renderer/src/components/task-page-github-work-item-filter-membership.test.ts
@@ -38,6 +38,28 @@ describe('shouldSoftHideTaskPageGitHubWorkItem', () => {
     ).toBe(true)
   })
 
+  it('keeps a queued PR in the is:open list', () => {
+    expect(
+      shouldSoftHideTaskPageGitHubWorkItem({
+        item: { state: 'queued', assignees: [], reviewRequests: [] },
+        query: baseQuery({ state: 'open' }),
+        viewerLogin: 'me',
+        skipMeQualifiers: false
+      })
+    ).toBe(false)
+  })
+
+  it('hides a queued PR from the is:closed list', () => {
+    expect(
+      shouldSoftHideTaskPageGitHubWorkItem({
+        item: { state: 'queued', assignees: [], reviewRequests: [] },
+        query: baseQuery({ state: 'closed' }),
+        viewerLogin: 'me',
+        skipMeQualifiers: false
+      })
+    ).toBe(true)
+  })
+
   it('does not state-soft-hide when state is null', () => {
     expect(
       shouldSoftHideTaskPageGitHubWorkItem({

--- a/src/renderer/src/components/task-page-github-work-item-filter-membership.ts
+++ b/src/renderer/src/components/task-page-github-work-item-filter-membership.ts
@@ -32,12 +32,18 @@ export function shouldSoftHideTaskPageGitHubWorkItem(args: {
 
   // State membership
   if (query.state === 'open') {
+    // Why: `queued` is an open PR (GitHub's search `state:open` returns it too).
     if (item.state === 'closed' || item.state === 'merged') {
       return true
     }
   } else if (query.state === 'closed') {
     // Why: closed-only lists treat merged as out-of-membership for soft-hide.
-    if (item.state === 'open' || item.state === 'merged' || item.state === 'draft') {
+    if (
+      item.state === 'open' ||
+      item.state === 'queued' ||
+      item.state === 'merged' ||
+      item.state === 'draft'
+    ) {
       return true
     }
   } else if (query.state === 'merged') {

--- a/src/renderer/src/components/task-page-github-work-item-status.test.ts
+++ b/src/renderer/src/components/task-page-github-work-item-status.test.ts
@@ -16,6 +16,15 @@ describe('task-page-github-work-item-status', () => {
     expect(getTaskPageGitHubWorkItemStateLabel({ type: 'pr', state: 'open' })).toBe('Open')
     expect(getTaskPageGitHubWorkItemStateLabel({ type: 'pr', state: 'closed' })).toBe('Closed')
     expect(getTaskPageGitHubWorkItemStateLabel({ type: 'pr', state: 'merged' })).toBe('Merged')
+    expect(getTaskPageGitHubWorkItemStateLabel({ type: 'pr', state: 'queued' })).toBe('Queued')
+  })
+
+  it('gives queued PRs a tone and icon distinct from the other four states', () => {
+    const queuedTone = getTaskPageGitHubWorkItemStateTone({ type: 'pr', state: 'queued' })
+    expect(queuedTone).toContain('blue')
+    expect(queuedTone).not.toContain('emerald')
+    expect(getTaskPageGitHubPRIconTone({ type: 'pr', state: 'queued' })).toContain('blue')
+    expect(isTaskPageGitHubDraftPR({ type: 'pr', state: 'queued' })).toBe(false)
   })
 
   it('maps issue states to labels', () => {

--- a/src/renderer/src/components/task-page-github-work-item-status.ts
+++ b/src/renderer/src/components/task-page-github-work-item-status.ts
@@ -14,6 +14,9 @@ export function getTaskPageGitHubWorkItemStateLabel(item: GitHubWorkItemStatusIt
     if (item.state === 'closed') {
       return translate('auto.components.TaskPage.d09bf34db7', 'Closed')
     }
+    if (item.state === 'queued') {
+      return translate('auto.components.task.page.github.work.item.status.da175c519c', 'Queued')
+    }
     return translate('auto.components.TaskPage.606a85c774', 'Open')
   }
 
@@ -35,6 +38,10 @@ export function getTaskPageGitHubWorkItemStateTone(item: GitHubWorkItemStatusIte
     }
     if (item.state === 'closed') {
       return 'border-rose-500/30 bg-rose-500/10 text-rose-700 dark:text-rose-200'
+    }
+    // Why: blue is the one unused slot next to open/merged/closed/draft.
+    if (item.state === 'queued') {
+      return 'border-blue-500/30 bg-blue-500/10 text-blue-700 dark:text-blue-200'
     }
     return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200'
   }
@@ -59,6 +66,8 @@ export function getTaskPageGitHubPRIconTone(item: GitHubWorkItemStatusItem): str
       return 'text-muted-foreground'
     case 'open':
       return 'text-emerald-600 dark:text-emerald-400'
+    case 'queued':
+      return 'text-blue-600 dark:text-blue-300'
     case 'merged':
       return 'text-purple-600 dark:text-purple-300'
     case 'closed':

--- a/src/renderer/src/components/task-page/github/github-work-item-row.tsx
+++ b/src/renderer/src/components/task-page/github/github-work-item-row.tsx
@@ -149,6 +149,7 @@ export function GithubWorkItemRow({
       <div className={GITHUB_TASK_STICKY_TITLE_CELL_CLASS}>
         <div className="flex min-w-0 items-center gap-2">
           <h3 className="truncate text-[13px] font-medium text-foreground">{item.title}</h3>
+          {/* Why: `queued` is worth badging even though it is an open PR. */}
           {item.type === 'pr' && item.state !== 'open' && item.state !== 'draft' ? (
             <TaskPageGitHubWorkItemStateBadge item={item} className="shrink-0 px-1.5 py-0" />
           ) : null}

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-candidate-row-data.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-candidate-row-data.ts
@@ -173,7 +173,11 @@ function hasGitStatusPill(candidate: WorkspaceCleanupCandidate): boolean {
 }
 
 export function getReviewPillTone(reviewInfo: WorkspaceCleanupReviewInfo): StatusPillTone {
-  if (reviewInfo.state === 'open' || reviewInfo.state === 'draft') {
+  if (
+    reviewInfo.state === 'open' ||
+    reviewInfo.state === 'queued' ||
+    reviewInfo.state === 'draft'
+  ) {
     return 'review'
   }
   return 'neutral'

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-labels.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-facet-labels.ts
@@ -81,6 +81,8 @@ export function getWorkspaceCleanupReviewStateLabel(state: WorkspaceCleanupRevie
   switch (state) {
     case 'open':
       return translate('components.workspace.cleanup.browse.review.open', 'Open')
+    case 'queued':
+      return translate('components.workspace.cleanup.browse.review.queued', 'Queued')
     case 'draft':
       return translate('components.workspace.cleanup.browse.review.draft', 'Draft')
     case 'merged':

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-filter-sort.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-filter-sort.ts
@@ -184,7 +184,12 @@ function matchesReviewFilter(
     case 'has-review':
       return reviewInfo.hasReview
     case 'open-review':
-      return reviewInfo.hasReview && (reviewInfo.state === 'open' || reviewInfo.state === 'draft')
+      return (
+        reviewInfo.hasReview &&
+        (reviewInfo.state === 'open' ||
+          reviewInfo.state === 'queued' ||
+          reviewInfo.state === 'draft')
+      )
     case 'closed-review':
       return (
         reviewInfo.hasReview && (reviewInfo.state === 'closed' || reviewInfo.state === 'merged')
@@ -232,7 +237,11 @@ function getReviewSortRank(reviewInfo: WorkspaceCleanupReviewInfo): number {
   if (!reviewInfo.hasReview) {
     return 0
   }
-  if (reviewInfo.state === 'open' || reviewInfo.state === 'draft') {
+  if (
+    reviewInfo.state === 'open' ||
+    reviewInfo.state === 'queued' ||
+    reviewInfo.state === 'draft'
+  ) {
     return 3
   }
   if (reviewInfo.state === 'unknown') {

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-presentation.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-presentation.ts
@@ -2,7 +2,11 @@ import { getHostedReviewCacheKey } from '@/store/slices/hosted-review'
 import type { AppState } from '@/store/types'
 import { translate } from '@/i18n/i18n'
 import { getRepoExecutionHostId } from '../../../../shared/execution-host'
-import type { HostedReviewInfo, HostedReviewProvider } from '../../../../shared/hosted-review'
+import type {
+  HostedReviewInfo,
+  HostedReviewProvider,
+  HostedReviewDisplayState
+} from '../../../../shared/hosted-review'
 import type { Repo } from '../../../../shared/repo-types'
 import type { Worktree } from '../../../../shared/worktree/types'
 import type { WorkspaceCleanupCandidate } from '../../../../shared/workspace-cleanup'
@@ -31,7 +35,7 @@ export type WorkspaceCleanupFilters = {
 export type WorkspaceCleanupReviewInfo = {
   hasReview: boolean
   label: string | null
-  state: 'open' | 'closed' | 'merged' | 'draft' | 'unknown' | null
+  state: HostedReviewDisplayState | 'unknown' | null
   provider: HostedReviewProvider | null
   title: string | null
 }

--- a/src/renderer/src/hooks/ipc-events/direct-ssh-hydration-fanout.test.ts
+++ b/src/renderer/src/hooks/ipc-events/direct-ssh-hydration-fanout.test.ts
@@ -64,8 +64,7 @@ describe('direct SSH hydration fanout', () => {
       api: {
         ui: {},
         ssh: {
-          listTargets: () =>
-            Promise.resolve(targets.map((id) => ({ id, label: id }))),
+          listTargets: () => Promise.resolve(targets.map((id) => ({ id, label: id }))),
           listRemovedTargetLabels: () => Promise.resolve({}),
           // A wedged relay answers nothing until the 30s RPC timeout fires.
           getState: ({ targetId }: { targetId: string }) => {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2346,6 +2346,18 @@
               "fbd4f57f0a": "Checks passed. Merge eligibility will be checked again before merging.",
               "4ab19a62ef": "Enable auto-merge",
               "8f6cb3772f": "Merge this pull request automatically once requirements are met"
+            },
+            "queue": {
+              "presentation": {
+                "e77682f1ad": "next to merge",
+                "54e43b657c": "#{{position}} in line",
+                "aed8678f01": "~{{duration}}",
+                "0cabcd9e02": "Queued",
+                "5c1debcfb8": "Added to the GitHub merge queue.",
+                "6c286b2fe3": "{{base}} It is {{place}} (ETA {{eta}}).",
+                "cd9e09f8b7": "{{base}} It is {{place}}.",
+                "d1a73d2387": "{{base}} ETA {{eta}}."
+              }
             }
           }
         },
@@ -5409,7 +5421,8 @@
           "e888362def": "State: Closed",
           "f394b3e86e": "State: Merged",
           "af2b07bda5": "State: {{value0}}",
-          "29df45afa2": "MR"
+          "29df45afa2": "MR",
+          "66d63eaedd": "State: Queued"
         },
         "WorktreeCardPorts": {
           "34f733dda2": "Go to Worktree",
@@ -15843,6 +15856,13 @@
                   }
                 }
               }
+            },
+            "work": {
+              "item": {
+                "status": {
+                  "da175c519c": "Queued"
+                }
+              }
             }
           },
           "hooks": {
@@ -16488,7 +16508,8 @@
             "merged": "Merged",
             "closed": "Closed",
             "unknown": "Unknown",
-            "otherProvider": "Other"
+            "otherProvider": "Other",
+            "queued": "Queued"
           },
           "ticket": {
             "workItem": "Work item",
@@ -16755,7 +16776,8 @@
         "open": "Open review",
         "draft": "Draft review",
         "merged": "Merged review",
-        "closed": "Closed review"
+        "closed": "Closed review",
+        "queued": "Queued review"
       },
       "subagents_one": "{{count}} subagent",
       "subagents_other": "{{count}} subagents"
@@ -16774,7 +16796,8 @@
         "draft": "Draft",
         "merged": "Merged",
         "closed": "Closed",
-        "none": "No review"
+        "none": "No review",
+        "queued": "Queued"
       },
       "reviewChip": "Review: {{state}}",
       "label": "Filter",

--- a/src/renderer/src/lib/github-work-item-source-lookup.ts
+++ b/src/renderer/src/lib/github-work-item-source-lookup.ts
@@ -1,6 +1,7 @@
 import type { GitHubWorkItem, GitHubWorkItemDetails } from '../../../shared/github/work-item-types'
 import type { TaskSourceContext } from '../../../shared/task-source-context'
 import { callRuntimeRpc } from '@/runtime/runtime-rpc-client'
+import { withDerivedPullRequestQueueState } from '../../../shared/github/pull-request-queue-state'
 import {
   getGitHubRuntimeRepoId,
   getGitHubSourceRuntimeHost,
@@ -56,7 +57,11 @@ export async function lookupGitHubWorkItemForSource(
           number: args.number,
           type: args.type
         })
-  return item ? ({ ...item, repoId: args.repoId } as GitHubWorkItem) : null
+  // Why: the wire carries `open` + `mergeQueueEntry`; derive `queued` here, at the
+  // point the item enters renderer state, using the one shared derivation.
+  return item
+    ? (withDerivedPullRequestQueueState({ ...item, repoId: args.repoId }) as GitHubWorkItem)
+    : null
 }
 
 export async function lookupGitHubWorkItemByOwnerRepoForSource(
@@ -87,7 +92,21 @@ export async function lookupGitHubWorkItemByOwnerRepoForSource(
           number: args.number,
           type: args.type
         })
-  return item ? ({ ...item, repoId: args.repoId } as GitHubWorkItem) : null
+  return item
+    ? (withDerivedPullRequestQueueState({ ...item, repoId: args.repoId }) as GitHubWorkItem)
+    : null
+}
+
+// Why: details are spread over the list-provided item on the PR page, so they must
+// carry the derived state too — otherwise a queued PR flips back to Open on load.
+function withDerivedDetailsQueueState(
+  details: GitHubWorkItemDetails | null
+): GitHubWorkItemDetails | null {
+  if (!details) {
+    return null
+  }
+  const item = withDerivedPullRequestQueueState(details.item)
+  return item === details.item ? details : { ...details, item }
 }
 
 export function lookupGitHubWorkItemDetailsForSource(
@@ -105,13 +124,15 @@ export function lookupGitHubWorkItemDetailsForSource(
         type: args.type
       },
       { timeoutMs: 30_000 }
-    )
+    ).then(withDerivedDetailsQueueState)
   }
-  return window.api.gh.workItemDetails({
-    repoPath: args.repoPath,
-    repoId: args.repoId,
-    sourceContext,
-    number: args.number,
-    type: args.type
-  })
+  return window.api.gh
+    .workItemDetails({
+      repoPath: args.repoPath,
+      repoId: args.repoId,
+      sourceContext,
+      number: args.number,
+      type: args.type
+    })
+    .then(withDerivedDetailsQueueState)
 }

--- a/src/renderer/src/store/github/cache-model.ts
+++ b/src/renderer/src/store/github/cache-model.ts
@@ -1,5 +1,5 @@
 import type { ClassifiedError } from '../../../../shared/classified-error'
-import type { GitHubOwnerRepo } from '../../../../shared/github/pull-request-types'
+import type { GitHubOwnerRepo, PRState } from '../../../../shared/github/pull-request-types'
 import type { GitHubPRRefreshAlias } from '../../../../shared/github/pull-request-refresh-types'
 import type { GitHubProjectViewError } from '../../../../shared/github/project-result-types'
 import type { TaskSourceContext } from '../../../../shared/task-source-context'
@@ -54,7 +54,7 @@ export type ProjectRowContentUpdate = {
 export type ProjectRowContentPatch = {
   title?: string
   body?: string
-  state?: 'open' | 'closed' | 'merged' | 'draft'
+  state?: PRState
   labels?: string[]
   assignees?: string[]
 }

--- a/src/renderer/src/store/github/pull-request-execution.ts
+++ b/src/renderer/src/store/github/pull-request-execution.ts
@@ -11,6 +11,7 @@ import type {
   PRRefreshOutcome
 } from '../../../../shared/github/pull-request-refresh-types'
 import { normalizeGitHubPRForBranchOutcome } from '../../../../shared/github/pull-request-for-branch-outcome'
+import { withDerivedPRInfoQueueState } from '../../../../shared/github/pull-request-queue-state'
 import { getRepoExecutionHostId, LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
 import { callRuntimeRpc } from '../../runtime/runtime-rpc-client'
 import { debouncedSaveCache } from './cache-persistence'
@@ -120,8 +121,10 @@ export function startPullRequestLookup(args: {
                 })
             return normalizeGitHubPRForBranchOutcome(response)
           })()
+      // Why: the wire carries `open` + `mergeQueueEntry`; derive `queued` here, at the
+      // point the value enters renderer state, so every consumer sees one representation.
       const pr: PRInfo | null =
-        outcome.kind === 'found' ? outcome.pr : outcome.kind === 'no-pr' ? null : null
+        outcome.kind === 'found' ? withDerivedPRInfoQueueState(outcome.pr) : null
       if (outcome.kind === 'upstream-error') {
         // Why: the runtime RPC path skips the coordinator broadcast that fills prRefreshStates on native, so record the classified error here for Checks parity with native (design criterion 2).
         if (runtimeRepo && prRequestGenerations.get(cacheKey) === generation) {

--- a/src/renderer/src/store/github/refresh-event-actions.ts
+++ b/src/renderer/src/store/github/refresh-event-actions.ts
@@ -15,6 +15,7 @@ import {
   prRefreshStartedEntryKey,
   setPRRefreshStartedHostedReviewEntry
 } from './pr-result-cache'
+import { withDerivedPullRequestQueueState } from '../../../../shared/github/pull-request-queue-state'
 import { prRefreshStartedHostedReviewEntries } from './request-coordination'
 import { getRefreshAliasExecutionHostId } from './repository-routing'
 import {
@@ -32,7 +33,19 @@ export const createRefreshEventActions = (
   set: Parameters<StateCreator<AppState>>[0],
   get: Parameters<StateCreator<AppState>>[1]
 ): Pick<GitHubSlice, 'applyGitHubPRRefreshEvent'> => ({
-  applyGitHubPRRefreshEvent: (event) => {
+  applyGitHubPRRefreshEvent: (rawEvent) => {
+    // Why: the coordinator broadcast is the other boundary the wire shape arrives on.
+    // Derive `queued` once here so prCache and the hosted-review cache it feeds agree.
+    const event =
+      rawEvent.outcome?.kind === 'found'
+        ? {
+            ...rawEvent,
+            outcome: {
+              ...rawEvent.outcome,
+              pr: withDerivedPullRequestQueueState(rawEvent.outcome.pr)
+            }
+          }
+        : rawEvent
     // Why: local-repo sidebar refresh routes through the main PR coordinator, so run the same guarded diverged-merged-PR clear.
     const divergedLinkedPRClears: {
       worktreeId: string

--- a/src/renderer/src/store/github/worktree-refresh.ts
+++ b/src/renderer/src/store/github/worktree-refresh.ts
@@ -166,7 +166,7 @@ export function shouldClearBranchMismatchedLinkedOpenPR(args: {
     linkedPRNumber != null &&
     pr?.number === linkedPRNumber &&
     // Draft reviews are open PRs too; don't let their distinct renderer state leave a stale durable link wedged after a branch switch.
-    (pr.state === 'open' || pr.state === 'draft') &&
+    (pr.state === 'open' || pr.state === 'queued' || pr.state === 'draft') &&
     requestHeadOid !== null &&
     headRefName !== '' &&
     currentBranch !== '' &&

--- a/src/renderer/src/store/slices/hosted-review.ts
+++ b/src/renderer/src/store/slices/hosted-review.ts
@@ -10,6 +10,7 @@ import type {
   HostedReviewCreationEligibilityArgs,
   HostedReviewInfo
 } from '../../../../shared/hosted-review'
+import { withDerivedHostedReviewQueueState } from '../../../../shared/github/pull-request-queue-state'
 import type { Repo } from '../../../../shared/repo-types'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import type { AppState } from '../types'
@@ -436,7 +437,7 @@ export const createHostedReviewSlice: StateCreator<AppState, [], [], HostedRevie
             linkedAzureDevOpsPR: options?.linkedAzureDevOpsPR ?? null,
             linkedGiteaPR: options?.linkedGiteaPR ?? null
           }
-          const review =
+          const fetched =
             target.kind === 'environment'
               ? await callRuntimeRpc<HostedReviewInfo | null>(
                   target,
@@ -452,6 +453,9 @@ export const createHostedReviewSlice: StateCreator<AppState, [], [], HostedRevie
                   repoPath,
                   ...args
                 })
+          // Why: hosts publish `open` + `mergeQueueEntry`; derive `queued` as the review
+          // enters renderer state so there is one representation, wire path or local IPC.
+          const review = withDerivedHostedReviewQueueState(fetched)
           if (requestGenerations.get(cacheKey) === generation) {
             set((state) => {
               if (

--- a/src/shared/dashboard-snapshot.ts
+++ b/src/shared/dashboard-snapshot.ts
@@ -1,5 +1,6 @@
 import type { AgentType, AgentWorkingMode } from './agent-status-types'
 import type { ExecutionHostId } from './execution-host'
+import type { PRState } from './github/pull-request-types'
 import type { RepoIcon } from './repo-icon'
 import type { TuiAgent } from './tui-agent'
 
@@ -49,7 +50,7 @@ export function dashboardCardDisplayState(
 
 export type DashboardCardReview = {
   number: number
-  state: 'open' | 'closed' | 'merged' | 'draft'
+  state: PRState
 }
 
 export type DashboardCardSubagent = {

--- a/src/shared/github/pull-request-auto-merge-availability.ts
+++ b/src/shared/github/pull-request-auto-merge-availability.ts
@@ -10,6 +10,8 @@ export type GitHubPRAutoMergeAvailabilityInput = {
   mergeQueueRequired?: boolean | null
 }
 
+// Why: `queued` is an open PR that is already in the merge queue — auto-merge
+// would only re-enqueue it, so it is deliberately excluded here.
 function isOpenPR(item: GitHubPRAutoMergeAvailabilityInput): boolean {
   return item.state === 'open'
 }

--- a/src/shared/github/pull-request-queue-state.ts
+++ b/src/shared/github/pull-request-queue-state.ts
@@ -1,0 +1,51 @@
+import type { HostedReviewInfo, HostedReviewWireInfo } from '../hosted-review'
+import type { PRInfo, PRState, PRWireState, PullRequestMergeQueueEntry } from './pull-request-types'
+
+type QueueStateCarrier = {
+  state: PRState
+  mergeQueueEntry?: PullRequestMergeQueueEntry
+}
+
+/**
+ * Whether a review is sitting in a provider merge queue. The presence of
+ * `mergeQueueEntry` is the discriminator — hosts publish `open` alongside it and
+ * clients derive `queued` here, so an older client simply reads it as open,
+ * which it genuinely is.
+ */
+export function isQueuedPullRequest(carrier: QueueStateCarrier): boolean {
+  return (carrier.state === 'open' || carrier.state === 'queued') && carrier.mergeQueueEntry != null
+}
+
+/** Narrows a possibly-derived state back to what a host is allowed to publish. */
+export function toPullRequestWireState(state: PRState): PRWireState {
+  return state === 'queued' ? 'open' : state
+}
+
+export function withDerivedPullRequestQueueState<T extends QueueStateCarrier>(value: T): T
+export function withDerivedPullRequestQueueState<T extends QueueStateCarrier>(
+  value: T | null | undefined
+): T | null | undefined
+export function withDerivedPullRequestQueueState<T extends QueueStateCarrier>(
+  value: T | null | undefined
+): T | null | undefined {
+  if (!value || !isQueuedPullRequest(value) || value.state === 'queued') {
+    return value
+  }
+  return { ...value, state: 'queued' }
+}
+
+/** Convenience wrapper preserving `PRInfo | null` for cache/store call sites. */
+export function withDerivedPRInfoQueueState(pr: PRInfo | null): PRInfo | null {
+  return withDerivedPullRequestQueueState(pr) ?? null
+}
+
+export function withDerivedHostedReviewQueueState(
+  review: HostedReviewInfo | HostedReviewWireInfo | null
+): HostedReviewInfo | null {
+  if (!review) {
+    return null
+  }
+  // Why: only GitHub publishes queue entries today; the derivation is
+  // provider-neutral so a GitLab merge train can light it up with no change here.
+  return withDerivedPullRequestQueueState(review as HostedReviewInfo) ?? null
+}

--- a/src/shared/github/pull-request-refresh-types.ts
+++ b/src/shared/github/pull-request-refresh-types.ts
@@ -74,6 +74,8 @@ export type GitHubPRRefreshCandidate = GitHubPRRefreshAlias & {
   cachedChecksStatus?: CheckStatus | null
   cachedMergeable?: PRMergeableState | null
   cachedMergeStateStatus?: string | null
+  /** Why: hosts set this derived flag because `queued` is not part of the published wire state. */
+  cachedMergeQueued?: boolean
   localGitOptions?: { wslDistro?: string }
 }
 

--- a/src/shared/github/pull-request-types.ts
+++ b/src/shared/github/pull-request-types.ts
@@ -1,4 +1,15 @@
-export type PRState = 'open' | 'closed' | 'merged' | 'draft'
+// Why: `queued` refines `open` — a review waiting in a provider merge queue (or
+// train) is still open upstream, so treat it as an active PR everywhere except
+// presentation and merge-action gating. Provider-neutral on purpose: GitLab
+// merge trains can adopt it with no type change.
+// Why not on the wire: `queued` is derived by the client from `mergeQueueEntry`,
+// never published — see `PRWireState`.
+export type PRState = 'open' | 'closed' | 'merged' | 'draft' | 'queued'
+
+// Why: hosts and clients update independently, so a host must never publish a
+// state value an older client cannot interpret. `queued` is carried across the
+// wire as `open` + `mergeQueueEntry` and re-derived client-side.
+export type PRWireState = Exclude<PRState, 'queued'>
 export type IssueState = 'open' | 'closed'
 export type CheckStatus = 'pending' | 'success' | 'failure' | 'neutral'
 
@@ -18,6 +29,29 @@ export type PRConflictSummary = {
 export type GitHubRepositoryIdentity = { owner: string; repo: string; host?: string }
 
 export type GitHubPRMergeMethod = 'merge' | 'squash' | 'rebase'
+
+/**
+ * A review's membership in a provider merge queue. Its presence is the wire
+ * discriminator for the `queued` state; absence means "not queued".
+ *
+ * Why every field but `state` is optional: providers expose different subsets.
+ * GitHub's GraphQL `mergeQueueEntry` has all four; a GitLab merge train has no
+ * ETA at all and needs GraphQL `MergeTrainCar.index` for position. Consumers
+ * must drop each absent field independently rather than render a placeholder.
+ *
+ * Why `state` is `string` and not an enum: it absorbs GitHub's
+ * QUEUED/AWAITING_CHECKS/MERGEABLE/UNMERGEABLE/LOCKED and GitLab's
+ * idle/fresh/stale/merging without a type change — the same shape-reuse this
+ * repo already does for `mergeStateStatus`, which GitLab rides with its own
+ * `detailed_merge_status` values (see `gitlab-types.ts`).
+ */
+export type PullRequestMergeQueueEntry = {
+  state: string
+  position?: number | null
+  /** Seconds until the provider expects the entry to merge. Absent where unsupported. */
+  estimatedTimeToMerge?: number | null
+  enqueuedAt?: string | null
+}
 
 export type GitHubPRMergeMethodSettings = {
   defaultMethod: GitHubPRMergeMethod
@@ -60,6 +94,8 @@ export type PRInfo = {
   autoMergeEnabled?: boolean
   autoMergeAllowed?: boolean | null
   mergeQueueRequired?: boolean | null
+  /** Present only while the review is actually sitting in the queue. Wire discriminator for `queued`. */
+  mergeQueueEntry?: PullRequestMergeQueueEntry
   mergeMethodSettings?: GitHubPRMergeMethodSettings
   mergeStateStatus?: string | null
   /** GitHub-registered stack metadata. Absent for ordinary dependent PR chains. */

--- a/src/shared/github/work-item-types.ts
+++ b/src/shared/github/work-item-types.ts
@@ -10,6 +10,8 @@ import type {
   GitHubRepositoryIdentity,
   PRMergeableState,
   PRReviewDecision,
+  PRState,
+  PullRequestMergeQueueEntry,
   ProviderCheckSummary
 } from './pull-request-types'
 
@@ -18,7 +20,7 @@ export type GitHubWorkItem = {
   type: 'issue' | 'pr'
   number: number
   title: string
-  state: 'open' | 'closed' | 'merged' | 'draft'
+  state: PRState
   url: string
   labels: string[]
   updatedAt: string
@@ -46,6 +48,9 @@ export type GitHubWorkItem = {
   autoMergeEnabled?: boolean
   autoMergeAllowed?: boolean | null
   mergeQueueRequired?: boolean | null
+  /** Wire discriminator for `queued`. Only the single-item fetch carries it —
+   *  the list path never probes, so list rows correctly read as `open`. */
+  mergeQueueEntry?: PullRequestMergeQueueEntry
   mergeMethodSettings?: GitHubPRMergeMethodSettings
   mergeStateStatus?: string | null
   maintainerCanModify?: boolean

--- a/src/shared/hosted-review-github.ts
+++ b/src/shared/hosted-review-github.ts
@@ -15,6 +15,7 @@ export function hostedReviewInfoFromGitHubPRInfo(pr: PRInfo): HostedReviewInfo {
     ...(pr.autoMergeEnabled !== undefined ? { autoMergeEnabled: pr.autoMergeEnabled } : {}),
     ...(pr.autoMergeAllowed !== undefined ? { autoMergeAllowed: pr.autoMergeAllowed } : {}),
     ...(pr.mergeQueueRequired !== undefined ? { mergeQueueRequired: pr.mergeQueueRequired } : {}),
+    ...(pr.mergeQueueEntry ? { mergeQueueEntry: pr.mergeQueueEntry } : {}),
     ...(pr.mergeStateStatus !== undefined ? { mergeStateStatus: pr.mergeStateStatus } : {}),
     ...(pr.headSha ? { headSha: pr.headSha } : {}),
     ...(pr.prRepo ? { githubRepository: pr.prRepo } : {}),

--- a/src/shared/hosted-review.ts
+++ b/src/shared/hosted-review.ts
@@ -1,5 +1,6 @@
 import type {
   CheckStatus,
+  PullRequestMergeQueueEntry,
   GitHubRepositoryIdentity,
   PRConflictSummary,
   PRMergeableState,
@@ -14,7 +15,14 @@ export type HostedReviewProvider =
   | 'gitea'
   | 'unsupported'
 
+// Why: the wire contract. A host may only ever publish one of these four — see
+// `HostedReviewDisplayState` for the client-derived `queued` refinement.
 export type HostedReviewState = 'open' | 'closed' | 'merged' | 'draft'
+
+// Why: mirrors PRState. `queued` never crosses the wire; the client derives it
+// from `mergeQueueEntry` as the value enters renderer state, so every
+// "is this review still live" check must accept it alongside open/draft.
+export type HostedReviewDisplayState = HostedReviewState | 'queued'
 
 // Why: Bitbucket Cloud's API has no draft pull requests, so offering the toggle
 // there would either publish a live PR or fail at submit.
@@ -31,7 +39,7 @@ export type HostedReviewInfo = {
   provider: HostedReviewProvider
   number: number
   title: string
-  state: HostedReviewState
+  state: HostedReviewDisplayState
   url: string
   status: CheckStatus
   updatedAt: string
@@ -40,6 +48,8 @@ export type HostedReviewInfo = {
   autoMergeEnabled?: boolean
   autoMergeAllowed?: boolean | null
   mergeQueueRequired?: boolean | null
+  /** Present only while the review is actually sitting in the queue. Wire discriminator for `queued`. */
+  mergeQueueEntry?: PullRequestMergeQueueEntry
   mergeStateStatus?: string | null
   headSha?: string
   /** GitHub repository that owns the PR; absent on older runtimes and other providers. */
@@ -50,6 +60,15 @@ export type HostedReviewInfo = {
   /** Target branch name for review-created worktree compare-base repair. */
   baseRefName?: string
   conflictSummary?: PRConflictSummary
+}
+
+/**
+ * The publish-side view of `HostedReviewInfo`: identical except that `state` is
+ * narrowed to the wire contract. Host mappers return this so assigning a
+ * possibly-`queued` PR state is a compile error rather than a wire regression.
+ */
+export type HostedReviewWireInfo = Omit<HostedReviewInfo, 'state'> & {
+  state: HostedReviewState
 }
 
 export type HostedReviewForBranchArgs = {

--- a/src/shared/source-control-primary-action-decision.ts
+++ b/src/shared/source-control-primary-action-decision.ts
@@ -92,7 +92,7 @@ export function resolveSourceControlPrimaryActionDecision(
   }
 
   const hasStaged = stagedCount > 0
-  const hasOpenHostedReview = prState === 'open' || prState === 'draft'
+  const hasOpenHostedReview = prState === 'open' || prState === 'queued' || prState === 'draft'
 
   if (hasStaged && hasMessage) {
     return {

--- a/src/shared/workspace-cleanup-facet-rankings.ts
+++ b/src/shared/workspace-cleanup-facet-rankings.ts
@@ -50,7 +50,8 @@ const REVIEW_RANK: Record<WorkspaceCleanupReviewState, number> = {
   closed: 1,
   unknown: 2,
   draft: 3,
-  open: 3
+  open: 3,
+  queued: 3
 }
 
 export const WORKSPACE_CLEANUP_BLOCKER_VALUES = Object.keys(

--- a/src/shared/workspace-cleanup-filter-model.ts
+++ b/src/shared/workspace-cleanup-filter-model.ts
@@ -18,7 +18,13 @@ export type WorkspaceCleanupIdleSignal = 'last-visited' | 'last-activity' | 'cre
 export type WorkspaceCleanupGitState = 'clean' | 'dirty' | 'unpushed' | 'unknown'
 export type WorkspaceCleanupAgentState = 'working' | 'permission' | 'idle'
 /** `draft` is a review STATE, not a separate flag. */
-export type WorkspaceCleanupReviewState = 'open' | 'draft' | 'merged' | 'closed' | 'unknown'
+export type WorkspaceCleanupReviewState =
+  | 'open'
+  | 'queued'
+  | 'draft'
+  | 'merged'
+  | 'closed'
+  | 'unknown'
 export type WorkspaceCleanupTicketSource = 'work-item' | 'linear' | 'issue'
 export type WorkspaceCleanupBlockerMode = 'any-of' | 'none-of'
 


### PR DESCRIPTION
## ELI5

When your PR is already waiting in GitHub's merge queue, Orca still showed a **Merge when ready** button — as if you still had to put it in the queue. Orca had no way to say "this PR is in the queue", so it fell back to the ordinary open-PR view.

This adds `queued` as a real PR state. A queued PR now reads `Queued · #3 in line · ~10m` instead of offering to enqueue something that is already enqueued.

## What Changed

- **New `queued` PR state**, a refinement of `open`. A queued PR still matches `is:open` filters and keeps its live-review affordances; only the merge affordance and badge change.
- **Detection** (`src/main/github/client/detect/pull-request-merge-queue-entry.ts`): a per-PR GraphQL probe reading `isInMergeQueue` / `mergeQueueEntry` (`state`, `position`, `estimatedTimeToMerge`, `enqueuedAt`). Any failure degrades to "not queued" so a refresh never breaks on it.
- **Cost gating**: the probe is gated on `mergeQueueRequired === true` and wired only into single-PR lookups (`pull-request-lookup-hydration.ts`, `work-item-fetch.ts`) — never the work-item list path.
- **Wire shape**: hosts publish `state: 'open'` plus a new **optional** `mergeQueueEntry` field; clients derive `queued` as the value enters renderer state.
- **UI**: the Checks panel renders position and ETA, degrading to a bare `Queued` when either is missing. Presentation lives in `github-pr-merge-queue-presentation.ts`; the auto-merge action was split out into `github-pr-auto-merge-action.ts`.

## Why

**Why GraphQL is the only source.** `gh pr view --json` exposes no queue fields at all, and `mergeStateStatus` *cannot* express queue state — its enum (`DIRTY`/`UNKNOWN`/`BLOCKED`/`BEHIND`/`UNSTABLE`/`HAS_HOOKS`/`CLEAN`) has no `QUEUED` value, so a queued PR still reports one of the ordinary seven. `isInMergeQueue` / `mergeQueueEntry` are the only signals that exist.

**Why the probe is affordable.** It is one extra GraphQL call, paid only by repos whose base branch actually requires a merge queue, and only on single-PR lookups. Repos without a merge queue pay zero extra API calls, and list refreshes are unchanged. Wiring it into the list path would fan out N calls per refresh, so `pull-request-merge-queue-probe-callers.test.ts` is a filesystem ratchet pinning the probe's importers to exactly those two files — a queued PR reading as `open` in a list row is the correct, intended degradation.

**Why `queued` is deliberately kept off the wire.** Clients and remote hosts update independently, so a new state value on the wire would be read by an older client that has no case for it. Publishing `state: 'open'` + optional `mergeQueueEntry` means an older client reads a queued PR as an ordinary open PR — which is *genuinely true*, since GitHub itself reports it as `OPEN`. This follows the existing `workingMode` precedent in `runtime-worktree-contracts.ts` (additive optional field, derive on the client) rather than the heavier capability-downgrade precedent in `skills.ts`, because there is nothing to downgrade: the old rendering is already correct, just less specific. Type-level and behavioural regression guards cover all three types that cross the RPC boundary — `PRInfo`, `HostedReviewInfo`, and `GitHubWorkItem` — in `merge-queue-wire-contract.test.ts`.

## Linked Issue

Closes #12316

## Visual Proof

Not attached. I do not have a repository with a populated merge queue to screenshot against, and a fabricated screenshot would be worse than none. The rendered copy is pinned by unit tests instead:

| Data available | Rendered |
| --- | --- |
| position 3, ETA 600s | `Queued · #3 in line · ~10m` |
| position 1, ETA 600s | `Queued · next to merge · ~10m` |
| position only | `Queued · #3 in line` |
| neither | `Queued` |

## Testing

- `pnpm tc` — clean.
- `pnpm run check:code-quality:changed` — 0 new findings.
- `oxlint` — clean.
- Renderer suite: 2773 files / 23538 tests passing.
- Merge-queue guard suite (detection, wire contract, probe-caller ratchet, presentation, mappers, hydration, work-item fetch): 7 files / 42 tests passing.

Platforms: logic-only change on the main/renderer side with no platform-dependent code paths; verified on macOS.

**Pre-existing failure, unrelated to this change:** `src/main/source-control/hosted-review-bitbucket.integration.test.ts` fails on this branch. I confirmed it is pre-existing by reproducing it against a stashed clean tree — flagging it so a reviewer is not surprised by a red test.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

## AI Disclosure

Claude (Opus) was used for implementation and test authoring; design decisions, the wire-compatibility choice, and the verification above are mine.

## Review

### Notes / open items

Things this PR does **not** cover, stated up front:

1. **`MergeQueueEntry.position` is assumed 1-based.** GitHub's schema declares it `Int!` but does not document the base, and I could not verify it against a live queue (none was populated at the time). If it is in fact 0-based, the head-of-queue entry renders incorrectly (`#0`-style off-by-one at the boundary). Happy to flip it if a maintainer can confirm against a real queue.
2. **No dequeue action.** A queued PR has no in-app way to leave the queue. This was left out deliberately rather than overlooked: the honest fix is a `dequeuePullRequest` mutation, and the previously-shown "Disable auto-merge" was itself dubious — GitHub does not specify whether `gh pr merge --disable-auto` dequeues.
3. **GitLab merge trains are not implemented.** The `queued` state is written provider-neutral so merge trains can adopt it later with no type change, but GitLab exposes no ETA field and needs GraphQL for position, so it is a separate piece of work.
4. **`mobile/` was verified by reading, not by `tsc --noEmit`** — `mobile/node_modules` was not installed in my working tree. Mobile reads the wire directly and never derives `queued`, so it renders a queued PR as Open: the wire design degrading exactly as intended.

## Agent skill upstream boundary

- [x] Not applicable — this change touches no skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [ ] Before/after screenshots or videos attached for UI changes — see Visual Proof: no populated merge queue was available to capture against; rendered copy is pinned by unit tests instead
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered — remote wire compatibility is the central design constraint above
- [x] `pnpm tc`, `oxlint`, and the affected test suites pass locally; `pnpm build` left to CI
