### PR TITLE
fix(windows): stop a wedged process-table reader retaining a callback per cooldown

### DIFF
--- a/docs/reference/windows-process-enumeration.md
+++ b/docs/reference/windows-process-enumeration.md
@@ -46,6 +46,40 @@ risk — but the headroom is roughly 2x on time and 1.7x on bytes, not the ~4x t
 parse, and the read rejects, so a busy host loses the table rather than
 receiving a wrong one.
 
+## When a read wedges
+
+The vendored reader pushes every callback onto a module-global queue and drains
+that queue only when the request holding its `requestInProgress` latch
+completes. If a Toolhelp32 snapshot never comes back — an EDR hook, a restricted
+token, a worker that dies — the latch is stuck for the life of the process and
+every later call parks another closure in that queue.
+
+Two guards, and they work together:
+
+- a **3 s deadline** on each read, so a caller gets a rejection instead of a
+  promise that never settles;
+- a **sticky wedge**: once a read misses its deadline and has not called back,
+  the module refuses every further read until that read's callback fires.
+
+The wedge used to be a 30 s cooldown that let one probe through per window. That
+bounded the *rate* of new callbacks but not the total: a permanently wedged
+reader retained one more closure every 30 s for as long as the app ran, and each
+probe also blocked its caller for the full 3 s deadline first. Gating on the
+outstanding read instead bounds retention at exactly one callback, and gives up
+nothing on recovery — a probe queued behind the latch could never have observed
+recovery anyway, whereas the stuck callback firing is the drain itself. On the
+relay's bare addon, which has no queue of its own, it is also what keeps Orca
+from re-entering `CreateToolhelp32Snapshot` while a call is still running.
+
+That last part is not just tidiness. The addon runs each read as a
+`Napi::AsyncWorker`, so a wedged read holds a libuv threadpool slot for good. On
+the relay the JS queue is not there to absorb the retries, so one probe per
+window would have pinned all four default threads inside ~2 minutes — hanging
+every async `fs` and DNS call in that process, not only the process table.
+
+A wedge does **not** engage the PowerShell fallback; see the next section for
+why only absence does.
+
 ## The relay has no binding, and falls back
 
 Relay deployment installs only `node-pty` and `@parcel/watcher` on the remote

--- a/src/main/windows/windows-process-table.test.ts
+++ b/src/main/windows/windows-process-table.test.ts
@@ -288,6 +288,27 @@ describe('sticky wedge', () => {
     expect(getAllProcesses).toHaveBeenCalledTimes(2)
   })
 
+  it('ignores a pending timeout from before a test reset', async () => {
+    vi.useFakeTimers()
+    const getAllProcesses = vi.fn((_cb: (rows: typeof NATIVE | undefined) => void) => {})
+    __setWindowsProcessTreeLoaderForTests(() => ({
+      ProcessDataFlag: { None: 0, Memory: 1, CommandLine: 2 },
+      getAllProcesses
+    }))
+
+    const staleRead = readWindowsProcessTableFresh()
+    const staleAssertion = expect(staleRead).rejects.toThrow(/timed out/)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(getAllProcesses).toHaveBeenCalledTimes(1)
+    resetWindowsProcessTableForTests()
+    await vi.advanceTimersByTimeAsync(3_000)
+    await staleAssertion
+
+    getAllProcesses.mockImplementation((cb) => cb(NATIVE))
+    await expect(readWindowsProcessTableFresh()).resolves.toHaveLength(NATIVE.length)
+    expect(getAllProcesses).toHaveBeenCalledTimes(2)
+  })
+
   it('clears the deadline when the reader throws synchronously', async () => {
     // An orphaned timer would fire later and wedge a reader that had recovered.
     vi.useFakeTimers()

--- a/src/main/windows/windows-process-table.test.ts
+++ b/src/main/windows/windows-process-table.test.ts
@@ -184,7 +184,7 @@ describe('PowerShell fallback when the native binding is absent', () => {
   })
 })
 
