### PR TITLE
fix(relay): survivable mobile pairing recovery + desktop assign rate gate

### DIFF
--- a/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.test.ts
@@ -3,6 +3,7 @@ import type { MobileRelayRpcSession } from './mobile-relay-rpc-session'
 import { MobileE2EEAuthenticationError } from './mobile-e2ee-v2-physical-channel'
 import { RelayOuterError } from './mobile-relay-e2ee-link'
 import { RelayReconnectController } from './mobile-relay-reconnect-controller'
+import { RelayDirectorHttpError } from './mobile-relay-resume-director'
 import type { StableLogicalRpcClient } from './stable-logical-rpc-client'
 
 vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }))
@@ -334,6 +335,41 @@ describe('relay reconnect controller', () => {
     expect(onRetry).toHaveBeenCalledOnce()
     vi.advanceTimersByTime(1)
     expect(onRetry).toHaveBeenCalledTimes(2)
+  })
+
+  it('paces the next dial by the director Retry-After instead of the local backoff', () => {
+    const onRetry = vi.fn()
+    const reconnect = createController(onRetry)
+
+    reconnect.registerFailure(new RelayDirectorHttpError(503, 30_000))
+
+    expect(reconnect.retryDelayMs(0)).toBe(30_000)
+    vi.advanceTimersByTime(29_999)
+    expect(onRetry).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(1)
+    expect(onRetry).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the local backoff when the director sent no Retry-After', () => {
+    const onRetry = vi.fn()
+    const reconnect = createController(onRetry)
+
+    reconnect.registerFailure(new RelayDirectorHttpError(500, null))
+
+    expect(reconnect.retryDelayMs(0)).toBe(250)
+    vi.advanceTimersByTime(250)
+    expect(onRetry).toHaveBeenCalledOnce()
+  })
+
+  it('never lets a short Retry-After shorten an escalated backoff', () => {
+    const reconnect = createController(vi.fn())
+
+    for (let failure = 0; failure < 6; failure++) {
+      reconnect.registerFailure(new RelayOuterError(4429), false)
+    }
+    reconnect.registerFailure(new RelayDirectorHttpError(503, 100), false)
+
+    expect(reconnect.retryDelayMs(0)).toBe(15_000)
   })
 
   it('uses grace only when the outer relay credential was rejected', () => {

--- a/mobile/src/transport/mobile-relay-reconnect-controller.ts
+++ b/mobile/src/transport/mobile-relay-reconnect-controller.ts
@@ -7,6 +7,7 @@ import type { MobileRelayRpcSession } from './mobile-relay-rpc-session'
 import { MobileE2EEAuthenticationError } from './mobile-e2ee-v2-physical-channel'
 import { RelayOuterError } from './mobile-relay-e2ee-link'
 import { RELAY_STABLE_CONNECTION_MS, RelayRetryDelays } from './mobile-relay-retry-delays'
+import { relayDirectorRetryAfterMs } from './mobile-relay-resume-director'
 import { RelayCredentialEligibility } from './relay-credential-eligibility'
 import { RelayPairingRejectionLatch } from './relay-pairing-rejection-latch'
 import { RelayRecoveryFailureCount } from './relay-recovery-failure-count'
@@ -246,10 +247,9 @@ export class RelayReconnectController {
     // replacement dial is not revocation — banking it would fire a false re-pair alarm
     // the moment that healthy session drops for an unrelated transport error.
     this.pairingRejection.record(this.activeSession ? null : error)
-    const code = error instanceof RelayOuterError ? error.code : null
     const recovery =
-      code != null && isMobileRelayCloseCode(code)
-        ? mobileRelayRecoveryFor(code, 'phone-resume')
+      error instanceof RelayOuterError && isMobileRelayCloseCode(error.code)
+        ? mobileRelayRecoveryFor(error.code, 'phone-resume')
         : null
     if (
       this.recoveryGate === 'fresh-credential' ||
@@ -264,10 +264,12 @@ export class RelayReconnectController {
     const failureCount = this.failureCount.recordAfterConnection(this.activeRelayConnectedAt, now)
     // Why: only a stable authenticated Relay resets the failure streak.
     this.activeRelayConnectedAt = null
+    // Why: a director Retry-After is the server pacing a bounded overload, and it
+    // only reaches this branch — a director HTTP error carries no relay close code.
     const delay =
       recovery?.kind === 'retry-after-host-offline'
         ? this.delays.hostOfflineDelayMs()
-        : this.delays.transportDelayMs(failureCount)
+        : this.delays.transportDelayMs(failureCount, relayDirectorRetryAfterMs(error))
     this.nextAttemptAt = now + delay
     if (error instanceof MobileE2EEAuthenticationError) {
       // Why: an E2EE rejection is usually pairing revocation, but it also fires

--- a/mobile/src/transport/mobile-relay-resume-director.test.ts
+++ b/mobile/src/transport/mobile-relay-resume-director.test.ts
@@ -86,6 +86,10 @@ describe('mobile relay resume director', () => {
       retryAfterMs: 120_000
     })
     // A past date or unparseable header leaves the local backoff in charge.
+    const pastDate = new Date(Date.now() - 10 * 60_000).toUTCString()
+    await expect(resolveWith({ 'retry-after': pastDate })).rejects.toMatchObject({
+      retryAfterMs: null
+    })
     await expect(resolveWith({ 'retry-after': 'soon-ish' })).rejects.toMatchObject({
       retryAfterMs: null
     })

--- a/mobile/src/transport/mobile-relay-resume-director.test.ts
+++ b/mobile/src/transport/mobile-relay-resume-director.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { resolveMobileRelayEndpoint } from './mobile-relay-resume-director'
+import { RelayDirectorHttpError, resolveMobileRelayEndpoint } from './mobile-relay-resume-director'
 
 const relay = {
   v: 1 as const,
@@ -62,5 +62,37 @@ describe('mobile relay resume director', () => {
     await expect(
       resolveMobileRelayEndpoint({ relay, resumeToken: 'A'.repeat(43), fetchImpl: oversized })
     ).rejects.toThrow(/too large/)
+  })
+
+  it('carries the bounded-overload Retry-After off a rejected resolve', async () => {
+    const resolveWith = (headers: Record<string, string>) =>
+      resolveMobileRelayEndpoint({
+        relay,
+        resumeToken: 'A'.repeat(43),
+        fetchImpl: vi.fn(async () => new Response(null, { status: 503, headers }))
+      })
+
+    await expect(resolveWith({ 'retry-after': '30' })).rejects.toMatchObject({
+      status: 503,
+      retryAfterMs: 30_000,
+      message: 'relay director resolve failed (503)'
+    })
+    // An HTTP-date form resolves against the clock, and both forms clamp.
+    const httpDate = new Date(Date.now() + 10 * 60_000).toUTCString()
+    await expect(resolveWith({ 'retry-after': httpDate })).rejects.toMatchObject({
+      retryAfterMs: 120_000
+    })
+    await expect(resolveWith({ 'retry-after': '999999' })).rejects.toMatchObject({
+      retryAfterMs: 120_000
+    })
+    // A past date or unparseable header leaves the local backoff in charge.
+    await expect(resolveWith({ 'retry-after': 'soon-ish' })).rejects.toMatchObject({
+      retryAfterMs: null
+    })
+    await expect(resolveWith({})).rejects.toMatchObject({
+      status: 503,
+      retryAfterMs: null
+    })
+    await expect(resolveWith({})).rejects.toBeInstanceOf(RelayDirectorHttpError)
   })
 })

--- a/mobile/src/transport/mobile-relay-resume-director.ts
+++ b/mobile/src/transport/mobile-relay-resume-director.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
 import { parseRelayRetryAfterMs } from '../../../src/shared/relay-retry-after-header'
-import { RELAY_RETRY_AFTER_MAX_MS } from './mobile-relay-retry-delays'
+import { MOBILE_RELAY_RETRY_AFTER_MAX_MS } from './mobile-relay-retry-delays'
 import type { MobileRelayEndpoint } from '../../../src/shared/mobile-relay-credential-contract'
 
 const MAX_RESPONSE_BYTES = 16 * 1024
@@ -55,7 +55,7 @@ export async function resolveMobileRelayEndpoint(args: {
     if (!response.ok) {
       throw new RelayDirectorHttpError(
         response.status,
-        parseRelayRetryAfterMs(response.headers.get('retry-after'), RELAY_RETRY_AFTER_MAX_MS)
+        parseRelayRetryAfterMs(response.headers.get('retry-after'), MOBILE_RELAY_RETRY_AFTER_MAX_MS)
       )
     }
     const declaredLength = Number(response.headers.get('content-length') ?? 0)

--- a/mobile/src/transport/mobile-relay-resume-director.ts
+++ b/mobile/src/transport/mobile-relay-resume-director.ts
@@ -1,7 +1,28 @@
 import { z } from 'zod'
+import { parseRelayRetryAfterMs } from '../../../src/shared/relay-retry-after-header'
+import { RELAY_RETRY_AFTER_MAX_MS } from './mobile-relay-retry-delays'
 import type { MobileRelayEndpoint } from '../../../src/shared/mobile-relay-credential-contract'
 
 const MAX_RESPONSE_BYTES = 16 * 1024
+
+// Carries the director's own pacing so the reconnect cooldown can honor a
+// bounded-overload 503 instead of re-dialing on the local backoff.
+export class RelayDirectorHttpError extends Error {
+  readonly name = 'RelayDirectorHttpError'
+
+  constructor(
+    readonly status: number,
+    readonly retryAfterMs: number | null
+  ) {
+    super(`relay director resolve failed (${status})`)
+  }
+}
+
+// 0 when the director asked for nothing, so it only ever floors a local backoff.
+export function relayDirectorRetryAfterMs(error: Error | null): number {
+  return error instanceof RelayDirectorHttpError ? (error.retryAfterMs ?? 0) : 0
+}
+
 const ResolveResponseSchema = z
   .object({
     v: z.literal(1),
@@ -32,7 +53,10 @@ export async function resolveMobileRelayEndpoint(args: {
       signal: controller.signal
     })
     if (!response.ok) {
-      throw new Error(`relay director resolve failed (${response.status})`)
+      throw new RelayDirectorHttpError(
+        response.status,
+        parseRelayRetryAfterMs(response.headers.get('retry-after'), RELAY_RETRY_AFTER_MAX_MS)
+      )
     }
     const declaredLength = Number(response.headers.get('content-length') ?? 0)
     if (declaredLength > MAX_RESPONSE_BYTES) {

--- a/mobile/src/transport/mobile-relay-retry-delays.ts
+++ b/mobile/src/transport/mobile-relay-retry-delays.ts
@@ -12,17 +12,21 @@ const RELAY_HOST_OFFLINE_RETRY_MAX_MS = 15_000
 // forever one-minute beacon and a fleet-wide gating event cannot phase-align.
 const RELAY_GATE_REPROBE_BASE_MS = 60_000
 const RELAY_GATE_REPROBE_CEILING_MS = 15 * 60_000
+// A director Retry-After only ever floors a delay, so cap what one header can
+// park the phone for; anything longer is the gated reprobe cadence's job.
+export const RELAY_RETRY_AFTER_MAX_MS = 120_000
 
 // Every relay retry delay in one place: transport backoff, known-offline
 // polling, and the escalating gated reprobe cadence, all jittered.
 export class RelayRetryDelays {
   constructor(private readonly randomBytes: (length: number) => Uint8Array) {}
 
-  transportDelayMs(consecutiveFailures: number): number {
+  // floorMs: a server-supplied Retry-After, which paces the dial out but never in.
+  transportDelayMs(consecutiveFailures: number, floorMs = 0): number {
     const exponent = Math.max(0, consecutiveFailures - 1)
     const cap = Math.min(RELAY_BACKOFF_CEILING_MS, RELAY_BACKOFF_BASE_MS * 2 ** exponent)
     // Full jitter (uniform in [0, cap)), floored so retries never busy-loop.
-    return Math.max(RELAY_BACKOFF_MIN_MS, Math.floor(cap * this.jitterFraction()))
+    return Math.max(RELAY_BACKOFF_MIN_MS, floorMs, Math.floor(cap * this.jitterFraction()))
   }
 
   hostOfflineDelayMs(): number {

--- a/mobile/src/transport/mobile-relay-retry-delays.ts
+++ b/mobile/src/transport/mobile-relay-retry-delays.ts
@@ -14,7 +14,7 @@ const RELAY_GATE_REPROBE_BASE_MS = 60_000
 const RELAY_GATE_REPROBE_CEILING_MS = 15 * 60_000
 // A director Retry-After only ever floors a delay, so cap what one header can
 // park the phone for; anything longer is the gated reprobe cadence's job.
-export const RELAY_RETRY_AFTER_MAX_MS = 120_000
+export const MOBILE_RELAY_RETRY_AFTER_MAX_MS = 120_000
 
 // Every relay retry delay in one place: transport backoff, known-offline
 // polling, and the escalating gated reprobe cadence, all jittered.

--- a/mobile/src/transport/pairing-candidate-race.ts
+++ b/mobile/src/transport/pairing-candidate-race.ts
@@ -1,7 +1,9 @@
 import type { PairingCandidateClient } from './mobile-relay-physical-client'
 
+export type PairingCandidatePath = 'direct' | 'relay'
+
 export type PairingCandidate = {
-  path: 'direct' | 'relay'
+  path: PairingCandidatePath
   client: PairingCandidateClient
 }
 

--- a/mobile/src/transport/pairing-log-path.test.ts
+++ b/mobile/src/transport/pairing-log-path.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { attributePairingLogPath } from './pairing-log-path'
+import type { ConnectionLogEntry } from './types'
+
+const entry: ConnectionLogEntry = {
+  id: 'log-1',
+  ts: 1,
+  level: 'warn',
+  message: 'Reconnecting (attempt 2)',
+  detail: '10.5.0.2:6768'
+}
+
+describe('attributePairingLogPath', () => {
+  it('prefixes unlabelled lines with their pairing path', () => {
+    const entries: ConnectionLogEntry[] = []
+    attributePairingLogPath('direct', (value) => entries.push(value))!(entry)
+
+    expect(entries).toEqual([{ ...entry, message: 'Direct: Reconnecting (attempt 2)' }])
+  })
+
+  it('leaves a line that already names its path unchanged', () => {
+    const entries: ConnectionLogEntry[] = []
+    const relayEntry = { ...entry, message: 'Relay: cell dial failed' }
+    attributePairingLogPath('relay', (value) => entries.push(value))!(relayEntry)
+
+    expect(entries).toEqual([relayEntry])
+  })
+
+  it('labels relay lines that forgot their own prefix', () => {
+    const entries: ConnectionLogEntry[] = []
+    attributePairingLogPath('relay', (value) => entries.push(value))!(entry)
+
+    expect(entries[0]!.message).toBe('Relay: Reconnecting (attempt 2)')
+  })
+
+  it('stays undefined when there is no sink to attribute to', () => {
+    expect(attributePairingLogPath('direct', undefined)).toBeUndefined()
+  })
+})

--- a/mobile/src/transport/pairing-log-path.ts
+++ b/mobile/src/transport/pairing-log-path.ts
@@ -1,0 +1,27 @@
+import type { PairingCandidatePath } from './pairing-candidate-race'
+import type { ConnectionLogSink } from './types'
+
+const PATH_PREFIX: Record<PairingCandidatePath, string> = {
+  direct: 'Direct: ',
+  relay: 'Relay: '
+}
+
+// Why: the direct and relay candidates race into one pairing log, and only the
+// relay call sites prefixed themselves — so unlabelled direct lines
+// ("Reconnecting (attempt 2)", detail 10.5.0.2:6768) read as the relay
+// retrying a LAN address. Attributing at the candidate seam covers every line
+// each path emits, including ones whose call site forgets to say which it is.
+export function attributePairingLogPath(
+  path: PairingCandidatePath,
+  onLog: ConnectionLogSink | undefined
+): ConnectionLogSink | undefined {
+  if (!onLog) {
+    return undefined
+  }
+  const prefix = PATH_PREFIX[path]
+  return (entry) => {
+    onLog(
+      entry.message.startsWith(prefix) ? entry : { ...entry, message: `${prefix}${entry.message}` }
+    )
+  }
+}

--- a/mobile/src/transport/pairing-relay-candidate.test.ts
+++ b/mobile/src/transport/pairing-relay-candidate.test.ts
@@ -230,18 +230,23 @@ describe('recovering pairing relay candidate', () => {
   it('keeps a cell load refusal out of director recovery', async () => {
     const limited = client(Promise.reject(new RelayOuterError(4429)))
     const resolveDirector = vi.fn()
+    let connects = 0
     const candidate = createRecoveringPairingRelayCandidate({
       journal,
-      connect: () => limited,
+      connect: () => {
+        connects++
+        return limited
+      },
       resolveDirector,
       persistMove: vi.fn(),
       now: () => 1
     })
 
-    // Why: every cell dial burns an invite attempt server-side; a director hop
-    // cannot relieve cell load, so 4429 must fail fast instead of retrying.
+    // Why: 4429 is rejected after the cell reserves the invite credential, so a
+    // retry burns an attempt — and a director hop cannot relieve cell load.
     await expect(candidate.sendRequest('status.get')).rejects.toEqual(new RelayOuterError(4429))
     expect(resolveDirector).not.toHaveBeenCalled()
+    expect(connects).toBe(1)
   })
 
   it('does not ask the director to reinterpret endpoint-scoped host-offline', async () => {

--- a/mobile/src/transport/pairing-relay-candidate.test.ts
+++ b/mobile/src/transport/pairing-relay-candidate.test.ts
@@ -164,12 +164,46 @@ describe('recovering pairing relay candidate', () => {
     )
   })
 
-  it('does not retry a same-epoch move to a different cell', async () => {
+  it('retries the stored assignment when the director reports a non-newer different cell', async () => {
     const stale = client(Promise.reject(new RelayOuterError(1006)))
+    const target = client(Promise.resolve(success()))
+    const persistMove = vi.fn()
+    const sleep = vi.fn(async () => {})
     const resolveDirector = vi.fn(async (relay) => {
       throw new RelayDirectorMoveNotNewerError({
         cellUrl: 'https://relay-c2.onorca.dev',
         assignmentEpoch: relay.assignmentEpoch,
+        currentCellUrl: relay.cellUrl,
+        currentAssignmentEpoch: relay.assignmentEpoch
+      })
+    })
+    let connects = 0
+    const candidate = createRecoveringPairingRelayCandidate({
+      journal,
+      connect: (relay) => {
+        expect(relay.cellUrl).toBe(journal.metadata.relay.cellUrl)
+        return connects++ === 0 ? stale : target
+      },
+      resolveDirector,
+      persistMove,
+      now: () => 1,
+      random: () => 0,
+      sleep
+    })
+
+    await expect(candidate.sendRequest('status.get')).resolves.toEqual(success())
+    expect(resolveDirector).toHaveBeenCalledOnce()
+    // Why: the non-newer move must never be adopted — the stored cell is redialed.
+    expect(persistMove).not.toHaveBeenCalled()
+    expect(sleep).toHaveBeenCalledWith(250)
+  })
+
+  it('gives up with the dial error once same-assignment retries exhaust the budget', async () => {
+    const stale = client(Promise.reject(new RelayOuterError(1006)))
+    const resolveDirector = vi.fn(async (relay) => {
+      throw new RelayDirectorMoveNotNewerError({
+        cellUrl: 'https://relay-c2.onorca.dev',
+        assignmentEpoch: relay.assignmentEpoch - 1,
         currentCellUrl: relay.cellUrl,
         currentAssignmentEpoch: relay.assignmentEpoch
       })
@@ -188,9 +222,26 @@ describe('recovering pairing relay candidate', () => {
       sleep: async () => {}
     })
 
-    await expect(candidate.sendRequest('status.get')).rejects.toThrow(/not strictly newer/)
+    await expect(candidate.sendRequest('status.get')).rejects.toEqual(new RelayOuterError(1006))
     expect(resolveDirector).toHaveBeenCalledTimes(3)
-    expect(connects).toBe(1)
+    expect(connects).toBe(4)
+  })
+
+  it('keeps a cell load refusal out of director recovery', async () => {
+    const limited = client(Promise.reject(new RelayOuterError(4429)))
+    const resolveDirector = vi.fn()
+    const candidate = createRecoveringPairingRelayCandidate({
+      journal,
+      connect: () => limited,
+      resolveDirector,
+      persistMove: vi.fn(),
+      now: () => 1
+    })
+
+    // Why: every cell dial burns an invite attempt server-side; a director hop
+    // cannot relieve cell load, so 4429 must fail fast instead of retrying.
+    await expect(candidate.sendRequest('status.get')).rejects.toEqual(new RelayOuterError(4429))
+    expect(resolveDirector).not.toHaveBeenCalled()
   })
 
   it('does not ask the director to reinterpret endpoint-scoped host-offline', async () => {

--- a/mobile/src/transport/pairing-relay-candidate.ts
+++ b/mobile/src/transport/pairing-relay-candidate.ts
@@ -161,7 +161,10 @@ function isDirectorRecoverable(error: unknown): boolean {
   if (!(error instanceof RelayOuterError)) {
     return true
   }
-  // 4429 stays out: a director hop cannot relieve cell load, and every cell
-  // dial burns an invite attempt toward cooldown/invalidation server-side.
+  // 4429 stays out: the cell rejects it after reserving the invite credential,
+  // so each retry burns an attempt toward cooldown/invalidation — and a
+  // director hop cannot relieve cell load anyway. The retained codes are
+  // rejected before reservation (4409/4503) or never reach the cell (1006),
+  // so their re-dials burn nothing.
   return error.code === 4409 || error.code === 4503 || error.code === 1006
 }

--- a/mobile/src/transport/pairing-relay-candidate.ts
+++ b/mobile/src/transport/pairing-relay-candidate.ts
@@ -96,7 +96,7 @@ export function createRecoveringPairingRelayCandidate(args: {
           // to re-dial it with a real pause, not to abandon the relay path.
           log(
             'info',
-            isCurrentAssignmentMove(error, relay)
+            directorEchoedCurrentAssignment(error, relay)
               ? 'Relay: director kept current assignment'
               : 'Relay: director has no newer assignment',
             redactSocketEndpoint(relay.cellUrl)
@@ -140,7 +140,7 @@ export function createRecoveringPairingRelayCandidate(args: {
 // the near-zero full jitter that would hammer the cell that refused the dial.
 const NOT_NEWER_RETRY_FLOOR_MS = 250
 
-function isCurrentAssignmentMove(error: unknown, relay: PairingRelay): boolean {
+function directorEchoedCurrentAssignment(error: unknown, relay: PairingRelay): boolean {
   return (
     error instanceof RelayDirectorMoveNotNewerError &&
     error.assignmentEpoch === relay.assignmentEpoch &&

--- a/mobile/src/transport/pairing-relay-candidate.ts
+++ b/mobile/src/transport/pairing-relay-candidate.ts
@@ -49,9 +49,9 @@ export function createRecoveringPairingRelayCandidate(args: {
     const random = args.random ?? Math.random
     const sleep =
       args.sleep ?? ((delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs)))
-    const backOff = async (attempt: number): Promise<void> => {
+    const backOff = async (attempt: number, floorMs = 0): Promise<void> => {
       const capMs = Math.min(2_000, 100 * 2 ** attempt)
-      const delayMs = Math.floor(random() * (capMs + 1))
+      const delayMs = Math.max(floorMs, Math.floor(random() * (capMs + 1)))
       if (delayMs > 0) {
         log('info', `Relay: backing off ${delayMs}ms`)
       }
@@ -89,14 +89,20 @@ export function createRecoveringPairingRelayCandidate(args: {
         return await client.sendRequest(method, params)
       } catch (error) {
         lastError = error
-        if (isCurrentAssignmentMove(error, relay)) {
+        if (error instanceof RelayDirectorMoveNotNewerError) {
+          // Why: the director has no "assignment unchanged" verb — a non-newer
+          // move IS that answer. The stored assignment stays authoritative (the
+          // move is never adopted or persisted), so the only correct action is
+          // to re-dial it with a real pause, not to abandon the relay path.
           log(
             'info',
-            'Relay: director kept current assignment',
+            isCurrentAssignmentMove(error, relay)
+              ? 'Relay: director kept current assignment'
+              : 'Relay: director has no newer assignment',
             redactSocketEndpoint(relay.cellUrl)
           )
           client.close()
-          await backOff(attempt)
+          await backOff(attempt, NOT_NEWER_RETRY_FLOOR_MS)
           if (closed) {
             throw new Error('relay pairing client closed')
           }
@@ -130,6 +136,10 @@ export function createRecoveringPairingRelayCandidate(args: {
   }
 }
 
+// Redialing the assignment the director just confirmed needs a real pause, not
+// the near-zero full jitter that would hammer the cell that refused the dial.
+const NOT_NEWER_RETRY_FLOOR_MS = 250
+
 function isCurrentAssignmentMove(error: unknown, relay: PairingRelay): boolean {
   return (
     error instanceof RelayDirectorMoveNotNewerError &&
@@ -151,5 +161,7 @@ function isDirectorRecoverable(error: unknown): boolean {
   if (!(error instanceof RelayOuterError)) {
     return true
   }
+  // 4429 stays out: a director hop cannot relieve cell load, and every cell
+  // dial burns an invite attempt toward cooldown/invalidation server-side.
   return error.code === 4409 || error.code === 4503 || error.code === 1006
 }

--- a/mobile/src/transport/pre-profile-pairing-coordinator.test.ts
+++ b/mobile/src/transport/pre-profile-pairing-coordinator.test.ts
@@ -4,7 +4,7 @@ import type { MobileRelayPairingJournal } from './mobile-relay-pairing-journal'
 import { racePairingCandidates } from './pairing-candidate-race'
 import { startPreProfilePairing } from './pre-profile-pairing-coordinator'
 import type { ConnectionLogEntry, HostProfile, PairingOffer, RpcResponse } from './types'
-import type { RpcClient } from './rpc-client'
+import type { connect, RpcClient } from './rpc-client'
 
 vi.mock('react-native', () => ({ Platform: { OS: 'ios' } }))
 vi.mock('expo-crypto', () => ({
@@ -97,7 +97,9 @@ function dependencies(client: RpcClient, events: string[]) {
     new Error('relay unavailable')
   )
   return {
-    connectDirect: vi.fn(() => (events.push('connect'), client)),
+    connectDirect: vi.fn(
+      (..._args: Parameters<typeof connect>) => (events.push('connect'), client)
+    ),
     connectRelay: vi.fn(() => unavailableRelay),
     resolveInviteDirector: vi.fn(async () => {
       throw new Error('director unavailable')
@@ -380,6 +382,62 @@ describe('pre-profile pairing coordinator', () => {
     ])
     expect(entries[0]!.detail).toBe('relay-c1.onorca.dev')
     expect(entries[2]).toMatchObject({ level: 'success', detail: 'winner: relay' })
+  })
+
+  it('attributes each racing candidate so direct retries cannot read as relay', async () => {
+    const entries: ConnectionLogEntry[] = []
+    const direct = fakeClient([])
+    ;(direct.sendRequest as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('LAN down'))
+    let journal: MobileRelayPairingJournal | null = null
+    const relay = relayProvisioningClient(() => journal!)
+    const deps = dependencies(direct, [])
+    deps.saveJournal.mockImplementation(async (value) => {
+      journal = value
+    })
+    // Why: the reconnect lines the direct client emits carry the LAN address
+    // and no path label — the exact shape that was misread as relay retrying.
+    deps.connectDirect.mockImplementation((...args) => {
+      const options = args[3]
+      if (options && typeof options !== 'function') {
+        options.onLog?.({
+          id: 'direct-reconnect',
+          ts: now,
+          level: 'warn',
+          message: 'Reconnecting (attempt 2)',
+          detail: '10.5.0.2:6768'
+        })
+      }
+      return direct
+    })
+    deps.connectRelay.mockImplementation((connectArgs) => {
+      connectArgs.onLog?.({
+        id: 'relay-dial',
+        ts: now,
+        level: 'info',
+        message: 'Relay: dialing cell',
+        detail: 'relay-c1.onorca.dev'
+      })
+      connectArgs.onLog?.({ id: 'relay-open', ts: now, level: 'info', message: 'Cell socket open' })
+      return relay
+    })
+
+    const attempt = startPreProfilePairing({
+      offer: relayOffer,
+      timeoutMs: 5_000,
+      connectOptions: { onLog: (entry) => entries.push(entry) },
+      dependencies: deps
+    })
+    await expect(attempt.result).resolves.toEqual({ hostId: `host-${now}` })
+
+    expect(entries.map((entry) => entry.message)).toEqual([
+      'Direct: Reconnecting (attempt 2)',
+      'Relay: pairing candidate started',
+      // Already self-labelled: attribution must not stutter into 'Relay: Relay:'.
+      'Relay: dialing cell',
+      'Relay: Cell socket open',
+      'Pairing path selected'
+    ])
+    expect(entries[0]).toMatchObject({ level: 'warn', detail: '10.5.0.2:6768' })
   })
 
   it('cancels the disposable physical client without publishing a host', async () => {

--- a/mobile/src/transport/pre-profile-pairing-coordinator.ts
+++ b/mobile/src/transport/pre-profile-pairing-coordinator.ts
@@ -26,6 +26,7 @@ import {
   type PairingCandidateClient
 } from './mobile-relay-physical-client'
 import { racePairingCandidates, type PairingCandidate } from './pairing-candidate-race'
+import { attributePairingLogPath } from './pairing-log-path'
 import { resolvePairingInviteThroughDirector } from './mobile-relay-invite-director'
 import { createRecoveringPairingRelayCandidate } from './pairing-relay-candidate'
 import { createPairingRelayLogger } from './pairing-relay-log'
@@ -155,7 +156,7 @@ async function runPairing(
     offer.endpoint,
     offer.deviceToken,
     offer.publicKeyB64,
-    connectOptions
+    { ...connectOptions, onLog: attributePairingLogPath('direct', connectOptions?.onLog) }
   )
   clients.add(directClient)
   const candidates: PairingCandidate[] = [{ path: 'direct', client: directClient }]
@@ -191,7 +192,7 @@ async function runPairing(
         await dependencies.updateJournal(journal.metadata.journalId, () => journal!.metadata)
       },
       now: dependencies.now,
-      onLog: connectOptions?.onLog
+      onLog: attributePairingLogPath('relay', connectOptions?.onLog)
     })
     clients.add(relayClient)
     candidates.push({ path: 'relay', client: relayClient })

--- a/src/main/runtime/relay/relay-assign-rate-gate.ts
+++ b/src/main/runtime/relay/relay-assign-rate-gate.ts
@@ -4,10 +4,23 @@
 // The gate lives below all of them, at the single call site that issues assigns.
 const ASSIGN_MIN_INTERVAL_MS = 5_000
 const ASSIGN_INTERVAL_JITTER_MS = 500
+// Sleep in slices so a raise landing mid-wait is honored and a superseded
+// caller aborts promptly instead of holding its IPC path for the full wait.
+const ASSIGN_WAIT_SLICE_MS = 1_000
+// Beyond this, fail fast with the remaining wait instead of parking the caller
+// (pairing IPC awaits reconcile inline): a Retry-After can legitimately reach
+// minutes, and the gate keeps the deadline for the scheduled retry.
+const ASSIGN_MAX_INLINE_WAIT_MS = 15_000
 
 export class RelayAssignAbortedError extends Error {
   constructor() {
     super('relay_assignment_aborted_stale')
+  }
+}
+
+export class RelayAssignRateLimitedError extends Error {
+  constructor(readonly retryAfterMs: number) {
+    super('relay_assignment_rate_limited_locally')
   }
 }
 
@@ -53,13 +66,23 @@ export class RelayAssignRateGate {
     let stale = false
     try {
       await prior
-      const waitMs = (this.nextPermittedAt.get(key) ?? 0) - this.now()
-      if (waitMs > 0) {
-        await this.sleep(waitMs)
+      // Re-read the deadline every slice: a sibling's Retry-After can raise it
+      // mid-wait, and a caller superseded mid-wait must not spend the slot.
+      for (;;) {
+        stale = isCurrent ? !isCurrent() : false
+        if (stale) {
+          break
+        }
+        const waitMs = (this.nextPermittedAt.get(key) ?? 0) - this.now()
+        if (waitMs <= 0) {
+          break
+        }
+        if (waitMs > ASSIGN_MAX_INLINE_WAIT_MS) {
+          this.pruneExpired()
+          throw new RelayAssignRateLimitedError(waitMs)
+        }
+        await this.sleep(Math.min(waitMs, ASSIGN_WAIT_SLICE_MS))
       }
-      // The wait widened the window between the caller's intent and the request;
-      // a superseded caller must not spend the host's slot.
-      stale = isCurrent ? !isCurrent() : false
       if (!stale) {
         this.book(key)
       }

--- a/src/main/runtime/relay/relay-assign-rate-gate.ts
+++ b/src/main/runtime/relay/relay-assign-rate-gate.ts
@@ -26,6 +26,8 @@ export class RelayAssignRateLimitedError extends Error {
 
 export type RelayAssignRateGateOptions = {
   now?: () => number
+  // Test fakes MUST advance `now` when sleeping — the wait loop re-reads the
+  // clock each slice, so a no-op sleep against a frozen clock never terminates.
   sleep?: (ms: number) => Promise<void>
   random?: () => number
 }

--- a/src/main/runtime/relay/relay-assign-rate-gate.ts
+++ b/src/main/runtime/relay/relay-assign-rate-gate.ts
@@ -1,0 +1,109 @@
+// Why: the director rate-limits /v1/assign per host at 5s, but every desktop
+// retry path (coordinator full-jitter, drain full-jitter, reconcile() cancelling
+// the Retry-After timer) can fire immediately, so hosts sit permanently limited.
+// The gate lives below all of them, at the single call site that issues assigns.
+const ASSIGN_MIN_INTERVAL_MS = 5_000
+const ASSIGN_INTERVAL_JITTER_MS = 500
+
+export class RelayAssignAbortedError extends Error {
+  constructor() {
+    super('relay_assignment_aborted_stale')
+  }
+}
+
+export type RelayAssignRateGateOptions = {
+  now?: () => number
+  sleep?: (ms: number) => Promise<void>
+  random?: () => number
+}
+
+export function relayAssignRateKey(directorUrl: string, relayHostId: string): string {
+  return `${directorUrl} ${relayHostId}`
+}
+
+export class RelayAssignRateGate {
+  private readonly now: () => number
+  private readonly sleep: (ms: number) => Promise<void>
+  private readonly random: () => number
+  private readonly nextPermittedAt = new Map<string, number>()
+  // Per-key promise chain: concurrent callers queue behind each other's booking
+  // instead of stampeding out of one shared sleep.
+  private readonly tails = new Map<string, Promise<void>>()
+
+  constructor(options: RelayAssignRateGateOptions = {}) {
+    this.now = options.now ?? Date.now
+    this.sleep = options.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)))
+    this.random = options.random ?? Math.random
+  }
+
+  get trackedKeyCount(): number {
+    return this.nextPermittedAt.size
+  }
+
+  // Waits out the remaining interval for this host, then books the next slot.
+  // Resolves only when the caller may send; throws if isCurrent went false while waiting.
+  async reserve(key: string, isCurrent?: () => boolean): Promise<void> {
+    const prior = this.tails.get(key)
+    let release = (): void => {}
+    const link = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const tail = prior ? prior.then(() => link) : link
+    this.tails.set(key, tail)
+    let stale = false
+    try {
+      await prior
+      const waitMs = (this.nextPermittedAt.get(key) ?? 0) - this.now()
+      if (waitMs > 0) {
+        await this.sleep(waitMs)
+      }
+      // The wait widened the window between the caller's intent and the request;
+      // a superseded caller must not spend the host's slot.
+      stale = isCurrent ? !isCurrent() : false
+      if (!stale) {
+        this.book(key)
+      }
+      this.pruneExpired()
+    } finally {
+      release()
+      if (this.tails.get(key) === tail) {
+        this.tails.delete(key)
+      }
+    }
+    if (stale) {
+      throw new RelayAssignAbortedError()
+    }
+  }
+
+  // Retry-After outlives the coordinator's armed timer, which reconcile() cancels.
+  noteRetryAfter(key: string, retryAfterMs: number): void {
+    if (retryAfterMs <= 0) {
+      return
+    }
+    const until = this.now() + retryAfterMs
+    if (until > (this.nextPermittedAt.get(key) ?? 0)) {
+      this.nextPermittedAt.set(key, until)
+    }
+  }
+
+  private book(key: string): void {
+    const until =
+      this.now() + ASSIGN_MIN_INTERVAL_MS + Math.floor(this.random() * ASSIGN_INTERVAL_JITTER_MS)
+    if (until > (this.nextPermittedAt.get(key) ?? 0)) {
+      this.nextPermittedAt.set(key, until)
+    }
+  }
+
+  private pruneExpired(): void {
+    const now = this.now()
+    for (const [key, until] of this.nextPermittedAt) {
+      if (until <= now) {
+        this.nextPermittedAt.delete(key)
+      }
+    }
+  }
+}
+
+// Shared so every assign path — coordinator, drain recovery, any reconcile()
+// bypass — books against the same per-host interval.
+export const sharedRelayAssignRateGate = new RelayAssignRateGate()

--- a/src/main/runtime/relay/relay-http-client.test.ts
+++ b/src/main/runtime/relay/relay-http-client.test.ts
@@ -450,6 +450,42 @@ describe('relay assignment rate gate', () => {
     expect(clock.sleeps).toEqual([])
   })
 
+  it('aborts before sending when the caller is superseded after reservation', async () => {
+    const clock = fakeAssignClock()
+    const assignRateGate = new RelayAssignRateGate(clock.options)
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => assignSuccessResponse())
+    // First reads happen inside reserve(); the last read guards the send.
+    const currency = [true, false]
+
+    await expect(
+      request({ fetch, assignRateGate, isCurrent: () => currency.shift() ?? false })
+    ).rejects.toBeInstanceOf(RelayAssignAbortedError)
+
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it('stops field-fallback retries when the caller is superseded mid-attempt', async () => {
+    const clock = fakeAssignClock()
+    const assignRateGate = new RelayAssignRateGate(clock.options)
+    let current = true
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => {
+      current = false
+      return Response.json({ error: 'invalid_request' }, { status: 400 })
+    })
+
+    await expect(
+      request({
+        fetch,
+        assignRateGate,
+        reconnect: true,
+        preferredRegion: 'asia-east2',
+        isCurrent: () => current
+      })
+    ).rejects.toBeInstanceOf(RelayAssignAbortedError)
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
   it('aborts without assigning when the caller is superseded during the wait', async () => {
     let current = true
     const clock = fakeAssignClock(() => {

--- a/src/main/runtime/relay/relay-http-client.test.ts
+++ b/src/main/runtime/relay/relay-http-client.test.ts
@@ -1,9 +1,49 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import nacl from 'tweetnacl'
 import { cancelTrackingResponse } from '../../lib/unread-response-body.test-fixtures'
+import { RelayAssignAbortedError, RelayAssignRateGate } from './relay-assign-rate-gate'
 import { exchangeRelayAuthorization, requestRelayAssignment } from './relay-http-client'
 
+type AssignInput = Parameters<typeof requestRelayAssignment>[0]
+
+function assignSuccessResponse(): Response {
+  return Response.json({
+    v: 1,
+    cellUrl: 'https://relay-c1.example',
+    assignmentEpoch: 4,
+    lease: 'lease-jwt'
+  })
+}
+
+// Advances only when the gate sleeps, so a wait is observable as an exact duration.
+function fakeAssignClock(onSleep?: () => void) {
+  let now = 1_000_000
+  const sleeps: number[] = []
+  return {
+    sleeps,
+    advance: (ms: number): void => {
+      now += ms
+    },
+    options: {
+      now: () => now,
+      random: () => 0,
+      sleep: async (ms: number): Promise<void> => {
+        sleeps.push(ms)
+        now += ms
+        onSleep?.()
+      }
+    }
+  }
+}
+
 describe('relay HTTP client', () => {
+  let gate = new RelayAssignRateGate()
+  beforeEach(() => {
+    gate = new RelayAssignRateGate()
+  })
+  const assign = (input: Omit<AssignInput, 'assignRateGate'>) =>
+    requestRelayAssignment({ ...input, assignRateGate: gate })
+
   it('exchanges only the ordinary bearer for a host-bound relay token', async () => {
     const keypair = nacl.box.keyPair()
     const fetch = vi.fn<typeof globalThis.fetch>(async () =>
@@ -42,7 +82,7 @@ describe('relay HTTP client', () => {
       })
     )
     await expect(
-      requestRelayAssignment({
+      assign({
         directorUrl: 'https://relay.example',
         relayToken: 'scoped-token',
         relayHostId: 'AbCdEf0123_-xyZ9',
@@ -66,7 +106,7 @@ describe('relay HTTP client', () => {
       })
     )
     await expect(
-      requestRelayAssignment({
+      assign({
         directorUrl: 'https://relay.example',
         relayToken: 'scoped-token',
         relayHostId: 'AbCdEf0123_-xyZ9',
@@ -95,7 +135,7 @@ describe('relay HTTP client', () => {
       )
 
     await expect(
-      requestRelayAssignment({
+      assign({
         directorUrl: 'https://relay.example',
         relayToken: 'scoped-token',
         relayHostId: 'AbCdEf0123_-xyZ9',
@@ -130,7 +170,7 @@ describe('relay HTTP client', () => {
         })
       )
     await expect(
-      requestRelayAssignment({
+      assign({
         directorUrl: 'https://relay.example',
         relayToken: 'scoped-token',
         relayHostId: 'AbCdEf0123_-xyZ9',
@@ -154,7 +194,7 @@ describe('relay HTTP client', () => {
     )
 
     await expect(
-      requestRelayAssignment({
+      assign({
         directorUrl: 'https://relay.example',
         relayToken: 'scoped-token',
         relayHostId: 'AbCdEf0123_-xyZ9',
@@ -197,7 +237,7 @@ describe('relay HTTP client', () => {
       })
     )
     await expect(
-      requestRelayAssignment({
+      assign({
         directorUrl: 'https://relay.example',
         relayToken: 'scoped-token',
         relayHostId: 'AbCdEf0123_-xyZ9',
@@ -227,7 +267,7 @@ describe('relay HTTP client', () => {
       })
     ).rejects.toThrow()
     await expect(
-      requestRelayAssignment({
+      assign({
         directorUrl: 'https://relay.example',
         relayToken: 'scoped-token',
         relayHostId: 'AbCdEf0123_-xyZ9',
@@ -243,7 +283,7 @@ describe('relay HTTP client', () => {
     )
 
     await expect(
-      requestRelayAssignment({
+      assign({
         directorUrl: 'https://relay.example',
         relayToken: 'scoped-token',
         relayHostId: 'AbCdEf0123_-xyZ9',
@@ -262,12 +302,128 @@ describe('relay HTTP client', () => {
     )
 
     await expect(
-      requestRelayAssignment({
+      assign({
         directorUrl: 'https://relay.example',
         relayToken: 'scoped-token',
         relayHostId: 'AbCdEf0123_-xyZ9',
         fetch
       })
     ).rejects.toMatchObject({ retryAfterMs: 5 * 60_000 })
+  })
+})
+
+describe('relay assignment rate gate', () => {
+  const request = (
+    input: Partial<AssignInput> & Pick<AssignInput, 'fetch' | 'assignRateGate'>
+  ): Promise<unknown> =>
+    requestRelayAssignment({
+      directorUrl: 'https://relay.example',
+      relayToken: 'scoped-token',
+      relayHostId: 'AbCdEf0123_-xyZ9',
+      ...input
+    })
+
+  it('holds a second assignment for the same host to the director interval', async () => {
+    const clock = fakeAssignClock()
+    const assignRateGate = new RelayAssignRateGate(clock.options)
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => assignSuccessResponse())
+
+    await request({ fetch, assignRateGate })
+    expect(clock.sleeps).toEqual([])
+    clock.advance(2_000)
+    await request({ fetch, assignRateGate })
+
+    expect(clock.sleeps).toEqual([3_000])
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not hold assignments for a different host or a different director', async () => {
+    const clock = fakeAssignClock()
+    const assignRateGate = new RelayAssignRateGate(clock.options)
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => assignSuccessResponse())
+
+    await request({ fetch, assignRateGate })
+    await request({ fetch, assignRateGate, relayHostId: 'OtherHost01234_x' })
+    await request({ fetch, assignRateGate, directorUrl: 'https://relay-eu.example' })
+
+    expect(clock.sleeps).toEqual([])
+  })
+
+  it('serializes concurrent callers behind one booking instead of stampeding', async () => {
+    const clock = fakeAssignClock()
+    const assignRateGate = new RelayAssignRateGate(clock.options)
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => assignSuccessResponse())
+
+    await Promise.all([
+      request({ fetch, assignRateGate }),
+      request({ fetch, assignRateGate }),
+      request({ fetch, assignRateGate })
+    ])
+
+    expect(clock.sleeps).toEqual([5_000, 5_000])
+  })
+
+  it('keeps a Retry-After hint past the retry timer the coordinator cancels', async () => {
+    const clock = fakeAssignClock()
+    const assignRateGate = new RelayAssignRateGate(clock.options)
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(new Response(null, { status: 429, headers: { 'retry-after': '30' } }))
+      .mockResolvedValueOnce(assignSuccessResponse())
+
+    await expect(request({ fetch, assignRateGate })).rejects.toThrow('relay_assignment_failed_429')
+    // A reconcile() cancels the armed retry timer and resets attempts; only the
+    // gate still remembers what the director asked for.
+    clock.advance(6_000)
+    await request({ fetch, assignRateGate })
+
+    expect(clock.sleeps).toEqual([24_000])
+  })
+
+  it('does not re-wait for the field-fallback retries of one attempt', async () => {
+    const clock = fakeAssignClock()
+    const assignRateGate = new RelayAssignRateGate(clock.options)
+    const fetch = vi
+      .fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(Response.json({ error: 'invalid_request' }, { status: 400 }))
+      .mockResolvedValueOnce(Response.json({ error: 'invalid_request' }, { status: 400 }))
+      .mockResolvedValueOnce(assignSuccessResponse())
+
+    await request({ fetch, assignRateGate, reconnect: true, preferredRegion: 'asia-east2' })
+
+    expect(fetch).toHaveBeenCalledTimes(3)
+    expect(clock.sleeps).toEqual([])
+  })
+
+  it('aborts without assigning when the caller is superseded during the wait', async () => {
+    let current = true
+    const clock = fakeAssignClock(() => {
+      current = false
+    })
+    const assignRateGate = new RelayAssignRateGate(clock.options)
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => assignSuccessResponse())
+
+    await request({ fetch, assignRateGate })
+    await expect(
+      request({ fetch, assignRateGate, isCurrent: () => current })
+    ).rejects.toBeInstanceOf(RelayAssignAbortedError)
+
+    expect(clock.sleeps).toEqual([5_000])
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('prunes hosts whose interval has elapsed so the map stays bounded', async () => {
+    const clock = fakeAssignClock()
+    const assignRateGate = new RelayAssignRateGate(clock.options)
+
+    await assignRateGate.reserve('https://relay.example host-a')
+    await assignRateGate.reserve('https://relay.example host-b')
+    await assignRateGate.reserve('https://relay.example host-c')
+    expect(assignRateGate.trackedKeyCount).toBe(3)
+
+    clock.advance(6_000)
+    await assignRateGate.reserve('https://relay.example host-d')
+
+    expect(assignRateGate.trackedKeyCount).toBe(1)
   })
 })

--- a/src/main/runtime/relay/relay-http-client.test.ts
+++ b/src/main/runtime/relay/relay-http-client.test.ts
@@ -1,8 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import nacl from 'tweetnacl'
 import { cancelTrackingResponse } from '../../lib/unread-response-body.test-fixtures'
-import { RelayAssignAbortedError, RelayAssignRateGate } from './relay-assign-rate-gate'
-import { exchangeRelayAuthorization, requestRelayAssignment } from './relay-http-client'
+import {
+  RelayAssignAbortedError,
+  RelayAssignRateGate,
+  sharedRelayAssignRateGate
+} from './relay-assign-rate-gate'
+import {
+  exchangeRelayAuthorization,
+  requestRelayAssignment,
+  shouldRetryRelayConnectionError
+} from './relay-http-client'
 
 type AssignInput = Parameters<typeof requestRelayAssignment>[0]
 
@@ -333,7 +341,7 @@ describe('relay assignment rate gate', () => {
     clock.advance(2_000)
     await request({ fetch, assignRateGate })
 
-    expect(clock.sleeps).toEqual([3_000])
+    expect(clock.sleeps).toEqual([1_000, 1_000, 1_000])
     expect(fetch).toHaveBeenCalledTimes(2)
   })
 
@@ -360,7 +368,7 @@ describe('relay assignment rate gate', () => {
       request({ fetch, assignRateGate })
     ])
 
-    expect(clock.sleeps).toEqual([5_000, 5_000])
+    expect(clock.sleeps).toEqual(Array.from({ length: 10 }, () => 1_000))
   })
 
   it('keeps a Retry-After hint past the retry timer the coordinator cancels', async () => {
@@ -373,11 +381,58 @@ describe('relay assignment rate gate', () => {
 
     await expect(request({ fetch, assignRateGate })).rejects.toThrow('relay_assignment_failed_429')
     // A reconcile() cancels the armed retry timer and resets attempts; only the
-    // gate still remembers what the director asked for.
+    // gate still remembers what the director asked for. A wait beyond the
+    // inline cap fails fast with the remainder instead of parking the caller
+    // (pairing IPC awaits reconcile inline).
     clock.advance(6_000)
-    await request({ fetch, assignRateGate })
+    await expect(request({ fetch, assignRateGate })).rejects.toMatchObject({
+      statusCode: 429,
+      retryAfterMs: 24_000
+    })
+    expect(clock.sleeps).toEqual([])
+    expect(fetch).toHaveBeenCalledTimes(1)
 
-    expect(clock.sleeps).toEqual([24_000])
+    clock.advance(25_000)
+    await request({ fetch, assignRateGate })
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('honors a deadline raise that lands mid-wait', async () => {
+    const key = 'https://relay.example AbCdEf0123_-xyZ9'
+    let raised = false
+    const clock = fakeAssignClock(() => {
+      if (!raised) {
+        raised = true
+        assignRateGate.noteRetryAfter(key, 10_000)
+      }
+    })
+    const assignRateGate = new RelayAssignRateGate(clock.options)
+
+    await assignRateGate.reserve(key)
+    await assignRateGate.reserve(key)
+
+    // First slice consumes 1s of the 5s interval; the raise then owes 10s more.
+    expect(clock.sleeps.reduce((sum, ms) => sum + ms, 0)).toBe(11_000)
+  })
+
+  it('routes ungated callers through the shared process-wide gate', async () => {
+    const reserve = vi.spyOn(sharedRelayAssignRateGate, 'reserve').mockResolvedValueOnce()
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => assignSuccessResponse())
+
+    await requestRelayAssignment({
+      directorUrl: 'https://relay.example',
+      relayToken: 'scoped-token',
+      relayHostId: 'AbCdEf0123_-xyZ9',
+      fetch
+    })
+
+    expect(reserve).toHaveBeenCalledWith('https://relay.example AbCdEf0123_-xyZ9', undefined)
+    reserve.mockRestore()
+  })
+
+  it('classifies a staleness abort as non-retryable', () => {
+    expect(shouldRetryRelayConnectionError(new RelayAssignAbortedError())).toBe(false)
+    expect(shouldRetryRelayConnectionError(new Error('socket hang up'))).toBe(true)
   })
 
   it('does not re-wait for the field-fallback retries of one attempt', async () => {
@@ -408,7 +463,7 @@ describe('relay assignment rate gate', () => {
       request({ fetch, assignRateGate, isCurrent: () => current })
     ).rejects.toBeInstanceOf(RelayAssignAbortedError)
 
-    expect(clock.sleeps).toEqual([5_000])
+    expect(clock.sleeps).toEqual([1_000])
     expect(fetch).toHaveBeenCalledTimes(1)
   })
 

--- a/src/main/runtime/relay/relay-http-client.ts
+++ b/src/main/runtime/relay/relay-http-client.ts
@@ -170,6 +170,11 @@ async function sendRelayAssignment(
   gate: RelayAssignRateGate,
   rateKey: string
 ): Promise<RelayAssignment> {
+  // A caller superseded after reserving — or between field-fallback retries —
+  // must not spend more requests on an assignment nobody will consume.
+  if (input.isCurrent && !input.isCurrent()) {
+    throw new RelayAssignAbortedError()
+  }
   const response = await (input.fetch ?? globalThis.fetch)(`${input.directorUrl}/v1/assign`, {
     method: 'POST',
     headers: {

--- a/src/main/runtime/relay/relay-http-client.ts
+++ b/src/main/runtime/relay/relay-http-client.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto'
 import { z } from 'zod'
 import type { E2EEKeypair } from '../e2ee-keypair'
 import { cancelUnreadResponseBody } from '../../lib/unread-response-body'
+import { parseRelayRetryAfterMs } from '../../../shared/relay-retry-after-header'
 import type { RelayRegion } from './relay-region-preference'
 
 const RELAY_HTTP_REQUEST_DEADLINE_MS = 15_000
@@ -42,16 +43,8 @@ export class RelayHttpError extends Error {
   }
 }
 
-function relayRetryAfterMs(value: string | null, nowMs = Date.now()): number | null {
-  if (!value) {
-    return null
-  }
-  const seconds = Number(value)
-  const delayMs = Number.isFinite(seconds) ? seconds * 1_000 : Date.parse(value) - nowMs
-  if (!Number.isFinite(delayMs) || delayMs <= 0) {
-    return null
-  }
-  return Math.min(RELAY_RETRY_AFTER_MAX_MS, Math.ceil(delayMs))
+function relayRetryAfterMs(value: string | null): number | null {
+  return parseRelayRetryAfterMs(value, RELAY_RETRY_AFTER_MAX_MS)
 }
 
 export function shouldRetryRelayConnectionError(error: unknown): boolean {

--- a/src/main/runtime/relay/relay-http-client.ts
+++ b/src/main/runtime/relay/relay-http-client.ts
@@ -4,6 +4,8 @@ import type { E2EEKeypair } from '../e2ee-keypair'
 import { cancelUnreadResponseBody } from '../../lib/unread-response-body'
 import { parseRelayRetryAfterMs } from '../../../shared/relay-retry-after-header'
 import {
+  RelayAssignAbortedError,
+  RelayAssignRateLimitedError,
   relayAssignRateKey,
   sharedRelayAssignRateGate,
   type RelayAssignRateGate
@@ -53,6 +55,11 @@ function relayRetryAfterMs(value: string | null): number | null {
 }
 
 export function shouldRetryRelayConnectionError(error: unknown): boolean {
+  // A staleness abort means the caller was superseded — retrying it would
+  // spend rate-gate slots on work whose owner is gone.
+  if (error instanceof RelayAssignAbortedError) {
+    return false
+  }
   if (!(error instanceof RelayHttpError)) {
     return true
   }
@@ -132,7 +139,16 @@ export async function requestRelayAssignment(
   }
   const gate = input.assignRateGate ?? sharedRelayAssignRateGate
   const rateKey = relayAssignRateKey(input.directorUrl, input.relayHostId)
-  await gate.reserve(rateKey, input.isCurrent)
+  try {
+    await gate.reserve(rateKey, input.isCurrent)
+  } catch (error) {
+    if (error instanceof RelayAssignRateLimitedError) {
+      // Surface a long local wait as the 429 it stands in for, so the existing
+      // schedulers pace with retryAfterMs instead of parking the caller inline.
+      throw new RelayHttpError('assignment', 429, error.retryAfterMs)
+    }
+    throw error
+  }
   return await sendRelayAssignment(input, gate, rateKey)
 }
 

--- a/src/main/runtime/relay/relay-http-client.ts
+++ b/src/main/runtime/relay/relay-http-client.ts
@@ -3,6 +3,11 @@ import { z } from 'zod'
 import type { E2EEKeypair } from '../e2ee-keypair'
 import { cancelUnreadResponseBody } from '../../lib/unread-response-body'
 import { parseRelayRetryAfterMs } from '../../../shared/relay-retry-after-header'
+import {
+  relayAssignRateKey,
+  sharedRelayAssignRateGate,
+  type RelayAssignRateGate
+} from './relay-assign-rate-gate'
 import type { RelayRegion } from './relay-region-preference'
 
 const RELAY_HTTP_REQUEST_DEADLINE_MS = 15_000
@@ -106,7 +111,7 @@ export async function exchangeRelayAuthorization(input: {
   return parsed.data
 }
 
-export async function requestRelayAssignment(input: {
+type RelayAssignmentRequest = {
   directorUrl: string
   relayToken: string
   relayHostId: string
@@ -114,10 +119,30 @@ export async function requestRelayAssignment(input: {
   preferredRegion?: RelayRegion
   fetch?: typeof globalThis.fetch
   requestDeadlineMs?: number
-}): Promise<RelayAssignment> {
+  // Fencing for the throttle wait: a superseded caller aborts instead of assigning.
+  isCurrent?: () => boolean
+  assignRateGate?: RelayAssignRateGate
+}
+
+export async function requestRelayAssignment(
+  input: RelayAssignmentRequest
+): Promise<RelayAssignment> {
   if (!isAllowedRelayOrigin(input.directorUrl)) {
     throw new RelayHttpError('assignment', 400)
   }
+  const gate = input.assignRateGate ?? sharedRelayAssignRateGate
+  const rateKey = relayAssignRateKey(input.directorUrl, input.relayHostId)
+  await gate.reserve(rateKey, input.isCurrent)
+  return await sendRelayAssignment(input, gate, rateKey)
+}
+
+// The field-fallback retries below are one logical attempt against one booked
+// slot; re-entering the gate would stall rolled-back-director compatibility 5s.
+async function sendRelayAssignment(
+  input: RelayAssignmentRequest,
+  gate: RelayAssignRateGate,
+  rateKey: string
+): Promise<RelayAssignment> {
   const response = await (input.fetch ?? globalThis.fetch)(`${input.directorUrl}/v1/assign`, {
     method: 'POST',
     headers: {
@@ -136,15 +161,18 @@ export async function requestRelayAssignment(input: {
   })
   if (!response.ok) {
     const retryAfterMs = relayRetryAfterMs(response.headers.get('retry-after'))
+    if (retryAfterMs !== null) {
+      gate.noteRetryAfter(rateKey, retryAfterMs)
+    }
     await cancelUnreadResponseBody(response)
     if (input.preferredRegion && response.status === 400) {
       // A rolled-back director rejects the regional hint; preserve the
       // reconnect lane while retrying without only that field.
-      return await requestRelayAssignment({ ...input, preferredRegion: undefined })
+      return await sendRelayAssignment({ ...input, preferredRegion: undefined }, gate, rateKey)
     }
     if (input.reconnect && response.status === 400) {
       // A rolled-back director rejects unknown fields; retry once unhinted.
-      return await requestRelayAssignment({ ...input, reconnect: false })
+      return await sendRelayAssignment({ ...input, reconnect: false }, gate, rateKey)
     }
     throw new RelayHttpError('assignment', response.status, retryAfterMs)
   }

--- a/src/main/runtime/relay/relay-http-client.ts
+++ b/src/main/runtime/relay/relay-http-client.ts
@@ -50,6 +50,15 @@ export class RelayHttpError extends Error {
   }
 }
 
+// Distinct message so log censuses can tell a locally-enforced wait from a real
+// director 429 — one server 429 would otherwise print several identical lines.
+export class RelayAssignLocallyPacedError extends RelayHttpError {
+  constructor(retryAfterMs: number) {
+    super('assignment', 429, retryAfterMs)
+    this.message = 'relay_assignment_locally_paced_429'
+  }
+}
+
 function relayRetryAfterMs(value: string | null): number | null {
   return parseRelayRetryAfterMs(value, RELAY_RETRY_AFTER_MAX_MS)
 }
@@ -145,7 +154,9 @@ export async function requestRelayAssignment(
     if (error instanceof RelayAssignRateLimitedError) {
       // Surface a long local wait as the 429 it stands in for, so the existing
       // schedulers pace with retryAfterMs instead of parking the caller inline.
-      throw new RelayHttpError('assignment', 429, error.retryAfterMs)
+      // Reachable only while a director Retry-After beyond the inline cap is
+      // still in force — local booking alone never exceeds ~5.5s.
+      throw new RelayAssignLocallyPacedError(error.retryAfterMs)
     }
     throw error
   }

--- a/src/main/runtime/relay/relay-origin-pool.ts
+++ b/src/main/runtime/relay/relay-origin-pool.ts
@@ -171,6 +171,7 @@ export class RelayOriginPool {
         // verifies this and admits through its reconnect fast lane.
         reconnect: true,
         preferredRegion,
+        isCurrent: () => this.isCurrent(),
         fetch: this.options.fetch
       })
       this.assertCurrent()

--- a/src/main/runtime/relay/relay-session-broker.test.ts
+++ b/src/main/runtime/relay/relay-session-broker.test.ts
@@ -223,8 +223,17 @@ describe('RelaySessionBroker lifecycle ownership', () => {
     )
     expect(fakes.assign).toHaveBeenNthCalledWith(
       1,
-      expect.objectContaining({ preferredRegion: 'asia-east2', reconnect: true })
+      expect.objectContaining({
+        preferredRegion: 'asia-east2',
+        reconnect: true,
+        // Why: the rate-gate wait relies on this fencing to abort superseded
+        // callers; dropping the wiring must fail here, not only in the field.
+        isCurrent: expect.any(Function)
+      })
     )
+    const wiredIsCurrent = (fakes.assign.mock.calls[0]![0] as { isCurrent: () => boolean })
+      .isCurrent
+    expect(wiredIsCurrent()).toBe(true)
     fakes.controls[0]!.options.onConnectionOpen({
       connId: 'old-basis',
       connTicket: 'T'.repeat(43),

--- a/src/main/runtime/relay/relay-session-broker.ts
+++ b/src/main/runtime/relay/relay-session-broker.ts
@@ -217,6 +217,7 @@ export class RelaySessionBroker {
       // through to the placement lane.
       reconnect: true,
       preferredRegion,
+      isCurrent: () => this.isCurrent(),
       fetch: this.options.fetch
     })
     this.assertCurrent()

--- a/src/shared/relay-retry-after-header.ts
+++ b/src/shared/relay-retry-after-header.ts
@@ -1,0 +1,17 @@
+// Relay director Retry-After: delta-seconds or HTTP-date. Null means the server
+// asked for no pacing, so the caller keeps its own backoff.
+export function parseRelayRetryAfterMs(
+  value: string | null | undefined,
+  maxMs: number,
+  nowMs = Date.now()
+): number | null {
+  if (!value) {
+    return null
+  }
+  const seconds = Number(value)
+  const delayMs = Number.isFinite(seconds) ? seconds * 1_000 : Date.parse(value) - nowMs
+  if (!Number.isFinite(delayMs) || delayMs <= 0) {
+    return null
+  }
+  return Math.min(maxMs, Math.ceil(delayMs))
+}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 7 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​498 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​481 |
| Prod | 12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​310 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​29 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​281 |

<!-- /orca-pr-loc -->

Client-side fixes for the mobile Relay connection-failure influx (STA-5457). One incident, four fixes, one commit each.

## Root cause being fixed

The director's only reply on `/v1/connect` is `relay-moved` with the **stored** epoch — it has no "you're already assigned there" verb, and sticky assignments reuse the same epoch indefinitely, so equal-epoch replies are the steady state. The phone treated any non-newer move as fatal, so **every pairing recovery after a transient cell-dial failure (DRAINING, 1006/network) dead-ended in <3s** on released Android 0.0.44. Off-LAN, the direct candidate can't reach the desktop's private IP either → "Couldn't connect within 25s".

## Changes

1. **`fix(mobile)`: retry the stored assignment on a non-newer director move.** The move is never adopted or persisted — the anti-rollback contract (`requireStrictlyNewerEpoch`) is untouched; the candidate re-dials the assignment the director just confirmed, with a 250ms floor. 4429 (LIMIT_EXCEEDED) deliberately stays non-recoverable: cell dials burn invite attempts server-side (reserve-before-cap ordering) and a director hop can't relieve cell load; a test pins that 4429 never reaches the director.
2. **`fix(mobile)`: honor `Retry-After` when pacing recovery.** `/v1/resolve` non-OK responses now carry status + `Retry-After` (clamped 120s) via `RelayDirectorHttpError`, floored into the existing reconnect delays — no new timers. The parser is extracted to `src/shared/relay-retry-after-header.ts` and reused by the desktop client.
3. **`fix(mobile)`: attribute pairing log lines `Direct:`/`Relay:`.** The pairing pane interleaves both racing candidates; unlabeled direct-candidate retries against a private LAN IP repeatedly read as Relay failures (misled users and two investigations).
4. **`fix(relay)`: gate desktop `/v1/assign` at the per-host 5s rate limit.** Current main's effective floor is ~0ms: full jitter draws from [0, cap], drain-path first attempts are undelayed, 400-fallbacks issue up to 3 assigns per round trip, and `reconcile()` cancels the armed Retry-After timer. Production shows livelocked hosts at ~100–200 rejects per success. A shared per-host gate at the single call site closes all four bypasses; `Retry-After` raises it persistently; fenced callers abort stale waits.

## Verification

- Mobile transport: 82 files, 611 passed. Desktop `src/main/runtime/relay/`: 91 passed; full `src/main/runtime`: 5376 passed.
- `pnpm tc` / `tc:node` clean; changed-code quality + React Doctor: 0 findings; oxlint (incl. max-lines) exit 0; mobile formatted with oxfmt.
- Independent adversarial safety review passed all conditions: anti-rollback intact, close-codes contract table unchanged and now honored (4429 → backoff, no director hop), 25s pairing budget arithmetic verified (≈16–17s worst case), retained recovery codes (4409/4503) are rejected server-side **before** invite-credential reservation so extra re-dials burn no attempts.
- New tests mutation-checked (gate floor, Retry-After persistence, prune, staleness abort, fallback no-re-wait; non-newer retry + no-persist + no-director-on-4429).

## Notes for reviewers

- `pre-profile-pairing-coordinator.ts` and `mobile-relay-reconnect-controller.ts` sit ~4 effective lines under the 300 max-lines cap.
- Follow-ups deliberately out of scope: threading the 25s pairing deadline into the recovery loop; cell request timeout (30s) exceeding the pairing budget; startup journal recovery never triggers director recovery (method-gated); protocol-level fix (phone sends epoch in `relay-auth`, director answers "assignment-current") tracked separately; server-side 4429 disambiguation + Retry-After on cell rejections.
