### PR TITLE
fix(settings): survive a non-string repoId on hydrated setup rows

### DIFF
--- a/src/renderer/src/store/project-host-setup-selector-normalization.ts
+++ b/src/renderer/src/store/project-host-setup-selector-normalization.ts
@@ -20,7 +20,7 @@ export function normalizeHydratedProjectHostSetupProjection(
   const projectIdByHydratedProjectId = new Map<string, string>()
   let changed = false
   const normalizedSetups = setups.map((setup) => {
-    // Why: hydrated rows can carry a non-string repoId, yet consumers call `.trim()` on it.
+    // Why: hydrated and remote catalog rows can carry a non-string repoId, yet consumers call `.trim()` on it.
     // Why no `changed = true`: that flag unions in repo-derived rows, and coercing one
     // field must never change which rows exist.
     const repoId = typeof setup.repoId === 'string' ? setup.repoId : ''

--- a/src/renderer/src/store/project-host-setup-selector-normalization.ts
+++ b/src/renderer/src/store/project-host-setup-selector-normalization.ts
@@ -20,15 +20,13 @@ export function normalizeHydratedProjectHostSetupProjection(
   const projectIdByHydratedProjectId = new Map<string, string>()
   let changed = false
   const normalizedSetups = setups.map((setup) => {
-    // Why: hydrated and remote catalog rows can carry a non-string repoId, but every
-    // consumer treats it as a string (`setup.repoId.trim()`). Coerce once here so a
-    // legacy row cannot crash Settings on open.
-    // Why not `changed = true` here: that flag routes callers onto the merged
-    // projection, which unions in repo-derived rows. A coerced repoId must not
-    // change which rows exist — only the value of this one field.
+    // Why: hydrated rows can carry a non-string repoId, yet consumers call `.trim()` on it.
+    // Why no `changed = true`: that flag unions in repo-derived rows, and coercing one
+    // field must never change which rows exist.
     const repoId = typeof setup.repoId === 'string' ? setup.repoId : ''
     const normalizedSetup = repoId === setup.repoId ? setup : { ...setup, repoId }
-    const repo = repoById.get(repoId) ?? repoById.get(setup.id)
+    // Why the guard: an empty repoId means "no repo attached", so it must match nothing.
+    const repo = (repoId ? repoById.get(repoId) : undefined) ?? repoById.get(setup.id)
     if (!repo) {
       return normalizedSetup
     }

--- a/src/renderer/src/store/project-host-setup-selector-normalization.ts
+++ b/src/renderer/src/store/project-host-setup-selector-normalization.ts
@@ -23,12 +23,11 @@ export function normalizeHydratedProjectHostSetupProjection(
     // Why: hydrated and remote catalog rows can carry a non-string repoId, but every
     // consumer treats it as a string (`setup.repoId.trim()`). Coerce once here so a
     // legacy row cannot crash Settings on open.
+    // Why not `changed = true` here: that flag routes callers onto the merged
+    // projection, which unions in repo-derived rows. A coerced repoId must not
+    // change which rows exist — only the value of this one field.
     const repoId = typeof setup.repoId === 'string' ? setup.repoId : ''
-    const repoIdNormalized = repoId !== setup.repoId
-    if (repoIdNormalized) {
-      changed = true
-    }
-    const normalizedSetup = repoIdNormalized ? { ...setup, repoId } : setup
+    const normalizedSetup = repoId === setup.repoId ? setup : { ...setup, repoId }
     const repo = repoById.get(repoId) ?? repoById.get(setup.id)
     if (!repo) {
       return normalizedSetup

--- a/src/renderer/src/store/project-host-setup-selector-normalization.ts
+++ b/src/renderer/src/store/project-host-setup-selector-normalization.ts
@@ -20,17 +20,26 @@ export function normalizeHydratedProjectHostSetupProjection(
   const projectIdByHydratedProjectId = new Map<string, string>()
   let changed = false
   const normalizedSetups = setups.map((setup) => {
-    const repo = repoById.get(setup.repoId) ?? repoById.get(setup.id)
+    // Why: hydrated and remote catalog rows can carry a non-string repoId, but every
+    // consumer treats it as a string (`setup.repoId.trim()`). Coerce once here so a
+    // legacy row cannot crash Settings on open.
+    const repoId = typeof setup.repoId === 'string' ? setup.repoId : ''
+    const repoIdNormalized = repoId !== setup.repoId
+    if (repoIdNormalized) {
+      changed = true
+    }
+    const normalizedSetup = repoIdNormalized ? { ...setup, repoId } : setup
+    const repo = repoById.get(repoId) ?? repoById.get(setup.id)
     if (!repo) {
-      return setup
+      return normalizedSetup
     }
     const projectId = getProjectIdentityKey(repo)
     if (projectId === setup.projectId || projectId === `repo:${repo.id}`) {
-      return setup
+      return normalizedSetup
     }
     changed = true
     projectIdByHydratedProjectId.set(setup.projectId, projectId)
-    return { ...setup, projectId }
+    return { ...normalizedSetup, projectId }
   })
   const normalizedProjects = projects.flatMap((project) => {
     const projectId = projectIdByHydratedProjectId.get(project.id)

--- a/src/renderer/src/store/project-host-setup-selector.null-repo-id.test.ts
+++ b/src/renderer/src/store/project-host-setup-selector.null-repo-id.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import type { Project, ProjectHostSetup } from '../../../shared/project-types'
+import type { Repo } from '../../../shared/repo-types'
+import { getProjectHostSetupProjectionFromState } from './project-host-setup-selector'
+
+// Crash 3bcc5be3 (v1.4.188, page.settings boundary): a hydrated setup row whose
+// repoId arrived as null reached Settings' projectByRepoId useMemo and threw
+// "Cannot read properties of null (reading 'trim')" while opening Settings.
+const repos = [
+  {
+    id: 'repo-1',
+    path: '/Users/alice/orca',
+    displayName: 'orca',
+    kind: 'git'
+  } as unknown as Repo
+]
+
+const projects: Project[] = [
+  {
+    id: 'project-1',
+    displayName: 'Project',
+    badgeColor: '#737373',
+    sourceRepoIds: ['repo-1'],
+    createdAt: 1,
+    updatedAt: 1
+  } as unknown as Project
+]
+
+function makeSetups(repoId: unknown): ProjectHostSetup[] {
+  return [
+    {
+      id: 'setup-1',
+      projectId: 'project-1',
+      hostId: 'local',
+      repoId,
+      path: '/Users/alice/orca',
+      displayName: 'orca',
+      setupState: 'ready',
+      setupMethod: 'legacy-repo',
+      createdAt: 1,
+      updatedAt: 1
+    } as unknown as ProjectHostSetup
+  ]
+}
+
+function projectionFor(repoId: unknown) {
+  return getProjectHostSetupProjectionFromState({
+    repos,
+    projects,
+    projectHostSetups: makeSetups(repoId)
+  })
+}
+
+// Mirrors the Settings.tsx projectByRepoId useMemo that crashed.
+function buildProjectByRepoIdLikeSettings(
+  setups: readonly ProjectHostSetup[],
+  projectList: readonly Project[]
+): Map<string, Project> {
+  const projectById = new Map(projectList.map((project) => [project.id, project]))
+  const nextProjectByRepoId = new Map<string, Project>()
+  for (const setup of setups) {
+    const project = projectById.get(setup.projectId)
+    if (project && setup.repoId.trim()) {
+      nextProjectByRepoId.set(setup.repoId, project)
+    }
+  }
+  return nextProjectByRepoId
+}
+
+describe('project host setup projection with a non-string repoId', () => {
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['a number', 42]
+  ])('coerces a %s repoId to an empty string', (_label, repoId) => {
+    const hydrated = projectionFor(repoId).setups.find((setup) => setup.id === 'setup-1')
+    expect(hydrated).toBeDefined()
+    expect(hydrated?.repoId).toBe('')
+  })
+
+  it('lets the Settings projectByRepoId memo run instead of throwing on .trim()', () => {
+    const projection = projectionFor(null)
+    expect(() =>
+      buildProjectByRepoIdLikeSettings(projection.setups, projection.projects)
+    ).not.toThrow()
+    // Why: an empty repoId is not an openable repo row, so it must not be indexed.
+    expect(buildProjectByRepoIdLikeSettings(projection.setups, projection.projects).has('')).toBe(
+      false
+    )
+  })
+
+  it('leaves a real repoId untouched and still indexes it', () => {
+    const projection = projectionFor('repo-1')
+    const hydrated = projection.setups.find((setup) => setup.id === 'setup-1')
+    expect(hydrated?.repoId).toBe('repo-1')
+    expect([
+      ...buildProjectByRepoIdLikeSettings(projection.setups, projection.projects).keys()
+    ]).toEqual(['repo-1'])
+  })
+
+  it('keeps the projection reference-stable for a repeated input', () => {
+    const setups = makeSetups(null)
+    const args = { repos, projects, projectHostSetups: setups }
+    expect(getProjectHostSetupProjectionFromState(args)).toBe(
+      getProjectHostSetupProjectionFromState(args)
+    )
+  })
+})

--- a/src/renderer/src/store/project-host-setup-selector.null-repo-id.test.ts
+++ b/src/renderer/src/store/project-host-setup-selector.null-repo-id.test.ts
@@ -175,13 +175,30 @@ describe('project host setup projection with a non-string repoId', () => {
     })
 
     it('keeps projects in input order with their identities intact', () => {
+      // Why two: a single-project fixture cannot detect reordering.
+      const twoProjects = [projects[0], { ...projects[0], id: 'project-2' }] as Project[]
       const projection = getProjectHostSetupProjectionFromState({
         repos,
+        projects: twoProjects,
+        projectHostSetups: coveringSetups(null)
+      })
+      expect(projection.projects.map((project) => project.id)).toEqual(['project-1', 'project-2'])
+      expect(projection.projects[0]).toBe(twoProjects[0])
+      expect(projection.projects[1]).toBe(twoProjects[1])
+    })
+
+    // Why: a repo with a GitHub upstream gets an identity key that flips `changed`, routing to
+    // the normalized-merge exit — the one most real installs take, and otherwise untested here.
+    it('coerces on the normalized-merge exit as well', () => {
+      const upstreamRepos = [
+        { ...repos[0], upstream: { owner: 'alice', repo: 'orca' } }
+      ] as unknown as Repo[]
+      const projection = getProjectHostSetupProjectionFromState({
+        repos: upstreamRepos,
         projects,
         projectHostSetups: coveringSetups(null)
       })
-      expect(projection.projects).toEqual(projects)
-      expect(projection.projects[0]).toBe(projects[0])
+      expect(projection.setups.find((setup) => typeof setup.repoId !== 'string')).toBeUndefined()
     })
 
     it('does not invent extra setup or project rows because one repoId was null', () => {

--- a/src/renderer/src/store/project-host-setup-selector.null-repo-id.test.ts
+++ b/src/renderer/src/store/project-host-setup-selector.null-repo-id.test.ts
@@ -98,6 +98,68 @@ describe('project host setup projection with a non-string repoId', () => {
     ]).toEqual(['repo-1'])
   })
 
+  // Why these two: the fixtures above leave every repo uncovered, which always takes the
+  // merge path. A row that covers every repo takes the passthrough path instead, and that
+  // is the shape the production crash had.
+  describe('when every repo is already covered (passthrough path)', () => {
+    const coveringSetups = (repoId: unknown): ProjectHostSetup[] =>
+      [
+        {
+          id: 'repo:repo-1::local',
+          projectId: 'repo:repo-1',
+          hostId: 'local',
+          repoId: 'repo-1',
+          path: '/Users/alice/orca',
+          displayName: 'orca',
+          setupState: 'ready',
+          setupMethod: 'legacy-repo',
+          createdAt: 1,
+          updatedAt: 1
+        },
+        {
+          id: 'repo:repo-1::local::2',
+          projectId: 'repo:repo-1',
+          hostId: 'local',
+          repoId,
+          path: '/Users/alice/orca-2',
+          displayName: 'orca-2',
+          setupState: 'ready',
+          setupMethod: 'legacy-repo',
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ] as unknown as ProjectHostSetup[]
+
+    it('still coerces a null repoId instead of leaking it through', () => {
+      const projection = getProjectHostSetupProjectionFromState({
+        repos,
+        projects,
+        projectHostSetups: coveringSetups(null)
+      })
+      const leaked = projection.setups.find((setup) => typeof setup.repoId !== 'string')
+      expect(leaked).toBeUndefined()
+      expect(projection.setups.find((setup) => setup.id === 'repo:repo-1::local::2')?.repoId).toBe(
+        ''
+      )
+    })
+
+    it('does not invent extra setup or project rows because one repoId was null', () => {
+      const rowIds = (repoId: unknown): { setups: string[]; projects: string[] } => {
+        const projection = getProjectHostSetupProjectionFromState({
+          repos,
+          projects,
+          projectHostSetups: coveringSetups(repoId)
+        })
+        return {
+          setups: projection.setups.map((setup) => setup.id).sort(),
+          projects: projection.projects.map((project) => project.id).sort()
+        }
+      }
+      // Why: a coerced field must change one value, never which rows exist.
+      expect(rowIds(null)).toEqual(rowIds(''))
+    })
+  })
+
   it('keeps the projection reference-stable for a repeated input', () => {
     const setups = makeSetups(null)
     const args = { repos, projects, projectHostSetups: setups }

--- a/src/renderer/src/store/project-host-setup-selector.null-repo-id.test.ts
+++ b/src/renderer/src/store/project-host-setup-selector.null-repo-id.test.ts
@@ -143,6 +143,23 @@ describe('project host setup projection with a non-string repoId', () => {
       )
     })
 
+    // Why: this path's cache is keyed on (projects, setups) only, so a repos array
+    // rebuilt with identical content must still hit it — a miss here is a re-render
+    // storm in a zustand selector compared with Object.is.
+    it.each([
+      ['a real repoId', 'repo-1'],
+      ['a coerced repoId', null]
+    ])('survives a new repos array of identical content (%s)', (_label, repoId) => {
+      const projectHostSetups = coveringSetups(repoId)
+      const first = getProjectHostSetupProjectionFromState({ repos, projects, projectHostSetups })
+      const second = getProjectHostSetupProjectionFromState({
+        repos: [...repos],
+        projects,
+        projectHostSetups
+      })
+      expect(second).toBe(first)
+    })
+
     it('does not invent extra setup or project rows because one repoId was null', () => {
       const rowIds = (repoId: unknown): { setups: string[]; projects: string[] } => {
         const projection = getProjectHostSetupProjectionFromState({

--- a/src/renderer/src/store/project-host-setup-selector.null-repo-id.test.ts
+++ b/src/renderer/src/store/project-host-setup-selector.null-repo-id.test.ts
@@ -160,6 +160,30 @@ describe('project host setup projection with a non-string repoId', () => {
       expect(second).toBe(first)
     })
 
+    // Why: TerminalPane and TabBarQuickCommandsButton use projection.setups as a useMemo
+    // dep, so an untouched row must keep its object identity across normalization.
+    it('reuses the original row objects and only reallocates the coerced one', () => {
+      const projectHostSetups = coveringSetups(null)
+      const projection = getProjectHostSetupProjectionFromState({
+        repos,
+        projects,
+        projectHostSetups
+      })
+      const byId = new Map(projection.setups.map((setup) => [setup.id, setup]))
+      expect(byId.get('repo:repo-1::local')).toBe(projectHostSetups[0])
+      expect(byId.get('repo:repo-1::local::2')).not.toBe(projectHostSetups[1])
+    })
+
+    it('keeps projects in input order with their identities intact', () => {
+      const projection = getProjectHostSetupProjectionFromState({
+        repos,
+        projects,
+        projectHostSetups: coveringSetups(null)
+      })
+      expect(projection.projects).toEqual(projects)
+      expect(projection.projects[0]).toBe(projects[0])
+    })
+
     it('does not invent extra setup or project rows because one repoId was null', () => {
       const rowIds = (repoId: unknown): { setups: string[]; projects: string[] } => {
         const projection = getProjectHostSetupProjectionFromState({

--- a/src/renderer/src/store/project-host-setup-selector.ts
+++ b/src/renderer/src/store/project-host-setup-selector.ts
@@ -33,7 +33,8 @@ function getCachedProjectHostSetupProjection(repos: AppState['repos']): ProjectH
 
 function getCachedProvidedProjectHostSetupProjection(
   projects: Project[],
-  setups: ProjectHostSetup[]
+  setups: ProjectHostSetup[],
+  normalized: ProjectHostSetupProjection
 ): ProjectHostSetupProjection {
   const cachedBySetups = providedProjectHostSetupProjectionCache.get(projects)
   const cachedProjection = cachedBySetups?.get(setups)
@@ -41,7 +42,9 @@ function getCachedProvidedProjectHostSetupProjection(
     return cachedProjection
   }
 
-  const projection = { projects, setups }
+  // Why serve the normalized rows: field-level coercion (a non-string repoId)
+  // must reach callers on this path too, and it leaves row identity untouched.
+  const projection = { projects: normalized.projects, setups: normalized.setups }
   const nextCachedBySetups =
     cachedBySetups ?? new WeakMap<ProjectHostSetup[], ProjectHostSetupProjection>()
   nextCachedBySetups.set(setups, projection)
@@ -175,7 +178,8 @@ export function getProjectHostSetupProjectionFromState(
     }
     return getCachedProvidedProjectHostSetupProjection(
       state.projects as Project[],
-      state.projectHostSetups as ProjectHostSetup[]
+      state.projectHostSetups as ProjectHostSetup[],
+      normalized
     )
   }
   return getCachedProjectHostSetupProjection(state.repos)

--- a/src/renderer/src/store/project-host-setup-selector.ts
+++ b/src/renderer/src/store/project-host-setup-selector.ts
@@ -143,7 +143,8 @@ export function getProjectHostSetupProjectionFromState(
     const coveredRepoIds = new Set<string>()
     for (const setup of state.projectHostSetups) {
       const repoId = typeof setup.repoId === 'string' ? setup.repoId : ''
-      if (repoIds.has(repoId)) {
+      // Why `repoId &&`: an empty repoId matches no repo, matching the normalizer's lookup guard.
+      if (repoId && repoIds.has(repoId)) {
         coveredRepoIds.add(repoId)
       }
       if (repoIds.has(setup.id)) {


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 1 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​228 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​228 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​19 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​8 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​11 |

<!-- /orca-pr-loc -->

## ELI5

Orca remembers a list of "this project, set up on this machine" rows. Each row is supposed to store a repo ID as text. Some older or remote-synced rows have `null` there instead.

Opening **Settings** ran `repoId.trim()` on every row. Calling `.trim()` on `null` throws, so the whole Settings page went blank behind a crash boundary.

The fix cleans that value up in the one place every row passes through: if it isn't text, it becomes an empty string. Empty already meant "no repo attached" everywhere in the app, so nothing else has to change.

## What Changed

Two files, one behavior change:

- `project-host-setup-selector-normalization.ts` — coerce a non-string `repoId` to `''`.
- `project-host-setup-selector.ts` — the passthrough cache path now serves the normalized rows, so the coercion reaches callers on that path too.

Plus a regression test covering both projection paths.

## Why

`ProjectHostSetup.repoId` is typed `string`, but rows are hydrated from persisted state and from remote catalogs, so the type is a promise the data doesn't keep. The selector already knew this — it does `typeof setup.repoId === 'string' ? setup.repoId : ''` for its coverage scan — but it passed the *raw* rows onward, so the null reached three unguarded `.trim()` call sites (`Settings.tsx:860`, `RepositoryHostSetupsSection.tsx:127,307`).

Fixing it in `normalizeHydratedProjectHostSetupProjection` covers every consumer at once rather than patching each `.trim()`.

## Linked Issue

No tracking issue — sourced from a production crash report.

Crash report `3bcc5be3-26aa-4b7e-a905-b89163ae84e3` — Orca 1.4.188, Linux 7.1.9-zen1-2-zen x64, boundary `page.settings`, fired 0.5 s after `settings_opened`:

```
error_name:    TypeError
error_message: Cannot read properties of null (reading 'trim')
    at Object.useMemo (...)
    at Settings (...)
    at RecoverableRenderErrorBoundary (...)
```

## Visual Proof

`N/A` — no visual change. This is a crash fix on a data-normalization path; the "after" state is Settings rendering exactly as it always did, for users whose data currently makes it crash.

## Testing

Same test file, fix reverted vs. applied:

```
=== WITHOUT FIX ===
  × coerces a null repoId to an empty string
  × coerces a undefined repoId to an empty string
  × coerces a a number repoId to an empty string
  × lets the Settings projectByRepoId memo run instead of throwing on .trim()
  AssertionError: expected [Function] to not throw an error but
  'TypeError: Cannot read properties of null (reading 'trim')' was thrown
  Tests  4 failed | 2 passed (6)

=== WITH FIX ===
  Tests  10 passed (10)
```

That is the exact error string from the crash report.

Each new test is ablation-proven to be load-bearing — removing one half of the fix fails exactly one test and no others:

```
ABLATION A — passthrough path serves raw rows again
  × still coerces a null repoId instead of leaking it through      1 failed | 7 passed

ABLATION B — reinstate `changed = true` on coercion
  × does not invent extra setup or project rows because one repoId was null
  × survives a new repos array of identical content (a coerced repoId)
                                                                   2 failed | 8 passed

RESTORED                                                           10 passed
```

Suite: **6352 tests pass** across `store/`, `components/settings/`, `components/sidebar/`. `pnpm tc` clean. `check:code-quality:changed` clean.

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Platforms: logic is platform-independent (pure store normalization, no path/shell/process handling). Verified on macOS; the crash was reported on Linux. Remote SSH is directly relevant and is the likely *source* of the malformed row — a remote catalog can publish a row whose `repoId` a local client never wrote.

## AI Disclosure

<!-- internal contributor -->

## Review

Adversarial review: **2 loops.**

**Loop 1 — 2 defects found, both fixed.**

1. *should-fix (regression introduced by the first cut).* The first version set `changed = true` when coercing. That flag doesn't just pick a cache — it routes to the merged projection, which unions in the repo-derived rows. One null `repoId` therefore invented a phantom setup row and a phantom project row that were never in the hydrated state, independently confirmed:

   ```
   repoId = ''    setups [project-1::local, project-1::local::2]     projects [project-1]
   repoId = null  setups [repo-1 ←PHANTOM, project-1::local, ...]    projects [repo:repo-1 ←PHANTOM, project-1]
   ```

   Downstream, `terminal-quick-command-project-scope.ts` then sees two project ids for one repo and returns `ambiguous`, so repo-scoped quick commands stop matching. Fixed by coercing without touching `changed`.

2. *should-fix (test gap).* Ablating `changed = true` left all 6 original tests green — the fixture left every repo uncovered, so it only ever exercised the merge path, never the passthrough path the crash actually took. Fixed with two new cases.

   Loop 1 also **refuted** two suspicions (reference stability holds; `''` is correct for all ~12 consumers) and corrected one claim of mine: `settings-project-list.ts` was never at risk, since it builds from repos rather than the hydrated selector.

**Loop 2 — clean.**

Performance review (`/perf` skill): **PASS WITH NOTES**, measured, not eyeballed.

- Passthrough result is `Object.is`-stable — 200 calls per fixture, all identical, both inner arrays stable. No re-render storm.
- Per-row object identity preserved: `{ ...setup, repoId }` allocates only for a row that actually needed coercing (`reusedRowObjects=10/10` all-strings; `10/11` with one malformed row), so downstream `useMemo` / `React.memo` bail-outs still hit.
- Cost: one `typeof` + string compare per row. `+1–5%` at realistic scale (100–250 setups ≈ 11 µs); the arrays were already being built and discarded on every call before this change.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

**Trade-offs / negative behavior changes**

- A row whose `repoId` was `null` now reports `''`. Every consumer already treated both as falsy, so no row that was hidden becomes visible and no grouping key newly collides — but the value visible to code *has* changed.
- One real edge, narrow but genuine: `automation-target-availability.ts:106` compares `setup.repoId === automation.runContext.repoId` strictly, and `automation-run-context.ts:33` persists `repoId` verbatim. An automation created **before** this fix from a repo-less setup stored `null`; after the fix `'' !== null`, so that automation's target reads as unavailable. Requires an automation bound to a repo-less setup.
- This does **not** repair already-persisted bad data — it normalizes on read. The malformed row stays malformed on disk.

**Known adjacent issue, deliberately not fixed here**

`project-grouping.ts:57,61,65` has the identical latent crash on `setup.path`, from the same hydration source. It is *worse*: it sits on the sidebar `WorktreeList` render path, so it takes down the main window rather than one error boundary, and it throws earlier than expected — `parseWslUncPath` does `path.replace(/\\/g,'/')` before the `.trim()` is reached. Different field, different blast radius; folding it in would widen an unrelated crash fix. Worth its own PR.

**Pre-existing perf note (not from this diff)**

`getProjectHostSetupProjectionFromState` does 100% of its `O(repos+setups+projects)` work on *every* call before consulting any cache — measured 11.6 µs at 200 setups, 61 µs at 800, on a store-subscriber hot path with one subscriber per terminal pane. A single 3-level WeakMap memo keyed on `(repos, projects, projectHostSetups)` would short-circuit it. Separate change.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test` pass locally
