### PR TITLE
Make post-paste submit delay per-agent, bump codex to 300ms

### DIFF
--- a/src/renderer/src/hooks/useAutomationDispatchEvents.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.ts
@@ -527,7 +527,8 @@ export function useAutomationDispatchEvents(): void {
                   const submitted = await submitPromptToAgentPty({
                     tabId: reusableSession.tabId,
                     ptyId: reusableSession.ptyId,
-                    content: automation.prompt
+                    content: automation.prompt,
+                    agent: automation.agentId
                   })
                   if (!submitted) {
                     cleanupRunObservers()

--- a/src/renderer/src/lib/active-agent-note-send-focused-session.test.ts
+++ b/src/renderer/src/lib/active-agent-note-send-focused-session.test.ts
@@ -131,6 +131,68 @@ describe('active agent note send', () => {
     )
   })
 
+  it.each([
+    ['codex' as const, 300],
+    [undefined, 50]
+  ])('waits the %s post-paste submit delay before Enter', async (launchAgent, expectedDelayMs) => {
+    testState.appState.tabsByWorktree = { 'wt-1': [{ id: 'tab-1', launchAgent }] }
+    testState.callRuntimeRpc.mockImplementation(async (_target, method, params) => {
+      if (method === 'terminal.list') {
+        return {
+          terminals: [
+            {
+              handle: 'term-1',
+              worktreeId: 'wt-1',
+              worktreePath: '/repo',
+              branch: 'main',
+              tabId: 'tab-1',
+              leafId: LEAF_ID,
+              title: 'Codex',
+              connected: true,
+              writable: true,
+              lastOutputAt: 1,
+              preview: ''
+            }
+          ],
+          totalCount: 1,
+          truncated: false
+        }
+      }
+      if (method === 'terminal.agentStatus') {
+        return { agentStatus: { handle: 'term-1', isRunningAgent: true, status: 'idle' } }
+      }
+      if (method === 'terminal.wait') {
+        return {
+          wait: {
+            handle: 'term-1',
+            condition: 'tui-idle',
+            satisfied: true,
+            status: 'running',
+            exitCode: null
+          }
+        }
+      }
+      if (method === 'terminal.send') {
+        return {
+          send: {
+            handle: 'term-1',
+            accepted: true,
+            bytesWritten: typeof params.text === 'string' ? params.text.length : 1
+          }
+        }
+      }
+      throw new Error(`unexpected method ${method}`)
+    })
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
+
+    await expect(
+      sendNotesToActiveAgentSession({ worktreeId: 'wt-1', prompt: 'File: src/app.ts' })
+    ).resolves.toEqual({ status: 'sent' })
+
+    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), expectedDelayMs)
+    setTimeoutSpy.mockRestore()
+  })
+
   it('maps active-focused guarded paste permission refusal to permission', async () => {
     testState.callRuntimeRpc.mockImplementation(async (_target, method, params) => {
       if (method === 'terminal.list') {

--- a/src/renderer/src/lib/active-agent-note-send.ts
+++ b/src/renderer/src/lib/active-agent-note-send.ts
@@ -1,4 +1,5 @@
 import type { RuntimeTerminalSend, RuntimeTerminalWait } from '../../../shared/runtime-types'
+import type { TuiAgent } from '../../../shared/tui-agent'
 import { sanitizeTerminalPasteText } from '@/components/terminal-pane/terminal-bracketed-paste'
 import { useAppStore } from '@/store'
 import { callRuntimeRpc, getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
@@ -11,7 +12,7 @@ import {
 import {
   BRACKETED_PASTE_BEGIN,
   BRACKETED_PASTE_END,
-  POST_PASTE_SUBMIT_DELAY_MS
+  resolvePostPasteSubmitDelayMs
 } from './agent-paste-draft'
 import type { ActiveAgentNotesSendResult } from './active-agent-note-send-result'
 import {
@@ -78,8 +79,17 @@ export async function sendNotesToActiveAgentSession({
     return { status: 'no-active-terminal' }
   }
 
+  const agent = state.tabsByWorktree[worktreeId]?.find(
+    (tab) => tab.id === noteTarget.tabId
+  )?.launchAgent
+
   if (explicitNoteTarget) {
-    return await sendPromptToExplicitAgentTarget(runtimeTarget, terminal.handle, trimmedPrompt)
+    return await sendPromptToExplicitAgentTarget(
+      runtimeTarget,
+      terminal.handle,
+      trimmedPrompt,
+      agent
+    )
   }
 
   const effectiveTimeoutMs = timeoutMs ?? ACTIVE_AGENT_SEND_TIMEOUT_MS
@@ -125,7 +135,8 @@ export async function sendNotesToActiveAgentSession({
 
   if (finalAgentStatus.supportsGuardedSend) {
     return await sendPromptWithGuardedPasteAndEnter(runtimeTarget, terminal.handle, trimmedPrompt, {
-      allowLegacyFallback: false
+      allowLegacyFallback: false,
+      agent
     })
   }
 
@@ -168,7 +179,7 @@ async function sendPromptWithGuardedPasteAndEnter(
   runtimeTarget: ReturnType<typeof getActiveRuntimeTarget>,
   terminalHandle: string,
   prompt: string,
-  options: { allowLegacyFallback: boolean }
+  options: { allowLegacyFallback: boolean; agent?: TuiAgent }
 ): Promise<ActiveAgentNotesSendResult> {
   const initialAgentStatus = await getTerminalAgentSendReadiness(runtimeTarget, terminalHandle, {
     allowLegacyFallback: options.allowLegacyFallback
@@ -214,7 +225,9 @@ async function sendPromptWithGuardedPasteAndEnter(
     throw error
   }
 
-  await new Promise<void>((resolve) => setTimeout(resolve, POST_PASTE_SUBMIT_DELAY_MS))
+  await new Promise<void>((resolve) =>
+    setTimeout(resolve, resolvePostPasteSubmitDelayMs(options.agent))
+  )
 
   try {
     const submitAgentStatus = await getTerminalAgentSendReadiness(runtimeTarget, terminalHandle, {
@@ -257,9 +270,11 @@ async function sendPromptWithGuardedPasteAndEnter(
 async function sendPromptToExplicitAgentTarget(
   runtimeTarget: ReturnType<typeof getActiveRuntimeTarget>,
   terminalHandle: string,
-  prompt: string
+  prompt: string,
+  agent?: TuiAgent
 ): Promise<ActiveAgentNotesSendResult> {
   return await sendPromptWithGuardedPasteAndEnter(runtimeTarget, terminalHandle, prompt, {
-    allowLegacyFallback: false
+    allowLegacyFallback: false,
+    agent
   })
 }

--- a/src/renderer/src/lib/agent-paste-draft-submit-delay.test.ts
+++ b/src/renderer/src/lib/agent-paste-draft-submit-delay.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  POST_PASTE_SUBMIT_DELAY_MS,
+  resolvePostPasteSubmitDelayMs,
+  sendBracketedPasteToRunningAgent
+} from './agent-paste-draft'
+import { TUI_AGENT_CONFIG } from '../../../shared/tui-agent-config'
+
+const testState = vi.hoisted(() => ({
+  sendRuntimePtyInputVerified: vi.fn()
+}))
+const CODEX_SUBMIT_RETRY_DELAY_MS = TUI_AGENT_CONFIG.codex.submitRetryDelayMs ?? 0
+
+vi.mock('@/store', () => ({
+  useAppStore: { getState: () => ({ settings: {} }), subscribe: () => () => {} }
+}))
+
+vi.mock('@/runtime/runtime-terminal-inspection', () => ({
+  isRemoteRuntimePtyId: vi.fn(() => false),
+  sendRuntimePtyInputVerified: testState.sendRuntimePtyInputVerified,
+  inspectRuntimeTerminalProcess: vi.fn()
+}))
+
+describe('post-paste submit delay', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.stubGlobal('window', {
+      setTimeout: globalThis.setTimeout,
+      clearTimeout: globalThis.clearTimeout
+    })
+    testState.sendRuntimePtyInputVerified.mockReset()
+    testState.sendRuntimePtyInputVerified.mockResolvedValue(true)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('resolves per agent, falling back to the shared default', () => {
+    expect(resolvePostPasteSubmitDelayMs('codex')).toBe(300)
+    expect(resolvePostPasteSubmitDelayMs('claude')).toBe(POST_PASTE_SUBMIT_DELAY_MS)
+    expect(resolvePostPasteSubmitDelayMs()).toBe(POST_PASTE_SUBMIT_DELAY_MS)
+  })
+
+  it.each([
+    ['codex' as const, 300],
+    [undefined, POST_PASTE_SUBMIT_DELAY_MS]
+  ])('holds Enter for the %s delay after the paste', async (agent, delayMs) => {
+    const promise = sendBracketedPasteToRunningAgent({ ptyId: 'pty-1', content: 'hi', agent })
+    await vi.advanceTimersByTimeAsync(delayMs - 1)
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(1)
+    if (agent === 'codex') {
+      await vi.advanceTimersByTimeAsync(CODEX_SUBMIT_RETRY_DELAY_MS)
+    }
+    await expect(promise).resolves.toBe(true)
+    expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(2, {}, 'pty-1', '\r')
+  })
+})

--- a/src/renderer/src/lib/agent-paste-draft.test.ts
+++ b/src/renderer/src/lib/agent-paste-draft.test.ts
@@ -9,6 +9,7 @@ import {
   pasteDraftToAgentPtyWhenReady,
   pasteDraftWhenAgentReady,
   POST_PASTE_SUBMIT_DELAY_MS,
+  resolvePostPasteSubmitDelayMs,
   sendAgentDraftPasteContent,
   sendBracketedPasteToRunningAgent,
   submitPromptToAgentPty
@@ -171,7 +172,9 @@ describe('pasteDraftWhenAgentReady', () => {
       'pty-1',
       PASTED_ISSUE_URL
     )
-    await vi.advanceTimersByTimeAsync(POST_PASTE_SUBMIT_DELAY_MS + CODEX_SUBMIT_RETRY_DELAY_MS)
+    await vi.advanceTimersByTimeAsync(
+      resolvePostPasteSubmitDelayMs('codex') + CODEX_SUBMIT_RETRY_DELAY_MS
+    )
     await expect(promise).resolves.toBe(true)
     expect(testState.sendRuntimePtyInputVerified).toHaveBeenNthCalledWith(2, {}, 'pty-1', '\r')
     expect(testState.unsubscribe).toHaveBeenCalledTimes(1)

--- a/src/renderer/src/lib/agent-paste-draft.ts
+++ b/src/renderer/src/lib/agent-paste-draft.ts
@@ -35,6 +35,14 @@ export const BRACKETED_PASTE_BEGIN = BRACKETED_PASTE_START
 export { BRACKETED_PASTE_END }
 export const POST_PASTE_SUBMIT_DELAY_MS = 50
 
+/** Per-agent override for the post-paste Enter delay; unknown agents keep the default. */
+export function resolvePostPasteSubmitDelayMs(agent?: TuiAgent): number {
+  return (
+    (agent ? TUI_AGENT_CONFIG[agent]?.postPasteSubmitDelayMs : undefined) ??
+    POST_PASTE_SUBMIT_DELAY_MS
+  )
+}
+
 // Why: "the tab has a PTY" and "the agent's composer accepts input" are separate
 // states with separate failure modes, so they get separate budgets. A PTY that
 // hasn't appeared in 8s means the launch itself failed — waiting the (longer)
@@ -178,20 +186,28 @@ export async function submitPromptToAgentPty(args: {
   tabId: string
   ptyId: string
   content: string
+  agent?: TuiAgent
 }): Promise<boolean> {
   return await sendBracketedPasteToAgent({
     settings: getSettingsForAgentTabRuntimeOwner(args.tabId),
     ptyId: args.ptyId,
     content: args.content,
-    submit: true
+    submit: true,
+    agent: args.agent
   })
 }
 
 export async function sendBracketedPasteToRunningAgent(args: {
   ptyId: string
   content: string
+  agent?: TuiAgent
 }): Promise<boolean> {
-  return await sendBracketedPasteToAgent({ ptyId: args.ptyId, content: args.content, submit: true })
+  return await sendBracketedPasteToAgent({
+    ptyId: args.ptyId,
+    content: args.content,
+    submit: true,
+    agent: args.agent
+  })
 }
 
 async function sendBracketedPasteToAgent(args: {
@@ -215,7 +231,9 @@ async function sendBracketedPasteToAgent(args: {
       // Why: Claude Code can leave a prompt as editable text when paste-end and
       // Enter arrive in the same PTY write. Split the submit into the next turn so
       // the TUI processes bracketed-paste termination before handling Enter.
-      await new Promise<void>((resolve) => window.setTimeout(resolve, POST_PASTE_SUBMIT_DELAY_MS))
+      await new Promise<void>((resolve) =>
+        window.setTimeout(resolve, resolvePostPasteSubmitDelayMs(agent))
+      )
       const submitted = await sendRuntimePtyInputVerified(settings, ptyId, '\r')
 
       if (submitRetryDelayMs !== undefined) {

--- a/src/shared/tui-agent-config.ts
+++ b/src/shared/tui-agent-config.ts
@@ -44,6 +44,8 @@ export type TuiAgentConfig = {
   draftPasteReadyTimeoutMs?: number
   /** Delay before one extra blind submit Enter, for agents that render their composer before Enter is live (codex); a no-op if the first Enter landed. */
   submitRetryDelayMs?: number
+  /** Wait before the post-paste Enter for agents that swallow it right after the composer first renders (codex). */
+  postPasteSubmitDelayMs?: number
   /** Windows Shift+Enter encoding override; omitted agents keep the legacy Esc+CR path. */
   windowsShiftEnterEncoding?: 'csi-u'
   /** Paste newlines for TUIs that read Windows console input records instead of VT paste frames. */
@@ -93,7 +95,8 @@ export const TUI_AGENT_CONFIG: Record<TuiAgent, TuiAgentConfig> = {
     preflightTrust: 'codex',
     draftPasteReadySignal: 'codex-composer-prompt',
     draftPasteReadyTimeoutMs: 20_000,
-    submitRetryDelayMs: 1200
+    submitRetryDelayMs: 1200,
+    postPasteSubmitDelayMs: 300
   },
   autohand: {
     detectCmd: 'autohand',


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 3 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​127 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​126 |
| Prod | 4 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​49 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​12 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​37 |

<!-- /orca-pr-loc -->

## Problem

Codex's composer swallows Enter for ~150ms after it first renders, but we were using a global 50ms delay before submitting. This causes the Enter to be silently dropped on codex, leaving the pasted prompt unanswered.

## Solution

Move the post-paste submit delay from a global constant into the per-agent config. Codex now gets 300ms (enough to clear its composition window), while other agents keep the default 50ms. The delay is resolved at send time based on the agent ID.

## What Changed

- Added `resolvePostPasteSubmitDelayMs(agent?)` to compute delay per agent, falling back to the default 50ms
- Added `postPasteSubmitDelayMs?: number` field to `TuiAgentConfig` and set it to 300ms for codex
- Threaded the agent ID through `submitPromptToAgentPty`, `sendNotesToActiveAgentSession`, and `sendBracketedPasteToRunningAgent` so the delay resolver has context
- Updated `useAutomationDispatchEvents` to pass `automation.agentId` when submitting prompts

## Why

Codex has a different composer lifecycle than other agents, requiring a longer delay to avoid dropping input. Per-agent configuration lets each agent specify its own needs without a global workaround.

## Linked Issue

Fixes STA-5379

## Visual Proof

N/A — no UI or interaction changes; this is a timing adjustment for input handling.

## Testing

- Added dedicated test file `agent-paste-draft-submit-delay.test.ts` with delay resolution and timing tests
- Updated existing test in `active-agent-note-send-focused-session.test.ts` to verify codex gets 300ms and undefined gets 50ms
- Existing agent paste draft tests updated to use `resolvePostPasteSubmitDelayMs('codex')` in timer assertions

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

## AI Disclosure

N/A (internal contributor)

## Review

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)