### PR TITLE
feat(appearance): add pure black dark variant

### DIFF
--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -2,6 +2,7 @@ import { BrowserWindow, nativeTheme, powerMonitor, screen } from 'electron'
 import { is } from '@electron-toolkit/utils'
 import { join } from 'node:path'
 import { getAppIconPath } from '../app-icon'
+import { resolveChromeBackgroundColor } from '../../shared/dark-appearance-variant'
 import { browserManager } from '../browser/browser-manager'
 import { getBrowserClientHostId } from '../browser/browser-client-host-id'
 import { formatBrowserClientHostIdArgument } from '../../shared/browser-client-host-id-argument'
@@ -94,7 +95,10 @@ export function createMainWindow(
     acceptFirstMouse: true,
     // Why: auto-hide the Windows/Linux menu bar to save a row (Alt reveals it); macOS uses the system menu bar anyway.
     autoHideMenuBar: true,
-    backgroundColor: nativeTheme.shouldUseDarkColors ? '#0a0a0a' : '#ffffff',
+    backgroundColor: resolveChromeBackgroundColor({
+      dark: nativeTheme.shouldUseDarkColors,
+      variant: settings?.darkAppearanceVariant
+    }),
     // Why: macOS 'hiddenInset' keeps native traffic lights in our custom titlebar; Windows 'hidden' removes the OS title bar so it doesn't double up.
     titleBarStyle:
       process.platform === 'darwin'

--- a/src/main/window/dashboard-popout-window.test.ts
+++ b/src/main/window/dashboard-popout-window.test.ts
@@ -144,8 +144,12 @@ import { readBrowserClientHostIdArgument } from '../../shared/browser-client-hos
 
 type FakeWindow = InstanceType<typeof BrowserWindowMock>
 
-function makeStore(ui: Record<string, unknown> = {}): {
+function makeStore(
+  ui: Record<string, unknown> = {},
+  settings: Record<string, unknown> = {}
+): {
   getUI: () => Record<string, unknown>
+  getSettings: () => Record<string, unknown>
   updateUI: ReturnType<typeof vi.fn>
   onUIChanged: ReturnType<typeof vi.fn>
   emitUIChanged: (next: Record<string, unknown>) => void
@@ -155,6 +159,7 @@ function makeStore(ui: Record<string, unknown> = {}): {
   const uiChangeUnsubscribe = vi.fn()
   return {
     getUI: () => ui,
+    getSettings: () => settings,
     updateUI: vi.fn(),
     onUIChanged: vi.fn((listener: (next: Record<string, unknown>) => void) => {
       listeners.push(listener)
@@ -250,6 +255,12 @@ describe('createOrFocusDashboardPopout', () => {
     const win = instances[0]
     expect(win.loadFile).not.toHaveBeenCalled()
     expect(win.loadURL).toHaveBeenCalledWith(`${RENDERER_URL}/popout.html?view=kanban`)
+  })
+
+  it('paints the pre-renderer fill black when the pure-black variant is persisted', () => {
+    createOrFocusDashboardPopout(makeStore({}, { darkAppearanceVariant: 'pure-black' }) as never)
+
+    expect(instances[0].options.backgroundColor).toBe('#000000')
   })
 
   it('focuses the existing window instead of creating a second one', () => {

--- a/src/main/window/dashboard-popout-window.ts
+++ b/src/main/window/dashboard-popout-window.ts
@@ -7,6 +7,7 @@ import { sendToTrustedUIRenderer } from '../ipc/ui'
 import { installPrivilegedWindowNavigationPolicy } from './privileged-window-navigation'
 import { stepUIZoomLevel, type UIZoomDirection } from '../../shared/ui-zoom-level'
 import { nativeZoomCommandMatchesKeybindings } from '../../shared/window-shortcut-policy'
+import { resolveChromeBackgroundColor } from '../../shared/dark-appearance-variant'
 import {
   keybindingMatchesAction,
   type KeybindingActionId,
@@ -165,7 +166,10 @@ export function createOrFocusDashboardPopout(
     title: 'Orca Agent Dashboard',
     show: false,
     autoHideMenuBar: true,
-    backgroundColor: nativeTheme.shouldUseDarkColors ? '#0a0a0a' : '#ffffff',
+    backgroundColor: resolveChromeBackgroundColor({
+      dark: nativeTheme.shouldUseDarkColors,
+      variant: store?.getSettings().darkAppearanceVariant
+    }),
     // Why: the pop-out uses a standard native frame so it is movable, closable,
     // and minimizable on every platform without reimplementing the main
     // window's custom titlebar/drag-region/window-control chrome. The main

--- a/src/renderer/src/app-shell/use-document-appearance.test.tsx
+++ b/src/renderer/src/app-shell/use-document-appearance.test.tsx
@@ -6,11 +6,13 @@ import { useAppStore } from '../store'
 
 const mocks = vi.hoisted(() => ({
   applyDocumentTheme: vi.fn(),
+  applyDarkAppearanceVariant: vi.fn(),
   buildAppFontFamily: vi.fn((fontFamily: string | null | undefined) => fontFamily ?? '')
 }))
 
 vi.mock('../lib/document-theme', () => ({
-  applyDocumentTheme: mocks.applyDocumentTheme
+  applyDocumentTheme: mocks.applyDocumentTheme,
+  applyDarkAppearanceVariant: mocks.applyDarkAppearanceVariant
 }))
 
 vi.mock('@/lib/app-font-family', () => ({
@@ -28,6 +30,7 @@ const initialState = useAppStore.getState()
 describe('useDocumentAppearance', () => {
   beforeEach(() => {
     mocks.applyDocumentTheme.mockReset()
+    mocks.applyDarkAppearanceVariant.mockReset()
     mocks.buildAppFontFamily.mockClear()
     useAppStore.setState({
       settings: {
@@ -74,5 +77,19 @@ describe('useDocumentAppearance', () => {
     expect(mocks.buildAppFontFamily).toHaveBeenLastCalledWith('Monaco')
     expect(mocks.buildAppFontFamily).toHaveBeenCalledTimes(2)
     unmount()
+  })
+
+  it('applies the persisted dark appearance variant', () => {
+    useAppStore.setState({
+      settings: {
+        ...getDefaultSettings('/tmp'),
+        theme: 'dark',
+        darkAppearanceVariant: 'pure-black'
+      }
+    })
+
+    renderHook(() => useDocumentAppearance())
+
+    expect(mocks.applyDarkAppearanceVariant).toHaveBeenLastCalledWith('pure-black')
   })
 })

--- a/src/renderer/src/app-shell/use-document-appearance.ts
+++ b/src/renderer/src/app-shell/use-document-appearance.ts
@@ -1,12 +1,13 @@
 import { useEffect } from 'react'
 import { buildAppFontFamily } from '@/lib/app-font-family'
-import { applyDocumentTheme } from '../lib/document-theme'
+import { applyDarkAppearanceVariant, applyDocumentTheme } from '../lib/document-theme'
 import { scheduleRuntimeGraphSync } from '../runtime/sync-runtime-graph'
 import { useAppStore } from '../store'
 
 /** Applies the settings-driven theme and app font to the document root. */
 export function useDocumentAppearance(): void {
   const theme = useAppStore((s) => s.settings?.theme)
+  const darkAppearanceVariant = useAppStore((s) => s.settings?.darkAppearanceVariant)
   const appFontFamily = useAppStore((s) => s.settings?.appFontFamily)
 
   useEffect(() => {
@@ -32,6 +33,10 @@ export function useDocumentAppearance(): void {
     mq.addEventListener('change', handler)
     return () => mq.removeEventListener('change', handler)
   }, [theme])
+
+  useEffect(() => {
+    applyDarkAppearanceVariant(darkAppearanceVariant)
+  }, [darkAppearanceVariant])
 
   useEffect(() => {
     document.documentElement.style.setProperty(

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -357,6 +357,34 @@
   --tab-group-split-divider-strong: #a1a1aa;
 }
 
+/* ── Pure Black (OLED) dark variant ──────────────────── */
+
+/* Why: dark mode separates canvas/card/popover by lightness (#0a0a0a → #171717
+   → #262626). Pure black collapses those tiers to #000 for OLED panels, so the
+   separation has to move to the hairline tokens instead — every `--border` and
+   `--input` here is deliberately brighter than its `.dark` counterpart. Only
+   surface/hairline tokens are overridden; hues, status, and git colors are
+   inherited from `.dark` so the two variants stay in sync. */
+.dark.pure-black {
+  --background: #000000;
+  --editor-surface: #000000;
+  --card: #000000;
+  /* The one surface that keeps a lift: `--shadow-floating` is invisible on #000,
+     so menus need their own value plus the brighter border to read as floating. */
+  --popover: #0d0d0d;
+  --secondary: #171717;
+  --muted: #141414;
+  --accent: #232323;
+  --border: rgb(255 255 255 / 0.12);
+  --input: rgb(255 255 255 / 0.2);
+  --worktree-sidebar: #000000;
+  --worktree-sidebar-accent: #1c1c1c;
+  --worktree-sidebar-border: rgb(255 255 255 / 0.12);
+  --sidebar: #000000;
+  --sidebar-accent: #1a1a1a;
+  --sidebar-border: rgb(255 255 255 / 0.12);
+}
+
 .plugin-security-chrome {
   /* Why: plugin themes may style the app, but provenance and consent must
      retain host-owned contrast so a pack cannot disguise a trust decision. */

--- a/src/renderer/src/components/automations/AutomationEditorPromptEditor.tsx
+++ b/src/renderer/src/components/automations/AutomationEditorPromptEditor.tsx
@@ -6,6 +6,7 @@ import { syncContentOnMount, syncContentUpdate } from '@/components/editor/monac
 import { isMonacoFindWidgetOpen } from '@/components/editor/monaco-find-widget'
 import { computeEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
 import { resolveDocumentTheme } from '@/lib/document-theme'
+import { useMonacoDarkThemeName } from '@/lib/monaco-editor-theme'
 import '@/lib/monaco-setup'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
@@ -75,6 +76,7 @@ export function AutomationEditorPromptEditor({
   const fontSize = computeEditorFontSize(settings?.terminalFontSize ?? 13, editorFontZoomLevel)
   const fontFamily = resolveEditorFontFamily(settings)
   const isDark = resolveDocumentTheme(settings?.theme ?? 'system')
+  const monacoDarkTheme = useMonacoDarkThemeName()
   const options = useMemo(
     () =>
       buildAutomationPromptEditorOptions({
@@ -155,7 +157,7 @@ export function AutomationEditorPromptEditor({
           // Why: defaultValue, not controlled value — this surface owns
           // post-mount sync so React cannot wipe Monaco's undo stack.
           defaultValue={value}
-          theme={isDark ? 'vs-dark' : 'vs'}
+          theme={isDark ? monacoDarkTheme : 'vs'}
           onChange={handleChange}
           onMount={handleMount}
           options={options}

--- a/src/renderer/src/components/editor/DiffSectionBody.tsx
+++ b/src/renderer/src/components/editor/DiffSectionBody.tsx
@@ -11,6 +11,7 @@ import { translate } from '@/i18n/i18n'
 import { LargeDiffFallback } from './LargeDiffFallback'
 import { buildDiffEditorWordWrapOptions } from './diff-editor-word-wrap-options'
 import { monacoFindOptions } from './monaco-find-options'
+import { useMonacoDarkThemeName } from '@/lib/monaco-editor-theme'
 
 const ImageDiffViewer = lazy(() => import('./ImageDiffViewer'))
 
@@ -70,6 +71,7 @@ export function DiffSectionBody({
   onMount
 }: DiffSectionBodyProps): React.JSX.Element {
   const renderLimit = section.largeDiffRenderLimit?.limited ? section.largeDiffRenderLimit : null
+  const monacoDarkTheme = useMonacoDarkThemeName()
 
   return (
     <div
@@ -177,7 +179,7 @@ export function DiffSectionBody({
           language={language}
           original={section.originalContent}
           modified={section.modifiedContent}
-          theme={isDark ? 'vs-dark' : 'vs'}
+          theme={isDark ? monacoDarkTheme : 'vs'}
           onMount={onMount}
           // Why: @monaco-editor/react can dispose models before widget teardown.
           // Keep them through unmount and dispose unattached models next tick.

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -27,6 +27,8 @@ import { buildDiffEditorWordWrapOptions } from './diff-editor-word-wrap-options'
 import { useDiffEditorRegistration } from './diff-navigation-context'
 import { preserveDiffViewStateAcrossModelSwaps } from './diff-model-swap-view-state'
 import { monacoFindOptions } from './monaco-find-options'
+import { useMonacoDarkThemeName } from '@/lib/monaco-editor-theme'
+import { useSystemPrefersDark } from '@/components/terminal-pane/use-system-prefers-dark'
 
 export default function DiffViewer({
   modelKey,
@@ -66,9 +68,9 @@ export default function DiffViewer({
   )
   const terminalFontSize = settings?.terminalFontSize ?? 13
   const diffEditorFontSize = computeDiffEditorFontSize(terminalFontSize, editorFontZoomLevel)
-  const isDark =
-    settings?.theme === 'dark' ||
-    (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+  const systemPrefersDark = useSystemPrefersDark()
+  const isDark = settings?.theme === 'dark' || (settings?.theme === 'system' && systemPrefersDark)
+  const monacoDarkTheme = useMonacoDarkThemeName()
 
   const diffEditorRef = useRef<editor.IStandaloneDiffEditor | null>(null)
   const { registerDiffEditor, unregisterDiffEditor } = useDiffEditorRegistration()
@@ -408,7 +410,7 @@ export default function DiffViewer({
             language={language}
             original={originalContent}
             modified={modifiedContent}
-            theme={isDark ? 'vs-dark' : 'vs'}
+            theme={isDark ? monacoDarkTheme : 'vs'}
             onMount={handleMount}
             // Why: a file can have multiple live diff tabs, so key models off tab identity (not file path) to avoid cross-tab reuse.
             // Why: Changes mode rotates only the original-side model after HEAD moves, preserving the modified side's undo stack.

--- a/src/renderer/src/components/editor/IpynbCellEditor.tsx
+++ b/src/renderer/src/components/editor/IpynbCellEditor.tsx
@@ -7,6 +7,7 @@ import remarkGfm from 'remark-gfm'
 import { monaco } from '@/lib/monaco-setup'
 import { computeEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
 import { resolveDocumentTheme } from '@/lib/document-theme'
+import { useMonacoDarkThemeName } from '@/lib/monaco-editor-theme'
 import { useAppStore } from '@/store'
 import { installEditorSaveShortcut, installMonacoEditorFindShortcut } from './editor-shortcuts'
 import { getIpynbCodeCellEditorHeight, getIpynbCodeCellPreviewLines } from './ipynb-code-cell-lines'
@@ -67,6 +68,7 @@ function IpynbCodeCellEditor({
   const fontSize = computeEditorFontSize(settings?.terminalFontSize ?? 13, editorFontZoomLevel)
   const editorHeight = getIpynbCodeCellEditorHeight(source, fontSize)
   const isDark = resolveDocumentTheme(settings?.theme ?? 'system')
+  const monacoDarkTheme = useMonacoDarkThemeName()
   const lines = useMemo(() => getIpynbCodeCellPreviewLines(source), [source])
   const handleMount: OnMount = useCallback((editorInstance, monacoInstance) => {
     editorInstance.focus()
@@ -91,8 +93,8 @@ function IpynbCodeCellEditor({
   }, [])
 
   useEffect(() => {
-    monaco.editor.setTheme(isDark ? 'vs-dark' : 'vs')
-  }, [isDark])
+    monaco.editor.setTheme(isDark ? monacoDarkTheme : 'vs')
+  }, [isDark, monacoDarkTheme])
 
   if (!active) {
     return (
@@ -124,7 +126,7 @@ function IpynbCodeCellEditor({
         height={editorHeight}
         defaultLanguage={cell.language}
         language={cell.language}
-        theme={isDark ? 'vs-dark' : 'vs'}
+        theme={isDark ? monacoDarkTheme : 'vs'}
         value={source}
         onMount={handleMount}
         onChange={(value) => onChange(value ?? '')}

--- a/src/renderer/src/components/editor/MonacoCodeExcerpt.tsx
+++ b/src/renderer/src/components/editor/MonacoCodeExcerpt.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react'
 import { monaco } from '@/lib/monaco-setup'
 import { computeEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
 import { resolveDocumentTheme } from '@/lib/document-theme'
+import { useMonacoDarkThemeName } from '@/lib/monaco-editor-theme'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
 
@@ -53,12 +54,13 @@ export default function MonacoCodeExcerpt({
   )
   const fontFamily = resolveEditorFontFamily(settings)
   const isDark = resolveDocumentTheme(settings?.theme ?? 'system')
+  const monacoDarkTheme = useMonacoDarkThemeName()
   const code = useMemo(() => lines.join('\n'), [lines])
   const [htmlLines, setHtmlLines] = useState<string[]>(() => lines.map(() => ''))
 
   useEffect(() => {
-    monaco.editor.setTheme(isDark ? 'vs-dark' : 'vs')
-  }, [isDark])
+    monaco.editor.setTheme(isDark ? monacoDarkTheme : 'vs')
+  }, [isDark, monacoDarkTheme])
 
   useEffect(() => {
     if (lines.length === 0) {

--- a/src/renderer/src/components/editor/MonacoEditor.tsx
+++ b/src/renderer/src/components/editor/MonacoEditor.tsx
@@ -4,6 +4,8 @@ import Editor from '@monaco-editor/react'
 import type { editor } from 'monaco-editor'
 import type { MarkdownDocument } from '../../../../shared/filesystem-entry-types'
 import { useAppStore } from '@/store'
+import { useMonacoDarkThemeName } from '@/lib/monaco-editor-theme'
+import { useSystemPrefersDark } from '@/components/terminal-pane/use-system-prefers-dark'
 import '@/lib/monaco-setup'
 import { computeEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
 
@@ -114,9 +116,9 @@ export default function MonacoEditor({
   const [gutterMenuOpen, setGutterMenuOpen] = useState(false)
   const [gutterMenuPoint, setGutterMenuPoint] = useState({ x: 0, y: 0 })
   const [gutterMenuLine, setGutterMenuLine] = useState(1)
-  const isDark =
-    settings?.theme === 'dark' ||
-    (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
+  const systemPrefersDark = useSystemPrefersDark()
+  const isDark = settings?.theme === 'dark' || (settings?.theme === 'system' && systemPrefersDark)
+  const monacoDarkTheme = useMonacoDarkThemeName()
 
   const { queueReveal, cancelScheduledReveal, clearTransientRevealHighlight } =
     useMonacoRevealScheduler()
@@ -231,7 +233,7 @@ export default function MonacoEditor({
         language={language}
         // Why: defaultValue, not controlled value — Orca owns post-mount content sync; a controlled path would double setValue.
         defaultValue={content}
-        theme={isDark ? 'vs-dark' : 'vs'}
+        theme={isDark ? monacoDarkTheme : 'vs'}
         onChange={contentSync.handleChange}
         onMount={handleMount}
         options={{

--- a/src/renderer/src/components/settings/AppearanceInterfaceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceInterfaceSection.tsx
@@ -1,6 +1,7 @@
 import type React from 'react'
 
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import type { DarkAppearanceVariant } from '../../../../shared/ui-chrome-types'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
 import { UIZoomControl } from './UIZoomControl'
 import { SearchableSetting } from './SearchableSetting'
@@ -19,6 +20,7 @@ import {
   getLanguageEntries,
   getMenuBarIconEntries,
   getSystemTrayEntries,
+  getDarkAppearanceEntries,
   getThemeEntries,
   getTitlebarEntries,
   getTypographyEntries,
@@ -33,6 +35,7 @@ import { translate } from '@/i18n/i18n'
 import type { UiLanguage } from '../../../../shared/ui-language'
 import { matchesSettingsSearch, normalizeSettingsSearchQuery } from './settings-search'
 import { usePluginLanguagePacks } from '@/store/plugin-language-packs'
+import { useSystemPrefersDark } from '../terminal-pane/use-system-prefers-dark'
 
 type AppearanceInterfaceSectionProps = {
   settings: GlobalSettings
@@ -65,6 +68,19 @@ export function AppearanceInterfaceSection({
   const systemTrayEntry = getSystemTrayEntries({ showSystemTray: true })[0]
   const themeEntry = getThemeEntries()[0]
   const themeLabel = translate('auto.components.settings.AppearancePane.932ff1fbff', 'Theme')
+  const darkAppearanceEntry = getDarkAppearanceEntries()[0]
+  const darkAppearanceLabel = translate(
+    'settings.appearance.darkAppearance.title',
+    'Dark Appearance'
+  )
+  const systemPrefersDark = useSystemPrefersDark()
+  const darkThemeActive =
+    settings.theme === 'dark' || (settings.theme === 'system' && systemPrefersDark)
+  // Why the search escape: the row is hidden as inert in light mode, but
+  // "oled"/"pure black" must still resolve to something the user can read.
+  const showDarkAppearance =
+    darkThemeActive ||
+    (isSearching && matchesSettingsSearch(searchQuery, getDarkAppearanceEntries()))
   const titlebarEntry = getTitlebarEntries()[0]
   const typographyEntry = getTypographyEntries()[0]
   const zoomEntry = getZoomEntries()[0]
@@ -112,6 +128,42 @@ export function AppearanceInterfaceSection({
           }
         />
       </SearchableSetting>
+
+      {showDarkAppearance ? (
+        <SearchableSetting
+          title={darkAppearanceLabel}
+          description={darkAppearanceEntry?.description}
+          keywords={darkAppearanceEntry?.keywords ?? ['pure black', 'oled', 'amoled', 'contrast']}
+          forceVisible={forceVisiblePrimary}
+        >
+          <SettingsRow
+            label={darkAppearanceLabel}
+            // Why kept despite the visibility gate: search can surface this row
+            // while Light is active, where the control does nothing.
+            description={translate(
+              'settings.appearance.darkAppearance.description',
+              'Pure Black drops the app surfaces to #000 for OLED displays. Applies whenever the dark theme is active.'
+            )}
+            control={
+              <SettingsSegmentedControl<DarkAppearanceVariant>
+                ariaLabel={darkAppearanceLabel}
+                value={settings.darkAppearanceVariant ?? 'default'}
+                onChange={(darkAppearanceVariant) => updateSettings({ darkAppearanceVariant })}
+                options={[
+                  {
+                    value: 'default',
+                    label: translate('settings.appearance.darkAppearance.default', 'Default')
+                  },
+                  {
+                    value: 'pure-black',
+                    label: translate('settings.appearance.darkAppearance.pureBlack', 'Pure Black')
+                  }
+                ]}
+              />
+            }
+          />
+        </SearchableSetting>
+      ) : null}
 
       {SHOW_UI_LANGUAGE_SETTING ? (
         <SearchableSetting

--- a/src/renderer/src/components/settings/AppearancePane.test.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.test.tsx
@@ -6,6 +6,7 @@ import { I18nextProvider } from 'react-i18next'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { i18n } from '@/i18n/i18n'
 import { getDefaultSettings } from '../../../../shared/constants'
+import { resetSystemPrefersDarkSubscriptionForTests } from '../terminal-pane/use-system-prefers-dark'
 import type { GlobalSettings } from '../../../../shared/global-settings-types'
 import type { StatusBarItem } from '../../../../shared/ui-chrome-types'
 
@@ -133,6 +134,58 @@ function createWarpThemesStub() {
   }
 }
 
+let originalMatchMedia: unknown
+let matchMediaStubbed = false
+let darkSchemeListeners: ((event: { matches: boolean }) => void)[] = []
+let stubbedPrefersDark = false
+
+/** The hook caches its MediaQueryList module-wide, so the reset must precede the stub. */
+function stubSystemPrefersDark(prefersDark: boolean): void {
+  resetSystemPrefersDarkSubscriptionForTests()
+  if (!matchMediaStubbed) {
+    originalMatchMedia = (window as unknown as { matchMedia?: unknown }).matchMedia
+    matchMediaStubbed = true
+  }
+  stubbedPrefersDark = prefersDark
+  darkSchemeListeners = []
+  ;(window as unknown as { matchMedia: unknown }).matchMedia = (query: string) => {
+    const isDarkQuery = query.includes('prefers-color-scheme: dark')
+    return {
+      get matches() {
+        return isDarkQuery ? stubbedPrefersDark : false
+      },
+      media: query,
+      addEventListener: (_type: string, listener: (event: { matches: boolean }) => void) => {
+        if (isDarkQuery) {
+          darkSchemeListeners.push(listener)
+        }
+      },
+      removeEventListener: (_type: string, listener: (event: { matches: boolean }) => void) => {
+        darkSchemeListeners = darkSchemeListeners.filter((entry) => entry !== listener)
+      }
+    }
+  }
+}
+
+/** Fire a real OS color-scheme change at whatever subscribed, with no re-render. */
+function emitSystemPrefersDarkChange(prefersDark: boolean): void {
+  stubbedPrefersDark = prefersDark
+  for (const listener of darkSchemeListeners) {
+    listener({ matches: prefersDark })
+  }
+}
+
+/** Restore before clearing the cache, so the next read re-reads the real matchMedia. */
+function restoreSystemPrefersDark(): void {
+  if (matchMediaStubbed) {
+    ;(window as unknown as { matchMedia: unknown }).matchMedia = originalMatchMedia
+    originalMatchMedia = undefined
+    matchMediaStubbed = false
+  }
+  darkSchemeListeners = []
+  resetSystemPrefersDarkSubscriptionForTests()
+}
+
 async function renderAppearancePane(
   settings: GlobalSettings,
   updateSettings: (updates: Partial<GlobalSettings>) => void = vi.fn(),
@@ -237,7 +290,107 @@ describe('AppearancePane', () => {
   })
 
   afterEach(() => {
+    restoreSystemPrefersDark()
     delete (window as unknown as { api?: unknown }).api
+  })
+
+  it('reacts to a live OS color-scheme change without a re-render', async () => {
+    // Guards the non-reactive matchMedia read: the pane must follow the OS on
+    // the media event alone, with no new render pass to refresh a stale value.
+    mocks.state.settingsSearchQuery = ''
+    stubSystemPrefersDark(false)
+    const container = await renderAppearancePane({
+      ...getDefaultSettings('/tmp'),
+      theme: 'system'
+    })
+    expect(container.querySelector('[role="radiogroup"][aria-label="Dark Appearance"]')).toBeNull()
+
+    await act(async () => {
+      emitSystemPrefersDarkChange(true)
+    })
+
+    expect(
+      container.querySelector('[role="radiogroup"][aria-label="Dark Appearance"]')
+    ).not.toBeNull()
+  })
+
+  it('offers the Dark Appearance choice while the dark theme is active', async () => {
+    mocks.state.settingsSearchQuery = ''
+    stubSystemPrefersDark(false)
+    const container = await renderAppearancePane({
+      ...getDefaultSettings('/tmp'),
+      theme: 'dark'
+    })
+
+    expect(
+      container.querySelector('[role="radiogroup"][aria-label="Dark Appearance"]')
+    ).not.toBeNull()
+  })
+
+  it('hides the inert Dark Appearance choice in light mode', async () => {
+    mocks.state.settingsSearchQuery = ''
+    stubSystemPrefersDark(true)
+    const container = await renderAppearancePane({
+      ...getDefaultSettings('/tmp'),
+      theme: 'light'
+    })
+
+    expect(container.querySelector('[role="radiogroup"][aria-label="Dark Appearance"]')).toBeNull()
+  })
+
+  it('follows the OS color scheme while the theme is System', async () => {
+    mocks.state.settingsSearchQuery = ''
+    stubSystemPrefersDark(false)
+    const lightContainer = await renderAppearancePane({
+      ...getDefaultSettings('/tmp'),
+      theme: 'system'
+    })
+    expect(
+      lightContainer.querySelector('[role="radiogroup"][aria-label="Dark Appearance"]')
+    ).toBeNull()
+
+    stubSystemPrefersDark(true)
+    const darkContainer = await renderAppearancePane({
+      ...getDefaultSettings('/tmp'),
+      theme: 'system'
+    })
+    expect(
+      darkContainer.querySelector('[role="radiogroup"][aria-label="Dark Appearance"]')
+    ).not.toBeNull()
+  })
+
+  it('keeps Dark Appearance reachable from search while light mode hides it', async () => {
+    mocks.state.settingsSearchQuery = 'oled'
+    stubSystemPrefersDark(false)
+    const container = await renderAppearancePane({
+      ...getDefaultSettings('/tmp'),
+      theme: 'light'
+    })
+
+    expect(
+      container.querySelector('[role="radiogroup"][aria-label="Dark Appearance"]')
+    ).not.toBeNull()
+  })
+
+  it('writes the pure-black variant when the choice is picked', async () => {
+    mocks.state.settingsSearchQuery = ''
+    stubSystemPrefersDark(true)
+    const updateSettings = vi.fn()
+    const container = await renderAppearancePane(
+      { ...getDefaultSettings('/tmp'), theme: 'dark' },
+      updateSettings
+    )
+    const pureBlack = Array.from(
+      container.querySelectorAll<HTMLButtonElement>(
+        '[role="radiogroup"][aria-label="Dark Appearance"] button[role="radio"]'
+      )
+    ).find((button) => button.textContent === 'Pure Black')
+
+    await act(async () => {
+      pureBlack?.click()
+    })
+
+    expect(updateSettings).toHaveBeenCalledWith({ darkAppearanceVariant: 'pure-black' })
   })
 
   it('shows language as a primary interface control without opening Advanced', async () => {

--- a/src/renderer/src/components/settings/AppearancePane.tsx
+++ b/src/renderer/src/components/settings/AppearancePane.tsx
@@ -14,6 +14,7 @@ import { USAGE_PERCENTAGE_DISPLAY_SETTING_ID } from './appearance-usage-percenta
 import {
   getAppIconEntries,
   getAppearancePaneSearchEntries,
+  getDarkAppearanceEntries,
   getLanguageEntries,
   getLayoutEntries,
   getMenuBarIconEntries,
@@ -138,6 +139,7 @@ export function AppearancePane({
   const interfaceSearchEntries = [
     { title: interfaceTitle },
     ...getThemeEntries(),
+    ...getDarkAppearanceEntries(),
     ...getZoomEntries(),
     ...getTypographyEntries(),
     ...(SHOW_UI_LANGUAGE_SETTING ? getLanguageEntries() : []),

--- a/src/renderer/src/components/settings/appearance-interface-summary.test.ts
+++ b/src/renderer/src/components/settings/appearance-interface-summary.test.ts
@@ -14,6 +14,18 @@ describe('resolveInterfaceSectionSummary', () => {
     expect(resolveInterfaceSectionSummary(settings)).toBe('Dark · 中文（简体） · Inter')
   })
 
+  it('qualifies the dark label with the pure-black variant', () => {
+    const settings = {
+      ...getDefaultSettings('/tmp'),
+      theme: 'system' as const,
+      darkAppearanceVariant: 'pure-black' as const,
+      uiLanguage: 'system' as const,
+      appFontFamily: 'Inter'
+    }
+
+    expect(resolveInterfaceSectionSummary(settings)).toBe('System · Pure Black · System · Inter')
+  })
+
   it('falls back to the default font label when app font is empty', () => {
     const settings = {
       ...getDefaultSettings('/tmp'),

--- a/src/renderer/src/components/settings/appearance-interface-summary.ts
+++ b/src/renderer/src/components/settings/appearance-interface-summary.ts
@@ -5,15 +5,21 @@ import {
   UI_LANGUAGE_CHOICES
 } from '@/i18n/supported-languages'
 import { translate } from '@/i18n/i18n'
+import { isPureBlackVariant } from '../../../../shared/dark-appearance-variant'
 
-function resolveThemeSummary(theme: GlobalSettings['theme']): string {
-  if (theme === 'system') {
-    return translate('auto.components.settings.AppearancePane.fb0e0b4453', 'System')
-  }
-  if (theme === 'light') {
+function resolveThemeSummary(settings: GlobalSettings): string {
+  if (settings.theme === 'light') {
     return translate('auto.components.settings.AppearancePane.fd89b5487c', 'Light')
   }
-  return translate('auto.components.settings.AppearancePane.7d26ccabe8', 'Dark')
+  // Why appended rather than replacing: the variant qualifies the theme, and
+  // System still resolves per-OS, so the base label has to survive.
+  const pureBlackSuffix = isPureBlackVariant(settings.darkAppearanceVariant)
+    ? ` · ${translate('settings.appearance.darkAppearance.pureBlack', 'Pure Black')}`
+    : ''
+  if (settings.theme === 'system') {
+    return `${translate('auto.components.settings.AppearancePane.fb0e0b4453', 'System')}${pureBlackSuffix}`
+  }
+  return `${translate('auto.components.settings.AppearancePane.7d26ccabe8', 'Dark')}${pureBlackSuffix}`
 }
 
 function resolveLanguageSummary(uiLanguage: GlobalSettings['uiLanguage']): string {
@@ -29,7 +35,7 @@ export function resolveInterfaceSectionSummary(settings: GlobalSettings): string
     settings.appFontFamily ||
     translate('auto.components.settings.AppearancePane.interfaceDefaultFont', 'Default font')
   if (!SHOW_UI_LANGUAGE_SETTING) {
-    return `${resolveThemeSummary(settings.theme)} · ${fontSummary}`
+    return `${resolveThemeSummary(settings)} · ${fontSummary}`
   }
-  return `${resolveThemeSummary(settings.theme)} · ${resolveLanguageSummary(settings.uiLanguage)} · ${fontSummary}`
+  return `${resolveThemeSummary(settings)} · ${resolveLanguageSummary(settings.uiLanguage)} · ${fontSummary}`
 }

--- a/src/renderer/src/components/settings/appearance-search.ts
+++ b/src/renderer/src/components/settings/appearance-search.ts
@@ -31,6 +31,24 @@ export const getThemeEntries = createLocalizedCatalog((): SettingsSearchEntry[] 
   }
 ])
 
+export const getDarkAppearanceEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
+  {
+    title: translate('settings.appearance.darkAppearance.title', 'Dark Appearance'),
+    description: translate(
+      'settings.appearance.darkAppearance.description',
+      'Pure Black drops the app surfaces to #000 for OLED displays. Applies whenever the dark theme is active.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('settings.appearance.darkAppearance.pureBlack', 'pure black'),
+      // Untranslated on purpose: users search the panel-tech names verbatim.
+      'oled',
+      'amoled',
+      'true black',
+      'contrast'
+    ]
+  }
+])
+
 export const getLanguageEntries = createLocalizedCatalog((): SettingsSearchEntry[] => [
   {
     title: translate('settings.appearance.language.title', 'Language'),
@@ -232,6 +250,7 @@ function buildAppearancePaneSearchEntries(
   return [
     ...getAppearanceSectionEntries(),
     ...getThemeEntries(),
+    ...getDarkAppearanceEntries(),
     ...(SHOW_UI_LANGUAGE_SETTING ? getLanguageEntries() : []),
     ...getTypographyEntries(),
     ...getZoomEntries(),

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -137,6 +137,12 @@
       "menuBarIcon": {
         "title": "Show Menu Bar Icon",
         "description": "Keep an Orca shortcut and activity indicator in the macOS menu bar."
+      },
+      "darkAppearance": {
+        "title": "Dark Appearance",
+        "description": "Pure Black drops the app surfaces to #000 for OLED displays. Applies whenever the dark theme is active.",
+        "default": "Default",
+        "pureBlack": "Pure Black"
       }
     },
     "browser": {

--- a/src/renderer/src/lib/document-theme.test.ts
+++ b/src/renderer/src/lib/document-theme.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
+  applyDarkAppearanceVariant,
   applyDocumentTheme,
+  PURE_BLACK_CLASS,
   resolveDocumentTheme,
   THEME_TRANSITION_DISABLED_CLASS
 } from './document-theme'
@@ -84,6 +86,33 @@ describe('document theme', () => {
   it('resolves system from matchMedia', () => {
     expect(resolveDocumentTheme('system', () => ({ matches: true }))).toBe(true)
     expect(resolveDocumentTheme('system', () => ({ matches: false }))).toBe(false)
+  })
+
+  it('toggles the pure-black class from the persisted variant', () => {
+    const root = createThemeRoot()
+
+    applyDarkAppearanceVariant('pure-black', { root })
+    expect(root.classList.contains(PURE_BLACK_CLASS)).toBe(true)
+
+    applyDarkAppearanceVariant('default', { root })
+    expect(root.classList.contains(PURE_BLACK_CLASS)).toBe(false)
+  })
+
+  it('treats a profile saved before the variant existed as default', () => {
+    const root = createThemeRoot()
+
+    applyDarkAppearanceVariant(undefined, { root })
+    expect(root.classList.contains(PURE_BLACK_CLASS)).toBe(false)
+  })
+
+  it('keeps the pure-black class when a theme preview reapplies the theme', () => {
+    const root = createThemeRoot()
+
+    applyDarkAppearanceVariant('pure-black', { root })
+    applyDocumentTheme('light', { root, disableTransitions: false })
+    applyDocumentTheme('dark', { root, disableTransitions: false })
+
+    expect(root.classList.contains(PURE_BLACK_CLASS)).toBe(true)
   })
 
   it('applies dark and light root classes', () => {

--- a/src/renderer/src/lib/document-theme.ts
+++ b/src/renderer/src/lib/document-theme.ts
@@ -1,8 +1,13 @@
 import type { GlobalSettings } from '../../../shared/global-settings-types'
+import type { DarkAppearanceVariant } from '../../../shared/ui-chrome-types'
+import { isPureBlackVariant } from '../../../shared/dark-appearance-variant'
 
 export type DocumentThemePreference = GlobalSettings['theme']
 
 export const THEME_TRANSITION_DISABLED_CLASS = 'theme-transition-disabled'
+
+/** Paired with `.dark` in `main.css`; harmless while `light` is resolved. */
+export const PURE_BLACK_CLASS = 'pure-black'
 
 const DARK_MODE_QUERY = '(prefers-color-scheme: dark)'
 
@@ -96,4 +101,16 @@ export function applyDocumentTheme(
     pendingTransitionDisableFrames.push(secondFrame)
   })
   pendingTransitionDisableFrames.push(firstFrame)
+}
+
+/**
+ * Toggled independently of `applyDocumentTheme` so imperative theme previews
+ * (settings, onboarding) cannot drop the variant the user already picked.
+ */
+export function applyDarkAppearanceVariant(
+  variant: DarkAppearanceVariant | null | undefined,
+  options: { root?: ThemeRoot } = {}
+): void {
+  const root = options.root ?? document.documentElement
+  root.classList.toggle(PURE_BLACK_CLASS, isPureBlackVariant(variant))
 }

--- a/src/renderer/src/lib/monaco-editor-theme.test.ts
+++ b/src/renderer/src/lib/monaco-editor-theme.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest'
+import type * as Monaco from 'monaco-editor'
+import {
+  PURE_BLACK_MONACO_THEME,
+  registerPureBlackMonacoTheme,
+  resolveMonacoDarkThemeName
+} from './monaco-editor-theme'
+
+describe('resolveMonacoDarkThemeName', () => {
+  it('keeps vs-dark unless pure black is selected', () => {
+    expect(resolveMonacoDarkThemeName(undefined)).toBe('vs-dark')
+    expect(resolveMonacoDarkThemeName('default')).toBe('vs-dark')
+  })
+
+  it('routes pure black to the registered Orca theme', () => {
+    expect(resolveMonacoDarkThemeName('pure-black')).toBe(PURE_BLACK_MONACO_THEME)
+  })
+})
+
+describe('registerPureBlackMonacoTheme', () => {
+  it('inherits vs-dark so only the surfaces move to #000', () => {
+    const defineTheme = vi.fn()
+    registerPureBlackMonacoTheme({ editor: { defineTheme } } as unknown as typeof Monaco)
+
+    expect(defineTheme).toHaveBeenCalledTimes(1)
+    const [name, data] = defineTheme.mock.calls[0] as [string, Monaco.editor.IStandaloneThemeData]
+    expect(name).toBe(PURE_BLACK_MONACO_THEME)
+    expect(data.base).toBe('vs-dark')
+    expect(data.inherit).toBe(true)
+    expect(data.rules).toEqual([])
+    expect(data.colors['editor.background']).toBe('#000000')
+  })
+})

--- a/src/renderer/src/lib/monaco-editor-theme.ts
+++ b/src/renderer/src/lib/monaco-editor-theme.ts
@@ -1,0 +1,53 @@
+import type * as Monaco from 'monaco-editor'
+import type { GlobalSettings } from '../../../shared/global-settings-types'
+import { isPureBlackVariant } from '../../../shared/dark-appearance-variant'
+import { useAppStore } from '../store'
+
+type MonacoModule = typeof Monaco
+
+export const PURE_BLACK_MONACO_THEME = 'orca-pure-black'
+
+/**
+ * Monaco owns its own palette, so the `.dark.pure-black` CSS tokens never reach
+ * it — without this the editor stays a #1e1e1e rectangle inside a #000 app.
+ * Inherits vs-dark so only the surfaces move; syntax colors are untouched.
+ */
+export function registerPureBlackMonacoTheme(monaco: MonacoModule): void {
+  monaco.editor.defineTheme(PURE_BLACK_MONACO_THEME, {
+    base: 'vs-dark',
+    inherit: true,
+    rules: [],
+    colors: {
+      'editor.background': '#000000',
+      'editorGutter.background': '#000000',
+      'editorStickyScroll.background': '#000000',
+      'minimap.background': '#000000',
+      'breadcrumb.background': '#000000',
+      'editorGroupHeader.tabsBackground': '#000000',
+      'editorPane.background': '#000000',
+      // Floating chrome keeps a hairline lift: drop shadows do not read on #000.
+      'editorWidget.background': '#0d0d0d',
+      'editorWidget.border': '#2a2a2a',
+      'editorSuggestWidget.background': '#0d0d0d',
+      'editorSuggestWidget.border': '#2a2a2a',
+      'editorHoverWidget.background': '#0d0d0d',
+      'editorHoverWidget.border': '#2a2a2a',
+      'peekViewEditor.background': '#000000',
+      'peekViewResult.background': '#0d0d0d',
+      'diffEditor.unchangedRegionBackground': '#000000'
+    }
+  })
+}
+
+export type MonacoDarkThemeName = 'vs-dark' | typeof PURE_BLACK_MONACO_THEME
+
+export function resolveMonacoDarkThemeName(
+  variant: GlobalSettings['darkAppearanceVariant']
+): MonacoDarkThemeName {
+  return isPureBlackVariant(variant) ? PURE_BLACK_MONACO_THEME : 'vs-dark'
+}
+
+/** Which dark Monaco theme every editor/diff/colorize surface should use. */
+export function useMonacoDarkThemeName(): MonacoDarkThemeName {
+  return resolveMonacoDarkThemeName(useAppStore((s) => s.settings?.darkAppearanceVariant))
+}

--- a/src/renderer/src/lib/monaco-setup.ts
+++ b/src/renderer/src/lib/monaco-setup.ts
@@ -12,6 +12,7 @@ import { registerJsonlLanguage } from './monaco-languages/register-jsonl'
 import { registerNimLanguage } from './monaco-languages/register-nim'
 import { registerSvelteLanguage } from './monaco-languages/register-svelte'
 import { registerVueLanguage } from './monaco-languages/register-vue'
+import { registerPureBlackMonacoTheme } from './monaco-editor-theme'
 import { installMonacoDelayerCancellationGuard } from './monaco-delayer-cancellation-guard'
 import { installMonacoDiffEditorDisposalGuard } from './monaco-diff-editor-disposal'
 import { installMonacoPeekReferencesPreviewOptions } from './monaco-peek-preview-options'
@@ -79,6 +80,7 @@ registerSvelteLanguage(monaco)
 registerAstroLanguage(monaco)
 registerNimLanguage(monaco)
 registerJsonlLanguage(monaco)
+registerPureBlackMonacoTheme(monaco)
 installMonacoDelayerCancellationGuard()
 installMonacoDiffEditorDisposalGuard(monaco)
 installMonacoPeekReferencesPreviewOptions()

--- a/src/renderer/src/popout.tsx
+++ b/src/renderer/src/popout.tsx
@@ -14,7 +14,7 @@ import {
   installRendererCrashDiagnostics,
   recordRendererCrashBreadcrumb
 } from './lib/crash-diagnostics'
-import { applyDocumentTheme } from './lib/document-theme'
+import { applyDarkAppearanceVariant, applyDocumentTheme } from './lib/document-theme'
 import { buildAppFontFamily } from './lib/app-font-family'
 import { I18nProvider } from './i18n/I18nProvider'
 import { translate } from './i18n/i18n'
@@ -33,6 +33,7 @@ setReactCommitCascadeRendererSurface('dashboard-popout')
 
 function applyPopoutAppearance(settings: GlobalSettings | null): void {
   applyDocumentTheme(settings?.theme ?? 'system', { disableTransitions: false })
+  applyDarkAppearanceVariant(settings?.darkAppearanceVariant)
   document.documentElement.style.setProperty(
     '--app-font-family',
     buildAppFontFamily(settings?.appFontFamily)

--- a/src/shared/dark-appearance-variant.test.ts
+++ b/src/shared/dark-appearance-variant.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DARK_CHROME_BACKGROUND,
+  LIGHT_CHROME_BACKGROUND,
+  PURE_BLACK_CHROME_BACKGROUND,
+  isPureBlackVariant,
+  resolveChromeBackgroundColor,
+  resolveDarkAppearanceVariant
+} from './dark-appearance-variant'
+
+describe('resolveDarkAppearanceVariant', () => {
+  it('keeps profiles saved before the variant on the gray dark theme', () => {
+    expect(resolveDarkAppearanceVariant(undefined)).toBe('default')
+    expect(resolveDarkAppearanceVariant(null)).toBe('default')
+  })
+
+  it('honors an explicit pure-black choice', () => {
+    expect(resolveDarkAppearanceVariant('pure-black')).toBe('pure-black')
+    expect(isPureBlackVariant('pure-black')).toBe(true)
+  })
+})
+
+describe('resolveChromeBackgroundColor', () => {
+  it('paints the pre-renderer window black so launch does not flash gray', () => {
+    expect(resolveChromeBackgroundColor({ dark: true, variant: 'pure-black' })).toBe(
+      PURE_BLACK_CHROME_BACKGROUND
+    )
+  })
+
+  it('leaves the default dark and light fills untouched', () => {
+    expect(resolveChromeBackgroundColor({ dark: true, variant: 'default' })).toBe(
+      DARK_CHROME_BACKGROUND
+    )
+    expect(resolveChromeBackgroundColor({ dark: true })).toBe(DARK_CHROME_BACKGROUND)
+    // The variant never applies in light mode, even when persisted.
+    expect(resolveChromeBackgroundColor({ dark: false, variant: 'pure-black' })).toBe(
+      LIGHT_CHROME_BACKGROUND
+    )
+  })
+})

--- a/src/shared/dark-appearance-variant.ts
+++ b/src/shared/dark-appearance-variant.ts
@@ -1,0 +1,28 @@
+import type { DarkAppearanceVariant } from './ui-chrome-types'
+
+/** Pre-paint window fills. Must track `--background` in `main.css` per theme/variant. */
+export const DARK_CHROME_BACKGROUND = '#0a0a0a'
+export const PURE_BLACK_CHROME_BACKGROUND = '#000000'
+export const LIGHT_CHROME_BACKGROUND = '#ffffff'
+
+/** Profiles saved before the variant existed persist `undefined`; they stay on the gray dark theme. */
+export function resolveDarkAppearanceVariant(
+  variant: DarkAppearanceVariant | null | undefined
+): DarkAppearanceVariant {
+  return variant === 'pure-black' ? 'pure-black' : 'default'
+}
+
+export function isPureBlackVariant(variant: DarkAppearanceVariant | null | undefined): boolean {
+  return resolveDarkAppearanceVariant(variant) === 'pure-black'
+}
+
+/** Window `backgroundColor` shown before the renderer paints, so launch does not flash gray. */
+export function resolveChromeBackgroundColor(args: {
+  dark: boolean
+  variant?: DarkAppearanceVariant | null
+}): string {
+  if (!args.dark) {
+    return LIGHT_CHROME_BACKGROUND
+  }
+  return isPureBlackVariant(args.variant) ? PURE_BLACK_CHROME_BACKGROUND : DARK_CHROME_BACKGROUND
+}

--- a/src/shared/default-global-settings.ts
+++ b/src/shared/default-global-settings.ts
@@ -41,6 +41,7 @@ export function buildDefaultSettings(args: {
     branchPrefix: 'git-username',
     branchPrefixCustom: '',
     theme: 'system',
+    darkAppearanceVariant: 'default',
     leftSidebarAppearanceMode: 'default',
     leftSidebarTintColor: DEFAULT_LEFT_SIDEBAR_TINT_COLOR,
     leftSidebarTintOpacity: DEFAULT_LEFT_SIDEBAR_TINT_OPACITY,

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -28,6 +28,7 @@ import type { TuiAgent } from './tui-agent'
 import type {
   AgentDashboardMode,
   BranchPrefixStrategy,
+  DarkAppearanceVariant,
   FloatingTerminalTriggerLocation,
   LeftSidebarAppearanceMode,
   OpenInApplication,
@@ -74,6 +75,8 @@ export type GlobalSettings = {
   branchPrefix: BranchPrefixStrategy
   branchPrefixCustom: string
   theme: 'system' | 'dark' | 'light'
+  /** Dark-mode surface family. Optional so profiles saved before it stay on the gray tiers. */
+  darkAppearanceVariant?: DarkAppearanceVariant
   /** Controls the left sidebar surface without changing terminal brightness. */
   leftSidebarAppearanceMode: LeftSidebarAppearanceMode
   leftSidebarTintColor?: string

--- a/src/shared/ui-chrome-types.ts
+++ b/src/shared/ui-chrome-types.ts
@@ -14,6 +14,9 @@ export type SourceControlGroupOrder = 'changes-first' | 'staged-first' | 'untrac
 
 export type LeftSidebarAppearanceMode = 'default' | 'match-terminal' | 'tinted'
 
+/** Dark-mode surface family. `pure-black` collapses the gray canvas/panel tiers to #000 for OLED panels. */
+export type DarkAppearanceVariant = 'default' | 'pure-black'
+
 /** Strategy for the prefix prepended to worktree branch names. */
 export type BranchPrefixStrategy = 'git-username' | 'custom' | 'none'
 


### PR DESCRIPTION
## ELI5

Orca's dark mode isn't actually black — it's a stack of dark grays. On OLED and
AMOLED screens, gray pixels stay lit, so the app looks washed out and burns more
power than it needs to. This adds a **Pure Black** option that drops the app's
backgrounds to true `#000`, and keeps everything readable by making the thin
divider lines slightly brighter to compensate for the lost contrast between
surfaces. Nothing changes for anyone who doesn't pick the new option.

## What Changed

New `darkAppearanceVariant` setting (`'default' | 'pure-black'`), surfaced as a
**Dark Appearance** segmented control in Settings → Appearance, directly under Theme.

**Tokens** — a `.dark.pure-black` block in `main.css` overrides surface and
hairline tokens only:

| Token | `.dark` | `.dark.pure-black` |
| --- | --- | --- |
| `--background`, `--card`, `--editor-surface` | `#0a0a0a` / `#171717` / `#1e1e1e` | `#000000` |
| `--sidebar`, `--worktree-sidebar` | `#171717` / `#2a2a2a` | `#000000` |
| `--popover` | `#171717` | `#0d0d0d` |
| `--secondary` / `--muted` / `--accent` | `#262626` / `#262626` / `#404040` | `#171717` / `#141414` / `#232323` |
| `--border` | `rgb(255 255 255 / .07)` | `rgb(255 255 255 / .12)` |
| `--input` | `rgb(255 255 255 / .15)` | `rgb(255 255 255 / .2)` |

`--popover` is the one surface that keeps a lift, because `shadow-floating` is
invisible on `#000` and menus need *something* to read as floating. Hues, status,
and git-decoration colors are inherited from `.dark` so the two variants cannot
drift. Every existing `.dark .foo` rule already `color-mix`es off these tokens,
so all card, hover, and selection states follow with no new rules.

**Monaco** — registers an `orca-pure-black` theme (`base: 'vs-dark'`,
`inherit: true`) that moves only the surfaces; syntax colors are untouched.
The seven theme call sites now share one `useMonacoDarkThemeName()` hook,
replacing seven `'vs-dark'` string literals.

**Window chrome** — `backgroundColor` for the main and popout windows was
hardcoded `#0a0a0a`; it now resolves from the persisted variant, so launch
doesn't flash gray before the renderer paints.

**Visibility** — the control is hidden while the light theme is active, since it
does nothing there. Under System it appears and disappears live as the OS flips,
via the existing shared `useSystemPrefersDark` store.

**Search** — registered `getDarkAppearanceEntries()` in the Appearance pane's
interface entries; without it, searching "oled" hid the entire Interface section.
The row also stays reachable from search while light mode otherwise hides it.

## Why

Gray-tiered dark mode is a real problem on OLED panels: the pixels never switch
off, so the UI reads washed out and draws more power than a true-black interface.

**The design decision worth reviewing is why this is a separate axis rather than a
fourth `theme` value.** About fifteen call sites across the renderer test:

```ts
settings?.theme === 'dark' ||
  (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
```

A `theme: 'black'` value would evaluate as *not dark* in every one of them —
Monaco, Mermaid, Markdown preview, and all four diff viewers would silently fall
back to their light themes. As its own axis, dark detection is untouched, and the
variant composes with System, so users on automatic day/night keep pure black at
night instead of having to choose between the two.

Only surface and hairline tokens are overridden; everything semantic is inherited
from `.dark`, so future palette work still lands in one place.

## Linked Issue

Fixes #16725

## Visual Proof

| Before | After |
| --- | --- |
| _Settings → Appearance, default dark_ | _same pane, Pure Black selected_ |
<img width="973" height="332" alt="image" src="https://github.com/user-attachments/assets/a2ed19f4-5d2f-44c3-b6d9-58666388b7ae" />

<img width="932" height="369" alt="image" src="https://github.com/user-attachments/assets/4cae0b24-9814-4314-ae56-b92de10a888e" />


<!-- drag + drop both screenshots into the two cells above -->

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Manually verified on **Windows 11**: toggled Default ↔ Pure Black, switched Theme
across System / Dark / Light, and confirmed the control hides in light mode and
reappears when the OS flips back to dark while Theme is System.

**Not verified on macOS or Linux.** The change is CSS tokens plus one Electron
`backgroundColor` string, with no platform branches, so I don't expect divergence
— but I can't claim I ran it there.

Automated coverage added:

| File | Covers |
| --- | --- |
| `src/shared/dark-appearance-variant.test.ts` | variant resolution; pre-paint background across dark / light / legacy-`undefined` profiles |
| `src/renderer/src/lib/monaco-editor-theme.test.ts` | theme-name routing; registered theme inherits `vs-dark` |
| `src/renderer/src/lib/document-theme.test.ts` | root class toggles; survives an imperative theme preview reapplying the theme |
| `src/renderer/src/app-shell/use-document-appearance.test.tsx` | hook applies the persisted variant |
| `src/renderer/src/components/settings/AppearancePane.test.tsx` | visibility across dark / light / System-both-ways; reachable from search while hidden; click writes the setting |
| `src/renderer/src/components/settings/appearance-interface-summary.test.ts` | summary label |

`pnpm lint`, `pnpm typecheck`, and `pnpm build` all pass locally. **1499 tests
pass** across the settings, app-shell, editor, and window suites.

Four failures in `src/main/window/clipboard-file-copy.test.ts` are **pre-existing
and unrelated** — I reproduced them on clean `upstream/main` with this commit
absent. They assert POSIX absolute paths (`file:///repo/a.png`), which resolve to
`file:///D:/repo/a.png` on a Windows checkout. This branch doesn't touch that file.

## AI Disclosure

<!-- FILL THIS IN, or delete the whole section if you are a stablyai team member. -->
<!-- Suggested minimal wording: -->
Claude Opus 5 xHigh Effort via Claude Code was used for implementation and test authoring. All changes were reviewed before submission.

## Review

- **Cross-platform** — no platform branches added. CSS tokens and one Electron
  `backgroundColor` string behave identically on macOS, Linux, and Windows. No new
  paths, shell invocations, child processes, or keyboard accelerators.
- **SSH / remote / local** — renderer-local presentation only. Nothing touches
  execution hosts, process reporting, or session inventory. No RPC params, stream
  frames, or published host content change, so remote wire compatibility is
  unaffected and no capability negotiation is needed.
- **Agents, integrations, git providers** — none touched. Terminal theming is a
  separate setting family and is left alone.
- **Backwards compatibility** — `darkAppearanceVariant` is optional. Profiles saved
  before it persist `undefined`, and `resolveDarkAppearanceVariant` resolves that
  to `'default'`, so existing users see no change until they opt in. Covered by test.
- **Performance** — the token override is static CSS with zero runtime cost. The
  Monaco theme registers once at `monaco-setup` init. Visibility reuses the existing
  shared `useSystemPrefersDark` store, which keeps one process-wide media listener
  rather than adding another per-component subscription.
- **UI quality** — follows `docs/STYLEGUIDE.md`: no new hex values in component
  code, no fourth shadow tier, and `SettingsSegmentedControl` is reused rather than
  a new control invented. Because surface lightness no longer separates elements,
  `--border` and `--input` were deliberately raised — **that trade-off is the main
  thing worth a designer's eye.**
- **Security** — no IPC, no new capability, no user input parsed, no network. The
  `.plugin-security-chrome` block is deliberately left untouched so plugin
  provenance and consent chrome keep host-owned contrast under the new variant.

## Agent skill upstream boundary

- [x] Not applicable — no skill-installer source, tests, fixtures, registry
      entries, path tables, comments, or documentation involved.

## Notes

**Mobile is not covered.** `mobile/src/theme/` has its own palette and does not read
`darkAppearanceVariant`. Happy to mirror it in this PR or a follow-up — say which.

**Onboarding** still offers System / Dark / Light only; the variant is settings-only
for now, to keep the first-run flow unchanged.

**No rendered-app screenshot in CI** — verified by token cascade reasoning and
tests rather than a rendered-UI check.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

X (Twitter): [@lanceranara13](https://x.com/lanceranara13)