### PR TITLE
fix(cmd+j): always enable See more for soft preview hints

### DIFF
--- a/src/renderer/src/components/WorktreeJumpPalette.tsx
+++ b/src/renderer/src/components/WorktreeJumpPalette.tsx
@@ -2303,14 +2303,10 @@ function WorktreeJumpPaletteContent({
       pushLeadingHeader()
       appendPaletteListEntries(entries, multiPrimaryLayout.leadingPreview as PaletteItem[])
       // Soft more for the leading section (rows resuming below + hard-cap tail).
-      // Why: only actionable when rows are actually hidden — with the whole
-      // section already rendered below, expanding would just reshuffle rows.
-      pushOverflowHint(
-        leadingHintId,
-        multiPrimaryLayout.leadingMoreCount,
-        multiPrimaryLayout.leadingHardOverflowCount > 0
-          ? () => handleExpandSection(leadingSectionKey)
-          : undefined
+      // Why: reveals the next batch into the leading preview so the user can
+      // keep browsing tabs without having to scroll past the worktrees section.
+      pushOverflowHint(leadingHintId, multiPrimaryLayout.leadingMoreCount, () =>
+        handleExpandSection(leadingSectionKey)
       )
       pushTrailingHeader()
       // Floor first, then remaining leading rows, then trailing rest — same order

--- a/src/renderer/src/components/worktree-jump-palette-interleaved-sections.test.tsx
+++ b/src/renderer/src/components/worktree-jump-palette-interleaved-sections.test.tsx
@@ -456,7 +456,7 @@ describe('WorktreeJumpPalette interleaved primary sections', () => {
     expect(testContainer.textContent).toContain('10 more')
   })
 
-  it('leaves the soft preview hint non-actionable when no rows are hidden', async () => {
+  it('expands soft preview when clicking See more even when all rows fit within the hard cap', async () => {
     await renderPalette(perfTabsPaletteProps(30))
 
     await act(async () => {
@@ -464,12 +464,33 @@ describe('WorktreeJumpPalette interleaved primary sections', () => {
     })
     await flushEffects()
 
-    // All 30 tabs render (6 preview + 24 remainder), so expanding would only reorder rows.
+    // 6 preview tabs, 24 more follow below the worktrees section
     expect(testContainer.textContent).toContain('24 more')
     const seeMoreBtn = Array.from(testContainer.querySelectorAll('button')).find((btn) =>
       btn.textContent?.includes('See more')
     )
-    expect(seeMoreBtn).toBeUndefined()
+    expect(seeMoreBtn).toBeDefined()
+
+    // Click See more: preview expands to 6 + 20 = 26 tabs, leaving 4 more
+    await act(async () => {
+      seeMoreBtn?.click()
+    })
+    await flushEffects()
+
+    expect(testContainer.textContent).toContain('4 more')
+
+    const seeMoreBtn2 = Array.from(testContainer.querySelectorAll('button')).find((btn) =>
+      btn.textContent?.includes('See more')
+    )
+    expect(seeMoreBtn2).toBeDefined()
+
+    // Click See more again: preview expands to 26 + 20 = 46 tabs (fits all 30), hint disappears
+    await act(async () => {
+      seeMoreBtn2?.click()
+    })
+    await flushEffects()
+
+    expect(testContainer.textContent).not.toContain('more')
   })
 
   it('resets expanded section caps when query changes', async () => {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​21 |
| Prod | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​4 |

<!-- /orca-pr-loc -->

## Problem

The "See more" button in Cmd+J soft preview hints was hidden when all rows fit within the hard cap. This forced users to scroll past the worktrees section to browse additional tabs, interrupting the browsing flow.

## Solution

Always show the "See more" button for soft preview hints, regardless of whether rows are hidden. When clicked, it expands the leading preview to display the next batch of tabs, allowing users to keep browsing without scrolling past other sections.

## Testing

- Updated test "expands soft preview when clicking See more even when all rows fit within the hard cap" to verify the button appears and functions correctly when no rows are initially hidden
- Test confirms preview expands incrementally with each click until all tabs are shown