### PR TITLE
fix(mobile): reset recycled paragraph layout before reuse

### DIFF
--- a/mobile/patches/react-native@0.83.9.patch
+++ b/mobile/patches/react-native@0.83.9.patch
@@ -46,3 +46,15 @@ index a3f2e01c130c1a53aee0b39e72927d21f2a6973d..c9d34f8b42644800b5c85e5be45b6ebf
      AttributedString::Range selectionRange;
      // ScrollView-like metrics
      Size contentSize;
+diff --git a/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm b/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+index 79ee7ffe43..956f189a1c 100644
+--- a/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
++++ b/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm
+@@ -136,6 +136,7 @@ using namespace facebook::react;
+ - (void)prepareForRecycle
+ {
+   [super prepareForRecycle];
+   _textView.state = nullptr;
++  _textView.layoutMetrics = EmptyLayoutMetrics;
+   _accessibilityProvider = nil;
+ }

--- a/mobile/pnpm-lock.yaml
+++ b/mobile/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
 
 patchedDependencies:
   react-native@0.83.9:
-    hash: a6502e7d63769bf1fd639cbbaab1cc0b8aebef31d22048e8f2186fb399d0c16e
+    hash: 44876634a8efbb0f2c3f66cd4332be170ec821d1cbfc0264ac80680983e8513d
     path: patches/react-native@0.83.9.patch
 
 importers:

--- a/mobile/src/session/mobile-native-chat-message-text.ts
+++ b/mobile/src/session/mobile-native-chat-message-text.ts
@@ -21,3 +21,28 @@ export function clampFontScale(scale: number): number {
   }
   return Math.min(FONT_SCALE_MAX, Math.max(FONT_SCALE_MIN, scale))
 }
+
+/** Granularity a pinch is allowed to commit at. */
+export const FONT_SCALE_STEP = 0.05
+
+/** Snap a proposed font scale to the nearest committed step.
+ *
+ *  Why quantize: the chat's `renderItem` closes over `fontScale`, so every
+ *  distinct value re-renders and re-measures every message in the list. A raw
+ *  pinch proposes a new scale on each gesture frame, so a single zoom drives
+ *  hundreds of whole-list re-measures — and because the pinch is composed
+ *  `Simultaneous` with the list's own scroll, an incidental second finger during
+ *  a scroll starts that storm at scales indistinguishable from 1. Those
+ *  re-measures run while rows are mounting and unmounting, which is when a
+ *  recycled iOS paragraph view can repaint with the previous row's content
+ *  frame and silently drop the tail of a long message. Snapping to steps keeps a
+ *  full-range pinch to at most 20 commits and makes a near-neutral pinch commit
+ *  nothing at all. */
+export function quantizeFontScale(scale: number): number {
+  if (Number.isNaN(scale)) {
+    return 1
+  }
+  const stepped = Math.round(clampFontScale(scale) / FONT_SCALE_STEP) * FONT_SCALE_STEP
+  // Re-clamp: rounding can push the outermost step past the bound.
+  return clampFontScale(Number(stepped.toFixed(2)))
+}

