### PR TITLE
fix(dashboard): reveal remote agent sessions from the dashboard

### DIFF
--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.test.tsx
@@ -635,6 +635,15 @@ describe('AgentTerminalPreview', () => {
     expect(view.queryByText(/No live terminal/)).not.toBeInTheDocument()
   })
 
+  it('shows a remote-specific message instead of "closed" when an SSH pty has no snapshot', async () => {
+    connect.mockResolvedValueOnce({ snapshot: null, replay: [] })
+    const sshPtyId = `ssh:${encodeURIComponent('conn-1')}@@pty-1`
+    const view = render(<AgentTerminalPreview ptyId={sshPtyId} />)
+
+    await waitFor(() => expect(view.getByText(/remote session/)).toBeInTheDocument())
+    expect(view.queryByText(/No live terminal/)).not.toBeInTheDocument()
+  })
+
   it('claims a grid sized to the dialog box and never re-requests an unchanged target', async () => {
     vi.useFakeTimers()
     const view = render(<AgentTerminalPreview ptyId="pty-1" />)

--- a/src/renderer/src/components/dashboard/useDashboardPopoutBridge.test.tsx
+++ b/src/renderer/src/components/dashboard/useDashboardPopoutBridge.test.tsx
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
     generatedAt: now,
     cards: []
   })),
+  activateAndRevealWorktree: vi.fn(),
   offRevealAgent: vi.fn(),
   offAckAgent: vi.fn(),
   offPopoutOpenChanged: vi.fn(),
