### PR TITLE
fix(agent-hooks): deliver hook events that fire while Orca is restarting (STA-5329)

### DIFF
--- a/src/main/agent-hooks/hook-script-outside-orca.test.ts
+++ b/src/main/agent-hooks/hook-script-outside-orca.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import { spawnSync } from 'node:child_process'
+import { chmodSync, mkdtempSync, readdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { _internals as codexInternals } from '../codex/hook-service'
+
+/** Managed hooks are installed into the user's agent config, so they also run when the
+ *  agent is launched from a plain terminal. There they must be inert and silent. */
+function runHook(dir: string, extraEnv: NodeJS.ProcessEnv = {}) {
+  const script = join(dir, 'codex-hook.sh')
+  writeFileSync(script, codexInternals.getManagedScript('posix'))
+  chmodSync(script, 0o755)
+  const clean: NodeJS.ProcessEnv = {}
+  for (const [k, v] of Object.entries(process.env)) {
+    if (!k.startsWith('ORCA_')) {
+      clean[k] = v
+    }
+  }
+  return spawnSync('/bin/sh', [script], {
+    input: '{"hook_event_name":"SubagentStop","agent_id":"child"}\n',
+    env: { ...clean, ...extraEnv },
+    timeout: 5000,
+    encoding: 'utf8'
+  })
+}
+
+describe('managed hook outside an Orca terminal', () => {
+  it('no Orca env at all: silent, exit 0, writes nothing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-outside-'))
+    const res = runHook(dir)
+    expect(res.status).toBe(0)
+    expect(res.stdout).toBe('')
+    expect(res.stderr).toBe('')
+    expect(readdirSync(dir)).toEqual(['codex-hook.sh'])
+  })
+
+  it('pane key present but no endpoint: still silent and writes nothing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-outside-partial-'))
+    const res = runHook(dir, { ORCA_PANE_KEY: 'tab:0', ORCA_TAB_ID: 'tab' })
+    expect(res.status).toBe(0)
+    expect(res.stdout).toBe('')
+    expect(res.stderr).toBe('')
+    expect(readdirSync(dir)).toEqual(['codex-hook.sh'])
+  })
+
+  it('endpoint points at a path that does not exist: silent, exit 0', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-outside-stale-'))
+    const res = runHook(dir, {
+      ORCA_AGENT_HOOK_ENDPOINT: join(dir, 'gone', 'deeper', 'endpoint.env'),
+      ORCA_PANE_KEY: 'tab:0'
+    })
+    expect(res.status).toBe(0)
+    expect(res.stdout).toBe('')
+    expect(res.stderr).toBe('')
+  })
+})

--- a/src/main/agent-hooks/hook-script-outside-orca.test.ts
+++ b/src/main/agent-hooks/hook-script-outside-orca.test.ts
@@ -57,6 +57,17 @@ describe('managed hook outside an Orca terminal', () => {
     // a stale env var must not create a spool tree for an Orca that is not installed here
     expect(readdirSync(dir)).toEqual(['codex-hook.sh'])
   })
