### PR TITLE
fix(terminal): sweep descendants when tearing down hand-typed agent sessions

### DIFF
--- a/src/main/daemon/agent-teardown-evidence.ts
+++ b/src/main/daemon/agent-teardown-evidence.ts
@@ -1,0 +1,12 @@
+import { recognizeAgentProcess } from '../../shared/agent-process-recognition'
+import type { TuiAgent } from '../../shared/tui-agent'
+
+/** Teardown must sweep descendants: agent-launched, or a recognized agent live in the
+ *  foreground — a hand-typed `claude` (bare, or under a wrapper the foreground tracker
+ *  resolved) leaks the same detached MCP children as a launched one. */
+export function hasAgentTeardownEvidence(
+  launchAgent: TuiAgent | null | undefined,
+  subprocess: { getForegroundProcess(): string | null }
+): boolean {
+  return Boolean(launchAgent) || recognizeAgentProcess(subprocess.getForegroundProcess()) !== null
+}

--- a/src/main/daemon/session-termination-controller.ts
+++ b/src/main/daemon/session-termination-controller.ts
@@ -1,5 +1,6 @@
 import { killWithDescendantSweep } from '../pty-descendant-termination'
 import { PhysicalExitTracker } from '../../shared/physical-exit-tracker'
+import { hasAgentTeardownEvidence } from './agent-teardown-evidence'
 import type { SubprocessHandle } from './session-subprocess-handle'
 import type { TuiAgent } from '../../shared/tui-agent'
 