--- a/mobile/src/session/use-mobile-native-chat-pinch-gesture.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-pinch-gesture.test.ts
@@ -1,0 +1,91 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FONT_SCALE_STEP, quantizeFontScale } from './mobile-native-chat-message-text'
+
+const handlers: { start?: () => void; update?: (e: { scale: number }) => void } = {}
+
+vi.mock('react-native-gesture-handler', () => {
+  const pinch = {
+    runOnJS: () => pinch,
+    onStart: (cb: () => void) => {
+      handlers.start = cb
+      return pinch
+    },
+    onUpdate: (cb: (e: { scale: number }) => void) => {
+      handlers.update = cb
+      return pinch
+    }
+  }
+  return {
+    Gesture: { Simultaneous: (...g: unknown[]) => g, Native: () => ({}), Pinch: () => pinch }
+  }
+})
+
+import { useMobileNativeChatPinchGesture } from './use-mobile-native-chat-pinch-gesture'
+
+describe('quantizeFontScale', () => {
+  it('snaps to the commit step and stays inside the supported range', () => {
+    expect(quantizeFontScale(1)).toBe(1)
+    expect(quantizeFontScale(1.01)).toBe(1)
+    expect(quantizeFontScale(1.024)).toBe(1)
+    expect(quantizeFontScale(1.03)).toBe(1.05)
+    expect(quantizeFontScale(5)).toBe(1.8)
+    expect(quantizeFontScale(0.1)).toBe(0.8)
+    expect(quantizeFontScale(Number.NaN)).toBe(1)
+  })
+
+  it('collapses a full-range pinch to at most one commit per step', () => {
+    const committed = new Set<number>()
+    for (let i = 0; i <= 600; i++) {
+      committed.add(quantizeFontScale(0.7 + i * 0.002))
+    }
+    expect(committed.size).toBeLessThanOrEqual(Math.round(1 / FONT_SCALE_STEP) + 1)
+  })
+})
+
+describe('useMobileNativeChatPinchGesture', () => {
+  let renderer: ReactTestRenderer | null = null
+  let latest = 1
+
+  function Probe(): null {
+    latest = useMobileNativeChatPinchGesture().fontScale
+    return null
+  }
+
+  beforeEach(() => {
+    latest = 1
+    act(() => {
+      renderer = create(createElement(Probe))
+    })
+  })
+
+  afterEach(() => {
+    act(() => renderer?.unmount())
+    renderer = null
+  })
+
+  // Why this matters: `renderItem` closes over `fontScale`, so each committed
+  // value re-measures every message in the list. Committing raw gesture scales
+  // drives hundreds of whole-list re-measures per pinch, and a stray second
+  // finger during an ordinary scroll starts that storm at scales the user cannot
+  // even see. Those re-measures are what expose the recycled-paragraph repaint
+  // that silently drops the tail of a long message.
+  it('commits nothing for gesture noise the user cannot see', () => {
+    act(() => handlers.start?.())
+    for (const scale of [1.001, 0.995, 1.008, 1.02, 0.982]) {
+      act(() => handlers.update?.({ scale }))
+    }
+    expect(latest).toBe(1)
+  })
+
+  it('commits a real pinch, on the step grid', () => {
+    act(() => handlers.start?.())
+    act(() => handlers.update?.({ scale: 1.34 }))
+    expect(latest).toBe(1.35)
+    act(() => handlers.update?.({ scale: 1.37 }))
+    expect(latest).toBe(1.35)
+    act(() => handlers.update?.({ scale: 1.42 }))
+    expect(latest).toBe(1.4)
+  })
+})

--- a/mobile/src/session/use-mobile-native-chat-pinch-gesture.test.ts
+++ b/mobile/src/session/use-mobile-native-chat-pinch-gesture.test.ts
@@ -1,5 +1,5 @@
 import { createElement } from 'react'
-import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { act, create } from 'react-test-renderer'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { FONT_SCALE_STEP, quantizeFontScale } from './mobile-native-chat-message-text'
 
