### PR TITLE
fix(orchestration): fence ambiguous worker starts

### DIFF
--- a/src/main/runtime/agent-prompt-submission-runtime-test-fixture.ts
+++ b/src/main/runtime/agent-prompt-submission-runtime-test-fixture.ts
@@ -7,7 +7,8 @@ export const AGENT_PROMPT_TEST_WORKTREE_ID = 'repo-1::/tmp/worktree-a'
 
 export async function createAgentPromptSubmissionRuntime(
   onWrite: (runtime: OrcaRuntimeService, data: string, writeIndex: number) => void,
-  launchAgent: TuiAgent = 'aider'
+  launchAgent: TuiAgent = 'aider',
+  getForegroundProcess: () => Promise<string | null> = async () => null
 ): Promise<{ runtime: OrcaRuntimeService; handle: string; writes: string[] }> {
   const runtime = new OrcaRuntimeService(makeStore() as never)
   const writes: string[] = []
@@ -19,7 +20,7 @@ export async function createAgentPromptSubmissionRuntime(
       return true
     },
     kill: () => true,
-    getForegroundProcess: async () => null
+    getForegroundProcess
   })
   const terminal = await runtime.createTerminal(`path:${AGENT_PROMPT_TEST_WORKTREE_PATH}`, {
     launchAgent

--- a/src/main/runtime/agent-prompt-submission-runtime.test.ts
+++ b/src/main/runtime/agent-prompt-submission-runtime.test.ts
@@ -443,6 +443,59 @@ describe('agent prompt submission runtime', () => {
     expect(writes.filter((data) => data === '\r')).toHaveLength(1)
   })
 
+  it('does not accept an unchanged repaint while the agent is already working', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    const repaint = '\x1b[2J\x1b[Hworking on the current turn'
+    const { runtime, handle, writes } = await createPromptRuntime((runtime, data) => {
+      if (data === '\r') {
+        runtime.onPtyData('pty-prompt', repaint, Date.now())
+      }
+    })
+    await runtime.acceptPtyDataBounded('pty-prompt', repaint, Date.now()).completion
+    runtime.onPtyData(
+      'pty-prompt',
+      '\x1b]9999;{"state":"working","agentType":"aider"}\x07',
+      Date.now()
+    )
+
+    const submission = runtime.sendTerminalAgentPrompt(handle, 'review this')
+    const rejected = expect(submission).rejects.toThrow('agent_prompt_stalled')
+    await vi.runAllTimersAsync()
+
+    await rejected
+    expect(writes.filter((data) => data === '\r')).toHaveLength(1)
+  })
+
+  it('uses the current foreground owner when a reused pane has stale launch metadata', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    const { runtime, handle, writes } = await createAgentPromptSubmissionRuntime(
+      (runtime, data) => {
+        if (data.includes(AGENT_PROMPT_BRACKETED_PASTE_END)) {
+          runtime.onPtyData('pty-prompt', '\x1b[?25hcomposer ready', Date.now())
+        } else if (data === '\r') {
+          setTimeout(() => {
+            runtime.onPtyData(
+              'pty-prompt',
+              '\x1b]9999;{"state":"working","agentType":"codex"}\x07',
+              Date.now()
+            )
+          }, 6_000)
+        }
+      },
+      'claude',
+      async () => 'codex'
+    )
+    await expect(runtime.isTerminalRunningSettledPromptAgent(handle)).resolves.toBe(true)
+
+    const submission = runtime.sendTerminalAgentPrompt(handle, 'review this')
+    await vi.runAllTimersAsync()
+
+    await expect(submission).resolves.toMatchObject({ accepted: true })
+    expect(writes.filter((data) => data === '\r')).toHaveLength(1)
+  })
+
   // Why: hook rows reach the runtime through this provider, which has no window and no OSC title —
   // the same path a headless `orca serve` host and a minimized desktop window take.
   async function createHookOnlyPromptRuntime(hook: {

--- a/src/main/runtime/agent-prompt-submission-runtime.test.ts
+++ b/src/main/runtime/agent-prompt-submission-runtime.test.ts
@@ -420,9 +420,9 @@ describe('agent prompt submission runtime', () => {
     expect(writes.filter((data) => data === '\r')).toHaveLength(1)
   })
 
-  // Why (#16095): a still-working agent can never produce a `→working` edge, so the old predicate
-  // was unsatisfiable for every follow-up prompt; pane output after Enter is the evidence left.
-  it('accepts pane output after Enter while the agent is already working', async () => {
+  // Output from the current turn is not causally tied to Enter; without a new-turn edge the
+  // submission remains ambiguous and must stay fenced for first-hand worker settlement.
+  it('does not accept unrelated pane output after Enter while the agent is already working', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000)
     const { runtime, handle, writes } = await createPromptRuntime((runtime, data) => {
@@ -437,9 +437,10 @@ describe('agent prompt submission runtime', () => {
     )
 
     const submission = runtime.sendTerminalAgentPrompt(handle, 'review this')
+    const rejected = expect(submission).rejects.toThrow('agent_prompt_stalled')
     await vi.runAllTimersAsync()
 
-    await expect(submission).resolves.toMatchObject({ accepted: true })
+    await rejected
     expect(writes.filter((data) => data === '\r')).toHaveLength(1)
   })
 

--- a/src/main/runtime/agent-prompt-submission-verification.test.ts
+++ b/src/main/runtime/agent-prompt-submission-verification.test.ts
@@ -14,9 +14,6 @@ function activity(overrides: Partial<AgentPromptActivity> = {}): AgentPromptActi
     permissionSequence: 2,
     workingSequence: 4,
     explicitWorkingStartedAt: null,
-    outputSequence: 7,
-    visibleOutputFingerprint: 'screen-a',
-    outputUpdatedAt: 0,
     status: 'idle',
     ...overrides
   }
@@ -174,28 +171,25 @@ describe('agent prompt submission verification', () => {
     })
     const rejected = expect(verification).rejects.toThrow('agent_prompt_stalled')
 
-    current = activity({ explicitWorkingStartedAt: 2_000, outputSequence: 40 })
+    current = activity({ explicitWorkingStartedAt: 2_000 })
     await vi.advanceTimersByTimeAsync(AGENT_PROMPT_EFFECT_TIMEOUT_MS)
 
     await rejected
   })
 
-  it('accepts pane output after Enter when the agent was already working', async () => {
+  it('does not accept unrelated current-turn output after Enter was swallowed', async () => {
     vi.useFakeTimers()
     let current = activity({ status: 'working' })
     const verification = verifyAgentPromptSubmission({
       baseline: current,
       readActivity: () => current
     })
+    const rejected = expect(verification).rejects.toThrow('agent_prompt_stalled')
 
-    current = activity({
-      status: 'working',
-      outputSequence: 8,
-      visibleOutputFingerprint: 'screen-b'
-    })
-    await vi.advanceTimersByTimeAsync(50)
+    current = activity({ status: 'working' })
+    await vi.advanceTimersByTimeAsync(AGENT_PROMPT_EFFECT_TIMEOUT_MS)
 
-    await expect(verification).resolves.toBeUndefined()
+    await rejected
   })
 
   it('does not accept pane output when the agent was idle at submit', async () => {
@@ -207,7 +201,7 @@ describe('agent prompt submission verification', () => {
     })
     const rejected = expect(verification).rejects.toThrow('agent_prompt_stalled')
 
-    current = activity({ outputSequence: 9 })
+    current = activity({ status: 'idle' })
     await vi.advanceTimersByTimeAsync(AGENT_PROMPT_EFFECT_TIMEOUT_MS)
 
     await rejected

--- a/src/main/runtime/agent-prompt-submission-verification.test.ts
+++ b/src/main/runtime/agent-prompt-submission-verification.test.ts
@@ -15,6 +15,8 @@ function activity(overrides: Partial<AgentPromptActivity> = {}): AgentPromptActi
     workingSequence: 4,
     explicitWorkingStartedAt: null,
     outputSequence: 7,
+    visibleOutputFingerprint: 'screen-a',
+    outputUpdatedAt: 0,
     status: 'idle',
     ...overrides
   }
@@ -186,7 +188,11 @@ describe('agent prompt submission verification', () => {
       readActivity: () => current
     })
 
-    current = activity({ status: 'working', outputSequence: 8 })
+    current = activity({
+      status: 'working',
+      outputSequence: 8,
+      visibleOutputFingerprint: 'screen-b'
+    })
     await vi.advanceTimersByTimeAsync(50)
 
     await expect(verification).resolves.toBeUndefined()

--- a/src/main/runtime/agent-prompt-submission-verification.ts
+++ b/src/main/runtime/agent-prompt-submission-verification.ts
@@ -8,7 +8,6 @@ export const AGENT_PROMPT_EFFECT_TIMEOUT_MS = 5_000
 // (30s, src/relay/dispatcher.ts), the budget a paired client's submission runs under.
 export const AGENT_PROMPT_HOOK_EFFECT_TIMEOUT_MS = 15_000
 const AGENT_PROMPT_EFFECT_POLL_MS = 50
-const AGENT_PROMPT_OUTPUT_SETTLE_MS = 50
 
 const HOOK_OBSERVED_TURN_START_AGENTS = new Set<TuiAgent>(['codex', 'kimi'])
 
@@ -22,11 +21,6 @@ export type AgentPromptActivity = Readonly<{
   /** When the hook's current `working` turn began; reaches the runtime with no window and no
    *  title coverage. Pinned across same-state pings, so a refresh alone cannot move it. */
   explicitWorkingStartedAt: number | null
-  /** PTY bytes seen on this pane; delivery evidence when a turn-start edge cannot be observed. */
-  outputSequence: number
-  /** The generic terminal model's visible text, so repainting the same frame is not a receipt. */
-  visibleOutputFingerprint: string
-  outputUpdatedAt: number | null
   status: 'working' | 'permission' | 'idle' | null
 }>
 
@@ -87,8 +81,7 @@ function agentPromptEffectObserved(
 ): boolean {
   return (
     current.workingSequence > baseline.workingSequence ||
-    observedHookWorkingAfterBaseline(baseline, current) ||
-    observedDeliveryEvidence(baseline, current)
+    observedHookWorkingAfterBaseline(baseline, current)
   )
 }
 
@@ -102,22 +95,6 @@ function observedHookWorkingAfterBaseline(
   return (
     current.explicitWorkingStartedAt !== null &&
     current.explicitWorkingStartedAt > (baseline.explicitWorkingStartedAt ?? 0)
-  )
-}
-
-// Why: a `→working` edge is unreachable for an agent that is already working, so the honest proof
-// that the prompt landed is the pane emitting bytes after Enter. An idle agent still owes a real
-// turn start, which keeps a swallowed Enter detectable.
-function observedDeliveryEvidence(
-  baseline: AgentPromptActivity,
-  current: AgentPromptActivity
-): boolean {
-  return (
-    baseline.status === 'working' &&
-    current.outputSequence > baseline.outputSequence &&
-    current.visibleOutputFingerprint !== baseline.visibleOutputFingerprint &&
-    current.outputUpdatedAt !== null &&
-    Date.now() - current.outputUpdatedAt >= AGENT_PROMPT_OUTPUT_SETTLE_MS
   )
 }
 

--- a/src/main/runtime/agent-prompt-submission-verification.ts
+++ b/src/main/runtime/agent-prompt-submission-verification.ts
@@ -8,6 +8,7 @@ export const AGENT_PROMPT_EFFECT_TIMEOUT_MS = 5_000
 // (30s, src/relay/dispatcher.ts), the budget a paired client's submission runs under.
 export const AGENT_PROMPT_HOOK_EFFECT_TIMEOUT_MS = 15_000
 const AGENT_PROMPT_EFFECT_POLL_MS = 50
+const AGENT_PROMPT_OUTPUT_SETTLE_MS = 50
 
 const HOOK_OBSERVED_TURN_START_AGENTS = new Set<TuiAgent>(['codex', 'kimi'])
 
@@ -23,6 +24,9 @@ export type AgentPromptActivity = Readonly<{
   explicitWorkingStartedAt: number | null
   /** PTY bytes seen on this pane; delivery evidence when a turn-start edge cannot be observed. */
   outputSequence: number
+  /** The generic terminal model's visible text, so repainting the same frame is not a receipt. */
+  visibleOutputFingerprint: string
+  outputUpdatedAt: number | null
   status: 'working' | 'permission' | 'idle' | null
 }>
 
@@ -108,7 +112,13 @@ function observedDeliveryEvidence(
   baseline: AgentPromptActivity,
   current: AgentPromptActivity
 ): boolean {
-  return baseline.status === 'working' && current.outputSequence > baseline.outputSequence
+  return (
+    baseline.status === 'working' &&
+    current.outputSequence > baseline.outputSequence &&
+    current.visibleOutputFingerprint !== baseline.visibleOutputFingerprint &&
+    current.outputUpdatedAt !== null &&
+    Date.now() - current.outputUpdatedAt >= AGENT_PROMPT_OUTPUT_SETTLE_MS
+  )
 }
 
 function assertSamePromptGeneration(

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -24915,6 +24915,20 @@ describe('OrcaRuntimeService', () => {
     await expect(runtime.isTerminalRunningSettledPromptAgent(terminal.handle)).resolves.toBe(false)
   })
 
+  it('refreshes a generic agent owner after wrapper enrichment', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: vi.fn().mockResolvedValueOnce('node').mockResolvedValue('gemini')
+    })
+    syncSinglePty(runtime, 'pty-1', { paneTitle: 'bash' })
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    await expect(runtime.refreshTerminalPromptAgentOwner(terminal.handle)).resolves.toBe('gemini')
+    await expect(runtime.isTerminalRunningSettledPromptAgent(terminal.handle)).resolves.toBe(false)
+  })
+
   it('keeps stale Codex launch identity on legacy delivery after the shell returns', async () => {
     const runtime = new OrcaRuntimeService(store)
     runtime.setPtyController({
@@ -25011,6 +25025,40 @@ describe('OrcaRuntimeService', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('fails owner refresh closed when wrapper enrichment never resolves', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: vi.fn().mockResolvedValue('node')
+    })
+    syncSinglePty(runtime, 'pty-1', { paneTitle: 'bash' })
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    vi.useFakeTimers()
+    try {
+      const result = runtime.refreshTerminalPromptAgentOwner(terminal.handle)
+      await vi.advanceTimersByTimeAsync(7_000)
+
+      await expect(result).resolves.toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('fails owner refresh closed when the foreground read is unavailable', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: vi.fn().mockRejectedValue(new Error('foreground unavailable'))
+    })
+    syncSinglePty(runtime, 'pty-1', { paneTitle: 'bash' })
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    await expect(runtime.refreshTerminalPromptAgentOwner(terminal.handle)).resolves.toBeNull()
   })
 
   it('lets live neutral pane titles retry wrapper foregrounds until recognized', async () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -24911,6 +24911,7 @@ describe('OrcaRuntimeService', () => {
     const [terminal] = (await runtime.listTerminals()).terminals
 
     await expect(runtime.isTerminalRunningAgent(terminal.handle)).resolves.toBe(true)
+    await expect(runtime.refreshTerminalPromptAgentOwner(terminal.handle)).resolves.toBe('gemini')
     await expect(runtime.isTerminalRunningSettledPromptAgent(terminal.handle)).resolves.toBe(false)
   })
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -17566,6 +17566,16 @@ export class OrcaRuntimeService {
       return
     }
 
+    const worker = isDeliberateTerminalExit(cause)
+      ? this._orchestrationDb.getWorkerDispatch(dispatch.id)
+      : undefined
+    if (worker && ['stopping', 'stop_unknown'].includes(worker.state)) {
+      // The close event is the durable proof a prior worker-stop receipt lacked; it may arrive
+      // after that RPC returned, so settle both in-flight and already-unknown local stops.
+      this._orchestrationDb.settleWorkerStop(dispatch.id)
+      return
+    }
+
     const errorContext = describeTerminalExitCause(cause)
     const settled = this._orchestrationDb.failDispatch(dispatch.id, errorContext, {
       workerProcessExited: true,
@@ -20100,13 +20110,18 @@ export class OrcaRuntimeService {
       // otherwise pass off an in-progress turn as a new one.
       explicitWorkingStartedAt: explicit?.status === 'working' ? explicit.stateStartedAt : null,
       outputSequence: this.getPtyOutputSequence(ptyId),
+      visibleOutputFingerprint:
+        this.headlessTerminals.get(ptyId)?.emulator.getVisibleLines().join('\n') ?? '',
+      outputUpdatedAt: this.ptysById.get(ptyId)?.lastOutputAt ?? null,
       status
     }
   }
 
   private getPtyAgent(ptyId: string): TuiAgent | null {
     const pty = this.ptysById.get(ptyId)
-    return pty?.launchAgent ?? pty?.foregroundAgent ?? null
+    // A reused pane can outlive its original launcher; a positively refreshed foreground owner is
+    // current execution evidence and therefore outranks stale launch metadata.
+    return pty?.foregroundAgent ?? pty?.launchAgent ?? null
   }
 
   private assertAgentPromptPermissionSafe(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -20109,10 +20109,6 @@ export class OrcaRuntimeService {
       // stateStartedAt, not updatedAt — same-state tool/prompt pings refresh updatedAt and would
       // otherwise pass off an in-progress turn as a new one.
       explicitWorkingStartedAt: explicit?.status === 'working' ? explicit.stateStartedAt : null,
-      outputSequence: this.getPtyOutputSequence(ptyId),
-      visibleOutputFingerprint:
-        this.headlessTerminals.get(ptyId)?.emulator.getVisibleLines().join('\n') ?? '',
-      outputUpdatedAt: this.ptysById.get(ptyId)?.lastOutputAt ?? null,
       status
     }
   }
@@ -35475,28 +35471,32 @@ export class OrcaRuntimeService {
     }
   }
 
-  async isTerminalRunningSettledPromptAgent(handle: string): Promise<boolean> {
+  async refreshTerminalPromptAgentOwner(handle: string): Promise<TuiAgent | null> {
     try {
       const livePty = this.getLivePtyForHandle(handle)
       const leaf = livePty ? null : this.getLiveLeafForHandle(handle).leaf
       const ptyId = livePty?.pty.ptyId ?? leaf?.ptyId ?? null
       const trackedPty = livePty?.pty ?? (ptyId ? this.ptysById.get(ptyId) : null)
       if (!ptyId || !trackedPty || !this.ptyController) {
-        return false
+        return null
       }
       const recognized = recognizeAgentProcess(await this.ptyController.getForegroundProcess(ptyId))
       const recognizedAgent = recognized?.agent
-      if (!isTerminalSendSettlementAgent(recognizedAgent)) {
-        return false
+      if (!recognizedAgent) {
+        return null
       }
       if (!(await this.isTerminalRunningAgent(handle, { retryForegroundWrappers: false }))) {
-        return false
+        return null
       }
       trackedPty.foregroundAgent = recognizedAgent
-      return true
+      return recognizedAgent
     } catch {
-      return false
+      return null
     }
+  }
+
+  async isTerminalRunningSettledPromptAgent(handle: string): Promise<boolean> {
+    return isTerminalSendSettlementAgent(await this.refreshTerminalPromptAgentOwner(handle))
   }
 
   private async isPtyRunningAgent(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -580,7 +580,8 @@ import { repoIsRemote } from '../../shared/agent-launch-remote'
 import {
   isAgentForegroundWrapperProcess,
   isExpectedAgentProcess,
-  recognizeAgentProcess
+  recognizeAgentProcess,
+  type RecognizedAgentProcess
 } from '../../shared/agent-process-recognition'
 import {
   haveSameDisabledTuiAgents,
@@ -35480,16 +35481,19 @@ export class OrcaRuntimeService {
       if (!ptyId || !trackedPty || !this.ptyController) {
         return null
       }
-      const recognized = recognizeAgentProcess(await this.ptyController.getForegroundProcess(ptyId))
-      const recognizedAgent = recognized?.agent
-      if (!recognizedAgent) {
+      const foregroundProcess = await this.ptyController.getForegroundProcess(ptyId)
+      if (!foregroundProcess) {
+        return null
+      }
+      const recognized = await this.recognizeForegroundAgentProcess(ptyId, foregroundProcess)
+      if (!recognized) {
         return null
       }
       if (!(await this.isTerminalRunningAgent(handle, { retryForegroundWrappers: false }))) {
         return null
       }
-      trackedPty.foregroundAgent = recognizedAgent
-      return recognizedAgent
+      trackedPty.foregroundAgent = recognized.agent
+      return recognized.agent
     } catch {
       return null
     }
@@ -35571,19 +35575,30 @@ export class OrcaRuntimeService {
     foregroundProcess: string,
     options: { suppressClaude?: boolean; retryWrappers?: boolean } = {}
   ): Promise<boolean> {
+    return (await this.recognizeForegroundAgentProcess(ptyId, foregroundProcess, options)) !== null
+  }
+
+  private async recognizeForegroundAgentProcess(
+    ptyId: string,
+    foregroundProcess: string,
+    options: { suppressClaude?: boolean; retryWrappers?: boolean } = {}
+  ): Promise<RecognizedAgentProcess | null> {
     const initialRecognition = recognizeAgentProcess(foregroundProcess)
     if (initialRecognition !== null) {
-      return !(
+      if (
         options.suppressClaude === true &&
         isExpectedAgentProcess(initialRecognition.processName, 'claude')
-      )
+      ) {
+        return null
+      }
+      return initialRecognition
     }
     if (
       options.retryWrappers === false ||
       !this.isAgentWrapperForegroundProcess(foregroundProcess) ||
       !this.ptyController
     ) {
-      return false
+      return null
     }
     const startedAt = Date.now()
     while (Date.now() - startedAt < FOREGROUND_AGENT_WRAPPER_RETRY_TIMEOUT_MS) {
@@ -35593,16 +35608,19 @@ export class OrcaRuntimeService {
       const refreshedProcess = await this.ptyController.getForegroundProcess(ptyId)
       const refreshedRecognition = recognizeAgentProcess(refreshedProcess)
       if (refreshedRecognition !== null) {
-        return !(
+        if (
           options.suppressClaude === true &&
           isExpectedAgentProcess(refreshedRecognition.processName, 'claude')
-        )
+        ) {
+          return null
+        }
+        return refreshedRecognition
       }
       if (!refreshedProcess || !this.isAgentWrapperForegroundProcess(refreshedProcess)) {
-        return false
+        return null
       }
     }
-    return false
+    return null
   }
 
   private isAgentWrapperForegroundProcess(processName: string): boolean {

--- a/src/main/runtime/orchestration/db/dispatch-context/worker-report-settlement.ts
+++ b/src/main/runtime/orchestration/db/dispatch-context/worker-report-settlement.ts
@@ -31,6 +31,7 @@ export function settleWorkerReportInTransaction(
     dispatchId: string
     outcome: WorkerReportOutcome
     result: string
+    source?: 'federation'
   }
 ): WorkerReportSettlement {
   const task = this.getTask(params.taskId)
@@ -72,6 +73,14 @@ export function settleWorkerReportInTransaction(
     reportingWorker.stage === 'dispatch_input' &&
     reportingWorker.last_error === AGENT_PROMPT_STALLED_ERROR &&
     dispatch.capability_revoked_at === null
+  // Federation import has already pinned the authenticated peer, exact Dispatch, and Task. A lost
+  // attach response cannot erase the first-hand report that proves the remote worker did start.
+  const authenticatedFederatedUnknown =
+    params.source === 'federation' &&
+    dispatch.status === 'pending' &&
+    task.status === 'blocked' &&
+    reportingWorker?.state === 'start_unknown' &&
+    this.getFederatedDispatch(params.dispatchId) !== undefined
   if (
     !settledByUnobservedPrompt &&
     dispatch.status === expectedDispatchStatus &&
@@ -79,11 +88,12 @@ export function settleWorkerReportInTransaction(
   ) {
     return { action: 'settled', outcome: params.outcome, duplicate: true }
   }
-  const previous = ambiguousPostSubmit
-    ? { dispatchStatus: 'pending', taskStatus: 'blocked', workerState: 'start_unknown' }
-    : settledByUnobservedPrompt
-      ? { dispatchStatus: 'failed', taskStatus: 'failed', workerState: 'failed' }
-      : { dispatchStatus: 'dispatched', taskStatus: 'dispatched', workerState: 'ready' }
+  const previous =
+    ambiguousPostSubmit || authenticatedFederatedUnknown
+      ? { dispatchStatus: 'pending', taskStatus: 'blocked', workerState: 'start_unknown' }
+      : settledByUnobservedPrompt
+        ? { dispatchStatus: 'failed', taskStatus: 'failed', workerState: 'failed' }
+        : { dispatchStatus: 'dispatched', taskStatus: 'dispatched', workerState: 'ready' }
   if (dispatch.status !== previous.dispatchStatus || task.status !== previous.taskStatus) {
     return {
       action: 'rejected',

--- a/src/main/runtime/orchestration/db/dispatch-context/worker-report-settlement.ts
+++ b/src/main/runtime/orchestration/db/dispatch-context/worker-report-settlement.ts
@@ -55,6 +55,7 @@ export function settleWorkerReportInTransaction(
 
   const expectedDispatchStatus = params.outcome === 'succeeded' ? 'completed' : 'failed'
   const expectedTaskStatus = params.outcome === 'succeeded' ? 'completed' : 'failed'
+  const reportingWorker = this.getWorkerDispatch(params.dispatchId)
   // Why (#16095): worker-start records a stalled prompt as failed, but the preamble was written
   // before verification ran — the worker may have been executing it the whole time. Its own report
   // is first-hand evidence and must be able to correct that record instead of being thrown away.
@@ -64,6 +65,13 @@ export function settleWorkerReportInTransaction(
     dispatch.status === 'failed' &&
     dispatch.last_failure === AGENT_PROMPT_STALLED_ERROR &&
     task.status === 'failed'
+  const ambiguousPostSubmit =
+    dispatch.status === 'pending' &&
+    task.status === 'blocked' &&
+    reportingWorker?.state === 'start_unknown' &&
+    reportingWorker.stage === 'dispatch_input' &&
+    reportingWorker.last_error === AGENT_PROMPT_STALLED_ERROR &&
+    dispatch.capability_revoked_at === null
   if (
     !settledByUnobservedPrompt &&
     dispatch.status === expectedDispatchStatus &&
@@ -71,10 +79,12 @@ export function settleWorkerReportInTransaction(
   ) {
     return { action: 'settled', outcome: params.outcome, duplicate: true }
   }
-  const previous = settledByUnobservedPrompt
-    ? { status: 'failed', workerState: 'failed' }
-    : { status: 'dispatched', workerState: 'ready' }
-  if (dispatch.status !== previous.status || task.status !== previous.status) {
+  const previous = ambiguousPostSubmit
+    ? { dispatchStatus: 'pending', taskStatus: 'blocked', workerState: 'start_unknown' }
+    : settledByUnobservedPrompt
+      ? { dispatchStatus: 'failed', taskStatus: 'failed', workerState: 'failed' }
+      : { dispatchStatus: 'dispatched', taskStatus: 'dispatched', workerState: 'ready' }
+  if (dispatch.status !== previous.dispatchStatus || task.status !== previous.taskStatus) {
     return {
       action: 'rejected',
       code: 'inactive_dispatch',
@@ -99,7 +109,6 @@ export function settleWorkerReportInTransaction(
       reason: `Task ${params.taskId} still has active supervised Dispatch ${conflictingWorker.id}; stop or settle it before completing ${params.dispatchId}.`
     }
   }
-  const reportingWorker = this.getWorkerDispatch(params.dispatchId)
   const latest = getActiveDispatchForTask(this, params.taskId)
   if (!reportingWorker && latest?.id !== params.dispatchId) {
     return {
@@ -129,7 +138,7 @@ export function settleWorkerReportInTransaction(
       expectedDispatchStatus,
       params.result,
       params.dispatchId,
-      previous.status
+      previous.dispatchStatus
     )
   const taskUpdate = this.db
     .prepare(
@@ -137,7 +146,7 @@ export function settleWorkerReportInTransaction(
        SET status = ?, result = ?, completed_at = datetime('now')
        WHERE id = ? AND status = ?`
     )
-    .run(expectedTaskStatus, params.result, params.taskId, previous.status)
+    .run(expectedTaskStatus, params.result, params.taskId, previous.taskStatus)
   if (dispatchUpdate.changes !== 1 || taskUpdate.changes !== 1) {
     this.db.exec('ROLLBACK TO settle_worker_report')
     this.db.exec('RELEASE settle_worker_report')

--- a/src/main/runtime/orchestration/db/federation/federation-relay-import.ts
+++ b/src/main/runtime/orchestration/db/federation/federation-relay-import.ts
@@ -95,7 +95,8 @@ export function importFederatedRelayItem(
         taskId: params.lifecycle.taskId,
         dispatchId: params.dispatchId,
         outcome: params.lifecycle.outcome,
-        result: params.lifecycle.result
+        result: params.lifecycle.result,
+        source: 'federation'
       })
       if (lifecycle.action === 'rejected' && !duplicate) {
         message = this.convertLifecycleMessageToRejection(

--- a/src/main/runtime/orchestration/db/federation/federation-relay-item.ts
+++ b/src/main/runtime/orchestration/db/federation/federation-relay-item.ts
@@ -40,7 +40,7 @@ export function settleRemoteAttachmentInRelayTransaction(
   if (attachment.state === state) {
     return
   }
-  if (attachment.state !== 'ready') {
+  if (!['ready', 'start_unknown'].includes(attachment.state)) {
     throw new OrchestrationError(
       'request_mismatch',
       `Remote Dispatch ${dispatchId} cannot settle as ${state} from ${attachment.state}.`
@@ -51,7 +51,7 @@ export function settleRemoteAttachmentInRelayTransaction(
       `UPDATE remote_dispatch_attachments
        SET state = ?, stage = ?, capability_hash = NULL,
            updated_at = datetime('now')
-       WHERE dispatch_id = ? AND state = 'ready'`
+       WHERE dispatch_id = ? AND state IN ('ready', 'start_unknown')`
     )
     .run(state, stage, dispatchId)
 }

--- a/src/main/runtime/orchestration/db/federation/remote-dispatch-attachment-authority.ts
+++ b/src/main/runtime/orchestration/db/federation/remote-dispatch-attachment-authority.ts
@@ -24,6 +24,12 @@ export function prepareRemoteAttachmentAuthority(
       `Remote Dispatch ${params.dispatchId} is not starting.`
     )
   }
+  const occupied = this.findActiveRemoteAttachmentForPane(params.paneKey)
+  if (occupied && occupied.dispatch_id !== params.dispatchId) {
+    throw new Error(
+      `Terminal ${params.terminalHandle} already has an active remote dispatch (${occupied.dispatch_id} for task ${occupied.task_id})`
+    )
+  }
   const capability = `dcap_${randomBytes(32).toString('base64url')}`
   const result = this.db
     .prepare(
@@ -96,11 +102,12 @@ export function failRemoteAttachment(
   const result = this.db
     .prepare(
       `UPDATE remote_dispatch_attachments
-       SET state = ?, stage = ?, last_error = ?, capability_hash = NULL,
+       SET state = ?, stage = ?, last_error = ?,
+           capability_hash = CASE WHEN ? = 1 THEN capability_hash ELSE NULL END,
            updated_at = datetime('now')
        WHERE dispatch_id = ? AND state = 'starting'`
     )
-    .run(state, stage, reason, dispatchId)
+    .run(state, stage, reason, unknown ? 1 : 0, dispatchId)
   if (result.changes !== 1) {
     throw new OrchestrationError(
       'dispatch_inactive',

--- a/src/main/runtime/orchestration/db/federation/remote-dispatch-attachment-stop.ts
+++ b/src/main/runtime/orchestration/db/federation/remote-dispatch-attachment-stop.ts
@@ -73,7 +73,8 @@ export function findActiveRemoteAttachmentForPane(
     return this.db
       .prepare(
         `SELECT * FROM remote_dispatch_attachments
-         WHERE state IN ('starting', 'ready') AND pane_key = ?
+         WHERE state IN ('starting', 'ready', 'start_unknown', 'stopping', 'stop_unknown')
+           AND pane_key = ?
          ORDER BY rowid DESC LIMIT 1`
       )
       .get(paneKey) as RemoteDispatchAttachmentRow | undefined
@@ -81,7 +82,8 @@ export function findActiveRemoteAttachmentForPane(
   return this.db
     .prepare(
       `SELECT * FROM remote_dispatch_attachments
-       WHERE state IN ('starting', 'ready') AND pane_key IS NOT NULL
+       WHERE state IN ('starting', 'ready', 'start_unknown', 'stopping', 'stop_unknown')
+         AND pane_key IS NOT NULL
          AND instr(pane_key, ':') > 1
          AND ${REMOTE_ATTACHMENT_PANE_KEY_MATCH_SUFFIX_SQL} = ?
        ORDER BY rowid DESC LIMIT 1`

--- a/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-outcome.ts
+++ b/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-outcome.ts
@@ -88,7 +88,8 @@ export function markWorkerStartUnknown(
   this: OrchestrationDb,
   dispatchId: string,
   stage: string,
-  reason: string
+  reason: string,
+  options: { retainCapability?: boolean } = {}
 ): WorkerDispatchRow {
   this.db.exec('BEGIN IMMEDIATE')
   try {
@@ -107,10 +108,11 @@ export function markWorkerStartUnknown(
     this.db
       .prepare(
         `UPDATE dispatch_contexts
-         SET capability_revoked_at = COALESCE(capability_revoked_at, datetime('now'))
+         SET capability_revoked_at = CASE WHEN ? = 1 THEN capability_revoked_at
+           ELSE COALESCE(capability_revoked_at, datetime('now')) END
          WHERE id = ?`
       )
-      .run(dispatchId)
+      .run(options.retainCapability ? 1 : 0, dispatchId)
     this.db.prepare("UPDATE tasks SET status = 'blocked' WHERE id = ?").run(dispatch.task_id)
     this.closeQuestionsForDispatch(dispatchId)
     this.db.exec('COMMIT')

--- a/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-stop.ts
+++ b/src/main/runtime/orchestration/db/worker-dispatch/worker-dispatch-stop.ts
@@ -93,20 +93,33 @@ export function settleWorkerStop(this: OrchestrationDb, dispatchId: string): Wor
   try {
     const worker = this.getWorkerDispatch(dispatchId)
     const dispatch = this.getDispatchContextById(dispatchId)
-    if (!worker || !dispatch || worker.state !== 'stopping') {
+    if (!worker || !dispatch) {
+      throw new OrchestrationError('dispatch_inactive', `Dispatch ${dispatchId} is not stopping.`)
+    }
+    if (
+      worker.state === 'stopped' &&
+      dispatch.status !== 'pending' &&
+      dispatch.status !== 'dispatched'
+    ) {
+      this.db.exec('COMMIT')
+      return worker
+    }
+    if (!['stopping', 'stop_unknown'].includes(worker.state)) {
       throw new OrchestrationError('dispatch_inactive', `Dispatch ${dispatchId} is not stopping.`)
     }
     this.db
       .prepare(
         `UPDATE worker_dispatches
-         SET state = 'stopped', stage = 'process_stopped', updated_at = datetime('now')
-         WHERE dispatch_id = ? AND state = 'stopping'`
+         SET state = 'stopped', stage = 'process_stopped', last_error = NULL,
+             updated_at = datetime('now')
+         WHERE dispatch_id = ? AND state IN ('stopping', 'stop_unknown')`
       )
       .run(dispatchId)
     this.db
       .prepare(
         `UPDATE dispatch_contexts
-         SET status = 'failed', completed_at = datetime('now'), last_failure = 'stopped'
+         SET status = 'failed', completed_at = datetime('now'), last_failure = 'stopped',
+             termination_reason = COALESCE(termination_reason, 'operator_close')
          WHERE id = ? AND status IN ('pending', 'dispatched')`
       )
       .run(dispatchId)

--- a/src/main/runtime/orchestration/orchestration-worker-dispatch-db.test.ts
+++ b/src/main/runtime/orchestration/orchestration-worker-dispatch-db.test.ts
@@ -357,7 +357,52 @@ describe('OrchestrationDb worker Dispatch state', () => {
     })
   })
 
-  it('bounds remote attachment lookup across pane remints and malformed suffix collisions', () => {
+  it('keeps a start-unknown remote pane fenced from an overlapping attachment', () => {
+    const d = createDb()
+    const paneKey = 'tab_remote:11111111-1111-4111-8111-111111111111'
+    const createAttachment = (dispatchId: string): void => {
+      d.createRemoteDispatchAttachment({
+        dispatchId,
+        taskId: `task_${dispatchId}`,
+        homePeerFingerprint: 'home_peer',
+        protocolVersion: 3,
+        runtimeEpoch: 'worker_epoch',
+        mutationReceipt: {
+          callerFingerprint: 'home_peer',
+          requestId: `request_${dispatchId}`,
+          method: 'orchestration.federationAttachStart',
+          payloadHash: `payload_${dispatchId}`
+        }
+      })
+    }
+    createAttachment('ctx_remote_first')
+    d.prepareRemoteAttachmentAuthority({
+      dispatchId: 'ctx_remote_first',
+      paneKey,
+      processIncarnation: 'worker_epoch:pty:1',
+      worktreeId: 'repo::worktree',
+      terminalHandle: 'term_remote',
+      setupState: 'not_applicable',
+      effects: []
+    })
+    d.failRemoteAttachment('ctx_remote_first', 'dispatch_input', 'agent_prompt_stalled', true)
+    expect(d.findActiveRemoteAttachmentForPane(paneKey)?.dispatch_id).toBe('ctx_remote_first')
+
+    createAttachment('ctx_remote_overlap')
+    expect(() =>
+      d.prepareRemoteAttachmentAuthority({
+        dispatchId: 'ctx_remote_overlap',
+        paneKey,
+        processIncarnation: 'worker_epoch:pty:1',
+        worktreeId: 'repo::worktree',
+        terminalHandle: 'term_remote',
+        setupState: 'not_applicable',
+        effects: []
+      })
+    ).toThrow('already has an active remote dispatch')
+  })
+
+  it('resolves remote attachment lookup across pane remints and malformed keys', () => {
     const d = createDb()
     const leafId = '11111111-1111-4111-8111-111111111111'
     const attach = (dispatchId: string, paneKey: string): void => {
@@ -386,13 +431,12 @@ describe('OrchestrationDb worker Dispatch state', () => {
     }
 
     attach('ctx_valid_old', `tab_old:${leafId}`)
-    for (let index = 0; index < 64; index += 1) {
-      attach(`ctx_malformed_${index}`, `:${leafId}`)
-    }
+    attach('ctx_malformed', `:${leafId}`)
 
     expect(d.findActiveRemoteAttachmentForPane(`tab_reminted:${leafId}`)?.dispatch_id).toBe(
       'ctx_valid_old'
     )
+    d.failRemoteAttachment('ctx_valid_old', 'dispatch_input', 'known rejection', false)
     attach('ctx_valid_new', `tab_new:${leafId}`)
     expect(d.findActiveRemoteAttachmentForPane(`tab_reminted:${leafId}`)?.dispatch_id).toBe(
       'ctx_valid_new'

--- a/src/main/runtime/orchestration/worker-start-unobserved-prompt-settlement.test.ts
+++ b/src/main/runtime/orchestration/worker-start-unobserved-prompt-settlement.test.ts
@@ -33,6 +33,39 @@ function verify(dispatchId: string, capability: string): { valid: boolean; reaso
 describe('worker start settled by an unobserved prompt', () => {
   afterEach(() => db?.close())
 
+  it('lets a late report settle an ambiguous post-submit worker-start', () => {
+    db = new OrchestrationDb(':memory:')
+    const { taskId, dispatchId, capability } = startWorker('run after an unobserved Enter')
+
+    db.markWorkerStartUnknown(dispatchId, 'dispatch_input', 'agent_prompt_stalled', {
+      retainCapability: true
+    })
+
+    expect(db.getDispatchContextById(dispatchId)).toMatchObject({
+      status: 'pending',
+      capability_revoked_at: null
+    })
+    expect(db.getTask(taskId)?.status).toBe('blocked')
+    expect(verify(dispatchId, capability)).toEqual({ valid: true })
+    expect(
+      db.settleWorkerReport({
+        taskId,
+        dispatchId,
+        outcome: 'succeeded',
+        result: 'late first-hand completion'
+      })
+    ).toEqual({ action: 'settled', outcome: 'succeeded', duplicate: false })
+    expect(db.getTask(taskId)).toMatchObject({
+      status: 'completed',
+      result: 'late first-hand completion'
+    })
+    expect(db.getDispatchContextById(dispatchId)?.status).toBe('completed')
+    expect(db.getWorkerDispatch(dispatchId)).toMatchObject({
+      state: 'succeeded',
+      stage: 'settled'
+    })
+  })
+
   it('keeps the capability and lets the worker report correct the record', () => {
     db = new OrchestrationDb(':memory:')
     const { taskId, dispatchId, capability } = startWorker('run to completion')

--- a/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
@@ -471,6 +471,46 @@ describe('orchestration RPC methods', () => {
       )
     })
 
+    it('keeps a post-submit stalled worker fenced from an overlapping worker-start', async () => {
+      setup()
+      mockCurrentWorkerStart()
+      vi.spyOn(runtime, 'isTerminalRunningAgent').mockResolvedValue(true)
+      vi.mocked(runtime.sendTerminalAgentPrompt).mockRejectedValueOnce(
+        new Error('agent_prompt_stalled')
+      )
+      const firstTask = db.createTask({ spec: 'possibly already running' })
+
+      const first = (await call('orchestration.workerStart', {
+        task: firstTask.id,
+        from: 'term_coord',
+        agent: 'codex'
+      })) as { dispatchId: string; state: string; failedStage: string }
+
+      expect(first).toMatchObject({
+        state: 'outcome_unknown',
+        failedStage: 'dispatch_input'
+      })
+      expect(db.getTask(firstTask.id)?.status).toBe('blocked')
+      expect(db.getDispatchContextById(first.dispatchId)).toMatchObject({
+        status: 'pending',
+        capability_revoked_at: null
+      })
+      expect(db.getWorkerDispatch(first.dispatchId)?.state).toBe('start_unknown')
+
+      const overlapTask = db.createTask({ spec: 'must not share the same pane' })
+      const overlap = (await call('orchestration.workerStart', {
+        task: overlapTask.id,
+        from: 'term_coord',
+        terminal: 'term_worker'
+      })) as { state: string; lastError: string }
+
+      expect(overlap).toMatchObject({
+        state: 'failed',
+        lastError: expect.stringContaining('already has an active dispatch')
+      })
+      expect(runtime.sendTerminalAgentPrompt).toHaveBeenCalledTimes(1)
+    })
+
     it.each(['codex-update-prompt', 'codex-trust-workspace'] as const)(
       'returns a truthful readiness failure for %s',
       async (blockedReason) => {

--- a/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
@@ -59,6 +59,7 @@ describe('orchestration RPC methods', () => {
         handle === 'term_worker' ? 'runtime_test:term_worker:1' : null
       )
       vi.spyOn(runtime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
+      vi.spyOn(runtime, 'refreshTerminalPromptAgentOwner').mockResolvedValue('codex')
       vi.spyOn(runtime, 'sendTerminalAgentPrompt').mockResolvedValue({
         handle: 'term_worker',
         accepted: true,
@@ -408,6 +409,29 @@ describe('orchestration RPC methods', () => {
       )
       expect(runtime.createTerminal).not.toHaveBeenCalled()
       expect(createWorktree).not.toHaveBeenCalled()
+    })
+
+    it('refreshes the current foreground owner before dispatching a reused pane', async () => {
+      setup()
+      mockCurrentWorkerStart()
+      // The generic liveness check can trust stale launch metadata. The settled preflight reads
+      // the live foreground owner used by prompt verification and its provider timeout.
+      vi.spyOn(runtime, 'isTerminalRunningAgent').mockResolvedValue(false)
+      const settled = vi
+        .spyOn(runtime, 'refreshTerminalPromptAgentOwner')
+        .mockResolvedValue('codex')
+      const task = db.createTask({ spec: 'reuse the pane under its current agent owner' })
+
+      await expect(
+        call('orchestration.workerStart', {
+          task: task.id,
+          from: 'term_coord',
+          terminal: 'term_worker'
+        })
+      ).resolves.toMatchObject({ state: 'ready' })
+
+      expect(settled).toHaveBeenCalledWith('term_worker')
+      expect(runtime.sendTerminalAgentPrompt).toHaveBeenCalledOnce()
     })
 
     it('returns a failed receipt and preserves a created terminal as residual', async () => {

--- a/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-composed-workers.test.ts
@@ -434,6 +434,77 @@ describe('orchestration RPC methods', () => {
       expect(runtime.sendTerminalAgentPrompt).toHaveBeenCalledOnce()
     })
 
+    it('waits for a reused pane wrapper to resolve its current foreground owner', async () => {
+      setup()
+      const internals = runtime as unknown as {
+        resolveTerminalWorkspaceLaunchScope: (selector: string) => Promise<unknown>
+      }
+      vi.spyOn(internals, 'resolveTerminalWorkspaceLaunchScope').mockResolvedValue({
+        id: 'repo::worktree',
+        path: '/repo/worktree',
+        connectionId: null,
+        repo: null,
+        folderWorkspace: null
+      })
+      const getForegroundProcess = vi.fn().mockResolvedValueOnce('node').mockResolvedValue('codex')
+      runtime.setPtyController({
+        spawn: vi.fn().mockResolvedValue({ id: 'pty_worker', incarnationId: 'inc_worker' }),
+        write: () => true,
+        kill: () => true,
+        getForegroundProcess
+      })
+      const terminal = await runtime.createTerminal('id:repo::worktree', {
+        tabId: 'tab_worker',
+        leafId: 'leaf_worker',
+        title: 'worker'
+      })
+      runtime.attachWindow(1)
+      runtime.syncWindowGraph(1, {
+        tabs: [
+          {
+            tabId: 'tab_worker',
+            worktreeId: 'repo::worktree',
+            title: 'worker',
+            activeLeafId: 'leaf_worker',
+            layout: null
+          }
+        ],
+        leaves: [
+          {
+            tabId: 'tab_worker',
+            worktreeId: 'repo::worktree',
+            leafId: 'leaf_worker',
+            paneRuntimeId: 1,
+            ptyId: 'pty_worker',
+            paneTitle: 'bash'
+          }
+        ]
+      })
+      mockCurrentWorkerStart()
+      vi.mocked(runtime.refreshTerminalPromptAgentOwner).mockRestore()
+      vi.mocked(runtime.getTerminalPaneKey).mockImplementation((handle) =>
+        handle === 'term_coord'
+          ? coordinatorPaneKey
+          : handle === terminal.handle
+            ? 'tab_worker:leaf_worker'
+            : null
+      )
+      vi.mocked(runtime.getTerminalProcessIncarnation).mockImplementation((handle) =>
+        handle === terminal.handle ? 'runtime_test:pty_worker:1' : null
+      )
+      const task = db.createTask({ spec: 'reuse the delayed wrapper pane' })
+
+      await expect(
+        call('orchestration.workerStart', {
+          task: task.id,
+          from: 'term_coord',
+          terminal: terminal.handle
+        })
+      ).resolves.toMatchObject({ state: 'ready' })
+
+      expect(runtime.sendTerminalAgentPrompt).toHaveBeenCalledOnce()
+    })
+
     it('returns a failed receipt and preserves a created terminal as residual', async () => {
       setup()
       mockCurrentWorkerStart({ ready: false })

--- a/src/main/runtime/rpc/methods/orchestration-federated-worker-start.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federated-worker-start.ts
@@ -22,6 +22,7 @@ import {
 } from './orchestration-worker-launch-preferences'
 import { validateFederatedWorkerStartPlacement } from './orchestration-worker-start-validation'
 import { resolveDispatchCreator } from './orchestration-dispatch-creator'
+import { isFederationPromptStalled } from './orchestration-federation-effects'
 
 export async function startFederatedWorker(args: {
   params: WorkerStartInput
@@ -211,7 +212,8 @@ export async function startFederatedWorker(args: {
       const worker = db.markWorkerStartUnknown(
         started.dispatch.id,
         remote.failedStage ?? 'remote_attach',
-        remote.lastError ?? 'The worker server reported an unknown start outcome.'
+        remote.lastError ?? 'The worker server reported an unknown start outcome.',
+        { retainCapability: isFederationPromptStalled(remote.lastError, remote.failedStage) }
       )
       return federatedUnknownReceipt(worker, task.id, server.name, launch)
     }

--- a/src/main/runtime/rpc/methods/orchestration-federation-ambiguous-start.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation-ambiguous-start.test.ts
@@ -1,0 +1,223 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ORCHESTRATION_CONTRACT_VERSION } from '../../../../shared/protocol-version'
+import type { RuntimeRpcResponse } from '../../../../shared/runtime-rpc-envelope'
+import { OrcaRuntimeService } from '../../orca-runtime'
+import { OrchestrationDb } from '../../orchestration/db'
+import type { OrchestrationEnvironmentTransport } from '../../orchestration/environment-transport'
+import { RpcDispatcher } from '../dispatcher'
+import { ORCHESTRATION_METHODS } from './orchestration'
+import { createFederationWorkerStartRequest as startRequest } from './orchestration-federation-test-request'
+
+describe('orchestration federation ambiguous starts', () => {
+  let homeDb: OrchestrationDb
+  let workerDb: OrchestrationDb
+  let homeRuntime: OrcaRuntimeService
+  let workerRuntime: OrcaRuntimeService
+  let homeDispatcher: RpcDispatcher
+  let workerDispatcher: RpcDispatcher
+  let failNextAttachAfterDelivery: boolean
+
+  beforeEach(() => {
+    homeDb = new OrchestrationDb(':memory:')
+    workerDb = new OrchestrationDb(':memory:')
+    workerRuntime = new OrcaRuntimeService()
+    workerRuntime.setOrchestrationDb(workerDb)
+    workerDispatcher = new RpcDispatcher({ runtime: workerRuntime, methods: ORCHESTRATION_METHODS })
+    failNextAttachAfterDelivery = false
+    const transport: OrchestrationEnvironmentTransport = {
+      resolve: () => ({
+        environmentId: 'environment_windows',
+        name: 'windows',
+        peerFingerprint: 'windows_peer_fingerprint'
+      }),
+      call: async (_selector, method, params, _timeoutMs, envelope) => {
+        if (method === 'status.get') {
+          return {
+            id: 'status',
+            ok: true,
+            result: workerRuntime.getStatus(),
+            _meta: { runtimeId: workerRuntime.getRuntimeId() }
+          }
+        }
+        const response = (await workerDispatcher.dispatch({
+          id: `remote_${method}`,
+          authToken: 'run-home-device-token',
+          method,
+          params,
+          orchestrationContractVersion: envelope?.orchestrationContractVersion,
+          orchestrationRequestId: envelope?.orchestrationRequestId,
+          orchestrationCapability: envelope?.orchestrationCapability
+        })) as RuntimeRpcResponse<unknown>
+        if (method === 'orchestration.federationAttachStart' && failNextAttachAfterDelivery) {
+          failNextAttachAfterDelivery = false
+          throw new Error('connection lost after remote attachment')
+        }
+        return response
+      }
+    }
+    homeRuntime = new OrcaRuntimeService(null, undefined, {
+      orchestrationEnvironmentTransport: transport
+    })
+    homeRuntime.setOrchestrationDb(homeDb)
+    homeDispatcher = new RpcDispatcher({ runtime: homeRuntime, methods: ORCHESTRATION_METHODS })
+    vi.spyOn(homeRuntime, 'getTerminalPaneKey').mockReturnValue(
+      'tab_coord:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    )
+    configureWorkerRuntime()
+  })
+
+  afterEach(() => {
+    homeRuntime.stopOrchestrationFederationRelay()
+    homeDb.close()
+    workerDb.close()
+  })
+
+  function configureWorkerRuntime(): void {
+    vi.spyOn(workerRuntime, 'validateOrchestrationAgentLauncher').mockImplementation(() => {})
+    vi.spyOn(workerRuntime, 'showRepo').mockResolvedValue({
+      id: 'windows-repo',
+      kind: 'git'
+    } as never)
+    vi.spyOn(workerRuntime, 'createManagedWorktree').mockResolvedValue({
+      worktree: { id: 'repo::windows-worktree', repoId: 'repo' },
+      startupTerminal: { spawned: true, handle: 'term_windows_worker' },
+      setupReceipt: {
+        requested: 'run',
+        hookFound: true,
+        startupPolicy: 'start-immediately',
+        state: 'running'
+      }
+    } as never)
+    vi.spyOn(workerRuntime, 'listTerminals').mockResolvedValue({
+      terminals: [{ handle: 'term_windows_worker', title: 'Codex' }],
+      totalCount: 1,
+      truncated: false
+    } as never)
+    vi.spyOn(workerRuntime, 'waitForTerminal').mockResolvedValue({
+      handle: 'term_windows_worker',
+      condition: 'tui-idle',
+      satisfied: true,
+      status: 'running',
+      exitCode: null
+    })
+    vi.spyOn(workerRuntime, 'getTerminalPaneKey').mockReturnValue(
+      'tab_worker:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+    )
+    vi.spyOn(workerRuntime, 'getTerminalProcessIncarnation').mockReturnValue(
+      'windows_runtime:pty:1'
+    )
+    vi.spyOn(workerRuntime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
+    vi.spyOn(workerRuntime, 'sendTerminalAgentPrompt').mockResolvedValue({
+      handle: 'term_windows_worker',
+      accepted: true,
+      bytesWritten: 1
+    })
+  }
+
+  function createHomeTask() {
+    const run = homeDb.createRun({
+      objective: 'Mac to Windows',
+      coordinatorHandle: 'term_coord',
+      coordinatorPaneKey: 'tab_coord:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    })
+    return homeDb.createTask({ spec: 'Audit Windows behavior', runId: run.id })
+  }
+
+  function dispatchRemoteCompletion(taskId: string, dispatchId: string, requestId: string) {
+    const prompt = vi.mocked(workerRuntime.sendTerminalAgentPrompt).mock.calls[0]?.[1] ?? ''
+    const capability = prompt.match(/--dispatch-capability (dcap_[A-Za-z0-9_-]+)/)?.[1]
+    return workerDispatcher.dispatch({
+      id: `rpc_${requestId}`,
+      authToken: 'worker-local-token',
+      orchestrationContractVersion: ORCHESTRATION_CONTRACT_VERSION,
+      orchestrationRequestId: requestId,
+      orchestrationCapability: capability,
+      method: 'orchestration.send',
+      params: {
+        from: 'term_windows_worker',
+        subject: 'Done',
+        type: 'worker_done',
+        payload: JSON.stringify({ taskId, dispatchId, outcome: 'succeeded' })
+      }
+    })
+  }
+
+  it('keeps an unobserved remote Enter fenced and accepts its late worker report', async () => {
+    vi.mocked(workerRuntime.sendTerminalAgentPrompt).mockRejectedValueOnce(
+      new Error('agent_prompt_stalled')
+    )
+    const task = createHomeTask()
+
+    const started = await homeDispatcher.dispatch(startRequest(task.id))
+    homeRuntime.stopOrchestrationFederationRelay()
+    expect(started).toMatchObject({
+      ok: true,
+      result: { state: 'outcome_unknown', failedStage: 'dispatch_input' }
+    })
+    const dispatch = homeDb.getDispatchContext(task.id)!
+    expect(homeDb.getTask(task.id)?.status).toBe('blocked')
+    expect(homeDb.getDispatchContextById(dispatch.id)).toMatchObject({
+      status: 'pending',
+      capability_revoked_at: null
+    })
+    expect(homeDb.getWorkerDispatch(dispatch.id)).toMatchObject({
+      state: 'start_unknown',
+      stage: 'dispatch_input'
+    })
+    expect(workerDb.getRemoteDispatchAttachment(dispatch.id)).toMatchObject({
+      state: 'start_unknown',
+      stage: 'dispatch_input',
+      last_error: 'agent_prompt_stalled',
+      capability_hash: expect.any(String)
+    })
+
+    const sent = dispatchRemoteCompletion(task.id, dispatch.id, 'stalled_remote_late_completion')
+    await vi.waitFor(() =>
+      expect(workerDb.listPendingFederationRelay(dispatch.id, 'to_home')).toHaveLength(1)
+    )
+    await homeRuntime.syncOrchestrationFederatedDispatch(dispatch.id)
+
+    await expect(sent).resolves.toMatchObject({
+      ok: true,
+      result: { lifecycle: { action: 'completed', authority: 'run_home' } }
+    })
+    expect(homeDb.getTask(task.id)?.status).toBe('completed')
+    expect(workerDb.getRemoteDispatchAttachment(dispatch.id)).toMatchObject({
+      state: 'succeeded',
+      stage: 'worker_report_settled',
+      capability_hash: null
+    })
+  })
+
+  it('accepts a late report after the remote attachment response is lost', async () => {
+    failNextAttachAfterDelivery = true
+    const task = createHomeTask()
+
+    const started = await homeDispatcher.dispatch(startRequest(task.id))
+    homeRuntime.stopOrchestrationFederationRelay()
+    expect(started).toMatchObject({
+      ok: true,
+      result: { state: 'outcome_unknown', failedStage: 'remote_attach' }
+    })
+    const dispatch = homeDb.getDispatchContext(task.id)!
+    expect(homeDb.getWorkerDispatch(dispatch.id)).toMatchObject({
+      state: 'start_unknown',
+      stage: 'remote_attach'
+    })
+    expect(workerDb.getRemoteDispatchAttachment(dispatch.id)?.state).toBe('ready')
+
+    const sent = dispatchRemoteCompletion(task.id, dispatch.id, 'lost_attach_late_completion')
+    await vi.waitFor(() =>
+      expect(workerDb.listPendingFederationRelay(dispatch.id, 'to_home')).toHaveLength(1)
+    )
+    await homeRuntime.syncOrchestrationFederatedDispatch(dispatch.id)
+
+    await expect(sent).resolves.toMatchObject({
+      ok: true,
+      result: { lifecycle: { action: 'completed', authority: 'run_home' } }
+    })
+    expect(homeDb.getTask(task.id)?.status).toBe('completed')
+    expect(homeDb.getDispatchContextById(dispatch.id)?.status).toBe('completed')
+    expect(workerDb.getRemoteDispatchAttachment(dispatch.id)?.state).toBe('succeeded')
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration-federation-effects.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation-effects.ts
@@ -1,3 +1,5 @@
+import { isAgentPromptStalledError } from '../../agent-prompt-submission-verification'
+
 export type FederationEffect = {
   kind: 'worktree' | 'terminal' | 'setup' | 'dispatch_input'
   action?: string
@@ -12,6 +14,11 @@ export type FederationEffect = {
   hookFound?: boolean
   startupPolicy?: string
   terminalId?: string
+}
+
+export function isFederationPromptStalled(error: unknown, stage: string | undefined): boolean {
+  const promptError = typeof error === 'string' ? new Error(error) : error
+  return stage === 'dispatch_input' && isAgentPromptStalledError(promptError)
 }
 
 export function appendFederationTerminalEffects(
@@ -69,6 +76,9 @@ export function isFederationEffectUnknown(error: unknown, stage: string): boolea
       ? (error as { code: string }).code
       : ''
   if (code === 'operation_unknown') {
+    return true
+  }
+  if (isFederationPromptStalled(error, stage)) {
     return true
   }
   if (!['worktree_create', 'terminal_create', 'dispatch_input'].includes(stage)) {

--- a/src/main/runtime/rpc/methods/orchestration-federation-lifecycle-settlement.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation-lifecycle-settlement.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Why: this end-to-end suite keeps both runtimes, transport faults, relay state, and authenticated lifecycle settlement on one shared federation harness. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   ORCHESTRATION_CONTRACT_VERSION,
@@ -22,6 +23,7 @@ describe('orchestration federation lifecycle settlement', () => {
   let workerDispatcher: RpcDispatcher
   let workerCapabilities: string[]
   let failNextAckBeforeDelivery: boolean
+  let failNextAttachAfterDelivery: boolean
   let ackAttempts: number
   let transport: OrchestrationEnvironmentTransport
 
@@ -33,6 +35,7 @@ describe('orchestration federation lifecycle settlement', () => {
     workerDispatcher = new RpcDispatcher({ runtime: workerRuntime, methods: ORCHESTRATION_METHODS })
     workerCapabilities = [...(workerRuntime.getStatus().capabilities ?? [])]
     failNextAckBeforeDelivery = false
+    failNextAttachAfterDelivery = false
     ackAttempts = 0
     transport = {
       resolve: () => ({
@@ -56,7 +59,7 @@ describe('orchestration federation lifecycle settlement', () => {
           failNextAckBeforeDelivery = false
           throw new Error('connection lost before acknowledgment')
         }
-        return (await workerDispatcher.dispatch({
+        const response = (await workerDispatcher.dispatch({
           id: `remote_${method}`,
           authToken: 'run-home-device-token',
           method,
@@ -65,6 +68,11 @@ describe('orchestration federation lifecycle settlement', () => {
           orchestrationRequestId: envelope?.orchestrationRequestId,
           orchestrationCapability: envelope?.orchestrationCapability
         })) as RuntimeRpcResponse<unknown>
+        if (method === 'orchestration.federationAttachStart' && failNextAttachAfterDelivery) {
+          failNextAttachAfterDelivery = false
+          throw new Error('connection lost after remote attachment')
+        }
+        return response
       }
     }
     homeRuntime = new OrcaRuntimeService(null, undefined, {
@@ -245,6 +253,85 @@ describe('orchestration federation lifecycle settlement', () => {
       stage: 'worker_report_settled',
       capability_hash: null
     })
+  })
+
+  it('keeps an unobserved remote Enter fenced and accepts its late worker report', async () => {
+    vi.mocked(workerRuntime.sendTerminalAgentPrompt).mockRejectedValueOnce(
+      new Error('agent_prompt_stalled')
+    )
+    const task = createHomeTask()
+
+    const started = await homeDispatcher.dispatch(startRequest(task.id))
+    homeRuntime.stopOrchestrationFederationRelay()
+    expect(started).toMatchObject({
+      ok: true,
+      result: { state: 'outcome_unknown', failedStage: 'dispatch_input' }
+    })
+    const dispatch = homeDb.getDispatchContext(task.id)!
+    expect(homeDb.getTask(task.id)?.status).toBe('blocked')
+    expect(homeDb.getDispatchContextById(dispatch.id)).toMatchObject({
+      status: 'pending',
+      capability_revoked_at: null
+    })
+    expect(homeDb.getWorkerDispatch(dispatch.id)).toMatchObject({
+      state: 'start_unknown',
+      stage: 'dispatch_input'
+    })
+    expect(workerDb.getRemoteDispatchAttachment(dispatch.id)).toMatchObject({
+      state: 'start_unknown',
+      stage: 'dispatch_input',
+      last_error: 'agent_prompt_stalled',
+      capability_hash: expect.any(String)
+    })
+
+    const sent = dispatchRemoteCompletion(task.id, dispatch.id, 'stalled_remote_late_completion')
+    await vi.waitFor(() =>
+      expect(workerDb.listPendingFederationRelay(dispatch.id, 'to_home')).toHaveLength(1)
+    )
+    await homeRuntime.syncOrchestrationFederatedDispatch(dispatch.id)
+
+    await expect(sent).resolves.toMatchObject({
+      ok: true,
+      result: { lifecycle: { action: 'completed', authority: 'run_home' } }
+    })
+    expect(homeDb.getTask(task.id)?.status).toBe('completed')
+    expect(workerDb.getRemoteDispatchAttachment(dispatch.id)).toMatchObject({
+      state: 'succeeded',
+      stage: 'worker_report_settled',
+      capability_hash: null
+    })
+  })
+
+  it('accepts a late report after the remote attachment response is lost', async () => {
+    failNextAttachAfterDelivery = true
+    const task = createHomeTask()
+
+    const started = await homeDispatcher.dispatch(startRequest(task.id))
+    homeRuntime.stopOrchestrationFederationRelay()
+    expect(started).toMatchObject({
+      ok: true,
+      result: { state: 'outcome_unknown', failedStage: 'remote_attach' }
+    })
+    const dispatch = homeDb.getDispatchContext(task.id)!
+    expect(homeDb.getWorkerDispatch(dispatch.id)).toMatchObject({
+      state: 'start_unknown',
+      stage: 'remote_attach'
+    })
+    expect(workerDb.getRemoteDispatchAttachment(dispatch.id)?.state).toBe('ready')
+
+    const sent = dispatchRemoteCompletion(task.id, dispatch.id, 'lost_attach_late_completion')
+    await vi.waitFor(() =>
+      expect(workerDb.listPendingFederationRelay(dispatch.id, 'to_home')).toHaveLength(1)
+    )
+    await homeRuntime.syncOrchestrationFederatedDispatch(dispatch.id)
+
+    await expect(sent).resolves.toMatchObject({
+      ok: true,
+      result: { lifecycle: { action: 'completed', authority: 'run_home' } }
+    })
+    expect(homeDb.getTask(task.id)?.status).toBe('completed')
+    expect(homeDb.getDispatchContextById(dispatch.id)?.status).toBe('completed')
+    expect(workerDb.getRemoteDispatchAttachment(dispatch.id)?.state).toBe('succeeded')
   })
 
   it('returns a Run-home rejection for a mismatched remote task', async () => {

--- a/src/main/runtime/rpc/methods/orchestration-federation-lifecycle-settlement.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation-lifecycle-settlement.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: this end-to-end suite keeps both runtimes, transport faults, relay state, and authenticated lifecycle settlement on one shared federation harness. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   ORCHESTRATION_CONTRACT_VERSION,
@@ -23,7 +22,6 @@ describe('orchestration federation lifecycle settlement', () => {
   let workerDispatcher: RpcDispatcher
   let workerCapabilities: string[]
   let failNextAckBeforeDelivery: boolean
-  let failNextAttachAfterDelivery: boolean
   let ackAttempts: number
   let transport: OrchestrationEnvironmentTransport
 
@@ -35,7 +33,6 @@ describe('orchestration federation lifecycle settlement', () => {
     workerDispatcher = new RpcDispatcher({ runtime: workerRuntime, methods: ORCHESTRATION_METHODS })
     workerCapabilities = [...(workerRuntime.getStatus().capabilities ?? [])]
     failNextAckBeforeDelivery = false
-    failNextAttachAfterDelivery = false
     ackAttempts = 0
     transport = {
       resolve: () => ({
@@ -68,10 +65,6 @@ describe('orchestration federation lifecycle settlement', () => {
           orchestrationRequestId: envelope?.orchestrationRequestId,
           orchestrationCapability: envelope?.orchestrationCapability
         })) as RuntimeRpcResponse<unknown>
-        if (method === 'orchestration.federationAttachStart' && failNextAttachAfterDelivery) {
-          failNextAttachAfterDelivery = false
-          throw new Error('connection lost after remote attachment')
-        }
         return response
       }
     }
@@ -253,85 +246,6 @@ describe('orchestration federation lifecycle settlement', () => {
       stage: 'worker_report_settled',
       capability_hash: null
     })
-  })
-
-  it('keeps an unobserved remote Enter fenced and accepts its late worker report', async () => {
-    vi.mocked(workerRuntime.sendTerminalAgentPrompt).mockRejectedValueOnce(
-      new Error('agent_prompt_stalled')
-    )
-    const task = createHomeTask()
-
-    const started = await homeDispatcher.dispatch(startRequest(task.id))
-    homeRuntime.stopOrchestrationFederationRelay()
-    expect(started).toMatchObject({
-      ok: true,
-      result: { state: 'outcome_unknown', failedStage: 'dispatch_input' }
-    })
-    const dispatch = homeDb.getDispatchContext(task.id)!
-    expect(homeDb.getTask(task.id)?.status).toBe('blocked')
-    expect(homeDb.getDispatchContextById(dispatch.id)).toMatchObject({
-      status: 'pending',
-      capability_revoked_at: null
-    })
-    expect(homeDb.getWorkerDispatch(dispatch.id)).toMatchObject({
-      state: 'start_unknown',
-      stage: 'dispatch_input'
-    })
-    expect(workerDb.getRemoteDispatchAttachment(dispatch.id)).toMatchObject({
-      state: 'start_unknown',
-      stage: 'dispatch_input',
-      last_error: 'agent_prompt_stalled',
-      capability_hash: expect.any(String)
-    })
-
-    const sent = dispatchRemoteCompletion(task.id, dispatch.id, 'stalled_remote_late_completion')
-    await vi.waitFor(() =>
-      expect(workerDb.listPendingFederationRelay(dispatch.id, 'to_home')).toHaveLength(1)
-    )
-    await homeRuntime.syncOrchestrationFederatedDispatch(dispatch.id)
-
-    await expect(sent).resolves.toMatchObject({
-      ok: true,
-      result: { lifecycle: { action: 'completed', authority: 'run_home' } }
-    })
-    expect(homeDb.getTask(task.id)?.status).toBe('completed')
-    expect(workerDb.getRemoteDispatchAttachment(dispatch.id)).toMatchObject({
-      state: 'succeeded',
-      stage: 'worker_report_settled',
-      capability_hash: null
-    })
-  })
-
-  it('accepts a late report after the remote attachment response is lost', async () => {
-    failNextAttachAfterDelivery = true
-    const task = createHomeTask()
-
-    const started = await homeDispatcher.dispatch(startRequest(task.id))
-    homeRuntime.stopOrchestrationFederationRelay()
-    expect(started).toMatchObject({
-      ok: true,
-      result: { state: 'outcome_unknown', failedStage: 'remote_attach' }
-    })
-    const dispatch = homeDb.getDispatchContext(task.id)!
-    expect(homeDb.getWorkerDispatch(dispatch.id)).toMatchObject({
-      state: 'start_unknown',
-      stage: 'remote_attach'
-    })
-    expect(workerDb.getRemoteDispatchAttachment(dispatch.id)?.state).toBe('ready')
-
-    const sent = dispatchRemoteCompletion(task.id, dispatch.id, 'lost_attach_late_completion')
-    await vi.waitFor(() =>
-      expect(workerDb.listPendingFederationRelay(dispatch.id, 'to_home')).toHaveLength(1)
-    )
-    await homeRuntime.syncOrchestrationFederatedDispatch(dispatch.id)
-
-    await expect(sent).resolves.toMatchObject({
-      ok: true,
-      result: { lifecycle: { action: 'completed', authority: 'run_home' } }
-    })
-    expect(homeDb.getTask(task.id)?.status).toBe('completed')
-    expect(homeDb.getDispatchContextById(dispatch.id)?.status).toBe('completed')
-    expect(workerDb.getRemoteDispatchAttachment(dispatch.id)?.state).toBe('succeeded')
   })
 
   it('returns a Run-home rejection for a mismatched remote task', async () => {

--- a/src/main/runtime/rpc/methods/orchestration-federation-reused-pane.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation-reused-pane.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RuntimeRpcResponse } from '../../../../shared/runtime-rpc-envelope'
+import { OrcaRuntimeService } from '../../orca-runtime'
+import { OrchestrationDb } from '../../orchestration/db'
+import type { OrchestrationEnvironmentTransport } from '../../orchestration/environment-transport'
+import { RpcDispatcher } from '../dispatcher'
+import { ORCHESTRATION_METHODS } from './orchestration'
+import { createFederationWorkerStartRequest as startRequest } from './orchestration-federation-test-request'
+
+describe('orchestration federation reused panes', () => {
+  let homeDb: OrchestrationDb
+  let workerDb: OrchestrationDb
+  let homeRuntime: OrcaRuntimeService
+  let workerRuntime: OrcaRuntimeService
+  let homeDispatcher: RpcDispatcher
+  let workerDispatcher: RpcDispatcher
+
+  beforeEach(() => {
+    homeDb = new OrchestrationDb(':memory:')
+    workerDb = new OrchestrationDb(':memory:')
+    workerRuntime = new OrcaRuntimeService()
+    workerRuntime.setOrchestrationDb(workerDb)
+    workerDispatcher = new RpcDispatcher({ runtime: workerRuntime, methods: ORCHESTRATION_METHODS })
+    const transport: OrchestrationEnvironmentTransport = {
+      resolve: () => ({
+        environmentId: 'environment_windows',
+        name: 'windows',
+        peerFingerprint: 'windows_peer_fingerprint'
+      }),
+      call: async (_selector, method, params, _timeoutMs, envelope) => {
+        if (method === 'status.get') {
+          return {
+            id: 'status',
+            ok: true,
+            result: workerRuntime.getStatus(),
+            _meta: { runtimeId: workerRuntime.getRuntimeId() }
+          }
+        }
+        return (await workerDispatcher.dispatch({
+          id: `remote_${method}`,
+          authToken: 'run-home-device-token',
+          method,
+          params,
+          orchestrationContractVersion: envelope?.orchestrationContractVersion,
+          orchestrationRequestId: envelope?.orchestrationRequestId,
+          orchestrationCapability: envelope?.orchestrationCapability
+        })) as RuntimeRpcResponse<unknown>
+      }
+    }
+    homeRuntime = new OrcaRuntimeService(null, undefined, {
+      orchestrationEnvironmentTransport: transport
+    })
+    homeRuntime.setOrchestrationDb(homeDb)
+    homeDispatcher = new RpcDispatcher({ runtime: homeRuntime, methods: ORCHESTRATION_METHODS })
+    vi.spyOn(homeRuntime, 'getTerminalPaneKey').mockReturnValue(
+      'tab_coord:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    )
+    vi.spyOn(workerRuntime, 'validateOrchestrationAgentLauncher').mockImplementation(() => {})
+    vi.spyOn(workerRuntime, 'getTerminalPaneKey').mockReturnValue(
+      'tab_worker:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+    )
+    vi.spyOn(workerRuntime, 'getTerminalProcessIncarnation').mockReturnValue(
+      'windows_runtime:pty:1'
+    )
+    vi.spyOn(workerRuntime, 'getTerminalOrchestrationCliCommand').mockReturnValue('orca')
+    vi.spyOn(workerRuntime, 'waitForTerminal').mockResolvedValue({
+      handle: 'term_windows_worker',
+      condition: 'tui-idle',
+      satisfied: true,
+      status: 'running',
+      exitCode: null
+    })
+    vi.spyOn(workerRuntime, 'showTerminal').mockImplementation(
+      async (handle) =>
+        ({ handle, worktreeId: 'repo::windows-worktree', status: 'running' }) as never
+    )
+    vi.spyOn(workerRuntime, 'sendTerminalAgentPrompt').mockResolvedValue({
+      handle: 'term_windows_worker',
+      accepted: true,
+      bytesWritten: 1
+    })
+  })
+
+  afterEach(() => {
+    homeRuntime.stopOrchestrationFederationRelay()
+    homeDb.close()
+    workerDb.close()
+  })
+
+  function createHomeTask() {
+    const run = homeDb.createRun({
+      objective: 'Mac to Windows',
+      coordinatorHandle: 'term_coord',
+      coordinatorPaneKey: 'tab_coord:aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    })
+    return homeDb.createTask({ spec: 'Audit Windows behavior', runId: run.id })
+  }
+
+  function stubRemoteWorktree(): void {
+    vi.spyOn(workerRuntime, 'showManagedTerminalWorkspace').mockResolvedValue({
+      id: 'repo::windows-worktree',
+      repoId: 'repo'
+    } as never)
+  }
+
+  it('refreshes a reused remote pane foreground owner before dispatch input', async () => {
+    stubRemoteWorktree()
+    vi.spyOn(workerRuntime, 'isTerminalRunningAgent').mockResolvedValue(false)
+    const refreshed = vi
+      .spyOn(workerRuntime, 'refreshTerminalPromptAgentOwner')
+      .mockResolvedValue('codex')
+    const task = createHomeTask()
+
+    const started = await homeDispatcher.dispatch(
+      startRequest(task.id, {
+        worktree: 'id:repo::windows-worktree',
+        terminal: 'term_windows_worker',
+        repo: undefined,
+        name: undefined,
+        agent: undefined
+      })
+    )
+
+    expect(started).toMatchObject({ ok: true, result: { state: 'ready' } })
+    expect(refreshed).toHaveBeenCalledWith('term_windows_worker')
+    expect(workerRuntime.sendTerminalAgentPrompt).toHaveBeenCalledOnce()
+  })
+
+  it('waits for a reused remote wrapper to resolve its current foreground owner', async () => {
+    stubRemoteWorktree()
+    const internals = workerRuntime as unknown as {
+      resolveTerminalWorkspaceLaunchScope: (selector: string) => Promise<unknown>
+    }
+    vi.spyOn(internals, 'resolveTerminalWorkspaceLaunchScope').mockResolvedValue({
+      id: 'repo::windows-worktree',
+      path: 'C:\\repo\\worktree',
+      connectionId: null,
+      repo: null,
+      folderWorkspace: null
+    })
+    workerRuntime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty_windows_worker', incarnationId: 'inc_worker' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: vi.fn().mockResolvedValueOnce('node').mockResolvedValue('codex')
+    })
+    const terminal = await workerRuntime.createTerminal('id:repo::windows-worktree', {
+      tabId: 'tab_worker',
+      leafId: 'leaf_worker',
+      title: 'worker'
+    })
+    workerRuntime.attachWindow(1)
+    workerRuntime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'tab_worker',
+          worktreeId: 'repo::windows-worktree',
+          title: 'worker',
+          activeLeafId: 'leaf_worker',
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'tab_worker',
+          worktreeId: 'repo::windows-worktree',
+          leafId: 'leaf_worker',
+          paneRuntimeId: 1,
+          ptyId: 'pty_windows_worker',
+          paneTitle: 'bash'
+        }
+      ]
+    })
+    const task = createHomeTask()
+
+    const started = await homeDispatcher.dispatch(
+      startRequest(task.id, {
+        worktree: 'id:repo::windows-worktree',
+        terminal: terminal.handle,
+        repo: undefined,
+        name: undefined,
+        agent: undefined
+      })
+    )
+
+    expect(started).toMatchObject({ ok: true, result: { state: 'ready' } })
+    expect(workerRuntime.sendTerminalAgentPrompt).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration-federation.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- Why: these federation RPC tests share one paired-runtime harness so attachment authority and remote resource ownership cannot drift between fixtures. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { RuntimeRpcResponse } from '../../../../shared/runtime-rpc-envelope'
 import {
@@ -210,32 +209,6 @@ describe('orchestration federation', () => {
       'term_windows_worker',
       expect.stringContaining(`Your task ID is: ${task.id}`)
     )
-  })
-
-  it('refreshes a reused remote pane foreground owner before dispatch input', async () => {
-    vi.spyOn(workerRuntime, 'showManagedTerminalWorkspace').mockResolvedValue({
-      id: 'repo::windows-worktree',
-      repoId: 'repo'
-    } as never)
-    vi.spyOn(workerRuntime, 'isTerminalRunningAgent').mockResolvedValue(false)
-    const settled = vi
-      .spyOn(workerRuntime, 'refreshTerminalPromptAgentOwner')
-      .mockResolvedValue('codex')
-    const task = createHomeTask()
-
-    const started = await homeDispatcher.dispatch(
-      startRequest(task.id, {
-        worktree: 'id:repo::windows-worktree',
-        terminal: 'term_windows_worker',
-        repo: undefined,
-        name: undefined,
-        agent: undefined
-      })
-    )
-
-    expect(started).toMatchObject({ ok: true, result: { state: 'ready' } })
-    expect(settled).toHaveBeenCalledWith('term_windows_worker')
-    expect(workerRuntime.sendTerminalAgentPrompt).toHaveBeenCalledOnce()
   })
 
   it('does not report remotely rejected preferences as effective', async () => {

--- a/src/main/runtime/rpc/methods/orchestration-federation.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- Why: these federation RPC tests share one paired-runtime harness so attachment authority and remote resource ownership cannot drift between fixtures. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { RuntimeRpcResponse } from '../../../../shared/runtime-rpc-envelope'
 import {
@@ -209,6 +210,32 @@ describe('orchestration federation', () => {
       'term_windows_worker',
       expect.stringContaining(`Your task ID is: ${task.id}`)
     )
+  })
+
+  it('refreshes a reused remote pane foreground owner before dispatch input', async () => {
+    vi.spyOn(workerRuntime, 'showManagedTerminalWorkspace').mockResolvedValue({
+      id: 'repo::windows-worktree',
+      repoId: 'repo'
+    } as never)
+    vi.spyOn(workerRuntime, 'isTerminalRunningAgent').mockResolvedValue(false)
+    const settled = vi
+      .spyOn(workerRuntime, 'refreshTerminalPromptAgentOwner')
+      .mockResolvedValue('codex')
+    const task = createHomeTask()
+
+    const started = await homeDispatcher.dispatch(
+      startRequest(task.id, {
+        worktree: 'id:repo::windows-worktree',
+        terminal: 'term_windows_worker',
+        repo: undefined,
+        name: undefined,
+        agent: undefined
+      })
+    )
+
+    expect(started).toMatchObject({ ok: true, result: { state: 'ready' } })
+    expect(settled).toHaveBeenCalledWith('term_windows_worker')
+    expect(workerRuntime.sendTerminalAgentPrompt).toHaveBeenCalledOnce()
   })
 
   it('does not report remotely rejected preferences as effective', async () => {

--- a/src/main/runtime/rpc/methods/orchestration-federation.ts
+++ b/src/main/runtime/rpc/methods/orchestration-federation.ts
@@ -148,7 +148,7 @@ export const ORCHESTRATION_FEDERATION_ATTACH_METHODS: RpcMethod[] = [
                 `Terminal ${terminalHandle} does not belong to worktree ${worktree.id}.`
               )
             }
-            if (!(await runtime.isTerminalRunningAgent(terminalHandle))) {
+            if (!(await runtime.refreshTerminalPromptAgentOwner(terminalHandle))) {
               throw new OrchestrationError(
                 'agent_unconfigured',
                 `Terminal ${terminalHandle} is not running a recognized agent.`

--- a/src/main/runtime/rpc/methods/orchestration-worker-release.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-release.test.ts
@@ -83,6 +83,7 @@ describe('orchestration worker release', () => {
       bytesWritten: 1
     })
     vi.spyOn(runtime, 'isTerminalRunningAgent').mockResolvedValue(true)
+    vi.spyOn(runtime, 'refreshTerminalPromptAgentOwner').mockResolvedValue('codex')
     vi.spyOn(runtime, 'getExactWorkerProviderSession').mockReturnValue(null)
     vi.spyOn(runtime, 'readTerminal').mockResolvedValue({
       handle: 'term_worker',

--- a/src/main/runtime/rpc/methods/orchestration-worker-start-outcome-classification.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-start-outcome-classification.test.ts
@@ -21,12 +21,10 @@ describe('worker start outcome classification', () => {
     expect(isUnknownWorkerStartOutcome(new Error('worktree exists'), 'worktree_create')).toBe(false)
   })
 
-  // Why: a stalled prompt still reports a definite failure to the caller — the correction path is
-  // the worker's own report, which keeps its capability and can re-settle the dispatch (see
-  // worker-start-unobserved-prompt-settlement.test.ts), not an outcome_unknown receipt.
-  it('does not class a stalled dispatch prompt as unknown', () => {
+  // Enter was already written, so a missing turn-start observation cannot prove failure.
+  it('classes a stalled dispatch prompt as unknown', () => {
     expect(isUnknownWorkerStartOutcome(new Error('agent_prompt_stalled'), 'dispatch_input')).toBe(
-      false
+      true
     )
   })
 })

--- a/src/main/runtime/rpc/methods/orchestration-worker-start-prompt-contract.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-start-prompt-contract.test.ts
@@ -237,7 +237,7 @@ describe('orchestration worker-start prompt contract', () => {
     expect(response).toMatchObject({
       ok: true,
       result: {
-        state: 'failed',
+        state: 'outcome_unknown',
         failedStage: 'dispatch_input',
         lastError: 'agent_prompt_stalled',
         mutation: { requestId: harness.requestId, replayed: false }
@@ -253,16 +253,15 @@ describe('orchestration worker-start prompt contract', () => {
     expect(harness.prematureSubmits()).toBe(0)
     expect(harness.writes.filter((data) => data === '\r')).toHaveLength(1)
     const persisted = reopenPromptContractDb(harness)
-    expect(persisted.getTask(harness.taskId)?.status).toBe('failed')
-    // Why (#16095): the receipt still reports the failure, but Enter was written before it was
-    // verified — so the capability survives and the worker's own report can correct the record.
+    expect(persisted.getTask(harness.taskId)?.status).toBe('blocked')
+    // Enter was written before verification, so the pane and capability stay fenced until the
+    // worker reports or the coordinator explicitly stops/abandons the ambiguous Dispatch.
     expect(persisted.getDispatchContextById(dispatchId)).toMatchObject({
-      status: 'failed',
-      last_failure: 'agent_prompt_stalled',
+      status: 'pending',
       capability_revoked_at: null
     })
     expect(persisted.getWorkerDispatch(dispatchId)).toMatchObject({
-      state: 'failed',
+      state: 'start_unknown',
       stage: 'dispatch_input',
       last_error: 'agent_prompt_stalled'
     })
@@ -271,7 +270,7 @@ describe('orchestration worker-start prompt contract', () => {
     expect(receipt).toMatchObject({ state: 'completed' })
     expect(JSON.parse(receipt?.receipt ?? 'null')).toMatchObject({
       dispatchId,
-      state: 'failed',
+      state: 'outcome_unknown',
       failedStage: 'dispatch_input',
       lastError: 'agent_prompt_stalled'
     })

--- a/src/main/runtime/rpc/methods/orchestration-worker-start-receipt.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-start-receipt.ts
@@ -17,9 +17,14 @@ export function failWorkerStartWithReceipt(args: {
   launch: OrchestrationWorkerLaunchReceipt
 }): unknown {
   const reason = args.error instanceof Error ? args.error.message : String(args.error)
+  // Enter is written before verification, so an unobserved turn is ambiguous and must keep the
+  // pane fenced until its worker reports or the coordinator explicitly stops/abandons it.
+  const unobservedPrompt = isAgentPromptStalledError(args.error)
   const unknown = isUnknownWorkerStartOutcome(args.error, args.failedStage)
   const worker = unknown
-    ? args.db.markWorkerStartUnknown(args.dispatchId, args.failedStage, reason)
+    ? args.db.markWorkerStartUnknown(args.dispatchId, args.failedStage, reason, {
+        retainCapability: unobservedPrompt
+      })
     : args.db.failWorkerStart(args.dispatchId, args.failedStage, reason, {
         // Why (#16095): the preamble is written before submission is verified, so a stalled
         // verdict never means the worker lacks its task — keep the authority its report needs.

--- a/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
@@ -2,6 +2,7 @@ import type { AgentLaunchPreferences } from '../../../../shared/agent-session-ho
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import type { OrcaRuntimeService } from '../../orca-runtime'
 import type { OrchestrationDb } from '../../orchestration/db'
+import { isAgentPromptStalledError } from '../../agent-prompt-submission-verification'
 
 export type WorkerEffect = {
   kind: 'worktree' | 'terminal' | 'setup' | 'dispatch_input'
@@ -272,6 +273,9 @@ export function isUnknownWorkerStartOutcome(error: unknown, stage: string): bool
       ? (error as { code: string }).code
       : ''
   if (code === 'operation_unknown') {
+    return true
+  }
+  if (stage === 'dispatch_input' && isAgentPromptStalledError(error)) {
     return true
   }
   if (stage !== 'worktree_create') {

--- a/src/main/runtime/rpc/methods/orchestration-workers-recovery.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers-recovery.test.ts
@@ -43,7 +43,10 @@ describe('orchestration worker recovery', () => {
     } as never)
   })
 
-  afterEach(() => db.close())
+  afterEach(() => {
+    vi.useRealTimers()
+    db.close()
+  })
 
   async function call(name: string, params: Record<string, unknown>) {
     const method = ORCHESTRATION_METHODS.find((candidate) => candidate.name === name)
@@ -114,6 +117,53 @@ describe('orchestration worker recovery', () => {
     })
     expect(runtime.closeTerminal).toHaveBeenCalledWith('term_worker')
     expect(db.getTask(task.id)?.status).toBe('blocked')
+  })
+
+  it('settles a stop_unknown after operator-close proof arrives more than a second later', async () => {
+    vi.useFakeTimers()
+    const { task, dispatch } = createWorker()
+    vi.mocked(runtime.closeTerminal).mockImplementationOnce(async () => {
+      setTimeout(() => {
+        ;(
+          runtime as unknown as {
+            failActiveDispatchOnExit: (
+              handle: string,
+              paneKey: string,
+              exitCode: number,
+              cause: { kind: 'operator_close' }
+            ) => void
+          }
+        ).failActiveDispatchOnExit(
+          'term_worker',
+          'tab_worker:bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+          0,
+          { kind: 'operator_close' }
+        )
+      }, 1_100)
+      return { handle: 'term_worker', tabId: 'tab-worker', ptyKilled: false } as never
+    })
+
+    await expect(
+      call('orchestration.workerStop', { dispatch: dispatch.id })
+    ).resolves.toMatchObject({ state: 'stop_unknown', processAction: 'closed_agent_terminal' })
+    expect(db.getWorkerDispatch(dispatch.id)?.state).toBe('stop_unknown')
+
+    await vi.advanceTimersByTimeAsync(1_099)
+    expect(db.getWorkerDispatch(dispatch.id)?.state).toBe('stop_unknown')
+    await vi.advanceTimersByTimeAsync(1)
+
+    expect(db.getWorkerDispatch(dispatch.id)).toMatchObject({
+      state: 'stopped',
+      stage: 'process_stopped',
+      last_error: null
+    })
+    expect(db.getTask(task.id)?.status).toBe('blocked')
+    expect(db.getDispatchContextById(dispatch.id)).toMatchObject({
+      status: 'failed',
+      failure_count: 0,
+      last_failure: 'stopped',
+      termination_reason: 'operator_close'
+    })
   })
 
   it('keeps an in-flight stop fenced during runtime-epoch reconciliation', async () => {

--- a/src/main/runtime/rpc/methods/orchestration-workers.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers.ts
@@ -94,7 +94,7 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
             `Terminal ${params.terminal} does not belong to worktree ${resolvedWorktree?.id}.`
           )
         }
-        if (!(await runtime.isTerminalRunningAgent(params.terminal))) {
+        if (!(await runtime.refreshTerminalPromptAgentOwner(params.terminal))) {
           throw new OrchestrationError(
             'agent_unconfigured',
             `Terminal ${params.terminal} is not running a recognized agent.`


### PR DESCRIPTION
## ELI5

When Orca presses Enter in an agent pane, it cannot always know immediately whether the
agent received the task. Previously, Orca could call that uncertainty a failure, revoke
the worker's reporting permission, and allow another worker to overlap work that was
already running. This change keeps the exact worker fenced until Orca receives real proof
that it started, stopped, or completed.

## What Changed

- Require causal prompt receipts instead of treating arbitrary ongoing terminal output as
  proof that a newly submitted prompt started a turn.
- Record post-Enter `agent_prompt_stalled` as `start_unknown` / `outcome_unknown`, retain
  the exact Dispatch capability, and reject overlapping starts on the same local or
  federated worker.
- Allow an authenticated late `worker_done` to settle the exact fenced Dispatch, including
  a lost federated attach-response race.
- Preserve and relay ambiguous federated start authority instead of converting it to a
  definite failure and clearing the capability.
- Settle delayed operator-close proof as `stopped / process_stopped / operator_close`
  without incrementing `failure_count`.
- Refresh reused-pane foreground ownership before selecting agent-specific submission
  behavior. SSH/daemon wrapper processes use the existing bounded enrichment retry, while
  unavailable or unresolved ownership remains fail-closed.
- Add local, federated, reused-pane, wrapper-resolution, overlap, late-report, and delayed
  stop regression coverage.

## Why

Writing Enter is an effect, not proof of the outcome. Treating an ambiguous result as a
safe failure can create duplicate work and reject the original worker's authoritative
completion report. Keeping the exact attempt fenced preserves at-most-one active
assignment while still allowing first-hand late evidence to settle it.

## Linked Issue

Fixes #16377
Fixes #16660

Related: #15180, #15958

## Visual Proof

N/A — this changes orchestration lifecycle and terminal receipt behavior, not UI layout.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Local validation on macOS arm64:

- Critical local/federated matrix: 174 tests passed.
- Broader orchestration DB suite: 544 passed, 4 skipped.
- Orchestration RPC suite: 411 passed.
- Final repository suite: 6,701 files passed, 43 skipped; 62,543 tests passed,
  252 skipped.
- Node, CLI, and web TypeScript projects passed.
- Changed-code quality, oxlint, React Doctor, oxfmt, max-lines, and diff checks passed.
- Independent adversarial review found no Critical or Important issues after the final
  wrapper-resolution follow-up.

A version-pinned 1.4.188 backport of the same lifecycle behavior was also packaged and
exercised against a disposable macOS profile: ambiguous Kilo submission remained fenced,
overlap was rejected, operator stop settled with `failure_count: 0`, and the exact terminal
exited. The current-main branch itself was not packaged for release.

Cross-platform considerations: the production path uses platform-neutral terminal
controller APIs. Delayed wrapper recognition reuses the existing bounded daemon/SSH
cmdline-enrichment policy. Missing controllers, failed reads, unresolved wrappers, remote
no-proof liveness, and federated disconnects remain fail-closed.

## AI Disclosure

OpenAI Codex was used for implementation, adversarial review, and test assistance.

## Review

Please focus on the boundary between ambiguous start authority and definite failure,
especially federated capability retention, late-report authentication, and reused-pane
foreground-owner refresh.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- No schema migration is introduced.
- No agent process is replaced or restarted by the new reconciliation path.
- The retry is limited to known wrapper/interpreter processes and uses the existing bounded
  6.5-second / 150-millisecond enrichment loop.
- No-proof stop and remote/federated failure paths remain fail-closed.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

`pnpm test`, the Node/CLI/web typechecks, and changed-code quality passed locally. CI will
run the remaining full lint/build matrix.
