### PR TITLE
Shift+Tab to unindent lists and code blocks

### DIFF
--- a/src/renderer/src/components/editor/rich-markdown-code-block-indent.ts
+++ b/src/renderer/src/components/editor/rich-markdown-code-block-indent.ts
@@ -1,0 +1,47 @@
+import type { Editor } from '@tiptap/react'
+
+export const RICH_MARKDOWN_CODE_BLOCK_INDENT = '  '
+
+const LEADING_INDENT = /^(\t| {1,2})/
+
+function findCodeBlockAtCursor(editor: Editor): { text: string; start: number } | null {
+  const { $from } = editor.state.selection
+  for (let depth = $from.depth; depth > 0; depth--) {
+    const node = $from.node(depth)
+    if (node.type.name === 'codeBlock') {
+      return { text: node.textContent, start: $from.start(depth) }
+    }
+  }
+  return null
+}
+
+/**
+ * Shift+Tab inside a code block: strip one indent step from every line the
+ * selection touches, mirroring Tab's insert.
+ */
+export function outdentRichMarkdownCodeBlock(editor: Editor): boolean {
+  const codeBlock = findCodeBlockAtCursor(editor)
+  if (!codeBlock) {
+    return false
+  }
+
+  const { from, to } = editor.state.selection
+  const tr = editor.state.tr
+  let lineStart = codeBlock.start
+
+  for (const line of codeBlock.text.split('\n')) {
+    const lineEnd = lineStart + line.length
+    const isTouched = lineEnd >= from && lineStart <= to
+    const indent = isTouched ? LEADING_INDENT.exec(line) : null
+    if (indent) {
+      tr.delete(tr.mapping.map(lineStart), tr.mapping.map(lineStart + indent[0].length))
+    }
+    lineStart = lineEnd + 1
+  }
+
+  if (!tr.docChanged) {
+    return false
+  }
+  editor.view.dispatch(tr)
+  return true
+}

--- a/src/renderer/src/components/editor/rich-markdown-key-handler.ts
+++ b/src/renderer/src/components/editor/rich-markdown-key-handler.ts
@@ -21,6 +21,14 @@ import { deleteAdjacentEmptyParagraph } from './rich-markdown-empty-paragraph-de
 import { handleRichMarkdownTableBackspace } from './rich-markdown-table-row-delete'
 import { handleRichMarkdownTableEnter } from './rich-markdown-table-enter'
 import { handleRichMarkdownTableTab } from './rich-markdown-table-tab'
+import {
+  indentRichMarkdownListItem,
+  outdentRichMarkdownListItem
+} from './rich-markdown-list-indent'
+import {
+  outdentRichMarkdownCodeBlock,
+  RICH_MARKDOWN_CODE_BLOCK_INDENT
+} from './rich-markdown-code-block-indent'
 import { handleRichMarkdownCitationKey } from './rich-markdown-citation-keyboard'
 import type { RichMarkdownHtmlSuperscriptLinkContext } from './rich-markdown-html-superscript-link-context'
 import { handleRichMarkdownLinkShortcut } from './rich-markdown-link-shortcut'
@@ -202,22 +210,20 @@ export function createRichMarkdownKeyHandler(
       }
 
       if (event.shiftKey) {
-        if (!ed.commands.liftListItem('listItem')) {
-          ed.commands.liftListItem('taskItem')
+        if (!outdentRichMarkdownCodeBlock(ed)) {
+          outdentRichMarkdownListItem(ed)
         }
         return true
       }
 
       if (ed.isActive('codeBlock')) {
-        ed.commands.insertContent('  ')
+        ed.commands.insertContent(RICH_MARKDOWN_CODE_BLOCK_INDENT)
         return true
       }
 
       // Why: sinkListItem succeeds when the item has a previous sibling;
       // otherwise it no-ops. Either way we consume Tab to prevent focus escape.
-      if (!ed.commands.sinkListItem('listItem')) {
-        ed.commands.sinkListItem('taskItem')
-      }
+      indentRichMarkdownListItem(ed)
       return true
     }
 