@@ -45,7 +45,7 @@ describe('quantizeFontScale', () => {
 })
 
 describe('useMobileNativeChatPinchGesture', () => {
-  let renderer: ReactTestRenderer | null = null
+  let renderer: { unmount: () => void } | null = null
   let latest = 1
 
   function Probe(): null {

--- a/mobile/src/session/use-mobile-native-chat-pinch-gesture.ts
+++ b/mobile/src/session/use-mobile-native-chat-pinch-gesture.ts
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useState } from 'react'
 import { Gesture } from 'react-native-gesture-handler'
 import type { ComposedGesture } from 'react-native-gesture-handler'
-import { clampFontScale } from './mobile-native-chat-message-text'
+import { quantizeFontScale } from './mobile-native-chat-message-text'
 
 /** Pinch-to-zoom chat font. `fontScale` is the committed size; `pinchBase`
  *  anchors the live gesture so successive pinches compound rather than reset. */
@@ -14,8 +14,8 @@ export function useMobileNativeChatPinchGesture(): {
   fontScaleRef.current = fontScale
   const pinchBase = useRef(1)
   // Why: run the gesture callbacks on the JS thread (not a reanimated worklet) so
-  // they can touch React refs/state and clampFontScale directly — accessing those
-  // from the UI-thread worklet crashes the app.
+  // they can touch React refs/state and quantizeFontScale directly — accessing
+  // those from the UI-thread worklet crashes the app.
   // Compose the pinch with the list's native scroll as Simultaneous so a
   // two-finger pinch is recognized even while the scroll view is active —
   // otherwise the scroll grabs the gesture first and the pinch never fires.
@@ -29,7 +29,7 @@ export function useMobileNativeChatPinchGesture(): {
             pinchBase.current = fontScaleRef.current
           })
           .onUpdate((e) => {
-            setFontScale(clampFontScale(pinchBase.current * e.scale))
+            setFontScale(quantizeFontScale(pinchBase.current * e.scale))
           })
       ),
     []


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​91 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​91 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​42 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 |

<!-- /orca-pr-loc -->

## What broke

A user bubble in mobile native chat painted **five** lines inside a frame that reserved **six**, with the last painted line cut through a glyph at the content edge and the tail of the message — "no longer needed." — silently gone.

![reported bubble](https://github.com/user-attachments/assets/f3be8683-4ac4-4916-9c8a-98ecf9b8f8e1)

## Why

The paint is React Native's. A `<Text>` with no `numberOfLines` gets a text container whose `lineBreakMode` is `NSLineBreakByClipping` (`RCTTextLayoutManager.mm:230`). `measureNSAttributedString:` lays out into `{width, CGFLOAT_MAX}`; `drawAttributedString:` lays out into the *mounted* content frame. So a frame one line short does not re-wrap — it puts the whole remainder on the last fitting line and clips it, with no ellipsis.

I modelled that exactly with a TextKit harness compiled for the simulator: container `291.33 x 138` gives the correct 6 lines; container `291.33 x 115` gives precisely the reported picture, and its per-line ink widths match the screenshot's first four lines to within 0.5pt.

Two conditions are each necessary for the short frame to reach `drawRect`:

1. a pooled `RCTParagraphComponentView` carrying a shorter row's content frame — `prepareForRecycle` clears `state` but not `_textView.layoutMetrics`;
2. whole-list re-measure churn while rows enter and leave that pool.

**Condition 2 was ours.** `renderItem` closes over `fontScale`, and `useMobileNativeChatPinchGesture` committed a new scale on *every* gesture frame, so one pinch drove hundreds of full-list re-measures. The pinch is composed `Gesture.Simultaneous` with the list's own scroll, so an incidental second finger during an ordinary scroll starts that storm at scales the user cannot see — which matches the report, whose glyph metrics are `fontScale` 1.0 exactly.

## The change

- `quantizeFontScale` snaps pinch commits to a 5% grid. React bails out of same-value state updates, so gesture noise commits nothing and a full-range pinch causes at most ~20 list remeasurements instead of hundreds.
- The React Native patch now resets `_textView.layoutMetrics` to `EmptyLayoutMetrics` in `RCTParagraphComponentView.prepareForRecycle`. That clears the stale mounted frame at the pooled-view lifecycle owner, closing the recycling window even when churn comes from a source other than pinch.
- The coupled `patchedDependencies` hash in `mobile/pnpm-lock.yaml` is updated for the verified React Native patch.

Zoom behavior is unchanged apart from landing on 5% steps.

## Evidence

### Before / after, same bubble, same font scale

Both frames are from the churn harness below, on a 390pt simulator, and both were re-checked by the measuring script rather than eyeballed.

**Before** — frame reserves 6 lines, 5 painted, a blank line left under the text, line 5 running to the content edge with "no longer needed." gone:

![before — 5 painted lines in a 6-line frame](https://github.com/user-attachments/assets/591eedfe-1333-42a1-b53e-45eabf8aac0f)

**After** — same message, same 17pt render, all 6 lines:

![after — all 6 lines](https://github.com/user-attachments/assets/1804912e-1d3b-4d74-9620-34360f925dc3)

### The same runs, side by side

One frame from the middle of the comparison — left is the build before this change, right is after, same churn harness:

![side by side, one frame](https://github.com/user-attachments/assets/a3b804b1-56f4-4668-8196-86d71d65082d)

Boxes are the measuring script's verdict for that frame, drawn during encoding rather than annotated afterwards:

- **red** — a real message bubble that has lost its tail. Two of them on the left, none on the right.
- **blue** — a *deliberately* broken reference bubble, hard-coded to a 5-line height with a 6-line string. It is broken in **both** panes on purpose: it is the positive control, and it stays broken in the "after" pane precisely because that is what shows the detector could still fire at the moment it scored the real bubbles clean. If it ever went unboxed, the zeros in the table below would mean nothing.
- the bar along the bottom flashes when a real bubble is scored broken in that frame, and decays over the next few frames so the flash is catchable at playback speed.

Full clip, slowed to 8fps. The real defect is a flash — 53 of 2135 frames in the before run — so the bar is the thing to watch:

https://github.com/user-attachments/assets/dffe1696-24c7-437e-8558-51dc0dcf288e

### How it was measured

Own simulator (iPhone 14, 390pt — the reported device is 390pt, not 393pt), prebuilt Expo dev client, a scratch route rendering the real `MobileNativeChatMessage` through the real ancestor chain, captured with `simctl io recordVideo` and measured per frame.

Every recording also rendered a **forced-defect control** bubble. The detector flagged it in **100% of frames of every run**, and flags the reported screenshot's broken bubble while passing its three correct siblings — so the zeros below are real zeros, not a blind instrument.

| run | fontScale driver | shorter rows present | frames | bubble renders measured | defects |
|---|---|---|---|---|---|
| `stress2` — list churn + autoscroll + fontScale churn, **constant text** | raw, per frame | yes | 2135 | 8806 | **80** |
| `stress3` — same, fontScale frozen | none | yes | 577 | 2660 | 0 |
| `stress5` — same as stress2, no shorter rows | raw, per frame | no | 1558 | 7763 | 0 |
| **`stress6` — same as stress2, quantized (this change)** | quantized | yes | 1592 | 6546 | **0** |

Counts are one sample per *coded* frame (`-fps_mode passthrough`), and every bubble is scored regardless of where it sits on screen; the control is identified by its pinned position rather than by a screen-half heuristic. Both corrections were made after a first pass got them wrong — the looser rule could have parked a real defect in the control bucket, so the "after" runs were re-scored before being reported.

Also negative with the control live: static mounts at 390pt plus a 300–440pt sweep in the TextKit model, pinch-only, shrink-only, text-growth, width churn, row insert/remove, and hard virtualized scrolling over 40 rows (~10k further bubble renders).

## Tests

- Focused native-chat tests: **4 files, 26 tests passed**.
- Full mobile session suite: **136 files, 1,234 tests passed**.
- Mobile TypeScript typecheck, type-aware/native-plugin lint, formatting, and changed-code quality checks passed.
- The React Native patch applied cleanly against a fresh 0.83.9 package, and its SHA-256 matched the lockfile hash.
- The previously failing Node 26 watcher shard reran locally: **23/23 passed**.
- CI is green, including Mobile Checks, static analysis, typecheck, Node 24/26 shards, macOS packaging, and Windows packaging.

The recycle reset is one O(1) assignment at reuse time; it adds no polling, render-path scans, timers, listeners, or allocation growth.

## Rebuilt native QA

A fresh iOS build from head `1516cdf17f` compiled and installed on an iPhone 17 Pro simulator (iOS 26.5). The built `RCTParagraphComponentView.o` contains `prepareForRecycle` and `EmptyLayoutMetrics`, confirming the patch was in the native client rather than only in Metro source.

In native chat, a six-line user bubble was exercised through five upward and five downward list swipes, a two-finger pinch, additional scrolling, and a return to latest. The tail remained fully painted after churn, with no glyph-edge clipping and no Metro redbox/native error.

![rebuilt iOS native chat after recycle churn](https://github.com/user-attachments/assets/414c8200-d293-455d-9d2c-6387ebde2ebe)

The original before state is not reproducible on the fixed head, so the measured before/harness evidence above remains the comparison. Electron was used only for exact-worktree identity, pairing, and visible desktop sanity; it does not prove the mobile fix. The rebuilt-device pass used a 393pt-class iPhone 17 Pro rather than the original 390pt iPhone 14 report device.

Author: @BrennanKB5
