### PR TITLE
fix(worktree): ignore orphan remote-tracking refs in branch conflicts

### DIFF
--- a/src/main/git/repo-base-ref-search.ts
+++ b/src/main/git/repo-base-ref-search.ts
@@ -218,6 +218,21 @@ export function parseAndFilterSearchRefDetails(
     .slice(0, Math.max(0, limit))
 }
 
+export function resolveConfiguredRemoteBranchName(
+  fullRef: string,
+  longestFirstRemoteNames: readonly string[]
+): string | null {
+  const remoteRefPrefix = 'refs/remotes/'
+  if (!fullRef.startsWith(remoteRefPrefix)) {
+    return null
+  }
+  const remoteAndBranch = fullRef.slice(remoteRefPrefix.length)
+  const remote = longestFirstRemoteNames.find((candidate) =>
+    remoteAndBranch.startsWith(`${candidate}/`)
+  )
+  return remote ? remoteAndBranch.slice(remote.length + 1) || null : null
+}
+
 export function resolveLocalBranchName(
   fullRef: string,
   shortRef: string,
@@ -227,11 +242,11 @@ export function resolveLocalBranchName(
   if (!fullRef.startsWith(remoteRefPrefix)) {
     return shortRef
   }
-  const remoteAndBranch = fullRef.slice(remoteRefPrefix.length)
-  const remote = remotes.find((candidate) => remoteAndBranch.startsWith(`${candidate}/`))
-  if (remote) {
-    return remoteAndBranch.slice(remote.length + 1)
+  const configuredBranch = resolveConfiguredRemoteBranchName(fullRef, remotes)
+  if (configuredBranch) {
+    return configuredBranch
   }
+  const remoteAndBranch = fullRef.slice(remoteRefPrefix.length)
   return remoteAndBranch.split('/').slice(1).join('/') || shortRef
 }
 

--- a/src/main/git/repo-branch-conflict.ts
+++ b/src/main/git/repo-branch-conflict.ts
@@ -4,6 +4,7 @@ import { gitExecFileAsync } from './runner'
 
 export type BranchConflictKind = 'local' | 'remote'
 
+/** Whether `ref` resolves in the repository at `path`. */
 async function hasGitRefAsync(
   path: string,
   ref: string,
@@ -17,6 +18,10 @@ async function hasGitRefAsync(
   }
 }
 
+/**
+ * Whether `branchName` is already taken, and by what. Only refs under a configured
+ * remote count as remote conflicts; `allowedBaseRef` exempts the ref being branched from.
+ */
 export async function getBranchConflictKind(
   path: string,
   branchName: string,
@@ -39,6 +44,12 @@ export async function getBranchConflictKind(
         return false
       }
       const shortRef = trimmed.replace(/^refs\/remotes\//, '')
+      // Why: a ref under a prefix no configured remote owns tracks nothing — a
+      // hand-planted ref, or a fork remote that was removed — so it cannot collide
+      // with a new local branch. Ref *display* still resolves those leniently.
+      if (!remoteNames.some((candidate) => shortRef.startsWith(`${candidate}/`))) {
+        return false
+      }
       return resolveLocalBranchName(trimmed, shortRef, remoteNames) === branchName
     })
 
@@ -48,6 +59,7 @@ export async function getBranchConflictKind(
   }
 }
 
+/** The one remote ref a caller may branch from without it counting as a conflict. */
 function isAllowedRemoteBaseRef(refName: string, allowedBaseRef: string | undefined): boolean {
   if (!allowedBaseRef) {
     return false

--- a/src/main/git/repo-branch-conflict.ts
+++ b/src/main/git/repo-branch-conflict.ts
@@ -1,56 +1,50 @@
-import { listRemoteNames, resolveLocalBranchName } from './repo-base-ref-search'
-import { gitExecOptions, type LocalGitExecOptions } from './repo-default-base-ref'
+import { resolveConfiguredRemoteBranchName } from './repo-base-ref-search'
+import { gitExecOptions, type GitExec, type LocalGitExecOptions } from './repo-default-base-ref'
 import { gitExecFileAsync } from './runner'
 
 export type BranchConflictKind = 'local' | 'remote'
 
-/** Whether `ref` resolves in the repository at `path`. */
-async function hasGitRefAsync(
-  path: string,
-  ref: string,
-  options: LocalGitExecOptions = {}
-): Promise<boolean> {
+async function hasGitRefAsync(exec: GitExec, ref: string): Promise<boolean> {
   try {
-    await gitExecFileAsync(['rev-parse', '--verify', ref], gitExecOptions(path, options))
-    return true
+    const { stdout } = await exec(['rev-parse', '--verify', ref])
+    return stdout.trim().length > 0
   } catch {
     return false
   }
 }
 
-/**
- * Whether `branchName` is already taken, and by what. Only refs under a configured
- * remote count as remote conflicts; `allowedBaseRef` exempts the ref being branched from.
- */
-export async function getBranchConflictKind(
-  path: string,
+async function listRemoteNamesViaExec(exec: GitExec): Promise<string[]> {
+  try {
+    const { stdout } = await exec(['remote'])
+    return stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .sort((a, b) => b.length - a.length)
+  } catch {
+    return []
+  }
+}
+
+/** Run branch-conflict policy through the host that owns Git execution. */
+export async function getBranchConflictKindViaExec(
+  exec: GitExec,
   branchName: string,
-  allowedBaseRef?: string,
-  options: LocalGitExecOptions = {}
+  allowedBaseRef?: string
 ): Promise<BranchConflictKind | null> {
-  if (await hasGitRefAsync(path, `refs/heads/${branchName}`, options)) {
+  if (await hasGitRefAsync(exec, `refs/heads/${branchName}`)) {
     return 'local'
   }
 
   try {
-    const remoteNames = (await listRemoteNames(path, options)).sort((a, b) => b.length - a.length)
-    const { stdout } = await gitExecFileAsync(
-      ['for-each-ref', '--format=%(refname)', 'refs/remotes'],
-      gitExecOptions(path, options)
-    )
-    const hasRemoteConflict = stdout.split('\n').some((ref) => {
+    const remoteNames = await listRemoteNamesViaExec(exec)
+    const { stdout } = await exec(['for-each-ref', '--format=%(refname)', 'refs/remotes'])
+    const hasRemoteConflict = stdout.split(/\r?\n/).some((ref) => {
       const trimmed = ref.trim()
       if (isAllowedRemoteBaseRef(trimmed, allowedBaseRef)) {
         return false
       }
-      const shortRef = trimmed.replace(/^refs\/remotes\//, '')
-      // Why: a ref under a prefix no configured remote owns tracks nothing — a
-      // hand-planted ref, or a fork remote that was removed — so it cannot collide
-      // with a new local branch. Ref *display* still resolves those leniently.
-      if (!remoteNames.some((candidate) => shortRef.startsWith(`${candidate}/`))) {
-        return false
-      }
-      return resolveLocalBranchName(trimmed, shortRef, remoteNames) === branchName
+      return resolveConfiguredRemoteBranchName(trimmed, remoteNames) === branchName
     })
 
     return hasRemoteConflict ? 'remote' : null
@@ -59,7 +53,20 @@ export async function getBranchConflictKind(
   }
 }
 
-/** The one remote ref a caller may branch from without it counting as a conflict. */
+export function getBranchConflictKind(
+  path: string,
+  branchName: string,
+  allowedBaseRef?: string,
+  options: LocalGitExecOptions = {}
+): Promise<BranchConflictKind | null> {
+  const execOptions = gitExecOptions(path, options)
+  return getBranchConflictKindViaExec(
+    (argv) => gitExecFileAsync(argv, execOptions),
+    branchName,
+    allowedBaseRef
+  )
+}
+
 function isAllowedRemoteBaseRef(refName: string, allowedBaseRef: string | undefined): boolean {
   if (!allowedBaseRef) {
     return false

--- a/src/main/git/repo.test.ts
+++ b/src/main/git/repo.test.ts
@@ -215,6 +215,7 @@ describe('searchBaseRefs (widened glob)', () => {
 
   it('allows creating a local branch from the selected matching remote base ref', async () => {
     const sha = getHeadSha(tmpDir)
+    git(tmpDir, ['remote', 'add', 'origin', 'https://example.invalid/repo.git'])
     createRemoteRef(tmpDir, 'origin/feature/something', sha)
 
     const result = await getBranchConflictKind(

--- a/src/main/git/repo.test.ts
+++ b/src/main/git/repo.test.ts
@@ -228,12 +228,48 @@ describe('searchBaseRefs (widened glob)', () => {
 
   it('still reports a remote conflict for a different tracking ref with the same branch name', async () => {
     const sha = getHeadSha(tmpDir)
+    // Why register both: a ref only tracks a branch when a remote actually owns its
+    // prefix, and this case is about a second *tracking* ref, not an orphan.
+    git(tmpDir, ['remote', 'add', 'origin', 'https://example.invalid/repo.git'])
+    git(tmpDir, ['remote', 'add', 'upstream', 'https://example.invalid/upstream.git'])
     createRemoteRef(tmpDir, 'origin/feature/something', sha)
     createRemoteRef(tmpDir, 'upstream/feature/something', sha)
 
     expect(
       await getBranchConflictKind(tmpDir, 'feature/something', 'origin/feature/something')
     ).toBe('remote')
+  })
+
+  it('ignores a ref whose prefix matches no configured remote', async () => {
+    const sha = getHeadSha(tmpDir)
+    git(tmpDir, ['remote', 'add', 'origin', 'https://example.invalid/repo.git'])
+    createRemoteRef(tmpDir, 'mimic-fork/my-task', sha)
+
+    expect(await getBranchConflictKind(tmpDir, 'my-task', 'origin/main')).toBeNull()
+  })
+
+  it('stops treating leftover refs from a removed remote as conflicts', async () => {
+    const sha = getHeadSha(tmpDir)
+    git(tmpDir, ['remote', 'add', 'origin', 'https://example.invalid/repo.git'])
+    git(tmpDir, ['remote', 'add', 'fork', 'https://example.invalid/fork.git'])
+    createRemoteRef(tmpDir, 'fork/my-task', sha)
+    expect(await getBranchConflictKind(tmpDir, 'my-task', 'origin/main')).toBe('remote')
+
+    // Why not `remote remove`: that prunes the tracking refs too, which would pass
+    // with or without the ownership guard. Dropping only the config leaves the
+    // orphan ref behind, which is the state this guard exists for.
+    git(tmpDir, ['config', '--remove-section', 'remote.fork'])
+
+    expect(await getBranchConflictKind(tmpDir, 'my-task', 'origin/main')).toBeNull()
+  })
+
+  it('still reports a local conflict when an unrelated ref shares the name', async () => {
+    const sha = getHeadSha(tmpDir)
+    git(tmpDir, ['remote', 'add', 'origin', 'https://example.invalid/repo.git'])
+    createRemoteRef(tmpDir, 'mimic-fork/my-task', sha)
+    git(tmpDir, ['branch', 'my-task'])
+
+    expect(await getBranchConflictKind(tmpDir, 'my-task', 'origin/main')).toBe('local')
   })
 
   it('reports remote conflicts when the remote name contains a slash', async () => {

--- a/src/main/ipc/worktree-remote-ssh-branch-conflict.test.ts
+++ b/src/main/ipc/worktree-remote-ssh-branch-conflict.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { getSshBranchConflictKind } from './worktree-remote'
+
+type ConflictProvider = Parameters<typeof getSshBranchConflictKind>[0]
+
+function providerAnswering(answers: {
+  remotes: string[]
+  localBranchHead?: string
+  remoteRefs: string[]
+}): ConflictProvider {
+  const exec: ConflictProvider['exec'] = vi.fn(async (args: string[]) => {
+    if (args[0] === 'remote') {
+      return { stdout: `${answers.remotes.join('\n')}\n`, stderr: '' }
+    }
+    if (args[0] === 'rev-parse') {
+      if (!answers.localBranchHead) {
+        throw new Error('missing ref')
+      }
+      return { stdout: `${answers.localBranchHead}\n`, stderr: '' }
+    }
+    if (args[0] === 'for-each-ref') {
+      return { stdout: `${answers.remoteRefs.join('\n')}\n`, stderr: '' }
+    }
+    throw new Error(`unexpected git ${args.join(' ')}`)
+  })
+  return { exec }
+}
+
+describe('getSshBranchConflictKind remote ownership', () => {
+  it('reports a local branch before scanning remote refs', async () => {
+    const provider = providerAnswering({
+      localBranchHead: 'abc123',
+      remotes: ['origin'],
+      remoteRefs: []
+    })
+
+    await expect(
+      getSshBranchConflictKind(provider, '/srv/repo', 'my-task', 'origin/main')
+    ).resolves.toBe('local')
+  })
+
+  it('ignores a ref whose prefix matches no configured remote', async () => {
+    const provider = providerAnswering({
+      remotes: ['origin'],
+      remoteRefs: ['refs/remotes/origin/main', 'refs/remotes/deleted-fork/my-task']
+    })
+
+    await expect(
+      getSshBranchConflictKind(provider, '/srv/repo', 'my-task', 'origin/main')
+    ).resolves.toBeNull()
+  })
+
+  it('still reports a ref owned by a configured remote', async () => {
+    const provider = providerAnswering({
+      remotes: ['origin'],
+      remoteRefs: ['refs/remotes/origin/main', 'refs/remotes/origin/my-task']
+    })
+
+    await expect(
+      getSshBranchConflictKind(provider, '/srv/repo', 'my-task', 'origin/main')
+    ).resolves.toBe('remote')
+  })
+
+  it('prefers the longest configured remote name', async () => {
+    const provider = providerAnswering({
+      remotes: ['foo', 'foo/bar'],
+      remoteRefs: ['refs/remotes/foo/bar/my-task']
+    })
+
+    await expect(
+      getSshBranchConflictKind(provider, '/srv/repo', 'my-task', 'origin/main')
+    ).resolves.toBe('remote')
+  })
+})

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -33,6 +33,7 @@ import {
   resolveDefaultBaseRefViaExec,
   resolveDefaultBaseRefWithLocalGit
 } from '../git/repo'
+import { getBranchConflictKindViaExec } from '../git/repo-branch-conflict'
 import { resolveLocalGitUsername, getSshGitUsername } from '../git/git-username'
 import { hasCommitObjectViaGitExec } from '../git/commit-object-ref'
 import { probeWorktreeBaseRefPresence } from '../git/worktree-base-ref-probe'
@@ -764,98 +765,19 @@ async function canCheckoutExistingLocalBranchSsh(
   return !worktrees.some((worktree) => normalizeLocalBranchName(worktree.branch) === branchName)
 }
 
-async function listSshRemoteNames(provider: SshGitProvider, repoPath: string): Promise<string[]> {
-  try {
-    const { stdout } = await provider.exec(['remote'], repoPath)
-    return stdout
-      .split(/\r?\n/)
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .sort((a, b) => b.length - a.length)
-  } catch {
-    return []
-  }
-}
+type SshGitExecutor = Pick<SshGitProvider, 'exec'>
 
-function isAllowedSshRemoteBaseRef(refName: string, allowedBaseRef: string): boolean {
-  if (!allowedBaseRef) {
-    return false
-  }
-  const normalizedAllowedRef = allowedBaseRef.startsWith('refs/remotes/')
-    ? allowedBaseRef
-    : `refs/remotes/${allowedBaseRef}`
-  return refName === normalizedAllowedRef
-}
-
-function resolveSshRemoteBranchName(refName: string, remoteNames: string[]): string {
-  const remotePrefix = 'refs/remotes/'
-  if (!refName.startsWith(remotePrefix)) {
-    return refName
-  }
-  const remoteAndBranch = refName.slice(remotePrefix.length)
-  const remote = remoteNames.find((candidate) => remoteAndBranch.startsWith(`${candidate}/`))
-  if (remote) {
-    return remoteAndBranch.slice(remote.length + 1)
-  }
-  return remoteAndBranch.split('/').slice(1).join('/') || remoteAndBranch
-}
-
-async function hasSshRemoteBranchConflict(
-  provider: SshGitProvider,
-  repoPath: string,
-  branchName: string,
-  allowedBaseRef: string
-): Promise<boolean> {
-  const remoteNames = await listSshRemoteNames(provider, repoPath)
-  try {
-    const { stdout } = await provider.exec(
-      ['for-each-ref', '--format=%(refname)', 'refs/remotes'],
-      repoPath
-    )
-    return stdout.split(/\r?\n/).some((line) => {
-      const refName = line.trim()
-      if (!refName || /^refs\/remotes\/.+\/HEAD$/.test(refName)) {
-        return false
-      }
-      if (isAllowedSshRemoteBaseRef(refName, allowedBaseRef)) {
-        return false
-      }
-      // Why: `git branch --all --list feature/x` doesn't match `remotes/origin/feature/x`; parse remote refs directly.
-      return resolveSshRemoteBranchName(refName, remoteNames) === branchName
-    })
-  } catch {
-    return false
-  }
-}
-
-async function hasSshLocalBranchConflict(
-  provider: SshGitProvider,
-  repoPath: string,
-  branchName: string
-): Promise<boolean> {
-  try {
-    const { stdout } = await provider.exec(
-      ['rev-parse', '--verify', '--quiet', `refs/heads/${branchName}^{commit}`],
-      repoPath
-    )
-    return stdout.trim().length > 0
-  } catch {
-    return false
-  }
-}
-
-async function getSshBranchConflictKind(
-  provider: SshGitProvider,
+export function getSshBranchConflictKind(
+  provider: SshGitExecutor,
   repoPath: string,
   branchName: string,
   allowedBaseRef: string
 ): Promise<'local' | 'remote' | null> {
-  if (await hasSshLocalBranchConflict(provider, repoPath, branchName)) {
-    return 'local'
-  }
-  return (await hasSshRemoteBranchConflict(provider, repoPath, branchName, allowedBaseRef))
-    ? 'remote'
-    : null
+  return getBranchConflictKindViaExec(
+    (argv) => provider.exec(argv, repoPath),
+    branchName,
+    allowedBaseRef
+  )
 }
 
 type SelectedReviewBranchInput = Pick<


### PR DESCRIPTION
## ELI5

Orca was treating a leftover name under refs/remotes as a real remote branch, so worktree creation could add an unnecessary -2 suffix. The original fix corrected native and WSL creation; the maintainer follow-up makes direct SSH use the same rule.

## What changed

- Added resolveConfiguredRemoteBranchName beside the existing lenient display resolver. It returns null when no configured remote matches the ref prefix.
- Routed native, WSL, and direct SSH branch-conflict checks through one getBranchConflictKindViaExec policy owned by the host that runs Git.
- Removed the duplicated SSH remote-name parser and conflict classifier.
- Added real-Git coverage for orphan and removed-remote refs, preserved local/configured-remote behavior, repaired the selected-base test so it is not vacuous, and added focused SSH parity coverage.

The final production diff is smaller than the original implementation because the SSH copy is deleted.

## Why

Ref display may reasonably guess a friendly branch name for an unfamiliar prefix. Conflict detection cannot: a hand-planted ref or a ref left behind after removing a remote does not belong to a configured remote and must not reserve a local branch name.

Centralizing the decision behind a Git executor also preserves the execution boundary: local Git stays local, WSL stays in its distro, and direct SSH runs every probe on the SSH host.

## Scope

Refs #16646 — partial.

This fixes orphan-prefix and removed-remote refs across native, WSL, and direct SSH creation. Conflicts from currently configured remotes remain unchanged, including the real fork-review cases discussed on the issue. The issue must remain open for that configured-remote and custom-refspec scope.

## Verification

- 59 focused tests passed across repo policy/API parity, SSH policy, and SSH worktree-create behavior.
- pnpm tc:node passed.
- Changed-code quality, type-aware quality, React Doctor, oxlint, oxfmt, and diff checks passed.
- The original change was reproduced on Windows 11; fresh PR CI covers the updated head, including Windows packaging and Git compatibility.
- No rendered UI changed, so visual proof is not applicable.

## Readiness notes

- SSH/remote: one host-owned policy now covers local, WSL, and direct SSH; no local fallback was added.
- Performance: no new Git subprocesses; duplicate parsing and a second remote-name scan were removed.
- Compatibility: no persisted state, mobile/wire schema, provider-specific behavior, dependency, or Git command changed. Existing commands remain compatible with the Git 2.25 baseline.
- Security/resources: no new shell execution, network sink, retry loop, listener, timer, cache, or unbounded structure.

## AI disclosure

Claude Opus 5 via Claude Code assisted the original root-cause analysis and implementation. Codex and independent review agents assisted the maintainer readiness pass and SSH-parity refactor.