### PR TITLE
fix(browser): reset inherited zoom on remote and offscreen pages

### DIFF
--- a/src/main/browser/browser-guest-page-zoom.test.ts
+++ b/src/main/browser/browser-guest-page-zoom.test.ts
@@ -1,0 +1,37 @@
+import { EventEmitter } from 'node:events'
+import { describe, expect, it, vi } from 'vitest'
+import { attachRemoteBrowserGuestPageZoomReassert } from './browser-guest-page-zoom'
+
+describe('attachRemoteBrowserGuestPageZoomReassert', () => {
+  it('resets inherited origin zoom immediately and after later loads', () => {
+    const guest = new EventEmitter() as EventEmitter & {
+      zoomLevel: number
+      isDestroyed: () => boolean
+      getZoomLevel: () => number
+      setZoomLevel: (level: number) => void
+    }
+    guest.zoomLevel = 3
+    guest.isDestroyed = () => false
+    guest.getZoomLevel = () => guest.zoomLevel
+    guest.setZoomLevel = vi.fn((level: number) => {
+      guest.zoomLevel = level
+    })
+
+    const detach = attachRemoteBrowserGuestPageZoomReassert(guest as never)
+    expect(guest.setZoomLevel).toHaveBeenCalledWith(0)
+    expect(guest.zoomLevel).toBe(0)
+
+    guest.zoomLevel = 2
+    guest.emit('dom-ready')
+    expect(guest.zoomLevel).toBe(0)
+
+    guest.zoomLevel = 4
+    guest.emit('did-finish-load')
+    expect(guest.zoomLevel).toBe(0)
+
+    detach()
+    guest.zoomLevel = 3
+    guest.emit('dom-ready')
+    expect(guest.zoomLevel).toBe(3)
+  })
+})

--- a/src/main/browser/browser-guest-page-zoom.ts
+++ b/src/main/browser/browser-guest-page-zoom.ts
@@ -1,0 +1,29 @@
+import type { WebContents } from 'electron'
+import {
+  applyBrowserPageZoomLevel,
+  DEFAULT_BROWSER_PAGE_ZOOM_LEVEL
+} from '../../shared/browser-page-zoom'
+
+const ZOOM_REASSERT_EVENTS = ['dom-ready', 'did-finish-load'] as const
+
+export function applyRemoteBrowserGuestPageZoom(guest: WebContents): number | null {
+  return applyBrowserPageZoomLevel(guest, DEFAULT_BROWSER_PAGE_ZOOM_LEVEL)
+}
+
+export function attachRemoteBrowserGuestPageZoomReassert(guest: WebContents): () => void {
+  const apply = (): void => {
+    applyRemoteBrowserGuestPageZoom(guest)
+  }
+  apply()
+  if (typeof guest.on !== 'function' || typeof guest.off !== 'function') {
+    return () => {}
+  }
+  for (const event of ZOOM_REASSERT_EVENTS) {
+    guest.on(event, apply)
+  }
+  return () => {
+    for (const event of ZOOM_REASSERT_EVENTS) {
+      guest.off(event, apply)
+    }
+  }
+}

--- a/src/main/browser/browser-screencast-lifecycle.test.ts
+++ b/src/main/browser/browser-screencast-lifecycle.test.ts
@@ -21,7 +21,18 @@ function createWebContents() {
     attached = false
   })
   debuggerApi.sendCommand = vi.fn(async () => ({}))
