### PR TITLE
fix(runtime): preserve worktree names across scan stalls

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -32979,6 +32979,12 @@ export class OrcaRuntimeService {
       store,
       scanRepo: (repo, projectRuntimeByRepoId) =>
         this.listRepoWorktreesForResolution(repo, projectRuntimeByRepoId),
+      lastSuccessfulScan: (repo) => {
+        const cached = this.worktreeScanCache.get(
+          `${repo.id}\0${getRepoExecutionHostId(repo)}`
+        )?.result
+        return cached?.ok ? cached.worktrees : null
+      },
       listFolderWorkspaces: (repo, repoOwnerCount) =>
         listRuntimeFolderWorkspaces(store, repo, repoOwnerCount)
     }

--- a/src/main/runtime/repo-worktree-row-resolution.test.ts
+++ b/src/main/runtime/repo-worktree-row-resolution.test.ts
@@ -38,6 +38,7 @@ function gitWorktree(path: string): GitWorktreeInfo {
 function createDeps(repos: Repo[]): RepoWorktreeRowDeps & {
   metaById: Record<string, WorktreeMeta>
   scanRepo: ReturnType<typeof vi.fn<RepoWorktreeRowDeps['scanRepo']>>
+  lastSuccessfulScan: ReturnType<typeof vi.fn<RepoWorktreeRowDeps['lastSuccessfulScan']>>
   listFolderWorkspaces: ReturnType<typeof vi.fn<RepoWorktreeRowDeps['listFolderWorkspaces']>>
 } {
   const metaById: Record<string, WorktreeMeta> = {}
@@ -57,8 +58,9 @@ function createDeps(repos: Repo[]): RepoWorktreeRowDeps & {
     ok: true,
     worktrees: [gitWorktree(owner.id === 'unrelated' ? '/unrelated/worktree' : '/same/worktree')]
   }))
+  const lastSuccessfulScan = vi.fn<RepoWorktreeRowDeps['lastSuccessfulScan']>(() => null)
   const listFolderWorkspaces = vi.fn<RepoWorktreeRowDeps['listFolderWorkspaces']>(() => [])
-  return { store, metaById, scanRepo, listFolderWorkspaces }
+  return { store, metaById, scanRepo, lastSuccessfulScan, listFolderWorkspaces }
 }
 
 describe('host-qualified scoped worktree resolution', () => {

--- a/src/main/runtime/repo-worktree-row-resolution.ts
+++ b/src/main/runtime/repo-worktree-row-resolution.ts
@@ -43,6 +43,8 @@ export type RepoWorktreeRowDeps = {
     repo: Repo,
     projectRuntimeByRepoId: ReadonlyMap<string, ProjectExecutionRuntimeResolution>
   ) => Promise<RuntimeWorktreeScanResult>
+  /** The last authoritative rows for a timed-out scan, even after their refresh TTL expired. */
+  lastSuccessfulScan: (repo: Repo) => GitWorktreeInfo[] | null
   /** Folder workspaces are stamped from runtime-owned identity helpers, so the caller supplies them. */
   listFolderWorkspaces: (repo: Repo, repoOwnerCount: number) => Worktree[]
 }
@@ -120,7 +122,11 @@ export async function resolveRepoWorktreeRows(
       .catch(() => ({ ok: false, worktrees: [] }) satisfies RuntimeWorktreeScanResult),
     RESOLVED_WORKTREE_REPO_TIMEOUT_MS,
     null
-  )) ?? { ok: false, worktrees: listStoredWorktreeRowsForRepo(store, repo, repoOwnerCount) }
+  )) ?? {
+    ok: false,
+    worktrees:
+      deps.lastSuccessfulScan(repo) ?? listStoredWorktreeRowsForRepo(store, repo, repoOwnerCount)
+  }
   const gitWorktrees = scan.worktrees
   if (scan.ok) {
     pruneLineageForMissingRepoWorktrees(store, repo, gitWorktrees)

--- a/src/main/runtime/worktree-ps-degraded-repo-scan.test.ts
+++ b/src/main/runtime/worktree-ps-degraded-repo-scan.test.ts
@@ -173,6 +173,52 @@ describe('worktree.ps on a degraded repo scan', () => {
     }
   })
 
