### PR TITLE
fix(agent-hooks): stop the Windows hook launcher spelling the AV-denied flag pair (STA-5237)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -703,6 +703,7 @@ jobs:
           src/main/providers/windows-conpty-wide-char-duplication.node-pty.test.ts
           src/main/providers/pty-repaint-wide-char-buffer.node-pty.test.ts
           src/shared/child-process/windows-command-line.win32.test.ts
+          src/main/agent-hooks/windows-hook-payload-delivery.test.ts
           src/main/windows/windows-pty-job.win32.test.ts
           src/main/windows/windows-host-job.win32.test.ts
           src/main/wsl/wsl-runner.test.ts

--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -604,7 +604,7 @@ describe('wrapPosixHookCommand', () => {
 })
 
 const qualifiedWindowsPowerShellCommand =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -EncodedCommand \S+$/
 
 function decodeWindowsHookCommand(command: string): string {
   const encodedCommand = command.match(/ -EncodedCommand (\S+)$/)?.[1]
@@ -762,7 +762,7 @@ describe('wrapRuntimeHomeHookCommand', () => {
     // applies to the exact same string (#16003).
     const command = wrapRuntimeHomeHookCommand('claude-hook')
 
-    expect(command).toContain('powershell.exe" -NoProfile -WindowStyle Hidden -EncodedCommand ')
+    expect(command).toContain('powershell.exe" -NoProfile -EncodedCommand ')
     expect(command).not.toMatch(/-ExecutionPolicy/i)
   })
 

--- a/src/main/agent-hooks/windows-powershell-hook-launcher.test.ts
+++ b/src/main/agent-hooks/windows-powershell-hook-launcher.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   encodeWindowsPowerShellHookCommand,
+  getWindowsPowerShellExecutablePath,
   WINDOWS_POWERSHELL_HOOK_SWITCHES,
   wrapWindowsPowerShellEncodedCommand
 } from './windows-powershell-hook-launcher'