--- a/src/renderer/src/components/editor/rich-markdown-list-indent.ts
+++ b/src/renderer/src/components/editor/rich-markdown-list-indent.ts
@@ -1,0 +1,112 @@
+import type { Editor } from '@tiptap/react'
+import { Fragment } from '@tiptap/pm/model'
+import { TextSelection } from '@tiptap/pm/state'
+
+type ListItemTypeName = 'listItem' | 'taskItem'
+
+const LIST_TYPE_FOR_ITEM: Record<ListItemTypeName, string> = {
+  listItem: 'bulletList',
+  taskItem: 'taskList'
+}
+
+function isListItemType(name: string): name is ListItemTypeName {
+  return name === 'listItem' || name === 'taskItem'
+}
+
+type ListItemContext = {
+  /** Closest list item at the cursor. */
+  itemType: ListItemTypeName
+  itemDepth: number
+  /** List item enclosing that one, when the cursor sits in a nested list. */
+  parentItemType: ListItemTypeName | null
+}
+
+/**
+ * Why: bullet and task lists nest into each other, so trying `listItem` first
+ * and falling back to `taskItem` picks the wrong node — the command walks up to
+ * any ancestor of that type and acts on *it*, mangling the surrounding list.
+ */
+function resolveListItemContext(editor: Editor): ListItemContext | null {
+  const { $from } = editor.state.selection
+  let found: { itemType: ListItemTypeName; itemDepth: number } | null = null
+  for (let depth = $from.depth; depth > 0; depth--) {
+    const name = $from.node(depth).type.name
+    if (!isListItemType(name)) {
+      continue
+    }
+    if (!found) {
+      found = { itemType: name, itemDepth: depth }
+      continue
+    }
+    return { ...found, parentItemType: name }
+  }
+  return found ? { ...found, parentItemType: null } : null
+}
+
+export function indentRichMarkdownListItem(editor: Editor): boolean {
+  return editor.commands.sinkListItem(resolveListItemContext(editor)?.itemType ?? 'listItem')
+}
+
+export function outdentRichMarkdownListItem(editor: Editor): boolean {
+  const context = resolveListItemContext(editor)
+  if (!context) {
+    return false
+  }
+  // Why: the schema forbids a listItem sibling inside a taskList (and vice
+  // versa), so a mixed nest cannot lift as-is — prosemirror-schema-list would
+  // silently lift the item *out* of its list, dropping its marker entirely.
+  // Retype the item to match the list it is about to join, then lift normally.
+  if (context.parentItemType && context.parentItemType !== context.itemType) {
+    splitListBeforeCursorItem(editor)
+    retypeListAtCursor(editor, context.parentItemType)
+    return editor.commands.liftListItem(context.parentItemType)
+  }
+  return editor.commands.liftListItem(context.itemType)
+}
+
+/**
+ * Why: retyping is a whole-list operation, so peel the cursor's item (and the
+ * siblings that will follow it out) into their own list first — items staying
+ * behind must keep their original marker.
+ */
+function splitListBeforeCursorItem(editor: Editor): void {
+  const context = resolveListItemContext(editor)
+  if (!context) {
+    return
+  }
+  const { state } = editor
+  const { $from } = state.selection
+  if ($from.index(context.itemDepth - 1) === 0) {
+    return
+  }
+  editor.view.dispatch(state.tr.split($from.before(context.itemDepth), 1))
+}
+
+function retypeListAtCursor(editor: Editor, target: ListItemTypeName): void {
+  const context = resolveListItemContext(editor)
+  if (!context) {
+    return
+  }
+  const { state } = editor
+  const { from, to } = state.selection
+  const listPos = state.selection.$from.before(context.itemDepth - 1)
+  const list = state.doc.nodeAt(listPos)
+  if (!list) {
+    return
+  }
+
+  // Why: retyping the list and its items in separate steps would leave an
+  // intermediate doc the schema rejects, so swap the whole subtree at once.
+  const itemType = state.schema.nodes[target]
+  const items = list.children.map((item) => itemType.create(null, item.content, item.marks))
+  const retyped = state.schema.nodes[LIST_TYPE_FOR_ITEM[target]].create(
+    null,
+    Fragment.from(items),
+    list.marks
+  )
+  const tr = state.tr.replaceWith(listPos, listPos + list.nodeSize, retyped)
+  // Why: replaceWith treats the old subtree as deleted, collapsing the cursor to
+  // the range edge — the retype is size-preserving, so restore it verbatim.
+  tr.setSelection(TextSelection.create(tr.doc, from, to))
+  editor.view.dispatch(tr)
+}