@@ -41,7 +42,8 @@ vi.mock('@/lib/activate-tab-and-focus-pane', () => ({
 }))
 
 vi.mock('@/lib/worktree-activation', () => ({
-  activateAndRevealWorkspace: mocks.activateAndRevealWorkspace
+  activateAndRevealWorkspace: mocks.activateAndRevealWorkspace,
+  activateAndRevealWorktree: mocks.activateAndRevealWorktree
 }))
 
 vi.mock('./build-dashboard-snapshot', () => ({
@@ -324,6 +326,31 @@ describe('useDashboardPopoutBridge', () => {
     expect(mocks.offAckAgent).toHaveBeenCalledTimes(1)
     expect(mocks.offPopoutOpenChanged).toHaveBeenCalledTimes(1)
     expect(mocks.offSnapshotRequested).toHaveBeenCalledTimes(1)
+  })
+
+  it('reveal activates the worktree through the full activation helper before focusing the pane', async () => {
+    mocks.activateAndRevealWorkspace.mockReturnValue({ primaryTabId: null })
+    await act(async () => root.render(<Harness enabled />))
+
+    const reveal = mocks.onRevealAgent.mock.calls[0]?.[0] as (args: {
+      repoId: string
+      worktreeId: string
+      tabId: string
+      leafId: string | null
+    }) => void
+    expect(reveal).toBeTypeOf('function')
+
+    await act(async () => {
+      reveal({ repoId: 'repo-1', worktreeId: 'wt-1', tabId: 'tab-1', leafId: 'leaf-1' })
+    })
+
+    // Why: bare setActiveWorktree skips setActiveView('terminal') and the
+    // initial-terminal/session-resume guards a remote worktree needs.
+    expect(mocks.activateAndRevealWorkspace).toHaveBeenCalledWith('wt-1', undefined)
+    expect(mocks.activateTabAndFocusPane).toHaveBeenCalledWith('tab-1', 'leaf-1', {
+      flashFocusedPane: true
+    })
+    expect(mocks.setActiveWorktree).not.toHaveBeenCalled()
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/focus-terminal-pane-event.test.ts
+++ b/src/renderer/src/components/terminal-pane/focus-terminal-pane-event.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { TerminalLeafId } from '../../../../shared/stable-pane-id'
 import { handleFocusTerminalPaneDetail } from './focus-terminal-pane-event'
+import { consumePendingPaneFocus, queuePaneFocus } from '@/lib/pending-pane-focus'
 
 const LEAF_ID = '11111111-1111-4111-8111-111111111111' as TerminalLeafId
 const OTHER_LEAF_ID = '22222222-2222-4222-8222-222222222222' as TerminalLeafId
@@ -119,5 +120,22 @@ describe('handleFocusTerminalPaneDetail', () => {
     expect(container.classList.contains('pane-focus-rim-flash')).toBe(false)
     expect(acknowledgeAgents).not.toHaveBeenCalled()
     expect(surfaceStaleAgentRow).toHaveBeenCalledWith('tab-1', LEAF_ID)
+  })
+
+  it('clears a parked focus for the tab once the live listener resolves it', () => {
+    const { manager } = createManager()
+    queuePaneFocus('tab-1', { tabId: 'tab-1', leafId: LEAF_ID })
+
+    handleFocusTerminalPaneDetail(
+      { tabId: 'tab-1', leafId: LEAF_ID },
+      {
+        tabId: 'tab-1',
+        manager,
+        acknowledgeAgents: vi.fn(),
+        surfaceStaleAgentRow: vi.fn()
+      }
+    )
+
+    expect(consumePendingPaneFocus('tab-1')).toBeNull()
   })
 })

--- a/src/renderer/src/components/terminal-pane/focus-terminal-pane-event.ts
+++ b/src/renderer/src/components/terminal-pane/focus-terminal-pane-event.ts
@@ -1,6 +1,7 @@
 import type { FocusTerminalPaneDetail } from '@/constants/terminal'
 import type { ManagedPane } from '@/lib/pane-manager/pane-manager'
 import { resolveLeafIdForManager } from '@/lib/pane-manager/pane-key-resolution'
+import { clearPendingPaneFocus } from '@/lib/pending-pane-focus'
 import { flashFocusedPaneRim } from './focused-pane-rim-flash'
 
 type FocusTerminalPaneManager = {
@@ -47,6 +48,9 @@ export function handleFocusTerminalPaneDetail(
     return
   }
   manager.setActivePane(resolution.numericPaneId, { focus: true })
+  // Why: the live listener handled it; drop any parked copy so a pane mounting
+  // late does not re-fire the same focus.
+  clearPendingPaneFocus(tabId)
   if (detail.scrollToBottomIfOutputSinceLastView) {
     scrollToBottomIfOutputSinceLastView?.(resolution.numericPaneId)
   }

--- a/src/renderer/src/components/terminal-pane/use-pending-pane-focus-consumer.ts
+++ b/src/renderer/src/components/terminal-pane/use-pending-pane-focus-consumer.ts
@@ -1,0 +1,35 @@
+import { useEffect } from 'react'
+import type { PaneManager } from '@/lib/pane-manager/pane-manager'
+import { consumePendingPaneFocus } from '@/lib/pending-pane-focus'
+import { useAppStore } from '@/store'
+import { handleFocusTerminalPaneDetail } from './focus-terminal-pane-event'
+import { surfaceStaleAgentRow } from './stale-agent-row'
+
+// Why: activateTabAndFocusPane may dispatch before a cold-parked pane mounts
+// its listener (hidden worktree, SSH connect gate); the parked detail is
+// consumed here. The lifecycle effect that creates managerRef.current runs
+// before this one, so the manager and its replayed panes already exist.
+export function useConsumePendingPaneFocus({
+  tabId,
+  managerRef,
+  scheduleFollowOutputIfNeeded
+}: {
+  tabId: string
+  managerRef: React.RefObject<PaneManager | null>
+  scheduleFollowOutputIfNeeded?: (paneId: number) => void
+}): void {
+  useEffect(() => {
+    const parked = consumePendingPaneFocus(tabId)
+    if (!parked) {
+      return
+    }
+    handleFocusTerminalPaneDetail(parked, {
+      tabId,
+      manager: managerRef.current,
+      acknowledgeAgents: (paneKeys) => useAppStore.getState().acknowledgeAgents(paneKeys),
+      surfaceStaleAgentRow,
+      scrollToBottomIfOutputSinceLastView: scheduleFollowOutputIfNeeded
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tabId])
+}

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-global-effects.ts
@@ -12,6 +12,7 @@ import type { IDisposable } from '@xterm/xterm'
 import { handleTerminalFileDrop } from './terminal-drop-handler'
 import { handleFocusTerminalPaneDetail } from './focus-terminal-pane-event'
 import { surfaceStaleAgentRow } from './stale-agent-row'
+import { useConsumePendingPaneFocus } from './use-pending-pane-focus-consumer'
 import { useAppStore } from '@/store'
 import { useTerminalScrollVisibilityMemory } from './use-terminal-scroll-visibility-memory'
 import { useTerminalContainerFitSync } from './use-terminal-container-fit-sync'
@@ -243,6 +244,8 @@ export function useTerminalPaneGlobalEffects({
     window.addEventListener(FOCUS_TERMINAL_PANE_EVENT, onFocusPane)
     return () => window.removeEventListener(FOCUS_TERMINAL_PANE_EVENT, onFocusPane)
   }, [tabId, managerRef, scheduleFollowOutputIfNeeded])
+
+  useConsumePendingPaneFocus({ tabId, managerRef, scheduleFollowOutputIfNeeded })
 
   useEffect(() => {
     const onPasteText = (event: Event): void => {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -17721,6 +17721,7 @@
     "terminal": {
       "closed": "No live terminal — this agent's pane has closed.",
       "remotePreviewUnavailable": "No preview for this remote session — open the workspace to view the terminal.",
+      "remoteUnavailable": "Live preview is unavailable for this remote session — open the worktree to view the terminal.",
       "focusWorktree": "Open worktree",
       "close": "Close"
     },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -14824,7 +14824,7 @@
     },
     "terminal": {
       "closed": "No live terminal — this agent's pane has closed.",
-      "remoteUnavailable": "Live preview is unavailable for this remote session — open the worktree to view the terminal.",
+      "remoteUnavailable": "La vista previa en vivo no está disponible para esta sesión remota; abre el worktree para ver la terminal.",
       "focusWorktree": "Open worktree",
       "close": "Close"
     },

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -14824,6 +14824,7 @@
     },
     "terminal": {
       "closed": "No live terminal — this agent's pane has closed.",
+      "remoteUnavailable": "Live preview is unavailable for this remote session — open the worktree to view the terminal.",
       "focusWorktree": "Open worktree",
       "close": "Close"
     },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -14859,6 +14859,7 @@
     },
     "terminal": {
       "closed": "実行中のターミナルがありません。この Agent のペインは閉じられています。",
+      "remoteUnavailable": "Live preview is unavailable for this remote session — open the worktree to view the terminal.",
       "focusWorktree": "ワークツリーを開く",
       "close": "閉じる"
     },

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -14859,7 +14859,7 @@
     },
     "terminal": {
       "closed": "実行中のターミナルがありません。この Agent のペインは閉じられています。",
-      "remoteUnavailable": "Live preview is unavailable for this remote session — open the worktree to view the terminal.",
+      "remoteUnavailable": "このリモートセッションのライブプレビューは利用できません。ターミナルを表示するにはワークツリーを開いてください。",
       "focusWorktree": "ワークツリーを開く",
       "close": "閉じる"
     },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -14998,6 +14998,7 @@
     },
     "terminal": {
       "closed": "실시간 터미널이 없습니다 — 이 에이전트의 창이 닫혔습니다.",
+      "remoteUnavailable": "Live preview is unavailable for this remote session — open the worktree to view the terminal.",
       "focusWorktree": "워크트리 열기",
       "close": "닫기"
     },

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -14998,7 +14998,7 @@
     },
     "terminal": {
       "closed": "실시간 터미널이 없습니다 — 이 에이전트의 창이 닫혔습니다.",
-      "remoteUnavailable": "Live preview is unavailable for this remote session — open the worktree to view the terminal.",
+      "remoteUnavailable": "이 원격 세션의 라이브 미리보기를 사용할 수 없습니다. 터미널을 보려면 워크트리를 여세요.",
       "focusWorktree": "워크트리 열기",
       "close": "닫기"
     },

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -14963,6 +14963,7 @@
     },
     "terminal": {
       "closed": "没有活动的终端 — 该智能体的窗格已关闭。",
+      "remoteUnavailable": "此远程会话暂不支持实时预览 — 请打开工作区查看终端。",
       "focusWorktree": "聚焦工作树",
       "close": "关闭"
     },

--- a/src/renderer/src/lib/activate-tab-and-focus-pane.test.ts
+++ b/src/renderer/src/lib/activate-tab-and-focus-pane.test.ts
@@ -103,4 +103,45 @@ describe('activateTabAndFocusPane', () => {
       flashFocusedPane: true
     })
   })
