### PR TITLE
fix(workspace-cleanup): color review pills by PR/MR state

### DIFF
--- a/src/renderer/src/components/github-item-dialog/load-item-details/work-item-state-badge.tsx
+++ b/src/renderer/src/components/github-item-dialog/load-item-details/work-item-state-badge.tsx
@@ -2,19 +2,11 @@ import React from 'react'
 import { cn } from '@/lib/utils'
 import type { GitHubWorkItem } from '../../../../../shared/github/work-item-types'
 import { getStateLabel } from '@/components/github/work-item-state-presentation'
+import { getReviewStateTone } from '@/components/github/review-state-presentation'
 
 export function getStateTone(item: GitHubWorkItem): string {
   if (item.type === 'pr') {
-    if (item.state === 'merged') {
-      return 'border-purple-500/30 bg-purple-500/10 text-purple-600 dark:text-purple-300'
-    }
-    if (item.state === 'draft') {
-      return 'border-slate-500/30 bg-slate-500/10 text-slate-600 dark:text-slate-300'
-    }
-    if (item.state === 'closed') {
-      return 'border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-300'
-    }
-    return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300'
+    return getReviewStateTone(item.state)
   }
   if (item.state === 'closed') {
     // Why: keep closed issues neutral (may be completed/resolved); red is reserved for PR closed-without-merge.

--- a/src/renderer/src/components/github-item-dialog/load-item-details/work-item-state-badge.tsx
+++ b/src/renderer/src/components/github-item-dialog/load-item-details/work-item-state-badge.tsx
@@ -1,18 +1,14 @@
 import React from 'react'
-import { cn } from '@/lib/utils'
+import {
+  getWorkItemStateTone,
+  WorkItemStateBadge as SharedWorkItemStateBadge
+} from '@/components/github/work-item-state-badge'
 import type { GitHubWorkItem } from '../../../../../shared/github/work-item-types'
-import { getStateLabel } from '@/components/github/work-item-state-presentation'
-import { getReviewStateTone } from '@/components/github/review-state-presentation'
 
+// Why: closed issues stay neutral here (may be completed/resolved); red is reserved
+// for PR closed-without-merge.
 export function getStateTone(item: GitHubWorkItem): string {
-  if (item.type === 'pr') {
-    return getReviewStateTone(item.state)
-  }
-  if (item.state === 'closed') {
-    // Why: keep closed issues neutral (may be completed/resolved); red is reserved for PR closed-without-merge.
-    return 'border-ring/50 bg-primary/10 text-foreground'
-  }
-  return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300'
+  return getWorkItemStateTone(item, 'neutral')
 }
 
 export function WorkItemStateBadge({
@@ -22,15 +18,5 @@ export function WorkItemStateBadge({
   item: GitHubWorkItem
   className?: string
 }): React.JSX.Element {
-  return (
-    <span
-      className={cn(
-        'inline-flex h-5 items-center rounded-full border px-2 text-[11px] font-medium',
-        getStateTone(item),
-        className
-      )}
-    >
-      {getStateLabel(item)}
-    </span>
-  )
+  return <SharedWorkItemStateBadge item={item} className={className} closedIssue="neutral" />
 }

--- a/src/renderer/src/components/github/review-state-presentation.ts
+++ b/src/renderer/src/components/github/review-state-presentation.ts
@@ -1,0 +1,37 @@
+import { GitMerge, GitPullRequestClosed, GitPullRequestDraft, type LucideIcon } from 'lucide-react'
+import type { HostedReviewState } from '../../../../shared/hosted-review'
+
+/** Every review surface renders state from here; `unknown` means we have a number but no fetched state. */
+export type ReviewStateForDisplay = HostedReviewState | 'unknown' | null | undefined
+
+/** Outline-pill tone: purple merged, rose closed, slate draft, emerald open, neutral unknown. */
+export function getReviewStateTone(state: ReviewStateForDisplay): string {
+  if (state === 'merged') {
+    return 'border-purple-500/30 bg-purple-500/10 text-purple-600 dark:text-purple-300'
+  }
+  if (state === 'draft') {
+    return 'border-slate-500/30 bg-slate-500/10 text-slate-600 dark:text-slate-300'
+  }
+  if (state === 'closed') {
+    return 'border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-300'
+  }
+  if (state === 'open') {
+    return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300'
+  }
+  return 'border-border bg-background text-muted-foreground'
+}
+
+// Why: the glyph must carry review state — tone alone made a draft with failing
+// checks render as a red PR icon, which reads as closed.
+export function getReviewStateIcon(state: ReviewStateForDisplay): LucideIcon | null {
+  if (state === 'merged') {
+    return GitMerge
+  }
+  if (state === 'closed') {
+    return GitPullRequestClosed
+  }
+  if (state === 'draft') {
+    return GitPullRequestDraft
+  }
+  return null
+}

--- a/src/renderer/src/components/github/review-state-presentation.ts
+++ b/src/renderer/src/components/github/review-state-presentation.ts
@@ -4,6 +4,10 @@ import type { HostedReviewState } from '../../../../shared/hosted-review'
 /** Every review surface renders state from here; `unknown` means we have a number but no fetched state. */
 export type ReviewStateForDisplay = HostedReviewState | 'unknown' | null | undefined
 
+/** Also the tone for an open issue, which reads the same as an open review. */
+export const OPEN_REVIEW_STATE_TONE =
+  'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300'
+
 /** Outline-pill tone: purple merged, rose closed, slate draft, emerald open, neutral unknown. */
 export function getReviewStateTone(state: ReviewStateForDisplay): string {
   if (state === 'merged') {
@@ -16,7 +20,7 @@ export function getReviewStateTone(state: ReviewStateForDisplay): string {
     return 'border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-300'
   }
   if (state === 'open') {
-    return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300'
+    return OPEN_REVIEW_STATE_TONE
   }
   return 'border-border bg-background text-muted-foreground'
 }

--- a/src/renderer/src/components/github/work-item-state-badge.tsx
+++ b/src/renderer/src/components/github/work-item-state-badge.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { cn } from '@/lib/utils'
+import { getStateLabel } from '@/components/github/work-item-state-presentation'
+import {
+  getReviewStateTone,
+  OPEN_REVIEW_STATE_TONE
+} from '@/components/github/review-state-presentation'
+import type { GitHubWorkItem } from '../../../../shared/github/work-item-types'
+
+/**
+ * Whether a closed ISSUE reads as failure or as neutral completion. PR state tone
+ * never varies — only surfaces disagree on what a closed issue means.
+ */
+export type ClosedIssueTone = 'destructive' | 'neutral'
+
+export function getWorkItemStateTone(item: GitHubWorkItem, closedIssue: ClosedIssueTone): string {
+  if (item.type === 'pr') {
+    return getReviewStateTone(item.state)
+  }
+  if (item.state === 'closed') {
+    return closedIssue === 'neutral'
+      ? 'border-ring/50 bg-primary/10 text-foreground'
+      : 'border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-300'
+  }
+  return OPEN_REVIEW_STATE_TONE
+}
+
+export function WorkItemStateBadge({
+  item,
+  className,
+  closedIssue
+}: {
+  item: GitHubWorkItem
+  className?: string
+  closedIssue: ClosedIssueTone
+}): React.JSX.Element {
+  return (
+    <span
+      className={cn(
+        'inline-flex h-5 items-center rounded-full border px-2 text-[11px] font-medium',
+        getWorkItemStateTone(item, closedIssue),
+        className
+      )}
+    >
+      {getStateLabel(item)}
+    </span>
+  )
+}

--- a/src/renderer/src/components/pull-request-page/presentation/state-badge.tsx
+++ b/src/renderer/src/components/pull-request-page/presentation/state-badge.tsx
@@ -1,20 +1,12 @@
 import React from 'react'
 import { cn } from '@/lib/utils'
 import { getStateLabel } from '@/components/github/work-item-state-presentation'
+import { getReviewStateTone } from '@/components/github/review-state-presentation'
 import type { GitHubWorkItem } from '../../../../../shared/github/work-item-types'
 
 export function getStateTone(item: GitHubWorkItem): string {
   if (item.type === 'pr') {
-    if (item.state === 'merged') {
-      return 'border-purple-500/30 bg-purple-500/10 text-purple-600 dark:text-purple-300'
-    }
-    if (item.state === 'draft') {
-      return 'border-slate-500/30 bg-slate-500/10 text-slate-600 dark:text-slate-300'
-    }
-    if (item.state === 'closed') {
-      return 'border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-300'
-    }
-    return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300'
+    return getReviewStateTone(item.state)
   }
   if (item.state === 'closed') {
     return 'border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-300'

--- a/src/renderer/src/components/pull-request-page/presentation/state-badge.tsx
+++ b/src/renderer/src/components/pull-request-page/presentation/state-badge.tsx
@@ -1,17 +1,12 @@
 import React from 'react'
-import { cn } from '@/lib/utils'
-import { getStateLabel } from '@/components/github/work-item-state-presentation'
-import { getReviewStateTone } from '@/components/github/review-state-presentation'
+import {
+  getWorkItemStateTone,
+  WorkItemStateBadge as SharedWorkItemStateBadge
+} from '@/components/github/work-item-state-badge'
 import type { GitHubWorkItem } from '../../../../../shared/github/work-item-types'
 
 export function getStateTone(item: GitHubWorkItem): string {
-  if (item.type === 'pr') {
-    return getReviewStateTone(item.state)
-  }
-  if (item.state === 'closed') {
-    return 'border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-300'
-  }
-  return 'border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-300'
+  return getWorkItemStateTone(item, 'destructive')
 }
 
 /** Filled counterpart of `getStateTone` for high-emphasis surfaces like the PR page header. */
@@ -34,15 +29,5 @@ export function WorkItemStateBadge({
   item: GitHubWorkItem
   className?: string
 }): React.JSX.Element {
-  return (
-    <span
-      className={cn(
-        'inline-flex h-5 items-center rounded-full border px-2 text-[11px] font-medium',
-        getStateTone(item),
-        className
-      )}
-    >
-      {getStateLabel(item)}
-    </span>
-  )
+  return <SharedWorkItemStateBadge item={item} className={className} closedIssue="destructive" />
 }

--- a/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
+++ b/src/renderer/src/components/sidebar/worktree-review-helpers.tsx
@@ -1,5 +1,6 @@
-import { GitMerge, GitPullRequestClosed, GitPullRequestDraft } from 'lucide-react'
+import { GitMerge } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { getReviewStateIcon } from '@/components/github/review-state-presentation'
 import { PullRequestIcon } from './WorktreeCardHelpers'
 import type { WorktreeCardPrDisplay } from './worktree-card-pr-display'
 
@@ -21,23 +22,6 @@ export function getProviderName(review: WorktreeCardPrDisplay): string {
     return 'Gitea'
   }
   return 'GitHub'
-}
-
-// Why: the glyph must carry review state — tone alone made a draft with failing
-// checks render as a red PR icon, which reads as closed.
-function getStateIcon(
-  state: WorktreeCardPrDisplay['state']
-): React.ComponentType<{ className?: string }> | null {
-  if (state === 'merged') {
-    return GitMerge
-  }
-  if (state === 'closed') {
-    return GitPullRequestClosed
-  }
-  if (state === 'draft') {
-    return GitPullRequestDraft
-  }
-  return null
 }
 
 // Why: checks only gate a review that is actually open; draft/closed/merged keep
@@ -88,6 +72,6 @@ export function ReviewIcon({
 }): React.JSX.Element {
   const providerIcon =
     variant === 'provider' && review.provider === 'gitlab' ? GitMerge : PullRequestIcon
-  const Icon = getStateIcon(review.state) ?? providerIcon
+  const Icon = getReviewStateIcon(review.state) ?? providerIcon
   return <Icon className={cn(className, getCheckTone(review) ?? getStateTone(review.state))} />
 }

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-candidate-row-data.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-candidate-row-data.ts
@@ -1,4 +1,5 @@
 import { translate } from '@/i18n/i18n'
+import { getReviewStateTone } from '@/components/github/review-state-presentation'
 import type { WorkspaceCleanupCandidate } from '../../../../shared/workspace-cleanup'
 import {
   getWorkspaceCleanupGitLabel,
@@ -172,11 +173,9 @@ function hasGitStatusPill(candidate: WorkspaceCleanupCandidate): boolean {
   return (candidate.git.upstreamAhead ?? 0) > 0 || candidate.git.clean === false
 }
 
-export function getReviewPillTone(reviewInfo: WorkspaceCleanupReviewInfo): StatusPillTone {
-  if (reviewInfo.state === 'open' || reviewInfo.state === 'draft') {
-    return 'review'
-  }
-  return 'neutral'
+/** Review pills carry the same state colors as the PR page and item dialog. */
+export function getReviewPillToneClassName(reviewInfo: WorkspaceCleanupReviewInfo): string {
+  return getReviewStateTone(reviewInfo.state)
 }
 
 export function getContextCount(candidate: WorkspaceCleanupCandidate): number {

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-candidate-row-data.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-candidate-row-data.ts
@@ -1,10 +1,6 @@
 import { translate } from '@/i18n/i18n'
-import { getReviewStateTone } from '@/components/github/review-state-presentation'
 import type { WorkspaceCleanupCandidate } from '../../../../shared/workspace-cleanup'
-import {
-  getWorkspaceCleanupGitLabel,
-  type WorkspaceCleanupReviewInfo
-} from './workspace-cleanup-presentation'
+import { getWorkspaceCleanupGitLabel } from './workspace-cleanup-presentation'
 import {
   formatUnpushedCommitCount,
   formatWorkspaceCleanupContextDetail,
@@ -171,11 +167,6 @@ function hasGitStatusPill(candidate: WorkspaceCleanupCandidate): boolean {
     return false
   }
   return (candidate.git.upstreamAhead ?? 0) > 0 || candidate.git.clean === false
-}
-
-/** Review pills carry the same state colors as the PR page and item dialog. */
-export function getReviewPillToneClassName(reviewInfo: WorkspaceCleanupReviewInfo): string {
-  return getReviewStateTone(reviewInfo.state)
 }
 
 export function getContextCount(candidate: WorkspaceCleanupCandidate): number {

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-candidate-row.test.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-candidate-row.test.tsx
@@ -247,4 +247,78 @@ describe('CandidateRow', () => {
     expect(container?.querySelector(`[aria-label="Select ${remoteName}"]`)).not.toBeNull()
     expect(container?.querySelector(`[aria-label="Host: builder"]`)).not.toBeNull()
   })
+
+  it('colors the review pill by state the way the PR page and item dialog do', () => {
+    const states = [
+      { state: 'merged' as const, label: 'PR #1', hue: 'purple' },
+      { state: 'closed' as const, label: 'PR #2', hue: 'rose' },
+      { state: 'open' as const, label: 'PR #3', hue: 'emerald' },
+      { state: 'draft' as const, label: 'PR #4', hue: 'slate' }
+    ]
+
+    for (const { state, label, hue } of states) {
+      const candidate = makeCandidate()
+
+      act(() => {
+        root?.render(
+          <CandidateRow
+            identity={getWorkspaceCleanupCandidateIdentity(candidate)}
+            candidate={candidate}
+            expanded={false}
+            last
+            lastActivityLabel="1d ago"
+            reviewInfo={{
+              hasReview: true,
+              label,
+              provider: 'github',
+              state,
+              title: 'Some change'
+            }}
+            selected={false}
+            onIgnore={vi.fn()}
+            onRemove={vi.fn()}
+            onToggleExpanded={vi.fn()}
+            onToggleSelected={vi.fn()}
+            onView={vi.fn()}
+          />
+        )
+      })
+
+      const pill = container?.querySelector(`[aria-label*="${label}"]`)
+      expect(pill?.className).toContain(`text-${hue}-`)
+      expect(pill?.className).not.toContain('text-muted-foreground')
+    }
+  })
+
+  it('leaves a review with an unfetched state neutral', () => {
+    const candidate = makeCandidate()
+
+    act(() => {
+      root?.render(
+        <CandidateRow
+          identity={getWorkspaceCleanupCandidateIdentity(candidate)}
+          candidate={candidate}
+          expanded={false}
+          last
+          lastActivityLabel="1d ago"
+          reviewInfo={{
+            hasReview: true,
+            label: 'PR #9',
+            provider: 'github',
+            state: 'unknown',
+            title: null
+          }}
+          selected={false}
+          onIgnore={vi.fn()}
+          onRemove={vi.fn()}
+          onToggleExpanded={vi.fn()}
+          onToggleSelected={vi.fn()}
+          onView={vi.fn()}
+        />
+      )
+    })
+
+    const pill = container?.querySelector('[aria-label*="PR #9"]')
+    expect(pill?.className).toContain('text-muted-foreground')
+  })
 })

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-candidate-row.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-candidate-row.tsx
@@ -36,10 +36,11 @@ import {
   getCandidateFactStatuses,
   getContextCount,
   getDirtyGitLabel,
-  getReviewPillTone,
+  getReviewPillToneClassName,
   getWorkspaceCleanupBlockerLabels,
   shouldShowGitMetadataChip
 } from './workspace-cleanup-candidate-row-data'
+import { getReviewStateIcon } from '@/components/github/review-state-presentation'
 import { StatusPill } from './workspace-cleanup-status-pill'
 import { WorkspaceCleanupMetadataChip } from './workspace-cleanup-metadata-chip'
 import { WorkspaceCleanupForgetLocallyButton } from './workspace-cleanup-forget-locally-button'
@@ -255,10 +256,10 @@ export const CandidateRow = React.memo(function CandidateRow({
             ) : null}
             {reviewInfo.label ? (
               <WorkspaceCleanupMetadataChip
-                icon={GitPullRequest}
+                icon={getReviewStateIcon(reviewInfo.state) ?? GitPullRequest}
                 label={getReviewTooltip(reviewInfo)}
                 value={reviewInfo.label}
-                tone={getReviewPillTone(reviewInfo)}
+                toneClassName={getReviewPillToneClassName(reviewInfo)}
               />
             ) : null}
           </div>

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-candidate-row.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-candidate-row.tsx
@@ -36,11 +36,13 @@ import {
   getCandidateFactStatuses,
   getContextCount,
   getDirtyGitLabel,
-  getReviewPillToneClassName,
   getWorkspaceCleanupBlockerLabels,
   shouldShowGitMetadataChip
 } from './workspace-cleanup-candidate-row-data'
-import { getReviewStateIcon } from '@/components/github/review-state-presentation'
+import {
+  getReviewStateIcon,
+  getReviewStateTone
+} from '@/components/github/review-state-presentation'
 import { StatusPill } from './workspace-cleanup-status-pill'
 import { WorkspaceCleanupMetadataChip } from './workspace-cleanup-metadata-chip'
 import { WorkspaceCleanupForgetLocallyButton } from './workspace-cleanup-forget-locally-button'
@@ -259,7 +261,7 @@ export const CandidateRow = React.memo(function CandidateRow({
                 icon={getReviewStateIcon(reviewInfo.state) ?? GitPullRequest}
                 label={getReviewTooltip(reviewInfo)}
                 value={reviewInfo.label}
-                toneClassName={getReviewPillToneClassName(reviewInfo)}
+                toneClassName={getReviewStateTone(reviewInfo.state)}
               />
             ) : null}
           </div>

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-confirm-remove.test.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-confirm-remove.test.tsx
@@ -218,4 +218,43 @@ describe('WorkspaceCleanupConfirmRemove', () => {
       '1 workspace currently shows risk and may need a force delete'
     )
   })
+
+  it('gives the review pill a text equivalent for its state color without repeating the number', () => {
+    const candidate = makeFacetCandidate({
+      worktreeId: 'repo-1::/repo/merged-review',
+      displayName: 'Merged review',
+      path: '/repo/merged-review'
+    })
+
+    act(() => {
+      root.render(
+        <WorkspaceCleanupConfirmRemove
+          candidates={[candidate]}
+          now={Date.now()}
+          reviewInfoByWorktreeId={
+            new Map([
+              [
+                candidate.worktreeId,
+                {
+                  hasReview: true,
+                  label: 'PR #15716',
+                  provider: 'github' as const,
+                  state: 'merged' as const,
+                  title: 'keep editor focus'
+                }
+              ]
+            ])
+          }
+          progress={null}
+          onBack={vi.fn()}
+          onCancel={vi.fn()}
+          onConfirm={vi.fn()}
+        />
+      )
+    })
+
+    const srText = container.querySelector('span.sr-only')?.textContent ?? ''
+    expect(srText).toContain('Merged')
+    expect(srText).not.toContain('PR #15716')
+  })
 })

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-confirm-remove.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-confirm-remove.tsx
@@ -20,6 +20,7 @@ import {
 } from './workspace-cleanup-candidate-row-data'
 import type { WorkspaceCleanupReviewInfo } from './workspace-cleanup-presentation'
 import { formatWorkspaceCleanupRelativeTime } from './workspace-cleanup-relative-time'
+import { getReviewTooltip } from './workspace-cleanup-row-labels'
 import { StatusPill } from './workspace-cleanup-status-pill'
 import { WorkspaceCleanupCandidateList } from './workspace-cleanup-candidate-list'
 import {
@@ -257,6 +258,7 @@ function ConfirmRemoveRow({
         {reviewInfo.label ? (
           <StatusPill toneClassName={getReviewPillToneClassName(reviewInfo)}>
             {reviewInfo.label}
+            <span className="sr-only">{getReviewTooltip(reviewInfo)}</span>
           </StatusPill>
         ) : null}
         {contextPillLabels.map((label) => (

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-confirm-remove.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-confirm-remove.tsx
@@ -15,7 +15,7 @@ import {
   getCandidateFactStatuses,
   formatContextDetailLabels,
   getDirtyGitLabel,
-  getReviewPillTone,
+  getReviewPillToneClassName,
   shouldShowGitMetadataChip
 } from './workspace-cleanup-candidate-row-data'
 import type { WorkspaceCleanupReviewInfo } from './workspace-cleanup-presentation'
@@ -255,7 +255,9 @@ function ConfirmRemoveRow({
           </StatusPill>
         ))}
         {reviewInfo.label ? (
-          <StatusPill tone={getReviewPillTone(reviewInfo)}>{reviewInfo.label}</StatusPill>
+          <StatusPill toneClassName={getReviewPillToneClassName(reviewInfo)}>
+            {reviewInfo.label}
+          </StatusPill>
         ) : null}
         {contextPillLabels.map((label) => (
           <StatusPill key={label}>{label}</StatusPill>

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-confirm-remove.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-confirm-remove.tsx
@@ -20,7 +20,7 @@ import {
 } from './workspace-cleanup-candidate-row-data'
 import type { WorkspaceCleanupReviewInfo } from './workspace-cleanup-presentation'
 import { formatWorkspaceCleanupRelativeTime } from './workspace-cleanup-relative-time'
-import { getReviewTooltip } from './workspace-cleanup-row-labels'
+import { getReviewStateSrText } from './workspace-cleanup-row-labels'
 import { StatusPill } from './workspace-cleanup-status-pill'
 import { WorkspaceCleanupCandidateList } from './workspace-cleanup-candidate-list'
 import {
@@ -258,7 +258,7 @@ function ConfirmRemoveRow({
         {reviewInfo.label ? (
           <StatusPill toneClassName={getReviewPillToneClassName(reviewInfo)}>
             {reviewInfo.label}
-            <span className="sr-only">{getReviewTooltip(reviewInfo)}</span>
+            <span className="sr-only">{getReviewStateSrText(reviewInfo)}</span>
           </StatusPill>
         ) : null}
         {contextPillLabels.map((label) => (

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-confirm-remove.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-confirm-remove.tsx
@@ -15,11 +15,11 @@ import {
   getCandidateFactStatuses,
   formatContextDetailLabels,
   getDirtyGitLabel,
-  getReviewPillToneClassName,
   shouldShowGitMetadataChip
 } from './workspace-cleanup-candidate-row-data'
 import type { WorkspaceCleanupReviewInfo } from './workspace-cleanup-presentation'
 import { formatWorkspaceCleanupRelativeTime } from './workspace-cleanup-relative-time'
+import { getReviewStateTone } from '@/components/github/review-state-presentation'
 import { getReviewStateSrText } from './workspace-cleanup-row-labels'
 import { StatusPill } from './workspace-cleanup-status-pill'
 import { WorkspaceCleanupCandidateList } from './workspace-cleanup-candidate-list'
@@ -256,7 +256,7 @@ function ConfirmRemoveRow({
           </StatusPill>
         ))}
         {reviewInfo.label ? (
-          <StatusPill toneClassName={getReviewPillToneClassName(reviewInfo)}>
+          <StatusPill toneClassName={getReviewStateTone(reviewInfo.state)}>
             {reviewInfo.label}
             <span className="sr-only">{getReviewStateSrText(reviewInfo)}</span>
           </StatusPill>

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-metadata-chip.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-metadata-chip.tsx
@@ -8,12 +8,15 @@ export function WorkspaceCleanupMetadataChip({
   icon: Icon,
   label,
   value,
-  tone = 'neutral'
+  tone = 'neutral',
+  toneClassName
 }: {
   icon: LucideIcon
   label: string
   value?: string
   tone?: StatusPillTone
+  /** Overrides `tone` for chips whose color comes from a domain state (e.g. review state). */
+  toneClassName?: string
 }): React.JSX.Element {
   return (
     <Tooltip>
@@ -25,7 +28,8 @@ export function WorkspaceCleanupMetadataChip({
             tone === 'ready' &&
               'border-[color:color-mix(in_srgb,var(--git-decoration-added)_45%,transparent)] bg-[color:color-mix(in_srgb,var(--git-decoration-added)_10%,transparent)] text-[var(--git-decoration-added)]',
             tone === 'review' && 'bg-muted text-foreground',
-            tone === 'destructive' && 'border-destructive/30 text-destructive'
+            tone === 'destructive' && 'border-destructive/30 text-destructive',
+            toneClassName
           )}
           aria-label={label}
         >

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-row-labels.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-row-labels.ts
@@ -6,7 +6,7 @@ export function formatCompactActivityLabel(label: string): string {
 }
 
 export function getReviewTooltip(reviewInfo: WorkspaceCleanupReviewInfo): string {
-  return [reviewInfo.label, reviewInfo.state, reviewInfo.title].filter(Boolean).join(' · ')
+  return [reviewInfo.label, getReviewStateSrText(reviewInfo)].filter(Boolean).join(' · ')
 }
 
 /** Text equivalent for the state color on pills that render the number visibly. */

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-row-labels.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-row-labels.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceCleanupReviewInfo } from './workspace-cleanup-presentation'
+import { getWorkspaceCleanupReviewStateLabel } from './workspace-cleanup-facet-labels'
 
 export function formatCompactActivityLabel(label: string): string {
   return label === 'Just now' ? 'now' : label.replace(/ ago$/, '')
@@ -6,4 +7,14 @@ export function formatCompactActivityLabel(label: string): string {
 
 export function getReviewTooltip(reviewInfo: WorkspaceCleanupReviewInfo): string {
   return [reviewInfo.label, reviewInfo.state, reviewInfo.title].filter(Boolean).join(' · ')
+}
+
+/** Text equivalent for the state color on pills that render the number visibly. */
+export function getReviewStateSrText(reviewInfo: WorkspaceCleanupReviewInfo): string {
+  if (!reviewInfo.state) {
+    return ''
+  }
+  return [getWorkspaceCleanupReviewStateLabel(reviewInfo.state), reviewInfo.title]
+    .filter(Boolean)
+    .join(' · ')
 }

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-status-pill.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-status-pill.tsx
@@ -4,10 +4,13 @@ import type { StatusPillTone } from './workspace-cleanup-candidate-row-data'
 
 export function StatusPill({
   children,
-  tone = 'neutral'
+  tone = 'neutral',
+  toneClassName
 }: {
   children: React.ReactNode
   tone?: StatusPillTone
+  /** Overrides `tone` for pills whose color comes from a domain state (e.g. review state). */
+  toneClassName?: string
 }): React.JSX.Element {
   return (
     <span
@@ -17,7 +20,8 @@ export function StatusPill({
         tone === 'ready' &&
           'border-status-success-border bg-status-success-background text-status-success',
         tone === 'review' && 'border-border bg-muted text-foreground',
-        tone === 'destructive' && 'border-destructive/30 text-destructive'
+        tone === 'destructive' && 'border-destructive/30 text-destructive',
+        toneClassName
       )}
     >
       {children}


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​113 | 0 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​113 |
| Prod | 11 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​143 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​99 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​44 |

<!-- /orca-pr-loc -->

## Problem

In the inactive-workspace review dialog, every linked review pill rendered in one of two flat tones (`bg-muted` for open/draft, neutral for everything else). A merged PR, a closed PR, and a row whose state hasn't been fetched all looked identical — you had to hover for the tooltip to learn a PR had already merged. Worse, the only pill that *did* stand out was the draft, which is the least significant state.

## Fix

Review pills now use the same state colors the PR page and the GitHub item dialog already use: **purple = merged, rose = closed, slate = draft, emerald = open**, staying neutral when the state hasn't been fetched. The pill glyph follows the state too (merge / closed / draft icon) instead of always being a generic PR icon.

### Before

Merged #15716, open #15824, closed #15656, and unfetched #15540 are indistinguishable:

![before.png](https://github.com/user-attachments/assets/04aa4533-eb59-4935-b1f1-3fd8e916615c)

### After

![after.png](https://github.com/user-attachments/assets/b075470d-8146-4714-9d31-bca84469d04d)

<sub>Captured by mounting the real `CandidateRow` against the app's own stylesheet at each commit (before = this PR's parent), not by re-implementing the markup.</sub>

## Reuse

An audit turned up 9 separate PR-state → color mappings and no shared helper; the dominant mapping had two byte-identical copies. Rather than adding a 10th, this adds `components/github/review-state-presentation.ts` and points the existing copies at it:

- `pull-request-page/presentation/state-badge.tsx` and `github-item-dialog/.../work-item-state-badge.tsx` delegate their `pr` branch to it (no behavior change; their issue branches are untouched and still differ deliberately).
- `sidebar/worktree-review-helpers.tsx` drops its private `getStateIcon` for the shared one.

The remaining inconsistencies the audit surfaced are left alone as out of scope: the kanban card and GitLab dialog use *violet* for merged, the checks panel uses `destructive` for closed, and draft has six different treatments.

## Verification

- `pnpm tc:web` clean; oxlint + oxfmt clean.
- 234 tests pass across the workspace-cleanup, sidebar, PR-page, and task-page suites.
- Two new `CandidateRow` tests. The color test was confirmed to **fail** against the pre-fix code, so it isn't vacuous; the second pins the neutral treatment for a review whose state hasn't been fetched.
