### PR TITLE
fix(terminal): scope the standalone-229 IME exemption to first-key-since-focus

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-ime-composition-tracker.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-composition-tracker.test.ts
@@ -4,6 +4,7 @@ import {
   installTerminalImeCompositionTracker,
   TERMINAL_IME_CANDIDATE_GUARD_POST_COMPOSITION_MS,
   TERMINAL_IME_CANDIDATE_GUARD_STALE_COMPOSITION_EXPIRY_MS,
+  TERMINAL_IME_SYLLABLE_BOUNDARY_GUARD_MS,
   type TerminalImeCompositionTracker
 } from './terminal-ime-composition-tracker'
 
@@ -154,10 +155,45 @@ describe('installTerminalImeCompositionTracker', () => {
     })
   })
 
+  describe('syllable boundary guard (#16042)', () => {
+    it('is inactive before any composition has ever committed', () => {
+      const harness = installTracker()
+      expect(harness.tracker.isWithinSyllableBoundaryGuard()).toBe(false)
+    })
+
+    it('activates immediately after an ordinary syllable commits', () => {
+      const harness = installTracker()
+      harness.composition('compositionstart', '')
+      harness.composition('compositionupdate', '한')
+      harness.composition('compositionend', '한')
+      expect(harness.tracker.isWithinSyllableBoundaryGuard()).toBe(true)
+    })
+
+    it('expires after the guard window so a later, unrelated keystroke is unaffected', () => {
+      const harness = installTracker()
+      harness.composition('compositionstart', '')
+      harness.composition('compositionend', '한')
+      harness.advance(TERMINAL_IME_SYLLABLE_BOUNDARY_GUARD_MS)
+      expect(harness.tracker.isWithinSyllableBoundaryGuard()).toBe(true)
+      harness.advance(1)
+      expect(harness.tracker.isWithinSyllableBoundaryGuard()).toBe(false)
+    })
+
+    it('clears on blur, re-arming the first-key-since-focus exemption on refocus', () => {
+      const harness = installTracker()
+      harness.composition('compositionstart', '')
+      harness.composition('compositionend', '한')
+      expect(harness.tracker.isWithinSyllableBoundaryGuard()).toBe(true)
+      harness.blur()
+      expect(harness.tracker.isWithinSyllableBoundaryGuard()).toBe(false)
+    })
+  })
+
   it('handles a missing terminal element', () => {
     const tracker = installTerminalImeCompositionTracker(null)
     expect(tracker.isActive()).toBe(false)
     expect(tracker.isCandidateKeyGuardActive()).toBe(false)
+    expect(tracker.isWithinSyllableBoundaryGuard()).toBe(false)
     expect(() => tracker.dispose()).not.toThrow()
   })
 

--- a/src/renderer/src/components/terminal-pane/terminal-ime-composition-tracker.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-composition-tracker.ts
@@ -10,6 +10,12 @@ export type TerminalImeCompositionTracker = IDisposable & {
    *  syllable as literal text instead of picking a candidate. Expires with the
    *  same staleness window as the other guards. */
   isHangulPreedit: () => boolean
+  /** True for a short window after any compositionend (real commits, not just
+   *  the Sogou/fcitx empty-update case). Distinguishes "the next syllable of
+   *  the word the user is still typing" from "the first keystroke after this
+   *  element gained focus or the input source changed," which never fired a
+   *  compositionend yet and so is never inside this window. */
+  isWithinSyllableBoundaryGuard: () => boolean
 }
 
 // Jamo, compatibility jamo, extended jamo, and precomposed syllables — every
@@ -24,6 +30,19 @@ export const TERMINAL_IME_CANDIDATE_GUARD_STALE_COMPOSITION_EXPIRY_MS = 10_000
 // keyup after compositionend; a narrow window absorbs those trailing events
 // without making the keys globally unavailable after IME use.
 export const TERMINAL_IME_CANDIDATE_GUARD_POST_COMPOSITION_MS = 250
