### PR TITLE
Prevent duplicate file renames when input unmounts after Enter

### DIFF
--- a/src/renderer/src/components/editor/editor-header-file-rename.ts
+++ b/src/renderer/src/components/editor/editor-header-file-rename.ts
@@ -42,7 +42,6 @@ export function useEditorHeaderFileRename(activeFile: OpenFile): EditorHeaderFil
 
   const commitRename = (): void => {
     if (renameCancelledRef.current) {
-      renameCancelledRef.current = false
       setIsRenaming(false)
       return
     }
@@ -52,6 +51,9 @@ export function useEditorHeaderFileRename(activeFile: OpenFile): EditorHeaderFil
       return
     }
     const newName = input.value.trim()
+    // onBlur follows Enter when the input unmounts; consume that trailing event
+    // so one user action cannot start a second rename against the old path.
+    renameCancelledRef.current = true
     setIsRenaming(false)
     if (!newName || newName === currentFileName) {
       return

--- a/src/renderer/src/components/tab-bar/EditorFileTab.test.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.test.tsx
@@ -454,6 +454,30 @@ describe('EditorFileTab rename menu', () => {
     })
   })
 
+  it('does not re-commit when unmounting the rename input emits multiple blur events', async () => {
+    const file = baseFile()
+    const firstRender = expandNode((await renderEditorFileTab(file)).element)
+    const renameItem = findMenuItemByText(firstRender, 'Rename')
+
+    ;(renameItem.props.onSelect as () => void)()
+
+    const secondRender = expandNode((await renderEditorFileTab(file)).element)
+    const input = findElementsByType(secondRender, 'input')[0]
+    const setInputRef = input.props.ref as (input: HTMLInputElement | null) => void
+    setInputRef({
+      focus: vi.fn(),
+      select: vi.fn(),
+      setSelectionRange: vi.fn(),
+      value: 'renamed.md'
+    } as unknown as HTMLInputElement)
+
+    pressInputKey(input, 'Enter')
+    ;(input.props.onBlur as () => void)()
+    ;(input.props.onBlur as () => void)()
+
+    expect(renameFileOnDiskMock).toHaveBeenCalledTimes(1)
+  })
+
   it('disables Rename for diff tabs that do not map to one writable file', async () => {
     const file = baseFile({
       mode: 'diff',

--- a/src/renderer/src/components/tab-bar/EditorFileTab.tsx
+++ b/src/renderer/src/components/tab-bar/EditorFileTab.tsx
@@ -132,7 +132,6 @@ export default function EditorFileTab({
 
   const commitRename = (): void => {
     if (renameCancelledRef.current) {
-      renameCancelledRef.current = false
       setIsRenaming(false)
       return
     }
@@ -142,6 +141,9 @@ export default function EditorFileTab({
       return
     }
     const newName = input.value.trim()
+    // onBlur follows Enter when the input unmounts; consume that trailing event
+    // so one user action cannot start a second rename against the old path.
+    renameCancelledRef.current = true
     setIsRenaming(false)
     if (!newName) {
       return

--- a/tests/e2e/floating-tab-rename.spec.ts
+++ b/tests/e2e/floating-tab-rename.spec.ts
@@ -141,6 +141,37 @@ test('concurrent floating Markdown renames do not clobber the destination', asyn
   ).toEqual(['first\n', 'second\n'])
 })
 
+test('Enter commits a floating Markdown rename only once', async ({ orcaPage }) => {
+  const seeded = await seedFloatingMarkdownFile(orcaPage)
+  await openFloatingPanel(orcaPage)
+
+  const panel = orcaPage.locator(OPEN_PANEL_SELECTOR)
+  const tab = panel.locator(`[data-tab-id="${seeded.tabId}"]`)
+  await tab.click({ button: 'right' })
+  await orcaPage.getByRole('menuitem').filter({ hasText: 'Rename' }).first().click()
+
+  const input = panel.getByRole('textbox', {
+    name: `Rename file ${seeded.originalName}`,
+    exact: true
+  })
+  await input.fill(seeded.renamedName)
+  await input.press('Enter')
+
+  await expect(tab).toContainText(seeded.renamedName)
+  await expect
+    .poll(() =>
+      orcaPage.evaluate(
+        async ({ originalPath, renamedPath }) => ({
+          originalExists: await window.api.fs.pathExists({ filePath: originalPath }),
+          renamedExists: await window.api.fs.pathExists({ filePath: renamedPath })
+        }),
+        { originalPath: seeded.originalPath, renamedPath: seeded.renamedPath }
+      )
+    )
+    .toEqual({ originalExists: false, renamedExists: true })
+  await expect(orcaPage.getByText(/Failed to rename/)).toHaveCount(0)
+})
+
 test('Electron serializes native Unicode rename aliases', async ({ orcaPage }) => {
   test.skip(process.platform !== 'darwin', 'Requires native Unicode aliasing')
   const directory = await orcaPage.evaluate(() => window.api.app.getFloatingMarkdownDirectory())


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​55 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​55 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​6 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​4 |

<!-- /orca-pr-loc -->

## Problem

When renaming a file by pressing Enter in the rename input, the input unmounts and triggers a trailing blur event. This blur event could fire the rename logic a second time against the old file path, attempting to rename the file again.

## Solution

Set the cancellation flag **after** extracting the new name but **before** hiding the input. This blocks any trailing blur events from attempting a second rename, since the flag will cause commitRename() to exit early.

The comment explains the timing: the flag must be consumed by the trailing blur so one user action doesn't trigger multiple renames.

## Changes

- `editor-header-file-rename.ts` and `EditorFileTab.tsx`: Moved `renameCancelledRef.current = true` to after trimming the new name, moved out of the early-return path
- Added unit test for multiple blur events during rename
- Added e2e test verifying Enter commits rename exactly once

## Testing

- [x] Unit test added: verifies `renameFileOnDiskMock` called exactly once despite multiple blur events
- [x] E2E test added: confirms file rename completes successfully with no duplication or errors
- [x] Existing tests pass