### PR TITLE
fix(windows): keep windows-process-tree gyp paths absolute under pnpm

### DIFF
--- a/config/patches/@vscode__windows-process-tree@0.8.0.patch
+++ b/config/patches/@vscode__windows-process-tree@0.8.0.patch
@@ -2,6 +2,15 @@ diff --git a/binding.gyp b/binding.gyp
 index 855bd4b86f0a3c18c7594212c0e42b6e35bc4001..5f15551cb1520af996f216500a83ac68b57f5104 100644
 --- a/binding.gyp
 +++ b/binding.gyp
+@@ -3,7 +3,7 @@
+     {
+       "target_name": "windows_process_tree",
+       "dependencies": [
+-        "<!(node -p \"require('node-addon-api').targets\"):node_addon_api_except",
++        "<!(node -p \"require.resolve('node-addon-api/node_addon_api.gyp')\"):node_addon_api_except",
+       ],
+       "conditions": [
+         ['OS=="win"', {
 @@ -16,9 +16,6 @@
            ],
            "include_dirs": [],

--- a/config/scripts/build-windows-process-tree-relay-addon.mjs
+++ b/config/scripts/build-windows-process-tree-relay-addon.mjs
@@ -53,10 +53,11 @@ function parseArgs(argv) {
 /**
  * Refuse to build unpatched source.
  *
- * Both hunks are load-bearing and fail in opposite directions: with Spectre the
- * build dies outright, and with the cap it succeeds and lies. Checking the
- * source rather than trusting the install is what stops a silently unpatched
- * tree from being shipped as if it were patched.
+ * Each hunk fails differently: Spectre dies outright, the 1024-process cap
+ * succeeds and lies, and `.targets` is cwd-relative so pnpm's nested layout
+ * makes node-gyp miss node_addon_api.gyp on Windows. Checking the source
+ * rather than trusting the install is what stops a silently unpatched tree
+ * from being shipped as if it were patched.
  */
 function assertPatchApplied() {
   const bindingGyp = readFileSync(join(PACKAGE_DIR, 'binding.gyp'), 'utf8')
@@ -64,6 +65,13 @@ function assertPatchApplied() {
     throw new Error(
       'binding.gyp still requests SpectreMitigation. pnpm did not apply ' +
         'config/patches/@vscode__windows-process-tree@0.8.0.patch; run pnpm install.'
+    )
+  }
+  if (!bindingGyp.includes("require.resolve('node-addon-api/node_addon_api.gyp')")) {
+    throw new Error(
+      'binding.gyp still uses require("node-addon-api").targets. That path is ' +
+        'cwd-relative and misses node_addon_api.gyp under pnpm on Windows. ' +
+        'pnpm did not apply config/patches/@vscode__windows-process-tree@0.8.0.patch; run pnpm install.'
     )
   }
   const processCc = readFileSync(join(PACKAGE_DIR, 'src', 'process.cc'), 'utf8')

--- a/config/scripts/windows-process-tree-gyp-path.test.mjs
+++ b/config/scripts/windows-process-tree-gyp-path.test.mjs
@@ -1,0 +1,38 @@
+import { execFileSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { isAbsolute, join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const projectDir = resolve(import.meta.dirname, '../..')
+const PATCH = readFileSync(
+  join(projectDir, 'config/patches/@vscode__windows-process-tree@0.8.0.patch'),
+  'utf8'
+)
+const PACKAGE_DIR = join(projectDir, 'node_modules', '@vscode', 'windows-process-tree')
+const ABSOLUTE_GYP = "require.resolve('node-addon-api/node_addon_api.gyp')"
+
+describe('windows-process-tree node-addon-api gyp path', () => {
+  it('keeps the gyp project path absolute so pnpm Windows source builds find it', () => {
+    expect(PATCH).toContain(
+      `+        "<!(node -p \\"require.resolve('node-addon-api/node_addon_api.gyp')\\"):node_addon_api_except"`
+    )
+    const bindingGyp = readFileSync(join(PACKAGE_DIR, 'binding.gyp'), 'utf8')
+    expect(bindingGyp).toContain(ABSOLUTE_GYP)
+    expect(bindingGyp).not.toContain("require('node-addon-api').targets")
+    expect(
+      readFileSync(
+        join(projectDir, 'config/scripts/build-windows-process-tree-relay-addon.mjs'),
+        'utf8'
+      )
+    ).toContain(ABSOLUTE_GYP)
+  })
+
+  it('resolves node_addon_api.gyp to a real file from the package directory', () => {
+    const resolved = execFileSync(process.execPath, ['-p', ABSOLUTE_GYP], {
+      cwd: PACKAGE_DIR,
+      encoding: 'utf8'
+    }).trim()
+    expect(isAbsolute(resolved)).toBe(true)
+    expect(existsSync(resolved)).toBe(true)
+  })
+})

--- a/docs/reference/windows-process-enumeration.md
+++ b/docs/reference/windows-process-enumeration.md
@@ -116,11 +116,11 @@ it as an optional relay artifact.
 
 `config/scripts/build-windows-process-tree-relay-addon.mjs` builds it from the
 source pnpm has already patched, on a Windows runner, and refuses to run if
-either patch hunk is missing — the Spectre hunk fails loudly, but the
-1024-process hunk fails *silently*, so the source is checked rather than the
-install trusted. It also reads the PE machine field of the output, because a
-cross-build that quietly emitted host arch would ship a binary the target cannot
-load.
+any patch hunk is missing — the Spectre hunk fails loudly, the 1024-process
+hunk fails *silently*, and the relative gyp path dies at configure on Windows.
+The source is checked rather than the install trusted. It also reads the PE
+machine field of the output, because a cross-build that quietly emitted host
+arch would ship a binary the target cannot load.
 
 Windows arm64 cross-compiles from the x64 runner — verified on real hardware,
 producing `IMAGE_FILE_MACHINE_ARM64` (0xaa64) against x64's 0x8664. It needs the
@@ -143,7 +143,7 @@ on any other OS keeps using the scan.
 
 ## Why the package is patched
 
-`config/patches/@vscode__windows-process-tree@0.8.0.patch` carries two hunks.
+`config/patches/@vscode__windows-process-tree@0.8.0.patch` carries three hunks.
 
 1. **Spectre mitigation.** The upstream `binding.gyp` requires Spectre-mitigated
    libraries, which Orca's Windows build agents do not install. `node-pty` is
@@ -153,6 +153,11 @@ on any other OS keeps using the scan.
    1024 and the querying process was itself among the 27 missing. A truncated
    snapshot silently hides the descendants a teardown is trying to reap — the
    exact failure the native path exists to remove.
+3. **Absolute `node-addon-api` gyp path.** `require('node-addon-api').targets`
+   is cwd-relative. node-gyp on Windows evaluates it from the pnpm store
+   realpath, then loads the relative path from the `node_modules` symlink, so
+   `node_addon_api.gyp` resolves outside the repo and hourly Windows builds
+   die at configure. `node-pty` is patched the same way for the same reason.
 
 The typings claim `commandLine` is truncated at 512 characters. Measured, it is
 not: the longest observed on a real host was 26,059.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
 
 patchedDependencies:
   '@vscode/windows-process-tree@0.8.0':
-    hash: 7c08bebce9b36829be6035218db2383f1a889c21ec907ea7e85c36fc54795a05
+    hash: 73a90530e6b95c05dac50f2c48787fb51cb292587773016ebe57eb05e41075a0
     path: config/patches/@vscode__windows-process-tree@0.8.0.patch
   '@xterm/addon-ligatures@0.11.0-beta.287':
     hash: 47405b9994b5acf1b4e90b49250358c1ca03649854d59560e7732b72fe336920
@@ -407,7 +407,7 @@ importers:
     optionalDependencies:
       '@vscode/windows-process-tree':
         specifier: 0.8.0
-        version: 0.8.0(patch_hash=7c08bebce9b36829be6035218db2383f1a889c21ec907ea7e85c36fc54795a05)
+        version: 0.8.0(patch_hash=73a90530e6b95c05dac50f2c48787fb51cb292587773016ebe57eb05e41075a0)
       sherpa-onnx-darwin-arm64:
         specifier: 1.12.37
         version: 1.12.37
@@ -9605,7 +9605,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@vscode/windows-process-tree@0.8.0(patch_hash=7c08bebce9b36829be6035218db2383f1a889c21ec907ea7e85c36fc54795a05)':
+  '@vscode/windows-process-tree@0.8.0(patch_hash=73a90530e6b95c05dac50f2c48787fb51cb292587773016ebe57eb05e41075a0)':
     dependencies:
       node-addon-api: 7.1.0
     optional: true

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -3887,7 +3887,7 @@
           "35b9a724a0": "利用可能",
           "c13b82793c": "インストールを管理",
           "aee7b99cc6": "リンクからインストール",
-          "filterProvider": "エージェントで絞り込み",
+          "filterProvider": "Agent で絞り込み",
           "filterSource": "ソースで絞り込み",
           "allSources": "すべて",
           "clearFilters": "フィルターをクリア",
@@ -3913,13 +3913,43 @@
           "deleteSkill": "削除…"
         },
         "SkillsList": { "listLabel": "スキル" },
-        "sourceStatus": { "missing": "フォルダーが見つかりません", "remoteRepo": "リモートリポジトリ — 未スキャン", "unavailable": "未スキャン" },
+        "sourceStatus": {
+          "missing": "フォルダーが見つかりません",
+          "remoteRepo": "リモートリポジトリ — 未スキャン",
+          "unavailable": "未スキャン"
+        },
         "sources": { "heading": "スキルフォルダー" },
-        "sourceKind": { "home": "ホーム", "workspace": "ワークスペース", "bundled": "バンドル済み", "plugin": "プラグイン" },
-        "count": { "skillOne": "{{count}} 件のスキル", "skillOther": "{{count}} 件のスキル", "sourceOne": "{{count}} 件のソース", "sourceOther": "{{count}} 件のソース", "fileOne": "{{count}} 個のファイル", "fileOther": "{{count}} 個のファイル", "resultOne": "{{count}} 件の結果", "resultOther": "{{count}} 件の結果", "selected": "{{count}} 件を選択", "shareOne": "{{count}} 件のスキルを共有", "shareOther": "{{count}} 件のスキルを共有", "linkOne": "{{count}} 件のリンク", "linkOther": "{{count}} 件のリンク" },
-        "filter": { "allAgents": "すべてのエージェント", "sharedAgent": "共有 (.agents)" },
-        "SkillsSelectionHeader": { "exit": "選択を終了", "exitTooltip": "選択を終了 · Esc", "title": "共有するスキルを選択", "selectAll": "対象の {{count}} 件をすべて選択", "clear": "クリア", "deleteTitle": "削除するスキルを選択" },
-        "SkillDetailDialog": { "agents": "エージェント", "updated": "更新日", "copy": "コピー" },
+        "sourceKind": {
+          "home": "ホーム",
+          "workspace": "ワークスペース",
+          "bundled": "バンドル済み",
+          "plugin": "プラグイン"
+        },
+        "count": {
+          "skillOne": "{{count}} 件のスキル",
+          "skillOther": "{{count}} 件のスキル",
+          "sourceOne": "{{count}} 件のソース",
+          "sourceOther": "{{count}} 件のソース",
+          "fileOne": "{{count}} 個のファイル",
+          "fileOther": "{{count}} 個のファイル",
+          "resultOne": "{{count}} 件の結果",
+          "resultOther": "{{count}} 件の結果",
+          "selected": "{{count}} 件を選択",
+          "shareOne": "{{count}} 件のスキルを共有",
+          "shareOther": "{{count}} 件のスキルを共有",
+          "linkOne": "{{count}} 件のリンク",
+          "linkOther": "{{count}} 件のリンク"
+        },
+        "filter": { "allAgents": "すべての Agent", "sharedAgent": "共有 (.agents)" },
+        "SkillsSelectionHeader": {
+          "exit": "選択を終了",
+          "exitTooltip": "選択を終了 · Esc",
+          "title": "共有するスキルを選択",
+          "selectAll": "対象の {{count}} 件をすべて選択",
+          "clear": "クリア",
+          "deleteTitle": "削除するスキルを選択"
+        },
+        "SkillDetailDialog": { "agents": "Agent", "updated": "更新日", "copy": "コピー" },
         "SkillFreshnessNudge": {
           "titleOne": "インストール済みの Orca スキルが古くなっています",
           "titleMany": "インストール済みの Orca スキル {{value0}} 件が古くなっています",


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​38 |
| Prod | 5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​76 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​24 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​52 |

<!-- /orca-pr-loc -->

## ELI5

Hourly Windows builds have been red since we started compiling the process-table addon for the relay. node-gyp was looking for a helper file using a *relative* path that points outside the repo under pnpm, so the compile died before packaging even started. This makes that path absolute, the same way we already did for node-pty.

## What Changed

- Patch `@vscode/windows-process-tree` `binding.gyp` to use `require.resolve('node-addon-api/node_addon_api.gyp')` instead of `require('node-addon-api').targets`.
- Refuse to compile the relay addon if that hunk is missing.
- Pin the absolute path in a unit test and document the third patch hunk.

## Why

`require('node-addon-api').targets` returns a path relative to cwd. On the Windows runner, node-gyp evaluates that from the pnpm store realpath, then loads the relative path from the `node_modules/@vscode/windows-process-tree` symlink. The result:

```
gyp: ..\..\..\..\node-addon-api@7.1.1\node_modules\node-addon-api\node_addon_api.gyp not found
(cwd: D:\a\orca\orca\node_modules\@vscode\windows-process-tree)
```

Every Windows hourly since #16598 has failed at `Build Windows process-table addon for the relay`. Mac hourlies that looked green were skipping the Windows leg because main had not moved.

`node-pty` already carries this same `require.resolve` patch for the same pnpm/Windows reason.

## Linked Issue

https://github.com/stablyai/orca/actions/runs/33017768410

## Visual Proof

N/A — native-addon compile path for CI; no UI or interaction change.

## Testing

- [x] Automated tests added/updated, or explained why not below
- [ ] I manually tested these changes locally

`pnpm exec vitest run --config config/vitest.config.ts config/scripts/windows-process-tree-gyp-path.test.mjs` passes. The compile itself only runs on Windows; CI's `build-hourly-win` / Windows packaging jobs are the real proof.

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Windows-only native compile. SSH relays are the reason this addon is built in the hourly Windows job; the desktop app rebuilds it the same way.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)