+
+  it('readable endpoint without a pane key: silent, writes nothing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-outside-readable-'))
+    const endpoint = join(dir, 'endpoint.env')
+    writeFileSync(endpoint, 'ORCA_AGENT_HOOK_PORT=9\nORCA_AGENT_HOOK_TOKEN=stale\n')
+    const res = runHook(dir, { ORCA_AGENT_HOOK_ENDPOINT: endpoint })
+    expect(res.status).toBe(0)
+    expect(res.stdout).toBe('')
+    expect(res.stderr).toBe('')
+    expect(readdirSync(dir).sort()).toEqual(['codex-hook.sh', 'endpoint.env'])
+  })
 })
 
 describe('antigravity out-of-band event name', () => {

--- a/src/main/agent-hooks/hook-script-outside-orca.test.ts
+++ b/src/main/agent-hooks/hook-script-outside-orca.test.ts
@@ -4,6 +4,7 @@ import { chmodSync, mkdtempSync, readdirSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { _internals as codexInternals } from '../codex/hook-service'
+import { buildPosixHookSpoolLines } from './hook-stdin-contract'
 
 /** Managed hooks are installed into the user's agent config, so they also run when the
  *  agent is launched from a plain terminal. There they must be inert and silent. */
@@ -53,5 +54,18 @@ describe('managed hook outside an Orca terminal', () => {
     expect(res.status).toBe(0)
     expect(res.stdout).toBe('')
     expect(res.stderr).toBe('')
+    // a stale env var must not create a spool tree for an Orca that is not installed here
+    expect(readdirSync(dir)).toEqual(['codex-hook.sh'])
+  })
+})
+
+describe('antigravity out-of-band event name', () => {
+  it('records hookEventName and filters tool progress on it', () => {
+    const lines = buildPosixHookSpoolLines('antigravity', 'ORCA_ANTIGRAVITY_EVENT').join('\n')
+    expect(lines).toContain('"hookEventName":"%s"')
+    expect(lines).toContain('${ORCA_ANTIGRAVITY_EVENT:-}')
+    expect(lines).toContain('in PreToolUse|PostToolUse|PostToolUseFailure) return 0')
+    // payload-based filtering stays the default for every other provider
+    expect(buildPosixHookSpoolLines('codex').join('\n')).toContain('case "$payload" in')
   })
 })

--- a/src/main/agent-hooks/hook-stdin-contract.ts
+++ b/src/main/agent-hooks/hook-stdin-contract.ts
@@ -32,11 +32,11 @@ export function buildPosixHookSpoolLines(source: string, eventNameVar?: string):
   const eventArg = eventNameVar ? ` "$(spool_json_escape "\${${eventNameVar}:-}")"` : ''
   const spoolRecordLine = "  { printf '\\n{".concat(
     eventFormat,
-    '"paneKey":"%s","tabId":"%s","worktreeId":"%s","env":"%s","version":"%s","launchToken":"%s","source":"%s","receivedAt":%s,"payload":\'',
+    '"paneKey":"%s","tabId":"%s","worktreeId":"%s","env":"%s","version":"%s","launchToken":"%s","source":"%s","receivedAt":%s,"payload":%s}\\n\'',
     eventArg,
     ' "$(spool_json_escape "${ORCA_PANE_KEY:-}")" "$(spool_json_escape "${ORCA_TAB_ID:-}")" "$(spool_json_escape "${ORCA_WORKTREE_ID:-}")" "$(spool_json_escape "${ORCA_AGENT_HOOK_ENV:-}")" "$(spool_json_escape "${ORCA_AGENT_HOOK_VERSION:-}")" "$(spool_json_escape "${ORCA_AGENT_LAUNCH_TOKEN:-}")" "$(spool_json_escape "',
     source,
-    '")" "$spool_now"; printf "%s}\\n" "$payload"; } >> "$spool_file" 2>/dev/null || :'
+    '")" "$spool_now" "$payload"; } >> "$spool_file" 2>/dev/null || :'
   )
   return [
     'spool_hook_event() {',

--- a/src/main/agent-hooks/hook-stdin-contract.ts
+++ b/src/main/agent-hooks/hook-stdin-contract.ts
@@ -44,6 +44,9 @@ export function buildPosixHookSpoolLines(source: string, eventNameVar?: string):
       ? `  case "\${${eventNameVar}:-}" in PreToolUse|PostToolUse|PostToolUseFailure) return 0 ;; esac`
       : '  case "$payload" in *\'"PreToolUse"\'*|*\'"PostToolUse"\'*|*\'"PostToolUseFailure"\'*) return 0 ;; esac',
     '  [ -n "${ORCA_AGENT_HOOK_ENDPOINT:-}" ] || return 0',
+    // Why: an endpoint can linger in a parent shell after leaving Orca; without a pane key
+    // the record is un-attributable and would accumulate as pane-unknown.jsonl.
+    '  [ -n "${ORCA_PANE_KEY:-}" ] || return 0',
     // Why: a stale env var must not create a spool tree for an Orca that is not installed here.
     '  [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ] || return 0',
     '  spool_base=${ORCA_AGENT_HOOK_ENDPOINT%/*}',

--- a/src/main/agent-hooks/hook-stdin-contract.ts
+++ b/src/main/agent-hooks/hook-stdin-contract.ts
@@ -22,17 +22,30 @@ export function buildPosixHookPayloadCapture(
   ]
 }
 
-/** Shell-side durable fallback shared by every POSIX managed hook. */
-export function buildPosixHookSpoolLines(source: string): string[] {
-  const spoolRecordLine =
-    '  { printf \'\\n{"paneKey":"%s","tabId":"%s","worktreeId":"%s","env":"%s","version":"%s","launchToken":"%s","source":"%s","receivedAt":%s,"payload":\' "$(spool_json_escape "${ORCA_PANE_KEY:-}")" "$(spool_json_escape "${ORCA_TAB_ID:-}")" "$(spool_json_escape "${ORCA_WORKTREE_ID:-}")" "$(spool_json_escape "${ORCA_AGENT_HOOK_ENV:-}")" "$(spool_json_escape "${ORCA_AGENT_HOOK_VERSION:-}")" "$(spool_json_escape "${ORCA_AGENT_LAUNCH_TOKEN:-}")" "$(spool_json_escape "'.concat(
-      source,
-      '")" "$spool_now"; printf "%s}\\n" "$payload"; } >> "$spool_file" 2>/dev/null || :'
-    )
+/** Shell-side durable fallback shared by every POSIX managed hook.
+ *  `eventNameVar` is for providers that send the event name out-of-band rather than in the
+ *  payload JSON; without it both the progress filter and replay would miss the event name. */
+export function buildPosixHookSpoolLines(source: string, eventNameVar?: string): string[] {
+  // Why: the event name must be a printf ARG, not inlined in the single-quoted format,
+  // where a command substitution would be emitted literally.
+  const eventFormat = eventNameVar ? '"hookEventName":"%s",' : ''
+  const eventArg = eventNameVar ? ` "$(spool_json_escape "\${${eventNameVar}:-}")"` : ''
+  const spoolRecordLine = "  { printf '\\n{".concat(
+    eventFormat,
+    '"paneKey":"%s","tabId":"%s","worktreeId":"%s","env":"%s","version":"%s","launchToken":"%s","source":"%s","receivedAt":%s,"payload":\'',
+    eventArg,
+    ' "$(spool_json_escape "${ORCA_PANE_KEY:-}")" "$(spool_json_escape "${ORCA_TAB_ID:-}")" "$(spool_json_escape "${ORCA_WORKTREE_ID:-}")" "$(spool_json_escape "${ORCA_AGENT_HOOK_ENV:-}")" "$(spool_json_escape "${ORCA_AGENT_HOOK_VERSION:-}")" "$(spool_json_escape "${ORCA_AGENT_LAUNCH_TOKEN:-}")" "$(spool_json_escape "',
+    source,
+    '")" "$spool_now"; printf "%s}\\n" "$payload"; } >> "$spool_file" 2>/dev/null || :'
+  )
   return [
     'spool_hook_event() {',
-    '  case "$payload" in *\'"PreToolUse"\'*|*\'"PostToolUse"\'*|*\'"PostToolUseFailure"\'*) return 0 ;; esac',
+    eventNameVar
+      ? `  case "\${${eventNameVar}:-}" in PreToolUse|PostToolUse|PostToolUseFailure) return 0 ;; esac`
+      : '  case "$payload" in *\'"PreToolUse"\'*|*\'"PostToolUse"\'*|*\'"PostToolUseFailure"\'*) return 0 ;; esac',
     '  [ -n "${ORCA_AGENT_HOOK_ENDPOINT:-}" ] || return 0',
+    // Why: a stale env var must not create a spool tree for an Orca that is not installed here.
+    '  [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ] || return 0',
     '  spool_base=${ORCA_AGENT_HOOK_ENDPOINT%/*}',
     '  spool_dir="$spool_base/spool"',
     '  mkdir -p "$spool_dir" 2>/dev/null || return 0',

--- a/src/main/agent-hooks/hook-stdin-contract.ts
+++ b/src/main/agent-hooks/hook-stdin-contract.ts
@@ -22,6 +22,35 @@ export function buildPosixHookPayloadCapture(
   ]
 }
 
+/** Shell-side durable fallback shared by every POSIX managed hook. */
+export function buildPosixHookSpoolLines(source: string): string[] {
+  const spoolRecordLine =
+    '  { printf \'\\n{"paneKey":"%s","tabId":"%s","worktreeId":"%s","env":"%s","version":"%s","launchToken":"%s","source":"%s","receivedAt":%s,"payload":\' "$(spool_json_escape "${ORCA_PANE_KEY:-}")" "$(spool_json_escape "${ORCA_TAB_ID:-}")" "$(spool_json_escape "${ORCA_WORKTREE_ID:-}")" "$(spool_json_escape "${ORCA_AGENT_HOOK_ENV:-}")" "$(spool_json_escape "${ORCA_AGENT_HOOK_VERSION:-}")" "$(spool_json_escape "${ORCA_AGENT_LAUNCH_TOKEN:-}")" "$(spool_json_escape "'.concat(
+      source,
+      '")" "$spool_now"; printf "%s}\\n" "$payload"; } >> "$spool_file" 2>/dev/null || :'
+    )
+  return [
+    'spool_hook_event() {',
+    '  case "$payload" in *\'"PreToolUse"\'*|*\'"PostToolUse"\'*|*\'"PostToolUseFailure"\'*) return 0 ;; esac',
+    '  [ -n "${ORCA_AGENT_HOOK_ENDPOINT:-}" ] || return 0',
+    '  spool_base=${ORCA_AGENT_HOOK_ENDPOINT%/*}',
+    '  spool_dir="$spool_base/spool"',
+    '  mkdir -p "$spool_dir" 2>/dev/null || return 0',
+    '  chmod 700 "$spool_dir" 2>/dev/null || :',
+    "  spool_id=$(printf %s \"${ORCA_PANE_KEY:-unknown}\" | tail -c 36 | tr '/:' '__')",
+    '  spool_file="$spool_dir/pane-$spool_id.jsonl"',
+    '  if [ -f "$spool_file" ] && find "$spool_file" -mtime +7 -print -quit 2>/dev/null | grep -q .; then : > "$spool_file"; fi',
+    '  spool_size=$(wc -c < "$spool_file" 2>/dev/null || printf 0)',
+    '  [ "$spool_size" -lt 5242880 ] || return 0',
+    '  spool_now=$(date +%s 2>/dev/null || printf 0)',
+    '  spool_now=$((spool_now * 1000))',
+    '  spool_json_escape() { printf %s "$1" | sed \'s/\\\\/\\\\\\\\/g; s/"/\\\\"/g; s/[[:cntrl:]]/ /g\'; }',
+    spoolRecordLine,
+    '  chmod 600 "$spool_file" 2>/dev/null || :',
+    '}'
+  ]
+}
+
 export const WINDOWS_HOOK_STDIN_DRAIN_LABEL = 'orca_agent_hook_drain_stdin'
 // Why: qualify the stdin reader because Windows searches the worktree for
 // executables before PATH and hook payloads must not reach repo-local code.

--- a/src/main/agent-hooks/hook-stdin-contract.ts
+++ b/src/main/agent-hooks/hook-stdin-contract.ts
@@ -40,6 +40,7 @@ export function buildPosixHookSpoolLines(source: string): string[] {
     "  spool_id=$(printf %s \"${ORCA_PANE_KEY:-unknown}\" | tail -c 36 | tr '/:' '__')",
     '  spool_file="$spool_dir/pane-$spool_id.jsonl"',
     '  if [ -f "$spool_file" ] && find "$spool_file" -mtime +7 -print -quit 2>/dev/null | grep -q .; then : > "$spool_file"; fi',
+    '  [ -f "$spool_file" ] || : > "$spool_file"',
     '  spool_size=$(wc -c < "$spool_file" 2>/dev/null || printf 0)',
     '  [ "$spool_size" -lt 5242880 ] || return 0',
     '  spool_now=$(date +%s 2>/dev/null || printf 0)',

--- a/src/main/agent-hooks/server-relay-listener-replay.test.ts
+++ b/src/main/agent-hooks/server-relay-listener-replay.test.ts
@@ -63,6 +63,7 @@ describe('AgentHookServer listener replay', () => {
     send(restartedRelay, { hook_event_name: 'SubagentStop', agent_id: 'child-a' })
     expect(server.getStatusSnapshot()[0]).toMatchObject({
       state: 'working',
+      prompt: 'coordinate reviewers',
       model: 'gpt-5.4',
       providerSession: { key: 'session_id', id: 'root-session' },
       subagents: [expect.objectContaining({ id: 'child-b' })]

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -116,7 +116,12 @@ import {
   type AgentProviderSessionMetadata
 } from '../../shared/agent-session-resume'
 import { isCommandCodeNewTurnWhileWorking } from '../../shared/command-code-turn-boundary'
-import { drainAgentHookSpool, type SpoolRecord } from './spool'
+import {
+  buildSpoolHookBody,
+  drainAgentHookSpool,
+  launchTokenHash,
+  type SpoolRecord
+} from '../../shared/agent-hook-spool'
 
 export type { AgentHookSource }
 
@@ -806,6 +811,37 @@ export class AgentHookServer {
   private withdrawReplayObservation(paneKey: string): void {
     if (this.runtimeObservedStatusPaneKeys.delete(paneKey)) {
       this.notifyStatusChangeListeners()
+    }
+  }
+
+  private ingestSpoolRecord(record: SpoolRecord): void {
+    if (!isAgentHookSource(record.source)) {
+      return
+    }
+    const body = this.normalizeHookBodyPaneKeyAlias(buildSpoolHookBody(record))
+    const normalized = this.normalizeLocalHookPayload(record.source, body)
+    if (!normalized.event) {
+      return
+    }
+    const replay = { ...normalized.event, isReplay: true as const }
+    const statusDisposition = this.getAgentStatusDisposition(replay.paneKey, {
+      source: record.source,
+      hookEventName: replay.hookEventName,
+      isReplay: true,
+      hasExplicitPrompt: replay.hasExplicitPrompt,
+      launchToken: replay.launchToken
+    })
+    if (statusDisposition === 'suppress') {
+      return
+    }
+    const event = statusDisposition === 'restart' ? { ...replay, launchToken: undefined } : replay
+    if (statusDisposition === 'restart') {
+      this.observations.rebind(event.paneKey)
+    }
+    this.recordCurrentAuthorityObservation(event)
+    this.applyNormalizedStatus(event, normalized.onAccepted)
+    if (event.payload.state !== 'done') {
+      this.withdrawReplayObservation(this.resolvePaneKeyAlias(event.paneKey))
     }
   }
 
@@ -2294,6 +2330,14 @@ export class AgentHookServer {
     if (!parsedPaneKey) {
       return
     }
+    // Why: fence relay spool replay at main so stale generations cannot overwrite hydrated state.
+    if (envelope.isReplay === true) {
+      const expectedLaunchTokenHash = this.hydratedLaunchTokenHashByPaneKey.get(paneKey)
+      const actualLaunchTokenHash = launchTokenHash(envelope.launchToken)
+      if (expectedLaunchTokenHash && actualLaunchTokenHash !== expectedLaunchTokenHash) {
+        return
+      }
+    }
     if (envelope.tabId !== undefined && typeof envelope.tabId !== 'string') {
       return
     }
@@ -2529,16 +2573,7 @@ export class AgentHookServer {
         endpointDir: this.endpointDir,
         getPersistedLaunchTokenHash: (paneKey) =>
           this.hydratedLaunchTokenHashByPaneKey.get(this.resolvePaneKeyAlias(paneKey)),
-        ingest: (record: SpoolRecord) => {
-          this.ingestRemote(record as Parameters<AgentHookServer['ingestRemote']>[0], null)
-          if (
-            record.payload &&
-            typeof record.payload === 'object' &&
-            (record.payload as { state?: unknown }).state !== 'done'
-          ) {
-            this.withdrawReplayObservation(this.resolvePaneKeyAlias(record.paneKey))
-          }
-        }
+        ingest: (record: SpoolRecord) => this.ingestSpoolRecord(record)
       })
     }
     const handleRequest = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -802,6 +802,13 @@ export class AgentHookServer {
     }
   }
 
+  /** Replay is durable evidence from a prior runtime, not a live observation. */
+  private withdrawReplayObservation(paneKey: string): void {
+    if (this.runtimeObservedStatusPaneKeys.delete(paneKey)) {
+      this.notifyStatusChangeListeners()
+    }
+  }
+
   setPaneStatusClearListener(listener: PaneStatusClearListener | null): void {
     this.onPaneStatusCleared = listener
   }
@@ -2260,14 +2267,14 @@ export class AgentHookServer {
       claudeRunningNonAgentTask?: unknown
       payload: unknown
     },
-    connectionId: string
+    connectionId: string | null
   ): void {
     // Why: wire crosses a trust boundary — re-check/trim so an empty connectionId can't poison caches.
-    if (typeof connectionId !== 'string') {
+    if (connectionId !== null && typeof connectionId !== 'string') {
       return
     }
-    const trimmedConnectionId = connectionId.trim()
-    if (trimmedConnectionId.length === 0) {
+    const trimmedConnectionId = connectionId?.trim() ?? null
+    if (trimmedConnectionId !== null && trimmedConnectionId.length === 0) {
       return
     }
     if (!envelope || typeof envelope.paneKey !== 'string') {
@@ -2523,10 +2530,14 @@ export class AgentHookServer {
         getPersistedLaunchTokenHash: (paneKey) =>
           this.hydratedLaunchTokenHashByPaneKey.get(this.resolvePaneKeyAlias(paneKey)),
         ingest: (record: SpoolRecord) => {
-          this.ingestRemote(
-            record as Parameters<AgentHookServer['ingestRemote']>[0],
-            'spool-replay'
-          )
+          this.ingestRemote(record as Parameters<AgentHookServer['ingestRemote']>[0], null)
+          if (
+            record.payload &&
+            typeof record.payload === 'object' &&
+            (record.payload as { state?: unknown }).state !== 'done'
+          ) {
+            this.withdrawReplayObservation(this.resolvePaneKeyAlias(record.paneKey))
+          }
         }
       })
     }
@@ -3324,6 +3335,8 @@ export class AgentHookServer {
         restoredUnconfirmed: _restoredUnconfirmed,
         // Why: same — the sequencer that issued it dies with the process (see PersistedAgentHookEventPayload).
         observation: _observation,
+        // Replay provenance is runtime-only and must not survive another restart.
+        isReplay: _isReplay,
         launchToken,
         ...persistedPayload
       } = enrichedPayload

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -116,6 +116,7 @@ import {
   type AgentProviderSessionMetadata
 } from '../../shared/agent-session-resume'
 import { isCommandCodeNewTurnWhileWorking } from '../../shared/command-code-turn-boundary'
+import { drainAgentHookSpool, type SpoolRecord } from './spool'
 
 export type { AgentHookSource }
 
@@ -2515,6 +2516,20 @@ export class AgentHookServer {
       this.hydrateLastStatusFromDisk()
     }
     this.captureHydratedAuthorityCommitments()
+    // Drain before binding the listener so replay cannot race a live hook during startup.
+    if (this.endpointDir) {
+      drainAgentHookSpool({
+        endpointDir: this.endpointDir,
+        getPersistedLaunchTokenHash: (paneKey) =>
+          this.hydratedLaunchTokenHashByPaneKey.get(this.resolvePaneKeyAlias(paneKey)),
+        ingest: (record: SpoolRecord) => {
+          this.ingestRemote(
+            record as Parameters<AgentHookServer['ingestRemote']>[0],
+            'spool-replay'
+          )
+        }
+      })
+    }
     const handleRequest = async (req: IncomingMessage, res: ServerResponse): Promise<void> => {
       if (req.method !== 'POST') {
         res.writeHead(404)

--- a/src/main/agent-hooks/spool.test.ts
+++ b/src/main/agent-hooks/spool.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import { mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { drainAgentHookSpool, launchTokenHash, readSpoolRecords } from './spool'
+import { AgentHookServer, _internals } from './server'
+import { buildBody } from './server.test-fixtures'
+
+describe('agent hook spool', () => {
+  it('drops torn lines while retaining complete records', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-spool-'))
+    const file = join(dir, 'pane.jsonl')
+    writeFileSync(
+      file,
+      '\n{"paneKey":"tab:1","source":"codex","receivedAt":1,"payload":{}}\n{"paneKey":'
+    )
+    expect(readSpoolRecords(file, 1)).toHaveLength(1)
+  })
+
+  it('rejects stale launch tokens before ingest and truncates in place', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-spool-'))
+    const spool = join(dir, 'spool')
+    mkdirSync(spool)
+    const file = join(spool, 'pane-1.jsonl')
+    writeFileSync(
+      file,
+      `\n${JSON.stringify({ paneKey: 'tab:1', source: 'codex', launchToken: 'old', receivedAt: Date.now(), payload: { state: 'done' } })}\n`
+    )
+    const inode = statSync(file).ino
+    const ingested: unknown[] = []
+    drainAgentHookSpool({
+      endpointDir: dir,
+      getPersistedLaunchTokenHash: () => launchTokenHash('new')!,
+      ingest: (record) => ingested.push(record)
+    })
+    expect(ingested).toHaveLength(0)
+    expect(readFileSync(file)).toHaveLength(0)
+    expect(statSync(file).ino).toBe(inode)
+  })
+
+  it('ingests a record with the matching launch token', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-spool-'))
+    const spool = join(dir, 'spool')
+    mkdirSync(spool)
+    const file = join(spool, 'pane-1.jsonl')
+    writeFileSync(
+      file,
+      `\n${JSON.stringify({ paneKey: 'tab:1', source: 'codex', launchToken: 'same', receivedAt: Date.now(), payload: { state: 'done' } })}\n`
+    )
+    const ingested: unknown[] = []
+    drainAgentHookSpool({
+      endpointDir: dir,
+      getPersistedLaunchTokenHash: () => launchTokenHash('same')!,
+      ingest: (record) => ingested.push(record)
+    })
+    expect(ingested).toHaveLength(1)
+    expect(ingested[0]).toMatchObject({ paneKey: 'tab:1', isReplay: true })
+  })
+
+  it('replays a spooled Codex SubagentStop through the server after restart', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-spool-e2e-'))
+    const paneKey = 'tab-spool:0'
+    const launchToken = 'generation-token'
+    const first = new AgentHookServer()
+    await first.start({ env: 'production', userDataPath })
+    const started = _internals.normalizeHookPayload(
+      'codex',
+      buildBody({ hook_event_name: 'SubagentStart', agent_id: 'child-spooled' }),
+      'production'
+    )!
+    first.ingestRemote(
+      {
+        paneKey,
+        source: 'codex',
+        hookEventName: 'SubagentStart',
+        launchToken,
+        payload: started.payload
+      },
+      'spool-test'
+    )
+    first.flushStatusPersistSync()
+    first.stop()
+    const stopped = _internals.normalizeHookPayload(
+      'codex',
+      buildBody({ hook_event_name: 'SubagentStop', agent_id: 'child-spooled' }),
+      'production'
+    )!
+    const spoolDir = join(userDataPath, 'agent-hooks', 'spool')
+    mkdirSync(spoolDir, { recursive: true })
+    writeFileSync(
+      join(spoolDir, 'pane-tab-spooled_0.jsonl'),
+      `\n${JSON.stringify({ paneKey, source: 'codex', hookEventName: 'SubagentStop', launchToken, receivedAt: Date.now(), payload: stopped.payload })}\n`
+    )
+    const restarted = new AgentHookServer()
+    await restarted.start({ env: 'production', userDataPath })
+    try {
+      expect(restarted.getStatusSnapshot()[0]?.payload.subagents).toBeUndefined()
+    } finally {
+      restarted.stop()
+    }
+  })
+})

--- a/src/main/agent-hooks/spool.test.ts
+++ b/src/main/agent-hooks/spool.test.ts
@@ -15,6 +15,7 @@ import { drainAgentHookSpool, launchTokenHash, readSpoolRecords } from './spool'
 import { AgentHookServer, _internals } from './server'
 import { buildBody } from './server.test-fixtures'
 import { _internals as codexInternals } from '../codex/hook-service'
+import { makePaneKey } from '../../shared/stable-pane-id'
 
 describe('agent hook spool', () => {
   it('drops torn lines while retaining complete records', () => {
@@ -69,7 +70,7 @@ describe('agent hook spool', () => {
 
   it('replays a spooled Codex SubagentStop through the server after restart', async () => {
     const userDataPath = mkdtempSync(join(tmpdir(), 'orca-spool-e2e-'))
-    const paneKey = 'tab-spool:0'
+    const paneKey = makePaneKey('tab-spool', '00000000-0000-4000-8000-000000000001')
     const launchToken = 'generation-token'
     const first = new AgentHookServer()
     await first.start({ env: 'production', userDataPath })
@@ -88,6 +89,7 @@ describe('agent hook spool', () => {
       },
       'spool-test'
     )
+    expect(first.getStatusSnapshot()).toHaveLength(1)
     first.flushStatusPersistSync()
     first.stop()
     const stopped = _internals.normalizeHookPayload(
@@ -104,7 +106,11 @@ describe('agent hook spool', () => {
     const restarted = new AgentHookServer()
     await restarted.start({ env: 'production', userDataPath })
     try {
-      expect(restarted.getStatusSnapshot()[0]?.payload.subagents).toBeUndefined()
+      const snapshot = restarted.getStatusSnapshot()
+      expect(snapshot).toHaveLength(1)
+      expect(snapshot[0]!.subagents).toBeUndefined()
+      restarted.flushStatusPersistSync()
+      expect(readFileSync(restarted.lastStatusPath!, 'utf8')).not.toContain('isReplay')
     } finally {
       restarted.stop()
     }
@@ -138,5 +144,43 @@ describe('agent hook spool', () => {
     expect(readFileSync(join(endpointDir, 'spool', spoolFiles[0]!), 'utf8')).toContain(
       'SubagentStop'
     )
+  })
+
+  it('does not mark a non-terminal downtime replay as runtime-observed', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-spool-observed-'))
+    const paneKey = makePaneKey('tab-observed', '00000000-0000-4000-8000-000000000002')
+    const launchToken = 'observed-generation'
+    const first = new AgentHookServer()
+    await first.start({ env: 'production', userDataPath })
+    const started = _internals.normalizeHookPayload(
+      'codex',
+      buildBody({ hook_event_name: 'SubagentStart', agent_id: 'child-observed' }),
+      'production'
+    )!
+    first.ingestRemote(
+      {
+        paneKey,
+        source: 'codex',
+        hookEventName: 'SubagentStart',
+        launchToken,
+        payload: started.payload
+      },
+      null
+    )
+    first.flushStatusPersistSync()
+    first.stop()
+    const spoolDir = join(userDataPath, 'agent-hooks', 'spool')
+    mkdirSync(spoolDir, { recursive: true })
+    writeFileSync(
+      join(spoolDir, 'pane-observed.jsonl'),
+      `\n${JSON.stringify({ paneKey, source: 'codex', hookEventName: 'SubagentStart', launchToken, receivedAt: Date.now(), payload: started.payload })}\n`
+    )
+    const restarted = new AgentHookServer()
+    await restarted.start({ env: 'production', userDataPath })
+    try {
+      expect(restarted.getStatusChangeSnapshot()[0]?.observedInCurrentRuntime).toBe(false)
+    } finally {
+      restarted.stop()
+    }
   })
 })

--- a/src/main/agent-hooks/spool.test.ts
+++ b/src/main/agent-hooks/spool.test.ts
@@ -11,13 +11,28 @@ import {
 import { execFileSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { drainAgentHookSpool, launchTokenHash, readSpoolRecords } from './spool'
+import {
+  AGENT_HOOK_SPOOL_MAX_FILES,
+  drainAgentHookSpool,
+  launchTokenHash,
+  readSpoolRecords
+} from './spool'
 import { AgentHookServer, _internals } from './server'
 import { buildBody } from './server.test-fixtures'
 import { _internals as codexInternals } from '../codex/hook-service'
 import { makePaneKey } from '../../shared/stable-pane-id'
+import { buildPosixHookSpoolLines } from './hook-stdin-contract'
 
 describe('agent hook spool', () => {
+  it('appends each record with one printf write to prevent concurrent field interleaving', () => {
+    const spoolLine = buildPosixHookSpoolLines('codex').find((line) =>
+      line.includes('>> "$spool_file"')
+    )
+    expect(spoolLine).toBeDefined()
+    expect(spoolLine!.match(/printf/g)).toHaveLength(1)
+    expect(spoolLine).toContain('"$spool_now" "$payload"')
+  })
+
   it('drops torn lines while retaining complete records', () => {
     const dir = mkdtempSync(join(tmpdir(), 'orca-spool-'))
     const file = join(dir, 'pane.jsonl')
@@ -26,6 +41,28 @@ describe('agent hook spool', () => {
       '\n{"paneKey":"tab:1","source":"codex","receivedAt":1,"payload":{}}\n{"paneKey":'
     )
     expect(readSpoolRecords(file, 1)).toHaveLength(1)
+  })
+
+  it('does not let historical empty pane files starve newer records', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-spool-empty-files-'))
+    const spool = join(dir, 'spool')
+    mkdirSync(spool)
+    for (let index = 0; index < AGENT_HOOK_SPOOL_MAX_FILES; index += 1) {
+      writeFileSync(join(spool, `pane-empty-${index}.jsonl`), '')
+    }
+    const live = join(spool, 'pane-live.jsonl')
+    writeFileSync(
+      live,
+      `\n${JSON.stringify({ paneKey: 'tab:live', source: 'codex', receivedAt: Date.now(), payload: { state: 'done' } })}\n`
+    )
+    const ingested: SpoolRecord[] = []
+    drainAgentHookSpool({
+      endpointDir: dir,
+      getPersistedLaunchTokenHash: () => undefined,
+      ingest: (record) => ingested.push(record)
+    })
+    expect(ingested).toHaveLength(1)
+    expect(ingested[0]?.paneKey).toBe('tab:live')
   })
 
   it('rejects stale launch tokens before ingest and truncates in place', () => {

--- a/src/main/agent-hooks/spool.test.ts
+++ b/src/main/agent-hooks/spool.test.ts
@@ -15,7 +15,8 @@ import {
   AGENT_HOOK_SPOOL_MAX_FILES,
   drainAgentHookSpool,
   launchTokenHash,
-  readSpoolRecords
+  readSpoolRecords,
+  type SpoolRecord
 } from './spool'
 import { AgentHookServer, _internals } from './server'
 import { buildBody } from './server.test-fixtures'

--- a/src/main/agent-hooks/spool.test.ts
+++ b/src/main/agent-hooks/spool.test.ts
@@ -18,7 +18,7 @@ import {
   launchTokenHash,
   readSpoolRecords,
   type SpoolRecord
-} from './spool'
+} from '../../shared/agent-hook-spool'
 import { AgentHookServer, _internals } from './server'
 import { buildBody } from './server.test-fixtures'
 import { _internals as codexInternals } from '../codex/hook-service'
@@ -159,16 +159,11 @@ describe('agent hook spool', () => {
     expect(first.getStatusSnapshot()).toHaveLength(1)
     first.flushStatusPersistSync()
     first.stop()
-    const stopped = _internals.normalizeHookPayload(
-      'codex',
-      buildBody({ hook_event_name: 'SubagentStop', agent_id: 'child-spooled' }),
-      'production'
-    )!
     const spoolDir = join(userDataPath, 'agent-hooks', 'spool')
     mkdirSync(spoolDir, { recursive: true })
     writeFileSync(
       join(spoolDir, 'pane-tab-spooled_0.jsonl'),
-      `\n${JSON.stringify({ paneKey, source: 'codex', hookEventName: 'SubagentStop', launchToken, receivedAt: Date.now(), payload: stopped.payload })}\n`
+      `\n${JSON.stringify({ paneKey, source: 'codex', hookEventName: 'SubagentStop', launchToken, receivedAt: Date.now(), payload: { hook_event_name: 'SubagentStop', agent_id: 'child-spooled' } })}\n`
     )
     const restarted = new AgentHookServer()
     await restarted.start({ env: 'production', userDataPath })
@@ -180,6 +175,47 @@ describe('agent hook spool', () => {
       expect(readFileSync(restarted.lastStatusPath!, 'utf8')).not.toContain('isReplay')
     } finally {
       restarted.stop()
+    }
+  })
+
+  it('rejects a stale remote replay against the hydrated launch-token fence', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-spool-remote-fence-'))
+    const paneKey = makePaneKey('tab-remote-fence', '00000000-0000-4000-8000-000000000003')
+    const first = new AgentHookServer()
+    const second = new AgentHookServer()
+    try {
+      await first.start({ env: 'production', userDataPath })
+      first.ingestRemote(
+        {
+          paneKey,
+          source: 'codex',
+          launchToken: 'old-generation',
+          payload: { state: 'working', agentType: 'codex', prompt: 'old' }
+        },
+        'ssh-1'
+      )
+      first.flushStatusPersistSync()
+      first.stop()
+
+      await second.start({ env: 'production', userDataPath })
+      second.ingestRemote(
+        {
+          paneKey,
+          source: 'codex',
+          launchToken: 'new-generation',
+          isReplay: true,
+          payload: { state: 'done', agentType: 'codex', prompt: 'stale completion' }
+        },
+        'ssh-2'
+      )
+      expect(second.getStatusSnapshot()[0]).toMatchObject({
+        paneKey,
+        state: 'working',
+        prompt: 'old'
+      })
+    } finally {
+      first.stop()
+      second.stop()
     }
   })
 

--- a/src/main/agent-hooks/spool.test.ts
+++ b/src/main/agent-hooks/spool.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  appendFileSync,
   chmodSync,
   mkdirSync,
   mkdtempSync,
@@ -42,6 +43,34 @@ describe('agent hook spool', () => {
       '\n{"paneKey":"tab:1","source":"codex","receivedAt":1,"payload":{}}\n{"paneKey":'
     )
     expect(readSpoolRecords(file, 1)).toHaveLength(1)
+  })
+
+  it('waits for a newline before replaying a complete-looking final record', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-spool-unterminated-'))
+    const spool = join(dir, 'spool')
+    mkdirSync(spool)
+    const file = join(spool, 'pane-live.jsonl')
+    const record = JSON.stringify({
+      paneKey: 'tab:live',
+      source: 'codex',
+      receivedAt: Date.now(),
+      payload: { state: 'done' }
+    })
+    writeFileSync(file, record)
+    const ingested: SpoolRecord[] = []
+    const options = {
+      endpointDir: dir,
+      getPersistedLaunchTokenHash: () => undefined,
+      ingest: (value: SpoolRecord) => ingested.push(value)
+    }
+    expect(readSpoolRecords(file)).toHaveLength(0)
+    expect(drainAgentHookSpool(options)).toBe(0)
+    expect(readFileSync(file, 'utf8')).toBe(record)
+
+    appendFileSync(file, '\n')
+    expect(drainAgentHookSpool(options)).toBe(1)
+    expect(ingested).toHaveLength(1)
+    expect(readFileSync(file)).toHaveLength(0)
   })
 
   it('does not let historical empty pane files starve newer records', () => {

--- a/src/main/agent-hooks/spool.test.ts
+++ b/src/main/agent-hooks/spool.test.ts
@@ -1,10 +1,20 @@
 import { describe, expect, it } from 'vitest'
-import { mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs'
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync
+} from 'node:fs'
+import { execFileSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { drainAgentHookSpool, launchTokenHash, readSpoolRecords } from './spool'
 import { AgentHookServer, _internals } from './server'
 import { buildBody } from './server.test-fixtures'
+import { _internals as codexInternals } from '../codex/hook-service'
 
 describe('agent hook spool', () => {
   it('drops torn lines while retaining complete records', () => {
@@ -98,5 +108,35 @@ describe('agent hook spool', () => {
     } finally {
       restarted.stop()
     }
+  })
+
+  it('spools when the endpoint is present but the receiver is unavailable', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-spool-failure-'))
+    const endpointDir = join(dir, 'agent-hooks')
+    mkdirSync(endpointDir, { recursive: true })
+    const endpoint = join(endpointDir, 'endpoint.env')
+    writeFileSync(
+      endpoint,
+      'ORCA_AGENT_HOOK_PORT=9\nORCA_AGENT_HOOK_TOKEN=stale\nORCA_AGENT_HOOK_ENV=production\nORCA_AGENT_HOOK_VERSION=1\n'
+    )
+    const script = join(dir, 'codex-hook.sh')
+    writeFileSync(script, codexInternals.getManagedScript('posix'))
+    chmodSync(script, 0o755)
+    execFileSync('/bin/sh', [script], {
+      input: '{"hook_event_name":"SubagentStop","agent_id":"child"}\n',
+      env: {
+        ...process.env,
+        ORCA_AGENT_HOOK_ENDPOINT: endpoint,
+        ORCA_PANE_KEY: 'tab-failure:0',
+        ORCA_TAB_ID: 'tab-failure',
+        ORCA_AGENT_LAUNCH_TOKEN: 'generation-token'
+      },
+      timeout: 5000
+    })
+    const spoolFiles = readdirSync(join(endpointDir, 'spool'))
+    expect(spoolFiles).toHaveLength(1)
+    expect(readFileSync(join(endpointDir, 'spool', spoolFiles[0]!), 'utf8')).toContain(
+      'SubagentStop'
+    )
   })
 })

--- a/src/main/agent-hooks/spool.ts
+++ b/src/main/agent-hooks/spool.ts
@@ -105,7 +105,9 @@ export function drainAgentHookSpool(options: SpoolDrainOptions): number {
       const path = join(spoolDir, name)
       try {
         const stat = statSync(path)
-        return stat.isFile() ? { path, mtimeMs: stat.mtimeMs } : null
+        // Empty files are retained to keep append handles race-safe, but they must not
+        // consume the bounded replay candidate set ahead of files with durable events.
+        return stat.isFile() && stat.size > 0 ? { path, mtimeMs: stat.mtimeMs } : null
       } catch {
         return null
       }

--- a/src/main/agent-hooks/spool.ts
+++ b/src/main/agent-hooks/spool.ts
@@ -5,8 +5,10 @@ import {
   ftruncateSync,
   openSync,
   readFileSync,
+  readSync,
   readdirSync,
-  statSync
+  statSync,
+  writeSync
 } from 'node:fs'
 import { join } from 'node:path'
 
@@ -33,19 +35,32 @@ export function launchTokenHash(token: string | undefined): string | null {
 }
 
 export function readSpoolRecords(path: string, now = Date.now()): SpoolRecord[] {
+  return readSpoolFile(path, now).records
+}
+
+/** Records plus the byte offset through the last COMPLETE line. A torn trailing line is
+ *  left unconsumed so a writer still finishing it is not truncated away. */
+export function readSpoolFile(
+  path: string,
+  now = Date.now()
+): { records: SpoolRecord[]; consumed: number } {
   let bytes: Buffer
   try {
     bytes = readFileSync(path)
   } catch {
-    return []
+    return { records: [], consumed: 0 }
   }
   const records: SpoolRecord[] = []
+  let consumed = 0
   let start = 0
   for (let end = 0; end <= bytes.length; end += 1) {
     if (end !== bytes.length && bytes[end] !== 0x0a) {
       continue
     }
     const lineBytes = bytes.subarray(start, end)
+    if (end !== bytes.length) {
+      consumed = end + 1
+    }
     start = end + 1
     if (lineBytes.length === 0) {
       continue
@@ -65,7 +80,7 @@ export function readSpoolRecords(path: string, now = Date.now()): SpoolRecord[] 
       // Torn lines are discarded while later complete lines remain replayable.
     }
   }
-  return records
+  return { records, consumed }
 }
 
 export type SpoolDrainOptions = {
@@ -100,7 +115,8 @@ export function drainAgentHookSpool(options: SpoolDrainOptions): number {
     .slice(0, AGENT_HOOK_SPOOL_MAX_FILES)
   let drained = 0
   for (const candidate of candidates) {
-    for (const record of readSpoolRecords(candidate.path, now)) {
+    const { records, consumed } = readSpoolFile(candidate.path, now)
+    for (const record of records) {
       const expected = options.getPersistedLaunchTokenHash(record.paneKey)
       const actual = launchTokenHash(record.launchToken)
       if (expected && actual !== expected) {
@@ -113,10 +129,18 @@ export function drainAgentHookSpool(options: SpoolDrainOptions): number {
       const fd = openSync(candidate.path, 'r+')
       try {
         // Keep the inode so a concurrent append handle cannot silently orphan writes.
-        ftruncateSync(fd, 0)
+        const size = fstatSync(fd).size
+        if (size > consumed) {
+          // Why: a hook may have appended between the read and here; shift the unread tail
+          // to the front instead of truncating to zero, which would erase it.
+          const tail = Buffer.alloc(size - consumed)
+          readSync(fd, tail, 0, tail.length, consumed)
+          writeSync(fd, tail, 0, tail.length, 0)
+          ftruncateSync(fd, tail.length)
+        } else {
+          ftruncateSync(fd, 0)
+        }
       } finally {
-        // fstat keeps the descriptor operation observable in tests and documents the inode contract.
-        fstatSync(fd)
         closeSync(fd)
       }
     } catch {

--- a/src/main/agent-hooks/spool.ts
+++ b/src/main/agent-hooks/spool.ts
@@ -57,6 +57,11 @@ export function readSpoolFile(
     if (end !== bytes.length && bytes[end] !== 0x0a) {
       continue
     }
+    // A final line without its newline may still be in flight from a hook writer.
+    // Leave it untouched until the writer terminates the record explicitly.
+    if (end === bytes.length && (end === 0 || bytes[end - 1] !== 0x0a)) {
+      break
+    }
     const lineBytes = bytes.subarray(start, end)
     if (end !== bytes.length) {
       consumed = end + 1

--- a/src/main/agent-hooks/spool.ts
+++ b/src/main/agent-hooks/spool.ts
@@ -1,0 +1,127 @@
+import { createHash } from 'node:crypto'
+import {
+  closeSync,
+  fstatSync,
+  ftruncateSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  statSync
+} from 'node:fs'
+import { join } from 'node:path'
+
+export const AGENT_HOOK_SPOOL_MAX_BYTES = 5 * 1024 * 1024
+export const AGENT_HOOK_SPOOL_MAX_FILES = 1024
+export const AGENT_HOOK_SPOOL_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000
+
+export type SpoolRecord = {
+  paneKey: string
+  tabId?: string
+  worktreeId?: string
+  env?: string
+  version?: string
+  launchToken?: string
+  hookEventName?: string
+  source: string
+  payload: unknown
+  receivedAt: number
+  [key: string]: unknown
+}
+
+export function launchTokenHash(token: string | undefined): string | null {
+  return token?.trim() ? createHash('sha256').update(token.trim()).digest('hex') : null
+}
+
+export function readSpoolRecords(path: string, now = Date.now()): SpoolRecord[] {
+  let bytes: Buffer
+  try {
+    bytes = readFileSync(path)
+  } catch {
+    return []
+  }
+  const records: SpoolRecord[] = []
+  let start = 0
+  for (let end = 0; end <= bytes.length; end += 1) {
+    if (end !== bytes.length && bytes[end] !== 0x0a) {
+      continue
+    }
+    const lineBytes = bytes.subarray(start, end)
+    start = end + 1
+    if (lineBytes.length === 0) {
+      continue
+    }
+    try {
+      const value = JSON.parse(lineBytes.toString('utf8')) as Partial<SpoolRecord>
+      if (
+        typeof value.paneKey === 'string' &&
+        typeof value.source === 'string' &&
+        value.payload !== undefined &&
+        typeof value.receivedAt === 'number' &&
+        value.receivedAt >= now - AGENT_HOOK_SPOOL_MAX_AGE_MS
+      ) {
+        records.push(value as SpoolRecord)
+      }
+    } catch {
+      // Torn lines are discarded while later complete lines remain replayable.
+    }
+  }
+  return records
+}
+
+export type SpoolDrainOptions = {
+  endpointDir: string
+  getPersistedLaunchTokenHash: (paneKey: string) => string | undefined
+  ingest: (record: SpoolRecord) => void
+  now?: number
+}
+
+/** Drain JSONL files in place; never replace or unlink an inode held by a hook writer. */
+export function drainAgentHookSpool(options: SpoolDrainOptions): number {
+  const spoolDir = join(options.endpointDir, 'spool')
+  let names: string[]
+  try {
+    names = readdirSync(spoolDir)
+  } catch {
+    return 0
+  }
+  const now = options.now ?? Date.now()
+  const candidates = names
+    .map((name) => {
+      const path = join(spoolDir, name)
+      try {
+        const stat = statSync(path)
+        return stat.isFile() ? { path, mtimeMs: stat.mtimeMs } : null
+      } catch {
+        return null
+      }
+    })
+    .filter((entry): entry is { path: string; mtimeMs: number } => entry !== null)
+    .sort((a, b) => a.mtimeMs - b.mtimeMs)
+    .slice(0, AGENT_HOOK_SPOOL_MAX_FILES)
+  let drained = 0
+  for (const candidate of candidates) {
+    for (const record of readSpoolRecords(candidate.path, now)) {
+      const expected = options.getPersistedLaunchTokenHash(record.paneKey)
+      const actual = launchTokenHash(record.launchToken)
+      if (expected && actual !== expected) {
+        continue
+      }
+      options.ingest({ ...record, isReplay: true })
+      drained += 1
+    }
+    try {
+      const fd = openSync(candidate.path, 'r+')
+      try {
+        // Keep the inode so a concurrent append handle cannot silently orphan writes.
+        ftruncateSync(fd, 0)
+      } finally {
+        // fstat keeps the descriptor operation observable in tests and documents the inode contract.
+        fstatSync(fd)
+        closeSync(fd)
+      }
+    } catch {
+      // A concurrently removed or inaccessible file is harmless; the next launch retries it.
+    }
+  }
+  return drained
+}

--- a/src/main/antigravity/hook-script.ts
+++ b/src/main/antigravity/hook-script.ts
@@ -56,7 +56,7 @@ export function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     // Why: some Antigravity events arrive without stdin but still need a
     // status post, so the shared capture maps empty input to an object.
     ...buildPosixHookPayloadCapture('empty-object'),
-    ...buildPosixHookSpoolLines('antigravity'),
+    ...buildPosixHookSpoolLines('antigravity', 'ORCA_ANTIGRAVITY_EVENT'),
     'if [ -n "$ORCA_AGENT_HOOK_ENDPOINT" ] && [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ]; then',
     '  . "$ORCA_AGENT_HOOK_ENDPOINT" 2>/dev/null || :',
     'fi',

--- a/src/main/antigravity/hook-script.ts
+++ b/src/main/antigravity/hook-script.ts
@@ -1,5 +1,6 @@
 import {
   buildPosixHookPayloadCapture,
+  buildPosixHookSpoolLines,
   buildWindowsHookEnvironmentGuardLines,
   buildWindowsHookStdinDrainEpilogue,
   WINDOWS_HOOK_STDIN_DRAIN_COMMAND
@@ -55,10 +56,12 @@ export function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     // Why: some Antigravity events arrive without stdin but still need a
     // status post, so the shared capture maps empty input to an object.
     ...buildPosixHookPayloadCapture('empty-object'),
+    ...buildPosixHookSpoolLines('antigravity'),
     'if [ -n "$ORCA_AGENT_HOOK_ENDPOINT" ] && [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ]; then',
     '  . "$ORCA_AGENT_HOOK_ENDPOINT" 2>/dev/null || :',
     'fi',
     'if [ -z "$ORCA_AGENT_HOOK_PORT" ] || [ -z "$ORCA_AGENT_HOOK_TOKEN" ] || [ -z "$ORCA_PANE_KEY" ]; then',
+    '  spool_hook_event',
     '  exit 0',
     'fi',
     // Timeout caps best-effort hook posts if the local listener stalls.
@@ -76,7 +79,7 @@ export function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     '  --data-urlencode "env=${ORCA_AGENT_HOOK_ENV}" \\',
     '  --data-urlencode "version=${ORCA_AGENT_HOOK_VERSION}" \\',
     '  --data-urlencode "hook_event_name=${ORCA_ANTIGRAVITY_EVENT}" \\',
-    '  --data-urlencode "payload@-" >/dev/null 2>&1 || true',
+    '  --data-urlencode "payload@-" >/dev/null 2>&1 || spool_hook_event',
     'exit 0',
     ''
   ].join('\n')

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -97,7 +97,7 @@ function getManagedScript(
     // Why: Claude-compatible permission hooks fail closed on empty stdout (#14818).
     'printf "{}\\n"',
     ...buildPosixHookPayloadCapture(),
-    ...buildPosixHookSpoolLines(options.agent),
+    ...buildPosixHookSpoolLines('claude'),
     ...(options.skipWhenDevinImportsClaude
       ? [
           // Why: Devin imports .claude hooks by default; skip Orca's managed hook there so status posts stay attributed to Devin.

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -17,6 +17,7 @@ import {
 import { refreshManagedScriptIfPresent } from '../agent-hooks/managed-hook-script-refresh'
 import {
   buildPosixHookPayloadCapture,
+  buildPosixHookSpoolLines,
   buildWindowsHookEnvironmentGuardLines,
   buildWindowsHookStdinDrainEpilogue,
   WINDOWS_HOOK_STDIN_DRAIN_LABEL
@@ -96,6 +97,7 @@ function getManagedScript(
     // Why: Claude-compatible permission hooks fail closed on empty stdout (#14818).
     'printf "{}\\n"',
     ...buildPosixHookPayloadCapture(),
+    ...buildPosixHookSpoolLines(options.agent),
     ...(options.skipWhenDevinImportsClaude
       ? [
           // Why: Devin imports .claude hooks by default; skip Orca's managed hook there so status posts stay attributed to Devin.
@@ -115,6 +117,7 @@ function getManagedScript(
     '  . "$ORCA_AGENT_HOOK_ENDPOINT" 2>/dev/null || :',
     'fi',
     'if [ -z "$ORCA_AGENT_HOOK_PORT" ] || [ -z "$ORCA_AGENT_HOOK_TOKEN" ] || [ -z "$ORCA_PANE_KEY" ]; then',
+    '  spool_hook_event',
     '  exit 0',
     'fi',
     // Why: post form fields because path-bearing payloads are unsafe in hand-built JSON.
@@ -129,7 +132,7 @@ function getManagedScript(
     '  --data-urlencode "worktreeId=${ORCA_WORKTREE_ID}" \\',
     '  --data-urlencode "env=${ORCA_AGENT_HOOK_ENV}" \\',
     '  --data-urlencode "version=${ORCA_AGENT_HOOK_VERSION}" \\',
-    '  --data-urlencode "payload@-" >/dev/null 2>&1 || true',
+    '  --data-urlencode "payload@-" >/dev/null 2>&1 || spool_hook_event',
     'exit 0',
     ''
   ].join('\n')

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -31,6 +31,7 @@ import {
 } from '../agent-hooks/installer-utils-remote'
 import {
   buildPosixHookPayloadCapture,
+  buildPosixHookSpoolLines,
   buildWindowsHookEnvironmentGuardLines,
   buildWindowsHookStdinDrainEpilogue,
   POSIX_HOOK_STDIN_DRAIN_COMMAND
@@ -794,6 +795,7 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
   return [
     '#!/bin/sh',
     ...buildPosixHookPayloadCapture(),
+    ...buildPosixHookSpoolLines('codex'),
     // Why: sourcing refreshes PORT/TOKEN/ENV/VERSION from the current Orca so a surviving PTY keeps reporting after a restart (see claude/hook-service.ts).
     'load_hook_endpoint() {',
     '  endpoint_path="$1"',
@@ -820,6 +822,7 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     '  load_hook_endpoint "$ORCA_AGENT_HOOK_ENDPOINT"',
     'fi',
     'if [ -z "$ORCA_AGENT_HOOK_PORT" ] || [ -z "$ORCA_AGENT_HOOK_TOKEN" ] || [ -z "$ORCA_PANE_KEY" ]; then',
+    '  spool_hook_event',
     '  exit 0',
     'fi',
     'post_codex_hook() {',

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -854,9 +854,13 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     'if is_wsl_runtime; then',
     '  windows_curl=$(command -v curl.exe 2>/dev/null || true)',
     '  if [ -n "$windows_curl" ] && [ -x "$windows_curl" ]; then',
-    '    post_codex_hook "$windows_curl" 3 5 >/dev/null 2>&1 || true',
+    '    if post_codex_hook "$windows_curl" 3 5 >/dev/null 2>&1; then',
+    '      exit 0',
+    '    fi',
+    '    # post_codex_hook "$windows_curl" 3 5 >/dev/null 2>&1 || true',
     '  fi',
     'fi',
+    'spool_hook_event',
     'exit 0',
     ''
   ].join('\n')

--- a/src/main/command-code/command-code-managed-script.ts
+++ b/src/main/command-code/command-code-managed-script.ts
@@ -1,6 +1,7 @@
 import { buildWindowsAgentHookPostCommand } from '../agent-hooks/installer-utils'
 import {
   buildPosixHookPayloadCapture,
+  buildPosixHookSpoolLines,
   buildWindowsHookEnvironmentGuardLines,
   buildWindowsHookStdinDrainEpilogue
 } from '../agent-hooks/hook-stdin-contract'
@@ -36,6 +37,7 @@ export function buildCommandCodeManagedScript(
   return [
     '#!/bin/sh',
     ...buildPosixHookPayloadCapture(),
+    ...buildPosixHookSpoolLines('command-code'),
     '__orca_read_ancestor_var() {',
     '  __orca_name="$1"',
     '  __orca_pid="${PPID:-}"',
@@ -119,6 +121,7 @@ export function buildCommandCodeManagedScript(
     '  done',
     'fi',
     'if [ -z "$ORCA_AGENT_HOOK_PORT" ] || [ -z "$ORCA_AGENT_HOOK_TOKEN" ] || [ -z "$ORCA_PANE_KEY" ]; then',
+    '  spool_hook_event',
     '  exit 0',
     'fi',
     // Timeout caps best-effort hook posts if the local listener stalls.
@@ -135,7 +138,7 @@ export function buildCommandCodeManagedScript(
     '  --data-urlencode "worktreeId=${ORCA_WORKTREE_ID}" \\',
     '  --data-urlencode "env=${ORCA_AGENT_HOOK_ENV}" \\',
     '  --data-urlencode "version=${ORCA_AGENT_HOOK_VERSION}" \\',
-    '  --data-urlencode "payload@-" >/dev/null 2>&1 || true',
+    '  --data-urlencode "payload@-" >/dev/null 2>&1 || spool_hook_event',
     'exit 0',
     ''
   ].join('\n')

--- a/src/main/copilot/copilot-managed-script.ts
+++ b/src/main/copilot/copilot-managed-script.ts
@@ -1,5 +1,8 @@
 import { getSharedManagedScriptPath } from '../agent-hooks/installer-utils'
-import { buildPosixHookPayloadCapture } from '../agent-hooks/hook-stdin-contract'
+import {
+  buildPosixHookPayloadCapture,
+  buildPosixHookSpoolLines
+} from '../agent-hooks/hook-stdin-contract'
 
 export function getManagedScriptFileName(): string {
   return process.platform === 'win32' ? 'copilot-hook.ps1' : 'copilot-hook.sh'
@@ -53,12 +56,14 @@ export function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     '#!/bin/sh',
     "printf '{}\\n'",
     ...buildPosixHookPayloadCapture(),
+    ...buildPosixHookSpoolLines('copilot'),
     // Why: Copilot consumes stdout for some hooks, so stdout is emitted before
     // endpoint refresh, stdin parsing, or the network POST can fail.
     'if [ -n "$ORCA_AGENT_HOOK_ENDPOINT" ] && [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ]; then',
     '  . "$ORCA_AGENT_HOOK_ENDPOINT" 2>/dev/null || :',
     'fi',
     'if [ -z "$ORCA_AGENT_HOOK_PORT" ] || [ -z "$ORCA_AGENT_HOOK_TOKEN" ] || [ -z "$ORCA_PANE_KEY" ]; then',
+    '  spool_hook_event',
     '  exit 0',
     'fi',
     // Why: pipe payload to curl's stdin (`payload@-`) instead of an inline
@@ -75,7 +80,7 @@ export function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     '  --data-urlencode "hookEventName=${ORCA_COPILOT_HOOK_EVENT}" \\',
     '  --data-urlencode "env=${ORCA_AGENT_HOOK_ENV}" \\',
     '  --data-urlencode "version=${ORCA_AGENT_HOOK_VERSION}" \\',
-    '  --data-urlencode "payload@-" >/dev/null 2>&1 || true',
+    '  --data-urlencode "payload@-" >/dev/null 2>&1 || spool_hook_event',
     'exit 0',
     ''
   ].join('\n')

--- a/src/main/cursor/hook-service.ts
+++ b/src/main/cursor/hook-service.ts
@@ -23,6 +23,7 @@ import {
 } from '../agent-hooks/installer-utils-remote'
 import {
   buildPosixHookPayloadCapture,
+  buildPosixHookSpoolLines,
   buildWindowsHookEnvironmentGuardLines,
   buildWindowsHookStdinDrainEpilogue
 } from '../agent-hooks/hook-stdin-contract'
@@ -76,11 +77,13 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
   return [
     '#!/bin/sh',
     ...buildPosixHookPayloadCapture(),
+    ...buildPosixHookSpoolLines('cursor'),
     // Why: refresh endpoint coordinates so surviving PTYs keep reporting.
     'if [ -n "$ORCA_AGENT_HOOK_ENDPOINT" ] && [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ]; then',
     '  . "$ORCA_AGENT_HOOK_ENDPOINT" 2>/dev/null || :',
     'fi',
     'if [ -z "$ORCA_AGENT_HOOK_PORT" ] || [ -z "$ORCA_AGENT_HOOK_TOKEN" ] || [ -z "$ORCA_PANE_KEY" ]; then',
+    '  spool_hook_event',
     '  exit 0',
     'fi',
     // Why: post form fields because path-bearing worktree IDs are unsafe in hand-built JSON.
@@ -95,7 +98,7 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     '  --data-urlencode "worktreeId=${ORCA_WORKTREE_ID}" \\',
     '  --data-urlencode "env=${ORCA_AGENT_HOOK_ENV}" \\',
     '  --data-urlencode "version=${ORCA_AGENT_HOOK_VERSION}" \\',
-    '  --data-urlencode "payload@-" >/dev/null 2>&1 || true',
+    '  --data-urlencode "payload@-" >/dev/null 2>&1 || spool_hook_event',
     'exit 0',
     ''
   ].join('\n')

--- a/src/main/devin/hook-service.ts
+++ b/src/main/devin/hook-service.ts
@@ -13,6 +13,7 @@ import {
 } from '../agent-hooks/installer-utils-remote'
 import {
   buildPosixHookPayloadCapture,
+  buildPosixHookSpoolLines,
   buildWindowsHookEnvironmentGuardLines,
   buildWindowsHookStdinDrainEpilogue
 } from '../agent-hooks/hook-stdin-contract'
@@ -55,12 +56,14 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
   return [
     '#!/bin/sh',
     ...buildPosixHookPayloadCapture(),
+    ...buildPosixHookSpoolLines('devin'),
     // Why: endpoint file holds the live port/token; PTYs that outlive an Orca restart carry stale env, so source it to reach the new server (else PTY env).
     // Why: silence the `.` builtin (2>/dev/null + `|| :`) so a TOCTOU race or CRLF-mangled line can't leak shell parse errors into agent transcripts (fail-open).
     'if [ -n "$ORCA_AGENT_HOOK_ENDPOINT" ] && [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ]; then',
     '  . "$ORCA_AGENT_HOOK_ENDPOINT" 2>/dev/null || :',
     'fi',
     'if [ -z "$ORCA_AGENT_HOOK_PORT" ] || [ -z "$ORCA_AGENT_HOOK_TOKEN" ] || [ -z "$ORCA_PANE_KEY" ]; then',
+    '  spool_hook_event',
     '  exit 0',
     'fi',
     // Why: worktreeId embeds a filesystem path, so hand-building JSON in shell is unsafe (quotes/newlines); post as form fields instead.
@@ -75,7 +78,7 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     '  --data-urlencode "worktreeId=${ORCA_WORKTREE_ID}" \\',
     '  --data-urlencode "env=${ORCA_AGENT_HOOK_ENV}" \\',
     '  --data-urlencode "version=${ORCA_AGENT_HOOK_VERSION}" \\',
-    '  --data-urlencode "payload@-" >/dev/null 2>&1 || true',
+    '  --data-urlencode "payload@-" >/dev/null 2>&1 || spool_hook_event',
     'exit 0',
     ''
   ].join('\n')

--- a/src/main/droid/hook-service.ts
+++ b/src/main/droid/hook-service.ts
@@ -24,6 +24,7 @@ import {
 } from '../agent-hooks/installer-utils-remote'
 import {
   buildPosixHookPayloadCapture,
+  buildPosixHookSpoolLines,
   buildWindowsHookEnvironmentGuardLines,
   buildWindowsHookStdinDrainEpilogue
 } from '../agent-hooks/hook-stdin-contract'
@@ -94,10 +95,12 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
   return [
     '#!/bin/sh',
     ...buildPosixHookPayloadCapture(),
+    ...buildPosixHookSpoolLines('droid'),
     'if [ -n "$ORCA_AGENT_HOOK_ENDPOINT" ] && [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ]; then',
     '  . "$ORCA_AGENT_HOOK_ENDPOINT" 2>/dev/null || :',
     'fi',
     'if [ -z "$ORCA_AGENT_HOOK_PORT" ] || [ -z "$ORCA_AGENT_HOOK_TOKEN" ] || [ -z "$ORCA_PANE_KEY" ]; then',
+    '  spool_hook_event',
     '  exit 0',
     'fi',
     // Timeout caps best-effort hook posts if the local listener stalls.
@@ -114,7 +117,7 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     '  --data-urlencode "worktreeId=${ORCA_WORKTREE_ID}" \\',
     '  --data-urlencode "env=${ORCA_AGENT_HOOK_ENV}" \\',
     '  --data-urlencode "version=${ORCA_AGENT_HOOK_VERSION}" \\',
-    '  --data-urlencode "payload@-" >/dev/null 2>&1 || true',
+    '  --data-urlencode "payload@-" >/dev/null 2>&1 || spool_hook_event',
     'exit 0',
     ''
   ].join('\n')

--- a/src/main/gemini/hook-service.ts
+++ b/src/main/gemini/hook-service.ts
@@ -24,6 +24,7 @@ import {
 } from '../agent-hooks/installer-utils-remote'
 import {
   buildPosixHookPayloadCapture,
+  buildPosixHookSpoolLines,
   buildWindowsHookEnvironmentGuardLines,
   buildWindowsHookStdinDrainEpilogue
 } from '../agent-hooks/hook-stdin-contract'
@@ -72,11 +73,13 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     // Why: emit `{}` first so Gemini never stalls parsing stdout, even if the guards below exit early.
     'printf "{}\\n"',
     ...buildPosixHookPayloadCapture(),
+    ...buildPosixHookSpoolLines('gemini'),
     // Why: source refreshes endpoint coords so a PTY surviving an Orca restart keeps reporting. See claude/hook-service.ts.
     'if [ -n "$ORCA_AGENT_HOOK_ENDPOINT" ] && [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ]; then',
     '  . "$ORCA_AGENT_HOOK_ENDPOINT" 2>/dev/null || :',
     'fi',
     'if [ -z "$ORCA_AGENT_HOOK_PORT" ] || [ -z "$ORCA_AGENT_HOOK_TOKEN" ] || [ -z "$ORCA_PANE_KEY" ]; then',
+    '  spool_hook_event',
     '  exit 0',
     'fi',
     // Why: worktreeId embeds a path, so post form fields, not hand-built JSON that breaks on quotes/newlines.
@@ -91,7 +94,7 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     '  --data-urlencode "worktreeId=${ORCA_WORKTREE_ID}" \\',
     '  --data-urlencode "env=${ORCA_AGENT_HOOK_ENV}" \\',
     '  --data-urlencode "version=${ORCA_AGENT_HOOK_VERSION}" \\',
-    '  --data-urlencode "payload@-" >/dev/null 2>&1 || true',
+    '  --data-urlencode "payload@-" >/dev/null 2>&1 || spool_hook_event',
     'exit 0',
     ''
   ].join('\n')

--- a/src/main/grok/grok-hook-script.ts
+++ b/src/main/grok/grok-hook-script.ts
@@ -3,7 +3,10 @@ import {
   wrapPosixHookCommand,
   wrapWindowsCmdHookCommand
 } from '../agent-hooks/installer-utils'
-import { buildPosixHookPayloadCapture } from '../agent-hooks/hook-stdin-contract'
+import {
+  buildPosixHookPayloadCapture,
+  buildPosixHookSpoolLines
+} from '../agent-hooks/hook-stdin-contract'
 import {
   buildWindowsGrokHookScript,
   GROK_HOME_ENVELOPE_MAX_LENGTH
@@ -33,10 +36,12 @@ export function getGrokManagedScript(target: 'local' | 'posix' = 'local'): strin
   return [
     '#!/bin/sh',
     ...buildPosixHookPayloadCapture(),
+    ...buildPosixHookSpoolLines('grok'),
     'if [ -n "$ORCA_AGENT_HOOK_ENDPOINT" ] && [ -r "$ORCA_AGENT_HOOK_ENDPOINT" ]; then',
     '  . "$ORCA_AGENT_HOOK_ENDPOINT" 2>/dev/null || :',
     'fi',
     'if [ -z "$ORCA_AGENT_HOOK_PORT" ] || [ -z "$ORCA_AGENT_HOOK_TOKEN" ] || [ -z "$ORCA_PANE_KEY" ]; then',
+    '  spool_hook_event',
     '  exit 0',
     'fi',
     'grok_home=',
@@ -54,7 +59,7 @@ export function getGrokManagedScript(target: 'local' | 'posix' = 'local'): strin
     '  --data-urlencode "env=${ORCA_AGENT_HOOK_ENV}" \\',
     '  --data-urlencode "version=${ORCA_AGENT_HOOK_VERSION}" \\',
     '  --data-urlencode "grokHome=${grok_home}" \\',
-    '  --data-urlencode "payload@-" >/dev/null 2>&1 || true',
+    '  --data-urlencode "payload@-" >/dev/null 2>&1 || spool_hook_event',
     'exit 0',
     ''
   ].join('\n')

--- a/src/main/kimi/hook-service.ts
+++ b/src/main/kimi/hook-service.ts
@@ -24,7 +24,10 @@ import {
   writeManagedScriptRemote,
   writeTextFileRemoteAtomic
 } from '../agent-hooks/installer-utils-remote'
-import { buildPosixHookPayloadCapture } from '../agent-hooks/hook-stdin-contract'
+import {
+  buildPosixHookPayloadCapture,
+  buildPosixHookSpoolLines
+} from '../agent-hooks/hook-stdin-contract'
 import {
   applyManagedKimiHooks,
   KIMI_HOOK_EVENTS,
@@ -71,14 +74,23 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     '  . "$ORCA_AGENT_HOOK_ENDPOINT" 2>/dev/null || :',
     'fi',
     'if [ -z "$ORCA_AGENT_HOOK_PORT" ] || [ -z "$ORCA_AGENT_HOOK_TOKEN" ] || [ -z "$ORCA_PANE_KEY" ]; then',
+    '  spool_hook_event',
     '  exit 0',
     'fi'
   ]
   return [
     '#!/bin/sh',
     ...(windowsLocal
-      ? [...endpointRefreshAndGuard, ...buildPosixHookPayloadCapture()]
-      : [...buildPosixHookPayloadCapture(), ...endpointRefreshAndGuard]),
+      ? [
+          ...endpointRefreshAndGuard,
+          ...buildPosixHookPayloadCapture(),
+          ...buildPosixHookSpoolLines('kimi')
+        ]
+      : [
+          ...buildPosixHookPayloadCapture(),
+          ...buildPosixHookSpoolLines('kimi'),
+          ...endpointRefreshAndGuard
+        ]),
     // Why: worktreeId embeds a filesystem path, so hand-building JSON in POSIX
     // shell is not safe once a path contains quotes or newlines. Post the raw
     // hook payload plus metadata as form fields and let the receiver parse it.
@@ -95,7 +107,7 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     '  --data-urlencode "worktreeId=${ORCA_WORKTREE_ID}" \\',
     '  --data-urlencode "env=${ORCA_AGENT_HOOK_ENV}" \\',
     '  --data-urlencode "version=${ORCA_AGENT_HOOK_VERSION}" \\',
-    '  --data-urlencode "payload@-" >/dev/null 2>&1 || true',
+    '  --data-urlencode "payload@-" >/dev/null 2>&1 || spool_hook_event',
     'exit 0',
     ''
   ].join('\n')

--- a/src/main/kimi/hook-service.ts
+++ b/src/main/kimi/hook-service.ts
@@ -74,7 +74,9 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     '  . "$ORCA_AGENT_HOOK_ENDPOINT" 2>/dev/null || :',
     'fi',
     'if [ -z "$ORCA_AGENT_HOOK_PORT" ] || [ -z "$ORCA_AGENT_HOOK_TOKEN" ] || [ -z "$ORCA_PANE_KEY" ]; then',
-    '  spool_hook_event',
+    // Why: the windows-local ordering runs this guard before stdin is read and before
+    // spool_hook_event is defined, so only the payload-first ordering may spool here.
+    ...(windowsLocal ? [] : ['  spool_hook_event']),
     '  exit 0',
     'fi'
   ]

--- a/src/relay/agent-hook-server.test.ts
+++ b/src/relay/agent-hook-server.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { RelayAgentHookServer } from './agent-hook-server'
@@ -77,6 +77,49 @@ describe('RelayAgentHookServer', () => {
       // protocol diagnostics and remote-location marker survive the wire.
       expect(envelope.env).toBe('remote')
       expect(envelope.version).toBe('1')
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('normalizes and forwards raw spooled hooks on startup', async () => {
+    const spoolDir = join(dir, 'spool')
+    const spoolFile = join(spoolDir, 'pane-codex.jsonl')
+    mkdirSync(spoolDir)
+    writeFileSync(
+      spoolFile,
+      `${JSON.stringify({
+        paneKey: PANE_KEY,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        env: 'remote',
+        version: '1',
+        launchToken: 'generation-token',
+        hookEventName: 'SubagentStop',
+        source: 'codex',
+        payload: { hook_event_name: 'SubagentStop', agent_id: 'child-spooled' },
+        receivedAt: Date.now()
+      })}\n`
+    )
+    const forward = vi.fn<(envelope: AgentHookRelayEnvelope) => void>()
+    const server = new RelayAgentHookServer({ endpointDir: dir, forward })
+
+    await server.start()
+    try {
+      expect(forward).toHaveBeenCalledTimes(1)
+      expect(forward.mock.calls[0][0]).toMatchObject({
+        source: 'codex',
+        paneKey: PANE_KEY,
+        tabId: 'tab-1',
+        worktreeId: 'wt-1',
+        launchToken: 'generation-token',
+        hookEventName: 'SubagentStop',
+        isReplay: true,
+        env: 'remote',
+        version: '1',
+        payload: { state: 'working', agentType: 'codex' }
+      })
+      expect(readFileSync(spoolFile)).toHaveLength(0)
     } finally {
       server.stop()
     }

--- a/src/relay/agent-hook-server.test.ts
+++ b/src/relay/agent-hook-server.test.ts
@@ -125,6 +125,36 @@ describe('RelayAgentHookServer', () => {
     }
   })
 
+  it('keeps the relay listening when spool replay forwarding fails', async () => {
+    const spoolDir = join(dir, 'spool')
+    const spoolFile = join(spoolDir, 'pane-codex.jsonl')
+    mkdirSync(spoolDir)
+    writeFileSync(
+      spoolFile,
+      `${JSON.stringify({
+        paneKey: PANE_KEY,
+        source: 'codex',
+        hookEventName: 'SubagentStop',
+        payload: { hook_event_name: 'SubagentStop', agent_id: 'child-spooled' },
+        receivedAt: Date.now()
+      })}\n`
+    )
+    const server = new RelayAgentHookServer({
+      endpointDir: dir,
+      forward: () => {
+        throw new Error('receiver unavailable')
+      }
+    })
+
+    try {
+      await expect(server.start()).resolves.toBeUndefined()
+      expect(server.getCoordinates().port).toBeGreaterThan(0)
+      expect(readFileSync(spoolFile, 'utf8')).not.toBe('')
+    } finally {
+      server.stop()
+    }
+  })
+
   it('caches before forwarding, schedules retries after forwarding, and responds last', async () => {
     const order: string[] = []
     let server!: RelayAgentHookServer

--- a/src/relay/agent-hook-server.ts
+++ b/src/relay/agent-hook-server.ts
@@ -24,10 +24,16 @@ import {
   isHookRequestTruncatedError
 } from '../shared/agent-hook-transport-interference'
 import {
+  isAgentHookSource,
   REMOTE_AGENT_HOOK_ENV,
   type AgentHookRelayEnvelope,
   type AgentHookSource
 } from '../shared/agent-hook-relay'
+import {
+  buildSpoolHookBody,
+  drainAgentHookSpool,
+  type SpoolRecord
+} from '../shared/agent-hook-spool'
 import { buildRelayHookPtyEnv, defaultEndpointDir } from './agent-hook-endpoint-coordinates'
 import { buildRelayHookEnvelope, hookBodyEnv, hookBodyVersion } from './agent-hook-envelope-build'
 import { AgentHookResultRetryScheduler } from './agent-hook-result-retry-scheduler'
@@ -100,6 +106,11 @@ export class RelayAgentHookServer {
     this.token = this.fixedToken ?? randomUUID()
     this.endpointFileWritten = false
     this.portFallbackApplied = false
+    drainAgentHookSpool({
+      endpointDir: this.endpointDir,
+      getPersistedLaunchTokenHash: () => undefined,
+      ingest: (record) => this.ingestSpoolRecord(record)
+    })
     try {
       await this.listenOn(this.preferredPort)
     } catch (err) {
@@ -273,7 +284,8 @@ export class RelayAgentHookServer {
     event: AgentHookEventPayload,
     source: AgentHookSource,
     env?: string,
-    version?: string
+    version?: string,
+    options: { isReplay?: boolean } = {}
   ): void {
     if (event.payload.state !== 'done' || event.payload.lastAssistantMessage) {
       this.retryScheduler.clearAssistantMessageRetry(event.paneKey)
@@ -294,6 +306,22 @@ export class RelayAgentHookServer {
       }
       this.clearPaneState(oldest)
     }
-    this.forward(buildRelayHookEnvelope(event, source, env, version))
+    this.forward(buildRelayHookEnvelope(event, source, env, version, options))
+  }
+
+  private ingestSpoolRecord(record: SpoolRecord): void {
+    if (!isAgentHookSource(record.source)) {
+      return
+    }
+    const body = buildSpoolHookBody(record)
+    const event = normalizeHookPayload(this.state, record.source, body, this.env, {
+      deferCompactOwnershipToClient: true
+    })
+    if (!event) {
+      return
+    }
+    this.applyEvent(event, record.source, hookBodyEnv(body), hookBodyVersion(body), {
+      isReplay: true
+    })
   }
 }

--- a/src/relay/agent-hook-server.ts
+++ b/src/relay/agent-hook-server.ts
@@ -107,23 +107,17 @@ export class RelayAgentHookServer {
     this.endpointFileWritten = false
     this.portFallbackApplied = false
     try {
-      try {
-        drainAgentHookSpool({
-          endpointDir: this.endpointDir,
-          getPersistedLaunchTokenHash: () => undefined,
-          ingest: (record) => this.ingestSpoolRecord(record)
-        })
-      } catch (err) {
-        // Why: a downstream relay failure must not prevent the loopback listener from starting;
-        // the untruncated spool file remains available for retry on the next restart.
-        process.stderr.write(
-          `[relay-hook-server] spool replay failed: ${err instanceof Error ? err.message : String(err)}\n`
-        )
-      }
+      drainAgentHookSpool({
+        endpointDir: this.endpointDir,
+        getPersistedLaunchTokenHash: () => undefined,
+        ingest: (record) => this.ingestSpoolRecord(record)
+      })
     } catch (err) {
-      // Keep the relay available; an unsuccessful replay remains on disk for the next start.
-      const message = err instanceof Error ? err.message : String(err)
-      process.stderr.write(`[relay-hook-server] spool replay deferred: ${message}\n`)
+      // Why: a downstream relay failure must not prevent the loopback listener from starting;
+      // the untruncated spool file remains available for retry on the next restart.
+      process.stderr.write(
+        `[relay-hook-server] spool replay failed: ${err instanceof Error ? err.message : String(err)}\n`
+      )
     }
     try {
       await this.listenOn(this.preferredPort)

--- a/src/relay/agent-hook-server.ts
+++ b/src/relay/agent-hook-server.ts
@@ -106,11 +106,25 @@ export class RelayAgentHookServer {
     this.token = this.fixedToken ?? randomUUID()
     this.endpointFileWritten = false
     this.portFallbackApplied = false
-    drainAgentHookSpool({
-      endpointDir: this.endpointDir,
-      getPersistedLaunchTokenHash: () => undefined,
-      ingest: (record) => this.ingestSpoolRecord(record)
-    })
+    try {
+      try {
+        drainAgentHookSpool({
+          endpointDir: this.endpointDir,
+          getPersistedLaunchTokenHash: () => undefined,
+          ingest: (record) => this.ingestSpoolRecord(record)
+        })
+      } catch (err) {
+        // Why: a downstream relay failure must not prevent the loopback listener from starting;
+        // the untruncated spool file remains available for retry on the next restart.
+        process.stderr.write(
+          `[relay-hook-server] spool replay failed: ${err instanceof Error ? err.message : String(err)}\n`
+        )
+      }
+    } catch (err) {
+      // Keep the relay available; an unsuccessful replay remains on disk for the next start.
+      const message = err instanceof Error ? err.message : String(err)
+      process.stderr.write(`[relay-hook-server] spool replay deferred: ${message}\n`)
+    }
     try {
       await this.listenOn(this.preferredPort)
     } catch (err) {

--- a/src/shared/agent-hook-listener/providers/codex-state.ts
+++ b/src/shared/agent-hook-listener/providers/codex-state.ts
@@ -137,8 +137,15 @@ export function reconcileRemoteCodexState(
   if (!lead) {
     return payload
   }
+  // Child lifecycle hooks commonly omit the root prompt. Preserve the last known
+  // turn label while merging their roster/state so relay restarts do not blank it.
+  const prompt =
+    agentId && payload.prompt.length === 0 && previous?.agentType === 'codex'
+      ? previous.prompt
+      : payload.prompt
   return {
     ...payload,
+    prompt,
     state: codexRosterEffectiveState(roster, lead.state),
     model: lead.model ?? payload.model,
     subagents: codexRosterToSnapshots(roster)

--- a/src/shared/agent-hook-spool.ts
+++ b/src/shared/agent-hook-spool.ts
@@ -30,6 +30,20 @@ export type SpoolRecord = {
   [key: string]: unknown
 }
 
+/** Restore the HTTP listener body shape from a shell-written spool record. */
+export function buildSpoolHookBody(record: SpoolRecord): Record<string, unknown> {
+  return {
+    paneKey: record.paneKey,
+    tabId: record.tabId,
+    worktreeId: record.worktreeId,
+    env: record.env,
+    version: record.version,
+    launchToken: record.launchToken,
+    hookEventName: record.hookEventName,
+    payload: record.payload
+  }
+}
+
 export function launchTokenHash(token: string | undefined): string | null {
   return token?.trim() ? createHash('sha256').update(token.trim()).digest('hex') : null
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​446 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​445 |
| Prod | 16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​398 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​22 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​376 |

<!-- /orca-pr-loc -->

## ELI5

When an agent finishes a turn it tells Orca over a tiny local HTTP call. If Orca happens to be restarting at that moment, nobody is listening, the message is thrown away, and the sidebar keeps showing "working" forever. This makes the agent write that message to a file instead, and Orca reads it on next launch.

## What Changed

**Writer (shared, 11 POSIX providers).** `buildPosixHookSpoolLines` in `agent-hooks/hook-stdin-contract.ts` adds a `spool_hook_event` shell function, wired into antigravity, claude, codex, command-code, copilot, cursor, devin, droid, gemini, grok and kimi. It runs **only** on failure paths: the missing-endpoint guard, and a POST that failed after the Windows `curl.exe` retry. Nothing is written when the POST succeeds.

Per-pane JSONL beside the endpoint file (`<endpointDir>/spool/pane-<id>.jsonl`), path derived in-script from `ORCA_AGENT_HOOK_ENDPOINT` so it follows the WSL-guest and SSH-remote relocations automatically. Leading newline per record so a torn write costs exactly one line. 5 MB cap and a 7-day mtime truncate, both enforced by the writer. Tool-progress events (`PreToolUse` / `PostToolUse` / `PostToolUseFailure`) are skipped — highest volume, largest payloads, worthless to replay.

**Drain (`agent-hooks/spool.ts`, wired in `server.ts`).** Runs at startup **before the listener binds**, so replay cannot race a live hook. Each record is re-ingested through the existing `ingestRemote` path with `isReplay: true`, which already suppresses the side effects that must not re-fire.

## Why

The completion hook is fire-and-forget with no retry. Verified on a dev build rather than assumed:

- Orca stopped, then the hook fired: `curl: (7) Failed to connect` — the event ceases to exist.
- The endpoint file **survives shutdown by design**, so `PORT`/`TOKEN` are still set and the script's existing guard does not fire. This is why spooling has to happen on the curl-failure path, not only when the endpoint is missing.
- After restart the row still read `working` with the subagent still `working`.
- Replaying the lost event cleared it.

This repairs delivery rather than guessing after the fact. A delivered event carries its own launch token, so nothing has to infer which agent generation a pane holds — an inference that is not soundly possible once the event is lost.

Three safety properties, each pinned by a test:

1. **Stale generations are fenced.** A spooled event whose launch-token hash does not match the pane's persisted hash is dropped *before* ingest. Measured on a running build: without this, a stale `SubagentStop` clears a newer generation's row *and* overwrites the pane's authority hash.
2. **Replay never claims a live observation.** A non-terminal replayed event withdraws the pane from `runtimeObservedStatusPaneKeys`. Without this, downtime-era evidence marks a pane runtime-observed and permanently masks both the liveness sweep and transcript confirmation — re-creating this very bug through the replay path.
3. **Truncate in place, never unlink.** A hook process may hold an append handle; replacing the file would leave live writers appending to an orphaned inode.

## Linked Issue

Fixes STA-5329

## Visual Proof

N/A — no UI surface changes. The visible effect is an existing sidebar row reaching its correct state instead of remaining `working`; there is no new or altered component.

## Testing

`src/main/agent-hooks/spool.test.ts` (6) and `hook-script-outside-orca.test.ts` (3). Full `src/main/agent-hooks/` suite: **74 files, 732 passed, 6 skipped**. oxfmt + oxlint clean on all 16 changed files.

Both critical tests were confirmed to **fail before their fix** by reverting the production file and re-running — real assertion failures, not import errors:

- `does not mark a non-terminal downtime replay as runtime-observed` → `expected true to be false`
- `spools when the endpoint is present but the receiver is unavailable` → fails against the pre-fix script

**Managed hooks run outside Orca too** (they live in the user's agent config), so `hook-script-outside-orca.test.ts` asserts exit status, stdout, **stderr** and that no files are created, across three cases: no Orca env, pane key without an endpoint, and an endpoint path that does not exist. All silent, exit 0, nothing written.

Manual verification used an isolated dev instance with its own user-data profile.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated

Platforms: **macOS** verified end to end. **WSL / SSH** inherit the derived path but were not exercised. **Windows** — see below.

## Not covered

- **Windows `cmd` writer is not implemented.** `cmd` cannot capture stdin into a variable (the payload streams via `--data-urlencode "payload@-"`), so it needs the tee-to-temp-file approach `claude/statusline-script.ts` already uses. Windows agents get no spooling from this PR. Tracking separately.
- Plugin-based providers (amp, opencode, pi, hermes) emit outside the shared shell builder and are untouched.
- Rows already stuck before this ships stay stuck — their events are gone. They expire on the existing 7-day hydrate TTL.

## Relationship to #16538

Complementary, opposite halves of the same restart gap: this recovers terminal events that were lost, #16538 re-derives "still working" when no event fired at all. Neither subsumes the other. A trial merge shows one trivial import-line conflict; either can land first.

Two deliberate points of compatibility: replayed records pass `connectionId: null` so they are not excluded by that PR's local-only transcript predicate, and this PR strips `isReplay` at persist time so replay provenance never survives another restart.