+// Why (#16042): xterm-bypass-policy exempts a standalone Process keydown (229)
+// so the *first* key after this element gains focus — stale macOS text input
+// context, or an input-source switch — can still commit. But `compositionActive`
+// alone can't tell that case apart from "the next syllable of the same word,"
+// since a syllable's compositionend also leaves composition inactive. Multi-
+// syllable Hangul (한글, 두벌식) commits one syllable per compositionend, so
+// without this window every syllable after the first looked like a fresh
+// focus/switch and got the same exemption — letting xterm swallow or corrupt
+// the next syllable's opening jamo instead of the browser composing it.
+// 500ms comfortably covers back-to-back syllables in normal typing cadence
+// while remaining short enough that a deliberate input-source switch — which
+// takes a menu click or shortcut plus reorientation — clears it first.
+export const TERMINAL_IME_SYLLABLE_BOUNDARY_GUARD_MS = 500
 
 export function installTerminalImeCompositionTracker(
   terminalElement: HTMLElement | null | undefined,
@@ -33,6 +52,12 @@ export function installTerminalImeCompositionTracker(
   let active = false
   let lastCompositionEventAt: number | null = null
   let compositionEndedAt: number | null = null
+  // Why separate from compositionEndedAt: that field only arms for the
+  // Sogou/fcitx empty-update case the candidate guard cares about. This one
+  // marks every real compositionend, including ordinary Hangul syllable
+  // commits, so the bypass policy can tell "next syllable" from "first key
+  // since focus/switch" (see TERMINAL_IME_SYLLABLE_BOUNDARY_GUARD_MS above).
+  let lastSyllableCommittedAt: number | null = null
   let sawEmptyCompositionUpdate = false
   // Why the preedit and not compositionend data: a Pinyin IME's preedit is the
   // Latin spelling it is picking candidates for, while its compositionend data
@@ -63,11 +88,16 @@ export function installTerminalImeCompositionTracker(
     )
   }
 
+  const isWithinSyllableBoundaryGuard = (): boolean =>
+    lastSyllableCommittedAt !== null &&
+    now() - lastSyllableCommittedAt <= TERMINAL_IME_SYLLABLE_BOUNDARY_GUARD_MS
+
   if (!terminalElement) {
     return {
       isActive: () => active,
       isCandidateKeyGuardActive,
       isHangulPreedit: () => isHangulPreeditAt(now()),
+      isWithinSyllableBoundaryGuard: () => false,
       dispose: () => undefined
     }
   }
@@ -101,6 +131,10 @@ export function installTerminalImeCompositionTracker(
     // Space/digit is likely IME-owned; broad post-end guards drop real typing.
     compositionEndedAt = sawEmptyCompositionUpdate ? now() : null
     sawEmptyCompositionUpdate = false
+    // Unlike compositionEndedAt above, this arms on every real commit —
+    // ordinary Hangul syllables included — so the next syllable's opening
+    // jamo doesn't read as "first key since focus/switch" (#16042).
+    lastSyllableCommittedAt = now()
   }
   const handleInput = (event: Event): void => {
     if (event instanceof InputEvent && event.inputType === 'insertCompositionText') {
@@ -118,6 +152,10 @@ export function installTerminalImeCompositionTracker(
     compositionEndedAt = null
     sawEmptyCompositionUpdate = false
     hangulPreedit = false
+    // Why reset here too: losing focus is exactly the kind of focus handoff
+    // #7102 needed the standalone-229 exemption for, so regaining focus
+    // should re-arm it rather than stay suppressed from before the blur.
+    lastSyllableCommittedAt = null
   }
 
   terminalElement.addEventListener('compositionstart', markActive, true)
@@ -130,6 +168,7 @@ export function installTerminalImeCompositionTracker(
     isActive: () => isActiveAt(now()),
     isCandidateKeyGuardActive,
     isHangulPreedit: () => isHangulPreeditAt(now()),
+    isWithinSyllableBoundaryGuard,
     dispose: () => {
       terminalElement.removeEventListener('compositionstart', markActive, true)
       terminalElement.removeEventListener('compositionupdate', updateComposition, true)

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -1113,6 +1113,7 @@ export function useTerminalPaneLifecycle({
             linuxOrphanCandidateDigitGuardActive:
               linuxCandidateClassification.candidateDigitGuardActive,
             hangulPreedit: imeCompositionTracker.isHangulPreedit(),
+            syllableBoundaryGuardActive: imeCompositionTracker.isWithinSyllableBoundaryGuard(),
             isMac,
             isLinux
           }

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.test.ts
@@ -207,6 +207,24 @@ describe('shouldSuppressTerminalImeKeyboardEvent — macOS', () => {
     ).toBe(false)
   })
 
+  it('#16042: suppresses a standalone Process key within the post-syllable guard window, so the next syllable of a multi-syllable word is not swallowed', () => {
+    expect(
+      shouldSuppressTerminalImeKeyboardEvent(
+        event({ key: 'Process', code: 'KeyN', keyCode: 229 }),
+        { ...idle, syllableBoundaryGuardActive: true }
+      )
+    ).toBe(true)
+  })
+
+  it('#16042: still lets a standalone Process key through once the post-syllable guard window has expired', () => {
+    expect(
+      shouldSuppressTerminalImeKeyboardEvent(
+        event({ key: 'Process', code: 'KeyN', keyCode: 229 }),
+        { ...idle, syllableBoundaryGuardActive: false }
+      )
+    ).toBe(false)
+  })
+
   it('suppresses standalone Process keyups so kitty release reporting cannot leak', () => {
     expect(
       shouldSuppressTerminalImeKeyboardEvent(

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
@@ -55,6 +55,11 @@ export type XtermImeKeyboardOptions = {
    *  claiming it (#15299): ibus-hangul's Hanja lookup table does index by digit,
    *  but only over a live preedit the composition guards already own. */
   hangulPreedit?: boolean
+  /** True for a short window after any compositionend, including an ordinary
+   *  Hangul syllable commit — see TERMINAL_IME_SYLLABLE_BOUNDARY_GUARD_MS
+   *  (#16042). Narrows the standalone-229 exemption below to the first key
+   *  since focus/switch, not every syllable of a multi-syllable word. */
+  syllableBoundaryGuardActive?: boolean
   // Required so no caller silently falls back to non-mac 229 suppression,
   // which re-swallows the first key after a macOS IME input-source switch.
   isMac: boolean
@@ -117,6 +122,7 @@ export function shouldSuppressTerminalImeKeyboardEvent(
     compositionActive,
     candidateKeyGuardActive,
     pendingCandidateKeyReleaseActive,
+    syllableBoundaryGuardActive,
     isMac,
     isLinux
   } = options
@@ -140,7 +146,13 @@ export function shouldSuppressTerminalImeKeyboardEvent(
   // diff (macOS: first key after an input-source switch; Linux: Sogou/fcitx
   // candidate commits outside a composition session). Windows keeps full
   // suppression until verified against its preedit-diff race.
-  const passesStandalone229Keydown = isMac || isLinux
+  // Why gated on !syllableBoundaryGuardActive (#16042): compositionActive alone
+  // can't tell "first key since focus/switch" from "next syllable of the word
+  // being typed" — a syllable's own compositionend also leaves composition
+  // inactive. Without this, every syllable after the first in Hangul (or any
+  // multi-syllable CJK) input got the same exemption and its opening jamo
+  // reached xterm raw instead of the browser's composer.
+  const passesStandalone229Keydown = (isMac || isLinux) && !syllableBoundaryGuardActive
   return (
     event.isComposing === true ||
     (event.keyCode === 229 &&


### PR DESCRIPTION
## ELI5

Typing a Korean word of more than one syllable in Orca's integrated terminal broke apart into separate jamo (e.g. 한글 → 한ㅡ) instead of composing into full syllables. The first syllable always worked; every syllable after it didn't.

## What Changed

- `terminal-ime-composition-tracker.ts`: added a time-windowed "syllable boundary guard" (`TERMINAL_IME_SYLLABLE_BOUNDARY_GUARD_MS`, 500ms) that arms on any real `compositionend` (not just the existing Sogou/fcitx empty-update case) and clears on blur.
- `xterm-bypass-policy.ts`: `shouldSuppressTerminalImeKeyboardEvent`'s standalone-229 exemption is now also gated on `!syllableBoundaryGuardActive`.
- `use-terminal-pane-lifecycle.ts`: wires the new tracker signal into the options passed to the policy function.

## Why

Fixes #16042. `shouldSuppressTerminalImeKeyboardEvent` exempts a standalone Process keydown (`keyCode 229`, not composing) on macOS/Linux so it reaches xterm's `CompositionHelper` — meant for the first key after this element gains focus or the input source changes (#7102: switching input method could swallow the first English letter). The exemption is gated only on `compositionActive`, which can't distinguish "first key since focus/switch" from "the next syllable of the word already being typed," because a syllable's own `compositionend` also leaves `compositionActive` false.

Multi-syllable Hangul commits one syllable per `compositionend` (2-Set 두벌식: 한 commits, then 글 starts a fresh composition). So every syllable after the first hit the same exemption meant for a one-time focus/switch case, and its opening jamo reached xterm raw instead of the browser's composer — producing separated jamo instead of composed syllables.

The fix adds a signal that's true only in the narrow window right after a real syllable commit, so:
- First key since focus, or after switching input source → still exempted (#7102 stays fixed).
- Next syllable of a word already being typed → no longer exempted, composes normally (#16042 fixed).

## Linked Issue

Fixes #16042

## Visual Proof

N/A — terminal input handling, not a UI change. Confirmed on real hardware (macOS 2-Set Korean) rather than a screenshot:

**Before this fix**, typing `한글` (g-k-s-r-m-f on a US physical keyboard under 2-Set) produced `한ㅡ` — first syllable composed, second syllable's jamo (ㄱ, ㄹ) dropped/uncomposed. A single syllable typed alone in a fresh terminal always composed correctly (`글`), which is what isolated this to the syllable-boundary transition rather than composition never engaging as the issue title suggested.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- New tests in `terminal-ime-composition-tracker.test.ts`: guard is inactive before any commit, activates on an ordinary syllable's `compositionend`, expires after the window, clears on blur.
- New tests in `xterm-bypass-policy.test.ts`: standalone 229 is suppressed while the guard is active, still exempted once it isn't.
- Verified the new `xterm-bypass-policy.test.ts` case actually catches the bug: reverted just the `syllableBoundaryGuardActive` gate locally and confirmed that one test fails with the pre-fix behavior, then restored the fix and confirmed it passes.
- `pnpm exec vitest run` on the full `src/renderer/src/components/terminal-pane/` directory: 395 files / 3819 tests passed, 1 pre-existing skip, no regressions.
- `pnpm run typecheck`: exit 0.
- `oxlint` on all changed files: clean.

## AI Disclosure

Anthropic Claude (via an OpenClaw agent) traced the bug from the linked issue to `xterm-bypass-policy.ts`, reproduced it on real macOS hardware with the 2-Set Korean input source (via `orca terminal create`/`terminal read` and OS-level keystroke injection into an isolated test terminal — not the reporter's original session), designed and implemented the fix, and wrote the regression tests. The diff was reviewed before submission.

## Review

- Security: no code paths touched beyond terminal keyboard-event policy.
- Cross-platform: Windows is unaffected (`passesStandalone229Keydown` already required `isMac || isLinux`, unchanged). Linux gets the same fix for the same class of multi-syllable CJK input.
- SSH/remote: not applicable — this is renderer-side keyboard handling, identical for local and remote terminals.
- Backwards compatibility: `syllableBoundaryGuardActive` is optional and defaults to falsy, so any other caller of `shouldSuppressTerminalImeKeyboardEvent` not yet passing it keeps today's behavior.
- Performance: one extra timestamp comparison per keydown; no new allocations or listeners.

## Agent skill upstream boundary

- [x] Not applicable — this is a terminal IME composition fix, unrelated to skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Scoped strictly to the standalone-229 exemption's gating condition; no other IME/composition logic touched. `#7102`'s fix and its test (`lets standalone Process keys reach xterm...`) still pass unchanged.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred) — lint/typecheck/test run locally as above; full `pnpm build` left to CI

## Author

- X / Twitter: N/A