-  return { isDestroyed: vi.fn(() => false), debugger: debuggerApi }
+  const emitter = new EventEmitter()
+  let zoomLevel = 0
+  return {
+    isDestroyed: vi.fn(() => false),
+    debugger: debuggerApi,
+    on: emitter.on.bind(emitter),
+    off: emitter.off.bind(emitter),
+    getZoomLevel: () => zoomLevel,
+    setZoomLevel: (level: number) => {
+      zoomLevel = level
+    }
+  }
 }
 
 describe('browser screencast lifecycle', () => {

--- a/src/main/browser/browser-screencast-snapshot-scaling.test.ts
+++ b/src/main/browser/browser-screencast-snapshot-scaling.test.ts
@@ -20,7 +20,19 @@ function createMockWebContents(capturePage: () => Promise<unknown>) {
     attached = false
   })
   dbg.sendCommand = vi.fn(async () => ({}))
-  return { isDestroyed: vi.fn(() => false), debugger: dbg, capturePage: vi.fn(capturePage) }
+  const emitter = new EventEmitter()
+  let zoomLevel = 0
+  return {
+    isDestroyed: vi.fn(() => false),
+    debugger: dbg,
+    capturePage: vi.fn(capturePage),
+    on: emitter.on.bind(emitter),
+    off: emitter.off.bind(emitter),
+    getZoomLevel: () => zoomLevel,
+    setZoomLevel: (level: number) => {
+      zoomLevel = level
+    }
+  }
 }
 
 function createCapturedImage(width: number, height: number) {

--- a/src/main/browser/browser-screencast-stream.test.ts
+++ b/src/main/browser/browser-screencast-stream.test.ts
@@ -22,9 +22,18 @@ function createMockWebContents() {
   })
   dbg.sendCommand = vi.fn(async () => ({}))
 
+  let zoomLevel = 3
+  const emitter = new EventEmitter()
   return {
     isDestroyed: vi.fn(() => false),
-    debugger: dbg
+    debugger: dbg,
+    on: emitter.on.bind(emitter),
+    off: emitter.off.bind(emitter),
+    emit: emitter.emit.bind(emitter),
+    getZoomLevel: vi.fn(() => zoomLevel),
+    setZoomLevel: vi.fn((level: number) => {
+      zoomLevel = level
+    })
   }
 }
 
