### PR TITLE
fix(crash-reporting): stop discarding the whole module list on POSIX dumps

### DIFF
--- a/src/main/crash-reporting/minidump-crash-signature.test.ts
+++ b/src/main/crash-reporting/minidump-crash-signature.test.ts
@@ -194,6 +194,22 @@ function buildDump(options: {
   return { dump: builder.build(streams) }
 }
 
+/** Offset of a stream's directory entry: `{type, size, rva}`. */
+function streamEntry(dump: Buffer, type: number): number {
+  const directoryRva = dump.readUInt32LE(12)
+  for (let index = 0; index < dump.readUInt32LE(8); index += 1) {
+    const entry = directoryRva + index * 12
+    if (dump.readUInt32LE(entry) === type) {
+      return entry
+    }
+  }
+  throw new Error(`no stream of type ${type}`)
+}
+
+function moduleListRva(dump: Buffer): number {
+  return dump.readUInt32LE(streamEntry(dump, STREAM_TYPE_MODULE_LIST) + 8)
+}
+
 const FATAL_LINE =
   '[8104:1234:0815/143022.123456:FATAL:render_frame_impl.cc(4821)] Check failed: !is_detached_.'
 
@@ -338,6 +354,37 @@ describe('parseMinidumpCrashSignature', () => {
     expect(signature?.exceptionAddress).toBe('0x7ff800001234')
     expect(signature?.faultingModule).toBe('chrome_elf.dll')
     expect(signature?.faultingModuleOffset).toBe('0x1234')
+  })
+
+  it('resolves a faulting module past index 1024 on a real macOS image count', () => {
+    // A measured macOS renderer carries 1042 loaded images; a cap below that
+    // dropped the whole module list, so no macOS report could name a module.
+    const modules = Array.from({ length: 1042 }, (_, index) => ({
+      base: 0x1_0000_0000n + BigInt(index) * 0x1_0000n,
+      size: 0x1000,
+      name: `/Applications/Orca.app/Contents/Frameworks/lib${index}.dylib`
+    }))
+    const { dump } = buildDump({
+      exception: { code: 11, address: 0x1_0000_0000n + 1030n * 0x1_0000n + 0x24n },
+      modules
+    })
+
+    const signature = parseMinidumpCrashSignature(dump)
+
+    expect(signature?.faultingModule).toBe('lib1030.dylib')
+    expect(signature?.faultingModuleOffset).toBe('0x24')
+  })
+
+  it('still drops the module list when the claimed module count is absurd', () => {
+    const { dump } = buildDump({
+      exception: { code: 11, address: 0x7ff7_0000_0010n },
+      modules: [{ base: 0x7ff7_0000_0000n, size: 0x1000, name: '/opt/orca/orca' }]
+    })
+    const corrupt = Buffer.from(dump)
+    corrupt.writeUInt32LE(0xffff_ffff, moduleListRva(corrupt))
+
+    expect(() => parseMinidumpCrashSignature(corrupt)).not.toThrow()
+    expect(parseMinidumpCrashSignature(corrupt)?.faultingModule).toBeUndefined()
   })
 
   it('omits the faulting module when no image range covers the address', () => {

--- a/src/main/crash-reporting/minidump-crash-signature.ts
+++ b/src/main/crash-reporting/minidump-crash-signature.ts
@@ -11,13 +11,16 @@
 // rather than throwing: a truncated dump must degrade, not break crash
 // reporting.
 
-import { findStream, isMinidump, MAX_MODULES, MinidumpView } from './minidump-stream-reader'
+import { findStream, isMinidump, MinidumpView } from './minidump-stream-reader'
 import { readCrashpadAnnotations } from './minidump-crashpad-annotations'
 
 const STREAM_TYPE_MODULE_LIST = 4
 const STREAM_TYPE_EXCEPTION = 6
 
 const MODULE_RECORD_SIZE = 108
+// 8x headroom over a measured 1042-image macOS renderer, whose whole list a
+// 1_024 cap dropped; a dump claiming more than this is corrupt.
+const MAX_MODULE_LIST_MODULES = 8_192
 const MODULE_BASE_OFFSET = 0
 const MODULE_SIZE_OFFSET = 8
 const MODULE_NAME_RVA_OFFSET = 20
@@ -70,7 +73,7 @@ function readModules(view: MinidumpView): ModuleRecord[] {
     return []
   }
   const count = view.u32(stream.rva)
-  if (count === null || count > MAX_MODULES) {
+  if (count === null || count > MAX_MODULE_LIST_MODULES) {
     return []
   }
   const modules: ModuleRecord[] = []

--- a/src/main/crash-reporting/minidump-stream-reader.ts
+++ b/src/main/crash-reporting/minidump-stream-reader.ts
@@ -13,7 +13,7 @@ const DIRECTORY_ENTRY_SIZE = 12
 // A dump claiming an absurd stream count is corrupt; cap before iterating.
 const MAX_STREAMS = 4_096
 export const MAX_ANNOTATION_VALUE_BYTES = 8_192
-// Shared cap: both the MINIDUMP_MODULE_LIST and Crashpad's per-module info list.
+// Cap for Crashpad's per-module info list; the MINIDUMP_MODULE_LIST is capped separately.
 export const MAX_MODULES = 1_024
 
 export type LocationDescriptor = {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​47 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​3 |

<!-- /orca-pr-loc -->

## What this does

Raises the cap on how many entries the `MINIDUMP_MODULE_LIST` walk will accept, from **1024 to 8192**. **Production diff is +9/−3.**

## The bug

`readModules` does:
```ts
if (count === null || count > MAX_MODULES) return []
```
Over-cap is **not** truncation of the tail — it discards the **entire** module list. So `findFaultingModule` gets nothing and no faulting module is ever named.

A measured macOS renderer carries **1042 loaded images**. That is over 1024. Which is exactly why the 1.4.188 census reads:

```
faulting module present:   27 / 27 Windows reports
                            0 /  9 POSIX reports
```

Every POSIX crash report silently lost its faulting module to an off-by-18 cap.

## Fix evidence

**BEFORE** — test written first, cap still 1024:
```
FAIL minidump-crash-signature.test.ts
  > resolves a faulting module past index 1024 on a real macOS image count
AssertionError: expected undefined to be 'lib1030.dylib'
  - Expected: "lib1030.dylib"
  + Received: undefined
Tests  1 failed | 17 passed (18)
```

**AFTER:** 18/18, and the whole crash-reporting directory 21 files / 229 tests green. Also exercised end-to-end against a **real 574,384-byte Crashpad dump**, not only synthetic fixtures.

## Why 8192 specifically

- Measured worst case is 1042. **2048 is only 1.97×** that — one Electron/Chromium bump, an extra locale or codec bundle, or a user with injected audio/input-method dylibs re-crosses it and silently regresses the same way. 8192 is ~7.9×, surviving a doubling twice over.
- **Cannot blow the dump budget.** The cap bounds how many records we're willing to *walk*, not an allocation. `MAX_DUMP_BYTES` is 64 MiB applied to the file *before* parsing; a module list at the new ceiling is `4 + 8192×108 = 884,740` bytes (~0.84 MiB), i.e. ~1.3% of an already-accepted dump. Every read still goes through `MinidumpView`'s bounds checks, so a dump *claiming* 8192 modules without containing them stops at the first out-of-range accessor.
- **Cannot meaningfully slow crash-time parsing.** One linear pass of bounds-checked reads; the per-name limit (`utf16String(nameRva, 2_048)`) is unchanged.

## ELI5

When Orca reads a crash dump it walks the list of loaded libraries to work out which one crashed. It refused to read any list longer than 1024 entries — and not by reading the first 1024, but by **throwing the whole list away**.

A Mac renderer loads about 1042 libraries. Eighteen over the line. So on every Mac and Linux crash, Orca discarded the entire list and reported no faulting module at all — while Windows, which loads fewer, worked fine. That's the whole reason Windows crashes had a culprit named and POSIX ones never did.

## Trade-offs and limitations

**The two caps are now separate, and the sibling one is unchanged.** `MAX_MODULES` (1024) still governs **Crashpad's per-module info list**; this PR adds a distinct `MAX_MODULE_LIST_MODULES` (8192) for the `MINIDUMP_MODULE_LIST`. Bumping the shared constant would have silently raised a different structure with different size characteristics.

**Consequence, stated plainly:** for that same 1042-module renderer, the Crashpad **annotation** walk is still over its 1024 cap and still degrades. This PR does **not** fix that path — it was explicitly out of scope, and the previous attempt (#16635) sank on exactly that machinery across five review loops. Worth a separate change.

**Not addressed:** the POSIX census gap may have other contributors beyond this cap. This fixes the one mechanism that is measured and provable; it does not claim to be the only one.

**No new absence-claim.** Over-cap still yields an empty list and therefore simply no `faultingModule` key — the code continues to say *nothing* rather than asserting "no module faulted." That degrade-to-silence path is unchanged and now pinned by a test.

## Readiness

`/readiness-checklist`: **RELEASE-READY.** No P0, no P1, no failed items. Two P2s, both scope-expansion suggestions, deliberately not applied.

One thing the reviewer would not let pass silently: the **1042** figure comes from this change's own comment and test data. The parser is verified to handle that count correctly, but the figure itself was not independently re-measured against a fresh macOS dump in this environment.

`/perf`: **PASS**, measured not asserted.

## Adversarial review

4 loops. Supersedes #16635 (+1072/−116 across 9 files).
