### PR TITLE
fix(terminal): route Enter to focused split pane

### DIFF
--- a/src/renderer/src/components/terminal-pane/keyboard-handlers-ime-enter-keyup.test.tsx
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers-ime-enter-keyup.test.tsx
@@ -28,9 +28,10 @@ function keyboardEvent(
   return event
 }
 
-function createHarness(): {
+function createHarness(options: { staleActivePane?: boolean } = {}): {
   deps: KeyboardHandlersDeps
   sendInput: ReturnType<typeof vi.fn>
+  setActivePane: ReturnType<typeof vi.fn>
   startComposition: () => void
   terminalInput: HTMLTextAreaElement
   dispose: () => void
@@ -40,7 +41,8 @@ function createHarness(): {
   const terminalInput = document.createElement('textarea')
   terminalInput.className = 'xterm-helper-textarea'
   terminalElement.append(terminalInput)
-  scope.append(terminalElement)
+  const staleTerminalElement = document.createElement('div')
+  scope.append(staleTerminalElement, terminalElement)
   document.body.append(scope)
 
   const sendInput = vi.fn(() => true)
@@ -49,7 +51,7 @@ function createHarness(): {
     sendInput
   } as unknown as PtyTransport
   const pane = {
-    id: 1,
+    id: options.staleActivePane ? 2 : 1,
     leafId: '00000000-0000-4000-8000-000000000001',
     terminal: {
       element: terminalElement,
@@ -57,9 +59,24 @@ function createHarness(): {
       getSelection: vi.fn(() => '')
     }
   }
+  const stalePane = {
+    id: 1,
+    leafId: '00000000-0000-4000-8000-000000000002',
+    terminal: {
+      element: staleTerminalElement,
+      focus: vi.fn(),
+      getSelection: vi.fn(() => '')
+    }
+  }
+  let activePane = options.staleActivePane ? stalePane : pane
+  const panes = options.staleActivePane ? [stalePane, pane] : [pane]
+  const setActivePane = vi.fn((paneId: number) => {
+    activePane = panes.find((candidate) => candidate.id === paneId) ?? activePane
+  })
   const manager = {
-    getActivePane: () => pane,
-    getPanes: () => [pane]
+    getActivePane: () => activePane,
+    getPanes: () => panes,
+    setActivePane
   } as unknown as PaneManager
   const route = installTerminalImeCompositionRoute({
     terminalElement,
@@ -96,6 +113,7 @@ function createHarness(): {
   return {
     deps,
     sendInput,
+    setActivePane,
     terminalInput,
     startComposition: () => {
       terminalElement.dispatchEvent(
@@ -332,6 +350,29 @@ describe('Windows IME Enter-keyup press-time evidence', () => {
     vi.runAllTimers()
 
     expect(harness.sendInput).toHaveBeenCalledTimes(1)
+    expect(harness.sendInput).toHaveBeenCalledWith('\x1b\r')
+    hook.unmount()
+    harness.dispose()
+  })
+
+  it('routes a swallowed Enter keydown fallback to the focused pane and repairs stale active state', () => {
+    const harness = createHarness({ staleActivePane: true })
+    const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
+    harness.startComposition()
+
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keyup', {
+        key: 'Enter',
+        code: 'Enter',
+        keyCode: 13,
+        timeStamp: 30,
+        shiftKey: true
+      })
+    )
+    vi.runAllTimers()
+
+    expect(harness.setActivePane).toHaveBeenCalledWith(2, { focus: false })
+    expect(harness.sendInput).toHaveBeenCalledOnce()
     expect(harness.sendInput).toHaveBeenCalledWith('\x1b\r')
     hook.unmount()
     harness.dispose()

--- a/src/renderer/src/components/terminal-pane/terminal-keyboard-event-handlers-focus.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-keyboard-event-handlers-focus.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest'
+import { createTerminalKeyboardEventHandlers } from './terminal-keyboard-event-handlers'
+
+describe('terminal keyboard pane ownership', () => {
+  it('submits Enter through the helper textarea pane when active state is stale', () => {
+    const scope = document.createElement('div')
+    const firstElement = document.createElement('div')
+    const focusedElement = document.createElement('div')
+    const focusedInput = document.createElement('textarea')
+    focusedInput.className = 'xterm-helper-textarea'
+    focusedElement.appendChild(focusedInput)
+    scope.append(firstElement, focusedElement)
+    document.body.appendChild(scope)
+
+    const first = { id: 1, leafId: 'leaf-1', terminal: { element: firstElement } }
+    const focused = { id: 2, leafId: 'leaf-2', terminal: { element: focusedElement } }
+    let active = first
+    const setActivePane = vi.fn((paneId: number) => {
+      active = paneId === focused.id ? focused : first
+    })
+    const sendFocused = vi.fn()
+    const handlers = createTerminalKeyboardEventHandlers({
+      isMac: false,
+      isWindows: false,
+      shortcutPlatform: 'linux',
+      keyboardScopeRef: { current: scope },
+      resolveShortcutEvent: () => ({ type: 'sendInput', data: '\r' }),
+      createCapturedInputSender: (pane) => (pane.id === focused.id ? sendFocused : vi.fn()),
+      nativeOnlyShortcutTracker: {
+        prepareKeyDown: vi.fn(),
+        armKeyDown: vi.fn()
+      },
+      observedEnterKeydownTimeStamps: new Map(),
+      modifiedEnterChordOwner: {
+        ownsRedispatchedEnter: () => false,
+        absorb: () => false,
+        claim: () => true
+      },
+      deferredNewlineSender: {
+        absorbRedispatchedEnter: () => false,
+        defer: vi.fn()
+      },
+      deferredChordSender: { defer: vi.fn() },
+      getModifiedEnterChord: () => null,
+      reconcileHeldImeEnterModifiers: vi.fn(),
+      optionKittyReleases: { arm: vi.fn(), armNativeDeadKey: vi.fn() },
+      terminalImeEnterModifierKeydowns: new Set(),
+      paneKittyKeyboardModesRef: { current: new Map() },
+      managerRef: {
+        current: {
+          getActivePane: () => active,
+          getPanes: () => [first, focused],
+          setActivePane
+        }
+      },
+      paneTransportsRef: { current: new Map() },
+      panePtyBindingsRef: { current: new Map() },
+      paneCwdRef: { current: new Map() },
+      tabId: 'tab-1',
+      worktreeId: 'worktree-1',
+      fallbackCwd: '',
+      expandedPaneIdRef: { current: null },
+      setExpandedPane: vi.fn(),
+      restoreExpandedLayout: vi.fn(),
+      refreshPaneSizes: vi.fn(),
+      persistLayoutSnapshot: vi.fn(),
+      toggleExpandPane: vi.fn(),
+      setSearchOpen: vi.fn(),
+      onSearchSelectedText: vi.fn(),
+      onRequestClosePane: vi.fn(),
+      onClearPaneScrollback: vi.fn(),
+      onSetTitle: vi.fn(),
+      onClearPaneTitle: vi.fn(),
+      searchOpenRef: { current: false },
+      searchStateRef: { current: { query: '', caseSensitive: false, regex: false } },
+      keybindings: undefined,
+      terminalShortcutPolicy: 'orca-first',
+      getKeyboardSplitTelemetrySource: () => 'keyboard'
+    } as never)
+
+    const event = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'Enter'
+    })
+    Object.defineProperty(event, 'keyCode', { value: 13 })
+    focusedInput.dispatchEvent(event)
+    handlers.onKeyDown(event)
+
+    expect(setActivePane).toHaveBeenCalledWith(2, { focus: false })
+    expect(sendFocused).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-keyboard-event-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-keyboard-event-handlers.ts
@@ -18,6 +18,7 @@ import {
 import { dispatchTerminalShortcutAction } from './terminal-keyboard-action-dispatch'
 import { getLayoutCharacterForCode } from '@/lib/keyboard-layout/layout-base-character'
 import { createTerminalKeyboardReleaseHandlers } from './terminal-keyboard-release-handlers'
+import { synchronizeTerminalKeyboardPane } from './terminal-keyboard-pane-resolution'
 
 const MAX_OBSERVED_ENTER_KEYDOWNS_PER_CODE = 8
 
@@ -111,6 +112,11 @@ export function createTerminalKeyboardEventHandlers(context: EventContext) {
       return
     }
 
+    // The browser's focused xterm helper is the input owner. A split can retain
+    // a stale manager activePaneId after focus moved, so repair it before any
+    // shortcut policy reads pane-scoped host/agent state.
+    const keyboardPane = synchronizeTerminalKeyboardPane(manager, e.target)
+
     const modifiedEnterChord = isWindows ? getModifiedEnterChord(e) : null
     if (
       e.key === 'Enter' &&
@@ -127,7 +133,7 @@ export function createTerminalKeyboardEventHandlers(context: EventContext) {
       return
     }
 
-    const terminalPaneForImeShortcut = manager.getActivePane() ?? manager.getPanes()[0]
+    const terminalPaneForImeShortcut = keyboardPane
     const hasPendingImeComposition = hasPendingTerminalImeComposition(
       terminalPaneForImeShortcut?.terminal.element
     )
@@ -139,7 +145,7 @@ export function createTerminalKeyboardEventHandlers(context: EventContext) {
     }
 
     if (matchFileSearchShortcut(e, shortcutPlatform, keybindings, terminalShortcutPolicy)) {
-      const pane = manager.getActivePane() ?? manager.getPanes()[0]
+      const pane = keyboardPane
       const selectedText = normalizeSelectedTextForFileSearch(pane?.terminal.getSelection())
       if (selectedText) {
         e.preventDefault()
@@ -160,7 +166,7 @@ export function createTerminalKeyboardEventHandlers(context: EventContext) {
       }
       e.preventDefault()
       e.stopImmediatePropagation()
-      const pane = manager.getActivePane() ?? manager.getPanes()[0]
+      const pane = keyboardPane
       if (!pane) {
         return
       }
@@ -210,7 +216,7 @@ export function createTerminalKeyboardEventHandlers(context: EventContext) {
     if (action.type === 'sendInput') {
       e.preventDefault()
       e.stopImmediatePropagation()
-      const pane = manager.getActivePane() ?? manager.getPanes()[0]
+      const pane = keyboardPane
       if (!pane) {
         return
       }

--- a/src/renderer/src/components/terminal-pane/terminal-keyboard-pane-resolution.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-keyboard-pane-resolution.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest'
+import {
+  resolveTerminalKeyboardPane,
+  synchronizeTerminalKeyboardPane
+} from './terminal-keyboard-pane-resolution'
+
+function pane(id: number): {
+  id: number
+  leafId: string
+  terminal: { element: HTMLElement }
+} {
+  return {
+    id,
+    leafId: `leaf-${id}`,
+    terminal: { element: document.createElement('div') }
+  }
+}
+
+describe('resolveTerminalKeyboardPane', () => {
+  it('uses the pane containing the event target when manager active state is stale', () => {
+    const active = pane(1)
+    const focused = pane(2)
+    const input = document.createElement('textarea')
+    focused.terminal.element.appendChild(input)
+    const manager = {
+      getActivePane: vi.fn(() => active),
+      getPanes: vi.fn(() => [active, focused])
+    }
+
+    expect(resolveTerminalKeyboardPane(manager as never, input)).toBe(focused)
+    expect(manager.getActivePane).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the manager active pane for non-terminal shortcuts', () => {
+    const active = pane(1)
+    const manager = {
+      getActivePane: vi.fn(() => active),
+      getPanes: vi.fn(() => [active])
+    }
+
+    expect(resolveTerminalKeyboardPane(manager as never, document.body)).toBe(active)
+  })
+
+  it('repairs stale active state without stealing DOM focus', () => {
+    const active = pane(1)
+    const focused = pane(2)
+    const input = document.createElement('textarea')
+    focused.terminal.element.appendChild(input)
+    let activePane = active
+    const setActivePane = vi.fn((id: number) => {
+      activePane = id === focused.id ? focused : active
+    })
+    const manager = {
+      getActivePane: vi.fn(() => activePane),
+      getPanes: vi.fn(() => [active, focused]),
+      setActivePane
+    }
+
+    expect(synchronizeTerminalKeyboardPane(manager as never, input)).toBe(focused)
+    expect(setActivePane).toHaveBeenCalledWith(focused.id, { focus: false })
+    expect(activePane).toBe(focused)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-keyboard-pane-resolution.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-keyboard-pane-resolution.ts
@@ -1,0 +1,28 @@
+import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
+
+/** Resolve keyboard ownership from the focused xterm surface before using manager state. */
+export function resolveTerminalKeyboardPane(
+  manager: Pick<PaneManager, 'getActivePane' | 'getPanes'>,
+  target: EventTarget | null
+): ManagedPane | null {
+  if (typeof Node !== 'undefined' && target instanceof Node) {
+    const focusedPane = manager
+      .getPanes()
+      .find((pane) => pane.terminal.element?.contains(target) === true)
+    if (focusedPane) {
+      return focusedPane
+    }
+  }
+  return manager.getActivePane() ?? manager.getPanes()[0] ?? null
+}
+
+export function synchronizeTerminalKeyboardPane(
+  manager: Pick<PaneManager, 'getActivePane' | 'getPanes' | 'setActivePane'>,
+  target: EventTarget | null
+): ManagedPane | null {
+  const pane = resolveTerminalKeyboardPane(manager, target)
+  if (pane && manager.getActivePane()?.id !== pane.id) {
+    manager.setActivePane(pane.id, { focus: false })
+  }
+  return pane
+}

--- a/src/renderer/src/components/terminal-pane/terminal-keyboard-release-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-keyboard-release-handlers.ts
@@ -4,6 +4,7 @@ import { isTerminalImeEnterKeyUp } from './terminal-ime-deferred-newline'
 import { isEditableTarget } from './terminal-keyboard-shortcut-matching'
 import { hasPendingTerminalImeComposition } from './terminal-ime-composition-route'
 import { keyboardEventBelongsToScope } from './terminal-keyboard-scope'
+import { resolveTerminalKeyboardPane } from './terminal-keyboard-pane-resolution'
 
 type Runtime = ReturnType<typeof createTerminalKeyboardRuntime>
 type ReleaseContext = KeyboardHandlersDeps &
@@ -101,7 +102,7 @@ export function createTerminalKeyboardReleaseHandlers(context: ReleaseContextWit
         !isEditableTarget(e.target) &&
         (!scope || keyboardEventBelongsToScope(e, scope))
       ) {
-        const pane = manager.getActivePane() ?? manager.getPanes()[0]
+        const pane = resolveTerminalKeyboardPane(manager, e.target)
         if (pane && hasPendingTerminalImeComposition(pane.terminal.element)) {
           const action = resolveShortcutEvent({
             key: 'Enter',

--- a/src/renderer/src/components/terminal-pane/terminal-keyboard-release-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-keyboard-release-handlers.ts
@@ -4,7 +4,7 @@ import { isTerminalImeEnterKeyUp } from './terminal-ime-deferred-newline'
 import { isEditableTarget } from './terminal-keyboard-shortcut-matching'
 import { hasPendingTerminalImeComposition } from './terminal-ime-composition-route'
 import { keyboardEventBelongsToScope } from './terminal-keyboard-scope'
-import { resolveTerminalKeyboardPane } from './terminal-keyboard-pane-resolution'
+import { synchronizeTerminalKeyboardPane } from './terminal-keyboard-pane-resolution'
 
 type Runtime = ReturnType<typeof createTerminalKeyboardRuntime>
 type ReleaseContext = KeyboardHandlersDeps &
@@ -102,7 +102,7 @@ export function createTerminalKeyboardReleaseHandlers(context: ReleaseContextWit
         !isEditableTarget(e.target) &&
         (!scope || keyboardEventBelongsToScope(e, scope))
       ) {
-        const pane = resolveTerminalKeyboardPane(manager, e.target)
+        const pane = synchronizeTerminalKeyboardPane(manager, e.target)
         if (pane && hasPendingTerminalImeComposition(pane.terminal.element)) {
           const action = resolveShortcutEvent({
             key: 'Enter',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​204 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​199 |
| Prod | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​40 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​5 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​35 |

<!-- /orca-pr-loc -->

Fixes #12227

## Summary
- resolve terminal keyboard ownership from the event target's xterm helper textarea
- repair stale split active-pane state without stealing DOM focus
- route IME Enter keyup fallback through the focused pane and synchronize active state

## Reliability contract
- Invariant (`terminal-input.focused-pane-routing`): keyboard submission is delivered to the pane whose terminal surface owns input focus, even when PaneManager active state is stale.
- Failure source: STA-3262 / #12227, where Windows Pi input remained drafted because Enter followed a stale sibling pane.
- Oracle: handler tests observe active-pane repair and exactly one Enter send through the focused sibling; the Windows IME swallowed-keydown test observes the same ownership and exact `Esc+CR` bytes.
- Gate: the focused Vitest slice and exact-head Electron proof are the active gate. Accepted manifest gap: no dedicated `config/reliability-gates.jsonc` entry is added for this narrow renderer repair.
- Provider/platform coverage: renderer selection is host-neutral across local, daemon, SSH, WSL, remote runtime, and folder workspaces; macOS Electron and simulated Windows/host-routing contracts are covered. Live Windows IME, WSL, SSH, paired-web, and Linux Wayland remain accepted gaps.
- Performance budget: each key event performs one bounded visible-pane DOM ownership scan; stale state causes one active-pane update. No IPC/RPC, subprocess, polling, timer, listener, or unbounded collection is added.
- Diagnostics: the pane DOM identity, active/inactive opacity, exact PTY ids, PTY liveness, and main-buffer snapshots identify a future routing failure without logging terminal content in product telemetry.
- Residual gaps: no physical Windows/Pi/IME artifact and no live SSH/WSL/paired-web artifact were collected.

## Verification
- `pnpm test` focused 8-file terminal/IME/host-routing slice: 85 tests passed on `8c97eb6e4b2c1b6e259868558e8f6ce2669f2792`.
- IME red/green proof: the new stale-pane keyup test failed before `synchronizeTerminalKeyboardPane` was used and passed after the fix.
- `pnpm tc:web`; direct oxlint; oxfmt check; `git diff --check`.
- Electron/Playwright CDP: intended `3262-stale-enter` dev instance, two live PTYs, first helper focused while the second pane remained active, then real Enter. The first pane rendered `STA3262_HEAD_8C97EB6E4B`, the sibling did not, and active-pane styling synchronized to the focused pane.
- Exact-head CI: 47 checks passed, 0 failed; the unchanged e2e job skipped because no e2e spec changed.