@@ -57,6 +66,27 @@ function jpegWithSize(width: number, height: number): Buffer {
 }
 
 describe('startBrowserScreencast', () => {
+  it('resets inherited origin zoom before the first frame', async () => {
+    const webContents = createMockWebContents()
+    const onFrame = vi.fn()
+
+    const session = await startBrowserScreencast(webContents as never, {
+      format: 'jpeg',
+      quality: 70,
+      maxWidth: 1440,
+      maxHeight: 1200,
+      everyNthFrame: 2,
+      minFrameIntervalMs: 0,
+      onFrame
+    })
+
+    expect(webContents.setZoomLevel).toHaveBeenCalledWith(0)
+    expect(webContents.getZoomLevel()).toBe(0)
+
+    session.stop()
+    await session.done
+  })
+
   it('emits an initial captured frame before CDP produces screencast events', async () => {
     const webContents = createMockWebContents()
     const firstFrame = Buffer.from('first-frame')

--- a/src/main/browser/browser-screencast-stream.ts
+++ b/src/main/browser/browser-screencast-stream.ts
@@ -3,6 +3,7 @@ import { BrowserError } from './cdp-bridge'
 import { acquireElectronDebugger, type ElectronDebuggerLease } from './electron-debugger-lease'
 import { createBrowserScreencastMessageHandler } from './browser-screencast-cdp-events'
 import { sendDebuggerCommand } from './browser-screencast-debugger-command'
+import { attachRemoteBrowserGuestPageZoomReassert } from './browser-guest-page-zoom'
 import { createBrowserScreencastDeviceMetrics } from './browser-screencast-device-metrics'
 import { createBrowserScreencastFramePacer } from './browser-screencast-frame-pacer'
 import { createBrowserScreencastSnapshotCapture } from './browser-screencast-snapshot-capture'
@@ -35,6 +36,7 @@ export async function startBrowserScreencast(
   let closed = false
   let stopping = false
   let resolveDone!: () => void
+  const detachZoomReassert = attachRemoteBrowserGuestPageZoomReassert(webContents)
   // Serializes viewport and frame-budget changes against the snapshot capture they trigger.
   let pendingUpdate = Promise.resolve()
   const done = new Promise<void>((resolve) => {
@@ -81,6 +83,7 @@ export async function startBrowserScreencast(
       return
     }
     closed = true
+    detachZoomReassert()
     snapshotCapture.clearNavigationCaptureTimer()
     framePacer.clearPending()
     dbg.removeListener('message', handleMessage as never)

--- a/src/main/browser/offscreen-browser-backend-lifecycle.test.ts
+++ b/src/main/browser/offscreen-browser-backend-lifecycle.test.ts
@@ -9,10 +9,19 @@ const mocks = vi.hoisted(() => ({
 
 class MockWebContents extends EventEmitter {
   readonly id: number
+  zoomLevel = 3
 
   constructor(id: number) {
     super()
     this.id = id
+  }
+
+  getZoomLevel(): number {
+    return this.zoomLevel
+  }
+
+  setZoomLevel(level: number): void {
+    this.zoomLevel = level
   }
 
   loadURL(): Promise<void> {
@@ -84,13 +93,37 @@ describe('OffscreenBrowserBackend lifecycle', () => {
       worktreeId: 'wt'
     })
     const webContents = mocks.windows[0].webContents
-    expect(webContents.listenerCount('did-finish-load')).toBe(1)
+    expect(webContents.listenerCount('did-finish-load')).toBe(2)
     expect(webContents.listenerCount('did-fail-load')).toBe(1)
+    expect(webContents.listenerCount('dom-ready')).toBe(1)
 
     await backend.closeTab('page-1')
     expect(webContents.listenerCount('did-finish-load')).toBe(0)
     expect(webContents.listenerCount('did-fail-load')).toBe(0)
+    expect(webContents.listenerCount('dom-ready')).toBe(0)
     expect(vi.getTimerCount()).toBe(0)
     vi.useRealTimers()
+  })
+
+  it('resets inherited origin zoom on the offscreen guest', async () => {
+    const browserManager = {
+      registerOffscreenGuest: vi.fn(),
+      unregisterGuest: vi.fn()
+    }
+    const backend = new OffscreenBrowserBackend(browserManager as never)
+
+    await backend.createTab({
+      browserPageId: 'page-zoom',
+      url: 'https://example.com',
+      worktreeId: 'wt'
+    })
+    const webContents = mocks.windows[0].webContents
+    expect(webContents.getZoomLevel()).toBe(0)
+
+    webContents.zoomLevel = 2
+    webContents.emit('dom-ready')
+    expect(webContents.getZoomLevel()).toBe(0)
+
+    await backend.closeTab('page-zoom')
   })
 })

--- a/src/main/browser/offscreen-browser-backend.ts
+++ b/src/main/browser/offscreen-browser-backend.ts
@@ -4,6 +4,7 @@ import { ORCA_BROWSER_PARTITION } from '../../shared/constants'
 import { ORCA_BROWSER_GUEST_WEB_PREFERENCES } from '../../shared/browser-guest-web-preferences'
 import type { BrowserBackend, BrowserBackendCreateTab } from './browser-backend'
 import type { BrowserManager } from './browser-manager'
+import { attachRemoteBrowserGuestPageZoomReassert } from './browser-guest-page-zoom'
 import { browserSessionRegistry } from './browser-session-registry'
 
 // Why: headless orca serve has no renderer window to host a <webview>, so each
@@ -19,6 +20,7 @@ const LOAD_TIMEOUT_MS = 30_000
 
 export class OffscreenBrowserBackend implements BrowserBackend {
   private readonly windowsByPageId = new Map<string, BrowserWindow>()
+  private readonly zoomReassertByPageId = new Map<string, () => void>()
 
   constructor(private readonly browserManager: BrowserManager) {}
 
@@ -50,11 +52,18 @@ export class OffscreenBrowserBackend implements BrowserBackend {
     })
 
     this.windowsByPageId.set(browserPageId, win)
+    // Why: remote/offscreen guests share the profile partition, so Chromium's
+    // per-origin HostZoomMap can inherit Cmd/+ from a local tab of the same host.
+    this.zoomReassertByPageId.set(
+      browserPageId,
+      attachRemoteBrowserGuestPageZoomReassert(win.webContents)
+    )
 
     // Why: if the offscreen window is destroyed out from under us (crash, app
     // teardown), drop the registry entry so commands fail cleanly instead of
     // resolving a dead WebContents.
     win.webContents.once('destroyed', () => {
+      this.detachZoomReassert(browserPageId)
       this.windowsByPageId.delete(browserPageId)
       this.browserManager.unregisterGuest(browserPageId)
     })
@@ -86,6 +95,7 @@ export class OffscreenBrowserBackend implements BrowserBackend {
 
   async closeTab(browserPageId: string): Promise<void> {
     const win = this.windowsByPageId.get(browserPageId)
+    this.detachZoomReassert(browserPageId)
     this.windowsByPageId.delete(browserPageId)
     this.browserManager.unregisterGuest(browserPageId)
     if (win && !win.isDestroyed()) {
@@ -100,12 +110,18 @@ export class OffscreenBrowserBackend implements BrowserBackend {
 
   destroyAll(): void {
     for (const [pageId, win] of this.windowsByPageId) {
+      this.detachZoomReassert(pageId)
       this.browserManager.unregisterGuest(pageId)
       if (!win.isDestroyed()) {
         win.destroy()
       }
     }
     this.windowsByPageId.clear()
+  }
+
+  private detachZoomReassert(browserPageId: string): void {
+    this.zoomReassertByPageId.get(browserPageId)?.()
+    this.zoomReassertByPageId.delete(browserPageId)
   }
 
   private async loadUrl(win: BrowserWindow, url: string): Promise<void> {

--- a/src/main/runtime/remote-browser-screencast-frame-admission.test.ts
+++ b/src/main/runtime/remote-browser-screencast-frame-admission.test.ts
@@ -24,7 +24,18 @@ function createMockWebContents() {
     attached = false
   })
   dbg.sendCommand = vi.fn(async () => ({}))
-  return { isDestroyed: vi.fn(() => false), debugger: dbg }
+  const emitter = new EventEmitter()
+  let zoomLevel = 0
+  return {
+    isDestroyed: vi.fn(() => false),
+    debugger: dbg,
+    on: emitter.on.bind(emitter),
+    off: emitter.off.bind(emitter),
+    getZoomLevel: () => zoomLevel,
+    setZoomLevel: (level: number) => {
+      zoomLevel = level
+    }
+  }
 }
 
 // Why: exercises the real E2EE channel so the oracle fails if an over-limit frame ever reaches

--- a/src/renderer/src/components/browser-pane/host-guest/browser-page-zoom.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/browser-page-zoom.ts
@@ -1,7 +1,7 @@
 import {
+  applyBrowserPageZoomLevel,
   DEFAULT_BROWSER_PAGE_ZOOM_LEVEL,
   nextBrowserPageZoomLevel,
-  normalizeBrowserPageZoomLevel,
   type BrowserPageZoomDirection
 } from '../../../../../shared/browser-page-zoom'
 
@@ -58,22 +58,7 @@ export function setBrowserPageZoomLevel(
   webview: BrowserPageZoomWebview | null | undefined,
   level: number
 ): number | null {
-  try {
-    if (!webview || webview.isDestroyed?.()) {
-      return null
-    }
-    const next = normalizeBrowserPageZoomLevel(level)
-    // Why compare first: Chromium's HostZoomMap is keyed by host per partition,
-    // so a no-op write still overwrites the host-wide zoom a sibling tab on the
-    // same hostname set. Only write when this pane actually needs to move.
-    if (normalizeBrowserPageZoomLevel(webview.getZoomLevel()) === next) {
-      return next
-    }
-    webview.setZoomLevel(next)
-    return next
-  } catch {
-    return null
-  }
+  return applyBrowserPageZoomLevel(webview, level)
 }
 
 // Why module-level: the guest webview outlives its React pane (a worktree

--- a/src/shared/browser-page-zoom.test.ts
+++ b/src/shared/browser-page-zoom.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest'
+import { applyBrowserPageZoomLevel, DEFAULT_BROWSER_PAGE_ZOOM_LEVEL } from './browser-page-zoom'
+
+describe('applyBrowserPageZoomLevel', () => {
+  it('writes a normalized level when the guest is not already there', () => {
+    const target = {
+      getZoomLevel: vi.fn(() => 3),
+      setZoomLevel: vi.fn()
+    }
+
+    expect(applyBrowserPageZoomLevel(target, DEFAULT_BROWSER_PAGE_ZOOM_LEVEL)).toBe(0)
+    expect(target.setZoomLevel).toHaveBeenCalledWith(0)
+  })
+
+  it('does not write when the guest is already at the requested level', () => {
+    const target = {
+      getZoomLevel: vi.fn(() => 0),
+      setZoomLevel: vi.fn()
+    }
+
+    expect(applyBrowserPageZoomLevel(target, 0)).toBe(0)
+    expect(target.setZoomLevel).not.toHaveBeenCalled()
+  })
+
+  it('returns null for a destroyed guest', () => {
+    const target = {
+      isDestroyed: () => true,
+      getZoomLevel: vi.fn(() => 3),
+      setZoomLevel: vi.fn()
+    }
+
+    expect(applyBrowserPageZoomLevel(target, 0)).toBeNull()
+    expect(target.setZoomLevel).not.toHaveBeenCalled()
+  })
+})

--- a/src/shared/browser-page-zoom.ts
+++ b/src/shared/browser-page-zoom.ts
@@ -40,3 +40,31 @@ export function nextBrowserPageZoomLevel(
 
   return normalizeBrowserPageZoomLevel(rawNext)
 }
+
+export type BrowserPageZoomTarget = {
+  getZoomLevel: () => number
+  setZoomLevel: (level: number) => void
+  isDestroyed?: () => boolean
+}
+
+export function applyBrowserPageZoomLevel(
+  target: BrowserPageZoomTarget | null | undefined,
+  level: number
+): number | null {
+  try {
+    if (!target || target.isDestroyed?.()) {
+      return null
+    }
+    const next = normalizeBrowserPageZoomLevel(level)
+    // Why compare first: Chromium's HostZoomMap is keyed by host per partition,
+    // so a no-op write still overwrites the host-wide zoom a sibling tab on the
+    // same hostname set. Only write when this target actually needs to move.
+    if (normalizeBrowserPageZoomLevel(target.getZoomLevel()) === next) {
+      return next
+    }
+    target.setZoomLevel(next)
+    return next
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## ELI5

Zoom a site in Orca on your Mac, then open that same site from a paired laptop or phone. The remote page comes in huge. This puts remote/offscreen pages back to 100%.

## What Changed

Local browser panes already reassert zoom on every load. Offscreen guests and screencast sessions did not. They now reset to 100% when the page is created, when screencast starts, and again on `dom-ready` / `did-finish-load`.

The write is skipped when the guest is already at 100%, matching the local HostZoomMap guard so a no-op does not clobber a sibling tab.

## Why

Chromium stores page zoom per origin per partition. A Cmd/+ on github.com locally is still sitting in that map when a paired client opens github.com through an offscreen or streamed guest. Cmd/0 on the remote pane never reached the guest.

## Linked Issue

Fixes #16675

## Visual Proof

Isolated Orca window, real `https://github.com/electron/electron`, `BrowserWindow.capturePage()`. Zoom level 3 (~173%) then 0 (100%).

Before:

![before](https://github.com/user-attachments/assets/67f08fa6-a781-425a-9aa0-97047eb4eca1)

After:

![after](https://github.com/user-attachments/assets/ad5ca87a-40a7-4e4b-b867-e2d37cf86048)

## Testing

- Unit tests for zoom apply/reassert, offscreen create, and screencast start.
- Isolated e2e Orca profile on macOS: opened GitHub in the real browser pane, set webview zoom to 3, captured the window, reset to 0, captured again.
- Did not use the running packaged Orca app.

### Reproduction (bug, without this branch)

1. On the host, open a local Orca browser tab to `https://github.com/electron/electron`.
2. Cmd++ a few times until the page is clearly zoomed.
3. Pair a remote client (another desktop, web client, or phone). Headless `orca serve` is the same path.
4. On the remote client, open a new browser tab to the same URL.
5. The remote page is zoomed in. GitHub's header overflows. Cmd/0 on the remote pane does not reset it.

### Reproduction (fix)

Same steps on this branch. The remote tab should open at 100%.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Cross-platform: offscreen guests are the headless Linux / `orca serve` path. Screencast is desktop, web, and mobile. SSH remote hosts use the same offscreen backend. Mixed client/host versions are fine: this is host-side `setZoomLevel`, no wire change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
