### PR TITLE
feat(runtime): make agent prompt stall timeout configurable via env

### DIFF
--- a/src/main/runtime/agent-prompt-submission-verification.ts
+++ b/src/main/runtime/agent-prompt-submission-verification.ts
@@ -1,4 +1,6 @@
-export const AGENT_PROMPT_EFFECT_TIMEOUT_MS = 5_000
+export const AGENT_PROMPT_EFFECT_TIMEOUT_MS = Number(
+  process.env.ORCA_AGENT_PROMPT_TIMEOUT_MS ?? 5_000
+)
 const AGENT_PROMPT_EFFECT_POLL_MS = 50
 
 export type AgentPromptActivity = Readonly<{


### PR DESCRIPTION
## Problem

`AGENT_PROMPT_EFFECT_TIMEOUT_MS` is hardcoded to 5s. Slow-booting agents (Hermes Agent CLI boots in 15-60s, Google Antigravity CLI similar) hit `agent_prompt_stalled` before reaching their first prompt — the dispatch is marked failed ~8s after launch even though the agent later completes the task (see #16660). There is no way to raise the window without rebuilding.

## Change

Make the stall window configurable via env, keeping the default at 5s:

```ts
export const AGENT_PROMPT_EFFECT_TIMEOUT_MS = Number(
  process.env.ORCA_AGENT_PROMPT_TIMEOUT_MS ?? 5_000
)
```

Operators can then run e.g. `ORCA_AGENT_PROMPT_TIMEOUT_MS=120000 orca serve` for slow-booting agents.

## Testing

Existing tests (`agent-prompt-submission-verification.test.ts`) reference the constant symbolically (`vi.advanceTimersByTimeAsync(AGENT_PROMPT_EFFECT_TIMEOUT_MS)`), so behavior is unchanged when the env var is unset. We verified the corresponding bundle patch on a live deployment: dispatch stalled-window grew 8s → ~129s with `120e3`.

## Notes

- The deeper issue (worker completes the task but activity hooks don't advance `workingSequence` for Hermes in dispatch mode, so verification still fails even at 120s) is tracked in #16660 — this PR is the enabler so deployments can at least tune the window while that is investigated.

Fixes #16660 (partially)