### PR TITLE
fix(cli): reject empty terminals and recover stripped deps

### DIFF
--- a/src/cli/handlers/orchestration-task-create-cli.test.ts
+++ b/src/cli/handlers/orchestration-task-create-cli.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const callMock = vi.hoisted(() => vi.fn())
+const getTerminalHandleMock = vi.hoisted(() => vi.fn())
+const originalTerminalHandle = process.env.ORCA_TERMINAL_HANDLE
+
+// Why: isolate flag-to-RPC mapping; printResult only writes output.
+vi.mock('../format', () => ({ printResult: vi.fn() }))
+vi.mock('../selectors', () => ({ getTerminalHandle: getTerminalHandleMock }))
+
+import { ORCHESTRATION_HANDLERS } from './orchestration'
+
+describe('orchestration task-create CLI mapping', () => {
+  beforeEach(() => {
+    callMock.mockReset()
+    getTerminalHandleMock.mockReset()
+    process.env.ORCA_TERMINAL_HANDLE = 'term_creator'
+  })
+
+  afterEach(() => {
+    if (originalTerminalHandle === undefined) {
+      delete process.env.ORCA_TERMINAL_HANDLE
+    } else {
+      process.env.ORCA_TERMINAL_HANDLE = originalTerminalHandle
+    }
+  })
+
+  it('passes PowerShell-stripped deps through to the runtime', async () => {
+    callMock
+      .mockResolvedValueOnce({ result: { terminal: { handle: 'term_creator' } } })
+      .mockResolvedValueOnce({ result: { task: { id: 'task_2', status: 'pending' } } })
+
+    await ORCHESTRATION_HANDLERS['orchestration task-create']({
+      flags: new Map<string, string | boolean>([
+        ['spec', 'do child work'],
+        ['deps', '[task_b2a580db74d8]']
+      ]),
+      client: { call: callMock },
+      cwd: '/tmp/repo',
+      json: true
+    } as never)
+
+    expect(callMock).toHaveBeenNthCalledWith(2, 'orchestration.taskCreate', {
+      spec: 'do child work',
+      taskTitle: undefined,
+      displayName: undefined,
+      deps: '[task_b2a580db74d8]',
+      parent: undefined,
+      run: undefined,
+      callerTerminalHandle: 'term_creator'
+    })
+    expect(getTerminalHandleMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/cli/selectors.test.ts
+++ b/src/cli/selectors.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RuntimeClient } from './runtime-client'
+import { getTerminalHandle } from './selectors'
+
+describe('getTerminalHandle', () => {
+  it('uses the active terminal only when --terminal is omitted', async () => {
+    const call = vi.fn().mockResolvedValue({ result: { handle: 'term_active' } })
+
+    await expect(
+      getTerminalHandle(new Map(), '/tmp/worktree', {
+        isRemote: true,
+        call
+      } as unknown as RuntimeClient)
+    ).resolves.toBe('term_active')
+
+    expect(call).toHaveBeenCalledWith('terminal.resolveActive', { worktree: undefined })
+  })
+
+  it('rejects an explicitly empty --terminal before resolving the active terminal', async () => {
+    const call = vi.fn()
+
+    await expect(
+      getTerminalHandle(new Map([['terminal', '']]), '/tmp/worktree', {
+        isRemote: true,
+        call
+      } as unknown as RuntimeClient)
+    ).rejects.toMatchObject({ code: 'invalid_argument' })
+
+    expect(call).not.toHaveBeenCalled()
+  })
+
+  it('rejects a bare --terminal flag before resolving the active terminal', async () => {
+    const call = vi.fn()
+
+    await expect(
+      getTerminalHandle(new Map([['terminal', true]]), '/tmp/worktree', {
+        isRemote: true,
+        call
+      } as unknown as RuntimeClient)
+    ).rejects.toMatchObject({ code: 'invalid_argument' })
+
+    expect(call).not.toHaveBeenCalled()
+  })
+})

--- a/src/cli/selectors.ts
+++ b/src/cli/selectors.ts
@@ -150,9 +150,12 @@ export async function getTerminalHandle(
   cwd: string,
   client: RuntimeClient
 ): Promise<string> {
-  const explicit = getOptionalStringFlag(flags, 'terminal')
-  if (explicit) {
-    return explicit
+  const explicit = flags.get('terminal')
+  if (explicit !== undefined) {
+    if (typeof explicit === 'string' && explicit.length > 0) {
+      return explicit
+    }
+    throw new RuntimeClientError('invalid_argument', 'Missing required --terminal')
   }
   const worktree = await getBrowserWorktreeSelector(flags, cwd, client)
   const response = await client.call<{ handle: string }>('terminal.resolveActive', { worktree })

--- a/src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts
@@ -52,6 +52,18 @@ describe('orchestration RPC methods', () => {
       expect(result.task.status).toBe('pending')
     })
 
+    it('creates a task with PowerShell-stripped JSON string deps', async () => {
+      setup()
+      const t1 = db.createTask({ spec: 'first' })
+
+      const result = (await call('orchestration.taskCreate', {
+        spec: 'second',
+        deps: `[${t1.id}]`
+      })) as { task: { status: string } }
+
+      expect(result.task.status).toBe('pending')
+    })
+
     it('records the caller pane, process, and Run generation when creating a task', async () => {
       setup()
       vi.spyOn(runtime, 'getTerminalPaneKey').mockImplementation((handle) =>

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -220,6 +220,37 @@ const TaskCreateParams = z.object({
   run: OptionalString
 })
 
+const GENERATED_TASK_ID_PATTERN = /^task_[0-9a-f]{12}$/i
+
+function parseTaskCreateDeps(rawDeps: string): string[] {
+  try {
+    const parsed: unknown = JSON.parse(rawDeps)
+    if (!Array.isArray(parsed) || !parsed.every((d) => typeof d === 'string')) {
+      throw new Error('not an array of strings')
+    }
+    return parsed
+  } catch {
+    const argvStripped = parseArgvStrippedTaskDeps(rawDeps)
+    if (argvStripped) {
+      return argvStripped
+    }
+    throw new Error('Invalid --deps: must be a JSON array of task IDs')
+  }
+}
+
+function parseArgvStrippedTaskDeps(rawDeps: string): string[] | null {
+  const trimmed = rawDeps.trim()
+  if (!trimmed.startsWith('[') || !trimmed.endsWith(']')) {
+    return null
+  }
+  const body = trimmed.slice(1, -1).trim()
+  if (body.length === 0) {
+    return []
+  }
+  const deps = body.split(',').map((entry) => entry.trim())
+  return deps.every((dep) => GENERATED_TASK_ID_PATTERN.test(dep)) ? deps : null
+}
+
 const TaskListParams = z.object({
   status: z.enum(['pending', 'ready', 'dispatched', 'completed', 'failed', 'blocked']).optional(),
   ready: OptionalBoolean,
@@ -1480,15 +1511,7 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
       const db = runtime.getOrchestrationDb()
       let deps: string[] | undefined
       if (params.deps) {
-        try {
-          const parsed = JSON.parse(params.deps)
-          if (!Array.isArray(parsed) || !parsed.every((d) => typeof d === 'string')) {
-            throw new Error('not an array of strings')
-          }
-          deps = parsed
-        } catch {
-          throw new Error('Invalid --deps: must be a JSON array of task IDs')
-        }
+        deps = parseTaskCreateDeps(params.deps)
       }
       const run = resolveRunScope(runtime, {
         runId: params.run,


### PR DESCRIPTION
## ELI5

Two CLI edge cases now fail or recover predictably: an explicit empty terminal handle no longer silently targets another active pane, and PowerShell-stripped task dependency arrays are accepted when they still contain valid generated task IDs.

## What Changed

- Treat `--terminal ""` and bare `--terminal` as invalid input instead of falling back to the active terminal.
- Keep omitted `--terminal` behavior unchanged: it still resolves the active terminal in the current worktree.
- Parse `orchestration task-create --deps [task_<hex>]` as a fallback for the Windows PowerShell path where JSON quotes can be stripped before reaching the runtime.
- Add CLI/RPC regression coverage for both behaviors.

## Why

An explicitly empty terminal handle is usually a script bug, not the same thing as omitting the flag. Failing closed prevents scripts from accidentally reading, waiting on, or acting against the wrong live pane.

For `--deps`, the normal JSON array path remains the primary contract. The fallback is intentionally narrow: it only accepts bracketed, comma-separated generated task IDs matching `task_[0-9a-f]{12}`, so malformed values still fail instead of broadening the accepted input shape.

## Linked Issue

Fixes #16694
Fixes #16706

## Visual Proof

N/A — CLI/runtime behavior only; no UI or visual change.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Local checks run on Windows workspace:

- `pnpm exec vitest run --config config/vitest.config.ts src/cli/selectors.test.ts src/cli/handlers/orchestration-task-create-cli.test.ts src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts src/cli/handlers/terminal.test.ts --reporter=dot`
- `pnpm exec oxlint src/cli/selectors.ts src/cli/selectors.test.ts src/cli/handlers/orchestration-task-create-cli.test.ts src/main/runtime/rpc/methods/orchestration.ts src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts`
- `pnpm exec oxfmt --check src/cli/selectors.ts src/cli/selectors.test.ts src/cli/handlers/orchestration-task-create-cli.test.ts src/main/runtime/rpc/methods/orchestration.ts src/main/runtime/rpc/methods/orchestration-tasks-dispatch.test.ts`
- `pnpm run typecheck:cli`
- `pnpm run typecheck:node`

Note: local typechecks emitted the existing engine warning because this environment uses Node v22.23.1 while the package declares Node 24.

## AI Disclosure

Implemented with GPT-5 Codex assistance under user direction. I inspected the linked issues, made the changes, and ran the checks listed above.

## Review

Ready for maintainer review.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security: fails closed for explicit empty terminal identifiers. Cross-platform: preserves normal JSON deps and adds a Windows PowerShell-specific recovery path without changing macOS/Linux behavior. Remote/SSH: changes are at the CLI/RPC validation boundary and do not introduce provider-specific assumptions. Backwards compatibility: omitted `--terminal` behavior is unchanged; invalid explicit terminal input now errors instead of silently falling back.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
