### PR TITLE
fix(cli): fail closed on empty --terminal handle (#16694)

### DIFF
--- a/src/cli/flags.test.ts
+++ b/src/cli/flags.test.ts
@@ -1,11 +1,21 @@
 import { describe, expect, it } from 'vitest'
 
-import { getRequiredStringFlagAllowingEmpty } from './flags'
+import { getOptionalPresentStringFlag, getRequiredStringFlagAllowingEmpty } from './flags'
 
 describe('CLI flags', () => {
   it('allows required string flags to be empty when the command opts in', () => {
     const flags = new Map<string, string | boolean>([['value', '']])
 
     expect(getRequiredStringFlagAllowingEmpty(flags, 'value')).toBe('')
+  })
+
+  it('treats a missing optional present flag as omitted', () => {
+    expect(getOptionalPresentStringFlag(new Map(), 'terminal')).toBeUndefined()
+  })
+
+  it('rejects an explicit empty optional present flag', () => {
+    expect(() => getOptionalPresentStringFlag(new Map([['terminal', '']]), 'terminal')).toThrow(
+      /non-empty/
+    )
   })
 })

--- a/src/cli/flags.ts
+++ b/src/cli/flags.ts
@@ -28,6 +28,26 @@ export function getOptionalStringFlag(
   return typeof value === 'string' && value.length > 0 ? value : undefined
 }
 
+// Why: `--flag "$VAR"` with an empty expansion is not omission. Callers that
+// treat success as "this value" would otherwise silently fall through.
+export function getOptionalPresentStringFlag(
+  flags: Map<string, string | boolean>,
+  name: string,
+  emptyErrorMessage?: string
+): string | undefined {
+  if (!flags.has(name)) {
+    return undefined
+  }
+  const value = flags.get(name)
+  if (typeof value === 'string' && value.length > 0) {
+    return value
+  }
+  throw new RuntimeClientError(
+    'invalid_argument',
+    emptyErrorMessage ?? `--${name} requires a non-empty value.`
+  )
+}
+
 export function getRepeatedStringFlag(
   flags: Map<string, string | boolean>,
   name: string

--- a/src/cli/handlers/orchestration-check-identity.test.ts
+++ b/src/cli/handlers/orchestration-check-identity.test.ts
@@ -57,6 +57,19 @@ describe('orchestration check identity', () => {
     )
   })
 
+  it('fails closed on an empty --terminal instead of using the ambient handle', async () => {
+    process.env.ORCA_TERMINAL_HANDLE = 'term_stale_env'
+    process.env.ORCA_PANE_KEY = 'tab_coord:leaf_coord'
+
+    await expect(
+      invokeCheck(new Map<string, string | boolean>([['terminal', '']]))
+    ).rejects.toMatchObject({
+      code: 'invalid_argument',
+      message: expect.stringContaining('non-empty handle')
+    })
+    expect(callMock).not.toHaveBeenCalled()
+  })
+
   it('keeps an explicit legacy terminal handle scoped to that handle', async () => {
     process.env.ORCA_TERMINAL_HANDLE = 'term_stale_env'
 

--- a/src/cli/handlers/orchestration/message-check-handler.ts
+++ b/src/cli/handlers/orchestration/message-check-handler.ts
@@ -1,6 +1,6 @@
 import type { CommandHandler } from '../../dispatch'
 import { printResult } from '../../format'
-import { getOptionalStringFlag } from '../../flags'
+import { getOptionalPresentStringFlag, getOptionalStringFlag } from '../../flags'
 import { RuntimeClientError } from '../../runtime-client'
 import type { RuntimeRpcSuccess } from '../../runtime-client'
 import {
@@ -39,7 +39,11 @@ export const ORCHESTRATION_CHECK_HANDLER: Record<string, CommandHandler> = {
       )
     }
     const timeoutMs = getOptionalPositiveIntegerValueFlag(flags, 'timeout-ms')
-    const explicitTerminal = getOptionalStringFlag(flags, 'terminal')
+    const explicitTerminal = getOptionalPresentStringFlag(
+      flags,
+      'terminal',
+      '--terminal requires a non-empty handle. Omit --terminal to use the current terminal.'
+    )
     const terminal = await resolveOrchestrationTerminalHandle(flags, cwd, client, 'terminal')
     const stopKeepalive = wait ? startCheckKeepalive(timeoutMs) : null
     let result: Awaited<ReturnType<typeof client.call<CheckResult>>>

--- a/src/cli/handlers/orchestration/message-inbox-handlers.ts
+++ b/src/cli/handlers/orchestration/message-inbox-handlers.ts
@@ -2,6 +2,7 @@ import type { CommandHandler } from '../../dispatch'
 import { printResult } from '../../format'
 import {
   getOptionalPositiveIntegerFlag,
+  getOptionalPresentStringFlag,
   getOptionalStringFlag,
   getRequiredStringFlag
 } from '../../flags'
@@ -36,7 +37,11 @@ export const ORCHESTRATION_INBOX_HANDLERS: Record<string, CommandHandler> = {
       count: number
     }>('orchestration.inbox', {
       limit: getOptionalPositiveIntegerFlag(flags, 'limit'),
-      terminal: getOptionalStringFlag(flags, 'terminal')
+      terminal: getOptionalPresentStringFlag(
+        flags,
+        'terminal',
+        '--terminal requires a non-empty handle. Omit --terminal to list the current mailbox.'
+      )
     })
     printResult(result, json, (value) => {
       if (value.count === 0) {

--- a/src/cli/handlers/orchestration/terminal-identity.ts
+++ b/src/cli/handlers/orchestration/terminal-identity.ts
@@ -1,7 +1,11 @@
 import type { RuntimeClient } from '../../runtime-client'
-import { getOptionalStringFlag } from '../../flags'
+import { getOptionalPresentStringFlag } from '../../flags'
 import { RuntimeClientError } from '../../runtime-client'
 import { getTerminalHandle } from '../../selectors'
+
+function emptyHandleMessage(flagName: 'from' | 'terminal'): string {
+  return `--${flagName} requires a non-empty handle. Omit --${flagName} to use the current terminal.`
+}
 
 export async function resolveOrchestrationTerminalHandle(
   flags: Map<string, string | boolean>,
@@ -10,7 +14,7 @@ export async function resolveOrchestrationTerminalHandle(
   flagName: 'from' | 'terminal',
   options: { validateEnvHandle?: boolean } = {}
 ): Promise<string> {
-  const explicit = getOptionalStringFlag(flags, flagName)
+  const explicit = getOptionalPresentStringFlag(flags, flagName, emptyHandleMessage(flagName))
   if (explicit) {
     return explicit
   }

--- a/src/cli/handlers/orchestration/worker-launch-handler.ts
+++ b/src/cli/handlers/orchestration/worker-launch-handler.ts
@@ -1,6 +1,10 @@
 import type { CommandHandler } from '../../dispatch'
 import { printResult } from '../../format'
-import { getOptionalStringFlag, getRequiredStringFlag } from '../../flags'
+import {
+  getOptionalPresentStringFlag,
+  getOptionalStringFlag,
+  getRequiredStringFlag
+} from '../../flags'
 import { RuntimeClientError } from '../../runtime-client'
 import type { RuntimeStatus } from '../../../shared/runtime-types'
 import { ORCHESTRATION_WORKER_LAUNCH_PREFERENCES_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
@@ -49,7 +53,11 @@ export const ORCHESTRATION_WORKER_LAUNCH_HANDLER: Record<string, CommandHandler>
       agent: getOptionalStringFlag(flags, 'agent'),
       model,
       effort,
-      terminal: getOptionalStringFlag(flags, 'terminal'),
+      terminal: getOptionalPresentStringFlag(
+        flags,
+        'terminal',
+        '--terminal requires a non-empty handle. Omit --terminal to launch in a new terminal.'
+      ),
       retryOf: getOptionalStringFlag(flags, 'retry-of'),
       timeoutMs: getOptionalPositiveIntegerValueFlag(flags, 'timeout-ms'),
       run: getOptionalStringFlag(flags, 'run'),

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -269,7 +269,7 @@ Common Commands:
 Selectors:
   --repo <selector>         Registered repo selector such as id:<id>, name:<name>, or path:<path>
   --worktree <selector>     Worktree selector such as id:<repo-id>::<path>, name:<displayName>, branch:<branch>, issue:<number>, path:<path>, or active/current
-  --terminal <handle>       Runtime-issued terminal handle returned by \`orca terminal list --json\`
+  --terminal <handle>       Runtime-issued terminal handle from \`orca terminal list --json\`. Omit to target the worktree-active pane; an empty value is not omission.
   --parent-worktree <selector> Parent worktree selector such as id:<repo-id>::<path>, branch:<branch>, issue:<number>, path:<path>, or active/current
   --no-parent               Force no parent lineage for unrelated worktree creation/update
 
@@ -587,7 +587,8 @@ export function formatFlagHelp(flag: string): string {
       '--restore-window     Bring the target app/window forward before the operation',
     session: '--session <id>        Snapshot namespace for a related computer-use workflow',
     setup: '--setup run|skip|inherit Setup policy for repo-defined setup hooks',
-    terminal: '--terminal <handle>  Runtime-issued terminal handle',
+    terminal:
+      '--terminal <handle>  Runtime-issued terminal handle; omit to target the worktree-active pane. An empty value is not omission.',
     text: '--text <text>          Text payload to send or type',
     'text-stdin': '--text-stdin          Read text payload from stdin',
     'task-id': '--task-id <id>        Task id to include in orchestration payload JSON',

--- a/src/cli/selectors.ts
+++ b/src/cli/selectors.ts
@@ -7,7 +7,7 @@ import type {
 import { isPathInsideOrEqual } from '../shared/cross-platform-path'
 import type { RuntimeClient } from './runtime-client'
 import { RuntimeClientError } from './runtime/types'
-import { getOptionalStringFlag, getRequiredStringFlag } from './flags'
+import { getOptionalPresentStringFlag, getOptionalStringFlag, getRequiredStringFlag } from './flags'
 
 export type BrowserCliTarget = {
   worktree?: string
@@ -142,21 +142,8 @@ export async function getBrowserWorktreeSelector(
   }
 }
 
-function readExplicitTerminalHandle(flags: Map<string, string | boolean>): string | undefined {
-  if (!flags.has('terminal')) {
-    return undefined
-  }
-  const explicit = flags.get('terminal')
-  if (typeof explicit === 'string' && explicit.length > 0) {
-    return explicit
-  }
-  // Why: `--terminal "$HANDLE"` with an empty expansion is not omission. Scripts
-  // that treat a successful read as "this pane" would otherwise hit another tab.
-  throw new RuntimeClientError(
-    'invalid_argument',
-    '--terminal requires a non-empty handle. Omit --terminal to target the active terminal in the current worktree.'
-  )
-}
+const EMPTY_TERMINAL_HANDLE_MESSAGE =
+  '--terminal requires a non-empty handle. Omit --terminal to target the active terminal in the current worktree.'
 
 // Why: mirrors browser's implicit active-tab targeting. When --terminal is
 // omitted, resolve the active terminal in the current worktree so commands
@@ -166,7 +153,7 @@ export async function getTerminalHandle(
   cwd: string,
   client: RuntimeClient
 ): Promise<string> {
-  const explicit = readExplicitTerminalHandle(flags)
+  const explicit = getOptionalPresentStringFlag(flags, 'terminal', EMPTY_TERMINAL_HANDLE_MESSAGE)
   if (explicit) {
     return explicit
   }

--- a/src/cli/selectors.ts
+++ b/src/cli/selectors.ts
@@ -142,6 +142,22 @@ export async function getBrowserWorktreeSelector(
   }
 }
 
+function readExplicitTerminalHandle(flags: Map<string, string | boolean>): string | undefined {
+  if (!flags.has('terminal')) {
+    return undefined
+  }
+  const explicit = flags.get('terminal')
+  if (typeof explicit === 'string' && explicit.length > 0) {
+    return explicit
+  }
+  // Why: `--terminal "$HANDLE"` with an empty expansion is not omission. Scripts
+  // that treat a successful read as "this pane" would otherwise hit another tab.
+  throw new RuntimeClientError(
+    'invalid_argument',
+    '--terminal requires a non-empty handle. Omit --terminal to target the active terminal in the current worktree.'
+  )
+}
+
 // Why: mirrors browser's implicit active-tab targeting. When --terminal is
 // omitted, resolve the active terminal in the current worktree so commands
 // like `orca terminal send --text "hello" --enter` Just Work.
@@ -150,7 +166,7 @@ export async function getTerminalHandle(
   cwd: string,
   client: RuntimeClient
 ): Promise<string> {
-  const explicit = getOptionalStringFlag(flags, 'terminal')
+  const explicit = readExplicitTerminalHandle(flags)
   if (explicit) {
     return explicit
   }

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -204,7 +204,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
       'orca terminal read [--terminal <handle>] [--cursor <n>] [--limit <n>] [--screen] [--json]',
     allowedFlags: [...GLOBAL_FLAGS, 'terminal', 'cursor', 'limit', 'screen'],
     notes: [
-      'Omit --terminal to target the active terminal in the current worktree.',
+      'Omit --terminal to target the active terminal in the current worktree. An empty --terminal is not omission and fails closed.',
       'By default this returns accumulated terminal output with escape sequences stripped, not the rendered screen. Any program that repaints a line — shells, progress bars, TUIs — comes back as stacked fragments, so one `clear` keystroke by keystroke reads as `cclclecleaclear`, and spaces a prompt draws by moving the cursor are absent.',
       'Use --screen to read what the terminal actually renders. Prefer it whenever the answer depends on how output looks rather than what was emitted over time; the default is unsuitable for verifying rendered output.',
       'The result reports source: stream when it is accumulated output, screen when it is the rendered screen, and screen-unavailable when a screen was asked for but none could be rendered and the accumulated output is being returned instead. An absent source means the host predates the field.',

--- a/src/cli/terminal-empty-handle.test.ts
+++ b/src/cli/terminal-empty-handle.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const {
+  callMock,
+  runtimeClientConstructorMock,
+  serveOrcaAppMock,
+  getDefaultUserDataPathMock,
+  addEnvironmentFromPairingCodeMock,
+  listEnvironmentsMock,
+  spawnMock
+} = vi.hoisted(() => ({
+  callMock: vi.fn(),
+  runtimeClientConstructorMock: vi.fn(),
+  serveOrcaAppMock: vi.fn(),
+  getDefaultUserDataPathMock: vi.fn(() => '/tmp/orca-user-data'),
+  addEnvironmentFromPairingCodeMock: vi.fn(),
+  listEnvironmentsMock: vi.fn(),
+  spawnMock: vi.fn()
+}))
+
+vi.mock('./runtime-client', async () => {
+  const { createRuntimeClientModuleMock } = await import('./index-test-harness.js')
+  return createRuntimeClientModuleMock({
+    callMock,
+    runtimeClientConstructorMock,
+    serveOrcaAppMock,
+    getDefaultUserDataPathMock
+  })
+})
+
+vi.mock('./runtime/environments', () => ({
+  addEnvironmentFromPairingCode: addEnvironmentFromPairingCodeMock,
+  listEnvironments: listEnvironmentsMock,
+  removeEnvironment: vi.fn(),
+  resolveEnvironment: vi.fn()
+}))
+
+vi.mock('child_process', async () => {
+  const { createChildProcessModuleMock } = await import('./index-test-harness.js')
+  return createChildProcessModuleMock(spawnMock)
+})
+
+import { printHelp } from './help'
+import { main } from './index'
+import { useWorktreeAwarenessEnvironment } from './index-test-harness'
+import type { RuntimeClient } from './runtime-client'
+import { getTerminalHandle } from './selectors'
+import { COMMAND_SPECS } from './specs'
+import { buildWorktree, okFixture, queueFixtures, worktreeListFixture } from './test-fixtures'
+
+function fakeClient(call: RuntimeClient['call']): RuntimeClient {
+  return { call, isRemote: false } as unknown as RuntimeClient
+}
+
+describe('getTerminalHandle empty --terminal', () => {
+  it('rejects an explicit empty handle without resolving the active pane', async () => {
+    const call = vi.fn()
+    await expect(
+      getTerminalHandle(new Map([['terminal', '']]), '/tmp/repo', fakeClient(call))
+    ).rejects.toMatchObject({
+      code: 'invalid_argument',
+      message: expect.stringContaining('non-empty handle')
+    })
+    expect(call).not.toHaveBeenCalled()
+  })
+
+  it('rejects a valueless --terminal flag without resolving the active pane', async () => {
+    const call = vi.fn()
+    await expect(
+      getTerminalHandle(new Map([['terminal', true]]), '/tmp/repo', fakeClient(call))
+    ).rejects.toMatchObject({ code: 'invalid_argument' })
+    expect(call).not.toHaveBeenCalled()
+  })
+
+  it('passes a whitespace handle through so the runtime can fail closed', async () => {
+    const call = vi.fn()
+    await expect(
+      getTerminalHandle(new Map([['terminal', ' ']]), '/tmp/repo', fakeClient(call))
+    ).resolves.toBe(' ')
+    expect(call).not.toHaveBeenCalled()
+  })
+
+  it('resolves the worktree-active pane only when --terminal is omitted', async () => {
+    const call = vi
+      .fn()
+      .mockResolvedValueOnce({
+        result: { worktrees: [buildWorktree('/tmp/repo', 'main')] }
+      })
+      .mockResolvedValueOnce({ result: { handle: 'term_active' } })
+
+    await expect(getTerminalHandle(new Map(), '/tmp/repo', fakeClient(call))).resolves.toBe(
+      'term_active'
+    )
+    expect(call).toHaveBeenNthCalledWith(1, 'worktree.list', { limit: 10_000 })
+    expect(call).toHaveBeenNthCalledWith(2, 'terminal.resolveActive', {
+      worktree: 'id:repo::/tmp/repo'
+    })
+  })
+})
+
+describe('orca terminal empty --terminal', () => {
+  useWorktreeAwarenessEnvironment({
+    callMock,
+    serveOrcaAppMock,
+    getDefaultUserDataPathMock,
+    addEnvironmentFromPairingCodeMock,
+    listEnvironmentsMock,
+    spawnMock
+  })
+
+  async function runEmptyHandle(argv: string[]): Promise<{ printed: unknown; exitCode: unknown }> {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+    process.exitCode = 0
+    await main(argv, '/tmp/repo')
+    const printed = JSON.parse(String(logSpy.mock.calls[0]?.[0] ?? 'null'))
+    const exitCode = process.exitCode
+    process.exitCode = priorExitCode
+    return { printed, exitCode }
+  }
+
+  it.each([
+    ['show', ['terminal', 'show', '--terminal', '', '--json']],
+    ['read', ['terminal', 'read', '--terminal', '', '--json']],
+    ['wait', ['terminal', 'wait', '--terminal', '', '--for', 'tui-idle', '--json']],
+    ['send', ['terminal', 'send', '--terminal', '', '--text', 'hi', '--json']]
+  ])(
+    'fails closed for empty --terminal on %s without contacting the runtime',
+    async (_verb, argv) => {
+      const { printed, exitCode } = await runEmptyHandle(argv)
+      expect(exitCode).toBe(1)
+      expect(printed).toMatchObject({
+        ok: false,
+        error: {
+          code: 'invalid_argument',
+          message: expect.stringContaining('Omit --terminal')
+        }
+      })
+      expect(callMock).not.toHaveBeenCalled()
+    }
+  )
+
+  it('still targets the worktree-active pane when --terminal is omitted', async () => {
+    queueFixtures(
+      callMock,
+      worktreeListFixture([buildWorktree('/tmp/repo', 'main')]),
+      okFixture('req_resolve', { handle: 'term_active' }),
+      okFixture('req_show', {
+        terminal: { handle: 'term_active', title: 'shell', worktreePath: '/tmp/repo' }
+      })
+    )
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['terminal', 'show', '--json'], '/tmp/repo')
+
+    expect(callMock).toHaveBeenCalledWith('terminal.resolveActive', {
+      worktree: 'id:repo::/tmp/repo'
+    })
+    expect(callMock).toHaveBeenCalledWith('terminal.show', { terminal: 'term_active' })
+    expect(JSON.parse(String(logSpy.mock.calls[0]?.[0]))).toMatchObject({
+      ok: true,
+      result: { terminal: { handle: 'term_active' } }
+    })
+  })
+
+  it('documents that an empty --terminal is not omission', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    printHelp(COMMAND_SPECS, ['terminal', 'read'])
+    const help = String(log.mock.calls[0]?.[0])
+    expect(help).toContain('Omit --terminal to target the active terminal in the current worktree')
+    expect(help).toContain('An empty --terminal is not omission and fails closed')
+  })
+})


### PR DESCRIPTION
## ELI5

If a script passes `--terminal ""` (empty handle), Orca used to pretend the flag was never there and quietly talk to whatever pane was currently active. That can be a different tab than the script meant. This change treats an empty `--terminal` as an error. Leaving the flag off still targets the active pane, as documented.

## What Changed

- `getTerminalHandle` now distinguishes **omitted** `--terminal` from **present but empty**.
- Empty (or valueless) `--terminal` fails closed with `invalid_argument` and does not call the runtime.
- Whitespace handles are still passed through so the runtime can return `terminal_handle_stale`, matching existing behavior.
- Help text for `--terminal` / `terminal read` now says an empty value is not omission.

## Why

`--terminal "$HANDLE"` is a common script pattern. When `HANDLE` is empty, success-plus-wrong-pane is a diagnostic footgun: `read`/`show`/`wait`/`send` look like they worked against the intended terminal. Failing closed makes the empty expansion visible.

Omitted `--terminal` still resolves the worktree-active pane, so `orca terminal send --text "hello" --enter` continues to Just Work.

## Linked Issue

Fixes #16694

## Visual Proof

N/A — CLI argument validation only; no UI or interaction change.

## Testing

- [x] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Added `src/cli/terminal-empty-handle.test.ts`:

- empty `--terminal` fails on `show` / `read` / `wait` / `send` without contacting the runtime
- omitted `--terminal` still calls `terminal.resolveActive`
- whitespace handle is passed through
- valueless `--terminal` (boolean flag) also fails closed
- help documents the distinction

Ran:

```
vitest run --config config/vitest.config.ts src/cli/terminal-empty-handle.test.ts
oxlint src/cli/selectors.ts src/cli/help.ts src/cli/specs/core.ts src/cli/terminal-empty-handle.test.ts
```

10 tests passed. I did not run full `pnpm lint` / `pnpm typecheck` / `pnpm build` locally: postinstall native rebuild (`node-pty` / Electron) failed on this machine (no Xcode CLT + proxy undici error). CI should cover the rest.

Platform: unit tests on macOS. Behavior is argv parsing in the CLI, so it is not OS-specific. SSH/remote is unchanged: the check happens before any runtime RPC.

## AI Disclosure

Drafted and implemented with Grok (xAI) in an Orca-managed session. I reviewed the change, tests, and this PR description.

## Review

- Cross-platform: no path or shortcut changes; empty-string argv is the same on macOS / Linux / Windows (PowerShell `%HANDLE%` / `$HANDLE` expansion is the motivating case).
- SSH/remote: fail-closed happens in the CLI before `terminal.resolveActive` / `terminal.show` / `terminal.send`.
- Performance: one extra `flags.has` + type check on an already-hot but tiny path.
- Security: prevents accidentally reading or sending to the wrong pane when a handle variable is empty.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

Ensure no issues in: Security, Cross-platoform support (Linux, Windows, Mac), Remote SSH, Mobile, general backwards compatibility, performance

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)