+  it('keeps the last successful branch and name when a later remote scan stalls', async () => {
+    vi.useFakeTimers()
+    try {
+      const listWorktrees = vi
+        .fn()
+        .mockResolvedValueOnce([
+          {
+            path: REPO_PATH,
+            head: 'abc',
+            branch: 'main',
+            isBare: false,
+            isMainWorktree: true
+          },
+          {
+            path: WORKTREE_PATH,
+            head: 'def',
+            branch: 'feature',
+            isBare: false,
+            isMainWorktree: false
+          }
+        ])
+        .mockImplementation(neverSettles)
+      getSshGitProviderMock.mockReturnValue({ listWorktrees })
+      const runtime = new OrcaRuntimeService(
+        makeStore({
+          connectionId: SSH_CONNECTION_ID,
+          metaById: {
+            [WORKTREE_ID]: makeMeta({ displayName: '' }),
+            [MAIN_WORKTREE_ID]: makeMeta({ displayName: '', instanceId: 'parent-instance' })
+          }
+        }) as never
+      )
+
+      await runtime.getWorktreePs(10_000)
+      await vi.advanceTimersByTimeAsync(31_000)
+      const degraded = await advancePastRepoScanBudget(runtime.getWorktreePs(10_000))
+
+      const worktree = degraded.worktrees.find((row) => row.worktreeId === WORKTREE_ID)
+      expect(worktree?.branch).toBe('feature')
+      expect(worktree?.displayName).toBe('feature')
+      expect(listWorktrees).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('keeps persisted worktrees when a remote repo is unreachable', async () => {
     getSshGitProviderMock.mockReturnValue(undefined)
     const runtime = new OrcaRuntimeService(makeStore({ connectionId: 'ssh-remote-1' }) as never)


### PR DESCRIPTION
## ELI5

When a worktree scan is temporarily slow, keep showing the last branch and workspace name we successfully learned instead of collapsing several worktrees to the repository name.

## What Changed

- Reuse the last successful per-host repo worktree scan when a later scan exceeds the runtime budget.
- Fall back to persisted branchless rows only when no successful scan exists.
- Preserve authoritative empty scans and existing host ownership boundaries.
- Add a regression test covering a successful SSH scan followed by a stalled refresh.

## Why

A stalled SSH git.listWorktrees request currently restores persisted rows with empty branch and head fields. Mobile then derives every unnamed workspace title from the repo display name, so distinct worktrees collapse to labels such as REPO until a healthy scan completes.

The successful cache is already host-qualified and retained after expiry, making it the narrowest source of last-known-good metadata. Rejected scans remain authoritative so deleted worktrees are not resurrected.

## Linked Issue

Fixes #16724

## Visual Proof

N/A: this changes runtime fallback data only; it does not alter UI rendering or layout.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Commands run:

- pnpm exec vitest run src/main/runtime/worktree-ps-degraded-repo-scan.test.ts src/main/runtime/repo-worktree-row-resolution.test.ts --reporter=verbose
- pnpm run typecheck
- pnpm run lint
- git diff --check

The regression test exercises the SSH-host timeout path. The fork release workflow also completed its full test suite and Desktop, Android, and iOS builds at the same stable patch content. A rebuilt client was not manually exercised.

## AI Disclosure

## Review

Please verify that timeout fallback may reuse only a successful scan for the same repo and execution host, while rejected scans continue to produce authoritative empty results.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows docs/reference/agent-skill-sharing-upstream-boundary.md and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

The change adds no wire fields or opcodes. It preserves folder workspace handling, SSH host isolation, and existing pruning behavior.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or N/A with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] pnpm lint, pnpm typecheck, pnpm test, and pnpm build pass (or CI will cover; local preferred)