### PR TITLE
fix(browser): let a live text selection keep Cmd+C

### DIFF
--- a/src/renderer/src/components/browser-pane/host-guest/browser-keyboard.test.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/browser-keyboard.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment happy-dom
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { hasHostTextSelection, isEditableKeyboardTarget } from './browser-keyboard'
+import {
+  hasHostTextSelection,
+  isEditableKeyboardTarget,
+  isNativeCopyChord
+} from './browser-keyboard'
 
 // Why: the old fakes passed a single joined selector to `closest`, so any
 // `selector.includes(token)` check matched every token. Use the real DOM instead.
@@ -100,5 +104,44 @@ describe('hasHostTextSelection', () => {
 
     window.getSelection()?.removeAllRanges()
     expect(hasHostTextSelection()).toBe(false)
+  })
+})
+
+describe('isNativeCopyChord', () => {
+  const chord = (over: Partial<KeyboardEvent> = {}): KeyboardEvent =>
+    ({
+      key: 'c',
+      metaKey: false,
+      ctrlKey: false,
+      altKey: false,
+      shiftKey: false,
+      ...over
+    }) as KeyboardEvent
+
+  it('recognizes the platform copy chord', () => {
+    expect(isNativeCopyChord(chord({ metaKey: true }), 'darwin')).toBe(true)
+    expect(isNativeCopyChord(chord({ ctrlKey: true }), 'win32')).toBe(true)
+    expect(isNativeCopyChord(chord({ ctrlKey: true }), 'linux')).toBe(true)
+  })
+
+  it('rejects the other platform primary modifier', () => {
+    expect(isNativeCopyChord(chord({ ctrlKey: true }), 'darwin')).toBe(false)
+    expect(isNativeCopyChord(chord({ metaKey: true }), 'win32')).toBe(false)
+  })
+
+  it('rejects a different key', () => {
+    expect(isNativeCopyChord(chord({ key: 'g', metaKey: true }), 'darwin')).toBe(false)
+  })
+
+  // Why: Ctrl+Shift+C and Alt variants are their own bindings, not the document copy chord, so a
+  // grab shortcut mapped to one of them keeps working with text selected.
+  it('rejects added Alt or Shift', () => {
+    expect(isNativeCopyChord(chord({ metaKey: true, shiftKey: true }), 'darwin')).toBe(false)
+    expect(isNativeCopyChord(chord({ metaKey: true, altKey: true }), 'darwin')).toBe(false)
+    expect(isNativeCopyChord(chord({ ctrlKey: true, shiftKey: true }), 'linux')).toBe(false)
+  })
+
+  it('rejects a bare key with no primary modifier', () => {
+    expect(isNativeCopyChord(chord(), 'darwin')).toBe(false)
   })
 })

--- a/src/renderer/src/components/browser-pane/host-guest/browser-keyboard.test.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/browser-keyboard.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { isEditableKeyboardTarget } from './browser-keyboard'
+import { hasHostTextSelection, isEditableKeyboardTarget } from './browser-keyboard'
 
 // Why: the old fakes passed a single joined selector to `closest`, so any
 // `selector.includes(token)` check matched every token. Use the real DOM instead.
@@ -65,5 +65,40 @@ describe('isEditableKeyboardTarget', () => {
 
   it('returns false for a null target', () => {
     expect(isEditableKeyboardTarget(null)).toBe(false)
+  })
+})
+
+describe('hasHostTextSelection', () => {
+  it('returns true for a non-collapsed selection with text', () => {
+    expect(hasHostTextSelection({ isCollapsed: false, toString: () => 'copied prose' })).toBe(true)
+  })
+
+  it('returns false for a collapsed caret', () => {
+    expect(hasHostTextSelection({ isCollapsed: true, toString: () => '' })).toBe(false)
+  })
+
+  // Why: a range can span layout whitespace between elements without selecting any text the user
+  // would recognize as copied, and suppressing the shortcut for that would look like a dead key.
+  it('returns false for a whitespace-only selection', () => {
+    expect(hasHostTextSelection({ isCollapsed: false, toString: () => '  \n ' })).toBe(false)
+  })
+
+  it('returns false when there is no selection', () => {
+    expect(hasHostTextSelection(null)).toBe(false)
+  })
+
+  it('reads the live document selection by default', () => {
+    const host = document.createElement('p')
+    host.textContent = 'assistant reply'
+    document.body.appendChild(host)
+    const range = document.createRange()
+    range.selectNodeContents(host)
+    window.getSelection()?.removeAllRanges()
+    window.getSelection()?.addRange(range)
+
+    expect(hasHostTextSelection()).toBe(true)
+
+    window.getSelection()?.removeAllRanges()
+    expect(hasHostTextSelection()).toBe(false)
   })
 })

