### PR TITLE
fix(cli): reject empty terminal handles

### DIFF
--- a/src/cli/selectors.test.ts
+++ b/src/cli/selectors.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RuntimeClient } from './runtime-client'
+import { getTerminalHandle } from './selectors'
+
+describe('getTerminalHandle', () => {
+  it('uses the active terminal only when --terminal is omitted', async () => {
+    const call = vi.fn().mockResolvedValue({ result: { handle: 'term_active' } })
+
+    await expect(
+      getTerminalHandle(new Map(), '/tmp/worktree', {
+        isRemote: true,
+        call
+      } as unknown as RuntimeClient)
+    ).resolves.toBe('term_active')
+
+    expect(call).toHaveBeenCalledWith('terminal.resolveActive', { worktree: undefined })
+  })
+
+  it('rejects an explicitly empty --terminal before resolving the active terminal', async () => {
+    const call = vi.fn()
+
+    await expect(
+      getTerminalHandle(new Map([['terminal', '']]), '/tmp/worktree', {
+        isRemote: true,
+        call
+      } as unknown as RuntimeClient)
+    ).rejects.toMatchObject({ code: 'invalid_argument' })
+
+    expect(call).not.toHaveBeenCalled()
+  })
+
+  it('rejects a bare --terminal flag before resolving the active terminal', async () => {
+    const call = vi.fn()
+
+    await expect(
+      getTerminalHandle(new Map([['terminal', true]]), '/tmp/worktree', {
+        isRemote: true,
+        call
+      } as unknown as RuntimeClient)
+    ).rejects.toMatchObject({ code: 'invalid_argument' })
+
+    expect(call).not.toHaveBeenCalled()
+  })
+})

--- a/src/cli/selectors.ts
+++ b/src/cli/selectors.ts
@@ -150,9 +150,12 @@ export async function getTerminalHandle(
   cwd: string,
   client: RuntimeClient
 ): Promise<string> {
-  const explicit = getOptionalStringFlag(flags, 'terminal')
-  if (explicit) {
-    return explicit
+  const explicit = flags.get('terminal')
+  if (explicit !== undefined) {
+    if (typeof explicit === 'string' && explicit.length > 0) {
+      return explicit
+    }
+    throw new RuntimeClientError('invalid_argument', 'Missing required --terminal')
   }
   const worktree = await getBrowserWorktreeSelector(flags, cwd, client)
   const response = await client.call<{ handle: string }>('terminal.resolveActive', { worktree })


### PR DESCRIPTION
## ELI5

If a script explicitly says "use this terminal" but passes an empty value, Orca now stops with an error instead of quietly picking some active pane.

## What Changed

- Treat `--terminal ""` and bare `--terminal` as invalid input.
- Keep omitted `--terminal` behavior unchanged: commands may still resolve the active terminal in the current worktree.
- Add focused coverage for omitted, empty, and bare `--terminal` handling.

## Why

An explicit empty handle usually means a script variable failed to populate. Falling back to the active terminal can make the command read or wait on a different pane than intended. Failing closed is safer and makes the bug visible at the CLI boundary.

## Linked Issue

Fixes #16694

## Visual Proof

N/A — CLI behavior only; no UI or visual change.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Local checks run on Windows workspace:

- `pnpm exec vitest run --config config/vitest.config.ts src/cli/selectors.test.ts src/cli/handlers/terminal.test.ts --reporter=dot`
- `pnpm exec oxlint src/cli/selectors.ts src/cli/selectors.test.ts`
- `pnpm exec oxfmt --check src/cli/selectors.ts src/cli/selectors.test.ts`
- `pnpm run typecheck:cli`

Note: local typecheck emitted the existing engine warning because this environment uses Node v22.23.1 while the package declares Node 24.

## AI Disclosure

Implemented with GPT-5 Codex assistance under user direction. I inspected the linked issue, made the focused change, and ran the checks listed above.

## Review

Ready for maintainer review.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Security: fail-closed behavior avoids accidental access to the wrong terminal pane. Cross-platform: this is CLI flag handling and does not introduce OS-specific path or shortcut assumptions. SSH/remote: omitted fallback remains unchanged; explicit empty terminal identifiers now fail before resolving any terminal.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