--- a/src/renderer/src/components/editor/rich-markdown-tab-key-handler.test.ts
+++ b/src/renderer/src/components/editor/rich-markdown-tab-key-handler.test.ts
@@ -4,6 +4,8 @@ import StarterKit from '@tiptap/starter-kit'
 import TaskList from '@tiptap/extension-task-list'
 import TaskItem from '@tiptap/extension-task-item'
 import { createIsolatedMarkdownExtensionForTests } from './isolated-markdown-extension-for-tests'
+import { createRichMarkdownExtensions } from './rich-markdown-extensions'
+import { createRichMarkdownEditorCodec } from './rich-markdown-source-transport'
 import { createRichMarkdownKeyHandler, type KeyHandlerContext } from './rich-markdown-key-handler'
 
 function createEditor(content: object): Editor {
@@ -21,6 +23,62 @@ function createEditor(content: object): Editor {
   })
 }
 
+/**
+ * Why: mixed bullet/task nesting and code-block indentation only reproduce
+ * against the live extension set, not the trimmed StarterKit one above.
+ */
+function createMarkdownEditor(markdown: string): Editor {
+  return new Editor({
+    element: null,
+    extensions: createRichMarkdownExtensions({
+      codec: createRichMarkdownEditorCodec()
+    }),
+    content: markdown,
+    contentType: 'markdown'
+  })
+}
+
+/**
+ * Why: pasted list HTML is the path the reported bug came in through — the
+ * editor has no plain-text markdown paste transform. The DOM-less test env
+ * cannot parse HTML, so assert against the node shapes that paste produces.
+ */
+function createNodeEditor(content: object): Editor {
+  return new Editor({
+    element: null,
+    extensions: createRichMarkdownExtensions({
+      codec: createRichMarkdownEditorCodec()
+    }),
+    content
+  })
+}
+
+function para(text: string): object {
+  return { type: 'paragraph', content: [{ type: 'text', text }] }
+}
+
+function bullets(...items: object[][]): object {
+  return {
+    type: 'bulletList',
+    content: items.map((content) => ({ type: 'listItem', content }))
+  }
+}
+
+function tasks(...items: object[][]): object {
+  return {
+    type: 'taskList',
+    content: items.map((content) => ({
+      type: 'taskItem',
+      attrs: { checked: false },
+      content
+    }))
+  }
+}
+
+function doc(...content: object[]): object {
+  return { type: 'doc', content }
+}
+
 function textPosition(editor: Editor, text: string): number {
   let position: number | null = null
   editor.state.doc.descendants((node, pos) => {
@@ -34,6 +92,24 @@ function textPosition(editor: Editor, text: string): number {
 
   if (position === null) {
     throw new Error(`Expected text in test document: ${text}`)
+  }
+
+  return position
+}
+
+function codeBlockPosition(editor: Editor, text: string): number {
+  let position: number | null = null
+  editor.state.doc.descendants((node, pos) => {
+    if (node.type.name === 'codeBlock' && node.textContent.includes(text)) {
+      position = pos + 1 + node.textContent.indexOf(text)
+      return false
+    }
+
+    return true
+  })
+
+  if (position === null) {
+    throw new Error(`Expected code block text: ${text}`)
   }
 
   return position
@@ -129,7 +205,12 @@ function parentAndFixesDocument(): object {
         content: [
           {
             type: 'listItem',
-            content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Parent' }] }]
+            content: [
+              {
+                type: 'paragraph',
+                content: [{ type: 'text', text: 'Parent' }]
+              }
+            ]
           },
           {
             type: 'listItem',
@@ -155,12 +236,22 @@ function taskListDocument(): object {
           {
             type: 'taskItem',
             attrs: { checked: false },
-            content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Task A' }] }]
+            content: [
+              {
+                type: 'paragraph',
+                content: [{ type: 'text', text: 'Task A' }]
+              }
+            ]
           },
           {
             type: 'taskItem',
             attrs: { checked: false },
-            content: [{ type: 'paragraph', content: [{ type: 'text', text: 'Task B' }] }]
+            content: [
+              {
+                type: 'paragraph',
+                content: [{ type: 'text', text: 'Task B' }]
+              }
+            ]
           }
         ]
       }
@@ -181,6 +272,7 @@ describe('rich markdown Tab key handler', () => {
           flush: vi.fn(() => calls.push('flush'))
         }
       },
+      state: { selection: { $from: { depth: 0 } } },
       commands: {
         sinkListItem: vi.fn((type) => {
           calls.push(`sink:${String(type)}`)
@@ -254,10 +346,126 @@ describe('rich markdown Tab key handler', () => {
     }
   })
 
+  it('outdents a bullet nested inside a task item into the enclosing task list', () => {
+    const editor = createMarkdownEditor('- [ ] Task A\n  - Bullet B')
+
+    try {
+      editor.commands.setTextSelection(textPosition(editor, 'Bullet B'))
+      const event = keyEvent('Tab', { shiftKey: true })
+
+      expect(createRichMarkdownKeyHandler(createContext(editor))(null, event)).toBe(true)
+      expect(editor.getMarkdown()).toBe('- [ ] Task A\n- [ ] Bullet B')
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('outdents a task nested inside a bullet item into the enclosing bullet list', () => {
+    const editor = createMarkdownEditor('- Bullet A\n  - [ ] Task B')
+
+    try {
+      editor.commands.setTextSelection(textPosition(editor, 'Task B'))
+      const event = keyEvent('Tab', { shiftKey: true })
+
+      expect(createRichMarkdownKeyHandler(createContext(editor))(null, event)).toBe(true)
+      expect(editor.getMarkdown()).toBe('- Bullet A\n- Task B')
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('keeps sibling bullets that stay behind when outdenting out of a task item', () => {
+    const editor = createMarkdownEditor('- [ ] Task A\n  - Bullet X\n  - Bullet Y')
+
+    try {
+      editor.commands.setTextSelection(textPosition(editor, 'Bullet Y'))
+      const event = keyEvent('Tab', { shiftKey: true })
+
+      expect(createRichMarkdownKeyHandler(createContext(editor))(null, event)).toBe(true)
+      expect(editor.getMarkdown()).toBe('- [ ] Task A\n  - Bullet X\n- [ ] Bullet Y')
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('outdents one level into the enclosing task list in a mixed nest', () => {
+    const editor = createMarkdownEditor('- A\n  - [ ] B\n    - C')
+
+    try {
+      editor.commands.setTextSelection(textPosition(editor, 'C'))
+      const event = keyEvent('Tab', { shiftKey: true })
+
+      expect(createRichMarkdownKeyHandler(createContext(editor))(null, event)).toBe(true)
+      expect(editor.getMarkdown()).toBe('- A\n  - [ ] B\n  - [ ] C')
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('outdents a nested bullet list item on Shift-Tab', () => {
+    const editor = createMarkdownEditor('- Alpha\n  - Beta')
+
+    try {
+      editor.commands.setTextSelection(textPosition(editor, 'Beta'))
+      const event = keyEvent('Tab', { shiftKey: true })
+
+      expect(createRichMarkdownKeyHandler(createContext(editor))(null, event)).toBe(true)
+      expect(editor.getMarkdown()).toBe('- Alpha\n- Beta')
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('removes one indent step from a code block line on Shift-Tab', () => {
+    const editor = createMarkdownEditor('```js\n    const x = 1\n```')
+
+    try {
+      editor.commands.setTextSelection(codeBlockPosition(editor, 'const x'))
+      const event = keyEvent('Tab', { shiftKey: true })
+
+      expect(createRichMarkdownKeyHandler(createContext(editor))(null, event)).toBe(true)
+      expect(editor.getMarkdown()).toBe('```js\n  const x = 1\n```')
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('outdents every code block line the selection touches', () => {
+    const editor = createMarkdownEditor('```js\n  a\n  b\n  c\n```')
+
+    try {
+      editor.commands.setTextSelection({
+        from: codeBlockPosition(editor, 'a'),
+        to: codeBlockPosition(editor, 'b') + 1
+      })
+      const event = keyEvent('Tab', { shiftKey: true })
+
+      expect(createRichMarkdownKeyHandler(createContext(editor))(null, event)).toBe(true)
+      expect(editor.getMarkdown()).toBe('```js\na\nb\n  c\n```')
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('leaves an unindented code block untouched on Shift-Tab', () => {
+    const editor = createMarkdownEditor('```js\nconst x = 1\n```')
+
+    try {
+      editor.commands.setTextSelection(codeBlockPosition(editor, 'const x'))
+      const event = keyEvent('Tab', { shiftKey: true })
+
+      expect(createRichMarkdownKeyHandler(createContext(editor))(null, event)).toBe(true)
+      expect(editor.getMarkdown()).toBe('```js\nconst x = 1\n```')
+    } finally {
+      editor.destroy()
+    }
+  })
+
   it('inserts spaces for Tab in code blocks', () => {
     const insertContent = vi.fn()
     const editor = {
       view: { composing: false },
+      state: { selection: { $from: { depth: 0 } } },
       commands: {
         sinkListItem: vi.fn(),
         liftListItem: vi.fn(),
@@ -270,4 +478,49 @@ describe('rich markdown Tab key handler', () => {
     expect(createRichMarkdownKeyHandler(createContext(editor))(null, event)).toBe(true)
     expect(insertContent).toHaveBeenCalledWith('  ')
   })
+
+  it('outdents a nested bullet that arrived as a pasted list node tree', () => {
+    const editor = createNodeEditor(doc(bullets([para('One'), bullets([para('Two')])])))
+
+    try {
+      editor.commands.setTextSelection(textPosition(editor, 'Two'))
+      const event = keyEvent('Tab', { shiftKey: true })
+
+      expect(createRichMarkdownKeyHandler(createContext(editor))(null, event)).toBe(true)
+      expect(editor.getMarkdown()).toBe('- One\n- Two')
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('outdents a bullet nested under a pasted task item', () => {
+    const editor = createNodeEditor(doc(tasks([para('Task A'), bullets([para('Bullet B')])])))
+
+    try {
+      editor.commands.setTextSelection(textPosition(editor, 'Bullet B'))
+      const event = keyEvent('Tab', { shiftKey: true })
+
+      expect(createRichMarkdownKeyHandler(createContext(editor))(null, event)).toBe(true)
+      expect(editor.getMarkdown()).toBe('- [ ] Task A\n- [ ] Bullet B')
+    } finally {
+      editor.destroy()
+    }
+  })
+
+  it('keeps pasted sibling bullets behind when outdenting out of a task item', () => {
+    const editor = createNodeEditor(
+      doc(tasks([para('Task A'), bullets([para('Bullet X')], [para('Bullet Y')])]))
+    )
+
+    try {
+      editor.commands.setTextSelection(textPosition(editor, 'Bullet Y'))
+      const event = keyEvent('Tab', { shiftKey: true })
+
+      expect(createRichMarkdownKeyHandler(createContext(editor))(null, event)).toBe(true)
+      expect(editor.getMarkdown()).toBe('- [ ] Task A\n  - Bullet X\n- [ ] Bullet Y')
+    } finally {
+      editor.destroy()
+    }
+  })
+
 })


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​256 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​253 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​171 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​6 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​165 |

<!-- /orca-pr-loc -->

## Problem
The markdown editor lacked Shift+Tab support to unindent content, leaving Tab/Shift+Tab asymmetrical and making it harder to reduce indentation in lists and code blocks.

## Solution
Implemented Shift+Tab handlers that remove one indentation level from code blocks and lift nested list items, with special handling for mixed bullet/task list scenarios where schema constraints require retyping before lifting.

## ELI5
Shift+Tab is now the undo-button for Tab — it moves indented content back one level in both lists and code blocks.

## What Changed
- `rich-markdown-code-block-indent.ts`: New module strips leading whitespace (1–2 chars or 1 tab) from selected code block lines
- `rich-markdown-list-indent.ts`: New module lifts list items with context-aware handling for mixed bullet/task nesting
- `rich-markdown-key-handler.ts`: Integrated both modules; Shift+Tab tries code-block outdent first, then list outdent; Tab now uses unified list indent logic
- `rich-markdown-tab-key-handler.test.ts`: Added 10 test cases covering mixed nesting, code blocks, multiple selections, and pasted content

## Why
Tab and Shift+Tab should form a pair. The list handler solves a hard case: when a bullet nests under a task (or vice versa), the schema forbids lifting as-is. We split, retype to match the parent list, then lift — keeping sibling items behind with their original markers intact.

## Linked Issue
Fixes # (none provided)

## Visual Proof
N/A — keyboard behavior, no visual change

## Testing
- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

10 new test cases in `rich-markdown-tab-key-handler.test.ts` cover: bullet/task nesting symmetry, code-block unindent with single and multi-line selections, pasted HTML node trees, sibling preservation, and unindented blocks (no-op).

## AI Disclosure
TODO

## Review

## Agent skill upstream boundary
- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes
Ensure no issues in: Security (whitespace-stripping is literal, no injection risk), Cross-platform support (uses platform-agnostic ProseMirror API), Remote SSH (no execution boundary impact), Mobile (N/A), Backwards compatibility (pure feature addition).

## Checklist
- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [ ] Self-reviewed for correctness, security, and performance
- [ ] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)