--- a/src/renderer/src/components/browser-pane/host-guest/browser-keyboard.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/browser-keyboard.ts
@@ -3,6 +3,25 @@ type EditableTargetLike = {
   closest?: (selector: string) => unknown
 }
 
+type TextSelectionLike = {
+  isCollapsed?: boolean
+  toString: () => string
+}
+
+// Why: the browser pane's global shortcuts repurpose keys the rest of the app still needs for
+// native copy, and isEditableKeyboardTarget only exempts focusable editors — prose surfaces such
+// as the chat transcript are plain elements it can never match. A live selection is the surface-
+// independent signal that the user is copying text. Guest selections live in the <webview>'s own
+// document and never reach window.getSelection(), so grabbing a page element is unaffected.
+export function hasHostTextSelection(
+  selection: TextSelectionLike | null = typeof window === 'undefined' ? null : window.getSelection()
+): boolean {
+  if (!selection || selection.isCollapsed === true) {
+    return false
+  }
+  return selection.toString().trim() !== ''
+}
+
 export function isEditableKeyboardTarget(target: EventTarget | EditableTargetLike | null): boolean {
   const element =
     target && typeof target === 'object' && ('closest' in target || 'isContentEditable' in target)

--- a/src/renderer/src/components/browser-pane/host-guest/browser-keyboard.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/browser-keyboard.ts
@@ -22,6 +22,19 @@ export function hasHostTextSelection(
   return selection.toString().trim() !== ''
 }
 
+type CopyChordEventLike = Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>
+
+// Why: only a binding that collides with the platform's native copy has a copy to yield to. A grab
+// shortcut rebound to something else — the workaround #12323 recommends — must keep firing with
+// text selected, so the selection exemption is scoped to the copy chord rather than applied to
+// every binding.
+export function isNativeCopyChord(event: CopyChordEventLike, platform: NodeJS.Platform): boolean {
+  if (event.key.toLowerCase() !== 'c' || event.altKey || event.shiftKey) {
+    return false
+  }
+  return platform === 'darwin' ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey
+}
+
 export function isEditableKeyboardTarget(target: EventTarget | EditableTargetLike | null): boolean {
   const element =
     target && typeof target === 'object' && ('closest' in target || 'isContentEditable' in target)

--- a/src/renderer/src/components/browser-pane/host-guest/use-browser-page-keyboard-shortcuts-selection.test.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/use-browser-page-keyboard-shortcuts-selection.test.ts
@@ -5,7 +5,7 @@ import { renderHook } from '@testing-library/react'
 const { getShortcutPlatformMock, useAppStoreMock, useBrowserPageWebviewShortcutsMock } = vi.hoisted(
   () => ({
     getShortcutPlatformMock: vi.fn(() => 'darwin' as NodeJS.Platform),
-    useAppStoreMock: vi.fn(() => undefined),
+    useAppStoreMock: vi.fn((_selector?: (state: unknown) => unknown): unknown => undefined),
     useBrowserPageWebviewShortcutsMock: vi.fn()
   })
 )
@@ -19,6 +19,13 @@ vi.mock('./use-browser-page-webview-shortcuts', () => ({
 import { useBrowserPageKeyboardShortcuts } from './use-browser-page-keyboard-shortcuts'
 
 const startGrabIntent = vi.fn()
+
+/** Mirrors the store selector the hook uses: `useAppStore((s) => s.keybindings)`. */
+function setKeybindingOverrides(overrides: Record<string, string[]> | undefined): void {
+  useAppStoreMock.mockImplementation((selector?: (state: unknown) => unknown) =>
+    selector ? selector({ keybindings: overrides }) : undefined
+  )
+}
 
 function renderShortcuts(): void {
   renderHook(() =>
@@ -64,6 +71,7 @@ function pressGrabShortcut(target: EventTarget): void {
 describe('useBrowserPageKeyboardShortcuts — grab shortcut vs host text selection', () => {
   beforeEach(() => {
     startGrabIntent.mockClear()
+    setKeybindingOverrides(undefined)
     ;(window as unknown as { api: unknown }).api = {
       browser: {
         onGrabModeToggle: vi.fn(() => vi.fn()),
@@ -112,6 +120,21 @@ describe('useBrowserPageKeyboardShortcuts — grab shortcut vs host text selecti
     renderShortcuts()
 
     pressGrabShortcut(prose)
+
+    expect(startGrabIntent).toHaveBeenCalledWith('copy')
+  })
+
+  // Why: #12323's own workaround is to rebind Grab Page Element off Cmd+C. A chord that does not
+  // collide with native copy has no copy to yield to, so a stray selection must not disable it.
+  it('still arms a grab shortcut rebound off the copy chord while text is selected', () => {
+    setKeybindingOverrides({ 'browser.grabElement': ['Mod+G'] })
+    const prose = mountTranscriptProse()
+    renderShortcuts()
+    selectAcross(prose)
+
+    prose.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'g', metaKey: true, bubbles: true, cancelable: true })
+    )
 
     expect(startGrabIntent).toHaveBeenCalledWith('copy')
   })

--- a/src/renderer/src/components/browser-pane/host-guest/use-browser-page-keyboard-shortcuts-selection.test.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/use-browser-page-keyboard-shortcuts-selection.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+const { getShortcutPlatformMock, useAppStoreMock, useBrowserPageWebviewShortcutsMock } = vi.hoisted(
+  () => ({
+    getShortcutPlatformMock: vi.fn(() => 'darwin' as NodeJS.Platform),
+    useAppStoreMock: vi.fn(() => undefined),
+    useBrowserPageWebviewShortcutsMock: vi.fn()
+  })
+)
+
+vi.mock('@/hooks/useShortcutLabel', () => ({ getShortcutPlatform: getShortcutPlatformMock }))
+vi.mock('@/store', () => ({ useAppStore: useAppStoreMock }))
+vi.mock('./use-browser-page-webview-shortcuts', () => ({
+  useBrowserPageWebviewShortcuts: useBrowserPageWebviewShortcutsMock
+}))
+
+import { useBrowserPageKeyboardShortcuts } from './use-browser-page-keyboard-shortcuts'
+
+const startGrabIntent = vi.fn()
+
+function renderShortcuts(): void {
+  renderHook(() =>
+    useBrowserPageKeyboardShortcuts({
+      browserTabId: 'tab-1',
+      isActive: true,
+      isActiveRef: { current: true },
+      markupIsActive: false,
+      webviewRef: { current: null },
+      paneZoomLevelRef: { current: 0 },
+      setBrowserDefaultZoomLevel: vi.fn(),
+      showBrowserZoomFeedback: vi.fn(),
+      reloadWebviewOrRecoverGuest: vi.fn(),
+      startGrabIntent,
+      handleGrabActionShortcut: vi.fn(),
+      grabIsInteractive: false
+    })
+  )
+}
+
+/** Chat transcript prose: a plain paragraph, matching none of the editable-host selectors. */
+function mountTranscriptProse(): HTMLElement {
+  const host = document.createElement('div')
+  host.innerHTML = '<p id="prose">assistant reply worth copying</p>'
+  document.body.appendChild(host)
+  return host.querySelector('#prose') as HTMLElement
+}
+
+function selectAcross(node: Node): void {
+  const range = document.createRange()
+  range.selectNodeContents(node)
+  const selection = window.getSelection()
+  selection?.removeAllRanges()
+  selection?.addRange(range)
+}
+
+function pressGrabShortcut(target: EventTarget): void {
+  target.dispatchEvent(
+    new KeyboardEvent('keydown', { key: 'c', metaKey: true, bubbles: true, cancelable: true })
+  )
+}
+
+describe('useBrowserPageKeyboardShortcuts — grab shortcut vs host text selection', () => {
+  beforeEach(() => {
+    startGrabIntent.mockClear()
+    ;(window as unknown as { api: unknown }).api = {
+      browser: {
+        onGrabModeToggle: vi.fn(() => vi.fn()),
+        onGrabActionShortcut: vi.fn(() => vi.fn())
+      }
+    }
+  })
+
+  afterEach(() => {
+    window.getSelection()?.removeAllRanges()
+    document.body.innerHTML = ''
+  })
+
+  // Why: the transcript is plain prose, so isEditableKeyboardTarget cannot exempt it. Without a
+  // selection check the pane-active listener eats Cmd+C and arms the picker instead of copying.
+  it('yields Cmd+C to a live selection in the host document', () => {
+    const prose = mountTranscriptProse()
+    renderShortcuts()
+    selectAcross(prose)
+
+    pressGrabShortcut(prose)
+
+    expect(startGrabIntent).not.toHaveBeenCalled()
+  })
+
+  it('does not swallow the keydown when it yields', () => {
+    const prose = mountTranscriptProse()
+    renderShortcuts()
+    selectAcross(prose)
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'c',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true
+    })
+    prose.dispatchEvent(event)
+
+    expect(event.defaultPrevented).toBe(false)
+  })
+
+  // Why: guest selections live in the <webview>'s own document and never reach
+  // window.getSelection(), so grabbing a page element must still work as before.
+  it('still arms grab when nothing is selected in the host document', () => {
+    const prose = mountTranscriptProse()
+    renderShortcuts()
+
+    pressGrabShortcut(prose)
+
+    expect(startGrabIntent).toHaveBeenCalledWith('copy')
+  })
+
+  it('still arms grab when the selection is collapsed', () => {
+    const prose = mountTranscriptProse()
+    renderShortcuts()
+    const range = document.createRange()
+    range.setStart(prose.firstChild as Node, 3)
+    range.collapse(true)
+    const selection = window.getSelection()
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+
+    pressGrabShortcut(prose)
+
+    expect(startGrabIntent).toHaveBeenCalledWith('copy')
+  })
+})

--- a/src/renderer/src/components/browser-pane/host-guest/use-browser-page-keyboard-shortcuts.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/use-browser-page-keyboard-shortcuts.ts
@@ -2,7 +2,11 @@ import { useEffect, type MutableRefObject } from 'react'
 import { getShortcutPlatform } from '@/hooks/useShortcutLabel'
 import { useAppStore } from '@/store'
 import { keybindingMatchesAction } from '../../../../../shared/keybindings'
-import { hasHostTextSelection, isEditableKeyboardTarget } from './browser-keyboard'
+import {
+  hasHostTextSelection,
+  isEditableKeyboardTarget,
+  isNativeCopyChord
+} from './browser-keyboard'
 import { useBrowserPageWebviewShortcuts } from './use-browser-page-webview-shortcuts'
 import type { GrabIntent } from '../describe-page/browser-page-types'
 
@@ -58,17 +62,18 @@ export function useBrowserPageKeyboardShortcuts({
       if (isEditableKeyboardTarget(e.target)) {
         return
       }
-      // Why: a live selection in the host document means the user is copying prose — chat
-      // transcript rows are plain elements no editable-host selector can cover, and this pane's
-      // listener is gated on being active rather than focused, so it would otherwise eat their Cmd+C.
-      if (hasHostTextSelection()) {
-        return
-      }
       // Why: don't start the in-guest picker behind an open markup overlay (matches the disabled toolbar buttons).
       if (
         !markupIsActive &&
         keybindingMatchesAction('browser.grabElement', e, shortcutPlatform, keybindings)
       ) {
+        // Why: a live selection in the host document means the user is copying prose — chat
+        // transcript rows are plain elements no editable-host selector can cover, and this listener
+        // is gated on the pane being active rather than focused, so it would otherwise eat their
+        // copy. Scoped to the copy chord so a rebound grab shortcut still fires with text selected.
+        if (isNativeCopyChord(e, shortcutPlatform) && hasHostTextSelection()) {
+          return
+        }
         e.preventDefault()
         startGrabIntent('copy')
       }

--- a/src/renderer/src/components/browser-pane/host-guest/use-browser-page-keyboard-shortcuts.ts
+++ b/src/renderer/src/components/browser-pane/host-guest/use-browser-page-keyboard-shortcuts.ts
@@ -2,7 +2,7 @@ import { useEffect, type MutableRefObject } from 'react'
 import { getShortcutPlatform } from '@/hooks/useShortcutLabel'
 import { useAppStore } from '@/store'
 import { keybindingMatchesAction } from '../../../../../shared/keybindings'
-import { isEditableKeyboardTarget } from './browser-keyboard'
+import { hasHostTextSelection, isEditableKeyboardTarget } from './browser-keyboard'
 import { useBrowserPageWebviewShortcuts } from './use-browser-page-webview-shortcuts'
 import type { GrabIntent } from '../describe-page/browser-page-types'
 
@@ -56,6 +56,12 @@ export function useBrowserPageKeyboardShortcuts({
     const handleKeyDown = (e: KeyboardEvent): void => {
       // Why: don't intercept in editable targets so native Cmd+C still copies in inputs/contentEditable.
       if (isEditableKeyboardTarget(e.target)) {
+        return
+      }
+      // Why: a live selection in the host document means the user is copying prose — chat
+      // transcript rows are plain elements no editable-host selector can cover, and this pane's
+      // listener is gated on being active rather than focused, so it would otherwise eat their Cmd+C.
+      if (hasHostTextSelection()) {
         return
       }
       // Why: don't start the in-guest picker behind an open markup overlay (matches the disabled toolbar buttons).


### PR DESCRIPTION
## ELI5

The browser pane borrows ⌘C for "grab a page element". It kept borrowing it even while you were selecting text in a chat transcript, so copying from chat silently did nothing. Now a live text selection wins ⌘C, and grabbing still works exactly as before when nothing is selected.

## What Changed

- New `hasHostTextSelection()` in `browser-pane/host-guest/browser-keyboard.ts` — true when the host document carries a non-collapsed, non-whitespace selection. Takes an optional selection so it is testable, defaults to `window.getSelection()`.
- New `isNativeCopyChord()` in the same file — whether an event is the platform's document copy chord (`Cmd+C` on darwin, `Ctrl+C` elsewhere, no Alt/Shift).
- `use-browser-page-keyboard-shortcuts.ts` yields the shortcut when both hold, inside the `browser.grabElement` match so only the copy chord is affected.

That is the whole behavior change. The bare `c` / `s` grab-action handler is untouched: it only runs once grab is armed, and this stops the bad arming at the source.

## Why

`browser.grabElement` defaults to `Mod+C`. Its listener is `window`-level and gated on the pane being **active, not focused**, so it runs while the user is working anywhere else in the app. Its only exemption is `isEditableKeyboardTarget`, whose selector list is all focusable editors:

```
input, textarea, select, [contenteditable], .monaco-editor, .diff-editor,
.rich-markdown-editor, .rich-markdown-editor-shell
```

Chat transcript rows are plain prose elements, so they match none of it and ⌘C is swallowed. The chat composer is a real `<textarea>` and the terminal has xterm's hidden textarea, which is why only the transcript is affected.

#12323 proposed two directions. This is the second one. The first — adding the transcript container to the selector list — fixes chat only and grows a per-surface allowlist that the next prose surface will fall out of again; this is the third time that list has needed a new entry (#2195, and #11348/#11351 for the same shape in Find).

A selection is the surface-independent signal. It also gives the behavior the right shape without special-casing anything:

| where the user is | host `getSelection()` | ⌘C |
|---|---|---|
| clicked into the browser page | not visible — the guest is a separate `<webview>` document, and a focused guest's ⌘C goes through `browser-guest-grab-shortcuts.ts` instead | **grab** (unchanged) |
| browser pane active, nothing selected | collapsed | **grab** (unchanged) |
| text selected in a chat transcript | non-collapsed | **copy** (fixed) |

The exemption is scoped to the copy chord on purpose: a grab shortcut rebound to something else — which is the workaround #12323 recommends — has no native copy to yield to, so it must keep firing with text selected.

Known trade-off: a selection left somewhere else in the host suppresses the default `Mod+C` grab until it is cleared. The address bar is an `<input>` and already exempt, so this is limited to stale prose selections, and clicking anywhere clears it. The issue author called out this trade-off when proposing the direction.

## Linked Issue

Fixes #12323

## Visual Proof

No visual change — the fix is that ⌘C reaches the clipboard instead of arming an overlay, so the "after" is the absence of the grab overlay.

**I was not able to capture an in-app before/after, and I want to be explicit about that rather than imply I did.** In my dev instance the browser pane's window-level shortcut layer never activated for a CLI-created tab: `Cmd+L` (`browser.focusAddressBar`, gated identically) was also inert, so the branch under test could not be reached live no matter what I selected. That is a harness/activation problem, not a statement about the fix.

What supplies that missing link is the report itself: in #12323 and in my own reproduction on **1.4.190**, ⌘C over a chat transcript *is* being eaten while a browser pane is open, and copying works the moment the browser pane is closed. That is direct evidence the listener runs in this situation on a real build — which is exactly the precondition my harness failed to recreate. The guard added here sits inside that same handler, on the branch that matches `browser.grabElement`, so if the handler is armed the guard runs.

## Testing

Final merge base: `026389a3bc`

**Automated** — new `use-browser-page-keyboard-shortcuts-selection.test.ts` renders the real hook and dispatches real `KeyboardEvent`s at a plain `<p>`, with real DOM selections:

| case | expectation |
|---|---|
| live selection over prose | `startGrabIntent` not called |
| live selection over prose | `defaultPrevented === false` (native copy survives) |
| nothing selected | `startGrabIntent('copy')` still called |
| collapsed caret | `startGrabIntent('copy')` still called |
| grab rebound to `Mod+G`, text selected | `startGrabIntent('copy')` still called |

The no-selection and collapsed-caret cases are positive controls: they fail if the listener is not actually being exercised, so the first two cannot pass vacuously. Confirmed RED before the change — the two new-behavior cases failed (grab armed, `defaultPrevented` true) while both controls already passed. The rebind case was likewise confirmed RED against an unscoped guard, where it was the only failure.

Plus unit cases in the existing `browser-keyboard.test.ts`: five for `hasHostTextSelection` (non-collapsed with text, collapsed caret, whitespace-only range, null, reading the live document selection by default) and five for `isNativeCopyChord` (each platform's chord, the opposite platform's primary modifier, a different key, added Alt/Shift, and a bare key).

```
npx vitest run --config config/vitest.config.ts src/renderer/src/components/browser-pane/
# Test Files 85 passed (85) | Tests 686 passed (686)
```

`tsc --noEmit -p config/tsconfig.tc.web.json` clean; oxlint and oxfmt clean on the changed files.

**Platforms:** the shortcut resolves through `keybindingMatchesAction` with `getShortcutPlatform()`, so Windows/Linux take the same branch with `Ctrl` — no platform-specific code was added or changed. Only macOS was exercised.

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Unchecking the manual box deliberately: the automated hook-level coverage is real and the user-facing reproduction is real, but I could not drive the fixed build through the UI myself, per the Visual Proof note above.

## AI Disclosure

Investigated and written with Claude (Opus 5) via Claude Code, then reviewed with Codex (`codex review`), which caught the rebound-shortcut regression addressed in the second commit. The RED/GREEN runs, the suite numbers, and the failed live-verification attempt above are all things that were actually run.

## Review

@OrcaWin — this is assigned to you, so if you already have a fix in progress, say the word and I will close this. Opened it because the issue has been open a while with no linked PR and I hit it myself.