+
+  it('clears a parked focus when a later activation supersedes it', () => {
+    const frameCallbacks: (() => void)[] = []
+    vi.stubGlobal('requestAnimationFrame', (cb: () => void) => {
+      frameCallbacks.push(cb)
+      return frameCallbacks.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    vi.stubGlobal('window', {
+      dispatchEvent: vi.fn()
+    })
+
+    activateTabAndFocusPane('tab-1', 'leaf-1')
+    frameCallbacks[0]?.()
+    activateTabAndFocusPane('tab-2', 'leaf-2')
+
+    expect(consumePendingPaneFocus('tab-1')).toBeNull()
+    frameCallbacks[1]?.()
+    expect(consumePendingPaneFocus('tab-2')).toEqual({
+      tabId: 'tab-2',
+      leafId: 'leaf-2'
+    })
+  })
+
+  it('clears a parked focus when a later tab-only activation supersedes it', () => {
+    const frameCallbacks: (() => void)[] = []
+    vi.stubGlobal('requestAnimationFrame', (cb: () => void) => {
+      frameCallbacks.push(cb)
+      return frameCallbacks.length
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    vi.stubGlobal('window', {
+      dispatchEvent: vi.fn()
+    })
+
+    activateTabAndFocusPane('tab-1', 'leaf-1')
+    frameCallbacks[0]?.()
+    activateTabAndFocusPane('tab-2', null)
+
+    expect(consumePendingPaneFocus('tab-1')).toBeNull()
+  })
 })

--- a/src/renderer/src/lib/activate-tab-and-focus-pane.test.ts
+++ b/src/renderer/src/lib/activate-tab-and-focus-pane.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { activateTabAndFocusPane } from './activate-tab-and-focus-pane'
+import { consumePendingPaneFocus } from './pending-pane-focus'
 
 const setActiveTab = vi.hoisted(() => vi.fn())
 const setActiveTabType = vi.hoisted(() => vi.fn())
@@ -80,5 +81,26 @@ describe('activateTabAndFocusPane', () => {
     expect(setActiveTab).toHaveBeenCalledWith('tab-1')
     expect(requestAnimationFrame).not.toHaveBeenCalled()
     expect(dispatchEvent).not.toHaveBeenCalled()
+  })
+
+  it('parks the focus detail so a late-mounting pane can consume it', () => {
+    const frameCallbacks: (() => void)[] = []
+    vi.stubGlobal('requestAnimationFrame', (cb: () => void) => {
+      frameCallbacks.push(cb)
+      return 12
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+    vi.stubGlobal('window', {
+      dispatchEvent: vi.fn()
+    })
+
+    activateTabAndFocusPane('tab-1', 'leaf-1', { flashFocusedPane: true })
+    expect(consumePendingPaneFocus('tab-1')).toBeNull()
+    frameCallbacks[0]?.()
+    expect(consumePendingPaneFocus('tab-1')).toEqual({
+      tabId: 'tab-1',
+      leafId: 'leaf-1',
+      flashFocusedPane: true
+    })
   })
 })

--- a/src/renderer/src/lib/activate-tab-and-focus-pane.ts
+++ b/src/renderer/src/lib/activate-tab-and-focus-pane.ts
@@ -1,5 +1,6 @@
 import { useAppStore } from '@/store'
 import { FOCUS_TERMINAL_PANE_EVENT, type FocusTerminalPaneDetail } from '@/constants/terminal'
+import { queuePaneFocus } from './pending-pane-focus'
 
 let pendingFocusPaneFrameId: number | null = null
 
@@ -41,6 +42,9 @@ export function activateTabAndFocusPane(
         ? { scrollToBottomIfOutputSinceLastView: true }
         : {})
     }
+    // Why: park the detail too — a cold-parked pane mounts its listener after
+    // this frame and would otherwise miss the dispatch entirely.
+    queuePaneFocus(tabId, detail)
     window.dispatchEvent(
       new CustomEvent<FocusTerminalPaneDetail>(FOCUS_TERMINAL_PANE_EVENT, {
         detail

--- a/src/renderer/src/lib/activate-tab-and-focus-pane.ts
+++ b/src/renderer/src/lib/activate-tab-and-focus-pane.ts
@@ -1,8 +1,9 @@
 import { useAppStore } from '@/store'
 import { FOCUS_TERMINAL_PANE_EVENT, type FocusTerminalPaneDetail } from '@/constants/terminal'
-import { queuePaneFocus } from './pending-pane-focus'
+import { clearPendingPaneFocus, queuePaneFocus } from './pending-pane-focus'
 
 let pendingFocusPaneFrameId: number | null = null
+let lastQueuedTabId: string | null = null
 
 function cancelPendingFocusPaneFrame(): void {
   if (pendingFocusPaneFrameId !== null) {
@@ -26,6 +27,12 @@ export function activateTabAndFocusPane(
   setActiveTabType('terminal')
   setActiveTab(tabId)
   cancelPendingFocusPaneFrame()
+  // Why: a later activation supersedes the parked focus — otherwise a
+  // slow-mounting pane for the previous tab could replay the stale request.
+  if (lastQueuedTabId !== null) {
+    clearPendingPaneFocus(lastQueuedTabId)
+    lastQueuedTabId = null
+  }
   if (leafId === null) {
     return
   }
@@ -45,6 +52,7 @@ export function activateTabAndFocusPane(
     // Why: park the detail too — a cold-parked pane mounts its listener after
     // this frame and would otherwise miss the dispatch entirely.
     queuePaneFocus(tabId, detail)
+    lastQueuedTabId = tabId
     window.dispatchEvent(
       new CustomEvent<FocusTerminalPaneDetail>(FOCUS_TERMINAL_PANE_EVENT, {
         detail

--- a/src/renderer/src/lib/pending-pane-focus.test.ts
+++ b/src/renderer/src/lib/pending-pane-focus.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { FocusTerminalPaneDetail } from '@/constants/terminal'
+import {
+  clearPendingPaneFocus,
+  consumePendingPaneFocus,
+  queuePaneFocus
+} from './pending-pane-focus'
+
+const DETAIL: FocusTerminalPaneDetail = { tabId: 'tab-1', leafId: 'leaf-1' }
+
+describe('pending-pane-focus', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    clearPendingPaneFocus('tab-1')
+    clearPendingPaneFocus('tab-2')
+  })
+
+  it('consumes a queued focus detail for the matching tab', () => {
+    queuePaneFocus('tab-1', DETAIL)
+    expect(consumePendingPaneFocus('tab-1')).toEqual(DETAIL)
+  })
+
+  it('returns null for a tab with no queued focus', () => {
+    queuePaneFocus('tab-1', DETAIL)
+    expect(consumePendingPaneFocus('tab-2')).toBeNull()
+  })
+
+  it('drains on consume so a second consume returns null', () => {
+    queuePaneFocus('tab-1', DETAIL)
+    consumePendingPaneFocus('tab-1')
+    expect(consumePendingPaneFocus('tab-1')).toBeNull()
+  })
+
+  it('clears a queued focus without consuming it', () => {
+    queuePaneFocus('tab-1', DETAIL)
+    clearPendingPaneFocus('tab-1')
+    expect(consumePendingPaneFocus('tab-1')).toBeNull()
+  })
+
+  it('expires a focus parked longer than the TTL', () => {
+    queuePaneFocus('tab-1', DETAIL)
+    vi.advanceTimersByTime(15_001)
+    expect(consumePendingPaneFocus('tab-1')).toBeNull()
+  })
+
+  it('replaces an older queued focus for the same tab', () => {
+    const newer: FocusTerminalPaneDetail = { tabId: 'tab-1', leafId: 'leaf-2' }
+    queuePaneFocus('tab-1', DETAIL)
+    queuePaneFocus('tab-1', newer)
+    expect(consumePendingPaneFocus('tab-1')).toEqual(newer)
+  })
+})

--- a/src/renderer/src/lib/pending-pane-focus.ts
+++ b/src/renderer/src/lib/pending-pane-focus.ts
@@ -1,0 +1,35 @@
+import type { FocusTerminalPaneDetail } from '@/constants/terminal'
+
+// Why: activateTabAndFocusPane dispatches FOCUS_TERMINAL_PANE_EVENT one frame
+// after setActiveTab. A cold-parked TerminalPane (hidden worktree, background
+// tab) mounts its listener several frames later — or behind an SSH connect
+// gate — so the dispatch lands on no listener and click-to-focus is silently
+// lost. Park the detail here so the mounting pane consumes it on the way up.
+const PENDING_FOCUS_TTL_MS = 15_000
+
+type PendingFocusEntry = {
+  detail: FocusTerminalPaneDetail
+  queuedAt: number
+}
+
+const pendingByTabId = new Map<string, PendingFocusEntry>()
+
+export function queuePaneFocus(tabId: string, detail: FocusTerminalPaneDetail): void {
+  pendingByTabId.set(tabId, { detail, queuedAt: Date.now() })
+}
+
+export function consumePendingPaneFocus(tabId: string): FocusTerminalPaneDetail | null {
+  const entry = pendingByTabId.get(tabId)
+  if (!entry) {
+    return null
+  }
+  pendingByTabId.delete(tabId)
+  if (Date.now() - entry.queuedAt > PENDING_FOCUS_TTL_MS) {
+    return null
+  }
+  return entry.detail
+}
+
+export function clearPendingPaneFocus(tabId: string): void {
+  pendingByTabId.delete(tabId)
+}


### PR DESCRIPTION
## Summary

Fixes #16731.

Clicking an agent in the Agent Dashboard (pop-out window or in-window drawer) failed to open **remote/SSH** sessions: the terminal preview falsely reported *"this agent's pane has closed"*, and "Open worktree" never focused the agent's pane. Entering the same remote project from the sidebar worked, which isolated the bug to the dashboard reveal path.

Two root causes, both fixed here:

1. **Lost focus event.** `activateTabAndFocusPane` dispatches `FOCUS_TERMINAL_PANE_EVENT` one `requestAnimationFrame` after `setActiveTab`. A cold-parked TerminalPane mounts its focus listener several frames later (or behind the SSH connect gate), so the dispatch landed on no listener. The focus detail is now parked in a pending registry; a late-mounting pane consumes it on the way up, and the live listener clears it on success.
2. **Incomplete worktree activation.** The dashboard reveal paths called bare `setActiveWorktree`, skipping `setActiveView('terminal')`, `ensureWorktreeHasInitialTerminal`, and `resumeSleepingAgentSessionsForWorktree`. They now use `activateAndRevealWorktree(..., { revealInSidebar: false })` — the same helper the sidebar's working path uses.

Additionally, when an SSH PTY has no serializable snapshot (no `getBufferSnapshot` on `SshPtyProvider`, no headless emulator, no mounted renderer serializer), the preview now shows an honest *"Live preview is unavailable for this remote session — open the worktree to view the terminal."* instead of the false *"pane has closed"*. A full live SSH preview (relay buffer-snapshot RPC) is a follow-up enhancement noted in the issue.

## Screenshots

No visual change for local sessions. For remote sessions without a mounted pane, the preview message changes from "No live terminal — this agent's pane has closed." to "Live preview is unavailable for this remote session — open the worktree to view the terminal."

## Testing

- [x] `oxlint` on all changed files (via lint-staged pre-commit hook)
- [x] `tsc --noEmit -p config/tsconfig.tc.web.json`
- [x] `vitest` on affected tests + the full `terminal-pane/`, `dashboard/`, `dashboard-popout/` directories (236 files, 3010 tests)
- [ ] `pnpm test` (full suite) — not run; the change is renderer-only and covered by the directory sweep above
- [ ] `pnpm build` — not run
- [x] Added/updated tests: `pending-pane-focus.test.ts` (new registry), `activate-tab-and-focus-pane.test.ts` (parking), `focus-terminal-pane-event.test.ts` (clearing on success), `useDashboardPopoutBridge.test.tsx` (reveal uses `activateAndRevealWorktree`), `AgentTerminalPreview.test.tsx` (remote message)

## AI Review Report

Reviewed the focus-dispatch race and the reveal activation gap. Main risks checked:

- **Double-focus**: the live listener and the mount-consumer could both fire. Verified `clearPendingPaneFocus` runs on successful resolution, and `consumePendingPaneFocus` is destructive, so only one path fires per detail.
- **Stale focus on a genuinely missing pane**: fail-closed behavior is preserved — `handleFocusTerminalPaneDetail` still calls `surfaceStaleAgentRow` when the leaf cannot resolve; the parked copy is only cleared on success.
- **Effect ordering**: the consuming effect relies on `managerRef.current` being set by the lifecycle effect, which is declared before the global-effects hook in `TerminalPane.tsx`, so React runs it first. Confirmed `replayTerminalLayout` creates panes synchronously in that same lifecycle effect.
- **Cross-platform**: no platform-specific code added. The SSH ptyId check uses the shared `parseAppSshPtyId` parser, which is host-agnostic. Keyboard shortcuts, labels, and paths are untouched.
- **React hooks rules**: `useConsumePendingPaneFocus` is called unconditionally; the hook file keeps the global-effects file under the 300-line `max-lines` limit (no `max-lines` disables added, per project rules).

## Security Audit

No new input handling, command execution, path handling, auth, secrets, or IPC surface. The pending-focus registry stores a `FocusTerminalPaneDetail` (tabId/leafId/flags) in memory with a 15s TTL — no persistence, no cross-origin exposure. The SSH ptyId is parsed with the existing shared parser and only used to select a display string. No follow-up needed.

## Notes

- The full live SSH terminal preview (relay `RecentPtyOutputBuffer` snapshot RPC + `SshPtyProvider.getBufferSnapshot`) is intentionally out of scope; tracked as a follow-up in #16731.
- Pre-existing unrelated working-tree changes (updater/serve files) are not included in this PR.