-describe('wedge cooldown', () => {
+describe('sticky wedge', () => {
   let platform: PropertyDescriptor | undefined
 
   beforeEach(() => {
@@ -204,7 +204,7 @@ describe('wedge cooldown', () => {
     // The vendored reader latches a global while a request is in flight and
     // drains its queue only when that request completes. In the wedge this
     // guards against it never does, so every retry would add a closure that is
-    // never called. One probe per cooldown bounds that.
+    // never called.
     vi.useFakeTimers()
     const getAllProcesses = vi.fn(() => {})
     __setWindowsProcessTreeLoaderForTests(() => ({
@@ -218,15 +218,15 @@ describe('wedge cooldown', () => {
     await firstAssertion
     expect(getAllProcesses).toHaveBeenCalledTimes(1)
 
-    await expect(readWindowsProcessTableFresh()).rejects.toThrow(/cooling down/)
+    await expect(readWindowsProcessTableFresh()).rejects.toThrow(/wedged/)
     expect(getAllProcesses).toHaveBeenCalledTimes(1)
   })
 
-  it('lets exactly one caller probe when the cooldown expires', async () => {
-    // Without claiming the recovery slot before probing, every concurrent
-    // caller passes the cooldown check at expiry and each enqueues a callback
-    // into the still-latched native queue -- so each cycle leaks another batch
-    // rather than bounding it to one probe.
+  it('never re-enters the reader while the timed-out read is still out', async () => {
+    // A cooldown bounds the RATE of new callbacks, not the total: one probe per
+    // window still retains one more closure in the still-latched native queue
+    // every window, for the life of the app. Only the outstanding read can
+    // reopen the gate, so a permanent wedge retains exactly one callback.
     vi.useFakeTimers()
     const getAllProcesses = vi.fn(() => {})
     __setWindowsProcessTreeLoaderForTests(() => ({
@@ -240,16 +240,51 @@ describe('wedge cooldown', () => {
     await wedgeAssertion
     expect(getAllProcesses).toHaveBeenCalledTimes(1)
 
-    await vi.advanceTimersByTimeAsync(30_000)
-    const attempts = [
-      readWindowsProcessTableFresh().catch(() => 'rejected'),
-      readWindowsProcessTableFresh().catch(() => 'rejected'),
-      readWindowsProcessTableFresh().catch(() => 'rejected')
-    ]
-    await vi.advanceTimersByTimeAsync(3_000)
-    await Promise.all(attempts)
+    // Four windows of the cooldown this replaced, each with concurrent callers.
+    // Rejection reasons are deliberately not asserted here: the leak this test
+    // pins is the call count, and it must fail on that alone.
+    for (let window = 0; window < 4; window += 1) {
+      await vi.advanceTimersByTimeAsync(30_000)
+      const attempts = [
+        readWindowsProcessTableFresh().catch(() => 'rejected'),
+        readWindowsProcessTableFresh().catch(() => 'rejected'),
+        readWindowsProcessTableFresh().catch(() => 'rejected')
+      ]
+      // Long enough for a probe's own deadline, had one been let through.
+      await vi.advanceTimersByTimeAsync(3_000)
+      expect(await Promise.all(attempts)).toEqual(['rejected', 'rejected', 'rejected'])
+    }
 
-    // One recovery probe, not three.
+    // Still the one callback the wedge is holding -- not one more per window.
+    expect(getAllProcesses).toHaveBeenCalledTimes(1)
+  })
+
+  it('resumes as soon as the timed-out read finally calls back', async () => {
+    // The stuck request completing is what drains the vendored queue, so it is
+    // the only honest evidence the reader recovered. Waiting out a wall clock
+    // afterwards would strand a reader that is already answering.
+    vi.useFakeTimers()
+    let stuck: ((rows: typeof NATIVE | undefined) => void) | undefined
+    const getAllProcesses = vi.fn((cb: (rows: typeof NATIVE | undefined) => void) => {
+      if (stuck) {
+        cb(NATIVE)
+        return
+      }
+      stuck = cb
+    })
+    __setWindowsProcessTreeLoaderForTests(() => ({
+      ProcessDataFlag: { None: 0, Memory: 1, CommandLine: 2 },
+      getAllProcesses
+    }))
+
+    const wedge = readWindowsProcessTableFresh()
+    const wedgeAssertion = expect(wedge).rejects.toThrow(/timed out/)
+    await vi.advanceTimersByTimeAsync(3_000)
+    await wedgeAssertion
+    await expect(readWindowsProcessTableFresh()).rejects.toThrow(/wedged/)
+
+    stuck?.(NATIVE)
+    await expect(readWindowsProcessTableFresh()).resolves.toHaveLength(NATIVE.length)
     expect(getAllProcesses).toHaveBeenCalledTimes(2)
   })
 

--- a/src/main/windows/windows-process-table.ts
+++ b/src/main/windows/windows-process-table.ts
@@ -147,24 +147,17 @@ const WINDOWS_PROCESS_QUERY_TIMEOUT_MS = 3_000
 
 /**
  * Reads that missed their deadline and have not called back yet.
- *
- * Why the wedge is sticky rather than a cooldown: a timed-out call leaves its
- * callback in the vendored module's queue, and that queue drains only when the
- * latched request completes -- which, in the wedge this guards against, never
- * happens. Probing again on a timer bounded the *rate* of new callbacks, not
- * the total: a permanently wedged reader retained one more closure every
- * cooldown for the life of the app. Refusing while the earlier read is still
- * out bounds it at one, and that read's callback finally firing is the only
- * honest evidence the queue drained -- strictly better than a wall-clock guess,
- * because a probe enqueued behind the latch could never have observed recovery
- * anyway. It also keeps the relay's bare addon, which has no queue of its own,
- * from re-entering CreateToolhelp32Snapshot while a call is still running.
- *
- * A set rather than a counter so a test reset, or a callback that arrives after
- * one, can never drive the tally negative and re-open the gate.
+ * Refusing re-entry bounds both vendored callbacks and relay addon workers to
+ * one; read ids keep a late callback from clearing a newer wedge.
  */
 const unreturnedReads = new Set<number>()
 let readSequence = 0
+let nativeReaderEpoch = 0
+
+function resetNativeReaderState(): void {
+  nativeReaderEpoch += 1
+  unreturnedReads.clear()
+}
 
 function readNativeRows(): Promise<WindowsProcessRow[]> {
   const native = moduleLoader()
@@ -188,6 +181,7 @@ function readNativeRows(): Promise<WindowsProcessRow[]> {
     )
   }
   const readId = ++readSequence
+  const readerEpoch = nativeReaderEpoch
   // Why always both flags: each adds an OpenProcess per process (Memory a
   // GetProcessMemoryInfo, CommandLine a PEB read), so asking for less would be
   // cheaper -- 15.9ms p50 versus 30.6ms at 1050 processes. But every read shares
@@ -202,7 +196,10 @@ function readNativeRows(): Promise<WindowsProcessRow[]> {
     let deadline: ReturnType<typeof setTimeout> | undefined
     try {
       deadline = setTimeout(() => {
-        unreturnedReads.add(readId)
+        // Test resets invalidate deadlines owned by the prior injected reader.
+        if (readerEpoch === nativeReaderEpoch) {
+          unreturnedReads.add(readId)
+        }
         reject(new Error('windows process table timed out'))
       }, WINDOWS_PROCESS_QUERY_TIMEOUT_MS)
       deadline.unref?.()
@@ -299,7 +296,7 @@ export function __setWindowsProcessTreeLoaderForTests(
 ): void {
   moduleLoader = loader ?? loadWindowsProcessTree
   cachedModule = undefined
-  unreturnedReads.clear()
+  resetNativeReaderState()
   snapshotReader.reset()
 }
 
@@ -310,7 +307,7 @@ export function __setWindowsProcessTreeRequireForTests(
   requireNative = resolve ?? requireFromMain
   moduleLoader = loadWindowsProcessTree
   cachedModule = undefined
-  unreturnedReads.clear()
+  resetNativeReaderState()
   snapshotReader.reset()
 }
 
@@ -326,5 +323,5 @@ export function __setWindowsProcessTableCimScanForTests(
 export function resetWindowsProcessTableForTests(): void {
   snapshotReader.reset()
   cachedModule = undefined
-  unreturnedReads.clear()
+  resetNativeReaderState()
 }

--- a/src/main/windows/windows-process-table.ts
+++ b/src/main/windows/windows-process-table.ts
@@ -146,20 +146,25 @@ function loadWindowsProcessTree(): WindowsProcessTreeModule | null {
 const WINDOWS_PROCESS_QUERY_TIMEOUT_MS = 3_000
 
 /**
- * How long to stop calling the reader after it misses its deadline.
+ * Reads that missed their deadline and have not called back yet.
  *
- * Why a cooldown and not just the deadline: a timed-out call leaves its
- * callback in the vendored module's queue, and that queue only drains when the
- * latched request finally completes -- which, in the wedge this guards against,
- * never happens. Retrying at the caller's poll rate would then add a closure
- * per tick forever. One probe per cooldown bounds it.
+ * Why the wedge is sticky rather than a cooldown: a timed-out call leaves its
+ * callback in the vendored module's queue, and that queue drains only when the
+ * latched request completes -- which, in the wedge this guards against, never
+ * happens. Probing again on a timer bounded the *rate* of new callbacks, not
+ * the total: a permanently wedged reader retained one more closure every
+ * cooldown for the life of the app. Refusing while the earlier read is still
+ * out bounds it at one, and that read's callback finally firing is the only
+ * honest evidence the queue drained -- strictly better than a wall-clock guess,
+ * because a probe enqueued behind the latch could never have observed recovery
+ * anyway. It also keeps the relay's bare addon, which has no queue of its own,
+ * from re-entering CreateToolhelp32Snapshot while a call is still running.
+ *
+ * A set rather than a counter so a test reset, or a callback that arrives after
+ * one, can never drive the tally negative and re-open the gate.
  */
-const WINDOWS_PROCESS_QUERY_COOLDOWN_MS = 30_000
-
-let wedgedUntilMs = 0
-// Why a generation: a request that already lost its deadline must not later
-// clear or re-arm the wedge on behalf of the request that replaced it.
-let readGeneration = 0
+const unreturnedReads = new Set<number>()
+let readSequence = 0
 
 function readNativeRows(): Promise<WindowsProcessRow[]> {
   const native = moduleLoader()
@@ -177,19 +182,12 @@ function readNativeRows(): Promise<WindowsProcessRow[]> {
     // tree dead. "Unavailable" has to stay distinguishable from "empty".
     return Promise.reject(new Error('windows process table unavailable'))
   }
-  const startedAt = Date.now()
-  if (startedAt < wedgedUntilMs) {
-    return Promise.reject(new Error('windows process table is cooling down after a timeout'))
+  if (unreturnedReads.size > 0) {
+    return Promise.reject(
+      new Error('windows process table is wedged: an earlier read has not returned')
+    )
   }
-  if (wedgedUntilMs > 0) {
-    // Coming out of a wedge: re-arm the cooldown BEFORE probing, so exactly one
-    // caller gets through. Without this every concurrent caller passes the
-    // check above at expiry, each enqueues a callback into the still-latched
-    // native queue, and each cooldown cycle leaks another batch rather than
-    // bounding it to one probe.
-    wedgedUntilMs = startedAt + WINDOWS_PROCESS_QUERY_COOLDOWN_MS
-  }
-  const generation = ++readGeneration
+  const readId = ++readSequence
   // Why always both flags: each adds an OpenProcess per process (Memory a
   // GetProcessMemoryInfo, CommandLine a PEB read), so asking for less would be
   // cheaper -- 15.9ms p50 versus 30.6ms at 1050 processes. But every read shares
@@ -204,18 +202,16 @@ function readNativeRows(): Promise<WindowsProcessRow[]> {
     let deadline: ReturnType<typeof setTimeout> | undefined
     try {
       deadline = setTimeout(() => {
-        if (generation === readGeneration) {
-          wedgedUntilMs = Date.now() + WINDOWS_PROCESS_QUERY_COOLDOWN_MS
-        }
+        unreturnedReads.add(readId)
         reject(new Error('windows process table timed out'))
       }, WINDOWS_PROCESS_QUERY_TIMEOUT_MS)
       deadline.unref?.()
       native.getAllProcesses((processes) => {
         clearTimeout(deadline)
-        // A callback proves the reader is answering, so stop refusing.
-        if (generation === readGeneration) {
-          wedgedUntilMs = 0
-        }
+        // A callback proves this read drained, so stop refusing. Unconditional:
+        // dropping an id that was never added is a no-op, and only the read
+        // that actually wedged can be holding the gate shut.
+        unreturnedReads.delete(readId)
         if (!processes) {
           reject(new Error('windows process table returned no snapshot'))
           return
@@ -303,7 +299,7 @@ export function __setWindowsProcessTreeLoaderForTests(
 ): void {
   moduleLoader = loader ?? loadWindowsProcessTree
   cachedModule = undefined
-  wedgedUntilMs = 0
+  unreturnedReads.clear()
   snapshotReader.reset()
 }
 
@@ -314,7 +310,7 @@ export function __setWindowsProcessTreeRequireForTests(
   requireNative = resolve ?? requireFromMain
   moduleLoader = loadWindowsProcessTree
   cachedModule = undefined
-  wedgedUntilMs = 0
+  unreturnedReads.clear()
   snapshotReader.reset()
 }
 
@@ -330,5 +326,5 @@ export function __setWindowsProcessTableCimScanForTests(
 export function resetWindowsProcessTableForTests(): void {
   snapshotReader.reset()
   cachedModule = undefined
-  wedgedUntilMs = 0
+  unreturnedReads.clear()
 }


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​72 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​16 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​56 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​60 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​33 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​27 |

<!-- /orca-pr-loc -->

## What's wrong

`src/main/windows/windows-process-table.ts` guards the vendored Toolhelp32 reader with a 3 s deadline plus a 30 s cooldown. The cooldown let exactly one probe through per window — deliberately, to avoid retrying at the caller's poll rate.

That bounds the **rate** of new callbacks, not the **total**. The vendored wrapper pushes every callback onto a module-global queue and drains it only when the request holding its `requestInProgress` latch completes:

```js
// @vscode/windows-process-tree lib/index.js
const globalRequestQueue = []
function getRawProcessList(callback, flags) {
  globalRequestQueue.push(callback)
  if (!requestInProgress) { requestInProgress = true; native.getProcessList(...) }
}
```

If a snapshot never comes back — EDR hook, restricted token, a worker that dies — that latch is stuck for the life of the process. So each cooldown window parked one more closure in `globalRequestQueue`, forever, and blocked whichever caller drew the probe for the full 3 s deadline first.

## The fix

Gate on the outstanding read rather than a wall clock. Once a read misses its deadline and has not called back, every further read is refused until that read's callback fires.

- **Retention is bounded at exactly one callback**, instead of one more every 30 s for the life of the app.
- **Nothing is given up on recovery.** A probe enqueued behind the latch could never have observed the drain anyway; the stuck callback firing *is* the drain. The reader now resumes the instant it recovers instead of up to 30 s later.
- **Wedged reads reject immediately** rather than blocking a caller 3 s per window.

A `Set` of read ids rather than a counter, so a test reset — or a callback arriving after one — can never drive the tally negative and re-open the gate.

### Why it matters more on a relay

A relay binds the bare addon, which has no JS queue to absorb the retries. Each read there is a `Napi::AsyncWorker` (`worker->Queue()` in `addon.cc`), so a wedged one holds a libuv threadpool slot permanently. One probe per window would have pinned all four default threads inside ~2 minutes, hanging every async `fs` and DNS call in the relay process — not just the process table.

### Deliberate trade-off

A permanently wedged native reader is now permanently refused on that host, where before it retried every 30 s. That is the intended shape: the wedge conditions are host-wide, so a retry hangs too, and on the addon path each retry is a lost threadpool slot. Callers already treat a rejection as *unverifiable* rather than as evidence a process died.

## What is unchanged

- A wedge still does **not** engage the PowerShell/CIM fallback — only module absence does (`docs/reference/windows-process-enumeration.md`). A present-but-failing reader must never start forking shells at the caller's poll rate.
- A wedged read still **rejects** rather than resolving empty, so "unavailable" stays distinguishable from "nothing is running" per `docs/reference/ssh-execution-boundary.md`.
- No wire, IPC, or cross-host contract touched. macOS/Linux/folder-workspace paths are byte-identical (the module resolves `null` off Windows and returns before the new gate).

## Tests

`src/main/windows/windows-process-table.test.ts` — the `wedge cooldown` block becomes `sticky wedge`:

| test | proves |
| --- | --- |
| `never re-enters the reader while the timed-out read is still out` | **the regression.** Four cooldown windows, three concurrent callers each. Asserts call count only, not messages. |
| `resumes as soon as the timed-out read finally calls back` | recovery is driven by the drain, with no wall-clock wait |
| `stops calling the reader after a timeout…` | first read after a wedge is refused |
| `clears the deadline when the reader throws synchronously` | unchanged — a sync throw must not wedge a recovered reader |

Non-vacuous — reverting only `windows-process-table.ts` and re-running:

```
× never re-enters the reader while the timed-out read is still out
  AssertionError: expected "vi.fn()" to be called 1 times, but got 5 times
      Tests  3 failed | 20 passed (23)
```

`5 = 1 + one per cooldown window` — the leak itself, measured.

## Checks

- `pnpm test src/main/windows src/main/providers src/main/ports src/shared/process-table-snapshot.test.ts` → 950 passed, 12 skipped
- `pnpm tc` → clean
- `oxlint` + `oxfmt` → clean (pre-commit hook)

## Not validated here

Windows-only runtime path; no Electron UI surface is involved, so there is nothing for CDP to observe. The wedge itself is not reproducible on macOS — it needs a real Toolhelp32 snapshot that never returns.

Fixes STA-5499.


## Reliability contract

- **Invariant (`terminal-session.windows-process-table-bounded-liveness`):** one timed-out native read may remain outstanding; later reads cannot add callbacks or relay workers until it returns, and a test reset cannot let an earlier deadline wedge the new reader generation. Process-table failure remains unavailable/unverifiable, never evidence that a process exited.
- **Failure source:** STA-5499 plus the reset-before-timeout review finding on PR #16696.
- **Oracle and gate:** `src/main/windows/windows-process-table.test.ts` uses fake time to prove four former cooldown windows retain one native call, recovery follows the original callback, and a pre-reset deadline cannot block a healthy post-reset read. This is focused evidence under the existing experimental `terminal-session.explicit-close-retirement` process-table gate.
- **Provider/platform coverage:** the npm wrapper and relay bare-addon paths share the same gate; CIM fallback remains absence-only. macOS/Linux still return before the Windows native path, and no IPC, wire, persistence, folder-workspace, WSL, SSH, remote-runtime, or mobile contract changes. Real Windows packaging is covered by PR CI; a genuinely wedged Toolhelp32 snapshot remains an accepted live-runtime gap.
- **Performance budget and diagnostics:** the permanent-wedge oracle bounds native calls and retained callbacks/workers at one, with no polling, retries, scans, subprocesses, listeners, or new timers. Existing `timed out` and `wedged` errors plus deterministic native-call counts identify the failure mode.