@@ -13,19 +14,19 @@ function decodePayload(command: string): string {
 
 /*
  * #16003 — endpoint security (Kaspersky, Windows 11) denies process creation
- * for `-WindowStyle Hidden` + `-EncodedCommand` whatever the payload decodes
- * to, and no exclusion re-enabled it. Measured on the reporting host: that pair
- * exits 126 with or without `-ExecutionPolicy Bypass` and with or without
- * `-NoProfile`, while `-NoProfile -EncodedCommand` alone runs 5/5. So the
- * command line spells neither the policy bypass (moved into the payload by
- * #16576) nor the window style.
+ * for the encoded launcher shape whatever the payload decodes to, and no
+ * exclusion re-enabled it. Measured on the reporting host: the denied shape
+ * exits 126 with or without the policy switch and with or without `-NoProfile`,
+ * while `-NoProfile -EncodedCommand` alone runs 5/5. So the command line spells
+ * neither the policy bypass (moved into the payload by #16576) nor the denied
+ * window switch.
  *
  * The counter-pressure is real and is NOT resolved by these assertions:
  * #14815 (+ #14828, #15117, #15447, #15767) reported consoles taking
- * foreground. `-WindowStyle Hidden` was that fix, but its suppression was never
- * measured — see the launcher's comment. These tests pin the shape so it cannot
- * be restored silently; whether a console appears is a question for a live
- * window measurement, which no unit test here can answer.
+ * foreground. The previous suppression switch was that fix, but its behavior
+ * was never measured — see the launcher's comment. These tests pin the shape
+ * so it cannot be restored silently; whether a console appears is a question
+ * for a live window measurement, which no unit test here can answer.
  */
 describe('windows PowerShell hook launcher', () => {
   it('never spells a denied flag on the command line', () => {
@@ -34,15 +35,15 @@ describe('windows PowerShell hook launcher', () => {
 
     expect(WINDOWS_POWERSHELL_HOOK_SWITCHES).not.toMatch(/-ExecutionPolicy/i)
     expect(switches).not.toMatch(/-ExecutionPolicy/i)
-    // Why: measured exit 126 paired with -EncodedCommand on the #16003 host.
-    expect(WINDOWS_POWERSHELL_HOOK_SWITCHES).not.toMatch(/-WindowStyle/i)
-    expect(switches).not.toMatch(/-WindowStyle/i)
+    // Why: measured exit 126 for the denied switch paired with -EncodedCommand.
+    expect(WINDOWS_POWERSHELL_HOOK_SWITCHES).toBe('-NoProfile')
+    expect(switches).toBe(`${getWindowsPowerShellExecutablePath()} -NoProfile`)
   })
 
   it('pins the exact launcher shape so a flag cannot come back unnoticed', () => {
-    // Why this is worth a test: #16576 round 3 dropped -WindowStyle Hidden by
-    // accident and updated the tests to match, so nothing caught it. Restoring
-    // either flag re-breaks every hook on an AV host (#16003).
+    // Why this is worth a test: #16576 round 3 dropped a required launcher
+    // invariant by accident and updated the tests to match, so nothing caught
+    // it. Restoring either denied switch re-breaks every hook on an AV host.
     const command = wrapWindowsPowerShellEncodedCommand('exit 0')
 
     expect(WINDOWS_POWERSHELL_HOOK_SWITCHES).toBe('-NoProfile')

--- a/src/main/agent-hooks/windows-powershell-hook-launcher.test.ts
+++ b/src/main/agent-hooks/windows-powershell-hook-launcher.test.ts
@@ -12,38 +12,41 @@ function decodePayload(command: string): string {
 }
 
 /*
- * Two reproduced Windows failures constrain this one string, in opposite
- * directions:
+ * #16003 — endpoint security (Kaspersky, Windows 11) denies process creation
+ * for `-WindowStyle Hidden` + `-EncodedCommand` whatever the payload decodes
+ * to, and no exclusion re-enabled it. Measured on the reporting host: that pair
+ * exits 126 with or without `-ExecutionPolicy Bypass` and with or without
+ * `-NoProfile`, while `-NoProfile -EncodedCommand` alone runs 5/5. So the
+ * command line spells neither the policy bypass (moved into the payload by
+ * #16576) nor the window style.
  *
- * #16003 — endpoint security (Kaspersky Premium, Windows 11) denies process
- * creation for `-ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand`
- * whatever the payload decodes to, and no exclusion re-enabled it. The triple
- * must stop being spelled.
- *
- * #14815 (+ #14828, #15117, #15447, #15767) — without `-WindowStyle Hidden`
- * every hook event allocates a console that takes foreground and eats the
- * user's keystrokes, and strands a visible window outright when the hook blocks
- * on stdin. Window suppression must stay.
- *
- * Both hold only if the flag that leaves the command line is the policy bypass,
- * which is the one with an exact in-payload equivalent.
+ * The counter-pressure is real and is NOT resolved by these assertions:
+ * #14815 (+ #14828, #15117, #15447, #15767) reported consoles taking
+ * foreground. `-WindowStyle Hidden` was that fix, but its suppression was never
+ * measured — see the launcher's comment. These tests pin the shape so it cannot
+ * be restored silently; whether a console appears is a question for a live
+ * window measurement, which no unit test here can answer.
  */
 describe('windows PowerShell hook launcher', () => {
-  it('never spells the denied flag triple on the command line', () => {
+  it('never spells a denied flag on the command line', () => {
     const command = wrapWindowsPowerShellEncodedCommand('exit 0')
+    const switches = command.replace(/ -EncodedCommand \S+$/, '')
 
     expect(WINDOWS_POWERSHELL_HOOK_SWITCHES).not.toMatch(/-ExecutionPolicy/i)
-    expect(command.replace(/ -EncodedCommand \S+$/, '')).not.toMatch(/-ExecutionPolicy/i)
+    expect(switches).not.toMatch(/-ExecutionPolicy/i)
+    // Why: measured exit 126 paired with -EncodedCommand on the #16003 host.
+    expect(WINDOWS_POWERSHELL_HOOK_SWITCHES).not.toMatch(/-WindowStyle/i)
+    expect(switches).not.toMatch(/-WindowStyle/i)
   })
 
-  it('keeps hiding the console window on every hook event (#14815)', () => {
-    // Dropping this flag is not a cosmetic flash: the console takes foreground
-    // and swallows what the user is typing into Orca (#14828), and never closes
-    // at all when the hook blocks reading stdin (#14815).
+  it('pins the exact launcher shape so a flag cannot come back unnoticed', () => {
+    // Why this is worth a test: #16576 round 3 dropped -WindowStyle Hidden by
+    // accident and updated the tests to match, so nothing caught it. Restoring
+    // either flag re-breaks every hook on an AV host (#16003).
     const command = wrapWindowsPowerShellEncodedCommand('exit 0')
 
-    expect(WINDOWS_POWERSHELL_HOOK_SWITCHES).toBe('-NoProfile -WindowStyle Hidden')
-    expect(command).toMatch(/ -NoProfile -WindowStyle Hidden -EncodedCommand [A-Za-z0-9+/=]+$/)
+    expect(WINDOWS_POWERSHELL_HOOK_SWITCHES).toBe('-NoProfile')
+    expect(command).toMatch(/ -NoProfile -EncodedCommand [A-Za-z0-9+/=]+$/)
   })
 
   it('keeps the execution-policy bypass, in the payload where AV cannot read it', () => {

--- a/src/main/agent-hooks/windows-powershell-hook-launcher.ts
+++ b/src/main/agent-hooks/windows-powershell-hook-launcher.ts
@@ -14,26 +14,33 @@ export function getWindowsPowerShellExecutablePath(): string {
  * Switches for the PowerShell that relays hook output and exit status
  * (#14818 — conhost does neither).
  *
- * `-WindowStyle Hidden` stays. It is the shipped fix for #14815 and its four
- * duplicates (#14828, #15117, #15447, #15767): without it Windows allocates a
- * console per hook event, which steals foreground from whatever the user is
- * typing into, and strands a permanently visible window whenever a hook blocks
- * reading stdin (see hook-stdin-contract.ts). Those are reported, reproduced
- * user-facing failures on every hook event of every managed agent.
+ * The command line spells no flag beyond `-NoProfile`, because AV denies the
+ * combinations. #16003 measured, on the reporting Kaspersky host:
  *
- * `-ExecutionPolicy Bypass` is the flag that leaves the command line, because
- * it is the only one of the three with an exact in-payload equivalent (below):
- * it costs nothing to move. #16003 measured `-NoProfile -ExecutionPolicy Bypass
- * -WindowStyle Hidden -EncodedCommand` as denied at CreateProcess (exit 126,
- * Kaspersky Premium on Windows 11) no matter what the payload decodes to, so
- * the triple has to stop being spelled; dropping the policy flag breaks it.
+ *   -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand  126
+ *   -NoProfile -WindowStyle Hidden -EncodedCommand                          126
+ *   -WindowStyle Hidden -EncodedCommand                                     126
+ *   -NoProfile -EncodedCommand                                              0 (5/5)
+ *   -NoProfile -ExecutionPolicy Bypass -Command                             0 (5/5)
  *
- * What is not established: that the remaining pair clears that AV signature —
- * the reporter measured no two-flag encoded shape. If it turns out not to, the
- * answer is another launcher shape that still suppresses the window, not
- * trading a reproduced regression for an unmeasured hope.
+ * The denial is at CreateProcess and is independent of the payload: `exit 0` is
+ * denied too, and bash reports it as `Permission denied`. So `-WindowStyle
+ * Hidden` + `-EncodedCommand` is the pair that has to stop being spelled.
+ * #16576 removed `-ExecutionPolicy Bypass` (kept in-payload below), which was
+ * the one flag of the three NOT in the signature — hooks kept failing.
+ *
+ * `-WindowStyle Hidden` was the shipped fix for #14815 (+#14828, #15117,
+ * #15447, #15767). Removing it is a real tradeoff and is recorded as such: its
+ * suppression was never measured — #14825 confirmed it *visually*, #16576's
+ * author stated it "remains unverified on a real box", and #15506's author
+ * argued it cannot help a `.cmd` child that has no console to inherit. The
+ * console is allocated by the parent chain, not by this command line.
+ *
+ * Do not restore the flag to fix a console report. That trades every hook on an
+ * AV host for a flicker. The answer is to shorten the interpreter chain — the
+ * shipped doctrine of #15520 and #15595 — or a launcher that owns no console.
  */
-export const WINDOWS_POWERSHELL_HOOK_SWITCHES = '-NoProfile -WindowStyle Hidden'
+export const WINDOWS_POWERSHELL_HOOK_SWITCHES = '-NoProfile'
 
 // Why: redirected PowerShell progress becomes CLIXML that can corrupt merged JSON
 // output. It must be the FIRST statement: Set-ExecutionPolicy autoloads

--- a/src/main/claude/hook-service.test.ts
+++ b/src/main/claude/hook-service.test.ts
@@ -40,9 +40,7 @@ describe('getWindowsManagedLifecycleHook', () => {
     const hook = getWindowsManagedLifecycleHook(scriptPath)
 
     expect(hook.args).toBeUndefined()
-    expect(hook.command).toMatch(
-      /\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand /
-    )
+    expect(hook.command).toMatch(/\/powershell\.exe -NoProfile -EncodedCommand /)
     expect(hook.command).not.toContain(scriptPath)
     // Why: Git Bash/MSYS mangles backslash paths and slash-prefixed switches.
     expect(hook.command.replace(/-EncodedCommand \S+$/, '')).not.toMatch(/\\| \/[a-zA-Z]+( |$)/)
@@ -384,9 +382,7 @@ describe('ClaudeHookService.install', () => {
         for (const eventName of ['UserPromptSubmit', 'Stop', 'StopFailure']) {
           const hook = settings.hooks[eventName]?.[0]?.hooks?.[0]
           expect(hook?.args).toBeUndefined()
-          expect(hook?.command).toMatch(
-            /\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand /
-          )
+          expect(hook?.command).toMatch(/\/powershell\.exe -NoProfile -EncodedCommand /)
           expect(hook?.command).not.toContain(scriptPath)
 
           const encoded = hook?.command.match(/-EncodedCommand (\S+)$/)?.[1]

--- a/src/main/codex/hook-service-managed-install.test.ts
+++ b/src/main/codex/hook-service-managed-install.test.ts
@@ -31,7 +31,7 @@ import { CodexHookService } from './hook-service'
 import { runExclusivelyForCodexTrustConfig } from './codex-trust-config-mutation-queue'
 
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -EncodedCommand \S+$/
 
 const homes = setupCodexHookHomes(homedirMock, getPathMock)
 

--- a/src/main/command-code/hook-service.test.ts
+++ b/src/main/command-code/hook-service.test.ts
@@ -21,7 +21,7 @@ vi.mock('os', async () => {
 import { CommandCodeHookService } from './hook-service'
 
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -EncodedCommand \S+$/
 
 describe('CommandCodeHookService', () => {
   let homeDir: string

--- a/src/main/cursor/hook-service.test.ts
+++ b/src/main/cursor/hook-service.test.ts
@@ -23,7 +23,7 @@ import { CURSOR_EVENTS, type CursorEvent } from './hook-events'
 
 const CURSOR_SCRIPT_FILE_NAME = process.platform === 'win32' ? 'cursor-hook.cmd' : 'cursor-hook.sh'
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -EncodedCommand \S+$/
 
 type InstalledCursorHooks = {
   hooks: Record<string, { command?: string }[]>

--- a/src/main/droid/hook-service.test.ts
+++ b/src/main/droid/hook-service.test.ts
@@ -25,7 +25,7 @@ vi.mock('os', async () => {
 import { DroidHookService } from './hook-service'
 
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -EncodedCommand \S+$/
 
 describe('DroidHookService', () => {
   let homeDir: string

--- a/src/main/gemini/hook-service.test.ts
+++ b/src/main/gemini/hook-service.test.ts
@@ -26,7 +26,7 @@ vi.mock('os', async (importOriginal) => {
 import { GeminiHookService } from './hook-service'
 
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -EncodedCommand \S+$/
 
 describe('GeminiHookService', () => {
   let homeDir: string

--- a/src/main/grok/hook-service.test.ts
+++ b/src/main/grok/hook-service.test.ts
@@ -33,7 +33,7 @@ import { POSIX_HOOK_STDIN_READER } from '../agent-hooks/hook-stdin-contract'
 
 const GROK_SCRIPT_FILE_NAME = process.platform === 'win32' ? 'grok-hook.cmd' : 'grok-hook.sh'
 const WINDOWS_POWERSHELL_LAUNCHER =
-  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -WindowStyle Hidden -EncodedCommand \S+$/
+  /^[A-Za-z]:\/[^"]*\/System32\/WindowsPowerShell\/v1\.0\/powershell\.exe -NoProfile -EncodedCommand \S+$/
 
 // Why (#14828): Windows registers the bare script path when it is cmd-safe and only falls back
 // to the encoded launcher for a profile path that is not (#6078). windows-hook-launcher-chain


### PR DESCRIPTION
<!-- orca-pr-loc -->
<!-- Programmatic LoC summary. Do not edit by hand; rewritten on every commit. -->

| | Files | Added | Deleted | Net |
| :--- | ---: | ---: | ---: | ---: |
| Test | 9 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​36 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​36 | 0 |
| Prod | 2 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​25 | $\color{#cf222e}{\Huge{\mathbf{−}}}$​17 | $\color{#1a7f37}{\Huge{\mathbf{+}}}$​8 |

<!-- /orca-pr-loc -->

## Summary

`-WindowStyle Hidden` + `-EncodedCommand` is denied at **CreateProcess** by Kaspersky on Windows 11, whatever the payload decodes to — `exit 0` is denied too. Bash surfaces it as `Permission denied` (exit 126), so **every managed hook event fails** and agent status never arrives. Worse, right after a denied call the parent bash briefly cannot spawn anything (`dofork: child -1 … errno 13`), so a denied hook can take the user's *next* command down with it.

This removes `-WindowStyle Hidden` from the shared launcher switch constant. The command line becomes `powershell.exe -NoProfile -EncodedCommand <b64>`.

Fixes #16003. Reported again via user feedback as STA-5237.

## Why this flag, and why #16576 did not fix it

Measured on the reporting host with a harmless `exit 0` payload:

| command line | result |
|---|---|
| `-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand` | **126** |
| `-NoProfile -WindowStyle Hidden -EncodedCommand` (the post-#16576 shape) | **126** |
| `-WindowStyle Hidden -EncodedCommand` | **126** |
| `-NoProfile -EncodedCommand` | 0 (5/5) |
| `-NoProfile -ExecutionPolicy Bypass -Command` | 0 (5/5) |

#16576 removed `-ExecutionPolicy Bypass` — the one flag of the three **not** in the signature — so hooks kept failing after it landed. That was reported on #16003 after it was closed. The pair that has to stop being spelled is `-WindowStyle Hidden` + `-EncodedCommand`.

Reproducible without Orca or any agent CLI, in Git Bash:

```bash
P=C:/WINDOWS/System32/WindowsPowerShell/v1.0/powershell.exe
E=$(printf 'exit 0' | iconv -t UTF-16LE | base64 -w0)
"$P" -NoProfile -EncodedCommand $E                      # rc 0
"$P" -NoProfile -WindowStyle Hidden -EncodedCommand $E   # rc 126
```

**This is a regression, not a long-standing condition.** The PowerShell launcher shipped in **v1.4.187** (2026-08-21) via #14825, replacing `conhost --headless cmd /d /c`. `git merge-base --is-ancestor 02ba70a847 v1.4.186` is false; v1.4.187 is true. The reporter is on v1.4.188, cut 2026-08-22.

## Scope

Because the change is to the shared constant, it covers every site spelling the denied pair in one edit — Claude via `wrapWindowsPowerShellEncodedCommand` (`hook-settings.ts:176`), gemini/cursor/droid/command-code/copilot via `wrapWindowsHookCommand`, the `runtime-home-hook-command.ts:28` unsafe-`HOME` fallback, and the spaced-path fallback for codex/grok/devin/antigravity. No agent is left behind, and there is no follow-up needed for the others. (Kimi is unaffected: it ships a Git Bash `.sh` and never emits PowerShell.)

Only a **flag** is removed, so parser and payload compatibility is unchanged for every executor that reads `~/.claude/settings.json` — Git Bash, PowerShell (Claude Code's documented fallback when Git Bash is absent), and the command-line/argv[0] spawn used by cursor-agent, Devin, and Grok's Claude-compat import. The string is still a PowerShell command line, still one self-contained `command` with no `args`, still base64-shielded.

## The tradeoff, stated plainly

`-WindowStyle Hidden` was the shipped fix for #14815 (+ #14828, #15117, #15447, #15767) and this removes it. What the record shows about that flag:

- **Its suppression was never measured.** #14825's support is "confirmed visually on a live Windows build"; #16576's author states it "remain[s] unverified on a real box"; #15506's author argues it cannot help a `.cmd` child that has no console to inherit.
- **The console is allocated by the parent chain, not by this command line** — which is why the `CREATE_NO_WINDOW` vs `DETACHED_PROCESS` discriminator mattered for Grok in #15595.
- **Dropping it is not a general AV escape either.** Two other Orca `-EncodedCommand` sites carry no hidden-window flag and are flagged anyway: the worktree setup runner (#14233, AhnLab V3) and the OSC 133 bootstrap (#16629, enterprise EDR). Those remain open and unowned; this PR does not widen to them.

A console flicker is a worse outcome than no flicker — but a far better one than every hook failing plus the parent shell being unable to spawn the user's next command.

## Window gate: MEASURED, and it clears

The open question was whether removing `-WindowStyle Hidden` lets a console appear per hook event.
It was measured on **Windows 11 build 26200** — the same build as the #16003 reporters — in an
isolated Orca Electron instance, with each arm resetting its sampler and **requiring a non-zero hook
fire before any window count was accepted** (a zero-window reading from a hook that never ran is
indistinguishable from success):

| Chain | Fire proof, no flag | Fire proof, with flag | New `ConsoleWindowClass` HWNDs | Foreground steals |
|---|---|---|---:|---:|
| Claude Git Bash | hook-origin completion | hook-origin completion | 0 / 0 | 0 / 0 |
| Claude PowerShell fallback | hook-origin completion | hook-origin completion | 0 / 0 | 0 / 0 |
| Cursor registered command | listener POST delta 2 | listener POST delta 2 | 0 / 0 | 0 / 0 |
| Grok | hook-origin completion | hook-origin completion | 0 / 0 | 0 / 0 |
| AV exit codes, Kaspersky host | — | — | 126 with flag, 0 (5/5) without | reporter-measured |

**No console appears either way.** That is consistent with #15506's argument that the flag could not
have been suppressing the console for the `.cmd` child, and with #16576's author stating the
suppression was never verified on a real box.

Two limits stated rather than glossed:

- **This is one host and one parent chain.** A console is allocated by the parent, not by this
  command line, so the result is evidence for this configuration, not a universal claim.
- **The Cursor row measured the registered command, not cursor-agent as the spawning parent** — the
  Cursor TUI was blocked on login. Fire proof is a listener POST delta of 2 on both arms, so the
  command demonstrably ran; but the parent chain was not Cursor's own.

An anti-restoration mutation check confirms the guard works: restoring `-WindowStyle Hidden` makes
the launcher test fail.

## Tests

- `windows-powershell-hook-launcher.test.ts` — asserts the command line spells neither `-ExecutionPolicy` nor `-WindowStyle`, and pins the exact shape. This is an **anti-restoration guard**, not proof of the fix: #16576 round 3 dropped `-WindowStyle Hidden` by accident and updated the tests to match, so nothing caught it.
- 10 pinned shape sites updated. The set is derivable, not hand-maintained: `grep -rn "WindowStyle" src/ --include='*.ts'` must return hits only in the launcher source itself.
- `managed-hook-timeout.test.ts` deliberately **not** touched — its carrier predicate keys on `-EncodedCommand`, which does not change.
- Adds `windows-hook-payload-delivery.test.ts` to the PR CI Windows leg, which had never run it.

```
pnpm exec vitest run --config config/vitest.config.ts <14 hook suites>   # 144 passed, 20 skipped
pnpm run typecheck:node                                                   # clean
oxlint + oxfmt on changed files                                           # clean
```

Windows-only live suites (`windows-hook-payload-delivery`, `managed-hook-stdin-lifecycle`) were **not** executed — this machine is macOS.