@@ -55,7 +56,7 @@ export class SessionTerminationController {
     if (!this.beginTermination()) {
       return
     }
-    if (!this.deps.launchAgent) {
+    if (!hasAgentTeardownEvidence(this.deps.launchAgent, this.deps.subprocess)) {
       this.signalTerminationRoot()
     } else {
       // Why: agent tool children live in detached process groups a dying shell's SIGHUP never reaches, so sweep them.

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -712,6 +712,27 @@ describe('Session', () => {
       expect(killWithDescendantSweepMock).not.toHaveBeenCalled()
     })
 
+    it('shell-foreground kill stays on the plain path', () => {
+      createSession()
+      subprocess.foregroundProcess = 'zsh'
+      session.kill()
+      expect(subprocess.killed).toBe(true)
+      expect(killWithDescendantSweepMock).not.toHaveBeenCalled()
+    })
+
+    it('recognized agent foreground kill routes through the descendant sweep without launchAgent', () => {
+      // Why: a hand-typed `claude` leaks its detached MCP children if teardown trusts launchAgent alone.
+      createSession()
+      subprocess.foregroundProcess = 'claude'
+      session.kill()
+      expect(killWithDescendantSweepMock).toHaveBeenCalledWith(
+        subprocess.pid,
+        expect.any(Function),
+        expect.objectContaining({ ownsRoot: expect.any(Function) })
+      )
+      expect(subprocess.killed).toBe(false)
+    })
+
     it('agent kill routes through the descendant sweep with the subprocess as root', () => {
       createSession({ launchAgent: 'claude' })
       session.kill()

--- a/src/main/daemon/terminal-session-teardown.test.ts
+++ b/src/main/daemon/terminal-session-teardown.test.ts
@@ -10,6 +10,7 @@ vi.mock('../pty-descendant-termination', () => ({
 function createPlainShellSession(overrides: Partial<Session> = {}): Session {
   return {
     launchAgent: undefined,
+    getForegroundProcess: () => null,
     pid: 4242,
     isAlive: true,
     forceKillAndWaitForExit: vi.fn(async () => {}),
@@ -119,6 +120,31 @@ describe('TerminalSessionTeardown plain-shell teardown', () => {
     expect(session.forceKillAndWaitForExit).not.toHaveBeenCalled()
     expect(session.kill).toHaveBeenCalled()
   })
+
+  it.each([
+    ['graceful', false],
+    ['immediate', true]
+  ])(
+    'hand-typed agent foreground routes %s kill through the agent sweep despite no launchAgent',
+    async (_case, immediate) => {
+      // Why: a `claude` the user typed into a plain shell has launchAgent unset, but its
+      // detached MCP children still outlive a root-only kill (the reported leak).
+      setPlatform('linux')
+      const session = createPlainShellSession({
+        getForegroundProcess: () => 'claude'
+      } as Partial<Session>)
+      const teardown = new TerminalSessionTeardown(new Map([['s1', session]]))
+
+      await teardown.killSession('s1', session, immediate)
+
+      expect(killWithDescendantSweepMock).toHaveBeenCalledWith(
+        4242,
+        expect.any(Function),
+        expect.objectContaining({ ownsRoot: expect.any(Function) })
+      )
+      expect(session.kill).not.toHaveBeenCalled()
+    }
+  )
 })
 
 describe('pty job ownership reaches the daemon teardown path', () => {

--- a/src/main/daemon/terminal-session-teardown.ts
+++ b/src/main/daemon/terminal-session-teardown.ts
@@ -1,4 +1,5 @@
 import { killWithDescendantSweep } from '../pty-descendant-termination'
+import { hasAgentTeardownEvidence } from './agent-teardown-evidence'
 import type { Session } from './session'
 
 type AgentTeardownOperation = {
@@ -34,7 +35,9 @@ export class TerminalSessionTeardown {
   }
 
   killSession(sessionId: string, session: Session, immediate: boolean): void | Promise<void> {
-    if (session.launchAgent) {
+    // Evidence, not launchAgent: a hand-typed `claude` in a plain shell needs the same
+    // descendant sweep or its detached MCP children survive the tab close.
+    if (hasAgentTeardownEvidence(session.launchAgent, session)) {
       return this.killAgentSession(sessionId, session, immediate)
     }
     if (immediate) {


### PR DESCRIPTION
## ELI5

If you open a plain terminal in Orca, type `claude` yourself, and later close the tab, the claude process and its MCP servers keep running forever. Orca only knew how to fully clean up agents it launched itself. Now closing the tab cleans up hand-typed agents the same way.

## What Changed

- New `src/main/daemon/agent-teardown-evidence.ts`: teardown treats a session as an agent session when `launchAgent` is set **or** a recognized agent is live in the foreground (`recognizeAgentProcess` over the daemon's existing foreground tracker, which already resolves agents running under wrappers).
- `terminal-session-teardown.ts` routes evidence-bearing sessions through `killAgentSession` (descendant snapshot → SIGTERM → SIGKILL survivors) for both graceful and immediate kills, instead of the root-only / tty-`killpg` plain-shell paths.
- `session-termination-controller.ts` applies the same gate to the graceful `kill()` primitive.
- Regression tests in `terminal-session-teardown.test.ts` and `session.test.ts` (hand-typed agent foreground → sweep; shell foreground → plain path unchanged).

## Why

The daemon gated the descendant sweep on `session.launchAgent`, which only Orca's explicit agent-launch path sets. A hand-typed `claude`/`codex` got root-only teardown on tab close:

- graceful: SIGHUP to the PTY root only, and the SIGKILL fallback is cancelled the moment the shell exits — the whole agent tree reparents to PID 1 and survives;
- immediate (POSIX): `killpg` over the controlling tty misses MCP servers that `setsid()`'d away.

The leaked sessions still carry agent-ownership evidence, so the Resource Manager's "Kill N orphan terminals" deliberately skips them (#8459 guard) — they're unreclaimable from the UI. The in-process fallback provider already unions `launchAgent || startupAgentRecognition` before sweeping (`local-pty-provider.ts`); this brings the daemon path — where real tab closes land — to the same rule, reusing the existing foreground tracker rather than adding a new probe.

Observed on a real workstation: 45 `connected` daemon sessions vs ~12 visible tabs; ~4GB RSS of leaked `claude` CLIs plus ~1.2GB of orphaned MCP servers, some alive 5+ days.

## Linked Issue

Fixes #16714

## Visual Proof

N/A — daemon process-teardown change with no UI or interaction change. Verifiable via `ps`/`orca terminal list` before/after closing a tab running a hand-typed `claude` (steps below).

## Testing

- Automated: `pnpm test src/main/daemon` — 141 files / 1655 tests pass, including new regression tests for the hand-typed-agent sweep (graceful + immediate) and the unchanged plain-shell path. `pnpm tc:node` and `oxlint` clean.
- Manual repro for reviewers (macOS): open a plain terminal tab, run `claude` (with MCP servers configured), close the tab, then check `ps aux | grep -E 'claude|mcp'` — before this change the tree survives; after, it is swept.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

Implemented with Claude Code (Fable 5); diagnosis, fix, and tests reviewed by the submitter.

## Review

Ready for review — no open findings; CodeRabbit reported no actionable comments (merge risk: minimal). The remaining docstring-coverage warning is the generic threshold check, consistent with prior PRs.

## Agent skill upstream boundary

N/A — daemon teardown change only; no agent skill files touched.

