### PR TITLE
fix(terminal): scope Git Bash capacity retention

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection-pty-exit-teardown.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-pty-exit-teardown.test.ts
@@ -1,7 +1,10 @@
 import type * as React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
-import { sendTerminalInputThroughPane } from './pty-connection-test-dom'
+import {
+  sendTerminalInputThroughPane,
+  temporarilySetNavigatorUserAgent
+} from './pty-connection-test-dom'
 import { flushAsyncTicks } from './pty-connection-test-async'
 import {
   LEAF_1,
@@ -40,6 +43,7 @@ let mockStoreState: StoreState
 let transportFactoryQueue: MockTransport[] = []
 let createdTransportOptions: Record<string, unknown>[] = []
 let storeSubscribers: ((state: StoreState) => void)[] = []
+let restoreNavigatorUserAgent: (() => void) | null = null
 
 vi.mock('@/runtime/sync-runtime-graph', () => ({
   scheduleRuntimeGraphSync
@@ -175,6 +179,8 @@ describe('connectPanePty', () => {
   })
 
   afterEach(async () => {
+    restoreNavigatorUserAgent?.()
+    restoreNavigatorUserAgent = null
     await restoreTerminalTestGlobals()
   })
 
@@ -422,7 +428,7 @@ describe('connectPanePty', () => {
     expect(manager.closePane).not.toHaveBeenCalled()
   })
 
-  it('keeps a failed local terminal visible after user input', async () => {
+  it('tears down a failed local terminal after user input', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const pane = createPane(1)
     const transport = createMockTransport('tab-pty')
@@ -438,17 +444,12 @@ describe('connectPanePty', () => {
     sendTerminalInputThroughPane(pane, 'agent startup\r')
     onPtyExit?.('tab-pty', 1)
 
-    expect(deps.onPaneProcessDied).toHaveBeenCalledWith({
-      paneId: 1,
-      exitCode: 1,
-      startup: null,
-      reason: 'process-failed'
-    })
-    expect(deps.onPtyExitRef.current).not.toHaveBeenCalled()
+    expect(deps.onPaneProcessDied).not.toHaveBeenCalled()
+    expect(deps.onPtyExitRef.current).toHaveBeenCalledWith('tab-pty')
     expect(manager.closePane).not.toHaveBeenCalled()
   })
 
-  it('keeps a failed local split pane visible', async () => {
+  it('closes a failed local split pane without the capacity marker', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('tab-pty')
     transportFactoryQueue.push(transport)
@@ -461,13 +462,8 @@ describe('connectPanePty', () => {
       | undefined
     onPtyExit?.('tab-pty', 1)
 
-    expect(deps.onPaneProcessDied).toHaveBeenCalledWith({
-      paneId: 1,
-      exitCode: 1,
-      startup: null,
-      reason: 'process-failed'
-    })
-    expect(manager.closePane).not.toHaveBeenCalled()
+    expect(deps.onPaneProcessDied).not.toHaveBeenCalled()
+    expect(manager.closePane).toHaveBeenCalledWith(1)
   })
 
   it('classifies the Git Bash capacity failure before retaining its pane', async () => {
@@ -482,12 +478,19 @@ describe('connectPanePty', () => {
     const manager = createManager(1)
     const startup = { command: 'codex --resume session-1' }
     const deps = createDeps({ onPaneProcessDied: vi.fn(), startup })
+    restoreNavigatorUserAgent = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
 
     connectPanePty(createPane(1) as never, manager as never, deps as never)
+    const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as
+      | ((ptyId: string) => void)
+      | undefined
     const onPtyExit = createdTransportOptions[0]?.onPtyExit as
       | ((ptyId: string, exitCode?: number) => void)
       | undefined
 
+    onPtySpawn?.('tab-pty')
     capturedDataCallback.current?.(
       'console device allocation failure - too many consoles in use, max consoles is 128'
     )
@@ -500,6 +503,37 @@ describe('connectPanePty', () => {
       reason: 'git-bash-console-capacity'
     })
     expect(deps.onPtyExitRef.current).not.toHaveBeenCalled()
+  })
+
+  it('does not retain the capacity marker outside native Windows', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const capturedDataCallback: { current: ((data: string) => void) | null } = { current: null }
+    const transport = createMockTransport('tab-pty')
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      capturedDataCallback.current = callbacks.onData ?? null
+      return 'tab-pty'
+    })
+    transportFactoryQueue.push(transport)
+    const manager = createManager(2)
+    const deps = createDeps({ onPaneProcessDied: vi.fn() })
+    restoreNavigatorUserAgent = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X)'
+    )
+
+    connectPanePty(createPane(1) as never, manager as never, deps as never)
+    const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as
+      | ((ptyId: string) => void)
+      | undefined
+    const onPtyExit = createdTransportOptions[0]?.onPtyExit as
+      | ((ptyId: string, exitCode?: number) => void)
+      | undefined
+
+    onPtySpawn?.('tab-pty')
+    capturedDataCallback.current?.('too many consoles in use, max consoles is 128')
+    onPtyExit?.('tab-pty', 1)
+
+    expect(deps.onPaneProcessDied).not.toHaveBeenCalled()
+    expect(manager.closePane).toHaveBeenCalledWith(1)
   })
 
   it('retains the cold-restore resume startup when its replacement hits capacity', async () => {
@@ -516,9 +550,16 @@ describe('connectPanePty', () => {
       startup: { command: 'codex stale-startup' },
       onPaneProcessDied: vi.fn()
     })
+    restoreNavigatorUserAgent = temporarilySetNavigatorUserAgent(
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+    )
 
     connectPanePty(createPane(1) as never, createManager(1) as never, deps as never)
     await flushAsyncTicks(20)
+    const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as
+      | ((ptyId: string) => void)
+      | undefined
+    onPtySpawn?.('resume-pty')
     callbacks[0]?.onData?.('too many consoles in use, max consoles is 128')
     const onPtyExit = createdTransportOptions[0]?.onPtyExit as
       | ((ptyId: string, exitCode?: number) => void)
@@ -572,12 +613,8 @@ describe('connectPanePty', () => {
       | undefined
     onPtyExit?.('resume-pty', 1)
 
-    expect(deps.onPaneProcessDied).toHaveBeenCalledWith({
-      paneId: 1,
-      exitCode: 1,
-      startup: null,
-      reason: 'process-failed'
-    })
+    expect(deps.onPaneProcessDied).not.toHaveBeenCalled()
+    expect(deps.onPtyExitRef.current).toHaveBeenCalledWith('resume-pty')
   })
 
   it('does not retain a failed direct-SSH terminal locally', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection/pane-pty-visibility-bind.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/pane-pty-visibility-bind.ts
@@ -118,6 +118,8 @@ export function installPanePtyVisibilityBind(session: ConnectPanePtySession): vo
     // just-created worktree) can be kept visible rather than tearing down the
     // worktree. Reattach/coldRestore skip onPtySpawn (pty-transport.ts).
     session.spawnedFreshPtyId = ptyId
+    // Fresh PTYs get an independent startup-retention decision.
+    session.lastTerminalInputAt = Number.NEGATIVE_INFINITY
     // Why: Command Code has no prompt-start hook. Seed the visible working row
     // once the PTY exists, then let real hook events refine or complete it.
     session.bindActivePanePty(ptyId, { seedInitialAgentStatus: true })

--- a/src/renderer/src/components/terminal-pane/pty-connection/pty-exit-hibernate.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/pty-exit-hibernate.ts
@@ -33,9 +33,12 @@ export function installPtyExitHibernate(session: ConnectPanePtySession): void {
   session.currentProcessExitState = session.createProcessExitState(session.paneStartup)
   session.processExitStateByPtyId = new Map<string, ProcessExitState>()
   session.bindProcessExitState = (ptyId: string, replacedPtyId?: string): void => {
-    const state =
-      (replacedPtyId ? session.processExitStateByPtyId.get(replacedPtyId) : undefined) ??
-      session.currentProcessExitState
+    // A replacement gets a clean state; never carry detector or restart context
+    // from the PTY it replaced.
+    const state = replacedPtyId
+      ? session.createProcessExitState(null)
+      : session.currentProcessExitState
+    session.currentProcessExitState = state
     session.processExitStateByPtyId.set(ptyId, state)
     if (replacedPtyId && replacedPtyId !== ptyId) {
       session.processExitStateByPtyId.delete(replacedPtyId)
@@ -201,8 +204,7 @@ export function installPtyExitHibernate(session: ConnectPanePtySession): void {
       return
     }
     session.handledExitPtyId = ptyId
-    const processExitState =
-      session.processExitStateByPtyId.get(ptyId) ?? session.currentProcessExitState
+    const processExitState = session.processExitStateByPtyId.get(ptyId)
     session.processExitStateByPtyId.delete(ptyId)
     session.agentCompletionCoordinator.dispose()
     session.dropSideEffectFactConsumer()
@@ -280,15 +282,22 @@ export function installPtyExitHibernate(session: ConnectPanePtySession): void {
       return
     }
     session.manager.setPaneGpuRendering(session.pane.id, true)
-    const failedLocalProcess =
-      !session.connectionId && session.runtimeEnvironmentId === null && exitCode !== 0
-    if (failedLocalProcess && session.deps.onPaneProcessDied) {
-      const gitBashConsoleCapacityFailure = processExitState.detector.detected()
+    const hasTerminalInput =
+      Number.isFinite(session.lastTerminalInputAt) || Boolean(session.pendingTerminalInputWrite)
+    const gitBashConsoleCapacityFailure =
+      session.isNativeWindowsConpty &&
+      !session.connectionId &&
+      session.runtimeEnvironmentId === null &&
+      exitCode !== 0 &&
+      session.spawnedFreshPtyId === ptyId &&
+      !hasTerminalInput &&
+      processExitState?.detector.detected() === true
+    if (gitBashConsoleCapacityFailure && session.deps.onPaneProcessDied) {
       session.deps.onPaneProcessDied({
         paneId: session.pane.id,
         exitCode,
-        startup: gitBashConsoleCapacityFailure ? processExitState.startup : null,
-        reason: gitBashConsoleCapacityFailure ? 'git-bash-console-capacity' : 'process-failed'
+        startup: processExitState.startup,
+        reason: 'git-bash-console-capacity'
       })
       return
     }
@@ -305,7 +314,7 @@ export function installPtyExitHibernate(session: ConnectPanePtySession): void {
       // for this ptyId — reattach/coldRestore skip it) that the user never typed
       // into, so a reattached-dead session or an explicit `exit` still tears
       // down as before.
-      if (session.spawnedFreshPtyId === ptyId && !Number.isFinite(session.lastTerminalInputAt)) {
+      if (session.spawnedFreshPtyId === ptyId && !hasTerminalInput) {
         return
       }
       session.deps.onPtyExitRef.current(ptyId)
@@ -315,7 +324,7 @@ export function installPtyExitHibernate(session: ConnectPanePtySession): void {
       session.deps.isVisibleRef.current &&
       session.hadExistingPaneTransportAtConnect &&
       !session.restoredPtyIdForTransport &&
-      !Number.isFinite(session.lastTerminalInputAt) &&
+      !hasTerminalInput &&
       !session.hasReceivedPtyOutput
     ) {
       // Why: a freshly split pane can lose its newborn PTY during setup; keep


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​60 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​23 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​24 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​13 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /orca-pr-loc -->

## Reference draft only — not ready to merge

This draft documents the focused fix direction for STA-5604. It is attached to the Linear ticket as a reference and is not a merge request for release.

### What this fixes

- Retains a local pane only for the genuine native Windows ConPTY Git Bash capacity marker (`too many consoles in use, max consoles is 128`).
- Requires a fresh PTY, non-zero exit, no terminal input (including a pending acknowledged write), and the exact marker.
- Preserves the startup command only for that capacity-specific Restart path.
- Restores ordinary non-zero exits to the existing teardown behavior on local macOS/Linux and for remote/SSH sessions.
- Resets detector/input lifecycle state across PTY replacement and covers split marker chunks, user input, replacement, and non-Windows regressions.

#16045 remains in place; this is a narrow forward fix to constrain its retention policy.

### Validation

- Focused PTY lifecycle + detector tests: 22 passed.
- Changed-file lint/code-quality, formatter, and `git diff --check`: passed.
- Full web typecheck remains blocked by unrelated pre-existing Automations errors on `origin/main` (listed in the handoff, not caused by this diff).

Do not merge this draft as-is; use it as the implementation reference for STA-5604 and review the small diff against current `main`.
